### PR TITLE
fix: show pending-question icon in task lists without opening the task

### DIFF
--- a/apps/backend/internal/backendapp/boot_state.go
+++ b/apps/backend/internal/backendapp/boot_state.go
@@ -623,6 +623,11 @@ func (b bootStateBuilder) taskDTOsWithSessionInfo(ctx context.Context, tasks []*
 		b.logBootError("get task detail primary session info", err)
 		return taskDTOs(tasks)
 	}
+	pendingBySession, err := b.p.taskSvc.GetPendingActionsForWaitingSessions(ctx, primaryInfoByTask)
+	if err != nil {
+		b.logBootError("get task detail pending session actions", err)
+		pendingBySession = map[string]taskmodels.SessionPendingAction{}
+	}
 	result := make([]taskdto.TaskDTO, 0, len(tasks))
 	for _, task := range tasks {
 		if task == nil {
@@ -643,7 +648,7 @@ func (b bootStateBuilder) taskDTOsWithSessionInfo(ctx context.Context, tasks []*
 			sessionCount = &count
 		}
 		info := bootSessionInfo(primaryInfoByTask[task.ID])
-		result = append(result, taskdto.FromTaskWithSessionInfo(
+		taskDTO := taskdto.FromTaskWithSessionInfo(
 			task,
 			primarySessionID,
 			sessionCount,
@@ -654,7 +659,14 @@ func (b bootStateBuilder) taskDTOsWithSessionInfo(ctx context.Context, tasks []*
 			info.agentName,
 			info.workingDirectory,
 			info.sessionState,
-		))
+		)
+		if primary := primaryInfoByTask[task.ID]; primary != nil {
+			if action, ok := pendingBySession[primary.ID]; ok {
+				val := string(action)
+				taskDTO.PrimarySessionPendingAction = &val
+			}
+		}
+		result = append(result, taskDTO)
 	}
 	return result
 }

--- a/apps/backend/internal/backendapp/boot_state_routes.go
+++ b/apps/backend/internal/backendapp/boot_state_routes.go
@@ -540,21 +540,22 @@ func mapKanbanTaskState(task taskdto.TaskDTO) map[string]any {
 		})
 	}
 	return map[string]any{
-		"id":                  task.ID,
-		"workflowStepId":      task.WorkflowStepID,
-		"title":               task.Title,
-		"description":         task.Description,
-		"position":            task.Position,
-		"state":               task.State,
-		"repositoryId":        primaryRepositoryID,
-		"repositories":        repositories,
-		"primarySessionId":    task.PrimarySessionID,
-		"primarySessionState": task.PrimarySessionState,
-		"sessionCount":        task.SessionCount,
-		"reviewStatus":        nullString(string(task.ReviewStatus)),
-		"parentTaskId":        nullString(task.ParentID),
-		"updatedAt":           task.UpdatedAt,
-		"createdAt":           task.CreatedAt,
+		"id":                          task.ID,
+		"workflowStepId":              task.WorkflowStepID,
+		"title":                       task.Title,
+		"description":                 task.Description,
+		"position":                    task.Position,
+		"state":                       task.State,
+		"repositoryId":                primaryRepositoryID,
+		"repositories":                repositories,
+		"primarySessionId":            task.PrimarySessionID,
+		"primarySessionState":         task.PrimarySessionState,
+		"primarySessionPendingAction": task.PrimarySessionPendingAction,
+		"sessionCount":                task.SessionCount,
+		"reviewStatus":                nullString(string(task.ReviewStatus)),
+		"parentTaskId":                nullString(task.ParentID),
+		"updatedAt":                   task.UpdatedAt,
+		"createdAt":                   task.CreatedAt,
 	}
 }
 

