### PR TITLE
fix: sync task completion with terminal workflow steps

### DIFF
--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_async_complete.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_async_complete.go
@@ -1,6 +1,7 @@
 package acp
 
 import (
+	"sync"
 	"time"
 
 	"github.com/kandev/kandev/internal/agentctl/types/streams"
@@ -12,7 +13,16 @@ const defaultAsyncTurnCompleteIdle = 5 * time.Second
 // asyncTurnCompleteIdle is the debounce window. Tests shorten it via
 // setAsyncTurnCompleteIdleForTest; do not add t.Parallel() to tests that call
 // that helper, or they will race each other on this global.
-var asyncTurnCompleteIdle = defaultAsyncTurnCompleteIdle
+var (
+	asyncTurnCompleteIdleMu sync.RWMutex
+	asyncTurnCompleteIdle   = defaultAsyncTurnCompleteIdle
+)
+
+func currentAsyncTurnCompleteIdle() time.Duration {
+	asyncTurnCompleteIdleMu.RLock()
+	defer asyncTurnCompleteIdleMu.RUnlock()
+	return asyncTurnCompleteIdle
+}
 
 func isAsyncTurnContentEvent(event AgentEvent) bool {
 	switch event.Type {
@@ -37,7 +47,7 @@ func (a *Adapter) maybeScheduleAsyncTurnComplete(event AgentEvent) {
 		return
 	}
 
-	delay := asyncTurnCompleteIdle
+	delay := currentAsyncTurnCompleteIdle()
 	a.asyncTurnMu.Lock()
 	finalizer := a.asyncTurnFinalizers[event.SessionID]
 	if finalizer == nil {
@@ -119,7 +129,7 @@ func (a *Adapter) emitCurrentAsyncTurnComplete(sessionID string, seq uint64, pro
 
 	a.logger.Info("emitting synthetic complete event for idle async ACP turn",
 		zap.String("session_id", sessionID),
-		zap.Duration("idle", asyncTurnCompleteIdle))
+		zap.Duration("idle", currentAsyncTurnCompleteIdle()))
 	a.sendUpdate(AgentEvent{
 		Type:      streams.EventTypeComplete,
 		SessionID: sessionID,

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/async_complete_test.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/async_complete_test.go
@@ -181,10 +181,14 @@ func TestAsyncTurnComplete_CancelledByLoadSession(t *testing.T) {
 
 func setAsyncTurnCompleteIdleForTest(t *testing.T, d time.Duration) {
 	t.Helper()
+	asyncTurnCompleteIdleMu.Lock()
 	previous := asyncTurnCompleteIdle
 	asyncTurnCompleteIdle = d
+	asyncTurnCompleteIdleMu.Unlock()
 	t.Cleanup(func() {
+		asyncTurnCompleteIdleMu.Lock()
 		asyncTurnCompleteIdle = previous
+		asyncTurnCompleteIdleMu.Unlock()
 	})
 }
 

--- a/apps/backend/internal/mcp/handlers/config_handlers_test.go
+++ b/apps/backend/internal/mcp/handlers/config_handlers_test.go
@@ -534,6 +534,37 @@ func TestHandleUpdateTaskState_MissingState(t *testing.T) {
 	assertWSError(t, resp, ws.ErrorCodeValidation)
 }
 
+func TestHandleUpdateTask_PersistsState(t *testing.T) {
+	svc, repo := newTestTaskService(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	require.NoError(t, repo.CreateWorkspace(ctx, &models.Workspace{
+		ID: "ws-update-state", Name: "Update State", CreatedAt: now, UpdatedAt: now,
+	}))
+	require.NoError(t, repo.CreateWorkflow(ctx, &models.Workflow{
+		ID: "wf-update-state", WorkspaceID: "ws-update-state", Name: "Board", CreatedAt: now, UpdatedAt: now,
+	}))
+	require.NoError(t, repo.CreateTask(ctx, &models.Task{
+		ID: "task-update-state", WorkspaceID: "ws-update-state", WorkflowID: "wf-update-state",
+		Title: "Stateful", State: v1.TaskStateReview, CreatedAt: now, UpdatedAt: now,
+	}))
+
+	h := &Handlers{taskSvc: svc, logger: testLogger(t).WithFields()}
+	msg := makeWSMessage(t, ws.ActionMCPUpdateTask, map[string]interface{}{
+		"task_id": "task-update-state",
+		"state":   "COMPLETED",
+	})
+
+	resp, err := h.handleUpdateTask(ctx, msg)
+	require.NoError(t, err)
+	assert.NotEqual(t, ws.MessageTypeError, resp.Type)
+
+	task, err := svc.GetTask(ctx, "task-update-state")
+	require.NoError(t, err)
+	assert.Equal(t, v1.TaskStateCompleted, task.State)
+}
+
 // TestHandleMoveTask_ActiveSessionWithoutPrompt_DefersMove pins the production
 // bug where an agent on Work called move_task_kandev → Done without a prompt
 // mid-turn. The immediate path hit validateMoveSessions (RUNNING session) and

--- a/apps/backend/internal/mcp/handlers/config_task_handlers.go
+++ b/apps/backend/internal/mcp/handlers/config_task_handlers.go
@@ -266,13 +266,7 @@ func (h *Handlers) handleUpdateTaskState(ctx context.Context, msg *ws.Message) (
 		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeValidation, "state is required", nil)
 	}
 	state := normalizeTaskState(req.State)
-	switch state {
-	case v1.TaskStateTODO, v1.TaskStateCreated, v1.TaskStateScheduling,
-		v1.TaskStateInProgress, v1.TaskStateReview, v1.TaskStateBlocked,
-		v1.TaskStateWaitingForInput, v1.TaskStateCompleted,
-		v1.TaskStateFailed, v1.TaskStateCancelled:
-		// valid
-	default:
+	if !isValidTaskState(state) {
 		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeValidation, "invalid task state: "+req.State, nil)
 	}
 
@@ -282,6 +276,18 @@ func (h *Handlers) handleUpdateTaskState(ctx context.Context, msg *ws.Message) (
 		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError, "Failed to update task state", nil)
 	}
 	return ws.NewResponse(msg.ID, msg.Action, dto.FromTask(task))
+}
+
+func isValidTaskState(state v1.TaskState) bool {
+	switch state {
+	case v1.TaskStateTODO, v1.TaskStateCreated, v1.TaskStateScheduling,
+		v1.TaskStateInProgress, v1.TaskStateReview, v1.TaskStateBlocked,
+		v1.TaskStateWaitingForInput, v1.TaskStateCompleted,
+		v1.TaskStateFailed, v1.TaskStateCancelled:
+		return true
+	default:
+		return false
+	}
 }
 
 // normalizeTaskState maps common agent-supplied aliases to canonical TaskState

--- a/apps/backend/internal/mcp/handlers/handlers.go
+++ b/apps/backend/internal/mcp/handlers/handlers.go
@@ -999,9 +999,19 @@ func (h *Handlers) handleUpdateTask(ctx context.Context, msg *ws.Message) (*ws.M
 		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeValidation, "task_id is required", nil)
 	}
 
+	var state *v1.TaskState
+	if req.State != nil {
+		normalized := normalizeTaskState(*req.State)
+		if !isValidTaskState(normalized) {
+			return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeValidation, "invalid task state: "+*req.State, nil)
+		}
+		state = &normalized
+	}
+
 	task, err := h.taskSvc.UpdateTask(ctx, req.TaskID, &service.UpdateTaskRequest{
 		Title:       req.Title,
 		Description: req.Description,
+		State:       state,
 	})
 	if err != nil {
 		h.logger.Error("failed to update task", zap.Error(err))

--- a/apps/backend/internal/orchestrator/event_handlers_children_completed.go
+++ b/apps/backend/internal/orchestrator/event_handlers_children_completed.go
@@ -49,15 +49,18 @@ func (s *Service) processParentChildrenCompletedForTerminalStepMove(ctx context.
 	if !s.workflowStepIsTerminal(ctx, stepID) {
 		return
 	}
-	s.markTaskCompletedForTerminalStep(ctx, taskID)
+	s.markTaskCompletedForTerminalStep(ctx, taskID, stepID)
 }
 
-func (s *Service) markTaskCompletedForTerminalStep(ctx context.Context, taskID string) {
+func (s *Service) markTaskCompletedForTerminalStep(ctx context.Context, taskID, terminalStepID string) {
 	task, err := s.repo.GetTask(ctx, taskID)
 	if err != nil {
 		s.logger.Warn("terminal step completion: failed to load task",
 			zap.String("task_id", taskID),
 			zap.Error(err))
+		return
+	}
+	if terminalStepID != "" && task.WorkflowStepID != terminalStepID {
 		return
 	}
 	if models.IsTerminalTaskState(task.State) {

--- a/apps/backend/internal/orchestrator/event_handlers_children_completed.go
+++ b/apps/backend/internal/orchestrator/event_handlers_children_completed.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kandev/kandev/internal/orchestrator/watcher"
 	"github.com/kandev/kandev/internal/task/models"
 	"github.com/kandev/kandev/internal/workflow/engine"
+	wfmodels "github.com/kandev/kandev/internal/workflow/models"
 	v1 "github.com/kandev/kandev/pkg/api/v1"
 )
 
@@ -42,6 +43,39 @@ func (s *Service) processParentChildrenCompletedForTaskState(ctx context.Context
 	}
 
 	s.processOnChildrenCompleted(ctx, child.ParentID)
+}
+
+func (s *Service) processParentChildrenCompletedForTerminalStepMove(ctx context.Context, taskID, stepID string) {
+	if !s.workflowStepIsTerminal(ctx, stepID) {
+		return
+	}
+	s.markTaskCompletedForTerminalStep(ctx, taskID)
+}
+
+func (s *Service) markTaskCompletedForTerminalStep(ctx context.Context, taskID string) {
+	task, err := s.repo.GetTask(ctx, taskID)
+	if err != nil {
+		s.logger.Warn("terminal step completion: failed to load task",
+			zap.String("task_id", taskID),
+			zap.Error(err))
+		return
+	}
+	if models.IsTerminalTaskState(task.State) {
+		s.processParentChildrenCompletedForTaskState(ctx, taskID, task.State)
+		return
+	}
+	oldState := task.State
+	task.State = v1.TaskStateCompleted
+	task.UpdatedAt = time.Now().UTC()
+	if err := s.repo.UpdateTask(ctx, task); err != nil {
+		s.logger.Warn("terminal step completion: failed to mark task completed",
+			zap.String("task_id", taskID),
+			zap.Error(err))
+		return
+	}
+	s.publishTaskUpdated(ctx, task)
+	s.publishTaskStateChanged(ctx, task, oldState)
+	s.processParentChildrenCompletedForTaskState(ctx, taskID, v1.TaskStateCompleted)
 }
 
 func (s *Service) processOnChildrenCompleted(ctx context.Context, parentID string) bool {
@@ -101,6 +135,7 @@ func (s *Service) readyChildCompletionRows(ctx context.Context, parentID string)
 			zap.Error(err))
 		return nil, false
 	}
+	s.annotateTerminalChildSteps(ctx, rows)
 	if len(rows) == 0 || !allChildrenTerminal(rows) {
 		return nil, false
 	}
@@ -208,11 +243,47 @@ func (s *Service) markChildCompletionApplied(ctx context.Context, parentID, oper
 
 func allChildrenTerminal(rows []models.ChildCompletionRow) bool {
 	for _, row := range rows {
-		if !models.IsTerminalTaskState(row.State) {
+		if !models.IsTerminalTaskState(row.State) && !row.TerminalWorkflowStep {
 			return false
 		}
 	}
 	return true
+}
+
+func (s *Service) annotateTerminalChildSteps(ctx context.Context, rows []models.ChildCompletionRow) {
+	if s.workflowStepGetter == nil {
+		return
+	}
+	cache := make(map[string]bool)
+	for i := range rows {
+		if models.IsTerminalTaskState(rows[i].State) || rows[i].WorkflowStepID == "" {
+			continue
+		}
+		terminal, ok := cache[rows[i].WorkflowStepID]
+		if !ok {
+			terminal = s.workflowStepIsTerminal(ctx, rows[i].WorkflowStepID)
+			cache[rows[i].WorkflowStepID] = terminal
+		}
+		rows[i].TerminalWorkflowStep = terminal
+	}
+}
+
+func (s *Service) workflowStepIsTerminal(ctx context.Context, workflowStepID string) bool {
+	if s.workflowStepGetter == nil || workflowStepID == "" {
+		return false
+	}
+	step, err := s.workflowStepGetter.GetStep(ctx, workflowStepID)
+	if err != nil || step == nil {
+		return false
+	}
+	nextStep, err := s.workflowStepGetter.GetNextStepByPosition(ctx, step.WorkflowID, step.Position)
+	if err != nil {
+		s.logger.Warn("failed to get next workflow step for terminal check",
+			zap.String("workflow_step_id", workflowStepID),
+			zap.Error(err))
+		return false
+	}
+	return wfmodels.IsTerminalStep(step, nextStep)
 }
 
 func childCompletionPayload(rows []models.ChildCompletionRow) engine.OnChildrenCompletedPayload {
@@ -220,11 +291,18 @@ func childCompletionPayload(rows []models.ChildCompletionRow) engine.OnChildrenC
 	for _, row := range rows {
 		summaries = append(summaries, engine.ChildSummary{
 			TaskID:  row.ID,
-			Status:  string(row.State),
+			Status:  childCompletionStatus(row),
 			Summary: row.Title,
 		})
 	}
 	return engine.OnChildrenCompletedPayload{ChildSummaries: summaries}
+}
+
+func childCompletionStatus(row models.ChildCompletionRow) string {
+	if row.TerminalWorkflowStep && !models.IsTerminalTaskState(row.State) {
+		return string(v1.TaskStateCompleted)
+	}
+	return string(row.State)
 }
 
 func childCompletionOperationID(parentID string, rows []models.ChildCompletionRow) string {
@@ -235,6 +313,14 @@ func childCompletionOperationID(parentID string, rows []models.ChildCompletionRo
 		b.WriteString(row.ID)
 		b.WriteString(":")
 		b.WriteString(string(row.State))
+		b.WriteString(":")
+		b.WriteString(row.WorkflowStepID)
+		b.WriteString(":")
+		if row.TerminalWorkflowStep {
+			b.WriteString("terminal")
+		} else {
+			b.WriteString("active")
+		}
 		b.WriteString(":")
 		b.WriteString(row.UpdatedAt.UTC().Format(time.RFC3339Nano))
 	}

--- a/apps/backend/internal/orchestrator/event_handlers_children_completed.go
+++ b/apps/backend/internal/orchestrator/event_handlers_children_completed.go
@@ -68,7 +68,6 @@ func (s *Service) markTaskCompletedForTerminalStep(ctx context.Context, taskID, 
 	}
 	if models.IsTerminalTaskState(task.State) {
 		s.taskRuntimeStateMu.Unlock()
-		s.processParentChildrenCompletedForTaskState(ctx, taskID, task.State)
 		return
 	}
 	oldState := task.State

--- a/apps/backend/internal/orchestrator/event_handlers_children_completed.go
+++ b/apps/backend/internal/orchestrator/event_handlers_children_completed.go
@@ -53,17 +53,21 @@ func (s *Service) processParentChildrenCompletedForTerminalStepMove(ctx context.
 }
 
 func (s *Service) markTaskCompletedForTerminalStep(ctx context.Context, taskID, terminalStepID string) {
+	s.taskRuntimeStateMu.Lock()
 	task, err := s.repo.GetTask(ctx, taskID)
 	if err != nil {
+		s.taskRuntimeStateMu.Unlock()
 		s.logger.Warn("terminal step completion: failed to load task",
 			zap.String("task_id", taskID),
 			zap.Error(err))
 		return
 	}
 	if terminalStepID != "" && task.WorkflowStepID != terminalStepID {
+		s.taskRuntimeStateMu.Unlock()
 		return
 	}
 	if models.IsTerminalTaskState(task.State) {
+		s.taskRuntimeStateMu.Unlock()
 		s.processParentChildrenCompletedForTaskState(ctx, taskID, task.State)
 		return
 	}
@@ -71,11 +75,13 @@ func (s *Service) markTaskCompletedForTerminalStep(ctx context.Context, taskID, 
 	task.State = v1.TaskStateCompleted
 	task.UpdatedAt = time.Now().UTC()
 	if err := s.repo.UpdateTask(ctx, task); err != nil {
+		s.taskRuntimeStateMu.Unlock()
 		s.logger.Warn("terminal step completion: failed to mark task completed",
 			zap.String("task_id", taskID),
 			zap.Error(err))
 		return
 	}
+	s.taskRuntimeStateMu.Unlock()
 	s.publishTaskUpdated(ctx, task)
 	s.publishTaskStateChanged(ctx, task, oldState)
 	s.processParentChildrenCompletedForTaskState(ctx, taskID, v1.TaskStateCompleted)

--- a/apps/backend/internal/orchestrator/event_handlers_children_completed_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_children_completed_test.go
@@ -301,6 +301,57 @@ func TestTerminalStepMoveIgnoresStaleTaskStep(t *testing.T) {
 	}
 }
 
+func TestTerminalStepMoveSkipsAlreadyTerminalTaskState(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "parent", "parent-session", "step_wait")
+
+	stepGetter := newMockStepGetter()
+	stepGetter.steps["step_wait"] = &wfmodels.WorkflowStep{
+		ID:         "step_wait",
+		WorkflowID: "wf1",
+		Name:       "Wait for Subtasks",
+		Position:   0,
+		Events: wfmodels.StepEvents{
+			OnChildrenCompleted: []wfmodels.GenericAction{
+				{Type: wfmodels.GenericActionMoveToNext},
+			},
+		},
+	}
+	stepGetter.steps["step_done"] = &wfmodels.WorkflowStep{
+		ID:         "step_done",
+		WorkflowID: "wf1",
+		Name:       "Done",
+		Position:   1,
+	}
+	stepGetter.steps["child_done"] = &wfmodels.WorkflowStep{
+		ID:         "child_done",
+		WorkflowID: "wf-child",
+		Name:       "Done",
+		Position:   0,
+	}
+
+	agentMgr := &mockAgentManager{repoForExecutionLookup: repo}
+	svc := createEngineService(t, repo, stepGetter, agentMgr)
+
+	now := time.Now().UTC()
+	requireCreateTask(t, repo, &models.Task{
+		ID: "child-already-terminal", WorkspaceID: "ws1", WorkflowID: "wf-child", WorkflowStepID: "child_done",
+		Title: "Child already terminal", State: v1.TaskStateCompleted, ParentID: "parent",
+		CreatedAt: now, UpdatedAt: now,
+	})
+
+	svc.processParentChildrenCompletedForTerminalStepMove(ctx, "child-already-terminal", "child_done")
+
+	parent, err := repo.GetTask(ctx, "parent")
+	if err != nil {
+		t.Fatalf("load parent after redundant terminal move: %v", err)
+	}
+	if parent.WorkflowStepID != "step_wait" {
+		t.Fatalf("expected parent to remain on step_wait after redundant terminal move, got %q", parent.WorkflowStepID)
+	}
+}
+
 func requireCreateTask(t *testing.T, repo interface {
 	CreateTask(context.Context, *models.Task) error
 }, task *models.Task) {

--- a/apps/backend/internal/orchestrator/event_handlers_children_completed_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_children_completed_test.go
@@ -231,6 +231,14 @@ func TestHandleTaskMovedToTerminalStepProcessesParentChildrenCompleted(t *testin
 	})
 	waitForChildrenCompletedOnEnter(t, onEnterDone)
 
+	child, err := repo.GetTask(ctx, "child-terminal-move")
+	if err != nil {
+		t.Fatalf("load child after terminal move: %v", err)
+	}
+	if child.State != v1.TaskStateCompleted {
+		t.Fatalf("expected child state COMPLETED after terminal move, got %q", child.State)
+	}
+
 	parent, err := repo.GetTask(ctx, "parent")
 	if err != nil {
 		t.Fatalf("load parent after child move: %v", err)

--- a/apps/backend/internal/orchestrator/event_handlers_children_completed_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_children_completed_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kandev/kandev/internal/orchestrator/watcher"
 	"github.com/kandev/kandev/internal/task/models"
 	wfmodels "github.com/kandev/kandev/internal/workflow/models"
 	v1 "github.com/kandev/kandev/pkg/api/v1"
@@ -105,6 +106,146 @@ func TestProcessOnChildrenCompleted_TransitionsParentWhenAllActiveChildrenTermin
 	}
 	if parent.WorkflowStepID != "step_done" {
 		t.Fatalf("expected parent to remain on step_done after duplicate evaluation, got %q", parent.WorkflowStepID)
+	}
+}
+
+func TestProcessOnChildrenCompleted_TreatsTerminalStepAsCompleted(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "parent", "parent-session", "step_wait")
+
+	stepGetter := newMockStepGetter()
+	stepGetter.steps["step_wait"] = &wfmodels.WorkflowStep{
+		ID:         "step_wait",
+		WorkflowID: "wf1",
+		Name:       "Wait for Subtasks",
+		Position:   0,
+		Events: wfmodels.StepEvents{
+			OnChildrenCompleted: []wfmodels.GenericAction{
+				{Type: wfmodels.GenericActionMoveToNext},
+			},
+		},
+	}
+	stepGetter.steps["step_parent_done"] = &wfmodels.WorkflowStep{
+		ID:         "step_parent_done",
+		WorkflowID: "wf1",
+		Name:       "Done",
+		Position:   1,
+	}
+	stepGetter.steps["child_done"] = &wfmodels.WorkflowStep{
+		ID:         "child_done",
+		WorkflowID: "wf-child",
+		Name:       "Done",
+		Position:   1,
+	}
+
+	agentMgr := &mockAgentManager{repoForExecutionLookup: repo}
+	svc := createEngineService(t, repo, stepGetter, agentMgr)
+	onEnterDone := make(chan struct{}, 1)
+	svc.onProcessOnEnterComplete = func() {
+		select {
+		case onEnterDone <- struct{}{}:
+		default:
+		}
+	}
+
+	now := time.Now().UTC()
+	requireCreateTask(t, repo, &models.Task{
+		ID: "child-terminal-step", WorkspaceID: "ws1", WorkflowID: "wf1", WorkflowStepID: "child_done",
+		Title: "Child in Done", State: v1.TaskStateReview, ParentID: "parent",
+		CreatedAt: now, UpdatedAt: now,
+	})
+
+	if transitioned := svc.processOnChildrenCompleted(ctx, "parent"); !transitioned {
+		t.Fatalf("expected child in terminal workflow step to transition parent")
+	}
+	waitForChildrenCompletedOnEnter(t, onEnterDone)
+
+	parent, err := repo.GetTask(ctx, "parent")
+	if err != nil {
+		t.Fatalf("load parent after transition: %v", err)
+	}
+	if parent.WorkflowStepID != "step_parent_done" {
+		t.Fatalf("expected parent to move to step_parent_done, got %q", parent.WorkflowStepID)
+	}
+}
+
+func TestHandleTaskMovedToTerminalStepProcessesParentChildrenCompleted(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "parent", "parent-session", "step_wait")
+
+	stepGetter := newMockStepGetter()
+	stepGetter.steps["step_wait"] = &wfmodels.WorkflowStep{
+		ID:         "step_wait",
+		WorkflowID: "wf1",
+		Name:       "Wait for Subtasks",
+		Position:   0,
+		Events: wfmodels.StepEvents{
+			OnChildrenCompleted: []wfmodels.GenericAction{
+				{Type: wfmodels.GenericActionMoveToNext},
+			},
+		},
+	}
+	stepGetter.steps["step_parent_done"] = &wfmodels.WorkflowStep{
+		ID:         "step_parent_done",
+		WorkflowID: "wf1",
+		Name:       "Done",
+		Position:   1,
+	}
+	stepGetter.steps["child_work"] = &wfmodels.WorkflowStep{
+		ID:         "child_work",
+		WorkflowID: "wf-child",
+		Name:       "Work",
+		Position:   0,
+	}
+	stepGetter.steps["child_done"] = &wfmodels.WorkflowStep{
+		ID:         "child_done",
+		WorkflowID: "wf-child",
+		Name:       "Done",
+		Position:   1,
+	}
+
+	agentMgr := &mockAgentManager{repoForExecutionLookup: repo}
+	svc := createEngineService(t, repo, stepGetter, agentMgr)
+	onEnterDone := make(chan struct{}, 1)
+	svc.onProcessOnEnterComplete = func() {
+		select {
+		case onEnterDone <- struct{}{}:
+		default:
+		}
+	}
+
+	now := time.Now().UTC()
+	requireCreateTask(t, repo, &models.Task{
+		ID: "child-terminal-move", WorkspaceID: "ws1", WorkflowID: "wf-child", WorkflowStepID: "child_done",
+		Title: "Child moved to Done", State: v1.TaskStateReview, ParentID: "parent",
+		CreatedAt: now, UpdatedAt: now,
+	})
+
+	svc.handleTaskMoved(ctx, watcher.TaskMovedEventData{
+		TaskID:     "child-terminal-move",
+		FromStepID: "child_work",
+		ToStepID:   "child_done",
+		WorkflowID: "wf-child",
+	})
+	waitForChildrenCompletedOnEnter(t, onEnterDone)
+
+	parent, err := repo.GetTask(ctx, "parent")
+	if err != nil {
+		t.Fatalf("load parent after child move: %v", err)
+	}
+	if parent.WorkflowStepID != "step_parent_done" {
+		t.Fatalf("expected parent to move to step_parent_done, got %q", parent.WorkflowStepID)
+	}
+}
+
+func requireCreateTask(t *testing.T, repo interface {
+	CreateTask(context.Context, *models.Task) error
+}, task *models.Task) {
+	t.Helper()
+	if err := repo.CreateTask(context.Background(), task); err != nil {
+		t.Fatalf("create task %s: %v", task.ID, err)
 	}
 }
 

--- a/apps/backend/internal/orchestrator/event_handlers_children_completed_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_children_completed_test.go
@@ -151,7 +151,7 @@ func TestProcessOnChildrenCompleted_TreatsTerminalStepAsCompleted(t *testing.T) 
 
 	now := time.Now().UTC()
 	requireCreateTask(t, repo, &models.Task{
-		ID: "child-terminal-step", WorkspaceID: "ws1", WorkflowID: "wf1", WorkflowStepID: "child_done",
+		ID: "child-terminal-step", WorkspaceID: "ws1", WorkflowID: "wf-child", WorkflowStepID: "child_done",
 		Title: "Child in Done", State: v1.TaskStateReview, ParentID: "parent",
 		CreatedAt: now, UpdatedAt: now,
 	})
@@ -237,6 +237,59 @@ func TestHandleTaskMovedToTerminalStepProcessesParentChildrenCompleted(t *testin
 	}
 	if parent.WorkflowStepID != "step_parent_done" {
 		t.Fatalf("expected parent to move to step_parent_done, got %q", parent.WorkflowStepID)
+	}
+}
+
+func TestTerminalStepMoveIgnoresStaleTaskStep(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "parent", "parent-session", "step_wait")
+
+	stepGetter := newMockStepGetter()
+	stepGetter.steps["step_wait"] = &wfmodels.WorkflowStep{
+		ID:         "step_wait",
+		WorkflowID: "wf1",
+		Name:       "Wait for Subtasks",
+		Position:   0,
+	}
+	stepGetter.steps["child_work"] = &wfmodels.WorkflowStep{
+		ID:         "child_work",
+		WorkflowID: "wf-child",
+		Name:       "Work",
+		Position:   0,
+	}
+	stepGetter.steps["child_done"] = &wfmodels.WorkflowStep{
+		ID:         "child_done",
+		WorkflowID: "wf-child",
+		Name:       "Done",
+		Position:   1,
+	}
+
+	agentMgr := &mockAgentManager{repoForExecutionLookup: repo}
+	svc := createEngineService(t, repo, stepGetter, agentMgr)
+
+	now := time.Now().UTC()
+	requireCreateTask(t, repo, &models.Task{
+		ID: "child-stale-terminal-move", WorkspaceID: "ws1", WorkflowID: "wf-child", WorkflowStepID: "child_work",
+		Title: "Child already moved out", State: v1.TaskStateReview, ParentID: "parent",
+		CreatedAt: now, UpdatedAt: now,
+	})
+
+	svc.processParentChildrenCompletedForTerminalStepMove(ctx, "child-stale-terminal-move", "child_done")
+
+	child, err := repo.GetTask(ctx, "child-stale-terminal-move")
+	if err != nil {
+		t.Fatalf("load child after stale move: %v", err)
+	}
+	if child.State != v1.TaskStateReview {
+		t.Fatalf("expected child to remain REVIEW after stale terminal move, got %q", child.State)
+	}
+	parent, err := repo.GetTask(ctx, "parent")
+	if err != nil {
+		t.Fatalf("load parent after stale move: %v", err)
+	}
+	if parent.WorkflowStepID != "step_wait" {
+		t.Fatalf("expected parent to remain on step_wait, got %q", parent.WorkflowStepID)
 	}
 }
 

--- a/apps/backend/internal/orchestrator/event_handlers_pending_move_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_pending_move_test.go
@@ -81,6 +81,42 @@ func TestPendingMove_ReviewToInProgress_OneTransitionOnly(t *testing.T) {
 	sc.assertOneTransitionToInProgress(t, *stepHistory)
 }
 
+func TestPendingMove_OutOfTerminalStepReopensCompletedTask(t *testing.T) {
+	sc := buildPendingMoveScenario(t)
+	sc.stepGetter.steps[stepReviewedID].Name = "Done"
+
+	task, err := sc.repo.GetTask(sc.ctx, "task-1")
+	if err != nil {
+		t.Fatalf("load task: %v", err)
+	}
+	task.WorkflowStepID = stepReviewedID
+	task.State = v1.TaskStateCompleted
+	if err := sc.repo.UpdateTask(sc.ctx, task); err != nil {
+		t.Fatalf("seed terminal task state: %v", err)
+	}
+
+	session, err := sc.repo.GetTaskSession(sc.ctx, sc.reviewSessionID)
+	if err != nil {
+		t.Fatalf("load review session: %v", err)
+	}
+	sc.svc.applyPendingMove(sc.ctx, "task-1", sc.reviewSessionID, session, &messagequeue.PendingMove{
+		TaskID:         "task-1",
+		WorkflowID:     "wf1",
+		WorkflowStepID: stepInProgressID,
+	})
+
+	task, err = sc.repo.GetTask(sc.ctx, "task-1")
+	if err != nil {
+		t.Fatalf("load moved task: %v", err)
+	}
+	if task.WorkflowStepID != stepInProgressID {
+		t.Fatalf("workflow_step_id = %q, want %q", task.WorkflowStepID, stepInProgressID)
+	}
+	if task.State != v1.TaskStateTODO {
+		t.Fatalf("state = %q, want TODO after pending move out of terminal step", task.State)
+	}
+}
+
 // --- Pending-move scenario builder & assertions ---
 
 const (

--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -2148,7 +2148,7 @@ func (s *Service) applyEngineTransition(
 	}
 
 	if terminalTarget {
-		s.markTaskCompletedForTerminalStep(ctx, taskID)
+		s.markTaskCompletedForTerminalStep(ctx, taskID, targetStep.ID)
 	}
 
 	if !triggerOnEnter {

--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -270,6 +270,7 @@ func (s *Service) executeStepTransition(ctx context.Context, taskID, sessionID s
 	// Publish task updated event via the task service so the payload carries
 	// the full context (session counts, primary session, repositories).
 	s.publishTaskUpdated(ctx, task)
+	s.processParentChildrenCompletedForTerminalStepMove(ctx, taskID, toStepID)
 
 	s.logger.Info("workflow transition completed",
 		zap.String("task_id", taskID),
@@ -326,6 +327,8 @@ func (s *Service) handleTaskMoved(ctx context.Context, data watcher.TaskMovedEve
 	if s.workflowStepGetter == nil {
 		return
 	}
+
+	s.processParentChildrenCompletedForTerminalStepMove(ctx, data.TaskID, data.ToStepID)
 
 	// No session yet — check if we need to create one via auto-start
 	if data.SessionID == "" {
@@ -1054,6 +1057,8 @@ func (s *Service) applyPendingMove(ctx context.Context, taskID, sessionID string
 		zap.String("session_id", sessionID),
 		zap.String("from_step_id", fromStepID),
 		zap.String("to_step_id", move.WorkflowStepID))
+
+	s.processParentChildrenCompletedForTerminalStepMove(ctx, taskID, move.WorkflowStepID)
 
 	// Run on_exit + on_enter asynchronously. This call originated from
 	// handleAgentReady on the WS event reader goroutine; processStepExitAndEnter
@@ -2107,6 +2112,8 @@ func (s *Service) applyEngineTransition(
 		}
 	}
 
+	terminalTarget := s.workflowStepIsTerminal(ctx, targetStep.ID)
+
 	fromStep, err := s.workflowStepGetter.GetStep(ctx, result.FromStepID)
 	if err != nil {
 		s.logger.Warn("failed to load from-step for on_exit",
@@ -2138,6 +2145,10 @@ func (s *Service) applyEngineTransition(
 				zap.String("session_id", session.ID),
 				zap.Error(err))
 		}
+	}
+
+	if terminalTarget {
+		s.markTaskCompletedForTerminalStep(ctx, taskID)
 	}
 
 	if !triggerOnEnter {
@@ -2172,7 +2183,9 @@ func (s *Service) applyEngineTransition(
 	if session.State == models.TaskSessionStateRunning || session.State == models.TaskSessionStateStarting {
 		s.updateTaskSessionState(ctx, taskID, session.ID, models.TaskSessionStateWaitingForInput, "", false, session)
 		session.State = models.TaskSessionStateWaitingForInput
-		s.writeTaskReviewState(ctx, taskID, session.ID)
+		if !terminalTarget {
+			s.writeTaskReviewState(ctx, taskID, session.ID)
+		}
 	}
 
 	// Launch processOnEnter asynchronously to avoid blocking the stream reader goroutine.

--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -1058,7 +1058,7 @@ func (s *Service) applyPendingMove(ctx context.Context, taskID, sessionID string
 		zap.String("from_step_id", fromStepID),
 		zap.String("to_step_id", move.WorkflowStepID))
 
-	s.processParentChildrenCompletedForTerminalStepMove(ctx, taskID, move.WorkflowStepID)
+	s.syncTaskStateForPendingMove(ctx, taskID, fromStepID, move.WorkflowStepID)
 
 	// Run on_exit + on_enter asynchronously. This call originated from
 	// handleAgentReady on the WS event reader goroutine; processStepExitAndEnter
@@ -1069,6 +1069,44 @@ func (s *Service) applyPendingMove(ctx context.Context, taskID, sessionID string
 	// it's safe to defer the rest.
 	taskDescription := task.Description
 	go s.processStepExitAndEnter(context.WithoutCancel(ctx), taskID, session, fromStepID, move.WorkflowStepID, taskDescription)
+}
+
+func (s *Service) syncTaskStateForPendingMove(ctx context.Context, taskID, fromStepID, toStepID string) {
+	if s.workflowStepIsTerminal(ctx, toStepID) {
+		s.markTaskCompletedForTerminalStep(ctx, taskID, toStepID)
+		return
+	}
+	if fromStepID == toStepID || !s.workflowStepIsTerminal(ctx, fromStepID) {
+		return
+	}
+
+	s.taskRuntimeStateMu.Lock()
+	task, err := s.repo.GetTask(ctx, taskID)
+	if err != nil {
+		s.taskRuntimeStateMu.Unlock()
+		s.logger.Warn("pending move state sync: failed to load task",
+			zap.String("task_id", taskID),
+			zap.Error(err))
+		return
+	}
+	if task.WorkflowStepID != toStepID || task.State != v1.TaskStateCompleted {
+		s.taskRuntimeStateMu.Unlock()
+		return
+	}
+
+	oldState := task.State
+	task.State = v1.TaskStateTODO
+	task.UpdatedAt = time.Now().UTC()
+	if err := s.repo.UpdateTask(ctx, task); err != nil {
+		s.taskRuntimeStateMu.Unlock()
+		s.logger.Warn("pending move state sync: failed to reopen completed task",
+			zap.String("task_id", taskID),
+			zap.Error(err))
+		return
+	}
+	s.taskRuntimeStateMu.Unlock()
+	s.publishTaskUpdated(ctx, task)
+	s.publishTaskStateChanged(ctx, task, oldState)
 }
 
 // drainQueuedMessageForPromptableSession takes the next queued message and dispatches

--- a/apps/backend/internal/orchestrator/service.go
+++ b/apps/backend/internal/orchestrator/service.go
@@ -109,6 +109,7 @@ type TurnService interface {
 // payloads itself.
 type TaskEventPublisher interface {
 	PublishTaskUpdated(ctx context.Context, task *models.Task)
+	PublishTaskStateChanged(ctx context.Context, task *models.Task, oldState v1.TaskState)
 }
 
 // WorkflowStepGetter retrieves workflow step information for prompt building.
@@ -608,6 +609,13 @@ func (s *Service) publishTaskUpdated(ctx context.Context, task *models.Task) {
 		return
 	}
 	s.taskEvents.PublishTaskUpdated(ctx, task)
+}
+
+func (s *Service) publishTaskStateChanged(ctx context.Context, task *models.Task, oldState v1.TaskState) {
+	if s.taskEvents == nil || task == nil {
+		return
+	}
+	s.taskEvents.PublishTaskStateChanged(ctx, task, oldState)
 }
 
 // StepRequiresCompletionSignal reports whether the workflow step bound to taskID

--- a/apps/backend/internal/orchestrator/workflow_e2e_test.go
+++ b/apps/backend/internal/orchestrator/workflow_e2e_test.go
@@ -439,7 +439,10 @@ func TestProcessOnTurnCompleteViaEngine_NonTerminalStepWritesTaskStateReview(t *
 	}
 
 	assertStepByName(t, ctx, repo, "s1", "In Progress", nameToID)
-	if state, ok := taskRepo.updatedStates["t1"]; !ok || state != v1.TaskStateReview {
+	taskRepo.mu.Lock()
+	state, ok := taskRepo.updatedStates["t1"]
+	taskRepo.mu.Unlock()
+	if !ok || state != v1.TaskStateReview {
 		t.Errorf("tasks.state = %q, want %q (ok=%v)", state, v1.TaskStateReview, ok)
 	}
 }

--- a/apps/backend/internal/orchestrator/workflow_e2e_test.go
+++ b/apps/backend/internal/orchestrator/workflow_e2e_test.go
@@ -411,19 +411,10 @@ func assertSessionState(t *testing.T, ctx context.Context, repo sessionExecutorS
 	}
 }
 
-// Regression for #985: an on_turn_complete engine transition flips the
-// session to WAITING_FOR_INPUT and moves the task to the next step, but the
-// pre-fix code path forgot to write tasks.state = REVIEW. That left the
-// kanban card stuck in IN_PROGRESS — with a spinning loader — even though
-// the agent had paused and the card had already moved into the "Review"
-// column. Mirrors what setSessionWaitingForInput (the non-engine path)
-// has always done via writeTaskReviewState.
-//
-// The chosen transition is "New Step" → "Done": "Done" has no on_enter, so
-// no follow-up action can mask the missing write (e.g. auto_start_agent
-// would otherwise overwrite tasks.state back to IN_PROGRESS via
-// setSessionRunning).
-func TestProcessOnTurnCompleteViaEngine_WritesTaskStateReview(t *testing.T) {
+// A terminal on_turn_complete engine transition flips the session to
+// WAITING_FOR_INPUT, moves the task to the Done step, and persists
+// tasks.state = COMPLETED so the board column and API state agree.
+func TestProcessOnTurnCompleteViaEngine_TerminalStepCompletesTask(t *testing.T) {
 	ctx := context.Background()
 
 	sg, nameToID := buildWorkflowFromJSON(t, developmentWorkflowJSON)
@@ -433,10 +424,7 @@ func TestProcessOnTurnCompleteViaEngine_WritesTaskStateReview(t *testing.T) {
 	setSessionState(t, ctx, repo, "s1", models.TaskSessionStateRunning)
 
 	agentMgr := &mockAgentManager{repoForExecutionLookup: repo}
-	taskRepo := newMockTaskRepo()
-	seedMockTaskState(taskRepo, "t1", v1.TaskStateInProgress)
 	svc := createEngineService(t, repo, sg, agentMgr)
-	svc.taskRepo = taskRepo
 
 	session, err := repo.GetTaskSession(ctx, "s1")
 	if err != nil {
@@ -448,18 +436,18 @@ func TestProcessOnTurnCompleteViaEngine_WritesTaskStateReview(t *testing.T) {
 		t.Fatalf("expected a transition from New Step → Done, got none")
 	}
 
-	// writeTaskReviewState and ApplyTransition both run synchronously inside
+	// Terminal completion and ApplyTransition both run synchronously inside
 	// applyEngineTransition (before processOnEnter's goroutine), so the
 	// task-state and step assertions need no async wait. assertSessionState
 	// has its own polling loop for the WAITING_FOR_INPUT flip.
 	assertStepByName(t, ctx, repo, "s1", "Done", nameToID)
 	assertSessionState(t, ctx, repo, "s1", models.TaskSessionStateWaitingForInput)
 
-	got, ok := taskRepo.updatedStates["t1"]
-	if !ok {
-		t.Fatalf("expected tasks.state to be updated, but UpdateTaskState was never called")
+	task, err := repo.GetTask(ctx, "t1")
+	if err != nil {
+		t.Fatalf("failed to load task: %v", err)
 	}
-	if got != v1.TaskStateReview {
-		t.Errorf("tasks.state = %q, want %q (the kanban card would still show the spinner)", got, v1.TaskStateReview)
+	if task.State != v1.TaskStateCompleted {
+		t.Errorf("tasks.state = %q, want %q", task.State, v1.TaskStateCompleted)
 	}
 }

--- a/apps/backend/internal/orchestrator/workflow_e2e_test.go
+++ b/apps/backend/internal/orchestrator/workflow_e2e_test.go
@@ -411,6 +411,39 @@ func assertSessionState(t *testing.T, ctx context.Context, repo sessionExecutorS
 	}
 }
 
+// A non-terminal on_turn_complete engine transition must still write
+// tasks.state = REVIEW. This preserves the #985 regression coverage while
+// terminal targets use COMPLETED instead.
+func TestProcessOnTurnCompleteViaEngine_NonTerminalStepWritesTaskStateReview(t *testing.T) {
+	ctx := context.Background()
+
+	sg, nameToID := buildWorkflowFromJSON(t, developmentWorkflowJSON)
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "t1", "s1", nameToID["Backlog"])
+	setSessionExecID(t, repo, "s1", "exec-1")
+	setSessionState(t, ctx, repo, "s1", models.TaskSessionStateRunning)
+
+	agentMgr := &mockAgentManager{repoForExecutionLookup: repo}
+	svc := createEngineService(t, repo, sg, agentMgr)
+	taskRepo := svc.taskRepo.(*mockTaskRepo)
+	seedMockTaskState(taskRepo, "t1", v1.TaskStateInProgress)
+
+	session, err := repo.GetTaskSession(ctx, "s1")
+	if err != nil {
+		t.Fatalf("failed to load session: %v", err)
+	}
+
+	transitioned := svc.processOnTurnCompleteViaEngine(ctx, "t1", session)
+	if !transitioned {
+		t.Fatalf("expected a transition from Backlog -> In Progress, got none")
+	}
+
+	assertStepByName(t, ctx, repo, "s1", "In Progress", nameToID)
+	if state, ok := taskRepo.updatedStates["t1"]; !ok || state != v1.TaskStateReview {
+		t.Errorf("tasks.state = %q, want %q (ok=%v)", state, v1.TaskStateReview, ok)
+	}
+}
+
 // A terminal on_turn_complete engine transition flips the session to
 // WAITING_FOR_INPUT, moves the task to the Done step, and persists
 // tasks.state = COMPLETED so the board column and API state agree.

--- a/apps/backend/internal/task/models/models.go
+++ b/apps/backend/internal/task/models/models.go
@@ -365,7 +365,7 @@ type ChildCompletionRow struct {
 	State                v1.TaskState `json:"state" db:"state"`
 	Title                string       `json:"title" db:"title"`
 	WorkflowStepID       string       `json:"workflow_step_id" db:"workflow_step_id"`
-	TerminalWorkflowStep bool         `json:"terminal_workflow_step"`
+	TerminalWorkflowStep bool         `json:"terminal_workflow_step"` // computed by annotateTerminalChildSteps, not a DB column
 	UpdatedAt            time.Time    `json:"updated_at" db:"updated_at"`
 }
 

--- a/apps/backend/internal/task/models/models.go
+++ b/apps/backend/internal/task/models/models.go
@@ -361,10 +361,12 @@ type Task struct {
 // ChildCompletionRow is the compact active-child projection used to decide
 // whether a parent task's on_children_completed trigger is ready to fire.
 type ChildCompletionRow struct {
-	ID        string       `json:"id" db:"id"`
-	State     v1.TaskState `json:"state" db:"state"`
-	Title     string       `json:"title" db:"title"`
-	UpdatedAt time.Time    `json:"updated_at" db:"updated_at"`
+	ID                   string       `json:"id" db:"id"`
+	State                v1.TaskState `json:"state" db:"state"`
+	Title                string       `json:"title" db:"title"`
+	WorkflowStepID       string       `json:"workflow_step_id" db:"workflow_step_id"`
+	TerminalWorkflowStep bool         `json:"terminal_workflow_step"`
+	UpdatedAt            time.Time    `json:"updated_at" db:"updated_at"`
 }
 
 // IsTerminalTaskState reports whether a task state means no further child work

--- a/apps/backend/internal/task/repository/sqlite/task.go
+++ b/apps/backend/internal/task/repository/sqlite/task.go
@@ -365,7 +365,7 @@ func (r *Repository) ListChildCompletionRows(ctx context.Context, parentID strin
 	}
 	var rows []models.ChildCompletionRow
 	err := r.ro.SelectContext(ctx, &rows, r.ro.Rebind(`
-		SELECT id, state, title, updated_at
+		SELECT id, state, title, workflow_step_id, updated_at
 		FROM tasks
 		WHERE parent_id = ? AND archived_at IS NULL AND is_ephemeral = 0
 		ORDER BY created_at ASC, id ASC

--- a/apps/backend/internal/task/service/service_events.go
+++ b/apps/backend/internal/task/service/service_events.go
@@ -21,6 +21,12 @@ func (s *Service) PublishTaskUpdated(ctx context.Context, task *models.Task) {
 	s.publishTaskEvent(ctx, events.TaskUpdated, task, nil)
 }
 
+// PublishTaskStateChanged publishes a task.state_changed event for callers
+// that mutate task state outside the normal task service update path.
+func (s *Service) PublishTaskStateChanged(ctx context.Context, task *models.Task, oldState v1.TaskState) {
+	s.publishTaskEvent(ctx, events.TaskStateChanged, task, &oldState)
+}
+
 // PublishTaskDeleted publishes a task.deleted event for the given task.
 // Used by cascade-delete callers (HandoffService.DeleteTaskTree) that
 // bypass Service.DeleteTask and therefore would otherwise leave WS

--- a/apps/backend/internal/task/service/service_workflow.go
+++ b/apps/backend/internal/task/service/service_workflow.go
@@ -398,6 +398,31 @@ func (s *Service) syncTaskStateForWorkflowMove(ctx context.Context, task *models
 	return nil
 }
 
+func (s *Service) syncTaskStateForBulkWorkflowMove(ctx context.Context, task *models.Task, oldStepID, targetStepID string, targetIsTerminal, sourceIsTerminal, sourceTerminalKnown bool) error {
+	if targetIsTerminal {
+		if !models.IsTerminalTaskState(task.State) {
+			task.State = v1.TaskStateCompleted
+		}
+		return nil
+	}
+	if oldStepID == targetStepID || task.State != v1.TaskStateCompleted {
+		return nil
+	}
+
+	oldTerminal := sourceIsTerminal
+	if !sourceTerminalKnown {
+		var err error
+		oldTerminal, err = s.terminalWorkflowStep(ctx, oldStepID)
+		if err != nil {
+			return err
+		}
+	}
+	if oldTerminal {
+		task.State = v1.TaskStateTODO
+	}
+	return nil
+}
+
 func (s *Service) validateTaskMove(ctx context.Context, task *models.Task, workflowID, workflowStepID string, opts MoveTaskOptions) error {
 	if task.ArchivedAt != nil {
 		return fmt.Errorf("archived tasks cannot be moved")
@@ -591,21 +616,9 @@ func (s *Service) BulkMoveTasks(ctx context.Context, sourceWorkflowID, sourceSte
 		task.WorkflowID = targetWorkflowID
 		task.WorkflowStepID = targetStepID
 		task.Position = i
-		if targetIsTerminal {
-			if !models.IsTerminalTaskState(task.State) {
-				task.State = v1.TaskStateCompleted
-			}
-		} else if oldStepID != targetStepID && task.State == v1.TaskStateCompleted {
-			oldTerminal := sourceIsTerminal
-			if !sourceTerminalKnown {
-				oldTerminal, err = s.terminalWorkflowStep(ctx, oldStepID)
-				if err != nil {
-					return nil, fmt.Errorf("failed to sync task state for bulk move %s: %w", task.ID, err)
-				}
-			}
-			if oldTerminal {
-				task.State = v1.TaskStateTODO
-			}
+		err := s.syncTaskStateForBulkWorkflowMove(ctx, task, oldStepID, targetStepID, targetIsTerminal, sourceIsTerminal, sourceTerminalKnown)
+		if err != nil {
+			return nil, fmt.Errorf("failed to sync task state for bulk move %s: %w", task.ID, err)
 		}
 		task.UpdatedAt = now
 

--- a/apps/backend/internal/task/service/service_workflow.go
+++ b/apps/backend/internal/task/service/service_workflow.go
@@ -380,7 +380,9 @@ func (s *Service) syncTaskStateForWorkflowMove(ctx context.Context, task *models
 		return err
 	}
 	if newTerminal {
-		task.State = v1.TaskStateCompleted
+		if !models.IsTerminalTaskState(task.State) {
+			task.State = v1.TaskStateCompleted
+		}
 		return nil
 	}
 	if oldStepID == newStepID || task.State != v1.TaskStateCompleted {
@@ -571,6 +573,15 @@ func (s *Service) BulkMoveTasks(ctx context.Context, sourceWorkflowID, sourceSte
 	if err != nil {
 		return nil, fmt.Errorf("failed to check target step terminal status: %w", err)
 	}
+	sourceIsTerminal := false
+	sourceTerminalKnown := false
+	if sourceStepID != "" {
+		sourceIsTerminal, err = s.terminalWorkflowStep(ctx, sourceStepID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to check source step terminal status: %w", err)
+		}
+		sourceTerminalKnown = true
+	}
 
 	now := time.Now().UTC()
 	for i, task := range tasks {
@@ -581,11 +592,16 @@ func (s *Service) BulkMoveTasks(ctx context.Context, sourceWorkflowID, sourceSte
 		task.WorkflowStepID = targetStepID
 		task.Position = i
 		if targetIsTerminal {
-			task.State = v1.TaskStateCompleted
+			if !models.IsTerminalTaskState(task.State) {
+				task.State = v1.TaskStateCompleted
+			}
 		} else if oldStepID != targetStepID && task.State == v1.TaskStateCompleted {
-			oldTerminal, err := s.terminalWorkflowStep(ctx, oldStepID)
-			if err != nil {
-				return nil, fmt.Errorf("failed to sync task state for bulk move %s: %w", task.ID, err)
+			oldTerminal := sourceIsTerminal
+			if !sourceTerminalKnown {
+				oldTerminal, err = s.terminalWorkflowStep(ctx, oldStepID)
+				if err != nil {
+					return nil, fmt.Errorf("failed to sync task state for bulk move %s: %w", task.ID, err)
+				}
 			}
 			if oldTerminal {
 				task.State = v1.TaskStateTODO

--- a/apps/backend/internal/task/service/service_workflow.go
+++ b/apps/backend/internal/task/service/service_workflow.go
@@ -289,11 +289,15 @@ func (s *Service) MoveTaskWithOptions(
 
 	oldWorkflowID := task.WorkflowID
 	oldStepID := task.WorkflowStepID
+	oldState := task.State
 	stepChanged := oldStepID != workflowStepID
 
 	task.WorkflowID = workflowID
 	task.WorkflowStepID = workflowStepID
 	task.Position = position
+	if s.isTerminalWorkflowStep(ctx, workflowStepID) {
+		task.State = v1.TaskStateCompleted
+	}
 	task.UpdatedAt = time.Now().UTC()
 
 	if err := s.tasks.UpdateTask(ctx, task); err != nil {
@@ -308,6 +312,9 @@ func (s *Service) MoveTaskWithOptions(
 	}
 
 	s.publishTaskEvent(ctx, events.TaskUpdated, task, nil, oldWorkflowID)
+	if oldState != task.State {
+		s.publishTaskEvent(ctx, events.TaskStateChanged, task, &oldState)
+	}
 
 	// Publish task.moved event so the orchestrator can process on_exit/on_enter actions
 	if stepChanged {
@@ -336,6 +343,24 @@ func (s *Service) MoveTaskWithOptions(
 	}
 
 	return result, nil
+}
+
+func (s *Service) isTerminalWorkflowStep(ctx context.Context, workflowStepID string) bool {
+	if s.workflowStepGetter == nil || workflowStepID == "" {
+		return false
+	}
+	step, err := s.workflowStepGetter.GetStep(ctx, workflowStepID)
+	if err != nil || step == nil {
+		return false
+	}
+	nextStep, err := s.workflowStepGetter.GetNextStepByPosition(ctx, step.WorkflowID, step.Position)
+	if err != nil {
+		s.logger.Warn("failed to get next workflow step for terminal check",
+			zap.String("workflow_step_id", workflowStepID),
+			zap.Error(err))
+		return false
+	}
+	return wfmodels.IsTerminalStep(step, nextStep)
 }
 
 func (s *Service) validateTaskMove(ctx context.Context, task *models.Task, workflowID, workflowStepID string, opts MoveTaskOptions) error {

--- a/apps/backend/internal/task/service/service_workflow.go
+++ b/apps/backend/internal/task/service/service_workflow.go
@@ -356,17 +356,6 @@ func (s *Service) MoveTaskWithOptions(
 	return result, nil
 }
 
-func (s *Service) isTerminalWorkflowStep(ctx context.Context, workflowStepID string) bool {
-	terminal, err := s.terminalWorkflowStep(ctx, workflowStepID)
-	if err != nil {
-		s.logger.Warn("failed to get workflow step terminal status",
-			zap.String("workflow_step_id", workflowStepID),
-			zap.Error(err))
-		return false
-	}
-	return terminal
-}
-
 func (s *Service) terminalWorkflowStep(ctx context.Context, workflowStepID string) (bool, error) {
 	if s.workflowStepGetter == nil || workflowStepID == "" {
 		return false, nil
@@ -394,7 +383,7 @@ func (s *Service) syncTaskStateForWorkflowMove(ctx context.Context, task *models
 		task.State = v1.TaskStateCompleted
 		return nil
 	}
-	if oldStepID == newStepID || !models.IsTerminalTaskState(task.State) {
+	if oldStepID == newStepID || task.State != v1.TaskStateCompleted {
 		return nil
 	}
 	oldTerminal, err := s.terminalWorkflowStep(ctx, oldStepID)
@@ -578,6 +567,11 @@ func (s *Service) BulkMoveTasks(ctx context.Context, sourceWorkflowID, sourceSte
 		return &BulkMoveTasksResult{MovedCount: 0}, nil
 	}
 
+	targetIsTerminal, err := s.terminalWorkflowStep(ctx, targetStepID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check target step terminal status: %w", err)
+	}
+
 	now := time.Now().UTC()
 	for i, task := range tasks {
 		oldWorkflowID := task.WorkflowID
@@ -586,8 +580,16 @@ func (s *Service) BulkMoveTasks(ctx context.Context, sourceWorkflowID, sourceSte
 		task.WorkflowID = targetWorkflowID
 		task.WorkflowStepID = targetStepID
 		task.Position = i
-		if err := s.syncTaskStateForWorkflowMove(ctx, task, oldStepID, targetStepID); err != nil {
-			return nil, fmt.Errorf("failed to sync task state for bulk move %s: %w", task.ID, err)
+		if targetIsTerminal {
+			task.State = v1.TaskStateCompleted
+		} else if oldStepID != targetStepID && task.State == v1.TaskStateCompleted {
+			oldTerminal, err := s.terminalWorkflowStep(ctx, oldStepID)
+			if err != nil {
+				return nil, fmt.Errorf("failed to sync task state for bulk move %s: %w", task.ID, err)
+			}
+			if oldTerminal {
+				task.State = v1.TaskStateTODO
+			}
 		}
 		task.UpdatedAt = now
 

--- a/apps/backend/internal/task/service/service_workflow.go
+++ b/apps/backend/internal/task/service/service_workflow.go
@@ -78,7 +78,9 @@ func (s *Service) applyApprovalStepTransition(ctx context.Context, sessionID str
 			zap.String("task_id", result.Session.TaskID),
 			zap.Error(err))
 	} else {
+		oldState := task.State
 		task.WorkflowStepID = newStepID
+		s.syncTaskStateForWorkflowMove(ctx, task, step.ID, newStepID)
 		task.UpdatedAt = time.Now().UTC()
 		if err := s.tasks.UpdateTask(ctx, task); err != nil {
 			s.logger.Error("failed to move task to next step after approval",
@@ -87,6 +89,9 @@ func (s *Service) applyApprovalStepTransition(ctx context.Context, sessionID str
 				zap.Error(err))
 		} else {
 			s.publishTaskEvent(ctx, events.TaskUpdated, task, nil)
+			if oldState != task.State {
+				s.publishTaskEvent(ctx, events.TaskStateChanged, task, &oldState)
+			}
 			result.Task = task
 		}
 	}
@@ -295,9 +300,7 @@ func (s *Service) MoveTaskWithOptions(
 	task.WorkflowID = workflowID
 	task.WorkflowStepID = workflowStepID
 	task.Position = position
-	if s.isTerminalWorkflowStep(ctx, workflowStepID) {
-		task.State = v1.TaskStateCompleted
-	}
+	s.syncTaskStateForWorkflowMove(ctx, task, oldStepID, workflowStepID)
 	task.UpdatedAt = time.Now().UTC()
 
 	if err := s.tasks.UpdateTask(ctx, task); err != nil {
@@ -361,6 +364,16 @@ func (s *Service) isTerminalWorkflowStep(ctx context.Context, workflowStepID str
 		return false
 	}
 	return wfmodels.IsTerminalStep(step, nextStep)
+}
+
+func (s *Service) syncTaskStateForWorkflowMove(ctx context.Context, task *models.Task, oldStepID, newStepID string) {
+	if s.isTerminalWorkflowStep(ctx, newStepID) {
+		task.State = v1.TaskStateCompleted
+		return
+	}
+	if oldStepID != newStepID && models.IsTerminalTaskState(task.State) && s.isTerminalWorkflowStep(ctx, oldStepID) {
+		task.State = v1.TaskStateTODO
+	}
 }
 
 func (s *Service) validateTaskMove(ctx context.Context, task *models.Task, workflowID, workflowStepID string, opts MoveTaskOptions) error {
@@ -535,11 +548,19 @@ func (s *Service) BulkMoveTasks(ctx context.Context, sourceWorkflowID, sourceSte
 	}
 
 	now := time.Now().UTC()
+	targetIsTerminal := s.isTerminalWorkflowStep(ctx, targetStepID)
 	for i, task := range tasks {
 		oldWorkflowID := task.WorkflowID
+		oldStepID := task.WorkflowStepID
+		oldState := task.State
 		task.WorkflowID = targetWorkflowID
 		task.WorkflowStepID = targetStepID
 		task.Position = i
+		if targetIsTerminal {
+			task.State = v1.TaskStateCompleted
+		} else if oldStepID != targetStepID && models.IsTerminalTaskState(task.State) && s.isTerminalWorkflowStep(ctx, oldStepID) {
+			task.State = v1.TaskStateTODO
+		}
 		task.UpdatedAt = now
 
 		if err := s.tasks.UpdateTask(ctx, task); err != nil {
@@ -550,6 +571,9 @@ func (s *Service) BulkMoveTasks(ctx context.Context, sourceWorkflowID, sourceSte
 		}
 
 		s.publishTaskEvent(ctx, events.TaskUpdated, task, nil, oldWorkflowID)
+		if oldState != task.State {
+			s.publishTaskEvent(ctx, events.TaskStateChanged, task, &oldState)
+		}
 	}
 
 	s.logger.Info("bulk moved tasks",

--- a/apps/backend/internal/task/service/service_workflow.go
+++ b/apps/backend/internal/task/service/service_workflow.go
@@ -80,7 +80,13 @@ func (s *Service) applyApprovalStepTransition(ctx context.Context, sessionID str
 	} else {
 		oldState := task.State
 		task.WorkflowStepID = newStepID
-		s.syncTaskStateForWorkflowMove(ctx, task, step.ID, newStepID)
+		if err := s.syncTaskStateForWorkflowMove(ctx, task, step.ID, newStepID); err != nil {
+			s.logger.Error("failed to sync task state for approval transition",
+				zap.String("task_id", result.Session.TaskID),
+				zap.String("step_id", newStepID),
+				zap.Error(err))
+			return
+		}
 		task.UpdatedAt = time.Now().UTC()
 		if err := s.tasks.UpdateTask(ctx, task); err != nil {
 			s.logger.Error("failed to move task to next step after approval",
@@ -300,7 +306,9 @@ func (s *Service) MoveTaskWithOptions(
 	task.WorkflowID = workflowID
 	task.WorkflowStepID = workflowStepID
 	task.Position = position
-	s.syncTaskStateForWorkflowMove(ctx, task, oldStepID, workflowStepID)
+	if err := s.syncTaskStateForWorkflowMove(ctx, task, oldStepID, workflowStepID); err != nil {
+		return nil, fmt.Errorf("failed to sync task state for workflow move: %w", err)
+	}
 	task.UpdatedAt = time.Now().UTC()
 
 	if err := s.tasks.UpdateTask(ctx, task); err != nil {
@@ -349,31 +357,54 @@ func (s *Service) MoveTaskWithOptions(
 }
 
 func (s *Service) isTerminalWorkflowStep(ctx context.Context, workflowStepID string) bool {
-	if s.workflowStepGetter == nil || workflowStepID == "" {
-		return false
-	}
-	step, err := s.workflowStepGetter.GetStep(ctx, workflowStepID)
-	if err != nil || step == nil {
-		return false
-	}
-	nextStep, err := s.workflowStepGetter.GetNextStepByPosition(ctx, step.WorkflowID, step.Position)
+	terminal, err := s.terminalWorkflowStep(ctx, workflowStepID)
 	if err != nil {
-		s.logger.Warn("failed to get next workflow step for terminal check",
+		s.logger.Warn("failed to get workflow step terminal status",
 			zap.String("workflow_step_id", workflowStepID),
 			zap.Error(err))
 		return false
 	}
-	return wfmodels.IsTerminalStep(step, nextStep)
+	return terminal
 }
 
-func (s *Service) syncTaskStateForWorkflowMove(ctx context.Context, task *models.Task, oldStepID, newStepID string) {
-	if s.isTerminalWorkflowStep(ctx, newStepID) {
-		task.State = v1.TaskStateCompleted
-		return
+func (s *Service) terminalWorkflowStep(ctx context.Context, workflowStepID string) (bool, error) {
+	if s.workflowStepGetter == nil || workflowStepID == "" {
+		return false, nil
 	}
-	if oldStepID != newStepID && models.IsTerminalTaskState(task.State) && s.isTerminalWorkflowStep(ctx, oldStepID) {
+	step, err := s.workflowStepGetter.GetStep(ctx, workflowStepID)
+	if err != nil {
+		return false, fmt.Errorf("failed to get workflow step %s: %w", workflowStepID, err)
+	}
+	if step == nil {
+		return false, nil
+	}
+	nextStep, err := s.workflowStepGetter.GetNextStepByPosition(ctx, step.WorkflowID, step.Position)
+	if err != nil {
+		return false, fmt.Errorf("failed to get next workflow step after %s: %w", workflowStepID, err)
+	}
+	return wfmodels.IsTerminalStep(step, nextStep), nil
+}
+
+func (s *Service) syncTaskStateForWorkflowMove(ctx context.Context, task *models.Task, oldStepID, newStepID string) error {
+	newTerminal, err := s.terminalWorkflowStep(ctx, newStepID)
+	if err != nil {
+		return err
+	}
+	if newTerminal {
+		task.State = v1.TaskStateCompleted
+		return nil
+	}
+	if oldStepID == newStepID || !models.IsTerminalTaskState(task.State) {
+		return nil
+	}
+	oldTerminal, err := s.terminalWorkflowStep(ctx, oldStepID)
+	if err != nil {
+		return err
+	}
+	if oldTerminal {
 		task.State = v1.TaskStateTODO
 	}
+	return nil
 }
 
 func (s *Service) validateTaskMove(ctx context.Context, task *models.Task, workflowID, workflowStepID string, opts MoveTaskOptions) error {
@@ -548,7 +579,6 @@ func (s *Service) BulkMoveTasks(ctx context.Context, sourceWorkflowID, sourceSte
 	}
 
 	now := time.Now().UTC()
-	targetIsTerminal := s.isTerminalWorkflowStep(ctx, targetStepID)
 	for i, task := range tasks {
 		oldWorkflowID := task.WorkflowID
 		oldStepID := task.WorkflowStepID
@@ -556,10 +586,8 @@ func (s *Service) BulkMoveTasks(ctx context.Context, sourceWorkflowID, sourceSte
 		task.WorkflowID = targetWorkflowID
 		task.WorkflowStepID = targetStepID
 		task.Position = i
-		if targetIsTerminal {
-			task.State = v1.TaskStateCompleted
-		} else if oldStepID != targetStepID && models.IsTerminalTaskState(task.State) && s.isTerminalWorkflowStep(ctx, oldStepID) {
-			task.State = v1.TaskStateTODO
+		if err := s.syncTaskStateForWorkflowMove(ctx, task, oldStepID, targetStepID); err != nil {
+			return nil, fmt.Errorf("failed to sync task state for bulk move %s: %w", task.ID, err)
 		}
 		task.UpdatedAt = now
 

--- a/apps/backend/internal/task/service/service_workflow_test.go
+++ b/apps/backend/internal/task/service/service_workflow_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -13,7 +14,8 @@ import (
 )
 
 type fakeWorkflowStepGetter struct {
-	steps map[string]*wfmodels.WorkflowStep
+	steps   map[string]*wfmodels.WorkflowStep
+	nextErr error
 }
 
 func (f *fakeWorkflowStepGetter) GetStep(_ context.Context, stepID string) (*wfmodels.WorkflowStep, error) {
@@ -24,6 +26,9 @@ func (f *fakeWorkflowStepGetter) GetStep(_ context.Context, stepID string) (*wfm
 }
 
 func (f *fakeWorkflowStepGetter) GetNextStepByPosition(_ context.Context, workflowID string, currentPosition int) (*wfmodels.WorkflowStep, error) {
+	if f.nextErr != nil {
+		return nil, f.nextErr
+	}
 	for _, step := range f.steps {
 		if step.WorkflowID == workflowID && step.Position == currentPosition+1 {
 			return step, nil
@@ -168,6 +173,29 @@ func TestService_MoveTaskToTerminalStepCompletesTask(t *testing.T) {
 		t.Fatalf("persisted task state = %q, want COMPLETED", task.State)
 	}
 	findPublishedEvent(t, eventBus.GetPublishedEvents(), events.TaskStateChanged)
+}
+
+func TestService_MoveTaskFailsWhenTerminalStatusLookupFails(t *testing.T) {
+	svc, _, repo := createTestService(t)
+	ctx := context.Background()
+	seedMoveWorkflows(t, ctx, repo)
+	seedMoveSteps(svc)
+	getter := svc.workflowStepGetter.(*fakeWorkflowStepGetter)
+	getter.nextErr = errors.New("next step lookup failed")
+	createMoveTask(t, ctx, repo, "task-terminal-lookup-error", "wf-source", "step-source", nil)
+
+	_, err := svc.MoveTask(ctx, "task-terminal-lookup-error", "wf-source", "step-review-target", 0)
+	if err == nil {
+		t.Fatalf("expected move to fail when terminal status lookup fails")
+	}
+
+	task, err := repo.GetTask(ctx, "task-terminal-lookup-error")
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if task.WorkflowStepID != "step-source" {
+		t.Fatalf("task moved despite lookup error: %s", task.WorkflowStepID)
+	}
 }
 
 func TestService_MoveTaskOutOfTerminalStepReopensTask(t *testing.T) {

--- a/apps/backend/internal/task/service/service_workflow_test.go
+++ b/apps/backend/internal/task/service/service_workflow_test.go
@@ -170,6 +170,76 @@ func TestService_MoveTaskToTerminalStepCompletesTask(t *testing.T) {
 	findPublishedEvent(t, eventBus.GetPublishedEvents(), events.TaskStateChanged)
 }
 
+func TestService_MoveTaskOutOfTerminalStepReopensTask(t *testing.T) {
+	svc, eventBus, repo := createTestService(t)
+	ctx := context.Background()
+	seedMoveWorkflows(t, ctx, repo)
+	seedMoveSteps(svc)
+	getter := svc.workflowStepGetter.(*fakeWorkflowStepGetter)
+	getter.steps["step-done"] = &wfmodels.WorkflowStep{
+		ID: "step-done", WorkflowID: "wf-source", Name: "Done", Position: 2,
+	}
+	createMoveTask(t, ctx, repo, "task-reopened", "wf-source", "step-done", nil)
+	task, err := repo.GetTask(ctx, "task-reopened")
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	task.State = v1.TaskStateCompleted
+	must(t, repo.UpdateTask(ctx, task))
+	eventBus.ClearEvents()
+
+	moved, err := svc.MoveTask(ctx, "task-reopened", "wf-source", "step-source", 0)
+	if err != nil {
+		t.Fatalf("MoveTask: %v", err)
+	}
+	if moved.Task.State != v1.TaskStateTODO {
+		t.Fatalf("moved task state = %q, want TODO", moved.Task.State)
+	}
+
+	task, err = repo.GetTask(ctx, "task-reopened")
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if task.State != v1.TaskStateTODO {
+		t.Fatalf("persisted task state = %q, want TODO", task.State)
+	}
+	findPublishedEvent(t, eventBus.GetPublishedEvents(), events.TaskStateChanged)
+}
+
+func TestService_ApproveSessionToTerminalStepCompletesTask(t *testing.T) {
+	svc, eventBus, repo := createTestService(t)
+	ctx := context.Background()
+	seedMoveWorkflows(t, ctx, repo)
+	seedMoveSteps(svc)
+	getter := svc.workflowStepGetter.(*fakeWorkflowStepGetter)
+	getter.steps["step-done"] = &wfmodels.WorkflowStep{
+		ID: "step-done", WorkflowID: "wf-source", Name: "Approved", Position: 2,
+	}
+	createMoveTask(t, ctx, repo, "task-approved", "wf-source", "step-review-target", nil)
+	createMoveSession(t, ctx, repo, "session-approved", "task-approved", models.TaskSessionStateWaitingForInput, models.ReviewStatusPending)
+	eventBus.ClearEvents()
+
+	result, err := svc.ApproveSession(ctx, "session-approved")
+	if err != nil {
+		t.Fatalf("ApproveSession: %v", err)
+	}
+	if result.Task == nil || result.Task.WorkflowStepID != "step-done" {
+		t.Fatalf("approved task step = %+v, want step-done", result.Task)
+	}
+	if result.Task.State != v1.TaskStateCompleted {
+		t.Fatalf("approved task state = %q, want COMPLETED", result.Task.State)
+	}
+
+	task, err := repo.GetTask(ctx, "task-approved")
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if task.State != v1.TaskStateCompleted {
+		t.Fatalf("persisted task state = %q, want COMPLETED", task.State)
+	}
+	findPublishedEvent(t, eventBus.GetPublishedEvents(), events.TaskStateChanged)
+}
+
 func TestService_MoveTaskRejectsRunningSession(t *testing.T) {
 	svc, _, repo := createTestService(t)
 	ctx := context.Background()
@@ -290,6 +360,33 @@ func TestService_BulkMoveTasksUpdatedEventIncludesSourceWorkflow(t *testing.T) {
 	if got := updatedData["old_workflow_id"]; got != "wf-source" {
 		t.Fatalf("old_workflow_id = %v, want wf-source", got)
 	}
+}
+
+func TestService_BulkMoveTasksToTerminalStepCompletesTasks(t *testing.T) {
+	svc, eventBus, repo := createTestService(t)
+	ctx := context.Background()
+	seedMoveWorkflows(t, ctx, repo)
+	seedMoveSteps(svc)
+	getter := svc.workflowStepGetter.(*fakeWorkflowStepGetter)
+	getter.steps["step-done"] = &wfmodels.WorkflowStep{
+		ID: "step-done", WorkflowID: "wf-source", Name: "Done", Position: 2,
+	}
+	createMoveTask(t, ctx, repo, "task-bulk-terminal", "wf-source", "step-source", nil)
+	eventBus.ClearEvents()
+
+	_, err := svc.BulkMoveTasks(ctx, "wf-source", "step-source", "wf-source", "step-done")
+	if err != nil {
+		t.Fatalf("BulkMoveTasks: %v", err)
+	}
+
+	task, err := repo.GetTask(ctx, "task-bulk-terminal")
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if task.State != v1.TaskStateCompleted {
+		t.Fatalf("bulk-moved task state = %q, want COMPLETED", task.State)
+	}
+	findPublishedEvent(t, eventBus.GetPublishedEvents(), events.TaskStateChanged)
 }
 
 func TestService_BulkMoveSelectedTasksValidatesBatchBeforeMoving(t *testing.T) {

--- a/apps/backend/internal/task/service/service_workflow_test.go
+++ b/apps/backend/internal/task/service/service_workflow_test.go
@@ -179,6 +179,52 @@ func TestService_MoveTaskToTerminalStepCompletesTask(t *testing.T) {
 	findPublishedEvent(t, eventBus.GetPublishedEvents(), events.TaskStateChanged)
 }
 
+func TestService_MoveTaskToTerminalStepPreservesTerminalFailureStates(t *testing.T) {
+	cases := []struct {
+		name  string
+		state v1.TaskState
+	}{
+		{name: "failed", state: v1.TaskStateFailed},
+		{name: "cancelled", state: v1.TaskStateCancelled},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			svc, _, repo := createTestService(t)
+			ctx := context.Background()
+			seedMoveWorkflows(t, ctx, repo)
+			seedMoveSteps(svc)
+			getter := svc.workflowStepGetter.(*fakeWorkflowStepGetter)
+			getter.steps["step-done"] = &wfmodels.WorkflowStep{
+				ID: "step-done", WorkflowID: "wf-source", Name: "Done", Position: 2,
+			}
+			createMoveTask(t, ctx, repo, "task-terminal-"+tc.name, "wf-source", "step-source", nil)
+			task, err := repo.GetTask(ctx, "task-terminal-"+tc.name)
+			if err != nil {
+				t.Fatalf("GetTask: %v", err)
+			}
+			task.State = tc.state
+			must(t, repo.UpdateTask(ctx, task))
+
+			moved, err := svc.MoveTask(ctx, task.ID, "wf-source", "step-done", 0)
+			if err != nil {
+				t.Fatalf("MoveTask: %v", err)
+			}
+			if moved.Task.State != tc.state {
+				t.Fatalf("moved task state = %q, want %q", moved.Task.State, tc.state)
+			}
+
+			task, err = repo.GetTask(ctx, task.ID)
+			if err != nil {
+				t.Fatalf("GetTask: %v", err)
+			}
+			if task.State != tc.state {
+				t.Fatalf("persisted task state = %q, want %q", task.State, tc.state)
+			}
+		})
+	}
+}
+
 func TestService_MoveTaskFailsWhenTerminalStatusLookupFails(t *testing.T) {
 	svc, _, repo := createTestService(t)
 	ctx := context.Background()
@@ -419,6 +465,49 @@ func TestService_BulkMoveTasksToTerminalStepCompletesTasks(t *testing.T) {
 		t.Fatalf("bulk-moved task state = %q, want COMPLETED", task.State)
 	}
 	findPublishedEvent(t, eventBus.GetPublishedEvents(), events.TaskStateChanged)
+}
+
+func TestService_BulkMoveTasksToTerminalStepPreservesTerminalFailureStates(t *testing.T) {
+	cases := []struct {
+		name  string
+		state v1.TaskState
+	}{
+		{name: "failed", state: v1.TaskStateFailed},
+		{name: "cancelled", state: v1.TaskStateCancelled},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			svc, _, repo := createTestService(t)
+			ctx := context.Background()
+			seedMoveWorkflows(t, ctx, repo)
+			seedMoveSteps(svc)
+			getter := svc.workflowStepGetter.(*fakeWorkflowStepGetter)
+			getter.steps["step-done"] = &wfmodels.WorkflowStep{
+				ID: "step-done", WorkflowID: "wf-source", Name: "Done", Position: 2,
+			}
+			createMoveTask(t, ctx, repo, "task-bulk-terminal-"+tc.name, "wf-source", "step-source", nil)
+			task, err := repo.GetTask(ctx, "task-bulk-terminal-"+tc.name)
+			if err != nil {
+				t.Fatalf("GetTask: %v", err)
+			}
+			task.State = tc.state
+			must(t, repo.UpdateTask(ctx, task))
+
+			_, err = svc.BulkMoveTasks(ctx, "wf-source", "step-source", "wf-source", "step-done")
+			if err != nil {
+				t.Fatalf("BulkMoveTasks: %v", err)
+			}
+
+			task, err = repo.GetTask(ctx, task.ID)
+			if err != nil {
+				t.Fatalf("GetTask: %v", err)
+			}
+			if task.State != tc.state {
+				t.Fatalf("bulk-moved task state = %q, want %q", task.State, tc.state)
+			}
+		})
+	}
 }
 
 func TestService_BulkMoveSelectedTasksValidatesBatchBeforeMoving(t *testing.T) {

--- a/apps/backend/internal/task/service/service_workflow_test.go
+++ b/apps/backend/internal/task/service/service_workflow_test.go
@@ -29,12 +29,16 @@ func (f *fakeWorkflowStepGetter) GetNextStepByPosition(_ context.Context, workfl
 	if f.nextErr != nil {
 		return nil, f.nextErr
 	}
+	var next *wfmodels.WorkflowStep
 	for _, step := range f.steps {
-		if step.WorkflowID == workflowID && step.Position == currentPosition+1 {
-			return step, nil
+		if step.WorkflowID != workflowID || step.Position <= currentPosition {
+			continue
+		}
+		if next == nil || step.Position < next.Position {
+			next = step
 		}
 	}
-	return nil, nil
+	return next, nil
 }
 
 type testStepNotFound struct{}

--- a/apps/backend/internal/task/service/service_workflow_test.go
+++ b/apps/backend/internal/task/service/service_workflow_test.go
@@ -140,6 +140,36 @@ func TestService_MoveTaskAllowsPendingReviewWhenSessionIdle(t *testing.T) {
 	}
 }
 
+func TestService_MoveTaskToTerminalStepCompletesTask(t *testing.T) {
+	svc, eventBus, repo := createTestService(t)
+	ctx := context.Background()
+	seedMoveWorkflows(t, ctx, repo)
+	seedMoveSteps(svc)
+	getter := svc.workflowStepGetter.(*fakeWorkflowStepGetter)
+	getter.steps["step-done"] = &wfmodels.WorkflowStep{
+		ID: "step-done", WorkflowID: "wf-source", Name: "Done", Position: 2,
+	}
+	createMoveTask(t, ctx, repo, "task-terminal", "wf-source", "step-source", nil)
+	eventBus.ClearEvents()
+
+	moved, err := svc.MoveTask(ctx, "task-terminal", "wf-source", "step-done", 0)
+	if err != nil {
+		t.Fatalf("MoveTask: %v", err)
+	}
+	if moved.Task.State != v1.TaskStateCompleted {
+		t.Fatalf("moved task state = %q, want COMPLETED", moved.Task.State)
+	}
+
+	task, err := repo.GetTask(ctx, "task-terminal")
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if task.State != v1.TaskStateCompleted {
+		t.Fatalf("persisted task state = %q, want COMPLETED", task.State)
+	}
+	findPublishedEvent(t, eventBus.GetPublishedEvents(), events.TaskStateChanged)
+}
+
 func TestService_MoveTaskRejectsRunningSession(t *testing.T) {
 	svc, _, repo := createTestService(t)
 	ctx := context.Background()

--- a/apps/backend/internal/workflow/models/terminal.go
+++ b/apps/backend/internal/workflow/models/terminal.go
@@ -1,0 +1,22 @@
+package models
+
+import "strings"
+
+// IsTerminalStep reports whether a workflow step represents finished work by
+// the existing board convention: a final column named Done/Complete/Approved.
+func IsTerminalStep(step, nextStep *WorkflowStep) bool {
+	if step == nil || nextStep != nil {
+		return false
+	}
+	return IsTerminalStepName(step.Name)
+}
+
+// IsTerminalStepName recognizes the existing built-in terminal column names.
+func IsTerminalStepName(name string) bool {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "done", "complete", "completed", "approved":
+		return true
+	default:
+		return false
+	}
+}

--- a/apps/backend/internal/workflow/models/terminal_test.go
+++ b/apps/backend/internal/workflow/models/terminal_test.go
@@ -1,0 +1,66 @@
+package models
+
+import "testing"
+
+func TestIsTerminalStepName(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{name: "done", want: true},
+		{name: "Done", want: true},
+		{name: "DONE", want: true},
+		{name: " Done ", want: true},
+		{name: "complete", want: true},
+		{name: "Complete", want: true},
+		{name: "COMPLETE", want: true},
+		{name: " Complete ", want: true},
+		{name: "completed", want: true},
+		{name: "Completed", want: true},
+		{name: "COMPLETED", want: true},
+		{name: " Completed ", want: true},
+		{name: "approved", want: true},
+		{name: "Approved", want: true},
+		{name: "APPROVED", want: true},
+		{name: " Approved ", want: true},
+		{name: "Work", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsTerminalStepName(tt.name); got != tt.want {
+				t.Fatalf("IsTerminalStepName(%q) = %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsTerminalStep(t *testing.T) {
+	t.Run("nil step", func(t *testing.T) {
+		if IsTerminalStep(nil, nil) {
+			t.Fatalf("nil step reported terminal")
+		}
+	})
+
+	t.Run("matching final step", func(t *testing.T) {
+		step := &WorkflowStep{Name: "Done"}
+		if !IsTerminalStep(step, nil) {
+			t.Fatalf("final Done step was not terminal")
+		}
+	})
+
+	t.Run("matching non-final step", func(t *testing.T) {
+		step := &WorkflowStep{Name: "Done"}
+		nextStep := &WorkflowStep{Name: "Archive"}
+		if IsTerminalStep(step, nextStep) {
+			t.Fatalf("non-final Done step reported terminal")
+		}
+	})
+
+	t.Run("non-matching final step", func(t *testing.T) {
+		step := &WorkflowStep{Name: "Work"}
+		if IsTerminalStep(step, nil) {
+			t.Fatalf("final Work step reported terminal")
+		}
+	})
+}

--- a/docs/specs/tasks/subtask-completion-trigger.md
+++ b/docs/specs/tasks/subtask-completion-trigger.md
@@ -17,17 +17,21 @@ orchestration logic into the parent prompt instead of the workflow system.
 
 - A workflow step can define an `on_children_completed` event.
 - The event fires on a parent task's current workflow step when every direct,
-  active child task has reached a terminal task state.
+  active child task has reached terminal completion.
 - Terminal task states are `COMPLETED`, `FAILED`, and `CANCELLED`.
-- The event is driven by task state changes, including subtasks created through
-  `create_task_kandev` with `parent_id`.
+- A child also counts as terminal when it is in a final workflow step named
+  `Done`, `Complete`, `Completed`, or `Approved`; entering that step persists
+  `tasks.state = COMPLETED`.
+- The event is driven by task state changes and workflow-step moves into a
+  terminal step, including subtasks created through `create_task_kandev` with
+  `parent_id`.
 - The event runs the step actions configured on `on_children_completed`, such as
   queueing a parent-agent run or moving the parent to a verification step.
 - Workflow authors can configure the event from the workflow step editor with
   the "When Child Tasks Complete" transition selector. The editor explains that
   the trigger belongs on the parent step, waits for direct active children only,
-  treats `COMPLETED`, `FAILED`, and `CANCELLED` as terminal, and ignores
-  archived or ephemeral child tasks.
+  treats terminal task states and terminal workflow-step membership as terminal,
+  and ignores archived or ephemeral child tasks.
 - The event fires at most once for the same completed child set. If a child is
   reopened and later returns to a terminal state, the parent can receive a new
   event for the new completion cycle.
@@ -49,13 +53,18 @@ Children with `archived_at` set or `is_ephemeral = 1` are ignored by this
 feature, matching existing active-child listing semantics.
 
 The existing `tasks.state` field defines terminal child completion. The terminal
-set for this feature is:
+state set for this feature is:
 
 ```text
 COMPLETED
 FAILED
 CANCELLED
 ```
+
+`tasks.workflow_step_id` is also considered. A child task is complete when its
+current step is the final step in that workflow and the step name is `Done`,
+`Complete`, `Completed`, or `Approved`. This keeps visual board completion and
+API state consistent without adding a new persistent terminal-step flag.
 
 ### Workflow operation idempotency
 
@@ -125,9 +134,10 @@ does not block the trigger.
 
 ## State machine
 
-- A child enters a terminal state when its task state changes from a
-  non-terminal state to `COMPLETED`, `FAILED`, or `CANCELLED`.
-- On that transition, the system checks the child's parent.
+- A child enters terminal completion when its task state changes from a
+  non-terminal state to `COMPLETED`, `FAILED`, or `CANCELLED`, or when it moves
+  into a terminal workflow step.
+- On that transition or move, the system checks the child's parent.
 - If the child has no parent, no parent event is considered.
 - If any active direct child of the parent is still non-terminal, no parent event
   fires.
@@ -147,7 +157,8 @@ This feature adds no new permission boundary.
 - Agents and users can only create child tasks through existing task creation
   permissions and MCP tool exposure.
 - Agents cannot fire `on_children_completed` directly; they can only cause it by
-  changing task state through existing task completion paths.
+  changing task state or moving a child task through existing task completion
+  paths.
 - Workflow authors control the parent reaction by configuring
   `on_children_completed` actions on the parent step.
 
@@ -157,6 +168,7 @@ This feature adds no new permission boundary.
   is logged.
 - If sibling lookup fails, no parent trigger fires for that event and a warning
   is logged. A later child state transition can retry the check.
+- If terminal step lookup fails, the child is evaluated by task state only.
 - If the parent has no active or primary session, no new parent session is
   created. The skip is logged at debug/info level.
 - If the workflow engine rejects or fails a configured action, the error is
@@ -182,6 +194,11 @@ This feature adds no new permission boundary.
 - **GIVEN** a parent task has two direct children and the first child is
   `COMPLETED`, **WHEN** the second child changes from `IN_PROGRESS` to
   `COMPLETED`, **THEN** the parent receives one `on_children_completed` trigger.
+
+- **GIVEN** a child task still has `state = REVIEW`, **WHEN** it moves into a
+  final workflow step named `Done`, **THEN** the child persists
+  `state = COMPLETED` and the parent completion check treats that child as
+  terminal.
 
 - **GIVEN** a parent step configures `on_children_completed` with `move_to_next`,
   **WHEN** all direct children are terminal, **THEN** the parent moves to the


### PR DESCRIPTION
Task state writes through the config MCP could silently no-op, leaving board position and task state out of sync. State updates now persist, and moving work into a terminal workflow column marks it completed so parent completion automation sees the correct outcome.

## Important Changes

- `update_task_kandev` validates and persists `state` updates instead of dropping them.
- Final workflow columns named `Done`, `Complete`, `Completed`, or `Approved` now persist `COMPLETED`, emit state-change events, and trigger parent child-completion checks.
- Child-completion payloads and the task spec now treat terminal-step children as completed.

## Validation

- `pnpm install --frozen-lockfile`
- `git fetch origin main`
- `git rebase origin/main`
- `make fmt`
- `node apps/web/scripts/generate-release-notes.mjs`
- `node apps/web/scripts/generate-changelog.mjs`
- `make typecheck`
- `make test`
- `make lint`
- `git diff --check`

Closes #1631

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1639?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->