### PR TITLE
feat: add workflow WIP pull system

### DIFF
--- a/apps/backend/internal/mcp/handlers/config_handlers_test.go
+++ b/apps/backend/internal/mcp/handlers/config_handlers_test.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
@@ -616,6 +617,21 @@ func TestHandleMoveTask_ActiveSessionWithoutPrompt_DefersMove(t *testing.T) {
 	task, err := svc.GetTask(ctx, "task-move")
 	require.NoError(t, err)
 	assert.Equal(t, "step-work", task.WorkflowStepID, "deferred move must not apply immediately")
+}
+
+func TestMoveTaskErrorMessage_SanitizesClassifiedErrors(t *testing.T) {
+	assert.Equal(t,
+		"Move task conflicts with the current task or workflow state",
+		moveTaskErrorMessage(fmt.Errorf("WIP limit exceeded for workflow step secret-step")),
+	)
+	assert.Equal(t,
+		"Invalid move_task request",
+		moveTaskErrorMessage(fmt.Errorf("workflow_step_id is required")),
+	)
+	assert.Equal(t,
+		"Failed to move task",
+		moveTaskErrorMessage(fmt.Errorf("database path /tmp/private failed")),
+	)
 }
 
 func TestNormalizeTaskState_AcceptsCommonAliases(t *testing.T) {

--- a/apps/backend/internal/mcp/handlers/config_task_handlers.go
+++ b/apps/backend/internal/mcp/handlers/config_task_handlers.go
@@ -148,7 +148,7 @@ func (h *Handlers) applyMoveTaskImmediate(
 			}
 		}
 		h.logger.Error("failed to move task", zap.Error(err))
-		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError, "Failed to move task", nil)
+		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError, err.Error(), nil)
 	}
 	return ws.NewResponse(msg.ID, msg.Action, dto.FromTask(result.Task))
 }

--- a/apps/backend/internal/mcp/handlers/config_task_handlers.go
+++ b/apps/backend/internal/mcp/handlers/config_task_handlers.go
@@ -148,9 +148,36 @@ func (h *Handlers) applyMoveTaskImmediate(
 			}
 		}
 		h.logger.Error("failed to move task", zap.Error(err))
-		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError, err.Error(), nil)
+		return ws.NewError(msg.ID, msg.Action, classifyMoveTaskError(err), moveTaskErrorMessage(err), nil)
 	}
 	return ws.NewResponse(msg.ID, msg.Action, dto.FromTask(result.Task))
+}
+
+func classifyMoveTaskError(err error) string {
+	if err == nil {
+		return ws.ErrorCodeInternalError
+	}
+	msg := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(msg, "wip limit exceeded"),
+		strings.Contains(msg, "active session"),
+		strings.Contains(msg, "archived tasks cannot be moved"),
+		strings.Contains(msg, "different workspace"),
+		strings.Contains(msg, "does not belong to target workflow"):
+		return ws.ErrorCodeConflict
+	case strings.Contains(msg, "invalid"),
+		strings.Contains(msg, "required"):
+		return ws.ErrorCodeValidation
+	default:
+		return ws.ErrorCodeInternalError
+	}
+}
+
+func moveTaskErrorMessage(err error) string {
+	if classifyMoveTaskError(err) == ws.ErrorCodeInternalError {
+		return "Failed to move task"
+	}
+	return err.Error()
 }
 
 // synthesizeMovedTaskDTO returns a task DTO with the post-move step/workflow

