### PR TITLE
fix(web): keep settings section actions aligned on narrow screens

### DIFF
--- a/apps/web/components/settings/settings-section.tsx
+++ b/apps/web/components/settings/settings-section.tsx
@@ -17,15 +17,18 @@ export function SettingsSection({
 }: SettingsSectionProps) {
   return (
     <section className="space-y-4">
-      <div className="flex items-start justify-between">
-        <div>
+      {/* Stack the action row under the title on narrow screens instead of
+          squeezing both onto one line; shrink-0 keeps the actions from being
+          compressed by a long description when side by side. */}
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0">
           <h3 className="text-lg font-semibold flex items-center gap-2">
             {icon}
             {title}
           </h3>
           {description && <p className="text-sm text-muted-foreground mt-1">{description}</p>}
         </div>
-        {action && <div>{action}</div>}
+        {action && <div className="shrink-0">{action}</div>}
       </div>
       {children}
     </section>

--- a/apps/web/components/settings/workflow-section-actions.tsx
+++ b/apps/web/components/settings/workflow-section-actions.tsx
@@ -20,7 +20,9 @@ export function WorkflowSectionActions({
   onGitHubSync,
 }: WorkflowSectionActionsProps) {
   return (
-    <div className="flex flex-wrap gap-2">
+    // sm:justify-end keeps wrapped rows right-aligned next to the section
+    // title; below sm the toolbar sits under the title, left-aligned.
+    <div className="flex flex-wrap gap-2 sm:justify-end">
       <WorkflowSyncButton onClick={onGitHubSync} />
       <Button
         type="button"


### PR DESCRIPTION
On smaller viewports the Workflows settings toolbar (GitHub Sync · Export All · Import · Add Workflow) wrapped awkwardly — the section header forced the title and actions onto one line, so the toolbar's second row dangled left-aligned with "Add Workflow" floating alone. The section header now stacks actions under the title below `sm`, keeps them from being compressed by long descriptions, and right-aligns wrapped toolbar rows when side by side with the title.

## Validation

- `cd apps/web && pnpm run typecheck`
- `pnpm exec eslint components/settings/settings-section.tsx components/settings/workflow-section-actions.tsx`
- `pnpm exec vitest run components/settings` (18 files / 77 tests)

## Possible Improvements

Low risk — `SettingsSection` is shared by all settings pages, so every section header gains the stacking behavior below `sm`; that is the intended, consistent outcome but touches more surfaces than the Workflows page alone.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1727?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

