### PR TITLE
fix: fail closed in ProfileReconciler.cleanupOrphans on empty registry

### DIFF
--- a/apps/backend/internal/agent/settings/controller/reconciler.go
+++ b/apps/backend/internal/agent/settings/controller/reconciler.go
@@ -62,8 +62,9 @@ func (r *ProfileReconciler) Run(ctx context.Context) error {
 		return fmt.Errorf("reconciler not fully configured")
 	}
 
-	// Orphan cleanup first: removed agents can't come back, regardless of
-	// probe state, so we can clean these unconditionally.
+	// Orphan cleanup first: removed agents can't come back, so we run this
+	// regardless of per-agent probe state (see cleanupOrphans for the
+	// fail-closed guard against a not-yet-populated registry).
 	r.cleanupOrphans(ctx)
 
 	// Walk enabled inference agents and reconcile each one.
@@ -82,10 +83,23 @@ func (r *ProfileReconciler) Run(ctx context.Context) error {
 // behind by the removed streamjson-based variants). The settings store keys
 // each DB agent by a UUID in `id`, with the registry-facing identifier stored
 // in `name` — we match against the registry on `name`.
+//
+// Fails closed on an empty enabled set: every built-in agent type hardcodes
+// Enabled() == true, so ListEnabled() returning zero agents can never
+// legitimately mean "every agent type was removed" — it means the registry
+// hasn't finished loading yet (boot race, a reload racing with
+// reconciliation, a discovery hiccup). Trusting that empty result as
+// authoritative soft-deletes every profile for every configured agent in a
+// single pass, which is exactly what happened in kdlbs/kandev#1652.
 func (r *ProfileReconciler) cleanupOrphans(ctx context.Context) {
-	enabled := make(map[string]struct{})
-	for _, ag := range r.registry.ListEnabled() {
+	enabledAgents := r.registry.ListEnabled()
+	enabled := make(map[string]struct{}, len(enabledAgents))
+	for _, ag := range enabledAgents {
 		enabled[ag.ID()] = struct{}{}
+	}
+	if len(enabled) == 0 {
+		r.log.Warn("orphan cleanup: skipping pass, registry reported zero enabled agents")
+		return
 	}
 
 	dbAgents, err := r.store.ListAgents(ctx)
@@ -93,6 +107,9 @@ func (r *ProfileReconciler) cleanupOrphans(ctx context.Context) {
 		r.log.Warn("orphan cleanup: list agents failed", zap.Error(err))
 		return
 	}
+	r.log.Info("orphan cleanup: starting pass",
+		zap.Int("enabled_agent_count", len(enabled)),
+		zap.Int("db_agent_count", len(dbAgents)))
 	for _, dbAgent := range dbAgents {
 		if _, ok := enabled[dbAgent.Name]; ok {
 			continue

--- a/apps/backend/internal/agent/settings/controller/reconciler_test.go
+++ b/apps/backend/internal/agent/settings/controller/reconciler_test.go
@@ -346,6 +346,41 @@ func TestProfileReconciler_CleansOrphanProfiles(t *testing.T) {
 	}
 }
 
+// TestProfileReconciler_DoesNotCleanOrphansWhenRegistryEmpty guards against
+// kdlbs/kandev#1652: a registry that hasn't finished loading yet (boot race,
+// a reload racing with reconciliation, a discovery hiccup) also reports zero
+// enabled agents via ListEnabled(), indistinguishable from "every agent type
+// was genuinely removed". Every built-in agent type hardcodes
+// Enabled() == true, so an empty enabled set can never legitimately mean the
+// latter. cleanupOrphans must fail closed and skip the whole pass instead of
+// soft-deleting every profile for every configured agent in one batch.
+func TestProfileReconciler_DoesNotCleanOrphansWhenRegistryEmpty(t *testing.T) {
+	st := newFakeStore()
+	// A previously-provisioned agent with a live profile, as if the app had
+	// booted normally before this reconciliation pass.
+	dbAgent := &models.Agent{Name: "claude-acp"}
+	_ = st.CreateAgent(context.Background(), dbAgent)
+	liveProfile := &models.AgentProfile{AgentID: dbAgent.ID, Name: "Sonnet 4.6", Model: "claude-sonnet"}
+	_ = st.CreateAgentProfile(context.Background(), liveProfile)
+
+	log, err := logger.NewLogger(logger.LoggingConfig{Level: "error", Format: "json"})
+	if err != nil {
+		t.Fatalf("logger: %v", err)
+	}
+	// Empty registry: nothing registered yet, modelling the transient
+	// not-ready state rather than a genuine removal of every agent type.
+	reg := registry.NewRegistry(log)
+	caps := &fakeCapReader{caps: map[string]hostutility.AgentCapabilities{}}
+	r := NewProfileReconciler(caps, reg, st, log)
+
+	if err := r.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(st.softDeleted) != 0 {
+		t.Fatalf("expected no profiles soft-deleted when registry reports zero enabled agents, got %v", st.softDeleted)
+	}
+}
+
 // newDiscoveryController builds a Controller with just the dependencies that
 // syncAgentFromDiscovery touches: the agent registry, the store, and a logger.
 func newDiscoveryController(t *testing.T, st *fakeStore, ag agents.Agent) *Controller {


### PR DESCRIPTION
`ProfileReconciler.cleanupOrphans` treated a registry reporting zero enabled agents as proof every agent type had been removed, soft-deleting every `agent_profiles` row across every configured agent type in one pass whenever `registry.ListEnabled()` raced empty at boot — this hit production twice within 24h with no user action (#1652). `cleanupOrphans` now fails closed and skips the whole pass when the enabled set is empty, and logs the enabled/DB agent counts at Info level so a recurrence is diagnosable from logs alone.

## Important Changes

- `cleanupOrphans` skips the orphan-cleanup pass entirely (zero deletions) when `registry.ListEnabled()` returns zero agents, instead of treating "nothing enabled" as "every configured agent was removed". Every built-in agent type hardcodes `Enabled() == true`, so an empty set can only mean the registry hasn't finished loading yet.
- Added an Info-level log line with the enabled/DB agent counts at the start of each pass, and a Warn line when the pass is skipped, for future diagnosability without DB forensics.

## Validation

- Added `TestProfileReconciler_DoesNotCleanOrphansWhenRegistryEmpty`; confirmed it reproduces the mass-deletion bug against the pre-fix code (`got [profile-1]`), then passes against the fix.
- `go test ./internal/agent/settings/controller/... -run TestProfileReconciler -v` — all 5 reconciler tests pass, including the existing `TestProfileReconciler_CleansOrphanProfiles` (genuine single-agent orphan cleanup still works).
- `make fmt`
- `make typecheck`
- `make test` (backend/web/cli/scripts) — green, except three pre-existing sandbox-only issues confirmed present on `main` before this change and unrelated to the touched files: `TestProcessRunnerCapturesOutput` (timing-sensitive subprocess test; reproduced identically via `git stash`), 3 web tests failing on `Promise.withResolvers` (sandbox has Node 20, repo requires Node ^24), and `opencode-code-review.test.sh` (sandbox is missing the `rg` binary).
- `make lint` (backend/web/harness) — 0 issues.

## Possible Improvements

Low risk: an early-return guard plus logging on an existing, single-call-site background pass; the non-empty-registry path (including genuine orphan cleanup) is unchanged and covered by existing tests. The incident report flagged an unconfirmed second gap — why incident 2's registry was empty without an observed process restart — which this fix doesn't identify, but it closes the blast radius regardless of the exact trigger, and the new Info-level logging gives visibility if it recurs.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.

Closes #1652


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1655?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

