### PR TITLE
fix(web): preserve active workspace on settings bootstrap

### DIFF
--- a/apps/web/app/page.test.ts
+++ b/apps/web/app/page.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveActiveKanbanWorkspaceId } from "./page";
+
+describe("resolveActiveKanbanWorkspaceId", () => {
+  it("ignores office workspaces when resolving cookie and settings IDs", () => {
+    const activeId = resolveActiveKanbanWorkspaceId(
+      [
+        { id: "ws-office", office_workflow_id: "office-flow" },
+        { id: "ws-kanban", office_workflow_id: null },
+      ],
+      undefined,
+      "ws-office",
+      "ws-kanban",
+    );
+
+    expect(activeId).toBe("ws-kanban");
+  });
+
+  it("honors explicit URL workspace IDs even for office workspaces", () => {
+    const activeId = resolveActiveKanbanWorkspaceId(
+      [
+        { id: "ws-office", office_workflow_id: "office-flow" },
+        { id: "ws-kanban", office_workflow_id: null },
+      ],
+      "ws-office",
+      null,
+      "ws-kanban",
+    );
+
+    expect(activeId).toBe("ws-office");
+  });
+});

--- a/apps/web/app/page.test.ts
+++ b/apps/web/app/page.test.ts
@@ -17,7 +17,7 @@ describe("resolveActiveKanbanWorkspaceId", () => {
     expect(activeId).toBe("ws-kanban");
   });
 
