### PR TITLE
fix(web): render walkthrough surfaces behind dialogs

### DIFF
--- a/apps/web/components/diff/walkthrough-floating-window.tsx
+++ b/apps/web/components/diff/walkthrough-floating-window.tsx
@@ -156,7 +156,7 @@ function WalkthroughConnector({ cardRect }: { cardRect: WalkthroughViewportRect 
     <svg
       aria-hidden="true"
       data-testid="walkthrough-connector"
-      className="pointer-events-none fixed inset-0 z-[65] hidden h-screen w-screen sm:block"
+      className="pointer-events-none fixed inset-0 z-[42] hidden h-screen w-screen sm:block"
     >
       <path
         d={path}
@@ -236,7 +236,7 @@ export function WalkthroughFloatingWindow({
         data-testid="walkthrough-floating"
         data-mobile-variant="bottom-sheet"
         className={cn(
-          "fixed inset-x-2 bottom-2 z-[70] max-h-[calc(100dvh-1rem)] overflow-y-auto rounded-xl",
+          "fixed inset-x-2 bottom-2 z-[43] max-h-[calc(100dvh-1rem)] overflow-y-auto rounded-xl",
           "sm:inset-x-auto sm:bottom-auto sm:w-[400px] sm:max-w-[calc(100vw-2rem)]",
         )}
         style={isDesktop && position ? { left: position.x, top: position.y } : undefined}

--- a/apps/web/components/review/walkthrough-overlay.tsx
+++ b/apps/web/components/review/walkthrough-overlay.tsx
@@ -46,7 +46,7 @@ function WalkthroughLauncher({
   stepCount,
 }: WalkthroughLauncherProps) {
   return (
-    <div className="group fixed bottom-6 right-6 z-[60]">
+    <div className="group fixed bottom-6 right-6 z-[41]">
       <button
         type="button"
         data-testid="walkthrough-launcher"

--- a/apps/web/e2e/tests/review/mobile-walkthrough.spec.ts
+++ b/apps/web/e2e/tests/review/mobile-walkthrough.spec.ts
@@ -3,6 +3,7 @@ import { SessionPage } from "../../pages/session-page";
 import type { ApiClient } from "../../helpers/api-client";
 import type { SeedData } from "../../fixtures/test-base";
 import type { Page } from "@playwright/test";
+import { expectWalkthroughBehindDialog } from "./walkthrough-layering";
 
 async function seedWalkthroughTask(
   testPage: Page,
@@ -58,6 +59,17 @@ test.describe("Mobile code walkthrough", () => {
     await expect(testPage.getByTestId("walkthrough-editor-range")).toBeVisible({
       timeout: 15_000,
     });
+
+    await testPage.evaluate(() => window.dispatchEvent(new CustomEvent("open-review-dialog")));
+    const reviewDialog = testPage.getByRole("dialog", { name: "Review Changes" });
+    await expect(reviewDialog).toBeVisible({ timeout: 15_000 });
+    await expectWalkthroughBehindDialog(testPage, reviewDialog, [
+      { locator: card, name: "walkthrough window" },
+      {
+        locator: testPage.getByTestId("walkthrough-launcher").locator(".."),
+        name: "walkthrough launcher",
+      },
+    ]);
   });
 
   test("requests a walkthrough from Changes and opens the generated bottom sheet", async ({

--- a/apps/web/e2e/tests/review/walkthrough-layering.ts
+++ b/apps/web/e2e/tests/review/walkthrough-layering.ts
@@ -1,0 +1,32 @@
+import { expect, type Locator, type Page } from "@playwright/test";
+
+type WalkthroughSurface = {
+  locator: Locator;
+  name: string;
+};
+
+async function zIndex(locator: Locator): Promise<number> {
+  return locator.evaluate((element) => Number.parseInt(getComputedStyle(element).zIndex, 10));
+}
+
+export async function expectWalkthroughBehindDialog(
+  page: Page,
+  dialog: Locator,
+  surfaces: WalkthroughSurface[],
+): Promise<void> {
+  const backdrop = page.locator('[data-slot$="dialog-overlay"]:visible');
+  await expect(backdrop).toBeVisible();
+
+  const dialogZIndex = await zIndex(dialog);
+  const backdropZIndex = await zIndex(backdrop);
+
+  for (const surface of surfaces) {
+    const surfaceZIndex = await zIndex(surface.locator);
+    expect(surfaceZIndex, `${surface.name} should be below dialog content`).toBeLessThan(
+      dialogZIndex,
+    );
+    expect(surfaceZIndex, `${surface.name} should be below dialog backdrop`).toBeLessThan(
+      backdropZIndex,
+    );
+  }
+}

--- a/apps/web/e2e/tests/review/walkthrough-layering.ts
+++ b/apps/web/e2e/tests/review/walkthrough-layering.ts
@@ -5,8 +5,13 @@ type WalkthroughSurface = {
   name: string;
 };
 
-async function zIndex(locator: Locator): Promise<number> {
-  return locator.evaluate((element) => Number.parseInt(getComputedStyle(element).zIndex, 10));
+async function zIndex(locator: Locator, name: string): Promise<number> {
+  const rawValue = await locator.evaluate((element) => getComputedStyle(element).zIndex);
+  const value = Number.parseInt(rawValue, 10);
+  if (Number.isNaN(value)) {
+    throw new Error(`${name} must have a numeric z-index; received ${JSON.stringify(rawValue)}`);
+  }
+  return value;
 }
 
 export async function expectWalkthroughBehindDialog(
@@ -17,11 +22,11 @@ export async function expectWalkthroughBehindDialog(
   const backdrop = page.locator('[data-slot$="dialog-overlay"]:visible');
   await expect(backdrop).toBeVisible();
 
-  const dialogZIndex = await zIndex(dialog);
-  const backdropZIndex = await zIndex(backdrop);
+  const dialogZIndex = await zIndex(dialog, "dialog content");
+  const backdropZIndex = await zIndex(backdrop, "dialog backdrop");
 
   for (const surface of surfaces) {
-    const surfaceZIndex = await zIndex(surface.locator);
+    const surfaceZIndex = await zIndex(surface.locator, surface.name);
     expect(surfaceZIndex, `${surface.name} should be below dialog content`).toBeLessThan(
       dialogZIndex,
     );

--- a/apps/web/e2e/tests/review/walkthrough-layering.ts
+++ b/apps/web/e2e/tests/review/walkthrough-layering.ts
@@ -20,6 +20,7 @@ export async function expectWalkthroughBehindDialog(
   surfaces: WalkthroughSurface[],
 ): Promise<void> {
   const backdrop = page.locator('[data-slot$="dialog-overlay"]:visible');
+  await expect(dialog).toBeVisible();
   await expect(backdrop).toBeVisible();
 
   const dialogZIndex = await zIndex(dialog, "dialog content");

--- a/apps/web/e2e/tests/review/walkthrough.spec.ts
+++ b/apps/web/e2e/tests/review/walkthrough.spec.ts
@@ -3,6 +3,7 @@ import { SessionPage } from "../../pages/session-page";
 import type { ApiClient } from "../../helpers/api-client";
 import type { SeedData } from "../../fixtures/test-base";
 import type { Page, Locator } from "@playwright/test";
+import { expectWalkthroughBehindDialog } from "./walkthrough-layering";
 
 async function seedWalkthroughTask(
   testPage: Page,
@@ -309,11 +310,26 @@ test.describe("Code walkthrough", () => {
     const card = await openWalkthrough(testPage);
     await expect(session.walkthroughEditorRange()).toBeVisible({ timeout: 15_000 });
 
+    await testPage.evaluate(() => window.dispatchEvent(new CustomEvent("open-review-dialog")));
+    const reviewDialog = testPage.getByRole("dialog", { name: "Review Changes" });
+    await expect(reviewDialog).toBeVisible({ timeout: 15_000 });
+    await expectWalkthroughBehindDialog(testPage, reviewDialog, [
+      { locator: card, name: "walkthrough window" },
+      { locator: session.walkthroughLauncher().locator(".."), name: "walkthrough launcher" },
+    ]);
+    await reviewDialog.getByRole("button", { name: "Close review" }).click();
+    await expect(reviewDialog).toBeHidden({ timeout: 15_000 });
+
     await session.walkthroughLauncher().hover();
     await expect(session.walkthroughDiscardButton()).toBeVisible({ timeout: 5_000 });
     await session.walkthroughDiscardButton().click();
-    await expect(session.walkthroughDiscardDialog()).toBeVisible();
-    await session.walkthroughDiscardDialog().getByRole("button", { name: "Cancel" }).click();
+    const discardDialog = session.walkthroughDiscardDialog();
+    await expect(discardDialog).toBeVisible();
+    await expectWalkthroughBehindDialog(testPage, discardDialog, [
+      { locator: card, name: "walkthrough window" },
+      { locator: session.walkthroughLauncher().locator(".."), name: "walkthrough launcher" },
+    ]);
+    await discardDialog.getByRole("button", { name: "Cancel" }).click();
     await expect(card).toBeVisible();
     await expect(session.walkthroughLauncher()).toHaveCount(1);
 


### PR DESCRIPTION
Walkthrough surfaces could render above modal content and backdrops because their layer exceeded the dialog tier. They now remain above app chrome but behind dialogs on desktop and mobile.

## Validation

- `pnpm e2e:run --no-build -- tests/review/walkthrough.spec.ts` (9 passed)
- `pnpm e2e:run --no-build --project mobile-chrome -- tests/review/mobile-walkthrough.spec.ts` (3 passed)
- `make fmt`
- `make typecheck`
- `make test`
- `make lint`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1717?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->