### PR TITLE
fix: prevent stale ready events from completing replacement turns

### DIFF
--- a/apps/backend/internal/agent/runtime/agentctl/agent.go
+++ b/apps/backend/internal/agent/runtime/agentctl/agent.go
@@ -247,11 +247,17 @@ func (c *Client) Authenticate(ctx context.Context, methodID string) error {
 // Prompt sends a fire-and-forget prompt to the agent via the agent WebSocket stream.
 // The server returns an accepted response immediately; completion is signaled via stream events.
 // Attachments (images) are passed to the agent if provided.
-func (c *Client) Prompt(ctx context.Context, text string, attachments []v1.MessageAttachment) error {
+func (c *Client) Prompt(
+	ctx context.Context,
+	text string,
+	attachments []v1.MessageAttachment,
+	promptGeneration uint64,
+) error {
 	payload := struct {
-		Text        string                 `json:"text"`
-		Attachments []v1.MessageAttachment `json:"attachments,omitempty"`
-	}{Text: text, Attachments: attachments}
+		Text             string                 `json:"text"`
+		Attachments      []v1.MessageAttachment `json:"attachments,omitempty"`
+		PromptGeneration uint64                 `json:"prompt_generation,omitempty"`
+	}{Text: text, Attachments: attachments, PromptGeneration: promptGeneration}
 
 	resp, err := c.sendStreamRequest(ctx, "agent.prompt", payload)
 	if err != nil {

--- a/apps/backend/internal/agent/runtime/agentctl/agent_test.go
+++ b/apps/backend/internal/agent/runtime/agentctl/agent_test.go
@@ -450,13 +450,17 @@ func TestPrompt_Success(t *testing.T) {
 		}
 		// Verify payload
 		var payload struct {
-			Text string `json:"text"`
+			Text             string `json:"text"`
+			PromptGeneration uint64 `json:"prompt_generation"`
 		}
 		if err := msg.ParsePayload(&payload); err != nil {
 			t.Errorf("failed to parse payload: %v", err)
 		}
 		if payload.Text != "hello agent" {
 			t.Errorf("expected text 'hello agent', got %q", payload.Text)
+		}
+		if payload.PromptGeneration != 42 {
+			t.Errorf("expected prompt generation 42, got %d", payload.PromptGeneration)
 		}
 		resp, _ := ws.NewResponse(msg.ID, msg.Action, map[string]interface{}{
 			"success": true,
@@ -469,7 +473,7 @@ func TestPrompt_Success(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	err := c.Prompt(ctx, "hello agent", nil)
+	err := c.Prompt(ctx, "hello agent", nil, 42)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -486,7 +490,7 @@ func TestPrompt_NoActiveSession(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	err := c.Prompt(ctx, "hello agent", nil)
+	err := c.Prompt(ctx, "hello agent", nil, 0)
 	if err == nil {
 		t.Fatal("expected error")
 	}

--- a/apps/backend/internal/agent/runtime/lifecycle/event_types.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/event_types.go
@@ -19,6 +19,7 @@ type AgentEventPayload struct {
 	FinishedAt       *time.Time `json:"finished_at,omitempty"`
 	ErrorMessage     string     `json:"error_message,omitempty"`
 	ExitCode         *int       `json:"exit_code,omitempty"`
+	PromptGeneration uint64     `json:"prompt_generation,omitempty"`
 }
 
 // AgentctlEventPayload is the payload for agentctl lifecycle events (starting, ready, error).

--- a/apps/backend/internal/agent/runtime/lifecycle/events.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/events.go
@@ -31,11 +31,31 @@ func NewEventPublisher(eventBus bus.EventBus, log *logger.Logger) *EventPublishe
 
 // PublishAgentEvent publishes an agent lifecycle event (started, stopped, ready, completed, failed).
 func (p *EventPublisher) PublishAgentEvent(ctx context.Context, eventType string, execution *AgentExecution) {
+	p.publishAgentEventPayload(ctx, eventType, newAgentEventPayload(execution))
+}
+
+// publishAgentEventPayload publishes an immutable agent lifecycle snapshot.
+func (p *EventPublisher) publishAgentEventPayload(ctx context.Context, eventType string, payload AgentEventPayload) {
 	if p.eventBus == nil {
 		return
 	}
 
-	payload := AgentEventPayload{
+	event := bus.NewEvent(eventType, "agent-manager", payload)
+
+	if err := p.eventBus.Publish(ctx, eventType, event); err != nil {
+		p.logger.Error("failed to publish event",
+			zap.String("event_type", eventType),
+			zap.String("instance_id", payload.AgentExecutionID),
+			zap.Error(err))
+	} else {
+		p.logger.Debug("published agent event",
+			zap.String("event_type", eventType),
+			zap.String("instance_id", payload.AgentExecutionID))
+	}
+}
+
+func newAgentEventPayload(execution *AgentExecution) AgentEventPayload {
+	return AgentEventPayload{
 		AgentExecutionID: execution.ID,
 		TaskID:           execution.TaskID,
 		SessionID:        execution.SessionID,
@@ -46,19 +66,7 @@ func (p *EventPublisher) PublishAgentEvent(ctx context.Context, eventType string
 		FinishedAt:       execution.FinishedAt,
 		ErrorMessage:     execution.ErrorMessage,
 		ExitCode:         execution.ExitCode,
-	}
-
-	event := bus.NewEvent(eventType, "agent-manager", payload)
-
-	if err := p.eventBus.Publish(ctx, eventType, event); err != nil {
-		p.logger.Error("failed to publish event",
-			zap.String("event_type", eventType),
-			zap.String("instance_id", execution.ID),
-			zap.Error(err))
-	} else {
-		p.logger.Debug("published agent event",
-			zap.String("event_type", eventType),
-			zap.String("instance_id", execution.ID))
+		PromptGeneration: execution.promptGeneration,
 	}
 }
 

--- a/apps/backend/internal/agent/runtime/lifecycle/execution_store.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/execution_store.go
@@ -134,6 +134,20 @@ func (s *ExecutionStore) GetBySessionID(sessionID string) (*AgentExecution, bool
 	return execution, exists
 }
 
+// OwnsPromptGeneration reports whether executionID and generation still own
+// sessionID's active lifecycle prompt.
+func (s *ExecutionStore) OwnsPromptGeneration(sessionID, executionID string, generation uint64) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	currentExecutionID, exists := s.bySession[sessionID]
+	if !exists || currentExecutionID != executionID {
+		return false
+	}
+	execution, exists := s.executions[currentExecutionID]
+	return exists && generation != 0 && execution.promptGeneration == generation
+}
+
 // GetByTaskEnvironmentID returns any execution associated with a task environment ID.
 func (s *ExecutionStore) GetByTaskEnvironmentID(taskEnvironmentID string) (*AgentExecution, bool) {
 	s.mu.RLock()
@@ -179,8 +193,15 @@ func (s *ExecutionStore) UpdateStatus(executionID string, status v1.AgentStatus)
 	defer s.mu.Unlock()
 
 	if execution, exists := s.executions[executionID]; exists {
-		execution.Status = status
+		setExecutionStatus(execution, status)
 	}
+}
+
+func setExecutionStatus(execution *AgentExecution, status v1.AgentStatus) {
+	if status == v1.AgentStatusRunning && execution.Status != v1.AgentStatusRunning {
+		execution.promptGeneration++
+	}
+	execution.Status = status
 }
 
 // UpdateError updates the error message of an agent execution and sets its status to failed.

--- a/apps/backend/internal/agent/runtime/lifecycle/execution_store.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/execution_store.go
@@ -193,15 +193,26 @@ func (s *ExecutionStore) UpdateStatus(executionID string, status v1.AgentStatus)
 	defer s.mu.Unlock()
 
 	if execution, exists := s.executions[executionID]; exists {
-		setExecutionStatus(execution, status)
+		execution.Status = status
 	}
 }
 
-func setExecutionStatus(execution *AgentExecution, status v1.AgentStatus) {
-	if status == v1.AgentStatusRunning && execution.Status != v1.AgentStatusRunning {
-		execution.promptGeneration++
+// BeginPrompt assigns a new immutable identity to the next prompt dispatch.
+func (s *ExecutionStore) BeginPrompt(executionID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	execution, exists := s.executions[executionID]
+	if !exists {
+		return ErrExecutionNotFound
 	}
-	execution.Status = status
+	beginExecutionPrompt(execution)
+	return nil
+}
+
+func beginExecutionPrompt(execution *AgentExecution) {
+	execution.promptGeneration++
+	execution.Status = v1.AgentStatusRunning
 }
 
 // UpdateError updates the error message of an agent execution and sets its status to failed.

--- a/apps/backend/internal/agent/runtime/lifecycle/execution_store.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/execution_store.go
@@ -198,21 +198,28 @@ func (s *ExecutionStore) UpdateStatus(executionID string, status v1.AgentStatus)
 }
 
 // BeginPrompt assigns a new immutable identity to the next prompt dispatch.
-func (s *ExecutionStore) BeginPrompt(executionID string) error {
+func (s *ExecutionStore) BeginPrompt(executionID string) (uint64, error) {
+	execution, exists := s.Get(executionID)
+	if !exists {
+		return 0, ErrExecutionNotFound
+	}
+	execution.promptLifecycleMu.Lock()
+	defer execution.promptLifecycleMu.Unlock()
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	execution, exists := s.executions[executionID]
-	if !exists {
-		return ErrExecutionNotFound
+	current, exists := s.executions[executionID]
+	if !exists || current != execution {
+		return 0, ErrExecutionNotFound
 	}
-	beginExecutionPrompt(execution)
-	return nil
+	return beginExecutionPrompt(current), nil
 }
 
-func beginExecutionPrompt(execution *AgentExecution) {
+func beginExecutionPrompt(execution *AgentExecution) uint64 {
 	execution.promptGeneration++
 	execution.Status = v1.AgentStatusRunning
+	return execution.promptGeneration
 }
 
 // UpdateError updates the error message of an agent execution and sets its status to failed.

--- a/apps/backend/internal/agent/runtime/lifecycle/execution_store_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/execution_store_test.go
@@ -81,23 +81,27 @@ func TestExecutionStore_AddNoSessionIDAlwaysSucceeds(t *testing.T) {
 	}
 }
 
-func TestExecutionStore_UpdateStatusAdvancesPromptGeneration(t *testing.T) {
+func TestExecutionStore_BeginPromptAlwaysAdvancesGeneration(t *testing.T) {
 	store := NewExecutionStore()
 	exec := &AgentExecution{
 		ID:        "exec-1",
 		SessionID: "session-1",
-		Status:    v1.AgentStatusReady,
+		Status:    v1.AgentStatusRunning,
 	}
 	if err := store.Add(exec); err != nil {
 		t.Fatalf("Add: %v", err)
 	}
 
-	store.UpdateStatus(exec.ID, v1.AgentStatusRunning)
-	if !store.OwnsPromptGeneration(exec.SessionID, exec.ID, 1) {
-		t.Fatal("first running transition must create generation 1")
+	if err := store.BeginPrompt(exec.ID); err != nil {
+		t.Fatalf("BeginPrompt: %v", err)
 	}
-	store.UpdateStatus(exec.ID, v1.AgentStatusRunning)
 	if !store.OwnsPromptGeneration(exec.SessionID, exec.ID, 1) {
-		t.Fatal("duplicate running status must retain generation 1")
+		t.Fatal("first prompt must create generation 1")
+	}
+	if err := store.BeginPrompt(exec.ID); err != nil {
+		t.Fatalf("BeginPrompt replacement: %v", err)
+	}
+	if !store.OwnsPromptGeneration(exec.SessionID, exec.ID, 2) {
+		t.Fatal("replacement prompt must create generation 2 while already running")
 	}
 }

--- a/apps/backend/internal/agent/runtime/lifecycle/execution_store_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/execution_store_test.go
@@ -92,13 +92,13 @@ func TestExecutionStore_BeginPromptAlwaysAdvancesGeneration(t *testing.T) {
 		t.Fatalf("Add: %v", err)
 	}
 
-	if err := store.BeginPrompt(exec.ID); err != nil {
+	if _, err := store.BeginPrompt(exec.ID); err != nil {
 		t.Fatalf("BeginPrompt: %v", err)
 	}
 	if !store.OwnsPromptGeneration(exec.SessionID, exec.ID, 1) {
 		t.Fatal("first prompt must create generation 1")
 	}
-	if err := store.BeginPrompt(exec.ID); err != nil {
+	if _, err := store.BeginPrompt(exec.ID); err != nil {
 		t.Fatalf("BeginPrompt replacement: %v", err)
 	}
 	if !store.OwnsPromptGeneration(exec.SessionID, exec.ID, 2) {

--- a/apps/backend/internal/agent/runtime/lifecycle/execution_store_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/execution_store_test.go
@@ -3,6 +3,8 @@ package lifecycle
 import (
 	"errors"
 	"testing"
+
+	v1 "github.com/kandev/kandev/pkg/api/v1"
 )
 
 // TestExecutionStore_AddRejectsDuplicateSession is the regression test for the
@@ -76,5 +78,26 @@ func TestExecutionStore_AddNoSessionIDAlwaysSucceeds(t *testing.T) {
 	}
 	if err := store.Add(&AgentExecution{ID: "exec-b"}); err != nil {
 		t.Errorf("Add without SessionID (second): %v", err)
+	}
+}
+
+func TestExecutionStore_UpdateStatusAdvancesPromptGeneration(t *testing.T) {
+	store := NewExecutionStore()
+	exec := &AgentExecution{
+		ID:        "exec-1",
+		SessionID: "session-1",
+		Status:    v1.AgentStatusReady,
+	}
+	if err := store.Add(exec); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	store.UpdateStatus(exec.ID, v1.AgentStatusRunning)
+	if !store.OwnsPromptGeneration(exec.SessionID, exec.ID, 1) {
+		t.Fatal("first running transition must create generation 1")
+	}
+	store.UpdateStatus(exec.ID, v1.AgentStatusRunning)
+	if !store.OwnsPromptGeneration(exec.SessionID, exec.ID, 1) {
+		t.Fatal("duplicate running status must retain generation 1")
 	}
 }

--- a/apps/backend/internal/agent/runtime/lifecycle/manager.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager.go
@@ -218,7 +218,7 @@ func NewManager(
 
 	// Set session manager dependencies for full orchestration
 	sessionManager.SetDependencies(eventPublisher, mgr.streamManager, executionStore, historyManager)
-	sessionManager.SetStatusUpdater(mgr.UpdateStatus)
+	sessionManager.SetPromptStarter(mgr.BeginPrompt)
 
 	mgr.pollAggregator = newWorkspacePollAggregator(mgr)
 

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_events.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_events.go
@@ -161,8 +161,107 @@ func handleCompleteEventSignal(execution *AgentExecution, event *agentctl.AgentE
 	}
 }
 
+type promptCompletionClaim struct {
+	execution      *AgentExecution
+	readyPayload   AgentEventPayload
+	runningPayload AgentEventPayload
+	publishRunning bool
+	locked         bool
+}
+
+func (m *Manager) claimPromptCompletion(
+	execution *AgentExecution,
+	event *agentctl.AgentEvent,
+	isError bool,
+) (promptCompletionClaim, bool) {
+	claim := promptCompletionClaim{}
+	if event.PromptGeneration == 0 {
+		return claim, true
+	}
+
+	execution.promptLifecycleMu.Lock()
+	claim.locked = true
+	claimed := false
+	err := m.executionStore.WithLock(execution.ID, func(current *AgentExecution) {
+		if current != execution || current.promptGeneration != event.PromptGeneration {
+			return
+		}
+		claimed = true
+		claim.execution = current
+		if isError {
+			return
+		}
+		if current.Status != v1.AgentStatusReady {
+			current.firstActivityOnce.Do(func() {
+				claim.publishRunning = true
+				claim.runningPayload = newAgentEventPayload(current)
+			})
+		}
+		current.Status = v1.AgentStatusReady
+		claim.readyPayload = newAgentEventPayload(current)
+	})
+	if err == nil && claimed {
+		return claim, true
+	}
+
+	execution.promptLifecycleMu.Unlock()
+	m.logger.Debug("ignoring completion for superseded prompt generation",
+		zap.String("execution_id", execution.ID),
+		zap.Uint64("event_prompt_generation", event.PromptGeneration))
+	return promptCompletionClaim{}, false
+}
+
+func completeEventResult(event *agentctl.AgentEvent) (bool, string) {
+	isError := false
+	if event.Data != nil {
+		isError, _ = event.Data["is_error"].(bool)
+	}
+	if isError {
+		return true, "error"
+	}
+	if event.Data != nil {
+		if stopReason, ok := event.Data["stop_reason"].(string); ok && stopReason != "" {
+			return false, stopReason
+		}
+	}
+	return false, "end_turn"
+}
+
+func (m *Manager) finishPromptCompletion(
+	execution *AgentExecution,
+	event *agentctl.AgentEvent,
+	isError bool,
+	claim promptCompletionClaim,
+) {
+	handleCompleteEventSignal(execution, event, isError)
+	if event.PromptGeneration == 0 || isError {
+		m.handleCompleteEventMarkState(execution, event, isError)
+		if claim.locked {
+			execution.promptLifecycleMu.Unlock()
+		}
+		return
+	}
+
+	m.persistExecutorRunning(context.Background(), claim.execution)
+	execution.promptLifecycleMu.Unlock()
+	if claim.publishRunning {
+		m.eventPublisher.publishAgentEventPayload(context.Background(), events.AgentRunning, claim.runningPayload)
+	}
+	m.eventPublisher.publishAgentEventPayload(context.Background(), events.AgentReady, claim.readyPayload)
+}
+
 // handleCompleteEvent handles a "complete" agent event: flushes buffers, marks state, and signals SendPrompt.
-func (m *Manager) handleCompleteEvent(execution *AgentExecution, event *agentctl.AgentEvent) {
+func (m *Manager) handleCompleteEvent(execution *AgentExecution, event *agentctl.AgentEvent) bool {
+	isError, stopReason := completeEventResult(event)
+	claim, claimed := m.claimPromptCompletion(execution, event, isError)
+	if !claimed {
+		return false
+	}
+
+	execution.lastActivityAtMu.Lock()
+	execution.lastActivityAt = time.Now()
+	execution.lastActivityAtMu.Unlock()
+
 	// Check buffer content BEFORE any processing
 	execution.messageMu.Lock()
 	bufferContentBeforeFlush := execution.messageBuffer.String()
@@ -172,24 +271,6 @@ func (m *Manager) handleCompleteEvent(execution *AgentExecution, event *agentctl
 	bufferPreview := bufferContentBeforeFlush
 	if len(bufferPreview) > 100 {
 		bufferPreview = bufferPreview[:100] + "..."
-	}
-
-	// Check if this is an error completion (agent failed to process the prompt)
-	isError := false
-	if event.Data != nil {
-		if v, ok := event.Data["is_error"].(bool); ok {
-			isError = v
-		}
-	}
-
-	// Determine stop reason for tracing
-	stopReason := "end_turn"
-	if isError {
-		stopReason = "error"
-	} else if event.Data != nil {
-		if sr, ok := event.Data["stop_reason"].(string); ok && sr != "" {
-			stopReason = sr
-		}
 	}
 
 	// Create a turn_end span on the session trace
@@ -231,8 +312,8 @@ func (m *Manager) handleCompleteEvent(execution *AgentExecution, event *agentctl
 	// the drain races with the first SendPrompt's receive and can steal the signal,
 	// leaving the first SendPrompt hung and the second prompt's completion event
 	// never reaching the event bus.
-	handleCompleteEventSignal(execution, event, isError)
-	m.handleCompleteEventMarkState(execution, event, isError)
+	m.finishPromptCompletion(execution, event, isError, claim)
+	return true
 }
 
 // handleToolCallEvent processes the "tool_call" agent event: flushes the message buffer
@@ -407,7 +488,17 @@ func (m *Manager) handleStreamDisconnect(execution *AgentExecution, err error) {
 
 // handleAgentEvent processes incoming agent events from the agent
 func (m *Manager) handleAgentEvent(execution *AgentExecution, event agentctl.AgentEvent) {
-	m.recordActivity(execution, event)
+	if event.Type == "error" &&
+		event.PromptGeneration != 0 &&
+		!m.OwnsPromptGeneration(execution.SessionID, execution.ID, event.PromptGeneration) {
+		m.logger.Debug("ignoring error for superseded prompt generation",
+			zap.String("execution_id", execution.ID),
+			zap.Uint64("event_prompt_generation", event.PromptGeneration))
+		return
+	}
+	if event.Type != toolStatusComplete || event.PromptGeneration == 0 {
+		m.recordActivity(execution, event)
+	}
 
 	m.logger.Debug("handleAgentEvent entry",
 		zap.String("execution_id", execution.ID),
@@ -439,7 +530,9 @@ func (m *Manager) handleAgentEvent(execution *AgentExecution, event agentctl.Age
 		return
 
 	case toolStatusComplete:
-		m.handleCompleteEvent(execution, &event)
+		if !m.handleCompleteEvent(execution, &event) {
+			return
+		}
 
 	case "permission_request":
 		m.logger.Debug("permission request received",

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_events.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_events.go
@@ -349,18 +349,18 @@ func (m *Manager) handleToolUpdateEvent(execution *AgentExecution, event agentct
 	}
 }
 
-// handleErrorEvent processes the "error" agent event: flushes buffers, marks state as failed,
-// and signals prompt completion. The raw error event is not published to the frontend stream;
-// the agent failure path (handleAgentFailed) sets session FAILED with the error message.
-func (m *Manager) handleErrorEvent(execution *AgentExecution, event agentctl.AgentEvent) {
-	m.flushMessageBuffer(execution)
-	m.logger.Error("agent error",
-		zap.String("execution_id", execution.ID),
-		zap.String("error", event.Error),
-		zap.String("text", event.Text),
-		zap.Any("data", event.Data))
-	m.handleCompleteEventMarkState(execution, &event, true)
-	handleCompleteEventSignal(execution, &event, true)
+// handleErrorEvent processes a raw "error" as an error completion so generation
+// ownership remains held across validation, buffer flushing, and state mutation.
+// The raw error event is not published to the frontend stream; the agent failure
+// path (handleAgentFailed) sets session FAILED with the error message.
+func (m *Manager) handleErrorEvent(execution *AgentExecution, event agentctl.AgentEvent) bool {
+	data := make(map[string]any, len(event.Data)+1)
+	for key, value := range event.Data {
+		data[key] = value
+	}
+	data["is_error"] = true
+	event.Data = data
+	return m.handleCompleteEvent(execution, &event)
 }
 
 // handleContextWindowEvent processes the "context_window" agent event: logs and publishes it.
@@ -488,15 +488,7 @@ func (m *Manager) handleStreamDisconnect(execution *AgentExecution, err error) {
 
 // handleAgentEvent processes incoming agent events from the agent
 func (m *Manager) handleAgentEvent(execution *AgentExecution, event agentctl.AgentEvent) {
-	if event.Type == "error" &&
-		event.PromptGeneration != 0 &&
-		!m.OwnsPromptGeneration(execution.SessionID, execution.ID, event.PromptGeneration) {
-		m.logger.Debug("ignoring error for superseded prompt generation",
-			zap.String("execution_id", execution.ID),
-			zap.Uint64("event_prompt_generation", event.PromptGeneration))
-		return
-	}
-	if event.Type != toolStatusComplete || event.PromptGeneration == 0 {
+	if event.PromptGeneration == 0 || (event.Type != toolStatusComplete && event.Type != "error") {
 		m.recordActivity(execution, event)
 	}
 

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_events_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_events_test.go
@@ -6,7 +6,11 @@ import (
 	"testing"
 	"time"
 
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+
 	agentctl "github.com/kandev/kandev/internal/agent/runtime/agentctl"
+	"github.com/kandev/kandev/internal/common/logger"
 	"github.com/kandev/kandev/internal/events"
 	"github.com/kandev/kandev/internal/events/bus"
 	v1 "github.com/kandev/kandev/pkg/api/v1"
@@ -603,6 +607,90 @@ func TestHandleAgentEvent_DelayedCompleteCannotFinishReplacementPrompt(t *testin
 		if published.Subject == events.AgentReady {
 			t.Fatal("delayed completion published AgentReady for replacement prompt")
 		}
+	}
+}
+
+func TestHandleAgentEvent_ErrorClaimCannotRaceReplacementPrompt(t *testing.T) {
+	mgr, _ := createTestManagerWithTracking()
+	execution := createTestExecution("exec-1", "task-1", "session-1")
+	if err := mgr.executionStore.Add(execution); err != nil {
+		t.Fatalf("add execution: %v", err)
+	}
+	if _, err := mgr.executionStore.BeginPrompt(execution.ID); err != nil {
+		t.Fatalf("begin original prompt: %v", err)
+	}
+
+	errorReached := make(chan struct{})
+	releaseError := make(chan struct{})
+	var blockOnce sync.Once
+	zapLogger := zap.NewExample().WithOptions(zap.Hooks(func(entry zapcore.Entry) error {
+		if entry.Message != "agent error" && entry.Message != "agent turn complete" {
+			return nil
+		}
+		blockOnce.Do(func() {
+			close(errorReached)
+			<-releaseError
+		})
+		return nil
+	}))
+	mgr.logger, _ = logger.NewFromZap(zapLogger)
+
+	errorHandled := make(chan struct{})
+	go func() {
+		defer close(errorHandled)
+		mgr.handleAgentEvent(execution, agentctl.AgentEvent{
+			Type:             "error",
+			Error:            "original prompt failed",
+			SessionID:        execution.SessionID,
+			PromptGeneration: 1,
+		})
+	}()
+	<-errorReached
+
+	errorOwnsLifecycle := !execution.promptLifecycleMu.TryLock()
+	if !errorOwnsLifecycle {
+		execution.promptLifecycleMu.Unlock()
+	}
+
+	replacementStarted := make(chan error, 1)
+	go func() {
+		_, err := mgr.executionStore.BeginPrompt(execution.ID)
+		replacementStarted <- err
+	}()
+	writeReplacementOutput := func() {
+		execution.messageMu.Lock()
+		execution.messageBuffer.WriteString("replacement output")
+		execution.currentMessageID = "replacement-message"
+		execution.messageMu.Unlock()
+	}
+	if !errorOwnsLifecycle {
+		if err := <-replacementStarted; err != nil {
+			t.Fatalf("begin replacement prompt: %v", err)
+		}
+		writeReplacementOutput()
+	}
+
+	close(releaseError)
+	if errorOwnsLifecycle {
+		if err := <-replacementStarted; err != nil {
+			t.Fatalf("begin replacement prompt: %v", err)
+		}
+		writeReplacementOutput()
+	}
+	<-errorHandled
+
+	if !errorOwnsLifecycle {
+		t.Error("error event released prompt lifecycle ownership before mutating execution state")
+	}
+	if execution.Status != v1.AgentStatusRunning {
+		t.Fatalf("replacement status = %s, want %s", execution.Status, v1.AgentStatusRunning)
+	}
+	execution.messageMu.Lock()
+	buffer := execution.messageBuffer.String()
+	messageID := execution.currentMessageID
+	execution.messageMu.Unlock()
+	if buffer != "replacement output" || messageID != "replacement-message" {
+		t.Fatalf("replacement stream state changed: buffer=%q message_id=%q", buffer, messageID)
 	}
 }
 

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_events_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_events_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	agentctl "github.com/kandev/kandev/internal/agent/runtime/agentctl"
+	"github.com/kandev/kandev/internal/events"
 	"github.com/kandev/kandev/internal/events/bus"
 	v1 "github.com/kandev/kandev/pkg/api/v1"
 )
@@ -556,6 +557,52 @@ func TestHandleAgentEvent_PromptDoneChDoesNotBlockWhenFull(t *testing.T) {
 		// Good — didn't block
 	case <-time.After(2 * time.Second):
 		t.Fatal("handleAgentEvent blocked when promptDoneCh was full")
+	}
+}
+
+func TestHandleAgentEvent_DelayedCompleteCannotFinishReplacementPrompt(t *testing.T) {
+	mgr, eventBus := createTestManagerWithTracking()
+	execution := createTestExecution("exec-1", "task-1", "session-1")
+	if err := mgr.executionStore.Add(execution); err != nil {
+		t.Fatalf("add execution: %v", err)
+	}
+	if _, err := mgr.executionStore.BeginPrompt(execution.ID); err != nil {
+		t.Fatalf("begin original prompt: %v", err)
+	}
+	if _, err := mgr.executionStore.BeginPrompt(execution.ID); err != nil {
+		t.Fatalf("begin replacement prompt: %v", err)
+	}
+
+	execution.messageMu.Lock()
+	execution.messageBuffer.WriteString("replacement output")
+	execution.currentMessageID = "replacement-message"
+	execution.messageMu.Unlock()
+
+	mgr.handleAgentEvent(execution, agentctl.AgentEvent{
+		Type:             "complete",
+		SessionID:        execution.SessionID,
+		PromptGeneration: 1,
+	})
+
+	if execution.Status != v1.AgentStatusRunning {
+		t.Fatalf("replacement status = %s, want %s", execution.Status, v1.AgentStatusRunning)
+	}
+	select {
+	case signal := <-execution.promptDoneCh:
+		t.Fatalf("delayed completion signaled replacement prompt: %+v", signal)
+	default:
+	}
+	execution.messageMu.Lock()
+	buffer := execution.messageBuffer.String()
+	messageID := execution.currentMessageID
+	execution.messageMu.Unlock()
+	if buffer != "replacement output" || messageID != "replacement-message" {
+		t.Fatalf("replacement stream state changed: buffer=%q message_id=%q", buffer, messageID)
+	}
+	for _, published := range eventBus.PublishedEvents {
+		if published.Subject == events.AgentReady {
+			t.Fatal("delayed completion published AgentReady for replacement prompt")
+		}
 	}
 }
 

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_interaction.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_interaction.go
@@ -1056,7 +1056,7 @@ func (m *Manager) UpdateStatus(executionID string, status v1.AgentStatus) error 
 func (m *Manager) updateStatusAndPersist(ctx context.Context, executionID string, status v1.AgentStatus) error {
 	var updated *AgentExecution
 	if err := m.executionStore.WithLock(executionID, func(execution *AgentExecution) {
-		setExecutionStatus(execution, status)
+		execution.Status = status
 		updated = execution
 	}); err != nil {
 		if errors.Is(err, ErrExecutionNotFound) {
@@ -1071,6 +1071,25 @@ func (m *Manager) updateStatusAndPersist(ctx context.Context, executionID string
 
 	if updated != nil {
 		m.persistExecutorRunning(context.WithoutCancel(ctx), updated)
+	}
+	return nil
+}
+
+// BeginPrompt advances prompt ownership and marks the execution running before dispatch.
+func (m *Manager) BeginPrompt(executionID string) error {
+	var updated *AgentExecution
+	if err := m.executionStore.WithLock(executionID, func(execution *AgentExecution) {
+		beginExecutionPrompt(execution)
+		updated = execution
+	}); err != nil {
+		if errors.Is(err, ErrExecutionNotFound) {
+			return fmt.Errorf("execution %q not found", executionID)
+		}
+		return err
+	}
+
+	if updated != nil {
+		m.persistExecutorRunning(context.Background(), updated)
 	}
 	return nil
 }
@@ -1161,7 +1180,7 @@ func (m *Manager) markReadyEventWithContext(ctx context.Context, executionID, ev
 			alreadyReady = true
 			return
 		}
-		setExecutionStatus(execution, v1.AgentStatusReady)
+		execution.Status = v1.AgentStatusReady
 		payload = newAgentEventPayload(execution)
 		updated = execution
 	}); err != nil {

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_interaction.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_interaction.go
@@ -1056,7 +1056,7 @@ func (m *Manager) UpdateStatus(executionID string, status v1.AgentStatus) error 
 func (m *Manager) updateStatusAndPersist(ctx context.Context, executionID string, status v1.AgentStatus) error {
 	var updated *AgentExecution
 	if err := m.executionStore.WithLock(executionID, func(execution *AgentExecution) {
-		execution.Status = status
+		setExecutionStatus(execution, status)
 		updated = execution
 	}); err != nil {
 		if errors.Is(err, ErrExecutionNotFound) {
@@ -1073,6 +1073,12 @@ func (m *Manager) updateStatusAndPersist(ctx context.Context, executionID string
 		m.persistExecutorRunning(context.WithoutCancel(ctx), updated)
 	}
 	return nil
+}
+
+// OwnsPromptGeneration reports whether a ready event's immutable execution and
+// prompt generation still identify the lifecycle prompt active for sessionID.
+func (m *Manager) OwnsPromptGeneration(sessionID, executionID string, generation uint64) bool {
+	return m.executionStore.OwnsPromptGeneration(sessionID, executionID, generation)
 }
 
 // MarkReady marks an execution as ready for follow-up prompts AFTER A TURN.
@@ -1143,34 +1149,40 @@ func (m *Manager) markBootReadyFromFailed(ctx context.Context, executionID strin
 // handleAgentReady try to re-acquire that same guard from the very same
 // goroutine that is already holding it — sync.Mutex is not reentrant, so
 // that blocks forever. Deferring the publish lets the guard-holding caller
-// finish (and release the guard) first; handleAgentReady's own blocking
-// acquire then proceeds normally on its own goroutine, reloads the session,
-// finds it past this turn, and safely no-ops instead of deadlocking.
+// finish (and release the guard) first. The detached publish receives the
+// immutable payload captured while Ready was set, so handleAgentReady can
+// reject it if another prompt generation starts before delivery.
 func (m *Manager) markReadyEventWithContext(ctx context.Context, executionID, eventType string, asyncPublish bool) error {
-	execution, exists := m.executionStore.Get(executionID)
-	if !exists {
-		return fmt.Errorf("execution %q not found", executionID)
-	}
-
-	// Skip if already ready (prevents duplicate events). This guard is shared
-	// across MarkReady and MarkBootReady — once Ready is set, neither type fires
-	// again until the next status transition (Running on prompt, Stopped on stop).
-	if execution.Status == v1.AgentStatusReady {
-		return nil
-	}
-
-	if err := m.updateStatusAndPersist(ctx, executionID, v1.AgentStatusReady); err != nil {
+	var payload AgentEventPayload
+	var updated *AgentExecution
+	var alreadyReady bool
+	if err := m.executionStore.WithLock(executionID, func(execution *AgentExecution) {
+		if execution.Status == v1.AgentStatusReady {
+			alreadyReady = true
+			return
+		}
+		execution.Status = v1.AgentStatusReady
+		payload = newAgentEventPayload(execution)
+		updated = execution
+	}); err != nil {
+		if errors.Is(err, ErrExecutionNotFound) {
+			return fmt.Errorf("execution %q not found", executionID)
+		}
 		return err
 	}
+	if alreadyReady {
+		return nil
+	}
+	m.persistExecutorRunning(context.WithoutCancel(ctx), updated)
 
 	m.logger.Info("execution ready",
 		zap.String("execution_id", executionID),
 		zap.String("event_type", eventType))
 
 	if asyncPublish {
-		go m.eventPublisher.PublishAgentEvent(context.Background(), eventType, execution)
+		go m.eventPublisher.publishAgentEventPayload(context.Background(), eventType, payload)
 	} else {
-		m.eventPublisher.PublishAgentEvent(ctx, eventType, execution)
+		m.eventPublisher.publishAgentEventPayload(ctx, eventType, payload)
 	}
 	return nil
 }

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_interaction.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_interaction.go
@@ -1076,22 +1076,19 @@ func (m *Manager) updateStatusAndPersist(ctx context.Context, executionID string
 }
 
 // BeginPrompt advances prompt ownership and marks the execution running before dispatch.
-func (m *Manager) BeginPrompt(executionID string) error {
-	var updated *AgentExecution
-	if err := m.executionStore.WithLock(executionID, func(execution *AgentExecution) {
-		beginExecutionPrompt(execution)
-		updated = execution
-	}); err != nil {
+func (m *Manager) BeginPrompt(executionID string) (uint64, error) {
+	generation, err := m.executionStore.BeginPrompt(executionID)
+	if err != nil {
 		if errors.Is(err, ErrExecutionNotFound) {
-			return fmt.Errorf("execution %q not found", executionID)
+			return 0, fmt.Errorf("execution %q not found", executionID)
 		}
-		return err
+		return 0, err
 	}
 
-	if updated != nil {
+	if updated, exists := m.executionStore.Get(executionID); exists {
 		m.persistExecutorRunning(context.Background(), updated)
 	}
-	return nil
+	return generation, nil
 }
 
 // OwnsPromptGeneration reports whether a ready event's immutable execution and

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_interaction.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_interaction.go
@@ -1161,7 +1161,7 @@ func (m *Manager) markReadyEventWithContext(ctx context.Context, executionID, ev
 			alreadyReady = true
 			return
 		}
-		execution.Status = v1.AgentStatusReady
+		setExecutionStatus(execution, v1.AgentStatusReady)
 		payload = newAgentEventPayload(execution)
 		updated = execution
 	}); err != nil {

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_interaction_cancel_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_interaction_cancel_test.go
@@ -375,7 +375,8 @@ func TestMarkReadyAsync_PublishesImmutablePromptGenerationSnapshot(t *testing.T)
 	payload, payloadOK := (<-publishEntered).(AgentEventPayload)
 	require.True(t, payloadOK)
 
-	require.NoError(t, mgr.BeginPrompt(exec.ID))
+	_, err := mgr.BeginPrompt(exec.ID)
+	require.NoError(t, err)
 	require.True(t, mgr.OwnsPromptGeneration(exec.SessionID, exec.ID, 2))
 	close(releasePublish)
 	<-mockBus.Notify

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_interaction_cancel_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_interaction_cancel_test.go
@@ -375,7 +375,7 @@ func TestMarkReadyAsync_PublishesImmutablePromptGenerationSnapshot(t *testing.T)
 	payload, payloadOK := (<-publishEntered).(AgentEventPayload)
 	require.True(t, payloadOK)
 
-	require.NoError(t, mgr.UpdateStatus(exec.ID, v1.AgentStatusRunning))
+	require.NoError(t, mgr.BeginPrompt(exec.ID))
 	require.True(t, mgr.OwnsPromptGeneration(exec.SessionID, exec.ID, 2))
 	close(releasePublish)
 	<-mockBus.Notify

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_interaction_cancel_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_interaction_cancel_test.go
@@ -343,3 +343,43 @@ func TestManager_CancelAgent_EscalationDoesNotDeadlockOnReentrantReadySubscriber
 		t.Fatal("simulated AgentReady subscriber did not finish after the guard was released")
 	}
 }
+
+func TestMarkReadyAsync_PublishesImmutablePromptGenerationSnapshot(t *testing.T) {
+	mgr := newTestManager(t)
+	mockBus, ok := mgr.eventBus.(*MockEventBus)
+	require.True(t, ok)
+
+	exec := &AgentExecution{
+		ID:               "exec-generation-snapshot",
+		TaskID:           "task-1",
+		SessionID:        "session-1",
+		Status:           v1.AgentStatusRunning,
+		promptGeneration: 1,
+	}
+	require.NoError(t, mgr.executionStore.Add(exec))
+
+	publishEntered := make(chan interface{}, 1)
+	releasePublish := make(chan struct{})
+	mockBus.Notify = make(chan struct{}, 1)
+	mockBus.OnPublish = func(subject string, event *bus.Event) {
+		if subject != events.AgentReady {
+			return
+		}
+		publishEntered <- event.Data
+		<-releasePublish
+	}
+
+	require.NoError(t, mgr.markReadyEventWithContext(
+		context.Background(), exec.ID, events.AgentReady, true,
+	))
+	payload, payloadOK := (<-publishEntered).(AgentEventPayload)
+	require.True(t, payloadOK)
+
+	require.NoError(t, mgr.UpdateStatus(exec.ID, v1.AgentStatusRunning))
+	require.True(t, mgr.OwnsPromptGeneration(exec.SessionID, exec.ID, 2))
+	close(releasePublish)
+	<-mockBus.Notify
+
+	require.Equal(t, uint64(1), payload.PromptGeneration)
+	require.Equal(t, string(v1.AgentStatusReady), payload.Status)
+}

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_test.go
@@ -388,24 +388,19 @@ func TestManager_UpdateStatus(t *testing.T) {
 	}
 }
 
-func TestManager_UpdateStatusAdvancesPromptGenerationOnRunningTransition(t *testing.T) {
+func TestManager_BeginPromptAlwaysAdvancesPromptGeneration(t *testing.T) {
 	mgr := newTestManager(t)
 	exec := &AgentExecution{
 		ID:        "exec-prompt-generation",
 		SessionID: "session-prompt-generation",
-		Status:    v1.AgentStatusReady,
+		Status:    v1.AgentStatusRunning,
 	}
 	require.NoError(t, mgr.executionStore.Add(exec))
 
-	require.NoError(t, mgr.UpdateStatus(exec.ID, v1.AgentStatusRunning))
+	require.NoError(t, mgr.BeginPrompt(exec.ID))
 	require.True(t, mgr.OwnsPromptGeneration(exec.SessionID, exec.ID, 1))
 	require.False(t, mgr.OwnsPromptGeneration(exec.SessionID, "other-execution", 1))
 
-	require.NoError(t, mgr.UpdateStatus(exec.ID, v1.AgentStatusRunning))
-	require.True(t, mgr.OwnsPromptGeneration(exec.SessionID, exec.ID, 1),
-		"duplicate running status must not create a second generation")
-
-	require.NoError(t, mgr.UpdateStatus(exec.ID, v1.AgentStatusReady))
-	require.NoError(t, mgr.UpdateStatus(exec.ID, v1.AgentStatusRunning))
+	require.NoError(t, mgr.BeginPrompt(exec.ID))
 	require.True(t, mgr.OwnsPromptGeneration(exec.SessionID, exec.ID, 2))
 }

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kandev/kandev/internal/common/logger"
 	"github.com/kandev/kandev/internal/events/bus"
 	v1 "github.com/kandev/kandev/pkg/api/v1"
+	"github.com/stretchr/testify/require"
 )
 
 // testAgent implements agents.Agent for use in lifecycle tests.
@@ -385,4 +386,26 @@ func TestManager_UpdateStatus(t *testing.T) {
 	if err == nil {
 		t.Error("expected error for non-existent execution")
 	}
+}
+
+func TestManager_UpdateStatusAdvancesPromptGenerationOnRunningTransition(t *testing.T) {
+	mgr := newTestManager(t)
+	exec := &AgentExecution{
+		ID:        "exec-prompt-generation",
+		SessionID: "session-prompt-generation",
+		Status:    v1.AgentStatusReady,
+	}
+	require.NoError(t, mgr.executionStore.Add(exec))
+
+	require.NoError(t, mgr.UpdateStatus(exec.ID, v1.AgentStatusRunning))
+	require.True(t, mgr.OwnsPromptGeneration(exec.SessionID, exec.ID, 1))
+	require.False(t, mgr.OwnsPromptGeneration(exec.SessionID, "other-execution", 1))
+
+	require.NoError(t, mgr.UpdateStatus(exec.ID, v1.AgentStatusRunning))
+	require.True(t, mgr.OwnsPromptGeneration(exec.SessionID, exec.ID, 1),
+		"duplicate running status must not create a second generation")
+
+	require.NoError(t, mgr.UpdateStatus(exec.ID, v1.AgentStatusReady))
+	require.NoError(t, mgr.UpdateStatus(exec.ID, v1.AgentStatusRunning))
+	require.True(t, mgr.OwnsPromptGeneration(exec.SessionID, exec.ID, 2))
 }

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_test.go
@@ -397,10 +397,12 @@ func TestManager_BeginPromptAlwaysAdvancesPromptGeneration(t *testing.T) {
 	}
 	require.NoError(t, mgr.executionStore.Add(exec))
 
-	require.NoError(t, mgr.BeginPrompt(exec.ID))
+	_, err := mgr.BeginPrompt(exec.ID)
+	require.NoError(t, err)
 	require.True(t, mgr.OwnsPromptGeneration(exec.SessionID, exec.ID, 1))
 	require.False(t, mgr.OwnsPromptGeneration(exec.SessionID, "other-execution", 1))
 
-	require.NoError(t, mgr.BeginPrompt(exec.ID))
+	_, err = mgr.BeginPrompt(exec.ID)
+	require.NoError(t, err)
 	require.True(t, mgr.OwnsPromptGeneration(exec.SessionID, exec.ID, 2))
 }

--- a/apps/backend/internal/agent/runtime/lifecycle/session.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/session.go
@@ -27,7 +27,7 @@ type SessionManager struct {
 	eventPublisher *EventPublisher
 	streamManager  *StreamManager
 	executionStore *ExecutionStore
-	promptStarter  func(executionID string) error
+	promptStarter  func(executionID string) (uint64, error)
 	historyManager *SessionHistoryManager
 	stopCh         <-chan struct{} // For graceful shutdown coordination
 }
@@ -49,7 +49,7 @@ func (sm *SessionManager) SetDependencies(ep *EventPublisher, strm *StreamManage
 	sm.historyManager = history
 }
 
-func (sm *SessionManager) SetPromptStarter(starter func(executionID string) error) {
+func (sm *SessionManager) SetPromptStarter(starter func(executionID string) (uint64, error)) {
 	sm.promptStarter = starter
 }
 
@@ -619,17 +619,24 @@ func (sm *SessionManager) SendPrompt(
 
 	// Every dispatch attempt gets a distinct identity, including initial prompts
 	// and replacements accepted while the execution is already running.
+	var promptGeneration uint64
 	switch {
 	case sm.promptStarter != nil:
-		if err := sm.promptStarter(execution.ID); err != nil {
+		var err error
+		promptGeneration, err = sm.promptStarter(execution.ID)
+		if err != nil {
 			return nil, err
 		}
 	case sm.executionStore != nil:
-		if err := sm.executionStore.BeginPrompt(execution.ID); err != nil {
+		var err error
+		promptGeneration, err = sm.executionStore.BeginPrompt(execution.ID)
+		if err != nil {
 			return nil, err
 		}
 	default:
-		beginExecutionPrompt(execution)
+		// Tests that construct SessionManager without lifecycle dependencies
+		// still need a generation, but no concurrent owner can mutate it here.
+		promptGeneration = beginExecutionPrompt(execution)
 	}
 
 	// Clear buffers and streaming state before starting prompt
@@ -662,21 +669,8 @@ func (sm *SessionManager) SendPrompt(
 	execution.lastActivityAtMu.Unlock()
 
 	// Fire the prompt (returns immediately now — completion comes via WebSocket complete event)
-	if err := execution.agentctl.Prompt(ctx, effectivePrompt, attachments); err != nil {
-		if isAgentStreamNotConnectedErr(err) && sm.streamManager != nil {
-			sm.logger.Warn("agent stream not connected, reconnecting and retrying prompt once",
-				zap.String("execution_id", execution.ID))
-			retryErr := sm.retryPromptAfterReconnect(ctx, execution, effectivePrompt, attachments)
-			if retryErr == nil {
-				if dispatchOnly {
-					return &PromptResult{StopReason: PromptStopReasonDispatched}, nil
-				}
-				return sm.waitForPromptDone(ctx, execution)
-			}
-			sm.logger.Warn("prompt retry after stream reconnect failed",
-				zap.String("execution_id", execution.ID),
-				zap.Error(retryErr))
-		}
+	err := sm.dispatchPrompt(ctx, execution, effectivePrompt, attachments, promptGeneration)
+	if err != nil {
 		if isCancelReleaseError(err.Error()) {
 			sm.logger.Info("prompt trigger abandoned after cancel; requeueing",
 				zap.String("execution_id", execution.ID),
@@ -697,6 +691,30 @@ func (sm *SessionManager) SendPrompt(
 	return sm.waitForPromptDone(ctx, execution)
 }
 
+func (sm *SessionManager) dispatchPrompt(
+	ctx context.Context,
+	execution *AgentExecution,
+	prompt string,
+	attachments []v1.MessageAttachment,
+	promptGeneration uint64,
+) error {
+	err := execution.agentctl.Prompt(ctx, prompt, attachments, promptGeneration)
+	if err == nil || !isAgentStreamNotConnectedErr(err) || sm.streamManager == nil {
+		return err
+	}
+
+	sm.logger.Warn("agent stream not connected, reconnecting and retrying prompt once",
+		zap.String("execution_id", execution.ID))
+	retryErr := sm.retryPromptAfterReconnect(ctx, execution, prompt, attachments, promptGeneration)
+	if retryErr == nil {
+		return nil
+	}
+	sm.logger.Warn("prompt retry after stream reconnect failed",
+		zap.String("execution_id", execution.ID),
+		zap.Error(retryErr))
+	return err
+}
+
 // beginPromptBarrier sets up a completion signal on the execution so CancelAgent
 // can wait for the in-flight SendPrompt to finish before the caller retries.
 // Returns a cleanup function that must be deferred: defer beginPromptBarrier(exec)()
@@ -713,6 +731,7 @@ func (sm *SessionManager) retryPromptAfterReconnect(
 	execution *AgentExecution,
 	prompt string,
 	attachments []v1.MessageAttachment,
+	promptGeneration uint64,
 ) error {
 	reconnectCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
@@ -734,7 +753,9 @@ func (sm *SessionManager) retryPromptAfterReconnect(
 		}
 
 		if execution.agentctl.HasAgentStream() {
-			if err := execution.agentctl.Prompt(reconnectCtx, prompt, attachments); err == nil {
+			if err := execution.agentctl.Prompt(
+				reconnectCtx, prompt, attachments, promptGeneration,
+			); err == nil {
 				return nil
 			} else if !isAgentStreamNotConnectedErr(err) {
 				return err

--- a/apps/backend/internal/agent/runtime/lifecycle/session.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/session.go
@@ -27,7 +27,7 @@ type SessionManager struct {
 	eventPublisher *EventPublisher
 	streamManager  *StreamManager
 	executionStore *ExecutionStore
-	statusUpdater  func(executionID string, status v1.AgentStatus) error
+	promptStarter  func(executionID string) error
 	historyManager *SessionHistoryManager
 	stopCh         <-chan struct{} // For graceful shutdown coordination
 }
@@ -49,8 +49,8 @@ func (sm *SessionManager) SetDependencies(ep *EventPublisher, strm *StreamManage
 	sm.historyManager = history
 }
 
-func (sm *SessionManager) SetStatusUpdater(updater func(executionID string, status v1.AgentStatus) error) {
-	sm.statusUpdater = updater
+func (sm *SessionManager) SetPromptStarter(starter func(executionID string) error) {
+	sm.promptStarter = starter
 }
 
 // InitializeResult contains the result of session initialization
@@ -610,18 +610,26 @@ func (sm *SessionManager) SendPrompt(
 		ctx = trace.ContextWithSpan(ctx, sessionSpan)
 	}
 
-	// For follow-up prompts, validate status and update to RUNNING
+	// For follow-up prompts, validate status before claiming a new generation.
 	if validateStatus {
 		if execution.Status != v1.AgentStatusRunning && execution.Status != v1.AgentStatusReady {
 			return nil, fmt.Errorf("execution %q is not ready for prompts (status: %s)", execution.ID, execution.Status)
 		}
-		if sm.statusUpdater != nil {
-			if err := sm.statusUpdater(execution.ID, v1.AgentStatusRunning); err != nil {
-				return nil, err
-			}
-		} else if sm.executionStore != nil {
-			sm.executionStore.UpdateStatus(execution.ID, v1.AgentStatusRunning)
+	}
+
+	// Every dispatch attempt gets a distinct identity, including initial prompts
+	// and replacements accepted while the execution is already running.
+	switch {
+	case sm.promptStarter != nil:
+		if err := sm.promptStarter(execution.ID); err != nil {
+			return nil, err
 		}
+	case sm.executionStore != nil:
+		if err := sm.executionStore.BeginPrompt(execution.ID); err != nil {
+			return nil, err
+		}
+	default:
+		beginExecutionPrompt(execution)
 	}
 
 	// Clear buffers and streaming state before starting prompt

--- a/apps/backend/internal/agent/runtime/lifecycle/session_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/session_test.go
@@ -893,7 +893,7 @@ func TestSendPrompt_DispatchOnlyReturnsWithoutWaiting(t *testing.T) {
 
 func TestSendPrompt_AdvancesGenerationForEveryDispatch(t *testing.T) {
 	mock := newMockAgentServer(t)
-	defer mock.Close()
+	t.Cleanup(mock.Close)
 
 	log := newSessionTestLogger()
 	sm := NewSessionManager(log, make(chan struct{}))
@@ -901,7 +901,7 @@ func TestSendPrompt_AdvancesGenerationForEveryDispatch(t *testing.T) {
 	sm.SetDependencies(nil, nil, store, nil)
 
 	client := createTestClient(t, mock.server.URL)
-	defer client.Close()
+	t.Cleanup(client.Close)
 
 	ctx := context.Background()
 	if err := client.StreamUpdates(ctx, func(event agentctl.AgentEvent) {}, nil, nil); err != nil {

--- a/apps/backend/internal/agent/runtime/lifecycle/session_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/session_test.go
@@ -19,6 +19,7 @@ import (
 	agentctl "github.com/kandev/kandev/internal/agent/runtime/agentctl"
 	"github.com/kandev/kandev/internal/common/logger"
 	"github.com/kandev/kandev/pkg/agent"
+	v1 "github.com/kandev/kandev/pkg/api/v1"
 	ws "github.com/kandev/kandev/pkg/websocket"
 )
 
@@ -887,6 +888,52 @@ func TestSendPrompt_DispatchOnlyReturnsWithoutWaiting(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("SendPrompt(dispatchOnly=true) blocked waiting for completion signal")
+	}
+}
+
+func TestSendPrompt_AdvancesGenerationForEveryDispatch(t *testing.T) {
+	mock := newMockAgentServer(t)
+	defer mock.Close()
+
+	log := newSessionTestLogger()
+	sm := NewSessionManager(log, make(chan struct{}))
+	store := NewExecutionStore()
+	sm.SetDependencies(nil, nil, store, nil)
+
+	client := createTestClient(t, mock.server.URL)
+	defer client.Close()
+
+	ctx := context.Background()
+	if err := client.StreamUpdates(ctx, func(event agentctl.AgentEvent) {}, nil, nil); err != nil {
+		t.Fatalf("failed to connect stream: %v", err)
+	}
+	waitForWSConnected(t, mock)
+
+	execution := &AgentExecution{
+		ID:            "test-exec",
+		TaskID:        "test-task",
+		SessionID:     "test-session",
+		WorkspacePath: "/workspace",
+		Status:        v1.AgentStatusRunning,
+		agentctl:      client,
+		promptDoneCh:  make(chan PromptCompletionSignal, 1),
+	}
+	if err := store.Add(execution); err != nil {
+		t.Fatalf("add execution: %v", err)
+	}
+
+	if _, err := sm.SendPrompt(ctx, execution, "initial", false, nil, true); err != nil {
+		t.Fatalf("dispatch initial prompt: %v", err)
+	}
+	if !store.OwnsPromptGeneration(execution.SessionID, execution.ID, 1) {
+		t.Fatal("initial prompt must own generation 1 even when execution starts running")
+	}
+
+	if _, err := sm.SendPrompt(ctx, execution, "replacement", true, nil, true); err != nil {
+		t.Fatalf("dispatch replacement prompt: %v", err)
+	}
+	if !store.OwnsPromptGeneration(execution.SessionID, execution.ID, 2) {
+		t.Fatal("replacement prompt must advance generation while execution remains running")
 	}
 }
 

--- a/apps/backend/internal/agent/runtime/lifecycle/types.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/types.go
@@ -43,6 +43,7 @@ type AgentExecution struct {
 	ExitCode          *int
 	ErrorMessage      string
 	Metadata          map[string]interface{}
+	promptGeneration  uint64
 
 	// PrepareResult carries the environment preparation result back to the caller
 	// so it can be persisted synchronously before UpdateTaskSession clobbers metadata.

--- a/apps/backend/internal/agent/runtime/lifecycle/types.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/types.go
@@ -44,6 +44,7 @@ type AgentExecution struct {
 	ErrorMessage      string
 	Metadata          map[string]interface{}
 	promptGeneration  uint64
+	promptLifecycleMu sync.Mutex
 
 	// PrepareResult carries the environment preparation result back to the caller
 	// so it can be persisted synchronously before UpdateTaskSession clobbers metadata.

--- a/apps/backend/internal/agent/runtime/lifecycle/wakeup_e2e_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/wakeup_e2e_test.go
@@ -267,7 +267,7 @@ func TestWakeupE2EFullPipeline_BridgeToEventBus(t *testing.T) {
 
 	t.Logf("sending initial prompt…")
 	initialStart := time.Now()
-	if err := adp.Prompt(ctx, prompt, nil); err != nil {
+	if err := adp.Prompt(ctx, prompt, nil, 0); err != nil {
 		t.Fatalf("initial Prompt: %v", err)
 	}
 	initialEnd := time.Now()

--- a/apps/backend/internal/agentctl/server/adapter/adapter.go
+++ b/apps/backend/internal/agentctl/server/adapter/adapter.go
@@ -179,7 +179,7 @@ type AgentAdapter interface {
 	// Prompt sends a prompt to the agent.
 	// The agent's responses are streamed via the Updates channel.
 	// Attachments (images) are passed to the agent if provided.
-	Prompt(ctx context.Context, message string, attachments []v1.MessageAttachment) error
+	Prompt(ctx context.Context, message string, attachments []v1.MessageAttachment, promptGeneration uint64) error
 
 	// Cancel cancels the current operation.
 	Cancel(ctx context.Context) error

--- a/apps/backend/internal/agentctl/server/adapter/e2e/harness.go
+++ b/apps/backend/internal/agentctl/server/adapter/e2e/harness.go
@@ -192,7 +192,7 @@ func collectEventsUntilPromptDone(
 	}()
 
 	// Send prompt (blocks until turn completes or context cancels)
-	if err := adpt.Prompt(ctx, prompt, nil); err != nil {
+	if err := adpt.Prompt(ctx, prompt, nil, 0); err != nil {
 		t.Fatalf("prompt failed: %v", err)
 	}
 

--- a/apps/backend/internal/agentctl/server/adapter/e2e/mock_agent_test.go
+++ b/apps/backend/internal/agentctl/server/adapter/e2e/mock_agent_test.go
@@ -394,7 +394,7 @@ func collectPromptEvents(ctx context.Context, t *testing.T, setup *agentSetup, p
 		}
 	}()
 
-	if err := setup.adpt.Prompt(ctx, prompt, nil); err != nil {
+	if err := setup.adpt.Prompt(ctx, prompt, nil, 0); err != nil {
 		collectCancel()
 		t.Fatalf("prompt failed: %v", err)
 	}

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_prompt.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_prompt.go
@@ -17,9 +17,14 @@ import (
 // If pending context is set (from SetPendingContext), it will be prepended to the message.
 // Attachments (images) are converted to ACP ImageBlocks and included in the prompt.
 // When the prompt completes, a complete event is emitted via the updates channel.
-func (a *Adapter) Prompt(ctx context.Context, message string, attachments []v1.MessageAttachment) error {
+func (a *Adapter) Prompt(
+	ctx context.Context,
+	message string,
+	attachments []v1.MessageAttachment,
+	promptGeneration uint64,
+) error {
 	// A user prompt always targets the current session, so it is not pinned.
-	return a.sendPrompt(ctx, message, attachments, "")
+	return a.sendPrompt(ctx, message, attachments, "", promptGeneration)
 }
 
 // sendPrompt serializes session/prompt calls through promptGate and sends one
@@ -30,7 +35,13 @@ func (a *Adapter) Prompt(ctx context.Context, message string, attachments []v1.M
 // a wakeup must reach the session it was scheduled for or not at all.
 //
 //nolint:cyclop,funlen // pre-existing complexity preserved from adapter.go file split
-func (a *Adapter) sendPrompt(ctx context.Context, message string, attachments []v1.MessageAttachment, expectSession string) error {
+func (a *Adapter) sendPrompt(
+	ctx context.Context,
+	message string,
+	attachments []v1.MessageAttachment,
+	expectSession string,
+	promptGeneration uint64,
+) error {
 	// Acquire the prompt gate, honouring ctx so a queued wakeup whose context
 	// is cancelled (timeout / adapter Close) aborts instead of blocking on a
 	// stuck in-flight turn.
@@ -197,10 +208,11 @@ func (a *Adapter) sendPrompt(ctx context.Context, message string, attachments []
 		usage.ProviderReportedCostSubcents = costSubcents
 	}
 	a.sendUpdate(AgentEvent{
-		Type:      streams.EventTypeComplete,
-		SessionID: sessionID,
-		Data:      map[string]any{"stop_reason": stopReason},
-		Usage:     usage,
+		Type:             streams.EventTypeComplete,
+		SessionID:        sessionID,
+		PromptGeneration: promptGeneration,
+		Data:             map[string]any{"stop_reason": stopReason},
+		Usage:            usage,
 	})
 
 	return nil
@@ -314,7 +326,7 @@ func (a *Adapter) fireWakeup(sessionID, prompt string) {
 		defer cancel()
 		// Pin to the scheduled session: if the active session changed while this
 		// wakeup waited on the prompt gate, sendPrompt drops it.
-		if err := a.sendPrompt(ctx, prompt, nil, sessionID); err != nil {
+		if err := a.sendPrompt(ctx, prompt, nil, sessionID, 0); err != nil {
 			a.logger.Error("synthetic wakeup prompt failed",
 				zap.String("session_id", sessionID),
 				zap.Error(err))

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/wakeup_concurrency_test.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/wakeup_concurrency_test.go
@@ -113,6 +113,42 @@ func waitForPromptComplete(t *testing.T, a *Adapter) {
 	}
 }
 
+func TestPromptCompleteEchoesLifecycleGeneration(t *testing.T) {
+	a, fa := setupConcurrencyFakeAgent(t)
+	ctx := context.Background()
+	if err := a.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	if _, err := a.NewSession(ctx, nil); err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- a.Prompt(ctx, "user message", nil, 42)
+	}()
+	<-fa.entered
+	close(fa.release)
+	if err := <-done; err != nil {
+		t.Fatalf("Prompt: %v", err)
+	}
+
+	for {
+		select {
+		case event := <-a.updatesCh:
+			if event.Type != streams.EventTypeComplete {
+				continue
+			}
+			if event.PromptGeneration != 42 {
+				t.Fatalf("complete prompt generation = %d, want 42", event.PromptGeneration)
+			}
+			return
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out waiting for complete event")
+		}
+	}
+}
+
 // TestWakeupDoesNotRaceConcurrentPromptWithUserPrompt reproduces the
 // turn-misalignment bug: when a ScheduleWakeup timer fires while a user prompt
 // is still in flight, fireWakeup must NOT issue a second, concurrent
@@ -140,7 +176,7 @@ func TestWakeupDoesNotRaceConcurrentPromptWithUserPrompt(t *testing.T) {
 	userWG.Add(1)
 	go func() {
 		defer userWG.Done()
-		_ = a.Prompt(ctx, "user message", nil)
+		_ = a.Prompt(ctx, "user message", nil, 0)
 	}()
 
 	// Wait until the user prompt is parked inside the agent's Prompt handler.
@@ -198,7 +234,7 @@ func TestWakeupDroppedWhenSessionChangesWhileQueued(t *testing.T) {
 	userWG.Add(1)
 	go func() {
 		defer userWG.Done()
-		_ = a.Prompt(ctx, "user message", nil)
+		_ = a.Prompt(ctx, "user message", nil, 0)
 	}()
 	select {
 	case <-fa.entered:

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/wakeup_e2e_test.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/wakeup_e2e_test.go
@@ -232,7 +232,7 @@ func TestWakeupE2E_BridgeQueuedTurnDrainsViaSyntheticPrompt(t *testing.T) {
 
 	t.Logf("sending initial prompt (will trigger ScheduleWakeup, delay=%ds)…", wakeupDelaySeconds)
 	initialStart := time.Now()
-	if err := w.adapter.Prompt(ctx, prompt, nil); err != nil {
+	if err := w.adapter.Prompt(ctx, prompt, nil, 0); err != nil {
 		t.Fatalf("initial Prompt failed: %v", err)
 	}
 	initialEnd := time.Now()

--- a/apps/backend/internal/agentctl/server/api/agent.go
+++ b/apps/backend/internal/agentctl/server/api/agent.go
@@ -77,8 +77,9 @@ type LoadSessionResponse struct {
 
 // PromptRequest is a request to send a prompt to the agent
 type PromptRequest struct {
-	Text        string                 `json:"text"`                  // Simple text prompt
-	Attachments []v1.MessageAttachment `json:"attachments,omitempty"` // Optional image attachments
+	Text             string                 `json:"text"`                  // Simple text prompt
+	Attachments      []v1.MessageAttachment `json:"attachments,omitempty"` // Optional image attachments
+	PromptGeneration uint64                 `json:"prompt_generation,omitempty"`
 }
 
 // PromptResponse is the response to a prompt call
@@ -466,14 +467,14 @@ func (s *Server) handleWSPrompt(ctx context.Context, msg *ws.Message) *ws.Messag
 	// The prompt completes naturally when the agent process exits (stdin/stdout close),
 	// the user cancels, or agentctl shuts down.
 	go func() {
-		if err := adapter.Prompt(context.Background(), req.Text, req.Attachments); err != nil {
+		if err := adapter.Prompt(context.Background(), req.Text, req.Attachments, req.PromptGeneration); err != nil {
 			if acptransport.IsPromptAbandonedAfterCancel(err) {
 				s.logger.Info("async prompt abandoned after cancel; suppressing stale error event",
 					zap.Error(err))
 				return
 			}
 			s.logger.Error("async prompt failed", zap.Error(err))
-			s.procMgr.SendErrorEvent(err.Error())
+			s.procMgr.SendErrorEvent(err.Error(), req.PromptGeneration)
 		}
 	}()
 

--- a/apps/backend/internal/agentctl/server/api/agent_test.go
+++ b/apps/backend/internal/agentctl/server/api/agent_test.go
@@ -254,15 +254,16 @@ func TestHandleWSPrompt_NoAdapter(t *testing.T) {
 
 func TestHandleWSPrompt_SuppressesPromptAbandonedAfterCancel(t *testing.T) {
 	s := newTestServer(t)
-	prompted := make(chan struct{}, 1)
+	prompted := make(chan uint64, 1)
 	s.procMgr.SetAdapterForTest(&promptErrorAdapter{
 		sessionID: "session-123",
 		err:       errors.New("prompt failed: prompt abandoned after cancel"),
 		prompted:  prompted,
 	})
 
-	msg, _ := ws.NewRequest("req-1", "agent.prompt", map[string]string{
-		"text": "hello",
+	msg, _ := ws.NewRequest("req-1", "agent.prompt", PromptRequest{
+		Text:             "hello",
+		PromptGeneration: 42,
 	})
 	resp := s.handleWSPrompt(context.Background(), msg)
 
@@ -278,7 +279,10 @@ func TestHandleWSPrompt_SuppressesPromptAbandonedAfterCancel(t *testing.T) {
 	}
 
 	select {
-	case <-prompted:
+	case generation := <-prompted:
+		if generation != 42 {
+			t.Fatalf("prompt generation = %d, want 42", generation)
+		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("prompt was not called")
 	}
@@ -312,7 +316,7 @@ func TestHandleWSCancel_NoAdapter(t *testing.T) {
 type promptErrorAdapter struct {
 	sessionID string
 	err       error
-	prompted  chan<- struct{}
+	prompted  chan<- uint64
 }
 
 func (a *promptErrorAdapter) PrepareEnvironment() (map[string]string, error) {
@@ -344,8 +348,13 @@ func (a *promptErrorAdapter) LoadSession(_ context.Context, sessionID string, _ 
 	return nil
 }
 
-func (a *promptErrorAdapter) Prompt(_ context.Context, _ string, _ []v1.MessageAttachment) error {
-	a.prompted <- struct{}{}
+func (a *promptErrorAdapter) Prompt(
+	_ context.Context,
+	_ string,
+	_ []v1.MessageAttachment,
+	promptGeneration uint64,
+) error {
+	a.prompted <- promptGeneration
 	return a.err
 }
 

--- a/apps/backend/internal/agentctl/server/process/manager.go
+++ b/apps/backend/internal/agentctl/server/process/manager.go
@@ -1222,11 +1222,12 @@ func (m *Manager) GetUpdates() <-chan adapter.AgentEvent {
 
 // SendErrorEvent sends an error event on the updates channel so the
 // lifecycle manager (and ultimately the UI) learns about the failure.
-func (m *Manager) SendErrorEvent(errorMessage string) {
+func (m *Manager) SendErrorEvent(errorMessage string, promptGeneration uint64) {
 	select {
 	case m.updatesCh <- adapter.AgentEvent{
-		Type:  adapter.EventTypeError,
-		Error: errorMessage,
+		Type:             adapter.EventTypeError,
+		Error:            errorMessage,
+		PromptGeneration: promptGeneration,
 	}:
 	default:
 		m.logger.Warn("updates channel full, could not send error event")

--- a/apps/backend/internal/agentctl/server/process/manager_temp_test.go
+++ b/apps/backend/internal/agentctl/server/process/manager_temp_test.go
@@ -26,7 +26,7 @@ func (stubAgentAdapter) NewSession(context.Context, []types.McpServer) (string, 
 func (stubAgentAdapter) LoadSession(context.Context, string, []types.McpServer) error {
 	return nil
 }
-func (stubAgentAdapter) Prompt(context.Context, string, []v1.MessageAttachment) error {
+func (stubAgentAdapter) Prompt(context.Context, string, []v1.MessageAttachment, uint64) error {
 	return nil
 }
 func (stubAgentAdapter) Cancel(context.Context) error                   { return nil }

--- a/apps/backend/internal/agentctl/server/process/manager_test.go
+++ b/apps/backend/internal/agentctl/server/process/manager_test.go
@@ -54,12 +54,14 @@ func (s *stubAdapter) NewSession(_ context.Context, _ []types.McpServer) (string
 	return "", nil
 }
 func (s *stubAdapter) LoadSession(context.Context, string, []types.McpServer) error { return nil }
-func (s *stubAdapter) Prompt(context.Context, string, []v1.MessageAttachment) error { return nil }
-func (s *stubAdapter) Cancel(context.Context) error                                 { return nil }
-func (s *stubAdapter) Updates() <-chan adapter.AgentEvent                           { return s.updatesCh }
-func (s *stubAdapter) GetSessionID() string                                         { return "" }
-func (s *stubAdapter) GetOperationID() string                                       { return "" }
-func (s *stubAdapter) SetPermissionHandler(adapter.PermissionHandler)               {}
+func (s *stubAdapter) Prompt(context.Context, string, []v1.MessageAttachment, uint64) error {
+	return nil
+}
+func (s *stubAdapter) Cancel(context.Context) error                   { return nil }
+func (s *stubAdapter) Updates() <-chan adapter.AgentEvent             { return s.updatesCh }
+func (s *stubAdapter) GetSessionID() string                           { return "" }
+func (s *stubAdapter) GetOperationID() string                         { return "" }
+func (s *stubAdapter) SetPermissionHandler(adapter.PermissionHandler) {}
 func (s *stubAdapter) Close() error {
 	close(s.updatesCh)
 	return nil

--- a/apps/backend/internal/agentctl/types/streams/agent.go
+++ b/apps/backend/internal/agentctl/types/streams/agent.go
@@ -89,6 +89,11 @@ type AgentEvent struct {
 	// For Codex this is the turn ID, for other protocols it may be empty.
 	OperationID string `json:"operation_id,omitempty"`
 
+	// PromptGeneration is the lifecycle-owned identity assigned when this
+	// prompt was accepted. Terminal events echo it so delayed completions
+	// cannot be attributed to a newer prompt on the same execution.
+	PromptGeneration uint64 `json:"prompt_generation,omitempty"`
+
 	// --- Message fields (for "message_chunk" type) ---
 
 	// Text contains streaming text content from the agent.

--- a/apps/backend/internal/backendapp/adapters.go
+++ b/apps/backend/internal/backendapp/adapters.go
@@ -66,6 +66,10 @@ type lifecycleAdapter struct {
 	logger   *logger.Logger
 }
 
+var _ interface {
+	OwnsPromptGeneration(sessionID, executionID string, generation uint64) bool
+} = (*lifecycleAdapter)(nil)
+
 // newLifecycleAdapter creates a new lifecycle adapter
 func newLifecycleAdapter(mgr *lifecycle.Manager, reg *registry.Registry, log *logger.Logger) *lifecycleAdapter {
 	return &lifecycleAdapter{
@@ -333,6 +337,10 @@ func (a *lifecycleAdapter) ListAgentTypes(ctx context.Context) ([]*v1.AgentType,
 
 func (a *lifecycleAdapter) WasSessionInitialized(executionID string) bool {
 	return a.mgr.WasSessionInitialized(executionID)
+}
+
+func (a *lifecycleAdapter) OwnsPromptGeneration(sessionID, executionID string, generation uint64) bool {
+	return a.mgr.OwnsPromptGeneration(sessionID, executionID, generation)
 }
 
 func (a *lifecycleAdapter) GetSessionAuthMethods(sessionID string) []streams.AuthMethodInfo {

--- a/apps/backend/internal/orchestrator/event_handlers_agent.go
+++ b/apps/backend/internal/orchestrator/event_handlers_agent.go
@@ -360,6 +360,8 @@ func (s *Service) handleAgentReady(ctx context.Context, data watcher.AgentEventD
 		generationOwner, ok := s.agentManager.(interface {
 			OwnsPromptGeneration(sessionID, executionID string, generation uint64) bool
 		})
+		// Generation-bearing events fail closed: without an ownership validator,
+		// the handler cannot prove that the event still belongs to this turn.
 		if !ok || !generationOwner.OwnsPromptGeneration(
 			data.SessionID, data.AgentExecutionID, data.PromptGeneration,
 		) {

--- a/apps/backend/internal/orchestrator/event_handlers_agent.go
+++ b/apps/backend/internal/orchestrator/event_handlers_agent.go
@@ -356,6 +356,21 @@ func (s *Service) handleAgentReady(ctx context.Context, data watcher.AgentEventD
 			zap.String("session_state", string(session.State)))
 		return
 	}
+	if data.PromptGeneration != 0 {
+		generationOwner, ok := s.agentManager.(interface {
+			OwnsPromptGeneration(sessionID, executionID string, generation uint64) bool
+		})
+		if !ok || !generationOwner.OwnsPromptGeneration(
+			data.SessionID, data.AgentExecutionID, data.PromptGeneration,
+		) {
+			s.logger.Debug("stale agent.ready: prompt generation no longer owns the session",
+				zap.String("task_id", data.TaskID),
+				zap.String("session_id", data.SessionID),
+				zap.String("agent_execution_id", data.AgentExecutionID),
+				zap.Uint64("event_prompt_generation", data.PromptGeneration))
+			return
+		}
+	}
 	if s.turnService != nil {
 		if turnSnapshotErr != nil {
 			s.logger.Warn("could not confirm this event's active turn before waiting for the guard; treating as stale rather than risk completing a possible successor turn",

--- a/apps/backend/internal/orchestrator/event_handlers_clarification.go
+++ b/apps/backend/internal/orchestrator/event_handlers_clarification.go
@@ -285,7 +285,7 @@ func (s *Service) cancelAndDispatchClarificationRetry(ctx context.Context, data 
 			zap.Error(err))
 		// Force-revert session state so the retry prompt can proceed
 		if revertErr := s.repo.UpdateTaskSessionState(ctx, data.SessionID, models.TaskSessionStateWaitingForInput, ""); revertErr != nil {
-			s.logger.Error("failed to force-revert session state for clarification recovery",
+			s.logger.Warn("failed to force-revert session state for clarification recovery",
 				zap.String("session_id", data.SessionID),
 				zap.Error(revertErr))
 			return revertErr

--- a/apps/backend/internal/orchestrator/event_handlers_clarification.go
+++ b/apps/backend/internal/orchestrator/event_handlers_clarification.go
@@ -257,12 +257,23 @@ func (s *Service) retryClarificationAfterCancel(ctx context.Context, data clarif
 		zap.String("task_id", data.TaskID),
 		zap.String("session_id", data.SessionID))
 
-	// Claim the shared per-session guard across the whole cancel-then-retry
-	// sequence, not just the cancel call — see the Service.cancelInFlight
-	// field doc comment. Releasing between the cancel and the retry prompt
-	// would let a concurrent QueueAndInterruptForPeerMessage (or another
-	// drain) take-and-dispatch a queued entry in that gap, only for this
-	// retry's own PromptTask call to then prompt over top of it.
+	if err := s.cancelAndDispatchClarificationRetry(ctx, data, prompt); err != nil {
+		s.logger.Error("failed to resume agent after cancel in clarification recovery",
+			zap.String("task_id", data.TaskID),
+			zap.String("session_id", data.SessionID),
+			zap.Error(err))
+		return false
+	}
+
+	s.logger.Info("successfully recovered stuck agent with clarification answer",
+		zap.String("task_id", data.TaskID),
+		zap.String("session_id", data.SessionID))
+	return true
+}
+
+// cancelAndDispatchClarificationRetry owns the guard through cancellation and
+// retry acceptance, then releases it while the recovered agent turn runs.
+func (s *Service) cancelAndDispatchClarificationRetry(ctx context.Context, data clarificationAnsweredData, prompt string) error {
 	lock, release := s.acquireCancelInFlightGuard(data.SessionID)
 	defer release()
 	lock.Lock()
@@ -277,23 +288,15 @@ func (s *Service) retryClarificationAfterCancel(ctx context.Context, data clarif
 			s.logger.Error("failed to force-revert session state for clarification recovery",
 				zap.String("session_id", data.SessionID),
 				zap.Error(revertErr))
-			return false
+			return revertErr
 		}
 		s.completeTurnForSession(ctx, data.SessionID)
 	}
 
-	if _, err := s.PromptTask(ctx, data.TaskID, data.SessionID, prompt, "", false, nil, false); err != nil {
-		s.logger.Error("failed to resume agent after cancel in clarification recovery",
-			zap.String("task_id", data.TaskID),
-			zap.String("session_id", data.SessionID),
-			zap.Error(err))
-		return false
+	if _, err := s.PromptTask(ctx, data.TaskID, data.SessionID, prompt, "", false, nil, true); err != nil {
+		return err
 	}
-
-	s.logger.Info("successfully recovered stuck agent with clarification answer",
-		zap.String("task_id", data.TaskID),
-		zap.String("session_id", data.SessionID))
-	return true
+	return nil
 }
 
 // PauseForClarificationInput converts a no-answer ask_user_question outcome

--- a/apps/backend/internal/orchestrator/event_handlers_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_test.go
@@ -19,6 +19,8 @@ import (
 	"github.com/kandev/kandev/internal/agentctl/types/streams"
 	"github.com/kandev/kandev/internal/common/logger"
 	"github.com/kandev/kandev/internal/db"
+	"github.com/kandev/kandev/internal/events"
+	eventbus "github.com/kandev/kandev/internal/events/bus"
 	"github.com/kandev/kandev/internal/orchestrator/executor"
 	"github.com/kandev/kandev/internal/orchestrator/messagequeue"
 	"github.com/kandev/kandev/internal/orchestrator/queue"
@@ -29,6 +31,7 @@ import (
 	sqliterepo "github.com/kandev/kandev/internal/task/repository/sqlite"
 	wfmodels "github.com/kandev/kandev/internal/workflow/models"
 	v1 "github.com/kandev/kandev/pkg/api/v1"
+	"github.com/stretchr/testify/require"
 )
 
 // --- Mocks ---
@@ -230,6 +233,9 @@ type mockAgentManager struct {
 	// ErrCancelEscalated sentinels handled inside cancelAgentSilent).
 	cancelAgentErr error
 
+	currentPromptGeneration  atomic.Uint64
+	currentPromptExecutionID string
+
 	// set_session_mode tracking (issue #1183). Records (sessionID, modeID) for
 	// every SetSessionModeBySessionID call. setSessionModeErr, when set, is
 	// returned to simulate "no running agent".
@@ -347,6 +353,10 @@ func (m *mockAgentManager) IsAgentReadyForPrompt(ctx context.Context, sessionID 
 		return m.isAgentReadyFn(ctx, sessionID)
 	}
 	return m.IsAgentRunningForSession(ctx, sessionID)
+}
+
+func (m *mockAgentManager) OwnsPromptGeneration(_ string, executionID string, generation uint64) bool {
+	return executionID == m.currentPromptExecutionID && generation == m.currentPromptGeneration.Load()
 }
 
 // RowLiveness makes the mock satisfy the orchestrator's optional
@@ -1055,6 +1065,99 @@ func TestHandleAgentReadyGuards_ConcurrentInterruptRaces(t *testing.T) {
 		if move.WorkflowStepID != "step2" {
 			t.Fatalf("expected the pending move to still target step2, got %q", move.WorkflowStepID)
 		}
+	})
+}
+
+func TestHandleAgentReady_DelayedOldGenerationDoesNotCompleteReplacementTurn(t *testing.T) {
+	ctx := context.Background()
+
+	runScenario := func(t *testing.T, withPendingMove bool) {
+		t.Helper()
+		repo := setupTestRepo(t)
+		seedSession(t, repo, "t1", "s1", "step1")
+
+		stepGetter := newMockStepGetter()
+		stepGetter.steps["step1"] = &wfmodels.WorkflowStep{
+			ID: "step1", WorkflowID: "wf1", Name: "Step 1", Position: 0,
+		}
+		taskRepo := newMockTaskRepo()
+		seedMockTaskState(taskRepo, "t1", v1.TaskStateInProgress)
+		agentMgr := &mockAgentManager{isAgentRunning: true}
+		agentMgr.currentPromptExecutionID = "exec-1"
+		agentMgr.currentPromptGeneration.Store(2)
+		svc := createTestServiceWithAgent(repo, stepGetter, taskRepo, agentMgr)
+		svc.turnService = &repoTurnService{repo: repo}
+
+		oldTurn, err := svc.turnService.StartTurn(ctx, "s1")
+		require.NoError(t, err)
+
+		memoryBus := eventbus.NewMemoryEventBus(testLogger())
+		t.Cleanup(memoryBus.Close)
+		eventWatcher := watcher.NewWatcher(memoryBus, watcher.EventHandlers{
+			OnAgentReady: svc.handleAgentReady,
+		}, "stale-ready-regression", testLogger())
+		require.NoError(t, eventWatcher.Start(ctx))
+		t.Cleanup(func() { require.NoError(t, eventWatcher.Stop()) })
+
+		oldReady := eventbus.NewEvent(events.AgentReady, "agent-manager", map[string]interface{}{
+			"task_id":            "t1",
+			"session_id":         "s1",
+			"agent_execution_id": "exec-1",
+			"prompt_generation":  1,
+		})
+		publishWaiting := make(chan struct{})
+		releaseOldReady := make(chan struct{})
+		publishDone := make(chan error, 1)
+		go func() {
+			close(publishWaiting)
+			<-releaseOldReady
+			publishDone <- memoryBus.Publish(ctx, events.AgentReady, oldReady)
+		}()
+		<-publishWaiting
+
+		svc.completeTurnForSession(ctx, "s1")
+		replacementTurn, err := svc.turnService.StartTurn(ctx, "s1")
+		require.NoError(t, err)
+		require.NotEqual(t, oldTurn.ID, replacementTurn.ID)
+		if withPendingMove {
+			svc.messageQueue.SetPendingMove(ctx, "s1", &messagequeue.PendingMove{
+				TaskID: "t1", WorkflowID: "wf1", WorkflowStepID: "missing-step",
+			})
+		}
+
+		close(releaseOldReady)
+		select {
+		case err := <-publishDone:
+			require.NoError(t, err)
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out releasing the delayed old-generation ready event")
+		}
+
+		active, err := svc.turnService.GetActiveTurn(ctx, "s1")
+		require.NoError(t, err)
+		require.NotNil(t, active, "replacement turn must remain open")
+		require.Equal(t, replacementTurn.ID, active.ID)
+
+		updatedTask, err := repo.GetTask(ctx, "t1")
+		require.NoError(t, err)
+		require.Equal(t, "step1", updatedTask.WorkflowStepID,
+			"old ready must not evaluate on_turn_complete for the replacement turn")
+		updatedSession, err := repo.GetTaskSession(ctx, "s1")
+		require.NoError(t, err)
+		require.Equal(t, models.TaskSessionStateRunning, updatedSession.State,
+			"old ready must not run replacement-turn completion bookkeeping")
+		if withPendingMove {
+			move, exists := svc.messageQueue.GetPendingMove(ctx, "s1")
+			require.True(t, exists, "old ready must not consume the replacement turn's pending move")
+			require.Equal(t, "missing-step", move.WorkflowStepID)
+		}
+	}
+
+	t.Run("on_turn_complete remains unevaluated", func(t *testing.T) {
+		runScenario(t, false)
+	})
+	t.Run("pending move remains untouched", func(t *testing.T) {
+		runScenario(t, true)
 	})
 }
 

--- a/apps/backend/internal/orchestrator/task_operations_test.go
+++ b/apps/backend/internal/orchestrator/task_operations_test.go
@@ -1745,6 +1745,102 @@ func TestQueueAndInterruptForPeerMessage_RacesClarificationTimeoutRecovery(t *te
 	require.Equal(t, 1, status.Count, "the parent's message stays queued for the recovered turn's own natural drain")
 }
 
+func TestClarificationRecovery_ReleasesGuardAfterRetryDispatch(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	retryAccepted := make(chan struct{})
+	promptAccepted := make(chan promptCall, 2)
+	turnComplete := make(chan struct{})
+	var retryAcceptedOnce sync.Once
+	agentMgr := &mockAgentManager{
+		isAgentRunning:         true,
+		repoForExecutionLookup: repo,
+		promptAgentFunc: func(_ context.Context, executionID string, prompt string, _ []v1.MessageAttachment, dispatchOnly bool) (*executor.PromptResult, error) {
+			promptAccepted <- promptCall{ExecutionID: executionID, Prompt: prompt, DispatchOnly: dispatchOnly}
+			if prompt == "clarification answer" {
+				retryAcceptedOnce.Do(func() { close(retryAccepted) })
+			}
+			if !dispatchOnly {
+				<-turnComplete
+			}
+			return &executor.PromptResult{}, nil
+		},
+	}
+	svc := createTestServiceWithAgent(repo, newMockStepGetter(), newMockTaskRepo(), agentMgr)
+	svc.executor = executor.NewExecutor(agentMgr, repo, testLogger(), executor.ExecutorConfig{})
+
+	seedTaskAndSession(t, repo, "task1", "session1", models.TaskSessionStateRunning)
+	seedExecutorRunning(t, repo, "session1", "task1", "exec-1")
+	turnSync := &turnSnapshotSyncTurnService{
+		repoTurnService: &repoTurnService{repo: repo},
+		sessionID:       "session1",
+		snapshotTaken:   make(chan struct{}),
+	}
+	svc.turnService = turnSync
+	_, err := turnSync.StartTurn(ctx, "session1")
+	require.NoError(t, err)
+
+	recoveryDone := make(chan bool, 1)
+	go func() {
+		recoveryDone <- svc.retryClarificationAfterCancel(ctx, clarificationAnsweredData{
+			TaskID: "task1", SessionID: "session1",
+		}, "clarification answer", fmt.Errorf("wrap: %w", ErrAgentPromptInProgress))
+	}()
+	<-retryAccepted
+
+	interruptDone := make(chan struct{})
+	var queued *messagequeue.QueuedMessage
+	var dispatched bool
+	var interruptErr error
+	go func() {
+		queued, dispatched, interruptErr = svc.QueueAndInterruptForPeerMessage(
+			ctx, "task1", "session1", "parent steer", nil,
+		)
+		close(interruptDone)
+	}()
+	<-turnSync.snapshotTaken
+
+	select {
+	case <-interruptDone:
+	case <-time.After(2 * time.Second):
+		close(turnComplete)
+		<-interruptDone
+		t.Fatal("parent interrupt remained blocked on clarification recovery until the recovered turn completed")
+	}
+
+	select {
+	case recovered := <-recoveryDone:
+		require.True(t, recovered)
+	default:
+		close(turnComplete)
+		t.Fatal("clarification recovery must return after retry dispatch acceptance")
+	}
+	close(turnComplete)
+
+	require.NoError(t, interruptErr)
+	require.NotNil(t, queued)
+	require.True(t, dispatched, "interrupt begun after retry acceptance must interrupt the recovered turn")
+	require.Equal(t, int32(2), agentMgr.cancelAgentCalls.Load(), "recovery and parent interrupt each cancel their owned turn")
+
+	firstPrompt := <-promptAccepted
+	secondPrompt := <-promptAccepted
+	require.Equal(t, "clarification answer", firstPrompt.Prompt)
+	require.True(t, firstPrompt.DispatchOnly)
+	require.Equal(t, "parent steer", secondPrompt.Prompt)
+	require.False(t, secondPrompt.DispatchOnly, "normal queued dispatch keeps its existing completion-wait behavior")
+
+	agentMgr.mu.Lock()
+	promptCalls := append([]promptCall(nil), agentMgr.capturedPromptCalls...)
+	agentMgr.mu.Unlock()
+	require.Len(t, promptCalls, 2, "clarification retry and parent message must each dispatch exactly once")
+
+	active, err := svc.turnService.GetActiveTurn(ctx, "session1")
+	require.NoError(t, err)
+	require.NotNil(t, active, "parent interrupt replacement turn must remain active")
+	status := svc.messageQueue.GetStatus(ctx, "session1")
+	require.Equal(t, 0, status.Count, "accepted parent message must be removed from the queue exactly once")
+}
+
 // TestCancelAgent_RacesHandleAgentReady_QueuedMessageStillDelivered covers a
 // real cross-goroutine race at the orchestrator level: a user's Cancel-button
 // click (Service.CancelAgent) racing the same agent's own asynchronous

--- a/apps/backend/internal/orchestrator/watcher/watcher.go
+++ b/apps/backend/internal/orchestrator/watcher/watcher.go
@@ -31,6 +31,7 @@ type AgentEventData struct {
 	AgentProfileID   string `json:"agent_profile_id"`
 	ExitCode         *int   `json:"exit_code,omitempty"`
 	ErrorMessage     string `json:"error_message,omitempty"`
+	PromptGeneration uint64 `json:"prompt_generation,omitempty"`
 }
 
 // ACPSessionEventData contains data from ACP session events

--- a/docs/decisions/0035-version-agent-ready-events-by-prompt-generation.md
+++ b/docs/decisions/0035-version-agent-ready-events-by-prompt-generation.md
@@ -12,13 +12,15 @@ Cancel escalation must publish `agent.ready` outside the cancelling goroutine be
 
 Lifecycle prompt ownership is identified by `(agent_execution_id, prompt_generation)`. The generation advances explicitly before every prompt dispatch attempt, including the initial prompt and replacements dispatched while the execution is already `RUNNING`; status transitions alone do not create prompt identities. Turn-ending ready events include both values, and lifecycle captures the complete ready payload atomically with the transition to `Ready` before any detached publication begins.
 
+The generation is also part of the lifecycle-to-agentctl prompt request. The adapter echoes it on the terminal `complete` or prompt-error event instead of lifecycle reading the execution's current generation when that event eventually arrives. Lifecycle atomically compares the echoed generation with the active prompt before flushing buffers, signaling prompt completion, changing execution status, or publishing `agent.ready`. A terminal event for a superseded generation is discarded in full. Synthetic adapter turns that do not originate from a lifecycle prompt carry generation zero and retain their existing wakeup reconciliation path.
+
 The orchestrator validates this identity against the lifecycle execution store while holding the session's `cancelInFlightGuard`, before turn completion, pending moves, or `on_turn_complete` evaluation. Backend adapters between the orchestrator and lifecycle manager must preserve this ownership-validation capability; a generation-bearing ready event that cannot prove current ownership is stale and is ignored. Ordinary `MarkReady` and `MarkBootReady` publication remains synchronous; only cancel escalation uses detached publication.
 
 The same session guard may cover cancel plus replacement-prompt acceptance, but it must be released after acceptance. It must never remain held while waiting for that prompt's complete event.
 
 ## Consequences
 
-Delayed cancel-escalation events cannot be reassigned to replacement turns, including after an execution is replaced and generation numbers restart. Detached publishers carry immutable values instead of reading mutable execution state later. Prompt dispatch attempts and ready events now have a lifecycle-local generation contract that event consumers must preserve. A failed dispatch may consume a generation; generations identify ownership and are not a count of successful turns.
+Delayed cancel-escalation events and delayed ordinary prompt completions cannot be reassigned to replacement turns, including after an execution is replaced and generation numbers restart. Detached publishers carry immutable values instead of reading mutable execution state later. Prompt dispatch attempts, agentctl terminal events, and ready events now have a lifecycle-local generation contract that intermediaries and event consumers must preserve. A failed dispatch may consume a generation; generations identify ownership and are not a count of successful turns.
 
 Guard holders may still wait for bounded cancellation and prompt-dispatch acknowledgement. Concurrent parent interrupts become eligible immediately after a clarification retry is accepted and can either interrupt that recovered turn or back off if they snapshotted the superseded generation.
 

--- a/docs/decisions/0035-version-agent-ready-events-by-prompt-generation.md
+++ b/docs/decisions/0035-version-agent-ready-events-by-prompt-generation.md
@@ -10,15 +10,15 @@ Cancel escalation must publish `agent.ready` outside the cancelling goroutine be
 
 ## Decision
 
-Lifecycle prompt ownership is identified by `(agent_execution_id, prompt_generation)`. The generation advances when an execution transitions into `RUNNING` for a new prompt. Turn-ending ready events include both values, and lifecycle captures the complete ready payload atomically with the transition to `Ready` before any detached publication begins.
+Lifecycle prompt ownership is identified by `(agent_execution_id, prompt_generation)`. The generation advances explicitly before every prompt dispatch attempt, including the initial prompt and replacements dispatched while the execution is already `RUNNING`; status transitions alone do not create prompt identities. Turn-ending ready events include both values, and lifecycle captures the complete ready payload atomically with the transition to `Ready` before any detached publication begins.
 
-The orchestrator validates this identity against the lifecycle execution store while holding the session's `cancelInFlightGuard`, before turn completion, pending moves, or `on_turn_complete` evaluation. A generation-bearing ready event that cannot prove current ownership is stale and is ignored. Ordinary `MarkReady` and `MarkBootReady` publication remains synchronous; only cancel escalation uses detached publication.
+The orchestrator validates this identity against the lifecycle execution store while holding the session's `cancelInFlightGuard`, before turn completion, pending moves, or `on_turn_complete` evaluation. Backend adapters between the orchestrator and lifecycle manager must preserve this ownership-validation capability; a generation-bearing ready event that cannot prove current ownership is stale and is ignored. Ordinary `MarkReady` and `MarkBootReady` publication remains synchronous; only cancel escalation uses detached publication.
 
 The same session guard may cover cancel plus replacement-prompt acceptance, but it must be released after acceptance. It must never remain held while waiting for that prompt's complete event.
 
 ## Consequences
 
-Delayed cancel-escalation events cannot be reassigned to replacement turns, including after an execution is replaced and generation numbers restart. Detached publishers carry immutable values instead of reading mutable execution state later. Prompt starts and ready events now have a lifecycle-local generation contract that event consumers must preserve.
+Delayed cancel-escalation events cannot be reassigned to replacement turns, including after an execution is replaced and generation numbers restart. Detached publishers carry immutable values instead of reading mutable execution state later. Prompt dispatch attempts and ready events now have a lifecycle-local generation contract that event consumers must preserve. A failed dispatch may consume a generation; generations identify ownership and are not a count of successful turns.
 
 Guard holders may still wait for bounded cancellation and prompt-dispatch acknowledgement. Concurrent parent interrupts become eligible immediately after a clarification retry is accepted and can either interrupt that recovered turn or back off if they snapshotted the superseded generation.
 

--- a/docs/decisions/0035-version-agent-ready-events-by-prompt-generation.md
+++ b/docs/decisions/0035-version-agent-ready-events-by-prompt-generation.md
@@ -1,0 +1,27 @@
+# 0035: Version AgentReady Events by Prompt Generation
+
+**Status:** accepted
+**Date:** 2026-07-14
+**Area:** backend
+
+## Context
+
+Cancel escalation must publish `agent.ready` outside the cancelling goroutine because the in-memory event bus invokes orchestrator subscribers synchronously and those subscribers acquire the same per-session cancel guard. A detached publish avoided that reentrant deadlock, but an unversioned event could be delayed until a replacement prompt was active and then complete the replacement turn. Passing `*AgentExecution` to the detached goroutine also let the eventual payload observe mutable replacement state.
+
+## Decision
+
+Lifecycle prompt ownership is identified by `(agent_execution_id, prompt_generation)`. The generation advances when an execution transitions into `RUNNING` for a new prompt. Turn-ending ready events include both values, and lifecycle captures the complete ready payload atomically with the transition to `Ready` before any detached publication begins.
+
+The orchestrator validates this identity against the lifecycle execution store while holding the session's `cancelInFlightGuard`, before turn completion, pending moves, or `on_turn_complete` evaluation. A generation-bearing ready event that cannot prove current ownership is stale and is ignored. Ordinary `MarkReady` and `MarkBootReady` publication remains synchronous; only cancel escalation uses detached publication.
+
+The same session guard may cover cancel plus replacement-prompt acceptance, but it must be released after acceptance. It must never remain held while waiting for that prompt's complete event.
+
+## Consequences
+
+Delayed cancel-escalation events cannot be reassigned to replacement turns, including after an execution is replaced and generation numbers restart. Detached publishers carry immutable values instead of reading mutable execution state later. Prompt starts and ready events now have a lifecycle-local generation contract that event consumers must preserve.
+
+Guard holders may still wait for bounded cancellation and prompt-dispatch acknowledgement. Concurrent parent interrupts become eligible immediately after a clarification retry is accepted and can either interrupt that recovered turn or back off if they snapshotted the superseded generation.
+
+## Alternatives Considered
+
+Publishing `agent.ready` synchronously was rejected because synchronous subscribers re-enter the already-held session guard. Reading the active orchestrator turn only when the handler begins was rejected because a delayed event can see the replacement turn as both its baseline and current turn. Posting an unversioned reconciliation callback after guard release was rejected because it would create a second completion path with separate ownership and error handling.

--- a/docs/decisions/INDEX.md
+++ b/docs/decisions/INDEX.md
@@ -40,3 +40,4 @@ Read individual ADRs for full context. Create new ones via `/record decision` or
 | 0032 | [Configurable worktree branch names](0032-configurable-worktree-branch-names.md)                                                    | accepted   | backend, frontend           | 2026-07-07 |
 | 0033 | [Durable plan implementation start marker](0033-durable-plan-implementation-start.md)                                               | accepted   | backend, frontend           | 2026-07-09 |
 | 0034 | [Agent Client Protocol Codex ACP Bridge](0034-agentclientprotocol-codex-acp.md)                                                     | accepted   | backend, protocol           | 2026-07-10 |
+| 0035 | [Version AgentReady events by prompt generation](0035-version-agent-ready-events-by-prompt-generation.md)                          | accepted   | backend                     | 2026-07-14 |

--- a/docs/specs/tasks/parent-child-message-interrupt.md
+++ b/docs/specs/tasks/parent-child-message-interrupt.md
@@ -120,8 +120,10 @@ clarification-timeout recovery — that the loser correctly does not cancel into
 is accounted for exactly once: dispatched, or left queued for its own future turn boundary.
 
 The guard is acquired *before* any turn-completion bookkeeping runs (not just around the
-final queue-drain decision). Each turn-ending `agent.ready` signal carries the immutable
-`(agent_execution_id, prompt_generation)` captured when lifecycle created the ready signal.
+final queue-drain decision). Lifecycle assigns each accepted prompt an immutable generation,
+passes it through agentctl, and requires the terminal event to echo it before lifecycle may
+flush or complete that prompt. Each resulting turn-ending `agent.ready` signal carries the
+immutable `(agent_execution_id, prompt_generation)` captured from that accepted prompt.
 Once the guard is held, bookkeeping verifies that identity still owns the session and also
 re-validates the active orchestrator turn when turn tracking is wired. A ready event that
 raced a parent interrupt and lost cannot complete (or transition the workflow for) a turn the

--- a/docs/specs/tasks/parent-child-message-interrupt.md
+++ b/docs/specs/tasks/parent-child-message-interrupt.md
@@ -91,6 +91,8 @@ failure is still logged server-side.
 
 ### Composition with the FIFO queue and turn-safety guarantees
 
+Decision: [ADR-0035](../../decisions/0035-version-agent-ready-events-by-prompt-generation.md)
+
 `delivery_mode="interrupt"` queues the message and cancels-and-takes it in one atomic
 orchestrator call, not two separate steps: queuing followed by a separate interrupt call
 would leave a window where the target's turn could complete naturally, the ordinary FIFO
@@ -103,7 +105,9 @@ Every path that can cancel a session's active turn or take-and-dispatch its next
 message — the parent interrupt, a manual or workflow-triggered queue drain, CI-automation
 drains, and clarification-timeout recovery — serializes through one per-session guard. Two
 such operations targeting the same session never interleave: whichever acquires the guard
-first completes its cancel/take-and-dispatch before the other proceeds. This guarantees at
+first completes its cancel/take-and-dispatch through prompt acceptance before the other
+proceeds. The guard is released immediately after acceptance and is never held while waiting
+for the dispatched agent turn to complete. This guarantees at
 most one dispatch per queued entry (no double dispatch) and no entry is ever silently
 dropped — but it does *not* guarantee that one of the two racing callers itself performs an
 immediate delivery. The loser backs off once it observes the winner already changed the
@@ -116,12 +120,14 @@ clarification-timeout recovery — that the loser correctly does not cancel into
 is accounted for exactly once: dispatched, or left queued for its own future turn boundary.
 
 The guard is acquired *before* any turn-completion bookkeeping runs (not just around the
-final queue-drain decision), and — whenever the orchestrator has turn identity tracking
-wired — bookkeeping re-validates that the turn it is about to complete is still the same one
-that was active when the event fired, once the guard is actually held. A ready event that
+final queue-drain decision). Each turn-ending `agent.ready` signal carries the immutable
+`(agent_execution_id, prompt_generation)` captured when lifecycle created the ready signal.
+Once the guard is held, bookkeeping verifies that identity still owns the session and also
+re-validates the active orchestrator turn when turn tracking is wired. A ready event that
 raced a parent interrupt and lost cannot complete (or transition the workflow for) a turn the
-interrupt already cancelled and replaced; it detects the turn changed out from under it and
-backs off instead, leaving that turn's own eventual completion to whatever superseded it.
+interrupt already cancelled and replaced, even if delivery did not begin until after the
+replacement turn started. It backs off instead, leaving that turn's own eventual completion
+to whatever superseded it.
 Conversely, if the interrupt's own cancel genuinely fails while a ready event was blocked
 behind the same guard, the message is not stranded: the still-pending ready event finds the
 turn exactly as it left it (not stale) and delivers the message itself through the ordinary
@@ -204,9 +210,16 @@ causing a second, competing dispatch.
 
 **GIVEN** a parent's `delivery_mode="interrupt"` call cancels and redispatches a session
 through a brand new turn, **WHEN** a `agent.ready` event for the *original* (now-cancelled)
-turn was already in flight when the interrupt started, **THEN** that ready event detects the
-turn changed once it can proceed and backs off without completing or transitioning the
-workflow for the interrupt's new turn.
+turn is delayed until after the replacement prompt has claimed `RUNNING`, **THEN** that ready
+event retains the original prompt generation and backs off without completing the replacement
+turn, consuming its pending move, or evaluating its `on_turn_complete` transition.
+
+**GIVEN** clarification recovery has cancelled a stuck turn and its retry prompt has been
+accepted but remains incomplete, **WHEN** the direct parent requests
+`delivery_mode="interrupt"`, **THEN** the request does not wait for the recovered turn to
+complete. It either interrupts that current recovered turn and dispatches the parent message,
+or, if it began against the superseded generation, leaves the parent message queued without
+loss or duplicate dispatch.
 
 **GIVEN** a parent's `delivery_mode="interrupt"` call's own cancel step genuinely fails
 (not one of the tolerated "already idle"/"no active execution" cases) while a ready event


### PR DESCRIPTION
Delayed cancel-escalation readiness could be reassigned to a replacement turn, while clarification
recovery could monopolize the cancel guard for that turn's full duration. Ready events now retain
immutable prompt ownership and clarification retry releases the guard immediately after dispatch.

## Important Changes

- Version turn-ending ready events by agent execution and prompt generation so stale delivery fails closed.
- Capture escalation payloads before detached publication while preserving synchronous ordinary ready events.
- Bound clarification recovery guard ownership to cancellation and retry prompt acceptance.
- Record the durable event-generation and guard-ownership contracts in ADR 0035 and the feature spec.

## Validation

- `make fmt`
- `node apps/web/scripts/generate-release-notes.mjs`
- `node apps/web/scripts/generate-changelog.mjs`
- `make typecheck`
- `make test`
- `make lint`
- `go test -race ./internal/agent/runtime/lifecycle ./internal/orchestrator ./internal/mcp/handlers -count=1`
- `pnpm e2e:run tests/session/pause-resume-recovery.spec.ts -- --grep "a message queued during a running turn is delivered when the turn is paused"`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1678?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->