### PR TITLE
fix: stop task renames from wiping task repositories

### DIFF
--- a/apps/backend/internal/task/handlers/task_handlers.go
+++ b/apps/backend/internal/task/handlers/task_handlers.go
@@ -168,3 +168,16 @@ func convertToServiceRepos(repos []dto.TaskRepositoryInput) []service.TaskReposi
 	}
 	return result
 }
+
+// convertUpdateRepositories maps an update request's repositories field to the
+// service's replace semantics: an absent field (provided=false) must stay nil
+// so UpdateTask leaves task repositories untouched; a provided list — including
+// an explicitly empty one — replaces them. convertToServiceRepos alone returns
+// a non-nil empty slice for nil input, which wiped repositories on title-only
+// renames.
+func convertUpdateRepositories(provided bool, repos []dto.TaskRepositoryInput) []service.TaskRepositoryInput {
+	if !provided {
+		return nil
+	}
+	return convertToServiceRepos(repos)
+}

--- a/apps/backend/internal/task/handlers/task_http_handlers.go
+++ b/apps/backend/internal/task/handlers/task_http_handlers.go
@@ -1039,7 +1039,7 @@ func (h *TaskHandlers) httpUpdateTask(c *gin.Context) {
 		Description:  description,
 		Priority:     body.Priority,
 		State:        body.State,
-		Repositories: convertToServiceRepos(repos),
+		Repositories: convertUpdateRepositories(body.Repositories != nil, repos),
 		Position:     body.Position,
 		Metadata:     body.Metadata,
 	})

--- a/apps/backend/internal/task/handlers/task_update_repositories_test.go
+++ b/apps/backend/internal/task/handlers/task_update_repositories_test.go
@@ -43,6 +43,9 @@ func (m *captureUpdateTaskRepo) DeleteTaskRepositoriesByTask(_ context.Context, 
 }
 
 func (m *captureUpdateTaskRepo) ListTaskRepositories(_ context.Context, taskID string) ([]*models.TaskRepository, error) {
+	if m.deleteReposCalled {
+		return nil, nil
+	}
 	return []*models.TaskRepository{
 		{ID: "tr-1", TaskID: taskID, RepositoryID: "repo-1", BaseBranch: "main"},
 	}, nil
@@ -60,6 +63,21 @@ func newUpdateTaskHandlers(t *testing.T) (*TaskHandlers, *captureUpdateTaskRepo)
 		Reviews: repo,
 	}, nil, log, service.RepositoryDiscoveryConfig{})
 	return &TaskHandlers{service: svc, logger: log}, repo
