### PR TITLE
fix(web): compact plan implement control

### DIFF
--- a/apps/web/components/task/chat/implement-plan-button.tsx
+++ b/apps/web/components/task/chat/implement-plan-button.tsx
@@ -67,6 +67,7 @@ export function ImplementPlanButton({
     menuTrigger: testIds?.menuTrigger ?? "implement-plan-menu-trigger",
     freshItem: testIds?.freshItem ?? "implement-fresh-menu-item",
   };
+  const controlHeightClass = framed ? "h-6" : "h-7";
   const primaryButton = (
     <span className="inline-flex">
       <Button
@@ -76,7 +77,8 @@ export function ImplementPlanButton({
         data-testid={ids.button}
         disabled={disabled}
         className={cn(
-          "h-7 gap-1.5 px-2 text-violet-400 rounded-r-none pr-1.5 border-transparent",
+          "gap-1.5 px-2 text-violet-400 rounded-r-none pr-1.5 border-transparent",
+          controlHeightClass,
           "hover:bg-muted/40 focus-visible:border-transparent focus-visible:ring-violet-400/30",
           disabled ? "pointer-events-none cursor-not-allowed" : "cursor-pointer",
         )}
@@ -117,7 +119,8 @@ export function ImplementPlanButton({
             aria-disabled={disabled}
             disabled={disabled}
             className={cn(
-              "h-7 px-1 text-violet-400 rounded-l-none border-y-0 border-r-0 border-l border-violet-400/20",
+              "px-1 text-violet-400 rounded-l-none border-y-0 border-r-0 border-l border-violet-400/20",
+              controlHeightClass,
               "hover:bg-muted/40 focus-visible:border-y-0 focus-visible:border-r-0 focus-visible:border-l-violet-400/20 focus-visible:ring-0",
               disabled ? "pointer-events-none cursor-not-allowed" : "cursor-pointer",
             )}

--- a/apps/web/components/task/chat/implement-plan-button.tsx
+++ b/apps/web/components/task/chat/implement-plan-button.tsx
@@ -67,7 +67,7 @@ export function ImplementPlanButton({
     menuTrigger: testIds?.menuTrigger ?? "implement-plan-menu-trigger",
     freshItem: testIds?.freshItem ?? "implement-fresh-menu-item",
   };
-  const controlHeightClass = framed ? "h-6" : "h-7";
+  const controlHeightClass = framed ? "h-5" : "h-7";
   const primaryButton = (
     <span className="inline-flex">
       <Button

--- a/apps/web/e2e/tests/task/mobile-plan-toolbar-implement.spec.ts
+++ b/apps/web/e2e/tests/task/mobile-plan-toolbar-implement.spec.ts
@@ -68,7 +68,7 @@ test.describe("mobile: Plan toolbar implement", () => {
         };
       });
     expect(toolbarSpacing?.toolbarHeight).toBe(30);
-    expect(toolbarSpacing?.controlHeight).toBeLessThanOrEqual(26);
+    expect(toolbarSpacing?.controlHeight).toBe(22);
     expect(toolbarSpacing?.top).toBeGreaterThanOrEqual(1);
     expect(toolbarSpacing?.bottom).toBeGreaterThanOrEqual(1);
 

--- a/apps/web/e2e/tests/task/mobile-plan-toolbar-implement.spec.ts
+++ b/apps/web/e2e/tests/task/mobile-plan-toolbar-implement.spec.ts
@@ -53,6 +53,25 @@ test.describe("mobile: Plan toolbar implement", () => {
     await expect(toolbarButton).toBeVisible({ timeout: 10_000 });
     await expect(toolbarButton).toBeInViewport();
 
+    const toolbarSpacing = await testPage
+      .getByTestId("plan-toolbar-implement-control")
+      .evaluate((control) => {
+        const toolbar = control.closest(".border-b");
+        if (!(toolbar instanceof HTMLElement)) return null;
+        const controlRect = control.getBoundingClientRect();
+        const toolbarRect = toolbar.getBoundingClientRect();
+        return {
+          top: controlRect.top - toolbarRect.top,
+          bottom: toolbarRect.bottom - controlRect.bottom,
+          toolbarHeight: toolbarRect.height,
+          controlHeight: controlRect.height,
+        };
+      });
+    expect(toolbarSpacing?.toolbarHeight).toBe(30);
+    expect(toolbarSpacing?.controlHeight).toBeLessThanOrEqual(26);
+    expect(toolbarSpacing?.top).toBeGreaterThanOrEqual(1);
+    expect(toolbarSpacing?.bottom).toBeGreaterThanOrEqual(1);
+
     const overflow = await testPage.evaluate(() => {
       const root = document.scrollingElement ?? document.documentElement;
       return root.scrollWidth > root.clientWidth + 1;

--- a/apps/web/e2e/tests/task/plan-toolbar-implement.spec.ts
+++ b/apps/web/e2e/tests/task/plan-toolbar-implement.spec.ts
@@ -57,6 +57,25 @@ test.describe("Plan toolbar implement", () => {
     const toolbarButton = testPage.getByTestId("plan-toolbar-implement-button");
     await expect(toolbarButton).toBeVisible({ timeout: 10_000 });
 
+    const toolbarSpacing = await testPage
+      .getByTestId("plan-toolbar-implement-control")
+      .evaluate((control) => {
+        const toolbar = control.closest(".border-b");
+        if (!(toolbar instanceof HTMLElement)) return null;
+        const controlRect = control.getBoundingClientRect();
+        const toolbarRect = toolbar.getBoundingClientRect();
+        return {
+          top: controlRect.top - toolbarRect.top,
+          bottom: toolbarRect.bottom - controlRect.bottom,
+          toolbarHeight: toolbarRect.height,
+          controlHeight: controlRect.height,
+        };
+      });
+    expect(toolbarSpacing?.toolbarHeight).toBe(30);
+    expect(toolbarSpacing?.controlHeight).toBeLessThanOrEqual(26);
+    expect(toolbarSpacing?.top).toBeGreaterThanOrEqual(1);
+    expect(toolbarSpacing?.bottom).toBeGreaterThanOrEqual(1);
+
     const uniqueEdit = `toolbar marker ${Date.now()}`;
     await session.planEditor().click();
     await testPage.keyboard.press(process.platform === "darwin" ? "Meta+End" : "Control+End");

--- a/apps/web/e2e/tests/task/plan-toolbar-implement.spec.ts
+++ b/apps/web/e2e/tests/task/plan-toolbar-implement.spec.ts
@@ -72,7 +72,7 @@ test.describe("Plan toolbar implement", () => {
         };
       });
     expect(toolbarSpacing?.toolbarHeight).toBe(30);
-    expect(toolbarSpacing?.controlHeight).toBeLessThanOrEqual(26);
+    expect(toolbarSpacing?.controlHeight).toBe(22);
     expect(toolbarSpacing?.top).toBeGreaterThanOrEqual(1);
     expect(toolbarSpacing?.bottom).toBeGreaterThanOrEqual(1);
 


### PR DESCRIPTION
The plan toolbar's framed Implement control no longer crowds adjacent panel borders while all panel headers retain consistent alignment.

## Validation

- `make fmt`
- `make typecheck`
- `make test`
- `make lint`
- `pnpm e2e:run tests/task/plan-toolbar-implement.spec.ts`
- `pnpm e2e:run --no-build --project mobile-chrome tests/task/mobile-plan-toolbar-implement.spec.ts`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1719?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->