### PR TITLE
fix(web): refresh agent capability status

### DIFF
--- a/apps/web/components/settings/profile-form-fields.tsx
+++ b/apps/web/components/settings/profile-form-fields.tsx
@@ -225,8 +225,8 @@ function PermissionToggles({
   );
 }
 
-function capabilityStatusMessage(modelConfig: ModelConfig): string | null {
-  switch (modelConfig.status) {
+function capabilityStatusMessage(status: ModelConfig["status"]): string | null {
+  switch (status) {
     case "probing":
       return "Checking agent capabilities…";
     case "auth_required":
@@ -240,13 +240,13 @@ function capabilityStatusMessage(modelConfig: ModelConfig): string | null {
   }
 }
 
-function CapabilityStatusMessage({ modelConfig }: { modelConfig: ModelConfig }) {
-  const msg = capabilityStatusMessage(modelConfig);
+function CapabilityStatusMessage({ status }: { status: ModelConfig["status"] }) {
+  const msg = capabilityStatusMessage(status);
   if (!msg) return null;
   return (
     <p
       data-testid="profile-capability-status"
-      data-status={modelConfig.status}
+      data-status={status}
       className="text-xs text-muted-foreground"
     >
       {msg}
@@ -510,7 +510,7 @@ function CapabilitiesRow({
         <p className="text-xs text-muted-foreground">{activeMode.description}</p>
       )}
       {commands.length > 0 && <CommandsButton commands={commands} />}
-      <CapabilityStatusMessage modelConfig={{ ...modelConfig, status }} />
+      <CapabilityStatusMessage status={status} />
     </div>
   );
 }

--- a/apps/web/components/settings/profile-form-fields.tsx
+++ b/apps/web/components/settings/profile-form-fields.tsx
@@ -423,6 +423,7 @@ function CapabilitiesRow({
   commands,
   currentModelId,
   currentModeId,
+  status,
   onChange,
   isCompact,
   isLoading,
@@ -437,6 +438,7 @@ function CapabilitiesRow({
   commands: CommandEntry[];
   currentModelId: string | undefined;
   currentModeId: string | undefined;
+  status: ModelConfig["status"];
   onChange: (patch: Partial<ProfileFormData>) => void;
   isCompact: boolean;
   isLoading: boolean;
@@ -462,7 +464,6 @@ function CapabilitiesRow({
     );
   }
 
-  const status = modelConfig.status;
   if (status === "probing") {
     return <ProbingPanel />;
   }
@@ -509,7 +510,7 @@ function CapabilitiesRow({
         <p className="text-xs text-muted-foreground">{activeMode.description}</p>
       )}
       {commands.length > 0 && <CommandsButton commands={commands} />}
-      <CapabilityStatusMessage modelConfig={modelConfig} />
+      <CapabilityStatusMessage modelConfig={{ ...modelConfig, status }} />
     </div>
   );
 }
@@ -580,6 +581,7 @@ export function ProfileFormFields({
         commands={caps.commands}
         currentModelId={caps.currentModelId}
         currentModeId={caps.currentModeId}
+        status={caps.status}
         agentName={agentName}
         onChange={onChange}
         isCompact={isCompact}

--- a/apps/web/hooks/domains/settings/use-dynamic-models.test.ts
+++ b/apps/web/hooks/domains/settings/use-dynamic-models.test.ts
@@ -1,0 +1,82 @@
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { DynamicModelsResponse, ModelConfig } from "@/lib/types/http";
+
+const fetchDynamicModelsMock = vi.fn();
+
+vi.mock("@/lib/api/domains/settings-api", () => ({
+  fetchDynamicModels: (...args: unknown[]) => fetchDynamicModelsMock(...args),
+}));
+
+import { useAgentCapabilities } from "./use-dynamic-models";
+
+const initialConfig: ModelConfig = {
+  default_model: "",
+  available_models: [],
+  available_modes: [],
+  available_commands: [],
+  supports_dynamic_models: true,
+  status: "not_installed",
+  error: "agent not installed",
+};
+
+function response(status: DynamicModelsResponse["status"]): DynamicModelsResponse {
+  return {
+    agent_name: "grok-acp",
+    status,
+    models: [],
+    modes: [],
+    commands: [],
+    error: null,
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  fetchDynamicModelsMock.mockReset();
+});
+
+describe("useAgentCapabilities", () => {
+  it("exposes the status returned by a forced capability refresh", async () => {
+    fetchDynamicModelsMock
+      .mockResolvedValueOnce(response("not_installed"))
+      .mockResolvedValueOnce(response("ok"));
+
+    const { result } = renderHook(() => useAgentCapabilities("grok-acp", initialConfig));
+    await waitFor(() => expect(fetchDynamicModelsMock).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(result.current.status).toBe("ok");
+    expect(fetchDynamicModelsMock).toHaveBeenLastCalledWith("grok-acp", { refresh: true });
+  });
+
+  it("updates status when the probe returns status detail text", async () => {
+    fetchDynamicModelsMock.mockResolvedValueOnce({
+      ...response("auth_required"),
+      error: "login required",
+    });
+
+    const { result } = renderHook(() => useAgentCapabilities("grok-acp", initialConfig));
+
+    await waitFor(() => expect(result.current.error).toBe("login required"));
+    expect(result.current.status).toBe("auth_required");
+  });
+
+  it("keeps status in sync with a newer available-agent snapshot", async () => {
+    fetchDynamicModelsMock.mockResolvedValue(response("not_installed"));
+
+    const { result, rerender } = renderHook(
+      ({ initial }) => useAgentCapabilities("grok-acp", initial),
+      { initialProps: { initial: initialConfig } },
+    );
+    await waitFor(() => expect(fetchDynamicModelsMock).toHaveBeenCalledTimes(1));
+
+    rerender({ initial: { ...initialConfig, status: "probing" } });
+
+    expect(result.current.status).toBe("probing");
+  });
+});

--- a/apps/web/hooks/domains/settings/use-dynamic-models.test.ts
+++ b/apps/web/hooks/domains/settings/use-dynamic-models.test.ts
@@ -79,4 +79,50 @@ describe("useAgentCapabilities", () => {
 
     expect(result.current.status).toBe("probing");
   });
+
+  it("keeps loaded capabilities when a refresh probe fails", async () => {
+    fetchDynamicModelsMock
+      .mockResolvedValueOnce({
+        ...response("ok"),
+        models: [{ id: "grok-4", name: "Grok 4" }],
+        current_model_id: "grok-4",
+      })
+      .mockResolvedValueOnce({
+        agent_name: "grok-acp",
+        status: "failed",
+        models: [],
+        error: "probe failed",
+      });
+
+    const { result } = renderHook(() => useAgentCapabilities("grok-acp", initialConfig));
+    await waitFor(() => expect(result.current.models).toHaveLength(1));
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(result.current.status).toBe("failed");
+    expect(result.current.error).toBe("probe failed");
+    expect(result.current.models).toEqual([{ id: "grok-4", name: "Grok 4" }]);
+    expect(result.current.currentModelId).toBe("grok-4");
+  });
+
+  it("does not let a stale snapshot overwrite a completed manual refresh", async () => {
+    fetchDynamicModelsMock
+      .mockResolvedValueOnce(response("not_installed"))
+      .mockResolvedValueOnce(response("ok"));
+
+    const { result, rerender } = renderHook(
+      ({ initial }) => useAgentCapabilities("grok-acp", initial),
+      { initialProps: { initial: initialConfig } },
+    );
+    await waitFor(() => expect(fetchDynamicModelsMock).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+    rerender({ initial: { ...initialConfig, status: "probing" } });
+
+    expect(result.current.status).toBe("ok");
+  });
 });

--- a/apps/web/hooks/domains/settings/use-dynamic-models.ts
+++ b/apps/web/hooks/domains/settings/use-dynamic-models.ts
@@ -41,6 +41,8 @@ export function useAgentCapabilities(
   );
   const [currentModeId, setCurrentModeId] = useState<string | undefined>(initial.current_mode_id);
   const [status, setStatus] = useState<CapabilityStatus | undefined>(initial.status);
+  const [manualRefreshAgentName, setManualRefreshAgentName] = useState<string>();
+  const hasManualRefresh = manualRefreshAgentName === agentName;
   const [isLoading, setIsLoading] = useState(supportsDynamicModels && !!agentName);
   const [error, setError] = useState<string | null>(null);
 
@@ -57,11 +59,16 @@ export function useAgentCapabilities(
         });
         setStatus(response.status);
         setError(response.error ?? null);
-        setModels(response.models ?? []);
-        setModes(response.modes ?? []);
-        setCommands(response.commands ?? []);
-        setCurrentModelId(response.current_model_id);
-        setCurrentModeId(response.current_mode_id);
+        if (forceRefresh) {
+          setManualRefreshAgentName(agentName);
+        }
+        if (response.status !== "failed") {
+          setModels(response.models ?? []);
+          setModes(response.modes ?? []);
+          setCommands(response.commands ?? []);
+          setCurrentModelId(response.current_model_id);
+          setCurrentModeId(response.current_mode_id);
+        }
       } catch (err) {
         setError(err instanceof Error ? err.message : "Failed to fetch capabilities");
       } finally {
@@ -72,8 +79,10 @@ export function useAgentCapabilities(
   );
 
   useEffect(() => {
-    setStatus(initial.status);
-  }, [initial.status]);
+    if (!hasManualRefresh) {
+      setStatus(initial.status);
+    }
+  }, [hasManualRefresh, initial.status]);
 
   useEffect(() => {
     if (supportsDynamicModels && agentName) {

--- a/apps/web/hooks/domains/settings/use-dynamic-models.ts
+++ b/apps/web/hooks/domains/settings/use-dynamic-models.ts
@@ -4,6 +4,7 @@ import type {
   CommandEntry,
   ModeEntry,
   ModelEntry,
+  CapabilityStatus,
   DynamicModelsResponse,
   ModelConfig,
 } from "@/lib/types/http";
@@ -14,6 +15,7 @@ type UseAgentCapabilitiesState = {
   commands: CommandEntry[];
   currentModelId: string | undefined;
   currentModeId: string | undefined;
+  status: CapabilityStatus | undefined;
   isLoading: boolean;
   error: string | null;
   refresh: () => Promise<void>;
@@ -38,6 +40,7 @@ export function useAgentCapabilities(
     initial.current_model_id,
   );
   const [currentModeId, setCurrentModeId] = useState<string | undefined>(initial.current_mode_id);
+  const [status, setStatus] = useState<CapabilityStatus | undefined>(initial.status);
   const [isLoading, setIsLoading] = useState(supportsDynamicModels && !!agentName);
   const [error, setError] = useState<string | null>(null);
 
@@ -52,10 +55,8 @@ export function useAgentCapabilities(
         const response: DynamicModelsResponse = await fetchDynamicModels(agentName, {
           refresh: forceRefresh,
         });
-        if (response.error) {
-          setError(response.error);
-          return;
-        }
+        setStatus(response.status);
+        setError(response.error ?? null);
         setModels(response.models ?? []);
         setModes(response.modes ?? []);
         setCommands(response.commands ?? []);
@@ -71,6 +72,10 @@ export function useAgentCapabilities(
   );
 
   useEffect(() => {
+    setStatus(initial.status);
+  }, [initial.status]);
+
+  useEffect(() => {
     if (supportsDynamicModels && agentName) {
       void fetchCaps(false);
     }
@@ -78,5 +83,15 @@ export function useAgentCapabilities(
 
   const refresh = useCallback(() => fetchCaps(true), [fetchCaps]);
 
-  return { models, modes, commands, currentModelId, currentModeId, isLoading, error, refresh };
+  return {
+    models,
+    modes,
+    commands,
+    currentModelId,
+    currentModeId,
+    status,
+    isLoading,
+    error,
+    refresh,
+  };
 }


### PR DESCRIPTION
Agent capability refreshes now update the settings page status, so newly installed CLIs no longer remain marked as not installed. Probe results that require authentication now retain their returned diagnostic detail.

## Validation

- `make fmt`
- `make typecheck`
- `make -C apps/backend test`
- `make test-web` (606 files, 4,934 tests)
- `make test-cli` (280 tests)
- `make lint`
- `make test-scripts` was blocked only by the local Rust 1.85 toolchain; the desktop check requires Rust 1.88.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1736?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->