--- a/apps/backend/internal/task/dto/dto.go
+++ b/apps/backend/internal/task/dto/dto.go
@@ -119,31 +119,36 @@ type EnvironmentDTO struct {
 }
 
 type TaskDTO struct {
-	ID                      string                 `json:"id"`
-	WorkspaceID             string                 `json:"workspace_id"`
-	WorkflowID              string                 `json:"workflow_id"`
-	WorkflowStepID          string                 `json:"workflow_step_id"`
-	Title                   string                 `json:"title"`
-	Description             string                 `json:"description"`
-	State                   v1.TaskState           `json:"state"`
-	Priority                string                 `json:"priority"`
-	Repositories            []TaskRepositoryDTO    `json:"repositories,omitempty"`
-	Position                int                    `json:"position"`
-	PrimarySessionID        *string                `json:"primary_session_id,omitempty"`
-	SessionCount            *int                   `json:"session_count,omitempty"`
-	ReviewStatus            models.ReviewStatus    `json:"review_status,omitempty"`
-	PrimaryExecutorID       *string                `json:"primary_executor_id,omitempty"`
-	PrimaryExecutorType     *string                `json:"primary_executor_type,omitempty"`
-	PrimaryExecutorName     *string                `json:"primary_executor_name,omitempty"`
-	PrimaryAgentName        *string                `json:"primary_agent_name,omitempty"`
-	PrimaryWorkingDirectory *string                `json:"primary_working_directory,omitempty"`
-	PrimarySessionState     *string                `json:"primary_session_state,omitempty"`
-	IsRemoteExecutor        bool                   `json:"is_remote_executor,omitempty"`
-	ParentID                string                 `json:"parent_id,omitempty"`
-	ArchivedAt              *time.Time             `json:"archived_at,omitempty"`
-	CreatedAt               time.Time              `json:"created_at"`
-	UpdatedAt               time.Time              `json:"updated_at"`
-	Metadata                map[string]interface{} `json:"metadata,omitempty"`
+	ID                      string              `json:"id"`
+	WorkspaceID             string              `json:"workspace_id"`
+	WorkflowID              string              `json:"workflow_id"`
+	WorkflowStepID          string              `json:"workflow_step_id"`
+	Title                   string              `json:"title"`
+	Description             string              `json:"description"`
+	State                   v1.TaskState        `json:"state"`
+	Priority                string              `json:"priority"`
+	Repositories            []TaskRepositoryDTO `json:"repositories,omitempty"`
+	Position                int                 `json:"position"`
+	PrimarySessionID        *string             `json:"primary_session_id,omitempty"`
+	SessionCount            *int                `json:"session_count,omitempty"`
+	ReviewStatus            models.ReviewStatus `json:"review_status,omitempty"`
+	PrimaryExecutorID       *string             `json:"primary_executor_id,omitempty"`
+	PrimaryExecutorType     *string             `json:"primary_executor_type,omitempty"`
+	PrimaryExecutorName     *string             `json:"primary_executor_name,omitempty"`
+	PrimaryAgentName        *string             `json:"primary_agent_name,omitempty"`
+	PrimaryWorkingDirectory *string             `json:"primary_working_directory,omitempty"`
+	PrimarySessionState     *string             `json:"primary_session_state,omitempty"`
+	// PrimarySessionPendingAction is set when the primary session is in
+	// WAITING_FOR_INPUT because it is blocked on a pending clarification or
+	// permission request ("clarification" | "permission"). Lets list surfaces
+	// show the "needs input" indicator without loading session messages.
+	PrimarySessionPendingAction *string                `json:"primary_session_pending_action,omitempty"`
+	IsRemoteExecutor            bool                   `json:"is_remote_executor,omitempty"`
+	ParentID                    string                 `json:"parent_id,omitempty"`
+	ArchivedAt                  *time.Time             `json:"archived_at,omitempty"`
+	CreatedAt                   time.Time              `json:"created_at"`
+	UpdatedAt                   time.Time              `json:"updated_at"`
+	Metadata                    map[string]interface{} `json:"metadata,omitempty"`
 
 	// Office extensions
 	AssigneeAgentProfileID string `json:"assignee_agent_profile_id,omitempty"`

--- a/apps/backend/internal/task/handlers/process_handlers_test.go
+++ b/apps/backend/internal/task/handlers/process_handlers_test.go
@@ -203,6 +203,9 @@ func (m *mockRepository) FindMessageByPendingIDAndQuestion(ctx context.Context, 
 func (m *mockRepository) FindPendingClarificationMessagesBySessionID(ctx context.Context, sessionID string) ([]*models.Message, error) {
 	return nil, nil
 }
+func (m *mockRepository) GetPendingSessionActions(ctx context.Context, sessionIDs []string) (map[string]models.SessionPendingAction, error) {
+	return map[string]models.SessionPendingAction{}, nil
+}
 func (m *mockRepository) UpdateMessage(ctx context.Context, message *models.Message) error {
 	return nil
 }

--- a/apps/backend/internal/task/handlers/task_http_handlers.go
+++ b/apps/backend/internal/task/handlers/task_http_handlers.go
@@ -106,6 +106,10 @@ func buildTaskDTOsWithSessionInfo(ctx context.Context, svc *service.Service, tas
 	if err != nil {
 		return nil, err
 	}
+	pendingBySession, err := svc.GetPendingActionsForWaitingSessions(ctx, primarySessionInfoMap)
+	if err != nil {
+		return nil, err
+	}
 	result := make([]dto.TaskDTO, 0, len(tasks))
 	for _, task := range tasks {
 		sessions := sessionsByTask[task.ID]
@@ -122,7 +126,7 @@ func buildTaskDTOsWithSessionInfo(ctx context.Context, svc *service.Service, tas
 			sessionCount = &n
 		}
 		si := extractSessionInfo(primarySessionInfoMap[task.ID])
-		result = append(result, dto.FromTaskWithSessionInfo(
+		taskDTO := dto.FromTaskWithSessionInfo(
 			task,
 			primarySessionID,
 			sessionCount,
@@ -133,9 +137,27 @@ func buildTaskDTOsWithSessionInfo(ctx context.Context, svc *service.Service, tas
 			si.agentName,
 			si.workingDirectory,
 			si.sessionState,
-		))
+		)
+		setPendingAction(&taskDTO, primarySessionInfoMap[task.ID], pendingBySession)
+		result = append(result, taskDTO)
 	}
 	return result, nil
+}
+
+// setPendingAction copies the primary session's blocking pending action (if
+// any) onto the DTO so list surfaces can flag "needs input" without messages.
+func setPendingAction(
+	taskDTO *dto.TaskDTO,
+	primarySession *models.TaskSession,
+	pendingBySession map[string]models.SessionPendingAction,
+) {
+	if primarySession == nil {
+		return
+	}
+	if action, ok := pendingBySession[primarySession.ID]; ok {
+		val := string(action)
+		taskDTO.PrimarySessionPendingAction = &val
+	}
 }
 
 type sessionInfoFields struct {

--- a/apps/backend/internal/task/models/models.go
+++ b/apps/backend/internal/task/models/models.go
@@ -646,6 +646,19 @@ const (
 	TaskSessionStateCancelled TaskSessionState = "CANCELLED"
 )
 
+// SessionPendingAction identifies the kind of request a WAITING_FOR_INPUT
+// session is blocked on. Denormalized onto task snapshots so list surfaces
+// (sidebar, kanban cards) can show the "needs input" indicator without
+// loading the session's messages.
+type SessionPendingAction string
+
+const (
+	// SessionPendingActionClarification - a clarification_request message is pending
+	SessionPendingActionClarification SessionPendingAction = "clarification"
+	// SessionPendingActionPermission - the latest permission_request message is pending
+	SessionPendingActionPermission SessionPendingAction = "permission"
+)
+
 // TaskSessionWorktree represents the association between a task session and a worktree
 type TaskSessionWorktree struct {
 	ID           string    `json:"id"`

--- a/apps/backend/internal/task/repository/interface.go
+++ b/apps/backend/internal/task/repository/interface.go
@@ -122,6 +122,10 @@ type MessageRepository interface {
 	FindMessagesByPendingID(ctx context.Context, pendingID string) ([]*models.Message, error)
 	FindMessageByPendingIDAndQuestion(ctx context.Context, sessionID, pendingID, questionID string) (*models.Message, error)
 	FindPendingClarificationMessagesBySessionID(ctx context.Context, sessionID string) ([]*models.Message, error)
+	// GetPendingSessionActions reports, per session, whether it is blocked on a
+	// pending clarification_request or permission_request message. Sessions with
+	// no blocking request are omitted from the result map.
+	GetPendingSessionActions(ctx context.Context, sessionIDs []string) (map[string]models.SessionPendingAction, error)
 	UpdateMessage(ctx context.Context, message *models.Message) error
 	ListMessages(ctx context.Context, sessionID string) ([]*models.Message, error)
 	ListMessagesByTurnID(ctx context.Context, turnID string) ([]*models.Message, error)

--- a/apps/backend/internal/task/repository/sqlite/message.go
+++ b/apps/backend/internal/task/repository/sqlite/message.go
@@ -504,3 +504,64 @@ func (r *Repository) CountToolCallMessagesBySession(ctx context.Context, session
 	}
 	return out, rows.Err()
 }
+
+// GetPendingSessionActions returns, for each session in `sessionIDs` that is
+// currently blocked on a request, which kind of request blocks it:
+// models.SessionPendingActionClarification when any clarification_request row
+// is still pending, otherwise models.SessionPendingActionPermission when the
+// session's latest permission_request row is still pending. Sessions with no
+// blocking request are omitted. Mirrors the web client's message-derived
+// indicator semantics (`hasPendingClarification` / `hasPendingPermissionRequest`):
+// an old pending permission row superseded by a newer decided one must not
+// count, hence latest-permission-wins rather than an EXISTS check.
+func (r *Repository) GetPendingSessionActions(ctx context.Context, sessionIDs []string) (map[string]models.SessionPendingAction, error) {
+	out := make(map[string]models.SessionPendingAction)
+	if len(sessionIDs) == 0 {
+		return out, nil
+	}
+	placeholders := make([]string, len(sessionIDs))
+	args := make([]interface{}, 0, len(sessionIDs))
+	for i, id := range sessionIDs {
+		placeholders[i] = "?"
+		args = append(args, id)
+	}
+	drv := r.ro.DriverName()
+	query := fmt.Sprintf(`SELECT task_session_id, type, COALESCE(%s, '') AS status
+	          FROM task_session_messages
+	          WHERE type IN ('clarification_request', 'permission_request')
+	            AND task_session_id IN (`+strings.Join(placeholders, ",")+`)
+	          ORDER BY created_at ASC, id ASC`, dialect.JSONExtract(drv, "metadata", "status"))
+	rows, err := r.ro.QueryxContext(ctx, r.ro.Rebind(query), args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	lastPermissionPending := make(map[string]bool)
+	for rows.Next() {
+		var sessionID, msgType, status string
+		if err := rows.Scan(&sessionID, &msgType, &status); err != nil {
+			return nil, err
+		}
+		pending := status == "" || status == "pending"
+		switch msgType {
+		case string(models.MessageTypeClarificationRequest):
+			if pending {
+				out[sessionID] = models.SessionPendingActionClarification
+			}
+		case string(models.MessageTypePermissionRequest):
+			// Rows are ordered by created_at, so the last row seen wins.
+			lastPermissionPending[sessionID] = pending
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	for sessionID, pending := range lastPermissionPending {
+		if pending {
+			if _, hasClarification := out[sessionID]; !hasClarification {
+				out[sessionID] = models.SessionPendingActionPermission
+			}
+		}
+	}
+	return out, nil
+}

--- a/apps/backend/internal/task/repository/sqlite/message_test.go
+++ b/apps/backend/internal/task/repository/sqlite/message_test.go
@@ -159,3 +159,73 @@ func TestCountToolCallMessagesBySession_Multi(t *testing.T) {
 		t.Errorf("s3 should be omitted (zero tool_call rows), got %d", got["s3"])
 	}
 }
+
+// insertMsgWithMetadata inserts a message row with an explicit metadata JSON
+// payload, so tests can control clarification/permission pending status.
+func insertMsgWithMetadata(t *testing.T, repo *Repository, id, sessionID, turnID, msgType, metadata string, ts time.Time) {
+	t.Helper()
+	_, err := repo.db.Exec(repo.db.Rebind(`
+		INSERT INTO task_session_messages
+			(id, task_session_id, task_id, turn_id, author_type, author_id, content, requests_input, type, metadata, created_at)
+		VALUES (?, ?, '', ?, 'agent', '', '', 0, ?, ?, ?)
+	`), id, sessionID, turnID, msgType, metadata, ts)
+	if err != nil {
+		t.Fatalf("insert message %s: %v", id, err)
+	}
+}
+
+func TestGetPendingSessionActions(t *testing.T) {
+	repo := newRepoForSessionTests(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	seedForMsgTest(t, repo, "task-P", "s-clar", "turn-1")
+	seedForMsgTest(t, repo, "task-P2", "s-perm", "turn-2")
+	seedForMsgTest(t, repo, "task-P3", "s-perm-decided", "turn-3")
+	seedForMsgTest(t, repo, "task-P4", "s-clar-answered", "turn-4")
+	seedForMsgTest(t, repo, "task-P5", "s-none", "turn-5")
+	seedForMsgTest(t, repo, "task-P6", "s-both", "turn-6")
+
+	// Pending clarification: metadata.status missing counts as pending.
+	insertMsgWithMetadata(t, repo, "m-c1", "s-clar", "turn-1", "clarification_request", `{}`, now)
+	// Latest permission pending → "permission".
+	insertMsgWithMetadata(t, repo, "m-p1", "s-perm", "turn-2", "permission_request", `{"status":"approved"}`, now)
+	insertMsgWithMetadata(t, repo, "m-p2", "s-perm", "turn-2", "permission_request", `{"status":"pending"}`, now.Add(time.Second))
+	// Latest permission decided → stale earlier pending row must NOT count.
+	insertMsgWithMetadata(t, repo, "m-pd1", "s-perm-decided", "turn-3", "permission_request", `{"status":"pending"}`, now)
+	insertMsgWithMetadata(t, repo, "m-pd2", "s-perm-decided", "turn-3", "permission_request", `{"status":"approved"}`, now.Add(time.Second))
+	// Answered clarification → no pending action.
+	insertMsgWithMetadata(t, repo, "m-ca1", "s-clar-answered", "turn-4", "clarification_request", `{"status":"answered"}`, now)
+	// Plain messages only → omitted.
+	insertMsgWithType(t, repo, "m-n1", "s-none", "turn-5", "message", now)
+	// Both pending → clarification wins.
+	insertMsgWithMetadata(t, repo, "m-b1", "s-both", "turn-6", "permission_request", `{"status":"pending"}`, now)
+	insertMsgWithMetadata(t, repo, "m-b2", "s-both", "turn-6", "clarification_request", `{"status":"pending"}`, now.Add(time.Second))
+
+	got, err := repo.GetPendingSessionActions(ctx, []string{
+		"s-clar", "s-perm", "s-perm-decided", "s-clar-answered", "s-none", "s-both",
+	})
+	if err != nil {
+		t.Fatalf("GetPendingSessionActions: %v", err)
+	}
+	want := map[string]models.SessionPendingAction{
+		"s-clar": models.SessionPendingActionClarification,
+		"s-perm": models.SessionPendingActionPermission,
+		"s-both": models.SessionPendingActionClarification,
+	}
+	if len(got) != len(want) {
+		t.Errorf("got %d entries (%v), want %d", len(got), got, len(want))
+	}
+	for sessionID, action := range want {
+		if got[sessionID] != action {
+			t.Errorf("%s = %q, want %q", sessionID, got[sessionID], action)
+		}
+	}
+
+	empty, err := repo.GetPendingSessionActions(ctx, nil)
+	if err != nil {
+		t.Fatalf("GetPendingSessionActions(nil): %v", err)
+	}
+	if len(empty) != 0 {
+		t.Errorf("expected empty map for no session ids, got %v", empty)
+	}
+}

--- a/apps/backend/internal/task/service/service_events.go
+++ b/apps/backend/internal/task/service/service_events.go
@@ -145,6 +145,7 @@ func (s *Service) addTaskSessionEventFields(ctx context.Context, taskID string, 
 	if !ok || sessionInfo == nil {
 		data["primary_session_id"] = nil
 		data["primary_session_state"] = nil
+		data["primary_session_pending_action"] = nil
 		return
 	}
 	data["primary_session_id"] = sessionInfo.ID
@@ -155,6 +156,14 @@ func (s *Service) addTaskSessionEventFields(ctx context.Context, taskID string, 
 		data["primary_session_state"] = string(sessionInfo.State)
 	} else {
 		data["primary_session_state"] = nil
+	}
+	// Explicit nil when there is no blocking request so WS consumers clear a
+	// previously-set pending indicator instead of keeping it stale.
+	data["primary_session_pending_action"] = nil
+	if pending, err := s.GetPendingActionsForWaitingSessions(ctx, primarySessionInfoMap); err == nil {
+		if action, ok := pending[sessionInfo.ID]; ok {
+			data["primary_session_pending_action"] = string(action)
+		}
 	}
 	if sessionInfo.ExecutorID != "" {
 		data["primary_executor_id"] = sessionInfo.ExecutorID

--- a/apps/backend/internal/task/service/service_messages.go
+++ b/apps/backend/internal/task/service/service_messages.go
@@ -268,6 +268,28 @@ func (s *Service) ListMessages(ctx context.Context, sessionID string) ([]*models
 	return s.messages.ListMessages(ctx, sessionID)
 }
 
+// GetPendingActionsForWaitingSessions returns the blocking pending action
+// (clarification/permission) per session ID for the subset of the given
+// sessions currently in WAITING_FOR_INPUT. Sessions in any other state are
+// skipped: a pending message row left behind by a crash must not flag a
+// session that has already moved on. Used to denormalize the "needs input"
+// indicator onto task snapshots (issue #1657).
+func (s *Service) GetPendingActionsForWaitingSessions(
+	ctx context.Context,
+	sessions map[string]*models.TaskSession,
+) (map[string]models.SessionPendingAction, error) {
+	ids := make([]string, 0, len(sessions))
+	for _, session := range sessions {
+		if session != nil && session.State == models.TaskSessionStateWaitingForInput {
+			ids = append(ids, session.ID)
+		}
+	}
+	if len(ids) == 0 {
+		return map[string]models.SessionPendingAction{}, nil
+	}
+	return s.messages.GetPendingSessionActions(ctx, ids)
+}
+
 // ListMessagesPaginated returns messages for a session with pagination options.
 func (s *Service) ListMessagesPaginated(ctx context.Context, req ListMessagesRequest) ([]*models.Message, bool, error) {
 	limit := req.Limit

--- a/apps/web/components/kanban-card-content.tsx
+++ b/apps/web/components/kanban-card-content.tsx
@@ -224,7 +224,7 @@ function KanbanCardActions({
   const storeApi = useAppStoreApi();
   const debugEnabled = isDebug();
   const effectiveMenuOpen = menuOpen || Boolean(isDeleting) || Boolean(isArchiving);
-  const hasPendingClarificationRequest = useTaskPendingClarification(task.primarySessionId);
+  const hasPendingClarificationRequest = useTaskPendingClarification(task);
   const showQuestionIcon = shouldUseQuestionTaskIcon(task.state, hasPendingClarificationRequest);
   const showRunningSpinner = shouldShowTaskRunningSpinner(task.state, task.primarySessionState);
   const storeWouldShowRunningSpinner =

--- a/apps/web/components/kanban/graph2-step-node.tsx
+++ b/apps/web/components/kanban/graph2-step-node.tsx
@@ -101,7 +101,7 @@ export function Graph2StepNode({
 }: Graph2StepNodeProps) {
   const router = useRouter();
   const [isHovered, setIsHovered] = useState(false);
-  const hasPendingClarificationRequest = useTaskPendingClarification(task.primarySessionId);
+  const hasPendingClarificationRequest = useTaskPendingClarification(task);
 
   if (phase === "past") return <PastNode step={step} />;
   if (phase === "future") return <FutureNode step={step} />;

--- a/apps/web/components/kanban/swimlane-graph-content.tsx
+++ b/apps/web/components/kanban/swimlane-graph-content.tsx
@@ -74,7 +74,7 @@ function DraggableTaskChip({
     id: task.id,
   });
   const isPreviewed = useAppStore((state) => state.kanbanPreviewedTaskId === task.id);
-  const hasPendingClarificationRequest = useTaskPendingClarification(task.primarySessionId);
+  const hasPendingClarificationRequest = useTaskPendingClarification(task);
   const statusIcon = getTaskStateIcon(task.state, "h-3 w-3", hasPendingClarificationRequest);
 
   return (
@@ -101,7 +101,7 @@ function DraggableTaskChip({
 }
 
 function TaskChipPreview({ task }: { task: Task }) {
-  const hasPendingClarificationRequest = useTaskPendingClarification(task.primarySessionId);
+  const hasPendingClarificationRequest = useTaskPendingClarification(task);
   const statusIcon = getTaskStateIcon(task.state, "h-3 w-3", hasPendingClarificationRequest);
   return (
     <div

--- a/apps/web/components/task/task-session-sidebar-aggregate.test.ts
+++ b/apps/web/components/task/task-session-sidebar-aggregate.test.ts
@@ -3,6 +3,7 @@ import {
   aggregateSidebarTasks,
   buildPendingFlags,
   readPendingFlags,
+  resolvePendingFlags,
   type SidebarStepInfo,
   type WorkflowSnapshotMap,
 } from "./task-session-sidebar-aggregate";
@@ -183,5 +184,54 @@ describe("buildPendingFlags / readPendingFlags", () => {
   it("returns all-false for a null/unknown session", () => {
     expect(readPendingFlags({}, null)).toEqual({ clarification: false, permission: false });
     expect(readPendingFlags({}, "missing")).toEqual({ clarification: false, permission: false });
+  });
+});
+
+describe("resolvePendingFlags", () => {
+  it("prefers message-derived flags once the session's messages are loaded", () => {
+    const flags = buildPendingFlags({ "sess-1": [makePermissionRequest("p1", "approved")] }, [
+      "sess-1",
+    ]);
+    // Snapshot claims a pending permission, but the loaded messages say it
+    // was approved — the live flags win.
+    expect(resolvePendingFlags(flags, "sess-1", "WAITING_FOR_INPUT", "permission")).toEqual({
+      clarification: false,
+      permission: false,
+    });
+  });
+
+  it("falls back to the snapshot pending action when messages are not loaded", () => {
+    const flags = buildPendingFlags({}, ["sess-1"]);
+    expect(resolvePendingFlags(flags, "sess-1", "WAITING_FOR_INPUT", "clarification")).toEqual({
+      clarification: true,
+      permission: false,
+    });
+    expect(resolvePendingFlags(flags, "sess-1", "WAITING_FOR_INPUT", "permission")).toEqual({
+      clarification: false,
+      permission: true,
+    });
+  });
+
+  it("ignores a stale snapshot flag when the session is no longer WAITING_FOR_INPUT", () => {
+    const flags = buildPendingFlags({}, ["sess-1"]);
+    expect(resolvePendingFlags(flags, "sess-1", "RUNNING", "clarification")).toEqual({
+      clarification: false,
+      permission: false,
+    });
+  });
+
+  it("shows nothing for a waiting session without a snapshot pending action", () => {
+    const flags = buildPendingFlags({}, ["sess-1"]);
+    expect(resolvePendingFlags(flags, "sess-1", "WAITING_FOR_INPUT", null)).toEqual({
+      clarification: false,
+      permission: false,
+    });
+  });
+
+  it("returns all-false without a session id", () => {
+    expect(resolvePendingFlags({}, null, "WAITING_FOR_INPUT", "clarification")).toEqual({
+      clarification: false,
+      permission: false,
+    });
   });
 });

--- a/apps/web/components/task/task-session-sidebar-aggregate.ts
+++ b/apps/web/components/task/task-session-sidebar-aggregate.ts
@@ -10,6 +10,7 @@ import {
  *  every streaming token that churns the messages map. */
 const pendingClarKey = (sessionId: string) => `${sessionId}#clar`;
 const pendingPermKey = (sessionId: string) => `${sessionId}#perm`;
+const messagesLoadedKey = (sessionId: string) => `${sessionId}#loaded`;
 
 export function buildPendingFlags(
   bySession: Record<string, Message[] | undefined>,
@@ -20,6 +21,7 @@ export function buildPendingFlags(
     const msgs = bySession[id];
     flags[pendingClarKey(id)] = hasPendingClarification(msgs);
     flags[pendingPermKey(id)] = hasPendingPermissionRequest(msgs);
+    flags[messagesLoadedKey(id)] = msgs !== undefined;
   }
   return flags;
 }
@@ -32,6 +34,38 @@ export function readPendingFlags(
   return {
     clarification: pendingFlags[pendingClarKey(sessionId)] ?? false,
     permission: pendingFlags[pendingPermKey(sessionId)] ?? false,
+  };
+}
+
+export type SessionPendingActionSnapshot = "clarification" | "permission" | null | undefined;
+
+/**
+ * Resolve the pending clarification/permission flags for a task row.
+ *
+ * Message-derived flags are authoritative once the session's messages are in
+ * the store (they update live on answer/approve). Before that — a fresh page
+ * load with the task never opened — they always read `false`, which used to
+ * make blocked tasks look done in the sidebar. Fall back to the
+ * `primary_session_pending_action` snapshot the backend denormalizes onto the
+ * task, gated on the session still being WAITING_FOR_INPUT so a stale
+ * snapshot flag self-clears as soon as the session state moves on.
+ */
+export function resolvePendingFlags(
+  pendingFlags: Record<string, boolean>,
+  sessionId: string | null | undefined,
+  sessionState: string | null | undefined,
+  snapshotPendingAction: SessionPendingActionSnapshot,
+): { clarification: boolean; permission: boolean } {
+  if (!sessionId) return { clarification: false, permission: false };
+  if (pendingFlags[messagesLoadedKey(sessionId)]) {
+    return readPendingFlags(pendingFlags, sessionId);
+  }
+  if (sessionState !== "WAITING_FOR_INPUT") {
+    return { clarification: false, permission: false };
+  }
+  return {
+    clarification: snapshotPendingAction === "clarification",
+    permission: snapshotPendingAction === "permission",
   };
 }
 

--- a/apps/web/components/task/task-session-sidebar.tsx
+++ b/apps/web/components/task/task-session-sidebar.tsx
@@ -25,7 +25,7 @@ import { getWebSocketClient } from "@/lib/ws/connection";
 import { useArchivedTaskState } from "./task-archived-context";
 import { useRepositories } from "@/hooks/domains/workspace/use-repositories";
 import { useWorkspacePRs } from "@/hooks/domains/github/use-task-pr";
-import { buildPendingFlags, readPendingFlags } from "./task-session-sidebar-aggregate";
+import { buildPendingFlags, resolvePendingFlags } from "./task-session-sidebar-aggregate";
 import { useGroupedSidebarView } from "./task-session-sidebar-grouped-view";
 import { useSidebarLinkActions } from "./task-session-sidebar-link-actions";
 import { buildArchivedSidebarItem } from "./task-session-sidebar-archived-item";
@@ -113,7 +113,12 @@ function toSidebarItem(
   const repoSlug = task.repositoryId ? ctx.repositorySlugById.get(task.repositoryId) : undefined;
   // Sidebar shows just one slot; pick the primary PR (first by created_at).
   const pr = ctx.taskPRsByTaskId[task.id]?.[0];
-  const pending = readPendingFlags(ctx.pendingFlags, task.primarySessionId);
+  const pending = resolvePendingFlags(
+    ctx.pendingFlags,
+    task.primarySessionId,
+    resolvedSessionState,
+    task.primarySessionPendingAction,
+  );
 
   const diffStats = resolveDiffStats(
     sessionInfo.diffStats,

--- a/apps/web/e2e/tests/task/sidebar-pending-question.spec.ts
+++ b/apps/web/e2e/tests/task/sidebar-pending-question.spec.ts
@@ -1,0 +1,98 @@
+/**
+ * Regression test for kdlbs/kandev#1657: the sidebar "waiting for input"
+ * question icon must show for a task blocked on an agent clarification even
+ * when the task has never been opened — i.e. purely from the task snapshot,
+ * without the session's messages in the store.
+ *
+ * The old behavior derived the icon exclusively from loaded messages, so on a
+ * fresh page load a blocked task was indistinguishable from a finished one
+ * until the user clicked it.
+ */
+import { test, expect } from "../../fixtures/test-base";
+import type { ApiClient } from "../../helpers/api-client";
+import { SessionPage } from "../../pages/session-page";
+
+async function waitForSessionWaitingForInput(
+  apiClient: ApiClient,
+  taskId: string,
+  message: string,
+): Promise<void> {
+  await expect
+    .poll(
+      async () => {
+        const { sessions } = await apiClient.listTaskSessions(taskId);
+        return sessions[0]?.state ?? "";
+      },
+      { timeout: 60_000, message },
+    )
+    .toBe("WAITING_FOR_INPUT");
+}
+
+test.describe("Sidebar pending-question indicator without opening the task", () => {
+  test("blocked task shows the question icon on a fresh page load; idle task does not", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    // A task whose agent parks on a pending clarification. Never navigated to,
+    // so its messages are never loaded client-side.
+    const blockedTask = await apiClient.createTaskWithAgent(
+      seedData.workspaceId,
+      "Blocked On Question",
+      seedData.agentProfileId,
+      {
+        description: "/e2e:clarification",
+        workflow_id: seedData.workflowId,
+        workflow_step_id: seedData.startStepId,
+        repository_ids: [seedData.repositoryId],
+      },
+    );
+
+    // A control task that finishes its turn normally — its session also ends
+    // at WAITING_FOR_INPUT, but with no pending request it must NOT alert.
+    const idleTask = await apiClient.createTaskWithAgent(
+      seedData.workspaceId,
+      "Finished Quietly",
+      seedData.agentProfileId,
+      {
+        description: "/e2e:simple-message",
+        workflow_id: seedData.workflowId,
+        workflow_step_id: seedData.startStepId,
+        repository_ids: [seedData.repositoryId],
+      },
+    );
+
+    await waitForSessionWaitingForInput(
+      apiClient,
+      blockedTask.id,
+      "blocked task session should park on the clarification",
+    );
+    await waitForSessionWaitingForInput(
+      apiClient,
+      idleTask.id,
+      "idle task session should finish its turn",
+    );
+
+    // Fresh page load on an unrelated task: both seeded tasks stay unopened,
+    // so their pending state can only come from the task snapshot.
+    const navTask = await apiClient.createTask(seedData.workspaceId, "Nav Task", {
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+    });
+    await testPage.goto(`/t/${navTask.id}`);
+    const session = new SessionPage(testPage);
+    await session.waitForLoad();
+    await expect(session.sidebar).toBeVisible({ timeout: 10_000 });
+
+    const blockedRow = session.sidebarTaskItem("Blocked On Question");
+    await expect(blockedRow).toBeVisible({ timeout: 10_000 });
+    await expect(blockedRow.getByTestId("task-state-waiting-for-input")).toBeVisible({
+      timeout: 10_000,
+    });
+
+    const idleRow = session.sidebarTaskItem("Finished Quietly");
+    await expect(idleRow).toBeVisible({ timeout: 10_000 });
+    await expect(idleRow.getByTestId("task-state-waiting-for-input")).toHaveCount(0);
+    await expect(idleRow.getByTestId("task-state-pending-permission")).toHaveCount(0);
+  });
+});

--- a/apps/web/hooks/use-task-pending-clarification.test.tsx
+++ b/apps/web/hooks/use-task-pending-clarification.test.tsx
@@ -32,33 +32,89 @@ function wrapper(messagesBySession: Record<string, Message[]> = {}) {
 
 describe("useTaskPendingClarification", () => {
   it("returns false when primarySessionId is null", () => {
-    const { result } = renderHook(() => useTaskPendingClarification(null), {
-      wrapper: wrapper(),
-    });
+    const { result } = renderHook(
+      () => useTaskPendingClarification({ primarySessionId: null }),
+      { wrapper: wrapper() },
+    );
 
     expect(result.current).toBe(false);
   });
 
-  it("returns false when the session has no messages in store", () => {
-    const { result } = renderHook(() => useTaskPendingClarification("session-1"), {
-      wrapper: wrapper(),
-    });
+  it("returns false when the session has no messages in store and no snapshot flag", () => {
+    const { result } = renderHook(
+      () => useTaskPendingClarification({ primarySessionId: "session-1" }),
+      { wrapper: wrapper() },
+    );
 
     expect(result.current).toBe(false);
   });
 
   it("returns true when the session has a pending clarification", () => {
-    const { result } = renderHook(() => useTaskPendingClarification("session-1"), {
-      wrapper: wrapper({
-        "session-1": [
-          message({
-            type: "clarification_request",
-            metadata: { status: "pending" },
-          }),
-        ],
-      }),
-    });
+    const { result } = renderHook(
+      () => useTaskPendingClarification({ primarySessionId: "session-1" }),
+      {
+        wrapper: wrapper({
+          "session-1": [
+            message({
+              type: "clarification_request",
+              metadata: { status: "pending" },
+            }),
+          ],
+        }),
+      },
+    );
 
     expect(result.current).toBe(true);
+  });
+
+  it("falls back to the snapshot pending action when messages are not loaded", () => {
+    const { result } = renderHook(
+      () =>
+        useTaskPendingClarification({
+          primarySessionId: "session-1",
+          primarySessionState: "WAITING_FOR_INPUT",
+          primarySessionPendingAction: "clarification",
+        }),
+      { wrapper: wrapper() },
+    );
+
+    expect(result.current).toBe(true);
+  });
+
+  it("ignores the snapshot flag when the session is no longer WAITING_FOR_INPUT", () => {
+    const { result } = renderHook(
+      () =>
+        useTaskPendingClarification({
+          primarySessionId: "session-1",
+          primarySessionState: "RUNNING",
+          primarySessionPendingAction: "clarification",
+        }),
+      { wrapper: wrapper() },
+    );
+
+    expect(result.current).toBe(false);
+  });
+
+  it("prefers loaded messages over a stale snapshot flag", () => {
+    const { result } = renderHook(
+      () =>
+        useTaskPendingClarification({
+          primarySessionId: "session-1",
+          primarySessionState: "WAITING_FOR_INPUT",
+          primarySessionPendingAction: "clarification",
+        }),
+      {
+        wrapper: wrapper({
+          "session-1": [
+            message({
+              type: "clarification_request",
+              metadata: { status: "answered" },
+            }),
+          ],
+        }),
+      },
+    );
+
+    expect(result.current).toBe(false);
   });
 });

--- a/apps/web/hooks/use-task-pending-clarification.ts
+++ b/apps/web/hooks/use-task-pending-clarification.ts
@@ -1,8 +1,28 @@
 import { useAppStore } from "@/components/state-provider";
 import { hasPendingClarificationForSession } from "@/lib/utils/pending-clarification";
 
-export function useTaskPendingClarification(primarySessionId: string | null | undefined): boolean {
-  return useAppStore((state) =>
-    hasPendingClarificationForSession(state.messages.bySession, primarySessionId),
-  );
+type TaskPendingSnapshot = {
+  primarySessionId?: string | null;
+  primarySessionState?: string | null;
+  primarySessionPendingAction?: "clarification" | "permission" | null;
+};
+
+/**
+ * Whether the task's primary session is blocked on a pending clarification.
+ * Message-derived state wins once the session's messages are loaded; until
+ * then (fresh page load, task never opened) fall back to the
+ * `primary_session_pending_action` snapshot the backend denormalizes onto the
+ * task, gated on the session still being WAITING_FOR_INPUT.
+ */
+export function useTaskPendingClarification(task: TaskPendingSnapshot): boolean {
+  const { primarySessionId, primarySessionState, primarySessionPendingAction } = task;
+  return useAppStore((state) => {
+    if (primarySessionId && state.messages.bySession[primarySessionId] !== undefined) {
+      return hasPendingClarificationForSession(state.messages.bySession, primarySessionId);
+    }
+    return (
+      primarySessionState === "WAITING_FOR_INPUT" &&
+      primarySessionPendingAction === "clarification"
+    );
+  });
 }

--- a/apps/web/lib/kanban/map-task.test.ts
+++ b/apps/web/lib/kanban/map-task.test.ts
@@ -133,4 +133,22 @@ describe("toKanbanTask — HTTP DTO / WS payload parity", () => {
     expect(toKanbanTask(http).isRemoteExecutor).toBe(false);
     expect(toKanbanTask(ws).isRemoteExecutor).toBe(false);
   });
+
+  it("maps primary_session_pending_action from both shapes; unknown values dropped", () => {
+    const pending = { primary_session_pending_action: "clarification" as const };
+    expect(toKanbanTask(httpDTO(pending)).primarySessionPendingAction).toBe("clarification");
+    expect(toKanbanTask(wsPayload(pending)).primarySessionPendingAction).toBe("clarification");
+    expect(
+      toKanbanTask(httpDTO({ primary_session_pending_action: "permission" }))
+        .primarySessionPendingAction,
+    ).toBe("permission");
+    // Explicit null (no blocking request) and unexpected values both map to undefined.
+    expect(
+      toKanbanTask(httpDTO({ primary_session_pending_action: null })).primarySessionPendingAction,
+    ).toBeUndefined();
+    expect(
+      toKanbanTask(httpDTO({ primary_session_pending_action: "bogus" }))
+        .primarySessionPendingAction,
+    ).toBeUndefined();
+  });
 });

--- a/apps/web/lib/kanban/map-task.ts
+++ b/apps/web/lib/kanban/map-task.ts
@@ -35,6 +35,7 @@ export type TaskLike = {
   repository_id?: string;
   primary_session_id?: string | null;
   primary_session_state?: TaskSessionState | string | null;
+  primary_session_pending_action?: "clarification" | "permission" | string | null;
   session_count?: number | null;
   review_status?: "pending" | "approved" | "changes_requested" | "rejected" | null;
   primary_executor_id?: string | null;
@@ -46,6 +47,11 @@ export type TaskLike = {
   created_at?: string;
   metadata?: Record<string, unknown> | null;
 };
+
+function pickPendingAction(source: TaskLike): "clarification" | "permission" | undefined {
+  const action = source.primary_session_pending_action;
+  return action === "clarification" || action === "permission" ? action : undefined;
+}
 
 function pickRepositoryId(source: TaskLike): string | undefined {
   return source.repository_id ?? source.repositories?.[0]?.repository_id ?? undefined;
@@ -86,6 +92,7 @@ export function toKanbanTask(source: TaskLike): KanbanTask {
     repositories: pickRepositories(source),
     primarySessionId: source.primary_session_id ?? undefined,
     primarySessionState: source.primary_session_state ?? undefined,
+    primarySessionPendingAction: pickPendingAction(source),
     sessionCount: source.session_count ?? undefined,
     reviewStatus: source.review_status ?? undefined,
     primaryExecutorId: source.primary_executor_id ?? undefined,

--- a/apps/web/lib/ssr/mapper.ts
+++ b/apps/web/lib/ssr/mapper.ts
@@ -45,6 +45,7 @@ export function snapshotToState(snapshot: WorkflowSnapshot): Partial<AppState> {
         })),
         primarySessionId: task.primary_session_id ?? undefined,
         primarySessionState: task.primary_session_state ?? undefined,
+        primarySessionPendingAction: task.primary_session_pending_action ?? undefined,
         sessionCount: task.session_count ?? undefined,
         reviewStatus: task.review_status ?? undefined,
         parentTaskId: task.parent_id ?? undefined,

--- a/apps/web/lib/state/slices/kanban/types.ts
+++ b/apps/web/lib/state/slices/kanban/types.ts
@@ -57,6 +57,7 @@ export type KanbanState = {
     }>;
     primarySessionId?: string | null;
     primarySessionState?: string | null;
+    primarySessionPendingAction?: "clarification" | "permission" | null;
     sessionCount?: number | null;
     reviewStatus?: "pending" | "approved" | "changes_requested" | "rejected" | null;
     primaryExecutorId?: string | null;

--- a/apps/web/lib/types/http.ts
+++ b/apps/web/lib/types/http.ts
@@ -147,6 +147,8 @@ export type TaskSessionState =
   | "FAILED"
   | "CANCELLED";
 
+export type SessionPendingAction = "clarification" | "permission";
+
 export type Workflow = {
   id: WorkflowId;
   workspace_id: WorkspaceId;
@@ -278,6 +280,10 @@ export type Task = {
   repositories?: TaskRepository[];
   primary_session_id?: SessionId | null;
   primary_session_state?: TaskSessionState | null;
+  /** Set when the primary session is blocked on a pending clarification or
+   *  permission request; lets list surfaces show the "needs input" indicator
+   *  without loading the session's messages. */
+  primary_session_pending_action?: SessionPendingAction | null;
   session_count?: number | null;
   review_status?: "pending" | "approved" | "changes_requested" | "rejected" | null;
   primary_executor_id?: string | null;

--- a/apps/web/lib/ws/handlers/tasks.ts
+++ b/apps/web/lib/ws/handlers/tasks.ts
@@ -42,6 +42,12 @@ function mergeTaskUpdate(
   ) {
     merged.primarySessionState = existing.primarySessionState;
   }
+  if (
+    !hasPayloadField(payload, "primary_session_pending_action") &&
+    nextTask.primarySessionPendingAction === undefined
+  ) {
+    merged.primarySessionPendingAction = existing.primarySessionPendingAction;
+  }
   return merged;
 }
 


### PR DESCRIPTION
A task blocked on an agent clarification/permission request looked identical to a finished one in the sidebar task list and on kanban cards until it was opened once, because the "needs input" indicator was derived exclusively from client-loaded messages; the backend now denormalizes the blocking state onto the task snapshot so list surfaces show the icon on a fresh page load.

## Important changes

- New `TaskDTO.primary_session_pending_action` (`"clarification" | "permission"`, omitted when none), computed by one batch query over `task_session_messages` (pending clarification wins, else latest-permission-wins — mirroring the web client's message-derived semantics). Only primary sessions currently in `WAITING_FOR_INPUT` are queried.
- Populated at the existing DTO assembly sites (task list/get + workflow/workspace snapshots via `buildTaskDTOsWithSessionInfo`, boot payload via `bootStateBuilder`) and in task lifecycle WS event payloads.
- Sidebar rows and kanban cards prefer the live message-derived pending flags once a session's messages are loaded, and fall back to the snapshot field otherwise — gated on `primarySessionState === "WAITING_FOR_INPUT"` so a stale snapshot flag self-clears when the session moves on. Sessions that finished a turn normally (also `WAITING_FOR_INPUT`, no pending request) keep the green check.

## Validation

- `go test ./internal/task/... ./internal/backendapp/...` — green, incl. a new repo test for `GetPendingSessionActions` (pending/missing status counts as pending, stale pending permission superseded by a decided one does not, clarification wins over permission).
- `cd apps/web && pnpm run typecheck` clean; `pnpm exec vitest run components/task lib/ssr lib/kanban lib/ws hooks src/boot-payload.test.ts` — 2287 tests green, incl. new cases for `resolvePendingFlags`, `useTaskPendingClarification`, and `toKanbanTask` field parity.
- New e2e spec `tests/task/sidebar-pending-question.spec.ts`: seeds a mock-agent `/e2e:clarification` task that is **never opened**, plus a quietly-finished control task, reloads on an unrelated task, and asserts the blocked row shows `task-state-waiting-for-input` while the control row does not. Verified it **fails on `main` without this fix** (icon absent) and passes with it.
- Neighboring specs re-run green: `chat/clarification.spec.ts`, `chat/permission-approval.spec.ts`, `kanban/kanban-board.spec.ts` (29 passed).

## Possible improvements

Low risk. The snapshot field is only refreshed with task lifecycle events, so a question that arrives while the page is already open still won't flag a never-opened task until a task event or reload; wiring `pending_action` into `session.state_changed` publishers would close that residual gap.

Closes #1657


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1662?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

