### PR TITLE
feat: link GitHub issues to tasks (#1672)

### DIFF
--- a/apps/backend/internal/github/controller.go
+++ b/apps/backend/internal/github/controller.go
@@ -41,6 +41,7 @@ func (c *Controller) RegisterHTTPRoutes(router *gin.Engine) {
 	api.GET("/task-prs", c.httpListTaskPRs)
 	api.POST("/task-prs", c.httpCreateTaskPR)
 	api.GET("/task-prs/:taskId", c.httpGetTaskPR)
+	api.GET("/task-issues", c.httpListTaskIssues)
 	api.PUT("/tasks/:taskId/issue", c.httpLinkTaskIssue)
 	api.DELETE("/tasks/:taskId/issue", c.httpUnlinkTaskIssue)
 	api.GET("/tasks/:taskId/ci-options", c.httpGetTaskCIOptions)
@@ -204,6 +205,20 @@ func (c *Controller) httpGetTaskPR(ctx *gin.Context) {
 		return
 	}
 	ctx.JSON(http.StatusOK, tp)
+}
+
+func (c *Controller) httpListTaskIssues(ctx *gin.Context) {
+	workspaceID := ctx.Query("workspace_id")
+	if workspaceID == "" {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "workspace_id query parameter required"})
+		return
+	}
+	result, err := c.service.ListWorkspaceTaskIssues(ctx.Request.Context(), workspaceID)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	ctx.JSON(http.StatusOK, gin.H{"task_issues": result})
 }
 
 func (c *Controller) httpLinkTaskIssue(ctx *gin.Context) {

--- a/apps/backend/internal/github/controller_test.go
+++ b/apps/backend/internal/github/controller_test.go
@@ -227,6 +227,15 @@ func TestHttpListTaskIssues_WorkspaceScopedMetadataLinks(t *testing.T) {
 			t.Fatalf("insert task %s: %v", row.id, err)
 		}
 	}
+	if _, err := store.db.Exec(
+		`INSERT INTO tasks (id, workspace_id, title, metadata, archived_at) VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)`,
+		"archived-task",
+		"ws-1",
+		"Archived issue task",
+		`{"issue_url":"https://github.com/kdlbs/kandev/issues/1672","issue_number":1672}`,
+	); err != nil {
+		t.Fatalf("insert archived task: %v", err)
+	}
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/github/task-issues?workspace_id=ws-1", nil)
 	w := httptest.NewRecorder()
@@ -248,6 +257,9 @@ func TestHttpListTaskIssues_WorkspaceScopedMetadataLinks(t *testing.T) {
 	}
 	if len(got.TaskIssues) != 2 {
 		t.Fatalf("task issue count = %d, want 2: %+v", len(got.TaskIssues), got.TaskIssues)
+	}
+	if _, ok := got.TaskIssues["archived-task"]; ok {
+		t.Fatalf("archived task should not be listed: %+v", got.TaskIssues)
 	}
 	manual := got.TaskIssues["manual-task"]
 	if manual.TaskTitle != "Manual issue task" || manual.Owner != "kdlbs" ||

--- a/apps/backend/internal/github/controller_test.go
+++ b/apps/backend/internal/github/controller_test.go
@@ -163,7 +163,14 @@ func setupControllerStoreTest(t *testing.T) (*gin.Engine, *Store) {
 	}
 	sqlxDB := sqlx.NewDb(dbConn, "sqlite3")
 	t.Cleanup(func() { _ = sqlxDB.Close() })
