### PR TITLE
fix(web): keep chat readable after right-pane resize (#1682)

### DIFF
--- a/apps/web/components/task/dockview-layout-setup.ts
+++ b/apps/web/components/task/dockview-layout-setup.ts
@@ -54,16 +54,39 @@ let enforcing = false;
  *  reverted to the previous target on every intermediate layout change. */
 let sashDragging = false;
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function restoreColumnToTarget(sv: any, idx: number, target: number | undefined): void {
+function restoreColumnToTarget(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  sv: any,
+  idx: number,
+  target: number | undefined,
+  maximumWidth: number,
+): void {
   if (target === undefined) return;
+  const reachableTarget = Math.min(target, maximumWidth);
   const cur = sv.getViewSize(idx);
-  if (Math.abs(cur - target) <= 1) return;
+  if (Math.abs(cur - reachableTarget) <= 1) return;
   try {
-    sv.resizeView(idx, target);
+    sv.resizeView(idx, reachableTarget);
   } catch {
     /* dockview rejects unreachable sizes — ignore */
   }
+}
+
+/** Keep right-column constraints tied to Dockview's measured container, not
+ * `window.innerWidth`. The app sidebar sits outside Dockview, so the browser
+ * viewport can materially overstate the space available to chat + files. */
+function applyRightConstraints(api: DockviewReadyEvent["api"]): number {
+  const measuredWidth = api.width > 0 ? api.width : undefined;
+  const maximumWidth = computeRightMaxPx(measuredWidth);
+  for (const gid of [RIGHT_TOP_GROUP, RIGHT_BOTTOM_GROUP]) {
+    const group = api.groups.find((candidate) => candidate.id === gid);
+    if (!group) continue;
+    group.api.setConstraints({
+      maximumWidth,
+      minimumWidth: LAYOUT_PINNED_MIN_PX,
+    });
+  }
+  return maximumWidth;
 }
 
 function enforcePinnedTargets(api: DockviewReadyEvent["api"]): void {
@@ -76,7 +99,8 @@ function enforcePinnedTargets(api: DockviewReadyEvent["api"]): void {
   enforcing = true;
   try {
     if (store.rightPanelsVisible) {
-      restoreColumnToTarget(sv, sv.length - 1, getPinnedTarget("right"));
+      const maximumWidth = applyRightConstraints(api);
+      restoreColumnToTarget(sv, sv.length - 1, getPinnedTarget("right"), maximumWidth);
     }
   } finally {
     enforcing = false;
@@ -89,17 +113,7 @@ function setLooseConstraints(api: DockviewReadyEvent["api"]): void {
   if (store.isRestoringLayout) return;
   if (api.hasMaximizedGroup() || store.preMaximizeLayout !== null) return;
 
-  if (store.rightPanelsVisible) {
-    for (const gid of [RIGHT_TOP_GROUP, RIGHT_BOTTOM_GROUP]) {
-      const group = api.groups.find((g) => g.id === gid);
-      if (group) {
-        group.api.setConstraints({
-          maximumWidth: computeRightMaxPx(),
-          minimumWidth: LAYOUT_PINNED_MIN_PX,
-        });
-      }
-    }
-  }
+  if (store.rightPanelsVisible) applyRightConstraints(api);
 }
 
 /**
@@ -216,9 +230,10 @@ export function setupContainerResizeSync(api: DockviewReadyEvent["api"]): () => 
     if (w <= 0 || h <= 0) return;
     if (w === api.width && h === api.height) return;
     api.layout(w, h);
-    // `enforcePinnedTargets` (wired in `setupSashDragCapToggle`) restores
-    // sidebar/right to their target widths via `onDidLayoutChange`, so we
-    // don't need to redo that here.
+    // Dockview's direct `api.layout` path does not consistently emit
+    // `onDidLayoutChange`, so enforce immediately after the proportional
+    // rebalance instead of relying on the subscription above.
+    enforcePinnedTargets(api);
   });
   ro.observe(parent);
   return () => ro.disconnect();

--- a/apps/web/components/task/dockview-layout-setup.ts
+++ b/apps/web/components/task/dockview-layout-setup.ts
@@ -77,7 +77,9 @@ function restoreColumnToTarget(
  * viewport can materially overstate the space available to chat + files. */
 function applyRightConstraints(api: DockviewReadyEvent["api"]): number {
   const measuredWidth = api.width > 0 ? api.width : undefined;
-  const maximumWidth = computeRightMaxPx(measuredWidth);
+  const sv = getRootSplitview(api);
+  const sidebarWidth = sv?.length >= 3 ? sv.getViewSize(0) : 0;
+  const maximumWidth = computeRightMaxPx(measuredWidth, sidebarWidth);
   for (const gid of [RIGHT_TOP_GROUP, RIGHT_BOTTOM_GROUP]) {
     const group = api.groups.find((candidate) => candidate.id === gid);
     if (!group) continue;

--- a/apps/web/e2e/helpers/dockview-resize.ts
+++ b/apps/web/e2e/helpers/dockview-resize.ts
@@ -1,4 +1,5 @@
 import { expect, type Page } from "@playwright/test";
+import { computeRightMaxPx, computeSidebarMaxPx } from "../../lib/state/layout-manager/caps";
 import type { SeedData } from "../fixtures/test-base";
 import type { ApiClient } from "../helpers/api-client";
 import { SessionPage } from "../pages/session-page";
@@ -150,21 +151,20 @@ export async function resizeColumnViaSplitview(
   // to the same runtime cap, NOT unlimited — so cap-enforcement assertions
   // still work end-to-end. Production uses Dockview's measured width because
   // the app sidebar is outside the workbench.
-  const availableWidth = await page.evaluate(() => {
+  const { availableWidth, sidebarWidth } = await page.evaluate(() => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const api = (window as any).__dockviewApi__;
-    return api?.width ?? document.querySelector<HTMLElement>(".dv-dockview")?.clientWidth ?? 1440;
+    const sv = api?.component?.gridview?.root?.splitview;
+    return {
+      availableWidth:
+        api?.width ?? document.querySelector<HTMLElement>(".dv-dockview")?.clientWidth ?? 1440,
+      sidebarWidth: api?.getPanel("sidebar") && sv?.length >= 3 ? sv.getViewSize(0) : 0,
+    };
   });
-  // Mirror `caps.ts` exactly: the bound clamps the ratio-based cap to
-  // `availableWidth - reservedWidth` so the other columns retain usable room.
-  // Without this the test helper diverges from production on narrow viewports.
-  const PINNED_MIN = 180;
-  const reservedWidth = column === "sidebar" ? 300 : 480;
-  const rawCap =
+  const runtimeCap =
     column === "sidebar"
-      ? Math.max(350, Math.round(availableWidth * 0.3))
-      : Math.max(800, Math.round(availableWidth * 0.7));
-  const runtimeCap = Math.max(PINNED_MIN, Math.min(rawCap, availableWidth - reservedWidth));
+      ? computeSidebarMaxPx(availableWidth)
+      : computeRightMaxPx(availableWidth, sidebarWidth);
   await loosenPinnedConstraints(page, column, runtimeCap);
   const result = await page.evaluate(
     ({ col, target }) => {

--- a/apps/web/e2e/helpers/dockview-resize.ts
+++ b/apps/web/e2e/helpers/dockview-resize.ts
@@ -146,23 +146,25 @@ export async function resizeColumnViaSplitview(
   // Production locks pinned-column maxWidth to the current width to prevent
   // dockview's proportional rebalance from growing them. Real users bypass
   // that lock via the sash-drag handler (mousedown widens the cap to the
-  // runtime viewport-proportional cap). Tests simulate the same widening —
+  // runtime container-proportional cap). Tests simulate the same widening —
   // to the same runtime cap, NOT unlimited — so cap-enforcement assertions
-  // still work end-to-end. The bound is computed in Node and passed in so
-  // the browser-side script stays simple enough to satisfy the linter.
-  const viewport = page.viewportSize();
-  const vw = viewport?.width ?? 1440;
-  // Mirror `caps.ts` exactly: `viewportBound(value, vw)` clamps the ratio-based
-  // cap to `vw - VIEWPORT_RESERVE_PX (300)` so the center column always has
-  // room. Without this the test helper diverges from production on narrow
-  // viewports (e.g. vw=900 → sidebar cap would be 350 here but 300 in app).
+  // still work end-to-end. Production uses Dockview's measured width because
+  // the app sidebar is outside the workbench.
+  const availableWidth = await page.evaluate(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const api = (window as any).__dockviewApi__;
+    return api?.width ?? document.querySelector<HTMLElement>(".dv-dockview")?.clientWidth ?? 1440;
+  });
+  // Mirror `caps.ts` exactly: the bound clamps the ratio-based cap to
+  // `availableWidth - reservedWidth` so the other columns retain usable room.
+  // Without this the test helper diverges from production on narrow viewports.
   const PINNED_MIN = 180;
-  const VIEWPORT_RESERVE = 300;
+  const reservedWidth = column === "sidebar" ? 300 : 480;
   const rawCap =
     column === "sidebar"
-      ? Math.max(350, Math.round(vw * 0.3))
-      : Math.max(800, Math.round(vw * 0.7));
-  const runtimeCap = Math.max(PINNED_MIN, Math.min(rawCap, vw - VIEWPORT_RESERVE));
+      ? Math.max(350, Math.round(availableWidth * 0.3))
+      : Math.max(800, Math.round(availableWidth * 0.7));
+  const runtimeCap = Math.max(PINNED_MIN, Math.min(rawCap, availableWidth - reservedWidth));
   await loosenPinnedConstraints(page, column, runtimeCap);
   const result = await page.evaluate(
     ({ col, target }) => {

--- a/apps/web/e2e/tests/layout/pane-resize-right.spec.ts
+++ b/apps/web/e2e/tests/layout/pane-resize-right.spec.ts
@@ -9,21 +9,27 @@ import {
 import { KanbanPage } from "../../pages/kanban-page";
 import { SessionPage } from "../../pages/session-page";
 
-test.describe("Right pane resize — viewport-proportional cap", () => {
+test.describe("Right pane resize — container-proportional cap", () => {
   test("resizes past the old 450px hard cap", async ({ testPage, apiClient, seedData }) => {
     await openWideTask(testPage, apiClient, seedData, "Right resize past old cap");
     const actual = await resizeColumnViaSplitview(testPage, "right", 700);
     expect(actual).toBeGreaterThan(600);
   });
 
-  test("respects the viewport-proportional cap (max(800, vw*0.7))", async ({
+  test("respects the container cap and center comfort width", async ({
     testPage,
     apiClient,
     seedData,
   }) => {
     await openWideTask(testPage, apiClient, seedData, "Right cap respect");
     const actual = await resizeColumnViaSplitview(testPage, "right", 5000);
-    const cap = Math.round(WIDE_VIEWPORT.width * 0.7);
+    const dockviewBox = await testPage.locator(".dv-dockview").boundingBox();
+    expect(dockviewBox).not.toBeNull();
+    const availableWidth = dockviewBox?.width ?? 0;
+    const cap = Math.max(
+      180,
+      Math.min(Math.max(800, Math.round(availableWidth * 0.7)), availableWidth - 480),
+    );
     expect(actual).toBeLessThanOrEqual(cap + 10);
   });
 
@@ -53,12 +59,20 @@ test.describe("Right pane resize — viewport-proportional cap", () => {
     expect(wideWidth).toBeGreaterThan(700);
 
     await testPage.setViewportSize({ width: 1100, height: 800 });
-    // Allow ResizeObserver tick + applyDynamicConstraints to fire, then attempt
-    // a re-resize that would exceed the new cap.
-    await testPage.waitForTimeout(300);
-    const narrowWidth = await resizeColumnViaSplitview(testPage, "right", 1500);
+    // Allow the container ResizeObserver and pinned-target enforcement to
+    // settle. Do not call the resize helper here: it reapplies constraints and
+    // would mask a failure to update them automatically on viewport changes.
+    await testPage.waitForTimeout(500);
 
-    const newCap = Math.max(800, Math.round(1100 * 0.7));
+    const dockviewBox = await testPage.locator(".dv-dockview").boundingBox();
+    expect(dockviewBox).not.toBeNull();
+    const narrowWidth = await getDockviewGroupWidth(testPage, "files");
+    const centerComfortWidth = 480;
+    const pinnedMinimumWidth = 180;
+    const newCap = Math.max(
+      pinnedMinimumWidth,
+      Math.round((dockviewBox?.width ?? 0) - centerComfortWidth),
+    );
     expect(narrowWidth).toBeLessThanOrEqual(newCap + 10);
   });
 });

--- a/apps/web/e2e/tests/layout/pane-resize-right.spec.ts
+++ b/apps/web/e2e/tests/layout/pane-resize-right.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "../../fixtures/test-base";
+import { computeRightMaxPx } from "../../../lib/state/layout-manager/caps";
 import {
   WIDE_VIEWPORT,
   openWideTask,
@@ -26,10 +27,8 @@ test.describe("Right pane resize — container-proportional cap", () => {
     const dockviewBox = await testPage.locator(".dv-dockview").boundingBox();
     expect(dockviewBox).not.toBeNull();
     const availableWidth = dockviewBox?.width ?? 0;
-    const cap = Math.max(
-      180,
-      Math.min(Math.max(800, Math.round(availableWidth * 0.7)), availableWidth - 480),
-    );
+    const sidebarWidth = await getDockviewGroupWidth(testPage, "sidebar").catch(() => 0);
+    const cap = computeRightMaxPx(availableWidth, sidebarWidth);
     expect(actual).toBeLessThanOrEqual(cap + 10);
   });
 
@@ -67,12 +66,8 @@ test.describe("Right pane resize — container-proportional cap", () => {
     const dockviewBox = await testPage.locator(".dv-dockview").boundingBox();
     expect(dockviewBox).not.toBeNull();
     const narrowWidth = await getDockviewGroupWidth(testPage, "files");
-    const centerComfortWidth = 480;
-    const pinnedMinimumWidth = 180;
-    const newCap = Math.max(
-      pinnedMinimumWidth,
-      Math.round((dockviewBox?.width ?? 0) - centerComfortWidth),
-    );
+    const sidebarWidth = await getDockviewGroupWidth(testPage, "sidebar").catch(() => 0);
+    const newCap = computeRightMaxPx(dockviewBox?.width ?? 0, sidebarWidth);
     expect(narrowWidth).toBeLessThanOrEqual(newCap + 10);
   });
 });

--- a/apps/web/lib/state/dockview-layout-builders-fixups.test.ts
+++ b/apps/web/lib/state/dockview-layout-builders-fixups.test.ts
@@ -163,7 +163,7 @@ describe("applyLayoutFixups — pinned target capture", () => {
     applyLayoutFixups(api);
 
     expect(computeSidebarMaxPx).toHaveBeenCalledWith(1470);
-    expect(computeRightMaxPx).toHaveBeenCalledWith(1470);
+    expect(computeRightMaxPx).toHaveBeenCalledWith(1470, 350);
   });
 
   it("records the side-column target for a 3-column preset without RIGHT_TOP_GROUP", () => {

--- a/apps/web/lib/state/dockview-layout-builders.ts
+++ b/apps/web/lib/state/dockview-layout-builders.ts
@@ -29,6 +29,11 @@ function layoutWidth(api: DockviewApi): number | undefined {
   return api.width > 0 ? api.width : undefined;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function visibleSidebarWidth(sv: any): number {
+  return sv?.length >= 3 ? sv.getViewSize(0) : 0;
+}
+
 /** Best-effort caller chain for the fixups-capture debug log: pull the first
  *  few stack frames above `applyLayoutFixups` so we can see WHICH layout path
  *  (env-switch / restore / custom-layout / maximize) recorded a given target.
@@ -172,7 +177,7 @@ function captureRightTarget(api: DockviewApi, sv: any, savedRightWidth?: number)
   // Use the measured grid width, not the window.innerWidth fallback (see
   // captureSidebarTarget).
   const measuredWidth = layoutWidth(api);
-  const rightCap = computeRightMaxPx(measuredWidth);
+  const rightCap = computeRightMaxPx(measuredWidth, visibleSidebarWidth(sv));
   for (const gid of [RIGHT_TOP_GROUP, RIGHT_BOTTOM_GROUP]) {
     const group = api.groups.find((g) => g.id === gid);
     if (group) {
@@ -235,7 +240,7 @@ function logFixupsCapture(api: DockviewApi, sv: any): void {
   debugWidths(
     `fixups-capture caller=${captureCallerChain()} apiW=${api.width} innerW=${innerW} ` +
       `cols=${sv?.length ?? 0} sidebarCap=${Math.round(sidebarCap)} liveSidebar=${r(liveSidebar)} ` +
-      `rightCap=${Math.round(computeRightMaxPx(w))} liveRight=${r(liveRight)} ` +
+      `rightCap=${Math.round(computeRightMaxPx(w, visibleSidebarWidth(sv)))} liveRight=${r(liveRight)} ` +
       `sidebarOverCap=${typeof liveSidebar === "number" && liveSidebar > sidebarCap + 1}`,
   );
 }

--- a/apps/web/lib/state/layout-manager/applier.ts
+++ b/apps/web/lib/state/layout-manager/applier.ts
@@ -185,7 +185,8 @@ function configureRightPinned(
     if (col.id === "sidebar" || !col.pinned) continue;
     // Same rationale as `configureSidebarPinned`: derive the cap from the
     // measured dockview width, not `window.innerWidth`.
-    const cap = col.maxWidth ?? computePinnedMaxPxFor(col.id, viewportWidth);
+    const sidebarWidth = sv?.length >= 3 ? sv.getViewSize(0) : 0;
+    const cap = col.maxWidth ?? computePinnedMaxPxFor(col.id, viewportWidth, sidebarWidth);
     applyConstraintsToAllPanelGroups(api, col, cap);
     if (col.id !== "right") continue;
     const defaultWidth = getPinnedWidth(col, viewportWidth, undefined);

--- a/apps/web/lib/state/layout-manager/caps.test.ts
+++ b/apps/web/lib/state/layout-manager/caps.test.ts
@@ -24,7 +24,7 @@ describe("computeSidebarMaxPx", () => {
   it("never exceeds viewport - reserve so the center column survives", () => {
     // vw=500 → 30%=150 < floor 350; viewport reserve = 200. So 350 clamps to 200.
     // floor below LAYOUT_PINNED_MIN_PX is also enforced.
-    expect(computeSidebarMaxPx(500)).toBeLessThanOrEqual(500 - 300);
+    expect(computeSidebarMaxPx(500)).toBe(200);
     expect(computeSidebarMaxPx(500)).toBeGreaterThanOrEqual(LAYOUT_PINNED_MIN_PX);
   });
 
@@ -41,9 +41,8 @@ describe("computeRightMaxPx", () => {
   });
 
   it("hits the 800px floor on mid viewports", () => {
-    // vw=1024 → 70%=716 < floor 800; viewport reserve = 724. Clamp 800 → 724.
-    // (The viewport reserve protects narrow screens from over-allocation.)
-    expect(computeRightMaxPx(1024)).toBeLessThan(800);
+    // vw=1024 → 70%=716 < floor 800; center reserve leaves a 544px cap.
+    expect(computeRightMaxPx(1024)).toBe(544);
   });
 
   it("scales to viewport * 0.7 above the floor on roomy viewports", () => {
@@ -52,8 +51,8 @@ describe("computeRightMaxPx", () => {
   });
 
   it("never collapses the center column on narrow viewports", () => {
-    // vw=900 → 70%=630 < floor 800; reserve 300 → viewport bound 600.
-    expect(computeRightMaxPx(900)).toBe(600);
+    // vw=900 → 70%=630 < floor 800; reserve 480 → viewport bound 420.
+    expect(computeRightMaxPx(900)).toBe(420);
   });
 
   it("reads window.innerWidth when no argument passed", () => {

--- a/apps/web/lib/state/layout-manager/caps.test.ts
+++ b/apps/web/lib/state/layout-manager/caps.test.ts
@@ -50,6 +50,10 @@ describe("computeRightMaxPx", () => {
     expect(computeRightMaxPx(3000)).toBe(2100);
   });
 
+  it("reserves a visible sidebar so the center column retains its comfort width", () => {
+    expect(computeRightMaxPx(2000, 600)).toBe(920);
+  });
+
   it("never collapses the center column on narrow viewports", () => {
     // vw=900 → 70%=630 < floor 800; reserve 480 → viewport bound 420.
     expect(computeRightMaxPx(900)).toBe(420);

--- a/apps/web/lib/state/layout-manager/caps.test.ts
+++ b/apps/web/lib/state/layout-manager/caps.test.ts
@@ -74,6 +74,10 @@ describe("computePinnedMaxPxFor", () => {
     expect(computePinnedMaxPxFor("right", 2000)).toBe(1400);
     expect(computePinnedMaxPxFor("plan", 2000)).toBe(1400);
   });
+
+  it("passes the visible sidebar width through to the right-pane cap", () => {
+    expect(computePinnedMaxPxFor("right", 2000, 600)).toBe(920);
+  });
 });
 
 describe("LAYOUT_PINNED_MIN_PX", () => {

--- a/apps/web/lib/state/layout-manager/caps.ts
+++ b/apps/web/lib/state/layout-manager/caps.ts
@@ -48,13 +48,15 @@ export function computeSidebarMaxPx(availableWidth?: number): number {
   );
 }
 
-/** Right pane max: max(800, availableWidth * 0.7), bounded by available width. */
-export function computeRightMaxPx(availableWidth?: number): number {
+/** Right pane max: max(800, availableWidth * 0.7), bounded by available width.
+ *  When the left pinned column is visible, reserve its live width too so the
+ *  primary center column retains its preferred minimum. */
+export function computeRightMaxPx(availableWidth?: number, sidebarWidth = 0): number {
   const width = getAvailableWidth(availableWidth);
   return availableWidthBound(
     Math.max(RIGHT_FLOOR_PX, Math.round(width * RIGHT_RATIO)),
     width,
-    RIGHT_CENTER_MIN_PX,
+    RIGHT_CENTER_MIN_PX + Math.max(0, sidebarWidth),
   );
 }
 

--- a/apps/web/lib/state/layout-manager/caps.ts
+++ b/apps/web/lib/state/layout-manager/caps.ts
@@ -3,8 +3,8 @@
  *
  * The previous hard caps (350 sidebar, 450 right) were too strict on wide
  * displays — users wanted to drag the right panel out to half the screen for
- * file review or terminal work. Caps now scale with viewport so wider screens
- * get more room, while small screens still keep the center column usable.
+ * file review or terminal work. Caps now scale with available layout width so
+ * wider workbenches get more room, while small ones keep the center usable.
  *
  * Sidebar uses a tighter ratio than the right panel: file-tree / task-list
  * content rarely benefits from more than ~30% of the screen.
@@ -18,41 +18,50 @@ const SIDEBAR_FLOOR_PX = 350;
 const RIGHT_RATIO = 0.7;
 const RIGHT_FLOOR_PX = 800;
 
-/** Pixels reserved for the center column + opposite pinned column so the cap
- *  never grows past `viewport - VIEWPORT_RESERVE_PX`. Without this, an 800px
- *  right-cap floor on a 900px viewport would collapse the center to 0. */
-const VIEWPORT_RESERVE_PX = 300;
+const SIDEBAR_REMAINDER_MIN_PX = 300;
+
+/** Preferred minimum for the primary center/chat column when the right panel
+ *  is visible. On smaller containers the right panel's own minimum still wins. */
+const RIGHT_CENTER_MIN_PX = 480;
 
 /** Minimum pixel width for any pinned column. Below this the panel becomes
  *  unusable (icons clipped, scrollbars stacked). */
 export const LAYOUT_PINNED_MIN_PX = 180;
 
-function getViewport(viewportWidth?: number): number {
-  return viewportWidth ?? (typeof window !== "undefined" ? window.innerWidth : FALLBACK_VIEWPORT);
+function getAvailableWidth(availableWidth?: number): number {
+  return availableWidth ?? (typeof window !== "undefined" ? window.innerWidth : FALLBACK_VIEWPORT);
 }
 
-function viewportBound(value: number, viewportWidth: number): number {
-  // Always leave at least `VIEWPORT_RESERVE_PX` for the rest of the layout,
+function availableWidthBound(value: number, availableWidth: number, remainder: number): number {
+  // Always leave the other columns their reserved width,
   // and never go below the per-column min — even on absurdly narrow viewports.
-  return Math.max(LAYOUT_PINNED_MIN_PX, Math.min(value, viewportWidth - VIEWPORT_RESERVE_PX));
+  return Math.max(LAYOUT_PINNED_MIN_PX, Math.min(value, availableWidth - remainder));
 }
 
-/** Sidebar max width: max(350, viewportWidth * 0.3), bounded by viewport. */
-export function computeSidebarMaxPx(viewportWidth?: number): number {
-  const vw = getViewport(viewportWidth);
-  return viewportBound(Math.max(SIDEBAR_FLOOR_PX, Math.round(vw * SIDEBAR_RATIO)), vw);
+/** Sidebar max width: max(350, availableWidth * 0.3), bounded by available width. */
+export function computeSidebarMaxPx(availableWidth?: number): number {
+  const width = getAvailableWidth(availableWidth);
+  return availableWidthBound(
+    Math.max(SIDEBAR_FLOOR_PX, Math.round(width * SIDEBAR_RATIO)),
+    width,
+    SIDEBAR_REMAINDER_MIN_PX,
+  );
 }
 
-/** Right pane max width: max(800, viewportWidth * 0.7), bounded by viewport. */
-export function computeRightMaxPx(viewportWidth?: number): number {
-  const vw = getViewport(viewportWidth);
-  return viewportBound(Math.max(RIGHT_FLOOR_PX, Math.round(vw * RIGHT_RATIO)), vw);
+/** Right pane max: max(800, availableWidth * 0.7), bounded by available width. */
+export function computeRightMaxPx(availableWidth?: number): number {
+  const width = getAvailableWidth(availableWidth);
+  return availableWidthBound(
+    Math.max(RIGHT_FLOOR_PX, Math.round(width * RIGHT_RATIO)),
+    width,
+    RIGHT_CENTER_MIN_PX,
+  );
 }
 
 /** Pick the runtime cap appropriate for a given column ID. Non-sidebar
  *  pinned columns get the right-pane cap. */
-export function computePinnedMaxPxFor(columnId: string, viewportWidth?: number): number {
+export function computePinnedMaxPxFor(columnId: string, availableWidth?: number): number {
   return columnId === "sidebar"
-    ? computeSidebarMaxPx(viewportWidth)
-    : computeRightMaxPx(viewportWidth);
+    ? computeSidebarMaxPx(availableWidth)
+    : computeRightMaxPx(availableWidth);
 }

--- a/apps/web/lib/state/layout-manager/caps.ts
+++ b/apps/web/lib/state/layout-manager/caps.ts
@@ -62,8 +62,12 @@ export function computeRightMaxPx(availableWidth?: number, sidebarWidth = 0): nu
 
 /** Pick the runtime cap appropriate for a given column ID. Non-sidebar
  *  pinned columns get the right-pane cap. */
-export function computePinnedMaxPxFor(columnId: string, availableWidth?: number): number {
+export function computePinnedMaxPxFor(
+  columnId: string,
+  availableWidth?: number,
+  sidebarWidth?: number,
+): number {
   return columnId === "sidebar"
     ? computeSidebarMaxPx(availableWidth)
-    : computeRightMaxPx(availableWidth);
+    : computeRightMaxPx(availableWidth, sidebarWidth);
 }


### PR DESCRIPTION
Dragging a wide right panel and then narrowing the window could leave the chat feed unreadable. The panel now caps itself against the measured Dockview container and re-clamps after container resizes.

## Validation

- `make fmt`
- `make typecheck`
- `make test`
- `make lint`
- `pnpm e2e:run --host --no-build tests/layout/pane-resize-right.spec.ts` (5 passed)

## Related Issues

Closes #1682

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1691?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->