### PR TITLE
fix: isolate saved layouts from stale sessions

### DIFF
--- a/apps/web/components/task/dockview-desktop-layout.tsx
+++ b/apps/web/components/task/dockview-desktop-layout.tsx
@@ -56,6 +56,7 @@ import type { Terminal } from "@/hooks/domains/session/use-terminals";
 // Portal system
 import { PanelPortalHost, usePortalSlot } from "@/lib/layout/panel-portal-host";
 import { ENV_SCOPED_DOCKVIEW_COMPONENTS } from "@/lib/state/dockview-env-scoped-components";
+import { normalizeReusableSessionPanels, type LayoutState } from "@/lib/state/layout-manager";
 
 // ---------------------------------------------------------------------------
 // PORTAL SLOT — generic dockview component that adopts a persistent portal
@@ -153,16 +154,16 @@ function useSyncUserDefaultLayout() {
   const setUserDefaultLayout = useDockviewStore((s) => s.setUserDefaultLayout);
   useEffect(() => {
     const defaultLayout = savedLayouts.find((l) => l.is_default);
-    const state = defaultLayout?.layout as unknown as
-      | import("@/lib/state/layout-manager").LayoutState
-      | undefined;
+    const state = defaultLayout?.layout as unknown as LayoutState | undefined;
     // Drop the obsolete "sidebar" column: the dockview-embedded sidebar pane was
     // retired for the unified AppSidebar, but a default layout saved before that
     // change still carries it. The default-build path applies this layout
     // without the restore-time sanitize layer, so an orphaned sidebar column
     // (its panel component is no longer registered) renders a broken grid.
     const columns = state?.columns?.filter((c) => c.id !== "sidebar");
-    setUserDefaultLayout(columns && columns.length > 0 ? { ...state, columns } : null);
+    setUserDefaultLayout(
+      columns && columns.length > 0 ? normalizeReusableSessionPanels({ ...state, columns }) : null,
+    );
   }, [savedLayouts, setUserDefaultLayout]);
 }
 

--- a/apps/web/components/task/dockview-desktop-layout.tsx
+++ b/apps/web/components/task/dockview-desktop-layout.tsx
@@ -196,6 +196,12 @@ function useEnvSwitchCleanup(
 ) {
   const prevEnvRef = useRef<string | null | undefined>(undefined);
   const prevTaskRef = useRef<string | null | undefined>(undefined);
+  const currentSessionIdsKey = useAppStore((state) => {
+    if (!activeTaskId) return "";
+    return (state.taskSessionsByTask.itemsByTaskId[activeTaskId] ?? [])
+      .map((session) => session.id)
+      .join(",");
+  });
   useEffect(() => {
     const newEnvId = effectiveEnvId;
     const newTaskId = activeTaskId;
@@ -235,9 +241,13 @@ function useEnvSwitchCleanup(
     // through the sidebar/dropdown switch helpers. Same-env switches return
     // early above (no-op).
     if (newEnvId) {
-      performLayoutSwitch(oldEnvId, newEnvId, effectiveSessionId);
+      const currentSessionIds = currentSessionIdsKey ? currentSessionIdsKey.split(",") : [];
+      if (effectiveSessionId && !currentSessionIds.includes(effectiveSessionId)) {
+        currentSessionIds.unshift(effectiveSessionId);
+      }
+      performLayoutSwitch(oldEnvId, newEnvId, effectiveSessionId, currentSessionIds);
     }
-  }, [effectiveEnvId, effectiveSessionId, activeTaskId]);
+  }, [effectiveEnvId, effectiveSessionId, activeTaskId, currentSessionIdsKey]);
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/web/components/task/dockview-header-actions.tsx
+++ b/apps/web/components/task/dockview-header-actions.tsx
@@ -26,6 +26,7 @@ import { createUserShell } from "@/lib/api/domains/user-shell-api";
 import { useRepositoryScripts } from "@/hooks/domains/workspace/use-repository-scripts";
 import { replaceTaskUrl } from "@/lib/links";
 import type { Task, ProcessInfo } from "@/lib/types/http";
+import { sessionId as toSessionId } from "@/lib/types/ids";
 import type { ProcessStatusEntry } from "@/lib/state/slices";
 import { AddPanelMenuItems, MENU_ITEM_CLASS } from "./dockview-add-panel-items";
 import { useUserShells } from "@/hooks/domains/session/use-user-shells";
@@ -328,9 +329,15 @@ function SidebarRightActions() {
       const oldEnvId = oldSessionId ? (state.environmentIdBySessionId[oldSessionId] ?? null) : null;
       setActiveTask(task.id);
       if (meta?.taskSessionId) {
-        setActiveSession(task.id, meta.taskSessionId);
-        const newEnvId = appStore.getState().environmentIdBySessionId[meta.taskSessionId] ?? null;
-        if (newEnvId) performLayoutSwitch(oldEnvId, newEnvId, meta.taskSessionId);
+        const taskSessionId = toSessionId(meta.taskSessionId);
+        setActiveSession(task.id, taskSessionId);
+        const nextState = appStore.getState();
+        const newEnvId = nextState.environmentIdBySessionId[taskSessionId] ?? null;
+        const sessionIds = (nextState.taskSessionsByTask.itemsByTaskId[task.id] ?? []).map(
+          (session) => session.id,
+        );
+        if (!sessionIds.includes(taskSessionId)) sessionIds.unshift(taskSessionId);
+        if (newEnvId) performLayoutSwitch(oldEnvId, newEnvId, taskSessionId, sessionIds);
       }
       replaceTaskUrl(task.id);
     },

--- a/apps/web/components/task/layout-preset-selector-session-ids.test.ts
+++ b/apps/web/components/task/layout-preset-selector-session-ids.test.ts
@@ -37,4 +37,19 @@ describe("resolveLayoutApplySessionIds", () => {
     expect(loadSessions).not.toHaveBeenCalled();
     expect(result).toEqual([ACTIVE_SESSION_ID, SIBLING_SESSION_ID]);
   });
+
+  it("does not duplicate the active session when it is already loaded", async () => {
+    const loadSessions = vi.fn();
+
+    const result = await resolveLayoutApplySessionIds({
+      activeTaskId: "task-1",
+      activeSessionId: ACTIVE_SESSION_ID,
+      sessionsLoaded: true,
+      loadSessions,
+      getSessionsForTask: () => [{ id: ACTIVE_SESSION_ID }, { id: SIBLING_SESSION_ID }],
+    });
+
+    expect(loadSessions).not.toHaveBeenCalled();
+    expect(result).toEqual([ACTIVE_SESSION_ID, SIBLING_SESSION_ID]);
+  });
 });

--- a/apps/web/components/task/layout-preset-selector-session-ids.test.ts
+++ b/apps/web/components/task/layout-preset-selector-session-ids.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from "vitest";
+import { resolveLayoutApplySessionIds } from "./layout-preset-selector-session-ids";
+
+const ACTIVE_SESSION_ID = "active-session";
+const SIBLING_SESSION_ID = "sibling-session";
+
+describe("resolveLayoutApplySessionIds", () => {
+  it("loads task sessions before reading ids when the cache is not loaded", async () => {
+    let sessions = [{ id: ACTIVE_SESSION_ID }];
+    const loadSessions = vi.fn(async () => {
+      sessions = [{ id: ACTIVE_SESSION_ID }, { id: SIBLING_SESSION_ID }];
+    });
+
+    const result = await resolveLayoutApplySessionIds({
+      activeTaskId: "task-1",
+      activeSessionId: ACTIVE_SESSION_ID,
+      sessionsLoaded: false,
+      loadSessions,
+      getSessionsForTask: () => sessions,
+    });
+
+    expect(loadSessions).toHaveBeenCalledWith(true);
+    expect(result).toEqual([ACTIVE_SESSION_ID, SIBLING_SESSION_ID]);
+  });
+
+  it("keeps the active session when it is not in the loaded task-session list", async () => {
+    const loadSessions = vi.fn();
+
+    const result = await resolveLayoutApplySessionIds({
+      activeTaskId: "task-1",
+      activeSessionId: ACTIVE_SESSION_ID,
+      sessionsLoaded: true,
+      loadSessions,
+      getSessionsForTask: () => [{ id: SIBLING_SESSION_ID }],
+    });
+
+    expect(loadSessions).not.toHaveBeenCalled();
+    expect(result).toEqual([ACTIVE_SESSION_ID, SIBLING_SESSION_ID]);
+  });
+});

--- a/apps/web/components/task/layout-preset-selector-session-ids.ts
+++ b/apps/web/components/task/layout-preset-selector-session-ids.ts
@@ -1,0 +1,20 @@
+type LayoutSession = { id: string };
+
+export async function resolveLayoutApplySessionIds(args: {
+  activeTaskId: string | null;
+  activeSessionId: string | null;
+  sessionsLoaded: boolean;
+  loadSessions: (force?: boolean) => Promise<unknown> | unknown;
+  getSessionsForTask: (taskId: string) => readonly LayoutSession[];
+}): Promise<string[]> {
+  const { activeTaskId, activeSessionId, sessionsLoaded, loadSessions, getSessionsForTask } = args;
+  if (activeTaskId && !sessionsLoaded) await loadSessions(true);
+
+  const sessionIds = activeTaskId
+    ? getSessionsForTask(activeTaskId).map((session) => session.id)
+    : [];
+  if (activeSessionId && !sessionIds.includes(activeSessionId)) {
+    sessionIds.unshift(activeSessionId);
+  }
+  return sessionIds;
+}