-	if _, err := sqlxDB.Exec(`CREATE TABLE tasks (id TEXT PRIMARY KEY, workspace_id TEXT, archived_at DATETIME)`); err != nil {
+	if _, err := sqlxDB.Exec(`CREATE TABLE tasks (
+		id TEXT PRIMARY KEY,
+		workspace_id TEXT,
+		title TEXT NOT NULL DEFAULT '',
+		metadata TEXT NOT NULL DEFAULT '{}',
+		created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		archived_at DATETIME
+	)`); err != nil {
 		t.Fatalf("create tasks table: %v", err)
 	}
 	store, err := NewStore(sqlxDB, sqlxDB)
@@ -177,6 +184,91 @@ func setupControllerStoreTest(t *testing.T) (*gin.Engine, *Store) {
 	router := gin.New()
 	ctrl.RegisterHTTPRoutes(router)
 	return router, store
+}
+
+func TestHttpListTaskIssues_WorkspaceScopedMetadataLinks(t *testing.T) {
+	router, store := setupControllerStoreTest(t)
+	rows := []struct {
+		id          string
+		workspaceID string
+		title       string
+		metadata    string
+	}{
+		{
+			id:          "manual-task",
+			workspaceID: "ws-1",
+			title:       "Manual issue task",
+			metadata:    `{"issue_url":"https://github.com/kdlbs/kandev/issues/1672","issue_number":1672,"issue_owner":"kdlbs","issue_repo":"kandev","github_issue_linked":true}`,
+		},
+		{
+			id:          "watch-task",
+			workspaceID: "ws-1",
+			title:       "Watched issue task",
+			metadata:    `{"issue_url":"https://github.com/kdlbs/kandev/issues/1672","issue_number":1672,"issue_repo":"kdlbs/kandev","issue_watch_id":"watch-1"}`,
+		},
+		{
+			id:          "other-workspace",
+			workspaceID: "ws-2",
+			title:       "Hidden task",
+			metadata:    `{"issue_url":"https://github.com/kdlbs/kandev/issues/1672","issue_number":1672}`,
+		},
+		{
+			id:          "invalid-metadata",
+			workspaceID: "ws-1",
+			title:       "Invalid task",
+			metadata:    `{"issue_url":"https://gitlab.com/kdlbs/kandev/issues/1672","issue_number":1672}`,
+		},
+	}
+	for _, row := range rows {
+		if _, err := store.db.Exec(
+			`INSERT INTO tasks (id, workspace_id, title, metadata) VALUES (?, ?, ?, ?)`,
+			row.id, row.workspaceID, row.title, row.metadata,
+		); err != nil {
+			t.Fatalf("insert task %s: %v", row.id, err)
+		}
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/github/task-issues?workspace_id=ws-1", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", w.Code, w.Body.String())
+	}
+	type listedTaskIssue struct {
+		TaskTitle   string `json:"task_title"`
+		Owner       string `json:"owner"`
+		Repo        string `json:"repo"`
+		IssueNumber int    `json:"issue_number"`
+	}
+	var got struct {
+		TaskIssues map[string]listedTaskIssue `json:"task_issues"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&got); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(got.TaskIssues) != 2 {
+		t.Fatalf("task issue count = %d, want 2: %+v", len(got.TaskIssues), got.TaskIssues)
+	}
+	manual := got.TaskIssues["manual-task"]
+	if manual.TaskTitle != "Manual issue task" || manual.Owner != "kdlbs" ||
+		manual.Repo != "kandev" || manual.IssueNumber != 1672 {
+		t.Fatalf("unexpected manual link: %+v", manual)
+	}
+	watch := got.TaskIssues["watch-task"]
+	if watch.TaskTitle != "Watched issue task" || watch.Owner != manual.Owner ||
+		watch.Repo != manual.Repo || watch.IssueNumber != manual.IssueNumber {
+		t.Fatalf("unexpected watch link: %+v", watch)
+	}
+}
+
+func TestHttpListTaskIssues_RequiresWorkspace(t *testing.T) {
+	router, _ := setupControllerStoreTest(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/github/task-issues", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", w.Code, w.Body.String())
+	}
 }
 
 func TestHttpTriggerReviewWatchPublishesNewPREvents(t *testing.T) {

--- a/apps/backend/internal/github/mock_client.go
+++ b/apps/backend/internal/github/mock_client.go
@@ -227,22 +227,38 @@ func (m *MockClient) ListReviewRequestedPRs(context.Context, string, string, str
 	return result, nil
 }
 
-func (m *MockClient) ListIssues(context.Context, string, string) ([]*Issue, error) {
+func (m *MockClient) ListIssues(_ context.Context, filter, customQuery string) ([]*Issue, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	result := make([]*Issue, 0, len(m.issues))
 	for _, issue := range m.issues {
+		if !matchesIssueRepositoryQuery(issue, filter+" "+customQuery) {
+			continue
+		}
 		result = append(result, issue)
 	}
 	return result, nil
 }
 
-func (m *MockClient) ListIssuesPaged(ctx context.Context, _, _ string, page, perPage int) (*IssueSearchPage, error) {
-	issues, err := m.ListIssues(ctx, "", "")
+func (m *MockClient) ListIssuesPaged(ctx context.Context, filter, customQuery string, page, perPage int) (*IssueSearchPage, error) {
+	issues, err := m.ListIssues(ctx, filter, customQuery)
 	if err != nil {
 		return nil, err
 	}
 	return &IssueSearchPage{Issues: issues, TotalCount: len(issues), Page: page, PerPage: perPage}, nil
+}
+
+func matchesIssueRepositoryQuery(issue *Issue, query string) bool {
+	for _, term := range strings.Fields(query) {
+		if !strings.HasPrefix(term, "repo:") {
+			continue
+		}
+		owner, repo, found := strings.Cut(strings.TrimPrefix(term, "repo:"), "/")
+		if !found || !strings.EqualFold(issue.RepoOwner, owner) || !strings.EqualFold(issue.RepoName, repo) {
+			return false
+		}
+	}
+	return true
 }
 
 func (m *MockClient) SearchPRs(context.Context, string, string) ([]*PR, error) {

--- a/apps/backend/internal/github/mock_client.go
+++ b/apps/backend/internal/github/mock_client.go
@@ -228,11 +228,21 @@ func (m *MockClient) ListReviewRequestedPRs(context.Context, string, string, str
 }
 
 func (m *MockClient) ListIssues(context.Context, string, string) ([]*Issue, error) {
-	return nil, nil
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	result := make([]*Issue, 0, len(m.issues))
+	for _, issue := range m.issues {
+		result = append(result, issue)
+	}
+	return result, nil
 }
 
-func (m *MockClient) ListIssuesPaged(context.Context, string, string, int, int) (*IssueSearchPage, error) {
-	return &IssueSearchPage{Issues: []*Issue{}, TotalCount: 0, Page: 1, PerPage: 50}, nil
+func (m *MockClient) ListIssuesPaged(ctx context.Context, _, _ string, page, perPage int) (*IssueSearchPage, error) {
+	issues, err := m.ListIssues(ctx, "", "")
+	if err != nil {
+		return nil, err
+	}
+	return &IssueSearchPage{Issues: issues, TotalCount: len(issues), Page: page, PerPage: perPage}, nil
 }
 
 func (m *MockClient) SearchPRs(context.Context, string, string) ([]*PR, error) {

--- a/apps/backend/internal/github/mock_client_test.go
+++ b/apps/backend/internal/github/mock_client_test.go
@@ -100,6 +100,23 @@ func TestMockClient_AddIssueGetIssueAndReset(t *testing.T) {
 	}
 }
 
+func TestMockClient_ListIssuesPaged(t *testing.T) {
+	m := NewMockClient()
+	m.AddIssue(&Issue{Number: 1, RepoOwner: "owner", RepoName: "repo"})
+	m.AddIssue(&Issue{Number: 2, RepoOwner: "owner", RepoName: "repo"})
+
+	page, err := m.ListIssuesPaged(context.Background(), "state:open", "", 2, 10)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(page.Issues) != 2 || page.TotalCount != 2 {
+		t.Fatalf("expected two issues, got %#v", page)
+	}
+	if page.Page != 2 || page.PerPage != 10 {
+		t.Fatalf("expected pagination metadata to be preserved, got %#v", page)
+	}
+}
+
 func TestMockClient_FindPRByBranch(t *testing.T) {
 	m := NewMockClient()
 	ctx := context.Background()

--- a/apps/backend/internal/github/mock_client_test.go
+++ b/apps/backend/internal/github/mock_client_test.go
@@ -104,8 +104,9 @@ func TestMockClient_ListIssuesPaged(t *testing.T) {
 	m := NewMockClient()
 	m.AddIssue(&Issue{Number: 1, RepoOwner: "owner", RepoName: "repo"})
 	m.AddIssue(&Issue{Number: 2, RepoOwner: "owner", RepoName: "repo"})
+	m.AddIssue(&Issue{Number: 3, RepoOwner: "other", RepoName: "repo"})
 
-	page, err := m.ListIssuesPaged(context.Background(), "state:open", "", 2, 10)
+	page, err := m.ListIssuesPaged(context.Background(), "state:open repo:owner/repo", "", 2, 10)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/apps/backend/internal/github/service_task_issue.go
+++ b/apps/backend/internal/github/service_task_issue.go
@@ -97,6 +97,9 @@ func (s *Service) LinkTaskIssue(ctx context.Context, taskID string, req LinkTask
 
 // ListWorkspaceTaskIssues returns persisted GitHub issue links for one workspace.
 func (s *Service) ListWorkspaceTaskIssues(ctx context.Context, workspaceID string) (map[string]TaskIssueLinkResponse, error) {
+	if s.store == nil {
+		return nil, errStoreUnavailable
+	}
 	rows, err := s.store.ListTaskIssueMetadataByWorkspaceID(ctx, workspaceID)
 	if err != nil {
 		return nil, err

--- a/apps/backend/internal/github/service_task_issue.go
+++ b/apps/backend/internal/github/service_task_issue.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/url"
 	"strconv"
@@ -39,6 +40,7 @@ type LinkTaskIssueRequest struct {
 
 type TaskIssueLinkResponse struct {
 	TaskID      string `json:"task_id"`
+	TaskTitle   string `json:"task_title"`
 	Owner       string `json:"owner"`
 	Repo        string `json:"repo"`
 	IssueNumber int    `json:"issue_number"`
@@ -90,7 +92,23 @@ func (s *Service) LinkTaskIssue(ctx context.Context, taskID string, req LinkTask
 	if _, err := store.UpdateTaskMetadata(context.WithoutCancel(ctx), taskID, metadata); err != nil {
 		return nil, err
 	}
-	return taskIssueResponse(taskID, issue), nil
+	return taskIssueResponse(taskID, task.Title, issue), nil
+}
+
+// ListWorkspaceTaskIssues returns persisted GitHub issue links for one workspace.
+func (s *Service) ListWorkspaceTaskIssues(ctx context.Context, workspaceID string) (map[string]TaskIssueLinkResponse, error) {
+	rows, err := s.store.ListTaskIssueMetadataByWorkspaceID(ctx, workspaceID)
+	if err != nil {
+		return nil, err
+	}
+	result := make(map[string]TaskIssueLinkResponse)
+	for _, row := range rows {
+		link, ok := taskIssueLinkFromMetadata(row)
+		if ok {
+			result[row.TaskID] = link
+		}
+	}
+	return result, nil
 }
 
 func (s *Service) UnlinkTaskIssue(ctx context.Context, taskID string) error {
@@ -185,9 +203,49 @@ func copyMetadata(metadata map[string]interface{}) map[string]interface{} {
 	return out
 }
 
-func taskIssueResponse(taskID string, issue *Issue) *TaskIssueLinkResponse {
+func taskIssueLinkFromMetadata(row taskIssueMetadataRow) (TaskIssueLinkResponse, bool) {
+	var metadata map[string]interface{}
+	if err := json.Unmarshal([]byte(row.Metadata), &metadata); err != nil {
+		return TaskIssueLinkResponse{}, false
+	}
+	issueURL, ok := metadata[taskMetaIssueURL].(string)
+	if !ok || issueURL == "" {
+		return TaskIssueLinkResponse{}, false
+	}
+	metadataNumber, ok := positiveMetadataInt(metadata[taskMetaIssueNumber])
+	if !ok {
+		return TaskIssueLinkResponse{}, false
+	}
+	owner, repo, issueNumber, err := parseIssueReference(issueURL, "", "")
+	if err != nil || issueNumber != metadataNumber {
+		return TaskIssueLinkResponse{}, false
+	}
+	return TaskIssueLinkResponse{
+		TaskID:      row.TaskID,
+		TaskTitle:   row.TaskTitle,
+		Owner:       owner,
+		Repo:        repo,
+		IssueNumber: issueNumber,
+		IssueURL:    issueURL,
+	}, true
+}
+
+func positiveMetadataInt(value interface{}) (int, bool) {
+	switch number := value.(type) {
+	case int:
+		return number, number > 0
+	case float64:
+		integer := int(number)
+		return integer, integer > 0 && float64(integer) == number
+	default:
+		return 0, false
+	}
+}
+
+func taskIssueResponse(taskID, taskTitle string, issue *Issue) *TaskIssueLinkResponse {
 	return &TaskIssueLinkResponse{
 		TaskID:      taskID,
+		TaskTitle:   taskTitle,
 		Owner:       issue.RepoOwner,
 		Repo:        issue.RepoName,
 		IssueNumber: issue.Number,

--- a/apps/backend/internal/github/service_task_issue_test.go
+++ b/apps/backend/internal/github/service_task_issue_test.go
@@ -27,6 +27,15 @@ type countingIssueClient struct {
 	getIssueCalls int
 }
 
+func TestListWorkspaceTaskIssues_RequiresStore(t *testing.T) {
+	svc := NewService(nil, AuthMethodPAT, nil, nil, nil, testLogger(t))
+
+	_, err := svc.ListWorkspaceTaskIssues(context.Background(), "workspace-1")
+	if !errors.Is(err, errStoreUnavailable) {
+		t.Fatalf("err = %v, want errStoreUnavailable", err)
+	}
+}
+
 func (c *countingIssueClient) GetIssue(ctx context.Context, owner, repo string, number int) (*Issue, error) {
 	c.getIssueCalls++
 	return c.MockClient.GetIssue(ctx, owner, repo, number)

--- a/apps/backend/internal/github/store.go
+++ b/apps/backend/internal/github/store.go
@@ -20,6 +20,12 @@ type Store struct {
 	ro *sqlx.DB // reader
 }
 
+type taskIssueMetadataRow struct {
+	TaskID    string `db:"task_id"`
+	TaskTitle string `db:"task_title"`
+	Metadata  string `db:"metadata"`
+}
+
 // NewStore creates a new GitHub store and initializes the schema.
 func NewStore(writer, reader *sqlx.DB) (*Store, error) {
 	s := &Store{db: writer, ro: reader}
@@ -937,6 +943,18 @@ func (s *Store) ListTaskPRsByWorkspaceID(ctx context.Context, workspaceID string
 		return nil, err
 	}
 	return groupTaskPRsByTask(prs), nil
+}
+
+// ListTaskIssueMetadataByWorkspaceID projects task metadata for issue-link normalization.
+func (s *Store) ListTaskIssueMetadataByWorkspaceID(ctx context.Context, workspaceID string) ([]taskIssueMetadataRow, error) {
+	var rows []taskIssueMetadataRow
+	err := s.ro.SelectContext(ctx, &rows, s.ro.Rebind(
+		`SELECT id AS task_id, title AS task_title, COALESCE(metadata, '{}') AS metadata
+		 FROM tasks
+		 WHERE workspace_id = ?
+		 ORDER BY created_at ASC, id ASC`,
+	), workspaceID)
+	return rows, err
 }
 
 // ListTaskIDsByPRNumber returns the IDs of tasks in a workspace that have a PR

--- a/apps/backend/internal/github/store.go
+++ b/apps/backend/internal/github/store.go
@@ -953,7 +953,7 @@ func (s *Store) ListTaskIssueMetadataByWorkspaceID(ctx context.Context, workspac
 	err := s.ro.SelectContext(ctx, &rows, s.ro.Rebind(
 		`SELECT id AS task_id, title AS task_title, COALESCE(metadata, '{}') AS metadata
 		 FROM tasks
-		 WHERE workspace_id = ?
+		 WHERE workspace_id = ? AND archived_at IS NULL
 		 ORDER BY created_at ASC, id ASC`,
 	), workspaceID)
 	return rows, err

--- a/apps/backend/internal/github/store.go
+++ b/apps/backend/internal/github/store.go
@@ -945,7 +945,9 @@ func (s *Store) ListTaskPRsByWorkspaceID(ctx context.Context, workspaceID string
 	return groupTaskPRsByTask(prs), nil
 }
 
-// ListTaskIssueMetadataByWorkspaceID projects task metadata for issue-link normalization.
+// ListTaskIssueMetadataByWorkspaceID projects workspace-bounded task metadata for issue-link
+// normalization. Issue links are persisted in metadata, so parsing the two supported shapes in
+// Go keeps the SQL query independent of SQLite's JSON capabilities.
 func (s *Store) ListTaskIssueMetadataByWorkspaceID(ctx context.Context, workspaceID string) ([]taskIssueMetadataRow, error) {
 	var rows []taskIssueMetadataRow
 	err := s.ro.SelectContext(ctx, &rows, s.ro.Rebind(

--- a/apps/web/app/github/github-page-client.tsx
+++ b/apps/web/app/github/github-page-client.tsx
@@ -9,8 +9,9 @@ import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@kandev/ui/sheet";
 import { PageTopbar } from "@/components/page-topbar";
 import { useGitHubStatus } from "@/hooks/domains/github/use-github-status";
 import { usePRKeyToTasks } from "@/hooks/domains/github/use-pr-key-to-tasks";
+import { useIssueKeyToTasks } from "@/hooks/domains/github/use-issue-key-to-tasks";
 import type { Repository, Workflow, WorkflowStep } from "@/lib/types/http";
-import type { GitHubIssue, GitHubPR, TaskPR } from "@/lib/types/github";
+import type { GitHubIssue, GitHubPR, TaskIssueLink, TaskPR } from "@/lib/types/github";
 import { PRList } from "@/components/github/my-github/pr-list";
 import { IssueList } from "@/components/github/my-github/issue-list";
 import {
@@ -129,6 +130,7 @@ function ResultsList({
   issuePresets,
   onStartTask,
   prKeyToTasks,
+  issueKeyToTasks,
 }: {
   selection: SidebarSelection;
   items: Array<GitHubPR | GitHubIssue>;
@@ -138,6 +140,7 @@ function ResultsList({
   issuePresets: TaskPreset[];
   onStartTask: (payload: LaunchPayload) => void;
   prKeyToTasks: Map<string, TaskPR[]>;
+  issueKeyToTasks: Map<string, TaskIssueLink[]>;
 }) {
   if (selection.kind === "pr") {
     return (
@@ -158,6 +161,7 @@ function ResultsList({
       error={error}
       presets={issuePresets}
       onStartTask={onStartTask}
+      issueKeyToTasks={issueKeyToTasks}
     />
   );
 }
@@ -433,6 +437,7 @@ function AuthenticatedLayout({
 }) {
   const { selection, search, repoOptions, title } = state;
   const prKeyToTasks = usePRKeyToTasks(workspaceId ?? null);
+  const issueKeyToTasks = useIssueKeyToTasks(workspaceId ?? null);
   useAllWorkflowSnapshots(workspaceId ?? null);
   return (
     <main className="flex-1 flex flex-col min-w-0 overflow-hidden">
@@ -472,6 +477,7 @@ function AuthenticatedLayout({
           issuePresets={issuePresets}
           onStartTask={onStartTask}
           prKeyToTasks={prKeyToTasks}
+          issueKeyToTasks={issueKeyToTasks}
         />
       </div>
       <ResultsPagination

--- a/apps/web/components/github/my-github/issue-list.tsx
+++ b/apps/web/components/github/my-github/issue-list.tsx
@@ -13,8 +13,9 @@ import {
 import { Spinner } from "@kandev/ui/spinner";
 import { cn } from "@/lib/utils";
 import { formatRelativeTime } from "@/lib/utils";
-import type { GitHubIssue } from "@/lib/types/github";
+import type { GitHubIssue, TaskIssueLink } from "@/lib/types/github";
 import type { LaunchPayload, TaskPreset } from "./quick-task-launcher";
+import { TaskRowIndicator } from "./task-row-indicator";
 
 type IssueListProps = {
   items: GitHubIssue[];
@@ -22,6 +23,7 @@ type IssueListProps = {
   error: string | null;
   presets: TaskPreset[];
   onStartTask: (payload: LaunchPayload) => void;
+  issueKeyToTasks?: Map<string, TaskIssueLink[]>;
 };
 
 function StartTaskMenu({
@@ -85,10 +87,12 @@ function IssueRow({
   issue,
   presets,
   onStartTask,
+  tasks,
 }: {
   issue: GitHubIssue;
   presets: TaskPreset[];
   onStartTask: IssueListProps["onStartTask"];
+  tasks: TaskIssueLink[] | undefined;
 }) {
   const StateIcon = issue.state === "open" ? IconCircle : IconCircleCheck;
   const stateClass =
@@ -96,7 +100,11 @@ function IssueRow({
       ? "text-emerald-600 dark:text-emerald-400"
       : "text-purple-600 dark:text-purple-400";
   return (
-    <div className="flex items-start gap-3 px-4 py-3 hover:bg-muted/40 transition-colors">
+    <div
+      className="flex items-start gap-3 px-4 py-3 hover:bg-muted/40 transition-colors"
+      data-testid="issue-row"
+      data-issue-number={issue.number}
+    >
       <StateIcon className={cn("h-4 w-4 mt-1 shrink-0", stateClass)} />
       <div className="min-w-0 flex-1">
         <Link
@@ -116,6 +124,14 @@ function IssueRow({
             by {issue.author_login} · opened {formatRelativeTime(issue.created_at)}
           </span>
           <IssueLabels labels={issue.labels} />
+          <TaskRowIndicator
+            tasks={tasks?.map((task) => ({
+              id: task.task_id,
+              taskId: task.task_id,
+              fallbackTitle: task.task_title,
+            }))}
+            testIdPrefix="issue-row-task-indicator"
+          />
         </div>
       </div>
       <div className="shrink-0">
@@ -125,7 +141,14 @@ function IssueRow({
   );
 }
 
-function IssueListBody({ loading, error, items, presets, onStartTask }: IssueListProps) {
+function IssueListBody({
+  loading,
+  error,
+  items,
+  presets,
+  onStartTask,
+  issueKeyToTasks,
+}: IssueListProps) {
   if (loading) {
     return (
       <div className="flex justify-center py-10">
@@ -145,14 +168,18 @@ function IssueListBody({ loading, error, items, presets, onStartTask }: IssueLis
   }
   return (
     <div className="divide-y">
-      {items.map((issue) => (
-        <IssueRow
-          key={`${issue.repo_owner}/${issue.repo_name}#${issue.number}`}
-          issue={issue}
-          presets={presets}
-          onStartTask={onStartTask}
-        />
-      ))}
+      {items.map((issue) => {
+        const key = `${issue.repo_owner}/${issue.repo_name}#${issue.number}`;
+        return (
+          <IssueRow
+            key={key}
+            issue={issue}
+            presets={presets}
+            onStartTask={onStartTask}
+            tasks={issueKeyToTasks?.get(key)}
+          />
+        );
+      })}
     </div>
   );
 }

