### PR TITLE
fix(release): install xdg-open for Linux bundles

### DIFF
--- a/.github/scripts/release-workflow-contract_test.py
+++ b/.github/scripts/release-workflow-contract_test.py
@@ -114,6 +114,12 @@ class ReleaseWorkflowContractTest(unittest.TestCase):
             self.assertIn('"$DESKTOP_ASSET_VERIFIER"', block)
             self.assertNotIn('scripts/release/verify-desktop-assets.sh "', block)
 
+    def test_linux_appimage_build_installs_xdg_open(self) -> None:
+        install = step_block("Install Linux desktop dependencies")
+        self.assertIn("startsWith(matrix.platform, 'linux-')", install)
+        self.assertIn("xdg-utils", install)
+        self.assertIn("command -v xdg-open", install)
+
     def test_macos_dmg_build_has_retry_timeout_and_diagnostics(self) -> None:
         build = step_block("Build Tauri desktop app")
         self.assertIn("timeout-minutes: 70", build)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -655,7 +655,9 @@ jobs:
             libgtk-3-dev \
             libayatana-appindicator3-dev \
             librsvg2-dev \
+            xdg-utils \
             patchelf
+          command -v xdg-open
 
       - name: Install dependencies
         run: pnpm -C apps install --frozen-lockfile


### PR DESCRIPTION
The v0.79.0 backfill compiled the linux-arm64 desktop binary but failed during AppImage bundling because the runner did not provide `xdg-open`. Install the owning package for every Linux desktop matrix job and verify the binary before the expensive build starts.

## Important Changes

- Install `xdg-utils` alongside the existing Linux Tauri/AppImage dependencies.
- Run `command -v xdg-open` immediately after package installation so a missing prerequisite fails early.
- Add a release workflow contract test covering both requirements for Linux desktop jobs.

## Validation

- `python3 .github/scripts/release-workflow-contract_test.py`
- `python3 .github/scripts/lint-action-pinning.py`
- `python3 .github/scripts/lint-action-pinning_test.py`
- YAML parse validation for `.github/workflows/release.yml`
- `make fmt typecheck test lint` with Rust 1.88
- `git diff --check`

## Post-Merge Recovery

After merge, go to **Actions > Release > Run workflow** on `main` and set:

- `backfill_tag`: `v0.79.0`
- `dry_run`: `false`
- `desktop_validation_only`: `false`
- `bump`: any value; ignored when `backfill_tag` is set

Do not rerun failed run `29494767143` and do not run a normal version bump. Verify the backfill publishes GitHub release `v0.79.0` with `latest.json` and signed updater artifacts, then verify the npm and Homebrew jobs complete.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1731?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->