### PR TITLE
feat(orchestrator): persist ACP session id in session metadata

### DIFF
--- a/apps/backend/internal/orchestrator/event_handlers.go
+++ b/apps/backend/internal/orchestrator/event_handlers.go
@@ -104,30 +104,19 @@ func (s *Service) storeResumeToken(ctx context.Context, taskID, sessionID, expec
 }
 
 // persistACPSessionID mirrors the agent's ACP session id into the session's
-// "acp" metadata map (merging with whatever session_info already wrote, and
-// skipping the write when the stored id is already current). Best-effort:
-// resume correctness never depends on this copy — it exists so the id
-// survives executors_running cleanup for consumers that join sessions to
-// agent-CLI artifacts (e.g. transcript-based usage stats).
+// "acp" metadata map. Best-effort: resume correctness never depends on this
+// copy — it exists so the id survives executors_running cleanup for consumers
+// that join sessions to agent-CLI artifacts (e.g. transcript-based usage
+// stats). The repo performs the mirror as a single guarded UPDATE: it merges
+// into the existing acp map (preserving session_info keys), skips when the
+// stored id is already current, and only writes while executors_running still
+// holds acpSessionID as the resume token — so a stale event from a rotated
+// execution can never overwrite the live execution's id.
 func (s *Service) persistACPSessionID(ctx context.Context, sessionID, acpSessionID string) {
 	if sessionID == "" || acpSessionID == "" || s.repo == nil {
 		return
 	}
-	session, err := s.repo.GetTaskSession(ctx, sessionID)
-	if err != nil || session == nil {
-		return
-	}
-	info := map[string]interface{}{}
-	if existing, ok := session.Metadata["acp"].(map[string]interface{}); ok {
-		if existing["session_id"] == acpSessionID {
-			return
-		}
-		for key, value := range existing {
-			info[key] = value
-		}
-	}
-	info["session_id"] = acpSessionID
-	if err := s.repo.SetSessionMetadataKey(ctx, sessionID, "acp", info); err != nil {
+	if _, err := s.repo.SetSessionACPSessionID(ctx, sessionID, acpSessionID); err != nil {
 		s.logger.Warn("failed to persist ACP session id to session metadata",
 			zap.String("session_id", sessionID),
 			zap.String("acp_session_id", acpSessionID),

--- a/apps/backend/internal/orchestrator/event_handlers.go
+++ b/apps/backend/internal/orchestrator/event_handlers.go
@@ -69,6 +69,12 @@ func (s *Service) storeResumeToken(ctx context.Context, taskID, sessionID, expec
 			zap.String("expected_exec_id", expectedExecID),
 			zap.String("resume_token", acpSessionID),
 			zap.String("last_message_uuid", lastMessageUUID))
+		// The CAS above proved the token belongs to the session's current
+		// execution — mirror it into the session's durable "acp" metadata
+		// too. executors_running rows are operational state and get pruned;
+		// without this, the ACP session id only survives for agents that
+		// happen to emit a session_info frame (handleSessionInfoEvent).
+		s.persistACPSessionID(ctx, sessionID, acpSessionID)
 	case errors.Is(err, models.ErrExecutionRotated):
 		// The row's agent_execution_id has rotated since the event was emitted —
 		// the token belongs to a defunct execution and must be dropped. The new
@@ -93,6 +99,38 @@ func (s *Service) storeResumeToken(ctx context.Context, taskID, sessionID, expec
 		s.logger.Warn("failed to persist resume token for session",
 			zap.String("task_id", taskID),
 			zap.String("session_id", sessionID),
+			zap.Error(err))
+	}
+}
+
+// persistACPSessionID mirrors the agent's ACP session id into the session's
+// "acp" metadata map (merging with whatever session_info already wrote, and
+// skipping the write when the stored id is already current). Best-effort:
+// resume correctness never depends on this copy — it exists so the id
+// survives executors_running cleanup for consumers that join sessions to
+// agent-CLI artifacts (e.g. transcript-based usage stats).
+func (s *Service) persistACPSessionID(ctx context.Context, sessionID, acpSessionID string) {
+	if sessionID == "" || acpSessionID == "" || s.repo == nil {
+		return
+	}
+	session, err := s.repo.GetTaskSession(ctx, sessionID)
+	if err != nil || session == nil {
+		return
+	}
+	info := map[string]interface{}{}
+	if existing, ok := session.Metadata["acp"].(map[string]interface{}); ok {
+		if existing["session_id"] == acpSessionID {
+			return
+		}
+		for key, value := range existing {
+			info[key] = value
+		}
+	}
+	info["session_id"] = acpSessionID
+	if err := s.repo.SetSessionMetadataKey(ctx, sessionID, "acp", info); err != nil {
+		s.logger.Warn("failed to persist ACP session id to session metadata",
+			zap.String("session_id", sessionID),
+			zap.String("acp_session_id", acpSessionID),
 			zap.Error(err))
 	}
 }

--- a/apps/backend/internal/orchestrator/event_handlers_acp_metadata_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_acp_metadata_test.go
@@ -5,17 +5,37 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/kandev/kandev/internal/task/models"
+	sqliterepo "github.com/kandev/kandev/internal/task/repository/sqlite"
 )
 
+// seedResumeToken puts the session's executors_running row into the state
+// storeResumeToken leaves it in after a successful CAS: resume_token holds the
+// agent's ACP session id. persistACPSessionID only mirrors ids that match this
+// row, so every subtest that expects a write needs it.
+func seedResumeToken(t *testing.T, repo *sqliterepo.Repository, sessionID, taskID, token string) {
+	t.Helper()
+	require.NoError(t, repo.UpsertExecutorRunning(context.Background(), &models.ExecutorRunning{
+		ID:          sessionID,
+		SessionID:   sessionID,
+		TaskID:      taskID,
+		ResumeToken: token,
+		Status:      "ready",
+	}))
+}
+
 // persistACPSessionID must write the ACP session id into the session's "acp"
-// metadata map, preserve keys session_info already stored, and be a no-op
-// when the stored id is current.
+// metadata map, preserve keys session_info already stored, be a no-op when the
+// stored id is current, and refuse to mirror an id that no longer matches the
+// executors_running resume token (stale event from a rotated execution).
 func TestPersistACPSessionID(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("writes id into empty metadata", func(t *testing.T) {
 		repo := setupTestRepo(t)
 		seedSession(t, repo, "t1", "s1", "step1")
+		seedResumeToken(t, repo, "s1", "t1", "acp-123")
 		svc := createTestService(repo, newMockStepGetter(), newMockTaskRepo())
 
 		svc.persistACPSessionID(ctx, "s1", "acp-123")
@@ -30,6 +50,7 @@ func TestPersistACPSessionID(t *testing.T) {
 	t.Run("merges with existing acp map and updates stale id", func(t *testing.T) {
 		repo := setupTestRepo(t)
 		seedSession(t, repo, "t1", "s1", "step1")
+		seedResumeToken(t, repo, "s1", "t1", "acp-new")
 		require.NoError(t, repo.SetSessionMetadataKey(ctx, "s1", "acp",
 			map[string]interface{}{"session_id": "acp-old", "title": "My session"}))
 		svc := createTestService(repo, newMockStepGetter(), newMockTaskRepo())
@@ -46,6 +67,7 @@ func TestPersistACPSessionID(t *testing.T) {
 	t.Run("skips write when id is current", func(t *testing.T) {
 		repo := setupTestRepo(t)
 		seedSession(t, repo, "t1", "s1", "step1")
+		seedResumeToken(t, repo, "s1", "t1", "acp-123")
 		require.NoError(t, repo.SetSessionMetadataKey(ctx, "s1", "acp",
 			map[string]interface{}{"session_id": "acp-123"}))
 		before, err := repo.GetTaskSession(ctx, "s1")
@@ -57,5 +79,23 @@ func TestPersistACPSessionID(t *testing.T) {
 		after, err := repo.GetTaskSession(ctx, "s1")
 		require.NoError(t, err)
 		require.Equal(t, before.UpdatedAt, after.UpdatedAt, "no-op must not touch the row")
+	})
+
+	t.Run("skips write when execution rotated to a newer token", func(t *testing.T) {
+		repo := setupTestRepo(t)
+		seedSession(t, repo, "t1", "s1", "step1")
+		// The successor execution's CAS already stored its own token; a
+		// delayed mirror from the previous execution must not land.
+		seedResumeToken(t, repo, "s1", "t1", "acp-successor")
+		require.NoError(t, repo.SetSessionMetadataKey(ctx, "s1", "acp",
+			map[string]interface{}{"session_id": "acp-successor"}))
+		svc := createTestService(repo, newMockStepGetter(), newMockTaskRepo())
+
+		svc.persistACPSessionID(ctx, "s1", "acp-stale")
+
+		session, err := repo.GetTaskSession(ctx, "s1")
+		require.NoError(t, err)
+		acp := session.Metadata["acp"].(map[string]interface{})
+		require.Equal(t, "acp-successor", acp["session_id"], "stale id must not overwrite the live execution's id")
 	})
 }

--- a/apps/backend/internal/orchestrator/event_handlers_acp_metadata_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_acp_metadata_test.go
@@ -1,0 +1,61 @@
+package orchestrator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// persistACPSessionID must write the ACP session id into the session's "acp"
+// metadata map, preserve keys session_info already stored, and be a no-op
+// when the stored id is current.
+func TestPersistACPSessionID(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("writes id into empty metadata", func(t *testing.T) {
+		repo := setupTestRepo(t)
+		seedSession(t, repo, "t1", "s1", "step1")
+		svc := createTestService(repo, newMockStepGetter(), newMockTaskRepo())
+
+		svc.persistACPSessionID(ctx, "s1", "acp-123")
+
+		session, err := repo.GetTaskSession(ctx, "s1")
+		require.NoError(t, err)
+		acp, ok := session.Metadata["acp"].(map[string]interface{})
+		require.True(t, ok, "acp metadata map missing: %+v", session.Metadata)
+		require.Equal(t, "acp-123", acp["session_id"])
+	})
+
+	t.Run("merges with existing acp map and updates stale id", func(t *testing.T) {
+		repo := setupTestRepo(t)
+		seedSession(t, repo, "t1", "s1", "step1")
+		require.NoError(t, repo.SetSessionMetadataKey(ctx, "s1", "acp",
+			map[string]interface{}{"session_id": "acp-old", "title": "My session"}))
+		svc := createTestService(repo, newMockStepGetter(), newMockTaskRepo())
+
+		svc.persistACPSessionID(ctx, "s1", "acp-new")
+
+		session, err := repo.GetTaskSession(ctx, "s1")
+		require.NoError(t, err)
+		acp := session.Metadata["acp"].(map[string]interface{})
+		require.Equal(t, "acp-new", acp["session_id"])
+		require.Equal(t, "My session", acp["title"], "session_info keys must survive")
+	})
+
+	t.Run("skips write when id is current", func(t *testing.T) {
+		repo := setupTestRepo(t)
+		seedSession(t, repo, "t1", "s1", "step1")
+		require.NoError(t, repo.SetSessionMetadataKey(ctx, "s1", "acp",
+			map[string]interface{}{"session_id": "acp-123"}))
+		before, err := repo.GetTaskSession(ctx, "s1")
+		require.NoError(t, err)
+
+		svc := createTestService(repo, newMockStepGetter(), newMockTaskRepo())
+		svc.persistACPSessionID(ctx, "s1", "acp-123")
+
+		after, err := repo.GetTaskSession(ctx, "s1")
+		require.NoError(t, err)
+		require.Equal(t, before.UpdatedAt, after.UpdatedAt, "no-op must not touch the row")
+	})
+}

--- a/apps/backend/internal/orchestrator/service.go
+++ b/apps/backend/internal/orchestrator/service.go
@@ -165,6 +165,7 @@ type sessionExecutorStore interface {
 	UpdateSessionReviewStatus(ctx context.Context, sessionID string, status string) error
 	UpdateSessionMetadata(ctx context.Context, sessionID string, metadata map[string]interface{}) error
 	SetSessionMetadataKey(ctx context.Context, sessionID, key string, value interface{}) error
+	SetSessionACPSessionID(ctx context.Context, sessionID, acpSessionID string) (bool, error)
 	// Executor running state
 	ListExecutorsRunning(ctx context.Context) ([]*models.ExecutorRunning, error)
 	UpsertExecutorRunning(ctx context.Context, running *models.ExecutorRunning) error

--- a/apps/backend/internal/task/handlers/process_handlers_test.go
+++ b/apps/backend/internal/task/handlers/process_handlers_test.go
@@ -535,6 +535,9 @@ func (m *mockRepository) SetSessionMetadataKey(ctx context.Context, sessionID, k
 	}
 	return nil
 }
+func (m *mockRepository) SetSessionACPSessionID(_ context.Context, _ string, _ string) (bool, error) {
+	return false, nil
+}
 func (m *mockRepository) DismissLastAgentError(_ context.Context, _ string, _ models.LastAgentError, _ time.Time) (bool, error) {
 	return true, nil
 }

--- a/apps/backend/internal/task/repository/interface.go
+++ b/apps/backend/internal/task/repository/interface.go
@@ -184,6 +184,7 @@ type SessionRepository interface {
 	UpdateSessionReviewStatus(ctx context.Context, sessionID string, status string) error
 	UpdateSessionMetadata(ctx context.Context, sessionID string, metadata map[string]interface{}) error
 	SetSessionMetadataKey(ctx context.Context, sessionID, key string, value interface{}) error
+	SetSessionACPSessionID(ctx context.Context, sessionID, acpSessionID string) (bool, error)
 	DismissLastAgentError(ctx context.Context, sessionID string, expected models.LastAgentError, dismissedAt time.Time) (bool, error)
 	GetLastAgentMessage(ctx context.Context, sessionID string) (string, error)
 }

--- a/apps/backend/internal/task/repository/sqlite/session.go
+++ b/apps/backend/internal/task/repository/sqlite/session.go
@@ -646,6 +646,38 @@ func (r *Repository) SetSessionMetadataKey(ctx context.Context, sessionID, key s
 	return nil
 }
 
+// SetSessionACPSessionID mirrors the agent's ACP session id into the session's
+// "acp" metadata map as a single atomic UPDATE. json_patch merges the sub-key,
+// so keys session_info already wrote (title, ...) survive without a
+// read-modify-write round trip. The write only happens while the session's
+// executors_running row still holds acpSessionID as its resume token — i.e.
+// the CAS that stored the token hasn't been superseded by a rotated execution
+// — and is skipped when the stored id is already current, so a no-op never
+// touches updated_at. Returns whether a row was written.
+func (r *Repository) SetSessionACPSessionID(ctx context.Context, sessionID, acpSessionID string) (bool, error) {
+	patch, err := json.Marshal(map[string]interface{}{"acp": map[string]string{"session_id": acpSessionID}})
+	if err != nil {
+		return false, fmt.Errorf("failed to serialize metadata patch: %w", err)
+	}
+	now := time.Now().UTC()
+	result, err := r.db.ExecContext(ctx, r.db.Rebind(`
+		UPDATE task_sessions
+		SET metadata = json_patch(CASE WHEN metadata IS NULL OR metadata = 'null' OR metadata = '' THEN '{}' ELSE metadata END, json(?)),
+		    updated_at = ?
+		WHERE id = ?
+		  AND json_extract(metadata, '$.acp.session_id') IS NOT ?
+		  AND EXISTS (
+			SELECT 1 FROM executors_running er
+			WHERE er.session_id = task_sessions.id AND er.resume_token = ?
+		  )
+	`), string(patch), now, sessionID, acpSessionID, acpSessionID)
+	if err != nil {
+		return false, err
+	}
+	rows, _ := result.RowsAffected()
+	return rows > 0, nil
+}
+
 func (r *Repository) DismissLastAgentError(ctx context.Context, sessionID string, expected models.LastAgentError, dismissedAt time.Time) (bool, error) {
 	next := expected
 	next.DismissedAt = &dismissedAt


### PR DESCRIPTION
## Summary

Persist the agent CLI's ACP session id (`acp.session_id`) into `task_sessions.metadata` whenever a resume token is stored, instead of relying on the agent emitting an ACP `session_info` frame.

**Problem:** most agents/paths never send `session_info`, so most sessions have no durable record of their ACP session id. `executors_running.resume_token` holds it, but that table is operational state and rows get pruned. This blocks joining kandev sessions to agent-CLI artifacts (e.g. transcript-based token/cost stats — the ACP session UUID names the agent's local transcript file).

**Fix:** `storeResumeToken` now calls a new `persistACPSessionID` helper on its CAS-success path. The helper:

- reads the session and merges the id into the existing `acp` metadata map, preserving any `session_info` keys (title etc.)
- skips the write when the stored id is already current
- is best-effort: failures log a warning and never block resume-token storage

Forward-only metadata write — no schema change, no backfill, no docs/spec impact.

## Testing

- `go test ./internal/orchestrator/ -run TestPersistACPSessionID -count=1` — new tests covering fresh write, merge with existing `acp` map, and no-op when current
- Full `./internal/orchestrator/` package suite passes
- `make fmt` clean; `golangci-lint run ./internal/orchestrator/... --new-from-rev=origin/main` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1748?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->