### PR TITLE
fix(release): build macOS updater bundles

### DIFF
--- a/.github/scripts/release-workflow-contract_test.py
+++ b/.github/scripts/release-workflow-contract_test.py
@@ -128,6 +128,23 @@ class ReleaseWorkflowContractTest(unittest.TestCase):
             r"needs\.prepare\.outputs\.tag \}\}\^\{commit\}",
         )
 
+    def test_macos_signed_build_selects_updater_bundle(self) -> None:
+        build = step_block("Build Tauri desktop app")
+        collect = step_block("Collect desktop artifacts")
+        initialize = 'tauri_bundles="${{ matrix.tauri_bundles }}"'
+        append = 'tauri_bundles="${tauri_bundles},updater"'
+        invoke = '--bundles "$tauri_bundles"'
+
+        self.assertIn('[[ "${{ matrix.platform }}" == macos-*', build)
+        self.assertIn('"${UPDATER_SIGNING_ENABLED:-false}" = "true"', build)
+        self.assertIn(initialize, build)
+        self.assertIn(append, build)
+        self.assertIn(invoke, build)
+        self.assertLess(build.index(initialize), build.index(append))
+        self.assertLess(build.index(append), build.index(invoke))
+        self.assertIn('"${UPDATER_SIGNING_ENABLED:-false}" = "true"', collect)
+        self.assertIn('"$DESKTOP_ASSET_VERIFIER" --require-updaters', collect)
+
     def test_macos_dmg_build_has_retry_timeout_and_diagnostics(self) -> None:
         build = step_block("Build Tauri desktop app")
         self.assertIn("timeout-minutes: 70", build)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -848,9 +848,13 @@ jobs:
             unset WINDOWS_TIMESTAMP_URL
             unset WINDOWS_SIGNTOOL_PATH
           fi
+          tauri_bundles="${{ matrix.tauri_bundles }}"
           updater_config='{"bundle":{"createUpdaterArtifacts":false}}'
           if [ "${UPDATER_SIGNING_ENABLED:-false}" = "true" ]; then
             updater_config='{"bundle":{"createUpdaterArtifacts":"v1Compatible"}}'
+            if [[ "${{ matrix.platform }}" == macos-* ]]; then
+              tauri_bundles="${tauri_bundles},updater"
+            fi
           else
             unset TAURI_SIGNING_PRIVATE_KEY
             unset TAURI_SIGNING_PRIVATE_KEY_PASSWORD
@@ -917,7 +921,7 @@ jobs:
               pnpm tauri build \
                 --features desktop-runtime \
                 --target "${{ matrix.rust_target }}" \
-                --bundles "${{ matrix.tauri_bundles }}" \
+                --bundles "$tauri_bundles" \
                 --config "$updater_config"
           }
 
@@ -1070,7 +1074,12 @@ jobs:
             exit 1
           fi
 
-          bash "$DESKTOP_ASSET_VERIFIER" "$out_dir" "${{ matrix.platform }}"
+          if [ "${UPDATER_SIGNING_ENABLED:-false}" = "true" ]; then
+            bash "$DESKTOP_ASSET_VERIFIER" --require-updaters \
+              "$out_dir" "${{ matrix.platform }}"
+          else
+            bash "$DESKTOP_ASSET_VERIFIER" "$out_dir" "${{ matrix.platform }}"
+          fi
           ls -lh "$out_dir"
 
       - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5

--- a/scripts/release-desktop.test.sh
+++ b/scripts/release-desktop.test.sh
@@ -172,6 +172,25 @@ printf 'unsigned macOS artifact\n' > "$macos_artifact"
   "$macos_assets_dir" macos-arm64 >/dev/null
 pass "verify-desktop-assets accepts macOS artifacts without optional updater bundles"
 
+if "$ROOT_DIR/scripts/release/verify-desktop-assets.sh" --require-updaters \
+  "$macos_assets_dir" macos-arm64 >"$OUT_FILE" 2>"$ERR_FILE"; then
+  fail "verify-desktop-assets should require a key-enabled macOS updater bundle"
+fi
+grep -q "Missing updater artifact for platform: macos-arm64" "$ERR_FILE" || \
+  fail "verify-desktop-assets did not explain the missing macOS updater bundle"
+pass "verify-desktop-assets requires key-enabled updater bundles"
+
+macos_updater="$macos_assets_dir/kandev-desktop-macos-arm64-Kandev.app.tar.gz"
+printf 'signed macOS updater\n' > "$macos_updater"
+printf 'signature\n' > "$macos_updater.sig"
+"$ROOT_DIR/scripts/release/write-sha256.sh" \
+  "$macos_updater" "$macos_updater.sha256"
+"$ROOT_DIR/scripts/release/write-sha256.sh" \
+  "$macos_updater.sig" "$macos_updater.sig.sha256"
+"$ROOT_DIR/scripts/release/verify-desktop-assets.sh" --require-updaters \
+  "$macos_assets_dir" macos-arm64 >/dev/null
+pass "verify-desktop-assets accepts signed required updater bundles"
+
 missing_assets_dir="$TMP_DIR/missing-assets"
 mkdir -p "$missing_assets_dir"
 if "$ROOT_DIR/scripts/release/verify-desktop-assets.sh" \

