### PR TITLE
fix: repair grok docker auth and archived task control

### DIFF
--- a/apps/backend/internal/agent/agents/grok_acp.go
+++ b/apps/backend/internal/agent/agents/grok_acp.go
@@ -85,6 +85,7 @@ func (a *GrokACP) Runtime() *RuntimeConfig {
 			NativeSessionResume: true,
 			CanRecover:          &canRecover,
 			SessionDirTemplate:  "{home}/.grok",
+			SessionDirTarget:    "/root/.grok",
 		},
 	}
 }

--- a/apps/backend/internal/agent/agents/grok_acp_test.go
+++ b/apps/backend/internal/agent/agents/grok_acp_test.go
@@ -179,6 +179,9 @@ func TestGrokACP_SessionAndSkills(t *testing.T) {
 	if sc.SessionDirTemplate != "{home}/.grok" {
 		t.Errorf("SessionDirTemplate = %q, want {home}/.grok", sc.SessionDirTemplate)
 	}
+	if sc.SessionDirTarget != "/root/.grok" {
+		t.Errorf("SessionDirTarget = %q, want /root/.grok", sc.SessionDirTarget)
+	}
 }
 
 func TestGrokACP_PermissionAndBillingDefaults(t *testing.T) {

--- a/apps/backend/internal/agent/agents/project_skill_dir_test.go
+++ b/apps/backend/internal/agent/agents/project_skill_dir_test.go
@@ -8,9 +8,8 @@ import (
 )
 
 // TestProjectSkillDir_AllAgentTypes verifies that every registered agent type
-// sets a non-empty ProjectSkillDir in its RuntimeConfig, and that the fallback
-// function ProjectSkillDirFromRuntime returns a sensible default when the field
-// is absent.
+// resolves to a non-empty project skill directory, including agents that use
+// the default because ProjectSkillDir is absent from their RuntimeConfig.
 func TestProjectSkillDir_AllAgentTypes(t *testing.T) {
 	allAgents := []Agent{
 		NewClaudeACP(),
@@ -20,6 +19,19 @@ func TestProjectSkillDir_AllAgentTypes(t *testing.T) {
 		NewCopilotACP(),
 		NewAuggie(),
 		NewAmpACP(),
+		NewQwenACP(),
+		NewIFlowACP(),
+		NewDroidACP(),
+		NewKilocodeACP(),
+		NewPiACP(),
+		NewCursorACP(),
+		NewKimiACP(),
+		NewKiroACP(),
+		NewQoderACP(),
+		NewTraeACP(),
+		NewOmpACP(),
+		NewDevinACP(),
+		NewGrokACP(),
 		NewMockAgent(),
 	}
 

--- a/apps/backend/internal/agent/runtime/lifecycle/container_config_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/container_config_test.go
@@ -235,6 +235,7 @@ func TestBuildContainerConfig_SessionDirIsKandevManagedForEveryAgent(t *testing.
 		{"amp-acp", agents.NewAmpACP()},
 		{"gemini", agents.NewGemini()},
 		{"auggie", agents.NewAuggie()},
+		{"grok-acp", agents.NewGrokACP()},
 	}
 	const kandevHome = "/tmp/kandev-test-home"
 	const instanceID = "0123456789abcdef"

--- a/apps/web/components/task/task-top-bar.test.tsx
+++ b/apps/web/components/task/task-top-bar.test.tsx
@@ -19,6 +19,12 @@ vi.mock("@/components/task/executor-settings-button", () => ({
   ExecutorSettingsButton: () => <button data-testid="executor-settings-button">executor</button>,
 }));
 
+vi.mock("@/components/task/task-unarchive-button", () => ({
+  TaskUnarchiveButton: ({ taskId }: { taskId?: string | null }) => (
+    <button data-testid="task-unarchive-button">{taskId}</button>
+  ),
+}));
+
 vi.mock("@/components/task/port-forward-dialog", () => ({
   PortForwardButton: () => <button>ports</button>,
 }));
@@ -114,6 +120,14 @@ describe("TaskTopBar GitHub issue link", () => {
     );
     expect(screen.getByLabelText("Task status and attention").className).not.toContain("[&_a]");
     expect(issue.compareDocumentPosition(pr) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+});
+
+describe("TaskTopBar archived task controls", () => {
+  it("passes the task ID to the unarchive button", () => {
+    renderTopBar(<TaskTopBar taskId="task-1" isArchived />);
+
+    expect(screen.getByTestId("task-unarchive-button").textContent).toBe("task-1");
   });
 });
 

--- a/apps/web/components/task/task-top-bar.tsx
+++ b/apps/web/components/task/task-top-bar.tsx
@@ -95,6 +95,7 @@ const TaskTopBar = memo(function TaskTopBar({
         )}
       </div>
       <TopBarRight
+        taskId={taskId}
         activeSessionId={activeSessionId}
         showDebugOverlay={showDebugOverlay}
         onToggleDebugOverlay={onToggleDebugOverlay}
@@ -336,6 +337,7 @@ function TopbarToolsGroup({
  *  The former overflow popover was removed in the UI overhaul — every cluster
  *  is always visible so users don't have to discover the dots menu. */
 function TopBarRight({
+  taskId,
   activeSessionId,
   showDebugOverlay,
   onToggleDebugOverlay,
@@ -348,6 +350,7 @@ function TopBarRight({
   issueNumber,
   officeTaskHref,
 }: {
+  taskId?: string | null;
   activeSessionId?: string | null;
   showDebugOverlay?: boolean;
   onToggleDebugOverlay?: () => void;


### PR DESCRIPTION
Grok Docker sessions now expose seeded OAuth credentials to the CLI, while archived task controls receive the task ID required to unarchive safely.

## Validation

- `make fmt`
- `make typecheck`
- `make test`
- `make lint`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1693?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->