--- a/apps/web/components/github/my-github/pr-row-task-indicator.test.tsx
+++ b/apps/web/components/github/my-github/pr-row-task-indicator.test.tsx
@@ -81,11 +81,10 @@ describe("PRRowTaskIndicator", () => {
     expect(container.textContent).toContain("2");
   });
 
-  it("truncates long task titles (>40 chars)", () => {
+  it("keeps long task titles in the DOM while visually truncating them", () => {
     const longTitle = "This is an extremely long pull request title that should be truncated";
     renderWithStore(<PRRowTaskIndicator tasks={[makeTaskPR({ pr_title: longTitle })]} />);
     const btn = screen.getByRole("button");
-    expect(btn.textContent).toContain("…");
-    expect(btn.textContent!.length).toBeLessThan(longTitle.length + 5);
+    expect(btn.textContent).toContain(longTitle);
   });
 });

--- a/apps/web/components/github/my-github/pr-row-task-indicator.test.tsx
+++ b/apps/web/components/github/my-github/pr-row-task-indicator.test.tsx
@@ -86,5 +86,6 @@ describe("PRRowTaskIndicator", () => {
     renderWithStore(<PRRowTaskIndicator tasks={[makeTaskPR({ pr_title: longTitle })]} />);
     const btn = screen.getByRole("button");
     expect(btn.textContent).toContain(longTitle);
+    expect(screen.getByText(longTitle).classList.contains("truncate")).toBe(true);
   });
 });

--- a/apps/web/components/github/my-github/pr-row-task-indicator.tsx
+++ b/apps/web/components/github/my-github/pr-row-task-indicator.tsx
@@ -11,7 +11,7 @@ export function PRRowTaskIndicator({ tasks }: PRRowTaskIndicatorProps) {
   return (
     <TaskRowIndicator
       tasks={tasks?.map((task) => ({
-        id: task.task_id,
+        id: task.id,
         taskId: task.task_id,
         fallbackTitle: task.pr_title,
       }))}

--- a/apps/web/components/github/my-github/pr-row-task-indicator.tsx
+++ b/apps/web/components/github/my-github/pr-row-task-indicator.tsx
@@ -1,144 +1,22 @@
 "use client";
 
-import { useCallback } from "react";
-import { useRouter } from "@/lib/routing/client-router";
-import { IconChecklist } from "@tabler/icons-react";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@kandev/ui/dropdown-menu";
-import { Badge } from "@kandev/ui/badge";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
-import { useAppStore } from "@/components/state-provider";
-import { cn } from "@/lib/utils";
-import { linkToTask } from "@/lib/links";
-import { useTaskById } from "@/hooks/domains/kanban/use-task-by-id";
-import type { KanbanState } from "@/lib/state/slices";
 import type { TaskPR } from "@/lib/types/github";
+import { TaskRowIndicator } from "./task-row-indicator";
 
 type PRRowTaskIndicatorProps = {
   tasks: TaskPR[] | undefined;
 };
 
-function useTaskStepTitle(workflowStepId: string | undefined): string | null {
-  return useAppStore((state) => {
-    if (!workflowStepId) return null;
-    const findIn = (steps: KanbanState["steps"]) =>
-      steps.find((s) => s.id === workflowStepId)?.title ?? null;
-    const fromActive = findIn(state.kanban.steps);
-    if (fromActive) return fromActive;
-    for (const snap of Object.values(state.kanbanMulti.snapshots)) {
-      const t = findIn(snap.steps);
-      if (t) return t;
-    }
-    return null;
-  });
-}
-
-function truncateTitle(title: string): string {
-  return title.length > 40 ? title.slice(0, 40) + "…" : title;
-}
-
-function TaskTitle({ taskId, fallback }: { taskId: string; fallback: string }) {
-  const taskData = useTaskById(taskId);
-  const title = taskData?.title ?? fallback;
-  return <span className="truncate text-foreground/80">{truncateTitle(title)}</span>;
-}
-
-function SingleTaskButton({
-  task,
-  onNavigate,
-}: {
-  task: TaskPR;
-  onNavigate: (taskId: string) => void;
-}) {
-  const taskData = useTaskById(task.task_id);
-  const stepTitle = useTaskStepTitle(taskData?.workflowStepId);
-  const title = taskData?.title ?? task.pr_title;
-  return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <button
-          type="button"
-          data-testid="pr-row-task-indicator-single"
-          onClick={() => onNavigate(task.task_id)}
-          className={buttonClass}
-        >
-          <IconChecklist className={iconClass} />
-          <span className="truncate text-foreground/80">{truncateTitle(title)}</span>
-        </button>
-      </TooltipTrigger>
-      <TooltipContent>
-        <div className="flex flex-col gap-0.5 text-xs">
-          <span>Task: {title}</span>
-          {stepTitle ? <span className="text-muted-foreground">Step: {stepTitle}</span> : null}
-        </div>
-      </TooltipContent>
-    </Tooltip>
-  );
-}
-
-const buttonClass = cn(
-  "inline-flex items-center gap-1.5 rounded px-1.5 py-0.5 text-xs",
-  "hover:bg-muted/70 transition-colors cursor-pointer w-fit max-w-full",
-);
-
-const iconClass = "h-3 w-3 shrink-0 text-muted-foreground";
-
 export function PRRowTaskIndicator({ tasks }: PRRowTaskIndicatorProps) {
-  const setActiveTask = useAppStore((state) => state.setActiveTask);
-  const router = useRouter();
-
-  const navigate = useCallback(
-    (taskId: string) => {
-      setActiveTask(taskId);
-      router.push(linkToTask(taskId));
-    },
-    [setActiveTask, router],
-  );
-
-  if (!tasks || tasks.length === 0) {
-    return (
-      <span
-        data-testid="pr-row-task-indicator-empty"
-        className="inline-flex items-center gap-1 text-xs text-muted-foreground"
-      >
-        No task created yet
-      </span>
-    );
-  }
-
-  if (tasks.length === 1) {
-    return <SingleTaskButton task={tasks[0]} onNavigate={navigate} />;
-  }
-
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <button type="button" data-testid="pr-row-task-indicator-multi" className={buttonClass}>
-          <IconChecklist className={iconClass} />
-          <span className="text-foreground/80">Tasks</span>
-          <Badge variant="outline" className="h-4 px-1 py-0 text-[10px] shrink-0">
-            {tasks.length}
-          </Badge>
-        </button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="start" className="w-56">
-        {tasks.map((t) => (
-          // Use the TaskPR row id rather than task_id — multi-repo tasks can
-          // produce more than one TaskPR row for the same PR, which would
-          // collide on task_id.
-          <DropdownMenuItem
-            key={t.id}
-            className="cursor-pointer"
-            onSelect={() => navigate(t.task_id)}
-          >
-            <TaskTitle taskId={t.task_id} fallback={t.pr_title} />
-          </DropdownMenuItem>
-        ))}
-      </DropdownMenuContent>
-    </DropdownMenu>
+    <TaskRowIndicator
+      tasks={tasks?.map((task) => ({
+        id: task.id,
+        taskId: task.task_id,
+        fallbackTitle: task.pr_title,
+      }))}
+      testIdPrefix="pr-row-task-indicator"
+      emptyLabel="No task created yet"
+    />
   );
 }