--- a/apps/web/components/task/layout-preset-selector.tsx
+++ b/apps/web/components/task/layout-preset-selector.tsx
@@ -35,9 +35,11 @@ import {
 import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
 import { Badge } from "@kandev/ui/badge";
 import { useDockviewStore, type BuiltInPreset } from "@/lib/state/dockview-store";
-import { useAppStore } from "@/components/state-provider";
+import { useAppStore, useAppStoreApi } from "@/components/state-provider";
 import { updateUserSettings } from "@/lib/api/domains/settings-api";
 import type { SavedLayout } from "@/lib/types/http";
+import { useTaskSessions } from "@/hooks/use-task-sessions";
+import { resolveLayoutApplySessionIds } from "./layout-preset-selector-session-ids";
 
 type PresetOption = {
   id: BuiltInPreset;
@@ -172,7 +174,7 @@ function SavedLayoutItems({
   onDelete,
 }: {
   layouts: SavedLayout[];
-  onApply: (layout: SavedLayout) => void;
+  onApply: (layout: SavedLayout) => void | Promise<void>;
   onDelete: (layoutId: string) => void;
 }) {
   if (layouts.length === 0) {
@@ -182,7 +184,9 @@ function SavedLayoutItems({
     <DropdownMenuItem
       key={layout.id}
       className="cursor-pointer group/layout"
-      onClick={() => onApply(layout)}
+      onClick={() => {
+        void onApply(layout);
+      }}
     >
       <IconCheck className="h-3.5 w-3.5 mr-2 shrink-0 opacity-0" />
       <span className="text-xs truncate flex-1">{layout.name}</span>
@@ -228,26 +232,23 @@ function BuiltInPresetItems({ onApply }: { onApply: (presetId: BuiltInPreset) =>
   });
 }
 
-export function LayoutPresetSelector() {
-  const [saveDialogOpen, setSaveDialogOpen] = useState(false);
-  const [dropdownOpen, setDropdownOpen] = useState(false);
-  const [tooltipOpen, setTooltipOpen] = useState(false);
-  const recentlyClosedRef = useRef(false);
-  const applyBuiltInPreset = useDockviewStore((s) => s.applyBuiltInPreset);
+function useApplySavedLayout() {
   const applyCustomLayout = useDockviewStore((s) => s.applyCustomLayout);
-  const savedLayouts = useAppStore((s) => s.userSettings.savedLayouts);
+  const activeTaskId = useAppStore((s) => s.tasks.activeTaskId);
   const activeSessionId = useAppStore((s) => s.tasks.activeSessionId);
-  const activeTaskSessionIds = useAppStore((s) => {
-    const activeTaskId = s.tasks.activeTaskId;
-    if (!activeTaskId) return "";
-    return (s.taskSessionsByTask.itemsByTaskId[activeTaskId] ?? [])
-      .map((session) => session.id)
-      .join(",");
-  });
+  const appStore = useAppStoreApi();
+  const { isLoaded: taskSessionsLoaded, loadSessions } = useTaskSessions(activeTaskId);
 
-  const handleApplyCustom = useCallback(
-    (layout: SavedLayout) => {
-      const sessionIds = activeTaskSessionIds ? activeTaskSessionIds.split(",") : [];
+  return useCallback(
+    async (layout: SavedLayout) => {
+      const sessionIds = await resolveLayoutApplySessionIds({
+        activeTaskId,
+        activeSessionId,
+        sessionsLoaded: taskSessionsLoaded,
+        loadSessions,
+        getSessionsForTask: (taskId) =>
+          appStore.getState().taskSessionsByTask.itemsByTaskId[taskId] ?? [],
+      });
       applyCustomLayout(
         {
           id: layout.id,
@@ -259,8 +260,18 @@ export function LayoutPresetSelector() {
         { activeSessionId, sessionIds },
       );
     },
-    [activeSessionId, activeTaskSessionIds, applyCustomLayout],
+    [activeSessionId, activeTaskId, appStore, applyCustomLayout, loadSessions, taskSessionsLoaded],
   );
+}
+
+export function LayoutPresetSelector() {
+  const [saveDialogOpen, setSaveDialogOpen] = useState(false);
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+  const [tooltipOpen, setTooltipOpen] = useState(false);
+  const recentlyClosedRef = useRef(false);
+  const applyBuiltInPreset = useDockviewStore((s) => s.applyBuiltInPreset);
+  const savedLayouts = useAppStore((s) => s.userSettings.savedLayouts);
+  const handleApplyCustom = useApplySavedLayout();
 
   const handleDeleteLayout = useCallback(
     async (layoutId: string) => {

--- a/apps/web/components/task/layout-preset-selector.tsx
+++ b/apps/web/components/task/layout-preset-selector.tsx
@@ -236,17 +236,21 @@ export function LayoutPresetSelector() {
   const applyBuiltInPreset = useDockviewStore((s) => s.applyBuiltInPreset);
   const applyCustomLayout = useDockviewStore((s) => s.applyCustomLayout);
   const savedLayouts = useAppStore((s) => s.userSettings.savedLayouts);
+  const activeSessionId = useAppStore((s) => s.tasks.activeSessionId);
 
   const handleApplyCustom = useCallback(
     (layout: SavedLayout) =>
-      applyCustomLayout({
-        id: layout.id,
-        name: layout.name,
-        isDefault: layout.is_default,
-        layout: layout.layout,
-        createdAt: layout.created_at,
-      }),
-    [applyCustomLayout],
+      applyCustomLayout(
+        {
+          id: layout.id,
+          name: layout.name,
+          isDefault: layout.is_default,
+          layout: layout.layout,
+          createdAt: layout.created_at,
+        },
+        { activeSessionId },
+      ),
+    [activeSessionId, applyCustomLayout],
   );
 
   const handleDeleteLayout = useCallback(

--- a/apps/web/components/task/layout-preset-selector.tsx
+++ b/apps/web/components/task/layout-preset-selector.tsx
@@ -237,9 +237,17 @@ export function LayoutPresetSelector() {
   const applyCustomLayout = useDockviewStore((s) => s.applyCustomLayout);
   const savedLayouts = useAppStore((s) => s.userSettings.savedLayouts);
   const activeSessionId = useAppStore((s) => s.tasks.activeSessionId);
+  const activeTaskSessionIds = useAppStore((s) => {
+    const activeTaskId = s.tasks.activeTaskId;
+    if (!activeTaskId) return "";
+    return (s.taskSessionsByTask.itemsByTaskId[activeTaskId] ?? [])
+      .map((session) => session.id)
+      .join(",");
+  });
 
   const handleApplyCustom = useCallback(
-    (layout: SavedLayout) =>
+    (layout: SavedLayout) => {
+      const sessionIds = activeTaskSessionIds ? activeTaskSessionIds.split(",") : [];
       applyCustomLayout(
         {
           id: layout.id,
@@ -248,9 +256,10 @@ export function LayoutPresetSelector() {
           layout: layout.layout,
           createdAt: layout.created_at,
         },
-        { activeSessionId },
-      ),
-    [activeSessionId, applyCustomLayout],
+        { activeSessionId, sessionIds },
+      );
+    },
+    [activeSessionId, activeTaskSessionIds, applyCustomLayout],
   );
 
   const handleDeleteLayout = useCallback(

--- a/apps/web/components/task/sessions-dropdown.tsx
+++ b/apps/web/components/task/sessions-dropdown.tsx
@@ -106,8 +106,11 @@ function useSessionSelectionHandlers(taskId: string | null) {
       const oldSessionId = state.tasks.activeSessionId;
       const oldEnvId = oldSessionId ? (state.environmentIdBySessionId[oldSessionId] ?? null) : null;
       const newEnvId = state.environmentIdBySessionId[sessionId] ?? null;
+      const sessionIds = (state.taskSessionsByTask.itemsByTaskId[taskId] ?? []).map(
+        (session) => session.id,
+      );
       setActiveSession(taskId, sessionId);
-      if (newEnvId) performLayoutSwitch(oldEnvId, newEnvId, sessionId);
+      if (newEnvId) performLayoutSwitch(oldEnvId, newEnvId, sessionId, sessionIds);
       close();
     },
     [appStore, setActiveSession, taskId],

--- a/apps/web/components/task/task-select-helpers.test.ts
+++ b/apps/web/components/task/task-select-helpers.test.ts
@@ -46,9 +46,23 @@ function makeStore(activeSessionId: string | null): StoreApi<AppState> {
   } as unknown as StoreApi<AppState>;
 }
 
-function makeEnvStore(envIds: Record<string, string>): StoreApi<AppState> {
+function makeEnvStore(
+  envIds: Record<string, string>,
+  taskSessionsByTask: Record<string, string[]> = {},
+): StoreApi<AppState> {
   return {
-    getState: () => ({ environmentIdBySessionId: envIds }) as unknown as AppState,
+    getState: () =>
+      ({
+        environmentIdBySessionId: envIds,
+        taskSessionsByTask: {
+          itemsByTaskId: Object.fromEntries(
+            Object.entries(taskSessionsByTask).map(([taskId, sessionIds]) => [
+              taskId,
+              sessionIds.map((id) => ({ id })),
+            ]),
+          ),
+        },
+      }) as unknown as AppState,
   } as unknown as StoreApi<AppState>;
 }
 
@@ -251,14 +265,20 @@ describe("buildSwitchToSession", () => {
   });
 
   it("performs an env switch when the new session's environment is known", () => {
-    const store = makeEnvStore({ "sess-old": "env-A", "sess-new": "env-B" });
+    const store = makeEnvStore(
+      { "sess-old": "env-A", "sess-new": "env-B" },
+      { "task-new": ["sess-new", "sess-sibling"] },
+    );
     const setActiveSession = vi.fn();
     const switchToSession = buildSwitchToSession(store, setActiveSession);
 
     switchToSession("task-new", "sess-new", "sess-old");
 
     expect(setActiveSession).toHaveBeenCalledWith("task-new", "sess-new");
-    expect(performLayoutSwitch).toHaveBeenCalledWith("env-A", "env-B", "sess-new");
+    expect(performLayoutSwitch).toHaveBeenCalledWith("env-A", "env-B", "sess-new", [
+      "sess-new",
+      "sess-sibling",
+    ]);
     expect(releaseLayoutToDefault).not.toHaveBeenCalled();
   });
 

--- a/apps/web/components/task/task-select-helpers.ts
+++ b/apps/web/components/task/task-select-helpers.ts
@@ -27,6 +27,10 @@ export type SwitchToSessionFn = (
   oldSessionId: string | null | undefined,
 ) => void;
 
+function getTaskSessionIds(state: AppState, taskId: string): string[] {
+  return (state.taskSessionsByTask?.itemsByTaskId?.[taskId] ?? []).map((session) => session.id);
+}
+
 export function resolveLoadedSessionId(
   sessions: TaskSession[],
   preferredSessionId: string,
@@ -92,7 +96,7 @@ export function buildSwitchToSession(
     }
     setActiveSession(taskId, sessionId);
     if (newEnvId) {
-      performLayoutSwitch(oldEnvId, newEnvId, sessionId);
+      performLayoutSwitch(oldEnvId, newEnvId, sessionId, getTaskSessionIds(state, taskId));
       return;
     }
     // The new session's task_environment_id has not been loaded into the store

--- a/apps/web/e2e/helpers/api-client.ts
+++ b/apps/web/e2e/helpers/api-client.ts
@@ -660,6 +660,7 @@ export class ApiClient {
     default_utility_agent_id?: string;
     default_utility_model?: string;
     sidebar_views?: unknown[];
+    saved_layouts?: unknown[];
     kanban_view_mode?: string;
     tasks_list_sort?: string;
     tasks_list_group?: string;

--- a/apps/web/e2e/tests/layout/saved-layout-session-isolation.spec.ts
+++ b/apps/web/e2e/tests/layout/saved-layout-session-isolation.spec.ts
@@ -1,0 +1,126 @@
+import { expect, type Page } from "@playwright/test";
+import { test, type SeedData } from "../../fixtures/test-base";
+import type { ApiClient } from "../../helpers/api-client";
+
+const DONE_STATES = ["COMPLETED", "WAITING_FOR_INPUT"];
+
+async function createFinishedTaskWithSession(
+  apiClient: ApiClient,
+  seedData: SeedData,
+  title: string,
+  description: string,
+) {
+  const task = await apiClient.createTaskWithAgent(
+    seedData.workspaceId,
+    title,
+    seedData.agentProfileId,
+    {
+      description,
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+      repository_ids: [seedData.repositoryId],
+    },
+  );
+  if (!task.session_id) throw new Error(`${title} did not return a session_id`);
+
+  await expect
+    .poll(
+      async () => {
+        const { sessions } = await apiClient.listTaskSessions(task.id);
+        return DONE_STATES.includes(sessions[0]?.state ?? "");
+      },
+      { timeout: 30_000, message: `Waiting for ${title} session to finish` },
+    )
+    .toBe(true);
+
+  return { task, sessionId: task.session_id };
+}
+
+function simpleLayoutForSession(sessionId: string) {
+  return {
+    columns: [
+      {
+        id: "center",
+        groups: [
+          {
+            id: "group-center",
+            panels: [
+              {
+                id: `session:${sessionId}`,
+                component: "chat",
+                title: "Agent",
+                tabComponent: "sessionTab",
+                params: { sessionId },
+              },
+            ],
+            activePanel: `session:${sessionId}`,
+          },
+        ],
+      },
+    ],
+  };
+}
+
+async function dockviewPanelIds(page: Page) {
+  return page.evaluate(() => {
+    type DockviewWindow = Window & {
+      __dockviewApi__?: { panels: Array<{ id: string }> };
+    };
+    return ((window as DockviewWindow).__dockviewApi__?.panels ?? []).map((p) => p.id);
+  });
+}
+
+test.describe("saved Dockview layouts", () => {
+  test("applying a saved chat-only layout keeps the current task session", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    const taskA = await createFinishedTaskWithSession(
+      apiClient,
+      seedData,
+      "Saved Layout Source Task",
+      '/e2e:message("source task only")',
+    );
+    const taskB = await createFinishedTaskWithSession(
+      apiClient,
+      seedData,
+      "Saved Layout Target Task",
+      '/e2e:message("target task current")',
+    );
+
+    await apiClient.saveUserSettings({
+      workspace_id: seedData.workspaceId,
+      workflow_filter_id: seedData.workflowId,
+      saved_layouts: [
+        {
+          id: "layout-simple-stale-session",
+          name: "Simple",
+          is_default: false,
+          layout: simpleLayoutForSession(taskA.sessionId),
+          created_at: new Date().toISOString(),
+        },
+      ],
+    });
+
+    await testPage.goto(`/t/${taskB.task.id}`);
+    await expect(testPage.getByTestId("dockview-task-layout")).toBeVisible({ timeout: 15_000 });
+    await expect(testPage.getByText("target task current")).toBeVisible({ timeout: 30_000 });
+
+    await testPage.getByTestId("layout-preset-trigger").click();
+    await testPage.getByRole("menuitem", { name: /Simple/ }).click();
+
+    await expect
+      .poll(() => dockviewPanelIds(testPage), {
+        timeout: 10_000,
+        message: "Waiting for saved layout to settle on current session",
+      })
+      .toContain(`session:${taskB.sessionId}`);
+
+    const panelIds = await dockviewPanelIds(testPage);
+    expect(panelIds).not.toContain(`session:${taskA.sessionId}`);
+    await expect(testPage).toHaveURL((url) => url.pathname.includes(taskB.task.id));
+    await expect(testPage.getByText("target task current")).toBeVisible();
+    await expect(testPage.getByText("source task only")).not.toBeVisible();
+  });
+});

--- a/apps/web/e2e/tests/layout/saved-layout-session-isolation.spec.ts
+++ b/apps/web/e2e/tests/layout/saved-layout-session-isolation.spec.ts
@@ -29,7 +29,7 @@ async function createFinishedTaskWithSession(
         const { sessions } = await apiClient.listTaskSessions(task.id);
         return DONE_STATES.includes(sessions[0]?.state ?? "");
       },
-      { timeout: 30_000, message: `Waiting for ${title} session to finish` },
+      { timeout: 45_000, message: `Waiting for ${title} session to finish` },
     )
     .toBe(true);
 
@@ -71,7 +71,7 @@ async function dockviewPanelIds(page: Page) {
 }
 
 test.describe("saved Dockview layouts", () => {
-  test("applying a saved chat-only layout keeps the current task session", async ({
+  test("saved chat-only layouts keep the current task session", async ({
     testPage,
     apiClient,
     seedData,
@@ -94,6 +94,13 @@ test.describe("saved Dockview layouts", () => {
       workflow_filter_id: seedData.workflowId,
       saved_layouts: [
         {
+          id: "layout-default-stale-session",
+          name: "Default Chat",
+          is_default: true,
+          layout: simpleLayoutForSession(taskA.sessionId),
+          created_at: new Date().toISOString(),
+        },
+        {
           id: "layout-simple-stale-session",
           name: "Simple",
           is_default: false,
@@ -106,6 +113,14 @@ test.describe("saved Dockview layouts", () => {
     await testPage.goto(`/t/${taskB.task.id}`);
     await expect(testPage.getByTestId("dockview-task-layout")).toBeVisible({ timeout: 15_000 });
     await expect(testPage.getByText("target task current")).toBeVisible({ timeout: 30_000 });
+
+    await expect
+      .poll(() => dockviewPanelIds(testPage), {
+        timeout: 10_000,
+        message: "Waiting for default layout to settle on current session",
+      })
+      .toContain(`session:${taskB.sessionId}`);
+    expect(await dockviewPanelIds(testPage)).not.toContain(`session:${taskA.sessionId}`);
 
     await testPage.getByTestId("layout-preset-trigger").click();
     await testPage.getByRole("menuitem", { name: /Simple/ }).click();

--- a/apps/web/hooks/use-task-removal.ts
+++ b/apps/web/hooks/use-task-removal.ts
@@ -123,8 +123,12 @@ function switchToSessionForTask(params: {
   const { store, nextTask, sessionId, oldEnvId, useLayoutSwitch } = params;
   store.getState().setActiveSession(nextTask.id, sessionId);
   if (!useLayoutSwitch) return;
-  const newEnvId = store.getState().environmentIdBySessionId[sessionId] ?? null;
-  if (newEnvId) performLayoutSwitch(oldEnvId, newEnvId, sessionId);
+  const state = store.getState();
+  const newEnvId = state.environmentIdBySessionId[sessionId] ?? null;
+  const sessionIds = (state.taskSessionsByTask.itemsByTaskId[nextTask.id] ?? []).map(
+    (session) => session.id,
+  );
+  if (newEnvId) performLayoutSwitch(oldEnvId, newEnvId, sessionId, sessionIds);
 }
 
 async function switchToNextTask(params: {

--- a/apps/web/lib/state/dockview-env-switch-action.test.ts
+++ b/apps/web/lib/state/dockview-env-switch-action.test.ts
@@ -40,6 +40,90 @@ function makeMockApi(): DockviewApi {
   } as unknown as DockviewApi;
 }
 
+function testNormalizesStaleSessionPanelsOnSavedMaximize(): void {
+  const savedMaximizedJson = {
+    grid: {
+      root: {
+        type: "branch",
+        size: 600,
+        data: [{ type: "leaf", size: 600, data: { id: "g-center", views: ["chat"] } }],
+      },
+      height: 600,
+      width: 800,
+      orientation: "HORIZONTAL",
+    },
+    panels: {
+      chat: { id: "chat", contentComponent: "chat" },
+    },
+    activeGroup: "g-center",
+  };
+  vi.mocked(getEnvMaximizeState).mockImplementation((envId) =>
+    envId === "env-a"
+      ? { preMaximizeLayout: { columns: [] }, maximizedDockviewJson: savedMaximizedJson }
+      : null,
+  );
+
+  type TestPanel = {
+    id: string;
+    api: { component: string; close: () => void };
+    group: { id: string; panels: TestPanel[] };
+  };
+
+  const group = { id: "g-center", panels: [] as TestPanel[] };
+  const panels: TestPanel[] = [];
+  const removePanel = (id: string) => {
+    const panelIndex = panels.findIndex((p) => p.id === id);
+    if (panelIndex >= 0) panels.splice(panelIndex, 1);
+    const groupIndex = group.panels.findIndex((p) => p.id === id);
+    if (groupIndex >= 0) group.panels.splice(groupIndex, 1);
+  };
+  const closeStale = vi.fn(() => removePanel("session:stale"));
+  const stalePanel: TestPanel = {
+    id: "session:stale",
+    api: { component: "chat", close: closeStale },
+    group,
+  };
+  panels.push(stalePanel);
+  group.panels.push(stalePanel);
+
+  const api = {
+    ...makeMockApi(),
+    panels,
+    groups: [group],
+    getPanel: vi.fn((id: string) => panels.find((p) => p.id === id) ?? null),
+    addPanel: vi.fn((opts: { id: string; component: string }) => {
+      const panel: TestPanel = {
+        id: opts.id,
+        api: { component: opts.component, close: () => removePanel(opts.id) },
+        group,
+      };
+      panels.push(panel);
+      group.panels.push(panel);
+    }),
+  } as unknown as DockviewApi;
+
+  useDockviewStore.setState({ api, currentLayoutEnvId: "env-b" });
+  useDockviewStore
+    .getState()
+    .switchEnvLayout("env-b", "env-a", "session-a", ["session-a", "session-sibling"]);
+
+  expect(api.addPanel).toHaveBeenCalledWith(
+    expect.objectContaining({
+      id: "session:session-a",
+      position: { referenceGroup: group.id, index: 0 },
+    }),
+  );
+  expect(api.addPanel).toHaveBeenCalledWith(
+    expect.objectContaining({
+      id: "session:session-sibling",
+      params: { sessionId: "session-sibling" },
+      position: { referenceGroup: group.id, index: 1 },
+      inactive: true,
+    }),
+  );
+  expect(closeStale).toHaveBeenCalledOnce();
+}
+
 describe("switchEnvLayout — root fix for terminal/layout swapping", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -189,5 +273,9 @@ describe("switchEnvLayout — maximize+sidebar-switch regression", () => {
     const state = useDockviewStore.getState();
     expect(state.preMaximizeLayout).not.toBeNull();
     expect(state.maximizedGroupId).toBeTruthy();
+  });
+
+  it("normalizes stale session panels when restoring a saved maximize layout", () => {
+    testNormalizesStaleSessionPanelsOnSavedMaximize();
   });
 });

--- a/apps/web/lib/state/dockview-env-switch.test.ts
+++ b/apps/web/lib/state/dockview-env-switch.test.ts
@@ -33,7 +33,12 @@ vi.mock("./layout-manager", () => ({
 import { getEnvLayout } from "@/lib/local-storage";
 import { layoutStructuresMatch, savedLayoutMatchesLive } from "./layout-manager";
 
-const NEW_SESSION_PANEL_ID = "session:new-session";
+const NEW_SESSION_ID = "new-session";
+const OLD_SESSION_PANEL_ID = "session:old-session";
+const SIBLING_SESSION_ID = "sibling-session";
+const NEW_SESSION_PANEL_ID = `session:${NEW_SESSION_ID}`;
+const SIBLING_SESSION_PANEL_ID = `session:${SIBLING_SESSION_ID}`;
+const CENTER_GROUP_ID = "center-group";
 
 function makeMockApi() {
   return {
@@ -71,7 +76,7 @@ function makeParams(overrides?: Partial<EnvSwitchParams>): EnvSwitchParams {
     api: makeMockApi(),
     oldEnvId: "old-env",
     newEnvId: "new-env",
-    activeSessionId: "new-session",
+    activeSessionId: NEW_SESSION_ID,
     safeWidth: 800,
     safeHeight: 600,
     buildDefault: vi.fn(),
@@ -186,11 +191,11 @@ describe("performEnvSwitch", () => {
     vi.mocked(layoutStructuresMatch).mockReturnValueOnce(true);
     const groupPanels = [
       { id: "files", api: { component: "files" } },
-      { id: "session:old-session", api: { component: "chat" } },
+      { id: OLD_SESSION_PANEL_ID, api: { component: "chat" } },
       { id: "changes", api: { component: "changes" } },
       { id: "terminal-default", api: { component: "terminal" } },
     ];
-    const groupId = "center-group";
+    const groupId = CENTER_GROUP_ID;
     const outgoing = {
       ...groupPanels[1],
       group: { id: groupId, panels: groupPanels },
@@ -231,10 +236,10 @@ describe("performEnvSwitch fast-path group survival", () => {
     vi.mocked(layoutStructuresMatch).mockReturnValueOnce(true);
     const order: string[] = [];
     const closeOutgoing = vi.fn(() => order.push("close"));
-    const groupId = "center-group";
+    const groupId = CENTER_GROUP_ID;
     const outgoingPanels = [
       {
-        id: "session:old-session",
+        id: OLD_SESSION_PANEL_ID,
         api: { component: "chat", isActive: true, close: closeOutgoing },
       },
     ];
@@ -257,6 +262,73 @@ describe("performEnvSwitch fast-path group survival", () => {
       }),
     );
     expect(order).toEqual(["add", "close"]);
+  });
+
+  it("restores sibling session tabs when the fast path replaces the outgoing session", () => {
+    vi.mocked(layoutStructuresMatch).mockReturnValueOnce(true);
+
+    type TestPanel = {
+      id: string;
+      api: { component: string; isActive?: boolean; close: () => void };
+      group: { id: string; panels: TestPanel[] };
+    };
+
+    const group = { id: CENTER_GROUP_ID, panels: [] as TestPanel[] };
+    const panels: TestPanel[] = [];
+    const removePanel = (id: string) => {
+      const panelIndex = panels.findIndex((p) => p.id === id);
+      if (panelIndex >= 0) panels.splice(panelIndex, 1);
+      const groupIndex = group.panels.findIndex((p) => p.id === id);
+      if (groupIndex >= 0) group.panels.splice(groupIndex, 1);
+    };
+    const closeStale = vi.fn(() => removePanel(OLD_SESSION_PANEL_ID));
+    const stalePanel: TestPanel = {
+      id: OLD_SESSION_PANEL_ID,
+      api: { component: "chat", isActive: true, close: closeStale },
+      group,
+    };
+    panels.push(stalePanel);
+    group.panels.push(stalePanel);
+
+    const addPanel = vi.fn((opts: { id: string; component: string }) => {
+      const panel: TestPanel = {
+        id: opts.id,
+        api: { component: opts.component, close: () => removePanel(opts.id) },
+        group,
+      };
+      panels.push(panel);
+      group.panels.push(panel);
+    });
+    const api = {
+      ...makeMockApi(),
+      panels,
+      groups: [group],
+      getPanel: vi.fn((id: string) => panels.find((p) => p.id === id) ?? null),
+      addPanel,
+    } as unknown as EnvSwitchParams["api"];
+
+    performEnvSwitch(
+      makeParams({
+        api,
+        currentSessionIds: [NEW_SESSION_ID, SIBLING_SESSION_ID],
+      }),
+    );
+
+    expect(addPanel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: NEW_SESSION_PANEL_ID,
+        position: { referenceGroup: group.id, index: 0 },
+      }),
+    );
+    expect(addPanel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: SIBLING_SESSION_PANEL_ID,
+        params: { sessionId: SIBLING_SESSION_ID },
+        position: { referenceGroup: group.id, index: 1 },
+        inactive: true,
+      }),
+    );
+    expect(closeStale).toHaveBeenCalledOnce();
   });
 });
 

--- a/apps/web/lib/state/dockview-env-switch.test.ts
+++ b/apps/web/lib/state/dockview-env-switch.test.ts
@@ -349,6 +349,72 @@ describe("performEnvSwitch slow-path stale session strip", () => {
     );
     expect(closeStale).toHaveBeenCalledOnce();
   });
+});
+
+describe("performEnvSwitch slow-path session tab restoration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("restores sibling session tabs when slow-path replacement receives current session ids", () => {
+    vi.mocked(getEnvLayout)
+      .mockReturnValueOnce(makeHealthyLayoutWith({}))
+      .mockReturnValueOnce(makeHealthyLayoutWith({}));
+    vi.mocked(savedLayoutMatchesLive).mockReturnValueOnce(false);
+
+    const closeStale = vi.fn();
+    const groupId = "saved-center-group";
+    const groupPanels = [
+      { id: "session:phantom-from-other-env", api: { component: "chat", close: closeStale } },
+    ];
+    const stale = {
+      ...groupPanels[0],
+      group: { id: groupId, panels: groupPanels },
+    };
+    const panelsById = new Map<
+      string,
+      { id: string; api: { component: string }; group: unknown }
+    >();
+    const addPanel = vi.fn((opts: { id: string; component: string }) => {
+      panelsById.set(opts.id, {
+        id: opts.id,
+        api: { component: opts.component },
+        group: { id: groupId, panels: [] },
+      });
+    });
+    const api = {
+      ...makeMockApi(),
+      panels: [stale],
+      groups: [{ id: groupId }],
+      getPanel: vi.fn((id: string) => panelsById.get(id) ?? null),
+      addPanel,
+    } as unknown as EnvSwitchParams["api"];
+
+    performEnvSwitch(
+      makeParams({
+        api,
+        currentSessionIds: ["new-session", "sibling-session"],
+      }),
+    );
+
+    expect(addPanel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: NEW_SESSION_PANEL_ID,
+        component: "chat",
+        position: { referenceGroup: groupId, index: 0 },
+      }),
+    );
+    expect(addPanel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "session:sibling-session",
+        component: "chat",
+        params: { sessionId: "sibling-session" },
+        position: { referenceGroup: groupId, index: 0 },
+        inactive: true,
+      }),
+    );
+    expect(closeStale).toHaveBeenCalledOnce();
+  });
 
   it("skips addPanel when there is no active session (sessionless task)", () => {
     vi.mocked(getEnvLayout)

--- a/apps/web/lib/state/dockview-env-switch.ts
+++ b/apps/web/lib/state/dockview-env-switch.ts
@@ -196,7 +196,11 @@ function removeEphemeralPanels(api: DockviewApi, keepSessionId: string | null): 
  * File-editors/diffs/browser/etc. are NEVER touched here — they
  * legitimately belong to this env's saved state.
  */
-export function replaceStaleSessionPanels(api: DockviewApi, keepSessionId: string | null): void {
+export function replaceStaleSessionPanels(
+  api: DockviewApi,
+  keepSessionId: string | null,
+  currentSessionIds: string[] = [],
+): void {
   const keepId = keepSessionId ? `session:${keepSessionId}` : null;
   // keepId=null (sessionless task) → strips all session panels, unlike the
   // fast path's shouldRemoveDuringSwitch which keeps them. In practice
@@ -239,6 +243,29 @@ export function replaceStaleSessionPanels(api: DockviewApi, keepSessionId: strin
     } catch {
       /* panel may already be gone */
     }
+  }
+
+  addCurrentSessionSiblings(api, keepSessionId, currentSessionIds);
+}
+
+function addCurrentSessionSiblings(
+  api: DockviewApi,
+  keepSessionId: string | null,
+  currentSessionIds: string[],
+): void {
+  if (!keepSessionId) return;
+  const activePanel = api.getPanel(`session:${keepSessionId}`);
+  if (!activePanel) return;
+
+  const uniqueSessionIds = currentSessionIds.filter(
+    (sessionId, index, sessionIds) =>
+      sessionId && sessionId !== keepSessionId && sessionIds.indexOf(sessionId) === index,
+  );
+  for (const sessionId of uniqueSessionIds) {
+    if (api.getPanel(`session:${sessionId}`)) continue;
+    addIncomingSessionPanel(api, sessionId, activePanel.group.id, activePanel.group.panels.length, {
+      inactive: true,
+    });
   }
 }
 
@@ -459,6 +486,7 @@ function addIncomingSessionPanel(
   sessionId: string,
   outgoingGroupId: string | undefined,
   outgoingIndex: number,
+  options: { inactive?: boolean } = {},
 ): void {
   let position: import("dockview-react").AddPanelOptions["position"];
   if (outgoingGroupId && api.groups.some((g) => g.id === outgoingGroupId)) {
@@ -476,6 +504,7 @@ function addIncomingSessionPanel(
     title: "Agent",
     params: { sessionId },
     position,
+    inactive: options.inactive,
   });
 }
 

--- a/apps/web/lib/state/dockview-env-switch.ts
+++ b/apps/web/lib/state/dockview-env-switch.ts
@@ -133,6 +133,8 @@ export type EnvSwitchParams = {
   newEnvId: string;
   /** Active session for the incoming env — used to keep the right session chat tab. */
   activeSessionId: string | null;
+  /** All sessions for the active task, so slow-path restores keep sibling chat tabs. */
+  currentSessionIds?: string[];
   safeWidth: number;
   safeHeight: number;
   buildDefault: (api: DockviewApi) => void;
@@ -518,7 +520,16 @@ function addIncomingSessionPanel(
  * env-scoped portals before calling this function.
  */
 export function performEnvSwitch(params: EnvSwitchParams): LayoutGroupIds {
-  const { api, oldEnvId, newEnvId, activeSessionId, safeWidth, safeHeight, buildDefault } = params;
+  const {
+    api,
+    oldEnvId,
+    newEnvId,
+    activeSessionId,
+    currentSessionIds = [],
+    safeWidth,
+    safeHeight,
+    buildDefault,
+  } = params;
   if (isDebug()) {
     debug("performEnvSwitch: entry", {
       oldEnvId,
@@ -565,7 +576,7 @@ export function performEnvSwitch(params: EnvSwitchParams): LayoutGroupIds {
       // editors, etc.). File editors/diffs/etc. on their own are legitimately
       // part of this env's saved state and must NOT be touched.
       // useAutoSessionTab will still no-op if the panel was just added here.
-      replaceStaleSessionPanels(api, activeSessionId);
+      replaceStaleSessionPanels(api, activeSessionId, currentSessionIds);
       api.layout(safeWidth, safeHeight);
       if (isDebug()) {
         debug("performEnvSwitch: completed via slow path (fromJSON)", {

--- a/apps/web/lib/state/dockview-env-switch.ts
+++ b/apps/web/lib/state/dockview-env-switch.ts
@@ -141,37 +141,9 @@ export type EnvSwitchParams = {
   getDefaultLayout: () => LayoutState;
 };
 
-/**
- * Predicate matching panels that `removeEphemeralPanels` will close.
- *
- * Ephemeral panels (file-editors, diffs, commit-details, etc.) are env-scoped
- * and never carry across switches. When `keepSessionId` is provided, chat
- * panels for any other session are also removed so the old env's session tab
- * doesn't bleed into the new env.
- */
-function shouldRemoveDuringSwitch(
-  panel: { id: string; api: { component: string } },
-  keepSessionId: string | null,
-): boolean {
-  const comp = panel.api.component;
-  if (EPHEMERAL_COMPONENTS.has(comp)) return true;
-  if (
-    keepSessionId !== null &&
-    comp === "chat" &&
-    panel.id.startsWith("session:") &&
-    panel.id !== `session:${keepSessionId}`
-  ) {
-    return true;
-  }
-  return false;
-}
-
-/**
- * Close every panel that matches `shouldRemoveDuringSwitch`. Used to clear
- * env-scoped ephemerals before the new env's panels are restored.
- */
-function removeEphemeralPanels(api: DockviewApi, keepSessionId: string | null): void {
-  const toRemove = api.panels.filter((p) => shouldRemoveDuringSwitch(p, keepSessionId));
+/** Close non-session env-scoped panels before the new env's panels are restored. */
+function removeEphemeralPanels(api: DockviewApi): void {
+  const toRemove = api.panels.filter((p) => EPHEMERAL_COMPONENTS.has(p.api.component));
   for (const p of toRemove) {
     try {
       p.api.close();
@@ -204,10 +176,9 @@ export function replaceStaleSessionPanels(
   currentSessionIds: string[] = [],
 ): void {
   const keepId = keepSessionId ? `session:${keepSessionId}` : null;
-  // keepId=null (sessionless task) → strips all session panels, unlike the
-  // fast path's shouldRemoveDuringSwitch which keeps them. In practice
-  // sessionless tasks should have no session panels; useAutoSessionTab
-  // re-adds the panel when a session arrives.
+  // keepId=null (sessionless task) → strips all session panels. In practice
+  // sessionless tasks should have no session panels; useAutoSessionTab re-adds
+  // the panel when a session arrives.
   const stale = api.panels.filter(
     (p) => p.api.component === "chat" && p.id.startsWith("session:") && p.id !== keepId,
   );
@@ -271,39 +242,61 @@ function addCurrentSessionSiblings(
   }
 }
 
+function fastSwitchStructuresMatch(
+  params: EnvSwitchParams,
+  currentLayout: LayoutState,
+  saved: object | null,
+): boolean {
+  if (saved) {
+    return savedLayoutMatchesLive(currentLayout, saved as SerializedDockview);
+  }
+  return layoutStructuresMatch(currentLayout, params.getDefaultLayout());
+}
+
+function canUseFastEnvSwitch(
+  params: EnvSwitchParams,
+  currentLayout: LayoutState,
+  saved: object | null,
+): boolean {
+  if (!fastSwitchStructuresMatch(params, currentLayout, saved)) {
+    if (isDebug()) {
+      debug("tryFastEnvSwitch: structures do not match, falling back to slow path", {
+        newEnvId: params.newEnvId,
+        hasSaved: !!saved,
+        currentPanelIds: params.api.panels.map((p) => p.id),
+      });
+    }
+    return false;
+  }
+  if (!saved || !savedLayoutHasEphemeralPanels(saved as SerializedDockview)) return true;
+
+  debug("tryFastEnvSwitch: saved layout has ephemeral panels, falling back to slow path", {
+    newEnvId: params.newEnvId,
+  });
+  return false;
+}
+
+function isSessionPanel(p: DockviewApi["panels"][number]): boolean {
+  return p.id.startsWith("session:") || p.api.component === "chat";
+}
+
+function findOutgoingSessionPanel(api: DockviewApi): DockviewApi["panels"][number] | undefined {
+  return (
+    api.panels.find((p) => isSessionPanel(p) && p.api.isActive) ?? api.panels.find(isSessionPanel)
+  );
+}
+
 /**
  * Fast path: check if we can skip `api.fromJSON()` because the layout
  * structure hasn't changed. Returns group IDs if the fast path was taken,
  * or null if a full rebuild is needed.
  */
 function tryFastEnvSwitch(params: EnvSwitchParams): LayoutGroupIds | null {
-  const { api, newEnvId, activeSessionId, getDefaultLayout } = params;
+  const { api, newEnvId, activeSessionId, currentSessionIds = [] } = params;
   const currentLayout = fromDockviewApi(api);
   const saved = getHealthyEnvLayout(newEnvId);
 
-  let structuresMatch = false;
-  if (saved) {
-    structuresMatch = savedLayoutMatchesLive(currentLayout, saved as SerializedDockview);
-  } else {
-    structuresMatch = layoutStructuresMatch(currentLayout, getDefaultLayout());
-  }
-
-  if (!structuresMatch) {
-    if (isDebug()) {
-      debug("tryFastEnvSwitch: structures do not match, falling back to slow path", {
-        newEnvId,
-        hasSaved: !!saved,
-        currentPanelIds: api.panels.map((p) => p.id),
-      });
-    }
-    return null;
-  }
-  if (saved && savedLayoutHasEphemeralPanels(saved as SerializedDockview)) {
-    debug("tryFastEnvSwitch: saved layout has ephemeral panels, falling back to slow path", {
-      newEnvId,
-    });
-    return null;
-  }
+  if (!canUseFastEnvSwitch(params, currentLayout, saved)) return null;
   if (isDebug()) {
     debug("tryFastEnvSwitch: taking fast path", {
       newEnvId,
@@ -316,21 +309,13 @@ function tryFastEnvSwitch(params: EnvSwitchParams): LayoutGroupIds | null {
   // Prefer the active session panel so multi-session tasks anchor the
   // incoming panel to the group the user was looking at, not whichever
   // session tab happens to come first in `api.panels` iteration order.
-  const isSessionPanel = (p: (typeof api.panels)[number]) =>
-    p.id.startsWith("session:") || p.api.component === "chat";
-  const outgoingSessionPanel =
-    api.panels.find((p) => isSessionPanel(p) && p.api.isActive) ?? api.panels.find(isSessionPanel);
+  const outgoingSessionPanel = findOutgoingSessionPanel(api);
   const outgoingGroup = outgoingSessionPanel?.group;
   const outgoingGroupId = outgoingGroup?.id;
   // The outgoing session panel's current index in its group. We insert the
-  // incoming session at this same slot *before* removing the outgoing one, so
-  // removing the panels ahead of it shifts the new panel into the right final
-  // position (equivalent to the old "survivor index" math, minus the group
-  // death described below). This equivalence relies on every panel that
-  // `removeEphemeralPanels` removes *ahead of* the insert position being
-  // ephemeral/stale (they'd have been excluded by the old survivor count too).
-  // If `shouldRemoveDuringSwitch` ever retains a non-stale panel before the
-  // outgoing slot, this raw index would land the new panel off by one.
+  // incoming session at this same slot *before* removing stale session panels,
+  // so removing the stale panel shifts the new panel into the right final
+  // position.
   const outgoingIndex =
     outgoingGroup && outgoingSessionPanel
       ? outgoingGroup.panels.findIndex((p) => p.id === outgoingSessionPanel.id)
@@ -343,10 +328,11 @@ function tryFastEnvSwitch(params: EnvSwitchParams): LayoutGroupIds | null {
   // undefined position and dockview drops the incoming chat into whatever group
   // is active (e.g. the terminal) — collapsing the grid root to a vertical
   // stack. Adding first keeps the group alive throughout the swap.
-  if (activeSessionId && !api.getPanel(`session:${activeSessionId}`)) {
+  if (activeSessionId && !outgoingSessionPanel && !api.getPanel(`session:${activeSessionId}`)) {
     addIncomingSessionPanel(api, activeSessionId, outgoingGroupId, outgoingIndex);
   }
-  removeEphemeralPanels(api, activeSessionId);
+  removeEphemeralPanels(api);
+  replaceStaleSessionPanels(api, activeSessionId, currentSessionIds);
 
   // The fast path skips `fromJSON`, so per-group active tabs from the
   // outgoing env would otherwise persist into the incoming env. Reapply

--- a/apps/web/lib/state/dockview-env-switch.ts
+++ b/apps/web/lib/state/dockview-env-switch.ts
@@ -196,7 +196,7 @@ function removeEphemeralPanels(api: DockviewApi, keepSessionId: string | null): 
  * File-editors/diffs/browser/etc. are NEVER touched here — they
  * legitimately belong to this env's saved state.
  */
-function replaceStaleSessionPanels(api: DockviewApi, keepSessionId: string | null): void {
+export function replaceStaleSessionPanels(api: DockviewApi, keepSessionId: string | null): void {
   const keepId = keepSessionId ? `session:${keepSessionId}` : null;
   // keepId=null (sessionless task) → strips all session panels, unlike the
   // fast path's shouldRemoveDuringSwitch which keeps them. In practice

--- a/apps/web/lib/state/dockview-preset-persistence.test.ts
+++ b/apps/web/lib/state/dockview-preset-persistence.test.ts
@@ -38,43 +38,48 @@ vi.mock("./dockview-layout-builders", () => ({
   focusOrAddPanel: vi.fn(),
 }));
 
-vi.mock("./layout-manager", () => ({
-  SIDEBAR_GROUP: "sidebar",
-  CENTER_GROUP: "center",
-  RIGHT_TOP_GROUP: "right-top",
-  RIGHT_BOTTOM_GROUP: "right-bottom",
-  TERMINAL_DEFAULT_ID: "terminal",
-  LAYOUT_SIDEBAR_RATIO: 0.2,
-  LAYOUT_RIGHT_RATIO: 0.25,
-  LAYOUT_PINNED_MIN_PX: 200,
-  computeSidebarMaxPx: vi.fn(() => 350),
-  computeRightMaxPx: vi.fn(() => 500),
-  getPresetLayout: vi.fn(() => ({ columns: [] })),
-  applyLayout: vi.fn(() => ({
-    sidebarGroupId: "g-sidebar",
-    centerGroupId: "g-center",
-    rightTopGroupId: "g-right-top",
-    rightBottomGroupId: "g-right-bottom",
-  })),
-  getPinnedWidth: vi.fn(() => 350),
-  getRootSplitview: vi.fn(() => null),
-  fromDockviewApi: vi.fn(() => ({ columns: [] })),
-  filterEphemeral: vi.fn((s: unknown) => s),
-  defaultLayout: vi.fn(() => ({ columns: [] })),
-  mergeCurrentPanelsIntoPreset: vi.fn((_api: unknown, preset: unknown) => preset),
-  toSerializedDockview: vi.fn((s: unknown) => s),
-  injectIntentPanels: vi.fn(),
-  applyActivePanelOverrides: vi.fn(),
-  resolveNamedIntent: vi.fn(),
-  setPinnedTarget: vi.fn(),
-  clearPinnedTarget: vi.fn(),
-  getPinnedTarget: vi.fn(() => undefined),
-  layoutStructuresMatch: vi.fn(() => false),
-  savedLayoutMatchesLive: vi.fn(() => false),
-}));
+vi.mock("./layout-manager", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./layout-manager")>();
+  return {
+    ...actual,
+    SIDEBAR_GROUP: "sidebar",
+    CENTER_GROUP: "center",
+    RIGHT_TOP_GROUP: "right-top",
+    RIGHT_BOTTOM_GROUP: "right-bottom",
+    TERMINAL_DEFAULT_ID: "terminal",
+    LAYOUT_SIDEBAR_RATIO: 0.2,
+    LAYOUT_RIGHT_RATIO: 0.25,
+    LAYOUT_PINNED_MIN_PX: 200,
+    computeSidebarMaxPx: vi.fn(() => 350),
+    computeRightMaxPx: vi.fn(() => 500),
+    getPresetLayout: vi.fn(() => ({ columns: [] })),
+    applyLayout: vi.fn(() => ({
+      sidebarGroupId: "g-sidebar",
+      centerGroupId: "g-center",
+      rightTopGroupId: "g-right-top",
+      rightBottomGroupId: "g-right-bottom",
+    })),
+    getPinnedWidth: vi.fn(() => 350),
+    getRootSplitview: vi.fn(() => null),
+    fromDockviewApi: vi.fn(() => ({ columns: [] })),
+    filterEphemeral: vi.fn((s: unknown) => s),
+    defaultLayout: vi.fn(() => ({ columns: [] })),
+    mergeCurrentPanelsIntoPreset: vi.fn((_api: unknown, preset: unknown) => preset),
+    toSerializedDockview: vi.fn((s: unknown) => s),
+    injectIntentPanels: vi.fn(),
+    applyActivePanelOverrides: vi.fn(),
+    resolveNamedIntent: vi.fn(),
+    setPinnedTarget: vi.fn(),
+    clearPinnedTarget: vi.fn(),
+    getPinnedTarget: vi.fn(() => undefined),
+    layoutStructuresMatch: vi.fn(() => false),
+    savedLayoutMatchesLive: vi.fn(() => false),
+  };
+});
 
 import { setEnvLayout } from "@/lib/local-storage";
 import { persistEnvLayoutNow, useDockviewStore } from "./dockview-store";
+import { applyLayout } from "./layout-manager";
 
 function makeApi(snapshot: object = { columns: [] }): DockviewApi {
   return {
@@ -243,6 +248,56 @@ describe("applyBuiltInPreset — persistence at call site", () => {
 
 describe("applyCustomLayout — persistence at call site", () => {
   beforeEach(resetStoreForIntegration);
+
+  it("retargets saved session chat panels to the active session", async () => {
+    const api = makeStoreApi();
+    useDockviewStore.setState({ api, currentLayoutEnvId: "env-custom" });
+
+    const layoutWithOldSession = {
+      id: "simple",
+      name: "Simple",
+      layout: {
+        columns: [
+          {
+            id: "center",
+            groups: [
+              {
+                panels: [
+                  {
+                    id: "session:s-old",
+                    component: "chat",
+                    title: "Agent",
+                    tabComponent: "sessionTab",
+                    params: { sessionId: "s-old" },
+                  },
+                ],
+                activePanel: "session:s-old",
+              },
+            ],
+          },
+        ],
+      },
+    };
+
+    (
+      useDockviewStore.getState().applyCustomLayout as (
+        layout: ApplyCustomLayoutArg,
+        opts: { activeSessionId: string },
+      ) => void
+    )(layoutWithOldSession as unknown as ApplyCustomLayoutArg, { activeSessionId: "s-new" });
+
+    await flushRaf();
+
+    const appliedState = vi.mocked(applyLayout).mock.calls.at(-1)?.[1];
+    const panel = appliedState?.columns[0]?.groups[0]?.panels[0];
+    expect(panel).toMatchObject({
+      id: "session:s-new",
+      component: "chat",
+      tabComponent: "sessionTab",
+      params: { sessionId: "s-new" },
+    });
+    expect(appliedState?.columns[0]?.groups[0]?.activePanel).toBe("session:s-new");
+  });
 
   it("persists the env layout after isRestoringLayout clears", async () => {
     const api = makeStoreApi();

--- a/apps/web/lib/state/dockview-preset-persistence.test.ts
+++ b/apps/web/lib/state/dockview-preset-persistence.test.ts
@@ -185,6 +185,35 @@ const customLayout = {
   name: "custom",
   layout: { columns: [{ id: "center", views: [], activeView: null }] },
 };
+
+function staleSessionLayout() {
+  return {
+    id: "simple",
+    name: "Simple",
+    layout: {
+      columns: [
+        {
+          id: "center",
+          groups: [
+            {
+              panels: [
+                {
+                  id: "session:s-old",
+                  component: "chat",
+                  title: "Agent",
+                  tabComponent: "sessionTab",
+                  params: { sessionId: "s-old" },
+                },
+              ],
+              activePanel: "session:s-old",
+            },
+          ],
+        },
+      ],
+    },
+  };
+}
+
 type ApplyCustomLayoutArg = Parameters<
   ReturnType<typeof useDockviewStore.getState>["applyCustomLayout"]
 >[0];
@@ -253,38 +282,15 @@ describe("applyCustomLayout — persistence at call site", () => {
     const api = makeStoreApi();
     useDockviewStore.setState({ api, currentLayoutEnvId: "env-custom" });
 
-    const layoutWithOldSession = {
-      id: "simple",
-      name: "Simple",
-      layout: {
-        columns: [
-          {
-            id: "center",
-            groups: [
-              {
-                panels: [
-                  {
-                    id: "session:s-old",
-                    component: "chat",
-                    title: "Agent",
-                    tabComponent: "sessionTab",
-                    params: { sessionId: "s-old" },
-                  },
-                ],
-                activePanel: "session:s-old",
-              },
-            ],
-          },
-        ],
-      },
-    };
-
     (
       useDockviewStore.getState().applyCustomLayout as (
         layout: ApplyCustomLayoutArg,
-        opts: { activeSessionId: string },
+        opts: { activeSessionId: string; sessionIds: string[] },
       ) => void
-    )(layoutWithOldSession as unknown as ApplyCustomLayoutArg, { activeSessionId: "s-new" });
+    )(staleSessionLayout() as unknown as ApplyCustomLayoutArg, {
+      activeSessionId: "s-new",
+      sessionIds: ["s-sibling", "s-new"],
+    });
 
     await flushRaf();
 
@@ -296,6 +302,10 @@ describe("applyCustomLayout — persistence at call site", () => {
       tabComponent: "sessionTab",
       params: { sessionId: "s-new" },
     });
+    expect(appliedState?.columns[0]?.groups[0]?.panels.map((item) => item.id)).toEqual([
+      "session:s-new",
+      "session:s-sibling",
+    ]);
     expect(appliedState?.columns[0]?.groups[0]?.activePanel).toBe("session:s-new");
   });
 

--- a/apps/web/lib/state/dockview-preset-persistence.test.ts
+++ b/apps/web/lib/state/dockview-preset-persistence.test.ts
@@ -186,6 +186,12 @@ const customLayout = {
   layout: { columns: [{ id: "center", views: [], activeView: null }] },
 };
 
+const NEW_SESSION_ID = "s-new";
+const NEW_SESSION_PANEL_ID = `session:${NEW_SESSION_ID}`;
+const SIBLING_SESSION_ID = "s-sibling";
+const SIBLING_SESSION_PANEL_ID = `session:${SIBLING_SESSION_ID}`;
+const CUSTOM_ENV_ID = "env-custom";
+
 function staleSessionLayout() {
   return {
     id: "simple",
@@ -206,6 +212,35 @@ function staleSessionLayout() {
                 },
               ],
               activePanel: "session:s-old",
+            },
+          ],
+        },
+      ],
+    },
+  };
+}
+
+function staleSessionOnlyRightColumnLayout() {
+  return {
+    id: "simple",
+    name: "Simple",
+    layout: {
+      columns: [
+        staleSessionLayout().layout.columns[0],
+        {
+          id: "right",
+          groups: [
+            {
+              panels: [
+                {
+                  id: "session:s-other",
+                  component: "chat",
+                  title: "Agent",
+                  tabComponent: "sessionTab",
+                  params: { sessionId: "s-other" },
+                },
+              ],
+              activePanel: "session:s-other",
             },
           ],
         },
@@ -275,12 +310,12 @@ describe("applyBuiltInPreset — persistence at call site", () => {
   });
 });
 
-describe("applyCustomLayout — persistence at call site", () => {
+describe("applyCustomLayout — session panel normalization", () => {
   beforeEach(resetStoreForIntegration);
 
   it("retargets saved session chat panels to the active session", async () => {
     const api = makeStoreApi();
-    useDockviewStore.setState({ api, currentLayoutEnvId: "env-custom" });
+    useDockviewStore.setState({ api, currentLayoutEnvId: CUSTOM_ENV_ID });
 
     (
       useDockviewStore.getState().applyCustomLayout as (
@@ -288,8 +323,8 @@ describe("applyCustomLayout — persistence at call site", () => {
         opts: { activeSessionId: string; sessionIds: string[] },
       ) => void
     )(staleSessionLayout() as unknown as ApplyCustomLayoutArg, {
-      activeSessionId: "s-new",
-      sessionIds: ["s-sibling", "s-new"],
+      activeSessionId: NEW_SESSION_ID,
+      sessionIds: [SIBLING_SESSION_ID, NEW_SESSION_ID],
     });
 
     await flushRaf();
@@ -297,27 +332,54 @@ describe("applyCustomLayout — persistence at call site", () => {
     const appliedState = vi.mocked(applyLayout).mock.calls.at(-1)?.[1];
     const panel = appliedState?.columns[0]?.groups[0]?.panels[0];
     expect(panel).toMatchObject({
-      id: "session:s-new",
+      id: NEW_SESSION_PANEL_ID,
       component: "chat",
       tabComponent: "sessionTab",
-      params: { sessionId: "s-new" },
+      params: { sessionId: NEW_SESSION_ID },
     });
     expect(appliedState?.columns[0]?.groups[0]?.panels.map((item) => item.id)).toEqual([
-      "session:s-new",
-      "session:s-sibling",
+      NEW_SESSION_PANEL_ID,
+      SIBLING_SESSION_PANEL_ID,
     ]);
-    expect(appliedState?.columns[0]?.groups[0]?.activePanel).toBe("session:s-new");
+    expect(appliedState?.columns[0]?.groups[0]?.activePanel).toBe(NEW_SESSION_PANEL_ID);
   });
+
+  it("derives right panel visibility from the materialized custom layout", async () => {
+    const api = makeStoreApi();
+    useDockviewStore.setState({
+      api,
+      currentLayoutEnvId: CUSTOM_ENV_ID,
+      rightPanelsVisible: true,
+    });
+
+    (
+      useDockviewStore.getState().applyCustomLayout as (
+        layout: ApplyCustomLayoutArg,
+        opts: { activeSessionId: string },
+      ) => void
+    )(staleSessionOnlyRightColumnLayout() as unknown as ApplyCustomLayoutArg, {
+      activeSessionId: NEW_SESSION_ID,
+    });
+
+    const appliedState = vi.mocked(applyLayout).mock.calls.at(-1)?.[1];
+    expect(appliedState?.columns.map((column) => column.id)).toEqual(["center"]);
+    expect(useDockviewStore.getState().rightPanelsVisible).toBe(false);
+    await flushRaf();
+  });
+});
+
+describe("applyCustomLayout — persistence at call site", () => {
+  beforeEach(resetStoreForIntegration);
 
   it("persists the env layout after isRestoringLayout clears", async () => {
     const api = makeStoreApi();
-    useDockviewStore.setState({ api, currentLayoutEnvId: "env-custom" });
+    useDockviewStore.setState({ api, currentLayoutEnvId: CUSTOM_ENV_ID });
 
     useDockviewStore.getState().applyCustomLayout(customLayout as unknown as ApplyCustomLayoutArg);
     await flushRaf();
 
     expect(setEnvLayout).toHaveBeenCalledTimes(1);
-    expect(setEnvLayout).toHaveBeenCalledWith("env-custom", expect.any(Object));
+    expect(setEnvLayout).toHaveBeenCalledWith(CUSTOM_ENV_ID, expect.any(Object));
   });
 
   it("does not persist when no env is adopted yet", async () => {

--- a/apps/web/lib/state/dockview-store.ts
+++ b/apps/web/lib/state/dockview-store.ts
@@ -26,9 +26,11 @@ import {
   defaultLayout,
   mergeCurrentPanelsIntoPreset,
   toSerializedDockview,
+  normalizeReusableSessionPanels,
+  materializeReusableChatPanel,
 } from "./layout-manager";
 import type { BuiltInPreset, LayoutState, LayoutGroupIds } from "./layout-manager";
-import { performEnvSwitch } from "./dockview-env-switch";
+import { performEnvSwitch, replaceStaleSessionPanels } from "./dockview-env-switch";
 import { enforcePinnedTargets } from "./dockview-pinned-enforce";
 import {
   injectIntentPanels,
@@ -114,6 +116,10 @@ export type SavedLayoutConfig = {
   createdAt: string;
 };
 
+export type ApplyCustomLayoutOptions = {
+  activeSessionId?: string | null;
+};
+
 type DockviewStore = {
   api: DockviewApi | null;
   setApi: (api: DockviewApi | null) => void;
@@ -174,7 +180,7 @@ type DockviewStore = {
   applyBuiltInPreset: (preset: BuiltInPreset, resetWidths?: boolean) => void;
   defaultPreset: BuiltInPreset;
   setDefaultPreset: (preset: BuiltInPreset) => void;
-  applyCustomLayout: (layout: SavedLayoutConfig) => void;
+  applyCustomLayout: (layout: SavedLayoutConfig, opts?: ApplyCustomLayoutOptions) => void;
   captureCurrentLayout: () => Record<string, unknown>;
   isRestoringLayout: boolean;
   /** ID of the task environment whose layout is currently rendered. Layouts are
@@ -472,8 +478,7 @@ function buildPresetActions(set: StoreSet, get: StoreGet) {
       if (!api) return;
       const liveWidths = captureLiveWidths(api, set);
       preserveChatScrollDuringLayout();
-      // Capture dimensions before layout change — api.width can become stale
-      // inside the rAF callback after dockview serialization
+      // Capture before layout change; api.width can become stale in rAF.
       const { width: safeWidth, height: safeHeight } = measureDockviewContainer(api);
       set({ isRestoringLayout: true });
       const presetState = getPresetLayout(preset);
@@ -518,7 +523,7 @@ function buildPresetActions(set: StoreSet, get: StoreGet) {
         }
       });
     },
-    applyCustomLayout: (layout: SavedLayoutConfig) => {
+    applyCustomLayout: (layout: SavedLayoutConfig, opts?: ApplyCustomLayoutOptions) => {
       const { api } = get();
       if (!api) return;
       const liveWidths = captureLiveWidths(api, set);
@@ -530,13 +535,18 @@ function buildPresetActions(set: StoreSet, get: StoreGet) {
       if (!state?.columns) {
         try {
           api.fromJSON(layout.layout as unknown as SerializedDockview);
+          replaceStaleSessionPanels(api, opts?.activeSessionId ?? null);
           set(applyLayoutFixups(api));
         } catch (e) {
           console.warn("applyCustomLayout: old-format restore failed:", e);
           oldFormatRestoreFailed = true;
         }
       } else {
-        const ids = applyLayout(api, state, liveWidths, safeWidth, safeHeight);
+        const activeState = materializeReusableChatPanel(
+          normalizeReusableSessionPanels(state),
+          opts?.activeSessionId ?? null,
+        );
+        const ids = applyLayout(api, activeState, liveWidths, safeWidth, safeHeight);
         set(ids);
       }
       const hasSidebar = !!api.getPanel("sidebar");
@@ -557,14 +567,16 @@ function buildPresetActions(set: StoreSet, get: StoreGet) {
         }
       });
     },
-    captureCurrentLayout: (): Record<string, unknown> => {
-      const { api } = get();
-      if (!api) return {};
-      const state = fromDockviewApi(api);
-      const filtered = filterEphemeral(state);
-      return filtered as unknown as Record<string, unknown>;
-    },
+    captureCurrentLayout: () => captureReusableLayout(get),
   };
+}
+
+function captureReusableLayout(get: StoreGet): Record<string, unknown> {
+  const { api } = get();
+  if (!api) return {};
+  const state = fromDockviewApi(api);
+  const filtered = filterEphemeral(state);
+  return normalizeReusableSessionPanels(filtered) as unknown as Record<string, unknown>;
 }
 
 /** Restore a saved maximize state from sessionStorage onto the dockview API. */

--- a/apps/web/lib/state/dockview-store.ts
+++ b/apps/web/lib/state/dockview-store.ts
@@ -531,7 +531,7 @@ function buildPresetActions(set: StoreSet, get: StoreGet) {
       preserveChatScrollDuringLayout();
       const { width: safeWidth, height: safeHeight } = measureDockviewContainer(api);
       set({ isRestoringLayout: true });
-      const { state, oldFormatRestoreFailed } = restoreCustomLayout({
+      const { appliedState, oldFormatRestoreFailed } = restoreCustomLayout({
         api,
         layout,
         opts,
@@ -541,7 +541,7 @@ function buildPresetActions(set: StoreSet, get: StoreGet) {
         set,
       });
       const hasSidebar = !!api.getPanel("sidebar");
-      const colCount = state?.columns?.length ?? api.groups.length;
+      const colCount = appliedState?.columns?.length ?? api.groups.length;
       const sidebarCols = hasSidebar ? 1 : 0;
       const hasRight = colCount > sidebarCols + 1;
       set({ sidebarVisible: hasSidebar, rightPanelsVisible: hasRight });
@@ -580,26 +580,28 @@ function restoreCustomLayout({
   safeWidth,
   safeHeight,
   set,
-}: RestoreCustomLayoutParams): { state: LayoutState; oldFormatRestoreFailed: boolean } {
+}: RestoreCustomLayoutParams): { appliedState: LayoutState; oldFormatRestoreFailed: boolean } {
   const state = layout.layout as unknown as LayoutState;
   if (state?.columns) {
+    // Normalize first so both old saved layouts with session-specific panels
+    // and newer reusable layouts with chat placeholders apply through one path.
     const activeState = materializeReusableChatPanel(
       normalizeReusableSessionPanels(state),
       opts?.activeSessionId ?? null,
       opts?.sessionIds ?? [],
     );
     set(applyLayout(api, activeState, liveWidths, safeWidth, safeHeight));
-    return { state, oldFormatRestoreFailed: false };
+    return { appliedState: activeState, oldFormatRestoreFailed: false };
   }
 
   try {
     api.fromJSON(layout.layout as unknown as SerializedDockview);
     replaceStaleSessionPanels(api, opts?.activeSessionId ?? null, opts?.sessionIds ?? []);
     set(applyLayoutFixups(api));
-    return { state, oldFormatRestoreFailed: false };
+    return { appliedState: state, oldFormatRestoreFailed: false };
   } catch (e) {
     console.warn("applyCustomLayout: old-format restore failed:", e);
-    return { state, oldFormatRestoreFailed: true };
+    return { appliedState: state, oldFormatRestoreFailed: true };
   }
 }
 

--- a/apps/web/lib/state/dockview-store.ts
+++ b/apps/web/lib/state/dockview-store.ts
@@ -118,6 +118,7 @@ export type SavedLayoutConfig = {
 
 export type ApplyCustomLayoutOptions = {
   activeSessionId?: string | null;
+  sessionIds?: string[];
 };
 
 type DockviewStore = {
@@ -530,25 +531,15 @@ function buildPresetActions(set: StoreSet, get: StoreGet) {
       preserveChatScrollDuringLayout();
       const { width: safeWidth, height: safeHeight } = measureDockviewContainer(api);
       set({ isRestoringLayout: true });
-      const state = layout.layout as unknown as LayoutState;
-      let oldFormatRestoreFailed = false;
-      if (!state?.columns) {
-        try {
-          api.fromJSON(layout.layout as unknown as SerializedDockview);
-          replaceStaleSessionPanels(api, opts?.activeSessionId ?? null);
-          set(applyLayoutFixups(api));
-        } catch (e) {
-          console.warn("applyCustomLayout: old-format restore failed:", e);
-          oldFormatRestoreFailed = true;
-        }
-      } else {
-        const activeState = materializeReusableChatPanel(
-          normalizeReusableSessionPanels(state),
-          opts?.activeSessionId ?? null,
-        );
-        const ids = applyLayout(api, activeState, liveWidths, safeWidth, safeHeight);
-        set(ids);
-      }
+      const { state, oldFormatRestoreFailed } = restoreCustomLayout({
+        api,
+        layout,
+        opts,
+        liveWidths,
+        safeWidth,
+        safeHeight,
+        set,
+      });
       const hasSidebar = !!api.getPanel("sidebar");
       const colCount = state?.columns?.length ?? api.groups.length;
       const sidebarCols = hasSidebar ? 1 : 0;
@@ -569,6 +560,47 @@ function buildPresetActions(set: StoreSet, get: StoreGet) {
     },
     captureCurrentLayout: () => captureReusableLayout(get),
   };
+}
+
+type RestoreCustomLayoutParams = {
+  api: DockviewApi;
+  layout: SavedLayoutConfig;
+  opts: ApplyCustomLayoutOptions | undefined;
+  liveWidths: Map<string, number>;
+  safeWidth: number;
+  safeHeight: number;
+  set: StoreSet;
+};
+
+function restoreCustomLayout({
+  api,
+  layout,
+  opts,
+  liveWidths,
+  safeWidth,
+  safeHeight,
+  set,
+}: RestoreCustomLayoutParams): { state: LayoutState; oldFormatRestoreFailed: boolean } {
+  const state = layout.layout as unknown as LayoutState;
+  if (state?.columns) {
+    const activeState = materializeReusableChatPanel(
+      normalizeReusableSessionPanels(state),
+      opts?.activeSessionId ?? null,
+      opts?.sessionIds ?? [],
+    );
+    set(applyLayout(api, activeState, liveWidths, safeWidth, safeHeight));
+    return { state, oldFormatRestoreFailed: false };
+  }
+
+  try {
+    api.fromJSON(layout.layout as unknown as SerializedDockview);
+    replaceStaleSessionPanels(api, opts?.activeSessionId ?? null, opts?.sessionIds ?? []);
+    set(applyLayoutFixups(api));
+    return { state, oldFormatRestoreFailed: false };
+  } catch (e) {
+    console.warn("applyCustomLayout: old-format restore failed:", e);
+    return { state, oldFormatRestoreFailed: true };
+  }
 }
 
 function captureReusableLayout(get: StoreGet): Record<string, unknown> {

--- a/apps/web/lib/state/dockview-store.ts
+++ b/apps/web/lib/state/dockview-store.ts
@@ -615,11 +615,18 @@ function captureReusableLayout(get: StoreGet): Record<string, unknown> {
 }
 
 /** Restore a saved maximize state from sessionStorage onto the dockview API. */
-function restoreMaximizeFromStorage(api: DockviewApi, envId: string, set: StoreSet): boolean {
+function restoreMaximizeFromStorage(
+  api: DockviewApi,
+  envId: string,
+  set: StoreSet,
+  activeSessionId: string | null,
+  currentSessionIds: string[] = [],
+): boolean {
   const saved = getEnvMaximizeState(envId);
   if (!saved) return false;
   try {
     api.fromJSON(saved.maximizedDockviewJson as SerializedDockview);
+    replaceStaleSessionPanels(api, activeSessionId, currentSessionIds);
     // After fromJSON, `api.width/height` reflect the JSON's recorded grid
     // dims, which may not match the live container. Always lay out against
     // the measured DOM size so a stale value can't pin the dockview at the
@@ -776,7 +783,8 @@ function buildEnvSwitchAction(set: StoreSet, get: StoreGet) {
     set({ preMaximizeLayout: null, maximizedGroupId: null });
     set({ isRestoringLayout: true, currentLayoutEnvId: newEnvId });
     try {
-      if (restoreMaximizeFromStorage(api, newEnvId, set)) return;
+      if (restoreMaximizeFromStorage(api, newEnvId, set, activeSessionId, currentSessionIds))
+        return;
       const measured = measureDockviewContainer(api);
       const ids = performEnvSwitch({
         api,

--- a/apps/web/lib/state/dockview-store.ts
+++ b/apps/web/lib/state/dockview-store.ts
@@ -194,6 +194,7 @@ type DockviewStore = {
     oldEnvId: string | null,
     newEnvId: string,
     activeSessionId: string | null,
+    currentSessionIds?: string[],
   ) => void;
   deferredPanelActions: DeferredPanelAction[];
   queuePanelAction: (action: DeferredPanelAction) => void;
@@ -727,7 +728,12 @@ function saveOutgoingEnv(
 }
 
 function buildEnvSwitchAction(set: StoreSet, get: StoreGet) {
-  return (oldEnvId: string | null, newEnvId: string, activeSessionId: string | null) => {
+  return (
+    oldEnvId: string | null,
+    newEnvId: string,
+    activeSessionId: string | null,
+    currentSessionIds: string[] = [],
+  ) => {
     const { api, currentLayoutEnvId, preMaximizeLayout } = get();
     if (!api) {
       debugSwitch("envSwitch: skip (no api)", { oldEnvId, newEnvId, activeSessionId });
@@ -777,6 +783,7 @@ function buildEnvSwitchAction(set: StoreSet, get: StoreGet) {
         oldEnvId: effectiveOld,
         newEnvId,
         activeSessionId,
+        currentSessionIds,
         safeWidth: measured.width,
         safeHeight: measured.height,
         buildDefault: (a) => get().buildDefaultLayout(a),
@@ -1050,8 +1057,11 @@ export function performLayoutSwitch(
   oldEnvId: string | null,
   newEnvId: string,
   activeSessionId: string | null,
+  currentSessionIds: string[] = [],
 ): void {
-  useDockviewStore.getState().switchEnvLayout(oldEnvId, newEnvId, activeSessionId);
+  useDockviewStore
+    .getState()
+    .switchEnvLayout(oldEnvId, newEnvId, activeSessionId, currentSessionIds);
 }
 
 /**

--- a/apps/web/lib/state/layout-manager/index.ts
+++ b/apps/web/lib/state/layout-manager/index.ts
@@ -58,6 +58,13 @@ export { computeColumnWidths, computeGroupHeights, getPinnedWidth } from "./sizi
 // Serializer
 export { toSerializedDockview, fromDockviewApi, filterEphemeral } from "./serializer";
 
+// Session panel normalization for reusable saved layouts
+export {
+  isSessionChatPanel,
+  normalizeReusableSessionPanels,
+  materializeReusableChatPanel,
+} from "./session-panels";
+
 // Applier
 export {
   applyLayout,

--- a/apps/web/lib/state/layout-manager/session-panels.test.ts
+++ b/apps/web/lib/state/layout-manager/session-panels.test.ts
@@ -55,6 +55,19 @@ it("normalizes saved session chat panels to a reusable chat placeholder", () => 
   expect(normalized.columns[0]?.groups[0]?.panels).toEqual([chatPlaceholder(), panel("changes")]);
 });
 
+it("keeps normalized reusable chat placeholders idempotent", () => {
+  const once = normalizeReusableSessionPanels(
+    layoutWithGroup({
+      id: CENTER_GROUP_ID,
+      activePanel: CHAT_ID,
+      panels: [chatPlaceholder(), panel("plan")],
+    }),
+  );
+  const twice = normalizeReusableSessionPanels(once);
+
+  expect(twice).toEqual(once);
+});
+
 it("materializes reusable chat panels to the active task session", () => {
   const materialized = materializeReusableChatPanel(
     layoutWithGroup({

--- a/apps/web/lib/state/layout-manager/session-panels.test.ts
+++ b/apps/web/lib/state/layout-manager/session-panels.test.ts
@@ -1,0 +1,149 @@
+import { expect, it } from "vitest";
+
+import { materializeReusableChatPanel, normalizeReusableSessionPanels } from "./session-panels";
+import type { LayoutGroup, LayoutPanel, LayoutState } from "./types";
+
+const CENTER_GROUP_ID = "group-center";
+const OLD_SESSION_ID = "s-old";
+const NEW_SESSION_ID = "s-new";
+const OLD_SESSION_PANEL_ID = `session:${OLD_SESSION_ID}`;
+const NEW_SESSION_PANEL_ID = `session:${NEW_SESSION_ID}`;
+const CHAT_ID = "chat";
+const CHAT_COMPONENT = "chat";
+
+function panel(id: string, component = id): LayoutPanel {
+  return { id, component, title: id };
+}
+
+function chatPlaceholder(): LayoutPanel {
+  return { id: CHAT_ID, component: CHAT_COMPONENT, title: "Agent", tabComponent: "permanentTab" };
+}
+
+function oldSessionPanel(id = OLD_SESSION_PANEL_ID): LayoutPanel {
+  return {
+    id,
+    component: CHAT_COMPONENT,
+    title: "Old task",
+    tabComponent: "sessionTab",
+    params: { sessionId: OLD_SESSION_ID },
+  };
+}
+
+function layoutWithGroup(group: LayoutGroup): LayoutState {
+  return {
+    columns: [
+      {
+        id: "center",
+        groups: [group],
+      },
+    ],
+  };
+}
+
+it("normalizes saved session chat panels to a reusable chat placeholder", () => {
+  const normalized = normalizeReusableSessionPanels(
+    layoutWithGroup({
+      id: CENTER_GROUP_ID,
+      activePanel: OLD_SESSION_PANEL_ID,
+      panels: [oldSessionPanel(), panel("changes")],
+    }),
+  );
+
+  expect(normalized.columns[0]?.groups[0]?.activePanel).toBe(CHAT_ID);
+  expect(normalized.columns[0]?.groups[0]?.panels).toEqual([chatPlaceholder(), panel("changes")]);
+});
+
+it("materializes reusable chat panels to the active task session", () => {
+  const materialized = materializeReusableChatPanel(
+    layoutWithGroup({
+      id: CENTER_GROUP_ID,
+      activePanel: CHAT_ID,
+      panels: [chatPlaceholder(), panel("plan")],
+    }),
+    NEW_SESSION_ID,
+  );
+
+  expect(materialized.columns[0]?.groups[0]?.activePanel).toBe(NEW_SESSION_PANEL_ID);
+  expect(materialized.columns[0]?.groups[0]?.panels[0]).toEqual({
+    id: NEW_SESSION_PANEL_ID,
+    component: CHAT_COMPONENT,
+    title: "Agent",
+    tabComponent: "sessionTab",
+    params: { sessionId: NEW_SESSION_ID },
+  });
+});
+
+it("keeps tree and flat groups in sync when rewriting session panels", () => {
+  const materialized = materializeReusableChatPanel(
+    {
+      columns: [
+        {
+          id: "center",
+          groups: [],
+          tree: {
+            type: "leaf",
+            group: {
+              id: CENTER_GROUP_ID,
+              activePanel: OLD_SESSION_PANEL_ID,
+              panels: [oldSessionPanel()],
+            },
+          },
+        },
+      ],
+    },
+    NEW_SESSION_ID,
+  );
+  const group = materialized.columns[0]?.groups[0];
+
+  expect(group?.activePanel).toBe(NEW_SESSION_PANEL_ID);
+  expect(group?.panels[0]?.id).toBe(NEW_SESSION_PANEL_ID);
+  expect(materialized.columns[0]?.tree).toMatchObject({
+    type: "leaf",
+    group: {
+      activePanel: NEW_SESSION_PANEL_ID,
+      panels: [{ id: NEW_SESSION_PANEL_ID }],
+    },
+  });
+});
+
+it("drops duplicate chat session panels from reusable layouts", () => {
+  const materialized = materializeReusableChatPanel(
+    layoutWithGroup({
+      id: CENTER_GROUP_ID,
+      activePanel: OLD_SESSION_PANEL_ID,
+      panels: [oldSessionPanel(), oldSessionPanel("session:s-other"), panel("plan")],
+    }),
+    NEW_SESSION_ID,
+  );
+
+  expect(materialized.columns[0]?.groups[0]?.panels.map((item) => item.id)).toEqual([
+    NEW_SESSION_PANEL_ID,
+    "plan",
+  ]);
+});
+
+it("deduplicates session chat panels across columns", () => {
+  const materialized = materializeReusableChatPanel(
+    {
+      columns: [
+        {
+          id: "center",
+          groups: [{ id: CENTER_GROUP_ID, panels: [oldSessionPanel()] }],
+        },
+        {
+          id: "right",
+          groups: [
+            { id: "group-right", panels: [oldSessionPanel("session:s-other"), panel("plan")] },
+          ],
+        },
+      ],
+    },
+    NEW_SESSION_ID,
+  );
+
+  expect(materialized.columns.map((column) => column.id)).toEqual(["center", "right"]);
+  expect(materialized.columns[0]?.groups[0]?.panels.map((item) => item.id)).toEqual([
+    NEW_SESSION_PANEL_ID,
+  ]);
+  expect(materialized.columns[1]?.groups[0]?.panels.map((item) => item.id)).toEqual(["plan"]);
+});

--- a/apps/web/lib/state/layout-manager/session-panels.test.ts
+++ b/apps/web/lib/state/layout-manager/session-panels.test.ts
@@ -6,8 +6,10 @@ import type { LayoutGroup, LayoutPanel, LayoutState } from "./types";
 const CENTER_GROUP_ID = "group-center";
 const OLD_SESSION_ID = "s-old";
 const NEW_SESSION_ID = "s-new";
+const SIBLING_SESSION_ID = "s-sibling";
 const OLD_SESSION_PANEL_ID = `session:${OLD_SESSION_ID}`;
 const NEW_SESSION_PANEL_ID = `session:${NEW_SESSION_ID}`;
+const SIBLING_SESSION_PANEL_ID = `session:${SIBLING_SESSION_ID}`;
 const CHAT_ID = "chat";
 const CHAT_COMPONENT = "chat";
 
@@ -71,6 +73,25 @@ it("materializes reusable chat panels to the active task session", () => {
     tabComponent: "sessionTab",
     params: { sessionId: NEW_SESSION_ID },
   });
+});
+
+it("materializes sibling task session tabs beside the active session", () => {
+  const materialized = materializeReusableChatPanel(
+    layoutWithGroup({
+      id: CENTER_GROUP_ID,
+      activePanel: CHAT_ID,
+      panels: [chatPlaceholder(), panel("plan")],
+    }),
+    NEW_SESSION_ID,
+    [SIBLING_SESSION_ID, NEW_SESSION_ID],
+  );
+
+  expect(materialized.columns[0]?.groups[0]?.activePanel).toBe(NEW_SESSION_PANEL_ID);
+  expect(materialized.columns[0]?.groups[0]?.panels.map((item) => item.id)).toEqual([
+    NEW_SESSION_PANEL_ID,
+    SIBLING_SESSION_PANEL_ID,
+    "plan",
+  ]);
 });
 
 it("keeps tree and flat groups in sync when rewriting session panels", () => {
@@ -146,4 +167,43 @@ it("deduplicates session chat panels across columns", () => {
     NEW_SESSION_PANEL_ID,
   ]);
   expect(materialized.columns[1]?.groups[0]?.panels.map((item) => item.id)).toEqual(["plan"]);
+});
+
+it("preserves groups that were already empty before normalization", () => {
+  const normalized = normalizeReusableSessionPanels({
+    columns: [
+      {
+        id: "center",
+        groups: [
+          { id: CENTER_GROUP_ID, panels: [oldSessionPanel()] },
+          { id: "empty-split", panels: [] },
+        ],
+      },
+    ],
+  });
+
+  expect(normalized.columns[0]?.groups.map((group) => group.id)).toEqual([
+    CENTER_GROUP_ID,
+    "empty-split",
+  ]);
+  expect(normalized.columns[0]?.groups[1]?.panels).toEqual([]);
+});
+
+it("removes groups that become empty only after duplicate session tabs are discarded", () => {
+  const materialized = materializeReusableChatPanel(
+    {
+      columns: [
+        {
+          id: "center",
+          groups: [
+            { id: CENTER_GROUP_ID, panels: [oldSessionPanel()] },
+            { id: "duplicate-session-only", panels: [oldSessionPanel("session:s-other")] },
+          ],
+        },
+      ],
+    },
+    NEW_SESSION_ID,
+  );
+
+  expect(materialized.columns[0]?.groups.map((group) => group.id)).toEqual([CENTER_GROUP_ID]);
 });

--- a/apps/web/lib/state/layout-manager/session-panels.ts
+++ b/apps/web/lib/state/layout-manager/session-panels.ts
@@ -22,17 +22,43 @@ function sessionPanel(sessionId: string): LayoutPanel {
   };
 }
 
-function targetPanel(activeSessionId: string | null): LayoutPanel {
-  return activeSessionId ? sessionPanel(activeSessionId) : knownPanel(CHAT_PANEL_ID);
+function targetPanels(activeSessionId: string | null, currentSessionIds: string[]): LayoutPanel[] {
+  if (!activeSessionId) return [knownPanel(CHAT_PANEL_ID)];
+
+  const orderedSessionIds = [activeSessionId, ...currentSessionIds].filter(
+    (sessionId, index, sessionIds) => sessionId && sessionIds.indexOf(sessionId) === index,
+  );
+  return orderedSessionIds.map(sessionPanel);
+}
+
+function rewrittenActivePanel(
+  group: LayoutGroup,
+  panels: LayoutPanel[],
+  targets: LayoutPanel[],
+  activeWasRewritten: boolean,
+): string | undefined {
+  if (activeWasRewritten) {
+    const activeTargetId = targets[0]?.id;
+    return activeTargetId && panels.some((panel) => panel.id === activeTargetId)
+      ? activeTargetId
+      : panels[0]?.id;
+  }
+
+  if (group.activePanel && !panels.some((panel) => panel.id === group.activePanel)) {
+    return panels[0]?.id;
+  }
+
+  return group.activePanel;
 }
 
 function rewriteGroup(
   group: LayoutGroup,
-  target: LayoutPanel,
+  targets: LayoutPanel[],
   inserted: { value: boolean },
 ): LayoutGroup | null {
   let activeWasRewritten = false;
   const panels: LayoutPanel[] = [];
+  const hadPanels = group.panels.length > 0;
 
   for (const current of group.panels) {
     if (!isSessionChatPanel(current)) {
@@ -42,23 +68,17 @@ function rewriteGroup(
 
     activeWasRewritten = activeWasRewritten || group.activePanel === current.id;
     if (!inserted.value) {
-      panels.push(target);
+      panels.push(...targets);
       inserted.value = true;
     }
   }
 
-  if (panels.length === 0) return null;
-  const activeStillExists = group.activePanel && panels.some((p) => p.id === group.activePanel);
-  const targetStillExists = panels.some((p) => p.id === target.id);
-  let activePanel = group.activePanel;
-
-  if (activeWasRewritten) {
-    activePanel = targetStillExists ? target.id : panels[0]?.id;
-  } else if (group.activePanel && !activeStillExists) {
-    activePanel = panels[0]?.id;
-  }
-
-  return { ...group, panels, activePanel };
+  if (panels.length === 0) return hadPanels ? null : { ...group, panels };
+  return {
+    ...group,
+    panels,
+    activePanel: rewrittenActivePanel(group, panels, targets, activeWasRewritten),
+  };
 }
 
 function collectGroupsFromTree(node: LayoutNode): LayoutGroup[] {
@@ -68,16 +88,16 @@ function collectGroupsFromTree(node: LayoutNode): LayoutGroup[] {
 
 function rewriteTreeNode(
   node: LayoutNode,
-  target: LayoutPanel,
+  targets: LayoutPanel[],
   inserted: { value: boolean },
 ): LayoutNode | null {
   if (node.type === "leaf") {
-    const group = rewriteGroup(node.group, target, inserted);
+    const group = rewriteGroup(node.group, targets, inserted);
     return group ? { ...node, group } : null;
   }
 
   const children = node.children
-    .map((child) => rewriteTreeNode(child, target, inserted))
+    .map((child) => rewriteTreeNode(child, targets, inserted))
     .filter((child): child is LayoutNode => child !== null);
   if (children.length === 0) return null;
   return { ...node, children };
@@ -85,11 +105,11 @@ function rewriteTreeNode(
 
 function rewriteColumn(
   column: LayoutColumn,
-  target: LayoutPanel,
+  targets: LayoutPanel[],
   inserted: { value: boolean },
 ): LayoutColumn | null {
   if (column.tree) {
-    const tree = rewriteTreeNode(column.tree, target, inserted);
+    const tree = rewriteTreeNode(column.tree, targets, inserted);
     if (!tree) return null;
     return { ...column, tree, groups: collectGroupsFromTree(tree) };
   }
@@ -99,27 +119,28 @@ function rewriteColumn(
   }
 
   const groups = column.groups
-    .map((group) => rewriteGroup(group, target, inserted))
+    .map((group) => rewriteGroup(group, targets, inserted))
     .filter((group): group is LayoutGroup => group !== null);
   if (groups.length === 0) return null;
   return { ...column, groups };
 }
 
-function rewriteReusableChatPanels(state: LayoutState, target: LayoutPanel): LayoutState {
+function rewriteReusableChatPanels(state: LayoutState, targets: LayoutPanel[]): LayoutState {
   const inserted = { value: false };
   const columns = state.columns
-    .map((column) => rewriteColumn(column, target, inserted))
+    .map((column) => rewriteColumn(column, targets, inserted))
     .filter((column): column is LayoutColumn => column !== null);
   return { columns };
 }
 
 export function normalizeReusableSessionPanels(state: LayoutState): LayoutState {
-  return rewriteReusableChatPanels(state, knownPanel(CHAT_PANEL_ID));
+  return rewriteReusableChatPanels(state, [knownPanel(CHAT_PANEL_ID)]);
 }
 
 export function materializeReusableChatPanel(
   state: LayoutState,
   activeSessionId: string | null,
+  currentSessionIds: string[] = [],
 ): LayoutState {
-  return rewriteReusableChatPanels(state, targetPanel(activeSessionId));
+  return rewriteReusableChatPanels(state, targetPanels(activeSessionId, currentSessionIds));
 }

--- a/apps/web/lib/state/layout-manager/session-panels.ts
+++ b/apps/web/lib/state/layout-manager/session-panels.ts
@@ -1,0 +1,125 @@
+import { panel as knownPanel } from "./constants";
+import type { LayoutColumn, LayoutGroup, LayoutNode, LayoutPanel, LayoutState } from "./types";
+
+const SESSION_PANEL_PREFIX = "session:";
+const CHAT_COMPONENT = "chat";
+const CHAT_PANEL_ID = "chat";
+
+export function isSessionChatPanel(panel: LayoutPanel): boolean {
+  return (
+    panel.component === CHAT_COMPONENT &&
+    (panel.id === CHAT_PANEL_ID || panel.id.startsWith(SESSION_PANEL_PREFIX))
+  );
+}
+
+function sessionPanel(sessionId: string): LayoutPanel {
+  return {
+    id: `${SESSION_PANEL_PREFIX}${sessionId}`,
+    component: CHAT_COMPONENT,
+    title: "Agent",
+    tabComponent: "sessionTab",
+    params: { sessionId },
+  };
+}
+
+function targetPanel(activeSessionId: string | null): LayoutPanel {
+  return activeSessionId ? sessionPanel(activeSessionId) : knownPanel(CHAT_PANEL_ID);
+}
+
+function rewriteGroup(
+  group: LayoutGroup,
+  target: LayoutPanel,
+  inserted: { value: boolean },
+): LayoutGroup | null {
+  let activeWasRewritten = false;
+  const panels: LayoutPanel[] = [];
+
+  for (const current of group.panels) {
+    if (!isSessionChatPanel(current)) {
+      panels.push(current);
+      continue;
+    }
+
+    activeWasRewritten = activeWasRewritten || group.activePanel === current.id;
+    if (!inserted.value) {
+      panels.push(target);
+      inserted.value = true;
+    }
+  }
+
+  if (panels.length === 0) return null;
+  const activeStillExists = group.activePanel && panels.some((p) => p.id === group.activePanel);
+  const targetStillExists = panels.some((p) => p.id === target.id);
+  let activePanel = group.activePanel;
+
+  if (activeWasRewritten) {
+    activePanel = targetStillExists ? target.id : panels[0]?.id;
+  } else if (group.activePanel && !activeStillExists) {
+    activePanel = panels[0]?.id;
+  }
+
+  return { ...group, panels, activePanel };
+}
+
+function collectGroupsFromTree(node: LayoutNode): LayoutGroup[] {
+  if (node.type === "leaf") return [node.group];
+  return node.children.flatMap(collectGroupsFromTree);
+}
+
+function rewriteTreeNode(
+  node: LayoutNode,
+  target: LayoutPanel,
+  inserted: { value: boolean },
+): LayoutNode | null {
+  if (node.type === "leaf") {
+    const group = rewriteGroup(node.group, target, inserted);
+    return group ? { ...node, group } : null;
+  }
+
+  const children = node.children
+    .map((child) => rewriteTreeNode(child, target, inserted))
+    .filter((child): child is LayoutNode => child !== null);
+  if (children.length === 0) return null;
+  return { ...node, children };
+}
+
+function rewriteColumn(
+  column: LayoutColumn,
+  target: LayoutPanel,
+  inserted: { value: boolean },
+): LayoutColumn | null {
+  if (column.tree) {
+    const tree = rewriteTreeNode(column.tree, target, inserted);
+    if (!tree) return null;
+    return { ...column, tree, groups: collectGroupsFromTree(tree) };
+  }
+
+  if (!Array.isArray(column.groups)) {
+    return column;
+  }
+
+  const groups = column.groups
+    .map((group) => rewriteGroup(group, target, inserted))
+    .filter((group): group is LayoutGroup => group !== null);
+  if (groups.length === 0) return null;
+  return { ...column, groups };
+}
+
+function rewriteReusableChatPanels(state: LayoutState, target: LayoutPanel): LayoutState {
+  const inserted = { value: false };
+  const columns = state.columns
+    .map((column) => rewriteColumn(column, target, inserted))
+    .filter((column): column is LayoutColumn => column !== null);
+  return { columns };
+}
+
+export function normalizeReusableSessionPanels(state: LayoutState): LayoutState {
+  return rewriteReusableChatPanels(state, knownPanel(CHAT_PANEL_ID));
+}
+
+export function materializeReusableChatPanel(
+  state: LayoutState,
+  activeSessionId: string | null,
+): LayoutState {
+  return rewriteReusableChatPanels(state, targetPanel(activeSessionId));
+}

--- a/apps/web/lib/state/layout-manager/session-panels.ts
+++ b/apps/web/lib/state/layout-manager/session-panels.ts
@@ -67,6 +67,8 @@ function rewriteGroup(
     }
 
     activeWasRewritten = activeWasRewritten || group.activePanel === current.id;
+    // Keep only the first reusable chat slot. Later chat/session slots are
+    // duplicate stale session tabs and should disappear with their group/column.
     if (!inserted.value) {
       panels.push(...targets);
       inserted.value = true;


### PR DESCRIPTION
Saved Dockview layouts could carry a stale task `session:<id>` panel, causing a chat-only layout like "Simple" to show another task's chat after apply. Reusable saved layouts now normalize chat panels on save/load and materialize them to the active session when applied.

## Important Changes

- Added reusable session-panel normalization for saved layout capture, default-layout sync, and custom layout apply.
- Reused stale-session replacement for legacy Dockview JSON layouts.
- Added unit and Playwright coverage for applying a stale chat-only saved layout to another task.

## Validation

- `make fmt`
- `node apps/web/scripts/generate-release-notes.mjs`
- `node apps/web/scripts/generate-changelog.mjs`
- `make typecheck`
- `make test`
- `make lint`
- `cd apps/web && pnpm e2e:run tests/layout/saved-layout-session-isolation.spec.ts`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1649?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->