-  it("honors explicit URL workspace IDs even for office workspaces", () => {
+  it("falls back when explicit URL workspace ID is an office workspace", () => {
     const activeId = resolveActiveKanbanWorkspaceId(
       [
         { id: "ws-office", office_workflow_id: "office-flow" },
@@ -28,6 +28,6 @@ describe("resolveActiveKanbanWorkspaceId", () => {
       "ws-kanban",
     );
 
-    expect(activeId).toBe("ws-office");
+    expect(activeId).toBe("ws-kanban");
   });
 });

--- a/apps/web/app/page.test.ts
+++ b/apps/web/app/page.test.ts
@@ -1,14 +1,15 @@
 import { describe, expect, it } from "vitest";
 
+import { workspaceId, workflowId } from "@/lib/types/ids";
+import type { ListWorkspacesResponse } from "@/lib/types/http";
 import { resolveActiveKanbanWorkspaceId } from "./page";
+
+type WorkspaceRow = ListWorkspacesResponse["workspaces"][number];
 
 describe("resolveActiveKanbanWorkspaceId", () => {
   it("ignores office workspaces when resolving cookie and settings IDs", () => {
     const activeId = resolveActiveKanbanWorkspaceId(
-      [
-        { id: "ws-office", office_workflow_id: "office-flow" },
-        { id: "ws-kanban", office_workflow_id: null },
-      ],
+      [workspaceRow("ws-office", "office-flow"), workspaceRow("ws-kanban", null)],
       undefined,
       "ws-office",
       "ws-kanban",
@@ -19,10 +20,7 @@ describe("resolveActiveKanbanWorkspaceId", () => {
 
   it("falls back when explicit URL workspace ID is an office workspace", () => {
     const activeId = resolveActiveKanbanWorkspaceId(
-      [
-        { id: "ws-office", office_workflow_id: "office-flow" },
-        { id: "ws-kanban", office_workflow_id: null },
-      ],
+      [workspaceRow("ws-office", "office-flow"), workspaceRow("ws-kanban", null)],
       "ws-office",
       null,
       "ws-kanban",
@@ -31,3 +29,14 @@ describe("resolveActiveKanbanWorkspaceId", () => {
     expect(activeId).toBe("ws-kanban");
   });
 });
+
+function workspaceRow(id: string, officeWorkflowId: string | null): WorkspaceRow {
+  return {
+    id: workspaceId(id),
+    name: id,
+    owner_id: "owner-1",
+    office_workflow_id: officeWorkflowId ? workflowId(officeWorkflowId) : undefined,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  } as WorkspaceRow;
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -73,6 +73,16 @@ function buildBaseState(
   };
 }
 
+function resolveActiveKanbanWorkspaceId(
+  workspaces: WorkspaceItem[],
+  workspaceId: string | undefined,
+  cookieWorkspaceId: string | null,
+  settingsWorkspaceId: string | null,
+): string | null {
+  const kanbanWorkspaces = workspaces.filter((workspace) => !workspace.office_workflow_id);
+  return resolveActiveId(kanbanWorkspaces, workspaceId, cookieWorkspaceId, settingsWorkspaceId);
+}
+
 async function loadSnapshotState(
   workflowId: string,
   taskId: string | undefined,
@@ -125,10 +135,11 @@ export default async function Page({ searchParams }: PageProps) {
     const settingsWorkspaceId = userSettingsResponse?.settings?.workspace_id || null;
     const settingsWorkflowId = userSettingsResponse?.settings?.workflow_filter_id || null;
     // The sidebar picker writes the selected workspace to this cookie so the
-    // choice survives a refresh even when office is disabled (userSettings is
-    // not updated on select). Priority: URL param > cookie > saved setting.
-    const cookieWorkspaceId = cookieStore?.get("office-active-workspace")?.value ?? null;
-    const activeWorkspaceId = resolveActiveId(
+    // choice survives a refresh even when userSettings is not updated on select.
+    // Kanban home only resolves against kanban workspaces; office workspaces
+    // belong under /office.
+    const cookieWorkspaceId = cookieStore?.get("kandev-active-workspace")?.value ?? null;
+    const activeWorkspaceId = resolveActiveKanbanWorkspaceId(
       workspaces.workspaces,
       workspaceId,
       cookieWorkspaceId,

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -74,7 +74,7 @@ function buildBaseState(
   };
 }
 
-function resolveActiveKanbanWorkspaceId(
+export function resolveActiveKanbanWorkspaceId(
   workspaces: WorkspaceItem[],
   workspaceId: string | undefined,
   cookieWorkspaceId: string | null,

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -13,6 +13,7 @@ import { listWorkspaceTaskPRs } from "@/lib/api/domains/github-api";
 import { snapshotToState } from "@/lib/ssr/mapper";
 import { mapUserSettingsResponse } from "@/lib/ssr/user-settings";
 import { resolveDesiredWorkflowId } from "@/lib/kanban/resolve-workflow";
+import { ACTIVE_WORKSPACE_COOKIE } from "@/lib/routing/route-bootstrap";
 import { resolveActiveId } from "@/lib/ssr/resolve-active-id";
 import { readCookies } from "@/lib/server/cookies";
 import type { AppState } from "@/lib/state/store";
@@ -138,7 +139,7 @@ export default async function Page({ searchParams }: PageProps) {
     // choice survives a refresh even when userSettings is not updated on select.
     // Kanban home only resolves against kanban workspaces; office workspaces
     // belong under /office.
-    const cookieWorkspaceId = cookieStore?.get("kandev-active-workspace")?.value ?? null;
+    const cookieWorkspaceId = cookieStore?.get(ACTIVE_WORKSPACE_COOKIE)?.value ?? null;
     const activeWorkspaceId = resolveActiveKanbanWorkspaceId(
       workspaces.workspaces,
       workspaceId,

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -140,6 +140,9 @@ export default async function Page({ searchParams }: PageProps) {
     // Kanban home only resolves against kanban workspaces; office workspaces
     // belong under /office.
     const cookieWorkspaceId = cookieStore?.get(ACTIVE_WORKSPACE_COOKIE)?.value ?? null;
+    // `readCookies()` is client-only in this code path; during SSR this is empty.
+    // Workspace selection still works because spa-routes.tsx re-hydrates from
+    // `readActiveWorkspaceCookie()` and the generic resolver on first client render.
     const activeWorkspaceId = resolveActiveKanbanWorkspaceId(
       workspaces.workspaces,
       workspaceId,

--- a/apps/web/app/settings/layout.tsx
+++ b/apps/web/app/settings/layout.tsx
@@ -8,7 +8,9 @@ import {
   listExecutors,
   listWorkspaces,
 } from "@/lib/api";
+import { resolveActiveId } from "@/lib/ssr/resolve-active-id";
 import { mapUserSettingsResponse } from "@/lib/ssr/user-settings";
+import { readCookies } from "@/lib/server/cookies";
 import { toAgentProfileOption } from "@/lib/state/slices/settings/types";
 
 export default function SettingsLayout({ children }: { children: React.ReactNode }) {
@@ -21,7 +23,7 @@ async function SettingsLayoutServer({ children }: { children: React.ReactNode })
     // Fetch discovery + available agents alongside the DB-backed list so a
     // hard refresh of /settings/agents/[name] (where no profile exists yet)
     // can still render the agent from the discovered set.
-    const [workspaces, executors, agents, discovery, available, userSettingsResponse] =
+    const [workspaces, executors, agents, discovery, available, userSettingsResponse, cookieStore] =
       await Promise.all([
         listWorkspaces({ cache: "no-store" }),
         listExecutors({ cache: "no-store" }),
@@ -29,23 +31,30 @@ async function SettingsLayoutServer({ children }: { children: React.ReactNode })
         listAgentDiscovery({ cache: "no-store" }),
         listAvailableAgents({ cache: "no-store" }),
         fetchUserSettings({ cache: "no-store" }).catch(() => null),
+        readCookies().catch(() => null),
       ]);
     // Hydrate userSettings into the ROOT store so app-global, override-driven
     // shortcuts (TOGGLE_SIDEBAR, Quick Chat) work on settings routes too. The
     // settings/general page mounts its own nested store for editing; that store
     // is invisible to the root-mounted GlobalCommands/useAppShortcuts.
     const mappedUserSettings = mapUserSettingsResponse(userSettingsResponse);
+    const activeWorkspaceId = resolveActiveId(
+      workspaces.workspaces,
+      cookieStore?.get("kandev-active-workspace")?.value ?? null,
+      userSettingsResponse?.settings?.workspace_id ?? null,
+    );
     initialState = {
       workspaces: {
         items: workspaces.workspaces.map((workspace) => ({
           id: workspace.id,
           name: workspace.name,
+          office_workflow_id: workspace.office_workflow_id ?? null,
           default_executor_id: workspace.default_executor_id ?? null,
           default_environment_id: workspace.default_environment_id ?? null,
           default_agent_profile_id: workspace.default_agent_profile_id ?? null,
           default_config_agent_profile_id: workspace.default_config_agent_profile_id ?? null,
         })),
-        activeId: workspaces.workspaces[0]?.id ?? null,
+        activeId: activeWorkspaceId,
       },
       executors: {
         items: executors.executors,
@@ -77,7 +86,7 @@ async function SettingsLayoutServer({ children }: { children: React.ReactNode })
         ? {
             userSettings: {
               ...mappedUserSettings,
-              workspaceId: workspaces.workspaces[0]?.id ?? null,
+              workspaceId: activeWorkspaceId,
             },
           }
         : {}),

--- a/apps/web/app/settings/layout.tsx
+++ b/apps/web/app/settings/layout.tsx
@@ -46,6 +46,9 @@ async function SettingsLayoutServer({ children }: { children: React.ReactNode })
     const activeWorkspaceId = resolveSettingsActiveWorkspaceId(
       workspaceItems,
       null,
+      // `readCookies()` is client-only in this path; during SSR this is empty.
+      // Settings active workspace selection is completed on first client render by
+      // spa-routes via `readActiveWorkspaceCookie()`.
       cookieStore?.get(ACTIVE_WORKSPACE_COOKIE)?.value ?? null,
       userSettingsResponse?.settings?.workspace_id ?? null,
     );

--- a/apps/web/app/settings/layout.tsx
+++ b/apps/web/app/settings/layout.tsx
@@ -8,8 +8,11 @@ import {
   listExecutors,
   listWorkspaces,
 } from "@/lib/api";
-import { ACTIVE_WORKSPACE_COOKIE, mapWorkspaceItem } from "@/lib/routing/route-bootstrap";
-import { resolveActiveId } from "@/lib/ssr/resolve-active-id";
+import {
+  ACTIVE_WORKSPACE_COOKIE,
+  mapWorkspaceItem,
+  resolveSettingsActiveWorkspaceId,
+} from "@/lib/routing/route-bootstrap";
 import { mapUserSettingsResponse } from "@/lib/ssr/user-settings";
 import { readCookies } from "@/lib/server/cookies";
 import { toAgentProfileOption } from "@/lib/state/slices/settings/types";
@@ -39,14 +42,16 @@ async function SettingsLayoutServer({ children }: { children: React.ReactNode })
     // settings/general page mounts its own nested store for editing; that store
     // is invisible to the root-mounted GlobalCommands/useAppShortcuts.
     const mappedUserSettings = mapUserSettingsResponse(userSettingsResponse);
-    const activeWorkspaceId = resolveActiveId(
-      workspaces.workspaces,
+    const workspaceItems = workspaces.workspaces.map(mapWorkspaceItem);
+    const activeWorkspaceId = resolveSettingsActiveWorkspaceId(
+      workspaceItems,
+      null,
       cookieStore?.get(ACTIVE_WORKSPACE_COOKIE)?.value ?? null,
       userSettingsResponse?.settings?.workspace_id ?? null,
     );
     initialState = {
       workspaces: {
-        items: workspaces.workspaces.map(mapWorkspaceItem),
+        items: workspaceItems,
         activeId: activeWorkspaceId,
       },
       executors: {

--- a/apps/web/app/settings/layout.tsx
+++ b/apps/web/app/settings/layout.tsx
@@ -8,6 +8,7 @@ import {
   listExecutors,
   listWorkspaces,
 } from "@/lib/api";
+import { ACTIVE_WORKSPACE_COOKIE, mapWorkspaceItem } from "@/lib/routing/route-bootstrap";
 import { resolveActiveId } from "@/lib/ssr/resolve-active-id";
 import { mapUserSettingsResponse } from "@/lib/ssr/user-settings";
 import { readCookies } from "@/lib/server/cookies";
@@ -40,20 +41,12 @@ async function SettingsLayoutServer({ children }: { children: React.ReactNode })
     const mappedUserSettings = mapUserSettingsResponse(userSettingsResponse);
     const activeWorkspaceId = resolveActiveId(
       workspaces.workspaces,
-      cookieStore?.get("kandev-active-workspace")?.value ?? null,
+      cookieStore?.get(ACTIVE_WORKSPACE_COOKIE)?.value ?? null,
       userSettingsResponse?.settings?.workspace_id ?? null,
     );
     initialState = {
       workspaces: {
-        items: workspaces.workspaces.map((workspace) => ({
-          id: workspace.id,
-          name: workspace.name,
-          office_workflow_id: workspace.office_workflow_id ?? null,
-          default_executor_id: workspace.default_executor_id ?? null,
-          default_environment_id: workspace.default_environment_id ?? null,
-          default_agent_profile_id: workspace.default_agent_profile_id ?? null,
-          default_config_agent_profile_id: workspace.default_config_agent_profile_id ?? null,
-        })),
+        items: workspaces.workspaces.map(mapWorkspaceItem),
         activeId: activeWorkspaceId,
       },
       executors: {

--- a/apps/web/components/app-sidebar/app-sidebar-workspace-picker.test.tsx
+++ b/apps/web/components/app-sidebar/app-sidebar-workspace-picker.test.tsx
@@ -188,14 +188,14 @@ describe("AppSidebarWorkspacePicker — workspace select", () => {
     expect(screen.getByTestId(OFFICE_WORKSPACE_ITEM).textContent).toContain("Office");
   });
 
-  it("still no-ops on the active workspace when office routing is enabled", () => {
+  it("routes to the active workspace home when office routing is enabled", () => {
     storeState.features.office = true;
     render(<AppSidebarWorkspacePicker />);
 
     fireEvent.click(screen.getByTestId(KANBAN_WORKSPACE_ITEM));
 
-    expect(cookieWrites).toEqual([]);
+    expect(cookieWrites.some((c) => c.startsWith("kandev-active-workspace=w1"))).toBe(true);
     expect(storeState.setActiveWorkspace).not.toHaveBeenCalled();
-    expect(navigationMock.push).not.toHaveBeenCalled();
+    expect(navigationMock.push).toHaveBeenCalledWith("/?workspaceId=w1");
   });
 });

--- a/apps/web/components/app-sidebar/app-sidebar-workspace-picker.test.tsx
+++ b/apps/web/components/app-sidebar/app-sidebar-workspace-picker.test.tsx
@@ -188,7 +188,7 @@ describe("AppSidebarWorkspacePicker — workspace select", () => {
     expect(screen.getByTestId(OFFICE_WORKSPACE_ITEM).textContent).toContain("Office");
   });
 
-  it("routes to the active workspace home when office routing is enabled", () => {
+  it("routes to the active kanban workspace home when office routing is enabled", () => {
     storeState.features.office = true;
     render(<AppSidebarWorkspacePicker />);
 
@@ -197,5 +197,17 @@ describe("AppSidebarWorkspacePicker — workspace select", () => {
     expect(cookieWrites.some((c) => c.startsWith("kandev-active-workspace=w1"))).toBe(true);
     expect(storeState.setActiveWorkspace).not.toHaveBeenCalled();
     expect(navigationMock.push).toHaveBeenCalledWith("/?workspaceId=w1");
+  });
+
+  it("does not route when selecting the active office workspace", () => {
+    storeState.features.office = true;
+    storeState.workspaces.activeId = "w2";
+    render(<AppSidebarWorkspacePicker />);
+
+    fireEvent.click(screen.getByTestId(OFFICE_WORKSPACE_ITEM));
+
+    expect(cookieWrites).toEqual([]);
+    expect(storeState.setActiveWorkspace).not.toHaveBeenCalled();
+    expect(navigationMock.push).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/components/app-sidebar/app-sidebar-workspace-picker.tsx
+++ b/apps/web/components/app-sidebar/app-sidebar-workspace-picker.tsx
@@ -22,6 +22,7 @@ import { cn } from "@/lib/utils";
 import {
   rememberLastOfficeWorkspace,
   rememberLastKanbanWorkspace,
+  workspaceHomeHref,
 } from "./app-sidebar-workspace-navigation";
 
 /**
@@ -78,6 +79,14 @@ function WorkspaceTypeIcon({ type, className }: { type: WorkspaceType; className
   return <IconLayoutKanban className={className} />;
 }
 
+function rememberSelectedWorkspace(workspace: WorkspaceItem) {
+  if (workspaceType(workspace) === "office") {
+    rememberLastOfficeWorkspace(workspace);
+  } else {
+    rememberLastKanbanWorkspace(workspace);
+  }
+}
+
 export function AppSidebarWorkspacePicker() {
   const router = useRouter();
   const officeEnabled = useFeature("office");
@@ -93,6 +102,10 @@ export function AppSidebarWorkspacePicker() {
     (workspace: WorkspaceItem) => {
       const { id } = workspace;
       if (id === activeId) {
+        if (officeEnabled) {
+          rememberSelectedWorkspace(workspace);
+          router.push(workspaceHomeHref(workspace));
+        }
         setOpen(false);
         return;
       }

--- a/apps/web/components/app-sidebar/app-sidebar-workspace-picker.tsx
+++ b/apps/web/components/app-sidebar/app-sidebar-workspace-picker.tsx
@@ -102,7 +102,7 @@ export function AppSidebarWorkspacePicker() {
     (workspace: WorkspaceItem) => {
       const { id } = workspace;
       if (id === activeId) {
-        if (officeEnabled) {
+        if (officeEnabled && workspaceType(workspace) === "kanban") {
           rememberSelectedWorkspace(workspace);
           router.push(workspaceHomeHref(workspace));
         }

--- a/apps/web/lib/routing/route-bootstrap.test.ts
+++ b/apps/web/lib/routing/route-bootstrap.test.ts
@@ -51,9 +51,9 @@ describe("readCookie", () => {
     expect(readActiveWorkspaceCookie()).toBe("kanban-1");
   });
 
-  it("falls back to the legacy office active workspace cookie", () => {
+  it("does not use the legacy office cookie as the generic active workspace", () => {
     document.cookie = "office-active-workspace=office-1; path=/";
 
-    expect(readActiveWorkspaceCookie()).toBe("office-1");
+    expect(readActiveWorkspaceCookie()).toBeNull();
   });
 });

--- a/apps/web/lib/routing/route-bootstrap.test.ts
+++ b/apps/web/lib/routing/route-bootstrap.test.ts
@@ -1,6 +1,11 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
-import { mapWorkspaceItem, readActiveWorkspaceCookie, readCookie } from "./route-bootstrap";
+import {
+  mapWorkspaceItem,
+  readActiveWorkspaceCookie,
+  readCookie,
+  resolveSettingsActiveWorkspaceId,
+} from "./route-bootstrap";
 import type { ListWorkspacesResponse } from "@/lib/types/http";
 
 type WorkspaceItem = ListWorkspacesResponse["workspaces"][number];
@@ -55,5 +60,21 @@ describe("readCookie", () => {
     document.cookie = "office-active-workspace=office-1; path=/";
 
     expect(readActiveWorkspaceCookie()).toBeNull();
+  });
+});
+
+describe("resolveSettingsActiveWorkspaceId", () => {
+  it("falls back to a kanban workspace before an office workspace", () => {
+    expect(
+      resolveSettingsActiveWorkspaceId(
+        [
+          { id: "office-1", office_workflow_id: "office-workflow" },
+          { id: "kanban-1", office_workflow_id: null },
+        ],
+        null,
+        null,
+        null,
+      ),
+    ).toBe("kanban-1");
   });
 });

--- a/apps/web/lib/routing/route-bootstrap.test.ts
+++ b/apps/web/lib/routing/route-bootstrap.test.ts
@@ -64,17 +64,99 @@ describe("readCookie", () => {
 });
 
 describe("resolveSettingsActiveWorkspaceId", () => {
+  const officeWorkflow = "office-workflow";
+  const officeWorkflow1 = "office-workflow-1";
+  const officeWorkflow2 = "office-workflow-2";
+  const kanbanOne = "kanban-1";
+  const kanbanTwo = "kanban-2";
+
   it("falls back to a kanban workspace before an office workspace", () => {
     expect(
       resolveSettingsActiveWorkspaceId(
         [
-          { id: "office-1", office_workflow_id: "office-workflow" },
-          { id: "kanban-1", office_workflow_id: null },
+          { id: "office-1", office_workflow_id: officeWorkflow },
+          { id: kanbanOne, office_workflow_id: null },
         ],
         null,
         null,
         null,
       ),
-    ).toBe("kanban-1");
+    ).toBe(kanbanOne);
+  });
+
+  it("prefers explicit route workspace ID", () => {
+    expect(
+      resolveSettingsActiveWorkspaceId(
+        [
+          { id: "office-1", office_workflow_id: officeWorkflow },
+          { id: kanbanOne, office_workflow_id: null },
+        ],
+        "office-1",
+        null,
+        null,
+      ),
+    ).toBe("office-1");
+  });
+
+  it("uses active cookie when it matches a kanban workspace", () => {
+    expect(
+      resolveSettingsActiveWorkspaceId(
+        [
+          { id: "office-1", office_workflow_id: officeWorkflow },
+          { id: kanbanOne, office_workflow_id: null },
+          { id: kanbanTwo, office_workflow_id: null },
+        ],
+        null,
+        kanbanTwo,
+        null,
+      ),
+    ).toBe(kanbanTwo);
+  });
+
+  it("falls back to settings workspace when no cookie matches", () => {
+    expect(
+      resolveSettingsActiveWorkspaceId(
+        [
+          { id: "office-1", office_workflow_id: officeWorkflow },
+          { id: kanbanOne, office_workflow_id: null },
+          { id: kanbanTwo, office_workflow_id: null },
+        ],
+        null,
+        "ws-missing",
+        kanbanOne,
+      ),
+    ).toBe(kanbanOne);
+  });
+
+  it("returns null when no workspaces exist", () => {
+    expect(resolveSettingsActiveWorkspaceId([], null, "k-1", "k-2")).toBeNull();
+  });
+
+  it("falls back to office workspace only when no kanban workspaces exist", () => {
+    expect(
+      resolveSettingsActiveWorkspaceId(
+        [
+          { id: "office-1", office_workflow_id: officeWorkflow1 },
+          { id: "office-2", office_workflow_id: officeWorkflow2 },
+        ],
+        null,
+        "missing",
+        null,
+      ),
+    ).toBe("office-1");
+  });
+
+  it("returns first kanban workspace when multiple kanban options exist", () => {
+    expect(
+      resolveSettingsActiveWorkspaceId(
+        [
+          { id: kanbanOne, office_workflow_id: null },
+          { id: kanbanTwo, office_workflow_id: null },
+        ],
+        null,
+        null,
+        null,
+      ),
+    ).toBe(kanbanOne);
   });
 });

--- a/apps/web/lib/routing/route-bootstrap.ts
+++ b/apps/web/lib/routing/route-bootstrap.ts
@@ -34,5 +34,5 @@ export function readCookie(name: string): string | null {
 }
 
 export function readActiveWorkspaceCookie(): string | null {
-  return readCookie(ACTIVE_WORKSPACE_COOKIE) || readCookie(LEGACY_OFFICE_ACTIVE_WORKSPACE_COOKIE);
+  return readCookie(ACTIVE_WORKSPACE_COOKIE) || null;
 }

--- a/apps/web/lib/routing/route-bootstrap.ts
+++ b/apps/web/lib/routing/route-bootstrap.ts
@@ -36,3 +36,26 @@ export function readCookie(name: string): string | null {
 export function readActiveWorkspaceCookie(): string | null {
   return readCookie(ACTIVE_WORKSPACE_COOKIE) || null;
 }
+
+type SettingsWorkspaceItem = {
+  id: string;
+  office_workflow_id?: string | null;
+};
+
+export function resolveSettingsActiveWorkspaceId(
+  workspaceItems: SettingsWorkspaceItem[],
+  requestedWorkspaceId: string | null,
+  activeCookieWorkspaceId: string | null,
+  settingsWorkspaceId: string | null,
+): string | null {
+  const kanbanWorkspaceItems = workspaceItems.filter((workspace) => !workspace.office_workflow_id);
+
+  return (
+    workspaceItems.find((workspace) => workspace.id === requestedWorkspaceId)?.id ??
+    kanbanWorkspaceItems.find((workspace) => workspace.id === activeCookieWorkspaceId)?.id ??
+    kanbanWorkspaceItems.find((workspace) => workspace.id === settingsWorkspaceId)?.id ??
+    kanbanWorkspaceItems[0]?.id ??
+    workspaceItems[0]?.id ??
+    null
+  );
+}

--- a/apps/web/src/office-routes.test.ts
+++ b/apps/web/src/office-routes.test.ts
@@ -35,4 +35,19 @@ describe("resolveActiveOfficeWorkspaceId", () => {
 
     expect(activeId).toBe(wsOffice1);
   });
+
+  it("uses kandev-active-workspace when it holds an office workspace ID", () => {
+    const activeId = resolveActiveOfficeWorkspaceId(
+      [
+        { id: wsOffice1, office_workflow_id: "office-flow-1" },
+        { id: wsOffice2, office_workflow_id: "office-flow-2" },
+      ],
+      null,
+      wsOffice1,
+      wsOffice2,
+      null,
+    );
+
+    expect(activeId).toBe(wsOffice1);
+  });
 });

--- a/apps/web/src/office-routes.test.ts
+++ b/apps/web/src/office-routes.test.ts
@@ -5,12 +5,14 @@ import { resolveActiveOfficeWorkspaceId } from "./office-routes";
 describe("resolveActiveOfficeWorkspaceId", () => {
   const wsOffice1 = "ws-office-1";
   const wsOffice2 = "ws-office-2";
+  const officeFlow1 = "office-flow-1";
+  const officeFlow2 = "office-flow-2";
 
   it("prefers explicit route workspace ID", () => {
     const activeId = resolveActiveOfficeWorkspaceId(
       [
-        { id: wsOffice1, office_workflow_id: "office-flow-1" },
-        { id: wsOffice2, office_workflow_id: "office-flow-2" },
+        { id: wsOffice1, office_workflow_id: officeFlow1 },
+        { id: wsOffice2, office_workflow_id: officeFlow2 },
       ],
       wsOffice2,
       "ws-office-1",
@@ -21,11 +23,11 @@ describe("resolveActiveOfficeWorkspaceId", () => {
     expect(activeId).toBe(wsOffice2);
   });
 
-  it("falls back to the generic office workspace cookie and then settings", () => {
+  it("falls back to the generic office workspace cookie when active cookie misses", () => {
     const activeId = resolveActiveOfficeWorkspaceId(
       [
-        { id: wsOffice1, office_workflow_id: "office-flow-1" },
-        { id: wsOffice2, office_workflow_id: "office-flow-2" },
+        { id: wsOffice1, office_workflow_id: officeFlow1 },
+        { id: wsOffice2, office_workflow_id: officeFlow2 },
       ],
       null,
       "ws-missing",
@@ -36,11 +38,26 @@ describe("resolveActiveOfficeWorkspaceId", () => {
     expect(activeId).toBe(wsOffice1);
   });
 
+  it("falls back to settings workspace when no cookie matches", () => {
+    const activeId = resolveActiveOfficeWorkspaceId(
+      [
+        { id: wsOffice1, office_workflow_id: officeFlow1 },
+        { id: wsOffice2, office_workflow_id: officeFlow2 },
+      ],
+      null,
+      "ws-missing",
+      null,
+      wsOffice2,
+    );
+
+    expect(activeId).toBe(wsOffice2);
+  });
+
   it("uses kandev-active-workspace when it holds an office workspace ID", () => {
     const activeId = resolveActiveOfficeWorkspaceId(
       [
-        { id: wsOffice1, office_workflow_id: "office-flow-1" },
-        { id: wsOffice2, office_workflow_id: "office-flow-2" },
+        { id: wsOffice1, office_workflow_id: officeFlow1 },
+        { id: wsOffice2, office_workflow_id: officeFlow2 },
       ],
       null,
       wsOffice1,

--- a/apps/web/src/office-routes.test.ts
+++ b/apps/web/src/office-routes.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveActiveOfficeWorkspaceId } from "./office-routes";
+
+describe("resolveActiveOfficeWorkspaceId", () => {
+  const wsOffice1 = "ws-office-1";
+  const wsOffice2 = "ws-office-2";
+
+  it("prefers explicit route workspace ID", () => {
+    const activeId = resolveActiveOfficeWorkspaceId(
+      [
+        { id: wsOffice1, office_workflow_id: "office-flow-1" },
+        { id: wsOffice2, office_workflow_id: "office-flow-2" },
+      ],
+      wsOffice2,
+      "ws-office-1",
+      null,
+      null,
+    );
+
+    expect(activeId).toBe(wsOffice2);
+  });
+
+  it("falls back to the generic office workspace cookie and then settings", () => {
+    const activeId = resolveActiveOfficeWorkspaceId(
+      [
+        { id: wsOffice1, office_workflow_id: "office-flow-1" },
+        { id: wsOffice2, office_workflow_id: "office-flow-2" },
+      ],
+      null,
+      "ws-missing",
+      wsOffice1,
+      wsOffice2,
+    );
+
+    expect(activeId).toBe(wsOffice1);
+  });
+});

--- a/apps/web/src/office-routes.tsx
+++ b/apps/web/src/office-routes.tsx
@@ -247,7 +247,7 @@ function useOfficeRouteBootstrap(
   return bootstrap;
 }
 
-function resolveActiveOfficeWorkspaceId(
+export function resolveActiveOfficeWorkspaceId(
   workspaceItems: { id: string }[],
   routeWorkspaceId: string | null,
   activeCookieWorkspaceId: string | null,

--- a/apps/web/src/office-routes.tsx
+++ b/apps/web/src/office-routes.tsx
@@ -35,7 +35,12 @@ import {
 } from "@/lib/api/domains/office-api";
 import { useAppStore, useAppStoreApi } from "@/components/state-provider";
 import { useRouter, useSearchParams } from "@/lib/routing/client-router";
-import { mapWorkspaceItem, readActiveWorkspaceCookie } from "@/lib/routing/route-bootstrap";
+import {
+  LEGACY_OFFICE_ACTIVE_WORKSPACE_COOKIE,
+  mapWorkspaceItem,
+  readActiveWorkspaceCookie,
+  readCookie,
+} from "@/lib/routing/route-bootstrap";
 import type { WorkspaceState } from "@/lib/state/slices/workspace/types";
 import { mapUserSettingsResponse } from "@/lib/ssr/user-settings";
 import {
@@ -196,6 +201,7 @@ function useOfficeRouteBootstrap(
         officeWorkspaceItems,
         routeWorkspaceId,
         readActiveWorkspaceCookie(),
+        readCookie(LEGACY_OFFICE_ACTIVE_WORKSPACE_COOKIE),
         userSettingsResponse?.settings?.workspace_id ?? null,
       );
 
@@ -244,12 +250,14 @@ function useOfficeRouteBootstrap(
 function resolveActiveOfficeWorkspaceId(
   workspaceItems: { id: string }[],
   routeWorkspaceId: string | null,
-  cookieWorkspaceId: string | null,
+  activeCookieWorkspaceId: string | null,
+  officeCookieWorkspaceId: string | null,
   settingsWorkspaceId: string | null,
 ): string | null {
   return (
     workspaceItems.find((workspace) => workspace.id === routeWorkspaceId)?.id ??
-    workspaceItems.find((workspace) => workspace.id === cookieWorkspaceId)?.id ??
+    workspaceItems.find((workspace) => workspace.id === activeCookieWorkspaceId)?.id ??
+    workspaceItems.find((workspace) => workspace.id === officeCookieWorkspaceId)?.id ??
     workspaceItems.find((workspace) => workspace.id === settingsWorkspaceId)?.id ??
     workspaceItems[0]?.id ??
     null

--- a/apps/web/src/office-routes.tsx
+++ b/apps/web/src/office-routes.tsx
@@ -248,7 +248,7 @@ function useOfficeRouteBootstrap(
 }
 
 export function resolveActiveOfficeWorkspaceId(
-  workspaceItems: { id: string }[],
+  workspaceItems: { id: string; office_workflow_id?: string | null }[],
   routeWorkspaceId: string | null,
   activeCookieWorkspaceId: string | null,
   officeCookieWorkspaceId: string | null,

--- a/apps/web/src/settings-routes.test.ts
+++ b/apps/web/src/settings-routes.test.ts
@@ -4,55 +4,98 @@ import { workspaceId } from "@/lib/types/ids";
 import type { ListWorkspacesResponse, UserSettingsResponse } from "@/lib/types/http";
 import { buildSettingsInitialStateForRoute } from "./settings-routes";
 
+const ACTIVE_WORKSPACE_COOKIE = "kandev-active-workspace";
+const OWNER_ID = "owner-1";
+const TIMESTAMP = "2026-01-01T00:00:00Z";
+const SETTINGS_ROUTE = "/settings/integrations";
+
 describe("buildSettingsInitialStateForRoute", () => {
   beforeEach(() => {
-    document.cookie = "kandev-active-workspace=; path=/; max-age=0";
+    document.cookie = `${ACTIVE_WORKSPACE_COOKIE}=; path=/; max-age=0`;
   });
 
-  it("prefers the workspace matching the URL path param", () => {
-    const state = buildState({
-      pathname: "/settings/workspace/ws-2/repositories",
-      workspaces: workspaceRows(["ws-1", "ws-2"]),
-      userSettingsResponse: userSettings({ workspace_id: workspaceId("ws-1") }),
+  describe("workspace selection", () => {
+    it("prefers the workspace matching the URL path param", () => {
+      const state = buildState({
+        pathname: "/settings/workspace/ws-2/repositories",
+        workspaces: workspaceRows(["ws-1", "ws-2"]),
+        userSettingsResponse: userSettings({ workspace_id: workspaceId("ws-1") }),
+      });
+
+      expect(state.workspaces?.activeId).toBe("ws-2");
+      expect(state.userSettings?.workspaceId).toBe("ws-2");
     });
 
-    expect(state.workspaces?.activeId).toBe("ws-2");
-    expect(state.userSettings?.workspaceId).toBe("ws-2");
+    it("keeps the active workspace cookie on global settings pages", () => {
+      document.cookie = `${ACTIVE_WORKSPACE_COOKIE}=ws-2; path=/`;
+
+      const state = buildState({
+        pathname: SETTINGS_ROUTE,
+        workspaces: workspaceRows(["ws-1", "ws-2"]),
+        userSettingsResponse: userSettings({ workspace_id: workspaceId("ws-1") }),
+      });
+
+      expect(state.workspaces?.activeId).toBe("ws-2");
+      expect(state.userSettings?.workspaceId).toBe("ws-2");
+    });
+
+    it("falls back to user settings when cookie has an office workspace", () => {
+      document.cookie = `${ACTIVE_WORKSPACE_COOKIE}=ws-office; path=/`;
+
+      const state = buildState({
+        pathname: SETTINGS_ROUTE,
+        workspaces: [
+          buildWorkspace({ id: "ws-office", office_workflow_id: "office" }),
+          buildWorkspace({ id: "ws-kanban", office_workflow_id: null }),
+        ],
+        userSettingsResponse: userSettings({ workspace_id: workspaceId("ws-kanban") }),
+      });
+
+      expect(state.workspaces?.activeId).toBe("ws-kanban");
+      expect(state.userSettings?.workspaceId).toBe("ws-kanban");
+    });
   });
 
-  it("keeps the active workspace cookie on global settings pages", () => {
-    document.cookie = "kandev-active-workspace=ws-2; path=/";
+  describe("fallbacks", () => {
+    it("falls back to the settings workspace_id when no URL param matches", () => {
+      const state = buildState({
+        pathname: "/settings/workspace/missing/repositories",
+        workspaces: workspaceRows(["ws-1", "ws-2"]),
+        userSettingsResponse: userSettings({ workspace_id: workspaceId("ws-2") }),
+      });
 
-    const state = buildState({
-      pathname: "/settings/integrations",
-      workspaces: workspaceRows(["ws-1", "ws-2"]),
-      userSettingsResponse: userSettings({ workspace_id: workspaceId("ws-1") }),
+      expect(state.workspaces?.activeId).toBe("ws-2");
+      expect(state.userSettings?.workspaceId).toBe("ws-2");
     });
 
-    expect(state.workspaces?.activeId).toBe("ws-2");
-    expect(state.userSettings?.workspaceId).toBe("ws-2");
-  });
+    it("falls back to the first workspace when neither URL param nor settings match", () => {
+      const state = buildState({
+        pathname: "/settings/utility-agents",
+        workspaces: workspaceRows(["ws-1", "ws-2"]),
+        userSettingsResponse: userSettings({ workspace_id: workspaceId("missing") }),
+      });
 
-  it("falls back to the settings workspace_id when no URL param matches", () => {
-    const state = buildState({
-      pathname: "/settings/workspace/missing/repositories",
-      workspaces: workspaceRows(["ws-1", "ws-2"]),
-      userSettingsResponse: userSettings({ workspace_id: workspaceId("ws-2") }),
+      expect(state.workspaces?.activeId).toBe("ws-1");
+      expect(state.userSettings?.workspaceId).toBe("ws-1");
     });
 
-    expect(state.workspaces?.activeId).toBe("ws-2");
-    expect(state.userSettings?.workspaceId).toBe("ws-2");
-  });
+    it("returns empty state defaults when all API calls fail", () => {
+      const state = buildState({ userSettingsResponse: null });
 
-  it("falls back to the first workspace when neither URL param nor settings match", () => {
-    const state = buildState({
-      pathname: "/settings/utility-agents",
-      workspaces: workspaceRows(["ws-1", "ws-2"]),
-      userSettingsResponse: userSettings({ workspace_id: workspaceId("missing") }),
+      expect(state.workspaces).toEqual({ items: [], activeId: null });
+      expect(state.executors).toEqual({ items: [] });
+      expect(state.agentProfiles).toEqual({ items: [], version: 0 });
+      expect(state.settingsAgents).toEqual({ items: [] });
+      expect(state.agentDiscovery).toEqual({ items: [], loading: false, loaded: true });
+      expect(state.availableAgents).toEqual({
+        items: [],
+        tools: [],
+        loading: false,
+        loaded: true,
+      });
+      expect(state.settingsData).toEqual({ executorsLoaded: true, agentsLoaded: true });
+      expect(state.userSettings).toBeUndefined();
     });
-
-    expect(state.workspaces?.activeId).toBe("ws-1");
-    expect(state.userSettings?.workspaceId).toBe("ws-1");
   });
 
   it("only spreads userSettings when settings were loaded", () => {
@@ -67,24 +110,6 @@ describe("buildSettingsInitialStateForRoute", () => {
 
     expect(loaded.userSettings?.loaded).toBe(true);
     expect(failed.userSettings).toBeUndefined();
-  });
-
-  it("returns empty state defaults when all API calls fail", () => {
-    const state = buildState({ userSettingsResponse: null });
-
-    expect(state.workspaces).toEqual({ items: [], activeId: null });
-    expect(state.executors).toEqual({ items: [] });
-    expect(state.agentProfiles).toEqual({ items: [], version: 0 });
-    expect(state.settingsAgents).toEqual({ items: [] });
-    expect(state.agentDiscovery).toEqual({ items: [], loading: false, loaded: true });
-    expect(state.availableAgents).toEqual({
-      items: [],
-      tools: [],
-      loading: false,
-      loaded: true,
-    });
-    expect(state.settingsData).toEqual({ executorsLoaded: true, agentsLoaded: true });
-    expect(state.userSettings).toBeUndefined();
   });
 });
 
@@ -104,20 +129,30 @@ function buildState(
   });
 }
 
-function workspaceRows(ids: string[]): ListWorkspacesResponse["workspaces"] {
-  return ids.map((id) => ({
-    id: workspaceId(id),
-    name: `Workspace ${id}`,
+function buildWorkspace(
+  params: Partial<ListWorkspacesResponse["workspaces"][number]> & {
+    id: string;
+    office_workflow_id: string | null;
+  },
+) {
+  return {
+    id: workspaceId(params.id),
+    name: `Workspace ${params.id}`,
     description: null,
-    owner_id: "owner-1",
+    owner_id: OWNER_ID,
     default_executor_id: null,
     default_environment_id: null,
     default_agent_profile_id: null,
     default_config_agent_profile_id: null,
-    office_workflow_id: null,
-    created_at: "2026-01-01T00:00:00Z",
-    updated_at: "2026-01-01T00:00:00Z",
-  })) as unknown as ListWorkspacesResponse["workspaces"];
+    office_workflow_id: params.office_workflow_id,
+    created_at: TIMESTAMP,
+    updated_at: TIMESTAMP,
+    ...params,
+  } as unknown as ListWorkspacesResponse["workspaces"][number];
+}
+
+function workspaceRows(ids: string[]): ListWorkspacesResponse["workspaces"] {
+  return ids.map((id) => buildWorkspace({ id, office_workflow_id: null }));
 }
 
 function userSettings(
@@ -125,11 +160,11 @@ function userSettings(
 ): UserSettingsResponse {
   return {
     settings: {
-      user_id: "user-1",
+      user_id: OWNER_ID,
       workspace_id: workspaceId(""),
       workflow_filter_id: "",
       repository_ids: [],
-      updated_at: "2026-01-01T00:00:00Z",
+      updated_at: TIMESTAMP,
       ...settings,
     },
   };

--- a/apps/web/src/settings-routes.test.ts
+++ b/apps/web/src/settings-routes.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
-import { workspaceId } from "@/lib/types/ids";
+import { workspaceId, workflowId } from "@/lib/types/ids";
 import type { ListWorkspacesResponse, UserSettingsResponse } from "@/lib/types/http";
 import { buildSettingsInitialStateForRoute } from "./settings-routes";
 
@@ -45,7 +45,7 @@ describe("buildSettingsInitialStateForRoute", () => {
       const state = buildState({
         pathname: SETTINGS_ROUTE,
         workspaces: [
-          buildWorkspace({ id: "ws-office", office_workflow_id: "office" }),
+          buildWorkspace({ id: "ws-office", office_workflow_id: workflowId("office") }),
           buildWorkspace({ id: "ws-kanban", office_workflow_id: null }),
         ],
         userSettingsResponse: userSettings({ workspace_id: workspaceId("ws-kanban") }),
@@ -130,24 +130,28 @@ function buildState(
 }
 
 function buildWorkspace(
-  params: Partial<ListWorkspacesResponse["workspaces"][number]> & {
+  params: Omit<
+    Partial<ListWorkspacesResponse["workspaces"][number]>,
+    "id" | "office_workflow_id"
+  > & {
     id: string;
-    office_workflow_id: string | null;
+    office_workflow_id: ReturnType<typeof workflowId> | null;
   },
 ) {
+  const { id, office_workflow_id, ...rest } = params;
   return {
-    id: workspaceId(params.id),
-    name: `Workspace ${params.id}`,
+    id: workspaceId(id),
+    name: `Workspace ${id}`,
     description: null,
     owner_id: OWNER_ID,
     default_executor_id: null,
     default_environment_id: null,
     default_agent_profile_id: null,
     default_config_agent_profile_id: null,
-    office_workflow_id: params.office_workflow_id,
+    office_workflow_id,
     created_at: TIMESTAMP,
     updated_at: TIMESTAMP,
-    ...params,
+    ...rest,
   } as unknown as ListWorkspacesResponse["workspaces"][number];
 }
 
@@ -162,7 +166,7 @@ function userSettings(
     settings: {
       user_id: OWNER_ID,
       workspace_id: workspaceId(""),
-      workflow_filter_id: "",
+      workflow_filter_id: workflowId(""),
       repository_ids: [],
       updated_at: TIMESTAMP,
       ...settings,

--- a/apps/web/src/settings-routes.test.ts
+++ b/apps/web/src/settings-routes.test.ts
@@ -1,13 +1,30 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 
 import { workspaceId } from "@/lib/types/ids";
 import type { ListWorkspacesResponse, UserSettingsResponse } from "@/lib/types/http";
 import { buildSettingsInitialStateForRoute } from "./settings-routes";
 
 describe("buildSettingsInitialStateForRoute", () => {
+  beforeEach(() => {
+    document.cookie = "kandev-active-workspace=; path=/; max-age=0";
+  });
+
   it("prefers the workspace matching the URL path param", () => {
     const state = buildState({
       pathname: "/settings/workspace/ws-2/repositories",
+      workspaces: workspaceRows(["ws-1", "ws-2"]),
+      userSettingsResponse: userSettings({ workspace_id: workspaceId("ws-1") }),
+    });
+
+    expect(state.workspaces?.activeId).toBe("ws-2");
+    expect(state.userSettings?.workspaceId).toBe("ws-2");
+  });
+
+  it("keeps the active workspace cookie on global settings pages", () => {
+    document.cookie = "kandev-active-workspace=ws-2; path=/";
+
+    const state = buildState({
+      pathname: "/settings/integrations",
       workspaces: workspaceRows(["ws-1", "ws-2"]),
       userSettingsResponse: userSettings({ workspace_id: workspaceId("ws-1") }),
     });

--- a/apps/web/src/settings-routes.tsx
+++ b/apps/web/src/settings-routes.tsx
@@ -425,6 +425,7 @@ function resolveSettingsActiveWorkspaceId(
     workspaceItems.find((workspace) => workspace.id === requestedWorkspaceId)?.id ??
     kanbanWorkspaceItems.find((workspace) => workspace.id === activeCookieWorkspaceId)?.id ??
     kanbanWorkspaceItems.find((workspace) => workspace.id === settingsWorkspaceId)?.id ??
+    kanbanWorkspaceItems[0]?.id ??
     workspaceItems[0]?.id ??
     null
   );

--- a/apps/web/src/settings-routes.tsx
+++ b/apps/web/src/settings-routes.tsx
@@ -414,15 +414,17 @@ export function buildSettingsInitialStateForRoute({
 }
 
 function resolveSettingsActiveWorkspaceId(
-  workspaceItems: Array<{ id: string }>,
+  workspaceItems: Array<{ id: string; office_workflow_id: string | null }>,
   requestedWorkspaceId: string | null,
   activeCookieWorkspaceId: string | null,
   settingsWorkspaceId: string | null,
 ) {
+  const kanbanWorkspaceItems = workspaceItems.filter((workspace) => !workspace.office_workflow_id);
+
   return (
     workspaceItems.find((workspace) => workspace.id === requestedWorkspaceId)?.id ??
-    workspaceItems.find((workspace) => workspace.id === activeCookieWorkspaceId)?.id ??
-    workspaceItems.find((workspace) => workspace.id === settingsWorkspaceId)?.id ??
+    kanbanWorkspaceItems.find((workspace) => workspace.id === activeCookieWorkspaceId)?.id ??
+    kanbanWorkspaceItems.find((workspace) => workspace.id === settingsWorkspaceId)?.id ??
     workspaceItems[0]?.id ??
     null
   );

--- a/apps/web/src/settings-routes.tsx
+++ b/apps/web/src/settings-routes.tsx
@@ -66,7 +66,7 @@ import {
 import { listWorkflowTemplates } from "@/lib/api/domains/workflow-api";
 import { listRepositories, listWorkspaces } from "@/lib/api/domains/workspace-api";
 import { useRouter } from "@/lib/routing/client-router";
-import { mapWorkspaceItem } from "@/lib/routing/route-bootstrap";
+import { mapWorkspaceItem, readActiveWorkspaceCookie } from "@/lib/routing/route-bootstrap";
 import { mapUserSettingsResponse } from "@/lib/ssr/user-settings";
 import type { AppState } from "@/lib/state/store";
 import { toAgentProfileOption } from "@/lib/state/slices/settings/types";
@@ -379,6 +379,7 @@ export function buildSettingsInitialStateForRoute({
   const activeWorkspaceId = resolveSettingsActiveWorkspaceId(
     workspaceItems,
     matchSingle(pathname, /^\/settings\/workspace\/([^/]+)/),
+    readActiveWorkspaceCookie(),
     userSettingsResponse?.settings?.workspace_id ?? null,
   );
   const mappedUserSettings = mapUserSettingsResponse(userSettingsResponse);
@@ -415,10 +416,12 @@ export function buildSettingsInitialStateForRoute({
 function resolveSettingsActiveWorkspaceId(
   workspaceItems: Array<{ id: string }>,
   requestedWorkspaceId: string | null,
+  activeCookieWorkspaceId: string | null,
   settingsWorkspaceId: string | null,
 ) {
   return (
     workspaceItems.find((workspace) => workspace.id === requestedWorkspaceId)?.id ??
+    workspaceItems.find((workspace) => workspace.id === activeCookieWorkspaceId)?.id ??
     workspaceItems.find((workspace) => workspace.id === settingsWorkspaceId)?.id ??
     workspaceItems[0]?.id ??
     null

--- a/apps/web/src/settings-routes.tsx
+++ b/apps/web/src/settings-routes.tsx
@@ -66,7 +66,11 @@ import {
 import { listWorkflowTemplates } from "@/lib/api/domains/workflow-api";
 import { listRepositories, listWorkspaces } from "@/lib/api/domains/workspace-api";
 import { useRouter } from "@/lib/routing/client-router";
-import { mapWorkspaceItem, readActiveWorkspaceCookie } from "@/lib/routing/route-bootstrap";
+import {
+  mapWorkspaceItem,
+  readActiveWorkspaceCookie,
+  resolveSettingsActiveWorkspaceId,
+} from "@/lib/routing/route-bootstrap";
 import { mapUserSettingsResponse } from "@/lib/ssr/user-settings";
 import type { AppState } from "@/lib/state/store";
 import { toAgentProfileOption } from "@/lib/state/slices/settings/types";
@@ -411,24 +415,6 @@ export function buildSettingsInitialStateForRoute({
         }
       : {}),
   };
-}
-
-function resolveSettingsActiveWorkspaceId(
-  workspaceItems: Array<{ id: string; office_workflow_id: string | null }>,
-  requestedWorkspaceId: string | null,
-  activeCookieWorkspaceId: string | null,
-  settingsWorkspaceId: string | null,
-) {
-  const kanbanWorkspaceItems = workspaceItems.filter((workspace) => !workspace.office_workflow_id);
-
-  return (
-    workspaceItems.find((workspace) => workspace.id === requestedWorkspaceId)?.id ??
-    kanbanWorkspaceItems.find((workspace) => workspace.id === activeCookieWorkspaceId)?.id ??
-    kanbanWorkspaceItems.find((workspace) => workspace.id === settingsWorkspaceId)?.id ??
-    kanbanWorkspaceItems[0]?.id ??
-    workspaceItems[0]?.id ??
-    null
-  );
 }
 
 function WorkspaceRepositoriesRoute({ workspaceId }: { workspaceId: string }) {

--- a/apps/web/src/spa-routes.tsx
+++ b/apps/web/src/spa-routes.tsx
@@ -199,8 +199,11 @@ function useKanbanRouteBootstrap(route: Extract<SpaRoute, { kind: "kanban" }>) {
       const settingsWorkspaceId = settingsResponse?.settings?.workspace_id || null;
       const settingsWorkflowId = settingsResponse?.settings?.workflow_filter_id || null;
       const workspaceItems = workspacesResponse.workspaces.map(mapWorkspaceItem);
+      const kanbanWorkspaceItems = workspaceItems.filter(
+        (workspace) => !workspace.office_workflow_id,
+      );
       const activeWorkspaceId = resolveActiveId(
-        workspaceItems,
+        kanbanWorkspaceItems,
         route.workspaceId,
         readActiveWorkspaceCookie(),
         settingsWorkspaceId,


### PR DESCRIPTION
Fixing workspace context leakage prevented a navigation regression where `/settings/integrations` could redirect users to the wrong workspace on home after returning. This change ensures the active workspace preference is treated as Kanban-scoped state and is preserved consistently through settings and SPA boot routes.

## Important Changes
- Fixed settings bootstrap to preserve `kandev-active-workspace` and avoid silently falling back to the first/last-used workspace when switching route layers.
- Updated generic cookie workspace resolution to drop Office-specific fallback behavior and added an explicit Office-only path where needed.
- Added regression tests for settings-route workspace preference and home routing cookie fallback behavior.

## Validation
- Not run (not requested).

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1591?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->