### PR TITLE
fix: encode workflow hidden flag for postgres

### DIFF
--- a/apps/backend/internal/task/repository/sqlite/postgres_schema_test.go
+++ b/apps/backend/internal/task/repository/sqlite/postgres_schema_test.go
@@ -1,9 +1,11 @@
 package sqlite
 
 import (
+	"context"
 	"testing"
 	"time"
 
+	"github.com/kandev/kandev/internal/task/models"
 	"github.com/kandev/kandev/internal/testutil"
 )
 
@@ -51,6 +53,54 @@ func TestPostgresSkipsLegacyTaskEnvironmentBackfill(t *testing.T) {
 	}
 	if count != 0 {
 		t.Fatalf("task environment count = %d, want 0", count)
+	}
+}
+
+func TestPostgresWorkflowHiddenRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	db := testutil.OpenIsolatedPostgres(t, testutil.PostgresDSNFromEnv(t))
+	repo, err := NewWithDB(db, db, nil)
+	if err != nil {
+		t.Fatalf("init fresh postgres schema: %v", err)
+	}
+	if err := repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws-postgres", Name: "Postgres"}); err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+
+	visible := &models.Workflow{ID: "wf-visible", WorkspaceID: "ws-postgres", Name: "Visible"}
+	if err := repo.CreateWorkflow(ctx, visible); err != nil {
+		t.Fatalf("create visible workflow: %v", err)
+	}
+	retrieved, err := repo.GetWorkflow(ctx, visible.ID)
+	if err != nil {
+		t.Fatalf("get visible workflow: %v", err)
+	}
+	if retrieved.Hidden {
+		t.Fatalf("visible workflow Hidden = true, want false")
+	}
+
+	hidden := &models.Workflow{ID: "wf-hidden", WorkspaceID: "ws-postgres", Name: "Hidden", Hidden: true}
+	if err := repo.CreateWorkflow(ctx, hidden); err != nil {
+		t.Fatalf("create hidden workflow: %v", err)
+	}
+	retrieved, err = repo.GetWorkflow(ctx, hidden.ID)
+	if err != nil {
+		t.Fatalf("get hidden workflow: %v", err)
+	}
+	if !retrieved.Hidden {
+		t.Fatalf("hidden workflow Hidden = false, want true")
+	}
+
+	hidden.Hidden = false
+	if err := repo.UpdateWorkflow(ctx, hidden); err != nil {
+		t.Fatalf("update hidden workflow to visible: %v", err)
+	}
+	retrieved, err = repo.GetWorkflow(ctx, hidden.ID)
+	if err != nil {
+		t.Fatalf("get updated workflow: %v", err)
+	}
+	if retrieved.Hidden {
+		t.Fatalf("updated workflow Hidden = true, want false")
 	}
 }
 

--- a/apps/backend/internal/task/repository/sqlite/workflow.go
+++ b/apps/backend/internal/task/repository/sqlite/workflow.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jmoiron/sqlx"
 
+	"github.com/kandev/kandev/internal/db/dialect"
 	"github.com/kandev/kandev/internal/task/models"
 )
 
@@ -53,7 +54,7 @@ func (r *Repository) CreateWorkflow(ctx context.Context, workflow *models.Workfl
 	_, err = r.db.ExecContext(ctx, r.db.Rebind(`
 		INSERT INTO workflows (id, workspace_id, name, description, agent_profile_id, workflow_template_id, sort_order, hidden, style, created_at, updated_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-	`), workflow.ID, workflow.WorkspaceID, workflow.Name, workflow.Description, workflow.AgentProfileID, workflow.WorkflowTemplateID, workflow.SortOrder, workflow.Hidden, normalizeWorkflowStyle(workflow.Style), workflow.CreatedAt, workflow.UpdatedAt)
+	`), workflow.ID, workflow.WorkspaceID, workflow.Name, workflow.Description, workflow.AgentProfileID, workflow.WorkflowTemplateID, workflow.SortOrder, dialect.BoolToInt(workflow.Hidden), normalizeWorkflowStyle(workflow.Style), workflow.CreatedAt, workflow.UpdatedAt)
 
 	return err
 }
@@ -81,6 +82,7 @@ type workflowScanner interface {
 func scanWorkflowRow(scanner workflowScanner) (*models.Workflow, error) {
 	workflow := &models.Workflow{}
 	var workflowTemplateID, agentProfileID, style sql.NullString
+	var hidden int
 	if err := scanner.Scan(
 		&workflow.ID,
 		&workflow.WorkspaceID,
@@ -89,13 +91,14 @@ func scanWorkflowRow(scanner workflowScanner) (*models.Workflow, error) {
 		&agentProfileID,
 		&workflowTemplateID,
 		&workflow.SortOrder,
-		&workflow.Hidden,
+		&hidden,
 		&style,
 		&workflow.CreatedAt,
 		&workflow.UpdatedAt,
 	); err != nil {
 		return nil, err
 	}
+	workflow.Hidden = hidden != 0
 	if agentProfileID.Valid {
 		workflow.AgentProfileID = agentProfileID.String
 	}
@@ -143,7 +146,7 @@ func (r *Repository) UpdateWorkflow(ctx context.Context, workflow *models.Workfl
 
 	result, err := r.db.ExecContext(ctx, r.db.Rebind(`
 		UPDATE workflows SET name = ?, description = ?, agent_profile_id = ?, workflow_template_id = ?, hidden = ?, style = ?, updated_at = ? WHERE id = ?
-	`), workflow.Name, workflow.Description, workflow.AgentProfileID, workflow.WorkflowTemplateID, workflow.Hidden, normalizeWorkflowStyle(workflow.Style), workflow.UpdatedAt, workflow.ID)
+	`), workflow.Name, workflow.Description, workflow.AgentProfileID, workflow.WorkflowTemplateID, dialect.BoolToInt(workflow.Hidden), normalizeWorkflowStyle(workflow.Style), workflow.UpdatedAt, workflow.ID)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Workflow creation on Postgres failed because pgx could not encode a Go bool into the integer-backed `workflows.hidden` column. The repository now stores that flag as the existing 0/1 representation and preserves the model-level boolean on reads.

## Validation

- `pnpm install --frozen-lockfile` from `apps/`
- `make fmt`
- `node apps/web/scripts/generate-release-notes.mjs`
- `node apps/web/scripts/generate-changelog.mjs`
- `make typecheck`
- `make test`
- `make lint`
- `KANDEV_TEST_POSTGRES_DSN=postgres://postgres:postgres@localhost:55432/kandev_test?sslmode=disable go test -tags fts5 ./internal/task/repository/sqlite`

Closes #1353

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1614?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->