### PR TITLE
fix(deps): bump @playwright/test to ^1.61.1 to fix install hang on Node 26

### DIFF
--- a/.github/docker/ci-base/Dockerfile
+++ b/.github/docker/ci-base/Dockerfile
@@ -13,7 +13,7 @@
 #
 # Pinned versions (keep in sync with apps/backend/go.mod, apps/web/package.json,
 # and the matching workflow inputs):
-#   - Playwright base : v1.58.2-noble  (matches @playwright/test ^1.58.2)
+#   - Playwright base : v1.61.1-noble  (matches @playwright/test ^1.61.1)
 #   - Go              : 1.26.0         (matches apps/backend/go.mod)
 #   - Node            : 24             (matches actions/setup-node value)
 #   - pnpm            : 9.15.9         (matches pnpm/action-setup value)
@@ -24,7 +24,7 @@
 # =============================================================================
 # Stage 1: runtime — Playwright + Node + pnpm + Docker CLI (no Go)
 # =============================================================================
-FROM mcr.microsoft.com/playwright:v1.58.2-noble AS runtime
+FROM mcr.microsoft.com/playwright:v1.61.1-noble AS runtime
 
 ENV DEBIAN_FRONTEND=noninteractive \
     PNPM_HOME=/pnpm \

--- a/apps/pnpm-lock.yaml
+++ b/apps/pnpm-lock.yaml
@@ -496,8 +496,8 @@ importers:
         specifier: ^9.39.2
         version: 9.39.2
       '@playwright/test':
-        specifier: ^1.58.2
-        version: 1.58.2
+        specifier: ^1.61.1
+        version: 1.61.1
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.1.18
@@ -1815,8 +1815,8 @@ packages:
     resolution: {integrity: sha512-1j/H/fECBuc9dEvntdWI+l435HZapw+RCJTlqCA6BboQ5TjlnE005j/ROWutXIs8aq5OAc82JI2Kwk4A1WWBgw==}
     engines: {vscode: ^1.0.0}
 
-  '@playwright/test@1.58.2':
-    resolution: {integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==}
+  '@playwright/test@1.61.1':
+    resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -4638,7 +4638,7 @@ packages:
   git-raw-commits@4.0.0:
     resolution: {integrity: sha512-ICsMM1Wk8xSGMowkOmPrzo2Fgmfo4bMHLNX6ytHjajRJUqvHOw/TFapQ+QG75c3X/tTDDhOSRPGC52dDbNM8FQ==}
     engines: {node: '>=16'}
-    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   glob-parent@5.1.2:
@@ -5715,13 +5715,13 @@ packages:
   platform@1.3.6:
     resolution: {integrity: sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==}
 
-  playwright-core@1.58.2:
-    resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.58.2:
-    resolution: {integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==}
+  playwright@1.61.1:
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -8040,9 +8040,9 @@ snapshots:
 
   '@pierre/theme@0.0.28': {}
 
-  '@playwright/test@1.58.2':
+  '@playwright/test@1.61.1':
     dependencies:
-      playwright: 1.58.2
+      playwright: 1.61.1
 
   '@protobufjs/aspromise@1.1.2': {}
 
@@ -12185,11 +12185,11 @@ snapshots:
 
   platform@1.3.6: {}
 
-  playwright-core@1.58.2: {}
+  playwright-core@1.61.1: {}
 
-  playwright@1.58.2:
+  playwright@1.61.1:
     dependencies:
-      playwright-core: 1.58.2
+      playwright-core: 1.61.1
     optionalDependencies:
       fsevents: 2.3.2
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -125,7 +125,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.2",
-    "@playwright/test": "^1.58.2",
+    "@playwright/test": "^1.61.1",
     "@tailwindcss/postcss": "^4",
     "@testing-library/react": "^16.3.2",
     "@types/diff": "^8.0.0",


### PR DESCRIPTION
## Problem

`make start` / `make start-debug` stalled silently and never launched the server. The hang was in `make install-web`, whose final step runs `playwright install chromium`: the Chromium archive downloaded successfully but **extraction deadlocked forever** (`oopDownloadBrowserMain.js` frozen at "extracting archive", CPU 0%). Because that step never returned, startup never reached the "Starting Server" phase.

## Root cause

A Node.js / Playwright incompatibility. Node 26 (and Node >= 24.16.0) has a regression in ZIP extraction that hangs Playwright's browser installer. The repo pinned `@playwright/test@^1.58.2`, which is affected. Upstream fixed this in Playwright **1.60.0** by replacing the zip-extraction implementation.

- microsoft/playwright#40724
- nodejs/node#63487

## Fix

Bump `@playwright/test` to `^1.61.1` (via `pnpm --filter @kandev/web add -D`). This resolves the extraction hang independent of the Node version in use.

## Verification

- The previously-hanging `playwright install chromium` now extracts instantly.
- `make start` runs end-to-end; backend comes up at `http://localhost:38429`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1685?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->