### PR TITLE
fix(integrations): scope sidebar availability to active workspace

### DIFF
--- a/apps/backend/internal/integrations/workspacescope/workspacescope.go
+++ b/apps/backend/internal/integrations/workspacescope/workspacescope.go
@@ -4,7 +4,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
-	"sync"
 
 	"github.com/jmoiron/sqlx"
 )
@@ -13,28 +12,19 @@ import (
 // where integration config exists before the workspaces table is available.
 const FallbackWorkspaceID = "default"
 
-// CachedResolver memoizes the default workspace used by legacy integration
+// DefaultResolver resolves the default workspace used by legacy integration
 // methods that predate explicit workspace IDs. New request paths should pass a
 // workspace ID and bypass this fallback entirely.
-type CachedResolver struct {
-	mu          sync.Mutex
-	db          *sqlx.DB
-	workspaceID string
-}
+//
+// The resolved workspace is derived from the user's active workspace setting,
+// which is mutable at runtime, so it is re-read on every call rather than
+// memoized — caching it would pin the process to whichever workspace happened
+// to be active first and hide a configured integration after the user switches
+// workspaces.
+type DefaultResolver struct{}
 
-func (r *CachedResolver) Resolve(db *sqlx.DB) (string, error) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if r.workspaceID != "" && r.db == db {
-		return r.workspaceID, nil
-	}
-	workspaceID, err := ResolveMigrationTarget(db)
-	if err != nil {
-		return "", err
-	}
-	r.db = db
-	r.workspaceID = workspaceID
-	return workspaceID, nil
+func (DefaultResolver) Resolve(db *sqlx.DB) (string, error) {
+	return ResolveMigrationTarget(db)
 }
 
 // ResolveMigrationTarget returns the workspace that should receive an upgraded

--- a/apps/backend/internal/integrations/workspacescope/workspacescope_test.go
+++ b/apps/backend/internal/integrations/workspacescope/workspacescope_test.go
@@ -50,11 +50,11 @@ func seedActiveWorkspace(t *testing.T, db *sqlx.DB, workspaceID string) {
 	}
 }
 
