### PR TITLE
fix: clarify plan mode workflow guidance

### DIFF
--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -51,7 +51,9 @@ ci: add PR title linting workflow
 
 ## Steps
 
-**Create a task for each step below and mark them as completed as you go.**
+Track these steps with an internal todo/checklist and mark them complete as you go.
+Do not create, update, or delete Kandev subtasks for this workflow unless the user
+explicitly requests task tracking.
 
 1. **Understand changes:** Run `git status` and `git diff` to understand all changes. Review recent commits with `git log --oneline -10` to match project style.
 

--- a/.agents/skills/pr/SKILL.md
+++ b/.agents/skills/pr/SKILL.md
@@ -34,7 +34,9 @@ description: Commit, push, and create a PR. Default is ready-for-review with aut
 
 ## Steps
 
-**Create a task for each step below and mark them as completed as you go.**
+Track these steps with an internal todo/checklist and mark them complete as you go.
+Do not create, update, or delete Kandev subtasks for this workflow unless the user
+explicitly requests task tracking.
 
 1. **Uncommitted changes:** If there are dirty or staged changes, run `/commit` first (it runs `/verify` internally).
 

--- a/apps/web/components/settings/workflow-pipeline-editor-panels.tsx
+++ b/apps/web/components/settings/workflow-pipeline-editor-panels.tsx
@@ -407,7 +407,7 @@ function StepTransitionsSection({
             <Label htmlFor={`${step.id}-exit-disable-plan`} className="text-sm">
               Disable plan mode
             </Label>
-            <HelpTip text="Turn off plan mode when leaving this step." />
+            <HelpTip text="Keep plan mode on for every turn in this step, then turn it off only when the task moves to another step." />
           </div>
         </div>
       )}

--- a/apps/web/components/settings/workflow-pipeline-editor-step-actions.tsx
+++ b/apps/web/components/settings/workflow-pipeline-editor-step-actions.tsx
@@ -263,7 +263,7 @@ export function TurnCompleteSelect({
           <Label htmlFor={`${step.id}-disable-plan`} className="text-sm">
             Disable plan mode on complete
           </Label>
-          <HelpTip text="Turn off plan mode after the agent finishes this step." />
+          <HelpTip text="Turn off plan mode after the agent finishes a turn, even when the task remains in this step." />
         </div>
       )}
       {transitionType !== "none" && (


### PR DESCRIPTION
The workflow editor’s plan-mode options were easy to confuse because their helper text did not distinguish an agent turn from leaving a workflow step. The tooltips now explain the timing clearly, and the PR/commit skills use internal checklists instead of creating Kandev subtasks.

## Validation

- `make fmt`
- `node apps/web/scripts/generate-release-notes.mjs`
- `node apps/web/scripts/generate-changelog.mjs`
- `make typecheck`
- `make test`
- `make lint`
- Commit hooks: harness lint, Prettier, web lint, and Conventional Commits validation
- `git diff --check`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1666?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->