--- a/apps/web/components/github/my-github/pr-row-task-indicator.tsx
+++ b/apps/web/components/github/my-github/pr-row-task-indicator.tsx
@@ -11,7 +11,7 @@ export function PRRowTaskIndicator({ tasks }: PRRowTaskIndicatorProps) {
   return (
     <TaskRowIndicator
       tasks={tasks?.map((task) => ({
-        id: task.id,
+        id: task.task_id,
         taskId: task.task_id,
         fallbackTitle: task.pr_title,
       }))}

--- a/apps/web/components/github/my-github/quick-task-launcher.test.tsx
+++ b/apps/web/components/github/my-github/quick-task-launcher.test.tsx
@@ -6,6 +6,7 @@ import {
   repositoryId,
   workspaceId,
   type Repository,
+  type Task,
   type Workflow,
   type WorkflowStep,
 } from "@/lib/types/http";
@@ -21,9 +22,12 @@ const REPO_URL = "https://github.com/kdlbs/kandev/pull/1567";
 const ISSUE_URL = "https://github.com/kdlbs/kandev/issues/1567";
 
 const mocks = vi.hoisted(() => ({
-  dialogProps: undefined as { initialValues?: Record<string, unknown> } | undefined,
+  dialogProps: undefined as
+    | { initialValues?: Record<string, unknown>; onSuccess?: (task: Task) => void }
+    | undefined,
   push: vi.fn(),
   createTaskPR: vi.fn(),
+  linkTaskIssue: vi.fn(),
 }));
 
 vi.mock("@/components/task-create-dialog", () => ({
@@ -39,6 +43,7 @@ vi.mock("@/lib/routing/client-router", () => ({
 
 vi.mock("@/lib/api/domains/github-api", () => ({
   createTaskPR: mocks.createTaskPR,
+  linkTaskIssue: mocks.linkTaskIssue,
 }));
 
 const preset: TaskPreset = {
@@ -176,6 +181,7 @@ afterEach(() => {
   mocks.dialogProps = undefined;
   mocks.push.mockClear();
   mocks.createTaskPR.mockClear();
+  mocks.linkTaskIssue.mockClear();
 });
 
 describe("QuickTaskLauncher repository defaults", () => {
@@ -250,5 +256,17 @@ describe("QuickTaskLauncher repository defaults", () => {
       prBaseBranch: "main",
     });
     expect(initialValues?.repositoryId).toBeUndefined();
+  });
+});
+
+describe("QuickTaskLauncher issue linking", () => {
+  it("links a newly created task to the launched issue", () => {
+    mocks.linkTaskIssue.mockResolvedValue(undefined);
+    renderIssueLauncher([repo({ id: "local-repo" })]);
+
+    mocks.dialogProps?.onSuccess?.({ id: "task-1" } as Task);
+
+    expect(mocks.linkTaskIssue).toHaveBeenCalledWith("task-1", { issue: ISSUE_URL });
+    expect(mocks.push).toHaveBeenCalledWith("/tasks/task-1");
   });
 });

--- a/apps/web/components/github/my-github/quick-task-launcher.test.tsx
+++ b/apps/web/components/github/my-github/quick-task-launcher.test.tsx
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react";
+import { render, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Icon } from "@tabler/icons-react";
 import type { GitHubIssue, GitHubPR } from "@/lib/types/github";
@@ -20,6 +20,7 @@ const TASK_WORKTREE_ROOT = "/root/.kandev/tasks";
 const TASK_WORKTREE_PATH = "/root/.kandev/tasks/pr-1541-fix-skip-cle_3bm/kdlbs-kandev";
 const REPO_URL = "https://github.com/kdlbs/kandev/pull/1567";
 const ISSUE_URL = "https://github.com/kdlbs/kandev/issues/1567";
+const LOCAL_REPO_ID = "local-repo";
 
 const mocks = vi.hoisted(() => ({
   dialogProps: undefined as
@@ -28,6 +29,7 @@ const mocks = vi.hoisted(() => ({
   push: vi.fn(),
   createTaskPR: vi.fn(),
   linkTaskIssue: vi.fn(),
+  upsertTaskIssue: vi.fn(),
 }));
 
 vi.mock("@/components/task-create-dialog", () => ({
@@ -39,6 +41,10 @@ vi.mock("@/components/task-create-dialog", () => ({
 
 vi.mock("@/lib/routing/client-router", () => ({
   useRouter: () => ({ push: mocks.push }),
+}));
+
+vi.mock("@/components/state-provider", () => ({
+  useAppStore: (selector: (state: typeof mocks) => unknown) => selector(mocks),
 }));
 
 vi.mock("@/lib/api/domains/github-api", () => ({
@@ -182,6 +188,7 @@ afterEach(() => {
   mocks.push.mockClear();
   mocks.createTaskPR.mockClear();
   mocks.linkTaskIssue.mockClear();
+  mocks.upsertTaskIssue.mockClear();
 });
 
 describe("QuickTaskLauncher repository defaults", () => {
@@ -222,11 +229,11 @@ describe("QuickTaskLauncher repository defaults", () => {
 
   it("still preselects an ordinary matching local GitHub repo for issues", () => {
     const initialValues = renderIssueLauncher([
-      repo({ id: "local-repo", local_path: "/work/kandev" }),
+      repo({ id: LOCAL_REPO_ID, local_path: "/work/kandev" }),
     ]);
 
     expect(initialValues).toMatchObject({
-      repositoryId: "local-repo",
+      repositoryId: LOCAL_REPO_ID,
     });
     expect(initialValues?.githubUrl).toBeUndefined();
   });
@@ -260,13 +267,36 @@ describe("QuickTaskLauncher repository defaults", () => {
 });
 
 describe("QuickTaskLauncher issue linking", () => {
-  it("links a newly created task to the launched issue", () => {
-    mocks.linkTaskIssue.mockResolvedValue(undefined);
-    renderIssueLauncher([repo({ id: "local-repo" })]);
+  it("links and immediately stores a newly created task for the launched issue", async () => {
+    const link = {
+      task_id: "task-1",
+      task_title: "Review: add Download option",
+      owner: "kdlbs",
+      repo: "kandev",
+      issue_number: 1567,
+      issue_url: ISSUE_URL,
+      issue_title: "add Download option",
+    };
+    mocks.linkTaskIssue.mockResolvedValue(link);
+    renderIssueLauncher([repo({ id: LOCAL_REPO_ID })]);
 
     mocks.dialogProps?.onSuccess?.({ id: "task-1" } as Task);
 
     expect(mocks.linkTaskIssue).toHaveBeenCalledWith("task-1", { issue: ISSUE_URL });
+    await waitFor(() => {
+      expect(mocks.upsertTaskIssue).toHaveBeenCalledWith(WORKSPACE_ID, link);
+    });
     expect(mocks.push).toHaveBeenCalledWith("/tasks/task-1");
+  });
+
+  it("navigates when issue linking fails", async () => {
+    mocks.linkTaskIssue.mockRejectedValueOnce(new Error("offline"));
+    renderIssueLauncher([repo({ id: LOCAL_REPO_ID })]);
+
+    mocks.dialogProps?.onSuccess?.({ id: "task-1" } as Task);
+
+    expect(mocks.push).toHaveBeenCalledWith("/tasks/task-1");
+    await waitFor(() => expect(mocks.linkTaskIssue).toHaveBeenCalledTimes(1));
+    expect(mocks.upsertTaskIssue).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/components/github/my-github/quick-task-launcher.tsx
+++ b/apps/web/components/github/my-github/quick-task-launcher.tsx
@@ -4,7 +4,7 @@ import { useMemo } from "react";
 import { useRouter } from "@/lib/routing/client-router";
 import type { Icon } from "@tabler/icons-react";
 import { TaskCreateDialog } from "@/components/task-create-dialog";
-import { createTaskPR } from "@/lib/api/domains/github-api";
+import { createTaskPR, linkTaskIssue } from "@/lib/api/domains/github-api";
 import type { Repository, Task, TaskRepository, Workflow, WorkflowStep } from "@/lib/types/http";
 import type { GitHubPR, GitHubIssue } from "@/lib/types/github";
 
@@ -220,6 +220,11 @@ export function QuickTaskLauncher({
       }).catch(() => {
         // Silently ignore — the indicator will populate via the poller path
         // (legacy behavior) if branch matching succeeds.
+      });
+    }
+    if (payload?.kind === "issue") {
+      void linkTaskIssue(task.id, { issue: payload.issue.html_url }).catch(() => {
+        // Task creation succeeded; keep navigation available if GitHub linking fails.
       });
     }
     onClose();

--- a/apps/web/components/github/my-github/quick-task-launcher.tsx
+++ b/apps/web/components/github/my-github/quick-task-launcher.tsx
@@ -4,6 +4,7 @@ import { useMemo } from "react";
 import { useRouter } from "@/lib/routing/client-router";
 import type { Icon } from "@tabler/icons-react";
 import { TaskCreateDialog } from "@/components/task-create-dialog";
+import { useAppStore } from "@/components/state-provider";
 import { createTaskPR, linkTaskIssue } from "@/lib/api/domains/github-api";
 import type { Repository, Task, TaskRepository, Workflow, WorkflowStep } from "@/lib/types/http";
 import type { GitHubPR, GitHubIssue } from "@/lib/types/github";
@@ -180,6 +181,7 @@ export function QuickTaskLauncher({
   onClose,
 }: QuickTaskLauncherProps) {
   const router = useRouter();
+  const upsertTaskIssue = useAppStore((state) => state.upsertTaskIssue);
 
   const defaultWorkflow = workflows[0];
   const sortedStepsForWorkflow = useMemo(
@@ -223,9 +225,13 @@ export function QuickTaskLauncher({
       });
     }
     if (payload?.kind === "issue") {
-      void linkTaskIssue(task.id, { issue: payload.issue.html_url }).catch(() => {
-        // Task creation succeeded; keep navigation available if GitHub linking fails.
-      });
+      void linkTaskIssue(task.id, { issue: payload.issue.html_url })
+        .then((issue) => {
+          if (workspaceId) upsertTaskIssue(workspaceId, issue);
+        })
+        .catch(() => {
+          // Task creation succeeded; keep navigation available if GitHub linking fails.
+        });
     }
     onClose();
     router.push(`/tasks/${task.id}`);

--- a/apps/web/components/github/my-github/task-row-indicator.tsx
+++ b/apps/web/components/github/my-github/task-row-indicator.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { useCallback } from "react";
+import { useRouter } from "@/lib/routing/client-router";
+import { IconChecklist } from "@tabler/icons-react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@kandev/ui/dropdown-menu";
+import { Badge } from "@kandev/ui/badge";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
+import { useAppStore } from "@/components/state-provider";
+import { cn } from "@/lib/utils";
+import { linkToTask } from "@/lib/links";
+import { useTaskById } from "@/hooks/domains/kanban/use-task-by-id";
+import type { KanbanState } from "@/lib/state/slices";
+
+export type TaskRowLink = {
+  id: string;
+  taskId: string;
+  fallbackTitle: string;
+};
+
+type TaskRowIndicatorProps = {
+  tasks: TaskRowLink[] | undefined;
+  testIdPrefix: string;
+  emptyLabel?: string;
+};
+
+function useTaskStepTitle(workflowStepId: string | undefined): string | null {
+  return useAppStore((state) => {
+    if (!workflowStepId) return null;
+    const findIn = (steps: KanbanState["steps"]) =>
+      steps.find((step) => step.id === workflowStepId)?.title ?? null;
+    const activeTitle = findIn(state.kanban.steps);
+    if (activeTitle) return activeTitle;
+    for (const snapshot of Object.values(state.kanbanMulti.snapshots)) {
+      const title = findIn(snapshot.steps);
+      if (title) return title;
+    }
+    return null;
+  });
+}
+
+function truncateTitle(title: string): string {
+  return title.length > 40 ? `${title.slice(0, 40)}…` : title;
+}
+
+function TaskTitle({ task }: { task: TaskRowLink }) {
+  const taskData = useTaskById(task.taskId);
+  return (
+    <span className="truncate text-foreground/80">
+      {truncateTitle(taskData?.title ?? task.fallbackTitle)}
+    </span>
+  );
+}
+
+const buttonClass = cn(
+  "inline-flex items-center gap-1.5 rounded px-1.5 py-0.5 text-xs",
+  "hover:bg-muted/70 transition-colors cursor-pointer w-fit max-w-full",
+);
+const iconClass = "h-3 w-3 shrink-0 text-muted-foreground";
+
+function SingleTaskButton({
+  task,
+  testIdPrefix,
+  onNavigate,
+}: {
+  task: TaskRowLink;
+  testIdPrefix: string;
+  onNavigate: (taskId: string) => void;
+}) {
+  const taskData = useTaskById(task.taskId);
+  const stepTitle = useTaskStepTitle(taskData?.workflowStepId);
+  const title = taskData?.title ?? task.fallbackTitle;
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          data-testid={`${testIdPrefix}-single`}
+          onClick={() => onNavigate(task.taskId)}
+          className={buttonClass}
+        >
+          <IconChecklist className={iconClass} />
+          <span className="truncate text-foreground/80">{truncateTitle(title)}</span>
+        </button>
+      </TooltipTrigger>
+      <TooltipContent>
+        <div className="flex flex-col gap-0.5 text-xs">
+          <span>Task: {title}</span>
+          {stepTitle ? <span className="text-muted-foreground">Step: {stepTitle}</span> : null}
+        </div>
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+export function TaskRowIndicator({ tasks, testIdPrefix, emptyLabel }: TaskRowIndicatorProps) {
+  const setActiveTask = useAppStore((state) => state.setActiveTask);
+  const router = useRouter();
+  const navigate = useCallback(
+    (taskId: string) => {
+      setActiveTask(taskId);
+      router.push(linkToTask(taskId));
+    },
+    [router, setActiveTask],
+  );
+
+  if (!tasks || tasks.length === 0) {
+    return emptyLabel ? (
+      <span
+        data-testid={`${testIdPrefix}-empty`}
+        className="inline-flex items-center gap-1 text-xs text-muted-foreground"
+      >
+        {emptyLabel}
+      </span>
+    ) : null;
+  }
+  if (tasks.length === 1) {
+    return <SingleTaskButton task={tasks[0]} testIdPrefix={testIdPrefix} onNavigate={navigate} />;
+  }
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button type="button" data-testid={`${testIdPrefix}-multi`} className={buttonClass}>
+          <IconChecklist className={iconClass} />
+          <span className="text-foreground/80">Tasks</span>
+          <Badge variant="outline" className="h-4 px-1 py-0 text-[10px] shrink-0">
+            {tasks.length}
+          </Badge>
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="w-56">
+        {tasks.map((task) => (
+          <DropdownMenuItem
+            key={task.id}
+            className="cursor-pointer"
+            onSelect={() => navigate(task.taskId)}
+          >
+            <TaskTitle task={task} />
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/apps/web/components/github/my-github/task-row-indicator.tsx
+++ b/apps/web/components/github/my-github/task-row-indicator.tsx
@@ -44,10 +44,6 @@ function useTaskStepTitle(workflowStepId: string | undefined): string | null {
   });
 }
 
-function truncateTitle(title: string): string {
-  return title.length > 40 ? `${title.slice(0, 40)}…` : title;
-}
-
 function TaskTitle({ task }: { task: TaskRowLink }) {
   const taskData = useTaskById(task.taskId);
   const title = taskData?.title ?? task.fallbackTitle;
@@ -86,7 +82,7 @@ function SingleTaskButton({
           className={buttonClass}
         >
           <IconChecklist className={iconClass} />
-          <span className="truncate text-foreground/80">{truncateTitle(title)}</span>
+          <span className="truncate text-foreground/80">{title}</span>
         </button>
       </TooltipTrigger>
       <TooltipContent>

--- a/apps/web/components/github/my-github/task-row-indicator.tsx
+++ b/apps/web/components/github/my-github/task-row-indicator.tsx
@@ -50,9 +50,10 @@ function truncateTitle(title: string): string {
 
 function TaskTitle({ task }: { task: TaskRowLink }) {
   const taskData = useTaskById(task.taskId);
+  const title = taskData?.title ?? task.fallbackTitle;
   return (
-    <span className="truncate text-foreground/80">
-      {truncateTitle(taskData?.title ?? task.fallbackTitle)}
+    <span className="truncate text-foreground/80" title={title}>
+      {title}
     </span>
   );
 }

--- a/apps/web/e2e/tests/github/issue-list-task-indicator.spec.ts
+++ b/apps/web/e2e/tests/github/issue-list-task-indicator.spec.ts
@@ -1,0 +1,68 @@
+import { test, expect } from "../../fixtures/test-base";
+
+const OWNER = "testorg";
+const REPO = "testrepo";
+
+function issueMetadata(number: number) {
+  return {
+    issue_url: `https://github.com/${OWNER}/${REPO}/issues/${number}`,
+    issue_number: number,
+    issue_repo: `${OWNER}/${REPO}`,
+  };
+}
+
+test.describe("GitHub issue list task indicator", () => {
+  test("shows linked tasks, leaves unlinked issues unchanged, and navigates", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    test.setTimeout(60_000);
+    await apiClient.mockGitHubReset();
+    await apiClient.mockGitHubSetUser("test-user");
+    await apiClient.mockGitHubAddIssues(
+      [100, 101, 102].map((number) => ({
+        number,
+        title: `Issue ${number}`,
+        state: "open",
+        author_login: "test-user",
+        repo_owner: OWNER,
+        repo_name: REPO,
+        assignees: ["test-user"],
+      })),
+    );
+
+    const linked = await apiClient.createTask(seedData.workspaceId, "Linked issue task", {
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+      metadata: issueMetadata(100),
+    });
+    for (const title of ["First shared task", "Second shared task"]) {
+      await apiClient.createTask(seedData.workspaceId, title, {
+        workflow_id: seedData.workflowId,
+        workflow_step_id: seedData.startStepId,
+        metadata: issueMetadata(102),
+      });
+    }
+
+    await testPage.goto("/github");
+    const scopeBar = testPage.getByTestId("github-presets-scope-bar");
+    await expect(scopeBar).toBeVisible({ timeout: 15_000 });
+    await scopeBar.getByRole("button", { name: "Issues", exact: true }).click();
+
+    const linkedRow = testPage.locator('[data-testid="issue-row"][data-issue-number="100"]');
+    const unlinkedRow = testPage.locator('[data-testid="issue-row"][data-issue-number="101"]');
+    const sharedRow = testPage.locator('[data-testid="issue-row"][data-issue-number="102"]');
+    await expect(linkedRow).toBeVisible({ timeout: 15_000 });
+    await expect(linkedRow.getByTestId("issue-row-task-indicator-single")).toContainText(
+      "Linked issue task",
+    );
+    await expect(unlinkedRow.getByTestId("issue-row-task-indicator-single")).toHaveCount(0);
+    await expect(sharedRow.getByTestId("issue-row-task-indicator-multi")).toContainText("2");
+
+    await linkedRow.getByTestId("issue-row-task-indicator-single").click();
+    await expect(testPage).toHaveURL(new RegExp(`/t/${linked.id}(?:\\?|$)`), {
+      timeout: 15_000,
+    });
+  });
+});

--- a/apps/web/e2e/tests/github/mobile-issue-list-task-indicator.spec.ts
+++ b/apps/web/e2e/tests/github/mobile-issue-list-task-indicator.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from "../../fixtures/test-base";
+import { MobileGitHubPage } from "../../pages/mobile-github-page";
+
+test.describe("Mobile GitHub issue task indicator", () => {
+  test("keeps the linked task reachable by touch without horizontal overflow", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    const owner = "mobileorg";
+    const repo = "mobilerepo";
+    const number = 200;
+    await apiClient.mockGitHubReset();
+    await apiClient.mockGitHubSetUser("test-user");
+    await apiClient.mockGitHubAddIssues([
+      {
+        number,
+        title: "Mobile linked issue",
+        state: "open",
+        author_login: "test-user",
+        repo_owner: owner,
+        repo_name: repo,
+        assignees: ["test-user"],
+      },
+    ]);
+    const task = await apiClient.createTask(seedData.workspaceId, "Mobile linked task", {
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+      metadata: {
+        issue_url: `https://github.com/${owner}/${repo}/issues/${number}`,
+        issue_number: number,
+        issue_repo: `${owner}/${repo}`,
+      },
+    });
+
+    const github = new MobileGitHubPage(testPage);
+    await github.goto();
+    await github.mobileMenuButton.tap();
+    await github.mobileSidebar.getByRole("button", { name: "Issues", exact: true }).tap();
+
+    const row = testPage.locator(`[data-testid="issue-row"][data-issue-number="${number}"]`);
+    const indicator = row.getByTestId("issue-row-task-indicator-single");
+    await expect(indicator).toContainText("Mobile linked task", { timeout: 15_000 });
+    expect(
+      await testPage.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth),
+    ).toBe(true);
+
+    await indicator.tap();
+    await expect(testPage).toHaveURL(new RegExp(`/t/${task.id}(?:\\?|$)`), {
+      timeout: 15_000,
+    });
+  });
+});

--- a/apps/web/hooks/domains/github/use-issue-key-to-tasks.test.ts
+++ b/apps/web/hooks/domains/github/use-issue-key-to-tasks.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { StateProvider, useAppStore } from "@/components/state-provider";
+import type { TaskIssueLink } from "@/lib/types/github";
+import { issueKey, useIssueKeyToTasks } from "./use-issue-key-to-tasks";
+
+vi.mock("./use-task-issues", () => ({ useWorkspaceTaskIssues: () => undefined }));
+
+afterEach(() => cleanup());
+
+function wrapper({ children }: { children: ReactNode }) {
+  return createElement(StateProvider, null, children);
+}
+
+function link(taskId: string, issueNumber = 1672): TaskIssueLink {
+  return {
+    task_id: taskId,
+    task_title: `Task ${taskId}`,
+    owner: "kdlbs",
+    repo: "kandev",
+    issue_number: issueNumber,
+    issue_url: `https://github.com/kdlbs/kandev/issues/${issueNumber}`,
+    issue_title: "",
+  };
+}
+
+describe("useIssueKeyToTasks", () => {
+  it("groups multiple tasks linked to the same issue", () => {
+    const { result } = renderHook(
+      () => ({
+        map: useIssueKeyToTasks("ws-1"),
+        setTaskIssues: useAppStore((state) => state.setTaskIssues),
+      }),
+      { wrapper },
+    );
+
+    act(() =>
+      result.current.setTaskIssues("ws-1", { a: link("a"), b: link("b"), c: link("c", 2) }),
+    );
+
+    expect(result.current.map.get("kdlbs/kandev#1672")?.map((item) => item.task_id)).toEqual([
+      "a",
+      "b",
+    ]);
+    expect(result.current.map.get("kdlbs/kandev#2")?.[0]?.task_id).toBe("c");
+  });
+
+  it("does not expose links cached for another workspace", () => {
+    const { result } = renderHook(
+      () => ({
+        map: useIssueKeyToTasks("ws-2"),
+        setTaskIssues: useAppStore((state) => state.setTaskIssues),
+      }),
+      { wrapper },
+    );
+
+    act(() => result.current.setTaskIssues("ws-1", { a: link("a") }));
+
+    expect(result.current.map.size).toBe(0);
+  });
+});
+
+describe("issueKey", () => {
+  it("formats owner/repo#number", () => {
+    expect(issueKey("kdlbs", "kandev", 1672)).toBe("kdlbs/kandev#1672");
+  });
+});

--- a/apps/web/hooks/domains/github/use-issue-key-to-tasks.ts
+++ b/apps/web/hooks/domains/github/use-issue-key-to-tasks.ts
@@ -1,0 +1,27 @@
+"use client";
+
+import { useMemo } from "react";
+import { useAppStore } from "@/components/state-provider";
+import type { TaskIssueLink } from "@/lib/types/github";
+import { useWorkspaceTaskIssues } from "./use-task-issues";
+
+export function issueKey(owner: string, repo: string, issueNumber: number): string {
+  return `${owner}/${repo}#${issueNumber}`;
+}
+
+export function useIssueKeyToTasks(workspaceId: string | null): Map<string, TaskIssueLink[]> {
+  useWorkspaceTaskIssues(workspaceId);
+  const taskIssues = useAppStore((state) => state.taskIssues);
+
+  return useMemo(() => {
+    const map = new Map<string, TaskIssueLink[]>();
+    if (taskIssues.workspaceId !== workspaceId) return map;
+    for (const link of Object.values(taskIssues.byTaskId)) {
+      const key = issueKey(link.owner, link.repo, link.issue_number);
+      const existing = map.get(key) ?? [];
+      existing.push(link);
+      map.set(key, existing);
+    }
+    return map;
+  }, [taskIssues, workspaceId]);
+}

--- a/apps/web/hooks/domains/github/use-task-issues.test.ts
+++ b/apps/web/hooks/domains/github/use-task-issues.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { StateProvider, useAppStore } from "@/components/state-provider";
+import type { TaskIssueLink } from "@/lib/types/github";
+import { useWorkspaceTaskIssues } from "./use-task-issues";
+
+const mocks = vi.hoisted(() => ({ listWorkspaceTaskIssues: vi.fn() }));
+
+vi.mock("@/lib/api/domains/github-api", () => ({
+  listWorkspaceTaskIssues: mocks.listWorkspaceTaskIssues,
+}));
+
+afterEach(() => {
+  cleanup();
+  mocks.listWorkspaceTaskIssues.mockReset();
+});
+
+function wrapper({ children }: { children: ReactNode }) {
+  return createElement(StateProvider, null, children);
+}
+
+describe("useWorkspaceTaskIssues", () => {
+  it("loads workspace links into the GitHub store", async () => {
+    const link: TaskIssueLink = {
+      task_id: "task-1",
+      task_title: "Linked task",
+      owner: "kdlbs",
+      repo: "kandev",
+      issue_number: 1672,
+      issue_url: "https://github.com/kdlbs/kandev/issues/1672",
+      issue_title: "",
+    };
+    mocks.listWorkspaceTaskIssues.mockResolvedValue({ task_issues: { "task-1": link } });
+
+    const { result } = renderHook(
+      () => {
+        useWorkspaceTaskIssues("ws-1");
+        return useAppStore((state) => state.taskIssues);
+      },
+      { wrapper },
+    );
+
+    await waitFor(() =>
+      expect(result.current).toEqual({ workspaceId: "ws-1", byTaskId: { "task-1": link } }),
+    );
+    expect(mocks.listWorkspaceTaskIssues).toHaveBeenCalledWith("ws-1", {
+      cache: "no-store",
+    });
+  });
+});

--- a/apps/web/hooks/domains/github/use-task-issues.ts
+++ b/apps/web/hooks/domains/github/use-task-issues.ts
@@ -1,0 +1,31 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useAppStore } from "@/components/state-provider";
+import { listWorkspaceTaskIssues } from "@/lib/api/domains/github-api";
+
+export function useWorkspaceTaskIssues(workspaceId: string | null) {
+  const setTaskIssues = useAppStore((state) => state.setTaskIssues);
+  const fetchedRef = useRef<string | null>(null);
+  const requestRef = useRef(0);
+
+  useEffect(() => {
+    if (!workspaceId) {
+      requestRef.current += 1;
+      fetchedRef.current = null;
+      return;
+    }
+    if (fetchedRef.current === workspaceId) return;
+
+    const requestId = ++requestRef.current;
+    fetchedRef.current = workspaceId;
+    listWorkspaceTaskIssues(workspaceId, { cache: "no-store" })
+      .then((response) => {
+        if (requestRef.current !== requestId) return;
+        setTaskIssues(workspaceId, response?.task_issues ?? {});
+      })
+      .catch(() => {
+        if (requestRef.current === requestId) fetchedRef.current = null;
+      });
+  }, [setTaskIssues, workspaceId]);
+}

--- a/apps/web/lib/api/domains/github-api.test.ts
+++ b/apps/web/lib/api/domains/github-api.test.ts
@@ -12,6 +12,7 @@ import {
   getTaskCIAutomationOptions,
   GitHubUnavailableError,
   linkTaskIssue,
+  listWorkspaceTaskIssues,
   unlinkTaskIssue,
   updateTaskCIAutomationOptions,
   type AccessibleRepo,
@@ -133,6 +134,18 @@ describe("fetchIssueInfo", () => {
 });
 
 describe("task issue link helpers", () => {
+  it("lists task issue links for a workspace", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ task_issues: {} }));
+
+    await listWorkspaceTaskIssues("workspace/1", { cache: "no-store" });
+
+    const call = fetchSpy.mock.calls.at(-1);
+    expect(String(call?.[0])).toBe(
+      "http://api.test/api/v1/github/task-issues?workspace_id=workspace%2F1",
+    );
+    expect(call?.[1]).toMatchObject({ cache: "no-store" });
+  });
+
   it("links a GitHub pull request to a task", async () => {
     fetchSpy.mockResolvedValueOnce(
       jsonResponse({

--- a/apps/web/lib/api/domains/github-api.ts
+++ b/apps/web/lib/api/domains/github-api.ts
@@ -21,6 +21,7 @@ import type {
   TriggerIssueResponse,
   GitHubIssue,
   TaskIssueLink,
+  TaskIssueLinksResponse,
   SearchPRsResponse,
   SearchIssuesResponse,
   GitHubPRStatus,
@@ -101,6 +102,13 @@ export async function linkTaskIssue(
       body: JSON.stringify(data),
     },
   });
+}
+
+export async function listWorkspaceTaskIssues(workspaceId: string, options?: ApiRequestOptions) {
+  return fetchJson<TaskIssueLinksResponse>(
+    `/api/v1/github/task-issues?workspace_id=${encodeURIComponent(workspaceId)}`,
+    options,
+  );
 }
 
 export async function unlinkTaskIssue(taskId: string, options?: ApiRequestOptions) {

--- a/apps/web/lib/state/default-state.ts
+++ b/apps/web/lib/state/default-state.ts
@@ -67,6 +67,7 @@ export const defaultState = {
   sessionPollMode: defaultSessionRuntimeState.sessionPollMode,
   githubStatus: defaultGitHubState.githubStatus,
   taskPRs: defaultGitHubState.taskPRs,
+  taskIssues: defaultGitHubState.taskIssues,
   pendingPrUrlByTaskId: defaultGitHubState.pendingPrUrlByTaskId,
   prWatches: defaultGitHubState.prWatches,
   reviewWatches: defaultGitHubState.reviewWatches,
@@ -207,6 +208,7 @@ export function mergeInitialState(initialState?: Partial<DefaultState>): Default
     sessionPollMode: { ...defaultState.sessionPollMode, ...initialState.sessionPollMode },
     githubStatus: { ...defaultState.githubStatus, ...initialState.githubStatus },
     taskPRs: { ...defaultState.taskPRs, ...initialState.taskPRs },
+    taskIssues: { ...defaultState.taskIssues, ...initialState.taskIssues },
     pendingPrUrlByTaskId: {
       ...defaultState.pendingPrUrlByTaskId,
       ...initialState.pendingPrUrlByTaskId,

--- a/apps/web/lib/state/slices/github/github-slice.test.ts
+++ b/apps/web/lib/state/slices/github/github-slice.test.ts
@@ -3,7 +3,12 @@ import { create } from "zustand";
 import { immer } from "zustand/middleware/immer";
 import { createGitHubSlice } from "./github-slice";
 import type { GitHubSlice } from "./types";
-import type { GitHubStatus, TaskCIAutomationOptions, TaskPR } from "@/lib/types/github";
+import type {
+  GitHubStatus,
+  TaskCIAutomationOptions,
+  TaskIssueLink,
+  TaskPR,
+} from "@/lib/types/github";
 
 function makePR(overrides: Partial<TaskPR> = {}): TaskPR {
   return {
@@ -213,6 +218,28 @@ describe("setTaskPR", () => {
 
     expect(Array.isArray(store.getState().taskPRs.byTaskId["task-1"])).toBe(true);
     expect(store.getState().taskPRs.byTaskId["task-1"]).toEqual([pr]);
+  });
+});
+
+describe("setTaskIssues", () => {
+  it("replaces workspace issue links by task id", () => {
+    const store = makeStore();
+    const link: TaskIssueLink = {
+      task_id: "task-1",
+      task_title: "Fix issue",
+      owner: "kdlbs",
+      repo: "kandev",
+      issue_number: 1672,
+      issue_url: "https://github.com/kdlbs/kandev/issues/1672",
+      issue_title: "Issue title",
+    };
+
+    store.getState().setTaskIssues("ws-1", { "task-1": link });
+
+    expect(store.getState().taskIssues).toEqual({
+      workspaceId: "ws-1",
+      byTaskId: { "task-1": link },
+    });
   });
 });
 

--- a/apps/web/lib/state/slices/github/github-slice.test.ts
+++ b/apps/web/lib/state/slices/github/github-slice.test.ts
@@ -222,17 +222,18 @@ describe("setTaskPR", () => {
 });
 
 describe("setTaskIssues", () => {
+  const link: TaskIssueLink = {
+    task_id: "task-1",
+    task_title: "Fix issue",
+    owner: "kdlbs",
+    repo: "kandev",
+    issue_number: 1672,
+    issue_url: "https://github.com/kdlbs/kandev/issues/1672",
+    issue_title: "Issue title",
+  };
+
   it("replaces workspace issue links by task id", () => {
     const store = makeStore();
-    const link: TaskIssueLink = {
-      task_id: "task-1",
-      task_title: "Fix issue",
-      owner: "kdlbs",
-      repo: "kandev",
-      issue_number: 1672,
-      issue_url: "https://github.com/kdlbs/kandev/issues/1672",
-      issue_title: "Issue title",
-    };
 
     store.getState().setTaskIssues("ws-1", { "task-1": link });
 
@@ -240,6 +241,17 @@ describe("setTaskIssues", () => {
       workspaceId: "ws-1",
       byTaskId: { "task-1": link },
     });
+  });
+
+  it("upserts issue links only for the active workspace", () => {
+    const store = makeStore();
+    store.getState().setTaskIssues("ws-1", {});
+
+    store.getState().upsertTaskIssue("ws-2", link);
+    expect(store.getState().taskIssues.byTaskId).toEqual({});
+
+    store.getState().upsertTaskIssue("ws-1", link);
+    expect(store.getState().taskIssues.byTaskId).toEqual({ "task-1": link });
   });
 });
 

--- a/apps/web/lib/state/slices/github/github-slice.test.ts
+++ b/apps/web/lib/state/slices/github/github-slice.test.ts
@@ -253,6 +253,17 @@ describe("setTaskIssues", () => {
     store.getState().upsertTaskIssue("ws-1", link);
     expect(store.getState().taskIssues.byTaskId).toEqual({ "task-1": link });
   });
+
+  it("initializes an unloaded workspace with a newly linked issue", () => {
+    const store = makeStore();
+
+    store.getState().upsertTaskIssue("ws-1", link);
+
+    expect(store.getState().taskIssues).toEqual({
+      workspaceId: "ws-1",
+      byTaskId: { "task-1": link },
+    });
+  });
 });
 
 describe("setPendingPrUrlForTask", () => {

--- a/apps/web/lib/state/slices/github/github-slice.ts
+++ b/apps/web/lib/state/slices/github/github-slice.ts
@@ -62,7 +62,10 @@ function clearPendingForTaskPR(
 
 function createTaskPRActions(
   set: ImmerSet,
-): Pick<GitHubSlice, "setTaskPRs" | "setTaskPR" | "setPendingPrUrlForTask" | "setTaskIssues"> {
+): Pick<
+  GitHubSlice,
+  "setTaskPRs" | "setTaskPR" | "setPendingPrUrlForTask" | "setTaskIssues" | "upsertTaskIssue"
+> {
   return {
     setTaskPRs: (prs) =>
       set((draft) => {
@@ -72,6 +75,11 @@ function createTaskPRActions(
       set((draft) => {
         draft.taskIssues.workspaceId = workspaceId;
         draft.taskIssues.byTaskId = issues;
+      }),
+    upsertTaskIssue: (workspaceId, issue) =>
+      set((draft) => {
+        if (draft.taskIssues.workspaceId !== workspaceId) return;
+        draft.taskIssues.byTaskId[issue.task_id] = issue;
       }),
     setTaskPR: (taskId, pr) =>
       set((draft) => {

--- a/apps/web/lib/state/slices/github/github-slice.ts
+++ b/apps/web/lib/state/slices/github/github-slice.ts
@@ -4,6 +4,7 @@ import type { GitHubSlice, GitHubSliceState } from "./types";
 export const defaultGitHubState: GitHubSliceState = {
   githubStatus: { status: null, loaded: false, loading: false },
   taskPRs: { byTaskId: {} },
+  taskIssues: { workspaceId: null, byTaskId: {} },
   pendingPrUrlByTaskId: { byTaskId: {} },
   prWatches: { items: [], loaded: false, loading: false },
   reviewWatches: { items: [], loaded: false, loading: false },
@@ -61,11 +62,16 @@ function clearPendingForTaskPR(
 
 function createTaskPRActions(
   set: ImmerSet,
-): Pick<GitHubSlice, "setTaskPRs" | "setTaskPR" | "setPendingPrUrlForTask"> {
+): Pick<GitHubSlice, "setTaskPRs" | "setTaskPR" | "setPendingPrUrlForTask" | "setTaskIssues"> {
   return {
     setTaskPRs: (prs) =>
       set((draft) => {
         draft.taskPRs.byTaskId = prs;
+      }),
+    setTaskIssues: (workspaceId, issues) =>
+      set((draft) => {
+        draft.taskIssues.workspaceId = workspaceId;
+        draft.taskIssues.byTaskId = issues;
       }),
     setTaskPR: (taskId, pr) =>
       set((draft) => {

--- a/apps/web/lib/state/slices/github/github-slice.ts
+++ b/apps/web/lib/state/slices/github/github-slice.ts
@@ -78,7 +78,8 @@ function createTaskPRActions(
       }),
     upsertTaskIssue: (workspaceId, issue) =>
       set((draft) => {
-        if (draft.taskIssues.workspaceId !== workspaceId) return;
+        if (draft.taskIssues.workspaceId && draft.taskIssues.workspaceId !== workspaceId) return;
+        draft.taskIssues.workspaceId = workspaceId;
         draft.taskIssues.byTaskId[issue.task_id] = issue;
       }),
     setTaskPR: (taskId, pr) =>

--- a/apps/web/lib/state/slices/github/types.ts
+++ b/apps/web/lib/state/slices/github/types.ts
@@ -2,6 +2,7 @@ import type {
   GitHubStatus,
   GitHubRateLimitUpdate,
   TaskPR,
+  TaskIssueLink,
   PRWatch,
   ReviewWatch,
   IssueWatch,
@@ -19,6 +20,11 @@ export type GitHubStatusState = {
 export type TaskPRsState = {
   /** Each task may have multiple PRs (one per repository for multi-repo tasks). */
   byTaskId: Record<string, TaskPR[]>;
+};
+
+export type TaskIssuesState = {
+  workspaceId: string | null;
+  byTaskId: Record<string, TaskIssueLink>;
 };
 
 export type PendingPrUrlsState = {
@@ -72,6 +78,7 @@ export type TaskCIAutomationOptionsState = {
 export type GitHubSliceState = {
   githubStatus: GitHubStatusState;
   taskPRs: TaskPRsState;
+  taskIssues: TaskIssuesState;
   pendingPrUrlByTaskId: PendingPrUrlsState;
   prWatches: PRWatchesState;
   reviewWatches: ReviewWatchesState;
@@ -85,6 +92,7 @@ export type GitHubSliceActions = {
   setGitHubStatus: (status: GitHubStatus | null) => void;
   setGitHubStatusLoading: (loading: boolean) => void;
   setTaskPRs: (prs: Record<string, TaskPR[]>) => void;
+  setTaskIssues: (workspaceId: string, issues: Record<string, TaskIssueLink>) => void;
   setTaskPR: (taskId: string, pr: TaskPR) => void;
   setPendingPrUrlForTask: (taskId: string, repoKey: string, prUrl: string) => void;
   setPRWatches: (watches: PRWatch[]) => void;

--- a/apps/web/lib/state/slices/github/types.ts
+++ b/apps/web/lib/state/slices/github/types.ts
@@ -93,6 +93,7 @@ export type GitHubSliceActions = {
   setGitHubStatusLoading: (loading: boolean) => void;
   setTaskPRs: (prs: Record<string, TaskPR[]>) => void;
   setTaskIssues: (workspaceId: string, issues: Record<string, TaskIssueLink>) => void;
+  upsertTaskIssue: (workspaceId: string, issue: TaskIssueLink) => void;
   setTaskPR: (taskId: string, pr: TaskPR) => void;
   setPendingPrUrlForTask: (taskId: string, repoKey: string, prUrl: string) => void;
   setPRWatches: (watches: PRWatch[]) => void;

--- a/apps/web/lib/state/store.ts
+++ b/apps/web/lib/state/store.ts
@@ -181,6 +181,7 @@ export type AppState = {
   // GitHub slice
   githubStatus: (typeof defaultGitHubState)["githubStatus"];
   taskPRs: (typeof defaultGitHubState)["taskPRs"];
+  taskIssues: (typeof defaultGitHubState)["taskIssues"];
   pendingPrUrlByTaskId: (typeof defaultGitHubState)["pendingPrUrlByTaskId"];
   prWatches: (typeof defaultGitHubState)["prWatches"];
   reviewWatches: (typeof defaultGitHubState)["reviewWatches"];

--- a/apps/web/lib/types/github.ts
+++ b/apps/web/lib/types/github.ts
@@ -452,11 +452,16 @@ export type GitHubIssue = {
 
 export type TaskIssueLink = {
   task_id: string;
+  task_title: string;
   owner: string;
   repo: string;
   issue_number: number;
   issue_url: string;
   issue_title: string;
+};
+
+export type TaskIssueLinksResponse = {
+  task_issues: Record<string, TaskIssueLink>;
 };
 
 export type SearchPRsResponse = {

--- a/docs/plans/github-issue-task-linking/plan.md
+++ b/docs/plans/github-issue-task-linking/plan.md
@@ -1,0 +1,58 @@
+---
+spec: docs/specs/tasks/link-existing-task-github-issue.md
+created: 2026-07-13
+status: completed
+---
+
+# Implementation Plan: GitHub Issue Task Linking
+
+## Overview
+
+Reuse the metadata-backed GitHub issue link introduced for existing tasks. Add a workspace reverse lookup, call the existing link endpoint after issue quick-launch creation, and reuse the PR task-indicator interaction for issue rows without changing issue-watch deduplication.
+
+## Backend
+
+- Add `GET /api/v1/github/task-issues?workspace_id=<id>` in `apps/backend/internal/github/controller.go`.
+- Extend `apps/backend/internal/github/service_task_issue.go` with a workspace lookup that normalizes manual-link and issue-watch metadata into `TaskIssueLinkResponse` records grouped by task ID.
+- Add an indexed workspace-scoped metadata projection in `apps/backend/internal/github/store.go`; it reads `tasks.id`, `tasks.title`, and `tasks.metadata` without adding a second association table.
+
+## Frontend
+
+- Add the workspace task-issue API and types in `apps/web/lib/api/domains/github-api.ts` and `apps/web/lib/types/github.ts`.
+- Add `taskIssues.byTaskId` state and a `useIssueKeyToTasks` reverse-map hook following `usePRKeyToTasks`.
+- Call `linkTaskIssue` from `quick-task-launcher.tsx` after an issue task is created.
+- Extract the shared task-row indicator interaction from `PRRowTaskIndicator`, then render it from `issue-list.tsx` only for linked issues.
+- Pass the reverse map through `github-page-client.tsx`. Existing responsive row wrapping remains the desktop and mobile layout.
+
+## Tests
+
+- Backend service/store/controller tests cover manual and watched metadata shapes, malformed metadata, required workspace scope, and cross-workspace isolation.
+- Frontend API, store, hook, launcher, and indicator tests cover fetch shape, grouping multiple tasks, the automatic link call, empty issue behavior, and navigation labels.
+
+## E2E Tests
+
+- Desktop: seed linked and unlinked issues, verify single/multiple indicators, and navigate to a linked task.
+- Mobile: open the issues view, verify the linked indicator remains reachable without horizontal overflow, and tap through to the task.
+
+## Implementation Waves
+
+1. [x] [task-01-backend-reverse-lookup](task-01-backend-reverse-lookup.md)
+2. [x] [task-02-frontend-link-and-indicator](task-02-frontend-link-and-indicator.md)
+3. [x] [task-03-e2e-and-verification](task-03-e2e-and-verification.md)
+
+## Verification
+
+```bash
+rtk go test ./internal/github/...
+rtk pnpm --filter @kandev/web test -- --run lib/api/domains/github-api.test.ts lib/state/slices/github/github-slice.test.ts hooks/domains/github/use-issue-key-to-tasks.test.ts components/github/my-github/quick-task-launcher.test.tsx components/github/my-github/task-row-indicator.test.tsx
+rtk pnpm e2e:run tests/github/issue-list-task-indicator.spec.ts
+rtk pnpm e2e:run --no-build --project mobile-chrome tests/github/mobile-issue-list-task-indicator.spec.ts
+rtk make fmt
+rtk make typecheck test lint
+```
+
+## Risks
+
+- Metadata has two repository shapes; URL parsing is the canonical normalization path.
+- A task may be archived or absent from hydrated kanban snapshots, so the API must include a task-title fallback.
+- Automatic linking is a follow-up request after task creation and must not turn a successful task creation into a failed dialog submission.

--- a/docs/plans/github-issue-task-linking/plan.md
+++ b/docs/plans/github-issue-task-linking/plan.md
@@ -43,12 +43,12 @@ Reuse the metadata-backed GitHub issue link introduced for existing tasks. Add a
 ## Verification
 
 ```bash
-rtk go test ./internal/github/...
-rtk pnpm --filter @kandev/web test -- --run lib/api/domains/github-api.test.ts lib/state/slices/github/github-slice.test.ts hooks/domains/github/use-issue-key-to-tasks.test.ts components/github/my-github/quick-task-launcher.test.tsx components/github/my-github/task-row-indicator.test.tsx
-rtk pnpm e2e:run tests/github/issue-list-task-indicator.spec.ts
-rtk pnpm e2e:run --no-build --project mobile-chrome tests/github/mobile-issue-list-task-indicator.spec.ts
-rtk make fmt
-rtk make typecheck test lint
+cd apps/backend && go test ./internal/github/...
+cd apps && pnpm --filter @kandev/web test -- --run lib/api/domains/github-api.test.ts lib/state/slices/github/github-slice.test.ts hooks/domains/github/use-issue-key-to-tasks.test.ts components/github/my-github/quick-task-launcher.test.tsx components/github/my-github/pr-row-task-indicator.test.tsx
+cd apps/web && pnpm e2e:run tests/github/issue-list-task-indicator.spec.ts
+cd apps/web && pnpm e2e:run --no-build --project mobile-chrome tests/github/mobile-issue-list-task-indicator.spec.ts
+make fmt
+make typecheck test lint
 ```
 
 ## Risks

--- a/docs/plans/github-issue-task-linking/task-01-backend-reverse-lookup.md
+++ b/docs/plans/github-issue-task-linking/task-01-backend-reverse-lookup.md
@@ -1,0 +1,34 @@
+---
+id: "01-backend-reverse-lookup"
+title: "Backend issue-link reverse lookup"
+status: done
+wave: 1
+depends_on: []
+plan: "plan.md"
+spec: "../../specs/tasks/link-existing-task-github-issue.md"
+---
+
+# Task 01: Backend Issue-Link Reverse Lookup
+
+## Acceptance
+
+- A workspace-scoped endpoint returns valid metadata-backed GitHub issue links grouped by task ID.
+- Manual-link and issue-watch metadata resolve to the same owner/repo/number key.
+- Invalid metadata and tasks from other workspaces do not produce links.
+
+## Verification
+
+`cd apps/backend && rtk go test ./internal/github/...`
+
+## Files Likely Touched
+
+- `apps/backend/internal/github/controller.go`
+- `apps/backend/internal/github/controller_test.go`
+- `apps/backend/internal/github/service_task_issue.go`
+- `apps/backend/internal/github/service_task_issue_test.go`
+- `apps/backend/internal/github/store.go`
+- `apps/backend/internal/github/store_task_issue_test.go`
+
+## Output Contract
+
+Report the API shape, normalization behavior, files changed, tests run, blockers, and residual risks; mark this task done in this file and `plan.md`.

--- a/docs/plans/github-issue-task-linking/task-02-frontend-link-and-indicator.md
+++ b/docs/plans/github-issue-task-linking/task-02-frontend-link-and-indicator.md
@@ -18,7 +18,7 @@ spec: "../../specs/tasks/link-existing-task-github-issue.md"
 
 ## Verification
 
-`cd apps && rtk pnpm --filter @kandev/web test -- --run lib/api/domains/github-api.test.ts lib/state/slices/github/github-slice.test.ts hooks/domains/github/use-issue-key-to-tasks.test.ts components/github/my-github/quick-task-launcher.test.tsx components/github/my-github/task-row-indicator.test.tsx`
+`cd apps && pnpm --filter @kandev/web test -- --run lib/api/domains/github-api.test.ts lib/state/slices/github/github-slice.test.ts hooks/domains/github/use-issue-key-to-tasks.test.ts components/github/my-github/quick-task-launcher.test.tsx components/github/my-github/pr-row-task-indicator.test.tsx`
 
 ## Files Likely Touched
 

--- a/docs/plans/github-issue-task-linking/task-02-frontend-link-and-indicator.md
+++ b/docs/plans/github-issue-task-linking/task-02-frontend-link-and-indicator.md
@@ -1,0 +1,42 @@
+---
+id: "02-frontend-link-and-indicator"
+title: "Frontend automatic link and issue indicator"
+status: done
+wave: 2
+depends_on: ["01-backend-reverse-lookup"]
+plan: "plan.md"
+spec: "../../specs/tasks/link-existing-task-github-issue.md"
+---
+
+# Task 02: Frontend Automatic Link And Issue Indicator
+
+## Acceptance
+
+- Creating a task from an issue invokes the existing task-issue link endpoint with that issue URL.
+- Workspace links are inverted by owner/repo/number and rendered on matching issue rows.
+- Single and multiple task indicators navigate through the existing task route behavior; unlinked issue rows show no indicator.
+
+## Verification
+
+`cd apps && rtk pnpm --filter @kandev/web test -- --run lib/api/domains/github-api.test.ts lib/state/slices/github/github-slice.test.ts hooks/domains/github/use-issue-key-to-tasks.test.ts components/github/my-github/quick-task-launcher.test.tsx components/github/my-github/task-row-indicator.test.tsx`
+
+## Files Likely Touched
+
+- `apps/web/lib/types/github.ts`
+- `apps/web/lib/api/domains/github-api.ts`
+- `apps/web/lib/api/domains/github-api.test.ts`
+- `apps/web/lib/state/slices/github/types.ts`
+- `apps/web/lib/state/slices/github/github-slice.ts`
+- `apps/web/lib/state/slices/github/github-slice.test.ts`
+- `apps/web/hooks/domains/github/use-issue-key-to-tasks.ts`
+- `apps/web/hooks/domains/github/use-issue-key-to-tasks.test.ts`
+- `apps/web/components/github/my-github/quick-task-launcher.tsx`
+- `apps/web/components/github/my-github/quick-task-launcher.test.tsx`
+- `apps/web/components/github/my-github/task-row-indicator.tsx`
+- `apps/web/components/github/my-github/pr-row-task-indicator.tsx`
+- `apps/web/components/github/my-github/issue-list.tsx`
+- `apps/web/app/github/github-page-client.tsx`
+
+## Output Contract
+
+Report behavior, files changed, tests run, blockers, and mobile implications; mark this task done in this file and `plan.md`.

--- a/docs/plans/github-issue-task-linking/task-03-e2e-and-verification.md
+++ b/docs/plans/github-issue-task-linking/task-03-e2e-and-verification.md
@@ -19,9 +19,9 @@ spec: "../../specs/tasks/link-existing-task-github-issue.md"
 ## Verification
 
 ```bash
-cd apps/web && rtk pnpm e2e:run tests/github/issue-list-task-indicator.spec.ts
-cd apps/web && rtk pnpm e2e:run --no-build --project mobile-chrome tests/github/mobile-issue-list-task-indicator.spec.ts
-cd ../../ && rtk make fmt && rtk make typecheck test lint
+cd apps/web && pnpm e2e:run tests/github/issue-list-task-indicator.spec.ts
+cd apps/web && pnpm e2e:run --no-build --project mobile-chrome tests/github/mobile-issue-list-task-indicator.spec.ts
+make fmt && make typecheck test lint
 ```
 
 ## Files Likely Touched

--- a/docs/plans/github-issue-task-linking/task-03-e2e-and-verification.md
+++ b/docs/plans/github-issue-task-linking/task-03-e2e-and-verification.md
@@ -1,0 +1,35 @@
+---
+id: "03-e2e-and-verification"
+title: "Issue indicator E2E and verification"
+status: done
+wave: 3
+depends_on: ["02-frontend-link-and-indicator"]
+plan: "plan.md"
+spec: "../../specs/tasks/link-existing-task-github-issue.md"
+---
+
+# Task 03: Issue Indicator E2E And Verification
+
+## Acceptance
+
+- Desktop Playwright coverage proves linked/unlinked/multiple task states and task navigation.
+- Mobile Playwright coverage proves the indicator is reachable by touch and navigates without horizontal layout breakage.
+- Formatting, relevant tests, typecheck, and lint pass.
+
+## Verification
+
+```bash
+cd apps/web && rtk pnpm e2e:run tests/github/issue-list-task-indicator.spec.ts
+cd apps/web && rtk pnpm e2e:run --no-build --project mobile-chrome tests/github/mobile-issue-list-task-indicator.spec.ts
+cd ../../ && rtk make fmt && rtk make typecheck test lint
+```
+
+## Files Likely Touched
+
+- `apps/web/e2e/tests/github/issue-list-task-indicator.spec.ts`
+- `apps/web/e2e/tests/github/mobile-issue-list-task-indicator.spec.ts`
+- `apps/web/e2e/helpers/api-client.ts`
+
+## Output Contract
+
+Report desktop/mobile results, full verification commands, files changed, blockers, and follow-up risks; mark this task done in this file and `plan.md`.

--- a/docs/specs/tasks/link-existing-task-github-issue.md
+++ b/docs/specs/tasks/link-existing-task-github-issue.md
@@ -24,6 +24,8 @@ issue, or Sentry issue is identified later.
 - The pull request action accepts a GitHub PR URL. If the task has exactly one GitHub repository, a PR number such as `#1471` is also accepted.
 - The backend fetches the issue through the configured GitHub integration and only links it when the issue belongs to a GitHub repository attached to the task.
 - The link is stored in task metadata using the existing `issue_url` and `issue_number` fields, so kanban cards and task detail surfaces render it through the existing issue indicator.
+- Creating a task from a GitHub issue on the GitHub integration page automatically applies the same metadata-backed link after task creation.
+- The GitHub issues list resolves all metadata-backed issue links in the active workspace and shows the linked task title with navigation to that task. Links created manually, by the GitHub issue quick launcher, and by issue watches use the same indicator.
 - Pull request linking reuses the existing task PR association model and rendering.
 - A linked issue can be explicitly changed or unlinked from the same dialog.
 - Jira ticket linking is shown only when Jira is enabled and healthy for the
@@ -51,6 +53,7 @@ issue, or Sentry issue is identified later.
 - New issue synchronization beyond the existing metadata-backed reference.
 - Creating Jira tickets, Linear issues, or Sentry issues from Kandev.
 - A durable cross-provider `task_external_links` model.
+- Changing issue-watch reservation and deduplication semantics.
 - A Sentry linked-issue top-bar affordance.
 
 ## Scenarios
@@ -85,6 +88,43 @@ GIVEN an existing task that already has GitHub issue metadata
 WHEN the user opens Link > GitHub Issue and chooses Unlink
 THEN Kandev removes only the issue metadata keys and preserves unrelated task metadata
 
+### Create and link a task from the GitHub issues list
+
+GIVEN a GitHub issue shown on the GitHub integration page
+WHEN the user creates a task with an issue action preset
+THEN Kandev creates the task, stores that issue as the task's metadata-backed GitHub issue link, and preserves normal task navigation
+
+### Show tasks linked to an issue
+
+GIVEN one or more active-workspace tasks reference the same GitHub issue through task metadata
+WHEN the GitHub issues list renders that issue
+THEN the issue row shows the linked task title for one task or a task-count menu for multiple tasks, and each entry navigates to its task
+
+### Include issue-watch tasks in the issue indicator
+
+GIVEN an issue watch created a task with `issue_url`, `issue_number`, and `issue_repo` metadata
+WHEN the matching issue appears on the GitHub issues list
+THEN the issue row shows that task through the same indicator as a manually linked task
+
+### Keep unlinked issues unchanged
+
+GIVEN no task in the active workspace references a GitHub issue
+WHEN the GitHub issues list renders that issue
+THEN no task indicator is shown and the existing issue actions remain available
+
+## Data And API
+
+- Task metadata remains the canonical GitHub issue association. Manual links include `issue_url`, `issue_number`, `issue_owner`, `issue_repo`, and `github_issue_linked`; issue-watch tasks may use the legacy `issue_repo: owner/repo` shape.
+- Each task links to at most one GitHub issue, while one GitHub issue may link to multiple tasks.
+- `GET /api/v1/github/task-issues?workspace_id=<id>` returns links grouped by task ID for the requested workspace. The lookup derives owner, repository, and issue number from the canonical GitHub issue URL and never returns links from another workspace.
+- The workspace lookup uses the indexed task workspace boundary and does not depend on the GitHub token being currently configured because it reads persisted task metadata.
+
+## Failure Modes
+
+- A failed automatic link attempt does not roll back a successfully created task or block navigation to it.
+- Invalid or incomplete GitHub issue metadata is ignored by the workspace reverse lookup instead of producing a misleading issue-row association.
+- Existing link validation continues to reject issues from repositories not attached to the task.
+
 ### Link a Jira ticket to an existing task
 
 GIVEN Jira is enabled and healthy for the task workspace
@@ -115,3 +155,4 @@ THEN Kandev renames the task to `ENG-20: Fix login` instead of stacking prefixes
 - Invalid issue references and repository mismatches return clear errors.
 - Right-click context menu, sidebar menu, and touch/dropdown menu users can reach the Link submenu.
 - Jira, Linear, and Sentry actions are hidden when the corresponding integration is disabled or unauthenticated.
+- GitHub issue links are visible only in their task workspace, including after page reload.


### PR DESCRIPTION
GitHub issue tasks now retain their canonical task link and surface it directly in the issues view, so users can move from an issue to its related work without rebuilding the association manually.

## Important Changes

- Adds a workspace-scoped reverse lookup for manual and issue-watch task metadata.
- Links issue quick-launch tasks after creation without blocking normal navigation on link failure.
- Reuses the PR task indicator for single and multiple linked tasks, with desktop and mobile coverage.

## Validation

- `make fmt`
- `make typecheck`
- `make test`
- `make lint`
- `cd apps/web && pnpm e2e:run tests/github/issue-list-task-indicator.spec.ts`
- `cd apps/web && pnpm e2e:run --no-build --project mobile-chrome tests/github/mobile-issue-list-task-indicator.spec.ts`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.

Closes #1672


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1676?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->