### PR TITLE
fix: repair GitHub repository scope filters

### DIFF
--- a/apps/backend/internal/github/workspace_settings_service.go
+++ b/apps/backend/internal/github/workspace_settings_service.go
@@ -244,8 +244,8 @@ func (s *Service) fetchScopedPRsAcrossQualifiers(
 	perPage int,
 	qualifiers []string,
 ) ([]*PR, int, error) {
-	return fetchScopedResultsAcrossQualifiers(filter, customQuery, page, perPage, qualifiers, prScopeKey, func(scopedFilter, scopedCustomQuery string, fetchPerPage int) ([]*PR, int, error) {
-		result, err := s.client.SearchPRsPaged(ctx, scopedFilter, scopedCustomQuery, 1, fetchPerPage)
+	return fetchScopedResultsAcrossQualifiers(settings, filter, customQuery, page, perPage, qualifiers, prScopeKey, func(scopedFilter, scopedCustomQuery string, providerPage, fetchPerPage int) ([]*PR, int, error) {
+		result, err := s.client.SearchPRsPaged(ctx, scopedFilter, scopedCustomQuery, providerPage, fetchPerPage)
 		if err != nil {
 			return nil, 0, err
 		}
@@ -265,8 +265,8 @@ func (s *Service) fetchScopedIssuesAcrossQualifiers(
 	perPage int,
 	qualifiers []string,
 ) ([]*Issue, int, error) {
-	return fetchScopedResultsAcrossQualifiers(filter, customQuery, page, perPage, qualifiers, issueScopeKey, func(scopedFilter, scopedCustomQuery string, fetchPerPage int) ([]*Issue, int, error) {
-		result, err := s.client.ListIssuesPaged(ctx, scopedFilter, scopedCustomQuery, 1, fetchPerPage)
+	return fetchScopedResultsAcrossQualifiers(settings, filter, customQuery, page, perPage, qualifiers, issueScopeKey, func(scopedFilter, scopedCustomQuery string, providerPage, fetchPerPage int) ([]*Issue, int, error) {
+		result, err := s.client.ListIssuesPaged(ctx, scopedFilter, scopedCustomQuery, providerPage, fetchPerPage)
 		if err != nil {
 			return nil, 0, err
 		}
@@ -278,38 +278,49 @@ func (s *Service) fetchScopedIssuesAcrossQualifiers(
 }
 
 func fetchScopedResultsAcrossQualifiers[T any](
+	settings *WorkspaceSettings,
 	filter string,
 	customQuery string,
 	page int,
 	perPage int,
 	qualifiers []string,
 	resultKey func(T) string,
-	fetch func(scopedFilter string, scopedCustomQuery string, fetchPerPage int) ([]T, int, error),
+	fetch func(scopedFilter string, scopedCustomQuery string, providerPage int, fetchPerPage int) ([]T, int, error),
 ) ([]T, int, error) {
 	seen := make(map[string]struct{})
 	all := make([]T, 0, perPage)
-	total := 0
 	fetchPerPage := workspaceScopeFanoutFetchPerPage(page, perPage)
+	pagesToFetch := workspaceScopeFanoutPagesToFetch(page, perPage, fetchPerPage)
+	counts := make([]int, 0, len(qualifiers))
 	for _, qualifier := range qualifiers {
 		scopedFilter, scopedCustomQuery := appendWorkspaceScopeQualifierToSearch(filter, customQuery, qualifier)
-		items, count, err := fetch(scopedFilter, scopedCustomQuery, fetchPerPage)
-		if err != nil {
-			return nil, 0, err
-		}
-		total += count
-		for _, item := range items {
-			key := resultKey(item)
-			if key == "" {
-				continue
+		qualifierCount := 0
+		for providerPage := 1; providerPage <= pagesToFetch; providerPage++ {
+			items, count, err := fetch(scopedFilter, scopedCustomQuery, providerPage, fetchPerPage)
+			if err != nil {
+				return nil, 0, err
 			}
-			if _, ok := seen[key]; ok {
-				continue
+			if providerPage == 1 {
+				qualifierCount = count
 			}
-			seen[key] = struct{}{}
-			all = append(all, item)
+			for _, item := range items {
+				key := resultKey(item)
+				if key == "" {
+					continue
+				}
+				if _, ok := seen[key]; ok {
+					continue
+				}
+				seen[key] = struct{}{}
+				all = append(all, item)
+			}
+			if workspaceScopeFanoutFetchedAll(providerPage, fetchPerPage, count, len(items)) {
+				break
+			}
 		}
+		counts = append(counts, qualifierCount)
 	}
-	return all, total, nil
+	return all, workspaceScopeFanoutTotal(settings, counts, len(all)), nil
 }
 
 func workspaceScopeFanoutFetchPerPage(page, perPage int) int {
@@ -321,6 +332,61 @@ func workspaceScopeFanoutFetchPerPage(page, perPage int) int {
 		return 100
 	}
 	return fetchPerPage
+}
+
+func workspaceScopeFanoutPagesToFetch(page, perPage, fetchPerPage int) int {
+	if fetchPerPage <= 0 {
+		return 1
+	}
+	target := page * perPage
+	if target < perPage {
+		target = perPage
+	}
+	pages := target / fetchPerPage
+	if target%fetchPerPage != 0 {
+		pages++
+	}
+	if pages < 1 {
+		return 1
+	}
+	return pages
+}
+
+func workspaceScopeFanoutFetchedAll(providerPage, fetchPerPage, totalCount, itemCount int) bool {
+	if itemCount == 0 {
+		return true
+	}
+	if itemCount < fetchPerPage {
+		return true
+	}
+	return totalCount > 0 && providerPage*fetchPerPage >= totalCount
+}
+
+func workspaceScopeFanoutTotal(settings *WorkspaceSettings, counts []int, uniqueFetched int) int {
+	settings = normalizeWorkspaceSettings(settings)
+	if settings == nil || settings.RepoScopeMode != RepoScopeModeOrgs {
+		return sumInts(counts)
+	}
+	total := 0
+	for i := 0; i < len(counts); i += 2 {
+		if i+1 >= len(counts) {
+			total += counts[i]
+			continue
+		}
+		total += max(counts[i], counts[i+1])
+	}
+	if uniqueFetched > total {
+		return uniqueFetched
+	}
+	return total
+}
+
+func sumInts(values []int) int {
+	total := 0
+	for _, value := range values {
+		total += value
+	}
+	return total
 }
 
 func paginateSearchResults[T any](items []T, page, perPage int) []T {
@@ -396,14 +462,6 @@ func isValidRepoScopeMode(mode string) bool {
 	default:
 		return false
 	}
-}
-
-func appendWorkspaceScopeQuery(customQuery string, settings *WorkspaceSettings) string {
-	qualifiers := workspaceScopeQualifiers(settings)
-	if len(qualifiers) == 0 {
-		return customQuery
-	}
-	return appendWorkspaceScopeQualifier(customQuery, qualifiers[0])
 }
 
 func appendWorkspaceScopeToSearch(filter, customQuery string, settings *WorkspaceSettings) (string, string) {

--- a/apps/backend/internal/github/workspace_settings_service.go
+++ b/apps/backend/internal/github/workspace_settings_service.go
@@ -90,6 +90,10 @@ func (s *Service) searchUserPRsPagedScoped(
 	if workspaceSettingsHasEmptyScope(settings) {
 		return &PRSearchPage{PRs: []*PR{}, TotalCount: 0, Page: page, PerPage: perPage}, nil
 	}
+	qualifiers := workspaceScopeQualifiers(settings)
+	if len(qualifiers) > 1 {
+		return s.searchUserPRsPagedScopedAcrossQualifiers(ctx, settings, filter, customQuery, page, perPage, qualifiers)
+	}
 	filter, customQuery = appendWorkspaceScopeToSearch(filter, customQuery, settings)
 	v, err := s.searchUserPagedScoped("pr", settings, filter, customQuery, page, perPage, func(page, perPage int) (any, error) {
 		result, err := s.client.SearchPRsPaged(ctx, filter, customQuery, page, perPage)
@@ -114,6 +118,10 @@ func (s *Service) searchUserIssuesPagedScoped(
 ) (*IssueSearchPage, error) {
 	if workspaceSettingsHasEmptyScope(settings) {
 		return &IssueSearchPage{Issues: []*Issue{}, TotalCount: 0, Page: page, PerPage: perPage}, nil
+	}
+	qualifiers := workspaceScopeQualifiers(settings)
+	if len(qualifiers) > 1 {
+		return s.searchUserIssuesPagedScopedAcrossQualifiers(ctx, settings, filter, customQuery, page, perPage, qualifiers)
 	}
 	filter, customQuery = appendWorkspaceScopeToSearch(filter, customQuery, settings)
 	v, err := s.searchUserPagedScoped("issue", settings, filter, customQuery, page, perPage, func(page, perPage int) (any, error) {
@@ -147,6 +155,201 @@ func (s *Service) searchUserPagedScoped(
 	return s.searchCache.doOrFetch(key, func() (any, error) {
 		return fetch(page, perPage)
 	})
+}
+
+func (s *Service) searchUserPRsPagedScopedAcrossQualifiers(
+	ctx context.Context,
+	settings *WorkspaceSettings,
+	filter string,
+	customQuery string,
+	page int,
+	perPage int,
+	qualifiers []string,
+) (*PRSearchPage, error) {
+	result, err := cachedScopedSearchAcrossQualifiers(s.client, s.searchCache, "pr", settings, filter, customQuery, page, perPage, func(page, perPage int) ([]*PR, int, error) {
+		return s.fetchScopedPRsAcrossQualifiers(ctx, settings, filter, customQuery, page, perPage, qualifiers)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &PRSearchPage{PRs: result.items, TotalCount: result.total, Page: result.page, PerPage: result.perPage}, nil
+}
+
+func (s *Service) searchUserIssuesPagedScopedAcrossQualifiers(
+	ctx context.Context,
+	settings *WorkspaceSettings,
+	filter string,
+	customQuery string,
+	page int,
+	perPage int,
+	qualifiers []string,
+) (*IssueSearchPage, error) {
+	result, err := cachedScopedSearchAcrossQualifiers(s.client, s.searchCache, "issue", settings, filter, customQuery, page, perPage, func(page, perPage int) ([]*Issue, int, error) {
+		return s.fetchScopedIssuesAcrossQualifiers(ctx, settings, filter, customQuery, page, perPage, qualifiers)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &IssueSearchPage{Issues: result.items, TotalCount: result.total, Page: result.page, PerPage: result.perPage}, nil
+}
+
+type scopedFanoutResult[T any] struct {
+	items   []T
+	total   int
+	page    int
+	perPage int
+}
+
+func cachedScopedSearchAcrossQualifiers[T any](
+	client Client,
+	cache *ttlCache,
+	kind string,
+	settings *WorkspaceSettings,
+	filter string,
+	customQuery string,
+	page int,
+	perPage int,
+	fetch func(page int, perPage int) ([]T, int, error),
+) (scopedFanoutResult[T], error) {
+	if client == nil {
+		return scopedFanoutResult[T]{}, fmt.Errorf("github client not available")
+	}
+	page, perPage = clampSearchPage(page, perPage)
+	scopeKey := workspaceSearchScopeKey(settings)
+	key := searchCacheKey(kind+":"+scopeKey+":fanout", filter, customQuery, page, perPage)
+	v, err := cache.doOrFetch(key, func() (any, error) {
+		items, total, err := fetch(page, perPage)
+		if err != nil {
+			return nil, err
+		}
+		return scopedFanoutResult[T]{
+			items:   paginateSearchResults(items, page, perPage),
+			total:   total,
+			page:    page,
+			perPage: perPage,
+		}, nil
+	})
+	if err != nil {
+		return scopedFanoutResult[T]{}, err
+	}
+	return v.(scopedFanoutResult[T]), nil
+}
+
+func (s *Service) fetchScopedPRsAcrossQualifiers(
+	ctx context.Context,
+	settings *WorkspaceSettings,
+	filter string,
+	customQuery string,
+	page int,
+	perPage int,
+	qualifiers []string,
+) ([]*PR, int, error) {
+	return fetchScopedResultsAcrossQualifiers(filter, customQuery, page, perPage, qualifiers, prScopeKey, func(scopedFilter, scopedCustomQuery string, fetchPerPage int) ([]*PR, int, error) {
+		result, err := s.client.SearchPRsPaged(ctx, scopedFilter, scopedCustomQuery, 1, fetchPerPage)
+		if err != nil {
+			return nil, 0, err
+		}
+		if result == nil {
+			return []*PR{}, 0, nil
+		}
+		return filterPRsByWorkspaceScope(result.PRs, settings), result.TotalCount, nil
+	})
+}
+
+func (s *Service) fetchScopedIssuesAcrossQualifiers(
+	ctx context.Context,
+	settings *WorkspaceSettings,
+	filter string,
+	customQuery string,
+	page int,
+	perPage int,
+	qualifiers []string,
+) ([]*Issue, int, error) {
+	return fetchScopedResultsAcrossQualifiers(filter, customQuery, page, perPage, qualifiers, issueScopeKey, func(scopedFilter, scopedCustomQuery string, fetchPerPage int) ([]*Issue, int, error) {
+		result, err := s.client.ListIssuesPaged(ctx, scopedFilter, scopedCustomQuery, 1, fetchPerPage)
+		if err != nil {
+			return nil, 0, err
+		}
+		if result == nil {
+			return []*Issue{}, 0, nil
+		}
+		return filterIssuesByWorkspaceScope(result.Issues, settings), result.TotalCount, nil
+	})
+}
+
+func fetchScopedResultsAcrossQualifiers[T any](
+	filter string,
+	customQuery string,
+	page int,
+	perPage int,
+	qualifiers []string,
+	resultKey func(T) string,
+	fetch func(scopedFilter string, scopedCustomQuery string, fetchPerPage int) ([]T, int, error),
+) ([]T, int, error) {
+	seen := make(map[string]struct{})
+	all := make([]T, 0, perPage)
+	total := 0
+	fetchPerPage := workspaceScopeFanoutFetchPerPage(page, perPage)
+	for _, qualifier := range qualifiers {
+		scopedFilter, scopedCustomQuery := appendWorkspaceScopeQualifierToSearch(filter, customQuery, qualifier)
+		items, count, err := fetch(scopedFilter, scopedCustomQuery, fetchPerPage)
+		if err != nil {
+			return nil, 0, err
+		}
+		total += count
+		for _, item := range items {
+			key := resultKey(item)
+			if key == "" {
+				continue
+			}
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			all = append(all, item)
+		}
+	}
+	return all, total, nil
+}
+
+func workspaceScopeFanoutFetchPerPage(page, perPage int) int {
+	fetchPerPage := page * perPage
+	if fetchPerPage < perPage {
+		return perPage
+	}
+	if fetchPerPage > 100 {
+		return 100
+	}
+	return fetchPerPage
+}
+
+func paginateSearchResults[T any](items []T, page, perPage int) []T {
+	if len(items) == 0 {
+		return []T{}
+	}
+	start := (page - 1) * perPage
+	if start >= len(items) {
+		return []T{}
+	}
+	end := start + perPage
+	if end > len(items) {
+		end = len(items)
+	}
+	return append([]T(nil), items[start:end]...)
+}
+
+func prScopeKey(pr *PR) string {
+	if pr == nil {
+		return ""
+	}
+	return strings.ToLower(strings.TrimSpace(fmt.Sprintf("%s/%s#%d", pr.RepoOwner, pr.RepoName, pr.Number)))
+}
+
+func issueScopeKey(issue *Issue) string {
+	if issue == nil {
+		return ""
+	}
+	return strings.ToLower(strings.TrimSpace(fmt.Sprintf("%s/%s#%d", issue.RepoOwner, issue.RepoName, issue.Number)))
 }
 
 func scopedPRSearchPage(result *PRSearchPage, settings *WorkspaceSettings, page int, perPage int) *PRSearchPage {
@@ -200,18 +403,26 @@ func appendWorkspaceScopeQuery(customQuery string, settings *WorkspaceSettings) 
 	if len(qualifiers) == 0 {
 		return customQuery
 	}
-	scope := qualifiers[0]
-	if len(qualifiers) > 1 {
-		scope = "(" + strings.Join(qualifiers, " OR ") + ")"
-	}
-	return strings.TrimSpace(strings.Join([]string{customQuery, scope}, " "))
+	return appendWorkspaceScopeQualifier(customQuery, qualifiers[0])
 }
 
 func appendWorkspaceScopeToSearch(filter, customQuery string, settings *WorkspaceSettings) (string, string) {
-	if strings.TrimSpace(customQuery) != "" {
-		return filter, appendWorkspaceScopeQuery(customQuery, settings)
+	qualifiers := workspaceScopeQualifiers(settings)
+	if len(qualifiers) == 0 {
+		return filter, customQuery
 	}
-	return appendWorkspaceScopeQuery(filter, settings), customQuery
+	return appendWorkspaceScopeQualifierToSearch(filter, customQuery, qualifiers[0])
+}
+
+func appendWorkspaceScopeQualifierToSearch(filter, customQuery, qualifier string) (string, string) {
+	if strings.TrimSpace(customQuery) != "" {
+		return filter, appendWorkspaceScopeQualifier(customQuery, qualifier)
+	}
+	return appendWorkspaceScopeQualifier(filter, qualifier), customQuery
+}
+
+func appendWorkspaceScopeQualifier(query, qualifier string) string {
+	return strings.TrimSpace(strings.Join([]string{query, qualifier}, " "))
 }
 
 func workspaceScopeQualifiers(settings *WorkspaceSettings) []string {

--- a/apps/backend/internal/github/workspace_settings_test.go
+++ b/apps/backend/internal/github/workspace_settings_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"testing"
 )
@@ -124,6 +125,17 @@ func assertSearchCalls(t *testing.T, calls []searchCall, baseQuery string, quali
 	}
 }
 
+func assertHasSearchCall(t *testing.T, calls []searchCall, qualifier string, page, perPage int) {
+	t.Helper()
+	for _, call := range calls {
+		query := strings.TrimSpace(call.filter + " " + call.customQuery)
+		if strings.Contains(query, qualifier) && call.page == page && call.perPage == perPage {
+			return
+		}
+	}
+	t.Fatalf("search calls = %+v, want %s page=%d perPage=%d", calls, qualifier, page, perPage)
+}
+
 func TestService_SearchUserPRsPagedForWorkspace_OrgScopeIncludesPersonalOwner(t *testing.T) {
 	client := &capturingSearchClient{MockClient: NewMockClient()}
 	client.AddPR(&PR{RepoOwner: "octo", RepoName: "personal", Number: 1, Title: "in scope"})
@@ -141,6 +153,78 @@ func TestService_SearchUserPRsPagedForWorkspace_OrgScopeIncludesPersonalOwner(t 
 
 	if _, err := svc.SearchUserPRsPagedForWorkspace(ctx, "ws-1", "", "is:open", 1, 25); err != nil {
 		t.Fatalf("search scoped prs: %v", err)
+	}
+	assertSearchCalls(t, client.calls, "is:open", []string{"org:octo", "user:octo"})
+}
+
+func TestService_SearchUserPRsPagedForWorkspace_FanoutFetchesDeeperProviderPages(t *testing.T) {
+	client := &capturingSearchClient{MockClient: NewMockClient()}
+	for i := 1; i <= 150; i++ {
+		client.AddPR(&PR{RepoOwner: "kdlbs", RepoName: "kandev", Number: i, Title: fmt.Sprintf("kandev-%d", i)})
+	}
+	for i := 1; i <= 10; i++ {
+		client.AddPR(&PR{RepoOwner: "example", RepoName: "api", Number: i, Title: fmt.Sprintf("api-%d", i)})
+	}
+	store := newTestStore(t)
+	svc := NewService(client, AuthMethodPAT, nil, store, nil, testLogger(t))
+	ctx := context.Background()
+
+	if err := svc.UpsertWorkspaceSettings(ctx, &WorkspaceSettings{
+		WorkspaceID:   "ws-1",
+		RepoScopeMode: RepoScopeModeRepos,
+		RepoScopeRepos: []RepoFilter{
+			{Owner: "kdlbs", Name: "kandev"},
+			{Owner: "example", Name: "api"},
+		},
+	}); err != nil {
+		t.Fatalf("save workspace settings: %v", err)
+	}
+
+	page, err := svc.SearchUserPRsPagedForWorkspace(ctx, "ws-1", "", "is:open", 5, 25)
+	if err != nil {
+		t.Fatalf("search scoped prs: %v", err)
+	}
+	if page.TotalCount != 160 {
+		t.Fatalf("total count = %d, want 160", page.TotalCount)
+	}
+	if len(page.PRs) != 25 {
+		t.Fatalf("page PR count = %d, want 25", len(page.PRs))
+	}
+	if page.PRs[0].RepoOwner != "kdlbs" || page.PRs[0].RepoName != "kandev" || page.PRs[0].Number != 101 {
+		t.Fatalf("first PR on page = %+v, want kdlbs/kandev#101", page.PRs[0])
+	}
+	if page.PRs[24].RepoOwner != "kdlbs" || page.PRs[24].RepoName != "kandev" || page.PRs[24].Number != 125 {
+		t.Fatalf("last PR on page = %+v, want kdlbs/kandev#125", page.PRs[24])
+	}
+	assertHasSearchCall(t, client.calls, "repo:kdlbs/kandev", 2, 100)
+}
+
+func TestService_SearchUserPRsPagedForWorkspace_OrgScopeDedupesFanoutTotal(t *testing.T) {
+	client := &capturingSearchClient{MockClient: NewMockClient()}
+	for i := 1; i <= 120; i++ {
+		client.AddPR(&PR{RepoOwner: "octo", RepoName: "repo", Number: i, Title: fmt.Sprintf("octo-%d", i)})
+	}
+	store := newTestStore(t)
+	svc := NewService(client, AuthMethodPAT, nil, store, nil, testLogger(t))
+	ctx := context.Background()
+
+	if err := svc.UpsertWorkspaceSettings(ctx, &WorkspaceSettings{
+		WorkspaceID:   "ws-1",
+		RepoScopeMode: RepoScopeModeOrgs,
+		RepoScopeOrgs: []string{"octo"},
+	}); err != nil {
+		t.Fatalf("save workspace settings: %v", err)
+	}
+
+	page, err := svc.SearchUserPRsPagedForWorkspace(ctx, "ws-1", "", "is:open", 1, 25)
+	if err != nil {
+		t.Fatalf("search scoped prs: %v", err)
+	}
+	if page.TotalCount != 120 {
+		t.Fatalf("total count = %d, want 120", page.TotalCount)
+	}
+	if len(page.PRs) != 25 {
+		t.Fatalf("page PR count = %d, want 25", len(page.PRs))
 	}
 	assertSearchCalls(t, client.calls, "is:open", []string{"org:octo", "user:octo"})
 }
@@ -536,6 +620,8 @@ type capturingSearchClient struct {
 type searchCall struct {
 	filter      string
 	customQuery string
+	page        int
+	perPage     int
 }
 
 type rejectingORIssueSearchClient struct {
@@ -547,7 +633,7 @@ type rejectingORIssueSearchClient struct {
 func (c *capturingSearchClient) SearchPRsPaged(ctx context.Context, filter, customQuery string, page, perPage int) (*PRSearchPage, error) {
 	c.filter = filter
 	c.customQuery = customQuery
-	c.calls = append(c.calls, searchCall{filter: filter, customQuery: customQuery})
+	c.calls = append(c.calls, searchCall{filter: filter, customQuery: customQuery, page: page, perPage: perPage})
 	result, err := c.MockClient.SearchPRsPaged(ctx, filter, customQuery, page, perPage)
 	if err != nil {
 		return nil, err
@@ -564,14 +650,14 @@ func (c *issueSearchClient) ListIssuesPaged(context.Context, string, string, int
 }
 
 func (c *rejectingORIssueSearchClient) ListIssuesPaged(_ context.Context, filter, customQuery string, page, perPage int) (*IssueSearchPage, error) {
-	c.calls = append(c.calls, searchCall{filter: filter, customQuery: customQuery})
+	c.calls = append(c.calls, searchCall{filter: filter, customQuery: customQuery, page: page, perPage: perPage})
 	query := strings.TrimSpace(filter + " " + customQuery)
 	if strings.Contains(query, " OR ") || strings.ContainsAny(query, "()") {
 		return nil, fmt.Errorf("github rejected invalid qualifier query %q", query)
 	}
 	for repo, issues := range c.issuesByRepo {
 		if strings.Contains(query, "repo:"+repo) {
-			return &IssueSearchPage{Issues: issues, TotalCount: len(issues), Page: page, PerPage: perPage}, nil
+			return &IssueSearchPage{Issues: paginateSearchResults(issues, page, perPage), TotalCount: len(issues), Page: page, PerPage: perPage}, nil
 		}
 	}
 	return &IssueSearchPage{Issues: []*Issue{}, TotalCount: 0, Page: page, PerPage: perPage}, nil
@@ -590,7 +676,15 @@ func filterPRSearchPageByQuery(page *PRSearchPage, query string, pageNum, perPag
 			prs = append(prs, pr)
 		}
 	}
-	return &PRSearchPage{PRs: prs, TotalCount: len(prs), Page: pageNum, PerPage: perPage}
+	sort.Slice(prs, func(i, j int) bool {
+		left := strings.ToLower(prs[i].RepoOwner + "/" + prs[i].RepoName)
+		right := strings.ToLower(prs[j].RepoOwner + "/" + prs[j].RepoName)
+		if left != right {
+			return left < right
+		}
+		return prs[i].Number < prs[j].Number
+	})
+	return &PRSearchPage{PRs: paginateSearchResults(prs, pageNum, perPage), TotalCount: len(prs), Page: pageNum, PerPage: perPage}
 }
 
 func prMatchesQueryQualifier(pr *PR, query string) bool {

--- a/apps/backend/internal/github/workspace_settings_test.go
+++ b/apps/backend/internal/github/workspace_settings_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -98,17 +99,28 @@ func TestService_SearchUserPRsPagedForWorkspace_AppendsScopeToQuery(t *testing.T
 	if page.TotalCount != 1 || len(page.PRs) != 1 {
 		t.Fatalf("expected one scoped PR, got total=%d prs=%+v", page.TotalCount, page.PRs)
 	}
-	if !strings.Contains(client.customQuery, "is:open") ||
-		!strings.Contains(client.customQuery, "(repo:kdlbs/kandev OR repo:kdlbs/docs)") {
-		t.Fatalf("custom query was not workspace scoped: %q", client.customQuery)
-	}
+	assertSearchCalls(t, client.calls, "is:open", []string{"repo:kdlbs/kandev", "repo:kdlbs/docs"})
+	client.calls = nil
 
 	if _, err := svc.SearchUserPRsPagedForWorkspace(ctx, "ws-1", "review-requested:@me", "", 1, 25); err != nil {
 		t.Fatalf("search scoped prs with preset filter: %v", err)
 	}
-	if !strings.Contains(client.filter, "review-requested:@me") ||
-		!strings.Contains(client.filter, "(repo:kdlbs/kandev OR repo:kdlbs/docs)") {
-		t.Fatalf("filter query was not workspace scoped: %q", client.filter)
+	assertSearchCalls(t, client.calls, "review-requested:@me", []string{"repo:kdlbs/kandev", "repo:kdlbs/docs"})
+}
+
+func assertSearchCalls(t *testing.T, calls []searchCall, baseQuery string, qualifiers []string) {
+	t.Helper()
+	if len(calls) != len(qualifiers) {
+		t.Fatalf("search calls = %+v, want %d calls", calls, len(qualifiers))
+	}
+	for i, qualifier := range qualifiers {
+		query := strings.TrimSpace(calls[i].filter + " " + calls[i].customQuery)
+		if !strings.Contains(query, baseQuery) || !strings.Contains(query, qualifier) {
+			t.Fatalf("search call %d query = %q, want %q and %q", i, query, baseQuery, qualifier)
+		}
+		if strings.Contains(query, " OR ") || strings.ContainsAny(query, "()") {
+			t.Fatalf("search call %d should not OR qualifiers: %q", i, query)
+		}
 	}
 }
 
@@ -130,9 +142,7 @@ func TestService_SearchUserPRsPagedForWorkspace_OrgScopeIncludesPersonalOwner(t 
 	if _, err := svc.SearchUserPRsPagedForWorkspace(ctx, "ws-1", "", "is:open", 1, 25); err != nil {
 		t.Fatalf("search scoped prs: %v", err)
 	}
-	if !strings.Contains(client.customQuery, "(org:octo OR user:octo)") {
-		t.Fatalf("org scope did not include personal-owner qualifier: %q", client.customQuery)
-	}
+	assertSearchCalls(t, client.calls, "is:open", []string{"org:octo", "user:octo"})
 }
 
 func TestService_SearchUserPRsPagedForWorkspace_EmptyRepoScopeFailsClosed(t *testing.T) {
@@ -293,6 +303,51 @@ func TestService_SearchUserIssuesPagedForWorkspace_AllScopePreservesResults(t *t
 	}
 	if page.TotalCount != 2 || len(page.Issues) != 2 {
 		t.Fatalf("all scope should preserve results, got total=%d issues=%+v", page.TotalCount, page.Issues)
+	}
+}
+
+func TestService_SearchUserIssuesPagedForWorkspace_FansOutSelectedRepos(t *testing.T) {
+	client := &rejectingORIssueSearchClient{
+		MockClient: NewMockClient(),
+		issuesByRepo: map[string][]*Issue{
+			"kdlbs/kandev": {
+				{RepoOwner: "kdlbs", RepoName: "kandev", Number: 1, Title: "one"},
+			},
+			"example/api": {
+				{RepoOwner: "example", RepoName: "api", Number: 2, Title: "two"},
+			},
+		},
+	}
+	store := newTestStore(t)
+	svc := NewService(client, AuthMethodPAT, nil, store, nil, testLogger(t))
+	ctx := context.Background()
+
+	if err := svc.UpsertWorkspaceSettings(ctx, &WorkspaceSettings{
+		WorkspaceID:   "ws-1",
+		RepoScopeMode: RepoScopeModeRepos,
+		RepoScopeRepos: []RepoFilter{
+			{Owner: "kdlbs", Name: "kandev"},
+			{Owner: "example", Name: "api"},
+		},
+	}); err != nil {
+		t.Fatalf("save workspace settings: %v", err)
+	}
+
+	page, err := svc.SearchUserIssuesPagedForWorkspace(ctx, "ws-1", "", "is:open", 1, 25)
+	if err != nil {
+		t.Fatalf("search scoped issues: %v", err)
+	}
+	if page.TotalCount != 2 || len(page.Issues) != 2 {
+		t.Fatalf("expected both selected repo issues, got total=%d issues=%+v", page.TotalCount, page.Issues)
+	}
+	if len(client.calls) != 2 {
+		t.Fatalf("expected one provider search per selected repo, got calls=%+v", client.calls)
+	}
+	for _, call := range client.calls {
+		query := strings.TrimSpace(call.filter + " " + call.customQuery)
+		if strings.Contains(query, " OR ") || strings.ContainsAny(query, "()") {
+			t.Fatalf("provider query should not OR repo qualifiers: %q", query)
+		}
 	}
 }
 
@@ -475,12 +530,29 @@ type capturingSearchClient struct {
 	*MockClient
 	filter      string
 	customQuery string
+	calls       []searchCall
+}
+
+type searchCall struct {
+	filter      string
+	customQuery string
+}
+
+type rejectingORIssueSearchClient struct {
+	*MockClient
+	issuesByRepo map[string][]*Issue
+	calls        []searchCall
 }
 
 func (c *capturingSearchClient) SearchPRsPaged(ctx context.Context, filter, customQuery string, page, perPage int) (*PRSearchPage, error) {
 	c.filter = filter
 	c.customQuery = customQuery
-	return c.MockClient.SearchPRsPaged(ctx, filter, customQuery, page, perPage)
+	c.calls = append(c.calls, searchCall{filter: filter, customQuery: customQuery})
+	result, err := c.MockClient.SearchPRsPaged(ctx, filter, customQuery, page, perPage)
+	if err != nil {
+		return nil, err
+	}
+	return filterPRSearchPageByQuery(result, strings.TrimSpace(filter+" "+customQuery), page, perPage), nil
 }
 
 func (c *issueSearchClient) ListIssues(context.Context, string, string) ([]*Issue, error) {
@@ -489,4 +561,46 @@ func (c *issueSearchClient) ListIssues(context.Context, string, string) ([]*Issu
 
 func (c *issueSearchClient) ListIssuesPaged(context.Context, string, string, int, int) (*IssueSearchPage, error) {
 	return &IssueSearchPage{Issues: c.issues, TotalCount: len(c.issues), Page: 1, PerPage: 25}, nil
+}
+
+func (c *rejectingORIssueSearchClient) ListIssuesPaged(_ context.Context, filter, customQuery string, page, perPage int) (*IssueSearchPage, error) {
+	c.calls = append(c.calls, searchCall{filter: filter, customQuery: customQuery})
+	query := strings.TrimSpace(filter + " " + customQuery)
+	if strings.Contains(query, " OR ") || strings.ContainsAny(query, "()") {
+		return nil, fmt.Errorf("github rejected invalid qualifier query %q", query)
+	}
+	for repo, issues := range c.issuesByRepo {
+		if strings.Contains(query, "repo:"+repo) {
+			return &IssueSearchPage{Issues: issues, TotalCount: len(issues), Page: page, PerPage: perPage}, nil
+		}
+	}
+	return &IssueSearchPage{Issues: []*Issue{}, TotalCount: 0, Page: page, PerPage: perPage}, nil
+}
+
+func filterPRSearchPageByQuery(page *PRSearchPage, query string, pageNum, perPage int) *PRSearchPage {
+	if page == nil {
+		return nil
+	}
+	if !strings.Contains(query, "repo:") && !strings.Contains(query, "org:") && !strings.Contains(query, "user:") {
+		return page
+	}
+	prs := make([]*PR, 0, len(page.PRs))
+	for _, pr := range page.PRs {
+		if prMatchesQueryQualifier(pr, query) {
+			prs = append(prs, pr)
+		}
+	}
+	return &PRSearchPage{PRs: prs, TotalCount: len(prs), Page: pageNum, PerPage: perPage}
+}
+
+func prMatchesQueryQualifier(pr *PR, query string) bool {
+	if pr == nil {
+		return false
+	}
+	owner := strings.ToLower(strings.TrimSpace(pr.RepoOwner))
+	name := strings.ToLower(strings.TrimSpace(pr.RepoName))
+	query = strings.ToLower(query)
+	return strings.Contains(query, fmt.Sprintf("repo:%s/%s", owner, name)) ||
+		strings.Contains(query, "org:"+owner) ||
+		strings.Contains(query, "user:"+owner)
 }

--- a/apps/web/components/github/github-repo-scope-section.tsx
+++ b/apps/web/components/github/github-repo-scope-section.tsx
@@ -11,7 +11,11 @@ import {
   fetchGitHubWorkspaceSettings,
   updateGitHubWorkspaceSettings,
 } from "@/lib/api/domains/github-api";
-import type { GitHubRepoScopeMode, RepoFilter } from "@/lib/types/github";
+import type {
+  GitHubRepoScopeMode,
+  RepoFilter,
+  UpdateGitHubWorkspaceSettingsRequest,
+} from "@/lib/types/github";
 
 function splitCSV(value: string): string[] {
   return value
@@ -124,8 +128,8 @@ export function GitHubRepoScopeSection({ workspaceId }: { workspaceId: string })
   const parsedRepos = useMemo(() => parseRepoFilters(repos), [repos]);
   const invalidRepos = useMemo(() => {
     const entries = splitCSV(repos);
-    return entries.length > 0 && parsedRepos.length !== entries.length;
-  }, [parsedRepos.length, repos]);
+    return mode === "repos" && entries.length > 0 && parsedRepos.length !== entries.length;
+  }, [mode, parsedRepos.length, repos]);
 
   useEffect(() => {
     let cancelled = false;
@@ -156,12 +160,17 @@ export function GitHubRepoScopeSection({ workspaceId }: { workspaceId: string })
     }
     setSaving(true);
     try {
-      const updated = await updateGitHubWorkspaceSettings({
+      const payload: UpdateGitHubWorkspaceSettingsRequest = {
         workspace_id: workspaceId,
         repo_scope_mode: mode,
-        repo_scope_orgs: splitCSV(orgs),
-        repo_scope_repos: parsedRepos,
-      });
+      };
+      if (mode === "orgs") {
+        payload.repo_scope_orgs = splitCSV(orgs);
+      }
+      if (mode === "repos") {
+        payload.repo_scope_repos = parsedRepos;
+      }
+      const updated = await updateGitHubWorkspaceSettings(payload);
       setMode(updated.repo_scope_mode);
       setOrgs((updated.repo_scope_orgs ?? []).join(", "));
       setRepos(repoFiltersToInput(updated.repo_scope_repos ?? []));

--- a/apps/web/e2e/tests/integrations/github-workspace-settings.spec.ts
+++ b/apps/web/e2e/tests/integrations/github-workspace-settings.spec.ts
@@ -67,4 +67,67 @@ test.describe("GitHub workspace settings", () => {
     await expect(testPage.getByText("Out of scope PR")).toHaveCount(0);
     await expect(testPage.getByText("other/repo#6102")).toHaveCount(0);
   });
+
+  test("repository scope save only submits fields for the active mode", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    test.setTimeout(90_000);
+
+    await apiClient.mockGitHubReset();
+    await apiClient.mockGitHubSetUser("test-user");
+
+    await testPage.goto("/settings/integrations/github");
+    await expect(testPage.getByTestId("integration-workspace-switcher")).toBeVisible();
+
+    await testPage.getByTestId("github-scope-mode").click();
+    await testPage.getByRole("option", { name: "Selected repositories" }).click();
+    await testPage.getByTestId("github-scope-repos-input").fill("kdlbs/kandev");
+    await testPage.getByTestId("github-scope-mode").click();
+    await testPage.getByRole("option", { name: "Organizations" }).click();
+    await testPage.getByTestId("github-scope-orgs-input").fill("kdlbs");
+    await testPage.getByTestId("github-scope-save").click();
+    await expect(testPage.getByText("GitHub workspace settings saved")).toBeVisible({
+      timeout: 10_000,
+    });
+
+    const firstSettingsResponse = await apiClient.rawRequest(
+      "GET",
+      `/api/v1/github/workspace-settings?workspace_id=${seedData.workspaceId}`,
+    );
+    expect(firstSettingsResponse.status).toBe(200);
+    const firstSettings = (await firstSettingsResponse.json()) as {
+      repo_scope_mode: string;
+      repo_scope_orgs: string[];
+      repo_scope_repos: Array<{ owner: string; name: string }>;
+    };
+    expect(firstSettings.repo_scope_mode).toBe("orgs");
+    expect(firstSettings.repo_scope_orgs).toEqual(["kdlbs"]);
+    expect(firstSettings.repo_scope_repos).toEqual([]);
+
+    await testPage.getByTestId("github-scope-mode").click();
+    await testPage.getByRole("option", { name: "Selected repositories" }).click();
+    await testPage.getByTestId("github-scope-repos-input").fill("not-a-repo");
+    await testPage.getByTestId("github-scope-mode").click();
+    await testPage.getByRole("option", { name: "Organizations" }).click();
+    await testPage.getByTestId("github-scope-save").click();
+    await expect(testPage.getByText("GitHub workspace settings saved")).toBeVisible({
+      timeout: 10_000,
+    });
+
+    const secondSettingsResponse = await apiClient.rawRequest(
+      "GET",
+      `/api/v1/github/workspace-settings?workspace_id=${seedData.workspaceId}`,
+    );
+    expect(secondSettingsResponse.status).toBe(200);
+    const secondSettings = (await secondSettingsResponse.json()) as {
+      repo_scope_mode: string;
+      repo_scope_orgs: string[];
+      repo_scope_repos: Array<{ owner: string; name: string }>;
+    };
+    expect(secondSettings.repo_scope_mode).toBe("orgs");
+    expect(secondSettings.repo_scope_orgs).toEqual(["kdlbs"]);
+    expect(secondSettings.repo_scope_repos).toEqual([]);
+  });
 });


### PR DESCRIPTION
GitHub repository scopes broke when users selected multiple repositories because GitHub search rejects OR-combined qualifier queries. This fixes scoped searches by using valid per-qualifier requests and prevents stale inactive scope fields from blocking settings saves.

## Important Changes

- Fan out workspace-scoped GitHub PR/issue searches across individual scope qualifiers so multi-repo and org scopes use valid GitHub search syntax.
- Scope Repository Scope validation and update payloads to the active mode so inactive form values cannot block or leak into saves.

## Validation

- `make fmt`
- `make typecheck`
- `make test`
- `make lint`
- `cd apps/web && pnpm e2e:run tests/integrations/github-workspace-settings.spec.ts`

Closes #1635

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1641?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->