### PR TITLE
feat: show ACP shell command output in chat

### DIFF
--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter.go
@@ -37,6 +37,8 @@ const (
 	contentTypeImage    = "image"
 	contentTypeAudio    = "audio"
 	contentTypeResource = "resource"
+	contentTypeText     = "text"
+	toolContentType     = "content"
 
 	// configOptionIDModel is the well-known ConfigOption ID/Category value used
 	// by ACP agents to surface the active model as a selectable option.
@@ -373,6 +375,9 @@ func (a *Adapter) Initialize(ctx context.Context) error {
 
 	resp, err := a.acpConn.Initialize(ctx, acp.InitializeRequest{
 		ProtocolVersion: acp.ProtocolVersionNumber,
+		ClientCapabilities: acp.ClientCapabilities{
+			Meta: map[string]any{"terminal_output": true},
+		},
 		ClientInfo: &acp.Implementation{
 			Name:    "kandev-agentctl",
 			Version: "1.0.0",

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_tools.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_tools.go
@@ -26,7 +26,7 @@ func (a *Adapter) convertToolCallContents(contents []acp.ToolCallContent) []stre
 			cb := a.convertContentBlockToStreams(c.Content.Content)
 			if cb != nil {
 				items = append(items, streams.ToolCallContentItem{
-					Type:    "content",
+					Type:    toolContentType,
 					Content: cb,
 				})
 			}
@@ -47,7 +47,7 @@ func (a *Adapter) convertToolCallContents(contents []acp.ToolCallContent) []stre
 func (a *Adapter) convertContentBlockToStreams(cb acp.ContentBlock) *streams.ContentBlock {
 	switch {
 	case cb.Text != nil:
-		return &streams.ContentBlock{Type: "text", Text: cb.Text.Text}
+		return &streams.ContentBlock{Type: contentTypeText, Text: cb.Text.Text}
 	case cb.Image != nil:
 		return &streams.ContentBlock{Type: contentTypeImage, Data: cb.Image.Data, MimeType: cb.Image.MimeType, URI: derefStr(cb.Image.Uri)}
 	case cb.Audio != nil:
@@ -142,6 +142,7 @@ func (a *Adapter) convertToolCallUpdate(sessionID string, tc *acp.SessionUpdateT
 //nolint:gocognit,cyclop,funlen // pre-existing complexity preserved from adapter.go file split
 func (a *Adapter) convertToolCallResultUpdate(sessionID string, tcu *acp.SessionToolCallUpdate) *AgentEvent {
 	toolCallID := string(tcu.ToolCallId)
+	convertedContents := a.convertToolCallContents(tcu.Content)
 	status := ""
 	if tcu.Status != nil {
 		status = string(*tcu.Status)
@@ -215,14 +216,29 @@ func (a *Adapter) convertToolCallResultUpdate(sessionID string, tcu *acp.Session
 		status = toolStatusComplete
 	}
 
-	isTerminal := status == toolStatusComplete || status == toolStatusError || status == toolStatusCancelled
-
 	// Update stored payload with tool result output. Skip for tracked-Monitor
 	// terminal updates so Generic.Output stays the structured `{monitor: …}`
 	// view rather than getting clobbered by the rawOutput string.
-	if tcu.RawOutput != nil && payload != nil && !isTrackedMonitorTerminal {
+	recognizedShellUpdate := false
+	if payload != nil && payload.Kind() == streams.ToolKindShellExec {
+		recognizedShellUpdate = a.normalizer.NormalizeShellToolUpdate(payload, tcu.Meta, convertedContents, tcu.RawOutput)
+	} else if tcu.RawOutput != nil && payload != nil && !isTrackedMonitorTerminal {
 		a.normalizer.NormalizeToolResult(payload, tcu.RawOutput)
 	}
+	var shellExitCode *int
+	if payload != nil && payload.ShellExec() != nil && payload.ShellExec().Output != nil {
+		shellExitCode = payload.ShellExec().Output.ExitCode
+	}
+	if status == "" && recognizedShellUpdate {
+		status = toolStatusInProgress
+		if shellExitCode != nil {
+			status = toolStatusComplete
+		}
+	}
+	if shellExitCode != nil && *shellExitCode != 0 && status != toolStatusCancelled {
+		status = toolStatusError
+	}
+	isTerminal := status == toolStatusComplete || status == toolStatusError || status == toolStatusCancelled
 
 	// Subagent (Task) result metadata is split across meta (Claude) and
 	// rawOutput (OpenCode/Cursor); enrich the stored payload from both.
@@ -314,7 +330,7 @@ func (a *Adapter) convertToolCallResultUpdate(sessionID string, tcu *acp.Session
 		ToolTitle:         title,
 		ToolStatus:        status,
 		NormalizedPayload: payload,
-		ToolCallContents:  a.convertToolCallContents(tcu.Content),
+		ToolCallContents:  convertedContents,
 	}
 }
 

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_tools.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_tools.go
@@ -147,9 +147,12 @@ func (a *Adapter) convertToolCallResultUpdate(sessionID string, tcu *acp.Session
 	if tcu.Status != nil {
 		status = string(*tcu.Status)
 	}
-	// Normalize status - "completed" -> "complete" for frontend consistency
-	if status == "completed" {
+	// Normalize ACP status spellings for frontend and lifecycle consistency.
+	switch status {
+	case "completed":
 		status = toolStatusComplete
+	case "failed":
+		status = toolStatusError
 	}
 	// Claude-acp sends incremental updates (title, rawInput, content) with no
 	// Status field — e.g. the second tool_call_update for Bash carries the actual
@@ -231,12 +234,13 @@ func (a *Adapter) convertToolCallResultUpdate(sessionID string, tcu *acp.Session
 	}
 	if status == "" && recognizedShellUpdate {
 		status = toolStatusInProgress
-		if shellExitCode != nil {
+	}
+	if shellExitCode != nil && status != toolStatusCancelled {
+		if *shellExitCode != 0 {
+			status = toolStatusError
+		} else if recognizedShellUpdate && status != toolStatusError {
 			status = toolStatusComplete
 		}
-	}
-	if shellExitCode != nil && *shellExitCode != 0 && status != toolStatusCancelled {
-		status = toolStatusError
 	}
 	isTerminal := status == toolStatusComplete || status == toolStatusError || status == toolStatusCancelled
 

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_tools.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_tools.go
@@ -149,7 +149,7 @@ func (a *Adapter) convertToolCallResultUpdate(sessionID string, tcu *acp.Session
 	}
 	// Normalize ACP status spellings for frontend and lifecycle consistency.
 	switch status {
-	case "completed":
+	case toolStatusCompleted:
 		status = toolStatusComplete
 	case "failed":
 		status = toolStatusError

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/monitor.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/monitor.go
@@ -456,7 +456,7 @@ func (a *Adapter) captureReplayMonitor(sessionID string, u acp.SessionUpdate) {
 		// post-replay sweep doesn't double-emit a cancellation.
 		if tcu.Status != nil {
 			s := string(*tcu.Status)
-			if s == "completed" || s == "failed" || s == toolStatusCancelled {
+			if s == toolStatusCompleted || s == "failed" || s == toolStatusCancelled {
 				a.dropMonitorByToolCallID(sessionID, toolCallID)
 			}
 		}

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/monitor.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/monitor.go
@@ -418,7 +418,7 @@ func monitorEventEvent(sessionID, toolCallID string, body string, payload *strea
 		ToolStatus:        toolStatusInProgress,
 		NormalizedPayload: payload,
 		ToolCallContents: []streams.ToolCallContentItem{
-			{Type: "content", Content: &streams.ContentBlock{Type: "text", Text: body}},
+			{Type: toolContentType, Content: &streams.ContentBlock{Type: contentTypeText, Text: body}},
 		},
 	}
 }
@@ -550,7 +550,7 @@ func monitorTerminalEvent(sessionID, toolCallID, status, note string, payload *s
 	var contents []streams.ToolCallContentItem
 	if note != "" {
 		contents = []streams.ToolCallContentItem{
-			{Type: "content", Content: &streams.ContentBlock{Type: "text", Text: note}},
+			{Type: toolContentType, Content: &streams.ContentBlock{Type: contentTypeText, Text: note}},
 		}
 	}
 	return AgentEvent{

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/normalize.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/normalize.go
@@ -24,6 +24,7 @@ const (
 	toolTypeGeneric = "tool_call"
 
 	toolStatusComplete   = "complete"
+	toolStatusCompleted  = "completed"
 	toolStatusError      = "error"
 	toolStatusInProgress = "in_progress"
 	toolStatusCancelled  = "cancelled"

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/normalize.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/normalize.go
@@ -1,7 +1,6 @@
 package acp
 
 import (
-	"strconv"
 	"strings"
 
 	"github.com/kandev/kandev/internal/agentctl/server/adapter/transport/shared"
@@ -146,14 +145,8 @@ func (n *Normalizer) NormalizeToolResult(payload *streams.NormalizedPayload, res
 			}
 		}
 	case streams.ToolKindShellExec:
-		if payload.ShellExec() != nil && output != "" {
-			// Parse ACP's XML-like shell output format
-			exitCode, stdout, stderr := parseShellOutput(output)
-			payload.ShellExec().Output = &streams.ShellExecOutput{
-				ExitCode: exitCode,
-				Stdout:   stdout,
-				Stderr:   stderr,
-			}
+		if payload.ShellExec() != nil {
+			applyFinalShellResult(payload.ShellExec(), result)
 		}
 	case streams.ToolKindGeneric:
 		if payload.Generic() != nil {
@@ -210,51 +203,6 @@ func parseFileList(output string) []string {
 		files = append(files, line)
 	}
 	return files
-}
-
-// parseShellOutput parses ACP's XML-like shell output format.
-// Format: "...<return-code>N</return-code>...<output>...</output>..."
-// Falls back to treating the entire string as stdout when no XML tags are found
-// (e.g. Claude Code sends plain string rawOutput).
-// Returns exit code, stdout, and stderr (stderr from <stderr> tag if present).
-func parseShellOutput(output string) (exitCode int, stdout, stderr string) {
-	hasXMLTags := strings.Contains(output, "<return-code>") ||
-		strings.Contains(output, "<output>") ||
-		strings.Contains(output, "<stderr>")
-
-	if !hasXMLTags {
-		// Plain string output (e.g. Claude Code ACP) — treat entire string as stdout
-		return 0, strings.TrimSpace(output), ""
-	}
-
-	// Extract return code
-	if start := strings.Index(output, "<return-code>"); start != -1 {
-		start += len("<return-code>")
-		if end := strings.Index(output[start:], "</return-code>"); end != -1 {
-			codeStr := strings.TrimSpace(output[start : start+end])
-			if code, err := strconv.Atoi(codeStr); err == nil {
-				exitCode = code
-			}
-		}
-	}
-
-	// Extract stdout from <output> tag
-	if start := strings.Index(output, "<output>"); start != -1 {
-		start += len("<output>")
-		if end := strings.Index(output[start:], "</output>"); end != -1 {
-			stdout = strings.TrimSpace(output[start : start+end])
-		}
-	}
-
-	// Extract stderr from <stderr> tag if present
-	if start := strings.Index(output, "<stderr>"); start != -1 {
-		start += len("<stderr>")
-		if end := strings.Index(output[start:], "</stderr>"); end != -1 {
-			stderr = strings.TrimSpace(output[start : start+end])
-		}
-	}
-
-	return exitCode, stdout, stderr
 }
 
 // UpdatePayloadInput updates a stored NormalizedPayload with new rawInput data.

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/normalize_test.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/normalize_test.go
@@ -649,9 +649,8 @@ func TestNormalizerResult(t *testing.T) {
 		if payload.ShellExec().Output == nil {
 			t.Fatal("expected Output to be set")
 		}
-		if payload.ShellExec().Output.ExitCode != 0 {
-			t.Errorf("expected ExitCode 0, got %d", payload.ShellExec().Output.ExitCode)
-		}
+		require.NotNil(t, payload.ShellExec().Output.ExitCode)
+		require.Equal(t, 0, *payload.ShellExec().Output.ExitCode)
 		if payload.ShellExec().Output.Stdout != "/Users/cfl/project" {
 			t.Errorf("expected Stdout '/Users/cfl/project', got %q", payload.ShellExec().Output.Stdout)
 		}
@@ -674,9 +673,8 @@ func TestNormalizerResult(t *testing.T) {
 		if payload.ShellExec().Output == nil {
 			t.Fatal("expected Output to be set")
 		}
-		if payload.ShellExec().Output.ExitCode != 1 {
-			t.Errorf("expected ExitCode 1, got %d", payload.ShellExec().Output.ExitCode)
-		}
+		require.NotNil(t, payload.ShellExec().Output.ExitCode)
+		require.Equal(t, 1, *payload.ShellExec().Output.ExitCode)
 		if payload.ShellExec().Output.Stderr != "cat: nonexistent: No such file or directory" {
 			t.Errorf("expected Stderr, got %q", payload.ShellExec().Output.Stderr)
 		}
@@ -749,9 +747,7 @@ func TestParseShellOutputPlainString(t *testing.T) {
 		if payload.ShellExec().Output.Stdout != "/Users/cfl/Projects/1code" {
 			t.Errorf("expected Stdout '/Users/cfl/Projects/1code', got %q", payload.ShellExec().Output.Stdout)
 		}
-		if payload.ShellExec().Output.ExitCode != 0 {
-			t.Errorf("expected ExitCode 0, got %d", payload.ShellExec().Output.ExitCode)
-		}
+		require.Nil(t, payload.ShellExec().Output.ExitCode)
 	})
 
 	t.Run("XML-wrapped output still works", func(t *testing.T) {

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/shell_output.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/shell_output.go
@@ -12,12 +12,13 @@ import (
 const maxShellOutputBytes = 256 * 1024
 
 type normalizedShellResult struct {
-	exitCode  *int
-	stdout    string
-	stderr    string
-	hasStdout bool
-	hasStderr bool
-	truncated bool
+	exitCode        *int
+	stdout          string
+	stderr          string
+	hasStdout       bool
+	hasStderr       bool
+	stdoutTruncated bool
+	stderrTruncated bool
 }
 
 func applyFinalShellResult(payload *streams.ShellExecPayload, result any) {
@@ -28,12 +29,14 @@ func applyFinalShellResult(payload *streams.ShellExecPayload, result any) {
 	output := ensureShellOutput(payload)
 	if normalized.hasStdout {
 		output.Stdout = normalized.stdout
+		output.StdoutTruncated = normalized.stdoutTruncated
 	}
 	if normalized.hasStderr {
 		output.Stderr = normalized.stderr
+		output.StderrTruncated = normalized.stderrTruncated
 	}
 	if normalized.hasStdout || normalized.hasStderr {
-		output.Truncated = output.Truncated || normalized.truncated
+		syncShellTruncation(output)
 	}
 	if normalized.exitCode != nil {
 		output.ExitCode = normalized.exitCode
@@ -87,21 +90,31 @@ func ensureShellOutput(payload *streams.ShellExecPayload) *streams.ShellExecOutp
 	if payload.Output == nil {
 		payload.Output = &streams.ShellExecOutput{}
 	}
+	if payload.Output.Truncated && !payload.Output.StdoutTruncated && !payload.Output.StderrTruncated {
+		payload.Output.StdoutTruncated = payload.Output.Stdout != ""
+		payload.Output.StderrTruncated = payload.Output.Stderr != ""
+	}
 	return payload.Output
+}
+
+func syncShellTruncation(output *streams.ShellExecOutput) {
+	output.Truncated = output.StdoutTruncated || output.StderrTruncated
 }
 
 func appendShellStdout(payload *streams.ShellExecPayload, data string) {
 	output := ensureShellOutput(payload)
 	bounded, truncated := boundShellOutput(output.Stdout + data)
 	output.Stdout = bounded
-	output.Truncated = output.Truncated || truncated
+	output.StdoutTruncated = output.StdoutTruncated || truncated
+	syncShellTruncation(output)
 }
 
 func replaceShellStdout(payload *streams.ShellExecPayload, data string) {
 	output := ensureShellOutput(payload)
 	bounded, truncated := boundShellOutput(data)
 	output.Stdout = bounded
-	output.Truncated = output.Truncated || truncated
+	output.StdoutTruncated = truncated
+	syncShellTruncation(output)
 }
 
 func replaceOrAppendTerminalOutput(payload *streams.ShellExecPayload, data string) {
@@ -215,17 +228,15 @@ func normalizeShellResultMap(result map[string]any) normalizedShellResult {
 		}
 	}
 
-	normalized.stdout, normalized.truncated = boundShellOutput(normalized.stdout)
-	var stderrTruncated bool
-	normalized.stderr, stderrTruncated = boundShellOutput(normalized.stderr)
-	normalized.truncated = normalized.truncated || stderrTruncated
+	normalized.stdout, normalized.stdoutTruncated = boundShellOutput(normalized.stdout)
+	normalized.stderr, normalized.stderrTruncated = boundShellOutput(normalized.stderr)
 	return normalized
 }
 
 func normalizeShellText(output string) normalizedShellResult {
 	if !hasEmbeddedShellTags(output) {
 		stdout, truncated := boundShellOutput(output)
-		return normalizedShellResult{stdout: stdout, hasStdout: true, truncated: truncated}
+		return normalizedShellResult{stdout: stdout, hasStdout: true, stdoutTruncated: truncated}
 	}
 
 	stdout, hasStdout := embeddedShellField(output, "output")
@@ -246,10 +257,8 @@ func normalizeShellText(output string) normalizedShellResult {
 		result.hasStdout = true
 	}
 
-	result.stdout, result.truncated = boundShellOutput(result.stdout)
-	var stderrTruncated bool
-	result.stderr, stderrTruncated = boundShellOutput(result.stderr)
-	result.truncated = result.truncated || stderrTruncated
+	result.stdout, result.stdoutTruncated = boundShellOutput(result.stdout)
+	result.stderr, result.stderrTruncated = boundShellOutput(result.stderr)
 	return result
 }
 

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/shell_output.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/shell_output.go
@@ -105,6 +105,8 @@ func replaceOrAppendTerminalOutput(payload *streams.ShellExecPayload, data strin
 		replaceShellStdout(payload, data)
 		return
 	}
+	// ACP does not identify cumulative terminal_output values. Treat values
+	// without the current prefix as new chunks so mixed update streams remain intact.
 	appendShellStdout(payload, data)
 }
 

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/shell_output.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/shell_output.go
@@ -1,0 +1,302 @@
+package acp
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/kandev/kandev/internal/agentctl/types/streams"
+)
+
+const maxShellOutputBytes = 256 * 1024
+
+type normalizedShellResult struct {
+	exitCode  *int
+	stdout    string
+	stderr    string
+	hasOutput bool
+	truncated bool
+}
+
+func applyFinalShellResult(payload *streams.ShellExecPayload, result any) {
+	normalized := normalizeFinalShellResult(result)
+	if !normalized.hasOutput && normalized.exitCode == nil {
+		return
+	}
+	output := ensureShellOutput(payload)
+	if normalized.hasOutput {
+		output.Stdout = normalized.stdout
+		output.Stderr = normalized.stderr
+		output.Truncated = normalized.truncated
+	}
+	if normalized.exitCode != nil {
+		output.ExitCode = normalized.exitCode
+	}
+}
+
+// NormalizeShellToolUpdate merges live and final ACP shell result fields into
+// the active normalized payload. It reports whether the update contained a
+// recognized shell output field so statusless updates can be persisted.
+func (n *Normalizer) NormalizeShellToolUpdate(
+	payload *streams.NormalizedPayload,
+	meta map[string]any,
+	contents []streams.ToolCallContentItem,
+	rawOutput any,
+) bool {
+	if payload == nil || payload.ShellExec() == nil {
+		return false
+	}
+	shell := payload.ShellExec()
+	recognized := false
+
+	if data, ok := terminalOutputData(meta, "terminal_output_delta"); ok {
+		appendShellStdout(shell, data)
+		recognized = true
+	}
+	if content, ok := cumulativeShellContent(contents); ok {
+		replaceShellStdout(shell, content)
+		recognized = true
+	}
+	if rawOutput != nil {
+		applyFinalShellResult(shell, rawOutput)
+		recognized = true
+	}
+	if data, ok := terminalOutputData(meta, "terminal_output"); ok {
+		if rawOutput != nil {
+			replaceShellStdout(shell, data)
+		} else {
+			replaceOrAppendTerminalOutput(shell, data)
+		}
+		recognized = true
+	}
+	if exitCode, ok := terminalExitCode(meta); ok {
+		ensureShellOutput(shell).ExitCode = intPtr(exitCode)
+		recognized = true
+	}
+
+	return recognized
+}
+
+func ensureShellOutput(payload *streams.ShellExecPayload) *streams.ShellExecOutput {
+	if payload.Output == nil {
+		payload.Output = &streams.ShellExecOutput{}
+	}
+	return payload.Output
+}
+
+func appendShellStdout(payload *streams.ShellExecPayload, data string) {
+	output := ensureShellOutput(payload)
+	bounded, truncated := boundShellOutput(output.Stdout + data)
+	output.Stdout = bounded
+	output.Truncated = output.Truncated || truncated
+}
+
+func replaceShellStdout(payload *streams.ShellExecPayload, data string) {
+	output := ensureShellOutput(payload)
+	bounded, truncated := boundShellOutput(data)
+	output.Stdout = bounded
+	output.Truncated = output.Truncated || truncated
+}
+
+func replaceOrAppendTerminalOutput(payload *streams.ShellExecPayload, data string) {
+	current := ensureShellOutput(payload).Stdout
+	if current == "" || strings.HasPrefix(data, current) {
+		replaceShellStdout(payload, data)
+		return
+	}
+	appendShellStdout(payload, data)
+}
+
+func terminalOutputData(meta map[string]any, key string) (string, bool) {
+	if meta == nil {
+		return "", false
+	}
+	value, ok := meta[key]
+	if !ok {
+		return "", false
+	}
+	if data, ok := value.(string); ok {
+		return data, true
+	}
+	valueMap, ok := value.(map[string]any)
+	if !ok {
+		return "", false
+	}
+	data, ok := valueMap["data"].(string)
+	return data, ok
+}
+
+func terminalExitCode(meta map[string]any) (int, bool) {
+	if meta == nil {
+		return 0, false
+	}
+	exit, ok := meta["terminal_exit"].(map[string]any)
+	if !ok {
+		return 0, false
+	}
+	if code, ok := parseExitCode(exit["exit_code"]); ok {
+		return code, true
+	}
+	return parseExitCode(exit["code"])
+}
+
+func cumulativeShellContent(contents []streams.ToolCallContentItem) (string, bool) {
+	var content strings.Builder
+	found := false
+	for _, item := range contents {
+		if item.Type != toolContentType || item.Content == nil || item.Content.Type != contentTypeText {
+			continue
+		}
+		content.WriteString(item.Content.Text)
+		found = true
+	}
+	return content.String(), found
+}
+
+func normalizeFinalShellResult(result any) normalizedShellResult {
+	result = unwrapShellRawOutput(result)
+	switch value := result.(type) {
+	case string:
+		return normalizeShellText(value)
+	case map[string]any:
+		return normalizeShellResultMap(value)
+	default:
+		return normalizedShellResult{}
+	}
+}
+
+func unwrapShellRawOutput(result any) any {
+	resultMap, ok := result.(map[string]any)
+	if !ok {
+		return result
+	}
+	if rawOutput, ok := resultMap["rawOutput"]; ok {
+		return rawOutput
+	}
+	return result
+}
+
+func normalizeShellResultMap(result map[string]any) normalizedShellResult {
+	stdout, stdoutExplicit := result["stdout"].(string)
+	stderr, stderrExplicit := result["stderr"].(string)
+	formatted, hasFormatted := result["formatted_output"].(string)
+	output, hasOutput := result["output"].(string)
+
+	var normalized normalizedShellResult
+	switch {
+	case stdoutExplicit || stderrExplicit:
+		normalized.stdout = stdout
+		normalized.stderr = stderr
+		normalized.hasOutput = true
+	case hasFormatted:
+		normalized = normalizeShellText(formatted)
+	case hasOutput:
+		normalized = normalizeShellText(output)
+	}
+
+	if code, ok := parseExitCode(result["exit_code"]); ok {
+		normalized.exitCode = intPtr(code)
+	} else if metadata, ok := result["metadata"].(map[string]any); ok {
+		if code, ok := parseExitCode(metadata["exit"]); ok {
+			normalized.exitCode = intPtr(code)
+		}
+	}
+
+	normalized.stdout, normalized.truncated = boundShellOutput(normalized.stdout)
+	var stderrTruncated bool
+	normalized.stderr, stderrTruncated = boundShellOutput(normalized.stderr)
+	normalized.truncated = normalized.truncated || stderrTruncated
+	return normalized
+}
+
+func normalizeShellText(output string) normalizedShellResult {
+	if !hasEmbeddedShellTags(output) {
+		stdout, truncated := boundShellOutput(output)
+		return normalizedShellResult{stdout: stdout, hasOutput: true, truncated: truncated}
+	}
+
+	stdout, hasStdout := embeddedShellField(output, "output")
+	stderr, hasStderr := embeddedShellField(output, "stderr")
+	codeText, hasExit := embeddedShellField(output, "return-code")
+	result := normalizedShellResult{hasOutput: hasStdout || hasStderr}
+	if hasStdout {
+		result.stdout = strings.TrimSpace(stdout)
+	}
+	if hasStderr {
+		result.stderr = strings.TrimSpace(stderr)
+	}
+	if code, ok := parseExitCode(codeText); hasExit && ok {
+		result.exitCode = intPtr(code)
+	}
+	if !result.hasOutput {
+		result.stdout = output
+		result.hasOutput = true
+	}
+
+	result.stdout, result.truncated = boundShellOutput(result.stdout)
+	var stderrTruncated bool
+	result.stderr, stderrTruncated = boundShellOutput(result.stderr)
+	result.truncated = result.truncated || stderrTruncated
+	return result
+}
+
+func hasEmbeddedShellTags(output string) bool {
+	return strings.Contains(output, "<return-code>") ||
+		strings.Contains(output, "<output>") ||
+		strings.Contains(output, "<stderr>")
+}
+
+func embeddedShellField(output, field string) (string, bool) {
+	open := "<" + field + ">"
+	close := "</" + field + ">"
+	start := strings.Index(output, open)
+	if start == -1 {
+		return "", false
+	}
+	start += len(open)
+	end := strings.Index(output[start:], close)
+	if end == -1 {
+		return "", false
+	}
+	return output[start : start+end], true
+}
+
+func parseExitCode(value any) (int, bool) {
+	switch code := value.(type) {
+	case int:
+		return code, true
+	case int32:
+		return int(code), true
+	case int64:
+		return int(code), true
+	case float64:
+		if code != float64(int(code)) {
+			return 0, false
+		}
+		return int(code), true
+	case json.Number:
+		parsed, err := strconv.Atoi(code.String())
+		return parsed, err == nil
+	case string:
+		parsed, err := strconv.Atoi(strings.TrimSpace(code))
+		return parsed, err == nil
+	default:
+		return 0, false
+	}
+}
+
+func boundShellOutput(output string) (string, bool) {
+	if len(output) <= maxShellOutputBytes {
+		return output, false
+	}
+	start := len(output) - maxShellOutputBytes
+	for start < len(output) && !utf8.RuneStart(output[start]) {
+		start++
+	}
+	return output[start:], true
+}
+
+func intPtr(value int) *int {
+	return &value
+}

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/shell_output.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/shell_output.go
@@ -228,8 +228,12 @@ func normalizeShellResultMap(result map[string]any) normalizedShellResult {
 		}
 	}
 
-	normalized.stdout, normalized.stdoutTruncated = boundShellOutput(normalized.stdout)
-	normalized.stderr, normalized.stderrTruncated = boundShellOutput(normalized.stderr)
+	stdout, stdoutTruncated := boundShellOutput(normalized.stdout)
+	stderr, stderrTruncated := boundShellOutput(normalized.stderr)
+	normalized.stdout = stdout
+	normalized.stderr = stderr
+	normalized.stdoutTruncated = normalized.stdoutTruncated || stdoutTruncated
+	normalized.stderrTruncated = normalized.stderrTruncated || stderrTruncated
 	return normalized
 }
 

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/shell_output.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/shell_output.go
@@ -15,20 +15,25 @@ type normalizedShellResult struct {
 	exitCode  *int
 	stdout    string
 	stderr    string
-	hasOutput bool
+	hasStdout bool
+	hasStderr bool
 	truncated bool
 }
 
 func applyFinalShellResult(payload *streams.ShellExecPayload, result any) {
 	normalized := normalizeFinalShellResult(result)
-	if !normalized.hasOutput && normalized.exitCode == nil {
+	if !normalized.hasStdout && !normalized.hasStderr && normalized.exitCode == nil {
 		return
 	}
 	output := ensureShellOutput(payload)
-	if normalized.hasOutput {
+	if normalized.hasStdout {
 		output.Stdout = normalized.stdout
+	}
+	if normalized.hasStderr {
 		output.Stderr = normalized.stderr
-		output.Truncated = normalized.truncated
+	}
+	if normalized.hasStdout || normalized.hasStderr {
+		output.Truncated = output.Truncated || normalized.truncated
 	}
 	if normalized.exitCode != nil {
 		output.ExitCode = normalized.exitCode
@@ -188,9 +193,14 @@ func normalizeShellResultMap(result map[string]any) normalizedShellResult {
 	var normalized normalizedShellResult
 	switch {
 	case stdoutExplicit || stderrExplicit:
-		normalized.stdout = stdout
-		normalized.stderr = stderr
-		normalized.hasOutput = true
+		if stdoutExplicit {
+			normalized.stdout = stdout
+			normalized.hasStdout = true
+		}
+		if stderrExplicit {
+			normalized.stderr = stderr
+			normalized.hasStderr = true
+		}
 	case hasFormatted:
 		normalized = normalizeShellText(formatted)
 	case hasOutput:
@@ -215,13 +225,13 @@ func normalizeShellResultMap(result map[string]any) normalizedShellResult {
 func normalizeShellText(output string) normalizedShellResult {
 	if !hasEmbeddedShellTags(output) {
 		stdout, truncated := boundShellOutput(output)
-		return normalizedShellResult{stdout: stdout, hasOutput: true, truncated: truncated}
+		return normalizedShellResult{stdout: stdout, hasStdout: true, truncated: truncated}
 	}
 
 	stdout, hasStdout := embeddedShellField(output, "output")
 	stderr, hasStderr := embeddedShellField(output, "stderr")
 	codeText, hasExit := embeddedShellField(output, "return-code")
-	result := normalizedShellResult{hasOutput: hasStdout || hasStderr}
+	result := normalizedShellResult{hasStdout: hasStdout, hasStderr: hasStderr}
 	if hasStdout {
 		result.stdout = strings.TrimSpace(stdout)
 	}
@@ -231,9 +241,9 @@ func normalizeShellText(output string) normalizedShellResult {
 	if code, ok := parseExitCode(codeText); hasExit && ok {
 		result.exitCode = intPtr(code)
 	}
-	if !result.hasOutput {
+	if !result.hasStdout && !result.hasStderr && !hasExit {
 		result.stdout = output
-		result.hasOutput = true
+		result.hasStdout = true
 	}
 
 	result.stdout, result.truncated = boundShellOutput(result.stdout)

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/shell_output_test.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/shell_output_test.go
@@ -131,6 +131,29 @@ func TestNormalizeShellToolResultBoundsOutputAndPreservesUTF8(t *testing.T) {
 	require.NotContains(t, output, "exit_code")
 }
 
+func TestNormalizeShellToolResultProviderMapPreservesTruncation(t *testing.T) {
+	t.Parallel()
+
+	for _, field := range []string{"formatted_output", "output"} {
+		t.Run(field, func(t *testing.T) {
+			t.Parallel()
+
+			normalizer := NewNormalizer("")
+			payload := normalizer.NormalizeToolCall("execute", map[string]any{
+				"kind":      "execute",
+				"raw_input": map[string]any{"command": "long-command"},
+			})
+
+			normalizer.NormalizeToolResult(payload, map[string]any{
+				field: strings.Repeat("x", maxShellOutputBytes+1),
+			})
+
+			require.Len(t, payload.ShellExec().Output.Stdout, maxShellOutputBytes)
+			require.True(t, payload.ShellExec().Output.Truncated)
+		})
+	}
+}
+
 func TestNormalizeShellToolUpdateKeepsExplicitStderrTruncation(t *testing.T) {
 	t.Parallel()
 
@@ -263,6 +286,7 @@ func TestNormalizeShellToolUpdateCumulativeOutputRemainsCorrectAfterTruncation(t
 
 	want, _ := boundShellOutput(cumulative)
 	require.Equal(t, want, payload.ShellExec().Output.Stdout)
+	require.True(t, payload.ShellExec().Output.Truncated)
 }
 
 func shellOutputJSON(t *testing.T, output any) map[string]any {

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/shell_output_test.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/shell_output_test.go
@@ -58,6 +58,31 @@ func TestNormalizeShellToolResultProviderShapes(t *testing.T) {
 			wantStdout:  "claude output\n",
 			wantHasExit: false,
 		},
+		{
+			name: "explicit streams and top-level exit take precedence",
+			result: map[string]any{
+				"stdout":           "explicit stdout",
+				"stderr":           "explicit stderr",
+				"formatted_output": "formatted fallback",
+				"output":           "output fallback",
+				"exit_code":        float64(5),
+				"metadata":         map[string]any{"exit": float64(9)},
+			},
+			wantStdout:  "explicit stdout",
+			wantStderr:  "explicit stderr",
+			wantExit:    5,
+			wantHasExit: true,
+		},
+		{
+			name: "malformed exits stay unknown",
+			result: map[string]any{
+				"output":    "output with malformed exit",
+				"exit_code": "not-an-exit",
+				"metadata":  map[string]any{"exit": "still-not-an-exit"},
+			},
+			wantStdout:  "output with malformed exit",
+			wantHasExit: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -150,6 +175,74 @@ func TestNormalizeShellToolUpdateAppendsNonCumulativeLiveOutput(t *testing.T) {
 	)
 
 	require.Equal(t, "hello\nworld\n", payload.ShellExec().Output.Stdout)
+}
+
+func TestNormalizeShellToolUpdatePreservesStreamsMissingFromLaterResults(t *testing.T) {
+	t.Parallel()
+
+	normalizer := NewNormalizer("")
+	payload := normalizer.NormalizeToolCall("execute", map[string]any{
+		"kind":      "execute",
+		"raw_input": map[string]any{"command": "test-command"},
+	})
+	payload.ShellExec().Output = nil
+
+	normalizer.NormalizeShellToolUpdate(
+		payload,
+		nil,
+		nil,
+		map[string]any{"stdout": "first stdout", "stderr": "retained stderr"},
+	)
+	normalizer.NormalizeShellToolUpdate(payload, nil, nil, map[string]any{"stdout": "final stdout"})
+	require.Equal(t, "final stdout", payload.ShellExec().Output.Stdout)
+	require.Equal(t, "retained stderr", payload.ShellExec().Output.Stderr)
+
+	normalizer.NormalizeShellToolUpdate(payload, nil, nil, map[string]any{"stderr": "final stderr"})
+	require.Equal(t, "final stdout", payload.ShellExec().Output.Stdout)
+	require.Equal(t, "final stderr", payload.ShellExec().Output.Stderr)
+}
+
+func TestNormalizeShellToolResultReturnCodeOnlyDoesNotRenderMarkup(t *testing.T) {
+	t.Parallel()
+
+	normalizer := NewNormalizer("")
+	payload := normalizer.NormalizeToolCall("execute", map[string]any{
+		"kind":      "execute",
+		"raw_input": map[string]any{"command": "test-command"},
+	})
+
+	normalizer.NormalizeToolResult(payload, "<return-code>1</return-code>")
+
+	require.Empty(t, payload.ShellExec().Output.Stdout)
+	require.NotNil(t, payload.ShellExec().Output.ExitCode)
+	require.Equal(t, 1, *payload.ShellExec().Output.ExitCode)
+}
+
+func TestNormalizeShellToolUpdateCumulativeOutputRemainsCorrectAfterTruncation(t *testing.T) {
+	t.Parallel()
+
+	normalizer := NewNormalizer("")
+	payload := normalizer.NormalizeToolCall("execute", map[string]any{
+		"kind":      "execute",
+		"raw_input": map[string]any{"command": "test-command"},
+	})
+	initial := strings.Repeat("a", maxShellOutputBytes) + "first tail"
+	normalizer.NormalizeShellToolUpdate(
+		payload,
+		map[string]any{"terminal_output": map[string]any{"data": initial}},
+		nil,
+		nil,
+	)
+	cumulative := initial + " second tail"
+	normalizer.NormalizeShellToolUpdate(
+		payload,
+		map[string]any{"terminal_output": map[string]any{"data": cumulative}},
+		nil,
+		nil,
+	)
+
+	want, _ := boundShellOutput(cumulative)
+	require.Equal(t, want, payload.ShellExec().Output.Stdout)
 }
 
 func shellOutputJSON(t *testing.T, output any) map[string]any {

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/shell_output_test.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/shell_output_test.go
@@ -152,6 +152,26 @@ func TestNormalizeShellToolUpdateKeepsExplicitStderrTruncation(t *testing.T) {
 	require.True(t, payload.ShellExec().Output.Truncated)
 }
 
+func TestNormalizeShellToolUpdateClearsStdoutTruncationOnShortReplacement(t *testing.T) {
+	t.Parallel()
+
+	normalizer := NewNormalizer("")
+	payload := normalizer.NormalizeToolCall("execute", map[string]any{
+		"kind":      "execute",
+		"raw_input": map[string]any{"command": "test-command"},
+	})
+
+	normalizer.NormalizeShellToolUpdate(
+		payload,
+		map[string]any{"terminal_output": map[string]any{"data": "authoritative stdout"}},
+		nil,
+		strings.Repeat("x", maxShellOutputBytes+1),
+	)
+
+	require.Equal(t, "authoritative stdout", payload.ShellExec().Output.Stdout)
+	require.False(t, payload.ShellExec().Output.Truncated)
+}
+
 func TestNormalizeShellToolUpdateAppendsNonCumulativeLiveOutput(t *testing.T) {
 	t.Parallel()
 

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/shell_output_test.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/shell_output_test.go
@@ -1,0 +1,145 @@
+package acp
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeShellToolResultProviderShapes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		result      any
+		wantStdout  string
+		wantStderr  string
+		wantExit    float64
+		wantHasExit bool
+	}{
+		{
+			name: "codex formatted output and exit",
+			result: map[string]any{
+				"formatted_output": "codex output\n",
+				"exit_code":        float64(4),
+			},
+			wantStdout:  "codex output\n",
+			wantExit:    4,
+			wantHasExit: true,
+		},
+		{
+			name: "opencode output and nested exit",
+			result: map[string]any{
+				"output": "opencode output\n",
+				"metadata": map[string]any{
+					"exit": float64(7),
+				},
+			},
+			wantStdout:  "opencode output\n",
+			wantExit:    7,
+			wantHasExit: true,
+		},
+		{
+			name: "auggie embedded streams and return code",
+			result: map[string]any{
+				"output": "<return-code>1</return-code><output>auggie out</output><stderr>auggie err</stderr>",
+			},
+			wantStdout:  "auggie out",
+			wantStderr:  "auggie err",
+			wantExit:    1,
+			wantHasExit: true,
+		},
+		{
+			name:        "claude plain output keeps exit unknown",
+			result:      "claude output\n",
+			wantStdout:  "claude output\n",
+			wantHasExit: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			normalizer := NewNormalizer("")
+			payload := normalizer.NormalizeToolCall("execute", map[string]any{
+				"kind":      "execute",
+				"raw_input": map[string]any{"command": "test-command"},
+			})
+
+			normalizer.NormalizeToolResult(payload, tt.result)
+
+			output := shellOutputJSON(t, payload.ShellExec().Output)
+			require.Equal(t, tt.wantStdout, output["stdout"])
+			require.Equal(t, tt.wantStderr, stringValue(output["stderr"]))
+			exitCode, hasExit := output["exit_code"]
+			require.Equal(t, tt.wantHasExit, hasExit)
+			if tt.wantHasExit {
+				require.Equal(t, tt.wantExit, exitCode)
+			}
+		})
+	}
+}
+
+func TestNormalizeShellToolResultBoundsOutputAndPreservesUTF8(t *testing.T) {
+	t.Parallel()
+
+	normalizer := NewNormalizer("")
+	payload := normalizer.NormalizeToolCall("execute", map[string]any{
+		"kind":      "execute",
+		"raw_input": map[string]any{"command": "long-command"},
+	})
+	input := strings.Repeat("a", 256*1024) + "three bytes: \u2603"
+
+	normalizer.NormalizeToolResult(payload, input)
+
+	output := shellOutputJSON(t, payload.ShellExec().Output)
+	stdout, ok := output["stdout"].(string)
+	require.True(t, ok)
+	require.LessOrEqual(t, len(stdout), 256*1024)
+	require.True(t, utf8.ValidString(stdout))
+	require.Contains(t, stdout, "three bytes: \u2603")
+	require.Equal(t, true, output["truncated"])
+	require.NotContains(t, output, "exit_code")
+}
+
+func TestNormalizeShellToolUpdateKeepsExplicitStderrTruncation(t *testing.T) {
+	t.Parallel()
+
+	normalizer := NewNormalizer("")
+	payload := normalizer.NormalizeToolCall("execute", map[string]any{
+		"kind":      "execute",
+		"raw_input": map[string]any{"command": "test-command"},
+	})
+
+	normalizer.NormalizeShellToolUpdate(
+		payload,
+		map[string]any{"terminal_output": map[string]any{"data": "structured stdout"}},
+		nil,
+		map[string]any{"stdout": "fallback", "stderr": strings.Repeat("e", 256*1024+1)},
+	)
+
+	require.Equal(t, "structured stdout", payload.ShellExec().Output.Stdout)
+	require.Len(t, payload.ShellExec().Output.Stderr, 256*1024)
+	require.True(t, payload.ShellExec().Output.Truncated)
+}
+
+func shellOutputJSON(t *testing.T, output any) map[string]any {
+	t.Helper()
+	require.NotNil(t, output)
+
+	data, err := json.Marshal(output)
+	require.NoError(t, err)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	return decoded
+}
+
+func stringValue(value any) string {
+	result, _ := value.(string)
+	return result
+}

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/shell_output_test.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/shell_output_test.go
@@ -127,6 +127,31 @@ func TestNormalizeShellToolUpdateKeepsExplicitStderrTruncation(t *testing.T) {
 	require.True(t, payload.ShellExec().Output.Truncated)
 }
 
+func TestNormalizeShellToolUpdateAppendsNonCumulativeLiveOutput(t *testing.T) {
+	t.Parallel()
+
+	normalizer := NewNormalizer("")
+	payload := normalizer.NormalizeToolCall("execute", map[string]any{
+		"kind":      "execute",
+		"raw_input": map[string]any{"command": "test-command"},
+	})
+
+	normalizer.NormalizeShellToolUpdate(
+		payload,
+		map[string]any{"terminal_output_delta": map[string]any{"data": "hello\n"}},
+		nil,
+		nil,
+	)
+	normalizer.NormalizeShellToolUpdate(
+		payload,
+		map[string]any{"terminal_output": map[string]any{"data": "world\n"}},
+		nil,
+		nil,
+	)
+
+	require.Equal(t, "hello\nworld\n", payload.ShellExec().Output.Stdout)
+}
+
 func shellOutputJSON(t *testing.T, output any) map[string]any {
 	t.Helper()
 	require.NotNil(t, output)

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/tool_call_update_test.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/tool_call_update_test.go
@@ -329,3 +329,35 @@ func TestConvertToolCallResultUpdate_StatuslessExactExitCompletesTool(t *testing
 	require.Equal(t, toolStatusComplete, event.ToolStatus)
 	require.NotContains(t, a.activeToolCalls, "tc-exit-only")
 }
+
+func TestConvertToolCallResultUpdate_StatuslessTitleAndExitCompletesTool(t *testing.T) {
+	a := newTestAdapter()
+	seedExecuteToolCall(t, a, "tc-title-exit")
+	title := "printf done"
+
+	event := a.convertToolCallResultUpdate("session-1", &acp.SessionToolCallUpdate{
+		ToolCallId: "tc-title-exit",
+		Title:      &title,
+		Meta: map[string]any{
+			"terminal_exit": map[string]any{"exit_code": float64(0)},
+		},
+	})
+
+	require.Equal(t, toolStatusComplete, event.ToolStatus)
+	require.NotContains(t, a.activeToolCalls, "tc-title-exit")
+}
+
+func TestConvertToolCallResultUpdate_FailedWithoutExitTerminatesTool(t *testing.T) {
+	a := newTestAdapter()
+	seedExecuteToolCall(t, a, "tc-failed")
+	failed := acp.ToolCallStatus("failed")
+
+	event := a.convertToolCallResultUpdate("session-1", &acp.SessionToolCallUpdate{
+		ToolCallId: "tc-failed",
+		Status:     &failed,
+		RawOutput:  "command failed before reporting an exit code",
+	})
+
+	require.Equal(t, toolStatusError, event.ToolStatus)
+	require.NotContains(t, a.activeToolCalls, "tc-failed")
+}

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/tool_call_update_test.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/tool_call_update_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	acp "github.com/coder/acp-go-sdk"
+	"github.com/stretchr/testify/require"
 )
 
 // seedExecuteToolCall registers a pending Bash tool_call (Claude-acp pattern: empty
@@ -180,4 +181,151 @@ func TestConvertToolCallResultUpdate_ExplicitCompletedStatusUnchanged(t *testing
 	if ev.ToolStatus != "complete" {
 		t.Errorf("ToolStatus = %q, want %q", ev.ToolStatus, "complete")
 	}
+}
+
+func TestConvertToolCallResultUpdate_AppendsTerminalOutputDeltas(t *testing.T) {
+	a := newTestAdapter()
+	seedExecuteToolCall(t, a, "tc-delta")
+
+	for _, chunk := range []string{"first\n", "second\n"} {
+		event := a.convertToolCallResultUpdate("session-1", &acp.SessionToolCallUpdate{
+			ToolCallId: "tc-delta",
+			Meta: map[string]any{
+				"terminal_output_delta": map[string]any{"data": chunk},
+			},
+		})
+		require.Equal(t, toolStatusInProgress, event.ToolStatus)
+	}
+
+	payload := a.activeToolCalls["tc-delta"]
+	require.NotNil(t, payload)
+	require.Equal(t, "first\nsecond\n", payload.ShellExec().Output.Stdout)
+	require.Nil(t, payload.ShellExec().Output.ExitCode)
+}
+
+func TestConvertToolCallResultUpdate_ReplacesCumulativeContent(t *testing.T) {
+	a := newTestAdapter()
+	seedExecuteToolCall(t, a, "tc-content")
+
+	for _, cumulative := range []string{"first\n", "first\nsecond\n"} {
+		event := a.convertToolCallResultUpdate("session-1", &acp.SessionToolCallUpdate{
+			ToolCallId: "tc-content",
+			Content: []acp.ToolCallContent{{
+				Content: &acp.ToolCallContentContent{
+					Content: acp.TextBlock(cumulative),
+					Type:    "content",
+				},
+			}},
+		})
+		require.Equal(t, toolStatusInProgress, event.ToolStatus)
+	}
+
+	payload := a.activeToolCalls["tc-content"]
+	require.NotNil(t, payload)
+	require.Equal(t, "first\nsecond\n", payload.ShellExec().Output.Stdout)
+}
+
+func TestConvertToolCallResultUpdate_FinalOutputReplacesLiveWithoutDuplication(t *testing.T) {
+	a := newTestAdapter()
+	seedExecuteToolCall(t, a, "tc-final")
+
+	a.convertToolCallResultUpdate("session-1", &acp.SessionToolCallUpdate{
+		ToolCallId: "tc-final",
+		Meta: map[string]any{
+			"terminal_output_delta": map[string]any{"data": "first\n"},
+		},
+	})
+	completed := acp.ToolCallStatus("completed")
+	event := a.convertToolCallResultUpdate("session-1", &acp.SessionToolCallUpdate{
+		ToolCallId: "tc-final",
+		Status:     &completed,
+		RawOutput: map[string]any{
+			"formatted_output": "first\nsecond\n",
+			"exit_code":        float64(4),
+		},
+	})
+
+	require.Equal(t, toolStatusError, event.ToolStatus)
+	require.Equal(t, "first\nsecond\n", event.NormalizedPayload.ShellExec().Output.Stdout)
+	require.NotNil(t, event.NormalizedPayload.ShellExec().Output.ExitCode)
+	require.Equal(t, 4, *event.NormalizedPayload.ShellExec().Output.ExitCode)
+	require.NotContains(t, a.activeToolCalls, "tc-final")
+}
+
+func TestConvertToolCallResultUpdate_TerminalMetadataTakesPrecedence(t *testing.T) {
+	a := newTestAdapter()
+	seedExecuteToolCall(t, a, "tc-terminal")
+	completed := acp.ToolCallStatus("completed")
+
+	event := a.convertToolCallResultUpdate("session-1", &acp.SessionToolCallUpdate{
+		ToolCallId: "tc-terminal",
+		Status:     &completed,
+		RawOutput:  "fallback output",
+		Meta: map[string]any{
+			"terminal_output": map[string]any{"data": "structured output\n"},
+			"terminal_exit":   map[string]any{"exit_code": float64(3)},
+		},
+	})
+
+	require.Equal(t, toolStatusError, event.ToolStatus)
+	require.Equal(t, "structured output\n", event.NormalizedPayload.ShellExec().Output.Stdout)
+	require.NotNil(t, event.NormalizedPayload.ShellExec().Output.ExitCode)
+	require.Equal(t, 3, *event.NormalizedPayload.ShellExec().Output.ExitCode)
+}
+
+func TestConvertToolCallResultUpdate_FinalWithoutOutputPreservesLiveText(t *testing.T) {
+	a := newTestAdapter()
+	seedExecuteToolCall(t, a, "tc-preserve")
+
+	a.convertToolCallResultUpdate("session-1", &acp.SessionToolCallUpdate{
+		ToolCallId: "tc-preserve",
+		Meta: map[string]any{
+			"terminal_output_delta": map[string]any{"data": "retained output\n"},
+		},
+	})
+	completed := acp.ToolCallStatus("completed")
+	event := a.convertToolCallResultUpdate("session-1", &acp.SessionToolCallUpdate{
+		ToolCallId: "tc-preserve",
+		Status:     &completed,
+		RawOutput:  map[string]any{"exit_code": float64(0)},
+	})
+
+	require.Equal(t, toolStatusComplete, event.ToolStatus)
+	require.Equal(t, "retained output\n", event.NormalizedPayload.ShellExec().Output.Stdout)
+	require.NotNil(t, event.NormalizedPayload.ShellExec().Output.ExitCode)
+	require.Equal(t, 0, *event.NormalizedPayload.ShellExec().Output.ExitCode)
+}
+
+func TestConvertToolCallResultUpdate_NonzeroExitPreservesCancellation(t *testing.T) {
+	a := newTestAdapter()
+	seedExecuteToolCall(t, a, "tc-cancelled")
+	cancelled := acp.ToolCallStatus("cancelled")
+
+	event := a.convertToolCallResultUpdate("session-1", &acp.SessionToolCallUpdate{
+		ToolCallId: "tc-cancelled",
+		Status:     &cancelled,
+		RawOutput: map[string]any{
+			"formatted_output": "interrupted\n",
+			"exit_code":        float64(130),
+		},
+	})
+
+	require.Equal(t, toolStatusCancelled, event.ToolStatus)
+	require.NotNil(t, event.NormalizedPayload.ShellExec().Output.ExitCode)
+	require.Equal(t, 130, *event.NormalizedPayload.ShellExec().Output.ExitCode)
+}
+
+func TestConvertToolCallResultUpdate_StatuslessExactExitCompletesTool(t *testing.T) {
+	a := newTestAdapter()
+	seedExecuteToolCall(t, a, "tc-exit-only")
+
+	event := a.convertToolCallResultUpdate("session-1", &acp.SessionToolCallUpdate{
+		ToolCallId: "tc-exit-only",
+		Meta: map[string]any{
+			"terminal_exit": map[string]any{"exit_code": float64(0)},
+		},
+	})
+
+	require.Equal(t, toolStatusComplete, event.ToolStatus)
+	require.NotContains(t, a.activeToolCalls, "tc-exit-only")
 }

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/wakeup_concurrency_test.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/wakeup_concurrency_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/coder/acp-go-sdk"
 	"github.com/kandev/kandev/internal/agentctl/types/streams"
+	"github.com/stretchr/testify/require"
 )
 
 // concurrencyFakeAgent is a minimal acp.Agent whose Prompt handler blocks until
@@ -18,6 +19,7 @@ import (
 type concurrencyFakeAgent struct {
 	entered     chan struct{} // one signal per Prompt entry
 	release     chan struct{} // closed to unblock all parked Prompts
+	initialized chan acp.InitializeRequest
 	inFlight    atomic.Int32
 	maxInFlight atomic.Int32
 }
@@ -37,6 +39,9 @@ func (f *concurrencyFakeAgent) Prompt(_ context.Context, _ acp.PromptRequest) (a
 }
 
 func (f *concurrencyFakeAgent) Initialize(_ context.Context, params acp.InitializeRequest) (acp.InitializeResponse, error) {
+	if f.initialized != nil {
+		f.initialized <- params
+	}
 	return acp.InitializeResponse{ProtocolVersion: params.ProtocolVersion}, nil
 }
 
@@ -90,11 +95,21 @@ func setupConcurrencyFakeAgent(t *testing.T) (*Adapter, *concurrencyFakeAgent) {
 	}
 
 	fa := &concurrencyFakeAgent{
-		entered: make(chan struct{}, 8),
-		release: make(chan struct{}),
+		entered:     make(chan struct{}, 8),
+		release:     make(chan struct{}),
+		initialized: make(chan acp.InitializeRequest, 1),
 	}
 	_ = acp.NewAgentSideConnection(fa, a2cW, c2aR)
 	return a, fa
+}
+
+func TestInitializeAdvertisesTerminalOutputMetadata(t *testing.T) {
+	a, fakeAgent := setupConcurrencyFakeAgent(t)
+	require.NoError(t, a.Initialize(context.Background()))
+
+	request := <-fakeAgent.initialized
+	require.Equal(t, true, request.ClientCapabilities.Meta["terminal_output"])
+	require.False(t, request.ClientCapabilities.Terminal)
 }
 
 // waitForPromptComplete blocks until sendPrompt emits EventTypeComplete or times out.

--- a/apps/backend/internal/agentctl/types/streams/tool_payload.go
+++ b/apps/backend/internal/agentctl/types/streams/tool_payload.go
@@ -198,9 +198,10 @@ type ShellExecPayload struct {
 
 // ShellExecOutput contains the result of a shell command execution.
 type ShellExecOutput struct {
-	ExitCode int    `json:"exit_code"`
-	Stdout   string `json:"stdout,omitempty"`
-	Stderr   string `json:"stderr,omitempty"`
+	ExitCode  *int   `json:"exit_code,omitempty"`
+	Stdout    string `json:"stdout,omitempty"`
+	Stderr    string `json:"stderr,omitempty"`
+	Truncated bool   `json:"truncated,omitempty"`
 }
 
 // CodeSearchOutput contains the result of a code search operation.

--- a/apps/backend/internal/agentctl/types/streams/tool_payload.go
+++ b/apps/backend/internal/agentctl/types/streams/tool_payload.go
@@ -202,6 +202,9 @@ type ShellExecOutput struct {
 	Stdout    string `json:"stdout,omitempty"`
 	Stderr    string `json:"stderr,omitempty"`
 	Truncated bool   `json:"truncated,omitempty"`
+	// Internal stream state keeps the serialized combined flag accurate across replacements.
+	StdoutTruncated bool `json:"-"`
+	StderrTruncated bool `json:"-"`
 }
 
 // CodeSearchOutput contains the result of a code search operation.

--- a/apps/web/components/task/chat/messages/kandev-tool-message.test.tsx
+++ b/apps/web/components/task/chat/messages/kandev-tool-message.test.tsx
@@ -17,7 +17,7 @@ function kandevToolCall(opts: {
   toolName: string;
   input?: Record<string, unknown>;
   resultJson?: unknown;
-  status?: "pending" | "running" | "complete" | "error";
+  status?: "pending" | "running" | "in_progress" | "complete" | "error";
 }): Message {
   return {
     id: "msg-1",
@@ -80,6 +80,20 @@ const CHANGE_TOUR = "Change tour";
 // call visible to the user.
 
 describe("KandevToolMessage list renderers", () => {
+  it("normalizes ACP in_progress status to running", () => {
+    const html = renderToStaticMarkup(
+      <KandevToolMessage
+        comment={kandevToolCall({
+          status: "in_progress",
+          toolName: "mcp__kandev__list_workspaces_kandev",
+          resultJson: { workspaces: [{ id: "w1", name: "Live workspace" }], total: 1 },
+        })}
+      />,
+    );
+
+    expect(html).toContain("Live workspace");
+  });
+
   it("renders the workflow-steps list with structured fields, not raw JSON", () => {
     const html = renderToStaticMarkup(
       <KandevToolMessage

--- a/apps/web/components/task/chat/messages/kandev-tool-message.tsx
+++ b/apps/web/components/task/chat/messages/kandev-tool-message.tsx
@@ -32,7 +32,9 @@ type KandevToolMessageProps = {
 };
 
 function normalizeKandevStatus(status: ToolCallMetadata["status"]): KandevStatus {
-  return status === "in_progress" ? "running" : status;
+  if (status === "in_progress") return "running";
+  if (status === "cancelled") return undefined;
+  return status;
 }
 
 // kandevStemOf scans the several fields that may carry the raw MCP tool name

--- a/apps/web/components/task/chat/messages/kandev-tool-message.tsx
+++ b/apps/web/components/task/chat/messages/kandev-tool-message.tsx
@@ -7,7 +7,11 @@ import { extractKandevStem, extractMcpResult } from "./kandev/parse";
 import { getKandevRenderer } from "./kandev/registry";
 import { PermissionActionRow } from "./permission-action-row";
 import { parsePermission, usePermissionResponseHandlers } from "./use-permission-handlers";
-import { KandevPermissionUIProvider, type KandevPermissionUIState } from "./kandev/shared";
+import {
+  KandevPermissionUIProvider,
+  type KandevPermissionUIState,
+  type KandevStatus,
+} from "./kandev/shared";
 import type { PermissionRequestMetadata } from "./use-permission-handlers";
 
 // Approval falls through to `undefined` on purpose: the tool_call status
@@ -26,6 +30,10 @@ type KandevToolMessageProps = {
   comment: Message;
   permissionMessage?: Message;
 };
+
+function normalizeKandevStatus(status: ToolCallMetadata["status"]): KandevStatus {
+  return status === "in_progress" ? "running" : status;
+}
 
 // kandevStemOf scans the several fields that may carry the raw MCP tool name
 // and returns the first one that parses to a known kandev stem. The fields
@@ -94,6 +102,7 @@ export const KandevToolMessage = memo(function KandevToolMessage({
   const args = argsCandidate && typeof argsCandidate === "object" ? argsCandidate : undefined;
   const rawResult = generic?.output ?? meta?.result;
   const result = extractMcpResult(rawResult);
+  const status = normalizeKandevStatus(meta?.status);
 
   const permissionUI = derivePermissionUI(permissionStatus, isPermissionPending);
 
@@ -102,7 +111,7 @@ export const KandevToolMessage = memo(function KandevToolMessage({
   // and avoids the lint rule against "components created during render".
   const rendered = (
     <KandevPermissionUIProvider value={permissionUI}>
-      {renderer({ args, result, status: meta?.status })}
+      {renderer({ args, result, status })}
     </KandevPermissionUIProvider>
   );
 

--- a/apps/web/components/task/chat/messages/kandev-tool-message.tsx
+++ b/apps/web/components/task/chat/messages/kandev-tool-message.tsx
@@ -6,12 +6,9 @@ import type { ToolCallMetadata } from "@/components/task/chat/types";
 import { extractKandevStem, extractMcpResult } from "./kandev/parse";
 import { getKandevRenderer } from "./kandev/registry";
 import { PermissionActionRow } from "./permission-action-row";
+import { normalizeToolCallStatus } from "./tool-status";
 import { parsePermission, usePermissionResponseHandlers } from "./use-permission-handlers";
-import {
-  KandevPermissionUIProvider,
-  type KandevPermissionUIState,
-  type KandevStatus,
-} from "./kandev/shared";
+import { KandevPermissionUIProvider, type KandevPermissionUIState } from "./kandev/shared";
 import type { PermissionRequestMetadata } from "./use-permission-handlers";
 
 // Approval falls through to `undefined` on purpose: the tool_call status
@@ -30,12 +27,6 @@ type KandevToolMessageProps = {
   comment: Message;
   permissionMessage?: Message;
 };
-
-function normalizeKandevStatus(status: ToolCallMetadata["status"]): KandevStatus {
-  if (status === "in_progress") return "running";
-  if (status === "cancelled") return undefined;
-  return status;
-}
 
 // kandevStemOf scans the several fields that may carry the raw MCP tool name
 // and returns the first one that parses to a known kandev stem. The fields
@@ -104,7 +95,7 @@ export const KandevToolMessage = memo(function KandevToolMessage({
   const args = argsCandidate && typeof argsCandidate === "object" ? argsCandidate : undefined;
   const rawResult = generic?.output ?? meta?.result;
   const result = extractMcpResult(rawResult);
-  const status = normalizeKandevStatus(meta?.status);
+  const status = normalizeToolCallStatus(meta?.status);
 
   const permissionUI = derivePermissionUI(permissionStatus, isPermissionPending);
 

--- a/apps/web/components/task/chat/messages/kandev/shared.tsx
+++ b/apps/web/components/task/chat/messages/kandev/shared.tsx
@@ -15,7 +15,7 @@ import { ExpandableRow } from "../expandable-row";
 import { useExpandState } from "../use-expand-state";
 import { shortId } from "./parse";
 
-export type KandevStatus = "pending" | "running" | "complete" | "error" | undefined;
+export type KandevStatus = "pending" | "running" | "complete" | "error" | "cancelled" | undefined;
 
 export function KandevStatusIcon({ status }: { status: KandevStatus }) {
   if (status === "complete") return <IconCheck className="h-3.5 w-3.5 text-green-500" />;

--- a/apps/web/components/task/chat/messages/tool-execute-message.test.tsx
+++ b/apps/web/components/task/chat/messages/tool-execute-message.test.tsx
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { sessionId, taskId, type Message } from "@/lib/types/http";
+import { ToolExecuteMessage } from "./tool-execute-message";
+
+afterEach(cleanup);
+
+type ShellOutput = {
+  exit_code?: number | null;
+  stdout?: string;
+  stderr?: string;
+  truncated?: boolean;
+};
+
+function executeMessage(
+  status: "pending" | "running" | "complete" | "error",
+  output?: ShellOutput,
+): Message {
+  return {
+    id: `message-${status}`,
+    session_id: sessionId("session-1"),
+    task_id: taskId("task-1"),
+    author_type: "agent",
+    content: "printf command-output",
+    type: "tool_execute",
+    created_at: "2026-07-14T12:00:00Z",
+    metadata: {
+      status,
+      normalized: {
+        shell_exec: {
+          command: "printf command-output",
+          work_dir: "/workspace",
+          output,
+        },
+      },
+    },
+  };
+}
+
+function expandCommand() {
+  fireEvent.click(screen.getAllByText("printf command-output")[0]);
+}
+
+describe("ToolExecuteMessage command result", () => {
+  it("shows output and an exact successful exit code", () => {
+    render(
+      <ToolExecuteMessage
+        comment={executeMessage("complete", { exit_code: 0, stdout: "command output\n" })}
+      />,
+    );
+
+    expect(screen.getByLabelText("Command succeeded")).toBeTruthy();
+    expandCommand();
+    expect(screen.getByText("command output")).toBeTruthy();
+    expect(screen.getByText("Exit code 0")).toBeTruthy();
+  });
+
+  it("shows a known nonzero exit as failure", () => {
+    render(
+      <ToolExecuteMessage
+        comment={executeMessage("complete", { exit_code: 7, stderr: "failed output\n" })}
+      />,
+    );
+
+    expect(screen.getByLabelText("Command failed")).toBeTruthy();
+    expandCommand();
+    expect(screen.getByText("failed output")).toBeTruthy();
+    expect(screen.getByText("Exit code 7")).toBeTruthy();
+  });
+
+  it("keeps an unavailable exit code neutral", () => {
+    render(
+      <ToolExecuteMessage
+        comment={executeMessage("complete", { stdout: "result without status" })}
+      />,
+    );
+
+    expect(screen.queryByLabelText("Command succeeded")).toBeNull();
+    expect(screen.queryByLabelText("Command failed")).toBeNull();
+    expandCommand();
+    expect(screen.getByText("Exit code unavailable")).toBeTruthy();
+  });
+
+  it("auto-expands live output without a terminal exit label", () => {
+    render(
+      <ToolExecuteMessage comment={executeMessage("running", { stdout: "partial output\n" })} />,
+    );
+
+    expect(screen.getByLabelText("Command running")).toBeTruthy();
+    expect(screen.getByText("partial output")).toBeTruthy();
+    expect(screen.queryByText(/Exit code/)).toBeNull();
+  });
+
+  it("shows truncation and unknown exit state together", () => {
+    render(
+      <ToolExecuteMessage
+        comment={executeMessage("complete", { stdout: "latest output", truncated: true })}
+      />,
+    );
+
+    expandCommand();
+    expect(screen.getByText("Output truncated")).toBeTruthy();
+    expect(screen.getByText("Exit code unavailable")).toBeTruthy();
+  });
+});

--- a/apps/web/components/task/chat/messages/tool-execute-message.test.tsx
+++ b/apps/web/components/task/chat/messages/tool-execute-message.test.tsx
@@ -6,14 +6,14 @@ import { ToolExecuteMessage } from "./tool-execute-message";
 afterEach(cleanup);
 
 type ShellOutput = {
-  exit_code?: number | null;
+  exit_code?: number;
   stdout?: string;
   stderr?: string;
   truncated?: boolean;
 };
 
 function executeMessage(
-  status: "pending" | "running" | "complete" | "error",
+  status: "pending" | "running" | "in_progress" | "complete" | "error",
   output?: ShellOutput,
 ): Message {
   return {
@@ -88,6 +88,18 @@ describe("ToolExecuteMessage command result", () => {
 
     expect(screen.getByLabelText("Command running")).toBeTruthy();
     expect(screen.getByText("partial output")).toBeTruthy();
+    expect(screen.queryByText(/Exit code/)).toBeNull();
+  });
+
+  it("treats ACP in_progress output as live", () => {
+    render(
+      <ToolExecuteMessage
+        comment={executeMessage("in_progress", { stdout: "ACP partial output\n" })}
+      />,
+    );
+
+    expect(screen.getByLabelText("Command running")).toBeTruthy();
+    expect(screen.getByText("ACP partial output")).toBeTruthy();
     expect(screen.queryByText(/Exit code/)).toBeNull();
   });
 

--- a/apps/web/components/task/chat/messages/tool-execute-message.test.tsx
+++ b/apps/web/components/task/chat/messages/tool-execute-message.test.tsx
@@ -13,7 +13,7 @@ type ShellOutput = {
 };
 
 function executeMessage(
-  status: "pending" | "running" | "in_progress" | "complete" | "error",
+  status: "pending" | "running" | "in_progress" | "complete" | "error" | "cancelled",
   output?: ShellOutput,
 ): Message {
   return {
@@ -112,6 +112,16 @@ describe("ToolExecuteMessage command result", () => {
 
     expandCommand();
     expect(screen.getByText("Output truncated")).toBeTruthy();
+    expect(screen.getByText("Exit code unavailable")).toBeTruthy();
+  });
+
+  it("shows terminal details for a cancelled command", () => {
+    render(
+      <ToolExecuteMessage comment={executeMessage("cancelled", { stdout: "cancelled output" })} />,
+    );
+
+    expandCommand();
+    expect(screen.getByText("cancelled output")).toBeTruthy();
     expect(screen.getByText("Exit code unavailable")).toBeTruthy();
   });
 });

--- a/apps/web/components/task/chat/messages/tool-execute-message.tsx
+++ b/apps/web/components/task/chat/messages/tool-execute-message.tsx
@@ -19,7 +19,7 @@ function ExecuteStatusIcon({
   exitCode,
 }: {
   status: string | undefined;
-  exitCode: number | null | undefined;
+  exitCode: number | undefined;
 }) {
   if (status === "complete") {
     if (exitCode === 0) {
@@ -134,7 +134,7 @@ function ExecuteOutputContent({
 
 function parseExecuteMetadata(comment: Message) {
   const metadata = comment.metadata as ToolCallMetadata | undefined;
-  const status = metadata?.status;
+  const status = metadata?.status === "in_progress" ? "running" : metadata?.status;
   const shellExec = metadata?.normalized?.shell_exec;
   const output = shellExec?.output;
   const workDir = shellExec?.work_dir;

--- a/apps/web/components/task/chat/messages/tool-execute-message.tsx
+++ b/apps/web/components/task/chat/messages/tool-execute-message.tsx
@@ -6,6 +6,7 @@ import { GridSpinner } from "@/components/grid-spinner";
 import { transformPathsInText } from "@/lib/utils";
 import type { Message } from "@/lib/types/http";
 import { ExpandableRow } from "./expandable-row";
+import { normalizeToolCallStatus } from "./tool-status";
 import { useExpandState } from "./use-expand-state";
 import type { ShellExecOutput, ToolCallMetadata } from "../types";
 
@@ -134,7 +135,7 @@ function ExecuteOutputContent({
 
 function parseExecuteMetadata(comment: Message) {
   const metadata = comment.metadata as ToolCallMetadata | undefined;
-  const status = metadata?.status === "in_progress" ? "running" : metadata?.status;
+  const status = normalizeToolCallStatus(metadata?.status);
   const shellExec = metadata?.normalized?.shell_exec;
   const output = shellExec?.output;
   const workDir = shellExec?.work_dir;

--- a/apps/web/components/task/chat/messages/tool-execute-message.tsx
+++ b/apps/web/components/task/chat/messages/tool-execute-message.tsx
@@ -88,7 +88,7 @@ function ExecuteResultDetails({
   output: ShellExecOutput | undefined;
   status: ToolCallMetadata["status"];
 }) {
-  const isTerminal = status === "complete" || status === "error";
+  const isTerminal = status === "complete" || status === "error" || status === "cancelled";
   if (!isTerminal && !output?.truncated) return null;
   const exitLabel =
     typeof output?.exit_code === "number"

--- a/apps/web/components/task/chat/messages/tool-execute-message.tsx
+++ b/apps/web/components/task/chat/messages/tool-execute-message.tsx
@@ -7,24 +7,7 @@ import { transformPathsInText } from "@/lib/utils";
 import type { Message } from "@/lib/types/http";
 import { ExpandableRow } from "./expandable-row";
 import { useExpandState } from "./use-expand-state";
-
-type ShellExecOutput = {
-  exit_code?: number;
-  stdout?: string;
-  stderr?: string;
-};
-
-type ShellExecPayload = {
-  command?: string;
-  work_dir?: string;
-  output?: ShellExecOutput;
-};
-
-type ToolExecuteMetadata = {
-  tool_call_id?: string;
-  status?: "pending" | "running" | "complete" | "error";
-  normalized?: { shell_exec?: ShellExecPayload };
-};
+import type { ShellExecOutput, ToolCallMetadata } from "../types";
 
 type ToolExecuteMessageProps = {
   comment: Message;
@@ -36,17 +19,39 @@ function ExecuteStatusIcon({
   exitCode,
 }: {
   status: string | undefined;
-  exitCode: number | undefined;
+  exitCode: number | null | undefined;
 }) {
   if (status === "complete") {
-    return exitCode === 0 ? (
-      <IconCheck className="h-3.5 w-3.5 text-green-500" />
-    ) : (
-      <IconX className="h-3.5 w-3.5 text-red-500" />
+    if (exitCode === 0) {
+      return (
+        <span className="shrink-0" aria-label="Command succeeded">
+          <IconCheck aria-hidden className="h-3.5 w-3.5 text-green-500" />
+        </span>
+      );
+    }
+    if (typeof exitCode === "number") {
+      return (
+        <span className="shrink-0" aria-label="Command failed">
+          <IconX aria-hidden className="h-3.5 w-3.5 text-red-500" />
+        </span>
+      );
+    }
+    return null;
+  }
+  if (status === "error") {
+    return (
+      <span className="shrink-0" aria-label="Command failed">
+        <IconX aria-hidden className="h-3.5 w-3.5 text-red-500" />
+      </span>
     );
   }
-  if (status === "error") return <IconX className="h-3.5 w-3.5 text-red-500" />;
-  if (status === "running") return <GridSpinner className="text-muted-foreground" />;
+  if (status === "running") {
+    return (
+      <span className="shrink-0" aria-label="Command running">
+        <GridSpinner className="text-muted-foreground" />
+      </span>
+    );
+  }
   return null;
 }
 
@@ -55,16 +60,61 @@ type ExecuteOutputProps = {
   displayWorkDir: string | null;
   workDir: string | undefined;
   output: ShellExecOutput | undefined;
+  status: ToolCallMetadata["status"];
 };
+
+function TerminalOutput({ output }: { output: ShellExecOutput | undefined }) {
+  if (!output?.stdout && !output?.stderr) return null;
+  return (
+    <div className="space-y-2" data-testid="tool-execute-output">
+      {output.stdout && (
+        <pre className="text-xs bg-muted/30 rounded p-2 overflow-x-auto whitespace-pre-wrap break-words max-h-[200px]">
+          {output.stdout}
+        </pre>
+      )}
+      {output.stderr && (
+        <pre className="text-xs bg-red-500/10 text-red-600 dark:text-red-400 rounded max-h-[200px] p-2 overflow-x-auto whitespace-pre-wrap break-words">
+          {output.stderr}
+        </pre>
+      )}
+    </div>
+  );
+}
+
+function ExecuteResultDetails({
+  output,
+  status,
+}: {
+  output: ShellExecOutput | undefined;
+  status: ToolCallMetadata["status"];
+}) {
+  const isTerminal = status === "complete" || status === "error";
+  if (!isTerminal && !output?.truncated) return null;
+  const exitLabel =
+    typeof output?.exit_code === "number"
+      ? `Exit code ${output.exit_code}`
+      : "Exit code unavailable";
+
+  return (
+    <div
+      className="flex min-w-0 flex-wrap items-center justify-between gap-x-3 gap-y-1 border-t border-border/40 pt-2 text-xs text-muted-foreground"
+      data-testid="tool-execute-result-details"
+    >
+      {output?.truncated && <span>Output truncated</span>}
+      {isTerminal && <span className="font-mono">{exitLabel}</span>}
+    </div>
+  );
+}
 
 function ExecuteOutputContent({
   displayCommand,
   displayWorkDir,
   workDir,
   output,
+  status,
 }: ExecuteOutputProps) {
   return (
-    <div className="pl-4 border-l-2 border-border/30 space-y-2">
+    <div className="min-w-0 pl-4 border-l-2 border-border/30 space-y-2">
       <pre className="text-xs bg-muted/30 rounded p-2 whitespace-pre-wrap break-all font-mono">
         {displayCommand}
       </pre>
@@ -76,41 +126,27 @@ function ExecuteOutputContent({
           </span>
         </div>
       )}
-      {output?.stdout && (
-        <pre className="text-xs bg-muted/30 rounded p-2 overflow-x-auto whitespace-pre-wrap max-h-[200px]">
-          {output.stdout}
-        </pre>
-      )}
-      {output?.stderr && (
-        <pre className="text-xs bg-red-500/10 text-red-600 dark:text-red-400 rounded max-h-[200px] p-2 overflow-x-auto whitespace-pre-wrap">
-          {output.stderr}
-        </pre>
-      )}
+      <TerminalOutput output={output} />
+      <ExecuteResultDetails output={output} status={status} />
     </div>
   );
 }
 
-function isExecuteSuccess(
-  status: ToolExecuteMetadata["status"],
-  output: ShellExecOutput | undefined,
-): boolean {
-  if (status !== "complete") return false;
-  return output?.exit_code === 0 || output?.exit_code === undefined;
-}
-
 function parseExecuteMetadata(comment: Message) {
-  const metadata = comment.metadata as ToolExecuteMetadata | undefined;
+  const metadata = comment.metadata as ToolCallMetadata | undefined;
   const status = metadata?.status;
   const shellExec = metadata?.normalized?.shell_exec;
   const output = shellExec?.output;
   const workDir = shellExec?.work_dir;
-  const isSuccess = isExecuteSuccess(status, output);
-  return { status, output, workDir, isSuccess };
+  return { status, output, workDir };
 }
 
 function CommandHeader({ displayCommand }: { displayCommand: string }) {
   return (
-    <span className="font-mono text-xs text-muted-foreground truncate min-w-0 flex-1 text-left">
+    <span
+      className="font-mono text-xs text-muted-foreground truncate min-w-0 flex-1 text-left"
+      data-testid="tool-execute-command"
+    >
       {displayCommand}
     </span>
   );
@@ -120,7 +156,7 @@ export const ToolExecuteMessage = memo(function ToolExecuteMessage({
   comment,
   worktreePath,
 }: ToolExecuteMessageProps) {
-  const { status, output, workDir, isSuccess } = parseExecuteMetadata(comment);
+  const { status, output, workDir } = parseExecuteMetadata(comment);
   const autoExpanded = status === "running";
   const { isExpanded, handleToggle } = useExpandState(status, autoExpanded);
   const displayCommand = transformPathsInText(comment.content, worktreePath);
@@ -132,11 +168,7 @@ export const ToolExecuteMessage = memo(function ToolExecuteMessage({
       header={
         <div className="flex items-center gap-2 text-xs min-w-0">
           <CommandHeader displayCommand={displayCommand} />
-          {!isSuccess && (
-            <span className="shrink-0">
-              <ExecuteStatusIcon status={status} exitCode={output?.exit_code} />
-            </span>
-          )}
+          <ExecuteStatusIcon status={status} exitCode={output?.exit_code} />
         </div>
       }
       hasExpandableContent
@@ -148,6 +180,7 @@ export const ToolExecuteMessage = memo(function ToolExecuteMessage({
         displayWorkDir={displayWorkDir}
         workDir={workDir}
         output={output}
+        status={status}
       />
     </ExpandableRow>
   );

--- a/apps/web/components/task/chat/messages/tool-status.ts
+++ b/apps/web/components/task/chat/messages/tool-status.ts
@@ -1,0 +1,9 @@
+import type { ToolCallMetadata } from "../types";
+
+export type NormalizedToolCallStatus = Exclude<ToolCallMetadata["status"], "in_progress">;
+
+export function normalizeToolCallStatus(
+  status: ToolCallMetadata["status"],
+): NormalizedToolCallStatus {
+  return status === "in_progress" ? "running" : status;
+}

--- a/apps/web/components/task/chat/messages/turn-group-message.test.tsx
+++ b/apps/web/components/task/chat/messages/turn-group-message.test.tsx
@@ -25,6 +25,23 @@ function toolExecute(id: string, command = "gh pr checks"): Message {
   };
 }
 
+function cancelledToolExecute(id: string): Message {
+  const message = toolExecute(id);
+  return {
+    ...message,
+    metadata: {
+      ...message.metadata,
+      status: "cancelled",
+      normalized: {
+        shell_exec: {
+          command: "cancelled-command",
+          output: { stdout: "cancelled-output" },
+        },
+      },
+    },
+  };
+}
+
 describe("TurnGroupMessage repeated tool compaction", () => {
   it("summarizes the middle of a long run of identical terminal commands", () => {
     const messages = Array.from({ length: 6 }, (_, i) => toolExecute(`tool-${i + 1}`));
@@ -46,5 +63,22 @@ describe("TurnGroupMessage repeated tool compaction", () => {
 
     expect(html).toContain('data-testid="repeated-tool-summary"');
     expect(html).toContain("4 repeated identical terminal commands hidden");
+  });
+
+  it("treats a cancelled tool as terminal", () => {
+    const html = renderToStaticMarkup(
+      <TurnGroupMessage
+        group={{
+          type: "turn_group",
+          id: "turn-group-cancelled",
+          turnId: "turn-1",
+          messages: [cancelledToolExecute("tool-cancelled")],
+        }}
+        sessionId="s1"
+        permissionsByToolCallId={new Map()}
+      />,
+    );
+
+    expect(html).not.toContain('aria-label="Loading"');
   });
 });

--- a/apps/web/components/task/chat/messages/turn-group-message.tsx
+++ b/apps/web/components/task/chat/messages/turn-group-message.tsx
@@ -89,7 +89,7 @@ const TOOL_MESSAGE_TYPES = new Set([
 
 /**
  * Check if any tool or subagent in the group is still running.
- * A tool/subagent is considered running if it's not in a terminal state (complete or error).
+ * A tool/subagent is considered running if it's not in a terminal state.
  */
 function hasRunningTool(messages: Message[]): boolean {
   for (const msg of messages) {
@@ -98,7 +98,7 @@ function hasRunningTool(messages: Message[]): boolean {
     const isSubagent = metadata?.normalized?.kind === "subagent_task";
     if (!isToolMessage && !isSubagent) continue;
     const status = metadata?.status;
-    if (status !== "complete" && status !== "error") return true;
+    if (status !== "complete" && status !== "error" && status !== "cancelled") return true;
   }
   return false;
 }

--- a/apps/web/components/task/chat/types.ts
+++ b/apps/web/components/task/chat/types.ts
@@ -134,7 +134,7 @@ export type ToolCallMetadata = {
   parent_tool_call_id?: string; // For subagent nesting
   tool_name?: string;
   title?: string;
-  status?: "pending" | "running" | "in_progress" | "complete" | "error";
+  status?: "pending" | "running" | "in_progress" | "complete" | "error" | "cancelled";
   args?: Record<string, unknown>;
   result?: string;
   normalized?: NormalizedPayload;

--- a/apps/web/components/task/chat/types.ts
+++ b/apps/web/components/task/chat/types.ts
@@ -96,9 +96,10 @@ export type ModifyFilePayload = {
 };
 
 export type ShellExecOutput = {
-  exit_code?: number;
+  exit_code?: number | null;
   stdout?: string;
   stderr?: string;
+  truncated?: boolean;
 };
 
 export type ShellExecPayload = {

--- a/apps/web/components/task/chat/types.ts
+++ b/apps/web/components/task/chat/types.ts
@@ -96,7 +96,7 @@ export type ModifyFilePayload = {
 };
 
 export type ShellExecOutput = {
-  exit_code?: number | null;
+  exit_code?: number;
   stdout?: string;
   stderr?: string;
   truncated?: boolean;
@@ -134,7 +134,7 @@ export type ToolCallMetadata = {
   parent_tool_call_id?: string; // For subagent nesting
   tool_name?: string;
   title?: string;
-  status?: "pending" | "running" | "complete" | "error";
+  status?: "pending" | "running" | "in_progress" | "complete" | "error";
   args?: Record<string, unknown>;
   result?: string;
   normalized?: NormalizedPayload;

--- a/apps/web/e2e/tests/chat/mobile-tool-execute-output.spec.ts
+++ b/apps/web/e2e/tests/chat/mobile-tool-execute-output.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect } from "../../fixtures/test-base";
+import { SessionPage } from "../../pages/session-page";
+
+test.describe("mobile: shell command output", () => {
+  test("keeps truncated output and exit status inside the viewport", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    const task = await apiClient.createTask(seedData.workspaceId, "Mobile Command Output", {
+      description: "seeded mobile shell command output",
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+      agent_profile_id: seedData.agentProfileId,
+      repository_ids: [seedData.repositoryId],
+    });
+    const { session_id: sessionId } = await apiClient.seedTaskSession(task.id, {
+      state: "IDLE",
+      agentProfileId: seedData.agentProfileId,
+    });
+    const command = "printf mobile-command-output";
+    await apiClient.seedSessionMessage(sessionId, {
+      type: "tool_execute",
+      content: command,
+      metadata: {
+        status: "error",
+        tool_call_id: "tool-mobile-output",
+        normalized: {
+          shell_exec: {
+            command,
+            work_dir: "/workspace/a/very/long/path/that/must/not/expand/the/page",
+            output: {
+              exit_code: 9,
+              stdout: `latest output ${"unbroken-output-".repeat(80)}`,
+              truncated: true,
+            },
+          },
+        },
+      },
+    });
+
+    await testPage.goto(`/t/${task.id}`);
+    const session = new SessionPage(testPage);
+    await session.waitForLoad();
+    const chat = session.activeChat();
+    const commandRow = chat.getByTestId("tool-execute-command").filter({ hasText: command });
+    await expect(commandRow).toBeVisible({ timeout: 15_000 });
+    await commandRow.click();
+
+    const output = chat.getByTestId("tool-execute-output");
+    const details = chat.getByTestId("tool-execute-result-details");
+    await expect(output).toContainText("latest output");
+    await expect(details).toContainText("Output truncated");
+    await expect(details).toContainText("Exit code 9");
+
+    const viewportWidth = testPage.viewportSize()?.width ?? 0;
+    const outputBox = await output.boundingBox();
+    expect(outputBox).not.toBeNull();
+    expect(outputBox!.x).toBeGreaterThanOrEqual(0);
+    expect(outputBox!.x + outputBox!.width).toBeLessThanOrEqual(viewportWidth + 1);
+    expect(
+      await testPage.evaluate(
+        () => document.documentElement.scrollWidth <= document.documentElement.clientWidth,
+      ),
+    ).toBe(true);
+  });
+});

--- a/apps/web/e2e/tests/chat/tool-execute-output.spec.ts
+++ b/apps/web/e2e/tests/chat/tool-execute-output.spec.ts
@@ -1,0 +1,112 @@
+import { test, expect, type SeedData } from "../../fixtures/test-base";
+import { ApiClient } from "../../helpers/api-client";
+import { SessionPage } from "../../pages/session-page";
+
+type ShellOutput = {
+  exit_code?: number;
+  stdout?: string;
+  stderr?: string;
+};
+
+type SeedShellMessageOptions = {
+  title: string;
+  command: string;
+  status: "complete" | "error";
+  output: ShellOutput;
+};
+
+async function seedShellMessage(
+  apiClient: ApiClient,
+  seedData: SeedData,
+  options: SeedShellMessageOptions,
+) {
+  const task = await apiClient.createTask(seedData.workspaceId, options.title, {
+    description: "seeded shell command output",
+    workflow_id: seedData.workflowId,
+    workflow_step_id: seedData.startStepId,
+    agent_profile_id: seedData.agentProfileId,
+    repository_ids: [seedData.repositoryId],
+  });
+  const { session_id: sessionId } = await apiClient.seedTaskSession(task.id, {
+    state: "IDLE",
+    agentProfileId: seedData.agentProfileId,
+  });
+  await apiClient.seedSessionMessage(sessionId, {
+    type: "tool_execute",
+    content: options.command,
+    metadata: {
+      status: options.status,
+      tool_call_id: `tool-${options.title}`,
+      normalized: {
+        shell_exec: { command: options.command, work_dir: "/workspace", output: options.output },
+      },
+    },
+  });
+  return task.id;
+}
+
+test.describe("shell command output", () => {
+  test("shows persisted success, failure, and unknown exit results", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    const scenarios = [
+      {
+        title: "Successful Command",
+        command: "printf successful-command",
+        status: "complete" as const,
+        output: { exit_code: 0, stdout: "successful output\n" },
+        statusLabel: "Command succeeded",
+        exitLabel: "Exit code 0",
+        outputText: "successful output",
+      },
+      {
+        title: "Failed Command",
+        command: "printf failed-command",
+        status: "error" as const,
+        output: { exit_code: 7, stderr: "failed output\n" },
+        statusLabel: "Command failed",
+        exitLabel: "Exit code 7",
+        outputText: "failed output",
+      },
+      {
+        title: "Unknown Exit Command",
+        command: "printf unknown-exit-command",
+        status: "complete" as const,
+        output: { stdout: "unknown exit output\n" },
+        statusLabel: null,
+        exitLabel: "Exit code unavailable",
+        outputText: "unknown exit output",
+      },
+    ];
+
+    for (const scenario of scenarios) {
+      const taskId = await seedShellMessage(apiClient, seedData, {
+        title: scenario.title,
+        command: scenario.command,
+        status: scenario.status,
+        output: scenario.output,
+      });
+      await testPage.goto(`/t/${taskId}`);
+      const session = new SessionPage(testPage);
+      await session.waitForLoad();
+
+      const chat = session.activeChat();
+      const command = chat.getByTestId("tool-execute-command").filter({
+        hasText: scenario.command,
+      });
+      await expect(command).toBeVisible({ timeout: 15_000 });
+      if (scenario.statusLabel) {
+        await expect(chat.getByLabel(scenario.statusLabel)).toBeVisible();
+      } else {
+        await expect(chat.getByLabel("Command succeeded")).toHaveCount(0);
+        await expect(chat.getByLabel("Command failed")).toHaveCount(0);
+      }
+
+      await command.click();
+      await expect(chat.getByText(scenario.outputText)).toBeVisible();
+      await expect(chat.getByText(scenario.exitLabel)).toBeVisible();
+    }
+  });
+});

--- a/docs/decisions/0036-normalize-acp-shell-output-at-adapter-boundary.md
+++ b/docs/decisions/0036-normalize-acp-shell-output-at-adapter-boundary.md
@@ -1,0 +1,56 @@
+# ADR-0036: Normalize ACP Shell Output at the Adapter Boundary
+
+**Status:** accepted
+**Date:** 2026-07-14
+**Area:** backend, frontend, protocol
+
+## Context
+
+ACP agents expose shell output and exit status through incompatible shapes. Codex uses terminal metadata and a structured final result, Claude gates terminal metadata behind a client capability, OpenCode sends cumulative content and a nested exit value, and Auggie embeds the result in XML-like text. Some agents also report ACP status `completed` for a nonzero process exit.
+
+Kandev currently normalizes shell tool calls but defaults plain output to exit code `0`, ignores live terminal updates, and loses several provider-native exit fields. Passing raw ACP frames through to chat would make persistence and React responsible for provider protocol details.
+
+## Decision
+
+The ACP adapter owns shell-output normalization.
+
+- Provider-specific fields are converted into the existing provider-neutral `shell_exec` payload before stream events leave the adapter.
+- Exit code is nullable. Missing or malformed exit data remains unknown and is never converted to `0`.
+- A known nonzero exit makes the normalized tool result a failure even when the provider reports ACP status `completed`.
+- Live output is accumulated by tool-call ID. Delta updates append, cumulative updates replace, and a final aggregate replaces live text without duplication. A final update without output preserves the accumulated text.
+- Output is stored as a combined terminal stream unless the provider explicitly supplies separate stdout and stderr values.
+- Each output field is bounded before persistence. Tail retention preserves the most recent valid UTF-8 content and records truncation in the normalized payload.
+- Kandev advertises the ACP `_meta.terminal_output` client capability so providers can return terminal output and exit metadata. It does not advertise or implement client-owned terminal RPC methods as part of this feature.
+- The frontend renders only the normalized contract and does not inspect provider names or ACP metadata.
+
+## Consequences
+
+- Persisted task messages and live WebSocket events share one representation, so reloads render the same command output as the active session.
+- Provider quirks are tested in the ACP package rather than duplicated across the orchestrator and frontend.
+- Unknown exit status becomes an explicit neutral UI state. This changes the previous implicit-success behavior for plain output.
+- The adapter keeps bounded per-tool accumulation state until the tool reaches a terminal state or the existing prompt cleanup runs.
+- Output absent from upstream ACP frames cannot be recovered by Kandev.
+
+## Alternatives Considered
+
+### Parse provider payloads in React
+
+Rejected because raw ACP shapes would leak into the persisted message contract and require frontend changes for every provider revision.
+
+### Store raw frames and normalize only when rendering
+
+Rejected because live and reloaded messages could diverge, storage would grow without a bound, and non-UI consumers would still lack a reliable exit status.
+
+### Use ACP tool status as the command result
+
+Rejected because OpenCode can report `completed` for a nonzero shell exit and because status does not encode the exact exit code.
+
+### Treat a missing exit code as zero
+
+Rejected because absence is not evidence of success and caused false success indicators in chat.
+
+## References
+
+- [ACP shell command output spec](../specs/ui/acp-shell-command-output.md)
+- [Implementation plan](../plans/acp-shell-command-output/plan.md)
+- [ADR-0034: Agent Client Protocol Codex ACP Bridge](0034-agentclientprotocol-codex-acp.md)

--- a/docs/decisions/INDEX.md
+++ b/docs/decisions/INDEX.md
@@ -41,3 +41,4 @@ Read individual ADRs for full context. Create new ones via `/record decision` or
 | 0033 | [Durable plan implementation start marker](0033-durable-plan-implementation-start.md)                                               | accepted   | backend, frontend           | 2026-07-09 |
 | 0034 | [Agent Client Protocol Codex ACP Bridge](0034-agentclientprotocol-codex-acp.md)                                                     | accepted   | backend, protocol           | 2026-07-10 |
 | 0035 | [Version AgentReady events by prompt generation](0035-version-agent-ready-events-by-prompt-generation.md)                          | accepted   | backend                     | 2026-07-14 |
+| 0036 | [Normalize ACP shell output at the adapter boundary](0036-normalize-acp-shell-output-at-adapter-boundary.md)                        | accepted   | backend, frontend, protocol | 2026-07-14 |

--- a/docs/plans/acp-shell-command-output/plan.md
+++ b/docs/plans/acp-shell-command-output/plan.md
@@ -132,8 +132,8 @@ make -C apps/backend fmt
 (cd apps && pnpm --filter @kandev/web test -- components/task/chat/messages/tool-execute-message.test.tsx)
 (cd apps/web && pnpm run typecheck)
 (cd apps && pnpm --filter @kandev/web lint)
-(cd apps/web && pnpm e2e:run --project=chromium tests/chat/tool-execute-output.spec.ts)
-(cd apps/web && pnpm e2e:run --project=mobile-chrome tests/chat/mobile-tool-execute-output.spec.ts)
+(cd apps/web && pnpm e2e:run --project chromium tests/chat/tool-execute-output.spec.ts)
+(cd apps/web && pnpm e2e:run --no-build --project mobile-chrome tests/chat/mobile-tool-execute-output.spec.ts)
 make -C apps/backend test
 make -C apps/backend lint
 ```

--- a/docs/plans/acp-shell-command-output/plan.md
+++ b/docs/plans/acp-shell-command-output/plan.md
@@ -128,11 +128,12 @@ Dependency graph:
 
 ```bash
 make -C apps/backend fmt
-cd apps/backend && go test ./internal/agentctl/server/adapter/transport/acp
-cd apps && pnpm --filter @kandev/web test -- components/task/chat/messages/tool-execute-message.test.tsx
-cd apps/web && pnpm run typecheck
-cd apps && pnpm --filter @kandev/web lint
-cd apps/web && pnpm e2e:run tests/chat/tool-execute-output.spec.ts tests/chat/mobile-tool-execute-output.spec.ts
+(cd apps/backend && go test ./internal/agentctl/server/adapter/transport/acp)
+(cd apps && pnpm --filter @kandev/web test -- components/task/chat/messages/tool-execute-message.test.tsx)
+(cd apps/web && pnpm run typecheck)
+(cd apps && pnpm --filter @kandev/web lint)
+(cd apps/web && pnpm e2e:run --project=chromium tests/chat/tool-execute-output.spec.ts)
+(cd apps/web && pnpm e2e:run --project=mobile-chrome tests/chat/mobile-tool-execute-output.spec.ts)
 make -C apps/backend test
 make -C apps/backend lint
 ```

--- a/docs/plans/acp-shell-command-output/plan.md
+++ b/docs/plans/acp-shell-command-output/plan.md
@@ -1,0 +1,148 @@
+---
+spec: docs/specs/ui/acp-shell-command-output.md
+created: 2026-07-14
+status: complete
+---
+
+# Implementation Plan: ACP Shell Command Output
+
+## Overview
+
+Extend the existing normalized shell payload rather than adding a transport or storage layer. First define bounded, nullable provider normalization, then wire ACP capability negotiation and live tool updates into it. Finally update the existing command row and verify its persisted desktop/mobile rendering.
+
+---
+
+## Backend
+
+### Normalized Shell Output Contract
+
+Files:
+
+- `apps/backend/internal/agentctl/types/streams/tool_payload.go`
+- `apps/backend/internal/agentctl/server/adapter/transport/acp/normalize.go`
+- `apps/backend/internal/agentctl/server/adapter/transport/acp/shell_output.go` (new, if extraction keeps `normalize.go` within limits)
+- `apps/backend/internal/agentctl/server/adapter/transport/acp/normalize_test.go`
+- `apps/backend/internal/agentctl/server/adapter/transport/acp/shell_output_test.go` (new, if paired with the helper)
+
+Changes:
+
+- Change `ShellExecOutput.ExitCode` to a nullable pointer and add `Truncated`.
+- Replace the current plain-string-implies-zero behavior with provider-aware extraction for Codex `formatted_output`/`exit_code`, OpenCode `metadata.exit`, Auggie XML, and plain fallback output.
+- Add one bounded text helper with a 256 KiB per-field limit that retains the newest valid UTF-8 content.
+- Encode output update mode explicitly: Codex delta appends; Claude terminal output, OpenCode cumulative content, and final aggregates replace. Final missing output preserves accumulated text.
+- Apply exit precedence from the spec and keep unknown nullable.
+
+### ACP Capability and Live Updates
+
+Files:
+
+- `apps/backend/internal/agentctl/server/adapter/transport/acp/adapter.go`
+- `apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_tools.go`
+- `apps/backend/internal/agentctl/server/adapter/transport/acp/tool_call_update_test.go`
+- `apps/backend/internal/agentctl/server/adapter/transport/acp/conversion_test.go` or a focused initialize test file
+
+Changes:
+
+- Set `ClientCapabilities.Meta["terminal_output"] = true` on the initialize request without advertising ACP terminal RPC support.
+- Feed recognized `_meta.terminal_output_delta`, `_meta.terminal_output`, `_meta.terminal_exit`, text content, and raw output into the shell normalizer while the adapter lock owns the active payload.
+- Synthesize `in_progress` only for recognized statusless terminal-output updates so the orchestrator persists them.
+- Normalize before deleting terminal tool state; keep the existing prompt-end cleanup behavior.
+
+No orchestrator, database, HTTP, or WebSocket changes are planned. `tool_update` already replaces and publishes the persisted normalized message metadata.
+
+---
+
+## Frontend
+
+### Expandable Command Row
+
+Files:
+
+- `apps/web/components/task/chat/types.ts`
+- `apps/web/components/task/chat/messages/tool-execute-message.tsx`
+- `apps/web/components/task/chat/messages/tool-execute-message.test.tsx` (new)
+
+Changes:
+
+- Model exit status as `number | null | undefined` and add `truncated` to the shared shell output type.
+- Remove the current absent-exit-means-success rule.
+- Render live/final combined output in the current expanded content, plus a completion footer with `Exit code N` or `Exit code unavailable` and a truncation label when needed.
+- Keep known zero success, known nonzero/error failure, and unknown neutral. Preserve stable sizing, wrapping, horizontal scrolling, and the existing expand-state behavior.
+
+No new state, hook, or API client is needed.
+
+---
+
+## Tests
+
+- **What:** provider-specific output and exit extraction, precedence, unknown exit, append/replace behavior, deduplication, bounds, and UTF-8 safety.
+  **File:** `apps/backend/internal/agentctl/server/adapter/transport/acp/normalize_test.go` and/or `shell_output_test.go`.
+  **How:** table-driven tests built from the captured Codex, Claude, OpenCode, and Auggie frame shapes.
+- **What:** statusless terminal metadata becomes persisted `in_progress`, final updates retain output and exit, and terminal state is cleaned up.
+  **File:** `apps/backend/internal/agentctl/server/adapter/transport/acp/tool_call_update_test.go`.
+  **How:** drive initial tool call plus incremental/final `SessionToolCallUpdate` values through the adapter conversion methods.
+- **What:** ACP initialization advertises only the terminal-output meta extension required by Claude.
+  **File:** focused adapter initialize test or `conversion_test.go`.
+  **How:** capture the fake agent's `InitializeRequest` and assert `_meta.terminal_output == true`.
+- **What:** exit `0`, nonzero, and unknown render distinct status; live output and truncation are visible.
+  **File:** `apps/web/components/task/chat/messages/tool-execute-message.test.tsx`.
+  **How:** React Testing Library cases over persisted `Message` fixtures.
+
+---
+
+## E2E Tests
+
+- **Scenario:** GIVEN persisted successful, failed, and unknown-exit command messages, WHEN desktop chat expands each row, THEN combined output and the exact exit label are visible and unknown is not presented as success.
+  **File:** `apps/web/e2e/tests/chat/tool-execute-output.spec.ts`.
+- **Scenario:** GIVEN a persisted command with long wrapped output on a narrow viewport, WHEN mobile chat expands the row, THEN output, truncation state, and exit label remain readable without overlap or horizontal page overflow.
+  **File:** `apps/web/e2e/tests/chat/mobile-tool-execute-output.spec.ts`.
+
+The provider wire shapes are covered at the backend adapter level; E2E seeds the normalized persisted contract so it remains deterministic and does not require four external authenticated CLIs.
+
+---
+
+## Implementation Waves
+
+Wave 1:
+
+- [x] [task-01-backend-normalization](task-01-backend-normalization.md) (`done`)
+
+Wave 2 (parallel after Task 01):
+
+- [x] [task-02-acp-live-updates](task-02-acp-live-updates.md) (`done`)
+- [x] [task-03-frontend-command-row](task-03-frontend-command-row.md) (`done`)
+
+Wave 3:
+
+- [x] [task-04-e2e-and-verification](task-04-e2e-and-verification.md) (`done`)
+
+Dependency graph:
+
+```text
+01-backend-normalization
+  |-- 02-acp-live-updates --|
+  `-- 03-frontend-command-row --+--> 04-e2e-and-verification
+```
+
+## Verification
+
+```bash
+make -C apps/backend fmt
+cd apps/backend && go test ./internal/agentctl/server/adapter/transport/acp
+cd apps && pnpm --filter @kandev/web test -- components/task/chat/messages/tool-execute-message.test.tsx
+cd apps/web && pnpm run typecheck
+cd apps && pnpm --filter @kandev/web lint
+cd apps/web && pnpm e2e:run tests/chat/tool-execute-output.spec.ts tests/chat/mobile-tool-execute-output.spec.ts
+make -C apps/backend test
+make -C apps/backend lint
+```
+
+## Risks
+
+- Provider extensions are not part of the stable ACP schema. Parsing remains defensive and scoped to shell payloads so unrelated `_meta` cannot mutate other tool kinds.
+- Codex may omit output generated immediately after process start upstream. Kandev can only preserve bytes present in ACP frames; provider-side loss is explicitly out of scope.
+- OpenCode reports nonzero commands with ACP status `completed`; UI success must therefore use a known exit code before the generic completed status.
+
+## Open Questions
+
+None. The 256 KiB per-field bound and tail-retention behavior are explicit product constraints for this implementation.

--- a/docs/plans/acp-shell-command-output/task-01-backend-normalization.md
+++ b/docs/plans/acp-shell-command-output/task-01-backend-normalization.md
@@ -1,0 +1,46 @@
+---
+id: "01-backend-normalization"
+title: "Backend shell output normalization"
+status: done
+wave: 1
+depends_on: []
+plan: "plan.md"
+spec: "../../specs/ui/acp-shell-command-output.md"
+---
+
+# Task 01: Backend Shell Output Normalization
+
+## Acceptance
+
+- The normalized shell contract distinguishes explicit exit `0`, nonzero exit, and unknown exit, and bounds each output field to 256 KiB with valid UTF-8 tail retention.
+- Table-driven tests cover final Codex, Claude, OpenCode, and Auggie shapes, including precedence and malformed/absent exits.
+- Append, cumulative replace, final replace, final-without-output, and truncation behavior cannot duplicate or silently discard retained output.
+
+## Verification
+
+```bash
+make -C apps/backend fmt
+cd apps/backend && go test ./internal/agentctl/server/adapter/transport/acp -run 'Test.*Shell|TestNormalizerResult|TestParseShellOutput'
+```
+
+## Files likely touched
+
+- `apps/backend/internal/agentctl/types/streams/tool_payload.go`
+- `apps/backend/internal/agentctl/server/adapter/transport/acp/normalize.go`
+- `apps/backend/internal/agentctl/server/adapter/transport/acp/normalize_test.go`
+- `apps/backend/internal/agentctl/server/adapter/transport/acp/shell_output.go` (new, if needed)
+- `apps/backend/internal/agentctl/server/adapter/transport/acp/shell_output_test.go` (new, if needed)
+
+## Dependencies
+
+None.
+
+## Inputs
+
+- Spec sections `What`, `Data model`, and `Failure modes`.
+- Existing `NormalizeToolResult`, `extractRawOutput`, and `parseShellOutput` patterns in `normalize.go`.
+- Captured provider shapes in `acp-debug/codex-shell-output.jsonl`, `acp-debug/codex-shell-streaming-delayed-first.jsonl`, and `acp-debug/opencode-shell-output.jsonl`; Claude and Auggie shapes are pinned in the spec from adapter inspection.
+
+## Output contract
+
+Report the normalization API chosen, provider precedence, truncation behavior, tests run, files changed, blockers, and follow-up risks. Set this task to `done` and update `plan.md` only after targeted tests pass.

--- a/docs/plans/acp-shell-command-output/task-01-backend-normalization.md
+++ b/docs/plans/acp-shell-command-output/task-01-backend-normalization.md
@@ -47,7 +47,7 @@ Report the normalization API chosen, provider precedence, truncation behavior, t
 
 ## Completion Report
 
-- Added `NormalizeShellToolUpdate` and final-result normalization with independent stdout/stderr presence, explicit-field precedence, nullable exit codes, 256 KiB UTF-8 tail retention, and sticky combined truncation state.
+- Added `NormalizeShellToolUpdate` and final-result normalization with independent stdout/stderr presence and truncation state, explicit-field precedence, optional exit codes, and 256 KiB UTF-8 tail retention.
 - Covered Codex, Claude, OpenCode, and Auggie final shapes, malformed/absent exits, precedence, live append/replace behavior, partial stream merges, and truncation.
 - Changed `shell_output.go`, `shell_output_test.go`, `normalize.go`, `normalize_test.go`, and the normalized stream payload type.
 - Targeted ACP adapter tests, full backend tests, formatting, and backend lint passed. No blockers remain; new provider-specific shapes require new fixtures.

--- a/docs/plans/acp-shell-command-output/task-01-backend-normalization.md
+++ b/docs/plans/acp-shell-command-output/task-01-backend-normalization.md
@@ -20,7 +20,7 @@ spec: "../../specs/ui/acp-shell-command-output.md"
 
 ```bash
 make -C apps/backend fmt
-cd apps/backend && go test ./internal/agentctl/server/adapter/transport/acp -run 'Test.*Shell|TestNormalizerResult|TestParseShellOutput'
+(cd apps/backend && go test ./internal/agentctl/server/adapter/transport/acp -run 'Test.*Shell|TestNormalizerResult')
 ```
 
 ## Files likely touched
@@ -38,9 +38,16 @@ None.
 ## Inputs
 
 - Spec sections `What`, `Data model`, and `Failure modes`.
-- Existing `NormalizeToolResult`, `extractRawOutput`, and `parseShellOutput` patterns in `normalize.go`.
-- Captured provider shapes in `acp-debug/codex-shell-output.jsonl`, `acp-debug/codex-shell-streaming-delayed-first.jsonl`, and `acp-debug/opencode-shell-output.jsonl`; Claude and Auggie shapes are pinned in the spec from adapter inspection.
+- Existing `NormalizeToolResult` and `extractRawOutput` patterns in `normalize.go`, plus the checked-in provider cases in `shell_output_test.go`.
+- Provider mappings and captured-shape summaries pinned in the feature spec; raw ACP captures were investigation artifacts, not repository fixtures.
 
 ## Output contract
 
 Report the normalization API chosen, provider precedence, truncation behavior, tests run, files changed, blockers, and follow-up risks. Set this task to `done` and update `plan.md` only after targeted tests pass.
+
+## Completion Report
+
+- Added `NormalizeShellToolUpdate` and final-result normalization with independent stdout/stderr presence, explicit-field precedence, nullable exit codes, 256 KiB UTF-8 tail retention, and sticky combined truncation state.
+- Covered Codex, Claude, OpenCode, and Auggie final shapes, malformed/absent exits, precedence, live append/replace behavior, partial stream merges, and truncation.
+- Changed `shell_output.go`, `shell_output_test.go`, `normalize.go`, `normalize_test.go`, and the normalized stream payload type.
+- Targeted ACP adapter tests, full backend tests, formatting, and backend lint passed. No blockers remain; new provider-specific shapes require new fixtures.

--- a/docs/plans/acp-shell-command-output/task-02-acp-live-updates.md
+++ b/docs/plans/acp-shell-command-output/task-02-acp-live-updates.md
@@ -14,14 +14,14 @@ spec: "../../specs/ui/acp-shell-command-output.md"
 
 - Initialization advertises `_meta.terminal_output: true` without claiming support for ACP terminal RPC methods.
 - Codex deltas, Claude terminal output/exit, OpenCode cumulative content, and final raw output update the tracked shell payload using Task 01's normalization API.
-- Recognized statusless terminal updates persist as `in_progress`, and terminal updates expose their final bounded output/exit before active state is removed.
+- Output-only statusless terminal updates persist as `in_progress`; updates with a final exit expose their bounded output/exit before active state is removed.
 
 ## Verification
 
 ```bash
 make -C apps/backend fmt
-cd apps/backend && go test ./internal/agentctl/server/adapter/transport/acp -run 'Test.*Initialize|TestConvertToolCall.*(Output|Terminal|Content|Exit)'
-cd apps/backend && go test ./internal/agentctl/server/adapter/transport/acp
+(cd apps/backend && go test ./internal/agentctl/server/adapter/transport/acp -run 'Test.*Initialize|TestConvertToolCall.*(Output|Terminal|Content|Exit)')
+(cd apps/backend && go test ./internal/agentctl/server/adapter/transport/acp)
 ```
 
 ## Files likely touched
@@ -45,3 +45,10 @@ Task 01.
 ## Output contract
 
 Report the capability request, event-to-normalizer mapping, cleanup behavior, tests run, files changed, blockers, and follow-up risks. Set this task to `done` and update `plan.md` only after targeted tests pass.
+
+## Completion Report
+
+- Advertised `_meta.terminal_output: true` and routed delta, cumulative content, final raw output, terminal output, and terminal exit fields through the shell normalizer.
+- Output-only statusless updates become `in_progress`; completed, failed, cancelled, and exit-bearing updates emit their final payload before active-call cleanup.
+- Changed ACP initialization/update handling and focused update/concurrency tests.
+- Targeted and full ACP adapter tests, full backend tests, formatting, and lint passed. No blockers remain; lifecycle behavior still depends on providers emitting a terminal status or exit.

--- a/docs/plans/acp-shell-command-output/task-02-acp-live-updates.md
+++ b/docs/plans/acp-shell-command-output/task-02-acp-live-updates.md
@@ -1,0 +1,47 @@
+---
+id: "02-acp-live-updates"
+title: "ACP live shell updates"
+status: done
+wave: 2
+depends_on: ["01-backend-normalization"]
+plan: "plan.md"
+spec: "../../specs/ui/acp-shell-command-output.md"
+---
+
+# Task 02: ACP Live Shell Updates
+
+## Acceptance
+
+- Initialization advertises `_meta.terminal_output: true` without claiming support for ACP terminal RPC methods.
+- Codex deltas, Claude terminal output/exit, OpenCode cumulative content, and final raw output update the tracked shell payload using Task 01's normalization API.
+- Recognized statusless terminal updates persist as `in_progress`, and terminal updates expose their final bounded output/exit before active state is removed.
+
+## Verification
+
+```bash
+make -C apps/backend fmt
+cd apps/backend && go test ./internal/agentctl/server/adapter/transport/acp -run 'Test.*Initialize|TestConvertToolCall.*(Output|Terminal|Content|Exit)'
+cd apps/backend && go test ./internal/agentctl/server/adapter/transport/acp
+```
+
+## Files likely touched
+
+- `apps/backend/internal/agentctl/server/adapter/transport/acp/adapter.go`
+- `apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_tools.go`
+- `apps/backend/internal/agentctl/server/adapter/transport/acp/tool_call_update_test.go`
+- `apps/backend/internal/agentctl/server/adapter/transport/acp/conversion_test.go` or a focused initialize test file
+
+## Dependencies
+
+Task 01.
+
+## Inputs
+
+- Spec provider mapping and failure-mode scenarios.
+- Task 01's normalized shell update API.
+- Existing `activeToolCalls` ownership and `convertToolCallResultUpdate` lock/cleanup order.
+- Existing orchestrator behavior: only known tool statuses are persisted, so recognized statusless output must synthesize `in_progress`.
+
+## Output contract
+
+Report the capability request, event-to-normalizer mapping, cleanup behavior, tests run, files changed, blockers, and follow-up risks. Set this task to `done` and update `plan.md` only after targeted tests pass.

--- a/docs/plans/acp-shell-command-output/task-03-frontend-command-row.md
+++ b/docs/plans/acp-shell-command-output/task-03-frontend-command-row.md
@@ -19,9 +19,9 @@ spec: "../../specs/ui/acp-shell-command-output.md"
 ## Verification
 
 ```bash
-cd apps && pnpm --filter @kandev/web test -- components/task/chat/messages/tool-execute-message.test.tsx
-cd apps/web && pnpm run typecheck
-cd apps && pnpm --filter @kandev/web lint
+(cd apps && pnpm --filter @kandev/web test -- components/task/chat/messages/tool-execute-message.test.tsx)
+(cd apps/web && pnpm run typecheck)
+(cd apps && pnpm --filter @kandev/web lint)
 ```
 
 ## Files likely touched
@@ -32,7 +32,7 @@ cd apps && pnpm --filter @kandev/web lint
 
 ## Dependencies
 
-Task 01 defines the serialized nullable/truncation contract. This task can run in parallel with Task 02 afterward because their file ownership does not overlap.
+Task 01 defines the serialized optional-exit/truncation contract. This task can run in parallel with Task 02 afterward because their file ownership does not overlap.
 
 ## Inputs
 
@@ -43,3 +43,10 @@ Task 01 defines the serialized nullable/truncation contract. This task can run i
 ## Output contract
 
 Report rendered labels/status rules, tests run, files changed, blockers, and mobile layout risks. Set this task to `done` and update `plan.md` only after targeted tests, typecheck, and lint pass.
+
+## Completion Report
+
+- Added expandable live/final stdout and stderr, exact or unavailable exit labels, truncation state, and neutral unknown-exit semantics.
+- Normalized ACP `in_progress` to the running UI state and treated cancellation as terminal without inventing an exit code.
+- Changed the shell payload types, command-row component, and focused component tests.
+- Component tests, web typecheck, lint, production build, and desktop/mobile Playwright coverage passed. No blockers remain; very long unbroken output relies on the tested wrapping and scroll bounds.

--- a/docs/plans/acp-shell-command-output/task-03-frontend-command-row.md
+++ b/docs/plans/acp-shell-command-output/task-03-frontend-command-row.md
@@ -1,0 +1,45 @@
+---
+id: "03-frontend-command-row"
+title: "Frontend command output row"
+status: done
+wave: 2
+depends_on: ["01-backend-normalization"]
+plan: "plan.md"
+spec: "../../specs/ui/acp-shell-command-output.md"
+---
+
+# Task 03: Frontend Command Output Row
+
+## Acceptance
+
+- The expanded `ToolExecuteMessage` shows live/final combined output, explicit `Exit code N` or `Exit code unavailable`, and truncation state.
+- Exit `0`, nonzero exit, ACP error, and unknown exit use success, failure, failure, and neutral semantics respectively; missing exit is never success.
+- Focused component tests cover the four states without changing chat state or introducing a new API/hook.
+
+## Verification
+
+```bash
+cd apps && pnpm --filter @kandev/web test -- components/task/chat/messages/tool-execute-message.test.tsx
+cd apps/web && pnpm run typecheck
+cd apps && pnpm --filter @kandev/web lint
+```
+
+## Files likely touched
+
+- `apps/web/components/task/chat/types.ts`
+- `apps/web/components/task/chat/messages/tool-execute-message.tsx`
+- `apps/web/components/task/chat/messages/tool-execute-message.test.tsx` (new)
+
+## Dependencies
+
+Task 01 defines the serialized nullable/truncation contract. This task can run in parallel with Task 02 afterward because their file ownership does not overlap.
+
+## Inputs
+
+- Spec scenarios for known success, known failure, unknown exit, live output, and truncation.
+- Existing `ExpandableRow`, `useExpandState`, and `transformPathsInText` patterns in `tool-execute-message.tsx`.
+- Mobile-parity constraints in `apps/web/AGENTS.md`.
+
+## Output contract
+
+Report rendered labels/status rules, tests run, files changed, blockers, and mobile layout risks. Set this task to `done` and update `plan.md` only after targeted tests, typecheck, and lint pass.

--- a/docs/plans/acp-shell-command-output/task-04-e2e-and-verification.md
+++ b/docs/plans/acp-shell-command-output/task-04-e2e-and-verification.md
@@ -20,11 +20,12 @@ spec: "../../specs/ui/acp-shell-command-output.md"
 
 ```bash
 make -C apps/backend fmt
-cd apps/backend && go test ./internal/agentctl/server/adapter/transport/acp
-cd apps && pnpm --filter @kandev/web test -- components/task/chat/messages/tool-execute-message.test.tsx
-cd apps/web && pnpm run typecheck
-cd apps && pnpm --filter @kandev/web lint
-cd apps/web && pnpm e2e:run tests/chat/tool-execute-output.spec.ts tests/chat/mobile-tool-execute-output.spec.ts
+(cd apps/backend && go test ./internal/agentctl/server/adapter/transport/acp)
+(cd apps && pnpm --filter @kandev/web test -- components/task/chat/messages/tool-execute-message.test.tsx)
+(cd apps/web && pnpm run typecheck)
+(cd apps && pnpm --filter @kandev/web lint)
+(cd apps/web && pnpm e2e:run --project=chromium tests/chat/tool-execute-output.spec.ts)
+(cd apps/web && pnpm e2e:run --project=mobile-chrome tests/chat/mobile-tool-execute-output.spec.ts)
 make -C apps/backend test
 make -C apps/backend lint
 ```
@@ -50,3 +51,10 @@ Tasks 02 and 03.
 ## Output contract
 
 Report exact commands and pass/fail results, desktop/mobile projects exercised, failure artifact paths, files changed, blockers, and residual risks. Set this task to `done`, update `plan.md`, and change the spec to `shipped` only when all acceptance criteria pass.
+
+## Completion Report
+
+- Desktop Chromium covered success, failure, unknown exit, transcript expansion, and exact labels; mobile Chrome (Pixel 5) covered wrapping, truncation, exit readability, and horizontal overflow.
+- `make fmt`, generated web metadata, `make typecheck`, `make test`, and `make lint` passed, along with the production Vite build and both targeted Playwright projects.
+- Added the desktop/mobile chat specs and updated the plan, task reports, feature spec index, and ADR index. No failure artifacts or blockers remain.
+- Residual risk is limited to new provider wire shapes and provider-side output omitted before ACP delivery.

--- a/docs/plans/acp-shell-command-output/task-04-e2e-and-verification.md
+++ b/docs/plans/acp-shell-command-output/task-04-e2e-and-verification.md
@@ -24,10 +24,14 @@ make -C apps/backend fmt
 (cd apps && pnpm --filter @kandev/web test -- components/task/chat/messages/tool-execute-message.test.tsx)
 (cd apps/web && pnpm run typecheck)
 (cd apps && pnpm --filter @kandev/web lint)
-(cd apps/web && pnpm e2e:run --project=chromium tests/chat/tool-execute-output.spec.ts)
-(cd apps/web && pnpm e2e:run --project=mobile-chrome tests/chat/mobile-tool-execute-output.spec.ts)
+(cd apps/web && pnpm e2e:run --project chromium tests/chat/tool-execute-output.spec.ts)
+(cd apps/web && pnpm e2e:run --no-build --project mobile-chrome tests/chat/mobile-tool-execute-output.spec.ts)
 make -C apps/backend test
 make -C apps/backend lint
+make fmt
+make typecheck
+make test
+make lint
 ```
 
 ## Files likely touched
@@ -55,6 +59,6 @@ Report exact commands and pass/fail results, desktop/mobile projects exercised, 
 ## Completion Report
 
 - Desktop Chromium covered success, failure, unknown exit, transcript expansion, and exact labels; mobile Chrome (Pixel 5) covered wrapping, truncation, exit readability, and horizontal overflow.
-- `make fmt`, generated web metadata, `make typecheck`, `make test`, and `make lint` passed, along with the production Vite build and both targeted Playwright projects.
+- The repository-root `make fmt`, `make typecheck`, `make test`, and `make lint` commands passed, along with generated web metadata, the production Vite build, and both targeted Playwright projects.
 - Added the desktop/mobile chat specs and updated the plan, task reports, feature spec index, and ADR index. No failure artifacts or blockers remain.
 - Residual risk is limited to new provider wire shapes and provider-side output omitted before ACP delivery.

--- a/docs/plans/acp-shell-command-output/task-04-e2e-and-verification.md
+++ b/docs/plans/acp-shell-command-output/task-04-e2e-and-verification.md
@@ -1,0 +1,52 @@
+---
+id: "04-e2e-and-verification"
+title: "Command output E2E verification"
+status: done
+wave: 3
+depends_on: ["02-acp-live-updates", "03-frontend-command-row"]
+plan: "plan.md"
+spec: "../../specs/ui/acp-shell-command-output.md"
+---
+
+# Task 04: Command Output E2E Verification
+
+## Acceptance
+
+- Desktop E2E proves persisted success, failure, and unknown-exit command rows expand to the expected output and exact exit labels.
+- Mobile E2E proves wrapped/truncated output and exit status remain readable without overlap or page-level horizontal overflow.
+- Targeted E2E, backend tests/lint, frontend tests/typecheck/lint, and formatting complete successfully, with failures reported rather than hidden.
+
+## Verification
+
+```bash
+make -C apps/backend fmt
+cd apps/backend && go test ./internal/agentctl/server/adapter/transport/acp
+cd apps && pnpm --filter @kandev/web test -- components/task/chat/messages/tool-execute-message.test.tsx
+cd apps/web && pnpm run typecheck
+cd apps && pnpm --filter @kandev/web lint
+cd apps/web && pnpm e2e:run tests/chat/tool-execute-output.spec.ts tests/chat/mobile-tool-execute-output.spec.ts
+make -C apps/backend test
+make -C apps/backend lint
+```
+
+## Files likely touched
+
+- `apps/web/e2e/tests/chat/tool-execute-output.spec.ts` (new)
+- `apps/web/e2e/tests/chat/mobile-tool-execute-output.spec.ts` (new)
+- `apps/web/e2e/pages/session-page.ts` only if a small reusable command-row helper is justified
+- `docs/specs/ui/acp-shell-command-output.md` only if implementation reveals a contract correction
+- `docs/plans/acp-shell-command-output/plan.md`
+
+## Dependencies
+
+Tasks 02 and 03.
+
+## Inputs
+
+- All spec scenarios.
+- Existing `seedSessionMessage` pattern in `mobile-repeated-tool-activity.spec.ts`.
+- Existing desktop/mobile Playwright projects and active-chat scoping in `SessionPage`.
+
+## Output contract
+
+Report exact commands and pass/fail results, desktop/mobile projects exercised, failure artifact paths, files changed, blockers, and residual risks. Set this task to `done`, update `plan.md`, and change the spec to `shipped` only when all acceptance criteria pass.

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -96,6 +96,7 @@ Subscription quota tracking and per-agent cheap-model profile routing.
 | [ci-pr-automation](ui/ci-pr-automation.md) | draft |
 | [comment-markdown](ui/comment-markdown.md) | shipped |
 | [empty-turn-notice](ui/empty-turn-notice.md) | shipped |
+| [acp-shell-command-output](ui/acp-shell-command-output.md) | shipped |
 | [slash-command-composer](ui/slash-command-composer.md) | shipped |
 
 ## system-page/ — operational diagnostics & maintenance UI

--- a/docs/specs/ui/acp-shell-command-output.md
+++ b/docs/specs/ui/acp-shell-command-output.md
@@ -1,0 +1,92 @@
+---
+status: shipped
+created: 2026-07-14
+owner: cfl
+---
+
+# ACP Shell Command Output
+
+## Why
+
+Agent chat shows that a shell command ran, but ACP agents encode terminal output and exit status in different fields. Users need the expandable command row to preserve the actual terminal output and distinguish success, failure, and an unavailable exit status without knowing which agent produced the command.
+
+## What
+
+- Shell tool calls from Codex, Claude, Auggie, and OpenCode normalize into the existing `shell_exec` message payload.
+- Output received while a command is running is persisted on the existing tool message and appears in its expanded row before completion.
+- Kandev advertises `_meta.terminal_output: true` in ACP client capabilities so agents such as Claude can return structured terminal output and exit metadata.
+- Provider payloads normalize as follows:
+  - Codex: append `_meta.terminal_output_delta.data`; on completion prefer `rawOutput.formatted_output` as the authoritative combined output and `_meta.terminal_exit.exit_code` or `rawOutput.exit_code` as the exit status.
+  - Claude: replace the displayed output with `_meta.terminal_output.data` and read `_meta.terminal_exit.exit_code`. Plain final `rawOutput` remains a fallback for agents or versions that do not emit the extension.
+  - OpenCode: replace the displayed output from cumulative text `content`; on completion prefer `rawOutput.output` and read `rawOutput.metadata.exit`.
+  - Auggie: parse `rawOutput.output`, including its `<output>`, `<stderr>`, and `<return-code>` fields.
+- A final authoritative output replaces the accumulated live output rather than appending it a second time. If a final update omits output, the accumulated live output remains visible.
+- Exit-code precedence is `_meta.terminal_exit.exit_code`, provider-native structured exit fields, then Auggie's `<return-code>`. An absent or unparseable exit status remains unknown; it MUST NOT become exit `0`.
+- Terminal text is treated as a combined stream unless an agent explicitly supplies separate stdout and stderr fields. Kandev does not infer stream separation from line ordering.
+- Each normalized output text field is bounded to 256 KiB. When a field exceeds the bound, Kandev retains its most recent valid UTF-8 content and sets `truncated: true`.
+- The existing expandable command row shows combined output in a scrollable monospace region. On terminal completion it visibly shows `Exit code N` when known, or `Exit code unavailable` when unknown. Unknown is neutral, not success or failure.
+- A known exit code of `0` is success. A known nonzero exit code is failure even when an agent reports ACP status `completed`. ACP `failed`/`error` remains failure independently of whether an exit code is available.
+- Desktop and mobile chat expose the same output, truncation indication, and exit-status semantics.
+
+## Data model
+
+No table or migration is added. The existing persisted tool-message metadata carries:
+
+```text
+metadata.normalized.shell_exec.output
+  exit_code  integer  optional/nullable; absent or null means unknown
+  stdout     string   optional; combined terminal output unless streams are explicit
+  stderr     string   optional; only populated from an explicit stderr field
+  truncated  boolean  optional; true when either stored text field hit its bound
+```
+
+An explicit `exit_code: 0` is distinct from an absent or null exit code.
+
+## API surface
+
+This feature extends the existing `NormalizedPayload.shell_exec` JSON contract carried by agent stream events and task messages. It adds no HTTP route, WebSocket event type, or frontend store slice.
+
+ACP initialization includes:
+
+```json
+{
+  "clientCapabilities": {
+    "_meta": { "terminal_output": true }
+  }
+}
+```
+
+The extension is additive: agents that ignore it continue through their current `rawOutput` or `content` fallback.
+
+## Failure modes
+
+- Malformed provider output is retained as combined terminal text when possible; malformed exit metadata remains unknown.
+- A statusless update with recognized terminal output is treated as an in-progress tool update so it is not dropped by the existing persistence path.
+- Repeated cumulative output replaces the previous cumulative value; delta output appends once. Final aggregate output replaces either form and cannot duplicate the visible text.
+- Output exceeding the bound is truncated deterministically and remains valid UTF-8.
+- Unknown exit status never renders a success check or a failure cross solely because the value is absent.
+
+## Persistence guarantees
+
+Live output updates use the existing tool-message update path and are persisted with message metadata. The latest bounded output and final exit status survive reloads. In-memory per-tool accumulation is discarded when the tool reaches a terminal state, the prompt is swept, or the adapter stops.
+
+## Scenarios
+
+- **GIVEN** Codex emits two `terminal_output_delta` updates followed by `formatted_output` and exit `4`, **WHEN** the command row updates, **THEN** output appears during execution, the final text contains each line once, and completion shows `Exit code 4` as failure.
+- **GIVEN** Claude receives the advertised terminal-output capability and emits `terminal_output` followed by `terminal_exit`, **WHEN** the command completes, **THEN** its output is visible and the exact exit code is shown.
+- **GIVEN** OpenCode emits cumulative `content` values followed by `rawOutput.metadata.exit: 7` while ACP status is `completed`, **WHEN** the command completes, **THEN** the latest output is not duplicated and the row shows `Exit code 7` as failure.
+- **GIVEN** Auggie returns XML-like output with `<return-code>0</return-code>`, **WHEN** the command completes, **THEN** the parsed output is visible and the row shows `Exit code 0` as success.
+- **GIVEN** an agent returns plain output with no structured or embedded exit status, **WHEN** the command completes, **THEN** the output is visible and the row shows `Exit code unavailable` with neutral status.
+- **GIVEN** terminal output exceeds 256 KiB, **WHEN** live and final updates are normalized, **THEN** stored output remains within the bound, keeps the newest valid UTF-8 text, and the expanded row indicates truncation.
+- **GIVEN** a persisted completed shell message, **WHEN** chat is opened on desktop or mobile and the row is expanded, **THEN** its output and exit status are readable without overlapping adjacent chat content.
+
+## Out of scope
+
+- Reconstructing separate stdout and stderr streams when the agent sends only combined output.
+- Fixing provider-side output loss before an ACP frame reaches Kandev.
+- Adding a terminal emulator, ANSI replay, command re-run action, download action, or searchable output viewer to chat.
+- Changing non-ACP adapters or the standalone terminal panel.
+
+## Implementation plan
+
+See [the implementation plan](../../plans/acp-shell-command-output/plan.md).

--- a/docs/specs/ui/acp-shell-command-output.md
+++ b/docs/specs/ui/acp-shell-command-output.md
@@ -20,12 +20,13 @@ Agent chat shows that a shell command ran, but ACP agents encode terminal output
   - Claude: replace the displayed output with `_meta.terminal_output.data` and read `_meta.terminal_exit.exit_code`. Plain final `rawOutput` remains a fallback for agents or versions that do not emit the extension.
   - OpenCode: replace the displayed output from cumulative text `content`; on completion prefer `rawOutput.output` and read `rawOutput.metadata.exit`.
   - Auggie: parse `rawOutput.output`, including its `<output>`, `<stderr>`, and `<return-code>` fields.
-- A final authoritative output replaces the accumulated live output rather than appending it a second time. If a final update omits output, the accumulated live output remains visible.
+- A final authoritative output replaces the accumulated live output rather than appending it a second time. If a final update omits output or one explicit stream, the accumulated value for each omitted field remains visible.
 - Exit-code precedence is `_meta.terminal_exit.exit_code`, provider-native structured exit fields, then Auggie's `<return-code>`. An absent or unparseable exit status remains unknown; it MUST NOT become exit `0`.
 - Terminal text is treated as a combined stream unless an agent explicitly supplies separate stdout and stderr fields. Kandev does not infer stream separation from line ordering.
 - Each normalized output text field is bounded to 256 KiB. When a field exceeds the bound, Kandev retains its most recent valid UTF-8 content and sets `truncated: true`.
 - The existing expandable command row shows combined output in a scrollable monospace region. On terminal completion it visibly shows `Exit code N` when known, or `Exit code unavailable` when unknown. Unknown is neutral, not success or failure.
 - A known exit code of `0` is success. A known nonzero exit code is failure even when an agent reports ACP status `completed`. ACP `failed`/`error` remains failure independently of whether an exit code is available.
+- ACP cancellation is terminal and preserves the transcript while showing `Exit code unavailable` when no exit was reported.
 - Desktop and mobile chat expose the same output, truncation indication, and exit-status semantics.
 
 ## Data model
@@ -34,13 +35,13 @@ No table or migration is added. The existing persisted tool-message metadata car
 
 ```text
 metadata.normalized.shell_exec.output
-  exit_code  integer  optional/nullable; absent or null means unknown
+  exit_code  integer  optional; absent means unknown
   stdout     string   optional; combined terminal output unless streams are explicit
   stderr     string   optional; only populated from an explicit stderr field
   truncated  boolean  optional; true when either stored text field hit its bound
 ```
 
-An explicit `exit_code: 0` is distinct from an absent or null exit code.
+An explicit `exit_code: 0` is distinct from an absent exit code.
 
 ## API surface
 
@@ -65,6 +66,7 @@ The extension is additive: agents that ignore it continue through their current 
 - Repeated cumulative output replaces the previous cumulative value; delta output appends once. Final aggregate output replaces either form and cannot duplicate the visible text.
 - Output exceeding the bound is truncated deterministically and remains valid UTF-8.
 - Unknown exit status never renders a success check or a failure cross solely because the value is absent.
+- ACP `failed` and `cancelled` statuses terminate active-call tracking even when no exit code is available.
 
 ## Persistence guarantees
 
@@ -77,6 +79,7 @@ Live output updates use the existing tool-message update path and are persisted 
 - **GIVEN** OpenCode emits cumulative `content` values followed by `rawOutput.metadata.exit: 7` while ACP status is `completed`, **WHEN** the command completes, **THEN** the latest output is not duplicated and the row shows `Exit code 7` as failure.
 - **GIVEN** Auggie returns XML-like output with `<return-code>0</return-code>`, **WHEN** the command completes, **THEN** the parsed output is visible and the row shows `Exit code 0` as success.
 - **GIVEN** an agent returns plain output with no structured or embedded exit status, **WHEN** the command completes, **THEN** the output is visible and the row shows `Exit code unavailable` with neutral status.
+- **GIVEN** a command is cancelled without an exit code, **WHEN** its terminal update is persisted, **THEN** the transcript remains expandable and shows `Exit code unavailable`.
 - **GIVEN** terminal output exceeds 256 KiB, **WHEN** live and final updates are normalized, **THEN** stored output remains within the bound, keeps the newest valid UTF-8 text, and the expanded row indicates truncation.
 - **GIVEN** a persisted completed shell message, **WHEN** chat is opened on desktop or mobile and the row is expanded, **THEN** its output and exit status are readable without overlapping adjacent chat content.
 


### PR DESCRIPTION
ACP agents expose shell output and exit status in different wire shapes, which prevented chat from reliably showing command results. Normalize those events at the ACP adapter boundary so Codex, Claude, Auggie, and OpenCode command transcripts render consistently in chat.

## Important Changes

- Normalize cumulative, delta, and final ACP shell output into bounded stream payloads with nullable exit codes and truncation metadata.
- Advertise terminal output support and preserve live command output through completion, failure, and cancellation updates.
- Render expandable command transcripts with exit status on desktop and mobile, backed by component and Playwright coverage.
- Record the adapter-boundary decision, shipped feature spec, and completed implementation plan.

## Validation

- `make fmt`
- `node apps/web/scripts/generate-release-notes.mjs`
- `node apps/web/scripts/generate-changelog.mjs`
- `make typecheck`
- `make test`
- `make lint`
- Production Vite build
- Playwright command-output specs in desktop Chromium and Pixel 5 mobile viewports

## Possible Improvements

Low risk: future ACP providers may introduce additional output shapes that need explicit normalization fixtures.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1684?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->