### PR TITLE
feat: add strictly opt-in anonymous product telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Organize work across kanban and pipeline views with opinionated workflows and ex
 
 Run it locally or self-host it on your own infrastructure and access it from anywhere via [Tailscale](https://tailscale.com/) or any VPN.
 
-Open source, multi-provider, no telemetry, not tied to any cloud.
+Open source, multi-provider, telemetry strictly opt-in, not tied to any cloud.
 
 ## Vision
 
@@ -252,7 +252,7 @@ There are a few similar tools in this space, and new ones appearing everyday. He
 - **Remote runtimes** - Run agents on remote servers via SSH, Docker hosts, and cloud environments, not just your local machine.
 - **Multi-provider** - Use Claude Code, Codex, Copilot, Gemini, Amp, Auggie, OpenCode, Cursor, Devin, Qwen, Droid, iFlow, Kilocode, Pi, Kimi, Kiro, Qoder, Trae, Oh My Pi, and Grok side by side. Not locked to one vendor.
 - **CLI passthrough and chat** - Interact with agents through structured chat messages or, where supported, drop into raw CLI mode for full agent TUI capabilities.
-- **Open source and self-hostable** - No vendor lock-in, no telemetry, runs on your infrastructure.
+- **Open source and self-hostable** - No vendor lock-in, no telemetry unless you opt in, runs on your infrastructure.
 
 ## Contributing
 

--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -97,6 +97,7 @@ apps/backend/
 │   ├── secrets/          # Secret management
 │   ├── sprites/          # Sprites AI integration
 │   ├── sysprompt/        # System prompt injection
+│   ├── telemetry/        # Strictly opt-in product telemetry (consent, event allowlist, PostHog EU sink) — ADR 0039
 │   ├── tools/            # Tool integrations
 │   ├── user/             # User management
 │   ├── utility/          # Shared utility functions

--- a/apps/backend/internal/agent/runtime/lifecycle/event_types.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/event_types.go
@@ -18,8 +18,12 @@ type AgentEventPayload struct {
 	StartedAt        time.Time  `json:"started_at"`
 	FinishedAt       *time.Time `json:"finished_at,omitempty"`
 	ErrorMessage     string     `json:"error_message,omitempty"`
-	ExitCode         *int       `json:"exit_code,omitempty"`
-	PromptGeneration uint64     `json:"prompt_generation,omitempty"`
+	// ErrorCode / ErrorPhase are the routingerr classification enums for
+	// failed executions (e.g. "rate_limited" / "prompt_send").
+	ErrorCode        string `json:"error_code,omitempty"`
+	ErrorPhase       string `json:"error_phase,omitempty"`
+	ExitCode         *int   `json:"exit_code,omitempty"`
+	PromptGeneration uint64 `json:"prompt_generation,omitempty"`
 }
 
 // AgentctlEventPayload is the payload for agentctl lifecycle events (starting, ready, error).

--- a/apps/backend/internal/agent/runtime/lifecycle/events.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/events.go
@@ -65,6 +65,8 @@ func newAgentEventPayload(execution *AgentExecution) AgentEventPayload {
 		StartedAt:        execution.StartedAt,
 		FinishedAt:       execution.FinishedAt,
 		ErrorMessage:     execution.ErrorMessage,
+		ErrorCode:        execution.ErrorCode,
+		ErrorPhase:       execution.ErrorPhase,
 		ExitCode:         execution.ExitCode,
 		PromptGeneration: execution.promptGeneration,
 	}

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_interaction.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_interaction.go
@@ -1273,7 +1273,15 @@ func (m *Manager) MarkCompleted(executionID string, exitCode int, errorMessage s
 	eventType := events.AgentCompleted
 	if execution.Status == v1.AgentStatusFailed {
 		eventType = events.AgentFailed
-		m.classifyAndMaybeRemediate(execution, exitCode, errorMessage)
+		// Stamp the classification enums onto the execution so the
+		// AgentFailed payload published below carries them (opt-in
+		// telemetry forwards only these, never ErrorMessage).
+		if e := m.classifyAndMaybeRemediate(execution, exitCode, errorMessage); e != nil {
+			_ = m.executionStore.WithLock(executionID, func(exec *AgentExecution) {
+				exec.ErrorCode = string(e.Code)
+				exec.ErrorPhase = string(e.Phase)
+			})
+		}
 	}
 	m.eventPublisher.PublishAgentEvent(context.Background(), eventType, execution)
 
@@ -1289,7 +1297,10 @@ func (m *Manager) MarkCompleted(executionID string, exitCode int, errorMessage s
 // The remediation hook is injectable via Manager.remediateNpxCache;
 // production wiring points it at routingerr.RemediateNpxCache. Tests
 // stub it to avoid touching the real filesystem.
-func (m *Manager) classifyAndMaybeRemediate(execution *AgentExecution, exitCode int, errorMessage string) {
+//
+// Returns the classified error (nil when classification produced
+// nothing) so the caller can persist the enums under the store lock.
+func (m *Manager) classifyAndMaybeRemediate(execution *AgentExecution, exitCode int, errorMessage string) *routingerr.Error {
 	phase := routingerr.PhaseSessionInit
 	if execution.sessionInitialized {
 		phase = routingerr.PhasePromptSend
@@ -1306,7 +1317,7 @@ func (m *Manager) classifyAndMaybeRemediate(execution *AgentExecution, exitCode 
 		Stderr:     errorMessage,
 	})
 	if e == nil {
-		return
+		return nil
 	}
 	m.logger.Info("agent failure classified for provider routing",
 		zap.String("execution_id", execution.ID),
@@ -1323,7 +1334,7 @@ func (m *Manager) classifyAndMaybeRemediate(execution *AgentExecution, exitCode 
 		zap.String("remediation_path", e.RemediationPath))
 
 	if e.Code != routingerr.CodeNpxCacheCorrupted || e.RemediationPath == "" {
-		return
+		return e
 	}
 	remediate := m.remediateNpxCache
 	path := e.RemediationPath
@@ -1340,6 +1351,7 @@ func (m *Manager) classifyAndMaybeRemediate(execution *AgentExecution, exitCode 
 				zap.Error(err))
 		}
 	}()
+	return e
 }
 
 // RespondToPermission sends a response to an agent's permission request.

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_lifecycle_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_lifecycle_test.go
@@ -72,6 +72,20 @@ func TestManager_MarkCompleted_Failure(t *testing.T) {
 	if got.ExitCode == nil || *got.ExitCode != 1 {
 		t.Errorf("expected exit code 1, got %v", got.ExitCode)
 	}
+
+	// The failure boundary must stamp the routingerr classification enums so
+	// the AgentFailed payload (and opt-in telemetry) can report failure
+	// causes without the free-text message.
+	if got.ErrorCode == "" {
+		t.Error("expected ErrorCode to be stamped by classification")
+	}
+	if got.ErrorPhase != "session_init" {
+		t.Errorf("expected ErrorPhase 'session_init', got %q", got.ErrorPhase)
+	}
+	payload := newAgentEventPayload(got)
+	if payload.ErrorCode != got.ErrorCode || payload.ErrorPhase != got.ErrorPhase {
+		t.Errorf("payload must carry classification enums, got %+v", payload)
+	}
 }
 
 func TestManager_MarkCompleted_Idempotent(t *testing.T) {

--- a/apps/backend/internal/agent/runtime/lifecycle/types.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/types.go
@@ -42,6 +42,13 @@ type AgentExecution struct {
 	FinishedAt        *time.Time
 	ExitCode          *int
 	ErrorMessage      string
+	// ErrorCode / ErrorPhase carry the routingerr classification of a failed
+	// execution (closed enums, never free text). Set by
+	// classifyAndMaybeRemediate before the AgentFailed event publishes so
+	// downstream consumers (e.g. telemetry) can report failure causes
+	// without ever touching ErrorMessage.
+	ErrorCode         string
+	ErrorPhase        string
 	Metadata          map[string]interface{}
 	promptGeneration  uint64
 	promptLifecycleMu sync.Mutex

--- a/apps/backend/internal/backendapp/helpers.go
+++ b/apps/backend/internal/backendapp/helpers.go
@@ -69,6 +69,7 @@ import (
 	"github.com/kandev/kandev/internal/task/models"
 	sqliterepo "github.com/kandev/kandev/internal/task/repository/sqlite"
 	taskservice "github.com/kandev/kandev/internal/task/service"
+	"github.com/kandev/kandev/internal/telemetry"
 	usercontroller "github.com/kandev/kandev/internal/user/controller"
 	userhandlers "github.com/kandev/kandev/internal/user/handlers"
 	utilitycontroller "github.com/kandev/kandev/internal/utility/controller"
@@ -449,6 +450,7 @@ type routeParams struct {
 	eventBus                bus.EventBus
 	services                *Services
 	systemSvc               *systemsvc.Service
+	telemetrySvc            *telemetry.Service
 	runtimeFlagsSvc         *runtimeflags.Service
 	agentSettingsController *agentsettingscontroller.Controller
 	agentSettingsRepo       settingsstore.Repository
@@ -938,6 +940,10 @@ func registerSecondaryRoutes(
 	registerSystemRoutes(p)
 	if p.runtimeFlagsSvc != nil {
 		runtimeflags.RegisterRoutes(p.router, p.runtimeFlagsSvc)
+	}
+
+	if p.telemetrySvc != nil {
+		telemetry.RegisterRoutes(p.router, p.telemetrySvc)
 	}
 
 	if p.repoCloner != nil {

--- a/apps/backend/internal/backendapp/main.go
+++ b/apps/backend/internal/backendapp/main.go
@@ -111,6 +111,9 @@ import (
 	// System pages (status / database / backups / logs / updates / about)
 	systemsvc "github.com/kandev/kandev/internal/system"
 
+	// Opt-in product telemetry
+	"github.com/kandev/kandev/internal/telemetry"
+
 	// Database
 	"github.com/kandev/kandev/internal/db"
 
@@ -724,10 +727,21 @@ func startGatewayAndServe(
 	gateways.RegisterSystemNotifications(ctx, eventBus, gateway.Hub, log)
 
 	// ============================================
+	// TELEMETRY (strictly opt-in; see internal/telemetry)
+	// ============================================
+	telemetrySvc, telemetryErr := telemetry.Provide(cfg, log, dbPool, eventBus, Version)
+	if telemetryErr != nil {
+		log.Warn("Telemetry service unavailable (non-fatal)", zap.Error(telemetryErr))
+	} else {
+		telemetrySvc.Start(ctx)
+		addCleanup(func() error { telemetrySvc.Stop(); return nil })
+	}
+
+	// ============================================
 	// HTTP SERVER
 	// ============================================
 	server := buildHTTPServer(cfg, log, gateway, repos, services, agentSettingsController,
-		lifecycleMgr, eventBus, orchestratorSvc, notificationCtrl, msgCreator, agentRegistry, hostUtilityMgr, addCleanup, repoCloner, systemSvc)
+		lifecycleMgr, eventBus, orchestratorSvc, notificationCtrl, msgCreator, agentRegistry, hostUtilityMgr, addCleanup, repoCloner, systemSvc, telemetrySvc)
 
 	port := cfg.Server.Port
 	if port == 0 {
@@ -1613,6 +1627,7 @@ func buildHTTPServer(
 	addCleanup func(func() error),
 	repoCloner *repoclone.Cloner,
 	systemSvc *systemsvc.Service,
+	telemetrySvc *telemetry.Service,
 ) *http.Server {
 	gin.SetMode(gin.ReleaseMode)
 	router := gin.New()
@@ -1639,6 +1654,7 @@ func buildHTTPServer(
 		eventBus:                eventBus,
 		services:                services,
 		systemSvc:               systemSvc,
+		telemetrySvc:            telemetrySvc,
 		runtimeFlagsSvc:         services.RuntimeFlags,
 		agentSettingsController: agentSettingsController,
 		agentSettingsRepo:       repos.AgentSettings,

--- a/apps/backend/internal/common/config/config.go
+++ b/apps/backend/internal/common/config/config.go
@@ -164,9 +164,10 @@ type VoiceConfig struct {
 }
 
 // TelemetryConfig holds configuration for opt-in product telemetry.
-// Emission additionally requires the user's stored consent and is blocked
-// outright by the KANDEV_TELEMETRY=off / DO_NOT_TRACK=1 env kill switches,
-// which internal/telemetry reads directly from the process environment.
+// Emission additionally requires the user's stored consent — the single
+// user-facing control — and is blocked outright by DO_NOT_TRACK=1 and in
+// e2e mode (KANDEV_E2E_MOCK), which internal/telemetry reads directly
+// from the process environment.
 type TelemetryConfig struct {
 	// Endpoint overrides the analytics ingestion host. Empty means the
 	// built-in default (PostHog EU). Set via KANDEV_TELEMETRY_ENDPOINT.

--- a/apps/backend/internal/common/config/config.go
+++ b/apps/backend/internal/common/config/config.go
@@ -43,6 +43,7 @@ type Config struct {
 	Office              OfficeConfig              `mapstructure:"office"`
 	Voice               VoiceConfig               `mapstructure:"voice"`
 	Features            FeaturesConfig            `mapstructure:"features"`
+	Telemetry           TelemetryConfig           `mapstructure:"telemetry"`
 }
 
 // expandTilde expands a leading "~/" to the user's home directory.
@@ -160,6 +161,22 @@ type VoiceConfig struct {
 	// OpenAIAPIKey is the API key used to call OpenAI's Whisper transcription
 	// endpoint. Set via KANDEV_VOICE_OPENAI_API_KEY.
 	OpenAIAPIKey string `mapstructure:"openAIApiKey"`
+}
+
+// TelemetryConfig holds configuration for opt-in product telemetry.
+// Emission additionally requires the user's stored consent and is blocked
+// outright by the KANDEV_TELEMETRY=off / DO_NOT_TRACK=1 env kill switches,
+// which internal/telemetry reads directly from the process environment.
+type TelemetryConfig struct {
+	// Endpoint overrides the analytics ingestion host. Empty means the
+	// built-in default (PostHog EU). Set via KANDEV_TELEMETRY_ENDPOINT.
+	Endpoint string `mapstructure:"endpoint"`
+	// APIKey overrides the built-in write-only project API key.
+	// Set via KANDEV_TELEMETRY_API_KEY.
+	APIKey string `mapstructure:"apiKey"`
+	// Debug logs every outgoing telemetry payload locally so users can
+	// inspect exactly what would be sent. Set via KANDEV_TELEMETRY_DEBUG.
+	Debug bool `mapstructure:"debug"`
 }
 
 // FeaturesConfig is the central registry of runtime feature flags. Every flag
@@ -336,6 +353,12 @@ func setDefaults(v *viper.Viper) {
 	// Voice defaults
 	v.SetDefault("voice.openAIApiKey", "")
 
+	// Telemetry defaults — empty endpoint/apiKey mean "use the built-in
+	// PostHog EU defaults" declared in internal/telemetry.
+	v.SetDefault("telemetry.endpoint", "")
+	v.SetDefault("telemetry.apiKey", "")
+	v.SetDefault("telemetry.debug", false)
+
 	// Feature-flag defaults live in ./features.yaml (symlinked to
 	// apps/backend/internal/features/features.yaml). LoadWithPath applies
 	// them via features.ApplyDefaults after this function returns so the
@@ -453,6 +476,7 @@ func LoadWithPath(configPath string) (*Config, error) {
 	_ = v.BindEnv("debug.devMode", "KANDEV_DEBUG_DEV_MODE")
 	_ = v.BindEnv("debug.pprofEnabled", "KANDEV_DEBUG_PPROF_ENABLED")
 	_ = v.BindEnv("voice.openAIApiKey", "KANDEV_VOICE_OPENAI_API_KEY")
+	_ = v.BindEnv("telemetry.apiKey", "KANDEV_TELEMETRY_API_KEY")
 
 	// Configure config file
 	v.SetConfigName("config")

--- a/apps/backend/internal/profiles/profiles.yaml
+++ b/apps/backend/internal/profiles/profiles.yaml
@@ -117,6 +117,19 @@ debug:
     dev:  "true"
     e2e:  ""
 
+# ── Telemetry ─────────────────────────────────────────────────────
+# Opt-in product telemetry (PostHog EU). The env var is a hard kill
+# switch checked before the user's stored consent: "off" disables all
+# collection and hides the consent prompts. Prod leaves it unset so
+# the (strictly opt-in) consent flow is available; dev and e2e force
+# it off so local development and test runs can never emit events.
+# DO_NOT_TRACK=1 is honoured unconditionally as well.
+telemetry:
+  KANDEV_TELEMETRY:
+    prod: ""
+    dev:  "off"
+    e2e:  "off"
+
 # ── E2E test tuning ───────────────────────────────────────────────
 # Behaviour knobs that only matter when running playwright. These
 # don't belong in dev (would mask real interactions) and never in

--- a/apps/backend/internal/profiles/profiles.yaml
+++ b/apps/backend/internal/profiles/profiles.yaml
@@ -117,19 +117,6 @@ debug:
     dev:  "true"
     e2e:  ""
 
-# ── Telemetry ─────────────────────────────────────────────────────
-# Opt-in product telemetry (PostHog EU). The env var is a hard kill
-# switch checked before the user's stored consent: "off" disables all
-# collection and hides the consent prompts. Prod leaves it unset so
-# the (strictly opt-in) consent flow is available; dev and e2e force
-# it off so local development and test runs can never emit events.
-# DO_NOT_TRACK=1 is honoured unconditionally as well.
-telemetry:
-  KANDEV_TELEMETRY:
-    prod: ""
-    dev:  "off"
-    e2e:  "off"
-
 # ── E2E test tuning ───────────────────────────────────────────────
 # Behaviour knobs that only matter when running playwright. These
 # don't belong in dev (would mask real interactions) and never in

--- a/apps/backend/internal/telemetry/consent.go
+++ b/apps/backend/internal/telemetry/consent.go
@@ -76,27 +76,65 @@ func (s *Service) Consent() ConsentState {
 // install UUID (only then — never before consent) and emits an immediate
 // heartbeat so opted-in installs register without waiting a day. Denying
 // clears the install ID and drops anything still queued.
+//
+// Serialized under consentMu so concurrent requests cannot interleave
+// (e.g. two grants minting different install IDs).
 func (s *Service) SetConsent(ctx context.Context, status ConsentStatus) (ConsentState, error) {
 	if status != ConsentGranted && status != ConsentDenied {
 		return ConsentState{}, fmt.Errorf("invalid consent status %q", status)
 	}
-	installID := ""
+	s.consentMu.Lock()
+	defer s.consentMu.Unlock()
 	if status == ConsentGranted {
-		installID = s.currentOrNewInstallID()
+		return s.grantLocked(ctx)
 	}
-	if err := s.persistConsent(ctx, status, installID); err != nil {
+	return s.denyLocked(ctx)
+}
+
+// grantLocked persists the install ID and timestamp before the consent
+// flag, so a mid-write failure can never leave a durable grant without an
+// install ID. In-memory state (which gates emission) flips only after
+// everything is on disk.
+func (s *Service) grantLocked(ctx context.Context) (ConsentState, error) {
+	installID := s.currentOrNewInstallID()
+	if err := s.store.Save(ctx, installIDKey, []byte(installID)); err != nil {
+		return ConsentState{}, fmt.Errorf("save telemetry install id: %w", err)
+	}
+	if err := s.saveConsentTimestamp(ctx); err != nil {
 		return ConsentState{}, err
 	}
+	if err := s.store.Save(ctx, consentKey, []byte(ConsentGranted)); err != nil {
+		return ConsentState{}, fmt.Errorf("save telemetry consent: %w", err)
+	}
 	s.mu.Lock()
-	s.consent = status
+	s.consent = ConsentGranted
 	s.installID = installID
 	s.mu.Unlock()
 
-	if status == ConsentGranted {
-		s.enqueue(Event{Name: EventTelemetryEnabled})
-		s.enqueue(Event{Name: EventInstallHeartbeat})
-	} else {
-		s.drainQueue()
+	s.enqueue(Event{Name: EventTelemetryEnabled})
+	s.enqueue(Event{Name: EventInstallHeartbeat})
+	return s.Consent(), nil
+}
+
+// denyLocked flips the in-memory gate and drops the queue BEFORE touching
+// the store: emission must stop immediately even if persistence fails
+// (the error still surfaces so the UI can tell the user the preference
+// may not survive a restart).
+func (s *Service) denyLocked(ctx context.Context) (ConsentState, error) {
+	s.mu.Lock()
+	s.consent = ConsentDenied
+	s.installID = ""
+	s.mu.Unlock()
+	s.drainQueue()
+
+	if err := s.store.Save(ctx, installIDKey, []byte("")); err != nil {
+		return ConsentState{}, fmt.Errorf("clear telemetry install id: %w", err)
+	}
+	if err := s.saveConsentTimestamp(ctx); err != nil {
+		return ConsentState{}, err
+	}
+	if err := s.store.Save(ctx, consentKey, []byte(ConsentDenied)); err != nil {
+		return ConsentState{}, fmt.Errorf("save telemetry consent: %w", err)
 	}
 	return s.Consent(), nil
 }
@@ -110,13 +148,7 @@ func (s *Service) currentOrNewInstallID() string {
 	return uuid.New().String()
 }
 
-func (s *Service) persistConsent(ctx context.Context, status ConsentStatus, installID string) error {
-	if err := s.store.Save(ctx, consentKey, []byte(status)); err != nil {
-		return fmt.Errorf("save telemetry consent: %w", err)
-	}
-	if err := s.store.Save(ctx, installIDKey, []byte(installID)); err != nil {
-		return fmt.Errorf("save telemetry install id: %w", err)
-	}
+func (s *Service) saveConsentTimestamp(ctx context.Context) error {
 	timestamp := time.Now().UTC().Format(time.RFC3339)
 	if err := s.store.Save(ctx, consentUpdatedAtKey, []byte(timestamp)); err != nil {
 		return fmt.Errorf("save telemetry consent timestamp: %w", err)

--- a/apps/backend/internal/telemetry/consent.go
+++ b/apps/backend/internal/telemetry/consent.go
@@ -1,0 +1,125 @@
+package telemetry
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ConsentStatus is the tri-state opt-in record. "unasked" drives the
+// one-time onboarding prompt; only "granted" ever allows emission.
+type ConsentStatus string
+
+const (
+	ConsentUnasked ConsentStatus = "unasked"
+	ConsentGranted ConsentStatus = "granted"
+	ConsentDenied  ConsentStatus = "denied"
+)
+
+// Settings keys on the install-wide settings table.
+const (
+	consentKey          = "telemetry.consent"
+	installIDKey        = "telemetry.install_id"
+	consentUpdatedAtKey = "telemetry.consent_updated_at"
+)
+
+// SettingsStore is the slice of internal/system/settings.Store the
+// service needs; narrowed to an interface so tests can use an in-memory
+// fake without a database pool.
+type SettingsStore interface {
+	Get(ctx context.Context, key string) ([]byte, bool, error)
+	Save(ctx context.Context, key string, value []byte) error
+}
+
+// ConsentState is the wire shape of GET/PUT /api/v1/telemetry/consent.
+type ConsentState struct {
+	Status      ConsentStatus `json:"status"`
+	InstallID   string        `json:"install_id,omitempty"`
+	EnvDisabled bool          `json:"env_disabled"`
+}
+
+// loadConsent reads the persisted consent + install ID into the service's
+// in-memory copies. Missing rows mean "unasked".
+func (s *Service) loadConsent(ctx context.Context) error {
+	status := ConsentUnasked
+	raw, found, err := s.store.Get(ctx, consentKey)
+	if err != nil {
+		return fmt.Errorf("load telemetry consent: %w", err)
+	}
+	if found {
+		switch ConsentStatus(raw) {
+		case ConsentGranted, ConsentDenied:
+			status = ConsentStatus(raw)
+		}
+	}
+	installID := ""
+	if raw, found, err = s.store.Get(ctx, installIDKey); err == nil && found {
+		installID = string(raw)
+	}
+	s.mu.Lock()
+	s.consent = status
+	s.installID = installID
+	s.mu.Unlock()
+	return nil
+}
+
+// Consent returns the current consent state for the HTTP surface.
+func (s *Service) Consent() ConsentState {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return ConsentState{Status: s.consent, InstallID: s.installID, EnvDisabled: s.opts.EnvDisabled}
+}
+
+// SetConsent persists a grant or denial. Granting mints the anonymous
+// install UUID (only then — never before consent) and emits an immediate
+// heartbeat so opted-in installs register without waiting a day. Denying
+// clears the install ID and drops anything still queued.
+func (s *Service) SetConsent(ctx context.Context, status ConsentStatus) (ConsentState, error) {
+	if status != ConsentGranted && status != ConsentDenied {
+		return ConsentState{}, fmt.Errorf("invalid consent status %q", status)
+	}
+	installID := ""
+	if status == ConsentGranted {
+		installID = s.currentOrNewInstallID()
+	}
+	if err := s.persistConsent(ctx, status, installID); err != nil {
+		return ConsentState{}, err
+	}
+	s.mu.Lock()
+	s.consent = status
+	s.installID = installID
+	s.mu.Unlock()
+
+	if status == ConsentGranted {
+		s.enqueue(Event{Name: EventTelemetryEnabled})
+		s.enqueue(Event{Name: EventInstallHeartbeat})
+	} else {
+		s.drainQueue()
+	}
+	return s.Consent(), nil
+}
+
+func (s *Service) currentOrNewInstallID() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.installID != "" {
+		return s.installID
+	}
+	return uuid.New().String()
+}
+
+func (s *Service) persistConsent(ctx context.Context, status ConsentStatus, installID string) error {
+	if err := s.store.Save(ctx, consentKey, []byte(status)); err != nil {
+		return fmt.Errorf("save telemetry consent: %w", err)
+	}
+	if err := s.store.Save(ctx, installIDKey, []byte(installID)); err != nil {
+		return fmt.Errorf("save telemetry install id: %w", err)
+	}
+	timestamp := time.Now().UTC().Format(time.RFC3339)
+	if err := s.store.Save(ctx, consentUpdatedAtKey, []byte(timestamp)); err != nil {
+		return fmt.Errorf("save telemetry consent timestamp: %w", err)
+	}
+	return nil
+}

--- a/apps/backend/internal/telemetry/consent_test.go
+++ b/apps/backend/internal/telemetry/consent_test.go
@@ -1,0 +1,87 @@
+package telemetry
+
+import (
+	"context"
+	"testing"
+)
+
+func TestConsentDefaultsToUnasked(t *testing.T) {
+	svc, _, _ := newTestService(t, nil, Options{})
+	if err := svc.loadConsent(context.Background()); err != nil {
+		t.Fatalf("loadConsent: %v", err)
+	}
+	state := svc.Consent()
+	if state.Status != ConsentUnasked {
+		t.Fatalf("expected unasked, got %q", state.Status)
+	}
+	if state.InstallID != "" {
+		t.Fatalf("expected no install id before consent, got %q", state.InstallID)
+	}
+}
+
+func TestGrantMintsInstallIDAndPersists(t *testing.T) {
+	svc, store, _ := newTestService(t, nil, Options{})
+	state, err := svc.SetConsent(context.Background(), ConsentGranted)
+	if err != nil {
+		t.Fatalf("SetConsent: %v", err)
+	}
+	if state.Status != ConsentGranted || state.InstallID == "" {
+		t.Fatalf("expected granted with install id, got %+v", state)
+	}
+
+	// A fresh service over the same store must see the same state.
+	reloaded := NewService(store, nil, newTestLogger(), Options{Sink: &fakeSink{}})
+	if err := reloaded.loadConsent(context.Background()); err != nil {
+		t.Fatalf("loadConsent: %v", err)
+	}
+	got := reloaded.Consent()
+	if got.Status != ConsentGranted || got.InstallID != state.InstallID {
+		t.Fatalf("reload mismatch: %+v vs %+v", got, state)
+	}
+}
+
+func TestGrantIsStableAcrossRepeatedGrants(t *testing.T) {
+	svc, _, _ := newTestService(t, nil, Options{})
+	first, err := svc.SetConsent(context.Background(), ConsentGranted)
+	if err != nil {
+		t.Fatalf("SetConsent: %v", err)
+	}
+	second, err := svc.SetConsent(context.Background(), ConsentGranted)
+	if err != nil {
+		t.Fatalf("SetConsent: %v", err)
+	}
+	if first.InstallID != second.InstallID {
+		t.Fatalf("install id must be stable: %q vs %q", first.InstallID, second.InstallID)
+	}
+}
+
+func TestDenyClearsInstallID(t *testing.T) {
+	svc, store, _ := newTestService(t, nil, Options{})
+	if _, err := svc.SetConsent(context.Background(), ConsentGranted); err != nil {
+		t.Fatalf("SetConsent(granted): %v", err)
+	}
+	state, err := svc.SetConsent(context.Background(), ConsentDenied)
+	if err != nil {
+		t.Fatalf("SetConsent(denied): %v", err)
+	}
+	if state.Status != ConsentDenied || state.InstallID != "" {
+		t.Fatalf("expected denied without install id, got %+v", state)
+	}
+
+	reloaded := NewService(store, nil, newTestLogger(), Options{Sink: &fakeSink{}})
+	if err := reloaded.loadConsent(context.Background()); err != nil {
+		t.Fatalf("loadConsent: %v", err)
+	}
+	if got := reloaded.Consent(); got.Status != ConsentDenied || got.InstallID != "" {
+		t.Fatalf("reload after deny mismatch: %+v", got)
+	}
+}
+
+func TestSetConsentRejectsInvalidStatus(t *testing.T) {
+	svc, _, _ := newTestService(t, nil, Options{})
+	for _, status := range []ConsentStatus{ConsentUnasked, "yes", ""} {
+		if _, err := svc.SetConsent(context.Background(), status); err == nil {
+			t.Fatalf("expected error for status %q", status)
+		}
+	}
+}

--- a/apps/backend/internal/telemetry/handlers.go
+++ b/apps/backend/internal/telemetry/handlers.go
@@ -1,0 +1,67 @@
+package telemetry
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// Handler exposes the consent record and the frontend event intake.
+type Handler struct {
+	svc *Service
+}
+
+// RegisterRoutes mounts the telemetry HTTP surface. The routes exist
+// even when telemetry is env-disabled so the frontend can read that
+// state (and hide its consent prompts) instead of guessing from 404s.
+func RegisterRoutes(router gin.IRouter, svc *Service) {
+	h := &Handler{svc: svc}
+	api := router.Group("/api/v1/telemetry")
+	api.GET("/consent", h.getConsent)
+	api.PUT("/consent", h.putConsent)
+	api.POST("/events", h.postEvents)
+}
+
+func (h *Handler) getConsent(c *gin.Context) {
+	c.JSON(http.StatusOK, h.svc.Consent())
+}
+
+type putConsentRequest struct {
+	Status ConsentStatus `json:"status"`
+}
+
+func (h *Handler) putConsent(c *gin.Context) {
+	var req putConsentRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid consent payload"})
+		return
+	}
+	state, err := h.svc.SetConsent(c.Request.Context(), req.Status)
+	if err != nil {
+		if req.Status != ConsentGranted && req.Status != ConsentDenied {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "status must be granted or denied"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to save consent"})
+		return
+	}
+	c.JSON(http.StatusOK, state)
+}
+
+type postEventsRequest struct {
+	Events []UIEventSubmission `json:"events"`
+}
+
+// postEvents accepts allowlisted UI events. It always answers 202:
+// invalid entries are dropped server-side and consent gating happens at
+// enqueue time, so the response deliberately carries no consent signal
+// beyond the accepted count.
+func (h *Handler) postEvents(c *gin.Context) {
+	var req postEventsRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid events payload"})
+		return
+	}
+	accepted := h.svc.EnqueueUI(req.Events)
+	c.JSON(http.StatusAccepted, gin.H{"accepted": accepted})
+}

--- a/apps/backend/internal/telemetry/handlers.go
+++ b/apps/backend/internal/telemetry/handlers.go
@@ -36,12 +36,12 @@ func (h *Handler) putConsent(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid consent payload"})
 		return
 	}
+	if req.Status != ConsentGranted && req.Status != ConsentDenied {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "status must be granted or denied"})
+		return
+	}
 	state, err := h.svc.SetConsent(c.Request.Context(), req.Status)
 	if err != nil {
-		if req.Status != ConsentGranted && req.Status != ConsentDenied {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "status must be granted or denied"})
-			return
-		}
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to save consent"})
 		return
 	}
@@ -52,11 +52,16 @@ type postEventsRequest struct {
 	Events []UIEventSubmission `json:"events"`
 }
 
+// maxEventsBodyBytes bounds the /events request body before JSON
+// decoding; legitimate payloads are a few hundred bytes.
+const maxEventsBodyBytes = 16 << 10
+
 // postEvents accepts allowlisted UI events. It always answers 202:
 // invalid entries are dropped server-side and consent gating happens at
 // enqueue time, so the response deliberately carries no consent signal
 // beyond the accepted count.
 func (h *Handler) postEvents(c *gin.Context) {
+	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxEventsBodyBytes)
 	var req postEventsRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid events payload"})

--- a/apps/backend/internal/telemetry/handlers_test.go
+++ b/apps/backend/internal/telemetry/handlers_test.go
@@ -1,0 +1,135 @@
+package telemetry
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func newTestRouter(t *testing.T, svc *Service) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	RegisterRoutes(router, svc)
+	return router
+}
+
+func doJSON(t *testing.T, router *gin.Engine, method, path, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	var reader *strings.Reader
+	if body == "" {
+		reader = strings.NewReader("")
+	} else {
+		reader = strings.NewReader(body)
+	}
+	req := httptest.NewRequest(method, path, reader)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestGetConsentDefaults(t *testing.T) {
+	svc, _, _ := newTestService(t, nil, Options{})
+	router := newTestRouter(t, svc)
+
+	rec := doJSON(t, router, http.MethodGet, "/api/v1/telemetry/consent", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d", rec.Code)
+	}
+	var state ConsentState
+	if err := json.Unmarshal(rec.Body.Bytes(), &state); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if state.Status != ConsentUnasked || state.EnvDisabled || state.InstallID != "" {
+		t.Fatalf("unexpected state %+v", state)
+	}
+}
+
+func TestPutConsentGrantAndDeny(t *testing.T) {
+	svc, _, _ := newTestService(t, nil, Options{})
+	router := newTestRouter(t, svc)
+
+	rec := doJSON(t, router, http.MethodPut, "/api/v1/telemetry/consent", `{"status":"granted"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("grant status %d: %s", rec.Code, rec.Body.String())
+	}
+	var state ConsentState
+	_ = json.Unmarshal(rec.Body.Bytes(), &state)
+	if state.Status != ConsentGranted || state.InstallID == "" {
+		t.Fatalf("unexpected grant state %+v", state)
+	}
+
+	rec = doJSON(t, router, http.MethodPut, "/api/v1/telemetry/consent", `{"status":"denied"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("deny status %d", rec.Code)
+	}
+	state = ConsentState{} // deny omits install_id; don't inherit the grant's value
+	_ = json.Unmarshal(rec.Body.Bytes(), &state)
+	if state.Status != ConsentDenied || state.InstallID != "" {
+		t.Fatalf("unexpected deny state %+v", state)
+	}
+}
+
+func TestPutConsentRejectsInvalid(t *testing.T) {
+	svc, _, _ := newTestService(t, nil, Options{})
+	router := newTestRouter(t, svc)
+
+	for _, body := range []string{`{"status":"unasked"}`, `{"status":"maybe"}`, `{}`, `not json`} {
+		rec := doJSON(t, router, http.MethodPut, "/api/v1/telemetry/consent", body)
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("body %q: expected 400, got %d", body, rec.Code)
+		}
+	}
+}
+
+func TestPostEventsAcceptsAllowlistedOnly(t *testing.T) {
+	svc, _, sink := newTestService(t, nil, Options{})
+	grantConsent(t, svc)
+	svc.drainQueue()
+	router := newTestRouter(t, svc)
+
+	rec := doJSON(t, router, http.MethodPost, "/api/v1/telemetry/events",
+		`{"events":[{"name":"ui_page_viewed","properties":{"page":"settings_system"}},{"name":"evil","properties":{"page":"x"}}]}`)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status %d: %s", rec.Code, rec.Body.String())
+	}
+	var resp map[string]int
+	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+	if resp["accepted"] != 1 {
+		t.Fatalf("expected 1 accepted, got %d", resp["accepted"])
+	}
+	svc.flushOnce(context.Background())
+	if got := len(sink.sent()); got != 1 {
+		t.Fatalf("expected 1 event sent, got %d", got)
+	}
+}
+
+func TestPostEventsWithoutConsentAcceptsButSendsNothing(t *testing.T) {
+	svc, _, sink := newTestService(t, nil, Options{})
+	router := newTestRouter(t, svc)
+
+	rec := doJSON(t, router, http.MethodPost, "/api/v1/telemetry/events",
+		`{"events":[{"name":"ui_page_viewed","properties":{"page":"settings_system"}}]}`)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status %d", rec.Code)
+	}
+	svc.flushOnce(context.Background())
+	if got := len(sink.sent()); got != 0 {
+		t.Fatalf("expected 0 events sent without consent, got %d", got)
+	}
+}
+
+func TestPostEventsRejectsMalformedJSON(t *testing.T) {
+	svc, _, _ := newTestService(t, nil, Options{})
+	router := newTestRouter(t, svc)
+	rec := doJSON(t, router, http.MethodPost, "/api/v1/telemetry/events", `{"events": "nope"}`)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}

--- a/apps/backend/internal/telemetry/handlers_test.go
+++ b/apps/backend/internal/telemetry/handlers_test.go
@@ -60,7 +60,9 @@ func TestPutConsentGrantAndDeny(t *testing.T) {
 		t.Fatalf("grant status %d: %s", rec.Code, rec.Body.String())
 	}
 	var state ConsentState
-	_ = json.Unmarshal(rec.Body.Bytes(), &state)
+	if err := json.Unmarshal(rec.Body.Bytes(), &state); err != nil {
+		t.Fatalf("unmarshal grant response: %v", err)
+	}
 	if state.Status != ConsentGranted || state.InstallID == "" {
 		t.Fatalf("unexpected grant state %+v", state)
 	}
@@ -70,7 +72,9 @@ func TestPutConsentGrantAndDeny(t *testing.T) {
 		t.Fatalf("deny status %d", rec.Code)
 	}
 	state = ConsentState{} // deny omits install_id; don't inherit the grant's value
-	_ = json.Unmarshal(rec.Body.Bytes(), &state)
+	if err := json.Unmarshal(rec.Body.Bytes(), &state); err != nil {
+		t.Fatalf("unmarshal deny response: %v", err)
+	}
 	if state.Status != ConsentDenied || state.InstallID != "" {
 		t.Fatalf("unexpected deny state %+v", state)
 	}
@@ -100,7 +104,9 @@ func TestPostEventsAcceptsAllowlistedOnly(t *testing.T) {
 		t.Fatalf("status %d: %s", rec.Code, rec.Body.String())
 	}
 	var resp map[string]int
-	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal events response: %v", err)
+	}
 	if resp["accepted"] != 1 {
 		t.Fatalf("expected 1 accepted, got %d", resp["accepted"])
 	}
@@ -122,6 +128,16 @@ func TestPostEventsWithoutConsentAcceptsButSendsNothing(t *testing.T) {
 	svc.flushOnce(context.Background())
 	if got := len(sink.sent()); got != 0 {
 		t.Fatalf("expected 0 events sent without consent, got %d", got)
+	}
+}
+
+func TestPostEventsRejectsOversizedBody(t *testing.T) {
+	svc, _, _ := newTestService(t, nil, Options{})
+	router := newTestRouter(t, svc)
+	huge := `{"events":[{"name":"ui_page_viewed","properties":{"page":"` + strings.Repeat("a", maxEventsBodyBytes) + `"}}]}`
+	rec := doJSON(t, router, http.MethodPost, "/api/v1/telemetry/events", huge)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for oversized body, got %d", rec.Code)
 	}
 }
 

--- a/apps/backend/internal/telemetry/helpers_test.go
+++ b/apps/backend/internal/telemetry/helpers_test.go
@@ -1,0 +1,96 @@
+package telemetry
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/kandev/kandev/internal/common/logger"
+	"github.com/kandev/kandev/internal/events/bus"
+)
+
+func newTestLogger() *logger.Logger {
+	log, _ := logger.NewLogger(logger.LoggingConfig{Level: "error", Format: "json"})
+	return log
+}
+
+// fakeStore is an in-memory SettingsStore.
+type fakeStore struct {
+	mu     sync.Mutex
+	values map[string]string
+}
+
+func newFakeStore() *fakeStore {
+	return &fakeStore{values: map[string]string{}}
+}
+
+func (f *fakeStore) Get(_ context.Context, key string) ([]byte, bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	v, ok := f.values[key]
+	return []byte(v), ok, nil
+}
+
+func (f *fakeStore) Save(_ context.Context, key string, value []byte) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.values[key] = string(value)
+	return nil
+}
+
+// fakeSink records every batch it receives.
+type fakeSink struct {
+	mu      sync.Mutex
+	batches [][]Event
+	ids     []string
+}
+
+func (f *fakeSink) Send(_ context.Context, distinctID string, events []Event) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.batches = append(f.batches, events)
+	f.ids = append(f.ids, distinctID)
+	return nil
+}
+
+func (f *fakeSink) sent() []Event {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var all []Event
+	for _, b := range f.batches {
+		all = append(all, b...)
+	}
+	return all
+}
+
+func (f *fakeSink) distinctIDs() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.ids...)
+}
+
+// newTestService builds a Service with a fake store/sink and no bus
+// unless one is supplied.
+func newTestService(t *testing.T, eventBus bus.EventBus, opts Options) (*Service, *fakeStore, *fakeSink) {
+	t.Helper()
+	store := newFakeStore()
+	sink := &fakeSink{}
+	if opts.Sink == nil {
+		opts.Sink = sink
+	}
+	if opts.Version == "" {
+		opts.Version = "1.2.3-test"
+	}
+	if opts.DeployMode == "" {
+		opts.DeployMode = "local"
+	}
+	svc := NewService(store, eventBus, newTestLogger(), opts)
+	return svc, store, sink
+}
+
+func grantConsent(t *testing.T, svc *Service) {
+	t.Helper()
+	if _, err := svc.SetConsent(context.Background(), ConsentGranted); err != nil {
+		t.Fatalf("SetConsent(granted): %v", err)
+	}
+}

--- a/apps/backend/internal/telemetry/service.go
+++ b/apps/backend/internal/telemetry/service.go
@@ -57,6 +57,10 @@ type Service struct {
 	cancel    context.CancelFunc
 	subs      []bus.Subscription
 
+	// consentMu serializes SetConsent end-to-end (persist + memory +
+	// queue side effects); s.mu stays a short-hold field guard.
+	consentMu sync.Mutex
+
 	wg sync.WaitGroup
 }
 
@@ -285,7 +289,10 @@ func (s *Service) flushOnce(ctx context.Context) {
 		return
 	}
 	s.debugLogBatch(batch)
-	sendCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), sendTimeout)
+	// Derive from the caller's ctx so Stop's bounded final flush keeps its
+	// cap; a tick flush aborted by shutdown just drops the batch, which is
+	// the fail-silent contract anyway.
+	sendCtx, cancel := context.WithTimeout(ctx, sendTimeout)
 	defer cancel()
 	if err := s.opts.Sink.Send(sendCtx, state.InstallID, batch); err != nil {
 		s.log.Debug("telemetry: send failed, dropping batch",

--- a/apps/backend/internal/telemetry/service.go
+++ b/apps/backend/internal/telemetry/service.go
@@ -1,0 +1,340 @@
+package telemetry
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/kandev/kandev/internal/common/config"
+	"github.com/kandev/kandev/internal/common/logger"
+	"github.com/kandev/kandev/internal/db"
+	"github.com/kandev/kandev/internal/events/bus"
+	systemsettings "github.com/kandev/kandev/internal/system/settings"
+)
+
+const (
+	defaultFlushInterval     = 30 * time.Second
+	defaultHeartbeatInterval = 24 * time.Hour
+	defaultQueueSize         = 256
+	defaultMaxBatch          = 50
+	sendTimeout              = 10 * time.Second
+)
+
+// Options configures a Service. Zero values fall back to production
+// defaults; tests inject short intervals and a fake Sink.
+type Options struct {
+	Endpoint          string
+	APIKey            string
+	Debug             bool
+	EnvDisabled       bool
+	Version           string
+	DeployMode        string
+	FlushInterval     time.Duration
+	HeartbeatInterval time.Duration
+	QueueSize         int
+	MaxBatch          int
+	Sink              Sink
+}
+
+// Service owns the consent record, the event queue, the bus collector,
+// and the background flush/heartbeat goroutines. Every path is
+// fail-silent: telemetry must never delay or break product flows.
+type Service struct {
+	opts  Options
+	store SettingsStore
+	bus   bus.EventBus
+	log   *logger.Logger
+
+	queue chan Event
+
+	mu        sync.Mutex
+	consent   ConsentStatus
+	installID string
+	started   bool
+	cancel    context.CancelFunc
+	subs      []bus.Subscription
+
+	wg sync.WaitGroup
+}
+
+// Provide constructs the Service from app config. Failures are non-fatal
+// for the backend; the caller logs and continues without telemetry.
+func Provide(cfg *config.Config, log *logger.Logger, pool *db.Pool, eventBus bus.EventBus, version string) (*Service, error) {
+	store, err := systemsettings.NewStore(pool)
+	if err != nil {
+		return nil, err
+	}
+	return NewService(store, eventBus, log, Options{
+		Endpoint:    cfg.Telemetry.Endpoint,
+		APIKey:      cfg.Telemetry.APIKey,
+		Debug:       cfg.Telemetry.Debug,
+		EnvDisabled: EnvDisabled(),
+		Version:     version,
+		DeployMode:  detectDeployMode(),
+	}), nil
+}
+
+// NewService builds a Service with defaults applied. Consent is loaded
+// from the store in Start.
+func NewService(store SettingsStore, eventBus bus.EventBus, log *logger.Logger, opts Options) *Service {
+	if opts.Endpoint == "" {
+		opts.Endpoint = defaultEndpoint
+	}
+	if opts.APIKey == "" {
+		opts.APIKey = defaultAPIKey
+	}
+	if opts.FlushInterval <= 0 {
+		opts.FlushInterval = defaultFlushInterval
+	}
+	if opts.HeartbeatInterval <= 0 {
+		opts.HeartbeatInterval = defaultHeartbeatInterval
+	}
+	if opts.QueueSize <= 0 {
+		opts.QueueSize = defaultQueueSize
+	}
+	if opts.MaxBatch <= 0 {
+		opts.MaxBatch = defaultMaxBatch
+	}
+	if opts.Sink == nil {
+		opts.Sink = newPostHogSink(opts.Endpoint, opts.APIKey)
+	}
+	return &Service{
+		opts:    opts,
+		store:   store,
+		bus:     eventBus,
+		log:     log.WithFields(zap.String("component", "telemetry")),
+		queue:   make(chan Event, opts.QueueSize),
+		consent: ConsentUnasked,
+	}
+}
+
+// Start loads consent, subscribes the collector, and launches the flush
+// and heartbeat loops. A hard env kill switch means Start does nothing at
+// all — no subscriptions, no goroutines — beyond loading consent so the
+// HTTP surface can still report the stored preference.
+func (s *Service) Start(ctx context.Context) {
+	s.mu.Lock()
+	if s.started {
+		s.mu.Unlock()
+		return
+	}
+	s.started = true
+	s.mu.Unlock()
+
+	if err := s.loadConsent(ctx); err != nil {
+		s.log.Warn("telemetry: failed to load consent; treating as unasked", zap.Error(err))
+	}
+	if s.opts.EnvDisabled {
+		s.log.Debug("telemetry: disabled by environment")
+		return
+	}
+
+	loopCtx, cancel := context.WithCancel(context.WithoutCancel(ctx))
+	s.mu.Lock()
+	s.cancel = cancel
+	s.mu.Unlock()
+
+	s.subscribeCollector()
+
+	s.wg.Add(2)
+	go s.flushLoop(loopCtx)
+	go s.heartbeatLoop(loopCtx)
+}
+
+// Stop cancels the loops, detaches the collector, and makes a best-effort
+// final flush. Safe to call more than once.
+func (s *Service) Stop() {
+	s.mu.Lock()
+	cancel := s.cancel
+	s.cancel = nil
+	subs := s.subs
+	s.subs = nil
+	s.started = false
+	s.mu.Unlock()
+
+	for _, sub := range subs {
+		_ = sub.Unsubscribe()
+	}
+	if cancel == nil {
+		return
+	}
+	cancel()
+	s.wg.Wait()
+
+	flushCtx, flushCancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer flushCancel()
+	s.flushOnce(flushCtx)
+}
+
+// subscribeCollector attaches one bus subscription per allowlisted
+// domain event. The handlers forward nothing from the payload — the
+// event name is the entire signal.
+func (s *Service) subscribeCollector() {
+	if s.bus == nil {
+		return
+	}
+	var subs []bus.Subscription
+	for subject, name := range busEventAllowlist {
+		sub, err := s.bus.Subscribe(subject, func(context.Context, *bus.Event) error {
+			s.enqueue(Event{Name: name})
+			return nil
+		})
+		if err != nil {
+			s.log.Debug("telemetry: subscribe failed", zap.String("subject", subject), zap.Error(err))
+			continue
+		}
+		subs = append(subs, sub)
+	}
+	s.mu.Lock()
+	s.subs = subs
+	s.mu.Unlock()
+}
+
+// EnqueueUI validates and queues a batch of frontend-submitted events.
+// Returns how many were accepted; invalid entries are silently dropped.
+func (s *Service) EnqueueUI(submissions []UIEventSubmission) int {
+	accepted := 0
+	for i, submission := range submissions {
+		if i >= maxUIEventsPerRequest {
+			break
+		}
+		event, ok := sanitizeUIEvent(submission.Name, submission.Properties)
+		if !ok {
+			continue
+		}
+		s.enqueue(event)
+		accepted++
+	}
+	return accepted
+}
+
+// UIEventSubmission is one entry of POST /api/v1/telemetry/events.
+type UIEventSubmission struct {
+	Name       string            `json:"name"`
+	Properties map[string]string `json:"properties"`
+}
+
+// emissionAllowed is the single gate every enqueue passes through:
+// hard env switches first, then explicit granted consent.
+func (s *Service) emissionAllowed() bool {
+	if s.opts.EnvDisabled {
+		return false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.consent == ConsentGranted
+}
+
+func (s *Service) enqueue(event Event) {
+	if !s.emissionAllowed() {
+		return
+	}
+	if event.Timestamp.IsZero() {
+		event.Timestamp = time.Now().UTC()
+	}
+	select {
+	case s.queue <- event:
+	default:
+		s.log.Debug("telemetry: queue full, dropping event", zap.String("event", event.Name))
+	}
+}
+
+func (s *Service) drainQueue() {
+	for {
+		select {
+		case <-s.queue:
+		default:
+			return
+		}
+	}
+}
+
+func (s *Service) flushLoop(ctx context.Context) {
+	defer s.wg.Done()
+	ticker := time.NewTicker(s.opts.FlushInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.flushOnce(ctx)
+		}
+	}
+}
+
+// flushOnce drains up to MaxBatch queued events and hands them to the
+// sink. Failures drop the batch: no retries, no persistence, no impact
+// on the product. Intentionally package-internal so deterministic tests
+// can drive it without timers.
+func (s *Service) flushOnce(ctx context.Context) {
+	batch := s.collectBatch()
+	if len(batch) == 0 {
+		return
+	}
+	state := s.Consent()
+	if state.Status != ConsentGranted || state.InstallID == "" {
+		return
+	}
+	s.debugLogBatch(batch)
+	sendCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), sendTimeout)
+	defer cancel()
+	if err := s.opts.Sink.Send(sendCtx, state.InstallID, batch); err != nil {
+		s.log.Debug("telemetry: send failed, dropping batch",
+			zap.Int("events", len(batch)), zap.Error(err))
+	}
+}
+
+func (s *Service) collectBatch() []Event {
+	var batch []Event
+	base := s.baseProperties()
+	for len(batch) < s.opts.MaxBatch {
+		select {
+		case event := <-s.queue:
+			merged := make(map[string]string, len(base)+len(event.Properties))
+			for k, v := range base {
+				merged[k] = v
+			}
+			for k, v := range event.Properties {
+				merged[k] = v
+			}
+			event.Properties = merged
+			batch = append(batch, event)
+		default:
+			return batch
+		}
+	}
+	return batch
+}
+
+// debugLogBatch prints the exact outgoing payload when
+// KANDEV_TELEMETRY_DEBUG is on, so users can inspect what leaves the
+// machine (Turborepo-style transparency).
+func (s *Service) debugLogBatch(batch []Event) {
+	if !s.opts.Debug {
+		return
+	}
+	payload, err := json.Marshal(batch)
+	if err != nil {
+		return
+	}
+	s.log.Info("telemetry: sending batch", zap.ByteString("payload", payload))
+}
+
+func (s *Service) heartbeatLoop(ctx context.Context) {
+	defer s.wg.Done()
+	s.enqueue(Event{Name: EventInstallHeartbeat})
+	ticker := time.NewTicker(s.opts.HeartbeatInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.enqueue(Event{Name: EventInstallHeartbeat})
+		}
+	}
+}

--- a/apps/backend/internal/telemetry/service.go
+++ b/apps/backend/internal/telemetry/service.go
@@ -170,16 +170,21 @@ func (s *Service) Stop() {
 }
 
 // subscribeCollector attaches one bus subscription per allowlisted
-// domain event. The handlers forward nothing from the payload — the
-// event name is the entire signal.
+// domain event. The handlers forward nothing from the payload beyond the
+// per-subject enum keys in busEventPropertyKeys — for most events the
+// name is the entire signal.
 func (s *Service) subscribeCollector() {
 	if s.bus == nil {
 		return
 	}
 	var subs []bus.Subscription
 	for subject, name := range busEventAllowlist {
-		sub, err := s.bus.Subscribe(subject, func(context.Context, *bus.Event) error {
-			s.enqueue(Event{Name: name})
+		sub, err := s.bus.Subscribe(subject, func(_ context.Context, event *bus.Event) error {
+			var props map[string]string
+			if event != nil {
+				props = extractAllowlistedProps(subject, event.Data)
+			}
+			s.enqueue(Event{Name: name, Properties: props})
 			return nil
 		})
 		if err != nil {

--- a/apps/backend/internal/telemetry/service_test.go
+++ b/apps/backend/internal/telemetry/service_test.go
@@ -234,16 +234,13 @@ func TestEnvDisabledDetection(t *testing.T) {
 		{"do_not_track_1", "DO_NOT_TRACK", "1", true},
 		{"do_not_track_true", "DO_NOT_TRACK", "true", true},
 		{"do_not_track_0", "DO_NOT_TRACK", "0", false},
-		{"kandev_off", "KANDEV_TELEMETRY", "off", true},
-		{"kandev_false", "KANDEV_TELEMETRY", "false", true},
-		{"kandev_0", "KANDEV_TELEMETRY", "0", true},
-		{"kandev_disabled", "KANDEV_TELEMETRY", "DISABLED", true},
-		{"kandev_on", "KANDEV_TELEMETRY", "on", false},
+		{"e2e_mode", "KANDEV_E2E_MOCK", "true", true},
+		{"e2e_selector_unset_value", "KANDEV_E2E_MOCK", "false", false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Setenv("DO_NOT_TRACK", "")
-			t.Setenv("KANDEV_TELEMETRY", "")
+			t.Setenv("KANDEV_E2E_MOCK", "")
 			if tc.envVar != "" {
 				t.Setenv(tc.envVar, tc.value)
 			}

--- a/apps/backend/internal/telemetry/service_test.go
+++ b/apps/backend/internal/telemetry/service_test.go
@@ -119,6 +119,72 @@ func TestCollectorForwardsNothingFromPayload(t *testing.T) {
 	}
 }
 
+// agent.failed is the one subject with allowlisted payload keys: the
+// routingerr classification enums come through, everything else —
+// including the free-text error message — must not.
+func TestCollectorForwardsOnlyClassifiedFailureEnums(t *testing.T) {
+	eventBus := bus.NewMemoryEventBus(newTestLogger())
+	svc, _, sink := newTestService(t, eventBus, Options{})
+	grantConsent(t, svc)
+	svc.drainQueue()
+	svc.subscribeCollector()
+
+	payload := map[string]any{
+		"error_code":    "rate_limited",
+		"error_phase":   "prompt_send",
+		"error_message": "secret /home/user/repo stack trace",
+		"task_id":       "some-task-uuid",
+	}
+	if err := eventBus.Publish(context.Background(), events.AgentFailed,
+		bus.NewEvent(events.AgentFailed, "test", payload)); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	svc.flushOnce(context.Background())
+
+	sent := sink.sent()
+	if len(sent) != 1 {
+		t.Fatalf("expected exactly one event, got %d", len(sent))
+	}
+	props := sent[0].Properties
+	if props["error_code"] != "rate_limited" || props["error_phase"] != "prompt_send" {
+		t.Fatalf("classification enums missing: %v", props)
+	}
+	for key, value := range props {
+		if key == "error_message" || key == "task_id" || value == payload["error_message"] {
+			t.Fatalf("non-allowlisted payload field leaked: %q=%q", key, value)
+		}
+	}
+}
+
+func TestCollectorDropsNonEnumFailureValues(t *testing.T) {
+	eventBus := bus.NewMemoryEventBus(newTestLogger())
+	svc, _, sink := newTestService(t, eventBus, Options{})
+	grantConsent(t, svc)
+	svc.drainQueue()
+	svc.subscribeCollector()
+
+	payload := map[string]any{
+		"error_code":  "Free Text With Spaces /and/paths",
+		"error_phase": 42, // not even a string
+	}
+	if err := eventBus.Publish(context.Background(), events.AgentFailed,
+		bus.NewEvent(events.AgentFailed, "test", payload)); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	svc.flushOnce(context.Background())
+
+	sent := sink.sent()
+	if len(sent) != 1 {
+		t.Fatalf("expected exactly one event, got %d", len(sent))
+	}
+	if _, ok := sent[0].Properties["error_code"]; ok {
+		t.Fatalf("non-enum error_code survived: %v", sent[0].Properties)
+	}
+	if _, ok := sent[0].Properties["error_phase"]; ok {
+		t.Fatalf("non-string error_phase survived: %v", sent[0].Properties)
+	}
+}
+
 func TestDenyDropsQueuedEvents(t *testing.T) {
 	svc, _, sink := newTestService(t, nil, Options{})
 	grantConsent(t, svc) // queues telemetry_enabled + install_heartbeat

--- a/apps/backend/internal/telemetry/service_test.go
+++ b/apps/backend/internal/telemetry/service_test.go
@@ -1,0 +1,255 @@
+package telemetry
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/events"
+	"github.com/kandev/kandev/internal/events/bus"
+)
+
+func publish(t *testing.T, b bus.EventBus, subject string) {
+	t.Helper()
+	if err := b.Publish(context.Background(), subject, bus.NewEvent(subject, "test", nil)); err != nil {
+		t.Fatalf("publish %s: %v", subject, err)
+	}
+}
+
+func sentNames(sink *fakeSink) map[string]int {
+	names := map[string]int{}
+	for _, e := range sink.sent() {
+		names[e.Name]++
+	}
+	return names
+}
+
+// The off-path is the trust-critical path: nothing may reach the sink
+// while consent is unasked or denied, or when the env kill switch is on.
+func TestNoEmissionWhileUnaskedOrDenied(t *testing.T) {
+	for _, status := range []ConsentStatus{ConsentUnasked, ConsentDenied} {
+		eventBus := bus.NewMemoryEventBus(newTestLogger())
+		svc, store, sink := newTestService(t, eventBus, Options{})
+		if status == ConsentDenied {
+			_ = store.Save(context.Background(), consentKey, []byte(ConsentDenied))
+		}
+		if err := svc.loadConsent(context.Background()); err != nil {
+			t.Fatalf("loadConsent: %v", err)
+		}
+		svc.subscribeCollector()
+
+		publish(t, eventBus, events.TaskCreated)
+		svc.EnqueueUI([]UIEventSubmission{{Name: EventUIPageViewed, Properties: map[string]string{"page": "settings"}}})
+		svc.flushOnce(context.Background())
+
+		if got := sink.sent(); len(got) != 0 {
+			t.Fatalf("status %q: expected zero events sent, got %d", status, len(got))
+		}
+	}
+}
+
+func TestEnvKillSwitchBlocksEvenWhenGranted(t *testing.T) {
+	eventBus := bus.NewMemoryEventBus(newTestLogger())
+	svc, store, sink := newTestService(t, eventBus, Options{EnvDisabled: true})
+	// Simulate a store that already carries a grant: env must still win.
+	_ = store.Save(context.Background(), consentKey, []byte(ConsentGranted))
+	_ = store.Save(context.Background(), installIDKey, []byte("11111111-1111-1111-1111-111111111111"))
+
+	svc.Start(context.Background())
+	defer svc.Stop()
+
+	publish(t, eventBus, events.TaskCreated)
+	svc.EnqueueUI([]UIEventSubmission{{Name: EventUIPageViewed, Properties: map[string]string{"page": "settings"}}})
+	svc.flushOnce(context.Background())
+
+	if got := sink.sent(); len(got) != 0 {
+		t.Fatalf("env kill switch on: expected zero events sent, got %d", len(got))
+	}
+	if state := svc.Consent(); !state.EnvDisabled {
+		t.Fatal("consent state must report env_disabled")
+	}
+}
+
+func TestCollectorMapsOnlyAllowlistedBusEvents(t *testing.T) {
+	eventBus := bus.NewMemoryEventBus(newTestLogger())
+	svc, _, sink := newTestService(t, eventBus, Options{})
+	grantConsent(t, svc)
+	svc.subscribeCollector()
+
+	publish(t, eventBus, events.TaskCreated)
+	publish(t, eventBus, events.AgentStarted)
+	publish(t, eventBus, events.MessageAdded) // not allowlisted
+	svc.flushOnce(context.Background())
+
+	names := sentNames(sink)
+	if names[EventTaskCreated] != 1 || names[EventAgentRunStarted] != 1 {
+		t.Fatalf("expected mapped events, got %v", names)
+	}
+	for name := range names {
+		switch name {
+		case EventTaskCreated, EventAgentRunStarted, EventTelemetryEnabled, EventInstallHeartbeat:
+		default:
+			t.Fatalf("unexpected event %q sent (names: %v)", name, names)
+		}
+	}
+}
+
+func TestCollectorForwardsNothingFromPayload(t *testing.T) {
+	eventBus := bus.NewMemoryEventBus(newTestLogger())
+	svc, _, sink := newTestService(t, eventBus, Options{})
+	grantConsent(t, svc)
+	svc.drainQueue() // discard the grant-time events for a clean slate
+	svc.subscribeCollector()
+
+	payload := map[string]any{"title": "SECRET TASK TITLE", "repository": "org/secret-repo"}
+	if err := eventBus.Publish(context.Background(), events.TaskCreated,
+		bus.NewEvent(events.TaskCreated, "test", payload)); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	svc.flushOnce(context.Background())
+
+	sent := sink.sent()
+	if len(sent) != 1 {
+		t.Fatalf("expected exactly one event, got %d", len(sent))
+	}
+	for key, value := range sent[0].Properties {
+		if value == "SECRET TASK TITLE" || value == "org/secret-repo" {
+			t.Fatalf("payload leaked into property %q=%q", key, value)
+		}
+	}
+}
+
+func TestDenyDropsQueuedEvents(t *testing.T) {
+	svc, _, sink := newTestService(t, nil, Options{})
+	grantConsent(t, svc) // queues telemetry_enabled + install_heartbeat
+	if _, err := svc.SetConsent(context.Background(), ConsentDenied); err != nil {
+		t.Fatalf("SetConsent(denied): %v", err)
+	}
+	svc.flushOnce(context.Background())
+	if got := sink.sent(); len(got) != 0 {
+		t.Fatalf("expected queue dropped on deny, got %d events", len(got))
+	}
+}
+
+func TestFlushAttachesBasePropertiesAndInstallID(t *testing.T) {
+	svc, _, sink := newTestService(t, nil, Options{Version: "9.9.9", DeployMode: "docker"})
+	grantConsent(t, svc)
+	svc.flushOnce(context.Background())
+
+	sent := sink.sent()
+	if len(sent) == 0 {
+		t.Fatal("expected grant-time events to flush")
+	}
+	for _, e := range sent {
+		if e.Properties["app_version"] != "9.9.9" || e.Properties["deploy_mode"] != "docker" {
+			t.Fatalf("missing base properties: %v", e.Properties)
+		}
+		if e.Properties["os"] == "" || e.Properties["arch"] == "" {
+			t.Fatalf("missing os/arch: %v", e.Properties)
+		}
+	}
+	installID := svc.Consent().InstallID
+	for _, id := range sink.distinctIDs() {
+		if id != installID {
+			t.Fatalf("distinct id %q != install id %q", id, installID)
+		}
+	}
+}
+
+func TestEnqueueUIValidation(t *testing.T) {
+	svc, _, sink := newTestService(t, nil, Options{})
+	grantConsent(t, svc)
+	svc.drainQueue()
+
+	accepted := svc.EnqueueUI([]UIEventSubmission{
+		{Name: EventUIPageViewed, Properties: map[string]string{"page": "settings_system"}},
+		{Name: EventUIAction, Properties: map[string]string{"action": "task.create:dialog"}},
+		{Name: EventFeatureUsed, Properties: map[string]string{"feature": "office"}},
+		{Name: "custom_event", Properties: map[string]string{"page": "x"}},                           // unknown name
+		{Name: EventUIPageViewed, Properties: map[string]string{"page": "Has Spaces And Caps"}},      // free text
+		{Name: EventUIPageViewed, Properties: map[string]string{"other": "settings"}},                // wrong key
+		{Name: EventUIPageViewed, Properties: map[string]string{"page": "ok", "title": "user text"}}, // extra key stripped
+	})
+	if accepted != 4 {
+		t.Fatalf("expected 4 accepted, got %d", accepted)
+	}
+	svc.flushOnce(context.Background())
+	for _, e := range sink.sent() {
+		if _, leaked := e.Properties["title"]; leaked {
+			t.Fatalf("non-allowlisted property survived: %v", e.Properties)
+		}
+	}
+}
+
+func TestStartStopLifecycle(t *testing.T) {
+	eventBus := bus.NewMemoryEventBus(newTestLogger())
+	svc, _, sink := newTestService(t, eventBus, Options{
+		FlushInterval:     time.Hour, // ticks never fire; Stop's final flush delivers
+		HeartbeatInterval: time.Hour,
+	})
+	grantConsent(t, svc)
+	svc.Start(context.Background())
+	publish(t, eventBus, events.TurnCompleted)
+	svc.Stop()
+	svc.Stop() // idempotent
+
+	names := sentNames(sink)
+	if names[EventTurnCompleted] != 1 || names[EventInstallHeartbeat] == 0 {
+		t.Fatalf("expected turn_completed and heartbeat after Stop flush, got %v", names)
+	}
+
+	// After Stop, collector must be detached.
+	publish(t, eventBus, events.TurnCompleted)
+	svc.flushOnce(context.Background())
+	if got := sentNames(sink)[EventTurnCompleted]; got != 1 {
+		t.Fatalf("collector still attached after Stop: %d turn_completed", got)
+	}
+}
+
+func TestQueueOverflowDropsInsteadOfBlocking(t *testing.T) {
+	svc, _, sink := newTestService(t, nil, Options{QueueSize: 2, MaxBatch: 10})
+	grantConsent(t, svc) // two grant-time events fill the queue
+	done := make(chan struct{})
+	go func() {
+		svc.enqueue(Event{Name: EventTaskCreated}) // must drop, not block
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("enqueue blocked on full queue")
+	}
+	svc.flushOnce(context.Background())
+	if got := len(sink.sent()); got != 2 {
+		t.Fatalf("expected the 2 queued events only, got %d", got)
+	}
+}
+
+func TestEnvDisabledDetection(t *testing.T) {
+	cases := []struct {
+		name, envVar, value string
+		want                bool
+	}{
+		{"unset", "", "", false},
+		{"do_not_track_1", "DO_NOT_TRACK", "1", true},
+		{"do_not_track_true", "DO_NOT_TRACK", "true", true},
+		{"do_not_track_0", "DO_NOT_TRACK", "0", false},
+		{"kandev_off", "KANDEV_TELEMETRY", "off", true},
+		{"kandev_false", "KANDEV_TELEMETRY", "false", true},
+		{"kandev_0", "KANDEV_TELEMETRY", "0", true},
+		{"kandev_disabled", "KANDEV_TELEMETRY", "DISABLED", true},
+		{"kandev_on", "KANDEV_TELEMETRY", "on", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("DO_NOT_TRACK", "")
+			t.Setenv("KANDEV_TELEMETRY", "")
+			if tc.envVar != "" {
+				t.Setenv(tc.envVar, tc.value)
+			}
+			if got := EnvDisabled(); got != tc.want {
+				t.Fatalf("EnvDisabled() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/apps/backend/internal/telemetry/sink.go
+++ b/apps/backend/internal/telemetry/sink.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -18,7 +19,7 @@ type Sink interface {
 
 // postHogSink posts batches to the PostHog /batch/ endpoint using the
 // write-only project API key. Events are sent in anonymous mode
-// ($process_person_profiles: false) so no person profile is ever built.
+// ($process_person_profile: false) so no person profile is ever built.
 type postHogSink struct {
 	endpoint string
 	apiKey   string
@@ -44,8 +45,10 @@ func (p *postHogSink) Send(ctx context.Context, distinctID string, events []Even
 	items := make([]postHogItem, 0, len(events))
 	for _, event := range events {
 		properties := map[string]any{
-			"$process_person_profiles": false,
-			"$lib":                     "kandev",
+			// Singular per PostHog's capture API: $process_person_profile
+			// keeps events personless so no person profiles are created.
+			"$process_person_profile": false,
+			"$lib":                    "kandev",
 		}
 		for k, v := range event.Properties {
 			properties[k] = v
@@ -70,7 +73,11 @@ func (p *postHogSink) Send(ctx context.Context, distinctID string, events []Even
 	if err != nil {
 		return fmt.Errorf("post telemetry batch: %w", err)
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer func() {
+		// Drain (bounded) so the keep-alive connection is reusable.
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
+		_ = resp.Body.Close()
+	}()
 	if resp.StatusCode >= http.StatusMultipleChoices {
 		return fmt.Errorf("telemetry endpoint returned status %d", resp.StatusCode)
 	}

--- a/apps/backend/internal/telemetry/sink.go
+++ b/apps/backend/internal/telemetry/sink.go
@@ -1,0 +1,78 @@
+package telemetry
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Sink delivers a batch of events keyed by the anonymous install ID.
+// The production implementation posts to PostHog; tests inject fakes.
+type Sink interface {
+	Send(ctx context.Context, distinctID string, events []Event) error
+}
+
+// postHogSink posts batches to the PostHog /batch/ endpoint using the
+// write-only project API key. Events are sent in anonymous mode
+// ($process_person_profiles: false) so no person profile is ever built.
+type postHogSink struct {
+	endpoint string
+	apiKey   string
+	client   *http.Client
+}
+
+func newPostHogSink(endpoint, apiKey string) *postHogSink {
+	return &postHogSink{
+		endpoint: strings.TrimRight(endpoint, "/"),
+		apiKey:   apiKey,
+		client:   &http.Client{Timeout: sendTimeout},
+	}
+}
+
+type postHogItem struct {
+	Event      string         `json:"event"`
+	DistinctID string         `json:"distinct_id"`
+	Timestamp  string         `json:"timestamp"`
+	Properties map[string]any `json:"properties"`
+}
+
+func (p *postHogSink) Send(ctx context.Context, distinctID string, events []Event) error {
+	items := make([]postHogItem, 0, len(events))
+	for _, event := range events {
+		properties := map[string]any{
+			"$process_person_profiles": false,
+			"$lib":                     "kandev",
+		}
+		for k, v := range event.Properties {
+			properties[k] = v
+		}
+		items = append(items, postHogItem{
+			Event:      event.Name,
+			DistinctID: distinctID,
+			Timestamp:  event.Timestamp.UTC().Format(time.RFC3339),
+			Properties: properties,
+		})
+	}
+	body, err := json.Marshal(map[string]any{"api_key": p.apiKey, "batch": items})
+	if err != nil {
+		return fmt.Errorf("marshal telemetry batch: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, p.endpoint+"/batch/", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("build telemetry request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("post telemetry batch: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= http.StatusMultipleChoices {
+		return fmt.Errorf("telemetry endpoint returned status %d", resp.StatusCode)
+	}
+	return nil
+}

--- a/apps/backend/internal/telemetry/sink_test.go
+++ b/apps/backend/internal/telemetry/sink_test.go
@@ -1,0 +1,70 @@
+package telemetry
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestPostHogSinkPayloadShape(t *testing.T) {
+	var gotPath string
+	var gotBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &gotBody)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	sink := newPostHogSink(server.URL, "phc_test_key")
+	events := []Event{
+		{Name: EventTaskCreated, Timestamp: time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC),
+			Properties: map[string]string{"app_version": "1.0.0"}},
+	}
+	if err := sink.Send(context.Background(), "install-uuid-1", events); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	if gotPath != "/batch/" {
+		t.Fatalf("expected /batch/ path, got %q", gotPath)
+	}
+	if gotBody["api_key"] != "phc_test_key" {
+		t.Fatalf("api_key missing: %v", gotBody)
+	}
+	batch, ok := gotBody["batch"].([]any)
+	if !ok || len(batch) != 1 {
+		t.Fatalf("expected batch of 1, got %v", gotBody["batch"])
+	}
+	item := batch[0].(map[string]any)
+	if item["event"] != EventTaskCreated || item["distinct_id"] != "install-uuid-1" {
+		t.Fatalf("unexpected item: %v", item)
+	}
+	if item["timestamp"] != "2026-07-15T12:00:00Z" {
+		t.Fatalf("unexpected timestamp: %v", item["timestamp"])
+	}
+	properties := item["properties"].(map[string]any)
+	if properties["$process_person_profiles"] != false {
+		t.Fatalf("events must be anonymous-mode: %v", properties)
+	}
+	if properties["app_version"] != "1.0.0" || properties["$lib"] != "kandev" {
+		t.Fatalf("properties not merged: %v", properties)
+	}
+}
+
+func TestPostHogSinkErrorsOnNon2xx(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer server.Close()
+
+	sink := newPostHogSink(server.URL, "phc_test_key")
+	err := sink.Send(context.Background(), "id", []Event{{Name: EventTaskCreated, Timestamp: time.Now()}})
+	if err == nil {
+		t.Fatal("expected error on 502")
+	}
+}

--- a/apps/backend/internal/telemetry/sink_test.go
+++ b/apps/backend/internal/telemetry/sink_test.go
@@ -48,8 +48,8 @@ func TestPostHogSinkPayloadShape(t *testing.T) {
 		t.Fatalf("unexpected timestamp: %v", item["timestamp"])
 	}
 	properties := item["properties"].(map[string]any)
-	if properties["$process_person_profiles"] != false {
-		t.Fatalf("events must be anonymous-mode: %v", properties)
+	if properties["$process_person_profile"] != false {
+		t.Fatalf("events must be anonymous-mode ($process_person_profile: false): %v", properties)
 	}
 	if properties["app_version"] != "1.0.0" || properties["$lib"] != "kandev" {
 		t.Fatalf("properties not merged: %v", properties)

--- a/apps/backend/internal/telemetry/telemetry.go
+++ b/apps/backend/internal/telemetry/telemetry.go
@@ -16,6 +16,7 @@
 package telemetry
 
 import (
+	"encoding/json"
 	"os"
 	"regexp"
 	"runtime"
@@ -63,7 +64,8 @@ type Event struct {
 // event emitted when they fire. Deliberately name-only: the bus payloads
 // carry task titles, repository names, and branch names, none of which
 // may ever leave the machine, so the collector counts occurrences and
-// forwards nothing from the payload itself.
+// forwards nothing from the payload itself — except the specific
+// enum-shaped keys declared in busEventPropertyKeys.
 var busEventAllowlist = map[string]string{
 	events.TaskCreated:          EventTaskCreated,
 	events.TaskDeleted:          EventTaskDeleted,
@@ -73,6 +75,45 @@ var busEventAllowlist = map[string]string{
 	events.TurnCompleted:        EventTurnCompleted,
 	events.WorkspaceCreated:     EventWorkspaceCreated,
 	events.AutomationRunCreated: EventAutomationRun,
+}
+
+// busEventPropertyKeys lists, per subject, the only payload keys the
+// collector may forward. Values must additionally match safeValueRe, so
+// only closed-enum identifiers survive — free-text fields like
+// error_message are structurally unreachable. agent.failed carries the
+// routingerr classification (see docs/public/telemetry.md).
+var busEventPropertyKeys = map[string][]string{
+	events.AgentFailed: {"error_code", "error_phase"},
+}
+
+// extractAllowlistedProps pulls the per-subject allowlisted keys out of a
+// bus payload via a JSON round-trip (payload shapes vary by publisher and
+// the telemetry package must not import runtime-tier types).
+func extractAllowlistedProps(subject string, data any) map[string]string {
+	keys := busEventPropertyKeys[subject]
+	if len(keys) == 0 || data == nil {
+		return nil
+	}
+	raw, err := json.Marshal(data)
+	if err != nil {
+		return nil
+	}
+	var fields map[string]any
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return nil
+	}
+	var props map[string]string
+	for _, key := range keys {
+		value, ok := fields[key].(string)
+		if !ok || !safeValueRe.MatchString(value) {
+			continue
+		}
+		if props == nil {
+			props = map[string]string{}
+		}
+		props[key] = value
+	}
+	return props
 }
 
 // uiEventAllowlist declares which events the frontend may submit via

--- a/apps/backend/internal/telemetry/telemetry.go
+++ b/apps/backend/internal/telemetry/telemetry.go
@@ -1,10 +1,12 @@
 // Package telemetry implements strictly opt-in product telemetry.
 //
 // Nothing is ever collected or sent unless the user has explicitly granted
-// consent (stored install-wide via internal/system/settings). Two env kill
-// switches are honoured unconditionally, before consent is even consulted:
-// DO_NOT_TRACK=1 and KANDEV_TELEMETRY=off. When either is set the service
-// starts no goroutines, subscribes to nothing, and the HTTP surface reports
+// consent (stored install-wide via internal/system/settings). The stored
+// consent is the single user-facing control; two environment conditions
+// hard-disable collection before consent is even consulted: the
+// DO_NOT_TRACK=1 convention, and e2e test mode (KANDEV_E2E_MOCK), so CI
+// runs can never emit real events. When either applies the service starts
+// no goroutines, subscribes to nothing, and the HTTP surface reports
 // env_disabled so the frontend hides its consent prompts.
 //
 // Events are allowlisted by name and may only carry enum-like identifier
@@ -17,10 +19,10 @@ import (
 	"os"
 	"regexp"
 	"runtime"
-	"strings"
 	"time"
 
 	"github.com/kandev/kandev/internal/events"
+	"github.com/kandev/kandev/internal/profiles"
 )
 
 // Built-in PostHog EU ingestion defaults. The API key is a write-only
@@ -106,18 +108,15 @@ func sanitizeUIEvent(name string, properties map[string]string) (Event, bool) {
 // EnvDisabled reports whether telemetry is hard-disabled by environment.
 // Checked before consent: when true the service never starts and the UI
 // hides its consent prompts. DO_NOT_TRACK follows the consoledonottrack.com
-// convention; KANDEV_TELEMETRY is the Kandev-specific switch set to "off"
-// by the dev and e2e profiles in profiles.yaml.
+// convention; e2e mode piggybacks on the existing KANDEV_E2E_MOCK selector
+// so playwright-spawned backends can never emit real events even if a spec
+// grants consent. The stored opt-in is otherwise the only control.
 func EnvDisabled() bool {
 	switch os.Getenv("DO_NOT_TRACK") {
 	case "1", "true", "yes", "on":
 		return true
 	}
-	switch strings.ToLower(os.Getenv("KANDEV_TELEMETRY")) {
-	case "off", "false", "0", "disabled":
-		return true
-	}
-	return false
+	return profiles.DetectEnvironment() == profiles.EnvE2E
 }
 
 // detectDeployMode classifies how this install runs, as a coarse enum.

--- a/apps/backend/internal/telemetry/telemetry.go
+++ b/apps/backend/internal/telemetry/telemetry.go
@@ -1,0 +1,145 @@
+// Package telemetry implements strictly opt-in product telemetry.
+//
+// Nothing is ever collected or sent unless the user has explicitly granted
+// consent (stored install-wide via internal/system/settings). Two env kill
+// switches are honoured unconditionally, before consent is even consulted:
+// DO_NOT_TRACK=1 and KANDEV_TELEMETRY=off. When either is set the service
+// starts no goroutines, subscribes to nothing, and the HTTP surface reports
+// env_disabled so the frontend hides its consent prompts.
+//
+// Events are allowlisted by name and may only carry enum-like identifier
+// properties — never free text, repository names, paths, prompts, or task
+// titles. The full event table is documented in docs/public/telemetry.md;
+// keep the two in sync when adding events.
+package telemetry
+
+import (
+	"os"
+	"regexp"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/kandev/kandev/internal/events"
+)
+
+// Built-in PostHog EU ingestion defaults. The API key is a write-only
+// project key (it can only append events, not read anything), so shipping
+// it in the binary is safe and standard practice for product analytics.
+// Both can be overridden via KANDEV_TELEMETRY_ENDPOINT / _API_KEY.
+const (
+	defaultEndpoint = "https://eu.i.posthog.com"
+	defaultAPIKey   = "phc_yfDW5DdbvXqDuajS6UQ9gThUTEgY8Wk5qY4SfstUyVvA"
+)
+
+// Telemetry event names. snake_case, stable, and documented in
+// docs/public/telemetry.md.
+const (
+	EventInstallHeartbeat  = "install_heartbeat"
+	EventTelemetryEnabled  = "telemetry_enabled"
+	EventTaskCreated       = "task_created"
+	EventTaskDeleted       = "task_deleted"
+	EventAgentRunStarted   = "agent_run_started"
+	EventAgentRunCompleted = "agent_run_completed"
+	EventAgentRunFailed    = "agent_run_failed"
+	EventTurnCompleted     = "turn_completed"
+	EventWorkspaceCreated  = "workspace_created"
+	EventAutomationRun     = "automation_run_created"
+	EventUIPageViewed      = "ui_page_viewed"
+	EventUIAction          = "ui_action"
+	EventFeatureUsed       = "feature_used"
+)
+
+// Event is a single allowlisted telemetry event pending delivery.
+type Event struct {
+	Name       string
+	Properties map[string]string
+	Timestamp  time.Time
+}
+
+// busEventAllowlist maps internal event-bus subjects to the telemetry
+// event emitted when they fire. Deliberately name-only: the bus payloads
+// carry task titles, repository names, and branch names, none of which
+// may ever leave the machine, so the collector counts occurrences and
+// forwards nothing from the payload itself.
+var busEventAllowlist = map[string]string{
+	events.TaskCreated:          EventTaskCreated,
+	events.TaskDeleted:          EventTaskDeleted,
+	events.AgentStarted:         EventAgentRunStarted,
+	events.AgentCompleted:       EventAgentRunCompleted,
+	events.AgentFailed:          EventAgentRunFailed,
+	events.TurnCompleted:        EventTurnCompleted,
+	events.WorkspaceCreated:     EventWorkspaceCreated,
+	events.AutomationRunCreated: EventAutomationRun,
+}
+
+// uiEventAllowlist declares which events the frontend may submit via
+// POST /api/v1/telemetry/events and the single enum property each may
+// carry. Anything else is dropped server-side.
+var uiEventAllowlist = map[string]string{
+	EventUIPageViewed: "page",
+	EventUIAction:     "action",
+	EventFeatureUsed:  "feature",
+}
+
+// safeValueRe bounds UI-submitted property values to short enum-like
+// identifiers so free text can never ride along.
+var safeValueRe = regexp.MustCompile(`^[a-z0-9][a-z0-9_.:-]{0,63}$`)
+
+// maxUIEventsPerRequest caps a single POST /events payload.
+const maxUIEventsPerRequest = 20
+
+// sanitizeUIEvent validates a frontend-submitted event against the
+// allowlist. Returns the cleaned event and whether it is acceptable.
+func sanitizeUIEvent(name string, properties map[string]string) (Event, bool) {
+	propKey, ok := uiEventAllowlist[name]
+	if !ok {
+		return Event{}, false
+	}
+	value, ok := properties[propKey]
+	if !ok || !safeValueRe.MatchString(value) {
+		return Event{}, false
+	}
+	return Event{Name: name, Properties: map[string]string{propKey: value}}, true
+}
+
+// EnvDisabled reports whether telemetry is hard-disabled by environment.
+// Checked before consent: when true the service never starts and the UI
+// hides its consent prompts. DO_NOT_TRACK follows the consoledonottrack.com
+// convention; KANDEV_TELEMETRY is the Kandev-specific switch set to "off"
+// by the dev and e2e profiles in profiles.yaml.
+func EnvDisabled() bool {
+	switch os.Getenv("DO_NOT_TRACK") {
+	case "1", "true", "yes", "on":
+		return true
+	}
+	switch strings.ToLower(os.Getenv("KANDEV_TELEMETRY")) {
+	case "off", "false", "0", "disabled":
+		return true
+	}
+	return false
+}
+
+// detectDeployMode classifies how this install runs, as a coarse enum.
+func detectDeployMode() string {
+	if os.Getenv("KUBERNETES_SERVICE_HOST") != "" {
+		return "k8s"
+	}
+	if _, err := os.Stat("/.dockerenv"); err == nil {
+		return "docker"
+	}
+	if os.Getenv("KANDEV_DESKTOP_HEALTH_TOKEN") != "" {
+		return "desktop"
+	}
+	return "local"
+}
+
+// baseProperties returns the coarse context attached to every event.
+func (s *Service) baseProperties() map[string]string {
+	return map[string]string{
+		"app_version": s.opts.Version,
+		"os":          runtime.GOOS,
+		"arch":        runtime.GOARCH,
+		"deploy_mode": s.opts.DeployMode,
+	}
+}

--- a/apps/backend/internal/telemetry/testmain_test.go
+++ b/apps/backend/internal/telemetry/testmain_test.go
@@ -1,0 +1,14 @@
+package telemetry
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+// TestMain asserts no goroutines from this package outlive the tests.
+// The Service owns exactly two loops (flush, heartbeat) guarded by
+// Start/Stop; goleak catches any path that forgets the WaitGroup.
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -75,7 +75,7 @@ See [docs/run-as-a-service.md](../../docs/run-as-a-service.md) for the full guid
 
 ## Learn More
 
-Open source, multi-provider, no telemetry, not tied to any cloud.
+Open source, multi-provider, telemetry strictly opt-in, not tied to any cloud.
 
 See the [GitHub repository](https://github.com/kdlbs/kandev) for architecture, vision, development setup, and contributing guidelines.
 

--- a/apps/web/app/settings/system/telemetry/page.tsx
+++ b/apps/web/app/settings/system/telemetry/page.tsx
@@ -1,0 +1,13 @@
+import { TelemetrySettings } from "@/components/settings/system/telemetry-settings";
+import { SystemPageShell } from "@/components/settings/system/system-page-shell";
+
+export default function TelemetryPage() {
+  return (
+    <SystemPageShell
+      title="Telemetry"
+      description="Strictly opt-in anonymous usage sharing. Nothing is sent unless you enable it."
+    >
+      <TelemetrySettings />
+    </SystemPageShell>
+  );
+}

--- a/apps/web/components/app-sidebar/sections/settings/system-group.tsx
+++ b/apps/web/components/app-sidebar/sections/settings/system-group.tsx
@@ -3,6 +3,7 @@
 import {
   IconActivity,
   IconArchive,
+  IconChartDots,
   IconDatabase,
   IconFileText,
   IconFlask,
@@ -23,6 +24,7 @@ const ITEMS: Array<{ href: string; label: string; icon: TablerIcon }> = [
   { href: `${ROOT_HREF}/database`, label: "Database", icon: IconDatabase },
   { href: `${ROOT_HREF}/backups`, label: "Backups", icon: IconArchive },
   { href: `${ROOT_HREF}/logs`, label: "Logs", icon: IconFileText },
+  { href: `${ROOT_HREF}/telemetry`, label: "Telemetry", icon: IconChartDots },
   { href: `${ROOT_HREF}/updates`, label: "Updates", icon: IconRefresh },
   { href: `${ROOT_HREF}/about`, label: "About", icon: IconInfoCircle },
   { href: `${ROOT_HREF}/licenses`, label: "Licenses", icon: IconScale },

--- a/apps/web/components/onboarding-dialog.tsx
+++ b/apps/web/components/onboarding-dialog.tsx
@@ -33,6 +33,7 @@ import { permissionsToProfilePatch, profilePermissionValues } from "@/lib/agent-
 import { listAvailableAgents, listWorkflowTemplates } from "@/lib/api";
 import { listAgentsAction, updateAgentProfileAction } from "@/app/actions/agents";
 import { StepAgents, type AgentSetting } from "@/components/onboarding/step-agents";
+import { StepTelemetry, useTelemetryOnboarding } from "@/components/onboarding/step-telemetry";
 import type { AvailableAgent, ToolStatus, WorkflowTemplate, AgentProfile } from "@/lib/types/http";
 
 interface OnboardingDialogProps {
@@ -74,6 +75,12 @@ const STEP_DESCRIPTIONS = [
   "Quick access to actions from anywhere with a keyboard shortcut.",
 ];
 
+// Appended only while the install has never been asked about telemetry
+// (and the env kill switches are off). See step-telemetry.tsx.
+const TELEMETRY_STEP_TITLE = "Help improve Kandev";
+const TELEMETRY_STEP_DESCRIPTION =
+  "Optional anonymous usage sharing — stays off unless you turn it on.";
+
 function buildAgentSettings(
   avail: AvailableAgent[],
   saved: {
@@ -112,16 +119,17 @@ function buildAgentSettings(
 
 type OnboardingFooterProps = {
   step: number;
+  totalSteps: number;
   onSkip: () => void;
   onBack: () => void;
   onNext: () => void;
   onGetStarted: () => void;
 };
 
-function OnboardingStepDots({ step }: { step: number }) {
+function OnboardingStepDots({ step, totalSteps }: { step: number; totalSteps: number }) {
   return (
     <div className="flex justify-center gap-1.5 pb-2">
-      {Array.from({ length: TOTAL_STEPS }).map((_, i) => (
+      {Array.from({ length: totalSteps }).map((_, i) => (
         <div
           key={i}
           className={`h-1.5 rounded-full transition-all ${i === step ? "w-6 bg-primary" : "w-1.5 bg-muted-foreground/30"}`}
@@ -213,7 +221,14 @@ function useOnboardingResources(open: boolean) {
   };
 }
 
-function OnboardingFooter({ step, onSkip, onBack, onNext, onGetStarted }: OnboardingFooterProps) {
+function OnboardingFooter({
+  step,
+  totalSteps,
+  onSkip,
+  onBack,
+  onNext,
+  onGetStarted,
+}: OnboardingFooterProps) {
   return (
     <DialogFooter>
       <div className="flex w-full items-center justify-between">
@@ -228,7 +243,7 @@ function OnboardingFooter({ step, onSkip, onBack, onNext, onGetStarted }: Onboar
               Back
             </Button>
           )}
-          {step < TOTAL_STEPS - 1 ? (
+          {step < totalSteps - 1 ? (
             <Button onClick={onNext} className="cursor-pointer">
               Next
               <IconArrowRight className="ml-1.5 h-4 w-4" />
@@ -256,6 +271,11 @@ export function OnboardingDialog({ open, onComplete }: OnboardingDialogProps) {
     loadingAgents,
     loadingTemplates,
   } = useOnboardingResources(open);
+  const { showTelemetryStep } = useTelemetryOnboarding(open);
+  const totalSteps = showTelemetryStep ? TOTAL_STEPS + 1 : TOTAL_STEPS;
+  const stepTitle = step === TOTAL_STEPS ? TELEMETRY_STEP_TITLE : STEP_TITLES[step];
+  const stepDescription =
+    step === TOTAL_STEPS ? TELEMETRY_STEP_DESCRIPTION : STEP_DESCRIPTIONS[step];
 
   const saveAgentSettings = useCallback(async () => {
     await Promise.all(
@@ -278,7 +298,7 @@ export function OnboardingDialog({ open, onComplete }: OnboardingDialogProps) {
   };
   const handleNext = async () => {
     if (step === 0) await saveAgentSettings();
-    if (step < TOTAL_STEPS - 1) setStep(step + 1);
+    if (step < totalSteps - 1) setStep(step + 1);
   };
   const handleBack = () => {
     if (step > 0) setStep(step - 1);
@@ -303,8 +323,8 @@ export function OnboardingDialog({ open, onComplete }: OnboardingDialogProps) {
     <Dialog open={open} onOpenChange={() => {}}>
       <DialogContent className="sm:max-w-3xl" showCloseButton={false}>
         <DialogHeader>
-          <DialogTitle className="text-center text-2xl">{STEP_TITLES[step]}</DialogTitle>
-          <DialogDescription className="text-center">{STEP_DESCRIPTIONS[step]}</DialogDescription>
+          <DialogTitle className="text-center text-2xl">{stepTitle}</DialogTitle>
+          <DialogDescription className="text-center">{stepDescription}</DialogDescription>
         </DialogHeader>
         <div className="py-4 min-h-[220px]">
           {step === 0 && (
@@ -319,10 +339,12 @@ export function OnboardingDialog({ open, onComplete }: OnboardingDialogProps) {
           {step === 1 && <StepEnvironments />}
           {step === 2 && <StepWorkflows templates={templates} loading={loadingTemplates} />}
           {step === 3 && <StepCommandPanel />}
+          {step === 4 && <StepTelemetry />}
         </div>
-        <OnboardingStepDots step={step} />
+        <OnboardingStepDots step={step} totalSteps={totalSteps} />
         <OnboardingFooter
           step={step}
+          totalSteps={totalSteps}
           onSkip={handleSkip}
           onBack={handleBack}
           onNext={handleNext}

--- a/apps/web/components/onboarding/step-telemetry.tsx
+++ b/apps/web/components/onboarding/step-telemetry.tsx
@@ -38,7 +38,7 @@ export function useTelemetryOnboarding(open: boolean): { showTelemetryStep: bool
 }
 
 const SHARED_ITEMS = [
-  "Version, OS, and deploy mode (daily heartbeat)",
+  "Version, OS, CPU architecture, and deploy mode (daily heartbeat)",
   "Counts of events like task created or agent run completed",
   "Which UI pages and features are used (identifiers only)",
 ];

--- a/apps/web/components/onboarding/step-telemetry.tsx
+++ b/apps/web/components/onboarding/step-telemetry.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Button } from "@kandev/ui/button";
+import { IconChartDots, IconCheck, IconShieldLock } from "@tabler/icons-react";
+import { fetchTelemetryConsent, updateTelemetryConsent } from "@/lib/api/domains/telemetry-api";
+import { updateTelemetryConsentCache } from "@/lib/telemetry/track";
+import type { TelemetryConsentState, TelemetryConsentStatus } from "@/lib/types/telemetry";
+
+/**
+ * Decides whether the onboarding dialog should show the telemetry consent
+ * step: only when the install has never been asked and the env kill
+ * switches (KANDEV_TELEMETRY=off / DO_NOT_TRACK) are not active.
+ */
+export function useTelemetryOnboarding(open: boolean): { showTelemetryStep: boolean } {
+  const [consent, setConsent] = useState<TelemetryConsentState | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    fetchTelemetryConsent()
+      .then((res) => {
+        if (cancelled) return;
+        setConsent(res);
+        updateTelemetryConsentCache(res);
+      })
+      .catch(() => {
+        // Backend without telemetry support (or transient error): no step.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open]);
+
+  return {
+    showTelemetryStep: consent !== null && consent.status === "unasked" && !consent.env_disabled,
+  };
+}
+
+const SHARED_ITEMS = [
+  "Version, OS, and deploy mode (daily heartbeat)",
+  "Counts of events like task created or agent run completed",
+  "Which UI pages and features are used (identifiers only)",
+];
+
+const NEVER_ITEMS = ["Prompts, code, or diffs", "Task titles, repo names, branches, or paths"];
+
+/**
+ * The consent step body. Choosing either option records the decision
+ * immediately; leaving the step untouched keeps telemetry off and the
+ * question available later under Settings → System → Telemetry.
+ */
+export function StepTelemetry() {
+  const [choice, setChoice] = useState<Exclude<TelemetryConsentStatus, "unasked"> | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const choose = async (status: Exclude<TelemetryConsentStatus, "unasked">) => {
+    setIsSaving(true);
+    try {
+      const next = await updateTelemetryConsent(status);
+      updateTelemetryConsentCache(next);
+      setChoice(status);
+    } catch {
+      // Leave undecided; the settings page remains available.
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-2 sm:grid-cols-2">
+        <div className="rounded-lg border p-3">
+          <div className="flex items-center gap-2 text-sm font-medium">
+            <IconChartDots className="h-4 w-4 text-muted-foreground" />
+            Shared if you opt in
+          </div>
+          <ItemList items={SHARED_ITEMS} />
+        </div>
+        <div className="rounded-lg border p-3">
+          <div className="flex items-center gap-2 text-sm font-medium">
+            <IconShieldLock className="h-4 w-4 text-muted-foreground" />
+            Never shared
+          </div>
+          <ItemList items={NEVER_ITEMS} />
+        </div>
+      </div>
+      {choice === null ? (
+        <div className="flex flex-col items-center gap-2 sm:flex-row sm:justify-center">
+          <Button
+            onClick={() => void choose("granted")}
+            disabled={isSaving}
+            className="cursor-pointer"
+            data-testid="onboarding-telemetry-accept"
+          >
+            Share anonymous usage data
+          </Button>
+          <Button
+            variant="outline"
+            onClick={() => void choose("denied")}
+            disabled={isSaving}
+            className="cursor-pointer"
+            data-testid="onboarding-telemetry-decline"
+          >
+            No thanks
+          </Button>
+        </div>
+      ) : (
+        <p className="flex items-center justify-center gap-1.5 text-sm text-muted-foreground">
+          <IconCheck className="h-4 w-4 text-green-600 dark:text-green-400" />
+          {choice === "granted"
+            ? "Thank you! Anonymous usage sharing is on."
+            : "Understood — nothing will be shared."}{" "}
+          Change this anytime in Settings → System → Telemetry.
+        </p>
+      )}
+      <p className="text-center text-xs text-muted-foreground">
+        Strictly opt-in and anonymous (random install ID, EU-hosted). Skipping this step keeps
+        sharing off.
+      </p>
+    </div>
+  );
+}
+
+function ItemList({ items }: { items: string[] }) {
+  return (
+    <ul className="mt-1.5 list-disc space-y-1 pl-5 text-xs text-muted-foreground">
+      {items.map((item) => (
+        <li key={item}>{item}</li>
+      ))}
+    </ul>
+  );
+}

--- a/apps/web/components/onboarding/step-telemetry.tsx
+++ b/apps/web/components/onboarding/step-telemetry.tsx
@@ -9,8 +9,8 @@ import type { TelemetryConsentState, TelemetryConsentStatus } from "@/lib/types/
 
 /**
  * Decides whether the onboarding dialog should show the telemetry consent
- * step: only when the install has never been asked and the env kill
- * switches (KANDEV_TELEMETRY=off / DO_NOT_TRACK) are not active.
+ * step: only when the install has never been asked and the environment
+ * does not hard-disable telemetry (DO_NOT_TRACK / e2e test mode).
  */
 export function useTelemetryOnboarding(open: boolean): { showTelemetryStep: boolean } {
   const [consent, setConsent] = useState<TelemetryConsentState | null>(null);

--- a/apps/web/components/settings/system/telemetry-settings.tsx
+++ b/apps/web/components/settings/system/telemetry-settings.tsx
@@ -143,9 +143,8 @@ function ConsentCard({
         )}
         <p>
           Set <span className="font-mono text-xs">KANDEV_TELEMETRY_DEBUG=1</span> to log every
-          outgoing payload locally, or{" "}
-          <span className="font-mono text-xs">KANDEV_TELEMETRY=off</span> /{" "}
-          <span className="font-mono text-xs">DO_NOT_TRACK=1</span> to hard-disable collection.
+          outgoing payload locally. The <span className="font-mono text-xs">DO_NOT_TRACK=1</span>{" "}
+          convention is honoured and hard-disables collection.
         </p>
       </CardContent>
     </Card>
@@ -197,8 +196,8 @@ function EnvDisabledAlert() {
       <IconShieldLock className="h-4 w-4 text-muted-foreground" />
       <AlertTitle>Disabled by environment</AlertTitle>
       <AlertDescription className="text-muted-foreground">
-        KANDEV_TELEMETRY=off or DO_NOT_TRACK is set for this install, so telemetry is hard-disabled
-        regardless of the preference below and no data is ever sent.
+        DO_NOT_TRACK is set (or this is a test-mode run), so telemetry is hard-disabled regardless
+        of the preference below and no data is ever sent.
       </AlertDescription>
     </Alert>
   );

--- a/apps/web/components/settings/system/telemetry-settings.tsx
+++ b/apps/web/components/settings/system/telemetry-settings.tsx
@@ -1,0 +1,205 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { Alert, AlertDescription, AlertTitle } from "@kandev/ui/alert";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@kandev/ui/card";
+import { Spinner } from "@kandev/ui/spinner";
+import { Switch } from "@kandev/ui/switch";
+import { IconShieldLock } from "@tabler/icons-react";
+import { useToast } from "@/components/toast-provider";
+import { fetchTelemetryConsent, updateTelemetryConsent } from "@/lib/api/domains/telemetry-api";
+import { updateTelemetryConsentCache } from "@/lib/telemetry/track";
+import type { TelemetryConsentState } from "@/lib/types/telemetry";
+
+const TELEMETRY_DOCS_URL = "https://github.com/kdlbs/kandev/blob/main/docs/public/telemetry.md";
+
+const COLLECTED_ITEMS = [
+  "A daily heartbeat with the Kandev version, OS, CPU architecture, and deploy mode (local, Docker, Kubernetes, or desktop)",
+  "Counts of product events: task created/deleted, agent run started/completed/failed, turn completed, workspace created, automation run",
+  "Which UI pages and allowlisted actions are used (identifiers only)",
+];
+
+const NEVER_COLLECTED_ITEMS = [
+  "Prompts, chat messages, code, or diffs",
+  "Task titles, repository names, branch names, or file paths",
+  "Your name, email, IP-derived profile, or any account identifier",
+];
+
+export function TelemetrySettings() {
+  const [state, setState] = useState<TelemetryConsentState | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const { toast } = useToast();
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchTelemetryConsent()
+      .then((res) => {
+        if (cancelled) return;
+        setState(res);
+        updateTelemetryConsentCache(res);
+      })
+      .catch(() => {
+        if (!cancelled) setState(null);
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const setConsent = useCallback(
+    async (granted: boolean) => {
+      setIsSaving(true);
+      try {
+        const next = await updateTelemetryConsent(granted ? "granted" : "denied");
+        setState(next);
+        updateTelemetryConsentCache(next);
+        toast({
+          title: granted ? "Anonymous telemetry enabled" : "Telemetry disabled",
+          variant: "success",
+        });
+      } catch (err) {
+        toast({
+          title: "Failed to save telemetry preference",
+          description: err instanceof Error ? err.message : String(err),
+          variant: "error",
+        });
+      } finally {
+        setIsSaving(false);
+      }
+    },
+    [toast],
+  );
+
+  if (isLoading) {
+    return (
+      <Card>
+        <CardContent className="flex items-center gap-2 py-6 text-sm text-muted-foreground">
+          <Spinner className="size-4" />
+          Loading telemetry settings...
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (state === null) {
+    return (
+      <Card>
+        <CardContent className="py-6 text-sm text-muted-foreground">
+          Telemetry settings could not be loaded.
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-4" data-testid="telemetry-settings">
+      {state.env_disabled && <EnvDisabledAlert />}
+      <ConsentCard state={state} isSaving={isSaving} onConsentChange={setConsent} />
+      <CollectedCard />
+    </div>
+  );
+}
+
+function ConsentCard({
+  state,
+  isSaving,
+  onConsentChange,
+}: {
+  state: TelemetryConsentState;
+  isSaving: boolean;
+  onConsentChange: (granted: boolean) => Promise<void>;
+}) {
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-start justify-between gap-4 space-y-0">
+        <div className="space-y-1.5">
+          <CardTitle>Share anonymous usage data</CardTitle>
+          <CardDescription>
+            Strictly opt-in. Helps the Kandev team understand which features matter. Events are
+            anonymous, allowlisted, and sent to an EU-hosted PostHog instance.
+          </CardDescription>
+        </div>
+        <Switch
+          checked={state.status === "granted"}
+          disabled={isSaving || state.env_disabled}
+          onCheckedChange={(checked) => void onConsentChange(checked)}
+          aria-label="Share anonymous usage data"
+          data-testid="telemetry-consent-switch"
+        />
+      </CardHeader>
+      <CardContent className="space-y-2 text-sm text-muted-foreground">
+        {state.status === "unasked" && (
+          <p>You haven&apos;t decided yet — nothing is shared until you opt in.</p>
+        )}
+        {state.status === "granted" && state.install_id && (
+          <p>
+            Anonymous install ID: <span className="font-mono text-xs">{state.install_id}</span>{" "}
+            (random UUID, minted when you opted in; deleted if you opt out)
+          </p>
+        )}
+        <p>
+          Set <span className="font-mono text-xs">KANDEV_TELEMETRY_DEBUG=1</span> to log every
+          outgoing payload locally, or{" "}
+          <span className="font-mono text-xs">KANDEV_TELEMETRY=off</span> /{" "}
+          <span className="font-mono text-xs">DO_NOT_TRACK=1</span> to hard-disable collection.
+        </p>
+      </CardContent>
+    </Card>
+  );
+}
+
+function CollectedCard() {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">What is collected</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4 text-sm text-muted-foreground">
+        <ItemList items={COLLECTED_ITEMS} />
+        <div>
+          <p className="mb-1 font-medium text-foreground">Never collected</p>
+          <ItemList items={NEVER_COLLECTED_ITEMS} />
+        </div>
+        <p>
+          The full event table lives in{" "}
+          <a
+            href={TELEMETRY_DOCS_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline cursor-pointer"
+          >
+            the telemetry documentation
+          </a>
+          .
+        </p>
+      </CardContent>
+    </Card>
+  );
+}
+
+function ItemList({ items }: { items: string[] }) {
+  return (
+    <ul className="list-disc space-y-1 pl-5">
+      {items.map((item) => (
+        <li key={item}>{item}</li>
+      ))}
+    </ul>
+  );
+}
+
+function EnvDisabledAlert() {
+  return (
+    <Alert className="border-border/70 bg-muted/30">
+      <IconShieldLock className="h-4 w-4 text-muted-foreground" />
+      <AlertTitle>Disabled by environment</AlertTitle>
+      <AlertDescription className="text-muted-foreground">
+        KANDEV_TELEMETRY=off or DO_NOT_TRACK is set for this install, so telemetry is hard-disabled
+        regardless of the preference below and no data is ever sent.
+      </AlertDescription>
+    </Alert>
+  );
+}

--- a/apps/web/components/settings/system/telemetry-settings.tsx
+++ b/apps/web/components/settings/system/telemetry-settings.tsx
@@ -15,7 +15,7 @@ const TELEMETRY_DOCS_URL = "https://github.com/kdlbs/kandev/blob/main/docs/publi
 
 const COLLECTED_ITEMS = [
   "A daily heartbeat with the Kandev version, OS, CPU architecture, and deploy mode (local, Docker, Kubernetes, or desktop)",
-  "Counts of product events: task created/deleted, agent run started/completed/failed, turn completed, workspace created, automation run",
+  "Counts of product events: task created/deleted, agent run started/completed/failed (failures carry a coarse error class, never the message), turn completed, workspace created, automation run",
   "Which UI pages and allowlisted actions are used (identifiers only)",
 ];
 

--- a/apps/web/components/telemetry-page-view-bridge.tsx
+++ b/apps/web/components/telemetry-page-view-bridge.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { useEffect } from "react";
+import { usePathname } from "@/lib/routing/client-router";
+import { normalizePathForTelemetry, trackPageView } from "@/lib/telemetry/track";
+
+/**
+ * Emits an allowlisted ui_page_viewed telemetry event on route changes.
+ * Pathnames are reduced to route labels (IDs collapse to "id") before
+ * leaving the component, and the tracker itself is consent-gated — with
+ * telemetry unasked, denied, or env-disabled this renders to nothing
+ * observable.
+ */
+export function TelemetryPageViewBridge() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    trackPageView(normalizePathForTelemetry(pathname));
+  }, [pathname]);
+
+  return null;
+}

--- a/apps/web/e2e/tests/system/telemetry.spec.ts
+++ b/apps/web/e2e/tests/system/telemetry.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect } from "../../fixtures/test-base";
+
+/**
+ * Telemetry consent surface.
+ *
+ * E2E backends run with KANDEV_E2E_MOCK, which hard-disables telemetry
+ * (internal/telemetry.EnvDisabled) — the strongest guarantee that CI can
+ * never emit real events. That means the enabled-path UI toggle cannot be
+ * exercised here by design; grant/deny mechanics are covered at the API
+ * layer below and exhaustively in backend unit tests
+ * (internal/telemetry/*_test.go). This spec pins the wiring: the settings
+ * page renders, the env-disabled state is honest in both API and UI, and
+ * the consent API round-trips a preference without ever enabling emission.
+ *
+ * Single ordered test on purpose: the backend (and its consent row) is
+ * worker-scoped, so splitting grant/deny assertions into separate tests
+ * would create order-dependent flakes.
+ */
+test.describe("Telemetry settings", () => {
+  test("page renders env-disabled state and consent API round-trips", async ({
+    testPage,
+    backend,
+  }) => {
+    // 1. Fresh e2e install: consent unasked, hard-disabled by environment.
+    const initial = await (await fetch(`${backend.baseUrl}/api/v1/telemetry/consent`)).json();
+    expect(initial.status).toBe("unasked");
+    expect(initial.env_disabled).toBe(true);
+
+    // 2. Settings page renders with the banner and a disabled switch.
+    await testPage.goto("/settings/system/telemetry");
+    await expect(testPage.getByTestId("system-page-title")).toHaveText("Telemetry");
+    await expect(testPage.getByTestId("telemetry-settings")).toBeVisible();
+    await expect(testPage.getByText("Disabled by environment")).toBeVisible();
+    await expect(testPage.getByTestId("telemetry-consent-switch")).toBeDisabled();
+
+    // 3. The consent API still records the preference (grant mints an
+    //    install id, deny clears it) — emission stays impossible in e2e.
+    const grantRes = await fetch(`${backend.baseUrl}/api/v1/telemetry/consent`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status: "granted" }),
+    });
+    expect(grantRes.status).toBe(200);
+    const granted = await grantRes.json();
+    expect(granted.status).toBe("granted");
+    expect(granted.install_id).toBeTruthy();
+    expect(granted.env_disabled).toBe(true);
+
+    const denyRes = await fetch(`${backend.baseUrl}/api/v1/telemetry/consent`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status: "denied" }),
+    });
+    expect(denyRes.status).toBe(200);
+    const denied = await denyRes.json();
+    expect(denied.status).toBe("denied");
+    expect(denied.install_id).toBeFalsy();
+
+    // 4. Invalid statuses are rejected.
+    const badRes = await fetch(`${backend.baseUrl}/api/v1/telemetry/consent`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status: "unasked" }),
+    });
+    expect(badRes.status).toBe(400);
+  });
+});

--- a/apps/web/lib/api/domains/telemetry-api.test.ts
+++ b/apps/web/lib/api/domains/telemetry-api.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Pin the backend config to a deterministic base so URL assertions don't
+// depend on whatever environment the tests inherit.
+vi.mock("@/lib/config", () => ({
+  getBackendConfig: () => ({ apiBaseUrl: "http://api.test" }),
+}));
+
+import {
+  fetchTelemetryConsent,
+  sendTelemetryEvents,
+  updateTelemetryConsent,
+} from "./telemetry-api";
+
+const CONSENT_URL = "http://api.test/api/v1/telemetry/consent";
+const EVENTS_URL = "http://api.test/api/v1/telemetry/events";
+
+type FetchInput = Parameters<typeof fetch>[0];
+type FetchInit = Parameters<typeof fetch>[1];
+
+const fetchSpy = vi.fn<(...args: [FetchInput, FetchInit?]) => Promise<Response>>();
+
+beforeEach(() => {
+  fetchSpy.mockReset();
+  vi.stubGlobal("fetch", fetchSpy);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function jsonResponse(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  });
+}
+
+describe("fetchTelemetryConsent", () => {
+  it("GETs the consent endpoint", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ status: "unasked", env_disabled: false }));
+    const state = await fetchTelemetryConsent();
+    expect(state.status).toBe("unasked");
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe(CONSENT_URL);
+    expect(init?.method).toBeUndefined();
+  });
+});
+
+describe("updateTelemetryConsent", () => {
+  it("PUTs the new status", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      jsonResponse({ status: "granted", install_id: "abc", env_disabled: false }),
+    );
+    const state = await updateTelemetryConsent("granted");
+    expect(state.install_id).toBe("abc");
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe(CONSENT_URL);
+    expect(init?.method).toBe("PUT");
+    expect(JSON.parse(String(init?.body))).toEqual({ status: "granted" });
+  });
+});
+
+describe("sendTelemetryEvents", () => {
+  it("POSTs the event batch", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ accepted: 1 }, { status: 202 }));
+    const res = await sendTelemetryEvents([
+      { name: "ui_page_viewed", properties: { page: "settings.system.telemetry" } },
+    ]);
+    expect(res.accepted).toBe(1);
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe(EVENTS_URL);
+    expect(init?.method).toBe("POST");
+    expect(JSON.parse(String(init?.body))).toEqual({
+      events: [{ name: "ui_page_viewed", properties: { page: "settings.system.telemetry" } }],
+    });
+  });
+});

--- a/apps/web/lib/api/domains/telemetry-api.ts
+++ b/apps/web/lib/api/domains/telemetry-api.ts
@@ -1,0 +1,44 @@
+import { fetchJson, type ApiRequestOptions } from "../client";
+import type {
+  TelemetryConsentState,
+  TelemetryConsentStatus,
+  TelemetryEventsResponse,
+  TelemetryUIEvent,
+} from "@/lib/types/telemetry";
+
+const TELEMETRY_BASE = "/api/v1/telemetry";
+
+export function fetchTelemetryConsent(options?: ApiRequestOptions): Promise<TelemetryConsentState> {
+  return fetchJson<TelemetryConsentState>(`${TELEMETRY_BASE}/consent`, {
+    ...options,
+    cache: "no-store",
+  });
+}
+
+export function updateTelemetryConsent(
+  status: Exclude<TelemetryConsentStatus, "unasked">,
+  options?: ApiRequestOptions,
+): Promise<TelemetryConsentState> {
+  return fetchJson<TelemetryConsentState>(`${TELEMETRY_BASE}/consent`, {
+    ...options,
+    init: {
+      ...(options?.init ?? {}),
+      method: "PUT",
+      body: JSON.stringify({ status }),
+    },
+  });
+}
+
+export function sendTelemetryEvents(
+  events: TelemetryUIEvent[],
+  options?: ApiRequestOptions,
+): Promise<TelemetryEventsResponse> {
+  return fetchJson<TelemetryEventsResponse>(`${TELEMETRY_BASE}/events`, {
+    ...options,
+    init: {
+      ...(options?.init ?? {}),
+      method: "POST",
+      body: JSON.stringify({ events }),
+    },
+  });
+}

--- a/apps/web/lib/telemetry/track.test.ts
+++ b/apps/web/lib/telemetry/track.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { TelemetryConsentState } from "@/lib/types/telemetry";
+
+const fetchTelemetryConsent = vi.fn<() => Promise<TelemetryConsentState>>();
+const sendTelemetryEvents = vi.fn<() => Promise<{ accepted: number }>>();
+
+vi.mock("@/lib/api/domains/telemetry-api", () => ({
+  fetchTelemetryConsent: (...args: unknown[]) =>
+    (fetchTelemetryConsent as unknown as (...a: unknown[]) => unknown)(...args),
+  sendTelemetryEvents: (...args: unknown[]) =>
+    (sendTelemetryEvents as unknown as (...a: unknown[]) => unknown)(...args),
+}));
+
+import {
+  normalizePathForTelemetry,
+  resetTelemetryTrackingForTests,
+  trackAction,
+  trackPageView,
+  updateTelemetryConsentCache,
+} from "./track";
+
+function flushAsync(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+beforeEach(() => {
+  resetTelemetryTrackingForTests();
+  fetchTelemetryConsent.mockReset();
+  sendTelemetryEvents.mockReset();
+  sendTelemetryEvents.mockResolvedValue({ accepted: 1 });
+});
+
+describe("track gating", () => {
+  it("sends nothing while consent is unasked", async () => {
+    fetchTelemetryConsent.mockResolvedValue({ status: "unasked", env_disabled: false });
+    trackPageView("home");
+    await flushAsync();
+    expect(sendTelemetryEvents).not.toHaveBeenCalled();
+  });
+
+  it("sends nothing when denied or env-disabled", async () => {
+    fetchTelemetryConsent.mockResolvedValue({ status: "denied", env_disabled: false });
+    trackAction("task.create");
+    await flushAsync();
+
+    updateTelemetryConsentCache({ status: "granted", env_disabled: true });
+    trackAction("task.create");
+    await flushAsync();
+
+    expect(sendTelemetryEvents).not.toHaveBeenCalled();
+  });
+
+  it("sends when granted, and fetches consent only once", async () => {
+    fetchTelemetryConsent.mockResolvedValue({
+      status: "granted",
+      install_id: "abc",
+      env_disabled: false,
+    });
+    trackPageView("settings.system.telemetry");
+    trackAction("task.create");
+    await flushAsync();
+
+    expect(fetchTelemetryConsent).toHaveBeenCalledTimes(1);
+    expect(sendTelemetryEvents).toHaveBeenCalledTimes(2);
+    expect(sendTelemetryEvents).toHaveBeenCalledWith([
+      { name: "ui_page_viewed", properties: { page: "settings.system.telemetry" } },
+    ]);
+  });
+
+  it("reacts immediately to a consent cache update", async () => {
+    fetchTelemetryConsent.mockResolvedValue({ status: "unasked", env_disabled: false });
+    updateTelemetryConsentCache({ status: "granted", install_id: "abc", env_disabled: false });
+    trackPageView("home");
+    await flushAsync();
+    expect(fetchTelemetryConsent).not.toHaveBeenCalled();
+    expect(sendTelemetryEvents).toHaveBeenCalledTimes(1);
+  });
+
+  it("swallows consent fetch failures", async () => {
+    fetchTelemetryConsent.mockRejectedValue(new Error("backend down"));
+    trackPageView("home");
+    await flushAsync();
+    expect(sendTelemetryEvents).not.toHaveBeenCalled();
+  });
+});
+
+describe("normalizePathForTelemetry", () => {
+  it("maps the root to home", () => {
+    expect(normalizePathForTelemetry("/")).toBe("home");
+  });
+
+  it("joins segments with dots", () => {
+    expect(normalizePathForTelemetry("/settings/system/telemetry")).toBe(
+      "settings.system.telemetry",
+    );
+  });
+
+  it("collapses UUIDs and numeric ids", () => {
+    expect(normalizePathForTelemetry("/t/c2685309-00d9-41e8-bfe7-c29948b31530")).toBe("t.id");
+    expect(normalizePathForTelemetry("/tasks/12345")).toBe("tasks.id");
+  });
+
+  it("strips unsafe characters and caps length", () => {
+    const result = normalizePathForTelemetry("/Settings/Wörk spaces/" + "x".repeat(200));
+    expect(result.startsWith("settings.wrkspaces")).toBe(true);
+    expect(result.length).toBeLessThanOrEqual(64);
+    expect(/^[a-z0-9][a-z0-9_.:-]*$/.test(result)).toBe(true);
+  });
+});

--- a/apps/web/lib/telemetry/track.test.ts
+++ b/apps/web/lib/telemetry/track.test.ts
@@ -19,6 +19,8 @@ import {
   updateTelemetryConsentCache,
 } from "./track";
 
+const SAMPLE_ACTION = "task.create";
+
 function flushAsync(): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, 0));
 }
@@ -40,11 +42,11 @@ describe("track gating", () => {
 
   it("sends nothing when denied or env-disabled", async () => {
     fetchTelemetryConsent.mockResolvedValue({ status: "denied", env_disabled: false });
-    trackAction("task.create");
+    trackAction(SAMPLE_ACTION);
     await flushAsync();
 
     updateTelemetryConsentCache({ status: "granted", env_disabled: true });
-    trackAction("task.create");
+    trackAction(SAMPLE_ACTION);
     await flushAsync();
 
     expect(sendTelemetryEvents).not.toHaveBeenCalled();
@@ -57,13 +59,16 @@ describe("track gating", () => {
       env_disabled: false,
     });
     trackPageView("settings.system.telemetry");
-    trackAction("task.create");
+    trackAction(SAMPLE_ACTION);
     await flushAsync();
 
     expect(fetchTelemetryConsent).toHaveBeenCalledTimes(1);
     expect(sendTelemetryEvents).toHaveBeenCalledTimes(2);
-    expect(sendTelemetryEvents).toHaveBeenCalledWith([
+    expect(sendTelemetryEvents).toHaveBeenNthCalledWith(1, [
       { name: "ui_page_viewed", properties: { page: "settings.system.telemetry" } },
+    ]);
+    expect(sendTelemetryEvents).toHaveBeenNthCalledWith(2, [
+      { name: "ui_action", properties: { action: SAMPLE_ACTION } },
     ]);
   });
 
@@ -105,5 +110,12 @@ describe("normalizePathForTelemetry", () => {
     expect(result.startsWith("settings.wrkspaces")).toBe(true);
     expect(result.length).toBeLessThanOrEqual(64);
     expect(/^[a-z0-9][a-z0-9_.:-]*$/.test(result)).toBe(true);
+  });
+
+  it("never ends with a separator when the cap lands on one", () => {
+    // 63 chars of segment + "/x" → the dot separator falls exactly at the cap
+    const result = normalizePathForTelemetry("/" + "a".repeat(63) + "/x");
+    expect(result.endsWith(".")).toBe(false);
+    expect(/^[a-z0-9][a-z0-9_.:-]*[a-z0-9]$|^[a-z0-9]$/.test(result)).toBe(true);
   });
 });

--- a/apps/web/lib/telemetry/track.ts
+++ b/apps/web/lib/telemetry/track.ts
@@ -1,0 +1,71 @@
+// Frontend half of Kandev's strictly opt-in telemetry.
+//
+// Every helper here is fire-and-forget and consent-gated twice: locally
+// against a cached copy of the consent record (so no request is even made
+// without a grant), and again server-side where the backend enforces the
+// event allowlist and drops anything sent without consent. Values must be
+// short enum-like identifiers — the backend rejects free text.
+import { fetchTelemetryConsent, sendTelemetryEvents } from "@/lib/api/domains/telemetry-api";
+import type { TelemetryConsentState, TelemetryUIEventName } from "@/lib/types/telemetry";
+
+let consentPromise: Promise<TelemetryConsentState | null> | null = null;
+
+function loadConsent(): Promise<TelemetryConsentState | null> {
+  if (consentPromise === null) {
+    consentPromise = fetchTelemetryConsent().catch(() => null);
+  }
+  return consentPromise;
+}
+
+/**
+ * Keep the local gate in sync when the settings card or onboarding step
+ * changes consent, so tracking reacts immediately without a refetch.
+ */
+export function updateTelemetryConsentCache(state: TelemetryConsentState): void {
+  consentPromise = Promise.resolve(state);
+}
+
+export function resetTelemetryTrackingForTests(): void {
+  consentPromise = null;
+}
+
+async function track(name: TelemetryUIEventName, key: string, value: string): Promise<void> {
+  try {
+    const consent = await loadConsent();
+    if (!consent || consent.env_disabled || consent.status !== "granted") return;
+    await sendTelemetryEvents([{ name, properties: { [key]: value } }]);
+  } catch {
+    // Telemetry must never surface errors into the product.
+  }
+}
+
+/**
+ * Reduce a concrete pathname to an identifier-safe route label: IDs and
+ * UUID-ish segments collapse to "id" so no user data rides along, and the
+ * result fits the backend's ^[a-z0-9][a-z0-9_.:-]{0,63}$ allowlist.
+ */
+export function normalizePathForTelemetry(pathname: string): string {
+  const segments = pathname
+    .split("/")
+    .filter(Boolean)
+    .map((segment) => {
+      const lowered = segment.toLowerCase();
+      if (/^[0-9a-f]{8}-[0-9a-f-]{27,}$/.test(lowered) || /^\d+$/.test(lowered)) return "id";
+      const cleaned = lowered.replace(/[^a-z0-9_-]/g, "");
+      return cleaned === "" || /^[0-9a-f]{16,}$/.test(cleaned) ? "id" : cleaned;
+    });
+  if (segments.length === 0) return "home";
+  return segments.join(".").slice(0, 64);
+}
+
+export function trackPageView(page: string): void {
+  void track("ui_page_viewed", "page", page);
+}
+
+export function trackAction(action: string): void {
+  void track("ui_action", "action", action);
+}
+
+export function trackFeatureUsed(feature: string): void {
+  void track("feature_used", "feature", feature);
+}

--- a/apps/web/lib/telemetry/track.ts
+++ b/apps/web/lib/telemetry/track.ts
@@ -55,7 +55,9 @@ export function normalizePathForTelemetry(pathname: string): string {
       return cleaned === "" || /^[0-9a-f]{16,}$/.test(cleaned) ? "id" : cleaned;
     });
   if (segments.length === 0) return "home";
-  return segments.join(".").slice(0, 64);
+  // The 64-char cap can land mid-separator; trim so the value stays a
+  // clean identifier (no trailing dot).
+  return segments.join(".").slice(0, 64).replace(/\.+$/, "");
 }
 
 export function trackPageView(page: string): void {

--- a/apps/web/lib/types/telemetry.ts
+++ b/apps/web/lib/types/telemetry.ts
@@ -1,0 +1,20 @@
+export type TelemetryConsentStatus = "unasked" | "granted" | "denied";
+
+export type TelemetryConsentState = {
+  status: TelemetryConsentStatus;
+  /** Anonymous install UUID; present only after consent is granted. */
+  install_id?: string;
+  /** True when DO_NOT_TRACK / KANDEV_TELEMETRY=off hard-disable telemetry. */
+  env_disabled: boolean;
+};
+
+export type TelemetryUIEventName = "ui_page_viewed" | "ui_action" | "feature_used";
+
+export type TelemetryUIEvent = {
+  name: TelemetryUIEventName;
+  properties: Record<string, string>;
+};
+
+export type TelemetryEventsResponse = {
+  accepted: number;
+};

--- a/apps/web/lib/types/telemetry.ts
+++ b/apps/web/lib/types/telemetry.ts
@@ -4,7 +4,7 @@ export type TelemetryConsentState = {
   status: TelemetryConsentStatus;
   /** Anonymous install UUID; present only after consent is granted. */
   install_id?: string;
-  /** True when DO_NOT_TRACK / KANDEV_TELEMETRY=off hard-disable telemetry. */
+  /** True when DO_NOT_TRACK or e2e test mode hard-disables telemetry. */
   env_disabled: boolean;
 };
 

--- a/apps/web/src/app-shell.tsx
+++ b/apps/web/src/app-shell.tsx
@@ -9,6 +9,7 @@ import { RecentTaskSwitcher } from "@/components/task/recent-task-switcher";
 import { SessionFailureToastBridge } from "@/components/session-failure-toast-bridge";
 import { TaskDeletedToastBridge } from "@/components/task-deleted-toast-bridge";
 import { SidebarViewsSyncBridge } from "@/components/sidebar-views-sync-bridge";
+import { TelemetryPageViewBridge } from "@/components/telemetry-page-view-bridge";
 import { ThemeProvider } from "@/components/theme-provider";
 import { ToastProvider } from "@/components/toast-provider";
 import { WebSocketConnector } from "@/components/ws-connector";
@@ -30,6 +31,7 @@ export function AppShell({ children }: AppShellProps) {
             <SessionFailureToastBridge />
             <TaskDeletedToastBridge />
             <SidebarViewsSyncBridge />
+            <TelemetryPageViewBridge />
             <LogBufferBridge />
             <CommandRegistryProvider>
               <WebSocketConnector />

--- a/apps/web/src/settings-routes.tsx
+++ b/apps/web/src/settings-routes.tsx
@@ -48,6 +48,7 @@ import { HealthIssuesCard } from "@/components/settings/system/health-issues-car
 import { LicensesList } from "@/components/settings/system/licenses-list";
 import { LogViewer } from "@/components/settings/system/log-viewer";
 import { SystemPageShell } from "@/components/settings/system/system-page-shell";
+import { TelemetrySettings } from "@/components/settings/system/telemetry-settings";
 import { UIStateCard } from "@/components/settings/system/ui-state-card";
 import { UpdatesCard } from "@/components/settings/system/updates-card";
 import { VersionSummaryCard } from "@/components/settings/system/version-summary-card";
@@ -197,6 +198,14 @@ const SETTINGS_ROUTES: Record<string, RouteRenderer> = {
       </div>
       <DiskUsageCard />
       <UIStateCard />
+    </SystemPageShell>
+  ),
+  "/settings/system/telemetry": () => (
+    <SystemPageShell
+      title="Telemetry"
+      description="Strictly opt-in anonymous usage sharing. Nothing is sent unless you enable it."
+    >
+      <TelemetrySettings />
     </SystemPageShell>
   ),
   "/settings/system/updates": renderUpdatesRoute,

--- a/docs/decisions/0039-opt-in-telemetry.md
+++ b/docs/decisions/0039-opt-in-telemetry.md
@@ -35,9 +35,13 @@ Telemetry is **strictly opt-in** and lives in `internal/telemetry`:
 - **Consent:** tri-state (`unasked/granted/denied`) on the install-wide
   `settings` table, exposed via `GET/PUT /api/v1/telemetry/consent`, a
   one-time onboarding step, and `Settings → System → Telemetry`.
-- **Kill switches:** `DO_NOT_TRACK=1` and `KANDEV_TELEMETRY=off` win over
-  everything; with either set the service starts no goroutines and
-  subscribes to nothing. `profiles.yaml` forces `off` in dev and e2e.
+- **Hard-off conditions:** the stored opt-in is the single user-facing
+  control. Only two environment conditions override it: `DO_NOT_TRACK=1`
+  (convention) and e2e mode (the existing `KANDEV_E2E_MOCK` selector), so
+  CI backends can never emit real events. With either, the service starts
+  no goroutines and subscribes to nothing. A Kandev-specific
+  `KANDEV_TELEMETRY=off` switch existed briefly and was removed to keep
+  one control surface; dev-mode builds use the normal consent flow.
   `KANDEV_TELEMETRY_DEBUG=1` logs every outgoing payload.
 - **Delivery:** in-memory queue, batched flush, fail-silent, no disk
   persistence, drops on overflow — telemetry can never block product flows.

--- a/docs/decisions/0039-opt-in-telemetry.md
+++ b/docs/decisions/0039-opt-in-telemetry.md
@@ -20,7 +20,7 @@ Telemetry is **strictly opt-in** and lives in `internal/telemetry`:
 
 - **Sink:** PostHog Cloud EU (`eu.i.posthog.com`, write-only project key
   baked in, overridable via `KANDEV_TELEMETRY_ENDPOINT` / `_API_KEY`).
-  Events are sent in anonymous mode (`$process_person_profiles: false`)
+  Events are sent in anonymous mode (`$process_person_profile: false`)
   keyed by a random install UUID minted only after consent and deleted on
   opt-out. Chosen over Aptabase (weaker analysis), self-hosting (ops
   burden), and a custom endpoint (build cost) — 1M free events/month and an

--- a/docs/decisions/0039-opt-in-telemetry.md
+++ b/docs/decisions/0039-opt-in-telemetry.md
@@ -28,6 +28,9 @@ Telemetry is **strictly opt-in** and lives in `internal/telemetry`:
 - **Collection:** a bus subscriber maps an allowlist of domain events
   (task/agent/turn/workspace/automation lifecycle) to name-only telemetry
   events — payloads are never forwarded, so titles/repos/paths cannot leak.
+  The only payload exception is a per-event key allowlist for closed enums
+  (currently `agent_run_failed` carries the routingerr classification
+  `error_code` + `error_phase`), with values still pattern-validated.
   Frontend UI events go through `POST /api/v1/telemetry/events`, validated
   server-side against a per-event property allowlist with enum-shaped
   values; the backend is the single enforcement point for every client and

--- a/docs/decisions/0039-opt-in-telemetry.md
+++ b/docs/decisions/0039-opt-in-telemetry.md
@@ -1,0 +1,57 @@
+# 0039: Strictly opt-in product telemetry via PostHog EU
+
+**Status:** accepted
+**Date:** 2026-07-15
+**Area:** backend, frontend
+
+## Context
+
+Kandev had no product telemetry, so decisions about which features to invest
+in were made blind. Kandev is a local-first, open-source dev tool: its users
+are exactly the audience most hostile to silent data collection, and 2025–26
+incidents (GitHub CLI's default-on rollout, opt-out flags that leaked in
+Strapi and Continue.dev) show that getting this wrong costs more trust than
+the data is worth. The Go toolchain and Jan establish the defensible
+precedent: opt-in only, anonymous, fully documented.
+
+## Decision
+
+Telemetry is **strictly opt-in** and lives in `internal/telemetry`:
+
+- **Sink:** PostHog Cloud EU (`eu.i.posthog.com`, write-only project key
+  baked in, overridable via `KANDEV_TELEMETRY_ENDPOINT` / `_API_KEY`).
+  Events are sent in anonymous mode (`$process_person_profiles: false`)
+  keyed by a random install UUID minted only after consent and deleted on
+  opt-out. Chosen over Aptabase (weaker analysis), self-hosting (ops
+  burden), and a custom endpoint (build cost) — 1M free events/month and an
+  established OSS track record (Jan, n8n, Continue).
+- **Collection:** a bus subscriber maps an allowlist of domain events
+  (task/agent/turn/workspace/automation lifecycle) to name-only telemetry
+  events — payloads are never forwarded, so titles/repos/paths cannot leak.
+  Frontend UI events go through `POST /api/v1/telemetry/events`, validated
+  server-side against a per-event property allowlist with enum-shaped
+  values; the backend is the single enforcement point for every client and
+  deploy mode.
+- **Consent:** tri-state (`unasked/granted/denied`) on the install-wide
+  `settings` table, exposed via `GET/PUT /api/v1/telemetry/consent`, a
+  one-time onboarding step, and `Settings → System → Telemetry`.
+- **Kill switches:** `DO_NOT_TRACK=1` and `KANDEV_TELEMETRY=off` win over
+  everything; with either set the service starts no goroutines and
+  subscribes to nothing. `profiles.yaml` forces `off` in dev and e2e.
+  `KANDEV_TELEMETRY_DEBUG=1` logs every outgoing payload.
+- **Delivery:** in-memory queue, batched flush, fail-silent, no disk
+  persistence, drops on overflow — telemetry can never block product flows.
+
+The full public contract (every event and property) is
+`docs/public/telemetry.md`; it must be updated in the same PR as any
+allowlist change.
+
+## Consequences
+
+The team gets adoption and feature-usage signal from consenting installs
+with a privacy story that survives scrutiny: nothing identifies a person,
+nothing free-text leaves the machine, and the off-path is covered by tests
+(unasked/denied/env-off send zero events). Opt-in rates will be a fraction
+of opt-out rates — that is the accepted trade. Adding a new event costs one
+allowlist entry, a docs-table row, and tests; anything richer than
+identifier-shaped properties is rejected by design.

--- a/docs/decisions/INDEX.md
+++ b/docs/decisions/INDEX.md
@@ -44,3 +44,4 @@ Read individual ADRs for full context. Create new ones via `/record decision` or
 | 0036 | [Normalize ACP shell output at the adapter boundary](0036-normalize-acp-shell-output-at-adapter-boundary.md)                        | accepted   | backend, frontend, protocol | 2026-07-14 |
 | 0037 | [Resource-aware frontend unit tests](0037-resource-aware-frontend-unit-tests.md)                                                     | accepted   | frontend, infra             | 2026-07-14 |
 | 0038 | [Quick Chat Repository Isolation](0038-quick-chat-repository-isolation.md)                                                           | accepted   | backend, frontend           | 2026-07-14 |
+| 0039 | [Strictly opt-in product telemetry via PostHog EU](0039-opt-in-telemetry.md)                                                         | accepted   | backend, frontend           | 2026-07-15 |

--- a/docs/public/configuration.md
+++ b/docs/public/configuration.md
@@ -31,6 +31,7 @@ Backend configuration normally uses the `KANDEV_` prefix. Nested keys map by rep
 | `homeDir` | `KANDEV_HOME_DIR` (alias) |
 | `logging.level` | `KANDEV_LOG_LEVEL` (alias) |
 | `agent.standalonePort` | `AGENTCTL_PORT` or `KANDEV_AGENT_STANDALONE_PORT` (aliases) |
+| `telemetry.apiKey` | `KANDEV_TELEMETRY_API_KEY` (alias) |
 
 The aliases on the right are explicit bindings - see `LoadWithPath` in `config.go` for the full list. New keys should follow the deterministic rule (`KANDEV_<SECTION>_<KEYUPPERCASE>`) unless compatibility requires an explicit alias.
 
@@ -117,7 +118,15 @@ repoClone:
 
 debug:
   pprofEnabled: false      # enables /debug/pprof and /api/v1/debug/memory
+
+telemetry:
+  endpoint: ""             # empty = built-in PostHog EU host; see telemetry.md
+  apiKey: ""               # empty = built-in write-only project key
+  debug: false             # log every outgoing telemetry payload locally
 ```
+
+Telemetry is strictly opt-in regardless of these keys — see [telemetry.md](telemetry.md)
+for the consent model and the `KANDEV_TELEMETRY=off` / `DO_NOT_TRACK=1` kill switches.
 
 ## Required vs optional
 

--- a/docs/public/configuration.md
+++ b/docs/public/configuration.md
@@ -126,7 +126,7 @@ telemetry:
 ```
 
 Telemetry is strictly opt-in regardless of these keys — see [telemetry.md](telemetry.md)
-for the consent model and the `KANDEV_TELEMETRY=off` / `DO_NOT_TRACK=1` kill switches.
+for the consent model and the `DO_NOT_TRACK=1` convention.
 
 ## Required vs optional
 

--- a/docs/public/configuration.md
+++ b/docs/public/configuration.md
@@ -31,7 +31,7 @@ Backend configuration normally uses the `KANDEV_` prefix. Nested keys map by rep
 | `homeDir` | `KANDEV_HOME_DIR` (alias) |
 | `logging.level` | `KANDEV_LOG_LEVEL` (alias) |
 | `agent.standalonePort` | `AGENTCTL_PORT` or `KANDEV_AGENT_STANDALONE_PORT` (aliases) |
-| `telemetry.apiKey` | `KANDEV_TELEMETRY_API_KEY` (alias) |
+| `telemetry.apiKey` | `KANDEV_TELEMETRY_APIKEY` (or alias `KANDEV_TELEMETRY_API_KEY`) |
 
 The aliases on the right are explicit bindings - see `LoadWithPath` in `config.go` for the full list. New keys should follow the deterministic rule (`KANDEV_<SECTION>_<KEYUPPERCASE>`) unless compatibility requires an explicit alias.
 

--- a/docs/public/index.md
+++ b/docs/public/index.md
@@ -77,3 +77,4 @@ We'll move Office into the live feature inventory after it ships.
 - **Backups and restore:** Kandev creates snapshots before version upgrades and supports manual snapshots, download, restore, and deletion from the system settings page.
 - **Disk usage:** inspect storage used by worktrees, repositories, sessions, tasks, quick chat, and backups.
 - **Logs, database status, about, and licenses:** system settings include operational views useful for self-hosted installs.
+- **Opt-in telemetry:** strictly opt-in anonymous usage sharing, off by default, with env kill switches and a documented event allowlist. See [telemetry.md](telemetry.md).

--- a/docs/public/telemetry.md
+++ b/docs/public/telemetry.md
@@ -50,7 +50,8 @@ Every event carries only these context properties: Kandev version, OS
 | `telemetry_enabled` | You opt in | — |
 | `install_heartbeat` | Opt-in, then once per day while running | — |
 | `task_created` / `task_deleted` | A task is created/deleted | — |
-| `agent_run_started` / `agent_run_completed` / `agent_run_failed` | An agent execution starts/finishes/fails | — |
+| `agent_run_started` / `agent_run_completed` | An agent execution starts/finishes | — |
+| `agent_run_failed` | An agent execution fails | `error_code`: failure class from a closed enum (e.g. `auth_required`, `rate_limited`, `provider_overloaded`, `npx_cache_corrupted`); `error_phase`: lifecycle phase enum (e.g. `session_init`, `prompt_send`). Never the error message itself. |
 | `turn_completed` | An agent turn finishes | — |
 | `workspace_created` | A workspace is created | — |
 | `automation_run_created` | An automation run is recorded | — |
@@ -59,7 +60,10 @@ Every event carries only these context properties: Kandev version, OS
 | `feature_used` | An allowlisted feature is used | `feature`: short identifier |
 
 Domain events are counted by name only — the internal payloads (which contain
-titles, repository names, and similar) are never forwarded. UI events are
+titles, repository names, and similar) are never forwarded. The single
+exception is `agent_run_failed`, whose two classification enums are read from
+an explicit per-event key allowlist and must match the identifier pattern
+below; the raw error message is structurally unreachable. UI events are
 validated server-side against an allowlist; property values must be short
 identifiers (`^[a-z0-9][a-z0-9_.:-]{0,63}$`), so free text cannot ride along
 even from a modified client.

--- a/docs/public/telemetry.md
+++ b/docs/public/telemetry.md
@@ -1,10 +1,10 @@
 # Telemetry
 
 Kandev includes **strictly opt-in** anonymous product telemetry. Nothing is
-ever collected or sent unless you explicitly enable it, and two environment
-kill switches disable it unconditionally. This page is the complete, exact
-list of what can be sent — if an event is not in the tables below, Kandev
-does not send it.
+ever collected or sent unless you explicitly enable it — the in-app opt-in
+is the single control (with the `DO_NOT_TRACK` convention honoured on top).
+This page is the complete, exact list of what can be sent — if an event is
+not in the tables below, Kandev does not send it.
 
 ## How consent works
 
@@ -18,19 +18,19 @@ does not send it.
 - Consent is stored per install in Kandev's local database
   (`telemetry.consent` in the `settings` table).
 
-## Kill switches
+## Hard-off conditions
 
 These are honoured unconditionally, before your stored preference is even
-read. With either set, Kandev starts no telemetry machinery at all and the
-consent prompt is hidden:
+read. When either applies, Kandev starts no telemetry machinery at all and
+the consent prompt is hidden:
 
-| Variable | Effect |
+| Condition | Effect |
 | --- | --- |
 | `DO_NOT_TRACK=1` | Disables all telemetry ([consoledonottrack.com](https://consoledonottrack.com) convention) |
-| `KANDEV_TELEMETRY=off` | Disables all telemetry (Kandev-specific; `false`, `0`, and `disabled` also work) |
+| E2E test mode (`KANDEV_E2E_MOCK=true`) | Playwright/CI backends never emit events, even if a test grants consent |
 
-Dev mode and e2e test runs force `KANDEV_TELEMETRY=off` via `profiles.yaml`,
-so local development and CI never emit events.
+There is no other environment switch — outside those two conditions, the
+opt-in toggle in `Settings → System → Telemetry` is the only control.
 
 ## Inspecting what would be sent
 
@@ -80,5 +80,5 @@ is dropped — telemetry never blocks or retries aggressively, and unsent
 events are not persisted to disk.
 
 Self-hosters can redirect or replace the sink with
-`KANDEV_TELEMETRY_ENDPOINT` and `KANDEV_TELEMETRY_API_KEY`, or disable
-everything with the kill switches above.
+`KANDEV_TELEMETRY_ENDPOINT` and `KANDEV_TELEMETRY_API_KEY`, simply never
+opt in, or set `DO_NOT_TRACK=1`.

--- a/docs/public/telemetry.md
+++ b/docs/public/telemetry.md
@@ -48,7 +48,7 @@ Every event carries only these context properties: Kandev version, OS
 | Event | Trigger | Extra properties |
 | --- | --- | --- |
 | `telemetry_enabled` | You opt in | — |
-| `install_heartbeat` | Opt-in, then once per day while running | — |
+| `install_heartbeat` | At opt-in, at backend start while opted in, then once per day | — |
 | `task_created` / `task_deleted` | A task is created/deleted | — |
 | `agent_run_started` / `agent_run_completed` | An agent execution starts/finishes | — |
 | `agent_run_failed` | An agent execution fails | `error_code`: failure class from a closed enum (e.g. `auth_required`, `rate_limited`, `provider_overloaded`, `npx_cache_corrupted`); `error_phase`: lifecycle phase enum (e.g. `session_init`, `prompt_send`). Never the error message itself. |

--- a/docs/public/telemetry.md
+++ b/docs/public/telemetry.md
@@ -1,0 +1,84 @@
+# Telemetry
+
+Kandev includes **strictly opt-in** anonymous product telemetry. Nothing is
+ever collected or sent unless you explicitly enable it, and two environment
+kill switches disable it unconditionally. This page is the complete, exact
+list of what can be sent — if an event is not in the tables below, Kandev
+does not send it.
+
+## How consent works
+
+- **Off by default.** A fresh install sends nothing. The onboarding dialog
+  asks once ("Help improve Kandev"); skipping the question keeps telemetry
+  off.
+- **Change anytime** in `Settings → System → Telemetry`.
+- **Anonymous install ID.** When (and only when) you opt in, Kandev mints a
+  random UUID. It is not derived from your hardware, hostname, or account,
+  and it is deleted if you opt out.
+- Consent is stored per install in Kandev's local database
+  (`telemetry.consent` in the `settings` table).
+
+## Kill switches
+
+These are honoured unconditionally, before your stored preference is even
+read. With either set, Kandev starts no telemetry machinery at all and the
+consent prompt is hidden:
+
+| Variable | Effect |
+| --- | --- |
+| `DO_NOT_TRACK=1` | Disables all telemetry ([consoledonottrack.com](https://consoledonottrack.com) convention) |
+| `KANDEV_TELEMETRY=off` | Disables all telemetry (Kandev-specific; `false`, `0`, and `disabled` also work) |
+
+Dev mode and e2e test runs force `KANDEV_TELEMETRY=off` via `profiles.yaml`,
+so local development and CI never emit events.
+
+## Inspecting what would be sent
+
+Set `KANDEV_TELEMETRY_DEBUG=1` and every outgoing payload is logged locally
+before it leaves the machine.
+
+## What is collected
+
+Every event carries only these context properties: Kandev version, OS
+(`linux`/`darwin`/`windows`), CPU architecture, and deploy mode
+(`local`/`docker`/`k8s`/`desktop`).
+
+### Events
+
+| Event | Trigger | Extra properties |
+| --- | --- | --- |
+| `telemetry_enabled` | You opt in | — |
+| `install_heartbeat` | Opt-in, then once per day while running | — |
+| `task_created` / `task_deleted` | A task is created/deleted | — |
+| `agent_run_started` / `agent_run_completed` / `agent_run_failed` | An agent execution starts/finishes/fails | — |
+| `turn_completed` | An agent turn finishes | — |
+| `workspace_created` | A workspace is created | — |
+| `automation_run_created` | An automation run is recorded | — |
+| `ui_page_viewed` | A UI route is opened | `page`: route label with IDs stripped (e.g. `settings.system.telemetry`, `t.id`) |
+| `ui_action` | An allowlisted UI action | `action`: short identifier |
+| `feature_used` | An allowlisted feature is used | `feature`: short identifier |
+
+Domain events are counted by name only — the internal payloads (which contain
+titles, repository names, and similar) are never forwarded. UI events are
+validated server-side against an allowlist; property values must be short
+identifiers (`^[a-z0-9][a-z0-9_.:-]{0,63}$`), so free text cannot ride along
+even from a modified client.
+
+### Never collected
+
+- Prompts, chat messages, code, diffs, or terminal output
+- Task titles, repository names, branch names, file paths, or URLs
+- Your name, email, account identifiers, or IP-based profiles
+- Environment variables, secrets, or configuration values
+
+## Where the data goes
+
+Events are batched in memory and sent to an EU-hosted PostHog instance
+(`https://eu.i.posthog.com`) in anonymous mode (no person profiles are
+created). Delivery is fail-silent: if the endpoint is unreachable the batch
+is dropped — telemetry never blocks or retries aggressively, and unsent
+events are not persisted to disk.
+
+Self-hosters can redirect or replace the sink with
+`KANDEV_TELEMETRY_ENDPOINT` and `KANDEV_TELEMETRY_API_KEY`, or disable
+everything with the kill switches above.


### PR DESCRIPTION
Kandev had zero visibility into how the product is used; this adds strictly opt-in, anonymous product telemetry (PostHog Cloud EU) so feature investment can be guided by real usage while keeping a privacy story that survives OSS scrutiny — nothing is collected until the user explicitly opts in.

## Important Changes

- New `apps/backend/internal/telemetry/` package: tri-state consent (`unasked/granted/denied`) on the install-wide settings table, anonymous install UUID minted only on grant (deleted on deny), event-bus collector, batched fail-silent PostHog sink in anonymous mode, and a `GET/PUT /api/v1/telemetry/consent` + `POST /api/v1/telemetry/events` API as the single enforcement point for all clients.
- Collection is allowlist-only: domain events are counted by name; the sole payload exception is `agent_run_failed`, which carries the `routingerr` classification enums (`error_code`, `error_phase`) — values pattern-validated, the free-text error message is structurally unreachable.
- Consent UX: onboarding "Help improve Kandev" step (shown only while unasked) + `Settings → System → Telemetry` card; frontend `track()` helpers and a route-level page-view bridge that strips IDs from paths.
- Consent is the only user-facing control; hard-off applies for `DO_NOT_TRACK=1` and e2e mode (`KANDEV_E2E_MOCK`), so CI can never emit events. `KANDEV_TELEMETRY_DEBUG=1` logs every outgoing payload locally.
- Public contract in `docs/public/telemetry.md` (full event/property table) + ADR 0039.

## Validation

- `make -C apps/backend fmt` · `go build ./...` · full `go test ./...` and `go test -race` on the telemetry + lifecycle packages · `make -C apps/backend lint` (0 issues)
- `pnpm run typecheck`, full `pnpm run test` (vitest), `pnpm --filter @kandev/web lint`, prettier — all clean
- Off-path coverage: unit tests assert zero emission while unasked/denied/env-disabled, queue dropped on deny, payload fields (titles/repos/error messages) cannot leak, and non-enum values are rejected
- End-to-end manually verified against the live PostHog EU project: consent grant → events batched and ingested (`/batch/` accepted), confirmed in the PostHog activity feed and dashboards

## Possible Improvements

Low risk (feature is inert until opt-in and fail-silent by design); main follow-ups are instrumenting `ui_action`/`feature_used` call sites and deciding whether backend panic/5xx counters are worth adding.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1710?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->