### PR TITLE
fix: show implement button whenever plan mode is active

### DIFF
--- a/apps/web/components/task/passthrough-chat-composer.tsx
+++ b/apps/web/components/task/passthrough-chat-composer.tsx
@@ -38,6 +38,7 @@ export function PassthroughComposerPanel({
   taskId,
   isMoving,
   isSending,
+  onImplementPlan,
 }: {
   refHandle: RefObject<ChatInputContainerHandle | null>;
   onSubmit: PassthroughSubmitHandler;
@@ -46,6 +47,7 @@ export function PassthroughComposerPanel({
   taskId: string | null;
   isMoving: boolean;
   isSending: boolean;
+  onImplementPlan?: (fresh: boolean) => void;
 }) {
   const hasContextComments =
     panelState.planComments.length > 0 ||
@@ -85,6 +87,7 @@ export function PassthroughComposerPanel({
         contextFiles={panelState.contextFiles}
         onToggleContextFile={panelState.handleToggleContextFile}
         onAddContextFile={panelState.handleAddContextFile}
+        onImplementPlan={onImplementPlan}
         hideSessionsDropdown
         hideAgentControls
       />

--- a/apps/web/components/task/passthrough-toolbar.test.tsx
+++ b/apps/web/components/task/passthrough-toolbar.test.tsx
@@ -29,6 +29,8 @@ let mockSessionState: string | null = null;
 let mockKeyboardShortcuts: Record<string, { key: string; modifiers?: Record<string, boolean> }> =
   {};
 let mockPendingByFile: Record<string, import("@/lib/state/slices/comments").DiffComment[]> = {};
+let mockPlanModeEnabled = false;
+let mockImplementPlanHandler: ((fresh: boolean) => void) | undefined;
 let mockNextStep: {
   proceedStepName: string | null;
   proceed: ReturnType<typeof vi.fn>;
@@ -74,7 +76,7 @@ vi.mock("@/components/toast-provider", () => ({
 vi.mock("@/hooks/domains/kanban/use-plan-actions", () => ({
   usePlanActions: () => ({
     ...mockNextStep,
-    implementPlanHandler: undefined,
+    implementPlanHandler: mockImplementPlanHandler,
   }),
 }));
 
@@ -136,7 +138,7 @@ vi.mock("./chat/use-chat-panel-state", () => ({
     taskId: TASK_ID,
     task: { id: TASK_ID, title: "Task title" },
     taskDescription: "Task description",
-    planModeEnabled: false,
+    planModeEnabled: mockPlanModeEnabled,
     planModeAvailable: true,
     mcpServers: ["kandev"],
     handlePlanModeChange: vi.fn(),
@@ -245,6 +247,8 @@ function resetMocks() {
   mockSessionState = null;
   mockKeyboardShortcuts = {};
   mockPendingByFile = {};
+  mockPlanModeEnabled = false;
+  mockImplementPlanHandler = undefined;
   mockNextStep = { proceedStepName: null, proceed: vi.fn(), isMoving: false };
   mockWsRequestFn = vi.fn().mockResolvedValue(undefined);
   chatInputMock.renderProps.mockClear();
@@ -408,6 +412,50 @@ describe("PassthroughToolbar – composer toggle", () => {
     } finally {
       xterm.remove();
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Implement plan handler
+// ---------------------------------------------------------------------------
+
+describe("PassthroughToolbar – implement plan handler", () => {
+  beforeEach(resetMocks);
+  afterEach(cleanup);
+
+  it("forwards the implement handler to the composer while plan mode is active", async () => {
+    const implementHandler = vi.fn();
+    mockPlanModeEnabled = true;
+    mockImplementPlanHandler = implementHandler;
+
+    renderToolbar();
+    await openComposer();
+
+    expect(latestChatInputProps().planModeEnabled).toBe(true);
+    expect(latestChatInputProps().onImplementPlan).toBe(implementHandler);
+  });
+
+  it("does not forward an implement handler when plan mode is disabled", async () => {
+    mockPlanModeEnabled = false;
+    mockImplementPlanHandler = vi.fn();
+
+    renderToolbar();
+    await openComposer();
+
+    expect(latestChatInputProps().planModeEnabled).toBe(false);
+    expect(latestChatInputProps().onImplementPlan).toBeUndefined();
+  });
+
+  it("does not forward an implement handler while the passthrough session is busy", async () => {
+    mockPlanModeEnabled = true;
+    mockImplementPlanHandler = vi.fn();
+    mockSessionState = "RUNNING";
+
+    renderToolbar();
+    await openComposer();
+
+    expect(latestChatInputProps().planModeEnabled).toBe(true);
+    expect(latestChatInputProps().onImplementPlan).toBeUndefined();
   });
 });
 

--- a/apps/web/components/task/passthrough-toolbar.test.tsx
+++ b/apps/web/components/task/passthrough-toolbar.test.tsx
@@ -72,7 +72,10 @@ vi.mock("@/components/toast-provider", () => ({
 }));
 
 vi.mock("@/hooks/domains/kanban/use-plan-actions", () => ({
-  useNextWorkflowStep: () => mockNextStep,
+  usePlanActions: () => ({
+    ...mockNextStep,
+    implementPlanHandler: undefined,
+  }),
 }));
 
 vi.mock("@/hooks/domains/comments/use-diff-comments", () => ({

--- a/apps/web/components/task/passthrough-toolbar.tsx
+++ b/apps/web/components/task/passthrough-toolbar.tsx
@@ -113,6 +113,8 @@ export function PassthroughToolbar({
     chatInputRef,
   });
   const showProceed = !!planActions.proceedStepName && !isAgentBusy;
+  const implementPlanHandler =
+    isAgentBusy || !panelState.planModeEnabled ? undefined : planActions.implementPlanHandler;
 
   // Derive open state: auto-close when pending comments are cleared
   const commentsOpen = commentsOpenState && pendingCount > 0;
@@ -170,7 +172,7 @@ export function PassthroughToolbar({
           taskId={taskId}
           isMoving={planActions.isMoving}
           isSending={isSending}
-          onImplementPlan={planActions.implementPlanHandler}
+          onImplementPlan={implementPlanHandler}
         />
       )}
 

--- a/apps/web/components/task/passthrough-toolbar.tsx
+++ b/apps/web/components/task/passthrough-toolbar.tsx
@@ -25,7 +25,7 @@ import { PRMergedBanner } from "./chat/pr-archive-banners";
 import { type ChatInputContainerHandle } from "./chat/chat-input-container";
 import { useChatPanelState } from "./chat/use-chat-panel-state";
 import { useAppStore } from "@/components/state-provider";
-import { useNextWorkflowStep } from "@/hooks/domains/kanban/use-plan-actions";
+import { usePlanActions } from "@/hooks/domains/kanban/use-plan-actions";
 import { useKeyboardShortcut } from "@/hooks/use-keyboard-shortcut";
 import { usePendingDiffCommentsByFile } from "@/hooks/domains/comments/use-diff-comments";
 import { useCommentsStore } from "@/lib/state/slices/comments/comments-store";
@@ -101,13 +101,18 @@ export function PassthroughToolbar({
   const focusShortcut = getShortcut("FOCUS_PASSTHROUGH_INPUT", keyboardShortcuts);
   const isAgentBusy = sessionState === "RUNNING" || sessionState === "STARTING";
 
-  const nextStep = useNextWorkflowStep(taskId);
-  const showProceed = !!nextStep.proceedStepName && !isAgentBusy;
-
   const { pendingComments, pendingCount } = usePendingPassthroughComments(sessionId);
   const { isMobile } = useResponsiveBreakpoint();
   const { openFile } = useFileEditors();
   const panelState = useChatPanelState({ sessionId: sessionId ?? null, onOpenFile: openFile });
+  const planActions = usePlanActions({
+    resolvedSessionId: panelState.resolvedSessionId,
+    taskId,
+    planModeEnabled: panelState.planModeEnabled,
+    handlePlanModeChange: panelState.handlePlanModeChange,
+    chatInputRef,
+  });
+  const showProceed = !!planActions.proceedStepName && !isAgentBusy;
 
   // Derive open state: auto-close when pending comments are cleared
   const commentsOpen = commentsOpenState && pendingCount > 0;
@@ -163,16 +168,17 @@ export function PassthroughToolbar({
           onCancel={() => setComposerOpen(false)}
           panelState={panelState}
           taskId={taskId}
-          isMoving={nextStep.isMoving}
+          isMoving={planActions.isMoving}
           isSending={isSending}
+          onImplementPlan={planActions.implementPlanHandler}
         />
       )}
 
       <PassthroughStatusRow
         taskId={taskId}
-        nextStepName={nextStep.proceedStepName}
-        onProceed={nextStep.proceed}
-        isMoving={nextStep.isMoving}
+        nextStepName={planActions.proceedStepName}
+        onProceed={planActions.proceed}
+        isMoving={planActions.isMoving}
         showProceed={showProceed}
         composerOpen={composerOpen}
         focusShortcut={focusShortcut}

--- a/apps/web/hooks/domains/kanban/use-plan-actions.test.ts
+++ b/apps/web/hooks/domains/kanban/use-plan-actions.test.ts
@@ -1,16 +1,78 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { act, renderHook } from "@testing-library/react";
 import type { ContextFile } from "@/lib/state/context-files-store";
 
 const mockGetState = vi.fn();
+const mockMoveTask = vi.hoisted(() => vi.fn());
+const mockAppState = vi.hoisted(() => ({
+  value: {
+    kanban: { workflowId: "workflow-1", steps: [], tasks: [] },
+    tasks: { activeSessionId: "session-1" },
+    taskSessions: { items: {} },
+    setActiveSession: vi.fn(),
+    setPlanMode: vi.fn(),
+    setActiveDocument: vi.fn(),
+    setTaskPlan: vi.fn(),
+  } as Record<string, unknown>,
+}));
+const mockContextFilesStore = vi.hoisted(() => ({
+  value: {
+    removeFile: vi.fn(),
+  },
+}));
 
 vi.mock("@/lib/state/context-files-store", () => ({
-  useContextFilesStore: { getState: () => mockGetState() },
+  useContextFilesStore: Object.assign(
+    (selector: (state: typeof mockContextFilesStore.value) => unknown) =>
+      selector(mockContextFilesStore.value),
+    { getState: () => mockGetState() },
+  ),
+}));
+
+vi.mock("@/components/state-provider", () => ({
+  useAppStore: (selector: (state: typeof mockAppState.value) => unknown) =>
+    selector(mockAppState.value),
+}));
+
+vi.mock("@/components/toast-provider", () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+vi.mock("@/lib/ws/connection", () => ({
+  getWebSocketClient: () => ({ request: vi.fn() }),
+}));
+
+vi.mock("@/lib/local-storage", () => ({
+  setChatDraftContent: vi.fn(),
+}));
+
+vi.mock("@/lib/api/domains/kanban-api", () => ({
+  moveTask: mockMoveTask,
+}));
+
+vi.mock("@/lib/api/domains/plan-api", () => ({
+  markPlanImplementationStarted: vi.fn(),
+}));
+
+vi.mock("@/lib/state/layout-store", () => ({
+  useLayoutStore: (selector: (state: { closeDocument: () => void }) => unknown) =>
+    selector({ closeDocument: vi.fn() }),
+}));
+
+vi.mock("@/lib/state/dockview-store", () => ({
+  useDockviewStore: (selector: (state: { applyBuiltInPreset: () => void }) => unknown) =>
+    selector({ applyBuiltInPreset: vi.fn() }),
+}));
+
+vi.mock("./use-implement-fresh", () => ({
+  useImplementFresh: () => vi.fn(),
 }));
 
 import {
   buildImplementPlanContent,
   collectImplementPlanInput,
   readContextFilesMeta,
+  usePlanActions,
 } from "./use-plan-actions";
 
 describe("buildImplementPlanContent", () => {
@@ -90,5 +152,113 @@ describe("collectImplementPlanInput", () => {
       attachments: [],
       contextFilesMeta: [],
     });
+  });
+});
+
+describe("usePlanActions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockMoveTask.mockResolvedValue(undefined);
+    mockAppState.value = {
+      ...mockAppState.value,
+      kanban: {
+        workflowId: "workflow-1",
+        steps: [
+          {
+            id: "plan-step",
+            title: "Plan",
+            position: 1,
+            events: { on_enter: [{ type: "enable_plan_mode" }] },
+          },
+          {
+            id: "work-step",
+            title: "Work",
+            position: 2,
+            events: { on_enter: [{ type: "auto_start_agent" }] },
+          },
+        ],
+        tasks: [{ id: "task-1", workflowStepId: "plan-step" }],
+      },
+    };
+  });
+
+  it("keeps the implement handler available in plan mode before an auto-start work step", () => {
+    const chatInputRef = {
+      current: {
+        getValue: () => "",
+        getAttachments: () => [],
+        clear: vi.fn(),
+      },
+    };
+
+    const { result } = renderHook(() =>
+      usePlanActions({
+        resolvedSessionId: "session-1",
+        taskId: "task-1",
+        planModeEnabled: true,
+        handlePlanModeChange: vi.fn(),
+        chatInputRef: chatInputRef as never,
+      }),
+    );
+
+    expect(result.current.implementPlanHandler).toEqual(expect.any(Function));
+  });
+
+  it("routes implement through the next auto-start work step", async () => {
+    const { result } = renderHook(() =>
+      usePlanActions({
+        resolvedSessionId: "session-1",
+        taskId: "task-1",
+        planModeEnabled: true,
+        handlePlanModeChange: vi.fn(),
+        chatInputRef: { current: null },
+      }),
+    );
+
+    await act(async () => {
+      await result.current.implementPlanHandler?.(false);
+    });
+
+    expect(mockMoveTask).toHaveBeenCalledWith("task-1", {
+      workflow_id: "workflow-1",
+      workflow_step_id: "work-step",
+      position: 0,
+    });
+    expect(mockAppState.value.setPlanMode).toHaveBeenCalledWith("session-1", false);
+  });
+
+  it("keeps plan mode enabled when moving to the work step fails", async () => {
+    mockMoveTask.mockRejectedValueOnce(new Error("move failed"));
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const { result } = renderHook(() =>
+      usePlanActions({
+        resolvedSessionId: "session-1",
+        taskId: "task-1",
+        planModeEnabled: true,
+        handlePlanModeChange: vi.fn(),
+        chatInputRef: { current: null },
+      }),
+    );
+
+    await act(async () => {
+      await result.current.implementPlanHandler?.(false);
+    });
+
+    expect(mockMoveTask).toHaveBeenCalledTimes(1);
+    expect(mockAppState.value.setPlanMode).not.toHaveBeenCalled();
+  });
+
+  it("does not expose the implement handler outside plan mode", () => {
+    const { result } = renderHook(() =>
+      usePlanActions({
+        resolvedSessionId: "session-1",
+        taskId: "task-1",
+        planModeEnabled: false,
+        handlePlanModeChange: vi.fn(),
+        chatInputRef: { current: null },
+      }),
+    );
+
+    expect(result.current.implementPlanHandler).toBeUndefined();
   });
 });

--- a/apps/web/hooks/domains/kanban/use-plan-actions.ts
+++ b/apps/web/hooks/domains/kanban/use-plan-actions.ts
@@ -64,7 +64,7 @@ export function useNextWorkflowStep(taskId: string | null) {
   }, [nextStep]);
 
   const proceed = useCallback(async () => {
-    if (!taskId || !workflowId || !nextStep) return;
+    if (!taskId || !workflowId || !nextStep) return false;
     const capturedSessionId = activeSessionId;
     setMoveFromSessionId(capturedSessionId);
     try {
@@ -79,10 +79,12 @@ export function useNextWorkflowStep(taskId: string | null) {
       setTimeout(() => {
         setMoveFromSessionId((prev) => (prev === capturedSessionId ? null : prev));
       }, 10_000);
+      return true;
     } catch (err) {
       console.error("Failed to proceed to next step:", err);
       toast({ description: "Failed to proceed to next step", variant: "error" });
       setMoveFromSessionId(null);
+      return false;
     }
   }, [taskId, workflowId, nextStep, activeSessionId, toast]);
 
@@ -266,17 +268,22 @@ export function usePlanActions(opts: {
 
   const disablePlanMode = useDirectDisablePlanMode(opts.resolvedSessionId);
   const { planModeEnabled } = opts;
-  // Disable plan mode before proceeding so the layout switches back to default
-  // and the next step's auto-start prompt is visible in chat.
-  const proceed = useCallback(() => {
-    if (planModeEnabled) {
+  // Disable plan mode only after a successful move. A failed workflow move
+  // should leave the plan layout and context intact for retry.
+  const proceed = useCallback(async () => {
+    const moved = await rawProceed();
+    if (moved && planModeEnabled) {
       disablePlanMode();
     }
-    rawProceed();
   }, [planModeEnabled, disablePlanMode, rawProceed]);
 
-  const showImplement = opts.planModeEnabled && !nextStepIsWorkStep;
-  const implementPlanHandler = showImplement ? implementPlan : undefined;
+  const showImplement = opts.planModeEnabled;
+  const implementPlanHandler = showImplement
+    ? (fresh: boolean) => {
+        if (nextStepIsWorkStep) return proceed();
+        return implementPlan(fresh);
+      }
+    : undefined;
   return { implementPlanHandler, proceedStepName, proceed, isMoving };
 }
 


### PR DESCRIPTION
Plan-mode chat inputs could hide the Implement action based on workflow topology, which made the same user mode behave inconsistently across tasks. The button now follows the user-visible state: plan mode on exposes implementation, plan mode off hides it.

## Validation

- `pnpm install --frozen-lockfile` from `apps/`
- `pnpm exec vitest run hooks/domains/kanban/use-plan-actions.test.ts`
- `pnpm exec vitest run components/task/passthrough-chat-composer.test.ts`
- `pnpm exec vitest run components/task/passthrough-toolbar.test.tsx`
- `pnpm exec vitest run hooks/domains/kanban/use-plan-actions.test.ts components/task/passthrough-toolbar.test.tsx`
- `pnpm run typecheck` from `apps/web`
- `make fmt`
- `node apps/web/scripts/generate-release-notes.mjs`
- `node apps/web/scripts/generate-changelog.mjs`
- `make typecheck`
- `make test`
- `make lint`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1646?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->