### PR TITLE
feat: add idle storage maintenance

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -141,6 +141,7 @@ jobs:
         if: always()
         with:
           fromJSONFile: apps/backend/test-results.json
+          omit: successful
 
       - name: Upload test artifacts
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5

--- a/apps/backend/internal/agent/docker/activity_test.go
+++ b/apps/backend/internal/agent/docker/activity_test.go
@@ -1,0 +1,53 @@
+package docker
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+
+	"github.com/docker/docker/api/types/build"
+	"github.com/kandev/kandev/internal/agent/runtime/activity"
+	"github.com/kandev/kandev/internal/common/logger"
+	"go.uber.org/zap"
+)
+
+func TestBuildImageHoldsActivityUntilResponseBodyCloses(t *testing.T) {
+	log, err := logger.NewFromZap(zap.NewNop())
+	if err != nil {
+		t.Fatal(err)
+	}
+	coordinator := activity.NewCoordinator(activity.Options{})
+	client := &Client{
+		builder: &fakeImageBuilder{response: build.ImageBuildResponse{
+			Body: io.NopCloser(bytes.NewBufferString("build output")),
+		}},
+		logger: log,
+	}
+	client.SetActivityCoordinator(coordinator)
+
+	body, err := client.BuildImage(context.Background(), "FROM scratch", "test", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := coordinator.TryAcquireMaintenance(context.Background(), 0); err != activity.ErrBusy {
+		t.Fatalf("maintenance acquire error = %v, want ErrBusy", err)
+	}
+	if err := body.Close(); err != nil {
+		t.Fatal(err)
+	}
+	lease, _, err := coordinator.TryAcquireMaintenance(context.Background(), 0)
+	if err != nil {
+		t.Fatalf("maintenance remained busy after close: %v", err)
+	}
+	lease.Release()
+}
+
+type fakeImageBuilder struct {
+	response build.ImageBuildResponse
+	err      error
+}
+
+func (f *fakeImageBuilder) ImageBuild(context.Context, io.Reader, build.ImageBuildOptions) (build.ImageBuildResponse, error) {
+	return f.response, f.err
+}

--- a/apps/backend/internal/agent/docker/client.go
+++ b/apps/backend/internal/agent/docker/client.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"sync"
 	"time"
 
 	"github.com/docker/docker/api/types/build"
@@ -18,6 +19,7 @@ import (
 	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/client"
 	"github.com/docker/go-connections/nat"
+	"github.com/kandev/kandev/internal/agent/runtime/activity"
 	"github.com/kandev/kandev/internal/common/config"
 	"github.com/kandev/kandev/internal/common/logger"
 	"go.uber.org/zap"
@@ -69,10 +71,23 @@ type ContainerInfo struct {
 }
 
 // Client wraps the Docker client.
+type containerRemover interface {
+	ContainerRemove(context.Context, string, container.RemoveOptions) error
+}
+
+type imageBuilder interface {
+	ImageBuild(context.Context, io.Reader, build.ImageBuildOptions) (build.ImageBuildResponse, error)
+}
+
 type Client struct {
-	cli    *client.Client
-	logger *logger.Logger
-	config config.DockerConfig
+	cli      *client.Client
+	storage  storageAPI
+	remover  containerRemover
+	builder  imageBuilder
+	logger   *logger.Logger
+	config   config.DockerConfig
+	activity *activity.Coordinator
+	mu       sync.RWMutex
 }
 
 // NewClient creates a new Docker client.
@@ -100,10 +115,20 @@ func NewClient(cfg config.DockerConfig, log *logger.Logger) (*Client, error) {
 	)
 
 	return &Client{
-		cli:    cli,
-		logger: log,
-		config: cfg,
+		cli:     cli,
+		storage: cli,
+		remover: cli,
+		builder: cli,
+		logger:  log,
+		config:  cfg,
 	}, nil
+}
+
+// SetActivityCoordinator wires the optional install-wide host activity gate.
+func (c *Client) SetActivityCoordinator(coordinator *activity.Coordinator) {
+	c.mu.Lock()
+	c.activity = coordinator
+	c.mu.Unlock()
 }
 
 // Close closes the Docker client.
@@ -143,24 +168,65 @@ func (c *Client) PullImage(ctx context.Context, imageName string) error {
 // The caller is responsible for closing the returned reader.
 func (c *Client) BuildImage(ctx context.Context, dockerfile string, tag string, buildArgs map[string]*string) (io.ReadCloser, error) {
 	c.logger.Info("Building image", zap.String("tag", tag))
+	c.mu.RLock()
+	coordinator := c.activity
+	builder := c.builder
+	c.mu.RUnlock()
+	if builder == nil {
+		builder = c.cli
+	}
+	var activityLease *activity.TaskLease
+	var err error
+	if coordinator != nil {
+		activityLease, err = coordinator.AcquireTask(ctx, activity.KindDockerImageBuild)
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	buildContext, err := createDockerfileTar(dockerfile)
 	if err != nil {
+		activityLease.Release()
 		return nil, fmt.Errorf("failed to create build context: %w", err)
 	}
 
-	resp, err := c.cli.ImageBuild(ctx, buildContext, build.ImageBuildOptions{
+	resp, err := builder.ImageBuild(ctx, buildContext, build.ImageBuildOptions{
 		Tags:       []string{tag},
 		BuildArgs:  buildArgs,
 		Dockerfile: "Dockerfile",
 		Remove:     true,
 	})
 	if err != nil {
+		activityLease.Release()
 		c.logger.Error("Failed to build image", zap.String("tag", tag), zap.Error(err))
 		return nil, fmt.Errorf("failed to build image %s: %w", tag, err)
 	}
 
-	return resp.Body, nil
+	return &activityReadCloser{ReadCloser: resp.Body, lease: activityLease}, nil
+}
+
+type activityReadCloser struct {
+	io.ReadCloser
+	lease *activity.TaskLease
+	once  sync.Once
+}
+
+func (r *activityReadCloser) Read(p []byte) (int, error) {
+	n, err := r.ReadCloser.Read(p)
+	if err == io.EOF {
+		r.release()
+	}
+	return n, err
+}
+
+func (r *activityReadCloser) Close() error {
+	err := r.ReadCloser.Close()
+	r.release()
+	return err
+}
+
+func (r *activityReadCloser) release() {
+	r.once.Do(func() { r.lease.Release() })
 }
 
 // createDockerfileTar creates a tar archive containing a single Dockerfile.
@@ -299,7 +365,7 @@ func (c *Client) RemoveContainer(ctx context.Context, containerID string, force 
 		zap.Bool("force", force),
 	)
 
-	err := c.cli.ContainerRemove(ctx, containerID, container.RemoveOptions{
+	err := c.containerRemover().ContainerRemove(ctx, containerID, container.RemoveOptions{
 		Force:         force,
 		RemoveVolumes: true,
 	})
@@ -310,6 +376,13 @@ func (c *Client) RemoveContainer(ctx context.Context, containerID string, force 
 
 	c.logger.Info("Container removed", zap.String("container_id", containerID))
 	return nil
+}
+
+func (c *Client) containerRemover() containerRemover {
+	if c.remover != nil {
+		return c.remover
+	}
+	return c.cli
 }
 
 // KillContainer kills a container.

--- a/apps/backend/internal/agent/docker/storage.go
+++ b/apps/backend/internal/agent/docker/storage.go
@@ -1,0 +1,137 @@
+package docker
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"strconv"
+	"time"
+
+	dockertypes "github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/build"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/image"
+)
+
+type storageAPI interface {
+	DiskUsage(context.Context, dockertypes.DiskUsageOptions) (dockertypes.DiskUsage, error)
+	BuildCachePrune(context.Context, build.CachePruneOptions) (*build.CachePruneReport, error)
+	ImagesPrune(context.Context, filters.Args) (image.PruneReport, error)
+}
+
+type ImageUsage struct {
+	ID         string    `json:"id"`
+	SizeBytes  int64     `json:"size_bytes"`
+	Containers int64     `json:"containers"`
+	CreatedAt  time.Time `json:"created_at"`
+}
+
+type ContainerUsage struct {
+	ID            string            `json:"id"`
+	WritableBytes int64             `json:"writable_bytes"`
+	Labels        map[string]string `json:"labels"`
+}
+
+type DiskUsage struct {
+	BuildCacheBytes int64            `json:"build_cache_bytes"`
+	Images          []ImageUsage     `json:"images"`
+	Containers      []ContainerUsage `json:"containers"`
+}
+
+type BuildCachePruneOptions struct {
+	KeepBytes    int64
+	UnusedBefore time.Time
+}
+
+type PruneResult struct {
+	Deleted        int   `json:"deleted"`
+	BytesReclaimed int64 `json:"bytes_reclaimed"`
+}
+
+func (c *Client) DiskUsage(ctx context.Context) (DiskUsage, error) {
+	usage, err := c.storageClient().DiskUsage(ctx, dockertypes.DiskUsageOptions{
+		Types: []dockertypes.DiskUsageObject{
+			dockertypes.ContainerObject,
+			dockertypes.ImageObject,
+			dockertypes.BuildCacheObject,
+		},
+	})
+	if err != nil {
+		return DiskUsage{}, fmt.Errorf("read Docker disk usage: %w", err)
+	}
+	result := DiskUsage{
+		Images:     make([]ImageUsage, 0, len(usage.Images)),
+		Containers: make([]ContainerUsage, 0, len(usage.Containers)),
+	}
+	for _, cache := range usage.BuildCache {
+		if cache != nil && cache.Size > 0 {
+			result.BuildCacheBytes += cache.Size
+		}
+	}
+	for _, item := range usage.Images {
+		if item == nil {
+			continue
+		}
+		result.Images = append(result.Images, ImageUsage{
+			ID: item.ID, SizeBytes: item.Size, Containers: item.Containers,
+			CreatedAt: time.Unix(item.Created, 0).UTC(),
+		})
+	}
+	for _, item := range usage.Containers {
+		if item == nil {
+			continue
+		}
+		result.Containers = append(result.Containers, ContainerUsage{
+			ID: item.ID, WritableBytes: item.SizeRw, Labels: item.Labels,
+		})
+	}
+	return result, nil
+}
+
+func (c *Client) PruneBuildCache(ctx context.Context, options BuildCachePruneOptions) (PruneResult, error) {
+	pruneFilters := filters.NewArgs(filters.Arg("until", unixFilter(options.UnusedBefore)))
+	report, err := c.storageClient().BuildCachePrune(ctx, build.CachePruneOptions{
+		All: true, ReservedSpace: options.KeepBytes, KeepStorage: options.KeepBytes, Filters: pruneFilters,
+	})
+	if err != nil {
+		return PruneResult{}, fmt.Errorf("prune Docker build cache: %w", err)
+	}
+	if report == nil {
+		return PruneResult{}, nil
+	}
+	return PruneResult{
+		Deleted: len(report.CachesDeleted), BytesReclaimed: reclaimedBytes(report.SpaceReclaimed),
+	}, nil
+}
+
+func (c *Client) PruneUnusedImages(ctx context.Context, unusedBefore time.Time) (PruneResult, error) {
+	pruneFilters := filters.NewArgs(
+		filters.Arg("dangling", "false"),
+		filters.Arg("until", unixFilter(unusedBefore)),
+	)
+	report, err := c.storageClient().ImagesPrune(ctx, pruneFilters)
+	if err != nil {
+		return PruneResult{}, fmt.Errorf("prune unused Docker images: %w", err)
+	}
+	return PruneResult{
+		Deleted: len(report.ImagesDeleted), BytesReclaimed: reclaimedBytes(report.SpaceReclaimed),
+	}, nil
+}
+
+func (c *Client) storageClient() storageAPI {
+	if c.storage != nil {
+		return c.storage
+	}
+	return c.cli
+}
+
+func unixFilter(value time.Time) string {
+	return strconv.FormatInt(value.UTC().Unix(), 10)
+}
+
+func reclaimedBytes(value uint64) int64 {
+	if value > math.MaxInt64 {
+		return math.MaxInt64
+	}
+	return int64(value)
+}

--- a/apps/backend/internal/agent/docker/storage_test.go
+++ b/apps/backend/internal/agent/docker/storage_test.go
@@ -1,0 +1,187 @@
+package docker
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"testing"
+	"time"
+
+	dockertypes "github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/build"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/image"
+	"github.com/kandev/kandev/internal/common/logger"
+	"go.uber.org/zap"
+)
+
+func TestStorageResultJSONUsesSnakeCase(t *testing.T) {
+	tests := []struct {
+		name  string
+		value any
+		want  string
+	}{
+		{
+			name: "image usage", value: ImageUsage{
+				ID: "image", SizeBytes: 10, Containers: 2, CreatedAt: time.Unix(0, 0).UTC(),
+			},
+			want: `{"id":"image","size_bytes":10,"containers":2,"created_at":"1970-01-01T00:00:00Z"}`,
+		},
+		{
+			name: "container usage",
+			value: ContainerUsage{
+				ID: "container", WritableBytes: 20, Labels: map[string]string{"managed": "true"},
+			},
+			want: `{"id":"container","writable_bytes":20,"labels":{"managed":"true"}}`,
+		},
+		{
+			name: "disk usage",
+			value: DiskUsage{
+				BuildCacheBytes: 30, Images: []ImageUsage{}, Containers: []ContainerUsage{},
+			},
+			want: `{"build_cache_bytes":30,"images":[],"containers":[]}`,
+		},
+		{
+			name: "prune result", value: PruneResult{Deleted: 3, BytesReclaimed: 40},
+			want: `{"deleted":3,"bytes_reclaimed":40}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			encoded, err := json.Marshal(tt.value)
+			if err != nil {
+				t.Fatalf("Marshal: %v", err)
+			}
+			if string(encoded) != tt.want {
+				t.Fatalf("JSON = %s, want %s", encoded, tt.want)
+			}
+		})
+	}
+}
+
+func TestDiskUsageMapsTypedSDKResponse(t *testing.T) {
+	created := time.Unix(100, 0)
+	lastUsed := time.Unix(200, 0)
+	sdk := &fakeStorageAPI{usage: dockertypes.DiskUsage{
+		Images: []*image.Summary{{ID: "image-1", Size: 300, Containers: 0, Created: created.Unix()}},
+		Containers: []*container.Summary{
+			{ID: "managed", SizeRw: 75, Labels: map[string]string{"kandev.managed": "true"}},
+			{ID: "unrelated", SizeRw: 125, Labels: map[string]string{"owner": "user"}},
+		},
+		BuildCache: []*build.CacheRecord{
+			{ID: "cache-1", Size: 100},
+			{ID: "cache-2", Size: 200, LastUsedAt: &lastUsed},
+		},
+	}}
+	client := &Client{storage: sdk}
+
+	got, err := client.DiskUsage(context.Background())
+	if err != nil {
+		t.Fatalf("DiskUsage: %v", err)
+	}
+	if got.BuildCacheBytes != 300 || len(got.Images) != 1 || !got.Images[0].CreatedAt.Equal(created) ||
+		len(got.Containers) != 2 || got.Containers[0].WritableBytes != 75 ||
+		got.Containers[0].Labels["kandev.managed"] != "true" {
+		t.Fatalf("disk usage = %#v", got)
+	}
+	wantTypes := []dockertypes.DiskUsageObject{
+		dockertypes.ContainerObject, dockertypes.ImageObject, dockertypes.BuildCacheObject,
+	}
+	if !reflect.DeepEqual(sdk.usageOptions.Types, wantTypes) {
+		t.Fatalf("disk usage types = %#v, want %#v", sdk.usageOptions.Types, wantTypes)
+	}
+}
+
+func TestPruneBuildCacheUsesAgeAndReservedSpaceFilters(t *testing.T) {
+	sdk := &fakeStorageAPI{buildReport: &build.CachePruneReport{CachesDeleted: []string{"one"}, SpaceReclaimed: 42}}
+	client := &Client{storage: sdk}
+	cutoff := time.Unix(1234, 0).UTC()
+
+	got, err := client.PruneBuildCache(context.Background(), BuildCachePruneOptions{
+		KeepBytes: 1024, UnusedBefore: cutoff,
+	})
+	if err != nil {
+		t.Fatalf("PruneBuildCache: %v", err)
+	}
+	if got.Deleted != 1 || got.BytesReclaimed != 42 {
+		t.Fatalf("prune result = %#v", got)
+	}
+	if !sdk.buildOptions.All || sdk.buildOptions.ReservedSpace != 1024 ||
+		sdk.buildOptions.KeepStorage != 1024 ||
+		!sdk.buildOptions.Filters.ExactMatch("until", "1234") {
+		t.Fatalf("build prune options = %#v", sdk.buildOptions)
+	}
+}
+
+func TestPruneUnusedImagesUsesAllUnusedAndAgeFilters(t *testing.T) {
+	sdk := &fakeStorageAPI{imageReport: image.PruneReport{
+		ImagesDeleted: []image.DeleteResponse{{Deleted: "image-1"}}, SpaceReclaimed: 84,
+	}}
+	client := &Client{storage: sdk}
+
+	got, err := client.PruneUnusedImages(context.Background(), time.Unix(5678, 0).UTC())
+	if err != nil {
+		t.Fatalf("PruneUnusedImages: %v", err)
+	}
+	if got.Deleted != 1 || got.BytesReclaimed != 84 {
+		t.Fatalf("prune result = %#v", got)
+	}
+	if !sdk.imageFilters.ExactMatch("dangling", "false") || !sdk.imageFilters.ExactMatch("until", "5678") {
+		t.Fatalf("image prune filters = %#v", sdk.imageFilters)
+	}
+}
+
+func TestRemoveContainerRemovesAttachedVolumesWithoutGlobalPrune(t *testing.T) {
+	remover := &fakeContainerRemover{}
+	log, err := logger.NewFromZap(zap.NewNop())
+	if err != nil {
+		t.Fatalf("new logger: %v", err)
+	}
+	client := &Client{remover: remover, logger: log}
+
+	if err := client.RemoveContainer(context.Background(), "container-1", false); err != nil {
+		t.Fatalf("RemoveContainer: %v", err)
+	}
+	if remover.id != "container-1" || remover.options.Force || !remover.options.RemoveVolumes {
+		t.Fatalf("remove call id=%q options=%#v", remover.id, remover.options)
+	}
+}
+
+type fakeStorageAPI struct {
+	usage        dockertypes.DiskUsage
+	usageErr     error
+	usageOptions dockertypes.DiskUsageOptions
+	buildOptions build.CachePruneOptions
+	buildReport  *build.CachePruneReport
+	buildErr     error
+	imageFilters filters.Args
+	imageReport  image.PruneReport
+	imageErr     error
+}
+
+func (f *fakeStorageAPI) DiskUsage(_ context.Context, options dockertypes.DiskUsageOptions) (dockertypes.DiskUsage, error) {
+	f.usageOptions = options
+	return f.usage, f.usageErr
+}
+
+func (f *fakeStorageAPI) BuildCachePrune(_ context.Context, options build.CachePruneOptions) (*build.CachePruneReport, error) {
+	f.buildOptions = options
+	return f.buildReport, f.buildErr
+}
+
+func (f *fakeStorageAPI) ImagesPrune(_ context.Context, pruneFilters filters.Args) (image.PruneReport, error) {
+	f.imageFilters = pruneFilters
+	return f.imageReport, f.imageErr
+}
+
+type fakeContainerRemover struct {
+	id      string
+	options container.RemoveOptions
+}
+
+func (f *fakeContainerRemover) ContainerRemove(_ context.Context, id string, options container.RemoveOptions) error {
+	f.id = id
+	f.options = options
+	return nil
+}

--- a/apps/backend/internal/agent/runtime/activity/coordinator.go
+++ b/apps/backend/internal/agent/runtime/activity/coordinator.go
@@ -1,0 +1,196 @@
+// Package activity coordinates host-resource task work with destructive
+// install-wide maintenance without importing lifecycle or storage packages.
+package activity
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"sync"
+	"time"
+)
+
+var ErrBusy = errors.New("host resources are busy")
+
+type Kind string
+
+const (
+	KindExecutionStarting  Kind = "execution_starting"
+	KindExecutionPreparing Kind = "execution_preparing"
+	KindExecutionRunning   Kind = "execution_running"
+	KindExecutionStopping  Kind = "execution_stopping"
+	KindShellCommand       Kind = "shell_command"
+	KindTestCommand        Kind = "test_command"
+	KindSetupScript        Kind = "setup_script"
+	KindCleanupScript      Kind = "cleanup_script"
+	KindDockerImageBuild   Kind = "docker_image_build"
+	KindQuietPeriod        Kind = "quiet_period"
+)
+
+type Options struct {
+	Now func() time.Time
+}
+
+type Coordinator struct {
+	mu           sync.Mutex
+	now          func() time.Time
+	active       map[Kind]int
+	lastActivity time.Time
+	maintenance  *maintenanceState
+}
+
+type maintenanceState struct {
+	cancel context.CancelFunc
+	done   chan struct{}
+}
+
+func NewCoordinator(options Options) *Coordinator {
+	now := options.Now
+	if now == nil {
+		now = time.Now
+	}
+	return &Coordinator{
+		now: now, active: make(map[Kind]int), lastActivity: now().UTC(),
+	}
+}
+
+type TaskLease struct {
+	coordinator *Coordinator
+	mu          sync.Mutex
+	kind        Kind
+	released    bool
+}
+
+func (l *TaskLease) Release() {
+	if l == nil || l.coordinator == nil {
+		return
+	}
+	l.mu.Lock()
+	if l.released {
+		l.mu.Unlock()
+		return
+	}
+	l.released = true
+	kind := l.kind
+	l.mu.Unlock()
+	l.coordinator.releaseTask(kind)
+}
+
+func (l *TaskLease) SetKind(kind Kind) {
+	if l == nil || l.coordinator == nil || kind == "" {
+		return
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.released {
+		return
+	}
+	l.coordinator.mu.Lock()
+	defer l.coordinator.mu.Unlock()
+	if l.kind == kind {
+		return
+	}
+	l.coordinator.decrementLocked(l.kind)
+	l.coordinator.active[kind]++
+	l.kind = kind
+}
+
+type MaintenanceLease struct {
+	coordinator *Coordinator
+	state       *maintenanceState
+	ctx         context.Context
+	once        sync.Once
+}
+
+func (l *MaintenanceLease) Context() context.Context { return l.ctx }
+
+func (l *MaintenanceLease) Release() {
+	if l == nil || l.coordinator == nil {
+		return
+	}
+	l.once.Do(func() { l.coordinator.releaseMaintenance(l.state) })
+}
+
+func (c *Coordinator) AcquireTask(ctx context.Context, kind Kind) (*TaskLease, error) {
+	for {
+		c.mu.Lock()
+		maintenance := c.maintenance
+		if maintenance == nil {
+			c.active[kind]++
+			c.mu.Unlock()
+			return &TaskLease{coordinator: c, kind: kind}, nil
+		}
+		maintenance.cancel()
+		done := maintenance.done
+		c.mu.Unlock()
+		select {
+		case <-done:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+}
+
+func (c *Coordinator) TryAcquireMaintenance(
+	ctx context.Context,
+	quietPeriod time.Duration,
+) (*MaintenanceLease, []Kind, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.maintenance != nil {
+		return nil, []Kind{KindQuietPeriod}, ErrBusy
+	}
+	if busy := c.busyKindsLocked(); len(busy) > 0 {
+		return nil, busy, ErrBusy
+	}
+	if quietPeriod > 0 && c.now().UTC().Sub(c.lastActivity) < quietPeriod {
+		return nil, []Kind{KindQuietPeriod}, ErrBusy
+	}
+	maintenanceCtx, cancel := context.WithCancel(ctx)
+	state := &maintenanceState{cancel: cancel, done: make(chan struct{})}
+	c.maintenance = state
+	return &MaintenanceLease{coordinator: c, state: state, ctx: maintenanceCtx}, nil, nil
+}
+
+func (c *Coordinator) BusyKinds() []Kind {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.busyKindsLocked()
+}
+
+func (c *Coordinator) releaseTask(kind Kind) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.decrementLocked(kind)
+	if len(c.active) == 0 {
+		c.lastActivity = c.now().UTC()
+	}
+}
+
+func (c *Coordinator) decrementLocked(kind Kind) {
+	if c.active[kind] <= 1 {
+		delete(c.active, kind)
+		return
+	}
+	c.active[kind]--
+}
+
+func (c *Coordinator) releaseMaintenance(state *maintenanceState) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.maintenance != state {
+		return
+	}
+	c.maintenance = nil
+	state.cancel()
+	close(state.done)
+}
+
+func (c *Coordinator) busyKindsLocked() []Kind {
+	busy := make([]Kind, 0, len(c.active))
+	for kind := range c.active {
+		busy = append(busy, kind)
+	}
+	sort.Slice(busy, func(i, j int) bool { return busy[i] < busy[j] })
+	return busy
+}

--- a/apps/backend/internal/agent/runtime/activity/coordinator.go
+++ b/apps/backend/internal/agent/runtime/activity/coordinator.go
@@ -25,6 +25,7 @@ const (
 	KindCleanupScript      Kind = "cleanup_script"
 	KindDockerImageBuild   Kind = "docker_image_build"
 	KindQuietPeriod        Kind = "quiet_period"
+	KindMaintenanceRunning Kind = "maintenance_running"
 )
 
 type Options struct {
@@ -113,6 +114,9 @@ func (l *MaintenanceLease) Release() {
 
 func (c *Coordinator) AcquireTask(ctx context.Context, kind Kind) (*TaskLease, error) {
 	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		c.mu.Lock()
 		maintenance := c.maintenance
 		if maintenance == nil {
@@ -138,7 +142,7 @@ func (c *Coordinator) TryAcquireMaintenance(
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.maintenance != nil {
-		return nil, []Kind{KindQuietPeriod}, ErrBusy
+		return nil, []Kind{KindMaintenanceRunning}, ErrBusy
 	}
 	if busy := c.busyKindsLocked(); len(busy) > 0 {
 		return nil, busy, ErrBusy

--- a/apps/backend/internal/agent/runtime/activity/coordinator_test.go
+++ b/apps/backend/internal/agent/runtime/activity/coordinator_test.go
@@ -91,7 +91,7 @@ func TestMaintenanceAlreadyRunningReportsMaintenanceKind(t *testing.T) {
 	if !errors.Is(err, ErrBusy) {
 		t.Fatalf("second TryAcquireMaintenance error = %v, want ErrBusy", err)
 	}
-	want := Kind("maintenance_running")
+	want := KindMaintenanceRunning
 	if len(busy) != 1 || busy[0] != want {
 		t.Fatalf("busy kinds = %v, want [%s]", busy, want)
 	}

--- a/apps/backend/internal/agent/runtime/activity/coordinator_test.go
+++ b/apps/backend/internal/agent/runtime/activity/coordinator_test.go
@@ -1,0 +1,63 @@
+package activity
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestTaskAdmissionCancelsAndDrainsMaintenance(t *testing.T) {
+	coordinator := NewCoordinator(Options{})
+	maintenance, _, err := coordinator.TryAcquireMaintenance(context.Background(), 0)
+	if err != nil {
+		t.Fatalf("TryAcquireMaintenance: %v", err)
+	}
+
+	admitted := make(chan *TaskLease, 1)
+	go func() {
+		lease, acquireErr := coordinator.AcquireTask(context.Background(), KindExecutionStarting)
+		if acquireErr == nil {
+			admitted <- lease
+		}
+	}()
+
+	select {
+	case <-maintenance.Context().Done():
+	case <-time.After(time.Second):
+		t.Fatal("task admission did not cancel maintenance")
+	}
+	select {
+	case <-admitted:
+		t.Fatal("task admitted before cancelled maintenance drained")
+	default:
+	}
+	maintenance.Release()
+	select {
+	case lease := <-admitted:
+		lease.Release()
+	case <-time.After(time.Second):
+		t.Fatal("task was not admitted after maintenance drained")
+	}
+}
+
+func TestQuietPeriodUsesLastReleasedTaskActivity(t *testing.T) {
+	now := time.Date(2026, 7, 14, 10, 0, 0, 0, time.UTC)
+	coordinator := NewCoordinator(Options{Now: func() time.Time { return now }})
+	lease, err := coordinator.AcquireTask(context.Background(), KindShellCommand)
+	if err != nil {
+		t.Fatalf("AcquireTask: %v", err)
+	}
+	lease.Release()
+
+	now = now.Add(9 * time.Minute)
+	if _, _, err := coordinator.TryAcquireMaintenance(context.Background(), 10*time.Minute); !errors.Is(err, ErrBusy) {
+		t.Fatalf("maintenance at 9m error = %v, want ErrBusy", err)
+	}
+	now = now.Add(time.Minute)
+	maintenance, _, err := coordinator.TryAcquireMaintenance(context.Background(), 10*time.Minute)
+	if err != nil {
+		t.Fatalf("maintenance at 10m: %v", err)
+	}
+	maintenance.Release()
+}

--- a/apps/backend/internal/agent/runtime/activity/coordinator_test.go
+++ b/apps/backend/internal/agent/runtime/activity/coordinator_test.go
@@ -61,3 +61,38 @@ func TestQuietPeriodUsesLastReleasedTaskActivity(t *testing.T) {
 	}
 	maintenance.Release()
 }
+
+func TestAcquireTaskRejectsAlreadyCancelledContext(t *testing.T) {
+	coordinator := NewCoordinator(Options{})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	lease, err := coordinator.AcquireTask(ctx, KindExecutionStarting)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("AcquireTask error = %v, want context.Canceled", err)
+	}
+	if lease != nil {
+		t.Fatal("AcquireTask returned a lease for a cancelled context")
+	}
+	if busy := coordinator.BusyKinds(); len(busy) != 0 {
+		t.Fatalf("BusyKinds = %v, want empty", busy)
+	}
+}
+
+func TestMaintenanceAlreadyRunningReportsMaintenanceKind(t *testing.T) {
+	coordinator := NewCoordinator(Options{})
+	lease, _, err := coordinator.TryAcquireMaintenance(context.Background(), 0)
+	if err != nil {
+		t.Fatalf("TryAcquireMaintenance: %v", err)
+	}
+	defer lease.Release()
+
+	_, busy, err := coordinator.TryAcquireMaintenance(context.Background(), 0)
+	if !errors.Is(err, ErrBusy) {
+		t.Fatalf("second TryAcquireMaintenance error = %v, want ErrBusy", err)
+	}
+	want := Kind("maintenance_running")
+	if len(busy) != 1 || busy[0] != want {
+		t.Fatalf("busy kinds = %v, want [%s]", busy, want)
+	}
+}

--- a/apps/backend/internal/agent/runtime/lifecycle/activity.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/activity.go
@@ -10,8 +10,9 @@ import (
 )
 
 const (
-	executionActivityPrefix = "execution:"
-	processActivityPrefix   = "process:"
+	executionActivityPrefix   = "execution:"
+	processActivityPrefix     = "process:"
+	managedGoCacheMetadataKey = "managed_go_cache_path"
 )
 
 func (m *Manager) acquireActivity(ctx context.Context, kind activity.Kind) (*activity.TaskLease, error) {
@@ -32,6 +33,7 @@ func (m *Manager) trackActivity(key string, lease *activity.TaskLease) {
 	if m.activityLeases == nil {
 		m.activityLeases = make(map[string]*activity.TaskLease)
 	}
+	delete(m.activityPending, key)
 	previous := m.activityLeases[key]
 	m.activityLeases[key] = lease
 	m.activityMu.Unlock()
@@ -42,6 +44,7 @@ func (m *Manager) releaseActivity(key string) {
 	m.activityMu.Lock()
 	lease := m.activityLeases[key]
 	delete(m.activityLeases, key)
+	delete(m.activityPending, key)
 	m.activityMu.Unlock()
 	lease.Release()
 }
@@ -50,17 +53,51 @@ func (m *Manager) ensureExecutionActivity(ctx context.Context, executionID strin
 	key := executionActivityKey(executionID)
 	m.activityMu.Lock()
 	existing := m.activityLeases[key]
-	m.activityMu.Unlock()
 	if existing != nil {
+		m.activityMu.Unlock()
 		existing.SetKind(kind)
 		return nil
 	}
+	if m.activityPending == nil {
+		m.activityPending = make(map[string]uint64)
+	}
+	m.activityGeneration++
+	generation := m.activityGeneration
+	m.activityPending[key] = generation
+	m.activityMu.Unlock()
 	lease, err := m.acquireActivity(ctx, kind)
 	if err != nil {
+		m.clearPendingActivity(key, generation)
 		return err
 	}
-	m.trackActivity(key, lease)
+	if lease == nil {
+		m.clearPendingActivity(key, generation)
+		return nil
+	}
+	m.finishPendingActivity(key, generation, lease)
 	return nil
+}
+
+func (m *Manager) clearPendingActivity(key string, generation uint64) {
+	m.activityMu.Lock()
+	if m.activityPending[key] == generation {
+		delete(m.activityPending, key)
+	}
+	m.activityMu.Unlock()
+}
+
+func (m *Manager) finishPendingActivity(key string, generation uint64, lease *activity.TaskLease) {
+	m.activityMu.Lock()
+	if m.activityPending[key] != generation {
+		m.activityMu.Unlock()
+		lease.Release()
+		return
+	}
+	delete(m.activityPending, key)
+	previous := m.activityLeases[key]
+	m.activityLeases[key] = lease
+	m.activityMu.Unlock()
+	previous.Release()
 }
 
 func executionActivityKey(executionID string) string {

--- a/apps/backend/internal/agent/runtime/lifecycle/activity.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/activity.go
@@ -2,7 +2,9 @@ package lifecycle
 
 import (
 	"context"
+	"errors"
 	"strings"
+	"sync"
 
 	"github.com/kandev/kandev/internal/agent/runtime/activity"
 	agentctltypes "github.com/kandev/kandev/internal/agentctl/types"
@@ -14,6 +16,8 @@ const (
 	processActivityPrefix     = "process:"
 	managedGoCacheMetadataKey = "managed_go_cache_path"
 )
+
+var errExecutionActivityInvalidated = errors.New("execution activity invalidated")
 
 func (m *Manager) acquireActivity(ctx context.Context, kind activity.Kind) (*activity.TaskLease, error) {
 	m.activityMu.Lock()
@@ -33,71 +37,223 @@ func (m *Manager) trackActivity(key string, lease *activity.TaskLease) {
 	if m.activityLeases == nil {
 		m.activityLeases = make(map[string]*activity.TaskLease)
 	}
-	delete(m.activityPending, key)
 	previous := m.activityLeases[key]
+	previousClaimed := m.invalidateExecutionActivityClaimsLocked(key)
 	m.activityLeases[key] = lease
+	m.activityLeaseOwners[key] = 0
 	m.activityMu.Unlock()
-	previous.Release()
+	if !previousClaimed {
+		previous.Release()
+	}
 }
 
 func (m *Manager) releaseActivity(key string) {
 	m.activityMu.Lock()
 	lease := m.activityLeases[key]
+	leaseClaimed := m.invalidateExecutionActivityClaimsLocked(key)
 	delete(m.activityLeases, key)
-	delete(m.activityPending, key)
+	delete(m.activityLeaseOwners, key)
 	m.activityMu.Unlock()
-	lease.Release()
+	if !leaseClaimed {
+		lease.Release()
+	}
 }
 
-func (m *Manager) ensureExecutionActivity(ctx context.Context, executionID string, kind activity.Kind) error {
-	key := executionActivityKey(executionID)
-	m.activityMu.Lock()
-	existing := m.activityLeases[key]
-	if existing != nil {
-		m.activityMu.Unlock()
-		existing.SetKind(kind)
-		return nil
+type executionActivityClaim struct {
+	manager     *Manager
+	key         string
+	generation  uint64
+	lease       *activity.TaskLease
+	existing    bool
+	ctx         context.Context
+	cancel      context.CancelCauseFunc
+	invalidated bool
+	once        sync.Once
+}
+
+func (c *executionActivityClaim) Context(fallback context.Context) context.Context {
+	if c == nil {
+		return fallback
 	}
+	return c.ctx
+}
+
+func (c *executionActivityClaim) Commit() {
+	if c == nil {
+		return
+	}
+	c.once.Do(func() { c.manager.commitExecutionActivity(c) })
+}
+
+func (c *executionActivityClaim) Release() {
+	if c == nil {
+		return
+	}
+	c.once.Do(func() { c.manager.releaseExecutionActivityClaim(c) })
+}
+
+func (m *Manager) ensureExecutionActivity(
+	ctx context.Context,
+	executionID string,
+	kind activity.Kind,
+) (*executionActivityClaim, error) {
+	key := executionActivityKey(executionID)
+	claimCtx, cancel := context.WithCancelCause(ctx)
+	m.activityMu.Lock()
 	if m.activityPending == nil {
-		m.activityPending = make(map[string]uint64)
+		m.activityPending = make(map[string]map[uint64]*executionActivityClaim)
+	}
+	if m.activityLeaseOwners == nil {
+		m.activityLeaseOwners = make(map[string]uint64)
 	}
 	m.activityGeneration++
 	generation := m.activityGeneration
-	m.activityPending[key] = generation
+	claim := &executionActivityClaim{
+		manager: m, key: key, generation: generation, ctx: claimCtx, cancel: cancel,
+	}
+	pending := m.activityPending[key]
+	if pending == nil {
+		pending = make(map[uint64]*executionActivityClaim)
+		m.activityPending[key] = pending
+	}
+	pending[generation] = claim
+	existing := m.activityLeases[key]
+	if existing != nil && m.activityLeaseOwners[key] == 0 {
+		m.activityLeaseOwners[key] = generation
+		claim.lease = existing
+		claim.existing = true
+		m.activityMu.Unlock()
+		existing.SetKind(kind)
+		return claim, nil
+	}
 	m.activityMu.Unlock()
-	lease, err := m.acquireActivity(ctx, kind)
+	lease, err := m.acquireActivity(claimCtx, kind)
 	if err != nil {
-		m.clearPendingActivity(key, generation)
-		return err
+		m.clearPendingActivity(claim)
+		if cause := context.Cause(claimCtx); cause != nil {
+			return nil, cause
+		}
+		return nil, err
 	}
 	if lease == nil {
-		m.clearPendingActivity(key, generation)
-		return nil
+		m.clearPendingActivity(claim)
+		return nil, nil
 	}
-	m.finishPendingActivity(key, generation, lease)
-	return nil
+	return m.finishPendingActivity(claim, lease)
 }
 
-func (m *Manager) clearPendingActivity(key string, generation uint64) {
+func (m *Manager) clearPendingActivity(claim *executionActivityClaim) {
 	m.activityMu.Lock()
-	if m.activityPending[key] == generation {
-		delete(m.activityPending, key)
-	}
+	deletePendingGeneration(m.activityPending, claim.key, claim.generation)
 	m.activityMu.Unlock()
+	claim.cancel(nil)
 }
 
-func (m *Manager) finishPendingActivity(key string, generation uint64, lease *activity.TaskLease) {
+func (m *Manager) finishPendingActivity(
+	claim *executionActivityClaim,
+	lease *activity.TaskLease,
+) (*executionActivityClaim, error) {
 	m.activityMu.Lock()
-	if m.activityPending[key] != generation {
+	pending := m.activityPending[claim.key]
+	if pending[claim.generation] != claim || claim.invalidated {
 		m.activityMu.Unlock()
 		lease.Release()
+		claim.cancel(errExecutionActivityInvalidated)
+		return nil, errExecutionActivityInvalidated
+	}
+	claim.lease = lease
+	m.activityMu.Unlock()
+	return claim, nil
+}
+
+func (m *Manager) commitExecutionActivity(claim *executionActivityClaim) {
+	m.activityMu.Lock()
+	if claim.existing {
+		if m.activityLeases[claim.key] == claim.lease &&
+			m.activityLeaseOwners[claim.key] == claim.generation && !claim.invalidated {
+			m.activityLeaseOwners[claim.key] = 0
+			deletePendingGeneration(m.activityPending, claim.key, claim.generation)
+			m.activityMu.Unlock()
+			claim.cancel(nil)
+			return
+		}
+		deletePendingGeneration(m.activityPending, claim.key, claim.generation)
+		m.activityMu.Unlock()
+		claim.lease.Release()
+		claim.cancel(nil)
 		return
 	}
-	delete(m.activityPending, key)
-	previous := m.activityLeases[key]
-	m.activityLeases[key] = lease
+	pending := m.activityPending[claim.key]
+	if pending[claim.generation] != claim || claim.invalidated {
+		deletePendingGeneration(m.activityPending, claim.key, claim.generation)
+		m.activityMu.Unlock()
+		claim.lease.Release()
+		claim.cancel(nil)
+		return
+	}
+	deletePendingGeneration(m.activityPending, claim.key, claim.generation)
+	previous := m.activityLeases[claim.key]
+	if previous == nil || m.activityLeaseOwners[claim.key] != 0 {
+		previousClaimed := m.activityLeaseOwners[claim.key] != 0
+		if previousClaimed {
+			m.invalidateExecutionActivityOwnerLocked(claim.key)
+		}
+		m.activityLeases[claim.key] = claim.lease
+		m.activityLeaseOwners[claim.key] = 0
+		m.activityMu.Unlock()
+		if !previousClaimed {
+			previous.Release()
+		}
+		claim.cancel(nil)
+		return
+	}
 	m.activityMu.Unlock()
-	previous.Release()
+	claim.lease.Release()
+	claim.cancel(nil)
+}
+
+func (m *Manager) releaseExecutionActivityClaim(claim *executionActivityClaim) {
+	m.activityMu.Lock()
+	if claim.existing {
+		if m.activityLeases[claim.key] == claim.lease &&
+			m.activityLeaseOwners[claim.key] == claim.generation {
+			delete(m.activityLeases, claim.key)
+			delete(m.activityLeaseOwners, claim.key)
+		}
+	}
+	deletePendingGeneration(m.activityPending, claim.key, claim.generation)
+	m.activityMu.Unlock()
+	claim.lease.Release()
+	claim.cancel(nil)
+}
+
+func deletePendingGeneration(
+	pendingByKey map[string]map[uint64]*executionActivityClaim,
+	key string,
+	generation uint64,
+) {
+	pending := pendingByKey[key]
+	delete(pending, generation)
+	if len(pending) == 0 {
+		delete(pendingByKey, key)
+	}
+}
+
+func (m *Manager) invalidateExecutionActivityClaimsLocked(key string) bool {
+	owner := m.activityLeaseOwners[key]
+	for _, claim := range m.activityPending[key] {
+		claim.invalidated = true
+		claim.cancel(errExecutionActivityInvalidated)
+	}
+	return owner != 0
+}
+
+func (m *Manager) invalidateExecutionActivityOwnerLocked(key string) {
+	owner := m.activityLeaseOwners[key]
+	if claim := m.activityPending[key][owner]; claim != nil {
+		claim.invalidated = true
+		claim.cancel(errExecutionActivityInvalidated)
+	}
 }
 
 func executionActivityKey(executionID string) string {

--- a/apps/backend/internal/agent/runtime/lifecycle/activity.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/activity.go
@@ -1,0 +1,97 @@
+package lifecycle
+
+import (
+	"context"
+	"strings"
+
+	"github.com/kandev/kandev/internal/agent/runtime/activity"
+	agentctltypes "github.com/kandev/kandev/internal/agentctl/types"
+	"github.com/kandev/kandev/internal/agentctl/types/streams"
+)
+
+const (
+	executionActivityPrefix = "execution:"
+	processActivityPrefix   = "process:"
+)
+
+func (m *Manager) acquireActivity(ctx context.Context, kind activity.Kind) (*activity.TaskLease, error) {
+	m.activityMu.Lock()
+	coordinator := m.activityCoordinator
+	m.activityMu.Unlock()
+	if coordinator == nil {
+		return nil, nil
+	}
+	return coordinator.AcquireTask(ctx, kind)
+}
+
+func (m *Manager) trackActivity(key string, lease *activity.TaskLease) {
+	if lease == nil {
+		return
+	}
+	m.activityMu.Lock()
+	if m.activityLeases == nil {
+		m.activityLeases = make(map[string]*activity.TaskLease)
+	}
+	previous := m.activityLeases[key]
+	m.activityLeases[key] = lease
+	m.activityMu.Unlock()
+	previous.Release()
+}
+
+func (m *Manager) releaseActivity(key string) {
+	m.activityMu.Lock()
+	lease := m.activityLeases[key]
+	delete(m.activityLeases, key)
+	m.activityMu.Unlock()
+	lease.Release()
+}
+
+func (m *Manager) ensureExecutionActivity(ctx context.Context, executionID string, kind activity.Kind) error {
+	key := executionActivityKey(executionID)
+	m.activityMu.Lock()
+	existing := m.activityLeases[key]
+	m.activityMu.Unlock()
+	if existing != nil {
+		existing.SetKind(kind)
+		return nil
+	}
+	lease, err := m.acquireActivity(ctx, kind)
+	if err != nil {
+		return err
+	}
+	m.trackActivity(key, lease)
+	return nil
+}
+
+func executionActivityKey(executionID string) string {
+	return executionActivityPrefix + executionID
+}
+
+func processActivityKey(processID string) string {
+	return processActivityPrefix + processID
+}
+
+func processActivityKind(kind string) activity.Kind {
+	switch strings.ToLower(kind) {
+	case string(streams.ProcessKindSetup):
+		return activity.KindSetupScript
+	case string(agentctltypes.ProcessKindCleanup):
+		return activity.KindCleanupScript
+	case "test":
+		return activity.KindTestCommand
+	default:
+		return activity.KindShellCommand
+	}
+}
+
+func (m *Manager) releaseTerminalProcessActivity(status *agentctltypes.ProcessStatusUpdate) {
+	if status == nil {
+		return
+	}
+	switch status.Status {
+	case agentctltypes.ProcessStatusExited,
+		agentctltypes.ProcessStatusFailed,
+		agentctltypes.ProcessStatusStopped:
+		m.releaseActivity(processActivityKey(status.ProcessID))
+	}
+}

--- a/apps/backend/internal/agent/runtime/lifecycle/activity_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/activity_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/kandev/kandev/internal/agent/runtime/activity"
 	agentctltypes "github.com/kandev/kandev/internal/agentctl/types"
@@ -123,6 +124,11 @@ func TestStartAgentProcessFailureReleasesTrackedExecutionActivity(t *testing.T) 
 	if err := manager.executionStore.Add(execution); err != nil {
 		t.Fatalf("Add execution: %v", err)
 	}
+	lease, err := coordinator.AcquireTask(context.Background(), activity.KindExecutionPreparing)
+	if err != nil {
+		t.Fatalf("AcquireTask: %v", err)
+	}
+	manager.trackActivity(executionActivityKey(execution.ID), lease)
 
 	if err := manager.StartAgentProcess(context.Background(), execution.ID); err == nil {
 		t.Fatal("StartAgentProcess returned nil, want missing agentctl error")
@@ -146,9 +152,12 @@ func TestInitialPromptWaitFailureRetainsExecutionActivity(t *testing.T) {
 	}
 	manager.trackActivity(executionActivityKey("execution-prompt-wait"), lease)
 
-	if handler := manager.sessionManager.initialPromptFailure; handler != nil {
-		handler("execution-prompt-wait")
-	}
+	manager.sessionManager.SetInitialPromptFailureHandler(func(executionID string) {
+		if executionID != "execution-prompt-wait" {
+			t.Errorf("initial prompt failure execution ID = %q", executionID)
+		}
+	})
+	manager.sessionManager.initialPromptFailure("execution-prompt-wait")
 	maintenance, _, err := coordinator.TryAcquireMaintenance(context.Background(), 0)
 	if maintenance != nil {
 		maintenance.Release()
@@ -159,7 +168,7 @@ func TestInitialPromptWaitFailureRetainsExecutionActivity(t *testing.T) {
 	manager.releaseActivity(executionActivityKey("execution-prompt-wait"))
 }
 
-func TestReleaseInvalidatesPendingExecutionActivityAcquire(t *testing.T) {
+func TestReleaseCancelsPendingExecutionActivityAcquire(t *testing.T) {
 	manager := newTestManager(t)
 	coordinator := activity.NewCoordinator(activity.Options{})
 	manager.SetActivityCoordinator(coordinator)
@@ -170,15 +179,16 @@ func TestReleaseInvalidatesPendingExecutionActivityAcquire(t *testing.T) {
 
 	acquired := make(chan error, 1)
 	go func() {
-		acquired <- manager.ensureExecutionActivity(
+		_, acquireErr := manager.ensureExecutionActivity(
 			context.Background(), "completed-while-acquiring", activity.KindExecutionStarting,
 		)
+		acquired <- acquireErr
 	}()
 	<-maintenance.Context().Done()
 	manager.releaseActivity(executionActivityKey("completed-while-acquiring"))
 	maintenance.Release()
-	if err := <-acquired; err != nil {
-		t.Fatalf("ensureExecutionActivity: %v", err)
+	if err := <-acquired; !errors.Is(err, errExecutionActivityInvalidated) {
+		t.Fatalf("ensureExecutionActivity error = %v, want invalidation", err)
 	}
 
 	next, _, err := coordinator.TryAcquireMaintenance(context.Background(), 0)
@@ -186,4 +196,73 @@ func TestReleaseInvalidatesPendingExecutionActivityAcquire(t *testing.T) {
 		t.Fatalf("late execution lease remained active: %v", err)
 	}
 	next.Release()
+}
+
+func TestCancelledConcurrentExecutionActivityAcquireDoesNotInvalidateLeader(t *testing.T) {
+	manager := newTestManager(t)
+	coordinator := activity.NewCoordinator(activity.Options{})
+	manager.SetActivityCoordinator(coordinator)
+	maintenance, _, err := coordinator.TryAcquireMaintenance(context.Background(), 0)
+	if err != nil {
+		t.Fatalf("TryAcquireMaintenance: %v", err)
+	}
+
+	leaderDone := make(chan error, 1)
+	go func() {
+		claim, acquireErr := manager.ensureExecutionActivity(
+			context.Background(), "shared-start", activity.KindExecutionStarting,
+		)
+		if acquireErr == nil {
+			claim.Commit()
+		}
+		leaderDone <- acquireErr
+	}()
+	select {
+	case <-maintenance.Context().Done():
+	case <-time.After(time.Second):
+		t.Fatal("leader did not reach activity admission")
+	}
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	claim, err := manager.ensureExecutionActivity(
+		cancelledCtx, "shared-start", activity.KindExecutionStarting,
+	)
+	claim.Release()
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("concurrent acquire error = %v, want context cancellation", err)
+	}
+	maintenance.Release()
+	if err := <-leaderDone; err != nil {
+		t.Fatalf("leader acquire: %v", err)
+	}
+	if _, _, err := coordinator.TryAcquireMaintenance(context.Background(), 0); !errors.Is(err, activity.ErrBusy) {
+		t.Fatalf("maintenance error = %v, want ErrBusy after leader acquired", err)
+	}
+	manager.releaseActivity(executionActivityKey("shared-start"))
+}
+
+func TestStaleFailedExecutionActivityDoesNotReleaseSuccessfulSuccessor(t *testing.T) {
+	manager := newTestManager(t)
+	coordinator := activity.NewCoordinator(activity.Options{})
+	manager.SetActivityCoordinator(coordinator)
+
+	stale, err := manager.ensureExecutionActivity(
+		context.Background(), "shared-start", activity.KindExecutionStarting,
+	)
+	if err != nil {
+		t.Fatalf("stale acquire: %v", err)
+	}
+	successor, err := manager.ensureExecutionActivity(
+		context.Background(), "shared-start", activity.KindExecutionPreparing,
+	)
+	if err != nil {
+		t.Fatalf("successor acquire: %v", err)
+	}
+
+	successor.Commit()
+	stale.Release()
+	if _, _, err := coordinator.TryAcquireMaintenance(context.Background(), 0); !errors.Is(err, activity.ErrBusy) {
+		t.Fatalf("maintenance error = %v, want ErrBusy after successor succeeded", err)
+	}
+	manager.releaseActivity(executionActivityKey("shared-start"))
 }

--- a/apps/backend/internal/agent/runtime/lifecycle/activity_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/activity_test.go
@@ -1,0 +1,137 @@
+package lifecycle
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/kandev/kandev/internal/agent/runtime/activity"
+	agentctltypes "github.com/kandev/kandev/internal/agentctl/types"
+	v1 "github.com/kandev/kandev/pkg/api/v1"
+)
+
+func TestProcessActivityKind(t *testing.T) {
+	tests := []struct {
+		kind string
+		want activity.Kind
+	}{
+		{kind: "setup", want: activity.KindSetupScript},
+		{kind: "cleanup", want: activity.KindCleanupScript},
+		{kind: "test", want: activity.KindTestCommand},
+		{kind: "custom", want: activity.KindShellCommand},
+	}
+	for _, test := range tests {
+		t.Run(test.kind, func(t *testing.T) {
+			if got := processActivityKind(test.kind); got != test.want {
+				t.Fatalf("processActivityKind(%q) = %q, want %q", test.kind, got, test.want)
+			}
+		})
+	}
+}
+
+func TestTerminalProcessStatusReleasesTrackedActivity(t *testing.T) {
+	coordinator := activity.NewCoordinator(activity.Options{})
+	manager := &Manager{}
+	manager.SetActivityCoordinator(coordinator)
+
+	lease, err := manager.acquireActivity(context.Background(), activity.KindShellCommand)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manager.trackActivity(processActivityKey("process-1"), lease)
+	if len(coordinator.BusyKinds()) != 1 {
+		t.Fatal("expected process activity to hold the host gate")
+	}
+
+	manager.releaseTerminalProcessActivity(&agentctltypes.ProcessStatusUpdate{
+		ProcessID: "process-1",
+		Status:    agentctltypes.ProcessStatusExited,
+	})
+	if busy := coordinator.BusyKinds(); len(busy) != 0 {
+		t.Fatalf("terminal process left busy resources: %v", busy)
+	}
+
+	maintenance, _, err := coordinator.TryAcquireMaintenance(context.Background(), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer maintenance.Release()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := manager.acquireActivity(ctx, activity.KindExecutionStarting); !errors.Is(err, context.Canceled) {
+		t.Fatalf("acquireActivity error = %v, want context.Canceled", err)
+	}
+}
+
+func TestMarkCompletedReleasesTrackedExecutionActivity(t *testing.T) {
+	manager := newTestManager(t)
+	coordinator := activity.NewCoordinator(activity.Options{})
+	manager.SetActivityCoordinator(coordinator)
+	execution := &AgentExecution{ID: "execution-complete", Status: v1.AgentStatusRunning}
+	if err := manager.executionStore.Add(execution); err != nil {
+		t.Fatalf("Add execution: %v", err)
+	}
+	lease, err := coordinator.AcquireTask(context.Background(), activity.KindExecutionRunning)
+	if err != nil {
+		t.Fatalf("AcquireTask: %v", err)
+	}
+	manager.trackActivity(executionActivityKey(execution.ID), lease)
+
+	if err := manager.MarkCompleted(execution.ID, 0, ""); err != nil {
+		t.Fatalf("MarkCompleted: %v", err)
+	}
+	maintenance, _, err := coordinator.TryAcquireMaintenance(context.Background(), 0)
+	if maintenance != nil {
+		maintenance.Release()
+	}
+	if err != nil {
+		t.Fatalf("maintenance after MarkCompleted: %v", err)
+	}
+}
+
+func TestMarkBootReadyReleasesTrackedInitialExecutionActivity(t *testing.T) {
+	manager := newTestManager(t)
+	coordinator := activity.NewCoordinator(activity.Options{})
+	manager.SetActivityCoordinator(coordinator)
+	execution := &AgentExecution{ID: "execution-no-prompt", Status: v1.AgentStatusRunning}
+	if err := manager.executionStore.Add(execution); err != nil {
+		t.Fatalf("Add execution: %v", err)
+	}
+	lease, err := coordinator.AcquireTask(context.Background(), activity.KindExecutionPreparing)
+	if err != nil {
+		t.Fatalf("AcquireTask: %v", err)
+	}
+	manager.trackActivity(executionActivityKey(execution.ID), lease)
+
+	if err := manager.MarkBootReady(execution.ID); err != nil {
+		t.Fatalf("MarkBootReady: %v", err)
+	}
+	maintenance, _, err := coordinator.TryAcquireMaintenance(context.Background(), 0)
+	if maintenance != nil {
+		maintenance.Release()
+	}
+	if err != nil {
+		t.Fatalf("maintenance after MarkBootReady: %v", err)
+	}
+}
+
+func TestStartAgentProcessFailureReleasesTrackedExecutionActivity(t *testing.T) {
+	manager := newTestManager(t)
+	coordinator := activity.NewCoordinator(activity.Options{})
+	manager.SetActivityCoordinator(coordinator)
+	execution := &AgentExecution{ID: "execution-start-failure", Status: v1.AgentStatusStarting}
+	if err := manager.executionStore.Add(execution); err != nil {
+		t.Fatalf("Add execution: %v", err)
+	}
+
+	if err := manager.StartAgentProcess(context.Background(), execution.ID); err == nil {
+		t.Fatal("StartAgentProcess returned nil, want missing agentctl error")
+	}
+	maintenance, _, err := coordinator.TryAcquireMaintenance(context.Background(), 0)
+	if maintenance != nil {
+		maintenance.Release()
+	}
+	if err != nil {
+		t.Fatalf("maintenance after startup failure: %v", err)
+	}
+}

--- a/apps/backend/internal/agent/runtime/lifecycle/activity_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/activity_test.go
@@ -135,3 +135,55 @@ func TestStartAgentProcessFailureReleasesTrackedExecutionActivity(t *testing.T) 
 		t.Fatalf("maintenance after startup failure: %v", err)
 	}
 }
+
+func TestInitialPromptWaitFailureRetainsExecutionActivity(t *testing.T) {
+	manager := newTestManager(t)
+	coordinator := activity.NewCoordinator(activity.Options{})
+	manager.SetActivityCoordinator(coordinator)
+	lease, err := coordinator.AcquireTask(context.Background(), activity.KindExecutionRunning)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manager.trackActivity(executionActivityKey("execution-prompt-wait"), lease)
+
+	if handler := manager.sessionManager.initialPromptFailure; handler != nil {
+		handler("execution-prompt-wait")
+	}
+	maintenance, _, err := coordinator.TryAcquireMaintenance(context.Background(), 0)
+	if maintenance != nil {
+		maintenance.Release()
+	}
+	if !errors.Is(err, activity.ErrBusy) {
+		t.Fatalf("maintenance error = %v, want ErrBusy while execution may still run", err)
+	}
+	manager.releaseActivity(executionActivityKey("execution-prompt-wait"))
+}
+
+func TestReleaseInvalidatesPendingExecutionActivityAcquire(t *testing.T) {
+	manager := newTestManager(t)
+	coordinator := activity.NewCoordinator(activity.Options{})
+	manager.SetActivityCoordinator(coordinator)
+	maintenance, _, err := coordinator.TryAcquireMaintenance(context.Background(), 0)
+	if err != nil {
+		t.Fatalf("TryAcquireMaintenance: %v", err)
+	}
+
+	acquired := make(chan error, 1)
+	go func() {
+		acquired <- manager.ensureExecutionActivity(
+			context.Background(), "completed-while-acquiring", activity.KindExecutionStarting,
+		)
+	}()
+	<-maintenance.Context().Done()
+	manager.releaseActivity(executionActivityKey("completed-while-acquiring"))
+	maintenance.Release()
+	if err := <-acquired; err != nil {
+		t.Fatalf("ensureExecutionActivity: %v", err)
+	}
+
+	next, _, err := coordinator.TryAcquireMaintenance(context.Background(), 0)
+	if err != nil {
+		t.Fatalf("late execution lease remained active: %v", err)
+	}
+	next.Release()
+}

--- a/apps/backend/internal/agent/runtime/lifecycle/env_preparer.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/env_preparer.go
@@ -53,6 +53,7 @@ type RepoPrepareSpec struct {
 // EnvPrepareRequest contains the parameters for environment preparation.
 type EnvPrepareRequest struct {
 	TaskID          string
+	WorkspaceID     string
 	SessionID       string
 	TaskTitle       string
 	ExecutionID     string

--- a/apps/backend/internal/agent/runtime/lifecycle/env_preparer_worktree.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/env_preparer_worktree.go
@@ -248,6 +248,7 @@ func (p *WorktreePreparer) createWorktreeWithSync(
 func buildWorktreeCreateRequest(req *EnvPrepareRequest) worktree.CreateRequest {
 	return worktree.CreateRequest{
 		TaskID:                 req.TaskID,
+		WorkspaceID:            req.WorkspaceID,
 		SessionID:              req.SessionID,
 		TaskTitle:              req.TaskTitle,
 		RepositoryID:           req.RepositoryID,

--- a/apps/backend/internal/agent/runtime/lifecycle/executor_docker.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/executor_docker.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kandev/kandev/internal/agent/agents"
 	"github.com/kandev/kandev/internal/agent/docker"
 	"github.com/kandev/kandev/internal/agent/executor"
+	"github.com/kandev/kandev/internal/agent/runtime/activity"
 	agentctl "github.com/kandev/kandev/internal/agent/runtime/agentctl"
 	"github.com/kandev/kandev/internal/agentctl/server/process"
 	"github.com/kandev/kandev/internal/common/config"
@@ -87,6 +88,7 @@ type DockerExecutor struct {
 	initialized  bool
 	docker       *docker.Client
 	containerMgr *ContainerManager
+	activity     *activity.Coordinator
 }
 
 // NewDockerExecutor creates a new Docker runtime.
@@ -118,12 +120,22 @@ func (r *DockerExecutor) ensureClient() (*docker.Client, *ContainerManager, erro
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create docker client: %w", err)
 	}
+	cli.SetActivityCoordinator(r.activity)
 
 	r.docker = cli
 	r.containerMgr = NewContainerManager(cli, "", r.kandevHomeDir, r.logger)
 	r.initialized = true
 
 	return r.docker, r.containerMgr, nil
+}
+
+func (r *DockerExecutor) SetActivityCoordinator(coordinator *activity.Coordinator) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.activity = coordinator
+	if r.docker != nil {
+		r.docker.SetActivityCoordinator(coordinator)
+	}
 }
 
 // Client returns the lazily-initialized Docker client, or nil if Docker is unavailable.

--- a/apps/backend/internal/agent/runtime/lifecycle/executor_docker_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/executor_docker_test.go
@@ -3,6 +3,7 @@ package lifecycle
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -10,6 +11,7 @@ import (
 	"github.com/kandev/kandev/internal/agent/agents"
 	"github.com/kandev/kandev/internal/agent/docker"
 	"github.com/kandev/kandev/internal/agent/executor"
+	"github.com/kandev/kandev/internal/agent/runtime/activity"
 	"github.com/kandev/kandev/internal/common/config"
 	"github.com/kandev/kandev/internal/common/logger"
 )
@@ -44,6 +46,27 @@ func TestNewDockerExecutor(t *testing.T) {
 	}
 	if exec.newClientFunc == nil {
 		t.Error("expected newClientFunc to be set")
+	}
+}
+
+func TestSetActivityCoordinatorReachesLazilyCreatedDockerClient(t *testing.T) {
+	log := newTestDockerLogger()
+	dockerExec := NewDockerExecutor(config.DockerConfig{}, "", log)
+	dockerExec.newClientFunc = func(config.DockerConfig, *logger.Logger) (*docker.Client, error) {
+		return &docker.Client{}, nil
+	}
+	registry := NewExecutorRegistry(log)
+	registry.Register(dockerExec)
+	manager := NewManager(nil, nil, registry, nil, nil, nil, ExecutorFallbackWarn, "", log)
+	manager.SetActivityCoordinator(activity.NewCoordinator(activity.Options{}))
+
+	client := dockerExec.Client()
+	if client == nil {
+		t.Fatal("DockerExecutor.Client returned nil")
+	}
+	activityField := reflect.ValueOf(client).Elem().FieldByName("activity")
+	if !activityField.IsValid() || activityField.IsNil() {
+		t.Fatal("lazy Docker client did not receive the activity coordinator")
 	}
 }
 

--- a/apps/backend/internal/agent/runtime/lifecycle/manager.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager.go
@@ -140,6 +140,8 @@ type Manager struct {
 	activityCoordinator *activity.Coordinator
 	activityMu          sync.Mutex
 	activityLeases      map[string]*activity.TaskLease
+	activityPending     map[string]uint64
+	activityGeneration  uint64
 }
 
 // ManagedGoCacheEnvironmentProvider supplies the environment for one new
@@ -157,10 +159,23 @@ func (m *Manager) SetManagedGoCacheEnvironmentProvider(provider ManagedGoCacheEn
 // It is optional so embedded and test configurations retain legacy behavior.
 func (m *Manager) SetActivityCoordinator(coordinator *activity.Coordinator) {
 	m.activityMu.Lock()
-	defer m.activityMu.Unlock()
 	m.activityCoordinator = coordinator
 	if m.activityLeases == nil {
 		m.activityLeases = make(map[string]*activity.TaskLease)
+	}
+	if m.activityPending == nil {
+		m.activityPending = make(map[string]uint64)
+	}
+	m.activityMu.Unlock()
+	if m.executorRegistry == nil {
+		return
+	}
+	backend, err := m.executorRegistry.GetBackend(executor.NameDocker)
+	if err != nil {
+		return
+	}
+	if dockerExecutor, ok := backend.(*DockerExecutor); ok {
+		dockerExecutor.SetActivityCoordinator(coordinator)
 	}
 }
 
@@ -230,10 +245,6 @@ func NewManager(
 		skillDeployer:            NoopSkillDeployer(),
 		remediateNpxCache:        routingerr.RemediateNpxCache,
 	}
-	sessionManager.SetInitialPromptFailureHandler(func(executionID string) {
-		mgr.releaseActivity(executionActivityKey(executionID))
-	})
-
 	// Initialize stream manager with callbacks that delegate to manager methods
 	// mcpHandler will be set later via SetMCPHandler.
 	// stopCh is shared with the manager so workspace-stream backoff drains on Stop.

--- a/apps/backend/internal/agent/runtime/lifecycle/manager.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager.go
@@ -140,7 +140,8 @@ type Manager struct {
 	activityCoordinator *activity.Coordinator
 	activityMu          sync.Mutex
 	activityLeases      map[string]*activity.TaskLease
-	activityPending     map[string]uint64
+	activityLeaseOwners map[string]uint64
+	activityPending     map[string]map[uint64]*executionActivityClaim
 	activityGeneration  uint64
 }
 
@@ -163,8 +164,11 @@ func (m *Manager) SetActivityCoordinator(coordinator *activity.Coordinator) {
 	if m.activityLeases == nil {
 		m.activityLeases = make(map[string]*activity.TaskLease)
 	}
+	if m.activityLeaseOwners == nil {
+		m.activityLeaseOwners = make(map[string]uint64)
+	}
 	if m.activityPending == nil {
-		m.activityPending = make(map[string]uint64)
+		m.activityPending = make(map[string]map[uint64]*executionActivityClaim)
 	}
 	m.activityMu.Unlock()
 	if m.executorRegistry == nil {

--- a/apps/backend/internal/agent/runtime/lifecycle/manager.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager.go
@@ -3,6 +3,7 @@
 package lifecycle
 
 import (
+	"context"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -13,6 +14,7 @@ import (
 	"github.com/kandev/kandev/internal/agent/docker"
 	"github.com/kandev/kandev/internal/agent/executor"
 	"github.com/kandev/kandev/internal/agent/registry"
+	"github.com/kandev/kandev/internal/agent/runtime/activity"
 	agentctl "github.com/kandev/kandev/internal/agent/runtime/agentctl"
 	"github.com/kandev/kandev/internal/agent/runtime/routingerr"
 	"github.com/kandev/kandev/internal/common/logger"
@@ -130,6 +132,36 @@ type Manager struct {
 	// 0 when unset (tests, or before the launcher wires it). Never used for
 	// SSH/remote rows — their process lives on another host.
 	standaloneHostPID atomic.Int64
+
+	// managedGoCache provides the opt-in GOCACHE for host-local executions.
+	// System storage wiring installs it after settings persistence is ready.
+	managedGoCache ManagedGoCacheEnvironmentProvider
+
+	activityCoordinator *activity.Coordinator
+	activityMu          sync.Mutex
+	activityLeases      map[string]*activity.TaskLease
+}
+
+// ManagedGoCacheEnvironmentProvider supplies the environment for one new
+// local execution. Implementations must return an absolute GOCACHE path.
+type ManagedGoCacheEnvironmentProvider interface {
+	ExecutionEnvironment(ctx context.Context) (map[string]string, error)
+}
+
+// SetManagedGoCacheEnvironmentProvider wires install-wide managed cache settings.
+func (m *Manager) SetManagedGoCacheEnvironmentProvider(provider ManagedGoCacheEnvironmentProvider) {
+	m.managedGoCache = provider
+}
+
+// SetActivityCoordinator wires the install-wide host-resource activity gate.
+// It is optional so embedded and test configurations retain legacy behavior.
+func (m *Manager) SetActivityCoordinator(coordinator *activity.Coordinator) {
+	m.activityMu.Lock()
+	defer m.activityMu.Unlock()
+	m.activityCoordinator = coordinator
+	if m.activityLeases == nil {
+		m.activityLeases = make(map[string]*activity.TaskLease)
+	}
 }
 
 // SetStandaloneHostPID records the local agentctl control-server PID so
@@ -198,6 +230,9 @@ func NewManager(
 		skillDeployer:            NoopSkillDeployer(),
 		remediateNpxCache:        routingerr.RemediateNpxCache,
 	}
+	sessionManager.SetInitialPromptFailureHandler(func(executionID string) {
+		mgr.releaseActivity(executionActivityKey(executionID))
+	})
 
 	// Initialize stream manager with callbacks that delegate to manager methods
 	// mcpHandler will be set later via SetMCPHandler.

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_events.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_events.go
@@ -260,6 +260,7 @@ func (m *Manager) handleCompleteEvent(execution *AgentExecution, event *agentctl
 	if !claimed {
 		return false
 	}
+	m.releaseActivity(executionActivityKey(execution.ID))
 
 	execution.lastActivityAtMu.Lock()
 	execution.lastActivityAt = time.Now()
@@ -662,6 +663,7 @@ func (m *Manager) handleProcessStatus(execution *AgentExecution, status *agentct
 		zap.String("status", string(status.Status)),
 	)
 	m.eventPublisher.PublishProcessStatus(execution, status)
+	m.releaseTerminalProcessActivity(status)
 }
 
 // handleShellExit processes shell exit events from the workspace stream

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_execution.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_execution.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/uuid"
 	"go.uber.org/zap"
+	"golang.org/x/sync/singleflight"
 
 	"github.com/kandev/kandev/internal/agent/runtime/activity"
 	"github.com/kandev/kandev/internal/agentctl/tracing"
@@ -19,6 +20,11 @@ import (
 // ErrSessionWorkspaceNotReady indicates the task session exists but does not yet
 // have a resolved workspace path (typically while worktree preparation is in progress).
 var ErrSessionWorkspaceNotReady = errors.New("session workspace not ready")
+
+// coalescedExecutionCreationTimeout matches the runtime's 60-second agentctl
+// startup window while preventing blocked instance I/O from owning the shared
+// session slot and its activity lease for the lifetime of the manager.
+const coalescedExecutionCreationTimeout = time.Minute
 
 // GetOrEnsureExecution returns an existing execution or creates one on-demand.
 // Use this for workspace-oriented operations (files, shell, inference, ports, vscode, LSP)
@@ -39,15 +45,13 @@ func (m *Manager) GetOrEnsureExecution(ctx context.Context, sessionID string) (*
 	// Slow path: create on-demand, deduplicated by sessionID-keyed singleflight.
 	// Use ensureWorkspaceExecutionLocked (not EnsureWorkspaceExecutionForSession)
 	// to avoid recursing into the same singleflight slot we already hold.
-	v, err, _ := m.ensureExecutionGroup.Do(sessionID, func() (interface{}, error) {
-		creationCtx, cancel := coalescedExecutionContext(ctx)
-		defer cancel()
-		return m.ensureWorkspaceExecutionLocked(creationCtx, "", sessionID)
+	value, err := m.doCoalescedExecution(ctx, sessionID, func(sharedCtx context.Context) (interface{}, error) {
+		return m.ensureWorkspaceExecutionLocked(sharedCtx, "", sessionID)
 	})
 	if err != nil {
 		return nil, err
 	}
-	return v.(*AgentExecution), nil
+	return value.(*AgentExecution), nil
 }
 
 // GetOrEnsureExecutionForEnvironment returns an execution for a task environment,
@@ -95,9 +99,7 @@ func (m *Manager) GetOrEnsureExecutionForEnvironment(ctx context.Context, taskEn
 	// Share the sessionID-keyed bucket so we deduplicate against any concurrent
 	// GetOrEnsureExecution(sessionID) / EnsureWorkspaceExecutionForSession for
 	// the same session.
-	v, err, _ := m.ensureExecutionGroup.Do(info.SessionID, func() (interface{}, error) {
-		creationCtx, cancel := coalescedExecutionContext(ctx)
-		defer cancel()
+	value, err := m.doCoalescedExecution(ctx, info.SessionID, func(sharedCtx context.Context) (interface{}, error) {
 		if execution, exists := m.executionStore.GetBySessionID(info.SessionID); exists {
 			return execution, nil
 		}
@@ -107,7 +109,7 @@ func (m *Manager) GetOrEnsureExecutionForEnvironment(ctx context.Context, taskEn
 		// createExecution publishes AgentctlStarting before spawning the
 		// waitForAgentctlReady goroutine, so frontend gates flip out of
 		// `undefined` even on this lazy-create path.
-		execution, err := m.createExecution(creationCtx, info.TaskID, info)
+		execution, err := m.createExecution(sharedCtx, info.TaskID, info)
 		if err != nil {
 			return nil, err
 		}
@@ -116,7 +118,7 @@ func (m *Manager) GetOrEnsureExecutionForEnvironment(ctx context.Context, taskEn
 	if err != nil {
 		return nil, err
 	}
-	return v.(*AgentExecution), nil
+	return value.(*AgentExecution), nil
 }
 
 // EnsureWorkspaceExecutionForSession ensures an agentctl execution exists for a specific task session.
@@ -138,19 +140,56 @@ func (m *Manager) EnsureWorkspaceExecutionForSession(ctx context.Context, taskID
 		return execution, nil
 	}
 
-	v, err, _ := m.ensureExecutionGroup.Do(sessionID, func() (interface{}, error) {
-		creationCtx, cancel := coalescedExecutionContext(ctx)
-		defer cancel()
-		return m.ensureWorkspaceExecutionLocked(creationCtx, taskID, sessionID)
+	value, err := m.doCoalescedExecution(ctx, sessionID, func(sharedCtx context.Context) (interface{}, error) {
+		return m.ensureWorkspaceExecutionLocked(sharedCtx, taskID, sessionID)
 	})
 	if err != nil {
 		return nil, err
 	}
-	return v.(*AgentExecution), nil
+	return value.(*AgentExecution), nil
 }
 
-func coalescedExecutionContext(ctx context.Context) (context.Context, context.CancelFunc) {
-	return context.WithTimeout(context.WithoutCancel(ctx), time.Minute)
+func (m *Manager) doCoalescedExecution(
+	ctx context.Context,
+	key string,
+	operation func(context.Context) (interface{}, error),
+) (interface{}, error) {
+	result := m.ensureExecutionGroup.DoChan(key, func() (interface{}, error) {
+		sharedCtx, cancel := m.coalescedExecutionContext(ctx)
+		defer cancel()
+		return operation(sharedCtx)
+	})
+	return awaitCoalescedResult(ctx, result)
+}
+
+func (m *Manager) coalescedExecutionContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	sharedCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), coalescedExecutionCreationTimeout)
+	if m.stopCh == nil {
+		return sharedCtx, cancel
+	}
+	go func() {
+		select {
+		case <-m.stopCh:
+			cancel()
+		case <-sharedCtx.Done():
+		}
+	}()
+	return sharedCtx, cancel
+}
+
+func awaitCoalescedResult(
+	ctx context.Context,
+	result <-chan singleflight.Result,
+) (interface{}, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case completed := <-result:
+		if completed.Err != nil {
+			return nil, completed.Err
+		}
+		return completed.Val, nil
+	}
 }
 
 // ensureWorkspaceExecutionLocked is the body of EnsureWorkspaceExecutionForSession

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_execution.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_execution.go
@@ -40,7 +40,9 @@ func (m *Manager) GetOrEnsureExecution(ctx context.Context, sessionID string) (*
 	// Use ensureWorkspaceExecutionLocked (not EnsureWorkspaceExecutionForSession)
 	// to avoid recursing into the same singleflight slot we already hold.
 	v, err, _ := m.ensureExecutionGroup.Do(sessionID, func() (interface{}, error) {
-		return m.ensureWorkspaceExecutionLocked(ctx, "", sessionID)
+		creationCtx, cancel := coalescedExecutionContext(ctx)
+		defer cancel()
+		return m.ensureWorkspaceExecutionLocked(creationCtx, "", sessionID)
 	})
 	if err != nil {
 		return nil, err
@@ -94,6 +96,8 @@ func (m *Manager) GetOrEnsureExecutionForEnvironment(ctx context.Context, taskEn
 	// GetOrEnsureExecution(sessionID) / EnsureWorkspaceExecutionForSession for
 	// the same session.
 	v, err, _ := m.ensureExecutionGroup.Do(info.SessionID, func() (interface{}, error) {
+		creationCtx, cancel := coalescedExecutionContext(ctx)
+		defer cancel()
 		if execution, exists := m.executionStore.GetBySessionID(info.SessionID); exists {
 			return execution, nil
 		}
@@ -103,7 +107,7 @@ func (m *Manager) GetOrEnsureExecutionForEnvironment(ctx context.Context, taskEn
 		// createExecution publishes AgentctlStarting before spawning the
 		// waitForAgentctlReady goroutine, so frontend gates flip out of
 		// `undefined` even on this lazy-create path.
-		execution, err := m.createExecution(ctx, info.TaskID, info)
+		execution, err := m.createExecution(creationCtx, info.TaskID, info)
 		if err != nil {
 			return nil, err
 		}
@@ -135,12 +139,18 @@ func (m *Manager) EnsureWorkspaceExecutionForSession(ctx context.Context, taskID
 	}
 
 	v, err, _ := m.ensureExecutionGroup.Do(sessionID, func() (interface{}, error) {
-		return m.ensureWorkspaceExecutionLocked(ctx, taskID, sessionID)
+		creationCtx, cancel := coalescedExecutionContext(ctx)
+		defer cancel()
+		return m.ensureWorkspaceExecutionLocked(creationCtx, taskID, sessionID)
 	})
 	if err != nil {
 		return nil, err
 	}
 	return v.(*AgentExecution), nil
+}
+
+func coalescedExecutionContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.WithoutCancel(ctx), time.Minute)
 }
 
 // ensureWorkspaceExecutionLocked is the body of EnsureWorkspaceExecutionForSession
@@ -447,6 +457,13 @@ func (m *Manager) createExecution(ctx context.Context, taskID string, info *Work
 	if len(env) == 0 {
 		env = nil
 	}
+	metadata := make(map[string]interface{}, len(info.Metadata)+1)
+	for key, value := range info.Metadata {
+		metadata[key] = value
+	}
+	if managedReq.managedGoCachePath != "" {
+		metadata[managedGoCacheMetadataKey] = managedReq.managedGoCachePath
+	}
 
 	req := &ExecutorCreateRequest{
 		InstanceID:                     executionID,
@@ -461,7 +478,7 @@ func (m *Manager) createExecution(ctx context.Context, taskID string, info *Work
 		AutoApprovePermissions:         autoApprove,
 		AutoApprovePermissionsOverride: autoApproveOverride,
 		AgentConfig:                    agentConfig,
-		Metadata:                       info.Metadata,
+		Metadata:                       metadata,
 		PreviousExecutionID:            info.AgentExecutionID,
 		AuthToken:                      m.revealRuntimeSecret(ctx, info.Metadata, MetadataKeyAuthTokenSecret),
 		BootstrapNonce:                 m.revealRuntimeSecret(ctx, info.Metadata, MetadataKeyBootstrapNonceSecret),

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_execution.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_execution.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/uuid"
 	"go.uber.org/zap"
 
+	"github.com/kandev/kandev/internal/agent/runtime/activity"
 	"github.com/kandev/kandev/internal/agentctl/tracing"
 	"github.com/kandev/kandev/internal/common/appctx"
 	"github.com/kandev/kandev/internal/events"
@@ -385,6 +386,13 @@ func (m *Manager) verifyPassthroughEnabled(ctx context.Context, sessionID, profi
 // createExecution creates an agentctl execution.
 // The agent subprocess is NOT started - call ConfigureAgent + Start explicitly.
 func (m *Manager) createExecution(ctx context.Context, taskID string, info *WorkspaceInfo) (*AgentExecution, error) {
+	activityLease, err := m.acquireActivity(ctx, activity.KindExecutionStarting)
+	if err != nil {
+		return nil, err
+	}
+	defer activityLease.Release()
+	activityLease.SetKind(activity.KindExecutionPreparing)
+
 	// Select runtime based on executor type; falls back to standalone if empty/unavailable
 	rt, err := m.getExecutorBackend(info.ExecutorType)
 	if err != nil {
@@ -425,6 +433,11 @@ func (m *Manager) createExecution(ctx context.Context, taskID string, info *Work
 		}
 	}
 	m.mergeAgentProfileEnvFromInfo(ctx, profileInfo, env)
+	managedReq := &LaunchRequest{ExecutorType: info.ExecutorType, Env: env}
+	if err := m.prepareManagedGoCacheEnvironment(ctx, managedReq); err != nil {
+		return nil, err
+	}
+	env = managedReq.Env
 	autoApprove := false
 	var autoApproveOverride *bool
 	if profileInfo != nil {

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_execution_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_execution_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/kandev/kandev/internal/agent/executor"
+	"github.com/kandev/kandev/internal/agent/runtime/activity"
 	agentctl "github.com/kandev/kandev/internal/agent/runtime/agentctl"
 	settingsmodels "github.com/kandev/kandev/internal/agent/settings/models"
 	"github.com/kandev/kandev/internal/common/logger"
@@ -45,6 +46,46 @@ func TestErrSessionWorkspaceNotReady_UnrelatedError(t *testing.T) {
 
 	if errors.Is(unrelated, ErrSessionWorkspaceNotReady) {
 		t.Errorf("expected errors.Is to be false for unrelated error")
+	}
+}
+
+func TestGetOrEnsureExecutionLeaderCancellationDoesNotAbortLiveWaiter(t *testing.T) {
+	mgr, _ := newEnvironmentExecutionTestManager(t, &mockWorkspaceInfoProvider{
+		infos: map[string]*WorkspaceInfo{
+			"session-shared": {
+				TaskID: "task-1", SessionID: "session-shared", TaskEnvironmentID: "env-1",
+				WorkspacePath: "/workspace/task-1", AgentID: "auggie",
+			},
+		},
+	})
+	coordinator := activity.NewCoordinator(activity.Options{})
+	mgr.SetActivityCoordinator(coordinator)
+	maintenance, _, err := coordinator.TryAcquireMaintenance(context.Background(), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	leaderCtx, cancelLeader := context.WithCancel(context.Background())
+	defer cancelLeader()
+	results := make(chan error, 2)
+	go func() {
+		_, err := mgr.GetOrEnsureExecution(leaderCtx, "session-shared")
+		results <- err
+	}()
+	select {
+	case <-maintenance.Context().Done():
+	case <-time.After(time.Second):
+		t.Fatal("leader did not reach activity admission")
+	}
+	go func() {
+		_, err := mgr.GetOrEnsureExecution(context.Background(), "session-shared")
+		results <- err
+	}()
+	cancelLeader()
+	maintenance.Release()
+	for range 2 {
+		if err := <-results; err != nil {
+			t.Fatalf("coalesced execution failed after leader cancellation: %v", err)
+		}
 	}
 }
 

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_execution_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_execution_test.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/kandev/kandev/internal/agent/executor"
@@ -66,10 +67,14 @@ func TestGetOrEnsureExecutionLeaderCancellationDoesNotAbortLiveWaiter(t *testing
 	}
 	leaderCtx, cancelLeader := context.WithCancel(context.Background())
 	defer cancelLeader()
-	results := make(chan error, 2)
+	type result struct {
+		caller string
+		err    error
+	}
+	results := make(chan result, 2)
 	go func() {
 		_, err := mgr.GetOrEnsureExecution(leaderCtx, "session-shared")
-		results <- err
+		results <- result{caller: "leader", err: err}
 	}()
 	select {
 	case <-maintenance.Context().Done():
@@ -78,15 +83,176 @@ func TestGetOrEnsureExecutionLeaderCancellationDoesNotAbortLiveWaiter(t *testing
 	}
 	go func() {
 		_, err := mgr.GetOrEnsureExecution(context.Background(), "session-shared")
-		results <- err
+		results <- result{caller: "follower", err: err}
 	}()
 	cancelLeader()
 	maintenance.Release()
 	for range 2 {
-		if err := <-results; err != nil {
-			t.Fatalf("coalesced execution failed after leader cancellation: %v", err)
+		got := <-results
+		if got.caller == "leader" && !errors.Is(got.err, context.Canceled) {
+			t.Fatalf("leader error = %v, want context cancellation", got.err)
+		}
+		if got.caller == "follower" && got.err != nil {
+			t.Fatalf("live follower failed after leader cancellation: %v", got.err)
 		}
 	}
+}
+
+func TestShortDeadlineLeaderDoesNotAbortLiveCoalescedWaiter(t *testing.T) {
+	provider := &notifyingWorkspaceInfoProvider{
+		mockWorkspaceInfoProvider: &mockWorkspaceInfoProvider{
+			infos: map[string]*WorkspaceInfo{
+				"session-shared": {
+					TaskID: "task-1", SessionID: "session-shared", TaskEnvironmentID: "env-1",
+					WorkspacePath: "/workspace/task-1", AgentID: "auggie",
+				},
+			},
+		},
+		environmentReached: make(chan struct{}),
+	}
+	mgr, backend := newEnvironmentExecutionTestManager(t, provider)
+	backend.entered = make(chan struct{}, 1)
+	backend.barrier = make(chan struct{})
+	released := false
+	defer func() {
+		if !released {
+			close(backend.barrier)
+		}
+	}()
+
+	leaderCtx, cancelLeader := context.WithTimeout(context.Background(), 250*time.Millisecond)
+	defer cancelLeader()
+	leaderResult := make(chan error, 1)
+	go func() {
+		_, err := mgr.GetOrEnsureExecution(leaderCtx, "session-shared")
+		leaderResult <- err
+	}()
+	select {
+	case <-backend.entered:
+	case <-time.After(time.Second):
+		t.Fatal("leader did not reach CreateInstance")
+	}
+
+	followerResult := make(chan error, 1)
+	go func() {
+		_, err := mgr.GetOrEnsureExecutionForEnvironment(context.Background(), "env-1")
+		followerResult <- err
+	}()
+	select {
+	case <-provider.environmentReached:
+	case <-time.After(time.Second):
+		t.Fatal("follower did not resolve its environment")
+	}
+	select {
+	case err := <-followerResult:
+		t.Fatalf("follower returned before shared creation completed: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	if err := <-leaderResult; !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("leader error = %v, want context deadline", err)
+	}
+	close(backend.barrier)
+	released = true
+	if err := <-followerResult; err != nil {
+		t.Fatalf("live follower failed after leader deadline: %v", err)
+	}
+}
+
+func TestCoalescedExecutionStopsWithManager(t *testing.T) {
+	mgr, backend := newEnvironmentExecutionTestManager(t, &mockWorkspaceInfoProvider{
+		infos: map[string]*WorkspaceInfo{
+			"session-shutdown": {
+				TaskID: "task-1", SessionID: "session-shutdown", TaskEnvironmentID: "env-1",
+				WorkspacePath: "/workspace/task-1", AgentID: "auggie",
+			},
+		},
+	})
+	backend.entered = make(chan struct{}, 1)
+	backend.barrier = make(chan struct{})
+	released := false
+	defer func() {
+		if !released {
+			close(backend.barrier)
+		}
+	}()
+
+	result := make(chan error, 1)
+	go func() {
+		_, err := mgr.GetOrEnsureExecution(context.Background(), "session-shutdown")
+		result <- err
+	}()
+	select {
+	case <-backend.entered:
+	case <-time.After(time.Second):
+		t.Fatal("creation did not reach CreateInstance")
+	}
+	mgr.closeStopCh()
+	select {
+	case err := <-result:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("creation error = %v, want manager cancellation", err)
+		}
+	case <-time.After(100 * time.Millisecond):
+		close(backend.barrier)
+		released = true
+		<-result
+		t.Fatal("manager shutdown did not cancel coalesced creation")
+	}
+}
+
+func TestCoalescedExecutionCreationHasManagerDeadline(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		log := newTestLogger()
+		execRegistry := NewExecutorRegistry(log)
+		backend := &createInstanceExecutor{
+			MockExecutor: MockExecutor{name: executor.NameStandalone},
+			entered:      make(chan struct{}, 1),
+			barrier:      make(chan struct{}),
+		}
+		execRegistry.Register(backend)
+		mgr := NewManager(
+			newTestRegistry(), &MockEventBus{}, execRegistry, &MockCredentialsManager{},
+			&MockProfileResolver{}, nil, ExecutorFallbackWarn, "", log,
+		)
+		mgr.workspaceInfoProvider = &mockWorkspaceInfoProvider{
+			infos: map[string]*WorkspaceInfo{
+				"session-deadline": {
+					TaskID: "task-1", SessionID: "session-deadline", TaskEnvironmentID: "env-1",
+					WorkspacePath: "/workspace/task-1", AgentID: "auggie",
+				},
+			},
+		}
+		cleanupManagerStopCh(t, mgr)
+		coordinator := activity.NewCoordinator(activity.Options{})
+		mgr.SetActivityCoordinator(coordinator)
+
+		startedAt := time.Now()
+		result := make(chan error, 1)
+		go func() {
+			_, err := mgr.GetOrEnsureExecution(context.Background(), "session-deadline")
+			result <- err
+		}()
+		<-backend.entered
+
+		select {
+		case err := <-result:
+			if !errors.Is(err, context.DeadlineExceeded) {
+				t.Fatalf("creation error = %v, want manager deadline", err)
+			}
+			if elapsed := time.Since(startedAt); elapsed != coalescedExecutionCreationTimeout {
+				t.Fatalf("manager deadline elapsed after %v, want %v", elapsed, coalescedExecutionCreationTimeout)
+			}
+		case <-time.After(coalescedExecutionCreationTimeout + time.Second):
+			t.Fatal("blocked creation outlived the manager startup deadline")
+		}
+
+		maintenance, _, err := coordinator.TryAcquireMaintenance(context.Background(), 0)
+		if err != nil {
+			t.Fatalf("activity remained held after manager deadline: %v", err)
+		}
+		maintenance.Release()
+	})
 }
 
 func TestResolveTaskEnvironmentID(t *testing.T) {
@@ -671,6 +837,19 @@ func TestCreateExecutionResolvesProfileOnceForEnvAndAutoApprove(t *testing.T) {
 }
 
 // --- test helpers ---
+
+type notifyingWorkspaceInfoProvider struct {
+	*mockWorkspaceInfoProvider
+	environmentReached chan struct{}
+}
+
+func (p *notifyingWorkspaceInfoProvider) GetWorkspaceInfoForEnvironment(
+	ctx context.Context,
+	taskEnvironmentID string,
+) (*WorkspaceInfo, error) {
+	close(p.environmentReached)
+	return p.mockWorkspaceInfoProvider.GetWorkspaceInfoForEnvironment(ctx, taskEnvironmentID)
+}
 
 type createInstanceExecutor struct {
 	MockExecutor

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_interaction.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_interaction.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/kandev/kandev/internal/agent/agents"
 	"github.com/kandev/kandev/internal/agent/executor"
+	"github.com/kandev/kandev/internal/agent/runtime/activity"
 	agentctlclient "github.com/kandev/kandev/internal/agent/runtime/agentctl"
 	"github.com/kandev/kandev/internal/agent/runtime/routingerr"
 	agentctltypes "github.com/kandev/kandev/internal/agentctl/types"
@@ -89,7 +90,17 @@ func (m *Manager) PromptAgent(ctx context.Context, executionID string, prompt st
 	if !exists {
 		return nil, fmt.Errorf("execution %q not found: %w", executionID, ErrExecutionNotFound)
 	}
-	return m.sessionManager.SendPrompt(ctx, execution, prompt, true, attachments, dispatchOnly)
+	lease, err := m.acquireActivity(ctx, activity.KindExecutionRunning)
+	if err != nil {
+		return nil, err
+	}
+	key := executionActivityKey(executionID)
+	m.trackActivity(key, lease)
+	result, err := m.sessionManager.SendPrompt(ctx, execution, prompt, true, attachments, dispatchOnly)
+	if err != nil || !dispatchOnly {
+		m.releaseActivity(key)
+	}
+	return result, err
 }
 
 // cancelWaitTimeout bounds how long CancelAgent waits for the in-flight SendPrompt
@@ -525,6 +536,12 @@ func (m *Manager) StopAgentWithReason(ctx context.Context, executionID string, r
 	if !exists {
 		return fmt.Errorf("execution %q not found", executionID)
 	}
+	activityLease, err := m.acquireActivity(ctx, activity.KindExecutionStopping)
+	if err != nil {
+		return err
+	}
+	defer activityLease.Release()
+	m.releaseActivity(executionActivityKey(executionID))
 
 	m.logger.Info("stopping agent",
 		zap.String("execution_id", executionID),
@@ -1134,7 +1151,11 @@ func (m *Manager) MarkReady(executionID string) error {
 //
 // Publishes events.AgentBootReady. Returns error if execution not found.
 func (m *Manager) MarkBootReady(executionID string) error {
-	return m.markReadyEventWithContext(context.Background(), executionID, events.AgentBootReady, false)
+	err := m.markReadyEventWithContext(context.Background(), executionID, events.AgentBootReady, false)
+	if err == nil {
+		m.releaseActivity(executionActivityKey(executionID))
+	}
+	return err
 }
 
 // markReadyEvent is the shared body of MarkReady / MarkBootReady — both flip
@@ -1269,6 +1290,7 @@ func (m *Manager) MarkCompleted(executionID string, exitCode int, errorMessage s
 	// (#1597). Re-stamping here leaves the row truthful (terminal
 	// status + fresh last_seen_at) the moment the process is gone.
 	m.persistExecutorRunning(context.Background(), execution)
+	m.releaseActivity(executionActivityKey(executionID))
 
 	m.logger.Info("execution completed",
 		zap.String("execution_id", executionID),

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_launch.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_launch.go
@@ -384,7 +384,7 @@ func (m *Manager) scratchWorkspacePath(req *LaunchRequest) string {
 			zap.String("workspace_id", req.WorkspaceID))
 		return ""
 	}
-	if strings.ContainsAny(req.TaskID, `/\`) || strings.ContainsAny(req.WorkspaceID, `/\`) {
+	if invalidScratchPathID(req.TaskID) || invalidScratchPathID(req.WorkspaceID) {
 		m.logger.Warn("task or workspace ID contains path separator, rejecting",
 			zap.String("task_id", req.TaskID),
 			zap.String("workspace_id", req.WorkspaceID))
@@ -395,6 +395,10 @@ func (m *Manager) scratchWorkspacePath(req *LaunchRequest) string {
 	// workspaces live alongside the existing repo-bound worktree task dirs
 	// at <kandevHome>/tasks/<workspaceID>/<taskID>/.
 	return filepath.Join(m.dataDir, "tasks", req.WorkspaceID, req.TaskID)
+}
+
+func invalidScratchPathID(id string) bool {
+	return id == "." || id == ".." || strings.ContainsAny(id, `/\`)
 }
 
 // launchPrepareRequest copies the launch request, sets the resolved workspace path,

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_launch.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_launch.go
@@ -808,19 +808,18 @@ func (m *Manager) publishLaunchPrepareCompleted(req *LaunchRequest, result *EnvP
 // If req.SessionID is empty (quick chat / pre-session contexts), no
 // deduplication key exists and we fall through to direct execution.
 func (m *Manager) Launch(ctx context.Context, req *LaunchRequest) (*AgentExecution, error) {
-	activityLease, err := m.acquireActivity(ctx, activity.KindExecutionStarting)
-	if err != nil {
-		return nil, err
-	}
-	transferredActivity := false
-	defer func() {
-		if !transferredActivity {
-			activityLease.Release()
-		}
-	}()
-	activityLease.SetKind(activity.KindExecutionPreparing)
-
 	if req.SessionID == "" {
+		activityLease, err := m.acquireActivity(ctx, activity.KindExecutionStarting)
+		if err != nil {
+			return nil, err
+		}
+		transferredActivity := false
+		defer func() {
+			if !transferredActivity {
+				activityLease.Release()
+			}
+		}()
+		activityLease.SetKind(activity.KindExecutionPreparing)
 		execution, launchErr := m.launchInternal(ctx, req)
 		if launchErr == nil && req.StartAgent {
 			m.trackActivity(executionActivityKey(execution.ID), activityLease)
@@ -828,13 +827,19 @@ func (m *Manager) Launch(ctx context.Context, req *LaunchRequest) (*AgentExecuti
 		}
 		return execution, launchErr
 	}
-	v, err, _ := m.ensureExecutionGroup.Do(req.SessionID, func() (interface{}, error) {
-		return m.launchInternal(ctx, req)
+	value, err := m.doCoalescedExecution(ctx, req.SessionID, func(sharedCtx context.Context) (interface{}, error) {
+		activityLease, acquireErr := m.acquireActivity(sharedCtx, activity.KindExecutionStarting)
+		if acquireErr != nil {
+			return nil, acquireErr
+		}
+		defer activityLease.Release()
+		activityLease.SetKind(activity.KindExecutionPreparing)
+		return m.launchInternal(sharedCtx, req)
 	})
 	if err != nil {
 		return nil, err
 	}
-	execution := v.(*AgentExecution)
+	execution := value.(*AgentExecution)
 	// If this Launch call joined a workspace-only ensure peer's singleflight
 	// slot (EnsureWorkspaceExecutionForSession / GetOrEnsureExecution), the
 	// returned execution has no AgentCommand and the orchestrator's subsequent
@@ -847,8 +852,11 @@ func (m *Manager) Launch(ctx context.Context, req *LaunchRequest) (*AgentExecuti
 		}
 	}
 	if req.StartAgent {
+		activityLease, err := m.acquireActivity(ctx, activity.KindExecutionPreparing)
+		if err != nil {
+			return nil, err
+		}
 		m.trackActivity(executionActivityKey(execution.ID), activityLease)
-		transferredActivity = true
 	}
 	return execution, nil
 }
@@ -859,13 +867,18 @@ func (m *Manager) Launch(ctx context.Context, req *LaunchRequest) (*AgentExecuti
 // dedicated singleflight key so they don't race on the shared AgentExecution
 // pointer.
 func (m *Manager) promoteWorkspaceExecution(ctx context.Context, execution *AgentExecution, req *LaunchRequest) error {
-	_, err, _ := m.ensureExecutionGroup.Do("promote:"+req.SessionID, func() (interface{}, error) {
+	_, err := m.doCoalescedExecution(ctx, "promote:"+req.SessionID, func(sharedCtx context.Context) (interface{}, error) {
+		activityLease, acquireErr := m.acquireActivity(sharedCtx, activity.KindExecutionPreparing)
+		if acquireErr != nil {
+			return nil, acquireErr
+		}
+		defer activityLease.Release()
 		// Re-check after acquiring the slot — a peer Launch may have already
 		// promoted while we were waiting.
 		if execution.AgentCommand != "" {
 			return nil, nil
 		}
-		agentTypeName, profileInfo, err := m.resolveAgentProfile(ctx, req)
+		agentTypeName, profileInfo, err := m.resolveAgentProfile(sharedCtx, req)
 		if err != nil {
 			return nil, err
 		}
@@ -888,7 +901,7 @@ func (m *Manager) promoteWorkspaceExecution(ctx context.Context, execution *Agen
 		}
 		execution.IsPassthrough = req.IsPassthrough
 		if !req.IsPassthrough {
-			if err := m.materializeRuntimeProjectMCP(ctx, execution, agentConfig); err != nil {
+			if err := m.materializeRuntimeProjectMCP(sharedCtx, execution, agentConfig); err != nil {
 				execution.AgentCommand = ""
 				execution.ContinueCommand = ""
 				execution.isResumedSession = false

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_launch.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_launch.go
@@ -16,8 +16,10 @@ import (
 
 	"github.com/kandev/kandev/internal/agent/agents"
 	"github.com/kandev/kandev/internal/agent/executor"
+	"github.com/kandev/kandev/internal/agent/runtime/activity"
 	"github.com/kandev/kandev/internal/agent/settings/cliflags"
 	"github.com/kandev/kandev/internal/events"
+	storageworkspaces "github.com/kandev/kandev/internal/system/storage/workspaces"
 	"github.com/kandev/kandev/internal/task/models"
 	"github.com/kandev/kandev/internal/worktree"
 )
@@ -335,6 +337,16 @@ func (m *Manager) resolveScratchWorkspace(ctx context.Context, req *LaunchReques
 			zap.String("workspace_path", scratchPath),
 			zap.Error(err))
 		return ""
+	}
+	if !req.IsEphemeral {
+		if err := storageworkspaces.WriteOwnershipMarker(scratchPath, storageworkspaces.OwnershipMarker{
+			TaskID: req.TaskID, WorkspaceID: req.WorkspaceID, TaskDirName: req.TaskID,
+			LayoutVersion: storageworkspaces.LayoutVersionScratch,
+		}); err != nil {
+			m.logger.Warn("failed to mark scratch workspace ownership",
+				zap.String("workspace_path", scratchPath), zap.Error(err))
+			return ""
+		}
 	}
 	if err := m.initGitRepo(ctx, scratchPath); err != nil {
 		m.logger.Warn("failed to initialize git repository in scratch workspace",
@@ -660,6 +672,7 @@ func buildEnvPrepareRequest(req *LaunchRequest, workspacePath string, execName e
 	repoSetupScript, _ := req.Metadata[MetadataKeyRepoSetupScript].(string)
 	prepReq := &EnvPrepareRequest{
 		TaskID:                 req.TaskID,
+		WorkspaceID:            req.WorkspaceID,
 		SessionID:              req.SessionID,
 		TaskTitle:              req.TaskTitle,
 		ExecutorType:           execName,
@@ -791,8 +804,25 @@ func (m *Manager) publishLaunchPrepareCompleted(req *LaunchRequest, result *EnvP
 // If req.SessionID is empty (quick chat / pre-session contexts), no
 // deduplication key exists and we fall through to direct execution.
 func (m *Manager) Launch(ctx context.Context, req *LaunchRequest) (*AgentExecution, error) {
+	activityLease, err := m.acquireActivity(ctx, activity.KindExecutionStarting)
+	if err != nil {
+		return nil, err
+	}
+	transferredActivity := false
+	defer func() {
+		if !transferredActivity {
+			activityLease.Release()
+		}
+	}()
+	activityLease.SetKind(activity.KindExecutionPreparing)
+
 	if req.SessionID == "" {
-		return m.launchInternal(ctx, req)
+		execution, launchErr := m.launchInternal(ctx, req)
+		if launchErr == nil && req.StartAgent {
+			m.trackActivity(executionActivityKey(execution.ID), activityLease)
+			transferredActivity = true
+		}
+		return execution, launchErr
 	}
 	v, err, _ := m.ensureExecutionGroup.Do(req.SessionID, func() (interface{}, error) {
 		return m.launchInternal(ctx, req)
@@ -811,6 +841,10 @@ func (m *Manager) Launch(ctx context.Context, req *LaunchRequest) (*AgentExecuti
 		if err := m.promoteWorkspaceExecution(ctx, execution, req); err != nil {
 			return nil, err
 		}
+	}
+	if req.StartAgent {
+		m.trackActivity(executionActivityKey(execution.ID), activityLease)
+		transferredActivity = true
 	}
 	return execution, nil
 }
@@ -889,6 +923,9 @@ func (m *Manager) launchInternal(ctx context.Context, req *LaunchRequest) (*Agen
 	}
 	if !agentConfig.Enabled() {
 		return nil, fmt.Errorf("agent type %q is disabled", agentTypeName)
+	}
+	if err := m.prepareManagedGoCacheEnvironment(ctx, req); err != nil {
+		return nil, err
 	}
 
 	// 3. Check if session already has an agent running. A workspace-only

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_launch_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_launch_test.go
@@ -953,6 +953,133 @@ func TestLaunch_RejectsWhenAgentAlreadyRunning(t *testing.T) {
 	require.Contains(t, err.Error(), "already has an agent running")
 }
 
+func TestLaunchDeadlineDoesNotAbortLiveEnsureFollower(t *testing.T) {
+	provider := &notifyingWorkspaceInfoProvider{
+		mockWorkspaceInfoProvider: &mockWorkspaceInfoProvider{
+			infos: map[string]*WorkspaceInfo{
+				"session-mixed": {
+					TaskID: "task-1", SessionID: "session-mixed", TaskEnvironmentID: "env-1",
+					WorkspacePath: "/workspace/task-1", AgentID: "auggie",
+				},
+			},
+		},
+		environmentReached: make(chan struct{}),
+	}
+	mgr, backend := newEnvironmentExecutionTestManager(t, provider)
+	coordinator := activity.NewCoordinator(activity.Options{})
+	mgr.SetActivityCoordinator(coordinator)
+	backend.entered = make(chan struct{}, 1)
+	backend.barrier = make(chan struct{})
+	released := false
+	defer func() {
+		if !released {
+			close(backend.barrier)
+		}
+	}()
+
+	launchCtx, cancelLaunch := context.WithTimeout(context.Background(), 250*time.Millisecond)
+	defer cancelLaunch()
+	launchResult := make(chan error, 1)
+	go func() {
+		_, err := mgr.Launch(launchCtx, &LaunchRequest{
+			TaskID: "task-1", SessionID: "session-mixed", TaskEnvironmentID: "env-1",
+			AgentProfileID: "profile-1", WorkspacePath: "/workspace/task-1",
+		})
+		launchResult <- err
+	}()
+	select {
+	case <-backend.entered:
+	case <-time.After(time.Second):
+		t.Fatal("Launch did not reach CreateInstance")
+	}
+
+	ensureResult := make(chan error, 1)
+	go func() {
+		_, err := mgr.GetOrEnsureExecutionForEnvironment(context.Background(), "env-1")
+		ensureResult <- err
+	}()
+	<-provider.environmentReached
+	select {
+	case err := <-ensureResult:
+		t.Fatalf("ensure follower returned before shared launch completed: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	if err := <-launchResult; !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Launch error = %v, want caller deadline", err)
+	}
+	if _, _, err := coordinator.TryAcquireMaintenance(context.Background(), 0); !errors.Is(err, activity.ErrBusy) {
+		t.Fatalf("maintenance error = %v, want shared launch activity after leader deadline", err)
+	}
+	close(backend.barrier)
+	released = true
+	if err := <-ensureResult; err != nil {
+		t.Fatalf("live ensure follower failed after Launch deadline: %v", err)
+	}
+}
+
+func TestEnsureLeaderDoesNotHideLaunchWaiterDeadline(t *testing.T) {
+	mgr, backend := newEnvironmentExecutionTestManager(t, &mockWorkspaceInfoProvider{
+		infos: map[string]*WorkspaceInfo{
+			"session-mixed": {
+				TaskID: "task-1", SessionID: "session-mixed", TaskEnvironmentID: "env-1",
+				WorkspacePath: "/workspace/task-1", AgentID: "auggie",
+			},
+		},
+	})
+	coordinator := activity.NewCoordinator(activity.Options{})
+	mgr.SetActivityCoordinator(coordinator)
+	backend.entered = make(chan struct{}, 1)
+	backend.barrier = make(chan struct{})
+	released := false
+	defer func() {
+		if !released {
+			close(backend.barrier)
+		}
+	}()
+
+	ensureResult := make(chan error, 1)
+	go func() {
+		_, err := mgr.GetOrEnsureExecution(context.Background(), "session-mixed")
+		ensureResult <- err
+	}()
+	select {
+	case <-backend.entered:
+	case <-time.After(time.Second):
+		t.Fatal("ensure did not reach CreateInstance")
+	}
+
+	launchCtx, cancelLaunch := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancelLaunch()
+	launchResult := make(chan error, 1)
+	go func() {
+		_, err := mgr.Launch(launchCtx, &LaunchRequest{
+			TaskID: "task-1", SessionID: "session-mixed", TaskEnvironmentID: "env-1",
+			AgentProfileID: "profile-1", WorkspacePath: "/workspace/task-1",
+		})
+		launchResult <- err
+	}()
+	select {
+	case err := <-launchResult:
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("Launch error = %v, want caller deadline", err)
+		}
+	case <-time.After(250 * time.Millisecond):
+		close(backend.barrier)
+		released = true
+		<-ensureResult
+		<-launchResult
+		t.Fatal("Launch waiter did not observe its own deadline")
+	}
+	if _, _, err := coordinator.TryAcquireMaintenance(context.Background(), 0); !errors.Is(err, activity.ErrBusy) {
+		t.Fatalf("maintenance error = %v, want shared ensure activity", err)
+	}
+	close(backend.barrier)
+	released = true
+	if err := <-ensureResult; err != nil {
+		t.Fatalf("ensure leader failed after Launch waiter deadline: %v", err)
+	}
+}
+
 // TestLaunch_RaceRollback exercises the race window between the step-3 duplicate
 // session pre-check and the step-8 executionStore.Add in Launch. A barrier inside
 // CreateInstance keeps the goroutine in the race window; the test injects a

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_launch_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_launch_test.go
@@ -3,6 +3,7 @@ package lifecycle
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -14,10 +15,12 @@ import (
 	"testing"
 	"time"
 
+	storageworkspaces "github.com/kandev/kandev/internal/system/storage/workspaces"
 	"github.com/stretchr/testify/require"
 
 	"github.com/kandev/kandev/internal/agent/agents"
 	"github.com/kandev/kandev/internal/agent/executor"
+	"github.com/kandev/kandev/internal/agent/runtime/activity"
 	agentctl "github.com/kandev/kandev/internal/agent/runtime/agentctl"
 	settingsmodels "github.com/kandev/kandev/internal/agent/settings/models"
 	"github.com/kandev/kandev/internal/common/logger"
@@ -554,6 +557,115 @@ func (p *progressPreparer) Prepare(_ context.Context, _ *EnvPrepareRequest, onPr
 	return &EnvPrepareResult{Success: true, Steps: []PrepareStep{step}, WorkspacePath: "/tmp/ws"}, nil
 }
 
+type staticManagedGoCacheEnvironment struct {
+	path string
+}
+
+func (p staticManagedGoCacheEnvironment) ExecutionEnvironment(context.Context) (map[string]string, error) {
+	return map[string]string{"GOCACHE": p.path}, nil
+}
+
+func TestPrepareManagedGoCacheEnvironmentOverridesLocalRequest(t *testing.T) {
+	mgr := newTestManager(t)
+	managedPath := filepath.Join(t.TempDir(), "cache", "go-build")
+	mgr.SetManagedGoCacheEnvironmentProvider(staticManagedGoCacheEnvironment{path: managedPath})
+	req := &LaunchRequest{
+		ExecutorType: "local_pc",
+		Env:          map[string]string{"GOCACHE": "/home/user/.cache/go-build"},
+	}
+
+	err := mgr.prepareManagedGoCacheEnvironment(context.Background(), req)
+	if err != nil {
+		t.Fatalf("prepareManagedGoCacheEnvironment() error = %v", err)
+	}
+	if got := req.Env["GOCACHE"]; got != managedPath {
+		t.Fatalf("request GOCACHE = %q, want %q", got, managedPath)
+	}
+	if req.managedGoCachePath != managedPath {
+		t.Fatalf("managedGoCachePath = %q, want %q", req.managedGoCachePath, managedPath)
+	}
+}
+
+func TestManagedGoCacheEnvironmentPropagatesToPrepareAndRuntime(t *testing.T) {
+	mgr := newTestManager(t)
+	managedPath := filepath.Join(t.TempDir(), "cache", "go-build")
+	mgr.SetManagedGoCacheEnvironmentProvider(staticManagedGoCacheEnvironment{path: managedPath})
+	req := &LaunchRequest{
+		ExecutorType:   "worktree",
+		AgentProfileID: "profile-1",
+		Env:            map[string]string{"GOCACHE": "/tmp/user-cache"},
+	}
+	if err := mgr.prepareManagedGoCacheEnvironment(context.Background(), req); err != nil {
+		t.Fatalf("prepareManagedGoCacheEnvironment() error = %v", err)
+	}
+
+	prepareEnv := buildEnvPrepareRequest(req, "/tmp/workspace", executor.NameStandalone).Env
+	runtimeEnv, err := mgr.buildEnvForExecution(context.Background(), "exec-1", req, nil, nil)
+	if err != nil {
+		t.Fatalf("buildEnvForExecution() error = %v", err)
+	}
+	if prepareEnv["GOCACHE"] != managedPath || runtimeEnv["GOCACHE"] != managedPath {
+		t.Fatalf("GOCACHE diverged: prepare=%q runtime=%q want=%q",
+			prepareEnv["GOCACHE"], runtimeEnv["GOCACHE"], managedPath)
+	}
+}
+
+func TestManagedGoCacheEnvironmentSkipsRemoteExecution(t *testing.T) {
+	mgr := newTestManager(t)
+	mgr.SetManagedGoCacheEnvironmentProvider(staticManagedGoCacheEnvironment{path: "/tmp/managed-cache"})
+	req := &LaunchRequest{
+		ExecutorType: "local_docker",
+		Env:          map[string]string{"GOCACHE": "/container/cache"},
+	}
+
+	if err := mgr.prepareManagedGoCacheEnvironment(context.Background(), req); err != nil {
+		t.Fatalf("prepareManagedGoCacheEnvironment() error = %v", err)
+	}
+	if got := req.Env["GOCACHE"]; got != "/container/cache" {
+		t.Fatalf("remote GOCACHE = %q, want existing container value", got)
+	}
+}
+
+func TestLaunchKeepsInitialExecutionActivityAfterReturning(t *testing.T) {
+	log := newTestLogger()
+	execRegistry := NewExecutorRegistry(log)
+	execRegistry.Register(&createInstanceExecutor{
+		MockExecutor: MockExecutor{name: executor.NameDocker},
+		client:       newReadyAgentctlClient(t, log),
+	})
+	mgr := NewManager(
+		newTestRegistry(), &MockEventBus{}, execRegistry,
+		&MockCredentialsManager{}, &MockProfileResolver{}, nil,
+		ExecutorFallbackWarn, "", log,
+	)
+	cleanupManagerStopCh(t, mgr)
+	coordinator := activity.NewCoordinator(activity.Options{})
+	mgr.SetActivityCoordinator(coordinator)
+
+	execution, err := mgr.Launch(context.Background(), &LaunchRequest{
+		TaskID: "task-activity", SessionID: "session-activity", AgentProfileID: "profile-1",
+		ExecutorType: "local_docker", IsEphemeral: true, StartAgent: true,
+		TaskDescription: "initial prompt",
+	})
+	if err != nil {
+		t.Fatalf("Launch: %v", err)
+	}
+	maintenance, _, err := coordinator.TryAcquireMaintenance(context.Background(), 0)
+	if maintenance != nil {
+		maintenance.Release()
+	}
+	if !errors.Is(err, activity.ErrBusy) {
+		t.Fatalf("maintenance after Launch error = %v, want activity.ErrBusy", err)
+	}
+
+	mgr.RemoveExecution(execution.ID)
+	maintenance, _, err = coordinator.TryAcquireMaintenance(context.Background(), 0)
+	if err != nil {
+		t.Fatalf("maintenance after RemoveExecution: %v", err)
+	}
+	maintenance.Release()
+}
+
 func TestLaunch_PublishesPrepareCompletedAfterRuntimeProgress(t *testing.T) {
 	log := newTestLogger()
 	execRegistry := NewExecutorRegistry(log)
@@ -705,6 +817,12 @@ func TestLaunchResolveWorkspacePath_NonEphemeralRepoLessGetsScratchDir(t *testin
 	// New layout: <homeDir>/tasks/<workspaceID>/<taskID> (sibling to worktree task dirs).
 	require.Contains(t, workspacePath, filepath.Join("tasks", "ws-xyz", "task-xyz"))
 	require.NotContains(t, workspacePath, "quick-chat")
+	marker, found, err := storageworkspaces.ReadOwnershipMarker(workspacePath)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, "task-xyz", marker.TaskID)
+	require.Equal(t, "ws-xyz", marker.WorkspaceID)
+	require.Equal(t, storageworkspaces.LayoutVersionScratch, marker.LayoutVersion)
 }
 
 func TestLaunchResolveWorkspacePath_NonEphemeralWithoutWorkspaceIDReturnsEmpty(t *testing.T) {

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_launch_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_launch_test.go
@@ -584,6 +584,9 @@ func TestPrepareManagedGoCacheEnvironmentOverridesLocalRequest(t *testing.T) {
 	if req.managedGoCachePath != managedPath {
 		t.Fatalf("managedGoCachePath = %q, want %q", req.managedGoCachePath, managedPath)
 	}
+	if got, _ := req.Metadata[managedGoCacheMetadataKey].(string); got != managedPath {
+		t.Fatalf("managed cache metadata = %q, want %q", got, managedPath)
+	}
 }
 
 func TestManagedGoCacheEnvironmentPropagatesToPrepareAndRuntime(t *testing.T) {
@@ -839,6 +842,19 @@ func TestLaunchResolveWorkspacePath_NonEphemeralWithoutWorkspaceIDReturnsEmpty(t
 
 	workspacePath, _, _, _ := mgr.launchResolveWorkspacePath(context.Background(), req)
 	require.Empty(t, workspacePath)
+}
+
+func TestLaunchResolveWorkspacePathRejectsDotTaskID(t *testing.T) {
+	mgr := newTestManager(t)
+	mgr.dataDir = t.TempDir()
+	req := &LaunchRequest{
+		SessionID: "session-dot-task", TaskID: ".", WorkspaceID: "ws-1",
+	}
+
+	workspacePath, _, _, _ := mgr.launchResolveWorkspacePath(context.Background(), req)
+	if workspacePath != "" {
+		t.Fatalf("workspace path = %q, want empty for dot task ID", workspacePath)
+	}
 }
 
 func TestLaunchResolveWorkspacePath_PickedFolderUsedDirectly(t *testing.T) {

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_lifecycle.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_lifecycle.go
@@ -354,6 +354,7 @@ func (m *Manager) CleanupStaleExecutionBySessionID(ctx context.Context, sessionI
 // Typical usage: Called by cleanup loops or after successful StopAgent completion.
 // For stale/dead executions, use CleanupStaleExecutionBySessionID instead.
 func (m *Manager) RemoveExecution(executionID string) {
+	m.releaseActivity(executionActivityKey(executionID))
 	if execution, ok := m.executionStore.Get(executionID); ok {
 		m.cleanupPassthroughMCPConfig(execution)
 	}

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_startup.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_startup.go
@@ -305,6 +305,10 @@ func (m *Manager) prepareManagedGoCacheEnvironment(ctx context.Context, req *Lau
 		req.Env = make(map[string]string)
 	}
 	req.Env["GOCACHE"] = path
+	if req.Metadata == nil {
+		req.Metadata = make(map[string]interface{})
+	}
+	req.Metadata[managedGoCacheMetadataKey] = path
 	req.managedGoCachePath = path
 	return nil
 }

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_startup.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_startup.go
@@ -79,13 +79,17 @@ func (m *Manager) StartAgentProcess(ctx context.Context, executionID string) (re
 	if !exists {
 		return fmt.Errorf("execution %q not found", executionID)
 	}
-	if err := m.ensureExecutionActivity(ctx, executionID, activity.KindExecutionPreparing); err != nil {
+	activityClaim, err := m.ensureExecutionActivity(ctx, executionID, activity.KindExecutionPreparing)
+	if err != nil {
 		return err
 	}
+	operationCtx := activityClaim.Context(ctx)
 	defer func() {
 		if retErr != nil {
-			m.releaseActivity(executionActivityKey(executionID))
+			activityClaim.Release()
+			return
 		}
+		activityClaim.Commit()
 	}()
 
 	// Decide passthrough vs ACP. The session-creation snapshot
@@ -102,8 +106,12 @@ func (m *Manager) StartAgentProcess(ctx context.Context, executionID string) (re
 	// transient resolve error must not silently route a passthrough session
 	// to ACP — the resume branch routes on the snapshot alone, and the fresh
 	// branch surfaces the resolve error explicitly.
-	if isPassthrough, profileInfo := m.routePassthrough(ctx, execution); isPassthrough {
-		return m.startPassthroughExecution(ctx, execution, profileInfo)
+	isPassthrough, profileInfo := m.routePassthrough(operationCtx, execution)
+	if err := context.Cause(operationCtx); err != nil {
+		return err
+	}
+	if isPassthrough {
+		return m.startPassthroughExecution(operationCtx, execution, profileInfo)
 	}
 
 	if execution.agentctl == nil {
@@ -120,13 +128,13 @@ func (m *Manager) StartAgentProcess(ctx context.Context, executionID string) (re
 	}
 
 	// Wait for agentctl to be ready
-	if err := execution.agentctl.WaitForReady(ctx, 60*time.Second); err != nil {
+	if err := execution.agentctl.WaitForReady(operationCtx, 60*time.Second); err != nil {
 		m.updateExecutionError(executionID, "agentctl not ready: "+err.Error())
 		return fmt.Errorf("agentctl not ready: %w", err)
 	}
 
 	taskDescription := getTaskDescriptionFromMetadata(execution)
-	approvalPolicy, agentDisplayName := m.resolveApprovalPolicyAndDisplayName(ctx, execution)
+	approvalPolicy, agentDisplayName := m.resolveApprovalPolicyAndDisplayName(operationCtx, execution)
 
 	var bootCommand string
 	if reuseExisting {
@@ -145,7 +153,7 @@ func (m *Manager) StartAgentProcess(ctx context.Context, executionID string) (re
 			zap.String("acp_session_id", execution.ACPSessionID))
 
 		var err error
-		bootCommand, err = m.configureAndStartAgent(ctx, execution, approvalPolicy)
+		bootCommand, err = m.configureAndStartAgent(operationCtx, execution, approvalPolicy)
 		if err != nil {
 			return err
 		}
@@ -156,7 +164,7 @@ func (m *Manager) StartAgentProcess(ctx context.Context, executionID string) (re
 			zap.String("command", bootCommand))
 	}
 
-	return m.initializeAgentSession(ctx, execution, bootCommand, agentDisplayName, taskDescription)
+	return m.initializeAgentSession(operationCtx, execution, bootCommand, agentDisplayName, taskDescription)
 }
 
 // pollAgentStderr polls the agent's stderr buffer every 2 seconds and updates the boot message.

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_startup.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_startup.go
@@ -3,12 +3,14 @@ package lifecycle
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"time"
 
 	"go.uber.org/zap"
 
 	"github.com/kandev/kandev/internal/agent/agents"
+	"github.com/kandev/kandev/internal/agent/runtime/activity"
 	agentctl "github.com/kandev/kandev/internal/agent/runtime/agentctl"
 	"github.com/kandev/kandev/internal/common/appctx"
 	"github.com/kandev/kandev/internal/events"
@@ -72,11 +74,19 @@ func (m *Manager) routePassthrough(ctx context.Context, execution *AgentExecutio
 // StartAgentProcess configures and starts the agent subprocess for an execution.
 // This must be called after Launch() to actually start the agent (e.g., auggie, codex).
 // The command is built internally based on the execution's agent profile.
-func (m *Manager) StartAgentProcess(ctx context.Context, executionID string) error {
+func (m *Manager) StartAgentProcess(ctx context.Context, executionID string) (retErr error) {
 	execution, exists := m.executionStore.Get(executionID)
 	if !exists {
 		return fmt.Errorf("execution %q not found", executionID)
 	}
+	if err := m.ensureExecutionActivity(ctx, executionID, activity.KindExecutionPreparing); err != nil {
+		return err
+	}
+	defer func() {
+		if retErr != nil {
+			m.releaseActivity(executionActivityKey(executionID))
+		}
+	}()
 
 	// Decide passthrough vs ACP. The session-creation snapshot
 	// (execution.IsPassthrough, sourced from TaskSession.IsPassthrough) is
@@ -264,12 +274,48 @@ func (m *Manager) buildEnvForExecution(ctx context.Context, executionID string, 
 			}
 		}
 	}
+	if req.managedGoCachePath != "" {
+		env["GOCACHE"] = req.managedGoCachePath
+	}
 
 	if err := spillLargeWakePayloadEnv(env, req.WorkspacePath, m.logger.Zap()); err != nil {
 		return nil, err
 	}
 
 	return env, nil
+}
+
+func (m *Manager) prepareManagedGoCacheEnvironment(ctx context.Context, req *LaunchRequest) error {
+	if req == nil || m.managedGoCache == nil || !isHostLocalExecutor(req.ExecutorType) {
+		return nil
+	}
+	env, err := m.managedGoCache.ExecutionEnvironment(ctx)
+	if err != nil {
+		return fmt.Errorf("prepare managed Go cache: %w", err)
+	}
+	path := env["GOCACHE"]
+	if path == "" {
+		return nil
+	}
+	if !filepath.IsAbs(path) {
+		return fmt.Errorf("managed GOCACHE must be absolute: %q", path)
+	}
+	path = filepath.Clean(path)
+	if req.Env == nil {
+		req.Env = make(map[string]string)
+	}
+	req.Env["GOCACHE"] = path
+	req.managedGoCachePath = path
+	return nil
+}
+
+func isHostLocalExecutor(executorType string) bool {
+	switch models.ExecutorType(executorType) {
+	case "", models.ExecutorTypeLocal, "local_pc", models.ExecutorTypeWorktree:
+		return true
+	default:
+		return false
+	}
 }
 
 // waitForAgentctlReady waits for the agentctl HTTP server to be ready.

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_startup_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_startup_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"strings"
 	"testing"
+
+	"github.com/kandev/kandev/internal/agent/runtime/activity"
 )
 
 // mockAgentProfileResolver returns a profile pointing to the mock-agent.
@@ -13,6 +15,41 @@ import (
 type mockAgentProfileResolver struct {
 	cliPassthrough bool
 	err            error
+}
+
+type blockingAgentProfileResolver struct {
+	entered chan chan struct{}
+}
+
+type cancellableAgentProfileResolver struct {
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (r *cancellableAgentProfileResolver) ResolveProfile(
+	ctx context.Context,
+	_ string,
+) (*AgentProfileInfo, error) {
+	close(r.entered)
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-r.release:
+		return &AgentProfileInfo{AgentID: "mock-agent"}, nil
+	}
+}
+
+func (r *blockingAgentProfileResolver) ResolveProfile(
+	_ context.Context,
+	profileID string,
+) (*AgentProfileInfo, error) {
+	release := make(chan struct{})
+	r.entered <- release
+	<-release
+	return &AgentProfileInfo{
+		ProfileID: profileID,
+		AgentID:   "mock-agent",
+	}, nil
 }
 
 func (m *mockAgentProfileResolver) ResolveProfile(_ context.Context, profileID string) (*AgentProfileInfo, error) {
@@ -61,6 +98,78 @@ func TestStartAgentProcess_NonPassthrough_NoAgentctl(t *testing.T) {
 	if !strings.Contains(err.Error(), "no agentctl client") {
 		t.Errorf("expected 'no agentctl client' error, got: %v", err)
 	}
+}
+
+func TestFailedConcurrentStartDoesNotReleaseLiveStartActivity(t *testing.T) {
+	mgr := newTestManager(t)
+	coordinator := activity.NewCoordinator(activity.Options{})
+	mgr.SetActivityCoordinator(coordinator)
+	resolver := &blockingAgentProfileResolver{entered: make(chan chan struct{}, 2)}
+	mgr.profileResolver = resolver
+	if err := mgr.executionStore.Add(&AgentExecution{
+		ID: "exec-shared", AgentProfileID: "profile-1",
+	}); err != nil {
+		t.Fatalf("seed execution: %v", err)
+	}
+
+	results := make(chan error, 2)
+	go func() { results <- mgr.StartAgentProcess(context.Background(), "exec-shared") }()
+	releaseFirst := <-resolver.entered
+	go func() { results <- mgr.StartAgentProcess(context.Background(), "exec-shared") }()
+	releaseSecond := <-resolver.entered
+
+	close(releaseFirst)
+	if err := <-results; err == nil {
+		t.Fatal("first start returned nil, want missing agentctl error")
+	}
+	maintenance, _, maintenanceErr := coordinator.TryAcquireMaintenance(context.Background(), 0)
+	if maintenance != nil {
+		maintenance.Release()
+	}
+	close(releaseSecond)
+	if err := <-results; err == nil {
+		t.Fatal("second start returned nil, want missing agentctl error")
+	}
+	if !errors.Is(maintenanceErr, activity.ErrBusy) {
+		t.Fatalf("maintenance error = %v, want ErrBusy while second start is live", maintenanceErr)
+	}
+}
+
+func TestTerminalInvalidationCancelsAndDrainsAdmittedStart(t *testing.T) {
+	mgr := newTestManager(t)
+	coordinator := activity.NewCoordinator(activity.Options{})
+	mgr.SetActivityCoordinator(coordinator)
+	resolver := &cancellableAgentProfileResolver{
+		entered: make(chan struct{}), release: make(chan struct{}),
+	}
+	mgr.profileResolver = resolver
+	if err := mgr.executionStore.Add(&AgentExecution{
+		ID: "exec-invalidated", AgentProfileID: "profile-1",
+	}); err != nil {
+		t.Fatalf("seed execution: %v", err)
+	}
+
+	result := make(chan error, 1)
+	go func() { result <- mgr.StartAgentProcess(context.Background(), "exec-invalidated") }()
+	<-resolver.entered
+	mgr.releaseActivity(executionActivityKey("exec-invalidated"))
+	maintenance, _, maintenanceErr := coordinator.TryAcquireMaintenance(context.Background(), 0)
+	if maintenance != nil {
+		maintenance.Release()
+	}
+	if !errors.Is(maintenanceErr, activity.ErrBusy) {
+		close(resolver.release)
+		<-result
+		t.Fatalf("maintenance error = %v, want ErrBusy until invalidated start drains", maintenanceErr)
+	}
+	if err := <-result; !errors.Is(err, errExecutionActivityInvalidated) {
+		t.Fatalf("StartAgentProcess error = %v, want claim invalidation", err)
+	}
+	maintenance, _, err := coordinator.TryAcquireMaintenance(context.Background(), 0)
+	if err != nil {
+		t.Fatalf("maintenance after start drained: %v", err)
+	}
+	maintenance.Release()
 }
 
 func TestStartAgentProcess_Passthrough_NotResumed(t *testing.T) {

--- a/apps/backend/internal/agent/runtime/lifecycle/process_runner.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/process_runner.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	agentctl "github.com/kandev/kandev/internal/agent/runtime/agentctl"
+	agentctltypes "github.com/kandev/kandev/internal/agentctl/types"
 )
 
 type StartProcessRequest struct {
@@ -35,19 +36,25 @@ func (m *Manager) StartProcess(ctx context.Context, req StartProcessRequest) (*a
 	if err != nil {
 		return nil, err
 	}
-	process, err := client.StartProcess(ctx, agentctl.StartProcessRequest{
+	startCtx, cancelStart := context.WithTimeout(context.WithoutCancel(ctx), time.Minute)
+	defer cancelStart()
+	process, err := client.StartProcess(startCtx, agentctl.StartProcessRequest{
 		SessionID:  req.SessionID,
 		Kind:       agentctl.ProcessKind(req.Kind),
 		ScriptName: req.ScriptName,
 		Command:    req.Command,
 		WorkingDir: req.WorkingDir,
-		Env:        req.Env,
+		Env:        processEnvironment(execution, req.Env),
 	})
 	if err != nil {
 		lease.Release()
 		return nil, err
 	}
-	m.trackActivity(processActivityKey(process.ID), lease)
+	if isTerminalProcessStatus(process.Status) {
+		lease.Release()
+	} else {
+		m.trackActivity(processActivityKey(process.ID), lease)
+	}
 	return process, nil
 }
 
@@ -76,12 +83,37 @@ func (m *Manager) StopProcess(ctx context.Context, processID string) error {
 		if client == nil {
 			continue
 		}
+		if _, err := client.GetProcess(ctx, processID, false); err != nil {
+			continue
+		}
 		if err := client.StopProcess(ctx, processID); err == nil {
 			m.releaseActivity(processActivityKey(processID))
 			return nil
 		}
 	}
 	return fmt.Errorf("process not found: %s", processID)
+}
+
+func processEnvironment(execution *AgentExecution, requested map[string]string) map[string]string {
+	managedPath, _ := execution.Metadata[managedGoCacheMetadataKey].(string)
+	if managedPath == "" {
+		return requested
+	}
+	env := make(map[string]string, len(requested)+1)
+	for key, value := range requested {
+		env[key] = value
+	}
+	env["GOCACHE"] = managedPath
+	return env
+}
+
+func isTerminalProcessStatus(status agentctl.ProcessStatus) bool {
+	switch status {
+	case agentctltypes.ProcessStatusExited, agentctltypes.ProcessStatusFailed, agentctltypes.ProcessStatusStopped:
+		return true
+	default:
+		return false
+	}
 }
 
 // StopProcessForSession stops a running process by ID within a specific session.

--- a/apps/backend/internal/agent/runtime/lifecycle/process_runner.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/process_runner.go
@@ -31,7 +31,11 @@ func (m *Manager) StartProcess(ctx context.Context, req StartProcessRequest) (*a
 		return nil, fmt.Errorf("agentctl client not available for session %s", req.SessionID)
 	}
 
-	return client.StartProcess(ctx, agentctl.StartProcessRequest{
+	lease, err := m.acquireActivity(ctx, processActivityKind(req.Kind))
+	if err != nil {
+		return nil, err
+	}
+	process, err := client.StartProcess(ctx, agentctl.StartProcessRequest{
 		SessionID:  req.SessionID,
 		Kind:       agentctl.ProcessKind(req.Kind),
 		ScriptName: req.ScriptName,
@@ -39,6 +43,12 @@ func (m *Manager) StartProcess(ctx context.Context, req StartProcessRequest) (*a
 		WorkingDir: req.WorkingDir,
 		Env:        req.Env,
 	})
+	if err != nil {
+		lease.Release()
+		return nil, err
+	}
+	m.trackActivity(processActivityKey(process.ID), lease)
+	return process, nil
 }
 
 // WaitForAgentctlReadyForSession waits for agentctl to be ready for a session.
@@ -67,6 +77,7 @@ func (m *Manager) StopProcess(ctx context.Context, processID string) error {
 			continue
 		}
 		if err := client.StopProcess(ctx, processID); err == nil {
+			m.releaseActivity(processActivityKey(processID))
 			return nil
 		}
 	}
@@ -89,7 +100,11 @@ func (m *Manager) StopProcessForSession(ctx context.Context, sessionID, processI
 	if client == nil {
 		return fmt.Errorf("agentctl client not available for session %s", sessionID)
 	}
-	return client.StopProcess(ctx, processID)
+	if err := client.StopProcess(ctx, processID); err != nil {
+		return err
+	}
+	m.releaseActivity(processActivityKey(processID))
+	return nil
 }
 
 func (m *Manager) ListProcesses(ctx context.Context, sessionID string) ([]agentctl.ProcessInfo, error) {
@@ -140,6 +155,8 @@ func (m *Manager) StopAllProcesses(ctx context.Context) error {
 		for _, proc := range procs {
 			if err := client.StopProcess(ctx, proc.ID); err != nil {
 				errs = append(errs, err)
+			} else {
+				m.releaseActivity(processActivityKey(proc.ID))
 			}
 		}
 	}

--- a/apps/backend/internal/agent/runtime/lifecycle/process_runner.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/process_runner.go
@@ -86,10 +86,11 @@ func (m *Manager) StopProcess(ctx context.Context, processID string) error {
 		if _, err := client.GetProcess(ctx, processID, false); err != nil {
 			continue
 		}
-		if err := client.StopProcess(ctx, processID); err == nil {
-			m.releaseActivity(processActivityKey(processID))
-			return nil
+		if err := client.StopProcess(ctx, processID); err != nil {
+			return err
 		}
+		m.releaseActivity(processActivityKey(processID))
+		return nil
 	}
 	return fmt.Errorf("process not found: %s", processID)
 }

--- a/apps/backend/internal/agent/runtime/lifecycle/process_runner_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/process_runner_test.go
@@ -2,8 +2,40 @@ package lifecycle
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
 	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/agent/runtime/activity"
+	agentctl "github.com/kandev/kandev/internal/agent/runtime/agentctl"
+	agentctltypes "github.com/kandev/kandev/internal/agentctl/types"
+	"github.com/kandev/kandev/internal/common/logger"
+	"go.uber.org/zap"
 )
+
+func processTestClient(t *testing.T, handler http.Handler) *agentctl.Client {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	host, portText, err := net.SplitHostPort(server.Listener.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	port, err := strconv.Atoi(portText)
+	if err != nil {
+		t.Fatal(err)
+	}
+	log, err := logger.NewFromZap(zap.NewNop())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return agentctl.NewClient(host, port, log)
+}
 
 func TestProcessRunnerStartErrors(t *testing.T) {
 	manager := &Manager{executionStore: NewExecutionStore()}
@@ -52,4 +84,143 @@ func TestProcessRunnerGetErrors(t *testing.T) {
 	if _, err := manager.GetProcess(context.Background(), "process-1", false); err == nil {
 		t.Fatal("expected error when process not found")
 	}
+}
+
+func TestStartProcessMergesManagedGoCacheAndReleasesTerminalLease(t *testing.T) {
+	coordinator := activity.NewCoordinator(activity.Options{})
+	var received agentctl.StartProcessRequest
+	client := processTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&received); err != nil {
+			t.Errorf("decode start request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"process":{"id":"process-1","session_id":"session-1","status":"exited"}}`))
+	}))
+	manager := &Manager{executionStore: NewExecutionStore()}
+	manager.SetActivityCoordinator(coordinator)
+	execution := &AgentExecution{
+		ID: "exec-1", SessionID: "session-1", agentctl: client,
+		Metadata: map[string]interface{}{managedGoCacheMetadataKey: "/managed/go-cache"},
+	}
+	if err := manager.executionStore.Add(execution); err != nil {
+		t.Fatal(err)
+	}
+
+	process, err := manager.StartProcess(context.Background(), StartProcessRequest{
+		SessionID: "session-1", Kind: "test", Command: "go test ./...",
+		Env: map[string]string{"GOCACHE": "/user/go-cache"},
+	})
+	if err != nil {
+		t.Fatalf("StartProcess: %v", err)
+	}
+	if received.Env["GOCACHE"] != "/managed/go-cache" {
+		t.Fatalf("received GOCACHE = %q, want managed path", received.Env["GOCACHE"])
+	}
+	if process.Status != agentctltypes.ProcessStatusExited {
+		t.Fatalf("process status = %q, want exited", process.Status)
+	}
+	maintenance, _, err := coordinator.TryAcquireMaintenance(context.Background(), 0)
+	if err != nil {
+		t.Fatalf("terminal process retained activity lease: %v", err)
+	}
+	maintenance.Release()
+}
+
+func TestStopProcessVerifiesExecutionOwnershipBeforeReleasingLease(t *testing.T) {
+	nonOwnerStopCalled := false
+	nonOwner := processTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			nonOwnerStopCalled = true
+			_, _ = w.Write([]byte(`{"success":true}`))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	ownerStopped := false
+	owner := processTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodPost {
+			ownerStopped = true
+			_, _ = w.Write([]byte(`{"success":true}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"id":"process-owned","session_id":"session-owner","status":"running"}`))
+	}))
+	coordinator := activity.NewCoordinator(activity.Options{})
+	manager := &Manager{executionStore: NewExecutionStore()}
+	manager.SetActivityCoordinator(coordinator)
+	for _, execution := range []*AgentExecution{
+		{ID: "exec-non-owner", SessionID: "session-other", agentctl: nonOwner},
+		{ID: "exec-owner", SessionID: "session-owner", agentctl: owner},
+	} {
+		if err := manager.executionStore.Add(execution); err != nil {
+			t.Fatal(err)
+		}
+	}
+	lease, err := coordinator.AcquireTask(context.Background(), activity.KindShellCommand)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manager.trackActivity(processActivityKey("process-owned"), lease)
+
+	if err := manager.StopProcess(context.Background(), "process-owned"); err != nil {
+		t.Fatalf("StopProcess: %v", err)
+	}
+	if nonOwnerStopCalled || !ownerStopped {
+		t.Fatalf("stop calls: non-owner=%v owner=%v", nonOwnerStopCalled, ownerStopped)
+	}
+	maintenance, _, err := coordinator.TryAcquireMaintenance(context.Background(), 0)
+	if err != nil {
+		t.Fatalf("owned stopped process retained activity lease: %v", err)
+	}
+	maintenance.Release()
+}
+
+func TestStartProcessClientCancellationDoesNotDropIndeterminateLease(t *testing.T) {
+	accepted := make(chan struct{})
+	releaseResponse := make(chan struct{})
+	released := false
+	defer func() {
+		if !released {
+			close(releaseResponse)
+		}
+	}()
+	client := processTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		close(accepted)
+		<-releaseResponse
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"process":{"id":"process-late","session_id":"session-1","status":"running"}}`))
+	}))
+	coordinator := activity.NewCoordinator(activity.Options{})
+	manager := &Manager{executionStore: NewExecutionStore()}
+	manager.SetActivityCoordinator(coordinator)
+	if err := manager.executionStore.Add(&AgentExecution{
+		ID: "exec-1", SessionID: "session-1", agentctl: client,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan error, 1)
+	go func() {
+		_, err := manager.StartProcess(ctx, StartProcessRequest{
+			SessionID: "session-1", Kind: "dev", Command: "pnpm dev",
+		})
+		result <- err
+	}()
+	<-accepted
+	cancel()
+	select {
+	case err := <-result:
+		t.Fatalf("StartProcess returned before accepted start was reconciled: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	if _, _, err := coordinator.TryAcquireMaintenance(context.Background(), 0); !errors.Is(err, activity.ErrBusy) {
+		t.Fatalf("maintenance error = %v, want ErrBusy during indeterminate start", err)
+	}
+	close(releaseResponse)
+	released = true
+	if err := <-result; err != nil {
+		t.Fatalf("StartProcess after accepted response: %v", err)
+	}
+	manager.releaseActivity(processActivityKey("process-late"))
 }

--- a/apps/backend/internal/agent/runtime/lifecycle/process_runner_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/process_runner_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -174,6 +175,39 @@ func TestStopProcessVerifiesExecutionOwnershipBeforeReleasingLease(t *testing.T)
 		t.Fatalf("owned stopped process retained activity lease: %v", err)
 	}
 	maintenance.Release()
+}
+
+func TestStopProcessReturnsOwnerStopErrorAndRetainsLease(t *testing.T) {
+	client := processTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodPost {
+			http.Error(w, "stop exploded", http.StatusInternalServerError)
+			return
+		}
+		_, _ = w.Write([]byte(`{"id":"process-owned","session_id":"session-owner","status":"running"}`))
+	}))
+	coordinator := activity.NewCoordinator(activity.Options{})
+	manager := &Manager{executionStore: NewExecutionStore()}
+	manager.SetActivityCoordinator(coordinator)
+	if err := manager.executionStore.Add(&AgentExecution{
+		ID: "exec-owner", SessionID: "session-owner", agentctl: client,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	lease, err := coordinator.AcquireTask(context.Background(), activity.KindShellCommand)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manager.trackActivity(processActivityKey("process-owned"), lease)
+
+	err = manager.StopProcess(context.Background(), "process-owned")
+	if err == nil || !strings.Contains(err.Error(), "stop exploded") {
+		t.Fatalf("StopProcess error = %v, want owner stop failure", err)
+	}
+	if _, _, err := coordinator.TryAcquireMaintenance(context.Background(), 0); !errors.Is(err, activity.ErrBusy) {
+		t.Fatalf("maintenance error = %v, want ErrBusy while process may still run", err)
+	}
+	manager.releaseActivity(processActivityKey("process-owned"))
 }
 
 func TestStartProcessClientCancellationDoesNotDropIndeterminateLease(t *testing.T) {

--- a/apps/backend/internal/agent/runtime/lifecycle/session.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/session.go
@@ -26,13 +26,14 @@ const modelConfigOptionID = "model"
 
 // SessionManager handles ACP session initialization and management
 type SessionManager struct {
-	logger         *logger.Logger
-	eventPublisher *EventPublisher
-	streamManager  *StreamManager
-	executionStore *ExecutionStore
-	promptStarter  func(executionID string) (uint64, error)
-	historyManager *SessionHistoryManager
-	stopCh         <-chan struct{} // For graceful shutdown coordination
+	logger               *logger.Logger
+	eventPublisher       *EventPublisher
+	streamManager        *StreamManager
+	executionStore       *ExecutionStore
+	promptStarter        func(executionID string) (uint64, error)
+	initialPromptFailure func(executionID string)
+	historyManager       *SessionHistoryManager
+	stopCh               <-chan struct{} // For graceful shutdown coordination
 }
 
 // NewSessionManager creates a new SessionManager
@@ -54,6 +55,10 @@ func (sm *SessionManager) SetDependencies(ep *EventPublisher, strm *StreamManage
 
 func (sm *SessionManager) SetPromptStarter(starter func(executionID string) (uint64, error)) {
 	sm.promptStarter = starter
+}
+
+func (sm *SessionManager) SetInitialPromptFailureHandler(handler func(executionID string)) {
+	sm.initialPromptFailure = handler
 }
 
 // InitializeResult contains the result of session initialization
@@ -496,6 +501,9 @@ func (sm *SessionManager) dispatchInitialPrompt(ctx context.Context, execution *
 				sm.logger.Error("initial prompt failed",
 					zap.String("execution_id", execution.ID),
 					zap.Error(err))
+				if sm.initialPromptFailure != nil {
+					sm.initialPromptFailure(execution.ID)
+				}
 			}
 		}()
 	case sm.shouldInjectResumeContext(agentConfig, execution.SessionID):

--- a/apps/backend/internal/agent/runtime/lifecycle/types.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/types.go
@@ -489,6 +489,7 @@ type LaunchRequest struct {
 	// ExecutionProfileID selects the complete CLI runtime profile. Empty keeps
 	// backward-compatible behavior by using AgentProfileID.
 	ExecutionProfileID string
+	StartAgent         bool                // Transfer launch activity through initial startup/prompt
 	WorkspacePath      string              // Host path to workspace (original repository path)
 	TaskDescription    string              // Task description to send via ACP prompt
 	Attachments        []MessageAttachment // Attachments (images/files) for the initial prompt
@@ -554,6 +555,10 @@ type LaunchRequest struct {
 	// fields above are populated from Repositories[0] for callers that have not
 	// yet been updated.
 	Repositories []RepoLaunchSpec
+
+	// managedGoCachePath is resolved once before local preparation so setup
+	// scripts and the runtime instance cannot observe different settings.
+	managedGoCachePath string
 }
 
 // RepoSpecs returns the per-repo launch specs for this request. When

--- a/apps/backend/internal/backendapp/adapters.go
+++ b/apps/backend/internal/backendapp/adapters.go
@@ -110,6 +110,7 @@ func (a *lifecycleAdapter) LaunchAgent(ctx context.Context, req *executor.Launch
 		TaskTitle:           req.TaskTitle,
 		AgentProfileID:      officeProfileID,
 		ExecutionProfileID:  req.AgentProfileID,
+		StartAgent:          req.StartAgent,
 		WorkspacePath:       workspacePath,
 		TaskDescription:     req.TaskDescription,
 		Attachments:         convertToLifecycleAttachments(req.Attachments),

--- a/apps/backend/internal/backendapp/helpers.go
+++ b/apps/backend/internal/backendapp/helpers.go
@@ -462,6 +462,7 @@ type routeParams struct {
 	eventBus                bus.EventBus
 	services                *Services
 	systemSvc               *systemsvc.Service
+	workspaceRestorer       taskhandlers.WorkspaceQuarantineRestorer
 	runtimeFlagsSvc         *runtimeflags.Service
 	agentSettingsController *agentsettingscontroller.Controller
 	agentSettingsRepo       settingsstore.Repository
@@ -837,6 +838,9 @@ func registerTaskRoutes(p routeParams, planService *taskservice.PlanService, han
 	if handoffSvc != nil {
 		taskH.SetHandoffService(handoffSvc)
 	}
+	if p.workspaceRestorer != nil {
+		taskH.SetWorkspaceQuarantineRestorer(p.workspaceRestorer)
+	}
 	if p.services.GitHub != nil {
 		ghSvc := p.services.GitHub
 		taskH.SetOnTaskCreatedWithPR(func(ctx context.Context, taskID, sessionID, prURL, branch string) {
@@ -1087,12 +1091,16 @@ func registerHealthRoutes(p routeParams) {
 		oslimits.NewOSLimitsChecker(oslimits.NewInotifyProbe()),
 		5*time.Minute,
 	)
-	healthSvc := health.NewService(p.log,
+	checkers := []health.Checker{
 		health.NewGitExecutableChecker(),
 		githubChecker,
 		health.NewAgentChecker(p.agentSettingsController),
 		osLimitsChecker,
-	)
+	}
+	if p.systemSvc != nil && p.systemSvc.StorageRuntime != nil {
+		checkers = append(checkers, p.systemSvc.StorageRuntime)
+	}
+	healthSvc := health.NewService(p.log, checkers...)
 	health.RegisterRoutes(p.router, healthSvc, p.log)
 }
 

--- a/apps/backend/internal/backendapp/helpers_test.go
+++ b/apps/backend/internal/backendapp/helpers_test.go
@@ -20,6 +20,9 @@ import (
 	"github.com/kandev/kandev/internal/common/logger"
 	"github.com/kandev/kandev/internal/db"
 	"github.com/kandev/kandev/internal/events/bus"
+	gateways "github.com/kandev/kandev/internal/gateway/websocket"
+	storagepkg "github.com/kandev/kandev/internal/system/storage"
+	storageworkspaces "github.com/kandev/kandev/internal/system/storage/workspaces"
 	taskdto "github.com/kandev/kandev/internal/task/dto"
 	"github.com/kandev/kandev/internal/task/models"
 	taskrepo "github.com/kandev/kandev/internal/task/repository"
@@ -35,6 +38,69 @@ import (
 	v1 "github.com/kandev/kandev/pkg/api/v1"
 	ws "github.com/kandev/kandev/pkg/websocket"
 )
+
+func TestRegisterTaskRoutesWiresProductionWorkspaceRestorer(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	harness := newBootStateTestHarness(t)
+	ctx := context.Background()
+	workspaces, err := harness.taskSvc.ListWorkspaces(ctx)
+	if err != nil || len(workspaces) == 0 {
+		t.Fatalf("ListWorkspaces: workspaces=%d err=%v", len(workspaces), err)
+	}
+	workflows, err := harness.taskSvc.ListWorkflows(ctx, workspaces[0].ID, true)
+	if err != nil || len(workflows) == 0 {
+		t.Fatalf("ListWorkflows: workflows=%d err=%v", len(workflows), err)
+	}
+	steps, err := harness.workflowSvc.ListStepsByWorkflow(ctx, workflows[0].ID)
+	if err != nil || len(steps) == 0 {
+		t.Fatalf("ListStepsByWorkflow: steps=%d err=%v", len(steps), err)
+	}
+	task, err := harness.taskSvc.CreateTask(ctx, &taskservice.CreateTaskRequest{
+		WorkspaceID: workspaces[0].ID, WorkflowID: workflows[0].ID,
+		WorkflowStepID: steps[0].ID, Title: "Production unarchive wiring",
+	})
+	if err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	if err := harness.taskRepo.ArchiveTask(ctx, task.ID); err != nil {
+		t.Fatalf("ArchiveTask: %v", err)
+	}
+	log, _ := logger.NewLogger(logger.LoggingConfig{Level: "error", Format: "json", OutputPath: "stdout"})
+	router := gin.New()
+	gateway := gateways.NewGateway(log)
+	settings, store := newStorageMaintenanceStores(t)
+	composition := storageComposition{workspaceRestorer: &workspaceQuarantineController{
+		settings: settings,
+		factory: func(storagepkg.StorageMaintenanceSettings) *storageworkspaces.Provider {
+			return storageworkspaces.New(storageworkspaces.Config{Store: store})
+		},
+	}}
+	handoff := taskservice.NewHandoffService(
+		harness.taskRepo, harness.taskRepo,
+		taskservice.NewDocumentService(harness.taskRepo, log), nil, nil, log,
+	)
+	registerTaskRoutes(routeParams{
+		router: router, gateway: gateway, taskSvc: harness.taskSvc, taskRepo: harness.taskRepo,
+		services: &Services{Workflow: harness.workflowSvc}, workspaceRestorer: composition.workspaceRestorer, log: log,
+	}, taskservice.NewPlanService(harness.taskRepo, nil, log), handoff)
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/api/v1/tasks/"+task.ID+"/unarchive", nil)
+	router.ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("unarchive status = %d, body=%s", recorder.Code, recorder.Body.String())
+	}
+	var response struct {
+		WorkspaceRecovery []storageworkspaces.WorkspaceRecovery `json:"workspace_recovery"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(response.WorkspaceRecovery) != 1 || response.WorkspaceRecovery[0].Status != "not_found" {
+		t.Fatalf("workspace recovery = %#v", response.WorkspaceRecovery)
+	}
+}
 
 func decodePayload(t *testing.T, raw json.RawMessage) map[string]interface{} {
 	t.Helper()

--- a/apps/backend/internal/backendapp/main.go
+++ b/apps/backend/internal/backendapp/main.go
@@ -98,6 +98,7 @@ import (
 	workflowadapters "github.com/kandev/kandev/internal/workflow/adapters"
 	workflowengine "github.com/kandev/kandev/internal/workflow/engine"
 
+	taskhandlers "github.com/kandev/kandev/internal/task/handlers"
 	tasksqlite "github.com/kandev/kandev/internal/task/repository/sqlite"
 	taskservice "github.com/kandev/kandev/internal/task/service"
 	workflowservice "github.com/kandev/kandev/internal/workflow/service"
@@ -734,19 +735,30 @@ func startGatewayAndServe(
 	}, systemsvc.Wiring{
 		OrchestratorShutdown: func() { _ = orchestratorSvc.Stop() },
 	})
+	storageComposition, err := provideStorageComposition(
+		cfg, dbPool, systemSvc.Jobs, lifecycleMgr, services.WorktreeMgr, services.Task,
+	)
+	if err != nil {
+		log.Error("Failed to initialize storage maintenance", zap.Error(err))
+		return false
+	}
+	systemSvc.Storage = storageComposition.handler
+	systemSvc.StorageRuntime = storageComposition.runtime
 	if systemSvc.Metrics != nil {
 		systemSvc.Metrics.SetBroadcaster(gateway.Hub.BroadcastToSystemMetrics)
 		gateway.Hub.SetSystemMetricsInterestTracker(systemSvc.Metrics)
 		systemSvc.Metrics.SetExecutionProvider(lifecycleMetricProvider{manager: lifecycleMgr})
 	}
 	systemSvc.StartBackground(ctx)
+	addCleanup(func() error { systemSvc.StopBackground(); return nil })
 	gateways.RegisterSystemNotifications(ctx, eventBus, gateway.Hub, log)
 
 	// ============================================
 	// HTTP SERVER
 	// ============================================
 	server := buildHTTPServer(cfg, log, gateway, repos, services, agentSettingsController,
-		lifecycleMgr, eventBus, orchestratorSvc, notificationCtrl, msgCreator, agentRegistry, hostUtilityMgr, addCleanup, repoCloner, systemSvc)
+		lifecycleMgr, eventBus, orchestratorSvc, notificationCtrl, msgCreator, agentRegistry, hostUtilityMgr,
+		addCleanup, repoCloner, systemSvc, storageComposition.workspaceRestorer)
 
 	port := cfg.Server.Port
 	if port == 0 {
@@ -1157,17 +1169,6 @@ func startOfficeSchedulersAndGC(
 		officeRoutines = services.OfficeSvcs.Routines
 	}
 	startCronScheduler(ctx, repos, engineDispatcher, officeRoutines, log)
-	// Start GC sweep for orphaned worktrees and containers.
-	worktreeBase := filepath.Join(cfg.ResolvedHomeDir(), "tasks")
-	gc := officeinfra.NewGarbageCollector(
-		repos.Office,
-		services.WorktreeMgr, // WorktreeInventory — authoritative live-worktrees source
-		log, worktreeBase,
-		nil, // dockerClient - pass if Docker available
-		3*time.Hour,
-	)
-	go gc.Start(ctx)
-	log.Info("Office GC sweep started")
 }
 
 // wireWorkflowEngineForOffice composes the Phase 2 (ADR-0004)
@@ -1636,6 +1637,7 @@ func buildHTTPServer(
 	addCleanup func(func() error),
 	repoCloner *repoclone.Cloner,
 	systemSvc *systemsvc.Service,
+	workspaceRestorer taskhandlers.WorkspaceQuarantineRestorer,
 ) *http.Server {
 	gin.SetMode(gin.ReleaseMode)
 	router := gin.New()
@@ -1662,6 +1664,7 @@ func buildHTTPServer(
 		eventBus:                eventBus,
 		services:                services,
 		systemSvc:               systemSvc,
+		workspaceRestorer:       workspaceRestorer,
 		runtimeFlagsSvc:         services.RuntimeFlags,
 		agentSettingsController: agentSettingsController,
 		agentSettingsRepo:       repos.AgentSettings,

--- a/apps/backend/internal/backendapp/services.go
+++ b/apps/backend/internal/backendapp/services.go
@@ -72,6 +72,7 @@ func provideServices(cfg *config.Config, log *logger.Logger, repos *Repositories
 			Environments:     repos.Task,
 			TaskEnvironments: repos.Task,
 			Reviews:          repos.Task,
+			ResourceCleanups: repos.Task,
 		},
 		eventBus,
 		log,

--- a/apps/backend/internal/backendapp/storage_docker.go
+++ b/apps/backend/internal/backendapp/storage_docker.go
@@ -1,0 +1,87 @@
+package backendapp
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	agentdocker "github.com/kandev/kandev/internal/agent/docker"
+	"github.com/kandev/kandev/internal/agent/runtime/activity"
+	"github.com/kandev/kandev/internal/system/storage/dockerstore"
+)
+
+type lazyStorageDocker struct {
+	provider func() *agentdocker.Client
+	activity *activity.Coordinator
+}
+
+func (d *lazyStorageDocker) client() (*agentdocker.Client, error) {
+	if d.provider == nil {
+		return nil, errors.New("docker client is not configured")
+	}
+	client := d.provider()
+	if client == nil {
+		return nil, errors.New("docker client is unavailable")
+	}
+	client.SetActivityCoordinator(d.activity)
+	return client, nil
+}
+
+func (d *lazyStorageDocker) Ping(ctx context.Context) error {
+	client, err := d.client()
+	if err != nil {
+		return err
+	}
+	return client.Ping(ctx)
+}
+
+func (d *lazyStorageDocker) ListContainers(
+	ctx context.Context,
+	labels map[string]string,
+) ([]agentdocker.ContainerInfo, error) {
+	client, err := d.client()
+	if err != nil {
+		return nil, err
+	}
+	return client.ListContainers(ctx, labels)
+}
+
+func (d *lazyStorageDocker) RemoveContainer(ctx context.Context, id string, force bool) error {
+	client, err := d.client()
+	if err != nil {
+		return err
+	}
+	return client.RemoveContainer(ctx, id, force)
+}
+
+func (d *lazyStorageDocker) DiskUsage(ctx context.Context) (agentdocker.DiskUsage, error) {
+	client, err := d.client()
+	if err != nil {
+		return agentdocker.DiskUsage{}, err
+	}
+	return client.DiskUsage(ctx)
+}
+
+func (d *lazyStorageDocker) PruneBuildCache(
+	ctx context.Context,
+	options agentdocker.BuildCachePruneOptions,
+) (agentdocker.PruneResult, error) {
+	client, err := d.client()
+	if err != nil {
+		return agentdocker.PruneResult{}, err
+	}
+	return client.PruneBuildCache(ctx, options)
+}
+
+func (d *lazyStorageDocker) PruneUnusedImages(
+	ctx context.Context,
+	cutoff time.Time,
+) (agentdocker.PruneResult, error) {
+	client, err := d.client()
+	if err != nil {
+		return agentdocker.PruneResult{}, err
+	}
+	return client.PruneUnusedImages(ctx, cutoff)
+}
+
+var _ dockerstore.DockerClient = (*lazyStorageDocker)(nil)

--- a/apps/backend/internal/backendapp/storage_inventory.go
+++ b/apps/backend/internal/backendapp/storage_inventory.go
@@ -1,0 +1,142 @@
+package backendapp
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+
+	"github.com/kandev/kandev/internal/agent/runtime/lifecycle"
+	storagepkg "github.com/kandev/kandev/internal/system/storage"
+	"github.com/kandev/kandev/internal/system/storage/workspaces"
+	"github.com/kandev/kandev/internal/task/models"
+	"github.com/kandev/kandev/internal/worktree"
+	v1 "github.com/kandev/kandev/pkg/api/v1"
+)
+
+type storageInventory struct {
+	reader    *sqlx.DB
+	worktrees *worktree.Manager
+	lifecycle *lifecycle.Manager
+}
+
+func (i *storageInventory) LoadWorkspaceInventory(ctx context.Context) (workspaces.Inventory, error) {
+	if i.worktrees == nil || i.lifecycle == nil {
+		return workspaces.Inventory{}, workspaces.ErrInventoryIncomplete
+	}
+	paths, err := i.worktrees.ListActiveWorktreePaths(ctx)
+	if err != nil {
+		return workspaces.Inventory{}, err
+	}
+	inventory := workspaces.Inventory{Complete: true, WorktreePaths: paths}
+	for _, execution := range i.lifecycle.ListExecutions() {
+		if execution.WorkspacePath != "" && filepath.IsAbs(execution.WorkspacePath) {
+			inventory.ExecutionPaths = append(inventory.ExecutionPaths, execution.WorkspacePath)
+		}
+	}
+	rows, err := i.activeWorkspaceRows(ctx)
+	if err != nil {
+		return workspaces.Inventory{}, err
+	}
+	for _, row := range rows {
+		inventory.EnvironmentPaths = append(inventory.EnvironmentPaths, row.WorkspacePath)
+		if row.TaskID != "" && row.WorkspaceID != "" {
+			inventory.ScratchRoots = append(inventory.ScratchRoots, workspaces.ScratchRoot{
+				TaskID: row.TaskID, WorkspaceID: row.WorkspaceID, Path: row.WorkspacePath,
+			})
+		}
+	}
+	return inventory, nil
+}
+
+func (i *storageInventory) activeWorkspaceRows(ctx context.Context) ([]activeWorkspaceRow, error) {
+	rows := make([]activeWorkspaceRow, 0)
+	query := "SELECT te.task_id AS taskid, COALESCE(t.workspace_id, '') AS workspaceid, " +
+		"te.workspace_path AS workspacepath FROM task_environments te " +
+		"LEFT JOIN tasks t ON t.id = te.task_id " +
+		"WHERE te.status IN ('creating', 'ready') AND te.workspace_path <> ''"
+	if err := i.reader.SelectContext(ctx, &rows, query); err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+type activeWorkspaceRow struct {
+	TaskID        string
+	WorkspaceID   string
+	WorkspacePath string
+}
+
+type containerInventory struct{ reader *sqlx.DB }
+
+func (i *containerInventory) ContainerTaskRemovable(ctx context.Context, taskID string) (bool, error) {
+	task, err := i.loadContainerTask(ctx, taskID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return true, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if task.ArchivedAt == nil && !models.IsTerminalTaskState(task.State) {
+		return false, nil
+	}
+	hasEnvironment, err := i.hasLiveTaskEnvironment(ctx, taskID)
+	if err != nil || hasEnvironment {
+		return false, err
+	}
+	hasExecutor, err := i.hasLiveExecutor(ctx, taskID)
+	if err != nil || hasExecutor {
+		return false, err
+	}
+	return true, nil
+}
+
+type containerTask struct {
+	State      v1.TaskState `db:"state"`
+	ArchivedAt *time.Time   `db:"archived_at"`
+}
+
+func (i *containerInventory) loadContainerTask(ctx context.Context, taskID string) (containerTask, error) {
+	var task containerTask
+	query := i.reader.Rebind("SELECT state, archived_at FROM tasks WHERE id = ?")
+	err := i.reader.GetContext(ctx, &task, query, taskID)
+	return task, err
+}
+
+func (i *containerInventory) hasLiveTaskEnvironment(ctx context.Context, taskID string) (bool, error) {
+	var count int
+	query := i.reader.Rebind(
+		"SELECT COUNT(*) FROM task_environments " +
+			"WHERE task_id = ? AND status NOT IN (?, ?)",
+	)
+	if err := i.reader.GetContext(
+		ctx, &count, query, taskID,
+		models.TaskEnvironmentStatusStopped, models.TaskEnvironmentStatusFailed,
+	); err != nil {
+		return false, err
+	}
+	return count > 0, nil
+}
+
+func (i *containerInventory) hasLiveExecutor(ctx context.Context, taskID string) (bool, error) {
+	var count int
+	query := i.reader.Rebind(
+		"SELECT COUNT(*) FROM executors_running " +
+			"WHERE task_id = ? AND status NOT IN (?, ?, ?)",
+	)
+	if err := i.reader.GetContext(
+		ctx, &count, query, taskID,
+		models.ExecutorRunningStatusFailed,
+		models.ExecutorRunningStatusStopped,
+		models.ExecutorRunningStatusComplete,
+	); err != nil {
+		return false, err
+	}
+	return count > 0, nil
+}
+
+var _ workspaces.InventorySource = (*storageInventory)(nil)
+var _ storagepkg.CleanupProvider = namedCleanupProvider{}

--- a/apps/backend/internal/backendapp/storage_inventory_test.go
+++ b/apps/backend/internal/backendapp/storage_inventory_test.go
@@ -1,0 +1,204 @@
+package backendapp
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+	_ "github.com/mattn/go-sqlite3"
+
+	"github.com/kandev/kandev/internal/task/models"
+	v1 "github.com/kandev/kandev/pkg/api/v1"
+)
+
+func TestContainerInventoryRemovability(t *testing.T) {
+	tests := []struct {
+		name   string
+		taskID string
+		setup  func(*testing.T, *sqlx.DB)
+		want   bool
+	}{
+		{
+			name:   "missing task is removable",
+			taskID: "missing",
+			want:   true,
+		},
+		{
+			name:   "nonterminal task with stopped environment is retained",
+			taskID: "active-stopped-env",
+			setup: func(t *testing.T, database *sqlx.DB) {
+				insertContainerInventoryTask(t, database, "active-stopped-env", v1.TaskStateInProgress, false)
+				insertContainerInventoryEnvironment(t, database, "active-stopped-env", models.TaskEnvironmentStatusStopped)
+			},
+		},
+		{
+			name:   "archived task without live handles is removable",
+			taskID: "archived",
+			setup: func(t *testing.T, database *sqlx.DB) {
+				insertContainerInventoryTask(t, database, "archived", v1.TaskStateInProgress, true)
+			},
+			want: true,
+		},
+		{
+			name:   "terminal task without live handles is removable",
+			taskID: "terminal",
+			setup: func(t *testing.T, database *sqlx.DB) {
+				insertContainerInventoryTask(t, database, "terminal", v1.TaskStateCompleted, false)
+			},
+			want: true,
+		},
+		{
+			name:   "terminal task with live environment is retained",
+			taskID: "terminal-live-env",
+			setup: func(t *testing.T, database *sqlx.DB) {
+				insertContainerInventoryTask(t, database, "terminal-live-env", v1.TaskStateCompleted, false)
+				insertContainerInventoryEnvironment(t, database, "terminal-live-env", models.TaskEnvironmentStatusReady)
+			},
+		},
+		{
+			name:   "terminal task with unknown environment state is retained",
+			taskID: "terminal-unknown-env",
+			setup: func(t *testing.T, database *sqlx.DB) {
+				insertContainerInventoryTask(t, database, "terminal-unknown-env", v1.TaskStateCompleted, false)
+				insertContainerInventoryEnvironment(t, database, "terminal-unknown-env", "new-state")
+			},
+		},
+		{
+			name:   "archived task with live executor handle is retained",
+			taskID: "archived-live-executor",
+			setup: func(t *testing.T, database *sqlx.DB) {
+				insertContainerInventoryTask(t, database, "archived-live-executor", v1.TaskStateCompleted, true)
+				insertContainerInventoryExecutor(t, database, "archived-live-executor", models.ExecutorRunningStatusRunning)
+			},
+		},
+		{
+			name:   "terminal task with stopped executor is removable",
+			taskID: "terminal-stopped-executor",
+			setup: func(t *testing.T, database *sqlx.DB) {
+				insertContainerInventoryTask(t, database, "terminal-stopped-executor", v1.TaskStateFailed, false)
+				insertContainerInventoryExecutor(t, database, "terminal-stopped-executor", models.ExecutorRunningStatusStopped)
+			},
+			want: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			database := newContainerInventoryDatabase(t)
+			if test.setup != nil {
+				test.setup(t, database)
+			}
+
+			got, err := (&containerInventory{reader: database}).ContainerTaskRemovable(
+				context.Background(), test.taskID,
+			)
+			if err != nil {
+				t.Fatalf("ContainerTaskRemovable: %v", err)
+			}
+			if got != test.want {
+				t.Fatalf("ContainerTaskRemovable = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestContainerInventoryFailsClosedWhenInventoryUnavailable(t *testing.T) {
+	database := newContainerInventoryDatabase(t)
+	insertContainerInventoryTask(t, database, "inventory-error", v1.TaskStateCompleted, false)
+	if err := database.Close(); err != nil {
+		t.Fatalf("close inventory database: %v", err)
+	}
+
+	removable, err := (&containerInventory{reader: database}).ContainerTaskRemovable(
+		context.Background(), "inventory-error",
+	)
+	if err == nil {
+		t.Fatal("ContainerTaskRemovable error = nil, want inventory error")
+	}
+	if removable {
+		t.Fatal("ContainerTaskRemovable = true on inventory error, want fail-closed false")
+	}
+}
+
+func newContainerInventoryDatabase(t *testing.T) *sqlx.DB {
+	t.Helper()
+	database, err := sqlx.Open("sqlite3", filepath.Join(t.TempDir(), "inventory.db"))
+	if err != nil {
+		t.Fatalf("open inventory database: %v", err)
+	}
+	database.SetMaxOpenConns(1)
+	t.Cleanup(func() { _ = database.Close() })
+	const schema = `
+		CREATE TABLE tasks (
+			id TEXT PRIMARY KEY,
+			state TEXT NOT NULL,
+			archived_at TIMESTAMP
+		);
+		CREATE TABLE task_environments (
+			id TEXT PRIMARY KEY,
+			task_id TEXT NOT NULL,
+			status TEXT NOT NULL
+		);
+		CREATE TABLE executors_running (
+			id TEXT PRIMARY KEY,
+			task_id TEXT NOT NULL,
+			status TEXT NOT NULL,
+			runtime TEXT NOT NULL
+		);`
+	if _, err := database.Exec(schema); err != nil {
+		t.Fatalf("create inventory schema: %v", err)
+	}
+	return database
+}
+
+func insertContainerInventoryTask(
+	t *testing.T,
+	database *sqlx.DB,
+	taskID string,
+	state v1.TaskState,
+	archived bool,
+) {
+	t.Helper()
+	var archivedAt any
+	if archived {
+		archivedAt = time.Now().UTC()
+	}
+	if _, err := database.Exec(
+		"INSERT INTO tasks (id, state, archived_at) VALUES (?, ?, ?)",
+		taskID, state, archivedAt,
+	); err != nil {
+		t.Fatalf("insert task %q: %v", taskID, err)
+	}
+}
+
+func insertContainerInventoryEnvironment(
+	t *testing.T,
+	database *sqlx.DB,
+	taskID string,
+	status models.TaskEnvironmentStatus,
+) {
+	t.Helper()
+	if _, err := database.Exec(
+		"INSERT INTO task_environments (id, task_id, status) VALUES (?, ?, ?)",
+		"env-"+taskID, taskID, status,
+	); err != nil {
+		t.Fatalf("insert task environment for %q: %v", taskID, err)
+	}
+}
+
+func insertContainerInventoryExecutor(
+	t *testing.T,
+	database *sqlx.DB,
+	taskID string,
+	status string,
+) {
+	t.Helper()
+	if _, err := database.Exec(
+		"INSERT INTO executors_running (id, task_id, status, runtime) VALUES (?, ?, ?, ?)",
+		"executor-"+taskID, taskID, status, "docker",
+	); err != nil {
+		t.Fatalf("insert executor handle for %q: %v", taskID, err)
+	}
+}

--- a/apps/backend/internal/backendapp/storage_maintenance.go
+++ b/apps/backend/internal/backendapp/storage_maintenance.go
@@ -80,6 +80,7 @@ func provideStorageComposition(
 	})
 	quarantine := &workspaceQuarantineController{
 		settings: settings, store: store, factory: workspaceFactory, homeDir: cfg.ResolvedHomeDir(),
+		activity: coordinator,
 	}
 	operations := storagepkg.NewOperations(storagepkg.OperationsConfig{
 		Settings: settings, Store: store, Jobs: tracker, Activity: coordinator,
@@ -300,10 +301,24 @@ func (r *workspaceReconciler) Reconcile(ctx context.Context) error {
 
 type workspaceQuarantineController struct {
 	settings *storagepkg.SettingsStore
-	store    *storagepkg.Store
+	store    quarantineEntryStore
 	factory  workspaceFactory
 	homeDir  string
+	activity *activity.Coordinator
+	rename   func(string, string) error
 }
+
+type quarantineEntryStore interface {
+	GetQuarantineEntry(context.Context, string) (storagepkg.QuarantineEntry, error)
+	TransitionQuarantineEntry(
+		context.Context, string, storagepkg.QuarantineState, string,
+	) (storagepkg.QuarantineEntry, error)
+}
+
+const (
+	goCacheOwnershipManaged = "managed"
+	goCacheOwnershipAdopted = "adopted"
+)
 
 func (c *workspaceQuarantineController) RestoreTask(
 	ctx context.Context,
@@ -370,31 +385,91 @@ func (c *workspaceQuarantineController) restoreGoCache(
 	if err := c.validateGoCacheEntry(ctx, entry); err != nil {
 		return storagepkg.QuarantineEntry{}, err
 	}
+	lease, err := c.acquireGoCacheMaintenance(ctx)
+	if err != nil {
+		return storagepkg.QuarantineEntry{}, err
+	}
+	if lease != nil {
+		defer lease.Release()
+	}
 	if restored, resolved, err := c.resolveAlreadyRestoredGoCache(ctx, entry); resolved || err != nil {
 		return restored, err
 	}
-	if _, err := os.Lstat(entry.OriginalPath); err == nil {
-		return storagepkg.QuarantineEntry{}, fmt.Errorf("%w: Go-cache restore destination already exists", storagepkg.ErrConflict)
-	} else if !errors.Is(err, os.ErrNotExist) {
-		return storagepkg.QuarantineEntry{}, fmt.Errorf("inspect Go-cache restore destination: %w", err)
-	}
-	if err := c.validateGoCacheRestorePath(entry.OriginalPath); err != nil {
+	if err := c.prepareGoCacheRestoreDestination(entry); err != nil {
 		return storagepkg.QuarantineEntry{}, err
 	}
-	if err := os.MkdirAll(filepath.Dir(entry.OriginalPath), 0o700); err != nil {
-		return storagepkg.QuarantineEntry{}, fmt.Errorf("create Go-cache restore parent: %w", err)
-	}
-	if err := os.Rename(entry.QuarantinePath, entry.OriginalPath); err != nil {
+	if err := c.renamePath(entry.QuarantinePath, entry.OriginalPath); err != nil {
 		return storagepkg.QuarantineEntry{}, fmt.Errorf("restore Go cache: %w", err)
 	}
+	return c.persistGoCacheRestore(ctx, entry)
+}
+
+func (c *workspaceQuarantineController) prepareGoCacheRestoreDestination(
+	entry storagepkg.QuarantineEntry,
+) error {
+	if err := c.validateGoCacheRestorePath(entry.OriginalPath); err != nil {
+		return err
+	}
+	if _, err := os.Lstat(entry.OriginalPath); err == nil {
+		ownership, ownershipErr := goCacheEntryOwnership(entry)
+		if ownershipErr != nil {
+			return ownershipErr
+		}
+		removed, removeErr := gocache.RemoveRestorePlaceholder(
+			entry.OriginalPath, ownership == goCacheOwnershipAdopted,
+		)
+		if removeErr != nil {
+			return removeErr
+		}
+		if !removed {
+			return fmt.Errorf("%w: Go-cache restore destination already exists", storagepkg.ErrConflict)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("inspect Go-cache restore destination: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(entry.OriginalPath), 0o700); err != nil {
+		return fmt.Errorf("create Go-cache restore parent: %w", err)
+	}
+	return nil
+}
+
+func (c *workspaceQuarantineController) persistGoCacheRestore(
+	ctx context.Context,
+	entry storagepkg.QuarantineEntry,
+) (storagepkg.QuarantineEntry, error) {
 	restored, err := c.store.TransitionQuarantineEntry(
 		ctx, entry.ID, storagepkg.QuarantineStateRestored, "",
 	)
 	if err != nil {
-		_ = os.Rename(entry.OriginalPath, entry.QuarantinePath)
-		return storagepkg.QuarantineEntry{}, fmt.Errorf("persist Go-cache restore: %w", err)
+		persistErr := fmt.Errorf("persist Go-cache restore: %w", err)
+		if rollbackErr := c.renamePath(entry.OriginalPath, entry.QuarantinePath); rollbackErr != nil {
+			return storagepkg.QuarantineEntry{}, errors.Join(
+				persistErr, fmt.Errorf("rollback Go-cache restore: %w", rollbackErr),
+			)
+		}
+		return storagepkg.QuarantineEntry{}, persistErr
 	}
 	return restored, nil
+}
+
+func (c *workspaceQuarantineController) renamePath(oldPath, newPath string) error {
+	if c.rename != nil {
+		return c.rename(oldPath, newPath)
+	}
+	return os.Rename(oldPath, newPath)
+}
+
+func (c *workspaceQuarantineController) acquireGoCacheMaintenance(
+	ctx context.Context,
+) (*activity.MaintenanceLease, error) {
+	if c.activity == nil {
+		return nil, nil
+	}
+	lease, busy, err := c.activity.TryAcquireMaintenance(ctx, 0)
+	if errors.Is(err, activity.ErrBusy) {
+		return nil, &storagepkg.BusyError{Resources: busy}
+	}
+	return lease, err
 }
 
 func (c *workspaceQuarantineController) deleteGoCache(
@@ -427,25 +502,34 @@ func (c *workspaceQuarantineController) deleteGoCache(
 }
 
 func (c *workspaceQuarantineController) validateGoCacheEntry(
-	ctx context.Context,
+	_ context.Context,
 	entry storagepkg.QuarantineEntry,
 ) error {
 	if entry.State != storagepkg.QuarantineStateQuarantined &&
 		entry.State != storagepkg.QuarantineStateFailed {
 		return fmt.Errorf("%w: Go-cache quarantine entry is %q", storagepkg.ErrConflict, entry.State)
 	}
-	settings, err := c.settings.GetSettings(ctx)
+	expectedQuarantine := filepath.Join(c.homeDir, "trash", "go-cache", entry.ID)
+	if filepath.Clean(entry.QuarantinePath) != filepath.Clean(expectedQuarantine) {
+		return fmt.Errorf("%w: Go-cache quarantine paths do not match managed storage", storagepkg.ErrValidation)
+	}
+	ownership, err := goCacheEntryOwnership(entry)
 	if err != nil {
 		return err
 	}
-	expectedOriginal := settings.GoCache.AdoptedPath
-	if expectedOriginal == "" {
-		expectedOriginal = filepath.Join(c.homeDir, "cache", "go-build")
-	}
-	expectedQuarantine := filepath.Join(c.homeDir, "trash", "go-cache", entry.ID)
-	if filepath.Clean(entry.OriginalPath) != filepath.Clean(expectedOriginal) ||
-		filepath.Clean(entry.QuarantinePath) != filepath.Clean(expectedQuarantine) {
-		return fmt.Errorf("%w: Go-cache quarantine paths do not match managed storage", storagepkg.ErrValidation)
+	switch ownership {
+	case goCacheOwnershipManaged:
+		expectedOriginal := filepath.Join(c.homeDir, "cache", "go-build")
+		if filepath.Clean(entry.OriginalPath) != filepath.Clean(expectedOriginal) {
+			return fmt.Errorf("%w: managed Go-cache original path does not match owned storage", storagepkg.ErrValidation)
+		}
+	case goCacheOwnershipAdopted:
+		original := filepath.Clean(entry.OriginalPath)
+		if !filepath.IsAbs(original) || original == filepath.VolumeName(original)+string(filepath.Separator) {
+			return fmt.Errorf("%w: adopted Go-cache original path is unsafe", storagepkg.ErrValidation)
+		}
+	default:
+		return fmt.Errorf("%w: unknown Go-cache ownership policy %q", storagepkg.ErrValidation, ownership)
 	}
 	if err := storagepkg.ValidateNoSymlinkPath(c.homeDir, entry.QuarantinePath); err != nil {
 		return fmt.Errorf("%w: validate Go-cache quarantine path: %v", storagepkg.ErrValidation, err)
@@ -453,11 +537,22 @@ func (c *workspaceQuarantineController) validateGoCacheEntry(
 	return nil
 }
 
+func goCacheEntryOwnership(entry storagepkg.QuarantineEntry) (string, error) {
+	var metadata struct {
+		Ownership string `json:"ownership"`
+	}
+	if err := json.Unmarshal(entry.Metadata, &metadata); err != nil || metadata.Ownership == "" {
+		return "", fmt.Errorf("%w: invalid Go-cache quarantine ownership metadata", storagepkg.ErrValidation)
+	}
+	return metadata.Ownership, nil
+}
+
 func (c *workspaceQuarantineController) resolveAlreadyRestoredGoCache(
 	ctx context.Context,
 	entry storagepkg.QuarantineEntry,
 ) (storagepkg.QuarantineEntry, bool, error) {
-	if entry.State != storagepkg.QuarantineStateFailed {
+	if entry.State != storagepkg.QuarantineStateFailed &&
+		entry.State != storagepkg.QuarantineStateQuarantined {
 		return storagepkg.QuarantineEntry{}, false, nil
 	}
 	if _, err := os.Lstat(entry.OriginalPath); errors.Is(err, os.ErrNotExist) {

--- a/apps/backend/internal/backendapp/storage_maintenance.go
+++ b/apps/backend/internal/backendapp/storage_maintenance.go
@@ -1,0 +1,494 @@
+package backendapp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/kandev/kandev/internal/agent/runtime/activity"
+	"github.com/kandev/kandev/internal/agent/runtime/lifecycle"
+	"github.com/kandev/kandev/internal/common/config"
+	"github.com/kandev/kandev/internal/db"
+	"github.com/kandev/kandev/internal/system/jobs"
+	systemsettings "github.com/kandev/kandev/internal/system/settings"
+	storagepkg "github.com/kandev/kandev/internal/system/storage"
+	"github.com/kandev/kandev/internal/system/storage/dockerstore"
+	"github.com/kandev/kandev/internal/system/storage/gocache"
+	"github.com/kandev/kandev/internal/system/storage/workspaces"
+	taskservice "github.com/kandev/kandev/internal/task/service"
+	"github.com/kandev/kandev/internal/worktree"
+)
+
+type storageComposition struct {
+	handler           *storagepkg.Handler
+	runtime           *storagepkg.Runtime
+	workspaceRestorer *workspaceQuarantineController
+}
+
+func provideStorageComposition(
+	cfg *config.Config,
+	pool *db.Pool,
+	tracker *jobs.Tracker,
+	lifecycleMgr *lifecycle.Manager,
+	worktreeMgr *worktree.Manager,
+	taskSvc *taskservice.Service,
+) (*storageComposition, error) {
+	rawSettings, err := systemsettings.NewStore(pool)
+	if err != nil {
+		return nil, fmt.Errorf("initialize storage settings: %w", err)
+	}
+	settings := storagepkg.NewSettingsStore(rawSettings)
+	store, err := storagepkg.NewStore(pool)
+	if err != nil {
+		return nil, fmt.Errorf("initialize storage store: %w", err)
+	}
+	coordinator := activity.NewCoordinator(activity.Options{})
+	taskSvc.SetTaskResourceCleanupActivityGate(&taskCleanupActivityGate{coordinator: coordinator})
+	goCache := gocache.New(gocache.Config{
+		HomeDir: cfg.ResolvedHomeDir(), TrashDir: filepath.Join(cfg.ResolvedHomeDir(), "trash"),
+		Settings: settings, Store: store,
+	})
+	lifecycleMgr.SetActivityCoordinator(coordinator)
+	lifecycleMgr.SetManagedGoCacheEnvironmentProvider(goCache)
+	if worktreeMgr != nil {
+		worktreeMgr.SetScriptEnvironmentProvider(goCache)
+	}
+
+	inventory := &storageInventory{reader: pool.Reader(), worktrees: worktreeMgr, lifecycle: lifecycleMgr}
+	workspaceFactory := newWorkspaceFactory(cfg, store, inventory, worktreeMgr)
+	dockerClient := &lazyStorageDocker{provider: lifecycleMgr.DockerClientProvider(), activity: coordinator}
+	dockerProvider := dockerstore.NewProvider(
+		dockerClient, &containerInventory{reader: pool.Reader()}, settings,
+	)
+	overview := &storageOverview{
+		settings: settings, quarantine: store, workspaceFactory: workspaceFactory, goCache: goCache,
+		docker: dockerProvider, dockerClient: dockerClient, dockerHost: cfg.Docker.Host,
+		homeDir: cfg.ResolvedHomeDir(),
+	}
+	providers := storageCleanupProviders(settings, workspaceFactory, goCache, dockerProvider)
+	runner := storagepkg.NewRunner(storagepkg.RunnerConfig{
+		Activity: coordinator, Store: store, Providers: providers,
+	})
+	scheduler := storagepkg.NewScheduler(settings, runner, storagepkg.SchedulerOptions{})
+	runtime := storagepkg.NewRuntime(storagepkg.RuntimeConfig{
+		Scheduler: scheduler, Settings: settings, Worker: taskSvc,
+		Reconciler: &workspaceReconciler{settings: settings, factory: workspaceFactory},
+	})
+	quarantine := &workspaceQuarantineController{
+		settings: settings, store: store, factory: workspaceFactory, homeDir: cfg.ResolvedHomeDir(),
+	}
+	operations := storagepkg.NewOperations(storagepkg.OperationsConfig{
+		Settings: settings, Store: store, Jobs: tracker, Activity: coordinator,
+		Providers: providers, Overview: overview, GoCache: goCache, Quarantine: quarantine,
+	})
+	handler := storagepkg.NewHandler(storagepkg.HandlerConfig{
+		Settings: settings, Runs: store, Quarantine: store, Overview: overview,
+		Mutations: operations, OnSettingsChanged: runtime.ApplySettings,
+	})
+	return &storageComposition{
+		handler: handler, runtime: runtime, workspaceRestorer: quarantine,
+	}, nil
+}
+
+type taskCleanupActivityGate struct {
+	coordinator *activity.Coordinator
+}
+
+func (g *taskCleanupActivityGate) AcquireTaskResourceCleanup(
+	ctx context.Context,
+) (taskservice.TaskResourceCleanupActivityLease, error) {
+	return g.coordinator.AcquireTask(ctx, activity.KindCleanupScript)
+}
+
+type workspaceFactory func(storagepkg.StorageMaintenanceSettings) *workspaces.Provider
+
+func newWorkspaceFactory(
+	cfg *config.Config,
+	store *storagepkg.Store,
+	inventory workspaces.InventorySource,
+	pruner workspaces.WorktreePruner,
+) workspaceFactory {
+	return func(current storagepkg.StorageMaintenanceSettings) *workspaces.Provider {
+		return workspaces.New(workspaces.Config{
+			TasksRoot: filepath.Join(cfg.ResolvedHomeDir(), "tasks"),
+			TrashRoot: filepath.Join(cfg.ResolvedHomeDir(), "trash"),
+			Inventory: inventory, Store: store, Pruner: pruner,
+			GracePeriod: time.Duration(current.OrphanGraceHours) * time.Hour,
+			Retention:   time.Duration(current.QuarantineRetentionHours) * time.Hour,
+		})
+	}
+}
+
+type quarantineSummarizer interface {
+	SummarizeQuarantine(context.Context) (storagepkg.QuarantineSummary, error)
+}
+
+type storageOverview struct {
+	settings         *storagepkg.SettingsStore
+	quarantine       quarantineSummarizer
+	workspaceFactory workspaceFactory
+	goCache          *gocache.Provider
+	docker           *dockerstore.Provider
+	dockerClient     *lazyStorageDocker
+	dockerHost       string
+	homeDir          string
+}
+
+func (o *storageOverview) Summary(ctx context.Context) (storagepkg.Summary, error) {
+	settings, err := o.settings.GetSettings(ctx)
+	if err != nil {
+		return storagepkg.Summary{}, err
+	}
+	workspaceSummary, workspaceErr := o.workspaceFactory(settings).Analyze(ctx)
+	goCacheSummary, goCacheErr := o.goCache.Analyze(ctx)
+	quarantineSummary, quarantineErr := o.quarantine.SummarizeQuarantine(ctx)
+	dockerSummary := o.docker.Analyze(ctx)
+	return storagepkg.Summary{
+		Workspaces: summaryValue(workspaceSummary, workspaceErr),
+		GoCache:    summaryValue(goCacheSummary, goCacheErr),
+		Quarantine: summaryValue(quarantineSummary, quarantineErr),
+		Docker: map[string]any{
+			"available": dockerSummary.Available, "build_cache_bytes": dockerSummary.BuildCacheBytes,
+			"unused_image_bytes": dockerSummary.UnusedImageBytes, "warnings": dockerSummary.Warnings,
+			"managed_container_count": dockerSummary.ManagedContainerCount,
+			"managed_container_bytes": dockerSummary.ManagedContainerBytes,
+		},
+	}, nil
+}
+
+func (o *storageOverview) Capabilities(
+	ctx context.Context,
+	settings storagepkg.StorageMaintenanceSettings,
+) storagepkg.Capabilities {
+	dockerAvailable := o.dockerClient.Ping(ctx) == nil
+	goPath := settings.GoCache.AdoptedPath
+	if goPath == "" {
+		goPath = filepath.Join(o.homeDir, "cache", "go-build")
+	}
+	return storagepkg.Capabilities{
+		ManagedGoCachePath: goPath, GoCacheAdoptionAvailable: true,
+		DockerAvailable: dockerAvailable, DockerHost: o.dockerHost,
+		HostGlobalDockerCleanup: dockerAvailable && settings.Docker.DedicatedDaemonAcknowledged,
+	}
+}
+
+func summaryValue(value any, err error) any {
+	if err == nil {
+		return value
+	}
+	return map[string]any{"available": false, "warning": err.Error()}
+}
+
+type namedCleanupProvider struct {
+	name    string
+	cleanup func(context.Context) (map[string]any, error)
+}
+
+type goCacheCleanupProvider struct {
+	provider *gocache.Provider
+}
+
+func (p goCacheCleanupProvider) Name() string { return "go_cache" }
+func (p goCacheCleanupProvider) Cleanup(ctx context.Context) (map[string]any, error) {
+	result, err := p.provider.Cleanup(ctx)
+	return toMap(result), err
+}
+func (p goCacheCleanupProvider) CleanupExplicit(ctx context.Context) (map[string]any, error) {
+	result, err := p.provider.CleanupExplicit(ctx)
+	return toMap(result), err
+}
+
+func (p namedCleanupProvider) Name() string { return p.name }
+func (p namedCleanupProvider) Cleanup(ctx context.Context) (map[string]any, error) {
+	return p.cleanup(ctx)
+}
+
+func storageCleanupProviders(
+	settings *storagepkg.SettingsStore,
+	workspaceFactory workspaceFactory,
+	goCache *gocache.Provider,
+	docker *dockerstore.Provider,
+) []storagepkg.CleanupProvider {
+	return []storagepkg.CleanupProvider{
+		workspaceCleanupAdapter(settings, workspaceFactory),
+		goCacheCleanupProvider{provider: goCache},
+		dockerContainerCleanupAdapter(settings, docker),
+		dockerBuildCacheCleanupAdapter(settings, docker),
+		dockerImageCleanupAdapter(settings, docker),
+	}
+}
+
+func workspaceCleanupAdapter(
+	settings *storagepkg.SettingsStore,
+	factory workspaceFactory,
+) storagepkg.CleanupProvider {
+	return namedCleanupProvider{name: "workspaces", cleanup: func(ctx context.Context) (map[string]any, error) {
+		current, err := settings.GetSettings(ctx)
+		if err != nil || !current.Workspaces.Enabled {
+			return nil, err
+		}
+		result, err := factory(current).Cleanup(ctx)
+		return toMap(result), err
+	}}
+}
+
+func dockerContainerCleanupAdapter(
+	settings *storagepkg.SettingsStore,
+	provider *dockerstore.Provider,
+) storagepkg.CleanupProvider {
+	return namedCleanupProvider{name: "kandev_containers", cleanup: func(ctx context.Context) (map[string]any, error) {
+		current, err := settings.GetSettings(ctx)
+		if err != nil || !current.KandevContainers.Enabled {
+			return nil, err
+		}
+		return toMap(provider.CleanupContainers(ctx)), nil
+	}}
+}
+
+func dockerBuildCacheCleanupAdapter(
+	settings *storagepkg.SettingsStore,
+	provider *dockerstore.Provider,
+) storagepkg.CleanupProvider {
+	return namedCleanupProvider{name: "docker_build_cache", cleanup: func(ctx context.Context) (map[string]any, error) {
+		current, err := settings.GetSettings(ctx)
+		if err != nil || !current.Docker.BuildCacheEnabled {
+			return nil, err
+		}
+		result, err := provider.PruneBuildCache(ctx)
+		return toMap(result), err
+	}}
+}
+
+func dockerImageCleanupAdapter(
+	settings *storagepkg.SettingsStore,
+	provider *dockerstore.Provider,
+) storagepkg.CleanupProvider {
+	return namedCleanupProvider{name: "docker_unused_images", cleanup: func(ctx context.Context) (map[string]any, error) {
+		current, err := settings.GetSettings(ctx)
+		if err != nil || !current.Docker.UnusedImagesEnabled {
+			return nil, err
+		}
+		result, err := provider.PruneUnusedImages(ctx)
+		return toMap(result), err
+	}}
+}
+
+func toMap(value any) map[string]any {
+	encoded, _ := json.Marshal(value)
+	result := make(map[string]any)
+	_ = json.Unmarshal(encoded, &result)
+	return result
+}
+
+type workspaceReconciler struct {
+	settings *storagepkg.SettingsStore
+	factory  workspaceFactory
+}
+
+func (r *workspaceReconciler) Reconcile(ctx context.Context) error {
+	settings, err := r.settings.GetSettings(ctx)
+	if err != nil {
+		return err
+	}
+	_, err = r.factory(settings).Reconcile(ctx)
+	return err
+}
+
+type workspaceQuarantineController struct {
+	settings *storagepkg.SettingsStore
+	store    *storagepkg.Store
+	factory  workspaceFactory
+	homeDir  string
+}
+
+func (c *workspaceQuarantineController) RestoreTask(
+	ctx context.Context,
+	taskID string,
+) workspaces.WorkspaceRecovery {
+	current, err := c.settings.GetSettings(ctx)
+	if err != nil {
+		return workspaces.WorkspaceRecovery{TaskID: taskID, Status: "failed", Message: err.Error()}
+	}
+	return c.factory(current).RestoreTask(ctx, taskID)
+}
+
+func (c *workspaceQuarantineController) Restore(
+	ctx context.Context,
+	id string,
+) (storagepkg.QuarantineEntry, error) {
+	entry, err := c.store.GetQuarantineEntry(ctx, id)
+	if err != nil {
+		return storagepkg.QuarantineEntry{}, err
+	}
+	if entry.ResourceType == storagepkg.ResourceTypeGoCache {
+		return c.restoreGoCache(ctx, entry)
+	}
+	if entry.ResourceType != storagepkg.ResourceTypeTaskWorkspace {
+		return storagepkg.QuarantineEntry{}, fmt.Errorf("%w: unsupported quarantine resource %q", storagepkg.ErrValidation, entry.ResourceType)
+	}
+	settings, err := c.settings.GetSettings(ctx)
+	if err != nil {
+		return storagepkg.QuarantineEntry{}, err
+	}
+	restored, err := c.factory(settings).Restore(ctx, id)
+	if errors.Is(err, workspaces.ErrRestoreConflict) {
+		return storagepkg.QuarantineEntry{}, fmt.Errorf("%w: %v", storagepkg.ErrConflict, err)
+	}
+	return restored, err
+}
+
+func (c *workspaceQuarantineController) PermanentDelete(
+	ctx context.Context,
+	id string,
+	confirmation string,
+) (storagepkg.QuarantineEntry, error) {
+	entry, err := c.store.GetQuarantineEntry(ctx, id)
+	if err != nil {
+		return storagepkg.QuarantineEntry{}, err
+	}
+	if entry.ResourceType == storagepkg.ResourceTypeGoCache {
+		return c.deleteGoCache(ctx, entry, confirmation)
+	}
+	if entry.ResourceType != storagepkg.ResourceTypeTaskWorkspace {
+		return storagepkg.QuarantineEntry{}, fmt.Errorf("%w: unsupported quarantine resource %q", storagepkg.ErrValidation, entry.ResourceType)
+	}
+	settings, err := c.settings.GetSettings(ctx)
+	if err != nil {
+		return storagepkg.QuarantineEntry{}, err
+	}
+	return c.factory(settings).PermanentDelete(ctx, id, confirmation)
+}
+
+func (c *workspaceQuarantineController) restoreGoCache(
+	ctx context.Context,
+	entry storagepkg.QuarantineEntry,
+) (storagepkg.QuarantineEntry, error) {
+	if err := c.validateGoCacheEntry(ctx, entry); err != nil {
+		return storagepkg.QuarantineEntry{}, err
+	}
+	if restored, resolved, err := c.resolveAlreadyRestoredGoCache(ctx, entry); resolved || err != nil {
+		return restored, err
+	}
+	if _, err := os.Lstat(entry.OriginalPath); err == nil {
+		return storagepkg.QuarantineEntry{}, fmt.Errorf("%w: Go-cache restore destination already exists", storagepkg.ErrConflict)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return storagepkg.QuarantineEntry{}, fmt.Errorf("inspect Go-cache restore destination: %w", err)
+	}
+	if err := c.validateGoCacheRestorePath(entry.OriginalPath); err != nil {
+		return storagepkg.QuarantineEntry{}, err
+	}
+	if err := os.MkdirAll(filepath.Dir(entry.OriginalPath), 0o700); err != nil {
+		return storagepkg.QuarantineEntry{}, fmt.Errorf("create Go-cache restore parent: %w", err)
+	}
+	if err := os.Rename(entry.QuarantinePath, entry.OriginalPath); err != nil {
+		return storagepkg.QuarantineEntry{}, fmt.Errorf("restore Go cache: %w", err)
+	}
+	restored, err := c.store.TransitionQuarantineEntry(
+		ctx, entry.ID, storagepkg.QuarantineStateRestored, "",
+	)
+	if err != nil {
+		_ = os.Rename(entry.OriginalPath, entry.QuarantinePath)
+		return storagepkg.QuarantineEntry{}, fmt.Errorf("persist Go-cache restore: %w", err)
+	}
+	return restored, nil
+}
+
+func (c *workspaceQuarantineController) deleteGoCache(
+	ctx context.Context,
+	entry storagepkg.QuarantineEntry,
+	confirmation string,
+) (storagepkg.QuarantineEntry, error) {
+	if confirmation != "DELETE" {
+		return storagepkg.QuarantineEntry{}, fmt.Errorf("%w: quarantine deletion requires DELETE confirmation", storagepkg.ErrValidation)
+	}
+	if err := c.validateGoCacheEntry(ctx, entry); err != nil {
+		return storagepkg.QuarantineEntry{}, err
+	}
+	if time.Now().UTC().Before(entry.DeleteAfter) {
+		return storagepkg.QuarantineEntry{}, fmt.Errorf("%w: quarantine retention deadline has not elapsed", storagepkg.ErrConflict)
+	}
+	if restored, resolved, err := c.resolveAlreadyRestoredGoCache(ctx, entry); resolved || err != nil {
+		return restored, err
+	}
+	if err := os.RemoveAll(entry.QuarantinePath); err != nil {
+		return storagepkg.QuarantineEntry{}, fmt.Errorf("delete quarantined Go cache: %w", err)
+	}
+	deleted, err := c.store.TransitionQuarantineEntry(
+		ctx, entry.ID, storagepkg.QuarantineStateDeleted, "",
+	)
+	if err != nil {
+		return storagepkg.QuarantineEntry{}, fmt.Errorf("persist Go-cache deletion: %w", err)
+	}
+	return deleted, nil
+}
+
+func (c *workspaceQuarantineController) validateGoCacheEntry(
+	ctx context.Context,
+	entry storagepkg.QuarantineEntry,
+) error {
+	if entry.State != storagepkg.QuarantineStateQuarantined &&
+		entry.State != storagepkg.QuarantineStateFailed {
+		return fmt.Errorf("%w: Go-cache quarantine entry is %q", storagepkg.ErrConflict, entry.State)
+	}
+	settings, err := c.settings.GetSettings(ctx)
+	if err != nil {
+		return err
+	}
+	expectedOriginal := settings.GoCache.AdoptedPath
+	if expectedOriginal == "" {
+		expectedOriginal = filepath.Join(c.homeDir, "cache", "go-build")
+	}
+	expectedQuarantine := filepath.Join(c.homeDir, "trash", "go-cache", entry.ID)
+	if filepath.Clean(entry.OriginalPath) != filepath.Clean(expectedOriginal) ||
+		filepath.Clean(entry.QuarantinePath) != filepath.Clean(expectedQuarantine) {
+		return fmt.Errorf("%w: Go-cache quarantine paths do not match managed storage", storagepkg.ErrValidation)
+	}
+	if err := storagepkg.ValidateNoSymlinkPath(c.homeDir, entry.QuarantinePath); err != nil {
+		return fmt.Errorf("%w: validate Go-cache quarantine path: %v", storagepkg.ErrValidation, err)
+	}
+	return nil
+}
+
+func (c *workspaceQuarantineController) resolveAlreadyRestoredGoCache(
+	ctx context.Context,
+	entry storagepkg.QuarantineEntry,
+) (storagepkg.QuarantineEntry, bool, error) {
+	if entry.State != storagepkg.QuarantineStateFailed {
+		return storagepkg.QuarantineEntry{}, false, nil
+	}
+	if _, err := os.Lstat(entry.OriginalPath); errors.Is(err, os.ErrNotExist) {
+		return storagepkg.QuarantineEntry{}, false, nil
+	} else if err != nil {
+		return storagepkg.QuarantineEntry{}, false, fmt.Errorf("inspect failed Go-cache original path: %w", err)
+	}
+	if _, err := os.Lstat(entry.QuarantinePath); err == nil {
+		return storagepkg.QuarantineEntry{}, false, nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return storagepkg.QuarantineEntry{}, false, fmt.Errorf("inspect failed Go-cache quarantine path: %w", err)
+	}
+	if err := c.validateGoCacheRestorePath(entry.OriginalPath); err != nil {
+		return storagepkg.QuarantineEntry{}, false, err
+	}
+	restored, err := c.store.TransitionQuarantineEntry(
+		ctx, entry.ID, storagepkg.QuarantineStateRestored, "",
+	)
+	if err != nil {
+		return storagepkg.QuarantineEntry{}, false, fmt.Errorf("persist already-restored Go cache: %w", err)
+	}
+	return restored, true, nil
+}
+
+func (c *workspaceQuarantineController) validateGoCacheRestorePath(path string) error {
+	anchor, err := storagepkg.CommonPath(c.homeDir, path)
+	if err != nil {
+		return fmt.Errorf("%w: resolve Go-cache restore safety anchor: %v", storagepkg.ErrValidation, err)
+	}
+	if err := storagepkg.ValidateNoSymlinkPath(anchor, path); err != nil {
+		return fmt.Errorf("%w: validate Go-cache restore path: %v", storagepkg.ErrValidation, err)
+	}
+	return nil
+}

--- a/apps/backend/internal/backendapp/storage_maintenance.go
+++ b/apps/backend/internal/backendapp/storage_maintenance.go
@@ -392,8 +392,8 @@ func (c *workspaceQuarantineController) restoreGoCache(
 	if lease != nil {
 		defer lease.Release()
 	}
-	if restored, resolved, err := c.resolveAlreadyRestoredGoCache(ctx, entry); resolved || err != nil {
-		return restored, err
+	if err := c.rejectAmbiguousMissingGoCachePayload(entry); err != nil {
+		return storagepkg.QuarantineEntry{}, err
 	}
 	if err := c.prepareGoCacheRestoreDestination(entry); err != nil {
 		return storagepkg.QuarantineEntry{}, err
@@ -486,8 +486,8 @@ func (c *workspaceQuarantineController) deleteGoCache(
 	if time.Now().UTC().Before(entry.DeleteAfter) {
 		return storagepkg.QuarantineEntry{}, fmt.Errorf("%w: quarantine retention deadline has not elapsed", storagepkg.ErrConflict)
 	}
-	if restored, resolved, err := c.resolveAlreadyRestoredGoCache(ctx, entry); resolved || err != nil {
-		return restored, err
+	if err := c.rejectAmbiguousMissingGoCachePayload(entry); err != nil {
+		return storagepkg.QuarantineEntry{}, err
 	}
 	if err := os.RemoveAll(entry.QuarantinePath); err != nil {
 		return storagepkg.QuarantineEntry{}, fmt.Errorf("delete quarantined Go cache: %w", err)
@@ -547,34 +547,46 @@ func goCacheEntryOwnership(entry storagepkg.QuarantineEntry) (string, error) {
 	return metadata.Ownership, nil
 }
 
-func (c *workspaceQuarantineController) resolveAlreadyRestoredGoCache(
-	ctx context.Context,
+func (c *workspaceQuarantineController) rejectAmbiguousMissingGoCachePayload(
 	entry storagepkg.QuarantineEntry,
-) (storagepkg.QuarantineEntry, bool, error) {
+) error {
 	if entry.State != storagepkg.QuarantineStateFailed &&
 		entry.State != storagepkg.QuarantineStateQuarantined {
-		return storagepkg.QuarantineEntry{}, false, nil
+		return nil
 	}
 	if _, err := os.Lstat(entry.OriginalPath); errors.Is(err, os.ErrNotExist) {
-		return storagepkg.QuarantineEntry{}, false, nil
+		return nil
 	} else if err != nil {
-		return storagepkg.QuarantineEntry{}, false, fmt.Errorf("inspect failed Go-cache original path: %w", err)
+		return fmt.Errorf("inspect failed Go-cache original path: %w", err)
 	}
 	if _, err := os.Lstat(entry.QuarantinePath); err == nil {
-		return storagepkg.QuarantineEntry{}, false, nil
+		return nil
 	} else if !errors.Is(err, os.ErrNotExist) {
-		return storagepkg.QuarantineEntry{}, false, fmt.Errorf("inspect failed Go-cache quarantine path: %w", err)
+		return fmt.Errorf("inspect failed Go-cache quarantine path: %w", err)
 	}
 	if err := c.validateGoCacheRestorePath(entry.OriginalPath); err != nil {
-		return storagepkg.QuarantineEntry{}, false, err
+		return err
 	}
-	restored, err := c.store.TransitionQuarantineEntry(
-		ctx, entry.ID, storagepkg.QuarantineStateRestored, "",
+	ownership, err := goCacheEntryOwnership(entry)
+	if err != nil {
+		return err
+	}
+	placeholder, err := gocache.IsRestorePlaceholder(
+		entry.OriginalPath, ownership == goCacheOwnershipAdopted,
 	)
 	if err != nil {
-		return storagepkg.QuarantineEntry{}, false, fmt.Errorf("persist already-restored Go cache: %w", err)
+		return fmt.Errorf("inspect Go-cache restore placeholder: %w", err)
 	}
-	return restored, true, nil
+	if placeholder {
+		return fmt.Errorf(
+			"%w: quarantined Go-cache payload is missing and the original path is only a rotation placeholder",
+			storagepkg.ErrConflict,
+		)
+	}
+	return fmt.Errorf(
+		"%w: quarantined Go-cache payload is missing and the populated original cannot be proven restored",
+		storagepkg.ErrConflict,
+	)
 }
 
 func (c *workspaceQuarantineController) validateGoCacheRestorePath(path string) error {

--- a/apps/backend/internal/backendapp/storage_maintenance_test.go
+++ b/apps/backend/internal/backendapp/storage_maintenance_test.go
@@ -1,0 +1,479 @@
+package backendapp
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+	_ "github.com/mattn/go-sqlite3"
+
+	agentdocker "github.com/kandev/kandev/internal/agent/docker"
+	"github.com/kandev/kandev/internal/db"
+	systemsettings "github.com/kandev/kandev/internal/system/settings"
+	storagepkg "github.com/kandev/kandev/internal/system/storage"
+	"github.com/kandev/kandev/internal/system/storage/dockerstore"
+	"github.com/kandev/kandev/internal/system/storage/gocache"
+	"github.com/kandev/kandev/internal/system/storage/workspaces"
+)
+
+func TestStorageOverviewIncludesQuarantineAndManagedContainers(t *testing.T) {
+	home := t.TempDir()
+	for _, dir := range []string{filepath.Join(home, "tasks"), filepath.Join(home, "trash")} {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	settings, store := newStorageMaintenanceStores(t)
+	entry := storagepkg.QuarantineEntry{
+		ID: "overview-entry", ResourceType: storagepkg.ResourceTypeGoCache,
+		OriginalPath:   filepath.Join(home, "cache", "go-build"),
+		QuarantinePath: filepath.Join(home, "trash", "go-cache", "overview-entry"),
+		SizeBytes:      42, State: storagepkg.QuarantineStateQuarantined,
+		QuarantinedAt: time.Now().UTC(), DeleteAfter: time.Now().UTC().Add(time.Hour),
+	}
+	if err := store.CreateQuarantineEntry(context.Background(), &entry); err != nil {
+		t.Fatalf("CreateQuarantineEntry: %v", err)
+	}
+	docker := dockerstore.NewProvider(
+		&overviewDockerClient{usage: agentdocker.DiskUsage{Containers: []agentdocker.ContainerUsage{
+			{ID: "managed", WritableBytes: 64, Labels: map[string]string{"kandev.managed": "true"}},
+		}}},
+		overviewContainerInventory{}, settings,
+	)
+	workspaceFactory := func(current storagepkg.StorageMaintenanceSettings) *workspaces.Provider {
+		return workspaces.New(workspaces.Config{
+			TasksRoot: filepath.Join(home, "tasks"), TrashRoot: filepath.Join(home, "trash"),
+			Inventory: overviewWorkspaceInventory{}, Store: store,
+			GracePeriod: time.Duration(current.OrphanGraceHours) * time.Hour,
+			Retention:   time.Duration(current.QuarantineRetentionHours) * time.Hour,
+		})
+	}
+	overview := &storageOverview{
+		settings: settings, quarantine: store, workspaceFactory: workspaceFactory,
+		goCache: gocache.New(gocache.Config{
+			HomeDir: home, TrashDir: filepath.Join(home, "trash"), Settings: settings, Store: store,
+		}),
+		docker: docker, homeDir: home,
+	}
+
+	summary, err := overview.Summary(context.Background())
+	if err != nil {
+		t.Fatalf("Summary: %v", err)
+	}
+	quarantine, ok := summary.Quarantine.(storagepkg.QuarantineSummary)
+	if !ok || quarantine.Count != 1 || quarantine.SizeBytes != 42 {
+		t.Fatalf("quarantine summary = %#v", summary.Quarantine)
+	}
+	dockerSummary, ok := summary.Docker.(map[string]any)
+	if !ok || dockerSummary["managed_container_count"] != 1 || dockerSummary["managed_container_bytes"] != int64(64) {
+		t.Fatalf("docker summary = %#v", summary.Docker)
+	}
+
+	overview.quarantine = failingQuarantineSummarizer{err: errors.New("quarantine unavailable")}
+	degraded, err := overview.Summary(context.Background())
+	if err != nil {
+		t.Fatalf("degraded Summary: %v", err)
+	}
+	quarantineWarning, ok := degraded.Quarantine.(map[string]any)
+	if !ok || quarantineWarning["available"] != false || quarantineWarning["warning"] != "quarantine unavailable" {
+		t.Fatalf("degraded quarantine = %#v", degraded.Quarantine)
+	}
+	if _, ok := degraded.Workspaces.(workspaces.Analysis); !ok {
+		t.Fatalf("workspace summary should remain available, got %#v", degraded.Workspaces)
+	}
+}
+
+type failingQuarantineSummarizer struct{ err error }
+
+func (s failingQuarantineSummarizer) SummarizeQuarantine(context.Context) (storagepkg.QuarantineSummary, error) {
+	return storagepkg.QuarantineSummary{}, s.err
+}
+
+type overviewWorkspaceInventory struct{}
+
+func (overviewWorkspaceInventory) LoadWorkspaceInventory(context.Context) (workspaces.Inventory, error) {
+	return workspaces.Inventory{Complete: true}, nil
+}
+
+type overviewContainerInventory struct{}
+
+func (overviewContainerInventory) ContainerTaskRemovable(context.Context, string) (bool, error) {
+	return false, nil
+}
+
+type overviewDockerClient struct{ usage agentdocker.DiskUsage }
+
+func (c *overviewDockerClient) Ping(context.Context) error { return nil }
+func (c *overviewDockerClient) ListContainers(context.Context, map[string]string) ([]agentdocker.ContainerInfo, error) {
+	return nil, nil
+}
+func (c *overviewDockerClient) RemoveContainer(context.Context, string, bool) error { return nil }
+func (c *overviewDockerClient) DiskUsage(context.Context) (agentdocker.DiskUsage, error) {
+	return c.usage, nil
+}
+func (c *overviewDockerClient) PruneBuildCache(context.Context, agentdocker.BuildCachePruneOptions) (agentdocker.PruneResult, error) {
+	return agentdocker.PruneResult{}, nil
+}
+func (c *overviewDockerClient) PruneUnusedImages(context.Context, time.Time) (agentdocker.PruneResult, error) {
+	return agentdocker.PruneResult{}, nil
+}
+
+func TestWorkspaceQuarantineControllerRestoresTaskUsingCurrentSettings(t *testing.T) {
+	settings, store := newStorageMaintenanceStores(t)
+	want := storagepkg.DefaultSettings()
+	want.OrphanGraceHours = 48
+	if _, err := settings.SaveSettings(context.Background(), want); err != nil {
+		t.Fatalf("SaveSettings: %v", err)
+	}
+	var captured storagepkg.StorageMaintenanceSettings
+	controller := &workspaceQuarantineController{
+		settings: settings,
+		factory: func(current storagepkg.StorageMaintenanceSettings) *workspaces.Provider {
+			captured = current
+			return workspaces.New(workspaces.Config{Store: store})
+		},
+	}
+
+	recovery := controller.RestoreTask(context.Background(), "task-1")
+	if captured.OrphanGraceHours != want.OrphanGraceHours {
+		t.Fatalf("factory settings orphan_grace_hours = %d, want %d", captured.OrphanGraceHours, want.OrphanGraceHours)
+	}
+	if recovery.TaskID != "task-1" || recovery.Status != "not_found" {
+		t.Fatalf("recovery = %#v, want task-1 not_found", recovery)
+	}
+}
+
+func TestWorkspaceQuarantineControllerMapsRestoreConflict(t *testing.T) {
+	home := t.TempDir()
+	tasksRoot := filepath.Join(home, "tasks")
+	original := filepath.Join(tasksRoot, "task-1")
+	quarantined := filepath.Join(home, "trash", "tasks", "entry-1")
+	for _, path := range []string{original, quarantined} {
+		if err := os.MkdirAll(path, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	settings, store := newStorageMaintenanceStores(t)
+	entry := storagepkg.QuarantineEntry{
+		ID: "entry-1", ResourceType: storagepkg.ResourceTypeTaskWorkspace,
+		OriginalPath: original, QuarantinePath: quarantined,
+		State:         storagepkg.QuarantineStateQuarantined,
+		QuarantinedAt: time.Now().UTC(), DeleteAfter: time.Now().UTC().Add(time.Hour),
+	}
+	if err := store.CreateQuarantineEntry(context.Background(), &entry); err != nil {
+		t.Fatal(err)
+	}
+	controller := &workspaceQuarantineController{
+		settings: settings, store: store,
+		factory: func(current storagepkg.StorageMaintenanceSettings) *workspaces.Provider {
+			return workspaces.New(workspaces.Config{
+				TasksRoot: tasksRoot, TrashRoot: filepath.Join(home, "trash"), Store: store,
+				GracePeriod: time.Duration(current.OrphanGraceHours) * time.Hour,
+				Retention:   time.Duration(current.QuarantineRetentionHours) * time.Hour,
+			})
+		},
+	}
+
+	_, err := controller.Restore(context.Background(), entry.ID)
+	if !errors.Is(err, storagepkg.ErrConflict) {
+		t.Fatalf("Restore error = %v, want storage ErrConflict", err)
+	}
+}
+
+func TestQuarantineControllerRestoresGoCache(t *testing.T) {
+	home := t.TempDir()
+	original := filepath.Join(home, "cache", "go-build")
+	quarantined := filepath.Join(home, "trash", "go-cache", "entry-cache")
+	if err := os.MkdirAll(quarantined, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(quarantined, "artifact"), []byte("cache"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	settings, store := newStorageMaintenanceStores(t)
+	entry := createGoCacheQuarantineEntry(t, store, original, quarantined, time.Now().UTC().Add(time.Hour))
+	controller := &workspaceQuarantineController{settings: settings, store: store, homeDir: home}
+
+	restored, err := controller.Restore(context.Background(), entry.ID)
+	if err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+	if restored.State != storagepkg.QuarantineStateRestored {
+		t.Fatalf("state = %q, want restored", restored.State)
+	}
+	if _, err := os.Stat(filepath.Join(original, "artifact")); err != nil {
+		t.Fatalf("restored cache artifact: %v", err)
+	}
+}
+
+func TestQuarantineControllerRestoresAdoptedExternalGoCache(t *testing.T) {
+	root := t.TempDir()
+	home := filepath.Join(root, "home")
+	original := filepath.Join(root, "external", "go-build")
+	quarantined := filepath.Join(home, "trash", "go-cache", "entry-cache")
+	for _, path := range []string{home, original, quarantined} {
+		if err := os.MkdirAll(path, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(quarantined, "artifact"), []byte("cache"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(original); err != nil {
+		t.Fatalf("remove recreated cache destination: %v", err)
+	}
+	settings, store := newStorageMaintenanceStores(t)
+	if _, err := settings.AdoptGoCachePath(context.Background(), original); err != nil {
+		t.Fatalf("AdoptGoCachePath: %v", err)
+	}
+	entry := createGoCacheQuarantineEntry(
+		t, store, original, quarantined, time.Now().UTC().Add(time.Hour),
+	)
+	controller := &workspaceQuarantineController{settings: settings, store: store, homeDir: home}
+
+	restored, err := controller.Restore(context.Background(), entry.ID)
+	if err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+	if restored.State != storagepkg.QuarantineStateRestored {
+		t.Fatalf("state = %q, want restored", restored.State)
+	}
+	if _, err := os.Stat(filepath.Join(original, "artifact")); err != nil {
+		t.Fatalf("restored external cache artifact: %v", err)
+	}
+}
+
+func TestQuarantineControllerRetriesFailedGoCacheRestore(t *testing.T) {
+	home := t.TempDir()
+	original := filepath.Join(home, "cache", "go-build")
+	quarantined := filepath.Join(home, "trash", "go-cache", "entry-cache")
+	if err := os.MkdirAll(quarantined, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(quarantined, "artifact"), []byte("cache"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	settings, store := newStorageMaintenanceStores(t)
+	entry := createGoCacheQuarantineEntry(t, store, original, quarantined, time.Now().UTC().Add(time.Hour))
+	markGoCacheQuarantineFailed(t, store, entry.ID)
+	controller := &workspaceQuarantineController{settings: settings, store: store, homeDir: home}
+
+	restored, err := controller.Restore(context.Background(), entry.ID)
+	if err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+	if restored.State != storagepkg.QuarantineStateRestored {
+		t.Fatalf("state = %q, want restored", restored.State)
+	}
+	if _, err := os.Stat(filepath.Join(original, "artifact")); err != nil {
+		t.Fatalf("restored cache artifact: %v", err)
+	}
+}
+
+func TestQuarantineControllerRetriesFailedGoCacheDelete(t *testing.T) {
+	home := t.TempDir()
+	original := filepath.Join(home, "cache", "go-build")
+	quarantined := filepath.Join(home, "trash", "go-cache", "entry-cache")
+	if err := os.MkdirAll(quarantined, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	settings, store := newStorageMaintenanceStores(t)
+	entry := createGoCacheQuarantineEntry(t, store, original, quarantined, time.Now().UTC().Add(-time.Hour))
+	markGoCacheQuarantineFailed(t, store, entry.ID)
+	controller := &workspaceQuarantineController{settings: settings, store: store, homeDir: home}
+
+	deleted, err := controller.PermanentDelete(context.Background(), entry.ID, "DELETE")
+	if err != nil {
+		t.Fatalf("PermanentDelete: %v", err)
+	}
+	if deleted.State != storagepkg.QuarantineStateDeleted {
+		t.Fatalf("state = %q, want deleted", deleted.State)
+	}
+	if _, err := os.Stat(quarantined); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("quarantine path still exists: %v", err)
+	}
+}
+
+func TestQuarantineControllerFailedGoCacheRetryRecognizesAlreadyRestoredData(t *testing.T) {
+	for _, operation := range []string{"restore", "delete"} {
+		t.Run(operation, func(t *testing.T) {
+			home := t.TempDir()
+			original := filepath.Join(home, "cache", "go-build")
+			quarantined := filepath.Join(home, "trash", "go-cache", "entry-cache")
+			if err := os.MkdirAll(original, 0o700); err != nil {
+				t.Fatal(err)
+			}
+			artifact := filepath.Join(original, "artifact")
+			if err := os.WriteFile(artifact, []byte("keep"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			settings, store := newStorageMaintenanceStores(t)
+			entry := createGoCacheQuarantineEntry(
+				t, store, original, quarantined, time.Now().UTC().Add(-time.Hour),
+			)
+			markGoCacheQuarantineFailed(t, store, entry.ID)
+			controller := &workspaceQuarantineController{settings: settings, store: store, homeDir: home}
+
+			var resolved storagepkg.QuarantineEntry
+			var err error
+			if operation == "delete" {
+				resolved, err = controller.PermanentDelete(context.Background(), entry.ID, "DELETE")
+			} else {
+				resolved, err = controller.Restore(context.Background(), entry.ID)
+			}
+			if err != nil {
+				t.Fatalf("%s failed: %v", operation, err)
+			}
+			if resolved.State != storagepkg.QuarantineStateRestored {
+				t.Fatalf("state = %q, want restored", resolved.State)
+			}
+			if data, err := os.ReadFile(artifact); err != nil || string(data) != "keep" {
+				t.Fatalf("original cache changed: data=%q err=%v", data, err)
+			}
+		})
+	}
+}
+
+func TestQuarantineControllerFailedGoCacheRetryRejectsSymlinkedRestorePath(t *testing.T) {
+	root := t.TempDir()
+	home := filepath.Join(root, "home")
+	external := filepath.Join(root, "external")
+	if err := os.MkdirAll(filepath.Join(external, "go-build"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(home, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	linkedParent := filepath.Join(root, "linked-external")
+	if err := os.Symlink(external, linkedParent); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	original := filepath.Join(linkedParent, "go-build")
+	quarantined := filepath.Join(home, "trash", "go-cache", "entry-cache")
+	settings, store := newStorageMaintenanceStores(t)
+	if _, err := settings.AdoptGoCachePath(context.Background(), original); err != nil {
+		t.Fatalf("AdoptGoCachePath: %v", err)
+	}
+	entry := createGoCacheQuarantineEntry(
+		t, store, original, quarantined, time.Now().UTC().Add(time.Hour),
+	)
+	markGoCacheQuarantineFailed(t, store, entry.ID)
+	controller := &workspaceQuarantineController{settings: settings, store: store, homeDir: home}
+
+	_, err := controller.Restore(context.Background(), entry.ID)
+	if !errors.Is(err, storagepkg.ErrValidation) {
+		t.Fatalf("Restore error = %v, want storage ErrValidation", err)
+	}
+	stored, err := store.GetQuarantineEntry(context.Background(), entry.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.State != storagepkg.QuarantineStateFailed {
+		t.Fatalf("state = %q, want failed", stored.State)
+	}
+}
+
+func TestQuarantineControllerPermanentlyDeletesGoCache(t *testing.T) {
+	home := t.TempDir()
+	original := filepath.Join(home, "cache", "go-build")
+	quarantined := filepath.Join(home, "trash", "go-cache", "entry-cache")
+	if err := os.MkdirAll(quarantined, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	settings, store := newStorageMaintenanceStores(t)
+	entry := createGoCacheQuarantineEntry(t, store, original, quarantined, time.Now().UTC().Add(-time.Hour))
+	controller := &workspaceQuarantineController{settings: settings, store: store, homeDir: home}
+
+	deleted, err := controller.PermanentDelete(context.Background(), entry.ID, "DELETE")
+	if err != nil {
+		t.Fatalf("PermanentDelete: %v", err)
+	}
+	if deleted.State != storagepkg.QuarantineStateDeleted {
+		t.Fatalf("state = %q, want deleted", deleted.State)
+	}
+	if _, err := os.Stat(quarantined); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("quarantine path still exists: %v", err)
+	}
+}
+
+func TestQuarantineControllerRejectsEarlyGoCacheDeleteAndKeepsQuarantine(t *testing.T) {
+	home := t.TempDir()
+	original := filepath.Join(home, "cache", "go-build")
+	quarantined := filepath.Join(home, "trash", "go-cache", "entry-cache")
+	if err := os.MkdirAll(quarantined, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	settings, store := newStorageMaintenanceStores(t)
+	entry := createGoCacheQuarantineEntry(
+		t, store, original, quarantined, time.Now().UTC().Add(time.Hour),
+	)
+	controller := &workspaceQuarantineController{settings: settings, store: store, homeDir: home}
+
+	_, err := controller.PermanentDelete(context.Background(), entry.ID, "DELETE")
+	if !errors.Is(err, storagepkg.ErrConflict) {
+		t.Fatalf("PermanentDelete error = %v, want storage ErrConflict", err)
+	}
+	if _, err := os.Stat(quarantined); err != nil {
+		t.Fatalf("quarantine path changed before deadline: %v", err)
+	}
+	got, err := store.GetQuarantineEntry(context.Background(), entry.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.State != storagepkg.QuarantineStateQuarantined {
+		t.Fatalf("quarantine state = %q, want quarantined", got.State)
+	}
+}
+
+func createGoCacheQuarantineEntry(
+	t *testing.T,
+	store *storagepkg.Store,
+	original string,
+	quarantined string,
+	deleteAfter time.Time,
+) storagepkg.QuarantineEntry {
+	t.Helper()
+	entry := storagepkg.QuarantineEntry{
+		ID: "entry-cache", ResourceType: storagepkg.ResourceTypeGoCache,
+		OriginalPath: original, QuarantinePath: quarantined,
+		State:         storagepkg.QuarantineStateQuarantined,
+		QuarantinedAt: time.Now().UTC().Add(-2 * time.Hour), DeleteAfter: deleteAfter,
+	}
+	if err := store.CreateQuarantineEntry(context.Background(), &entry); err != nil {
+		t.Fatal(err)
+	}
+	return entry
+}
+
+func markGoCacheQuarantineFailed(t *testing.T, store *storagepkg.Store, id string) {
+	t.Helper()
+	if _, err := store.TransitionQuarantineEntry(
+		context.Background(), id, storagepkg.QuarantineStateFailed, "retryable failure",
+	); err != nil {
+		t.Fatalf("mark quarantine failed: %v", err)
+	}
+}
+
+func newStorageMaintenanceStores(t *testing.T) (*storagepkg.SettingsStore, *storagepkg.Store) {
+	t.Helper()
+	connection, err := sqlx.Open("sqlite3", filepath.Join(t.TempDir(), "storage.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	connection.SetMaxOpenConns(1)
+	pool := db.NewPool(connection, connection)
+	t.Cleanup(func() { _ = pool.Close() })
+	rawSettings, err := systemsettings.NewStore(pool)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := storagepkg.NewStore(pool)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return storagepkg.NewSettingsStore(rawSettings), store
+}

--- a/apps/backend/internal/backendapp/storage_maintenance_test.go
+++ b/apps/backend/internal/backendapp/storage_maintenance_test.go
@@ -2,9 +2,11 @@ package backendapp
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -12,6 +14,7 @@ import (
 	_ "github.com/mattn/go-sqlite3"
 
 	agentdocker "github.com/kandev/kandev/internal/agent/docker"
+	"github.com/kandev/kandev/internal/agent/runtime/activity"
 	"github.com/kandev/kandev/internal/db"
 	systemsettings "github.com/kandev/kandev/internal/system/settings"
 	storagepkg "github.com/kandev/kandev/internal/system/storage"
@@ -210,6 +213,93 @@ func TestQuarantineControllerRestoresGoCache(t *testing.T) {
 	}
 }
 
+func TestQuarantineControllerRestoresGoCacheOverEmptyReplacement(t *testing.T) {
+	home := t.TempDir()
+	original := filepath.Join(home, "cache", "go-build")
+	quarantined := filepath.Join(home, "trash", "go-cache", "entry-cache")
+	if err := os.MkdirAll(quarantined, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(quarantined, "artifact"), []byte("cache"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	settings, store := newStorageMaintenanceStores(t)
+	current, err := settings.GetSettings(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	current.GoCache.Enabled = true
+	if _, err := settings.SaveSettings(context.Background(), current); err != nil {
+		t.Fatal(err)
+	}
+	provider := gocache.New(gocache.Config{
+		HomeDir: home, TrashDir: filepath.Join(home, "trash"), Settings: settings,
+	})
+	if _, err := provider.ExecutionEnvironment(context.Background()); err != nil {
+		t.Fatalf("create managed replacement: %v", err)
+	}
+	entry := createGoCacheQuarantineEntry(t, store, original, quarantined, time.Now().UTC().Add(time.Hour))
+	controller := &workspaceQuarantineController{settings: settings, store: store, homeDir: home}
+
+	restored, err := controller.Restore(context.Background(), entry.ID)
+	if err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+	if restored.State != storagepkg.QuarantineStateRestored {
+		t.Fatalf("state = %q, want restored", restored.State)
+	}
+	if data, err := os.ReadFile(filepath.Join(original, "artifact")); err != nil || string(data) != "cache" {
+		t.Fatalf("restored cache artifact: data=%q err=%v", data, err)
+	}
+}
+
+func TestQuarantineControllerRetainsGoCacheWhileTaskActivityIsRunning(t *testing.T) {
+	home := t.TempDir()
+	original := filepath.Join(home, "cache", "go-build")
+	quarantined := filepath.Join(home, "trash", "go-cache", "entry-cache")
+	if err := os.MkdirAll(quarantined, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	artifact := filepath.Join(quarantined, "artifact")
+	if err := os.WriteFile(artifact, []byte("cache"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	settings, store := newStorageMaintenanceStores(t)
+	current, err := settings.GetSettings(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	current.GoCache.Enabled = true
+	if _, err := settings.SaveSettings(context.Background(), current); err != nil {
+		t.Fatal(err)
+	}
+	provider := gocache.New(gocache.Config{
+		HomeDir: home, TrashDir: filepath.Join(home, "trash"), Settings: settings,
+	})
+	if _, err := provider.ExecutionEnvironment(context.Background()); err != nil {
+		t.Fatalf("create managed replacement: %v", err)
+	}
+	entry := createGoCacheQuarantineEntry(t, store, original, quarantined, time.Now().UTC().Add(time.Hour))
+	coordinator := activity.NewCoordinator(activity.Options{})
+	taskLease, err := coordinator.AcquireTask(context.Background(), activity.KindExecutionRunning)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer taskLease.Release()
+	controller := &workspaceQuarantineController{
+		settings: settings, store: store, homeDir: home, activity: coordinator,
+	}
+
+	_, err = controller.Restore(context.Background(), entry.ID)
+	var busy *storagepkg.BusyError
+	if !errors.As(err, &busy) {
+		t.Fatalf("Restore error = %v, want BusyError", err)
+	}
+	if _, err := os.Stat(artifact); err != nil {
+		t.Fatalf("quarantined cache changed while task active: %v", err)
+	}
+}
+
 func TestQuarantineControllerRestoresAdoptedExternalGoCache(t *testing.T) {
 	root := t.TempDir()
 	home := filepath.Join(root, "home")
@@ -338,6 +428,107 @@ func TestQuarantineControllerFailedGoCacheRetryRecognizesAlreadyRestoredData(t *
 	}
 }
 
+func TestQuarantineControllerQuarantinedGoCacheRetryRecognizesAlreadyRestoredData(t *testing.T) {
+	home := t.TempDir()
+	original := filepath.Join(home, "cache", "go-build")
+	quarantined := filepath.Join(home, "trash", "go-cache", "entry-cache")
+	if err := os.MkdirAll(original, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	artifact := filepath.Join(original, "artifact")
+	if err := os.WriteFile(artifact, []byte("keep"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	settings, store := newStorageMaintenanceStores(t)
+	entry := createGoCacheQuarantineEntry(
+		t, store, original, quarantined, time.Now().UTC().Add(time.Hour),
+	)
+	controller := &workspaceQuarantineController{settings: settings, store: store, homeDir: home}
+
+	restored, err := controller.Restore(context.Background(), entry.ID)
+	if err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+	if restored.State != storagepkg.QuarantineStateRestored {
+		t.Fatalf("state = %q, want restored", restored.State)
+	}
+	if data, err := os.ReadFile(artifact); err != nil || string(data) != "keep" {
+		t.Fatalf("original cache changed: data=%q err=%v", data, err)
+	}
+}
+
+func TestQuarantineControllerReportsPersistenceAndRollbackFailures(t *testing.T) {
+	home := t.TempDir()
+	original := filepath.Join(home, "cache", "go-build")
+	quarantined := filepath.Join(home, "trash", "go-cache", "entry-cache")
+	if err := os.MkdirAll(quarantined, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	entry := storagepkg.QuarantineEntry{
+		ID: "entry-cache", ResourceType: storagepkg.ResourceTypeGoCache,
+		OriginalPath: original, QuarantinePath: quarantined,
+		State: storagepkg.QuarantineStateQuarantined, Metadata: []byte(`{"ownership":"managed"}`),
+	}
+	store := &failingTransitionQuarantineStore{entry: entry, err: errors.New("database unavailable")}
+	renameCalls := 0
+	controller := &workspaceQuarantineController{
+		store: store, homeDir: home,
+		rename: func(oldPath, newPath string) error {
+			renameCalls++
+			if renameCalls == 2 {
+				return errors.New("rollback blocked")
+			}
+			return os.Rename(oldPath, newPath)
+		},
+	}
+
+	_, err := controller.Restore(context.Background(), entry.ID)
+	if err == nil || !strings.Contains(err.Error(), "database unavailable") ||
+		!strings.Contains(err.Error(), "rollback blocked") {
+		t.Fatalf("Restore error = %v, want persistence and rollback failures", err)
+	}
+	if _, err := os.Stat(original); err != nil {
+		t.Fatalf("restored data missing after failed rollback: %v", err)
+	}
+	if _, err := os.Stat(quarantined); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("quarantine path exists after failed rollback: %v", err)
+	}
+
+	store.err = nil
+	restored, err := controller.Restore(context.Background(), entry.ID)
+	if err != nil {
+		t.Fatalf("reconcile retry: %v", err)
+	}
+	if restored.State != storagepkg.QuarantineStateRestored {
+		t.Fatalf("retry state = %q, want restored", restored.State)
+	}
+}
+
+type failingTransitionQuarantineStore struct {
+	entry storagepkg.QuarantineEntry
+	err   error
+}
+
+func (s *failingTransitionQuarantineStore) GetQuarantineEntry(
+	context.Context, string,
+) (storagepkg.QuarantineEntry, error) {
+	return s.entry, nil
+}
+
+func (s *failingTransitionQuarantineStore) TransitionQuarantineEntry(
+	_ context.Context,
+	_ string,
+	next storagepkg.QuarantineState,
+	lastError string,
+) (storagepkg.QuarantineEntry, error) {
+	if s.err != nil {
+		return storagepkg.QuarantineEntry{}, s.err
+	}
+	s.entry.State = next
+	s.entry.LastError = lastError
+	return s.entry, nil
+}
+
 func TestQuarantineControllerFailedGoCacheRetryRejectsSymlinkedRestorePath(t *testing.T) {
 	root := t.TempDir()
 	home := filepath.Join(root, "home")
@@ -400,6 +591,44 @@ func TestQuarantineControllerPermanentlyDeletesGoCache(t *testing.T) {
 	}
 }
 
+func TestQuarantineControllerDeletesHistoricalAdoptedGoCacheAfterReadoption(t *testing.T) {
+	root := t.TempDir()
+	home := filepath.Join(root, "home")
+	original := filepath.Join(root, "first-cache")
+	current := filepath.Join(root, "second-cache")
+	quarantined := filepath.Join(home, "trash", "go-cache", "entry-cache")
+	if err := os.MkdirAll(quarantined, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	settings, store := newStorageMaintenanceStores(t)
+	if _, err := settings.AdoptGoCachePath(context.Background(), current); err != nil {
+		t.Fatalf("AdoptGoCachePath: %v", err)
+	}
+	entry := storagepkg.QuarantineEntry{
+		ID: "entry-cache", ResourceType: storagepkg.ResourceTypeGoCache,
+		OriginalPath: original, QuarantinePath: quarantined,
+		State:         storagepkg.QuarantineStateQuarantined,
+		QuarantinedAt: time.Now().UTC().Add(-2 * time.Hour),
+		DeleteAfter:   time.Now().UTC().Add(-time.Hour),
+		Metadata:      json.RawMessage(`{"ownership":"adopted"}`),
+	}
+	if err := store.CreateQuarantineEntry(context.Background(), &entry); err != nil {
+		t.Fatal(err)
+	}
+	controller := &workspaceQuarantineController{settings: settings, store: store, homeDir: home}
+
+	deleted, err := controller.PermanentDelete(context.Background(), entry.ID, "DELETE")
+	if err != nil {
+		t.Fatalf("PermanentDelete: %v", err)
+	}
+	if deleted.State != storagepkg.QuarantineStateDeleted {
+		t.Fatalf("state = %q, want deleted", deleted.State)
+	}
+	if _, err := os.Stat(quarantined); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("historical quarantine path still exists: %v", err)
+	}
+}
+
 func TestQuarantineControllerRejectsEarlyGoCacheDeleteAndKeepsQuarantine(t *testing.T) {
 	home := t.TempDir()
 	original := filepath.Join(home, "cache", "go-build")
@@ -437,11 +666,21 @@ func createGoCacheQuarantineEntry(
 	deleteAfter time.Time,
 ) storagepkg.QuarantineEntry {
 	t.Helper()
+	homeDir := filepath.Dir(filepath.Dir(filepath.Dir(quarantined)))
+	ownership := "adopted"
+	if filepath.Clean(original) == filepath.Join(homeDir, "cache", "go-build") {
+		ownership = "managed"
+	}
+	metadata, err := json.Marshal(map[string]string{"ownership": ownership})
+	if err != nil {
+		t.Fatal(err)
+	}
 	entry := storagepkg.QuarantineEntry{
 		ID: "entry-cache", ResourceType: storagepkg.ResourceTypeGoCache,
 		OriginalPath: original, QuarantinePath: quarantined,
 		State:         storagepkg.QuarantineStateQuarantined,
 		QuarantinedAt: time.Now().UTC().Add(-2 * time.Hour), DeleteAfter: deleteAfter,
+		Metadata: metadata,
 	}
 	if err := store.CreateQuarantineEntry(context.Background(), &entry); err != nil {
 		t.Fatal(err)

--- a/apps/backend/internal/backendapp/storage_maintenance_test.go
+++ b/apps/backend/internal/backendapp/storage_maintenance_test.go
@@ -388,76 +388,95 @@ func TestQuarantineControllerRetriesFailedGoCacheDelete(t *testing.T) {
 	}
 }
 
-func TestQuarantineControllerFailedGoCacheRetryRecognizesAlreadyRestoredData(t *testing.T) {
-	for _, operation := range []string{"restore", "delete"} {
-		t.Run(operation, func(t *testing.T) {
-			home := t.TempDir()
-			original := filepath.Join(home, "cache", "go-build")
-			quarantined := filepath.Join(home, "trash", "go-cache", "entry-cache")
-			if err := os.MkdirAll(original, 0o700); err != nil {
-				t.Fatal(err)
-			}
-			artifact := filepath.Join(original, "artifact")
-			if err := os.WriteFile(artifact, []byte("keep"), 0o600); err != nil {
-				t.Fatal(err)
-			}
-			settings, store := newStorageMaintenanceStores(t)
-			entry := createGoCacheQuarantineEntry(
-				t, store, original, quarantined, time.Now().UTC().Add(-time.Hour),
-			)
-			markGoCacheQuarantineFailed(t, store, entry.ID)
-			controller := &workspaceQuarantineController{settings: settings, store: store, homeDir: home}
+func TestQuarantineControllerDoesNotTreatPopulatedReplacementAsRestoredPayload(t *testing.T) {
+	states := []storagepkg.QuarantineState{
+		storagepkg.QuarantineStateQuarantined,
+		storagepkg.QuarantineStateFailed,
+	}
+	for _, state := range states {
+		for _, operation := range []string{"restore", "delete"} {
+			t.Run(string(state)+"_"+operation, func(t *testing.T) {
+				home := t.TempDir()
+				original := filepath.Join(home, "cache", "go-build")
+				quarantined := filepath.Join(home, "trash", "go-cache", "entry-cache")
+				if err := os.MkdirAll(original, 0o700); err != nil {
+					t.Fatal(err)
+				}
+				artifact := filepath.Join(original, "replacement-artifact")
+				if err := os.WriteFile(artifact, []byte("active cache"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+				settings, store := newStorageMaintenanceStores(t)
+				entry := createGoCacheQuarantineEntry(
+					t, store, original, quarantined, time.Now().UTC().Add(-time.Hour),
+				)
+				if state == storagepkg.QuarantineStateFailed {
+					markGoCacheQuarantineFailed(t, store, entry.ID)
+				}
+				controller := &workspaceQuarantineController{settings: settings, store: store, homeDir: home}
 
-			var resolved storagepkg.QuarantineEntry
-			var err error
-			if operation == "delete" {
-				resolved, err = controller.PermanentDelete(context.Background(), entry.ID, "DELETE")
-			} else {
-				resolved, err = controller.Restore(context.Background(), entry.ID)
-			}
-			if err != nil {
-				t.Fatalf("%s failed: %v", operation, err)
-			}
-			if resolved.State != storagepkg.QuarantineStateRestored {
-				t.Fatalf("state = %q, want restored", resolved.State)
-			}
-			if data, err := os.ReadFile(artifact); err != nil || string(data) != "keep" {
-				t.Fatalf("original cache changed: data=%q err=%v", data, err)
-			}
-		})
+				var err error
+				if operation == "delete" {
+					_, err = controller.PermanentDelete(context.Background(), entry.ID, "DELETE")
+				} else {
+					_, err = controller.Restore(context.Background(), entry.ID)
+				}
+				if !errors.Is(err, storagepkg.ErrConflict) {
+					t.Fatalf("%s error = %v, want storage ErrConflict", operation, err)
+				}
+				stored, err := store.GetQuarantineEntry(context.Background(), entry.ID)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if stored.State != state {
+					t.Fatalf("state = %q, want unchanged %q", stored.State, state)
+				}
+				if data, err := os.ReadFile(artifact); err != nil || string(data) != "active cache" {
+					t.Fatalf("replacement cache changed: data=%q err=%v", data, err)
+				}
+			})
+		}
 	}
 }
 
-func TestQuarantineControllerQuarantinedGoCacheRetryRecognizesAlreadyRestoredData(t *testing.T) {
+func TestQuarantineControllerDoesNotMarkMissingPayloadPlaceholderRestored(t *testing.T) {
 	home := t.TempDir()
 	original := filepath.Join(home, "cache", "go-build")
 	quarantined := filepath.Join(home, "trash", "go-cache", "entry-cache")
-	if err := os.MkdirAll(original, 0o700); err != nil {
-		t.Fatal(err)
-	}
-	artifact := filepath.Join(original, "artifact")
-	if err := os.WriteFile(artifact, []byte("keep"), 0o600); err != nil {
-		t.Fatal(err)
-	}
 	settings, store := newStorageMaintenanceStores(t)
+	current, err := settings.GetSettings(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	current.GoCache.Enabled = true
+	if _, err := settings.SaveSettings(context.Background(), current); err != nil {
+		t.Fatal(err)
+	}
+	provider := gocache.New(gocache.Config{
+		HomeDir: home, TrashDir: filepath.Join(home, "trash"), Settings: settings,
+	})
+	if _, err := provider.ExecutionEnvironment(context.Background()); err != nil {
+		t.Fatalf("create managed replacement: %v", err)
+	}
 	entry := createGoCacheQuarantineEntry(
 		t, store, original, quarantined, time.Now().UTC().Add(time.Hour),
 	)
 	controller := &workspaceQuarantineController{settings: settings, store: store, homeDir: home}
 
-	restored, err := controller.Restore(context.Background(), entry.ID)
+	_, err = controller.Restore(context.Background(), entry.ID)
+	if !errors.Is(err, storagepkg.ErrConflict) {
+		t.Fatalf("Restore error = %v, want storage ErrConflict", err)
+	}
+	stored, err := store.GetQuarantineEntry(context.Background(), entry.ID)
 	if err != nil {
-		t.Fatalf("Restore: %v", err)
+		t.Fatal(err)
 	}
-	if restored.State != storagepkg.QuarantineStateRestored {
-		t.Fatalf("state = %q, want restored", restored.State)
-	}
-	if data, err := os.ReadFile(artifact); err != nil || string(data) != "keep" {
-		t.Fatalf("original cache changed: data=%q err=%v", data, err)
+	if stored.State != storagepkg.QuarantineStateQuarantined {
+		t.Fatalf("state = %q, want quarantined", stored.State)
 	}
 }
 
-func TestQuarantineControllerReportsPersistenceAndRollbackFailures(t *testing.T) {
+func TestQuarantineControllerReportsPersistenceAndFailsClosedAfterRollbackFailure(t *testing.T) {
 	home := t.TempDir()
 	original := filepath.Join(home, "cache", "go-build")
 	quarantined := filepath.Join(home, "trash", "go-cache", "entry-cache")
@@ -495,12 +514,12 @@ func TestQuarantineControllerReportsPersistenceAndRollbackFailures(t *testing.T)
 	}
 
 	store.err = nil
-	restored, err := controller.Restore(context.Background(), entry.ID)
-	if err != nil {
-		t.Fatalf("reconcile retry: %v", err)
+	_, err = controller.Restore(context.Background(), entry.ID)
+	if !errors.Is(err, storagepkg.ErrConflict) {
+		t.Fatalf("ambiguous retry error = %v, want storage ErrConflict", err)
 	}
-	if restored.State != storagepkg.QuarantineStateRestored {
-		t.Fatalf("retry state = %q, want restored", restored.State)
+	if store.entry.State != storagepkg.QuarantineStateQuarantined {
+		t.Fatalf("retry state = %q, want quarantined", store.entry.State)
 	}
 }
 

--- a/apps/backend/internal/orchestrator/executor/executor.go
+++ b/apps/backend/internal/orchestrator/executor/executor.go
@@ -287,6 +287,7 @@ type LaunchAgentRequest struct {
 	// OfficeAgentProfileID is the stable Office identity. AgentProfileID stays
 	// the concrete execution profile inside the executor for compatibility.
 	OfficeAgentProfileID string
+	StartAgent           bool // Keep lifecycle activity through initial startup/prompt
 	RepositoryURL        string
 	Branch               string
 	TaskDescription      string                 // Task description to send via ACP prompt

--- a/apps/backend/internal/orchestrator/executor/executor_execute.go
+++ b/apps/backend/internal/orchestrator/executor/executor_execute.go
@@ -630,6 +630,7 @@ func (e *Executor) LaunchPreparedSession(ctx context.Context, task *v1.Task, ses
 	if req.OfficeAgentProfileID == "" && session.AgentProfileID != "" {
 		req.OfficeAgentProfileID = session.AgentProfileID
 	}
+	req.StartAgent = startAgent
 	mergeEnv(req, opts.Env)
 	if opts.RouteOverride != nil {
 		req.RouteOverride = opts.RouteOverride

--- a/apps/backend/internal/orchestrator/executor/executor_test.go
+++ b/apps/backend/internal/orchestrator/executor/executor_test.go
@@ -256,6 +256,9 @@ func TestLaunchPreparedSession_Success(t *testing.T) {
 	agentManager := &mockAgentManager{
 		launchAgentFunc: func(ctx context.Context, req *LaunchAgentRequest) (*LaunchAgentResponse, error) {
 			launchCalled = true
+			if !req.StartAgent {
+				t.Error("expected lifecycle launch to retain initial-agent activity")
+			}
 			if req.SessionID != "session-123" {
 				t.Errorf("Expected session ID session-123, got %s", req.SessionID)
 			}
@@ -579,6 +582,9 @@ func TestLaunchPreparedSession_WorkspaceOnly(t *testing.T) {
 	agentManager := &mockAgentManager{
 		launchAgentFunc: func(ctx context.Context, req *LaunchAgentRequest) (*LaunchAgentResponse, error) {
 			launchCalled = true
+			if req.StartAgent {
+				t.Error("workspace-only launch retained initial-agent activity")
+			}
 			return &LaunchAgentResponse{
 				AgentExecutionID: "exec-123",
 				ContainerID:      "container-123",

--- a/apps/backend/internal/system/storage/dockerstore/provider.go
+++ b/apps/backend/internal/system/storage/dockerstore/provider.go
@@ -10,7 +10,10 @@ import (
 	"github.com/kandev/kandev/internal/system/storage"
 )
 
-var ErrGlobalCleanupDisabled = errors.New("global Docker cleanup is disabled")
+var (
+	ErrDockerUnavailable     = errors.New("docker client is unavailable")
+	ErrGlobalCleanupDisabled = errors.New("global Docker cleanup is disabled")
+)
 
 type DockerClient interface {
 	Ping(context.Context) error
@@ -99,6 +102,9 @@ func (p *Provider) Analyze(ctx context.Context) Analysis {
 }
 
 func (p *Provider) PruneBuildCache(ctx context.Context) (agentdocker.PruneResult, error) {
+	if p.docker == nil {
+		return agentdocker.PruneResult{}, ErrDockerUnavailable
+	}
 	settings, err := p.settings.GetSettings(ctx)
 	if err != nil {
 		return agentdocker.PruneResult{}, fmt.Errorf("read storage settings: %w", err)
@@ -119,6 +125,9 @@ func (p *Provider) PruneBuildCache(ctx context.Context) (agentdocker.PruneResult
 }
 
 func (p *Provider) PruneUnusedImages(ctx context.Context) (agentdocker.PruneResult, error) {
+	if p.docker == nil {
+		return agentdocker.PruneResult{}, ErrDockerUnavailable
+	}
 	settings, err := p.settings.GetSettings(ctx)
 	if err != nil {
 		return agentdocker.PruneResult{}, fmt.Errorf("read storage settings: %w", err)

--- a/apps/backend/internal/system/storage/dockerstore/provider.go
+++ b/apps/backend/internal/system/storage/dockerstore/provider.go
@@ -1,0 +1,207 @@
+package dockerstore
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	agentdocker "github.com/kandev/kandev/internal/agent/docker"
+	"github.com/kandev/kandev/internal/system/storage"
+)
+
+var ErrGlobalCleanupDisabled = errors.New("global Docker cleanup is disabled")
+
+type DockerClient interface {
+	Ping(context.Context) error
+	ListContainers(context.Context, map[string]string) ([]agentdocker.ContainerInfo, error)
+	RemoveContainer(context.Context, string, bool) error
+	DiskUsage(context.Context) (agentdocker.DiskUsage, error)
+	PruneBuildCache(context.Context, agentdocker.BuildCachePruneOptions) (agentdocker.PruneResult, error)
+	PruneUnusedImages(context.Context, time.Time) (agentdocker.PruneResult, error)
+}
+
+type TaskInventory interface {
+	ContainerTaskRemovable(context.Context, string) (bool, error)
+}
+
+type SettingsReader interface {
+	GetSettings(context.Context) (storage.StorageMaintenanceSettings, error)
+}
+
+type Result struct {
+	Available bool     `json:"available"`
+	Removed   int      `json:"removed"`
+	Kept      int      `json:"kept"`
+	Warnings  []string `json:"warnings"`
+}
+
+type Analysis struct {
+	Available             bool     `json:"available"`
+	ManagedContainerCount int      `json:"managed_container_count"`
+	ManagedContainerBytes int64    `json:"managed_container_bytes"`
+	BuildCacheBytes       int64    `json:"build_cache_bytes"`
+	UnusedImageBytes      int64    `json:"unused_image_bytes"`
+	Warnings              []string `json:"warnings"`
+}
+
+type Provider struct {
+	docker    DockerClient
+	inventory TaskInventory
+	settings  SettingsReader
+	now       func() time.Time
+}
+
+func NewProvider(docker DockerClient, inventory TaskInventory, settings SettingsReader) *Provider {
+	return &Provider{docker: docker, inventory: inventory, settings: settings, now: time.Now}
+}
+
+func (p *Provider) CleanupContainers(ctx context.Context) Result {
+	if warning := p.availabilityWarning(ctx); warning != "" {
+		return Result{Warnings: []string{warning}}
+	}
+	containers, err := p.docker.ListContainers(ctx, map[string]string{"kandev.managed": "true"})
+	if err != nil {
+		return Result{Warnings: []string{fmt.Sprintf("list Docker containers: %v", err)}}
+	}
+	result := Result{Available: true}
+	for _, candidate := range containers {
+		p.cleanupContainer(ctx, candidate, &result)
+	}
+	return result
+}
+
+func (p *Provider) Analyze(ctx context.Context) Analysis {
+	if warning := p.availabilityWarning(ctx); warning != "" {
+		return Analysis{Warnings: []string{warning}}
+	}
+	usage, err := p.docker.DiskUsage(ctx)
+	if err != nil {
+		return Analysis{Warnings: []string{fmt.Sprintf("read Docker disk usage: %v", err)}}
+	}
+	settings, err := p.settings.GetSettings(ctx)
+	if err != nil {
+		return Analysis{Warnings: []string{fmt.Sprintf("read storage settings: %v", err)}}
+	}
+	settings, err = storage.NormalizeSettings(settings)
+	if err != nil {
+		return Analysis{Warnings: []string{fmt.Sprintf("validate storage settings: %v", err)}}
+	}
+	cutoff := p.now().Add(-time.Duration(settings.Docker.UnusedImagesHours) * time.Hour)
+	managedCount, managedBytes := managedContainerUsage(usage.Containers)
+	return Analysis{
+		Available:             true,
+		ManagedContainerCount: managedCount,
+		ManagedContainerBytes: managedBytes,
+		BuildCacheBytes:       usage.BuildCacheBytes,
+		UnusedImageBytes:      unusedImageBytes(usage.Images, cutoff),
+	}
+}
+
+func (p *Provider) PruneBuildCache(ctx context.Context) (agentdocker.PruneResult, error) {
+	settings, err := p.settings.GetSettings(ctx)
+	if err != nil {
+		return agentdocker.PruneResult{}, fmt.Errorf("read storage settings: %w", err)
+	}
+	settings, err = storage.NormalizeSettings(settings)
+	if err != nil {
+		return agentdocker.PruneResult{}, fmt.Errorf("validate storage settings: %w", err)
+	}
+	if !settings.Docker.DedicatedDaemonAcknowledged || !settings.Docker.BuildCacheEnabled {
+		return agentdocker.PruneResult{}, ErrGlobalCleanupDisabled
+	}
+	return p.docker.PruneBuildCache(ctx, agentdocker.BuildCachePruneOptions{
+		KeepBytes: settings.Docker.BuildCacheKeepBytes,
+		UnusedBefore: p.now().Add(
+			-time.Duration(settings.Docker.BuildCacheUnusedHours) * time.Hour,
+		),
+	})
+}
+
+func (p *Provider) PruneUnusedImages(ctx context.Context) (agentdocker.PruneResult, error) {
+	settings, err := p.settings.GetSettings(ctx)
+	if err != nil {
+		return agentdocker.PruneResult{}, fmt.Errorf("read storage settings: %w", err)
+	}
+	settings, err = storage.NormalizeSettings(settings)
+	if err != nil {
+		return agentdocker.PruneResult{}, fmt.Errorf("validate storage settings: %w", err)
+	}
+	if !settings.Docker.DedicatedDaemonAcknowledged || !settings.Docker.UnusedImagesEnabled {
+		return agentdocker.PruneResult{}, ErrGlobalCleanupDisabled
+	}
+	cutoff := p.now().Add(-time.Duration(settings.Docker.UnusedImagesHours) * time.Hour)
+	return p.docker.PruneUnusedImages(ctx, cutoff)
+}
+
+func (p *Provider) availabilityWarning(ctx context.Context) string {
+	if p.docker == nil {
+		return "Docker unavailable: client not configured"
+	}
+	if err := p.docker.Ping(ctx); err != nil {
+		return fmt.Sprintf("Docker unavailable: %v", err)
+	}
+	return ""
+}
+
+func (p *Provider) cleanupContainer(ctx context.Context, candidate agentdocker.ContainerInfo, result *Result) {
+	if candidate.Labels["kandev.managed"] != "true" || !stoppedContainer(candidate.State) {
+		result.Kept++
+		return
+	}
+	taskID := candidate.Labels["kandev.task_id"]
+	if taskID == "" {
+		result.Kept++
+		return
+	}
+	removable, err := p.inventory.ContainerTaskRemovable(ctx, taskID)
+	if err != nil {
+		result.Kept++
+		result.Warnings = append(result.Warnings, fmt.Sprintf("classify container %s: %v", candidate.ID, err))
+		return
+	}
+	if !removable {
+		result.Kept++
+		return
+	}
+	if err := p.docker.RemoveContainer(ctx, candidate.ID, false); err != nil {
+		result.Kept++
+		result.Warnings = append(result.Warnings, fmt.Sprintf("remove container %s: %v", candidate.ID, err))
+		return
+	}
+	result.Removed++
+}
+
+func stoppedContainer(state string) bool {
+	switch state {
+	case "created", "exited", "dead":
+		return true
+	default:
+		return false
+	}
+}
+
+func unusedImageBytes(images []agentdocker.ImageUsage, cutoff time.Time) int64 {
+	var total int64
+	for _, image := range images {
+		if image.Containers == 0 && image.CreatedAt.Before(cutoff) && image.SizeBytes > 0 {
+			total += image.SizeBytes
+		}
+	}
+	return total
+}
+
+func managedContainerUsage(containers []agentdocker.ContainerUsage) (int, int64) {
+	var count int
+	var bytes int64
+	for _, item := range containers {
+		if item.Labels["kandev.managed"] != "true" {
+			continue
+		}
+		count++
+		if item.WritableBytes > 0 {
+			bytes += item.WritableBytes
+		}
+	}
+	return count, bytes
+}

--- a/apps/backend/internal/system/storage/dockerstore/provider_test.go
+++ b/apps/backend/internal/system/storage/dockerstore/provider_test.go
@@ -130,6 +130,41 @@ func TestGlobalPruneRechecksPersistedAcknowledgementImmediatelyBeforeSDKCall(t *
 	}
 }
 
+func TestGlobalPruneRejectsMissingDockerClient(t *testing.T) {
+	settings := storage.DefaultSettings()
+	settings.Docker.DedicatedDaemonAcknowledged = true
+	settings.Docker.BuildCacheEnabled = true
+	settings.Docker.UnusedImagesEnabled = true
+
+	tests := []struct {
+		name  string
+		prune func(*Provider) error
+	}{
+		{
+			name: "build cache",
+			prune: func(provider *Provider) error {
+				_, err := provider.PruneBuildCache(context.Background())
+				return err
+			},
+		},
+		{
+			name: "unused images",
+			prune: func(provider *Provider) error {
+				_, err := provider.PruneUnusedImages(context.Background())
+				return err
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := NewProvider(nil, &fakeInventory{}, staticSettings(settings))
+			if err := tt.prune(provider); !errors.Is(err, ErrDockerUnavailable) {
+				t.Fatalf("prune error = %v, want ErrDockerUnavailable", err)
+			}
+		})
+	}
+}
+
 func TestGlobalPruneRejectsOverflowingAgeWithoutSDKCall(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/apps/backend/internal/system/storage/dockerstore/provider_test.go
+++ b/apps/backend/internal/system/storage/dockerstore/provider_test.go
@@ -1,0 +1,244 @@
+package dockerstore
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"math"
+	"reflect"
+	"testing"
+	"time"
+
+	agentdocker "github.com/kandev/kandev/internal/agent/docker"
+	"github.com/kandev/kandev/internal/system/storage"
+)
+
+func TestResultJSONUsesStorageAPISnakeCase(t *testing.T) {
+	encoded, err := json.Marshal(Result{Available: true, Removed: 1, Kept: 2, Warnings: []string{"warn"}})
+	if err != nil {
+		t.Fatalf("Marshal Result: %v", err)
+	}
+	want := `{"available":true,"removed":1,"kept":2,"warnings":["warn"]}`
+	if string(encoded) != want {
+		t.Fatalf("Result JSON = %s, want %s", encoded, want)
+	}
+}
+
+func TestAnalysisJSONUsesStorageAPISnakeCase(t *testing.T) {
+	encoded, err := json.Marshal(Analysis{
+		Available: true, ManagedContainerCount: 1, ManagedContainerBytes: 2,
+		BuildCacheBytes: 3, UnusedImageBytes: 4, Warnings: []string{"warn"},
+	})
+	if err != nil {
+		t.Fatalf("Marshal Analysis: %v", err)
+	}
+	want := `{"available":true,"managed_container_count":1,"managed_container_bytes":2,"build_cache_bytes":3,"unused_image_bytes":4,"warnings":["warn"]}`
+	if string(encoded) != want {
+		t.Fatalf("Analysis JSON = %s, want %s", encoded, want)
+	}
+}
+
+func TestCleanupContainersRemovesOnlyPositivelyClassifiedStoppedManagedContainers(t *testing.T) {
+	docker := &fakeDockerClient{containers: []agentdocker.ContainerInfo{
+		{ID: "orphan", State: "exited", Labels: map[string]string{"kandev.managed": "true", "kandev.task_id": "gone"}},
+		{ID: "running", State: "running", Labels: map[string]string{"kandev.managed": "true", "kandev.task_id": "gone"}},
+		{ID: "unrelated", State: "exited", Labels: map[string]string{"kandev.task_id": "gone"}},
+		{ID: "active", State: "exited", Labels: map[string]string{"kandev.managed": "true", "kandev.task_id": "active"}},
+	}}
+	inventory := &fakeInventory{removable: map[string]bool{"gone": true, "active": false}}
+	provider := NewProvider(docker, inventory, staticSettings(storage.DefaultSettings()))
+
+	got := provider.CleanupContainers(context.Background())
+	if !got.Available || got.Removed != 1 || got.Kept != 3 {
+		t.Fatalf("cleanup result = %#v, want available removed=1 kept=3", got)
+	}
+	if !reflect.DeepEqual(docker.listLabels, map[string]string{"kandev.managed": "true"}) {
+		t.Fatalf("list labels = %#v", docker.listLabels)
+	}
+	if !reflect.DeepEqual(docker.removed, []removeCall{{id: "orphan", force: false}}) {
+		t.Fatalf("removed = %#v", docker.removed)
+	}
+}
+
+func TestCleanupContainersFailsClosedOnInventoryError(t *testing.T) {
+	docker := &fakeDockerClient{containers: []agentdocker.ContainerInfo{{
+		ID: "uncertain", State: "exited",
+		Labels: map[string]string{"kandev.managed": "true", "kandev.task_id": "task-1"},
+	}}}
+	provider := NewProvider(docker, &fakeInventory{err: errors.New("database unavailable")}, staticSettings(storage.DefaultSettings()))
+
+	got := provider.CleanupContainers(context.Background())
+	if got.Removed != 0 || got.Kept != 1 || len(got.Warnings) != 1 || len(docker.removed) != 0 {
+		t.Fatalf("cleanup result = %#v, removed calls = %#v", got, docker.removed)
+	}
+}
+
+func TestAnalyzeIsReadOnlyAndReportsUnavailableWithoutError(t *testing.T) {
+	t.Run("read only", func(t *testing.T) {
+		docker := &fakeDockerClient{usage: agentdocker.DiskUsage{
+			BuildCacheBytes: 200,
+			Containers: []agentdocker.ContainerUsage{
+				{ID: "managed", WritableBytes: 25, Labels: map[string]string{"kandev.managed": "true"}},
+				{ID: "managed-zero", WritableBytes: -1, Labels: map[string]string{"kandev.managed": "true"}},
+				{ID: "unrelated", WritableBytes: 75, Labels: map[string]string{"owner": "user"}},
+			},
+			Images: []agentdocker.ImageUsage{
+				{ID: "old-unused", SizeBytes: 300, Containers: 0, CreatedAt: time.Unix(1, 0)},
+				{ID: "used", SizeBytes: 400, Containers: 1, CreatedAt: time.Unix(1, 0)},
+			},
+		}}
+		provider := NewProvider(docker, &fakeInventory{}, staticSettings(storage.DefaultSettings()))
+		provider.now = func() time.Time { return time.Unix(2000000, 0) }
+
+		got := provider.Analyze(context.Background())
+		if !got.Available || got.BuildCacheBytes != 200 || got.UnusedImageBytes != 300 ||
+			got.ManagedContainerCount != 2 || got.ManagedContainerBytes != 25 {
+			t.Fatalf("analysis = %#v", got)
+		}
+		if docker.buildPrunes != 0 || docker.imagePrunes != 0 || len(docker.removed) != 0 {
+			t.Fatalf("analysis mutated Docker: %#v", docker)
+		}
+	})
+
+	t.Run("unavailable", func(t *testing.T) {
+		docker := &fakeDockerClient{pingErr: errors.New("no daemon")}
+		provider := NewProvider(docker, &fakeInventory{}, staticSettings(storage.DefaultSettings()))
+		got := provider.Analyze(context.Background())
+		if got.Available || len(got.Warnings) != 1 {
+			t.Fatalf("analysis = %#v, want unavailable warning", got)
+		}
+	})
+}
+
+func TestGlobalPruneRechecksPersistedAcknowledgementImmediatelyBeforeSDKCall(t *testing.T) {
+	settings := storage.DefaultSettings()
+	settings.Docker.DedicatedDaemonAcknowledged = true
+	settings.Docker.BuildCacheEnabled = true
+	settings.Docker.UnusedImagesEnabled = true
+	docker := &fakeDockerClient{}
+	reader := &sequenceSettings{values: []storage.StorageMaintenanceSettings{settings, storage.DefaultSettings()}}
+	provider := NewProvider(docker, &fakeInventory{}, reader)
+
+	if _, err := provider.PruneBuildCache(context.Background()); err != nil {
+		t.Fatalf("first prune: %v", err)
+	}
+	if _, err := provider.PruneUnusedImages(context.Background()); !errors.Is(err, ErrGlobalCleanupDisabled) {
+		t.Fatalf("second prune error = %v, want ErrGlobalCleanupDisabled", err)
+	}
+	if docker.buildPrunes != 1 || docker.imagePrunes != 0 {
+		t.Fatalf("prune calls build=%d image=%d", docker.buildPrunes, docker.imagePrunes)
+	}
+}
+
+func TestGlobalPruneRejectsOverflowingAgeWithoutSDKCall(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*storage.StorageMaintenanceSettings)
+		prune  func(*Provider) error
+	}{
+		{
+			name: "build cache",
+			mutate: func(settings *storage.StorageMaintenanceSettings) {
+				settings.Docker.BuildCacheEnabled = true
+				settings.Docker.BuildCacheUnusedHours = math.MaxInt
+			},
+			prune: func(provider *Provider) error {
+				_, err := provider.PruneBuildCache(context.Background())
+				return err
+			},
+		},
+		{
+			name: "unused images",
+			mutate: func(settings *storage.StorageMaintenanceSettings) {
+				settings.Docker.UnusedImagesEnabled = true
+				settings.Docker.UnusedImagesHours = math.MaxInt
+			},
+			prune: func(provider *Provider) error {
+				_, err := provider.PruneUnusedImages(context.Background())
+				return err
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			settings := storage.DefaultSettings()
+			settings.Docker.DedicatedDaemonAcknowledged = true
+			tt.mutate(&settings)
+			docker := &fakeDockerClient{}
+			provider := NewProvider(docker, &fakeInventory{}, staticSettings(settings))
+
+			if err := tt.prune(provider); !errors.Is(err, storage.ErrValidation) {
+				t.Fatalf("prune error = %v, want storage.ErrValidation", err)
+			}
+			if docker.buildPrunes != 0 || docker.imagePrunes != 0 {
+				t.Fatalf("unsafe SDK calls build=%d image=%d", docker.buildPrunes, docker.imagePrunes)
+			}
+		})
+	}
+}
+
+type fakeDockerClient struct {
+	containers  []agentdocker.ContainerInfo
+	listLabels  map[string]string
+	removed     []removeCall
+	pingErr     error
+	usage       agentdocker.DiskUsage
+	usageErr    error
+	buildPrunes int
+	imagePrunes int
+}
+
+type removeCall struct {
+	id    string
+	force bool
+}
+
+func (f *fakeDockerClient) Ping(context.Context) error { return f.pingErr }
+
+func (f *fakeDockerClient) ListContainers(_ context.Context, labels map[string]string) ([]agentdocker.ContainerInfo, error) {
+	f.listLabels = labels
+	return f.containers, nil
+}
+
+func (f *fakeDockerClient) RemoveContainer(_ context.Context, id string, force bool) error {
+	f.removed = append(f.removed, removeCall{id: id, force: force})
+	return nil
+}
+
+func (f *fakeDockerClient) DiskUsage(context.Context) (agentdocker.DiskUsage, error) {
+	return f.usage, f.usageErr
+}
+
+func (f *fakeDockerClient) PruneBuildCache(context.Context, agentdocker.BuildCachePruneOptions) (agentdocker.PruneResult, error) {
+	f.buildPrunes++
+	return agentdocker.PruneResult{BytesReclaimed: 10}, nil
+}
+
+func (f *fakeDockerClient) PruneUnusedImages(context.Context, time.Time) (agentdocker.PruneResult, error) {
+	f.imagePrunes++
+	return agentdocker.PruneResult{BytesReclaimed: 20}, nil
+}
+
+type fakeInventory struct {
+	removable map[string]bool
+	err       error
+}
+
+func (f *fakeInventory) ContainerTaskRemovable(_ context.Context, taskID string) (bool, error) {
+	return f.removable[taskID], f.err
+}
+
+type sequenceSettings struct {
+	values []storage.StorageMaintenanceSettings
+	index  int
+}
+
+func (s *sequenceSettings) GetSettings(context.Context) (storage.StorageMaintenanceSettings, error) {
+	value := s.values[s.index]
+	s.index++
+	return value, nil
+}
+
+func staticSettings(settings storage.StorageMaintenanceSettings) *sequenceSettings {
+	return &sequenceSettings{values: []storage.StorageMaintenanceSettings{settings}}
+}

--- a/apps/backend/internal/system/storage/gocache/provider.go
+++ b/apps/backend/internal/system/storage/gocache/provider.go
@@ -448,7 +448,7 @@ func probeAtomicRename(cachePath, trashRoot string) error {
 	if err := os.MkdirAll(trashRoot, 0o700); err != nil { // codeql[go/path-injection] validated by validateCacheAndTrash.
 		return fmt.Errorf("create Go-cache trash: %w", err)
 	}
-	probe, err := os.CreateTemp(cachePath, ".kandev-adoption-probe-")
+	probe, err := os.CreateTemp(cachePath, ".kandev-adoption-probe-") // codeql[go/path-injection] cachePath is validated by validateCacheAndTrash.
 	if err != nil {
 		return fmt.Errorf("create adoption probe: %w", err)
 	}

--- a/apps/backend/internal/system/storage/gocache/provider.go
+++ b/apps/backend/internal/system/storage/gocache/provider.go
@@ -445,24 +445,43 @@ func startsWithParent(rel string) bool {
 }
 
 func probeAtomicRename(cachePath, trashRoot string) error {
-	if err := os.MkdirAll(trashRoot, 0o700); err != nil { // codeql[go/path-injection] validated by validateCacheAndTrash.
+	anchor, err := storage.CommonPath(cachePath, trashRoot)
+	if err != nil {
+		return err
+	}
+	root, err := os.OpenRoot(anchor)
+	if err != nil {
+		return fmt.Errorf("open Go-cache adoption root: %w", err)
+	}
+	defer func() { _ = root.Close() }()
+
+	cacheRel, err := filepath.Rel(anchor, cachePath)
+	if err != nil {
+		return fmt.Errorf("resolve Go-cache probe path: %w", err)
+	}
+	trashRel, err := filepath.Rel(anchor, trashRoot)
+	if err != nil {
+		return fmt.Errorf("resolve Go-cache trash path: %w", err)
+	}
+	if err := root.MkdirAll(trashRel, 0o700); err != nil {
 		return fmt.Errorf("create Go-cache trash: %w", err)
 	}
-	probe, err := os.CreateTemp(cachePath, ".kandev-adoption-probe-") // codeql[go/path-injection] cachePath is validated by validateCacheAndTrash.
+	probeName := ".kandev-adoption-probe-" + uuid.NewString()
+	source := filepath.Join(cacheRel, probeName)
+	probe, err := root.OpenFile(source, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0o600)
 	if err != nil {
 		return fmt.Errorf("create adoption probe: %w", err)
 	}
-	source := probe.Name()
 	if err := probe.Close(); err != nil {
-		_ = os.Remove(source)
+		_ = root.Remove(source)
 		return fmt.Errorf("close adoption probe: %w", err)
 	}
-	destination := filepath.Join(trashRoot, filepath.Base(source))
-	if err := os.Rename(source, destination); err != nil {
-		_ = os.Remove(source)
+	destination := filepath.Join(trashRel, probeName)
+	if err := root.Rename(source, destination); err != nil {
+		_ = root.Remove(source)
 		return fmt.Errorf("adopted Go cache must support atomic rename into Kandev trash: %w", err)
 	}
-	if err := os.Remove(destination); err != nil {
+	if err := root.Remove(destination); err != nil {
 		return fmt.Errorf("remove adoption probe: %w", err)
 	}
 	return nil

--- a/apps/backend/internal/system/storage/gocache/provider.go
+++ b/apps/backend/internal/system/storage/gocache/provider.go
@@ -1,0 +1,417 @@
+// Package gocache owns Kandev's opt-in local Go build cache.
+package gocache
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/kandev/kandev/internal/system/storage"
+)
+
+var (
+	// ErrNotOwned is returned when the managed path lacks Kandev's marker.
+	ErrNotOwned             = errors.New("go cache is not owned by Kandev")
+	ErrAdoptionConfirmation = errors.New("go cache adoption requires ADOPT confirmation")
+)
+
+const (
+	markerName    = ".go-build.kandev-owned"
+	markerContent = "kandev-managed-go-cache\n"
+)
+
+// SettingsSource returns the persisted install-wide storage settings.
+type SettingsSource interface {
+	GetSettings(ctx context.Context) (storage.StorageMaintenanceSettings, error)
+}
+
+// QuarantineStore persists cache rotations before filesystem mutation.
+type QuarantineStore interface {
+	CreateQuarantineEntry(ctx context.Context, entry *storage.QuarantineEntry) error
+	TransitionQuarantineEntry(ctx context.Context, id string, next storage.QuarantineState, lastError string) (storage.QuarantineEntry, error)
+}
+
+// Config contains the provider's install-owned paths and persistence dependencies.
+type Config struct {
+	HomeDir  string
+	TrashDir string
+	Settings SettingsSource
+	Store    QuarantineStore
+}
+
+// Provider manages the single Go cache selected by persisted settings.
+type Provider struct {
+	config Config
+}
+
+// Analysis describes the configured cache without changing it.
+type Analysis struct {
+	Path      string `json:"path"`
+	SizeBytes int64  `json:"size_bytes"`
+	Owned     bool   `json:"owned"`
+	Enabled   bool   `json:"enabled"`
+}
+
+// CleanupResult describes one cache rotation.
+type CleanupResult struct {
+	Path            string                   `json:"path"`
+	BytesBefore     int64                    `json:"bytes_before"`
+	BytesAfter      int64                    `json:"bytes_after"`
+	ReclaimedBytes  int64                    `json:"reclaimed_bytes"`
+	QuarantineEntry *storage.QuarantineEntry `json:"quarantine_entry"`
+}
+
+// New creates a managed Go-cache provider.
+func New(config Config) *Provider {
+	return &Provider{config: config}
+}
+
+// ExecutionEnvironment returns variables injected into new local executions.
+func (p *Provider) ExecutionEnvironment(ctx context.Context) (map[string]string, error) {
+	settings, err := p.loadSettings(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if !settings.GoCache.Enabled {
+		return nil, nil
+	}
+	cachePath, adopted, err := p.cachePath(settings)
+	if err != nil {
+		return nil, err
+	}
+	if err := p.validateCachePath(cachePath); err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(cachePath, 0o755); err != nil {
+		return nil, fmt.Errorf("create managed Go cache: %w", err)
+	}
+	if !adopted {
+		if err := writeMarker(cachePath); err != nil {
+			return nil, fmt.Errorf("create Go-cache ownership marker: %w", err)
+		}
+	}
+	return map[string]string{"GOCACHE": cachePath}, nil
+}
+
+// Analyze reports the selected cache's current usage.
+func (p *Provider) Analyze(ctx context.Context) (Analysis, error) {
+	settings, err := p.loadSettings(ctx)
+	if err != nil {
+		return Analysis{}, err
+	}
+	cachePath, adopted, err := p.cachePath(settings)
+	if err != nil {
+		return Analysis{}, err
+	}
+	if err := p.validateCachePath(cachePath); err != nil {
+		return Analysis{}, err
+	}
+	owned := adopted || hasValidMarker(cachePath)
+	size, err := directorySize(cachePath)
+	if err != nil {
+		return Analysis{}, err
+	}
+	return Analysis{Path: cachePath, SizeBytes: size, Owned: owned, Enabled: settings.GoCache.Enabled}, nil
+}
+
+// Cleanup rotates an above-threshold cache into Kandev trash.
+func (p *Provider) Cleanup(ctx context.Context) (CleanupResult, error) {
+	return p.cleanup(ctx, false)
+}
+
+// CleanupExplicit rotates an above-threshold cache even when scheduled maintenance is disabled.
+func (p *Provider) CleanupExplicit(ctx context.Context) (CleanupResult, error) {
+	return p.cleanup(ctx, true)
+}
+
+func (p *Provider) cleanup(ctx context.Context, explicit bool) (CleanupResult, error) {
+	settings, err := p.loadSettings(ctx)
+	if err != nil {
+		return CleanupResult{}, err
+	}
+	cachePath, adopted, err := p.cachePath(settings)
+	if err != nil {
+		return CleanupResult{}, err
+	}
+	result := CleanupResult{Path: cachePath}
+	if !settings.GoCache.Enabled && !explicit {
+		return result, nil
+	}
+	if err := p.validateCacheAndTrash(cachePath); err != nil {
+		return result, err
+	}
+	if !adopted && !hasValidMarker(cachePath) {
+		return result, ErrNotOwned
+	}
+	result.BytesBefore, err = directorySize(cachePath)
+	if err != nil {
+		return result, err
+	}
+	if result.BytesBefore <= settings.GoCache.MaxBytes {
+		result.BytesAfter = result.BytesBefore
+		return result, nil
+	}
+	entry, err := p.rotate(ctx, cachePath, result.BytesBefore, settings.QuarantineRetentionHours, adopted)
+	if err != nil {
+		return result, err
+	}
+	result.QuarantineEntry = entry
+	result.ReclaimedBytes = result.BytesBefore
+	return result, nil
+}
+
+// ValidateAdoption verifies an explicitly confirmed external cache path.
+func (p *Provider) ValidateAdoption(_ context.Context, path, confirmation string) error {
+	if confirmation != "ADOPT" {
+		return ErrAdoptionConfirmation
+	}
+	if !filepath.IsAbs(path) {
+		return fmt.Errorf("adopted Go-cache path must be absolute: %q", path)
+	}
+	path = filepath.Clean(path)
+	if path == filepath.VolumeName(path)+string(filepath.Separator) {
+		return errors.New("filesystem root cannot be adopted as a Go cache")
+	}
+	trashRoot := filepath.Clean(p.config.TrashDir)
+	if !filepath.IsAbs(trashRoot) {
+		return fmt.Errorf("go-cache trash path must be absolute: %q", trashRoot)
+	}
+	if pathsOverlap(path, trashRoot) {
+		return errors.New("adopted Go cache and Kandev trash must not contain each other")
+	}
+	if err := p.validateCacheAndTrash(path); err != nil {
+		return err
+	}
+	return probeAtomicRename(path, trashRoot)
+}
+
+func (p *Provider) loadSettings(ctx context.Context) (storage.StorageMaintenanceSettings, error) {
+	if p.config.Settings == nil {
+		return storage.StorageMaintenanceSettings{}, errors.New("go-cache settings source is required")
+	}
+	settings, err := p.config.Settings.GetSettings(ctx)
+	if err != nil {
+		return storage.StorageMaintenanceSettings{}, fmt.Errorf("load Go-cache settings: %w", err)
+	}
+	return settings, nil
+}
+
+func (p *Provider) cachePath(settings storage.StorageMaintenanceSettings) (string, bool, error) {
+	path := settings.GoCache.AdoptedPath
+	adopted := path != ""
+	if !adopted {
+		path = filepath.Join(p.config.HomeDir, "cache", "go-build")
+	}
+	if !filepath.IsAbs(path) {
+		return "", false, fmt.Errorf("managed Go-cache path must be absolute: %q", path)
+	}
+	return filepath.Clean(path), adopted, nil
+}
+
+func (p *Provider) rotate(
+	ctx context.Context,
+	cachePath string,
+	sizeBytes int64,
+	retentionHours int,
+	adopted bool,
+) (*storage.QuarantineEntry, error) {
+	if p.config.Store == nil {
+		return nil, errors.New("go-cache quarantine store is required")
+	}
+	trashRoot := filepath.Clean(p.config.TrashDir)
+	if !filepath.IsAbs(trashRoot) {
+		return nil, fmt.Errorf("go-cache trash path must be absolute: %q", trashRoot)
+	}
+	if err := p.validateCacheAndTrash(cachePath); err != nil {
+		return nil, err
+	}
+	quarantineDir := filepath.Join(trashRoot, "go-cache")
+	anchor, err := storage.CommonPath(p.config.HomeDir, cachePath, trashRoot)
+	if err != nil {
+		return nil, err
+	}
+	if err := storage.ValidateNoSymlinkPath(anchor, quarantineDir); err != nil {
+		return nil, fmt.Errorf("validate Go-cache quarantine directory: %w", err)
+	}
+	if err := os.MkdirAll(quarantineDir, 0o700); err != nil {
+		return nil, fmt.Errorf("create Go-cache trash: %w", err)
+	}
+	now := time.Now().UTC()
+	id := uuid.NewString()
+	ownership := "managed"
+	if adopted {
+		ownership = "adopted"
+	}
+	metadata, _ := json.Marshal(map[string]string{"ownership": ownership})
+	entry := &storage.QuarantineEntry{
+		ID:             id,
+		ResourceType:   storage.ResourceTypeGoCache,
+		OriginalPath:   cachePath,
+		QuarantinePath: filepath.Join(quarantineDir, id),
+		SizeBytes:      sizeBytes,
+		State:          storage.QuarantineStateQuarantined,
+		QuarantinedAt:  now,
+		DeleteAfter:    now.Add(time.Duration(retentionHours) * time.Hour),
+		Metadata:       metadata,
+	}
+	if err := p.config.Store.CreateQuarantineEntry(ctx, entry); err != nil {
+		return nil, fmt.Errorf("persist Go-cache quarantine intent: %w", err)
+	}
+	if err := os.Rename(cachePath, entry.QuarantinePath); err != nil {
+		_, _ = p.config.Store.TransitionQuarantineEntry(ctx, id, storage.QuarantineStateFailed, err.Error())
+		return nil, fmt.Errorf("quarantine Go cache: %w", err)
+	}
+	if err := p.validateCachePath(cachePath); err != nil {
+		return nil, fmt.Errorf("validate replacement Go cache: %w", err)
+	}
+	if err := os.MkdirAll(cachePath, 0o755); err != nil {
+		return nil, fmt.Errorf("recreate managed Go cache: %w", err)
+	}
+	if !adopted {
+		if err := writeMarker(cachePath); err != nil {
+			return nil, fmt.Errorf("restore Go-cache ownership marker: %w", err)
+		}
+	}
+	return entry, nil
+}
+
+func writeMarker(cachePath string) error {
+	marker := filepath.Join(filepath.Dir(cachePath), markerName)
+	info, err := os.Lstat(marker)
+	if err == nil {
+		if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+			return ErrNotOwned
+		}
+		existing, readErr := os.ReadFile(marker)
+		if readErr != nil || string(existing) != markerContent {
+			return ErrNotOwned
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("inspect Go-cache ownership marker: %w", err)
+	}
+	return os.WriteFile(marker, []byte(markerContent), 0o600)
+}
+
+func hasValidMarker(cachePath string) bool {
+	path := filepath.Join(filepath.Dir(cachePath), markerName)
+	info, err := os.Lstat(path)
+	if err != nil || info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		return false
+	}
+	marker, err := os.ReadFile(path)
+	return err == nil && string(marker) == markerContent
+}
+
+func (p *Provider) validateCachePath(cachePath string) error {
+	anchor, err := storage.CommonPath(p.config.HomeDir, cachePath)
+	if err != nil {
+		return err
+	}
+	if err := storage.ValidateNoSymlinkPath(anchor, cachePath); err != nil {
+		return fmt.Errorf("validate Go-cache path: %w", err)
+	}
+	return rejectSymlink(cachePath)
+}
+
+func (p *Provider) validateCacheAndTrash(cachePath string) error {
+	trashRoot := filepath.Clean(p.config.TrashDir)
+	anchor, err := storage.CommonPath(p.config.HomeDir, cachePath, trashRoot)
+	if err != nil {
+		return err
+	}
+	for name, path := range map[string]string{"cache": cachePath, "trash": trashRoot} {
+		if err := storage.ValidateNoSymlinkPath(anchor, path); err != nil {
+			return fmt.Errorf("validate Go-cache %s path: %w", name, err)
+		}
+	}
+	return rejectSymlink(cachePath)
+}
+
+func rejectSymlink(path string) error {
+	info, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("inspect Go-cache path: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("go-cache path must not be a symlink: %s", path)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("go-cache path is not a directory: %s", path)
+	}
+	return nil
+}
+
+func directorySize(root string) (int64, error) {
+	if _, err := os.Lstat(root); errors.Is(err, os.ErrNotExist) {
+		return 0, nil
+	} else if err != nil {
+		return 0, fmt.Errorf("inspect Go-cache path: %w", err)
+	}
+	var total int64
+	err := filepath.WalkDir(root, func(_ string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			return fmt.Errorf("symlink found in Go cache: %s", entry.Name())
+		}
+		if entry.Type().IsRegular() {
+			info, err := entry.Info()
+			if err != nil {
+				return err
+			}
+			total += info.Size()
+		}
+		return nil
+	})
+	if err != nil {
+		return 0, fmt.Errorf("measure Go cache: %w", err)
+	}
+	return total, nil
+}
+
+func pathsOverlap(first, second string) bool {
+	return pathContains(first, second) || pathContains(second, first)
+}
+
+func pathContains(parent, child string) bool {
+	rel, err := filepath.Rel(parent, child)
+	return err == nil && rel != ".." && !filepath.IsAbs(rel) && !startsWithParent(rel)
+}
+
+func startsWithParent(rel string) bool {
+	return len(rel) >= 3 && rel[:3] == ".."+string(filepath.Separator)
+}
+
+func probeAtomicRename(cachePath, trashRoot string) error {
+	if err := os.MkdirAll(trashRoot, 0o700); err != nil {
+		return fmt.Errorf("create Go-cache trash: %w", err)
+	}
+	probe, err := os.CreateTemp(cachePath, ".kandev-adoption-probe-")
+	if err != nil {
+		return fmt.Errorf("create adoption probe: %w", err)
+	}
+	source := probe.Name()
+	if err := probe.Close(); err != nil {
+		_ = os.Remove(source)
+		return fmt.Errorf("close adoption probe: %w", err)
+	}
+	destination := filepath.Join(trashRoot, filepath.Base(source))
+	if err := os.Rename(source, destination); err != nil {
+		_ = os.Remove(source)
+		return fmt.Errorf("adopted Go cache must support atomic rename into Kandev trash: %w", err)
+	}
+	if err := os.Remove(destination); err != nil {
+		return fmt.Errorf("remove adoption probe: %w", err)
+	}
+	return nil
+}

--- a/apps/backend/internal/system/storage/gocache/provider.go
+++ b/apps/backend/internal/system/storage/gocache/provider.go
@@ -322,6 +322,24 @@ func markerPath(cachePath string) string {
 // rotation. Managed caches must contain only their bound ownership marker;
 // adopted caches must be completely empty.
 func RemoveRestorePlaceholder(cachePath string, adopted bool) (bool, error) {
+	placeholder, err := IsRestorePlaceholder(cachePath, adopted)
+	if err != nil || !placeholder {
+		return placeholder, err
+	}
+	if !adopted {
+		if err := os.Remove(markerPath(cachePath)); err != nil {
+			return false, fmt.Errorf("remove Go-cache restore marker: %w", err)
+		}
+	}
+	if err := os.Remove(cachePath); err != nil {
+		return false, fmt.Errorf("remove Go-cache restore placeholder: %w", err)
+	}
+	return true, nil
+}
+
+// IsRestorePlaceholder reports whether cachePath is the empty replacement
+// created after a cache rotation, without modifying it.
+func IsRestorePlaceholder(cachePath string, adopted bool) (bool, error) {
 	info, err := os.Lstat(cachePath)
 	if err != nil {
 		return false, err
@@ -334,21 +352,9 @@ func RemoveRestorePlaceholder(cachePath string, adopted bool) (bool, error) {
 		return false, fmt.Errorf("inspect Go-cache restore placeholder: %w", err)
 	}
 	if adopted {
-		if len(entries) != 0 {
-			return false, nil
-		}
-	} else if len(entries) != 1 || entries[0].Name() != markerName || !hasValidMarker(cachePath) {
-		return false, nil
+		return len(entries) == 0, nil
 	}
-	if !adopted {
-		if err := os.Remove(markerPath(cachePath)); err != nil {
-			return false, fmt.Errorf("remove Go-cache restore marker: %w", err)
-		}
-	}
-	if err := os.Remove(cachePath); err != nil {
-		return false, fmt.Errorf("remove Go-cache restore placeholder: %w", err)
-	}
-	return true, nil
+	return len(entries) == 1 && entries[0].Name() == markerName && hasValidMarker(cachePath), nil
 }
 
 func (p *Provider) validateCachePath(cachePath string) error {
@@ -377,7 +383,7 @@ func (p *Provider) validateCacheAndTrash(cachePath string) error {
 }
 
 func rejectSymlink(path string) error {
-	info, err := os.Lstat(path)
+	info, err := os.Lstat(path) // codeql[go/path-injection] path is constrained by ValidateNoSymlinkPath.
 	if errors.Is(err, os.ErrNotExist) {
 		return nil
 	}
@@ -439,7 +445,7 @@ func startsWithParent(rel string) bool {
 }
 
 func probeAtomicRename(cachePath, trashRoot string) error {
-	if err := os.MkdirAll(trashRoot, 0o700); err != nil {
+	if err := os.MkdirAll(trashRoot, 0o700); err != nil { // codeql[go/path-injection] validated by validateCacheAndTrash.
 		return fmt.Errorf("create Go-cache trash: %w", err)
 	}
 	probe, err := os.CreateTemp(cachePath, ".kandev-adoption-probe-")

--- a/apps/backend/internal/system/storage/gocache/provider.go
+++ b/apps/backend/internal/system/storage/gocache/provider.go
@@ -35,6 +35,7 @@ type SettingsSource interface {
 type QuarantineStore interface {
 	CreateQuarantineEntry(ctx context.Context, entry *storage.QuarantineEntry) error
 	TransitionQuarantineEntry(ctx context.Context, id string, next storage.QuarantineState, lastError string) (storage.QuarantineEntry, error)
+	ListQuarantineEntries(ctx context.Context, includeTerminal bool) ([]storage.QuarantineEntry, error)
 }
 
 // Config contains the provider's install-owned paths and persistence dependencies.
@@ -242,6 +243,11 @@ func (p *Provider) rotate(
 	if err := os.MkdirAll(quarantineDir, 0o700); err != nil {
 		return nil, fmt.Errorf("create Go-cache trash: %w", err)
 	}
+	if _, err := storage.ReleaseFailedQuarantineIntent(
+		ctx, p.config.Store, storage.ResourceTypeGoCache, cachePath,
+	); err != nil {
+		return nil, err
+	}
 	now := time.Now().UTC()
 	id := uuid.NewString()
 	ownership := "managed"
@@ -282,7 +288,7 @@ func (p *Provider) rotate(
 }
 
 func writeMarker(cachePath string) error {
-	marker := filepath.Join(filepath.Dir(cachePath), markerName)
+	marker := markerPath(cachePath)
 	info, err := os.Lstat(marker)
 	if err == nil {
 		if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
@@ -299,13 +305,50 @@ func writeMarker(cachePath string) error {
 }
 
 func hasValidMarker(cachePath string) bool {
-	path := filepath.Join(filepath.Dir(cachePath), markerName)
+	path := markerPath(cachePath)
 	info, err := os.Lstat(path)
 	if err != nil || info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
 		return false
 	}
 	marker, err := os.ReadFile(path)
 	return err == nil && string(marker) == markerContent
+}
+
+func markerPath(cachePath string) string {
+	return filepath.Join(cachePath, markerName)
+}
+
+// RemoveRestorePlaceholder removes the empty cache directory recreated after
+// rotation. Managed caches must contain only their bound ownership marker;
+// adopted caches must be completely empty.
+func RemoveRestorePlaceholder(cachePath string, adopted bool) (bool, error) {
+	info, err := os.Lstat(cachePath)
+	if err != nil {
+		return false, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return false, nil
+	}
+	entries, err := os.ReadDir(cachePath)
+	if err != nil {
+		return false, fmt.Errorf("inspect Go-cache restore placeholder: %w", err)
+	}
+	if adopted {
+		if len(entries) != 0 {
+			return false, nil
+		}
+	} else if len(entries) != 1 || entries[0].Name() != markerName || !hasValidMarker(cachePath) {
+		return false, nil
+	}
+	if !adopted {
+		if err := os.Remove(markerPath(cachePath)); err != nil {
+			return false, fmt.Errorf("remove Go-cache restore marker: %w", err)
+		}
+	}
+	if err := os.Remove(cachePath); err != nil {
+		return false, fmt.Errorf("remove Go-cache restore placeholder: %w", err)
+	}
+	return true, nil
 }
 
 func (p *Provider) validateCachePath(cachePath string) error {
@@ -357,12 +400,15 @@ func directorySize(root string) (int64, error) {
 		return 0, fmt.Errorf("inspect Go-cache path: %w", err)
 	}
 	var total int64
-	err := filepath.WalkDir(root, func(_ string, entry fs.DirEntry, walkErr error) error {
+	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
 		}
 		if entry.Type()&os.ModeSymlink != 0 {
 			return fmt.Errorf("symlink found in Go cache: %s", entry.Name())
+		}
+		if path == markerPath(root) {
+			return nil
 		}
 		if entry.Type().IsRegular() {
 			info, err := entry.Info()

--- a/apps/backend/internal/system/storage/gocache/provider_test.go
+++ b/apps/backend/internal/system/storage/gocache/provider_test.go
@@ -534,6 +534,13 @@ func TestAdoptedCacheCanBeRotatedWithoutManagedMarker(t *testing.T) {
 	if err := provider.ValidateAdoption(context.Background(), cachePath, "ADOPT"); err != nil {
 		t.Fatalf("ValidateAdoption() error = %v", err)
 	}
+	entries, err := os.ReadDir(cachePath)
+	if err != nil {
+		t.Fatalf("read cache after adoption validation: %v", err)
+	}
+	if len(entries) != 1 || entries[0].Name() != "artifact" {
+		t.Fatalf("cache after adoption validation = %v, want only artifact", entries)
+	}
 
 	result, err := provider.Cleanup(context.Background())
 	if err != nil {

--- a/apps/backend/internal/system/storage/gocache/provider_test.go
+++ b/apps/backend/internal/system/storage/gocache/provider_test.go
@@ -1,0 +1,434 @@
+package gocache
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kandev/kandev/internal/system/storage"
+)
+
+func TestAnalysisJSONUsesStorageAPISnakeCase(t *testing.T) {
+	encoded, err := json.Marshal(Analysis{Path: "/cache", SizeBytes: 42, Owned: true, Enabled: false})
+	if err != nil {
+		t.Fatalf("Marshal Analysis: %v", err)
+	}
+	want := `{"path":"/cache","size_bytes":42,"owned":true,"enabled":false}`
+	if string(encoded) != want {
+		t.Fatalf("Analysis JSON = %s, want %s", encoded, want)
+	}
+}
+
+func TestCleanupResultJSONUsesStorageAPISnakeCase(t *testing.T) {
+	encoded, err := json.Marshal(CleanupResult{
+		Path: "/cache", BytesBefore: 100, BytesAfter: 20, ReclaimedBytes: 80,
+	})
+	if err != nil {
+		t.Fatalf("Marshal CleanupResult: %v", err)
+	}
+	want := `{"path":"/cache","bytes_before":100,"bytes_after":20,"reclaimed_bytes":80,"quarantine_entry":null}`
+	if string(encoded) != want {
+		t.Fatalf("CleanupResult JSON = %s, want %s", encoded, want)
+	}
+}
+
+type recordingStore struct {
+	created    *storage.QuarantineEntry
+	createErr  error
+	transition storage.QuarantineState
+}
+
+func (s *recordingStore) CreateQuarantineEntry(_ context.Context, entry *storage.QuarantineEntry) error {
+	if s.createErr != nil {
+		return s.createErr
+	}
+	copy := *entry
+	s.created = &copy
+	return nil
+}
+
+func (s *recordingStore) TransitionQuarantineEntry(
+	_ context.Context,
+	_ string,
+	next storage.QuarantineState,
+	_ string,
+) (storage.QuarantineEntry, error) {
+	s.transition = next
+	return storage.QuarantineEntry{}, nil
+}
+
+type staticSettings struct {
+	settings storage.StorageMaintenanceSettings
+}
+
+func (s staticSettings) GetSettings(context.Context) (storage.StorageMaintenanceSettings, error) {
+	return s.settings, nil
+}
+
+func TestExecutionEnvironmentCreatesOwnedManagedCache(t *testing.T) {
+	home := t.TempDir()
+	settings := storage.DefaultSettings()
+	settings.GoCache.Enabled = true
+	settings.GoCache.MaxBytes = 1
+	provider := New(Config{
+		HomeDir:  home,
+		TrashDir: filepath.Join(home, "trash"),
+		Settings: staticSettings{settings: settings},
+	})
+
+	env, err := provider.ExecutionEnvironment(context.Background())
+	if err != nil {
+		t.Fatalf("ExecutionEnvironment() error = %v", err)
+	}
+	want := filepath.Join(home, "cache", "go-build")
+	if got := env["GOCACHE"]; got != want {
+		t.Fatalf("GOCACHE = %q, want %q", got, want)
+	}
+	if info, err := os.Stat(want); err != nil || !info.IsDir() {
+		t.Fatalf("managed cache directory was not created: info=%v err=%v", info, err)
+	}
+	if _, err := os.Stat(filepath.Join(filepath.Dir(want), ".go-build.kandev-owned")); err != nil {
+		t.Fatalf("ownership marker was not created: %v", err)
+	}
+}
+
+func TestCleanupRotatesOwnedCacheAboveThreshold(t *testing.T) {
+	home := t.TempDir()
+	settings := storage.DefaultSettings()
+	settings.GoCache.Enabled = true
+	settings.GoCache.MaxBytes = 1
+	store := &recordingStore{}
+	provider := New(Config{
+		HomeDir:  home,
+		TrashDir: filepath.Join(home, "trash"),
+		Settings: staticSettings{settings: settings},
+		Store:    store,
+	})
+	env, err := provider.ExecutionEnvironment(context.Background())
+	if err != nil {
+		t.Fatalf("ExecutionEnvironment() error = %v", err)
+	}
+	cachePath := env["GOCACHE"]
+	if err := os.WriteFile(filepath.Join(cachePath, "artifact"), []byte("1234"), 0o600); err != nil {
+		t.Fatalf("seed cache: %v", err)
+	}
+
+	result, err := provider.Cleanup(context.Background())
+	if err != nil {
+		t.Fatalf("Cleanup() error = %v", err)
+	}
+	if result.ReclaimedBytes != 4 {
+		t.Fatalf("ReclaimedBytes = %d, want 4", result.ReclaimedBytes)
+	}
+	if _, err := os.Stat(filepath.Join(cachePath, "artifact")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("old cache artifact still exists: %v", err)
+	}
+	if info, err := os.Stat(cachePath); err != nil || !info.IsDir() || info.Mode().Perm()&0o200 == 0 {
+		t.Fatalf("replacement cache is not writable: info=%v err=%v", info, err)
+	}
+	if store.created == nil || store.created.SizeBytes != 4 {
+		t.Fatalf("quarantine intent = %#v, want 4-byte entry", store.created)
+	}
+	if _, err := os.Stat(filepath.Join(store.created.QuarantinePath, "artifact")); err != nil {
+		t.Fatalf("quarantined artifact missing: %v", err)
+	}
+}
+
+func TestCleanupNeverClaimsUnmarkedManagedPath(t *testing.T) {
+	home := t.TempDir()
+	cachePath := filepath.Join(home, "cache", "go-build")
+	if err := os.MkdirAll(cachePath, 0o755); err != nil {
+		t.Fatalf("create cache: %v", err)
+	}
+	artifact := filepath.Join(cachePath, "artifact")
+	if err := os.WriteFile(artifact, []byte("1234"), 0o600); err != nil {
+		t.Fatalf("seed cache: %v", err)
+	}
+	settings := storage.DefaultSettings()
+	settings.GoCache.Enabled = true
+	settings.GoCache.MaxBytes = 1
+	provider := New(Config{
+		HomeDir:  home,
+		TrashDir: filepath.Join(home, "trash"),
+		Settings: staticSettings{settings: settings},
+		Store:    &recordingStore{},
+	})
+
+	_, err := provider.Cleanup(context.Background())
+	if !errors.Is(err, ErrNotOwned) {
+		t.Fatalf("Cleanup() error = %v, want ErrNotOwned", err)
+	}
+	if _, err := os.Stat(artifact); err != nil {
+		t.Fatalf("unowned cache was modified: %v", err)
+	}
+}
+
+func TestCleanupRejectsSymlinkedManagedCacheAncestor(t *testing.T) {
+	home := t.TempDir()
+	external := t.TempDir()
+	externalCache := filepath.Join(external, "go-build")
+	if err := os.MkdirAll(externalCache, 0o755); err != nil {
+		t.Fatalf("create external cache: %v", err)
+	}
+	artifact := filepath.Join(externalCache, "artifact")
+	if err := os.WriteFile(artifact, []byte("leave external data"), 0o600); err != nil {
+		t.Fatalf("seed external cache: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(external, markerName), []byte(markerContent), 0o600); err != nil {
+		t.Fatalf("seed external marker: %v", err)
+	}
+	if err := os.Symlink(external, filepath.Join(home, "cache")); err != nil {
+		t.Fatalf("symlink cache ancestor: %v", err)
+	}
+	settings := storage.DefaultSettings()
+	settings.GoCache.Enabled = true
+	settings.GoCache.MaxBytes = 1
+	store := &recordingStore{}
+	provider := New(Config{
+		HomeDir: home, TrashDir: filepath.Join(home, "trash"),
+		Settings: staticSettings{settings: settings}, Store: store,
+	})
+
+	if _, err := provider.Cleanup(context.Background()); err == nil {
+		t.Fatal("Cleanup succeeded through a symlinked managed-cache ancestor")
+	}
+	if data, err := os.ReadFile(artifact); err != nil || string(data) != "leave external data" {
+		t.Fatalf("external cache changed: data=%q err=%v", data, err)
+	}
+	if store.created != nil {
+		t.Fatalf("quarantine intent persisted for unsafe cache: %#v", store.created)
+	}
+}
+
+func TestCleanupRejectsSymlinkedTrashAncestor(t *testing.T) {
+	home := t.TempDir()
+	external := t.TempDir()
+	trashLink := filepath.Join(home, "trash-link")
+	if err := os.Symlink(external, trashLink); err != nil {
+		t.Fatalf("symlink trash ancestor: %v", err)
+	}
+	settings := storage.DefaultSettings()
+	settings.GoCache.Enabled = true
+	settings.GoCache.MaxBytes = 1
+	store := &recordingStore{}
+	provider := New(Config{
+		HomeDir: home, TrashDir: filepath.Join(trashLink, "nested"),
+		Settings: staticSettings{settings: settings}, Store: store,
+	})
+	env, err := provider.ExecutionEnvironment(context.Background())
+	if err != nil {
+		t.Fatalf("ExecutionEnvironment() error = %v", err)
+	}
+	artifact := filepath.Join(env["GOCACHE"], "artifact")
+	if err := os.WriteFile(artifact, []byte("keep cache"), 0o600); err != nil {
+		t.Fatalf("seed cache: %v", err)
+	}
+
+	if _, err := provider.Cleanup(context.Background()); err == nil {
+		t.Fatal("Cleanup succeeded through a symlinked trash ancestor")
+	}
+	if data, err := os.ReadFile(artifact); err != nil || string(data) != "keep cache" {
+		t.Fatalf("cache changed despite unsafe trash: data=%q err=%v", data, err)
+	}
+	if store.created != nil {
+		t.Fatalf("quarantine intent persisted for unsafe trash: %#v", store.created)
+	}
+	if _, err := os.Stat(filepath.Join(external, "nested")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("external trash target changed: %v", err)
+	}
+}
+
+func TestCleanupRejectsSymlinkedOwnershipMarker(t *testing.T) {
+	home := t.TempDir()
+	cachePath := filepath.Join(home, "cache", "go-build")
+	if err := os.MkdirAll(cachePath, 0o755); err != nil {
+		t.Fatalf("create cache: %v", err)
+	}
+	artifact := filepath.Join(cachePath, "artifact")
+	if err := os.WriteFile(artifact, []byte("keep cache"), 0o600); err != nil {
+		t.Fatalf("seed cache: %v", err)
+	}
+	externalMarker := filepath.Join(t.TempDir(), "marker")
+	if err := os.WriteFile(externalMarker, []byte(markerContent), 0o600); err != nil {
+		t.Fatalf("seed external marker: %v", err)
+	}
+	if err := os.Symlink(externalMarker, filepath.Join(filepath.Dir(cachePath), markerName)); err != nil {
+		t.Fatalf("symlink ownership marker: %v", err)
+	}
+	settings := storage.DefaultSettings()
+	settings.GoCache.Enabled = true
+	settings.GoCache.MaxBytes = 1
+	store := &recordingStore{}
+	provider := New(Config{
+		HomeDir: home, TrashDir: filepath.Join(home, "trash"),
+		Settings: staticSettings{settings: settings}, Store: store,
+	})
+
+	if _, err := provider.Cleanup(context.Background()); !errors.Is(err, ErrNotOwned) {
+		t.Fatalf("Cleanup() error = %v, want ErrNotOwned", err)
+	}
+	if data, err := os.ReadFile(artifact); err != nil || string(data) != "keep cache" {
+		t.Fatalf("cache changed despite symlinked marker: data=%q err=%v", data, err)
+	}
+	if store.created != nil {
+		t.Fatalf("quarantine intent persisted for symlinked marker: %#v", store.created)
+	}
+}
+
+func TestCleanupPersistsIntentBeforeRename(t *testing.T) {
+	home := t.TempDir()
+	settings := storage.DefaultSettings()
+	settings.GoCache.Enabled = true
+	settings.GoCache.MaxBytes = 1
+	storeErr := errors.New("database unavailable")
+	provider := New(Config{
+		HomeDir:  home,
+		TrashDir: filepath.Join(home, "trash"),
+		Settings: staticSettings{settings: settings},
+		Store:    &recordingStore{createErr: storeErr},
+	})
+	env, err := provider.ExecutionEnvironment(context.Background())
+	if err != nil {
+		t.Fatalf("ExecutionEnvironment() error = %v", err)
+	}
+	artifact := filepath.Join(env["GOCACHE"], "artifact")
+	if err := os.WriteFile(artifact, []byte("1234"), 0o600); err != nil {
+		t.Fatalf("seed cache: %v", err)
+	}
+
+	_, err = provider.Cleanup(context.Background())
+	if !errors.Is(err, storeErr) {
+		t.Fatalf("Cleanup() error = %v, want wrapped store error", err)
+	}
+	if _, err := os.Stat(artifact); err != nil {
+		t.Fatalf("cache moved before intent persisted: %v", err)
+	}
+}
+
+func TestDisabledEnvironmentDoesNotDeleteExistingManagedCache(t *testing.T) {
+	home := t.TempDir()
+	settings := storage.DefaultSettings()
+	settings.GoCache.Enabled = true
+	settings.GoCache.MaxBytes = 1
+	provider := New(Config{
+		HomeDir:  home,
+		TrashDir: filepath.Join(home, "trash"),
+		Settings: staticSettings{settings: settings},
+		Store:    &recordingStore{},
+	})
+	env, err := provider.ExecutionEnvironment(context.Background())
+	if err != nil {
+		t.Fatalf("ExecutionEnvironment() error = %v", err)
+	}
+	artifact := filepath.Join(env["GOCACHE"], "artifact")
+	if err := os.WriteFile(artifact, []byte("keep"), 0o600); err != nil {
+		t.Fatalf("seed cache: %v", err)
+	}
+	settings.GoCache.Enabled = false
+	provider.config.Settings = staticSettings{settings: settings}
+
+	disabledEnv, err := provider.ExecutionEnvironment(context.Background())
+	if err != nil {
+		t.Fatalf("disabled ExecutionEnvironment() error = %v", err)
+	}
+	if _, exists := disabledEnv["GOCACHE"]; exists {
+		t.Fatalf("disabled environment injected GOCACHE: %#v", disabledEnv)
+	}
+	if _, err := provider.Cleanup(context.Background()); err != nil {
+		t.Fatalf("disabled Cleanup() error = %v", err)
+	}
+	if _, err := os.Stat(artifact); err != nil {
+		t.Fatalf("disabling the cache deleted existing data: %v", err)
+	}
+	result, err := provider.CleanupExplicit(context.Background())
+	if err != nil {
+		t.Fatalf("disabled CleanupExplicit() error = %v", err)
+	}
+	if result.ReclaimedBytes == 0 {
+		t.Fatalf("disabled CleanupExplicit() result = %#v, want reclaimed bytes", result)
+	}
+	if _, err := os.Stat(artifact); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("explicit cleanup left the managed cache artifact: %v", err)
+	}
+}
+
+func TestValidateAdoptionRequiresExplicitConfirmation(t *testing.T) {
+	home := t.TempDir()
+	cachePath := filepath.Join(home, "user-go-cache")
+	if err := os.Mkdir(cachePath, 0o755); err != nil {
+		t.Fatalf("create cache: %v", err)
+	}
+	provider := New(Config{HomeDir: home, TrashDir: filepath.Join(home, "trash")})
+
+	err := provider.ValidateAdoption(context.Background(), cachePath, "")
+	if !errors.Is(err, ErrAdoptionConfirmation) {
+		t.Fatalf("ValidateAdoption() error = %v, want ErrAdoptionConfirmation", err)
+	}
+}
+
+func TestAdoptedCacheCanBeRotatedWithoutManagedMarker(t *testing.T) {
+	home := t.TempDir()
+	cachePath := filepath.Join(home, "user-go-cache")
+	if err := os.Mkdir(cachePath, 0o755); err != nil {
+		t.Fatalf("create cache: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cachePath, "artifact"), []byte("1234"), 0o600); err != nil {
+		t.Fatalf("seed cache: %v", err)
+	}
+	settings := storage.DefaultSettings()
+	settings.GoCache.Enabled = true
+	settings.GoCache.MaxBytes = 1
+	settings.GoCache.AdoptedPath = cachePath
+	store := &recordingStore{}
+	provider := New(Config{
+		HomeDir:  home,
+		TrashDir: filepath.Join(home, "trash"),
+		Settings: staticSettings{settings: settings},
+		Store:    store,
+	})
+	if err := provider.ValidateAdoption(context.Background(), cachePath, "ADOPT"); err != nil {
+		t.Fatalf("ValidateAdoption() error = %v", err)
+	}
+
+	result, err := provider.Cleanup(context.Background())
+	if err != nil {
+		t.Fatalf("Cleanup() error = %v", err)
+	}
+	if result.ReclaimedBytes != 4 || store.created == nil {
+		t.Fatalf("adopted cleanup result=%#v entry=%#v", result, store.created)
+	}
+}
+
+func TestCleanupDoesNotDiscoverUserDefaultCache(t *testing.T) {
+	home := t.TempDir()
+	userCache := filepath.Join(t.TempDir(), ".cache", "go-build")
+	if err := os.MkdirAll(userCache, 0o755); err != nil {
+		t.Fatalf("create user cache: %v", err)
+	}
+	artifact := filepath.Join(userCache, "artifact")
+	if err := os.WriteFile(artifact, []byte("leave me"), 0o600); err != nil {
+		t.Fatalf("seed user cache: %v", err)
+	}
+	settings := storage.DefaultSettings()
+	settings.GoCache.Enabled = true
+	settings.GoCache.MaxBytes = 1
+	provider := New(Config{
+		HomeDir:  home,
+		TrashDir: filepath.Join(home, "trash"),
+		Settings: staticSettings{settings: settings},
+		Store:    &recordingStore{},
+	})
+	if _, err := provider.ExecutionEnvironment(context.Background()); err != nil {
+		t.Fatalf("ExecutionEnvironment() error = %v", err)
+	}
+
+	if _, err := provider.Cleanup(context.Background()); err != nil {
+		t.Fatalf("Cleanup() error = %v", err)
+	}
+	if _, err := os.Stat(artifact); err != nil {
+		t.Fatalf("unadopted user cache was modified: %v", err)
+	}
+}

--- a/apps/backend/internal/system/storage/gocache/provider_test.go
+++ b/apps/backend/internal/system/storage/gocache/provider_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"sort"
 	"testing"
 
 	"github.com/kandev/kandev/internal/system/storage"
@@ -91,6 +92,12 @@ func (s *recordingStore) ListQuarantineEntries(
 		}
 		entries = append(entries, entry)
 	}
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].QuarantinedAt.Equal(entries[j].QuarantinedAt) {
+			return entries[i].ID > entries[j].ID
+		}
+		return entries[i].QuarantinedAt.After(entries[j].QuarantinedAt)
+	})
 	return entries, nil
 }
 
@@ -565,5 +572,39 @@ func TestCleanupDoesNotDiscoverUserDefaultCache(t *testing.T) {
 	}
 	if _, err := os.Stat(artifact); err != nil {
 		t.Fatalf("unadopted user cache was modified: %v", err)
+	}
+}
+
+func TestIsRestorePlaceholderDoesNotModifyCache(t *testing.T) {
+	tests := []struct {
+		name    string
+		adopted bool
+	}{
+		{name: "managed"},
+		{name: "adopted", adopted: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cachePath := filepath.Join(t.TempDir(), "go-build")
+			if err := os.MkdirAll(cachePath, 0o700); err != nil {
+				t.Fatal(err)
+			}
+			if !test.adopted {
+				if err := writeMarker(cachePath); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			placeholder, err := IsRestorePlaceholder(cachePath, test.adopted)
+			if err != nil {
+				t.Fatalf("IsRestorePlaceholder: %v", err)
+			}
+			if !placeholder {
+				t.Fatal("expected rotation placeholder")
+			}
+			if _, err := os.Stat(cachePath); err != nil {
+				t.Fatalf("placeholder was modified: %v", err)
+			}
+		})
 	}
 }

--- a/apps/backend/internal/system/storage/gocache/provider_test.go
+++ b/apps/backend/internal/system/storage/gocache/provider_test.go
@@ -39,25 +39,59 @@ type recordingStore struct {
 	created    *storage.QuarantineEntry
 	createErr  error
 	transition storage.QuarantineState
+	entries    map[string]storage.QuarantineEntry
+	onCreate   func(*storage.QuarantineEntry)
 }
 
 func (s *recordingStore) CreateQuarantineEntry(_ context.Context, entry *storage.QuarantineEntry) error {
 	if s.createErr != nil {
 		return s.createErr
 	}
+	if s.entries == nil {
+		s.entries = make(map[string]storage.QuarantineEntry)
+	}
+	for _, existing := range s.entries {
+		if existing.OriginalPath == entry.OriginalPath &&
+			(existing.State == storage.QuarantineStateQuarantined || existing.State == storage.QuarantineStateFailed) {
+			return errors.New("duplicate active quarantine original path")
+		}
+	}
 	copy := *entry
 	s.created = &copy
+	s.entries[entry.ID] = copy
+	if s.onCreate != nil {
+		s.onCreate(&copy)
+	}
 	return nil
 }
 
 func (s *recordingStore) TransitionQuarantineEntry(
 	_ context.Context,
-	_ string,
+	id string,
 	next storage.QuarantineState,
-	_ string,
+	lastError string,
 ) (storage.QuarantineEntry, error) {
 	s.transition = next
-	return storage.QuarantineEntry{}, nil
+	entry := s.entries[id]
+	entry.State = next
+	entry.LastError = lastError
+	s.entries[id] = entry
+	return entry, nil
+}
+
+func (s *recordingStore) ListQuarantineEntries(
+	_ context.Context,
+	includeTerminal bool,
+) ([]storage.QuarantineEntry, error) {
+	entries := make([]storage.QuarantineEntry, 0, len(s.entries))
+	for _, entry := range s.entries {
+		if !includeTerminal && entry.State != storage.QuarantineStateQuarantined &&
+			entry.State != storage.QuarantineStateFailed {
+			continue
+		}
+		entries = append(entries, entry)
+	}
+	return entries, nil
 }
 
 type staticSettings struct {
@@ -90,7 +124,7 @@ func TestExecutionEnvironmentCreatesOwnedManagedCache(t *testing.T) {
 	if info, err := os.Stat(want); err != nil || !info.IsDir() {
 		t.Fatalf("managed cache directory was not created: info=%v err=%v", info, err)
 	}
-	if _, err := os.Stat(filepath.Join(filepath.Dir(want), ".go-build.kandev-owned")); err != nil {
+	if _, err := os.Stat(filepath.Join(want, markerName)); err != nil {
 		t.Fatalf("ownership marker was not created: %v", err)
 	}
 }
@@ -166,6 +200,44 @@ func TestCleanupNeverClaimsUnmarkedManagedPath(t *testing.T) {
 	}
 }
 
+func TestCleanupDoesNotClaimReplacementDirectoryFromStaleMarker(t *testing.T) {
+	home := t.TempDir()
+	settings := storage.DefaultSettings()
+	settings.GoCache.Enabled = true
+	settings.GoCache.MaxBytes = 1
+	store := &recordingStore{}
+	provider := New(Config{
+		HomeDir: home, TrashDir: filepath.Join(home, "trash"),
+		Settings: staticSettings{settings: settings}, Store: store,
+	})
+	env, err := provider.ExecutionEnvironment(context.Background())
+	if err != nil {
+		t.Fatalf("ExecutionEnvironment() error = %v", err)
+	}
+	cachePath := env["GOCACHE"]
+	if err := os.RemoveAll(cachePath); err != nil {
+		t.Fatalf("replace managed cache: %v", err)
+	}
+	if err := os.MkdirAll(cachePath, 0o755); err != nil {
+		t.Fatalf("create replacement cache: %v", err)
+	}
+	artifact := filepath.Join(cachePath, "unrelated")
+	if err := os.WriteFile(artifact, []byte("keep"), 0o600); err != nil {
+		t.Fatalf("seed replacement cache: %v", err)
+	}
+
+	_, err = provider.Cleanup(context.Background())
+	if !errors.Is(err, ErrNotOwned) {
+		t.Fatalf("Cleanup() error = %v, want ErrNotOwned", err)
+	}
+	if data, err := os.ReadFile(artifact); err != nil || string(data) != "keep" {
+		t.Fatalf("replacement cache changed: data=%q err=%v", data, err)
+	}
+	if store.created != nil {
+		t.Fatalf("replacement cache was quarantined: %#v", store.created)
+	}
+}
+
 func TestCleanupRejectsSymlinkedManagedCacheAncestor(t *testing.T) {
 	home := t.TempDir()
 	external := t.TempDir()
@@ -177,7 +249,7 @@ func TestCleanupRejectsSymlinkedManagedCacheAncestor(t *testing.T) {
 	if err := os.WriteFile(artifact, []byte("leave external data"), 0o600); err != nil {
 		t.Fatalf("seed external cache: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(external, markerName), []byte(markerContent), 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(externalCache, markerName), []byte(markerContent), 0o600); err != nil {
 		t.Fatalf("seed external marker: %v", err)
 	}
 	if err := os.Symlink(external, filepath.Join(home, "cache")); err != nil {
@@ -255,7 +327,7 @@ func TestCleanupRejectsSymlinkedOwnershipMarker(t *testing.T) {
 	if err := os.WriteFile(externalMarker, []byte(markerContent), 0o600); err != nil {
 		t.Fatalf("seed external marker: %v", err)
 	}
-	if err := os.Symlink(externalMarker, filepath.Join(filepath.Dir(cachePath), markerName)); err != nil {
+	if err := os.Symlink(externalMarker, filepath.Join(cachePath, markerName)); err != nil {
 		t.Fatalf("symlink ownership marker: %v", err)
 	}
 	settings := storage.DefaultSettings()
@@ -305,6 +377,69 @@ func TestCleanupPersistsIntentBeforeRename(t *testing.T) {
 	}
 	if _, err := os.Stat(artifact); err != nil {
 		t.Fatalf("cache moved before intent persisted: %v", err)
+	}
+}
+
+func TestCleanupRetriesFailedGoCacheIntentWhenMoveNeverHappened(t *testing.T) {
+	home := t.TempDir()
+	settings := storage.DefaultSettings()
+	settings.GoCache.Enabled = true
+	settings.GoCache.MaxBytes = 1
+	store := &recordingStore{}
+	var firstID string
+	store.onCreate = func(entry *storage.QuarantineEntry) {
+		if firstID != "" {
+			return
+		}
+		firstID = entry.ID
+		if err := os.MkdirAll(entry.QuarantinePath, 0o700); err != nil {
+			t.Fatalf("create blocked quarantine: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(entry.QuarantinePath, "blocker"), []byte("block"), 0o600); err != nil {
+			t.Fatalf("write quarantine blocker: %v", err)
+		}
+	}
+	provider := New(Config{
+		HomeDir: home, TrashDir: filepath.Join(home, "trash"),
+		Settings: staticSettings{settings: settings}, Store: store,
+	})
+	env, err := provider.ExecutionEnvironment(context.Background())
+	if err != nil {
+		t.Fatalf("ExecutionEnvironment() error = %v", err)
+	}
+	artifact := filepath.Join(env["GOCACHE"], "artifact")
+	if err := os.WriteFile(artifact, []byte("1234"), 0o600); err != nil {
+		t.Fatalf("seed cache: %v", err)
+	}
+
+	if _, err := provider.Cleanup(context.Background()); err == nil {
+		t.Fatal("first Cleanup succeeded despite blocked quarantine destination")
+	}
+	if got := store.entries[firstID].State; got != storage.QuarantineStateFailed {
+		t.Fatalf("first intent state = %q, want failed", got)
+	}
+	if _, err := provider.Cleanup(context.Background()); !errors.Is(err, storage.ErrConflict) {
+		t.Fatalf("ambiguous retry error = %v, want ErrConflict", err)
+	}
+	if got := store.entries[firstID].State; got != storage.QuarantineStateFailed {
+		t.Fatalf("ambiguous intent state = %q, want failed", got)
+	}
+	if err := os.RemoveAll(store.entries[firstID].QuarantinePath); err != nil {
+		t.Fatalf("remove quarantine blocker: %v", err)
+	}
+
+	result, err := provider.Cleanup(context.Background())
+	if err != nil {
+		t.Fatalf("retry Cleanup: %v", err)
+	}
+	if result.QuarantineEntry == nil || result.QuarantineEntry.ID == firstID {
+		t.Fatalf("retry result = %#v, want fresh quarantine intent", result)
+	}
+	if got := store.entries[firstID].State; got != storage.QuarantineStateRestored {
+		t.Fatalf("released intent state = %q, want restored", got)
+	}
+	if _, err := os.Stat(artifact); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("retry left original cache artifact: %v", err)
 	}
 }
 

--- a/apps/backend/internal/system/storage/handler.go
+++ b/apps/backend/internal/system/storage/handler.go
@@ -237,7 +237,12 @@ func (h *Handler) patchSettings(c *gin.Context) {
 		SaveConfirmations{DedicatedDocker: request.Confirmations.DedicatedDocker == "DEDICATED"},
 	)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		if errors.Is(err, ErrValidation) || errors.Is(err, ErrAdoptionRequired) ||
+			errors.Is(err, ErrDedicatedDockerConfirmation) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to save storage settings"})
 		return
 	}
 	if h.config.OnSettingsChanged != nil {

--- a/apps/backend/internal/system/storage/handler.go
+++ b/apps/backend/internal/system/storage/handler.go
@@ -1,0 +1,247 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+)
+
+type SettingsManager interface {
+	GetSettings(context.Context) (StorageMaintenanceSettings, error)
+	SaveSettingsWithConfirmations(context.Context, StorageMaintenanceSettings, SaveConfirmations) (StorageMaintenanceSettings, error)
+}
+
+type RunLister interface {
+	ListRuns(context.Context, int) ([]MaintenanceRun, error)
+}
+
+type QuarantineLister interface {
+	ListQuarantineEntries(context.Context, bool) ([]QuarantineEntry, error)
+}
+
+type Mutations interface {
+	AdoptGoCache(context.Context, string, string) (StorageMaintenanceSettings, Capabilities, error)
+	Analyze(context.Context) (string, error)
+	RunNow(context.Context, []string) (string, error)
+	RestoreQuarantine(context.Context, string) (QuarantineEntry, error)
+	DeleteQuarantine(context.Context, string, string) (string, error)
+}
+
+type Capabilities struct {
+	ManagedGoCachePath       string `json:"managed_go_cache_path"`
+	GoCacheAdoptionAvailable bool   `json:"go_cache_adoption_available"`
+	DockerAvailable          bool   `json:"docker_available"`
+	DockerHost               string `json:"docker_host"`
+	HostGlobalDockerCleanup  bool   `json:"host_global_docker_cleanup_allowed"`
+}
+
+type Summary struct {
+	Workspaces any `json:"workspaces"`
+	GoCache    any `json:"go_cache"`
+	Quarantine any `json:"quarantine"`
+	Docker     any `json:"docker"`
+}
+
+type QuarantineSummary struct {
+	Count     int   `json:"count" db:"count"`
+	SizeBytes int64 `json:"size_bytes" db:"size_bytes"`
+}
+
+type OverviewProvider interface {
+	Summary(context.Context) (Summary, error)
+	Capabilities(context.Context, StorageMaintenanceSettings) Capabilities
+}
+
+type HandlerConfig struct {
+	Settings          SettingsManager
+	Runs              RunLister
+	Quarantine        QuarantineLister
+	Overview          OverviewProvider
+	Mutations         Mutations
+	OnSettingsChanged func(StorageMaintenanceSettings)
+}
+
+type Handler struct {
+	config HandlerConfig
+}
+
+func NewHandler(config HandlerConfig) *Handler {
+	return &Handler{config: config}
+}
+
+func RegisterRoutes(group *gin.RouterGroup, handler *Handler) {
+	group.GET("/storage", handler.getStorage)
+	group.PATCH("/storage/settings", handler.patchSettings)
+	group.POST("/storage/go-cache/adopt", handler.adoptGoCache)
+	group.POST("/storage/analyze", handler.analyze)
+	group.POST("/storage/run", handler.runNow)
+	group.GET("/storage/runs", handler.listRuns)
+	group.GET("/storage/quarantine", handler.listQuarantine)
+	group.POST("/storage/quarantine/:id/restore", handler.restoreQuarantine)
+	group.DELETE("/storage/quarantine/:id", handler.deleteQuarantine)
+}
+
+func (h *Handler) listRuns(c *gin.Context) {
+	limit, _ := strconv.Atoi(c.DefaultQuery("limit", "20"))
+	runs, err := h.config.Runs.ListRuns(c.Request.Context(), limit)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"runs": runs})
+}
+
+func (h *Handler) listQuarantine(c *gin.Context) {
+	entries, err := h.config.Quarantine.ListQuarantineEntries(c.Request.Context(), false)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"entries": entries})
+}
+
+type adoptRequest struct {
+	Path    string `json:"path" binding:"required"`
+	Confirm string `json:"confirm" binding:"required"`
+}
+
+func (h *Handler) adoptGoCache(c *gin.Context) {
+	var request adoptRequest
+	if err := c.ShouldBindJSON(&request); err != nil || request.Confirm != "ADOPT" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Go-cache adoption requires ADOPT confirmation"})
+		return
+	}
+	settings, capabilities, err := h.config.Mutations.AdoptGoCache(c.Request.Context(), request.Path, request.Confirm)
+	if err != nil {
+		writeMutationError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"settings": settings, "capabilities": capabilities})
+}
+
+type runRequest struct {
+	Resources []string `json:"resources"`
+}
+
+func (h *Handler) analyze(c *gin.Context) {
+	id, err := h.config.Mutations.Analyze(c.Request.Context())
+	writeAcceptedJob(c, id, err)
+}
+
+func (h *Handler) runNow(c *gin.Context) {
+	var request runRequest
+	if c.Request.ContentLength > 0 {
+		if err := c.ShouldBindJSON(&request); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+	}
+	id, err := h.config.Mutations.RunNow(c.Request.Context(), request.Resources)
+	var busy *BusyError
+	if errors.As(err, &busy) {
+		c.JSON(http.StatusConflict, gin.H{"error": busy.Error(), "busy_resources": busy.Resources})
+		return
+	}
+	writeAcceptedJob(c, id, err)
+}
+
+func (h *Handler) restoreQuarantine(c *gin.Context) {
+	entry, err := h.config.Mutations.RestoreQuarantine(c.Request.Context(), c.Param("id"))
+	if err != nil {
+		writeMutationError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"entry": entry})
+}
+
+type confirmationRequest struct {
+	Confirm string `json:"confirm" binding:"required"`
+}
+
+func (h *Handler) deleteQuarantine(c *gin.Context) {
+	var request confirmationRequest
+	if err := c.ShouldBindJSON(&request); err != nil || request.Confirm != "DELETE" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "quarantine deletion requires DELETE confirmation"})
+		return
+	}
+	id, err := h.config.Mutations.DeleteQuarantine(c.Request.Context(), c.Param("id"), request.Confirm)
+	writeAcceptedJob(c, id, err)
+}
+
+func writeAcceptedJob(c *gin.Context, id string, err error) {
+	if err != nil {
+		writeMutationError(c, err)
+		return
+	}
+	c.JSON(http.StatusAccepted, gin.H{"job_id": id})
+}
+
+func writeMutationError(c *gin.Context, err error) {
+	status := http.StatusInternalServerError
+	switch {
+	case errors.Is(err, ErrValidation), errors.Is(err, ErrAdoptionRequired),
+		errors.Is(err, ErrDedicatedDockerConfirmation):
+		status = http.StatusBadRequest
+	case errors.Is(err, ErrNotFound):
+		status = http.StatusNotFound
+	case errors.Is(err, ErrConflict):
+		status = http.StatusConflict
+	}
+	c.JSON(status, gin.H{"error": err.Error()})
+}
+
+func (h *Handler) getStorage(c *gin.Context) {
+	settings, err := h.config.Settings.GetSettings(c.Request.Context())
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	summary, err := h.config.Overview.Summary(c.Request.Context())
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	runs, err := h.config.Runs.ListRuns(c.Request.Context(), 1)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	var lastRun *MaintenanceRun
+	if len(runs) > 0 {
+		lastRun = &runs[0]
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"settings": settings, "capabilities": h.config.Overview.Capabilities(c.Request.Context(), settings),
+		"summary": summary, "last_run": lastRun,
+	})
+}
+
+type patchSettingsRequest struct {
+	Settings      StorageMaintenanceSettings `json:"settings" binding:"required"`
+	Confirmations struct {
+		DedicatedDocker string `json:"dedicated_docker"`
+	} `json:"confirmations"`
+}
+
+func (h *Handler) patchSettings(c *gin.Context) {
+	var request patchSettingsRequest
+	if err := c.ShouldBindJSON(&request); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	saved, err := h.config.Settings.SaveSettingsWithConfirmations(
+		c.Request.Context(), request.Settings,
+		SaveConfirmations{DedicatedDocker: request.Confirmations.DedicatedDocker == "DEDICATED"},
+	)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if h.config.OnSettingsChanged != nil {
+		h.config.OnSettingsChanged(saved)
+	}
+	c.JSON(http.StatusOK, gin.H{"settings": saved})
+}

--- a/apps/backend/internal/system/storage/handler_test.go
+++ b/apps/backend/internal/system/storage/handler_test.go
@@ -1,0 +1,54 @@
+package storage
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestPatchSettingsHidesInternalSaveFailure(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	group := router.Group("/api/v1/system")
+	RegisterRoutes(group, NewHandler(HandlerConfig{
+		Settings: failingSettingsManager{err: errors.New("database credentials leaked")},
+	}))
+	body, err := json.Marshal(map[string]any{"settings": DefaultSettings()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := httptest.NewRequest(
+		http.MethodPatch, "/api/v1/system/storage/settings", bytes.NewReader(body),
+	)
+	request.Header.Set("Content-Type", "application/json")
+	response := httptest.NewRecorder()
+	router.ServeHTTP(response, request)
+
+	if response.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", response.Code)
+	}
+	if strings.Contains(response.Body.String(), "credentials") {
+		t.Fatalf("response exposed internal failure: %s", response.Body.String())
+	}
+}
+
+type failingSettingsManager struct{ err error }
+
+func (f failingSettingsManager) GetSettings(context.Context) (StorageMaintenanceSettings, error) {
+	return DefaultSettings(), nil
+}
+
+func (f failingSettingsManager) SaveSettingsWithConfirmations(
+	context.Context,
+	StorageMaintenanceSettings,
+	SaveConfirmations,
+) (StorageMaintenanceSettings, error) {
+	return StorageMaintenanceSettings{}, f.err
+}

--- a/apps/backend/internal/system/storage/operations.go
+++ b/apps/backend/internal/system/storage/operations.go
@@ -202,11 +202,16 @@ func selectCleanupProviders(all []CleanupProvider, requested []string) ([]Cleanu
 		byName[provider.Name()] = provider
 	}
 	selected := make([]CleanupProvider, 0, len(requested))
+	seen := make(map[string]struct{}, len(requested))
 	for _, name := range requested {
 		provider, ok := byName[name]
 		if !ok {
 			return nil, validationError("unknown storage resource %q", name)
 		}
+		if _, duplicate := seen[name]; duplicate {
+			continue
+		}
+		seen[name] = struct{}{}
 		if explicit, ok := provider.(ExplicitCleanupProvider); ok {
 			provider = explicitCleanupSelection{CleanupProvider: provider, explicit: explicit}
 		}

--- a/apps/backend/internal/system/storage/operations.go
+++ b/apps/backend/internal/system/storage/operations.go
@@ -1,0 +1,239 @@
+package storage
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/kandev/kandev/internal/agent/runtime/activity"
+	"github.com/kandev/kandev/internal/system/jobs"
+)
+
+const (
+	JobKindAnalysis         = "storage-analysis"
+	JobKindCleanup          = "storage-cleanup"
+	JobKindQuarantineDelete = "storage-quarantine-delete"
+)
+
+type GoCacheAdopter interface {
+	ValidateAdoption(context.Context, string, string) error
+}
+
+type QuarantineController interface {
+	Restore(context.Context, string) (QuarantineEntry, error)
+	PermanentDelete(context.Context, string, string) (QuarantineEntry, error)
+}
+
+type OperationsConfig struct {
+	Settings   *SettingsStore
+	Store      *Store
+	Jobs       *jobs.Tracker
+	Activity   *activity.Coordinator
+	Providers  []CleanupProvider
+	Overview   OverviewProvider
+	GoCache    GoCacheAdopter
+	Quarantine QuarantineController
+}
+
+type Operations struct {
+	config OperationsConfig
+}
+
+func NewOperations(config OperationsConfig) *Operations {
+	return &Operations{config: config}
+}
+
+func (o *Operations) AdoptGoCache(
+	ctx context.Context,
+	path string,
+	confirmation string,
+) (StorageMaintenanceSettings, Capabilities, error) {
+	if o.config.GoCache == nil {
+		return StorageMaintenanceSettings{}, Capabilities{}, errors.New("go-cache provider is unavailable")
+	}
+	if err := o.config.GoCache.ValidateAdoption(ctx, path, confirmation); err != nil {
+		return StorageMaintenanceSettings{}, Capabilities{}, fmt.Errorf("%w: %v", ErrValidation, err)
+	}
+	settings, err := o.config.Settings.AdoptGoCachePath(ctx, path)
+	if err != nil {
+		return StorageMaintenanceSettings{}, Capabilities{}, err
+	}
+	return settings, o.config.Overview.Capabilities(ctx, settings), nil
+}
+
+func (o *Operations) Analyze(ctx context.Context) (string, error) {
+	settings, err := o.config.Settings.GetSettings(ctx)
+	if err != nil {
+		return "", err
+	}
+	return o.startTracked(ctx, JobKindAnalysis, func(jobCtx context.Context, id string) (map[string]any, error) {
+		if err := o.createRun(jobCtx, id, RunTriggerAnalysis, settings); err != nil {
+			return nil, err
+		}
+		if _, err := o.config.Store.TransitionRun(jobCtx, id, RunStateRunning, nil, ""); err != nil {
+			return nil, err
+		}
+		summary, analyzeErr := o.config.Overview.Summary(jobCtx)
+		return o.finishAnalysis(jobCtx, id, summary, analyzeErr)
+	}), nil
+}
+
+func (o *Operations) RunNow(ctx context.Context, resources []string) (string, error) {
+	settings, err := o.config.Settings.GetSettings(ctx)
+	if err != nil {
+		return "", err
+	}
+	providers, err := selectCleanupProviders(o.config.Providers, resources)
+	if err != nil {
+		return "", err
+	}
+	if err := o.preflight(ctx); err != nil {
+		return "", err
+	}
+	return o.startTracked(ctx, JobKindCleanup, func(jobCtx context.Context, id string) (map[string]any, error) {
+		runner := NewRunner(RunnerConfig{
+			Activity: o.config.Activity, Store: o.config.Store, Providers: providers,
+			NewID: func() string { return id },
+		})
+		run, runErr := runner.Run(jobCtx, RunTriggerManual, settings)
+		return runResultMap(run), runErr
+	}), nil
+}
+
+func (o *Operations) RestoreQuarantine(ctx context.Context, id string) (QuarantineEntry, error) {
+	if o.config.Quarantine == nil {
+		return QuarantineEntry{}, errors.New("quarantine provider is unavailable")
+	}
+	return o.config.Quarantine.Restore(ctx, id)
+}
+
+func (o *Operations) DeleteQuarantine(ctx context.Context, id, confirmation string) (string, error) {
+	if confirmation != "DELETE" {
+		return "", validationError("quarantine deletion requires DELETE confirmation")
+	}
+	if o.config.Quarantine == nil {
+		return "", errors.New("quarantine provider is unavailable")
+	}
+	entry, err := o.config.Store.GetQuarantineEntry(ctx, id)
+	if err != nil {
+		return "", err
+	}
+	if time.Now().UTC().Before(entry.DeleteAfter) {
+		return "", fmt.Errorf("%w: quarantine retention deadline has not elapsed", ErrConflict)
+	}
+	return o.startTracked(ctx, JobKindQuarantineDelete, func(jobCtx context.Context, _ string) (map[string]any, error) {
+		entry, err := o.config.Quarantine.PermanentDelete(jobCtx, id, confirmation)
+		return map[string]any{"entry": entry}, err
+	}), nil
+}
+
+func (o *Operations) preflight(ctx context.Context) error {
+	lease, busy, err := o.config.Activity.TryAcquireMaintenance(ctx, 0)
+	if errors.Is(err, activity.ErrBusy) {
+		return &BusyError{Resources: busy}
+	}
+	if err != nil {
+		return err
+	}
+	lease.Release()
+	return nil
+}
+
+func (o *Operations) startTracked(
+	ctx context.Context,
+	kind string,
+	fn func(context.Context, string) (map[string]any, error),
+) string {
+	ready := make(chan struct{})
+	var id string
+	jobCtx := context.WithoutCancel(ctx)
+	id = o.config.Jobs.Start(jobCtx, kind, func(runCtx context.Context) (map[string]any, error) {
+		<-ready
+		return fn(runCtx, id)
+	})
+	close(ready)
+	return id
+}
+
+func (o *Operations) createRun(
+	ctx context.Context,
+	id string,
+	trigger RunTrigger,
+	settings StorageMaintenanceSettings,
+) error {
+	snapshot, err := json.Marshal(settings)
+	if err != nil {
+		return err
+	}
+	return o.config.Store.CreateRun(ctx, &MaintenanceRun{
+		ID: id, Trigger: trigger, State: RunStateQueued,
+		SettingsSnapshot: snapshot, Result: json.RawMessage(`{}`), StartedAt: time.Now().UTC(),
+	})
+}
+
+func (o *Operations) finishAnalysis(
+	ctx context.Context,
+	id string,
+	summary Summary,
+	analyzeErr error,
+) (map[string]any, error) {
+	result := valueMap(summary)
+	state := RunStateSucceeded
+	message := ""
+	if analyzeErr != nil {
+		state = RunStateFailed
+		message = analyzeErr.Error()
+	}
+	_, transitionErr := o.config.Store.TransitionRun(ctx, id, state, marshalRunResult(result), message)
+	if transitionErr != nil {
+		return nil, transitionErr
+	}
+	return result, analyzeErr
+}
+
+func selectCleanupProviders(all []CleanupProvider, requested []string) ([]CleanupProvider, error) {
+	if len(requested) == 0 {
+		return all, nil
+	}
+	byName := make(map[string]CleanupProvider, len(all))
+	for _, provider := range all {
+		byName[provider.Name()] = provider
+	}
+	selected := make([]CleanupProvider, 0, len(requested))
+	for _, name := range requested {
+		provider, ok := byName[name]
+		if !ok {
+			return nil, validationError("unknown storage resource %q", name)
+		}
+		if explicit, ok := provider.(ExplicitCleanupProvider); ok {
+			provider = explicitCleanupSelection{CleanupProvider: provider, explicit: explicit}
+		}
+		selected = append(selected, provider)
+	}
+	return selected, nil
+}
+
+type explicitCleanupSelection struct {
+	CleanupProvider
+	explicit ExplicitCleanupProvider
+}
+
+func (p explicitCleanupSelection) Cleanup(ctx context.Context) (map[string]any, error) {
+	return p.explicit.CleanupExplicit(ctx)
+}
+
+func runResultMap(run MaintenanceRun) map[string]any {
+	result := valueMap(run.Result)
+	result["run_id"] = run.ID
+	result["state"] = run.State
+	return result
+}
+
+func valueMap(value any) map[string]any {
+	encoded, _ := json.Marshal(value)
+	result := make(map[string]any)
+	_ = json.Unmarshal(encoded, &result)
+	return result
+}

--- a/apps/backend/internal/system/storage/operations_test.go
+++ b/apps/backend/internal/system/storage/operations_test.go
@@ -85,6 +85,37 @@ func TestRunNowRejectsCurrentTaskActivity(t *testing.T) {
 	}
 }
 
+func TestRunNowMarksPreemptedTrackedJobFailed(t *testing.T) {
+	connection := newSQLite(t)
+	pool := db.NewPool(connection, connection)
+	rawSettings, err := systemsettings.NewStore(pool)
+	if err != nil {
+		t.Fatalf("new settings store: %v", err)
+	}
+	coordinator := activity.NewCoordinator(activity.Options{})
+	provider := &preemptingSuccessfulProvider{
+		coordinator: coordinator,
+		lease:       make(chan *activity.TaskLease, 1),
+	}
+	tracker := jobs.NewTracker(nil, newOperationsTestLogger(t))
+	operations := NewOperations(OperationsConfig{
+		Settings: NewSettingsStore(rawSettings), Store: newStorageStore(t, pool),
+		Jobs: tracker, Activity: coordinator, Providers: []CleanupProvider{provider},
+	})
+
+	jobID, err := operations.RunNow(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("RunNow: %v", err)
+	}
+	waitForJobState(t, tracker, jobID, jobs.StateFailed)
+	select {
+	case lease := <-provider.lease:
+		lease.Release()
+	case <-time.After(time.Second):
+		t.Fatal("preempting task lease was not acquired")
+	}
+}
+
 func TestSelectCleanupProvidersUsesExplicitCleanupOnlyForNamedResources(t *testing.T) {
 	provider := &explicitRecordingCleanupProvider{}
 
@@ -99,9 +130,12 @@ func TestSelectCleanupProvidersUsesExplicitCleanupOnlyForNamedResources(t *testi
 		t.Fatalf("global cleanup calls = normal:%d explicit:%d", provider.normalCalls, provider.explicitCalls)
 	}
 
-	selected, err = selectCleanupProviders([]CleanupProvider{provider}, []string{"explicit"})
+	selected, err = selectCleanupProviders([]CleanupProvider{provider}, []string{"explicit", "explicit"})
 	if err != nil {
 		t.Fatalf("select named provider: %v", err)
+	}
+	if len(selected) != 1 {
+		t.Fatalf("selected providers = %d, want duplicate resource de-duplicated", len(selected))
 	}
 	if _, err := selected[0].Cleanup(context.Background()); err != nil {
 		t.Fatalf("explicit cleanup: %v", err)
@@ -131,6 +165,22 @@ func TestDeleteQuarantineRejectsBeforeRetentionWithoutStartingDelete(t *testing.
 	if jobID != "" || quarantine.deleteCalls != 0 {
 		t.Fatalf("early deletion started: job_id=%q delete_calls=%d", jobID, quarantine.deleteCalls)
 	}
+}
+
+func waitForJobState(t *testing.T, tracker *jobs.Tracker, id string, state jobs.State) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		job := tracker.Get(id)
+		if job != nil && (job.State == jobs.StateSucceeded || job.State == jobs.StateFailed) {
+			if job.State != state {
+				t.Fatalf("job state=%q message=%q, want %q", job.State, job.Message, state)
+			}
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal("job did not finish")
 }
 
 type recordingQuarantineController struct {

--- a/apps/backend/internal/system/storage/operations_test.go
+++ b/apps/backend/internal/system/storage/operations_test.go
@@ -1,0 +1,188 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/agent/runtime/activity"
+	"github.com/kandev/kandev/internal/common/logger"
+	"github.com/kandev/kandev/internal/db"
+	"github.com/kandev/kandev/internal/system/jobs"
+	systemsettings "github.com/kandev/kandev/internal/system/settings"
+	"go.uber.org/zap"
+)
+
+func TestRunNowIgnoresQuietPeriodWithoutActiveTaskWork(t *testing.T) {
+	connection := newSQLite(t)
+	pool := db.NewPool(connection, connection)
+	rawSettings, err := systemsettings.NewStore(pool)
+	if err != nil {
+		t.Fatalf("new settings store: %v", err)
+	}
+	coordinator := activity.NewCoordinator(activity.Options{})
+	provider := &signallingCleanupProvider{called: make(chan struct{})}
+	tracker := jobs.NewTracker(nil, newOperationsTestLogger(t))
+	operations := NewOperations(OperationsConfig{
+		Settings: NewSettingsStore(rawSettings), Store: newStorageStore(t, pool),
+		Jobs: tracker, Activity: coordinator, Providers: []CleanupProvider{provider},
+	})
+
+	jobID, err := operations.RunNow(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("RunNow: %v", err)
+	}
+	if jobID == "" {
+		t.Fatal("RunNow returned an empty job ID")
+	}
+	select {
+	case <-provider.called:
+	case <-time.After(time.Second):
+		t.Fatal("manual provider did not run")
+	}
+	deadline := time.Now().Add(time.Second)
+	for {
+		job := tracker.Get(jobID)
+		if job != nil && (job.State == jobs.StateSucceeded || job.State == jobs.StateFailed) {
+			if job.State != jobs.StateSucceeded {
+				t.Fatalf("manual job state=%q message=%q, want succeeded", job.State, job.Message)
+			}
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("manual job did not finish")
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+func TestRunNowRejectsCurrentTaskActivity(t *testing.T) {
+	connection := newSQLite(t)
+	pool := db.NewPool(connection, connection)
+	rawSettings, err := systemsettings.NewStore(pool)
+	if err != nil {
+		t.Fatalf("new settings store: %v", err)
+	}
+	coordinator := activity.NewCoordinator(activity.Options{})
+	taskLease, err := coordinator.AcquireTask(context.Background(), activity.KindTestCommand)
+	if err != nil {
+		t.Fatalf("AcquireTask: %v", err)
+	}
+	defer taskLease.Release()
+	operations := NewOperations(OperationsConfig{
+		Settings: NewSettingsStore(rawSettings), Store: newStorageStore(t, pool),
+		Jobs: jobs.NewTracker(nil, newOperationsTestLogger(t)), Activity: coordinator,
+	})
+
+	jobID, err := operations.RunNow(context.Background(), nil)
+	var busyErr *BusyError
+	if !errors.As(err, &busyErr) {
+		t.Fatalf("RunNow error = %v, want BusyError", err)
+	}
+	if jobID != "" {
+		t.Fatalf("busy RunNow job ID = %q, want empty", jobID)
+	}
+}
+
+func TestSelectCleanupProvidersUsesExplicitCleanupOnlyForNamedResources(t *testing.T) {
+	provider := &explicitRecordingCleanupProvider{}
+
+	selected, err := selectCleanupProviders([]CleanupProvider{provider}, nil)
+	if err != nil {
+		t.Fatalf("select all providers: %v", err)
+	}
+	if _, err := selected[0].Cleanup(context.Background()); err != nil {
+		t.Fatalf("normal cleanup: %v", err)
+	}
+	if provider.normalCalls != 1 || provider.explicitCalls != 0 {
+		t.Fatalf("global cleanup calls = normal:%d explicit:%d", provider.normalCalls, provider.explicitCalls)
+	}
+
+	selected, err = selectCleanupProviders([]CleanupProvider{provider}, []string{"explicit"})
+	if err != nil {
+		t.Fatalf("select named provider: %v", err)
+	}
+	if _, err := selected[0].Cleanup(context.Background()); err != nil {
+		t.Fatalf("explicit cleanup: %v", err)
+	}
+	if provider.normalCalls != 1 || provider.explicitCalls != 1 {
+		t.Fatalf("named cleanup calls = normal:%d explicit:%d", provider.normalCalls, provider.explicitCalls)
+	}
+}
+
+func TestDeleteQuarantineRejectsBeforeRetentionWithoutStartingDelete(t *testing.T) {
+	connection := newSQLite(t)
+	store := newStorageStore(t, db.NewPool(connection, connection))
+	entry := testQuarantineEntry("retained-entry")
+	entry.DeleteAfter = time.Now().UTC().Add(time.Hour)
+	if err := store.CreateQuarantineEntry(context.Background(), &entry); err != nil {
+		t.Fatal(err)
+	}
+	quarantine := &recordingQuarantineController{}
+	operations := NewOperations(OperationsConfig{
+		Store: store, Jobs: jobs.NewTracker(nil, newOperationsTestLogger(t)), Quarantine: quarantine,
+	})
+
+	jobID, err := operations.DeleteQuarantine(context.Background(), entry.ID, "DELETE")
+	if !errors.Is(err, ErrConflict) {
+		t.Fatalf("DeleteQuarantine error = %v, want ErrConflict", err)
+	}
+	if jobID != "" || quarantine.deleteCalls != 0 {
+		t.Fatalf("early deletion started: job_id=%q delete_calls=%d", jobID, quarantine.deleteCalls)
+	}
+}
+
+type recordingQuarantineController struct {
+	deleteCalls int
+}
+
+type signallingCleanupProvider struct {
+	called chan struct{}
+}
+
+type explicitRecordingCleanupProvider struct {
+	normalCalls   int
+	explicitCalls int
+}
+
+func (p *explicitRecordingCleanupProvider) Name() string { return "explicit" }
+
+func (p *explicitRecordingCleanupProvider) Cleanup(context.Context) (map[string]any, error) {
+	p.normalCalls++
+	return nil, nil
+}
+
+func (p *explicitRecordingCleanupProvider) CleanupExplicit(context.Context) (map[string]any, error) {
+	p.explicitCalls++
+	return nil, nil
+}
+
+func (p *signallingCleanupProvider) Name() string { return "signalling" }
+
+func (p *signallingCleanupProvider) Cleanup(context.Context) (map[string]any, error) {
+	close(p.called)
+	return map[string]any{"cleaned": true}, nil
+}
+
+func (c *recordingQuarantineController) Restore(context.Context, string) (QuarantineEntry, error) {
+	return QuarantineEntry{}, nil
+}
+
+func (c *recordingQuarantineController) PermanentDelete(
+	context.Context,
+	string,
+	string,
+) (QuarantineEntry, error) {
+	c.deleteCalls++
+	return QuarantineEntry{}, nil
+}
+
+func newOperationsTestLogger(t *testing.T) *logger.Logger {
+	t.Helper()
+	log, err := logger.NewFromZap(zap.NewNop())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return log
+}

--- a/apps/backend/internal/system/storage/path_safety.go
+++ b/apps/backend/internal/system/storage/path_safety.go
@@ -1,0 +1,111 @@
+package storage
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// CommonPath returns the deepest lexical directory containing every path.
+func CommonPath(paths ...string) (string, error) {
+	if len(paths) == 0 {
+		return "", errors.New("at least one path is required")
+	}
+	common := filepath.Clean(paths[0])
+	if !filepath.IsAbs(common) {
+		return "", fmt.Errorf("path must be absolute: %q", paths[0])
+	}
+	for _, raw := range paths[1:] {
+		path := filepath.Clean(raw)
+		if !filepath.IsAbs(path) || filepath.VolumeName(path) != filepath.VolumeName(common) {
+			return "", fmt.Errorf("paths must be absolute and on one volume: %q", raw)
+		}
+		for !containsPath(common, path) {
+			parent := filepath.Dir(common)
+			if parent == common {
+				break
+			}
+			common = parent
+		}
+	}
+	return common, nil
+}
+
+// ValidateNoSymlinkPath rejects symlinks in every existing component from
+// anchor through path and verifies that the canonical existing prefix remains
+// beneath the canonical anchor. Missing trailing components are allowed.
+func ValidateNoSymlinkPath(anchor, path string) error {
+	anchor = filepath.Clean(anchor)
+	path = filepath.Clean(path)
+	if !filepath.IsAbs(anchor) || !filepath.IsAbs(path) || !containsPath(anchor, path) {
+		return fmt.Errorf("path %q is outside safety anchor %q", path, anchor)
+	}
+	if err := requireRealDirectory(anchor); err != nil {
+		return err
+	}
+	canonicalAnchor, err := filepath.EvalSymlinks(anchor)
+	if err != nil {
+		return fmt.Errorf("resolve safety anchor %s: %w", anchor, err)
+	}
+	relative, err := filepath.Rel(anchor, path)
+	if err != nil {
+		return err
+	}
+	deepest, err := deepestRealDirectory(anchor, relative)
+	if err != nil {
+		return err
+	}
+	canonicalDeepest, err := filepath.EvalSymlinks(deepest)
+	if err != nil {
+		return fmt.Errorf("resolve path component %s: %w", deepest, err)
+	}
+	if !containsPath(canonicalAnchor, canonicalDeepest) {
+		return fmt.Errorf("canonical path %s escapes safety anchor %s", canonicalDeepest, canonicalAnchor)
+	}
+	return nil
+}
+
+func deepestRealDirectory(anchor, relative string) (string, error) {
+	current := anchor
+	deepest := anchor
+	for _, component := range strings.Split(relative, string(filepath.Separator)) {
+		if component == "." || component == "" {
+			continue
+		}
+		current = filepath.Join(current, component)
+		info, statErr := os.Lstat(current)
+		if errors.Is(statErr, os.ErrNotExist) {
+			break
+		}
+		if statErr != nil {
+			return "", fmt.Errorf("inspect path component %s: %w", current, statErr)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return "", fmt.Errorf("path component must not be a symlink: %s", current)
+		}
+		if !info.IsDir() {
+			return "", fmt.Errorf("path component must be a directory: %s", current)
+		}
+		deepest = current
+	}
+	return deepest, nil
+}
+
+func requireRealDirectory(path string) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return fmt.Errorf("inspect safety anchor %s: %w", path, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return fmt.Errorf("safety anchor must be a real directory: %s", path)
+	}
+	return nil
+}
+
+func containsPath(parent, child string) bool {
+	relative, err := filepath.Rel(parent, child)
+	return err == nil && relative != ".." && !filepath.IsAbs(relative) &&
+		!strings.HasPrefix(relative, ".."+string(filepath.Separator))
+}

--- a/apps/backend/internal/system/storage/path_safety.go
+++ b/apps/backend/internal/system/storage/path_safety.go
@@ -75,7 +75,7 @@ func deepestRealDirectory(anchor, relative string) (string, error) {
 			continue
 		}
 		current = filepath.Join(current, component)
-		info, statErr := os.Lstat(current)
+		info, statErr := os.Lstat(current) // codeql[go/path-injection] component is constrained beneath anchor.
 		if errors.Is(statErr, os.ErrNotExist) {
 			break
 		}
@@ -94,7 +94,7 @@ func deepestRealDirectory(anchor, relative string) (string, error) {
 }
 
 func requireRealDirectory(path string) error {
-	info, err := os.Lstat(path)
+	info, err := os.Lstat(path) // codeql[go/path-injection] deliberate validation of the absolute safety anchor.
 	if err != nil {
 		return fmt.Errorf("inspect safety anchor %s: %w", path, err)
 	}

--- a/apps/backend/internal/system/storage/quarantine_retry.go
+++ b/apps/backend/internal/system/storage/quarantine_retry.go
@@ -1,0 +1,84 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const quarantineRetryReleaseReason = "quarantine move did not occur; intent released for retry"
+
+type quarantineRetryStore interface {
+	ListQuarantineEntries(context.Context, bool) ([]QuarantineEntry, error)
+	TransitionQuarantineEntry(
+		context.Context,
+		string,
+		QuarantineState,
+		string,
+	) (QuarantineEntry, error)
+}
+
+// ReleaseFailedQuarantineIntent releases a failed intent only when filesystem
+// state proves its move did not occur. Ambiguous states remain active for
+// recovery or reconciliation.
+func ReleaseFailedQuarantineIntent(
+	ctx context.Context,
+	store quarantineRetryStore,
+	resourceType ResourceType,
+	originalPath string,
+) (bool, error) {
+	entries, err := store.ListQuarantineEntries(ctx, false)
+	if err != nil {
+		return false, fmt.Errorf("list active quarantine intents: %w", err)
+	}
+	originalPath = filepath.Clean(originalPath)
+	for _, entry := range entries {
+		if entry.ResourceType != resourceType || filepath.Clean(entry.OriginalPath) != originalPath {
+			continue
+		}
+		if entry.State == QuarantineStateQuarantined {
+			return false, fmt.Errorf("%w: quarantine intent for %s is still active", ErrConflict, originalPath)
+		}
+		if entry.State == QuarantineStateFailed {
+			return releaseFailedIntentIfUnmoved(ctx, store, entry)
+		}
+	}
+	return false, nil
+}
+
+func releaseFailedIntentIfUnmoved(
+	ctx context.Context,
+	store quarantineRetryStore,
+	entry QuarantineEntry,
+) (bool, error) {
+	originalExists, err := quarantinePathExists(entry.OriginalPath)
+	if err != nil {
+		return false, fmt.Errorf("inspect failed quarantine original: %w", err)
+	}
+	quarantineExists, err := quarantinePathExists(entry.QuarantinePath)
+	if err != nil {
+		return false, fmt.Errorf("inspect failed quarantine destination: %w", err)
+	}
+	if !originalExists || quarantineExists {
+		return false, fmt.Errorf("%w: failed quarantine intent has ambiguous filesystem state", ErrConflict)
+	}
+	if _, err := store.TransitionQuarantineEntry(
+		ctx,
+		entry.ID,
+		QuarantineStateRestored,
+		quarantineRetryReleaseReason,
+	); err != nil {
+		return false, fmt.Errorf("release failed quarantine intent: %w", err)
+	}
+	return true, nil
+}
+
+func quarantinePathExists(path string) (bool, error) {
+	_, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	return err == nil, err
+}

--- a/apps/backend/internal/system/storage/runner.go
+++ b/apps/backend/internal/system/storage/runner.go
@@ -1,0 +1,177 @@
+package storage
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/kandev/kandev/internal/agent/runtime/activity"
+)
+
+type RunStore interface {
+	CreateRun(ctx context.Context, run *MaintenanceRun) error
+	TransitionRun(ctx context.Context, id string, next RunState, result json.RawMessage, message string) (MaintenanceRun, error)
+}
+
+type CleanupProvider interface {
+	Name() string
+	Cleanup(ctx context.Context) (map[string]any, error)
+}
+
+// ExplicitCleanupProvider may opt into behavior reserved for a specifically named manual run.
+type ExplicitCleanupProvider interface {
+	CleanupExplicit(ctx context.Context) (map[string]any, error)
+}
+
+type RunnerConfig struct {
+	Activity  *activity.Coordinator
+	Store     RunStore
+	Providers []CleanupProvider
+	NewID     func() string
+	Now       func() time.Time
+}
+
+type Runner struct {
+	activity  *activity.Coordinator
+	store     RunStore
+	providers []CleanupProvider
+	newID     func() string
+	now       func() time.Time
+}
+
+const terminalTransitionTimeout = 5 * time.Second
+
+type BusyError struct {
+	Resources []activity.Kind
+}
+
+func (e *BusyError) Error() string { return "storage maintenance is busy" }
+
+func NewRunner(config RunnerConfig) *Runner {
+	newID := config.NewID
+	if newID == nil {
+		newID = uuid.NewString
+	}
+	now := config.Now
+	if now == nil {
+		now = time.Now
+	}
+	return &Runner{
+		activity: config.Activity, store: config.Store, providers: config.Providers,
+		newID: newID, now: now,
+	}
+}
+
+func (r *Runner) Run(
+	ctx context.Context,
+	trigger RunTrigger,
+	settings StorageMaintenanceSettings,
+) (MaintenanceRun, error) {
+	run, err := r.createRun(ctx, trigger, settings)
+	if err != nil {
+		return MaintenanceRun{}, err
+	}
+	quietPeriod := quietPeriodForTrigger(trigger, settings)
+	lease, busy, err := r.activity.TryAcquireMaintenance(ctx, quietPeriod)
+	if errors.Is(err, activity.ErrBusy) {
+		result := marshalRunResult(map[string]any{"busy_resources": busy})
+		run, transitionErr := r.store.TransitionRun(ctx, run.ID, RunStateSkippedBusy, result, "host resources are busy")
+		if transitionErr != nil {
+			return MaintenanceRun{}, transitionErr
+		}
+		if trigger == RunTriggerManual {
+			return run, &BusyError{Resources: busy}
+		}
+		return run, nil
+	}
+	if err != nil {
+		return MaintenanceRun{}, err
+	}
+	defer lease.Release()
+	if _, err := r.store.TransitionRun(ctx, run.ID, RunStateRunning, nil, ""); err != nil {
+		return MaintenanceRun{}, err
+	}
+	result, runErr := r.runProviders(lease.Context())
+	return r.finishRun(ctx, run.ID, lease.Context(), result, runErr)
+}
+
+func quietPeriodForTrigger(trigger RunTrigger, settings StorageMaintenanceSettings) time.Duration {
+	if trigger == RunTriggerManual {
+		return 0
+	}
+	return time.Duration(settings.IdleForMinutes) * time.Minute
+}
+
+func (r *Runner) createRun(
+	ctx context.Context,
+	trigger RunTrigger,
+	settings StorageMaintenanceSettings,
+) (MaintenanceRun, error) {
+	snapshot, err := json.Marshal(settings)
+	if err != nil {
+		return MaintenanceRun{}, fmt.Errorf("encode storage settings snapshot: %w", err)
+	}
+	run := MaintenanceRun{
+		ID: r.newID(), Trigger: trigger, State: RunStateQueued,
+		SettingsSnapshot: snapshot, Result: json.RawMessage(`{}`), StartedAt: r.now().UTC(),
+	}
+	if err := r.store.CreateRun(ctx, &run); err != nil {
+		return MaintenanceRun{}, err
+	}
+	return run, nil
+}
+
+func (r *Runner) runProviders(ctx context.Context) (map[string]any, error) {
+	results := make(map[string]any, len(r.providers))
+	var errs []error
+	for _, provider := range r.providers {
+		if ctx.Err() != nil {
+			break
+		}
+		providerResult, err := provider.Cleanup(ctx)
+		entry := map[string]any{"result": providerResult}
+		if err != nil {
+			entry["error"] = err.Error()
+			errs = append(errs, fmt.Errorf("%s: %w", provider.Name(), err))
+		}
+		results[provider.Name()] = entry
+	}
+	return results, errors.Join(errs...)
+}
+
+func (r *Runner) finishRun(
+	ctx context.Context,
+	id string,
+	maintenanceCtx context.Context,
+	result map[string]any,
+	runErr error,
+) (MaintenanceRun, error) {
+	state := RunStateSucceeded
+	message := ""
+	if maintenanceCtx.Err() != nil {
+		state = RunStateCancelled
+		message = "maintenance preempted by task activity"
+	} else if runErr != nil {
+		state = RunStateFailed
+		message = runErr.Error()
+	}
+	transitionCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), terminalTransitionTimeout)
+	defer cancel()
+	run, err := r.store.TransitionRun(transitionCtx, id, state, marshalRunResult(result), message)
+	if err != nil {
+		return MaintenanceRun{}, err
+	}
+	return run, runErr
+}
+
+func marshalRunResult(result any) json.RawMessage {
+	encoded, err := json.Marshal(result)
+	if err != nil {
+		return json.RawMessage(`{"error":"encode maintenance result"}`)
+	}
+	return encoded
+}

--- a/apps/backend/internal/system/storage/runner.go
+++ b/apps/backend/internal/system/storage/runner.go
@@ -79,7 +79,7 @@ func (r *Runner) Run(
 	lease, busy, err := r.activity.TryAcquireMaintenance(ctx, quietPeriod)
 	if errors.Is(err, activity.ErrBusy) {
 		result := marshalRunResult(map[string]any{"busy_resources": busy})
-		run, transitionErr := r.store.TransitionRun(ctx, run.ID, RunStateSkippedBusy, result, "host resources are busy")
+		run, transitionErr := r.transitionRun(ctx, run.ID, RunStateSkippedBusy, result, "host resources are busy")
 		if transitionErr != nil {
 			return MaintenanceRun{}, transitionErr
 		}
@@ -89,10 +89,18 @@ func (r *Runner) Run(
 		return run, nil
 	}
 	if err != nil {
-		return MaintenanceRun{}, err
+		state := RunStateFailed
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			state = RunStateCancelled
+		}
+		run, transitionErr := r.transitionRun(ctx, run.ID, state, nil, err.Error())
+		if transitionErr != nil {
+			return MaintenanceRun{}, transitionErr
+		}
+		return run, err
 	}
 	defer lease.Release()
-	if _, err := r.store.TransitionRun(ctx, run.ID, RunStateRunning, nil, ""); err != nil {
+	if _, err := r.transitionRun(ctx, run.ID, RunStateRunning, nil, ""); err != nil {
 		return MaintenanceRun{}, err
 	}
 	result, runErr := r.runProviders(lease.Context())
@@ -155,17 +163,30 @@ func (r *Runner) finishRun(
 	if maintenanceCtx.Err() != nil {
 		state = RunStateCancelled
 		message = "maintenance preempted by task activity"
+		if runErr == nil {
+			runErr = maintenanceCtx.Err()
+		}
 	} else if runErr != nil {
 		state = RunStateFailed
 		message = runErr.Error()
 	}
-	transitionCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), terminalTransitionTimeout)
-	defer cancel()
-	run, err := r.store.TransitionRun(transitionCtx, id, state, marshalRunResult(result), message)
+	run, err := r.transitionRun(ctx, id, state, marshalRunResult(result), message)
 	if err != nil {
 		return MaintenanceRun{}, err
 	}
 	return run, runErr
+}
+
+func (r *Runner) transitionRun(
+	ctx context.Context,
+	id string,
+	state RunState,
+	result json.RawMessage,
+	message string,
+) (MaintenanceRun, error) {
+	transitionCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), terminalTransitionTimeout)
+	defer cancel()
+	return r.store.TransitionRun(transitionCtx, id, state, result, message)
 }
 
 func marshalRunResult(result any) json.RawMessage {

--- a/apps/backend/internal/system/storage/runner_test.go
+++ b/apps/backend/internal/system/storage/runner_test.go
@@ -222,8 +222,12 @@ func TestRunnerReturnsCancellationWhenPreemptedBetweenProviders(t *testing.T) {
 	if run.State != RunStateCancelled {
 		t.Fatalf("run state = %q, want cancelled", run.State)
 	}
-	lease := <-provider.lease
-	lease.Release()
+	select {
+	case lease := <-provider.lease:
+		lease.Release()
+	case <-time.After(time.Second):
+		t.Fatal("preempting task lease was not acquired")
+	}
 }
 
 type runnerResult struct {

--- a/apps/backend/internal/system/storage/runner_test.go
+++ b/apps/backend/internal/system/storage/runner_test.go
@@ -190,6 +190,42 @@ func TestRunnerPersistsCancelledRunAfterCallerCancellation(t *testing.T) {
 	}
 }
 
+func TestRunnerPersistsCancellationBetweenCreateAndAcquire(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	store := &cancelAfterCreateRunStore{cancel: cancel}
+	runner := NewRunner(RunnerConfig{
+		Activity: activity.NewCoordinator(activity.Options{}), Store: store,
+		NewID: func() string { return "cancel-after-create" },
+	})
+
+	run, err := runner.Run(ctx, RunTriggerManual, DefaultSettings())
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Run error = %v, want context cancellation", err)
+	}
+	if run.State != RunStateCancelled || store.terminalState() != RunStateCancelled {
+		t.Fatalf("cancelled run = %#v transitions=%v", run, store.transitions)
+	}
+}
+
+func TestRunnerReturnsCancellationWhenPreemptedBetweenProviders(t *testing.T) {
+	coordinator := activity.NewCoordinator(activity.Options{})
+	provider := &preemptingSuccessfulProvider{coordinator: coordinator, lease: make(chan *activity.TaskLease, 1)}
+	runner := NewRunner(RunnerConfig{
+		Activity: coordinator, Store: &recordingRunStore{}, Providers: []CleanupProvider{provider},
+		NewID: func() string { return "preempted-between-providers" },
+	})
+
+	run, err := runner.Run(context.Background(), RunTriggerManual, DefaultSettings())
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Run error = %v, want context cancellation", err)
+	}
+	if run.State != RunStateCancelled {
+		t.Fatalf("run state = %q, want cancelled", run.State)
+	}
+	lease := <-provider.lease
+	lease.Release()
+}
+
 type runnerResult struct {
 	run MaintenanceRun
 	err error
@@ -212,6 +248,58 @@ type cancellableProvider struct {
 
 type recordingCleanupProvider struct {
 	calls int
+}
+
+type cancelAfterCreateRunStore struct {
+	cancel      context.CancelFunc
+	transitions []RunState
+}
+
+func (s *cancelAfterCreateRunStore) CreateRun(_ context.Context, _ *MaintenanceRun) error {
+	s.cancel()
+	return nil
+}
+
+func (s *cancelAfterCreateRunStore) TransitionRun(
+	ctx context.Context,
+	id string,
+	state RunState,
+	result json.RawMessage,
+	message string,
+) (MaintenanceRun, error) {
+	if err := ctx.Err(); err != nil {
+		return MaintenanceRun{}, err
+	}
+	s.transitions = append(s.transitions, state)
+	completedAt := time.Now().UTC()
+	return MaintenanceRun{
+		ID: id, State: state, Result: result, Message: message, CompletedAt: &completedAt,
+	}, nil
+}
+
+func (s *cancelAfterCreateRunStore) terminalState() RunState {
+	if len(s.transitions) == 0 {
+		return ""
+	}
+	return s.transitions[len(s.transitions)-1]
+}
+
+type preemptingSuccessfulProvider struct {
+	coordinator *activity.Coordinator
+	lease       chan *activity.TaskLease
+}
+
+func (*preemptingSuccessfulProvider) Name() string { return "preempting" }
+
+func (p *preemptingSuccessfulProvider) Cleanup(ctx context.Context) (map[string]any, error) {
+	go func() {
+		lease, err := p.coordinator.AcquireTask(context.Background(), activity.KindExecutionStarting)
+		if err == nil {
+			p.lease <- lease
+		}
+	}()
+	<-ctx.Done()
+	return map[string]any{"stopped": true}, nil
 }
 
 func (p *recordingCleanupProvider) Name() string { return "recording" }

--- a/apps/backend/internal/system/storage/runner_test.go
+++ b/apps/backend/internal/system/storage/runner_test.go
@@ -1,0 +1,284 @@
+package storage
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/agent/runtime/activity"
+)
+
+func TestManualRunnerIgnoresQuietPeriodWithoutActiveTaskWork(t *testing.T) {
+	now := time.Date(2026, 7, 15, 10, 0, 0, 0, time.UTC)
+	coordinator := activity.NewCoordinator(activity.Options{Now: func() time.Time { return now }})
+	taskLease, err := coordinator.AcquireTask(context.Background(), activity.KindTestCommand)
+	if err != nil {
+		t.Fatalf("AcquireTask: %v", err)
+	}
+	taskLease.Release()
+	provider := &recordingCleanupProvider{}
+	runner := NewRunner(RunnerConfig{
+		Activity: coordinator, Store: &recordingRunStore{}, Providers: []CleanupProvider{provider},
+		NewID: func() string { return "manual-recent-activity" },
+	})
+	settings := DefaultSettings()
+	settings.IdleForMinutes = 10
+
+	run, err := runner.Run(context.Background(), RunTriggerManual, settings)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if run.State != RunStateSucceeded || provider.calls != 1 {
+		t.Fatalf("manual run state=%q provider calls=%d, want succeeded/1", run.State, provider.calls)
+	}
+}
+
+func TestManualRunnerRejectsCurrentTaskActivity(t *testing.T) {
+	coordinator := activity.NewCoordinator(activity.Options{})
+	taskLease, err := coordinator.AcquireTask(context.Background(), activity.KindTestCommand)
+	if err != nil {
+		t.Fatalf("AcquireTask: %v", err)
+	}
+	defer taskLease.Release()
+	provider := &recordingCleanupProvider{}
+	runner := NewRunner(RunnerConfig{
+		Activity: coordinator, Store: &recordingRunStore{}, Providers: []CleanupProvider{provider},
+		NewID: func() string { return "manual-active-task" },
+	})
+
+	run, err := runner.Run(context.Background(), RunTriggerManual, DefaultSettings())
+	var busyErr *BusyError
+	if !errors.As(err, &busyErr) {
+		t.Fatalf("Run error = %v, want BusyError", err)
+	}
+	if run.State != RunStateSkippedBusy || provider.calls != 0 {
+		t.Fatalf("manual run state=%q provider calls=%d, want skipped_busy/0", run.State, provider.calls)
+	}
+}
+
+func TestScheduledRunnerEnforcesQuietPeriodWithoutActiveTaskWork(t *testing.T) {
+	now := time.Date(2026, 7, 15, 10, 0, 0, 0, time.UTC)
+	coordinator := activity.NewCoordinator(activity.Options{Now: func() time.Time { return now }})
+	provider := &recordingCleanupProvider{}
+	runner := NewRunner(RunnerConfig{
+		Activity: coordinator, Store: &recordingRunStore{}, Providers: []CleanupProvider{provider},
+		NewID: func() string { return "scheduled-quiet-period" },
+	})
+	settings := DefaultSettings()
+	settings.IdleForMinutes = 10
+
+	run, err := runner.Run(context.Background(), RunTriggerScheduled, settings)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if run.State != RunStateSkippedBusy || provider.calls != 0 {
+		t.Fatalf("scheduled run state=%q provider calls=%d, want skipped_busy/0", run.State, provider.calls)
+	}
+}
+
+func TestScheduledRunnerPersistsSkippedBusy(t *testing.T) {
+	coordinator := activity.NewCoordinator(activity.Options{})
+	taskLease, err := coordinator.AcquireTask(context.Background(), activity.KindTestCommand)
+	if err != nil {
+		t.Fatalf("AcquireTask: %v", err)
+	}
+	defer taskLease.Release()
+	store := &recordingRunStore{}
+	runner := NewRunner(RunnerConfig{
+		Activity: coordinator, Store: store,
+		NewID: func() string { return "scheduled-busy" },
+	})
+	settings := DefaultSettings()
+	settings.Enabled = true
+	settings.IdleForMinutes = 10
+
+	run, err := runner.Run(context.Background(), RunTriggerScheduled, settings)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if run.State != RunStateSkippedBusy {
+		t.Fatalf("run state = %q, want skipped_busy", run.State)
+	}
+	if len(store.created) != 1 || len(store.transitions) != 1 || store.transitions[0] != RunStateSkippedBusy {
+		t.Fatalf("persistence created=%d transitions=%v", len(store.created), store.transitions)
+	}
+}
+
+func TestTaskAdmissionCancelsProviderBeforeProceeding(t *testing.T) {
+	coordinator := activity.NewCoordinator(activity.Options{})
+	provider := &cancellableProvider{started: make(chan struct{}), stopped: make(chan struct{})}
+	store := &recordingRunStore{}
+	runner := NewRunner(RunnerConfig{
+		Activity: coordinator, Store: store, Providers: []CleanupProvider{provider},
+		NewID: func() string { return "cancelled-run" },
+	})
+	settings := DefaultSettings()
+	settings.IdleForMinutes = 0
+
+	runDone := make(chan MaintenanceRun, 1)
+	go func() {
+		run, _ := runner.Run(context.Background(), RunTriggerScheduled, settings)
+		runDone <- run
+	}()
+	select {
+	case <-provider.started:
+	case <-time.After(time.Second):
+		t.Fatal("provider did not start")
+	}
+
+	taskAdmitted := make(chan *activity.TaskLease, 1)
+	go func() {
+		lease, err := coordinator.AcquireTask(context.Background(), activity.KindExecutionStarting)
+		if err == nil {
+			taskAdmitted <- lease
+		}
+	}()
+	select {
+	case <-provider.stopped:
+	case <-time.After(time.Second):
+		t.Fatal("provider did not stop after task arrival")
+	}
+	select {
+	case lease := <-taskAdmitted:
+		lease.Release()
+	case <-time.After(time.Second):
+		t.Fatal("task was not admitted after provider drained")
+	}
+	select {
+	case run := <-runDone:
+		if run.State != RunStateCancelled {
+			t.Fatalf("run state = %q, want cancelled", run.State)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("cancelled run did not finish")
+	}
+}
+
+func TestRunnerPersistsCancelledRunAfterCallerCancellation(t *testing.T) {
+	coordinator := activity.NewCoordinator(activity.Options{})
+	provider := &cancellableProvider{started: make(chan struct{}), stopped: make(chan struct{})}
+	store := &cancellationAwareRunStore{}
+	runner := NewRunner(RunnerConfig{
+		Activity: coordinator, Store: store, Providers: []CleanupProvider{provider},
+		NewID: func() string { return "caller-cancelled-run" },
+	})
+	settings := DefaultSettings()
+	settings.IdleForMinutes = 0
+
+	ctx, cancel := context.WithCancel(context.Background())
+	runDone := make(chan runnerResult, 1)
+	go func() {
+		run, err := runner.Run(ctx, RunTriggerScheduled, settings)
+		runDone <- runnerResult{run: run, err: err}
+	}()
+	<-provider.started
+	cancel()
+	<-provider.stopped
+
+	result := <-runDone
+	if !errors.Is(result.err, context.Canceled) {
+		t.Fatalf("Run error = %v, want context cancellation", result.err)
+	}
+	if result.run.State != RunStateCancelled {
+		t.Fatalf("run state = %q, want cancelled", result.run.State)
+	}
+	if terminal := store.terminalState(); terminal != RunStateCancelled {
+		t.Fatalf("persisted terminal state = %q, want cancelled", terminal)
+	}
+}
+
+type runnerResult struct {
+	run MaintenanceRun
+	err error
+}
+
+type recordingRunStore struct {
+	created     []MaintenanceRun
+	transitions []RunState
+}
+
+type cancellationAwareRunStore struct {
+	mu          sync.Mutex
+	transitions []RunState
+}
+
+type cancellableProvider struct {
+	started chan struct{}
+	stopped chan struct{}
+}
+
+type recordingCleanupProvider struct {
+	calls int
+}
+
+func (p *recordingCleanupProvider) Name() string { return "recording" }
+
+func (p *recordingCleanupProvider) Cleanup(context.Context) (map[string]any, error) {
+	p.calls++
+	return map[string]any{"cleaned": true}, nil
+}
+
+func (p *cancellableProvider) Name() string { return "cancellable" }
+
+func (p *cancellableProvider) Cleanup(ctx context.Context) (map[string]any, error) {
+	close(p.started)
+	<-ctx.Done()
+	close(p.stopped)
+	return nil, ctx.Err()
+}
+
+func (s *recordingRunStore) CreateRun(_ context.Context, run *MaintenanceRun) error {
+	s.created = append(s.created, *run)
+	return nil
+}
+
+func (s *recordingRunStore) TransitionRun(
+	_ context.Context,
+	id string,
+	state RunState,
+	result json.RawMessage,
+	message string,
+) (MaintenanceRun, error) {
+	s.transitions = append(s.transitions, state)
+	now := time.Now().UTC()
+	return MaintenanceRun{ID: id, State: state, Result: result, Message: message, CompletedAt: &now}, nil
+}
+
+func (s *cancellationAwareRunStore) CreateRun(ctx context.Context, _ *MaintenanceRun) error {
+	return ctx.Err()
+}
+
+func (s *cancellationAwareRunStore) TransitionRun(
+	ctx context.Context,
+	id string,
+	state RunState,
+	result json.RawMessage,
+	message string,
+) (MaintenanceRun, error) {
+	if err := ctx.Err(); err != nil {
+		return MaintenanceRun{}, err
+	}
+	s.mu.Lock()
+	s.transitions = append(s.transitions, state)
+	s.mu.Unlock()
+	completedAt := time.Now().UTC()
+	if state == RunStateRunning {
+		completedAt = time.Time{}
+		return MaintenanceRun{ID: id, State: state, Result: result, Message: message}, nil
+	}
+	return MaintenanceRun{
+		ID: id, State: state, Result: result, Message: message, CompletedAt: &completedAt,
+	}, nil
+}
+
+func (s *cancellationAwareRunStore) terminalState() RunState {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.transitions) == 0 {
+		return ""
+	}
+	return s.transitions[len(s.transitions)-1]
+}

--- a/apps/backend/internal/system/storage/runtime.go
+++ b/apps/backend/internal/system/storage/runtime.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"sort"
 	"sync"
 
 	"github.com/kandev/kandev/internal/health"
@@ -28,10 +29,11 @@ type RuntimeConfig struct {
 }
 
 type Runtime struct {
-	config RuntimeConfig
-	mu     sync.Mutex
-	ctx    context.Context
-	issues []health.Issue
+	config      RuntimeConfig
+	lifecycleMu sync.Mutex
+	mu          sync.Mutex
+	ctx         context.Context
+	issues      map[string]health.Issue
 }
 
 func NewRuntime(config RuntimeConfig) *Runtime {
@@ -39,6 +41,8 @@ func NewRuntime(config RuntimeConfig) *Runtime {
 }
 
 func (r *Runtime) Start(ctx context.Context) error {
+	r.lifecycleMu.Lock()
+	defer r.lifecycleMu.Unlock()
 	r.mu.Lock()
 	if r.ctx != nil {
 		r.mu.Unlock()
@@ -49,11 +53,15 @@ func (r *Runtime) Start(ctx context.Context) error {
 	if r.config.Worker != nil {
 		if err := r.config.Worker.StartTaskResourceCleanupWorker(ctx); err != nil {
 			r.setIssue("storage_cleanup_worker", "Task cleanup worker failed to start", err.Error())
+		} else {
+			r.clearIssue("storage_cleanup_worker")
 		}
 	}
 	if r.config.Reconciler != nil {
 		if err := r.config.Reconciler.Reconcile(ctx); err != nil {
 			r.setIssue("storage_reconciliation", "Storage reconciliation failed", err.Error())
+		} else {
+			r.clearIssue("storage_reconciliation")
 		}
 	}
 	settings, err := r.config.Settings.GetSettings(ctx)
@@ -61,13 +69,20 @@ func (r *Runtime) Start(ctx context.Context) error {
 		r.setIssue("storage_settings_invalid", "Storage maintenance is disabled", err.Error())
 		return nil
 	}
+	r.clearIssue("storage_settings_invalid")
 	if settings.Enabled && r.config.Scheduler != nil {
-		return r.config.Scheduler.Start(ctx)
+		if err := r.config.Scheduler.Start(ctx); err != nil {
+			r.setIssue("storage_scheduler", "Storage scheduler failed to start", err.Error())
+			return err
+		}
 	}
+	r.clearIssue("storage_scheduler")
 	return nil
 }
 
 func (r *Runtime) Stop() {
+	r.lifecycleMu.Lock()
+	defer r.lifecycleMu.Unlock()
 	if r.config.Scheduler != nil {
 		r.config.Scheduler.Stop()
 	}
@@ -80,6 +95,8 @@ func (r *Runtime) Stop() {
 }
 
 func (r *Runtime) ApplySettings(settings StorageMaintenanceSettings) {
+	r.lifecycleMu.Lock()
+	defer r.lifecycleMu.Unlock()
 	r.mu.Lock()
 	ctx := r.ctx
 	r.mu.Unlock()
@@ -88,12 +105,14 @@ func (r *Runtime) ApplySettings(settings StorageMaintenanceSettings) {
 	}
 	if !settings.Enabled {
 		r.config.Scheduler.Stop()
+		r.clearIssue("storage_scheduler")
 		return
 	}
 	if err := r.config.Scheduler.Start(ctx); err != nil {
 		r.setIssue("storage_scheduler", "Storage scheduler failed to start", err.Error())
 		return
 	}
+	r.clearIssue("storage_scheduler")
 	r.config.Scheduler.ApplySettings(settings)
 }
 
@@ -103,14 +122,28 @@ func (r *Runtime) Category() string { return "storage" }
 func (r *Runtime) Check(context.Context) []health.Issue {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	return append([]health.Issue(nil), r.issues...)
+	issues := make([]health.Issue, 0, len(r.issues))
+	for _, issue := range r.issues {
+		issues = append(issues, issue)
+	}
+	sort.Slice(issues, func(i, j int) bool { return issues[i].ID < issues[j].ID })
+	return issues
 }
 
 func (r *Runtime) setIssue(id, title, message string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.issues = append(r.issues, health.Issue{
+	if r.issues == nil {
+		r.issues = make(map[string]health.Issue)
+	}
+	r.issues[id] = health.Issue{
 		ID: id, Category: "storage", Title: title, Message: message,
 		Severity: health.SeverityWarning, FixURL: "/settings/system/storage", FixLabel: "Review storage",
-	})
+	}
+}
+
+func (r *Runtime) clearIssue(id string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.issues, id)
 }

--- a/apps/backend/internal/system/storage/runtime.go
+++ b/apps/backend/internal/system/storage/runtime.go
@@ -1,0 +1,116 @@
+package storage
+
+import (
+	"context"
+	"sync"
+
+	"github.com/kandev/kandev/internal/health"
+)
+
+type CleanupWorker interface {
+	StartTaskResourceCleanupWorker(context.Context) error
+	StopTaskResourceCleanupWorker()
+}
+
+type StartupReconciler interface {
+	Reconcile(context.Context) error
+}
+
+type RuntimeSettings interface {
+	GetSettings(context.Context) (StorageMaintenanceSettings, error)
+}
+
+type RuntimeConfig struct {
+	Scheduler  *Scheduler
+	Settings   RuntimeSettings
+	Worker     CleanupWorker
+	Reconciler StartupReconciler
+}
+
+type Runtime struct {
+	config RuntimeConfig
+	mu     sync.Mutex
+	ctx    context.Context
+	issues []health.Issue
+}
+
+func NewRuntime(config RuntimeConfig) *Runtime {
+	return &Runtime{config: config}
+}
+
+func (r *Runtime) Start(ctx context.Context) error {
+	r.mu.Lock()
+	if r.ctx != nil {
+		r.mu.Unlock()
+		return nil
+	}
+	r.ctx = ctx
+	r.mu.Unlock()
+	if r.config.Worker != nil {
+		if err := r.config.Worker.StartTaskResourceCleanupWorker(ctx); err != nil {
+			r.setIssue("storage_cleanup_worker", "Task cleanup worker failed to start", err.Error())
+		}
+	}
+	if r.config.Reconciler != nil {
+		if err := r.config.Reconciler.Reconcile(ctx); err != nil {
+			r.setIssue("storage_reconciliation", "Storage reconciliation failed", err.Error())
+		}
+	}
+	settings, err := r.config.Settings.GetSettings(ctx)
+	if err != nil {
+		r.setIssue("storage_settings_invalid", "Storage maintenance is disabled", err.Error())
+		return nil
+	}
+	if settings.Enabled && r.config.Scheduler != nil {
+		return r.config.Scheduler.Start(ctx)
+	}
+	return nil
+}
+
+func (r *Runtime) Stop() {
+	if r.config.Scheduler != nil {
+		r.config.Scheduler.Stop()
+	}
+	if r.config.Worker != nil {
+		r.config.Worker.StopTaskResourceCleanupWorker()
+	}
+	r.mu.Lock()
+	r.ctx = nil
+	r.mu.Unlock()
+}
+
+func (r *Runtime) ApplySettings(settings StorageMaintenanceSettings) {
+	r.mu.Lock()
+	ctx := r.ctx
+	r.mu.Unlock()
+	if r.config.Scheduler == nil || ctx == nil {
+		return
+	}
+	if !settings.Enabled {
+		r.config.Scheduler.Stop()
+		return
+	}
+	if err := r.config.Scheduler.Start(ctx); err != nil {
+		r.setIssue("storage_scheduler", "Storage scheduler failed to start", err.Error())
+		return
+	}
+	r.config.Scheduler.ApplySettings(settings)
+}
+
+func (r *Runtime) Name() string     { return "Storage maintenance" }
+func (r *Runtime) Category() string { return "storage" }
+
+func (r *Runtime) Check(context.Context) []health.Issue {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]health.Issue(nil), r.issues...)
+}
+
+func (r *Runtime) setIssue(id, title, message string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.issues = append(r.issues, health.Issue{
+		ID: id, Category: "storage", Title: title, Message: message,
+		Severity: health.SeverityWarning, FixURL: "/settings/system/storage", FixLabel: "Review storage",
+	})
+}

--- a/apps/backend/internal/system/storage/runtime_test.go
+++ b/apps/backend/internal/system/storage/runtime_test.go
@@ -1,0 +1,166 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestRuntimeStopSerializesWithApplySettings(t *testing.T) {
+	settings := DefaultSettings()
+	scheduler := NewScheduler(staticRuntimeSettings{settings: settings}, nil, SchedulerOptions{
+		After: func(time.Duration) <-chan time.Time { return make(chan time.Time) },
+	})
+	t.Cleanup(scheduler.Stop)
+	worker := &blockingStopWorker{started: make(chan struct{}), release: make(chan struct{})}
+	runtime := NewRuntime(RuntimeConfig{
+		Scheduler: scheduler, Settings: staticRuntimeSettings{settings: settings}, Worker: worker,
+	})
+	if err := runtime.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	stopped := make(chan struct{})
+	go func() {
+		runtime.Stop()
+		close(stopped)
+	}()
+	<-worker.started
+
+	enabled := settings
+	enabled.Enabled = true
+	applied := make(chan struct{})
+	go func() {
+		runtime.ApplySettings(enabled)
+		close(applied)
+	}()
+	select {
+	case <-applied:
+		t.Fatal("ApplySettings completed while Stop was still in progress")
+	default:
+	}
+	close(worker.release)
+	<-stopped
+	<-applied
+
+	scheduler.mu.Lock()
+	running := scheduler.cancel != nil
+	scheduler.mu.Unlock()
+	if running {
+		t.Fatal("scheduler restarted after runtime stop")
+	}
+}
+
+func TestRuntimeHealthIssuesAreCurrentAndUnique(t *testing.T) {
+	schedulerSettings := &mutableRuntimeSettings{
+		settings: DefaultSettings(), err: errors.New("scheduler unavailable"),
+	}
+	scheduler := NewScheduler(schedulerSettings, nil, SchedulerOptions{})
+	t.Cleanup(scheduler.Stop)
+	runtime := NewRuntime(RuntimeConfig{
+		Scheduler: scheduler, Settings: staticRuntimeSettings{settings: DefaultSettings()},
+	})
+	if err := runtime.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	enabled := DefaultSettings()
+	enabled.Enabled = true
+	runtime.ApplySettings(enabled)
+	runtime.ApplySettings(enabled)
+	if issues := runtime.Check(context.Background()); len(issues) != 1 || issues[0].ID != "storage_scheduler" {
+		t.Fatalf("issues after repeated failure = %#v, want one scheduler issue", issues)
+	}
+	schedulerSettings.err = nil
+	runtime.ApplySettings(enabled)
+	if issues := runtime.Check(context.Background()); len(issues) != 0 {
+		t.Fatalf("issues after scheduler recovery = %#v, want none", issues)
+	}
+}
+
+func TestRuntimeStartClearsRecoveredIssues(t *testing.T) {
+	settings := &mutableRuntimeSettings{err: errors.New("settings unavailable")}
+	worker := &toggleCleanupWorker{err: errors.New("worker unavailable")}
+	reconciler := &toggleReconciler{err: errors.New("reconciler unavailable")}
+	runtime := NewRuntime(RuntimeConfig{Settings: settings, Worker: worker, Reconciler: reconciler})
+	if err := runtime.Start(context.Background()); err != nil {
+		t.Fatalf("first Start: %v", err)
+	}
+	if issues := runtime.Check(context.Background()); len(issues) != 3 {
+		t.Fatalf("issues after failures = %#v, want three", issues)
+	}
+	runtime.Stop()
+	settings.err = nil
+	worker.err = nil
+	reconciler.err = nil
+	if err := runtime.Start(context.Background()); err != nil {
+		t.Fatalf("second Start: %v", err)
+	}
+	if issues := runtime.Check(context.Background()); len(issues) != 0 {
+		t.Fatalf("issues after recovery = %#v, want none", issues)
+	}
+}
+
+func TestRuntimeStartTracksAndClearsSchedulerIssue(t *testing.T) {
+	enabled := DefaultSettings()
+	enabled.Enabled = true
+	schedulerSettings := &mutableRuntimeSettings{settings: enabled, err: errors.New("scheduler unavailable")}
+	scheduler := NewScheduler(schedulerSettings, nil, SchedulerOptions{
+		After: func(time.Duration) <-chan time.Time { return make(chan time.Time) },
+	})
+	t.Cleanup(scheduler.Stop)
+	runtime := NewRuntime(RuntimeConfig{
+		Scheduler: scheduler, Settings: staticRuntimeSettings{settings: enabled},
+	})
+	if err := runtime.Start(context.Background()); err == nil {
+		t.Fatal("first Start returned nil error")
+	}
+	if issues := runtime.Check(context.Background()); len(issues) != 1 || issues[0].ID != "storage_scheduler" {
+		t.Fatalf("issues after scheduler failure = %#v, want scheduler issue", issues)
+	}
+	runtime.Stop()
+	schedulerSettings.err = nil
+	if err := runtime.Start(context.Background()); err != nil {
+		t.Fatalf("second Start: %v", err)
+	}
+	if issues := runtime.Check(context.Background()); len(issues) != 0 {
+		t.Fatalf("issues after scheduler recovery = %#v, want none", issues)
+	}
+}
+
+type mutableRuntimeSettings struct {
+	settings StorageMaintenanceSettings
+	err      error
+}
+
+type toggleCleanupWorker struct{ err error }
+
+func (w *toggleCleanupWorker) StartTaskResourceCleanupWorker(context.Context) error { return w.err }
+func (*toggleCleanupWorker) StopTaskResourceCleanupWorker()                         {}
+
+type toggleReconciler struct{ err error }
+
+func (r *toggleReconciler) Reconcile(context.Context) error { return r.err }
+
+func (s *mutableRuntimeSettings) GetSettings(context.Context) (StorageMaintenanceSettings, error) {
+	return s.settings, s.err
+}
+
+type staticRuntimeSettings struct {
+	settings StorageMaintenanceSettings
+}
+
+func (s staticRuntimeSettings) GetSettings(context.Context) (StorageMaintenanceSettings, error) {
+	return s.settings, nil
+}
+
+type blockingStopWorker struct {
+	started chan struct{}
+	release chan struct{}
+}
+
+func (*blockingStopWorker) StartTaskResourceCleanupWorker(context.Context) error { return nil }
+
+func (w *blockingStopWorker) StopTaskResourceCleanupWorker() {
+	close(w.started)
+	<-w.release
+}

--- a/apps/backend/internal/system/storage/runtime_test.go
+++ b/apps/backend/internal/system/storage/runtime_test.go
@@ -13,7 +13,7 @@ func TestRuntimeStopSerializesWithApplySettings(t *testing.T) {
 		After: func(time.Duration) <-chan time.Time { return make(chan time.Time) },
 	})
 	t.Cleanup(scheduler.Stop)
-	worker := &blockingStopWorker{started: make(chan struct{}), release: make(chan struct{})}
+	worker := &blockingStopWorker{stopStarted: make(chan struct{}), release: make(chan struct{})}
 	runtime := NewRuntime(RuntimeConfig{
 		Scheduler: scheduler, Settings: staticRuntimeSettings{settings: settings}, Worker: worker,
 	})
@@ -25,7 +25,7 @@ func TestRuntimeStopSerializesWithApplySettings(t *testing.T) {
 		runtime.Stop()
 		close(stopped)
 	}()
-	<-worker.started
+	<-worker.stopStarted
 
 	enabled := settings
 	enabled.Enabled = true
@@ -154,13 +154,13 @@ func (s staticRuntimeSettings) GetSettings(context.Context) (StorageMaintenanceS
 }
 
 type blockingStopWorker struct {
-	started chan struct{}
-	release chan struct{}
+	stopStarted chan struct{}
+	release     chan struct{}
 }
 
 func (*blockingStopWorker) StartTaskResourceCleanupWorker(context.Context) error { return nil }
 
 func (w *blockingStopWorker) StopTaskResourceCleanupWorker() {
-	close(w.started)
+	close(w.stopStarted)
 	<-w.release
 }

--- a/apps/backend/internal/system/storage/scheduler.go
+++ b/apps/backend/internal/system/storage/scheduler.go
@@ -1,0 +1,131 @@
+package storage
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+type SchedulerSettings interface {
+	GetSettings(ctx context.Context) (StorageMaintenanceSettings, error)
+}
+
+type ScheduledRunner interface {
+	Run(ctx context.Context, trigger RunTrigger, settings StorageMaintenanceSettings) (MaintenanceRun, error)
+}
+
+type SchedulerOptions struct {
+	After func(time.Duration) <-chan time.Time
+}
+
+type Scheduler struct {
+	settings SchedulerSettings
+	runner   ScheduledRunner
+	after    func(time.Duration) <-chan time.Time
+
+	lifecycleMu sync.Mutex
+	mu          sync.Mutex
+	cancel      context.CancelFunc
+	wake        chan struct{}
+	latest      StorageMaintenanceSettings
+	wg          sync.WaitGroup
+}
+
+func NewScheduler(settings SchedulerSettings, runner ScheduledRunner, options SchedulerOptions) *Scheduler {
+	after := options.After
+	if after == nil {
+		after = time.After
+	}
+	return &Scheduler{settings: settings, runner: runner, after: after}
+}
+
+func (s *Scheduler) Start(ctx context.Context) error {
+	s.lifecycleMu.Lock()
+	defer s.lifecycleMu.Unlock()
+	s.mu.Lock()
+	running := s.cancel != nil
+	s.mu.Unlock()
+	if running {
+		return nil
+	}
+	settings, err := s.settings.GetSettings(ctx)
+	if err != nil {
+		return err
+	}
+	s.mu.Lock()
+	workerCtx, cancel := context.WithCancel(ctx)
+	s.cancel = cancel
+	s.wake = make(chan struct{}, 1)
+	s.latest = settings
+	s.wg.Add(1)
+	wake := s.wake
+	s.mu.Unlock()
+	go s.run(workerCtx, settings, wake)
+	return nil
+}
+
+func (s *Scheduler) ApplySettings(settings StorageMaintenanceSettings) {
+	s.mu.Lock()
+	if s.cancel == nil || s.wake == nil {
+		s.mu.Unlock()
+		return
+	}
+	s.latest = settings
+	wake := s.wake
+	s.mu.Unlock()
+	select {
+	case wake <- struct{}{}:
+	default:
+	}
+}
+
+func (s *Scheduler) Stop() {
+	s.lifecycleMu.Lock()
+	defer s.lifecycleMu.Unlock()
+	s.mu.Lock()
+	cancel := s.cancel
+	s.cancel = nil
+	s.wake = nil
+	s.mu.Unlock()
+	if cancel != nil {
+		cancel()
+		s.wg.Wait()
+	}
+}
+
+func (s *Scheduler) run(
+	ctx context.Context,
+	settings StorageMaintenanceSettings,
+	wake <-chan struct{},
+) {
+	defer s.wg.Done()
+	var interval <-chan time.Time
+	if settings.Enabled {
+		interval = s.after(settingsInterval(settings))
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-wake:
+			settings = s.latestSettings()
+			interval = nil
+			if settings.Enabled {
+				interval = s.after(settingsInterval(settings))
+			}
+		case <-interval:
+			_, _ = s.runner.Run(ctx, RunTriggerScheduled, settings)
+			interval = s.after(settingsInterval(settings))
+		}
+	}
+}
+
+func (s *Scheduler) latestSettings() StorageMaintenanceSettings {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.latest
+}
+
+func settingsInterval(settings StorageMaintenanceSettings) time.Duration {
+	return time.Duration(settings.CheckIntervalHours) * time.Hour
+}

--- a/apps/backend/internal/system/storage/scheduler_test.go
+++ b/apps/backend/internal/system/storage/scheduler_test.go
@@ -1,0 +1,114 @@
+package storage
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"testing/synctest"
+	"time"
+)
+
+func TestSchedulerFirstEnabledRunWaitsFullInterval(t *testing.T) {
+	ticks := make(chan time.Time, 1)
+	runner := &recordingScheduledRunner{calls: make(chan struct{}, 1)}
+	settings := DefaultSettings()
+	settings.Enabled = true
+	scheduler := NewScheduler(staticSchedulerSettings{settings: settings}, runner, SchedulerOptions{
+		After: func(time.Duration) <-chan time.Time { return ticks },
+	})
+	if err := scheduler.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer scheduler.Stop()
+	select {
+	case <-runner.calls:
+		t.Fatal("scheduler ran before the first full interval")
+	default:
+	}
+	ticks <- time.Now()
+	select {
+	case <-runner.calls:
+	case <-time.After(time.Second):
+		t.Fatal("scheduler did not run after the interval")
+	}
+}
+
+func TestDisabledSchedulerStartsNoDestructiveLoop(t *testing.T) {
+	runner := &recordingScheduledRunner{calls: make(chan struct{}, 1)}
+	scheduler := NewScheduler(staticSchedulerSettings{settings: DefaultSettings()}, runner, SchedulerOptions{
+		After: func(time.Duration) <-chan time.Time {
+			t.Fatal("disabled scheduler created a destructive timer")
+			return nil
+		},
+	})
+	if err := scheduler.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	scheduler.Stop()
+	select {
+	case <-runner.calls:
+		t.Fatal("disabled scheduler ran maintenance")
+	default:
+	}
+}
+
+func TestSchedulerConcurrentApplySettingsAndStopDoNotBlock(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		scheduler := NewScheduler(
+			staticSchedulerSettings{settings: DefaultSettings()},
+			&recordingScheduledRunner{calls: make(chan struct{}, 1)},
+			SchedulerOptions{},
+		)
+		workerCtx, cancel := context.WithCancel(context.Background())
+		wake := make(chan struct{})
+		scheduler.mu.Lock()
+		scheduler.cancel = cancel
+		scheduler.wake = wake
+		scheduler.wg.Add(1)
+		scheduler.mu.Unlock()
+		go func() {
+			defer scheduler.wg.Done()
+			<-workerCtx.Done()
+		}()
+
+		applyDone := make(chan struct{})
+		go func() {
+			scheduler.ApplySettings(DefaultSettings())
+			close(applyDone)
+		}()
+		synctest.Wait()
+
+		scheduler.Stop()
+		synctest.Wait()
+		select {
+		case <-applyDone:
+			return
+		default:
+			// Drain the old implementation's blocking send before failing so the
+			// regression test itself does not leak a goroutine.
+			<-wake
+			synctest.Wait()
+			t.Fatal("ApplySettings remained blocked after concurrent Stop")
+		}
+	})
+}
+
+type staticSchedulerSettings struct {
+	settings StorageMaintenanceSettings
+}
+
+func (s staticSchedulerSettings) GetSettings(context.Context) (StorageMaintenanceSettings, error) {
+	return s.settings, nil
+}
+
+type recordingScheduledRunner struct {
+	mu    sync.Mutex
+	calls chan struct{}
+}
+
+func (r *recordingScheduledRunner) Run(context.Context, RunTrigger, StorageMaintenanceSettings) (MaintenanceRun, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls <- struct{}{}
+	return MaintenanceRun{}, nil
+}

--- a/apps/backend/internal/system/storage/settings.go
+++ b/apps/backend/internal/system/storage/settings.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	systemsettings "github.com/kandev/kandev/internal/system/settings"
@@ -57,7 +58,10 @@ func (s *SettingsStore) SaveSettingsWithConfirmations(
 	}
 	current, err := s.GetSettings(ctx)
 	if err != nil {
-		return StorageMaintenanceSettings{}, err
+		if !errors.Is(err, ErrInvalidPersistedSettings) {
+			return StorageMaintenanceSettings{}, err
+		}
+		current = DefaultSettings()
 	}
 	if normalized.GoCache.AdoptedPath != current.GoCache.AdoptedPath && !confirmations.adoptGoCache {
 		return StorageMaintenanceSettings{}, ErrAdoptionRequired
@@ -85,7 +89,10 @@ func (s *SettingsStore) AdoptGoCachePath(
 	}
 	settings, err := s.GetSettings(ctx)
 	if err != nil {
-		return StorageMaintenanceSettings{}, err
+		if !errors.Is(err, ErrInvalidPersistedSettings) {
+			return StorageMaintenanceSettings{}, err
+		}
+		settings = DefaultSettings()
 	}
 	settings.GoCache.AdoptedPath = path
 	return s.SaveSettingsWithConfirmations(ctx, settings, SaveConfirmations{adoptGoCache: true})

--- a/apps/backend/internal/system/storage/settings.go
+++ b/apps/backend/internal/system/storage/settings.go
@@ -1,0 +1,92 @@
+package storage
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	systemsettings "github.com/kandev/kandev/internal/system/settings"
+)
+
+const settingsKey = "storage_maintenance"
+
+type SettingsStore struct {
+	settings *systemsettings.Store
+}
+
+type SaveConfirmations struct {
+	DedicatedDocker bool
+	adoptGoCache    bool
+}
+
+func NewSettingsStore(settings *systemsettings.Store) *SettingsStore {
+	return &SettingsStore{settings: settings}
+}
+
+func (s *SettingsStore) GetSettings(ctx context.Context) (StorageMaintenanceSettings, error) {
+	raw, found, err := s.settings.Get(ctx, settingsKey)
+	if err != nil || !found {
+		return DefaultSettings(), err
+	}
+	settings := DefaultSettings()
+	if err := json.Unmarshal(raw, &settings); err != nil {
+		return DefaultSettings(), fmt.Errorf("%w: decode JSON: %w", ErrInvalidPersistedSettings, err)
+	}
+	normalized, err := NormalizeSettings(settings)
+	if err != nil {
+		return DefaultSettings(), fmt.Errorf("%w: %w", ErrInvalidPersistedSettings, err)
+	}
+	return normalized, nil
+}
+
+func (s *SettingsStore) SaveSettings(
+	ctx context.Context,
+	settings StorageMaintenanceSettings,
+) (StorageMaintenanceSettings, error) {
+	return s.SaveSettingsWithConfirmations(ctx, settings, SaveConfirmations{})
+}
+
+func (s *SettingsStore) SaveSettingsWithConfirmations(
+	ctx context.Context,
+	settings StorageMaintenanceSettings,
+	confirmations SaveConfirmations,
+) (StorageMaintenanceSettings, error) {
+	normalized, err := NormalizeSettings(settings)
+	if err != nil {
+		return StorageMaintenanceSettings{}, err
+	}
+	current, err := s.GetSettings(ctx)
+	if err != nil {
+		return StorageMaintenanceSettings{}, err
+	}
+	if normalized.GoCache.AdoptedPath != current.GoCache.AdoptedPath && !confirmations.adoptGoCache {
+		return StorageMaintenanceSettings{}, ErrAdoptionRequired
+	}
+	if normalized.Docker.DedicatedDaemonAcknowledged &&
+		!current.Docker.DedicatedDaemonAcknowledged && !confirmations.DedicatedDocker {
+		return StorageMaintenanceSettings{}, ErrDedicatedDockerConfirmation
+	}
+	raw, err := json.Marshal(normalized)
+	if err != nil {
+		return StorageMaintenanceSettings{}, err
+	}
+	if err := s.settings.Save(ctx, settingsKey, raw); err != nil {
+		return StorageMaintenanceSettings{}, err
+	}
+	return normalized, nil
+}
+
+func (s *SettingsStore) AdoptGoCachePath(
+	ctx context.Context,
+	path string,
+) (StorageMaintenanceSettings, error) {
+	if path == "" {
+		return StorageMaintenanceSettings{}, validationError("go_cache.adopted_path is required")
+	}
+	settings, err := s.GetSettings(ctx)
+	if err != nil {
+		return StorageMaintenanceSettings{}, err
+	}
+	settings.GoCache.AdoptedPath = path
+	return s.SaveSettingsWithConfirmations(ctx, settings, SaveConfirmations{adoptGoCache: true})
+}

--- a/apps/backend/internal/system/storage/settings_test.go
+++ b/apps/backend/internal/system/storage/settings_test.go
@@ -1,0 +1,248 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"reflect"
+	"testing"
+
+	"github.com/jmoiron/sqlx"
+	_ "github.com/mattn/go-sqlite3"
+
+	"github.com/kandev/kandev/internal/db"
+	systemsettings "github.com/kandev/kandev/internal/system/settings"
+)
+
+func TestSettingsStoreMissingUsesDisabledDefaults(t *testing.T) {
+	store, _ := newTestStores(t)
+
+	got, err := store.GetSettings(context.Background())
+	if err != nil {
+		t.Fatalf("GetSettings: %v", err)
+	}
+	want := StorageMaintenanceSettings{
+		Enabled:                  false,
+		CheckIntervalHours:       24,
+		IdleForMinutes:           10,
+		OrphanGraceHours:         168,
+		QuarantineRetentionHours: 168,
+		Workspaces:               ResourceSettings{Enabled: true},
+		KandevContainers:         ResourceSettings{Enabled: true},
+		GoCache: GoCacheSettings{
+			Enabled:     false,
+			MaxBytes:    16106127360,
+			AdoptedPath: "",
+		},
+		Docker: DockerSettings{
+			DedicatedDaemonAcknowledged: false,
+			BuildCacheEnabled:           false,
+			BuildCacheKeepBytes:         10737418240,
+			BuildCacheUnusedHours:       168,
+			UnusedImagesEnabled:         false,
+			UnusedImagesHours:           168,
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("settings = %#v, want %#v", got, want)
+	}
+}
+
+func TestSettingsStoreReadFillsMissingFieldsAndIgnoresUnknownFields(t *testing.T) {
+	store, rawStore := newTestStores(t)
+	if err := rawStore.Save(context.Background(), settingsKey, []byte(`{"enabled":true,"unknown":"ignored"}`)); err != nil {
+		t.Fatalf("seed settings: %v", err)
+	}
+
+	got, err := store.GetSettings(context.Background())
+	if err != nil {
+		t.Fatalf("GetSettings: %v", err)
+	}
+	if !got.Enabled || got.CheckIntervalHours != 24 || !got.Workspaces.Enabled || !got.KandevContainers.Enabled {
+		t.Fatalf("missing fields were not defaulted: %#v", got)
+	}
+}
+
+func TestSettingsStoreInvalidSavePreservesPreviousValue(t *testing.T) {
+	store, rawStore := newTestStores(t)
+	ctx := context.Background()
+	want := DefaultSettings()
+	want.Enabled = true
+	if _, err := store.SaveSettings(ctx, want); err != nil {
+		t.Fatalf("save valid settings: %v", err)
+	}
+
+	invalid := want
+	invalid.CheckIntervalHours = 169
+	if _, err := store.SaveSettings(ctx, invalid); !errors.Is(err, ErrValidation) {
+		t.Fatalf("invalid save error = %v, want ErrValidation", err)
+	}
+
+	raw, found, err := rawStore.Get(ctx, settingsKey)
+	if err != nil || !found {
+		t.Fatalf("read raw settings = (%q, %v, %v)", raw, found, err)
+	}
+	got, err := store.GetSettings(ctx)
+	if err != nil {
+		t.Fatalf("GetSettings: %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("settings after invalid save = %#v, want %#v", got, want)
+	}
+}
+
+func TestNormalizeSettingsValidatesRangesAndDockerAcknowledgement(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*StorageMaintenanceSettings)
+	}{
+		{name: "check interval too low", mutate: func(s *StorageMaintenanceSettings) { s.CheckIntervalHours = 0 }},
+		{name: "idle too high", mutate: func(s *StorageMaintenanceSettings) { s.IdleForMinutes = 1441 }},
+		{name: "orphan grace too low", mutate: func(s *StorageMaintenanceSettings) { s.OrphanGraceHours = 23 }},
+		{name: "quarantine retention too high", mutate: func(s *StorageMaintenanceSettings) { s.QuarantineRetentionHours = 2161 }},
+		{name: "go cache too small", mutate: func(s *StorageMaintenanceSettings) { s.GoCache.MaxBytes = 1073741823 }},
+		{name: "build cache too small", mutate: func(s *StorageMaintenanceSettings) { s.Docker.BuildCacheKeepBytes = 1073741823 }},
+		{name: "build cache age too low", mutate: func(s *StorageMaintenanceSettings) { s.Docker.BuildCacheUnusedHours = 23 }},
+		{name: "image age too low", mutate: func(s *StorageMaintenanceSettings) { s.Docker.UnusedImagesHours = 23 }},
+		{name: "build cache without dedicated daemon", mutate: func(s *StorageMaintenanceSettings) { s.Docker.BuildCacheEnabled = true }},
+		{name: "images without dedicated daemon", mutate: func(s *StorageMaintenanceSettings) { s.Docker.UnusedImagesEnabled = true }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			settings := DefaultSettings()
+			tt.mutate(&settings)
+			if _, err := NormalizeSettings(settings); !errors.Is(err, ErrValidation) {
+				t.Fatalf("NormalizeSettings error = %v, want ErrValidation", err)
+			}
+		})
+	}
+}
+
+func TestNormalizeSettingsAllowsAcknowledgedDockerCleanup(t *testing.T) {
+	settings := DefaultSettings()
+	settings.Docker.DedicatedDaemonAcknowledged = true
+	settings.Docker.BuildCacheEnabled = true
+	settings.Docker.UnusedImagesEnabled = true
+
+	if _, err := NormalizeSettings(settings); err != nil {
+		t.Fatalf("NormalizeSettings: %v", err)
+	}
+}
+
+func TestSettingsStoreRejectsRelativeAdoptedPath(t *testing.T) {
+	settings := DefaultSettings()
+	settings.GoCache.AdoptedPath = "relative/go-build"
+	if _, err := NormalizeSettings(settings); !errors.Is(err, ErrValidation) {
+		t.Fatalf("NormalizeSettings error = %v, want ErrValidation", err)
+	}
+}
+
+func TestSettingsStoreRequiresDedicatedAdoptionPath(t *testing.T) {
+	store, _ := newTestStores(t)
+	ctx := context.Background()
+	settings := DefaultSettings()
+	settings.GoCache.AdoptedPath = "/tmp/go-build"
+
+	if _, err := store.SaveSettings(ctx, settings); !errors.Is(err, ErrAdoptionRequired) {
+		t.Fatalf("SaveSettings error = %v, want ErrAdoptionRequired", err)
+	}
+	got, err := store.GetSettings(ctx)
+	if err != nil {
+		t.Fatalf("GetSettings: %v", err)
+	}
+	if got.GoCache.AdoptedPath != "" {
+		t.Fatalf("adopted path after rejected save = %q", got.GoCache.AdoptedPath)
+	}
+
+	got, err = store.AdoptGoCachePath(ctx, "/tmp/go-build")
+	if err != nil {
+		t.Fatalf("AdoptGoCachePath: %v", err)
+	}
+	if got.GoCache.AdoptedPath != "/tmp/go-build" {
+		t.Fatalf("adopted path = %q", got.GoCache.AdoptedPath)
+	}
+}
+
+func TestSettingsStoreRequiresDedicatedDockerConfirmation(t *testing.T) {
+	store, _ := newTestStores(t)
+	ctx := context.Background()
+	settings := DefaultSettings()
+	settings.Docker.DedicatedDaemonAcknowledged = true
+
+	if _, err := store.SaveSettings(ctx, settings); !errors.Is(err, ErrDedicatedDockerConfirmation) {
+		t.Fatalf("SaveSettings error = %v, want ErrDedicatedDockerConfirmation", err)
+	}
+	if _, err := store.SaveSettingsWithConfirmations(ctx, settings, SaveConfirmations{DedicatedDocker: true}); err != nil {
+		t.Fatalf("SaveSettingsWithConfirmations: %v", err)
+	}
+}
+
+func TestSettingsStoreInvalidPersistedValuesFailSafeToDisabledDefaults(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+	}{
+		{name: "corrupt JSON", raw: `{"enabled":true`},
+		{name: "overflowing Docker age", raw: `{
+			"enabled":true,
+			"docker":{
+				"dedicated_daemon_acknowledged":true,
+				"build_cache_enabled":true,
+				"build_cache_unused_hours":` + fmt.Sprint(math.MaxInt) + `
+			}
+		}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store, rawStore := newTestStores(t)
+			ctx := context.Background()
+			if err := rawStore.Save(ctx, settingsKey, []byte(tt.raw)); err != nil {
+				t.Fatalf("seed settings: %v", err)
+			}
+
+			got, err := store.GetSettings(ctx)
+			if !errors.Is(err, ErrInvalidPersistedSettings) {
+				t.Fatalf("GetSettings error = %v, want ErrInvalidPersistedSettings", err)
+			}
+			if !reflect.DeepEqual(got, DefaultSettings()) {
+				t.Fatalf("settings = %#v, want exact disabled defaults %#v", got, DefaultSettings())
+			}
+		})
+	}
+}
+
+func TestNormalizeSettingsRejectsOverflowingDockerAges(t *testing.T) {
+	settings := DefaultSettings()
+	settings.Docker.BuildCacheUnusedHours = math.MaxInt
+	if _, err := NormalizeSettings(settings); !errors.Is(err, ErrValidation) {
+		t.Fatalf("build cache age error = %v, want ErrValidation", err)
+	}
+
+	settings = DefaultSettings()
+	settings.Docker.UnusedImagesHours = math.MaxInt
+	if _, err := NormalizeSettings(settings); !errors.Is(err, ErrValidation) {
+		t.Fatalf("image age error = %v, want ErrValidation", err)
+	}
+}
+
+func newTestStores(t *testing.T) (*SettingsStore, *systemsettings.Store) {
+	t.Helper()
+	conn := newSQLite(t)
+	rawStore, err := systemsettings.NewStore(db.NewPool(conn, conn))
+	if err != nil {
+		t.Fatalf("new settings store: %v", err)
+	}
+	return NewSettingsStore(rawStore), rawStore
+}
+
+func newSQLite(t *testing.T) *sqlx.DB {
+	t.Helper()
+	conn, err := sqlx.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	conn.SetMaxOpenConns(1)
+	t.Cleanup(func() { _ = conn.Close() })
+	return conn
+}

--- a/apps/backend/internal/system/storage/settings_test.go
+++ b/apps/backend/internal/system/storage/settings_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"path/filepath"
 	"reflect"
 	"testing"
 
@@ -138,6 +139,14 @@ func TestSettingsStoreRejectsRelativeAdoptedPath(t *testing.T) {
 	}
 }
 
+func TestNormalizeSettingsRejectsFilesystemRootAdoptedPath(t *testing.T) {
+	settings := DefaultSettings()
+	settings.GoCache.AdoptedPath = string(filepath.Separator)
+	if _, err := NormalizeSettings(settings); !errors.Is(err, ErrValidation) {
+		t.Fatalf("NormalizeSettings error = %v, want ErrValidation", err)
+	}
+}
+
 func TestSettingsStoreRequiresDedicatedAdoptionPath(t *testing.T) {
 	store, _ := newTestStores(t)
 	ctx := context.Background()
@@ -207,6 +216,28 @@ func TestSettingsStoreInvalidPersistedValuesFailSafeToDisabledDefaults(t *testin
 			}
 			if !reflect.DeepEqual(got, DefaultSettings()) {
 				t.Fatalf("settings = %#v, want exact disabled defaults %#v", got, DefaultSettings())
+			}
+		})
+	}
+}
+
+func TestSettingsStoreCanOverwriteInvalidPersistedSettings(t *testing.T) {
+	for _, operation := range []string{"save", "adopt"} {
+		t.Run(operation, func(t *testing.T) {
+			store, rawStore := newTestStores(t)
+			ctx := context.Background()
+			if err := rawStore.Save(ctx, settingsKey, []byte(`{"enabled":true`)); err != nil {
+				t.Fatalf("seed invalid settings: %v", err)
+			}
+			if operation == "adopt" {
+				if _, err := store.AdoptGoCachePath(ctx, filepath.Join(t.TempDir(), "go-build")); err != nil {
+					t.Fatalf("AdoptGoCachePath: %v", err)
+				}
+			} else if _, err := store.SaveSettings(ctx, DefaultSettings()); err != nil {
+				t.Fatalf("SaveSettings: %v", err)
+			}
+			if _, err := store.GetSettings(ctx); err != nil {
+				t.Fatalf("GetSettings after overwrite: %v", err)
 			}
 		})
 	}

--- a/apps/backend/internal/system/storage/store.go
+++ b/apps/backend/internal/system/storage/store.go
@@ -432,7 +432,8 @@ func normalizeAbsolutePath(field, path string) (string, error) {
 
 func validRunTransition(current, next RunState) bool {
 	if current == RunStateQueued {
-		return next == RunStateRunning || next == RunStateSkippedBusy
+		return next == RunStateRunning || next == RunStateSkippedBusy ||
+			next == RunStateCancelled || next == RunStateFailed
 	}
 	if current == RunStateRunning {
 		return next == RunStateSucceeded || next == RunStateFailed || next == RunStateCancelled

--- a/apps/backend/internal/system/storage/store.go
+++ b/apps/backend/internal/system/storage/store.go
@@ -1,0 +1,521 @@
+package storage
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+
+	"github.com/kandev/kandev/internal/db"
+)
+
+const terminalRunRetention = 20
+
+var (
+	ErrNotFound          = errors.New("storage record not found")
+	ErrConflict          = errors.New("storage operation conflicts with current state")
+	ErrInvalidTransition = errors.New("invalid storage state transition")
+)
+
+type RunTrigger string
+
+const (
+	RunTriggerScheduled RunTrigger = "scheduled"
+	RunTriggerManual    RunTrigger = "manual"
+	RunTriggerAnalysis  RunTrigger = "analysis"
+)
+
+type RunState string
+
+const (
+	RunStateQueued      RunState = "queued"
+	RunStateRunning     RunState = "running"
+	RunStateSucceeded   RunState = "succeeded"
+	RunStateFailed      RunState = "failed"
+	RunStateCancelled   RunState = "cancelled"
+	RunStateSkippedBusy RunState = "skipped_busy"
+)
+
+type MaintenanceRun struct {
+	ID               string          `json:"id"`
+	Trigger          RunTrigger      `json:"trigger"`
+	State            RunState        `json:"state"`
+	SettingsSnapshot json.RawMessage `json:"settings_snapshot"`
+	Result           json.RawMessage `json:"result"`
+	Message          string          `json:"message"`
+	StartedAt        time.Time       `json:"started_at"`
+	CompletedAt      *time.Time      `json:"completed_at,omitempty"`
+}
+
+type ResourceType string
+
+const (
+	ResourceTypeTaskWorkspace ResourceType = "task_workspace"
+	ResourceTypeGoCache       ResourceType = "go_cache"
+)
+
+type QuarantineState string
+
+const (
+	QuarantineStateQuarantined QuarantineState = "quarantined"
+	QuarantineStateRestored    QuarantineState = "restored"
+	QuarantineStateDeleted     QuarantineState = "deleted"
+	QuarantineStateFailed      QuarantineState = "failed"
+)
+
+type QuarantineEntry struct {
+	ID             string          `json:"id"`
+	ResourceType   ResourceType    `json:"resource_type"`
+	TaskID         string          `json:"task_id,omitempty"`
+	WorkspaceID    string          `json:"workspace_id,omitempty"`
+	OriginalPath   string          `json:"original_path"`
+	QuarantinePath string          `json:"quarantine_path"`
+	SizeBytes      int64           `json:"size_bytes"`
+	State          QuarantineState `json:"state"`
+	QuarantinedAt  time.Time       `json:"quarantined_at"`
+	DeleteAfter    time.Time       `json:"delete_after"`
+	RestoredAt     *time.Time      `json:"restored_at,omitempty"`
+	DeletedAt      *time.Time      `json:"deleted_at,omitempty"`
+	LastError      string          `json:"last_error"`
+	Metadata       json.RawMessage `json:"metadata"`
+}
+
+type Store struct {
+	db *sqlx.DB
+	ro *sqlx.DB
+}
+
+func NewStore(pool *db.Pool) (*Store, error) {
+	store := &Store{db: pool.Writer(), ro: pool.Reader()}
+	if err := initStorageSchema(store.db); err != nil {
+		return nil, err
+	}
+	return store, nil
+}
+
+func (s *Store) CreateRun(ctx context.Context, run *MaintenanceRun) error {
+	if err := normalizeNewRun(run); err != nil {
+		return err
+	}
+	_, err := s.db.ExecContext(ctx, s.db.Rebind(`
+		INSERT INTO storage_maintenance_runs
+			(id, trigger, state, settings_snapshot, result, message, started_at, completed_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+	`), run.ID, run.Trigger, run.State, string(run.SettingsSnapshot), string(run.Result), run.Message,
+		run.StartedAt, run.CompletedAt)
+	if err != nil {
+		return fmt.Errorf("create storage maintenance run: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) GetRun(ctx context.Context, id string) (MaintenanceRun, error) {
+	row, err := getRunRow(ctx, s.ro, id)
+	if err != nil {
+		return MaintenanceRun{}, err
+	}
+	return row.run(), nil
+}
+
+func (s *Store) TransitionRun(
+	ctx context.Context,
+	id string,
+	next RunState,
+	result json.RawMessage,
+	message string,
+) (MaintenanceRun, error) {
+	tx, err := s.db.BeginTxx(ctx, nil)
+	if err != nil {
+		return MaintenanceRun{}, fmt.Errorf("begin run transition: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	current, err := getRunRow(ctx, tx, id)
+	if err != nil {
+		return MaintenanceRun{}, err
+	}
+	if !validRunTransition(RunState(current.State), next) {
+		return MaintenanceRun{}, transitionError("run", current.State, string(next))
+	}
+	if len(result) == 0 {
+		result = json.RawMessage(current.Result)
+	}
+	completedAt := runCompletionTime(next)
+	res, err := tx.ExecContext(ctx, tx.Rebind(`
+		UPDATE storage_maintenance_runs
+		SET state = ?, result = ?, message = ?, completed_at = ?
+		WHERE id = ? AND state = ?
+	`), next, string(normalizeJSON(result)), message, completedAt, id, current.State)
+	if err != nil {
+		return MaintenanceRun{}, fmt.Errorf("transition storage maintenance run: %w", err)
+	}
+	if err := requireOneRow(res); err != nil {
+		return MaintenanceRun{}, err
+	}
+	if isTerminalRunState(next) {
+		if err := pruneTerminalRuns(ctx, tx); err != nil {
+			return MaintenanceRun{}, err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return MaintenanceRun{}, fmt.Errorf("commit run transition: %w", err)
+	}
+	return s.GetRun(ctx, id)
+}
+
+func (s *Store) ListRuns(ctx context.Context, terminalLimit int) ([]MaintenanceRun, error) {
+	if terminalLimit <= 0 || terminalLimit > terminalRunRetention {
+		terminalLimit = terminalRunRetention
+	}
+	rows := make([]runRow, 0)
+	err := s.ro.SelectContext(ctx, &rows, s.ro.Rebind(`
+		SELECT id, trigger, state, settings_snapshot, result, message, started_at, completed_at
+		FROM storage_maintenance_runs
+		WHERE state NOT IN ('succeeded', 'failed', 'cancelled', 'skipped_busy')
+		   OR id IN (
+			SELECT id FROM storage_maintenance_runs
+			WHERE state IN ('succeeded', 'failed', 'cancelled', 'skipped_busy')
+			ORDER BY completed_at DESC, started_at DESC, id DESC
+			LIMIT ?
+		   )
+		ORDER BY started_at DESC, id DESC
+	`), terminalLimit)
+	if err != nil {
+		return nil, fmt.Errorf("list storage maintenance runs: %w", err)
+	}
+	runs := make([]MaintenanceRun, 0, len(rows))
+	for _, row := range rows {
+		runs = append(runs, row.run())
+	}
+	return runs, nil
+}
+
+func (s *Store) CreateQuarantineEntry(ctx context.Context, entry *QuarantineEntry) error {
+	if err := normalizeNewQuarantineEntry(entry); err != nil {
+		return err
+	}
+	_, err := s.db.ExecContext(ctx, s.db.Rebind(`
+		INSERT INTO storage_quarantine_entries
+			(id, resource_type, task_id, workspace_id, original_path, quarantine_path, size_bytes,
+			 state, quarantined_at, delete_after, restored_at, deleted_at, last_error, metadata)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`), entry.ID, entry.ResourceType, nullableString(entry.TaskID), nullableString(entry.WorkspaceID),
+		entry.OriginalPath, entry.QuarantinePath, entry.SizeBytes, entry.State, entry.QuarantinedAt,
+		entry.DeleteAfter, entry.RestoredAt, entry.DeletedAt, entry.LastError, string(entry.Metadata))
+	if err != nil {
+		return fmt.Errorf("create storage quarantine entry: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) GetQuarantineEntry(ctx context.Context, id string) (QuarantineEntry, error) {
+	row, err := getQuarantineRow(ctx, s.ro, id)
+	if err != nil {
+		return QuarantineEntry{}, err
+	}
+	return row.entry(), nil
+}
+
+func (s *Store) TransitionQuarantineEntry(
+	ctx context.Context,
+	id string,
+	next QuarantineState,
+	lastError string,
+) (QuarantineEntry, error) {
+	tx, err := s.db.BeginTxx(ctx, nil)
+	if err != nil {
+		return QuarantineEntry{}, fmt.Errorf("begin quarantine transition: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	current, err := getQuarantineRow(ctx, tx, id)
+	if err != nil {
+		return QuarantineEntry{}, err
+	}
+	if !validQuarantineTransition(QuarantineState(current.State), next) {
+		return QuarantineEntry{}, transitionError("quarantine", current.State, string(next))
+	}
+	restoredAt, deletedAt := quarantineCompletionTimes(next)
+	res, err := tx.ExecContext(ctx, tx.Rebind(`
+		UPDATE storage_quarantine_entries
+		SET state = ?, restored_at = ?, deleted_at = ?, last_error = ?
+		WHERE id = ? AND state = ?
+	`), next, restoredAt, deletedAt, lastError, id, current.State)
+	if err != nil {
+		return QuarantineEntry{}, fmt.Errorf("transition storage quarantine entry: %w", err)
+	}
+	if err := requireOneRow(res); err != nil {
+		return QuarantineEntry{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return QuarantineEntry{}, fmt.Errorf("commit quarantine transition: %w", err)
+	}
+	return s.GetQuarantineEntry(ctx, id)
+}
+
+func (s *Store) ListQuarantineEntries(ctx context.Context, includeTerminal bool) ([]QuarantineEntry, error) {
+	query := `SELECT id, resource_type, task_id, workspace_id, original_path, quarantine_path,
+		size_bytes, state, quarantined_at, delete_after, restored_at, deleted_at, last_error, metadata
+		FROM storage_quarantine_entries`
+	if !includeTerminal {
+		query += ` WHERE state IN ('quarantined', 'failed')`
+	}
+	query += ` ORDER BY quarantined_at DESC, id DESC`
+	rows := make([]quarantineRow, 0)
+	if err := s.ro.SelectContext(ctx, &rows, query); err != nil {
+		return nil, fmt.Errorf("list storage quarantine entries: %w", err)
+	}
+	entries := make([]QuarantineEntry, 0, len(rows))
+	for _, row := range rows {
+		entries = append(entries, row.entry())
+	}
+	return entries, nil
+}
+
+func (s *Store) SummarizeQuarantine(ctx context.Context) (QuarantineSummary, error) {
+	var summary QuarantineSummary
+	err := s.ro.GetContext(ctx, &summary, `
+		SELECT COUNT(*) AS count, COALESCE(SUM(size_bytes), 0) AS size_bytes
+		FROM storage_quarantine_entries
+		WHERE state IN ('quarantined', 'failed')
+	`)
+	if err != nil {
+		return QuarantineSummary{}, fmt.Errorf("summarize storage quarantine: %w", err)
+	}
+	return summary, nil
+}
+
+type queryer interface {
+	GetContext(context.Context, any, string, ...any) error
+	Rebind(string) string
+}
+
+type runRow struct {
+	ID               string     `db:"id"`
+	Trigger          string     `db:"trigger"`
+	State            string     `db:"state"`
+	SettingsSnapshot string     `db:"settings_snapshot"`
+	Result           string     `db:"result"`
+	Message          string     `db:"message"`
+	StartedAt        time.Time  `db:"started_at"`
+	CompletedAt      *time.Time `db:"completed_at"`
+}
+
+func getRunRow(ctx context.Context, conn queryer, id string) (runRow, error) {
+	var row runRow
+	err := conn.GetContext(ctx, &row, conn.Rebind(`
+		SELECT id, trigger, state, settings_snapshot, result, message, started_at, completed_at
+		FROM storage_maintenance_runs WHERE id = ?
+	`), id)
+	if errors.Is(err, sql.ErrNoRows) {
+		return runRow{}, ErrNotFound
+	}
+	if err != nil {
+		return runRow{}, fmt.Errorf("get storage maintenance run: %w", err)
+	}
+	return row, nil
+}
+
+func (r runRow) run() MaintenanceRun {
+	return MaintenanceRun{
+		ID: r.ID, Trigger: RunTrigger(r.Trigger), State: RunState(r.State),
+		SettingsSnapshot: json.RawMessage(r.SettingsSnapshot), Result: json.RawMessage(r.Result),
+		Message: r.Message, StartedAt: r.StartedAt, CompletedAt: r.CompletedAt,
+	}
+}
+
+type quarantineRow struct {
+	ID             string         `db:"id"`
+	ResourceType   string         `db:"resource_type"`
+	TaskID         sql.NullString `db:"task_id"`
+	WorkspaceID    sql.NullString `db:"workspace_id"`
+	OriginalPath   string         `db:"original_path"`
+	QuarantinePath string         `db:"quarantine_path"`
+	SizeBytes      int64          `db:"size_bytes"`
+	State          string         `db:"state"`
+	QuarantinedAt  time.Time      `db:"quarantined_at"`
+	DeleteAfter    time.Time      `db:"delete_after"`
+	RestoredAt     *time.Time     `db:"restored_at"`
+	DeletedAt      *time.Time     `db:"deleted_at"`
+	LastError      string         `db:"last_error"`
+	Metadata       string         `db:"metadata"`
+}
+
+func getQuarantineRow(ctx context.Context, conn queryer, id string) (quarantineRow, error) {
+	var row quarantineRow
+	err := conn.GetContext(ctx, &row, conn.Rebind(`
+		SELECT id, resource_type, task_id, workspace_id, original_path, quarantine_path,
+			size_bytes, state, quarantined_at, delete_after, restored_at, deleted_at, last_error, metadata
+		FROM storage_quarantine_entries WHERE id = ?
+	`), id)
+	if errors.Is(err, sql.ErrNoRows) {
+		return quarantineRow{}, ErrNotFound
+	}
+	if err != nil {
+		return quarantineRow{}, fmt.Errorf("get storage quarantine entry: %w", err)
+	}
+	return row, nil
+}
+
+func (r quarantineRow) entry() QuarantineEntry {
+	return QuarantineEntry{
+		ID: r.ID, ResourceType: ResourceType(r.ResourceType), TaskID: r.TaskID.String,
+		WorkspaceID: r.WorkspaceID.String, OriginalPath: r.OriginalPath, QuarantinePath: r.QuarantinePath,
+		SizeBytes: r.SizeBytes, State: QuarantineState(r.State), QuarantinedAt: r.QuarantinedAt,
+		DeleteAfter: r.DeleteAfter, RestoredAt: r.RestoredAt, DeletedAt: r.DeletedAt,
+		LastError: r.LastError, Metadata: json.RawMessage(r.Metadata),
+	}
+}
+
+func normalizeNewRun(run *MaintenanceRun) error {
+	if run == nil || run.ID == "" {
+		return validationError("run id is required")
+	}
+	if run.State != RunStateQueued {
+		return validationError("new run state must be queued")
+	}
+	if run.Trigger != RunTriggerScheduled && run.Trigger != RunTriggerManual && run.Trigger != RunTriggerAnalysis {
+		return validationError("unknown run trigger %q", run.Trigger)
+	}
+	run.SettingsSnapshot = normalizeJSON(run.SettingsSnapshot)
+	run.Result = normalizeJSON(run.Result)
+	if run.StartedAt.IsZero() {
+		run.StartedAt = time.Now().UTC()
+	}
+	run.StartedAt = run.StartedAt.UTC()
+	return nil
+}
+
+func normalizeNewQuarantineEntry(entry *QuarantineEntry) error {
+	if entry == nil || entry.ID == "" {
+		return validationError("quarantine entry id is required")
+	}
+	if entry.ResourceType != ResourceTypeTaskWorkspace && entry.ResourceType != ResourceTypeGoCache {
+		return validationError("unknown quarantine resource type %q", entry.ResourceType)
+	}
+	if entry.State != QuarantineStateQuarantined {
+		return validationError("new quarantine state must be quarantined")
+	}
+	if entry.SizeBytes < 0 {
+		return validationError("quarantine size_bytes cannot be negative")
+	}
+	var err error
+	entry.OriginalPath, err = normalizeAbsolutePath("original_path", entry.OriginalPath)
+	if err != nil {
+		return err
+	}
+	entry.QuarantinePath, err = normalizeAbsolutePath("quarantine_path", entry.QuarantinePath)
+	if err != nil {
+		return err
+	}
+	if entry.QuarantinedAt.IsZero() {
+		entry.QuarantinedAt = time.Now().UTC()
+	}
+	if entry.DeleteAfter.IsZero() || entry.DeleteAfter.Before(entry.QuarantinedAt) {
+		return validationError("delete_after must be at or after quarantined_at")
+	}
+	entry.QuarantinedAt = entry.QuarantinedAt.UTC()
+	entry.DeleteAfter = entry.DeleteAfter.UTC()
+	entry.Metadata = normalizeJSON(entry.Metadata)
+	return nil
+}
+
+func normalizeAbsolutePath(field, path string) (string, error) {
+	if path == "" || !filepath.IsAbs(path) {
+		return "", validationError("%s must be an absolute path", field)
+	}
+	return filepath.Clean(path), nil
+}
+
+func validRunTransition(current, next RunState) bool {
+	if current == RunStateQueued {
+		return next == RunStateRunning || next == RunStateSkippedBusy
+	}
+	if current == RunStateRunning {
+		return next == RunStateSucceeded || next == RunStateFailed || next == RunStateCancelled
+	}
+	return false
+}
+
+func validQuarantineTransition(current, next QuarantineState) bool {
+	if current == QuarantineStateQuarantined {
+		return next == QuarantineStateRestored || next == QuarantineStateDeleted || next == QuarantineStateFailed
+	}
+	if current == QuarantineStateFailed {
+		return next == QuarantineStateRestored || next == QuarantineStateDeleted
+	}
+	return false
+}
+
+func isTerminalRunState(state RunState) bool {
+	return state == RunStateSucceeded || state == RunStateFailed || state == RunStateCancelled || state == RunStateSkippedBusy
+}
+
+func runCompletionTime(state RunState) *time.Time {
+	if !isTerminalRunState(state) {
+		return nil
+	}
+	now := time.Now().UTC()
+	return &now
+}
+
+func quarantineCompletionTimes(state QuarantineState) (*time.Time, *time.Time) {
+	now := time.Now().UTC()
+	switch state {
+	case QuarantineStateRestored:
+		return &now, nil
+	case QuarantineStateDeleted:
+		return nil, &now
+	default:
+		return nil, nil
+	}
+}
+
+func normalizeJSON(value json.RawMessage) json.RawMessage {
+	if len(value) == 0 {
+		return json.RawMessage(`{}`)
+	}
+	return value
+}
+
+func transitionError(kind, current, next string) error {
+	return fmt.Errorf("%w: %s %s -> %s", ErrInvalidTransition, kind, current, next)
+}
+
+func requireOneRow(result sql.Result) error {
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("read transition result: %w", err)
+	}
+	if rows != 1 {
+		return ErrInvalidTransition
+	}
+	return nil
+}
+
+func pruneTerminalRuns(ctx context.Context, tx *sqlx.Tx) error {
+	_, err := tx.ExecContext(ctx, `
+		DELETE FROM storage_maintenance_runs
+		WHERE state IN ('succeeded', 'failed', 'cancelled', 'skipped_busy')
+		  AND id NOT IN (
+			SELECT id FROM storage_maintenance_runs
+			WHERE state IN ('succeeded', 'failed', 'cancelled', 'skipped_busy')
+			ORDER BY completed_at DESC, started_at DESC, id DESC
+			LIMIT 20
+		  )
+	`)
+	if err != nil {
+		return fmt.Errorf("prune storage maintenance runs: %w", err)
+	}
+	return nil
+}
+
+func nullableString(value string) any {
+	if value == "" {
+		return nil
+	}
+	return value
+}

--- a/apps/backend/internal/system/storage/store.go
+++ b/apps/backend/internal/system/storage/store.go
@@ -498,16 +498,17 @@ func requireOneRow(result sql.Result) error {
 }
 
 func pruneTerminalRuns(ctx context.Context, tx *sqlx.Tx) error {
-	_, err := tx.ExecContext(ctx, `
+	query := tx.Rebind(`
 		DELETE FROM storage_maintenance_runs
 		WHERE state IN ('succeeded', 'failed', 'cancelled', 'skipped_busy')
 		  AND id NOT IN (
 			SELECT id FROM storage_maintenance_runs
 			WHERE state IN ('succeeded', 'failed', 'cancelled', 'skipped_busy')
 			ORDER BY completed_at DESC, started_at DESC, id DESC
-			LIMIT 20
+			LIMIT ?
 		  )
 	`)
+	_, err := tx.ExecContext(ctx, query, terminalRunRetention)
 	if err != nil {
 		return fmt.Errorf("prune storage maintenance runs: %w", err)
 	}

--- a/apps/backend/internal/system/storage/store_migrations.go
+++ b/apps/backend/internal/system/storage/store_migrations.go
@@ -1,0 +1,54 @@
+package storage
+
+import (
+	"fmt"
+
+	"github.com/jmoiron/sqlx"
+)
+
+var storageSchemaStatements = []string{
+	`CREATE TABLE IF NOT EXISTS storage_maintenance_runs (
+		id TEXT PRIMARY KEY,
+		trigger TEXT NOT NULL,
+		state TEXT NOT NULL,
+		settings_snapshot TEXT NOT NULL,
+		result TEXT NOT NULL,
+		message TEXT NOT NULL DEFAULT '',
+		started_at TIMESTAMP NOT NULL,
+		completed_at TIMESTAMP NULL
+	)`,
+	`CREATE INDEX IF NOT EXISTS idx_storage_maintenance_runs_state_started
+		ON storage_maintenance_runs (state, started_at DESC)`,
+	`CREATE TABLE IF NOT EXISTS storage_quarantine_entries (
+		id TEXT PRIMARY KEY,
+		resource_type TEXT NOT NULL,
+		task_id TEXT NULL,
+		workspace_id TEXT NULL,
+		original_path TEXT NOT NULL,
+		quarantine_path TEXT NOT NULL UNIQUE,
+		size_bytes BIGINT NOT NULL,
+		state TEXT NOT NULL,
+		quarantined_at TIMESTAMP NOT NULL,
+		delete_after TIMESTAMP NOT NULL,
+		restored_at TIMESTAMP NULL,
+		deleted_at TIMESTAMP NULL,
+		last_error TEXT NOT NULL DEFAULT '',
+		metadata TEXT NOT NULL
+	)`,
+	`CREATE INDEX IF NOT EXISTS idx_storage_quarantine_state_deadline
+		ON storage_quarantine_entries (state, delete_after)`,
+	`CREATE INDEX IF NOT EXISTS idx_storage_quarantine_task
+		ON storage_quarantine_entries (task_id)`,
+	`CREATE UNIQUE INDEX IF NOT EXISTS idx_storage_quarantine_active_original
+		ON storage_quarantine_entries (original_path)
+		WHERE state IN ('quarantined', 'failed')`,
+}
+
+func initStorageSchema(conn *sqlx.DB) error {
+	for _, statement := range storageSchemaStatements {
+		if _, err := conn.Exec(statement); err != nil {
+			return fmt.Errorf("initialize storage maintenance schema: %w", err)
+		}
+	}
+	return nil
+}

--- a/apps/backend/internal/system/storage/store_test.go
+++ b/apps/backend/internal/system/storage/store_test.go
@@ -1,0 +1,337 @@
+package storage
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/db"
+	"github.com/kandev/kandev/internal/testutil"
+)
+
+func TestStoreRunTransitionsSurviveRecreation(t *testing.T) {
+	conn := newSQLite(t)
+	pool := db.NewPool(conn, conn)
+	store := newStorageStore(t, pool)
+	ctx := context.Background()
+	run := &MaintenanceRun{
+		ID:               "run-1",
+		Trigger:          RunTriggerManual,
+		State:            RunStateQueued,
+		SettingsSnapshot: json.RawMessage(`{"enabled":true}`),
+	}
+	if err := store.CreateRun(ctx, run); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	if _, err := store.TransitionRun(ctx, run.ID, RunStateRunning, nil, ""); err != nil {
+		t.Fatalf("transition running: %v", err)
+	}
+
+	store = newStorageStore(t, pool)
+	got, err := store.TransitionRun(ctx, run.ID, RunStateSucceeded, json.RawMessage(`{"bytes":42}`), "done")
+	if err != nil {
+		t.Fatalf("transition succeeded after recreation: %v", err)
+	}
+	if got.State != RunStateSucceeded || got.CompletedAt == nil || got.Message != "done" || string(got.Result) != `{"bytes":42}` {
+		t.Fatalf("completed run = %#v", got)
+	}
+}
+
+func TestStoreRejectsInvalidRunTransitions(t *testing.T) {
+	conn := newSQLite(t)
+	store := newStorageStore(t, db.NewPool(conn, conn))
+	ctx := context.Background()
+	if err := store.CreateRun(ctx, &MaintenanceRun{ID: "run-1", Trigger: RunTriggerScheduled, State: RunStateQueued}); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	if _, err := store.TransitionRun(ctx, "run-1", RunStateSucceeded, nil, ""); !errors.Is(err, ErrInvalidTransition) {
+		t.Fatalf("queued -> succeeded error = %v, want ErrInvalidTransition", err)
+	}
+}
+
+func TestStoreAllowsEveryRunStateTransition(t *testing.T) {
+	tests := []struct {
+		name  string
+		steps []RunState
+	}{
+		{name: "busy before running", steps: []RunState{RunStateSkippedBusy}},
+		{name: "succeeded", steps: []RunState{RunStateRunning, RunStateSucceeded}},
+		{name: "failed", steps: []RunState{RunStateRunning, RunStateFailed}},
+		{name: "cancelled", steps: []RunState{RunStateRunning, RunStateCancelled}},
+	}
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conn := newSQLite(t)
+			store := newStorageStore(t, db.NewPool(conn, conn))
+			id := fmt.Sprintf("run-%d", i)
+			if err := store.CreateRun(context.Background(), &MaintenanceRun{
+				ID: id, Trigger: RunTriggerScheduled, State: RunStateQueued,
+			}); err != nil {
+				t.Fatalf("CreateRun: %v", err)
+			}
+			for _, state := range tt.steps {
+				if _, err := store.TransitionRun(context.Background(), id, state, nil, ""); err != nil {
+					t.Fatalf("transition to %s: %v", state, err)
+				}
+			}
+		})
+	}
+}
+
+func TestStoreRunRetentionKeepsNewestTwentyTerminalAndAllNonTerminal(t *testing.T) {
+	conn := newSQLite(t)
+	store := newStorageStore(t, db.NewPool(conn, conn))
+	ctx := context.Background()
+	base := time.Date(2026, time.July, 14, 12, 0, 0, 0, time.UTC)
+	for i := range 25 {
+		run := &MaintenanceRun{
+			ID:        fmt.Sprintf("run-%02d", i),
+			Trigger:   RunTriggerManual,
+			State:     RunStateQueued,
+			StartedAt: base.Add(time.Duration(i) * time.Minute),
+		}
+		if err := store.CreateRun(ctx, run); err != nil {
+			t.Fatalf("CreateRun %d: %v", i, err)
+		}
+		if _, err := store.TransitionRun(ctx, run.ID, RunStateRunning, nil, ""); err != nil {
+			t.Fatalf("transition running %d: %v", i, err)
+		}
+		if _, err := store.TransitionRun(ctx, run.ID, RunStateSucceeded, nil, ""); err != nil {
+			t.Fatalf("transition succeeded %d: %v", i, err)
+		}
+	}
+	for _, state := range []RunState{RunStateQueued, RunStateRunning} {
+		id := "active-" + string(state)
+		if err := store.CreateRun(ctx, &MaintenanceRun{ID: id, Trigger: RunTriggerAnalysis, State: RunStateQueued}); err != nil {
+			t.Fatalf("CreateRun %s: %v", id, err)
+		}
+		if state == RunStateRunning {
+			if _, err := store.TransitionRun(ctx, id, state, nil, ""); err != nil {
+				t.Fatalf("transition %s: %v", id, err)
+			}
+		}
+	}
+
+	var terminal, nonTerminal int
+	if err := conn.Get(&terminal, `SELECT COUNT(*) FROM storage_maintenance_runs WHERE state IN ('succeeded','failed','cancelled','skipped_busy')`); err != nil {
+		t.Fatalf("count terminal: %v", err)
+	}
+	if err := conn.Get(&nonTerminal, `SELECT COUNT(*) FROM storage_maintenance_runs WHERE state IN ('queued','running')`); err != nil {
+		t.Fatalf("count non-terminal: %v", err)
+	}
+	if terminal != 20 || nonTerminal != 2 {
+		t.Fatalf("retained terminal=%d non-terminal=%d, want 20 and 2", terminal, nonTerminal)
+	}
+	if _, err := store.GetRun(ctx, "run-00"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("oldest run error = %v, want ErrNotFound", err)
+	}
+	if _, err := store.GetRun(ctx, "run-24"); err != nil {
+		t.Fatalf("newest run missing: %v", err)
+	}
+}
+
+func TestStoreQuarantineTransitionsSurviveRecreation(t *testing.T) {
+	conn := newSQLite(t)
+	pool := db.NewPool(conn, conn)
+	store := newStorageStore(t, pool)
+	ctx := context.Background()
+	entry := &QuarantineEntry{
+		ID:             "entry-1",
+		ResourceType:   ResourceTypeTaskWorkspace,
+		TaskID:         "task-1",
+		WorkspaceID:    "workspace-1",
+		OriginalPath:   "/tmp/tasks/task-1",
+		QuarantinePath: "/tmp/trash/tasks/task-1",
+		SizeBytes:      42,
+		State:          QuarantineStateQuarantined,
+		QuarantinedAt:  time.Date(2026, time.July, 14, 12, 0, 0, 0, time.UTC),
+		DeleteAfter:    time.Date(2026, time.July, 21, 12, 0, 0, 0, time.UTC),
+		Metadata:       json.RawMessage(`{"layout":1}`),
+	}
+	if err := store.CreateQuarantineEntry(ctx, entry); err != nil {
+		t.Fatalf("CreateQuarantineEntry: %v", err)
+	}
+	failed, err := store.TransitionQuarantineEntry(ctx, entry.ID, QuarantineStateFailed, "permission denied")
+	if err != nil {
+		t.Fatalf("transition failed: %v", err)
+	}
+	if failed.LastError != "permission denied" {
+		t.Fatalf("failed entry last_error = %q", failed.LastError)
+	}
+
+	store = newStorageStore(t, pool)
+	restored, err := store.TransitionQuarantineEntry(ctx, entry.ID, QuarantineStateRestored, "")
+	if err != nil {
+		t.Fatalf("transition restored after recreation: %v", err)
+	}
+	if restored.State != QuarantineStateRestored || restored.RestoredAt == nil || restored.LastError != "" {
+		t.Fatalf("restored entry = %#v", restored)
+	}
+	if _, err := store.TransitionQuarantineEntry(ctx, entry.ID, QuarantineStateDeleted, ""); !errors.Is(err, ErrInvalidTransition) {
+		t.Fatalf("restored -> deleted error = %v, want ErrInvalidTransition", err)
+	}
+}
+
+func TestStoreQuarantineOriginalPathUniqueWhileActive(t *testing.T) {
+	conn := newSQLite(t)
+	store := newStorageStore(t, db.NewPool(conn, conn))
+	ctx := context.Background()
+	first := &QuarantineEntry{
+		ID:             "entry-1",
+		ResourceType:   ResourceTypeGoCache,
+		OriginalPath:   "/tmp/go-build",
+		QuarantinePath: "/tmp/trash/go-build-1",
+		State:          QuarantineStateQuarantined,
+		QuarantinedAt:  time.Date(2026, time.July, 14, 12, 0, 0, 0, time.UTC),
+		DeleteAfter:    time.Date(2026, time.July, 21, 12, 0, 0, 0, time.UTC),
+	}
+	if err := store.CreateQuarantineEntry(ctx, first); err != nil {
+		t.Fatalf("create first entry: %v", err)
+	}
+	duplicate := *first
+	duplicate.ID = "entry-2"
+	duplicate.QuarantinePath = "/tmp/trash/go-build-2"
+	if err := store.CreateQuarantineEntry(ctx, &duplicate); err == nil {
+		t.Fatal("expected duplicate active original path to fail")
+	}
+	if _, err := store.TransitionQuarantineEntry(ctx, first.ID, QuarantineStateDeleted, ""); err != nil {
+		t.Fatalf("delete first entry: %v", err)
+	}
+	if err := store.CreateQuarantineEntry(ctx, &duplicate); err != nil {
+		t.Fatalf("reuse terminal original path: %v", err)
+	}
+}
+
+func TestStoreAllowsEveryQuarantineStateTransition(t *testing.T) {
+	tests := []struct {
+		name  string
+		steps []QuarantineState
+	}{
+		{name: "restored", steps: []QuarantineState{QuarantineStateRestored}},
+		{name: "deleted", steps: []QuarantineState{QuarantineStateDeleted}},
+		{name: "failed then restored", steps: []QuarantineState{QuarantineStateFailed, QuarantineStateRestored}},
+		{name: "failed then deleted", steps: []QuarantineState{QuarantineStateFailed, QuarantineStateDeleted}},
+	}
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conn := newSQLite(t)
+			store := newStorageStore(t, db.NewPool(conn, conn))
+			entry := testQuarantineEntry(fmt.Sprintf("entry-%d", i))
+			if err := store.CreateQuarantineEntry(context.Background(), &entry); err != nil {
+				t.Fatalf("CreateQuarantineEntry: %v", err)
+			}
+			for _, state := range tt.steps {
+				if _, err := store.TransitionQuarantineEntry(context.Background(), entry.ID, state, ""); err != nil {
+					t.Fatalf("transition to %s: %v", state, err)
+				}
+			}
+		})
+	}
+}
+
+func TestStoreSummarizeQuarantineCountsOnlyActiveEntries(t *testing.T) {
+	conn := newSQLite(t)
+	store := newStorageStore(t, db.NewPool(conn, conn))
+	ctx := context.Background()
+
+	entries := []QuarantineEntry{
+		testQuarantineEntry("quarantined"),
+		testQuarantineEntry("failed"),
+		testQuarantineEntry("restored"),
+		testQuarantineEntry("deleted"),
+	}
+	for index := range entries {
+		entries[index].SizeBytes = int64((index + 1) * 10)
+		if err := store.CreateQuarantineEntry(ctx, &entries[index]); err != nil {
+			t.Fatalf("CreateQuarantineEntry(%s): %v", entries[index].ID, err)
+		}
+	}
+	if _, err := store.TransitionQuarantineEntry(ctx, "failed", QuarantineStateFailed, "retryable"); err != nil {
+		t.Fatalf("transition failed: %v", err)
+	}
+	if _, err := store.TransitionQuarantineEntry(ctx, "restored", QuarantineStateRestored, ""); err != nil {
+		t.Fatalf("transition restored: %v", err)
+	}
+	if _, err := store.TransitionQuarantineEntry(ctx, "deleted", QuarantineStateDeleted, ""); err != nil {
+		t.Fatalf("transition deleted: %v", err)
+	}
+
+	summary, err := store.SummarizeQuarantine(ctx)
+	if err != nil {
+		t.Fatalf("SummarizeQuarantine: %v", err)
+	}
+	if summary.Count != 2 || summary.SizeBytes != 30 {
+		t.Fatalf("summary = %#v, want count=2 size_bytes=30", summary)
+	}
+}
+
+func TestStoreSummarizeQuarantineReturnsZeroWhenEmpty(t *testing.T) {
+	conn := newSQLite(t)
+	store := newStorageStore(t, db.NewPool(conn, conn))
+
+	summary, err := store.SummarizeQuarantine(context.Background())
+	if err != nil {
+		t.Fatalf("SummarizeQuarantine: %v", err)
+	}
+	if summary.Count != 0 || summary.SizeBytes != 0 {
+		t.Fatalf("empty summary = %#v", summary)
+	}
+}
+
+func TestStoreSchemaReplaySQLite(t *testing.T) {
+	conn := newSQLite(t)
+	pool := db.NewPool(conn, conn)
+	newStorageStore(t, pool)
+	newStorageStore(t, pool)
+}
+
+func TestStoreSchemaReplayPostgres(t *testing.T) {
+	conn := testutil.OpenIsolatedPostgres(t, testutil.PostgresDSNFromEnv(t))
+	pool := db.NewPool(conn, conn)
+	store := newStorageStore(t, pool)
+	ctx := context.Background()
+	if err := store.CreateRun(ctx, &MaintenanceRun{
+		ID: "postgres-run", Trigger: RunTriggerManual, State: RunStateQueued,
+	}); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	if _, err := store.TransitionRun(ctx, "postgres-run", RunStateRunning, nil, ""); err != nil {
+		t.Fatalf("transition running: %v", err)
+	}
+	entry := testQuarantineEntry("postgres-entry")
+	if err := store.CreateQuarantineEntry(ctx, &entry); err != nil {
+		t.Fatalf("CreateQuarantineEntry: %v", err)
+	}
+
+	store = newStorageStore(t, pool)
+	if _, err := store.TransitionRun(ctx, "postgres-run", RunStateSucceeded, nil, ""); err != nil {
+		t.Fatalf("transition succeeded after replay: %v", err)
+	}
+	if _, err := store.TransitionQuarantineEntry(ctx, entry.ID, QuarantineStateRestored, ""); err != nil {
+		t.Fatalf("transition restored after replay: %v", err)
+	}
+}
+
+func newStorageStore(t *testing.T, pool *db.Pool) *Store {
+	t.Helper()
+	store, err := NewStore(pool)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	return store
+}
+
+func testQuarantineEntry(id string) QuarantineEntry {
+	return QuarantineEntry{
+		ID:             id,
+		ResourceType:   ResourceTypeTaskWorkspace,
+		OriginalPath:   "/tmp/tasks/" + id,
+		QuarantinePath: "/tmp/trash/tasks/" + id,
+		State:          QuarantineStateQuarantined,
+		QuarantinedAt:  time.Date(2026, time.July, 14, 12, 0, 0, 0, time.UTC),
+		DeleteAfter:    time.Date(2026, time.July, 21, 12, 0, 0, 0, time.UTC),
+	}
+}

--- a/apps/backend/internal/system/storage/store_test.go
+++ b/apps/backend/internal/system/storage/store_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -58,6 +60,8 @@ func TestStoreAllowsEveryRunStateTransition(t *testing.T) {
 		steps []RunState
 	}{
 		{name: "busy before running", steps: []RunState{RunStateSkippedBusy}},
+		{name: "cancelled before running", steps: []RunState{RunStateCancelled}},
+		{name: "failed before running", steps: []RunState{RunStateFailed}},
 		{name: "succeeded", steps: []RunState{RunStateRunning, RunStateSucceeded}},
 		{name: "failed", steps: []RunState{RunStateRunning, RunStateFailed}},
 		{name: "cancelled", steps: []RunState{RunStateRunning, RunStateCancelled}},
@@ -202,6 +206,87 @@ func TestStoreQuarantineOriginalPathUniqueWhileActive(t *testing.T) {
 	}
 	if err := store.CreateQuarantineEntry(ctx, &duplicate); err != nil {
 		t.Fatalf("reuse terminal original path: %v", err)
+	}
+}
+
+func TestReleaseFailedQuarantineIntentRequiresProvenUnmovedState(t *testing.T) {
+	resourceTypes := []ResourceType{ResourceTypeTaskWorkspace, ResourceTypeGoCache}
+	states := []struct {
+		name             string
+		originalExists   bool
+		quarantineExists bool
+		wantReleased     bool
+	}{
+		{name: "original remains and quarantine is absent", originalExists: true, wantReleased: true},
+		{name: "quarantine exists", originalExists: true, quarantineExists: true},
+		{name: "original is absent", quarantineExists: true},
+		{name: "both paths are absent"},
+	}
+	for _, resourceType := range resourceTypes {
+		for _, state := range states {
+			t.Run(string(resourceType)+"/"+state.name, func(t *testing.T) {
+				conn := newSQLite(t)
+				store := newStorageStore(t, db.NewPool(conn, conn))
+				root := t.TempDir()
+				original := filepath.Join(root, "original")
+				quarantine := filepath.Join(root, "quarantine")
+				if state.originalExists {
+					if err := os.Mkdir(original, 0o700); err != nil {
+						t.Fatalf("create original: %v", err)
+					}
+				}
+				if state.quarantineExists {
+					if err := os.Mkdir(quarantine, 0o700); err != nil {
+						t.Fatalf("create quarantine: %v", err)
+					}
+				}
+				entry := testQuarantineEntry("failed-entry")
+				entry.ResourceType = resourceType
+				entry.OriginalPath = original
+				entry.QuarantinePath = quarantine
+				if err := store.CreateQuarantineEntry(context.Background(), &entry); err != nil {
+					t.Fatalf("create failed intent: %v", err)
+				}
+				if _, err := store.TransitionQuarantineEntry(
+					context.Background(), entry.ID, QuarantineStateFailed, "rename failed",
+				); err != nil {
+					t.Fatalf("mark intent failed: %v", err)
+				}
+
+				released, err := ReleaseFailedQuarantineIntent(
+					context.Background(), store, resourceType, original,
+				)
+				if state.wantReleased {
+					if err != nil || !released {
+						t.Fatalf("ReleaseFailedQuarantineIntent = %v, %v; want true, nil", released, err)
+					}
+				} else if !errors.Is(err, ErrConflict) || released {
+					t.Fatalf("ReleaseFailedQuarantineIntent = %v, %v; want false, ErrConflict", released, err)
+				}
+				stored, err := store.GetQuarantineEntry(context.Background(), entry.ID)
+				if err != nil {
+					t.Fatal(err)
+				}
+				wantState := QuarantineStateFailed
+				if state.wantReleased {
+					wantState = QuarantineStateRestored
+				}
+				if stored.State != wantState {
+					t.Fatalf("failed intent state = %q, want %q", stored.State, wantState)
+				}
+				replacement := entry
+				replacement.ID = "replacement-entry"
+				replacement.QuarantinePath = filepath.Join(root, "replacement-quarantine")
+				replacement.State = QuarantineStateQuarantined
+				createErr := store.CreateQuarantineEntry(context.Background(), &replacement)
+				if state.wantReleased && createErr != nil {
+					t.Fatalf("create replacement intent: %v", createErr)
+				}
+				if !state.wantReleased && createErr == nil {
+					t.Fatal("ambiguous failed intent released unique original-path slot")
+				}
+			})
+		}
 	}
 }
 

--- a/apps/backend/internal/system/storage/types.go
+++ b/apps/backend/internal/system/storage/types.go
@@ -118,6 +118,9 @@ func NormalizeSettings(in StorageMaintenanceSettings) (StorageMaintenanceSetting
 			return StorageMaintenanceSettings{}, validationError("go_cache.adopted_path must be absolute")
 		}
 		in.GoCache.AdoptedPath = filepath.Clean(in.GoCache.AdoptedPath)
+		if in.GoCache.AdoptedPath == filepath.VolumeName(in.GoCache.AdoptedPath)+string(filepath.Separator) {
+			return StorageMaintenanceSettings{}, validationError("go_cache.adopted_path cannot be a filesystem root")
+		}
 	}
 	return in, nil
 }

--- a/apps/backend/internal/system/storage/types.go
+++ b/apps/backend/internal/system/storage/types.go
@@ -1,0 +1,134 @@
+package storage
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+)
+
+var ErrValidation = errors.New("storage maintenance settings validation")
+
+var (
+	ErrAdoptionRequired            = errors.New("go cache adoption requires the dedicated endpoint")
+	ErrDedicatedDockerConfirmation = errors.New("dedicated Docker acknowledgement requires confirmation")
+	ErrInvalidPersistedSettings    = errors.New("invalid persisted storage maintenance settings")
+)
+
+const (
+	MinCheckIntervalHours       = 1
+	MaxCheckIntervalHours       = 168
+	MinIdleForMinutes           = 1
+	MaxIdleForMinutes           = 1440
+	MinGraceHours               = 24
+	MaxGraceHours               = 2160
+	MaxDockerUnusedHours        = 2562047
+	MinCacheBytes         int64 = 1073741824
+)
+
+type ResourceSettings struct {
+	Enabled bool `json:"enabled"`
+}
+
+type GoCacheSettings struct {
+	Enabled     bool   `json:"enabled"`
+	MaxBytes    int64  `json:"max_bytes"`
+	AdoptedPath string `json:"adopted_path"`
+}
+
+type DockerSettings struct {
+	DedicatedDaemonAcknowledged bool  `json:"dedicated_daemon_acknowledged"`
+	BuildCacheEnabled           bool  `json:"build_cache_enabled"`
+	BuildCacheKeepBytes         int64 `json:"build_cache_keep_bytes"`
+	BuildCacheUnusedHours       int   `json:"build_cache_unused_hours"`
+	UnusedImagesEnabled         bool  `json:"unused_images_enabled"`
+	UnusedImagesHours           int   `json:"unused_images_hours"`
+}
+
+type StorageMaintenanceSettings struct {
+	Enabled                  bool             `json:"enabled"`
+	CheckIntervalHours       int              `json:"check_interval_hours"`
+	IdleForMinutes           int              `json:"idle_for_minutes"`
+	OrphanGraceHours         int              `json:"orphan_grace_hours"`
+	QuarantineRetentionHours int              `json:"quarantine_retention_hours"`
+	Workspaces               ResourceSettings `json:"workspaces"`
+	KandevContainers         ResourceSettings `json:"kandev_containers"`
+	GoCache                  GoCacheSettings  `json:"go_cache"`
+	Docker                   DockerSettings   `json:"docker"`
+}
+
+func DefaultSettings() StorageMaintenanceSettings {
+	return StorageMaintenanceSettings{
+		CheckIntervalHours:       24,
+		IdleForMinutes:           10,
+		OrphanGraceHours:         168,
+		QuarantineRetentionHours: 168,
+		Workspaces:               ResourceSettings{Enabled: true},
+		KandevContainers:         ResourceSettings{Enabled: true},
+		GoCache: GoCacheSettings{
+			MaxBytes: 16106127360,
+		},
+		Docker: DockerSettings{
+			BuildCacheKeepBytes:   10737418240,
+			BuildCacheUnusedHours: 168,
+			UnusedImagesHours:     168,
+		},
+	}
+}
+
+func NormalizeSettings(in StorageMaintenanceSettings) (StorageMaintenanceSettings, error) {
+	if err := validateRange("check_interval_hours", in.CheckIntervalHours, MinCheckIntervalHours, MaxCheckIntervalHours); err != nil {
+		return StorageMaintenanceSettings{}, err
+	}
+	if err := validateRange("idle_for_minutes", in.IdleForMinutes, MinIdleForMinutes, MaxIdleForMinutes); err != nil {
+		return StorageMaintenanceSettings{}, err
+	}
+	if err := validateRange("orphan_grace_hours", in.OrphanGraceHours, MinGraceHours, MaxGraceHours); err != nil {
+		return StorageMaintenanceSettings{}, err
+	}
+	if err := validateRange("quarantine_retention_hours", in.QuarantineRetentionHours, MinGraceHours, MaxGraceHours); err != nil {
+		return StorageMaintenanceSettings{}, err
+	}
+	if in.GoCache.MaxBytes < MinCacheBytes {
+		return StorageMaintenanceSettings{}, validationError("go_cache.max_bytes must be at least %d", MinCacheBytes)
+	}
+	if in.Docker.BuildCacheKeepBytes < MinCacheBytes {
+		return StorageMaintenanceSettings{}, validationError("docker.build_cache_keep_bytes must be at least %d", MinCacheBytes)
+	}
+	if err := validateRange(
+		"docker.build_cache_unused_hours",
+		in.Docker.BuildCacheUnusedHours,
+		MinGraceHours,
+		MaxDockerUnusedHours,
+	); err != nil {
+		return StorageMaintenanceSettings{}, err
+	}
+	if err := validateRange(
+		"docker.unused_images_hours",
+		in.Docker.UnusedImagesHours,
+		MinGraceHours,
+		MaxDockerUnusedHours,
+	); err != nil {
+		return StorageMaintenanceSettings{}, err
+	}
+	if (in.Docker.BuildCacheEnabled || in.Docker.UnusedImagesEnabled) && !in.Docker.DedicatedDaemonAcknowledged {
+		return StorageMaintenanceSettings{}, validationError("docker cleanup requires dedicated daemon acknowledgement")
+	}
+	if in.GoCache.AdoptedPath != "" {
+		if !filepath.IsAbs(in.GoCache.AdoptedPath) {
+			return StorageMaintenanceSettings{}, validationError("go_cache.adopted_path must be absolute")
+		}
+		in.GoCache.AdoptedPath = filepath.Clean(in.GoCache.AdoptedPath)
+	}
+	return in, nil
+}
+
+func validateRange(field string, value, minValue, maxValue int) error {
+	if value < minValue || value > maxValue {
+		return validationError("%s must be between %d and %d", field, minValue, maxValue)
+	}
+	return nil
+}
+
+func validationError(format string, args ...any) error {
+	return fmt.Errorf("%w: %s", ErrValidation, fmt.Sprintf(format, args...))
+}

--- a/apps/backend/internal/system/storage/workspaces/marker.go
+++ b/apps/backend/internal/system/storage/workspaces/marker.go
@@ -1,0 +1,122 @@
+package workspaces
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const (
+	OwnershipMarkerFilename = ".kandev-workspace.json"
+	quarantineManifestName  = ".kandev-quarantine.json"
+)
+
+func WriteOwnershipMarker(root string, marker OwnershipMarker) error {
+	if err := normalizeOwnershipMarker(&marker); err != nil {
+		return err
+	}
+	if err := rejectRootSymlink(root); err != nil {
+		return err
+	}
+	matched, err := existingMarkerMatches(root, marker)
+	if err != nil {
+		return err
+	}
+	if matched {
+		return nil
+	}
+	encoded, err := json.Marshal(marker)
+	if err != nil {
+		return fmt.Errorf("encode workspace ownership marker: %w", err)
+	}
+	path := filepath.Join(root, OwnershipMarkerFilename)
+	if info, err := os.Lstat(path); err == nil && info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("workspace ownership marker is a symlink: %s", path)
+	} else if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("inspect workspace ownership marker: %w", err)
+	}
+	tmp, err := os.CreateTemp(root, ".kandev-workspace-*")
+	if err != nil {
+		return fmt.Errorf("create workspace ownership marker: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer func() { _ = os.Remove(tmpPath) }()
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(encoded); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("install workspace ownership marker: %w", err)
+	}
+	return nil
+}
+
+func normalizeOwnershipMarker(marker *OwnershipMarker) error {
+	if marker.TaskID == "" || marker.TaskDirName == "" {
+		return errors.New("workspace ownership marker requires task_id and task_dir_name")
+	}
+	if marker.LayoutVersion != LayoutVersionSemantic && marker.LayoutVersion != LayoutVersionScratch {
+		return fmt.Errorf("unsupported workspace layout version %d", marker.LayoutVersion)
+	}
+	if marker.CreatedAt.IsZero() {
+		marker.CreatedAt = time.Now().UTC()
+	} else {
+		marker.CreatedAt = marker.CreatedAt.UTC()
+	}
+	return nil
+}
+
+func existingMarkerMatches(root string, marker OwnershipMarker) (bool, error) {
+	existing, found, err := readOwnershipMarker(root)
+	if err != nil || !found {
+		return found, err
+	}
+	if existing.TaskID != marker.TaskID || existing.TaskDirName != marker.TaskDirName || existing.LayoutVersion != marker.LayoutVersion {
+		return false, errors.New("workspace ownership marker conflicts with requested task root")
+	}
+	if existing.WorkspaceID != "" && marker.WorkspaceID != "" && existing.WorkspaceID != marker.WorkspaceID {
+		return false, errors.New("workspace ownership marker conflicts with requested workspace")
+	}
+	return true, nil
+}
+
+func readOwnershipMarker(root string) (OwnershipMarker, bool, error) {
+	path := filepath.Join(root, OwnershipMarkerFilename)
+	info, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return OwnershipMarker{}, false, nil
+	}
+	if err != nil {
+		return OwnershipMarker{}, false, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		return OwnershipMarker{}, false, fmt.Errorf("invalid workspace ownership marker: %s", path)
+	}
+	encoded, err := os.ReadFile(path)
+	if err != nil {
+		return OwnershipMarker{}, false, err
+	}
+	var marker OwnershipMarker
+	if err := json.Unmarshal(encoded, &marker); err != nil {
+		return OwnershipMarker{}, false, fmt.Errorf("decode workspace ownership marker: %w", err)
+	}
+	if marker.TaskID == "" || marker.TaskDirName == "" ||
+		(marker.LayoutVersion != LayoutVersionSemantic && marker.LayoutVersion != LayoutVersionScratch) {
+		return OwnershipMarker{}, false, errors.New("invalid workspace ownership marker fields")
+	}
+	return marker, true, nil
+}
+
+func ReadOwnershipMarker(root string) (OwnershipMarker, bool, error) {
+	return readOwnershipMarker(root)
+}

--- a/apps/backend/internal/system/storage/workspaces/provider.go
+++ b/apps/backend/internal/system/storage/workspaces/provider.go
@@ -19,6 +19,12 @@ type Provider struct {
 	config Config
 }
 
+const (
+	workspaceRecoveryStatusNotFound = "not_found"
+	workspaceRecoveryStatusFailed   = "failed"
+	workspaceRecoveryStatusRestored = "restored"
+)
+
 func New(config Config) *Provider {
 	if config.Now == nil {
 		config.Now = time.Now
@@ -228,15 +234,15 @@ func (p *Provider) Restore(ctx context.Context, id string) (storage.QuarantineEn
 }
 
 func (p *Provider) RestoreTask(ctx context.Context, taskID string) WorkspaceRecovery {
-	recovery := WorkspaceRecovery{TaskID: taskID, Status: "not_found"}
+	recovery := WorkspaceRecovery{TaskID: taskID, Status: workspaceRecoveryStatusNotFound}
 	if p.config.Store == nil {
-		recovery.Status = "failed"
+		recovery.Status = workspaceRecoveryStatusFailed
 		recovery.Message = "workspace quarantine store is unavailable"
 		return recovery
 	}
 	entries, err := p.config.Store.ListQuarantineEntries(ctx, false)
 	if err != nil {
-		recovery.Status = "failed"
+		recovery.Status = workspaceRecoveryStatusFailed
 		recovery.Message = err.Error()
 		return recovery
 	}
@@ -257,21 +263,21 @@ func (p *Provider) RestoreTask(ctx context.Context, taskID string) WorkspaceReco
 	if newest.State == storage.QuarantineStateFailed {
 		resolved, err := p.resolveFailedTaskRestore(ctx, *newest)
 		if err != nil {
-			recovery.Status = "failed"
+			recovery.Status = workspaceRecoveryStatusFailed
 			recovery.Message = err.Error()
 			return recovery
 		}
 		if resolved {
-			recovery.Status = "restored"
+			recovery.Status = workspaceRecoveryStatusRestored
 			return recovery
 		}
 	}
 	if _, err := p.Restore(ctx, newest.ID); err != nil {
-		recovery.Status = "failed"
+		recovery.Status = workspaceRecoveryStatusFailed
 		recovery.Message = err.Error()
 		return recovery
 	}
-	recovery.Status = "restored"
+	recovery.Status = workspaceRecoveryStatusRestored
 	return recovery
 }
 

--- a/apps/backend/internal/system/storage/workspaces/provider.go
+++ b/apps/backend/internal/system/storage/workspaces/provider.go
@@ -244,22 +244,70 @@ func (p *Provider) RestoreTask(ctx context.Context, taskID string) WorkspaceReco
 	for i := range entries {
 		entry := &entries[i]
 		if entry.ResourceType != storage.ResourceTypeTaskWorkspace || entry.TaskID != taskID ||
-			entry.State != storage.QuarantineStateQuarantined {
+			(entry.State != storage.QuarantineStateQuarantined && entry.State != storage.QuarantineStateFailed) {
 			continue
 		}
 		if newest == nil || entry.QuarantinedAt.After(newest.QuarantinedAt) {
 			newest = entry
 		}
 	}
-	if newest != nil {
-		if _, err := p.Restore(ctx, newest.ID); err != nil {
+	if newest == nil {
+		return recovery
+	}
+	if newest.State == storage.QuarantineStateFailed {
+		resolved, err := p.resolveFailedTaskRestore(ctx, *newest)
+		if err != nil {
 			recovery.Status = "failed"
 			recovery.Message = err.Error()
 			return recovery
 		}
-		recovery.Status = "restored"
+		if resolved {
+			recovery.Status = "restored"
+			return recovery
+		}
 	}
+	if _, err := p.Restore(ctx, newest.ID); err != nil {
+		recovery.Status = "failed"
+		recovery.Message = err.Error()
+		return recovery
+	}
+	recovery.Status = "restored"
 	return recovery
+}
+
+func (p *Provider) resolveFailedTaskRestore(
+	ctx context.Context,
+	entry storage.QuarantineEntry,
+) (bool, error) {
+	if err := p.validateEntryPaths(entry); err != nil {
+		return false, err
+	}
+	originalExists, err := workspacePathExists(entry.OriginalPath)
+	if err != nil {
+		return false, fmt.Errorf("inspect failed workspace original: %w", err)
+	}
+	quarantineExists, err := workspacePathExists(entry.QuarantinePath)
+	if err != nil {
+		return false, fmt.Errorf("inspect failed workspace quarantine: %w", err)
+	}
+	if originalExists && !quarantineExists {
+		_, err := p.config.Store.TransitionQuarantineEntry(
+			ctx, entry.ID, storage.QuarantineStateRestored, "",
+		)
+		return err == nil, err
+	}
+	if !originalExists && quarantineExists {
+		return false, nil
+	}
+	return false, fmt.Errorf("%w: failed workspace quarantine state is ambiguous", storage.ErrConflict)
+}
+
+func workspacePathExists(path string) (bool, error) {
+	_, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	return err == nil, err
 }
 
 func (p *Provider) PermanentDelete(

--- a/apps/backend/internal/system/storage/workspaces/provider.go
+++ b/apps/backend/internal/system/storage/workspaces/provider.go
@@ -1,0 +1,663 @@
+package workspaces
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/kandev/kandev/internal/system/storage"
+)
+
+type Provider struct {
+	config Config
+}
+
+func New(config Config) *Provider {
+	if config.Now == nil {
+		config.Now = time.Now
+	}
+	if config.NewID == nil {
+		config.NewID = uuid.NewString
+	}
+	if config.GracePeriod <= 0 {
+		config.GracePeriod = 7 * 24 * time.Hour
+	}
+	if config.Retention <= 0 {
+		config.Retention = 7 * 24 * time.Hour
+	}
+	return &Provider{config: config}
+}
+
+type candidate struct {
+	path  string
+	owner OwnershipMarker
+	size  int64
+}
+
+func (p *Provider) Analyze(ctx context.Context) (Analysis, error) {
+	candidates, protected, warnings, err := p.classify(ctx)
+	if err != nil {
+		return Analysis{}, err
+	}
+	analysis := Analysis{Warnings: warnings}
+	for _, item := range candidates {
+		analysis.CandidateBytes += item.size
+	}
+	for path := range protected {
+		if size, sizeErr := directorySizeNoSymlinks(path); sizeErr == nil {
+			analysis.ActiveBytes += size
+		}
+	}
+	return analysis, nil
+}
+
+func (p *Provider) Cleanup(ctx context.Context) (CleanupResult, error) {
+	candidates, _, warnings, err := p.classify(ctx)
+	if err != nil {
+		return CleanupResult{}, err
+	}
+	result := CleanupResult{Candidates: len(candidates), Warnings: warnings}
+	for _, item := range candidates {
+		if err := ctx.Err(); err != nil {
+			return result, err
+		}
+		entry, err := p.quarantine(ctx, item)
+		if err != nil {
+			return result, err
+		}
+		result.Quarantined++
+		result.ReclaimedBytes += entry.SizeBytes
+	}
+	return result, nil
+}
+
+func (p *Provider) classify(ctx context.Context) ([]candidate, map[string]struct{}, []string, error) {
+	_, trashTasks, protected, roots, warnings, err := p.classificationInputs(ctx)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	candidates, err := p.eligibleCandidates(roots, protected, trashTasks)
+	return candidates, protected, warnings, err
+}
+
+func (p *Provider) classificationInputs(
+	ctx context.Context,
+) (string, string, map[string]struct{}, []candidate, []string, error) {
+	tasksRoot, trashTasks, err := p.roots()
+	if err != nil {
+		return "", "", nil, nil, nil, err
+	}
+	if p.config.Inventory == nil {
+		return "", "", nil, nil, nil, ErrInventoryIncomplete
+	}
+	inventory, err := p.config.Inventory.LoadWorkspaceInventory(ctx)
+	if err != nil {
+		return "", "", nil, nil, nil, fmt.Errorf("load authoritative workspace inventory: %w", err)
+	}
+	if !inventory.Complete {
+		return "", "", nil, nil, nil, ErrInventoryIncomplete
+	}
+	protected, err := buildProtectedSet(tasksRoot, inventory)
+	if err != nil {
+		return "", "", nil, nil, nil, err
+	}
+	roots, warnings, err := discoverTaskRoots(tasksRoot)
+	if err != nil {
+		return "", "", nil, nil, nil, err
+	}
+	return tasksRoot, trashTasks, protected, roots, warnings, nil
+}
+
+func (p *Provider) eligibleCandidates(
+	roots []candidate,
+	protected map[string]struct{},
+	trashTasks string,
+) ([]candidate, error) {
+	cutoff := p.config.Now().Add(-p.config.GracePeriod)
+	candidates := make([]candidate, 0)
+	for _, root := range roots {
+		if _, keep := protected[root.path]; keep {
+			continue
+		}
+		if pathContains(root.path, trashTasks) || pathContains(trashTasks, root.path) {
+			return nil, fmt.Errorf("workspace candidate overlaps trash: %s", root.path)
+		}
+		info, err := os.Lstat(root.path)
+		if err != nil {
+			return nil, fmt.Errorf("inspect workspace candidate %s: %w", root.path, err)
+		}
+		if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+			return nil, fmt.Errorf("workspace candidate is not a real directory: %s", root.path)
+		}
+		if info.ModTime().After(cutoff) {
+			continue
+		}
+		size, err := directorySizeNoSymlinks(root.path)
+		if err != nil {
+			return nil, fmt.Errorf("measure workspace candidate %s: %w", root.path, err)
+		}
+		root.size = size
+		candidates = append(candidates, root)
+	}
+	return candidates, nil
+}
+
+func (p *Provider) quarantine(ctx context.Context, item candidate) (storage.QuarantineEntry, error) {
+	if p.config.Store == nil {
+		return storage.QuarantineEntry{}, errors.New("workspace quarantine store is required")
+	}
+	_, trashTasks, err := p.roots()
+	if err != nil {
+		return storage.QuarantineEntry{}, err
+	}
+	if err := os.MkdirAll(trashTasks, 0o700); err != nil {
+		return storage.QuarantineEntry{}, fmt.Errorf("create workspace trash: %w", err)
+	}
+	now := p.config.Now().UTC()
+	id := p.config.NewID()
+	metadata, _ := json.Marshal(item.owner)
+	entry := storage.QuarantineEntry{
+		ID: id, ResourceType: storage.ResourceTypeTaskWorkspace,
+		TaskID: item.owner.TaskID, WorkspaceID: item.owner.WorkspaceID,
+		OriginalPath: item.path, QuarantinePath: filepath.Join(trashTasks, id),
+		SizeBytes: item.size, State: storage.QuarantineStateQuarantined,
+		QuarantinedAt: now, DeleteAfter: now.Add(p.config.Retention), Metadata: metadata,
+	}
+	if err := p.config.Store.CreateQuarantineEntry(ctx, &entry); err != nil {
+		return storage.QuarantineEntry{}, fmt.Errorf("persist workspace quarantine intent: %w", err)
+	}
+	manifest := quarantineManifest{Entry: entry, Owner: item.owner}
+	if err := writeJSONFile(filepath.Join(item.path, quarantineManifestName), manifest); err != nil {
+		_, _ = p.config.Store.TransitionQuarantineEntry(ctx, id, storage.QuarantineStateFailed, err.Error())
+		return storage.QuarantineEntry{}, fmt.Errorf("write workspace quarantine manifest: %w", err)
+	}
+	if err := os.Rename(item.path, entry.QuarantinePath); err != nil {
+		_, _ = p.config.Store.TransitionQuarantineEntry(ctx, id, storage.QuarantineStateFailed, err.Error())
+		return storage.QuarantineEntry{}, fmt.Errorf("quarantine workspace: %w", err)
+	}
+	return entry, nil
+}
+
+func (p *Provider) Restore(ctx context.Context, id string) (storage.QuarantineEntry, error) {
+	if p.config.Store == nil {
+		return storage.QuarantineEntry{}, errors.New("workspace quarantine store is required")
+	}
+	entry, err := p.config.Store.GetQuarantineEntry(ctx, id)
+	if err != nil {
+		return storage.QuarantineEntry{}, err
+	}
+	if err := p.validateEntryPaths(entry); err != nil {
+		return storage.QuarantineEntry{}, err
+	}
+	if _, err := os.Lstat(entry.OriginalPath); err == nil {
+		return entry, ErrRestoreConflict
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return entry, fmt.Errorf("inspect workspace restore destination: %w", err)
+	}
+	if err := rejectRootSymlink(entry.QuarantinePath); err != nil {
+		return entry, err
+	}
+	if err := ensureSafeParent(p.cleanTasksRoot(), filepath.Dir(entry.OriginalPath)); err != nil {
+		return entry, err
+	}
+	if err := os.MkdirAll(filepath.Dir(entry.OriginalPath), 0o755); err != nil {
+		return entry, fmt.Errorf("create workspace restore parent: %w", err)
+	}
+	if err := os.Rename(entry.QuarantinePath, entry.OriginalPath); err != nil {
+		return entry, fmt.Errorf("restore workspace: %w", err)
+	}
+	restored, err := p.config.Store.TransitionQuarantineEntry(ctx, id, storage.QuarantineStateRestored, "")
+	if err != nil {
+		_ = os.Rename(entry.OriginalPath, entry.QuarantinePath)
+		return entry, fmt.Errorf("persist workspace restore: %w", err)
+	}
+	_ = os.Remove(filepath.Join(entry.OriginalPath, quarantineManifestName))
+	return restored, nil
+}
+
+func (p *Provider) RestoreTask(ctx context.Context, taskID string) WorkspaceRecovery {
+	recovery := WorkspaceRecovery{TaskID: taskID, Status: "not_found"}
+	if p.config.Store == nil {
+		recovery.Status = "failed"
+		recovery.Message = "workspace quarantine store is unavailable"
+		return recovery
+	}
+	entries, err := p.config.Store.ListQuarantineEntries(ctx, false)
+	if err != nil {
+		recovery.Status = "failed"
+		recovery.Message = err.Error()
+		return recovery
+	}
+	for _, entry := range entries {
+		if entry.ResourceType != storage.ResourceTypeTaskWorkspace || entry.TaskID != taskID {
+			continue
+		}
+		if _, err := p.Restore(ctx, entry.ID); err != nil {
+			recovery.Status = "failed"
+			recovery.Message = err.Error()
+			return recovery
+		}
+		recovery.Status = "restored"
+		return recovery
+	}
+	return recovery
+}
+
+func (p *Provider) PermanentDelete(
+	ctx context.Context,
+	id string,
+	confirmation string,
+) (storage.QuarantineEntry, error) {
+	if confirmation != "DELETE" {
+		return storage.QuarantineEntry{}, ErrDeleteConfirmation
+	}
+	if p.config.Store == nil {
+		return storage.QuarantineEntry{}, errors.New("workspace quarantine store is required")
+	}
+	entry, err := p.config.Store.GetQuarantineEntry(ctx, id)
+	if err != nil {
+		return storage.QuarantineEntry{}, err
+	}
+	if err := p.validateEntryPaths(entry); err != nil {
+		return entry, err
+	}
+	if p.config.Now().Before(entry.DeleteAfter) {
+		return entry, fmt.Errorf("%w: quarantine retention deadline has not elapsed", storage.ErrConflict)
+	}
+	if _, err := directorySizeNoSymlinks(entry.QuarantinePath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return entry, fmt.Errorf("validate quarantined workspace: %w", err)
+	}
+	if p.config.Pruner != nil && !p.config.Now().Before(entry.DeleteAfter) {
+		if err := p.config.Pruner.PruneQuarantinedWorkspace(ctx, entry); err != nil {
+			_, _ = p.config.Store.TransitionQuarantineEntry(ctx, id, storage.QuarantineStateFailed, err.Error())
+			return entry, fmt.Errorf("prune stale Git worktree registration: %w", err)
+		}
+	}
+	if err := os.RemoveAll(entry.QuarantinePath); err != nil {
+		_, _ = p.config.Store.TransitionQuarantineEntry(ctx, id, storage.QuarantineStateFailed, err.Error())
+		return entry, fmt.Errorf("delete quarantined workspace: %w", err)
+	}
+	deleted, err := p.config.Store.TransitionQuarantineEntry(ctx, id, storage.QuarantineStateDeleted, "")
+	if err != nil {
+		return entry, fmt.Errorf("persist workspace deletion: %w", err)
+	}
+	return deleted, nil
+}
+
+func (p *Provider) Reconcile(ctx context.Context) (ReconcileResult, error) {
+	result := ReconcileResult{}
+	if p.config.Store == nil {
+		return result, errors.New("workspace quarantine store is required")
+	}
+	_, trashTasks, err := p.roots()
+	if err != nil {
+		return result, err
+	}
+	persisted, err := p.config.Store.ListQuarantineEntries(ctx, false)
+	if err != nil {
+		return result, err
+	}
+	entries, err := readTrashEntries(trashTasks)
+	if err != nil {
+		return result, err
+	}
+	seen := make(map[string]struct{}, len(entries))
+	for _, dir := range entries {
+		path := filepath.Join(trashTasks, dir.Name())
+		seen[path] = struct{}{}
+		recovered, failed, warning, err := p.reconcileDiskEntry(ctx, path, dir)
+		if err != nil {
+			return result, err
+		}
+		result.Recovered += recovered
+		result.Failed += failed
+		if warning != "" {
+			result.Warnings = append(result.Warnings, warning)
+		}
+	}
+	result.Failed += p.reconcileMissingEntries(ctx, persisted, seen)
+	return result, nil
+}
+
+func readTrashEntries(trashTasks string) ([]os.DirEntry, error) {
+	entries, err := os.ReadDir(trashTasks)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	return entries, err
+}
+
+func (p *Provider) reconcileDiskEntry(
+	ctx context.Context,
+	path string,
+	dir os.DirEntry,
+) (int, int, string, error) {
+	if dir.Type()&os.ModeSymlink != 0 || !dir.IsDir() {
+		return 0, 0, "unsafe quarantine path kept: " + path, nil
+	}
+	manifest, err := readQuarantineManifest(path)
+	if err != nil {
+		return 0, 0, err.Error(), nil
+	}
+	if filepath.Clean(manifest.Entry.QuarantinePath) != path {
+		return 0, 0, "quarantine manifest path conflict: " + path, nil
+	}
+	if err := p.validateEntryPaths(manifest.Entry); err != nil {
+		return 0, 0, err.Error(), nil
+	}
+	_, err = p.config.Store.GetQuarantineEntry(ctx, manifest.Entry.ID)
+	if errors.Is(err, storage.ErrNotFound) {
+		entry := manifest.Entry
+		if err := p.config.Store.CreateQuarantineEntry(ctx, &entry); err != nil {
+			return 0, 0, "", err
+		}
+		return 1, 0, "", nil
+	}
+	if err != nil {
+		return 0, 0, "", err
+	}
+	if _, err := os.Lstat(manifest.Entry.OriginalPath); err == nil {
+		_, _ = p.config.Store.TransitionQuarantineEntry(
+			ctx,
+			manifest.Entry.ID,
+			storage.QuarantineStateFailed,
+			"original and quarantine paths both exist",
+		)
+		return 0, 1, "", nil
+	}
+	return 0, 0, "", nil
+}
+
+func (p *Provider) reconcileMissingEntries(
+	ctx context.Context,
+	persisted []storage.QuarantineEntry,
+	seen map[string]struct{},
+) int {
+	failed := 0
+	for _, entry := range persisted {
+		if entry.ResourceType != storage.ResourceTypeTaskWorkspace {
+			continue
+		}
+		if _, exists := seen[entry.QuarantinePath]; exists {
+			continue
+		}
+		message := "quarantine path is missing"
+		if _, err := os.Lstat(entry.OriginalPath); err == nil {
+			message = "quarantine move did not complete"
+		}
+		_, _ = p.config.Store.TransitionQuarantineEntry(ctx, entry.ID, storage.QuarantineStateFailed, message)
+		failed++
+	}
+	return failed
+}
+
+func (p *Provider) roots() (string, string, error) {
+	tasksRoot := p.cleanTasksRoot()
+	trashRoot := filepath.Clean(p.config.TrashRoot)
+	if !filepath.IsAbs(tasksRoot) || !filepath.IsAbs(trashRoot) {
+		return "", "", errors.New("workspace tasks and trash roots must be absolute")
+	}
+	if pathContains(tasksRoot, trashRoot) || pathContains(trashRoot, tasksRoot) {
+		return "", "", errors.New("workspace tasks and trash roots must not overlap")
+	}
+	trashTasks := filepath.Join(trashRoot, "tasks")
+	anchor, err := storage.CommonPath(tasksRoot, trashRoot)
+	if err != nil {
+		return "", "", err
+	}
+	if err := storage.ValidateNoSymlinkPath(anchor, tasksRoot); err != nil {
+		return "", "", fmt.Errorf("validate workspace tasks root: %w", err)
+	}
+	if err := storage.ValidateNoSymlinkPath(anchor, trashRoot); err != nil {
+		return "", "", fmt.Errorf("validate workspace trash root: %w", err)
+	}
+	if err := storage.ValidateNoSymlinkPath(anchor, trashTasks); err != nil {
+		return "", "", fmt.Errorf("validate workspace task trash: %w", err)
+	}
+	if err := rejectRootSymlink(tasksRoot); err != nil {
+		return "", "", err
+	}
+	return tasksRoot, trashTasks, nil
+}
+
+func (p *Provider) cleanTasksRoot() string { return filepath.Clean(p.config.TasksRoot) }
+
+func (p *Provider) validateEntryPaths(entry storage.QuarantineEntry) error {
+	tasksRoot, trashTasks, err := p.roots()
+	if err != nil {
+		return err
+	}
+	original := filepath.Clean(entry.OriginalPath)
+	quarantine := filepath.Clean(entry.QuarantinePath)
+	if original != entry.OriginalPath || quarantine != entry.QuarantinePath ||
+		!pathContains(tasksRoot, original) || original == tasksRoot ||
+		!pathContains(trashTasks, quarantine) || quarantine == trashTasks {
+		return errors.New("quarantine entry paths are outside owned roots")
+	}
+	anchor, err := storage.CommonPath(tasksRoot, trashTasks)
+	if err != nil {
+		return err
+	}
+	if err := storage.ValidateNoSymlinkPath(anchor, original); err != nil {
+		return fmt.Errorf("validate original workspace path: %w", err)
+	}
+	if err := storage.ValidateNoSymlinkPath(anchor, quarantine); err != nil {
+		return fmt.Errorf("validate quarantined workspace path: %w", err)
+	}
+	return nil
+}
+
+func buildProtectedSet(tasksRoot string, inventory Inventory) (map[string]struct{}, error) {
+	paths := make([]string, 0, len(inventory.WorktreePaths)+len(inventory.EnvironmentPaths)+len(inventory.ExecutionPaths)+len(inventory.ScratchRoots))
+	paths = append(paths, inventory.WorktreePaths...)
+	paths = append(paths, inventory.EnvironmentPaths...)
+	paths = append(paths, inventory.ExecutionPaths...)
+	for _, scratch := range inventory.ScratchRoots {
+		if scratch.Path == "" || scratch.TaskID == "" || scratch.WorkspaceID == "" {
+			return nil, errors.New("active scratch inventory is incomplete")
+		}
+		paths = append(paths, scratch.Path)
+	}
+	protected := make(map[string]struct{})
+	for _, raw := range paths {
+		if raw == "" || !filepath.IsAbs(raw) {
+			return nil, fmt.Errorf("inventory path is not absolute: %q", raw)
+		}
+		path := filepath.Clean(raw)
+		if !pathContains(tasksRoot, path) || path == tasksRoot {
+			continue
+		}
+		for current := path; current != tasksRoot; current = filepath.Dir(current) {
+			protected[current] = struct{}{}
+			if current == filepath.Dir(current) {
+				return nil, fmt.Errorf("inventory path escaped tasks root: %s", path)
+			}
+		}
+	}
+	return protected, nil
+}
+
+func discoverTaskRoots(tasksRoot string) ([]candidate, []string, error) {
+	entries, err := os.ReadDir(tasksRoot)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil, nil
+	}
+	if err != nil {
+		return nil, nil, err
+	}
+	roots := make([]candidate, 0)
+	warnings := make([]string, 0)
+	for _, entry := range entries {
+		path := filepath.Join(tasksRoot, entry.Name())
+		discovered, classified, err := discoverTaskRoot(path, entry)
+		if err != nil {
+			return nil, nil, err
+		}
+		roots = append(roots, discovered...)
+		if entry.IsDir() && !classified {
+			warnings = append(warnings, "unclassified task directory kept: "+path)
+		}
+	}
+	return roots, warnings, nil
+}
+
+func discoverTaskRoot(path string, entry os.DirEntry) ([]candidate, bool, error) {
+	if entry.Type()&os.ModeSymlink != 0 {
+		return nil, false, fmt.Errorf("symlink beneath tasks root: %s", path)
+	}
+	if !entry.IsDir() {
+		return nil, false, nil
+	}
+	owner, marked, err := readOwnershipMarker(path)
+	if err != nil {
+		return nil, false, err
+	}
+	if marked {
+		return []candidate{{path: path, owner: owner}}, true, nil
+	}
+	if looksSemanticTaskDir(entry.Name()) {
+		owner = OwnershipMarker{TaskDirName: entry.Name(), LayoutVersion: LayoutVersionSemantic}
+		return []candidate{{path: path, owner: owner}}, true, nil
+	}
+	return discoverScratchRoots(path, entry.Name())
+}
+
+func discoverScratchRoots(workspacePath, workspaceID string) ([]candidate, bool, error) {
+	children, err := os.ReadDir(workspacePath)
+	if err != nil {
+		return nil, false, err
+	}
+	roots := make([]candidate, 0, len(children))
+	for _, child := range children {
+		childPath := filepath.Join(workspacePath, child.Name())
+		if child.Type()&os.ModeSymlink != 0 {
+			return nil, false, fmt.Errorf("symlink beneath tasks root: %s", childPath)
+		}
+		if !child.IsDir() {
+			continue
+		}
+		owner, marked, err := readOwnershipMarker(childPath)
+		if err != nil {
+			return nil, false, err
+		}
+		if marked && owner.LayoutVersion != LayoutVersionScratch {
+			return nil, false, fmt.Errorf("unexpected nested semantic workspace marker: %s", childPath)
+		}
+		if !marked {
+			owner = OwnershipMarker{
+				TaskID: child.Name(), WorkspaceID: workspaceID,
+				TaskDirName: child.Name(), LayoutVersion: LayoutVersionScratch,
+			}
+		}
+		roots = append(roots, candidate{path: childPath, owner: owner})
+	}
+	return roots, len(roots) > 0, nil
+}
+
+func looksSemanticTaskDir(name string) bool {
+	index := strings.LastIndexByte(name, '_')
+	return index > 0 && len(name[index+1:]) == 3
+}
+
+func directorySizeNoSymlinks(root string) (int64, error) {
+	var size int64
+	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			return fmt.Errorf("symlink found at %s", path)
+		}
+		if entry.Type().IsRegular() {
+			info, err := entry.Info()
+			if err != nil {
+				return err
+			}
+			size += info.Size()
+		}
+		return nil
+	})
+	return size, err
+}
+
+func rejectRootSymlink(root string) error {
+	info, err := os.Lstat(root)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return fmt.Errorf("owned root is not a real directory: %s", root)
+	}
+	return nil
+}
+
+func ensureSafeParent(root, parent string) error {
+	if !pathContains(root, parent) {
+		return fmt.Errorf("path escapes owned root: %s", parent)
+	}
+	rel, err := filepath.Rel(root, parent)
+	if err != nil {
+		return err
+	}
+	current := root
+	for _, part := range strings.Split(rel, string(filepath.Separator)) {
+		if part == "." || part == "" {
+			continue
+		}
+		current = filepath.Join(current, part)
+		info, err := os.Lstat(current)
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+			return fmt.Errorf("unsafe restore parent: %s", current)
+		}
+	}
+	return nil
+}
+
+func pathContains(parent, child string) bool {
+	rel, err := filepath.Rel(parent, child)
+	return err == nil && rel != ".." && !filepath.IsAbs(rel) && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+func writeJSONFile(path string, value any) error {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, encoded, 0o600)
+}
+
+func readQuarantineManifest(root string) (quarantineManifest, error) {
+	path := filepath.Join(root, quarantineManifestName)
+	info, err := os.Lstat(path)
+	if err != nil {
+		return quarantineManifest{}, fmt.Errorf("inspect quarantine manifest %s: %w", path, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		return quarantineManifest{}, fmt.Errorf("unsafe quarantine manifest: %s", path)
+	}
+	encoded, err := os.ReadFile(path)
+	if err != nil {
+		return quarantineManifest{}, err
+	}
+	var manifest quarantineManifest
+	if err := json.Unmarshal(encoded, &manifest); err != nil {
+		return quarantineManifest{}, fmt.Errorf("decode quarantine manifest: %w", err)
+	}
+	return manifest, nil
+}

--- a/apps/backend/internal/system/storage/workspaces/provider.go
+++ b/apps/backend/internal/system/storage/workspaces/provider.go
@@ -160,6 +160,11 @@ func (p *Provider) quarantine(ctx context.Context, item candidate) (storage.Quar
 	if err := os.MkdirAll(trashTasks, 0o700); err != nil {
 		return storage.QuarantineEntry{}, fmt.Errorf("create workspace trash: %w", err)
 	}
+	if _, err := storage.ReleaseFailedQuarantineIntent(
+		ctx, p.config.Store, storage.ResourceTypeTaskWorkspace, item.path,
+	); err != nil {
+		return storage.QuarantineEntry{}, err
+	}
 	now := p.config.Now().UTC()
 	id := p.config.NewID()
 	metadata, _ := json.Marshal(item.owner)
@@ -235,17 +240,24 @@ func (p *Provider) RestoreTask(ctx context.Context, taskID string) WorkspaceReco
 		recovery.Message = err.Error()
 		return recovery
 	}
-	for _, entry := range entries {
-		if entry.ResourceType != storage.ResourceTypeTaskWorkspace || entry.TaskID != taskID {
+	var newest *storage.QuarantineEntry
+	for i := range entries {
+		entry := &entries[i]
+		if entry.ResourceType != storage.ResourceTypeTaskWorkspace || entry.TaskID != taskID ||
+			entry.State != storage.QuarantineStateQuarantined {
 			continue
 		}
-		if _, err := p.Restore(ctx, entry.ID); err != nil {
+		if newest == nil || entry.QuarantinedAt.After(newest.QuarantinedAt) {
+			newest = entry
+		}
+	}
+	if newest != nil {
+		if _, err := p.Restore(ctx, newest.ID); err != nil {
 			recovery.Status = "failed"
 			recovery.Message = err.Error()
 			return recovery
 		}
 		recovery.Status = "restored"
-		return recovery
 	}
 	return recovery
 }

--- a/apps/backend/internal/system/storage/workspaces/provider_test.go
+++ b/apps/backend/internal/system/storage/workspaces/provider_test.go
@@ -605,13 +605,7 @@ func TestRestoreTaskReconcilesFailedEntryFilesystemState(t *testing.T) {
 				t.Fatalf("entry state = %q, want %q", got, test.wantState)
 			}
 			if test.wantStatus == "restored" {
-				wantContents := "original"
-				if test.createQuarantine {
-					wantContents = "quarantine"
-				}
-				if data, err := os.ReadFile(filepath.Join(original, "artifact")); err != nil || string(data) != wantContents {
-					t.Fatalf("restored artifact: data=%q err=%v", data, err)
-				}
+				assertRestoredWorkspace(t, original, quarantined, test.createQuarantine)
 				return
 			}
 			if test.createOriginal {
@@ -625,6 +619,23 @@ func TestRestoreTaskReconcilesFailedEntryFilesystemState(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func assertRestoredWorkspace(t *testing.T, original, quarantined string, restoredFromQuarantine bool) {
+	t.Helper()
+	wantContents := "original"
+	if restoredFromQuarantine {
+		wantContents = "quarantine"
+	}
+	if data, err := os.ReadFile(filepath.Join(original, "artifact")); err != nil || string(data) != wantContents {
+		t.Fatalf("restored artifact: data=%q err=%v", data, err)
+	}
+	if !restoredFromQuarantine {
+		return
+	}
+	if _, err := os.Lstat(quarantined); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("quarantine path remains after restore: %v", err)
 	}
 }
 

--- a/apps/backend/internal/system/storage/workspaces/provider_test.go
+++ b/apps/backend/internal/system/storage/workspaces/provider_test.go
@@ -23,6 +23,7 @@ func (s fakeInventorySource) LoadWorkspaceInventory(context.Context) (Inventory,
 
 type fakeQuarantineStore struct {
 	entries map[string]storage.QuarantineEntry
+	order   []string
 }
 
 func newFakeQuarantineStore() *fakeQuarantineStore {
@@ -33,7 +34,14 @@ func (s *fakeQuarantineStore) CreateQuarantineEntry(_ context.Context, entry *st
 	if _, exists := s.entries[entry.ID]; exists {
 		return errors.New("duplicate quarantine entry")
 	}
+	for _, existing := range s.entries {
+		if existing.OriginalPath == entry.OriginalPath &&
+			(existing.State == storage.QuarantineStateQuarantined || existing.State == storage.QuarantineStateFailed) {
+			return errors.New("duplicate active quarantine original path")
+		}
+	}
 	s.entries[entry.ID] = *entry
+	s.order = append(s.order, entry.ID)
 	return nil
 }
 
@@ -61,9 +69,17 @@ func (s *fakeQuarantineStore) TransitionQuarantineEntry(
 	return entry, nil
 }
 
-func (s *fakeQuarantineStore) ListQuarantineEntries(context.Context, bool) ([]storage.QuarantineEntry, error) {
+func (s *fakeQuarantineStore) ListQuarantineEntries(
+	_ context.Context,
+	includeTerminal bool,
+) ([]storage.QuarantineEntry, error) {
 	entries := make([]storage.QuarantineEntry, 0, len(s.entries))
-	for _, entry := range s.entries {
+	for _, id := range s.order {
+		entry := s.entries[id]
+		if !includeTerminal && entry.State != storage.QuarantineStateQuarantined &&
+			entry.State != storage.QuarantineStateFailed {
+			continue
+		}
 		entries = append(entries, entry)
 	}
 	return entries, nil
@@ -155,6 +171,60 @@ func TestCleanupQuarantinesOldOwnedOrphanAndRestoreIsConflictSafe(t *testing.T) 
 	}
 	if data, err := os.ReadFile(module); err != nil || string(data) != "large dependency" {
 		t.Fatalf("restored node_modules data = %q, %v", data, err)
+	}
+}
+
+func TestCleanupRetriesFailedWorkspaceIntentWhenMoveNeverHappened(t *testing.T) {
+	provider, tasksRoot, store := newProviderFixture(t, Inventory{Complete: true}, nil)
+	candidate := createOwnedCandidate(t, tasksRoot, "retry-task_abc", OwnershipMarker{
+		TaskID: "retry-task", TaskDirName: "retry-task_abc", LayoutVersion: LayoutVersionSemantic,
+	})
+	old := time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC)
+	if err := os.Chtimes(candidate, old, old); err != nil {
+		t.Fatalf("age candidate: %v", err)
+	}
+	blockedQuarantine := filepath.Join(provider.config.TrashRoot, "tasks", "entry-1")
+	if err := os.MkdirAll(blockedQuarantine, 0o700); err != nil {
+		t.Fatalf("create blocked quarantine: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(blockedQuarantine, "blocker"), []byte("block"), 0o600); err != nil {
+		t.Fatalf("write quarantine blocker: %v", err)
+	}
+
+	if _, err := provider.Cleanup(context.Background()); err == nil {
+		t.Fatal("first Cleanup succeeded despite blocked quarantine destination")
+	}
+	if got := store.entries["entry-1"].State; got != storage.QuarantineStateFailed {
+		t.Fatalf("first intent state = %q, want failed", got)
+	}
+	if err := os.Chtimes(candidate, old, old); err != nil {
+		t.Fatalf("re-age candidate for ambiguous retry: %v", err)
+	}
+	if _, err := provider.Cleanup(context.Background()); !errors.Is(err, storage.ErrConflict) {
+		t.Fatalf("ambiguous retry error = %v, want ErrConflict", err)
+	}
+	if got := store.entries["entry-1"].State; got != storage.QuarantineStateFailed {
+		t.Fatalf("ambiguous intent state = %q, want failed", got)
+	}
+	if err := os.RemoveAll(blockedQuarantine); err != nil {
+		t.Fatalf("remove quarantine blocker: %v", err)
+	}
+	if err := os.Chtimes(candidate, old, old); err != nil {
+		t.Fatalf("re-age candidate: %v", err)
+	}
+
+	result, err := provider.Cleanup(context.Background())
+	if err != nil {
+		t.Fatalf("retry Cleanup: %v", err)
+	}
+	if result.Quarantined != 1 {
+		t.Fatalf("retry result = %#v, want one quarantined workspace", result)
+	}
+	if got := store.entries["entry-1"].State; got != storage.QuarantineStateRestored {
+		t.Fatalf("released intent state = %q, want restored", got)
+	}
+	if got := store.entries["entry-2"].State; got != storage.QuarantineStateQuarantined {
+		t.Fatalf("replacement intent state = %q, want quarantined", got)
 	}
 }
 
@@ -458,6 +528,38 @@ func TestRestoreTaskReportsRestoredNotFoundAndFailed(t *testing.T) {
 	store.entries[entry.ID] = entry
 	if got := provider.RestoreTask(context.Background(), "restore-task"); got.Status != "failed" {
 		t.Fatalf("conflicted recovery = %#v", got)
+	}
+}
+
+func TestRestoreTaskChoosesNewestQuarantinedEntry(t *testing.T) {
+	provider, root, store := newProviderFixture(t, Inventory{Complete: true}, nil)
+	original := filepath.Join(root, "restore-task_abc")
+	trashTasks := filepath.Join(filepath.Dir(root), "trash", "tasks")
+	oldFailed := storage.QuarantineEntry{
+		ID: "old-failed", ResourceType: storage.ResourceTypeTaskWorkspace, TaskID: "restore-task",
+		OriginalPath: original, QuarantinePath: filepath.Join(trashTasks, "old-failed"),
+		State: storage.QuarantineStateFailed, QuarantinedAt: time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC),
+	}
+	newest := storage.QuarantineEntry{
+		ID: "newest", ResourceType: storage.ResourceTypeTaskWorkspace, TaskID: "restore-task",
+		OriginalPath: original, QuarantinePath: filepath.Join(trashTasks, "newest"),
+		State: storage.QuarantineStateQuarantined, QuarantinedAt: time.Date(2026, time.July, 2, 0, 0, 0, 0, time.UTC),
+	}
+	store.entries[oldFailed.ID] = oldFailed
+	store.entries[newest.ID] = newest
+	store.order = append(store.order, oldFailed.ID, newest.ID)
+	if err := os.MkdirAll(newest.QuarantinePath, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(newest.QuarantinePath, "artifact"), []byte("keep"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := provider.RestoreTask(context.Background(), "restore-task"); got.Status != "restored" {
+		t.Fatalf("RestoreTask = %#v, want restored", got)
+	}
+	if _, err := os.Stat(filepath.Join(original, "artifact")); err != nil {
+		t.Fatalf("restored newest workspace: %v", err)
 	}
 }
 

--- a/apps/backend/internal/system/storage/workspaces/provider_test.go
+++ b/apps/backend/internal/system/storage/workspaces/provider_test.go
@@ -1,0 +1,501 @@
+package workspaces
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/system/storage"
+)
+
+type fakeInventorySource struct {
+	inventory Inventory
+	err       error
+}
+
+func (s fakeInventorySource) LoadWorkspaceInventory(context.Context) (Inventory, error) {
+	return s.inventory, s.err
+}
+
+type fakeQuarantineStore struct {
+	entries map[string]storage.QuarantineEntry
+}
+
+func newFakeQuarantineStore() *fakeQuarantineStore {
+	return &fakeQuarantineStore{entries: make(map[string]storage.QuarantineEntry)}
+}
+
+func (s *fakeQuarantineStore) CreateQuarantineEntry(_ context.Context, entry *storage.QuarantineEntry) error {
+	if _, exists := s.entries[entry.ID]; exists {
+		return errors.New("duplicate quarantine entry")
+	}
+	s.entries[entry.ID] = *entry
+	return nil
+}
+
+func (s *fakeQuarantineStore) GetQuarantineEntry(_ context.Context, id string) (storage.QuarantineEntry, error) {
+	entry, ok := s.entries[id]
+	if !ok {
+		return storage.QuarantineEntry{}, storage.ErrNotFound
+	}
+	return entry, nil
+}
+
+func (s *fakeQuarantineStore) TransitionQuarantineEntry(
+	_ context.Context,
+	id string,
+	next storage.QuarantineState,
+	lastError string,
+) (storage.QuarantineEntry, error) {
+	entry, ok := s.entries[id]
+	if !ok {
+		return storage.QuarantineEntry{}, storage.ErrNotFound
+	}
+	entry.State = next
+	entry.LastError = lastError
+	s.entries[id] = entry
+	return entry, nil
+}
+
+func (s *fakeQuarantineStore) ListQuarantineEntries(context.Context, bool) ([]storage.QuarantineEntry, error) {
+	entries := make([]storage.QuarantineEntry, 0, len(s.entries))
+	for _, entry := range s.entries {
+		entries = append(entries, entry)
+	}
+	return entries, nil
+}
+
+func TestCleanupFailsClosedWhenInventoryIsIncompleteOrErrors(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		inventory Inventory
+		err       error
+	}{
+		{name: "incomplete", inventory: Inventory{Complete: false}},
+		{name: "error", err: errors.New("inventory unavailable")},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			provider, root, store := newProviderFixture(t, tt.inventory, tt.err)
+			candidate := createOwnedCandidate(t, root, "old-task_abc", OwnershipMarker{
+				TaskID: "task-1", WorkspaceID: "workspace-1", TaskDirName: "old-task_abc",
+				LayoutVersion: LayoutVersionSemantic,
+			})
+
+			if _, err := provider.Cleanup(context.Background()); err == nil {
+				t.Fatal("Cleanup succeeded without complete authoritative inventory")
+			}
+			if _, err := os.Stat(candidate); err != nil {
+				t.Fatalf("candidate moved despite inventory failure: %v", err)
+			}
+			if len(store.entries) != 0 {
+				t.Fatalf("quarantine entries = %d, want none", len(store.entries))
+			}
+		})
+	}
+}
+
+func TestCleanupQuarantinesOldOwnedOrphanAndRestoreIsConflictSafe(t *testing.T) {
+	provider, root, store := newProviderFixture(t, Inventory{Complete: true}, nil)
+	candidate := createOwnedCandidate(t, root, "orphan-task_abc", OwnershipMarker{
+		TaskID: "task-orphan", WorkspaceID: "workspace-1", TaskDirName: "orphan-task_abc",
+		LayoutVersion: LayoutVersionSemantic,
+	})
+	module := filepath.Join(candidate, "repo", "node_modules", "package", "index.js")
+	if err := os.MkdirAll(filepath.Dir(module), 0o755); err != nil {
+		t.Fatalf("MkdirAll node_modules: %v", err)
+	}
+	if err := os.WriteFile(module, []byte("large dependency"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	old := time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC)
+	if err := os.Chtimes(candidate, old, old); err != nil {
+		t.Fatalf("Chtimes: %v", err)
+	}
+
+	result, err := provider.Cleanup(context.Background())
+	if err != nil {
+		t.Fatalf("Cleanup: %v", err)
+	}
+	if result.Quarantined != 1 || result.ReclaimedBytes < int64(len("large dependency")) {
+		t.Fatalf("cleanup result = %#v", result)
+	}
+	entry := store.entries["entry-1"]
+	if entry.TaskID != "task-orphan" || entry.OriginalPath != candidate {
+		t.Fatalf("persisted entry = %#v", entry)
+	}
+	if _, err := os.Stat(candidate); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("original still exists after quarantine: %v", err)
+	}
+	if _, err := os.Stat(entry.QuarantinePath); err != nil {
+		t.Fatalf("quarantine missing: %v", err)
+	}
+
+	if err := os.MkdirAll(candidate, 0o755); err != nil {
+		t.Fatalf("create restore conflict: %v", err)
+	}
+	if _, err := provider.Restore(context.Background(), entry.ID); !errors.Is(err, ErrRestoreConflict) {
+		t.Fatalf("Restore conflict error = %v, want ErrRestoreConflict", err)
+	}
+	if got := store.entries[entry.ID]; got.State != storage.QuarantineStateQuarantined {
+		t.Fatalf("conflicted entry state = %q, want quarantined", got.State)
+	}
+	if err := os.Remove(candidate); err != nil {
+		t.Fatalf("remove conflict: %v", err)
+	}
+	restored, err := provider.Restore(context.Background(), entry.ID)
+	if err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+	if restored.State != storage.QuarantineStateRestored {
+		t.Fatalf("restored state = %q", restored.State)
+	}
+	if data, err := os.ReadFile(module); err != nil || string(data) != "large dependency" {
+		t.Fatalf("restored node_modules data = %q, %v", data, err)
+	}
+}
+
+func TestCleanupProtectsEveryInventorySourceAndScratchSiblingsIndependently(t *testing.T) {
+	home := t.TempDir()
+	tasksRoot := filepath.Join(home, "tasks")
+	trashRoot := filepath.Join(home, "trash")
+	store := newFakeQuarantineStore()
+	now := time.Date(2026, time.July, 14, 0, 0, 0, 0, time.UTC)
+	type rootSpec struct {
+		rel    string
+		marker OwnershipMarker
+	}
+	roots := []rootSpec{
+		{rel: "worktree-task_abc", marker: OwnershipMarker{TaskID: "task-worktree", TaskDirName: "worktree-task_abc", LayoutVersion: LayoutVersionSemantic}},
+		{rel: "environment-task_def", marker: OwnershipMarker{TaskID: "task-environment", TaskDirName: "environment-task_def", LayoutVersion: LayoutVersionSemantic}},
+		{rel: "execution-task_ghi", marker: OwnershipMarker{TaskID: "task-execution", TaskDirName: "execution-task_ghi", LayoutVersion: LayoutVersionSemantic}},
+		{rel: filepath.Join("workspace-1", "task-active"), marker: OwnershipMarker{TaskID: "task-active", WorkspaceID: "workspace-1", TaskDirName: "task-active", LayoutVersion: LayoutVersionScratch}},
+		{rel: filepath.Join("workspace-1", "task-orphan"), marker: OwnershipMarker{TaskID: "task-orphan", WorkspaceID: "workspace-1", TaskDirName: "task-orphan", LayoutVersion: LayoutVersionScratch}},
+	}
+	paths := make(map[string]string)
+	for _, spec := range roots {
+		path := createOwnedCandidate(t, tasksRoot, spec.rel, spec.marker)
+		old := now.Add(-8 * 24 * time.Hour)
+		if err := os.Chtimes(path, old, old); err != nil {
+			t.Fatalf("Chtimes(%s): %v", path, err)
+		}
+		paths[spec.marker.TaskID] = path
+	}
+	inventory := Inventory{
+		Complete:         true,
+		WorktreePaths:    []string{filepath.Join(paths["task-worktree"], "repo")},
+		EnvironmentPaths: []string{paths["task-environment"]},
+		ExecutionPaths:   []string{filepath.Join(paths["task-execution"], "repo")},
+		ScratchRoots: []ScratchRoot{{
+			TaskID: "task-active", WorkspaceID: "workspace-1", Path: paths["task-active"],
+		}},
+	}
+	provider := New(Config{
+		TasksRoot: tasksRoot, TrashRoot: trashRoot, Store: store,
+		Inventory: fakeInventorySource{inventory: inventory}, GracePeriod: 7 * 24 * time.Hour,
+		Now: func() time.Time { return now }, NewID: func() string { return "entry-orphan" },
+	})
+	result, err := provider.Cleanup(context.Background())
+	if err != nil {
+		t.Fatalf("Cleanup: %v", err)
+	}
+	if result.Quarantined != 1 || store.entries["entry-orphan"].TaskID != "task-orphan" {
+		t.Fatalf("cleanup result=%#v entries=%#v", result, store.entries)
+	}
+	for _, taskID := range []string{"task-worktree", "task-environment", "task-execution", "task-active"} {
+		if _, err := os.Stat(paths[taskID]); err != nil {
+			t.Fatalf("protected %s root moved: %v", taskID, err)
+		}
+	}
+}
+
+func TestCleanupPathUncertaintyAbortsBeforeAnyMove(t *testing.T) {
+	provider, root, store := newProviderFixture(t, Inventory{Complete: true}, nil)
+	first := createOwnedCandidate(t, root, "first-task_abc", OwnershipMarker{TaskID: "first", TaskDirName: "first-task_abc", LayoutVersion: LayoutVersionSemantic})
+	unsafe := createOwnedCandidate(t, root, "unsafe-task_def", OwnershipMarker{TaskID: "unsafe", TaskDirName: "unsafe-task_def", LayoutVersion: LayoutVersionSemantic})
+	for _, path := range []string{first, unsafe} {
+		old := time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC)
+		if err := os.Chtimes(path, old, old); err != nil {
+			t.Fatalf("Chtimes: %v", err)
+		}
+	}
+	if err := os.Symlink(t.TempDir(), filepath.Join(unsafe, "escape")); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+	old := time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC)
+	if err := os.Chtimes(unsafe, old, old); err != nil {
+		t.Fatalf("Chtimes unsafe after symlink: %v", err)
+	}
+	if _, err := provider.Cleanup(context.Background()); err == nil {
+		t.Fatal("Cleanup succeeded with symlink uncertainty")
+	}
+	if len(store.entries) != 0 {
+		t.Fatalf("persisted %d entries before validating every candidate", len(store.entries))
+	}
+	for _, path := range []string{first, unsafe} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("candidate moved despite path uncertainty: %v", err)
+		}
+	}
+}
+
+func TestCleanupRejectsSymlinkedTrashPathsBeforeAnyMutation(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		linkTarget func(t *testing.T, trashRoot, external string)
+	}{
+		{
+			name: "trash root",
+			linkTarget: func(t *testing.T, trashRoot, external string) {
+				t.Helper()
+				if err := os.Symlink(external, trashRoot); err != nil {
+					t.Fatalf("symlink trash root: %v", err)
+				}
+			},
+		},
+		{
+			name: "tasks beneath trash root",
+			linkTarget: func(t *testing.T, trashRoot, external string) {
+				t.Helper()
+				if err := os.MkdirAll(trashRoot, 0o700); err != nil {
+					t.Fatalf("create trash root: %v", err)
+				}
+				if err := os.Symlink(external, filepath.Join(trashRoot, "tasks")); err != nil {
+					t.Fatalf("symlink task trash: %v", err)
+				}
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			provider, tasksRoot, store := newProviderFixture(t, Inventory{Complete: true}, nil)
+			candidate := createOwnedCandidate(t, tasksRoot, "unsafe-trash_abc", OwnershipMarker{
+				TaskID: "task-unsafe", TaskDirName: "unsafe-trash_abc", LayoutVersion: LayoutVersionSemantic,
+			})
+			old := time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC)
+			if err := os.Chtimes(candidate, old, old); err != nil {
+				t.Fatalf("age candidate: %v", err)
+			}
+			external := t.TempDir()
+			test.linkTarget(t, provider.config.TrashRoot, external)
+
+			if _, err := provider.Cleanup(context.Background()); err == nil {
+				t.Fatal("Cleanup succeeded with a symlinked trash path")
+			}
+			if _, err := os.Stat(candidate); err != nil {
+				t.Fatalf("candidate changed despite unsafe trash: %v", err)
+			}
+			if len(store.entries) != 0 {
+				t.Fatalf("persisted %d entries before trash validation", len(store.entries))
+			}
+			externalEntries, err := os.ReadDir(external)
+			if err != nil || len(externalEntries) != 0 {
+				t.Fatalf("external trash target changed: entries=%v err=%v", externalEntries, err)
+			}
+		})
+	}
+}
+
+func TestCleanupRejectsSymlinkedOwnershipMarker(t *testing.T) {
+	provider, tasksRoot, store := newProviderFixture(t, Inventory{Complete: true}, nil)
+	candidate := filepath.Join(tasksRoot, "marker-link_abc")
+	if err := os.MkdirAll(candidate, 0o755); err != nil {
+		t.Fatalf("create candidate: %v", err)
+	}
+	externalMarker := filepath.Join(t.TempDir(), "marker.json")
+	marker := OwnershipMarker{
+		TaskID: "task-link", TaskDirName: "marker-link_abc", LayoutVersion: LayoutVersionSemantic,
+	}
+	if err := writeJSONFile(externalMarker, marker); err != nil {
+		t.Fatalf("write external marker: %v", err)
+	}
+	if err := os.Symlink(externalMarker, filepath.Join(candidate, OwnershipMarkerFilename)); err != nil {
+		t.Fatalf("symlink marker: %v", err)
+	}
+	old := time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC)
+	if err := os.Chtimes(candidate, old, old); err != nil {
+		t.Fatalf("age candidate: %v", err)
+	}
+
+	if _, err := provider.Cleanup(context.Background()); err == nil {
+		t.Fatal("Cleanup accepted a symlinked ownership marker")
+	}
+	if _, err := os.Stat(candidate); err != nil {
+		t.Fatalf("candidate changed despite symlinked marker: %v", err)
+	}
+	if len(store.entries) != 0 {
+		t.Fatalf("persisted %d entries for symlinked marker", len(store.entries))
+	}
+}
+
+func TestCleanupSupportsLegacySemanticAndScratchLayouts(t *testing.T) {
+	provider, root, store := newProviderFixture(t, Inventory{Complete: true}, nil)
+	semantic := filepath.Join(root, "legacy-task_abc")
+	scratch := filepath.Join(root, "workspace-legacy", "task-legacy")
+	for _, path := range []string{semantic, scratch} {
+		if err := os.MkdirAll(filepath.Join(path, ".git"), 0o755); err != nil {
+			t.Fatalf("MkdirAll(%s): %v", path, err)
+		}
+		old := time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC)
+		if err := os.Chtimes(path, old, old); err != nil {
+			t.Fatalf("Chtimes(%s): %v", path, err)
+		}
+	}
+	result, err := provider.Cleanup(context.Background())
+	if err != nil {
+		t.Fatalf("Cleanup: %v", err)
+	}
+	if result.Quarantined != 2 || len(store.entries) != 2 {
+		t.Fatalf("legacy cleanup result=%#v entries=%#v", result, store.entries)
+	}
+}
+
+type recordingPruner struct{ calls int }
+
+func (p *recordingPruner) PruneQuarantinedWorkspace(context.Context, storage.QuarantineEntry) error {
+	p.calls++
+	return nil
+}
+
+func TestPermanentDeleteRequiresConfirmationAndPreservesRecoveryMetadata(t *testing.T) {
+	provider, root, store := newProviderFixture(t, Inventory{Complete: true}, nil)
+	pruner := &recordingPruner{}
+	provider.config.Pruner = pruner
+	candidate := createOwnedCandidate(t, root, "delete-task_abc", OwnershipMarker{TaskID: "delete-task", TaskDirName: "delete-task_abc", LayoutVersion: LayoutVersionSemantic})
+	old := time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC)
+	if err := os.Chtimes(candidate, old, old); err != nil {
+		t.Fatalf("Chtimes: %v", err)
+	}
+	if _, err := provider.Cleanup(context.Background()); err != nil {
+		t.Fatalf("Cleanup: %v", err)
+	}
+	entry := store.entries["entry-1"]
+	provider.config.Now = func() time.Time { return entry.DeleteAfter.Add(time.Hour) }
+	if _, err := provider.PermanentDelete(context.Background(), entry.ID, "wrong"); !errors.Is(err, ErrDeleteConfirmation) {
+		t.Fatalf("PermanentDelete confirmation error = %v", err)
+	}
+	if _, err := os.Stat(entry.QuarantinePath); err != nil {
+		t.Fatalf("quarantine changed without confirmation: %v", err)
+	}
+	deleted, err := provider.PermanentDelete(context.Background(), entry.ID, "DELETE")
+	if err != nil {
+		t.Fatalf("PermanentDelete: %v", err)
+	}
+	if deleted.State != storage.QuarantineStateDeleted || pruner.calls != 1 {
+		t.Fatalf("deleted=%#v prune calls=%d", deleted, pruner.calls)
+	}
+	if entry.TaskID != "delete-task" || entry.Metadata == nil {
+		t.Fatalf("historical quarantine identity lost: %#v", entry)
+	}
+}
+
+func TestPermanentDeleteBeforeRetentionReturnsConflictAndKeepsQuarantine(t *testing.T) {
+	provider, root, store := newProviderFixture(t, Inventory{Complete: true}, nil)
+	candidate := createOwnedCandidate(t, root, "retained-task_abc", OwnershipMarker{
+		TaskID: "retained-task", TaskDirName: "retained-task_abc", LayoutVersion: LayoutVersionSemantic,
+	})
+	old := time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC)
+	if err := os.Chtimes(candidate, old, old); err != nil {
+		t.Fatalf("Chtimes: %v", err)
+	}
+	if _, err := provider.Cleanup(context.Background()); err != nil {
+		t.Fatalf("Cleanup: %v", err)
+	}
+	entry := store.entries["entry-1"]
+
+	_, err := provider.PermanentDelete(context.Background(), entry.ID, "DELETE")
+	if !errors.Is(err, storage.ErrConflict) {
+		t.Fatalf("PermanentDelete error = %v, want storage.ErrConflict", err)
+	}
+	if _, err := os.Stat(entry.QuarantinePath); err != nil {
+		t.Fatalf("quarantine path changed before deadline: %v", err)
+	}
+	if got := store.entries[entry.ID]; got.State != storage.QuarantineStateQuarantined {
+		t.Fatalf("quarantine state = %q, want quarantined", got.State)
+	}
+}
+
+func TestReconcileRecreatesMissingRecordFromQuarantineManifest(t *testing.T) {
+	provider, root, store := newProviderFixture(t, Inventory{Complete: true}, nil)
+	candidate := createOwnedCandidate(t, root, "reconcile-task_abc", OwnershipMarker{TaskID: "reconcile-task", TaskDirName: "reconcile-task_abc", LayoutVersion: LayoutVersionSemantic})
+	old := time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC)
+	if err := os.Chtimes(candidate, old, old); err != nil {
+		t.Fatalf("Chtimes: %v", err)
+	}
+	if _, err := provider.Cleanup(context.Background()); err != nil {
+		t.Fatalf("Cleanup: %v", err)
+	}
+	delete(store.entries, "entry-1")
+	result, err := provider.Reconcile(context.Background())
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if result.Recovered != 1 || store.entries["entry-1"].TaskID != "reconcile-task" {
+		t.Fatalf("reconcile result=%#v entries=%#v", result, store.entries)
+	}
+}
+
+func TestRestoreTaskReportsRestoredNotFoundAndFailed(t *testing.T) {
+	provider, root, store := newProviderFixture(t, Inventory{Complete: true}, nil)
+	candidate := createOwnedCandidate(t, root, "restore-task_abc", OwnershipMarker{TaskID: "restore-task", TaskDirName: "restore-task_abc", LayoutVersion: LayoutVersionSemantic})
+	old := time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC)
+	if err := os.Chtimes(candidate, old, old); err != nil {
+		t.Fatalf("Chtimes: %v", err)
+	}
+	if _, err := provider.Cleanup(context.Background()); err != nil {
+		t.Fatalf("Cleanup: %v", err)
+	}
+	if got := provider.RestoreTask(context.Background(), "missing-task"); got.Status != "not_found" {
+		t.Fatalf("missing recovery = %#v", got)
+	}
+	if got := provider.RestoreTask(context.Background(), "restore-task"); got.Status != "restored" {
+		t.Fatalf("restore recovery = %#v", got)
+	}
+	entry := store.entries["entry-1"]
+	entry.State = storage.QuarantineStateQuarantined
+	store.entries[entry.ID] = entry
+	if got := provider.RestoreTask(context.Background(), "restore-task"); got.Status != "failed" {
+		t.Fatalf("conflicted recovery = %#v", got)
+	}
+}
+
+func newProviderFixture(
+	t *testing.T,
+	inventory Inventory,
+	inventoryErr error,
+) (*Provider, string, *fakeQuarantineStore) {
+	t.Helper()
+	home := t.TempDir()
+	tasksRoot := filepath.Join(home, "tasks")
+	trashRoot := filepath.Join(home, "trash")
+	if err := os.MkdirAll(tasksRoot, 0o755); err != nil {
+		t.Fatalf("MkdirAll tasks: %v", err)
+	}
+	store := newFakeQuarantineStore()
+	now := time.Date(2026, time.July, 14, 0, 0, 0, 0, time.UTC)
+	nextID := 0
+	provider := New(Config{
+		TasksRoot: tasksRoot, TrashRoot: trashRoot,
+		Inventory: fakeInventorySource{inventory: inventory, err: inventoryErr}, Store: store,
+		GracePeriod: 7 * 24 * time.Hour, Retention: 7 * 24 * time.Hour,
+		Now: func() time.Time { return now }, NewID: func() string {
+			nextID++
+			return fmt.Sprintf("entry-%d", nextID)
+		},
+	})
+	return provider, tasksRoot, store
+}
+
+func createOwnedCandidate(t *testing.T, tasksRoot, relative string, marker OwnershipMarker) string {
+	t.Helper()
+	root := filepath.Join(tasksRoot, relative)
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("MkdirAll candidate: %v", err)
+	}
+	if err := WriteOwnershipMarker(root, marker); err != nil {
+		t.Fatalf("WriteOwnershipMarker: %v", err)
+	}
+	return root
+}

--- a/apps/backend/internal/system/storage/workspaces/provider_test.go
+++ b/apps/backend/internal/system/storage/workspaces/provider_test.go
@@ -563,6 +563,81 @@ func TestRestoreTaskChoosesNewestQuarantinedEntry(t *testing.T) {
 	}
 }
 
+func TestRestoreTaskReconcilesFailedEntryFilesystemState(t *testing.T) {
+	tests := []struct {
+		name             string
+		createOriginal   bool
+		createQuarantine bool
+		wantStatus       string
+		wantState        storage.QuarantineState
+	}{
+		{name: "original only", createOriginal: true, wantStatus: "restored", wantState: storage.QuarantineStateRestored},
+		{name: "quarantine only", createQuarantine: true, wantStatus: "restored", wantState: storage.QuarantineStateRestored},
+		{
+			name: "both paths", createOriginal: true, createQuarantine: true,
+			wantStatus: "failed", wantState: storage.QuarantineStateFailed,
+		},
+		{name: "neither path", wantStatus: "failed", wantState: storage.QuarantineStateFailed},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			provider, root, store := newProviderFixture(t, Inventory{Complete: true}, nil)
+			original := filepath.Join(root, "restore-failed_abc")
+			quarantined := filepath.Join(filepath.Dir(root), "trash", "tasks", "failed-entry")
+			if test.createOriginal {
+				writeWorkspaceArtifact(t, original, "original")
+			}
+			if test.createQuarantine {
+				writeWorkspaceArtifact(t, quarantined, "quarantine")
+			}
+			entry := storage.QuarantineEntry{
+				ID: "failed-entry", ResourceType: storage.ResourceTypeTaskWorkspace, TaskID: "restore-failed",
+				OriginalPath: original, QuarantinePath: quarantined, State: storage.QuarantineStateFailed,
+				QuarantinedAt: time.Now().UTC(),
+			}
+			store.entries[entry.ID] = entry
+			store.order = append(store.order, entry.ID)
+
+			if got := provider.RestoreTask(context.Background(), entry.TaskID); got.Status != test.wantStatus {
+				t.Fatalf("RestoreTask = %#v, want status %q", got, test.wantStatus)
+			}
+			if got := store.entries[entry.ID].State; got != test.wantState {
+				t.Fatalf("entry state = %q, want %q", got, test.wantState)
+			}
+			if test.wantStatus == "restored" {
+				wantContents := "original"
+				if test.createQuarantine {
+					wantContents = "quarantine"
+				}
+				if data, err := os.ReadFile(filepath.Join(original, "artifact")); err != nil || string(data) != wantContents {
+					t.Fatalf("restored artifact: data=%q err=%v", data, err)
+				}
+				return
+			}
+			if test.createOriginal {
+				if data, err := os.ReadFile(filepath.Join(original, "artifact")); err != nil || string(data) != "original" {
+					t.Fatalf("original artifact changed: data=%q err=%v", data, err)
+				}
+			}
+			if test.createQuarantine {
+				if data, err := os.ReadFile(filepath.Join(quarantined, "artifact")); err != nil || string(data) != "quarantine" {
+					t.Fatalf("quarantine artifact changed: data=%q err=%v", data, err)
+				}
+			}
+		})
+	}
+}
+
+func writeWorkspaceArtifact(t *testing.T, root, contents string) {
+	t.Helper()
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "artifact"), []byte(contents), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func newProviderFixture(
 	t *testing.T,
 	inventory Inventory,

--- a/apps/backend/internal/system/storage/workspaces/types.go
+++ b/apps/backend/internal/system/storage/workspaces/types.go
@@ -1,0 +1,100 @@
+// Package workspaces safely quarantines orphaned Kandev task workspaces.
+package workspaces
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/kandev/kandev/internal/system/storage"
+)
+
+const (
+	LayoutVersionSemantic = 1
+	LayoutVersionScratch  = 2
+)
+
+var (
+	ErrInventoryIncomplete = errors.New("workspace inventory is incomplete")
+	ErrRestoreConflict     = errors.New("workspace restore destination already exists")
+	ErrDeleteConfirmation  = errors.New("workspace permanent deletion requires DELETE confirmation")
+)
+
+type OwnershipMarker struct {
+	TaskID        string    `json:"task_id"`
+	WorkspaceID   string    `json:"workspace_id"`
+	TaskDirName   string    `json:"task_dir_name"`
+	LayoutVersion int       `json:"layout_version"`
+	CreatedAt     time.Time `json:"created_at"`
+}
+
+type ScratchRoot struct {
+	TaskID      string
+	WorkspaceID string
+	Path        string
+}
+
+type Inventory struct {
+	Complete         bool
+	WorktreePaths    []string
+	EnvironmentPaths []string
+	ExecutionPaths   []string
+	ScratchRoots     []ScratchRoot
+}
+
+type InventorySource interface {
+	LoadWorkspaceInventory(ctx context.Context) (Inventory, error)
+}
+
+type QuarantineStore interface {
+	CreateQuarantineEntry(ctx context.Context, entry *storage.QuarantineEntry) error
+	GetQuarantineEntry(ctx context.Context, id string) (storage.QuarantineEntry, error)
+	TransitionQuarantineEntry(ctx context.Context, id string, next storage.QuarantineState, lastError string) (storage.QuarantineEntry, error)
+	ListQuarantineEntries(ctx context.Context, includeTerminal bool) ([]storage.QuarantineEntry, error)
+}
+
+type Config struct {
+	TasksRoot   string
+	TrashRoot   string
+	Inventory   InventorySource
+	Store       QuarantineStore
+	GracePeriod time.Duration
+	Retention   time.Duration
+	Now         func() time.Time
+	NewID       func() string
+	Pruner      WorktreePruner
+}
+
+type WorktreePruner interface {
+	PruneQuarantinedWorkspace(ctx context.Context, entry storage.QuarantineEntry) error
+}
+
+type CleanupResult struct {
+	Candidates     int      `json:"candidates"`
+	Quarantined    int      `json:"quarantined"`
+	ReclaimedBytes int64    `json:"reclaimed_bytes"`
+	Warnings       []string `json:"warnings,omitempty"`
+}
+
+type Analysis struct {
+	ActiveBytes    int64    `json:"active_bytes"`
+	CandidateBytes int64    `json:"candidate_bytes"`
+	Warnings       []string `json:"warnings,omitempty"`
+}
+
+type WorkspaceRecovery struct {
+	TaskID  string `json:"task_id"`
+	Status  string `json:"status"`
+	Message string `json:"message,omitempty"`
+}
+
+type ReconcileResult struct {
+	Recovered int      `json:"recovered"`
+	Failed    int      `json:"failed"`
+	Warnings  []string `json:"warnings,omitempty"`
+}
+
+type quarantineManifest struct {
+	Entry storage.QuarantineEntry `json:"entry"`
+	Owner OwnershipMarker         `json:"owner"`
+}

--- a/apps/backend/internal/system/storage_routes_test.go
+++ b/apps/backend/internal/system/storage_routes_test.go
@@ -142,6 +142,7 @@ func newStorageRoutesTestRouterWithMutations(t *testing.T, mutations storage.Mut
 	if err != nil {
 		t.Fatal(err)
 	}
+	connection.SetMaxOpenConns(1)
 	t.Cleanup(func() { _ = connection.Close() })
 	pool := db.NewPool(connection, connection)
 	rawSettings, err := systemsettings.NewStore(pool)

--- a/apps/backend/internal/system/storage_routes_test.go
+++ b/apps/backend/internal/system/storage_routes_test.go
@@ -1,0 +1,202 @@
+package system
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/jmoiron/sqlx"
+	"github.com/kandev/kandev/internal/common/logger"
+	"github.com/kandev/kandev/internal/db"
+	systemsettings "github.com/kandev/kandev/internal/system/settings"
+	"github.com/kandev/kandev/internal/system/storage"
+	_ "github.com/mattn/go-sqlite3"
+	"go.uber.org/zap"
+)
+
+func TestRegisterRoutesExposesStorageSummary(t *testing.T) {
+	router := newStorageRoutesTestRouter(t)
+
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/system/storage", nil)
+	response := httptest.NewRecorder()
+	router.ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("GET /api/v1/system/storage status = %d, want 200", response.Code)
+	}
+}
+
+func TestStorageSettingsRejectInvalidPatch(t *testing.T) {
+	router := newStorageRoutesTestRouter(t)
+	settings := storage.DefaultSettings()
+	settings.CheckIntervalHours = storage.MaxCheckIntervalHours + 1
+	body, err := json.Marshal(map[string]any{"settings": settings})
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := httptest.NewRequest(http.MethodPatch, "/api/v1/system/storage/settings", bytes.NewReader(body))
+	request.Header.Set("Content-Type", "application/json")
+	response := httptest.NewRecorder()
+	router.ServeHTTP(response, request)
+
+	if response.Code != http.StatusBadRequest {
+		t.Fatalf("PATCH invalid storage settings status = %d, want 400", response.Code)
+	}
+}
+
+func TestStorageCollectionRoutesAndConfirmationGates(t *testing.T) {
+	router := newStorageRoutesTestRouter(t)
+	tests := []struct {
+		method string
+		path   string
+		body   string
+		want   int
+	}{
+		{method: http.MethodGet, path: "/api/v1/system/storage/runs", want: http.StatusOK},
+		{method: http.MethodGet, path: "/api/v1/system/storage/quarantine", want: http.StatusOK},
+		{method: http.MethodPost, path: "/api/v1/system/storage/go-cache/adopt", body: `{"path":"/tmp/cache","confirm":"WRONG"}`, want: http.StatusBadRequest},
+		{method: http.MethodDelete, path: "/api/v1/system/storage/quarantine/entry-1", body: `{"confirm":"WRONG"}`, want: http.StatusBadRequest},
+	}
+	for _, test := range tests {
+		t.Run(test.method+" "+test.path, func(t *testing.T) {
+			request := httptest.NewRequest(test.method, test.path, bytes.NewBufferString(test.body))
+			request.Header.Set("Content-Type", "application/json")
+			response := httptest.NewRecorder()
+			router.ServeHTTP(response, request)
+			if response.Code != test.want {
+				t.Fatalf("status = %d, want %d", response.Code, test.want)
+			}
+		})
+	}
+}
+
+func TestStorageAsyncRoutesAndBusyResponse(t *testing.T) {
+	mutations := &fakeStorageMutations{}
+	router := newStorageRoutesTestRouterWithMutations(t, mutations)
+	for _, path := range []string{"/api/v1/system/storage/analyze", "/api/v1/system/storage/run"} {
+		request := httptest.NewRequest(http.MethodPost, path, bytes.NewBufferString(`{}`))
+		request.Header.Set("Content-Type", "application/json")
+		response := httptest.NewRecorder()
+		router.ServeHTTP(response, request)
+		if response.Code != http.StatusAccepted {
+			t.Fatalf("POST %s status = %d, want 202", path, response.Code)
+		}
+	}
+
+	mutations.busy = true
+	request := httptest.NewRequest(http.MethodPost, "/api/v1/system/storage/run", bytes.NewBufferString(`{}`))
+	request.Header.Set("Content-Type", "application/json")
+	response := httptest.NewRecorder()
+	router.ServeHTTP(response, request)
+	if response.Code != http.StatusConflict {
+		t.Fatalf("busy run status = %d, want 409", response.Code)
+	}
+}
+
+func TestStorageRestoreConflictReturnsConflict(t *testing.T) {
+	mutations := &fakeStorageMutations{restoreErr: storage.ErrConflict}
+	router := newStorageRoutesTestRouterWithMutations(t, mutations)
+	request := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/system/storage/quarantine/entry-1/restore",
+		nil,
+	)
+	response := httptest.NewRecorder()
+	router.ServeHTTP(response, request)
+
+	if response.Code != http.StatusConflict {
+		t.Fatalf("restore conflict status = %d, want 409", response.Code)
+	}
+}
+
+func TestStorageEarlyQuarantineDeleteReturnsConflict(t *testing.T) {
+	mutations := &fakeStorageMutations{deleteErr: storage.ErrConflict}
+	router := newStorageRoutesTestRouterWithMutations(t, mutations)
+	request := httptest.NewRequest(
+		http.MethodDelete,
+		"/api/v1/system/storage/quarantine/entry-1",
+		bytes.NewBufferString(`{"confirm":"DELETE"}`),
+	)
+	request.Header.Set("Content-Type", "application/json")
+	response := httptest.NewRecorder()
+	router.ServeHTTP(response, request)
+
+	if response.Code != http.StatusConflict {
+		t.Fatalf("early delete status = %d, want 409", response.Code)
+	}
+}
+
+func newStorageRoutesTestRouter(t *testing.T) *gin.Engine {
+	return newStorageRoutesTestRouterWithMutations(t, &fakeStorageMutations{})
+}
+
+func newStorageRoutesTestRouterWithMutations(t *testing.T, mutations storage.Mutations) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	connection, err := sqlx.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = connection.Close() })
+	pool := db.NewPool(connection, connection)
+	rawSettings, err := systemsettings.NewStore(pool)
+	if err != nil {
+		t.Fatal(err)
+	}
+	storageStore, err := storage.NewStore(pool)
+	if err != nil {
+		t.Fatal(err)
+	}
+	service := &Service{Storage: storage.NewHandler(storage.HandlerConfig{
+		Settings: storage.NewSettingsStore(rawSettings), Runs: storageStore,
+		Quarantine: storageStore, Overview: emptyStorageOverview{}, Mutations: mutations,
+	})}
+	log, err := logger.NewFromZap(zap.NewNop())
+	if err != nil {
+		t.Fatal(err)
+	}
+	service.RegisterRoutes(router, log)
+	return router
+}
+
+type fakeStorageMutations struct {
+	busy       bool
+	restoreErr error
+	deleteErr  error
+}
+
+func (f *fakeStorageMutations) AdoptGoCache(_ context.Context, _ string, _ string) (storage.StorageMaintenanceSettings, storage.Capabilities, error) {
+	return storage.DefaultSettings(), storage.Capabilities{}, nil
+}
+
+func (f *fakeStorageMutations) Analyze(context.Context) (string, error) { return "analysis-job", nil }
+
+func (f *fakeStorageMutations) RunNow(context.Context, []string) (string, error) {
+	if f.busy {
+		return "", &storage.BusyError{}
+	}
+	return "cleanup-job", nil
+}
+
+func (f *fakeStorageMutations) RestoreQuarantine(context.Context, string) (storage.QuarantineEntry, error) {
+	return storage.QuarantineEntry{}, f.restoreErr
+}
+
+func (f *fakeStorageMutations) DeleteQuarantine(context.Context, string, string) (string, error) {
+	return "delete-job", f.deleteErr
+}
+
+type emptyStorageOverview struct{}
+
+func (emptyStorageOverview) Summary(context.Context) (storage.Summary, error) {
+	return storage.Summary{}, nil
+}
+
+func (emptyStorageOverview) Capabilities(context.Context, storage.StorageMaintenanceSettings) storage.Capabilities {
+	return storage.Capabilities{}
+}

--- a/apps/backend/internal/system/system.go
+++ b/apps/backend/internal/system/system.go
@@ -28,6 +28,7 @@ import (
 	"github.com/kandev/kandev/internal/system/metrics"
 	"github.com/kandev/kandev/internal/system/restart"
 	systemsettings "github.com/kandev/kandev/internal/system/settings"
+	"github.com/kandev/kandev/internal/system/storage"
 	"github.com/kandev/kandev/internal/system/updates"
 	"go.uber.org/zap"
 )
@@ -62,6 +63,9 @@ type Service struct {
 	Metrics  *metrics.Service
 	Updates  *updates.Service
 	Restart  restart.Manager
+	Storage  *storage.Handler
+	// StorageRuntime owns the scheduler, reconciliation, and durable cleanup worker.
+	StorageRuntime *storage.Runtime
 }
 
 // Provide constructs the composed Service. The HTTP routes are
@@ -117,6 +121,9 @@ func (s *Service) RegisterRoutes(router *gin.Engine, log *logger.Logger) {
 	g := router.Group("/api/v1/system")
 
 	g.GET("/info", info.Handler(s.Info))
+	if s.Storage != nil {
+		storage.RegisterRoutes(g, s.Storage)
+	}
 
 	g.GET("/disk-usage", disk.HandleGet(s.Disk))
 	g.POST("/disk-usage/refresh", disk.HandleRefresh(s.Disk))
@@ -153,5 +160,15 @@ func (s *Service) RegisterRoutes(router *gin.Engine, log *logger.Logger) {
 func (s *Service) StartBackground(ctx context.Context) {
 	if s.Updates != nil {
 		s.Updates.StartPoller(ctx)
+	}
+	if s.StorageRuntime != nil {
+		_ = s.StorageRuntime.Start(ctx)
+	}
+}
+
+// StopBackground joins owned storage background workers.
+func (s *Service) StopBackground() {
+	if s.StorageRuntime != nil {
+		s.StorageRuntime.Stop()
 	}
 }

--- a/apps/backend/internal/task/handlers/task_handlers.go
+++ b/apps/backend/internal/task/handlers/task_handlers.go
@@ -2,11 +2,13 @@ package handlers
 
 import (
 	"context"
+	"time"
 
 	"github.com/gin-gonic/gin"
 
 	"github.com/kandev/kandev/internal/common/logger"
 	"github.com/kandev/kandev/internal/orchestrator"
+	storageworkspaces "github.com/kandev/kandev/internal/system/storage/workspaces"
 	"github.com/kandev/kandev/internal/task/dto"
 	"github.com/kandev/kandev/internal/task/models"
 	"github.com/kandev/kandev/internal/task/service"
@@ -34,9 +36,24 @@ type TaskHandlers struct {
 	repo                       handlerRepo
 	planService                *service.PlanService
 	handoffSvc                 *service.HandoffService
+	workspaceRestorer          WorkspaceQuarantineRestorer
+	unarchiveRecoveryTimeout   time.Duration
 	taskCreateLastUsedRecorder taskCreateLastUsedRecorder
 	onTaskCreatedWithPR        func(ctx context.Context, taskID, sessionID, prURL, branch string)
 	logger                     *logger.Logger
+}
+
+const defaultUnarchiveRecoveryTimeout = 30 * time.Second
+
+func (h *TaskHandlers) detachedRecoveryTimeout() time.Duration {
+	if h.unarchiveRecoveryTimeout > 0 {
+		return h.unarchiveRecoveryTimeout
+	}
+	return defaultUnarchiveRecoveryTimeout
+}
+
+type WorkspaceQuarantineRestorer interface {
+	RestoreTask(ctx context.Context, taskID string) storageworkspaces.WorkspaceRecovery
 }
 
 type taskCreateLastUsedRecorder interface {
@@ -49,6 +66,10 @@ type taskCreateLastUsedRecorder interface {
 // post-create attachment, matching the pre-handoffs behaviour.
 func (h *TaskHandlers) SetHandoffService(svc *service.HandoffService) {
 	h.handoffSvc = svc
+}
+
+func (h *TaskHandlers) SetWorkspaceQuarantineRestorer(restorer WorkspaceQuarantineRestorer) {
+	h.workspaceRestorer = restorer
 }
 
 func (h *TaskHandlers) SetTaskCreateLastUsedRecorder(recorder taskCreateLastUsedRecorder) {

--- a/apps/backend/internal/task/handlers/task_http_handlers.go
+++ b/apps/backend/internal/task/handlers/task_http_handlers.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kandev/kandev/internal/common/constants"
 	"github.com/kandev/kandev/internal/common/logger"
 	"github.com/kandev/kandev/internal/orchestrator"
+	storageworkspaces "github.com/kandev/kandev/internal/system/storage/workspaces"
 	"github.com/kandev/kandev/internal/task/dto"
 	"github.com/kandev/kandev/internal/task/models"
 	"github.com/kandev/kandev/internal/task/service"
@@ -1227,7 +1228,17 @@ func (h *TaskHandlers) httpUnarchiveTask(c *gin.Context) {
 	// list just means nothing was recoverable. Detached from the request
 	// context: the tasks are already unarchived, so a client disconnect
 	// must not skip the checkout_branch restore.
-	recoveryCtx := context.WithoutCancel(c.Request.Context())
+	recoveryCtx, cancelRecovery := context.WithTimeout(
+		context.WithoutCancel(c.Request.Context()),
+		h.detachedRecoveryTimeout(),
+	)
+	defer cancelRecovery()
+	workspaceRecovery := make([]storageworkspaces.WorkspaceRecovery, 0, len(outcome.ArchivedTaskIDs))
+	if h.workspaceRestorer != nil {
+		for _, id := range outcome.ArchivedTaskIDs {
+			workspaceRecovery = append(workspaceRecovery, h.workspaceRestorer.RestoreTask(recoveryCtx, id))
+		}
+	}
 	recovery := make([]service.BranchRecovery, 0)
 	for _, id := range outcome.ArchivedTaskIDs {
 		recovery = append(recovery, h.service.RecoverTaskBranches(recoveryCtx, id)...)
@@ -1238,6 +1249,7 @@ func (h *TaskHandlers) httpUnarchiveTask(c *gin.Context) {
 		"unarchived_ids":     outcome.ArchivedTaskIDs,
 		"skipped_ids":        outcome.SkippedTaskIDs,
 		"affected_group_ids": outcome.ReleasedGroupIDs,
+		"workspace_recovery": workspaceRecovery,
 		"recovery":           recovery,
 	})
 }

--- a/apps/backend/internal/task/handlers/task_http_handlers.go
+++ b/apps/backend/internal/task/handlers/task_http_handlers.go
@@ -1233,15 +1233,15 @@ func (h *TaskHandlers) httpUnarchiveTask(c *gin.Context) {
 		h.detachedRecoveryTimeout(),
 	)
 	defer cancelRecovery()
+	recovery := make([]service.BranchRecovery, 0)
+	for _, id := range outcome.ArchivedTaskIDs {
+		recovery = append(recovery, h.service.RecoverTaskBranches(recoveryCtx, id)...)
+	}
 	workspaceRecovery := make([]storageworkspaces.WorkspaceRecovery, 0, len(outcome.ArchivedTaskIDs))
 	if h.workspaceRestorer != nil {
 		for _, id := range outcome.ArchivedTaskIDs {
 			workspaceRecovery = append(workspaceRecovery, h.workspaceRestorer.RestoreTask(recoveryCtx, id))
 		}
-	}
-	recovery := make([]service.BranchRecovery, 0)
-	for _, id := range outcome.ArchivedTaskIDs {
-		recovery = append(recovery, h.service.RecoverTaskBranches(recoveryCtx, id)...)
 	}
 	c.JSON(http.StatusOK, gin.H{
 		"success":            true,

--- a/apps/backend/internal/task/handlers/task_http_unarchive_workspace_test.go
+++ b/apps/backend/internal/task/handlers/task_http_unarchive_workspace_test.go
@@ -13,6 +13,7 @@ import (
 	storageworkspaces "github.com/kandev/kandev/internal/system/storage/workspaces"
 	"github.com/kandev/kandev/internal/task/models"
 	"github.com/kandev/kandev/internal/task/service"
+	"github.com/kandev/kandev/internal/worktree"
 )
 
 type unarchiveWorkspaceRepo struct {
@@ -41,6 +42,33 @@ type recordingWorkspaceRestorer struct {
 
 type blockingWorkspaceRestorer struct {
 	contextErr chan error
+}
+
+type branchFirstWorktreeCleanup struct {
+	called chan struct{}
+}
+
+func (c *branchFirstWorktreeCleanup) OnTaskDeleted(context.Context, string) error { return nil }
+func (c *branchFirstWorktreeCleanup) GetAllByTaskID(context.Context, string) ([]*worktree.Worktree, error) {
+	close(c.called)
+	return nil, nil
+}
+func (c *branchFirstWorktreeCleanup) BranchRecoveryStatus(context.Context, string, string) string {
+	return worktree.BranchStatusMissing
+}
+
+type orderingWorkspaceRestorer struct {
+	branchCalled <-chan struct{}
+	wrongOrder   bool
+}
+
+func (r *orderingWorkspaceRestorer) RestoreTask(_ context.Context, taskID string) storageworkspaces.WorkspaceRecovery {
+	select {
+	case <-r.branchCalled:
+	default:
+		r.wrongOrder = true
+	}
+	return storageworkspaces.WorkspaceRecovery{TaskID: taskID, Status: "restored"}
 }
 
 func (r *blockingWorkspaceRestorer) RestoreTask(ctx context.Context, taskID string) storageworkspaces.WorkspaceRecovery {
@@ -127,5 +155,29 @@ func TestHTTPUnarchiveBoundsDetachedWorkspaceRecovery(t *testing.T) {
 		}
 	default:
 		t.Fatal("blocking restorer did not observe bounded context cancellation")
+	}
+}
+
+func TestHTTPUnarchiveRecoversBranchesBeforeWorkspaceIO(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	repo := &unarchiveWorkspaceRepo{archived: true}
+	taskSvc := service.NewService(service.Repos{}, nil, newTestLogger(t), service.RepositoryDiscoveryConfig{})
+	branchCleanup := &branchFirstWorktreeCleanup{called: make(chan struct{})}
+	taskSvc.SetWorktreeCleanup(branchCleanup)
+	restorer := &orderingWorkspaceRestorer{branchCalled: branchCleanup.called}
+	handler := &TaskHandlers{
+		service: taskSvc, handoffSvc: service.NewHandoffService(repo, nil, nil, nil, nil, nil),
+		logger: newTestLogger(t),
+	}
+	handler.SetWorkspaceQuarantineRestorer(restorer)
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = httptest.NewRequest("POST", "/api/v1/tasks/task-1/unarchive", nil)
+	ctx.Params = gin.Params{{Key: "id", Value: "task-1"}}
+
+	handler.httpUnarchiveTask(ctx)
+
+	if restorer.wrongOrder {
+		t.Fatal("workspace recovery ran before branch recovery")
 	}
 }

--- a/apps/backend/internal/task/handlers/task_http_unarchive_workspace_test.go
+++ b/apps/backend/internal/task/handlers/task_http_unarchive_workspace_test.go
@@ -1,0 +1,131 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	storageworkspaces "github.com/kandev/kandev/internal/system/storage/workspaces"
+	"github.com/kandev/kandev/internal/task/models"
+	"github.com/kandev/kandev/internal/task/service"
+)
+
+type unarchiveWorkspaceRepo struct {
+	mockRepository
+	archived bool
+}
+
+func (r *unarchiveWorkspaceRepo) GetTask(context.Context, string) (*models.Task, error) {
+	task := &models.Task{ID: "task-1", WorkspaceID: "workspace-1"}
+	if r.archived {
+		now := time.Now().UTC()
+		task.ArchivedAt = &now
+	}
+	return task, nil
+}
+
+func (r *unarchiveWorkspaceRepo) UnarchiveTask(context.Context, string) (bool, error) {
+	r.archived = false
+	return true, nil
+}
+
+type recordingWorkspaceRestorer struct {
+	calls  []string
+	result storageworkspaces.WorkspaceRecovery
+}
+
+type blockingWorkspaceRestorer struct {
+	contextErr chan error
+}
+
+func (r *blockingWorkspaceRestorer) RestoreTask(ctx context.Context, taskID string) storageworkspaces.WorkspaceRecovery {
+	<-ctx.Done()
+	r.contextErr <- ctx.Err()
+	return storageworkspaces.WorkspaceRecovery{TaskID: taskID, Status: "failed", Message: ctx.Err().Error()}
+}
+
+func (r *recordingWorkspaceRestorer) RestoreTask(_ context.Context, taskID string) storageworkspaces.WorkspaceRecovery {
+	r.calls = append(r.calls, taskID)
+	result := r.result
+	result.TaskID = taskID
+	return result
+}
+
+func TestHTTPUnarchiveReportsWorkspaceRestoreFailureWithoutBlocking(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	repo := &unarchiveWorkspaceRepo{archived: true}
+	taskSvc := service.NewService(service.Repos{}, nil, newTestLogger(t), service.RepositoryDiscoveryConfig{})
+	handler := &TaskHandlers{
+		service: taskSvc, handoffSvc: service.NewHandoffService(repo, nil, nil, nil, nil, nil),
+		logger: newTestLogger(t),
+	}
+	restorer := &recordingWorkspaceRestorer{result: storageworkspaces.WorkspaceRecovery{
+		Status: "failed", Message: "restore path conflict",
+	}}
+	handler.SetWorkspaceQuarantineRestorer(restorer)
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = httptest.NewRequest("POST", "/api/v1/tasks/task-1/unarchive", nil)
+	ctx.Params = gin.Params{{Key: "id", Value: "task-1"}}
+
+	handler.httpUnarchiveTask(ctx)
+
+	if recorder.Code != 200 || repo.archived {
+		t.Fatalf("unarchive response code=%d archived=%v body=%s", recorder.Code, repo.archived, recorder.Body.String())
+	}
+	if len(restorer.calls) != 1 || restorer.calls[0] != "task-1" {
+		t.Fatalf("restore calls = %v", restorer.calls)
+	}
+	var response struct {
+		WorkspaceRecovery []storageworkspaces.WorkspaceRecovery `json:"workspace_recovery"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(response.WorkspaceRecovery) != 1 || response.WorkspaceRecovery[0].Status != "failed" {
+		t.Fatalf("workspace recovery response = %#v", response.WorkspaceRecovery)
+	}
+}
+
+func TestHTTPUnarchiveBoundsDetachedWorkspaceRecovery(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	repo := &unarchiveWorkspaceRepo{archived: true}
+	taskSvc := service.NewService(service.Repos{}, nil, newTestLogger(t), service.RepositoryDiscoveryConfig{})
+	handler := &TaskHandlers{
+		service: taskSvc, handoffSvc: service.NewHandoffService(repo, nil, nil, nil, nil, nil),
+		logger: newTestLogger(t), unarchiveRecoveryTimeout: 20 * time.Millisecond,
+	}
+	restorer := &blockingWorkspaceRestorer{contextErr: make(chan error, 1)}
+	handler.SetWorkspaceQuarantineRestorer(restorer)
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = httptest.NewRequest("POST", "/api/v1/tasks/task-1/unarchive", nil)
+	ctx.Params = gin.Params{{Key: "id", Value: "task-1"}}
+
+	done := make(chan struct{})
+	go func() {
+		handler.httpUnarchiveTask(ctx)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("unarchive remained blocked after detached recovery timeout")
+	}
+	if recorder.Code != 200 || repo.archived {
+		t.Fatalf("unarchive response code=%d archived=%v body=%s", recorder.Code, repo.archived, recorder.Body.String())
+	}
+	select {
+	case err := <-restorer.contextErr:
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("blocking restorer context error = %v", err)
+		}
+	default:
+		t.Fatal("blocking restorer did not observe bounded context cancellation")
+	}
+}

--- a/apps/backend/internal/task/models/resource_cleanup.go
+++ b/apps/backend/internal/task/models/resource_cleanup.go
@@ -1,0 +1,48 @@
+package models
+
+import "time"
+
+type TaskResourceCleanupTrigger string
+
+const (
+	TaskResourceCleanupTriggerArchive         TaskResourceCleanupTrigger = "archive"
+	TaskResourceCleanupTriggerDelete          TaskResourceCleanupTrigger = "delete"
+	TaskResourceCleanupTriggerCascadeArchive  TaskResourceCleanupTrigger = "cascade_archive"
+	TaskResourceCleanupTriggerCascadeDelete   TaskResourceCleanupTrigger = "cascade_delete"
+	TaskResourceCleanupTriggerWorkspaceDelete TaskResourceCleanupTrigger = "workspace_delete"
+	TaskResourceCleanupTriggerQuickChatExpire TaskResourceCleanupTrigger = "quick_chat_expire"
+	TaskResourceCleanupTriggerReconcile       TaskResourceCleanupTrigger = "reconcile"
+)
+
+type TaskResourceCleanupState string
+
+const (
+	TaskResourceCleanupStatePending   TaskResourceCleanupState = "pending"
+	TaskResourceCleanupStateRunning   TaskResourceCleanupState = "running"
+	TaskResourceCleanupStateRetryWait TaskResourceCleanupState = "retry_wait"
+	TaskResourceCleanupStateSucceeded TaskResourceCleanupState = "succeeded"
+	TaskResourceCleanupStateCancelled TaskResourceCleanupState = "cancelled"
+)
+
+// TaskResourceCleanupJob is a durable task-lifecycle cleanup intent. TaskID is
+// deliberately not foreign-keyed: delete cleanup must outlive task/session
+// cascades and use ResourceSnapshot as its recovery inventory.
+type TaskResourceCleanupJob struct {
+	ID               string
+	OperationID      string
+	TaskID           string
+	Trigger          TaskResourceCleanupTrigger
+	State            TaskResourceCleanupState
+	ResourceSnapshot string
+	Attempts         int
+	NextAttemptAt    *time.Time
+	LastError        string
+	CreatedAt        time.Time
+	UpdatedAt        time.Time
+	CompletedAt      *time.Time
+}
+
+func (j *TaskResourceCleanupJob) IsArchive() bool {
+	return j != nil && (j.Trigger == TaskResourceCleanupTriggerArchive ||
+		j.Trigger == TaskResourceCleanupTriggerCascadeArchive)
+}

--- a/apps/backend/internal/task/models/resource_cleanup.go
+++ b/apps/backend/internal/task/models/resource_cleanup.go
@@ -17,6 +17,7 @@ const (
 type TaskResourceCleanupState string
 
 const (
+	TaskResourceCleanupStatePrepared  TaskResourceCleanupState = "prepared"
 	TaskResourceCleanupStatePending   TaskResourceCleanupState = "pending"
 	TaskResourceCleanupStateRunning   TaskResourceCleanupState = "running"
 	TaskResourceCleanupStateRetryWait TaskResourceCleanupState = "retry_wait"

--- a/apps/backend/internal/task/repository/archive_repository_test.go
+++ b/apps/backend/internal/task/repository/archive_repository_test.go
@@ -47,6 +47,50 @@ func TestSQLiteRepository_ArchiveTask(t *testing.T) {
 	}
 }
 
+func TestSQLiteRepository_CascadeArchiveRoundTripPreservesOwner(t *testing.T) {
+	repo, cleanup := createTestSQLiteRepo(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	if err := repo.CreateWorkspace(ctx, &models.Workspace{ID: "cascade-ws", Name: "Cascade"}); err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+	if err := repo.CreateWorkflow(ctx, &models.Workflow{
+		ID: "cascade-wf", WorkspaceID: "cascade-ws", Name: "Cascade",
+	}); err != nil {
+		t.Fatalf("CreateWorkflow: %v", err)
+	}
+	if err := repo.CreateTask(ctx, &models.Task{
+		ID: "cascade-task", WorkspaceID: "cascade-ws", WorkflowID: "cascade-wf", Title: "Cascade",
+	}); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+
+	archived, err := repo.ArchiveTaskIfActive(ctx, "cascade-task", "cascade-owner")
+	if err != nil || !archived {
+		t.Fatalf("ArchiveTaskIfActive: archived=%v err=%v", archived, err)
+	}
+	loaded, err := repo.GetTask(ctx, "cascade-task")
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if loaded.ArchivedByCascadeID != "cascade-owner" {
+		t.Fatalf("ArchivedByCascadeID = %q, want cascade-owner", loaded.ArchivedByCascadeID)
+	}
+
+	unarchived, err := repo.UnarchiveTaskByCascade(ctx, loaded.ID, loaded.ArchivedByCascadeID)
+	if err != nil || !unarchived {
+		t.Fatalf("UnarchiveTaskByCascade: unarchived=%v err=%v", unarchived, err)
+	}
+	loaded, err = repo.GetTask(ctx, "cascade-task")
+	if err != nil {
+		t.Fatalf("GetTask after unarchive: %v", err)
+	}
+	if loaded.ArchivedAt != nil || loaded.ArchivedByCascadeID != "" {
+		t.Fatalf("unarchived task = archived_at:%v cascade:%q", loaded.ArchivedAt, loaded.ArchivedByCascadeID)
+	}
+}
+
 func TestSQLiteRepository_ArchiveTask_ExcludesFromListTasks(t *testing.T) {
 	repo, cleanup := createTestSQLiteRepo(t)
 	defer cleanup()

--- a/apps/backend/internal/task/repository/interface.go
+++ b/apps/backend/internal/task/repository/interface.go
@@ -211,6 +211,19 @@ type SessionWorktreeRepository interface {
 	DeleteTaskSessionWorktreesBySession(ctx context.Context, sessionID string) error
 }
 
+// TaskResourceCleanupRepository persists restart-safe task lifecycle cleanup.
+type TaskResourceCleanupRepository interface {
+	CreateTaskResourceCleanupJob(ctx context.Context, job *models.TaskResourceCleanupJob) error
+	GetTaskResourceCleanupJob(ctx context.Context, id string) (*models.TaskResourceCleanupJob, error)
+	GetTaskResourceCleanupJobByOperationID(ctx context.Context, operationID string) (*models.TaskResourceCleanupJob, error)
+	ListDueTaskResourceCleanupJobs(ctx context.Context, now time.Time, limit int) ([]*models.TaskResourceCleanupJob, error)
+	MarkTaskResourceCleanupJobRunning(ctx context.Context, id string) (bool, error)
+	CompleteClaimedTaskResourceCleanupJob(ctx context.Context, id string, attempt int, state models.TaskResourceCleanupState, lastError string, nextAttemptAt *time.Time) (bool, error)
+	CompleteTaskResourceCleanupJob(ctx context.Context, id string, state models.TaskResourceCleanupState, lastError string, nextAttemptAt *time.Time) error
+	CancelArchiveTaskResourceCleanupJobs(ctx context.Context, taskID string) error
+	ResetRunningTaskResourceCleanupJobs(ctx context.Context) error
+}
+
 // GitSnapshotRepository handles git snapshots and session commit records.
 type GitSnapshotRepository interface {
 	CreateGitSnapshot(ctx context.Context, snapshot *models.GitSnapshot) error

--- a/apps/backend/internal/task/repository/interface.go
+++ b/apps/backend/internal/task/repository/interface.go
@@ -216,6 +216,7 @@ type TaskResourceCleanupRepository interface {
 	CreateTaskResourceCleanupJob(ctx context.Context, job *models.TaskResourceCleanupJob) error
 	GetTaskResourceCleanupJob(ctx context.Context, id string) (*models.TaskResourceCleanupJob, error)
 	GetTaskResourceCleanupJobByOperationID(ctx context.Context, operationID string) (*models.TaskResourceCleanupJob, error)
+	ListPreparedTaskResourceCleanupJobs(ctx context.Context) ([]*models.TaskResourceCleanupJob, error)
 	ListDueTaskResourceCleanupJobs(ctx context.Context, now time.Time, limit int) ([]*models.TaskResourceCleanupJob, error)
 	StartPreparedTaskResourceCleanupJob(ctx context.Context, id string) (bool, error)
 	MarkTaskResourceCleanupJobRunning(ctx context.Context, id string) (bool, error)

--- a/apps/backend/internal/task/repository/interface.go
+++ b/apps/backend/internal/task/repository/interface.go
@@ -217,6 +217,7 @@ type TaskResourceCleanupRepository interface {
 	GetTaskResourceCleanupJob(ctx context.Context, id string) (*models.TaskResourceCleanupJob, error)
 	GetTaskResourceCleanupJobByOperationID(ctx context.Context, operationID string) (*models.TaskResourceCleanupJob, error)
 	ListDueTaskResourceCleanupJobs(ctx context.Context, now time.Time, limit int) ([]*models.TaskResourceCleanupJob, error)
+	StartPreparedTaskResourceCleanupJob(ctx context.Context, id string) (bool, error)
 	MarkTaskResourceCleanupJobRunning(ctx context.Context, id string) (bool, error)
 	CompleteClaimedTaskResourceCleanupJob(ctx context.Context, id string, attempt int, state models.TaskResourceCleanupState, lastError string, nextAttemptAt *time.Time) (bool, error)
 	CompleteTaskResourceCleanupJob(ctx context.Context, id string, state models.TaskResourceCleanupState, lastError string, nextAttemptAt *time.Time) error

--- a/apps/backend/internal/task/repository/sqlite/base_schema.go
+++ b/apps/backend/internal/task/repository/sqlite/base_schema.go
@@ -20,6 +20,7 @@ func (r *Repository) initSchema() error {
 		r.initWalkthroughsSchema,
 		r.initDocumentsSchema,
 		r.initSessionSchema,
+		r.initTaskResourceCleanupSchema,
 		r.initGitSchema,
 		r.initReviewSchema,
 		r.migrateExecutorProfiles,
@@ -43,6 +44,33 @@ func (r *Repository) initSchema() error {
 		}
 	}
 	return nil
+}
+
+const taskResourceCleanupSchemaDDL = `
+	CREATE TABLE IF NOT EXISTS task_resource_cleanup_jobs (
+		id TEXT PRIMARY KEY,
+		operation_id TEXT NOT NULL UNIQUE,
+		task_id TEXT NOT NULL,
+		trigger TEXT NOT NULL,
+		state TEXT NOT NULL DEFAULT 'pending',
+		resource_snapshot TEXT NOT NULL DEFAULT '{}',
+		attempts INTEGER NOT NULL DEFAULT 0,
+		next_attempt_at TIMESTAMP,
+		last_error TEXT NOT NULL DEFAULT '',
+		created_at TIMESTAMP NOT NULL,
+		updated_at TIMESTAMP NOT NULL,
+		completed_at TIMESTAMP
+	);
+
+	CREATE INDEX IF NOT EXISTS idx_task_resource_cleanup_jobs_task_id
+		ON task_resource_cleanup_jobs(task_id);
+	CREATE INDEX IF NOT EXISTS idx_task_resource_cleanup_jobs_due
+		ON task_resource_cleanup_jobs(state, next_attempt_at, created_at);
+`
+
+func (r *Repository) initTaskResourceCleanupSchema() error {
+	_, err := r.db.Exec(taskResourceCleanupSchemaDDL)
+	return err
 }
 
 // ensureWorkspaceIndexes creates workspace-related indexes

--- a/apps/backend/internal/task/repository/sqlite/resource_cleanup.go
+++ b/apps/backend/internal/task/repository/sqlite/resource_cleanup.go
@@ -52,6 +52,27 @@ func (r *Repository) GetTaskResourceCleanupJob(ctx context.Context, id string) (
 	return scanTaskResourceCleanupJob(row)
 }
 
+func (r *Repository) ListPreparedTaskResourceCleanupJobs(ctx context.Context) ([]*models.TaskResourceCleanupJob, error) {
+	rows, err := r.ro.QueryContext(ctx, r.ro.Rebind(`
+		SELECT `+taskResourceCleanupColumns+`
+		FROM task_resource_cleanup_jobs
+		WHERE state = ? ORDER BY created_at ASC
+	`), models.TaskResourceCleanupStatePrepared)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	jobs := make([]*models.TaskResourceCleanupJob, 0)
+	for rows.Next() {
+		job, scanErr := scanTaskResourceCleanupJob(rows)
+		if scanErr != nil {
+			return nil, scanErr
+		}
+		jobs = append(jobs, job)
+	}
+	return jobs, rows.Err()
+}
+
 func scanTaskResourceCleanupJob(row interface{ Scan(...any) error }) (*models.TaskResourceCleanupJob, error) {
 	job := &models.TaskResourceCleanupJob{}
 	err := row.Scan(&job.ID, &job.OperationID, &job.TaskID, &job.Trigger, &job.State,

--- a/apps/backend/internal/task/repository/sqlite/resource_cleanup.go
+++ b/apps/backend/internal/task/repository/sqlite/resource_cleanup.go
@@ -1,0 +1,169 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/kandev/kandev/internal/task/models"
+)
+
+const taskResourceCleanupColumns = `
+	id, operation_id, task_id, trigger, state, resource_snapshot, attempts,
+	next_attempt_at, last_error, created_at, updated_at, completed_at`
+
+func (r *Repository) CreateTaskResourceCleanupJob(ctx context.Context, job *models.TaskResourceCleanupJob) error {
+	if job.ID == "" {
+		job.ID = uuid.NewString()
+	}
+	now := time.Now().UTC()
+	job.CreatedAt = now
+	job.UpdatedAt = now
+	if job.State == "" {
+		job.State = models.TaskResourceCleanupStatePending
+	}
+	_, err := r.db.ExecContext(ctx, r.db.Rebind(`
+		INSERT INTO task_resource_cleanup_jobs (`+taskResourceCleanupColumns+`)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(operation_id) DO NOTHING
+	`), job.ID, job.OperationID, job.TaskID, job.Trigger, job.State,
+		job.ResourceSnapshot, job.Attempts, job.NextAttemptAt, job.LastError,
+		job.CreatedAt, job.UpdatedAt, job.CompletedAt)
+	return err
+}
+
+func (r *Repository) GetTaskResourceCleanupJobByOperationID(ctx context.Context, operationID string) (*models.TaskResourceCleanupJob, error) {
+	row := r.ro.QueryRowContext(ctx, r.ro.Rebind(`
+		SELECT `+taskResourceCleanupColumns+`
+		FROM task_resource_cleanup_jobs WHERE operation_id = ?
+	`), operationID)
+	return scanTaskResourceCleanupJob(row)
+}
+
+func (r *Repository) GetTaskResourceCleanupJob(ctx context.Context, id string) (*models.TaskResourceCleanupJob, error) {
+	row := r.ro.QueryRowContext(ctx, r.ro.Rebind(`
+		SELECT `+taskResourceCleanupColumns+`
+		FROM task_resource_cleanup_jobs WHERE id = ?
+	`), id)
+	return scanTaskResourceCleanupJob(row)
+}
+
+func scanTaskResourceCleanupJob(row interface{ Scan(...any) error }) (*models.TaskResourceCleanupJob, error) {
+	job := &models.TaskResourceCleanupJob{}
+	err := row.Scan(&job.ID, &job.OperationID, &job.TaskID, &job.Trigger, &job.State,
+		&job.ResourceSnapshot, &job.Attempts, &job.NextAttemptAt, &job.LastError,
+		&job.CreatedAt, &job.UpdatedAt, &job.CompletedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, fmt.Errorf("task resource cleanup job not found")
+	}
+	return job, err
+}
+
+func (r *Repository) ListDueTaskResourceCleanupJobs(ctx context.Context, now time.Time, limit int) ([]*models.TaskResourceCleanupJob, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+	rows, err := r.ro.QueryContext(ctx, r.ro.Rebind(`
+		SELECT `+taskResourceCleanupColumns+`
+		FROM task_resource_cleanup_jobs
+		WHERE state = ? OR (state = ? AND (next_attempt_at IS NULL OR next_attempt_at <= ?))
+		ORDER BY created_at ASC LIMIT ?
+	`), models.TaskResourceCleanupStatePending, models.TaskResourceCleanupStateRetryWait, now.UTC(), limit)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	jobs := make([]*models.TaskResourceCleanupJob, 0)
+	for rows.Next() {
+		job, scanErr := scanTaskResourceCleanupJob(rows)
+		if scanErr != nil {
+			return nil, scanErr
+		}
+		jobs = append(jobs, job)
+	}
+	return jobs, rows.Err()
+}
+
+func (r *Repository) MarkTaskResourceCleanupJobRunning(ctx context.Context, id string) (bool, error) {
+	now := time.Now().UTC()
+	result, err := r.db.ExecContext(ctx, r.db.Rebind(`
+		UPDATE task_resource_cleanup_jobs
+		SET state = ?, attempts = attempts + 1, next_attempt_at = NULL, updated_at = ?
+		WHERE id = ? AND state IN (?, ?)
+	`), models.TaskResourceCleanupStateRunning, now, id,
+		models.TaskResourceCleanupStatePending, models.TaskResourceCleanupStateRetryWait)
+	if err != nil {
+		return false, err
+	}
+	count, _ := result.RowsAffected()
+	return count == 1, nil
+}
+
+func (r *Repository) CompleteTaskResourceCleanupJob(ctx context.Context, id string, state models.TaskResourceCleanupState, lastError string, nextAttemptAt *time.Time) error {
+	now := time.Now().UTC()
+	var completedAt *time.Time
+	if state == models.TaskResourceCleanupStateSucceeded || state == models.TaskResourceCleanupStateCancelled {
+		completedAt = &now
+	}
+	_, err := r.db.ExecContext(ctx, r.db.Rebind(`
+		UPDATE task_resource_cleanup_jobs
+		SET state = ?, last_error = ?, next_attempt_at = ?, completed_at = ?, updated_at = ?
+		WHERE id = ?
+	`), state, lastError, nextAttemptAt, completedAt, now, id)
+	return err
+}
+
+// CompleteClaimedTaskResourceCleanupJob applies a worker result only to the
+// exact running claim that produced it. A concurrent cancellation or a newer
+// retry generation wins and keeps its state and historical metadata.
+func (r *Repository) CompleteClaimedTaskResourceCleanupJob(
+	ctx context.Context,
+	id string,
+	attempt int,
+	state models.TaskResourceCleanupState,
+	lastError string,
+	nextAttemptAt *time.Time,
+) (bool, error) {
+	now := time.Now().UTC()
+	var completedAt *time.Time
+	if state == models.TaskResourceCleanupStateSucceeded || state == models.TaskResourceCleanupStateCancelled {
+		completedAt = &now
+	}
+	result, err := r.db.ExecContext(ctx, r.db.Rebind(`
+		UPDATE task_resource_cleanup_jobs
+		SET state = ?, last_error = ?, next_attempt_at = ?, completed_at = ?, updated_at = ?
+		WHERE id = ? AND state = ? AND attempts = ?
+	`), state, lastError, nextAttemptAt, completedAt, now, id,
+		models.TaskResourceCleanupStateRunning, attempt)
+	if err != nil {
+		return false, err
+	}
+	count, _ := result.RowsAffected()
+	return count == 1, nil
+}
+
+func (r *Repository) CancelArchiveTaskResourceCleanupJobs(ctx context.Context, taskID string) error {
+	now := time.Now().UTC()
+	_, err := r.db.ExecContext(ctx, r.db.Rebind(`
+		UPDATE task_resource_cleanup_jobs
+		SET state = ?, completed_at = ?, updated_at = ?
+		WHERE task_id = ? AND trigger IN (?, ?) AND state IN (?, ?, ?)
+	`), models.TaskResourceCleanupStateCancelled, now, now, taskID,
+		models.TaskResourceCleanupTriggerArchive, models.TaskResourceCleanupTriggerCascadeArchive,
+		models.TaskResourceCleanupStatePending, models.TaskResourceCleanupStateRunning,
+		models.TaskResourceCleanupStateRetryWait)
+	return err
+}
+
+func (r *Repository) ResetRunningTaskResourceCleanupJobs(ctx context.Context) error {
+	now := time.Now().UTC()
+	_, err := r.db.ExecContext(ctx, r.db.Rebind(`
+		UPDATE task_resource_cleanup_jobs
+		SET state = ?, next_attempt_at = ?, updated_at = ? WHERE state = ?
+	`), models.TaskResourceCleanupStateRetryWait, now, now, models.TaskResourceCleanupStateRunning)
+	return err
+}

--- a/apps/backend/internal/task/repository/sqlite/resource_cleanup.go
+++ b/apps/backend/internal/task/repository/sqlite/resource_cleanup.go
@@ -103,6 +103,20 @@ func (r *Repository) MarkTaskResourceCleanupJobRunning(ctx context.Context, id s
 	return count == 1, nil
 }
 
+func (r *Repository) StartPreparedTaskResourceCleanupJob(ctx context.Context, id string) (bool, error) {
+	now := time.Now().UTC()
+	result, err := r.db.ExecContext(ctx, r.db.Rebind(`
+		UPDATE task_resource_cleanup_jobs
+		SET state = ?, next_attempt_at = NULL, updated_at = ?
+		WHERE id = ? AND state = ?
+	`), models.TaskResourceCleanupStatePending, now, id, models.TaskResourceCleanupStatePrepared)
+	if err != nil {
+		return false, err
+	}
+	count, _ := result.RowsAffected()
+	return count == 1, nil
+}
+
 func (r *Repository) CompleteTaskResourceCleanupJob(ctx context.Context, id string, state models.TaskResourceCleanupState, lastError string, nextAttemptAt *time.Time) error {
 	now := time.Now().UTC()
 	var completedAt *time.Time
@@ -151,10 +165,11 @@ func (r *Repository) CancelArchiveTaskResourceCleanupJobs(ctx context.Context, t
 	_, err := r.db.ExecContext(ctx, r.db.Rebind(`
 		UPDATE task_resource_cleanup_jobs
 		SET state = ?, completed_at = ?, updated_at = ?
-		WHERE task_id = ? AND trigger IN (?, ?) AND state IN (?, ?, ?)
+		WHERE task_id = ? AND trigger IN (?, ?) AND state IN (?, ?, ?, ?)
 	`), models.TaskResourceCleanupStateCancelled, now, now, taskID,
 		models.TaskResourceCleanupTriggerArchive, models.TaskResourceCleanupTriggerCascadeArchive,
-		models.TaskResourceCleanupStatePending, models.TaskResourceCleanupStateRunning,
+		models.TaskResourceCleanupStatePrepared, models.TaskResourceCleanupStatePending,
+		models.TaskResourceCleanupStateRunning,
 		models.TaskResourceCleanupStateRetryWait)
 	return err
 }

--- a/apps/backend/internal/task/repository/sqlite/resource_cleanup_test.go
+++ b/apps/backend/internal/task/repository/sqlite/resource_cleanup_test.go
@@ -1,0 +1,112 @@
+package sqlite
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/task/models"
+)
+
+func TestTaskResourceCleanupJobSurvivesTaskDeletion(t *testing.T) {
+	ctx := context.Background()
+	repo := newRepoForHealTests(t)
+	seedExecutorRunningCleanupTask(t, repo, "task-cleanup")
+
+	job := &models.TaskResourceCleanupJob{
+		ID: "job-1", OperationID: "delete:task-cleanup", TaskID: "task-cleanup",
+		Trigger:          models.TaskResourceCleanupTriggerDelete,
+		State:            models.TaskResourceCleanupStatePending,
+		ResourceSnapshot: `{"workspace_path":"/tmp/task-cleanup"}`,
+	}
+	if err := repo.CreateTaskResourceCleanupJob(ctx, job); err != nil {
+		t.Fatalf("persist cleanup intent before task deletion: %v", err)
+	}
+	if err := repo.DeleteTask(ctx, "task-cleanup"); err != nil {
+		t.Fatalf("DeleteTask: %v", err)
+	}
+
+	var taskID, snapshot string
+	if err := repo.ro.QueryRowContext(ctx, `
+		SELECT task_id, resource_snapshot
+		FROM task_resource_cleanup_jobs
+		WHERE operation_id = 'delete:task-cleanup'
+	`).Scan(&taskID, &snapshot); err != nil {
+		t.Fatalf("load cleanup job after task deletion: %v", err)
+	}
+	if taskID != "task-cleanup" || snapshot != `{"workspace_path":"/tmp/task-cleanup"}` {
+		t.Fatalf("cleanup snapshot changed after task cascade: task_id=%q snapshot=%q", taskID, snapshot)
+	}
+}
+
+func TestTaskResourceCleanupJobClaimAndRetry(t *testing.T) {
+	ctx := context.Background()
+	repo := newRepoForHealTests(t)
+	job := &models.TaskResourceCleanupJob{
+		ID: "job-retry", OperationID: "delete:retry", TaskID: "task-retry",
+		Trigger: models.TaskResourceCleanupTriggerDelete,
+		State:   models.TaskResourceCleanupStatePending, ResourceSnapshot: `{}`,
+	}
+	if err := repo.CreateTaskResourceCleanupJob(ctx, job); err != nil {
+		t.Fatalf("CreateTaskResourceCleanupJob: %v", err)
+	}
+	claimed, err := repo.MarkTaskResourceCleanupJobRunning(ctx, job.ID)
+	if err != nil || !claimed {
+		t.Fatalf("first claim = %v, %v; want true", claimed, err)
+	}
+	claimed, err = repo.MarkTaskResourceCleanupJobRunning(ctx, job.ID)
+	if err != nil || claimed {
+		t.Fatalf("second claim = %v, %v; want false", claimed, err)
+	}
+	past := time.Now().UTC().Add(-time.Minute)
+	if err := repo.CompleteTaskResourceCleanupJob(ctx, job.ID, models.TaskResourceCleanupStateRetryWait, "retry", &past); err != nil {
+		t.Fatalf("mark retry: %v", err)
+	}
+	due, err := repo.ListDueTaskResourceCleanupJobs(ctx, time.Now().UTC(), 10)
+	if err != nil || len(due) != 1 || due[0].ID != job.ID {
+		t.Fatalf("due jobs = %#v, %v; want job-retry", due, err)
+	}
+}
+
+func TestTaskResourceCleanupJobStaleClaimCannotOverwriteCancellation(t *testing.T) {
+	ctx := context.Background()
+	repo := newRepoForHealTests(t)
+	job := &models.TaskResourceCleanupJob{
+		ID: "job-cancel-race", OperationID: "archive:cancel-race", TaskID: "task-cancel-race",
+		Trigger: models.TaskResourceCleanupTriggerArchive,
+		State:   models.TaskResourceCleanupStatePending, ResourceSnapshot: `{"worktree":"preserve-me"}`,
+	}
+	if err := repo.CreateTaskResourceCleanupJob(ctx, job); err != nil {
+		t.Fatalf("CreateTaskResourceCleanupJob: %v", err)
+	}
+	claimed, err := repo.MarkTaskResourceCleanupJobRunning(ctx, job.ID)
+	if err != nil || !claimed {
+		t.Fatalf("claim = %v, %v; want true", claimed, err)
+	}
+	claimedJob, err := repo.GetTaskResourceCleanupJob(ctx, job.ID)
+	if err != nil {
+		t.Fatalf("GetTaskResourceCleanupJob after claim: %v", err)
+	}
+	if err := repo.CancelArchiveTaskResourceCleanupJobs(ctx, job.TaskID); err != nil {
+		t.Fatalf("CancelArchiveTaskResourceCleanupJobs: %v", err)
+	}
+	updated, err := repo.CompleteClaimedTaskResourceCleanupJob(
+		ctx, job.ID, claimedJob.Attempts, models.TaskResourceCleanupStateSucceeded, "", nil,
+	)
+	if err != nil {
+		t.Fatalf("CompleteClaimedTaskResourceCleanupJob: %v", err)
+	}
+	if updated {
+		t.Fatal("stale claimed completion overwrote cancellation")
+	}
+	got, err := repo.GetTaskResourceCleanupJob(ctx, job.ID)
+	if err != nil {
+		t.Fatalf("GetTaskResourceCleanupJob: %v", err)
+	}
+	if got.State != models.TaskResourceCleanupStateCancelled || got.Attempts != claimedJob.Attempts {
+		t.Fatalf("job = state %q attempts %d, want cancelled generation %d", got.State, got.Attempts, claimedJob.Attempts)
+	}
+	if got.ResourceSnapshot != job.ResourceSnapshot || got.CompletedAt == nil {
+		t.Fatalf("cancelled job lost historical metadata: %#v", got)
+	}
+}

--- a/apps/backend/internal/task/repository/sqlite/resource_cleanup_test.go
+++ b/apps/backend/internal/task/repository/sqlite/resource_cleanup_test.go
@@ -68,6 +68,33 @@ func TestTaskResourceCleanupJobClaimAndRetry(t *testing.T) {
 	}
 }
 
+func TestListPreparedTaskResourceCleanupJobsExcludesRunnableStates(t *testing.T) {
+	ctx := context.Background()
+	repo := newRepoForHealTests(t)
+	for _, job := range []*models.TaskResourceCleanupJob{
+		{
+			ID: "job-prepared", OperationID: "delete:prepared", TaskID: "task-prepared",
+			Trigger: models.TaskResourceCleanupTriggerDelete, State: models.TaskResourceCleanupStatePrepared,
+		},
+		{
+			ID: "job-pending", OperationID: "delete:pending", TaskID: "task-pending",
+			Trigger: models.TaskResourceCleanupTriggerDelete, State: models.TaskResourceCleanupStatePending,
+		},
+	} {
+		if err := repo.CreateTaskResourceCleanupJob(ctx, job); err != nil {
+			t.Fatalf("CreateTaskResourceCleanupJob(%s): %v", job.ID, err)
+		}
+	}
+
+	jobs, err := repo.ListPreparedTaskResourceCleanupJobs(ctx)
+	if err != nil {
+		t.Fatalf("ListPreparedTaskResourceCleanupJobs: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].ID != "job-prepared" {
+		t.Fatalf("prepared jobs = %#v, want only job-prepared", jobs)
+	}
+}
+
 func TestTaskResourceCleanupJobStaleClaimCannotOverwriteCancellation(t *testing.T) {
 	ctx := context.Background()
 	repo := newRepoForHealTests(t)

--- a/apps/backend/internal/task/repository/sqlite/task.go
+++ b/apps/backend/internal/task/repository/sqlite/task.go
@@ -43,6 +43,9 @@ var taskScanColumns = []taskScanColumn{
 	{name: "is_ephemeral"},
 	{name: "parent_id"},
 	{name: "archived_at"},
+	{name: "archived_by_cascade_id", selectExpr: func(alias string) string {
+		return `COALESCE(` + alias + `.archived_by_cascade_id, '') AS archived_by_cascade_id`
+	}},
 	{name: "created_at"},
 	{name: "updated_at"},
 	{name: "assignee_agent_profile_id", selectExpr: func(alias string) string {
@@ -832,7 +835,7 @@ func (r *Repository) scanSingleTask(row *sql.Row) (*models.Task, error) {
 	err := row.Scan(
 		&task.ID, &task.WorkspaceID, &task.WorkflowID, &task.WorkflowStepID,
 		&task.Title, &task.Description, &task.State, &task.Priority, &task.Position,
-		&metadata, &task.IsEphemeral, &task.ParentID, &archivedAt,
+		&metadata, &task.IsEphemeral, &task.ParentID, &archivedAt, &task.ArchivedByCascadeID,
 		&task.CreatedAt, &task.UpdatedAt,
 		&task.AssigneeAgentProfileID, &task.Origin, &task.ProjectID,
 		&task.Labels, &identifier, &task.IsFromOffice,
@@ -861,7 +864,7 @@ func (r *Repository) scanTasks(rows *sql.Rows) ([]*models.Task, error) {
 		err := rows.Scan(
 			&task.ID, &task.WorkspaceID, &task.WorkflowID, &task.WorkflowStepID,
 			&task.Title, &task.Description, &task.State, &task.Priority, &task.Position,
-			&metadata, &task.IsEphemeral, &task.ParentID, &archivedAt,
+			&metadata, &task.IsEphemeral, &task.ParentID, &archivedAt, &task.ArchivedByCascadeID,
 			&task.CreatedAt, &task.UpdatedAt,
 			&task.AssigneeAgentProfileID, &task.Origin, &task.ProjectID,
 			&task.Labels, &identifier, &task.IsFromOffice,

--- a/apps/backend/internal/task/service/handoff_cascade.go
+++ b/apps/backend/internal/task/service/handoff_cascade.go
@@ -348,7 +348,8 @@ func (s *HandoffService) prepareCascadeResourceCleanup(
 	operations := make(map[string]string, len(taskIDs))
 	for _, taskID := range taskIDs {
 		operationID := string(trigger) + ":" + cascadeID + ":" + taskID
-		if err := coordinator.PrepareTaskResourceCleanup(ctx, taskID, trigger, operationID, false); err != nil {
+		deleteEnvironmentRow := trigger == models.TaskResourceCleanupTriggerCascadeDelete
+		if err := coordinator.PrepareTaskResourceCleanup(ctx, taskID, trigger, operationID, deleteEnvironmentRow); err != nil {
 			s.cancelCascadeResourceCleanupRange(ctx, taskIDs, operations)
 			return nil, fmt.Errorf("prepare cleanup %s: %w", taskID, err)
 		}

--- a/apps/backend/internal/task/service/handoff_cascade.go
+++ b/apps/backend/internal/task/service/handoff_cascade.go
@@ -189,6 +189,10 @@ func (s *HandoffService) ArchiveTaskTree(ctx context.Context, rootID string, cas
 	} else {
 		all = []string{rootID}
 	}
+	cleanupOps, err := s.prepareCascadeResourceCleanup(ctx, all, cascadeID, models.TaskResourceCleanupTriggerCascadeArchive)
+	if err != nil {
+		return out, err
+	}
 
 	// Cancel active runs first. Failures are logged and skipped — a
 	// stuck cancel must not block the archive cascade; the orchestrator
@@ -201,6 +205,7 @@ func (s *HandoffService) ArchiveTaskTree(ctx context.Context, rootID string, cas
 	for i := len(all) - 1; i >= 0; i-- {
 		ok, err := s.tasks.ArchiveTaskIfActive(ctx, all[i], cascadeID)
 		if err != nil {
+			s.cancelCascadeResourceCleanupRange(ctx, all[:i+1], cleanupOps)
 			return out, fmt.Errorf("archive %s: %w", all[i], err)
 		}
 		if ok {
@@ -215,10 +220,13 @@ func (s *HandoffService) ArchiveTaskTree(ctx context.Context, rootID string, cas
 			// Tear down runtime resources (container/sandbox/worktree).
 			// Cancellation above stopped the agent but does not remove the
 			// container. Archive preserves the env row (deleteEnvRow=false).
-			if s.resourceCleaner != nil {
+			if operationID := cleanupOps[all[i]]; operationID != "" {
+				s.startCascadeResourceCleanup(ctx, operationID)
+			} else if s.resourceCleaner != nil {
 				s.resourceCleaner.CleanupTaskResources(ctx, all[i], false)
 			}
 		} else {
+			s.cancelCascadeResourceCleanup(ctx, cleanupOps[all[i]])
 			out.SkippedTaskIDs = append(out.SkippedTaskIDs, all[i])
 		}
 	}
@@ -269,6 +277,10 @@ func (s *HandoffService) DeleteTaskTree(ctx context.Context, rootID string, casc
 	if err != nil {
 		return nil, err
 	}
+	cleanupOps, err := s.prepareCascadeResourceCleanup(ctx, all, cascadeID, models.TaskResourceCleanupTriggerCascadeDelete)
+	if err != nil {
+		return out, err
+	}
 
 	s.cancelActiveRuns(ctx, all, "task tree deleted")
 
@@ -278,6 +290,7 @@ func (s *HandoffService) DeleteTaskTree(ctx context.Context, rootID string, casc
 	// longer log who left.
 	groupIDs, err := s.releaseMembershipsForCascade(ctx, all, orchmodels.WorkspaceReleaseReasonDeleted, cascadeID)
 	if err != nil {
+		s.cancelCascadeResourceCleanupRange(ctx, all, cleanupOps)
 		return out, err
 	}
 	out.ReleasedGroupIDs = groupIDs
@@ -298,11 +311,14 @@ func (s *HandoffService) DeleteTaskTree(ctx context.Context, rootID string, casc
 		// Tear down runtime resources BEFORE the DB delete so the env / worktree
 		// rows are still queryable for the gather step. The actual destroy work
 		// runs async after this returns. Delete cascade removes the env row.
-		if s.resourceCleaner != nil {
-			s.resourceCleaner.CleanupTaskResources(ctx, all[i], true)
-		}
 		if err := s.tasks.DeleteTask(ctx, all[i]); err != nil {
+			s.cancelCascadeResourceCleanupRange(ctx, all[:i+1], cleanupOps)
 			return out, fmt.Errorf("delete %s: %w", all[i], err)
+		}
+		if operationID := cleanupOps[all[i]]; operationID != "" {
+			s.startCascadeResourceCleanup(ctx, operationID)
+		} else if s.resourceCleaner != nil {
+			s.resourceCleaner.CleanupTaskResources(ctx, all[i], true)
 		}
 		out.ArchivedTaskIDs = append(out.ArchivedTaskIDs, all[i])
 		if s.eventPublisher != nil && snapshot != nil {
@@ -317,6 +333,58 @@ func (s *HandoffService) DeleteTaskTree(ctx context.Context, rootID string, casc
 		}
 	}
 	return out, nil
+}
+
+func (s *HandoffService) prepareCascadeResourceCleanup(
+	ctx context.Context,
+	taskIDs []string,
+	cascadeID string,
+	trigger models.TaskResourceCleanupTrigger,
+) (map[string]string, error) {
+	coordinator, ok := s.resourceCleaner.(taskResourceCleanupCoordinator)
+	if !ok {
+		return nil, nil
+	}
+	operations := make(map[string]string, len(taskIDs))
+	for _, taskID := range taskIDs {
+		operationID := string(trigger) + ":" + cascadeID + ":" + taskID
+		if err := coordinator.PrepareTaskResourceCleanup(ctx, taskID, trigger, operationID, false); err != nil {
+			s.cancelCascadeResourceCleanupRange(ctx, taskIDs, operations)
+			return nil, fmt.Errorf("prepare cleanup %s: %w", taskID, err)
+		}
+		operations[taskID] = operationID
+	}
+	return operations, nil
+}
+
+func (s *HandoffService) cancelCascadeResourceCleanupRange(
+	ctx context.Context,
+	taskIDs []string,
+	operations map[string]string,
+) {
+	for _, taskID := range taskIDs {
+		s.cancelCascadeResourceCleanup(ctx, operations[taskID])
+	}
+}
+
+func (s *HandoffService) startCascadeResourceCleanup(ctx context.Context, operationID string) {
+	coordinator, ok := s.resourceCleaner.(taskResourceCleanupCoordinator)
+	if !ok || operationID == "" {
+		return
+	}
+	if err := coordinator.StartPreparedTaskResourceCleanup(ctx, operationID); err != nil {
+		s.logf().Error("start cascade resource cleanup", zap.String("operation_id", operationID), zap.Error(err))
+	}
+}
+
+func (s *HandoffService) cancelCascadeResourceCleanup(ctx context.Context, operationID string) {
+	coordinator, ok := s.resourceCleaner.(taskResourceCleanupCoordinator)
+	if !ok || operationID == "" {
+		return
+	}
+	if err := coordinator.CancelPreparedTaskResourceCleanup(ctx, operationID); err != nil {
+		s.logf().Error("cancel cascade resource cleanup", zap.String("operation_id", operationID), zap.Error(err))
+	}
 }
 
 // cancelActiveRuns invokes the configured RunCanceller for every task
@@ -366,6 +434,9 @@ func (s *HandoffService) UnarchiveTaskTree(ctx context.Context, rootID string) (
 	// Unarchive shallow→deep so the root's restored state is visible
 	// before children are queried by anyone watching the bus.
 	for _, id := range all {
+		if err := s.cancelArchiveResourceCleanup(ctx, id); err != nil {
+			return out, fmt.Errorf("cancel archive cleanup %s: %w", id, err)
+		}
 		ok, err := s.tasks.UnarchiveTaskByCascade(ctx, id, cascadeID)
 		if err != nil {
 			return out, fmt.Errorf("unarchive %s: %w", id, err)
@@ -416,6 +487,9 @@ func (s *HandoffService) unarchiveManualRoot(ctx context.Context, root *models.T
 		return nil, errors.New("task is not archived")
 	}
 	out := &CascadeOutcome{}
+	if err := s.cancelArchiveResourceCleanup(ctx, root.ID); err != nil {
+		return out, fmt.Errorf("cancel archive cleanup %s: %w", root.ID, err)
+	}
 	ok, err := s.tasks.UnarchiveTask(ctx, root.ID)
 	if err != nil {
 		return out, fmt.Errorf("unarchive %s: %w", root.ID, err)
@@ -442,6 +516,14 @@ func (s *HandoffService) unarchiveManualRoot(ctx context.Context, root *models.T
 		}
 	}
 	return out, nil
+}
+
+func (s *HandoffService) cancelArchiveResourceCleanup(ctx context.Context, taskID string) error {
+	canceller, ok := s.resourceCleaner.(archiveTaskResourceCleanupCanceller)
+	if !ok {
+		return nil
+	}
+	return canceller.CancelArchiveTaskResourceCleanup(ctx, taskID)
 }
 
 // resolveDeleteSet returns the set of task IDs DeleteTaskTree should
@@ -557,9 +639,8 @@ func (s *HandoffService) allChildrenIncludingArchived(ctx context.Context, paren
 
 // releaseMembershipsForCascade releases group membership for each task
 // in the input slice and returns the unique set of group IDs that had
-// at least one member released. Failures are logged and skipped — a
-// failed release does not abort the cascade since the row stays in the
-// audit log either way.
+// at least one member released. Inventory and release failures abort so the
+// caller can cancel prepared resource cleanup before task rows are mutated.
 func (s *HandoffService) releaseMembershipsForCascade(ctx context.Context, taskIDs []string, reason, cascadeID string) ([]string, error) {
 	if s.wsGroups == nil {
 		return nil, nil
@@ -569,16 +650,13 @@ func (s *HandoffService) releaseMembershipsForCascade(ctx context.Context, taskI
 	for _, id := range taskIDs {
 		g, err := s.wsGroups.GetWorkspaceGroupForTask(ctx, id)
 		if err != nil {
-			s.logf().Error("lookup group for task", zap.String("task_id", id), zap.Error(err))
-			continue
+			return groups, fmt.Errorf("lookup group for task %s: %w", id, err)
 		}
 		if g == nil {
 			continue
 		}
 		if err := s.wsGroups.ReleaseWorkspaceGroupMember(ctx, g.ID, id, reason, cascadeID); err != nil {
-			s.logf().Error("release membership",
-				zap.String("group_id", g.ID), zap.String("task_id", id), zap.Error(err))
-			continue
+			return groups, fmt.Errorf("release membership for task %s from group %s: %w", id, g.ID, err)
 		}
 		if !seen[g.ID] {
 			seen[g.ID] = true

--- a/apps/backend/internal/task/service/handoff_cascade_test.go
+++ b/apps/backend/internal/task/service/handoff_cascade_test.go
@@ -117,11 +117,12 @@ func (f *fakeWSGroupRepoCascade) ReleaseWorkspaceGroupMember(_ context.Context, 
 }
 
 type recordingCleanupCoordinator struct {
-	mu        sync.Mutex
-	prepared  []string
-	started   []string
-	cancelled []string
-	cleaned   []string
+	mu                    sync.Mutex
+	prepared              []string
+	deleteEnvironmentRows []bool
+	started               []string
+	cancelled             []string
+	cleaned               []string
 }
 
 func (c *recordingCleanupCoordinator) CleanupTaskResources(_ context.Context, taskID string, _ bool) {
@@ -135,12 +136,30 @@ func (c *recordingCleanupCoordinator) PrepareTaskResourceCleanup(
 	_ string,
 	_ models.TaskResourceCleanupTrigger,
 	operationID string,
-	_ bool,
+	deleteEnvironmentRow bool,
 ) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.prepared = append(c.prepared, operationID)
+	c.deleteEnvironmentRows = append(c.deleteEnvironmentRows, deleteEnvironmentRow)
 	return nil
+}
+
+func TestDeleteTaskTreePreparedCleanupDeletesEnvironmentRow(t *testing.T) {
+	tasks := newFakeTaskRepo()
+	tasks.addTask("root", "", "ws-1")
+	coordinator := &recordingCleanupCoordinator{}
+	svc := NewHandoffService(&fakeDeleteRepo{fakeCascadeRepo: newCascadeRepo(tasks)}, nil, nil, nil, nil, nil)
+	svc.SetTaskResourceCleaner(coordinator)
+
+	if _, err := svc.DeleteTaskTree(context.Background(), "root", false); err != nil {
+		t.Fatalf("DeleteTaskTree: %v", err)
+	}
+	coordinator.mu.Lock()
+	defer coordinator.mu.Unlock()
+	if len(coordinator.deleteEnvironmentRows) != 1 || !coordinator.deleteEnvironmentRows[0] {
+		t.Fatalf("deleteEnvironmentRows = %v, want [true]", coordinator.deleteEnvironmentRows)
+	}
 }
 
 func (c *recordingCleanupCoordinator) StartPreparedTaskResourceCleanup(_ context.Context, operationID string) error {

--- a/apps/backend/internal/task/service/handoff_cascade_test.go
+++ b/apps/backend/internal/task/service/handoff_cascade_test.go
@@ -64,6 +64,7 @@ func (r *fakeCascadeRepo) UnarchiveTask(_ context.Context, id string) (bool, err
 // release/restore/cleanup-status methods.
 type fakeWSGroupRepoCascade struct {
 	*fakeWSGroupRepo
+	releaseErr   error
 	releaseCalls []struct {
 		groupID, taskID, reason, cascadeID string
 	}
@@ -104,12 +105,97 @@ func (f *fakeWSGroupRepoCascade) ListWorkspaceGroupMembers(ctx context.Context, 
 func (f *fakeWSGroupRepoCascade) ReleaseWorkspaceGroupMember(_ context.Context, groupID, taskID, reason, cascadeID string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	if f.releaseErr != nil {
+		return f.releaseErr
+	}
 	f.releaseCalls = append(f.releaseCalls, struct {
 		groupID, taskID, reason, cascadeID string
 	}{groupID, taskID, reason, cascadeID})
 	// Mark the member released by removing it from the live members map.
 	delete(f.members[groupID], taskID)
 	return nil
+}
+
+type recordingCleanupCoordinator struct {
+	mu        sync.Mutex
+	prepared  []string
+	started   []string
+	cancelled []string
+	cleaned   []string
+}
+
+func (c *recordingCleanupCoordinator) CleanupTaskResources(_ context.Context, taskID string, _ bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.cleaned = append(c.cleaned, taskID)
+}
+
+func (c *recordingCleanupCoordinator) PrepareTaskResourceCleanup(
+	_ context.Context,
+	_ string,
+	_ models.TaskResourceCleanupTrigger,
+	operationID string,
+	_ bool,
+) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.prepared = append(c.prepared, operationID)
+	return nil
+}
+
+func (c *recordingCleanupCoordinator) StartPreparedTaskResourceCleanup(_ context.Context, operationID string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.started = append(c.started, operationID)
+	return nil
+}
+
+func (c *recordingCleanupCoordinator) CancelPreparedTaskResourceCleanup(_ context.Context, operationID string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.cancelled = append(c.cancelled, operationID)
+	return nil
+}
+
+func TestDeleteTaskTree_MembershipReleaseFailureCancelsEveryPreparedCleanup(t *testing.T) {
+	tasks := newFakeTaskRepo()
+	tasks.addTask("root", "", "ws-1")
+	tasks.addTask("child", "root", "ws-1")
+	groups := newCascadeWSGroupRepo()
+	releaseErr := errors.New("membership release unavailable")
+	groups.releaseErr = releaseErr
+	if err := groups.CreateWorkspaceGroup(context.Background(), &orchmodels.WorkspaceGroup{
+		ID: "group-1", WorkspaceID: "ws-1",
+	}); err != nil {
+		t.Fatalf("CreateWorkspaceGroup: %v", err)
+	}
+	for _, taskID := range []string{"root", "child"} {
+		if err := groups.AddWorkspaceGroupMember(context.Background(), "group-1", taskID, "member"); err != nil {
+			t.Fatalf("AddWorkspaceGroupMember(%s): %v", taskID, err)
+		}
+	}
+	coordinator := &recordingCleanupCoordinator{}
+	svc := NewHandoffService(&fakeDeleteRepo{fakeCascadeRepo: newCascadeRepo(tasks)}, nil, nil, nil, groups, nil)
+	svc.SetTaskResourceCleaner(coordinator)
+
+	_, err := svc.DeleteTaskTree(context.Background(), "root", true)
+	if !errors.Is(err, releaseErr) {
+		t.Fatalf("DeleteTaskTree error = %v, want membership release error", err)
+	}
+	coordinator.mu.Lock()
+	defer coordinator.mu.Unlock()
+	if len(coordinator.prepared) != 2 {
+		t.Fatalf("prepared cleanup count = %d, want 2", len(coordinator.prepared))
+	}
+	if len(coordinator.cancelled) != len(coordinator.prepared) {
+		t.Fatalf("cancelled cleanup count = %d, want all %d prepared operations", len(coordinator.cancelled), len(coordinator.prepared))
+	}
+	if len(coordinator.started) != 0 || len(coordinator.cleaned) != 0 {
+		t.Fatalf("cleanup ran after release failure: started=%v cleaned=%v", coordinator.started, coordinator.cleaned)
+	}
+	if task, getErr := tasks.GetTask(context.Background(), "root"); getErr != nil || task == nil {
+		t.Fatalf("root task mutated after release failure: task=%#v err=%v", task, getErr)
+	}
 }
 
 func (f *fakeWSGroupRepoCascade) RestoreWorkspaceGroupMemberByCascade(_ context.Context, taskID, cascadeID string) error {

--- a/apps/backend/internal/task/service/handoff_service.go
+++ b/apps/backend/internal/task/service/handoff_service.go
@@ -242,6 +242,16 @@ type TaskResourceCleaner interface {
 	CleanupTaskResources(ctx context.Context, taskID string, deleteEnvRow bool)
 }
 
+type archiveTaskResourceCleanupCanceller interface {
+	CancelArchiveTaskResourceCleanup(ctx context.Context, taskID string) error
+}
+
+type taskResourceCleanupCoordinator interface {
+	PrepareTaskResourceCleanup(ctx context.Context, taskID string, trigger models.TaskResourceCleanupTrigger, operationID string, deleteEnvironmentRow bool) error
+	StartPreparedTaskResourceCleanup(ctx context.Context, operationID string) error
+	CancelPreparedTaskResourceCleanup(ctx context.Context, operationID string) error
+}
+
 // SetTaskResourceCleaner wires the resource teardown surface invoked by
 // cascade archive/delete to release containers / sandboxes / worktrees.
 // Optional — when nil the cascade does not tear down runtime resources.

--- a/apps/backend/internal/task/service/resource_cleanup_activation_test.go
+++ b/apps/backend/internal/task/service/resource_cleanup_activation_test.go
@@ -1,0 +1,581 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/task/models"
+	"github.com/kandev/kandev/internal/task/repository"
+)
+
+type transientStartCleanupRepository struct {
+	repository.TaskResourceCleanupRepository
+	mu       sync.Mutex
+	failures int
+	calls    int
+}
+
+type failOnceResetCleanupRepository struct {
+	repository.TaskResourceCleanupRepository
+	mu        sync.Mutex
+	calls     int
+	dueListed chan struct{}
+	dueOnce   sync.Once
+}
+
+func (r *failOnceResetCleanupRepository) ResetRunningTaskResourceCleanupJobs(ctx context.Context) error {
+	r.mu.Lock()
+	r.calls++
+	calls := r.calls
+	r.mu.Unlock()
+	if calls == 1 {
+		return errors.New("transient reset running cleanup failure")
+	}
+	return r.TaskResourceCleanupRepository.ResetRunningTaskResourceCleanupJobs(ctx)
+}
+
+func (r *failOnceResetCleanupRepository) ListDueTaskResourceCleanupJobs(
+	ctx context.Context,
+	now time.Time,
+	limit int,
+) ([]*models.TaskResourceCleanupJob, error) {
+	jobs, err := r.TaskResourceCleanupRepository.ListDueTaskResourceCleanupJobs(ctx, now, limit)
+	if r.dueListed != nil {
+		r.dueOnce.Do(func() { close(r.dueListed) })
+	}
+	return jobs, err
+}
+
+func (r *transientStartCleanupRepository) StartPreparedTaskResourceCleanupJob(
+	ctx context.Context,
+	id string,
+) (bool, error) {
+	r.mu.Lock()
+	r.calls++
+	if r.failures > 0 {
+		r.failures--
+		r.mu.Unlock()
+		return false, errors.New("transient prepared cleanup start failure")
+	}
+	r.mu.Unlock()
+	return r.TaskResourceCleanupRepository.StartPreparedTaskResourceCleanupJob(ctx, id)
+}
+
+type blockingTaskMutationRepository struct {
+	repository.TaskRepository
+	archiveEntered chan struct{}
+	deleteEntered  chan struct{}
+	release        <-chan struct{}
+}
+
+type failPostArchiveReadRepository struct {
+	repository.TaskRepository
+	archived bool
+}
+
+func (r *failPostArchiveReadRepository) ArchiveTask(ctx context.Context, id string) error {
+	if err := r.TaskRepository.ArchiveTask(ctx, id); err != nil {
+		return err
+	}
+	r.archived = true
+	return nil
+}
+
+func (r *failPostArchiveReadRepository) GetTask(ctx context.Context, id string) (*models.Task, error) {
+	if r.archived {
+		return nil, errors.New("post-archive task read failed")
+	}
+	return r.TaskRepository.GetTask(ctx, id)
+}
+
+func (r *blockingTaskMutationRepository) ArchiveTask(ctx context.Context, id string) error {
+	if r.archiveEntered != nil {
+		close(r.archiveEntered)
+		select {
+		case <-r.release:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return r.TaskRepository.ArchiveTask(ctx, id)
+}
+
+func (r *blockingTaskMutationRepository) DeleteTask(ctx context.Context, id string) error {
+	if r.deleteEntered != nil {
+		close(r.deleteEntered)
+		select {
+		case <-r.release:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return r.TaskRepository.DeleteTask(ctx, id)
+}
+
+func TestStartPreparedCleanupUsesDetachedContextAndRetriesTransientFailure(t *testing.T) {
+	taskSvc, repo := setupOfficeTest(t)
+	ctx := context.Background()
+	seedCleanupTaskAndSession(t, repo, "task-start-retry", "session-start-retry")
+	const operationID = "delete:start-retry"
+	if err := taskSvc.PrepareTaskResourceCleanup(
+		ctx, "task-start-retry", models.TaskResourceCleanupTriggerDelete, operationID, true,
+	); err != nil {
+		t.Fatalf("PrepareTaskResourceCleanup: %v", err)
+	}
+	transient := &transientStartCleanupRepository{
+		TaskResourceCleanupRepository: taskSvc.resourceCleanups,
+		failures:                      1,
+	}
+	taskSvc.resourceCleanups = transient
+	cancelledCtx, cancel := context.WithCancel(ctx)
+	cancel()
+
+	if err := taskSvc.StartPreparedTaskResourceCleanup(cancelledCtx, operationID); err != nil {
+		t.Fatalf("StartPreparedTaskResourceCleanup: %v", err)
+	}
+	transient.mu.Lock()
+	calls := transient.calls
+	transient.mu.Unlock()
+	if calls != 2 {
+		t.Fatalf("start attempts = %d, want 2", calls)
+	}
+	job, err := repo.GetTaskResourceCleanupJobByOperationID(ctx, operationID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if job.State == models.TaskResourceCleanupStatePrepared {
+		t.Fatal("cleanup remained prepared after committed lifecycle mutation")
+	}
+}
+
+func TestArchiveAndDeleteCleanupRemainPreparedUntilMutationCommits(t *testing.T) {
+	tests := []struct {
+		name    string
+		trigger models.TaskResourceCleanupTrigger
+		mutate  func(context.Context, *Service, string) error
+	}{
+		{
+			name: "archive", trigger: models.TaskResourceCleanupTriggerArchive,
+			mutate: func(ctx context.Context, svc *Service, taskID string) error {
+				return svc.ArchiveTask(ctx, taskID)
+			},
+		},
+		{
+			name: "delete", trigger: models.TaskResourceCleanupTriggerDelete,
+			mutate: func(ctx context.Context, svc *Service, taskID string) error {
+				return svc.DeleteTask(ctx, taskID)
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			taskSvc, repo := setupOfficeTest(t)
+			ctx := context.Background()
+			taskID := "task-two-phase-" + test.name
+			seedCleanupTaskAndSession(t, repo, taskID, "session-two-phase-"+test.name)
+			entered := make(chan struct{})
+			release := make(chan struct{})
+			var releaseOnce sync.Once
+			t.Cleanup(func() { releaseOnce.Do(func() { close(release) }) })
+			blocked := &blockingTaskMutationRepository{TaskRepository: taskSvc.tasks, release: release}
+			if test.name == "archive" {
+				blocked.archiveEntered = entered
+			} else {
+				blocked.deleteEntered = entered
+			}
+			taskSvc.tasks = blocked
+			done := make(chan error, 1)
+			go func() { done <- test.mutate(ctx, taskSvc, taskID) }()
+			select {
+			case <-entered:
+			case <-time.After(time.Second):
+				t.Fatal("task mutation did not reach commit barrier")
+			}
+
+			var state models.TaskResourceCleanupState
+			if err := repo.DB().QueryRowContext(ctx, `
+				SELECT state FROM task_resource_cleanup_jobs WHERE task_id = ? AND trigger = ?
+			`, taskID, test.trigger).Scan(&state); err != nil {
+				t.Fatalf("load cleanup state: %v", err)
+			}
+			if state != models.TaskResourceCleanupStatePrepared {
+				t.Fatalf("cleanup state before task mutation commit = %q, want prepared", state)
+			}
+			if err := taskSvc.processDueTaskResourceCleanupJobs(ctx); err != nil {
+				t.Fatalf("periodic cleanup during task mutation: %v", err)
+			}
+			if err := repo.DB().QueryRowContext(ctx, `
+				SELECT state FROM task_resource_cleanup_jobs WHERE task_id = ? AND trigger = ?
+			`, taskID, test.trigger).Scan(&state); err != nil {
+				t.Fatalf("reload cleanup state: %v", err)
+			}
+			if state != models.TaskResourceCleanupStatePrepared {
+				t.Fatalf("periodic reconciliation changed in-flight cleanup to %q", state)
+			}
+
+			releaseOnce.Do(func() { close(release) })
+			select {
+			case err := <-done:
+				if err != nil {
+					t.Fatalf("%s task: %v", test.name, err)
+				}
+			case <-time.After(time.Second):
+				t.Fatalf("%s did not finish after mutation commit", test.name)
+			}
+		})
+	}
+}
+
+func TestRestartReconcilesCommittedPreparedCleanup(t *testing.T) {
+	tests := []struct {
+		name    string
+		trigger models.TaskResourceCleanupTrigger
+		commit  func(context.Context, repository.TaskRepository, string) error
+	}{
+		{
+			name: "archive", trigger: models.TaskResourceCleanupTriggerArchive,
+			commit: func(ctx context.Context, tasks repository.TaskRepository, taskID string) error {
+				return tasks.ArchiveTask(ctx, taskID)
+			},
+		},
+		{
+			name: "delete", trigger: models.TaskResourceCleanupTriggerDelete,
+			commit: func(ctx context.Context, tasks repository.TaskRepository, taskID string) error {
+				return tasks.DeleteTask(ctx, taskID)
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			taskSvc, repo := setupOfficeTest(t)
+			taskSvc.StopTaskResourceCleanupWorker()
+			ctx := context.Background()
+			taskID := "task-restart-" + test.name
+			seedCleanupTaskAndSession(t, repo, taskID, "session-restart-"+test.name)
+			operationID := test.name + ":restart"
+			if err := taskSvc.PrepareTaskResourceCleanup(ctx, taskID, test.trigger, operationID, true); err != nil {
+				t.Fatalf("PrepareTaskResourceCleanup: %v", err)
+			}
+			if err := test.commit(ctx, repo, taskID); err != nil {
+				t.Fatalf("commit lifecycle mutation: %v", err)
+			}
+
+			if err := taskSvc.StartTaskResourceCleanupWorker(ctx); err != nil {
+				t.Fatalf("restart cleanup worker: %v", err)
+			}
+			job, err := repo.GetTaskResourceCleanupJobByOperationID(ctx, operationID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if job.State == models.TaskResourceCleanupStatePrepared {
+				t.Fatal("committed cleanup remained prepared after worker restart")
+			}
+		})
+	}
+}
+
+func TestPreparedCleanupReconciliationFailsClosedBeforeMutationCommit(t *testing.T) {
+	tests := []struct {
+		name    string
+		trigger models.TaskResourceCleanupTrigger
+	}{
+		{name: "archive", trigger: models.TaskResourceCleanupTriggerArchive},
+		{name: "delete", trigger: models.TaskResourceCleanupTriggerDelete},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			taskSvc, repo := setupOfficeTest(t)
+			taskSvc.StopTaskResourceCleanupWorker()
+			ctx := context.Background()
+			taskID := "task-uncommitted-" + test.name
+			seedCleanupTaskAndSession(t, repo, taskID, "session-uncommitted-"+test.name)
+			operationID := test.name + ":uncommitted"
+			if err := taskSvc.PrepareTaskResourceCleanup(ctx, taskID, test.trigger, operationID, true); err != nil {
+				t.Fatalf("PrepareTaskResourceCleanup: %v", err)
+			}
+
+			if err := taskSvc.StartTaskResourceCleanupWorker(ctx); err != nil {
+				t.Fatalf("restart cleanup worker: %v", err)
+			}
+			job, err := repo.GetTaskResourceCleanupJobByOperationID(ctx, operationID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if job.State != models.TaskResourceCleanupStateCancelled {
+				t.Fatalf("uncommitted cleanup state = %q, want cancelled", job.State)
+			}
+		})
+	}
+}
+
+func TestPeriodicReconciliationRecoversPreparedCleanupAfterActivationOutage(t *testing.T) {
+	taskSvc, repo := setupOfficeTest(t)
+	taskSvc.StopTaskResourceCleanupWorker()
+	ctx := context.Background()
+	seedCleanupTaskAndSession(t, repo, "task-activation-outage", "session-activation-outage")
+	const operationID = "delete:activation-outage"
+	if err := taskSvc.PrepareTaskResourceCleanup(
+		ctx, "task-activation-outage", models.TaskResourceCleanupTriggerDelete, operationID, true,
+	); err != nil {
+		t.Fatalf("PrepareTaskResourceCleanup: %v", err)
+	}
+	if err := repo.DeleteTask(ctx, "task-activation-outage"); err != nil {
+		t.Fatalf("commit delete: %v", err)
+	}
+
+	if err := taskSvc.processDueTaskResourceCleanupJobs(ctx); err != nil {
+		t.Fatalf("periodic cleanup reconciliation: %v", err)
+	}
+	job, err := repo.GetTaskResourceCleanupJobByOperationID(ctx, operationID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if job.State == models.TaskResourceCleanupStatePrepared {
+		t.Fatal("cleanup remained prepared after activation service recovered")
+	}
+}
+
+func TestPeriodicReconciliationRecoversAfterActivationRetryWindowExpires(t *testing.T) {
+	taskSvc, repo := setupOfficeTest(t)
+	taskSvc.StopTaskResourceCleanupWorker()
+	ctx := context.Background()
+	seedCleanupTaskAndSession(t, repo, "task-persistent-outage", "session-persistent-outage")
+	const operationID = "delete:persistent-outage"
+	if err := taskSvc.PrepareTaskResourceCleanup(
+		ctx, "task-persistent-outage", models.TaskResourceCleanupTriggerDelete, operationID, true,
+	); err != nil {
+		t.Fatalf("PrepareTaskResourceCleanup: %v", err)
+	}
+	if err := repo.DeleteTask(ctx, "task-persistent-outage"); err != nil {
+		t.Fatalf("commit delete: %v", err)
+	}
+	persistentFailure := &transientStartCleanupRepository{
+		TaskResourceCleanupRepository: taskSvc.resourceCleanups,
+		failures:                      1 << 30,
+	}
+	taskSvc.resourceCleanups = persistentFailure
+	if err := taskSvc.StartPreparedTaskResourceCleanup(ctx, operationID); err == nil {
+		t.Fatal("activation unexpectedly succeeded during persistent repository outage")
+	}
+	job, err := repo.GetTaskResourceCleanupJobByOperationID(ctx, operationID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if job.State != models.TaskResourceCleanupStatePrepared {
+		t.Fatalf("cleanup state after activation outage = %q, want prepared", job.State)
+	}
+
+	taskSvc.resourceCleanups = repo
+	if err := taskSvc.processDueTaskResourceCleanupJobs(ctx); err != nil {
+		t.Fatalf("periodic cleanup reconciliation after recovery: %v", err)
+	}
+	job, err = repo.GetTaskResourceCleanupJobByOperationID(ctx, operationID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if job.State == models.TaskResourceCleanupStatePrepared {
+		t.Fatal("cleanup remained prepared after persistent activation outage recovered")
+	}
+}
+
+func TestPreparedActivationFailureDoesNotStarveRunnableCleanup(t *testing.T) {
+	taskSvc, repo := setupOfficeTest(t)
+	taskSvc.StopTaskResourceCleanupWorker()
+	ctx := context.Background()
+	seedCleanupTaskAndSession(t, repo, "task-starved-prepared", "session-starved-prepared")
+	if err := taskSvc.PrepareTaskResourceCleanup(
+		ctx, "task-starved-prepared", models.TaskResourceCleanupTriggerDelete, "delete:starved-prepared", true,
+	); err != nil {
+		t.Fatalf("PrepareTaskResourceCleanup: %v", err)
+	}
+	if err := repo.DeleteTask(ctx, "task-starved-prepared"); err != nil {
+		t.Fatalf("commit prepared delete: %v", err)
+	}
+	pending := &models.TaskResourceCleanupJob{
+		ID: "job-runnable", OperationID: "delete:runnable", TaskID: "task-runnable",
+		Trigger: models.TaskResourceCleanupTriggerDelete, State: models.TaskResourceCleanupStatePending,
+		ResourceSnapshot: `{}`,
+	}
+	if err := repo.CreateTaskResourceCleanupJob(ctx, pending); err != nil {
+		t.Fatalf("CreateTaskResourceCleanupJob: %v", err)
+	}
+	taskSvc.resourceCleanups = &transientStartCleanupRepository{
+		TaskResourceCleanupRepository: repo,
+		failures:                      1 << 30,
+	}
+
+	if err := taskSvc.processDueTaskResourceCleanupJobs(ctx); err == nil {
+		t.Fatal("periodic cleanup unexpectedly ignored prepared activation failure")
+	}
+	job, err := repo.GetTaskResourceCleanupJob(ctx, pending.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if job.State != models.TaskResourceCleanupStateSucceeded {
+		t.Fatalf("runnable cleanup state = %q, want succeeded despite prepared activation failure", job.State)
+	}
+}
+
+func TestStartupActivationFailureKeepsWorkerRunningForRecovery(t *testing.T) {
+	taskSvc, repo := setupOfficeTest(t)
+	taskSvc.StopTaskResourceCleanupWorker()
+	ctx := context.Background()
+	seedCleanupTaskAndSession(t, repo, "task-startup-outage", "session-startup-outage")
+	const operationID = "delete:startup-outage"
+	if err := taskSvc.PrepareTaskResourceCleanup(
+		ctx, "task-startup-outage", models.TaskResourceCleanupTriggerDelete, operationID, true,
+	); err != nil {
+		t.Fatalf("PrepareTaskResourceCleanup: %v", err)
+	}
+	if err := repo.DeleteTask(ctx, "task-startup-outage"); err != nil {
+		t.Fatalf("commit delete: %v", err)
+	}
+	taskSvc.resourceCleanups = &transientStartCleanupRepository{
+		TaskResourceCleanupRepository: repo,
+		failures:                      1,
+	}
+	taskSvc.setCleanupDoneForTestHook(make(chan struct{}, 1))
+	if err := taskSvc.StartTaskResourceCleanupWorker(ctx); err == nil {
+		t.Fatal("worker startup unexpectedly hid initial activation failure")
+	}
+	taskSvc.startTaskResourceCleanup(&models.TaskResourceCleanupJob{ID: "wake-after-recovery"})
+	waitForCleanupDone(t, taskSvc)
+	job, err := repo.GetTaskResourceCleanupJobByOperationID(ctx, operationID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if job.State != models.TaskResourceCleanupStateSucceeded {
+		t.Fatalf("cleanup state after startup recovery = %q, want succeeded", job.State)
+	}
+}
+
+func TestWorkerRetriesFullResumeAfterStartupResetFailure(t *testing.T) {
+	taskSvc, repo := setupOfficeTest(t)
+	taskSvc.StopTaskResourceCleanupWorker()
+	ctx := context.Background()
+	running := &models.TaskResourceCleanupJob{
+		ID: "job-interrupted-running", OperationID: "delete:interrupted-running", TaskID: "task-running-missing",
+		Trigger: models.TaskResourceCleanupTriggerDelete, State: models.TaskResourceCleanupStatePending,
+		ResourceSnapshot: `{}`,
+	}
+	prepared := &models.TaskResourceCleanupJob{
+		ID: "job-committed-prepared", OperationID: "delete:committed-prepared", TaskID: "task-prepared-missing",
+		Trigger: models.TaskResourceCleanupTriggerDelete, State: models.TaskResourceCleanupStatePrepared,
+		ResourceSnapshot: `{}`,
+	}
+	for _, job := range []*models.TaskResourceCleanupJob{running, prepared} {
+		if err := repo.CreateTaskResourceCleanupJob(ctx, job); err != nil {
+			t.Fatalf("CreateTaskResourceCleanupJob(%s): %v", job.ID, err)
+		}
+	}
+	claimed, err := repo.MarkTaskResourceCleanupJobRunning(ctx, running.ID)
+	if err != nil || !claimed {
+		t.Fatalf("MarkTaskResourceCleanupJobRunning = %v, %v", claimed, err)
+	}
+	failOnce := &failOnceResetCleanupRepository{TaskResourceCleanupRepository: repo}
+	taskSvc.resourceCleanups = failOnce
+	taskSvc.setCleanupDoneForTestHook(make(chan struct{}, 2))
+
+	if err := taskSvc.StartTaskResourceCleanupWorker(ctx); err == nil {
+		t.Fatal("worker startup unexpectedly hid reset failure")
+	}
+	taskSvc.startTaskResourceCleanup(&models.TaskResourceCleanupJob{ID: "retry-full-resume"})
+	waitForCleanupDone(t, taskSvc)
+	waitForCleanupDone(t, taskSvc)
+	for _, id := range []string{running.ID, prepared.ID} {
+		job, err := repo.GetTaskResourceCleanupJob(ctx, id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if job.State != models.TaskResourceCleanupStateSucceeded {
+			t.Fatalf("cleanup %s state = %q, want succeeded", id, job.State)
+		}
+	}
+}
+
+func TestWorkerResumeRetryPreservesPreparedCleanupCreatedAfterStartup(t *testing.T) {
+	taskSvc, repo := setupOfficeTest(t)
+	taskSvc.StopTaskResourceCleanupWorker()
+	ctx := context.Background()
+	seedCleanupTaskAndSession(t, repo, "task-live-mutation", "session-live-mutation")
+	const operationID = "delete:live-mutation"
+	dueListed := make(chan struct{})
+	failOnce := &failOnceResetCleanupRepository{
+		TaskResourceCleanupRepository: repo,
+		dueListed:                     dueListed,
+	}
+	taskSvc.resourceCleanups = failOnce
+
+	if err := taskSvc.StartTaskResourceCleanupWorker(ctx); err == nil {
+		t.Fatal("worker startup unexpectedly hid reset failure")
+	}
+	if err := taskSvc.PrepareTaskResourceCleanup(
+		ctx, "task-live-mutation", models.TaskResourceCleanupTriggerDelete, operationID, true,
+	); err != nil {
+		t.Fatalf("PrepareTaskResourceCleanup: %v", err)
+	}
+	taskSvc.startTaskResourceCleanup(&models.TaskResourceCleanupJob{ID: "retry-during-live-mutation"})
+	select {
+	case <-dueListed:
+	case <-time.After(time.Second):
+		t.Fatal("worker did not finish startup resume retry")
+	}
+
+	job, err := repo.GetTaskResourceCleanupJobByOperationID(ctx, operationID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if job.State != models.TaskResourceCleanupStatePrepared {
+		t.Fatalf("live cleanup state after startup retry = %q, want prepared", job.State)
+	}
+
+	taskSvc.setCleanupDoneForTestHook(make(chan struct{}, 1))
+	if err := repo.DeleteTask(ctx, "task-live-mutation"); err != nil {
+		t.Fatalf("commit live mutation: %v", err)
+	}
+	if err := taskSvc.StartPreparedTaskResourceCleanup(ctx, operationID); err != nil {
+		t.Fatalf("StartPreparedTaskResourceCleanup: %v", err)
+	}
+	waitForCleanupDone(t, taskSvc)
+	job, err = repo.GetTaskResourceCleanupJobByOperationID(ctx, operationID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if job.State != models.TaskResourceCleanupStateSucceeded {
+		t.Fatalf("live cleanup state after commit = %q, want succeeded", job.State)
+	}
+}
+
+func TestArchiveReadFailureLeavesRecoverablePreparedCleanup(t *testing.T) {
+	taskSvc, repo := setupOfficeTest(t)
+	taskSvc.StopTaskResourceCleanupWorker()
+	ctx := context.Background()
+	seedCleanupTaskAndSession(t, repo, "task-archive-reread", "session-archive-reread")
+	failingTasks := &failPostArchiveReadRepository{TaskRepository: taskSvc.tasks}
+	taskSvc.tasks = failingTasks
+
+	if err := taskSvc.ArchiveTask(ctx, "task-archive-reread"); err == nil {
+		t.Fatal("ArchiveTask succeeded despite forced post-commit read failure")
+	}
+	var operationID string
+	if err := repo.DB().QueryRowContext(ctx, `
+		SELECT operation_id FROM task_resource_cleanup_jobs
+		WHERE task_id = ? AND trigger = ?
+	`, "task-archive-reread", models.TaskResourceCleanupTriggerArchive).Scan(&operationID); err != nil {
+		t.Fatalf("load prepared cleanup: %v", err)
+	}
+	taskSvc.tasks = repo
+	if err := taskSvc.ResumeTaskResourceCleanupJobs(ctx); err != nil {
+		t.Fatalf("ResumeTaskResourceCleanupJobs: %v", err)
+	}
+	job, err := repo.GetTaskResourceCleanupJobByOperationID(ctx, operationID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if job.State == models.TaskResourceCleanupStatePrepared {
+		t.Fatal("post-commit archive cleanup remained prepared after reconciliation")
+	}
+}

--- a/apps/backend/internal/task/service/resource_cleanup_jobs.go
+++ b/apps/backend/internal/task/service/resource_cleanup_jobs.go
@@ -1,0 +1,455 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+
+	"github.com/kandev/kandev/internal/task/models"
+	taskrepo "github.com/kandev/kandev/internal/task/repository"
+	"github.com/kandev/kandev/internal/worktree"
+)
+
+const taskResourceCleanupRetryDelay = time.Minute
+
+type persistedTaskStopTarget struct {
+	SessionID   string `json:"session_id"`
+	ExecutionID string `json:"execution_id,omitempty"`
+	Terminal    bool   `json:"terminal,omitempty"`
+}
+
+type taskResourceCleanupSnapshot struct {
+	Sessions              []*models.TaskSession     `json:"sessions,omitempty"`
+	Worktrees             []*worktree.Worktree      `json:"worktrees,omitempty"`
+	StopTargets           []persistedTaskStopTarget `json:"stop_targets,omitempty"`
+	TaskEnvironment       *models.TaskEnvironment   `json:"task_environment,omitempty"`
+	DeleteEnvironmentRow  bool                      `json:"delete_environment_row,omitempty"`
+	LegacyWorktreeCleanup bool                      `json:"legacy_worktree_cleanup,omitempty"`
+}
+
+type taskResourceCleanupRun struct {
+	job    *models.TaskResourceCleanupJob
+	cancel context.CancelFunc
+	done   chan struct{}
+}
+
+func newTaskResourceCleanupOperationID(trigger models.TaskResourceCleanupTrigger, taskID string) string {
+	return string(trigger) + ":" + taskID + ":" + uuid.NewString()
+}
+
+func (s *Service) persistTaskResourceCleanup(
+	ctx context.Context,
+	taskID string,
+	trigger models.TaskResourceCleanupTrigger,
+	operationID string,
+	sessions []*models.TaskSession,
+	worktrees []*worktree.Worktree,
+	stopTargets []taskStopTarget,
+	envCleanup taskEnvironmentCleanup,
+) (*models.TaskResourceCleanupJob, error) {
+	if s.resourceCleanups == nil {
+		return nil, nil
+	}
+	if operationID == "" {
+		operationID = newTaskResourceCleanupOperationID(trigger, taskID)
+	}
+	snapshot := taskResourceCleanupSnapshot{
+		Sessions: sessions, Worktrees: worktrees,
+		StopTargets:           persistStopTargets(stopTargets),
+		TaskEnvironment:       envCleanup.env,
+		DeleteEnvironmentRow:  envCleanup.deleteRow,
+		LegacyWorktreeCleanup: s.hasLegacyWorktreeCleanup(),
+	}
+	encoded, err := json.Marshal(snapshot)
+	if err != nil {
+		return nil, fmt.Errorf("encode task resource cleanup snapshot: %w", err)
+	}
+	job := &models.TaskResourceCleanupJob{
+		OperationID: operationID, TaskID: taskID, Trigger: trigger,
+		State: models.TaskResourceCleanupStatePending, ResourceSnapshot: string(encoded),
+	}
+	if err := s.resourceCleanups.CreateTaskResourceCleanupJob(ctx, job); err != nil {
+		return nil, fmt.Errorf("persist task resource cleanup intent: %w", err)
+	}
+	return s.resourceCleanups.GetTaskResourceCleanupJobByOperationID(ctx, operationID)
+}
+
+func persistStopTargets(targets []taskStopTarget) []persistedTaskStopTarget {
+	result := make([]persistedTaskStopTarget, 0, len(targets))
+	for _, target := range targets {
+		result = append(result, persistedTaskStopTarget{
+			SessionID: target.sessionID, ExecutionID: target.executionID, Terminal: target.terminal,
+		})
+	}
+	return result
+}
+
+func restoreStopTargets(targets []persistedTaskStopTarget) []taskStopTarget {
+	result := make([]taskStopTarget, 0, len(targets))
+	for _, target := range targets {
+		result = append(result, taskStopTarget{
+			sessionID: target.SessionID, executionID: target.ExecutionID, terminal: target.Terminal,
+		})
+	}
+	return result
+}
+
+func (s *Service) startTaskResourceCleanup(job *models.TaskResourceCleanupJob) {
+	if job == nil {
+		return
+	}
+	s.cleanupWorkerMu.Lock()
+	wake := s.cleanupWorkerWake
+	s.cleanupWorkerMu.Unlock()
+	if wake != nil {
+		select {
+		case wake <- struct{}{}:
+		default:
+		}
+		return
+	}
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cancel()
+		if err := s.processTaskResourceCleanupJob(ctx, job.ID); err != nil {
+			s.logger.Warn("task resource cleanup job failed",
+				zap.String("job_id", job.ID), zap.String("task_id", job.TaskID), zap.Error(err))
+		}
+	}()
+}
+
+// StartTaskResourceCleanupWorker owns the install-wide durable task cleanup
+// loop. StopTaskResourceCleanupWorker joins it during backend shutdown.
+func (s *Service) StartTaskResourceCleanupWorker(ctx context.Context) error {
+	if s.resourceCleanups == nil {
+		return nil
+	}
+	s.cleanupWorkerMu.Lock()
+	if s.cleanupWorkerCancel != nil {
+		s.cleanupWorkerMu.Unlock()
+		return nil
+	}
+	workerCtx, cancel := context.WithCancel(ctx)
+	wake := make(chan struct{}, 1)
+	s.cleanupWorkerCancel = cancel
+	s.cleanupWorkerWake = wake
+	s.cleanupWorkerMu.Unlock()
+	if err := s.ResumeTaskResourceCleanupJobs(workerCtx); err != nil {
+		s.StopTaskResourceCleanupWorker()
+		return err
+	}
+	s.cleanupWorkerWG.Add(1)
+	go s.runTaskResourceCleanupWorker(workerCtx, wake)
+	return nil
+}
+
+func (s *Service) runTaskResourceCleanupWorker(ctx context.Context, wake <-chan struct{}) {
+	defer s.cleanupWorkerWG.Done()
+	ticker := time.NewTicker(taskResourceCleanupRetryDelay)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		case <-wake:
+		}
+		if err := s.processDueTaskResourceCleanupJobs(ctx); err != nil && ctx.Err() == nil {
+			s.logger.Warn("process due task resource cleanup jobs", zap.Error(err))
+		}
+	}
+}
+
+func (s *Service) StopTaskResourceCleanupWorker() {
+	s.cleanupWorkerMu.Lock()
+	cancel := s.cleanupWorkerCancel
+	s.cleanupWorkerCancel = nil
+	s.cleanupWorkerWake = nil
+	s.cleanupWorkerMu.Unlock()
+	if cancel != nil {
+		cancel()
+		s.cleanupWorkerWG.Wait()
+	}
+}
+
+// ResumeTaskResourceCleanupJobs reconstructs interrupted task cleanup after a
+// backend restart. It is independent of optional scheduled storage maintenance.
+func (s *Service) ResumeTaskResourceCleanupJobs(ctx context.Context) error {
+	if s.resourceCleanups == nil {
+		return nil
+	}
+	if err := s.resourceCleanups.ResetRunningTaskResourceCleanupJobs(ctx); err != nil {
+		return fmt.Errorf("reset interrupted task cleanup jobs: %w", err)
+	}
+	return s.processDueTaskResourceCleanupJobs(ctx)
+}
+
+func (s *Service) processDueTaskResourceCleanupJobs(ctx context.Context) error {
+	jobs, err := s.resourceCleanups.ListDueTaskResourceCleanupJobs(ctx, time.Now().UTC(), 100)
+	if err != nil {
+		return fmt.Errorf("list due task cleanup jobs: %w", err)
+	}
+	for _, job := range jobs {
+		if err := s.processTaskResourceCleanupJob(ctx, job.ID); err != nil {
+			s.logger.Warn("resumed task resource cleanup job failed")
+		}
+	}
+	return nil
+}
+
+func (s *Service) processTaskResourceCleanupJob(ctx context.Context, id string) error {
+	candidate, err := s.resourceCleanups.GetTaskResourceCleanupJob(ctx, id)
+	if err != nil {
+		return err
+	}
+	runCtx, run := s.registerTaskResourceCleanupRun(ctx, candidate)
+	defer s.finishTaskResourceCleanupRun(run)
+
+	claimed, err := s.resourceCleanups.MarkTaskResourceCleanupJobRunning(ctx, id)
+	if err != nil || !claimed {
+		return err
+	}
+	job, err := s.resourceCleanups.GetTaskResourceCleanupJob(runCtx, id)
+	if err != nil {
+		return err
+	}
+	if s.cleanupActivity != nil {
+		lease, acquireErr := s.cleanupActivity.AcquireTaskResourceCleanup(runCtx)
+		if acquireErr != nil {
+			return s.retryTaskResourceCleanupJob(runCtx, job, acquireErr)
+		}
+		defer lease.Release()
+	}
+	if cancelled, cancelErr := s.cancelIfTaskUnarchived(runCtx, job); cancelErr != nil || cancelled {
+		if cancelErr != nil {
+			return s.retryTaskResourceCleanupJob(runCtx, job, cancelErr)
+		}
+		return nil
+	}
+	var snapshot taskResourceCleanupSnapshot
+	if err := json.Unmarshal([]byte(job.ResourceSnapshot), &snapshot); err != nil {
+		return s.retryTaskResourceCleanupJob(runCtx, job, fmt.Errorf("decode resource snapshot: %w", err))
+	}
+	cleanupErr := s.executeTaskResourceCleanupJob(runCtx, job, snapshot)
+	if cleanupErr != nil {
+		return s.retryTaskResourceCleanupJob(runCtx, job, cleanupErr)
+	}
+	_, err = s.resourceCleanups.CompleteClaimedTaskResourceCleanupJob(
+		runCtx, job.ID, job.Attempts, models.TaskResourceCleanupStateSucceeded, "", nil,
+	)
+	return err
+}
+
+func (s *Service) registerTaskResourceCleanupRun(
+	ctx context.Context,
+	job *models.TaskResourceCleanupJob,
+) (context.Context, *taskResourceCleanupRun) {
+	runCtx, cancel := context.WithCancel(ctx)
+	run := &taskResourceCleanupRun{job: job, cancel: cancel, done: make(chan struct{})}
+	s.cleanupRunsMu.Lock()
+	if s.cleanupRuns == nil {
+		s.cleanupRuns = make(map[*taskResourceCleanupRun]struct{})
+	}
+	s.cleanupRuns[run] = struct{}{}
+	s.cleanupRunsMu.Unlock()
+	return runCtx, run
+}
+
+func (s *Service) finishTaskResourceCleanupRun(run *taskResourceCleanupRun) {
+	run.cancel()
+	s.cleanupRunsMu.Lock()
+	delete(s.cleanupRuns, run)
+	close(run.done)
+	s.cleanupRunsMu.Unlock()
+}
+
+func (s *Service) cancelAndJoinArchiveTaskResourceCleanupRuns(ctx context.Context, taskID string) error {
+	s.cleanupRunsMu.Lock()
+	runs := make([]*taskResourceCleanupRun, 0)
+	for run := range s.cleanupRuns {
+		if run.job != nil && run.job.TaskID == taskID && run.job.IsArchive() {
+			run.cancel()
+			runs = append(runs, run)
+		}
+	}
+	s.cleanupRunsMu.Unlock()
+	for _, run := range runs {
+		select {
+		case <-run.done:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return nil
+}
+
+func (s *Service) executeTaskResourceCleanupJob(
+	ctx context.Context,
+	job *models.TaskResourceCleanupJob,
+	snapshot taskResourceCleanupSnapshot,
+) error {
+	targets := restoreStopTargets(snapshot.StopTargets)
+	failedStops := s.stopTaskRuntimeTargets(ctx, job.TaskID, targets, taskResourceCleanupStopReason(job.Trigger), "task cleanup runtime stop failed")
+	if cancelled, err := s.cancelIfTaskUnarchived(ctx, job); err != nil || cancelled {
+		return err
+	}
+	errs := s.performTaskCleanup(ctx, job.TaskID, snapshot.Sessions, snapshot.Worktrees, targets,
+		taskEnvironmentCleanup{env: snapshot.TaskEnvironment, deleteRow: snapshot.DeleteEnvironmentRow}, failedStops)
+	if cause := context.Cause(ctx); cause != nil {
+		return errors.Join(append(errs, cause)...)
+	}
+	if snapshot.LegacyWorktreeCleanup && len(failedStops) == 0 && s.worktreeCleanup != nil {
+		if err := s.worktreeCleanup.OnTaskDeleted(ctx, job.TaskID); err != nil {
+			errs = append(errs, fmt.Errorf("legacy worktree cleanup: %w", err))
+		}
+	}
+	if cause := context.Cause(ctx); cause != nil {
+		return errors.Join(append(errs, cause)...)
+	}
+	s.signalCleanupDoneForTest()
+	if len(errs) == 0 && len(failedStops) == 0 {
+		return nil
+	}
+	if len(failedStops) > 0 {
+		errs = append(errs, fmt.Errorf("%d runtime stop operations failed", len(failedStops)))
+	}
+	return errors.Join(errs...)
+}
+
+func (s *Service) hasLegacyWorktreeCleanup() bool {
+	if s.worktreeCleanup == nil {
+		return false
+	}
+	_, isProvider := s.worktreeCleanup.(WorktreeProvider)
+	return !isProvider
+}
+
+func taskResourceCleanupStopReason(trigger models.TaskResourceCleanupTrigger) string {
+	switch trigger {
+	case models.TaskResourceCleanupTriggerArchive:
+		return "task archived"
+	case models.TaskResourceCleanupTriggerCascadeArchive:
+		return "cascade archive"
+	case models.TaskResourceCleanupTriggerCascadeDelete:
+		return "cascade delete"
+	default:
+		return "task deleted"
+	}
+}
+
+func (s *Service) cancelIfTaskUnarchived(ctx context.Context, job *models.TaskResourceCleanupJob) (bool, error) {
+	if !job.IsArchive() {
+		return false, nil
+	}
+	current, err := s.resourceCleanups.GetTaskResourceCleanupJob(ctx, job.ID)
+	if err != nil {
+		return false, err
+	}
+	if current.State == models.TaskResourceCleanupStateCancelled {
+		return true, nil
+	}
+	task, err := s.tasks.GetTask(ctx, job.TaskID)
+	if err != nil && !errors.Is(err, taskrepo.ErrTaskNotFound) {
+		return false, err
+	}
+	if errors.Is(err, taskrepo.ErrTaskNotFound) || task == nil || task.ArchivedAt == nil {
+		_, completeErr := s.resourceCleanups.CompleteClaimedTaskResourceCleanupJob(
+			ctx, job.ID, current.Attempts, models.TaskResourceCleanupStateCancelled, "", nil,
+		)
+		return true, completeErr
+	}
+	return false, nil
+}
+
+func (s *Service) cancelTaskResourceCleanupJob(ctx context.Context, job *models.TaskResourceCleanupJob) {
+	if job == nil || s.resourceCleanups == nil {
+		return
+	}
+	_ = s.resourceCleanups.CompleteTaskResourceCleanupJob(
+		ctx, job.ID, models.TaskResourceCleanupStateCancelled, "", nil,
+	)
+}
+
+func (s *Service) retryTaskResourceCleanupJob(ctx context.Context, job *models.TaskResourceCleanupJob, cleanupErr error) error {
+	nextAttempt := time.Now().UTC().Add(taskResourceCleanupRetryDelay)
+	_, err := s.resourceCleanups.CompleteClaimedTaskResourceCleanupJob(
+		ctx, job.ID, job.Attempts, models.TaskResourceCleanupStateRetryWait, cleanupErr.Error(), &nextAttempt,
+	)
+	if err != nil {
+		return errors.Join(cleanupErr, err)
+	}
+	return cleanupErr
+}
+
+// CancelArchiveTaskResourceCleanup cancels retryable archive cleanup before an
+// unarchive mutation makes the task active again.
+func (s *Service) CancelArchiveTaskResourceCleanup(ctx context.Context, taskID string) error {
+	if s.resourceCleanups == nil {
+		return nil
+	}
+	cancelErr := s.resourceCleanups.CancelArchiveTaskResourceCleanupJobs(ctx, taskID)
+	joinErr := s.cancelAndJoinArchiveTaskResourceCleanupRuns(ctx, taskID)
+	return errors.Join(cancelErr, joinErr)
+}
+
+// PrepareTaskResourceCleanup captures cleanup handles before a cascade mutates
+// task rows. StartPreparedTaskResourceCleanup is called only after the matching
+// lifecycle mutation commits.
+func (s *Service) PrepareTaskResourceCleanup(
+	ctx context.Context,
+	taskID string,
+	trigger models.TaskResourceCleanupTrigger,
+	operationID string,
+	deleteEnvironmentRow bool,
+) error {
+	sessions, err := s.sessions.ListTaskSessions(ctx, taskID)
+	if err != nil {
+		return fmt.Errorf("list task sessions for cleanup snapshot: %w", err)
+	}
+	stopTargets, err := s.buildStopTargets(ctx, taskID, sessions)
+	if err != nil {
+		return fmt.Errorf("list runtime cleanup inventory: %w", err)
+	}
+	worktrees, err := s.gatherWorktreesForDelete(ctx, taskID)
+	if err != nil {
+		return fmt.Errorf("list worktrees for cleanup snapshot: %w", err)
+	}
+	taskEnv, err := s.gatherTaskEnvironmentForCleanup(ctx, taskID)
+	if err != nil {
+		return fmt.Errorf("lookup task environment for cleanup snapshot: %w", err)
+	}
+	_, err = s.persistTaskResourceCleanup(ctx, taskID, trigger, operationID,
+		sessions, worktrees, stopTargets,
+		taskEnvironmentCleanup{env: taskEnv, deleteRow: deleteEnvironmentRow})
+	return err
+}
+
+func (s *Service) StartPreparedTaskResourceCleanup(ctx context.Context, operationID string) error {
+	if s.resourceCleanups == nil {
+		return nil
+	}
+	job, err := s.resourceCleanups.GetTaskResourceCleanupJobByOperationID(ctx, operationID)
+	if err != nil {
+		return err
+	}
+	s.startTaskResourceCleanup(job)
+	return nil
+}
+
+func (s *Service) CancelPreparedTaskResourceCleanup(ctx context.Context, operationID string) error {
+	if s.resourceCleanups == nil {
+		return nil
+	}
+	job, err := s.resourceCleanups.GetTaskResourceCleanupJobByOperationID(ctx, operationID)
+	if err != nil {
+		return err
+	}
+	return s.resourceCleanups.CompleteTaskResourceCleanupJob(
+		ctx, job.ID, models.TaskResourceCleanupStateCancelled, "", nil,
+	)
+}

--- a/apps/backend/internal/task/service/resource_cleanup_jobs.go
+++ b/apps/backend/internal/task/service/resource_cleanup_jobs.go
@@ -51,6 +51,7 @@ func (s *Service) persistTaskResourceCleanup(
 	worktrees []*worktree.Worktree,
 	stopTargets []taskStopTarget,
 	envCleanup taskEnvironmentCleanup,
+	prepared bool,
 ) (*models.TaskResourceCleanupJob, error) {
 	if s.resourceCleanups == nil {
 		return nil, nil
@@ -69,9 +70,13 @@ func (s *Service) persistTaskResourceCleanup(
 	if err != nil {
 		return nil, fmt.Errorf("encode task resource cleanup snapshot: %w", err)
 	}
+	state := models.TaskResourceCleanupStatePending
+	if prepared {
+		state = models.TaskResourceCleanupStatePrepared
+	}
 	job := &models.TaskResourceCleanupJob{
 		OperationID: operationID, TaskID: taskID, Trigger: trigger,
-		State: models.TaskResourceCleanupStatePending, ResourceSnapshot: string(encoded),
+		State: state, ResourceSnapshot: string(encoded),
 	}
 	if err := s.resourceCleanups.CreateTaskResourceCleanupJob(ctx, job); err != nil {
 		return nil, fmt.Errorf("persist task resource cleanup intent: %w", err)
@@ -111,16 +116,7 @@ func (s *Service) startTaskResourceCleanup(job *models.TaskResourceCleanupJob) {
 		case wake <- struct{}{}:
 		default:
 		}
-		return
 	}
-	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
-		defer cancel()
-		if err := s.processTaskResourceCleanupJob(ctx, job.ID); err != nil {
-			s.logger.Warn("task resource cleanup job failed",
-				zap.String("job_id", job.ID), zap.String("task_id", job.TaskID), zap.Error(err))
-		}
-	}()
 }
 
 // StartTaskResourceCleanupWorker owns the install-wide durable task cleanup
@@ -138,12 +134,13 @@ func (s *Service) StartTaskResourceCleanupWorker(ctx context.Context) error {
 	wake := make(chan struct{}, 1)
 	s.cleanupWorkerCancel = cancel
 	s.cleanupWorkerWake = wake
+	s.cleanupWorkerWG.Add(1)
 	s.cleanupWorkerMu.Unlock()
 	if err := s.ResumeTaskResourceCleanupJobs(workerCtx); err != nil {
+		s.cleanupWorkerWG.Done()
 		s.StopTaskResourceCleanupWorker()
 		return err
 	}
-	s.cleanupWorkerWG.Add(1)
 	go s.runTaskResourceCleanupWorker(workerCtx, wake)
 	return nil
 }
@@ -196,7 +193,8 @@ func (s *Service) processDueTaskResourceCleanupJobs(ctx context.Context) error {
 	}
 	for _, job := range jobs {
 		if err := s.processTaskResourceCleanupJob(ctx, job.ID); err != nil {
-			s.logger.Warn("resumed task resource cleanup job failed")
+			s.logger.Warn("resumed task resource cleanup job failed",
+				zap.String("job_id", job.ID), zap.String("task_id", job.TaskID), zap.Error(err))
 		}
 	}
 	return nil
@@ -377,13 +375,19 @@ func (s *Service) cancelTaskResourceCleanupJob(ctx context.Context, job *models.
 
 func (s *Service) retryTaskResourceCleanupJob(ctx context.Context, job *models.TaskResourceCleanupJob, cleanupErr error) error {
 	nextAttempt := time.Now().UTC().Add(taskResourceCleanupRetryDelay)
+	transitionCtx, cancel := detachedCleanupTransitionContext(ctx)
+	defer cancel()
 	_, err := s.resourceCleanups.CompleteClaimedTaskResourceCleanupJob(
-		ctx, job.ID, job.Attempts, models.TaskResourceCleanupStateRetryWait, cleanupErr.Error(), &nextAttempt,
+		transitionCtx, job.ID, job.Attempts, models.TaskResourceCleanupStateRetryWait, cleanupErr.Error(), &nextAttempt,
 	)
 	if err != nil {
 		return errors.Join(cleanupErr, err)
 	}
 	return cleanupErr
+}
+
+func detachedCleanupTransitionContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
 }
 
 // CancelArchiveTaskResourceCleanup cancels retryable archive cleanup before an
@@ -425,7 +429,7 @@ func (s *Service) PrepareTaskResourceCleanup(
 	}
 	_, err = s.persistTaskResourceCleanup(ctx, taskID, trigger, operationID,
 		sessions, worktrees, stopTargets,
-		taskEnvironmentCleanup{env: taskEnv, deleteRow: deleteEnvironmentRow})
+		taskEnvironmentCleanup{env: taskEnv, deleteRow: deleteEnvironmentRow}, true)
 	return err
 }
 
@@ -437,6 +441,14 @@ func (s *Service) StartPreparedTaskResourceCleanup(ctx context.Context, operatio
 	if err != nil {
 		return err
 	}
+	started, err := s.resourceCleanups.StartPreparedTaskResourceCleanupJob(ctx, job.ID)
+	if err != nil {
+		return err
+	}
+	if !started {
+		return nil
+	}
+	job.State = models.TaskResourceCleanupStatePending
 	s.startTaskResourceCleanup(job)
 	return nil
 }

--- a/apps/backend/internal/task/service/resource_cleanup_jobs.go
+++ b/apps/backend/internal/task/service/resource_cleanup_jobs.go
@@ -449,9 +449,12 @@ func (s *Service) cancelTaskResourceCleanupJob(ctx context.Context, job *models.
 	if job == nil || s.resourceCleanups == nil {
 		return
 	}
-	_ = s.resourceCleanups.CompleteTaskResourceCleanupJob(
+	if err := s.resourceCleanups.CompleteTaskResourceCleanupJob(
 		ctx, job.ID, models.TaskResourceCleanupStateCancelled, "", nil,
-	)
+	); err != nil {
+		s.logger.Warn("cancel task resource cleanup job failed",
+			zap.String("job_id", job.ID), zap.String("task_id", job.TaskID), zap.Error(err))
+	}
 }
 
 func (s *Service) retryTaskResourceCleanupJob(ctx context.Context, job *models.TaskResourceCleanupJob, cleanupErr error) error {

--- a/apps/backend/internal/task/service/resource_cleanup_jobs.go
+++ b/apps/backend/internal/task/service/resource_cleanup_jobs.go
@@ -15,7 +15,10 @@ import (
 	"github.com/kandev/kandev/internal/worktree"
 )
 
-const taskResourceCleanupRetryDelay = time.Minute
+const (
+	taskResourceCleanupRetryDelay       = time.Minute
+	preparedCleanupTransitionRetryDelay = 50 * time.Millisecond
+)
 
 type persistedTaskStopTarget struct {
 	SessionID   string `json:"session_id"`
@@ -125,6 +128,7 @@ func (s *Service) StartTaskResourceCleanupWorker(ctx context.Context) error {
 	if s.resourceCleanups == nil {
 		return nil
 	}
+	startupPreparedCutoff := time.Now().UTC()
 	s.cleanupWorkerMu.Lock()
 	if s.cleanupWorkerCancel != nil {
 		s.cleanupWorkerMu.Unlock()
@@ -136,16 +140,17 @@ func (s *Service) StartTaskResourceCleanupWorker(ctx context.Context) error {
 	s.cleanupWorkerWake = wake
 	s.cleanupWorkerWG.Add(1)
 	s.cleanupWorkerMu.Unlock()
-	if err := s.ResumeTaskResourceCleanupJobs(workerCtx); err != nil {
-		s.cleanupWorkerWG.Done()
-		s.StopTaskResourceCleanupWorker()
-		return err
-	}
-	go s.runTaskResourceCleanupWorker(workerCtx, wake)
-	return nil
+	resumeErr := s.resumeTaskResourceCleanupJobs(workerCtx, startupPreparedCutoff)
+	go s.runTaskResourceCleanupWorker(workerCtx, wake, resumeErr != nil, startupPreparedCutoff)
+	return resumeErr
 }
 
-func (s *Service) runTaskResourceCleanupWorker(ctx context.Context, wake <-chan struct{}) {
+func (s *Service) runTaskResourceCleanupWorker(
+	ctx context.Context,
+	wake <-chan struct{},
+	resumePending bool,
+	startupPreparedCutoff time.Time,
+) {
 	defer s.cleanupWorkerWG.Done()
 	ticker := time.NewTicker(taskResourceCleanupRetryDelay)
 	defer ticker.Stop()
@@ -155,6 +160,16 @@ func (s *Service) runTaskResourceCleanupWorker(ctx context.Context, wake <-chan 
 			return
 		case <-ticker.C:
 		case <-wake:
+		}
+		if resumePending {
+			if err := s.resumeTaskResourceCleanupJobs(ctx, startupPreparedCutoff); err != nil {
+				if ctx.Err() == nil {
+					s.logger.Warn("resume task resource cleanup jobs", zap.Error(err))
+				}
+				continue
+			}
+			resumePending = false
+			continue
 		}
 		if err := s.processDueTaskResourceCleanupJobs(ctx); err != nil && ctx.Err() == nil {
 			s.logger.Warn("process due task resource cleanup jobs", zap.Error(err))
@@ -177,19 +192,27 @@ func (s *Service) StopTaskResourceCleanupWorker() {
 // ResumeTaskResourceCleanupJobs reconstructs interrupted task cleanup after a
 // backend restart. It is independent of optional scheduled storage maintenance.
 func (s *Service) ResumeTaskResourceCleanupJobs(ctx context.Context) error {
+	return s.resumeTaskResourceCleanupJobs(ctx, time.Now().UTC())
+}
+
+func (s *Service) resumeTaskResourceCleanupJobs(ctx context.Context, startupPreparedCutoff time.Time) error {
 	if s.resourceCleanups == nil {
 		return nil
 	}
 	if err := s.resourceCleanups.ResetRunningTaskResourceCleanupJobs(ctx); err != nil {
 		return fmt.Errorf("reset interrupted task cleanup jobs: %w", err)
 	}
+	if err := s.reconcilePreparedTaskResourceCleanupJobs(ctx, &startupPreparedCutoff); err != nil {
+		return err
+	}
 	return s.processDueTaskResourceCleanupJobs(ctx)
 }
 
 func (s *Service) processDueTaskResourceCleanupJobs(ctx context.Context) error {
+	reconcileErr := s.reconcilePreparedTaskResourceCleanupJobs(ctx, nil)
 	jobs, err := s.resourceCleanups.ListDueTaskResourceCleanupJobs(ctx, time.Now().UTC(), 100)
 	if err != nil {
-		return fmt.Errorf("list due task cleanup jobs: %w", err)
+		return errors.Join(reconcileErr, fmt.Errorf("list due task cleanup jobs: %w", err))
 	}
 	for _, job := range jobs {
 		if err := s.processTaskResourceCleanupJob(ctx, job.ID); err != nil {
@@ -197,7 +220,65 @@ func (s *Service) processDueTaskResourceCleanupJobs(ctx context.Context) error {
 				zap.String("job_id", job.ID), zap.String("task_id", job.TaskID), zap.Error(err))
 		}
 	}
-	return nil
+	return reconcileErr
+}
+
+func (s *Service) reconcilePreparedTaskResourceCleanupJobs(
+	ctx context.Context,
+	cancelUncommittedBefore *time.Time,
+) error {
+	jobs, err := s.resourceCleanups.ListPreparedTaskResourceCleanupJobs(ctx)
+	if err != nil {
+		return fmt.Errorf("list prepared task cleanup jobs: %w", err)
+	}
+	var errs []error
+	for _, job := range jobs {
+		committed, commitErr := s.preparedTaskCleanupMutationCommitted(ctx, job)
+		if commitErr != nil {
+			errs = append(errs, fmt.Errorf("verify prepared cleanup %s: %w", job.ID, commitErr))
+			continue
+		}
+		if !committed {
+			if cancelUncommittedBefore == nil || !job.CreatedAt.Before(*cancelUncommittedBefore) {
+				continue
+			}
+			if err := s.resourceCleanups.CompleteTaskResourceCleanupJob(
+				ctx, job.ID, models.TaskResourceCleanupStateCancelled, "", nil,
+			); err != nil {
+				errs = append(errs, fmt.Errorf("cancel uncommitted prepared cleanup %s: %w", job.ID, err))
+			}
+			continue
+		}
+		if err := s.activatePreparedTaskResourceCleanupJob(ctx, job); err != nil {
+			errs = append(errs, fmt.Errorf("start committed prepared cleanup %s: %w", job.ID, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func (s *Service) preparedTaskCleanupMutationCommitted(
+	ctx context.Context,
+	job *models.TaskResourceCleanupJob,
+) (bool, error) {
+	if job == nil || s.tasks == nil {
+		return false, errors.New("task repository is unavailable")
+	}
+	task, err := s.tasks.GetTask(ctx, job.TaskID)
+	if err != nil && !errors.Is(err, taskrepo.ErrTaskNotFound) {
+		return false, err
+	}
+	taskExists := err == nil && task != nil
+	switch job.Trigger {
+	case models.TaskResourceCleanupTriggerArchive, models.TaskResourceCleanupTriggerCascadeArchive:
+		return taskExists && task.ArchivedAt != nil, nil
+	case models.TaskResourceCleanupTriggerDelete,
+		models.TaskResourceCleanupTriggerCascadeDelete,
+		models.TaskResourceCleanupTriggerWorkspaceDelete,
+		models.TaskResourceCleanupTriggerQuickChatExpire:
+		return !taskExists, nil
+	default:
+		return false, nil
+	}
 }
 
 func (s *Service) processTaskResourceCleanupJob(ctx context.Context, id string) error {
@@ -437,16 +518,35 @@ func (s *Service) StartPreparedTaskResourceCleanup(ctx context.Context, operatio
 	if s.resourceCleanups == nil {
 		return nil
 	}
-	job, err := s.resourceCleanups.GetTaskResourceCleanupJobByOperationID(ctx, operationID)
-	if err != nil {
-		return err
+	transitionCtx, cancel := detachedCleanupTransitionContext(ctx)
+	defer cancel()
+	var lastErr error
+	for {
+		job, err := s.resourceCleanups.GetTaskResourceCleanupJobByOperationID(transitionCtx, operationID)
+		if err == nil {
+			err = s.activatePreparedTaskResourceCleanupJob(transitionCtx, job)
+			if err == nil {
+				return nil
+			}
+		}
+		lastErr = err
+		timer := time.NewTimer(preparedCleanupTransitionRetryDelay)
+		select {
+		case <-transitionCtx.Done():
+			timer.Stop()
+			return errors.Join(lastErr, transitionCtx.Err())
+		case <-timer.C:
+		}
 	}
+}
+
+func (s *Service) activatePreparedTaskResourceCleanupJob(
+	ctx context.Context,
+	job *models.TaskResourceCleanupJob,
+) error {
 	started, err := s.resourceCleanups.StartPreparedTaskResourceCleanupJob(ctx, job.ID)
-	if err != nil {
+	if err != nil || !started {
 		return err
-	}
-	if !started {
-		return nil
 	}
 	job.State = models.TaskResourceCleanupStatePending
 	s.startTaskResourceCleanup(job)

--- a/apps/backend/internal/task/service/resource_cleanup_jobs.go
+++ b/apps/backend/internal/task/service/resource_cleanup_jobs.go
@@ -314,6 +314,7 @@ func (s *Service) processTaskResourceCleanupJob(ctx context.Context, id string) 
 	if err := json.Unmarshal([]byte(job.ResourceSnapshot), &snapshot); err != nil {
 		return s.retryTaskResourceCleanupJob(runCtx, job, fmt.Errorf("decode resource snapshot: %w", err))
 	}
+	defer s.signalCleanupDoneForTest()
 	cleanupErr := s.executeTaskResourceCleanupJob(runCtx, job, snapshot)
 	if cleanupErr != nil {
 		return s.retryTaskResourceCleanupJob(runCtx, job, cleanupErr)
@@ -390,7 +391,6 @@ func (s *Service) executeTaskResourceCleanupJob(
 	if cause := context.Cause(ctx); cause != nil {
 		return errors.Join(append(errs, cause)...)
 	}
-	s.signalCleanupDoneForTest()
 	if len(errs) == 0 && len(failedStops) == 0 {
 		return nil
 	}

--- a/apps/backend/internal/task/service/resource_cleanup_jobs_test.go
+++ b/apps/backend/internal/task/service/resource_cleanup_jobs_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kandev/kandev/internal/agent/runtime/activity"
 	"github.com/kandev/kandev/internal/agentruntime"
 	"github.com/kandev/kandev/internal/task/models"
+	"github.com/kandev/kandev/internal/task/repository"
 	"github.com/kandev/kandev/internal/worktree"
 )
 
@@ -21,6 +22,33 @@ type cancellableCleanupBarrier struct {
 	stopped chan struct{}
 	release chan struct{}
 	once    sync.Once
+}
+
+type joinCleanupBarrier struct {
+	started   chan struct{}
+	cancelled chan struct{}
+	release   chan struct{}
+	stopped   chan struct{}
+}
+
+func newJoinCleanupBarrier() *joinCleanupBarrier {
+	return &joinCleanupBarrier{
+		started: make(chan struct{}), cancelled: make(chan struct{}),
+		release: make(chan struct{}), stopped: make(chan struct{}),
+	}
+}
+
+func (b *joinCleanupBarrier) OnTaskDeleted(context.Context, string) error { return nil }
+func (b *joinCleanupBarrier) GetAllByTaskID(context.Context, string) ([]*worktree.Worktree, error) {
+	return nil, nil
+}
+func (b *joinCleanupBarrier) CleanupWorktrees(ctx context.Context, _ []*worktree.Worktree) error {
+	close(b.started)
+	<-ctx.Done()
+	close(b.cancelled)
+	<-b.release
+	close(b.stopped)
+	return ctx.Err()
 }
 
 type recordingLegacyCleanup struct {
@@ -64,6 +92,18 @@ type activityCleanupBarrier struct {
 	started        chan struct{}
 	release        chan struct{}
 	maintenanceErr chan error
+}
+
+type blockingResumeCleanupRepository struct {
+	repository.TaskResourceCleanupRepository
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (r *blockingResumeCleanupRepository) ResetRunningTaskResourceCleanupJobs(context.Context) error {
+	close(r.entered)
+	<-r.release
+	return nil
 }
 
 func (b *activityCleanupBarrier) OnTaskDeleted(context.Context, string) error { return nil }
@@ -199,7 +239,7 @@ func TestUnarchiveCancelsAndJoinsClaimedArchiveCleanup(t *testing.T) {
 	if err := repo.CreateTaskResourceCleanupJob(ctx, job); err != nil {
 		t.Fatalf("CreateTaskResourceCleanupJob: %v", err)
 	}
-	barrier := newCancellableCleanupBarrier()
+	barrier := newJoinCleanupBarrier()
 	taskSvc.SetWorktreeCleanup(barrier)
 	processDone := make(chan error, 1)
 	go func() { processDone <- taskSvc.processTaskResourceCleanupJob(ctx, job.ID) }()
@@ -211,22 +251,46 @@ func TestUnarchiveCancelsAndJoinsClaimedArchiveCleanup(t *testing.T) {
 
 	handoff := NewHandoffService(repo, repo, nil, nil, nil, nil)
 	handoff.SetTaskResourceCleaner(taskSvc)
-	_, unarchiveErr := handoff.UnarchiveTaskTree(ctx, task.ID)
-
-	joined := false
+	type unarchiveResult struct {
+		outcome *CascadeOutcome
+		err     error
+	}
+	unarchiveDone := make(chan unarchiveResult, 1)
+	go func() {
+		outcome, err := handoff.UnarchiveTaskTree(ctx, task.ID)
+		unarchiveDone <- unarchiveResult{outcome: outcome, err: err}
+	}()
+	select {
+	case <-barrier.cancelled:
+	case <-time.After(time.Second):
+		t.Fatal("cleanup did not observe unarchive cancellation")
+	}
+	select {
+	case result := <-unarchiveDone:
+		t.Fatalf("unarchive returned before claimed cleanup joined: outcome=%#v err=%v", result.outcome, result.err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(barrier.release)
 	select {
 	case <-barrier.stopped:
-		joined = true
-	default:
-		close(barrier.release)
-		<-barrier.stopped
+	case <-time.After(time.Second):
+		t.Fatal("cleanup did not stop after release")
 	}
-	processErr := <-processDone
+	var unarchiveErr error
+	select {
+	case result := <-unarchiveDone:
+		unarchiveErr = result.err
+	case <-time.After(time.Second):
+		t.Fatal("unarchive did not return after cleanup joined")
+	}
 	if unarchiveErr != nil {
 		t.Fatalf("UnarchiveTaskTree: %v", unarchiveErr)
 	}
-	if !joined {
-		t.Error("unarchive returned before the claimed destructive cleanup was cancelled and joined")
+	var processErr error
+	select {
+	case processErr = <-processDone:
+	case <-time.After(time.Second):
+		t.Fatal("cleanup processor did not return after release")
 	}
 	if processErr != nil && !errors.Is(processErr, context.Canceled) {
 		t.Fatalf("cleanup worker error = %v, want nil or context cancellation", processErr)
@@ -563,6 +627,189 @@ func TestCascadeDeletePersistsCleanupBeforeTaskMutation(t *testing.T) {
 	if _, err := handoff.DeleteTaskTree(ctx, task.ID, false); err != nil {
 		t.Fatalf("DeleteTaskTree: %v", err)
 	}
+}
+
+func TestPreparedCleanupIsNotRunnableUntilStarted(t *testing.T) {
+	taskSvc, repo := setupOfficeTest(t)
+	ctx := context.Background()
+	seedCleanupTaskAndSession(t, repo, "task-prepared", "session-prepared")
+	const operationID = "cascade_delete:cascade-1:task-prepared"
+
+	if err := taskSvc.PrepareTaskResourceCleanup(ctx, "task-prepared",
+		models.TaskResourceCleanupTriggerCascadeDelete, operationID, true); err != nil {
+		t.Fatalf("PrepareTaskResourceCleanup: %v", err)
+	}
+	prepared, err := repo.GetTaskResourceCleanupJobByOperationID(ctx, operationID)
+	if err != nil {
+		t.Fatalf("GetTaskResourceCleanupJobByOperationID: %v", err)
+	}
+	if prepared.State != models.TaskResourceCleanupState("prepared") {
+		t.Fatalf("prepared state = %q, want prepared", prepared.State)
+	}
+	due, err := repo.ListDueTaskResourceCleanupJobs(ctx, time.Now().UTC(), 10)
+	if err != nil {
+		t.Fatalf("ListDueTaskResourceCleanupJobs: %v", err)
+	}
+	if len(due) != 0 {
+		t.Fatalf("prepared cleanup was runnable: %#v", due)
+	}
+
+	taskSvc.cleanupWorkerMu.Lock()
+	taskSvc.cleanupWorkerWake = make(chan struct{}, 1)
+	taskSvc.cleanupWorkerMu.Unlock()
+	if err := taskSvc.StartPreparedTaskResourceCleanup(ctx, operationID); err != nil {
+		t.Fatalf("StartPreparedTaskResourceCleanup: %v", err)
+	}
+	started, err := repo.GetTaskResourceCleanupJobByOperationID(ctx, operationID)
+	if err != nil {
+		t.Fatalf("reload started cleanup: %v", err)
+	}
+	if started.State != models.TaskResourceCleanupStatePending {
+		t.Fatalf("started state = %q, want pending", started.State)
+	}
+}
+
+func TestRetryTaskResourceCleanupJobPersistsAfterRunContextCancellation(t *testing.T) {
+	taskSvc, repo := setupOfficeTest(t)
+	ctx := context.Background()
+	job := &models.TaskResourceCleanupJob{
+		ID: "timed-out-job", OperationID: "delete:timed-out", TaskID: "task-timed-out",
+		Trigger: models.TaskResourceCleanupTriggerDelete,
+		State:   models.TaskResourceCleanupStatePending, ResourceSnapshot: `{}`,
+	}
+	if err := repo.CreateTaskResourceCleanupJob(ctx, job); err != nil {
+		t.Fatalf("CreateTaskResourceCleanupJob: %v", err)
+	}
+	claimed, err := repo.MarkTaskResourceCleanupJobRunning(ctx, job.ID)
+	if err != nil || !claimed {
+		t.Fatalf("MarkTaskResourceCleanupJobRunning = %v, %v", claimed, err)
+	}
+	job, err = repo.GetTaskResourceCleanupJob(ctx, job.ID)
+	if err != nil {
+		t.Fatalf("GetTaskResourceCleanupJob: %v", err)
+	}
+	runCtx, cancel := context.WithCancel(ctx)
+	cancel()
+	cleanupErr := errors.New("cleanup deadline exceeded")
+	if err := taskSvc.retryTaskResourceCleanupJob(runCtx, job, cleanupErr); !errors.Is(err, cleanupErr) {
+		t.Fatalf("retryTaskResourceCleanupJob error = %v, want cleanup error", err)
+	}
+	got, err := repo.GetTaskResourceCleanupJob(ctx, job.ID)
+	if err != nil {
+		t.Fatalf("reload cleanup job: %v", err)
+	}
+	if got.State != models.TaskResourceCleanupStateRetryWait {
+		t.Fatalf("cleanup state = %q, want retry_wait", got.State)
+	}
+}
+
+func TestCancelWorkspaceDeleteCleanupUsesDetachedContext(t *testing.T) {
+	taskSvc, repo := setupOfficeTest(t)
+	ctx := context.Background()
+	job := &models.TaskResourceCleanupJob{
+		ID: "workspace-delete-cancel", OperationID: "workspace_delete:cancel", TaskID: "task-cancel",
+		Trigger: models.TaskResourceCleanupTriggerWorkspaceDelete,
+		State:   models.TaskResourceCleanupState("prepared"), ResourceSnapshot: `{}`,
+	}
+	if err := repo.CreateTaskResourceCleanupJob(ctx, job); err != nil {
+		t.Fatalf("CreateTaskResourceCleanupJob: %v", err)
+	}
+	cancelledCtx, cancel := context.WithCancel(ctx)
+	cancel()
+	taskSvc.cancelWorkspaceDeleteTaskCleanupJobs(cancelledCtx, []workspaceDeleteTaskCleanup{{cleanupJob: job}})
+	got, err := repo.GetTaskResourceCleanupJob(ctx, job.ID)
+	if err != nil {
+		t.Fatalf("GetTaskResourceCleanupJob: %v", err)
+	}
+	if got.State != models.TaskResourceCleanupStateCancelled {
+		t.Fatalf("cleanup state = %q, want cancelled", got.State)
+	}
+}
+
+func TestStopTaskResourceCleanupWorkerJoinsStartupResume(t *testing.T) {
+	taskSvc, _ := setupOfficeTest(t)
+	taskSvc.StopTaskResourceCleanupWorker()
+	blocking := &blockingResumeCleanupRepository{
+		TaskResourceCleanupRepository: taskSvc.resourceCleanups,
+		entered:                       make(chan struct{}), release: make(chan struct{}),
+	}
+	taskSvc.resourceCleanups = blocking
+	startDone := make(chan error, 1)
+	go func() { startDone <- taskSvc.StartTaskResourceCleanupWorker(context.Background()) }()
+	<-blocking.entered
+	stopDone := make(chan struct{})
+	go func() {
+		taskSvc.StopTaskResourceCleanupWorker()
+		close(stopDone)
+	}()
+	select {
+	case <-stopDone:
+		t.Fatal("StopTaskResourceCleanupWorker returned before startup resume drained")
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(blocking.release)
+	select {
+	case <-stopDone:
+	case <-time.After(time.Second):
+		t.Fatal("StopTaskResourceCleanupWorker did not return after startup resume drained")
+	}
+	if err := <-startDone; err == nil {
+		t.Fatal("StartTaskResourceCleanupWorker succeeded after concurrent stop")
+	}
+}
+
+func TestStartTaskResourceCleanupLeavesPendingJobForOwnedWorker(t *testing.T) {
+	taskSvc, repo := setupOfficeTest(t)
+	taskSvc.StopTaskResourceCleanupWorker()
+	ctx := context.Background()
+	snapshot, err := json.Marshal(taskResourceCleanupSnapshot{
+		Worktrees: []*worktree.Worktree{{ID: "worktree-owned-worker", TaskID: "task-owned-worker"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	job := &models.TaskResourceCleanupJob{
+		ID: "job-owned-worker", OperationID: "delete:owned-worker", TaskID: "task-owned-worker",
+		Trigger: models.TaskResourceCleanupTriggerDelete,
+		State:   models.TaskResourceCleanupStatePending, ResourceSnapshot: string(snapshot),
+	}
+	if err := repo.CreateTaskResourceCleanupJob(ctx, job); err != nil {
+		t.Fatalf("CreateTaskResourceCleanupJob: %v", err)
+	}
+	barrier := newCancellableCleanupBarrier()
+	taskSvc.SetWorktreeCleanup(barrier)
+
+	taskSvc.startTaskResourceCleanup(job)
+	select {
+	case <-barrier.started:
+		close(barrier.release)
+		<-barrier.stopped
+		t.Fatal("cleanup ran in an unowned fallback goroutine")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	startDone := make(chan error, 1)
+	go func() { startDone <- taskSvc.StartTaskResourceCleanupWorker(ctx) }()
+	select {
+	case <-barrier.started:
+	case <-time.After(time.Second):
+		t.Fatal("owned cleanup worker did not process pending job")
+	}
+	close(barrier.release)
+	select {
+	case <-barrier.stopped:
+	case <-time.After(time.Second):
+		t.Fatal("owned cleanup worker did not finish job")
+	}
+	select {
+	case err := <-startDone:
+		if err != nil {
+			t.Fatalf("StartTaskResourceCleanupWorker: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("StartTaskResourceCleanupWorker did not return")
+	}
+	taskSvc.StopTaskResourceCleanupWorker()
 }
 
 func seedCleanupTaskAndSession(t *testing.T, repo interface {

--- a/apps/backend/internal/task/service/resource_cleanup_jobs_test.go
+++ b/apps/backend/internal/task/service/resource_cleanup_jobs_test.go
@@ -1,0 +1,590 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/agent/runtime/activity"
+	"github.com/kandev/kandev/internal/agentruntime"
+	"github.com/kandev/kandev/internal/task/models"
+	"github.com/kandev/kandev/internal/worktree"
+)
+
+type cancellableCleanupBarrier struct {
+	started chan struct{}
+	stopped chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+type recordingLegacyCleanup struct {
+	calls int
+}
+
+func (c *recordingLegacyCleanup) OnTaskDeleted(context.Context, string) error {
+	c.calls++
+	return nil
+}
+
+type activityCleanupStopper struct {
+	coordinator *activity.Coordinator
+}
+
+type coordinatorCleanupActivityGate struct {
+	coordinator *activity.Coordinator
+}
+
+func (g coordinatorCleanupActivityGate) AcquireTaskResourceCleanup(
+	ctx context.Context,
+) (TaskResourceCleanupActivityLease, error) {
+	return g.coordinator.AcquireTask(ctx, activity.KindCleanupScript)
+}
+
+func (s *activityCleanupStopper) StopTask(context.Context, string, string, bool) error { return nil }
+func (s *activityCleanupStopper) StopSession(context.Context, string, string, bool) error {
+	return nil
+}
+func (s *activityCleanupStopper) StopExecution(ctx context.Context, _ string, _ string, _ bool) error {
+	lease, err := s.coordinator.AcquireTask(ctx, activity.KindExecutionStopping)
+	if err != nil {
+		return err
+	}
+	lease.Release()
+	return nil
+}
+
+type activityCleanupBarrier struct {
+	coordinator    *activity.Coordinator
+	started        chan struct{}
+	release        chan struct{}
+	maintenanceErr chan error
+}
+
+func (b *activityCleanupBarrier) OnTaskDeleted(context.Context, string) error { return nil }
+func (b *activityCleanupBarrier) GetAllByTaskID(context.Context, string) ([]*worktree.Worktree, error) {
+	return nil, nil
+}
+func (b *activityCleanupBarrier) CleanupWorktrees(ctx context.Context, _ []*worktree.Worktree) error {
+	close(b.started)
+	lease, _, err := b.coordinator.TryAcquireMaintenance(context.Background(), 0)
+	if lease != nil {
+		lease.Release()
+	}
+	b.maintenanceErr <- err
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-b.release:
+		return nil
+	}
+}
+
+func TestClaimedCleanupDrainsMaintenanceAndHoldsActivityThroughDestructiveWork(t *testing.T) {
+	taskSvc, repo := setupOfficeTest(t)
+	coordinator := activity.NewCoordinator(activity.Options{})
+	maintenance, _, err := coordinator.TryAcquireMaintenance(context.Background(), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	barrier := &activityCleanupBarrier{
+		coordinator: coordinator, started: make(chan struct{}), release: make(chan struct{}),
+		maintenanceErr: make(chan error, 1),
+	}
+	taskSvc.SetExecutionStopper(&activityCleanupStopper{coordinator: coordinator})
+	taskSvc.SetTaskResourceCleanupActivityGate(coordinatorCleanupActivityGate{coordinator: coordinator})
+	taskSvc.SetWorktreeCleanup(barrier)
+	snapshot, err := json.Marshal(taskResourceCleanupSnapshot{
+		StopTargets: []persistedTaskStopTarget{{SessionID: "session-1", ExecutionID: "execution-1"}},
+		Worktrees:   []*worktree.Worktree{{ID: "worktree-1", TaskID: "task-1"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	job := &models.TaskResourceCleanupJob{
+		ID: "activity-cleanup", OperationID: "delete:activity-cleanup", TaskID: "task-1",
+		Trigger: models.TaskResourceCleanupTriggerDelete,
+		State:   models.TaskResourceCleanupStatePending, ResourceSnapshot: string(snapshot),
+	}
+	if err := repo.CreateTaskResourceCleanupJob(context.Background(), job); err != nil {
+		t.Fatal(err)
+	}
+	processDone := make(chan error, 1)
+	go func() { processDone <- taskSvc.processTaskResourceCleanupJob(context.Background(), job.ID) }()
+	select {
+	case <-maintenance.Context().Done():
+	case <-time.After(time.Second):
+		t.Fatal("claimed cleanup did not cancel active maintenance")
+	}
+	select {
+	case <-barrier.started:
+		t.Fatal("destructive cleanup started before maintenance drained")
+	default:
+	}
+	maintenance.Release()
+	select {
+	case <-barrier.started:
+	case <-time.After(time.Second):
+		t.Fatal("destructive cleanup did not start after maintenance drained")
+	}
+	if err := <-barrier.maintenanceErr; !errors.Is(err, activity.ErrBusy) {
+		t.Fatalf("maintenance during destructive cleanup error = %v, want ErrBusy", err)
+	}
+	close(barrier.release)
+	if err := <-processDone; err != nil {
+		t.Fatalf("processTaskResourceCleanupJob: %v", err)
+	}
+	lease, _, err := coordinator.TryAcquireMaintenance(context.Background(), 0)
+	if err != nil {
+		t.Fatalf("cleanup activity lease was not released: %v", err)
+	}
+	lease.Release()
+}
+
+func newCancellableCleanupBarrier() *cancellableCleanupBarrier {
+	return &cancellableCleanupBarrier{
+		started: make(chan struct{}),
+		stopped: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+}
+
+func (c *cancellableCleanupBarrier) OnTaskDeleted(context.Context, string) error { return nil }
+
+func (c *cancellableCleanupBarrier) GetAllByTaskID(context.Context, string) ([]*worktree.Worktree, error) {
+	return nil, nil
+}
+
+func (c *cancellableCleanupBarrier) CleanupWorktrees(ctx context.Context, _ []*worktree.Worktree) error {
+	c.once.Do(func() { close(c.started) })
+	defer close(c.stopped)
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-c.release:
+		return nil
+	}
+}
+
+func TestUnarchiveCancelsAndJoinsClaimedArchiveCleanup(t *testing.T) {
+	taskSvc, repo := setupOfficeTest(t)
+	ctx := context.Background()
+	coordinator := activity.NewCoordinator(activity.Options{})
+	taskSvc.SetTaskResourceCleanupActivityGate(coordinatorCleanupActivityGate{coordinator: coordinator})
+	task, err := taskSvc.CreateTask(ctx, &CreateTaskRequest{
+		WorkspaceID: "ws-1", Title: "Archived task", ProjectID: "proj-1",
+	})
+	if err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	if err := repo.ArchiveTask(ctx, task.ID); err != nil {
+		t.Fatalf("ArchiveTask: %v", err)
+	}
+	snapshot, err := json.Marshal(taskResourceCleanupSnapshot{
+		Worktrees: []*worktree.Worktree{{ID: "worktree-claimed", TaskID: task.ID}},
+	})
+	if err != nil {
+		t.Fatalf("marshal cleanup snapshot: %v", err)
+	}
+	job := &models.TaskResourceCleanupJob{
+		ID: "archive-job-claimed", OperationID: "archive:" + task.ID,
+		TaskID: task.ID, Trigger: models.TaskResourceCleanupTriggerArchive,
+		State: models.TaskResourceCleanupStatePending, ResourceSnapshot: string(snapshot),
+	}
+	if err := repo.CreateTaskResourceCleanupJob(ctx, job); err != nil {
+		t.Fatalf("CreateTaskResourceCleanupJob: %v", err)
+	}
+	barrier := newCancellableCleanupBarrier()
+	taskSvc.SetWorktreeCleanup(barrier)
+	processDone := make(chan error, 1)
+	go func() { processDone <- taskSvc.processTaskResourceCleanupJob(ctx, job.ID) }()
+	select {
+	case <-barrier.started:
+	case <-time.After(time.Second):
+		t.Fatal("cleanup did not reach the post-claim barrier")
+	}
+
+	handoff := NewHandoffService(repo, repo, nil, nil, nil, nil)
+	handoff.SetTaskResourceCleaner(taskSvc)
+	_, unarchiveErr := handoff.UnarchiveTaskTree(ctx, task.ID)
+
+	joined := false
+	select {
+	case <-barrier.stopped:
+		joined = true
+	default:
+		close(barrier.release)
+		<-barrier.stopped
+	}
+	processErr := <-processDone
+	if unarchiveErr != nil {
+		t.Fatalf("UnarchiveTaskTree: %v", unarchiveErr)
+	}
+	if !joined {
+		t.Error("unarchive returned before the claimed destructive cleanup was cancelled and joined")
+	}
+	if processErr != nil && !errors.Is(processErr, context.Canceled) {
+		t.Fatalf("cleanup worker error = %v, want nil or context cancellation", processErr)
+	}
+	got, err := repo.GetTaskResourceCleanupJob(ctx, job.ID)
+	if err != nil {
+		t.Fatalf("GetTaskResourceCleanupJob: %v", err)
+	}
+	if got.State != models.TaskResourceCleanupStateCancelled {
+		t.Fatalf("cleanup state = %q, want cancelled", got.State)
+	}
+	if got.Attempts != 1 {
+		t.Fatalf("cleanup attempts = %d, want claimed generation 1 preserved", got.Attempts)
+	}
+	lease, _, err := coordinator.TryAcquireMaintenance(ctx, 0)
+	if err != nil {
+		t.Fatalf("cancelled cleanup activity lease was not released: %v", err)
+	}
+	lease.Release()
+}
+
+func TestUnarchiveCancellationPreservesCleanupResourcesAfterBlockedCleaner(t *testing.T) {
+	taskSvc, repo := setupOfficeTest(t)
+	ctx := context.Background()
+	task, err := taskSvc.CreateTask(ctx, &CreateTaskRequest{
+		WorkspaceID: "ws-1", Title: "Archived task", ProjectID: "proj-1",
+	})
+	if err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	const sessionID = "session-cancel-boundary"
+	if err := repo.CreateTaskSession(ctx, &models.TaskSession{
+		ID: sessionID, TaskID: task.ID, State: models.TaskSessionStateCompleted,
+	}); err != nil {
+		t.Fatalf("CreateTaskSession: %v", err)
+	}
+	if err := repo.UpsertExecutorRunning(ctx, &models.ExecutorRunning{
+		ID: sessionID, SessionID: sessionID, TaskID: task.ID, ExecutorID: "executor-1",
+		Runtime: agentruntime.RuntimeStandalone, Status: models.ExecutorRunningStatusStarting,
+	}); err != nil {
+		t.Fatalf("UpsertExecutorRunning: %v", err)
+	}
+	quickChatRoot := t.TempDir()
+	taskSvc.SetQuickChatDir(quickChatRoot)
+	sessionDir := filepath.Join(quickChatRoot, sessionID)
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+		t.Fatalf("create quick-chat session directory: %v", err)
+	}
+	if err := repo.ArchiveTask(ctx, task.ID); err != nil {
+		t.Fatalf("ArchiveTask: %v", err)
+	}
+	snapshot, err := json.Marshal(taskResourceCleanupSnapshot{
+		Sessions:  []*models.TaskSession{{ID: sessionID, TaskID: task.ID}},
+		Worktrees: []*worktree.Worktree{{ID: "worktree-cancel-boundary", TaskID: task.ID}},
+	})
+	if err != nil {
+		t.Fatalf("marshal cleanup snapshot: %v", err)
+	}
+	job := &models.TaskResourceCleanupJob{
+		ID: "archive-job-cancel-boundary", OperationID: "archive:" + task.ID,
+		TaskID: task.ID, Trigger: models.TaskResourceCleanupTriggerArchive,
+		State: models.TaskResourceCleanupStatePending, ResourceSnapshot: string(snapshot),
+	}
+	if err := repo.CreateTaskResourceCleanupJob(ctx, job); err != nil {
+		t.Fatalf("CreateTaskResourceCleanupJob: %v", err)
+	}
+	barrier := newCancellableCleanupBarrier()
+	taskSvc.SetWorktreeCleanup(barrier)
+	processDone := make(chan error, 1)
+	go func() { processDone <- taskSvc.processTaskResourceCleanupJob(ctx, job.ID) }()
+	select {
+	case <-barrier.started:
+	case <-time.After(time.Second):
+		t.Fatal("cleanup did not reach the blocked worktree cleaner")
+	}
+
+	handoff := NewHandoffService(repo, repo, nil, nil, nil, nil)
+	handoff.SetTaskResourceCleaner(taskSvc)
+	if _, err := handoff.UnarchiveTaskTree(ctx, task.ID); err != nil {
+		t.Fatalf("UnarchiveTaskTree: %v", err)
+	}
+	if err := <-processDone; err != nil && !errors.Is(err, context.Canceled) {
+		t.Fatalf("cleanup worker error = %v, want nil or context cancellation", err)
+	}
+	if _, err := os.Stat(sessionDir); err != nil {
+		t.Fatalf("quick-chat session directory removed after cancellation: %v", err)
+	}
+	if _, err := repo.GetExecutorRunningBySessionID(ctx, sessionID); err != nil {
+		t.Fatalf("executor runtime row removed after cancellation: %v", err)
+	}
+	got, err := repo.GetTaskResourceCleanupJob(ctx, job.ID)
+	if err != nil {
+		t.Fatalf("GetTaskResourceCleanupJob: %v", err)
+	}
+	if got.State != models.TaskResourceCleanupStateCancelled {
+		t.Fatalf("cleanup state = %q, want cancelled", got.State)
+	}
+}
+
+func TestExecuteTaskResourceCleanupJob_CancellationSkipsLegacyCleanup(t *testing.T) {
+	taskSvc, _, _ := createTestService(t)
+	legacy := &recordingLegacyCleanup{}
+	taskSvc.SetWorktreeCleanup(legacy)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := taskSvc.executeTaskResourceCleanupJob(ctx, &models.TaskResourceCleanupJob{
+		ID: "delete-job-cancelled", TaskID: "task-cancelled",
+		Trigger: models.TaskResourceCleanupTriggerDelete,
+	}, taskResourceCleanupSnapshot{LegacyWorktreeCleanup: true})
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("cleanup error = %v, want context cancellation", err)
+	}
+	if legacy.calls != 0 {
+		t.Fatalf("legacy cleanup calls after cancellation = %d, want 0", legacy.calls)
+	}
+}
+
+func TestPerformTaskCleanup_CancellationStopsBeforeWorktreeCleanup(t *testing.T) {
+	taskSvc, _, _ := createTestService(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	taskSvc.SetEnvironmentDestroyer(&stubDestroyer{cancelAfterContainer: cancel})
+	barrier := newCancellableCleanupBarrier()
+	taskSvc.SetWorktreeCleanup(barrier)
+
+	errs := taskSvc.performTaskCleanup(ctx, "task-cancelled", nil,
+		[]*worktree.Worktree{{ID: "worktree-after-environment", TaskID: "task-cancelled"}}, nil,
+		taskEnvironmentCleanup{env: &models.TaskEnvironment{ContainerID: "container-1"}}, nil)
+
+	if !errors.Is(errors.Join(errs...), context.Canceled) {
+		t.Fatalf("cleanup errors = %v, want context cancellation", errs)
+	}
+	select {
+	case <-barrier.started:
+		t.Fatal("worktree cleanup started after environment teardown cancelled")
+	default:
+	}
+}
+
+func TestUnarchiveTaskTreeCancelsPendingArchiveCleanup(t *testing.T) {
+	taskSvc, repo := setupOfficeTest(t)
+	ctx := context.Background()
+	task, err := taskSvc.CreateTask(ctx, &CreateTaskRequest{
+		WorkspaceID: "ws-1", Title: "Archived task", ProjectID: "proj-1",
+	})
+	if err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	if err := repo.ArchiveTask(ctx, task.ID); err != nil {
+		t.Fatalf("ArchiveTask: %v", err)
+	}
+	job := &models.TaskResourceCleanupJob{
+		ID: "archive-job", OperationID: "archive:" + task.ID, TaskID: task.ID,
+		Trigger: models.TaskResourceCleanupTriggerArchive,
+		State:   models.TaskResourceCleanupStatePending, ResourceSnapshot: `{}`,
+	}
+	if err := repo.CreateTaskResourceCleanupJob(ctx, job); err != nil {
+		t.Fatalf("CreateTaskResourceCleanupJob: %v", err)
+	}
+
+	handoff := NewHandoffService(repo, repo, nil, nil, nil, nil)
+	handoff.SetTaskResourceCleaner(taskSvc)
+	if _, err := handoff.UnarchiveTaskTree(ctx, task.ID); err != nil {
+		t.Fatalf("UnarchiveTaskTree: %v", err)
+	}
+	got, err := repo.GetTaskResourceCleanupJob(ctx, job.ID)
+	if err != nil {
+		t.Fatalf("GetTaskResourceCleanupJob: %v", err)
+	}
+	if got.State != models.TaskResourceCleanupStateCancelled {
+		t.Fatalf("cleanup state = %q, want cancelled", got.State)
+	}
+}
+
+func TestResumeTaskResourceCleanupJobsReconstructsInterruptedJob(t *testing.T) {
+	svc, _, repo := createTestService(t)
+	ctx := context.Background()
+	job := &models.TaskResourceCleanupJob{
+		ID: "interrupted-job", OperationID: "delete:interrupted", TaskID: "deleted-task",
+		Trigger: models.TaskResourceCleanupTriggerDelete,
+		State:   models.TaskResourceCleanupStateRunning, ResourceSnapshot: `{}`,
+	}
+	if err := repo.CreateTaskResourceCleanupJob(ctx, job); err != nil {
+		t.Fatalf("CreateTaskResourceCleanupJob: %v", err)
+	}
+	if err := svc.ResumeTaskResourceCleanupJobs(ctx); err != nil {
+		t.Fatalf("ResumeTaskResourceCleanupJobs: %v", err)
+	}
+	got, err := repo.GetTaskResourceCleanupJob(ctx, job.ID)
+	if err != nil {
+		t.Fatalf("GetTaskResourceCleanupJob: %v", err)
+	}
+	if got.State != models.TaskResourceCleanupStateSucceeded || got.Attempts != 1 {
+		t.Fatalf("reconstructed job = state %q attempts %d, want succeeded/1", got.State, got.Attempts)
+	}
+}
+
+func TestDeleteTaskCleanupSnapshotSurvivesSessionCascade(t *testing.T) {
+	svc, _, repo := createTestService(t)
+	ctx := context.Background()
+	seedCleanupTaskAndSession(t, repo, "task-delete-snapshot", "session-delete-snapshot")
+	if err := svc.DeleteTask(ctx, "task-delete-snapshot"); err != nil {
+		t.Fatalf("DeleteTask: %v", err)
+	}
+	var encoded string
+	if err := repo.DB().QueryRowContext(ctx, `
+		SELECT resource_snapshot FROM task_resource_cleanup_jobs
+		WHERE task_id = ? AND trigger = 'delete'
+	`, "task-delete-snapshot").Scan(&encoded); err != nil {
+		t.Fatalf("load delete snapshot: %v", err)
+	}
+	var snapshot taskResourceCleanupSnapshot
+	if err := json.Unmarshal([]byte(encoded), &snapshot); err != nil {
+		t.Fatalf("decode snapshot: %v", err)
+	}
+	if len(snapshot.Sessions) != 1 || snapshot.Sessions[0].ID != "session-delete-snapshot" {
+		t.Fatalf("snapshot sessions = %#v, want deleted session handle", snapshot.Sessions)
+	}
+}
+
+func TestArchiveCleanupPreservesHistoricalWorktreeBranchMetadata(t *testing.T) {
+	svc, _, repo := createTestService(t)
+	ctx := context.Background()
+	seedCleanupTaskAndSession(t, repo, "task-history", "session-history")
+	if err := repo.CreateTaskSessionWorktree(ctx, &models.TaskSessionWorktree{
+		ID: "session-worktree-history", SessionID: "session-history", WorktreeID: "worktree-history",
+		RepositoryID: "repo-history", WorktreePath: "/tmp/history", WorktreeBranch: "feature/history",
+	}); err != nil {
+		t.Fatalf("CreateTaskSessionWorktree: %v", err)
+	}
+	svc.setCleanupDoneForTestHook(make(chan struct{}, 1))
+	if err := svc.ArchiveTask(ctx, "task-history"); err != nil {
+		t.Fatalf("ArchiveTask: %v", err)
+	}
+	waitForCleanupDone(t, svc)
+	rows, err := repo.ListTaskSessionWorktrees(ctx, "session-history")
+	if err != nil {
+		t.Fatalf("ListTaskSessionWorktrees: %v", err)
+	}
+	if len(rows) != 1 || rows[0].WorktreeBranch != "feature/history" {
+		t.Fatalf("historical worktrees = %#v, want preserved branch metadata", rows)
+	}
+}
+
+func TestArchiveFailsBeforeMutationWhenCleanupIntentCannotPersist(t *testing.T) {
+	svc, _, repo := createTestService(t)
+	ctx := context.Background()
+	seedCleanupTaskAndSession(t, repo, "task-persist-fail", "session-persist-fail")
+	if _, err := repo.DB().Exec(`
+		CREATE TRIGGER reject_cleanup_intent BEFORE INSERT ON task_resource_cleanup_jobs
+		BEGIN SELECT RAISE(ABORT, 'cleanup persistence unavailable'); END
+	`); err != nil {
+		t.Fatalf("create trigger: %v", err)
+	}
+	if err := svc.ArchiveTask(ctx, "task-persist-fail"); err == nil {
+		t.Fatal("ArchiveTask succeeded without durable cleanup intent")
+	}
+	task, err := repo.GetTask(ctx, "task-persist-fail")
+	if err != nil || task.ArchivedAt != nil {
+		t.Fatalf("task mutated after cleanup persistence failure: task=%#v err=%v", task, err)
+	}
+}
+
+func TestCascadeArchivePersistsCleanupBeforeTaskMutation(t *testing.T) {
+	taskSvc, repo := setupOfficeTest(t)
+	ctx := context.Background()
+	task, err := taskSvc.CreateTask(ctx, &CreateTaskRequest{
+		WorkspaceID: "ws-1", Title: "Cascade archive", ProjectID: "proj-1",
+	})
+	if err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	if _, err := repo.DB().Exec(`
+		CREATE TRIGGER require_cascade_archive_cleanup
+		BEFORE UPDATE OF archived_at ON tasks
+		WHEN NEW.archived_at IS NOT NULL AND NOT EXISTS (
+			SELECT 1 FROM task_resource_cleanup_jobs
+			WHERE task_id = NEW.id AND trigger = 'cascade_archive'
+		)
+		BEGIN SELECT RAISE(ABORT, 'missing cascade archive cleanup'); END
+	`); err != nil {
+		t.Fatalf("create trigger: %v", err)
+	}
+	handoff := NewHandoffService(repo, repo, nil, nil, nil, nil)
+	handoff.SetTaskResourceCleaner(taskSvc)
+	if _, err := handoff.ArchiveTaskTree(ctx, task.ID, false); err != nil {
+		t.Fatalf("ArchiveTaskTree: %v", err)
+	}
+}
+
+func TestWorkspaceDeletePersistsCleanupBeforeTaskCascade(t *testing.T) {
+	svc, _, repo := createTestService(t)
+	ctx := context.Background()
+	seedCleanupTaskAndSession(t, repo, "task-workspace-delete", "session-workspace-delete")
+	if _, err := repo.DB().Exec(`
+		CREATE TRIGGER require_workspace_delete_cleanup
+		BEFORE DELETE ON tasks
+		WHEN NOT EXISTS (
+			SELECT 1 FROM task_resource_cleanup_jobs
+			WHERE task_id = OLD.id AND trigger = 'workspace_delete'
+		)
+		BEGIN SELECT RAISE(ABORT, 'missing workspace delete cleanup'); END
+	`); err != nil {
+		t.Fatalf("create trigger: %v", err)
+	}
+	if err := svc.DeleteWorkspace(ctx, "ws-task-workspace-delete"); err != nil {
+		t.Fatalf("DeleteWorkspace: %v", err)
+	}
+}
+
+func TestCascadeDeletePersistsCleanupBeforeTaskMutation(t *testing.T) {
+	taskSvc, repo := setupOfficeTest(t)
+	ctx := context.Background()
+	task, err := taskSvc.CreateTask(ctx, &CreateTaskRequest{
+		WorkspaceID: "ws-1", Title: "Cascade delete", ProjectID: "proj-1",
+	})
+	if err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	if _, err := repo.DB().Exec(`
+		CREATE TRIGGER require_cascade_delete_cleanup
+		BEFORE DELETE ON tasks
+		WHEN NOT EXISTS (
+			SELECT 1 FROM task_resource_cleanup_jobs
+			WHERE task_id = OLD.id AND trigger = 'cascade_delete'
+		)
+		BEGIN SELECT RAISE(ABORT, 'missing cascade delete cleanup'); END
+	`); err != nil {
+		t.Fatalf("create trigger: %v", err)
+	}
+	handoff := NewHandoffService(repo, repo, nil, nil, nil, nil)
+	handoff.SetTaskResourceCleaner(taskSvc)
+	if _, err := handoff.DeleteTaskTree(ctx, task.ID, false); err != nil {
+		t.Fatalf("DeleteTaskTree: %v", err)
+	}
+}
+
+func seedCleanupTaskAndSession(t *testing.T, repo interface {
+	CreateWorkspace(context.Context, *models.Workspace) error
+	CreateWorkflow(context.Context, *models.Workflow) error
+	CreateTask(context.Context, *models.Task) error
+	CreateTaskSession(context.Context, *models.TaskSession) error
+}, taskID, sessionID string) {
+	t.Helper()
+	ctx := context.Background()
+	workspaceID := "ws-" + taskID
+	workflowID := "wf-" + taskID
+	if err := repo.CreateWorkspace(ctx, &models.Workspace{ID: workspaceID, Name: "Workspace"}); err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+	if err := repo.CreateWorkflow(ctx, &models.Workflow{ID: workflowID, WorkspaceID: workspaceID, Name: "Workflow"}); err != nil {
+		t.Fatalf("CreateWorkflow: %v", err)
+	}
+	if err := repo.CreateTask(ctx, &models.Task{ID: taskID, WorkspaceID: workspaceID, WorkflowID: workflowID, WorkflowStepID: "step", Title: "Task", Priority: "medium"}); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	if err := repo.CreateTaskSession(ctx, &models.TaskSession{ID: sessionID, TaskID: taskID, State: models.TaskSessionStateCompleted}); err != nil {
+		t.Fatalf("CreateTaskSession: %v", err)
+	}
+}

--- a/apps/backend/internal/task/service/service.go
+++ b/apps/backend/internal/task/service/service.go
@@ -43,6 +43,15 @@ type TaskExecutionStopper interface {
 	StopExecution(ctx context.Context, executionID, reason string, force bool) error
 }
 
+// TaskResourceCleanupActivityGate serializes durable cleanup with install-wide maintenance.
+type TaskResourceCleanupActivityGate interface {
+	AcquireTaskResourceCleanup(context.Context) (TaskResourceCleanupActivityLease, error)
+}
+
+type TaskResourceCleanupActivityLease interface {
+	Release()
+}
+
 // ProviderDefaultBranchProber resolves a provider repo's default branch
 // (e.g. "main" / "master") without requiring a local clone. Used by
 // AddBranchToTask to satisfy the worktree-create precondition synchronously,
@@ -157,6 +166,7 @@ type Repos struct {
 	Environments     repository.EnvironmentRepository
 	TaskEnvironments repository.TaskEnvironmentRepository
 	Reviews          repository.ReviewRepository
+	ResourceCleanups repository.TaskResourceCleanupRepository
 }
 
 // Service provides task business logic
@@ -174,11 +184,13 @@ type Service struct {
 	environments          repository.EnvironmentRepository
 	taskEnvironments      repository.TaskEnvironmentRepository
 	reviews               repository.ReviewRepository
+	resourceCleanups      repository.TaskResourceCleanupRepository
 	eventBus              bus.EventBus
 	logger                *logger.Logger
 	discoveryConfig       RepositoryDiscoveryConfig
 	worktreeCleanup       WorktreeCleanup
 	executionStopper      TaskExecutionStopper
+	cleanupActivity       TaskResourceCleanupActivityGate
 	branchMaterializer    BranchMaterializer
 	providerProber        ProviderDefaultBranchProber
 	gitArchiveCapture     GitArchiveCapture
@@ -197,7 +209,13 @@ type Service struct {
 	baseBranchPusher      AgentBaseBranchPusher
 	runtimeOverridesMu    sync.Mutex
 	// cleanupDoneForTest lets unit tests wait for async cleanup; nil in production.
-	cleanupDoneForTest chan struct{}
+	cleanupDoneForTest  chan struct{}
+	cleanupWorkerMu     sync.Mutex
+	cleanupWorkerCancel context.CancelFunc
+	cleanupWorkerWG     sync.WaitGroup
+	cleanupWorkerWake   chan struct{}
+	cleanupRunsMu       sync.Mutex
+	cleanupRuns         map[*taskResourceCleanupRun]struct{}
 }
 
 // NewService creates a new task service
@@ -216,6 +234,7 @@ func NewService(repos Repos, eventBus bus.EventBus, log *logger.Logger, discover
 		environments:     repos.Environments,
 		taskEnvironments: repos.TaskEnvironments,
 		reviews:          repos.Reviews,
+		resourceCleanups: repos.ResourceCleanups,
 		eventBus:         eventBus,
 		logger:           log,
 		discoveryConfig:  discoveryConfig,
@@ -258,6 +277,10 @@ func (s *Service) SetProviderDefaultBranchProber(p ProviderDefaultBranchProber) 
 // SetExecutionStopper wires the task execution stopper (orchestrator).
 func (s *Service) SetExecutionStopper(stopper TaskExecutionStopper) {
 	s.executionStopper = stopper
+}
+
+func (s *Service) SetTaskResourceCleanupActivityGate(gate TaskResourceCleanupActivityGate) {
+	s.cleanupActivity = gate
 }
 
 // SetGitArchiveCapture wires the git archive capture handler.

--- a/apps/backend/internal/task/service/service_cleanup_inventory_test.go
+++ b/apps/backend/internal/task/service/service_cleanup_inventory_test.go
@@ -1,0 +1,99 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/kandev/kandev/internal/task/models"
+	"github.com/kandev/kandev/internal/task/repository"
+	"github.com/kandev/kandev/internal/worktree"
+)
+
+type failingCleanupInventoryWorktree struct {
+	err error
+}
+
+type failingActiveCleanupSessions struct {
+	repository.SessionRepository
+	err error
+}
+
+func (r failingActiveCleanupSessions) ListActiveTaskSessionsByTaskID(context.Context, string) ([]*models.TaskSession, error) {
+	return nil, r.err
+}
+
+func (c failingCleanupInventoryWorktree) OnTaskDeleted(context.Context, string) error { return nil }
+
+func (c failingCleanupInventoryWorktree) GetAllByTaskID(context.Context, string) ([]*worktree.Worktree, error) {
+	return nil, c.err
+}
+
+func TestTaskMutationAbortsOnAuthoritativeCleanupInventoryReadError(t *testing.T) {
+	inventoryErr := errors.New("cleanup inventory unavailable")
+	actions := []struct {
+		name string
+		run  func(context.Context, *Service, string) error
+	}{
+		{name: "archive", run: func(ctx context.Context, svc *Service, taskID string) error {
+			return svc.ArchiveTask(ctx, taskID)
+		}},
+		{name: "delete", run: func(ctx context.Context, svc *Service, taskID string) error {
+			return svc.DeleteTask(ctx, taskID)
+		}},
+	}
+	inventories := []struct {
+		name   string
+		inject func(*Service, repository.SessionRepository)
+	}{
+		{name: "sessions", inject: func(svc *Service, sessions repository.SessionRepository) {
+			svc.sessions = failingListTaskSessionsRepo{SessionRepository: sessions, err: inventoryErr}
+		}},
+		{name: "active_sessions", inject: func(svc *Service, sessions repository.SessionRepository) {
+			svc.SetExecutionStopper(newRecordingTaskExecutionStopper())
+			svc.sessions = failingActiveCleanupSessions{SessionRepository: sessions, err: inventoryErr}
+		}},
+		{name: "worktrees", inject: func(svc *Service, _ repository.SessionRepository) {
+			svc.SetWorktreeCleanup(failingCleanupInventoryWorktree{err: inventoryErr})
+		}},
+		{name: "environment", inject: func(svc *Service, _ repository.SessionRepository) {
+			svc.taskEnvironments = &stubEnvRepo{getErr: inventoryErr}
+		}},
+	}
+
+	for _, action := range actions {
+		for _, inventory := range inventories {
+			t.Run(action.name+"/"+inventory.name, func(t *testing.T) {
+				svc, _, repo := createTestService(t)
+				ctx := context.Background()
+				taskID := "task-" + action.name + "-" + inventory.name
+				seedCleanupTaskAndSession(t, repo, taskID, "session-"+taskID)
+				// Keep the current failing implementation from launching a cleanup
+				// goroutine after it incorrectly mutates the task.
+				svc.cleanupWorkerWake = make(chan struct{}, 1)
+				inventory.inject(svc, repo)
+
+				err := action.run(ctx, svc, taskID)
+				if !errors.Is(err, inventoryErr) {
+					t.Fatalf("%s error = %v, want inventory error", action.name, err)
+				}
+				task, getErr := repo.GetTask(ctx, taskID)
+				if getErr != nil {
+					t.Fatalf("task missing after inventory error: %v", getErr)
+				}
+				if task.ArchivedAt != nil {
+					t.Fatal("task archived after inventory error")
+				}
+				var jobs int
+				if err := repo.DB().QueryRowContext(ctx, `
+					SELECT COUNT(*) FROM task_resource_cleanup_jobs WHERE task_id = ?
+				`, taskID).Scan(&jobs); err != nil {
+					t.Fatalf("count cleanup intents: %v", err)
+				}
+				if jobs != 0 {
+					t.Fatalf("cleanup intents = %d, want none before authoritative inventory succeeds", jobs)
+				}
+			})
+		}
+	}
+}

--- a/apps/backend/internal/task/service/service_resources.go
+++ b/apps/backend/internal/task/service/service_resources.go
@@ -33,6 +33,7 @@ type workspaceDeleteTaskCleanup struct {
 	worktrees   []*worktree.Worktree
 	stopTargets []taskStopTarget
 	taskEnv     *models.TaskEnvironment
+	cleanupJob  *models.TaskResourceCleanupJob
 }
 
 type repositorySessionPruner interface {
@@ -147,6 +148,7 @@ func (s *Service) deleteWorkspace(ctx context.Context, workspace *models.Workspa
 		deletedTasks, deletedWorkflows, err = s.workspaces.DeleteWorkspaceCascadeWithName(ctx, workspace.ID, *confirmedName)
 	}
 	if err != nil {
+		s.cancelWorkspaceDeleteTaskCleanupJobs(ctx, cleanups)
 		return s.mapWorkspaceDeleteError(workspace.ID, err)
 	}
 	cleanups = s.appendWorkspaceDeleteMissingTaskCleanups(ctx, cleanups, deletedTasks)
@@ -165,6 +167,7 @@ func (s *Service) prepareWorkspaceDeleteTaskCleanups(ctx context.Context, tasks 
 		}
 		cleanup, err := s.prepareWorkspaceDeleteTaskCleanup(ctx, task)
 		if err != nil {
+			s.cancelWorkspaceDeleteTaskCleanupJobs(ctx, cleanups)
 			return nil, err
 		}
 		cleanups = append(cleanups, cleanup)
@@ -204,30 +207,47 @@ func (s *Service) appendWorkspaceDeleteMissingTaskCleanups(
 }
 
 func (s *Service) prepareWorkspaceDeleteTaskCleanup(ctx context.Context, task *models.Task) (workspaceDeleteTaskCleanup, error) {
-	cleanup := workspaceDeleteTaskCleanup{
-		task:      task,
-		worktrees: s.gatherWorktreesForDelete(ctx, task.ID),
-		taskEnv:   s.gatherTaskEnvironmentForCleanup(ctx, task.ID),
+	worktrees, err := s.gatherWorktreesForDelete(ctx, task.ID)
+	if err != nil {
+		return workspaceDeleteTaskCleanup{}, fmt.Errorf("list worktrees for workspace delete task %q: %w", task.ID, err)
 	}
-	var err error
+	taskEnv, err := s.gatherTaskEnvironmentForCleanup(ctx, task.ID)
+	if err != nil {
+		return workspaceDeleteTaskCleanup{}, fmt.Errorf("lookup environment for workspace delete task %q: %w", task.ID, err)
+	}
+	cleanup := workspaceDeleteTaskCleanup{task: task, worktrees: worktrees, taskEnv: taskEnv}
 	cleanup.sessions, err = s.sessions.ListTaskSessions(ctx, task.ID)
 	if err != nil {
 		return workspaceDeleteTaskCleanup{}, fmt.Errorf("list task sessions for workspace delete task %q: %w", task.ID, err)
 	}
-	if s.executionStopper == nil {
-		return cleanup, nil
+	if s.executionStopper != nil {
+		activeSessions, listErr := s.sessions.ListActiveTaskSessionsByTaskID(ctx, task.ID)
+		if listErr != nil {
+			return workspaceDeleteTaskCleanup{}, fmt.Errorf("list active sessions for workspace delete task %q: %w", task.ID, listErr)
+		}
+		cleanup.stopTargets, err = s.buildStopTargets(ctx, task.ID, activeSessions)
+		if err != nil {
+			return workspaceDeleteTaskCleanup{}, fmt.Errorf("list runtime cleanup inventory: %w", err)
+		}
 	}
-	activeSessions, err := s.sessions.ListActiveTaskSessionsByTaskID(ctx, task.ID)
-	if err != nil {
-		s.logger.Warn("failed to list active task sessions for workspace delete",
-			zap.String("task_id", task.ID),
-			zap.Error(err))
+	cleanup.cleanupJob, err = s.persistTaskResourceCleanup(
+		ctx, task.ID, models.TaskResourceCleanupTriggerWorkspaceDelete,
+		newTaskResourceCleanupOperationID(models.TaskResourceCleanupTriggerWorkspaceDelete, task.ID),
+		cleanup.sessions, cleanup.worktrees, cleanup.stopTargets,
+		taskEnvironmentCleanup{env: cleanup.taskEnv, deleteRow: false},
+	)
+	return cleanup, err
+}
+
+func (s *Service) cancelWorkspaceDeleteTaskCleanupJobs(ctx context.Context, cleanups []workspaceDeleteTaskCleanup) {
+	for _, cleanup := range cleanups {
+		if cleanup.cleanupJob == nil || s.resourceCleanups == nil {
+			continue
+		}
+		_ = s.resourceCleanups.CompleteTaskResourceCleanupJob(
+			ctx, cleanup.cleanupJob.ID, models.TaskResourceCleanupStateCancelled, "", nil,
+		)
 	}
-	cleanup.stopTargets, err = s.buildStopTargets(ctx, task.ID, activeSessions)
-	if err != nil {
-		return workspaceDeleteTaskCleanup{}, fmt.Errorf("list runtime cleanup inventory: %w", err)
-	}
-	return cleanup, nil
 }
 
 func (s *Service) publishWorkspaceDeleteChildEvents(ctx context.Context, tasks []*models.Task, workflows []*models.Workflow) {
@@ -305,6 +325,12 @@ func (s *Service) runWorkspaceDeleteTaskCleanupJobs(jobs []workspaceDeleteTaskCl
 }
 
 func (s *Service) runWorkspaceDeleteTaskCleanup(cleanup workspaceDeleteTaskCleanup) {
+	if cleanup.cleanupJob != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cancel()
+		_ = s.processTaskResourceCleanupJob(ctx, cleanup.cleanupJob.ID)
+		return
+	}
 	envCleanup := taskEnvironmentCleanup{env: cleanup.taskEnv, deleteRow: false}
 	s.runTaskCleanup(cleanup.task.ID, cleanup.sessions, cleanup.worktrees, cleanup.stopTargets, envCleanup,
 		"task deleted", "failed to stop session on task delete", "task cleanup completed")

--- a/apps/backend/internal/task/service/service_resources.go
+++ b/apps/backend/internal/task/service/service_resources.go
@@ -234,19 +234,25 @@ func (s *Service) prepareWorkspaceDeleteTaskCleanup(ctx context.Context, task *m
 		ctx, task.ID, models.TaskResourceCleanupTriggerWorkspaceDelete,
 		newTaskResourceCleanupOperationID(models.TaskResourceCleanupTriggerWorkspaceDelete, task.ID),
 		cleanup.sessions, cleanup.worktrees, cleanup.stopTargets,
-		taskEnvironmentCleanup{env: cleanup.taskEnv, deleteRow: false},
+		taskEnvironmentCleanup{env: cleanup.taskEnv, deleteRow: false}, true,
 	)
 	return cleanup, err
 }
 
 func (s *Service) cancelWorkspaceDeleteTaskCleanupJobs(ctx context.Context, cleanups []workspaceDeleteTaskCleanup) {
+	transitionCtx, cancel := detachedCleanupTransitionContext(ctx)
+	defer cancel()
 	for _, cleanup := range cleanups {
 		if cleanup.cleanupJob == nil || s.resourceCleanups == nil {
 			continue
 		}
-		_ = s.resourceCleanups.CompleteTaskResourceCleanupJob(
-			ctx, cleanup.cleanupJob.ID, models.TaskResourceCleanupStateCancelled, "", nil,
-		)
+		if err := s.resourceCleanups.CompleteTaskResourceCleanupJob(
+			transitionCtx, cleanup.cleanupJob.ID, models.TaskResourceCleanupStateCancelled, "", nil,
+		); err != nil {
+			s.logger.Warn("cancel workspace delete task cleanup job",
+				zap.String("job_id", cleanup.cleanupJob.ID),
+				zap.String("task_id", cleanup.cleanupJob.TaskID), zap.Error(err))
+		}
 	}
 }
 
@@ -326,9 +332,15 @@ func (s *Service) runWorkspaceDeleteTaskCleanupJobs(jobs []workspaceDeleteTaskCl
 
 func (s *Service) runWorkspaceDeleteTaskCleanup(cleanup workspaceDeleteTaskCleanup) {
 	if cleanup.cleanupJob != nil {
-		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		transitionCtx, cancel := detachedCleanupTransitionContext(context.Background())
 		defer cancel()
-		_ = s.processTaskResourceCleanupJob(ctx, cleanup.cleanupJob.ID)
+		if err := s.StartPreparedTaskResourceCleanup(
+			transitionCtx, cleanup.cleanupJob.OperationID,
+		); err != nil {
+			s.logger.Warn("start workspace delete task cleanup job",
+				zap.String("job_id", cleanup.cleanupJob.ID),
+				zap.String("task_id", cleanup.cleanupJob.TaskID), zap.Error(err))
+		}
 		return
 	}
 	envCleanup := taskEnvironmentCleanup{env: cleanup.taskEnv, deleteRow: false}

--- a/apps/backend/internal/task/service/service_resources_test.go
+++ b/apps/backend/internal/task/service/service_resources_test.go
@@ -80,10 +80,17 @@ func TestWorkspaceDeleteDurableCleanupSignalsOwnedWorker(t *testing.T) {
 	}()
 	select {
 	case <-done:
-	case <-time.After(100 * time.Millisecond):
+	case <-barrier.started:
 		close(barrier.release)
-		<-barrier.stopped
+		select {
+		case <-barrier.stopped:
+		case <-time.After(time.Second):
+			t.Fatal("synchronous workspace cleanup did not stop after release")
+		}
 		t.Fatal("workspace deletion processed durable cleanup synchronously")
+	case <-time.After(time.Second):
+		close(barrier.release)
+		t.Fatal("workspace deletion did not return")
 	}
 	select {
 	case <-wake:

--- a/apps/backend/internal/task/service/service_resources_test.go
+++ b/apps/backend/internal/task/service/service_resources_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -46,6 +47,55 @@ func (c *blockingWorktreeCleanup) CleanupWorktrees(ctx context.Context, _ []*wor
 		return ctx.Err()
 	case <-c.release:
 		return nil
+	}
+}
+
+func TestWorkspaceDeleteDurableCleanupSignalsOwnedWorker(t *testing.T) {
+	taskSvc, repo := setupOfficeTest(t)
+	ctx := context.Background()
+	snapshot, err := json.Marshal(taskResourceCleanupSnapshot{
+		Worktrees: []*worktree.Worktree{{ID: "workspace-delete-worktree", TaskID: "workspace-delete-task"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	job := &models.TaskResourceCleanupJob{
+		ID: "workspace-delete-job", OperationID: "workspace_delete:workspace-delete-task",
+		TaskID: "workspace-delete-task", Trigger: models.TaskResourceCleanupTriggerWorkspaceDelete,
+		State: models.TaskResourceCleanupStatePrepared, ResourceSnapshot: string(snapshot),
+	}
+	if err := repo.CreateTaskResourceCleanupJob(ctx, job); err != nil {
+		t.Fatalf("CreateTaskResourceCleanupJob: %v", err)
+	}
+	barrier := newCancellableCleanupBarrier()
+	taskSvc.SetWorktreeCleanup(barrier)
+	wake := make(chan struct{}, 1)
+	taskSvc.cleanupWorkerMu.Lock()
+	taskSvc.cleanupWorkerWake = wake
+	taskSvc.cleanupWorkerMu.Unlock()
+	done := make(chan struct{})
+	go func() {
+		taskSvc.runWorkspaceDeleteTaskCleanup(workspaceDeleteTaskCleanup{cleanupJob: job})
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(100 * time.Millisecond):
+		close(barrier.release)
+		<-barrier.stopped
+		t.Fatal("workspace deletion processed durable cleanup synchronously")
+	}
+	select {
+	case <-wake:
+	default:
+		t.Fatal("workspace deletion did not wake owned cleanup worker")
+	}
+	got, err := repo.GetTaskResourceCleanupJob(ctx, job.ID)
+	if err != nil {
+		t.Fatalf("GetTaskResourceCleanupJob: %v", err)
+	}
+	if got.State != models.TaskResourceCleanupStatePending {
+		t.Fatalf("cleanup state = %q, want pending", got.State)
 	}
 }
 

--- a/apps/backend/internal/task/service/service_task_environments.go
+++ b/apps/backend/internal/task/service/service_task_environments.go
@@ -331,6 +331,9 @@ func (s *Service) ResetTaskEnvironment(ctx context.Context, taskID string, opts 
 // single error so a stuck container can't permanently orphan the worktree.
 // On any error, the caller should preserve the row so the user can retry.
 func (s *Service) teardownEnvironmentResources(ctx context.Context, env *models.TaskEnvironment) error {
+	if cause := context.Cause(ctx); cause != nil {
+		return cause
+	}
 	if env.ContainerID == "" && env.SandboxID == "" && env.WorktreeID == "" {
 		return nil
 	}
@@ -339,20 +342,38 @@ func (s *Service) teardownEnvironmentResources(ctx context.Context, env *models.
 	}
 
 	var errs []error
+	contextError := func() error {
+		if cause := context.Cause(ctx); cause != nil {
+			return errors.Join(errors.Join(errs...), cause)
+		}
+		return nil
+	}
 	if env.ContainerID != "" {
+		if err := contextError(); err != nil {
+			return err
+		}
 		if err := s.envDestroyer.DestroyContainer(ctx, env.ContainerID); err != nil {
 			errs = append(errs, fmt.Errorf("destroy container %s: %w", env.ContainerID, err))
 		}
 	}
 	if env.SandboxID != "" {
+		if err := contextError(); err != nil {
+			return err
+		}
 		if err := s.envDestroyer.DestroySandbox(ctx, env.SandboxID, ""); err != nil {
 			errs = append(errs, fmt.Errorf("destroy sandbox %s: %w", env.SandboxID, err))
 		}
 	}
 	if env.WorktreeID != "" {
+		if err := contextError(); err != nil {
+			return err
+		}
 		if err := s.envDestroyer.DestroyWorktree(ctx, env.WorktreeID); err != nil {
 			errs = append(errs, fmt.Errorf("destroy worktree %s: %w", env.WorktreeID, err))
 		}
+	}
+	if err := contextError(); err != nil {
+		return err
 	}
 	return errors.Join(errs...)
 }

--- a/apps/backend/internal/task/service/service_task_environments_test.go
+++ b/apps/backend/internal/task/service/service_task_environments_test.go
@@ -53,18 +53,22 @@ func (s *stubEnvRepo) DeleteTaskEnvironment(context.Context, string) error {
 func (s *stubEnvRepo) DeleteTaskEnvironmentsByTask(context.Context, string) error { return nil }
 
 type stubDestroyer struct {
-	containerCalls []string
-	sandboxCalls   []string
-	worktreeCalls  []string
-	pushCalls      int
-	containerErr   error
-	sandboxErr     error
-	worktreeErr    error
-	pushErr        error
+	containerCalls       []string
+	sandboxCalls         []string
+	worktreeCalls        []string
+	cancelAfterContainer context.CancelFunc
+	pushCalls            int
+	containerErr         error
+	sandboxErr           error
+	worktreeErr          error
+	pushErr              error
 }
 
 func (s *stubDestroyer) DestroyContainer(_ context.Context, id string) error {
 	s.containerCalls = append(s.containerCalls, id)
+	if s.cancelAfterContainer != nil {
+		s.cancelAfterContainer()
+	}
 	return s.containerErr
 }
 func (s *stubDestroyer) DestroySandbox(_ context.Context, id, _ string) error {
@@ -175,6 +179,43 @@ func TestResetTaskEnvironment_DestroysEachResourceTypeAndDeletesRow(t *testing.T
 	}
 	if len(destroyer.worktreeCalls) != 1 || destroyer.worktreeCalls[0] != "wt-1" {
 		t.Errorf("expected 1 worktree destroy call, got %v", destroyer.worktreeCalls)
+	}
+}
+
+func TestTeardownEnvironmentResources_CancellationStopsBeforeNextResource(t *testing.T) {
+	svc := newResetTestService(t, &stubEnvRepo{})
+	ctx, cancel := context.WithCancel(context.Background())
+	destroyer := &stubDestroyer{cancelAfterContainer: cancel}
+	svc.SetEnvironmentDestroyer(destroyer)
+
+	err := svc.teardownEnvironmentResources(ctx, &models.TaskEnvironment{
+		ContainerID: "container-1", SandboxID: "sandbox-1", WorktreeID: "worktree-1",
+	})
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("teardown error = %v, want context cancellation", err)
+	}
+	if len(destroyer.sandboxCalls) != 0 || len(destroyer.worktreeCalls) != 0 {
+		t.Fatalf("resources destroyed after cancellation: sandboxes=%v worktrees=%v",
+			destroyer.sandboxCalls, destroyer.worktreeCalls)
+	}
+}
+
+func TestCleanupTaskEnvironment_CancellationPreservesEnvironmentRow(t *testing.T) {
+	repo := &stubEnvRepo{}
+	svc := newResetTestService(t, repo)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	errs := svc.cleanupTaskEnvironment(ctx, "task-1", taskEnvironmentCleanup{
+		env: &models.TaskEnvironment{ID: "environment-1", TaskID: "task-1"}, deleteRow: true,
+	})
+
+	if !errors.Is(errors.Join(errs...), context.Canceled) {
+		t.Fatalf("cleanup errors = %v, want context cancellation", errs)
+	}
+	if repo.deleted {
+		t.Fatal("environment row deleted after cancellation")
 	}
 }
 

--- a/apps/backend/internal/task/service/service_tasks.go
+++ b/apps/backend/internal/task/service/service_tasks.go
@@ -958,7 +958,7 @@ func (s *Service) ArchiveTask(ctx context.Context, id string) error {
 	envCleanup := taskEnvironmentCleanup{env: taskEnv, deleteRow: true}
 	cleanupJob, err := s.persistTaskResourceCleanup(
 		ctx, id, models.TaskResourceCleanupTriggerArchive, "",
-		sessions, worktrees, stopTargets, envCleanup, false,
+		sessions, worktrees, stopTargets, envCleanup, true,
 	)
 	if err != nil {
 		return err
@@ -997,7 +997,10 @@ func (s *Service) ArchiveTask(ctx context.Context, id string) error {
 
 	// 6. Background: Stop agents and cleanup worktrees
 	if cleanupJob != nil {
-		s.startTaskResourceCleanup(cleanupJob)
+		if err := s.StartPreparedTaskResourceCleanup(ctx, cleanupJob.OperationID); err != nil {
+			s.logger.Warn("start committed archive resource cleanup",
+				zap.String("job_id", cleanupJob.ID), zap.String("task_id", id), zap.Error(err))
+		}
 	} else if len(stopTargets) > 0 || s.worktreeCleanup != nil || len(sessions) > 0 || taskEnv != nil {
 		s.runAsyncTaskCleanup(id, sessions, worktrees, stopTargets, envCleanup,
 			"task archived", "failed to stop session on task archive", "task archive cleanup completed")
@@ -1084,7 +1087,7 @@ func (s *Service) deleteTaskWithReasonAndDBDelete(
 
 	envCleanup := taskEnvironmentCleanup{env: taskEnv, deleteRow: false}
 	cleanupJob, err := s.persistTaskResourceCleanup(
-		ctx, id, trigger, "", sessions, worktrees, stopTargets, envCleanup, false,
+		ctx, id, trigger, "", sessions, worktrees, stopTargets, envCleanup, true,
 	)
 	if err != nil {
 		return false, err
@@ -1118,7 +1121,10 @@ func (s *Service) deleteTaskWithReasonAndDBDelete(
 	//    cleanup running when only the env needs reclaiming).
 	hasCleanup := len(stopTargets) > 0 || s.worktreeCleanup != nil || len(sessions) > 0 || task.IsEphemeral || taskEnv != nil
 	if cleanupJob != nil {
-		s.startTaskResourceCleanup(cleanupJob)
+		if err := s.StartPreparedTaskResourceCleanup(ctx, cleanupJob.OperationID); err != nil {
+			s.logger.Warn("start committed delete resource cleanup",
+				zap.String("job_id", cleanupJob.ID), zap.String("task_id", id), zap.Error(err))
+		}
 	} else if hasCleanup {
 		s.runAsyncTaskCleanup(id, sessions, worktrees, stopTargets, envCleanup,
 			"task deleted", "failed to stop session on task delete", "task cleanup completed")

--- a/apps/backend/internal/task/service/service_tasks.go
+++ b/apps/backend/internal/task/service/service_tasks.go
@@ -958,7 +958,7 @@ func (s *Service) ArchiveTask(ctx context.Context, id string) error {
 	envCleanup := taskEnvironmentCleanup{env: taskEnv, deleteRow: true}
 	cleanupJob, err := s.persistTaskResourceCleanup(
 		ctx, id, models.TaskResourceCleanupTriggerArchive, "",
-		sessions, worktrees, stopTargets, envCleanup,
+		sessions, worktrees, stopTargets, envCleanup, false,
 	)
 	if err != nil {
 		return err
@@ -1084,7 +1084,7 @@ func (s *Service) deleteTaskWithReasonAndDBDelete(
 
 	envCleanup := taskEnvironmentCleanup{env: taskEnv, deleteRow: false}
 	cleanupJob, err := s.persistTaskResourceCleanup(
-		ctx, id, trigger, "", sessions, worktrees, stopTargets, envCleanup,
+		ctx, id, trigger, "", sessions, worktrees, stopTargets, envCleanup, false,
 	)
 	if err != nil {
 		return false, err

--- a/apps/backend/internal/task/service/service_tasks.go
+++ b/apps/backend/internal/task/service/service_tasks.go
@@ -914,9 +914,7 @@ func (s *Service) ArchiveTask(ctx context.Context, id string) error {
 	var stopTargets []taskStopTarget
 	activeSessions, err := s.sessions.ListActiveTaskSessionsByTaskID(ctx, id)
 	if err != nil {
-		s.logger.Warn("failed to list active sessions for archive",
-			zap.String("task_id", id),
-			zap.Error(err))
+		return fmt.Errorf("list active task sessions for archive: %w", err)
 	}
 	if s.executionStopper != nil {
 		stopTargets, err = s.buildStopTargets(ctx, id, activeSessions)
@@ -946,26 +944,29 @@ func (s *Service) ArchiveTask(ctx context.Context, id string) error {
 
 	sessions, err := s.sessions.ListTaskSessions(ctx, id)
 	if err != nil {
-		s.logger.Warn("failed to list task sessions for archive",
-			zap.String("task_id", id),
-			zap.Error(err))
+		return fmt.Errorf("list task sessions for archive: %w", err)
 	}
 
-	var worktrees []*worktree.Worktree
-	if s.worktreeCleanup != nil {
-		if provider, ok := s.worktreeCleanup.(WorktreeProvider); ok {
-			worktrees, err = provider.GetAllByTaskID(ctx, id)
-			if err != nil {
-				s.logger.Warn("failed to list worktrees for archive",
-					zap.String("task_id", id),
-					zap.Error(err))
-			}
-		}
+	worktrees, err := s.gatherWorktreesForDelete(ctx, id)
+	if err != nil {
+		return fmt.Errorf("list worktrees for archive: %w", err)
 	}
-	taskEnv := s.gatherTaskEnvironmentForCleanup(ctx, id)
+	taskEnv, err := s.gatherTaskEnvironmentForCleanup(ctx, id)
+	if err != nil {
+		return fmt.Errorf("lookup task environment for archive: %w", err)
+	}
+	envCleanup := taskEnvironmentCleanup{env: taskEnv, deleteRow: true}
+	cleanupJob, err := s.persistTaskResourceCleanup(
+		ctx, id, models.TaskResourceCleanupTriggerArchive, "",
+		sessions, worktrees, stopTargets, envCleanup,
+	)
+	if err != nil {
+		return err
+	}
 
 	// 3. Set archived_at in DB
 	if err := s.tasks.ArchiveTask(ctx, id); err != nil {
+		s.cancelTaskResourceCleanupJob(ctx, cleanupJob)
 		return err
 	}
 
@@ -995,8 +996,9 @@ func (s *Service) ArchiveTask(ctx context.Context, id string) error {
 		zap.Duration("duration", time.Since(start)))
 
 	// 6. Background: Stop agents and cleanup worktrees
-	envCleanup := taskEnvironmentCleanup{env: taskEnv, deleteRow: true}
-	if len(stopTargets) > 0 || s.worktreeCleanup != nil || len(sessions) > 0 || taskEnv != nil {
+	if cleanupJob != nil {
+		s.startTaskResourceCleanup(cleanupJob)
+	} else if len(stopTargets) > 0 || s.worktreeCleanup != nil || len(sessions) > 0 || taskEnv != nil {
 		s.runAsyncTaskCleanup(id, sessions, worktrees, stopTargets, envCleanup,
 			"task archived", "failed to stop session on task archive", "task archive cleanup completed")
 	}
@@ -1019,7 +1021,7 @@ func (s *Service) DeleteTaskWithReason(ctx context.Context, id, reason string) e
 }
 
 func (s *Service) deleteTaskWithReason(ctx context.Context, id, reason string) error {
-	_, err := s.deleteTaskWithReasonAndDBDelete(ctx, id, reason, func(ctx context.Context, id string) (bool, error) {
+	_, err := s.deleteTaskWithReasonAndDBDelete(ctx, id, reason, models.TaskResourceCleanupTriggerDelete, func(ctx context.Context, id string) (bool, error) {
 		if err := s.tasks.DeleteTask(ctx, id); err != nil {
 			return false, err
 		}
@@ -1029,7 +1031,7 @@ func (s *Service) deleteTaskWithReason(ctx context.Context, id, reason string) e
 }
 
 func (s *Service) deleteExpiredQuickChatTask(ctx context.Context, id string, cutoff time.Time) (bool, error) {
-	deleted, err := s.deleteTaskWithReasonAndDBDelete(ctx, id, "", func(ctx context.Context, id string) (bool, error) {
+	deleted, err := s.deleteTaskWithReasonAndDBDelete(ctx, id, "", models.TaskResourceCleanupTriggerQuickChatExpire, func(ctx context.Context, id string) (bool, error) {
 		return s.tasks.DeleteExpiredQuickChatTask(ctx, id, cutoff)
 	})
 	if errors.Is(err, taskrepo.ErrTaskNotFound) {
@@ -1042,6 +1044,7 @@ func (s *Service) deleteTaskWithReasonAndDBDelete(
 	ctx context.Context,
 	id string,
 	reason string,
+	trigger models.TaskResourceCleanupTrigger,
 	deleteFromDB func(context.Context, string) (bool, error),
 ) (bool, error) {
 	start := time.Now()
@@ -1055,13 +1058,21 @@ func (s *Service) deleteTaskWithReasonAndDBDelete(
 	// 2. Gather data needed for cleanup BEFORE delete (sync, fast)
 	sessions, err := s.sessions.ListTaskSessions(ctx, id)
 	if err != nil {
-		s.logger.Warn("failed to list task sessions for delete",
-			zap.String("task_id", id),
-			zap.Error(err))
+		return false, fmt.Errorf("list task sessions for delete: %w", err)
 	}
 
-	worktrees := s.gatherWorktreesForDelete(ctx, id)
-	taskEnv := s.gatherTaskEnvironmentForCleanup(ctx, id)
+	worktrees, err := s.gatherWorktreesForDelete(ctx, id)
+	if err != nil {
+		return false, fmt.Errorf("list worktrees for delete: %w", err)
+	}
+	taskEnv, err := s.gatherTaskEnvironmentForCleanup(ctx, id)
+	if err != nil {
+		return false, fmt.Errorf("lookup task environment for delete: %w", err)
+	}
+	stopTargets, err := s.deleteTaskStopTargets(ctx, id)
+	if err != nil {
+		return false, err
+	}
 	if preserved, err := s.preserveTaskEnvironmentForActiveBorrower(ctx, id, taskEnv); err != nil {
 		return false, err
 	} else if preserved {
@@ -1071,7 +1082,10 @@ func (s *Service) deleteTaskWithReasonAndDBDelete(
 			zap.String("new_owner_task_id", taskEnv.TaskID))
 	}
 
-	stopTargets, err := s.deleteTaskStopTargets(ctx, id)
+	envCleanup := taskEnvironmentCleanup{env: taskEnv, deleteRow: false}
+	cleanupJob, err := s.persistTaskResourceCleanup(
+		ctx, id, trigger, "", sessions, worktrees, stopTargets, envCleanup,
+	)
 	if err != nil {
 		return false, err
 	}
@@ -1079,10 +1093,12 @@ func (s *Service) deleteTaskWithReasonAndDBDelete(
 	// 4. Delete from DB (sync, fast)
 	deleted, err := deleteFromDB(ctx, id)
 	if err != nil {
+		s.cancelTaskResourceCleanupJob(ctx, cleanupJob)
 		s.logger.Error("failed to delete task", zap.String("task_id", id), zap.Error(err))
 		return false, err
 	}
 	if !deleted {
+		s.cancelTaskResourceCleanupJob(ctx, cleanupJob)
 		return false, nil
 	}
 
@@ -1100,9 +1116,10 @@ func (s *Service) deleteTaskWithReasonAndDBDelete(
 	//    envCleanup struct so the task environment row is reset alongside
 	//    the worktrees (an extra task.taskEnv != nil branch keeps the
 	//    cleanup running when only the env needs reclaiming).
-	envCleanup := taskEnvironmentCleanup{env: taskEnv, deleteRow: false}
 	hasCleanup := len(stopTargets) > 0 || s.worktreeCleanup != nil || len(sessions) > 0 || task.IsEphemeral || taskEnv != nil
-	if hasCleanup {
+	if cleanupJob != nil {
+		s.startTaskResourceCleanup(cleanupJob)
+	} else if hasCleanup {
 		s.runAsyncTaskCleanup(id, sessions, worktrees, stopTargets, envCleanup,
 			"task deleted", "failed to stop session on task delete", "task cleanup completed")
 	}
@@ -1117,9 +1134,7 @@ func (s *Service) deleteTaskStopTargets(ctx context.Context, id string) ([]taskS
 	}
 	activeSessions, err := s.sessions.ListActiveTaskSessionsByTaskID(ctx, id)
 	if err != nil {
-		s.logger.Warn("failed to list active sessions for delete",
-			zap.String("task_id", id),
-			zap.Error(err))
+		return nil, fmt.Errorf("list active sessions for delete: %w", err)
 	}
 	stopTargets, err := s.buildStopTargets(ctx, id, activeSessions)
 	if err != nil {
@@ -1161,8 +1176,18 @@ func (s *Service) CleanupTaskResources(ctx context.Context, taskID string, delet
 			return
 		}
 	}
-	worktrees := s.gatherWorktreesForDelete(ctx, taskID)
-	taskEnv := s.gatherTaskEnvironmentForCleanup(ctx, taskID)
+	worktrees, err := s.gatherWorktreesForDelete(ctx, taskID)
+	if err != nil {
+		s.logger.Warn("skipping cascade cleanup because worktree inventory failed",
+			zap.String("task_id", taskID), zap.Error(err))
+		return
+	}
+	taskEnv, err := s.gatherTaskEnvironmentForCleanup(ctx, taskID)
+	if err != nil {
+		s.logger.Warn("skipping cascade cleanup because task environment inventory failed",
+			zap.String("task_id", taskID), zap.Error(err))
+		return
+	}
 	if deleteEnvRow {
 		preserved, err := s.preserveTaskEnvironmentForActiveBorrower(ctx, taskID, taskEnv)
 		if err != nil {
@@ -1195,41 +1220,38 @@ func (s *Service) CleanupTaskResources(ctx context.Context, taskID string, delet
 // gatherWorktreesForDelete collects worktrees for a task before it is deleted.
 // For legacy WorktreeCleanup implementations that do not implement WorktreeProvider,
 // it triggers cleanup immediately and returns nil.
-func (s *Service) gatherWorktreesForDelete(ctx context.Context, taskID string) []*worktree.Worktree {
+func (s *Service) gatherWorktreesForDelete(ctx context.Context, taskID string) ([]*worktree.Worktree, error) {
 	if s.worktreeCleanup == nil {
-		return nil
+		return nil, nil
 	}
 	provider, ok := s.worktreeCleanup.(WorktreeProvider)
 	if !ok {
-		// Fallback for legacy implementations: cleanup before delete.
-		if err := s.worktreeCleanup.OnTaskDeleted(ctx, taskID); err != nil {
-			s.logger.Warn("failed to cleanup worktree on task deletion",
-				zap.String("task_id", taskID),
-				zap.Error(err))
+		// Durable cleanup must persist its intent before invoking a destructive
+		// legacy callback. Non-durable test/legacy wiring keeps the old behavior.
+		if s.resourceCleanups == nil {
+			if err := s.worktreeCleanup.OnTaskDeleted(ctx, taskID); err != nil {
+				s.logger.Warn("failed to cleanup worktree on task deletion",
+					zap.String("task_id", taskID), zap.Error(err))
+			}
 		}
-		return nil
+		return nil, nil
 	}
 	worktrees, err := provider.GetAllByTaskID(ctx, taskID)
 	if err != nil {
-		s.logger.Warn("failed to list worktrees for delete",
-			zap.String("task_id", taskID),
-			zap.Error(err))
+		return nil, err
 	}
-	return worktrees
+	return worktrees, nil
 }
 
-func (s *Service) gatherTaskEnvironmentForCleanup(ctx context.Context, taskID string) *models.TaskEnvironment {
+func (s *Service) gatherTaskEnvironmentForCleanup(ctx context.Context, taskID string) (*models.TaskEnvironment, error) {
 	if s.taskEnvironments == nil {
-		return nil
+		return nil, nil
 	}
 	env, err := s.taskEnvironments.GetTaskEnvironmentByTaskID(ctx, taskID)
 	if err != nil {
-		s.logger.Warn("failed to lookup task environment for cleanup",
-			zap.String("task_id", taskID),
-			zap.Error(err))
-		return nil
+		return nil, err
 	}
-	return env
+	return env, nil
 }
 
 func (s *Service) runAsyncTaskCleanup(
@@ -1353,6 +1375,9 @@ func (s *Service) stopTaskRuntimeTargets(ctx context.Context, taskID string, sto
 		return failedStops
 	}
 	for _, target := range stopTargets {
+		if context.Cause(ctx) != nil {
+			return failedStops
+		}
 		if target.executionID != "" {
 			if err := s.executionStopper.StopExecution(ctx, target.executionID, stopReason, true); err != nil {
 				if target.terminal {
@@ -1403,6 +1428,9 @@ func (s *Service) performTaskCleanup(
 	preserveExecutorRows map[string]struct{},
 ) []error {
 	var errs []error
+	if cause := context.Cause(ctx); cause != nil {
+		return []error{cause}
+	}
 	hasPreservedRuntimes := len(preserveExecutorRows) > 0
 
 	if hasPreservedRuntimes {
@@ -1411,6 +1439,9 @@ func (s *Service) performTaskCleanup(
 			zap.Int("preserved_runtime_count", len(preserveExecutorRows)))
 	}
 	errs = append(errs, s.cleanupDestructiveTaskResources(ctx, taskID, sessions, worktrees, envCleanup, preserveExecutorRows)...)
+	if cause := context.Cause(ctx); cause != nil {
+		return append(errs, cause)
+	}
 
 	sessionIDs := cleanupSessionIDs(sessions, stopTargets)
 	for _, sessionID := range sessionIDs {
@@ -1419,6 +1450,9 @@ func (s *Service) performTaskCleanup(
 				zap.String("task_id", taskID),
 				zap.String("session_id", sessionID))
 			continue
+		}
+		if cause := context.Cause(ctx); cause != nil {
+			return append(errs, cause)
 		}
 		if err := s.executors.DeleteExecutorRunningBySessionID(ctx, sessionID); err != nil {
 			s.logger.Debug("failed to delete executor runtime for session",
@@ -1432,7 +1466,10 @@ func (s *Service) performTaskCleanup(
 	// Cleanup quick-chat workspace directories for all tasks (not just ephemeral).
 	// Non-ephemeral office tasks also get quick-chat dirs allocated by manager_launch.go;
 	// both cases must be cleaned up to avoid a disk leak.
-	errs = append(errs, s.cleanupQuickChatDirs(taskID, sessionIDs, preserveExecutorRows)...)
+	if cause := context.Cause(ctx); cause != nil {
+		return append(errs, cause)
+	}
+	errs = append(errs, s.cleanupQuickChatDirs(ctx, taskID, sessionIDs, preserveExecutorRows)...)
 
 	return errs
 }
@@ -1474,6 +1511,7 @@ func appendUniqueSessionID(sessionIDs []string, seen map[string]struct{}, sessio
 }
 
 func (s *Service) cleanupQuickChatDirs(
+	ctx context.Context,
 	taskID string,
 	sessionIDs []string,
 	preserveExecutorRows map[string]struct{},
@@ -1490,6 +1528,9 @@ func (s *Service) cleanupQuickChatDirs(
 		if _, statErr := os.Stat(sessionDir); statErr != nil {
 			// Directory does not exist — nothing to remove.
 			continue
+		}
+		if cause := context.Cause(ctx); cause != nil {
+			return append(errs, cause)
 		}
 		if err := os.RemoveAll(sessionDir); err != nil {
 			s.logger.Warn("failed to cleanup quick-chat workspace directory",
@@ -1517,6 +1558,9 @@ func (s *Service) cleanupDestructiveTaskResources(
 	preserveExecutorRows map[string]struct{},
 ) []error {
 	var errs []error
+	if cause := context.Cause(ctx); cause != nil {
+		return []error{cause}
+	}
 	skipOwnedEnvironment, err := s.hasActiveOtherTaskSessionsForEnvironment(ctx, taskID, envCleanup.env)
 	if err != nil {
 		s.logger.Warn("skipping task environment cleanup after shared-environment ownership check failed",
@@ -1531,8 +1575,14 @@ func (s *Service) cleanupDestructiveTaskResources(
 			zap.String("task_id", taskID),
 			zap.String("env_id", taskEnvironmentID(envCleanup.env)))
 	}
+	if cause := context.Cause(ctx); cause != nil {
+		return append(errs, cause)
+	}
 	if len(preserveExecutorRows) == 0 && !skipOwnedEnvironment {
 		errs = append(errs, s.cleanupTaskEnvironment(ctx, taskID, envCleanup)...)
+		if cause := context.Cause(ctx); cause != nil {
+			return append(errs, cause)
+		}
 	}
 	originalWorktreeCount := len(worktrees)
 	worktrees = s.filterOwnedWorktreesForTaskCleanup(ctx, taskID, sessions, worktrees, envCleanup.env, skipOwnedEnvironment)
@@ -1549,6 +1599,9 @@ func (s *Service) cleanupDestructiveTaskResources(
 	cleaner, ok := s.worktreeCleanup.(WorktreeBatchCleaner)
 	if !ok {
 		return errs
+	}
+	if cause := context.Cause(ctx); cause != nil {
+		return append(errs, cause)
 	}
 	if err := cleaner.CleanupWorktrees(ctx, worktrees); err != nil {
 		s.logger.Warn("failed to cleanup worktrees after delete",
@@ -1714,6 +1767,9 @@ func (s *Service) cleanupTaskEnvironment(
 	if cleanup.env == nil {
 		return nil
 	}
+	if cause := context.Cause(ctx); cause != nil {
+		return []error{cause}
+	}
 	if err := s.teardownEnvironmentResources(ctx, cleanup.env); err != nil {
 		s.logger.Warn("failed to teardown task environment during task cleanup",
 			zap.String("task_id", taskID),
@@ -1722,6 +1778,9 @@ func (s *Service) cleanupTaskEnvironment(
 		return []error{fmt.Errorf("teardown task environment %s: %w", cleanup.env.ID, err)}
 	}
 	if cleanup.deleteRow {
+		if cause := context.Cause(ctx); cause != nil {
+			return []error{cause}
+		}
 		if err := s.taskEnvironments.DeleteTaskEnvironment(ctx, cleanup.env.ID); err != nil {
 			s.logger.Warn("failed to delete task environment row during task cleanup",
 				zap.String("task_id", taskID),

--- a/apps/backend/internal/task/service/service_tasks_stop_test.go
+++ b/apps/backend/internal/task/service/service_tasks_stop_test.go
@@ -157,6 +157,31 @@ func (s *stubStopper) StopSession(_ context.Context, _, _ string, _ bool) error 
 	return s.stopSessionErr
 }
 
+type cancelAfterFirstStopper struct {
+	cancel context.CancelFunc
+	calls  []string
+}
+
+func (s *cancelAfterFirstStopper) StopTask(context.Context, string, string, bool) error {
+	return nil
+}
+
+func (s *cancelAfterFirstStopper) StopExecution(_ context.Context, id, _ string, _ bool) error {
+	s.calls = append(s.calls, id)
+	if len(s.calls) == 1 {
+		s.cancel()
+	}
+	return nil
+}
+
+func (s *cancelAfterFirstStopper) StopSession(_ context.Context, id, _ string, _ bool) error {
+	s.calls = append(s.calls, id)
+	if len(s.calls) == 1 {
+		s.cancel()
+	}
+	return nil
+}
+
 func TestStopTaskRuntimeTargets_TerminalStopFailureDoesNotBlockCleanup(t *testing.T) {
 	svc, _, _ := createTestService(t)
 	svc.executors = &stubExecutors{}
@@ -184,6 +209,22 @@ func TestStopTaskRuntimeTargets_NonTerminalStopFailureBlocksCleanup(t *testing.T
 	failed := svc.stopTaskRuntimeTargets(context.Background(), "task-b", targets, "archive", "stop failed")
 	if _, ok := failed["sess-running"]; !ok {
 		t.Error("non-terminal stop failure must add session to failedStops")
+	}
+}
+
+func TestStopTaskRuntimeTargets_CancellationStopsBeforeNextTarget(t *testing.T) {
+	svc, _, _ := createTestService(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	stopper := &cancelAfterFirstStopper{cancel: cancel}
+	svc.executionStopper = stopper
+
+	svc.stopTaskRuntimeTargets(ctx, "task-cancel", []taskStopTarget{
+		{sessionID: "session-1", executionID: "execution-1"},
+		{sessionID: "session-2", executionID: "execution-2"},
+	}, "archive", "stop failed")
+
+	if len(stopper.calls) != 1 || stopper.calls[0] != "execution-1" {
+		t.Fatalf("stop calls after cancellation = %v, want [execution-1]", stopper.calls)
 	}
 }
 

--- a/apps/backend/internal/task/service/service_test.go
+++ b/apps/backend/internal/task/service/service_test.go
@@ -124,6 +124,7 @@ func createTestService(t *testing.T) (*Service, *MockEventBus, *sqliterepo.Repos
 		Environments:     repo,
 		TaskEnvironments: repo,
 		Reviews:          repo,
+		ResourceCleanups: repo,
 	}, eventBus, log, RepositoryDiscoveryConfig{})
 	return svc, eventBus, repo
 }
@@ -1450,6 +1451,16 @@ func TestService_DeleteTaskPreservesExecutorRunningWhenStopFails(t *testing.T) {
 	if _, err := os.Stat(sessionDir); err != nil {
 		t.Fatalf("quick-chat directory should remain when stop fails: %v", err)
 	}
+	var cleanupState string
+	if err := repo.DB().QueryRowContext(ctx, `
+		SELECT state FROM task_resource_cleanup_jobs
+		WHERE task_id = ? AND trigger = 'delete'
+	`, "task-123").Scan(&cleanupState); err != nil {
+		t.Fatalf("load cleanup retry state: %v", err)
+	}
+	if cleanupState != string(models.TaskResourceCleanupStateRetryWait) {
+		t.Fatalf("cleanup state = %q, want retry_wait", cleanupState)
+	}
 }
 
 func TestService_DeleteTaskCleansSuccessfulSessionResourcesOnPartialStopFailure(t *testing.T) {
@@ -1776,6 +1787,31 @@ func TestService_ArchiveTaskFailsClosedWhenRuntimeInventoryFails(t *testing.T) {
 	}
 	if task.ArchivedAt != nil {
 		t.Fatal("task should not be archived when runtime inventory fails")
+	}
+}
+
+func TestService_ArchiveTaskPersistsCleanupIntentBeforeMutation(t *testing.T) {
+	svc, _, repo := createTestService(t)
+	ctx := context.Background()
+	_ = repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws-cleanup", Name: "Workspace"})
+	_ = repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf-cleanup", WorkspaceID: "ws-cleanup", Name: "Workflow"})
+	_ = repo.CreateTask(ctx, &models.Task{
+		ID: "task-cleanup", WorkspaceID: "ws-cleanup", WorkflowID: "wf-cleanup",
+		WorkflowStepID: "step-cleanup", Title: "Cleanup", Priority: "medium",
+	})
+
+	if err := svc.ArchiveTask(ctx, "task-cleanup"); err != nil {
+		t.Fatalf("ArchiveTask: %v", err)
+	}
+	var count int
+	if err := repo.DB().QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM task_resource_cleanup_jobs
+		WHERE task_id = ? AND trigger = 'archive'
+	`, "task-cleanup").Scan(&count); err != nil {
+		t.Fatalf("count cleanup jobs: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("archive cleanup jobs = %d, want 1", count)
 	}
 }
 

--- a/apps/backend/internal/task/service/service_test.go
+++ b/apps/backend/internal/task/service/service_test.go
@@ -126,6 +126,10 @@ func createTestService(t *testing.T) (*Service, *MockEventBus, *sqliterepo.Repos
 		Reviews:          repo,
 		ResourceCleanups: repo,
 	}, eventBus, log, RepositoryDiscoveryConfig{})
+	if err := svc.StartTaskResourceCleanupWorker(context.Background()); err != nil {
+		t.Fatalf("failed to start task resource cleanup worker: %v", err)
+	}
+	t.Cleanup(svc.StopTaskResourceCleanupWorker)
 	return svc, eventBus, repo
 }
 

--- a/apps/backend/internal/worktree/manager.go
+++ b/apps/backend/internal/worktree/manager.go
@@ -47,14 +47,26 @@ type Manager struct {
 	repoLockMu sync.Mutex
 
 	// Optional dependencies for script execution
-	repoProvider     RepositoryProvider
-	scriptMsgHandler ScriptMessageHandler
+	repoProvider      RepositoryProvider
+	scriptMsgHandler  ScriptMessageHandler
+	scriptEnvProvider ScriptEnvironmentProvider
 
 	// Timeouts for best-effort remote sync before creating a worktree.
 	fetchTimeout time.Duration
 	pullTimeout  time.Duration
 	// Bound for cheap git ref-inspection commands (branchExists, currentBranch).
 	inspectTimeout time.Duration
+}
+
+// ScriptEnvironmentProvider supplies install-managed environment variables to
+// repository setup and cleanup scripts.
+type ScriptEnvironmentProvider interface {
+	ExecutionEnvironment(ctx context.Context) (map[string]string, error)
+}
+
+// SetScriptEnvironmentProvider wires managed script environment settings.
+func (m *Manager) SetScriptEnvironmentProvider(provider ScriptEnvironmentProvider) {
+	m.scriptEnvProvider = provider
 }
 
 // ScriptMessageHandler provides script execution and message streaming.

--- a/apps/backend/internal/worktree/manager_cleanup.go
+++ b/apps/backend/internal/worktree/manager_cleanup.go
@@ -2,6 +2,7 @@ package worktree
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -10,7 +11,34 @@ import (
 	"time"
 
 	"go.uber.org/zap"
+
+	"github.com/kandev/kandev/internal/system/storage"
+	storageworkspaces "github.com/kandev/kandev/internal/system/storage/workspaces"
 )
+
+func (m *Manager) PruneQuarantinedWorkspace(ctx context.Context, entry storage.QuarantineEntry) error {
+	worktrees, err := m.GetAllByTaskID(ctx, entry.TaskID)
+	if err != nil {
+		return err
+	}
+	seen := make(map[string]struct{})
+	var errs []error
+	for _, wt := range worktrees {
+		if wt == nil || wt.RepositoryPath == "" {
+			continue
+		}
+		if _, ok := seen[wt.RepositoryPath]; ok {
+			continue
+		}
+		seen[wt.RepositoryPath] = struct{}{}
+		cmd := exec.CommandContext(ctx, "git", "worktree", "prune")
+		cmd.Dir = wt.RepositoryPath
+		if err := runGitCmd(ctx, cmd); err != nil {
+			errs = append(errs, fmt.Errorf("prune worktree registration for %s: %w", wt.RepositoryPath, err))
+		}
+	}
+	return errors.Join(errs...)
+}
 
 // RemoveByID removes a specific worktree by its ID and optionally its branch.
 func (m *Manager) RemoveByID(ctx context.Context, worktreeID string, removeBranch bool) error {
@@ -128,6 +156,7 @@ func (m *Manager) runWorktreeSetupScript(ctx context.Context, wt *Worktree) {
 		Script:       repo.SetupScript,
 		WorkingDir:   wt.Path,
 		ScriptType:   "setup",
+		Env:          m.managedScriptEnvironment(ctx),
 	}
 	if err := m.scriptMsgHandler.ExecuteSetupScript(ctx, scriptReq); err != nil {
 		// Non-fatal: keep the worktree and surface a warning. The detailed
@@ -168,6 +197,7 @@ func (m *Manager) runWorktreeCleanupScript(ctx context.Context, wt *Worktree) {
 		Script:       repo.CleanupScript,
 		WorkingDir:   wt.Path,
 		ScriptType:   "cleanup",
+		Env:          m.managedScriptEnvironment(ctx),
 	}
 	if err := m.scriptMsgHandler.ExecuteCleanupScript(ctx, scriptReq); err != nil {
 		m.logger.Warn("cleanup script failed, proceeding with deletion",
@@ -177,6 +207,22 @@ func (m *Manager) runWorktreeCleanupScript(ctx context.Context, wt *Worktree) {
 		m.logger.Info("cleanup script completed successfully",
 			zap.String("worktree_id", wt.ID))
 	}
+}
+
+func (m *Manager) managedScriptEnvironment(ctx context.Context) map[string]string {
+	if m.scriptEnvProvider == nil {
+		return nil
+	}
+	env, err := m.scriptEnvProvider.ExecutionEnvironment(ctx)
+	if err != nil {
+		m.logger.Warn("failed to resolve managed script environment", zap.Error(err))
+		return nil
+	}
+	cachePath := env["GOCACHE"]
+	if cachePath == "" || !filepath.IsAbs(cachePath) {
+		return nil
+	}
+	return map[string]string{"GOCACHE": filepath.Clean(cachePath)}
 }
 
 // CleanupWorktrees removes provided worktrees without re-fetching from the store.
@@ -270,6 +316,13 @@ func (m *Manager) tryRemoveEmptyTaskDir(worktreePath string) {
 	// tasksBase itself or any deeper / unrelated location.
 	if filepath.Dir(parent) != tasksBase {
 		return
+	}
+	entries, readErr := os.ReadDir(parent)
+	if readErr == nil && len(entries) == 1 && entries[0].Name() == storageworkspaces.OwnershipMarkerFilename && entries[0].Type().IsRegular() {
+		if err := os.Remove(filepath.Join(parent, storageworkspaces.OwnershipMarkerFilename)); err != nil && !os.IsNotExist(err) {
+			m.logger.Debug("task ownership marker not removed", zap.String("path", parent), zap.Error(err))
+			return
+		}
 	}
 	if err := os.Remove(parent); err != nil && !os.IsNotExist(err) {
 		m.logger.Debug("task dir not removed (likely non-empty)",

--- a/apps/backend/internal/worktree/manager_cleanup.go
+++ b/apps/backend/internal/worktree/manager_cleanup.go
@@ -24,20 +24,57 @@ func (m *Manager) PruneQuarantinedWorkspace(ctx context.Context, entry storage.Q
 	seen := make(map[string]struct{})
 	var errs []error
 	for _, wt := range worktrees {
-		if wt == nil || wt.RepositoryPath == "" {
+		if wt == nil || wt.RepositoryPath == "" || wt.Path == "" {
 			continue
 		}
-		if _, ok := seen[wt.RepositoryPath]; ok {
+		key := wt.RepositoryPath + "\x00" + filepath.Clean(wt.Path)
+		if _, ok := seen[key]; ok {
 			continue
 		}
-		seen[wt.RepositoryPath] = struct{}{}
-		cmd := exec.CommandContext(ctx, "git", "worktree", "prune")
-		cmd.Dir = wt.RepositoryPath
-		if err := runGitCmd(ctx, cmd); err != nil {
-			errs = append(errs, fmt.Errorf("prune worktree registration for %s: %w", wt.RepositoryPath, err))
+		seen[key] = struct{}{}
+		if err := m.pruneQuarantinedWorktree(ctx, wt); err != nil {
+			errs = append(errs, err)
 		}
 	}
 	return errors.Join(errs...)
+}
+
+func (m *Manager) pruneQuarantinedWorktree(ctx context.Context, wt *Worktree) error {
+	repoLock := m.getRepoLock(wt.RepositoryPath)
+	repoLock.Lock()
+	defer func() {
+		repoLock.Unlock()
+		m.releaseRepoLock(wt.RepositoryPath)
+	}()
+
+	cmd := exec.CommandContext(ctx, "git", "worktree", "remove", "--force", wt.Path)
+	cmd.Dir = wt.RepositoryPath
+	if _, err := runGitCmdCombinedOutput(ctx, cmd); err != nil {
+		present, inspectErr := worktreeRegistrationExists(ctx, wt.RepositoryPath, wt.Path)
+		if inspectErr != nil {
+			return fmt.Errorf("verify worktree registration for %s: %w", wt.Path, inspectErr)
+		}
+		if present {
+			return fmt.Errorf("remove worktree registration for %s: %w", wt.Path, err)
+		}
+	}
+	return nil
+}
+
+func worktreeRegistrationExists(ctx context.Context, repoPath, worktreePath string) (bool, error) {
+	cmd := exec.CommandContext(ctx, "git", "worktree", "list", "--porcelain", "-z")
+	cmd.Dir = repoPath
+	output, err := runGitCmdCombinedOutput(ctx, cmd)
+	if err != nil {
+		return false, err
+	}
+	want := filepath.Clean(worktreePath)
+	for _, field := range strings.Split(string(output), "\x00") {
+		if path, ok := strings.CutPrefix(field, "worktree "); ok && filepath.Clean(path) == want {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // RemoveByID removes a specific worktree by its ID and optionally its branch.

--- a/apps/backend/internal/worktree/manager_lifecycle.go
+++ b/apps/backend/internal/worktree/manager_lifecycle.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	storageworkspaces "github.com/kandev/kandev/internal/system/storage/workspaces"
 	"go.uber.org/zap"
 
 	"github.com/kandev/kandev/internal/worktree/copyfiles"
@@ -226,6 +227,12 @@ func (m *Manager) createInTaskDir(ctx context.Context, req CreateRequest, baseRe
 	taskDir := filepath.Dir(worktreePath)
 	if err := os.MkdirAll(taskDir, 0755); err != nil {
 		return nil, fmt.Errorf("failed to create task directory: %w", err)
+	}
+	if err := storageworkspaces.WriteOwnershipMarker(taskDir, storageworkspaces.OwnershipMarker{
+		TaskID: req.TaskID, WorkspaceID: req.WorkspaceID, TaskDirName: req.TaskDirName,
+		LayoutVersion: storageworkspaces.LayoutVersionSemantic,
+	}); err != nil {
+		return nil, fmt.Errorf("mark task directory ownership: %w", err)
 	}
 
 	_, branchName := m.buildWorktreeNames(req)

--- a/apps/backend/internal/worktree/manager_lifecycle.go
+++ b/apps/backend/internal/worktree/manager_lifecycle.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/kandev/kandev/internal/system/storage"
 	storageworkspaces "github.com/kandev/kandev/internal/system/storage/workspaces"
 	"go.uber.org/zap"
 
@@ -210,29 +211,9 @@ func (m *Manager) resolveBaseRefWithFallback(ctx context.Context, req *CreateReq
 // worktree one level below the task root and break agentctl's sibling-based
 // multi-repo detection.
 func (m *Manager) createInTaskDir(ctx context.Context, req CreateRequest, baseRef, fallbackWarning, fallbackDetail string) (*Worktree, error) {
-	repoDir := SanitizeRepoDirName(req.RepoName)
-	if repoDir == "" {
-		return nil, ErrInvalidRepoName
-	}
-	branchSlug := SanitizeBranchSlug(req.BranchSlug)
-	if req.BranchSlug != "" && branchSlug == "" {
-		return nil, ErrInvalidBranchSlug
-	}
-	worktreePath, err := m.config.TaskWorktreePath(req.TaskDirName, repoDir, branchSlug)
+	worktreePath, err := m.prepareTaskWorktreePath(req)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get task worktree path: %w", err)
-	}
-
-	// Ensure parent task directory exists
-	taskDir := filepath.Dir(worktreePath)
-	if err := os.MkdirAll(taskDir, 0755); err != nil {
-		return nil, fmt.Errorf("failed to create task directory: %w", err)
-	}
-	if err := storageworkspaces.WriteOwnershipMarker(taskDir, storageworkspaces.OwnershipMarker{
-		TaskID: req.TaskID, WorkspaceID: req.WorkspaceID, TaskDirName: req.TaskDirName,
-		LayoutVersion: storageworkspaces.LayoutVersionSemantic,
-	}); err != nil {
-		return nil, fmt.Errorf("mark task directory ownership: %w", err)
+		return nil, err
 	}
 
 	_, branchName := m.buildWorktreeNames(req)
@@ -318,6 +299,55 @@ func (m *Manager) createInTaskDir(ctx context.Context, req CreateRequest, baseRe
 		zap.String("branch", wt.Branch))
 
 	return wt, nil
+}
+
+func (m *Manager) prepareTaskWorktreePath(req CreateRequest) (string, error) {
+	repoDir := SanitizeRepoDirName(req.RepoName)
+	if repoDir == "" {
+		return "", ErrInvalidRepoName
+	}
+	branchSlug := SanitizeBranchSlug(req.BranchSlug)
+	if req.BranchSlug != "" && branchSlug == "" {
+		return "", ErrInvalidBranchSlug
+	}
+	worktreePath, err := m.config.TaskWorktreePath(req.TaskDirName, repoDir, branchSlug)
+	if err != nil {
+		return "", fmt.Errorf("failed to get task worktree path: %w", err)
+	}
+
+	taskDir := filepath.Dir(worktreePath)
+	if err := m.validateTaskDir(taskDir); err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(taskDir, 0755); err != nil {
+		return "", fmt.Errorf("failed to create task directory: %w", err)
+	}
+	if err := storageworkspaces.WriteOwnershipMarker(taskDir, storageworkspaces.OwnershipMarker{
+		TaskID: req.TaskID, WorkspaceID: req.WorkspaceID, TaskDirName: req.TaskDirName,
+		LayoutVersion: storageworkspaces.LayoutVersionSemantic,
+	}); err != nil {
+		return "", fmt.Errorf("mark task directory ownership: %w", err)
+	}
+	return worktreePath, nil
+}
+
+func (m *Manager) validateTaskDir(taskDir string) error {
+	tasksBase, err := m.config.ExpandedTasksBasePath()
+	if err != nil {
+		return fmt.Errorf("failed to resolve tasks base path: %w", err)
+	}
+	absTasksBase, err := filepath.Abs(tasksBase)
+	if err != nil {
+		return fmt.Errorf("failed to resolve tasks base path: %w", err)
+	}
+	absTaskDir, err := filepath.Abs(taskDir)
+	if err != nil {
+		return fmt.Errorf("failed to resolve task directory: %w", err)
+	}
+	if err := storage.ValidateNoSymlinkPath(absTasksBase, absTaskDir); err != nil {
+		return fmt.Errorf("unsafe task directory: %w", err)
+	}
+	return nil
 }
 
 // addWorktreeForBranch creates the git worktree, trying the checkout branch directly first

--- a/apps/backend/internal/worktree/manager_quarantine_cleanup_test.go
+++ b/apps/backend/internal/worktree/manager_quarantine_cleanup_test.go
@@ -50,10 +50,20 @@ func TestPruneQuarantinedWorkspacePreservesOtherRecoverableRegistration(t *testi
 	}
 	worktreeList := runGit(t, repoPath, "worktree", "list", "--porcelain")
 	if strings.Contains(worktreeList, "worktree "+firstPath) {
-		t.Fatalf("selected worktree registration was preserved:\n%s", worktreeList)
+		t.Fatalf("selected worktree registration remains after prune:\n%s", worktreeList)
+	}
+	if !strings.Contains(worktreeList, "worktree "+secondPath) {
+		t.Fatalf("recoverable sibling registration was removed:\n%s", worktreeList)
 	}
 	if err := mgr.PruneQuarantinedWorkspace(context.Background(), storage.QuarantineEntry{TaskID: "task-1"}); err != nil {
 		t.Fatalf("repeat PruneQuarantinedWorkspace: %v", err)
+	}
+	worktreeList = runGit(t, repoPath, "worktree", "list", "--porcelain")
+	if strings.Contains(worktreeList, "worktree "+firstPath) {
+		t.Fatalf("selected worktree registration returned after repeated prune:\n%s", worktreeList)
+	}
+	if !strings.Contains(worktreeList, "worktree "+secondPath) {
+		t.Fatalf("repeated prune removed recoverable sibling registration:\n%s", worktreeList)
 	}
 	if err := os.Rename(secondQuarantine, filepath.Dir(secondPath)); err != nil {
 		t.Fatalf("restore second workspace: %v", err)

--- a/apps/backend/internal/worktree/manager_quarantine_cleanup_test.go
+++ b/apps/backend/internal/worktree/manager_quarantine_cleanup_test.go
@@ -1,0 +1,168 @@
+package worktree
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/system/storage"
+)
+
+func TestPruneQuarantinedWorkspacePreservesOtherRecoverableRegistration(t *testing.T) {
+	repoPath := initGitRepoForWorktreeTest(t)
+	store := newMockStore()
+	mgr, err := NewManager(newTestConfig(t), store, newTestLogger())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	originalRoot := t.TempDir()
+	quarantineRoot := t.TempDir()
+	firstPath := filepath.Join(originalRoot, "task-1", "repo")
+	secondPath := filepath.Join(originalRoot, "task-2", "repo")
+	runGit(t, repoPath, "branch", "task-1")
+	runGit(t, repoPath, "branch", "task-2")
+	runGit(t, repoPath, "worktree", "add", firstPath, "task-1")
+	runGit(t, repoPath, "worktree", "add", secondPath, "task-2")
+
+	firstQuarantine := filepath.Join(quarantineRoot, "entry-1")
+	secondQuarantine := filepath.Join(quarantineRoot, "entry-2")
+	if err := os.Rename(filepath.Dir(firstPath), firstQuarantine); err != nil {
+		t.Fatalf("quarantine first workspace: %v", err)
+	}
+	if err := os.Rename(filepath.Dir(secondPath), secondQuarantine); err != nil {
+		t.Fatalf("quarantine second workspace: %v", err)
+	}
+	store.worktrees["wt-1"] = &Worktree{
+		ID: "wt-1", TaskID: "task-1", RepositoryPath: repoPath, Path: firstPath,
+	}
+	store.worktrees["wt-2"] = &Worktree{
+		ID: "wt-2", TaskID: "task-2", RepositoryPath: repoPath, Path: secondPath,
+	}
+
+	if err := mgr.PruneQuarantinedWorkspace(context.Background(), storage.QuarantineEntry{TaskID: "task-1"}); err != nil {
+		t.Fatalf("PruneQuarantinedWorkspace: %v", err)
+	}
+	worktreeList := runGit(t, repoPath, "worktree", "list", "--porcelain")
+	if strings.Contains(worktreeList, "worktree "+firstPath) {
+		t.Fatalf("selected worktree registration was preserved:\n%s", worktreeList)
+	}
+	if err := mgr.PruneQuarantinedWorkspace(context.Background(), storage.QuarantineEntry{TaskID: "task-1"}); err != nil {
+		t.Fatalf("repeat PruneQuarantinedWorkspace: %v", err)
+	}
+	if err := os.Rename(secondQuarantine, filepath.Dir(secondPath)); err != nil {
+		t.Fatalf("restore second workspace: %v", err)
+	}
+	cmd := exec.Command("git", "status", "--porcelain")
+	cmd.Dir = secondPath
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("restored sibling worktree is unusable: %v\n%s", err, output)
+	}
+}
+
+func TestPruneQuarantinedWorkspaceWaitsForRepositoryLock(t *testing.T) {
+	repoPath := initGitRepoForWorktreeTest(t)
+	store := newMockStore()
+	mgr, err := NewManager(newTestConfig(t), store, newTestLogger())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	worktreePath := filepath.Join(t.TempDir(), "task-1", "repo")
+	runGit(t, repoPath, "branch", "task-1")
+	runGit(t, repoPath, "worktree", "add", worktreePath, "task-1")
+	store.worktrees["wt-1"] = &Worktree{
+		ID: "wt-1", TaskID: "task-1", RepositoryPath: repoPath, Path: worktreePath,
+	}
+
+	repoLock := mgr.getRepoLock(repoPath)
+	repoLock.Lock()
+	lockHeld := true
+	t.Cleanup(func() {
+		if lockHeld {
+			repoLock.Unlock()
+			mgr.releaseRepoLock(repoPath)
+		}
+	})
+
+	done := make(chan error, 1)
+	go func() {
+		done <- mgr.PruneQuarantinedWorkspace(
+			context.Background(),
+			storage.QuarantineEntry{TaskID: "task-1"},
+		)
+	}()
+
+	deadline := time.NewTimer(time.Second)
+	defer deadline.Stop()
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+	for {
+		mgr.repoLockMu.Lock()
+		entry := mgr.repoLocks[repoPath]
+		waitingForLock := entry != nil && entry.refCount == 2
+		mgr.repoLockMu.Unlock()
+		if waitingForLock {
+			break
+		}
+		select {
+		case err := <-done:
+			repoLock.Unlock()
+			mgr.releaseRepoLock(repoPath)
+			lockHeld = false
+			t.Fatalf("PruneQuarantinedWorkspace returned while repository lock was held: %v", err)
+		case <-deadline.C:
+			t.Fatal("PruneQuarantinedWorkspace did not acquire the repository lock")
+		case <-ticker.C:
+		}
+	}
+	select {
+	case err := <-done:
+		t.Fatalf("PruneQuarantinedWorkspace returned while waiting for repository lock: %v", err)
+	default:
+	}
+
+	repoLock.Unlock()
+	mgr.releaseRepoLock(repoPath)
+	lockHeld = false
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("PruneQuarantinedWorkspace: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("PruneQuarantinedWorkspace did not resume after repository lock was released")
+	}
+}
+
+func TestCreateInTaskDirRejectsSymlinkedTaskDirectory(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation may require elevated privileges on Windows")
+	}
+	repoPath := initGitRepoForWorktreeTest(t)
+	tasksBase := t.TempDir()
+	outside := t.TempDir()
+	linkedParent := filepath.Join(tasksBase, "linked-parent")
+	if err := os.Symlink(outside, linkedParent); err != nil {
+		t.Fatalf("create task-directory symlink: %v", err)
+	}
+	cfg := newTestConfig(t)
+	cfg.TasksBasePath = tasksBase
+	mgr, err := NewManager(cfg, newMockStore(), newTestLogger())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	_, err = mgr.createInTaskDir(context.Background(), CreateRequest{
+		TaskID: "task-1", SessionID: "session-1", RepositoryID: "repo-1",
+		RepositoryPath: repoPath, BaseBranch: "main", TaskDirName: "linked-parent/task-1", RepoName: "repo",
+	}, "main", "", "")
+	if err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("createInTaskDir() error = %v, want symlink rejection", err)
+	}
+}

--- a/apps/backend/internal/worktree/manager_script_environment_test.go
+++ b/apps/backend/internal/worktree/manager_script_environment_test.go
@@ -1,0 +1,63 @@
+package worktree
+
+import (
+	"context"
+	"testing"
+)
+
+type staticScriptEnvironment struct {
+	env map[string]string
+}
+
+func (p staticScriptEnvironment) ExecutionEnvironment(context.Context) (map[string]string, error) {
+	return p.env, nil
+}
+
+type cleanupEnvironmentRecorder struct {
+	setupReq   ScriptExecutionRequest
+	cleanupReq ScriptExecutionRequest
+}
+
+func (r *cleanupEnvironmentRecorder) ExecuteSetupScript(_ context.Context, req ScriptExecutionRequest) error {
+	r.setupReq = req
+	return nil
+}
+
+func (r *cleanupEnvironmentRecorder) ExecuteCleanupScript(_ context.Context, req ScriptExecutionRequest) error {
+	r.cleanupReq = req
+	return nil
+}
+
+func TestRunWorktreeCleanupScriptInjectsManagedGoCacheOnly(t *testing.T) {
+	provider := &fakeRepoProvider{repo: &Repository{
+		ID:            "repo-1",
+		SetupScript:   "go build ./...",
+		CleanupScript: "go clean -cache",
+	}}
+	recorder := &cleanupEnvironmentRecorder{}
+	mgr := newManagerForSetupTest(t, provider, recorder)
+	mgr.SetScriptEnvironmentProvider(staticScriptEnvironment{env: map[string]string{
+		"GOCACHE": "/opt/kandev/cache/go-build",
+		"TOKEN":   "must-not-be-injected",
+	}})
+
+	worktree := &Worktree{
+		ID:           "worktree-1",
+		TaskID:       "task-1",
+		SessionID:    "session-1",
+		RepositoryID: "repo-1",
+		Path:         t.TempDir(),
+	}
+	mgr.runWorktreeSetupScript(context.Background(), worktree)
+	mgr.runWorktreeCleanupScript(context.Background(), worktree)
+
+	if got := recorder.setupReq.Env["GOCACHE"]; got != "/opt/kandev/cache/go-build" {
+		t.Fatalf("setup GOCACHE = %q, want managed path", got)
+	}
+	if got := recorder.cleanupReq.Env["GOCACHE"]; got != "/opt/kandev/cache/go-build" {
+		t.Fatalf("cleanup GOCACHE = %q, want managed path", got)
+	}
+	if _, exists := recorder.cleanupReq.Env["TOKEN"]; exists {
+		t.Fatalf("cleanup script received unrelated provider environment: %#v", recorder.cleanupReq.Env)
+	}
+}

--- a/apps/backend/internal/worktree/manager_taskdir_checkout_branch_test.go
+++ b/apps/backend/internal/worktree/manager_taskdir_checkout_branch_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	storageworkspaces "github.com/kandev/kandev/internal/system/storage/workspaces"
 )
 
 func TestCreateInTaskDir_CheckoutBranchUsesRemoteStartPointAndUpstream(t *testing.T) {
@@ -22,6 +24,7 @@ func TestCreateInTaskDir_CheckoutBranchUsesRemoteStartPointAndUpstream(t *testin
 
 	wt1, err := mgr.Create(context.Background(), CreateRequest{
 		TaskID:         "task-1",
+		WorkspaceID:    "workspace-1",
 		SessionID:      "session-1",
 		TaskTitle:      "PR Review 1",
 		RepositoryID:   "repo-1",
@@ -36,6 +39,10 @@ func TestCreateInTaskDir_CheckoutBranchUsesRemoteStartPointAndUpstream(t *testin
 	}
 	if wt1.Branch != "feature/pr-branch" {
 		t.Fatalf("first worktree branch = %q, want %q", wt1.Branch, "feature/pr-branch")
+	}
+	marker, found, err := storageworkspaces.ReadOwnershipMarker(filepath.Dir(wt1.Path))
+	if err != nil || !found || marker.TaskID != "task-1" || marker.WorkspaceID != "workspace-1" || marker.LayoutVersion != storageworkspaces.LayoutVersionSemantic {
+		t.Fatalf("task root ownership marker = %#v found=%v err=%v", marker, found, err)
 	}
 
 	wt2, err := mgr.Create(context.Background(), CreateRequest{

--- a/apps/backend/internal/worktree/script_message_handler.go
+++ b/apps/backend/internal/worktree/script_message_handler.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/exec"
 	"sort"
-	"strings"
 	"sync"
 	"time"
 
@@ -340,24 +339,14 @@ func scriptProcessEnvironment(overrides map[string]string) []string {
 	if len(overrides) == 0 {
 		return nil
 	}
-	merged := make(map[string]string)
-	for _, item := range os.Environ() {
-		key, value, found := strings.Cut(item, "=")
-		if found {
-			merged[key] = value
-		}
-	}
-	for key, value := range overrides {
-		merged[key] = value
-	}
-	keys := make([]string, 0, len(merged))
-	for key := range merged {
+	env := os.Environ()
+	keys := make([]string, 0, len(overrides))
+	for key := range overrides {
 		keys = append(keys, key)
 	}
 	sort.Strings(keys)
-	env := make([]string, 0, len(keys))
 	for _, key := range keys {
-		env = append(env, key+"="+merged[key])
+		env = append(env, key+"="+overrides[key])
 	}
 	return env
 }

--- a/apps/backend/internal/worktree/script_message_handler.go
+++ b/apps/backend/internal/worktree/script_message_handler.go
@@ -5,7 +5,10 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
+	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -24,6 +27,7 @@ type ScriptExecutionRequest struct {
 	Script       string
 	WorkingDir   string
 	ScriptType   string // "setup" or "cleanup"
+	Env          map[string]string
 }
 
 // DefaultScriptMessageHandler manages script execution and streams output to session messages.
@@ -216,6 +220,7 @@ func (h *DefaultScriptMessageHandler) createScriptMessage(ctx context.Context, r
 func (h *DefaultScriptMessageHandler) runScriptWithOutput(ctx context.Context, req ScriptExecutionRequest, msg *models.Message) (int, error) {
 	cmd := shellexec.CommandContext(ctx, shellexec.PosixSh, req.Script)
 	cmd.Dir = req.WorkingDir
+	cmd.Env = scriptProcessEnvironment(req.Env)
 
 	stdoutPipe, err := cmd.StdoutPipe()
 	if err != nil {
@@ -290,6 +295,7 @@ func (h *DefaultScriptMessageHandler) runScriptWithoutMessage(ctx context.Contex
 	// Run script under the host shell (sh -c on Unix, bash/cmd on Windows).
 	cmd := shellexec.CommandContext(ctx, shellexec.PosixSh, req.Script)
 	cmd.Dir = req.WorkingDir
+	cmd.Env = scriptProcessEnvironment(req.Env)
 
 	// Capture output for logging
 	output, err := cmd.CombinedOutput()
@@ -328,4 +334,30 @@ func (h *DefaultScriptMessageHandler) runScriptWithoutMessage(ctx context.Contex
 	}
 
 	return nil
+}
+
+func scriptProcessEnvironment(overrides map[string]string) []string {
+	if len(overrides) == 0 {
+		return nil
+	}
+	merged := make(map[string]string)
+	for _, item := range os.Environ() {
+		key, value, found := strings.Cut(item, "=")
+		if found {
+			merged[key] = value
+		}
+	}
+	for key, value := range overrides {
+		merged[key] = value
+	}
+	keys := make([]string, 0, len(merged))
+	for key := range merged {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	env := make([]string, 0, len(keys))
+	for _, key := range keys {
+		env = append(env, key+"="+merged[key])
+	}
+	return env
 }

--- a/apps/backend/internal/worktree/script_message_handler_env_test.go
+++ b/apps/backend/internal/worktree/script_message_handler_env_test.go
@@ -30,3 +30,20 @@ func TestRunCleanupScriptWithoutMessageUsesRequestEnvironment(t *testing.T) {
 		t.Fatalf("cleanup GOCACHE = %q, want %q", got, req.Env["GOCACHE"])
 	}
 }
+
+func TestScriptProcessEnvironmentAppendsOverrideAfterCaseVariant(t *testing.T) {
+	t.Setenv("gocache", "/inherited/cache")
+	env := scriptProcessEnvironment(map[string]string{"GOCACHE": "/managed/cache"})
+	inheritedIndex, managedIndex := -1, -1
+	for i, item := range env {
+		switch item {
+		case "gocache=/inherited/cache":
+			inheritedIndex = i
+		case "GOCACHE=/managed/cache":
+			managedIndex = i
+		}
+	}
+	if inheritedIndex < 0 || managedIndex < 0 || managedIndex <= inheritedIndex {
+		t.Fatalf("environment order does not put managed override last: %v", env)
+	}
+}

--- a/apps/backend/internal/worktree/script_message_handler_env_test.go
+++ b/apps/backend/internal/worktree/script_message_handler_env_test.go
@@ -1,0 +1,32 @@
+package worktree
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestRunCleanupScriptWithoutMessageUsesRequestEnvironment(t *testing.T) {
+	t.Setenv("GOCACHE", "/home/user/.cache/go-build")
+	workDir := t.TempDir()
+	handler := NewDefaultScriptMessageHandler(newTestLogger(), nil, time.Minute)
+	req := ScriptExecutionRequest{
+		Script:     `printf '%s' "$GOCACHE" > gocache.txt`,
+		WorkingDir: workDir,
+		ScriptType: "cleanup",
+		Env:        map[string]string{"GOCACHE": "/opt/kandev/cache/go-build"},
+	}
+
+	if err := handler.runScriptWithoutMessage(context.Background(), req, false); err != nil {
+		t.Fatalf("runScriptWithoutMessage() error = %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(workDir, "gocache.txt"))
+	if err != nil {
+		t.Fatalf("read cleanup output: %v", err)
+	}
+	if string(got) != req.Env["GOCACHE"] {
+		t.Fatalf("cleanup GOCACHE = %q, want %q", got, req.Env["GOCACHE"])
+	}
+}

--- a/apps/backend/internal/worktree/worktree.go
+++ b/apps/backend/internal/worktree/worktree.go
@@ -180,6 +180,10 @@ type CreateRequest struct {
 	// ~/.kandev/tasks/{TaskDirName}/{RepoName}/ instead of ~/.kandev/worktrees/.
 	TaskDirName string
 
+	// WorkspaceID is persisted in the task-root ownership marker used by
+	// install-wide workspace maintenance.
+	WorkspaceID string
+
 	// RepoName is the repository name used as subdirectory inside the task directory.
 	// Only used when TaskDirName is also set.
 	RepoName string

--- a/apps/cli/src/release-config.test.ts
+++ b/apps/cli/src/release-config.test.ts
@@ -3,6 +3,7 @@ import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
 const repoRoot = resolve(__dirname, "../../..");
+const externalPnpmWorkflowFiles = new Set([".github/workflows/notify-docs.yml"]);
 
 function readRepoFile(path: string): string {
   return readFileSync(resolve(repoRoot, path), "utf8");
@@ -147,7 +148,7 @@ function extractWorkflowPnpmVersions(workflow: string): Array<string | undefined
   return versions;
 }
 
-function assertWorkflowPnpmVersions(file: string, expectedVersion: string): number {
+function assertWorkflowPnpmVersions(file: string, expectedVersion?: string): number {
   const versions = extractWorkflowPnpmVersions(readRepoFile(file));
   for (const version of versions) {
     if (version === undefined) {
@@ -155,9 +156,11 @@ function assertWorkflowPnpmVersions(file: string, expectedVersion: string): numb
       continue;
     }
 
-    expect(version, `${file}: pnpm/action-setup version must match apps/package.json`).toBe(
-      expectedVersion,
-    );
+    if (expectedVersion !== undefined) {
+      expect(version, `${file}: pnpm/action-setup version must match apps/package.json`).toBe(
+        expectedVersion,
+      );
+    }
   }
 
   return versions.length;
@@ -214,10 +217,10 @@ describe("release runtime tooling configuration", () => {
       'npm install -g --prefix /usr/local "pnpm@${PNPM_VERSION}"',
     );
 
-    const workflowSetupCount = workflowFiles().reduce(
-      (count, file) => count + assertWorkflowPnpmVersions(file, packagePnpmVersion),
-      0,
-    );
+    const workflowSetupCount = workflowFiles().reduce((count, file) => {
+      const expectedVersion = externalPnpmWorkflowFiles.has(file) ? undefined : packagePnpmVersion;
+      return count + assertWorkflowPnpmVersions(file, expectedVersion);
+    }, 0);
     expect(workflowSetupCount).toBeGreaterThan(0);
   });
 });

--- a/apps/web/app/settings/system/storage/page.tsx
+++ b/apps/web/app/settings/system/storage/page.tsx
@@ -1,0 +1,13 @@
+import { StorageMaintenanceSettings } from "@/components/settings/system/storage/storage-maintenance-settings";
+import { SystemPageShell } from "@/components/settings/system/system-page-shell";
+
+export default function StoragePage() {
+  return (
+    <SystemPageShell
+      title="Storage"
+      description="Analyze disk use and safely maintain Kandev-owned workspaces, caches, and Docker resources."
+    >
+      <StorageMaintenanceSettings />
+    </SystemPageShell>
+  );
+}

--- a/apps/web/app/settings/system/storage/page.tsx
+++ b/apps/web/app/settings/system/storage/page.tsx
@@ -5,7 +5,7 @@ export default function StoragePage() {
   return (
     <SystemPageShell
       title="Storage"
-      description="Analyze disk use and safely maintain Kandev-owned workspaces, caches, and Docker resources."
+      description="Review disk use and reclaim space from Kandev-owned workspaces, caches, and Docker resources whenever your installation needs it."
     >
       <StorageMaintenanceSettings />
     </SystemPageShell>

--- a/apps/web/components/app-sidebar/sections/settings/system-group.tsx
+++ b/apps/web/components/app-sidebar/sections/settings/system-group.tsx
@@ -10,6 +10,7 @@ import {
   IconRefresh,
   IconScale,
   IconServerCog,
+  IconTrash,
 } from "@tabler/icons-react";
 import type { Icon as TablerIcon } from "@tabler/icons-react";
 import { SettingsGroup, SettingsLeaf } from "./settings-nav-primitives";
@@ -22,6 +23,7 @@ const ITEMS: Array<{ href: string; label: string; icon: TablerIcon }> = [
   { href: `${ROOT_HREF}/feature-toggles`, label: "Feature Toggles", icon: IconFlask },
   { href: `${ROOT_HREF}/database`, label: "Database", icon: IconDatabase },
   { href: `${ROOT_HREF}/backups`, label: "Backups", icon: IconArchive },
+  { href: `${ROOT_HREF}/storage`, label: "Storage", icon: IconTrash },
   { href: `${ROOT_HREF}/logs`, label: "Logs", icon: IconFileText },
   { href: `${ROOT_HREF}/updates`, label: "Updates", icon: IconRefresh },
   { href: `${ROOT_HREF}/about`, label: "About", icon: IconInfoCircle },

--- a/apps/web/components/settings/agent-usage-section.test.tsx
+++ b/apps/web/components/settings/agent-usage-section.test.tsx
@@ -2,10 +2,9 @@ import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { TooltipProvider } from "@kandev/ui/tooltip";
 import { AgentUsageSection } from "@/components/settings/agent-usage-section";
-import type { AgentSubscriptionUsageResponse } from "@/lib/types/http";
 
 const listAgentSubscriptionUsage = vi.hoisted(() =>
-  vi.fn<() => Promise<AgentSubscriptionUsageResponse>>(),
+  vi.fn<typeof import("@/lib/api").listAgentSubscriptionUsage>(),
 );
 
 vi.mock("@/lib/api", () => ({

--- a/apps/web/components/settings/system/storage/storage-action-button.tsx
+++ b/apps/web/components/settings/system/storage/storage-action-button.tsx
@@ -1,0 +1,27 @@
+import type { ComponentProps } from "react";
+import { Button } from "@kandev/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
+
+type Props = ComponentProps<typeof Button> & { disabledReason?: string };
+
+export function StorageActionButton({ disabledReason, disabled, className, ...props }: Props) {
+  const isDisabled = disabled || Boolean(disabledReason);
+  const button = (
+    <Button
+      {...props}
+      disabled={isDisabled}
+      className={`min-h-11 cursor-pointer ${className ?? ""}`}
+    />
+  );
+  if (!disabledReason) return button;
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span tabIndex={0} className="inline-flex min-h-11">
+          {button}
+        </span>
+      </TooltipTrigger>
+      <TooltipContent className="max-w-xs">{disabledReason}</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/apps/web/components/settings/system/storage/storage-confirmation-dialogs.tsx
+++ b/apps/web/components/settings/system/storage/storage-confirmation-dialogs.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@kandev/ui/alert-dialog";
+import { Input } from "@kandev/ui/input";
+import type { StorageQuarantineEntry } from "@/lib/types/system";
+
+type ConfirmationDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  description: string;
+  phrase: "DEDICATED" | "ADOPT" | "DELETE";
+  actionLabel: string;
+  actionTestId: string;
+  destructive?: boolean;
+  onConfirm: () => void;
+};
+
+function ConfirmationDialog(props: ConfirmationDialogProps) {
+  const [confirmation, setConfirmation] = useState("");
+  useEffect(() => {
+    if (!props.open) setConfirmation("");
+  }, [props.open]);
+  return (
+    <AlertDialog open={props.open} onOpenChange={props.onOpenChange}>
+      <AlertDialogContent className="max-w-[calc(100vw-2rem)] sm:max-w-md">
+        <AlertDialogHeader>
+          <AlertDialogTitle>{props.title}</AlertDialogTitle>
+          <AlertDialogDescription className="text-left">
+            {props.description} Type <strong>{props.phrase}</strong> to continue.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <Input
+          value={confirmation}
+          onChange={(event) => setConfirmation(event.target.value)}
+          className="h-11"
+          aria-label={`Type ${props.phrase} to confirm`}
+          data-testid={`${props.actionTestId}-confirmation`}
+        />
+        <AlertDialogFooter>
+          <AlertDialogCancel className="min-h-11 cursor-pointer">Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            variant={props.destructive ? "destructive" : "default"}
+            disabled={confirmation !== props.phrase}
+            onClick={props.onConfirm}
+            className="min-h-11 cursor-pointer"
+            data-testid={props.actionTestId}
+          >
+            {props.actionLabel}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}
+
+export function DedicatedDockerDialog(
+  props: Pick<ConfirmationDialogProps, "open" | "onOpenChange" | "onConfirm">,
+) {
+  return (
+    <ConfirmationDialog
+      {...props}
+      title="Use this dedicated Docker daemon"
+      description="Build-cache and unused-image cleanup affect the entire configured daemon, including resources created outside Kandev. Only acknowledge a daemon dedicated to this installation."
+      phrase="DEDICATED"
+      actionLabel="Acknowledge daemon"
+      actionTestId="storage-docker-confirm"
+    />
+  );
+}
+
+export function ExternalGoCacheDialog({
+  path,
+  ...props
+}: Pick<ConfirmationDialogProps, "open" | "onOpenChange" | "onConfirm"> & { path: string }) {
+  return (
+    <ConfirmationDialog
+      {...props}
+      title="Adopt an external Go build cache"
+      description={`Kandev will be allowed to rotate and quarantine the existing cache at ${path || "the selected path"}. This path must be absolute and on the same filesystem as Kandev trash.`}
+      phrase="ADOPT"
+      actionLabel="Adopt cache"
+      actionTestId="storage-go-cache-adopt-confirm"
+    />
+  );
+}
+
+export function PermanentDeleteDialog({
+  entry,
+  ...props
+}: Pick<ConfirmationDialogProps, "open" | "onOpenChange" | "onConfirm"> & {
+  entry: StorageQuarantineEntry | null;
+}) {
+  return (
+    <ConfirmationDialog
+      {...props}
+      title="Permanently delete quarantined data"
+      description={`This cannot be undone. Kandev will permanently remove ${entry?.quarantine_path ?? "the selected quarantine entry"}.`}
+      phrase="DELETE"
+      actionLabel="Delete permanently"
+      actionTestId="storage-quarantine-delete-confirm"
+      destructive
+    />
+  );
+}

--- a/apps/web/components/settings/system/storage/storage-maintenance-settings.test.tsx
+++ b/apps/web/components/settings/system/storage/storage-maintenance-settings.test.tsx
@@ -1,11 +1,12 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { TooltipProvider } from "@kandev/ui/tooltip";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { StorageOverviewResponse } from "@/lib/types/system";
 import { StorageMaintenanceSettings } from "./storage-maintenance-settings";
 
 const mocks = vi.hoisted(() => ({
   useStorageMaintenance: vi.fn(),
+  useSystemJob: vi.fn(),
 }));
 
 vi.mock("@/hooks/domains/system/use-storage-maintenance", () => ({
@@ -13,7 +14,7 @@ vi.mock("@/hooks/domains/system/use-storage-maintenance", () => ({
 }));
 
 vi.mock("@/hooks/domains/system/use-system-jobs", () => ({
-  useSystemJob: () => undefined,
+  useSystemJob: mocks.useSystemJob,
   useSystemJobs: () => [],
 }));
 
@@ -79,8 +80,34 @@ function controller(currentOverview: StorageOverviewResponse) {
 }
 
 describe("StorageMaintenanceSettings", () => {
+  afterEach(cleanup);
+
   beforeEach(() => {
+    mocks.useSystemJob.mockReturnValue(undefined);
     mocks.useStorageMaintenance.mockReturnValue(controller(overview));
+  });
+
+  it("keeps analysis completion beside the Analyze action", () => {
+    mocks.useSystemJob.mockReturnValue({
+      id: "analysis-1",
+      kind: "storage-analysis",
+      state: "succeeded",
+      started_at: "2026-07-16T00:00:00Z",
+    });
+    mocks.useStorageMaintenance.mockReturnValue({
+      ...controller(overview),
+      analysisJob: { id: "analysis-1" },
+    });
+
+    render(
+      <TooltipProvider>
+        <StorageMaintenanceSettings />
+      </TooltipProvider>,
+    );
+
+    const analyzeControl = screen.getByTestId("storage-analyze-control");
+    expect(analyzeControl.textContent).toContain("Analyze");
+    expect(analyzeControl.textContent).toContain("Analysis complete");
   });
 
   it("preserves a dirty policy draft when refreshed overview data arrives", () => {

--- a/apps/web/components/settings/system/storage/storage-maintenance-settings.test.tsx
+++ b/apps/web/components/settings/system/storage/storage-maintenance-settings.test.tsx
@@ -1,0 +1,109 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { TooltipProvider } from "@kandev/ui/tooltip";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { StorageOverviewResponse } from "@/lib/types/system";
+import { StorageMaintenanceSettings } from "./storage-maintenance-settings";
+
+const mocks = vi.hoisted(() => ({
+  useStorageMaintenance: vi.fn(),
+}));
+
+vi.mock("@/hooks/domains/system/use-storage-maintenance", () => ({
+  useStorageMaintenance: mocks.useStorageMaintenance,
+}));
+
+vi.mock("@/hooks/domains/system/use-system-jobs", () => ({
+  useSystemJob: () => undefined,
+  useSystemJobs: () => [],
+}));
+
+const overview = {
+  settings: {
+    enabled: false,
+    check_interval_hours: 24,
+    idle_for_minutes: 10,
+    orphan_grace_hours: 168,
+    quarantine_retention_hours: 168,
+    workspaces: { enabled: true },
+    kandev_containers: { enabled: true },
+    go_cache: { enabled: false, max_bytes: 16106127360, adopted_path: "" },
+    docker: {
+      dedicated_daemon_acknowledged: false,
+      build_cache_enabled: false,
+      build_cache_keep_bytes: 10737418240,
+      build_cache_unused_hours: 168,
+      unused_images_enabled: false,
+      unused_images_hours: 168,
+    },
+  },
+  capabilities: {
+    managed_go_cache_path: "/data/cache/go-build",
+    go_cache_adoption_available: true,
+    docker_available: true,
+    docker_host: "",
+    host_global_docker_cleanup_allowed: true,
+  },
+  summary: {
+    workspaces: { active_bytes: 0, candidate_bytes: 0 },
+    go_cache: { path: "/data/cache/go-build", size_bytes: 0, owned: true, enabled: false },
+    quarantine: { count: 0, size_bytes: 0 },
+    docker: {
+      available: true,
+      build_cache_bytes: 0,
+      unused_image_bytes: 0,
+      managed_container_count: 0,
+      managed_container_bytes: 0,
+    },
+  },
+  last_run: null,
+} satisfies StorageOverviewResponse;
+
+function controller(currentOverview: StorageOverviewResponse) {
+  return {
+    overview: currentOverview,
+    runs: [],
+    quarantine: [],
+    pendingAction: null,
+    error: null,
+    analysisJob: undefined,
+    cleanupJob: undefined,
+    deleteJob: undefined,
+    analyze: vi.fn(),
+    runNow: vi.fn(),
+    save: vi.fn(),
+    adopt: vi.fn(),
+    restore: vi.fn(),
+    permanentlyDelete: vi.fn(),
+    reload: vi.fn(),
+  };
+}
+
+describe("StorageMaintenanceSettings", () => {
+  beforeEach(() => {
+    mocks.useStorageMaintenance.mockReturnValue(controller(overview));
+  });
+
+  it("preserves a dirty policy draft when refreshed overview data arrives", () => {
+    const { rerender } = render(
+      <TooltipProvider>
+        <StorageMaintenanceSettings />
+      </TooltipProvider>,
+    );
+    const idlePeriod = screen.getByTestId("storage-idle-period") as HTMLInputElement;
+    fireEvent.change(idlePeriod, { target: { value: "31" } });
+
+    mocks.useStorageMaintenance.mockReturnValue(
+      controller({
+        ...overview,
+        settings: { ...overview.settings, check_interval_hours: 48 },
+      }),
+    );
+    rerender(
+      <TooltipProvider>
+        <StorageMaintenanceSettings />
+      </TooltipProvider>,
+    );
+
+    expect((screen.getByTestId("storage-idle-period") as HTMLInputElement).value).toBe("31");
+  });
+});

--- a/apps/web/components/settings/system/storage/storage-maintenance-settings.test.tsx
+++ b/apps/web/components/settings/system/storage/storage-maintenance-settings.test.tsx
@@ -87,16 +87,17 @@ describe("StorageMaintenanceSettings", () => {
     mocks.useStorageMaintenance.mockReturnValue(controller(overview));
   });
 
-  it("keeps analysis completion beside the Analyze action", () => {
-    mocks.useSystemJob.mockReturnValue({
+  it("shows analysis completion inside the Analyze button", () => {
+    const analysisJob = {
       id: "analysis-1",
       kind: "storage-analysis",
       state: "succeeded",
       started_at: "2026-07-16T00:00:00Z",
-    });
+    } as const;
+    mocks.useSystemJob.mockReturnValue(analysisJob);
     mocks.useStorageMaintenance.mockReturnValue({
       ...controller(overview),
-      analysisJob: { id: "analysis-1" },
+      analysisJob,
     });
 
     render(
@@ -105,9 +106,33 @@ describe("StorageMaintenanceSettings", () => {
       </TooltipProvider>,
     );
 
-    const analyzeControl = screen.getByTestId("storage-analyze-control");
-    expect(analyzeControl.textContent).toContain("Analyze");
-    expect(analyzeControl.textContent).toContain("Analysis complete");
+    const analyzeButton = screen.getByTestId("storage-analyze");
+    expect(analyzeButton.textContent?.trim()).toBe("Analysis complete");
+    expect(analyzeButton.getAttribute("data-job-state")).toBe("succeeded");
+    expect(screen.queryByTestId("storage-analysis-job")).toBeNull();
+  });
+
+  it("keeps the Analyze button disabled while its job is active", () => {
+    const analysisJob = {
+      id: "analysis-1",
+      kind: "storage-analysis",
+      state: "running",
+      started_at: "2026-07-16T00:00:00Z",
+    } as const;
+    mocks.useStorageMaintenance.mockReturnValue({
+      ...controller(overview),
+      analysisJob,
+    });
+
+    render(
+      <TooltipProvider>
+        <StorageMaintenanceSettings />
+      </TooltipProvider>,
+    );
+
+    const analyzeButton = screen.getByTestId("storage-analyze") as HTMLButtonElement;
+    expect(analyzeButton.textContent?.trim()).toBe("Analyzing...");
+    expect(analyzeButton.disabled).toBe(true);
   });
 
   it("preserves a dirty policy draft when refreshed overview data arrives", () => {

--- a/apps/web/components/settings/system/storage/storage-maintenance-settings.tsx
+++ b/apps/web/components/settings/system/storage/storage-maintenance-settings.tsx
@@ -1,16 +1,59 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import { Alert, AlertDescription, AlertTitle } from "@kandev/ui/alert";
-import { IconAlertTriangle, IconPlayerPlay, IconRefresh } from "@tabler/icons-react";
+import { Spinner } from "@kandev/ui/spinner";
+import { IconAlertTriangle, IconCheck, IconPlayerPlay, IconRefresh } from "@tabler/icons-react";
 import { useStorageMaintenance } from "@/hooks/domains/system/use-storage-maintenance";
-import type { StorageMaintenanceSettings as Settings } from "@/lib/types/system";
-import { JobProgressIndicator } from "../job-progress-indicator";
+import type { StorageMaintenanceSettings as Settings, SystemJob } from "@/lib/types/system";
 import { StorageActionButton } from "./storage-action-button";
 import { StorageOverviewCard } from "./storage-overview-card";
 import { StoragePolicyCard } from "./storage-policy-card";
 import { StorageQuarantineCard } from "./storage-quarantine-card";
 import { StorageRunHistory } from "./storage-run-history";
+
+function StorageJobButtonContent({
+  job,
+  idleLabel,
+  activeLabel,
+  successLabel,
+  failedLabel,
+  idleIcon,
+}: {
+  job?: SystemJob;
+  idleLabel: string;
+  activeLabel: string;
+  successLabel: string;
+  failedLabel: string;
+  idleIcon: ReactNode;
+}) {
+  if (job?.state === "queued" || job?.state === "running") {
+    return (
+      <>
+        <Spinner className="size-4" /> {activeLabel}
+      </>
+    );
+  }
+  if (job?.state === "succeeded") {
+    return (
+      <>
+        <IconCheck className="size-4" /> {successLabel}
+      </>
+    );
+  }
+  if (job?.state === "failed") {
+    return (
+      <>
+        <IconAlertTriangle className="size-4" /> {failedLabel}
+      </>
+    );
+  }
+  return (
+    <>
+      {idleIcon} {idleLabel}
+    </>
+  );
+}
 
 function StorageActions({
   controller,
@@ -19,6 +62,10 @@ function StorageActions({
   controller: ReturnType<typeof useStorageMaintenance>;
   disabledReason?: string;
 }) {
+  const analysisActive =
+    controller.analysisJob?.state === "queued" || controller.analysisJob?.state === "running";
+  const cleanupActive =
+    controller.cleanupJob?.state === "queued" || controller.cleanupJob?.state === "running";
   return (
     <div className="flex min-w-0 flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
       <div className="min-w-0 sm:max-w-xl">
@@ -29,44 +76,46 @@ function StorageActions({
         </p>
       </div>
       <div className="grid min-w-0 grid-cols-1 gap-3 sm:grid-cols-2">
-        <div
-          className="flex flex-col items-stretch gap-2 sm:items-end"
-          data-testid="storage-analyze-control"
-        >
+        <div data-testid="storage-analyze-control">
           <StorageActionButton
             variant="outline"
-            className="w-full sm:w-auto"
-            disabledReason={disabledReason}
+            className="w-full sm:w-44"
+            disabledReason={
+              disabledReason ?? (analysisActive ? "Storage analysis is still running." : undefined)
+            }
             onClick={() => void controller.analyze()}
             data-testid="storage-analyze"
+            data-job-state={controller.analysisJob?.state}
           >
-            <IconRefresh className="size-4" /> Analyze
+            <StorageJobButtonContent
+              job={controller.analysisJob}
+              idleLabel="Analyze"
+              activeLabel="Analyzing..."
+              successLabel="Analysis complete"
+              failedLabel="Analysis failed"
+              idleIcon={<IconRefresh className="size-4" />}
+            />
           </StorageActionButton>
-          <JobProgressIndicator
-            kind="storage-analysis"
-            jobId={controller.analysisJob?.id}
-            successLabel="Analysis complete"
-            testId="storage-analysis-job"
-          />
         </div>
-        <div
-          className="flex flex-col items-stretch gap-2 sm:items-end"
-          data-testid="storage-cleanup-control"
-        >
+        <div data-testid="storage-cleanup-control">
           <StorageActionButton
-            className="w-full sm:w-auto"
-            disabledReason={disabledReason}
+            className="w-full sm:w-44"
+            disabledReason={
+              disabledReason ?? (cleanupActive ? "Storage cleanup is still running." : undefined)
+            }
             onClick={() => void controller.runNow()}
             data-testid="storage-run-now"
+            data-job-state={controller.cleanupJob?.state}
           >
-            <IconPlayerPlay className="size-4" /> Run now
+            <StorageJobButtonContent
+              job={controller.cleanupJob}
+              idleLabel="Run now"
+              activeLabel="Cleaning..."
+              successLabel="Cleanup complete"
+              failedLabel="Cleanup failed"
+              idleIcon={<IconPlayerPlay className="size-4" />}
+            />
           </StorageActionButton>
-          <JobProgressIndicator
-            kind="storage-cleanup"
-            jobId={controller.cleanupJob?.id}
-            successLabel="Cleanup complete"
-            testId="storage-cleanup-job"
-          />
         </div>
       </div>
     </div>

--- a/apps/web/components/settings/system/storage/storage-maintenance-settings.tsx
+++ b/apps/web/components/settings/system/storage/storage-maintenance-settings.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Alert, AlertDescription, AlertTitle } from "@kandev/ui/alert";
+import { IconAlertTriangle, IconPlayerPlay, IconRefresh } from "@tabler/icons-react";
+import { useStorageMaintenance } from "@/hooks/domains/system/use-storage-maintenance";
+import type { StorageMaintenanceSettings as Settings } from "@/lib/types/system";
+import { JobProgressIndicator } from "../job-progress-indicator";
+import { StorageActionButton } from "./storage-action-button";
+import { StorageOverviewCard } from "./storage-overview-card";
+import { StoragePolicyCard } from "./storage-policy-card";
+import { StorageQuarantineCard } from "./storage-quarantine-card";
+import { StorageRunHistory } from "./storage-run-history";
+
+export function StorageMaintenanceSettings() {
+  const controller = useStorageMaintenance();
+  const [draft, setDraft] = useState<Settings | null>(null);
+  useEffect(() => {
+    if (controller.overview) setDraft(controller.overview.settings);
+  }, [controller.overview]);
+  const pending = controller.pendingAction !== null;
+  const disabledReason = pending ? "Wait for the current storage action to finish." : undefined;
+
+  return (
+    <div className="min-w-0 space-y-6" data-testid="storage-settings-page">
+      <div className="flex min-w-0 flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex min-w-0 flex-col gap-2">
+          <JobProgressIndicator
+            kind="storage-analysis"
+            jobId={controller.analysisJob?.id}
+            testId="storage-analysis-job"
+          />
+          <JobProgressIndicator
+            kind="storage-cleanup"
+            jobId={controller.cleanupJob?.id}
+            testId="storage-cleanup-job"
+          />
+          <JobProgressIndicator
+            kind="storage-quarantine-delete"
+            jobId={controller.deleteJob?.id}
+            testId="storage-delete-job"
+          />
+        </div>
+        <div className="flex flex-col gap-2 sm:flex-row">
+          <StorageActionButton
+            variant="outline"
+            disabledReason={disabledReason}
+            onClick={() => void controller.analyze()}
+            data-testid="storage-analyze"
+          >
+            <IconRefresh className="size-4" /> Analyze
+          </StorageActionButton>
+          <StorageActionButton
+            disabledReason={disabledReason}
+            onClick={() => void controller.runNow()}
+            data-testid="storage-run-now"
+          >
+            <IconPlayerPlay className="size-4" /> Run now
+          </StorageActionButton>
+        </div>
+      </div>
+
+      {controller.error && (
+        <Alert variant="destructive" data-testid="storage-error">
+          <IconAlertTriangle className="size-4" />
+          <AlertTitle>Storage action failed</AlertTitle>
+          <AlertDescription className="break-words">{controller.error}</AlertDescription>
+        </Alert>
+      )}
+
+      <div className="grid min-w-0 grid-cols-1 gap-4 xl:grid-cols-2">
+        <StorageOverviewCard
+          overview={controller.overview}
+          disabledReason={disabledReason}
+          onRunGoCache={() => void controller.runNow(["go_cache"])}
+        />
+        {draft && controller.overview && (
+          <StoragePolicyCard
+            settings={draft}
+            capabilities={controller.overview.capabilities}
+            pending={pending}
+            onChange={setDraft}
+            onSave={() => controller.save(draft)}
+            onDedicatedConfirm={(next) => controller.save(next, "DEDICATED")}
+            onAdopt={controller.adopt}
+          />
+        )}
+      </div>
+      <StorageRunHistory runs={controller.runs} />
+      <StorageQuarantineCard
+        entries={controller.quarantine}
+        disabledReason={disabledReason}
+        onRestore={controller.restore}
+        onDelete={controller.permanentlyDelete}
+      />
+    </div>
+  );
+}

--- a/apps/web/components/settings/system/storage/storage-maintenance-settings.tsx
+++ b/apps/web/components/settings/system/storage/storage-maintenance-settings.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Alert, AlertDescription, AlertTitle } from "@kandev/ui/alert";
 import { IconAlertTriangle, IconPlayerPlay, IconRefresh } from "@tabler/icons-react";
 import { useStorageMaintenance } from "@/hooks/domains/system/use-storage-maintenance";
@@ -15,8 +15,18 @@ import { StorageRunHistory } from "./storage-run-history";
 export function StorageMaintenanceSettings() {
   const controller = useStorageMaintenance();
   const [draft, setDraft] = useState<Settings | null>(null);
+  const previousServerSettings = useRef<Settings | null>(null);
   useEffect(() => {
-    if (controller.overview) setDraft(controller.overview.settings);
+    if (!controller.overview) return;
+    const nextSettings = controller.overview.settings;
+    setDraft((current) => {
+      const previous = previousServerSettings.current;
+      if (!current || !previous || JSON.stringify(current) === JSON.stringify(previous)) {
+        return nextSettings;
+      }
+      return current;
+    });
+    previousServerSettings.current = nextSettings;
   }, [controller.overview]);
   const pending = controller.pendingAction !== null;
   const disabledReason = pending ? "Wait for the current storage action to finish." : undefined;

--- a/apps/web/components/settings/system/storage/storage-maintenance-settings.tsx
+++ b/apps/web/components/settings/system/storage/storage-maintenance-settings.tsx
@@ -12,6 +12,67 @@ import { StoragePolicyCard } from "./storage-policy-card";
 import { StorageQuarantineCard } from "./storage-quarantine-card";
 import { StorageRunHistory } from "./storage-run-history";
 
+function StorageActions({
+  controller,
+  disabledReason,
+}: {
+  controller: ReturnType<typeof useStorageMaintenance>;
+  disabledReason?: string;
+}) {
+  return (
+    <div className="flex min-w-0 flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+      <div className="min-w-0 sm:max-w-xl">
+        <p className="text-sm font-medium">Reclaim disk space safely</p>
+        <p className="text-xs text-muted-foreground">
+          Analyze for a read-only snapshot, or run the enabled cleanup rules when you want to
+          recover space immediately.
+        </p>
+      </div>
+      <div className="grid min-w-0 grid-cols-1 gap-3 sm:grid-cols-2">
+        <div
+          className="flex flex-col items-stretch gap-2 sm:items-end"
+          data-testid="storage-analyze-control"
+        >
+          <StorageActionButton
+            variant="outline"
+            className="w-full sm:w-auto"
+            disabledReason={disabledReason}
+            onClick={() => void controller.analyze()}
+            data-testid="storage-analyze"
+          >
+            <IconRefresh className="size-4" /> Analyze
+          </StorageActionButton>
+          <JobProgressIndicator
+            kind="storage-analysis"
+            jobId={controller.analysisJob?.id}
+            successLabel="Analysis complete"
+            testId="storage-analysis-job"
+          />
+        </div>
+        <div
+          className="flex flex-col items-stretch gap-2 sm:items-end"
+          data-testid="storage-cleanup-control"
+        >
+          <StorageActionButton
+            className="w-full sm:w-auto"
+            disabledReason={disabledReason}
+            onClick={() => void controller.runNow()}
+            data-testid="storage-run-now"
+          >
+            <IconPlayerPlay className="size-4" /> Run now
+          </StorageActionButton>
+          <JobProgressIndicator
+            kind="storage-cleanup"
+            jobId={controller.cleanupJob?.id}
+            successLabel="Cleanup complete"
+            testId="storage-cleanup-job"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export function StorageMaintenanceSettings() {
   const controller = useStorageMaintenance();
   const [draft, setDraft] = useState<Settings | null>(null);
@@ -33,42 +94,7 @@ export function StorageMaintenanceSettings() {
 
   return (
     <div className="min-w-0 space-y-6" data-testid="storage-settings-page">
-      <div className="flex min-w-0 flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <div className="flex min-w-0 flex-col gap-2">
-          <JobProgressIndicator
-            kind="storage-analysis"
-            jobId={controller.analysisJob?.id}
-            testId="storage-analysis-job"
-          />
-          <JobProgressIndicator
-            kind="storage-cleanup"
-            jobId={controller.cleanupJob?.id}
-            testId="storage-cleanup-job"
-          />
-          <JobProgressIndicator
-            kind="storage-quarantine-delete"
-            jobId={controller.deleteJob?.id}
-            testId="storage-delete-job"
-          />
-        </div>
-        <div className="flex flex-col gap-2 sm:flex-row">
-          <StorageActionButton
-            variant="outline"
-            disabledReason={disabledReason}
-            onClick={() => void controller.analyze()}
-            data-testid="storage-analyze"
-          >
-            <IconRefresh className="size-4" /> Analyze
-          </StorageActionButton>
-          <StorageActionButton
-            disabledReason={disabledReason}
-            onClick={() => void controller.runNow()}
-            data-testid="storage-run-now"
-          >
-            <IconPlayerPlay className="size-4" /> Run now
-          </StorageActionButton>
-        </div>
-      </div>
+      <StorageActions controller={controller} disabledReason={disabledReason} />
 
       {controller.error && (
         <Alert variant="destructive" data-testid="storage-error">
@@ -78,7 +104,7 @@ export function StorageMaintenanceSettings() {
         </Alert>
       )}
 
-      <div className="grid min-w-0 grid-cols-1 gap-4 xl:grid-cols-2">
+      <div className="min-w-0 space-y-4" data-testid="storage-primary-sections">
         <StorageOverviewCard
           overview={controller.overview}
           disabledReason={disabledReason}
@@ -99,6 +125,7 @@ export function StorageMaintenanceSettings() {
       <StorageRunHistory runs={controller.runs} />
       <StorageQuarantineCard
         entries={controller.quarantine}
+        deleteJobId={controller.deleteJob?.id}
         disabledReason={disabledReason}
         onRestore={controller.restore}
         onDelete={controller.permanentlyDelete}

--- a/apps/web/components/settings/system/storage/storage-overview-card.test.tsx
+++ b/apps/web/components/settings/system/storage/storage-overview-card.test.tsx
@@ -1,5 +1,5 @@
-import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { StorageOverviewResponse } from "@/lib/types/system";
 import { StorageOverviewCard } from "./storage-overview-card";
 
@@ -44,6 +44,8 @@ const degradedOverview = {
   last_run: null,
 } satisfies StorageOverviewResponse;
 
+afterEach(cleanup);
+
 describe("StorageOverviewCard", () => {
   it("renders a degraded quarantine warning without inventing zero usage", () => {
     render(<StorageOverviewCard overview={degradedOverview} onRunGoCache={vi.fn()} />);
@@ -53,5 +55,16 @@ describe("StorageOverviewCard", () => {
     expect(trigger.textContent).not.toContain("0 B");
     fireEvent.click(trigger);
     expect(screen.getByText("quarantine database unavailable")).toBeTruthy();
+  });
+
+  it("renders unavailable Docker resources without inventing zero usage", () => {
+    render(<StorageOverviewCard overview={degradedOverview} onRunGoCache={vi.fn()} />);
+
+    const dockerResourceIds = ["managed-containers", "docker-build-cache", "docker-unused-images"];
+    for (const resourceId of dockerResourceIds) {
+      const trigger = screen.getByTestId(`storage-resource-${resourceId}-trigger`);
+      expect(trigger.textContent).toContain("Unavailable");
+      expect(trigger.textContent).not.toContain("0 B");
+    }
   });
 });

--- a/apps/web/components/settings/system/storage/storage-overview-card.test.tsx
+++ b/apps/web/components/settings/system/storage/storage-overview-card.test.tsx
@@ -1,0 +1,57 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { StorageOverviewResponse } from "@/lib/types/system";
+import { StorageOverviewCard } from "./storage-overview-card";
+
+const degradedOverview = {
+  settings: {
+    enabled: false,
+    check_interval_hours: 24,
+    idle_for_minutes: 10,
+    orphan_grace_hours: 168,
+    quarantine_retention_hours: 168,
+    workspaces: { enabled: true },
+    kandev_containers: { enabled: true },
+    go_cache: { enabled: false, max_bytes: 16106127360, adopted_path: "" },
+    docker: {
+      dedicated_daemon_acknowledged: false,
+      build_cache_enabled: false,
+      build_cache_keep_bytes: 10737418240,
+      build_cache_unused_hours: 168,
+      unused_images_enabled: false,
+      unused_images_hours: 168,
+    },
+  },
+  capabilities: {
+    managed_go_cache_path: "/data/cache/go-build",
+    go_cache_adoption_available: true,
+    docker_available: false,
+    docker_host: "",
+    host_global_docker_cleanup_allowed: false,
+  },
+  summary: {
+    workspaces: { active_bytes: 0, candidate_bytes: 0 },
+    go_cache: { path: "/data/cache/go-build", size_bytes: 0, owned: true, enabled: false },
+    quarantine: { available: false, warning: "quarantine database unavailable" },
+    docker: {
+      available: false,
+      build_cache_bytes: 0,
+      unused_image_bytes: 0,
+      managed_container_count: 0,
+      managed_container_bytes: 0,
+    },
+  },
+  last_run: null,
+} satisfies StorageOverviewResponse;
+
+describe("StorageOverviewCard", () => {
+  it("renders a degraded quarantine warning without inventing zero usage", () => {
+    render(<StorageOverviewCard overview={degradedOverview} onRunGoCache={vi.fn()} />);
+
+    const trigger = screen.getByTestId("storage-resource-quarantine-trigger");
+    expect(trigger.textContent).toContain("Unavailable");
+    expect(trigger.textContent).not.toContain("0 B");
+    fireEvent.click(trigger);
+    expect(screen.getByText("quarantine database unavailable")).toBeTruthy();
+  });
+});

--- a/apps/web/components/settings/system/storage/storage-overview-card.tsx
+++ b/apps/web/components/settings/system/storage/storage-overview-card.tsx
@@ -49,6 +49,17 @@ function quarantineResource(summary: StorageQuarantineSummary): StorageResource 
   };
 }
 
+function dockerMeasurement(
+  available: boolean,
+  value: string,
+  detail: string,
+): Pick<StorageResource, "value" | "detail"> {
+  if (!available) {
+    return { value: "Unavailable", detail: "Docker usage could not be measured" };
+  }
+  return { value, detail };
+}
+
 function storageResources(overview: StorageOverviewResponse): StorageResource[] {
   const { summary } = overview;
   const dockerWarning = summary.docker.warnings?.join(" · ");
@@ -64,8 +75,11 @@ function storageResources(overview: StorageOverviewResponse): StorageResource[] 
     {
       id: "managed-containers",
       label: "Kandev containers",
-      value: formatBytes(summary.docker.managed_container_bytes ?? 0),
-      detail: `${summary.docker.managed_container_count ?? 0} managed containers`,
+      ...dockerMeasurement(
+        summary.docker.available,
+        formatBytes(summary.docker.managed_container_bytes ?? 0),
+        `${summary.docker.managed_container_count ?? 0} managed containers`,
+      ),
       warning: dockerWarning,
     },
     {
@@ -78,15 +92,21 @@ function storageResources(overview: StorageOverviewResponse): StorageResource[] 
     {
       id: "docker-build-cache",
       label: "Docker build cache",
-      value: formatBytes(summary.docker.build_cache_bytes),
-      detail: overview.capabilities.docker_host || "Default Docker host",
+      ...dockerMeasurement(
+        summary.docker.available,
+        formatBytes(summary.docker.build_cache_bytes),
+        overview.capabilities.docker_host || "Default Docker host",
+      ),
       warning: dockerWarning,
     },
     {
       id: "docker-unused-images",
       label: "Unused Docker images",
-      value: formatBytes(summary.docker.unused_image_bytes),
-      detail: "Unused by every container and older than the configured age",
+      ...dockerMeasurement(
+        summary.docker.available,
+        formatBytes(summary.docker.unused_image_bytes),
+        "Unused by every container and older than the configured age",
+      ),
       warning: dockerWarning,
     },
   ];

--- a/apps/web/components/settings/system/storage/storage-overview-card.tsx
+++ b/apps/web/components/settings/system/storage/storage-overview-card.tsx
@@ -1,10 +1,10 @@
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@kandev/ui/accordion";
 import { Badge } from "@kandev/ui/badge";
-import { Card, CardContent, CardHeader, CardTitle } from "@kandev/ui/card";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@kandev/ui/card";
 import { IconChartPie, IconTrash } from "@tabler/icons-react";
 import type { StorageOverviewResponse, StorageQuarantineSummary } from "@/lib/types/system";
-import { formatBytes } from "@/lib/utils/format-bytes";
 import { StorageActionButton } from "./storage-action-button";
+import { formatGigabytes } from "./storage-units";
 
 interface Props {
   overview: StorageOverviewResponse | null;
@@ -44,8 +44,8 @@ function quarantineResource(summary: StorageQuarantineSummary): StorageResource 
   return {
     id: "quarantine",
     label: "Quarantined resources",
-    value: formatBytes(summary.size_bytes),
-    detail: `${summary.count} resources awaiting recovery or deletion`,
+    value: formatGigabytes(summary.size_bytes),
+    detail: `${summary.count} items moved aside for recovery before permanent deletion`,
   };
 }
 
@@ -67,8 +67,8 @@ function storageResources(overview: StorageOverviewResponse): StorageResource[] 
     {
       id: "workspaces",
       label: "Task workspaces",
-      value: formatBytes(summary.workspaces.candidate_bytes ?? 0),
-      detail: `Active ${formatBytes(summary.workspaces.active_bytes ?? 0)}`,
+      value: formatGigabytes(summary.workspaces.candidate_bytes ?? 0),
+      detail: `Active workspaces use ${formatGigabytes(summary.workspaces.active_bytes ?? 0)}`,
       warning: summary.workspaces.warning,
     },
     quarantineResource(summary.quarantine),
@@ -77,7 +77,7 @@ function storageResources(overview: StorageOverviewResponse): StorageResource[] 
       label: "Kandev containers",
       ...dockerMeasurement(
         summary.docker.available,
-        formatBytes(summary.docker.managed_container_bytes ?? 0),
+        formatGigabytes(summary.docker.managed_container_bytes ?? 0),
         `${summary.docker.managed_container_count ?? 0} managed containers`,
       ),
       warning: dockerWarning,
@@ -85,7 +85,7 @@ function storageResources(overview: StorageOverviewResponse): StorageResource[] 
     {
       id: "go-cache",
       label: "Go build cache",
-      value: formatBytes(summary.go_cache.size_bytes ?? 0),
+      value: formatGigabytes(summary.go_cache.size_bytes ?? 0),
       detail: summary.go_cache.path ?? overview.capabilities.managed_go_cache_path,
       warning: summary.go_cache.warning,
     },
@@ -94,7 +94,7 @@ function storageResources(overview: StorageOverviewResponse): StorageResource[] 
       label: "Docker build cache",
       ...dockerMeasurement(
         summary.docker.available,
-        formatBytes(summary.docker.build_cache_bytes),
+        formatGigabytes(summary.docker.build_cache_bytes),
         overview.capabilities.docker_host || "Default Docker host",
       ),
       warning: dockerWarning,
@@ -104,7 +104,7 @@ function storageResources(overview: StorageOverviewResponse): StorageResource[] 
       label: "Unused Docker images",
       ...dockerMeasurement(
         summary.docker.available,
-        formatBytes(summary.docker.unused_image_bytes),
+        formatGigabytes(summary.docker.unused_image_bytes),
         "Unused by every container and older than the configured age",
       ),
       warning: dockerWarning,
@@ -169,6 +169,10 @@ export function StorageOverviewCard({ overview, disabledReason, onRunGoCache }: 
           <IconChartPie className="size-4" /> Storage analysis
           {!summary.docker.available && <Badge variant="outline">Docker unavailable</Badge>}
         </CardTitle>
+        <CardDescription>
+          A read-only breakdown of current usage and reclaimable space. Run Analyze occasionally to
+          refresh these estimates; it never deletes or moves anything.
+        </CardDescription>
       </CardHeader>
       <CardContent className="min-w-0">
         <Accordion type="multiple" className="min-w-0">

--- a/apps/web/components/settings/system/storage/storage-overview-card.tsx
+++ b/apps/web/components/settings/system/storage/storage-overview-card.tsx
@@ -1,0 +1,167 @@
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@kandev/ui/accordion";
+import { Badge } from "@kandev/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@kandev/ui/card";
+import { IconChartPie, IconTrash } from "@tabler/icons-react";
+import type { StorageOverviewResponse, StorageQuarantineSummary } from "@/lib/types/system";
+import { formatBytes } from "@/lib/utils/format-bytes";
+import { StorageActionButton } from "./storage-action-button";
+
+interface Props {
+  overview: StorageOverviewResponse | null;
+  disabledReason?: string;
+  onRunGoCache: () => void;
+}
+
+interface StorageResource {
+  id: string;
+  label: string;
+  value: string;
+  detail: string;
+  warning?: string;
+}
+
+function goCacheDisabledReason(overview: StorageOverviewResponse, pendingReason?: string) {
+  if (pendingReason) return pendingReason;
+  if (overview.summary.go_cache.owned !== true) {
+    return "Only a Kandev-owned Go build cache can be cleaned.";
+  }
+  if ((overview.summary.go_cache.size_bytes ?? 0) <= overview.settings.go_cache.max_bytes) {
+    return "The Go build cache is below its configured size limit.";
+  }
+  return undefined;
+}
+
+function quarantineResource(summary: StorageQuarantineSummary): StorageResource {
+  if (summary.available === false) {
+    return {
+      id: "quarantine",
+      label: "Quarantined resources",
+      value: "Unavailable",
+      detail: "Quarantine usage could not be measured",
+      warning: summary.warning,
+    };
+  }
+  return {
+    id: "quarantine",
+    label: "Quarantined resources",
+    value: formatBytes(summary.size_bytes),
+    detail: `${summary.count} resources awaiting recovery or deletion`,
+  };
+}
+
+function storageResources(overview: StorageOverviewResponse): StorageResource[] {
+  const { summary } = overview;
+  const dockerWarning = summary.docker.warnings?.join(" · ");
+  return [
+    {
+      id: "workspaces",
+      label: "Task workspaces",
+      value: formatBytes(summary.workspaces.candidate_bytes ?? 0),
+      detail: `Active ${formatBytes(summary.workspaces.active_bytes ?? 0)}`,
+      warning: summary.workspaces.warning,
+    },
+    quarantineResource(summary.quarantine),
+    {
+      id: "managed-containers",
+      label: "Kandev containers",
+      value: formatBytes(summary.docker.managed_container_bytes ?? 0),
+      detail: `${summary.docker.managed_container_count ?? 0} managed containers`,
+      warning: dockerWarning,
+    },
+    {
+      id: "go-cache",
+      label: "Go build cache",
+      value: formatBytes(summary.go_cache.size_bytes ?? 0),
+      detail: summary.go_cache.path ?? overview.capabilities.managed_go_cache_path,
+      warning: summary.go_cache.warning,
+    },
+    {
+      id: "docker-build-cache",
+      label: "Docker build cache",
+      value: formatBytes(summary.docker.build_cache_bytes),
+      detail: overview.capabilities.docker_host || "Default Docker host",
+      warning: dockerWarning,
+    },
+    {
+      id: "docker-unused-images",
+      label: "Unused Docker images",
+      value: formatBytes(summary.docker.unused_image_bytes),
+      detail: "Unused by every container and older than the configured age",
+      warning: dockerWarning,
+    },
+  ];
+}
+
+interface ResourceRowProps {
+  resource: StorageResource;
+  goCacheCleanupDisabledReason?: string;
+  onRunGoCache: () => void;
+}
+
+function ResourceRow({ resource, goCacheCleanupDisabledReason, onRunGoCache }: ResourceRowProps) {
+  return (
+    <AccordionItem value={resource.id} data-testid={`storage-resource-${resource.id}`}>
+      <AccordionTrigger
+        className="min-h-11 items-center px-3 no-underline"
+        data-testid={`storage-resource-${resource.id}-trigger`}
+      >
+        <span className="min-w-0">
+          <span className="block text-sm">{resource.label}</span>
+          <span className="block text-xs font-normal text-muted-foreground">{resource.value}</span>
+        </span>
+      </AccordionTrigger>
+      <AccordionContent className="px-3">
+        <p className="break-all text-muted-foreground">{resource.detail}</p>
+        {resource.warning && <p className="mt-2 break-words text-amber-600">{resource.warning}</p>}
+        {resource.id === "go-cache" && (
+          <StorageActionButton
+            variant="outline"
+            className="mt-3 w-full sm:w-auto"
+            disabledReason={goCacheCleanupDisabledReason}
+            onClick={onRunGoCache}
+            data-testid="storage-go-cache-clean"
+          >
+            <IconTrash className="size-4" /> Clean Go cache
+          </StorageActionButton>
+        )}
+      </AccordionContent>
+    </AccordionItem>
+  );
+}
+
+export function StorageOverviewCard({ overview, disabledReason, onRunGoCache }: Props) {
+  if (!overview) {
+    return (
+      <Card data-testid="storage-overview-card">
+        <CardContent className="py-8 text-sm text-muted-foreground">
+          Loading storage data…
+        </CardContent>
+      </Card>
+    );
+  }
+  const { summary } = overview;
+  const cleanupDisabledReason = goCacheDisabledReason(overview, disabledReason);
+  const resources = storageResources(overview);
+  return (
+    <Card className="min-w-0" data-testid="storage-overview-card">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base">
+          <IconChartPie className="size-4" /> Storage analysis
+          {!summary.docker.available && <Badge variant="outline">Docker unavailable</Badge>}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="min-w-0">
+        <Accordion type="multiple" className="min-w-0">
+          {resources.map((resource) => (
+            <ResourceRow
+              key={resource.id}
+              resource={resource}
+              goCacheCleanupDisabledReason={cleanupDisabledReason}
+              onRunGoCache={onRunGoCache}
+            />
+          ))}
+        </Accordion>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/components/settings/system/storage/storage-policy-card.test.tsx
+++ b/apps/web/components/settings/system/storage/storage-policy-card.test.tsx
@@ -1,0 +1,115 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { TooltipProvider } from "@kandev/ui/tooltip";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { StorageMaintenanceSettings } from "@/lib/types/system";
+import { StoragePolicyCard } from "./storage-policy-card";
+
+const settings: StorageMaintenanceSettings = {
+  enabled: false,
+  check_interval_hours: 24,
+  idle_for_minutes: 10,
+  orphan_grace_hours: 168,
+  quarantine_retention_hours: 168,
+  workspaces: { enabled: true },
+  kandev_containers: { enabled: true },
+  go_cache: { enabled: false, max_bytes: 16106127360, adopted_path: "" },
+  docker: {
+    dedicated_daemon_acknowledged: true,
+    build_cache_enabled: true,
+    build_cache_keep_bytes: 10737418240,
+    build_cache_unused_hours: 168,
+    unused_images_enabled: true,
+    unused_images_hours: 168,
+  },
+};
+
+const capabilities = {
+  managed_go_cache_path: "/data/cache/go-build",
+  go_cache_adoption_available: true,
+  docker_available: true,
+  docker_host: "",
+  host_global_docker_cleanup_allowed: true,
+};
+
+afterEach(cleanup);
+
+function renderCard(pending = false, onChange = vi.fn()) {
+  render(
+    <TooltipProvider>
+      <StoragePolicyCard
+        settings={settings}
+        capabilities={capabilities}
+        pending={pending}
+        onChange={onChange}
+        onSave={vi.fn()}
+        onDedicatedConfirm={vi.fn()}
+        onAdopt={vi.fn()}
+      />
+    </TooltipProvider>,
+  );
+  return onChange;
+}
+
+describe("StoragePolicyCard", () => {
+  it("edits every Docker cleanup threshold", () => {
+    const onChange = renderCard();
+
+    fireEvent.change(screen.getByTestId("storage-docker-build-cache-keep-bytes"), {
+      target: { value: "2147483648" },
+    });
+    expect(onChange).toHaveBeenLastCalledWith({
+      ...settings,
+      docker: { ...settings.docker, build_cache_keep_bytes: 2147483648 },
+    });
+
+    fireEvent.change(screen.getByTestId("storage-docker-build-cache-unused-hours"), {
+      target: { value: "72" },
+    });
+    expect(onChange).toHaveBeenLastCalledWith({
+      ...settings,
+      docker: { ...settings.docker, build_cache_unused_hours: 72 },
+    });
+
+    fireEvent.change(screen.getByTestId("storage-docker-unused-images-hours"), {
+      target: { value: "96" },
+    });
+    expect(onChange).toHaveBeenLastCalledWith({
+      ...settings,
+      docker: { ...settings.docker, unused_images_hours: 96 },
+    });
+  });
+
+  it("disables policy controls while an action is pending", () => {
+    renderCard(true);
+
+    const testIds = [
+      "storage-scheduling-enabled",
+      "storage-go-cache-enabled",
+      "storage-check-interval",
+      "storage-idle-period",
+      "storage-orphan-grace",
+      "storage-quarantine-retention",
+      "storage-go-cache-max",
+      "storage-go-cache-adopt-path",
+      "storage-go-cache-adopt",
+      "storage-docker-dedicated",
+      "storage-docker-build-cache",
+      "storage-docker-build-cache-keep-bytes",
+      "storage-docker-build-cache-unused-hours",
+      "storage-docker-unused-images",
+      "storage-docker-unused-images-hours",
+      "storage-save-settings",
+    ];
+    for (const testId of testIds) {
+      expect((screen.getByTestId(testId) as HTMLButtonElement | HTMLInputElement).disabled).toBe(
+        true,
+      );
+    }
+    expect(
+      (screen.getByLabelText("Clean orphan task workspaces") as HTMLButtonElement).disabled,
+    ).toBe(true);
+    expect((screen.getByLabelText("Clean Kandev containers") as HTMLButtonElement).disabled).toBe(
+      true,
+    );
+  });
+});

--- a/apps/web/components/settings/system/storage/storage-policy-card.test.tsx
+++ b/apps/web/components/settings/system/storage/storage-policy-card.test.tsx
@@ -54,8 +54,21 @@ describe("StoragePolicyCard", () => {
   it("edits every Docker cleanup threshold", () => {
     const onChange = renderCard();
 
+    expect((screen.getByTestId("storage-go-cache-max") as HTMLInputElement).value).toBe("15");
+    expect(
+      (screen.getByTestId("storage-docker-build-cache-keep-bytes") as HTMLInputElement).value,
+    ).toBe("10");
+
+    fireEvent.change(screen.getByTestId("storage-go-cache-max"), {
+      target: { value: "20" },
+    });
+    expect(onChange).toHaveBeenLastCalledWith({
+      ...settings,
+      go_cache: { ...settings.go_cache, max_bytes: 21_474_836_480 },
+    });
+
     fireEvent.change(screen.getByTestId("storage-docker-build-cache-keep-bytes"), {
-      target: { value: "2147483648" },
+      target: { value: "2" },
     });
     expect(onChange).toHaveBeenLastCalledWith({
       ...settings,
@@ -111,5 +124,20 @@ describe("StoragePolicyCard", () => {
     expect((screen.getByLabelText("Clean Kandev containers") as HTMLButtonElement).disabled).toBe(
       true,
     );
+  });
+
+  it("groups related settings and provides help for every policy option", () => {
+    renderCard();
+
+    for (const heading of [
+      "Schedule",
+      "Workspaces and containers",
+      "Go build cache",
+      "Docker cleanup",
+      "Quarantine safety",
+    ]) {
+      expect(screen.getByText(heading)).toBeTruthy();
+    }
+    expect(screen.getAllByLabelText(/^More information about /)).toHaveLength(16);
   });
 });

--- a/apps/web/components/settings/system/storage/storage-policy-card.test.tsx
+++ b/apps/web/components/settings/system/storage/storage-policy-card.test.tsx
@@ -31,13 +31,24 @@ const capabilities = {
   host_global_docker_cleanup_allowed: true,
 };
 
+const testIds = {
+  goCacheMax: "storage-go-cache-max",
+  dockerBuildCacheKeep: "storage-docker-build-cache-keep-bytes",
+  dockerBuildCacheUnused: "storage-docker-build-cache-unused-hours",
+  dockerImagesUnused: "storage-docker-unused-images-hours",
+};
+
 afterEach(cleanup);
 
-function renderCard(pending = false, onChange = vi.fn()) {
+function renderCard(
+  pending = false,
+  onChange = vi.fn(),
+  currentSettings: StorageMaintenanceSettings = settings,
+) {
   render(
     <TooltipProvider>
       <StoragePolicyCard
-        settings={settings}
+        settings={currentSettings}
         capabilities={capabilities}
         pending={pending}
         onChange={onChange}
@@ -54,12 +65,10 @@ describe("StoragePolicyCard", () => {
   it("edits every Docker cleanup threshold", () => {
     const onChange = renderCard();
 
-    expect((screen.getByTestId("storage-go-cache-max") as HTMLInputElement).value).toBe("15");
-    expect(
-      (screen.getByTestId("storage-docker-build-cache-keep-bytes") as HTMLInputElement).value,
-    ).toBe("10");
+    expect((screen.getByTestId(testIds.goCacheMax) as HTMLInputElement).value).toBe("15");
+    expect((screen.getByTestId(testIds.dockerBuildCacheKeep) as HTMLInputElement).value).toBe("10");
 
-    fireEvent.change(screen.getByTestId("storage-go-cache-max"), {
+    fireEvent.change(screen.getByTestId(testIds.goCacheMax), {
       target: { value: "20" },
     });
     expect(onChange).toHaveBeenLastCalledWith({
@@ -67,7 +76,7 @@ describe("StoragePolicyCard", () => {
       go_cache: { ...settings.go_cache, max_bytes: 21_474_836_480 },
     });
 
-    fireEvent.change(screen.getByTestId("storage-docker-build-cache-keep-bytes"), {
+    fireEvent.change(screen.getByTestId(testIds.dockerBuildCacheKeep), {
       target: { value: "2" },
     });
     expect(onChange).toHaveBeenLastCalledWith({
@@ -75,7 +84,7 @@ describe("StoragePolicyCard", () => {
       docker: { ...settings.docker, build_cache_keep_bytes: 2147483648 },
     });
 
-    fireEvent.change(screen.getByTestId("storage-docker-build-cache-unused-hours"), {
+    fireEvent.change(screen.getByTestId(testIds.dockerBuildCacheUnused), {
       target: { value: "72" },
     });
     expect(onChange).toHaveBeenLastCalledWith({
@@ -83,7 +92,7 @@ describe("StoragePolicyCard", () => {
       docker: { ...settings.docker, build_cache_unused_hours: 72 },
     });
 
-    fireEvent.change(screen.getByTestId("storage-docker-unused-images-hours"), {
+    fireEvent.change(screen.getByTestId(testIds.dockerImagesUnused), {
       target: { value: "96" },
     });
     expect(onChange).toHaveBeenLastCalledWith({
@@ -91,29 +100,31 @@ describe("StoragePolicyCard", () => {
       docker: { ...settings.docker, unused_images_hours: 96 },
     });
   });
+});
 
+describe("StoragePolicyCard interactions", () => {
   it("disables policy controls while an action is pending", () => {
     renderCard(true);
 
-    const testIds = [
+    const pendingTestIds = [
       "storage-scheduling-enabled",
       "storage-go-cache-enabled",
       "storage-check-interval",
       "storage-idle-period",
       "storage-orphan-grace",
       "storage-quarantine-retention",
-      "storage-go-cache-max",
+      testIds.goCacheMax,
       "storage-go-cache-adopt-path",
       "storage-go-cache-adopt",
       "storage-docker-dedicated",
       "storage-docker-build-cache",
-      "storage-docker-build-cache-keep-bytes",
-      "storage-docker-build-cache-unused-hours",
+      testIds.dockerBuildCacheKeep,
+      testIds.dockerBuildCacheUnused,
       "storage-docker-unused-images",
-      "storage-docker-unused-images-hours",
+      testIds.dockerImagesUnused,
       "storage-save-settings",
     ];
-    for (const testId of testIds) {
+    for (const testId of pendingTestIds) {
       expect((screen.getByTestId(testId) as HTMLButtonElement | HTMLInputElement).disabled).toBe(
         true,
       );
@@ -124,6 +135,49 @@ describe("StoragePolicyCard", () => {
     expect((screen.getByLabelText("Clean Kandev containers") as HTMLButtonElement).disabled).toBe(
       true,
     );
+  });
+
+  it("disables child fields when their cleanup option is off", () => {
+    renderCard(false, vi.fn(), {
+      ...settings,
+      enabled: false,
+      workspaces: { enabled: false },
+      go_cache: { ...settings.go_cache, enabled: false },
+      docker: {
+        ...settings.docker,
+        build_cache_enabled: false,
+        unused_images_enabled: false,
+      },
+    });
+
+    for (const testId of [
+      "storage-check-interval",
+      "storage-idle-period",
+      "storage-orphan-grace",
+      testIds.goCacheMax,
+      "storage-go-cache-adopt-path",
+      "storage-go-cache-adopt",
+      testIds.dockerBuildCacheKeep,
+      testIds.dockerBuildCacheUnused,
+      testIds.dockerImagesUnused,
+    ]) {
+      expect((screen.getByTestId(testId) as HTMLButtonElement | HTMLInputElement).disabled).toBe(
+        true,
+      );
+    }
+    expect((screen.getByTestId("storage-quarantine-retention") as HTMLInputElement).disabled).toBe(
+      false,
+    );
+  });
+
+  it("renders each maintenance group as a separate card", () => {
+    renderCard();
+
+    for (const section of ["schedule", "workspaces", "go-cache", "docker", "quarantine"]) {
+      expect(
+        screen.getByTestId(`storage-policy-section-${section}`).getAttribute("data-slot"),
+      ).toBe("card");
+    }
   });
 
   it("groups related settings and provides help for every policy option", () => {

--- a/apps/web/components/settings/system/storage/storage-policy-card.tsx
+++ b/apps/web/components/settings/system/storage/storage-policy-card.tsx
@@ -5,10 +5,12 @@ import { Card, CardContent, CardHeader, CardTitle } from "@kandev/ui/card";
 import { Input } from "@kandev/ui/input";
 import { Label } from "@kandev/ui/label";
 import { Switch } from "@kandev/ui/switch";
-import type { StorageCapabilities, StorageMaintenanceSettings } from "@/lib/types/system";
 import { settingsWithDockerAcknowledgement } from "@/hooks/domains/system/use-storage-maintenance";
+import type { StorageCapabilities, StorageMaintenanceSettings } from "@/lib/types/system";
 import { DedicatedDockerDialog, ExternalGoCacheDialog } from "./storage-confirmation-dialogs";
 import { StorageActionButton } from "./storage-action-button";
+import { StorageSettingHelp } from "./storage-setting-help";
+import { bytesToGigabytes, gigabytesToBytes } from "./storage-units";
 
 type Props = {
   settings: StorageMaintenanceSettings;
@@ -20,19 +22,46 @@ type Props = {
   onAdopt: (path: string) => Promise<void>;
 };
 
+type PolicySectionProps = Pick<Props, "settings" | "capabilities" | "onChange" | "pending">;
+
+function PolicySection({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className="border-t py-5 first:border-t-0 first:pt-0">
+      <div className="mb-3">
+        <h3 className="text-sm font-medium">{title}</h3>
+        <p className="text-xs text-muted-foreground">{description}</p>
+      </div>
+      {children}
+    </section>
+  );
+}
+
 function SettingRow({
   title,
   description,
+  help,
   control,
 }: {
   title: string;
   description: string;
+  help: string;
   control: ReactNode;
 }) {
   return (
     <div className="flex min-h-11 items-center justify-between gap-4 border-b py-3 last:border-b-0">
       <div className="min-w-0">
-        <Label className="text-sm">{title}</Label>
+        <div className="flex items-center gap-1">
+          <Label className="text-sm">{title}</Label>
+          <StorageSettingHelp label={title}>{help}</StorageSettingHelp>
+        </div>
         <p className="text-xs text-muted-foreground">{description}</p>
       </div>
       <div className="shrink-0">{control}</div>
@@ -42,6 +71,7 @@ function SettingRow({
 
 function NumberField({
   label,
+  help,
   value,
   min,
   max,
@@ -50,6 +80,7 @@ function NumberField({
   testId,
 }: {
   label: string;
+  help: string;
   value: number;
   min: number;
   max?: number;
@@ -58,9 +89,15 @@ function NumberField({
   testId: string;
 }) {
   return (
-    <label className="min-w-0 space-y-1 text-xs text-muted-foreground">
-      <span>{label}</span>
+    <div className="min-w-0 space-y-1">
+      <div className="flex items-center gap-1">
+        <Label htmlFor={testId} className="text-xs text-muted-foreground">
+          {label}
+        </Label>
+        <StorageSettingHelp label={label}>{help}</StorageSettingHelp>
+      </div>
       <Input
+        id={testId}
         type="number"
         min={min}
         max={max}
@@ -70,18 +107,20 @@ function NumberField({
         className="h-11"
         data-testid={testId}
       />
-    </label>
+    </div>
   );
 }
 
-type PolicySectionProps = Pick<Props, "settings" | "capabilities" | "onChange" | "pending">;
-
-function PolicySwitches({ settings, capabilities, pending, onChange }: PolicySectionProps) {
+function ScheduleSection({ settings, pending, onChange }: PolicySectionProps) {
   return (
-    <div>
+    <PolicySection
+      title="Schedule"
+      description="Controls when automatic maintenance is allowed to start. Manual actions remain available when scheduling is off."
+    >
       <SettingRow
         title="Scheduled maintenance"
-        description="Disabled by default; runs only after the configured idle period."
+        description="Periodically reclaim disk space using the enabled resource rules."
+        help="When enabled, Kandev checks this policy at the configured interval and starts only after Kandev has been idle for the required period. Turning it off does not disable Analyze or Run now."
         control={
           <Switch
             checked={settings.enabled}
@@ -92,9 +131,42 @@ function PolicySwitches({ settings, capabilities, pending, onChange }: PolicySec
           />
         }
       />
+      <div className="grid min-w-0 grid-cols-1 gap-3 pt-3 sm:grid-cols-2">
+        <NumberField
+          label="Check every (hours)"
+          help="How often Kandev checks whether scheduled maintenance is due. A check that finds Kandev busy is skipped and tried again at the next interval."
+          value={settings.check_interval_hours}
+          min={1}
+          max={168}
+          disabled={pending}
+          onChange={(check_interval_hours) => onChange({ ...settings, check_interval_hours })}
+          testId="storage-check-interval"
+        />
+        <NumberField
+          label="Require idle for (minutes)"
+          help="Scheduled cleanup starts only after no task, shell command, test, setup, cleanup, or image build has used managed resources for this long. Run now does not wait for this timer, but it still refuses to run while resources are active."
+          value={settings.idle_for_minutes}
+          min={1}
+          max={1440}
+          disabled={pending}
+          onChange={(idle_for_minutes) => onChange({ ...settings, idle_for_minutes })}
+          testId="storage-idle-period"
+        />
+      </div>
+    </PolicySection>
+  );
+}
+
+function WorkspaceSection({ settings, pending, onChange }: PolicySectionProps) {
+  return (
+    <PolicySection
+      title="Workspaces and containers"
+      description="Reclaim resources that Kandev can positively identify as no longer in use."
+    >
       <SettingRow
         title="Orphan task workspaces"
-        description="Move positively identified orphan task roots to quarantine."
+        description="Move confirmed orphan workspaces to quarantine."
+        help="Kandev only selects a task workspace after inventory confirms that no active task, environment, session, or protected worktree uses it. The workspace is moved to quarantine first, where it can be restored before permanent deletion."
         control={
           <Switch
             checked={settings.workspaces.enabled}
@@ -104,9 +176,22 @@ function PolicySwitches({ settings, capabilities, pending, onChange }: PolicySec
           />
         }
       />
+      <div className="grid min-w-0 grid-cols-1 gap-3 py-3 sm:grid-cols-2">
+        <NumberField
+          label="Wait before orphaning (hours)"
+          help="A workspace must be unused for at least this long before it can be classified as an orphan. Increasing this value keeps old workspaces longer before they enter quarantine."
+          value={settings.orphan_grace_hours}
+          min={24}
+          max={2160}
+          disabled={pending}
+          onChange={(orphan_grace_hours) => onChange({ ...settings, orphan_grace_hours })}
+          testId="storage-orphan-grace"
+        />
+      </div>
       <SettingRow
         title="Kandev containers"
-        description="Remove stopped managed containers only after inventory confirms they are unused."
+        description="Remove stopped, unused containers created and labeled by Kandev."
+        help="Only stopped containers labeled as Kandev-managed are considered, and inventory must confirm they are no longer needed. Running containers and unrelated Docker containers are never removed by this option."
         control={
           <Switch
             checked={settings.kandev_containers.enabled}
@@ -116,95 +201,11 @@ function PolicySwitches({ settings, capabilities, pending, onChange }: PolicySec
           />
         }
       />
-      <SettingRow
-        title="Managed Go cache"
-        description={`New local executions use ${capabilities.managed_go_cache_path}.`}
-        control={
-          <Switch
-            checked={settings.go_cache.enabled}
-            disabled={pending}
-            onCheckedChange={(enabled) =>
-              onChange({ ...settings, go_cache: { ...settings.go_cache, enabled } })
-            }
-            aria-label="Enable managed Go cache"
-            data-testid="storage-go-cache-enabled"
-          />
-        }
-      />
-    </div>
+    </PolicySection>
   );
 }
 
-function CorePolicySection({ settings, capabilities, pending, onChange }: PolicySectionProps) {
-  const setNumber = (
-    key:
-      | "check_interval_hours"
-      | "idle_for_minutes"
-      | "orphan_grace_hours"
-      | "quarantine_retention_hours",
-    value: number,
-  ) => onChange({ ...settings, [key]: value });
-  return (
-    <>
-      <PolicySwitches
-        settings={settings}
-        capabilities={capabilities}
-        pending={pending}
-        onChange={onChange}
-      />
-      <div className="grid min-w-0 grid-cols-1 gap-3 sm:grid-cols-2">
-        <NumberField
-          label="Check interval (hours)"
-          value={settings.check_interval_hours}
-          min={1}
-          max={168}
-          disabled={pending}
-          onChange={(value) => setNumber("check_interval_hours", value)}
-          testId="storage-check-interval"
-        />
-        <NumberField
-          label="Idle period (minutes)"
-          value={settings.idle_for_minutes}
-          min={1}
-          max={1440}
-          disabled={pending}
-          onChange={(value) => setNumber("idle_for_minutes", value)}
-          testId="storage-idle-period"
-        />
-        <NumberField
-          label="Orphan grace (hours)"
-          value={settings.orphan_grace_hours}
-          min={24}
-          max={2160}
-          disabled={pending}
-          onChange={(value) => setNumber("orphan_grace_hours", value)}
-          testId="storage-orphan-grace"
-        />
-        <NumberField
-          label="Quarantine retention (hours)"
-          value={settings.quarantine_retention_hours}
-          min={24}
-          max={2160}
-          disabled={pending}
-          onChange={(value) => setNumber("quarantine_retention_hours", value)}
-          testId="storage-quarantine-retention"
-        />
-        <NumberField
-          label="Go cache maximum (bytes)"
-          value={settings.go_cache.max_bytes}
-          min={1073741824}
-          disabled={pending}
-          onChange={(value) =>
-            onChange({ ...settings, go_cache: { ...settings.go_cache, max_bytes: value } })
-          }
-          testId="storage-go-cache-max"
-        />
-      </div>
-    </>
-  );
-}
-
-function AdoptionSection({
+function AdoptionField({
   path,
   setPath,
   onOpen,
@@ -219,10 +220,17 @@ function AdoptionSection({
   if (pending) disabledReason = "Wait for the current storage action to finish.";
   else if (!path.trim()) disabledReason = "Enter an absolute cache path first.";
   return (
-    <div className="min-w-0 space-y-2 rounded-md border p-3">
-      <Label htmlFor="storage-adoption-path">External Go-cache path</Label>
+    <div className="min-w-0 space-y-2 pt-3">
+      <div className="flex items-center gap-1">
+        <Label htmlFor="storage-adoption-path">External Go cache</Label>
+        <StorageSettingHelp label="External Go cache">
+          Adoption gives Kandev explicit permission to rotate this existing cache. Kandev never
+          cleans a default user cache or another path unless you adopt that exact absolute path and
+          confirm the destructive access.
+        </StorageSettingHelp>
+      </div>
       <p className="text-xs text-muted-foreground">
-        Adoption grants Kandev permission to rotate this existing cache.
+        Optionally allow Kandev to maintain an existing host cache outside its managed path.
       </p>
       <div className="flex min-w-0 flex-col gap-2 sm:flex-row">
         <Input
@@ -247,54 +255,183 @@ function AdoptionSection({
   );
 }
 
-function DockerThresholdFields({
-  settings,
-  pending,
-  onChange,
-}: Pick<PolicySectionProps, "settings" | "pending" | "onChange">) {
-  const setDockerNumber = (
-    key: "build_cache_keep_bytes" | "build_cache_unused_hours" | "unused_images_hours",
-    value: number,
-  ) => onChange({ ...settings, docker: { ...settings.docker, [key]: value } });
-  return (
-    <div className="grid min-w-0 grid-cols-1 gap-3 py-3 sm:grid-cols-2">
-      <NumberField
-        label="Build cache retained (bytes)"
-        value={settings.docker.build_cache_keep_bytes}
-        min={1073741824}
-        disabled={pending}
-        onChange={(value) => setDockerNumber("build_cache_keep_bytes", value)}
-        testId="storage-docker-build-cache-keep-bytes"
-      />
-      <NumberField
-        label="Build cache unused age (hours)"
-        value={settings.docker.build_cache_unused_hours}
-        min={24}
-        max={2562047}
-        disabled={pending}
-        onChange={(value) => setDockerNumber("build_cache_unused_hours", value)}
-        testId="storage-docker-build-cache-unused-hours"
-      />
-      <NumberField
-        label="Unused image age (hours)"
-        value={settings.docker.unused_images_hours}
-        min={24}
-        max={2562047}
-        disabled={pending}
-        onChange={(value) => setDockerNumber("unused_images_hours", value)}
-        testId="storage-docker-unused-images-hours"
-      />
-    </div>
-  );
-}
-
-function DockerPolicySection({
+function GoCacheSection({
   settings,
   capabilities,
   pending,
   onChange,
-  onOpen,
-}: PolicySectionProps & { onOpen: () => void }) {
+  adoptionPath,
+  setAdoptionPath,
+  onOpenAdoption,
+}: PolicySectionProps & {
+  adoptionPath: string;
+  setAdoptionPath: (path: string) => void;
+  onOpenAdoption: () => void;
+}) {
+  return (
+    <PolicySection
+      title="Go build cache"
+      description="Use and trim a Kandev-owned cache for new host-local Go executions."
+    >
+      <SettingRow
+        title="Managed Go cache"
+        description={`New host-local executions use ${capabilities.managed_go_cache_path}.`}
+        help="When enabled, Kandev gives new local task processes a dedicated Go build cache and may rotate it during maintenance when it exceeds the maximum. Turning this off stops using the managed cache for new executions but does not delete it."
+        control={
+          <Switch
+            checked={settings.go_cache.enabled}
+            disabled={pending}
+            onCheckedChange={(enabled) =>
+              onChange({ ...settings, go_cache: { ...settings.go_cache, enabled } })
+            }
+            aria-label="Enable managed Go cache"
+            data-testid="storage-go-cache-enabled"
+          />
+        }
+      />
+      <div className="grid min-w-0 grid-cols-1 gap-3 pt-3 sm:grid-cols-2">
+        <NumberField
+          label="Maximum cache size (GB)"
+          help="This is a cleanup trigger, not a hard quota. The cache may grow past this size while tasks are active. Maintenance rotates the owned cache into quarantine and recreates an empty cache after the limit is exceeded."
+          value={bytesToGigabytes(settings.go_cache.max_bytes)}
+          min={1}
+          disabled={pending}
+          onChange={(gigabytes) =>
+            onChange({
+              ...settings,
+              go_cache: { ...settings.go_cache, max_bytes: gigabytesToBytes(gigabytes) },
+            })
+          }
+          testId="storage-go-cache-max"
+        />
+      </div>
+      {capabilities.go_cache_adoption_available && (
+        <AdoptionField
+          path={adoptionPath}
+          setPath={setAdoptionPath}
+          pending={pending}
+          onOpen={onOpenAdoption}
+        />
+      )}
+    </PolicySection>
+  );
+}
+
+type DockerSettings = StorageMaintenanceSettings["docker"];
+
+function DockerBuildCacheSettings({
+  docker,
+  pending,
+  disabledReason,
+  updateDocker,
+}: {
+  docker: DockerSettings;
+  pending: boolean;
+  disabledReason?: string;
+  updateDocker: (docker: DockerSettings) => void;
+}) {
+  return (
+    <>
+      <SettingRow
+        title="Docker build cache"
+        description="Remove old build cache while retaining the configured amount."
+        help="Uses Docker's age and storage filters to remove old build cache. It does not run docker system prune, does not remove volumes globally, and remains disabled until the dedicated-daemon acknowledgment is confirmed."
+        control={
+          <Switch
+            checked={docker.build_cache_enabled}
+            disabled={Boolean(disabledReason)}
+            onCheckedChange={(build_cache_enabled) =>
+              updateDocker({ ...docker, build_cache_enabled })
+            }
+            aria-label="Clean Docker build cache"
+            data-testid="storage-docker-build-cache"
+          />
+        }
+      />
+      <div className="grid min-w-0 grid-cols-1 gap-3 py-3 sm:grid-cols-2">
+        <NumberField
+          label="Build cache to retain (GB)"
+          help="Docker keeps approximately this much build cache when pruning eligible records. A larger value preserves more reusable build layers but reclaims less disk space."
+          value={bytesToGigabytes(docker.build_cache_keep_bytes)}
+          min={1}
+          disabled={pending}
+          onChange={(gigabytes) =>
+            updateDocker({
+              ...docker,
+              build_cache_keep_bytes: gigabytesToBytes(gigabytes),
+            })
+          }
+          testId="storage-docker-build-cache-keep-bytes"
+        />
+        <NumberField
+          label="Build cache must be unused for (hours)"
+          help="Only build cache records older than this unused-age threshold are eligible. Increasing it protects recent build layers for longer."
+          value={docker.build_cache_unused_hours}
+          min={24}
+          max={2562047}
+          disabled={pending}
+          onChange={(build_cache_unused_hours) =>
+            updateDocker({ ...docker, build_cache_unused_hours })
+          }
+          testId="storage-docker-build-cache-unused-hours"
+        />
+      </div>
+    </>
+  );
+}
+
+function DockerImageSettings({
+  docker,
+  pending,
+  disabledReason,
+  updateDocker,
+}: {
+  docker: DockerSettings;
+  pending: boolean;
+  disabledReason?: string;
+  updateDocker: (docker: DockerSettings) => void;
+}) {
+  return (
+    <>
+      <SettingRow
+        title="Unused Docker images"
+        description="Remove old images that no container uses."
+        help="Removes an image only when no running or stopped container references it and it is older than the configured age. This is daemon-wide and therefore requires the dedicated-daemon acknowledgment."
+        control={
+          <Switch
+            checked={docker.unused_images_enabled}
+            disabled={Boolean(disabledReason)}
+            onCheckedChange={(unused_images_enabled) =>
+              updateDocker({ ...docker, unused_images_enabled })
+            }
+            aria-label="Clean unused Docker images"
+            data-testid="storage-docker-unused-images"
+          />
+        }
+      />
+      <div className="grid min-w-0 grid-cols-1 gap-3 pt-3 sm:grid-cols-2">
+        <NumberField
+          label="Image must be unused for (hours)"
+          help="An image must be unused by every container and older than this age before Kandev can remove it. Increasing the value keeps old images available for longer."
+          value={docker.unused_images_hours}
+          min={24}
+          max={2562047}
+          disabled={pending}
+          onChange={(unused_images_hours) => updateDocker({ ...docker, unused_images_hours })}
+          testId="storage-docker-unused-images-hours"
+        />
+      </div>
+    </>
+  );
+}
+
+function DockerSection({
+  settings,
+  capabilities,
+  pending,
+  onChange,
+  onOpenDedicated,
+}: PolicySectionProps & { onOpenDedicated: () => void }) {
   const unavailable = capabilities.docker_available
     ? undefined
     : "Docker is unavailable on the configured host.";
@@ -304,17 +441,23 @@ function DockerPolicySection({
     (!settings.docker.dedicated_daemon_acknowledged
       ? "Acknowledge a dedicated Docker daemon first."
       : undefined);
+  const updateDocker = (docker: StorageMaintenanceSettings["docker"]) =>
+    onChange({ ...settings, docker });
   return (
-    <div className="space-y-1 rounded-md border p-3">
+    <PolicySection
+      title="Docker cleanup"
+      description="Optional daemon-wide cleanup. Enable it only when this Docker daemon is dedicated to Kandev."
+    >
       <SettingRow
         title="Dedicated Docker daemon"
-        description="Required for host-global build-cache and unused-image cleanup."
+        description="Confirm that unrelated workloads do not share this Docker daemon."
+        help="Build cache and image ownership cannot be attributed reliably to Kandev. This acknowledgment unlocks daemon-wide cleanup and should only be enabled when the configured Docker daemon is used exclusively by Kandev. Kandev never performs a volume-wide prune."
         control={
           <Switch
             checked={settings.docker.dedicated_daemon_acknowledged}
             disabled={pending || !capabilities.docker_available}
             onCheckedChange={(checked) => {
-              if (checked) onOpen();
+              if (checked) onOpenDedicated();
               else onChange(settingsWithDockerAcknowledgement(settings, false));
             }}
             aria-label="Dedicated Docker daemon"
@@ -323,49 +466,48 @@ function DockerPolicySection({
         }
       />
       {unavailable && (
-        <p className="text-xs text-amber-600">
-          Docker unavailable: daemon-wide actions remain disabled.
+        <p className="py-2 text-xs text-amber-600">
+          Docker is unavailable; Docker cleanup options cannot run on this host.
         </p>
       )}
-      <SettingRow
-        title="Docker build cache"
-        description="Uses Docker API age and storage filters; never runs system prune."
-        control={
-          <Switch
-            checked={settings.docker.build_cache_enabled}
-            disabled={Boolean(disabledReason)}
-            onCheckedChange={(enabled) =>
-              onChange({
-                ...settings,
-                docker: { ...settings.docker, build_cache_enabled: enabled },
-              })
-            }
-            aria-label="Clean Docker build cache"
-            data-testid="storage-docker-build-cache"
-          />
-        }
+      <DockerBuildCacheSettings
+        docker={settings.docker}
+        pending={pending}
+        disabledReason={disabledReason}
+        updateDocker={updateDocker}
       />
-      <SettingRow
-        title="Unused Docker images"
-        description="Only images unused by every container and older than the configured age."
-        control={
-          <Switch
-            checked={settings.docker.unused_images_enabled}
-            disabled={Boolean(disabledReason)}
-            onCheckedChange={(enabled) =>
-              onChange({
-                ...settings,
-                docker: { ...settings.docker, unused_images_enabled: enabled },
-              })
-            }
-            aria-label="Clean unused Docker images"
-            data-testid="storage-docker-unused-images"
-          />
-        }
+      <DockerImageSettings
+        docker={settings.docker}
+        pending={pending}
+        disabledReason={disabledReason}
+        updateDocker={updateDocker}
       />
-      <DockerThresholdFields settings={settings} pending={pending} onChange={onChange} />
-      {disabledReason && <p className="text-xs text-muted-foreground">{disabledReason}</p>}
-    </div>
+      {disabledReason && <p className="pt-2 text-xs text-muted-foreground">{disabledReason}</p>}
+    </PolicySection>
+  );
+}
+
+function QuarantineSection({ settings, pending, onChange }: PolicySectionProps) {
+  return (
+    <PolicySection
+      title="Quarantine safety"
+      description="Keep recoverable resources for a grace period before permanent deletion."
+    >
+      <div className="grid min-w-0 grid-cols-1 gap-3 sm:grid-cols-2">
+        <NumberField
+          label="Keep quarantined items for (hours)"
+          help="Cleanup first moves orphan workspaces and rotated Go caches into Kandev's trash area instead of deleting them immediately. During this retention period you can restore an item. After the deadline, a later maintenance run may permanently delete it."
+          value={settings.quarantine_retention_hours}
+          min={24}
+          max={2160}
+          disabled={pending}
+          onChange={(quarantine_retention_hours) =>
+            onChange({ ...settings, quarantine_retention_hours })
+          }
+          testId="storage-quarantine-retention"
+        />
+      </div>
+    </PolicySection>
   );
 }
 
@@ -385,30 +527,46 @@ export function StoragePolicyCard({
     <Card className="min-w-0" data-testid="storage-policy-card">
       <CardHeader>
         <CardTitle className="text-base">Maintenance policy</CardTitle>
+        <p className="text-xs text-muted-foreground">
+          Choose what Kandev may reclaim automatically and the safety limits it must follow.
+        </p>
       </CardHeader>
-      <CardContent className="space-y-5">
-        <CorePolicySection
+      <CardContent>
+        <ScheduleSection
           settings={settings}
           capabilities={capabilities}
           pending={pending}
           onChange={onChange}
         />
-        {capabilities.go_cache_adoption_available && (
-          <AdoptionSection
-            path={adoptionPath}
-            setPath={setAdoptionPath}
-            pending={pending}
-            onOpen={() => setAdoptionDialogOpen(true)}
-          />
-        )}
-        <DockerPolicySection
+        <WorkspaceSection
           settings={settings}
           capabilities={capabilities}
           pending={pending}
           onChange={onChange}
-          onOpen={() => setDockerDialogOpen(true)}
         />
-        <div className="flex justify-end">
+        <GoCacheSection
+          settings={settings}
+          capabilities={capabilities}
+          pending={pending}
+          onChange={onChange}
+          adoptionPath={adoptionPath}
+          setAdoptionPath={setAdoptionPath}
+          onOpenAdoption={() => setAdoptionDialogOpen(true)}
+        />
+        <DockerSection
+          settings={settings}
+          capabilities={capabilities}
+          pending={pending}
+          onChange={onChange}
+          onOpenDedicated={() => setDockerDialogOpen(true)}
+        />
+        <QuarantineSection
+          settings={settings}
+          capabilities={capabilities}
+          pending={pending}
+          onChange={onChange}
+        />
+        <div className="flex justify-end border-t pt-5">
           <StorageActionButton
             disabledReason={pending ? "Wait for the current storage action to finish." : undefined}
             onClick={() => void onSave()}

--- a/apps/web/components/settings/system/storage/storage-policy-card.tsx
+++ b/apps/web/components/settings/system/storage/storage-policy-card.tsx
@@ -45,6 +45,7 @@ function NumberField({
   value,
   min,
   max,
+  disabled,
   onChange,
   testId,
 }: {
@@ -52,6 +53,7 @@ function NumberField({
   value: number;
   min: number;
   max?: number;
+  disabled?: boolean;
   onChange: (value: number) => void;
   testId: string;
 }) {
@@ -62,6 +64,7 @@ function NumberField({
         type="number"
         min={min}
         max={max}
+        disabled={disabled}
         value={value}
         onChange={(event) => onChange(Number(event.target.value))}
         className="h-11"
@@ -71,9 +74,9 @@ function NumberField({
   );
 }
 
-type PolicySectionProps = Pick<Props, "settings" | "capabilities" | "onChange">;
+type PolicySectionProps = Pick<Props, "settings" | "capabilities" | "onChange" | "pending">;
 
-function PolicySwitches({ settings, capabilities, onChange }: PolicySectionProps) {
+function PolicySwitches({ settings, capabilities, pending, onChange }: PolicySectionProps) {
   return (
     <div>
       <SettingRow
@@ -82,6 +85,7 @@ function PolicySwitches({ settings, capabilities, onChange }: PolicySectionProps
         control={
           <Switch
             checked={settings.enabled}
+            disabled={pending}
             onCheckedChange={(enabled) => onChange({ ...settings, enabled })}
             aria-label="Scheduled maintenance"
             data-testid="storage-scheduling-enabled"
@@ -94,6 +98,7 @@ function PolicySwitches({ settings, capabilities, onChange }: PolicySectionProps
         control={
           <Switch
             checked={settings.workspaces.enabled}
+            disabled={pending}
             onCheckedChange={(enabled) => onChange({ ...settings, workspaces: { enabled } })}
             aria-label="Clean orphan task workspaces"
           />
@@ -105,6 +110,7 @@ function PolicySwitches({ settings, capabilities, onChange }: PolicySectionProps
         control={
           <Switch
             checked={settings.kandev_containers.enabled}
+            disabled={pending}
             onCheckedChange={(enabled) => onChange({ ...settings, kandev_containers: { enabled } })}
             aria-label="Clean Kandev containers"
           />
@@ -116,6 +122,7 @@ function PolicySwitches({ settings, capabilities, onChange }: PolicySectionProps
         control={
           <Switch
             checked={settings.go_cache.enabled}
+            disabled={pending}
             onCheckedChange={(enabled) =>
               onChange({ ...settings, go_cache: { ...settings.go_cache, enabled } })
             }
@@ -128,7 +135,7 @@ function PolicySwitches({ settings, capabilities, onChange }: PolicySectionProps
   );
 }
 
-function CorePolicySection({ settings, capabilities, onChange }: PolicySectionProps) {
+function CorePolicySection({ settings, capabilities, pending, onChange }: PolicySectionProps) {
   const setNumber = (
     key:
       | "check_interval_hours"
@@ -139,13 +146,19 @@ function CorePolicySection({ settings, capabilities, onChange }: PolicySectionPr
   ) => onChange({ ...settings, [key]: value });
   return (
     <>
-      <PolicySwitches settings={settings} capabilities={capabilities} onChange={onChange} />
+      <PolicySwitches
+        settings={settings}
+        capabilities={capabilities}
+        pending={pending}
+        onChange={onChange}
+      />
       <div className="grid min-w-0 grid-cols-1 gap-3 sm:grid-cols-2">
         <NumberField
           label="Check interval (hours)"
           value={settings.check_interval_hours}
           min={1}
           max={168}
+          disabled={pending}
           onChange={(value) => setNumber("check_interval_hours", value)}
           testId="storage-check-interval"
         />
@@ -154,6 +167,7 @@ function CorePolicySection({ settings, capabilities, onChange }: PolicySectionPr
           value={settings.idle_for_minutes}
           min={1}
           max={1440}
+          disabled={pending}
           onChange={(value) => setNumber("idle_for_minutes", value)}
           testId="storage-idle-period"
         />
@@ -162,6 +176,7 @@ function CorePolicySection({ settings, capabilities, onChange }: PolicySectionPr
           value={settings.orphan_grace_hours}
           min={24}
           max={2160}
+          disabled={pending}
           onChange={(value) => setNumber("orphan_grace_hours", value)}
           testId="storage-orphan-grace"
         />
@@ -170,6 +185,7 @@ function CorePolicySection({ settings, capabilities, onChange }: PolicySectionPr
           value={settings.quarantine_retention_hours}
           min={24}
           max={2160}
+          disabled={pending}
           onChange={(value) => setNumber("quarantine_retention_hours", value)}
           testId="storage-quarantine-retention"
         />
@@ -177,6 +193,7 @@ function CorePolicySection({ settings, capabilities, onChange }: PolicySectionPr
           label="Go cache maximum (bytes)"
           value={settings.go_cache.max_bytes}
           min={1073741824}
+          disabled={pending}
           onChange={(value) =>
             onChange({ ...settings, go_cache: { ...settings.go_cache, max_bytes: value } })
           }
@@ -191,11 +208,16 @@ function AdoptionSection({
   path,
   setPath,
   onOpen,
+  pending,
 }: {
   path: string;
   setPath: (path: string) => void;
   onOpen: () => void;
+  pending: boolean;
 }) {
+  let disabledReason: string | undefined;
+  if (pending) disabledReason = "Wait for the current storage action to finish.";
+  else if (!path.trim()) disabledReason = "Enter an absolute cache path first.";
   return (
     <div className="min-w-0 space-y-2 rounded-md border p-3">
       <Label htmlFor="storage-adoption-path">External Go-cache path</Label>
@@ -206,6 +228,7 @@ function AdoptionSection({
         <Input
           id="storage-adoption-path"
           value={path}
+          disabled={pending}
           onChange={(event) => setPath(event.target.value)}
           placeholder="/root/.cache/go-build"
           className="h-11 min-w-0 font-mono"
@@ -213,7 +236,7 @@ function AdoptionSection({
         />
         <StorageActionButton
           variant="outline"
-          disabledReason={!path.trim() ? "Enter an absolute cache path first." : undefined}
+          disabledReason={disabledReason}
           onClick={onOpen}
           data-testid="storage-go-cache-adopt"
         >
@@ -224,9 +247,51 @@ function AdoptionSection({
   );
 }
 
+function DockerThresholdFields({
+  settings,
+  pending,
+  onChange,
+}: Pick<PolicySectionProps, "settings" | "pending" | "onChange">) {
+  const setDockerNumber = (
+    key: "build_cache_keep_bytes" | "build_cache_unused_hours" | "unused_images_hours",
+    value: number,
+  ) => onChange({ ...settings, docker: { ...settings.docker, [key]: value } });
+  return (
+    <div className="grid min-w-0 grid-cols-1 gap-3 py-3 sm:grid-cols-2">
+      <NumberField
+        label="Build cache retained (bytes)"
+        value={settings.docker.build_cache_keep_bytes}
+        min={1073741824}
+        disabled={pending}
+        onChange={(value) => setDockerNumber("build_cache_keep_bytes", value)}
+        testId="storage-docker-build-cache-keep-bytes"
+      />
+      <NumberField
+        label="Build cache unused age (hours)"
+        value={settings.docker.build_cache_unused_hours}
+        min={24}
+        max={2562047}
+        disabled={pending}
+        onChange={(value) => setDockerNumber("build_cache_unused_hours", value)}
+        testId="storage-docker-build-cache-unused-hours"
+      />
+      <NumberField
+        label="Unused image age (hours)"
+        value={settings.docker.unused_images_hours}
+        min={24}
+        max={2562047}
+        disabled={pending}
+        onChange={(value) => setDockerNumber("unused_images_hours", value)}
+        testId="storage-docker-unused-images-hours"
+      />
+    </div>
+  );
+}
+
 function DockerPolicySection({
   settings,
   capabilities,
+  pending,
   onChange,
   onOpen,
 }: PolicySectionProps & { onOpen: () => void }) {
@@ -234,6 +299,7 @@ function DockerPolicySection({
     ? undefined
     : "Docker is unavailable on the configured host.";
   const disabledReason =
+    (pending ? "Wait for the current storage action to finish." : undefined) ??
     unavailable ??
     (!settings.docker.dedicated_daemon_acknowledged
       ? "Acknowledge a dedicated Docker daemon first."
@@ -246,7 +312,7 @@ function DockerPolicySection({
         control={
           <Switch
             checked={settings.docker.dedicated_daemon_acknowledged}
-            disabled={!capabilities.docker_available}
+            disabled={pending || !capabilities.docker_available}
             onCheckedChange={(checked) => {
               if (checked) onOpen();
               else onChange(settingsWithDockerAcknowledgement(settings, false));
@@ -297,6 +363,7 @@ function DockerPolicySection({
           />
         }
       />
+      <DockerThresholdFields settings={settings} pending={pending} onChange={onChange} />
       {disabledReason && <p className="text-xs text-muted-foreground">{disabledReason}</p>}
     </div>
   );
@@ -320,17 +387,24 @@ export function StoragePolicyCard({
         <CardTitle className="text-base">Maintenance policy</CardTitle>
       </CardHeader>
       <CardContent className="space-y-5">
-        <CorePolicySection settings={settings} capabilities={capabilities} onChange={onChange} />
+        <CorePolicySection
+          settings={settings}
+          capabilities={capabilities}
+          pending={pending}
+          onChange={onChange}
+        />
         {capabilities.go_cache_adoption_available && (
           <AdoptionSection
             path={adoptionPath}
             setPath={setAdoptionPath}
+            pending={pending}
             onOpen={() => setAdoptionDialogOpen(true)}
           />
         )}
         <DockerPolicySection
           settings={settings}
           capabilities={capabilities}
+          pending={pending}
           onChange={onChange}
           onOpen={() => setDockerDialogOpen(true)}
         />

--- a/apps/web/components/settings/system/storage/storage-policy-card.tsx
+++ b/apps/web/components/settings/system/storage/storage-policy-card.tsx
@@ -1,0 +1,368 @@
+"use client";
+
+import { useState, type ReactNode } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@kandev/ui/card";
+import { Input } from "@kandev/ui/input";
+import { Label } from "@kandev/ui/label";
+import { Switch } from "@kandev/ui/switch";
+import type { StorageCapabilities, StorageMaintenanceSettings } from "@/lib/types/system";
+import { settingsWithDockerAcknowledgement } from "@/hooks/domains/system/use-storage-maintenance";
+import { DedicatedDockerDialog, ExternalGoCacheDialog } from "./storage-confirmation-dialogs";
+import { StorageActionButton } from "./storage-action-button";
+
+type Props = {
+  settings: StorageMaintenanceSettings;
+  capabilities: StorageCapabilities;
+  pending: boolean;
+  onChange: (settings: StorageMaintenanceSettings) => void;
+  onSave: () => Promise<void>;
+  onDedicatedConfirm: (settings: StorageMaintenanceSettings) => Promise<void>;
+  onAdopt: (path: string) => Promise<void>;
+};
+
+function SettingRow({
+  title,
+  description,
+  control,
+}: {
+  title: string;
+  description: string;
+  control: ReactNode;
+}) {
+  return (
+    <div className="flex min-h-11 items-center justify-between gap-4 border-b py-3 last:border-b-0">
+      <div className="min-w-0">
+        <Label className="text-sm">{title}</Label>
+        <p className="text-xs text-muted-foreground">{description}</p>
+      </div>
+      <div className="shrink-0">{control}</div>
+    </div>
+  );
+}
+
+function NumberField({
+  label,
+  value,
+  min,
+  max,
+  onChange,
+  testId,
+}: {
+  label: string;
+  value: number;
+  min: number;
+  max?: number;
+  onChange: (value: number) => void;
+  testId: string;
+}) {
+  return (
+    <label className="min-w-0 space-y-1 text-xs text-muted-foreground">
+      <span>{label}</span>
+      <Input
+        type="number"
+        min={min}
+        max={max}
+        value={value}
+        onChange={(event) => onChange(Number(event.target.value))}
+        className="h-11"
+        data-testid={testId}
+      />
+    </label>
+  );
+}
+
+type PolicySectionProps = Pick<Props, "settings" | "capabilities" | "onChange">;
+
+function PolicySwitches({ settings, capabilities, onChange }: PolicySectionProps) {
+  return (
+    <div>
+      <SettingRow
+        title="Scheduled maintenance"
+        description="Disabled by default; runs only after the configured idle period."
+        control={
+          <Switch
+            checked={settings.enabled}
+            onCheckedChange={(enabled) => onChange({ ...settings, enabled })}
+            aria-label="Scheduled maintenance"
+            data-testid="storage-scheduling-enabled"
+          />
+        }
+      />
+      <SettingRow
+        title="Orphan task workspaces"
+        description="Move positively identified orphan task roots to quarantine."
+        control={
+          <Switch
+            checked={settings.workspaces.enabled}
+            onCheckedChange={(enabled) => onChange({ ...settings, workspaces: { enabled } })}
+            aria-label="Clean orphan task workspaces"
+          />
+        }
+      />
+      <SettingRow
+        title="Kandev containers"
+        description="Remove stopped managed containers only after inventory confirms they are unused."
+        control={
+          <Switch
+            checked={settings.kandev_containers.enabled}
+            onCheckedChange={(enabled) => onChange({ ...settings, kandev_containers: { enabled } })}
+            aria-label="Clean Kandev containers"
+          />
+        }
+      />
+      <SettingRow
+        title="Managed Go cache"
+        description={`New local executions use ${capabilities.managed_go_cache_path}.`}
+        control={
+          <Switch
+            checked={settings.go_cache.enabled}
+            onCheckedChange={(enabled) =>
+              onChange({ ...settings, go_cache: { ...settings.go_cache, enabled } })
+            }
+            aria-label="Enable managed Go cache"
+            data-testid="storage-go-cache-enabled"
+          />
+        }
+      />
+    </div>
+  );
+}
+
+function CorePolicySection({ settings, capabilities, onChange }: PolicySectionProps) {
+  const setNumber = (
+    key:
+      | "check_interval_hours"
+      | "idle_for_minutes"
+      | "orphan_grace_hours"
+      | "quarantine_retention_hours",
+    value: number,
+  ) => onChange({ ...settings, [key]: value });
+  return (
+    <>
+      <PolicySwitches settings={settings} capabilities={capabilities} onChange={onChange} />
+      <div className="grid min-w-0 grid-cols-1 gap-3 sm:grid-cols-2">
+        <NumberField
+          label="Check interval (hours)"
+          value={settings.check_interval_hours}
+          min={1}
+          max={168}
+          onChange={(value) => setNumber("check_interval_hours", value)}
+          testId="storage-check-interval"
+        />
+        <NumberField
+          label="Idle period (minutes)"
+          value={settings.idle_for_minutes}
+          min={1}
+          max={1440}
+          onChange={(value) => setNumber("idle_for_minutes", value)}
+          testId="storage-idle-period"
+        />
+        <NumberField
+          label="Orphan grace (hours)"
+          value={settings.orphan_grace_hours}
+          min={24}
+          max={2160}
+          onChange={(value) => setNumber("orphan_grace_hours", value)}
+          testId="storage-orphan-grace"
+        />
+        <NumberField
+          label="Quarantine retention (hours)"
+          value={settings.quarantine_retention_hours}
+          min={24}
+          max={2160}
+          onChange={(value) => setNumber("quarantine_retention_hours", value)}
+          testId="storage-quarantine-retention"
+        />
+        <NumberField
+          label="Go cache maximum (bytes)"
+          value={settings.go_cache.max_bytes}
+          min={1073741824}
+          onChange={(value) =>
+            onChange({ ...settings, go_cache: { ...settings.go_cache, max_bytes: value } })
+          }
+          testId="storage-go-cache-max"
+        />
+      </div>
+    </>
+  );
+}
+
+function AdoptionSection({
+  path,
+  setPath,
+  onOpen,
+}: {
+  path: string;
+  setPath: (path: string) => void;
+  onOpen: () => void;
+}) {
+  return (
+    <div className="min-w-0 space-y-2 rounded-md border p-3">
+      <Label htmlFor="storage-adoption-path">External Go-cache path</Label>
+      <p className="text-xs text-muted-foreground">
+        Adoption grants Kandev permission to rotate this existing cache.
+      </p>
+      <div className="flex min-w-0 flex-col gap-2 sm:flex-row">
+        <Input
+          id="storage-adoption-path"
+          value={path}
+          onChange={(event) => setPath(event.target.value)}
+          placeholder="/root/.cache/go-build"
+          className="h-11 min-w-0 font-mono"
+          data-testid="storage-go-cache-adopt-path"
+        />
+        <StorageActionButton
+          variant="outline"
+          disabledReason={!path.trim() ? "Enter an absolute cache path first." : undefined}
+          onClick={onOpen}
+          data-testid="storage-go-cache-adopt"
+        >
+          Adopt cache
+        </StorageActionButton>
+      </div>
+    </div>
+  );
+}
+
+function DockerPolicySection({
+  settings,
+  capabilities,
+  onChange,
+  onOpen,
+}: PolicySectionProps & { onOpen: () => void }) {
+  const unavailable = capabilities.docker_available
+    ? undefined
+    : "Docker is unavailable on the configured host.";
+  const disabledReason =
+    unavailable ??
+    (!settings.docker.dedicated_daemon_acknowledged
+      ? "Acknowledge a dedicated Docker daemon first."
+      : undefined);
+  return (
+    <div className="space-y-1 rounded-md border p-3">
+      <SettingRow
+        title="Dedicated Docker daemon"
+        description="Required for host-global build-cache and unused-image cleanup."
+        control={
+          <Switch
+            checked={settings.docker.dedicated_daemon_acknowledged}
+            disabled={!capabilities.docker_available}
+            onCheckedChange={(checked) => {
+              if (checked) onOpen();
+              else onChange(settingsWithDockerAcknowledgement(settings, false));
+            }}
+            aria-label="Dedicated Docker daemon"
+            data-testid="storage-docker-dedicated"
+          />
+        }
+      />
+      {unavailable && (
+        <p className="text-xs text-amber-600">
+          Docker unavailable: daemon-wide actions remain disabled.
+        </p>
+      )}
+      <SettingRow
+        title="Docker build cache"
+        description="Uses Docker API age and storage filters; never runs system prune."
+        control={
+          <Switch
+            checked={settings.docker.build_cache_enabled}
+            disabled={Boolean(disabledReason)}
+            onCheckedChange={(enabled) =>
+              onChange({
+                ...settings,
+                docker: { ...settings.docker, build_cache_enabled: enabled },
+              })
+            }
+            aria-label="Clean Docker build cache"
+            data-testid="storage-docker-build-cache"
+          />
+        }
+      />
+      <SettingRow
+        title="Unused Docker images"
+        description="Only images unused by every container and older than the configured age."
+        control={
+          <Switch
+            checked={settings.docker.unused_images_enabled}
+            disabled={Boolean(disabledReason)}
+            onCheckedChange={(enabled) =>
+              onChange({
+                ...settings,
+                docker: { ...settings.docker, unused_images_enabled: enabled },
+              })
+            }
+            aria-label="Clean unused Docker images"
+            data-testid="storage-docker-unused-images"
+          />
+        }
+      />
+      {disabledReason && <p className="text-xs text-muted-foreground">{disabledReason}</p>}
+    </div>
+  );
+}
+
+export function StoragePolicyCard({
+  settings,
+  capabilities,
+  pending,
+  onChange,
+  onSave,
+  onDedicatedConfirm,
+  onAdopt,
+}: Props) {
+  const [dockerDialogOpen, setDockerDialogOpen] = useState(false);
+  const [adoptionDialogOpen, setAdoptionDialogOpen] = useState(false);
+  const [adoptionPath, setAdoptionPath] = useState("");
+  return (
+    <Card className="min-w-0" data-testid="storage-policy-card">
+      <CardHeader>
+        <CardTitle className="text-base">Maintenance policy</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-5">
+        <CorePolicySection settings={settings} capabilities={capabilities} onChange={onChange} />
+        {capabilities.go_cache_adoption_available && (
+          <AdoptionSection
+            path={adoptionPath}
+            setPath={setAdoptionPath}
+            onOpen={() => setAdoptionDialogOpen(true)}
+          />
+        )}
+        <DockerPolicySection
+          settings={settings}
+          capabilities={capabilities}
+          onChange={onChange}
+          onOpen={() => setDockerDialogOpen(true)}
+        />
+        <div className="flex justify-end">
+          <StorageActionButton
+            disabledReason={pending ? "Wait for the current storage action to finish." : undefined}
+            onClick={() => void onSave()}
+            data-testid="storage-save-settings"
+          >
+            Save policy
+          </StorageActionButton>
+        </div>
+      </CardContent>
+      <DedicatedDockerDialog
+        open={dockerDialogOpen}
+        onOpenChange={setDockerDialogOpen}
+        onConfirm={() => {
+          const next = settingsWithDockerAcknowledgement(settings, true);
+          onChange(next);
+          void onDedicatedConfirm(next);
+          setDockerDialogOpen(false);
+        }}
+      />
+      <ExternalGoCacheDialog
+        path={adoptionPath}
+        open={adoptionDialogOpen}
+        onOpenChange={setAdoptionDialogOpen}
+        onConfirm={() => {
+          void onAdopt(adoptionPath.trim());
+          setAdoptionDialogOpen(false);
+        }}
+      />
+    </Card>
+  );
+}

--- a/apps/web/components/settings/system/storage/storage-policy-card.tsx
+++ b/apps/web/components/settings/system/storage/storage-policy-card.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { useState, type ReactNode } from "react";
-import { Card, CardContent, CardHeader, CardTitle } from "@kandev/ui/card";
+import { useState } from "react";
 import { Input } from "@kandev/ui/input";
 import { Label } from "@kandev/ui/label";
 import { Switch } from "@kandev/ui/switch";
@@ -9,6 +8,7 @@ import { settingsWithDockerAcknowledgement } from "@/hooks/domains/system/use-st
 import type { StorageCapabilities, StorageMaintenanceSettings } from "@/lib/types/system";
 import { DedicatedDockerDialog, ExternalGoCacheDialog } from "./storage-confirmation-dialogs";
 import { StorageActionButton } from "./storage-action-button";
+import { NumberField, PolicySection, SettingRow } from "./storage-policy-fields";
 import { StorageSettingHelp } from "./storage-setting-help";
 import { bytesToGigabytes, gigabytesToBytes } from "./storage-units";
 
@@ -24,96 +24,10 @@ type Props = {
 
 type PolicySectionProps = Pick<Props, "settings" | "capabilities" | "onChange" | "pending">;
 
-function PolicySection({
-  title,
-  description,
-  children,
-}: {
-  title: string;
-  description: string;
-  children: ReactNode;
-}) {
-  return (
-    <section className="border-t py-5 first:border-t-0 first:pt-0">
-      <div className="mb-3">
-        <h3 className="text-sm font-medium">{title}</h3>
-        <p className="text-xs text-muted-foreground">{description}</p>
-      </div>
-      {children}
-    </section>
-  );
-}
-
-function SettingRow({
-  title,
-  description,
-  help,
-  control,
-}: {
-  title: string;
-  description: string;
-  help: string;
-  control: ReactNode;
-}) {
-  return (
-    <div className="flex min-h-11 items-center justify-between gap-4 border-b py-3 last:border-b-0">
-      <div className="min-w-0">
-        <div className="flex items-center gap-1">
-          <Label className="text-sm">{title}</Label>
-          <StorageSettingHelp label={title}>{help}</StorageSettingHelp>
-        </div>
-        <p className="text-xs text-muted-foreground">{description}</p>
-      </div>
-      <div className="shrink-0">{control}</div>
-    </div>
-  );
-}
-
-function NumberField({
-  label,
-  help,
-  value,
-  min,
-  max,
-  disabled,
-  onChange,
-  testId,
-}: {
-  label: string;
-  help: string;
-  value: number;
-  min: number;
-  max?: number;
-  disabled?: boolean;
-  onChange: (value: number) => void;
-  testId: string;
-}) {
-  return (
-    <div className="min-w-0 space-y-1">
-      <div className="flex items-center gap-1">
-        <Label htmlFor={testId} className="text-xs text-muted-foreground">
-          {label}
-        </Label>
-        <StorageSettingHelp label={label}>{help}</StorageSettingHelp>
-      </div>
-      <Input
-        id={testId}
-        type="number"
-        min={min}
-        max={max}
-        disabled={disabled}
-        value={value}
-        onChange={(event) => onChange(Number(event.target.value))}
-        className="h-11"
-        data-testid={testId}
-      />
-    </div>
-  );
-}
-
 function ScheduleSection({ settings, pending, onChange }: PolicySectionProps) {
   return (
     <PolicySection
+      sectionId="schedule"
       title="Schedule"
       description="Controls when automatic maintenance is allowed to start. Manual actions remain available when scheduling is off."
     >
@@ -138,7 +52,7 @@ function ScheduleSection({ settings, pending, onChange }: PolicySectionProps) {
           value={settings.check_interval_hours}
           min={1}
           max={168}
-          disabled={pending}
+          disabled={pending || !settings.enabled}
           onChange={(check_interval_hours) => onChange({ ...settings, check_interval_hours })}
           testId="storage-check-interval"
         />
@@ -148,7 +62,7 @@ function ScheduleSection({ settings, pending, onChange }: PolicySectionProps) {
           value={settings.idle_for_minutes}
           min={1}
           max={1440}
-          disabled={pending}
+          disabled={pending || !settings.enabled}
           onChange={(idle_for_minutes) => onChange({ ...settings, idle_for_minutes })}
           testId="storage-idle-period"
         />
@@ -160,6 +74,7 @@ function ScheduleSection({ settings, pending, onChange }: PolicySectionProps) {
 function WorkspaceSection({ settings, pending, onChange }: PolicySectionProps) {
   return (
     <PolicySection
+      sectionId="workspaces"
       title="Workspaces and containers"
       description="Reclaim resources that Kandev can positively identify as no longer in use."
     >
@@ -183,7 +98,7 @@ function WorkspaceSection({ settings, pending, onChange }: PolicySectionProps) {
           value={settings.orphan_grace_hours}
           min={24}
           max={2160}
-          disabled={pending}
+          disabled={pending || !settings.workspaces.enabled}
           onChange={(orphan_grace_hours) => onChange({ ...settings, orphan_grace_hours })}
           testId="storage-orphan-grace"
         />
@@ -210,14 +125,17 @@ function AdoptionField({
   setPath,
   onOpen,
   pending,
+  enabled,
 }: {
   path: string;
   setPath: (path: string) => void;
   onOpen: () => void;
   pending: boolean;
+  enabled: boolean;
 }) {
   let disabledReason: string | undefined;
   if (pending) disabledReason = "Wait for the current storage action to finish.";
+  else if (!enabled) disabledReason = "Enable the managed Go cache first.";
   else if (!path.trim()) disabledReason = "Enter an absolute cache path first.";
   return (
     <div className="min-w-0 space-y-2 pt-3">
@@ -236,7 +154,7 @@ function AdoptionField({
         <Input
           id="storage-adoption-path"
           value={path}
-          disabled={pending}
+          disabled={pending || !enabled}
           onChange={(event) => setPath(event.target.value)}
           placeholder="/root/.cache/go-build"
           className="h-11 min-w-0 font-mono"
@@ -270,6 +188,7 @@ function GoCacheSection({
 }) {
   return (
     <PolicySection
+      sectionId="go-cache"
       title="Go build cache"
       description="Use and trim a Kandev-owned cache for new host-local Go executions."
     >
@@ -295,7 +214,7 @@ function GoCacheSection({
           help="This is a cleanup trigger, not a hard quota. The cache may grow past this size while tasks are active. Maintenance rotates the owned cache into quarantine and recreates an empty cache after the limit is exceeded."
           value={bytesToGigabytes(settings.go_cache.max_bytes)}
           min={1}
-          disabled={pending}
+          disabled={pending || !settings.go_cache.enabled}
           onChange={(gigabytes) =>
             onChange({
               ...settings,
@@ -310,6 +229,7 @@ function GoCacheSection({
           path={adoptionPath}
           setPath={setAdoptionPath}
           pending={pending}
+          enabled={settings.go_cache.enabled}
           onOpen={onOpenAdoption}
         />
       )}
@@ -321,12 +241,10 @@ type DockerSettings = StorageMaintenanceSettings["docker"];
 
 function DockerBuildCacheSettings({
   docker,
-  pending,
   disabledReason,
   updateDocker,
 }: {
   docker: DockerSettings;
-  pending: boolean;
   disabledReason?: string;
   updateDocker: (docker: DockerSettings) => void;
 }) {
@@ -354,7 +272,7 @@ function DockerBuildCacheSettings({
           help="Docker keeps approximately this much build cache when pruning eligible records. A larger value preserves more reusable build layers but reclaims less disk space."
           value={bytesToGigabytes(docker.build_cache_keep_bytes)}
           min={1}
-          disabled={pending}
+          disabled={Boolean(disabledReason) || !docker.build_cache_enabled}
           onChange={(gigabytes) =>
             updateDocker({
               ...docker,
@@ -369,7 +287,7 @@ function DockerBuildCacheSettings({
           value={docker.build_cache_unused_hours}
           min={24}
           max={2562047}
-          disabled={pending}
+          disabled={Boolean(disabledReason) || !docker.build_cache_enabled}
           onChange={(build_cache_unused_hours) =>
             updateDocker({ ...docker, build_cache_unused_hours })
           }
@@ -382,12 +300,10 @@ function DockerBuildCacheSettings({
 
 function DockerImageSettings({
   docker,
-  pending,
   disabledReason,
   updateDocker,
 }: {
   docker: DockerSettings;
-  pending: boolean;
   disabledReason?: string;
   updateDocker: (docker: DockerSettings) => void;
 }) {
@@ -416,7 +332,7 @@ function DockerImageSettings({
           value={docker.unused_images_hours}
           min={24}
           max={2562047}
-          disabled={pending}
+          disabled={Boolean(disabledReason) || !docker.unused_images_enabled}
           onChange={(unused_images_hours) => updateDocker({ ...docker, unused_images_hours })}
           testId="storage-docker-unused-images-hours"
         />
@@ -445,6 +361,7 @@ function DockerSection({
     onChange({ ...settings, docker });
   return (
     <PolicySection
+      sectionId="docker"
       title="Docker cleanup"
       description="Optional daemon-wide cleanup. Enable it only when this Docker daemon is dedicated to Kandev."
     >
@@ -472,13 +389,11 @@ function DockerSection({
       )}
       <DockerBuildCacheSettings
         docker={settings.docker}
-        pending={pending}
         disabledReason={disabledReason}
         updateDocker={updateDocker}
       />
       <DockerImageSettings
         docker={settings.docker}
-        pending={pending}
         disabledReason={disabledReason}
         updateDocker={updateDocker}
       />
@@ -490,6 +405,7 @@ function DockerSection({
 function QuarantineSection({ settings, pending, onChange }: PolicySectionProps) {
   return (
     <PolicySection
+      sectionId="quarantine"
       title="Quarantine safety"
       description="Keep recoverable resources for a grace period before permanent deletion."
     >
@@ -524,14 +440,14 @@ export function StoragePolicyCard({
   const [adoptionDialogOpen, setAdoptionDialogOpen] = useState(false);
   const [adoptionPath, setAdoptionPath] = useState("");
   return (
-    <Card className="min-w-0" data-testid="storage-policy-card">
-      <CardHeader>
-        <CardTitle className="text-base">Maintenance policy</CardTitle>
+    <section className="min-w-0 space-y-4" data-testid="storage-policy-card">
+      <div>
+        <h2 className="text-base font-medium">Maintenance policy</h2>
         <p className="text-xs text-muted-foreground">
           Choose what Kandev may reclaim automatically and the safety limits it must follow.
         </p>
-      </CardHeader>
-      <CardContent>
+      </div>
+      <div className="space-y-3">
         <ScheduleSection
           settings={settings}
           capabilities={capabilities}
@@ -566,16 +482,16 @@ export function StoragePolicyCard({
           pending={pending}
           onChange={onChange}
         />
-        <div className="flex justify-end border-t pt-5">
-          <StorageActionButton
-            disabledReason={pending ? "Wait for the current storage action to finish." : undefined}
-            onClick={() => void onSave()}
-            data-testid="storage-save-settings"
-          >
-            Save policy
-          </StorageActionButton>
-        </div>
-      </CardContent>
+      </div>
+      <div className="flex justify-end">
+        <StorageActionButton
+          disabledReason={pending ? "Wait for the current storage action to finish." : undefined}
+          onClick={() => void onSave()}
+          data-testid="storage-save-settings"
+        >
+          Save policy
+        </StorageActionButton>
+      </div>
       <DedicatedDockerDialog
         open={dockerDialogOpen}
         onOpenChange={setDockerDialogOpen}
@@ -595,6 +511,6 @@ export function StoragePolicyCard({
           setAdoptionDialogOpen(false);
         }}
       />
-    </Card>
+    </section>
   );
 }

--- a/apps/web/components/settings/system/storage/storage-policy-fields.tsx
+++ b/apps/web/components/settings/system/storage/storage-policy-fields.tsx
@@ -1,0 +1,94 @@
+import type { ReactNode } from "react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@kandev/ui/card";
+import { Input } from "@kandev/ui/input";
+import { Label } from "@kandev/ui/label";
+import { StorageSettingHelp } from "./storage-setting-help";
+
+export function PolicySection({
+  sectionId,
+  title,
+  description,
+  children,
+}: {
+  sectionId: string;
+  title: string;
+  description: string;
+  children: ReactNode;
+}) {
+  return (
+    <Card className="min-w-0" data-testid={`storage-policy-section-${sectionId}`}>
+      <CardHeader>
+        <CardTitle className="text-sm">{title}</CardTitle>
+        <CardDescription className="text-xs">{description}</CardDescription>
+      </CardHeader>
+      <CardContent>{children}</CardContent>
+    </Card>
+  );
+}
+
+export function SettingRow({
+  title,
+  description,
+  help,
+  control,
+}: {
+  title: string;
+  description: string;
+  help: string;
+  control: ReactNode;
+}) {
+  return (
+    <div className="flex min-h-11 items-center justify-between gap-4 border-b py-3 last:border-b-0">
+      <div className="min-w-0">
+        <div className="flex items-center gap-1">
+          <Label className="text-sm">{title}</Label>
+          <StorageSettingHelp label={title}>{help}</StorageSettingHelp>
+        </div>
+        <p className="text-xs text-muted-foreground">{description}</p>
+      </div>
+      <div className="shrink-0">{control}</div>
+    </div>
+  );
+}
+
+export function NumberField({
+  label,
+  help,
+  value,
+  min,
+  max,
+  disabled,
+  onChange,
+  testId,
+}: {
+  label: string;
+  help: string;
+  value: number;
+  min: number;
+  max?: number;
+  disabled?: boolean;
+  onChange: (value: number) => void;
+  testId: string;
+}) {
+  return (
+    <div className="min-w-0 space-y-1">
+      <div className="flex items-center gap-1">
+        <Label htmlFor={testId} className="text-xs text-muted-foreground">
+          {label}
+        </Label>
+        <StorageSettingHelp label={label}>{help}</StorageSettingHelp>
+      </div>
+      <Input
+        id={testId}
+        type="number"
+        min={min}
+        max={max}
+        disabled={disabled}
+        value={value}
+        onChange={(event) => onChange(Number(event.target.value))}
+        className="h-11"
+        data-testid={testId}
+      />
+    </div>
+  );
+}

--- a/apps/web/components/settings/system/storage/storage-quarantine-card.tsx
+++ b/apps/web/components/settings/system/storage/storage-quarantine-card.tsx
@@ -2,26 +2,54 @@
 
 import { useState } from "react";
 import { Badge } from "@kandev/ui/badge";
-import { Card, CardContent, CardHeader, CardTitle } from "@kandev/ui/card";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@kandev/ui/card";
 import { IconRestore, IconTrash } from "@tabler/icons-react";
 import type { StorageQuarantineEntry } from "@/lib/types/system";
-import { formatBytes } from "@/lib/utils/format-bytes";
+import { JobProgressIndicator } from "../job-progress-indicator";
 import { PermanentDeleteDialog } from "./storage-confirmation-dialogs";
 import { StorageActionButton } from "./storage-action-button";
+import { StorageSettingHelp } from "./storage-setting-help";
+import { formatGigabytes } from "./storage-units";
 
 type Props = {
   entries: StorageQuarantineEntry[];
+  deleteJobId?: string;
   disabledReason?: string;
   onRestore: (id: string) => Promise<void>;
   onDelete: (id: string) => Promise<void>;
 };
 
-export function StorageQuarantineCard({ entries, disabledReason, onRestore, onDelete }: Props) {
+export function StorageQuarantineCard({
+  entries,
+  deleteJobId,
+  disabledReason,
+  onRestore,
+  onDelete,
+}: Props) {
   const [deleteEntry, setDeleteEntry] = useState<StorageQuarantineEntry | null>(null);
   return (
     <Card className="min-w-0" data-testid="storage-quarantine-card">
       <CardHeader>
-        <CardTitle className="text-base">Quarantine</CardTitle>
+        <div className="flex min-w-0 flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <CardTitle className="flex items-center gap-1 text-base">
+            Quarantine
+            <StorageSettingHelp label="Quarantine">
+              Quarantine is Kandev's recoverable holding area. Orphan task workspaces and rotated Go
+              caches are moved here before deletion. You can restore an item during its retention
+              period; after the deadline, a later maintenance run may permanently delete it.
+            </StorageSettingHelp>
+          </CardTitle>
+          <JobProgressIndicator
+            kind="storage-quarantine-delete"
+            jobId={deleteJobId}
+            successLabel="Deletion complete"
+            testId="storage-delete-job"
+          />
+        </div>
+        <CardDescription>
+          Cleanup moves recoverable data here first instead of deleting it immediately. Restore an
+          item if you still need it, or delete it permanently when you are certain.
+        </CardDescription>
       </CardHeader>
       <CardContent className="space-y-3">
         {entries.length === 0 && (
@@ -38,7 +66,7 @@ export function StorageQuarantineCard({ entries, disabledReason, onRestore, onDe
                 <div className="flex flex-wrap items-center gap-2">
                   <Badge variant="outline">{entry.resource_type.replace("_", " ")}</Badge>
                   <span className="text-xs text-muted-foreground">
-                    {formatBytes(entry.size_bytes)}
+                    {formatGigabytes(entry.size_bytes)}
                   </span>
                 </div>
                 <p className="break-all font-mono text-xs">{entry.original_path}</p>

--- a/apps/web/components/settings/system/storage/storage-quarantine-card.tsx
+++ b/apps/web/components/settings/system/storage/storage-quarantine-card.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useState } from "react";
+import { Badge } from "@kandev/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@kandev/ui/card";
+import { IconRestore, IconTrash } from "@tabler/icons-react";
+import type { StorageQuarantineEntry } from "@/lib/types/system";
+import { formatBytes } from "@/lib/utils/format-bytes";
+import { PermanentDeleteDialog } from "./storage-confirmation-dialogs";
+import { StorageActionButton } from "./storage-action-button";
+
+type Props = {
+  entries: StorageQuarantineEntry[];
+  disabledReason?: string;
+  onRestore: (id: string) => Promise<void>;
+  onDelete: (id: string) => Promise<void>;
+};
+
+export function StorageQuarantineCard({ entries, disabledReason, onRestore, onDelete }: Props) {
+  const [deleteEntry, setDeleteEntry] = useState<StorageQuarantineEntry | null>(null);
+  return (
+    <Card className="min-w-0" data-testid="storage-quarantine-card">
+      <CardHeader>
+        <CardTitle className="text-base">Quarantine</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {entries.length === 0 && (
+          <p className="text-sm text-muted-foreground">No restorable quarantined resources.</p>
+        )}
+        {entries.map((entry) => (
+          <div
+            key={entry.id}
+            className="min-w-0 rounded-lg border p-3"
+            data-testid={`storage-quarantine-${entry.id}`}
+          >
+            <div className="flex min-w-0 flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+              <div className="min-w-0 space-y-1">
+                <div className="flex flex-wrap items-center gap-2">
+                  <Badge variant="outline">{entry.resource_type.replace("_", " ")}</Badge>
+                  <span className="text-xs text-muted-foreground">
+                    {formatBytes(entry.size_bytes)}
+                  </span>
+                </div>
+                <p className="break-all font-mono text-xs">{entry.original_path}</p>
+                <p className="break-all text-[11px] text-muted-foreground">
+                  Trash: {entry.quarantine_path}
+                </p>
+                {entry.last_error && (
+                  <p className="break-words text-xs text-red-500">{entry.last_error}</p>
+                )}
+              </div>
+              <div className="flex shrink-0 flex-col gap-2 sm:flex-row">
+                <StorageActionButton
+                  variant="outline"
+                  disabledReason={disabledReason}
+                  onClick={() => void onRestore(entry.id)}
+                  data-testid={`storage-quarantine-${entry.id}-restore`}
+                >
+                  <IconRestore className="size-4" /> Restore
+                </StorageActionButton>
+                <StorageActionButton
+                  variant="destructive"
+                  disabledReason={disabledReason}
+                  onClick={() => setDeleteEntry(entry)}
+                  data-testid={`storage-quarantine-${entry.id}-delete`}
+                >
+                  <IconTrash className="size-4" /> Delete
+                </StorageActionButton>
+              </div>
+            </div>
+          </div>
+        ))}
+      </CardContent>
+      <PermanentDeleteDialog
+        entry={deleteEntry}
+        open={deleteEntry !== null}
+        onOpenChange={(open) => {
+          if (!open) setDeleteEntry(null);
+        }}
+        onConfirm={() => {
+          if (deleteEntry) void onDelete(deleteEntry.id);
+          setDeleteEntry(null);
+        }}
+      />
+    </Card>
+  );
+}

--- a/apps/web/components/settings/system/storage/storage-run-history.tsx
+++ b/apps/web/components/settings/system/storage/storage-run-history.tsx
@@ -1,0 +1,46 @@
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@kandev/ui/accordion";
+import { Badge } from "@kandev/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@kandev/ui/card";
+import type { StorageMaintenanceRun } from "@/lib/types/system";
+
+function dateLabel(value: string): string {
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? value : parsed.toLocaleString();
+}
+
+export function StorageRunHistory({ runs }: { runs: StorageMaintenanceRun[] }) {
+  return (
+    <Card className="min-w-0" data-testid="storage-run-history">
+      <CardHeader>
+        <CardTitle className="text-base">Maintenance history</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {runs.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No storage maintenance runs yet.</p>
+        ) : (
+          <Accordion type="multiple">
+            {runs.map((run) => (
+              <AccordionItem key={run.id} value={run.id} data-testid={`storage-run-${run.id}`}>
+                <AccordionTrigger className="min-h-11 items-center px-3 no-underline">
+                  <span className="flex min-w-0 flex-1 flex-wrap items-center gap-2">
+                    <Badge variant={run.state === "failed" ? "destructive" : "outline"}>
+                      {run.state}
+                    </Badge>
+                    <span className="capitalize">{run.trigger}</span>
+                    <span className="text-muted-foreground">{dateLabel(run.started_at)}</span>
+                  </span>
+                </AccordionTrigger>
+                <AccordionContent className="px-3">
+                  {run.message && <p className="mb-2 break-words text-amber-600">{run.message}</p>}
+                  <pre className="max-w-full overflow-hidden whitespace-pre-wrap break-all rounded bg-muted p-3 text-[11px]">
+                    {JSON.stringify(run.result, null, 2)}
+                  </pre>
+                </AccordionContent>
+              </AccordionItem>
+            ))}
+          </Accordion>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/components/settings/system/storage/storage-setting-help.tsx
+++ b/apps/web/components/settings/system/storage/storage-setting-help.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@kandev/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
+import { IconInfoCircle } from "@tabler/icons-react";
+
+export function StorageSettingHelp({ label, children }: { label: string; children: string }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <Tooltip open={open} onOpenChange={setOpen}>
+      <TooltipTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          className="size-11 shrink-0 cursor-help text-muted-foreground sm:size-7"
+          aria-label={`More information about ${label}`}
+          onClick={() => setOpen((current) => !current)}
+        >
+          <IconInfoCircle className="size-4" />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent className="max-w-xs text-xs leading-relaxed">{children}</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/apps/web/components/settings/system/storage/storage-units.test.ts
+++ b/apps/web/components/settings/system/storage/storage-units.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { bytesToGigabytes, formatGigabytes, gigabytesToBytes } from "./storage-units";
+
+describe("storage units", () => {
+  it("converts between API bytes and editable gigabytes", () => {
+    expect(bytesToGigabytes(16_106_127_360)).toBe(15);
+    expect(gigabytesToBytes(2.5)).toBe(2_684_354_560);
+  });
+
+  it("always presents storage usage in gigabytes", () => {
+    expect(formatGigabytes(0)).toBe("0 GB");
+    expect(formatGigabytes(1)).toBe("<0.01 GB");
+    expect(formatGigabytes(16_106_127_360)).toBe("15 GB");
+  });
+});

--- a/apps/web/components/settings/system/storage/storage-units.test.ts
+++ b/apps/web/components/settings/system/storage/storage-units.test.ts
@@ -7,9 +7,16 @@ describe("storage units", () => {
     expect(gigabytesToBytes(2.5)).toBe(2_684_354_560);
   });
 
-  it("always presents storage usage in gigabytes", () => {
+  it("formats normal byte values as gigabytes", () => {
     expect(formatGigabytes(0)).toBe("0 GB");
     expect(formatGigabytes(1)).toBe("<0.01 GB");
     expect(formatGigabytes(16_106_127_360)).toBe("15 GB");
+  });
+
+  it("returns a dash for missing or non-finite values", () => {
+    expect(formatGigabytes(null)).toBe("-");
+    expect(formatGigabytes(undefined)).toBe("-");
+    expect(formatGigabytes(Infinity)).toBe("-");
+    expect(formatGigabytes(NaN)).toBe("-");
   });
 });

--- a/apps/web/components/settings/system/storage/storage-units.ts
+++ b/apps/web/components/settings/system/storage/storage-units.ts
@@ -1,0 +1,17 @@
+const BYTES_PER_GIGABYTE = 1024 ** 3;
+
+export function bytesToGigabytes(bytes: number): number {
+  return bytes / BYTES_PER_GIGABYTE;
+}
+
+export function gigabytesToBytes(gigabytes: number): number {
+  return Math.round(gigabytes * BYTES_PER_GIGABYTE);
+}
+
+export function formatGigabytes(bytes: number | null | undefined): string {
+  if (bytes == null || !Number.isFinite(bytes)) return "-";
+  if (bytes <= 0) return "0 GB";
+  const gigabytes = bytesToGigabytes(bytes);
+  if (gigabytes < 0.01) return "<0.01 GB";
+  return `${Number(gigabytes.toFixed(2))} GB`;
+}

--- a/apps/web/e2e/helpers/storage-maintenance.ts
+++ b/apps/web/e2e/helpers/storage-maintenance.ts
@@ -1,0 +1,15 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const ABOVE_DEFAULT_LIMIT_BYTES = 16 * 1024 * 1024 * 1024;
+
+export function seedManagedGoCache(tmpDir: string): { artifact: string } {
+  const cacheRoot = path.join(tmpDir, ".kandev", "cache");
+  const cachePath = path.join(cacheRoot, "go-build");
+  const artifact = path.join(cachePath, "e2e-sparse-artifact");
+  fs.mkdirSync(cachePath, { recursive: true });
+  fs.writeFileSync(path.join(cacheRoot, ".go-build.kandev-owned"), "kandev-managed-go-cache\n");
+  fs.closeSync(fs.openSync(artifact, "w"));
+  fs.truncateSync(artifact, ABOVE_DEFAULT_LIMIT_BYTES);
+  return { artifact };
+}

--- a/apps/web/e2e/helpers/storage-maintenance.ts
+++ b/apps/web/e2e/helpers/storage-maintenance.ts
@@ -8,7 +8,7 @@ export function seedManagedGoCache(tmpDir: string): { artifact: string } {
   const cachePath = path.join(cacheRoot, "go-build");
   const artifact = path.join(cachePath, "e2e-sparse-artifact");
   fs.mkdirSync(cachePath, { recursive: true });
-  fs.writeFileSync(path.join(cacheRoot, ".go-build.kandev-owned"), "kandev-managed-go-cache\n");
+  fs.writeFileSync(path.join(cachePath, ".go-build.kandev-owned"), "kandev-managed-go-cache\n");
   fs.closeSync(fs.openSync(artifact, "w"));
   fs.truncateSync(artifact, ABOVE_DEFAULT_LIMIT_BYTES);
   return { artifact };

--- a/apps/web/e2e/tests/docker/storage-maintenance.spec.ts
+++ b/apps/web/e2e/tests/docker/storage-maintenance.spec.ts
@@ -31,15 +31,15 @@ test("removes only stopped Kandev-labeled containers and gates daemon-wide clean
     await testPage.goto("/settings/system/storage");
     await expect(testPage.getByTestId("storage-docker-build-cache")).toBeDisabled();
     await expect(testPage.getByTestId("storage-resource-managed-containers-trigger")).toContainText(
-      /Kandev containers[1-9]\d* B/,
+      "Kandev containers<0.01 GB",
     );
     await testPage.getByTestId("storage-resource-managed-containers-trigger").click();
     await expect(testPage.getByTestId("storage-resource-managed-containers")).toContainText(
       "2 managed containers",
     );
     await testPage.getByTestId("storage-run-now").click();
-    await expect(testPage.getByTestId("storage-cleanup-job")).toHaveAttribute(
-      "data-state",
+    await expect(testPage.getByTestId("storage-run-now")).toHaveAttribute(
+      "data-job-state",
       "succeeded",
     );
     await expect.poll(() => dockerInspectExists(managed)).toBe(false);

--- a/apps/web/e2e/tests/docker/storage-maintenance.spec.ts
+++ b/apps/web/e2e/tests/docker/storage-maintenance.spec.ts
@@ -1,0 +1,58 @@
+import { execFileSync } from "node:child_process";
+import { test, expect } from "../../fixtures/docker-test-base";
+import { E2E_IMAGE_TAG } from "../../fixtures/docker-probe";
+import { dockerInspectExists, dockerRemove } from "../../helpers/docker";
+
+function createStoppedContainer(labels: string[]): string {
+  const args = ["create"];
+  for (const label of labels) args.push("--label", label);
+  args.push(E2E_IMAGE_TAG, "sh", "-c", "printf managed-data > /managed-storage-fixture");
+  const id = execFileSync("docker", args, { encoding: "utf8" }).trim();
+  execFileSync("docker", ["start", "-a", id]);
+  return id;
+}
+
+test("removes only stopped Kandev-labeled containers and gates daemon-wide cleanup", async ({
+  testPage,
+  apiClient,
+  seedData,
+}) => {
+  const activeTask = await apiClient.createTask(seedData.workspaceId, "Retain active container", {
+    workflow_id: seedData.workflowId,
+    workflow_step_id: seedData.startStepId,
+  });
+  const managed = createStoppedContainer([
+    "kandev.managed=true",
+    `kandev.task_id=e2e-storage-missing-${Date.now()}`,
+  ]);
+  const active = createStoppedContainer(["kandev.managed=true", `kandev.task_id=${activeTask.id}`]);
+  const unrelated = createStoppedContainer(["e2e.storage=unrelated"]);
+  try {
+    await testPage.goto("/settings/system/storage");
+    await expect(testPage.getByTestId("storage-docker-build-cache")).toBeDisabled();
+    await expect(testPage.getByTestId("storage-resource-managed-containers-trigger")).toContainText(
+      /Kandev containers[1-9]\d* B/,
+    );
+    await testPage.getByTestId("storage-resource-managed-containers-trigger").click();
+    await expect(testPage.getByTestId("storage-resource-managed-containers")).toContainText(
+      "2 managed containers",
+    );
+    await testPage.getByTestId("storage-run-now").click();
+    await expect(testPage.getByTestId("storage-cleanup-job")).toHaveAttribute(
+      "data-state",
+      "succeeded",
+    );
+    await expect.poll(() => dockerInspectExists(managed)).toBe(false);
+    expect(dockerInspectExists(active)).toBe(true);
+    expect(dockerInspectExists(unrelated)).toBe(true);
+
+    await testPage.getByTestId("storage-docker-dedicated").click();
+    await testPage.getByTestId("storage-docker-confirm-confirmation").fill("DEDICATED");
+    await testPage.getByTestId("storage-docker-confirm").click();
+    await expect(testPage.getByTestId("storage-docker-build-cache")).toBeEnabled();
+  } finally {
+    if (dockerInspectExists(managed)) dockerRemove(managed);
+    if (dockerInspectExists(active)) dockerRemove(active);
+    if (dockerInspectExists(unrelated)) dockerRemove(unrelated);
+  }
+});

--- a/apps/web/e2e/tests/review/walkthrough.spec.ts
+++ b/apps/web/e2e/tests/review/walkthrough.spec.ts
@@ -134,7 +134,7 @@ test.describe("Code walkthrough", () => {
     try {
       await session.clickTab("Changes");
 
-      await session.changes.getByRole("button", { name: "Review" }).click();
+      await session.changes.getByRole("button", { name: "Review", exact: true }).click();
       const dialog = testPage.getByRole("dialog", { name: "Review Changes" });
       await expect(dialog).toBeVisible({ timeout: 15_000 });
 

--- a/apps/web/e2e/tests/system/mobile-storage-maintenance.spec.ts
+++ b/apps/web/e2e/tests/system/mobile-storage-maintenance.spec.ts
@@ -1,0 +1,44 @@
+import fs from "node:fs";
+import { test, expect } from "../../fixtures/test-base";
+import { seedManagedGoCache } from "../../helpers/storage-maintenance";
+import { MobileKanbanPage } from "../../pages/mobile-kanban-page";
+
+test.describe("Mobile storage maintenance", () => {
+  test("opens Storage from mobile navigation and analyzes without horizontal overflow", async ({
+    testPage,
+    backend,
+  }) => {
+    const cache = seedManagedGoCache(backend.tmpDir);
+    const mobile = new MobileKanbanPage(testPage);
+    await mobile.goto();
+    await mobile.mobileMenuButton.click();
+    await testPage.getByRole("link", { name: "Settings" }).click();
+    await testPage.getByTestId("settings-mobile-menu-button").click();
+    const settingsMenu = testPage.getByTestId("settings-mobile-menu");
+    await settingsMenu.getByRole("button", { name: "Expand System" }).click();
+    await settingsMenu.getByRole("link", { name: "Storage" }).click();
+
+    await expect(testPage.getByTestId("storage-settings-page")).toBeVisible();
+    await testPage.getByTestId("storage-analyze").click();
+    await expect(testPage.getByTestId("storage-analysis-job")).toHaveAttribute(
+      "data-state",
+      "succeeded",
+    );
+    await testPage.getByTestId("storage-resource-workspaces-trigger").click();
+    await expect(testPage.getByTestId("storage-resource-workspaces")).toBeVisible();
+    await testPage.getByTestId("storage-resource-go-cache-trigger").click();
+    const explicitRequest = testPage.waitForRequest(
+      (request) =>
+        request.method() === "POST" &&
+        new URL(request.url()).pathname === "/api/v1/system/storage/run",
+    );
+    await testPage.getByTestId("storage-go-cache-clean").click();
+    expect((await explicitRequest).postDataJSON()).toEqual({ resources: ["go_cache"] });
+    await expect.poll(() => fs.existsSync(cache.artifact)).toBe(false);
+    await expect
+      .poll(() =>
+        testPage.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth),
+      )
+      .toBe(true);
+  });
+});

--- a/apps/web/e2e/tests/system/mobile-storage-maintenance.spec.ts
+++ b/apps/web/e2e/tests/system/mobile-storage-maintenance.spec.ts
@@ -19,6 +19,13 @@ test.describe("Mobile storage maintenance", () => {
     await settingsMenu.getByRole("link", { name: "Storage" }).click();
 
     await expect(testPage.getByTestId("storage-settings-page")).toBeVisible();
+    await testPage
+      .getByRole("button", { name: "More information about Scheduled maintenance" })
+      .click();
+    await expect(testPage.getByRole("tooltip")).toContainText(
+      "Turning it off does not disable Analyze or Run now",
+    );
+    await testPage.keyboard.press("Escape");
     await testPage.getByTestId("storage-analyze").click();
     await expect(testPage.getByTestId("storage-analysis-job")).toHaveAttribute(
       "data-state",
@@ -35,6 +42,8 @@ test.describe("Mobile storage maintenance", () => {
     await testPage.getByTestId("storage-go-cache-clean").click();
     expect((await explicitRequest).postDataJSON()).toEqual({ resources: ["go_cache"] });
     await expect.poll(() => fs.existsSync(cache.artifact)).toBe(false);
+    await testPage.getByRole("button", { name: "More information about Quarantine" }).click();
+    await expect(testPage.getByRole("tooltip")).toContainText("recoverable holding area");
     await expect
       .poll(() =>
         testPage.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth),

--- a/apps/web/e2e/tests/system/mobile-storage-maintenance.spec.ts
+++ b/apps/web/e2e/tests/system/mobile-storage-maintenance.spec.ts
@@ -27,10 +27,11 @@ test.describe("Mobile storage maintenance", () => {
     );
     await testPage.keyboard.press("Escape");
     await testPage.getByTestId("storage-analyze").click();
-    await expect(testPage.getByTestId("storage-analysis-job")).toHaveAttribute(
-      "data-state",
+    await expect(testPage.getByTestId("storage-analyze")).toHaveAttribute(
+      "data-job-state",
       "succeeded",
     );
+    await expect(testPage.getByTestId("storage-analyze")).toHaveText("Analysis complete");
     await testPage.getByTestId("storage-resource-workspaces-trigger").click();
     await expect(testPage.getByTestId("storage-resource-workspaces")).toBeVisible();
     await testPage.getByTestId("storage-resource-go-cache-trigger").click();

--- a/apps/web/e2e/tests/system/storage-maintenance.spec.ts
+++ b/apps/web/e2e/tests/system/storage-maintenance.spec.ts
@@ -70,6 +70,11 @@ test.describe("System storage maintenance", () => {
   }) => {
     const orphan = seedOrphanWorkspace(backend.tmpDir);
     await testPage.goto("/settings/system/storage");
+    const overviewBox = await testPage.getByTestId("storage-overview-card").boundingBox();
+    const policyBox = await testPage.getByTestId("storage-policy-card").boundingBox();
+    expect(overviewBox).not.toBeNull();
+    expect(policyBox).not.toBeNull();
+    expect(policyBox!.y).toBeGreaterThanOrEqual(overviewBox!.y + overviewBox!.height);
     const scheduling = testPage.getByTestId("storage-scheduling-enabled");
     await expect(scheduling).toHaveAttribute("data-state", "unchecked");
     await expect(testPage.getByTestId("storage-check-interval")).toHaveValue("24");
@@ -94,7 +99,7 @@ test.describe("System storage maintenance", () => {
     );
     await testPage.getByTestId("storage-resource-workspaces-trigger").click();
     await expect(testPage.getByTestId("storage-resource-workspaces-trigger")).toContainText(
-      /Task workspaces[1-9]\d* B/,
+      "Task workspaces<0.01 GB",
     );
     expect(fs.existsSync(orphan.artifact)).toBe(true);
 

--- a/apps/web/e2e/tests/system/storage-maintenance.spec.ts
+++ b/apps/web/e2e/tests/system/storage-maintenance.spec.ts
@@ -1,0 +1,180 @@
+import fs from "node:fs";
+import path from "node:path";
+import { test, expect } from "../../fixtures/test-base";
+import { seedManagedGoCache } from "../../helpers/storage-maintenance";
+
+function seedOrphanWorkspace(tmpDir: string): { root: string; artifact: string } {
+  const root = path.join(tmpDir, ".kandev", "tasks", "e2e-storage-orphan_abc");
+  const artifact = path.join(root, "repo", "node_modules", "fixture", "index.js");
+  fs.mkdirSync(path.dirname(artifact), { recursive: true });
+  fs.writeFileSync(artifact, "orphan-node-modules-fixture");
+  fs.writeFileSync(
+    path.join(root, ".kandev-workspace.json"),
+    JSON.stringify({
+      task_id: "e2e-storage-orphan",
+      workspace_id: "e2e-orphan-workspace",
+      task_dir_name: "e2e-storage-orphan_abc",
+      layout_version: 1,
+      created_at: "2026-06-01T00:00:00Z",
+    }),
+  );
+  const old = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000);
+  fs.utimesSync(root, old, old);
+  return { root, artifact };
+}
+
+test.describe("System storage maintenance", () => {
+  test("cleans a disabled managed Go cache only through its explicit action", async ({
+    testPage,
+    backend,
+  }) => {
+    const cache = seedManagedGoCache(backend.tmpDir);
+    expect(fs.statSync(cache.artifact).size).toBeGreaterThan(15 * 1024 * 1024 * 1024);
+    const overviewResponse = testPage.waitForResponse(
+      (response) => new URL(response.url()).pathname === "/api/v1/system/storage",
+    );
+    await testPage.goto("/settings/system/storage");
+    const overview = await (await overviewResponse).json();
+    expect(overview.summary.go_cache).toMatchObject({ owned: true });
+    expect(overview.summary.go_cache.size_bytes).toBeGreaterThan(15 * 1024 * 1024 * 1024);
+    await testPage.getByTestId("storage-resource-go-cache-trigger").click();
+    const cleanButton = testPage.getByTestId("storage-go-cache-clean");
+    await expect(cleanButton).toBeEnabled();
+
+    const globalRequest = testPage.waitForRequest(
+      (request) =>
+        request.method() === "POST" &&
+        new URL(request.url()).pathname === "/api/v1/system/storage/run",
+    );
+    await testPage.getByTestId("storage-run-now").click();
+    expect((await globalRequest).postDataJSON()).toEqual({});
+    await expect(testPage.getByTestId("storage-cleanup-job")).toHaveAttribute(
+      "data-state",
+      "succeeded",
+    );
+    expect(fs.existsSync(cache.artifact)).toBe(true);
+
+    const explicitRequest = testPage.waitForRequest(
+      (request) =>
+        request.method() === "POST" &&
+        new URL(request.url()).pathname === "/api/v1/system/storage/run",
+    );
+    await cleanButton.click();
+    expect((await explicitRequest).postDataJSON()).toEqual({ resources: ["go_cache"] });
+    await expect.poll(() => fs.existsSync(cache.artifact)).toBe(false);
+  });
+
+  test("persists policy and analyzes, quarantines, and restores an orphan workspace", async ({
+    testPage,
+    backend,
+  }) => {
+    const orphan = seedOrphanWorkspace(backend.tmpDir);
+    await testPage.goto("/settings/system/storage");
+    const scheduling = testPage.getByTestId("storage-scheduling-enabled");
+    await expect(scheduling).toHaveAttribute("data-state", "unchecked");
+    await expect(testPage.getByTestId("storage-check-interval")).toHaveValue("24");
+
+    await scheduling.click();
+    await testPage.getByTestId("storage-idle-period").fill("11");
+    await testPage.getByTestId("storage-save-settings").click();
+    await expect(testPage.getByText("Storage policy saved")).toBeVisible();
+    await testPage.reload();
+    await expect(scheduling).toHaveAttribute("data-state", "checked");
+    await expect(testPage.getByTestId("storage-idle-period")).toHaveValue("11");
+
+    // Stop the newly enabled scheduler before exercising a deterministic manual run.
+    await scheduling.click();
+    await testPage.getByTestId("storage-save-settings").click();
+    await expect(scheduling).toHaveAttribute("data-state", "unchecked");
+
+    await testPage.getByTestId("storage-analyze").click();
+    await expect(testPage.getByTestId("storage-analysis-job")).toHaveAttribute(
+      "data-state",
+      "succeeded",
+    );
+    await testPage.getByTestId("storage-resource-workspaces-trigger").click();
+    await expect(testPage.getByTestId("storage-resource-workspaces-trigger")).toContainText(
+      /Task workspaces[1-9]\d* B/,
+    );
+    expect(fs.existsSync(orphan.artifact)).toBe(true);
+
+    await backend.restart();
+    await testPage.reload();
+    await expect(testPage.getByTestId("storage-idle-period")).toHaveValue("11");
+
+    await testPage.getByTestId("storage-run-now").click();
+    await expect(testPage.getByTestId("storage-cleanup-job")).toHaveAttribute(
+      "data-state",
+      "succeeded",
+    );
+    const quarantineCard = testPage.getByTestId("storage-quarantine-card");
+    const entry = quarantineCard
+      .locator('[data-testid^="storage-quarantine-"]')
+      .filter({ hasText: orphan.root })
+      .last();
+    await expect(entry).toBeVisible();
+    expect(fs.existsSync(orphan.root)).toBe(false);
+
+    await entry.getByRole("button", { name: "Restore" }).click();
+    await expect.poll(() => fs.existsSync(orphan.artifact)).toBe(true);
+    await expect(quarantineCard.getByText(orphan.root)).toHaveCount(0);
+  });
+
+  test("shows busy feedback instead of forcing maintenance over an active task", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    const task = await apiClient.createTaskWithAgent(
+      seedData.workspaceId,
+      "Storage activity gate",
+      seedData.agentProfileId,
+      {
+        description: "/e2e:simple-message",
+        workflow_id: seedData.workflowId,
+        workflow_step_id: seedData.startStepId,
+        repository_ids: [seedData.repositoryId],
+      },
+    );
+    if (!task.session_id) throw new Error("createTaskWithAgent did not return session_id");
+    await expect
+      .poll(
+        async () => {
+          const { sessions } = await apiClient.listTaskSessions(task.id);
+          return sessions.find((session) => session.id === task.session_id)?.state ?? "";
+        },
+        { timeout: 20_000, message: "Waiting for initial task turn to finish" },
+      )
+      .toBe("WAITING_FOR_INPUT");
+    await apiClient.addUserMessage(
+      task.id,
+      task.session_id,
+      'e2e:delay(15000)\ne2e:message("activity finished")',
+    );
+    await expect
+      .poll(
+        async () => {
+          const { sessions } = await apiClient.listTaskSessions(task.id);
+          return sessions.find((session) => session.id === task.session_id)?.state ?? "";
+        },
+        { timeout: 20_000, message: "Waiting for active task storage gate" },
+      )
+      .toBe("RUNNING");
+
+    await testPage.goto("/settings/system/storage");
+    const responsePromise = testPage.waitForResponse(
+      (response) =>
+        response.request().method() === "POST" &&
+        new URL(response.url()).pathname === "/api/v1/system/storage/run",
+    );
+    await testPage.getByTestId("storage-run-now").click();
+    const response = await responsePromise;
+    const responseBody = await response.json();
+    expect({ status: response.status(), body: responseBody }).toMatchObject({
+      status: 409,
+      body: { busy_resources: expect.any(Array) },
+    });
+    await expect(testPage.getByTestId("storage-error")).toContainText(/busy|active/i);
+    await expect(testPage.getByTestId("storage-cleanup-job")).toHaveCount(0);
+  });
+});

--- a/apps/web/e2e/tests/system/storage-maintenance.spec.ts
+++ b/apps/web/e2e/tests/system/storage-maintenance.spec.ts
@@ -48,8 +48,8 @@ test.describe("System storage maintenance", () => {
     );
     await testPage.getByTestId("storage-run-now").click();
     expect((await globalRequest).postDataJSON()).toEqual({});
-    await expect(testPage.getByTestId("storage-cleanup-job")).toHaveAttribute(
-      "data-state",
+    await expect(testPage.getByTestId("storage-run-now")).toHaveAttribute(
+      "data-job-state",
       "succeeded",
     );
     expect(fs.existsSync(cache.artifact)).toBe(true);
@@ -78,8 +78,12 @@ test.describe("System storage maintenance", () => {
     const scheduling = testPage.getByTestId("storage-scheduling-enabled");
     await expect(scheduling).toHaveAttribute("data-state", "unchecked");
     await expect(testPage.getByTestId("storage-check-interval")).toHaveValue("24");
+    await expect(testPage.getByTestId("storage-check-interval")).toBeDisabled();
+    await expect(testPage.getByTestId("storage-idle-period")).toBeDisabled();
 
     await scheduling.click();
+    await expect(testPage.getByTestId("storage-check-interval")).toBeEnabled();
+    await expect(testPage.getByTestId("storage-idle-period")).toBeEnabled();
     await testPage.getByTestId("storage-idle-period").fill("11");
     await testPage.getByTestId("storage-save-settings").click();
     await expect(testPage.getByText("Storage policy saved")).toBeVisible();
@@ -93,8 +97,8 @@ test.describe("System storage maintenance", () => {
     await expect(scheduling).toHaveAttribute("data-state", "unchecked");
 
     await testPage.getByTestId("storage-analyze").click();
-    await expect(testPage.getByTestId("storage-analysis-job")).toHaveAttribute(
-      "data-state",
+    await expect(testPage.getByTestId("storage-analyze")).toHaveAttribute(
+      "data-job-state",
       "succeeded",
     );
     await testPage.getByTestId("storage-resource-workspaces-trigger").click();
@@ -108,8 +112,8 @@ test.describe("System storage maintenance", () => {
     await expect(testPage.getByTestId("storage-idle-period")).toHaveValue("11");
 
     await testPage.getByTestId("storage-run-now").click();
-    await expect(testPage.getByTestId("storage-cleanup-job")).toHaveAttribute(
-      "data-state",
+    await expect(testPage.getByTestId("storage-run-now")).toHaveAttribute(
+      "data-job-state",
       "succeeded",
     );
     const quarantineCard = testPage.getByTestId("storage-quarantine-card");
@@ -180,6 +184,6 @@ test.describe("System storage maintenance", () => {
       body: { busy_resources: expect.any(Array) },
     });
     await expect(testPage.getByTestId("storage-error")).toContainText(/busy|active/i);
-    await expect(testPage.getByTestId("storage-cleanup-job")).toHaveCount(0);
+    await expect(testPage.getByTestId("storage-run-now")).not.toHaveAttribute("data-job-state");
   });
 });

--- a/apps/web/e2e/tests/task/unarchive-storage-recovery.spec.ts
+++ b/apps/web/e2e/tests/task/unarchive-storage-recovery.spec.ts
@@ -32,8 +32,8 @@ test("unarchive restores a quarantined workspace before branch recovery", async 
 
   await testPage.goto("/settings/system/storage");
   await testPage.getByTestId("storage-run-now").click();
-  await expect(testPage.getByTestId("storage-cleanup-job")).toHaveAttribute(
-    "data-state",
+  await expect(testPage.getByTestId("storage-run-now")).toHaveAttribute(
+    "data-job-state",
     "succeeded",
   );
   expect(fs.existsSync(root)).toBe(false);

--- a/apps/web/e2e/tests/task/unarchive-storage-recovery.spec.ts
+++ b/apps/web/e2e/tests/task/unarchive-storage-recovery.spec.ts
@@ -1,0 +1,56 @@
+import fs from "node:fs";
+import path from "node:path";
+import { test, expect } from "../../fixtures/test-base";
+
+test("unarchive restores a quarantined workspace before branch recovery", async ({
+  testPage,
+  apiClient,
+  seedData,
+  backend,
+}) => {
+  const task = await apiClient.createTask(seedData.workspaceId, "Archived storage recovery", {
+    workflow_id: seedData.workflowId,
+    workflow_step_id: seedData.startStepId,
+  });
+  await apiClient.archiveTask(task.id);
+  const root = path.join(backend.tmpDir, ".kandev", "tasks", seedData.workspaceId, task.id);
+  const artifact = path.join(root, "node_modules", "fixture", "index.js");
+  fs.mkdirSync(path.dirname(artifact), { recursive: true });
+  fs.writeFileSync(artifact, "restore-before-branch-probe");
+  fs.writeFileSync(
+    path.join(root, ".kandev-workspace.json"),
+    JSON.stringify({
+      task_id: task.id,
+      workspace_id: seedData.workspaceId,
+      task_dir_name: task.id,
+      layout_version: 2,
+      created_at: "2026-06-01T00:00:00Z",
+    }),
+  );
+  const old = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000);
+  fs.utimesSync(root, old, old);
+
+  await testPage.goto("/settings/system/storage");
+  await testPage.getByTestId("storage-run-now").click();
+  await expect(testPage.getByTestId("storage-cleanup-job")).toHaveAttribute(
+    "data-state",
+    "succeeded",
+  );
+  expect(fs.existsSync(root)).toBe(false);
+
+  await testPage.goto(`/t/${task.id}`);
+  const responsePromise = testPage.waitForResponse((response) =>
+    response.url().endsWith(`/api/v1/tasks/${task.id}/unarchive`),
+  );
+  await testPage.getByTestId("task-unarchive-button").click();
+  const response = await responsePromise;
+  const body = (await response.json()) as {
+    unarchived_ids: string[];
+    workspace_recovery: Array<{ status: string }>;
+  };
+  expect(body.unarchived_ids).toEqual([task.id]);
+  expect(body.workspace_recovery).toEqual([expect.objectContaining({ status: "restored" })]);
+  expect(body).toHaveProperty("recovery");
+  await expect.poll(() => fs.existsSync(artifact)).toBe(true);
+  await expect(testPage.getByText("Task unarchived")).toBeVisible();
+});

--- a/apps/web/hooks/domains/system/use-storage-maintenance.test.tsx
+++ b/apps/web/hooks/domains/system/use-storage-maintenance.test.tsx
@@ -1,0 +1,183 @@
+import type { ReactNode } from "react";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { StateProvider } from "@/components/state-provider";
+import type { StorageMaintenanceSettings, StorageOverviewResponse } from "@/lib/types/system";
+
+const mocks = vi.hoisted(() => ({
+  adopt: vi.fn(),
+  analyze: vi.fn(),
+  deleteEntry: vi.fn(),
+  fetchJob: vi.fn(),
+  fetchOverview: vi.fn(),
+  fetchQuarantine: vi.fn(),
+  fetchRuns: vi.fn(),
+  restore: vi.fn(),
+  run: vi.fn(),
+  save: vi.fn(),
+  toast: vi.fn(),
+}));
+
+vi.mock("@/components/toast-provider", () => ({
+  useToast: () => ({ toast: mocks.toast }),
+}));
+
+vi.mock("@/lib/api/domains/system-api", () => ({
+  adoptStorageGoCache: mocks.adopt,
+  analyzeStorage: mocks.analyze,
+  deleteStorageQuarantine: mocks.deleteEntry,
+  fetchSystemJob: mocks.fetchJob,
+  fetchStorageOverview: mocks.fetchOverview,
+  fetchStorageQuarantine: mocks.fetchQuarantine,
+  fetchStorageRuns: mocks.fetchRuns,
+  restoreStorageQuarantine: mocks.restore,
+  runStorageMaintenance: mocks.run,
+  saveStorageSettings: mocks.save,
+}));
+
+import {
+  settingsWithDockerAcknowledgement,
+  useStorageMaintenance,
+} from "./use-storage-maintenance";
+
+const settings: StorageMaintenanceSettings = {
+  enabled: false,
+  check_interval_hours: 24,
+  idle_for_minutes: 10,
+  orphan_grace_hours: 168,
+  quarantine_retention_hours: 168,
+  workspaces: { enabled: true },
+  kandev_containers: { enabled: true },
+  go_cache: { enabled: false, max_bytes: 16106127360, adopted_path: "" },
+  docker: {
+    dedicated_daemon_acknowledged: true,
+    build_cache_enabled: true,
+    build_cache_keep_bytes: 10737418240,
+    build_cache_unused_hours: 168,
+    unused_images_enabled: true,
+    unused_images_hours: 168,
+  },
+};
+
+const overview: StorageOverviewResponse = {
+  settings,
+  capabilities: {
+    managed_go_cache_path: "/data/cache/go-build",
+    go_cache_adoption_available: true,
+    docker_available: true,
+    docker_host: "unix:///var/run/docker.sock",
+    host_global_docker_cleanup_allowed: true,
+  },
+  summary: {
+    workspaces: { active_bytes: 10, candidate_bytes: 20 },
+    go_cache: { path: "/data/cache/go-build", size_bytes: 30, owned: true, enabled: false },
+    quarantine: { count: 2, size_bytes: 35 },
+    docker: {
+      available: true,
+      build_cache_bytes: 40,
+      unused_image_bytes: 50,
+      managed_container_count: 3,
+      managed_container_bytes: 60,
+    },
+  },
+  last_run: null,
+};
+
+const cleanupJob = {
+  id: "cleanup-job",
+  kind: "storage-cleanup",
+  state: "running",
+  started_at: "2026-07-15T00:00:00Z",
+};
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <StateProvider>{children}</StateProvider>;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.fetchOverview.mockResolvedValue(overview);
+  mocks.fetchRuns.mockResolvedValue([]);
+  mocks.fetchQuarantine.mockResolvedValue([]);
+  mocks.fetchJob.mockResolvedValue(cleanupJob);
+  mocks.save.mockResolvedValue({ settings });
+  // Keep cleanup jobs deterministic for controller action tests.
+  mocks.run.mockResolvedValue({ job_id: "cleanup-job" });
+});
+
+describe("useStorageMaintenance", () => {
+  it("loads overview, run history, and quarantine through the domain controller", async () => {
+    const { result } = renderHook(() => useStorageMaintenance(), { wrapper });
+    await waitFor(() => expect(result.current.overview).toEqual(overview));
+    expect(mocks.fetchRuns).toHaveBeenCalledWith(20);
+    expect(mocks.fetchQuarantine).toHaveBeenCalledTimes(1);
+    expect(result.current.pendingAction).toBeNull();
+  });
+
+  it("owns confirmed settings persistence and success feedback", async () => {
+    const { result } = renderHook(() => useStorageMaintenance(), { wrapper });
+    await waitFor(() => expect(result.current.overview).toEqual(overview));
+    await act(async () => {
+      await result.current.save(settings, "DEDICATED");
+    });
+    expect(mocks.save).toHaveBeenCalledWith(settings, "DEDICATED");
+    expect(mocks.toast).toHaveBeenCalledWith({
+      title: "Storage policy saved",
+      variant: "success",
+    });
+  });
+
+  it("clearing Docker acknowledgement also disables global cleanup", () => {
+    const updated = settingsWithDockerAcknowledgement(settings, false);
+    expect(updated.docker).toMatchObject({
+      dedicated_daemon_acknowledged: false,
+      build_cache_enabled: false,
+      unused_images_enabled: false,
+    });
+  });
+
+  it("passes a named resource through for explicit cleanup", async () => {
+    const { result } = renderHook(() => useStorageMaintenance(), { wrapper });
+    await waitFor(() => expect(result.current.overview).toEqual(overview));
+    await act(async () => {
+      await result.current.runNow(["go_cache"]);
+    });
+    expect(mocks.run).toHaveBeenCalledWith(["go_cache"]);
+  });
+
+  it("does not retain the prior cleanup job when a second run is rejected", async () => {
+    const { result } = renderHook(() => useStorageMaintenance(), { wrapper });
+    await waitFor(() => expect(result.current.overview).toEqual(overview));
+    await act(async () => {
+      await result.current.runNow();
+    });
+    await waitFor(() => expect(result.current.cleanupJob?.id).toBe("cleanup-job"));
+
+    mocks.run.mockRejectedValueOnce(new Error("storage maintenance is busy"));
+    await act(async () => {
+      await result.current.runNow();
+    });
+
+    expect(result.current.cleanupJob).toBeUndefined();
+    expect(result.current.error).toBe("storage maintenance is busy");
+  });
+
+  it("surfaces and retries a failed refresh after a cleanup job finishes", async () => {
+    mocks.fetchJob.mockResolvedValue({
+      ...cleanupJob,
+      state: "succeeded",
+      ended_at: "2026-07-15T00:01:00Z",
+    });
+    const { result } = renderHook(() => useStorageMaintenance(), { wrapper });
+    await waitFor(() => expect(result.current.overview).toEqual(overview));
+    mocks.fetchOverview.mockRejectedValueOnce(new Error("refresh unavailable"));
+
+    await act(async () => {
+      await result.current.runNow();
+    });
+
+    await waitFor(() => expect(String(result.current.error)).toContain("refresh unavailable"));
+    await waitFor(() => expect(mocks.fetchOverview).toHaveBeenCalledTimes(3), { timeout: 2500 });
+    await waitFor(() => expect(result.current.error).toBeNull());
+  });
+});

--- a/apps/web/hooks/domains/system/use-storage-maintenance.test.tsx
+++ b/apps/web/hooks/domains/system/use-storage-maintenance.test.tsx
@@ -161,7 +161,9 @@ describe("useStorageMaintenance", () => {
     expect(result.current.cleanupJob).toBeUndefined();
     expect(result.current.error).toBe("storage maintenance is busy");
   });
+});
 
+describe("useStorageMaintenance terminal refresh", () => {
   it("surfaces and retries a failed refresh after a cleanup job finishes", async () => {
     mocks.fetchJob.mockResolvedValue({
       ...cleanupJob,
@@ -179,5 +181,109 @@ describe("useStorageMaintenance", () => {
     await waitFor(() => expect(String(result.current.error)).toContain("refresh unavailable"));
     await waitFor(() => expect(mocks.fetchOverview).toHaveBeenCalledTimes(3), { timeout: 2500 });
     await waitFor(() => expect(result.current.error).toBeNull());
+  });
+
+  it("backs off and stops after six terminal refresh attempts", async () => {
+    vi.useFakeTimers();
+    try {
+      mocks.fetchJob.mockResolvedValue({
+        ...cleanupJob,
+        state: "succeeded",
+        ended_at: "2026-07-15T00:01:00Z",
+      });
+      const { result } = renderHook(() => useStorageMaintenance(), { wrapper });
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(result.current.overview).toEqual(overview);
+
+      mocks.fetchOverview.mockRejectedValue(new Error("refresh unavailable"));
+      await act(async () => {
+        await result.current.runNow();
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(mocks.fetchOverview).toHaveBeenCalledTimes(2);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(999);
+      });
+      expect(mocks.fetchOverview).toHaveBeenCalledTimes(2);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1);
+      });
+      expect(mocks.fetchOverview).toHaveBeenCalledTimes(3);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1999);
+      });
+      expect(mocks.fetchOverview).toHaveBeenCalledTimes(3);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1);
+      });
+      expect(mocks.fetchOverview).toHaveBeenCalledTimes(4);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(3999);
+      });
+      expect(mocks.fetchOverview).toHaveBeenCalledTimes(4);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1);
+      });
+      expect(mocks.fetchOverview).toHaveBeenCalledTimes(5);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(7999);
+      });
+      expect(mocks.fetchOverview).toHaveBeenCalledTimes(5);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1);
+      });
+      expect(mocks.fetchOverview).toHaveBeenCalledTimes(6);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(7999);
+      });
+      expect(mocks.fetchOverview).toHaveBeenCalledTimes(6);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1);
+      });
+      expect(mocks.fetchOverview).toHaveBeenCalledTimes(7);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(60000);
+      });
+      expect(mocks.fetchOverview).toHaveBeenCalledTimes(7);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe("useStorageMaintenance reload ordering", () => {
+  it("does not let an older reload overwrite a newer result", async () => {
+    const { result } = renderHook(() => useStorageMaintenance(), { wrapper });
+    await waitFor(() => expect(result.current.overview).toEqual(overview));
+    let resolveOlder!: (value: StorageOverviewResponse) => void;
+    const olderResponse = new Promise<StorageOverviewResponse>((resolve) => {
+      resolveOlder = resolve;
+    });
+    const newerOverview = {
+      ...overview,
+      settings: { ...overview.settings, idle_for_minutes: 22 },
+    };
+    mocks.fetchOverview.mockReturnValueOnce(olderResponse).mockResolvedValueOnce(newerOverview);
+
+    let olderReload!: Promise<void>;
+    await act(async () => {
+      olderReload = result.current.reload();
+      await result.current.reload();
+    });
+    await waitFor(() => expect(result.current.overview).toEqual(newerOverview));
+    await act(async () => {
+      resolveOlder(overview);
+      await olderReload;
+    });
+
+    expect(result.current.overview).toEqual(newerOverview);
   });
 });

--- a/apps/web/hooks/domains/system/use-storage-maintenance.ts
+++ b/apps/web/hooks/domains/system/use-storage-maintenance.ts
@@ -1,0 +1,234 @@
+"use client";
+
+import { useCallback, useEffect, useState, type Dispatch, type SetStateAction } from "react";
+import { useAppStore } from "@/components/state-provider";
+import { useToast } from "@/components/toast-provider";
+import {
+  adoptStorageGoCache,
+  analyzeStorage,
+  deleteStorageQuarantine,
+  fetchStorageOverview,
+  fetchStorageQuarantine,
+  fetchStorageRuns,
+  restoreStorageQuarantine,
+  runStorageMaintenance,
+  saveStorageSettings,
+} from "@/lib/api/domains/system-api";
+import type { StorageMaintenanceSettings, SystemJob } from "@/lib/types/system";
+import { useSystemJob } from "./use-system-jobs";
+
+export type StoragePendingAction =
+  | "load"
+  | "save"
+  | "analyze"
+  | "run"
+  | "adopt"
+  | "restore"
+  | "delete"
+  | null;
+
+function messageFromError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isTerminal(state?: string): boolean {
+  return state === "succeeded" || state === "failed";
+}
+
+export function settingsWithDockerAcknowledgement(
+  settings: StorageMaintenanceSettings,
+  acknowledged: boolean,
+): StorageMaintenanceSettings {
+  return {
+    ...settings,
+    docker: {
+      ...settings.docker,
+      dedicated_daemon_acknowledged: acknowledged,
+      build_cache_enabled: acknowledged && settings.docker.build_cache_enabled,
+      unused_images_enabled: acknowledged && settings.docker.unused_images_enabled,
+    },
+  };
+}
+
+type Reload = () => Promise<void>;
+type SetStorageError = Dispatch<SetStateAction<string | null>>;
+const TERMINAL_REFRESH_RETRY_MS = 1000;
+
+function useStorageActions(reload: Reload) {
+  const { toast } = useToast();
+  const [pendingAction, setPendingAction] = useState<StoragePendingAction>("load");
+  const [error, setError] = useState<string | null>(null);
+  const [analysisJobId, setAnalysisJobId] = useState<string | null>(null);
+  const [cleanupJobId, setCleanupJobId] = useState<string | null>(null);
+  const [deleteJobId, setDeleteJobId] = useState<string | null>(null);
+  const finishLoading = useCallback(() => setPendingAction(null), []);
+  const analysisJob = useSystemJob(analysisJobId);
+  const cleanupJob = useSystemJob(cleanupJobId);
+  const deleteJob = useSystemJob(deleteJobId);
+  const perform = useCallback(
+    async (action: Exclude<StoragePendingAction, "load" | null>, work: () => Promise<void>) => {
+      setPendingAction(action);
+      setError(null);
+      try {
+        await work();
+      } catch (requestError) {
+        const message = messageFromError(requestError);
+        setError(message);
+        toast({ title: "Storage action failed", description: message, variant: "error" });
+      } finally {
+        setPendingAction(null);
+      }
+    },
+    [toast],
+  );
+
+  const save = useCallback(
+    async (settings: StorageMaintenanceSettings, confirmation?: "DEDICATED") =>
+      perform("save", async () => {
+        await saveStorageSettings(settings, confirmation);
+        await reload();
+        toast({ title: "Storage policy saved", variant: "success" });
+      }),
+    [perform, reload, toast],
+  );
+
+  const adopt = useCallback(
+    async (path: string) =>
+      perform("adopt", async () => {
+        await adoptStorageGoCache(path);
+        await reload();
+        toast({ title: "Go build cache adopted", variant: "success" });
+      }),
+    [perform, reload, toast],
+  );
+
+  const analyze = useCallback(
+    async () =>
+      perform("analyze", async () => {
+        const accepted = await analyzeStorage();
+        setAnalysisJobId(accepted.job_id);
+        toast({ title: "Storage analysis started", variant: "success" });
+      }),
+    [perform, toast],
+  );
+
+  const runNow = useCallback(
+    async (resources?: string[]) => {
+      setCleanupJobId(null);
+      return perform("run", async () => {
+        const accepted = await runStorageMaintenance(resources);
+        setCleanupJobId(accepted.job_id);
+        toast({ title: "Storage maintenance started", variant: "success" });
+      });
+    },
+    [perform, toast],
+  );
+
+  const restore = useCallback(
+    async (id: string) =>
+      perform("restore", async () => {
+        await restoreStorageQuarantine(id);
+        await reload();
+        toast({ title: "Quarantined resource restored", variant: "success" });
+      }),
+    [perform, reload, toast],
+  );
+
+  const permanentlyDelete = useCallback(
+    async (id: string) =>
+      perform("delete", async () => {
+        const accepted = await deleteStorageQuarantine(id);
+        setDeleteJobId(accepted.job_id);
+        toast({ title: "Permanent deletion started", variant: "success" });
+      }),
+    [perform, toast],
+  );
+
+  return {
+    pendingAction,
+    error,
+    finishLoading,
+    setError,
+    save,
+    analyze,
+    runNow,
+    adopt,
+    restore,
+    permanentlyDelete,
+    analysisJob,
+    cleanupJob,
+    deleteJob,
+  };
+}
+
+function useTerminalJobRefresh(reload: Reload, setError: SetStorageError, job?: SystemJob) {
+  const terminalKey = job && isTerminal(job.state) ? `${job.id}:${job.state}` : "";
+  useEffect(() => {
+    if (!terminalKey) return;
+    let cancelled = false;
+    let retryTimer: ReturnType<typeof setTimeout> | undefined;
+    let refreshError: string | null = null;
+    const refresh = async () => {
+      try {
+        await reload();
+        if (cancelled || !refreshError) return;
+        const resolvedError = refreshError;
+        setError((current) => (current === resolvedError ? null : current));
+      } catch (requestError) {
+        if (cancelled) return;
+        refreshError = `Refresh storage data: ${messageFromError(requestError)}`;
+        setError(refreshError);
+        retryTimer = setTimeout(() => void refresh(), TERMINAL_REFRESH_RETRY_MS);
+      }
+    };
+    void refresh();
+    return () => {
+      cancelled = true;
+      if (retryTimer) clearTimeout(retryTimer);
+    };
+  }, [reload, setError, terminalKey]);
+}
+
+function useReloadCompletedJobs(
+  reload: Reload,
+  setError: SetStorageError,
+  analysisJob?: SystemJob,
+  cleanupJob?: SystemJob,
+  deleteJob?: SystemJob,
+) {
+  useTerminalJobRefresh(reload, setError, analysisJob);
+  useTerminalJobRefresh(reload, setError, cleanupJob);
+  useTerminalJobRefresh(reload, setError, deleteJob);
+}
+
+export function useStorageMaintenance() {
+  const storage = useAppStore((state) => state.system.storage);
+  const setOverview = useAppStore((state) => state.setSystemStorageOverview);
+  const setRuns = useAppStore((state) => state.setSystemStorageRuns);
+  const setQuarantine = useAppStore((state) => state.setSystemStorageQuarantine);
+  const reload = useCallback(async () => {
+    const [overview, runs, quarantine] = await Promise.all([
+      fetchStorageOverview(),
+      fetchStorageRuns(20),
+      fetchStorageQuarantine(),
+    ]);
+    setOverview(overview);
+    setRuns(runs);
+    setQuarantine(quarantine);
+  }, [setOverview, setQuarantine, setRuns]);
+  const { finishLoading, setError, ...actions } = useStorageActions(reload);
+
+  useEffect(() => {
+    void reload()
+      .catch((requestError) => setError(messageFromError(requestError)))
+      .finally(finishLoading);
+  }, [finishLoading, reload, setError]);
+  useReloadCompletedJobs(
+    reload,
+    setError,
+    actions.analysisJob,
+    actions.cleanupJob,
+    actions.deleteJob,
+  );
+  return { ...storage, ...actions, reload };
+}

--- a/apps/web/hooks/domains/system/use-storage-maintenance.ts
+++ b/apps/web/hooks/domains/system/use-storage-maintenance.ts
@@ -1,6 +1,13 @@
 "use client";
 
-import { useCallback, useEffect, useState, type Dispatch, type SetStateAction } from "react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type Dispatch,
+  type SetStateAction,
+} from "react";
 import { useAppStore } from "@/components/state-provider";
 import { useToast } from "@/components/toast-provider";
 import {
@@ -53,6 +60,8 @@ export function settingsWithDockerAcknowledgement(
 type Reload = () => Promise<void>;
 type SetStorageError = Dispatch<SetStateAction<string | null>>;
 const TERMINAL_REFRESH_RETRY_MS = 1000;
+const TERMINAL_REFRESH_MAX_RETRY_MS = 8000;
+const MAX_TERMINAL_REFRESH_ATTEMPTS = 6;
 
 function useStorageActions(reload: Reload) {
   const { toast } = useToast();
@@ -168,6 +177,7 @@ function useTerminalJobRefresh(reload: Reload, setError: SetStorageError, job?: 
     let cancelled = false;
     let retryTimer: ReturnType<typeof setTimeout> | undefined;
     let refreshError: string | null = null;
+    let attempts = 0;
     const refresh = async () => {
       try {
         await reload();
@@ -178,7 +188,13 @@ function useTerminalJobRefresh(reload: Reload, setError: SetStorageError, job?: 
         if (cancelled) return;
         refreshError = `Refresh storage data: ${messageFromError(requestError)}`;
         setError(refreshError);
-        retryTimer = setTimeout(() => void refresh(), TERMINAL_REFRESH_RETRY_MS);
+        attempts += 1;
+        if (attempts >= MAX_TERMINAL_REFRESH_ATTEMPTS) return;
+        const retryDelay = Math.min(
+          TERMINAL_REFRESH_RETRY_MS * 2 ** (attempts - 1),
+          TERMINAL_REFRESH_MAX_RETRY_MS,
+        );
+        retryTimer = setTimeout(() => void refresh(), retryDelay);
       }
     };
     void refresh();
@@ -206,12 +222,15 @@ export function useStorageMaintenance() {
   const setOverview = useAppStore((state) => state.setSystemStorageOverview);
   const setRuns = useAppStore((state) => state.setSystemStorageRuns);
   const setQuarantine = useAppStore((state) => state.setSystemStorageQuarantine);
+  const reloadGeneration = useRef(0);
   const reload = useCallback(async () => {
+    const generation = ++reloadGeneration.current;
     const [overview, runs, quarantine] = await Promise.all([
       fetchStorageOverview(),
       fetchStorageRuns(20),
       fetchStorageQuarantine(),
     ]);
+    if (generation !== reloadGeneration.current) return;
     setOverview(overview);
     setRuns(runs);
     setQuarantine(quarantine);

--- a/apps/web/lib/api/domains/system-api.test.ts
+++ b/apps/web/lib/api/domains/system-api.test.ts
@@ -27,6 +27,15 @@ import {
   fetchSystemJob,
   fetchRestartCapability,
   requestRestart,
+  adoptStorageGoCache,
+  analyzeStorage,
+  deleteStorageQuarantine,
+  fetchStorageOverview,
+  fetchStorageQuarantine,
+  fetchStorageRuns,
+  restoreStorageQuarantine,
+  runStorageMaintenance,
+  saveStorageSettings,
 } from "./system-api";
 
 const BASE = "http://api.test/api/v1/system";
@@ -299,5 +308,80 @@ describe("restart", () => {
     expect(lastCall().url).toBe(`${BASE}/restart`);
     expect(method()).toBe("POST");
     expect(res.accepted).toBe(true);
+  });
+});
+
+describe("storage maintenance", () => {
+  const settings = {
+    enabled: false,
+    check_interval_hours: 24,
+    idle_for_minutes: 10,
+    orphan_grace_hours: 168,
+    quarantine_retention_hours: 168,
+    workspaces: { enabled: true },
+    kandev_containers: { enabled: true },
+    go_cache: { enabled: false, max_bytes: 16106127360, adopted_path: "" },
+    docker: {
+      dedicated_daemon_acknowledged: false,
+      build_cache_enabled: false,
+      build_cache_keep_bytes: 10737418240,
+      build_cache_unused_hours: 168,
+      unused_images_enabled: false,
+      unused_images_hours: 168,
+    },
+  };
+
+  it("loads overview and list resources without caching", async () => {
+    fetchSpy
+      .mockResolvedValueOnce(
+        jsonResponse({ settings, summary: {}, capabilities: {}, last_run: null }),
+      )
+      .mockResolvedValueOnce(jsonResponse({ runs: [{ id: "run-1" }] }))
+      .mockResolvedValueOnce(jsonResponse({ entries: [{ id: "entry-1" }] }));
+
+    await fetchStorageOverview();
+    expect(lastCall().url).toBe(`${BASE}/storage`);
+    expect(lastCall().init?.cache).toBe("no-store");
+    expect((await fetchStorageRuns())[0]?.id).toBe("run-1");
+    expect(lastCall().url).toBe(`${BASE}/storage/runs?limit=20`);
+    expect((await fetchStorageQuarantine())[0]?.id).toBe("entry-1");
+  });
+
+  it("saves dedicated Docker acknowledgement with its confirmation", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ settings }));
+    await saveStorageSettings(settings, "DEDICATED");
+    expect(lastCall().url).toBe(`${BASE}/storage/settings`);
+    expect(method()).toBe("PATCH");
+    expect(JSON.parse(String(lastCall().init?.body))).toEqual({
+      settings,
+      confirmations: { dedicated_docker: "DEDICATED" },
+    });
+  });
+
+  it("uses fixed confirmations for Go-cache adoption and permanent deletion", async () => {
+    fetchSpy
+      .mockResolvedValueOnce(jsonResponse({ settings, capabilities: {} }))
+      .mockResolvedValueOnce(jsonResponse({ job_id: "delete-job" }));
+    await adoptStorageGoCache("/root/.cache/go-build");
+    expect(JSON.parse(String(lastCall().init?.body))).toEqual({
+      path: "/root/.cache/go-build",
+      confirm: "ADOPT",
+    });
+    const response = await deleteStorageQuarantine("entry/1");
+    expect(lastCall().url).toBe(`${BASE}/storage/quarantine/entry%2F1`);
+    expect(method()).toBe("DELETE");
+    expect(JSON.parse(String(lastCall().init?.body))).toEqual({ confirm: "DELETE" });
+    expect(response.job_id).toBe("delete-job");
+  });
+
+  it("starts analysis, selected cleanup, and restore operations", async () => {
+    fetchSpy
+      .mockResolvedValueOnce(jsonResponse({ job_id: "analysis" }))
+      .mockResolvedValueOnce(jsonResponse({ job_id: "cleanup" }))
+      .mockResolvedValueOnce(jsonResponse({ entry: { id: "restored" } }));
+    expect((await analyzeStorage()).job_id).toBe("analysis");
+    expect((await runStorageMaintenance(["workspaces"])).job_id).toBe("cleanup");
+    expect(JSON.parse(String(lastCall().init?.body))).toEqual({ resources: ["workspaces"] });
+    expect((await restoreStorageQuarantine("entry-1")).id).toBe("restored");
   });
 });

--- a/apps/web/lib/api/domains/system-api.ts
+++ b/apps/web/lib/api/domains/system-api.ts
@@ -11,6 +11,12 @@ import type {
   JobAcceptResponse,
   RestartCapability,
   RestartResponse,
+  StorageAdoptionResponse,
+  StorageMaintenanceRun,
+  StorageMaintenanceSettings,
+  StorageOverviewResponse,
+  StorageQuarantineEntry,
+  StorageSettingsResponse,
 } from "@/lib/types/system";
 
 const SYSTEM_BASE = "/api/v1/system";
@@ -185,4 +191,119 @@ export function requestRestart(options?: ApiRequestOptions): Promise<RestartResp
     ...options,
     init: { ...(options?.init ?? {}), method: "POST" },
   });
+}
+
+// --- Storage maintenance ------------------------------------------------
+
+export function fetchStorageOverview(
+  options?: ApiRequestOptions,
+): Promise<StorageOverviewResponse> {
+  return fetchJson<StorageOverviewResponse>(`${SYSTEM_BASE}/storage`, {
+    ...options,
+    cache: "no-store",
+  });
+}
+
+export function saveStorageSettings(
+  settings: StorageMaintenanceSettings,
+  dedicatedDockerConfirmation?: "DEDICATED",
+  options?: ApiRequestOptions,
+): Promise<StorageSettingsResponse> {
+  return fetchJson<StorageSettingsResponse>(`${SYSTEM_BASE}/storage/settings`, {
+    ...options,
+    init: {
+      ...(options?.init ?? {}),
+      method: "PATCH",
+      body: JSON.stringify({
+        settings,
+        confirmations: dedicatedDockerConfirmation
+          ? { dedicated_docker: dedicatedDockerConfirmation }
+          : {},
+      }),
+    },
+  });
+}
+
+export function adoptStorageGoCache(
+  path: string,
+  options?: ApiRequestOptions,
+): Promise<StorageAdoptionResponse> {
+  return fetchJson<StorageAdoptionResponse>(`${SYSTEM_BASE}/storage/go-cache/adopt`, {
+    ...options,
+    init: {
+      ...(options?.init ?? {}),
+      method: "POST",
+      body: JSON.stringify({ path, confirm: "ADOPT" }),
+    },
+  });
+}
+
+export function analyzeStorage(options?: ApiRequestOptions): Promise<JobAcceptResponse> {
+  return fetchJson<JobAcceptResponse>(`${SYSTEM_BASE}/storage/analyze`, {
+    ...options,
+    init: { ...(options?.init ?? {}), method: "POST" },
+  });
+}
+
+export function runStorageMaintenance(
+  resources?: string[],
+  options?: ApiRequestOptions,
+): Promise<JobAcceptResponse> {
+  return fetchJson<JobAcceptResponse>(`${SYSTEM_BASE}/storage/run`, {
+    ...options,
+    init: {
+      ...(options?.init ?? {}),
+      method: "POST",
+      body: JSON.stringify(resources?.length ? { resources } : {}),
+    },
+  });
+}
+
+export async function fetchStorageRuns(
+  limit = 20,
+  options?: ApiRequestOptions,
+): Promise<StorageMaintenanceRun[]> {
+  const response = await fetchJson<{ runs: StorageMaintenanceRun[] }>(
+    `${SYSTEM_BASE}/storage/runs?limit=${encodeURIComponent(String(limit))}`,
+    { ...options, cache: "no-store" },
+  );
+  return response.runs ?? [];
+}
+
+export async function fetchStorageQuarantine(
+  options?: ApiRequestOptions,
+): Promise<StorageQuarantineEntry[]> {
+  const response = await fetchJson<{ entries: StorageQuarantineEntry[] }>(
+    `${SYSTEM_BASE}/storage/quarantine`,
+    { ...options, cache: "no-store" },
+  );
+  return response.entries ?? [];
+}
+
+export async function restoreStorageQuarantine(
+  id: string,
+  options?: ApiRequestOptions,
+): Promise<StorageQuarantineEntry> {
+  const response = await fetchJson<{ entry: StorageQuarantineEntry }>(
+    `${SYSTEM_BASE}/storage/quarantine/${encodeURIComponent(id)}/restore`,
+    { ...options, init: { ...(options?.init ?? {}), method: "POST" } },
+  );
+  return response.entry;
+}
+
+export function deleteStorageQuarantine(
+  id: string,
+  options?: ApiRequestOptions,
+): Promise<JobAcceptResponse> {
+  return fetchJson<JobAcceptResponse>(
+    `${SYSTEM_BASE}/storage/quarantine/${encodeURIComponent(id)}`,
+    {
+      ...options,
+      init: {
+        ...(options?.init ?? {}),
+        method: "DELETE",
+        body: JSON.stringify({ confirm: "DELETE" }),
+      },
+    },
+  );
 }

--- a/apps/web/lib/state/slices/system/system-slice.test.ts
+++ b/apps/web/lib/state/slices/system/system-slice.test.ts
@@ -11,6 +11,7 @@ import type {
   LogFileInfo,
   UpdatesResponse,
   SystemJob,
+  StorageOverviewResponse,
 } from "@/lib/types/system";
 
 const TS = "2026-05-18T00:00:00Z";
@@ -88,6 +89,56 @@ const JOB: SystemJob = {
   state: "running",
   started_at: TS,
 };
+
+describe("system storage slice", () => {
+  it("stores storage overview, runs, and quarantine state", () => {
+    const store = makeStore();
+    const overview = {
+      settings: {
+        enabled: false,
+        check_interval_hours: 24,
+        idle_for_minutes: 10,
+        orphan_grace_hours: 168,
+        quarantine_retention_hours: 168,
+        workspaces: { enabled: true },
+        kandev_containers: { enabled: true },
+        go_cache: { enabled: false, max_bytes: 16106127360, adopted_path: "" },
+        docker: {
+          dedicated_daemon_acknowledged: false,
+          build_cache_enabled: false,
+          build_cache_keep_bytes: 10737418240,
+          build_cache_unused_hours: 168,
+          unused_images_enabled: false,
+          unused_images_hours: 168,
+        },
+      },
+      capabilities: {
+        managed_go_cache_path: "/data/cache/go-build",
+        go_cache_adoption_available: true,
+        docker_available: false,
+        docker_host: "",
+        host_global_docker_cleanup_allowed: false,
+      },
+      summary: {
+        workspaces: { active_bytes: 1, candidate_bytes: 2 },
+        go_cache: { path: "/data/cache/go-build", size_bytes: 3, owned: true, enabled: false },
+        quarantine: { count: 0, size_bytes: 0 },
+        docker: {
+          available: false,
+          build_cache_bytes: 0,
+          unused_image_bytes: 0,
+          managed_container_count: 0,
+          managed_container_bytes: 0,
+        },
+      },
+      last_run: null,
+    } satisfies StorageOverviewResponse;
+    store.getState().setSystemStorageOverview(overview);
+    store.getState().setSystemStorageRuns([]);
+    store.getState().setSystemStorageQuarantine([]);
+    expect(store.getState().system.storage).toEqual({ overview, runs: [], quarantine: [] });
+  });
+});
 
 describe("system slice", () => {
   it("starts with empty defaults", () => {

--- a/apps/web/lib/state/slices/system/system-slice.ts
+++ b/apps/web/lib/state/slices/system/system-slice.ts
@@ -11,6 +11,7 @@ export const defaultSystemState: SystemSliceState = {
     updates: null,
     jobs: {},
     metrics: null,
+    storage: { overview: null, runs: [], quarantine: [] },
   },
 };
 
@@ -65,5 +66,17 @@ export const createSystemSlice: StateCreator<
   setSystemMetricsSnapshot: (snapshot) =>
     set((draft) => {
       draft.system.metrics = snapshot;
+    }),
+  setSystemStorageOverview: (overview) =>
+    set((draft) => {
+      draft.system.storage.overview = overview;
+    }),
+  setSystemStorageRuns: (runs) =>
+    set((draft) => {
+      draft.system.storage.runs = runs;
+    }),
+  setSystemStorageQuarantine: (entries) =>
+    set((draft) => {
+      draft.system.storage.quarantine = entries;
     }),
 });

--- a/apps/web/lib/state/slices/system/types.ts
+++ b/apps/web/lib/state/slices/system/types.ts
@@ -7,6 +7,9 @@ import type {
   UpdatesResponse,
   SystemJob,
   SystemMetricsSnapshot,
+  StorageMaintenanceRun,
+  StorageOverviewResponse,
+  StorageQuarantineEntry,
 } from "@/lib/types/system";
 
 export type SystemBackupsState = {
@@ -32,6 +35,11 @@ export type SystemSliceState = {
     updates: UpdatesResponse | null;
     jobs: SystemJobsMap;
     metrics: SystemMetricsSnapshot | null;
+    storage: {
+      overview: StorageOverviewResponse | null;
+      runs: StorageMaintenanceRun[];
+      quarantine: StorageQuarantineEntry[];
+    };
   };
 };
 
@@ -46,6 +54,9 @@ export type SystemSliceActions = {
   upsertSystemJob: (job: SystemJob) => void;
   clearSystemJob: (jobId: string) => void;
   setSystemMetricsSnapshot: (snapshot: SystemMetricsSnapshot) => void;
+  setSystemStorageOverview: (overview: StorageOverviewResponse) => void;
+  setSystemStorageRuns: (runs: StorageMaintenanceRun[]) => void;
+  setSystemStorageQuarantine: (entries: StorageQuarantineEntry[]) => void;
 };
 
 export type SystemSlice = SystemSliceState & SystemSliceActions;

--- a/apps/web/lib/types/system.ts
+++ b/apps/web/lib/types/system.ts
@@ -95,7 +95,10 @@ export type SystemJobKind =
   | "backup-create"
   | "restore"
   | "disk-walk"
-  | "self-update";
+  | "self-update"
+  | "storage-analysis"
+  | "storage-cleanup"
+  | "storage-quarantine-delete";
 
 export type SystemJobState = "queued" | "running" | "succeeded" | "failed";
 
@@ -156,6 +159,143 @@ export interface SystemMetricsSnapshot {
 
 export interface JobAcceptResponse {
   job_id: string;
+}
+
+export interface StorageResourceSettings {
+  enabled: boolean;
+}
+
+export interface StorageGoCacheSettings {
+  enabled: boolean;
+  max_bytes: number;
+  adopted_path: string;
+}
+
+export interface StorageDockerSettings {
+  dedicated_daemon_acknowledged: boolean;
+  build_cache_enabled: boolean;
+  build_cache_keep_bytes: number;
+  build_cache_unused_hours: number;
+  unused_images_enabled: boolean;
+  unused_images_hours: number;
+}
+
+export interface StorageMaintenanceSettings {
+  enabled: boolean;
+  check_interval_hours: number;
+  idle_for_minutes: number;
+  orphan_grace_hours: number;
+  quarantine_retention_hours: number;
+  workspaces: StorageResourceSettings;
+  kandev_containers: StorageResourceSettings;
+  go_cache: StorageGoCacheSettings;
+  docker: StorageDockerSettings;
+}
+
+export interface StorageCapabilities {
+  managed_go_cache_path: string;
+  go_cache_adoption_available: boolean;
+  docker_available: boolean;
+  docker_host: string;
+  host_global_docker_cleanup_allowed: boolean;
+}
+
+export interface StorageWorkspaceSummary {
+  active_bytes?: number;
+  candidate_bytes?: number;
+  warnings?: string[];
+  available?: boolean;
+  warning?: string;
+}
+
+export interface StorageGoCacheSummary {
+  path?: string;
+  size_bytes?: number;
+  owned?: boolean;
+  enabled?: boolean;
+  available?: boolean;
+  warning?: string;
+}
+
+export interface StorageDockerSummary {
+  available: boolean;
+  build_cache_bytes: number;
+  unused_image_bytes: number;
+  managed_container_count: number;
+  managed_container_bytes: number;
+  warnings?: string[];
+}
+
+export type StorageQuarantineSummary =
+  | {
+      available?: true;
+      count: number;
+      size_bytes: number;
+      warning?: never;
+    }
+  | {
+      available: false;
+      warning: string;
+      count?: never;
+      size_bytes?: never;
+    };
+
+export interface StorageSummary {
+  workspaces: StorageWorkspaceSummary;
+  go_cache: StorageGoCacheSummary;
+  quarantine: StorageQuarantineSummary;
+  docker: StorageDockerSummary;
+}
+
+export type StorageRunState =
+  | "queued"
+  | "running"
+  | "succeeded"
+  | "failed"
+  | "cancelled"
+  | "skipped_busy";
+
+export interface StorageMaintenanceRun {
+  id: string;
+  trigger: "scheduled" | "manual" | "analysis";
+  state: StorageRunState;
+  settings_snapshot: StorageMaintenanceSettings;
+  result: Record<string, unknown>;
+  message: string;
+  started_at: string;
+  completed_at?: string;
+}
+
+export interface StorageQuarantineEntry {
+  id: string;
+  resource_type: "task_workspace" | "go_cache";
+  task_id?: string;
+  workspace_id?: string;
+  original_path: string;
+  quarantine_path: string;
+  size_bytes: number;
+  state: "quarantined" | "restored" | "deleted" | "failed";
+  quarantined_at: string;
+  delete_after: string;
+  restored_at?: string;
+  deleted_at?: string;
+  last_error: string;
+  metadata: Record<string, unknown>;
+}
+
+export interface StorageOverviewResponse {
+  settings: StorageMaintenanceSettings;
+  capabilities: StorageCapabilities;
+  summary: StorageSummary;
+  last_run: StorageMaintenanceRun | null;
+}
+
+export interface StorageSettingsResponse {
+  settings: StorageMaintenanceSettings;
+}
+
+export interface StorageAdoptionResponse extends StorageSettingsResponse {
+  capabilities: StorageCapabilities;
 }
 
 export interface RestartCapability {

--- a/apps/web/src/settings-routes.tsx
+++ b/apps/web/src/settings-routes.tsx
@@ -20,6 +20,7 @@ import IntegrationsSentryPage from "@/app/settings/integrations/sentry/page";
 import IntegrationsSlackPage from "@/app/settings/integrations/slack/page";
 import PluginsSettingsPage from "@/app/settings/plugins/page";
 import PluginDetailPage from "@/app/settings/plugins/[pluginId]/page";
+import StoragePage from "@/app/settings/system/storage/page";
 import UtilityAgentsSettingsPage from "@/app/settings/utility-agents/page";
 import AutomationsPage from "@/app/settings/workspace/[id]/automations/page";
 import AutomationEditorPage from "@/app/settings/workspace/[id]/automations/[automationId]/page";
@@ -209,6 +210,7 @@ const SETTINGS_ROUTES: Record<string, RouteRenderer> = {
       <UIStateCard />
     </SystemPageShell>
   ),
+  "/settings/system/storage": () => <StoragePage />,
   "/settings/system/updates": renderUpdatesRoute,
   "/settings/changelog": () => <SettingsRedirect to="/settings/system/updates" />,
 };

--- a/docs/decisions/0045-install-wide-storage-maintenance.md
+++ b/docs/decisions/0045-install-wide-storage-maintenance.md
@@ -1,0 +1,75 @@
+# 0045: Install-wide storage maintenance uses typed ownership providers and quarantine
+
+**Status:** accepted
+**Date:** 2026-07-14
+**Area:** backend, frontend, infra
+
+## Context
+
+Kandev task churn can leave large task directories, Go build artifacts, and Docker resources on
+self-hosted machines. The existing `office/infra` garbage collector is an unconditional periodic
+loop focused on worktree directories, while task archive/delete cleanup runs in a detached,
+time-bounded goroutine. Neither gives operators an install-wide policy or durable retry surface,
+and broad host commands such as `docker system prune -a` can delete resources Kandev does not own.
+
+Task unarchive support added by PR #1687 also makes cleanup history significant: archived local
+worktrees are disposable, but historical worktree records and branch names are needed to recover a
+pushed branch later. Cleanup must distinguish filesystem payload from recovery metadata.
+
+## Decision
+
+Kandev will own one install-wide storage-maintenance service under `internal/system/storage`.
+It replaces the periodic `office/infra` GC loop and is available whether Office mode is enabled or
+not. Scheduled destructive maintenance is persisted in the install-wide `settings` store and is
+disabled by default; durable cleanup requested directly by task archive/delete remains active
+regardless of that preference.
+
+Maintenance is composed from typed providers for task workspaces, the Kandev-managed Go cache,
+Kandev-labeled containers, Docker build cache, and Docker images. It never executes an arbitrary
+configured command. Each provider declares whether its resources are Kandev-owned or host-global.
+Host-global Docker providers require a persisted dedicated-daemon acknowledgment.
+
+All destructive providers share an activity gate with execution launch and shell/build operations.
+The scheduler runs only after a quiet period, rechecks activity after acquiring the gate, and is
+cancelled when a new task launch needs the gate.
+
+Filesystem candidates are classified from a complete authoritative inventory and fail closed under
+ADR 0009. Task workspaces and owned Go caches are atomically quarantined beneath
+`<KANDEV_HOME_DIR>/trash` before permanent deletion. Quarantine and cleanup intent are durable, so a
+backend restart can reconcile an interrupted rename or retry failed task lifecycle cleanup.
+
+Archive/delete paths persist a cleanup job and resource snapshot before mutating the task row.
+Archive jobs re-check that the task remains archived before destructive steps. Unarchive cancels a
+pending archive job and restores a matching quarantined workspace when possible. Storage cleanup
+does not delete historical archived-task worktree rows or branch metadata used by PR #1687's branch
+recovery.
+
+## Consequences
+
+- Operators can configure and inspect cleanup from Kandev without host cron or systemd overrides.
+- A systemd-managed Kandev process does not gain implicit authority to delete host resources;
+  scheduling and host-global Docker actions remain explicit opt-ins.
+- Detached cleanup failures become durable and retryable rather than silent disk leaks.
+- Quarantine adds disk usage during the retention window, but turns filesystem classification
+  mistakes and unarchive races into recoverable events.
+- Execution launch and maintenance need a shared cancellation-aware activity gate.
+- Docker build-cache and image cleanup remain conservative on shared daemons, even if that leaves
+  reclaimable bytes for the operator.
+- The existing Office GC package and startup wiring are removed or reduced to adapters over the
+  System storage service to avoid two competing sweepers.
+
+## Alternatives Considered
+
+- **Run `go clean` and `docker system prune -a` from a generic scheduled-command feature.** Rejected
+  because it grants the daemon arbitrary command execution and cannot encode ownership or
+  fail-closed behavior.
+- **Keep the Office GC and add separate cache timers.** Rejected because independent sweepers would
+  race, expose inconsistent settings, and leave non-Office installations without the same controls.
+- **Delete orphan workspaces immediately after the grace period.** Rejected because uncommitted task
+  files and classification errors are more valuable than the temporary space saved by skipping
+  quarantine.
+- **Treat every historical worktree row as a live filesystem reference.** Rejected because archive
+  intentionally removes the local worktree; the row is recovery metadata and would otherwise keep
+  failed-cleanup directories forever.
+- **Make systemd installation enable cleanup automatically.** Rejected because process supervision
+  does not imply user consent for destructive host maintenance.

--- a/docs/decisions/INDEX.md
+++ b/docs/decisions/INDEX.md
@@ -45,9 +45,10 @@ Read individual ADRs for full context. Create new ones via `/record decision` or
 | 0037 | [Resource-aware frontend unit tests](0037-resource-aware-frontend-unit-tests.md)                                                     | accepted   | frontend, infra             | 2026-07-14 |
 | 0038 | [Quick Chat Repository Isolation](0038-quick-chat-repository-isolation.md)                                                           | accepted   | backend, frontend           | 2026-07-14 |
 | 0039 | [Native desktop integration boundary](0039-native-desktop-integration-boundary.md)                                                  | accepted   | desktop, frontend, backend, infra | 2026-07-15 |
-| 0040 | [Separate updater integrity from OS publisher identity](0040-separate-updater-integrity-from-os-publisher-identity.md)                  | accepted   | desktop, infra, workflow    | 2026-07-15 |
+| 0040 | [Separate updater integrity from OS publisher identity](0040-separate-updater-integrity-from-os-publisher-identity.md)              | accepted   | desktop, infra, workflow    | 2026-07-15 |
 | 0041 | [Backend-owned portable user settings](0041-backend-owned-portable-user-settings.md)                                               | accepted   | backend, frontend           | 2026-07-15 |
 | 0042 | [Project shell output and fetch it on demand](0042-project-shell-output-and-fetch-on-demand.md)                                    | accepted   | backend, frontend, protocol | 2026-07-16 |
 | 0043 | [Plugins read/write kandev data via capability-gated Host gRPC RPCs](0043-plugin-host-data-api.md)                                  | accepted   | backend, protocol           | 2026-07-17 |
 | 2026-07-15-office-agent-execution-profile-routing | [Separate Office identity from routed execution profiles](2026-07-15-office-agent-execution-profile-routing.md) | proposed | backend, frontend | 2026-07-15 |
 | 0044 | [ACP agent compatibility dialects](0044-acp-agent-compatibility-dialects.md)                                                        | accepted   | backend, protocol           | 2026-07-16 |
+| 0045 | [Install-wide storage maintenance uses typed ownership providers and quarantine](0045-install-wide-storage-maintenance.md)          | accepted   | backend, frontend, infra    | 2026-07-14 |

--- a/docs/plans/storage-maintenance/plan.md
+++ b/docs/plans/storage-maintenance/plan.md
@@ -1,0 +1,290 @@
+---
+spec: docs/specs/system-page/storage-maintenance.md
+created: 2026-07-14
+status: done
+---
+
+# Implementation Plan: Storage Maintenance
+
+## Overview
+
+Build one install-wide storage service under `internal/system/storage`, backed by durable settings,
+run history, quarantine records, and task cleanup intents. Land persistence and activity admission
+first, then implement ownership-specific providers, expose the System API, and finish with a
+responsive Storage settings page and desktop/mobile/container E2E coverage. The existing
+`office/infra` sweep is retired only after the replacement workspace reconciler is wired.
+
+The implementation preserves PR #1687's unarchive contract: archived filesystem payload may be
+reclaimed, historical worktree rows and branch metadata remain, and pending archive cleanup is
+cancelled when a task becomes active again.
+
+---
+
+## Backend
+
+### Durable task lifecycle cleanup
+
+- Add `task_resource_cleanup_jobs` creation and replay-safe indexes in
+  `apps/backend/internal/task/repository/sqlite/base_schema.go` and
+  `base_migrations.go`, plus repository operations in a new
+  `resource_cleanup.go`.
+- Define the serialized cleanup snapshot and job state in
+  `apps/backend/internal/task/models/resource_cleanup.go`.
+- Replace `Service.runAsyncTaskCleanup` in
+  `apps/backend/internal/task/service/service_tasks.go` with enqueue/claim/retry logic in new
+  `resource_cleanup_jobs.go` and `resource_cleanup_worker.go` files. Capture cleanup handles before
+  archive/delete/cascade mutations and keep the worker independent of the optional maintenance
+  scheduler.
+- Check archived state before each archive-job destructive step. Wire unarchive in
+  `handoff_cascade.go` to cancel non-terminal archive jobs before publishing the restored task.
+- Preserve `task_session_worktrees` history for archived tasks. Delete snapshots carry paths and
+  runtime handles that would otherwise disappear through foreign-key cascades.
+
+### Persistent storage contracts
+
+- Create `apps/backend/internal/system/storage/` with `types.go`, `settings.go`, `store.go`, and
+  `store_migrations.go`.
+- Store `StorageMaintenanceSettings` as JSON under the existing `settings` key
+  `storage_maintenance`, following `internal/system/metrics/store.go`.
+- Create `storage_maintenance_runs` and `storage_quarantine_entries` with replay-safe SQLite and
+  Postgres DDL. Normalize settings with the ranges and cross-field dedicated-Docker validation in
+  the spec.
+- Persist every analysis/cleanup run and retain the newest 20 terminal rows plus all non-terminal
+  rows.
+
+### Resource activity coordinator
+
+- Add a neutral package at `apps/backend/internal/agent/runtime/activity/` with a process-wide
+  `Coordinator`, cancellable maintenance lease, active-resource snapshot, and quiet-period clock.
+- Instrument lifecycle launch/prepare/stop and agent turn execution in
+  `internal/agent/runtime/lifecycle/`; instrument task shell/process requests in the agentctl client
+  or API boundary; instrument worktree setup/cleanup scripts and Docker image builds.
+- A task-resource lease cancels a maintenance lease and waits for provider cancellation before
+  admission. Maintenance acquisition rechecks active leases after locking to close the idle-check
+  race.
+- Scheduled acquisition enforces the configured quiet period. Manual Run now skips that elapsed-idle
+  check while retaining the same current-activity and mutual-exclusion checks.
+- Expose the same coordinator to the storage scheduler through backend composition.
+
+### Workspace inventory and quarantine
+
+- Implement `internal/system/storage/workspaces/` with an authoritative `Inventory` interface,
+  analyzer, candidate classifier, quarantine mover, restore operation, permanent deletion, and
+  startup reconciliation.
+- Extend task/worktree repository queries to return protected paths from active worktrees,
+  `TaskEnvironment.WorkspacePath`, active execution metadata, and repository-less task paths.
+  Normalize paths and protect every ancestor beneath `<KANDEV_HOME_DIR>/tasks`.
+- Update task-root creation in lifecycle/worktree preparation to write an atomic ownership marker.
+  Support both semantic multi-repo roots and `<workspace-id>/<task-id>` scratch roots.
+- Move candidates using same-filesystem rename into `<KANDEV_HOME_DIR>/trash/tasks`, persist the
+  quarantine record, and reconcile marker/DB disagreement after restart. Never follow symlinks or
+  operate outside the configured roots.
+- Add a `WorkspaceRecovery` hook to the merged PR #1687 unarchive path in
+  `task_http_handlers.go`: restore a task-matched quarantine entry before
+  `RecoverTaskBranches`, report `restored|not_found|failed`, and leave branch recovery unchanged.
+- Remove `internal/office/infra/gc.go` startup ownership after parity tests prove the System
+  provider protects all live layouts. Do not leave both periodic sweepers enabled.
+
+### Managed Go build cache
+
+- Implement `internal/system/storage/gocache/` analysis and cleanup for
+  `<KANDEV_HOME_DIR>/cache/go-build`, including ownership marker, containment validation,
+  quarantine rotation, recreation, and optional confirmed adoption of an external absolute path.
+- Inject the managed `GOCACHE` into host-local executor, setup/cleanup script, shell, and agent process
+  environments when `go_cache.enabled=true`. Centralize this in lifecycle environment construction
+  so profile values cannot create inconsistent paths within one execution.
+- Treat the configured byte maximum as an idle-time cleanup trigger, not a quota. Never discover
+  and delete `$HOME/.cache/go-build` implicitly.
+- Keep disabled-cache cleanup out of scheduled and global manual runs. Dispatch the provider's
+  explicit cleanup path only for a non-empty manual resource selection containing `go_cache`.
+
+### Docker storage provider
+
+- Extend `internal/agent/docker/client.go` with typed usage and prune methods backed by the Docker
+  SDK: Kandev-labeled container inventory/removal, build-cache usage/prune filters, and unused-image
+  usage/removal filters.
+- Implement `internal/system/storage/dockerstore/` as an optional provider. Kandev container cleanup
+  requires label and positive task/runtime inventory evidence; it never removes running containers.
+- Include exactly labeled managed-container count and writable-layer bytes in read-only analysis,
+  independently degrading Docker usage errors.
+- Revalidate `dedicated_daemon_acknowledged` immediately before build-cache or image deletion.
+  Do not expose daemon-wide volume/network prune operations.
+- Report unavailable Docker capability without failing other storage providers.
+
+### Scheduler, service, and API
+
+- Add `service.go`, `scheduler.go`, `runner.go`, and `handler.go` under
+  `internal/system/storage/`. The runner executes selected providers independently, aggregates
+  bytes/counts/warnings, and mirrors persistent run state into the existing System jobs tracker.
+- Start the scheduler from `internal/system/system.go:StartBackground` only when persisted settings
+  enable it. The first run waits a full interval; busy intervals create `skipped_busy` history.
+- Register the spec routes under `/api/v1/system/storage`, including confirmed Go-cache adoption,
+  settings, analyze, manual run, run history, quarantine restore, and confirmed permanent delete.
+- Wire settings store, task cleanup worker, lifecycle activity coordinator, worktree/task inventory,
+  Docker client, and unarchive recovery in `internal/backendapp` composition.
+- Add health issues for invalid persisted settings, retry-exhausted cleanup jobs, failed quarantine
+  entries, and unavailable explicitly-enabled providers.
+
+---
+
+## Frontend
+
+### Route and navigation
+
+- Add `apps/web/app/settings/system/storage/page.tsx` and a **Storage** leaf to
+  `components/app-sidebar/sections/settings/system-group.tsx`.
+- Reuse `SystemPageShell`; hydrate initial storage state through the existing Go-served SPA/API
+  conventions rather than fetching directly from components.
+
+### API, types, state, and hooks
+
+- Add storage contracts to `apps/web/lib/types/system.ts` and API calls to
+  `apps/web/lib/api/domains/system-api.ts`.
+- Extend the system Zustand slice and WS job handling for persisted storage runs, capabilities,
+  settings, summary, and quarantine entries.
+- Add `hooks/domains/system/use-storage-maintenance.ts` to own loading, save, analyze, run, restore,
+  delete, polling fallback, and feedback state.
+
+### Responsive Storage page
+
+- Add components beneath `apps/web/components/settings/system/storage/`:
+  `storage-summary-card.tsx`, `maintenance-settings-card.tsx`,
+  `storage-resource-card.tsx`, `maintenance-history-card.tsx`,
+  `quarantine-card.tsx`, and confirmation dialogs.
+- Desktop uses a two-column summary/settings grid followed by full-width resource, quarantine, and
+  history cards. Mobile stacks every card, wraps action bars, renders resource/history rows as
+  vertical key/value blocks, and keeps all primary actions at least 44 px high.
+- The dedicated-Docker acknowledgment and external Go-cache adoption use explicit warning dialogs.
+  Permanent quarantine deletion requires typing `DELETE`; restore remains a normal confirm action.
+- No required action is hover-only. Long paths wrap, byte counts remain aligned, and the page does
+  not introduce horizontal document scrolling at Pixel 5 width.
+- Show quarantine count/bytes and managed-container count/writable bytes in the analysis accordion,
+  and expose a responsive, threshold/ownership-gated **Clean Go cache** action on the Go-cache row.
+
+---
+
+## Tests
+
+- **What:** task archive/delete persists cleanup before mutation, retries across restart, captures
+  handles before FK cascades, and cancels on unarchive.
+  **File:** `apps/backend/internal/task/service/resource_cleanup_worker_test.go` and
+  `internal/task/repository/sqlite/resource_cleanup_test.go`.
+  **How:** table-driven service tests plus real SQLite replay tests; include a backend-restart worker
+  reconstruction test.
+- **What:** settings defaults, range validation, dedicated-Docker cross-field validation, run
+  persistence/retention, and quarantine state transitions.
+  **File:** `apps/backend/internal/system/storage/settings_test.go` and `store_test.go`.
+  **How:** table-driven normalization plus SQLite and env-gated Postgres replay tests.
+- **What:** activity admission closes the idle race, task work cancels maintenance, scheduled runs
+  enforce the quiet period, and manual runs gate only on current activity or another maintenance run.
+  **File:** `apps/backend/internal/agent/runtime/activity/coordinator_test.go`.
+  **How:** `testing/synctest` tests with explicit lease channels; no sleeps.
+- **What:** live semantic roots, live scratch roots, multi-repo ancestors, inventory errors,
+  symlinks, grace periods, quarantine reconciliation, restore conflicts, and permanent deletion.
+  **File:** `apps/backend/internal/system/storage/workspaces/provider_test.go`.
+  **How:** table-driven filesystem tests under `t.TempDir()` with fake complete/error inventories.
+- **What:** ownership-marker creation for every local task layout.
+  **File:** lifecycle and worktree preparation tests beside the existing layout tests.
+  **How:** real temporary worktree and repository-less launch fixtures.
+- **What:** unarchive cancels pending cleanup, restores task-matched quarantine first, preserves
+  historical worktree records, and reports restore failures without blocking unarchive.
+  **File:** `apps/backend/internal/task/service/handoff_unarchive_test.go`,
+  `task/handlers/task_http_handlers_test.go`, and storage workspace integration tests.
+  **How:** service integration tests aligned with PR #1687 branch-recovery cases.
+- **What:** managed Go path injection is consistent across processes; cleanup only rotates marked
+  owned paths above threshold; unadopted `/root/.cache/go-build` is untouched.
+  **File:** `apps/backend/internal/system/storage/gocache/provider_test.go` and lifecycle env tests.
+  **How:** temporary filesystem tests and environment-construction unit tests.
+- **What:** Docker provider scopes Kandev containers by label, keeps running/unrelated containers,
+  rejects global cleanup without acknowledgment, and applies age/storage filters.
+  **File:** `apps/backend/internal/system/storage/dockerstore/provider_test.go` and
+  `internal/agent/docker/client_test.go`.
+  **How:** mocked SDK unit tests plus an env-gated real-Docker integration test.
+- **What:** handler-to-service-to-store contracts for every Storage endpoint, including `409` busy,
+  `400` validation, async job IDs, and `DELETE` confirmation.
+  **File:** `apps/backend/internal/system/storage/handler_test.go`.
+  **How:** Gin integration tests using a real SQLite store and fake providers.
+- **What:** frontend API shapes, settings state, capability warnings, action feedback, responsive row
+  rendering, and typed confirmation state.
+  **File:** colocated `*.test.ts(x)` files under `lib/api/domains`, `lib/state/slices/system`, and
+  `components/settings/system/storage`.
+  **How:** Vitest API mocks and Testing Library interaction tests.
+
+Verification for backend tasks starts with focused package tests, then runs:
+
+```bash
+make -C apps/backend fmt
+make -C apps/backend test
+make -C apps/backend lint
+```
+
+Frontend verification runs:
+
+```bash
+cd apps/web && pnpm run typecheck
+cd apps && pnpm --filter @kandev/web lint
+cd apps && pnpm --filter @kandev/web test
+```
+
+---
+
+## E2E Tests
+
+- **Scenario:** scheduling defaults off; analyze reports an orphan task directory with
+  `node_modules`; manual run quarantines it; restore returns it to the original path.
+  **File:** `apps/web/e2e/tests/system/storage-maintenance.spec.ts`.
+  **What to verify:** settings persist after reload, job progress/result renders, quarantine row
+  appears, byte counts change, and restore succeeds through the UI.
+- **Scenario:** a busy task blocks manual maintenance and scheduled maintenance records
+  `skipped_busy` without moving its workspace.
+  **File:** `apps/web/e2e/tests/system/storage-maintenance.spec.ts`.
+  **What to verify:** visible busy feedback and unchanged task files.
+- **Scenario:** an archived task with a quarantined workspace is unarchived.
+  **File:** `apps/web/e2e/tests/task/unarchive-storage-recovery.spec.ts`.
+  **What to verify:** workspace recovery is reported before branch recovery and the task can launch
+  from the restored path.
+- **Scenario:** the complete Storage workflow works through the mobile settings sheet.
+  **File:** `apps/web/e2e/tests/system/mobile-storage-maintenance.spec.ts`.
+  **What to verify:** navigate from the mobile sheet, analyze, expand resource details, save safe
+  settings, and restore a quarantine entry without horizontal page scrolling.
+- **Scenario:** real Docker analysis and Kandev-labeled stopped-container cleanup do not remove an
+  unrelated container; build-cache cleanup remains gated by acknowledgment.
+  **File:** `apps/web/e2e/tests/docker/storage-maintenance.spec.ts` using `docker-test-base`.
+  **What to verify:** labeled orphan removed, unrelated/running containers retained, global action
+  disabled until acknowledgment.
+
+Run focused UI tests through the managed production-build runner:
+
+```bash
+cd apps/web && pnpm e2e:run tests/system/storage-maintenance.spec.ts
+cd apps/web && pnpm e2e:run tests/system/mobile-storage-maintenance.spec.ts -- --project=mobile-chrome
+cd apps/web && KANDEV_E2E_CONTAINERS=1 pnpm e2e --project=containers tests/docker/storage-maintenance.spec.ts
+```
+
+---
+
+## Implementation Waves
+
+Wave 1 (parallel foundations):
+
+- [x] [Task 01 — Durable task cleanup](task-01-durable-task-cleanup.md)
+- [x] [Task 02 — Storage persistence contracts](task-02-storage-persistence.md)
+
+Wave 2 (parallel providers after Task 02; activity also depends on Task 01):
+
+- [x] [Task 03 — Activity gate and scheduler core](task-03-activity-gate-scheduler.md)
+- [x] [Task 04 — Workspace quarantine and unarchive](task-04-workspace-quarantine.md)
+- [x] [Task 05 — Managed Go build cache](task-05-managed-go-cache.md)
+- [x] [Task 06 — Docker storage provider](task-06-docker-storage.md)
+
+Wave 3:
+
+- [x] [Task 07 — System storage API and composition](task-07-system-storage-api.md)
+
+Wave 4:
+
+- [x] [Task 08 — Responsive Storage settings UI](task-08-storage-settings-ui.md)
+
+Wave 5:
+
+- [x] [Task 09 — E2E, QA, and final verification](task-09-e2e-qa-verification.md)

--- a/docs/plans/storage-maintenance/task-01-durable-task-cleanup.md
+++ b/docs/plans/storage-maintenance/task-01-durable-task-cleanup.md
@@ -1,0 +1,56 @@
+---
+id: "01-durable-task-cleanup"
+title: "Durable task cleanup"
+status: done
+wave: 1
+depends_on: []
+plan: "plan.md"
+spec: "../../specs/system-page/storage-maintenance.md"
+---
+
+# Task 01: Durable task cleanup
+
+Replace detached task cleanup with a persisted, restart-safe job and captured resource inventory.
+
+## Acceptance
+
+- Every archive/delete/cascade/workspace-delete/expiration path persists cleanup intent before task
+  mutation; deletion cleanup survives task/session/worktree FK cascades.
+- Retryable failures resume after worker reconstruction, while archive jobs cancel when the task is
+  unarchived.
+- Archived-task historical worktree rows and branch metadata remain available after filesystem
+  cleanup.
+
+## Verification
+
+```bash
+cd apps/backend && go test ./internal/task/repository/sqlite ./internal/task/service
+```
+
+## Files likely touched
+
+- `apps/backend/internal/task/models/resource_cleanup.go`
+- `apps/backend/internal/task/repository/sqlite/base_schema.go`
+- `apps/backend/internal/task/repository/sqlite/base_migrations.go`
+- `apps/backend/internal/task/repository/sqlite/resource_cleanup.go`
+- `apps/backend/internal/task/service/service_tasks.go`
+- `apps/backend/internal/task/service/handoff_cascade.go`
+- `apps/backend/internal/task/service/resource_cleanup_jobs.go`
+- `apps/backend/internal/task/service/resource_cleanup_worker.go`
+- focused `*_test.go` files beside those sources
+
+## Dependencies
+
+None.
+
+## Inputs
+
+- Spec sections: Task cleanup and orphan workspaces; Unarchive compatibility; Persistence guarantees
+- `docs/specs/tasks/runtime-cleanup.md`
+- ADR 0025 runtime inventory rules
+- PR #1687 unarchive CAS and branch recovery behavior
+
+## Output contract
+
+Report schema/model changes, lifecycle paths migrated, retry/cancellation behavior, tests run,
+remaining blockers/risks, and update this task plus `plan.md` to done.

--- a/docs/plans/storage-maintenance/task-02-storage-persistence.md
+++ b/docs/plans/storage-maintenance/task-02-storage-persistence.md
@@ -1,0 +1,52 @@
+---
+id: "02-storage-persistence"
+title: "Storage persistence contracts"
+status: done
+wave: 1
+depends_on: []
+plan: "plan.md"
+spec: "../../specs/system-page/storage-maintenance.md"
+---
+
+# Task 02: Storage persistence contracts
+
+Create normalized install settings, persistent maintenance-run history, and quarantine storage.
+
+## Acceptance
+
+- Missing settings produce the exact disabled defaults; invalid ranges or unsafe Docker combinations
+  fail without overwriting saved values.
+- Maintenance runs and quarantine entries implement every spec state transition and survive store
+  recreation on SQLite and Postgres-supported paths.
+- Retention keeps the newest 20 terminal runs plus every non-terminal run.
+
+## Verification
+
+```bash
+cd apps/backend && go test ./internal/system/settings ./internal/system/storage
+```
+
+## Files likely touched
+
+- `apps/backend/internal/system/storage/types.go`
+- `apps/backend/internal/system/storage/settings.go`
+- `apps/backend/internal/system/storage/store.go`
+- `apps/backend/internal/system/storage/store_migrations.go`
+- `apps/backend/internal/system/storage/settings_test.go`
+- `apps/backend/internal/system/storage/store_test.go`
+
+## Dependencies
+
+None.
+
+## Inputs
+
+- Spec Data model and State machine sections
+- `apps/backend/internal/system/settings/store.go`
+- `apps/backend/internal/system/metrics/store.go`
+- ADR 0027 replayable schema migrations
+
+## Output contract
+
+Report persisted shapes, migration/replay coverage, validation behavior, tests run, blockers/risks,
+and update this task plus `plan.md` to done.

--- a/docs/plans/storage-maintenance/task-03-activity-gate-scheduler.md
+++ b/docs/plans/storage-maintenance/task-03-activity-gate-scheduler.md
@@ -1,0 +1,53 @@
+---
+id: "03-activity-gate-scheduler"
+title: "Activity gate and scheduler core"
+status: done
+wave: 2
+depends_on: ["01-durable-task-cleanup", "02-storage-persistence"]
+plan: "plan.md"
+spec: "../../specs/system-page/storage-maintenance.md"
+---
+
+# Task 03: Activity gate and scheduler core
+
+Coordinate destructive maintenance with task, shell, script, test, and Docker-build activity.
+
+## Acceptance
+
+- Resource leases cover every activity named by the spec and maintain a deterministic quiet-period
+  clock.
+- Maintenance acquisition rechecks under lock; new task work cancels and drains a maintenance lease
+  before admission.
+- Disabled scheduling starts no destructive loop, the first enabled run waits a full interval, and
+  busy intervals persist `skipped_busy`.
+
+## Verification
+
+```bash
+cd apps/backend && go test ./internal/agent/runtime/activity ./internal/agent/runtime/lifecycle ./internal/system/storage
+```
+
+## Files likely touched
+
+- `apps/backend/internal/agent/runtime/activity/coordinator.go`
+- `apps/backend/internal/agent/runtime/activity/coordinator_test.go`
+- lifecycle launch, prepare, stop, shell/process, script, and Docker-build call sites
+- `apps/backend/internal/system/storage/service.go`
+- `apps/backend/internal/system/storage/runner.go`
+- `apps/backend/internal/system/storage/scheduler.go`
+
+## Dependencies
+
+- Task 01 supplies durable lifecycle cleanup behavior.
+- Task 02 supplies settings and run persistence.
+
+## Inputs
+
+- Spec What and Scheduled maintenance state machine
+- Lifecycle `Start`/`Stop` ownership conventions in `apps/backend/AGENTS.md`
+- Existing System `jobs.Tracker` behavior
+
+## Output contract
+
+Report instrumented activity sources, race/cancellation tests, scheduler behavior, tests run,
+blockers/risks, and update this task plus `plan.md` to done.

--- a/docs/plans/storage-maintenance/task-04-workspace-quarantine.md
+++ b/docs/plans/storage-maintenance/task-04-workspace-quarantine.md
@@ -1,0 +1,56 @@
+---
+id: "04-workspace-quarantine"
+title: "Workspace quarantine and unarchive"
+status: done
+wave: 2
+depends_on: ["01-durable-task-cleanup", "02-storage-persistence"]
+plan: "plan.md"
+spec: "../../specs/system-page/storage-maintenance.md"
+---
+
+# Task 04: Workspace quarantine and unarchive
+
+Classify both task-directory layouts safely, quarantine confirmed orphans, and integrate restore
+with unarchive.
+
+## Acceptance
+
+- Complete inventory protects active worktrees, environments, executions, scratch task roots, and
+  ancestors; any inventory/path uncertainty performs no move.
+- New roots carry ownership markers; confirmed old candidates move atomically to tracked quarantine
+  and support restore, permanent deletion, and restart reconciliation.
+- Unarchive cancels pending archive cleanup, restores a task-matched quarantine entry before branch
+  probing, and never deletes historical recovery metadata or Git branches.
+
+## Verification
+
+```bash
+cd apps/backend && go test ./internal/system/storage/workspaces ./internal/worktree ./internal/task/service ./internal/task/handlers
+```
+
+## Files likely touched
+
+- `apps/backend/internal/system/storage/workspaces/` provider and tests
+- `apps/backend/internal/worktree/manager.go`
+- `apps/backend/internal/worktree/manager_cleanup.go`
+- `apps/backend/internal/agent/runtime/lifecycle/manager_launch.go`
+- `apps/backend/internal/task/service/handoff_cascade.go`
+- `apps/backend/internal/task/handlers/task_http_handlers.go`
+- PR #1687 branch-recovery tests and new quarantine integration tests
+
+## Dependencies
+
+- Task 01 for cleanup cancellation.
+- Task 02 for quarantine persistence.
+
+## Inputs
+
+- Spec Task cleanup, Unarchive compatibility, and workspace scenarios
+- ADR 0009 fail-closed GC semantics
+- Existing `office/infra/gc.go` and tests as migration inputs, not a parallel final service
+- PR #1687 merged behavior
+
+## Output contract
+
+Report inventory sources, path safety rules, legacy layout behavior, unarchive outcomes, tests run,
+blockers/risks, and update this task plus `plan.md` to done.

--- a/docs/plans/storage-maintenance/task-05-managed-go-cache.md
+++ b/docs/plans/storage-maintenance/task-05-managed-go-cache.md
@@ -1,0 +1,50 @@
+---
+id: "05-managed-go-cache"
+title: "Managed Go build cache"
+status: done
+wave: 2
+depends_on: ["02-storage-persistence"]
+plan: "plan.md"
+spec: "../../specs/system-page/storage-maintenance.md"
+---
+
+# Task 05: Managed Go build cache
+
+Own one explicit Go build cache for local Kandev executions and rotate it safely above threshold.
+
+## Acceptance
+
+- Enabling the provider injects one absolute managed `GOCACHE` into setup, cleanup, shell, agent,
+  test, and build processes for every new local execution.
+- Analysis and cleanup operate only on a marked Kandev path or explicitly confirmed adopted path;
+  default user caches remain untouched.
+- Above-threshold idle cleanup quarantines the cache, recreates an empty writable directory, and
+  reports byte deltas; disabling injection does not implicitly delete old data.
+
+## Verification
+
+```bash
+cd apps/backend && go test ./internal/system/storage/gocache ./internal/agent/runtime/lifecycle
+```
+
+## Files likely touched
+
+- `apps/backend/internal/system/storage/gocache/provider.go`
+- `apps/backend/internal/system/storage/gocache/provider_test.go`
+- lifecycle environment construction and script/shell propagation files
+- focused lifecycle environment tests
+
+## Dependencies
+
+- Task 02 for settings and quarantine records.
+
+## Inputs
+
+- Spec Go build cache section
+- Existing agent/executor profile environment merge order
+- Go's absolute `GOCACHE` contract
+
+## Output contract
+
+Report path ownership and adoption safeguards, propagation call sites, cleanup behavior, tests run,
+blockers/risks, and update this task plus `plan.md` to done.

--- a/docs/plans/storage-maintenance/task-06-docker-storage.md
+++ b/docs/plans/storage-maintenance/task-06-docker-storage.md
@@ -1,0 +1,49 @@
+---
+id: "06-docker-storage"
+title: "Docker storage provider"
+status: done
+wave: 2
+depends_on: ["02-storage-persistence"]
+plan: "plan.md"
+spec: "../../specs/system-page/storage-maintenance.md"
+---
+
+# Task 06: Docker storage provider
+
+Analyze Docker disk use, clean positively owned stopped containers, and gate daemon-global actions.
+
+## Acceptance
+
+- Container cleanup is label- and inventory-scoped, retains running/unrelated containers, and uses
+  the existing attached-volume removal behavior.
+- Build-cache and unused-image analysis is read-only; deletion is rejected unless the persisted
+  dedicated-daemon acknowledgment is still true immediately before the SDK call.
+- No code path exposes global volume/network prune or shells out to `docker system prune`.
+
+## Verification
+
+```bash
+cd apps/backend && go test ./internal/agent/docker ./internal/system/storage/dockerstore
+```
+
+## Files likely touched
+
+- `apps/backend/internal/agent/docker/client.go`
+- `apps/backend/internal/agent/docker/client_test.go`
+- `apps/backend/internal/system/storage/dockerstore/provider.go`
+- `apps/backend/internal/system/storage/dockerstore/provider_test.go`
+
+## Dependencies
+
+- Task 02 for settings validation and run result types.
+
+## Inputs
+
+- Spec Docker storage section
+- Existing `kandev.managed=true` labels and `RemoveContainer(...RemoveVolumes: true)` behavior
+- ADR 0009 container fail-closed rules
+
+## Output contract
+
+Report Docker SDK contracts/filters, capability degradation, scope guarantees, tests run,
+blockers/risks, and update this task plus `plan.md` to done.

--- a/docs/plans/storage-maintenance/task-07-system-storage-api.md
+++ b/docs/plans/storage-maintenance/task-07-system-storage-api.md
@@ -1,0 +1,59 @@
+---
+id: "07-system-storage-api"
+title: "System storage API and composition"
+status: done
+wave: 3
+depends_on:
+  [
+    "03-activity-gate-scheduler",
+    "04-workspace-quarantine",
+    "05-managed-go-cache",
+    "06-docker-storage",
+  ]
+plan: "plan.md"
+spec: "../../specs/system-page/storage-maintenance.md"
+---
+
+# Task 07: System storage API and composition
+
+Expose the complete Storage contract and replace the old Office GC wiring with the composed service.
+
+## Acceptance
+
+- Every spec endpoint returns the documented status/shape, validates Go-cache/Docker confirmation
+  and busy states, and publishes/persists matching System jobs.
+- Backend composition supplies all providers, activity coordinator, cleanup worker, health checks,
+  and startup reconciliation with correct start/stop ownership.
+- The unconditional `office/infra` sweep no longer runs; optional scheduling is available with
+  Office disabled and waits one interval before its first run.
+
+## Verification
+
+```bash
+cd apps/backend && go test ./internal/system/storage ./internal/system ./internal/backendapp ./internal/office/infra
+```
+
+## Files likely touched
+
+- `apps/backend/internal/system/storage/handler.go`
+- `apps/backend/internal/system/storage/handler_test.go`
+- `apps/backend/internal/system/system.go`
+- `apps/backend/internal/backendapp/main.go`
+- `apps/backend/internal/backendapp/services.go`
+- `apps/backend/internal/office/infra/gc.go` and tests (remove/migrate)
+- health provider wiring and tests
+
+## Dependencies
+
+Tasks 03–06.
+
+## Inputs
+
+- Spec API surface, permissions, failures, and persistence guarantees
+- Existing System route/service/job patterns
+- Existing backend provider cleanup ownership conventions
+
+## Output contract
+
+Report API matrix, composition lifecycle, old-GC migration, health behavior, tests run,
+blockers/risks, and update this task plus `plan.md` to done.

--- a/docs/plans/storage-maintenance/task-08-storage-settings-ui.md
+++ b/docs/plans/storage-maintenance/task-08-storage-settings-ui.md
@@ -1,0 +1,57 @@
+---
+id: "08-storage-settings-ui"
+title: "Responsive Storage settings UI"
+status: done
+wave: 4
+depends_on: ["07-system-storage-api"]
+plan: "plan.md"
+spec: "../../specs/system-page/storage-maintenance.md"
+---
+
+# Task 08: Responsive Storage settings UI
+
+Build the desktop and mobile System Storage surface with safe confirmations and persisted feedback.
+
+## Acceptance
+
+- The page supports analyze, settings persistence, manual run, resource results, run history,
+  quarantine restore, and confirmed permanent deletion without component-level direct fetching.
+- Dedicated-Docker and external-Go-cache warnings are explicit; disabled/unavailable actions explain
+  why, and async jobs recover through WS plus polling fallback.
+- At Pixel 5 width, every action is reachable through the settings sheet, cards stack without page
+  overflow, long paths wrap, and touch actions are at least 44 px high.
+
+## Verification
+
+```bash
+cd apps/web && pnpm run typecheck
+cd apps && pnpm --filter @kandev/web lint
+cd apps && pnpm --filter @kandev/web test
+```
+
+## Files likely touched
+
+- `apps/web/app/settings/system/storage/page.tsx`
+- `apps/web/components/app-sidebar/sections/settings/system-group.tsx`
+- `apps/web/components/settings/system/storage/*.tsx`
+- `apps/web/hooks/domains/system/use-storage-maintenance.ts`
+- `apps/web/lib/api/domains/system-api.ts`
+- `apps/web/lib/types/system.ts`
+- system Zustand slice/WS handler files
+- colocated frontend tests
+
+## Dependencies
+
+Task 07.
+
+## Inputs
+
+- Spec UI/API scenarios
+- `apps/web/AGENTS.md` data-flow and component rules
+- Existing System cards, job progress, dialogs, settings mobile sheet, and action feedback patterns
+- Mobile parity requirements
+
+## Output contract
+
+Report desktop/mobile layout, API/state wiring, confirmations, rendered verification, tests run,
+blockers/risks, and update this task plus `plan.md` to done.

--- a/docs/plans/storage-maintenance/task-08-storage-settings-ui.md
+++ b/docs/plans/storage-maintenance/task-08-storage-settings-ui.md
@@ -14,7 +14,7 @@ Build the desktop and mobile System Storage surface with safe confirmations and 
 
 ## Acceptance
 
-- The page supports analyze, settings persistence, manual run, resource results, run history,
+- The page supports analysis, settings persistence, manual run, resource results, run history,
   quarantine restore, and confirmed permanent deletion without component-level direct fetching.
 - Dedicated-Docker and external-Go-cache warnings are explicit; disabled/unavailable actions explain
   why, and async jobs recover through WS plus polling fallback.

--- a/docs/plans/storage-maintenance/task-09-e2e-qa-verification.md
+++ b/docs/plans/storage-maintenance/task-09-e2e-qa-verification.md
@@ -1,0 +1,83 @@
+---
+id: "09-e2e-qa-verification"
+title: "E2E, QA, and final verification"
+status: done
+wave: 5
+depends_on: ["08-storage-settings-ui"]
+plan: "plan.md"
+spec: "../../specs/system-page/storage-maintenance.md"
+---
+
+# Task 09: E2E, QA, and final verification
+
+Prove the feature through real backend/UI flows, mobile parity, Docker isolation, and final checks.
+
+## Acceptance
+
+- Desktop E2E covers defaults, analyze, idle/busy behavior, quarantine, restore, persisted settings,
+  and unarchive recovery; mobile E2E completes the same primary user value from the settings sheet.
+- Container-project E2E proves Kandev-label scoping and dedicated-daemon gating without deleting an
+  unrelated container.
+- Formatting precedes typecheck/test/lint; all focused and final verification is recorded, and
+  docs/spec/ADR/AGENTS references remain accurate.
+
+## Verification
+
+```bash
+cd apps/web && pnpm e2e:run tests/system/storage-maintenance.spec.ts
+cd apps/web && pnpm e2e:run tests/system/mobile-storage-maintenance.spec.ts -- --project=mobile-chrome
+cd apps/web && KANDEV_E2E_CONTAINERS=1 pnpm e2e --project=containers tests/docker/storage-maintenance.spec.ts
+make fmt
+make typecheck test lint
+```
+
+## Files likely touched
+
+- `apps/web/e2e/tests/system/storage-maintenance.spec.ts`
+- `apps/web/e2e/tests/system/mobile-storage-maintenance.spec.ts`
+- `apps/web/e2e/tests/task/unarchive-storage-recovery.spec.ts`
+- `apps/web/e2e/tests/docker/storage-maintenance.spec.ts`
+- E2E fixture/API/page helpers needed to seed owned orphan resources safely
+- relevant `AGENTS.md`, spec, ADR, and plan status files if implementation changes their facts
+
+## Dependencies
+
+Task 08 and transitively all backend/provider tasks.
+
+## Inputs
+
+- Every spec scenario
+- `/e2e`, `/mobile-parity`, `/qa`, and `/verify` workflows
+- `apps/web/e2e/README.md`
+
+## Output contract
+
+Report exact E2E/final commands and results, artifacts or blockers, conformance gaps, residual risk,
+and update this task plus `plan.md` to done only when the full feature is verified.
+
+## Verification results
+
+- `cd apps/web && pnpm e2e --project=chromium tests/system/storage-maintenance.spec.ts` — 3 passed,
+  including the disabled-cache global-run no-op and explicit `go_cache` cleanup flow.
+- `cd apps/web && pnpm e2e:run tests/task/unarchive-storage-recovery.spec.ts` — production build
+  succeeded and 1 passed.
+- `cd apps/web && pnpm e2e --project=mobile-chrome tests/system/mobile-storage-maintenance.spec.ts`
+  — 1 passed at the Pixel 5 viewport, including explicit Go-cache cleanup and the
+  horizontal-overflow assertion.
+- `cd apps/web && pnpm e2e --project=containers tests/docker/storage-maintenance.spec.ts`
+  — 1 skipped because no Docker daemon was reachable in the verification environment. The test is
+  discovered and retains its managed writable-byte/count, Kandev-label isolation, and
+  dedicated-daemon assertions.
+- `cd apps/backend && go test ./internal/agent/docker ./internal/system/storage/... ./internal/backendapp`
+  and the same package set with `-race` — 190 passed in 6 packages for each run.
+- Focused storage web Vitest — 43 passed across the controller, API, and system-slice suites;
+  focused Prettier and ESLint passed, and `pnpm run typecheck` passed.
+- Final repository verification passed formatting, generated release-note/changelog checks,
+  typecheck, lint, and `git diff --check`. Feature backend packages and focused race suites passed.
+  The full test target also passed after resolving macOS `TMPDIR` to its physical `/private/var`
+  path, avoiding the host's `/var` symlink alias in path-equality assertions.
+
+E2E QA found and drove fixes for the manual quiet-period gate, initial-turn activity lease, cascade
+archive projection, production quarantine-restorer wiring, and Go-cache analysis JSON shape. The
+final host and mobile runs are green; real Docker execution remains the only environment-limited
+verification.

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -120,6 +120,7 @@ System pages (Radarr/Sonarr-style) for status, disk usage, database maintenance,
 |---|---|
 | [system-page](system-page/spec.md) | draft |
 | [feature-toggles](feature-toggles/spec.md) | draft |
+| [storage-maintenance](system-page/storage-maintenance.md) | building |
 
 ---
 

--- a/docs/specs/system-page/spec.md
+++ b/docs/specs/system-page/spec.md
@@ -14,7 +14,7 @@ Radarr and Sonarr solve this with a dedicated **System** area: a group of read-o
 
 ## What (v1)
 
-A new **System** group is added to the existing settings sidebar (`apps/web/components/settings/settings-app-sidebar.tsx`), alongside General/Workspaces/Agents/Executors/Integrations/etc. The group contains seven child pages, each on its own route under `/settings/system/*`. The existing `/settings/changelog` route is removed and its UI is absorbed into the new **Updates** page.
+A new **System** group is added to the existing settings sidebar (`apps/web/components/settings/settings-app-sidebar.tsx`), alongside General/Workspaces/Agents/Executors/Integrations/etc. The group contains nine child pages, each on its own route under `/settings/system/*`. The existing `/settings/changelog` route is removed and its UI is absorbed into the new **Updates** page.
 
 ### Pages
 
@@ -22,27 +22,36 @@ A new **System** group is added to the existing settings sidebar (`apps/web/comp
    - **Health issues** card: renders the existing `GET /api/v1/system/health` payload (warning/error/info issues with messages and links).
    - **Disk usage** card: shows total kandev data footprint with a per-subdirectory breakdown (`data dir / worktrees / repos / sessions / tasks / quick-chat / backups`), an "as of HH:MM" timestamp, and a **Refresh** button. The disk walk is lazy and asynchronous: the first visit after a cold start (or after the 2h cache expires) returns `null` immediately and the page shows a loading spinner while the walk runs in the background; subsequent visits within 2h return the cached value instantly.
    - **Version + update** card: short summary of current version and "update available" badge, with a CTA to the Updates page.
-2. **Database** — `/settings/system/database`
+2. **Feature Toggles** — `/settings/system/feature-toggles`
+   - Install-wide runtime flags, risk metadata, environment locks, and restart handling.
+   - The full contract lives in [Feature Toggles](../feature-toggles/spec.md).
+3. **Database** — `/settings/system/database`
    - Read-only: database driver, database size, and schema version. SQLite additionally shows file path, WAL size, and last-backup timestamp (from `<data-dir>/backups/`). Postgres shows database-level size and does not render SQLite file/WAL/backup rows.
    - SQLite-only **VACUUM** button — safe, reclaims space; shows progress and final size delta.
    - SQLite-only **Optimize** button — runs `PRAGMA optimize`; shows progress.
    - SQLite-only **Factory Reset** button — destructive. Wipes the full kandev install (database + worktrees + repo clones + session dirs + tasks dir + quick-chat dir), equivalent to deleting `~/.kandev/` and starting over. Opens a modal that requires (a) typing the literal string `RESET` to enable the confirm button, (b) acknowledging that the backend will create a pre-reset snapshot first and then restart. Server-side: stop orchestrator and running executions → snapshot DB to `<data-dir>/backups/pre-reset-<ts>.db` → drop DB tables and re-run migrations → `rm -rf` the worktrees/repos/sessions/tasks/quick-chat subdirs → restart backend process. The frontend disables the UI and waits for the backend to come back, then routes to the empty onboarding state.
-3. **Backups** — `/settings/system/backups`
+4. **Backups** — `/settings/system/backups`
    - Lists existing snapshots in `<data-dir>/backups/` with name, size, and mtime.
    - Per-row actions: **Download**, **Restore** (gated like Factory Reset), **Delete** (confirm-only).
    - **Create snapshot** button at the top of the list; uses the existing `VACUUM INTO` path.
-4. **Logs** — `/settings/system/logs`
+5. **Logs** — `/settings/system/logs`
    - Static log viewer: last 1000 lines of the current lumberjack log file, with a **Refresh** button. No live tail in v1.
    - List of rotated log files with name/size/mtime and a per-row **Download** button.
    - **Download current** button at the top.
-5. **Updates** — `/settings/system/updates`
+6. **Updates** — `/settings/system/updates`
    - Shows running version, latest available version, and a "new version available" badge if newer.
    - **Check now** button — forces a re-poll (rate-limited 30s per process).
    - Below: the embedded changelog list (the content currently rendered at `/settings/changelog` via `@/generated/changelog.json`).
-6. **Licenses** — `/settings/system/licenses`
+7. **Licenses** — `/settings/system/licenses`
    - Renders a JSON manifest of all third-party OSS dependencies (npm + Go), each with its license name, version, repository URL, and license text. The manifest is generated at build time and committed to the repo.
    - Searchable list (filter by package name or license type), one-line per row, expand to see full license text.
-7. **About** — `/settings/system/about`
+8. **Storage** — `/settings/system/storage`
+   - Analyzes Kandev task workspaces, quarantine, managed Go cache, and Docker storage.
+   - Configures opt-in idle-time maintenance and exposes manual analyze/run actions.
+   - Lists cleanup history and restorable quarantined task workspaces.
+   - The full ownership, API, persistence, and safety contract lives in
+     [Storage Maintenance](storage-maintenance.md).
+9. **About** — `/settings/system/about`
    - Version, build commit, build timestamp, Go runtime version, Node runtime version, OS/arch.
    - Links: GitHub repo, documentation, license, "Report an issue".
 
@@ -75,6 +84,8 @@ GET    /api/v1/system/updates                     - { current, latest, latestChe
 POST   /api/v1/system/updates/check               - force GitHub re-poll; rate-limited 30s
 POST   /api/v1/system/updates/apply               - queue service-only self-update; body { confirm: "UPDATE" }
 ```
+
+Storage endpoints are defined separately in [Storage Maintenance](storage-maintenance.md).
 
 Long-running operations (vacuum, optimize, reset, restore, snapshot create, disk walk) return `202 Accepted` with a `jobId` and publish progress on the existing event bus. The frontend subscribes via WS (`system.job.update` event) to render progress and final result. On success/failure the operation flips a corresponding entry in the existing health surface (e.g., a "VACUUM completed: reclaimed X MB" info issue that auto-expires).
 

--- a/docs/specs/system-page/storage-maintenance.md
+++ b/docs/specs/system-page/storage-maintenance.md
@@ -19,6 +19,14 @@ reclaim that space without maintaining cron or systemd configuration outside Kan
 
 - Settings includes a **System → Storage** page at `/settings/system/storage` for disk
   analysis, maintenance policy, manual cleanup, run history, and quarantined workspaces.
+- The page presents storage analysis and maintenance policy as separate full-width sections.
+  Analysis and cleanup progress stays beside the action that started it instead of appearing as
+  detached page status.
+- User-facing storage totals and editable size limits are shown in GB. The frontend converts those
+  values to and from the byte-based API without changing the persisted data model.
+- Maintenance settings are grouped by scope: schedule, workspaces and containers, Go build cache,
+  Docker cleanup, and quarantine safety. Every option includes focusable, pointer-accessible help
+  that explains what it can change, when it runs, and which safety checks apply.
 - Read-only analysis is available even when scheduled maintenance is disabled. It reports
   active task workspace bytes, orphan-candidate bytes, active quarantined count and bytes, the
   managed Go cache, Kandev-managed container count and writable-layer bytes, Docker build cache,
@@ -77,6 +85,8 @@ reclaim that space without maintaining cron or systemd configuration outside Kan
 - Candidate task directories are atomically moved, on the same filesystem, to
   `~/.kandev/trash/tasks/`; they are not immediately deleted. Quarantine entries record their
   original path, size, task/workspace identity when known, and permanent-deletion deadline.
+- The Storage page describes quarantine as a recoverable holding area, explains when Kandev uses
+  it, and distinguishes restore from immediate permanent deletion.
 - The default orphan grace period is seven days and the default quarantine retention is seven
   additional days. Both are configurable in whole hours and apply to scheduled and manual runs.
 - Quarantine never deletes a Git branch. Permanent deletion removes the quarantined files and

--- a/docs/specs/system-page/storage-maintenance.md
+++ b/docs/specs/system-page/storage-maintenance.md
@@ -1,0 +1,432 @@
+---
+status: shipped
+created: 2026-07-14
+owner: cfl
+---
+
+# Storage Maintenance
+
+## Why
+
+Self-hosted Kandev installations execute many short-lived tasks that create worktrees,
+dependency directories, Go build artifacts, and Docker resources. Archive and delete
+normally release task resources, but interrupted cleanup and shared tool caches can still
+consume the disk until an operator edits the host or runs broad commands such as
+`docker system prune -a`. Operators need an in-app, ownership-aware way to understand and
+reclaim that space without maintaining cron or systemd configuration outside Kandev.
+
+## What
+
+- Settings includes a **System → Storage** page at `/settings/system/storage` for disk
+  analysis, maintenance policy, manual cleanup, run history, and quarantined workspaces.
+- Read-only analysis is available even when scheduled maintenance is disabled. It reports
+  active task workspace bytes, orphan-candidate bytes, active quarantined count and bytes, the
+  managed Go cache, Kandev-managed container count and writable-layer bytes, Docker build cache,
+  and unused Docker images.
+- Scheduled maintenance is install-wide, persists in Kandev's database, and is disabled by
+  default. Enabling it does not require editing the VM, a systemd unit, or environment
+  variables.
+- Scheduled destructive work runs only after Kandev has been resource-idle for the configured
+  quiet period. Resource-idle means there is no task execution starting, preparing, running,
+  stopping, or executing a shell command, test, setup script, cleanup script, or Docker image
+  build.
+- A task launch that arrives after maintenance acquired the idle gate cancels the maintenance
+  context, waits for the active provider operation to stop, and then proceeds. Maintenance
+  never races a newly admitted task.
+- Manual **Run now** uses the same mutual-exclusion/current-activity gate, but does not wait out
+  the configured quiet period. It returns a visible busy result when task activity is current or
+  another maintenance run holds the gate, and has no force-while-busy mode.
+- The Go-cache analysis row exposes a resource-specific **Clean Go cache** action only when the
+  cache is Kandev-owned and above its configured maximum. That action submits an explicit
+  `go_cache` selection through the same manual-run gate.
+- Manual **Analyze** is read-only, does not require the idle gate, and never changes files,
+  containers, images, caches, or database rows.
+- Each cleanup resource has its own enablement and threshold. The initial defaults are:
+  - orphan task workspaces: enabled after scheduled maintenance is enabled;
+  - stopped/orphaned Kandev-managed containers: enabled after scheduled maintenance is enabled;
+  - Kandev-managed Go build cache: disabled, 15 GiB maximum when enabled;
+  - Docker build cache: disabled;
+  - unused Docker images: disabled;
+  - Docker volumes: never globally pruned.
+- Host-global Docker cleanup requires a persisted **This is a dedicated Docker daemon**
+  acknowledgment. Clearing the acknowledgment disables Docker build-cache and unused-image
+  cleanup immediately.
+- Kandev invokes typed, built-in maintenance providers. Users cannot configure arbitrary shell
+  commands to run as the Kandev service account.
+
+### Task cleanup and orphan workspaces
+
+- Archive, delete, cascade, workspace-delete, and quick-chat expiration persist a task resource
+  cleanup intent before mutating or removing the task row. Cleanup inventory needed after a
+  task deletion is captured in that intent and is not dependent on foreign-keyed rows surviving.
+- A durable worker replaces detached fire-and-forget task cleanup. Failed and interrupted jobs
+  remain retryable across backend restarts with their last error and next attempt time.
+- Archive-triggered cleanup re-checks that the task is still archived before every destructive
+  step. If it has been unarchived, remaining cleanup is cancelled without deleting the newly
+  active task's resources.
+- The storage reconciler treats `~/.kandev/tasks/` as Kandev-owned but follows the fail-closed
+  inventory rules in [ADR 0009](../../decisions/0009-fail-closed-gc-semantics.md). A directory is
+  only a candidate when an authoritative inventory query succeeds, no active task environment,
+  execution, session worktree, or protected ancestor references it, and it is older than the
+  configured orphan grace period.
+- The authoritative inventory covers both task layouts:
+  `tasks/<semantic-task-dir>/<repo>` and `tasks/<workspace-id>/<task-id>`.
+- New task roots contain a Kandev ownership marker with the task ID, workspace ID, task directory
+  name, layout version, and creation time. Legacy unmarked directories remain eligible only when
+  the authoritative inventory and grace-period checks positively classify them as unreferenced.
+- Candidate task directories are atomically moved, on the same filesystem, to
+  `~/.kandev/trash/tasks/`; they are not immediately deleted. Quarantine entries record their
+  original path, size, task/workspace identity when known, and permanent-deletion deadline.
+- The default orphan grace period is seven days and the default quarantine retention is seven
+  additional days. Both are configurable in whole hours and apply to scheduled and manual runs.
+- Quarantine never deletes a Git branch. Permanent deletion removes the quarantined files and
+  prunes stale Git worktree registration only after the retention deadline.
+- Users can restore a quarantined task workspace to its original path while that path is free.
+  A path conflict fails closed and leaves the quarantine entry intact.
+
+### Unarchive compatibility
+
+- Storage cleanup preserves historical `task_session_worktrees` rows and branch metadata for
+  archived tasks. A historical row is recovery metadata, not proof that its old on-disk path is
+  active.
+- When an archived task is unarchived while its workspace is quarantined and the quarantine entry
+  carries that task ID, Kandev restores the directory to its original path before probing branch
+  recovery. If restoration fails, unarchive still succeeds and reports the quarantine failure
+  alongside the existing branch-recovery status.
+- When no quarantine entry exists, unarchive behavior remains the contract introduced by
+  [PR #1687](https://github.com/kdlbs/kandev/pull/1687): the next task execution reuses a local or
+  remote branch when recoverable and warns when the branch is missing.
+- Permanently deleting an archived workspace does not delete historical recovery rows. A later
+  unarchive can still recover a pushed branch from its remote.
+
+### Go build cache
+
+- Enabling managed Go cache changes new host-local task executions to use
+  `<KANDEV_HOME_DIR>/cache/go-build` through an injected absolute `GOCACHE` value. Kandev setup,
+  cleanup, shell, agent, test, and build processes for that execution observe the same value.
+- Containerized and remote executors keep an executor-local cache. Kandev does not inject a host
+  cache path into them without an explicit mount or remote storage contract.
+- Kandev creates an ownership marker beside the managed cache. It never deletes the default user
+  cache such as `/root/.cache/go-build` unless that exact path was explicitly adopted through the
+  Storage page with a destructive confirmation.
+- Analysis reports the managed cache's current bytes. Cleanup rotates the owned cache into
+  Kandev trash and recreates an empty cache when its size is greater than the configured maximum.
+  The limit is a cleanup trigger, not a hard quota; the cache can temporarily grow beyond it while
+  tasks are active.
+- Disabling managed Go cache stops injecting `GOCACHE` into new executions. It does not delete the
+  previously managed cache. Scheduled cleanup and a global manual run with no resource selection
+  leave it untouched; only a manual run whose non-empty selection includes `go_cache` may rotate it.
+
+### Docker storage
+
+- Kandev-owned container cleanup lists only containers labeled `kandev.managed=true`. It removes
+  a stopped container only after the task/runtime inventory positively shows it is orphaned or no
+  longer needed. Running containers are never removed by storage maintenance.
+- Analysis reports the count and writable-layer bytes of exactly labeled Kandev-managed containers;
+  an unavailable usage API degrades Docker analysis without failing the other resource summaries.
+- Docker build-cache and unused-image analysis may inspect the configured Docker daemon without
+  changing it.
+- Docker build-cache cleanup uses the Docker API's age/storage filters and does not invoke
+  `docker system prune`.
+- Unused-image cleanup removes only images unused by any container and older than the configured
+  age. Because image/build-cache ownership cannot be reliably attributed to Kandev, both actions
+  remain disabled unless the dedicated-daemon acknowledgment is set.
+- Kandev never performs a daemon-wide volume prune. Volumes attached to a positively identified
+  Kandev container may be removed through the existing container teardown path.
+- An unavailable or unsupported Docker daemon degrades the Docker cards to **Unavailable** and
+  does not fail workspace or Go-cache maintenance.
+
+## Data model
+
+### Install setting: `storage_maintenance`
+
+The existing install-wide `settings` key/value table stores one JSON object under the
+`storage_maintenance` key.
+
+```text
+enabled                              bool      default false
+check_interval_hours                 int       default 24; range 1..168
+idle_for_minutes                     int       default 10; range 1..1440
+orphan_grace_hours                   int       default 168; range 24..2160
+quarantine_retention_hours           int       default 168; range 24..2160
+workspaces.enabled                   bool      default true
+kandev_containers.enabled            bool      default true
+go_cache.enabled                     bool      default false
+go_cache.max_bytes                   int64     default 16106127360; minimum 1073741824
+go_cache.adopted_path                string    default ""; absolute and explicitly confirmed
+docker.dedicated_daemon_acknowledged bool      default false
+docker.build_cache_enabled           bool      default false
+docker.build_cache_keep_bytes        int64     default 10737418240; minimum 1073741824
+docker.build_cache_unused_hours      int       default 168; minimum 24
+docker.unused_images_enabled         bool      default false
+docker.unused_images_hours           int       default 168; minimum 24
+```
+
+Unknown JSON fields are ignored on read. Missing fields receive current defaults. Invalid writes
+return `400` and preserve the previously saved object. `PATCH settings` cannot set a previously
+empty `go_cache.adopted_path` without the dedicated adoption endpoint, and a transition of
+`docker.dedicated_daemon_acknowledged` from false to true requires the confirmation token described
+below. An adopted Go-cache path must be on the same filesystem as Kandev trash so quarantine remains
+an atomic rename.
+
+### `task_resource_cleanup_jobs`
+
+Durable intent for task lifecycle cleanup. It deliberately has no foreign key to `tasks`, because
+delete cleanup must survive removal of the task row.
+
+```text
+id                string     primary key
+operation_id      string     unique idempotency key for one lifecycle mutation
+task_id           string     indexed, no foreign key
+trigger           enum       archive | delete | cascade_archive | cascade_delete |
+                             workspace_delete | quick_chat_expire | reconcile
+state             enum       pending | running | retry_wait | succeeded | cancelled
+resource_snapshot json       captured runtime/environment/worktree/path handles
+attempts          int        non-negative
+next_attempt_at   timestamp  nullable
+last_error        string     default ""
+created_at        timestamp
+updated_at        timestamp
+completed_at      timestamp  nullable
+```
+
+Each lifecycle mutation supplies one stable `operation_id` to its cleanup job. Repeated delivery of
+the same mutation reuses that job; a later archive/delete cycle uses a new operation ID.
+
+### `storage_maintenance_runs`
+
+```text
+id               string     primary key; also the System job ID
+trigger          enum       scheduled | manual | analysis
+state            enum       queued | running | succeeded | failed | cancelled | skipped_busy
+settings_snapshot json      policy used by this run
+result           json       per-provider counts, bytes before/after, warnings
+message          string     default ""
+started_at       timestamp
+completed_at     timestamp  nullable
+```
+
+The UI lists the newest 20 runs. Run rows survive backend restarts.
+
+### `storage_quarantine_entries`
+
+```text
+id                string     primary key
+resource_type     enum       task_workspace | go_cache
+task_id           string     nullable, no foreign key
+workspace_id      string     nullable, no foreign key
+original_path     string     absolute, normalized, unique while active
+quarantine_path   string     absolute, beneath <KANDEV_HOME_DIR>/trash
+size_bytes        int64
+state             enum       quarantined | restored | deleted | failed
+quarantined_at    timestamp
+delete_after      timestamp
+restored_at       timestamp  nullable
+deleted_at        timestamp  nullable
+last_error        string     default ""
+metadata          json       ownership marker and Git worktree details
+```
+
+## API surface
+
+All routes are under the existing authenticated System route group.
+
+```text
+GET    /api/v1/system/storage
+       -> { settings, capabilities, summary, last_run }
+
+PATCH  /api/v1/system/storage/settings
+       body: {
+         settings: complete StorageMaintenanceSettings object,
+         confirmations?: { dedicated_docker?: "DEDICATED" }
+       }
+       -> { settings }
+
+POST   /api/v1/system/storage/go-cache/adopt
+       body: { path: string, confirm: "ADOPT" }
+       -> { settings, capabilities }
+
+POST   /api/v1/system/storage/analyze
+       -> 202 { job_id }
+
+POST   /api/v1/system/storage/run
+       body: { resources?: string[] }
+       -> 202 { job_id }
+       -> 409 { error, busy_resources[] } when the idle gate is unavailable
+
+GET    /api/v1/system/storage/runs?limit=20
+       -> { runs: StorageMaintenanceRun[] }
+
+GET    /api/v1/system/storage/quarantine
+       -> { entries: StorageQuarantineEntry[] }
+
+POST   /api/v1/system/storage/quarantine/:id/restore
+       -> { entry }
+
+DELETE /api/v1/system/storage/quarantine/:id
+       body: { confirm: "DELETE" }
+       -> 202 { job_id }
+```
+
+`capabilities` reports the managed Go path, whether Go-cache adoption is available, Docker
+availability, configured Docker host, and whether host-global Docker cleanup is allowed. API
+responses never expose secret environment values.
+
+Storage operations use the existing `system.job.update` WebSocket event and polling fallback.
+Job kinds are `storage-analysis`, `storage-cleanup`, and `storage-quarantine-delete`.
+
+The task unarchive response may additionally include:
+
+```json
+{
+  "workspace_recovery": [
+    {
+      "task_id": "...",
+      "status": "restored|not_found|failed",
+      "message": "..."
+    }
+  ]
+}
+```
+
+## State machine
+
+### Scheduled maintenance
+
+```text
+disabled
+  -> eligible                 setting enabled or next interval reached
+eligible
+  -> skipped_busy             quiet period or idle gate unavailable
+  -> running                  quiet period satisfied and idle gate acquired
+running
+  -> succeeded                selected providers finish
+  -> failed                   provider or persistence failure
+  -> cancelled                task launch preempts maintenance
+```
+
+A `skipped_busy` run does not advance destructive state. The scheduler evaluates eligibility again
+at the next interval. Provider failure is isolated: a Docker failure does not roll back a workspace
+quarantine or prevent a later Go-cache provider from running, but the overall run is `failed` and
+records each provider result.
+
+### Task cleanup intent
+
+```text
+pending -> running -> succeeded
+                   -> cancelled       archived task became active again
+                   -> retry_wait      bounded attempt failed
+retry_wait -> running                 next attempt or manual maintenance run
+```
+
+### Quarantine entry
+
+```text
+quarantined -> restored
+            -> deleted
+            -> failed -> restored|deleted
+```
+
+## Permissions
+
+Storage routes use the same install-user authorization as other System pages. Adopting an external
+Go cache, acknowledging a dedicated Docker daemon, permanently deleting a quarantine entry, and
+enabling host-global Docker cleanup require explicit UI confirmation and server-side validation.
+
+## Failure modes
+
+- Any authoritative workspace inventory query failure aborts workspace classification and performs
+  no workspace move or deletion.
+- Any uncertainty about path ownership, containment, active descendants, symlink traversal, or
+  task activity keeps the directory and records a warning.
+- A quarantine rename failure leaves the original directory untouched and records a failed entry
+  only when the failure can be associated with a durable candidate ID.
+- A backend crash after rename but before the database update is reconciled at startup by scanning
+  ownership manifests beneath `<KANDEV_HOME_DIR>/trash`.
+- A task unarchived while archive cleanup is pending cancels remaining destructive cleanup. A task
+  launch cannot pass the activity gate until cancellation completes.
+- An unarchive quarantine restore conflict leaves both the existing destination and quarantine
+  entry untouched and reports `workspace_recovery.status=failed`.
+- An invalid or unreadable settings object falls back to disabled scheduling, reports a health
+  warning, and does not run destructive maintenance.
+- A managed Go-cache cleanup failure leaves either the original cache or its quarantined rename
+  intact; it never recursively deletes outside the configured owned path.
+- Docker list/usage failure marks Docker analysis unavailable. Docker prune failure records the
+  daemon error and does not affect other providers.
+- Loss of the dedicated-daemon acknowledgment between analysis and cleanup cancels host-global
+  Docker operations.
+- Failure to persist a run or cleanup intent prevents its destructive operation from starting.
+
+## Persistence guarantees
+
+- Settings, cleanup intents, maintenance runs, and quarantine entries survive backend restarts.
+- A scheduled loop starts only when `enabled=true`; startup does not immediately run destructive
+  cleanup. The first scheduled run is eligible after one full configured interval.
+- Pending/retryable task cleanup resumes after startup independent of scheduled-maintenance
+  enablement. Task lifecycle cleanup is a correctness guarantee, not an optional disk policy.
+- Kandev retains historical archived-task worktree rows required by branch recovery. Filesystem
+  cleanup and permanent quarantine deletion do not cascade-delete that history.
+- Quarantined data remains restorable until permanent deletion succeeds. A failed permanent delete
+  remains visible and retryable.
+- Run history retains the newest 20 completed entries plus all non-terminal entries.
+
+## Scenarios
+
+- **GIVEN** scheduled maintenance has never been configured, **WHEN** Kandev starts as a systemd
+  daemon, **THEN** no destructive storage cleanup runs and the Storage page shows scheduling off.
+- **GIVEN** scheduling is disabled, **WHEN** the user selects **Analyze**, **THEN** the page shows
+  reclaimable bytes without changing any filesystem or Docker resource.
+- **GIVEN** scheduling is enabled and a task is running a Go test, **WHEN** the maintenance interval
+  arrives, **THEN** the run is recorded as `skipped_busy` and no provider changes resources.
+- **GIVEN** maintenance holds the idle gate, **WHEN** a new task launch arrives, **THEN** maintenance
+  is cancelled and the launch proceeds only after the active provider stops.
+- **GIVEN** an unreferenced task directory older than the orphan grace period contains
+  `node_modules`, **WHEN** workspace cleanup runs with a successful authoritative inventory,
+  **THEN** the whole task root moves to quarantine and its measured bytes appear in the run result.
+- **GIVEN** the worktree inventory query fails, **WHEN** workspace cleanup runs, **THEN** no task
+  directory moves and the run reports the inventory error.
+- **GIVEN** a multi-repository task has one active descendant worktree, **WHEN** workspace cleanup
+  scans the task root, **THEN** ancestor protection keeps the complete task root.
+- **GIVEN** a repository-less task uses `tasks/<workspace-id>/<task-id>`, **WHEN** it is active,
+  **THEN** inventory protection keeps that task directory without protecting unrelated orphan task
+  siblings in the same workspace directory.
+- **GIVEN** a quarantined task workspace has not reached its deletion deadline, **WHEN** the user
+  selects **Restore**, **THEN** it returns to its original path and remains available to the task.
+- **GIVEN** an archived task has a quarantined workspace, **WHEN** the user unarchives it, **THEN**
+  Kandev restores the quarantined directory before reporting branch recovery.
+- **GIVEN** an archive cleanup job is waiting to retry, **WHEN** the task is unarchived, **THEN** the
+  cleanup job becomes `cancelled` and does not delete the active task's resources.
+- **GIVEN** an archived task's workspace was permanently deleted but its branch exists on origin,
+  **WHEN** the task is unarchived, **THEN** branch recovery remains `remote` and a new execution can
+  recreate the worktree from origin.
+- **GIVEN** managed Go cache is enabled and is 20 GiB with a 15 GiB threshold, **WHEN** an idle
+  cleanup runs, **THEN** Kandev rotates the owned cache to trash, recreates an empty cache, and
+  reports the reclaimed bytes.
+- **GIVEN** `/root/.cache/go-build` was not explicitly adopted, **WHEN** storage cleanup runs,
+  **THEN** Kandev does not modify it.
+- **GIVEN** an exited container has `kandev.managed=true` and its task is positively absent,
+  **WHEN** container cleanup runs, **THEN** the container and its attached Kandev volumes are removed.
+- **GIVEN** an unrelated exited container exists, **WHEN** Kandev container cleanup runs, **THEN**
+  the container remains unchanged.
+- **GIVEN** Docker build-cache cleanup is selected without the dedicated-daemon acknowledgment,
+  **WHEN** settings are saved or cleanup is requested, **THEN** the request is rejected without
+  invoking Docker prune APIs.
+- **GIVEN** the Storage page is opened on a mobile viewport, **WHEN** the user navigates through the
+  settings sheet, analyzes storage, and expands a resource result, **THEN** every value and action is
+  available without horizontal page scrolling or hover-only controls.
+- **GIVEN** settings were saved, **WHEN** the backend restarts, **THEN** the Storage page shows the
+  persisted policy and the next run uses it.
+
+## Out of scope
+
+- A hard filesystem quota for Go or Docker caches.
+- Arbitrary user-defined maintenance commands or cron expressions.
+- Global Docker volume or network pruning.
+- Killing processes by executable name when no durable Kandev ownership handle exists.
+- Cleaning remote SSH executor filesystems; remote maintenance requires a separate explicit design.
+- Restoring uncommitted files after their quarantine retention has expired.
+- Automatically cleaning a pre-existing user Go cache without explicit path adoption.
+
+## Implementation plan
+
+See [the implementation plan](../../plans/storage-maintenance/plan.md).

--- a/docs/specs/system-page/storage-maintenance.md
+++ b/docs/specs/system-page/storage-maintenance.md
@@ -20,13 +20,15 @@ reclaim that space without maintaining cron or systemd configuration outside Kan
 - Settings includes a **System → Storage** page at `/settings/system/storage` for disk
   analysis, maintenance policy, manual cleanup, run history, and quarantined workspaces.
 - The page presents storage analysis and maintenance policy as separate full-width sections.
-  Analysis and cleanup progress stays beside the action that started it instead of appearing as
-  detached page status.
+  Analysis and cleanup state replaces the label and icon inside the action button that started it
+  instead of appearing as detached page status.
 - User-facing storage totals and editable size limits are shown in GB. The frontend converts those
   values to and from the byte-based API without changing the persisted data model.
-- Maintenance settings are grouped by scope: schedule, workspaces and containers, Go build cache,
-  Docker cleanup, and quarantine safety. Every option includes focusable, pointer-accessible help
-  that explains what it can change, when it runs, and which safety checks apply.
+- Maintenance settings use separate cards grouped by scope: schedule, workspaces and containers,
+  Go build cache, Docker cleanup, and quarantine safety. Every option includes focusable,
+  pointer-accessible help that explains what it can change, when it runs, and which safety checks
+  apply. Threshold and path fields are disabled while their parent cleanup option is disabled;
+  quarantine retention remains independently editable because it also governs existing entries.
 - Read-only analysis is available even when scheduled maintenance is disabled. It reports
   active task workspace bytes, orphan-candidate bytes, active quarantined count and bytes, the
   managed Go cache, Kandev-managed container count and writable-layer bytes, Docker build cache,

--- a/docs/specs/tasks/runtime-cleanup.md
+++ b/docs/specs/tasks/runtime-cleanup.md
@@ -52,6 +52,15 @@ worktrees, or executor rows behind and the machine slowly runs out of memory.
 - Cleanup is idempotent: repeating archive/delete cleanup, startup reconciliation,
   or explicit session stop does not fail because the process, task, session, or
   worktree was already removed.
+- Archive, delete, cascade, workspace-delete, and quick-chat expiration persist a
+  cleanup intent and resource snapshot before mutating or deleting task state.
+  Cleanup is performed by a durable worker rather than a detached goroutine.
+- Archive cleanup revalidates that the task remains archived before every
+  destructive step. Unarchiving a task cancels its pending archive cleanup so a
+  delayed retry cannot remove the newly active task's resources.
+- Cleanup preserves historical archived-task worktree records and branch metadata
+  used by unarchive recovery. Filesystem removal does not imply recovery-history
+  removal.
 
 ## Data Model
 
@@ -80,6 +89,15 @@ is in progress. Rows must not reference missing task/session state indefinitely.
 not imply runtime resources have been released. Cleanup code must not use terminal
 session state as a reason to skip runtime teardown when an `executors_running`
 row exists.
+
+### `task_resource_cleanup_jobs`
+
+`task_resource_cleanup_jobs` is the durable task-lifecycle cleanup intent. It has
+no foreign key to `tasks`, so delete cleanup survives deletion of the owning row.
+It stores the trigger, state, retry timing, last error, and a JSON snapshot of the
+runtime, environment, worktree, and path handles captured before task mutation.
+Only one non-terminal row exists for an operation ID; repeated event delivery
+reuses the same cleanup job.
 
 ## API Surface
 
@@ -124,6 +142,16 @@ Allowed transitions:
 - `stop_requested` -> `retryable_failure` on timeout or uncertain runtime state.
 - `retryable_failure` -> `stop_requested` on the next cleanup attempt.
 
+The durable cleanup job wraps that resource lifecycle:
+
+- `pending` -> `running` when the cleanup worker claims the job.
+- `running` -> `succeeded` when runtime and owned resource cleanup finish.
+- `running` -> `retry_wait` when bounded cleanup fails and the resource snapshot
+  must be retried.
+- `retry_wait` -> `running` on the next scheduled retry or manual storage run.
+- `pending|running|retry_wait` -> `cancelled` when an archive-triggered cleanup
+  observes that its task has been unarchived.
+
 ## Failure Modes
 
 - If querying `executors_running` for a task fails, archive/delete still updates
@@ -153,6 +181,12 @@ Allowed transitions:
 - If startup reconciliation finds rows for archived tasks, deleted tasks, missing
   sessions, or terminal sessions with no live runtime, it removes only rows that
   are positively confirmed safe to remove.
+- If cleanup intent or its resource snapshot cannot be persisted, the lifecycle
+  mutation fails before destructive cleanup begins; Kandev does not rely on an
+  unrecorded background goroutine.
+- If an archived task is unarchived before cleanup completes, the worker cancels
+  remaining archive cleanup. Already completed resource removal remains valid and
+  the unarchive branch-recovery flow recreates the environment when possible.
 
 ## Persistence Guarantees
 
@@ -162,6 +196,12 @@ Allowed transitions:
   attempted for every runtime row owned by the task.
 - Startup reconciliation is allowed to recover from a previous backend crash by
   reattempting cleanup for stale runtime rows.
+- Pending and retryable task cleanup jobs survive restart and resume independently
+  of whether optional scheduled storage maintenance is enabled.
+- Cleanup snapshots needed after task deletion survive without foreign-keyed task,
+  session, environment, or worktree rows.
+- Historical worktree rows for archived tasks remain available to unarchive branch
+  recovery even after their on-disk directories are removed.
 - Orphaned OS processes without any durable `executors_running` row are outside
   normal cleanup guarantees; they may be handled by an explicit operator recovery
   tool, but automatic task cleanup must not rely on process-name scanning.
@@ -207,6 +247,15 @@ Allowed transitions:
   still references, **WHEN** parent cleanup runs, **THEN** destructive
   environment and worktree teardown is deferred until the child no longer holds
   the environment.
+- **GIVEN** the backend exits after a task is deleted but before its worktree is
+  removed, **WHEN** the backend restarts, **THEN** the durable cleanup job retries
+  using its captured resource snapshot.
+- **GIVEN** an archive cleanup job is pending, **WHEN** the task is unarchived,
+  **THEN** the job is cancelled and cannot delete resources created after
+  unarchive.
+- **GIVEN** archive cleanup removed a local worktree, **WHEN** the task is
+  unarchived, **THEN** its historical worktree branch metadata remains available
+  for local/remote recovery.
 
 ## Out of Scope
 


### PR DESCRIPTION
Short-lived tasks can leave workspaces, dependency trees, Go build cache, and Docker data consuming
self-hosted disks. Kandev now provides disabled-by-default, idle-aware storage analysis and cleanup
with ownership checks, quarantine, recovery, and persisted policy under Settings > System > Storage.

## Important Changes

- Adds a durable task-resource cleanup queue that survives restart and cooperates with unarchive.
- Introduces an install-wide activity gate so task work preempts cleanup without destructive races.
- Adds ownership-aware workspace, managed Go-cache, and Docker providers with quarantine and restore.
- Adds persisted scheduling, run history, health reporting, System APIs, and responsive desktop/mobile UI.

## Validation

- `make fmt`
- Generated release-note and changelog checks
- `make typecheck`
- `env TMPDIR=<physical-macos-temp-path> make test`
- `make lint`
- Focused backend package tests under normal and race modes
- Storage desktop Playwright: 3 passed
- Storage unarchive recovery Playwright: 1 passed
- Storage mobile Playwright: 1 passed with horizontal-overflow coverage
- Docker storage Playwright: discovered but skipped locally because no Docker daemon was available

## Possible Improvements

Low risk: rerun the Docker container E2E on a daemon-enabled runner to supplement the passing SDK and
provider tests.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1699?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->