--- a/scripts/release/verify-desktop-assets.sh
+++ b/scripts/release/verify-desktop-assets.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 usage() {
   cat <<'EOF'
-Usage: verify-desktop-assets.sh <assets-dir> [platform...]
+Usage: verify-desktop-assets.sh [--require-updaters] <assets-dir> [platform...]
 
 Checks that each required platform has at least one desktop artifact named:
 
@@ -14,6 +14,8 @@ and that every matching artifact has a sibling .sha256 file. If no platform is
 given, all supported desktop platforms are required. Signed Tauri updater
 artifacts (`*.app.tar.gz`, `*.AppImage.tar.gz`, and `*.nsis.zip`) must have a
 matching `*.sig` file, and signatures without their updater bundle are rejected.
+When --require-updaters is set, every requested platform must also include its
+signed updater bundle.
 EOF
 }
 
@@ -22,7 +24,13 @@ if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
   exit 0
 fi
 
-ASSETS_DIR="${1:?Usage: verify-desktop-assets.sh <assets-dir> [platform...]}"
+REQUIRE_UPDATERS=false
+if [ "${1:-}" = "--require-updaters" ]; then
+  REQUIRE_UPDATERS=true
+  shift
+fi
+
+ASSETS_DIR="${1:?Usage: verify-desktop-assets.sh [--require-updaters] <assets-dir> [platform...]}"
 shift || true
 
 if [ "$#" -gt 0 ]; then
@@ -86,7 +94,9 @@ for platform in "${REQUIRED_PLATFORMS[@]}"; do
   fi
 
   updater_suffix="$(updater_suffix_for_platform "$platform")"
+  updater_found=0
   for updater_bundle in "$ASSETS_DIR"/kandev-desktop-"$platform"-$updater_suffix; do
+    updater_found=$((updater_found + 1))
     if [ ! -f "$updater_bundle.sig" ]; then
       echo "Missing updater signature: $updater_bundle.sig" >&2
       exit 1
@@ -99,6 +109,10 @@ for platform in "${REQUIRED_PLATFORMS[@]}"; do
       exit 1
     fi
   done
+  if [ "$REQUIRE_UPDATERS" = true ] && [ "$updater_found" -eq 0 ]; then
+    echo "Missing updater artifact for platform: $platform" >&2
+    exit 1
+  fi
 done
 
 echo "Desktop release assets verified in $ASSETS_DIR"


### PR DESCRIPTION
Tauri does not include its hidden macOS updater package when `--bundles dmg` is selected, so the v0.79.0 backfill produced no Darwin updater archives and the manifest failed closed. Select the updater package for key-enabled macOS builds and fail each desktop job immediately when an expected updater artifact is missing.

## Important Changes

- Append Tauri's `updater` bundle only for macOS builds with `TAURI_SIGNING_PRIVATE_KEY`; Apple and Windows OS-signing credentials remain optional.
- Run strict updater artifact validation in every key-enabled desktop matrix job using the verifier from `github.workflow_sha`, while application inputs remain pinned to the release tag.
- Preserve non-strict verification for unsigned desktop builds and add regressions for missing and valid macOS updater bundles.

## Validation

- `python3 .github/scripts/release-workflow-contract_test.py`
- `bash scripts/release-desktop.test.sh` with Rust 1.88
- `python3 .github/scripts/lint-action-pinning_test.py`
- Parsed `.github/workflows/release.yml` with PyYAML
- `bash -n scripts/release/verify-desktop-assets.sh scripts/release-desktop.test.sh`
- `make fmt` with Rust 1.88
- `make typecheck` with Rust 1.88
- `make test` with Rust 1.88
- `make lint` with Rust 1.88

## Post-Merge Recovery

After merge, go to **Actions > Release > Run workflow** on `main` and set:

- `backfill_tag`: `v0.79.0`
- `dry_run`: `false`
- `desktop_validation_only`: `false`
- `bump`: any value; it is ignored when `backfill_tag` is set

Do not rerun failed run 29504508531 and do not run a normal version bump. Verify that the backfill publishes GitHub release `v0.79.0` with `latest.json` and signed updater artifacts, then verify the npm and Homebrew jobs complete.

## Possible Improvements

Low risk: the remaining validation is a real macOS release runner confirming Tauri emits both `.app.tar.gz` updater archives.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1733?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- kandev-preview-start -->
### Preview Environment

| | |
|---|---|
| **URL** | https://kandev-pr-1733-bwo7.sprites.app |
| **Commit** | `e5f2b22` |
| **Agent** | Mock agent |

> Updates automatically on each push. Destroyed when the PR is closed.
<!-- kandev-preview-end -->