### PR TITLE
fix(web): soften deferred clarification notice

### DIFF
--- a/apps/web/components/task/chat/clarification-input-overlay.tsx
+++ b/apps/web/components/task/chat/clarification-input-overlay.tsx
@@ -123,7 +123,7 @@ function ClarificationCard(props: CardProps) {
       {showAgentDisconnected && (
         <div
           data-testid="clarification-deferred-notice"
-          className="mt-2 text-xs text-amber-500/90 flex items-center gap-1.5"
+          className="mt-2 flex items-center gap-1.5 text-xs text-slate-600 dark:text-slate-400"
         >
           <IconInfoCircle className="h-3.5 w-3.5 flex-shrink-0" />
           The agent has moved on. Your response will be sent as a new message.


### PR DESCRIPTION
Reframes the deferred clarification notice as an informational state, reducing the alarm caused by its yellow warning treatment.

## Validation

- `make fmt`
- `make typecheck`
- `make test`
- `make lint`
- `pnpm e2e:run tests/chat/clarification.spec.ts -- --grep "timeout detaches clarification but keeps overlay for deferred answer"` *(blocked before launch: the E2E runtime image provides Playwright 1.58.2 while the workspace requires 1.61.1)*

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1690?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->