-func TestCachedResolverReusesSuccessfulResolution(t *testing.T) {
+func TestDefaultResolverReflectsActiveWorkspaceChange(t *testing.T) {
 	db := newTestDB(t)
 	seedActiveWorkspace(t, db, "ws-first")
 
-	var resolver CachedResolver
+	var resolver DefaultResolver
 	got, err := resolver.Resolve(db)
 	if err != nil {
 		t.Fatalf("first resolve: %v", err)
@@ -63,23 +63,25 @@ func TestCachedResolverReusesSuccessfulResolution(t *testing.T) {
 		t.Fatalf("expected ws-first, got %q", got)
 	}
 
+	// The active workspace is mutable at runtime; switching it must be
+	// reflected on the next resolve, not pinned to the first value.
 	seedActiveWorkspace(t, db, "ws-second")
 	got, err = resolver.Resolve(db)
 	if err != nil {
 		t.Fatalf("second resolve: %v", err)
 	}
-	if got != "ws-first" {
-		t.Fatalf("expected cached ws-first, got %q", got)
+	if got != "ws-second" {
+		t.Fatalf("expected ws-second after switch, got %q", got)
 	}
 }
 
-func TestCachedResolverCachesPerDB(t *testing.T) {
+func TestDefaultResolverIsPerDB(t *testing.T) {
 	db1 := newTestDB(t)
 	db2 := newTestDB(t)
 	seedActiveWorkspace(t, db1, "ws-one")
 	seedActiveWorkspace(t, db2, "ws-two")
 
-	var resolver CachedResolver
+	var resolver DefaultResolver
 	got, err := resolver.Resolve(db1)
 	if err != nil {
 		t.Fatalf("resolve db1: %v", err)
@@ -96,7 +98,7 @@ func TestCachedResolverCachesPerDB(t *testing.T) {
 	}
 }
 
-func TestCachedResolverDoesNotMemoizeErrors(t *testing.T) {
+func TestDefaultResolverRecoversAfterError(t *testing.T) {
 	db := newTestDB(t)
 	now := time.Now().UTC()
 	if _, err := db.Exec(`
@@ -115,7 +117,7 @@ func TestCachedResolverDoesNotMemoizeErrors(t *testing.T) {
 		t.Fatalf("seed malformed users table: %v", err)
 	}
 
-	var resolver CachedResolver
+	var resolver DefaultResolver
 	if _, err := resolver.Resolve(db); err == nil {
 		t.Fatal("expected malformed users table to fail")
 	}

--- a/apps/backend/internal/jira/store.go
+++ b/apps/backend/internal/jira/store.go
@@ -19,7 +19,7 @@ type Store struct {
 	db *sqlx.DB
 	ro *sqlx.DB
 
-	defaultWorkspace workspacescope.CachedResolver
+	defaultWorkspace workspacescope.DefaultResolver
 
 	// migratedToWorkspace records the workspace_id that received a legacy
 	// singleton row during initSchema. Provider reads this to migrate the

--- a/apps/backend/internal/linear/store.go
+++ b/apps/backend/internal/linear/store.go
@@ -18,7 +18,7 @@ type Store struct {
 	db *sqlx.DB
 	ro *sqlx.DB
 
-	defaultWorkspace workspacescope.CachedResolver
+	defaultWorkspace workspacescope.DefaultResolver
 
 	// migratedToWorkspace records the workspace_id that received a legacy
 	// singleton row during initSchema. Provider reads this to migrate the

--- a/apps/backend/internal/sentry/store.go
+++ b/apps/backend/internal/sentry/store.go
@@ -17,7 +17,7 @@ import (
 type Store struct {
 	db                  *sqlx.DB
 	ro                  *sqlx.DB
-	defaultWorkspace    workspacescope.CachedResolver
+	defaultWorkspace    workspacescope.DefaultResolver
 	migratedToWorkspace string
 }
 

--- a/apps/backend/internal/slack/store.go
+++ b/apps/backend/internal/slack/store.go
@@ -18,7 +18,7 @@ type Store struct {
 	db *sqlx.DB
 	ro *sqlx.DB
 
-	defaultWorkspace workspacescope.CachedResolver
+	defaultWorkspace workspacescope.DefaultResolver
 
 	// migratedToWorkspace records the workspace_id that received a legacy
 	// singleton row during initSchema. Provider reads this to migrate the

--- a/apps/web/components/integrations/integrations-menu.test.ts
+++ b/apps/web/components/integrations/integrations-menu.test.ts
@@ -14,7 +14,10 @@ const useGitHubStatusMock = vi.hoisted(() => vi.fn());
 const useGitLabAvailableMock = vi.hoisted(() => vi.fn());
 const useJiraAvailableMock = vi.hoisted(() => vi.fn());
 const useLinearAvailableMock = vi.hoisted(() => vi.fn());
-const activeWorkspaceRef = vi.hoisted(() => ({ id: null as string | null }));
+const activeWorkspaceRef = vi.hoisted(() => ({
+  id: null as string | null,
+  items: [] as Array<{ id: string }>,
+}));
 
 vi.mock("@/hooks/domains/github/use-github-status", () => ({
   useGitHubStatus: useGitHubStatusMock,
@@ -33,8 +36,14 @@ vi.mock("@/hooks/domains/linear/use-linear-availability", () => ({
 }));
 
 vi.mock("@/components/state-provider", () => ({
-  useAppStore: (selector: (state: { workspaces: { activeId: string | null } }) => unknown) =>
-    selector({ workspaces: { activeId: activeWorkspaceRef.id } }),
+  useAppStore: (
+    selector: (state: {
+      workspaces: { activeId: string | null; items: Array<{ id: string }> };
+    }) => unknown,
+  ) =>
+    selector({
+      workspaces: { activeId: activeWorkspaceRef.id, items: activeWorkspaceRef.items },
+    }),
 }));
 
 function status(overrides: Partial<GitHubStatus>): GitHubStatus {
@@ -72,6 +81,7 @@ afterEach(() => {
   cleanup();
   vi.clearAllMocks();
   activeWorkspaceRef.id = null;
+  activeWorkspaceRef.items = [];
 });
 
 describe("getGitHubIntegrationStatus", () => {
@@ -157,6 +167,7 @@ describe("IntegrationsMenu", () => {
 
   it("passes the active workspace id to the per-workspace availability hooks", () => {
     activeWorkspaceRef.id = "ws-active";
+    activeWorkspaceRef.items = [{ id: "ws-active" }];
     mockAvailability({ githubReady: true, jiraAvailable: true, linearAvailable: true });
 
     render(createElement(IntegrationsMenu, {}));
@@ -165,6 +176,20 @@ describe("IntegrationsMenu", () => {
     // workspace so the sidebar reflects the workspace the user is viewing.
     expect(useJiraAvailableMock).toHaveBeenCalledWith("ws-active");
     expect(useLinearAvailableMock).toHaveBeenCalledWith("ws-active");
+  });
+
+  it("falls back to null scope when the active workspace id is stale", () => {
+    // The active workspace was removed but activeId was not reconciled. Scoping
+    // to the deleted id would hide the links; fall back to null instead so the
+    // backend's default-workspace resolution applies.
+    activeWorkspaceRef.id = "ws-deleted";
+    activeWorkspaceRef.items = [{ id: "ws-remaining" }];
+    mockAvailability({ githubReady: false, jiraAvailable: true, linearAvailable: true });
+
+    render(createElement(IntegrationsMenu, {}));
+
+    expect(useJiraAvailableMock).toHaveBeenCalledWith(null);
+    expect(useLinearAvailableMock).toHaveBeenCalledWith(null);
   });
 });
 

--- a/apps/web/components/integrations/integrations-menu.test.ts
+++ b/apps/web/components/integrations/integrations-menu.test.ts
@@ -14,6 +14,7 @@ const useGitHubStatusMock = vi.hoisted(() => vi.fn());
 const useGitLabAvailableMock = vi.hoisted(() => vi.fn());
 const useJiraAvailableMock = vi.hoisted(() => vi.fn());
 const useLinearAvailableMock = vi.hoisted(() => vi.fn());
+const activeWorkspaceRef = vi.hoisted(() => ({ id: null as string | null }));
 
 vi.mock("@/hooks/domains/github/use-github-status", () => ({
   useGitHubStatus: useGitHubStatusMock,
@@ -29,6 +30,11 @@ vi.mock("@/hooks/domains/jira/use-jira-availability", () => ({
 
 vi.mock("@/hooks/domains/linear/use-linear-availability", () => ({
   useLinearAvailable: useLinearAvailableMock,
+}));
+
+vi.mock("@/components/state-provider", () => ({
+  useAppStore: (selector: (state: { workspaces: { activeId: string | null } }) => unknown) =>
+    selector({ workspaces: { activeId: activeWorkspaceRef.id } }),
 }));
 
 function status(overrides: Partial<GitHubStatus>): GitHubStatus {
@@ -65,6 +71,7 @@ function mockAvailability({
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
+  activeWorkspaceRef.id = null;
 });
 
 describe("getGitHubIntegrationStatus", () => {
@@ -146,6 +153,18 @@ describe("IntegrationsMenu", () => {
     render(createElement(IntegrationsMenu, {}));
 
     expect(screen.queryByRole("button", { name: "Integrations" })).toBeNull();
+  });
+
+  it("passes the active workspace id to the per-workspace availability hooks", () => {
+    activeWorkspaceRef.id = "ws-active";
+    mockAvailability({ githubReady: true, jiraAvailable: true, linearAvailable: true });
+
+    render(createElement(IntegrationsMenu, {}));
+
+    // Jira and Linear are per-workspace: they must be scoped to the active
+    // workspace so the sidebar reflects the workspace the user is viewing.
+    expect(useJiraAvailableMock).toHaveBeenCalledWith("ws-active");
+    expect(useLinearAvailableMock).toHaveBeenCalledWith("ws-active");
   });
 });
 

--- a/apps/web/components/integrations/integrations-menu.tsx
+++ b/apps/web/components/integrations/integrations-menu.tsx
@@ -22,6 +22,7 @@ import { useJiraAvailable } from "@/hooks/domains/jira/use-jira-availability";
 import { useLinearAvailable } from "@/hooks/domains/linear/use-linear-availability";
 import { useGitHubStatus } from "@/hooks/domains/github/use-github-status";
 import { useGitLabAvailable } from "@/hooks/domains/gitlab/use-task-mr";
+import { useAppStore } from "@/components/state-provider";
 import type { GitHubStatus } from "@/lib/types/github";
 
 type MobileIntegrationsSectionProps = {
@@ -84,10 +85,16 @@ export function getGitHubIntegrationStatus(status: GitHubStatus | null, loading:
 }
 
 export function useConfiguredIntegrationLinks(): IntegrationLink[] {
+  // Jira and Linear are per-workspace integrations, so their availability must
+  // be checked against the active workspace. Omitting the id makes the backend
+  // fall back to a legacy default-workspace resolver that can point at the
+  // wrong workspace, hiding a configured integration from the sidebar. GitHub
+  // and GitLab are install-wide and don't need the workspace id.
+  const activeWorkspaceId = useAppStore((s) => s.workspaces.activeId);
   const { status, loading } = useGitHubStatus();
   const gitlabAvailable = useGitLabAvailable();
-  const jiraAvailable = useJiraAvailable();
-  const linearAvailable = useLinearAvailable();
+  const jiraAvailable = useJiraAvailable(activeWorkspaceId);
+  const linearAvailable = useLinearAvailable(activeWorkspaceId);
   const githubStatus = getGitHubIntegrationStatus(status, loading);
 
   return getAvailableIntegrationLinks({

--- a/apps/web/components/integrations/integrations-menu.tsx
+++ b/apps/web/components/integrations/integrations-menu.tsx
@@ -91,10 +91,19 @@ export function useConfiguredIntegrationLinks(): IntegrationLink[] {
   // wrong workspace, hiding a configured integration from the sidebar. GitHub
   // and GitLab are install-wide and don't need the workspace id.
   const activeWorkspaceId = useAppStore((s) => s.workspaces.activeId);
+  const activeWorkspaceExists = useAppStore((s) =>
+    s.workspaces.items.some((item) => item.id === s.workspaces.activeId),
+  );
+  // Guard against a stale active id: if the active workspace was removed but
+  // activeId was not reconciled (e.g. setWorkspaces keeps a non-null id),
+  // scoping to the deleted id would return no config and hide the links even
+  // when another workspace is configured. Fall back to null so the backend's
+  // default-workspace resolution applies instead.
+  const scopedWorkspaceId = activeWorkspaceExists ? activeWorkspaceId : null;
   const { status, loading } = useGitHubStatus();
   const gitlabAvailable = useGitLabAvailable();
-  const jiraAvailable = useJiraAvailable(activeWorkspaceId);
-  const linearAvailable = useLinearAvailable(activeWorkspaceId);
+  const jiraAvailable = useJiraAvailable(scopedWorkspaceId);
+  const linearAvailable = useLinearAvailable(scopedWorkspaceId);
   const githubStatus = getGitHubIntegrationStatus(status, loading);
 
   return getAvailableIntegrationLinks({

--- a/apps/web/hooks/domains/integrations/use-integration-availability.test.ts
+++ b/apps/web/hooks/domains/integrations/use-integration-availability.test.ts
@@ -1,0 +1,85 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useIntegrationAuthed, type IntegrationConfigStatus } from "./use-integration-availability";
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+describe("useIntegrationAuthed", () => {
+  it("reports authed once a healthy config resolves", async () => {
+    const fetchConfig = vi.fn(
+      async (): Promise<IntegrationConfigStatus | null> => ({
+        hasSecret: true,
+        lastOk: true,
+      }),
+    );
+
+    const { result } = renderHook(() => useIntegrationAuthed(fetchConfig));
+
+    await waitFor(() => expect(result.current).toBe(true));
+  });
+
+  it("clears stale authed state while a new fetchConfig probe is in flight", async () => {
+    // First workspace: configured and healthy.
+    const first = vi.fn(
+      async (): Promise<IntegrationConfigStatus | null> => ({
+        hasSecret: true,
+        lastOk: true,
+      }),
+    );
+
+    const { result, rerender } = renderHook(
+      ({ fetchConfig }) => useIntegrationAuthed(fetchConfig),
+      { initialProps: { fetchConfig: first } },
+    );
+
+    await waitFor(() => expect(result.current).toBe(true));
+
+    // Switch to a second workspace whose probe has not resolved yet. The hook
+    // must drop the previous "authed" result immediately rather than keep
+    // showing the prior workspace's state during the in-flight recheck.
+    const pending = deferred<IntegrationConfigStatus | null>();
+    const second = vi.fn(() => pending.promise);
+
+    rerender({ fetchConfig: second });
+
+    expect(result.current).toBe(false);
+
+    // The unconfigured workspace resolves to no config; stays not-authed.
+    await act(async () => {
+      pending.resolve(null);
+      await pending.promise;
+    });
+
+    await waitFor(() => expect(result.current).toBe(false));
+  });
+
+  it("clears authed state when made inactive", async () => {
+    const fetchConfig = vi.fn(
+      async (): Promise<IntegrationConfigStatus | null> => ({
+        hasSecret: true,
+        lastOk: true,
+      }),
+    );
+
+    const { result, rerender } = renderHook(
+      ({ active }) => useIntegrationAuthed(fetchConfig, undefined, active),
+      { initialProps: { active: true } },
+    );
+
+    await waitFor(() => expect(result.current).toBe(true));
+
+    rerender({ active: false });
+
+    expect(result.current).toBe(false);
+  });
+});

--- a/apps/web/hooks/domains/integrations/use-integration-availability.ts
+++ b/apps/web/hooks/domains/integrations/use-integration-availability.ts
@@ -29,6 +29,11 @@ export function useIntegrationAuthed(
       setAuthed(false);
       return;
     }
+    // Drop any auth state carried over from a previous `fetchConfig` before the
+    // new probe resolves. `fetchConfig` is keyed by workspace for per-workspace
+    // integrations, so a workspace switch must not keep showing the previous
+    // workspace's "authed" result during the in-flight recheck.
+    setAuthed(false);
     let cancelled = false;
     // Monotonic request id: if a slow earlier probe finishes after a newer
     // one we ignore it, otherwise an old "auth ok" could clobber a fresh


### PR DESCRIPTION
A configured Jira integration was missing from the sidebar's INTEGRATIONS list even though its dedicated page worked, because the sidebar checked availability without a workspace id and the backend fell back to a stale default-workspace resolver that pointed at the wrong workspace. The sidebar now scopes per-workspace integrations to the active workspace, and the resolver no longer memoizes the mutable active workspace.

## Important Changes

- Frontend: `useConfiguredIntegrationLinks` reads the active workspace id from the store and passes it to `useJiraAvailable`/`useLinearAvailable`; GitHub/GitLab stay install-wide and unchanged.
- Backend: the shared `workspacescope` resolver cached the active workspace for the whole process lifetime, so switching workspaces was never reflected. Dropped the cache and re-resolve on every call (`CachedResolver` renamed to `DefaultResolver`). This is a shared dependency, so it also fixes the same staleness for Slack and Sentry.

## Validation

- `go build` for workspacescope, jira, linear, slack, sentry
- `go test ./internal/integrations/workspacescope/... ./internal/jira/... ./internal/linear/... ./internal/slack/... ./internal/sentry/...`
- `golangci-lint run` on the five affected backend packages — 0 issues
- `pnpm vitest run components/integrations/integrations-menu.test.ts` — 11 passed
- `pnpm run typecheck` and `eslint` on the changed web files
- Reproduced against a running backend: no `workspace_id` returned 204, the active workspace returned 200 with the config present

## Possible Improvements

Low risk. The resolver now issues a couple of cheap indexed queries per legacy call instead of one cached lookup; the correct long-term path is for all callers to pass an explicit workspace id and bypass the fallback entirely.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1620?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->