### PR TITLE
chore: migrate codex acp package

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Connect Kandev to the tools your team already uses — pull issues into the kanb
 | Agent | Launch |
 |:-------:|:----------:|
 | **Claude Code** | `npx -y @agentclientprotocol/claude-agent-acp` |
-| **Codex** | `npx -y @zed-industries/codex-acp` |
+| **Codex** | `npx -y @agentclientprotocol/codex-acp` |
 | **GitHub Copilot** | `npx -y @github/copilot --acp` |
 | **Gemini CLI** | `npx -y @google/gemini-cli --acp` |
 | **Amp** | `npx -y amp-acp` |

--- a/apps/backend/internal/agent/agents/codex_acp.go
+++ b/apps/backend/internal/agent/agents/codex_acp.go
@@ -16,11 +16,7 @@ var codexACPLogoLight []byte
 //go:embed logos/codex_dark.svg
 var codexACPLogoDark []byte
 
-const codexACPPkg = "@zed-industries/codex-acp"
-
-// CodexACPSandboxDiskFullReadCLIFlag is the seeded cli_flags text for disk-full-read sandbox access.
-// Single quotes preserve inner JSON double-quotes through cliflags.Tokenise.
-const CodexACPSandboxDiskFullReadCLIFlag = `-c 'sandbox_permissions=["disk-full-read-access"]'`
+const codexACPPkg = "@agentclientprotocol/codex-acp"
 
 var (
 	_ Agent            = (*CodexACP)(nil)
@@ -28,40 +24,19 @@ var (
 	_ InferenceAgent   = (*CodexACP)(nil)
 )
 
-// CodexACP implements Agent for the Zed Industries codex-acp package.
-// It speaks the ACP protocol (JSON-RPC 2.0 over stdin/stdout) via a Rust binary
-// wrapping OpenAI Codex. Used for A/B comparison against the native Codex agent.
+// CodexACP implements Agent for the agentclientprotocol codex-acp package.
+// It speaks the ACP protocol (JSON-RPC 2.0 over stdin/stdout) via the Codex App
+// Server bridge. Used for A/B comparison against the native Codex agent.
 type CodexACP struct {
 	StandardPassthrough
 }
 
-// codexACPPermSettings seeds profile cli_flags for @zed-industries/codex-acp.
-// Values are passed as -c key=value overrides (see codex-acp --help and
-// https://developers.openai.com/codex/config-reference). Toggles default off;
-var codexACPPermSettings = map[string]PermissionSetting{
-	"config_approval_policy_never": {
-		Supported:    true,
-		Default:      false,
-		Label:        "Skip approval prompts (config)",
-		Description:  "-c approval_policy=never (allowed: untrusted, on-request, never, granular)",
-		ApplyMethod:  PermissionApplyMethodCLIFlag,
-		CLIFlag:      "-c",
-		CLIFlagValue: "approval_policy=never",
-	},
-	"config_sandbox_disk_full_read": {
-		Supported:    true,
-		Default:      false,
-		Label:        "Disk full read access (config)",
-		Description:  `-c sandbox_permissions=["disk-full-read-access"] (legacy list; prefer sandbox_mode in config.toml)`,
-		ApplyMethod:  PermissionApplyMethodCLIFlag,
-		CLIFlag:      "-c",
-		CLIFlagValue: `'sandbox_permissions=["disk-full-read-access"]'`,
-	},
-}
+var codexACPPermSettings = emptyPermSettings
 
 // codexPassthroughPermSettings maps passthrough-only toggles to @openai/codex CLI
-// flags. Not returned from PermissionSettings(): @zed-industries/codex-acp only
-// accepts -c/--config overrides; ACP auto-approve uses agentctl approval_policy.
+// flags. Not returned from PermissionSettings(): ACP auto-approve uses
+// agentctl approval_policy/session mode, while the @agentclientprotocol/codex-acp
+// server does not accept the old @zed-industries/codex-acp -c overrides.
 // The legacy --full-auto flag was removed; auto_approve uses --ask-for-approval never.
 var codexPassthroughPermSettings = map[string]PermissionSetting{
 	PermissionKeyAutoApprove: {
@@ -99,7 +74,7 @@ func (a *CodexACP) ID() string          { return "codex-acp" }
 func (a *CodexACP) Name() string        { return "Codex ACP Agent" }
 func (a *CodexACP) DisplayName() string { return "Codex" }
 func (a *CodexACP) Description() string {
-	return "OpenAI Codex coding agent using the ACP protocol via the Zed Industries bridge."
+	return "OpenAI Codex coding agent using the ACP protocol via the agentclientprotocol bridge."
 }
 func (a *CodexACP) Enabled() bool     { return true }
 func (a *CodexACP) DisplayOrder() int { return 2 }
@@ -188,8 +163,7 @@ func (a *CodexACP) LoginCommand() *LoginCommand {
 }
 
 // Install both the user-facing OpenAI codex CLI (which `codex login` runs
-// against) and the ACP bridge package — the bridge wraps codex internally
-// and depends on it being on PATH.
+// against) and the ACP bridge package.
 func (a *CodexACP) InstallScript() string {
 	return "npm install -g @openai/codex " + codexACPPkg
 }

--- a/apps/backend/internal/agent/agents/codex_acp_cliflags_test.go
+++ b/apps/backend/internal/agent/agents/codex_acp_cliflags_test.go
@@ -1,59 +1,12 @@
 package agents
 
-import (
-	"reflect"
-	"testing"
+import "testing"
 
-	"github.com/kandev/kandev/internal/agent/settings/cliflags"
-	"github.com/kandev/kandev/internal/agent/settings/models"
-)
-
-func TestCodexACP_CLIFlagTokenise(t *testing.T) {
-	t.Parallel()
-	cases := []struct {
-		name string
-		raw  string
-		want []string
-	}{
-		{
-			name: "approval_policy",
-			raw:  "-c approval_policy=never",
-			want: []string{"-c", "approval_policy=never"},
-		},
-		{
-			name: "sandbox_permissions",
-			raw:  CodexACPSandboxDiskFullReadCLIFlag,
-			want: []string{"-c", `sandbox_permissions=["disk-full-read-access"]`},
-		},
+func TestCodexACP_NoLegacyAdapterCLIFlags(t *testing.T) {
+	if _, ok := codexACPPermSettings["config_approval_policy_never"]; ok {
+		t.Fatal("codex-acp must not expose the old -c approval_policy flag")
 	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			got, err := cliflags.Tokenise(tc.raw)
-			if err != nil {
-				t.Fatalf("Tokenise: %v", err)
-			}
-			if !reflect.DeepEqual(got, tc.want) {
-				t.Fatalf("tokens = %#v, want %#v", got, tc.want)
-			}
-		})
-	}
-}
-
-func TestCodexACP_ResolveSeededCLIFlags_DefaultDisabled(t *testing.T) {
-	flags := make([]models.CLIFlag, 0, len(codexACPPermSettings))
-	for _, s := range codexACPPermSettings {
-		flagText := s.CLIFlag
-		if s.CLIFlagValue != "" {
-			flagText = s.CLIFlag + " " + s.CLIFlagValue
-		}
-		flags = append(flags, models.CLIFlag{Flag: flagText, Enabled: s.Default})
-	}
-	got, err := cliflags.Resolve(flags)
-	if err != nil {
-		t.Fatalf("Resolve: %v", err)
-	}
-	if got != nil {
-		t.Fatalf("expected no argv when defaults disabled, got %#v", got)
+	if _, ok := codexACPPermSettings["config_sandbox_disk_full_read"]; ok {
+		t.Fatal("codex-acp must not expose the old -c sandbox_permissions flag")
 	}
 }

--- a/apps/backend/internal/agent/agents/codex_acp_test.go
+++ b/apps/backend/internal/agent/agents/codex_acp_test.go
@@ -19,43 +19,13 @@ func TestCodexACPRuntimeNoLongerBindMountsHostHome(t *testing.T) {
 
 func TestCodexACP_PermissionSettings_CuratedConfigOverrides(t *testing.T) {
 	settings := NewCodexACP().PermissionSettings()
-	want := map[string]struct {
-		flagText  string
-		defaultOn bool
-	}{
-		"config_approval_policy_never": {
-			flagText: "-c approval_policy=never", defaultOn: false,
-		},
-		"config_sandbox_disk_full_read": {
-			flagText: CodexACPSandboxDiskFullReadCLIFlag, defaultOn: false,
-		},
-	}
-	if len(settings) != len(want) {
-		t.Fatalf("PermissionSettings() len = %d, want %d: %#v", len(settings), len(want), settings)
-	}
-	for key, spec := range want {
-		s, ok := settings[key]
-		if !ok {
-			t.Fatalf("missing %q in PermissionSettings()", key)
-		}
-		if !s.Supported || s.ApplyMethod != PermissionApplyMethodCLIFlag {
-			t.Fatalf("%q: unsupported or wrong apply method: %+v", key, s)
-		}
-		if s.Default != spec.defaultOn {
-			t.Fatalf("%q: Default=%v, want %v", key, s.Default, spec.defaultOn)
-		}
-		gotFlag := s.CLIFlag
-		if s.CLIFlagValue != "" {
-			gotFlag = s.CLIFlag + " " + s.CLIFlagValue
-		}
-		if gotFlag != spec.flagText {
-			t.Fatalf("%q: flag text %q, want %q", key, gotFlag, spec.flagText)
-		}
+	if len(settings) != 0 {
+		t.Fatalf("PermissionSettings() = %#v, want no Codex ACP CLI flags", settings)
 	}
 }
 
 func TestCodexACP_BuildCommand_NoCodexCLIFlags(t *testing.T) {
-	want := []string{"npx", "-y", codexACPPkg}
+	want := []string{"npx", "-y", "@agentclientprotocol/codex-acp"}
 	cmd := NewCodexACP().BuildCommand(CommandOptions{
 		PermissionValues: map[string]bool{PermissionKeyAutoApprove: true},
 	})

--- a/apps/backend/internal/agent/agents/helpers_catalog_test.go
+++ b/apps/backend/internal/agent/agents/helpers_catalog_test.go
@@ -26,12 +26,15 @@ func TestCatalogPermissionSettings_MergesCursorForce(t *testing.T) {
 	}
 }
 
-func TestCatalogPermissionSettings_MergesCodexCLIFlags(t *testing.T) {
+func TestCatalogPermissionSettings_CodexDoesNotExposeLegacyCLIFlags(t *testing.T) {
 	catalog := CatalogPermissionSettings(NewCodexACP())
-	if len(codexACPPermSettings) != 2 {
-		t.Fatalf("codexACPPermSettings len = %d, want 2", len(codexACPPermSettings))
+	if len(codexACPPermSettings) != 0 {
+		t.Fatalf("codexACPPermSettings len = %d, want 0", len(codexACPPermSettings))
 	}
-	if _, ok := catalog["config_approval_policy_never"]; !ok {
-		t.Fatal("missing codex config_approval_policy_never")
+	if _, ok := catalog["config_approval_policy_never"]; ok {
+		t.Fatal("codex catalog must not include old config_approval_policy_never CLI flag")
+	}
+	if catalog[PermissionKeyAutoApprove].ApplyMethod != PermissionApplyMethodAgentctlAutoApprove {
+		t.Fatal("codex auto_approve must be agentctl-managed")
 	}
 }

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_launch_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_launch_test.go
@@ -276,7 +276,7 @@ func TestConfigureAndStartAgent_DoesNotSendTaskDescriptionEnv(t *testing.T) {
 		TaskID:         "task-1",
 		SessionID:      "session-1",
 		AgentProfileID: "profile-1",
-		AgentCommand:   "npx -y @zed-industries/codex-acp",
+		AgentCommand:   "npx -y @agentclientprotocol/codex-acp",
 		WorkspacePath:  t.TempDir(),
 		Metadata: map[string]interface{}{
 			"runtime_env":      map[string]string{"KEEP_ME": "yes"},
@@ -289,7 +289,7 @@ func TestConfigureAndStartAgent_DoesNotSendTaskDescriptionEnv(t *testing.T) {
 	if err != nil {
 		t.Fatalf("configureAndStartAgent() error = %v", err)
 	}
-	if bootCommand != "npx -y @zed-industries/codex-acp" {
+	if bootCommand != "npx -y @agentclientprotocol/codex-acp" {
 		t.Fatalf("bootCommand = %q, want agent command", bootCommand)
 	}
 	if configuredEnv["KEEP_ME"] != "yes" {
@@ -311,7 +311,7 @@ func TestConfigureAndStartAgent_SpillsLargeWakePayloadEnv(t *testing.T) {
 		TaskID:         "task-1",
 		SessionID:      "session-1",
 		AgentProfileID: "profile-1",
-		AgentCommand:   "npx -y @zed-industries/codex-acp",
+		AgentCommand:   "npx -y @agentclientprotocol/codex-acp",
 		WorkspacePath:  workspace,
 		Metadata: map[string]interface{}{
 			"runtime_env": map[string]string{
@@ -388,7 +388,7 @@ func newConfigureCaptureAgentctlClient(t *testing.T, log *logger.Logger, capture
 			*captured = req.Env
 			_, _ = w.Write([]byte(`{"success":true}`))
 		case "/api/v1/start":
-			_, _ = w.Write([]byte(`{"success":true,"command":"npx -y @zed-industries/codex-acp"}`))
+			_, _ = w.Write([]byte(`{"success":true,"command":"npx -y @agentclientprotocol/codex-acp"}`))
 		default:
 			w.WriteHeader(http.StatusNotFound)
 		}

--- a/apps/backend/internal/agent/settings/controller/profile_crud_test.go
+++ b/apps/backend/internal/agent/settings/controller/profile_crud_test.go
@@ -61,30 +61,13 @@ func TestSeedCLIFlags_EmptyForAgentWithNoCurated(t *testing.T) {
 	}
 }
 
-// TestSeedCLIFlags_FromCodexACP seeds codex-acp -c config overrides (off by
-// default) and never @openai/codex passthrough flags like --ask-for-approval.
-func TestSeedCLIFlags_FromCodexACP(t *testing.T) {
+// TestSeedCLIFlags_EmptyForCodexACP verifies the new Codex ACP adapter does
+// not seed the old @zed-industries/codex-acp -c config overrides.
+func TestSeedCLIFlags_EmptyForCodexACP(t *testing.T) {
 	flags := seedCLIFlags(agents.NewCodexACP())
 
-	want := map[string]bool{
-		"-c approval_policy=never":                false,
-		agents.CodexACPSandboxDiskFullReadCLIFlag: false,
-	}
-	if len(flags) != len(want) {
-		t.Fatalf("expected %d seeded flags, got %d: %+v", len(want), len(flags), flags)
-	}
-	for _, f := range flags {
-		enabled, ok := want[f.Flag]
-		if !ok {
-			t.Errorf("unexpected seeded flag: %q", f.Flag)
-			continue
-		}
-		if f.Enabled != enabled {
-			t.Errorf("%q: Enabled=%v, want %v", f.Flag, f.Enabled, enabled)
-		}
-		if f.Description == "" {
-			t.Errorf("%q: missing Description", f.Flag)
-		}
+	if len(flags) != 0 {
+		t.Fatalf("expected no seeded flags for codex-acp, got %+v", flags)
 	}
 }
 

--- a/apps/web/e2e/tests/settings/agent-profile-acp.spec.ts
+++ b/apps/web/e2e/tests/settings/agent-profile-acp.spec.ts
@@ -5,7 +5,7 @@ import { SessionPage } from "../../pages/session-page";
  * Verifies the ACP-first profile editor:
  *
  * - Universal agentctl auto-approve toggle renders with danger styling.
- * - Codex curated `-c` config toggles render (off by default).
+ * - Codex does not render legacy Zed adapter `-c` config toggles.
  * - Profile name edits persist across reload (exercises the new AgentProfile
  *   DTO shape with `mode` / `migrated_from` columns).
  * - Mode picker renders when the agent's capability cache advertises modes.
@@ -38,10 +38,10 @@ test.describe("Agent profile — ACP-first", () => {
     if (agent.name === "codex-acp") {
       await expect(
         testPage.getByTestId("cli-flag-curated-config_approval_policy_never"),
-      ).toBeVisible();
+      ).toHaveCount(0);
       await expect(
         testPage.getByTestId("cli-flag-curated-config_sandbox_disk_full_read"),
-      ).toBeVisible();
+      ).toHaveCount(0);
     }
 
     // The mock agent advertises modes, so the mode picker is rendered.

--- a/docs/decisions/0034-agentclientprotocol-codex-acp-package.md
+++ b/docs/decisions/0034-agentclientprotocol-codex-acp-package.md
@@ -1,0 +1,23 @@
+# 0034: Agent Client Protocol Codex ACP Package
+
+**Status:** accepted
+**Date:** 2026-07-10
+**Area:** backend
+
+## Context
+Kandev launched Codex ACP through `@zed-industries/codex-acp`, the original Zed-maintained adapter package. By July 10, 2026, the Zed repository directs new installs to `agentclientprotocol/codex-acp`, and the npm package is deprecated in favor of `@agentclientprotocol/codex-acp`. The replacement package exposes the same `codex-acp` binary name, is maintained under the Agent Client Protocol organization, and includes a compatible `@openai/codex` dependency.
+
+## Decision
+Kandev launches Codex ACP with `npx -y @agentclientprotocol/codex-acp` from `apps/backend/internal/agent/agents/codex_acp.go`. Remote install scripts install both `@openai/codex` for the interactive `codex login --device-auth` flow and `@agentclientprotocol/codex-acp` for ACP sessions.
+
+The old Zed adapter-specific `-c` profile CLI flags are no longer seeded for Codex ACP profiles. The new adapter configures approval and sandbox behavior through ACP session modes and config options, not those legacy argv flags. Existing user-saved custom `cli_flags` rows remain user-owned and are not rewritten by this dependency migration.
+
+## Consequences
+New Codex ACP launches and documentation follow the maintained Agent Client Protocol package. New and backfilled Codex ACP profiles do not show stale `-c approval_policy=never` or `-c sandbox_permissions=...` entries.
+
+Kandev still keeps `@openai/codex` in the install script because the login UI invokes the user-facing `codex` binary directly. If Codex ACP later exposes a browserless login command with equivalent behavior, Kandev can revisit that separate install.
+
+## Alternatives Considered
+Continue using `@zed-industries/codex-acp`: rejected because its own repository and npm metadata point users to the Agent Client Protocol package for ongoing updates.
+
+Rewrite old profile CLI flags into `CODEX_CONFIG` or a default session mode: rejected for this migration because `cli_flags` are persisted as user-owned profile data, and translating enabled legacy flags into mode/config values could silently change profile behavior. Profile mode/config management should be handled by the ACP config-option path.

--- a/docs/decisions/INDEX.md
+++ b/docs/decisions/INDEX.md
@@ -37,5 +37,5 @@ Read individual ADRs for full context. Create new ones via `/record decision` or
 | 0029 | [Release backfill and desktop diagnostics](0029-release-backfill-and-desktop-diagnostics.md)                                        | accepted   | infra, workflow             | 2026-07-01 |
 | 0030 | [Workspace-scoped integration settings](0030-workspace-scoped-integration-settings.md)                                             | accepted   | backend, frontend           | 2026-07-01 |
 | 0031 | [Office skill reference files](0031-office-skill-reference-files.md)                                                                | accepted   | backend                     | 2026-07-06 |
-| 0032 | [Configurable worktree branch names](0032-configurable-worktree-branch-names.md)                                                    | accepted   | backend, frontend           | 2026-07-07 |
 | 0033 | [Durable plan implementation start marker](0033-durable-plan-implementation-start.md)                                               | accepted   | backend, frontend           | 2026-07-09 |
+| 0034 | [Agent Client Protocol Codex ACP package](0034-agentclientprotocol-codex-acp-package.md)                                            | accepted   | backend                     | 2026-07-10 |


### PR DESCRIPTION
Codex ACP was still launching through the deprecated Zed adapter package. The runtime now follows the maintained Agent Client Protocol package and avoids exposing stale Zed-only profile flags.

## Important Changes

- Codex ACP launch, runtime, inference, README docs, and lifecycle tests now use `@agentclientprotocol/codex-acp`.
- New Codex ACP profiles no longer seed legacy `-c` adapter flags because the new adapter configures approval and sandboxing through ACP modes/config options.
- ADR 0034 records the dependency-source decision and the choice not to rewrite user-owned saved `cli_flags`.

## Validation

- `make fmt`
- `make typecheck`
- `make test`
- `make lint`
- `go test ./internal/agent/agents ./internal/agent/settings/controller ./internal/agent/runtime/lifecycle -run 'TestCodexACP|TestCatalogPermissionSettings_Codex|TestSeedCLIFlags_EmptyForCodexACP|TestBuildAgentCommand|TestConfigureAndStartAgent|TestBuildContainerConfig_SessionDirIsKandevManagedForEveryAgent'`
- `pnpm e2e:run tests/settings/agent-profile-acp.spec.ts -- --grep "profile editor loads"`

## Possible Improvements

Low risk: existing user-saved custom Codex `cli_flags` are intentionally left untouched and can still be edited manually.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1658?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- kandev-preview-start -->
### Preview Environment

| | |
|---|---|
| **URL** | https://kandev-pr-1658-bwo7.sprites.app |
| **Commit** | `3ded084` |
| **Agent** | Mock agent |

> Updates automatically on each push. Destroyed when the PR is closed.
<!-- kandev-preview-end -->