### PR TITLE
fix: handle config MCP executor listing

### DIFF
--- a/apps/backend/internal/mcp/handlers/config_executor_handlers.go
+++ b/apps/backend/internal/mcp/handlers/config_executor_handlers.go
@@ -20,7 +20,7 @@ func (h *Handlers) handleListExecutors(ctx context.Context, msg *ws.Message) (*w
 
 	profiles, err := h.taskSvc.ListAllExecutorProfiles(ctx)
 	if err != nil {
-		h.logger.Warn("failed to list executor profiles for executor listing", zap.Error(err))
+		h.logger.Error("failed to list executor profiles for executor listing", zap.Error(err))
 		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError, "Failed to list executor profiles", nil)
 	}
 	profilesByExecutor := make(map[string][]dto.ExecutorProfileDTO, len(executors))

--- a/apps/backend/internal/mcp/handlers/config_executor_handlers.go
+++ b/apps/backend/internal/mcp/handlers/config_executor_handlers.go
@@ -21,7 +21,7 @@ func (h *Handlers) handleListExecutors(ctx context.Context, msg *ws.Message) (*w
 	profiles, err := h.taskSvc.ListAllExecutorProfiles(ctx)
 	if err != nil {
 		h.logger.Warn("failed to list executor profiles for executor listing", zap.Error(err))
-		profiles = nil
+		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError, "Failed to list executor profiles", nil)
 	}
 	profilesByExecutor := make(map[string][]dto.ExecutorProfileDTO, len(executors))
 	for _, profile := range profiles {

--- a/apps/backend/internal/mcp/handlers/config_executor_handlers.go
+++ b/apps/backend/internal/mcp/handlers/config_executor_handlers.go
@@ -11,6 +11,29 @@ import (
 	"go.uber.org/zap"
 )
 
+func (h *Handlers) handleListExecutors(ctx context.Context, msg *ws.Message) (*ws.Message, error) {
+	executors, err := h.taskSvc.ListExecutors(ctx)
+	if err != nil {
+		h.logger.Error("failed to list executors", zap.Error(err))
+		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError, "Failed to list executors", nil)
+	}
+
+	profiles, _ := h.taskSvc.ListAllExecutorProfiles(ctx)
+	profilesByExecutor := make(map[string][]dto.ExecutorProfileDTO, len(executors))
+	for _, profile := range profiles {
+		profilesByExecutor[profile.ExecutorID] = append(profilesByExecutor[profile.ExecutorID], dto.FromExecutorProfile(profile))
+	}
+
+	dtos := make([]dto.ExecutorDTO, 0, len(executors))
+	for _, executor := range executors {
+		executorDTO := dto.FromExecutor(executor)
+		executorDTO.Profiles = profilesByExecutor[executor.ID]
+		dtos = append(dtos, executorDTO)
+	}
+
+	return ws.NewResponse(msg.ID, msg.Action, dto.ListExecutorsResponse{Executors: dtos, Total: len(dtos)})
+}
+
 func (h *Handlers) handleListExecutorProfiles(ctx context.Context, msg *ws.Message) (*ws.Message, error) {
 	return h.handleListByField(ctx, msg, "executor_id", "failed to list executor profiles", "Failed to list executor profiles",
 		func(ctx context.Context, executorID string) (any, error) {

--- a/apps/backend/internal/mcp/handlers/config_executor_handlers.go
+++ b/apps/backend/internal/mcp/handlers/config_executor_handlers.go
@@ -18,7 +18,11 @@ func (h *Handlers) handleListExecutors(ctx context.Context, msg *ws.Message) (*w
 		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError, "Failed to list executors", nil)
 	}
 
-	profiles, _ := h.taskSvc.ListAllExecutorProfiles(ctx)
+	profiles, err := h.taskSvc.ListAllExecutorProfiles(ctx)
+	if err != nil {
+		h.logger.Warn("failed to list executor profiles for executor listing", zap.Error(err))
+		profiles = nil
+	}
 	profilesByExecutor := make(map[string][]dto.ExecutorProfileDTO, len(executors))
 	for _, profile := range profiles {
 		profilesByExecutor[profile.ExecutorID] = append(profilesByExecutor[profile.ExecutorID], dto.FromExecutorProfile(profile))

--- a/apps/backend/internal/mcp/handlers/config_handlers_test.go
+++ b/apps/backend/internal/mcp/handlers/config_handlers_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/kandev/kandev/internal/common/logger"
 	"github.com/kandev/kandev/internal/orchestrator/messagequeue"
+	"github.com/kandev/kandev/internal/task/dto"
 	"github.com/kandev/kandev/internal/task/models"
 	"github.com/kandev/kandev/internal/task/service"
 	v1 "github.com/kandev/kandev/pkg/api/v1"
@@ -616,6 +617,34 @@ func TestRegisterHandlers_NilDeps_DoesNotPanic(t *testing.T) {
 
 	// Should not panic with nil config/task deps — handlers simply not registered.
 	assert.NotPanics(t, func() { h.RegisterHandlers(d) })
+}
+
+func TestRegisterHandlers_ListExecutorsActionDispatches(t *testing.T) {
+	svc, _ := newTestTaskService(t)
+	h := &Handlers{taskSvc: svc, logger: testLogger(t).WithFields()}
+	d := ws.NewDispatcher()
+	h.RegisterHandlers(d)
+
+	msg := makeWSMessage(t, ws.ActionMCPListExecutors, map[string]interface{}{})
+	resp, err := d.Dispatch(context.Background(), msg)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, ws.MessageTypeResponse, resp.Type)
+	assert.Equal(t, ws.ActionMCPListExecutors, resp.Action)
+
+	var payload dto.ListExecutorsResponse
+	require.NoError(t, json.Unmarshal(resp.Payload, &payload))
+	assert.Equal(t, len(payload.Executors), payload.Total)
+	assert.Contains(t, executorIDs(payload.Executors), models.ExecutorIDLocal)
+}
+
+func executorIDs(executors []dto.ExecutorDTO) []string {
+	ids := make([]string, 0, len(executors))
+	for _, executor := range executors {
+		ids = append(ids, executor.ID)
+	}
+	return ids
 }
 
 // --- Helper function tests ---

--- a/apps/backend/internal/mcp/handlers/handlers.go
+++ b/apps/backend/internal/mcp/handlers/handlers.go
@@ -223,10 +223,11 @@ func (h *Handlers) RegisterHandlers(d *ws.Dispatcher) {
 		d.RegisterFunc(ws.ActionMCPDeleteAgentProfile, h.handleDeleteAgentProfile)
 		count += 6
 	}
-	// list_executor_profiles is always available (read-only, used in task mode for create_task)
+	// Executor discovery/profile listing is always available (read-only, used in task mode for create_task)
 	if h.taskSvc != nil {
+		d.RegisterFunc(ws.ActionMCPListExecutors, h.handleListExecutors)
 		d.RegisterFunc(ws.ActionMCPListExecutorProfiles, h.handleListExecutorProfiles)
-		count++
+		count += 2
 	}
 	if h.mcpConfigSvc != nil {
 		d.RegisterFunc(ws.ActionMCPGetMcpConfig, h.handleGetMcpConfig)


### PR DESCRIPTION
The config MCP quick-chat toolset advertised executor discovery, but the backend dispatcher rejected the forwarded action. The missing `mcp.list_executors` handler is now registered and covered by a dispatcher-level regression test.

## Validation

- `pnpm install --frozen-lockfile` from `apps/`
- `make fmt`
- `node apps/web/scripts/generate-release-notes.mjs`
- `node apps/web/scripts/generate-changelog.mjs`
- `make typecheck`
- `make test`
- `make lint`

Closes #1625

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1628?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->