### PR TITLE
fix: route controlled diff comment updates

### DIFF
--- a/apps/web/components/diff/diff-viewer-comment-edit.test.tsx
+++ b/apps/web/components/diff/diff-viewer-comment-edit.test.tsx
@@ -81,6 +81,7 @@ function latestCommentText(): string | undefined {
 }
 
 beforeEach(() => {
+  window.sessionStorage.clear();
   useCommentsStore.setState({
     byId: {},
     bySession: {},
@@ -92,7 +93,7 @@ beforeEach(() => {
 
 afterEach(cleanup);
 
-describe("DiffViewer comment editing (internal store mode)", () => {
+describe("DiffViewer comment editing", () => {
   it("propagates an edited comment's new text to the renderer", async () => {
     useCommentsStore.getState().addComment(comment(ORIGINAL_TEXT));
 
@@ -122,5 +123,32 @@ describe("DiffViewer comment editing (internal store mode)", () => {
 
     await waitFor(() => expect(latestCommentText()).toBe(EDITED_TEXT));
     expect(screen.getByText(EDITED_TEXT)).toBeTruthy();
+  });
+
+  it("routes controlled inline edits to onCommentUpdate", async () => {
+    const onCommentUpdate = vi.fn();
+
+    render(
+      <DiffViewer
+        data={data}
+        sessionId={SESSION_ID}
+        enableComments
+        comments={[comment(ORIGINAL_TEXT)]}
+        onCommentUpdate={onCommentUpdate}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByText(ORIGINAL_TEXT)).toBeTruthy());
+
+    fireEvent.click(screen.getByLabelText("Edit comment"));
+    fireEvent.change(screen.getByPlaceholderText("Add a comment..."), {
+      target: { value: EDITED_TEXT },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Update/i }));
+
+    await waitFor(() =>
+      expect(onCommentUpdate).toHaveBeenCalledWith(COMMENT_ID, { text: EDITED_TEXT }),
+    );
+    expect(useCommentsStore.getState().byId[COMMENT_ID]?.text).not.toBe(EDITED_TEXT);
   });
 });

--- a/apps/web/components/diff/diff-viewer-comment-edit.test.tsx
+++ b/apps/web/components/diff/diff-viewer-comment-edit.test.tsx
@@ -1,0 +1,126 @@
+import type { ReactNode } from "react";
+import type { DiffLineAnnotation } from "@pierre/diffs";
+import { cleanup, fireEvent, render, screen, waitFor, act } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { DiffViewer } from "./diff-viewer";
+import type { FileDiffData, DiffComment } from "@/lib/diff/types";
+import { useCommentsStore } from "@/lib/state/slices/comments";
+import type { AnnotationMetadata } from "./use-diff-annotation-renderer";
+
+type CapturedProps = {
+  lineAnnotations?: Array<DiffLineAnnotation<AnnotationMetadata>>;
+  renderAnnotation?: (annotation: DiffLineAnnotation<AnnotationMetadata>) => ReactNode;
+};
+
+const captured: CapturedProps[] = [];
+
+vi.mock("@/components/theme/app-theme", () => ({
+  useTheme: () => ({ resolvedTheme: "dark" }),
+}));
+
+// Capture the props (notably lineAnnotations) handed to Pierre's FileDiff so we
+// can assert the internal comment-edit pipeline reaches the renderer with the
+// updated text. Pierre itself is a web-component-backed renderer that does not
+// run meaningfully in jsdom, so stubbing it and inspecting props is the
+// reliable way to test propagation.
+vi.mock("@pierre/diffs/react", () => ({
+  FileDiff: (props: CapturedProps) => {
+    captured.push(props);
+    return (
+      <div data-testid="file-diff">
+        {props.lineAnnotations?.map((annotation, index) => (
+          <div key={`${annotation.metadata.type}-${index}`}>
+            {props.renderAnnotation?.(annotation)}
+          </div>
+        ))}
+      </div>
+    );
+  },
+}));
+
+const SESSION_ID = "session-edit-test";
+const FILE_PATH = "src/example.ts";
+const COMMENT_ID = "comment-1";
+const ORIGINAL_TEXT = "original text";
+const EDITED_TEXT = "edited text";
+
+const data: FileDiffData = {
+  filePath: FILE_PATH,
+  diff: "diff --git a/src/example.ts b/src/example.ts\n--- a/src/example.ts\n+++ b/src/example.ts\n@@ -1 +1 @@\n-old\n+new\n",
+  oldContent: "old\n",
+  newContent: "new\n",
+  additions: 1,
+  deletions: 1,
+};
+
+function comment(text: string): DiffComment {
+  return {
+    id: COMMENT_ID,
+    sessionId: SESSION_ID,
+    source: "diff",
+    filePath: FILE_PATH,
+    startLine: 1,
+    endLine: 1,
+    side: "additions",
+    codeContent: "new",
+    text,
+    createdAt: "2026-01-01T00:00:00Z",
+    status: "pending",
+  };
+}
+
+/** Latest comment annotation text handed to Pierre for the target comment. */
+function latestCommentText(): string | undefined {
+  for (let i = captured.length - 1; i >= 0; i--) {
+    const annotations = captured[i].lineAnnotations ?? [];
+    const match = annotations.find((a) => a.metadata.comment?.id === COMMENT_ID);
+    if (match) return match.metadata.comment?.text;
+  }
+  return undefined;
+}
+
+beforeEach(() => {
+  useCommentsStore.setState({
+    byId: {},
+    bySession: {},
+    pendingForChat: [],
+    editingCommentId: null,
+  });
+  captured.length = 0;
+});
+
+afterEach(cleanup);
+
+describe("DiffViewer comment editing (internal store mode)", () => {
+  it("propagates an edited comment's new text to the renderer", async () => {
+    useCommentsStore.getState().addComment(comment(ORIGINAL_TEXT));
+
+    render(<DiffViewer data={data} sessionId={SESSION_ID} enableComments />);
+
+    await waitFor(() => expect(latestCommentText()).toBe(ORIGINAL_TEXT));
+
+    act(() => {
+      useCommentsStore.getState().updateComment(COMMENT_ID, { text: EDITED_TEXT });
+    });
+
+    await waitFor(() => expect(latestCommentText()).toBe(EDITED_TEXT));
+  });
+
+  it("submits edited text from the inline comment form", async () => {
+    useCommentsStore.getState().addComment(comment(ORIGINAL_TEXT));
+
+    render(<DiffViewer data={data} sessionId={SESSION_ID} enableComments />);
+
+    await waitFor(() => expect(screen.getByText(ORIGINAL_TEXT)).toBeTruthy());
+
+    fireEvent.click(screen.getByLabelText("Edit comment"));
+    fireEvent.change(screen.getByPlaceholderText("Add a comment..."), {
+      target: { value: EDITED_TEXT },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Update/i }));
+
+    await waitFor(() => expect(latestCommentText()).toBe(EDITED_TEXT));
+    expect(screen.getByText(EDITED_TEXT)).toBeTruthy();
+  });
+});

--- a/apps/web/components/diff/diff-viewer-resolver.tsx
+++ b/apps/web/components/diff/diff-viewer-resolver.tsx
@@ -17,6 +17,7 @@ interface DiffViewerResolverProps {
   sessionId?: string;
   onCommentAdd?: (comment: DiffComment) => void;
   onCommentDelete?: (commentId: string) => void;
+  onCommentUpdate?: (commentId: string, updates: Partial<DiffComment>) => void;
   onCommentRun?: (comment: DiffComment) => void;
   comments?: DiffComment[];
   className?: string;

--- a/apps/web/components/diff/diff-viewer-resolver.tsx
+++ b/apps/web/components/diff/diff-viewer-resolver.tsx
@@ -7,7 +7,7 @@ import {
   DiffViewInline as PierreDiffViewInline,
 } from "./diff-viewer";
 import { MonacoDiffViewer } from "@/components/editors/monaco/monaco-diff-viewer";
-import type { FileDiffData, DiffComment } from "@/lib/diff/types";
+import type { FileDiffData, DiffComment, DiffCommentUpdate } from "@/lib/diff/types";
 import type { RevertBlockInfo } from "./diff-viewer";
 export type { RevertBlockInfo };
 
@@ -17,7 +17,7 @@ interface DiffViewerResolverProps {
   sessionId?: string;
   onCommentAdd?: (comment: DiffComment) => void;
   onCommentDelete?: (commentId: string) => void;
-  onCommentUpdate?: (commentId: string, updates: Partial<DiffComment>) => void;
+  onCommentUpdate?: (commentId: string, updates: DiffCommentUpdate) => void;
   onCommentRun?: (comment: DiffComment) => void;
   comments?: DiffComment[];
   className?: string;

--- a/apps/web/components/diff/diff-viewer.test.tsx
+++ b/apps/web/components/diff/diff-viewer.test.tsx
@@ -38,4 +38,17 @@ describe("DiffViewer", () => {
     await waitFor(() => expect(fileDiffProps.length).toBeGreaterThan(0));
     expect(fileDiffProps.at(-1)?.options?.overflow).toBe("wrap");
   });
+
+  it("rerenders when the controlled delete handler changes", async () => {
+    const firstDelete = vi.fn();
+    const secondDelete = vi.fn();
+    const { rerender } = render(<DiffViewer data={data} onCommentDelete={firstDelete} />);
+
+    await waitFor(() => expect(fileDiffProps.length).toBeGreaterThan(0));
+    const renderCount = fileDiffProps.length;
+
+    rerender(<DiffViewer data={data} onCommentDelete={secondDelete} />);
+
+    await waitFor(() => expect(fileDiffProps.length).toBeGreaterThan(renderCount));
+  });
 });

--- a/apps/web/components/diff/diff-viewer.test.tsx
+++ b/apps/web/components/diff/diff-viewer.test.tsx
@@ -51,4 +51,17 @@ describe("DiffViewer", () => {
 
     await waitFor(() => expect(fileDiffProps.length).toBeGreaterThan(renderCount));
   });
+
+  it("rerenders when the controlled update handler changes", async () => {
+    const firstUpdate = vi.fn();
+    const secondUpdate = vi.fn();
+    const { rerender } = render(<DiffViewer data={data} onCommentUpdate={firstUpdate} />);
+
+    await waitFor(() => expect(fileDiffProps.length).toBeGreaterThan(0));
+    const renderCount = fileDiffProps.length;
+
+    rerender(<DiffViewer data={data} onCommentUpdate={secondUpdate} />);
+
+    await waitFor(() => expect(fileDiffProps.length).toBeGreaterThan(renderCount));
+  });
 });

--- a/apps/web/components/diff/diff-viewer.tsx
+++ b/apps/web/components/diff/diff-viewer.tsx
@@ -25,6 +25,7 @@ interface DiffViewerProps {
   sessionId?: string;
   onCommentAdd?: (comment: DiffComment) => void;
   onCommentDelete?: (commentId: string) => void;
+  onCommentUpdate?: (commentId: string, updates: Partial<DiffComment>) => void;
   onCommentRun?: (comment: DiffComment) => void;
   comments?: DiffComment[];
   className?: string;
@@ -51,6 +52,10 @@ interface DiffViewerProps {
 const SCALAR_PROP_KEYS: (keyof DiffViewerProps)[] = [
   "enableComments",
   "sessionId",
+  "onCommentAdd",
+  "onCommentDelete",
+  "onCommentUpdate",
+  "onCommentRun",
   "compact",
   "hideHeader",
   "className",
@@ -193,6 +198,7 @@ export const DiffViewer = memo(function DiffViewer({
   sessionId,
   onCommentAdd,
   onCommentDelete,
+  onCommentUpdate,
   onCommentRun,
   comments: externalComments,
   className,
@@ -227,6 +233,7 @@ export const DiffViewer = memo(function DiffViewer({
     sessionId,
     onCommentAdd,
     onCommentDelete,
+    onCommentUpdate,
     onCommentRun,
     externalComments,
     onRevertBlock,

--- a/apps/web/components/diff/diff-viewer.tsx
+++ b/apps/web/components/diff/diff-viewer.tsx
@@ -52,6 +52,7 @@ interface DiffViewerProps {
 const SCALAR_PROP_KEYS: (keyof DiffViewerProps)[] = [
   "enableComments",
   "sessionId",
+  "onCommentDelete",
   "onCommentUpdate",
   "compact",
   "hideHeader",

--- a/apps/web/components/diff/diff-viewer.tsx
+++ b/apps/web/components/diff/diff-viewer.tsx
@@ -3,7 +3,7 @@
 import { useState, useRef, useCallback, memo, useEffect } from "react";
 import { FileDiff } from "@pierre/diffs/react";
 import { cn } from "@kandev/ui/lib/utils";
-import type { FileDiffData, DiffComment } from "@/lib/diff/types";
+import type { FileDiffData, DiffComment, DiffCommentUpdate } from "@/lib/diff/types";
 import { useHunkHover } from "./use-hunk-hover";
 import { useAnnotationRenderer } from "./use-diff-annotation-renderer";
 import { DEFAULT_DIFF_WORD_WRAP } from "./diff-defaults";
@@ -25,7 +25,7 @@ interface DiffViewerProps {
   sessionId?: string;
   onCommentAdd?: (comment: DiffComment) => void;
   onCommentDelete?: (commentId: string) => void;
-  onCommentUpdate?: (commentId: string, updates: Partial<DiffComment>) => void;
+  onCommentUpdate?: (commentId: string, updates: DiffCommentUpdate) => void;
   onCommentRun?: (comment: DiffComment) => void;
   comments?: DiffComment[];
   className?: string;
@@ -52,10 +52,7 @@ interface DiffViewerProps {
 const SCALAR_PROP_KEYS: (keyof DiffViewerProps)[] = [
   "enableComments",
   "sessionId",
-  "onCommentAdd",
-  "onCommentDelete",
   "onCommentUpdate",
-  "onCommentRun",
   "compact",
   "hideHeader",
   "className",

--- a/apps/web/components/diff/file-diff-viewer.tsx
+++ b/apps/web/components/diff/file-diff-viewer.tsx
@@ -14,6 +14,7 @@ interface FileDiffViewerProps {
   sessionId?: string;
   onCommentAdd?: (comment: DiffComment) => void;
   onCommentDelete?: (commentId: string) => void;
+  onCommentUpdate?: (commentId: string, updates: Partial<DiffComment>) => void;
   onCommentRun?: (comment: DiffComment) => void;
   comments?: DiffComment[];
   className?: string;
@@ -54,6 +55,7 @@ export const FileDiffViewer = memo(function FileDiffViewer({
   sessionId,
   onCommentAdd,
   onCommentDelete,
+  onCommentUpdate,
   onCommentRun,
   comments,
   className,
@@ -80,6 +82,7 @@ export const FileDiffViewer = memo(function FileDiffViewer({
       sessionId={sessionId}
       onCommentAdd={onCommentAdd}
       onCommentDelete={onCommentDelete}
+      onCommentUpdate={onCommentUpdate}
       onCommentRun={onCommentRun}
       comments={comments}
       className={className}

--- a/apps/web/components/diff/file-diff-viewer.tsx
+++ b/apps/web/components/diff/file-diff-viewer.tsx
@@ -3,7 +3,7 @@
 import { memo, useMemo } from "react";
 import { DiffViewerResolved as DiffViewer } from "./diff-viewer-resolver";
 import { transformGitDiff } from "@/lib/diff";
-import type { DiffComment } from "@/lib/diff/types";
+import type { DiffComment, DiffCommentUpdate } from "@/lib/diff/types";
 import type { RevertBlockInfo } from "./diff-viewer-resolver";
 
 interface FileDiffViewerProps {
@@ -14,7 +14,7 @@ interface FileDiffViewerProps {
   sessionId?: string;
   onCommentAdd?: (comment: DiffComment) => void;
   onCommentDelete?: (commentId: string) => void;
-  onCommentUpdate?: (commentId: string, updates: Partial<DiffComment>) => void;
+  onCommentUpdate?: (commentId: string, updates: DiffCommentUpdate) => void;
   onCommentRun?: (comment: DiffComment) => void;
   comments?: DiffComment[];
   className?: string;

--- a/apps/web/components/diff/use-diff-comments.ts
+++ b/apps/web/components/diff/use-diff-comments.ts
@@ -6,7 +6,12 @@ import type { SelectedLineRange } from "@pierre/diffs";
 import { useCommentsStore } from "@/lib/state/slices/comments";
 import { useDiffFileComments } from "@/hooks/domains/comments/use-diff-comments";
 import { commentsToAnnotations, extractCodeFromDiff, extractCodeFromContent } from "@/lib/diff";
-import type { DiffComment, AnnotationSide, CommentAnnotation } from "@/lib/diff/types";
+import type {
+  DiffComment,
+  DiffCommentUpdate,
+  AnnotationSide,
+  CommentAnnotation,
+} from "@/lib/diff/types";
 
 interface UseDiffCommentsOptions {
   sessionId: string;
@@ -29,7 +34,7 @@ interface UseDiffCommentsReturn {
   /** Remove a comment */
   removeComment: (commentId: string) => void;
   /** Update a comment */
-  updateComment: (commentId: string, updates: Partial<DiffComment>) => void;
+  updateComment: (commentId: string, updates: DiffCommentUpdate) => void;
   /** Currently editing comment ID */
   editingCommentId: string | null;
   /** Set the editing comment ID */
@@ -104,7 +109,7 @@ export function useDiffComments({
   );
 
   const updateComment = useCallback(
-    (commentId: string, updates: Partial<DiffComment>) => {
+    (commentId: string, updates: DiffCommentUpdate) => {
       storeUpdateComment(commentId, updates);
     },
     [storeUpdateComment],

--- a/apps/web/components/diff/use-diff-viewer-state.ts
+++ b/apps/web/components/diff/use-diff-viewer-state.ts
@@ -6,7 +6,7 @@ import type {
   AnnotationSide,
   ChangeContent,
 } from "@pierre/diffs";
-import type { FileDiffData, DiffComment } from "@/lib/diff/types";
+import type { FileDiffData, DiffComment, DiffCommentUpdate } from "@/lib/diff/types";
 import { buildDiffComment, useCommentActions } from "@/lib/diff/comment-utils";
 import { useDiffComments } from "./use-diff-comments";
 import { useDiffMetadata } from "./use-diff-metadata";
@@ -137,7 +137,7 @@ type UseDiffViewerStateOpts = {
   sessionId?: string;
   onCommentAdd?: (comment: DiffComment) => void;
   onCommentDelete?: (commentId: string) => void;
-  onCommentUpdate?: (commentId: string, updates: Partial<DiffComment>) => void;
+  onCommentUpdate?: (commentId: string, updates: DiffCommentUpdate) => void;
   onCommentRun?: (comment: DiffComment) => void;
   externalComments?: DiffComment[];
   onRevertBlock?: (filePath: string, info: RevertBlockInfo) => Promise<void> | void;
@@ -202,10 +202,10 @@ type CommentHandlerOpts = {
   sessionId?: string;
   addComment: (range: SelectedLineRange, content: string) => DiffComment;
   removeComment: (commentId: string) => void;
-  updateComment: (commentId: string, updates: Partial<DiffComment>) => void;
+  updateComment: (commentId: string, updates: DiffCommentUpdate) => void;
   setEditingComment: (commentId: string | null) => void;
   onCommentDelete?: (commentId: string) => void;
-  onCommentUpdate?: (commentId: string, updates: Partial<DiffComment>) => void;
+  onCommentUpdate?: (commentId: string, updates: DiffCommentUpdate) => void;
 };
 
 function useDiffViewerCommentHandlers(opts: CommentHandlerOpts) {

--- a/apps/web/components/diff/use-diff-viewer-state.ts
+++ b/apps/web/components/diff/use-diff-viewer-state.ts
@@ -137,6 +137,7 @@ type UseDiffViewerStateOpts = {
   sessionId?: string;
   onCommentAdd?: (comment: DiffComment) => void;
   onCommentDelete?: (commentId: string) => void;
+  onCommentUpdate?: (commentId: string, updates: Partial<DiffComment>) => void;
   onCommentRun?: (comment: DiffComment) => void;
   externalComments?: DiffComment[];
   onRevertBlock?: (filePath: string, info: RevertBlockInfo) => Promise<void> | void;
@@ -204,6 +205,7 @@ type CommentHandlerOpts = {
   updateComment: (commentId: string, updates: Partial<DiffComment>) => void;
   setEditingComment: (commentId: string | null) => void;
   onCommentDelete?: (commentId: string) => void;
+  onCommentUpdate?: (commentId: string, updates: Partial<DiffComment>) => void;
 };
 
 function useDiffViewerCommentHandlers(opts: CommentHandlerOpts) {
@@ -222,6 +224,7 @@ function useDiffViewerCommentHandlers(opts: CommentHandlerOpts) {
     updateComment,
     setEditingComment,
     onCommentDelete,
+    onCommentUpdate,
   } = opts;
   const handleLineSelectionEnd = useCallback(
     (range: SelectedLineRange | null) => {
@@ -289,6 +292,7 @@ function useDiffViewerCommentHandlers(opts: CommentHandlerOpts) {
     updateComment,
     setEditingComment,
     onCommentDelete,
+    onCommentUpdate,
     externalComments,
   });
 
@@ -325,6 +329,7 @@ export function useDiffViewerState(opts: UseDiffViewerStateOpts) {
     sessionId,
     onCommentAdd,
     onCommentDelete,
+    onCommentUpdate,
     onCommentRun,
     externalComments,
     onRevertBlock,
@@ -393,6 +398,7 @@ export function useDiffViewerState(opts: UseDiffViewerStateOpts) {
     updateComment,
     setEditingComment,
     onCommentDelete,
+    onCommentUpdate,
   });
 
   return {

--- a/apps/web/components/editors/monaco/monaco-diff-viewer.tsx
+++ b/apps/web/components/editors/monaco/monaco-diff-viewer.tsx
@@ -28,6 +28,7 @@ interface MonacoDiffViewerProps {
   sessionId?: string;
   onCommentAdd?: (comment: DiffComment) => void;
   onCommentDelete?: (commentId: string) => void;
+  onCommentUpdate?: (commentId: string, updates: Partial<DiffComment>) => void;
   onCommentRun?: (comment: DiffComment) => void;
   comments?: DiffComment[];
   className?: string;
@@ -47,6 +48,7 @@ function useMonacoDiffViewerState(props: MonacoDiffViewerProps) {
     compact = false,
     onCommentAdd,
     onCommentDelete,
+    onCommentUpdate,
     onCommentRun,
     comments: externalComments,
     onModifiedContentChange,
@@ -68,6 +70,7 @@ function useMonacoDiffViewerState(props: MonacoDiffViewerProps) {
     compact,
     onCommentAdd,
     onCommentDelete,
+    onCommentUpdate,
     onCommentRun,
     externalComments,
     onModifiedContentChange,

--- a/apps/web/components/editors/monaco/monaco-diff-viewer.tsx
+++ b/apps/web/components/editors/monaco/monaco-diff-viewer.tsx
@@ -4,7 +4,7 @@ import { useLayoutEffect, useMemo, useRef, useState } from "react";
 import { DiffEditor } from "@monaco-editor/react";
 import { useTheme } from "@/components/theme/app-theme";
 import { cn } from "@kandev/ui/lib/utils";
-import type { FileDiffData, DiffComment } from "@/lib/diff/types";
+import type { FileDiffData, DiffComment, DiffCommentUpdate } from "@/lib/diff/types";
 import { getMonacoLanguage } from "@/lib/editor/language-map";
 import { useCommandPanelOpen } from "@/lib/commands/command-registry";
 import { useDiffEditorHeight } from "@/hooks/use-diff-editor-height";
@@ -28,7 +28,7 @@ interface MonacoDiffViewerProps {
   sessionId?: string;
   onCommentAdd?: (comment: DiffComment) => void;
   onCommentDelete?: (commentId: string) => void;
-  onCommentUpdate?: (commentId: string, updates: Partial<DiffComment>) => void;
+  onCommentUpdate?: (commentId: string, updates: DiffCommentUpdate) => void;
   onCommentRun?: (comment: DiffComment) => void;
   comments?: DiffComment[];
   className?: string;

--- a/apps/web/components/editors/monaco/use-diff-viewer-comments.ts
+++ b/apps/web/components/editors/monaco/use-diff-viewer-comments.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { editor as monacoEditor } from "monaco-editor";
 import type { DiffOnMount } from "@monaco-editor/react";
-import type { DiffComment } from "@/lib/diff/types";
+import type { DiffComment, DiffCommentUpdate } from "@/lib/diff/types";
 import { buildDiffComment, useCommentedLines, useCommentActions } from "@/lib/diff/comment-utils";
 import { useDiffComments } from "@/components/diff/use-diff-comments";
 import { useGutterComments } from "@/hooks/use-gutter-comments";
@@ -31,7 +31,7 @@ interface UseDiffViewerCommentsOpts {
   compact: boolean;
   onCommentAdd?: (comment: DiffComment) => void;
   onCommentDelete?: (commentId: string) => void;
-  onCommentUpdate?: (commentId: string, updates: Partial<DiffComment>) => void;
+  onCommentUpdate?: (commentId: string, updates: DiffCommentUpdate) => void;
   onCommentRun?: (comment: DiffComment) => void;
   externalComments?: DiffComment[];
   onModifiedContentChange?: (filePath: string, content: string) => void;

--- a/apps/web/components/editors/monaco/use-diff-viewer-comments.ts
+++ b/apps/web/components/editors/monaco/use-diff-viewer-comments.ts
@@ -31,6 +31,7 @@ interface UseDiffViewerCommentsOpts {
   compact: boolean;
   onCommentAdd?: (comment: DiffComment) => void;
   onCommentDelete?: (commentId: string) => void;
+  onCommentUpdate?: (commentId: string, updates: Partial<DiffComment>) => void;
   onCommentRun?: (comment: DiffComment) => void;
   externalComments?: DiffComment[];
   onModifiedContentChange?: (filePath: string, content: string) => void;
@@ -44,6 +45,7 @@ export function useDiffViewerComments(opts: UseDiffViewerCommentsOpts) {
     compact,
     onCommentAdd,
     onCommentDelete,
+    onCommentUpdate,
     onCommentRun,
     externalComments,
     onModifiedContentChange,
@@ -245,6 +247,7 @@ export function useDiffViewerComments(opts: UseDiffViewerCommentsOpts) {
     updateComment,
     setEditingComment,
     onCommentDelete,
+    onCommentUpdate,
     externalComments,
   });
 

--- a/apps/web/components/review/review-comments-overview.test.tsx
+++ b/apps/web/components/review/review-comments-overview.test.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, cleanup, within } from "@testing-library/react";
+import type { DiffComment } from "@/lib/diff/types";
+import { ReviewCommentsOverview, groupCommentsByFile } from "./review-comments-overview";
+
+afterEach(cleanup);
+
+const APP_PATH = "src/app.tsx";
+
+function comment(overrides: Partial<DiffComment>): DiffComment {
+  return {
+    id: "c1",
+    sessionId: "s1",
+    source: "diff",
+    filePath: APP_PATH,
+    startLine: 10,
+    endLine: 10,
+    side: "additions",
+    codeContent: "const x = 1;",
+    text: "fix this",
+    createdAt: "2026-01-01T00:00:00Z",
+    status: "pending",
+    ...overrides,
+  };
+}
+
+describe("groupCommentsByFile", () => {
+  it("groups comments by file preserving first-seen order", () => {
+    const groups = groupCommentsByFile([
+      comment({ id: "a", filePath: "b.ts" }),
+      comment({ id: "b", filePath: "a.ts" }),
+      comment({ id: "c", filePath: "b.ts" }),
+    ]);
+    expect(groups.map((g) => g.filePath)).toEqual(["b.ts", "a.ts"]);
+    expect(groups[0].comments.map((c) => c.id)).toEqual(["a", "c"]);
+    expect(groups[1].comments.map((c) => c.id)).toEqual(["b"]);
+  });
+
+  it("returns an empty list for no comments", () => {
+    expect(groupCommentsByFile([])).toEqual([]);
+  });
+});
+
+describe("ReviewCommentsOverview", () => {
+  it("shows an empty state when there are no comments", () => {
+    render(<ReviewCommentsOverview comments={[]} />);
+    expect(screen.getByText(/No comments to fix yet/i)).toBeDefined();
+    expect(screen.queryByTestId("review-comments-overview")).toBeNull();
+  });
+
+  it("summarizes comment and file totals with pluralization", () => {
+    render(
+      <ReviewCommentsOverview
+        comments={[
+          comment({ id: "a", filePath: APP_PATH }),
+          comment({ id: "b", filePath: "src/util.ts" }),
+          comment({ id: "c", filePath: "src/util.ts" }),
+        ]}
+      />,
+    );
+    expect(screen.getByText("3 comments")).toBeDefined();
+    expect(screen.getByText("across 2 files")).toBeDefined();
+  });
+
+  it("uses singular labels for a single comment on a single file", () => {
+    render(<ReviewCommentsOverview comments={[comment({ id: "a" })]} />);
+    expect(screen.getByText("1 comment")).toBeDefined();
+    expect(screen.getByText("across 1 file")).toBeDefined();
+  });
+
+  it("renders the file name, line range, side and text for each comment", () => {
+    render(
+      <ReviewCommentsOverview
+        comments={[
+          comment({ id: "a", filePath: APP_PATH, startLine: 5, endLine: 8, text: "range note" }),
+          comment({ id: "b", filePath: APP_PATH, side: "deletions", text: "removed note" }),
+        ]}
+      />,
+    );
+    expect(screen.getByText("app.tsx")).toBeDefined();
+    expect(screen.getByText("src")).toBeDefined();
+    expect(screen.getByText("L5-8")).toBeDefined();
+    expect(screen.getByText(/new/)).toBeDefined();
+    expect(screen.getByText(/old/)).toBeDefined();
+    expect(screen.getByText("range note")).toBeDefined();
+    expect(screen.getByText("removed note")).toBeDefined();
+  });
+
+  it("shows a per-file comment count badge", () => {
+    render(
+      <ReviewCommentsOverview
+        comments={[
+          comment({ id: "a", filePath: APP_PATH }),
+          comment({ id: "b", filePath: APP_PATH }),
+        ]}
+      />,
+    );
+    const overview = screen.getByTestId("review-comments-overview");
+    expect(within(overview).getByText("2")).toBeDefined();
+  });
+});

--- a/apps/web/components/review/review-comments-overview.test.tsx
+++ b/apps/web/components/review/review-comments-overview.test.tsx
@@ -58,13 +58,13 @@ describe("ReviewCommentsOverview", () => {
         ]}
       />,
     );
-    expect(screen.getByText("3 comments")).toBeDefined();
+    expect(screen.getByText("3 pending review comments")).toBeDefined();
     expect(screen.getByText("across 2 files")).toBeDefined();
   });
 
   it("uses singular labels for a single comment on a single file", () => {
     render(<ReviewCommentsOverview comments={[comment({ id: "a" })]} />);
-    expect(screen.getByText("1 comment")).toBeDefined();
+    expect(screen.getByText("1 pending review comment")).toBeDefined();
     expect(screen.getByText("across 1 file")).toBeDefined();
   });
 

--- a/apps/web/components/review/review-comments-overview.test.tsx
+++ b/apps/web/components/review/review-comments-overview.test.tsx
@@ -36,6 +36,17 @@ describe("groupCommentsByFile", () => {
     expect(groups[1].comments.map((c) => c.id)).toEqual(["b"]);
   });
 
+  it("keeps matching paths in different repositories as separate groups", () => {
+    const groups = groupCommentsByFile([
+      comment({ id: "a", repositoryId: "repo-1", filePath: APP_PATH }),
+      comment({ id: "b", repositoryId: "repo-2", filePath: APP_PATH }),
+      comment({ id: "c", repositoryId: "repo-1", filePath: APP_PATH }),
+    ]);
+    expect(groups.map((g) => g.filePath)).toEqual([APP_PATH, APP_PATH]);
+    expect(groups[0].comments.map((c) => c.id)).toEqual(["a", "c"]);
+    expect(groups[1].comments.map((c) => c.id)).toEqual(["b"]);
+  });
+
   it("returns an empty list for no comments", () => {
     expect(groupCommentsByFile([])).toEqual([]);
   });

--- a/apps/web/components/review/review-comments-overview.tsx
+++ b/apps/web/components/review/review-comments-overview.tsx
@@ -56,7 +56,7 @@ export function ReviewCommentsOverview({ comments }: { comments: DiffComment[] }
       <div className="flex items-center gap-2 border-b border-border/60 px-3 py-2">
         <IconMessage className="h-4 w-4 shrink-0 text-blue-500" />
         <span className="text-sm font-medium">
-          {total} comment{total !== 1 ? "s" : ""}
+          {total} pending review comment{total !== 1 ? "s" : ""}
         </span>
         <span className="text-xs text-muted-foreground">
           across {groups.length} file{groups.length !== 1 ? "s" : ""}

--- a/apps/web/components/review/review-comments-overview.tsx
+++ b/apps/web/components/review/review-comments-overview.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { IconMessage } from "@tabler/icons-react";
+import type { DiffComment } from "@/lib/diff/types";
+import { formatLineRange } from "@/lib/diff";
+
+type FileGroup = { filePath: string; comments: DiffComment[] };
+
+/**
+ * Groups comments by file, preserving first-seen file order so the overview
+ * mirrors the order comments were added / appear in the file tree.
+ */
+export function groupCommentsByFile(comments: DiffComment[]): FileGroup[] {
+  const order: string[] = [];
+  const byFile = new Map<string, DiffComment[]>();
+  for (const comment of comments) {
+    const existing = byFile.get(comment.filePath);
+    if (existing) {
+      existing.push(comment);
+    } else {
+      order.push(comment.filePath);
+      byFile.set(comment.filePath, [comment]);
+    }
+  }
+  return order.map((filePath) => ({ filePath, comments: byFile.get(filePath)! }));
+}
+
+function fileDir(filePath: string): string {
+  const idx = filePath.lastIndexOf("/");
+  return idx === -1 ? "" : filePath.slice(0, idx);
+}
+
+function fileName(filePath: string): string {
+  const idx = filePath.lastIndexOf("/");
+  return idx === -1 ? filePath : filePath.slice(idx + 1);
+}
+
+/**
+ * Scrollable overview of pending review comments, grouped per file. Rendered
+ * inside the "Fix Comments" hover popover on the review top bar.
+ */
+export function ReviewCommentsOverview({ comments }: { comments: DiffComment[] }) {
+  const groups = groupCommentsByFile(comments);
+  const total = comments.length;
+
+  if (total === 0) {
+    return (
+      <div className="px-3 py-4 text-center text-xs text-muted-foreground">
+        No comments to fix yet.
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex max-h-[min(60vh,26rem)] flex-col" data-testid="review-comments-overview">
+      <div className="flex items-center gap-2 border-b border-border/60 px-3 py-2">
+        <IconMessage className="h-4 w-4 shrink-0 text-blue-500" />
+        <span className="text-sm font-medium">
+          {total} comment{total !== 1 ? "s" : ""}
+        </span>
+        <span className="text-xs text-muted-foreground">
+          across {groups.length} file{groups.length !== 1 ? "s" : ""}
+        </span>
+      </div>
+
+      <div
+        className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-2 py-1.5"
+        data-testid="review-comments-overview-scroll"
+      >
+        {groups.map((group) => (
+          <div key={group.filePath} className="mb-2 last:mb-0">
+            <div className="flex items-baseline gap-1.5 px-1 pb-1">
+              <span className="truncate text-xs font-medium text-foreground" title={group.filePath}>
+                {fileName(group.filePath)}
+              </span>
+              {fileDir(group.filePath) && (
+                <span className="min-w-0 flex-1 truncate text-[11px] text-muted-foreground/70">
+                  {fileDir(group.filePath)}
+                </span>
+              )}
+              <span className="ml-auto shrink-0 rounded-full bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
+                {group.comments.length}
+              </span>
+            </div>
+
+            <div className="space-y-1">
+              {group.comments.map((comment) => (
+                <div
+                  key={comment.id}
+                  className="rounded-md border border-border/50 bg-muted/30 px-2 py-1.5"
+                >
+                  <div className="mb-0.5 flex items-center gap-1 text-[10px] font-medium text-muted-foreground">
+                    <span>{formatLineRange(comment.startLine, comment.endLine)}</span>
+                    <span className="text-muted-foreground/60">
+                      · {comment.side === "additions" ? "new" : "old"}
+                    </span>
+                  </div>
+                  <p className="line-clamp-2 whitespace-pre-wrap text-xs leading-snug text-foreground/90">
+                    {comment.text}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/review/review-comments-overview.tsx
+++ b/apps/web/components/review/review-comments-overview.tsx
@@ -4,7 +4,11 @@ import { IconMessage } from "@tabler/icons-react";
 import type { DiffComment } from "@/lib/diff/types";
 import { formatLineRange } from "@/lib/diff";
 
-type FileGroup = { filePath: string; comments: DiffComment[] };
+type FileGroup = { key: string; filePath: string; comments: DiffComment[] };
+
+function fileGroupKey(comment: DiffComment): string {
+  return JSON.stringify([comment.repositoryId ?? null, comment.filePath]);
+}
 
 /**
  * Groups comments by file, preserving first-seen file order so the overview
@@ -13,16 +17,23 @@ type FileGroup = { filePath: string; comments: DiffComment[] };
 export function groupCommentsByFile(comments: DiffComment[]): FileGroup[] {
   const order: string[] = [];
   const byFile = new Map<string, DiffComment[]>();
+  const filePathByKey = new Map<string, string>();
   for (const comment of comments) {
-    const existing = byFile.get(comment.filePath);
+    const key = fileGroupKey(comment);
+    const existing = byFile.get(key);
     if (existing) {
       existing.push(comment);
     } else {
-      order.push(comment.filePath);
-      byFile.set(comment.filePath, [comment]);
+      order.push(key);
+      filePathByKey.set(key, comment.filePath);
+      byFile.set(key, [comment]);
     }
   }
-  return order.map((filePath) => ({ filePath, comments: byFile.get(filePath)! }));
+  return order.map((key) => ({
+    key,
+    filePath: filePathByKey.get(key)!,
+    comments: byFile.get(key)!,
+  }));
 }
 
 function fileDir(filePath: string): string {
@@ -68,7 +79,7 @@ export function ReviewCommentsOverview({ comments }: { comments: DiffComment[] }
         data-testid="review-comments-overview-scroll"
       >
         {groups.map((group) => (
-          <div key={group.filePath} className="mb-2 last:mb-0">
+          <div key={group.key} className="mb-2 last:mb-0">
             <div className="flex items-baseline gap-1.5 px-1 pb-1">
               <span className="truncate text-xs font-medium text-foreground" title={group.filePath}>
                 {fileName(group.filePath)}

--- a/apps/web/components/review/review-dialog.build-files.test.ts
+++ b/apps/web/components/review/review-dialog.build-files.test.ts
@@ -1,6 +1,24 @@
 import { describe, it, expect } from "vitest";
-import { buildAllFiles } from "./review-dialog";
+import { buildAllFiles, filterPendingDiffCommentsForSession } from "./review-dialog";
 import type { CumulativeDiff } from "@/lib/state/slices/session-runtime/types";
+import type { Comment } from "@/lib/state/slices/comments";
+
+function pendingDiffComment(overrides: Partial<Comment>): Comment {
+  return {
+    id: "c1",
+    sessionId: "s1",
+    source: "diff",
+    filePath: "src/app.tsx",
+    startLine: 1,
+    endLine: 1,
+    side: "additions",
+    codeContent: "const value = 1;",
+    text: "fix this",
+    createdAt: "2026-01-01T00:00:00Z",
+    status: "pending",
+    ...overrides,
+  } as Comment;
+}
 
 describe("buildAllFiles (review dialog)", () => {
   // Regression for the "No changes to review" bug introduced by multi-repo
@@ -118,5 +136,27 @@ describe("buildAllFiles (review dialog)", () => {
     // Exact equality (not toContain) so a future normalization change that
     // appends or rewrites diff content can't silently pass this guard.
     expect(result[0].diff).toBe("@@ -1 +1 @@\n-u\n+u");
+  });
+});
+
+describe("filterPendingDiffCommentsForSession", () => {
+  it("keeps only diff comments from the active session", () => {
+    const comments = [
+      pendingDiffComment({ id: "current", sessionId: "current" }),
+      pendingDiffComment({ id: "other", sessionId: "other" }),
+      {
+        id: "plan",
+        sessionId: "current",
+        source: "plan",
+        selectedText: "task text",
+        text: "plan note",
+        createdAt: "2026-01-01T00:00:00Z",
+        status: "pending",
+      },
+    ] satisfies Comment[];
+
+    expect(filterPendingDiffCommentsForSession(comments, "current").map((c) => c.id)).toEqual([
+      "current",
+    ]);
   });
 });

--- a/apps/web/components/review/review-dialog.tsx
+++ b/apps/web/components/review/review-dialog.tsx
@@ -5,6 +5,7 @@ import { Dialog, DialogContent, DialogTitle } from "@kandev/ui/dialog";
 import type { DiffComment } from "@/lib/diff/types";
 import type { FileInfo, CumulativeDiff } from "@/lib/state/slices/session-runtime/types";
 import type { PRDiffFile } from "@/lib/types/github";
+import type { Comment } from "@/lib/state/slices/comments";
 import { useCommentsStore, isDiffComment } from "@/lib/state/slices/comments";
 import { useSessionFileReviews } from "@/hooks/use-session-file-reviews";
 import { useGitOperations } from "@/hooks/use-git-operations";
@@ -149,6 +150,15 @@ export function buildAllFiles(
   if (cumulativeDiff?.files) addCumulativeDiffFiles(fileMap, cumulativeDiff.files, gitStatusFiles);
   if (prDiffFiles) addPRFiles(fileMap, prDiffFiles);
   return Array.from(fileMap.values()).sort((a, b) => a.path.localeCompare(b.path));
+}
+
+export function filterPendingDiffCommentsForSession(
+  comments: Comment[],
+  sessionId: string,
+): DiffComment[] {
+  return comments.filter(
+    (comment): comment is DiffComment => comment.sessionId === sessionId && isDiffComment(comment),
+  );
 }
 
 type ReviewDialogProps = {
@@ -324,8 +334,8 @@ function useReviewDialogState(props: ReviewDialogProps) {
   const sessionCommentIds = useCommentsStore((s) => s.bySession[sessionId]);
   const getStorePendingComments = useCommentsStore((s) => s.getPendingComments);
   const getPendingComments = useCallback((): DiffComment[] => {
-    return getStorePendingComments().filter(isDiffComment);
-  }, [getStorePendingComments]);
+    return filterPendingDiffCommentsForSession(getStorePendingComments(), sessionId);
+  }, [getStorePendingComments, sessionId]);
   const markCommentsSent = useCommentsStore((s) => s.markCommentsSent);
 
   const [filter, setFilter] = useState("");

--- a/apps/web/components/review/review-fix-comments-button.tsx
+++ b/apps/web/components/review/review-fix-comments-button.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useCallback } from "react";
+import { IconMessageForward } from "@tabler/icons-react";
+import { Button } from "@kandev/ui/button";
+import { Popover, PopoverAnchor, PopoverContent } from "@kandev/ui/popover";
+import type { DiffComment } from "@/lib/diff/types";
+import { useHoverPopover } from "@/hooks/domains/github/use-hover-popover";
+import { ReviewCommentsOverview } from "./review-comments-overview";
+
+const COMMENTS_HOVER_OPEN_DELAY_MS = 150;
+const COMMENTS_HOVER_CLOSE_DELAY_MS = 150;
+
+function shouldOpenOverviewOnClick(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(hover: none), (pointer: coarse)").matches
+  );
+}
+
+type FixCommentsButtonProps = {
+  commentCount: number;
+  getPendingComments: () => DiffComment[];
+  onFixComments: () => void;
+};
+
+export function FixCommentsButton({
+  commentCount,
+  getPendingComments,
+  onFixComments,
+}: FixCommentsButtonProps) {
+  const { open, onOpenChange, onTriggerEnter, onTriggerLeave, onContentEnter, onContentLeave } =
+    useHoverPopover({
+      openDelayMs: COMMENTS_HOVER_OPEN_DELAY_MS,
+      closeDelayMs: COMMENTS_HOVER_CLOSE_DELAY_MS,
+    });
+  const handleClick = useCallback(() => {
+    if (!open && shouldOpenOverviewOnClick()) {
+      onOpenChange(true);
+      return;
+    }
+    onFixComments();
+  }, [open, onOpenChange, onFixComments]);
+
+  return (
+    <Popover open={open} onOpenChange={onOpenChange}>
+      <PopoverAnchor asChild>
+        <span
+          className="inline-flex"
+          onMouseOver={onTriggerEnter}
+          onMouseEnter={onTriggerEnter}
+          onMouseMove={onTriggerEnter}
+          onPointerOver={onTriggerEnter}
+          onPointerEnter={onTriggerEnter}
+          onPointerMove={onTriggerEnter}
+          onMouseLeave={onTriggerLeave}
+          onPointerLeave={onTriggerLeave}
+          onFocus={onTriggerEnter}
+          onBlur={onTriggerLeave}
+        >
+          <Button
+            size="sm"
+            variant="outline"
+            className="cursor-pointer"
+            onClick={handleClick}
+            data-testid="review-fix-comments-button"
+          >
+            <IconMessageForward className="h-4 w-4" />
+            Fix Comments
+            <span className="ml-1 rounded-full bg-blue-500/10 px-1.5 py-0.5 text-xs font-medium text-blue-600 dark:text-blue-400">
+              {commentCount}
+            </span>
+          </Button>
+        </span>
+      </PopoverAnchor>
+      <PopoverContent
+        side="bottom"
+        align="end"
+        sideOffset={8}
+        className="w-80 p-0"
+        onMouseEnter={onContentEnter}
+        onMouseMove={onContentEnter}
+        onPointerEnter={onContentEnter}
+        onPointerMove={onContentEnter}
+        onMouseLeave={onContentLeave}
+        onPointerLeave={onContentLeave}
+        onOpenAutoFocus={(e) => e.preventDefault()}
+      >
+        <ReviewCommentsOverview comments={getPendingComments()} />
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/web/components/review/review-top-bar.tsx
+++ b/apps/web/components/review/review-top-bar.tsx
@@ -17,12 +17,18 @@ import {
   DropdownMenuTrigger,
 } from "@kandev/ui/dropdown-menu";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
+import { Popover, PopoverAnchor, PopoverContent } from "@kandev/ui/popover";
 import { Checkbox } from "@kandev/ui/checkbox";
 import type { DiffComment } from "@/lib/diff/types";
 import { useAppStore } from "@/components/state-provider";
+import { useHoverPopover } from "@/hooks/domains/github/use-hover-popover";
 import { getWebSocketClient } from "@/lib/ws/connection";
 import { updateUserSettings } from "@/lib/api";
 import { VcsSplitButton } from "@/components/vcs-split-button";
+import { ReviewCommentsOverview } from "./review-comments-overview";
+
+const COMMENTS_HOVER_OPEN_DELAY_MS = 150;
+const COMMENTS_HOVER_CLOSE_DELAY_MS = 150;
 
 type ReviewTopBarProps = {
   sessionId: string;
@@ -78,6 +84,60 @@ function ReviewSettingsMenu({ reviewAutoMarkOnScroll, onToggleAutoMark }: Review
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
+  );
+}
+
+type FixCommentsButtonProps = {
+  commentCount: number;
+  getPendingComments: () => DiffComment[];
+  onFixComments: () => void;
+};
+
+function FixCommentsButton({
+  commentCount,
+  getPendingComments,
+  onFixComments,
+}: FixCommentsButtonProps) {
+  const hover = useHoverPopover({
+    openDelayMs: COMMENTS_HOVER_OPEN_DELAY_MS,
+    closeDelayMs: COMMENTS_HOVER_CLOSE_DELAY_MS,
+  });
+
+  return (
+    <Popover open={hover.open} onOpenChange={hover.onOpenChange}>
+      <PopoverAnchor asChild>
+        <span
+          className="inline-flex"
+          onMouseEnter={hover.onTriggerEnter}
+          onMouseLeave={hover.onTriggerLeave}
+        >
+          <Button
+            size="sm"
+            variant="outline"
+            className="cursor-pointer"
+            onClick={onFixComments}
+            data-testid="review-fix-comments-button"
+          >
+            <IconMessageForward className="h-4 w-4" />
+            Fix Comments
+            <span className="ml-1 rounded-full bg-blue-500/10 px-1.5 py-0.5 text-xs font-medium text-blue-600 dark:text-blue-400">
+              {commentCount}
+            </span>
+          </Button>
+        </span>
+      </PopoverAnchor>
+      <PopoverContent
+        side="bottom"
+        align="end"
+        sideOffset={8}
+        className="w-80 p-0"
+        onMouseEnter={hover.onContentEnter}
+        onMouseLeave={hover.onContentLeave}
+        onOpenAutoFocus={(e) => e.preventDefault()}
+      >
+        <ReviewCommentsOverview comments={getPendingComments()} />
+      </PopoverContent>
+    </Popover>
   );
 }
 
@@ -174,13 +234,11 @@ export const ReviewTopBar = memo(function ReviewTopBar({
         </TooltipContent>
       </Tooltip>
       {commentCount > 0 && (
-        <Button size="sm" variant="outline" className="cursor-pointer" onClick={handleFixComments}>
-          <IconMessageForward className="h-4 w-4" />
-          Fix Comments
-          <span className="ml-1 rounded-full bg-blue-500/10 px-1.5 py-0.5 text-xs font-medium text-blue-600 dark:text-blue-400">
-            {commentCount}
-          </span>
-        </Button>
+        <FixCommentsButton
+          commentCount={commentCount}
+          getPendingComments={getPendingComments}
+          onFixComments={handleFixComments}
+        />
       )}
       <VcsSplitButton sessionId={sessionId} baseBranch={baseBranch} />
       <Button size="sm" variant="ghost" className="px-2 cursor-pointer" onClick={onClose}>

--- a/apps/web/components/review/review-top-bar.tsx
+++ b/apps/web/components/review/review-top-bar.tsx
@@ -4,7 +4,6 @@ import { memo, useCallback } from "react";
 import {
   IconSettings,
   IconX,
-  IconMessageForward,
   IconLayoutColumns,
   IconLayoutRows,
   IconTextWrap,
@@ -17,26 +16,13 @@ import {
   DropdownMenuTrigger,
 } from "@kandev/ui/dropdown-menu";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
-import { Popover, PopoverAnchor, PopoverContent } from "@kandev/ui/popover";
 import { Checkbox } from "@kandev/ui/checkbox";
 import type { DiffComment } from "@/lib/diff/types";
 import { useAppStore } from "@/components/state-provider";
-import { useHoverPopover } from "@/hooks/domains/github/use-hover-popover";
 import { getWebSocketClient } from "@/lib/ws/connection";
 import { updateUserSettings } from "@/lib/api";
 import { VcsSplitButton } from "@/components/vcs-split-button";
-import { ReviewCommentsOverview } from "./review-comments-overview";
-
-const COMMENTS_HOVER_OPEN_DELAY_MS = 150;
-const COMMENTS_HOVER_CLOSE_DELAY_MS = 150;
-
-function shouldOpenOverviewOnClick(): boolean {
-  return (
-    typeof window !== "undefined" &&
-    typeof window.matchMedia === "function" &&
-    window.matchMedia("(hover: none), (pointer: coarse)").matches
-  );
-}
+import { FixCommentsButton } from "./review-fix-comments-button";
 
 type ReviewTopBarProps = {
   sessionId: string;
@@ -92,64 +78,6 @@ function ReviewSettingsMenu({ reviewAutoMarkOnScroll, onToggleAutoMark }: Review
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
-  );
-}
-
-type FixCommentsButtonProps = {
-  commentCount: number;
-  getPendingComments: () => DiffComment[];
-  onFixComments: () => void;
-};
-
-function FixCommentsButton({
-  commentCount,
-  getPendingComments,
-  onFixComments,
-}: FixCommentsButtonProps) {
-  const { open, onOpenChange, onTriggerEnter, onTriggerLeave, onContentEnter, onContentLeave } =
-    useHoverPopover({
-      openDelayMs: COMMENTS_HOVER_OPEN_DELAY_MS,
-      closeDelayMs: COMMENTS_HOVER_CLOSE_DELAY_MS,
-    });
-  const handleClick = useCallback(() => {
-    if (!open && shouldOpenOverviewOnClick()) {
-      onOpenChange(true);
-      return;
-    }
-    onFixComments();
-  }, [open, onOpenChange, onFixComments]);
-
-  return (
-    <Popover open={open} onOpenChange={onOpenChange}>
-      <PopoverAnchor asChild>
-        <span className="inline-flex" onMouseEnter={onTriggerEnter} onMouseLeave={onTriggerLeave}>
-          <Button
-            size="sm"
-            variant="outline"
-            className="cursor-pointer"
-            onClick={handleClick}
-            data-testid="review-fix-comments-button"
-          >
-            <IconMessageForward className="h-4 w-4" />
-            Fix Comments
-            <span className="ml-1 rounded-full bg-blue-500/10 px-1.5 py-0.5 text-xs font-medium text-blue-600 dark:text-blue-400">
-              {commentCount}
-            </span>
-          </Button>
-        </span>
-      </PopoverAnchor>
-      <PopoverContent
-        side="bottom"
-        align="end"
-        sideOffset={8}
-        className="w-80 p-0"
-        onMouseEnter={onContentEnter}
-        onMouseLeave={onContentLeave}
-        onOpenAutoFocus={(e) => e.preventDefault()}
-      >
-        <ReviewCommentsOverview comments={getPendingComments()} />
-      </PopoverContent>
-    </Popover>
   );
 }
 

--- a/apps/web/components/review/review-top-bar.tsx
+++ b/apps/web/components/review/review-top-bar.tsx
@@ -30,6 +30,14 @@ import { ReviewCommentsOverview } from "./review-comments-overview";
 const COMMENTS_HOVER_OPEN_DELAY_MS = 150;
 const COMMENTS_HOVER_CLOSE_DELAY_MS = 150;
 
+function shouldOpenOverviewOnClick(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(hover: none), (pointer: coarse)").matches
+  );
+}
+
 type ReviewTopBarProps = {
   sessionId: string;
   reviewedCount: number;
@@ -98,24 +106,28 @@ function FixCommentsButton({
   getPendingComments,
   onFixComments,
 }: FixCommentsButtonProps) {
-  const hover = useHoverPopover({
-    openDelayMs: COMMENTS_HOVER_OPEN_DELAY_MS,
-    closeDelayMs: COMMENTS_HOVER_CLOSE_DELAY_MS,
-  });
+  const { open, onOpenChange, onTriggerEnter, onTriggerLeave, onContentEnter, onContentLeave } =
+    useHoverPopover({
+      openDelayMs: COMMENTS_HOVER_OPEN_DELAY_MS,
+      closeDelayMs: COMMENTS_HOVER_CLOSE_DELAY_MS,
+    });
+  const handleClick = useCallback(() => {
+    if (!open && shouldOpenOverviewOnClick()) {
+      onOpenChange(true);
+      return;
+    }
+    onFixComments();
+  }, [open, onOpenChange, onFixComments]);
 
   return (
-    <Popover open={hover.open} onOpenChange={hover.onOpenChange}>
+    <Popover open={open} onOpenChange={onOpenChange}>
       <PopoverAnchor asChild>
-        <span
-          className="inline-flex"
-          onMouseEnter={hover.onTriggerEnter}
-          onMouseLeave={hover.onTriggerLeave}
-        >
+        <span className="inline-flex" onMouseEnter={onTriggerEnter} onMouseLeave={onTriggerLeave}>
           <Button
             size="sm"
             variant="outline"
             className="cursor-pointer"
-            onClick={onFixComments}
+            onClick={handleClick}
             data-testid="review-fix-comments-button"
           >
             <IconMessageForward className="h-4 w-4" />
@@ -131,8 +143,8 @@ function FixCommentsButton({
         align="end"
         sideOffset={8}
         className="w-80 p-0"
-        onMouseEnter={hover.onContentEnter}
-        onMouseLeave={hover.onContentLeave}
+        onMouseEnter={onContentEnter}
+        onMouseLeave={onContentLeave}
         onOpenAutoFocus={(e) => e.preventDefault()}
       >
         <ReviewCommentsOverview comments={getPendingComments()} />

--- a/apps/web/e2e/tests/review/mobile-review-fix-comments-popover.spec.ts
+++ b/apps/web/e2e/tests/review/mobile-review-fix-comments-popover.spec.ts
@@ -1,0 +1,36 @@
+// Filename starts with "mobile-" so the mobile-chrome project exercises the
+// touch path for the Fix Comments overview.
+import { test, expect } from "../../fixtures/test-base";
+import {
+  loadSession,
+  openDialogWithChanges,
+  seedComments,
+  seedReviewTask,
+} from "./review-fix-comments-popover-flow";
+
+test.describe("Review dialog Fix Comments popover on mobile", () => {
+  test.describe.configure({ retries: 2, timeout: 120_000 });
+
+  test("tapping Fix Comments opens the comments overview before sending", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    const task = await seedReviewTask(testPage, apiClient, seedData);
+    const sessionId = task.session_id!;
+    expect(sessionId).toBeTruthy();
+    const comments = await seedComments(testPage, sessionId);
+
+    await loadSession(testPage, task.id);
+    const dialog = await openDialogWithChanges(testPage);
+
+    const button = dialog.getByTestId("review-fix-comments-button");
+    await expect(button).toBeVisible();
+    await button.tap();
+
+    const overview = testPage.getByTestId("review-comments-overview");
+    await expect(overview).toBeVisible();
+    await expect(overview).toContainText(`${comments.length} pending review comments`);
+    await expect(dialog).toBeVisible();
+  });
+});

--- a/apps/web/e2e/tests/review/review-fix-comments-popover-flow.ts
+++ b/apps/web/e2e/tests/review/review-fix-comments-popover-flow.ts
@@ -1,0 +1,134 @@
+import { expect, type Locator, type Page } from "@playwright/test";
+import { SessionPage } from "../../pages/session-page";
+import type { ApiClient } from "../../helpers/api-client";
+import type { SeedData } from "../../fixtures/test-base";
+
+// The single file the `/e2e:review-cumulative-setup` scenario produces. A
+// pending comment must reference a file present in the diff for the "Fix
+// Comments" button to render (see computeCommentCounts in review-dialog.tsx).
+export const DIFF_FILE = "review_cumulative_test.txt";
+
+export type SeededComment = {
+  id: string;
+  sessionId: string;
+  source: "diff";
+  filePath: string;
+  startLine: number;
+  endLine: number;
+  side: "additions" | "deletions";
+  codeContent: string;
+  text: string;
+  createdAt: string;
+  status: "pending";
+};
+
+function makeComment(sessionId: string, index: number, filePath: string): SeededComment {
+  return {
+    id: `e2e-comment-${index}`,
+    sessionId,
+    source: "diff",
+    filePath,
+    startLine: index,
+    endLine: index,
+    side: "additions",
+    codeContent: `line ${index}`,
+    text: `E2E review comment number ${index} — needs a change here.`,
+    createdAt: new Date(2026, 0, 1, 0, 0, index).toISOString(),
+    status: "pending",
+  };
+}
+
+/**
+ * Seed pending diff comments into sessionStorage *before* navigation so the
+ * comments store's `hydrateSession` picks them up on session mount. Mirrors the
+ * addInitScript pattern in review-sidebar-resize.spec.ts.
+ *
+ * The first comment references the real diff file so the "Fix Comments" button
+ * renders; the rest are spread across several files to exercise per-file
+ * grouping and to overflow the popover's max height so it scrolls.
+ */
+export async function seedComments(testPage: Page, sessionId: string): Promise<SeededComment[]> {
+  const comments: SeededComment[] = [
+    makeComment(sessionId, 1, DIFF_FILE),
+    ...Array.from({ length: 40 }, (_, k) =>
+      makeComment(sessionId, k + 2, `src/module-${(k % 5) + 1}/file-${(k % 5) + 1}.ts`),
+    ),
+  ];
+  await testPage.addInitScript(
+    ({ key, val }) => {
+      try {
+        sessionStorage.setItem(key, val);
+      } catch {
+        // sessionStorage may be unavailable in some contexts; ignore.
+      }
+    },
+    { key: `kandev.comments.${sessionId}`, val: JSON.stringify(comments) },
+  );
+  return comments;
+}
+
+export async function seedReviewTask(testPage: Page, apiClient: ApiClient, seedData: SeedData) {
+  return apiClient.createTaskWithAgent(
+    seedData.workspaceId,
+    "Review Fix Comments Popover E2E",
+    seedData.agentProfileId,
+    {
+      description: "/e2e:review-cumulative-setup",
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+      repository_ids: [seedData.repositoryId],
+    },
+  );
+}
+
+export async function loadSession(testPage: Page, taskId: string) {
+  await testPage.goto(`/t/${taskId}`);
+  const session = new SessionPage(testPage);
+  await session.waitForLoad();
+  await expect(
+    session.chat.getByText("review-cumulative-setup complete", { exact: false }),
+  ).toBeVisible({ timeout: 45_000 });
+  return session;
+}
+
+export async function openDialogWithChanges(testPage: Page) {
+  const changesTab = testPage.locator(".dv-default-tab", { hasText: "Changes" });
+  const mobileChangesButton = testPage.getByRole("button", { name: /Changes/ }).last();
+  const hasMobileChangesNav =
+    (await mobileChangesButton.count()) > 0 &&
+    (await mobileChangesButton.isVisible().catch(() => false));
+
+  if (hasMobileChangesNav) {
+    await mobileChangesButton.tap();
+    await expect(testPage.getByTestId("mobile-changes-panel")).toBeVisible({ timeout: 15_000 });
+  } else {
+    await expect(changesTab).toBeVisible({ timeout: 10_000 });
+    await changesTab.click();
+  }
+
+  await expect(testPage.getByTestId(`file-row-${DIFF_FILE}`)).toBeVisible({ timeout: 15_000 });
+  await testPage.evaluate(() => window.dispatchEvent(new CustomEvent("open-review-dialog")));
+  const dialog = testPage.getByRole("dialog", { name: "Review Changes" });
+  await expect(dialog).toBeVisible({ timeout: 10_000 });
+  return dialog;
+}
+
+/**
+ * Open the hover popover by moving the real cursor onto the button and also
+ * dispatching the hover events, then assert the overview is visible. Mirrors
+ * SessionPage.hoverPRTopbar — the popover is driven by useHoverPopover, not a
+ * native :hover, and needs both the cursor move and the synthetic events to
+ * open reliably across browsers.
+ */
+export async function hoverFixComments(testPage: Page, button: Locator, overview: Locator) {
+  await expect(async () => {
+    const box = await button.boundingBox();
+    expect(box).not.toBeNull();
+    await testPage.mouse.move(0, 0);
+    await testPage.mouse.move(box!.x + box!.width / 2, box!.y + box!.height / 2);
+    await button.dispatchEvent("mouseover", { bubbles: true });
+    await button.dispatchEvent("mouseenter", { bubbles: false });
+    await button.dispatchEvent("mousemove", { bubbles: true });
+    await expect(overview).toBeVisible({ timeout: 1_500 });
+  }).toPass({ timeout: 10_000 });
+}

--- a/apps/web/e2e/tests/review/review-fix-comments-popover.spec.ts
+++ b/apps/web/e2e/tests/review/review-fix-comments-popover.spec.ts
@@ -1,0 +1,192 @@
+import { test, expect } from "../../fixtures/test-base";
+import { SessionPage } from "../../pages/session-page";
+import type { ApiClient } from "../../helpers/api-client";
+import type { SeedData } from "../../fixtures/test-base";
+import type { Page, Locator } from "@playwright/test";
+
+// The single file the `/e2e:review-cumulative-setup` scenario produces. A
+// pending comment must reference a file present in the diff for the "Fix
+// Comments" button to render (see computeCommentCounts in review-dialog.tsx).
+const DIFF_FILE = "review_cumulative_test.txt";
+
+type SeededComment = {
+  id: string;
+  sessionId: string;
+  source: "diff";
+  filePath: string;
+  startLine: number;
+  endLine: number;
+  side: "additions" | "deletions";
+  codeContent: string;
+  text: string;
+  createdAt: string;
+  status: "pending";
+};
+
+function makeComment(sessionId: string, index: number, filePath: string): SeededComment {
+  return {
+    id: `e2e-comment-${index}`,
+    sessionId,
+    source: "diff",
+    filePath,
+    startLine: index,
+    endLine: index,
+    side: "additions",
+    codeContent: `line ${index}`,
+    text: `E2E review comment number ${index} — needs a change here.`,
+    createdAt: new Date(2026, 0, 1, 0, 0, index).toISOString(),
+    status: "pending",
+  };
+}
+
+/**
+ * Seed pending diff comments into sessionStorage *before* navigation so the
+ * comments store's `hydrateSession` picks them up on session mount. Mirrors the
+ * addInitScript pattern in review-sidebar-resize.spec.ts.
+ *
+ * The first comment references the real diff file so the "Fix Comments" button
+ * renders; the rest are spread across several files to exercise per-file
+ * grouping and to overflow the popover's max height so it scrolls.
+ */
+async function seedComments(testPage: Page, sessionId: string): Promise<SeededComment[]> {
+  const comments: SeededComment[] = [
+    makeComment(sessionId, 1, DIFF_FILE),
+    ...Array.from({ length: 40 }, (_, k) =>
+      makeComment(sessionId, k + 2, `src/module-${(k % 5) + 1}/file-${(k % 5) + 1}.ts`),
+    ),
+  ];
+  await testPage.addInitScript(
+    ({ key, val }) => {
+      try {
+        sessionStorage.setItem(key, val);
+      } catch {
+        // sessionStorage may be unavailable in some contexts; ignore.
+      }
+    },
+    { key: `kandev.comments.${sessionId}`, val: JSON.stringify(comments) },
+  );
+  return comments;
+}
+
+async function seedReviewTask(testPage: Page, apiClient: ApiClient, seedData: SeedData) {
+  const task = await apiClient.createTaskWithAgent(
+    seedData.workspaceId,
+    "Review Fix Comments Popover E2E",
+    seedData.agentProfileId,
+    {
+      description: "/e2e:review-cumulative-setup",
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+      repository_ids: [seedData.repositoryId],
+    },
+  );
+  return task;
+}
+
+async function loadSession(testPage: Page, taskId: string) {
+  await testPage.goto(`/t/${taskId}`);
+  const session = new SessionPage(testPage);
+  await session.waitForLoad();
+  await expect(
+    session.chat.getByText("review-cumulative-setup complete", { exact: false }),
+  ).toBeVisible({ timeout: 45_000 });
+  return session;
+}
+
+async function openDialogWithChanges(testPage: Page) {
+  const changesTab = testPage.locator(".dv-default-tab", { hasText: "Changes" });
+  await expect(changesTab).toBeVisible({ timeout: 10_000 });
+  await changesTab.click();
+  await expect(testPage.getByTestId(`file-row-${DIFF_FILE}`)).toBeVisible({ timeout: 15_000 });
+  await testPage.evaluate(() => window.dispatchEvent(new CustomEvent("open-review-dialog")));
+  const dialog = testPage.getByRole("dialog", { name: "Review Changes" });
+  await expect(dialog).toBeVisible({ timeout: 10_000 });
+  return dialog;
+}
+
+/**
+ * Open the hover popover by moving the real cursor onto the button and also
+ * dispatching the hover events, then assert the overview is visible. Mirrors
+ * SessionPage.hoverPRTopbar — the popover is driven by useHoverPopover, not a
+ * native :hover, and needs both the cursor move and the synthetic events to
+ * open reliably across browsers.
+ */
+async function hoverFixComments(testPage: Page, button: Locator, overview: Locator) {
+  await expect(async () => {
+    const box = await button.boundingBox();
+    expect(box).not.toBeNull();
+    await testPage.mouse.move(0, 0);
+    await testPage.mouse.move(box!.x + box!.width / 2, box!.y + box!.height / 2);
+    await button.dispatchEvent("mouseover", { bubbles: true });
+    await button.dispatchEvent("mouseenter", { bubbles: false });
+    await button.dispatchEvent("mousemove", { bubbles: true });
+    await expect(overview).toBeVisible({ timeout: 1_500 });
+  }).toPass({ timeout: 10_000 });
+}
+
+test.describe("Review dialog Fix Comments popover", () => {
+  test.describe.configure({ retries: 2, timeout: 120_000 });
+
+  test("hovering Fix Comments shows a scrollable per-file overview", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    const task = await seedReviewTask(testPage, apiClient, seedData);
+    const sessionId = task.session_id!;
+    expect(sessionId).toBeTruthy();
+    const comments = await seedComments(testPage, sessionId);
+
+    await loadSession(testPage, task.id);
+    const dialog = await openDialogWithChanges(testPage);
+
+    const button = dialog.getByTestId("review-fix-comments-button");
+    await expect(button).toBeVisible();
+    // Count badge reflects only comments on files present in the diff — here
+    // the single DIFF_FILE comment.
+    await expect(button).toContainText("1");
+
+    const overview = testPage.getByTestId("review-comments-overview");
+    await hoverFixComments(testPage, button, overview);
+
+    // Header summarizes totals across every pending comment (not just the ones
+    // on diff files): 41 comments across 6 files (DIFF_FILE + 5 module files).
+    await expect(overview).toContainText(`${comments.length} comments`);
+    await expect(overview.getByText(/across 6 files/)).toBeVisible();
+
+    // Per-file grouping: the diff file and at least one module file appear.
+    await expect(overview.getByText(DIFF_FILE, { exact: true })).toBeVisible();
+    await expect(overview.getByText("file-1.ts", { exact: true })).toBeVisible();
+
+    // The overview overflows its max height, so the inner region must scroll.
+    const scroller = overview.getByTestId("review-comments-overview-scroll");
+    const metrics = await scroller.evaluate((el) => ({
+      scrollHeight: el.scrollHeight,
+      clientHeight: el.clientHeight,
+    }));
+    expect(metrics.scrollHeight).toBeGreaterThan(metrics.clientHeight);
+
+    await scroller.evaluate((el) => {
+      el.scrollTop = el.scrollHeight;
+    });
+    await expect
+      .poll(async () => scroller.evaluate((el) => el.scrollTop), { timeout: 5_000 })
+      .toBeGreaterThan(0);
+
+    // The bridge keeps the popover open while the cursor is over the content.
+    await scroller.hover();
+    await expect(overview).toBeVisible();
+  });
+
+  test("no Fix Comments button when there are no comments", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    const task = await seedReviewTask(testPage, apiClient, seedData);
+    await loadSession(testPage, task.id);
+    const dialog = await openDialogWithChanges(testPage);
+
+    await expect(dialog.getByTestId("review-fix-comments-button")).toHaveCount(0);
+  });
+});

--- a/apps/web/e2e/tests/review/review-fix-comments-popover.spec.ts
+++ b/apps/web/e2e/tests/review/review-fix-comments-popover.spec.ts
@@ -62,6 +62,25 @@ test.describe("Review dialog Fix Comments popover", () => {
     await expect(overview).toBeVisible();
   });
 
+  test("focusing Fix Comments shows the comments overview", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    const task = await seedReviewTask(testPage, apiClient, seedData);
+    const sessionId = task.session_id!;
+    expect(sessionId).toBeTruthy();
+    await seedComments(testPage, sessionId);
+
+    await loadSession(testPage, task.id);
+    const dialog = await openDialogWithChanges(testPage);
+
+    const button = dialog.getByTestId("review-fix-comments-button");
+    await button.focus();
+
+    await expect(testPage.getByTestId("review-comments-overview")).toBeVisible();
+  });
+
   test("no Fix Comments button when there are no comments", async ({
     testPage,
     apiClient,

--- a/apps/web/e2e/tests/review/review-fix-comments-popover.spec.ts
+++ b/apps/web/e2e/tests/review/review-fix-comments-popover.spec.ts
@@ -1,128 +1,12 @@
 import { test, expect } from "../../fixtures/test-base";
-import { SessionPage } from "../../pages/session-page";
-import type { ApiClient } from "../../helpers/api-client";
-import type { SeedData } from "../../fixtures/test-base";
-import type { Page, Locator } from "@playwright/test";
-
-// The single file the `/e2e:review-cumulative-setup` scenario produces. A
-// pending comment must reference a file present in the diff for the "Fix
-// Comments" button to render (see computeCommentCounts in review-dialog.tsx).
-const DIFF_FILE = "review_cumulative_test.txt";
-
-type SeededComment = {
-  id: string;
-  sessionId: string;
-  source: "diff";
-  filePath: string;
-  startLine: number;
-  endLine: number;
-  side: "additions" | "deletions";
-  codeContent: string;
-  text: string;
-  createdAt: string;
-  status: "pending";
-};
-
-function makeComment(sessionId: string, index: number, filePath: string): SeededComment {
-  return {
-    id: `e2e-comment-${index}`,
-    sessionId,
-    source: "diff",
-    filePath,
-    startLine: index,
-    endLine: index,
-    side: "additions",
-    codeContent: `line ${index}`,
-    text: `E2E review comment number ${index} — needs a change here.`,
-    createdAt: new Date(2026, 0, 1, 0, 0, index).toISOString(),
-    status: "pending",
-  };
-}
-
-/**
- * Seed pending diff comments into sessionStorage *before* navigation so the
- * comments store's `hydrateSession` picks them up on session mount. Mirrors the
- * addInitScript pattern in review-sidebar-resize.spec.ts.
- *
- * The first comment references the real diff file so the "Fix Comments" button
- * renders; the rest are spread across several files to exercise per-file
- * grouping and to overflow the popover's max height so it scrolls.
- */
-async function seedComments(testPage: Page, sessionId: string): Promise<SeededComment[]> {
-  const comments: SeededComment[] = [
-    makeComment(sessionId, 1, DIFF_FILE),
-    ...Array.from({ length: 40 }, (_, k) =>
-      makeComment(sessionId, k + 2, `src/module-${(k % 5) + 1}/file-${(k % 5) + 1}.ts`),
-    ),
-  ];
-  await testPage.addInitScript(
-    ({ key, val }) => {
-      try {
-        sessionStorage.setItem(key, val);
-      } catch {
-        // sessionStorage may be unavailable in some contexts; ignore.
-      }
-    },
-    { key: `kandev.comments.${sessionId}`, val: JSON.stringify(comments) },
-  );
-  return comments;
-}
-
-async function seedReviewTask(testPage: Page, apiClient: ApiClient, seedData: SeedData) {
-  const task = await apiClient.createTaskWithAgent(
-    seedData.workspaceId,
-    "Review Fix Comments Popover E2E",
-    seedData.agentProfileId,
-    {
-      description: "/e2e:review-cumulative-setup",
-      workflow_id: seedData.workflowId,
-      workflow_step_id: seedData.startStepId,
-      repository_ids: [seedData.repositoryId],
-    },
-  );
-  return task;
-}
-
-async function loadSession(testPage: Page, taskId: string) {
-  await testPage.goto(`/t/${taskId}`);
-  const session = new SessionPage(testPage);
-  await session.waitForLoad();
-  await expect(
-    session.chat.getByText("review-cumulative-setup complete", { exact: false }),
-  ).toBeVisible({ timeout: 45_000 });
-  return session;
-}
-
-async function openDialogWithChanges(testPage: Page) {
-  const changesTab = testPage.locator(".dv-default-tab", { hasText: "Changes" });
-  await expect(changesTab).toBeVisible({ timeout: 10_000 });
-  await changesTab.click();
-  await expect(testPage.getByTestId(`file-row-${DIFF_FILE}`)).toBeVisible({ timeout: 15_000 });
-  await testPage.evaluate(() => window.dispatchEvent(new CustomEvent("open-review-dialog")));
-  const dialog = testPage.getByRole("dialog", { name: "Review Changes" });
-  await expect(dialog).toBeVisible({ timeout: 10_000 });
-  return dialog;
-}
-
-/**
- * Open the hover popover by moving the real cursor onto the button and also
- * dispatching the hover events, then assert the overview is visible. Mirrors
- * SessionPage.hoverPRTopbar — the popover is driven by useHoverPopover, not a
- * native :hover, and needs both the cursor move and the synthetic events to
- * open reliably across browsers.
- */
-async function hoverFixComments(testPage: Page, button: Locator, overview: Locator) {
-  await expect(async () => {
-    const box = await button.boundingBox();
-    expect(box).not.toBeNull();
-    await testPage.mouse.move(0, 0);
-    await testPage.mouse.move(box!.x + box!.width / 2, box!.y + box!.height / 2);
-    await button.dispatchEvent("mouseover", { bubbles: true });
-    await button.dispatchEvent("mouseenter", { bubbles: false });
-    await button.dispatchEvent("mousemove", { bubbles: true });
-    await expect(overview).toBeVisible({ timeout: 1_500 });
-  }).toPass({ timeout: 10_000 });
-}
+import {
+  DIFF_FILE,
+  hoverFixComments,
+  loadSession,
+  openDialogWithChanges,
+  seedComments,
+  seedReviewTask,
+} from "./review-fix-comments-popover-flow";
 
 test.describe("Review dialog Fix Comments popover", () => {
   test.describe.configure({ retries: 2, timeout: 120_000 });
@@ -151,7 +35,7 @@ test.describe("Review dialog Fix Comments popover", () => {
 
     // Header summarizes totals across every pending comment (not just the ones
     // on diff files): 41 comments across 6 files (DIFF_FILE + 5 module files).
-    await expect(overview).toContainText(`${comments.length} comments`);
+    await expect(overview).toContainText(`${comments.length} pending review comments`);
     await expect(overview.getByText(/across 6 files/)).toBeVisible();
 
     // Per-file grouping: the diff file and at least one module file appear.

--- a/apps/web/lib/diff/comment-utils.test.ts
+++ b/apps/web/lib/diff/comment-utils.test.ts
@@ -23,26 +23,33 @@ function comment(): DiffComment {
   };
 }
 
+type UseCommentActionsParams = Parameters<typeof useCommentActions>[0];
+
+function renderCommentActions(overrides: Partial<UseCommentActionsParams> = {}) {
+  const removeComment = vi.fn();
+  const updateComment = vi.fn();
+  const setEditingComment = vi.fn();
+  const params = {
+    removeComment,
+    updateComment,
+    setEditingComment,
+    ...overrides,
+  };
+  const { result } = renderHook(() => useCommentActions(params));
+  return { result, removeComment, updateComment, setEditingComment };
+}
+
 afterEach(() => {
   vi.restoreAllMocks();
 });
 
 describe("useCommentActions", () => {
   it("routes updates to the external handler in controlled comment mode", () => {
-    const removeComment = vi.fn();
-    const updateComment = vi.fn();
-    const setEditingComment = vi.fn();
     const onCommentUpdate = vi.fn();
-
-    const { result } = renderHook(() =>
-      useCommentActions({
-        removeComment,
-        updateComment,
-        setEditingComment,
-        onCommentUpdate,
-        externalComments: [comment()],
-      }),
-    );
+    const { result, removeComment, updateComment, setEditingComment } = renderCommentActions({
+      onCommentUpdate,
+      externalComments: [comment()],
+    });
 
     act(() => {
       result.current.handleCommentUpdate(COMMENT_ID, EDITED_TEXT);
@@ -55,16 +62,7 @@ describe("useCommentActions", () => {
   });
 
   it("updates the internal store handler when comments are uncontrolled", () => {
-    const updateComment = vi.fn();
-    const setEditingComment = vi.fn();
-
-    const { result } = renderHook(() =>
-      useCommentActions({
-        removeComment: vi.fn(),
-        updateComment,
-        setEditingComment,
-      }),
-    );
+    const { result, updateComment, setEditingComment } = renderCommentActions();
 
     act(() => {
       result.current.handleCommentUpdate(COMMENT_ID, EDITED_TEXT);
@@ -75,18 +73,10 @@ describe("useCommentActions", () => {
   });
 
   it("does not write to the internal store when controlled updates lack a handler", () => {
-    const updateComment = vi.fn();
-    const setEditingComment = vi.fn();
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-
-    const { result } = renderHook(() =>
-      useCommentActions({
-        removeComment: vi.fn(),
-        updateComment,
-        setEditingComment,
-        externalComments: [comment()],
-      }),
-    );
+    const { result, updateComment, setEditingComment } = renderCommentActions({
+      externalComments: [comment()],
+    });
 
     act(() => {
       result.current.handleCommentUpdate(COMMENT_ID, EDITED_TEXT);
@@ -98,18 +88,11 @@ describe("useCommentActions", () => {
   });
 
   it("routes deletes to the external handler in controlled comment mode", () => {
-    const removeComment = vi.fn();
     const onCommentDelete = vi.fn();
-
-    const { result } = renderHook(() =>
-      useCommentActions({
-        removeComment,
-        updateComment: vi.fn(),
-        setEditingComment: vi.fn(),
-        onCommentDelete,
-        externalComments: [comment()],
-      }),
-    );
+    const { result, removeComment } = renderCommentActions({
+      onCommentDelete,
+      externalComments: [comment()],
+    });
 
     act(() => {
       result.current.handleCommentDelete(COMMENT_ID);
@@ -119,16 +102,20 @@ describe("useCommentActions", () => {
     expect(removeComment).not.toHaveBeenCalled();
   });
 
-  it("routes deletes to the internal store handler when comments are uncontrolled", () => {
-    const removeComment = vi.fn();
+  it("does not write to the internal store when controlled deletes lack a handler", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { result, removeComment } = renderCommentActions({ externalComments: [comment()] });
 
-    const { result } = renderHook(() =>
-      useCommentActions({
-        removeComment,
-        updateComment: vi.fn(),
-        setEditingComment: vi.fn(),
-      }),
-    );
+    act(() => {
+      result.current.handleCommentDelete(COMMENT_ID);
+    });
+
+    expect(removeComment).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("`onCommentDelete`"));
+  });
+
+  it("routes deletes to the internal store handler when comments are uncontrolled", () => {
+    const { result, removeComment } = renderCommentActions();
 
     act(() => {
       result.current.handleCommentDelete(COMMENT_ID);

--- a/apps/web/lib/diff/comment-utils.test.ts
+++ b/apps/web/lib/diff/comment-utils.test.ts
@@ -1,0 +1,72 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { useCommentActions } from "./comment-utils";
+import type { DiffComment } from "./types";
+
+const COMMENT_ID = "comment-1";
+const EDITED_TEXT = "edited text";
+
+function comment(): DiffComment {
+  return {
+    id: COMMENT_ID,
+    source: "diff",
+    sessionId: "session-1",
+    filePath: "src/example.ts",
+    startLine: 1,
+    endLine: 1,
+    side: "additions",
+    codeContent: "new line",
+    text: "original",
+    createdAt: "2026-01-01T00:00:00Z",
+    status: "pending",
+  };
+}
+
+describe("useCommentActions", () => {
+  it("routes updates to the external handler in controlled comment mode", () => {
+    const removeComment = vi.fn();
+    const updateComment = vi.fn();
+    const setEditingComment = vi.fn();
+    const onCommentUpdate = vi.fn();
+
+    const { result } = renderHook(() =>
+      useCommentActions({
+        removeComment,
+        updateComment,
+        setEditingComment,
+        onCommentUpdate,
+        externalComments: [comment()],
+      }),
+    );
+
+    act(() => {
+      result.current.handleCommentUpdate(COMMENT_ID, EDITED_TEXT);
+    });
+
+    expect(onCommentUpdate).toHaveBeenCalledWith(COMMENT_ID, { text: EDITED_TEXT });
+    expect(updateComment).not.toHaveBeenCalled();
+    expect(setEditingComment).toHaveBeenCalledWith(null);
+    expect(removeComment).not.toHaveBeenCalled();
+  });
+
+  it("updates the internal store handler when comments are uncontrolled", () => {
+    const updateComment = vi.fn();
+    const setEditingComment = vi.fn();
+
+    const { result } = renderHook(() =>
+      useCommentActions({
+        removeComment: vi.fn(),
+        updateComment,
+        setEditingComment,
+      }),
+    );
+
+    act(() => {
+      result.current.handleCommentUpdate(COMMENT_ID, EDITED_TEXT);
+    });
+
+    expect(updateComment).toHaveBeenCalledWith(COMMENT_ID, { text: EDITED_TEXT });
+    expect(setEditingComment).toHaveBeenCalledWith(null);
+  });
+});

--- a/apps/web/lib/diff/comment-utils.test.ts
+++ b/apps/web/lib/diff/comment-utils.test.ts
@@ -94,7 +94,7 @@ describe("useCommentActions", () => {
 
     expect(updateComment).not.toHaveBeenCalled();
     expect(warn).toHaveBeenCalledWith(expect.stringContaining("`onCommentUpdate`"));
-    expect(setEditingComment).toHaveBeenCalledWith(null);
+    expect(setEditingComment).not.toHaveBeenCalled();
   });
 
   it("routes deletes to the external handler in controlled comment mode", () => {

--- a/apps/web/lib/diff/comment-utils.test.ts
+++ b/apps/web/lib/diff/comment-utils.test.ts
@@ -1,5 +1,5 @@
 import { act, renderHook } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { useCommentActions } from "./comment-utils";
 import type { DiffComment } from "./types";
@@ -22,6 +22,10 @@ function comment(): DiffComment {
     status: "pending",
   };
 }
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("useCommentActions", () => {
   it("routes updates to the external handler in controlled comment mode", () => {
@@ -68,5 +72,68 @@ describe("useCommentActions", () => {
 
     expect(updateComment).toHaveBeenCalledWith(COMMENT_ID, { text: EDITED_TEXT });
     expect(setEditingComment).toHaveBeenCalledWith(null);
+  });
+
+  it("does not write to the internal store when controlled updates lack a handler", () => {
+    const updateComment = vi.fn();
+    const setEditingComment = vi.fn();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const { result } = renderHook(() =>
+      useCommentActions({
+        removeComment: vi.fn(),
+        updateComment,
+        setEditingComment,
+        externalComments: [comment()],
+      }),
+    );
+
+    act(() => {
+      result.current.handleCommentUpdate(COMMENT_ID, EDITED_TEXT);
+    });
+
+    expect(updateComment).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("`onCommentUpdate`"));
+    expect(setEditingComment).toHaveBeenCalledWith(null);
+  });
+
+  it("routes deletes to the external handler in controlled comment mode", () => {
+    const removeComment = vi.fn();
+    const onCommentDelete = vi.fn();
+
+    const { result } = renderHook(() =>
+      useCommentActions({
+        removeComment,
+        updateComment: vi.fn(),
+        setEditingComment: vi.fn(),
+        onCommentDelete,
+        externalComments: [comment()],
+      }),
+    );
+
+    act(() => {
+      result.current.handleCommentDelete(COMMENT_ID);
+    });
+
+    expect(onCommentDelete).toHaveBeenCalledWith(COMMENT_ID);
+    expect(removeComment).not.toHaveBeenCalled();
+  });
+
+  it("routes deletes to the internal store handler when comments are uncontrolled", () => {
+    const removeComment = vi.fn();
+
+    const { result } = renderHook(() =>
+      useCommentActions({
+        removeComment,
+        updateComment: vi.fn(),
+        setEditingComment: vi.fn(),
+      }),
+    );
+
+    act(() => {
+      result.current.handleCommentDelete(COMMENT_ID);
+    });
+
+    expect(removeComment).toHaveBeenCalledWith(COMMENT_ID);
   });
 });

--- a/apps/web/lib/diff/comment-utils.ts
+++ b/apps/web/lib/diff/comment-utils.ts
@@ -60,8 +60,14 @@ export function useCommentActions(params: {
 
   const handleCommentDelete = useCallback(
     (commentId: string) => {
-      if (onCommentDelete && externalComments !== undefined) {
-        onCommentDelete(commentId);
+      if (externalComments !== undefined) {
+        if (onCommentDelete) {
+          onCommentDelete(commentId);
+        } else if (isDevelopmentMode()) {
+          console.warn(
+            "[DiffViewer] `comments` is set without `onCommentDelete`; deleted comments must be handled by the controlled owner.",
+          );
+        }
       } else {
         removeComment(commentId);
       }

--- a/apps/web/lib/diff/comment-utils.ts
+++ b/apps/web/lib/diff/comment-utils.ts
@@ -1,5 +1,5 @@
 import { useMemo, useCallback } from "react";
-import type { DiffComment } from "./types";
+import type { DiffComment, DiffCommentUpdate } from "./types";
 
 /** Build a DiffComment object from common parameters */
 export function buildDiffComment(params: {
@@ -43,10 +43,10 @@ export function useCommentedLines(comments: DiffComment[]): Set<number> {
  */
 export function useCommentActions(params: {
   removeComment: (commentId: string) => void;
-  updateComment: (commentId: string, updates: Partial<DiffComment>) => void;
+  updateComment: (commentId: string, updates: DiffCommentUpdate) => void;
   setEditingComment: (id: string | null) => void;
   onCommentDelete?: (commentId: string) => void;
-  onCommentUpdate?: (commentId: string, updates: Partial<DiffComment>) => void;
+  onCommentUpdate?: (commentId: string, updates: DiffCommentUpdate) => void;
   externalComments?: DiffComment[];
 }) {
   const {
@@ -72,8 +72,14 @@ export function useCommentActions(params: {
   const handleCommentUpdate = useCallback(
     (commentId: string, content: string) => {
       const updates = { text: content };
-      if (onCommentUpdate && externalComments !== undefined) {
-        onCommentUpdate(commentId, updates);
+      if (externalComments !== undefined) {
+        if (onCommentUpdate) {
+          onCommentUpdate(commentId, updates);
+        } else if (isDevelopmentMode()) {
+          console.warn(
+            "[DiffViewer] `comments` is set without `onCommentUpdate`; edited comments must be handled by the controlled owner.",
+          );
+        }
       } else {
         updateComment(commentId, updates);
       }
@@ -83,4 +89,16 @@ export function useCommentActions(params: {
   );
 
   return { handleCommentDelete, handleCommentUpdate };
+}
+
+function isDevelopmentMode(): boolean {
+  const viteEnv = (
+    import.meta as unknown as {
+      env?: { DEV?: boolean };
+    }
+  ).env;
+  return (
+    viteEnv?.DEV === true ||
+    (typeof process !== "undefined" && process.env.NODE_ENV !== "production")
+  );
 }

--- a/apps/web/lib/diff/comment-utils.ts
+++ b/apps/web/lib/diff/comment-utils.ts
@@ -75,6 +75,7 @@ export function useCommentActions(params: {
       if (externalComments !== undefined) {
         if (onCommentUpdate) {
           onCommentUpdate(commentId, updates);
+          setEditingComment(null);
         } else if (isDevelopmentMode()) {
           console.warn(
             "[DiffViewer] `comments` is set without `onCommentUpdate`; edited comments must be handled by the controlled owner.",
@@ -82,8 +83,8 @@ export function useCommentActions(params: {
         }
       } else {
         updateComment(commentId, updates);
+        setEditingComment(null);
       }
-      setEditingComment(null);
     },
     [updateComment, onCommentUpdate, externalComments, setEditingComment],
   );

--- a/apps/web/lib/diff/comment-utils.ts
+++ b/apps/web/lib/diff/comment-utils.ts
@@ -49,8 +49,14 @@ export function useCommentActions(params: {
   onCommentUpdate?: (commentId: string, updates: Partial<DiffComment>) => void;
   externalComments?: DiffComment[];
 }) {
-  const { removeComment, updateComment, setEditingComment, onCommentDelete, externalComments } =
-    params;
+  const {
+    removeComment,
+    updateComment,
+    setEditingComment,
+    onCommentDelete,
+    onCommentUpdate,
+    externalComments,
+  } = params;
 
   const handleCommentDelete = useCallback(
     (commentId: string) => {
@@ -65,10 +71,15 @@ export function useCommentActions(params: {
 
   const handleCommentUpdate = useCallback(
     (commentId: string, content: string) => {
-      updateComment(commentId, { text: content });
+      const updates = { text: content };
+      if (onCommentUpdate && externalComments !== undefined) {
+        onCommentUpdate(commentId, updates);
+      } else {
+        updateComment(commentId, updates);
+      }
       setEditingComment(null);
     },
-    [updateComment, setEditingComment],
+    [updateComment, onCommentUpdate, externalComments, setEditingComment],
   );
 
   return { handleCommentDelete, handleCommentUpdate };

--- a/apps/web/lib/diff/types.ts
+++ b/apps/web/lib/diff/types.ts
@@ -25,6 +25,8 @@ export type CommentAnnotation = DiffLineAnnotation<{
   isEditing: boolean;
 }>;
 
+export type DiffCommentUpdate = Partial<Pick<DiffComment, "text" | "status" | "codeContent">>;
+
 /**
  * Store state for diff comments — kept for backward compat type references.
  * @deprecated Use CommentsState from '@/lib/state/slices/comments' instead.
@@ -41,7 +43,7 @@ export interface DiffCommentsState {
  */
 export interface DiffCommentsActions {
   addComment: (comment: DiffComment) => void;
-  updateComment: (commentId: string, updates: Partial<DiffComment>) => void;
+  updateComment: (commentId: string, updates: DiffCommentUpdate) => void;
   removeComment: (sessionId: string, filePath: string, commentId: string) => void;
   addToPending: (commentId: string) => void;
   removeFromPending: (commentId: string) => void;
@@ -85,7 +87,7 @@ export interface DiffViewerProps {
   /** Callback when comment is deleted */
   onCommentDelete?: (commentId: string) => void;
   /** Callback when comment is updated */
-  onCommentUpdate?: (commentId: string, updates: Partial<DiffComment>) => void;
+  onCommentUpdate?: (commentId: string, updates: DiffCommentUpdate) => void;
   /** External comments (controlled mode) */
   comments?: DiffComment[];
   /** Additional class name */

--- a/apps/web/lib/diff/types.ts
+++ b/apps/web/lib/diff/types.ts
@@ -84,6 +84,8 @@ export interface DiffViewerProps {
   onCommentAdd?: (comment: DiffComment) => void;
   /** Callback when comment is deleted */
   onCommentDelete?: (commentId: string) => void;
+  /** Callback when comment is updated */
+  onCommentUpdate?: (commentId: string, updates: Partial<DiffComment>) => void;
   /** External comments (controlled mode) */
   comments?: DiffComment[];
   /** Additional class name */


### PR DESCRIPTION
Reviewers need quick context before fixing review comments, and controlled diff comment edits were not notifying their owner. The review header now exposes a grouped, scrollable pending-comments popover, and diff comment updates flow through `onCommentUpdate` across Pierre and Monaco.

## Important Changes

- Added a hover popover for `Fix Comments` that groups pending comments by file and keeps long lists scrollable.
- Routed controlled diff comment edits through `onCommentUpdate` so external comment owners receive saved edits.

## Validation

- `make fmt`
- `node apps/web/scripts/generate-release-notes.mjs`
- `node apps/web/scripts/generate-changelog.mjs`
- `make typecheck`
- `make test`
- `make lint`
- `cd apps/web && pnpm e2e:run tests/review/review-fix-comments-popover.spec.ts -- --project=chromium`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1599?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->