--- a/apps/backend/internal/mcp/handlers/config_task_handlers.go
+++ b/apps/backend/internal/mcp/handlers/config_task_handlers.go
@@ -174,10 +174,14 @@ func classifyMoveTaskError(err error) string {
 }
 
 func moveTaskErrorMessage(err error) string {
-	if classifyMoveTaskError(err) == ws.ErrorCodeInternalError {
+	switch classifyMoveTaskError(err) {
+	case ws.ErrorCodeConflict:
+		return "Move task conflicts with the current task or workflow state"
+	case ws.ErrorCodeValidation:
+		return "Invalid move_task request"
+	default:
 		return "Failed to move task"
 	}
-	return err.Error()
 }
 
 // synthesizeMovedTaskDTO returns a task DTO with the post-move step/workflow

--- a/apps/backend/internal/mcp/handlers/config_workflow_handlers.go
+++ b/apps/backend/internal/mcp/handlers/config_workflow_handlers.go
@@ -140,6 +140,8 @@ func (h *Handlers) handleCreateWorkflowStep(ctx context.Context, msg *ws.Message
 		AllowManualMove           *bool                `json:"allow_manual_move"`
 		ShowInCommandPanel        *bool                `json:"show_in_command_panel"`
 		AutoAdvanceRequiresSignal *bool                `json:"auto_advance_requires_signal"`
+		WIPLimit                  *int                 `json:"wip_limit"`
+		PullFromStepID            *string              `json:"pull_from_step_id"`
 		Events                    *wfmodels.StepEvents `json:"events"`
 	}
 	if err := json.Unmarshal(msg.Payload, &req); err != nil {
@@ -161,6 +163,8 @@ func (h *Handlers) handleCreateWorkflowStep(ctx context.Context, msg *ws.Message
 		IsStartStep:               req.IsStartStep,
 		ShowInCommandPanel:        req.ShowInCommandPanel,
 		AutoAdvanceRequiresSignal: req.AutoAdvanceRequiresSignal,
+		WIPLimit:                  req.WIPLimit,
+		PullFromStepID:            req.PullFromStepID,
 		Events:                    req.Events,
 	}
 	if req.AllowManualMove != nil {
@@ -188,6 +192,8 @@ func (h *Handlers) handleUpdateWorkflowStep(ctx context.Context, msg *ws.Message
 		ShowInCommandPanel        *bool                `json:"show_in_command_panel"`
 		AutoArchiveAfterHours     *int                 `json:"auto_archive_after_hours"`
 		AutoAdvanceRequiresSignal *bool                `json:"auto_advance_requires_signal"`
+		WIPLimit                  *int                 `json:"wip_limit"`
+		PullFromStepID            *string              `json:"pull_from_step_id"`
 		Events                    *wfmodels.StepEvents `json:"events"`
 	}
 	if err := json.Unmarshal(msg.Payload, &req); err != nil {
@@ -207,6 +213,8 @@ func (h *Handlers) handleUpdateWorkflowStep(ctx context.Context, msg *ws.Message
 		ShowInCommandPanel:        req.ShowInCommandPanel,
 		AutoArchiveAfterHours:     req.AutoArchiveAfterHours,
 		AutoAdvanceRequiresSignal: req.AutoAdvanceRequiresSignal,
+		WIPLimit:                  req.WIPLimit,
+		PullFromStepID:            req.PullFromStepID,
 		Events:                    req.Events,
 	}
 

--- a/apps/backend/internal/mcp/handlers/config_workflow_handlers.go
+++ b/apps/backend/internal/mcp/handlers/config_workflow_handlers.go
@@ -293,6 +293,8 @@ func (h *Handlers) publishWorkflowStepEvent(ctx context.Context, eventType strin
 			"allow_manual_move":            step.AllowManualMove,
 			"is_start_step":                step.IsStartStep,
 			"auto_archive_after_hours":     step.AutoArchiveAfterHours,
+			"wip_limit":                    step.WIPLimit,
+			"pull_from_step_id":            step.PullFromStepID,
 			"agent_profile_id":             step.AgentProfileID,
 			"stage_type":                   string(step.StageType),
 			"auto_advance_requires_signal": step.AutoAdvanceRequiresSignal,

--- a/apps/backend/internal/mcp/server/config_handlers.go
+++ b/apps/backend/internal/mcp/server/config_handlers.go
@@ -89,6 +89,8 @@ func (s *Server) registerConfigWorkflowStepTools() {
 			mcp.WithBoolean("allow_manual_move", mcp.Description("Allow manual task moves into this step (default: false)")),
 			mcp.WithBoolean("show_in_command_panel", mcp.Description("Show this step in the command panel")),
 			mcp.WithBoolean("auto_advance_requires_signal", mcp.Description("Require step_complete_kandev before on_turn_complete auto-advance transitions run")),
+			mcp.WithNumber("wip_limit", mcp.Description("Work-in-progress limit for this step. 0 means unlimited.")),
+			mcp.WithString("pull_from_step_id", mcp.Description("Optional feeder workflow step ID to pull from when capacity opens.")),
 			mcp.WithObject("events", mcp.Description("Event-driven actions. Keys: on_enter, on_exit, on_turn_start, on_turn_complete. Each is an array of {type, config} objects.")),
 		),
 		s.wrapHandler("create_workflow_step_kandev", s.createWorkflowStepHandler()),
@@ -105,6 +107,8 @@ func (s *Server) registerConfigWorkflowStepTools() {
 			mcp.WithBoolean("show_in_command_panel", mcp.Description("Show this step in the command panel")),
 			mcp.WithNumber("auto_archive_after_hours", mcp.Description("Auto-archive tasks after N hours in this step (0 to disable)")),
 			mcp.WithBoolean("auto_advance_requires_signal", mcp.Description("Require step_complete_kandev before on_turn_complete auto-advance transitions run")),
+			mcp.WithNumber("wip_limit", mcp.Description("Work-in-progress limit for this step. 0 means unlimited.")),
+			mcp.WithString("pull_from_step_id", mcp.Description("Optional feeder workflow step ID to pull from when capacity opens.")),
 			mcp.WithObject("events", mcp.Description("Event-driven actions. Keys: on_enter, on_exit, on_turn_start, on_turn_complete.")),
 		),
 		s.wrapHandler("update_workflow_step_kandev", s.updateWorkflowStepHandler()),
@@ -399,7 +403,7 @@ func (s *Server) createWorkflowStepHandler() server.ToolHandlerFunc {
 			payload["prompt"] = prompt
 		}
 		args := req.GetArguments()
-		for _, key := range []string{"position", "is_start_step", "allow_manual_move", "show_in_command_panel", "auto_advance_requires_signal", "events"} {
+		for _, key := range []string{"position", "is_start_step", "allow_manual_move", "show_in_command_panel", "auto_advance_requires_signal", "wip_limit", "pull_from_step_id", "events"} {
 			if args[key] != nil {
 				payload[key] = args[key]
 			}
@@ -425,7 +429,7 @@ func (s *Server) updateWorkflowStepHandler() server.ToolHandlerFunc {
 			payload["prompt"] = prompt
 		}
 		args := req.GetArguments()
-		for _, key := range []string{"is_start_step", "allow_manual_move", "show_in_command_panel", "auto_archive_after_hours", "auto_advance_requires_signal", "events"} {
+		for _, key := range []string{"is_start_step", "allow_manual_move", "show_in_command_panel", "auto_archive_after_hours", "auto_advance_requires_signal", "wip_limit", "pull_from_step_id", "events"} {
 			if args[key] != nil {
 				payload[key] = args[key]
 			}

--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -224,16 +224,6 @@ func (s *Service) ProcessOnTurnStart(ctx context.Context, taskID, sessionID stri
 // If triggerOnEnter is true, on_enter actions (like auto_start_agent) are processed.
 // If false, only the step change is applied (used for on_turn_start where the user is about to send a message).
 func (s *Service) executeStepTransition(ctx context.Context, taskID, sessionID string, fromStep *wfmodels.WorkflowStep, toStepID string, triggerOnEnter bool) {
-	// Process on_exit actions for the step we're leaving (before the step change).
-	// Freshly load the session since the caller may not have it (legacy path).
-	exitSession, exitErr := s.repo.GetTaskSession(ctx, sessionID)
-	if exitErr != nil {
-		s.logger.Warn("failed to load session for on_exit",
-			zap.String("session_id", sessionID), zap.Error(exitErr))
-	} else {
-		s.processOnExit(ctx, taskID, exitSession, fromStep)
-	}
-
 	// Get the target step
 	targetStep, err := s.workflowStepGetter.GetStep(ctx, toStepID)
 	if err != nil {
@@ -252,6 +242,24 @@ func (s *Service) executeStepTransition(ctx context.Context, taskID, sessionID s
 			zap.Error(err))
 		s.setSessionWaitingForInput(ctx, taskID, sessionID)
 		return
+	}
+	if err := s.validateTransitionWIPLimit(ctx, task, targetStep); err != nil {
+		s.logger.Warn("workflow transition rejected by WIP limit",
+			zap.String("task_id", taskID),
+			zap.String("to_step_id", toStepID),
+			zap.Error(err))
+		s.setSessionWaitingForInput(ctx, taskID, sessionID)
+		return
+	}
+
+	// Process on_exit actions for the step we're leaving (before the step change).
+	// Freshly load the session since the caller may not have it (legacy path).
+	exitSession, exitErr := s.repo.GetTaskSession(ctx, sessionID)
+	if exitErr != nil {
+		s.logger.Warn("failed to load session for on_exit",
+			zap.String("session_id", sessionID), zap.Error(exitErr))
+	} else {
+		s.processOnExit(ctx, taskID, exitSession, fromStep)
 	}
 
 	// Update the task's workflow step
@@ -278,6 +286,10 @@ func (s *Service) executeStepTransition(ctx context.Context, taskID, sessionID s
 		zap.String("from_step", fromStep.Name),
 		zap.String("to_step", targetStep.Name),
 		zap.Bool("trigger_on_enter", triggerOnEnter))
+
+	if s.workflowStore != nil {
+		s.workflowStore.pullNextTaskOnVacate(ctx, fromStep.ID, taskID)
+	}
 
 	if triggerOnEnter {
 		// ADR 0015 — clear any pending completion-signal bag for the
@@ -310,6 +322,24 @@ func (s *Service) executeStepTransition(ctx context.Context, taskID, sessionID s
 		}
 		s.setSessionWaitingForInput(ctx, taskID, effectiveSession.ID)
 	}
+}
+
+func (s *Service) validateTransitionWIPLimit(ctx context.Context, task *models.Task, targetStep *wfmodels.WorkflowStep) error {
+	if targetStep == nil || targetStep.WIPLimit <= 0 || task.WorkflowStepID == targetStep.ID {
+		return nil
+	}
+	limitsRepo, ok := s.repo.(workflowMoveLimitsRepository)
+	if !ok {
+		return fmt.Errorf("WIP limit cannot be checked for workflow step %s", targetStep.ID)
+	}
+	occupants, err := limitsRepo.CountTasksByWorkflowStepExcludingTask(ctx, targetStep.ID, task.ID)
+	if err != nil {
+		return fmt.Errorf("count target workflow step tasks: %w", err)
+	}
+	if occupants >= targetStep.WIPLimit {
+		return fmt.Errorf("WIP limit exceeded for workflow step %s: limit %d already occupied", targetStep.ID, targetStep.WIPLimit)
+	}
+	return nil
 }
 
 // handleTaskMoved handles manual task step changes (drag-and-drop, stepper "Move here").

--- a/apps/backend/internal/orchestrator/service.go
+++ b/apps/backend/internal/orchestrator/service.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/kandev/kandev/internal/agentctl/types/streams"
 	"github.com/kandev/kandev/internal/common/logger"
+	"github.com/kandev/kandev/internal/events"
 	"github.com/kandev/kandev/internal/events/bus"
 	"github.com/kandev/kandev/internal/gitlab"
 	"github.com/kandev/kandev/internal/orchestrator/executor"
@@ -618,6 +619,29 @@ func (s *Service) publishTaskStateChanged(ctx context.Context, task *models.Task
 	s.taskEvents.PublishTaskStateChanged(ctx, task, oldState)
 }
 
+func (s *Service) publishTaskMoved(ctx context.Context, task *models.Task, fromWorkflowID, fromStepID, toStepID, sessionID string) {
+	if s.eventBus == nil || task == nil {
+		return
+	}
+	data := map[string]interface{}{
+		"task_id":                   task.ID,
+		"from_workflow_id":          fromWorkflowID,
+		"to_workflow_id":            task.WorkflowID,
+		"from_step_id":              fromStepID,
+		"to_step_id":                toStepID,
+		"session_id":                sessionID,
+		"workflow_id":               task.WorkflowID,
+		"task_description":          task.Description,
+		"parent_id":                 task.ParentID,
+		"assignee_agent_profile_id": task.AssigneeAgentProfileID,
+	}
+	event := bus.NewEvent(events.TaskMoved, "orchestrator", data)
+	if err := s.eventBus.Publish(ctx, events.TaskMoved, event); err != nil {
+		s.logger.Error("failed to publish pulled task.moved event",
+			zap.String("task_id", task.ID), zap.Error(err))
+	}
+}
+
 // StepRequiresCompletionSignal reports whether the workflow step bound to taskID
 // has `auto_advance_requires_signal = true` (ADR 0015). Used by sysprompt
 // injection sites to decide whether to expose the `step_complete_kandev` MCP
@@ -685,7 +709,7 @@ func (s *Service) initWorkflowEngine() {
 	if s.workflowStepGetter == nil {
 		return
 	}
-	store := newWorkflowStore(s.repo, s.workflowStepGetter, s.agentManager, s.publishTaskUpdated, s.logger)
+	store := newWorkflowStore(s.repo, s.workflowStepGetter, s.agentManager, s.publishTaskUpdated, s.logger, s.publishTaskMoved)
 	callbacks := buildWorkflowCallbacks(s)
 	s.workflowStore = store
 	s.workflowEngine = engine.New(store, callbacks, s.engineOptions...)

--- a/apps/backend/internal/orchestrator/workflow_store.go
+++ b/apps/backend/internal/orchestrator/workflow_store.go
@@ -189,7 +189,7 @@ func (s *workflowStore) pullNextTaskOnVacate(ctx context.Context, vacatedStepID,
 	if vacatedStep == nil {
 		return
 	}
-	limitsRepo, pullRepo, ok := s.pullRepositories(vacatedStep.ID)
+	limitsRepo, pullRepo, limitedRepo, ok := s.pullRepositories(vacatedStep.ID)
 	if !ok {
 		return
 	}
@@ -199,7 +199,7 @@ func (s *workflowStore) pullNextTaskOnVacate(ctx context.Context, vacatedStepID,
 	}
 	skipped := map[string]struct{}{excludeTaskID: {}}
 	for occupants < vacatedStep.WIPLimit {
-		pulled := s.pullOneFeederTask(ctx, pullRepo, vacatedStep, occupants, skipped)
+		pulled := s.pullOneFeederTask(ctx, pullRepo, limitedRepo, vacatedStep, occupants, skipped)
 		if !pulled {
 			return
 		}
@@ -221,20 +221,26 @@ func (s *workflowStore) pullEnabledStep(ctx context.Context, vacatedStepID strin
 	return vacatedStep
 }
 
-func (s *workflowStore) pullRepositories(stepID string) (workflowMoveLimitsRepository, workflowPullRepository, bool) {
+func (s *workflowStore) pullRepositories(stepID string) (workflowMoveLimitsRepository, workflowPullRepository, workflowLimitedMoveRepository, bool) {
 	limitsRepo, ok := s.repo.(workflowMoveLimitsRepository)
 	if !ok {
 		s.logger.Warn("cannot pull feeder task: WIP limit repository unavailable",
 			zap.String("step_id", stepID))
-		return nil, nil, false
+		return nil, nil, nil, false
 	}
 	pullRepo, ok := s.repo.(workflowPullRepository)
 	if !ok {
 		s.logger.Warn("cannot pull feeder task: pull repository unavailable",
 			zap.String("step_id", stepID))
-		return nil, nil, false
+		return nil, nil, nil, false
 	}
-	return limitsRepo, pullRepo, true
+	limitedRepo, ok := s.repo.(workflowLimitedMoveRepository)
+	if !ok {
+		s.logger.Warn("cannot pull feeder task: transactional WIP limit repository unavailable",
+			zap.String("step_id", stepID))
+		return nil, nil, nil, false
+	}
+	return limitsRepo, pullRepo, limitedRepo, true
 }
 
 func (s *workflowStore) currentWIPOccupants(ctx context.Context, limitsRepo workflowMoveLimitsRepository, stepID string) (int, bool) {
@@ -250,6 +256,7 @@ func (s *workflowStore) currentWIPOccupants(ctx context.Context, limitsRepo work
 func (s *workflowStore) pullOneFeederTask(
 	ctx context.Context,
 	pullRepo workflowPullRepository,
+	limitedRepo workflowLimitedMoveRepository,
 	vacatedStep *wfmodels.WorkflowStep,
 	position int,
 	skipped map[string]struct{},
@@ -274,7 +281,7 @@ func (s *workflowStore) pullOneFeederTask(
 		candidate.WorkflowStepID = vacatedStep.ID
 		candidate.Position = position
 		candidate.UpdatedAt = time.Now().UTC()
-		if err := s.repo.UpdateTask(ctx, candidate); err != nil {
+		if err := limitedRepo.UpdateTaskIfWorkflowStepHasCapacity(ctx, candidate, vacatedStep.ID, candidate.ID, vacatedStep.WIPLimit); err != nil {
 			skipped[candidate.ID] = struct{}{}
 			s.logger.Warn("skipping feeder task that could not be pulled",
 				zap.String("task_id", candidate.ID), zap.Error(err))

--- a/apps/backend/internal/orchestrator/workflow_store.go
+++ b/apps/backend/internal/orchestrator/workflow_store.go
@@ -12,12 +12,23 @@ import (
 	"github.com/kandev/kandev/internal/orchestrator/executor"
 	"github.com/kandev/kandev/internal/task/models"
 	"github.com/kandev/kandev/internal/workflow/engine"
+	wfmodels "github.com/kandev/kandev/internal/workflow/models"
 )
 
 // taskUpdatedPublisher is the minimal hook the workflow store needs to emit
 // task.updated events. The orchestrator Service binds this to its shared
 // publishTaskUpdated helper so the publisher wiring stays in one place.
 type taskUpdatedPublisher func(ctx context.Context, task *models.Task)
+
+type taskMovedPublisher func(ctx context.Context, task *models.Task, fromWorkflowID, fromStepID, toStepID, sessionID string)
+
+type workflowMoveLimitsRepository interface {
+	CountTasksByWorkflowStepExcludingTask(ctx context.Context, stepID, excludeTaskID string) (int, error)
+}
+
+type workflowPullRepository interface {
+	NextPullCandidate(ctx context.Context, stepID, excludeTaskID string) (*models.Task, error)
+}
 
 // workflowStore implements engine.TransitionStore by delegating to the
 // orchestrator's existing repositories and services.
@@ -26,6 +37,7 @@ type workflowStore struct {
 	workflowStepGetter WorkflowStepGetter
 	agentManager       executor.AgentManagerClient
 	publishTaskUpdated taskUpdatedPublisher
+	publishTaskMoved   taskMovedPublisher
 	logger             *logger.Logger
 	appliedOps         sync.Map
 }
@@ -36,12 +48,18 @@ func newWorkflowStore(
 	agentMgr executor.AgentManagerClient,
 	publishTaskUpdated taskUpdatedPublisher,
 	log *logger.Logger,
+	publishTaskMoved ...taskMovedPublisher,
 ) *workflowStore {
+	var moved taskMovedPublisher
+	if len(publishTaskMoved) > 0 {
+		moved = publishTaskMoved[0]
+	}
 	return &workflowStore{
 		repo:               repo,
 		workflowStepGetter: stepGetter,
 		agentManager:       agentMgr,
 		publishTaskUpdated: publishTaskUpdated,
+		publishTaskMoved:   moved,
 		logger:             log,
 	}
 }
@@ -100,6 +118,13 @@ func (s *workflowStore) ApplyTransition(ctx context.Context, taskID, sessionID, 
 	if err != nil {
 		return fmt.Errorf("load task for transition: %w", err)
 	}
+	targetStep, err := s.workflowStepGetter.GetStep(ctx, toStepID)
+	if err != nil {
+		return fmt.Errorf("load target step for transition: %w", err)
+	}
+	if err := s.validateWIPLimit(ctx, task, targetStep); err != nil {
+		return err
+	}
 
 	task.WorkflowStepID = toStepID
 	task.UpdatedAt = time.Now().UTC()
@@ -121,7 +146,125 @@ func (s *workflowStore) ApplyTransition(ctx context.Context, taskID, sessionID, 
 		zap.String("from_step_id", fromStepID),
 		zap.String("to_step_id", toStepID))
 
+	s.pullNextTaskOnVacate(ctx, fromStepID, taskID)
+
 	return nil
+}
+
+func (s *workflowStore) validateWIPLimit(ctx context.Context, task *models.Task, targetStep *wfmodels.WorkflowStep) error {
+	if targetStep == nil || targetStep.WIPLimit <= 0 || task.WorkflowStepID == targetStep.ID {
+		return nil
+	}
+	limitsRepo, ok := s.repo.(workflowMoveLimitsRepository)
+	if !ok {
+		return fmt.Errorf("WIP limit cannot be checked for workflow step %s", targetStep.ID)
+	}
+	occupants, err := limitsRepo.CountTasksByWorkflowStepExcludingTask(ctx, targetStep.ID, task.ID)
+	if err != nil {
+		return fmt.Errorf("count target workflow step tasks: %w", err)
+	}
+	if occupants >= targetStep.WIPLimit {
+		return fmt.Errorf("WIP limit exceeded for workflow step %s: limit %d already occupied", targetStep.ID, targetStep.WIPLimit)
+	}
+	return nil
+}
+
+func (s *workflowStore) pullNextTaskOnVacate(ctx context.Context, vacatedStepID, excludeTaskID string) {
+	vacatedStep := s.pullEnabledStep(ctx, vacatedStepID)
+	if vacatedStep == nil {
+		return
+	}
+	limitsRepo, pullRepo, ok := s.pullRepositories(vacatedStep.ID)
+	if !ok {
+		return
+	}
+	occupants, ok := s.currentWIPOccupants(ctx, limitsRepo, vacatedStep.ID)
+	if !ok || occupants >= vacatedStep.WIPLimit {
+		return
+	}
+	for occupants < vacatedStep.WIPLimit {
+		pulled := s.pullOneFeederTask(ctx, pullRepo, vacatedStep, occupants, excludeTaskID)
+		if !pulled {
+			return
+		}
+		occupants++
+	}
+}
+
+func (s *workflowStore) pullEnabledStep(ctx context.Context, vacatedStepID string) *wfmodels.WorkflowStep {
+	if s.workflowStepGetter == nil || s.publishTaskMoved == nil || vacatedStepID == "" {
+		return nil
+	}
+	vacatedStep, err := s.workflowStepGetter.GetStep(ctx, vacatedStepID)
+	if err != nil || vacatedStep == nil || vacatedStep.WIPLimit <= 0 || vacatedStep.PullFromStepID == "" {
+		return nil
+	}
+	if vacatedStep.PullFromStepID == vacatedStep.ID {
+		return nil
+	}
+	return vacatedStep
+}
+
+func (s *workflowStore) pullRepositories(stepID string) (workflowMoveLimitsRepository, workflowPullRepository, bool) {
+	limitsRepo, ok := s.repo.(workflowMoveLimitsRepository)
+	if !ok {
+		s.logger.Warn("cannot pull feeder task: WIP limit repository unavailable",
+			zap.String("step_id", stepID))
+		return nil, nil, false
+	}
+	pullRepo, ok := s.repo.(workflowPullRepository)
+	if !ok {
+		s.logger.Warn("cannot pull feeder task: pull repository unavailable",
+			zap.String("step_id", stepID))
+		return nil, nil, false
+	}
+	return limitsRepo, pullRepo, true
+}
+
+func (s *workflowStore) currentWIPOccupants(ctx context.Context, limitsRepo workflowMoveLimitsRepository, stepID string) (int, bool) {
+	occupants, err := limitsRepo.CountTasksByWorkflowStepExcludingTask(ctx, stepID, "")
+	if err != nil {
+		s.logger.Warn("cannot pull feeder task: failed to count vacated step",
+			zap.String("step_id", stepID), zap.Error(err))
+		return 0, false
+	}
+	return occupants, true
+}
+
+func (s *workflowStore) pullOneFeederTask(
+	ctx context.Context,
+	pullRepo workflowPullRepository,
+	vacatedStep *wfmodels.WorkflowStep,
+	position int,
+	excludeTaskID string,
+) bool {
+	candidate, err := pullRepo.NextPullCandidate(ctx, vacatedStep.PullFromStepID, excludeTaskID)
+	if err != nil {
+		s.logger.Warn("cannot pull feeder task: failed to select candidate",
+			zap.String("step_id", vacatedStep.ID), zap.Error(err))
+		return false
+	}
+	if candidate == nil {
+		return false
+	}
+	fromWorkflowID := candidate.WorkflowID
+	fromStepID := candidate.WorkflowStepID
+	candidate.WorkflowID = vacatedStep.WorkflowID
+	candidate.WorkflowStepID = vacatedStep.ID
+	candidate.Position = position
+	candidate.UpdatedAt = time.Now().UTC()
+	if err := s.repo.UpdateTask(ctx, candidate); err != nil {
+		s.logger.Warn("failed to pull feeder task into vacated WIP-limited step",
+			zap.String("task_id", candidate.ID), zap.Error(err))
+		return false
+	}
+	s.publishTaskUpdated(ctx, candidate)
+	sessionID := ""
+	if session, err := s.repo.GetActiveTaskSessionByTaskID(ctx, candidate.ID); err == nil && session != nil {
+		sessionID = session.ID
+	}
+	s.publishTaskMoved(ctx, candidate, fromWorkflowID, fromStepID, vacatedStep.ID, sessionID)
+	return true
 }
 
 func (s *workflowStore) PersistData(ctx context.Context, sessionID string, data map[string]any) error {

--- a/apps/backend/internal/orchestrator/workflow_store.go
+++ b/apps/backend/internal/orchestrator/workflow_store.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -299,7 +300,15 @@ func (s *workflowStore) pullOneFeederTask(
 
 func (s *workflowStore) feederCandidateBlocked(ctx context.Context, taskID string) bool {
 	session, err := s.repo.GetActiveTaskSessionByTaskID(ctx, taskID)
-	if err != nil || session == nil {
+	if err != nil {
+		if errors.Is(err, models.ErrTaskSessionNotFound) {
+			return false
+		}
+		s.logger.Warn("skipping feeder task after active session lookup failed",
+			zap.String("task_id", taskID), zap.Error(err))
+		return true
+	}
+	if session == nil {
 		return false
 	}
 	return session.State == models.TaskSessionStateStarting ||

--- a/apps/backend/internal/orchestrator/workflow_store.go
+++ b/apps/backend/internal/orchestrator/workflow_store.go
@@ -26,8 +26,12 @@ type workflowMoveLimitsRepository interface {
 	CountTasksByWorkflowStepExcludingTask(ctx context.Context, stepID, excludeTaskID string) (int, error)
 }
 
+type workflowLimitedMoveRepository interface {
+	UpdateTaskIfWorkflowStepHasCapacity(ctx context.Context, task *models.Task, targetStepID, excludeTaskID string, limit int) error
+}
+
 type workflowPullRepository interface {
-	NextPullCandidate(ctx context.Context, stepID, excludeTaskID string) (*models.Task, error)
+	NextPullCandidateExcluding(ctx context.Context, stepID string, excludeTaskIDs []string) (*models.Task, error)
 }
 
 // workflowStore implements engine.TransitionStore by delegating to the
@@ -128,7 +132,7 @@ func (s *workflowStore) ApplyTransition(ctx context.Context, taskID, sessionID, 
 
 	task.WorkflowStepID = toStepID
 	task.UpdatedAt = time.Now().UTC()
-	if err := s.repo.UpdateTask(ctx, task); err != nil {
+	if err := s.updateTransitionTask(ctx, task, targetStep); err != nil {
 		return fmt.Errorf("update task workflow step: %w", err)
 	}
 
@@ -149,6 +153,17 @@ func (s *workflowStore) ApplyTransition(ctx context.Context, taskID, sessionID, 
 	s.pullNextTaskOnVacate(ctx, fromStepID, taskID)
 
 	return nil
+}
+
+func (s *workflowStore) updateTransitionTask(ctx context.Context, task *models.Task, targetStep *wfmodels.WorkflowStep) error {
+	if targetStep == nil || targetStep.WIPLimit <= 0 {
+		return s.repo.UpdateTask(ctx, task)
+	}
+	limitedRepo, ok := s.repo.(workflowLimitedMoveRepository)
+	if !ok {
+		return fmt.Errorf("WIP limit cannot be checked for workflow step %s", targetStep.ID)
+	}
+	return limitedRepo.UpdateTaskIfWorkflowStepHasCapacity(ctx, task, targetStep.ID, task.ID, targetStep.WIPLimit)
 }
 
 func (s *workflowStore) validateWIPLimit(ctx context.Context, task *models.Task, targetStep *wfmodels.WorkflowStep) error {
@@ -182,8 +197,9 @@ func (s *workflowStore) pullNextTaskOnVacate(ctx context.Context, vacatedStepID,
 	if !ok || occupants >= vacatedStep.WIPLimit {
 		return
 	}
+	skipped := map[string]struct{}{excludeTaskID: {}}
 	for occupants < vacatedStep.WIPLimit {
-		pulled := s.pullOneFeederTask(ctx, pullRepo, vacatedStep, occupants, excludeTaskID)
+		pulled := s.pullOneFeederTask(ctx, pullRepo, vacatedStep, occupants, skipped)
 		if !pulled {
 			return
 		}
@@ -236,35 +252,61 @@ func (s *workflowStore) pullOneFeederTask(
 	pullRepo workflowPullRepository,
 	vacatedStep *wfmodels.WorkflowStep,
 	position int,
-	excludeTaskID string,
+	skipped map[string]struct{},
 ) bool {
-	candidate, err := pullRepo.NextPullCandidate(ctx, vacatedStep.PullFromStepID, excludeTaskID)
-	if err != nil {
-		s.logger.Warn("cannot pull feeder task: failed to select candidate",
-			zap.String("step_id", vacatedStep.ID), zap.Error(err))
+	for {
+		candidate, err := pullRepo.NextPullCandidateExcluding(ctx, vacatedStep.PullFromStepID, skippedTaskIDs(skipped))
+		if err != nil {
+			s.logger.Warn("cannot pull feeder task: failed to select candidate",
+				zap.String("step_id", vacatedStep.ID), zap.Error(err))
+			return false
+		}
+		if candidate == nil {
+			return false
+		}
+		if s.feederCandidateBlocked(ctx, candidate.ID) {
+			skipped[candidate.ID] = struct{}{}
+			continue
+		}
+		fromWorkflowID := candidate.WorkflowID
+		fromStepID := candidate.WorkflowStepID
+		candidate.WorkflowID = vacatedStep.WorkflowID
+		candidate.WorkflowStepID = vacatedStep.ID
+		candidate.Position = position
+		candidate.UpdatedAt = time.Now().UTC()
+		if err := s.repo.UpdateTask(ctx, candidate); err != nil {
+			skipped[candidate.ID] = struct{}{}
+			s.logger.Warn("skipping feeder task that could not be pulled",
+				zap.String("task_id", candidate.ID), zap.Error(err))
+			continue
+		}
+		s.publishTaskUpdated(ctx, candidate)
+		sessionID := ""
+		if session, err := s.repo.GetActiveTaskSessionByTaskID(ctx, candidate.ID); err == nil && session != nil {
+			sessionID = session.ID
+		}
+		s.publishTaskMoved(ctx, candidate, fromWorkflowID, fromStepID, vacatedStep.ID, sessionID)
+		return true
+	}
+}
+
+func (s *workflowStore) feederCandidateBlocked(ctx context.Context, taskID string) bool {
+	session, err := s.repo.GetActiveTaskSessionByTaskID(ctx, taskID)
+	if err != nil || session == nil {
 		return false
 	}
-	if candidate == nil {
-		return false
+	return session.State == models.TaskSessionStateStarting ||
+		session.State == models.TaskSessionStateRunning
+}
+
+func skippedTaskIDs(skipped map[string]struct{}) []string {
+	ids := make([]string, 0, len(skipped))
+	for id := range skipped {
+		if id != "" {
+			ids = append(ids, id)
+		}
 	}
-	fromWorkflowID := candidate.WorkflowID
-	fromStepID := candidate.WorkflowStepID
-	candidate.WorkflowID = vacatedStep.WorkflowID
-	candidate.WorkflowStepID = vacatedStep.ID
-	candidate.Position = position
-	candidate.UpdatedAt = time.Now().UTC()
-	if err := s.repo.UpdateTask(ctx, candidate); err != nil {
-		s.logger.Warn("failed to pull feeder task into vacated WIP-limited step",
-			zap.String("task_id", candidate.ID), zap.Error(err))
-		return false
-	}
-	s.publishTaskUpdated(ctx, candidate)
-	sessionID := ""
-	if session, err := s.repo.GetActiveTaskSessionByTaskID(ctx, candidate.ID); err == nil && session != nil {
-		sessionID = session.ID
-	}
-	s.publishTaskMoved(ctx, candidate, fromWorkflowID, fromStepID, vacatedStep.ID, sessionID)
-	return true
+	return ids
 }
 
 func (s *workflowStore) PersistData(ctx context.Context, sessionID string, data map[string]any) error {

--- a/apps/backend/internal/orchestrator/workflow_store_test.go
+++ b/apps/backend/internal/orchestrator/workflow_store_test.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/kandev/kandev/internal/task/models"
@@ -139,6 +140,104 @@ func TestWorkflowStore_ApplyTransition(t *testing.T) {
 	}
 	if session.ReviewStatus != models.ReviewStatusNone {
 		t.Errorf("expected review status to be cleared, got %q", session.ReviewStatus)
+	}
+}
+
+func TestWorkflowStore_ApplyTransitionRejectsFullWIPLimitedTarget(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "t1", "s1", "step1")
+	if err := repo.CreateTask(ctx, &models.Task{
+		ID:             "occupant",
+		WorkspaceID:    "ws1",
+		WorkflowID:     "wf1",
+		WorkflowStepID: "step2",
+		Title:          "Occupant",
+		State:          "TODO",
+		Priority:       "medium",
+	}); err != nil {
+		t.Fatalf("CreateTask occupant: %v", err)
+	}
+
+	stepGetter := newMockStepGetter()
+	stepGetter.steps["step2"] = &wfmodels.WorkflowStep{
+		ID: "step2", WorkflowID: "wf1", Name: "Limited", Position: 1, WIPLimit: 1,
+	}
+	store := newWorkflowStore(repo, stepGetter, nil, noopPublisher, testLogger())
+
+	err := store.ApplyTransition(ctx, "t1", "s1", "step1", "step2", "on_turn_complete")
+	if err == nil {
+		t.Fatalf("expected WIP-limited transition to be rejected")
+	}
+	if !strings.Contains(err.Error(), "WIP limit") {
+		t.Fatalf("error = %q, want WIP limit rejection", err.Error())
+	}
+
+	task, err := repo.GetTask(ctx, "t1")
+	if err != nil {
+		t.Fatalf("failed to get task: %v", err)
+	}
+	if task.WorkflowStepID != "step1" {
+		t.Fatalf("task moved despite WIP limit: %s", task.WorkflowStepID)
+	}
+}
+
+func TestWorkflowStore_ApplyTransitionPullsNextFeederTaskOnVacate(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "t1", "s1", "step-limited")
+	if err := repo.CreateTask(ctx, &models.Task{
+		ID:             "task-low",
+		WorkspaceID:    "ws1",
+		WorkflowID:     "wf1",
+		WorkflowStepID: "step-feeder",
+		Title:          "Low",
+		State:          "TODO",
+		Priority:       "low",
+		Position:       0,
+	}); err != nil {
+		t.Fatalf("CreateTask low: %v", err)
+	}
+	if err := repo.CreateTask(ctx, &models.Task{
+		ID:             "task-critical",
+		WorkspaceID:    "ws1",
+		WorkflowID:     "wf1",
+		WorkflowStepID: "step-feeder",
+		Title:          "Critical",
+		State:          "TODO",
+		Priority:       "critical",
+		Position:       0,
+	}); err != nil {
+		t.Fatalf("CreateTask critical: %v", err)
+	}
+
+	stepGetter := newMockStepGetter()
+	stepGetter.steps["step-limited"] = &wfmodels.WorkflowStep{
+		ID: "step-limited", WorkflowID: "wf1", Name: "Limited", Position: 0,
+		WIPLimit: 1, PullFromStepID: "step-feeder",
+	}
+	stepGetter.steps["step-next"] = &wfmodels.WorkflowStep{
+		ID: "step-next", WorkflowID: "wf1", Name: "Next", Position: 1,
+	}
+	var movedTaskID string
+	store := newWorkflowStore(repo, stepGetter, nil, noopPublisher, testLogger(),
+		func(_ context.Context, task *models.Task, _, _, _, _ string) {
+			movedTaskID = task.ID
+		})
+
+	if err := store.ApplyTransition(ctx, "t1", "s1", "step-limited", "step-next", "on_turn_complete"); err != nil {
+		t.Fatalf("ApplyTransition: %v", err)
+	}
+
+	pulled, err := repo.GetTask(ctx, "task-critical")
+	if err != nil {
+		t.Fatalf("GetTask(task-critical): %v", err)
+	}
+	if pulled.WorkflowStepID != "step-limited" {
+		t.Fatalf("critical feeder task step = %s, want step-limited", pulled.WorkflowStepID)
+	}
+	if movedTaskID != "task-critical" {
+		t.Fatalf("moved event task = %s, want task-critical", movedTaskID)
 	}
 }
 

--- a/apps/backend/internal/task/dto/converters.go
+++ b/apps/backend/internal/task/dto/converters.go
@@ -20,6 +20,8 @@ func FromWorkflowStep(step *wfmodels.WorkflowStep) WorkflowStepDTO {
 		ShowInCommandPanel:    step.ShowInCommandPanel,
 		AutoArchiveAfterHours: step.AutoArchiveAfterHours,
 		AgentProfileID:        step.AgentProfileID,
+		WIPLimit:              step.WIPLimit,
+		PullFromStepID:        step.PullFromStepID,
 		StageType:             string(step.StageType),
 	}
 	if hasStepEvents(step.Events) {

--- a/apps/backend/internal/task/dto/converters_test.go
+++ b/apps/backend/internal/task/dto/converters_test.go
@@ -37,3 +37,22 @@ func TestFromWorkflowStep_PreservesGenericEvents(t *testing.T) {
 		t.Fatalf("action reason = %v, want children_completed", action.Config["reason"])
 	}
 }
+
+func TestFromWorkflowStep_PreservesWIPFields(t *testing.T) {
+	step := &wfmodels.WorkflowStep{
+		ID:             "step-1",
+		WorkflowID:     "wf-1",
+		Name:           "Work",
+		WIPLimit:       3,
+		PullFromStepID: "queue-step",
+	}
+
+	got := FromWorkflowStep(step)
+
+	if got.WIPLimit != 3 {
+		t.Fatalf("WIPLimit = %d, want 3", got.WIPLimit)
+	}
+	if got.PullFromStepID != "queue-step" {
+		t.Fatalf("PullFromStepID = %q, want queue-step", got.PullFromStepID)
+	}
+}

--- a/apps/backend/internal/task/dto/dto.go
+++ b/apps/backend/internal/task/dto/dto.go
@@ -696,6 +696,8 @@ type WorkflowStepDTO struct {
 	ShowInCommandPanel    bool           `json:"show_in_command_panel"`
 	AutoArchiveAfterHours int            `json:"auto_archive_after_hours,omitempty"`
 	AgentProfileID        string         `json:"agent_profile_id,omitempty"`
+	WIPLimit              int            `json:"wip_limit"`
+	PullFromStepID        string         `json:"pull_from_step_id,omitempty"`
 	// StageType is a Phase 2 (ADR-0004) semantic hint for the frontend.
 	// Allowed values: "work" | "review" | "approval" | "custom".
 	StageType string    `json:"stage_type,omitempty"`

--- a/apps/backend/internal/task/handlers/errors.go
+++ b/apps/backend/internal/task/handlers/errors.go
@@ -64,7 +64,8 @@ func isMoveConflict(err error) bool {
 	return strings.Contains(msg, "active session") ||
 		strings.Contains(msg, "archived tasks cannot be moved") ||
 		strings.Contains(msg, "different workspace") ||
-		strings.Contains(msg, "does not belong to target workflow")
+		strings.Contains(msg, "does not belong to target workflow") ||
+		strings.Contains(msg, "wip limit")
 }
 
 func isValidationError(err error) bool {

--- a/apps/backend/internal/task/handlers/errors.go
+++ b/apps/backend/internal/task/handlers/errors.go
@@ -65,7 +65,7 @@ func isMoveConflict(err error) bool {
 		strings.Contains(msg, "archived tasks cannot be moved") ||
 		strings.Contains(msg, "different workspace") ||
 		strings.Contains(msg, "does not belong to target workflow") ||
-		strings.Contains(msg, "wip limit")
+		strings.Contains(msg, "wip limit exceeded")
 }
 
 func isValidationError(err error) bool {

--- a/apps/backend/internal/task/repository/sqlite/task.go
+++ b/apps/backend/internal/task/repository/sqlite/task.go
@@ -337,6 +337,53 @@ func (r *Repository) CountTasksByWorkflowStep(ctx context.Context, stepID string
 	return count, nil
 }
 
+// CountTasksByWorkflowStepExcludingTask returns active, visible occupants in
+// a workflow step, excluding the task currently being moved.
+func (r *Repository) CountTasksByWorkflowStepExcludingTask(ctx context.Context, stepID, excludeTaskID string) (int, error) {
+	var count int
+	err := r.ro.QueryRowContext(ctx, r.ro.Rebind(`
+		SELECT COUNT(*) FROM tasks
+		WHERE workflow_step_id = ?
+		  AND id != ?
+		  AND archived_at IS NULL
+		  AND is_ephemeral = 0
+	`), stepID, excludeTaskID).Scan(&count)
+	if err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
+// NextPullCandidate returns the next active, visible task from a feeder step.
+func (r *Repository) NextPullCandidate(ctx context.Context, stepID, excludeTaskID string) (*models.Task, error) {
+	row := r.ro.QueryRowContext(ctx, r.ro.Rebind(`
+		SELECT `+taskSelectColumns("t")+`
+		FROM tasks t
+		WHERE t.workflow_step_id = ?
+		  AND t.id != ?
+		  AND t.archived_at IS NULL
+		  AND t.is_ephemeral = 0
+		ORDER BY
+		  t.position ASC,
+		  CASE LOWER(COALESCE(t.priority, ''))
+		    WHEN 'critical' THEN 0
+		    WHEN 'high' THEN 1
+		    WHEN 'medium' THEN 2
+		    WHEN 'low' THEN 3
+		    WHEN 'none' THEN 4
+		    ELSE 4
+		  END ASC,
+		  t.created_at ASC,
+		  t.id ASC
+		LIMIT 1
+	`), stepID, excludeTaskID)
+	task, err := r.scanSingleTask(row)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	return task, err
+}
+
 // ListChildren returns non-archived, non-ephemeral children of parentID.
 // Returns an empty list when parentID is empty (so root tasks resolve to
 // "no children" cleanly).

--- a/apps/backend/internal/task/repository/sqlite/task.go
+++ b/apps/backend/internal/task/repository/sqlite/task.go
@@ -285,6 +285,52 @@ func (r *Repository) UpdateTask(ctx context.Context, task *models.Task) error {
 	return tx.Commit()
 }
 
+// UpdateTaskIfWorkflowStepHasCapacity updates a task inside the same write
+// transaction that checks a WIP-limited target step's current occupancy.
+func (r *Repository) UpdateTaskIfWorkflowStepHasCapacity(ctx context.Context, task *models.Task, targetStepID, excludeTaskID string, limit int) error {
+	task.UpdatedAt = time.Now().UTC()
+	metadata, err := json.Marshal(task.Metadata)
+	if err != nil {
+		metadata = []byte("{}")
+	}
+
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var occupants int
+	if err := tx.QueryRowContext(ctx, r.db.Rebind(`
+		SELECT COUNT(*) FROM tasks
+		WHERE workflow_step_id = ?
+		  AND id != ?
+		  AND archived_at IS NULL
+		  AND is_ephemeral = 0
+	`), targetStepID, excludeTaskID).Scan(&occupants); err != nil {
+		return err
+	}
+	if occupants >= limit {
+		return fmt.Errorf("WIP limit exceeded for workflow step %s: limit %d already occupied", targetStepID, limit)
+	}
+
+	result, err := tx.ExecContext(ctx, r.db.Rebind(`
+		UPDATE tasks SET workspace_id = ?, workflow_id = ?, workflow_step_id = ?, title = ?, description = ?, state = ?, priority = ?, position = ?, metadata = ?, parent_id = ?, updated_at = ?, origin = ?, project_id = ?, labels = ?, identifier = ?
+		WHERE id = ?
+	`), task.WorkspaceID, task.WorkflowID, task.WorkflowStepID, task.Title, task.Description, task.State, task.Priority, task.Position, string(metadata), task.ParentID, task.UpdatedAt, task.Origin, task.ProjectID, task.Labels, task.Identifier, task.ID)
+	if err != nil {
+		return err
+	}
+	rows, _ := result.RowsAffected()
+	if rows == 0 {
+		return fmt.Errorf("%w: %s", ErrTaskNotFound, task.ID)
+	}
+	if err := syncRunnerInTx(ctx, tx, task.WorkflowStepID, task.ID, task.AssigneeAgentProfileID); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
 // DeleteTask deletes a task by ID
 func (r *Repository) DeleteTask(ctx context.Context, id string) error {
 	result, err := r.db.ExecContext(ctx, r.db.Rebind(`DELETE FROM tasks WHERE id = ?`), id)
@@ -356,16 +402,41 @@ func (r *Repository) CountTasksByWorkflowStepExcludingTask(ctx context.Context, 
 
 // NextPullCandidate returns the next active, visible task from a feeder step.
 func (r *Repository) NextPullCandidate(ctx context.Context, stepID, excludeTaskID string) (*models.Task, error) {
+	excludeTaskIDs := []string(nil)
+	if excludeTaskID != "" {
+		excludeTaskIDs = append(excludeTaskIDs, excludeTaskID)
+	}
+	return r.NextPullCandidateExcluding(ctx, stepID, excludeTaskIDs)
+}
+
+// NextPullCandidateExcluding returns the next active, visible task from a
+// feeder step, skipping any candidate IDs the caller already tried.
+func (r *Repository) NextPullCandidateExcluding(ctx context.Context, stepID string, excludeTaskIDs []string) (*models.Task, error) {
+	args := []any{stepID}
+	excludeClause := ""
+	if len(excludeTaskIDs) > 0 {
+		placeholders := make([]string, 0, len(excludeTaskIDs))
+		for _, id := range excludeTaskIDs {
+			if id == "" {
+				continue
+			}
+			placeholders = append(placeholders, "?")
+			args = append(args, id)
+		}
+		if len(placeholders) > 0 {
+			excludeClause = " AND t.id NOT IN (" + strings.Join(placeholders, ", ") + ")"
+		}
+	}
 	row := r.ro.QueryRowContext(ctx, r.ro.Rebind(`
-		SELECT `+taskSelectColumns("t")+`
-		FROM tasks t
-		WHERE t.workflow_step_id = ?
-		  AND t.id != ?
-		  AND t.archived_at IS NULL
-		  AND t.is_ephemeral = 0
-		ORDER BY
-		  t.position ASC,
-		  CASE LOWER(COALESCE(t.priority, ''))
+			SELECT `+taskSelectColumns("t")+`
+			FROM tasks t
+			WHERE t.workflow_step_id = ?
+			  AND t.archived_at IS NULL
+			  AND t.is_ephemeral = 0
+			  `+excludeClause+`
+			ORDER BY
+			  t.position ASC,
+			  CASE LOWER(COALESCE(t.priority, ''))
 		    WHEN 'critical' THEN 0
 		    WHEN 'high' THEN 1
 		    WHEN 'medium' THEN 2
@@ -374,9 +445,9 @@ func (r *Repository) NextPullCandidate(ctx context.Context, stepID, excludeTaskI
 		    ELSE 4
 		  END ASC,
 		  t.created_at ASC,
-		  t.id ASC
-		LIMIT 1
-	`), stepID, excludeTaskID)
+			  t.id ASC
+			LIMIT 1
+		`), args...)
 	task, err := r.scanSingleTask(row)
 	if err == sql.ErrNoRows {
 		return nil, nil

--- a/apps/backend/internal/task/service/service_workflow.go
+++ b/apps/backend/internal/task/service/service_workflow.go
@@ -52,8 +52,8 @@ func (s *Service) ApproveSession(ctx context.Context, sessionID string) (*Approv
 			s.logger.Warn("failed to get workflow step for approval transition",
 				zap.String("workflow_step_id", task.WorkflowStepID),
 				zap.Error(err))
-		} else {
-			s.applyApprovalStepTransition(ctx, sessionID, step, result)
+		} else if err := s.applyApprovalStepTransition(ctx, sessionID, step, result); err != nil {
+			return nil, err
 		}
 	}
 
@@ -61,7 +61,7 @@ func (s *Service) ApproveSession(ctx context.Context, sessionID string) (*Approv
 }
 
 // applyApprovalStepTransition resolves the next workflow step and updates session/task accordingly.
-func (s *Service) applyApprovalStepTransition(ctx context.Context, sessionID string, step *wfmodels.WorkflowStep, result *ApproveSessionResult) {
+func (s *Service) applyApprovalStepTransition(ctx context.Context, sessionID string, step *wfmodels.WorkflowStep, result *ApproveSessionResult) error {
 	newStepID := s.resolveApprovalNextStep(ctx, step)
 
 	if newStepID == "" {
@@ -69,51 +69,32 @@ func (s *Service) applyApprovalStepTransition(ctx context.Context, sessionID str
 			zap.String("session_id", sessionID),
 			zap.String("current_step", step.ID),
 			zap.String("current_step_name", step.Name))
-		return
+		return nil
 	}
 
-	// Move the task to the new step
-	if task, err := s.tasks.GetTask(ctx, result.Session.TaskID); err != nil {
-		s.logger.Error("failed to get task for approval transition",
-			zap.String("task_id", result.Session.TaskID),
-			zap.Error(err))
-	} else {
-		oldState := task.State
-		task.WorkflowStepID = newStepID
-		if err := s.syncTaskStateForWorkflowMove(ctx, task, step.ID, newStepID); err != nil {
-			s.logger.Error("failed to sync task state for approval transition",
-				zap.String("task_id", result.Session.TaskID),
-				zap.String("step_id", newStepID),
-				zap.Error(err))
-			return
-		}
-		task.UpdatedAt = time.Now().UTC()
-		if err := s.tasks.UpdateTask(ctx, task); err != nil {
-			s.logger.Error("failed to move task to next step after approval",
-				zap.String("task_id", result.Session.TaskID),
-				zap.String("step_id", newStepID),
-				zap.Error(err))
-		} else {
-			s.publishTaskEvent(ctx, events.TaskUpdated, task, nil)
-			if oldState != task.State {
-				s.publishTaskEvent(ctx, events.TaskStateChanged, task, &oldState)
-			}
-			result.Task = task
-		}
+	moved, err := s.MoveTask(ctx, result.Session.TaskID, step.WorkflowID, newStepID, 0)
+	if err != nil {
+		return fmt.Errorf("failed to move task to next step after approval: %w", err)
 	}
+	result.Task = moved.Task
+	result.WorkflowStep = moved.WorkflowStep
 
 	// Reload session with new step
 	result.Session, _ = s.sessions.GetTaskSession(ctx, sessionID)
 
 	// Get the new workflow step for the response
-	if newStep, err := s.workflowStepGetter.GetStep(ctx, newStepID); err == nil {
-		result.WorkflowStep = newStep
+	if result.WorkflowStep == nil {
+		newStep, err := s.workflowStepGetter.GetStep(ctx, newStepID)
+		if err == nil {
+			result.WorkflowStep = newStep
+		}
 	}
 
 	s.logger.Info("session approved and moved to next step",
 		zap.String("session_id", sessionID),
 		zap.String("from_step", step.ID),
 		zap.String("to_step", newStepID))
+	return nil
 }
 
 // resolveApprovalNextStep determines the target step ID from a step's on_turn_complete actions,
@@ -279,8 +260,12 @@ type workflowMoveLimitsRepository interface {
 	CountTasksByWorkflowStepExcludingTask(ctx context.Context, stepID, excludeTaskID string) (int, error)
 }
 
+type workflowLimitedMoveRepository interface {
+	UpdateTaskIfWorkflowStepHasCapacity(ctx context.Context, task *models.Task, targetStepID, excludeTaskID string, limit int) error
+}
+
 type workflowPullRepository interface {
-	NextPullCandidate(ctx context.Context, stepID, excludeTaskID string) (*models.Task, error)
+	NextPullCandidateExcluding(ctx context.Context, stepID string, excludeTaskIDs []string) (*models.Task, error)
 }
 
 // MoveTask moves a task to a different workflow step and position
@@ -302,7 +287,8 @@ func (s *Service) MoveTaskWithOptions(
 		return nil, err
 	}
 
-	if err := s.validateTaskMove(ctx, task, workflowID, workflowStepID, opts); err != nil {
+	targetStep, err := s.validateTaskMove(ctx, task, workflowID, workflowStepID, opts)
+	if err != nil {
 		return nil, err
 	}
 
@@ -319,7 +305,7 @@ func (s *Service) MoveTaskWithOptions(
 	}
 	task.UpdatedAt = time.Now().UTC()
 
-	if err := s.tasks.UpdateTask(ctx, task); err != nil {
+	if err := s.updateMovedTask(ctx, task, oldStepID, targetStep); err != nil {
 		s.logger.Error("failed to move task", zap.String("task_id", id), zap.Error(err))
 		return nil, err
 	}
@@ -445,8 +431,9 @@ func (s *Service) pullNextTaskOnVacate(ctx context.Context, vacatedStepID, exclu
 	if !ok || occupants >= vacatedStep.WIPLimit {
 		return
 	}
+	skipped := map[string]struct{}{excludeTaskID: {}}
 	for occupants < vacatedStep.WIPLimit {
-		pulled := s.pullOneFeederTask(ctx, pullRepo, vacatedStep, occupants, excludeTaskID)
+		pulled := s.pullOneFeederTask(ctx, pullRepo, vacatedStep, occupants, skipped)
 		if !pulled {
 			return
 		}
@@ -499,56 +486,83 @@ func (s *Service) pullOneFeederTask(
 	pullRepo workflowPullRepository,
 	vacatedStep *wfmodels.WorkflowStep,
 	position int,
-	excludeTaskID string,
+	skipped map[string]struct{},
 ) bool {
-	candidate, err := pullRepo.NextPullCandidate(ctx, vacatedStep.PullFromStepID, excludeTaskID)
-	if err != nil {
-		s.logger.Warn("cannot pull feeder task: failed to select candidate",
-			zap.String("step_id", vacatedStep.ID), zap.Error(err))
-		return false
+	for {
+		candidate, err := pullRepo.NextPullCandidateExcluding(ctx, vacatedStep.PullFromStepID, skippedTaskIDs(skipped))
+		if err != nil {
+			s.logger.Warn("cannot pull feeder task: failed to select candidate",
+				zap.String("step_id", vacatedStep.ID), zap.Error(err))
+			return false
+		}
+		if candidate == nil {
+			return false
+		}
+		if _, seen := skipped[candidate.ID]; seen {
+			return false
+		}
+		if _, err := s.MoveTask(ctx, candidate.ID, vacatedStep.WorkflowID, vacatedStep.ID, position); err != nil {
+			skipped[candidate.ID] = struct{}{}
+			s.logger.Warn("skipping feeder task that could not be pulled",
+				zap.String("task_id", candidate.ID),
+				zap.String("from_step_id", vacatedStep.PullFromStepID),
+				zap.String("to_step_id", vacatedStep.ID),
+				zap.Error(err))
+			continue
+		}
+		return true
 	}
-	if candidate == nil {
-		return false
-	}
-	if _, err := s.MoveTask(ctx, candidate.ID, vacatedStep.WorkflowID, vacatedStep.ID, position); err != nil {
-		s.logger.Warn("failed to pull feeder task into vacated WIP-limited step",
-			zap.String("task_id", candidate.ID),
-			zap.String("from_step_id", vacatedStep.PullFromStepID),
-			zap.String("to_step_id", vacatedStep.ID),
-			zap.Error(err))
-		return false
-	}
-	return true
 }
 
-func (s *Service) validateTaskMove(ctx context.Context, task *models.Task, workflowID, workflowStepID string, opts MoveTaskOptions) error {
+func skippedTaskIDs(skipped map[string]struct{}) []string {
+	ids := make([]string, 0, len(skipped))
+	for id := range skipped {
+		if id != "" {
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}
+
+func (s *Service) updateMovedTask(ctx context.Context, task *models.Task, oldStepID string, targetStep *wfmodels.WorkflowStep) error {
+	if targetStep == nil || targetStep.WIPLimit <= 0 || oldStepID == targetStep.ID {
+		return s.tasks.UpdateTask(ctx, task)
+	}
+	limitedRepo, ok := s.tasks.(workflowLimitedMoveRepository)
+	if !ok {
+		return fmt.Errorf("WIP limit cannot be checked for workflow step %s", targetStep.ID)
+	}
+	return limitedRepo.UpdateTaskIfWorkflowStepHasCapacity(ctx, task, targetStep.ID, task.ID, targetStep.WIPLimit)
+}
+
+func (s *Service) validateTaskMove(ctx context.Context, task *models.Task, workflowID, workflowStepID string, opts MoveTaskOptions) (*wfmodels.WorkflowStep, error) {
 	if task.ArchivedAt != nil {
-		return fmt.Errorf("archived tasks cannot be moved")
+		return nil, fmt.Errorf("archived tasks cannot be moved")
 	}
 	if err := s.validateMoveSessions(ctx, task.ID, opts); err != nil {
-		return err
+		return nil, err
 	}
 	targetWorkflow, err := s.workflows.GetWorkflow(ctx, workflowID)
 	if err != nil {
-		return fmt.Errorf("failed to get target workflow: %w", err)
+		return nil, fmt.Errorf("failed to get target workflow: %w", err)
 	}
 	if targetWorkflow.WorkspaceID != task.WorkspaceID {
-		return fmt.Errorf("target workflow is in a different workspace")
+		return nil, fmt.Errorf("target workflow is in a different workspace")
 	}
 	if s.workflowStepGetter == nil {
-		return nil
+		return nil, nil
 	}
 	targetStep, err := s.workflowStepGetter.GetStep(ctx, workflowStepID)
 	if err != nil {
-		return fmt.Errorf("failed to get target workflow step: %w", err)
+		return nil, fmt.Errorf("failed to get target workflow step: %w", err)
 	}
 	if targetStep.WorkflowID != workflowID {
-		return fmt.Errorf("target workflow step does not belong to target workflow")
+		return nil, fmt.Errorf("target workflow step does not belong to target workflow")
 	}
 	if err := s.validateMoveWIPLimit(ctx, task, targetStep); err != nil {
-		return err
+		return nil, err
 	}
-	return nil
+	return targetStep, nil
 }
 
 func (s *Service) validateMoveWIPLimit(ctx context.Context, task *models.Task, targetStep *wfmodels.WorkflowStep) error {
@@ -641,6 +655,9 @@ func (s *Service) BulkMoveSelectedTasks(ctx context.Context, taskIDs []string, t
 	if err != nil {
 		return nil, err
 	}
+	if err := s.validateBulkMoveWIPCapacity(ctx, tasks, targetStepID); err != nil {
+		return nil, err
+	}
 
 	nextPosition, err := s.tasks.CountTasksByWorkflowStep(ctx, targetStepID)
 	if err != nil {
@@ -685,13 +702,48 @@ func (s *Service) validateSelectedMoveBatch(ctx context.Context, taskIDs []strin
 			return nil, err
 		}
 		if task.WorkflowID != targetWorkflowID || task.WorkflowStepID != targetStepID {
-			if err := s.validateTaskMove(ctx, task, targetWorkflowID, targetStepID, MoveTaskOptions{}); err != nil {
+			if _, err := s.validateTaskMove(ctx, task, targetWorkflowID, targetStepID, MoveTaskOptions{}); err != nil {
 				return nil, fmt.Errorf("task %s cannot be moved: %w", id, err)
 			}
 		}
 		tasks = append(tasks, task)
 	}
 	return tasks, nil
+}
+
+func (s *Service) validateBulkMoveWIPCapacity(ctx context.Context, tasks []*models.Task, targetStepID string) error {
+	if s.workflowStepGetter == nil {
+		return nil
+	}
+	targetStep, err := s.workflowStepGetter.GetStep(ctx, targetStepID)
+	if err != nil {
+		return fmt.Errorf("failed to get target workflow step: %w", err)
+	}
+	if targetStep.WIPLimit <= 0 {
+		return nil
+	}
+	incoming := 0
+	for _, task := range tasks {
+		if task.WorkflowStepID != targetStepID {
+			incoming++
+		}
+	}
+	if incoming == 0 {
+		return nil
+	}
+	limitsRepo, ok := s.tasks.(workflowMoveLimitsRepository)
+	if !ok {
+		return fmt.Errorf("WIP limit cannot be checked for workflow step %s", targetStep.ID)
+	}
+	occupants, err := limitsRepo.CountTasksByWorkflowStepExcludingTask(ctx, targetStep.ID, "")
+	if err != nil {
+		return fmt.Errorf("failed to count target workflow step tasks: %w", err)
+	}
+	if occupants+incoming > targetStep.WIPLimit {
+		return fmt.Errorf("WIP limit exceeded for workflow step %s: limit %d, occupied %d, moving %d",
+			targetStep.ID, targetStep.WIPLimit, occupants, incoming)
+	}
+	return nil
 }
 
 // BulkMoveTasks moves all tasks from a source workflow/step to a target workflow/step.
@@ -711,6 +763,9 @@ func (s *Service) BulkMoveTasks(ctx context.Context, sourceWorkflowID, sourceSte
 
 	if len(tasks) == 0 {
 		return &BulkMoveTasksResult{MovedCount: 0}, nil
+	}
+	if err := s.validateBulkMoveWIPCapacity(ctx, tasks, targetStepID); err != nil {
+		return nil, err
 	}
 
 	for i, task := range tasks {

--- a/apps/backend/internal/task/service/service_workflow.go
+++ b/apps/backend/internal/task/service/service_workflow.go
@@ -25,17 +25,11 @@ type ApproveSessionResult struct {
 // It reads the step's on_turn_complete actions to determine where to transition.
 // If no transition actions are configured, it falls back to the next step by position.
 func (s *Service) ApproveSession(ctx context.Context, sessionID string) (*ApproveSessionResult, error) {
-	// Update review status to approved
-	if err := s.sessions.UpdateSessionReviewStatus(ctx, sessionID, "approved"); err != nil {
-		return nil, fmt.Errorf("failed to update review status: %w", err)
-	}
-
 	result := &ApproveSessionResult{}
 
-	// Reload session to get updated review status
 	session, err := s.sessions.GetTaskSession(ctx, sessionID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to reload session: %w", err)
+		return nil, fmt.Errorf("failed to get session: %w", err)
 	}
 	result.Session = session
 
@@ -55,6 +49,13 @@ func (s *Service) ApproveSession(ctx context.Context, sessionID string) (*Approv
 		} else if err := s.applyApprovalStepTransition(ctx, sessionID, step, result); err != nil {
 			return nil, err
 		}
+	}
+
+	if err := s.sessions.UpdateSessionReviewStatus(ctx, sessionID, "approved"); err != nil {
+		return nil, fmt.Errorf("failed to update review status: %w", err)
+	}
+	if session, err := s.sessions.GetTaskSession(ctx, sessionID); err == nil {
+		result.Session = session
 	}
 
 	return result, nil

--- a/apps/backend/internal/task/service/service_workflow.go
+++ b/apps/backend/internal/task/service/service_workflow.go
@@ -275,6 +275,14 @@ type MoveTaskOptions struct {
 	AllowActivePrimarySession bool
 }
 
+type workflowMoveLimitsRepository interface {
+	CountTasksByWorkflowStepExcludingTask(ctx context.Context, stepID, excludeTaskID string) (int, error)
+}
+
+type workflowPullRepository interface {
+	NextPullCandidate(ctx context.Context, stepID, excludeTaskID string) (*models.Task, error)
+}
+
 // MoveTask moves a task to a different workflow step and position
 func (s *Service) MoveTask(ctx context.Context, id string, workflowID string, workflowStepID string, position int) (*MoveTaskResult, error) {
 	return s.MoveTaskWithOptions(ctx, id, workflowID, workflowStepID, position, MoveTaskOptions{})
@@ -330,6 +338,7 @@ func (s *Service) MoveTaskWithOptions(
 	// Publish task.moved event so the orchestrator can process on_exit/on_enter actions
 	if stepChanged {
 		s.publishTaskMovedEvent(ctx, task, oldWorkflowID, oldStepID, workflowStepID, sessionID)
+		s.pullNextTaskOnVacate(ctx, oldStepID, task.ID)
 	}
 
 	s.logger.Info("task moved",
@@ -423,6 +432,95 @@ func (s *Service) syncTaskStateForBulkWorkflowMove(ctx context.Context, task *mo
 	return nil
 }
 
+func (s *Service) pullNextTaskOnVacate(ctx context.Context, vacatedStepID, excludeTaskID string) {
+	vacatedStep := s.pullEnabledStep(ctx, vacatedStepID)
+	if vacatedStep == nil {
+		return
+	}
+	limitsRepo, pullRepo, ok := s.pullRepositories(vacatedStep.ID)
+	if !ok {
+		return
+	}
+	occupants, ok := s.currentWIPOccupants(ctx, limitsRepo, vacatedStep.ID)
+	if !ok || occupants >= vacatedStep.WIPLimit {
+		return
+	}
+	for occupants < vacatedStep.WIPLimit {
+		pulled := s.pullOneFeederTask(ctx, pullRepo, vacatedStep, occupants, excludeTaskID)
+		if !pulled {
+			return
+		}
+		occupants++
+	}
+}
+
+func (s *Service) pullEnabledStep(ctx context.Context, vacatedStepID string) *wfmodels.WorkflowStep {
+	if s.workflowStepGetter == nil || vacatedStepID == "" {
+		return nil
+	}
+	vacatedStep, err := s.workflowStepGetter.GetStep(ctx, vacatedStepID)
+	if err != nil || vacatedStep == nil || vacatedStep.WIPLimit <= 0 || vacatedStep.PullFromStepID == "" {
+		return nil
+	}
+	if vacatedStep.PullFromStepID == vacatedStep.ID {
+		return nil
+	}
+	return vacatedStep
+}
+
+func (s *Service) pullRepositories(stepID string) (workflowMoveLimitsRepository, workflowPullRepository, bool) {
+	limitsRepo, ok := s.tasks.(workflowMoveLimitsRepository)
+	if !ok {
+		s.logger.Warn("cannot pull feeder task: WIP limit repository unavailable",
+			zap.String("step_id", stepID))
+		return nil, nil, false
+	}
+	pullRepo, ok := s.tasks.(workflowPullRepository)
+	if !ok {
+		s.logger.Warn("cannot pull feeder task: pull repository unavailable",
+			zap.String("step_id", stepID))
+		return nil, nil, false
+	}
+	return limitsRepo, pullRepo, true
+}
+
+func (s *Service) currentWIPOccupants(ctx context.Context, limitsRepo workflowMoveLimitsRepository, stepID string) (int, bool) {
+	occupants, err := limitsRepo.CountTasksByWorkflowStepExcludingTask(ctx, stepID, "")
+	if err != nil {
+		s.logger.Warn("cannot pull feeder task: failed to count vacated step",
+			zap.String("step_id", stepID), zap.Error(err))
+		return 0, false
+	}
+	return occupants, true
+}
+
+func (s *Service) pullOneFeederTask(
+	ctx context.Context,
+	pullRepo workflowPullRepository,
+	vacatedStep *wfmodels.WorkflowStep,
+	position int,
+	excludeTaskID string,
+) bool {
+	candidate, err := pullRepo.NextPullCandidate(ctx, vacatedStep.PullFromStepID, excludeTaskID)
+	if err != nil {
+		s.logger.Warn("cannot pull feeder task: failed to select candidate",
+			zap.String("step_id", vacatedStep.ID), zap.Error(err))
+		return false
+	}
+	if candidate == nil {
+		return false
+	}
+	if _, err := s.MoveTask(ctx, candidate.ID, vacatedStep.WorkflowID, vacatedStep.ID, position); err != nil {
+		s.logger.Warn("failed to pull feeder task into vacated WIP-limited step",
+			zap.String("task_id", candidate.ID),
+			zap.String("from_step_id", vacatedStep.PullFromStepID),
+			zap.String("to_step_id", vacatedStep.ID),
+			zap.Error(err))
+		return false
+	}
+	return true
+}
+
 func (s *Service) validateTaskMove(ctx context.Context, task *models.Task, workflowID, workflowStepID string, opts MoveTaskOptions) error {
 	if task.ArchivedAt != nil {
 		return fmt.Errorf("archived tasks cannot be moved")
@@ -446,6 +544,27 @@ func (s *Service) validateTaskMove(ctx context.Context, task *models.Task, workf
 	}
 	if targetStep.WorkflowID != workflowID {
 		return fmt.Errorf("target workflow step does not belong to target workflow")
+	}
+	if err := s.validateMoveWIPLimit(ctx, task, targetStep); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *Service) validateMoveWIPLimit(ctx context.Context, task *models.Task, targetStep *wfmodels.WorkflowStep) error {
+	if targetStep == nil || targetStep.WIPLimit <= 0 || task.WorkflowStepID == targetStep.ID {
+		return nil
+	}
+	limitsRepo, ok := s.tasks.(workflowMoveLimitsRepository)
+	if !ok {
+		return fmt.Errorf("WIP limit cannot be checked for workflow step %s", targetStep.ID)
+	}
+	occupants, err := limitsRepo.CountTasksByWorkflowStepExcludingTask(ctx, targetStep.ID, task.ID)
+	if err != nil {
+		return fmt.Errorf("failed to count target workflow step tasks: %w", err)
+	}
+	if occupants >= targetStep.WIPLimit {
+		return fmt.Errorf("WIP limit exceeded for workflow step %s: limit %d already occupied", targetStep.ID, targetStep.WIPLimit)
 	}
 	return nil
 }
@@ -594,44 +713,9 @@ func (s *Service) BulkMoveTasks(ctx context.Context, sourceWorkflowID, sourceSte
 		return &BulkMoveTasksResult{MovedCount: 0}, nil
 	}
 
-	targetIsTerminal, err := s.terminalWorkflowStep(ctx, targetStepID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to check target step terminal status: %w", err)
-	}
-	sourceIsTerminal := false
-	sourceTerminalKnown := false
-	if sourceStepID != "" {
-		sourceIsTerminal, err = s.terminalWorkflowStep(ctx, sourceStepID)
-		if err != nil {
-			return nil, fmt.Errorf("failed to check source step terminal status: %w", err)
-		}
-		sourceTerminalKnown = true
-	}
-
-	now := time.Now().UTC()
 	for i, task := range tasks {
-		oldWorkflowID := task.WorkflowID
-		oldStepID := task.WorkflowStepID
-		oldState := task.State
-		task.WorkflowID = targetWorkflowID
-		task.WorkflowStepID = targetStepID
-		task.Position = i
-		err := s.syncTaskStateForBulkWorkflowMove(ctx, task, oldStepID, targetStepID, targetIsTerminal, sourceIsTerminal, sourceTerminalKnown)
-		if err != nil {
-			return nil, fmt.Errorf("failed to sync task state for bulk move %s: %w", task.ID, err)
-		}
-		task.UpdatedAt = now
-
-		if err := s.tasks.UpdateTask(ctx, task); err != nil {
-			s.logger.Error("failed to move task in bulk move",
-				zap.String("task_id", task.ID),
-				zap.Error(err))
+		if _, err := s.MoveTask(ctx, task.ID, targetWorkflowID, targetStepID, i); err != nil {
 			return nil, fmt.Errorf("failed to move task %s: %w", task.ID, err)
-		}
-
-		s.publishTaskEvent(ctx, events.TaskUpdated, task, nil, oldWorkflowID)
-		if oldState != task.State {
-			s.publishTaskEvent(ctx, events.TaskStateChanged, task, &oldState)
 		}
 	}
 

--- a/apps/backend/internal/task/service/service_workflow.go
+++ b/apps/backend/internal/task/service/service_workflow.go
@@ -500,7 +500,7 @@ func (s *Service) pullOneFeederTask(
 			return false
 		}
 		if _, seen := skipped[candidate.ID]; seen {
-			return false
+			continue
 		}
 		if _, err := s.MoveTask(ctx, candidate.ID, vacatedStep.WorkflowID, vacatedStep.ID, position); err != nil {
 			skipped[candidate.ID] = struct{}{}

--- a/apps/backend/internal/task/service/service_workflow_test.go
+++ b/apps/backend/internal/task/service/service_workflow_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -369,6 +370,137 @@ func TestService_MoveTaskWithOptionsAllowsRunningPrimarySession(t *testing.T) {
 	}
 }
 
+func TestService_MoveTaskRejectsFullWIPLimitedTarget(t *testing.T) {
+	svc, _, repo := createTestService(t)
+	ctx := context.Background()
+	seedMoveWorkflows(t, ctx, repo)
+	seedMoveSteps(svc)
+	svc.SetWorkflowStepGetter(&fakeWorkflowStepGetter{steps: map[string]*wfmodels.WorkflowStep{
+		"step-source": {ID: "step-source", WorkflowID: "wf-source", Name: "Source", Position: 0},
+		"step-full":   {ID: "step-full", WorkflowID: "wf-source", Name: "Full", Position: 1, WIPLimit: 1},
+	}})
+	createMoveTask(t, ctx, repo, "task-moving", "wf-source", "step-source", nil)
+	createMoveTask(t, ctx, repo, "task-occupant", "wf-source", "step-full", nil)
+
+	_, err := svc.MoveTask(ctx, "task-moving", "wf-source", "step-full", 0)
+	if err == nil {
+		t.Fatalf("expected WIP-limited move to be rejected")
+	}
+	if !strings.Contains(err.Error(), "WIP limit") {
+		t.Fatalf("error = %q, want WIP limit rejection", err.Error())
+	}
+
+	task, err := repo.GetTask(ctx, "task-moving")
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if task.WorkflowStepID != "step-source" {
+		t.Fatalf("task moved despite WIP limit: %s", task.WorkflowStepID)
+	}
+}
+
+func TestService_MoveTaskAllowsSameStepReorderWhenStepAlreadyOverLimit(t *testing.T) {
+	svc, _, repo := createTestService(t)
+	ctx := context.Background()
+	seedMoveWorkflows(t, ctx, repo)
+	svc.SetWorkflowStepGetter(&fakeWorkflowStepGetter{steps: map[string]*wfmodels.WorkflowStep{
+		"step-full": {ID: "step-full", WorkflowID: "wf-source", Name: "Full", Position: 0, WIPLimit: 1},
+	}})
+	createMoveTask(t, ctx, repo, "task-moving", "wf-source", "step-full", nil)
+	createMoveTask(t, ctx, repo, "task-occupant", "wf-source", "step-full", nil)
+
+	moved, err := svc.MoveTask(ctx, "task-moving", "wf-source", "step-full", 5)
+	if err != nil {
+		t.Fatalf("same-step reorder should be exempt from WIP limit: %v", err)
+	}
+	if moved.Task.Position != 5 {
+		t.Fatalf("position = %d, want 5", moved.Task.Position)
+	}
+}
+
+func TestService_MoveTaskIgnoresArchivedAndEphemeralOccupantsForWIPLimit(t *testing.T) {
+	svc, _, repo := createTestService(t)
+	ctx := context.Background()
+	seedMoveWorkflows(t, ctx, repo)
+	svc.SetWorkflowStepGetter(&fakeWorkflowStepGetter{steps: map[string]*wfmodels.WorkflowStep{
+		"step-source":  {ID: "step-source", WorkflowID: "wf-source", Name: "Source", Position: 0},
+		"step-limited": {ID: "step-limited", WorkflowID: "wf-source", Name: "Limited", Position: 1, WIPLimit: 1},
+	}})
+	now := time.Now().UTC()
+	createMoveTask(t, ctx, repo, "task-moving", "wf-source", "step-source", nil)
+	createMoveTask(t, ctx, repo, "task-archived", "wf-source", "step-limited", &now)
+	if err := repo.CreateTask(ctx, &models.Task{
+		ID:             "task-ephemeral",
+		WorkspaceID:    "ws-1",
+		WorkflowID:     "wf-source",
+		WorkflowStepID: "step-limited",
+		Title:          "Ephemeral",
+		State:          v1.TaskStateTODO,
+		Priority:       "medium",
+		IsEphemeral:    true,
+	}); err != nil {
+		t.Fatalf("CreateTask(ephemeral): %v", err)
+	}
+
+	moved, err := svc.MoveTask(ctx, "task-moving", "wf-source", "step-limited", 0)
+	if err != nil {
+		t.Fatalf("archived/ephemeral occupants should not consume WIP: %v", err)
+	}
+	if moved.Task.WorkflowStepID != "step-limited" {
+		t.Fatalf("step = %s, want step-limited", moved.Task.WorkflowStepID)
+	}
+}
+
+func TestService_MoveTaskPullsNextFeederTaskOnVacate(t *testing.T) {
+	svc, eventBus, repo := createTestService(t)
+	ctx := context.Background()
+	seedMoveWorkflows(t, ctx, repo)
+	svc.SetWorkflowStepGetter(&fakeWorkflowStepGetter{steps: map[string]*wfmodels.WorkflowStep{
+		"step-limited": {
+			ID: "step-limited", WorkflowID: "wf-source", Name: "Limited", Position: 0,
+			WIPLimit: 1, PullFromStepID: "step-feeder",
+		},
+		"step-feeder": {ID: "step-feeder", WorkflowID: "wf-source", Name: "Feeder", Position: 1},
+		"step-target": {ID: "step-target", WorkflowID: "wf-target", Name: "Target", Position: 0},
+	}})
+	createMoveTask(t, ctx, repo, "task-vacating", "wf-source", "step-limited", nil)
+	createMoveTask(t, ctx, repo, "task-low", "wf-source", "step-feeder", nil)
+	createMoveTask(t, ctx, repo, "task-critical", "wf-source", "step-feeder", nil)
+	setMoveTaskOrder(t, ctx, repo, "task-low", 0, "low")
+	setMoveTaskOrder(t, ctx, repo, "task-critical", 0, "critical")
+	eventBus.ClearEvents()
+
+	_, err := svc.MoveTask(ctx, "task-vacating", "wf-target", "step-target", 0)
+	if err != nil {
+		t.Fatalf("MoveTask: %v", err)
+	}
+
+	pulled, err := repo.GetTask(ctx, "task-critical")
+	if err != nil {
+		t.Fatalf("GetTask(task-critical): %v", err)
+	}
+	if pulled.WorkflowStepID != "step-limited" {
+		t.Fatalf("critical feeder task step = %s, want step-limited", pulled.WorkflowStepID)
+	}
+	notPulled, err := repo.GetTask(ctx, "task-low")
+	if err != nil {
+		t.Fatalf("GetTask(task-low): %v", err)
+	}
+	if notPulled.WorkflowStepID != "step-feeder" {
+		t.Fatalf("low feeder task step = %s, want step-feeder", notPulled.WorkflowStepID)
+	}
+
+	movedEvents := 0
+	for _, event := range eventBus.GetPublishedEvents() {
+		if event.Type == events.TaskMoved {
+			movedEvents++
+		}
+	}
+	if movedEvents != 2 {
+		t.Fatalf("task.moved events = %d, want 2", movedEvents)
+	}
+}
+
 func TestService_MoveTaskRejectsArchivedTask(t *testing.T) {
 	svc, _, repo := createTestService(t)
 	ctx := context.Background()
@@ -619,6 +751,22 @@ func createMoveTask(t *testing.T, ctx context.Context, repo interface {
 	}))
 	if archivedAt != nil {
 		must(t, repo.ArchiveTask(ctx, id))
+	}
+}
+
+func setMoveTaskOrder(t *testing.T, ctx context.Context, repo interface {
+	GetTask(context.Context, string) (*models.Task, error)
+	UpdateTask(context.Context, *models.Task) error
+}, id string, position int, priority string) {
+	t.Helper()
+	task, err := repo.GetTask(ctx, id)
+	if err != nil {
+		t.Fatalf("GetTask(%s): %v", id, err)
+	}
+	task.Position = position
+	task.Priority = priority
+	if err := repo.UpdateTask(ctx, task); err != nil {
+		t.Fatalf("UpdateTask(%s): %v", id, err)
 	}
 }
 

--- a/apps/backend/internal/task/service/service_workflow_test.go
+++ b/apps/backend/internal/task/service/service_workflow_test.go
@@ -397,6 +397,7 @@ func TestService_MoveTaskRejectsFullWIPLimitedTarget(t *testing.T) {
 	if task.WorkflowStepID != "step-source" {
 		t.Fatalf("task moved despite WIP limit: %s", task.WorkflowStepID)
 	}
+
 }
 
 func TestService_ApproveSessionRejectsFullWIPLimitedTarget(t *testing.T) {
@@ -434,6 +435,14 @@ func TestService_ApproveSessionRejectsFullWIPLimitedTarget(t *testing.T) {
 	}
 	if task.WorkflowStepID != "step-source" {
 		t.Fatalf("task moved despite WIP limit: %s", task.WorkflowStepID)
+	}
+
+	session, err := repo.GetTaskSession(ctx, "session-approve")
+	if err != nil {
+		t.Fatalf("GetTaskSession: %v", err)
+	}
+	if session.ReviewStatus != models.ReviewStatusPending {
+		t.Fatalf("review status = %q, want pending after rejected approval", session.ReviewStatus)
 	}
 }
 

--- a/apps/backend/internal/task/service/service_workflow_test.go
+++ b/apps/backend/internal/task/service/service_workflow_test.go
@@ -399,6 +399,44 @@ func TestService_MoveTaskRejectsFullWIPLimitedTarget(t *testing.T) {
 	}
 }
 
+func TestService_ApproveSessionRejectsFullWIPLimitedTarget(t *testing.T) {
+	svc, _, repo := createTestService(t)
+	ctx := context.Background()
+	seedMoveWorkflows(t, ctx, repo)
+	sourceStep := &wfmodels.WorkflowStep{
+		ID: "step-source", WorkflowID: "wf-source", Name: "Source", Position: 0,
+		Events: wfmodels.StepEvents{OnTurnComplete: []wfmodels.OnTurnCompleteAction{{
+			Type: wfmodels.OnTurnCompleteMoveToStep,
+			Config: map[string]interface{}{
+				"step_id": "step-full",
+			},
+		}}},
+	}
+	svc.SetWorkflowStepGetter(&fakeWorkflowStepGetter{steps: map[string]*wfmodels.WorkflowStep{
+		"step-source": sourceStep,
+		"step-full":   {ID: "step-full", WorkflowID: "wf-source", Name: "Full", Position: 1, WIPLimit: 1},
+	}})
+	createMoveTask(t, ctx, repo, "task-approve", "wf-source", "step-source", nil)
+	createMoveTask(t, ctx, repo, "task-occupant", "wf-source", "step-full", nil)
+	createMoveSession(t, ctx, repo, "session-approve", "task-approve", models.TaskSessionStateWaitingForInput, models.ReviewStatusPending)
+
+	_, err := svc.ApproveSession(ctx, "session-approve")
+	if err == nil {
+		t.Fatalf("expected approval transition to be rejected")
+	}
+	if !strings.Contains(err.Error(), "WIP limit") {
+		t.Fatalf("error = %q, want WIP limit rejection", err.Error())
+	}
+
+	task, err := repo.GetTask(ctx, "task-approve")
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if task.WorkflowStepID != "step-source" {
+		t.Fatalf("task moved despite WIP limit: %s", task.WorkflowStepID)
+	}
+}
+
 func TestService_MoveTaskAllowsSameStepReorderWhenStepAlreadyOverLimit(t *testing.T) {
 	svc, _, repo := createTestService(t)
 	ctx := context.Background()
@@ -498,6 +536,46 @@ func TestService_MoveTaskPullsNextFeederTaskOnVacate(t *testing.T) {
 	}
 	if movedEvents != 2 {
 		t.Fatalf("task.moved events = %d, want 2", movedEvents)
+	}
+}
+
+func TestService_MoveTaskPullSkipsBlockedFeederCandidate(t *testing.T) {
+	svc, _, repo := createTestService(t)
+	ctx := context.Background()
+	seedMoveWorkflows(t, ctx, repo)
+	svc.SetWorkflowStepGetter(&fakeWorkflowStepGetter{steps: map[string]*wfmodels.WorkflowStep{
+		"step-limited": {
+			ID: "step-limited", WorkflowID: "wf-source", Name: "Limited", Position: 0,
+			WIPLimit: 1, PullFromStepID: "step-feeder",
+		},
+		"step-feeder": {ID: "step-feeder", WorkflowID: "wf-source", Name: "Feeder", Position: 1},
+		"step-target": {ID: "step-target", WorkflowID: "wf-target", Name: "Target", Position: 0},
+	}})
+	createMoveTask(t, ctx, repo, "task-vacating", "wf-source", "step-limited", nil)
+	createMoveTask(t, ctx, repo, "task-blocked", "wf-source", "step-feeder", nil)
+	createMoveTask(t, ctx, repo, "task-eligible", "wf-source", "step-feeder", nil)
+	setMoveTaskOrder(t, ctx, repo, "task-blocked", 0, "critical")
+	setMoveTaskOrder(t, ctx, repo, "task-eligible", 1, "medium")
+	createMoveSession(t, ctx, repo, "session-blocked", "task-blocked", models.TaskSessionStateRunning, models.ReviewStatusNone)
+
+	_, err := svc.MoveTask(ctx, "task-vacating", "wf-target", "step-target", 0)
+	if err != nil {
+		t.Fatalf("MoveTask: %v", err)
+	}
+
+	blocked, err := repo.GetTask(ctx, "task-blocked")
+	if err != nil {
+		t.Fatalf("GetTask(task-blocked): %v", err)
+	}
+	if blocked.WorkflowStepID != "step-feeder" {
+		t.Fatalf("blocked task step = %s, want step-feeder", blocked.WorkflowStepID)
+	}
+	eligible, err := repo.GetTask(ctx, "task-eligible")
+	if err != nil {
+		t.Fatalf("GetTask(task-eligible): %v", err)
+	}
+	if eligible.WorkflowStepID != "step-limited" {
+		t.Fatalf("eligible task step = %s, want step-limited", eligible.WorkflowStepID)
 	}
 }
 
@@ -663,6 +741,36 @@ func TestService_BulkMoveSelectedTasksValidatesBatchBeforeMoving(t *testing.T) {
 		}
 		if task.WorkflowID != "wf-source" || task.WorkflowStepID != "step-source" {
 			t.Fatalf("%s moved despite rejected batch: workflow=%s step=%s", id, task.WorkflowID, task.WorkflowStepID)
+		}
+	}
+}
+
+func TestService_BulkMoveSelectedTasksRejectsOverCapacityBeforeMoving(t *testing.T) {
+	svc, _, repo := createTestService(t)
+	ctx := context.Background()
+	seedMoveWorkflows(t, ctx, repo)
+	svc.SetWorkflowStepGetter(&fakeWorkflowStepGetter{steps: map[string]*wfmodels.WorkflowStep{
+		"step-source": {ID: "step-source", WorkflowID: "wf-source", Name: "Source", Position: 0},
+		"step-full":   {ID: "step-full", WorkflowID: "wf-source", Name: "Full", Position: 1, WIPLimit: 1},
+	}})
+	createMoveTask(t, ctx, repo, "task-batch-a", "wf-source", "step-source", nil)
+	createMoveTask(t, ctx, repo, "task-batch-b", "wf-source", "step-source", nil)
+
+	_, err := svc.BulkMoveSelectedTasks(ctx, []string{"task-batch-a", "task-batch-b"}, "wf-source", "step-full")
+	if err == nil {
+		t.Fatalf("expected selected batch move to be rejected")
+	}
+	if !strings.Contains(err.Error(), "WIP limit") {
+		t.Fatalf("error = %q, want WIP limit rejection", err.Error())
+	}
+
+	for _, id := range []string{"task-batch-a", "task-batch-b"} {
+		task, err := repo.GetTask(ctx, id)
+		if err != nil {
+			t.Fatalf("GetTask(%s): %v", id, err)
+		}
+		if task.WorkflowStepID != "step-source" {
+			t.Fatalf("%s moved despite rejected batch: %s", id, task.WorkflowStepID)
 		}
 	}
 }

--- a/apps/backend/internal/workflow/controller/controller.go
+++ b/apps/backend/internal/workflow/controller/controller.go
@@ -243,6 +243,34 @@ func (c *Controller) validatePullFromStep(ctx context.Context, step *models.Work
 	if source.WorkflowID != step.WorkflowID {
 		return fmt.Errorf("pull_from_step_id must reference a step in the same workflow")
 	}
+	if err := c.validatePullFromStepAcyclic(ctx, step.ID, source); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *Controller) validatePullFromStepAcyclic(ctx context.Context, stepID string, source *models.WorkflowStep) error {
+	if stepID == "" {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	for current := source; current != nil && current.PullFromStepID != ""; {
+		if current.PullFromStepID == stepID {
+			return fmt.Errorf("pull_from_step_id cannot create a pull cycle")
+		}
+		if _, ok := seen[current.ID]; ok {
+			return fmt.Errorf("pull_from_step_id cannot create a pull cycle")
+		}
+		seen[current.ID] = struct{}{}
+		next, err := c.svc.GetStep(ctx, current.PullFromStepID)
+		if err != nil {
+			return fmt.Errorf("pull_from_step_id is invalid: %w", err)
+		}
+		if next.WorkflowID != source.WorkflowID {
+			return fmt.Errorf("pull_from_step_id must reference a step in the same workflow")
+		}
+		current = next
+	}
 	return nil
 }
 

--- a/apps/backend/internal/workflow/controller/controller.go
+++ b/apps/backend/internal/workflow/controller/controller.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/kandev/kandev/internal/workflow/models"
@@ -105,6 +106,8 @@ type CreateStepRequest struct {
 	IsStartStep               *bool              `json:"is_start_step,omitempty"`
 	ShowInCommandPanel        *bool              `json:"show_in_command_panel,omitempty"`
 	AutoAdvanceRequiresSignal *bool              `json:"auto_advance_requires_signal,omitempty"`
+	WIPLimit                  *int               `json:"wip_limit,omitempty"`
+	PullFromStepID            *string            `json:"pull_from_step_id,omitempty"`
 }
 
 // CreateStep creates a new workflow step.
@@ -131,6 +134,18 @@ func (c *Controller) CreateStep(ctx context.Context, req CreateStepRequest) (*Ge
 	if req.AutoAdvanceRequiresSignal != nil {
 		step.AutoAdvanceRequiresSignal = *req.AutoAdvanceRequiresSignal
 	}
+	if req.WIPLimit != nil {
+		if *req.WIPLimit < 0 {
+			return nil, fmt.Errorf("wip_limit must be non-negative")
+		}
+		step.WIPLimit = *req.WIPLimit
+	}
+	if req.PullFromStepID != nil {
+		step.PullFromStepID = strings.TrimSpace(*req.PullFromStepID)
+	}
+	if err := c.validatePullFromStep(ctx, step); err != nil {
+		return nil, err
+	}
 	demotedStartSteps, err := c.svc.CreateStepWithStartStepUpdates(ctx, step)
 	if err != nil {
 		return nil, err
@@ -152,6 +167,8 @@ type UpdateStepRequest struct {
 	AutoArchiveAfterHours     *int               `json:"auto_archive_after_hours,omitempty"`
 	AgentProfileID            *string            `json:"agent_profile_id,omitempty"`
 	AutoAdvanceRequiresSignal *bool              `json:"auto_advance_requires_signal,omitempty"`
+	WIPLimit                  *int               `json:"wip_limit,omitempty"`
+	PullFromStepID            *string            `json:"pull_from_step_id,omitempty"`
 }
 
 // UpdateStep updates an existing workflow step.
@@ -193,11 +210,40 @@ func (c *Controller) UpdateStep(ctx context.Context, req UpdateStepRequest) (*Ge
 	if req.AutoAdvanceRequiresSignal != nil {
 		step.AutoAdvanceRequiresSignal = *req.AutoAdvanceRequiresSignal
 	}
+	if req.WIPLimit != nil {
+		if *req.WIPLimit < 0 {
+			return nil, fmt.Errorf("wip_limit must be non-negative")
+		}
+		step.WIPLimit = *req.WIPLimit
+	}
+	if req.PullFromStepID != nil {
+		step.PullFromStepID = strings.TrimSpace(*req.PullFromStepID)
+	}
+	if err := c.validatePullFromStep(ctx, step); err != nil {
+		return nil, err
+	}
 	demotedStartSteps, err := c.svc.UpdateStepWithStartStepUpdates(ctx, step)
 	if err != nil {
 		return nil, err
 	}
 	return &GetStepResponse{Step: step, DemotedStartSteps: demotedStartSteps}, nil
+}
+
+func (c *Controller) validatePullFromStep(ctx context.Context, step *models.WorkflowStep) error {
+	if step.PullFromStepID == "" {
+		return nil
+	}
+	if step.ID != "" && step.PullFromStepID == step.ID {
+		return fmt.Errorf("pull_from_step_id cannot reference the same step")
+	}
+	source, err := c.svc.GetStep(ctx, step.PullFromStepID)
+	if err != nil {
+		return fmt.Errorf("pull_from_step_id is invalid: %w", err)
+	}
+	if source.WorkflowID != step.WorkflowID {
+		return fmt.Errorf("pull_from_step_id must reference a step in the same workflow")
+	}
+	return nil
 }
 
 // DeleteStep deletes a workflow step.

--- a/apps/backend/internal/workflow/handlers/handlers.go
+++ b/apps/backend/internal/workflow/handlers/handlers.go
@@ -162,7 +162,7 @@ func (h *Handlers) httpCreateStep(c *gin.Context) {
 	resp, err := h.controller.CreateStep(c.Request.Context(), req)
 	if err != nil {
 		h.logger.Error("failed to create step", zap.Error(err))
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create step"})
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
 	c.JSON(http.StatusCreated, resp.Step)
@@ -178,7 +178,7 @@ func (h *Handlers) httpUpdateStep(c *gin.Context) {
 	resp, err := h.controller.UpdateStep(c.Request.Context(), req)
 	if err != nil {
 		h.logger.Error("failed to update step", zap.Error(err))
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update step"})
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
 	c.JSON(http.StatusOK, resp.Step)

--- a/apps/backend/internal/workflow/handlers/handlers.go
+++ b/apps/backend/internal/workflow/handlers/handlers.go
@@ -162,7 +162,7 @@ func (h *Handlers) httpCreateStep(c *gin.Context) {
 	resp, err := h.controller.CreateStep(c.Request.Context(), req)
 	if err != nil {
 		h.logger.Error("failed to create step", zap.Error(err))
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		h.writeStepMutationError(c, err)
 		return
 	}
 	c.JSON(http.StatusCreated, resp.Step)
@@ -178,10 +178,29 @@ func (h *Handlers) httpUpdateStep(c *gin.Context) {
 	resp, err := h.controller.UpdateStep(c.Request.Context(), req)
 	if err != nil {
 		h.logger.Error("failed to update step", zap.Error(err))
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		h.writeStepMutationError(c, err)
 		return
 	}
 	c.JSON(http.StatusOK, resp.Step)
+}
+
+func (h *Handlers) writeStepMutationError(c *gin.Context, err error) {
+	msg := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(msg, "not found"):
+		c.JSON(http.StatusNotFound, gin.H{"error": "Step not found"})
+	case isStepValidationError(msg):
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+	default:
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to save step"})
+	}
+}
+
+func isStepValidationError(msg string) bool {
+	return strings.Contains(msg, "wip_limit must be non-negative") ||
+		strings.Contains(msg, "pull_from_step_id") ||
+		strings.Contains(msg, "same workflow") ||
+		strings.Contains(msg, "pull cycle")
 }
 
 func (h *Handlers) httpDeleteStep(c *gin.Context) {

--- a/apps/backend/internal/workflow/handlers/handlers.go
+++ b/apps/backend/internal/workflow/handlers/handlers.go
@@ -187,10 +187,10 @@ func (h *Handlers) httpUpdateStep(c *gin.Context) {
 func (h *Handlers) writeStepMutationError(c *gin.Context, err error) {
 	msg := strings.ToLower(err.Error())
 	switch {
-	case strings.Contains(msg, "not found"):
-		c.JSON(http.StatusNotFound, gin.H{"error": "Step not found"})
 	case isStepValidationError(msg):
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+	case strings.Contains(msg, "not found"):
+		c.JSON(http.StatusNotFound, gin.H{"error": "Step not found"})
 	default:
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to save step"})
 	}

--- a/apps/backend/internal/workflow/models/export.go
+++ b/apps/backend/internal/workflow/models/export.go
@@ -53,6 +53,8 @@ type StepPortable struct {
 	AutoArchiveAfterHours     int                   `json:"auto_archive_after_hours,omitempty" yaml:"auto_archive_after_hours,omitempty"`
 	AgentProfile              *AgentProfilePortable `json:"agent_profile,omitempty" yaml:"agent_profile,omitempty"`
 	AutoAdvanceRequiresSignal bool                  `json:"auto_advance_requires_signal" yaml:"auto_advance_requires_signal"`
+	WIPLimit                  int                   `json:"wip_limit,omitempty" yaml:"wip_limit,omitempty"`
+	PullFromStepPosition      *int                  `json:"pull_from_step_position,omitempty" yaml:"pull_from_step_position,omitempty"`
 }
 
 // BuildWorkflowExport builds a portable WorkflowExport from domain models.
@@ -90,6 +92,10 @@ func buildWorkflowPortable(wf *taskmodels.Workflow, steps []*WorkflowStep, resol
 			AllowManualMove:           s.AllowManualMove,
 			AutoArchiveAfterHours:     s.AutoArchiveAfterHours,
 			AutoAdvanceRequiresSignal: s.AutoAdvanceRequiresSignal,
+			WIPLimit:                  s.WIPLimit,
+		}
+		if pos, ok := idToPos[s.PullFromStepID]; ok {
+			sp.PullFromStepPosition = &pos
 		}
 		if resolveProfile != nil && s.AgentProfileID != "" {
 			sp.AgentProfile = resolveProfile(s.AgentProfileID)
@@ -135,13 +141,43 @@ func (e *WorkflowExport) Validate() error {
 			if err := validateOnEnterActions(step); err != nil {
 				return fmt.Errorf("workflow %d step %d: %w", i, j, err)
 			}
+			if step.WIPLimit < 0 {
+				return fmt.Errorf("workflow %d step %d: wip_limit must be non-negative", i, j)
+			}
 		}
 		// Validate that move_to_step references point to valid positions.
 		if err := validateStepPositionRefs(wf.Steps, positions); err != nil {
 			return fmt.Errorf("workflow %d: %w", i, err)
 		}
+		if err := validatePullSourceRefs(wf.Steps, positions); err != nil {
+			return fmt.Errorf("workflow %d: %w", i, err)
+		}
 	}
 	return nil
+}
+
+func validatePullSourceRefs(steps []StepPortable, validPositions map[int]bool) error {
+	for _, step := range steps {
+		if step.PullFromStepPosition == nil {
+			continue
+		}
+		pos := *step.PullFromStepPosition
+		if pos == step.Position {
+			return fmt.Errorf("step %q: pull_from_step_position cannot reference itself", step.Name)
+		}
+		if !validPositions[pos] {
+			return fmt.Errorf("step %q: pull_from_step_position %d does not match any step", step.Name, pos)
+		}
+	}
+	return nil
+}
+
+// PullFromStepID maps the portable pull-source position to a workflow-step ID.
+func (s StepPortable) PullFromStepID(posToID map[int]string) string {
+	if s.PullFromStepPosition == nil {
+		return ""
+	}
+	return posToID[*s.PullFromStepPosition]
 }
 
 // validateOnEnterActions rejects malformed on_enter actions in a portable step.

--- a/apps/backend/internal/workflow/models/export.go
+++ b/apps/backend/internal/workflow/models/export.go
@@ -157,6 +157,7 @@ func (e *WorkflowExport) Validate() error {
 }
 
 func validatePullSourceRefs(steps []StepPortable, validPositions map[int]bool) error {
+	pullSources := make(map[int]int, len(steps))
 	for _, step := range steps {
 		if step.PullFromStepPosition == nil {
 			continue
@@ -168,8 +169,44 @@ func validatePullSourceRefs(steps []StepPortable, validPositions map[int]bool) e
 		if !validPositions[pos] {
 			return fmt.Errorf("step %q: pull_from_step_position %d does not match any step", step.Name, pos)
 		}
+		pullSources[step.Position] = pos
+	}
+	if hasPullSourceCycle(pullSources) {
+		return fmt.Errorf("pull_from_step_position cannot create a pull cycle")
 	}
 	return nil
+}
+
+func hasPullSourceCycle(pullSources map[int]int) bool {
+	const (
+		visiting = 1
+		visited  = 2
+	)
+
+	states := make(map[int]int, len(pullSources))
+	for start := range pullSources {
+		if states[start] == visited {
+			continue
+		}
+		current := start
+		path := make([]int, 0)
+		for states[current] != visited {
+			if states[current] == visiting {
+				return true
+			}
+			states[current] = visiting
+			path = append(path, current)
+			next, ok := pullSources[current]
+			if !ok {
+				break
+			}
+			current = next
+		}
+		for _, position := range path {
+			states[position] = visited
+		}
+	}
+	return false
 }
 
 // PullFromStepID maps the portable pull-source position to a workflow-step ID.

--- a/apps/backend/internal/workflow/models/export_test.go
+++ b/apps/backend/internal/workflow/models/export_test.go
@@ -254,6 +254,15 @@ func TestValidate(t *testing.T) {
 		e.Workflows[0].Steps[1].PullFromStepPosition = &pos
 		assert.ErrorContains(t, e.Validate(), "cannot reference itself")
 	})
+
+	t.Run("pull source cycle fails", func(t *testing.T) {
+		e := validExport()
+		firstPosition := 0
+		secondPosition := 1
+		e.Workflows[0].Steps[0].PullFromStepPosition = &secondPosition
+		e.Workflows[0].Steps[1].PullFromStepPosition = &firstPosition
+		assert.ErrorContains(t, e.Validate(), "cannot create a pull cycle")
+	})
 }
 
 func TestConvertStepIDToPosition(t *testing.T) {

--- a/apps/backend/internal/workflow/models/export_test.go
+++ b/apps/backend/internal/workflow/models/export_test.go
@@ -66,6 +66,32 @@ func TestBuildWorkflowExport(t *testing.T) {
 		assert.Len(t, sp.Events.OnTurnStart, 1)
 		assert.Equal(t, OnTurnStartMoveToNext, sp.Events.OnTurnStart[0].Type)
 	})
+
+	t.Run("exports pull source as portable step position", func(t *testing.T) {
+		wf := &taskmodels.Workflow{ID: "wf-1", Name: "Pull Workflow"}
+		steps := []*WorkflowStep{
+			{ID: "queue", Name: "Queue", Position: 0, Color: "gray"},
+			{
+				ID:             "work",
+				Name:           "Work",
+				Position:       1,
+				Color:          "blue",
+				WIPLimit:       1,
+				PullFromStepID: "queue",
+			},
+		}
+
+		export := BuildWorkflowExport(
+			[]*taskmodels.Workflow{wf},
+			map[string][]*WorkflowStep{"wf-1": steps},
+			nil,
+		)
+
+		require.Len(t, export.Workflows[0].Steps, 2)
+		assert.Equal(t, 1, export.Workflows[0].Steps[1].WIPLimit)
+		require.NotNil(t, export.Workflows[0].Steps[1].PullFromStepPosition)
+		assert.Equal(t, 0, *export.Workflows[0].Steps[1].PullFromStepPosition)
+	})
 }
 
 func TestValidate(t *testing.T) {
@@ -213,6 +239,20 @@ func TestValidate(t *testing.T) {
 			},
 		}
 		assert.ErrorContains(t, e.Validate(), "unexpected type")
+	})
+
+	t.Run("invalid pull source position fails", func(t *testing.T) {
+		e := validExport()
+		pos := 99
+		e.Workflows[0].Steps[1].PullFromStepPosition = &pos
+		assert.ErrorContains(t, e.Validate(), "pull_from_step_position 99 does not match any step")
+	})
+
+	t.Run("self pull source position fails", func(t *testing.T) {
+		e := validExport()
+		pos := 1
+		e.Workflows[0].Steps[1].PullFromStepPosition = &pos
+		assert.ErrorContains(t, e.Validate(), "cannot reference itself")
 	})
 }
 
@@ -380,6 +420,19 @@ func TestAutoAdvanceRequiresSignalExport(t *testing.T) {
 		assert.False(t, export.Workflows[0].Steps[0].AutoAdvanceRequiresSignal)
 		assert.True(t, export.Workflows[0].Steps[1].AutoAdvanceRequiresSignal)
 	})
+}
+
+func TestPullFromStepPositionToID(t *testing.T) {
+	position := 0
+	step := StepPortable{
+		Name:                 "Work",
+		Position:             1,
+		WIPLimit:             1,
+		PullFromStepPosition: &position,
+	}
+	posToID := map[int]string{0: "queue-id", 1: "work-id"}
+
+	assert.Equal(t, "queue-id", step.PullFromStepID(posToID))
 }
 
 func TestShowInCommandPanelExport(t *testing.T) {

--- a/apps/backend/internal/workflow/models/models.go
+++ b/apps/backend/internal/workflow/models/models.go
@@ -173,6 +173,8 @@ type StepDefinition struct {
 	ShowInCommandPanel    bool       `json:"show_in_command_panel"`
 	AutoArchiveAfterHours int        `json:"auto_archive_after_hours,omitempty"`
 	AgentProfileID        string     `json:"agent_profile_id,omitempty"`
+	WIPLimit              int        `json:"wip_limit,omitempty" yaml:"wip_limit,omitempty"`
+	PullFromStepID        string     `json:"pull_from_step_id,omitempty" yaml:"pull_from_step_id,omitempty"`
 	// StageType mirrors WorkflowStep.StageType for templates so the office
 	// default + coordination workflows can declare their UX role
 	// ("work", "review", "approval", "custom") in YAML.
@@ -196,6 +198,8 @@ type WorkflowStep struct {
 	ShowInCommandPanel    bool       `json:"show_in_command_panel"`
 	AutoArchiveAfterHours int        `json:"auto_archive_after_hours,omitempty"`
 	AgentProfileID        string     `json:"agent_profile_id,omitempty"`
+	WIPLimit              int        `json:"wip_limit,omitempty"`
+	PullFromStepID        string     `json:"pull_from_step_id,omitempty"`
 	// StageType is a Phase 2 (ADR-0004) semantic hint for the frontend
 	// ("work", "review", "approval", "custom"). The engine does not branch
 	// on it. Stored as TEXT in workflow_steps.stage_type, defaulting to
@@ -234,6 +238,18 @@ func (s *WorkflowStep) HasOnTurnCompleteAction(actionType OnTurnCompleteActionTy
 		}
 	}
 	return false
+}
+
+// RemapStepID returns the mapped workflow-step ID when id references a template
+// step alias; otherwise it returns id unchanged.
+func RemapStepID(id string, idMap map[string]string) string {
+	if id == "" {
+		return ""
+	}
+	if mapped, ok := idMap[id]; ok {
+		return mapped
+	}
+	return id
 }
 
 // StepTransitionTrigger represents how a session moved between steps

--- a/apps/backend/internal/workflow/repository/sqlite.go
+++ b/apps/backend/internal/workflow/repository/sqlite.go
@@ -847,15 +847,13 @@ func (r *Repository) ClearStepReferences(ctx context.Context, workflowID, stepID
 				}
 			}
 		}
+		if step.PullFromStepID == stepID {
+			step.PullFromStepID = ""
+			modified = true
+		}
 		if modified {
 			if err := r.UpdateStep(ctx, step); err != nil {
 				return fmt.Errorf("failed to clear step reference from step %s: %w", step.ID, err)
-			}
-		}
-		if step.PullFromStepID == stepID {
-			step.PullFromStepID = ""
-			if err := r.UpdateStep(ctx, step); err != nil {
-				return fmt.Errorf("failed to clear pull source from step %s: %w", step.ID, err)
 			}
 		}
 	}

--- a/apps/backend/internal/workflow/repository/sqlite.go
+++ b/apps/backend/internal/workflow/repository/sqlite.go
@@ -71,6 +71,8 @@ func (r *Repository) initSchema() error {
 		is_start_step INTEGER DEFAULT 0,
 		show_in_command_panel INTEGER DEFAULT 1,
 		auto_archive_after_hours INTEGER DEFAULT 0,
+		wip_limit INTEGER NOT NULL DEFAULT 0,
+		pull_from_step_id TEXT NOT NULL DEFAULT '',
 		created_at TIMESTAMP NOT NULL,
 		updated_at TIMESTAMP NOT NULL,
 		FOREIGN KEY (workflow_id) REFERENCES workflows(id) ON DELETE CASCADE
@@ -116,6 +118,12 @@ func (r *Repository) initSchema() error {
 	// MCP signal. Idempotent ALTER; existing rows keep today's behaviour
 	// (immediate transition on turn-end) until the column is set to 1.
 	r.migrate.Apply("workflow_steps.auto_advance_requires_signal", `ALTER TABLE workflow_steps ADD COLUMN auto_advance_requires_signal INTEGER NOT NULL DEFAULT 0`)
+	r.migrate.Apply("workflow_steps.wip_limit", `ALTER TABLE workflow_steps ADD COLUMN wip_limit INTEGER NOT NULL DEFAULT 0`)
+	r.migrate.Apply("workflow_steps.pull_from_step_id", `ALTER TABLE workflow_steps ADD COLUMN pull_from_step_id TEXT NOT NULL DEFAULT ''`)
+	r.migrate.Apply("idx_workflow_steps_pull_from", `
+		CREATE INDEX IF NOT EXISTS idx_workflow_steps_pull_from
+		ON workflow_steps(pull_from_step_id)
+	`)
 
 	// Phase 2 — multi-agent participation tables. Empty rows for a step
 	// preserve today's single-agent behaviour, so existing kanban
@@ -223,12 +231,12 @@ func (r *Repository) seedDefaultWorkflowSteps() error {
 			if _, err := r.db.Exec(r.db.Rebind(`
 				INSERT INTO workflow_steps (
 					id, workflow_id, name, position, color,
-					prompt, events, allow_manual_move, is_start_step, show_in_command_panel, created_at, updated_at
-				) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+					prompt, events, allow_manual_move, is_start_step, show_in_command_panel, wip_limit, pull_from_step_id, created_at, updated_at
+				) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 			`),
 				idMap[stepDef.ID], workflowID, stepDef.Name, stepDef.Position, stepDef.Color,
 				stepDef.Prompt, string(eventsJSON), dialect.BoolToInt(stepDef.AllowManualMove),
-				dialect.BoolToInt(stepDef.IsStartStep), dialect.BoolToInt(stepDef.ShowInCommandPanel), now, now,
+				dialect.BoolToInt(stepDef.IsStartStep), dialect.BoolToInt(stepDef.ShowInCommandPanel), stepDef.WIPLimit, models.RemapStepID(stepDef.PullFromStepID, idMap), now, now,
 			); err != nil {
 				return err
 			}
@@ -613,11 +621,11 @@ func (r *Repository) CreateStepWithDemotedStartSteps(ctx context.Context, step *
 	_, err = tx.ExecContext(ctx, tx.Rebind(`
 		INSERT INTO workflow_steps (
 			id, workflow_id, name, position, color,
-			prompt, events, allow_manual_move, is_start_step, show_in_command_panel, auto_archive_after_hours, agent_profile_id, stage_type, auto_advance_requires_signal, created_at, updated_at
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			prompt, events, allow_manual_move, is_start_step, show_in_command_panel, auto_archive_after_hours, agent_profile_id, stage_type, auto_advance_requires_signal, wip_limit, pull_from_step_id, created_at, updated_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`), step.ID, step.WorkflowID, step.Name, step.Position, step.Color,
 		step.Prompt, string(eventsJSON), dialect.BoolToInt(step.AllowManualMove),
-		dialect.BoolToInt(step.IsStartStep), dialect.BoolToInt(step.ShowInCommandPanel), step.AutoArchiveAfterHours, step.AgentProfileID, normalizeStageType(step.StageType), dialect.BoolToInt(step.AutoAdvanceRequiresSignal), step.CreatedAt, step.UpdatedAt)
+		dialect.BoolToInt(step.IsStartStep), dialect.BoolToInt(step.ShowInCommandPanel), step.AutoArchiveAfterHours, step.AgentProfileID, normalizeStageType(step.StageType), dialect.BoolToInt(step.AutoAdvanceRequiresSignal), step.WIPLimit, step.PullFromStepID, step.CreatedAt, step.UpdatedAt)
 	if err != nil {
 		return nil, err
 	}
@@ -646,10 +654,10 @@ func (r *Repository) scanStep(row interface {
 	step := &models.WorkflowStep{}
 	var allowManualMove, isStartStep, showInCommandPanel, autoAdvanceRequiresSignal int
 	var autoArchiveAfterHours sql.NullInt64
-	var color, prompt, eventsJSON, agentProfileID, stageType sql.NullString
+	var color, prompt, eventsJSON, agentProfileID, stageType, pullFromStepID sql.NullString
 
 	err := row.Scan(&step.ID, &step.WorkflowID, &step.Name, &step.Position, &color,
-		&prompt, &eventsJSON, &allowManualMove, &isStartStep, &showInCommandPanel, &autoArchiveAfterHours, &agentProfileID, &stageType, &autoAdvanceRequiresSignal, &step.CreatedAt, &step.UpdatedAt)
+		&prompt, &eventsJSON, &allowManualMove, &isStartStep, &showInCommandPanel, &autoArchiveAfterHours, &agentProfileID, &stageType, &autoAdvanceRequiresSignal, &step.WIPLimit, &pullFromStepID, &step.CreatedAt, &step.UpdatedAt)
 
 	if err != nil {
 		return nil, err
@@ -670,6 +678,9 @@ func (r *Repository) scanStep(row interface {
 	} else {
 		step.StageType = models.StageTypeCustom
 	}
+	if pullFromStepID.Valid {
+		step.PullFromStepID = pullFromStepID.String
+	}
 	if color.Valid {
 		step.Color = color.String
 	}
@@ -685,7 +696,7 @@ func (r *Repository) scanStep(row interface {
 	return step, nil
 }
 
-const stepSelectColumns = `id, workflow_id, name, position, color, prompt, events, allow_manual_move, is_start_step, show_in_command_panel, auto_archive_after_hours, agent_profile_id, stage_type, auto_advance_requires_signal, created_at, updated_at`
+const stepSelectColumns = `id, workflow_id, name, position, color, prompt, events, allow_manual_move, is_start_step, show_in_command_panel, auto_archive_after_hours, agent_profile_id, stage_type, auto_advance_requires_signal, wip_limit, pull_from_step_id, created_at, updated_at`
 
 // GetStep retrieves a workflow step by ID.
 func (r *Repository) GetStep(ctx context.Context, id string) (*models.WorkflowStep, error) {
@@ -738,11 +749,11 @@ func (r *Repository) UpdateStepWithDemotedStartSteps(ctx context.Context, step *
 		UPDATE workflow_steps SET
 			name = ?, position = ?, color = ?,
 			prompt = ?, events = ?,
-			allow_manual_move = ?, is_start_step = ?, show_in_command_panel = ?, auto_archive_after_hours = ?, agent_profile_id = ?, stage_type = ?, auto_advance_requires_signal = ?, updated_at = ?
+			allow_manual_move = ?, is_start_step = ?, show_in_command_panel = ?, auto_archive_after_hours = ?, agent_profile_id = ?, stage_type = ?, auto_advance_requires_signal = ?, wip_limit = ?, pull_from_step_id = ?, updated_at = ?
 		WHERE id = ?
 	`), step.Name, step.Position, step.Color,
 		step.Prompt, string(eventsJSON),
-		dialect.BoolToInt(step.AllowManualMove), dialect.BoolToInt(step.IsStartStep), dialect.BoolToInt(step.ShowInCommandPanel), step.AutoArchiveAfterHours, step.AgentProfileID, normalizeStageType(step.StageType), dialect.BoolToInt(step.AutoAdvanceRequiresSignal), step.UpdatedAt, step.ID)
+		dialect.BoolToInt(step.AllowManualMove), dialect.BoolToInt(step.IsStartStep), dialect.BoolToInt(step.ShowInCommandPanel), step.AutoArchiveAfterHours, step.AgentProfileID, normalizeStageType(step.StageType), dialect.BoolToInt(step.AutoAdvanceRequiresSignal), step.WIPLimit, step.PullFromStepID, step.UpdatedAt, step.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -841,6 +852,12 @@ func (r *Repository) ClearStepReferences(ctx context.Context, workflowID, stepID
 				return fmt.Errorf("failed to clear step reference from step %s: %w", step.ID, err)
 			}
 		}
+		if step.PullFromStepID == stepID {
+			step.PullFromStepID = ""
+			if err := r.UpdateStep(ctx, step); err != nil {
+				return fmt.Errorf("failed to clear pull source from step %s: %w", step.ID, err)
+			}
+		}
 	}
 
 	return nil
@@ -878,7 +895,7 @@ func (r *Repository) ListStepsByWorkflow(ctx context.Context, workflowID string)
 func (r *Repository) ListStepsByWorkspaceID(ctx context.Context, workspaceID string) ([]*models.WorkflowStep, error) {
 	rows, err := r.ro.QueryContext(ctx, r.ro.Rebind(`
 		SELECT ws.id, ws.workflow_id, ws.name, ws.position, ws.color, ws.prompt, ws.events,
-			ws.allow_manual_move, ws.is_start_step, ws.show_in_command_panel, ws.auto_archive_after_hours, ws.agent_profile_id, ws.stage_type, ws.auto_advance_requires_signal, ws.created_at, ws.updated_at
+			ws.allow_manual_move, ws.is_start_step, ws.show_in_command_panel, ws.auto_archive_after_hours, ws.agent_profile_id, ws.stage_type, ws.auto_advance_requires_signal, ws.wip_limit, ws.pull_from_step_id, ws.created_at, ws.updated_at
 		FROM workflow_steps ws
 		JOIN workflows w ON ws.workflow_id = w.id
 		WHERE w.workspace_id = ?

--- a/apps/backend/internal/workflow/repository/sqlite_test.go
+++ b/apps/backend/internal/workflow/repository/sqlite_test.go
@@ -151,6 +151,7 @@ func TestWorkflowStepWIPFields_ReplayMigrationDefaultsExistingRows(t *testing.T)
 	if err != nil {
 		t.Fatalf("failed to open sqlite: %v", err)
 	}
+	rawDB.SetMaxOpenConns(1)
 	db := sqlx.NewDb(rawDB, "sqlite3")
 	t.Cleanup(func() { _ = db.Close() })
 
@@ -352,6 +353,7 @@ func TestInitSchema_NormalizesDuplicateStartSteps(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to open sqlite: %v", err)
 	}
+	rawDB.SetMaxOpenConns(1)
 	db := sqlx.NewDb(rawDB, "sqlite3")
 	t.Cleanup(func() { _ = db.Close() })
 	ctx := context.Background()

--- a/apps/backend/internal/workflow/repository/sqlite_test.go
+++ b/apps/backend/internal/workflow/repository/sqlite_test.go
@@ -22,6 +22,7 @@ func setupTestRepoWithDB(t *testing.T) (*Repository, *sqlx.DB) {
 	if err != nil {
 		t.Fatalf("failed to open sqlite: %v", err)
 	}
+	rawDB.SetMaxOpenConns(1)
 	sqlxDB := sqlx.NewDb(rawDB, "sqlite3")
 	t.Cleanup(func() { _ = sqlxDB.Close() })
 	// Enable FK enforcement explicitly so workflow_step_participants

--- a/apps/backend/internal/workflow/repository/sqlite_test.go
+++ b/apps/backend/internal/workflow/repository/sqlite_test.go
@@ -90,6 +90,156 @@ func TestStepAgentProfileID_CreateAndGet(t *testing.T) {
 	}
 }
 
+func TestWorkflowStepWIPFields_CreateUpdateAndGet(t *testing.T) {
+	repo := setupTestRepo(t)
+	ctx := context.Background()
+
+	feeder := &models.WorkflowStep{
+		WorkflowID: "wf-test",
+		Name:       "Queue",
+		Position:   0,
+		Color:      "#999999",
+	}
+	if err := repo.CreateStep(ctx, feeder); err != nil {
+		t.Fatalf("failed to create feeder step: %v", err)
+	}
+
+	step := &models.WorkflowStep{
+		WorkflowID:      "wf-test",
+		Name:            "Work",
+		Position:        1,
+		Color:           "#000000",
+		WIPLimit:        2,
+		PullFromStepID:  feeder.ID,
+		AllowManualMove: true,
+	}
+	if err := repo.CreateStep(ctx, step); err != nil {
+		t.Fatalf("failed to create step: %v", err)
+	}
+
+	retrieved, err := repo.GetStep(ctx, step.ID)
+	if err != nil {
+		t.Fatalf("failed to get step: %v", err)
+	}
+	if retrieved.WIPLimit != 2 {
+		t.Fatalf("WIPLimit = %d, want 2", retrieved.WIPLimit)
+	}
+	if retrieved.PullFromStepID != feeder.ID {
+		t.Fatalf("PullFromStepID = %q, want %q", retrieved.PullFromStepID, feeder.ID)
+	}
+
+	retrieved.WIPLimit = 1
+	retrieved.PullFromStepID = ""
+	if err := repo.UpdateStep(ctx, retrieved); err != nil {
+		t.Fatalf("failed to update step: %v", err)
+	}
+	updated, err := repo.GetStep(ctx, step.ID)
+	if err != nil {
+		t.Fatalf("failed to get updated step: %v", err)
+	}
+	if updated.WIPLimit != 1 {
+		t.Fatalf("updated WIPLimit = %d, want 1", updated.WIPLimit)
+	}
+	if updated.PullFromStepID != "" {
+		t.Fatalf("updated PullFromStepID = %q, want empty", updated.PullFromStepID)
+	}
+}
+
+func TestWorkflowStepWIPFields_ReplayMigrationDefaultsExistingRows(t *testing.T) {
+	rawDB, err := sql.Open("sqlite3", ":memory:?_foreign_keys=on")
+	if err != nil {
+		t.Fatalf("failed to open sqlite: %v", err)
+	}
+	db := sqlx.NewDb(rawDB, "sqlite3")
+	t.Cleanup(func() { _ = db.Close() })
+
+	_, err = db.Exec(`
+		CREATE TABLE workflows (
+			id TEXT PRIMARY KEY, workspace_id TEXT NOT NULL DEFAULT '',
+			workflow_template_id TEXT DEFAULT '', name TEXT NOT NULL,
+			description TEXT DEFAULT '', created_at TIMESTAMP NOT NULL, updated_at TIMESTAMP NOT NULL
+		);
+		CREATE TABLE task_sessions (id TEXT PRIMARY KEY);
+		CREATE TABLE workflow_steps (
+			id TEXT PRIMARY KEY,
+			workflow_id TEXT NOT NULL,
+			name TEXT NOT NULL,
+			position INTEGER NOT NULL,
+			color TEXT,
+			prompt TEXT,
+			events TEXT,
+			allow_manual_move INTEGER DEFAULT 1,
+			is_start_step INTEGER DEFAULT 0,
+			show_in_command_panel INTEGER DEFAULT 1,
+			auto_archive_after_hours INTEGER DEFAULT 0,
+			agent_profile_id TEXT DEFAULT '',
+			stage_type TEXT NOT NULL DEFAULT 'custom',
+			auto_advance_requires_signal INTEGER NOT NULL DEFAULT 0,
+			created_at TIMESTAMP NOT NULL,
+			updated_at TIMESTAMP NOT NULL,
+			FOREIGN KEY (workflow_id) REFERENCES workflows(id) ON DELETE CASCADE
+		);
+		INSERT INTO workflows (id, workspace_id, name, created_at, updated_at)
+			VALUES ('wf-test', '', 'Test', datetime('now'), datetime('now'));
+		INSERT INTO workflow_steps (
+			id, workflow_id, name, position, created_at, updated_at
+		) VALUES ('legacy-step', 'wf-test', 'Legacy Step', 0, datetime('now'), datetime('now'));
+	`)
+	if err != nil {
+		t.Fatalf("seed legacy database: %v", err)
+	}
+
+	reopened, err := NewWithDB(db, db, nil)
+	if err != nil {
+		t.Fatalf("reopen repo: %v", err)
+	}
+	step, err := reopened.GetStep(context.Background(), "legacy-step")
+	if err != nil {
+		t.Fatalf("get legacy step: %v", err)
+	}
+	if step.WIPLimit != 0 {
+		t.Fatalf("WIPLimit = %d, want default 0", step.WIPLimit)
+	}
+	if step.PullFromStepID != "" {
+		t.Fatalf("PullFromStepID = %q, want default empty", step.PullFromStepID)
+	}
+}
+
+func TestClearStepReferencesClearsPullSource(t *testing.T) {
+	repo := setupTestRepo(t)
+	ctx := context.Background()
+
+	feeder := &models.WorkflowStep{
+		WorkflowID: "wf-test",
+		Name:       "Queue",
+		Position:   0,
+	}
+	if err := repo.CreateStep(ctx, feeder); err != nil {
+		t.Fatalf("failed to create feeder: %v", err)
+	}
+	consumer := &models.WorkflowStep{
+		WorkflowID:     "wf-test",
+		Name:           "Work",
+		Position:       1,
+		WIPLimit:       1,
+		PullFromStepID: feeder.ID,
+	}
+	if err := repo.CreateStep(ctx, consumer); err != nil {
+		t.Fatalf("failed to create consumer: %v", err)
+	}
+
+	if err := repo.ClearStepReferences(ctx, "wf-test", feeder.ID); err != nil {
+		t.Fatalf("clear references: %v", err)
+	}
+	got, err := repo.GetStep(ctx, consumer.ID)
+	if err != nil {
+		t.Fatalf("get consumer: %v", err)
+	}
+	if got.PullFromStepID != "" {
+		t.Fatalf("PullFromStepID = %q, want empty", got.PullFromStepID)
+	}
+}
+
 func TestStepAgentProfileID_Update(t *testing.T) {
 	repo := setupTestRepo(t)
 	ctx := context.Background()

--- a/apps/backend/internal/workflow/service/service.go
+++ b/apps/backend/internal/workflow/service/service.go
@@ -219,6 +219,8 @@ func (s *Service) CreateStepsFromTemplate(ctx context.Context, workflowID, templ
 			ShowInCommandPanel:    stepDef.ShowInCommandPanel,
 			AutoArchiveAfterHours: stepDef.AutoArchiveAfterHours,
 			AgentProfileID:        stepDef.AgentProfileID,
+			WIPLimit:              stepDef.WIPLimit,
+			PullFromStepID:        models.RemapStepID(stepDef.PullFromStepID, idMap),
 			StageType:             stepDef.StageType,
 		}
 
@@ -541,6 +543,8 @@ func (s *Service) importSingleWorkflow(ctx context.Context, workspaceID string, 
 			AllowManualMove:           sp.AllowManualMove,
 			AutoArchiveAfterHours:     sp.AutoArchiveAfterHours,
 			AutoAdvanceRequiresSignal: sp.AutoAdvanceRequiresSignal,
+			WIPLimit:                  sp.WIPLimit,
+			PullFromStepID:            sp.PullFromStepID(posToID),
 		}
 		// Match step-level agent profile if present.
 		if sp.AgentProfile != nil && s.matchProfile != nil {

--- a/apps/web/app/actions/workspaces.test.ts
+++ b/apps/web/app/actions/workspaces.test.ts
@@ -4,7 +4,13 @@ vi.mock("@/lib/config", () => ({
   getBackendConfig: () => ({ apiBaseUrl: "http://backend.test" }),
 }));
 
-import { deleteWorkspaceAction, exportAllWorkflowsAction } from "./workspaces";
+import {
+  createWorkflowStepAction,
+  deleteWorkspaceAction,
+  exportAllWorkflowsAction,
+  listWorkflowStepsAction,
+  updateWorkflowStepAction,
+} from "./workspaces";
 
 describe("exportAllWorkflowsAction", () => {
   beforeEach(() => {
@@ -66,5 +72,93 @@ describe("deleteWorkspaceAction", () => {
     expect(url).toBe("http://backend.test/api/v1/office/workspaces/ws-1");
     expect(init.method).toBe("DELETE");
     expect(JSON.parse(init.body as string)).toEqual({ confirm_name: "My Workspace" });
+  });
+});
+
+describe("workflow step WIP fields", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json({
+          id: "step-1",
+          workflow_id: "wf-1",
+          name: "Review",
+          position: 1,
+          color: "bg-blue-500",
+          wip_limit: 2,
+          pull_from_step_id: "step-0",
+          created_at: "",
+          updated_at: "",
+        }),
+      ),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("preserves WIP fields returned from workflow step APIs", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json({
+          steps: [
+            {
+              id: "step-1",
+              workflow_id: "wf-1",
+              name: "Review",
+              position: 1,
+              color: "bg-blue-500",
+              wip_limit: 2,
+              pull_from_step_id: "step-0",
+              created_at: "",
+              updated_at: "",
+            },
+          ],
+        }),
+      ),
+    );
+
+    const result = await listWorkflowStepsAction("wf-1");
+
+    expect(result.steps[0]).toMatchObject({
+      wip_limit: 2,
+      pull_from_step_id: "step-0",
+    });
+  });
+
+  it("sends WIP fields when creating a workflow step", async () => {
+    await createWorkflowStepAction({
+      workflow_id: "wf-1",
+      name: "Review",
+      position: 1,
+      color: "bg-blue-500",
+      wip_limit: 2,
+      pull_from_step_id: "step-0",
+    } as Parameters<typeof createWorkflowStepAction>[0]);
+
+    const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
+    const [, init] = fetchMock.mock.calls[0];
+    expect(JSON.parse(init.body as string)).toMatchObject({
+      wip_limit: 2,
+      pull_from_step_id: "step-0",
+    });
+  });
+
+  it("sends WIP fields when updating a workflow step", async () => {
+    await updateWorkflowStepAction("step-1", {
+      wip_limit: 3,
+      pull_from_step_id: "",
+    } as Parameters<typeof updateWorkflowStepAction>[1]);
+
+    const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
+    const [, init] = fetchMock.mock.calls[0];
+    expect(JSON.parse(init.body as string)).toMatchObject({
+      wip_limit: 3,
+      pull_from_step_id: "",
+    });
   });
 });

--- a/apps/web/app/actions/workspaces.ts
+++ b/apps/web/app/actions/workspaces.ts
@@ -312,6 +312,8 @@ type BackendTemplateStep = {
   events?: StepEvents;
   is_start_step?: boolean;
   show_in_command_panel?: boolean;
+  wip_limit?: number;
+  pull_from_step_id?: string | null;
 };
 
 type BackendWorkflowTemplate = Omit<WorkflowTemplate, "default_steps"> & {
@@ -329,6 +331,8 @@ const normalizeWorkflowTemplate = (template: BackendWorkflowTemplate): WorkflowT
     events: step.events,
     is_start_step: step.is_start_step,
     show_in_command_panel: step.show_in_command_panel,
+    wip_limit: step.wip_limit,
+    pull_from_step_id: step.pull_from_step_id ?? null,
   }));
   return {
     ...template,
@@ -363,6 +367,8 @@ type BackendWorkflowStep = {
   auto_archive_after_hours?: number;
   agent_profile_id?: string;
   auto_advance_requires_signal?: boolean;
+  wip_limit?: number;
+  pull_from_step_id?: string | null;
   created_at: string;
   updated_at: string;
 };
@@ -381,6 +387,8 @@ const transformWorkflowStep = (step: BackendWorkflowStep): WorkflowStep => ({
   auto_archive_after_hours: step.auto_archive_after_hours,
   agent_profile_id: step.agent_profile_id,
   auto_advance_requires_signal: step.auto_advance_requires_signal,
+  wip_limit: step.wip_limit ?? 0,
+  pull_from_step_id: step.pull_from_step_id ?? null,
   created_at: step.created_at,
   updated_at: step.updated_at,
 });
@@ -420,6 +428,8 @@ export async function createWorkflowStepAction(payload: {
   events?: StepEvents;
   is_start_step?: boolean;
   allow_manual_move?: boolean;
+  wip_limit?: number;
+  pull_from_step_id?: string | null;
 }): Promise<WorkflowStep> {
   const body = {
     workflow_id: payload.workflow_id,
@@ -430,6 +440,8 @@ export async function createWorkflowStepAction(payload: {
     events: payload.events,
     allow_manual_move: payload.allow_manual_move ?? true,
     is_start_step: payload.is_start_step ?? false,
+    wip_limit: payload.wip_limit ?? 0,
+    pull_from_step_id: payload.pull_from_step_id ?? "",
   };
   const response = await fetchJson<BackendWorkflowStep>(`${apiBaseUrl}/api/v1/workflow/steps`, {
     method: "POST",
@@ -454,6 +466,8 @@ export async function updateWorkflowStepAction(
       | "auto_archive_after_hours"
       | "agent_profile_id"
       | "auto_advance_requires_signal"
+      | "wip_limit"
+      | "pull_from_step_id"
     >
   >,
 ): Promise<WorkflowStep> {
@@ -472,6 +486,8 @@ export async function updateWorkflowStepAction(
   if (payload.agent_profile_id !== undefined) body.agent_profile_id = payload.agent_profile_id;
   if (payload.auto_advance_requires_signal !== undefined)
     body.auto_advance_requires_signal = payload.auto_advance_requires_signal;
+  if (payload.wip_limit !== undefined) body.wip_limit = payload.wip_limit;
+  if (payload.pull_from_step_id !== undefined) body.pull_from_step_id = payload.pull_from_step_id;
   const response = await fetchJson<BackendWorkflowStep>(
     `${apiBaseUrl}/api/v1/workflow/steps/${stepId}`,
     {

--- a/apps/web/components/kanban-column.tsx
+++ b/apps/web/components/kanban-column.tsx
@@ -8,6 +8,7 @@ import { cn } from "@/lib/utils";
 import { useAppStore } from "@/components/state-provider";
 import type { KanbanExternalLinkAvailability } from "./kanban-external-link-availability";
 import type { Repository } from "@/lib/types/http";
+import { formatWipCount, isOverWipLimit } from "@/lib/kanban/wip-limit";
 
 export interface WorkflowStep {
   id: string;
@@ -17,6 +18,8 @@ export interface WorkflowStep {
     on_enter?: Array<{ type: string; config?: Record<string, unknown> }>;
     on_turn_complete?: Array<{ type: string; config?: Record<string, unknown> }>;
   };
+  wip_limit?: number;
+  pull_from_step_id?: string | null;
 }
 
 interface KanbanColumnProps {
@@ -76,6 +79,8 @@ export function KanbanColumn({
   // Ordered ids of the cards rendered in this column — the source of truth for
   // shift-click range selection (matches exactly what the user sees).
   const columnTaskIds = useMemo(() => tasks.map((t) => t.id), [tasks]);
+  const overWipLimit = isOverWipLimit(tasks.length, step.wip_limit);
+  const wipCountLabel = formatWipCount(tasks.length, step.wip_limit);
 
   return (
     <div
@@ -93,8 +98,17 @@ export function KanbanColumn({
           <div className="flex items-center gap-2">
             <div className={cn("w-2 h-2 rounded-full", step.color)} />
             <h2 className="font-semibold text-sm">{step.title}</h2>
-            <Badge variant="secondary" className="text-xs">
-              {tasks.length}
+            <Badge
+              variant="secondary"
+              className={cn(
+                "text-xs tabular-nums",
+                overWipLimit &&
+                  "border-amber-500/50 bg-amber-500/15 text-amber-700 dark:text-amber-300",
+              )}
+              aria-label={overWipLimit ? `${wipCountLabel} tasks, over WIP limit` : undefined}
+              title={overWipLimit ? "Over WIP limit" : undefined}
+            >
+              {wipCountLabel}
             </Badge>
           </div>
         </div>

--- a/apps/web/components/kanban/mobile-column-tabs.tsx
+++ b/apps/web/components/kanban/mobile-column-tabs.tsx
@@ -4,6 +4,7 @@ import { useRef, useEffect } from "react";
 import { cn } from "@/lib/utils";
 import { Badge } from "@kandev/ui/badge";
 import type { WorkflowStep } from "../kanban-column";
+import { formatWipCount, isOverWipLimit } from "@/lib/kanban/wip-limit";
 
 type MobileColumnTabsProps = {
   steps: WorkflowStep[];
@@ -45,28 +46,41 @@ export function MobileColumnTabs({
       ref={tabsRef}
       className="flex overflow-x-auto overflow-y-hidden scrollbar-hide border-b border-border px-4 gap-1"
     >
-      {steps.map((step, index) => (
-        <button
-          key={step.id}
-          ref={index === activeIndex ? activeTabRef : null}
-          data-testid={`column-tab-${index}`}
-          data-active={index === activeIndex}
-          onClick={() => onColumnChange(index)}
-          className={cn(
-            "flex items-center gap-2 px-3 py-2 text-sm font-medium whitespace-nowrap transition-colors",
-            "border-b-2 -mb-px",
-            index === activeIndex
-              ? "border-primary text-foreground"
-              : "border-transparent text-muted-foreground hover:text-foreground",
-          )}
-        >
-          <div className={cn("w-2 h-2 rounded-full flex-shrink-0", step.color)} />
-          <span className="truncate max-w-[100px]">{step.title}</span>
-          <Badge variant="secondary" className="text-xs h-5 px-1.5">
-            {taskCounts[step.id] ?? 0}
-          </Badge>
-        </button>
-      ))}
+      {steps.map((step, index) => {
+        const count = taskCounts[step.id] ?? 0;
+        const overWipLimit = isOverWipLimit(count, step.wip_limit);
+        const wipCountLabel = formatWipCount(count, step.wip_limit);
+        return (
+          <button
+            key={step.id}
+            ref={index === activeIndex ? activeTabRef : null}
+            data-testid={`column-tab-${index}`}
+            data-active={index === activeIndex}
+            onClick={() => onColumnChange(index)}
+            className={cn(
+              "flex items-center gap-2 px-3 py-2 text-sm font-medium whitespace-nowrap transition-colors",
+              "border-b-2 -mb-px",
+              index === activeIndex
+                ? "border-primary text-foreground"
+                : "border-transparent text-muted-foreground hover:text-foreground",
+            )}
+          >
+            <div className={cn("w-2 h-2 rounded-full flex-shrink-0", step.color)} />
+            <span className="truncate max-w-[100px]">{step.title}</span>
+            <Badge
+              variant="secondary"
+              className={cn(
+                "text-xs h-5 px-1.5 tabular-nums",
+                overWipLimit &&
+                  "border-amber-500/50 bg-amber-500/15 text-amber-700 dark:text-amber-300",
+              )}
+              aria-label={overWipLimit ? `${wipCountLabel} tasks, over WIP limit` : undefined}
+            >
+              {wipCountLabel}
+            </Badge>
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/apps/web/components/settings/workflow-card-actions.test.ts
+++ b/apps/web/components/settings/workflow-card-actions.test.ts
@@ -1,7 +1,13 @@
 import { act, renderHook } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
+import {
+  createWorkflowAction,
+  createWorkflowStepAction,
+  listWorkflowStepsAction,
+  updateWorkflowStepAction,
+} from "@/app/actions/workspaces";
 import type { Workflow, WorkflowStep } from "@/lib/types/http";
-import { useWorkflowStepActions } from "./workflow-card-actions";
+import { useWorkflowSaveActions, useWorkflowStepActions } from "./workflow-card-actions";
 
 vi.mock("@/app/actions/workspaces", () => ({
   createWorkflowAction: vi.fn(),
@@ -78,5 +84,65 @@ describe("useWorkflowStepActions", () => {
         .filter((s) => s.is_start_step)
         .map((s) => s.id),
     ).toEqual(["step-2"]);
+  });
+});
+
+describe("useWorkflowSaveActions", () => {
+  it("remaps added template step pull sources to backend-created template steps", async () => {
+    const createdWorkflowId = "wf-created" as Workflow["id"];
+    const templateName = "Template Step";
+    const addedName = "Added Step";
+    const backendTemplateId = "backend-template";
+    const backendAddedId = "backend-added";
+    const draftTemplateId = "draft-template";
+
+    vi.mocked(createWorkflowAction).mockResolvedValue({
+      ...workflow,
+      id: createdWorkflowId,
+      workflow_template_id: "template-1",
+    });
+    vi.mocked(listWorkflowStepsAction).mockResolvedValue({
+      steps: [
+        {
+          ...step(backendTemplateId, templateName, 0, true),
+          id: backendTemplateId,
+          workflow_id: createdWorkflowId,
+        },
+      ],
+      total: 1,
+    });
+    vi.mocked(createWorkflowStepAction).mockResolvedValue({
+      ...step(backendAddedId, addedName, 1, false),
+      id: backendAddedId,
+      workflow_id: createdWorkflowId,
+    });
+    vi.mocked(updateWorkflowStepAction).mockResolvedValue(
+      step(backendAddedId, addedName, 1, false),
+    );
+
+    const templateStep = step(draftTemplateId, templateName, 0, true);
+    const addedStep = {
+      ...step("draft-added", addedName, 1, false),
+      pull_from_step_id: draftTemplateId,
+    };
+    const { result } = renderHook(() =>
+      useWorkflowSaveActions({
+        workflow: { ...workflow, workflow_template_id: "template-1" },
+        isNewWorkflow: true,
+        workflowSteps: [templateStep, addedStep],
+        templateStepCount: 1,
+        onSaveWorkflow: vi.fn(),
+        onWorkflowCreated: vi.fn(),
+        toast: vi.fn(),
+      }),
+    );
+
+    await act(async () => {
+      await result.current.handleSaveWorkflow();
+    });
+
+    expect(updateWorkflowStepAction).toHaveBeenCalledWith(backendAddedId, {
+      pull_from_step_id: backendTemplateId,
+    });
   });
 });

--- a/apps/web/components/settings/workflow-card-actions.test.ts
+++ b/apps/web/components/settings/workflow-card-actions.test.ts
@@ -88,7 +88,7 @@ describe("useWorkflowStepActions", () => {
 });
 
 describe("useWorkflowSaveActions", () => {
-  it("remaps added template step pull sources to backend-created template steps", async () => {
+  it("remaps template workflow pull sources between backend-created and added steps", async () => {
     const createdWorkflowId = "wf-created" as Workflow["id"];
     const templateName = "Template Step";
     const addedName = "Added Step";
@@ -120,7 +120,10 @@ describe("useWorkflowSaveActions", () => {
       step(backendAddedId, addedName, 1, false),
     );
 
-    const templateStep = step(draftTemplateId, templateName, 0, true);
+    const templateStep = {
+      ...step(draftTemplateId, templateName, 0, true),
+      pull_from_step_id: "draft-added",
+    };
     const addedStep = {
       ...step("draft-added", addedName, 1, false),
       pull_from_step_id: draftTemplateId,
@@ -141,8 +144,14 @@ describe("useWorkflowSaveActions", () => {
       await result.current.handleSaveWorkflow();
     });
 
+    expect(createWorkflowStepAction).toHaveBeenCalledWith(
+      expect.objectContaining({ pull_from_step_id: "" }),
+    );
     expect(updateWorkflowStepAction).toHaveBeenCalledWith(backendAddedId, {
       pull_from_step_id: backendTemplateId,
+    });
+    expect(updateWorkflowStepAction).toHaveBeenCalledWith(backendTemplateId, {
+      pull_from_step_id: backendAddedId,
     });
   });
 });

--- a/apps/web/components/settings/workflow-card-actions.ts
+++ b/apps/web/components/settings/workflow-card-actions.ts
@@ -465,6 +465,7 @@ async function createStepsThenRemapPullSources(
     const createdID = addedStepIDByDraftID.get(step.id) ?? createdByPosition.get(step.position);
     if (createdID) await updateWorkflowStepAction(createdID, { pull_from_step_id: pullFromStepID });
   }
+  return addedStepIDByDraftID;
 }
 
 async function reconcileTemplateSteps(
@@ -479,6 +480,18 @@ async function reconcileTemplateSteps(
     if (userStep) stepIDByDraftID.set(userStep.id, backendStep.id);
   }
 
+  // Create added steps first so template-step updates can remap pull sources
+  // that point at a newly-added step.
+  const addedSteps = userSteps.filter((step) => step.position >= templateStepCount);
+  const addedStepIDByDraftID = await createStepsThenRemapPullSources(
+    createdId,
+    addedSteps,
+    stepIDByDraftID,
+  );
+  for (const [draftID, createdID] of addedStepIDByDraftID) {
+    stepIDByDraftID.set(draftID, createdID);
+  }
+
   // Reconcile user edits (name, color, etc.) with backend steps.
   // We do NOT touch events - the backend has correct step_id UUIDs.
   for (const backendStep of backendSteps) {
@@ -487,10 +500,6 @@ async function reconcileTemplateSteps(
     const updates = diffStepUpdates(userStep, backendStep, stepIDByDraftID);
     if (Object.keys(updates).length > 0) await updateWorkflowStepAction(backendStep.id, updates);
   }
-
-  // Create any additional steps the user added beyond the template
-  const addedSteps = userSteps.filter((step) => step.position >= templateStepCount);
-  await createStepsThenRemapPullSources(createdId, addedSteps, stepIDByDraftID);
 }
 
 type WorkflowSaveActionsParams = {

--- a/apps/web/components/settings/workflow-card-actions.ts
+++ b/apps/web/components/settings/workflow-card-actions.ts
@@ -405,6 +405,10 @@ function diffStepUpdates(userStep: WorkflowStep, backendStep: WorkflowStep): Par
     updates.is_start_step = userStep.is_start_step;
   if (userStep.allow_manual_move !== backendStep.allow_manual_move)
     updates.allow_manual_move = userStep.allow_manual_move;
+  if ((userStep.wip_limit ?? 0) !== (backendStep.wip_limit ?? 0))
+    updates.wip_limit = userStep.wip_limit ?? 0;
+  if ((userStep.pull_from_step_id ?? "") !== (backendStep.pull_from_step_id ?? ""))
+    updates.pull_from_step_id = userStep.pull_from_step_id ?? "";
   // Events are NOT compared - backend has correct step_id UUIDs, user has template aliases
   return updates;
 }
@@ -419,6 +423,8 @@ function stepPayload(workflowId: string, step: WorkflowStep) {
     events: step.events,
     is_start_step: step.is_start_step,
     allow_manual_move: step.allow_manual_move,
+    wip_limit: step.wip_limit ?? 0,
+    pull_from_step_id: step.pull_from_step_id ?? "",
   };
 }
 

--- a/apps/web/components/settings/workflow-card-actions.ts
+++ b/apps/web/components/settings/workflow-card-actions.ts
@@ -396,7 +396,19 @@ export function useStepDeleteHandlers({
  * with properly remapped step_id references (template aliases → real UUIDs).
  * If we compared events, the template aliases would overwrite the backend's UUIDs.
  */
-function diffStepUpdates(userStep: WorkflowStep, backendStep: WorkflowStep): Partial<WorkflowStep> {
+function remapPullFromStepID(
+  pullFromStepID: string | null | undefined,
+  stepIDByDraftID: Map<string, string>,
+) {
+  if (!pullFromStepID) return "";
+  return stepIDByDraftID.get(pullFromStepID) ?? pullFromStepID;
+}
+
+function diffStepUpdates(
+  userStep: WorkflowStep,
+  backendStep: WorkflowStep,
+  stepIDByDraftID: Map<string, string>,
+): Partial<WorkflowStep> {
   const updates: Partial<WorkflowStep> = {};
   if (userStep.name !== backendStep.name) updates.name = userStep.name;
   if (userStep.color !== backendStep.color) updates.color = userStep.color;
@@ -407,8 +419,9 @@ function diffStepUpdates(userStep: WorkflowStep, backendStep: WorkflowStep): Par
     updates.allow_manual_move = userStep.allow_manual_move;
   if ((userStep.wip_limit ?? 0) !== (backendStep.wip_limit ?? 0))
     updates.wip_limit = userStep.wip_limit ?? 0;
-  if ((userStep.pull_from_step_id ?? "") !== (backendStep.pull_from_step_id ?? ""))
-    updates.pull_from_step_id = userStep.pull_from_step_id ?? "";
+  const pullFromStepID = remapPullFromStepID(userStep.pull_from_step_id, stepIDByDraftID);
+  if (pullFromStepID !== (backendStep.pull_from_step_id ?? ""))
+    updates.pull_from_step_id = pullFromStepID;
   // Events are NOT compared - backend has correct step_id UUIDs, user has template aliases
   return updates;
 }
@@ -428,28 +441,50 @@ function stepPayload(workflowId: string, step: WorkflowStep) {
   };
 }
 
+function stepPayloadWithoutPullSource(workflowId: string, step: WorkflowStep) {
+  return { ...stepPayload(workflowId, step), pull_from_step_id: "" };
+}
+
+async function createStepsThenRemapPullSources(workflowId: string, steps: WorkflowStep[]) {
+  const createdByDraftID = new Map<string, string>();
+  const createdByPosition = new Map<number, string>();
+  for (const step of steps) {
+    const created = await createWorkflowStepAction(stepPayloadWithoutPullSource(workflowId, step));
+    createdByDraftID.set(step.id, created.id);
+    createdByPosition.set(step.position, created.id);
+  }
+  for (const step of steps) {
+    const pullFromStepID = remapPullFromStepID(step.pull_from_step_id, createdByDraftID);
+    if (!pullFromStepID) continue;
+    const createdID = createdByDraftID.get(step.id) ?? createdByPosition.get(step.position);
+    if (createdID) await updateWorkflowStepAction(createdID, { pull_from_step_id: pullFromStepID });
+  }
+}
+
 async function reconcileTemplateSteps(
   createdId: string,
   userSteps: WorkflowStep[],
   templateStepCount: number,
 ) {
   const { steps: backendSteps = [] } = await listWorkflowStepsAction(createdId);
+  const stepIDByDraftID = new Map<string, string>();
+  for (const backendStep of backendSteps) {
+    const userStep = userSteps.find((s) => s.position === backendStep.position);
+    if (userStep) stepIDByDraftID.set(userStep.id, backendStep.id);
+  }
 
   // Reconcile user edits (name, color, etc.) with backend steps.
   // We do NOT touch events - the backend has correct step_id UUIDs.
   for (const backendStep of backendSteps) {
     const userStep = userSteps.find((s) => s.position === backendStep.position);
     if (!userStep) continue;
-    const updates = diffStepUpdates(userStep, backendStep);
+    const updates = diffStepUpdates(userStep, backendStep, stepIDByDraftID);
     if (Object.keys(updates).length > 0) await updateWorkflowStepAction(backendStep.id, updates);
   }
 
   // Create any additional steps the user added beyond the template
-  for (const step of userSteps) {
-    if (step.position >= templateStepCount) {
-      await createWorkflowStepAction(stepPayload(createdId, step));
-    }
-  }
+  const addedSteps = userSteps.filter((step) => step.position >= templateStepCount);
+  await createStepsThenRemapPullSources(createdId, addedSteps);
 }
 
 type WorkflowSaveActionsParams = {
@@ -486,9 +521,7 @@ export function useWorkflowSaveActions({
       // Reconcile user edits and additions on top.
       await reconcileTemplateSteps(created.id, workflowSteps, templateStepCount);
     } else {
-      for (const step of workflowSteps) {
-        await createWorkflowStepAction(stepPayload(created.id, step));
-      }
+      await createStepsThenRemapPullSources(created.id, workflowSteps);
     }
 
     onWorkflowCreated?.(created);

--- a/apps/web/components/settings/workflow-card-actions.ts
+++ b/apps/web/components/settings/workflow-card-actions.ts
@@ -445,18 +445,24 @@ function stepPayloadWithoutPullSource(workflowId: string, step: WorkflowStep) {
   return { ...stepPayload(workflowId, step), pull_from_step_id: "" };
 }
 
-async function createStepsThenRemapPullSources(workflowId: string, steps: WorkflowStep[]) {
-  const createdByDraftID = new Map<string, string>();
+async function createStepsThenRemapPullSources(
+  workflowId: string,
+  steps: WorkflowStep[],
+  existingStepIDByDraftID = new Map<string, string>(),
+) {
+  const createdByDraftID = new Map(existingStepIDByDraftID);
+  const addedStepIDByDraftID = new Map<string, string>();
   const createdByPosition = new Map<number, string>();
   for (const step of steps) {
     const created = await createWorkflowStepAction(stepPayloadWithoutPullSource(workflowId, step));
     createdByDraftID.set(step.id, created.id);
+    addedStepIDByDraftID.set(step.id, created.id);
     createdByPosition.set(step.position, created.id);
   }
   for (const step of steps) {
     const pullFromStepID = remapPullFromStepID(step.pull_from_step_id, createdByDraftID);
     if (!pullFromStepID) continue;
-    const createdID = createdByDraftID.get(step.id) ?? createdByPosition.get(step.position);
+    const createdID = addedStepIDByDraftID.get(step.id) ?? createdByPosition.get(step.position);
     if (createdID) await updateWorkflowStepAction(createdID, { pull_from_step_id: pullFromStepID });
   }
 }
@@ -484,7 +490,7 @@ async function reconcileTemplateSteps(
 
   // Create any additional steps the user added beyond the template
   const addedSteps = userSteps.filter((step) => step.position >= templateStepCount);
-  await createStepsThenRemapPullSources(createdId, addedSteps);
+  await createStepsThenRemapPullSources(createdId, addedSteps, stepIDByDraftID);
 }
 
 type WorkflowSaveActionsParams = {

--- a/apps/web/components/settings/workflow-pipeline-editor-panels.tsx
+++ b/apps/web/components/settings/workflow-pipeline-editor-panels.tsx
@@ -217,6 +217,81 @@ function StepAutoArchiveRow({ step, onUpdate, readOnly }: StepAutoArchiveRowProp
   );
 }
 
+// --- StepWipControls ---
+
+type StepWipControlsProps = {
+  step: WorkflowStep;
+  steps: WorkflowStep[];
+  onUpdate: (updates: Partial<WorkflowStep>) => void;
+  readOnly: boolean;
+};
+
+function parseWipLimit(value: string): number {
+  const next = Number.parseInt(value, 10);
+  if (!Number.isFinite(next)) return 0;
+  return Math.max(0, next);
+}
+
+function StepWipControls({ step, steps, onUpdate, readOnly }: StepWipControlsProps) {
+  const otherSteps = steps.filter((s) => s.id !== step.id);
+  const pullFromValue = step.pull_from_step_id || "none";
+
+  return (
+    <div className="grid grid-cols-1 gap-3 pt-3 sm:grid-cols-2 xl:grid-cols-[180px_minmax(220px,320px)]">
+      <div className="space-y-1.5">
+        <div className="flex items-center gap-1.5">
+          <Label htmlFor={`${step.id}-wip-limit`} className="text-xs font-medium">
+            WIP limit
+          </Label>
+          <HelpTip text="Maximum tasks allowed in this step at once. Use 0 for unlimited." />
+        </div>
+        <Input
+          id={`${step.id}-wip-limit`}
+          data-testid={`${step.id}-wip-limit-input`}
+          type="number"
+          min={0}
+          inputMode="numeric"
+          value={step.wip_limit ?? 0}
+          onChange={(e) => {
+            if (readOnly) return;
+            onUpdate({ wip_limit: parseWipLimit(e.target.value) });
+          }}
+          disabled={readOnly}
+          className="h-8"
+        />
+      </div>
+      <div className="space-y-1.5">
+        <div className="flex items-center gap-1.5">
+          <Label className="text-xs font-medium">Pull from</Label>
+          <HelpTip text="Optional feeder step to pull work from when this step has capacity." />
+        </div>
+        <Select
+          value={pullFromValue}
+          onValueChange={(value) => {
+            if (readOnly) return;
+            onUpdate({ pull_from_step_id: value === "none" ? "" : value });
+          }}
+          disabled={readOnly || otherSteps.length === 0}
+        >
+          <SelectTrigger className="h-8" data-testid={`${step.id}-pull-from-step-select`}>
+            <SelectValue placeholder="No feeder step" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="none" className="cursor-pointer">
+              No feeder step
+            </SelectItem>
+            {otherSteps.map((candidate) => (
+              <SelectItem key={candidate.id} value={candidate.id} className="cursor-pointer">
+                {candidate.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
+  );
+}
+
 // --- StepCheckboxRow ---
 
 type StepCheckboxRowProps = {
@@ -256,6 +331,7 @@ function StepCheckboxRow({
 
 type StepBehaviorSectionProps = {
   step: WorkflowStep;
+  steps: WorkflowStep[];
   onUpdate: (updates: Partial<WorkflowStep>) => void;
   toggleOnEnterAction: (type: string) => void;
   readOnly: boolean;
@@ -263,6 +339,7 @@ type StepBehaviorSectionProps = {
 
 function StepBehaviorSection({
   step,
+  steps,
   onUpdate,
   toggleOnEnterAction,
   readOnly,
@@ -324,6 +401,7 @@ function StepBehaviorSection({
         />
         <StepAutoArchiveRow step={step} onUpdate={onUpdate} readOnly={readOnly} />
       </div>
+      <StepWipControls step={step} steps={steps} onUpdate={onUpdate} readOnly={readOnly} />
     </div>
   );
 }
@@ -531,6 +609,7 @@ export function StepConfigPanel({
       <div className="p-4 space-y-5">
         <StepBehaviorSection
           step={step}
+          steps={steps}
           onUpdate={onUpdate}
           toggleOnEnterAction={actions.toggleOnEnterAction}
           readOnly={readOnly}

--- a/apps/web/components/settings/workflow-pipeline-editor-panels.tsx
+++ b/apps/web/components/settings/workflow-pipeline-editor-panels.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from "react";
 import { IconRobot, IconTrash } from "@tabler/icons-react";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@kandev/ui/tooltip";
 import { Button } from "@kandev/ui/button";
 import { Input } from "@kandev/ui/input";
 import { Checkbox } from "@kandev/ui/checkbox";
@@ -54,44 +53,35 @@ function StepAgentProfileSelect({
   const healthyProfiles = useHealthyAgentProfiles(step.agent_profile_id);
 
   return (
-    <TooltipProvider>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <div className="flex items-center">
-            <Select
-              value={step.agent_profile_id || "none"}
-              onValueChange={(value) => {
-                if (readOnly) return;
-                onUpdate({ agent_profile_id: value === "none" ? "" : value });
-              }}
-              disabled={readOnly}
-            >
-              <SelectTrigger
-                className="w-[220px] h-8 cursor-pointer"
-                data-testid="step-agent-profile-select"
-              >
-                <IconRobot className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-                <SelectValue placeholder="No profile override" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="none" className="cursor-pointer">
-                  No profile override
-                </SelectItem>
-                {healthyProfiles.map((p) => (
-                  <SelectItem key={p.id} value={p.id} className="cursor-pointer">
-                    {p.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-        </TooltipTrigger>
-        <TooltipContent className="max-w-xs">
-          Override the agent profile for this step. A different profile creates a new session with
-          fresh context when entering this step.
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
+    <div className="flex items-center gap-1.5">
+      <Select
+        value={step.agent_profile_id || "none"}
+        onValueChange={(value) => {
+          if (readOnly) return;
+          onUpdate({ agent_profile_id: value === "none" ? "" : value });
+        }}
+        disabled={readOnly}
+      >
+        <SelectTrigger
+          className="w-[220px] h-8 cursor-pointer"
+          data-testid="step-agent-profile-select"
+        >
+          <IconRobot className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+          <SelectValue placeholder="No profile override" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="none" className="cursor-pointer">
+            No profile override
+          </SelectItem>
+          {healthyProfiles.map((p) => (
+            <SelectItem key={p.id} value={p.id} className="cursor-pointer">
+              {p.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <HelpTip text="Override the agent profile for this step. A different profile creates a new session with fresh context when entering this step." />
+    </div>
   );
 }
 

--- a/apps/web/components/settings/workflow-pipeline-editor-panels.tsx
+++ b/apps/web/components/settings/workflow-pipeline-editor-panels.tsx
@@ -29,6 +29,7 @@ import {
   TurnCompleteSelect,
   ChildrenCompletedSelect,
 } from "./workflow-pipeline-editor-step-actions";
+import { StepWipControls } from "./workflow-pipeline-editor-wip-controls";
 
 const STEP_PROMPT_PLACEHOLDERS: ScriptPlaceholder[] = [
   {
@@ -203,81 +204,6 @@ function StepAutoArchiveRow({ step, onUpdate, readOnly }: StepAutoArchiveRowProp
           <span className="text-sm text-muted-foreground">hours</span>
         </>
       )}
-    </div>
-  );
-}
-
-// --- StepWipControls ---
-
-type StepWipControlsProps = {
-  step: WorkflowStep;
-  steps: WorkflowStep[];
-  onUpdate: (updates: Partial<WorkflowStep>) => void;
-  readOnly: boolean;
-};
-
-function parseWipLimit(value: string): number {
-  const next = Number.parseInt(value, 10);
-  if (!Number.isFinite(next)) return 0;
-  return Math.max(0, next);
-}
-
-function StepWipControls({ step, steps, onUpdate, readOnly }: StepWipControlsProps) {
-  const otherSteps = steps.filter((s) => s.id !== step.id);
-  const pullFromValue = step.pull_from_step_id || "none";
-
-  return (
-    <div className="grid grid-cols-1 gap-3 pt-3 sm:grid-cols-2 xl:grid-cols-[180px_minmax(220px,320px)]">
-      <div className="space-y-1.5">
-        <div className="flex items-center gap-1.5">
-          <Label htmlFor={`${step.id}-wip-limit`} className="text-xs font-medium">
-            WIP limit
-          </Label>
-          <HelpTip text="Maximum tasks allowed in this step at once. Use 0 for unlimited." />
-        </div>
-        <Input
-          id={`${step.id}-wip-limit`}
-          data-testid={`${step.id}-wip-limit-input`}
-          type="number"
-          min={0}
-          inputMode="numeric"
-          value={step.wip_limit ?? 0}
-          onChange={(e) => {
-            if (readOnly) return;
-            onUpdate({ wip_limit: parseWipLimit(e.target.value) });
-          }}
-          disabled={readOnly}
-          className="h-8"
-        />
-      </div>
-      <div className="space-y-1.5">
-        <div className="flex items-center gap-1.5">
-          <Label className="text-xs font-medium">Pull from</Label>
-          <HelpTip text="Optional feeder step to pull work from when this step has capacity." />
-        </div>
-        <Select
-          value={pullFromValue}
-          onValueChange={(value) => {
-            if (readOnly) return;
-            onUpdate({ pull_from_step_id: value === "none" ? "" : value });
-          }}
-          disabled={readOnly || otherSteps.length === 0}
-        >
-          <SelectTrigger className="h-8" data-testid={`${step.id}-pull-from-step-select`}>
-            <SelectValue placeholder="No feeder step" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="none" className="cursor-pointer">
-              No feeder step
-            </SelectItem>
-            {otherSteps.map((candidate) => (
-              <SelectItem key={candidate.id} value={candidate.id} className="cursor-pointer">
-                {candidate.name}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      </div>
     </div>
   );
 }

--- a/apps/web/components/settings/workflow-pipeline-editor-wip-controls.tsx
+++ b/apps/web/components/settings/workflow-pipeline-editor-wip-controls.tsx
@@ -22,6 +22,7 @@ function parseWipLimit(value: string): number {
 export function StepWipControls({ step, steps, onUpdate, readOnly }: StepWipControlsProps) {
   const otherSteps = steps.filter((s) => s.id !== step.id);
   const pullFromValue = step.pull_from_step_id || "none";
+  const pullFromSelectID = `${step.id}-pull-from-step`;
 
   return (
     <div className="grid grid-cols-1 gap-3 pt-3 sm:grid-cols-2 xl:grid-cols-[180px_minmax(220px,320px)]">
@@ -49,7 +50,9 @@ export function StepWipControls({ step, steps, onUpdate, readOnly }: StepWipCont
       </div>
       <div className="space-y-1.5">
         <div className="flex items-center gap-1.5">
-          <Label className="text-xs font-medium">Pull from</Label>
+          <Label htmlFor={pullFromSelectID} className="text-xs font-medium">
+            Pull from
+          </Label>
           <HelpTip text="Optional feeder step to pull work from when this step has capacity." />
         </div>
         <Select
@@ -60,7 +63,11 @@ export function StepWipControls({ step, steps, onUpdate, readOnly }: StepWipCont
           }}
           disabled={readOnly || otherSteps.length === 0}
         >
-          <SelectTrigger className="h-8" data-testid={`${step.id}-pull-from-step-select`}>
+          <SelectTrigger
+            id={pullFromSelectID}
+            className="h-8"
+            data-testid={`${step.id}-pull-from-step-select`}
+          >
             <SelectValue placeholder="No feeder step" />
           </SelectTrigger>
           <SelectContent>

--- a/apps/web/components/settings/workflow-pipeline-editor-wip-controls.tsx
+++ b/apps/web/components/settings/workflow-pipeline-editor-wip-controls.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { Input } from "@kandev/ui/input";
+import { Label } from "@kandev/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@kandev/ui/select";
+import type { WorkflowStep } from "@/lib/types/http";
+import { HelpTip } from "./workflow-pipeline-editor-helpers";
+
+type StepWipControlsProps = {
+  step: WorkflowStep;
+  steps: WorkflowStep[];
+  onUpdate: (updates: Partial<WorkflowStep>) => void;
+  readOnly: boolean;
+};
+
+function parseWipLimit(value: string): number {
+  const next = Number.parseInt(value, 10);
+  if (!Number.isFinite(next)) return 0;
+  return Math.max(0, next);
+}
+
+export function StepWipControls({ step, steps, onUpdate, readOnly }: StepWipControlsProps) {
+  const otherSteps = steps.filter((s) => s.id !== step.id);
+  const pullFromValue = step.pull_from_step_id || "none";
+
+  return (
+    <div className="grid grid-cols-1 gap-3 pt-3 sm:grid-cols-2 xl:grid-cols-[180px_minmax(220px,320px)]">
+      <div className="space-y-1.5">
+        <div className="flex items-center gap-1.5">
+          <Label htmlFor={`${step.id}-wip-limit`} className="text-xs font-medium">
+            WIP limit
+          </Label>
+          <HelpTip text="Maximum tasks allowed in this step at once. Use 0 for unlimited." />
+        </div>
+        <Input
+          id={`${step.id}-wip-limit`}
+          data-testid={`${step.id}-wip-limit-input`}
+          type="number"
+          min={0}
+          inputMode="numeric"
+          value={step.wip_limit ?? 0}
+          onChange={(e) => {
+            if (readOnly) return;
+            onUpdate({ wip_limit: parseWipLimit(e.target.value) });
+          }}
+          disabled={readOnly}
+          className="h-8"
+        />
+      </div>
+      <div className="space-y-1.5">
+        <div className="flex items-center gap-1.5">
+          <Label className="text-xs font-medium">Pull from</Label>
+          <HelpTip text="Optional feeder step to pull work from when this step has capacity." />
+        </div>
+        <Select
+          value={pullFromValue}
+          onValueChange={(value) => {
+            if (readOnly) return;
+            onUpdate({ pull_from_step_id: value === "none" ? "" : value });
+          }}
+          disabled={readOnly || otherSteps.length === 0}
+        >
+          <SelectTrigger className="h-8" data-testid={`${step.id}-pull-from-step-select`}>
+            <SelectValue placeholder="No feeder step" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="none" className="cursor-pointer">
+              No feeder step
+            </SelectItem>
+            {otherSteps.map((candidate) => (
+              <SelectItem key={candidate.id} value={candidate.id} className="cursor-pointer">
+                {candidate.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/e2e/helpers/api-client.ts
+++ b/apps/web/e2e/helpers/api-client.ts
@@ -708,6 +708,8 @@ export class ApiClient {
         on_budget_alert?: Array<{ type: string; config?: Record<string, unknown> }>;
         on_agent_error?: Array<{ type: string; config?: Record<string, unknown> }>;
       };
+      wip_limit?: number;
+      pull_from_step_id?: string | null;
     },
   ): Promise<void> {
     await this.request("PUT", `/api/v1/workflow/steps/${stepId}`, { id: stepId, ...updates });

--- a/apps/web/e2e/tests/kanban/mobile-kanban.spec.ts
+++ b/apps/web/e2e/tests/kanban/mobile-kanban.spec.ts
@@ -203,6 +203,32 @@ test.describe("Mobile kanban view", () => {
     }
   });
 
+  test("column tabs show WIP occupancy over limit", async ({ testPage, apiClient, seedData }) => {
+    const workflow = await apiClient.createWorkflow(seedData.workspaceId, "Mobile WIP Workflow");
+    const limitedStep = await apiClient.createWorkflowStep(workflow.id, "Limited", 0, {
+      is_start_step: true,
+    });
+    await apiClient.createWorkflowStep(workflow.id, "Done", 1);
+    await apiClient.updateWorkflowStep(limitedStep.id, { wip_limit: 1 });
+    await apiClient.createTask(seedData.workspaceId, "Mobile WIP One", {
+      workflow_id: workflow.id,
+      workflow_step_id: limitedStep.id,
+    });
+    await apiClient.createTask(seedData.workspaceId, "Mobile WIP Two", {
+      workflow_id: workflow.id,
+      workflow_step_id: limitedStep.id,
+    });
+    await apiClient.saveUserSettings({
+      workspace_id: seedData.workspaceId,
+      workflow_filter_id: workflow.id,
+    });
+
+    const mobile = new MobileKanbanPage(testPage);
+    await mobile.goto();
+
+    await expect(testPage.getByTestId("column-tab-0")).toContainText("2/1");
+  });
+
   test("mobile search bar filters tasks", async ({ testPage, apiClient, seedData }) => {
     await apiClient.createTask(seedData.workspaceId, "Searchable Alpha", {
       workflow_id: seedData.workflowId,

--- a/apps/web/e2e/tests/workflow/workflow-agent-profile.spec.ts
+++ b/apps/web/e2e/tests/workflow/workflow-agent-profile.spec.ts
@@ -74,6 +74,9 @@ test.describe("Workflow agent profile", () => {
     const profileLabel = `${agentProfile.agent_display_name} \u2022 ${agentProfile.name}`;
 
     // Select an agent profile for this step
+    await testPage.addStyleTag({
+      content: '[data-slot="tooltip-content"] { display: none !important; }',
+    });
     await stepProfileSelect.click();
     await testPage.getByRole("option", { name: profileLabel }).click();
 

--- a/apps/web/e2e/tests/workflow/workflow-settings.spec.ts
+++ b/apps/web/e2e/tests/workflow/workflow-settings.spec.ts
@@ -136,6 +136,35 @@ test.describe("Workflow settings", () => {
       .toEqual([{ type: "move_to_step", config: { step_id: doneStep.id } }]);
   });
 
+  test("configures WIP limit and feeder step", async ({ testPage, apiClient, seedData }) => {
+    const workflow = await apiClient.createWorkflow(seedData.workspaceId, "WIP Settings");
+    const backlogStep = await apiClient.createWorkflowStep(workflow.id, "Backlog", 0);
+    const reviewStep = await apiClient.createWorkflowStep(workflow.id, "Review", 1);
+
+    const page = new WorkflowSettingsPage(testPage);
+    await page.goto(seedData.workspaceId);
+
+    const card = await page.findWorkflowCard("WIP Settings");
+    await expect(card).toBeVisible();
+    await page.stepNodeByName(card, "Review").click();
+
+    await card.getByTestId(`${reviewStep.id}-wip-limit-input`).fill("2");
+    await card.getByTestId(`${reviewStep.id}-pull-from-step-select`).click();
+    await testPage.getByRole("option", { name: "Backlog" }).click();
+
+    await page.saveButton(card).click();
+
+    await expect
+      .poll(async () => {
+        const { steps } = await apiClient.listWorkflowSteps(workflow.id);
+        return steps.find((step) => step.id === reviewStep.id);
+      })
+      .toMatchObject({
+        wip_limit: 2,
+        pull_from_step_id: backlogStep.id,
+      });
+  });
+
   test("modifies a template step name and persists after save", async ({ testPage, seedData }) => {
     const page = new WorkflowSettingsPage(testPage);
     await page.goto(seedData.workspaceId);

--- a/apps/web/hooks/domains/kanban/use-all-workflow-snapshots.test.ts
+++ b/apps/web/hooks/domains/kanban/use-all-workflow-snapshots.test.ts
@@ -122,6 +122,12 @@ describe("useAllWorkflowSnapshots — workspace scoping", () => {
     expect(mockFetchWorkflowSnapshot.mock.calls[1][0]).toBe("wf-A2");
     expect(mockClearKanbanMulti).not.toHaveBeenCalled();
   });
+});
+
+describe("useAllWorkflowSnapshots — fetch guards", () => {
+  beforeEach(() => {
+    resetMocks([{ id: "wf-A", workspaceId: "ws-A", name: "A" }]);
+  });
 
   it("discards a stale in-flight fetch when workspace switches mid-fetch", async () => {
     // Hold the first fetch open so it resolves after the workspace switch.
@@ -158,5 +164,38 @@ describe("useAllWorkflowSnapshots — workspace scoping", () => {
 
     const writtenIds = mockSetWorkflowSnapshot.mock.calls.map((args) => args[0]);
     expect(writtenIds).not.toContain("wf-A");
+  });
+});
+
+describe("useAllWorkflowSnapshots — snapshot mapping", () => {
+  beforeEach(() => {
+    resetMocks([{ id: "wf-A", workspaceId: "ws-A", name: "A" }]);
+  });
+
+  it("preserves workflow step WIP fields in snapshots", async () => {
+    mockFetchWorkflowSnapshot.mockResolvedValueOnce({
+      steps: [
+        {
+          id: "step-1",
+          name: "Review",
+          position: 1,
+          color: "bg-blue-500",
+          wip_limit: 2,
+          pull_from_step_id: "step-0",
+        },
+      ],
+      tasks: [],
+    });
+
+    renderHook(
+      ({ workspaceId }: { workspaceId: string | null }) => useAllWorkflowSnapshots(workspaceId),
+      { initialProps: { workspaceId: "ws-A" } },
+    );
+
+    await waitFor(() => expect(mockSetWorkflowSnapshot).toHaveBeenCalled());
+    expect(mockSetWorkflowSnapshot.mock.calls[0][1].steps[0]).toMatchObject({
+      wip_limit: 2,
+      pull_from_step_id: "step-0",
+    });
   });
 });

--- a/apps/web/hooks/domains/kanban/use-all-workflow-snapshots.ts
+++ b/apps/web/hooks/domains/kanban/use-all-workflow-snapshots.ts
@@ -35,7 +35,11 @@ async function fetchAndWriteSnapshot(
       allow_manual_move: step.allow_manual_move,
       prompt: step.prompt,
       is_start_step: step.is_start_step,
+      show_in_command_panel: step.show_in_command_panel,
       agent_profile_id: step.agent_profile_id,
+      wip_limit: step.wip_limit,
+      pull_from_step_id: step.pull_from_step_id ?? null,
+      stage_type: step.stage_type,
     }));
     const stepIds = new Set(steps.map((s) => s.id));
 

--- a/apps/web/lib/api/domains/workflow-api.ts
+++ b/apps/web/lib/api/domains/workflow-api.ts
@@ -17,6 +17,8 @@ type BackendTemplateStep = {
   events?: StepEvents;
   is_start_step?: boolean;
   show_in_command_panel?: boolean;
+  wip_limit?: number;
+  pull_from_step_id?: string | null;
 };
 
 type BackendWorkflowTemplate = Omit<WorkflowTemplate, "default_steps"> & {
@@ -34,6 +36,8 @@ const normalizeWorkflowTemplate = (template: BackendWorkflowTemplate): WorkflowT
     events: step.events,
     is_start_step: step.is_start_step,
     show_in_command_panel: step.show_in_command_panel,
+    wip_limit: step.wip_limit,
+    pull_from_step_id: step.pull_from_step_id ?? null,
   }));
   return {
     ...template,
@@ -83,6 +87,8 @@ export async function createWorkflowStep(
     color?: string;
     prompt?: string;
     events?: StepEvents;
+    wip_limit?: number;
+    pull_from_step_id?: string | null;
   },
   options?: ApiRequestOptions,
 ) {

--- a/apps/web/lib/kanban/wip-limit.test.ts
+++ b/apps/web/lib/kanban/wip-limit.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { formatWipCount, isOverWipLimit } from "./wip-limit";
+
+describe("WIP limit display helpers", () => {
+  it("formats unlimited steps as a plain task count", () => {
+    expect(formatWipCount(3, 0)).toBe("3");
+    expect(formatWipCount(3, undefined)).toBe("3");
+  });
+
+  it("formats limited steps as occupied over limit", () => {
+    expect(formatWipCount(3, 5)).toBe("3/5");
+  });
+
+  it("only warns when a positive limit is exceeded", () => {
+    expect(isOverWipLimit(3, 2)).toBe(true);
+    expect(isOverWipLimit(2, 2)).toBe(false);
+    expect(isOverWipLimit(99, 0)).toBe(false);
+  });
+});

--- a/apps/web/lib/kanban/wip-limit.ts
+++ b/apps/web/lib/kanban/wip-limit.ts
@@ -1,0 +1,14 @@
+export function normalizeWipLimit(limit: number | null | undefined): number {
+  if (!Number.isFinite(limit)) return 0;
+  return Math.max(0, Math.trunc(limit ?? 0));
+}
+
+export function formatWipCount(taskCount: number, limit: number | null | undefined): string {
+  const normalizedLimit = normalizeWipLimit(limit);
+  return normalizedLimit > 0 ? `${taskCount}/${normalizedLimit}` : String(taskCount);
+}
+
+export function isOverWipLimit(taskCount: number, limit: number | null | undefined): boolean {
+  const normalizedLimit = normalizeWipLimit(limit);
+  return normalizedLimit > 0 && taskCount > normalizedLimit;
+}

--- a/apps/web/lib/ssr/mapper.test.ts
+++ b/apps/web/lib/ssr/mapper.test.ts
@@ -58,4 +58,34 @@ describe("snapshotToState", () => {
 
     expect(state.kanban?.tasks[0]?.primarySessionPendingAction).toBeUndefined();
   });
+
+  it("preserves workflow step WIP fields", () => {
+    const state = snapshotToState({
+      workflow: {
+        id: workflowID,
+        workspace_id: workspaceID,
+        name: "Workflow",
+        created_at: now,
+        updated_at: now,
+      },
+      steps: [
+        {
+          id: "step-1",
+          workflow_id: workflowID,
+          name: "Review",
+          position: 1,
+          color: "bg-blue-500",
+          allow_manual_move: true,
+          wip_limit: 2,
+          pull_from_step_id: "step-0",
+        },
+      ],
+      tasks: [],
+    } as unknown as WorkflowSnapshot);
+
+    expect(state.kanban?.steps[0]).toMatchObject({
+      wip_limit: 2,
+      pull_from_step_id: "step-0",
+    });
+  });
 });

--- a/apps/web/lib/ssr/mapper.ts
+++ b/apps/web/lib/ssr/mapper.ts
@@ -73,6 +73,8 @@ export function snapshotToState(snapshot: WorkflowSnapshot): Partial<AppState> {
         is_start_step: step.is_start_step,
         show_in_command_panel: step.show_in_command_panel,
         agent_profile_id: step.agent_profile_id,
+        wip_limit: step.wip_limit,
+        pull_from_step_id: step.pull_from_step_id ?? null,
         stage_type: step.stage_type,
       })),
       tasks,

--- a/apps/web/lib/state/slices/kanban/types.ts
+++ b/apps/web/lib/state/slices/kanban/types.ts
@@ -27,6 +27,10 @@ export type KanbanState = {
     is_start_step?: boolean;
     show_in_command_panel?: boolean;
     agent_profile_id?: string;
+    /** Maximum concurrent tasks allowed in this step. 0 or undefined means unlimited. */
+    wip_limit?: number;
+    /** Optional upstream step used by automation to pull more work. */
+    pull_from_step_id?: string | null;
     /**
      * Phase 2 (ADR-0004) semantic UX hint. Read by `<TaskMetaRail>` to
      * pick the right meta surface (review/approval shows multi-agent

--- a/apps/web/lib/types/backend.ts
+++ b/apps/web/lib/types/backend.ts
@@ -52,6 +52,8 @@ export type KanbanUpdatePayload = {
       on_turn_complete?: Array<{ type: string; config?: Record<string, unknown> }>;
     };
     show_in_command_panel?: boolean;
+    wip_limit?: number;
+    pull_from_step_id?: string | null;
   }>;
   tasks: Array<{
     id: string;
@@ -182,6 +184,8 @@ export type StepPayload = {
   show_in_command_panel?: boolean;
   auto_archive_after_hours?: number;
   agent_profile_id?: string;
+  wip_limit?: number;
+  pull_from_step_id?: string | null;
   /** Phase 2 (ADR-0004) UX hint — frontend-only. */
   stage_type?: "work" | "review" | "approval" | "custom";
   created_at?: string;
@@ -564,13 +568,4 @@ export type RunEventAppendedPayload = {
 };
 
 // Workspace file types (extracted to reduce file size)
-export {
-  type FileTreeNode,
-  type FileTreeResponse,
-  type FileContentResponse,
-  type FileSearchResponse,
-  type FileChangeEvent,
-  type FileChangeNotificationPayload,
-  type OpenFileTab,
-  FILE_EXTENSION_COLORS,
-} from "./workspace-files";
+export * from "./workspace-files";

--- a/apps/web/lib/types/http.ts
+++ b/apps/web/lib/types/http.ts
@@ -75,6 +75,8 @@ export type StepDefinition = {
   is_start_step?: boolean;
   show_in_command_panel?: boolean;
   agent_profile_id?: AgentProfileId;
+  wip_limit?: number;
+  pull_from_step_id?: string | null;
 };
 
 // Workflow Step - instance of a step on a workflow
@@ -91,6 +93,8 @@ export type WorkflowStep = {
   show_in_command_panel?: boolean;
   auto_archive_after_hours?: number;
   agent_profile_id?: string;
+  wip_limit?: number;
+  pull_from_step_id?: string | null;
   /**
    * Phase 2 (ADR-0004) semantic UX hint. Backend code does not branch on this;
    * frontend uses it to choose presentation (review/approval styling, etc).
@@ -337,6 +341,8 @@ export type WorkflowStepDTO = {
   auto_archive_after_hours?: number;
   agent_profile_id?: AgentProfileId;
   stage_type?: "work" | "review" | "approval" | "custom";
+  wip_limit?: number;
+  pull_from_step_id?: string | null;
   created_at?: string;
   updated_at?: string;
 };
@@ -676,6 +682,8 @@ export type StepPortable = {
   is_start_step: boolean;
   allow_manual_move: boolean;
   auto_archive_after_hours?: number;
+  wip_limit?: number;
+  pull_from_step_position?: number;
 };
 
 export type ImportWorkflowsResult = {

--- a/apps/web/lib/ws/handlers/kanban.test.ts
+++ b/apps/web/lib/ws/handlers/kanban.test.ts
@@ -43,6 +43,33 @@ function makeUpdateMessage(workflowId: string, tasks: unknown[], steps: unknown[
 }
 
 describe("kanban.update handler — primarySessionId preservation", () => {
+  it("preserves workflow step WIP fields", () => {
+    const store = makeStore();
+    const handler = registerKanbanHandlers(store)["kanban.update"]!;
+
+    handler(
+      makeUpdateMessage(
+        WORKFLOW_ID,
+        [],
+        [
+          {
+            id: STEP_ID,
+            title: "Review",
+            position: 1,
+            color: "bg-blue-500",
+            wip_limit: 2,
+            pull_from_step_id: "step-0",
+          },
+        ],
+      ),
+    );
+
+    expect(store.getState().kanban.steps[0]).toMatchObject({
+      wip_limit: 2,
+      pull_from_step_id: "step-0",
+    });
+  });
+
   it("preserves primarySessionId from existing tasks", () => {
     const store = makeStore({
       kanban: {

--- a/apps/web/lib/ws/handlers/kanban.ts
+++ b/apps/web/lib/ws/handlers/kanban.ts
@@ -32,6 +32,8 @@ export function registerKanbanHandlers(store: StoreApi<AppState>): WsHandlers {
         events: step.events,
         show_in_command_panel: step.show_in_command_panel,
         agent_profile_id: step.agent_profile_id,
+        wip_limit: step.wip_limit,
+        pull_from_step_id: step.pull_from_step_id ?? null,
       }));
 
       store.setState((state) => {

--- a/apps/web/lib/ws/handlers/workflows.test.ts
+++ b/apps/web/lib/ws/handlers/workflows.test.ts
@@ -45,6 +45,18 @@ function createdMessage(payload: WorkflowPayload): BackendMessageMap["workflow.c
   };
 }
 
+function stepUpdatedMessage(
+  step: BackendMessageMap["workflow.step.updated"]["payload"]["step"],
+): BackendMessageMap["workflow.step.updated"] {
+  return {
+    id: "msg-1",
+    type: "notification",
+    action: "workflow.step.updated",
+    payload: { step },
+    timestamp: "2026-01-01T00:00:00Z",
+  };
+}
+
 describe("workflow.created handler — preserves user filter", () => {
   it("does not promote a new workflow when activeId is null ('All Workflows')", () => {
     const store = makeStore(
@@ -139,5 +151,38 @@ describe("workflow.updated handler — hidden flag reconciles activeId", () => {
 
     expect(store.getState().workflows.activeId).toBe("wf-1");
     expect(store.getState().workflows.items[0]?.name).toBe("New Name");
+  });
+});
+
+describe("workflow step handlers", () => {
+  it("preserves WIP fields from step update payloads", () => {
+    const store = makeStore([{ id: "wf-1", workspaceId: "ws-1", name: "Workflow" }], "wf-1");
+    store.setState({
+      ...store.getState(),
+      kanban: {
+        workflowId: "wf-1",
+        steps: [{ id: "step-1", title: "Review", color: "bg-blue-500", position: 1 }],
+        tasks: [],
+      },
+    } as AppState);
+    const handlers = registerWorkflowsHandlers(store);
+
+    handlers["workflow.step.updated"]?.(
+      stepUpdatedMessage({
+        id: "step-1",
+        workflow_id: "wf-1",
+        name: "Review",
+        state: "",
+        position: 1,
+        color: "bg-blue-500",
+        wip_limit: 2,
+        pull_from_step_id: "step-0",
+      }),
+    );
+
+    expect(store.getState().kanban.steps[0]).toMatchObject({
+      wip_limit: 2,
+      pull_from_step_id: "step-0",
+    });
   });
 });

--- a/apps/web/lib/ws/handlers/workflows.ts
+++ b/apps/web/lib/ws/handlers/workflows.ts
@@ -16,6 +16,8 @@ function stepFromPayload(step: any) {
     prompt: step.prompt,
     is_start_step: step.is_start_step,
     agent_profile_id: step.agent_profile_id,
+    wip_limit: step.wip_limit,
+    pull_from_step_id: step.pull_from_step_id ?? null,
     stage_type: step.stage_type,
   };
 }

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -48,6 +48,7 @@ Kandev's task model: documents, execution stages, labels, blocker escalation, su
 | [blocked-task-escalation](tasks/blocked-task-escalation.md) | draft |
 | [runtime-cleanup](tasks/runtime-cleanup.md) | draft |
 | [link-existing-task-github-issue](tasks/link-existing-task-github-issue.md) | building |
+| [wip-limit-pull-system](tasks/wip-limit-pull-system.md) | building |
 | [multi-branch](tasks/multi-branch/spec.md) | shipped |
 | [quick-chat-expiration](tasks/quick-chat-expiration.md) | draft |
 

--- a/docs/specs/tasks/wip-limit-pull-system.md
+++ b/docs/specs/tasks/wip-limit-pull-system.md
@@ -1,0 +1,64 @@
+---
+status: building
+---
+
+# WIP Limit Pull System
+
+## What
+
+Workflow steps can define a work-in-progress limit and an optional feeder step.
+`wip_limit` is a non-negative integer on each workflow step. `0` means unlimited
+and preserves existing behavior. `pull_from_step_id` is empty by default; when it
+is set, it must reference another step in the same workflow.
+
+When a limited step is full, manual moves, drag/drop moves, API moves, MCP moves,
+bulk moves, and workflow-engine transitions into that step are rejected instead
+of overfilling the step. Same-step reordering is allowed.
+
+When a task leaves a limited step that has a feeder configured, Kandev attempts
+to pull queued tasks from the feeder into the vacated step until the step reaches
+its limit or no feeder task remains. Pull order is deterministic: position ASC,
+priority rank (`critical`, `high`, `medium`, `low`, none/unknown), created time
+ASC, then task id ASC.
+
+The Kanban board shows the current task count for unlimited steps and
+`occupied/limit` for limited steps. If legacy or concurrent data leaves a step
+over limit, the board shows the over-limit count as a warning state.
+
+## Why
+
+Kanban teams often work by pulling the next highest-priority task when capacity
+opens instead of pushing arbitrary tasks forward. Without a step-level limit,
+Kandev can start too many tasks in the same workflow stage and cannot model a
+simple queue-to-work pull system.
+
+## Data Model
+
+`workflow_steps` stores:
+
+- `wip_limit INTEGER NOT NULL DEFAULT 0`
+- `pull_from_step_id TEXT NOT NULL DEFAULT ''`
+
+Workflow step API responses, workflow template definitions, workflow export and
+import data, task DTOs, WebSocket payloads, and MCP workflow-step config tools
+all preserve these fields.
+
+Workflow export stores the pull source portably as a step position instead of an
+instance-specific UUID. Import maps that position back to the newly-created step
+ID.
+
+## Failure Modes
+
+Moving into a full limited step returns a conflict with a user-visible message
+that includes the target step and limit. Optimistic UI moves must roll back.
+
+If a pull attempt races with another actor that fills the slot, the pull attempt
+stops without overfilling the target step.
+
+Deleting a step clears any `pull_from_step_id` that points at it.
+
+## Scope Note
+
+`agent_profiles.max_concurrent_sessions` is related but separate. This feature
+adds per-step WIP limits and pull behavior. Kanban enforcement of profile-level
+session caps remains tracked separately unless implemented in the same change.


### PR DESCRIPTION
Workflow teams need a way to cap active work and refill capacity automatically, so this adds WIP limits and pull-based feeder steps across workflow storage, task moves, and Kanban views.

## Important Changes

- Workflow steps now persist, validate, export, and import `wip_limit` and `pull_from_step_id`.
- Manual moves and workflow-engine transitions reject moves that exceed a configured WIP limit.
- Vacated pull-enabled steps automatically pull the next eligible feeder task and publish normal move/update events.
- Settings and desktop/mobile Kanban views expose WIP configuration and occupancy indicators.

## Validation

- `make fmt`
- `node apps/web/scripts/generate-release-notes.mjs`
- `node apps/web/scripts/generate-changelog.mjs`
- `make typecheck`
- `make test`
- `make lint`
- `pnpm e2e:run --host tests/workflow/workflow-settings.spec.ts -- --grep "configures WIP limit" --project=chromium`
- `pnpm e2e:run --host --no-build tests/kanban/mobile-kanban.spec.ts -- --grep "WIP occupancy" --project=mobile-chrome`

## Possible Improvements

Medium risk: teams may want configurable pull ordering after using the first shipped priority/position ordering.

Closes #1609

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1613?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->