### PR TITLE
fix(release): use Bash 3.2-safe artifact verifier

### DIFF
--- a/.github/scripts/release-workflow-contract_test.py
+++ b/.github/scripts/release-workflow-contract_test.py
@@ -101,6 +101,19 @@ class ReleaseWorkflowContractTest(unittest.TestCase):
         self.assertIn('bash "$helper"', detect)
         self.assertNotIn("bash scripts/release/updater-signing-ready.sh", detect)
 
+    def test_desktop_asset_validation_uses_workflow_control_revision(self) -> None:
+        for job in ("build-desktop", "publish-release"):
+            block = job_block(job)
+            self.assertIn("ref: ${{ needs.prepare.outputs.ref }}", block)
+            self.assertIn("GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}", block)
+            self.assertIn(
+                "scripts/release/verify-desktop-assets.sh?ref=${{ github.workflow_sha }}",
+                block,
+            )
+            self.assertIn("DESKTOP_ASSET_VERIFIER=$helper", block)
+            self.assertIn('"$DESKTOP_ASSET_VERIFIER"', block)
+            self.assertNotIn('scripts/release/verify-desktop-assets.sh "', block)
+
     def test_macos_dmg_build_has_retry_timeout_and_diagnostics(self) -> None:
         build = step_block("Build Tauri desktop app")
         self.assertIn("timeout-minutes: 70", build)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -585,6 +585,18 @@ jobs:
           ref: ${{ needs.prepare.outputs.ref }}
           persist-credentials: false
 
+      - name: Prepare desktop asset verifier
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          helper="$RUNNER_TEMP/verify-desktop-assets.sh"
+          gh api \
+            --header "Accept: application/vnd.github.raw+json" \
+            "repos/${{ github.repository }}/contents/scripts/release/verify-desktop-assets.sh?ref=${{ github.workflow_sha }}" \
+            > "$helper"
+          echo "DESKTOP_ASSET_VERIFIER=$helper" >> "$GITHUB_ENV"
+
       - name: Prepare macOS desktop diagnostics helper
         if: startsWith(matrix.platform, 'macos-')
         continue-on-error: true
@@ -1056,7 +1068,7 @@ jobs:
             exit 1
           fi
 
-          scripts/release/verify-desktop-assets.sh "$out_dir" "${{ matrix.platform }}"
+          bash "$DESKTOP_ASSET_VERIFIER" "$out_dir" "${{ matrix.platform }}"
           ls -lh "$out_dir"
 
       - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
@@ -1427,6 +1439,18 @@ jobs:
           ref: ${{ needs.prepare.outputs.ref }}
           fetch-depth: 0
 
+      - name: Prepare desktop asset verifier
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          helper="$RUNNER_TEMP/verify-desktop-assets.sh"
+          gh api \
+            --header "Accept: application/vnd.github.raw+json" \
+            "repos/${{ github.repository }}/contents/scripts/release/verify-desktop-assets.sh?ref=${{ github.workflow_sha }}" \
+            > "$helper"
+          echo "DESKTOP_ASSET_VERIFIER=$helper" >> "$GITHUB_ENV"
+
       - name: Install updater signature verifier toolchain
         run: rustup toolchain install 1.88.0 --profile minimal
 
@@ -1508,7 +1532,7 @@ jobs:
               exit 1
             fi
           done
-          scripts/release/verify-desktop-assets.sh dist/release-assets
+          bash "$DESKTOP_ASSET_VERIFIER" dist/release-assets
           ls -lh dist/release-assets
 
       - name: Generate and verify updater manifest

--- a/docs/desktop-tauri-signing.md
+++ b/docs/desktop-tauri-signing.md
@@ -6,7 +6,7 @@ Unsigned desktop artifacts may require manual OS security bypasses and must not 
 
 Use `desktop_validation_only=true` for maintainer inspection builds. That mode uploads workflow artifacts but does not publish a GitHub release, npm packages, Homebrew updates, or public container tags.
 
-Release backfills build application code and artifacts from the requested immutable tag. Updater signing-readiness validation is control-plane logic and runs from `github.workflow_sha`, so a workflow fix on main can recover an existing tag without moving it or substituting main-branch application source.
+Release backfills build application code and artifacts from the requested immutable tag. Updater signing-readiness and desktop artifact validation are control-plane logic and run from `github.workflow_sha`, so a workflow fix on main can recover an existing tag without moving it or substituting main-branch application source.
 
 ## macOS
 

--- a/scripts/release-desktop.test.sh
+++ b/scripts/release-desktop.test.sh
@@ -172,7 +172,17 @@ printf 'unsigned macOS artifact\n' > "$macos_artifact"
   "$macos_assets_dir" macos-arm64 >/dev/null
 pass "verify-desktop-assets accepts macOS artifacts without optional updater bundles"
 
-if grep -Eq 'updater_(bundles|signatures)=\(' \
+missing_assets_dir="$TMP_DIR/missing-assets"
+mkdir -p "$missing_assets_dir"
+if "$ROOT_DIR/scripts/release/verify-desktop-assets.sh" \
+  "$missing_assets_dir" macos-arm64 >"$OUT_FILE" 2>"$ERR_FILE"; then
+  fail "verify-desktop-assets should reject a missing platform artifact"
+fi
+grep -q "Missing desktop artifact for platform: macos-arm64" "$ERR_FILE" || \
+  fail "verify-desktop-assets did not explain the missing platform artifact"
+pass "verify-desktop-assets reports missing platform artifacts"
+
+if grep -Eq '(artifacts|updater_bundles|updater_signatures)=\(' \
   "$ROOT_DIR/scripts/release/verify-desktop-assets.sh"; then
   fail "verify-desktop-assets uses optional arrays that fail under Bash 3.2 nounset"
 fi

