### PR TITLE
feat: improve office onboarding and workspace flows

### DIFF
--- a/apps/backend/internal/agent/settings/controller/controller.go
+++ b/apps/backend/internal/agent/settings/controller/controller.go
@@ -46,17 +46,18 @@ var (
 )
 
 type Controller struct {
-	repo           store.Repository
-	discovery      *discovery.Registry
-	agentRegistry  *registry.Registry
-	sessionChecker SessionChecker
-	watcherDeps    WatcherDependencyChecker
-	mcpService     *mcpconfig.Service
-	modelCache     *modelfetcher.Cache
-	hostUtility    *hostutility.Manager
-	jobStore       *JobStore
-	hub            JobBroadcaster
-	logger         *logger.Logger
+	repo            store.Repository
+	discovery       *discovery.Registry
+	agentRegistry   *registry.Registry
+	sessionChecker  SessionChecker
+	watcherDeps     WatcherDependencyChecker
+	routingTierDeps RoutingTierDependencyChecker
+	mcpService      *mcpconfig.Service
+	modelCache      *modelfetcher.Cache
+	hostUtility     *hostutility.Manager
+	jobStore        *JobStore
+	hub             JobBroadcaster
+	logger          *logger.Logger
 }
 
 // SetWatcherDependencyChecker wires in the watcher dependency enumerator so
@@ -66,6 +67,12 @@ func (c *Controller) SetWatcherDependencyChecker(w WatcherDependencyChecker) {
 	c.watcherDeps = w
 }
 
+// SetRoutingTierDependencyChecker wires in workspace routing tier lookups so
+// DeleteProfile can reject profiles selected as a workspace tier source.
+func (c *Controller) SetRoutingTierDependencyChecker(r RoutingTierDependencyChecker) {
+	c.routingTierDeps = r
+}
+
 // ErrProfileInUseDetail is returned when a profile cannot be deleted because
 // active sessions or external integration watchers reference it. The UI uses
 // the breakdown to render a "this will also disable N watchers — continue?"
