### PR TITLE
fix(web): prioritize subscription usage

### DIFF
--- a/apps/web/app/settings/agents/page.tsx
+++ b/apps/web/app/settings/agents/page.tsx
@@ -218,14 +218,14 @@ function InstalledAgentsSection({
 
   return (
     <div className="space-y-4">
-      <div className="flex items-start justify-between gap-4">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
         <div>
           <h3 className="text-lg font-semibold">Installed Agents</h3>
           <p className="text-sm text-muted-foreground">
             Agents detected on this machine are ready to configure.
           </p>
         </div>
-        <div className="flex gap-2">
+        <div className="flex w-full gap-2 sm:w-auto">
           <Button
             variant="outline"
             size="sm"
@@ -563,6 +563,8 @@ export default function AgentsSettingsPage() {
         </p>
       </div>
 
+      <AgentUsageSection />
+
       <Separator />
 
       <InstalledAgentsSection
@@ -575,8 +577,6 @@ export default function AgentsSettingsPage() {
         setTuiDialogOpen={setTuiDialogOpen}
         handleRescan={handleRescan}
       />
-
-      <AgentUsageSection />
 
       <SuggestInstallSection
         notInstalledAgents={notInstalledAgents}

--- a/apps/web/components/task/chat/token-usage-display.test.tsx
+++ b/apps/web/components/task/chat/token-usage-display.test.tsx
@@ -102,10 +102,14 @@ describe("TokenUsageDisplay", () => {
       },
     });
 
-    const { container, getByText } = render(<TokenUsageDisplay sessionId="sess-1" />);
+    const { container, getByTestId, getByText } = render(<TokenUsageDisplay sessionId="sess-1" />);
 
     expect(container.querySelector('[data-testid="doughnut-subscription-usage"]')).not.toBeNull();
     expect(getByText(/Subscription usage · max/i)).toBeDefined();
+    expect(
+      getByTestId("doughnut-subscription-usage").compareDocumentPosition(getByText(/^28%/)) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
     // Worst window is 86% → provider status "High".
     expect(getByText("High")).toBeDefined();
     expect(getByText("5h")).toBeDefined();

--- a/apps/web/components/task/chat/token-usage-display.test.tsx
+++ b/apps/web/components/task/chat/token-usage-display.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, fireEvent, render } from "@testing-library/react";
 import { useSessionContextWindow } from "@/hooks/domains/session/use-session-context-window";
 import { useSessionAgentUsage } from "@/hooks/domains/session/use-session-agent-usage";
 import { isContextWindowReliable, TokenUsageDisplay } from "./token-usage-display";
@@ -13,7 +13,11 @@ vi.mock("@/hooks/domains/session/use-session-agent-usage", () => ({
 }));
 
 vi.mock("@kandev/ui/tooltip", () => ({
-  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  Tooltip: ({ children, open }: { children: React.ReactNode; open?: boolean }) => (
+    <div data-testid="tooltip-root" data-open={open}>
+      {children}
+    </div>
+  ),
   TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
@@ -73,6 +77,21 @@ describe("TokenUsageDisplay", () => {
     expect(container.querySelector("svg")).not.toBeNull();
   });
 
+  it("opens the tooltip when the context ring is tapped", () => {
+    vi.mocked(useSessionContextWindow).mockReturnValue({
+      size: 200_000,
+      used: 56_047,
+      remaining: 143_953,
+      efficiency: 28,
+    });
+
+    const { getByRole, getByTestId } = render(<TokenUsageDisplay sessionId="sess-1" />);
+
+    fireEvent.click(getByRole("button", { name: "Context window: 28% used" }));
+
+    expect(getByTestId("tooltip-root").getAttribute("data-open")).toBe("true");
+  });
+
   it("shows subscription usage rows in the tooltip when the agent has them", () => {
     vi.mocked(useSessionContextWindow).mockReturnValue({
       size: 200_000,
@@ -102,13 +121,19 @@ describe("TokenUsageDisplay", () => {
       },
     });
 
-    const { container, getByTestId, getByText } = render(<TokenUsageDisplay sessionId="sess-1" />);
+    const { container, getByRole, getByTestId, getByText } = render(
+      <TokenUsageDisplay sessionId="sess-1" />,
+    );
 
     expect(container.querySelector('[data-testid="doughnut-subscription-usage"]')).not.toBeNull();
-    expect(getByText(/Subscription usage · max/i)).toBeDefined();
+    expect(getByRole("button", { name: "Context window: 28% used" })).toBeDefined();
+    expect(getByText("Context window")).toBeDefined();
+    expect(getByText("56.0K of 200.0K tokens")).toBeDefined();
+    expect(getByText(/Subscription · max/i)).toBeDefined();
     expect(
-      getByTestId("doughnut-subscription-usage").compareDocumentPosition(getByText(/^28%/)) &
-        Node.DOCUMENT_POSITION_FOLLOWING,
+      getByTestId("context-window-usage").compareDocumentPosition(
+        getByTestId("doughnut-subscription-usage"),
+      ) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
     // Worst window is 86% → provider status "High".
     expect(getByText("High")).toBeDefined();

--- a/apps/web/components/task/chat/token-usage-display.tsx
+++ b/apps/web/components/task/chat/token-usage-display.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { memo } from "react";
+import { memo, useState } from "react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { UsageWindowRows, usageStatus } from "@/components/usage/usage-window-rows";
@@ -54,16 +54,16 @@ function SessionUsageRows({ sessionId }: { sessionId: string | null }) {
 
   return (
     <div
-      className="pb-2 mb-2 border-b border-border/60 space-y-2 min-w-56"
+      className="pt-2 mt-2 border-t border-border/60 space-y-2 min-w-64 opacity-80"
       data-testid="doughnut-subscription-usage"
     >
       <div className="flex items-center justify-between gap-4">
-        <span className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
-          Subscription usage{usage.plan ? ` · ${usage.plan}` : ""}
+        <span className="text-[10px] font-medium uppercase text-muted-foreground">
+          Subscription{usage.plan ? ` · ${usage.plan}` : ""}
         </span>
-        <span className={cn("text-[10px] font-semibold", status.className)}>{status.label}</span>
+        <span className={cn("text-[10px] font-medium", status.className)}>{status.label}</span>
       </div>
-      <UsageWindowRows usage={usage} />
+      <UsageWindowRows usage={usage} className="text-[11px]" />
     </div>
   );
 }
@@ -72,6 +72,7 @@ export const TokenUsageDisplay = memo(function TokenUsageDisplay({
   sessionId,
   className,
 }: TokenUsageDisplayProps) {
+  const [tooltipOpen, setTooltipOpen] = useState(false);
   const contextWindow = useSessionContextWindow(sessionId);
 
   if (!contextWindow) return null;
@@ -92,44 +93,71 @@ export const TokenUsageDisplay = memo(function TokenUsageDisplay({
   const strokeDashoffset = circumference * (1 - progress);
 
   return (
-    <Tooltip>
+    <Tooltip open={tooltipOpen} onOpenChange={setTooltipOpen}>
       <TooltipTrigger asChild>
-        <div className={cn("flex items-center gap-2 cursor-help", className)}>
-          <div className="relative flex items-center justify-center">
-            <svg viewBox="0 0 24 24" className="w-5 h-5 -rotate-90" aria-hidden="true">
-              {/* Background circle */}
-              <circle
-                cx="12"
-                cy="12"
-                r={radius}
-                fill="none"
-                stroke="currentColor"
-                strokeWidth={strokeWidth}
-                className="text-muted"
-              />
-              {/* Progress circle */}
-              <circle
-                cx="12"
-                cy="12"
-                r={radius}
-                fill="none"
-                stroke="currentColor"
-                strokeWidth={strokeWidth}
-                strokeLinecap="round"
-                strokeDasharray={circumference}
-                strokeDashoffset={strokeDashoffset}
-                className={cn(getCircleColor(usagePercent), "transition-all duration-300 ease-out")}
-              />
-            </svg>
-          </div>
-        </div>
+        <button
+          type="button"
+          aria-label={`Context window: ${usagePercent.toFixed(0)}% used`}
+          onClick={() => setTooltipOpen(true)}
+          className={cn(
+            "flex size-7 cursor-help items-center justify-center rounded-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring sm:size-5",
+            className,
+          )}
+        >
+          <svg viewBox="0 0 24 24" className="size-5 -rotate-90" aria-hidden="true">
+            {/* Background circle */}
+            <circle
+              cx="12"
+              cy="12"
+              r={radius}
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={strokeWidth}
+              className="text-muted"
+            />
+            {/* Progress circle */}
+            <circle
+              cx="12"
+              cy="12"
+              r={radius}
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={strokeWidth}
+              strokeLinecap="round"
+              strokeDasharray={circumference}
+              strokeDashoffset={strokeDashoffset}
+              className={cn(getCircleColor(usagePercent), "transition-all duration-300 ease-out")}
+            />
+          </svg>
+        </button>
       </TooltipTrigger>
       <TooltipContent side="top">
-        <div className="text-xs">
-          <SessionUsageRows sessionId={sessionId} />
-          <div className="text-[11px] text-muted-foreground">
-            {usagePercent.toFixed(0)}% ({formatNumber(used)} / {formatNumber(size)})
+        <div className="min-w-64 text-xs">
+          <div className="space-y-2" data-testid="context-window-usage">
+            <div className="flex items-baseline justify-between gap-6">
+              <span className="text-[10px] font-medium uppercase text-muted-foreground">
+                Context window
+              </span>
+              <span className="text-base font-semibold tabular-nums text-foreground">
+                {usagePercent.toFixed(0)}%
+              </span>
+            </div>
+            <div
+              className={cn(
+                "h-1.5 overflow-hidden rounded-full bg-muted",
+                getCircleColor(usagePercent),
+              )}
+            >
+              <div
+                className="h-full rounded-full bg-current transition-all duration-300 ease-out"
+                style={{ width: `${usagePercent}%` }}
+              />
+            </div>
+            <div className="text-[11px] tabular-nums text-muted-foreground">
+              {formatNumber(used)} of {formatNumber(size)} tokens
+            </div>
           </div>
+          <SessionUsageRows sessionId={sessionId} />
         </div>
       </TooltipContent>
     </Tooltip>

--- a/apps/web/components/task/chat/token-usage-display.tsx
+++ b/apps/web/components/task/chat/token-usage-display.tsx
@@ -54,7 +54,7 @@ function SessionUsageRows({ sessionId }: { sessionId: string | null }) {
 
   return (
     <div
-      className="pt-2 mt-2 border-t border-border/60 space-y-2 min-w-56"
+      className="pb-2 mb-2 border-b border-border/60 space-y-2 min-w-56"
       data-testid="doughnut-subscription-usage"
     >
       <div className="flex items-center justify-between gap-4">
@@ -125,11 +125,11 @@ export const TokenUsageDisplay = memo(function TokenUsageDisplay({
         </div>
       </TooltipTrigger>
       <TooltipContent side="top">
-        <div className="text-xs space-y-1">
-          <div className="font-medium">
+        <div className="text-xs">
+          <SessionUsageRows sessionId={sessionId} />
+          <div className="text-[11px] text-muted-foreground">
             {usagePercent.toFixed(0)}% ({formatNumber(used)} / {formatNumber(size)})
           </div>
-          <SessionUsageRows sessionId={sessionId} />
         </div>
       </TooltipContent>
     </Tooltip>


### PR DESCRIPTION
Subscription rate limits now stay prominent wherever agent capacity is shown, ahead of less-urgent context details. The Agents settings page surfaces available subscription data first and keeps installed-agent actions usable on mobile.

## Validation

- `make fmt`
- `make typecheck`
- `make lint`
- `make test` (backend, web, and CLI suites passed; desktop script validation is blocked because this environment has Rust 1.85 and requires Rust 1.88)
- Verified the context tooltip and Agents settings at desktop and mobile viewport sizes in Chromium.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1741?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->