### PR TITLE
fix(release): dereference tags for updater dates

### DIFF
--- a/.github/scripts/release-workflow-contract_test.py
+++ b/.github/scripts/release-workflow-contract_test.py
@@ -120,6 +120,14 @@ class ReleaseWorkflowContractTest(unittest.TestCase):
         self.assertIn("xdg-utils", install)
         self.assertIn("command -v xdg-open", install)
 
+    def test_updater_manifest_date_dereferences_annotated_tag(self) -> None:
+        generate = step_block("Generate and verify updater manifest")
+        self.assertIn("git show -s --format=%cI", generate)
+        self.assertRegex(
+            generate,
+            r"needs\.prepare\.outputs\.tag \}\}\^\{commit\}",
+        )
+
     def test_macos_dmg_build_has_retry_timeout_and_diagnostics(self) -> None:
         build = step_block("Build Tauri desktop app")
         self.assertIn("timeout-minutes: 70", build)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1542,7 +1542,7 @@ jobs:
           RUSTUP_TOOLCHAIN: 1.88.0
         run: |
           set -euo pipefail
-          pub_date="$(git show -s --format=%cI '${{ needs.prepare.outputs.tag }}')"
+          pub_date="$(git show -s --format=%cI '${{ needs.prepare.outputs.tag }}^{commit}')"
           node scripts/release/updater-manifest.mjs generate \
             --assets-dir dist/release-assets \
             --output dist/release-assets/latest.json \


### PR DESCRIPTION
The v0.79.0 backfill built and verified every release artifact but failed while generating `latest.json` because `git show` emitted the annotated tag header alongside the commit timestamp. Dereference the release tag to its commit so updater `pub_date` is exactly one RFC 3339 value.

## Important Changes

- Resolve `${tag}^{commit}` before formatting the updater publication date.
- Add a workflow contract test requiring explicit commit dereferencing in the manifest generation step.
- Preserve the immutable `v0.79.0` tag, tagged source checkout, and all signed artifacts from the matrix.

## Validation

- Reproduced `git show -s --format=%cI v0.79.0` returning the annotated tag header plus timestamp.
- Verified `git show -s --format=%cI 'v0.79.0^{commit}'` returns only `2026-07-16T08:39:43Z`.
- `python3 .github/scripts/release-workflow-contract_test.py`
- `python3 .github/scripts/lint-action-pinning.py`
- YAML parse validation for `.github/workflows/release.yml`
- `RUSTUP_TOOLCHAIN=1.88.0 bash scripts/release-desktop.test.sh`
- `make fmt typecheck test lint` with Rust 1.88
- `git diff --check`

## Post-Merge Recovery

After merge, go to **Actions > Release > Run workflow** on `main` and set:

- `backfill_tag`: `v0.79.0`
- `dry_run`: `false`
- `desktop_validation_only`: `false`
- `bump`: any value; ignored when `backfill_tag` is set

Do not rerun failed run `29501815801` and do not run a normal version bump. Verify the backfill publishes GitHub release `v0.79.0` with `latest.json` and signed updater artifacts, then verify the npm and Homebrew jobs complete.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1732?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->