+}
+
+func decodeTaskRepositoryIDs(t *testing.T, data []byte) []string {
+	t.Helper()
+	var resp struct {
+		Repositories []struct {
+			RepositoryID string `json:"repository_id"`
+		} `json:"repositories"`
+	}
+	require.NoError(t, json.Unmarshal(data, &resp))
+	ids := make([]string, 0, len(resp.Repositories))
+	for _, r := range resp.Repositories {
+		ids = append(ids, r.RepositoryID)
+	}
+	return ids
 }
 
 func doUpdateTaskRequest(t *testing.T, h *TaskHandlers, body string) *httptest.ResponseRecorder {
@@ -84,15 +102,7 @@ func TestHTTPUpdateTaskTitleOnlyPreservesRepositories(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
 	assert.False(t, repo.deleteReposCalled, "title-only update must not touch task repositories")
-
-	var resp struct {
-		Repositories []struct {
-			RepositoryID string `json:"repository_id"`
-		} `json:"repositories"`
-	}
-	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
-	require.Len(t, resp.Repositories, 1)
-	assert.Equal(t, "repo-1", resp.Repositories[0].RepositoryID)
+	assert.Equal(t, []string{"repo-1"}, decodeTaskRepositoryIDs(t, rec.Body.Bytes()))
 }
 
 func TestHTTPUpdateTaskExplicitEmptyRepositoriesClears(t *testing.T) {
@@ -103,6 +113,7 @@ func TestHTTPUpdateTaskExplicitEmptyRepositoriesClears(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
 	assert.True(t, repo.deleteReposCalled, "an explicitly empty repositories list must still clear")
+	assert.Empty(t, decodeTaskRepositoryIDs(t, rec.Body.Bytes()), "response must reflect the cleared repositories")
 }
 
 func TestWSUpdateTaskTitleOnlyPreservesRepositories(t *testing.T) {
@@ -119,6 +130,7 @@ func TestWSUpdateTaskTitleOnlyPreservesRepositories(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, ws.MessageTypeResponse, resp.Type)
 	assert.False(t, repo.deleteReposCalled, "title-only update must not touch task repositories")
+	assert.Equal(t, []string{"repo-1"}, decodeTaskRepositoryIDs(t, resp.Payload))
 }
 
 func TestConvertUpdateRepositories(t *testing.T) {

--- a/apps/backend/internal/task/handlers/task_update_repositories_test.go
+++ b/apps/backend/internal/task/handlers/task_update_repositories_test.go
@@ -1,0 +1,134 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kandev/kandev/internal/task/dto"
+	"github.com/kandev/kandev/internal/task/models"
+	"github.com/kandev/kandev/internal/task/service"
+	v1 "github.com/kandev/kandev/pkg/api/v1"
+	ws "github.com/kandev/kandev/pkg/websocket"
+)
+
+// captureUpdateTaskRepo backs the update-task tests: it serves a task with an
+// attached repository and records whether the task's repository rows were
+// wiped (the replace path always deletes before recreating).
+type captureUpdateTaskRepo struct {
+	mockRepository
+	deleteReposCalled bool
+}
+
+func (m *captureUpdateTaskRepo) GetTask(_ context.Context, id string) (*models.Task, error) {
+	return &models.Task{
+		ID:          id,
+		WorkspaceID: "ws-1",
+		WorkflowID:  "wf-1",
+		Title:       "Old title",
+		State:       v1.TaskStateTODO,
+	}, nil
+}
+
+func (m *captureUpdateTaskRepo) DeleteTaskRepositoriesByTask(_ context.Context, _ string) error {
+	m.deleteReposCalled = true
+	return nil
+}
+
+func (m *captureUpdateTaskRepo) ListTaskRepositories(_ context.Context, taskID string) ([]*models.TaskRepository, error) {
+	return []*models.TaskRepository{
+		{ID: "tr-1", TaskID: taskID, RepositoryID: "repo-1", BaseBranch: "main"},
+	}, nil
+}
+
+func newUpdateTaskHandlers(t *testing.T) (*TaskHandlers, *captureUpdateTaskRepo) {
+	t.Helper()
+	log := newTestLogger(t)
+	repo := &captureUpdateTaskRepo{}
+	svc := service.NewService(service.Repos{
+		Workspaces: repo, Tasks: repo, TaskRepos: repo,
+		Workflows: repo, Messages: repo, Turns: repo,
+		Sessions: repo, GitSnapshots: repo, RepoEntities: repo,
+		Executors: repo, Environments: repo, TaskEnvironments: repo,
+		Reviews: repo,
+	}, nil, log, service.RepositoryDiscoveryConfig{})
+	return &TaskHandlers{service: svc, logger: log}, repo
+}
+
+func doUpdateTaskRequest(t *testing.T, h *TaskHandlers, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Params = gin.Params{{Key: "id", Value: "task-1"}}
+	c.Request = httptest.NewRequest(http.MethodPatch, "/tasks/task-1", strings.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	h.httpUpdateTask(c)
+	return rec
+}
+
+// Regression: a title-only PATCH (rename) used to wipe every task_repositories
+// row because the absent repositories field was converted to a non-nil empty
+// slice, which Service.UpdateTask treats as an explicit replace-with-nothing.
+func TestHTTPUpdateTaskTitleOnlyPreservesRepositories(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h, repo := newUpdateTaskHandlers(t)
+
+	rec := doUpdateTaskRequest(t, h, `{"title": "Renamed"}`)
+
+	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+	assert.False(t, repo.deleteReposCalled, "title-only update must not touch task repositories")
+
+	var resp struct {
+		Repositories []struct {
+			RepositoryID string `json:"repository_id"`
+		} `json:"repositories"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp.Repositories, 1)
+	assert.Equal(t, "repo-1", resp.Repositories[0].RepositoryID)
+}
+
+func TestHTTPUpdateTaskExplicitEmptyRepositoriesClears(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h, repo := newUpdateTaskHandlers(t)
+
+	rec := doUpdateTaskRequest(t, h, `{"repositories": []}`)
+
+	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+	assert.True(t, repo.deleteReposCalled, "an explicitly empty repositories list must still clear")
+}
+
+func TestWSUpdateTaskTitleOnlyPreservesRepositories(t *testing.T) {
+	h, repo := newUpdateTaskHandlers(t)
+
+	msg, err := ws.NewRequest("msg-1", ws.ActionTaskUpdate, map[string]any{
+		"id":    "task-1",
+		"title": "Renamed",
+	})
+	require.NoError(t, err)
+
+	resp, err := h.wsUpdateTask(context.Background(), msg)
+
+	require.NoError(t, err)
+	require.Equal(t, ws.MessageTypeResponse, resp.Type)
+	assert.False(t, repo.deleteReposCalled, "title-only update must not touch task repositories")
+}
+
+func TestConvertUpdateRepositories(t *testing.T) {
+	assert.Nil(t, convertUpdateRepositories(false, nil), "absent field must stay nil")
+
+	empty := convertUpdateRepositories(true, nil)
+	require.NotNil(t, empty, "provided empty list must map to a non-nil slice so it clears")
+	assert.Len(t, empty, 0)
+
+	converted := convertUpdateRepositories(true, []dto.TaskRepositoryInput{{RepositoryID: "repo-1"}})
+	require.Len(t, converted, 1)
+	assert.Equal(t, "repo-1", converted[0].RepositoryID)
+}

--- a/apps/backend/internal/task/handlers/task_ws_handlers.go
+++ b/apps/backend/internal/task/handlers/task_ws_handlers.go
@@ -285,7 +285,7 @@ func (h *TaskHandlers) wsUpdateTask(ctx context.Context, msg *ws.Message) (*ws.M
 		Description:  description,
 		Priority:     req.Priority,
 		State:        req.State,
-		Repositories: convertToServiceRepos(repos),
+		Repositories: convertUpdateRepositories(req.Repositories != nil, repos),
 		Position:     req.Position,
 		Metadata:     req.Metadata,
 	})


### PR DESCRIPTION
## Summary
- Renaming a task (top-bar inline rename or the sidebar rename dialog) permanently deleted all of the task's `task_repositories` rows, so the task dropped out of repository-filtered/grouped sidebar views. This was server-side data loss, not a frontend cache issue.
- Root cause: both update handlers (`httpUpdateTask` and `wsUpdateTask`) unconditionally ran the request's repositories field through `convertToServiceRepos`, which turns a nil slice into a **non-nil empty** slice. `Service.UpdateTask` treats any non-nil `Repositories` as "replace", so a title-only PATCH became "replace repositories with nothing".
- Fix: a small `convertUpdateRepositories(provided, repos)` helper maps "field absent" → `nil` (leave repositories untouched) and "field provided, even empty" → converted slice (replace/clear), used at both update call sites.

## Implementation notes
The fix is handler-layer only. The service's replace semantics (`nil` = leave untouched, non-nil empty = clear) are correct and relied upon elsewhere — the bug was that the handlers erased the nil/non-nil distinction. Making `convertToServiceRepos` itself return nil for nil input was rejected because it would break the explicit-`[]`-clears contract at the update sites and silently change four other call sites (create paths and the explicit replace endpoint, which are intentional).

The explicit-clear contract is preserved: JSON `"repositories": []` unmarshals to a non-nil empty slice → `provided == true` → repositories are still cleared. `"repositories": null` and an absent field both map to nil → preserved. As a side effect, all other partial updates through these endpoints (description-only, metadata-only, state, position, priority) also become non-destructive to repositories.

Tests live in a new file `task_update_repositories_test.go` (rather than appended to `task_http_handlers_test.go`) to stay under revive's 800-line file-length limit.

## Test plan
- [x] `TestHTTPUpdateTaskTitleOnlyPreservesRepositories` — title-only PATCH returns 200, `DeleteTaskRepositoriesByTask` not called, response still lists the repo (fails on `main`, passes with the fix)
- [x] `TestWSUpdateTaskTitleOnlyPreservesRepositories` — same guarantee for the WS `task.update` path (fails on `main`, passes with the fix)
- [x] `TestHTTPUpdateTaskExplicitEmptyRepositoriesClears` — explicit `"repositories": []` still clears (contract guard)
- [x] `TestConvertUpdateRepositories` — helper unit cases: absent → nil; provided empty → non-nil empty; provided list → converted
- [x] `go test ./internal/task/handlers/ -race` and full `make -C apps/backend test` pass
- [x] `make -C apps/backend fmt && make -C apps/backend lint` clean; changed-file CI-style `golangci-lint run --new-from-rev` clean
- [ ] CI green on this PR

## Risks & rollback
Blast radius is one 8-line helper plus two one-line call-site edits; no API shape change, no migration. The only behavior change beyond the fix: a client relying on "PATCH without a repositories field clears repositories" would break — no such client exists in-repo (the edit dialog always sends `repositories`, and a dedicated replace endpoint exists). Rollback is a single-commit revert with no data cleanup. Tasks renamed before this fix have already lost their repository rows; this change prevents future loss but cannot restore them (users re-attach via task settings / add-branch).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1705?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->