### PR TITLE
fix(web): preserve office workspace mode in task routes

### DIFF
--- a/apps/web/lib/ssr/session-page-state.test.ts
+++ b/apps/web/lib/ssr/session-page-state.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AppState } from "@/lib/state/store";
+import type { Task } from "@/lib/types/http";
+
+const mocks = vi.hoisted(() => ({
+  fetchTask: vi.fn(),
+  fetchTaskSession: vi.fn(),
+  fetchUserSettings: vi.fn(),
+  fetchWorkflowSnapshot: vi.fn(),
+  listAgents: vi.fn(),
+  listRepositories: vi.fn(),
+  listTaskSessionMessages: vi.fn(),
+  listTaskSessions: vi.fn(),
+  listWorkflows: vi.fn(),
+  listWorkspaces: vi.fn(),
+}));
+
+vi.mock("@/lib/api", () => ({
+  fetchTask: mocks.fetchTask,
+  fetchTaskSession: mocks.fetchTaskSession,
+  fetchUserSettings: mocks.fetchUserSettings,
+  fetchWorkflowSnapshot: mocks.fetchWorkflowSnapshot,
+  listAgents: mocks.listAgents,
+  listRepositories: mocks.listRepositories,
+  listTaskSessionMessages: mocks.listTaskSessionMessages,
+  listTaskSessions: mocks.listTaskSessions,
+  listWorkflows: mocks.listWorkflows,
+  listWorkspaces: mocks.listWorkspaces,
+}));
+
+vi.mock("@/lib/api/domains/session-api", () => ({
+  listSessionTurns: vi.fn(),
+}));
+
+vi.mock("@/lib/api/domains/user-shell-api", () => ({
+  fetchTerminals: vi.fn(),
+}));
+
+import { fetchSessionDataForTask } from "./session-page-state";
+
+const NOW = "2026-07-16T12:00:00Z";
+
+describe("fetchSessionDataForTask workspace hydration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.fetchTask.mockResolvedValue({
+      id: "task-1",
+      workspace_id: "workspace-office",
+      workflow_id: "",
+      workflow_step_id: "",
+      position: 0,
+      title: "Office task",
+      description: "",
+      state: "TODO",
+      priority: 0,
+      created_at: NOW,
+      updated_at: NOW,
+    } as unknown as Task);
+    mocks.listTaskSessions.mockResolvedValue({ sessions: [] });
+    mocks.listAgents.mockResolvedValue({ agents: [] });
+    mocks.listRepositories.mockResolvedValue({ repositories: [] });
+    mocks.listWorkflows.mockResolvedValue({ workflows: [] });
+    mocks.fetchUserSettings.mockResolvedValue(null);
+    mocks.listWorkspaces.mockResolvedValue({
+      workspaces: [
+        {
+          id: "workspace-office",
+          name: "Office",
+          owner_id: "",
+          office_workflow_id: "workflow-office",
+          created_at: NOW,
+          updated_at: NOW,
+        },
+      ],
+    });
+  });
+
+  it("preserves the Office workflow ID in task-route state", async () => {
+    const result = await fetchSessionDataForTask("task-1");
+    const initialState = result.initialState as unknown as Partial<AppState>;
+
+    expect(initialState.workspaces?.items[0]?.office_workflow_id).toBe("workflow-office");
+  });
+});

--- a/apps/web/lib/ssr/session-page-state.ts
+++ b/apps/web/lib/ssr/session-page-state.ts
@@ -25,6 +25,7 @@ import { mapUserSettingsResponse } from "@/lib/ssr/user-settings";
 import { prepareResultToSessionState } from "@/lib/state/slices/session-runtime/prepare-result";
 import type { SessionPrepareState } from "@/lib/state/slices/session-runtime/types";
 import type { AppState } from "@/lib/state/store";
+import { mapWorkspaceItem } from "@/lib/routing/route-bootstrap";
 
 function buildWorktreeState(allSessions: TaskSession[]) {
   const sessionsWithWorktrees = allSessions.filter((s) => s.worktree_id);
@@ -100,17 +101,7 @@ function buildResourceState(p: BuildSessionPageStateParams) {
   const scripts = repository?.scripts ?? [];
   return {
     workspaces: {
-      items: workspaces.map((w) => ({
-        id: w.id,
-        name: w.name,
-        description: w.description ?? null,
-        owner_id: w.owner_id,
-        default_executor_id: w.default_executor_id ?? null,
-        default_environment_id: w.default_environment_id ?? null,
-        default_agent_profile_id: w.default_agent_profile_id ?? null,
-        created_at: w.created_at,
-        updated_at: w.updated_at,
-      })),
+      items: workspaces.map(mapWorkspaceItem),
       activeId: task.workspace_id,
     },
     // Don't write activeId — null means "All Workflows"; task context lives in kanban.workflowId.


### PR DESCRIPTION
Task-detail hydration dropped the Office workspace discriminator, causing the workspace picker to label Office workspaces as Kanban. Reusing the canonical workspace mapper preserves the correct mode when navigating to the advanced task view.

## Validation

- `make fmt`
- `make typecheck`
- `make test`
- `make lint`
- Headless Chromium: Office home -> Office task -> Open in advanced view preserves the `Office` label

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1738?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->