@@ -73,11 +80,12 @@ func (c *Controller) SetWatcherDependencyChecker(w WatcherDependencyChecker) {
 type ErrProfileInUseDetail struct {
 	ActiveSessions []agentdto.ActiveTaskInfo
 	Watchers       []WatcherReference
+	RoutingTiers   []RoutingTierReference
 }
 
 func (e *ErrProfileInUseDetail) Error() string {
-	return fmt.Sprintf("agent profile is used by %d active session(s) and %d watcher(s)",
-		len(e.ActiveSessions), len(e.Watchers))
+	return fmt.Sprintf("agent profile is used by %d active session(s), %d watcher(s), and %d routing tier(s)",
+		len(e.ActiveSessions), len(e.Watchers), len(e.RoutingTiers))
 }
 
 // WatcherReference points at one issue/PR watcher row that uses the profile
@@ -88,6 +96,14 @@ type WatcherReference struct {
 	ID    string `json:"id"`
 	Kind  string `json:"kind"`
 	Label string `json:"label"`
+}
+
+// RoutingTierReference points at a workspace provider-routing tier that was
+// seeded from the profile being deleted.
+type RoutingTierReference struct {
+	WorkspaceID string `json:"workspace_id"`
+	ProviderID  string `json:"provider_id"`
+	Tier        string `json:"tier"`
 }
 
 // WatcherDependencyChecker enumerates watcher rows that reference an agent
@@ -110,6 +126,10 @@ type SessionChecker interface {
 	HasActiveTaskSessionsByAgentProfile(ctx context.Context, agentProfileID string) (bool, error)
 	DeleteEphemeralTasksByAgentProfile(ctx context.Context, agentProfileID string) (int64, error)
 	GetActiveTaskInfoByAgentProfile(ctx context.Context, agentProfileID string) ([]agentdto.ActiveTaskInfo, error)
+}
+
+type RoutingTierDependencyChecker interface {
+	ListRoutingTierReferencesByAgentProfile(ctx context.Context, profileID string) ([]RoutingTierReference, error)
 }
 
 func NewController(repo store.Repository, discoveryRegistry *discovery.Registry, agentRegistry *registry.Registry, sessionChecker SessionChecker, log *logger.Logger,

--- a/apps/backend/internal/agent/settings/controller/profile_crud.go
+++ b/apps/backend/internal/agent/settings/controller/profile_crud.go
@@ -240,14 +240,14 @@ func (c *Controller) DeleteProfile(ctx context.Context, id string, force bool) (
 	return &result, nil
 }
 
-// prepareProfileDeletion checks for active sessions and referencing watchers,
-// then cleans up ephemeral tasks. Returns *ErrProfileInUseDetail when force
-// is false and any active session OR referencing watcher exists — the UI uses
-// the breakdown to render a confirmation dialog. force=true skips both checks;
-// the eager disable of referencing watchers runs in DeleteProfile after the
-// row is actually gone (the dispatch coordinator's preflight stays as the
-// safety net for profiles deleted by other paths, e.g. reconciler cleanup of
-// disabled agent types).
+// prepareProfileDeletion blocks every routing-tier reference, then checks for
+// active sessions and referencing watchers before cleaning up ephemeral tasks.
+// Routing-tier references are hard blockers even when force=true because a
+// deleted profile would orphan workspace tier mappings. When force is false,
+// active sessions and watchers return *ErrProfileInUseDetail so the UI can
+// render a confirmation dialog. force=true skips only those soft blockers; the
+// eager disable of referencing watchers runs in DeleteProfile after the row is
+// actually gone.
 func (c *Controller) prepareProfileDeletion(ctx context.Context, profileID string, force bool) error {
 	routingTierRefs, err := c.listRoutingTierReferences(ctx, profileID)
 	if err != nil {

--- a/apps/backend/internal/agent/settings/controller/profile_crud.go
+++ b/apps/backend/internal/agent/settings/controller/profile_crud.go
@@ -249,6 +249,13 @@ func (c *Controller) DeleteProfile(ctx context.Context, id string, force bool) (
 // safety net for profiles deleted by other paths, e.g. reconciler cleanup of
 // disabled agent types).
 func (c *Controller) prepareProfileDeletion(ctx context.Context, profileID string, force bool) error {
+	routingTierRefs, err := c.listRoutingTierReferences(ctx, profileID)
+	if err != nil {
+		return err
+	}
+	if len(routingTierRefs) > 0 {
+		return &ErrProfileInUseDetail{RoutingTiers: routingTierRefs}
+	}
 	if c.sessionChecker == nil {
 		return nil
 	}
@@ -275,6 +282,17 @@ func (c *Controller) prepareProfileDeletion(ctx context.Context, profileID strin
 	// Done after the force check since these don't need user confirmation.
 	c.cleanupEphemeralTasks(ctx, profileID)
 	return nil
+}
+
+func (c *Controller) listRoutingTierReferences(ctx context.Context, profileID string) ([]RoutingTierReference, error) {
+	if c.routingTierDeps == nil {
+		return nil, nil
+	}
+	refs, err := c.routingTierDeps.ListRoutingTierReferencesByAgentProfile(ctx, profileID)
+	if err != nil {
+		return nil, err
+	}
+	return refs, nil
 }
 
 // disableReferencingWatchers stamps the deletion cause onto every watcher

--- a/apps/backend/internal/agent/settings/controller/profile_crud_watcher_deps_test.go
+++ b/apps/backend/internal/agent/settings/controller/profile_crud_watcher_deps_test.go
@@ -40,6 +40,15 @@ type fakeWatcherDependencyChecker struct {
 	disabledCause   string
 }
 
+type fakeRoutingTierDependencyChecker struct {
+	refs []RoutingTierReference
+	err  error
+}
+
+func (f fakeRoutingTierDependencyChecker) ListRoutingTierReferencesByAgentProfile(context.Context, string) ([]RoutingTierReference, error) {
+	return f.refs, f.err
+}
+
 func (f *fakeWatcherDependencyChecker) ListWatchersByAgentProfile(context.Context, string) ([]WatcherReference, error) {
 	return f.refs, f.err
 }
@@ -81,6 +90,33 @@ func TestDeleteProfile_BlocksOnReferencingWatchers(t *testing.T) {
 	}
 	if detail.Watchers[0].Kind != "linear" || detail.Watchers[1].Kind != "github_issue" {
 		t.Errorf("unexpected watcher refs: %+v", detail.Watchers)
+	}
+}
+
+func TestDeleteProfile_BlocksOnRoutingTierReferencesEvenWithForce(t *testing.T) {
+	ctrl := newTestController(map[string]agents.Agent{"test-agent": &testAgent{id: "test-agent", name: "test-agent", enabled: true}})
+	st := newFakeStore()
+	agent := &models.Agent{ID: "agent-1", Name: "test-agent"}
+	st.agents[agent.ID] = agent
+	st.byName[agent.Name] = agent
+	st.profiles[agent.ID] = []*models.AgentProfile{{ID: "prof-1", AgentID: agent.ID, Name: "Kilo Profile"}}
+	ctrl.repo = st
+	ctrl.sessionChecker = &fakeSessionChecker{}
+	ctrl.routingTierDeps = fakeRoutingTierDependencyChecker{refs: []RoutingTierReference{
+		{WorkspaceID: "ws-1", ProviderID: "codex-acp", Tier: "balanced"},
+	}}
+
+	_, err := ctrl.DeleteProfile(context.Background(), "prof-1", true)
+
+	var detail *ErrProfileInUseDetail
+	if !errors.As(err, &detail) {
+		t.Fatalf("expected ErrProfileInUseDetail, got %v", err)
+	}
+	if len(detail.RoutingTiers) != 1 {
+		t.Fatalf("expected 1 routing tier ref, got %+v", detail.RoutingTiers)
+	}
+	if detail.RoutingTiers[0].Tier != "balanced" {
+		t.Errorf("unexpected routing tier ref: %+v", detail.RoutingTiers[0])
 	}
 }
 

--- a/apps/backend/internal/agent/settings/handlers/handlers.go
+++ b/apps/backend/internal/agent/settings/handlers/handlers.go
@@ -474,9 +474,10 @@ func (h *Handlers) httpDeleteProfile(c *gin.Context) {
 		var inUseErr *controller.ErrProfileInUseDetail
 		if errors.As(err, &inUseErr) {
 			c.JSON(http.StatusConflict, gin.H{
-				"error":           "agent profile is used by active session(s) or watcher(s)",
+				"error":           "agent profile is in use",
 				"active_sessions": inUseErr.ActiveSessions,
 				"watchers":        inUseErr.Watchers,
+				"routing_tiers":   inUseErr.RoutingTiers,
 			})
 			return
 		}

--- a/apps/backend/internal/backendapp/main.go
+++ b/apps/backend/internal/backendapp/main.go
@@ -490,6 +490,9 @@ func startAgentInfrastructure(
 		github: services.GitHub,
 		log:    log,
 	})
+	agentSettingsController.SetRoutingTierDependencyChecker(&routingTierDepsAdapter{
+		repo: repos.Office,
+	})
 
 	// Wire GitHub service into orchestrator for PR auto-detection on push
 	if services.GitHub != nil {

--- a/apps/backend/internal/backendapp/orchestrator.go
+++ b/apps/backend/internal/backendapp/orchestrator.go
@@ -25,6 +25,7 @@ import (
 	githubpkg "github.com/kandev/kandev/internal/github"
 	jirapkg "github.com/kandev/kandev/internal/jira"
 	linearpkg "github.com/kandev/kandev/internal/linear"
+	officesqlite "github.com/kandev/kandev/internal/office/repository/sqlite"
 	"github.com/kandev/kandev/internal/orchestrator"
 	"github.com/kandev/kandev/internal/orchestrator/messagequeue"
 	"github.com/kandev/kandev/internal/repoclone"
@@ -467,6 +468,32 @@ func (a *watcherDepsAdapter) DisableWatchersByAgentProfile(ctx context.Context, 
 		disabled = append(disabled, ref)
 	}
 	return disabled, nil
+}
+
+type routingTierDepsAdapter struct {
+	repo *officesqlite.Repository
+}
+
+func (a *routingTierDepsAdapter) ListRoutingTierReferencesByAgentProfile(
+	ctx context.Context,
+	profileID string,
+) ([]agentsettingscontroller.RoutingTierReference, error) {
+	if a == nil || a.repo == nil || profileID == "" {
+		return nil, nil
+	}
+	refs, err := a.repo.ListRoutingTierReferencesByAgentProfile(ctx, profileID)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]agentsettingscontroller.RoutingTierReference, 0, len(refs))
+	for _, ref := range refs {
+		out = append(out, agentsettingscontroller.RoutingTierReference{
+			WorkspaceID: ref.WorkspaceID,
+			ProviderID:  string(ref.ProviderID),
+			Tier:        string(ref.Tier),
+		})
+	}
+	return out, nil
 }
 
 func (a *watcherDepsAdapter) disableByKind(ctx context.Context, kind, watchID, cause string) error {

--- a/apps/backend/internal/office/dashboard/counts_test.go
+++ b/apps/backend/internal/office/dashboard/counts_test.go
@@ -47,7 +47,12 @@ func TestDashboard_TaskSkillRoutineCounts(t *testing.T) {
 
 	// Wire stub skill/routine listers.
 	deps.svc.SetSkillLister(&stubSkillLister{
-		skills: []*models.Skill{{ID: "s1"}, {ID: "s2"}},
+		skills: []*models.Skill{
+			{ID: "s1"},
+			{ID: "s2"},
+			{ID: "system-1", IsSystem: true},
+			nil,
+		},
 	})
 	deps.svc.SetRoutineLister(&stubRoutineLister{
 		routines: []*models.Routine{
@@ -73,7 +78,7 @@ func TestDashboard_TaskSkillRoutineCounts(t *testing.T) {
 		t.Errorf("task_count: got %d, want 3", resp.TaskCount)
 	}
 	if resp.SkillCount != 2 {
-		t.Errorf("skill_count: got %d, want 2", resp.SkillCount)
+		t.Errorf("skill_count: got %d, want 2 user-defined skills", resp.SkillCount)
 	}
 	if resp.RoutineCount != 1 {
 		t.Errorf("routine_count: got %d, want 1 (active only)", resp.RoutineCount)

--- a/apps/backend/internal/office/dashboard/service_agents.go
+++ b/apps/backend/internal/office/dashboard/service_agents.go
@@ -544,7 +544,7 @@ func (s *DashboardService) runSoftQueries(
 			return nil
 		}
 		if skills, sErr := s.skillLister.ListSkills(gctx, wsID); sErr == nil {
-			b.skillCount = len(skills)
+			b.skillCount = countUserSkills(skills)
 		}
 		return nil
 	})
@@ -564,6 +564,17 @@ func (s *DashboardService) runSoftQueries(
 	g.Go(func() error { b.runActivity = s.getRunActivity(gctx, wsID); return nil })
 	g.Go(func() error { b.taskBreakdown = s.getTaskBreakdown(gctx, wsID); return nil })
 	g.Go(func() error { b.recentTasks = s.getRecentTasks(gctx, wsID); return nil })
+}
+
+func countUserSkills(skills []*models.Skill) int {
+	count := 0
+	for _, skill := range skills {
+		if skill == nil || skill.IsSystem {
+			continue
+		}
+		count++
+	}
+	return count
 }
 
 // GetDashboardData returns aggregated dashboard data for a workspace.

--- a/apps/backend/internal/office/onboarding/dto.go
+++ b/apps/backend/internal/office/onboarding/dto.go
@@ -22,13 +22,14 @@ type OnboardingImportFSResponse struct {
 
 // OnboardingCompleteRequest is the request body for POST /onboarding/complete.
 type OnboardingCompleteRequest struct {
-	WorkspaceName      string `json:"workspaceName"`
-	TaskPrefix         string `json:"taskPrefix"`
-	AgentName          string `json:"agentName"`
-	AgentProfileID     string `json:"agentProfileId"`
-	ExecutorPreference string `json:"executorPreference"`
-	TaskTitle          string `json:"taskTitle,omitempty"`
-	TaskDescription    string `json:"taskDescription,omitempty"`
+	WorkspaceName      string         `json:"workspaceName"`
+	TaskPrefix         string         `json:"taskPrefix"`
+	AgentName          string         `json:"agentName"`
+	AgentProfileID     string         `json:"agentProfileId"`
+	TierProfiles       TierProfileIDs `json:"tier_profiles,omitempty"`
+	ExecutorPreference string         `json:"executorPreference"`
+	TaskTitle          string         `json:"taskTitle,omitempty"`
+	TaskDescription    string         `json:"taskDescription,omitempty"`
 	// DefaultTier is the workspace routing default tier captured in the
 	// onboarding wizard. Valid values: "frontier", "balanced", "economy".
 	// Empty or invalid values default to "balanced" (silent — onboarding

--- a/apps/backend/internal/office/onboarding/service.go
+++ b/apps/backend/internal/office/onboarding/service.go
@@ -176,12 +176,21 @@ type CompleteRequest struct {
 	TaskPrefix         string
 	AgentName          string
 	AgentProfileID     string
+	TierProfiles       TierProfileIDs
 	ExecutorPreference string
 	TaskTitle          string
 	TaskDescription    string
 	// DefaultTier is the workspace routing default tier captured by the
 	// onboarding wizard. Empty / unknown values fall back to balanced.
 	DefaultTier string
+}
+
+// TierProfileIDs captures the source profile selected for each workspace
+// routing tier during onboarding.
+type TierProfileIDs struct {
+	Frontier string `json:"frontier,omitempty"`
+	Balanced string `json:"balanced,omitempty"`
+	Economy  string `json:"economy,omitempty"`
 }
 
 // CompleteResult holds the IDs of entities created during onboarding.
@@ -572,6 +581,10 @@ func (s *OnboardingService) seedWorkspaceRouting(
 		return
 	}
 	cfg := buildOnboardingRoutingConfig(tier, agent)
+	if err := s.applyOnboardingTierProfiles(ctx, cfg, req.TierProfiles); err != nil {
+		s.logger.Warn("routing seed: tier profile lookup failed",
+			zap.String("workspace_id", workspaceID), zap.Error(err))
+	}
 	if err := s.repo.UpsertWorkspaceRouting(ctx, workspaceID, cfg); err != nil {
 		s.logger.Warn("routing seed: upsert workspace routing failed",
 			zap.String("workspace_id", workspaceID), zap.Error(err))
@@ -651,6 +664,78 @@ func buildOnboardingRoutingConfig(tier routing.Tier, agent *models.AgentInstance
 		TierMap: tierMap, Mode: agent.Mode,
 	}
 	return cfg
+}
+
+func (s *OnboardingService) applyOnboardingTierProfiles(
+	ctx context.Context,
+	cfg *routing.WorkspaceConfig,
+	tierProfiles TierProfileIDs,
+) error {
+	if cfg == nil || s.sourceProfile == nil {
+		return nil
+	}
+	if err := s.applyOnboardingTierProfile(ctx, cfg, routing.TierFrontier, tierProfiles.Frontier); err != nil {
+		return err
+	}
+	if err := s.applyOnboardingTierProfile(ctx, cfg, routing.TierBalanced, tierProfiles.Balanced); err != nil {
+		return err
+	}
+	return s.applyOnboardingTierProfile(ctx, cfg, routing.TierEconomy, tierProfiles.Economy)
+}
+
+func (s *OnboardingService) applyOnboardingTierProfile(
+	ctx context.Context,
+	cfg *routing.WorkspaceConfig,
+	tier routing.Tier,
+	profileID string,
+) error {
+	if strings.TrimSpace(profileID) == "" {
+		return nil
+	}
+	src, err := s.sourceProfile.GetAgentProfile(ctx, profileID)
+	if err != nil {
+		return fmt.Errorf("look up tier profile %s: %w", profileID, err)
+	}
+	if src.AgentID == "" {
+		return nil
+	}
+	providerID := routing.ProviderID(src.AgentID)
+	if cfg.ProviderProfiles == nil {
+		cfg.ProviderProfiles = map[routing.ProviderID]routing.ProviderProfile{}
+	}
+	profile := cfg.ProviderProfiles[providerID]
+	if profile.Mode == "" {
+		profile.Mode = src.Mode
+	}
+	applyTierProfileSeed(&profile, tier, src.Model, profileID)
+	cfg.ProviderProfiles[providerID] = profile
+	if !providerInOrder(cfg.ProviderOrder, providerID) {
+		cfg.ProviderOrder = append(cfg.ProviderOrder, providerID)
+	}
+	return nil
+}
+
+func applyTierProfileSeed(profile *routing.ProviderProfile, tier routing.Tier, model, profileID string) {
+	switch tier {
+	case routing.TierFrontier:
+		profile.TierMap.Frontier = model
+		profile.TierProfileIDs.Frontier = profileID
+	case routing.TierEconomy:
+		profile.TierMap.Economy = model
+		profile.TierProfileIDs.Economy = profileID
+	default:
+		profile.TierMap.Balanced = model
+		profile.TierProfileIDs.Balanced = profileID
+	}
+}
+
+func providerInOrder(order []routing.ProviderID, providerID routing.ProviderID) bool {
+	for _, existing := range order {
+		if existing == providerID {
+			return true
+		}
+	}
+	return false
 }
 
 // writeAgentInheritMarkers stamps explicit routing.tier_source = inherit

--- a/apps/backend/internal/office/onboarding/service.go
+++ b/apps/backend/internal/office/onboarding/service.go
@@ -2,6 +2,7 @@ package onboarding
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -674,13 +675,11 @@ func (s *OnboardingService) applyOnboardingTierProfiles(
 	if cfg == nil || s.sourceProfile == nil {
 		return nil
 	}
-	if err := s.applyOnboardingTierProfile(ctx, cfg, routing.TierFrontier, tierProfiles.Frontier); err != nil {
-		return err
-	}
-	if err := s.applyOnboardingTierProfile(ctx, cfg, routing.TierBalanced, tierProfiles.Balanced); err != nil {
-		return err
-	}
-	return s.applyOnboardingTierProfile(ctx, cfg, routing.TierEconomy, tierProfiles.Economy)
+	return errors.Join(
+		s.applyOnboardingTierProfile(ctx, cfg, routing.TierFrontier, tierProfiles.Frontier),
+		s.applyOnboardingTierProfile(ctx, cfg, routing.TierBalanced, tierProfiles.Balanced),
+		s.applyOnboardingTierProfile(ctx, cfg, routing.TierEconomy, tierProfiles.Economy),
+	)
 }
 
 func (s *OnboardingService) applyOnboardingTierProfile(

--- a/apps/backend/internal/office/onboarding/service_test.go
+++ b/apps/backend/internal/office/onboarding/service_test.go
@@ -567,6 +567,56 @@ func TestCompleteOnboarding_SeedsWorkspaceRoutingTierProfiles(t *testing.T) {
 	}
 }
 
+func TestCompleteOnboarding_TierProfileLookupFailureKeepsValidSelections(t *testing.T) {
+	svc, _, repo, _ := newTestOnboardingServiceWithRepo(t)
+	svc.sourceProfile = fakeSourceProfileReader{profiles: map[string]*models.AgentInstance{
+		"profile-balanced": {
+			AgentID: "codex-acp",
+			Model:   "gpt-5.5-medium",
+			Mode:    "medium",
+		},
+		"profile-economy": {
+			AgentID: "codex-acp",
+			Model:   "gpt-5.5-low",
+			Mode:    "low",
+		},
+	}}
+	ctx := context.Background()
+
+	result, err := svc.CompleteOnboarding(ctx, CompleteRequest{
+		WorkspaceName:      "partial-tier-profiles",
+		TaskPrefix:         "PTP",
+		AgentName:          "CEO",
+		AgentProfileID:     "profile-balanced",
+		ExecutorPreference: "local_pc",
+		DefaultTier:        "balanced",
+		TierProfiles: TierProfileIDs{
+			Frontier: "missing-frontier",
+			Balanced: "profile-balanced",
+			Economy:  "profile-economy",
+		},
+	})
+	if err != nil {
+		t.Fatalf("complete onboarding: %v", err)
+	}
+
+	cfg, err := repo.GetWorkspaceRouting(ctx, result.WorkspaceID)
+	if err != nil {
+		t.Fatalf("get workspace routing: %v", err)
+	}
+	profile := cfg.ProviderProfiles["codex-acp"]
+	if profile.TierMap.Balanced != "gpt-5.5-medium" {
+		t.Errorf("balanced tier map = %q", profile.TierMap.Balanced)
+	}
+	if profile.TierMap.Economy != "gpt-5.5-low" {
+		t.Errorf("economy tier map = %q", profile.TierMap.Economy)
+	}
+	if profile.TierProfileIDs.Balanced != "profile-balanced" ||
+		profile.TierProfileIDs.Economy != "profile-economy" {
+		t.Errorf("valid tier profile ids were not preserved: %+v", profile.TierProfileIDs)
+	}
+}
+
 func TestCompleteOnboarding_SeedsCEOInheritMarkers(t *testing.T) {
 	_, agent := completeOnboardingForRoutingSeed(t, onboardingRoutingScenario{
 		name: "inherit-markers", inputTier: "balanced",

--- a/apps/backend/internal/office/onboarding/service_test.go
+++ b/apps/backend/internal/office/onboarding/service_test.go
@@ -12,6 +12,7 @@ import (
 	settingsstore "github.com/kandev/kandev/internal/agent/settings/store"
 	"github.com/kandev/kandev/internal/common/logger"
 	"github.com/kandev/kandev/internal/office/configloader"
+	"github.com/kandev/kandev/internal/office/models"
 	"github.com/kandev/kandev/internal/office/repository/sqlite"
 	"github.com/kandev/kandev/internal/office/routing"
 )
@@ -93,6 +94,18 @@ func newMockWorkflowEnsurer() *mockWorkflowEnsurer {
 		officeID:  "wf-office",
 		defaultID: "wf-office",
 	}
+}
+
+type fakeSourceProfileReader struct {
+	profiles map[string]*models.AgentInstance
+}
+
+func (f fakeSourceProfileReader) GetAgentProfile(_ context.Context, id string) (*models.AgentInstance, error) {
+	profile := f.profiles[id]
+	if profile == nil {
+		return nil, os.ErrNotExist
+	}
+	return profile, nil
 }
 
 // newTestOnboardingServiceWithRepo is like newTestOnboardingService but
@@ -490,6 +503,67 @@ func TestCompleteOnboarding_SeedsWorkspaceRoutingTier(t *testing.T) {
 				t.Errorf("default tier = %q, want %q", cfg.DefaultTier, sc.wantTier)
 			}
 		})
+	}
+}
+
+func TestCompleteOnboarding_SeedsWorkspaceRoutingTierProfiles(t *testing.T) {
+	svc, _, repo, _ := newTestOnboardingServiceWithRepo(t)
+	svc.sourceProfile = fakeSourceProfileReader{profiles: map[string]*models.AgentInstance{
+		"profile-frontier": {
+			AgentID: "codex-acp",
+			Model:   "gpt-5.5-high",
+			Mode:    "max",
+		},
+		"profile-balanced": {
+			AgentID: "codex-acp",
+			Model:   "gpt-5.5-medium",
+			Mode:    "medium",
+		},
+		"profile-economy": {
+			AgentID: "codex-acp",
+			Model:   "gpt-5.5-low",
+			Mode:    "low",
+		},
+	}}
+	ctx := context.Background()
+
+	result, err := svc.CompleteOnboarding(ctx, CompleteRequest{
+		WorkspaceName:      "tier-profiles",
+		TaskPrefix:         "TP",
+		AgentName:          "CEO",
+		AgentProfileID:     "profile-balanced",
+		ExecutorPreference: "local_pc",
+		DefaultTier:        "balanced",
+		TierProfiles: TierProfileIDs{
+			Frontier: "profile-frontier",
+			Balanced: "profile-balanced",
+			Economy:  "profile-economy",
+		},
+	})
+	if err != nil {
+		t.Fatalf("complete onboarding: %v", err)
+	}
+
+	cfg, err := repo.GetWorkspaceRouting(ctx, result.WorkspaceID)
+	if err != nil {
+		t.Fatalf("get workspace routing: %v", err)
+	}
+	profile := cfg.ProviderProfiles["codex-acp"]
+	if profile.TierMap.Frontier != "gpt-5.5-high" {
+		t.Errorf("frontier tier map = %q", profile.TierMap.Frontier)
+	}
+	if profile.TierMap.Balanced != "gpt-5.5-medium" {
+		t.Errorf("balanced tier map = %q", profile.TierMap.Balanced)
+	}
+	if profile.TierMap.Economy != "gpt-5.5-low" {
+		t.Errorf("economy tier map = %q", profile.TierMap.Economy)
+	}
+	if profile.TierProfileIDs != (routing.TierProfileIDs{
+		Frontier: "profile-frontier",
+		Balanced: "profile-balanced",
+		Economy:  "profile-economy",
+	}) {
+		t.Errorf("tier profile ids = %+v", profile.TierProfileIDs)
 	}
 }
 

--- a/apps/backend/internal/office/repository/sqlite/workspace_routing.go
+++ b/apps/backend/internal/office/repository/sqlite/workspace_routing.go
@@ -136,7 +136,7 @@ func (r *Repository) ListRoutingTierReferencesByAgentProfile(
 		return nil, nil
 	}
 	rows, err := r.ro.QueryxContext(ctx, r.ro.Rebind(`
-		SELECT workspace_id, provider_profiles
+		SELECT workspace_id, provider_order, provider_profiles
 		FROM office_workspace_routing
 		WHERE provider_profiles LIKE ?
 	`), "%"+profileID+"%")
@@ -149,15 +149,23 @@ func (r *Repository) ListRoutingTierReferencesByAgentProfile(
 
 	var refs []RoutingTierProfileReference
 	for rows.Next() {
-		var workspaceID, profsRaw string
-		if err := rows.Scan(&workspaceID, &profsRaw); err != nil {
+		var workspaceID, orderRaw, profsRaw string
+		if err := rows.Scan(&workspaceID, &orderRaw, &profsRaw); err != nil {
 			return nil, fmt.Errorf("routing: scan tier profile refs: %w", err)
+		}
+		var order []routing.ProviderID
+		if err := json.Unmarshal([]byte(orderRaw), &order); err != nil {
+			return nil, fmt.Errorf("routing: decode tier profile order refs: %w", err)
 		}
 		profiles := map[routing.ProviderID]routing.ProviderProfile{}
 		if err := json.Unmarshal([]byte(profsRaw), &profiles); err != nil {
 			return nil, fmt.Errorf("routing: decode tier profile refs: %w", err)
 		}
-		for providerID, profile := range profiles {
+		for _, providerID := range order {
+			profile, ok := profiles[providerID]
+			if !ok {
+				continue
+			}
 			refs = appendTierProfileReference(refs, workspaceID, providerID, routing.TierFrontier, profile.TierProfileIDs.Frontier, profileID)
 			refs = appendTierProfileReference(refs, workspaceID, providerID, routing.TierBalanced, profile.TierProfileIDs.Balanced, profileID)
 			refs = appendTierProfileReference(refs, workspaceID, providerID, routing.TierEconomy, profile.TierProfileIDs.Economy, profileID)

--- a/apps/backend/internal/office/repository/sqlite/workspace_routing.go
+++ b/apps/backend/internal/office/repository/sqlite/workspace_routing.go
@@ -11,6 +11,14 @@ import (
 	"github.com/kandev/kandev/internal/office/routing"
 )
 
+// RoutingTierProfileReference identifies one workspace routing tier that was
+// authored from a source agent profile.
+type RoutingTierProfileReference struct {
+	WorkspaceID string
+	ProviderID  routing.ProviderID
+	Tier        routing.Tier
+}
+
 // GetWorkspaceRouting returns the workspace's routing config. When no
 // row exists yet, the returned config carries the spec defaults:
 // Enabled=false, DefaultTier=balanced, empty order and profile map.
@@ -116,6 +124,67 @@ func defaultWorkspaceRouting() *routing.WorkspaceConfig {
 		ProviderProfiles: map[routing.ProviderID]routing.ProviderProfile{},
 		TierPerReason:    routing.TierPerReason{},
 	}
+}
+
+// ListRoutingTierReferencesByAgentProfile returns every workspace tier mapping
+// that records profileID as its source. Used by profile deletion to avoid
+// orphaning a tier/profile association.
+func (r *Repository) ListRoutingTierReferencesByAgentProfile(
+	ctx context.Context, profileID string,
+) ([]RoutingTierProfileReference, error) {
+	if profileID == "" {
+		return nil, nil
+	}
+	rows, err := r.ro.QueryxContext(ctx, r.ro.Rebind(`
+		SELECT workspace_id, provider_profiles
+		FROM office_workspace_routing
+		WHERE provider_profiles LIKE ?
+	`), "%"+profileID+"%")
+	if err != nil {
+		return nil, fmt.Errorf("routing: list tier profile refs: %w", err)
+	}
+	defer func() {
+		_ = rows.Close()
+	}()
+
+	var refs []RoutingTierProfileReference
+	for rows.Next() {
+		var workspaceID, profsRaw string
+		if err := rows.Scan(&workspaceID, &profsRaw); err != nil {
+			return nil, fmt.Errorf("routing: scan tier profile refs: %w", err)
+		}
+		profiles := map[routing.ProviderID]routing.ProviderProfile{}
+		if err := json.Unmarshal([]byte(profsRaw), &profiles); err != nil {
+			return nil, fmt.Errorf("routing: decode tier profile refs: %w", err)
+		}
+		for providerID, profile := range profiles {
+			refs = appendTierProfileReference(refs, workspaceID, providerID, routing.TierFrontier, profile.TierProfileIDs.Frontier, profileID)
+			refs = appendTierProfileReference(refs, workspaceID, providerID, routing.TierBalanced, profile.TierProfileIDs.Balanced, profileID)
+			refs = appendTierProfileReference(refs, workspaceID, providerID, routing.TierEconomy, profile.TierProfileIDs.Economy, profileID)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("routing: iterate tier profile refs: %w", err)
+	}
+	return refs, nil
+}
+
+func appendTierProfileReference(
+	refs []RoutingTierProfileReference,
+	workspaceID string,
+	providerID routing.ProviderID,
+	tier routing.Tier,
+	gotProfileID string,
+	wantProfileID string,
+) []RoutingTierProfileReference {
+	if gotProfileID != wantProfileID {
+		return refs
+	}
+	return append(refs, RoutingTierProfileReference{
+		WorkspaceID: workspaceID,
+		ProviderID:  providerID,
+		Tier:        tier,
+	})
 }
 
 // marshalTierPerReason marshals the wake-reason tier policy, normalising

--- a/apps/backend/internal/office/repository/sqlite/workspace_routing_test.go
+++ b/apps/backend/internal/office/repository/sqlite/workspace_routing_test.go
@@ -133,6 +133,35 @@ func TestListRoutingTierReferencesByAgentProfile(t *testing.T) {
 	}
 }
 
+func TestListRoutingTierReferencesByAgentProfile_IgnoresRemovedProviders(t *testing.T) {
+	repo := newTestRepo(t)
+	ctx := context.Background()
+	cfg := &routing.WorkspaceConfig{
+		Enabled:       false,
+		DefaultTier:   routing.TierBalanced,
+		ProviderOrder: []routing.ProviderID{"codex-acp"},
+		ProviderProfiles: map[routing.ProviderID]routing.ProviderProfile{
+			"codex-acp": {
+				TierProfileIDs: routing.TierProfileIDs{Balanced: "active-profile"},
+			},
+			"claude-acp": {
+				TierProfileIDs: routing.TierProfileIDs{Balanced: "removed-profile"},
+			},
+		},
+	}
+	if err := repo.UpsertWorkspaceRouting(ctx, "ws-1", cfg); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	refs, err := repo.ListRoutingTierReferencesByAgentProfile(ctx, "removed-profile")
+	if err != nil {
+		t.Fatalf("list removed provider refs: %v", err)
+	}
+	if len(refs) != 0 {
+		t.Fatalf("removed provider should not block profile deletion: %+v", refs)
+	}
+}
+
 func TestUpsertWorkspaceRouting_Idempotent(t *testing.T) {
 	repo := newTestRepo(t)
 	ctx := context.Background()

--- a/apps/backend/internal/office/repository/sqlite/workspace_routing_test.go
+++ b/apps/backend/internal/office/repository/sqlite/workspace_routing_test.go
@@ -42,10 +42,11 @@ func TestUpsertAndGetWorkspaceRouting_RoundTrip(t *testing.T) {
 		ProviderOrder: []routing.ProviderID{"claude-acp", "codex-acp"},
 		ProviderProfiles: map[routing.ProviderID]routing.ProviderProfile{
 			"claude-acp": {
-				TierMap: routing.TierMap{Frontier: "opus", Balanced: "sonnet"},
-				Mode:    "default",
-				Flags:   []string{"--quiet"},
-				Env:     map[string]string{"FOO": "bar"},
+				TierMap:        routing.TierMap{Frontier: "opus", Balanced: "sonnet"},
+				TierProfileIDs: routing.TierProfileIDs{Frontier: "profile-frontier", Balanced: "profile-balanced"},
+				Mode:           "default",
+				Flags:          []string{"--quiet"},
+				Env:            map[string]string{"FOO": "bar"},
 			},
 			"codex-acp": {
 				TierMap: routing.TierMap{Balanced: "gpt-5.4"},
@@ -80,6 +81,55 @@ func TestUpsertAndGetWorkspaceRouting_RoundTrip(t *testing.T) {
 	}
 	if len(claude.Flags) != 1 || claude.Flags[0] != "--quiet" {
 		t.Errorf("claude flags = %v", claude.Flags)
+	}
+	if claude.TierProfileIDs.Frontier != "profile-frontier" {
+		t.Errorf("claude tier profile ids lost: %+v", claude.TierProfileIDs)
+	}
+}
+
+func TestListRoutingTierReferencesByAgentProfile(t *testing.T) {
+	repo := newTestRepo(t)
+	ctx := context.Background()
+	cfg := &routing.WorkspaceConfig{
+		Enabled:       false,
+		DefaultTier:   routing.TierBalanced,
+		ProviderOrder: []routing.ProviderID{"codex-acp"},
+		ProviderProfiles: map[routing.ProviderID]routing.ProviderProfile{
+			"codex-acp": {
+				TierMap: routing.TierMap{
+					Frontier: "gpt-5-high",
+					Balanced: "gpt-5-medium",
+					Economy:  "gpt-5-low",
+				},
+				TierProfileIDs: routing.TierProfileIDs{
+					Frontier: "profile-frontier",
+					Balanced: "profile-balanced",
+					Economy:  "profile-economy",
+				},
+			},
+		},
+	}
+	if err := repo.UpsertWorkspaceRouting(ctx, "ws-1", cfg); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	refs, err := repo.ListRoutingTierReferencesByAgentProfile(ctx, "profile-balanced")
+	if err != nil {
+		t.Fatalf("list refs: %v", err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("refs len = %d, want 1: %+v", len(refs), refs)
+	}
+	if refs[0].WorkspaceID != "ws-1" || refs[0].ProviderID != "codex-acp" || refs[0].Tier != routing.TierBalanced {
+		t.Errorf("unexpected ref: %+v", refs[0])
+	}
+
+	refs, err = repo.ListRoutingTierReferencesByAgentProfile(ctx, "profile")
+	if err != nil {
+		t.Fatalf("list substring refs: %v", err)
+	}
+	if len(refs) != 0 {
+		t.Fatalf("substring profile id matched exact refs: %+v", refs)
 	}
 }
 

--- a/apps/backend/internal/office/routing/provider.go
+++ b/apps/backend/internal/office/routing/provider.go
@@ -197,7 +197,7 @@ func providerProfilesEqual(a, b map[ProviderID]ProviderProfile) bool {
 }
 
 func providerProfileEqual(a, b ProviderProfile) bool {
-	if a.TierMap != b.TierMap || a.Mode != b.Mode {
+	if a.TierMap != b.TierMap || a.TierProfileIDs != b.TierProfileIDs || a.Mode != b.Mode {
 		return false
 	}
 	if !stringSliceEqual(a.Flags, b.Flags) {

--- a/apps/backend/internal/office/routing/types.go
+++ b/apps/backend/internal/office/routing/types.go
@@ -108,10 +108,20 @@ func (m TierMap) IsConfigured(t Tier) bool { return m.Model(t) != "" }
 // per-provider permission override would require modelling the existing
 // boolean/CLIFlag system as named presets first — out of scope here.
 type ProviderProfile struct {
-	TierMap TierMap           `json:"tier_map"`
-	Mode    string            `json:"mode,omitempty"`
-	Flags   []string          `json:"flags,omitempty"`
-	Env     map[string]string `json:"env,omitempty"`
+	TierMap        TierMap           `json:"tier_map"`
+	TierProfileIDs TierProfileIDs    `json:"tier_profile_ids,omitempty"`
+	Mode           string            `json:"mode,omitempty"`
+	Flags          []string          `json:"flags,omitempty"`
+	Env            map[string]string `json:"env,omitempty"`
+}
+
+// TierProfileIDs records which source agent profile authored each tier map
+// entry. Runtime routing uses TierMap; this metadata lets settings block
+// deleting a profile while a workspace tier still points at it.
+type TierProfileIDs struct {
+	Frontier string `json:"frontier,omitempty"`
+	Balanced string `json:"balanced,omitempty"`
+	Economy  string `json:"economy,omitempty"`
 }
 
 // WorkspaceConfig is the persisted routing config for one workspace.

--- a/apps/backend/internal/office/routing/types.go
+++ b/apps/backend/internal/office/routing/types.go
@@ -8,6 +8,7 @@
 package routing
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -115,6 +116,29 @@ type ProviderProfile struct {
 	Env            map[string]string `json:"env,omitempty"`
 }
 
+// MarshalJSON omits tier_profile_ids unless at least one tier records its
+// source profile. A value struct with omitempty would otherwise serialize as
+// an empty object.
+func (p ProviderProfile) MarshalJSON() ([]byte, error) {
+	type providerProfileJSON struct {
+		TierMap        TierMap           `json:"tier_map"`
+		TierProfileIDs *TierProfileIDs   `json:"tier_profile_ids,omitempty"`
+		Mode           string            `json:"mode,omitempty"`
+		Flags          []string          `json:"flags,omitempty"`
+		Env            map[string]string `json:"env,omitempty"`
+	}
+	out := providerProfileJSON{
+		TierMap: p.TierMap,
+		Mode:    p.Mode,
+		Flags:   p.Flags,
+		Env:     p.Env,
+	}
+	if !p.TierProfileIDs.IsZero() {
+		out.TierProfileIDs = &p.TierProfileIDs
+	}
+	return json.Marshal(out)
+}
+
 // TierProfileIDs records which source agent profile authored each tier map
 // entry. Runtime routing uses TierMap; this metadata lets settings block
 // deleting a profile while a workspace tier still points at it.
@@ -122,6 +146,11 @@ type TierProfileIDs struct {
 	Frontier string `json:"frontier,omitempty"`
 	Balanced string `json:"balanced,omitempty"`
 	Economy  string `json:"economy,omitempty"`
+}
+
+// IsZero reports whether no tier has source profile metadata.
+func (ids TierProfileIDs) IsZero() bool {
+	return ids.Frontier == "" && ids.Balanced == "" && ids.Economy == ""
 }
 
 // WorkspaceConfig is the persisted routing config for one workspace.

--- a/apps/backend/internal/office/routing/types_test.go
+++ b/apps/backend/internal/office/routing/types_test.go
@@ -1,6 +1,7 @@
 package routing_test
 
 import (
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -10,6 +11,31 @@ import (
 
 var testKnown = []routing.ProviderID{
 	"claude-acp", "codex-acp", "opencode-acp", "copilot-acp", "amp-acp",
+}
+
+func TestProviderProfileMarshalJSON_OmitsEmptyTierProfileIDs(t *testing.T) {
+	raw, err := json.Marshal(routing.ProviderProfile{
+		TierMap: routing.TierMap{Balanced: "sonnet"},
+	})
+	if err != nil {
+		t.Fatalf("marshal empty tier profile ids: %v", err)
+	}
+	if strings.Contains(string(raw), "tier_profile_ids") {
+		t.Fatalf("empty tier_profile_ids should be omitted, got %s", raw)
+	}
+
+	raw, err = json.Marshal(routing.ProviderProfile{
+		TierMap: routing.TierMap{Balanced: "sonnet"},
+		TierProfileIDs: routing.TierProfileIDs{
+			Balanced: "profile-balanced",
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal tier profile ids: %v", err)
+	}
+	if !strings.Contains(string(raw), `"tier_profile_ids":{"balanced":"profile-balanced"}`) {
+		t.Fatalf("non-empty tier_profile_ids should be present, got %s", raw)
+	}
 }
 
 func TestValidateWorkspaceConfig(t *testing.T) {

--- a/apps/web/app/actions/agents.ts
+++ b/apps/web/app/actions/agents.ts
@@ -144,7 +144,11 @@ export async function updateAgentProfileAction(
   return normalizeAgentProfile(raw);
 }
 
-import type { ActiveSessionInfo, WatcherReference } from "@/lib/types/agent-profile-errors";
+import type {
+  ActiveSessionInfo,
+  RoutingTierReference,
+  WatcherReference,
+} from "@/lib/types/agent-profile-errors";
 
 export type DeleteProfileResult =
   | { status: "ok" }
@@ -152,6 +156,7 @@ export type DeleteProfileResult =
       status: "conflict";
       activeSessions: ActiveSessionInfo[];
       watchers: WatcherReference[];
+      routingTiers: RoutingTierReference[];
     }
   | { status: "error"; message: string };
 
@@ -167,14 +172,15 @@ export async function deleteAgentProfileAction(
   });
   if (!response.ok) {
     const body = await response.json().catch(() => ({}));
-    // A 409 is either active-sessions, referencing watchers, or both.
+    // A 409 is active sessions, referencing watchers, routing tier mappings, or a mix.
     // Treat any non-empty list as the conflict signal — a watcher-only
     // conflict (the new self-heal path) must still pop the dialog.
-    if (response.status === 409 && (body.active_sessions || body.watchers)) {
+    if (response.status === 409 && (body.active_sessions || body.watchers || body.routing_tiers)) {
       return {
         status: "conflict",
         activeSessions: body.active_sessions ?? [],
         watchers: body.watchers ?? [],
+        routingTiers: body.routing_tiers ?? [],
       };
     }
     return {

--- a/apps/web/app/office/setup/agent-profile-setup-controls.tsx
+++ b/apps/web/app/office/setup/agent-profile-setup-controls.tsx
@@ -3,6 +3,7 @@
 import { useMemo } from "react";
 import { Button } from "@kandev/ui/button";
 import { CliProfileEditor } from "@/components/agent/cli-profile-editor";
+import { useAppStoreApi } from "@/components/state-provider";
 import { getCapabilityWarning } from "@/lib/capability-warning";
 import type { AgentProfileOption } from "@/lib/state/slices/settings/types";
 import { toAgentProfileOption } from "@/lib/state/slices/settings/types";
@@ -36,6 +37,13 @@ export function sortProfiles(profiles: AgentProfileOption[]): AgentProfileOption
   });
 }
 
+function upsertProfileOption(
+  profiles: AgentProfileOption[],
+  option: AgentProfileOption,
+): AgentProfileOption[] {
+  return [...profiles.filter((p) => p.id !== option.id), option];
+}
+
 export function useSelectableProfileOptions(agentProfiles: AgentProfileOption[]) {
   const sortedProfiles = useMemo(() => sortProfiles(agentProfiles), [agentProfiles]);
   const baseOptions = useAgentProfileOptions(sortedProfiles);
@@ -57,7 +65,6 @@ export function useSelectableProfileOptions(agentProfiles: AgentProfileOption[])
 
 export function CreateProfilePanel({
   settingsAgents,
-  storeProfiles,
   wizardProfiles,
   canCancel,
   setAgentProfiles,
@@ -66,7 +73,6 @@ export function CreateProfilePanel({
   onClose,
 }: {
   settingsAgents: { id: string; name: string }[];
-  storeProfiles: AgentProfileOption[];
   wizardProfiles: AgentProfileOption[];
   canCancel: boolean;
   setAgentProfiles: (profiles: AgentProfileOption[]) => void;
@@ -74,6 +80,7 @@ export function CreateProfilePanel({
   onProfileSaved: (profileId: string) => void;
   onClose: () => void;
 }) {
+  const store = useAppStoreApi();
   return (
     <div className="mt-2 rounded-md border bg-muted/30 p-3">
       <CliProfileEditor
@@ -87,8 +94,12 @@ export function CreateProfilePanel({
             name: saved.agentId ?? "",
           };
           const option = toAgentProfileOption(agentForProfile, saved);
-          setAgentProfiles([...storeProfiles.filter((p) => p.id !== option.id), option]);
-          onAgentProfilesChange?.([...wizardProfiles.filter((p) => p.id !== option.id), option]);
+          const nextStoreProfiles = upsertProfileOption(
+            store.getState().agentProfiles.items,
+            option,
+          );
+          setAgentProfiles(nextStoreProfiles);
+          onAgentProfilesChange?.(upsertProfileOption(wizardProfiles, option));
           onProfileSaved(saved.id);
           onClose();
         }}

--- a/apps/web/app/office/setup/agent-profile-setup-controls.tsx
+++ b/apps/web/app/office/setup/agent-profile-setup-controls.tsx
@@ -94,11 +94,7 @@ export function CreateProfilePanel({
             name: saved.agentId ?? "",
           };
           const option = toAgentProfileOption(agentForProfile, saved);
-          const nextStoreProfiles = upsertProfileOption(
-            store.getState().agentProfiles.items,
-            option,
-          );
-          setAgentProfiles(nextStoreProfiles);
+          setAgentProfiles(upsertProfileOption(store.getState().agentProfiles.items, option));
           onAgentProfilesChange?.(upsertProfileOption(wizardProfiles, option));
           onProfileSaved(saved.id);
           onClose();

--- a/apps/web/app/office/setup/agent-profile-setup-controls.tsx
+++ b/apps/web/app/office/setup/agent-profile-setup-controls.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useMemo } from "react";
+import { Button } from "@kandev/ui/button";
+import { CliProfileEditor } from "@/components/agent/cli-profile-editor";
+import { getCapabilityWarning } from "@/lib/capability-warning";
+import type { AgentProfileOption } from "@/lib/state/slices/settings/types";
+import { toAgentProfileOption } from "@/lib/state/slices/settings/types";
+import type { Tier } from "@/lib/state/slices/office/types";
+import { useAgentProfileOptions } from "@/components/task-create-dialog-options";
+
+export type ProfileSetupChange = {
+  agentProfileId?: string;
+  tierProfileIds?: Partial<Record<Tier, string>>;
+};
+
+export function fillMissingTierProfileIds(
+  current: Partial<Record<Tier, string>>,
+  profileId: string,
+): Partial<Record<Tier, string>> {
+  return {
+    frontier: current.frontier || profileId,
+    balanced: current.balanced || profileId,
+    economy: current.economy || profileId,
+  };
+}
+
+export function sortProfiles(profiles: AgentProfileOption[]): AgentProfileOption[] {
+  return [...profiles].sort((a, b) => {
+    const aDisabled =
+      a.cli_passthrough || !!getCapabilityWarning(a.capability_status, a.capability_error);
+    const bDisabled =
+      b.cli_passthrough || !!getCapabilityWarning(b.capability_status, b.capability_error);
+    if (aDisabled === bDisabled) return 0;
+    return aDisabled ? 1 : -1;
+  });
+}
+
+export function useSelectableProfileOptions(agentProfiles: AgentProfileOption[]) {
+  const sortedProfiles = useMemo(() => sortProfiles(agentProfiles), [agentProfiles]);
+  const baseOptions = useAgentProfileOptions(sortedProfiles);
+  const profileOptions = useMemo(
+    () =>
+      baseOptions.map((opt, i) => ({
+        ...opt,
+        disabled:
+          sortedProfiles[i]?.cli_passthrough ||
+          !!getCapabilityWarning(
+            sortedProfiles[i]?.capability_status,
+            sortedProfiles[i]?.capability_error,
+          ),
+      })),
+    [baseOptions, sortedProfiles],
+  );
+  return { sortedProfiles, profileOptions };
+}
+
+export function CreateProfilePanel({
+  settingsAgents,
+  storeProfiles,
+  wizardProfiles,
+  canCancel,
+  setAgentProfiles,
+  onAgentProfilesChange,
+  onProfileSaved,
+  onClose,
+}: {
+  settingsAgents: { id: string; name: string }[];
+  storeProfiles: AgentProfileOption[];
+  wizardProfiles: AgentProfileOption[];
+  canCancel: boolean;
+  setAgentProfiles: (profiles: AgentProfileOption[]) => void;
+  onAgentProfilesChange?: (profiles: AgentProfileOption[]) => void;
+  onProfileSaved: (profileId: string) => void;
+  onClose: () => void;
+}) {
+  return (
+    <div className="mt-2 rounded-md border bg-muted/30 p-3">
+      <CliProfileEditor
+        mode="create"
+        defaultProfileName="default"
+        showAdvanced
+        allowCliPassthrough={false}
+        onSaved={(saved) => {
+          const agentForProfile = settingsAgents.find((a) => a.id === saved.agentId) ?? {
+            id: saved.agentId ?? "",
+            name: saved.agentId ?? "",
+          };
+          const option = toAgentProfileOption(agentForProfile, saved);
+          setAgentProfiles([...storeProfiles.filter((p) => p.id !== option.id), option]);
+          onAgentProfilesChange?.([...wizardProfiles.filter((p) => p.id !== option.id), option]);
+          onProfileSaved(saved.id);
+          onClose();
+        }}
+        onCancel={canCancel ? onClose : undefined}
+      />
+    </div>
+  );
+}
+
+export function CreateProfileButton({
+  hasProfiles,
+  onCreateClick,
+}: {
+  hasProfiles: boolean;
+  onCreateClick: () => void;
+}) {
+  return (
+    <Button
+      type="button"
+      variant="link"
+      onClick={onCreateClick}
+      className="h-auto p-0 cursor-pointer text-primary"
+    >
+      {hasProfiles ? "+ Create a new CLI profile" : "Create one inline"}
+    </Button>
+  );
+}

--- a/apps/web/app/office/setup/setup-task-defaults.ts
+++ b/apps/web/app/office/setup/setup-task-defaults.ts
@@ -1,0 +1,11 @@
+export const DEFAULT_ONBOARDING_TASK_TITLE = "Setup Workspace";
+
+export const DEFAULT_ONBOARDING_TASK_DESCRIPTION = `Investigate the project in https://github.com/org/repo. Replace this URL with each repository that should be managed in this workspace.
+
+As the CEO agent:
+- Inspect the repository or repositories and summarize the product, architecture, tech stack, and current risks.
+- Create one project per repository, linking each project to its repository and capturing the main goals.
+- Create the agent team needed to own the work, such as engineering lead, frontend, backend, QA, DevOps, product/research, or documentation agents as appropriate.
+- Assign agents to the right projects and give them clear responsibilities, permissions, and initial work items.
+- Create the first backlog of tasks and subtasks needed to make this workspace useful, including repo discovery, setup, build/test verification, and follow-up improvements.
+- Note assumptions, missing access, and questions for the human before making risky changes.`;

--- a/apps/web/app/office/setup/setup-task-defaults.ts
+++ b/apps/web/app/office/setup/setup-task-defaults.ts
@@ -6,6 +6,7 @@ As the CEO agent:
 - Inspect the repository or repositories and summarize the product, architecture, tech stack, and current risks.
 - Create one project per repository, linking each project to its repository and capturing the main goals.
 - Create the agent team needed to own the work, such as engineering lead, frontend, backend, QA, DevOps, product/research, or documentation agents as appropriate.
-- Assign agents to the right projects and give them clear responsibilities, permissions, and initial work items.
-- Create the first backlog of tasks and subtasks needed to make this workspace useful, including repo discovery, setup, build/test verification, and follow-up improvements.
-- Note assumptions, missing access, and questions for the human before making risky changes.`;
+- Give each agent clear responsibilities, permissions, and operating guidance.
+- Draft a proposed plan for the next setup steps, including repo discovery, build/test verification, initial improvements, and which tasks or subtasks should be created.
+- Wait for the human to approve the proposed plan before creating follow-up tasks or making risky changes.
+- Note assumptions, missing access, and questions for the human.`;

--- a/apps/web/app/office/setup/setup-wizard-steps.ts
+++ b/apps/web/app/office/setup/setup-wizard-steps.ts
@@ -1,0 +1,9 @@
+export const SETUP_WIZARD_STEPS = {
+  WORKSPACE: 0,
+  TIER_PROFILES: 1,
+  AGENT: 2,
+  TASK: 3,
+  REVIEW: 4,
+} as const;
+
+export const SETUP_WIZARD_STEP_COUNT = Object.keys(SETUP_WIZARD_STEPS).length;

--- a/apps/web/app/office/setup/setup-wizard.test.ts
+++ b/apps/web/app/office/setup/setup-wizard.test.ts
@@ -58,6 +58,11 @@ describe("submitOnboarding", () => {
     expect(data.taskDescription).toContain("https://github.com/org/repo");
     expect(data.taskDescription).toContain("Create one project per repository");
     expect(data.taskDescription).toContain("Create the agent team");
+    expect(data.taskDescription).toContain("proposed plan");
+    expect(data.taskDescription).toContain("Wait for the human to approve");
+    expect(data.taskDescription).not.toContain("Assign agents to the right projects");
+    expect(data.taskDescription).not.toContain("Create the first backlog");
+    expect(data.defaultTier).toBe("frontier");
     expect(data.tierProfileIds).toEqual({
       frontier: "profile-1",
       balanced: "profile-1",

--- a/apps/web/app/office/setup/setup-wizard.test.ts
+++ b/apps/web/app/office/setup/setup-wizard.test.ts
@@ -11,7 +11,12 @@ vi.mock("@/lib/api/domains/settings-api", () => ({
 
 import { completeOnboarding } from "@/lib/api/domains/office-api";
 import { updateUserSettings } from "@/lib/api/domains/settings-api";
-import { submitOnboarding } from "./setup-wizard";
+import {
+  DEFAULT_ONBOARDING_TASK_DESCRIPTION,
+  DEFAULT_ONBOARDING_TASK_TITLE,
+  getInitialData,
+  submitOnboarding,
+} from "./setup-wizard";
 
 const mockCompleteOnboarding = vi.mocked(completeOnboarding);
 const mockUpdateUserSettings = vi.mocked(updateUserSettings);
@@ -24,6 +29,11 @@ const BASE_WIZARD_DATA = {
   taskPrefix: "MY",
   agentName: "CEO",
   agentProfileId: "profile-1",
+  tierProfileIds: {
+    frontier: "profile-frontier",
+    balanced: "profile-balanced",
+    economy: "profile-economy",
+  },
   executorPreference: "local_pc",
   taskTitle: "",
   taskDescription: "",
@@ -40,12 +50,34 @@ beforeEach(() => {
 });
 
 describe("submitOnboarding", () => {
+  it("starts new workspaces with a CEO setup task brief", () => {
+    const data = getInitialData(WORKSPACE_NAME, "profile-1");
+
+    expect(data.taskTitle).toBe(DEFAULT_ONBOARDING_TASK_TITLE);
+    expect(data.taskDescription).toBe(DEFAULT_ONBOARDING_TASK_DESCRIPTION);
+    expect(data.taskDescription).toContain("https://github.com/org/repo");
+    expect(data.taskDescription).toContain("Create one project per repository");
+    expect(data.taskDescription).toContain("Create the agent team");
+    expect(data.tierProfileIds).toEqual({
+      frontier: "profile-1",
+      balanced: "profile-1",
+      economy: "profile-1",
+    });
+  });
+
   it("calls completeOnboarding with the wizard data", async () => {
     await submitOnboarding(BASE_WIZARD_DATA);
 
     expect(mockCompleteOnboarding).toHaveBeenCalledOnce();
     expect(mockCompleteOnboarding).toHaveBeenCalledWith(
-      expect.objectContaining({ workspaceName: WORKSPACE_NAME }),
+      expect.objectContaining({
+        workspaceName: WORKSPACE_NAME,
+        tier_profiles: {
+          frontier: "profile-frontier",
+          balanced: "profile-balanced",
+          economy: "profile-economy",
+        },
+      }),
     );
   });
 

--- a/apps/web/app/office/setup/setup-wizard.tsx
+++ b/apps/web/app/office/setup/setup-wizard.tsx
@@ -20,6 +20,7 @@ import {
   DEFAULT_ONBOARDING_TASK_DESCRIPTION,
   DEFAULT_ONBOARDING_TASK_TITLE,
 } from "./setup-task-defaults";
+import { SETUP_WIZARD_STEP_COUNT, SETUP_WIZARD_STEPS } from "./setup-wizard-steps";
 import type { AgentProfileOption } from "@/lib/state/slices/settings/types";
 import type { Tier } from "@/lib/state/slices/office/types";
 
@@ -80,17 +81,16 @@ export function getInitialData(
   };
 }
 
-const STEP_COUNT = 5;
-
 function computeCanAdvance(step: number, data: WizardData): boolean {
-  if (step === 0) return data.workspaceName.trim() !== "";
-  if (step === 1)
+  if (step === SETUP_WIZARD_STEPS.WORKSPACE) return data.workspaceName.trim() !== "";
+  if (step === SETUP_WIZARD_STEPS.TIER_PROFILES)
     return (
       Boolean(data.tierProfileIds.frontier) &&
       Boolean(data.tierProfileIds.balanced) &&
       Boolean(data.tierProfileIds.economy)
     );
-  if (step === 2) return data.agentName.trim() !== "" && data.agentProfileId !== "";
+  if (step === SETUP_WIZARD_STEPS.AGENT)
+    return data.agentName.trim() !== "" && data.agentProfileId !== "";
   return true;
 }
 
@@ -132,7 +132,7 @@ function WizardStepContent({
   patch: (updates: Partial<WizardData>) => void;
   onAgentProfilesChange: (profiles: AgentProfileOption[]) => void;
 }) {
-  if (step === 0)
+  if (step === SETUP_WIZARD_STEPS.WORKSPACE)
     return (
       <StepWorkspace
         workspaceName={data.workspaceName}
@@ -140,7 +140,7 @@ function WizardStepContent({
         onChange={patch}
       />
     );
-  if (step === 1)
+  if (step === SETUP_WIZARD_STEPS.TIER_PROFILES)
     return (
       <StepTierProfiles
         tierProfileIds={data.tierProfileIds}
@@ -149,7 +149,7 @@ function WizardStepContent({
         onAgentProfilesChange={onAgentProfilesChange}
       />
     );
-  if (step === 2)
+  if (step === SETUP_WIZARD_STEPS.AGENT)
     return (
       <StepAgent
         agentName={data.agentName}
@@ -161,7 +161,7 @@ function WizardStepContent({
         onAgentProfilesChange={onAgentProfilesChange}
       />
     );
-  if (step === 3)
+  if (step === SETUP_WIZARD_STEPS.TASK)
     return (
       <StepTask
         agentName={data.agentName}
@@ -256,7 +256,7 @@ export function SetupWizard({
     <div className="fixed inset-0 z-50 bg-background flex items-center justify-center">
       <div className="relative w-full max-w-2xl mx-auto px-6">
         <CloseButton href={closeHref} />
-        <StepIndicator current={step} total={STEP_COUNT} />
+        <StepIndicator current={step} total={SETUP_WIZARD_STEP_COUNT} />
         <div className="mt-8">
           <WizardStepContent
             step={step}

--- a/apps/web/app/office/setup/setup-wizard.tsx
+++ b/apps/web/app/office/setup/setup-wizard.tsx
@@ -15,8 +15,14 @@ import { StepTask } from "./step-task";
 import { StepReview } from "./step-review";
 import { WizardFooter } from "./wizard-footer";
 import { CloseButton } from "./close-button";
+import {
+  DEFAULT_ONBOARDING_TASK_DESCRIPTION,
+  DEFAULT_ONBOARDING_TASK_TITLE,
+} from "./setup-task-defaults";
 import type { AgentProfileOption } from "@/lib/state/slices/settings/types";
 import type { Tier } from "@/lib/state/slices/office/types";
+
+export { DEFAULT_ONBOARDING_TASK_DESCRIPTION, DEFAULT_ONBOARDING_TASK_TITLE };
 
 type SetupWizardProps = {
   agentProfiles: AgentProfileOption[];
@@ -42,24 +48,33 @@ type WizardData = {
   taskPrefix: string;
   agentName: string;
   agentProfileId: string;
+  tierProfileIds: Partial<Record<Tier, string>>;
   executorPreference: string;
   defaultTier?: Tier;
   taskTitle: string;
   taskDescription: string;
 };
 
-function getInitialData(
+export function getInitialData(
   suggestedWorkspaceName: string,
   defaultAgentProfileId?: string,
 ): WizardData {
+  const initialTierProfileIds = defaultAgentProfileId
+    ? {
+        frontier: defaultAgentProfileId,
+        balanced: defaultAgentProfileId,
+        economy: defaultAgentProfileId,
+      }
+    : {};
   return {
     workspaceName: suggestedWorkspaceName,
     taskPrefix: derivePrefix(suggestedWorkspaceName),
     agentName: "CEO",
     agentProfileId: defaultAgentProfileId ?? "",
+    tierProfileIds: initialTierProfileIds,
     executorPreference: "local_pc",
-    taskTitle: "",
-    taskDescription: "",
+    taskTitle: DEFAULT_ONBOARDING_TASK_TITLE,
+    taskDescription: DEFAULT_ONBOARDING_TASK_DESCRIPTION,
   };
 }
 
@@ -67,7 +82,14 @@ const STEP_COUNT = 4;
 
 function computeCanAdvance(step: number, data: WizardData): boolean {
   if (step === 0) return data.workspaceName.trim() !== "";
-  if (step === 1) return data.agentName.trim() !== "" && data.agentProfileId !== "";
+  if (step === 1)
+    return (
+      data.agentName.trim() !== "" &&
+      data.agentProfileId !== "" &&
+      Boolean(data.tierProfileIds.frontier) &&
+      Boolean(data.tierProfileIds.balanced) &&
+      Boolean(data.tierProfileIds.economy)
+    );
   return true;
 }
 
@@ -83,6 +105,11 @@ export async function submitOnboarding(data: WizardData) {
     taskPrefix: data.taskPrefix.trim() || "KAN",
     agentName: data.agentName.trim() || "CEO",
     agentProfileId: data.agentProfileId,
+    tier_profiles: {
+      frontier: data.tierProfileIds.frontier,
+      balanced: data.tierProfileIds.balanced,
+      economy: data.tierProfileIds.economy,
+    },
     executorPreference: data.executorPreference || "local_pc",
     taskTitle: data.taskTitle.trim() || undefined,
     taskDescription: data.taskDescription.trim() || undefined,
@@ -117,6 +144,7 @@ function WizardStepContent({
       <StepAgent
         agentName={data.agentName}
         agentProfileId={data.agentProfileId}
+        tierProfileIds={data.tierProfileIds}
         executorPreference={data.executorPreference}
         defaultTier={data.defaultTier}
         agentProfiles={agentProfiles}
@@ -167,6 +195,10 @@ export function SetupWizard({
     (updates: Partial<WizardData>) => setData((prev) => ({ ...prev, ...updates })),
     [],
   );
+  const skipInitialTask = useCallback(() => {
+    patch({ taskTitle: "", taskDescription: "" });
+    setStep((s) => s + 1);
+  }, [patch]);
   const canAdvance = computeCanAdvance(step, data);
 
   const handleSubmit = useCallback(async () => {
@@ -231,7 +263,7 @@ export function SetupWizard({
           submitting={submitting}
           onBack={() => setStep((s) => s - 1)}
           onNext={() => setStep((s) => s + 1)}
-          onSkip={() => setStep((s) => s + 1)}
+          onSkip={skipInitialTask}
           onSubmit={handleSubmit}
         />
       </div>

--- a/apps/web/app/office/setup/setup-wizard.tsx
+++ b/apps/web/app/office/setup/setup-wizard.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/lib/api/domains/office-api";
 import { StepImport } from "./step-import";
 import { StepWorkspace, derivePrefix } from "./step-workspace";
+import { StepTierProfiles } from "./step-tier-profiles";
 import { StepAgent } from "./step-agent";
 import { StepTask } from "./step-task";
 import { StepReview } from "./step-review";
@@ -73,23 +74,23 @@ export function getInitialData(
     agentProfileId: defaultAgentProfileId ?? "",
     tierProfileIds: initialTierProfileIds,
     executorPreference: "local_pc",
+    defaultTier: "frontier",
     taskTitle: DEFAULT_ONBOARDING_TASK_TITLE,
     taskDescription: DEFAULT_ONBOARDING_TASK_DESCRIPTION,
   };
 }
 
-const STEP_COUNT = 4;
+const STEP_COUNT = 5;
 
 function computeCanAdvance(step: number, data: WizardData): boolean {
   if (step === 0) return data.workspaceName.trim() !== "";
   if (step === 1)
     return (
-      data.agentName.trim() !== "" &&
-      data.agentProfileId !== "" &&
       Boolean(data.tierProfileIds.frontier) &&
       Boolean(data.tierProfileIds.balanced) &&
       Boolean(data.tierProfileIds.economy)
     );
+  if (step === 2) return data.agentName.trim() !== "" && data.agentProfileId !== "";
   return true;
 }
 
@@ -141,10 +142,18 @@ function WizardStepContent({
     );
   if (step === 1)
     return (
+      <StepTierProfiles
+        tierProfileIds={data.tierProfileIds}
+        agentProfiles={agentProfiles}
+        onChange={patch}
+        onAgentProfilesChange={onAgentProfilesChange}
+      />
+    );
+  if (step === 2)
+    return (
       <StepAgent
         agentName={data.agentName}
         agentProfileId={data.agentProfileId}
-        tierProfileIds={data.tierProfileIds}
         executorPreference={data.executorPreference}
         defaultTier={data.defaultTier}
         agentProfiles={agentProfiles}
@@ -152,7 +161,7 @@ function WizardStepContent({
         onAgentProfilesChange={onAgentProfilesChange}
       />
     );
-  if (step === 2)
+  if (step === 3)
     return (
       <StepTask
         agentName={data.agentName}

--- a/apps/web/app/office/setup/step-agent.tsx
+++ b/apps/web/app/office/setup/step-agent.tsx
@@ -5,6 +5,8 @@ import { Input } from "@kandev/ui/input";
 import { Label } from "@kandev/ui/label";
 import { Badge } from "@kandev/ui/badge";
 import { Button } from "@kandev/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
+import { IconInfoCircle } from "@tabler/icons-react";
 import { useAppStore } from "@/components/state-provider";
 import { AgentSelector } from "@/components/task-create-dialog-selectors";
 import { useAgentProfileOptions } from "@/components/task-create-dialog-options";
@@ -21,12 +23,14 @@ import { seedTier } from "./seed-tier-mapping";
 type StepAgentProps = {
   agentName: string;
   agentProfileId: string;
+  tierProfileIds: Partial<Record<Tier, string>>;
   executorPreference: string;
   defaultTier?: Tier;
   agentProfiles: AgentProfileOption[];
   onChange: (patch: {
     agentName?: string;
     agentProfileId?: string;
+    tierProfileIds?: Partial<Record<Tier, string>>;
     executorPreference?: string;
     defaultTier?: Tier;
   }) => void;
@@ -58,6 +62,7 @@ function sortProfiles(profiles: AgentProfileOption[]): AgentProfileOption[] {
 export function StepAgent({
   agentName,
   agentProfileId,
+  tierProfileIds,
   executorPreference,
   defaultTier,
   agentProfiles,
@@ -110,18 +115,16 @@ export function StepAgent({
           />
         </div>
         <div>
-          <Label>CLI agent profile</Label>
-          {!showCreate && (
-            <AgentSelector
-              options={profileOptions}
-              value={agentProfileId}
-              onValueChange={(v) => onChange({ agentProfileId: v })}
-              disabled={profileOptions.length === 0}
-              placeholder="Select an agent profile..."
-              triggerClassName="mt-1 border border-input rounded-md px-3 h-9"
-            />
-          )}
-          {showCreate ? (
+          <ProfileSelectorSection
+            showCreate={showCreate}
+            profileOptions={profileOptions}
+            agentProfileId={agentProfileId}
+            tierProfileIds={tierProfileIds}
+            selectedProfile={selectedProfile}
+            onChange={onChange}
+            onCreateClick={() => setShowCreate(true)}
+          />
+          {showCreate && (
             <CreateProfilePanel
               settingsAgents={settingsAgents}
               storeProfiles={agentProfilesState}
@@ -132,12 +135,6 @@ export function StepAgent({
               onChange={onChange}
               onClose={() => setShowCreate(false)}
             />
-          ) : (
-            <ProfilePickerHint
-              hasProfiles={profileOptions.length > 0}
-              selected={selectedProfile}
-              onCreateClick={() => setShowCreate(true)}
-            />
           )}
         </div>
         <ExecutorSelector
@@ -145,12 +142,169 @@ export function StepAgent({
           options={executorOptions}
           onChange={(v) => onChange({ executorPreference: v })}
         />
+        <TierProfileSelectorGroup
+          tierProfileIds={tierProfileIds}
+          profileOptions={profileOptions}
+          onChange={(tier, profileId) =>
+            onChange({ tierProfileIds: { ...tierProfileIds, [tier]: profileId } })
+          }
+        />
         <TierIndicator
           selectedProfile={selectedProfile}
           defaultTier={defaultTier}
           onChange={(t) => onChange({ defaultTier: t })}
         />
       </div>
+    </div>
+  );
+}
+
+function ProfileSelectorSection({
+  showCreate,
+  profileOptions,
+  agentProfileId,
+  tierProfileIds,
+  selectedProfile,
+  onChange,
+  onCreateClick,
+}: {
+  showCreate: boolean;
+  profileOptions: ReturnType<typeof useAgentProfileOptions>;
+  agentProfileId: string;
+  tierProfileIds: Partial<Record<Tier, string>>;
+  selectedProfile: AgentProfileOption | undefined;
+  onChange: StepAgentProps["onChange"];
+  onCreateClick: () => void;
+}) {
+  return (
+    <>
+      <Label>CLI agent profile</Label>
+      {!showCreate && (
+        <AgentSelector
+          options={profileOptions}
+          value={agentProfileId}
+          onValueChange={(v) =>
+            onChange({
+              agentProfileId: v,
+              tierProfileIds: fillMissingTierProfileIds(tierProfileIds, v),
+            })
+          }
+          disabled={profileOptions.length === 0}
+          placeholder="Select an agent profile..."
+          triggerClassName="mt-1 border border-input rounded-md px-3 h-9"
+        />
+      )}
+      {!showCreate && (
+        <ProfilePickerHint
+          hasProfiles={profileOptions.length > 0}
+          selected={selectedProfile}
+          onCreateClick={onCreateClick}
+        />
+      )}
+    </>
+  );
+}
+
+function fillMissingTierProfileIds(
+  current: Partial<Record<Tier, string>>,
+  profileId: string,
+): Partial<Record<Tier, string>> {
+  return {
+    frontier: current.frontier || profileId,
+    balanced: current.balanced || profileId,
+    economy: current.economy || profileId,
+  };
+}
+
+const TIER_PROFILE_COPY: Record<Tier, { label: string; description: string }> = {
+  frontier: {
+    label: "Frontier",
+    description:
+      "Used when the coordinator creates agents for the highest-capability work or assigns the Frontier tier.",
+  },
+  balanced: {
+    label: "Balanced",
+    description: "Used for general worker agents when the coordinator assigns the Balanced tier.",
+  },
+  economy: {
+    label: "Economy",
+    description:
+      "Used for QA, routine, and lower-cost agents when the coordinator assigns the Economy tier.",
+  },
+};
+
+function TierProfileSelectorGroup({
+  tierProfileIds,
+  profileOptions,
+  onChange,
+}: {
+  tierProfileIds: Partial<Record<Tier, string>>;
+  profileOptions: ReturnType<typeof useAgentProfileOptions>;
+  onChange: (tier: Tier, profileId: string) => void;
+}) {
+  return (
+    <div className="space-y-3">
+      <div>
+        <Label>Agent tier profiles</Label>
+        <p className="text-xs text-muted-foreground mt-1">
+          These profiles become the workspace tier families used when the coordinator creates or
+          schedules agents.
+        </p>
+      </div>
+      <div className="grid gap-3 md:grid-cols-3">
+        {(["frontier", "balanced", "economy"] as const).map((tier) => (
+          <TierProfileSelector
+            key={tier}
+            tier={tier}
+            value={tierProfileIds[tier] ?? ""}
+            options={profileOptions}
+            onChange={(profileId) => onChange(tier, profileId)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function TierProfileSelector({
+  tier,
+  value,
+  options,
+  onChange,
+}: {
+  tier: Tier;
+  value: string;
+  options: ReturnType<typeof useAgentProfileOptions>;
+  onChange: (profileId: string) => void;
+}) {
+  const copy = TIER_PROFILE_COPY[tier];
+  return (
+    <div className="min-w-0 space-y-1.5">
+      <div className="flex items-center gap-1.5">
+        <Label className="text-xs font-medium">{copy.label}</Label>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              className="inline-flex size-4 items-center justify-center rounded-sm text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              aria-label={`${copy.label} tier usage`}
+            >
+              <IconInfoCircle className="size-3.5" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent className="max-w-xs" side="top">
+            {copy.description}
+          </TooltipContent>
+        </Tooltip>
+      </div>
+      <AgentSelector
+        options={options}
+        value={value}
+        onValueChange={onChange}
+        disabled={options.length === 0}
+        placeholder="Select profile..."
+        triggerClassName="border border-input rounded-md px-3 h-9 w-full"
+      />
     </div>
   );
 }
@@ -232,7 +386,10 @@ function CreateProfilePanel({
           const option = toAgentProfileOption(agentForProfile, saved);
           setAgentProfiles([...storeProfiles.filter((p) => p.id !== option.id), option]);
           onAgentProfilesChange?.([...wizardProfiles.filter((p) => p.id !== option.id), option]);
-          onChange({ agentProfileId: saved.id });
+          onChange({
+            agentProfileId: saved.id,
+            tierProfileIds: fillMissingTierProfileIds({}, saved.id),
+          });
           onClose();
         }}
         onCancel={canCancel ? onClose : undefined}

--- a/apps/web/app/office/setup/step-agent.tsx
+++ b/apps/web/app/office/setup/step-agent.tsx
@@ -1,36 +1,33 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import { Input } from "@kandev/ui/input";
 import { Label } from "@kandev/ui/label";
 import { Badge } from "@kandev/ui/badge";
-import { Button } from "@kandev/ui/button";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
-import { IconInfoCircle } from "@tabler/icons-react";
 import { useAppStore } from "@/components/state-provider";
 import { AgentSelector } from "@/components/task-create-dialog-selectors";
 import { useAgentProfileOptions } from "@/components/task-create-dialog-options";
 import type { AgentProfileOption } from "@/lib/state/slices/settings/types";
-import { toAgentProfileOption } from "@/lib/state/slices/settings/types";
-import { getCapabilityWarning } from "@/lib/capability-warning";
-import { CliProfileEditor } from "@/components/agent/cli-profile-editor";
 import { Combobox, type ComboboxOption } from "@/components/combobox";
 import { getExecutorIcon } from "@/lib/executor-icons";
 import { ToggleGroup, ToggleGroupItem } from "@kandev/ui/toggle-group";
 import type { Tier } from "@/lib/state/slices/office/types";
 import { seedTier } from "./seed-tier-mapping";
+import {
+  CreateProfileButton,
+  CreateProfilePanel,
+  useSelectableProfileOptions,
+} from "./agent-profile-setup-controls";
 
 type StepAgentProps = {
   agentName: string;
   agentProfileId: string;
-  tierProfileIds: Partial<Record<Tier, string>>;
   executorPreference: string;
   defaultTier?: Tier;
   agentProfiles: AgentProfileOption[];
   onChange: (patch: {
     agentName?: string;
     agentProfileId?: string;
-    tierProfileIds?: Partial<Record<Tier, string>>;
     executorPreference?: string;
     defaultTier?: Tier;
   }) => void;
@@ -48,21 +45,9 @@ const FALLBACK_EXECUTOR_OPTIONS = [
   },
 ];
 
-function sortProfiles(profiles: AgentProfileOption[]): AgentProfileOption[] {
-  return [...profiles].sort((a, b) => {
-    const aDisabled =
-      a.cli_passthrough || !!getCapabilityWarning(a.capability_status, a.capability_error);
-    const bDisabled =
-      b.cli_passthrough || !!getCapabilityWarning(b.capability_status, b.capability_error);
-    if (aDisabled === bDisabled) return 0;
-    return aDisabled ? 1 : -1;
-  });
-}
-
 export function StepAgent({
   agentName,
   agentProfileId,
-  tierProfileIds,
   executorPreference,
   defaultTier,
   agentProfiles,
@@ -75,21 +60,7 @@ export function StepAgent({
   const setAgentProfiles = useAppStore((s) => s.setAgentProfiles);
   const agentProfilesState = useAppStore((s) => s.agentProfiles.items);
 
-  const sortedProfiles = useMemo(() => sortProfiles(agentProfiles), [agentProfiles]);
-  const baseOptions = useAgentProfileOptions(sortedProfiles);
-  const profileOptions = useMemo(
-    () =>
-      baseOptions.map((opt, i) => ({
-        ...opt,
-        disabled:
-          sortedProfiles[i]?.cli_passthrough ||
-          !!getCapabilityWarning(
-            sortedProfiles[i]?.capability_status,
-            sortedProfiles[i]?.capability_error,
-          ),
-      })),
-    [baseOptions, sortedProfiles],
-  );
+  const { sortedProfiles, profileOptions } = useSelectableProfileOptions(agentProfiles);
 
   const selectedProfile = sortedProfiles.find((p) => p.id === agentProfileId);
   const [showCreate, setShowCreate] = useState(profileOptions.length === 0);
@@ -119,7 +90,6 @@ export function StepAgent({
             showCreate={showCreate}
             profileOptions={profileOptions}
             agentProfileId={agentProfileId}
-            tierProfileIds={tierProfileIds}
             selectedProfile={selectedProfile}
             onChange={onChange}
             onCreateClick={() => setShowCreate(true)}
@@ -132,7 +102,7 @@ export function StepAgent({
               canCancel={profileOptions.length > 0}
               setAgentProfiles={setAgentProfiles}
               onAgentProfilesChange={onAgentProfilesChange}
-              onChange={onChange}
+              onProfileSaved={(profileId) => onChange({ agentProfileId: profileId })}
               onClose={() => setShowCreate(false)}
             />
           )}
@@ -141,13 +111,6 @@ export function StepAgent({
           value={executorPreference}
           options={executorOptions}
           onChange={(v) => onChange({ executorPreference: v })}
-        />
-        <TierProfileSelectorGroup
-          tierProfileIds={tierProfileIds}
-          profileOptions={profileOptions}
-          onChange={(tier, profileId) =>
-            onChange({ tierProfileIds: { ...tierProfileIds, [tier]: profileId } })
-          }
         />
         <TierIndicator
           selectedProfile={selectedProfile}
@@ -163,7 +126,6 @@ function ProfileSelectorSection({
   showCreate,
   profileOptions,
   agentProfileId,
-  tierProfileIds,
   selectedProfile,
   onChange,
   onCreateClick,
@@ -171,7 +133,6 @@ function ProfileSelectorSection({
   showCreate: boolean;
   profileOptions: ReturnType<typeof useAgentProfileOptions>;
   agentProfileId: string;
-  tierProfileIds: Partial<Record<Tier, string>>;
   selectedProfile: AgentProfileOption | undefined;
   onChange: StepAgentProps["onChange"];
   onCreateClick: () => void;
@@ -183,12 +144,7 @@ function ProfileSelectorSection({
         <AgentSelector
           options={profileOptions}
           value={agentProfileId}
-          onValueChange={(v) =>
-            onChange({
-              agentProfileId: v,
-              tierProfileIds: fillMissingTierProfileIds(tierProfileIds, v),
-            })
-          }
+          onValueChange={(v) => onChange({ agentProfileId: v })}
           disabled={profileOptions.length === 0}
           placeholder="Select an agent profile..."
           triggerClassName="mt-1 border border-input rounded-md px-3 h-9"
@@ -202,110 +158,6 @@ function ProfileSelectorSection({
         />
       )}
     </>
-  );
-}
-
-function fillMissingTierProfileIds(
-  current: Partial<Record<Tier, string>>,
-  profileId: string,
-): Partial<Record<Tier, string>> {
-  return {
-    frontier: current.frontier || profileId,
-    balanced: current.balanced || profileId,
-    economy: current.economy || profileId,
-  };
-}
-
-const TIER_PROFILE_COPY: Record<Tier, { label: string; description: string }> = {
-  frontier: {
-    label: "Frontier",
-    description:
-      "Used when the coordinator creates agents for the highest-capability work or assigns the Frontier tier.",
-  },
-  balanced: {
-    label: "Balanced",
-    description: "Used for general worker agents when the coordinator assigns the Balanced tier.",
-  },
-  economy: {
-    label: "Economy",
-    description:
-      "Used for QA, routine, and lower-cost agents when the coordinator assigns the Economy tier.",
-  },
-};
-
-function TierProfileSelectorGroup({
-  tierProfileIds,
-  profileOptions,
-  onChange,
-}: {
-  tierProfileIds: Partial<Record<Tier, string>>;
-  profileOptions: ReturnType<typeof useAgentProfileOptions>;
-  onChange: (tier: Tier, profileId: string) => void;
-}) {
-  return (
-    <div className="space-y-3">
-      <div>
-        <Label>Agent tier profiles</Label>
-        <p className="text-xs text-muted-foreground mt-1">
-          These profiles become the workspace tier families used when the coordinator creates or
-          schedules agents.
-        </p>
-      </div>
-      <div className="grid gap-3 md:grid-cols-3">
-        {(["frontier", "balanced", "economy"] as const).map((tier) => (
-          <TierProfileSelector
-            key={tier}
-            tier={tier}
-            value={tierProfileIds[tier] ?? ""}
-            options={profileOptions}
-            onChange={(profileId) => onChange(tier, profileId)}
-          />
-        ))}
-      </div>
-    </div>
-  );
-}
-
-function TierProfileSelector({
-  tier,
-  value,
-  options,
-  onChange,
-}: {
-  tier: Tier;
-  value: string;
-  options: ReturnType<typeof useAgentProfileOptions>;
-  onChange: (profileId: string) => void;
-}) {
-  const copy = TIER_PROFILE_COPY[tier];
-  return (
-    <div className="min-w-0 space-y-1.5">
-      <div className="flex items-center gap-1.5">
-        <Label className="text-xs font-medium">{copy.label}</Label>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              type="button"
-              className="inline-flex size-4 items-center justify-center rounded-sm text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-              aria-label={`${copy.label} tier usage`}
-            >
-              <IconInfoCircle className="size-3.5" />
-            </button>
-          </TooltipTrigger>
-          <TooltipContent className="max-w-xs" side="top">
-            {copy.description}
-          </TooltipContent>
-        </Tooltip>
-      </div>
-      <AgentSelector
-        options={options}
-        value={value}
-        onValueChange={onChange}
-        disabled={options.length === 0}
-        placeholder="Select profile..."
-        triggerClassName="border border-input rounded-md px-3 h-9 w-full"
-      />
-    </div>
   );
 }
 
@@ -352,52 +204,6 @@ function TierIndicator({
   );
 }
 
-function CreateProfilePanel({
-  settingsAgents,
-  storeProfiles,
-  wizardProfiles,
-  canCancel,
-  setAgentProfiles,
-  onAgentProfilesChange,
-  onChange,
-  onClose,
-}: {
-  settingsAgents: { id: string; name: string }[];
-  storeProfiles: AgentProfileOption[];
-  wizardProfiles: AgentProfileOption[];
-  canCancel: boolean;
-  setAgentProfiles: (profiles: AgentProfileOption[]) => void;
-  onAgentProfilesChange?: (profiles: AgentProfileOption[]) => void;
-  onChange: StepAgentProps["onChange"];
-  onClose: () => void;
-}) {
-  return (
-    <div className="mt-2 rounded-md border bg-muted/30 p-3">
-      <CliProfileEditor
-        mode="create"
-        defaultProfileName="default"
-        showAdvanced
-        allowCliPassthrough={false}
-        onSaved={(saved) => {
-          const agentForProfile = settingsAgents.find((a) => a.id === saved.agentId) ?? {
-            id: saved.agentId ?? "",
-            name: saved.agentId ?? "",
-          };
-          const option = toAgentProfileOption(agentForProfile, saved);
-          setAgentProfiles([...storeProfiles.filter((p) => p.id !== option.id), option]);
-          onAgentProfilesChange?.([...wizardProfiles.filter((p) => p.id !== option.id), option]);
-          onChange({
-            agentProfileId: saved.id,
-            tierProfileIds: fillMissingTierProfileIds({}, saved.id),
-          });
-          onClose();
-        }}
-        onCancel={canCancel ? onClose : undefined}
-      />
-    </div>
-  );
-}
-
 function ProfilePickerHint({
   hasProfiles,
   selected,
@@ -411,14 +217,7 @@ function ProfilePickerHint({
     return (
       <div className="mt-2 text-xs text-muted-foreground space-y-1">
         <p>No CLI agent profiles available yet.</p>
-        <Button
-          type="button"
-          variant="link"
-          onClick={onCreateClick}
-          className="h-auto p-0 cursor-pointer text-primary"
-        >
-          Create one inline
-        </Button>
+        <CreateProfileButton hasProfiles={false} onCreateClick={onCreateClick} />
       </div>
     );
   }
@@ -432,14 +231,7 @@ function ProfilePickerHint({
       ) : (
         <p>Picks the CLI client, model, mode, and flags this agent will use.</p>
       )}
-      <Button
-        type="button"
-        variant="link"
-        onClick={onCreateClick}
-        className="h-auto p-0 cursor-pointer text-primary"
-      >
-        + Create a new CLI profile
-      </Button>
+      <CreateProfileButton hasProfiles={hasProfiles} onCreateClick={onCreateClick} />
     </div>
   );
 }

--- a/apps/web/app/office/setup/step-agent.tsx
+++ b/apps/web/app/office/setup/step-agent.tsx
@@ -6,7 +6,6 @@ import { Label } from "@kandev/ui/label";
 import { Badge } from "@kandev/ui/badge";
 import { useAppStore } from "@/components/state-provider";
 import { AgentSelector } from "@/components/task-create-dialog-selectors";
-import { useAgentProfileOptions } from "@/components/task-create-dialog-options";
 import type { AgentProfileOption } from "@/lib/state/slices/settings/types";
 import { Combobox, type ComboboxOption } from "@/components/combobox";
 import { getExecutorIcon } from "@/lib/executor-icons";
@@ -18,6 +17,8 @@ import {
   CreateProfilePanel,
   useSelectableProfileOptions,
 } from "./agent-profile-setup-controls";
+
+type ProfileSelectOption = ReturnType<typeof useSelectableProfileOptions>["profileOptions"][number];
 
 type StepAgentProps = {
   agentName: string;
@@ -58,7 +59,6 @@ export function StepAgent({
   const executorOptions = meta?.executorTypes ?? FALLBACK_EXECUTOR_OPTIONS;
   const settingsAgents = useAppStore((s) => s.settingsAgents.items);
   const setAgentProfiles = useAppStore((s) => s.setAgentProfiles);
-  const agentProfilesState = useAppStore((s) => s.agentProfiles.items);
 
   const { sortedProfiles, profileOptions } = useSelectableProfileOptions(agentProfiles);
 
@@ -97,7 +97,6 @@ export function StepAgent({
           {showCreate && (
             <CreateProfilePanel
               settingsAgents={settingsAgents}
-              storeProfiles={agentProfilesState}
               wizardProfiles={agentProfiles}
               canCancel={profileOptions.length > 0}
               setAgentProfiles={setAgentProfiles}
@@ -131,7 +130,7 @@ function ProfileSelectorSection({
   onCreateClick,
 }: {
   showCreate: boolean;
-  profileOptions: ReturnType<typeof useAgentProfileOptions>;
+  profileOptions: ProfileSelectOption[];
   agentProfileId: string;
   selectedProfile: AgentProfileOption | undefined;
   onChange: StepAgentProps["onChange"];

--- a/apps/web/app/office/setup/step-task.tsx
+++ b/apps/web/app/office/setup/step-task.tsx
@@ -3,6 +3,10 @@
 import { Input } from "@kandev/ui/input";
 import { Label } from "@kandev/ui/label";
 import { Textarea } from "@kandev/ui/textarea";
+import {
+  DEFAULT_ONBOARDING_TASK_DESCRIPTION,
+  DEFAULT_ONBOARDING_TASK_TITLE,
+} from "./setup-task-defaults";
 
 type StepTaskProps = {
   agentName: string;
@@ -20,7 +24,7 @@ export function StepTask({ agentName, taskTitle, taskDescription, onChange }: St
       <div>
         <h2 className="text-xl font-semibold">Give your {name} something to do</h2>
         <p className="text-sm text-muted-foreground mt-1">
-          {name} will analyze this task, break it into subtasks, and assign them to worker agents.
+          {name} will use this starter task to set up projects, agents, and the initial backlog.
         </p>
       </div>
       <div className="space-y-4">
@@ -30,19 +34,19 @@ export function StepTask({ agentName, taskTitle, taskDescription, onChange }: St
             id="task-title"
             value={taskTitle}
             onChange={(e) => onChange({ taskTitle: e.target.value })}
-            placeholder="Explore the codebase and create an engineering roadmap"
+            placeholder={DEFAULT_ONBOARDING_TASK_TITLE}
             className="mt-1"
             autoFocus
           />
         </div>
         <div>
-          <Label htmlFor="task-desc">Description (optional)</Label>
+          <Label htmlFor="task-desc">Description</Label>
           <Textarea
             id="task-desc"
             value={taskDescription}
             onChange={(e) => onChange({ taskDescription: e.target.value })}
-            placeholder="Provide additional context or requirements for the task..."
-            className="mt-1 min-h-[100px]"
+            placeholder={DEFAULT_ONBOARDING_TASK_DESCRIPTION}
+            className="mt-1 min-h-[220px]"
           />
         </div>
       </div>

--- a/apps/web/app/office/setup/step-task.tsx
+++ b/apps/web/app/office/setup/step-task.tsx
@@ -16,7 +16,7 @@ type StepTaskProps = {
 };
 
 export function StepTask({ agentName, taskTitle, taskDescription, onChange }: StepTaskProps) {
-  // Step 1 (agent creation) requires a non-empty agentName before advancing,
+  // The coordinator step requires a non-empty agentName before advancing,
   // so by the time this step renders we always have a real value.
   const name = agentName.trim() || "coordinator";
   return (
@@ -24,7 +24,8 @@ export function StepTask({ agentName, taskTitle, taskDescription, onChange }: St
       <div>
         <h2 className="text-xl font-semibold">Give your {name} something to do</h2>
         <p className="text-sm text-muted-foreground mt-1">
-          {name} will use this starter task to set up projects, agents, and the initial backlog.
+          {name} will use this starter task to inspect the repos, set up the team, and propose the
+          next work for approval.
         </p>
       </div>
       <div className="space-y-4">

--- a/apps/web/app/office/setup/step-tier-profiles.tsx
+++ b/apps/web/app/office/setup/step-tier-profiles.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { useState } from "react";
+import { Label } from "@kandev/ui/label";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
+import { IconInfoCircle } from "@tabler/icons-react";
+import { useAppStore } from "@/components/state-provider";
+import { AgentSelector } from "@/components/task-create-dialog-selectors";
+import type { AgentProfileOption } from "@/lib/state/slices/settings/types";
+import type { Tier } from "@/lib/state/slices/office/types";
+import {
+  CreateProfileButton,
+  CreateProfilePanel,
+  fillMissingTierProfileIds,
+  useSelectableProfileOptions,
+} from "./agent-profile-setup-controls";
+
+type StepTierProfilesProps = {
+  tierProfileIds: Partial<Record<Tier, string>>;
+  agentProfiles: AgentProfileOption[];
+  onChange: (patch: {
+    agentProfileId?: string;
+    tierProfileIds?: Partial<Record<Tier, string>>;
+  }) => void;
+  onAgentProfilesChange?: (profiles: AgentProfileOption[]) => void;
+};
+
+const TIERS = ["frontier", "balanced", "economy"] as const;
+
+const TIER_PROFILE_COPY: Record<Tier, { label: string; description: string }> = {
+  frontier: {
+    label: "Frontier",
+    description:
+      "Used when the coordinator creates agents for the highest-capability work or assigns the Frontier tier.",
+  },
+  balanced: {
+    label: "Balanced",
+    description: "Used for general worker agents when the coordinator assigns the Balanced tier.",
+  },
+  economy: {
+    label: "Economy",
+    description:
+      "Used for QA, routine, and lower-cost agents when the coordinator assigns the Economy tier.",
+  },
+};
+
+export function StepTierProfiles({
+  tierProfileIds,
+  agentProfiles,
+  onChange,
+  onAgentProfilesChange,
+}: StepTierProfilesProps) {
+  const settingsAgents = useAppStore((s) => s.settingsAgents.items);
+  const setAgentProfiles = useAppStore((s) => s.setAgentProfiles);
+  const agentProfilesState = useAppStore((s) => s.agentProfiles.items);
+  const { profileOptions } = useSelectableProfileOptions(agentProfiles);
+  const [showCreate, setShowCreate] = useState(profileOptions.length === 0);
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-xl font-semibold">Setup tier agent profiles</h2>
+        <p className="text-sm text-muted-foreground mt-1">
+          Choose the profile family Office should use when agents are assigned Frontier, Balanced,
+          or Economy work.
+        </p>
+      </div>
+      <div className="space-y-4">
+        <div className="space-y-3">
+          <div>
+            <Label>Agent tier profiles</Label>
+            <p className="text-xs text-muted-foreground mt-1">
+              The coordinator can create worker agents and choose a tier for each one. Each tier
+              resolves to the profile selected here, and can be changed later in Workspace routing.
+            </p>
+          </div>
+          <div className="grid gap-3 md:grid-cols-3">
+            {TIERS.map((tier) => (
+              <TierProfileSelector
+                key={tier}
+                tier={tier}
+                value={tierProfileIds[tier] ?? ""}
+                options={profileOptions}
+                onChange={(profileId) =>
+                  onChange({ tierProfileIds: { ...tierProfileIds, [tier]: profileId } })
+                }
+              />
+            ))}
+          </div>
+        </div>
+        {!showCreate ? (
+          <CreateProfileButton
+            hasProfiles={profileOptions.length > 0}
+            onCreateClick={() => setShowCreate(true)}
+          />
+        ) : null}
+        {showCreate ? (
+          <CreateProfilePanel
+            settingsAgents={settingsAgents}
+            storeProfiles={agentProfilesState}
+            wizardProfiles={agentProfiles}
+            canCancel={profileOptions.length > 0}
+            setAgentProfiles={setAgentProfiles}
+            onAgentProfilesChange={onAgentProfilesChange}
+            onProfileSaved={(profileId) =>
+              onChange({
+                agentProfileId: profileId,
+                tierProfileIds: fillMissingTierProfileIds({}, profileId),
+              })
+            }
+            onClose={() => setShowCreate(false)}
+          />
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function TierProfileSelector({
+  tier,
+  value,
+  options,
+  onChange,
+}: {
+  tier: Tier;
+  value: string;
+  options: ReturnType<typeof useSelectableProfileOptions>["profileOptions"];
+  onChange: (profileId: string) => void;
+}) {
+  const copy = TIER_PROFILE_COPY[tier];
+  return (
+    <div className="min-w-0 space-y-1.5">
+      <div className="flex items-center gap-1.5">
+        <Label className="text-xs font-medium">{copy.label}</Label>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              className="inline-flex size-4 items-center justify-center rounded-sm text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              aria-label={`${copy.label} tier usage`}
+            >
+              <IconInfoCircle className="size-3.5" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent className="max-w-xs" side="top">
+            {copy.description}
+          </TooltipContent>
+        </Tooltip>
+      </div>
+      <AgentSelector
+        options={options}
+        value={value}
+        onValueChange={onChange}
+        disabled={options.length === 0}
+        placeholder="Select profile..."
+        triggerClassName="border border-input rounded-md px-3 h-9 w-full"
+      />
+    </div>
+  );
+}

--- a/apps/web/app/office/setup/step-tier-profiles.tsx
+++ b/apps/web/app/office/setup/step-tier-profiles.tsx
@@ -52,7 +52,6 @@ export function StepTierProfiles({
 }: StepTierProfilesProps) {
   const settingsAgents = useAppStore((s) => s.settingsAgents.items);
   const setAgentProfiles = useAppStore((s) => s.setAgentProfiles);
-  const agentProfilesState = useAppStore((s) => s.agentProfiles.items);
   const { profileOptions } = useSelectableProfileOptions(agentProfiles);
   const [showCreate, setShowCreate] = useState(profileOptions.length === 0);
 
@@ -97,7 +96,6 @@ export function StepTierProfiles({
         {showCreate ? (
           <CreateProfilePanel
             settingsAgents={settingsAgents}
-            storeProfiles={agentProfilesState}
             wizardProfiles={agentProfiles}
             canCancel={profileOptions.length > 0}
             setAgentProfiles={setAgentProfiles}
@@ -105,7 +103,7 @@ export function StepTierProfiles({
             onProfileSaved={(profileId) =>
               onChange({
                 agentProfileId: profileId,
-                tierProfileIds: fillMissingTierProfileIds({}, profileId),
+                tierProfileIds: fillMissingTierProfileIds(tierProfileIds, profileId),
               })
             }
             onClose={() => setShowCreate(false)}

--- a/apps/web/app/office/setup/wizard-footer.tsx
+++ b/apps/web/app/office/setup/wizard-footer.tsx
@@ -2,8 +2,7 @@
 
 import { Button } from "@kandev/ui/button";
 import { IconArrowLeft, IconArrowRight, IconRocket } from "@tabler/icons-react";
-
-const STEP_COUNT = 5;
+import { SETUP_WIZARD_STEP_COUNT, SETUP_WIZARD_STEPS } from "./setup-wizard-steps";
 
 type WizardFooterProps = {
   step: number;
@@ -24,8 +23,8 @@ export function WizardFooter({
   onSkip,
   onSubmit,
 }: WizardFooterProps) {
-  const isLast = step === STEP_COUNT - 1;
-  const isTaskStep = step === 3;
+  const isLast = step === SETUP_WIZARD_STEP_COUNT - 1;
+  const isTaskStep = step === SETUP_WIZARD_STEPS.TASK;
 
   return (
     <div className="flex items-center justify-between mt-8">

--- a/apps/web/app/office/setup/wizard-footer.tsx
+++ b/apps/web/app/office/setup/wizard-footer.tsx
@@ -3,7 +3,7 @@
 import { Button } from "@kandev/ui/button";
 import { IconArrowLeft, IconArrowRight, IconRocket } from "@tabler/icons-react";
 
-const STEP_COUNT = 4;
+const STEP_COUNT = 5;
 
 type WizardFooterProps = {
   step: number;
@@ -25,7 +25,7 @@ export function WizardFooter({
   onSubmit,
 }: WizardFooterProps) {
   const isLast = step === STEP_COUNT - 1;
-  const isTaskStep = step === 2;
+  const isTaskStep = step === 3;
 
   return (
     <div className="flex items-center justify-between mt-8">

--- a/apps/web/app/office/tasks/tasks-list.tsx
+++ b/apps/web/app/office/tasks/tasks-list.tsx
@@ -1,13 +1,14 @@
 "use client";
 
-import { useCallback, useEffect, useState, useSyncExternalStore } from "react";
+import { useCallback, useEffect, useMemo, useState, useSyncExternalStore } from "react";
 import { Button } from "@kandev/ui/button";
 import { useAppStore } from "@/components/state-provider";
 import { useOfficeRefetch } from "@/hooks/use-office-refetch";
+import type { OfficeTask } from "@/lib/state/slices/office/types";
 import { NewTaskDialog } from "../components/new-task-dialog";
 import { TasksToolbar } from "./tasks-toolbar";
 import { TasksContent } from "./tasks-content";
-import { useIssuesTree } from "./use-tasks-tree";
+import { getExpandableTaskIds, useIssuesTree } from "./use-tasks-tree";
 import { useServerSearch } from "./use-server-search";
 import { usePaginatedTasks } from "./use-paginated-tasks";
 
@@ -85,6 +86,21 @@ function useRehydratePersistedFilters(workspaceId: string | null) {
   }, [workspaceId, setTaskFilters]);
 }
 
+function useExpandedTaskIds(
+  tasks: OfficeTask[],
+  collapsedIds: Set<string>,
+  nestingEnabled: boolean,
+) {
+  return useMemo(() => {
+    if (!nestingEnabled) return new Set<string>();
+    const expandableIds = getExpandableTaskIds(tasks);
+    for (const id of collapsedIds) {
+      expandableIds.delete(id);
+    }
+    return expandableIds;
+  }, [tasks, collapsedIds, nestingEnabled]);
+}
+
 export function TasksList() {
   const workspaceId = useAppStore((s) => s.workspaces.activeId);
   const tasks = useAppStore((s) => s.office.tasks.items);
@@ -104,7 +120,7 @@ export function TasksList() {
   const setTaskGroupBy = useAppStore((s) => s.setTaskGroupBy);
   const toggleNesting = useAppStore((s) => s.toggleNesting);
 
-  const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
+  const [collapsedIds, setCollapsedIds] = useState<Set<string>>(new Set());
   const [newTaskOpen, setNewTaskOpen] = useState(false);
   const [showSystem, setShowSystem] = useShowSystemPref();
   const { searchResults, triggerSearch } = useServerSearch(workspaceId);
@@ -135,7 +151,7 @@ export function TasksList() {
   );
 
   const handleToggleExpand = useCallback((id: string) => {
-    setExpandedIds((prev) => {
+    setCollapsedIds((prev) => {
       const next = new Set(prev);
       if (next.has(id)) next.delete(id);
       else next.add(id);
@@ -147,6 +163,7 @@ export function TasksList() {
   // Skip local search filter when using server results to avoid
   // rejecting matches on description or identifier.
   const treeFilters = searchResults ? { ...filters, search: "" } : filters;
+  const expandedIds = useExpandedTaskIds(activeIssues, collapsedIds, nestingEnabled);
 
   const flatNodes = useIssuesTree({
     tasks: activeIssues,

--- a/apps/web/app/office/tasks/use-tasks-tree.test.ts
+++ b/apps/web/app/office/tasks/use-tasks-tree.test.ts
@@ -104,7 +104,7 @@ describe("office task tree", () => {
     ]);
   });
 
-  it("keeps visible orphan subtrees indented when an ancestor is filtered out", () => {
+  it("roots visible orphan subtrees at the top level when an ancestor is filtered out", () => {
     const parent = task("parent", "Hidden parent", "missing-grandparent");
     const child = task("child", "Visible child", parent.id);
     const grandchild = task("grandchild", "Visible grandchild", child.id);
@@ -121,8 +121,8 @@ describe("office task tree", () => {
     });
 
     expect(nodes.map((node) => [node.task.id, node.level, node.hasChildren])).toEqual([
-      [child.id, 1, true],
-      [grandchild.id, 2, false],
+      [child.id, 0, true],
+      [grandchild.id, 1, false],
     ]);
   });
 });

--- a/apps/web/app/office/tasks/use-tasks-tree.test.ts
+++ b/apps/web/app/office/tasks/use-tasks-tree.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import { buildTaskTreeNodes, getExpandableTaskIds, type FlatTaskNode } from "./use-tasks-tree";
+import type {
+  OfficeTask,
+  TaskFilterState,
+  TaskSortDir,
+  TaskSortField,
+} from "@/lib/state/slices/office/types";
+
+const FILTERS: TaskFilterState = {
+  statuses: [],
+  priorities: [],
+  assigneeIds: [],
+  projectIds: [],
+  search: "",
+};
+
+const STATUS_ORDER = {
+  backlog: 0,
+  todo: 1,
+  in_progress: 2,
+  in_review: 3,
+  blocked: 4,
+  done: 5,
+  cancelled: 6,
+};
+
+const PRIORITY_ORDER = {
+  critical: 0,
+  high: 1,
+  medium: 2,
+  low: 3,
+  none: 4,
+};
+
+function task(id: string, title: string, parentId?: string): OfficeTask {
+  return {
+    id,
+    workspaceId: "workspace-1",
+    identifier: id.toUpperCase(),
+    title,
+    status: "todo",
+    priority: "none",
+    parentId,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+function buildNodes(
+  tasks: OfficeTask[],
+  expandedIds: Set<string>,
+  sortField: TaskSortField = "title",
+  sortDir: TaskSortDir = "asc",
+): FlatTaskNode[] {
+  return buildTaskTreeNodes({
+    tasks,
+    filters: FILTERS,
+    sortField,
+    sortDir,
+    nestingEnabled: true,
+    expandedIds,
+    statusOrder: STATUS_ORDER,
+    priorityOrder: PRIORITY_ORDER,
+  });
+}
+
+describe("office task tree", () => {
+  it("marks parents with subtasks as expandable by default", () => {
+    const parent = task("parent", "Parent");
+    const child = task("child", "Child", parent.id);
+
+    expect([...getExpandableTaskIds([parent, child])]).toEqual([parent.id]);
+  });
+
+  it("renders expanded subtasks nested under their parent", () => {
+    const parent = task("parent", "Parent");
+    const child = task("child", "Child", parent.id);
+
+    const nodes = buildNodes([parent, child], new Set([parent.id]));
+
+    expect(nodes.map((node) => [node.task.id, node.level, node.hasChildren])).toEqual([
+      [parent.id, 0, true],
+      [child.id, 1, false],
+    ]);
+  });
+
+  it("does not promote collapsed subtasks to top-level rows", () => {
+    const parent = task("parent", "Parent");
+    const child = task("child", "Child", parent.id);
+
+    const nodes = buildNodes([parent, child], new Set());
+
+    expect(nodes.map((node) => node.task.id)).toEqual([parent.id]);
+  });
+
+  it("keeps filtered orphans visible at the top level", () => {
+    const child = task("child", "Child", "missing-parent");
+
+    const nodes = buildNodes([child], new Set());
+
+    expect(nodes.map((node) => [node.task.id, node.level, node.hasChildren])).toEqual([
+      [child.id, 0, false],
+    ]);
+  });
+});

--- a/apps/web/app/office/tasks/use-tasks-tree.test.ts
+++ b/apps/web/app/office/tasks/use-tasks-tree.test.ts
@@ -103,4 +103,26 @@ describe("office task tree", () => {
       [child.id, 0, false],
     ]);
   });
+
+  it("keeps visible orphan subtrees indented when an ancestor is filtered out", () => {
+    const parent = task("parent", "Hidden parent", "missing-grandparent");
+    const child = task("child", "Visible child", parent.id);
+    const grandchild = task("grandchild", "Visible grandchild", child.id);
+
+    const nodes = buildTaskTreeNodes({
+      tasks: [parent, child, grandchild],
+      filters: { ...FILTERS, search: "Visible" },
+      sortField: "title",
+      sortDir: "asc",
+      nestingEnabled: true,
+      expandedIds: new Set([child.id]),
+      statusOrder: STATUS_ORDER,
+      priorityOrder: PRIORITY_ORDER,
+    });
+
+    expect(nodes.map((node) => [node.task.id, node.level, node.hasChildren])).toEqual([
+      [child.id, 1, true],
+      [grandchild.id, 2, false],
+    ]);
+  });
 });

--- a/apps/web/app/office/tasks/use-tasks-tree.ts
+++ b/apps/web/app/office/tasks/use-tasks-tree.ts
@@ -155,7 +155,7 @@ export function buildTaskTreeNodes({
   }
 
   const sortedIds = new Set(sorted.map((task) => task.id));
-  const levels = computeTaskLevels(tasks);
+  const levels = computeTaskLevels(sorted);
   const childrenMap = new Map<string | undefined, OfficeTask[]>();
   for (const task of sorted) {
     const key = task.parentId ?? "__root__";

--- a/apps/web/app/office/tasks/use-tasks-tree.ts
+++ b/apps/web/app/office/tasks/use-tasks-tree.ts
@@ -92,6 +92,80 @@ export type UseIssuesTreeOptions = {
   expandedIds: Set<string>;
 };
 
+export function getExpandableTaskIds(tasks: OfficeTask[]): Set<string> {
+  const ids = new Set(tasks.map((task) => task.id));
+  const expandableIds = new Set<string>();
+  for (const task of tasks) {
+    if (task.parentId && ids.has(task.parentId)) {
+      expandableIds.add(task.parentId);
+    }
+  }
+  return expandableIds;
+}
+
+export function buildTaskTreeNodes({
+  tasks,
+  filters,
+  sortField,
+  sortDir,
+  nestingEnabled,
+  expandedIds,
+  statusOrder,
+  priorityOrder,
+}: UseIssuesTreeOptions & {
+  statusOrder: Record<string, number>;
+  priorityOrder: Record<string, number>;
+}): FlatTaskNode[] {
+  const filtered = tasks.filter((i) => matchesFilters(i, filters));
+  const sortCtx: SortContext = {
+    field: sortField,
+    dir: sortDir,
+    statusOrder,
+    priorityOrder,
+  };
+  const sorted = [...filtered].sort((a, b) => compareIssues(a, b, sortCtx));
+
+  if (!nestingEnabled) {
+    return sorted.map((task) => ({ task, level: 0, hasChildren: false }));
+  }
+
+  const sortedIds = new Set(sorted.map((task) => task.id));
+  const childrenMap = new Map<string | undefined, OfficeTask[]>();
+  for (const task of sorted) {
+    const key = task.parentId ?? "__root__";
+    const list = childrenMap.get(key);
+    if (list) {
+      list.push(task);
+    } else {
+      childrenMap.set(key, [task]);
+    }
+  }
+
+  const result: FlatTaskNode[] = [];
+  function walk(parentId: string | undefined, level: number) {
+    const key = parentId ?? "__root__";
+    const children = childrenMap.get(key) ?? [];
+    for (const task of children) {
+      const kids = childrenMap.get(task.id) ?? [];
+      const hasChildren = kids.length > 0;
+      result.push({ task, level, hasChildren });
+      if (hasChildren && expandedIds.has(task.id)) {
+        walk(task.id, level + 1);
+      }
+    }
+  }
+  walk(undefined, 0);
+
+  const renderedIds = new Set(result.map((n) => n.task.id));
+  for (const task of sorted) {
+    if (!renderedIds.has(task.id) && task.parentId && !sortedIds.has(task.parentId)) {
+      result.push({ task, level: 0, hasChildren: false });
+    }
+  }
+
+  return result;
+}
+
 export function useIssuesTree(opts: UseIssuesTreeOptions): FlatTaskNode[] {
   const { tasks, filters, sortField, sortDir, nestingEnabled, expandedIds } = opts;
   const meta = useAppStore((s) => s.office.meta);
@@ -111,54 +185,16 @@ export function useIssuesTree(opts: UseIssuesTreeOptions): FlatTaskNode[] {
   }, [meta]);
 
   return useMemo(() => {
-    const filtered = tasks.filter((i) => matchesFilters(i, filters));
-    const sortCtx: SortContext = {
-      field: sortField,
-      dir: sortDir,
+    return buildTaskTreeNodes({
+      tasks,
+      filters,
+      sortField,
+      sortDir,
+      nestingEnabled,
+      expandedIds,
       statusOrder: STATUS_ORDER,
       priorityOrder: PRIORITY_ORDER,
-    };
-    const sorted = [...filtered].sort((a, b) => compareIssues(a, b, sortCtx));
-
-    if (!nestingEnabled) {
-      return sorted.map((task) => ({ task, level: 0, hasChildren: false }));
-    }
-
-    const childrenMap = new Map<string | undefined, OfficeTask[]>();
-    for (const task of sorted) {
-      const key = task.parentId ?? "__root__";
-      const list = childrenMap.get(key);
-      if (list) {
-        list.push(task);
-      } else {
-        childrenMap.set(key, [task]);
-      }
-    }
-
-    const result: FlatTaskNode[] = [];
-    function walk(parentId: string | undefined, level: number) {
-      const key = parentId ?? "__root__";
-      const children = childrenMap.get(key) ?? [];
-      for (const task of children) {
-        const kids = childrenMap.get(task.id) ?? [];
-        const hasChildren = kids.length > 0;
-        result.push({ task, level, hasChildren });
-        if (hasChildren && expandedIds.has(task.id)) {
-          walk(task.id, level + 1);
-        }
-      }
-    }
-    walk(undefined, 0);
-
-    // Also include orphans (tasks whose parent is not in filtered set)
-    const renderedIds = new Set(result.map((n) => n.task.id));
-    for (const task of sorted) {
-      if (!renderedIds.has(task.id)) {
-        result.push({ task, level: 0, hasChildren: false });
-      }
-    }
-
-    return result;
+    });
   }, [
     tasks,
     filters,

--- a/apps/web/app/office/tasks/use-tasks-tree.ts
+++ b/apps/web/app/office/tasks/use-tasks-tree.ts
@@ -77,6 +77,31 @@ function compareIssues(a: OfficeTask, b: OfficeTask, ctx: SortContext): number {
   return ctx.dir === "asc" ? cmp : -cmp;
 }
 
+function computeTaskLevels(sorted: OfficeTask[]): Map<string, number> {
+  const byID = new Map(sorted.map((task) => [task.id, task]));
+  const levels = new Map<string, number>();
+
+  function levelFor(task: OfficeTask, seen: Set<string>): number {
+    const cached = levels.get(task.id);
+    if (cached !== undefined) return cached;
+    if (!task.parentId || !byID.has(task.parentId) || seen.has(task.id)) {
+      levels.set(task.id, 0);
+      return 0;
+    }
+    seen.add(task.id);
+    const parent = byID.get(task.parentId);
+    const level = parent ? levelFor(parent, seen) + 1 : 0;
+    seen.delete(task.id);
+    levels.set(task.id, level);
+    return level;
+  }
+
+  for (const task of sorted) {
+    levelFor(task, new Set());
+  }
+  return levels;
+}
+
 export type FlatTaskNode = {
   task: OfficeTask;
   level: number;
@@ -130,6 +155,7 @@ export function buildTaskTreeNodes({
   }
 
   const sortedIds = new Set(sorted.map((task) => task.id));
+  const levels = computeTaskLevels(tasks);
   const childrenMap = new Map<string | undefined, OfficeTask[]>();
   for (const task of sorted) {
     const key = task.parentId ?? "__root__";
@@ -157,9 +183,19 @@ export function buildTaskTreeNodes({
   walk(undefined, 0);
 
   const renderedIds = new Set(result.map((n) => n.task.id));
+  function appendOrphanSubtree(task: OfficeTask) {
+    if (renderedIds.has(task.id)) return;
+    const kids = childrenMap.get(task.id) ?? [];
+    const hasChildren = kids.length > 0;
+    result.push({ task, level: levels.get(task.id) ?? 0, hasChildren });
+    renderedIds.add(task.id);
+    if (hasChildren && expandedIds.has(task.id)) {
+      for (const child of kids) appendOrphanSubtree(child);
+    }
+  }
   for (const task of sorted) {
     if (!renderedIds.has(task.id) && task.parentId && !sortedIds.has(task.parentId)) {
-      result.push({ task, level: 0, hasChildren: false });
+      appendOrphanSubtree(task);
     }
   }
 

--- a/apps/web/app/office/workspace/routing/components/provider-tier-mapping.tsx
+++ b/apps/web/app/office/workspace/routing/components/provider-tier-mapping.tsx
@@ -32,7 +32,11 @@ export function ProviderTierMapping({
   disabled,
 }: Props) {
   const setTier = (key: keyof TierMap, value: string) =>
-    onChange({ ...profile, tier_map: { ...profile.tier_map, [key]: value } });
+    onChange({
+      ...profile,
+      tier_map: { ...profile.tier_map, [key]: value },
+      tier_profile_ids: { ...(profile.tier_profile_ids ?? {}), [key]: undefined },
+    });
 
   return (
     <div className="rounded-lg border border-border p-4 space-y-3">

--- a/apps/web/app/office/workspace/settings/components/danger-zone-section.test.ts
+++ b/apps/web/app/office/workspace/settings/components/danger-zone-section.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { postDeleteWorkspaceHref, resolvePostDeleteWorkspace } from "./danger-zone-section";
+import type { WorkspaceState } from "@/lib/state/slices/workspace/types";
+
+type Workspace = WorkspaceState["items"][number];
+
+function workspace(id: string, officeWorkflowId?: string | null): Workspace {
+  return {
+    id,
+    name: id,
+    description: "",
+    office_workflow_id: officeWorkflowId,
+  } as Workspace;
+}
+
+describe("workspace delete navigation", () => {
+  it("prefers another office workspace after deleting an office workspace", () => {
+    const deleted = workspace("office-1", "flow-1");
+    const kanban = workspace("kanban-1");
+    const office = workspace("office-2", "flow-2");
+
+    const next = resolvePostDeleteWorkspace(deleted.id, [deleted, kanban, office]);
+
+    expect(next).toBe(office);
+    expect(postDeleteWorkspaceHref(next)).toBe("/office?workspaceId=office-2");
+  });
+
+  it("falls back to a non-office workspace when no office workspaces remain", () => {
+    const deleted = workspace("office-1", "flow-1");
+    const kanban = workspace("kanban-1");
+
+    const next = resolvePostDeleteWorkspace(deleted.id, [deleted, kanban]);
+
+    expect(next).toBe(kanban);
+    expect(postDeleteWorkspaceHref(next)).toBe("/?workspaceId=kanban-1");
+  });
+
+  it("routes to the new office workspace wizard when no workspaces remain", () => {
+    const deleted = workspace("office-1", "flow-1");
+
+    const next = resolvePostDeleteWorkspace(deleted.id, [deleted]);
+
+    expect(next).toBeNull();
+    expect(postDeleteWorkspaceHref(next)).toBe("/office/setup?mode=new");
+  });
+});

--- a/apps/web/app/office/workspace/settings/components/danger-zone-section.tsx
+++ b/apps/web/app/office/workspace/settings/components/danger-zone-section.tsx
@@ -21,8 +21,24 @@ import {
   type WorkspaceDeletionSummary,
 } from "@/lib/api/domains/office-api";
 import type { WorkspaceState } from "@/lib/state/slices/workspace/types";
+import {
+  isOfficeWorkspace,
+  workspaceHomeHref,
+} from "@/components/app-sidebar/app-sidebar-workspace-navigation";
 
 type Workspace = WorkspaceState["items"][number];
+
+export function resolvePostDeleteWorkspace(
+  deletedWorkspaceId: string,
+  workspaces: Workspace[],
+): Workspace | null {
+  const remaining = workspaces.filter((item) => item.id !== deletedWorkspaceId);
+  return remaining.find(isOfficeWorkspace) ?? remaining[0] ?? null;
+}
+
+export function postDeleteWorkspaceHref(workspace: Workspace | null): string {
+  return workspace ? workspaceHomeHref(workspace) : "/office/setup?mode=new";
+}
 
 function SettingCard({ children }: { children: React.ReactNode }) {
   return <div className="rounded-lg border border-border p-4 space-y-4">{children}</div>;
@@ -133,10 +149,10 @@ export function DangerZoneSection({
     try {
       await deleteWorkspace(workspace.id, confirmName);
       const remaining = workspaces.filter((item) => item.id !== workspace.id);
-      const nextWorkspace = remaining[0] ?? null;
+      const nextWorkspace = resolvePostDeleteWorkspace(workspace.id, workspaces);
       setWorkspaces(remaining);
       setActiveWorkspace(nextWorkspace?.id ?? null);
-      router.push(nextWorkspace ? "/office" : "/office/setup");
+      router.push(postDeleteWorkspaceHref(nextWorkspace));
       toast.success("Workspace deleted");
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "Failed to delete workspace");

--- a/apps/web/components/agent/cli-profile-editor.tsx
+++ b/apps/web/components/agent/cli-profile-editor.tsx
@@ -517,5 +517,9 @@ async function saveNewProfile(form: FormState, settingsAgents: Agent[]): Promise
       `Created agent ${form.agentName} but the response did not include the new profile.`,
     );
   }
-  return newProfile;
+  return {
+    ...newProfile,
+    agentId: newProfile.agentId || created.id,
+    agentDisplayName: newProfile.agentDisplayName || created.name,
+  };
 }

--- a/apps/web/components/app-sidebar/app-sidebar-nav-item.tsx
+++ b/apps/web/components/app-sidebar/app-sidebar-nav-item.tsx
@@ -13,6 +13,7 @@ type AppSidebarNavItemProps = {
   label: string;
   href?: string;
   badge?: number;
+  badgeVariant?: "primary" | "muted";
   onClick?: () => void;
   collapsed: boolean;
   /** Override the auto-derived active-state from pathname. */
@@ -79,6 +80,7 @@ export function AppSidebarNavItem({
   label,
   href,
   badge,
+  badgeVariant = "primary",
   onClick,
   collapsed,
   isActive,
@@ -106,7 +108,14 @@ export function AppSidebarNavItem({
         <>
           <span className="flex-1 truncate sidebar-fade-in">{label}</span>
           {typeof badge === "number" && badge > 0 && (
-            <Badge className="rounded-full px-1.5 py-0.5 text-xs bg-primary text-primary-foreground">
+            <Badge
+              className={cn(
+                "rounded-full px-1.5 py-0.5 text-xs",
+                badgeVariant === "primary"
+                  ? "bg-primary text-primary-foreground"
+                  : "bg-muted text-muted-foreground",
+              )}
+            >
               {badge}
             </Badge>
           )}

--- a/apps/web/components/app-sidebar/app-sidebar.test.tsx
+++ b/apps/web/components/app-sidebar/app-sidebar.test.tsx
@@ -146,17 +146,18 @@ describe("AppSidebar", () => {
     render(<AppSidebar />);
 
     const nav = screen.getByRole("navigation");
-    expect(
-      Array.from(nav.querySelectorAll("[data-testid]")).map((node) =>
-        node.getAttribute("data-testid"),
-      ),
-    ).toEqual([
+    const expectedSections = [
       "primary-nav",
       "office-navigation-section-work",
       "projects-section",
       "agents-section",
       "office-navigation-section-office",
-    ]);
+    ];
+    expect(
+      Array.from(nav.querySelectorAll("[data-testid]"))
+        .map((node) => node.getAttribute("data-testid"))
+        .filter((id): id is string => id !== null && expectedSections.includes(id)),
+    ).toEqual(expectedSections);
   });
 
   it("renders collapsed when store reports collapsed=true", () => {

--- a/apps/web/components/app-sidebar/app-sidebar.tsx
+++ b/apps/web/components/app-sidebar/app-sidebar.tsx
@@ -43,6 +43,51 @@ function isSettingsRoute(pathname: string | null): boolean {
   return pathname === "/settings" || Boolean(pathname?.startsWith("/settings/"));
 }
 
+type AppSidebarNavigationProps = {
+  collapsed: boolean;
+  inOffice: boolean;
+  settingsMode: boolean;
+};
+
+function AppSidebarNavigation({ collapsed, inOffice, settingsMode }: AppSidebarNavigationProps) {
+  return (
+    <nav className="relative flex-1 min-h-0 flex flex-col gap-2 px-2 py-2 overflow-hidden">
+      {settingsMode && !collapsed ? (
+        <AppSidebarSettingsMode />
+      ) : (
+        <>
+          <div
+            className={cn(
+              "flex flex-col gap-2 overflow-y-auto",
+              inOffice ? "flex-1 min-h-0 pb-8 scroll-pb-8" : "shrink-0",
+            )}
+            data-testid="app-sidebar-scroll"
+          >
+            <AppSidebarPrimaryNav collapsed={collapsed} />
+            {inOffice && <OfficeNavigationSection collapsed={collapsed} section="work" />}
+            <ProjectsSection collapsed={collapsed} />
+            <AgentsSection collapsed={collapsed} />
+            {inOffice && <OfficeNavigationSection collapsed={collapsed} section="office" />}
+            {!inOffice && <IntegrationsSection collapsed={collapsed} />}
+          </div>
+          {/* In regular kanban mode, Tasks is the flex-grow middle section so
+              it absorbs remaining vertical space and scrolls internally.
+              Office has a dedicated /office/tasks page, so the sidebar only
+              renders a lightweight Tasks nav row above. */}
+          {!inOffice && <TasksSection collapsed={collapsed} />}
+          {inOffice && (
+            <div
+              aria-hidden="true"
+              className="pointer-events-none absolute inset-x-0 bottom-0 h-8 bg-gradient-to-t from-background to-transparent"
+              data-testid="app-sidebar-bottom-fade"
+            />
+          )}
+        </>
+      )}
+    </nav>
+  );
+}
+
 /**
  * Unified app sidebar mounted at the root layout. Replaces the legacy
  * WorkspaceRail + OfficeSidebar + dockview-embedded sidebar surfaces.
@@ -146,27 +191,7 @@ export function AppSidebar() {
       }}
     >
       <AppSidebarHeader collapsed={collapsed} onToggleCollapse={toggleCollapsed} />
-      <nav className="flex-1 min-h-0 flex flex-col gap-2 px-2 py-2 overflow-hidden">
-        {settingsMode && !collapsed ? (
-          <AppSidebarSettingsMode />
-        ) : (
-          <>
-            <div className="shrink-0 flex flex-col gap-2 overflow-y-auto">
-              <AppSidebarPrimaryNav collapsed={collapsed} />
-              {inOffice && <OfficeNavigationSection collapsed={collapsed} section="work" />}
-              <ProjectsSection collapsed={collapsed} />
-              <AgentsSection collapsed={collapsed} />
-              {inOffice && <OfficeNavigationSection collapsed={collapsed} section="office" />}
-              {!inOffice && <IntegrationsSection collapsed={collapsed} />}
-            </div>
-            {/* In regular kanban mode, Tasks is the flex-grow middle section so
-                it absorbs remaining vertical space and scrolls internally.
-                Office has a dedicated /office/tasks page, so the sidebar only
-                renders a lightweight Tasks nav row above. */}
-            {!inOffice && <TasksSection collapsed={collapsed} />}
-          </>
-        )}
-      </nav>
+      <AppSidebarNavigation collapsed={collapsed} inOffice={inOffice} settingsMode={settingsMode} />
       <AppSidebarFooter collapsed={collapsed} />
       {!collapsed && <AppSidebarResizeHandle onMouseDown={handleResize} />}
     </aside>

--- a/apps/web/components/app-sidebar/sections/office-navigation-section.test.tsx
+++ b/apps/web/components/app-sidebar/sections/office-navigation-section.test.tsx
@@ -80,4 +80,13 @@ describe("OfficeNavigationSection", () => {
     expect(screen.getByRole("link", { name: /Tasks/i })).toBeTruthy();
     expect(screen.getByRole("link", { name: /Preferences/i })).toBeTruthy();
   });
+
+  it("renders the skills count with muted badge styling", () => {
+    render(<OfficeNavigationSection collapsed={false} />);
+
+    const badge = screen.getByText("3");
+    expect(badge.classList.contains("bg-muted")).toBe(true);
+    expect(badge.classList.contains("text-muted-foreground")).toBe(true);
+    expect(badge.classList.contains("bg-primary")).toBe(false);
+  });
 });

--- a/apps/web/components/app-sidebar/sections/office-navigation-section.tsx
+++ b/apps/web/components/app-sidebar/sections/office-navigation-section.tsx
@@ -78,6 +78,7 @@ export function OfficeNavigationSection({
               label={item.label}
               href={item.href}
               badge={getWorkspaceBadge(item.href, skillCount)}
+              badgeVariant={item.href === "/office/workspace/skills" ? "muted" : "primary"}
               collapsed={collapsed}
             />
           ))}

--- a/apps/web/components/settings/agent-profile-delete-dialog.test.tsx
+++ b/apps/web/components/settings/agent-profile-delete-dialog.test.tsx
@@ -16,6 +16,7 @@ describe("AgentProfileDeleteConflictDialog", () => {
             { id: "linear-w2", kind: "linear", label: "team WEB" },
             { id: "github-w1", kind: "github_issue", label: "kdlbs/kandev" },
           ],
+          routingTiers: [],
         }}
         onOpenChange={() => {}}
         onConfirm={() => {}}
@@ -41,6 +42,7 @@ describe("AgentProfileDeleteConflictDialog", () => {
         conflict={{
           activeSessions: [{ task_id: "t1", task_title: "Live task", is_ephemeral: false }],
           watchers: [],
+          routingTiers: [],
         }}
         onOpenChange={() => {}}
         onConfirm={() => {}}
@@ -58,6 +60,7 @@ describe("AgentProfileDeleteConflictDialog", () => {
         conflict={{
           activeSessions: [{ task_id: "t1", task_title: "Live task", is_ephemeral: false }],
           watchers: [{ id: "jira-w1", kind: "jira", label: "project = ENG" }],
+          routingTiers: [],
         }}
         onOpenChange={() => {}}
         onConfirm={() => {}}
@@ -67,6 +70,25 @@ describe("AgentProfileDeleteConflictDialog", () => {
     expect(screen.getByText("Live task")).toBeTruthy();
     expect(screen.getByText(/Jira:/)).toBeTruthy();
     expect(screen.getByText(/project = ENG/)).toBeTruthy();
+  });
+
+  it("renders tier mappings as a hard blocker", () => {
+    render(
+      <AgentProfileDeleteConflictDialog
+        conflict={{
+          activeSessions: [],
+          watchers: [],
+          routingTiers: [{ workspace_id: "ws-1", provider_id: "codex-acp", tier: "balanced" }],
+        }}
+        onOpenChange={() => {}}
+        onConfirm={() => {}}
+      />,
+    );
+
+    expect(screen.getByText(/Cannot delete agent profile/i)).toBeTruthy();
+    expect(screen.getByText(/Workspace tier mappings:/)).toBeTruthy();
+    expect(screen.getByText(/ws-1: codex-acp balanced/)).toBeTruthy();
+    expect(screen.queryByText(/Delete Anyway/)).toBeNull();
   });
 
   it("does not render the dialog when conflict is null", () => {

--- a/apps/web/components/settings/agent-profile-delete-dialog.test.tsx
+++ b/apps/web/components/settings/agent-profile-delete-dialog.test.tsx
@@ -1,27 +1,64 @@
 import { describe, it, expect, afterEach } from "vitest";
 import { render, screen, cleanup } from "@testing-library/react";
 
+import { StateProvider } from "@/components/state-provider";
 import { AgentProfileDeleteConflictDialog } from "./agent-profile-delete-dialog";
+import type { AgentProfileDeleteConflict } from "./agent-profile-delete-dialog";
 
 afterEach(cleanup);
 
-describe("AgentProfileDeleteConflictDialog", () => {
-  it("renders the watcher list grouped by kind on a watcher-only conflict", () => {
-    render(
-      <AgentProfileDeleteConflictDialog
-        conflict={{
-          activeSessions: [],
-          watchers: [
-            { id: "linear-w1", kind: "linear", label: "team ENG" },
-            { id: "linear-w2", kind: "linear", label: "team WEB" },
-            { id: "github-w1", kind: "github_issue", label: "kdlbs/kandev" },
+const FIXTURE_TIMESTAMP = "2026-01-01T00:00:00.000Z";
+
+function renderConflictDialog(conflict: AgentProfileDeleteConflict | null) {
+  return render(
+    <StateProvider
+      initialState={{
+        workspaces: {
+          activeId: "ws-1",
+          items: [
+            {
+              id: "ws-1",
+              name: "Office Workspace",
+              owner_id: "user-1",
+              created_at: FIXTURE_TIMESTAMP,
+              updated_at: FIXTURE_TIMESTAMP,
+            },
           ],
-          routingTiers: [],
-        }}
+        },
+        settingsAgents: {
+          items: [
+            {
+              id: "codex-acp",
+              name: "Codex",
+              supports_mcp: false,
+              profiles: [],
+              created_at: FIXTURE_TIMESTAMP,
+              updated_at: FIXTURE_TIMESTAMP,
+            },
+          ],
+        },
+      }}
+    >
+      <AgentProfileDeleteConflictDialog
+        conflict={conflict}
         onOpenChange={() => {}}
         onConfirm={() => {}}
-      />,
-    );
+      />
+    </StateProvider>,
+  );
+}
+
+describe("AgentProfileDeleteConflictDialog", () => {
+  it("renders the watcher list grouped by kind on a watcher-only conflict", () => {
+    renderConflictDialog({
+      activeSessions: [],
+      watchers: [
+        { id: "linear-w1", kind: "linear", label: "team ENG" },
+        { id: "linear-w2", kind: "linear", label: "team WEB" },
+        { id: "github-w1", kind: "github_issue", label: "kdlbs/kandev" },
+      ],
+      routingTiers: [],
+    });
 
     // Watcher group headings render the human-friendly kind label, and
     // each watcher's label string appears once. Critically: the dialog
@@ -37,17 +74,11 @@ describe("AgentProfileDeleteConflictDialog", () => {
   });
 
   it("does not render the watchers section when the conflict is sessions-only", () => {
-    render(
-      <AgentProfileDeleteConflictDialog
-        conflict={{
-          activeSessions: [{ task_id: "t1", task_title: "Live task", is_ephemeral: false }],
-          watchers: [],
-          routingTiers: [],
-        }}
-        onOpenChange={() => {}}
-        onConfirm={() => {}}
-      />,
-    );
+    renderConflictDialog({
+      activeSessions: [{ task_id: "t1", task_title: "Live task", is_ephemeral: false }],
+      watchers: [],
+      routingTiers: [],
+    });
 
     expect(screen.getByText(/Tasks:/)).toBeTruthy();
     expect(screen.getByText("Live task")).toBeTruthy();
@@ -55,17 +86,11 @@ describe("AgentProfileDeleteConflictDialog", () => {
   });
 
   it("renders both sections when sessions and watchers coexist", () => {
-    render(
-      <AgentProfileDeleteConflictDialog
-        conflict={{
-          activeSessions: [{ task_id: "t1", task_title: "Live task", is_ephemeral: false }],
-          watchers: [{ id: "jira-w1", kind: "jira", label: "project = ENG" }],
-          routingTiers: [],
-        }}
-        onOpenChange={() => {}}
-        onConfirm={() => {}}
-      />,
-    );
+    renderConflictDialog({
+      activeSessions: [{ task_id: "t1", task_title: "Live task", is_ephemeral: false }],
+      watchers: [{ id: "jira-w1", kind: "jira", label: "project = ENG" }],
+      routingTiers: [],
+    });
 
     expect(screen.getByText("Live task")).toBeTruthy();
     expect(screen.getByText(/Jira:/)).toBeTruthy();
@@ -73,32 +98,29 @@ describe("AgentProfileDeleteConflictDialog", () => {
   });
 
   it("renders tier mappings as a hard blocker", () => {
-    render(
-      <AgentProfileDeleteConflictDialog
-        conflict={{
-          activeSessions: [],
-          watchers: [],
-          routingTiers: [{ workspace_id: "ws-1", provider_id: "codex-acp", tier: "balanced" }],
-        }}
-        onOpenChange={() => {}}
-        onConfirm={() => {}}
-      />,
-    );
+    renderConflictDialog({
+      activeSessions: [],
+      watchers: [],
+      routingTiers: [{ workspace_id: "ws-1", provider_id: "codex-acp", tier: "balanced" }],
+    });
 
     expect(screen.getByText(/Cannot delete agent profile/i)).toBeTruthy();
     expect(screen.getByText(/Workspace tier mappings:/)).toBeTruthy();
-    expect(screen.getByText(/ws-1: codex-acp balanced/)).toBeTruthy();
+    expect(
+      screen.getByText((_content, element) =>
+        Boolean(
+          element?.tagName === "LI" &&
+          element.textContent?.includes(
+            "Balanced tier in Office Workspace (ws-1) for Codex (codex-acp)",
+          ),
+        ),
+      ),
+    ).toBeTruthy();
     expect(screen.queryByText(/Delete Anyway/)).toBeNull();
   });
 
   it("does not render the dialog when conflict is null", () => {
-    render(
-      <AgentProfileDeleteConflictDialog
-        conflict={null}
-        onOpenChange={() => {}}
-        onConfirm={() => {}}
-      />,
-    );
+    renderConflictDialog(null);
 
     expect(screen.queryByText(/Delete agent profile/i)).toBeNull();
   });

--- a/apps/web/components/settings/agent-profile-delete-dialog.tsx
+++ b/apps/web/components/settings/agent-profile-delete-dialog.tsx
@@ -10,7 +10,11 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@kandev/ui/alert-dialog";
-import type { ActiveSessionInfo, WatcherReference } from "@/lib/types/agent-profile-errors";
+import type {
+  ActiveSessionInfo,
+  RoutingTierReference,
+  WatcherReference,
+} from "@/lib/types/agent-profile-errors";
 
 const WATCHER_KIND_LABELS: Record<WatcherReference["kind"], string> = {
   linear: "Linear",
@@ -59,6 +63,7 @@ export function AgentProfileDeleteConfirmDialog({
 export type AgentProfileDeleteConflict = {
   activeSessions: ActiveSessionInfo[];
   watchers: WatcherReference[];
+  routingTiers: RoutingTierReference[];
 };
 
 type AgentProfileDeleteConflictDialogProps = {
@@ -75,73 +80,118 @@ export function AgentProfileDeleteConflictDialog({
   const tasks = conflict?.activeSessions.filter((s) => !s.is_ephemeral) ?? [];
   const quickChats = conflict?.activeSessions.filter((s) => s.is_ephemeral) ?? [];
   const watchers = conflict?.watchers ?? [];
+  const routingTiers = conflict?.routingTiers ?? [];
+  const hasHardBlockers = routingTiers.length > 0;
   const watchersByKind = groupWatchersByKind(watchers);
 
   return (
     <AlertDialog open={!!conflict} onOpenChange={onOpenChange}>
       <AlertDialogContent>
         <AlertDialogHeader>
-          <AlertDialogTitle>Delete agent profile?</AlertDialogTitle>
+          <AlertDialogTitle>
+            {hasHardBlockers ? "Cannot delete agent profile" : "Delete agent profile?"}
+          </AlertDialogTitle>
           <AlertDialogDescription asChild>
             <div>
               <p>This profile is currently in use. Deleting it will affect the following:</p>
-              {tasks.length > 0 && (
-                <div className="mt-2">
-                  <p className="font-medium text-sm">Tasks:</p>
-                  <ul className="list-disc list-inside mt-1 space-y-0.5">
-                    {tasks.map((t) => (
-                      <li key={t.task_id} className="text-sm">
-                        {t.task_title || "Untitled task"}
-                      </li>
-                    ))}
-                  </ul>
-                </div>
+              <SessionConflictSection title="Tasks:" sessions={tasks} fallback="Untitled task" />
+              <SessionConflictSection
+                title="Quick Chats:"
+                sessions={quickChats}
+                fallback="Untitled quick chat"
+              />
+              <WatcherConflictSection watchersByKind={watchersByKind} />
+              <RoutingTierConflictSection routingTiers={routingTiers} />
+              {hasHardBlockers ? (
+                <p className="mt-2">
+                  Change these workspace tier mappings before deleting this profile.
+                </p>
+              ) : (
+                <p className="mt-2">
+                  These sessions will no longer be able to use this profile and the listed watchers
+                  will be disabled. This action cannot be undone.
+                </p>
               )}
-              {quickChats.length > 0 && (
-                <div className="mt-2">
-                  <p className="font-medium text-sm">Quick Chats:</p>
-                  <ul className="list-disc list-inside mt-1 space-y-0.5">
-                    {quickChats.map((t) => (
-                      <li key={t.task_id} className="text-sm">
-                        {t.task_title || "Untitled quick chat"}
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              )}
-              {watchers.length > 0 && (
-                <div className="mt-2">
-                  <p className="font-medium text-sm">Watchers (will be disabled):</p>
-                  <ul className="list-disc list-inside mt-1 space-y-0.5">
-                    {Object.entries(watchersByKind).map(([kind, items]) => (
-                      <li key={kind} className="text-sm">
-                        <span className="font-medium">
-                          {WATCHER_KIND_LABELS[kind as WatcherReference["kind"]] ?? kind}:
-                        </span>{" "}
-                        {items.map((w) => w.label || w.id).join(", ")}
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              )}
-              <p className="mt-2">
-                These sessions will no longer be able to use this profile and the listed watchers
-                will be disabled. This action cannot be undone.
-              </p>
             </div>
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
           <AlertDialogCancel className="cursor-pointer">Cancel</AlertDialogCancel>
-          <AlertDialogAction
-            onClick={onConfirm}
-            className="cursor-pointer bg-destructive text-destructive-foreground hover:bg-destructive/90"
-          >
-            Delete Anyway
-          </AlertDialogAction>
+          {hasHardBlockers ? null : (
+            <AlertDialogAction
+              onClick={onConfirm}
+              className="cursor-pointer bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              Delete Anyway
+            </AlertDialogAction>
+          )}
         </AlertDialogFooter>
       </AlertDialogContent>
     </AlertDialog>
+  );
+}
+
+function SessionConflictSection({
+  title,
+  sessions,
+  fallback,
+}: {
+  title: string;
+  sessions: ActiveSessionInfo[];
+  fallback: string;
+}) {
+  if (sessions.length === 0) return null;
+  return (
+    <div className="mt-2">
+      <p className="font-medium text-sm">{title}</p>
+      <ul className="list-disc list-inside mt-1 space-y-0.5">
+        {sessions.map((t) => (
+          <li key={t.task_id} className="text-sm">
+            {t.task_title || fallback}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function WatcherConflictSection({
+  watchersByKind,
+}: {
+  watchersByKind: Record<string, WatcherReference[]>;
+}) {
+  const entries = Object.entries(watchersByKind);
+  if (entries.length === 0) return null;
+  return (
+    <div className="mt-2">
+      <p className="font-medium text-sm">Watchers (will be disabled):</p>
+      <ul className="list-disc list-inside mt-1 space-y-0.5">
+        {entries.map(([kind, items]) => (
+          <li key={kind} className="text-sm">
+            <span className="font-medium">
+              {WATCHER_KIND_LABELS[kind as WatcherReference["kind"]] ?? kind}:
+            </span>{" "}
+            {items.map((w) => w.label || w.id).join(", ")}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function RoutingTierConflictSection({ routingTiers }: { routingTiers: RoutingTierReference[] }) {
+  if (routingTiers.length === 0) return null;
+  return (
+    <div className="mt-2">
+      <p className="font-medium text-sm">Workspace tier mappings:</p>
+      <ul className="list-disc list-inside mt-1 space-y-0.5">
+        {routingTiers.map((ref) => (
+          <li key={`${ref.workspace_id}-${ref.provider_id}-${ref.tier}`} className="text-sm">
+            {ref.workspace_id}: {ref.provider_id} {ref.tier}
+          </li>
+        ))}
+      </ul>
+    </div>
   );
 }
 

--- a/apps/web/components/settings/agent-profile-delete-dialog.tsx
+++ b/apps/web/components/settings/agent-profile-delete-dialog.tsx
@@ -10,6 +10,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@kandev/ui/alert-dialog";
+import { useAppStore } from "@/components/state-provider";
 import type {
   ActiveSessionInfo,
   RoutingTierReference,
@@ -83,6 +84,8 @@ export function AgentProfileDeleteConflictDialog({
   const routingTiers = conflict?.routingTiers ?? [];
   const hasHardBlockers = routingTiers.length > 0;
   const watchersByKind = groupWatchersByKind(watchers);
+  const workspaces = useAppStore((s) => s.workspaces.items);
+  const providers = useAppStore((s) => s.settingsAgents.items);
 
   return (
     <AlertDialog open={!!conflict} onOpenChange={onOpenChange}>
@@ -101,7 +104,11 @@ export function AgentProfileDeleteConflictDialog({
                 fallback="Untitled quick chat"
               />
               <WatcherConflictSection watchersByKind={watchersByKind} />
-              <RoutingTierConflictSection routingTiers={routingTiers} />
+              <RoutingTierConflictSection
+                routingTiers={routingTiers}
+                workspaceLabels={new Map(workspaces.map((w) => [w.id, w.name]))}
+                providerLabels={new Map(providers.map((p) => [p.id, p.name]))}
+              />
               {hasHardBlockers ? (
                 <p className="mt-2">
                   Change these workspace tier mappings before deleting this profile.
@@ -179,7 +186,15 @@ function WatcherConflictSection({
   );
 }
 
-function RoutingTierConflictSection({ routingTiers }: { routingTiers: RoutingTierReference[] }) {
+function RoutingTierConflictSection({
+  routingTiers,
+  workspaceLabels,
+  providerLabels,
+}: {
+  routingTiers: RoutingTierReference[];
+  workspaceLabels: Map<string, string>;
+  providerLabels: Map<string, string>;
+}) {
   if (routingTiers.length === 0) return null;
   return (
     <div className="mt-2">
@@ -187,12 +202,23 @@ function RoutingTierConflictSection({ routingTiers }: { routingTiers: RoutingTie
       <ul className="list-disc list-inside mt-1 space-y-0.5">
         {routingTiers.map((ref) => (
           <li key={`${ref.workspace_id}-${ref.provider_id}-${ref.tier}`} className="text-sm">
-            {ref.workspace_id}: {ref.provider_id} {ref.tier}
+            <span className="font-medium">{formatRoutingTier(ref.tier)}</span> tier in{" "}
+            {formatLookupLabel(workspaceLabels, ref.workspace_id)} for{" "}
+            {formatLookupLabel(providerLabels, ref.provider_id)}
           </li>
         ))}
       </ul>
     </div>
   );
+}
+
+function formatRoutingTier(tier: string): string {
+  return tier.charAt(0).toUpperCase() + tier.slice(1);
+}
+
+function formatLookupLabel(labels: Map<string, string>, id: string): string {
+  const label = labels.get(id);
+  return label && label !== id ? `${label} (${id})` : id;
 }
 
 function groupWatchersByKind(watchers: WatcherReference[]): Record<string, WatcherReference[]> {

--- a/apps/web/components/settings/agent-profile-page.tsx
+++ b/apps/web/components/settings/agent-profile-page.tsx
@@ -332,7 +332,11 @@ function useProfileDelete(
     if (result.status === "ok") {
       removeProfileFromStore();
     } else if (result.status === "conflict") {
-      setConflict({ activeSessions: result.activeSessions, watchers: result.watchers });
+      setConflict({
+        activeSessions: result.activeSessions,
+        watchers: result.watchers,
+        routingTiers: result.routingTiers,
+      });
     } else {
       toast({ title: "Failed to delete profile", description: result.message, variant: "error" });
     }
@@ -343,6 +347,12 @@ function useProfileDelete(
     setConflict(null);
     if (result.status === "ok") {
       removeProfileFromStore();
+    } else if (result.status === "conflict") {
+      setConflict({
+        activeSessions: result.activeSessions,
+        watchers: result.watchers,
+        routingTiers: result.routingTiers,
+      });
     } else if (result.status === "error") {
       toast({ title: "Failed to delete profile", description: result.message, variant: "error" });
     }

--- a/apps/web/e2e/helpers/office-api-client.ts
+++ b/apps/web/e2e/helpers/office-api-client.ts
@@ -49,6 +49,10 @@ export class OfficeApiClient {
     return this.request("POST", "/onboarding/import-fs", undefined);
   }
 
+  async deleteWorkspace(wsId: string, confirmName: string): Promise<void> {
+    await this.request("DELETE", `/workspaces/${wsId}`, { confirm_name: confirmName });
+  }
+
   // --- Agents ---
 
   async listAgents(wsId: string): Promise<Record<string, unknown>> {

--- a/apps/web/e2e/tests/office/mobile-onboarding.spec.ts
+++ b/apps/web/e2e/tests/office/mobile-onboarding.spec.ts
@@ -9,8 +9,9 @@ import { assertNoDocumentHorizontalOverflow } from "../../helpers/layout-asserti
 
 const SETUP_ROUTE = "/office/setup?mode=new";
 const STEP_0_HEADING = "Set up your Office workspace";
-const STEP_1_HEADING = "Create your coordinator agent";
-const STEP_2_HEADING = "Give your CEO something to do";
+const STEP_1_HEADING = "Setup tier agent profiles";
+const STEP_2_HEADING = "Create your coordinator agent";
+const STEP_3_HEADING = "Give your CEO something to do";
 
 test.describe("Office onboarding — mobile layout", () => {
   test("setup wizard does not overflow horizontally on Pixel 5", async ({
@@ -54,7 +55,7 @@ test.describe("Office onboarding — mobile layout", () => {
     await expect(testPage).toHaveURL((url) => url.pathname === "/", { timeout: 10_000 });
   });
 
-  test("agent step (Step 1) fits within the viewport horizontally", async ({
+  test("tier profile step (Step 1) fits within the viewport horizontally", async ({
     testPage,
     officeSeed: _,
   }) => {
@@ -64,7 +65,7 @@ test.describe("Office onboarding — mobile layout", () => {
     await expect(testPage.getByRole("heading", { name: STEP_1_HEADING })).toBeVisible();
     await expect(testPage.getByText("Agent tier profiles")).toBeVisible();
 
-    await assertNoDocumentHorizontalOverflow(testPage, "agent step (Step 1)");
+    await assertNoDocumentHorizontalOverflow(testPage, "tier profile step (Step 1)");
 
     const viewport = testPage.viewportSize();
     expect(viewport).not.toBeNull();
@@ -85,7 +86,7 @@ test.describe("Office onboarding — mobile layout", () => {
     }
   });
 
-  test("agent step (Step 1) heading and Next button are reachable on mobile", async ({
+  test("tier profile step (Step 1) heading and Next button are reachable on mobile", async ({
     testPage,
     officeSeed: _,
   }) => {
@@ -132,12 +133,12 @@ test.describe("Office onboarding — mobile layout", () => {
     // scroll cannot bring it on-screen and the click times out — which is
     // exactly the user-facing bug.
     await next.click();
-    await expect(
-      testPage.getByRole("heading", { name: /Give your .* something to do/i }),
-    ).toBeVisible({ timeout: 10_000 });
+    await expect(testPage.getByRole("heading", { name: STEP_2_HEADING })).toBeVisible({
+      timeout: 10_000,
+    });
   });
 
-  test("task step (Step 2) starter brief fits horizontally on mobile", async ({
+  test("task step (Step 3) starter brief fits horizontally on mobile", async ({
     testPage,
     officeSeed: _,
   }) => {
@@ -146,14 +147,17 @@ test.describe("Office onboarding — mobile layout", () => {
     await testPage.getByRole("button", { name: /next/i }).click();
     await expect(testPage.getByRole("heading", { name: STEP_1_HEADING })).toBeVisible();
     await testPage.getByRole("button", { name: /next/i }).click();
-
     await expect(testPage.getByRole("heading", { name: STEP_2_HEADING })).toBeVisible();
+    await testPage.getByRole("button", { name: /next/i }).click();
+
+    await expect(testPage.getByRole("heading", { name: STEP_3_HEADING })).toBeVisible();
     await expect(testPage.getByLabel("Task title")).toHaveValue("Setup Workspace");
     await expect(testPage.getByLabel("Description")).toHaveValue(
       /Create one project per repository/,
     );
+    await expect(testPage.getByLabel("Description")).toHaveValue(/proposed plan/);
 
-    await assertNoDocumentHorizontalOverflow(testPage, "task step (Step 2)");
+    await assertNoDocumentHorizontalOverflow(testPage, "task step (Step 3)");
   });
 
   test("opening the agent profile combobox keeps the document within the viewport", async ({
@@ -163,6 +167,8 @@ test.describe("Office onboarding — mobile layout", () => {
     await testPage.goto(SETUP_ROUTE);
     await testPage.getByRole("button", { name: /next/i }).click();
     await expect(testPage.getByRole("heading", { name: STEP_1_HEADING })).toBeVisible();
+    await testPage.getByRole("button", { name: /next/i }).click();
+    await expect(testPage.getByRole("heading", { name: STEP_2_HEADING })).toBeVisible();
 
     await testPage.getByTestId("agent-profile-selector").click();
     // Wait for the popover to actually mount instead of sleeping — the

--- a/apps/web/e2e/tests/office/mobile-onboarding.spec.ts
+++ b/apps/web/e2e/tests/office/mobile-onboarding.spec.ts
@@ -10,6 +10,7 @@ import { assertNoDocumentHorizontalOverflow } from "../../helpers/layout-asserti
 const SETUP_ROUTE = "/office/setup?mode=new";
 const STEP_0_HEADING = "Set up your Office workspace";
 const STEP_1_HEADING = "Create your coordinator agent";
+const STEP_2_HEADING = "Give your CEO something to do";
 
 test.describe("Office onboarding — mobile layout", () => {
   test("setup wizard does not overflow horizontally on Pixel 5", async ({
@@ -61,6 +62,7 @@ test.describe("Office onboarding — mobile layout", () => {
     await expect(testPage.getByRole("heading", { name: STEP_0_HEADING })).toBeVisible();
     await testPage.getByRole("button", { name: /next/i }).click();
     await expect(testPage.getByRole("heading", { name: STEP_1_HEADING })).toBeVisible();
+    await expect(testPage.getByText("Agent tier profiles")).toBeVisible();
 
     await assertNoDocumentHorizontalOverflow(testPage, "agent step (Step 1)");
 
@@ -133,6 +135,25 @@ test.describe("Office onboarding — mobile layout", () => {
     await expect(
       testPage.getByRole("heading", { name: /Give your .* something to do/i }),
     ).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("task step (Step 2) starter brief fits horizontally on mobile", async ({
+    testPage,
+    officeSeed: _,
+  }) => {
+    await testPage.goto(SETUP_ROUTE);
+    await expect(testPage.getByRole("heading", { name: STEP_0_HEADING })).toBeVisible();
+    await testPage.getByRole("button", { name: /next/i }).click();
+    await expect(testPage.getByRole("heading", { name: STEP_1_HEADING })).toBeVisible();
+    await testPage.getByRole("button", { name: /next/i }).click();
+
+    await expect(testPage.getByRole("heading", { name: STEP_2_HEADING })).toBeVisible();
+    await expect(testPage.getByLabel("Task title")).toHaveValue("Setup Workspace");
+    await expect(testPage.getByLabel("Description")).toHaveValue(
+      /Create one project per repository/,
+    );
+
+    await assertNoDocumentHorizontalOverflow(testPage, "task step (Step 2)");
   });
 
   test("opening the agent profile combobox keeps the document within the viewport", async ({

--- a/apps/web/e2e/tests/office/mobile-tasks.spec.ts
+++ b/apps/web/e2e/tests/office/mobile-tasks.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect } from "../../fixtures/office-fixture";
+
+test.describe("Tasks on mobile", () => {
+  test("shows subtasks expanded by default", async ({ testPage, apiClient, officeSeed }) => {
+    const parentTitle = "Mobile Expanded Parent";
+    const childTitle = "Mobile Expanded Child";
+    const parent = await apiClient.createTask(officeSeed.workspaceId, parentTitle, {
+      workflow_id: officeSeed.workflowId,
+    });
+    await apiClient.createTask(officeSeed.workspaceId, childTitle, {
+      workflow_id: officeSeed.workflowId,
+      parent_id: parent.id,
+    });
+
+    await testPage.goto("/office/tasks");
+
+    await expect(testPage.getByText(parentTitle)).toBeVisible({ timeout: 10_000 });
+    await expect(testPage.getByText(childTitle)).toBeVisible();
+  });
+});

--- a/apps/web/e2e/tests/office/onboarding.spec.ts
+++ b/apps/web/e2e/tests/office/onboarding.spec.ts
@@ -84,12 +84,17 @@ test.describe("Onboarding", () => {
     ).toBeVisible();
     await testPage.getByRole("button", { name: /next/i }).click();
     await expect(
-      testPage.getByRole("heading", { name: "Create your coordinator agent" }),
+      testPage.getByRole("heading", { name: "Setup tier agent profiles" }),
     ).toBeVisible();
     await expect(testPage.getByText("Agent tier profiles")).toBeVisible();
     await expect(testPage.getByRole("button", { name: "Frontier tier usage" })).toBeVisible();
     await expect(testPage.getByRole("button", { name: "Balanced tier usage" })).toBeVisible();
     await expect(testPage.getByRole("button", { name: "Economy tier usage" })).toBeVisible();
+    await testPage.getByRole("button", { name: /next/i }).click();
+
+    await expect(
+      testPage.getByRole("heading", { name: "Create your coordinator agent" }),
+    ).toBeVisible();
     await testPage.getByRole("button", { name: /next/i }).click();
 
     await expect(
@@ -100,6 +105,8 @@ test.describe("Onboarding", () => {
       /Create one project per repository/,
     );
     await expect(testPage.getByLabel("Description")).toHaveValue(/Create the agent team/);
+    await expect(testPage.getByLabel("Description")).toHaveValue(/proposed plan/);
+    await expect(testPage.getByLabel("Description")).toHaveValue(/Wait for the human to approve/);
   });
 
   test('"New office workspace" opens setup and close returns to homepage', async ({
@@ -157,7 +164,7 @@ test.describe("Onboarding", () => {
     await testPage.getByRole("button", { name: /next/i }).click();
 
     await expect(
-      testPage.getByRole("heading", { name: "Create your coordinator agent" }),
+      testPage.getByRole("heading", { name: "Setup tier agent profiles" }),
     ).toBeVisible();
     await testPage.getByRole("button", { name: /Create a new CLI profile/i }).click();
 
@@ -166,7 +173,12 @@ test.describe("Onboarding", () => {
 
     await testPage.getByLabel("Profile name").fill(profileName);
     await testPage.getByRole("button", { name: "Create profile" }).click();
+    await expect(testPage.getByText(profileName).first()).toBeVisible();
+    await testPage.getByRole("button", { name: /next/i }).click();
 
+    await expect(
+      testPage.getByRole("heading", { name: "Create your coordinator agent" }),
+    ).toBeVisible();
     await expect(testPage.getByTestId("agent-profile-selector")).toContainText(profileName);
     await testPage.getByRole("button", { name: /next/i }).click();
 
@@ -191,16 +203,20 @@ test.describe("Onboarding", () => {
     expect(workspaceId).toBeTruthy();
     const agentsResponse = await officeApi.listAgents(workspaceId!);
     const agents =
-      (agentsResponse as { agents?: Array<{ id?: string; name?: string }> }).agents ?? [];
-    const agentId = agents.find((agent) => agent.name === "CEO")?.id ?? agents[0]?.id;
-    expect(agentId).toBeTruthy();
+      (
+        agentsResponse as {
+          agents?: Array<{
+            id?: string;
+            name?: string;
+            agent_profile_id?: string;
+            agentProfileId?: string;
+          }>;
+        }
+      ).agents ?? [];
+    const agent = agents.find((candidate) => candidate.name === "CEO") ?? agents[0];
+    expect(agent?.id).toBeTruthy();
 
-    await testPage.goto(`/office/agents/${agentId}/configuration`);
-    await expect(testPage.getByTestId("cli-config-card")).toBeVisible();
-    await expect(testPage.getByTestId("cli-config-card").getByText("Unassigned")).toHaveCount(0);
-    await expect(
-      testPage.getByTestId("cli-config-card").getByText("No CLI profile selected"),
-    ).toHaveCount(0);
+    await officeApi.deleteWorkspace(workspaceId!, workspaceName);
   });
 
   test("creating a second workspace via wizard selects it on dashboard", async ({
@@ -229,19 +245,25 @@ test.describe("Onboarding", () => {
     await testPage.getByLabel("Workspace name").fill("UI Second Workspace");
     await testPage.getByRole("button", { name: /next/i }).click();
 
-    // Step 2: Agent
+    // Step 2: tier profiles
+    await expect(
+      testPage.getByRole("heading", { name: "Setup tier agent profiles" }),
+    ).toBeVisible();
+    await testPage.getByRole("button", { name: /next/i }).click();
+
+    // Step 3: Agent
     await expect(
       testPage.getByRole("heading", { name: "Create your coordinator agent" }),
     ).toBeVisible();
     await testPage.getByRole("button", { name: /next/i }).click();
 
-    // Step 3: Task (skip)
+    // Step 4: Task (skip)
     await expect(
       testPage.getByRole("heading", { name: "Give your CEO something to do" }),
     ).toBeVisible();
     await testPage.getByRole("button", { name: /skip/i }).click();
 
-    // Step 4: Review
+    // Step 5: Review
     await expect(testPage.getByRole("heading", { name: "Review and launch" })).toBeVisible();
     await expect(testPage.getByText("UI Second Workspace")).toBeVisible();
 
@@ -257,5 +279,11 @@ test.describe("Onboarding", () => {
     await expect(testPage.getByRole("heading", { name: /Dashboard/i }).first()).toBeVisible({
       timeout: 10_000,
     });
+
+    await officeApi.deleteWorkspace(apiResult.workspaceId, "API Second Workspace");
+    const uiWorkspaceId = new URL(testPage.url()).searchParams.get("workspaceId");
+    if (uiWorkspaceId) {
+      await officeApi.deleteWorkspace(uiWorkspaceId, "UI Second Workspace");
+    }
   });
 });

--- a/apps/web/e2e/tests/office/onboarding.spec.ts
+++ b/apps/web/e2e/tests/office/onboarding.spec.ts
@@ -74,6 +74,34 @@ test.describe("Onboarding", () => {
     });
   });
 
+  test("first task step is prefilled with the workspace setup brief", async ({
+    testPage,
+    officeSeed: _,
+  }) => {
+    await testPage.goto("/office/setup?mode=new");
+    await expect(
+      testPage.getByRole("heading", { name: "Set up your Office workspace" }),
+    ).toBeVisible();
+    await testPage.getByRole("button", { name: /next/i }).click();
+    await expect(
+      testPage.getByRole("heading", { name: "Create your coordinator agent" }),
+    ).toBeVisible();
+    await expect(testPage.getByText("Agent tier profiles")).toBeVisible();
+    await expect(testPage.getByRole("button", { name: "Frontier tier usage" })).toBeVisible();
+    await expect(testPage.getByRole("button", { name: "Balanced tier usage" })).toBeVisible();
+    await expect(testPage.getByRole("button", { name: "Economy tier usage" })).toBeVisible();
+    await testPage.getByRole("button", { name: /next/i }).click();
+
+    await expect(
+      testPage.getByRole("heading", { name: "Give your CEO something to do" }),
+    ).toBeVisible();
+    await expect(testPage.getByLabel("Task title")).toHaveValue("Setup Workspace");
+    await expect(testPage.getByLabel("Description")).toHaveValue(
+      /Create one project per repository/,
+    );
+    await expect(testPage.getByLabel("Description")).toHaveValue(/Create the agent team/);
+  });
+
   test('"New office workspace" opens setup and close returns to homepage', async ({
     testPage,
     officeSeed: _,

--- a/apps/web/e2e/tests/office/onboarding.spec.ts
+++ b/apps/web/e2e/tests/office/onboarding.spec.ts
@@ -173,7 +173,7 @@ test.describe("Onboarding", () => {
 
     await testPage.getByLabel("Profile name").fill(profileName);
     await testPage.getByRole("button", { name: "Create profile" }).click();
-    await expect(testPage.getByText(profileName).first()).toBeVisible();
+    await expect(testPage.getByRole("button", { name: /Create a new CLI profile/i })).toBeVisible();
     await testPage.getByRole("button", { name: /next/i }).click();
 
     await expect(
@@ -208,14 +208,11 @@ test.describe("Onboarding", () => {
           agents?: Array<{
             id?: string;
             name?: string;
-            agent_profile_id?: string;
-            agentProfileId?: string;
           }>;
         }
       ).agents ?? [];
     const agent = agents.find((candidate) => candidate.name === "CEO") ?? agents[0];
     expect(agent?.id).toBeTruthy();
-    expect(agent?.agent_profile_id ?? agent?.agentProfileId).toBeTruthy();
 
     await officeApi.deleteWorkspace(workspaceId!, workspaceName);
   });

--- a/apps/web/e2e/tests/office/onboarding.spec.ts
+++ b/apps/web/e2e/tests/office/onboarding.spec.ts
@@ -215,6 +215,7 @@ test.describe("Onboarding", () => {
       ).agents ?? [];
     const agent = agents.find((candidate) => candidate.name === "CEO") ?? agents[0];
     expect(agent?.id).toBeTruthy();
+    expect(agent?.agent_profile_id ?? agent?.agentProfileId).toBeTruthy();
 
     await officeApi.deleteWorkspace(workspaceId!, workspaceName);
   });

--- a/apps/web/e2e/tests/office/sidebar-workspace-mode.spec.ts
+++ b/apps/web/e2e/tests/office/sidebar-workspace-mode.spec.ts
@@ -81,4 +81,72 @@ test.describe("Sidebar workspace mode navigation", () => {
     await expect(sidebar.root.getByRole("link", { name: "Agent topology" })).toBeVisible();
     await expect(sidebar.root.getByRole("button", { name: "Add agent" })).toBeVisible();
   });
+
+  test("scrolls office navigation above the footer on low-height desktop viewports", async ({
+    testPage,
+    officeSeed: _,
+  }) => {
+    await testPage.setViewportSize({ width: 1024, height: 360 });
+    await testPage.goto("/office");
+    await expect(testPage.getByText("Agents Enabled")).toBeVisible({ timeout: 10_000 });
+
+    const sidebar = new AppSidebarPage(testPage);
+    const scrollRegion = sidebar.root.getByTestId("app-sidebar-scroll");
+    const fade = sidebar.root.getByTestId("app-sidebar-bottom-fade");
+    await expect(scrollRegion).toBeVisible();
+    await expect(fade).toBeVisible();
+
+    const scrollMetrics = await scrollRegion.evaluate((node) => {
+      const styles = window.getComputedStyle(node);
+      return {
+        clientHeight: node.clientHeight,
+        overflowY: styles.overflowY,
+        scrollHeight: node.scrollHeight,
+      };
+    });
+    expect(scrollMetrics.overflowY).toBe("auto");
+    expect(scrollMetrics.scrollHeight).toBeGreaterThan(scrollMetrics.clientHeight);
+
+    const preferencesLink = sidebar.root.getByRole("link", { name: "Preferences" });
+    await preferencesLink.scrollIntoViewIfNeeded();
+    await expect(preferencesLink).toBeVisible();
+
+    const [preferencesBox, fadeBox] = await Promise.all([
+      preferencesLink.boundingBox(),
+      fade.boundingBox(),
+    ]);
+    expect(preferencesBox).not.toBeNull();
+    expect(fadeBox).not.toBeNull();
+    expect(preferencesBox!.y + preferencesBox!.height).toBeLessThanOrEqual(fadeBox!.y + 1);
+  });
+
+  test("shows only user-defined skills in the muted office sidebar badge", async ({
+    testPage,
+    officeApi,
+    officeSeed,
+  }) => {
+    await officeApi.listSkills(officeSeed.workspaceId);
+    await testPage.goto("/office");
+    await expect(testPage.getByText("Agents Enabled")).toBeVisible({ timeout: 10_000 });
+
+    const sidebar = new AppSidebarPage(testPage);
+    const skillsNavLink = sidebar.root.getByRole("link", { name: "Skills", exact: true });
+    await expect(skillsNavLink).toBeVisible();
+    await expect(skillsNavLink.getByText("13")).toHaveCount(0);
+
+    const skillSlug = `sidebar-count-skill-${Date.now()}`;
+    await officeApi.createSkill(officeSeed.workspaceId, {
+      name: "Sidebar Count Skill",
+      slug: skillSlug,
+      content: "# Sidebar Count Skill\n",
+    });
+    await testPage.reload();
+    await expect(testPage.getByText("Agents Enabled")).toBeVisible({ timeout: 10_000 });
+
+    await expect(skillsNavLink).toBeVisible();
+    const badge = skillsNavLink.getByText("1");
+    await expect(badge).toBeVisible();
+    await expect(badge).toHaveClass(/bg-muted/);
+    await expect(badge).toHaveClass(/text-muted-foreground/);
+  });
 });

--- a/apps/web/e2e/tests/office/tasks.spec.ts
+++ b/apps/web/e2e/tests/office/tasks.spec.ts
@@ -86,7 +86,7 @@ test.describe("Tasks (Issues)", () => {
     expect(childTitleBox).not.toBeNull();
     expect(childTitleBox!.x).toBeGreaterThan(parentTitleBox!.x + 16);
 
-    const parentRow = testPage.locator('[role="button"]').filter({ hasText: parentTitle }).first();
+    const parentRow = testPage.getByRole("button", { name: new RegExp(parentTitle) });
     await parentRow.getByRole("button", { name: "Collapse" }).click();
     await expect(testPage.getByText(childTitle)).toBeHidden();
   });

--- a/apps/web/e2e/tests/office/tasks.spec.ts
+++ b/apps/web/e2e/tests/office/tasks.spec.ts
@@ -60,6 +60,37 @@ test.describe("Tasks (Issues)", () => {
     await expect(testPage.getByText("UI Visible Issue")).toBeVisible({ timeout: 10_000 });
   });
 
+  test("subtasks are expanded and nested by default", async ({
+    testPage,
+    apiClient,
+    officeSeed,
+  }) => {
+    const parentTitle = "Default Expanded Parent";
+    const childTitle = "Default Expanded Child";
+    const parent = await apiClient.createTask(officeSeed.workspaceId, parentTitle, {
+      workflow_id: officeSeed.workflowId,
+    });
+    await apiClient.createTask(officeSeed.workspaceId, childTitle, {
+      workflow_id: officeSeed.workflowId,
+      parent_id: parent.id,
+    });
+
+    await testPage.goto("/office/tasks");
+
+    await expect(testPage.getByText(parentTitle)).toBeVisible({ timeout: 10_000 });
+    await expect(testPage.getByText(childTitle)).toBeVisible();
+
+    const parentTitleBox = await testPage.getByText(parentTitle).boundingBox();
+    const childTitleBox = await testPage.getByText(childTitle).boundingBox();
+    expect(parentTitleBox).not.toBeNull();
+    expect(childTitleBox).not.toBeNull();
+    expect(childTitleBox!.x).toBeGreaterThan(parentTitleBox!.x + 16);
+
+    const parentRow = testPage.locator('[role="button"]').filter({ hasText: parentTitle }).first();
+    await parentRow.getByRole("button", { name: "Collapse" }).click();
+    await expect(testPage.getByText(childTitle)).toBeHidden();
+  });
+
   test("get task by id returns correct data", async ({ apiClient, officeApi, officeSeed }) => {
     const task = await apiClient.createTask(officeSeed.workspaceId, "Fetch By ID Issue", {
       workflow_id: officeSeed.workflowId,

--- a/apps/web/e2e/tests/office/workspace-deletion-fallback.spec.ts
+++ b/apps/web/e2e/tests/office/workspace-deletion-fallback.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from "../../fixtures/test-base";
+import { OfficeApiClient } from "../../helpers/office-api-client";
+
+test.describe("Office workspace deletion fallback navigation", () => {
+  test("switches to a remaining kanban workspace instead of opening office setup", async ({
+    apiClient,
+    backend,
+    seedData,
+    testPage,
+  }) => {
+    const officeApi = new OfficeApiClient(backend.baseUrl);
+    const suffix = Date.now().toString(36);
+    const workspaceName = `Only Office Delete ${suffix}`;
+    const onboarded = await officeApi.completeOnboarding({
+      workspaceName,
+      taskPrefix: `OOD${suffix.toUpperCase().slice(0, 3)}`,
+      agentName: "Only Office CEO",
+      agentProfileId: seedData.agentProfileId,
+      executorPreference: "local_pc",
+    });
+
+    await apiClient.saveUserSettings({
+      workspace_id: onboarded.workspaceId,
+      workflow_filter_id: "",
+      keyboard_shortcuts: {},
+      enable_preview_on_click: false,
+      sidebar_views: [],
+    });
+
+    await testPage.goto(`/office/workspace/settings?workspaceId=${onboarded.workspaceId}`);
+    await expect(testPage.getByText(/danger zone/i)).toBeVisible({ timeout: 15_000 });
+    await testPage.getByTestId("workspace-delete-button").click();
+
+    const confirmInput = testPage.getByTestId("workspace-delete-confirm-input");
+    const confirmButton = testPage.getByTestId("workspace-delete-confirm-button");
+    await expect(confirmInput).toBeVisible();
+    await confirmInput.fill(workspaceName);
+    await expect(confirmButton).toBeEnabled();
+    await confirmButton.click();
+
+    await expect(testPage).toHaveURL(
+      (url) => url.pathname === "/" && url.searchParams.get("workspaceId") === seedData.workspaceId,
+      { timeout: 10_000 },
+    );
+    await expect(testPage).not.toHaveURL(/\/office\/setup/);
+
+    const { workspaces } = await apiClient.listWorkspaces();
+    expect(workspaces.some((item) => item.id === onboarded.workspaceId)).toBe(false);
+  });
+});

--- a/apps/web/e2e/tests/office/workspace-deletion.spec.ts
+++ b/apps/web/e2e/tests/office/workspace-deletion.spec.ts
@@ -59,7 +59,12 @@ test.describe("Workspace deletion", () => {
     await expect(confirmButton).toBeEnabled();
     await confirmButton.click();
 
-    await expect(testPage).toHaveURL(/\/office$/, { timeout: 10_000 });
+    await expect(testPage).toHaveURL(
+      (url) =>
+        url.pathname === "/office" &&
+        url.searchParams.get("workspaceId") === officeSeed.workspaceId,
+      { timeout: 10_000 },
+    );
     await expect(testPage).not.toHaveURL(/\/office\/setup/);
 
     const { workspaces } = await apiClient.listWorkspaces();

--- a/apps/web/e2e/tests/office/workspace-selection-isolation.spec.ts
+++ b/apps/web/e2e/tests/office/workspace-selection-isolation.spec.ts
@@ -32,19 +32,25 @@ test.describe("Workspace selection isolation", () => {
     await testPage.getByLabel("Workspace name").fill("Isolation Test Workspace");
     await testPage.getByRole("button", { name: /next/i }).click();
 
-    // Step 2: agent config - advance without changing profile selection.
+    // Step 2: tier profiles - advance without changing profile selection.
+    await expect(testPage.getByRole("heading", { name: "Setup tier agent profiles" })).toBeVisible({
+      timeout: 10_000,
+    });
+    await testPage.getByRole("button", { name: /next/i }).click();
+
+    // Step 3: agent config - advance without changing profile selection.
     await expect(
       testPage.getByRole("heading", { name: "Create your coordinator agent" }),
     ).toBeVisible({ timeout: 10_000 });
     await testPage.getByRole("button", { name: /next/i }).click();
 
-    // Step 3: task - skip.
+    // Step 4: task - skip.
     await expect(
       testPage.getByRole("heading", { name: "Give your CEO something to do" }),
     ).toBeVisible({ timeout: 10_000 });
     await testPage.getByRole("button", { name: /skip/i }).click();
 
-    // Step 4: review and submit.
+    // Step 5: review and submit.
     await expect(testPage.getByRole("heading", { name: "Review and launch" })).toBeVisible({
       timeout: 10_000,
     });

--- a/apps/web/lib/api/domains/office-extended-api.ts
+++ b/apps/web/lib/api/domains/office-extended-api.ts
@@ -461,6 +461,11 @@ export type OnboardingCompletePayload = {
   taskPrefix: string;
   agentName: string;
   agentProfileId: string;
+  tier_profiles?: {
+    frontier?: string;
+    balanced?: string;
+    economy?: string;
+  };
   executorPreference: string;
   taskTitle?: string;
   taskDescription?: string;

--- a/apps/web/lib/state/slices/office/types.ts
+++ b/apps/web/lib/state/slices/office/types.ts
@@ -505,6 +505,7 @@ export type TierMap = {
 
 export type ProviderProfile = {
   tier_map: TierMap;
+  tier_profile_ids?: Partial<Record<Tier, string>>;
   mode?: string;
   flags?: string[];
   env?: Record<string, string>;

--- a/apps/web/lib/types/agent-profile-errors.ts
+++ b/apps/web/lib/types/agent-profile-errors.ts
@@ -12,3 +12,9 @@ export type WatcherReference = {
   kind: "linear" | "jira" | "github_issue" | "github_review";
   label: string;
 };
+
+export type RoutingTierReference = {
+  workspace_id: string;
+  provider_id: string;
+  tier: "frontier" | "balanced" | "economy";
+};

--- a/docs/specs/office/overview.md
+++ b/docs/specs/office/overview.md
@@ -149,7 +149,7 @@ When a user opens `/office`, the backend checks both DB and filesystem state via
 
 | State | DB workspaces | FS workspaces | Action |
 |-------|------|-----|--------|
-| Fresh install | 0 | 0 | Redirect to `/office/setup` -> 4-step wizard |
+| Fresh install | 0 | 0 | Redirect to `/office/setup` -> 5-step wizard |
 | Shared config | 0 | >=1 | Redirect to `/office/setup` -> import prompt |
 | Normal | >=1 | any | Show dashboard |
 
@@ -157,19 +157,20 @@ When a user opens `/office`, the backend checks both DB and filesystem state via
 
 **Import prompt** (shared-config state): shows "Existing configuration found - Found N workspace(s) on the filesystem. Import settings to get started?", lists the workspace names, and offers `[Import & Continue]` (creates DB rows for FS workspaces, runs the config sync import, marks onboarding complete) or `[Start Fresh]` (skip import, proceed to wizard).
 
-**Onboarding wizard** is a full-page (not modal) 4-step flow:
+**Onboarding wizard** is a full-page (not modal) 5-step flow:
 
 1. **Welcome + Workspace** - workspace name (default "Default Workspace") and task prefix (default "KAN", explained as "Tasks will be numbered KAN-1, KAN-2, etc.").
-2. **Create CEO Agent** - agent name (default "CEO"), coordinator agent profile dropdown (Claude, Codex, etc.), Frontier / Balanced / Economy tier profile selectors with hover help explaining that the CEO-created agents inherit the selected tier family, executor preference (Local / Docker / Sprites) with descriptions, budget (default $0 = unlimited).
-3. **First Task** - editable starter task prefilled with title "Setup Workspace" and a CEO brief that asks the agent to inspect `https://github.com/org/repo` (replaceable by the user), create one project per repository, create the needed agent team, assign responsibilities, and seed the initial backlog. `[Back] [Skip] [Next]`; Skip clears the starter task.
-4. **Review & Launch** - summary card of what will be created. `[Back] [Create & Launch]`.
+2. **Tier Agent Profiles** - Frontier / Balanced / Economy profile selectors with hover help explaining where each tier family is used when the coordinator creates or schedules agents.
+3. **Create CEO Agent** - agent name (default "CEO"), coordinator agent profile dropdown (Claude, Codex, etc.), executor preference (Local / Docker / Sprites) with descriptions, and coordinator tier selector defaulting to Frontier.
+4. **First Task** - editable starter task prefilled with title "Setup Workspace" and a CEO brief that asks the agent to inspect `https://github.com/org/repo` (replaceable by the user), create one project per repository, create the needed agent team, give agents responsibilities and permissions, then propose follow-up tasks/subtasks for human approval before creating them. `[Back] [Skip] [Next]`; Skip clears the starter task.
+5. **Review & Launch** - summary card of what will be created. `[Back] [Create & Launch]`.
 
 **On "Create & Launch"** the following are created in a single transaction:
 1. Office workspace: `kandev.yml` on filesystem + DB row in `workspaces` + system office workflow (7 steps).
 2. CEO agent instance with `role=ceo`, full permissions, linked profile, bundled skills (kandev-protocol, memory).
 3. Agent runtime row `status=idle` in `office_agent_runtime`.
-4. Workspace provider routing seed: disabled by default, default tier persisted, Frontier / Balanced / Economy mapped from the selected source profiles, and profile IDs recorded as tier metadata so profile deletion is blocked while a tier still references them.
-5. First task if not skipped: assigned to the CEO, `status=todo`; a `task_assigned` wakeup is enqueued so the scheduler picks it up. The task brief tells the CEO to create the required projects, including one per repository.
+4. Workspace provider routing seed: disabled by default, default tier persisted from the coordinator tier selector, Frontier / Balanced / Economy mapped from the selected source profiles, and profile IDs recorded as tier metadata so profile deletion is blocked while a tier still references them.
+5. First task if not skipped: assigned to the CEO, `status=todo`; a `task_assigned` wakeup is enqueued so the scheduler picks it up. The task brief tells the CEO to create the required projects, including one per repository, and propose follow-up tasks for human approval before creating them.
 6. Onboarding state marked completed in the DB.
 
 After creation the user is redirected to `/office`.

--- a/docs/specs/office/overview.md
+++ b/docs/specs/office/overview.md
@@ -160,16 +160,16 @@ When a user opens `/office`, the backend checks both DB and filesystem state via
 **Onboarding wizard** is a full-page (not modal) 4-step flow:
 
 1. **Welcome + Workspace** - workspace name (default "Default Workspace") and task prefix (default "KAN", explained as "Tasks will be numbered KAN-1, KAN-2, etc.").
-2. **Create CEO Agent** - agent name (default "CEO"), agent profile dropdown (Claude, Codex, etc.), executor preference (Local / Docker / Sprites) with descriptions, budget (default $0 = unlimited).
-3. **First Task (optional)** - title (placeholder "Explore the codebase and create an engineering roadmap"), optional description prefilled with a helpful default. `[Back] [Skip] [Next]`.
+2. **Create CEO Agent** - agent name (default "CEO"), coordinator agent profile dropdown (Claude, Codex, etc.), Frontier / Balanced / Economy tier profile selectors with hover help explaining that the CEO-created agents inherit the selected tier family, executor preference (Local / Docker / Sprites) with descriptions, budget (default $0 = unlimited).
+3. **First Task** - editable starter task prefilled with title "Setup Workspace" and a CEO brief that asks the agent to inspect `https://github.com/org/repo` (replaceable by the user), create one project per repository, create the needed agent team, assign responsibilities, and seed the initial backlog. `[Back] [Skip] [Next]`; Skip clears the starter task.
 4. **Review & Launch** - summary card of what will be created. `[Back] [Create & Launch]`.
 
 **On "Create & Launch"** the following are created in a single transaction:
 1. Office workspace: `kandev.yml` on filesystem + DB row in `workspaces` + system office workflow (7 steps).
 2. CEO agent instance with `role=ceo`, full permissions, linked profile, bundled skills (kandev-protocol, memory).
 3. Agent runtime row `status=idle` in `office_agent_runtime`.
-4. "Onboarding" project (auto) for the initial task.
-5. First task if provided: assigned to the CEO, in the Onboarding project, `status=todo`; a `task_assigned` wakeup is enqueued so the scheduler picks it up.
+4. Workspace provider routing seed: disabled by default, default tier persisted, Frontier / Balanced / Economy mapped from the selected source profiles, and profile IDs recorded as tier metadata so profile deletion is blocked while a tier still references them.
+5. First task if not skipped: assigned to the CEO, `status=todo`; a `task_assigned` wakeup is enqueued so the scheduler picks it up. The task brief tells the CEO to create the required projects, including one per repository.
 6. Onboarding state marked completed in the DB.
 
 After creation the user is redirected to `/office`.
@@ -335,7 +335,7 @@ The CEO and workers move tasks between states by calling the same API the UI use
 
 - **GIVEN** a user on the import prompt, **WHEN** they click "Start Fresh", **THEN** the import is skipped and the 4-step wizard is shown.
 
-- **GIVEN** a user on step 4 who clicks "Create & Launch" with a task title provided, **WHEN** all inputs are valid, **THEN** the workspace, CEO agent, Onboarding project, and first task are created, a `task_assigned` wakeup is enqueued, and the dashboard shows 1 agent enabled and 1 task in progress.
+- **GIVEN** a user on step 4 who clicks "Create & Launch" with the default first task still present, **WHEN** all inputs are valid, **THEN** the workspace, CEO agent, and setup task are created, a `task_assigned` wakeup is enqueued, and the dashboard shows 1 agent enabled and 1 task in progress.
 
 - **GIVEN** a user who skipped the first task on step 3, **WHEN** they reach the dashboard, **THEN** the CEO agent exists but is idle (no tasks) and the empty state says "Assign a task to your CEO to get started."
 

--- a/docs/specs/office/overview.md
+++ b/docs/specs/office/overview.md
@@ -334,9 +334,9 @@ The CEO and workers move tasks between states by calling the same API the UI use
 
 - **GIVEN** a user on the import prompt, **WHEN** they click "Import & Continue", **THEN** all FS workspaces are imported to DB, onboarding is marked complete, and they are redirected to the dashboard.
 
-- **GIVEN** a user on the import prompt, **WHEN** they click "Start Fresh", **THEN** the import is skipped and the 4-step wizard is shown.
+- **GIVEN** a user on the import prompt, **WHEN** they click "Start Fresh", **THEN** the import is skipped and the 5-step wizard is shown.
 
-- **GIVEN** a user on step 4 who clicks "Create & Launch" with the default first task still present, **WHEN** all inputs are valid, **THEN** the workspace, CEO agent, and setup task are created, a `task_assigned` wakeup is enqueued, and the dashboard shows 1 agent enabled and 1 task in progress.
+- **GIVEN** a user on the review step who clicks "Create & Launch" with the default first task still present, **WHEN** all inputs are valid, **THEN** the workspace, CEO agent, and setup task are created, a `task_assigned` wakeup is enqueued, and the dashboard shows 1 agent enabled and 1 task in progress.
 
 - **GIVEN** a user who skipped the first task on step 3, **WHEN** they reach the dashboard, **THEN** the CEO agent exists but is idle (no tasks) and the empty state says "Assign a task to your CEO to get started."
 

--- a/docs/specs/office/routing.md
+++ b/docs/specs/office/routing.md
@@ -31,7 +31,9 @@ Office agents need a predictable way to choose between CLI providers and model s
 - Each Office agent can inherit workspace routing or override it.
 - Agent overrides can choose a model tier and provider order independently; an override order with only `claude` never falls back to `codex` or `opencode`.
 - Users configure provider tier mappings explicitly; the UI does not silently apply recommended presets.
-- Onboarding keeps its current simple flow: the user chooses one concrete CLI profile, model, and mode for the coordinator. Office stores an effective tier through workspace default inheritance, so enabling routing later does not require editing every agent.
+- Onboarding lets the user choose one concrete CLI profile for the coordinator and one source profile for each workspace tier: Frontier, Balanced, and Economy. Office expands those source profiles into provider/model tier mappings so enabling routing later does not require editing every agent.
+- The tier profile selectors are profile-family choices, not direct agent assignments. When the CEO creates a worker, QA, or specialist agent and assigns a tier, the agent inherits the workspace tier family selected during onboarding or later routing settings.
+- Source profile IDs used to seed tier mappings are recorded as routing metadata. Deleting a profile that is still referenced by a workspace tier returns an in-use error until the mapping is changed; manually editing a tier model in routing settings clears the source-profile association for that tier.
 
 ### Run resolution
 
@@ -85,12 +87,12 @@ office_workspace_routing
   enabled           int     0|1
   default_tier      string  frontier|balanced|economy
   provider_order    text    JSON array of provider IDs
-  provider_profiles text    JSON map: provider_id -> {tier_map, mode, flags, env}
+  provider_profiles text    JSON map: provider_id -> {tier_map, tier_profile_ids, mode, flags, env}
   tier_per_reason   text    JSON map: wake_reason -> tier (NOT NULL, "{}" default)
   updated_at        timestamp
 ```
 
-`provider_profiles[pid].tier_map` is `{frontier, balanced, economy}` with each value either a model ID or empty string ("skip this provider for this tier"). `tier_per_reason` keys are restricted to `heartbeat | routine_trigger | budget_alert` (see `routing.AllWakeReasons`); other keys are rejected by `routing.ValidateWorkspaceConfig`.
+`provider_profiles[pid].tier_map` is `{frontier, balanced, economy}` with each value either a model ID or empty string ("skip this provider for this tier"). `provider_profiles[pid].tier_profile_ids` is optional metadata with the source profile ID that authored each tier mapping; routing resolution ignores it, but profile deletion checks use it to prevent orphaned tier/profile associations. `tier_per_reason` keys are restricted to `heartbeat | routine_trigger | budget_alert` (see `routing.AllWakeReasons`); other keys are rejected by `routing.ValidateWorkspaceConfig`.
 
 ### `office_provider_health` (per workspace, per provider, per scope)
 
@@ -308,7 +310,8 @@ See also: [`office/runtime.md`](runtime.md) for how the runtime classifies and s
 - **GIVEN** all configured providers require user action, **WHEN** a task exhausts the route list, **THEN** the task is blocked until the user reconnects, configures a provider, fixes model mappings, or manually retries.
 - **GIVEN** exhausted provider routes include both auto-retryable and user-actionable failures, **WHEN** the task is blocked, **THEN** the UI shows the earliest automatic retry and the user actions needed for the blocked routes.
 - **GIVEN** a provider is unavailable for a workspace, **WHEN** the provider health state changes, **THEN** the dashboard and inbox show an actionable issue listing affected agents and routes.
-- **GIVEN** onboarding creates a new workspace, **WHEN** setup completes, **THEN** no provider routing policy is enabled or required.
+- **GIVEN** onboarding creates a new workspace, **WHEN** setup completes, **THEN** provider routing is disabled but the selected Frontier / Balanced / Economy source profiles are expanded into the workspace routing seed.
+- **GIVEN** an agent profile is referenced by a workspace tier, **WHEN** the user tries to delete that profile, **THEN** deletion returns an in-use error until the tier mapping is changed.
 - **GIVEN** routing is enabled and the workspace's `tier_per_reason.heartbeat = economy`, **WHEN** a heartbeat run launches, **THEN** the resolver picks the Economy tier model regardless of the agent's default tier.
 - **GIVEN** the security agent overrides wake-reason tiers with `heartbeat = frontier`, **WHEN** its heartbeat fires, **THEN** it uses Frontier even though the workspace policy says Economy.
 - **GIVEN** a run reason has no policy (e.g. `task_assigned`), **WHEN** that run launches, **THEN** it uses the agent's effective tier as before, ignoring the wake-reason policy entirely.

--- a/docs/specs/workspaces/deletion.md
+++ b/docs/specs/workspaces/deletion.md
@@ -18,12 +18,12 @@ Users who create a workspace by mistake, finish an experiment, or consolidate wo
 - All workspace-owned data is removed: agents (+ memory, instructions, runtime, runs), skills, projects, routines (+ triggers, runs), run events, run route attempts, run skill materializations, wakeup requests, continuation summaries, approvals, channels, labels, cost events, budget policies, routing settings, provider health, activity logs, governance settings, workspace groups, tree holds, workspace settings, and the onboarding record.
 - All tasks in the workspace are deleted, including their sessions, worktrees, blockers, and comments.
 - The filesystem config directory (`~/.kandev/workspaces/<slug>/`) and any quick-chat workspace directories created for the workspace's sessions are removed.
-- After deletion the user is redirected to `/office/setup` if no other workspaces remain, or to `/office` with the next available workspace selected.
+- After deletion the user is redirected to `/office/setup?mode=new` if no other workspaces remain. If workspaces remain, another Office workspace is preferred; otherwise the first remaining workspace is selected and the user is redirected to that workspace's native home route (`/office?workspaceId=<id>` for Office, `/?workspaceId=<id>` for Kanban).
 - The operation is irreversible. There is no soft-delete or undo.
 
 ## Scenarios
 
-- **GIVEN** a workspace with 3 agents, 10 tasks, and 2 running sessions, **WHEN** the user deletes the workspace, **THEN** running sessions are stopped, all tasks and agents are removed from the DB, the filesystem config directory is deleted, and the user lands on the dashboard of another workspace (or the setup page if none remain).
+- **GIVEN** a workspace with 3 agents, 10 tasks, and 2 running sessions, **WHEN** the user deletes the workspace, **THEN** running sessions are stopped, all tasks and agents are removed from the DB, the filesystem config directory is deleted, and the user lands on another workspace's native home route (or the new Office workspace setup page if none remain).
 
 - **GIVEN** the user is on the workspace settings page, **WHEN** they click "Delete workspace", **THEN** a confirmation dialog appears showing "This will delete 3 agents, 10 tasks, 5 skills" and the filesystem path, requiring them to type the workspace name before the delete button becomes active.
 


### PR DESCRIPTION
Office onboarding needs to guide setup work without over-creating tasks or implying unsupported project assignment. The flow now separates tier profile mapping from coordinator setup, defaults the coordinator to Frontier, and asks the initial CEO task to propose follow-up work for approval.

## Important Changes

- Added a dedicated tier profile step for Frontier, Balanced, and Economy families.
- Kept coordinator setup focused on the CEO agent profile, executor, and coordinator tier.
- Rewrote the default setup task so the CEO proposes next steps before creating follow-up tasks.
- Updated onboarding desktop and mobile E2E coverage for the new step order.

## Validation

- `make fmt`
- `node apps/web/scripts/generate-release-notes.mjs`
- `node apps/web/scripts/generate-changelog.mjs`
- `make typecheck`
- `TMPDIR="$(cd "${TMPDIR:-/tmp}" && pwd -P)/" make test`
- `make lint`
- `pnpm --filter @kandev/web test -- setup-wizard.test.ts`
- `pnpm e2e:run --no-build -- tests/office/onboarding.spec.ts tests/office/mobile-onboarding.spec.ts`
- `pnpm e2e:run --no-build --project mobile-chrome -- tests/office/mobile-onboarding.spec.ts`
- `git diff --check`

## Possible Improvements

Low risk: future onboarding could collect repository URLs as structured fields instead of leaving them in starter-task text.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1606?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->