### PR TITLE
fix(automation): stop scheduled trigger retry storm on concurrency cap skip

### DIFF
--- a/apps/backend/internal/automation/scheduler_test.go
+++ b/apps/backend/internal/automation/scheduler_test.go
@@ -1,0 +1,144 @@
+package automation
+
+import (
+	"context"
+	"encoding/json"
+	"go.uber.org/zap"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/common/logger"
+)
+
+// TestFireTrigger_SkippedForConcurrencyCap_UpdatesLastEvaluatedAt guards
+// against the scheduler retrying a scheduled trigger on every check tick
+// once max_concurrent_runs is reached. FireTrigger must record that the
+// trigger was evaluated even when the run itself is skipped, otherwise
+// CronScheduler.shouldFire sees a stale LastEvaluatedAt forever and fires
+// again on the very next tick instead of waiting out the configured
+// interval.
+func TestFireTrigger_SkippedForConcurrencyCap_UpdatesLastEvaluatedAt(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	a := &Automation{
+		WorkspaceID:       "ws-1",
+		Name:              "Daily rebase",
+		WorkflowID:        "wf-1",
+		WorkflowStepID:    "s-1",
+		Enabled:           true,
+		MaxConcurrentRuns: 1,
+	}
+	if err := svc.store.CreateAutomation(ctx, a); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, _ := json.Marshal(ScheduledTriggerConfig{CronExpression: "@daily"})
+	trig := &AutomationTrigger{AutomationID: a.ID, Type: TriggerTypeScheduled, Config: cfg, Enabled: true}
+	if err := svc.store.CreateTrigger(ctx, trig); err != nil {
+		t.Fatal(err)
+	}
+
+	// Seed an already-active run so the automation sits at its concurrency cap.
+	active := &AutomationRun{
+		AutomationID: a.ID,
+		TriggerID:    trig.ID,
+		TriggerType:  TriggerTypeScheduled,
+		Status:       RunStatusTaskCreated,
+		DedupKey:     "seed-active-run",
+		TriggerData:  json.RawMessage(`{}`),
+	}
+	if err := svc.store.CreateRun(ctx, active); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := svc.FireTrigger(ctx, a.ID, trig.ID, TriggerTypeScheduled, json.RawMessage(`{}`), "scheduled:trig:1"); err != nil {
+		t.Fatalf("FireTrigger returned error for a skip: %v", err)
+	}
+
+	runs, err := svc.store.ListRuns(ctx, a.ID, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	skipped := 0
+	for _, r := range runs {
+		if r.Status == RunStatusSkipped {
+			skipped++
+		}
+	}
+	if skipped != 1 {
+		t.Fatalf("expected 1 skipped run, got %d (runs=%+v)", skipped, runs)
+	}
+
+	triggers, err := svc.store.ListTriggers(ctx, a.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(triggers) != 1 {
+		t.Fatalf("expected 1 trigger, got %d", len(triggers))
+	}
+	if triggers[0].LastEvaluatedAt == nil {
+		t.Fatal("expected LastEvaluatedAt to be set after a concurrency-cap skip, got nil")
+	}
+}
+
+// TestCronScheduler_DailyTrigger_DoesNotRefireNextTick reproduces the
+// reported bug end to end: a daily scheduled trigger that gets skipped for
+// max_concurrent_runs must not be considered due again on the scheduler's
+// next check tick (30s later in production). Before the fix, a stale
+// LastEvaluatedAt made shouldFire return true on every tick, spamming a new
+// "max_concurrent_runs=n reached" skipped run roughly once a minute forever.
+func TestCronScheduler_DailyTrigger_DoesNotRefireNextTick(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+	log, _ := logger.NewFromZap(zap.NewNop())
+	cs := NewCronScheduler(svc, log)
+
+	a := &Automation{
+		WorkspaceID:       "ws-1",
+		Name:              "Daily rebase",
+		WorkflowID:        "wf-1",
+		WorkflowStepID:    "s-1",
+		Enabled:           true,
+		MaxConcurrentRuns: 1,
+	}
+	if err := svc.store.CreateAutomation(ctx, a); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, _ := json.Marshal(ScheduledTriggerConfig{CronExpression: "@daily"})
+	trig := &AutomationTrigger{AutomationID: a.ID, Type: TriggerTypeScheduled, Config: cfg, Enabled: true}
+	if err := svc.store.CreateTrigger(ctx, trig); err != nil {
+		t.Fatal(err)
+	}
+
+	active := &AutomationRun{
+		AutomationID: a.ID,
+		TriggerID:    trig.ID,
+		TriggerType:  TriggerTypeScheduled,
+		Status:       RunStatusTaskCreated,
+		DedupKey:     "seed-active-run",
+		TriggerData:  json.RawMessage(`{}`),
+	}
+	if err := svc.store.CreateRun(ctx, active); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now()
+	cs.fire(ctx, trig, now)
+
+	triggers, err := svc.store.ListTriggers(ctx, a.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(triggers) != 1 {
+		t.Fatalf("expected 1 trigger, got %d", len(triggers))
+	}
+	updated := triggers[0]
+
+	// One minute later — well within the @daily interval — the scheduler
+	// must not treat the trigger as due again.
+	if cs.shouldFire(&updated, now.Add(time.Minute)) {
+		t.Fatal("expected shouldFire to be false one minute after a skipped evaluation of a daily trigger")
+	}
+}

--- a/apps/backend/internal/automation/scheduler_test.go
+++ b/apps/backend/internal/automation/scheduler_test.go
@@ -142,3 +142,58 @@ func TestCronScheduler_DailyTrigger_DoesNotRefireNextTick(t *testing.T) {
 		t.Fatal("expected shouldFire to be false one minute after a skipped evaluation of a daily trigger")
 	}
 }
+
+// TestFireTrigger_ConcurrencyCapCheckError_DoesNotAdvanceLastEvaluatedAt guards
+// against silently missing a whole day of a @daily trigger's schedule. If
+// maybeSkipForConcurrencyCap fails for an infrastructural reason (e.g. the
+// reader pool backing CountActiveRuns is briefly unavailable), FireTrigger
+// must return the error without having already advanced LastEvaluatedAt.
+// Otherwise CronScheduler.shouldFire treats the trigger as freshly
+// evaluated and suppresses the next attempt until the full cron interval
+// elapses, instead of retrying on the next 30s scheduler tick.
+func TestFireTrigger_ConcurrencyCapCheckError_DoesNotAdvanceLastEvaluatedAt(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	a := &Automation{
+		WorkspaceID:       "ws-1",
+		Name:              "Daily rebase",
+		WorkflowID:        "wf-1",
+		WorkflowStepID:    "s-1",
+		Enabled:           true,
+		MaxConcurrentRuns: 1,
+	}
+	if err := svc.store.CreateAutomation(ctx, a); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, _ := json.Marshal(ScheduledTriggerConfig{CronExpression: "@daily"})
+	trig := &AutomationTrigger{AutomationID: a.ID, Type: TriggerTypeScheduled, Config: cfg, Enabled: true}
+	if err := svc.store.CreateTrigger(ctx, trig); err != nil {
+		t.Fatal(err)
+	}
+
+	// Break CountActiveRuns in isolation: it queries automation_runs while
+	// GetAutomation (the earlier lookup in maybeSkipForConcurrencyCap) only
+	// queries automations, so dropping just the former reproduces "the cap
+	// check itself failed" without masking the failure behind an earlier,
+	// softly-handled lookup error.
+	if _, err := svc.store.db.ExecContext(ctx, `DROP TABLE automation_runs`); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := svc.FireTrigger(ctx, a.ID, trig.ID, TriggerTypeScheduled, json.RawMessage(`{}`), ""); err == nil {
+		t.Fatal("expected FireTrigger to return the concurrency-cap check error")
+	}
+
+	triggers, err := svc.store.ListTriggers(ctx, a.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(triggers) != 1 {
+		t.Fatalf("expected 1 trigger, got %d", len(triggers))
+	}
+	if triggers[0].LastEvaluatedAt != nil {
+		t.Fatal("expected LastEvaluatedAt to remain nil after a concurrency-cap check error, got non-nil")
+	}
+}

--- a/apps/backend/internal/automation/service.go
+++ b/apps/backend/internal/automation/service.go
@@ -193,6 +193,18 @@ func (s *Service) FireTrigger(ctx context.Context, automationID, triggerID strin
 		}
 	}
 
+	// Record that the trigger was evaluated regardless of outcome. Scheduled
+	// triggers use this to pace themselves against their cron interval
+	// (CronScheduler.shouldFire): if it were only updated on an actual fire,
+	// a trigger stuck behind max_concurrent_runs would look "overdue" again
+	// on every subsequent scheduler tick and get re-evaluated — and
+	// re-skipped — far more often than its configured schedule.
+	now := time.Now().UTC()
+	if updateErr := s.store.UpdateTriggerEvaluatedAt(ctx, triggerID, now); updateErr != nil {
+		s.logger.Warn("failed to update last_evaluated_at",
+			zap.String("trigger_id", triggerID), zap.Error(updateErr))
+	}
+
 	// Enforce max_concurrent_runs: a run is "active" while still in
 	// task_created (succeeded/failed/skipped don't count). If at the cap,
 	// record a skipped run so the user can see the cap kicked in.
@@ -212,14 +224,9 @@ func (s *Service) FireTrigger(ctx context.Context, automationID, triggerID strin
 		DedupKey:     dedupKey,
 	}
 
-	now := time.Now().UTC()
 	if updateErr := s.store.UpdateLastTriggered(ctx, automationID, now); updateErr != nil {
 		s.logger.Warn("failed to update last_triggered_at",
 			zap.String("automation_id", automationID), zap.Error(updateErr))
-	}
-	if updateErr := s.store.UpdateTriggerEvaluatedAt(ctx, triggerID, now); updateErr != nil {
-		s.logger.Warn("failed to update last_evaluated_at",
-			zap.String("trigger_id", triggerID), zap.Error(updateErr))
 	}
 
 	event := bus.NewEvent(events.AutomationTriggered, "automation_service", evt)

--- a/apps/backend/internal/automation/service.go
+++ b/apps/backend/internal/automation/service.go
@@ -193,24 +193,29 @@ func (s *Service) FireTrigger(ctx context.Context, automationID, triggerID strin
 		}
 	}
 
-	// Record that the trigger was evaluated regardless of outcome. Scheduled
-	// triggers use this to pace themselves against their cron interval
-	// (CronScheduler.shouldFire): if it were only updated on an actual fire,
-	// a trigger stuck behind max_concurrent_runs would look "overdue" again
-	// on every subsequent scheduler tick and get re-evaluated — and
-	// re-skipped — far more often than its configured schedule.
-	now := time.Now().UTC()
-	if updateErr := s.store.UpdateTriggerEvaluatedAt(ctx, triggerID, now); updateErr != nil {
-		s.logger.Warn("failed to update last_evaluated_at",
-			zap.String("trigger_id", triggerID), zap.Error(updateErr))
-	}
-
 	// Enforce max_concurrent_runs: a run is "active" while still in
 	// task_created (succeeded/failed/skipped don't count). If at the cap,
 	// record a skipped run so the user can see the cap kicked in.
 	skipped, capErr := s.maybeSkipForConcurrencyCap(ctx, automationID, triggerID, triggerType, triggerData, dedupKey)
 	if capErr != nil {
 		return capErr
+	}
+
+	// Record that the trigger was evaluated now that the cap check itself
+	// has succeeded. Scheduled triggers use this to pace themselves against
+	// their cron interval (CronScheduler.shouldFire): if this were updated
+	// before the cap check (or despite the cap check returning an error), an
+	// infrastructural failure in the check would look like a completed
+	// evaluation and suppress the next attempt until the full cron interval
+	// elapses, instead of retrying on the next scheduler tick. And if it
+	// were only updated on an actual fire, a trigger stuck behind
+	// max_concurrent_runs would look "overdue" again on every subsequent
+	// tick and get re-evaluated — and re-skipped — far more often than its
+	// configured schedule.
+	now := time.Now().UTC()
+	if updateErr := s.store.UpdateTriggerEvaluatedAt(ctx, triggerID, now); updateErr != nil {
+		s.logger.Warn("failed to update last_evaluated_at",
+			zap.String("trigger_id", triggerID), zap.Error(updateErr))
 	}
 	if skipped {
 		return nil


### PR DESCRIPTION
Scheduled automations were retrying roughly once a minute forever after hitting `max_concurrent_runs`, regardless of their configured cron interval (e.g. a `@daily` trigger), because the skip path never advanced the trigger's evaluation clock.

## Validation

- `go test ./internal/automation/...` (new tests `TestFireTrigger_SkippedForConcurrencyCap_UpdatesLastEvaluatedAt` and `TestCronScheduler_DailyTrigger_DoesNotRefireNextTick` fail before the fix, pass after)
- `make -C apps/backend fmt`
- `make -C apps/backend lint` — 0 issues
- `make -C apps/backend test` — full suite green, aside from `TestProcessRunnerCapturesOutput` in `internal/agentctl/server/process`, confirmed pre-existing/flaky via `git stash` on a clean tree (unrelated package, untouched by this change)
- `apps/web` typecheck and lint — unaffected (no frontend files changed)

## Possible Improvements

Low risk: change is confined to `FireTrigger`'s bookkeeping order in one file; behavior for non-scheduled trigger types (webhook/manual/PR) is unaffected since only the scheduler reads `last_evaluated_at`.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1598?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