--- a/scripts/release-desktop.test.sh
+++ b/scripts/release-desktop.test.sh
@@ -162,6 +162,22 @@ printf 'desktop artifact\n' > "$artifact"
 "$ROOT_DIR/scripts/release/verify-desktop-assets.sh" "$assets_dir" linux-x64 >/dev/null
 pass "verify-desktop-assets accepts matching checksums"
 
+macos_assets_dir="$TMP_DIR/macos-assets"
+mkdir -p "$macos_assets_dir"
+macos_artifact="$macos_assets_dir/kandev-desktop-macos-arm64-Kandev.dmg"
+printf 'unsigned macOS artifact\n' > "$macos_artifact"
+"$ROOT_DIR/scripts/release/write-sha256.sh" \
+  "$macos_artifact" "$macos_artifact.sha256"
+"$ROOT_DIR/scripts/release/verify-desktop-assets.sh" \
+  "$macos_assets_dir" macos-arm64 >/dev/null
+pass "verify-desktop-assets accepts macOS artifacts without optional updater bundles"
+
+if grep -Eq 'updater_(bundles|signatures)=\(' \
+  "$ROOT_DIR/scripts/release/verify-desktop-assets.sh"; then
+  fail "verify-desktop-assets uses optional arrays that fail under Bash 3.2 nounset"
+fi
+pass "verify-desktop-assets avoids Bash 3.2 empty-array nounset failures"
+
 if signing_secret_env "$ROOT_DIR/scripts/release/desktop-signing-ready.sh" macos >"$OUT_FILE" 2>"$ERR_FILE"; then
   fail "desktop-signing-ready should report macOS signing not ready without secrets"
 fi

--- a/scripts/release/verify-desktop-assets.sh
+++ b/scripts/release/verify-desktop-assets.sh
@@ -87,15 +87,13 @@ for platform in "${REQUIRED_PLATFORMS[@]}"; do
   fi
 
   updater_suffix="$(updater_suffix_for_platform "$platform")"
-  updater_bundles=("$ASSETS_DIR"/kandev-desktop-"$platform"-$updater_suffix)
-  updater_signatures=("$ASSETS_DIR"/kandev-desktop-"$platform"-$updater_suffix.sig)
-  for updater_bundle in "${updater_bundles[@]}"; do
+  for updater_bundle in "$ASSETS_DIR"/kandev-desktop-"$platform"-$updater_suffix; do
     if [ ! -f "$updater_bundle.sig" ]; then
       echo "Missing updater signature: $updater_bundle.sig" >&2
       exit 1
     fi
   done
-  for updater_signature in "${updater_signatures[@]}"; do
+  for updater_signature in "$ASSETS_DIR"/kandev-desktop-"$platform"-$updater_suffix.sig; do
     updater_bundle="${updater_signature%.sig}"
     if [ ! -f "$updater_bundle" ]; then
       echo "Missing updater bundle for signature: $updater_signature" >&2

--- a/scripts/release/verify-desktop-assets.sh
+++ b/scripts/release/verify-desktop-assets.sh
@@ -62,10 +62,9 @@ updater_suffix_for_platform() {
 }
 
 for platform in "${REQUIRED_PLATFORMS[@]}"; do
-  artifacts=("$ASSETS_DIR"/kandev-desktop-"$platform"-*)
   found=0
 
-  for artifact in "${artifacts[@]}"; do
+  for artifact in "$ASSETS_DIR"/kandev-desktop-"$platform"-*; do
     if [[ "$artifact" == *.sha256 ]]; then
       continue
     fi


### PR DESCRIPTION
The v0.79.0 backfill reached artifact collection but failed because macOS Bash 3.2 treats an empty optional updater array as unbound under `set -u`. Make optional artifact checks Bash 3.2-safe and source the verifier from the fixed workflow revision so the immutable tag can be recovered.

## Important Changes

- Iterate optional updater bundles through `nullglob` directly, avoiding Bash 3.2 empty-array expansion.
- Fetch desktop artifact validation from `github.workflow_sha` in build and publish jobs while retaining `needs.prepare.outputs.ref` for tagged source and artifacts.
- Cover unsigned macOS artifacts and the workflow control-plane boundary with regression tests.

## Validation

- `RUSTUP_TOOLCHAIN=1.88.0 bash scripts/release-desktop.test.sh`
- `python3 .github/scripts/release-workflow-contract_test.py`
- `python3 .github/scripts/lint-action-pinning.py`
- `python3 .github/scripts/lint-action-pinning_test.py`
- `bash -n scripts/release/verify-desktop-assets.sh scripts/release-desktop.test.sh`
- YAML parse validation for `.github/workflows/release.yml`
- `make fmt typecheck test lint` with Rust 1.88
- `git diff --check`

## Post-Merge Recovery

After merge, go to **Actions > Release > Run workflow** on `main` and set:

- `backfill_tag`: `v0.79.0`
- `dry_run`: `false`
- `desktop_validation_only`: `false`
- `bump`: any value; ignored when `backfill_tag` is set

Do not rerun either failed workflow and do not run a normal version bump. Verify the backfill publishes GitHub release `v0.79.0` with `latest.json` and signed updater artifacts, then verify the npm and Homebrew jobs complete.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1730?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

