### PR TITLE
fix: prune orphaned task worktree repositories

### DIFF
--- a/apps/backend/internal/task/repository/interface.go
+++ b/apps/backend/internal/task/repository/interface.go
@@ -14,6 +14,7 @@ var ErrWorkspaceNameMismatch = repoerrors.ErrWorkspaceNameMismatch
 var ErrWorkspaceNotFound = repoerrors.ErrWorkspaceNotFound
 var ErrTaskNotFound = repoerrors.ErrTaskNotFound
 var ErrTaskPlanNotFound = repoerrors.ErrTaskPlanNotFound
+var ErrRepositoryNotFound = repoerrors.ErrRepositoryNotFound
 
 // WorkspaceRepository handles workspace CRUD.
 type WorkspaceRepository interface {

--- a/apps/backend/internal/task/repository/repoerrors/errors.go
+++ b/apps/backend/internal/task/repository/repoerrors/errors.go
@@ -14,3 +14,6 @@ var ErrTaskNotFound = errors.New("task not found")
 
 // ErrTaskPlanNotFound reports that no task plan row matched the supplied task id.
 var ErrTaskPlanNotFound = errors.New("task plan not found")
+
+// ErrRepositoryNotFound reports that no live repository row matched the supplied id.
+var ErrRepositoryNotFound = errors.New("repository not found")

--- a/apps/backend/internal/task/repository/sqlite/repository_entity.go
+++ b/apps/backend/internal/task/repository/sqlite/repository_entity.go
@@ -93,6 +93,37 @@ func (r *Repository) DeleteRepository(ctx context.Context, id string) error {
 	return nil
 }
 
+// DeleteRepositoryIfNoActiveTaskSessions soft-deletes a repository only when
+// no live task linked to it has a session that blocks deletion. Keeping the
+// predicate in the UPDATE prevents a session from becoming active between a
+// separate check and the delete.
+func (r *Repository) DeleteRepositoryIfNoActiveTaskSessions(ctx context.Context, id string) (bool, error) {
+	now := time.Now().UTC()
+	result, err := r.db.ExecContext(ctx, r.db.Rebind(`
+		UPDATE repositories
+		SET deleted_at = ?, updated_at = ?
+		WHERE id = ?
+			AND deleted_at IS NULL
+			AND NOT EXISTS (
+				SELECT 1
+				FROM task_sessions s
+				INNER JOIN task_repositories tr ON tr.task_id = s.task_id
+				INNER JOIN tasks t ON t.id = s.task_id
+				WHERE tr.repository_id = repositories.id
+					AND t.archived_at IS NULL
+					AND s.state IN ('CREATED', 'STARTING', 'RUNNING', 'IDLE', 'WAITING_FOR_INPUT')
+			)
+	`), now, now, id)
+	if err != nil {
+		return false, err
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return rows > 0, nil
+}
+
 // ListRepositories returns all repositories for a workspace
 func (r *Repository) ListRepositories(ctx context.Context, workspaceID string) ([]*models.Repository, error) {
 	rows, err := r.ro.QueryContext(ctx, r.ro.Rebind(`

--- a/apps/backend/internal/task/repository/sqlite/repository_entity.go
+++ b/apps/backend/internal/task/repository/sqlite/repository_entity.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/kandev/kandev/internal/db/dialect"
 	"github.com/kandev/kandev/internal/task/models"
+	"github.com/kandev/kandev/internal/task/repository/repoerrors"
 )
 
 // CreateRepository creates a new repository
@@ -49,7 +50,7 @@ func (r *Repository) GetRepository(ctx context.Context, id string) (*models.Repo
 	)
 
 	if err == sql.ErrNoRows {
-		return nil, fmt.Errorf("repository not found: %s", id)
+		return nil, fmt.Errorf("%w: %s", repoerrors.ErrRepositoryNotFound, id)
 	}
 	return repository, err
 }

--- a/apps/backend/internal/task/repository/sqlite/repository_entity_test.go
+++ b/apps/backend/internal/task/repository/sqlite/repository_entity_test.go
@@ -2,6 +2,7 @@ package sqlite
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 	"testing"
 
@@ -9,6 +10,7 @@ import (
 
 	"github.com/kandev/kandev/internal/db"
 	"github.com/kandev/kandev/internal/task/models"
+	"github.com/kandev/kandev/internal/task/repository/repoerrors"
 )
 
 func newRepoForEntityTests(t *testing.T) *Repository {
@@ -67,6 +69,14 @@ func TestRepositoryCopyFiles_RoundTrip(t *testing.T) {
 	}
 	if len(list) != 1 || list[0].CopyFiles != ".env, *.local" {
 		t.Errorf("ListRepositories CopyFiles = %v, want one repo with %q", list, ".env, *.local")
+	}
+}
+
+func TestGetRepositoryReturnsNotFoundError(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+	_, err := repo.GetRepository(context.Background(), "missing")
+	if !errors.Is(err, repoerrors.ErrRepositoryNotFound) {
+		t.Fatalf("GetRepository error = %v, want ErrRepositoryNotFound", err)
 	}
 }
 

--- a/apps/backend/internal/task/repository/sqlite/repository_entity_test.go
+++ b/apps/backend/internal/task/repository/sqlite/repository_entity_test.go
@@ -129,6 +129,39 @@ func TestRepositoryCopyFiles_DefaultEmpty(t *testing.T) {
 	}
 }
 
+func TestDeleteRepositoryIfNoActiveTaskSessions(t *testing.T) {
+	ctx := context.Background()
+
+	for _, tc := range []struct {
+		name    string
+		state   string
+		deleted bool
+	}{
+		{name: "completed session", state: "COMPLETED", deleted: true},
+		{name: "idle session", state: "IDLE", deleted: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := newRepoForEntityTests(t)
+			seedRepoLink(t, repo, "ws-1", "repo-1", "task-1", "session-1", tc.state)
+
+			deleted, err := repo.DeleteRepositoryIfNoActiveTaskSessions(ctx, "repo-1")
+			if err != nil {
+				t.Fatalf("DeleteRepositoryIfNoActiveTaskSessions: %v", err)
+			}
+			if deleted != tc.deleted {
+				t.Fatalf("deleted = %v, want %v", deleted, tc.deleted)
+			}
+			_, err = repo.GetRepository(ctx, "repo-1")
+			if tc.deleted && err == nil {
+				t.Fatal("deleted repository remains live")
+			}
+			if !tc.deleted && err != nil {
+				t.Fatalf("retained repository was deleted: %v", err)
+			}
+		})
+	}
+}
+
 // TestRunMigrations_Idempotent verifies that re-running migrations on an
 // already-migrated schema does not error (Apply swallows "duplicate column"
 // failures by design).

--- a/apps/backend/internal/task/repository/sqlite/session.go
+++ b/apps/backend/internal/task/repository/sqlite/session.go
@@ -940,13 +940,14 @@ func (r *Repository) FindActiveTaskSessionTaskIDByTaskEnvironmentExcludingTask(c
 func (r *Repository) HasActiveTaskSessionsByRepository(ctx context.Context, repositoryID string) (bool, error) {
 	var exists int
 	// Only sessions of live (non-archived) tasks count; archived tasks never
-	// block repository deletion.
+	// block repository deletion. IDLE office sessions are resumable and must
+	// preserve their repository rows.
 	err := r.ro.QueryRowContext(ctx, r.ro.Rebind(`
 		SELECT 1
 		FROM task_sessions s
 		INNER JOIN task_repositories tr ON tr.task_id = s.task_id
 		INNER JOIN tasks t ON t.id = s.task_id
-		WHERE s.state IN ('CREATED', 'STARTING', 'RUNNING', 'WAITING_FOR_INPUT')
+		WHERE s.state IN ('CREATED', 'STARTING', 'RUNNING', 'IDLE', 'WAITING_FOR_INPUT')
 			AND tr.repository_id = ?
 			AND t.archived_at IS NULL
 		LIMIT 1
@@ -959,14 +960,14 @@ func (r *Repository) HasActiveTaskSessionsByRepository(ctx context.Context, repo
 
 func (r *Repository) CountActiveTaskSessionsByRepository(ctx context.Context, repositoryID string) (int, error) {
 	var count int
-	// Counts only sessions of live (non-archived) tasks, matching
-	// HasActiveTaskSessionsByRepository.
+	// Counts only sessions of live (non-archived) tasks, including resumable
+	// IDLE sessions, matching HasActiveTaskSessionsByRepository.
 	err := r.ro.QueryRowContext(ctx, r.ro.Rebind(`
 		SELECT COUNT(*)
 		FROM task_sessions s
 		INNER JOIN task_repositories tr ON tr.task_id = s.task_id
 		INNER JOIN tasks t ON t.id = s.task_id
-		WHERE s.state IN ('CREATED', 'STARTING', 'RUNNING', 'WAITING_FOR_INPUT')
+		WHERE s.state IN ('CREATED', 'STARTING', 'RUNNING', 'IDLE', 'WAITING_FOR_INPUT')
 			AND tr.repository_id = ?
 			AND t.archived_at IS NULL
 	`), repositoryID).Scan(&count)

--- a/apps/backend/internal/task/repository/sqlite/session.go
+++ b/apps/backend/internal/task/repository/sqlite/session.go
@@ -940,7 +940,7 @@ func (r *Repository) FindActiveTaskSessionTaskIDByTaskEnvironmentExcludingTask(c
 func (r *Repository) HasActiveTaskSessionsByRepository(ctx context.Context, repositoryID string) (bool, error) {
 	var exists int
 	// Only sessions of live (non-archived) tasks count; archived tasks never
-	// block repository deletion. IDLE office sessions are resumable and must
+	// block repository deletion. IDLE sessions are resumable and must
 	// preserve their repository rows.
 	err := r.ro.QueryRowContext(ctx, r.ro.Rebind(`
 		SELECT 1

--- a/apps/backend/internal/task/repository/sqlite/session_test.go
+++ b/apps/backend/internal/task/repository/sqlite/session_test.go
@@ -478,8 +478,8 @@ func TestCountActiveTaskSessionsByRepository_NoSessions(t *testing.T) {
 }
 
 // TestCountActiveTaskSessionsByRepository_CountsActiveOnly verifies the join
-// counts sessions in active states (CREATED, STARTING, RUNNING,
-// WAITING_FOR_INPUT) and excludes sessions in terminal states.
+// counts sessions in active or resumable states (CREATED, STARTING, RUNNING,
+// IDLE, WAITING_FOR_INPUT) and excludes sessions in terminal states.
 func TestCountActiveTaskSessionsByRepository_CountsActiveOnly(t *testing.T) {
 	repo := newRepoForSessionTests(t)
 	ctx := context.Background()
@@ -487,6 +487,7 @@ func TestCountActiveTaskSessionsByRepository_CountsActiveOnly(t *testing.T) {
 	// Two active sessions across two tasks linked to the repo.
 	seedRepoLink(t, repo, "ws-a", "repo-a", "task-a1", "sess-a1", "RUNNING")
 	seedRepoLink(t, repo, "ws-a", "repo-a", "task-a2", "sess-a2", "WAITING_FOR_INPUT")
+	seedRepoLink(t, repo, "ws-a", "repo-a", "task-a4", "sess-a4", "IDLE")
 	// Terminal-state session linked to the repo — must NOT count.
 	seedRepoLink(t, repo, "ws-a", "repo-a", "task-a3", "sess-a3", "COMPLETED")
 	// Active session linked to a different repo — must NOT count.
@@ -496,8 +497,8 @@ func TestCountActiveTaskSessionsByRepository_CountsActiveOnly(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if count != 2 {
-		t.Errorf("expected 2 active sessions, got %d", count)
+	if count != 3 {
+		t.Errorf("expected 3 active or resumable sessions, got %d", count)
 	}
 }
 

--- a/apps/backend/internal/task/service/service_resources.go
+++ b/apps/backend/internal/task/service/service_resources.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -744,7 +745,32 @@ func (s *Service) DeleteRepository(ctx context.Context, id string) error {
 }
 
 func (s *Service) ListRepositories(ctx context.Context, workspaceID string) ([]*models.Repository, error) {
-	return s.repoEntities.ListRepositories(ctx, workspaceID)
+	repositories, err := s.repoEntities.ListRepositories(ctx, workspaceID)
+	if err != nil {
+		return nil, err
+	}
+
+	live := repositories[:0]
+	for _, repository := range repositories {
+		if repository == nil || repository.SourceType != sourceTypeLocal || !s.isKandevTaskWorktreeRepository(repository) {
+			live = append(live, repository)
+			continue
+		}
+		if _, statErr := os.Stat(repository.LocalPath); !errors.Is(statErr, os.ErrNotExist) {
+			live = append(live, repository)
+			continue
+		}
+		if err := s.DeleteRepository(ctx, repository.ID); err != nil {
+			if !errors.Is(err, ErrActiveTaskSessions) {
+				s.logger.Warn("failed to prune missing task worktree repository",
+					zap.String("repository_id", repository.ID),
+					zap.String("local_path", repository.LocalPath),
+					zap.Error(err))
+			}
+			live = append(live, repository)
+		}
+	}
+	return live, nil
 }
 
 // CountActiveSessionsByRepository returns the number of agent sessions in an

--- a/apps/backend/internal/task/service/service_resources.go
+++ b/apps/backend/internal/task/service/service_resources.go
@@ -782,8 +782,16 @@ func (s *Service) ListRepositories(ctx context.Context, workspaceID string) ([]*
 			s.publishRepositoryEvent(ctx, events.RepositoryDeleted, repository)
 			continue
 		}
-		if current, getErr := s.repoEntities.GetRepository(ctx, repository.ID); getErr == nil {
+		current, getErr := s.repoEntities.GetRepository(ctx, repository.ID)
+		if getErr == nil {
 			live = append(live, current)
+			continue
+		}
+		if !errors.Is(getErr, taskrepo.ErrRepositoryNotFound) {
+			s.logger.Warn("failed to re-read retained task worktree repository, using cached value",
+				zap.String("repository_id", repository.ID),
+				zap.Error(getErr))
+			live = append(live, repository)
 		}
 	}
 	return live, nil

--- a/apps/backend/internal/task/service/service_resources.go
+++ b/apps/backend/internal/task/service/service_resources.go
@@ -34,6 +34,10 @@ type workspaceDeleteTaskCleanup struct {
 	taskEnv     *models.TaskEnvironment
 }
 
+type repositorySessionPruner interface {
+	DeleteRepositoryIfNoActiveTaskSessions(ctx context.Context, id string) (bool, error)
+}
+
 // Workspace operations
 
 // CreateWorkspace creates a new workspace
@@ -750,7 +754,8 @@ func (s *Service) ListRepositories(ctx context.Context, workspaceID string) ([]*
 		return nil, err
 	}
 
-	live := repositories[:0]
+	live := make([]*models.Repository, 0, len(repositories))
+	pruner, canPrune := s.repoEntities.(repositorySessionPruner)
 	for _, repository := range repositories {
 		if repository == nil || repository.SourceType != sourceTypeLocal || !s.isKandevTaskWorktreeRepository(repository) {
 			live = append(live, repository)
@@ -760,14 +765,25 @@ func (s *Service) ListRepositories(ctx context.Context, workspaceID string) ([]*
 			live = append(live, repository)
 			continue
 		}
-		if err := s.DeleteRepository(ctx, repository.ID); err != nil {
-			if !errors.Is(err, ErrActiveTaskSessions) {
-				s.logger.Warn("failed to prune missing task worktree repository",
-					zap.String("repository_id", repository.ID),
-					zap.String("local_path", repository.LocalPath),
-					zap.Error(err))
-			}
+		if !canPrune {
 			live = append(live, repository)
+			continue
+		}
+		deleted, err := pruner.DeleteRepositoryIfNoActiveTaskSessions(ctx, repository.ID)
+		if err != nil {
+			s.logger.Warn("failed to prune missing task worktree repository",
+				zap.String("repository_id", repository.ID),
+				zap.String("local_path", repository.LocalPath),
+				zap.Error(err))
+			live = append(live, repository)
+			continue
+		}
+		if deleted {
+			s.publishRepositoryEvent(ctx, events.RepositoryDeleted, repository)
+			continue
+		}
+		if current, getErr := s.repoEntities.GetRepository(ctx, repository.ID); getErr == nil {
+			live = append(live, current)
 		}
 	}
 	return live, nil

--- a/apps/backend/internal/task/service/service_test.go
+++ b/apps/backend/internal/task/service/service_test.go
@@ -128,6 +128,140 @@ func createTestService(t *testing.T) (*Service, *MockEventBus, *sqliterepo.Repos
 	return svc, eventBus, repo
 }
 
+func TestService_ListRepositoriesPrunesMissingTaskWorktreeRepository(t *testing.T) {
+	svc, eventBus, repo := createTestService(t)
+	ctx := context.Background()
+	taskRoot := filepath.Join(t.TempDir(), "tasks")
+	svc.discoveryConfig.TaskWorktreeRoots = []string{taskRoot}
+
+	if err := repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws-1", Name: "Workspace"}); err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+	if err := repo.CreateRepository(ctx, &models.Repository{
+		ID:          "repo-orphaned-worktree",
+		WorkspaceID: "ws-1",
+		Name:        "orphaned-worktree",
+		SourceType:  sourceTypeLocal,
+		LocalPath:   filepath.Join(taskRoot, "deleted-task", "repo"),
+	}); err != nil {
+		t.Fatalf("CreateRepository: %v", err)
+	}
+
+	repositories, err := svc.ListRepositories(ctx, "ws-1")
+	if err != nil {
+		t.Fatalf("ListRepositories: %v", err)
+	}
+	if len(repositories) != 0 {
+		t.Fatalf("ListRepositories returned %d repositories, want orphan pruned", len(repositories))
+	}
+	if _, err := repo.GetRepository(ctx, "repo-orphaned-worktree"); err == nil {
+		t.Fatal("orphaned task worktree repository remains live")
+	}
+
+	events := eventBus.GetPublishedEvents()
+	if len(events) != 1 || events[0].Type != "repository.deleted" {
+		t.Fatalf("published events = %#v, want one repository.deleted event", events)
+	}
+}
+
+func TestService_ListRepositoriesPreservesExistingAndUserOwnedRepositories(t *testing.T) {
+	svc, eventBus, repo := createTestService(t)
+	ctx := context.Background()
+	testRoot := t.TempDir()
+	taskRoot := filepath.Join(testRoot, "tasks")
+	existingTaskWorktree := filepath.Join(taskRoot, "active-task", "repo")
+	if err := os.MkdirAll(existingTaskWorktree, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	svc.discoveryConfig.TaskWorktreeRoots = []string{taskRoot}
+
+	if err := repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws-1", Name: "Workspace"}); err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+	for _, repository := range []*models.Repository{
+		{
+			ID:          "repo-active-worktree",
+			WorkspaceID: "ws-1",
+			Name:        "active-worktree",
+			SourceType:  sourceTypeLocal,
+			LocalPath:   existingTaskWorktree,
+		},
+		{
+			ID:          "repo-user-owned",
+			WorkspaceID: "ws-1",
+			Name:        "user-owned",
+			SourceType:  sourceTypeLocal,
+			LocalPath:   filepath.Join(testRoot, "unmounted-user-repo"),
+		},
+	} {
+		if err := repo.CreateRepository(ctx, repository); err != nil {
+			t.Fatalf("CreateRepository(%s): %v", repository.ID, err)
+		}
+	}
+
+	repositories, err := svc.ListRepositories(ctx, "ws-1")
+	if err != nil {
+		t.Fatalf("ListRepositories: %v", err)
+	}
+	if len(repositories) != 2 {
+		t.Fatalf("ListRepositories returned %d repositories, want both preserved", len(repositories))
+	}
+	if events := eventBus.GetPublishedEvents(); len(events) != 0 {
+		t.Fatalf("published events = %#v, want none", events)
+	}
+}
+
+func TestService_ListRepositoriesPreservesMissingTaskWorktreeWithActiveSession(t *testing.T) {
+	svc, eventBus, repo := createTestService(t)
+	ctx := context.Background()
+	taskRoot := filepath.Join(t.TempDir(), "tasks")
+	svc.discoveryConfig.TaskWorktreeRoots = []string{taskRoot}
+
+	if err := repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws-1", Name: "Workspace"}); err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+	if err := repo.CreateRepository(ctx, &models.Repository{
+		ID:          "repo-active-session",
+		WorkspaceID: "ws-1",
+		Name:        "active-session",
+		SourceType:  sourceTypeLocal,
+		LocalPath:   filepath.Join(taskRoot, "active-task", "repo"),
+	}); err != nil {
+		t.Fatalf("CreateRepository: %v", err)
+	}
+	if err := repo.CreateTask(ctx, &models.Task{ID: "task-1", WorkspaceID: "ws-1", Title: "Task"}); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	if err := repo.CreateTaskRepository(ctx, &models.TaskRepository{
+		ID:           "task-repo-1",
+		TaskID:       "task-1",
+		RepositoryID: "repo-active-session",
+	}); err != nil {
+		t.Fatalf("CreateTaskRepository: %v", err)
+	}
+	if err := repo.CreateTaskSession(ctx, &models.TaskSession{
+		ID:     "session-1",
+		TaskID: "task-1",
+		State:  models.TaskSessionStateRunning,
+	}); err != nil {
+		t.Fatalf("CreateTaskSession: %v", err)
+	}
+
+	repositories, err := svc.ListRepositories(ctx, "ws-1")
+	if err != nil {
+		t.Fatalf("ListRepositories: %v", err)
+	}
+	if len(repositories) != 1 || repositories[0].ID != "repo-active-session" {
+		t.Fatalf("ListRepositories = %#v, want active repository preserved", repositories)
+	}
+	if _, err := repo.GetRepository(ctx, "repo-active-session"); err != nil {
+		t.Fatalf("active repository was deleted: %v", err)
+	}
+	if events := eventBus.GetPublishedEvents(); len(events) != 0 {
+		t.Fatalf("published events = %#v, want none", events)
+	}
+}
+
 // Task tests
 
 func TestService_CreateTask(t *testing.T) {

--- a/apps/backend/internal/task/service/service_test.go
+++ b/apps/backend/internal/task/service/service_test.go
@@ -211,7 +211,7 @@ func TestService_ListRepositoriesPreservesExistingAndUserOwnedRepositories(t *te
 	}
 }
 
-func TestService_ListRepositoriesPreservesMissingTaskWorktreeWithActiveSession(t *testing.T) {
+func TestService_ListRepositoriesPreservesMissingTaskWorktreeWithResumableSession(t *testing.T) {
 	svc, eventBus, repo := createTestService(t)
 	ctx := context.Background()
 	taskRoot := filepath.Join(t.TempDir(), "tasks")
@@ -247,19 +247,69 @@ func TestService_ListRepositoriesPreservesMissingTaskWorktreeWithActiveSession(t
 		t.Fatalf("CreateTaskSession: %v", err)
 	}
 
-	repositories, err := svc.ListRepositories(ctx, "ws-1")
-	if err != nil {
-		t.Fatalf("ListRepositories: %v", err)
-	}
-	if len(repositories) != 1 || repositories[0].ID != "repo-active-session" {
-		t.Fatalf("ListRepositories = %#v, want active repository preserved", repositories)
+	for _, state := range []models.TaskSessionState{
+		models.TaskSessionStateRunning,
+		models.TaskSessionStateIdle,
+	} {
+		t.Run(string(state), func(t *testing.T) {
+			if err := repo.UpdateTaskSessionState(ctx, "session-1", state, ""); err != nil {
+				t.Fatalf("UpdateTaskSessionState: %v", err)
+			}
+			repositories, err := svc.ListRepositories(ctx, "ws-1")
+			if err != nil {
+				t.Fatalf("ListRepositories: %v", err)
+			}
+			if len(repositories) != 1 || repositories[0].ID != "repo-active-session" {
+				t.Fatalf("ListRepositories = %#v, want resumable repository preserved", repositories)
+			}
+		})
 	}
 	if _, err := repo.GetRepository(ctx, "repo-active-session"); err != nil {
-		t.Fatalf("active repository was deleted: %v", err)
+		t.Fatalf("resumable repository was deleted: %v", err)
 	}
 	if events := eventBus.GetPublishedEvents(); len(events) != 0 {
 		t.Fatalf("published events = %#v, want none", events)
 	}
+}
+
+func TestService_ListRepositoriesPreservesRepositoryWhenPruningFails(t *testing.T) {
+	svc, eventBus, repo := createTestService(t)
+	ctx := context.Background()
+	taskRoot := filepath.Join(t.TempDir(), "tasks")
+	svc.discoveryConfig.TaskWorktreeRoots = []string{taskRoot}
+
+	if err := repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws-1", Name: "Workspace"}); err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+	if err := repo.CreateRepository(ctx, &models.Repository{
+		ID:          "repo-prune-error",
+		WorkspaceID: "ws-1",
+		Name:        "prune-error",
+		SourceType:  sourceTypeLocal,
+		LocalPath:   filepath.Join(taskRoot, "deleted-task", "repo"),
+	}); err != nil {
+		t.Fatalf("CreateRepository: %v", err)
+	}
+	svc.repoEntities = failingPruneRepository{RepositoryEntityRepository: repo}
+
+	repositories, err := svc.ListRepositories(ctx, "ws-1")
+	if err != nil {
+		t.Fatalf("ListRepositories: %v", err)
+	}
+	if len(repositories) != 1 || repositories[0].ID != "repo-prune-error" {
+		t.Fatalf("ListRepositories = %#v, want repository preserved", repositories)
+	}
+	if events := eventBus.GetPublishedEvents(); len(events) != 0 {
+		t.Fatalf("published events = %#v, want none", events)
+	}
+}
+
+type failingPruneRepository struct {
+	repository.RepositoryEntityRepository
+}
+
+func (failingPruneRepository) DeleteRepositoryIfNoActiveTaskSessions(context.Context, string) (bool, error) {
+	return false, errors.New("database unavailable")
 }
 
 // Task tests

--- a/apps/backend/internal/task/service/service_test.go
+++ b/apps/backend/internal/task/service/service_test.go
@@ -304,12 +304,56 @@ func TestService_ListRepositoriesPreservesRepositoryWhenPruningFails(t *testing.
 	}
 }
 
+func TestService_ListRepositoriesPreservesRepositoryWhenRetainedRowReadFails(t *testing.T) {
+	svc, eventBus, repo := createTestService(t)
+	ctx := context.Background()
+	taskRoot := filepath.Join(t.TempDir(), "tasks")
+	svc.discoveryConfig.TaskWorktreeRoots = []string{taskRoot}
+
+	if err := repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws-1", Name: "Workspace"}); err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+	if err := repo.CreateRepository(ctx, &models.Repository{
+		ID:          "repo-read-error",
+		WorkspaceID: "ws-1",
+		Name:        "read-error",
+		SourceType:  sourceTypeLocal,
+		LocalPath:   filepath.Join(taskRoot, "active-task", "repo"),
+	}); err != nil {
+		t.Fatalf("CreateRepository: %v", err)
+	}
+	svc.repoEntities = retainedRepositoryReadError{RepositoryEntityRepository: repo}
+
+	repositories, err := svc.ListRepositories(ctx, "ws-1")
+	if err != nil {
+		t.Fatalf("ListRepositories: %v", err)
+	}
+	if len(repositories) != 1 || repositories[0].ID != "repo-read-error" {
+		t.Fatalf("ListRepositories = %#v, want repository preserved", repositories)
+	}
+	if events := eventBus.GetPublishedEvents(); len(events) != 0 {
+		t.Fatalf("published events = %#v, want none", events)
+	}
+}
+
 type failingPruneRepository struct {
 	repository.RepositoryEntityRepository
 }
 
 func (failingPruneRepository) DeleteRepositoryIfNoActiveTaskSessions(context.Context, string) (bool, error) {
 	return false, errors.New("database unavailable")
+}
+
+type retainedRepositoryReadError struct {
+	repository.RepositoryEntityRepository
+}
+
+func (retainedRepositoryReadError) DeleteRepositoryIfNoActiveTaskSessions(context.Context, string) (bool, error) {
+	return false, nil
+}
+
+func (retainedRepositoryReadError) GetRepository(context.Context, string) (*models.Repository, error) {
+	return nil, errors.New("database unavailable")
 }
 
 // Task tests


### PR DESCRIPTION
Prevents deleted Kandev task worktrees from remaining selectable as repositories by pruning only definitively missing managed paths while preserving active sessions and user-owned paths.

## Validation

- `make fmt`
- `make typecheck`
- `make test`
- `make lint`

Closes #1665

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1667?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->