### PR TITLE
fix(release): prevent duplicate asset uploads

### DIFF
--- a/.github/scripts/release-workflow-contract_test.py
+++ b/.github/scripts/release-workflow-contract_test.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Contract tests for the maintainer release workflow."""
 
+import fnmatch
 import re
 import unittest
 from pathlib import Path
@@ -145,6 +146,32 @@ class ReleaseWorkflowContractTest(unittest.TestCase):
         self.assertLess(build.index(append), build.index(invoke))
         self.assertIn('"${UPDATER_SIGNING_ENABLED:-false}" = "true"', collect)
         self.assertIn('"$DESKTOP_ASSET_VERIFIER" --require-updaters', collect)
+
+    def test_release_asset_globs_are_disjoint_and_upload_sequentially(self) -> None:
+        publish = step_block("Publish release")
+        files = re.search(r"\n          files: \|\n((?:            \S+\n)+)", publish)
+        self.assertIsNotNone(files)
+        patterns = [line.strip() for line in files.group(1).splitlines()]
+        assets = (
+            "kandev-linux-x64.tar.gz",
+            "kandev-linux-x64.tar.gz.sha256",
+            "kandev-macos-arm64.tar.gz",
+            "kandev-macos-arm64.tar.gz.sha256",
+            "kandev-windows-x64.tar.gz",
+            "kandev-windows-x64.tar.gz.sha256",
+            "kandev-desktop-macos-arm64-Kandev.app.tar.gz",
+            "kandev-desktop-macos-arm64-Kandev.app.tar.gz.sha256",
+            "kandev-desktop-macos-arm64-Kandev.app.tar.gz.sig",
+            "kandev-desktop-macos-arm64-Kandev.app.tar.gz.sig.sha256",
+            "latest.json",
+        )
+
+        for asset in assets:
+            path = f"dist/release-assets/{asset}"
+            matches = [pattern for pattern in patterns if fnmatch.fnmatchcase(path, pattern)]
+            self.assertEqual(len(matches), 1, f"release glob count for {asset}: {matches}")
+
+        self.assertIn("preserve_order: true", publish)
 
     def test_macos_dmg_build_has_retry_timeout_and_diagnostics(self) -> None:
         build = step_block("Build Tauri desktop app")

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1578,10 +1578,15 @@ jobs:
           name: ${{ needs.prepare.outputs.tag }}
           body_path: RELEASE_NOTES.md
           files: |
-            dist/release-assets/kandev-*.tar.gz
-            dist/release-assets/kandev-*.tar.gz.sha256
+            dist/release-assets/kandev-linux-*.tar.gz
+            dist/release-assets/kandev-linux-*.tar.gz.sha256
+            dist/release-assets/kandev-macos-*.tar.gz
+            dist/release-assets/kandev-macos-*.tar.gz.sha256
+            dist/release-assets/kandev-windows-*.tar.gz
+            dist/release-assets/kandev-windows-*.tar.gz.sha256
             dist/release-assets/kandev-desktop-*
             dist/release-assets/latest.json
+          preserve_order: true
 
   publish-npm:
     name: Publish npm packages


### PR DESCRIPTION
The v0.79.0 backfill created a draft release with verified updater assets, but overlapping file globs submitted updater archives twice in parallel and `action-gh-release` failed while one upload deleted metadata another upload was updating. Make asset selection disjoint and serialize uploads so the existing draft can be reused and finalized safely.

## Important Changes

- Replace broad `kandev-*.tar.gz*` patterns with explicit Linux, macOS, and Windows runtime bundle patterns that cannot match `kandev-desktop-*` updater archives.
- Enable `preserve_order` on the pinned release action to avoid concurrent delete, upload, and metadata update races during backfill overwrite.
- Add a workflow contract that requires every representative release asset to match exactly one pattern and requires sequential upload mode.

## Validation

- `python3 .github/scripts/release-workflow-contract_test.py` (red with duplicate updater matches, green after)
- `bash scripts/release-desktop.test.sh` with Rust 1.88
- `python3 .github/scripts/lint-action-pinning_test.py`
- Parsed `.github/workflows/release.yml` with PyYAML
- `make fmt` with Rust 1.88
- `make typecheck` with Rust 1.88
- `make test` with Rust 1.88
- `make lint` with Rust 1.88
- Confirmed GitHub release `v0.79.0` is currently a draft containing `latest.json` and signed macOS, Linux, and Windows updater assets

## Post-Merge Recovery

Do not manually publish or delete the existing draft release. After merge, go to **Actions > Release > Run workflow** on `main` and set:

- `backfill_tag`: `v0.79.0`
- `dry_run`: `false`
- `desktop_validation_only`: `false`
- `bump`: any value; it is ignored when `backfill_tag` is set

Do not rerun failed run 29508331305 and do not run a normal version bump. Verify that the backfill finalizes GitHub release `v0.79.0` with `latest.json` and signed updater artifacts, then verify the npm and Homebrew jobs complete.

## Possible Improvements

Low risk: sequential publication trades some upload speed for deterministic draft recovery and release finalization.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1737?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->