### PR TITLE
fix: complete idle acp monitor turns

### DIFF
--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter.go
@@ -253,6 +253,7 @@ type Adapter struct {
 	// prompt response, so sendPrompt's normal complete emission never runs.
 	asyncTurnMu         sync.Mutex
 	asyncTurnFinalizers map[string]*asyncTurnFinalizer
+	asyncTurnEpochs     map[string]uint64
 
 	// lifetimeCtx is cancelled by Close. Background work that may outlive
 	// the call site (e.g. the synthetic wakeup prompt goroutine) derives its
@@ -270,8 +271,9 @@ type promptTurnState struct {
 }
 
 type asyncTurnFinalizer struct {
-	timer *time.Timer
-	seq   uint64
+	timer       *time.Timer
+	seq         uint64
+	promptEpoch uint64
 }
 
 // promptCancelJoinTimeout bounds how long Cancel and sendPrompt wait for a stuck
@@ -298,6 +300,7 @@ func NewAdapter(cfg *shared.Config, log *logger.Logger) *Adapter {
 		attachMgr:           shared.NewAttachmentManager(cfg.WorkDir, l.Zap()),
 		promptGate:          make(chan struct{}, 1),
 		asyncTurnFinalizers: make(map[string]*asyncTurnFinalizer),
+		asyncTurnEpochs:     make(map[string]uint64),
 		lifetimeCtx:         ctx,
 		lifetimeCancel:      cancel,
 	}

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter.go
@@ -247,6 +247,13 @@ type Adapter struct {
 	// blocking on a stuck turn).
 	promptGate chan struct{}
 
+	// asyncTurnFinalizers synthesize a turn completion for ACP updates that
+	// arrive while no session/prompt RPC is active. Claude's Monitor tool can
+	// produce assistant chunks from a background callback without returning a
+	// prompt response, so sendPrompt's normal complete emission never runs.
+	asyncTurnMu         sync.Mutex
+	asyncTurnFinalizers map[string]*asyncTurnFinalizer
+
 	// lifetimeCtx is cancelled by Close. Background work that may outlive
 	// the call site (e.g. the synthetic wakeup prompt goroutine) derives its
 	// context from this one so it aborts when the adapter shuts down rather
@@ -262,6 +269,11 @@ type promptTurnState struct {
 	abortCh chan struct{}
 }
 
+type asyncTurnFinalizer struct {
+	timer *time.Timer
+	seq   uint64
+}
+
 // promptCancelJoinTimeout bounds how long Cancel and sendPrompt wait for a stuck
 // session/prompt RPC to end after a user cancel. Exposed as a var for tests.
 var promptCancelJoinTimeout = 3 * time.Second
@@ -273,20 +285,21 @@ func NewAdapter(cfg *shared.Config, log *logger.Logger) *Adapter {
 	l := log.WithFields(zap.String("adapter", "acp"), zap.String("agent_id", cfg.AgentID))
 	ctx, cancel := context.WithCancel(context.Background())
 	a := &Adapter{
-		cfg:             cfg,
-		logger:          l,
-		agentID:         cfg.AgentID,
-		normalizer:      NewNormalizer(cfg.AgentID),
-		updatesCh:       make(chan AgentEvent, 100),
-		notifQueue:      make(chan notifWork, notifQueueCapacity),
-		activeToolCalls: make(map[string]*streams.NormalizedPayload),
-		activeMonitors:  make(map[string]map[string]string),
-		pendingWakeups:  make(map[string]*pendingWakeup),
-		usageBySession:  make(map[string]*usageTracker),
-		attachMgr:       shared.NewAttachmentManager(cfg.WorkDir, l.Zap()),
-		promptGate:      make(chan struct{}, 1),
-		lifetimeCtx:     ctx,
-		lifetimeCancel:  cancel,
+		cfg:                 cfg,
+		logger:              l,
+		agentID:             cfg.AgentID,
+		normalizer:          NewNormalizer(cfg.AgentID),
+		updatesCh:           make(chan AgentEvent, 100),
+		notifQueue:          make(chan notifWork, notifQueueCapacity),
+		activeToolCalls:     make(map[string]*streams.NormalizedPayload),
+		activeMonitors:      make(map[string]map[string]string),
+		pendingWakeups:      make(map[string]*pendingWakeup),
+		usageBySession:      make(map[string]*usageTracker),
+		attachMgr:           shared.NewAttachmentManager(cfg.WorkDir, l.Zap()),
+		promptGate:          make(chan struct{}, 1),
+		asyncTurnFinalizers: make(map[string]*asyncTurnFinalizer),
+		lifetimeCtx:         ctx,
+		lifetimeCancel:      cancel,
 	}
 	a.wakeup = newWakeupScheduler(l, a.fireWakeup)
 	// Start the update worker before returning so any caller that connects
@@ -481,6 +494,7 @@ func (a *Adapter) Close() error {
 	if a.wakeup != nil {
 		a.wakeup.cancel()
 	}
+	a.cancelAllAsyncTurnCompletes()
 	if a.lifetimeCancel != nil {
 		a.lifetimeCancel()
 	}

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_async_complete.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_async_complete.go
@@ -9,6 +9,9 @@ import (
 
 const defaultAsyncTurnCompleteIdle = 5 * time.Second
 
+// asyncTurnCompleteIdle is the debounce window. Tests shorten it via
+// setAsyncTurnCompleteIdleForTest; do not add t.Parallel() to tests that call
+// that helper, or they will race each other on this global.
 var asyncTurnCompleteIdle = defaultAsyncTurnCompleteIdle
 
 func isAsyncTurnContentEvent(event AgentEvent) bool {
@@ -53,6 +56,8 @@ func (a *Adapter) maybeScheduleAsyncTurnComplete(event AgentEvent) {
 }
 
 func (a *Adapter) emitAsyncTurnComplete(sessionID string, seq uint64) {
+	// Fast-path stale timers before the more expensive notification-queue drain.
+	// consumeAsyncTurnFinalizer below is still the authoritative emit gate.
 	if !a.isCurrentAsyncTurnFinalizer(sessionID, seq) {
 		return
 	}

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_async_complete.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_async_complete.go
@@ -51,6 +51,10 @@ func (a *Adapter) maybeScheduleAsyncTurnComplete(event AgentEvent) {
 	if finalizer.timer != nil {
 		finalizer.timer.Stop()
 	}
+	// time.AfterFunc goroutines are not tracked by workerWg. A timer that fires
+	// concurrently with Close may call emitAsyncTurnComplete after
+	// cancelAllAsyncTurnCompletes returns; the path is safe because sendUpdate
+	// checks a.closed and syncNotifQueue respects lifetimeCtx.
 	finalizer.timer = time.AfterFunc(delay, func() {
 		a.emitAsyncTurnComplete(event.SessionID, seq, promptEpoch)
 	})

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_async_complete.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_async_complete.go
@@ -46,35 +46,72 @@ func (a *Adapter) maybeScheduleAsyncTurnComplete(event AgentEvent) {
 	}
 	finalizer.seq++
 	seq := finalizer.seq
+	finalizer.promptEpoch = a.asyncTurnEpochs[event.SessionID]
+	promptEpoch := finalizer.promptEpoch
 	if finalizer.timer != nil {
 		finalizer.timer.Stop()
 	}
 	finalizer.timer = time.AfterFunc(delay, func() {
-		a.emitAsyncTurnComplete(event.SessionID, seq)
+		a.emitAsyncTurnComplete(event.SessionID, seq, promptEpoch)
 	})
 	a.asyncTurnMu.Unlock()
 }
 
-func (a *Adapter) emitAsyncTurnComplete(sessionID string, seq uint64) {
+func (a *Adapter) emitAsyncTurnComplete(sessionID string, seq uint64, promptEpoch uint64) {
 	// Fast-path stale timers before the more expensive notification-queue drain.
-	// consumeAsyncTurnFinalizer below is still the authoritative emit gate.
-	if !a.isCurrentAsyncTurnFinalizer(sessionID, seq) {
+	// emitCurrentAsyncTurnComplete below is still the authoritative emit gate.
+	if !a.isCurrentAsyncTurnFinalizer(sessionID, seq, promptEpoch) {
 		return
 	}
 	if a.currentPromptTurn() != nil {
-		a.consumeAsyncTurnFinalizer(sessionID, seq)
+		a.consumeAsyncTurnFinalizer(sessionID, seq, promptEpoch)
 		return
 	}
 
 	a.syncNotifQueue()
 
 	if a.currentPromptTurn() != nil {
-		a.consumeAsyncTurnFinalizer(sessionID, seq)
+		a.consumeAsyncTurnFinalizer(sessionID, seq, promptEpoch)
 		return
 	}
-	if !a.consumeAsyncTurnFinalizer(sessionID, seq) {
+	a.emitCurrentAsyncTurnComplete(sessionID, seq, promptEpoch)
+}
+
+func (a *Adapter) isCurrentAsyncTurnFinalizer(sessionID string, seq uint64, promptEpoch uint64) bool {
+	a.asyncTurnMu.Lock()
+	defer a.asyncTurnMu.Unlock()
+	finalizer := a.asyncTurnFinalizers[sessionID]
+	return finalizer != nil &&
+		finalizer.seq == seq &&
+		finalizer.promptEpoch == promptEpoch &&
+		a.asyncTurnEpochs[sessionID] == promptEpoch
+}
+
+func (a *Adapter) consumeAsyncTurnFinalizer(sessionID string, seq uint64, promptEpoch uint64) bool {
+	a.asyncTurnMu.Lock()
+	defer a.asyncTurnMu.Unlock()
+	finalizer := a.asyncTurnFinalizers[sessionID]
+	if finalizer == nil ||
+		finalizer.seq != seq ||
+		finalizer.promptEpoch != promptEpoch ||
+		a.asyncTurnEpochs[sessionID] != promptEpoch {
+		return false
+	}
+	delete(a.asyncTurnFinalizers, sessionID)
+	return true
+}
+
+func (a *Adapter) emitCurrentAsyncTurnComplete(sessionID string, seq uint64, promptEpoch uint64) {
+	a.asyncTurnMu.Lock()
+	defer a.asyncTurnMu.Unlock()
+	finalizer := a.asyncTurnFinalizers[sessionID]
+	if finalizer == nil ||
+		finalizer.seq != seq ||
+		finalizer.promptEpoch != promptEpoch ||
+		a.asyncTurnEpochs[sessionID] != promptEpoch {
 		return
 	}
+	delete(a.asyncTurnFinalizers, sessionID)
 
 	a.logger.Info("emitting synthetic complete event for idle async ACP turn",
 		zap.String("session_id", sessionID),
@@ -90,27 +127,20 @@ func (a *Adapter) emitAsyncTurnComplete(sessionID string, seq uint64) {
 	})
 }
 
-func (a *Adapter) isCurrentAsyncTurnFinalizer(sessionID string, seq uint64) bool {
+func (a *Adapter) beginPromptTurn(sessionID string) {
 	a.asyncTurnMu.Lock()
 	defer a.asyncTurnMu.Unlock()
-	finalizer := a.asyncTurnFinalizers[sessionID]
-	return finalizer != nil && finalizer.seq == seq
-}
-
-func (a *Adapter) consumeAsyncTurnFinalizer(sessionID string, seq uint64) bool {
-	a.asyncTurnMu.Lock()
-	defer a.asyncTurnMu.Unlock()
-	finalizer := a.asyncTurnFinalizers[sessionID]
-	if finalizer == nil || finalizer.seq != seq {
-		return false
-	}
-	delete(a.asyncTurnFinalizers, sessionID)
-	return true
+	a.asyncTurnEpochs[sessionID]++
+	a.cancelAsyncTurnCompleteLocked(sessionID)
 }
 
 func (a *Adapter) cancelAsyncTurnComplete(sessionID string) {
 	a.asyncTurnMu.Lock()
 	defer a.asyncTurnMu.Unlock()
+	a.cancelAsyncTurnCompleteLocked(sessionID)
+}
+
+func (a *Adapter) cancelAsyncTurnCompleteLocked(sessionID string) {
 	finalizer := a.asyncTurnFinalizers[sessionID]
 	if finalizer == nil {
 		return
@@ -129,5 +159,8 @@ func (a *Adapter) cancelAllAsyncTurnCompletes() {
 			finalizer.timer.Stop()
 		}
 		delete(a.asyncTurnFinalizers, sessionID)
+	}
+	for sessionID := range a.asyncTurnEpochs {
+		delete(a.asyncTurnEpochs, sessionID)
 	}
 }

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_async_complete.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_async_complete.go
@@ -1,0 +1,128 @@
+package acp
+
+import (
+	"time"
+
+	"github.com/kandev/kandev/internal/agentctl/types/streams"
+	"go.uber.org/zap"
+)
+
+const defaultAsyncTurnCompleteIdle = 5 * time.Second
+
+var asyncTurnCompleteIdle = defaultAsyncTurnCompleteIdle
+
+func isAsyncTurnContentEvent(event AgentEvent) bool {
+	switch event.Type {
+	case streams.EventTypeMessageChunk,
+		streams.EventTypeReasoning,
+		streams.EventTypeToolCall,
+		streams.EventTypeToolUpdate,
+		streams.EventTypePlan,
+		streams.EventTypeAgentPlan,
+		streams.EventTypePermissionRequest:
+		return true
+	default:
+		return false
+	}
+}
+
+func (a *Adapter) maybeScheduleAsyncTurnComplete(event AgentEvent) {
+	if !isAsyncTurnContentEvent(event) || event.SessionID == "" {
+		return
+	}
+	if a.currentPromptTurn() != nil {
+		return
+	}
+
+	delay := asyncTurnCompleteIdle
+	a.asyncTurnMu.Lock()
+	finalizer := a.asyncTurnFinalizers[event.SessionID]
+	if finalizer == nil {
+		finalizer = &asyncTurnFinalizer{}
+		a.asyncTurnFinalizers[event.SessionID] = finalizer
+	}
+	finalizer.seq++
+	seq := finalizer.seq
+	if finalizer.timer != nil {
+		finalizer.timer.Stop()
+	}
+	finalizer.timer = time.AfterFunc(delay, func() {
+		a.emitAsyncTurnComplete(event.SessionID, seq)
+	})
+	a.asyncTurnMu.Unlock()
+}
+
+func (a *Adapter) emitAsyncTurnComplete(sessionID string, seq uint64) {
+	if !a.isCurrentAsyncTurnFinalizer(sessionID, seq) {
+		return
+	}
+	if a.currentPromptTurn() != nil {
+		a.consumeAsyncTurnFinalizer(sessionID, seq)
+		return
+	}
+
+	a.syncNotifQueue()
+
+	if a.currentPromptTurn() != nil {
+		a.consumeAsyncTurnFinalizer(sessionID, seq)
+		return
+	}
+	if !a.consumeAsyncTurnFinalizer(sessionID, seq) {
+		return
+	}
+
+	a.logger.Info("emitting synthetic complete event for idle async ACP turn",
+		zap.String("session_id", sessionID),
+		zap.Duration("idle", asyncTurnCompleteIdle))
+	a.sendUpdate(AgentEvent{
+		Type:      streams.EventTypeComplete,
+		SessionID: sessionID,
+		Data: map[string]any{
+			"stop_reason":      "end_turn",
+			"synthetic":        true,
+			"synthetic_reason": "async_turn_idle",
+		},
+	})
+}
+
+func (a *Adapter) isCurrentAsyncTurnFinalizer(sessionID string, seq uint64) bool {
+	a.asyncTurnMu.Lock()
+	defer a.asyncTurnMu.Unlock()
+	finalizer := a.asyncTurnFinalizers[sessionID]
+	return finalizer != nil && finalizer.seq == seq
+}
+
+func (a *Adapter) consumeAsyncTurnFinalizer(sessionID string, seq uint64) bool {
+	a.asyncTurnMu.Lock()
+	defer a.asyncTurnMu.Unlock()
+	finalizer := a.asyncTurnFinalizers[sessionID]
+	if finalizer == nil || finalizer.seq != seq {
+		return false
+	}
+	delete(a.asyncTurnFinalizers, sessionID)
+	return true
+}
+
+func (a *Adapter) cancelAsyncTurnComplete(sessionID string) {
+	a.asyncTurnMu.Lock()
+	defer a.asyncTurnMu.Unlock()
+	finalizer := a.asyncTurnFinalizers[sessionID]
+	if finalizer == nil {
+		return
+	}
+	if finalizer.timer != nil {
+		finalizer.timer.Stop()
+	}
+	delete(a.asyncTurnFinalizers, sessionID)
+}
+
+func (a *Adapter) cancelAllAsyncTurnCompletes() {
+	a.asyncTurnMu.Lock()
+	defer a.asyncTurnMu.Unlock()
+	for sessionID, finalizer := range a.asyncTurnFinalizers {
+		if finalizer.timer != nil {
+			finalizer.timer.Stop()
+		}
+		delete(a.asyncTurnFinalizers, sessionID)
+	}
+}

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_prompt.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_prompt.go
@@ -169,6 +169,7 @@ func (a *Adapter) sendPrompt(ctx context.Context, message string, attachments []
 	a.logger.Debug("emitting complete event after prompt",
 		zap.String("session_id", sessionID),
 		zap.String("stop_reason", stopReason))
+	a.cancelAsyncTurnComplete(sessionID)
 	usage := extractUsage(&resp)
 	// codex-acp emits no per-turn usage frame, only cumulative
 	// usage_update.used. Fall back to the inferred delta so the office

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_prompt.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_prompt.go
@@ -76,6 +76,7 @@ func (a *Adapter) sendPrompt(ctx context.Context, message string, attachments []
 			zap.String("session_id", sessionID),
 			zap.Int("context_length", len(pendingContext)))
 	}
+	a.beginPromptTurn(sessionID)
 
 	contentBlocks := a.buildPromptContentBlocks(finalMessage, attachments)
 

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_session.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_session.go
@@ -33,6 +33,7 @@ func (a *Adapter) NewSession(ctx context.Context, mcpServers []types.McpServer) 
 	a.pendingWakeups = make(map[string]*pendingWakeup)
 	a.wakeup.cancel()
 	a.mu.Unlock()
+	a.cancelAllAsyncTurnCompletes()
 
 	ctx, span := shared.TraceProtocolRequest(ctx, shared.ProtocolACP, a.agentID, "session.new")
 	defer span.End()
@@ -281,14 +282,15 @@ func (a *Adapter) LoadSession(ctx context.Context, sessionID string, mcpServers 
 		return fmt.Errorf("agent does not support session loading (LoadSession capability is false)")
 	}
 
-	// Loading a different session invalidates any pending wakeup keyed to the
-	// prior session — same reset block as NewSession to avoid leaving an armed
-	// timer for a session id that's about to change and accumulating stale
-	// pendingWakeups entries across reloads.
+	// Loading a different session invalidates any pending wakeup or async turn
+	// finalizer keyed to the prior session — same reset block as NewSession to
+	// avoid leaving an armed timer for a session id that's about to change and
+	// accumulating stale pendingWakeups entries across reloads.
 	a.mu.Lock()
 	a.pendingWakeups = make(map[string]*pendingWakeup)
 	a.wakeup.cancel()
 	a.mu.Unlock()
+	a.cancelAllAsyncTurnCompletes()
 
 	ctx, span := shared.TraceProtocolRequest(ctx, shared.ProtocolACP, a.agentID, "session.load")
 	defer span.End()

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_updates.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_updates.go
@@ -160,6 +160,7 @@ func (a *Adapter) handleACPUpdate(n acp.SessionNotification) {
 		shared.TraceProtocolEvent(a.getPromptTraceCtx(), shared.ProtocolACP, a.agentID,
 			event.Type, rawData, event)
 		a.sendUpdate(*event)
+		a.maybeScheduleAsyncTurnComplete(*event)
 	} else if updateJSON, err := json.Marshal(n.Update); err == nil {
 		a.logger.Warn("unhandled ACP session notification",
 			zap.String("session_id", sessionID),
@@ -466,7 +467,9 @@ func (a *Adapter) routeMonitorEvents(sessionID, text string) string {
 		payload := a.activeToolCalls[toolCallID]
 		appendMonitorEvent(payload, ev.TaskID, monitorCommandFromPayload(payload), ev.Body)
 		a.mu.Unlock()
-		a.sendUpdate(monitorEventEvent(sessionID, toolCallID, ev.Body, payload))
+		update := monitorEventEvent(sessionID, toolCallID, ev.Body, payload)
+		a.sendUpdate(update)
+		a.maybeScheduleAsyncTurnComplete(update)
 		a.logger.Debug("monitor event routed",
 			zap.String("session_id", sessionID),
 			zap.String("task_id", ev.TaskID),

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/async_complete_test.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/async_complete_test.go
@@ -1,0 +1,83 @@
+package acp
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	acp "github.com/coder/acp-go-sdk"
+	"github.com/kandev/kandev/internal/agentctl/types/streams"
+)
+
+func TestHandleACPUpdate_AsyncMonitorTextWithoutPromptEmitsIdleComplete(t *testing.T) {
+	setAsyncTurnCompleteIdleForTest(t, 10*time.Millisecond)
+	a := newTestAdapter()
+	t.Cleanup(func() { _ = a.Close() })
+
+	a.handleACPUpdate(makeNotification("s-monitor", acp.SessionUpdate{
+		AgentMessageChunk: &acp.SessionUpdateAgentMessageChunk{
+			Content: acp.TextBlock("monitor finished without a prompt response"),
+		},
+	}))
+
+	first := readAdapterEvent(t, a, 100*time.Millisecond)
+	if first.Type != streams.EventTypeMessageChunk {
+		t.Fatalf("first event type = %q, want %q", first.Type, streams.EventTypeMessageChunk)
+	}
+
+	complete := readAdapterEvent(t, a, 250*time.Millisecond)
+	if complete.Type != streams.EventTypeComplete {
+		t.Fatalf("second event type = %q, want %q", complete.Type, streams.EventTypeComplete)
+	}
+	if complete.SessionID != "s-monitor" {
+		t.Errorf("complete SessionID = %q, want s-monitor", complete.SessionID)
+	}
+	if complete.Data["synthetic_reason"] != "async_turn_idle" {
+		t.Errorf("synthetic_reason = %v, want async_turn_idle", complete.Data["synthetic_reason"])
+	}
+}
+
+func TestHandleACPUpdate_DoesNotEmitIdleCompleteWhilePromptActive(t *testing.T) {
+	setAsyncTurnCompleteIdleForTest(t, 10*time.Millisecond)
+	a := newTestAdapter()
+	t.Cleanup(func() { _ = a.Close() })
+	_, turn := a.registerPromptTurn(context.Background())
+	defer a.clearPromptTurn(turn)
+
+	a.handleACPUpdate(makeNotification("s-prompt", acp.SessionUpdate{
+		AgentMessageChunk: &acp.SessionUpdateAgentMessageChunk{
+			Content: acp.TextBlock("normal prompt chunk"),
+		},
+	}))
+
+	first := readAdapterEvent(t, a, 100*time.Millisecond)
+	if first.Type != streams.EventTypeMessageChunk {
+		t.Fatalf("first event type = %q, want %q", first.Type, streams.EventTypeMessageChunk)
+	}
+
+	select {
+	case ev := <-a.updatesCh:
+		t.Fatalf("unexpected event while prompt active: %+v", ev)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func setAsyncTurnCompleteIdleForTest(t *testing.T, d time.Duration) {
+	t.Helper()
+	previous := asyncTurnCompleteIdle
+	asyncTurnCompleteIdle = d
+	t.Cleanup(func() {
+		asyncTurnCompleteIdle = previous
+	})
+}
+
+func readAdapterEvent(t *testing.T, a *Adapter, timeout time.Duration) AgentEvent {
+	t.Helper()
+	select {
+	case ev := <-a.updatesCh:
+		return ev
+	case <-time.After(timeout):
+		t.Fatalf("timed out waiting for adapter event after %s", timeout)
+		return AgentEvent{}
+	}
+}

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/async_complete_test.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/async_complete_test.go
@@ -118,6 +118,67 @@ func TestAsyncTurnComplete_CancelledByPromptStart(t *testing.T) {
 	})
 }
 
+func TestAsyncTurnComplete_CancelledByNewSession(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		setAsyncTurnCompleteIdleForTest(t, 50*time.Millisecond)
+		a, _ := setupConcurrencyFakeAgent(t)
+		if err := a.Initialize(context.Background()); err != nil {
+			t.Fatalf("Initialize: %v", err)
+		}
+		_ = drainEvents(a)
+
+		a.handleACPUpdate(makeNotification("s-old", acp.SessionUpdate{
+			AgentMessageChunk: &acp.SessionUpdateAgentMessageChunk{
+				Content: acp.TextBlock("old session async chunk"),
+			},
+		}))
+		first := readAdapterEvent(t, a, 100*time.Millisecond)
+		if first.Type != streams.EventTypeMessageChunk {
+			t.Fatalf("first event type = %q, want %q", first.Type, streams.EventTypeMessageChunk)
+		}
+
+		if _, err := a.NewSession(context.Background(), nil); err != nil {
+			t.Fatalf("NewSession: %v", err)
+		}
+		_ = drainEvents(a)
+
+		time.Sleep(150 * time.Millisecond)
+		synctest.Wait()
+		assertNoAdapterEvent(t, a, "after NewSession")
+	})
+}
+
+func TestAsyncTurnComplete_CancelledByLoadSession(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		setAsyncTurnCompleteIdleForTest(t, 50*time.Millisecond)
+		a, _ := setupConcurrencyFakeAgent(t)
+		if err := a.Initialize(context.Background()); err != nil {
+			t.Fatalf("Initialize: %v", err)
+		}
+		_ = drainEvents(a)
+		a.capabilities.LoadSession = true
+
+		a.handleACPUpdate(makeNotification("s-old", acp.SessionUpdate{
+			AgentMessageChunk: &acp.SessionUpdateAgentMessageChunk{
+				Content: acp.TextBlock("old session async chunk"),
+			},
+		}))
+		first := readAdapterEvent(t, a, 100*time.Millisecond)
+		if first.Type != streams.EventTypeMessageChunk {
+			t.Fatalf("first event type = %q, want %q", first.Type, streams.EventTypeMessageChunk)
+		}
+
+		if err := a.LoadSession(context.Background(), "s-new", nil); err != nil {
+			t.Fatalf("LoadSession: %v", err)
+		}
+		_ = drainEvents(a)
+
+		time.Sleep(150 * time.Millisecond)
+		synctest.Wait()
+		assertNoAdapterEvent(t, a, "after LoadSession")
+	})
+}
+
 func setAsyncTurnCompleteIdleForTest(t *testing.T, d time.Duration) {
 	t.Helper()
 	previous := asyncTurnCompleteIdle

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/async_complete_test.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/async_complete_test.go
@@ -3,6 +3,7 @@ package acp
 import (
 	"context"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	acp "github.com/coder/acp-go-sdk"
@@ -10,106 +11,111 @@ import (
 )
 
 func TestHandleACPUpdate_AsyncMonitorTextWithoutPromptEmitsIdleComplete(t *testing.T) {
-	setAsyncTurnCompleteIdleForTest(t, 10*time.Millisecond)
-	a := newTestAdapter()
-	t.Cleanup(func() { _ = a.Close() })
+	synctest.Test(t, func(t *testing.T) {
+		setAsyncTurnCompleteIdleForTest(t, 10*time.Millisecond)
+		a := newTestAdapter()
+		defer func() { _ = a.Close() }()
 
-	a.handleACPUpdate(makeNotification("s-monitor", acp.SessionUpdate{
-		AgentMessageChunk: &acp.SessionUpdateAgentMessageChunk{
-			Content: acp.TextBlock("monitor finished without a prompt response"),
-		},
-	}))
+		a.handleACPUpdate(makeNotification("s-monitor", acp.SessionUpdate{
+			AgentMessageChunk: &acp.SessionUpdateAgentMessageChunk{
+				Content: acp.TextBlock("monitor finished without a prompt response"),
+			},
+		}))
 
-	first := readAdapterEvent(t, a, 100*time.Millisecond)
-	if first.Type != streams.EventTypeMessageChunk {
-		t.Fatalf("first event type = %q, want %q", first.Type, streams.EventTypeMessageChunk)
-	}
+		first := readAdapterEvent(t, a, 100*time.Millisecond)
+		if first.Type != streams.EventTypeMessageChunk {
+			t.Fatalf("first event type = %q, want %q", first.Type, streams.EventTypeMessageChunk)
+		}
 
-	complete := readAdapterEvent(t, a, 250*time.Millisecond)
-	if complete.Type != streams.EventTypeComplete {
-		t.Fatalf("second event type = %q, want %q", complete.Type, streams.EventTypeComplete)
-	}
-	if complete.SessionID != "s-monitor" {
-		t.Errorf("complete SessionID = %q, want s-monitor", complete.SessionID)
-	}
-	if complete.Data["synthetic_reason"] != "async_turn_idle" {
-		t.Errorf("synthetic_reason = %v, want async_turn_idle", complete.Data["synthetic_reason"])
-	}
+		time.Sleep(50 * time.Millisecond)
+		synctest.Wait()
+
+		complete := readAdapterEvent(t, a, 100*time.Millisecond)
+		if complete.Type != streams.EventTypeComplete {
+			t.Fatalf("second event type = %q, want %q", complete.Type, streams.EventTypeComplete)
+		}
+		if complete.SessionID != "s-monitor" {
+			t.Errorf("complete SessionID = %q, want s-monitor", complete.SessionID)
+		}
+		if complete.Data["synthetic_reason"] != "async_turn_idle" {
+			t.Errorf("synthetic_reason = %v, want async_turn_idle", complete.Data["synthetic_reason"])
+		}
+	})
 }
 
 func TestHandleACPUpdate_DoesNotEmitIdleCompleteWhilePromptActive(t *testing.T) {
-	setAsyncTurnCompleteIdleForTest(t, 10*time.Millisecond)
-	a := newTestAdapter()
-	t.Cleanup(func() { _ = a.Close() })
-	_, turn := a.registerPromptTurn(context.Background())
-	defer a.clearPromptTurn(turn)
+	synctest.Test(t, func(t *testing.T) {
+		setAsyncTurnCompleteIdleForTest(t, 10*time.Millisecond)
+		a := newTestAdapter()
+		defer func() { _ = a.Close() }()
+		_, turn := a.registerPromptTurn(context.Background())
+		defer a.clearPromptTurn(turn)
 
-	a.handleACPUpdate(makeNotification("s-prompt", acp.SessionUpdate{
-		AgentMessageChunk: &acp.SessionUpdateAgentMessageChunk{
-			Content: acp.TextBlock("normal prompt chunk"),
-		},
-	}))
+		a.handleACPUpdate(makeNotification("s-prompt", acp.SessionUpdate{
+			AgentMessageChunk: &acp.SessionUpdateAgentMessageChunk{
+				Content: acp.TextBlock("normal prompt chunk"),
+			},
+		}))
 
-	first := readAdapterEvent(t, a, 100*time.Millisecond)
-	if first.Type != streams.EventTypeMessageChunk {
-		t.Fatalf("first event type = %q, want %q", first.Type, streams.EventTypeMessageChunk)
-	}
+		first := readAdapterEvent(t, a, 100*time.Millisecond)
+		if first.Type != streams.EventTypeMessageChunk {
+			t.Fatalf("first event type = %q, want %q", first.Type, streams.EventTypeMessageChunk)
+		}
 
-	select {
-	case ev := <-a.updatesCh:
-		t.Fatalf("unexpected event while prompt active: %+v", ev)
-	case <-time.After(50 * time.Millisecond):
-	}
+		time.Sleep(50 * time.Millisecond)
+		synctest.Wait()
+		assertNoAdapterEvent(t, a, "while prompt active")
+	})
 }
 
 func TestAsyncTurnComplete_CancelledByRealPromptCompletion(t *testing.T) {
-	setAsyncTurnCompleteIdleForTest(t, 50*time.Millisecond)
-	a := newTestAdapter()
-	t.Cleanup(func() { _ = a.Close() })
+	synctest.Test(t, func(t *testing.T) {
+		setAsyncTurnCompleteIdleForTest(t, 50*time.Millisecond)
+		a := newTestAdapter()
+		defer func() { _ = a.Close() }()
 
-	a.handleACPUpdate(makeNotification("s-cancel", acp.SessionUpdate{
-		AgentMessageChunk: &acp.SessionUpdateAgentMessageChunk{
-			Content: acp.TextBlock("async chunk"),
-		},
-	}))
+		a.handleACPUpdate(makeNotification("s-cancel", acp.SessionUpdate{
+			AgentMessageChunk: &acp.SessionUpdateAgentMessageChunk{
+				Content: acp.TextBlock("async chunk"),
+			},
+		}))
 
-	first := readAdapterEvent(t, a, 100*time.Millisecond)
-	if first.Type != streams.EventTypeMessageChunk {
-		t.Fatalf("first event type = %q, want %q", first.Type, streams.EventTypeMessageChunk)
-	}
+		first := readAdapterEvent(t, a, 100*time.Millisecond)
+		if first.Type != streams.EventTypeMessageChunk {
+			t.Fatalf("first event type = %q, want %q", first.Type, streams.EventTypeMessageChunk)
+		}
 
-	a.cancelAsyncTurnComplete("s-cancel")
+		a.cancelAsyncTurnComplete("s-cancel")
 
-	select {
-	case ev := <-a.updatesCh:
-		t.Fatalf("unexpected event after cancel: %+v", ev)
-	case <-time.After(150 * time.Millisecond):
-	}
+		time.Sleep(150 * time.Millisecond)
+		synctest.Wait()
+		assertNoAdapterEvent(t, a, "after cancel")
+	})
 }
 
 func TestAsyncTurnComplete_CancelledByPromptStart(t *testing.T) {
-	setAsyncTurnCompleteIdleForTest(t, 50*time.Millisecond)
-	a := newTestAdapter()
-	t.Cleanup(func() { _ = a.Close() })
+	synctest.Test(t, func(t *testing.T) {
+		setAsyncTurnCompleteIdleForTest(t, 50*time.Millisecond)
+		a := newTestAdapter()
+		defer func() { _ = a.Close() }()
 
-	a.handleACPUpdate(makeNotification("s-start", acp.SessionUpdate{
-		AgentMessageChunk: &acp.SessionUpdateAgentMessageChunk{
-			Content: acp.TextBlock("async chunk before prompt"),
-		},
-	}))
+		a.handleACPUpdate(makeNotification("s-start", acp.SessionUpdate{
+			AgentMessageChunk: &acp.SessionUpdateAgentMessageChunk{
+				Content: acp.TextBlock("async chunk before prompt"),
+			},
+		}))
 
-	first := readAdapterEvent(t, a, 100*time.Millisecond)
-	if first.Type != streams.EventTypeMessageChunk {
-		t.Fatalf("first event type = %q, want %q", first.Type, streams.EventTypeMessageChunk)
-	}
+		first := readAdapterEvent(t, a, 100*time.Millisecond)
+		if first.Type != streams.EventTypeMessageChunk {
+			t.Fatalf("first event type = %q, want %q", first.Type, streams.EventTypeMessageChunk)
+		}
 
-	a.beginPromptTurn("s-start")
+		a.beginPromptTurn("s-start")
 
-	select {
-	case ev := <-a.updatesCh:
-		t.Fatalf("unexpected event after prompt start: %+v", ev)
-	case <-time.After(150 * time.Millisecond):
-	}
+		time.Sleep(150 * time.Millisecond)
+		synctest.Wait()
+		assertNoAdapterEvent(t, a, "after prompt start")
+	})
 }
 
 func setAsyncTurnCompleteIdleForTest(t *testing.T, d time.Duration) {
@@ -129,5 +135,14 @@ func readAdapterEvent(t *testing.T, a *Adapter, timeout time.Duration) AgentEven
 	case <-time.After(timeout):
 		t.Fatalf("timed out waiting for adapter event after %s", timeout)
 		return AgentEvent{}
+	}
+}
+
+func assertNoAdapterEvent(t *testing.T, a *Adapter, context string) {
+	t.Helper()
+	select {
+	case ev := <-a.updatesCh:
+		t.Fatalf("unexpected event %s: %+v", context, ev)
+	default:
 	}
 }

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/async_complete_test.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/async_complete_test.go
@@ -87,6 +87,31 @@ func TestAsyncTurnComplete_CancelledByRealPromptCompletion(t *testing.T) {
 	}
 }
 
+func TestAsyncTurnComplete_CancelledByPromptStart(t *testing.T) {
+	setAsyncTurnCompleteIdleForTest(t, 50*time.Millisecond)
+	a := newTestAdapter()
+	t.Cleanup(func() { _ = a.Close() })
+
+	a.handleACPUpdate(makeNotification("s-start", acp.SessionUpdate{
+		AgentMessageChunk: &acp.SessionUpdateAgentMessageChunk{
+			Content: acp.TextBlock("async chunk before prompt"),
+		},
+	}))
+
+	first := readAdapterEvent(t, a, 100*time.Millisecond)
+	if first.Type != streams.EventTypeMessageChunk {
+		t.Fatalf("first event type = %q, want %q", first.Type, streams.EventTypeMessageChunk)
+	}
+
+	a.beginPromptTurn("s-start")
+
+	select {
+	case ev := <-a.updatesCh:
+		t.Fatalf("unexpected event after prompt start: %+v", ev)
+	case <-time.After(150 * time.Millisecond):
+	}
+}
+
 func setAsyncTurnCompleteIdleForTest(t *testing.T, d time.Duration) {
 	t.Helper()
 	previous := asyncTurnCompleteIdle

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/async_complete_test.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/async_complete_test.go
@@ -62,6 +62,31 @@ func TestHandleACPUpdate_DoesNotEmitIdleCompleteWhilePromptActive(t *testing.T) 
 	}
 }
 
+func TestAsyncTurnComplete_CancelledByRealPromptCompletion(t *testing.T) {
+	setAsyncTurnCompleteIdleForTest(t, 50*time.Millisecond)
+	a := newTestAdapter()
+	t.Cleanup(func() { _ = a.Close() })
+
+	a.handleACPUpdate(makeNotification("s-cancel", acp.SessionUpdate{
+		AgentMessageChunk: &acp.SessionUpdateAgentMessageChunk{
+			Content: acp.TextBlock("async chunk"),
+		},
+	}))
+
+	first := readAdapterEvent(t, a, 100*time.Millisecond)
+	if first.Type != streams.EventTypeMessageChunk {
+		t.Fatalf("first event type = %q, want %q", first.Type, streams.EventTypeMessageChunk)
+	}
+
+	a.cancelAsyncTurnComplete("s-cancel")
+
+	select {
+	case ev := <-a.updatesCh:
+		t.Fatalf("unexpected event after cancel: %+v", ev)
+	case <-time.After(150 * time.Millisecond):
+	}
+}
+
 func setAsyncTurnCompleteIdleForTest(t *testing.T, d time.Duration) {
 	t.Helper()
 	previous := asyncTurnCompleteIdle

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/monitor_test.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/monitor_test.go
@@ -3,6 +3,7 @@ package acp
 import (
 	"strings"
 	"testing"
+	"time"
 
 	acp "github.com/coder/acp-go-sdk"
 	"github.com/kandev/kandev/internal/agentctl/types/streams"
@@ -179,6 +180,32 @@ func TestRouteMonitorEvents_EmitsSyntheticUpdateAndStripsEnvelope(t *testing.T) 
 	if len(ev.ToolCallContents) != 1 || ev.ToolCallContents[0].Content == nil ||
 		ev.ToolCallContents[0].Content.Text != "event-A" {
 		t.Errorf("contents = %+v, want one text content 'event-A'", ev.ToolCallContents)
+	}
+}
+
+func TestRouteMonitorEvents_AsyncMonitorEventEmitsIdleComplete(t *testing.T) {
+	setAsyncTurnCompleteIdleForTest(t, 10*time.Millisecond)
+	a := newTestAdapter()
+	t.Cleanup(func() { _ = a.Close() })
+	seedMonitor(t, a, "s1", "t1", "tc-monitor")
+
+	cleaned := a.routeMonitorEvents("s1",
+		"<task-notification><task-id>t1</task-id><event>event-A</event></task-notification>")
+	if strings.TrimSpace(cleaned) != "" {
+		t.Errorf("cleaned = %q, want empty", cleaned)
+	}
+
+	update := readAdapterEvent(t, a, 100*time.Millisecond)
+	if update.Type != streams.EventTypeToolUpdate {
+		t.Fatalf("first event type = %q, want %q", update.Type, streams.EventTypeToolUpdate)
+	}
+
+	complete := readAdapterEvent(t, a, 250*time.Millisecond)
+	if complete.Type != streams.EventTypeComplete {
+		t.Fatalf("second event type = %q, want %q", complete.Type, streams.EventTypeComplete)
+	}
+	if complete.Data["synthetic_reason"] != "async_turn_idle" {
+		t.Errorf("synthetic_reason = %v, want async_turn_idle", complete.Data["synthetic_reason"])
 	}
 }
 

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/monitor_test.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/monitor_test.go
@@ -3,6 +3,7 @@ package acp
 import (
 	"strings"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	acp "github.com/coder/acp-go-sdk"
@@ -184,29 +185,34 @@ func TestRouteMonitorEvents_EmitsSyntheticUpdateAndStripsEnvelope(t *testing.T) 
 }
 
 func TestRouteMonitorEvents_AsyncMonitorEventEmitsIdleComplete(t *testing.T) {
-	setAsyncTurnCompleteIdleForTest(t, 10*time.Millisecond)
-	a := newTestAdapter()
-	t.Cleanup(func() { _ = a.Close() })
-	seedMonitor(t, a, "s1", "t1", "tc-monitor")
+	synctest.Test(t, func(t *testing.T) {
+		setAsyncTurnCompleteIdleForTest(t, 10*time.Millisecond)
+		a := newTestAdapter()
+		defer func() { _ = a.Close() }()
+		seedMonitor(t, a, "s1", "t1", "tc-monitor")
 
-	cleaned := a.routeMonitorEvents("s1",
-		"<task-notification><task-id>t1</task-id><event>event-A</event></task-notification>")
-	if strings.TrimSpace(cleaned) != "" {
-		t.Errorf("cleaned = %q, want empty", cleaned)
-	}
+		cleaned := a.routeMonitorEvents("s1",
+			"<task-notification><task-id>t1</task-id><event>event-A</event></task-notification>")
+		if strings.TrimSpace(cleaned) != "" {
+			t.Errorf("cleaned = %q, want empty", cleaned)
+		}
 
-	update := readAdapterEvent(t, a, 100*time.Millisecond)
-	if update.Type != streams.EventTypeToolUpdate {
-		t.Fatalf("first event type = %q, want %q", update.Type, streams.EventTypeToolUpdate)
-	}
+		update := readAdapterEvent(t, a, 100*time.Millisecond)
+		if update.Type != streams.EventTypeToolUpdate {
+			t.Fatalf("first event type = %q, want %q", update.Type, streams.EventTypeToolUpdate)
+		}
 
-	complete := readAdapterEvent(t, a, 250*time.Millisecond)
-	if complete.Type != streams.EventTypeComplete {
-		t.Fatalf("second event type = %q, want %q", complete.Type, streams.EventTypeComplete)
-	}
-	if complete.Data["synthetic_reason"] != "async_turn_idle" {
-		t.Errorf("synthetic_reason = %v, want async_turn_idle", complete.Data["synthetic_reason"])
-	}
+		time.Sleep(50 * time.Millisecond)
+		synctest.Wait()
+
+		complete := readAdapterEvent(t, a, 100*time.Millisecond)
+		if complete.Type != streams.EventTypeComplete {
+			t.Fatalf("second event type = %q, want %q", complete.Type, streams.EventTypeComplete)
+		}
+		if complete.Data["synthetic_reason"] != "async_turn_idle" {
+			t.Errorf("synthetic_reason = %v, want async_turn_idle", complete.Data["synthetic_reason"])
+		}
+	})
 }
 
 func TestRouteMonitorEvents_UnknownTaskIDLeavesTextIntact(t *testing.T) {

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/wakeup_concurrency_test.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/wakeup_concurrency_test.go
@@ -54,6 +54,9 @@ func (f *concurrencyFakeAgent) CloseSession(_ context.Context, _ acp.CloseSessio
 func (f *concurrencyFakeAgent) ListSessions(_ context.Context, _ acp.ListSessionsRequest) (acp.ListSessionsResponse, error) {
 	return acp.ListSessionsResponse{}, nil
 }
+func (f *concurrencyFakeAgent) LoadSession(_ context.Context, _ acp.LoadSessionRequest) (acp.LoadSessionResponse, error) {
+	return acp.LoadSessionResponse{}, nil
+}
 func (f *concurrencyFakeAgent) ResumeSession(_ context.Context, _ acp.ResumeSessionRequest) (acp.ResumeSessionResponse, error) {
 	return acp.ResumeSessionResponse{}, nil
 }


### PR DESCRIPTION
Claude Monitor callbacks can emit assistant/tool updates outside an active prompt RPC, leaving Kandev waiting for a prompt completion that will never arrive. Idle async ACP turn content now synthesizes a completion after a short debounce, so lifecycle flushes buffered messages and future prompts remain usable.

## Important Changes

- Added a per-session async turn finalizer for ACP content updates that arrive while no prompt is active.
- Canceled pending synthetic completions when a real prompt completion arrives, so normal prompt turns keep the existing completion path.
- Covered raw async message chunks and stripped Monitor task notifications with regression tests.

## Validation

- `make fmt`
- `node apps/web/scripts/generate-release-notes.mjs`
- `node apps/web/scripts/generate-changelog.mjs`
- `make typecheck`
- `make test`
- `make lint`

Closes #1597

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1600?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->