### PR TITLE
fix(release): use macOS app updater target

### DIFF
--- a/.github/scripts/release-workflow-contract_test.py
+++ b/.github/scripts/release-workflow-contract_test.py
@@ -128,17 +128,18 @@ class ReleaseWorkflowContractTest(unittest.TestCase):
             r"needs\.prepare\.outputs\.tag \}\}\^\{commit\}",
         )
 
-    def test_macos_signed_build_selects_updater_bundle(self) -> None:
+    def test_macos_signed_build_selects_app_bundle_for_updater(self) -> None:
         build = step_block("Build Tauri desktop app")
         collect = step_block("Collect desktop artifacts")
         initialize = 'tauri_bundles="${{ matrix.tauri_bundles }}"'
-        append = 'tauri_bundles="${tauri_bundles},updater"'
+        append = 'tauri_bundles="${tauri_bundles},app"'
         invoke = '--bundles "$tauri_bundles"'
 
         self.assertIn('[[ "${{ matrix.platform }}" == macos-*', build)
         self.assertIn('"${UPDATER_SIGNING_ENABLED:-false}" = "true"', build)
         self.assertIn(initialize, build)
         self.assertIn(append, build)
+        self.assertNotIn('tauri_bundles="${tauri_bundles},updater"', build)
         self.assertIn(invoke, build)
         self.assertLess(build.index(initialize), build.index(append))
         self.assertLess(build.index(append), build.index(invoke))

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -853,7 +853,8 @@ jobs:
           if [ "${UPDATER_SIGNING_ENABLED:-false}" = "true" ]; then
             updater_config='{"bundle":{"createUpdaterArtifacts":"v1Compatible"}}'
             if [[ "${{ matrix.platform }}" == macos-* ]]; then
-              tauri_bundles="${tauri_bundles},updater"
+              # Tauri derives the macOS updater archive from the app bundle.
+              tauri_bundles="${tauri_bundles},app"
             fi
           else
             unset TAURI_SIGNING_PRIVATE_KEY


### PR DESCRIPTION
The v0.79.0 backfill passed updater-key validation but Tauri warned that `dmg,updater` contained no updater-enabled macOS target, so strict artifact validation stopped the release. Select Tauri's macOS `app` target, which produces the signed `.app.tar.gz` updater archive alongside the DMG.

## Important Changes

- Replace the hidden `updater` bundle selection with Tauri's supported `app` target for key-enabled macOS builds.
- Keep DMG generation, strict signed-updater validation, immutable tagged application inputs, and current-workflow control logic unchanged.
- Add a workflow contract regression that requires `app` and explicitly rejects the failed `updater` selection.

## Validation

- `python3 .github/scripts/release-workflow-contract_test.py` (red before the workflow fix, green after)
- `bash scripts/release-desktop.test.sh` with Rust 1.88
- `python3 .github/scripts/lint-action-pinning_test.py`
- Parsed `.github/workflows/release.yml` with PyYAML
- `make fmt` with Rust 1.88
- `make typecheck` with Rust 1.88
- `make test` with Rust 1.88
- `make lint` with Rust 1.88

## Post-Merge Recovery

After merge, go to **Actions > Release > Run workflow** on `main` and set:

- `backfill_tag`: `v0.79.0`
- `dry_run`: `false`
- `desktop_validation_only`: `false`
- `bump`: any value; it is ignored when `backfill_tag` is set

Do not rerun failed run 29506959376 and do not run a normal version bump. Verify that the backfill publishes GitHub release `v0.79.0` with `latest.json` and signed updater artifacts, then verify the npm and Homebrew jobs complete.

## Possible Improvements

Low risk: the real macOS release runner remains the final confirmation that Tauri emits both architecture-specific `.app.tar.gz` archives.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1735?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- kandev-preview-start -->
### Preview Environment

| | |
|---|---|
| **URL** | https://kandev-pr-1735-bwo7.sprites.app |
| **Commit** | `320c1a3` |
| **Agent** | Mock agent |

> Updates automatically on each push. Destroyed when the PR is closed.
<!-- kandev-preview-end -->