### PR TITLE
feat: rename task inline from the top bar via double-click

### DIFF
--- a/apps/web/components/settings/agent-usage-section.test.tsx
+++ b/apps/web/components/settings/agent-usage-section.test.tsx
@@ -5,7 +5,7 @@ import { AgentUsageSection } from "@/components/settings/agent-usage-section";
 import type { AgentSubscriptionUsageResponse } from "@/lib/types/http";
 
 const listAgentSubscriptionUsage = vi.hoisted(() =>
-  vi.fn<[], Promise<AgentSubscriptionUsageResponse>>(),
+  vi.fn<() => Promise<AgentSubscriptionUsageResponse>>(),
 );
 
 vi.mock("@/lib/api", () => ({

--- a/apps/web/components/task/task-top-bar-title.test.tsx
+++ b/apps/web/components/task/task-top-bar-title.test.tsx
@@ -88,6 +88,17 @@ describe("TaskTopBarTitle", () => {
     expect(queryInput()).toBeNull();
   });
 
+  it("ignores Enter fired during IME composition", () => {
+    render(<TaskTopBarTitle taskId="task-1" taskTitle="My task" />);
+
+    const input = startEditing();
+    fireEvent.change(input, { target: { value: "New title" } });
+    fireEvent.keyDown(input, { key: "Enter", isComposing: true });
+
+    expect(mockRename).not.toHaveBeenCalled();
+    expect(queryInput()).not.toBeNull();
+  });
+
   it("cancels on Escape without renaming", () => {
     render(<TaskTopBarTitle taskId="task-1" taskTitle="My task" />);
 

--- a/apps/web/components/task/task-top-bar-title.test.tsx
+++ b/apps/web/components/task/task-top-bar-title.test.tsx
@@ -99,6 +99,29 @@ describe("TaskTopBarTitle", () => {
     expect(queryInput()).not.toBeNull();
   });
 
+  it("ignores the IME-accepting Enter reported as keyCode 229", () => {
+    render(<TaskTopBarTitle taskId="task-1" taskTitle="My task" />);
+
+    const input = startEditing();
+    fireEvent.change(input, { target: { value: "New title" } });
+    fireEvent.keyDown(input, { key: "Enter", keyCode: 229 });
+
+    expect(mockRename).not.toHaveBeenCalled();
+    expect(queryInput()).not.toBeNull();
+  });
+
+  it("does not rename on Enter when the task was archived mid-edit", () => {
+    const { rerender } = render(<TaskTopBarTitle taskId="task-1" taskTitle="My task" />);
+
+    const input = startEditing();
+    fireEvent.change(input, { target: { value: "New title" } });
+    rerender(<TaskTopBarTitle taskId="task-1" taskTitle="My task" isArchived />);
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(mockRename).not.toHaveBeenCalled();
+    expect(queryInput()).toBeNull();
+  });
+
   it("cancels on Escape without renaming", () => {
     render(<TaskTopBarTitle taskId="task-1" taskTitle="My task" />);
 

--- a/apps/web/components/task/task-top-bar-title.test.tsx
+++ b/apps/web/components/task/task-top-bar-title.test.tsx
@@ -32,7 +32,7 @@ function startEditing() {
   return screen.getByTestId("task-title-rename-input") as HTMLInputElement;
 }
 
-describe("TaskTopBarTitle", () => {
+describe("TaskTopBarTitle — idle state", () => {
   it("renders the title as the breadcrumb page when idle", () => {
     render(<TaskTopBarTitle taskId="task-1" taskTitle="My task" />);
 
@@ -40,14 +40,35 @@ describe("TaskTopBarTitle", () => {
     expect(queryInput()).toBeNull();
     // Not aria-disabled, so pointer-actionability checks treat it as interactive.
     expect(getTitle().getAttribute("aria-disabled")).toBe("false");
+    // Keyboard-operable: reachable via Tab.
+    expect(getTitle().getAttribute("tabindex")).toBe("0");
   });
 
-  it("keeps the breadcrumb aria-disabled when the task is archived", () => {
+  it("keeps the breadcrumb aria-disabled and unfocusable when the task is archived", () => {
     render(<TaskTopBarTitle taskId="task-1" taskTitle="My task" isArchived />);
 
     expect(getTitle().getAttribute("aria-disabled")).toBe("true");
+    expect(getTitle().getAttribute("tabindex")).toBeNull();
   });
 
+  it("does not enter edit mode when the task is archived", () => {
+    render(<TaskTopBarTitle taskId="task-1" taskTitle="My task" isArchived />);
+
+    fireEvent.doubleClick(getTitle());
+
+    expect(queryInput()).toBeNull();
+  });
+
+  it("does not enter edit mode without a task id", () => {
+    render(<TaskTopBarTitle taskTitle="My task" />);
+
+    fireEvent.doubleClick(getTitle());
+
+    expect(queryInput()).toBeNull();
+  });
+});
+
+describe("TaskTopBarTitle — entering edit mode", () => {
   it("swaps to an input pre-filled with the current title on double-click", () => {
     render(<TaskTopBarTitle taskId="task-1" taskTitle="My task" />);
 
@@ -56,6 +77,25 @@ describe("TaskTopBarTitle", () => {
     expect(input.value).toBe("My task");
   });
 
+  it("enters edit mode on Enter when the title is focused", () => {
+    render(<TaskTopBarTitle taskId="task-1" taskTitle="My task" />);
+
+    fireEvent.keyDown(getTitle(), { key: "Enter" });
+
+    const input = screen.getByTestId("task-title-rename-input") as HTMLInputElement;
+    expect(input.value).toBe("My task");
+  });
+
+  it("does not enter edit mode on title Enter when the task is archived", () => {
+    render(<TaskTopBarTitle taskId="task-1" taskTitle="My task" isArchived />);
+
+    fireEvent.keyDown(getTitle(), { key: "Enter" });
+
+    expect(queryInput()).toBeNull();
+  });
+});
+
+describe("TaskTopBarTitle — committing a rename", () => {
   it("renames on Enter with a changed value, trimming whitespace", () => {
     render(<TaskTopBarTitle taskId="task-1" taskTitle="My task" />);
 
@@ -121,7 +161,9 @@ describe("TaskTopBarTitle", () => {
     expect(mockRename).not.toHaveBeenCalled();
     expect(queryInput()).toBeNull();
   });
+});
 
+describe("TaskTopBarTitle — cancelling a rename", () => {
   it("cancels on Escape without renaming", () => {
     render(<TaskTopBarTitle taskId="task-1" taskTitle="My task" />);
 
@@ -145,19 +187,12 @@ describe("TaskTopBarTitle", () => {
     expect(queryInput()).toBeNull();
   });
 
-  it("does not enter edit mode when the task is archived", () => {
-    render(<TaskTopBarTitle taskId="task-1" taskTitle="My task" isArchived />);
+  it("returns focus to the title after a keyboard exit", () => {
+    render(<TaskTopBarTitle taskId="task-1" taskTitle="My task" />);
 
-    fireEvent.doubleClick(getTitle());
+    const input = startEditing();
+    fireEvent.keyDown(input, { key: "Escape" });
 
-    expect(queryInput()).toBeNull();
-  });
-
-  it("does not enter edit mode without a task id", () => {
-    render(<TaskTopBarTitle taskTitle="My task" />);
-
-    fireEvent.doubleClick(getTitle());
-
-    expect(queryInput()).toBeNull();
+    expect(document.activeElement).toBe(getTitle());
   });
 });

--- a/apps/web/components/task/task-top-bar-title.test.tsx
+++ b/apps/web/components/task/task-top-bar-title.test.tsx
@@ -1,0 +1,129 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TaskTopBarTitle } from "./task-top-bar-title";
+
+const mockRename = vi.hoisted(() => vi.fn(() => Promise.resolve()));
+
+vi.mock("@kandev/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/hooks/use-task-actions", () => ({
+  useTaskActions: () => ({ renameTaskById: mockRename }),
+}));
+
+afterEach(() => {
+  cleanup();
+  mockRename.mockClear();
+});
+
+function getTitle() {
+  return screen.getByText("My task", { selector: '[aria-current="page"]' });
+}
+
+function queryInput() {
+  return screen.queryByTestId("task-title-rename-input");
+}
+
+function startEditing() {
+  fireEvent.doubleClick(getTitle());
+  return screen.getByTestId("task-title-rename-input") as HTMLInputElement;
+}
+
+describe("TaskTopBarTitle", () => {
+  it("renders the title as the breadcrumb page when idle", () => {
+    render(<TaskTopBarTitle taskId="task-1" taskTitle="My task" />);
+
+    expect(getTitle()).toBeTruthy();
+    expect(queryInput()).toBeNull();
+    // Not aria-disabled, so pointer-actionability checks treat it as interactive.
+    expect(getTitle().getAttribute("aria-disabled")).toBe("false");
+  });
+
+  it("keeps the breadcrumb aria-disabled when the task is archived", () => {
+    render(<TaskTopBarTitle taskId="task-1" taskTitle="My task" isArchived />);
+
+    expect(getTitle().getAttribute("aria-disabled")).toBe("true");
+  });
+
+  it("swaps to an input pre-filled with the current title on double-click", () => {
+    render(<TaskTopBarTitle taskId="task-1" taskTitle="My task" />);
+
+    const input = startEditing();
+
+    expect(input.value).toBe("My task");
+  });
+
+  it("renames on Enter with a changed value, trimming whitespace", () => {
+    render(<TaskTopBarTitle taskId="task-1" taskTitle="My task" />);
+
+    const input = startEditing();
+    fireEvent.change(input, { target: { value: "  New title  " } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(mockRename).toHaveBeenCalledWith("task-1", "New title");
+    expect(queryInput()).toBeNull();
+  });
+
+  it("does not rename on Enter when the value is unchanged", () => {
+    render(<TaskTopBarTitle taskId="task-1" taskTitle="My task" />);
+
+    const input = startEditing();
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(mockRename).not.toHaveBeenCalled();
+    expect(queryInput()).toBeNull();
+  });
+
+  it("does not rename on Enter when the value is whitespace-only", () => {
+    render(<TaskTopBarTitle taskId="task-1" taskTitle="My task" />);
+
+    const input = startEditing();
+    fireEvent.change(input, { target: { value: "   " } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(mockRename).not.toHaveBeenCalled();
+    expect(queryInput()).toBeNull();
+  });
+
+  it("cancels on Escape without renaming", () => {
+    render(<TaskTopBarTitle taskId="task-1" taskTitle="My task" />);
+
+    const input = startEditing();
+    fireEvent.change(input, { target: { value: "New title" } });
+    fireEvent.keyDown(input, { key: "Escape" });
+
+    expect(mockRename).not.toHaveBeenCalled();
+    expect(queryInput()).toBeNull();
+    expect(getTitle()).toBeTruthy();
+  });
+
+  it("cancels on blur without renaming", () => {
+    render(<TaskTopBarTitle taskId="task-1" taskTitle="My task" />);
+
+    const input = startEditing();
+    fireEvent.change(input, { target: { value: "New title" } });
+    fireEvent.blur(input);
+
+    expect(mockRename).not.toHaveBeenCalled();
+    expect(queryInput()).toBeNull();
+  });
+
+  it("does not enter edit mode when the task is archived", () => {
+    render(<TaskTopBarTitle taskId="task-1" taskTitle="My task" isArchived />);
+
+    fireEvent.doubleClick(getTitle());
+
+    expect(queryInput()).toBeNull();
+  });
+
+  it("does not enter edit mode without a task id", () => {
+    render(<TaskTopBarTitle taskTitle="My task" />);
+
+    fireEvent.doubleClick(getTitle());
+
+    expect(queryInput()).toBeNull();
+  });
+});

--- a/apps/web/components/task/task-top-bar-title.tsx
+++ b/apps/web/components/task/task-top-bar-title.tsx
@@ -28,6 +28,9 @@ export function TaskTopBarTitle({ taskId, taskTitle, isArchived }: TaskTopBarTit
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
+      // IME composition uses Enter to confirm a candidate; let the IME
+      // handle it instead of committing the rename.
+      if (e.nativeEvent.isComposing) return;
       if (e.key === "Enter") {
         e.preventDefault();
         const trimmed = draft.trim();

--- a/apps/web/components/task/task-top-bar-title.tsx
+++ b/apps/web/components/task/task-top-bar-title.tsx
@@ -28,13 +28,14 @@ export function TaskTopBarTitle({ taskId, taskTitle, isArchived }: TaskTopBarTit
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
-      // IME composition uses Enter to confirm a candidate; let the IME
-      // handle it instead of committing the rename.
-      if (e.nativeEvent.isComposing) return;
+      // IME composition uses Enter to confirm a candidate; let the IME handle
+      // it instead of committing the rename. keyCode 229 covers IMEs that
+      // report the accepting Enter after isComposing has flipped false.
+      if (e.nativeEvent.isComposing || e.nativeEvent.keyCode === 229) return;
       if (e.key === "Enter") {
         e.preventDefault();
         const trimmed = draft.trim();
-        if (taskId && trimmed && trimmed !== taskTitle) {
+        if (taskId && !isArchived && trimmed && trimmed !== taskTitle) {
           renameTaskById(taskId, trimmed).catch((err) =>
             console.error("Failed to rename task:", err),
           );
@@ -46,7 +47,7 @@ export function TaskTopBarTitle({ taskId, taskTitle, isArchived }: TaskTopBarTit
         setIsEditing(false);
       }
     },
-    [draft, taskId, taskTitle, renameTaskById],
+    [draft, taskId, isArchived, taskTitle, renameTaskById],
   );
 
   if (isEditing) {

--- a/apps/web/components/task/task-top-bar-title.tsx
+++ b/apps/web/components/task/task-top-bar-title.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { Breadcrumb, BreadcrumbItem, BreadcrumbList, BreadcrumbPage } from "@kandev/ui/breadcrumb";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
+import { Input } from "@kandev/ui/input";
+import { useTaskActions } from "@/hooks/use-task-actions";
+
+type TaskTopBarTitleProps = {
+  taskId?: string | null;
+  taskTitle?: string;
+  isArchived?: boolean;
+};
+
+export function TaskTopBarTitle({ taskId, taskTitle, isArchived }: TaskTopBarTitleProps) {
+  const { renameTaskById } = useTaskActions();
+  const [isEditing, setIsEditing] = useState(false);
+  const [draft, setDraft] = useState("");
+  const canRename = Boolean(taskId) && !isArchived;
+
+  const handleDoubleClick = useCallback(() => {
+    if (!taskId || isArchived) return;
+    setDraft(taskTitle ?? "");
+    setIsEditing(true);
+  }, [taskId, isArchived, taskTitle]);
+
+  const handleCancel = useCallback(() => setIsEditing(false), []);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        const trimmed = draft.trim();
+        if (taskId && trimmed && trimmed !== taskTitle) {
+          renameTaskById(taskId, trimmed).catch((err) =>
+            console.error("Failed to rename task:", err),
+          );
+        }
+        setIsEditing(false);
+      } else if (e.key === "Escape") {
+        e.preventDefault();
+        e.stopPropagation();
+        setIsEditing(false);
+      }
+    },
+    [draft, taskId, taskTitle, renameTaskById],
+  );
+
+  if (isEditing) {
+    return (
+      <Input
+        data-testid="task-title-rename-input"
+        aria-label="Task title"
+        autoFocus
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onFocus={(e) => e.target.select()}
+        onBlur={handleCancel}
+        onKeyDown={handleKeyDown}
+        className="h-7 w-72 max-w-full text-sm font-medium"
+      />
+    );
+  }
+
+  return (
+    <Breadcrumb className="min-w-0 max-w-full">
+      <BreadcrumbList className="min-w-0 max-w-full flex-nowrap text-sm">
+        <BreadcrumbItem className="min-w-0 max-w-full">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              {/* BreadcrumbPage defaults to aria-disabled="true"; mark it enabled
+                  when renameable so pointer-actionability checks (and AT) see the
+                  double-click target as interactive. */}
+              <BreadcrumbPage
+                className="block max-w-full truncate font-medium"
+                aria-disabled={!canRename}
+                onDoubleClick={handleDoubleClick}
+              >
+                {taskTitle ?? "Task details"}
+              </BreadcrumbPage>
+            </TooltipTrigger>
+            <TooltipContent>{taskTitle ?? "Task details"}</TooltipContent>
+          </Tooltip>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  );
+}

--- a/apps/web/components/task/task-top-bar-title.tsx
+++ b/apps/web/components/task/task-top-bar-title.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Breadcrumb, BreadcrumbItem, BreadcrumbList, BreadcrumbPage } from "@kandev/ui/breadcrumb";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
 import { Input } from "@kandev/ui/input";
@@ -16,13 +16,35 @@ export function TaskTopBarTitle({ taskId, taskTitle, isArchived }: TaskTopBarTit
   const { renameTaskById } = useTaskActions();
   const [isEditing, setIsEditing] = useState(false);
   const [draft, setDraft] = useState("");
+  const titleRef = useRef<HTMLSpanElement>(null);
+  const restoreFocusRef = useRef(false);
   const canRename = Boolean(taskId) && !isArchived;
 
-  const handleDoubleClick = useCallback(() => {
+  // Return focus to the title after a keyboard-driven exit (Enter/Escape) so
+  // keyboard users don't lose their place; blur exits keep focus where the
+  // user clicked.
+  useEffect(() => {
+    if (!isEditing && restoreFocusRef.current) {
+      restoreFocusRef.current = false;
+      titleRef.current?.focus();
+    }
+  }, [isEditing]);
+
+  const startEditing = useCallback(() => {
     if (!taskId || isArchived) return;
     setDraft(taskTitle ?? "");
     setIsEditing(true);
   }, [taskId, isArchived, taskTitle]);
+
+  const handleTitleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLSpanElement>) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        startEditing();
+      }
+    },
+    [startEditing],
+  );
 
   const handleCancel = useCallback(() => setIsEditing(false), []);
 
@@ -40,10 +62,12 @@ export function TaskTopBarTitle({ taskId, taskTitle, isArchived }: TaskTopBarTit
             console.error("Failed to rename task:", err),
           );
         }
+        restoreFocusRef.current = true;
         setIsEditing(false);
       } else if (e.key === "Escape") {
         e.preventDefault();
         e.stopPropagation();
+        restoreFocusRef.current = true;
         setIsEditing(false);
       }
     },
@@ -72,13 +96,16 @@ export function TaskTopBarTitle({ taskId, taskTitle, isArchived }: TaskTopBarTit
         <BreadcrumbItem className="min-w-0 max-w-full">
           <Tooltip>
             <TooltipTrigger asChild>
-              {/* BreadcrumbPage defaults to aria-disabled="true"; mark it enabled
-                  when renameable so pointer-actionability checks (and AT) see the
-                  double-click target as interactive. */}
+              {/* BreadcrumbPage defaults to aria-disabled="true"; when renameable,
+                  mark it enabled and make it keyboard-operable (tab + Enter) so
+                  AT and pointer-actionability checks see a working control. */}
               <BreadcrumbPage
-                className="block max-w-full truncate font-medium"
+                ref={titleRef}
+                className="block max-w-full truncate rounded-sm font-medium outline-none focus-visible:ring-[2px] focus-visible:ring-ring/35"
                 aria-disabled={!canRename}
-                onDoubleClick={handleDoubleClick}
+                tabIndex={canRename ? 0 : undefined}
+                onDoubleClick={startEditing}
+                onKeyDown={canRename ? handleTitleKeyDown : undefined}
               >
                 {taskTitle ?? "Task details"}
               </BreadcrumbPage>

--- a/apps/web/components/task/task-top-bar.tsx
+++ b/apps/web/components/task/task-top-bar.tsx
@@ -4,8 +4,8 @@ import { memo, type ReactNode } from "react";
 import Link from "@/components/routing/app-link";
 import { IconBug, IconCircleDot } from "@tabler/icons-react";
 import { Button } from "@kandev/ui/button";
-import { Breadcrumb, BreadcrumbItem, BreadcrumbList, BreadcrumbPage } from "@kandev/ui/breadcrumb";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
+import { TaskTopBarTitle } from "@/components/task/task-top-bar-title";
 import { EditorsMenu } from "@/components/task/editors-menu";
 import { LayoutPresetSelector } from "@/components/task/layout-preset-selector";
 import { DocumentControls } from "@/components/task/document/document-controls";
@@ -151,20 +151,7 @@ function TopBarLeft({
   const showExecutorSettings = shouldShowExecutorEnvironmentControls(remoteExecutorType);
   return (
     <div className="flex min-w-0 max-w-[min(44rem,45vw)] items-center gap-2.5 overflow-hidden">
-      <Breadcrumb className="min-w-0 max-w-full">
-        <BreadcrumbList className="min-w-0 max-w-full flex-nowrap text-sm">
-          <BreadcrumbItem className="min-w-0 max-w-full">
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <BreadcrumbPage className="block max-w-full truncate font-medium">
-                  {taskTitle ?? "Task details"}
-                </BreadcrumbPage>
-              </TooltipTrigger>
-              <TooltipContent>{taskTitle ?? "Task details"}</TooltipContent>
-            </Tooltip>
-          </BreadcrumbItem>
-        </BreadcrumbList>
-      </Breadcrumb>
+      <TaskTopBarTitle taskId={taskId} taskTitle={taskTitle} isArchived={isArchived} />
 
       {!isArchived && showExecutorSettings && (
         <ExecutorSettingsButton taskId={taskId} sessionId={activeSessionId ?? null} />

--- a/apps/web/e2e/tests/task/topbar-rename.spec.ts
+++ b/apps/web/e2e/tests/task/topbar-rename.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from "../../fixtures/test-base";
+import { SessionPage } from "../../pages/session-page";
+
+test.describe("Task topbar inline rename", () => {
+  test("renames the task by double-clicking the title and pressing Enter", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    test.setTimeout(90_000);
+
+    const task = await apiClient.createTaskWithAgent(
+      seedData.workspaceId,
+      "Topbar rename original",
+      seedData.agentProfileId,
+      {
+        description: "/e2e:simple-message",
+        workflow_id: seedData.workflowId,
+        workflow_step_id: seedData.startStepId,
+        repository_ids: [seedData.repositoryId],
+      },
+    );
+
+    await testPage.goto(`/t/${task.id}`);
+    const session = new SessionPage(testPage);
+    await session.waitForLoad();
+
+    const title = testPage.locator('[data-testid="task-topbar"] [aria-current="page"]');
+    await expect(title).toHaveText("Topbar rename original", { timeout: 10_000 });
+
+    await title.dblclick();
+    const input = testPage.getByTestId("task-title-rename-input");
+    await expect(input).toBeVisible();
+    await input.fill("Topbar rename updated");
+    await input.press("Enter");
+
+    // Title re-renders from the store once the task.updated WS event lands.
+    await expect(title).toHaveText("Topbar rename updated", { timeout: 10_000 });
+
+    // Escape cancels without renaming.
+    await title.dblclick();
+    await input.fill("Should not persist");
+    await input.press("Escape");
+    await expect(input).not.toBeVisible();
+    await expect(title).toHaveText("Topbar rename updated");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds inline renaming of a task from the task page top bar: double-click the title to edit, **Enter** commits, **Escape**/blur cancels.
- Extracts the top-bar title into a new self-contained `TaskTopBarTitle` component that reuses the existing `useTaskActions().renameTaskById` (PATCH `/api/v1/tasks/:id`); the UI refreshes via the existing `task.updated` WebSocket event, same as the sidebar rename dialog.
- Frontend-only — no backend, API-client, store, or hook changes.

## Implementation notes
`TaskTopBarTitle` owns local edit state (`isEditing` + `draft`) and renders the exact previous breadcrumb markup when idle (`BreadcrumbPage` with `aria-current="page"`, truncate + tooltip), so existing layout e2e locators keep working. On Enter it trims the draft and only calls the API when the value is non-empty and actually changed, mirroring `TaskRenameDialog.canSubmit`; blur deliberately cancels rather than commits so Enter is the sole commit gesture. Archived tasks and the loading state (no `taskId`) stay read-only.

Two non-obvious decisions:
- **IME hardening**: Enter events fired during IME composition (`isComposing` or the trailing `keyCode === 229` Enter some IMEs report) are ignored, so confirming a CJK candidate doesn't accidentally commit the rename. A mid-edit archive (task archived while the input is open) also blocks the commit.
- **`aria-disabled` override**: `BreadcrumbPage` hardcodes `aria-disabled="true"`, which Playwright's actionability checks treat as non-interactive (double-click times out). The component now sets `aria-disabled={!canRename}` — semantically honest, and it restores `"true"` for archived/loading states. Pinned by unit tests.

Mobile is intentionally out of scope: the desktop-only `TaskTopBar` gets the shortcut, while mobile keeps its existing rename path (task-switcher context menu → `TaskRenameDialog`), so no workflow becomes desktop-only.

The one-line change in `agent-usage-section.test.tsx` fixes a pre-existing vitest 4 `vi.fn` generics typecheck error on `main` (from 55c8b461b) that blocked `pnpm run typecheck`.

## Test plan
- [x] New unit tests (`task-top-bar-title.test.tsx`, 12 cases): idle markup keeps `aria-current="page"`; double-click opens a pre-filled input; Enter renames with trimming; unchanged/whitespace-only Enter is a no-op; IME Enter (`isComposing` and `keyCode` 229) is ignored; mid-edit archive blocks the commit; Escape/blur cancel; archived and missing-`taskId` double-clicks are no-ops.
- [x] Existing `task-top-bar.test.tsx` still passes unmodified.
- [x] New e2e `topbar-rename.spec.ts`: creates a task, double-clicks the topbar title, renames via Enter, asserts the title updates after the `task.updated` WS round-trip, then verifies Escape cancels.
- [x] Existing layout e2e `task-topbar-long-title.spec.ts` re-verified green (its `[aria-current="page"]` locator is preserved).
- [x] `pnpm run typecheck` and `pnpm lint` clean in `apps/web`.
- [ ] Full CI suite on this PR.

## Risks & rollback
Low risk: reuses an existing authenticated PATCH endpoint and payload; no data or API changes. The main watch-out is layout-spec locator drift if the idle markup ever diverges from the old breadcrumb — it's currently byte-compatible apart from the dynamic `aria-disabled`. Rollback: revert the small edit to `task-top-bar.tsx` and delete the three new files (`task-top-bar-title.tsx`, its test, `topbar-rename.spec.ts`).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1702?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->