### PR TITLE
fix(web): silence Vitest network noise

### DIFF
--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -2,6 +2,8 @@ import { defineConfig, mergeConfig } from "vitest/config";
 
 import viteConfig from "./vite.config";
 
+if (process.env.DEBUG === "1") process.env.DEBUG = "";
+
 const configuredMaxWorkers = process.env.VITEST_MAX_WORKERS?.trim();
 const maxWorkers = resolveMaxWorkers(configuredMaxWorkers, Boolean(process.env.CI));
 
@@ -10,6 +12,15 @@ export default mergeConfig(
   defineConfig({
     test: {
       environment: "happy-dom",
+      environmentOptions: {
+        happyDOM: {
+          settings: {
+            navigation: {
+              disableChildFrameNavigation: true,
+            },
+          },
+        },
+      },
       setupFiles: ["./vitest.setup.ts"],
       exclude: ["e2e/**", "node_modules/**"],
       pool: "threads",

--- a/apps/web/vitest.setup.ts
+++ b/apps/web/vitest.setup.ts
@@ -1,3 +1,5 @@
+import type { Window as HappyDOMWindow } from "happy-dom";
+
 function createLocalStorageMock(): Storage {
   const store = new Map<string, string>();
 
@@ -31,6 +33,12 @@ Object.defineProperty(globalThis, "localStorage", {
 });
 
 if (typeof window !== "undefined") {
+  const happyDOMWindow = window as unknown as HappyDOMWindow;
+  happyDOMWindow.happyDOM.settings.fetch.interceptor = {
+    beforeAsyncRequest: ({ window: requestWindow }) =>
+      Promise.resolve(new requestWindow.Response(null, { status: 404 })),
+  };
+
   Object.defineProperty(window, "localStorage", {
     configurable: true,
     value: localStorageMock,

--- a/docs/decisions/0037-resource-aware-frontend-unit-tests.md
+++ b/docs/decisions/0037-resource-aware-frontend-unit-tests.md
@@ -14,6 +14,8 @@ On a 10-logical-CPU development host, the old uncapped suite averaged roughly 7.
 
 Kandev keeps Vitest as the frontend unit-test runner and aligns it with the application's current Vite major. Local full-suite runs use the worker-thread pool and at most 20 percent of the host's available parallelism. `pool: "threads"` is explicit because Vitest 2+ defaults to `forks`; the suite's isolation trial showed that `forks` produces widespread cross-file mock and DOM failures. CI remains uncapped so dedicated runners can use their assigned capacity, and `VITEST_MAX_WORKERS` can override either default for an explicit execution environment when it is a positive integer or percentage. Vitest is upgraded to 4.1.10; Vite remains locked at 8.0.16 rather than the incompatible 8.1.4.
 
+The unit-test environment disables Happy DOM child-frame navigation and intercepts otherwise unmocked Happy DOM requests with a deterministic non-success response, so component tests cannot make real requests to its default `http://localhost:3000` origin. Tests that explicitly replace `fetch` retain full control over their response. The Vitest config also clears the generic inherited `DEBUG=1` value, which otherwise enables Tailwind's per-file transform diagnostics; namespaced debug values remain available for intentional tooling diagnostics.
+
 Targeted test-file runs remain the normal development loop. Full frontend suites run during final verification and CI rather than after every edit. Per-file isolation remains enabled because the suite relies on module and DOM isolation.
 
 ## Consequences
@@ -22,6 +24,7 @@ Targeted test-file runs remain the normal development loop. Full frontend suites
 - A local full-suite run takes longer when it is the only workload, but overlapping runs cause less contention and thermal pressure.
 - CI performance is unchanged unless the CI environment explicitly sets `VITEST_MAX_WORKERS`.
 - Vitest and Vite share a supported dependency generation instead of loading a second legacy Vite toolchain.
+- Unit tests do not load iframe content, access the network through Happy DOM, or inherit the host's generic debug verbosity.
 - The percentage limit scales across developer machines without hard-coding a workstation-specific core count.
 - Vite updates require a production-build smoke check until the Rolldown re-export regression is fixed upstream.
 


### PR DESCRIPTION
Vitest 4 exposed unmocked Happy DOM requests and inherited Tailwind debug output, obscuring real failures. The test environment now blocks those requests deterministically and keeps normal runs focused on actionable output.

## Validation

- `pnpm test` - 577 files passed; 4,659 tests passed, 4 skipped
- `pnpm exec vitest run lib/preview-url-detector.test.ts --reporter=verbose --maxWorkers=1`
- `make fmt`
- `make typecheck`
- `make test`
- `make lint`
- `git diff --check`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1700?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->