### PR TITLE
feat(web): add quick chat entry points on mobile

### DIFF
--- a/apps/web/components/kanban/kanban-header-mobile.test.tsx
+++ b/apps/web/components/kanban/kanban-header-mobile.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { StateProvider } from "@/components/state-provider";
@@ -30,17 +30,26 @@ vi.mock("./mobile-menu-sheet", () => ({
   MobileMenuSheet: () => null,
 }));
 
+const quickChatMocks = vi.hoisted(() => ({ openQuickChat: vi.fn() }));
+
+vi.mock("@/hooks/use-quick-chat-launcher", () => ({
+  useQuickChatLauncher: () => quickChatMocks.openQuickChat,
+}));
+
 const LEFT_ACTIONS_TEST_ID = "topbar-left-actions";
+const QUICK_CHAT_TEST_ID = "mobile-quick-chat-button";
 
 afterEach(() => {
   cleanup();
+  quickChatMocks.openQuickChat.mockClear();
 });
 
-function renderHeader(title: string) {
+function renderHeader(title: string, workspaceId?: string) {
   return render(
     <StateProvider>
       <KanbanHeaderMobile
         title={title}
+        workspaceId={workspaceId}
         workspaceLabel="/root/kandev"
         showHealthIndicator={false}
         onOpenHealthDialog={() => undefined}
@@ -65,5 +74,18 @@ describe("KanbanHeaderMobile", () => {
     expect(leftActions.textContent).toContain("Tasks");
     expect(leftActions.textContent).toContain("/root/kandev");
     expect(leftActions.firstElementChild?.className).toContain("max-w-[38vw]");
+  });
+
+  it("opens quick chat from the header action when a workspace is active", () => {
+    renderHeader("Home", "workspace-1");
+
+    fireEvent.click(screen.getByTestId(QUICK_CHAT_TEST_ID));
+    expect(quickChatMocks.openQuickChat).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides the quick chat action without an active workspace", () => {
+    renderHeader("Home");
+
+    expect(screen.queryByTestId(QUICK_CHAT_TEST_ID)).toBeNull();
   });
 });

--- a/apps/web/components/kanban/kanban-header-mobile.tsx
+++ b/apps/web/components/kanban/kanban-header-mobile.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import { Button } from "@kandev/ui/button";
-import { IconMenu2, IconSearch } from "@tabler/icons-react";
+import { IconMenu2, IconMessageCircle, IconSearch } from "@tabler/icons-react";
 import { PageTopbar } from "@/components/page-topbar";
 import { TopbarMetrics } from "@/components/system-metrics/topbar-metrics";
 import { MobileMenuSheet } from "./mobile-menu-sheet";
 import { useAppStore } from "@/components/state-provider";
+import { useQuickChatLauncher } from "@/hooks/use-quick-chat-launcher";
 
 type KanbanHeaderMobileProps = {
   workspaceId?: string;
@@ -36,6 +37,7 @@ export function KanbanHeaderMobile({
   const setMenuOpen = useAppStore((state) => state.setMobileKanbanMenuOpen);
   const isSearchOpen = useAppStore((state) => state.mobileKanban.isSearchOpen);
   const setSearchOpen = useAppStore((state) => state.setMobileKanbanSearchOpen);
+  const handleOpenQuickChat = useQuickChatLauncher(workspaceId);
   const isHome = title === "Home";
 
   const toggleSearch = () => {
@@ -69,6 +71,18 @@ export function KanbanHeaderMobile({
         actions={
           <>
             <TopbarMetrics size="lg" />
+            {workspaceId && (
+              <Button
+                variant="outline"
+                size="icon-lg"
+                onClick={handleOpenQuickChat}
+                className="cursor-pointer"
+                aria-label="Quick Chat"
+                data-testid="mobile-quick-chat-button"
+              >
+                <IconMessageCircle className="h-4 w-4" />
+              </Button>
+            )}
             {onSearchChange && (
               <Button
                 variant={isSearchOpen ? "secondary" : "outline"}

--- a/apps/web/components/kanban/kanban-header.tsx
+++ b/apps/web/components/kanban/kanban-header.tsx
@@ -5,7 +5,13 @@ import { useRouter } from "@/lib/routing/client-router";
 import { Button } from "@kandev/ui/button";
 import { ToggleGroup, ToggleGroupItem } from "@kandev/ui/toggle-group";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@kandev/ui/tooltip";
-import { IconList, IconLayoutKanban, IconMenu2, IconTimeline } from "@tabler/icons-react";
+import {
+  IconList,
+  IconLayoutKanban,
+  IconMenu2,
+  IconMessageCircle,
+  IconTimeline,
+} from "@tabler/icons-react";
 import { PageTopbar } from "@/components/page-topbar";
 import { KanbanDisplayDropdown } from "../kanban-display-dropdown";
 import { ReleaseNotesDialog } from "../release-notes/release-notes-dialog";
@@ -19,6 +25,7 @@ import { useAppStore } from "@/components/state-provider";
 import { useKanbanDisplaySettings } from "@/hooks/use-kanban-display-settings";
 import { useReleaseNotes } from "@/hooks/use-release-notes";
 import { useSystemHealthIndicator } from "@/hooks/use-system-health-indicator";
+import { useQuickChatLauncher } from "@/hooks/use-quick-chat-launcher";
 import { TopbarMetrics } from "@/components/system-metrics/topbar-metrics";
 import type { ComponentProps, RefObject } from "react";
 
@@ -130,6 +137,7 @@ function useIsHeaderNarrow(ref: RefObject<HTMLElement | null>): boolean {
 function TabletHeader({
   title,
   workspaceLabel,
+  workspaceId,
   searchQuery,
   onSearchChange,
   isSearchLoading,
@@ -142,6 +150,7 @@ function TabletHeader({
 }: {
   title: string;
   workspaceLabel: string;
+  workspaceId?: string;
   searchQuery: string;
   onSearchChange?: (query: string) => void;
   isSearchLoading: boolean;
@@ -153,6 +162,7 @@ function TabletHeader({
   hideTitle?: boolean;
 }) {
   const isHome = title === "Home";
+  const handleOpenQuickChat = useQuickChatLauncher(workspaceId);
 
   return (
     <PageTopbar
@@ -174,6 +184,18 @@ function TabletHeader({
             />
           )}
           <TopbarMetrics size="lg" />
+          {workspaceId && (
+            <Button
+              variant="outline"
+              size="icon-lg"
+              onClick={handleOpenQuickChat}
+              className="cursor-pointer"
+              aria-label="Quick Chat"
+              data-testid="tablet-quick-chat-button"
+            >
+              <IconMessageCircle className="h-4 w-4" />
+            </Button>
+          )}
           <TooltipProvider>
             <ViewToggleGroup toggleValue={toggleValue} onValueChange={handleViewChange} size="lg" />
           </TooltipProvider>
@@ -330,6 +352,7 @@ export function KanbanHeader({
           <TabletHeader
             title={title}
             workspaceLabel={workspaceLabel}
+            workspaceId={workspaceId}
             hideTitle={hideTitle}
             {...sharedSearch}
             toggleValue={toggleValue}

--- a/apps/web/components/quick-chat/quick-chat-modal.tsx
+++ b/apps/web/components/quick-chat/quick-chat-modal.tsx
@@ -4,7 +4,7 @@ import { memo, type CSSProperties } from "react";
 import { useShallow } from "zustand/react/shallow";
 import { Dialog, DialogContent, DialogTitle } from "@kandev/ui/dialog";
 import { Button } from "@kandev/ui/button";
-import { IconPlus } from "@tabler/icons-react";
+import { IconPlus, IconX } from "@tabler/icons-react";
 import { useAppStore } from "@/components/state-provider";
 import { PassthroughTerminal } from "@/components/task/passthrough-terminal";
 import { QuickChatContent } from "./quick-chat-content";
@@ -25,6 +25,7 @@ function QuickChatTabs({
   onTabClose,
   onNewChat,
   onRename,
+  onCloseModal,
 }: {
   sessions: Array<{ sessionId: string; workspaceId: string; name?: string }>;
   activeSessionId: string;
@@ -32,6 +33,7 @@ function QuickChatTabs({
   onTabClose: (sessionId: string) => void;
   onNewChat: () => void;
   onRename: (sessionId: string, name: string) => void;
+  onCloseModal: () => void;
 }) {
   if (sessions.length === 0) return null;
 
@@ -63,6 +65,18 @@ function QuickChatTabs({
           <IconPlus className="h-3.5 w-3.5" />
         </Button>
       </div>
+      {/* Touch devices have no Escape key or visible overlay to dismiss the
+          full-screen dialog, so give them an explicit close control. */}
+      <Button
+        size="sm"
+        variant="ghost"
+        className="h-6 w-6 p-0 cursor-pointer shrink-0 sm:hidden"
+        onClick={onCloseModal}
+        aria-label="Close quick chat"
+        data-testid="quick-chat-close"
+      >
+        <IconX className="h-3.5 w-3.5" />
+      </Button>
     </div>
   );
 }
@@ -160,6 +174,7 @@ export const QuickChatModal = memo(function QuickChatModal({ workspaceId }: Quic
             onTabClose={handleCloseTab}
             onNewChat={handleNewChat}
             onRename={handleRename}
+            onCloseModal={() => handleOpenChange(false)}
           />
           {activeSessionId && !activeSessionNeedsAgent && (
             <QuickChatSessionView sessionId={activeSessionId} />

--- a/apps/web/components/task/mobile/session-task-switcher-sheet.tsx
+++ b/apps/web/components/task/mobile/session-task-switcher-sheet.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useMemo, useState, memo } from "react";
-import { IconPlus } from "@tabler/icons-react";
+import { IconMessageCircle, IconPlus } from "@tabler/icons-react";
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@kandev/ui/sheet";
 import { Button } from "@kandev/ui/button";
 import { TaskSwitcher } from "../task-switcher";
@@ -22,6 +22,7 @@ import { SidebarLinkDialogs } from "../task-session-sidebar-dialogs";
 import { useSidebarLinkActions } from "../task-session-sidebar-link-actions";
 import { useSidebarTaskLinking } from "../task-session-sidebar-task-linking";
 import { useSheetData, useSheetActions } from "./session-task-switcher-sheet-hooks";
+import { useQuickChatLauncher } from "@/hooks/use-quick-chat-launcher";
 
 type SessionTaskSwitcherSheetProps = {
   open: boolean;
@@ -131,6 +132,58 @@ export function MobileTaskList({
   );
 }
 
+function TaskSwitcherSheetHeader({
+  workspaceId,
+  workspaces,
+  onWorkspaceChange,
+  onQuickChat,
+  onNewTask,
+}: {
+  workspaceId: string | null;
+  workspaces: Array<{ id: string; name: string }>;
+  onWorkspaceChange: (workspaceId: string) => void;
+  onQuickChat: () => void;
+  onNewTask: () => void;
+}) {
+  return (
+    <SheetHeader className="p-4 pb-2 border-b border-border">
+      <div className="flex items-center justify-between">
+        <SheetTitle className="text-base">Tasks</SheetTitle>
+        <div className="flex items-center gap-2">
+          {workspaceId && (
+            <Button
+              size="sm"
+              variant="outline"
+              className="h-7 gap-1 cursor-pointer"
+              onClick={onQuickChat}
+              data-testid="mobile-sheet-quick-chat"
+            >
+              <IconMessageCircle className="h-4 w-4" />
+              Chat
+            </Button>
+          )}
+          <Button
+            size="sm"
+            variant="outline"
+            className="h-7 gap-1 cursor-pointer"
+            onClick={onNewTask}
+          >
+            <IconPlus className="h-4 w-4" />
+            New
+          </Button>
+        </div>
+      </div>
+      <div className="pt-2">
+        <WorkspaceSwitcher
+          workspaces={workspaces}
+          activeWorkspaceId={workspaceId}
+          onSelect={onWorkspaceChange}
+        />
+      </div>
+    </SheetHeader>
+  );
+}
+
 export const SessionTaskSwitcherSheet = memo(function SessionTaskSwitcherSheet({
   open,
   onOpenChange,
@@ -141,6 +194,11 @@ export const SessionTaskSwitcherSheet = memo(function SessionTaskSwitcherSheet({
   const data = useSheetData(workspaceId);
   const actions = useSheetActions(workspaceId, onOpenChange);
   const linking = useMobileTaskLinking(workspaceId);
+  const openQuickChat = useQuickChatLauncher(workspaceId);
+  const handleQuickChat = useCallback(() => {
+    onOpenChange(false);
+    openQuickChat();
+  }, [onOpenChange, openQuickChat]);
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
@@ -149,27 +207,13 @@ export const SessionTaskSwitcherSheet = memo(function SessionTaskSwitcherSheet({
         side="left"
         className="w-[85vw] max-w-sm p-0 flex flex-col"
       >
-        <SheetHeader className="p-4 pb-2 border-b border-border">
-          <div className="flex items-center justify-between">
-            <SheetTitle className="text-base">Tasks</SheetTitle>
-            <Button
-              size="sm"
-              variant="outline"
-              className="h-7 gap-1 cursor-pointer"
-              onClick={() => setDialogOpen(true)}
-            >
-              <IconPlus className="h-4 w-4" />
-              New
-            </Button>
-          </div>
-          <div className="pt-2">
-            <WorkspaceSwitcher
-              workspaces={data.workspaces.map((w) => ({ id: w.id, name: w.name }))}
-              activeWorkspaceId={workspaceId}
-              onSelect={actions.handleWorkspaceChange}
-            />
-          </div>
-        </SheetHeader>
+        <TaskSwitcherSheetHeader
+          workspaceId={workspaceId}
+          workspaces={data.workspaces.map((w) => ({ id: w.id, name: w.name }))}
+          onWorkspaceChange={actions.handleWorkspaceChange}
+          onQuickChat={handleQuickChat}
+          onNewTask={() => setDialogOpen(true)}
+        />
 
         <SidebarFilterBar />
 

--- a/apps/web/e2e/tests/chat/mobile-quick-chat-entry.spec.ts
+++ b/apps/web/e2e/tests/chat/mobile-quick-chat-entry.spec.ts
@@ -1,0 +1,61 @@
+/**
+ * Mobile entry points for Quick Chat.
+ *
+ * Desktop opens Quick Chat via keyboard shortcut, command palette, or the app
+ * sidebar — none of which exist on a touch viewport. These tests cover the
+ * touch affordances: the kanban header button on Home, the task-switcher sheet
+ * button on a session page, and the explicit close control (touch devices have
+ * no Escape key and the full-screen dialog leaves no overlay to tap).
+ *
+ * Lives in `mobile-*.spec.ts` so the `mobile-chrome` Playwright project applies
+ * the mobile device automatically.
+ */
+import { test, expect } from "../../fixtures/test-base";
+import { SessionPage } from "../../pages/session-page";
+
+async function assertNoHorizontalOverflow(page: import("@playwright/test").Page) {
+  const dimensions = await page.evaluate(() => ({
+    scrollWidth: document.documentElement.scrollWidth,
+    clientWidth: document.documentElement.clientWidth,
+  }));
+  expect(dimensions.scrollWidth).toBeLessThanOrEqual(dimensions.clientWidth + 1);
+}
+
+test.describe("Quick Chat entry points on mobile", () => {
+  test("opens from the home header and closes with the touch control", async ({ testPage }) => {
+    await testPage.goto("/");
+    await testPage.waitForLoadState("networkidle");
+    await assertNoHorizontalOverflow(testPage);
+
+    await testPage.getByTestId("mobile-quick-chat-button").click();
+
+    const dialog = testPage.getByRole("dialog", { name: "Quick Chat" });
+    await expect(dialog.getByTestId("quick-chat-setup")).toBeVisible({ timeout: 10_000 });
+    await assertNoHorizontalOverflow(testPage);
+
+    await dialog.getByTestId("quick-chat-close").click();
+    await expect(dialog).not.toBeVisible();
+  });
+
+  test("opens from the task switcher sheet on a session page", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    const seeded = await apiClient.seedTask(seedData.workspaceId, "Mobile Quick Chat Task", {
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+    });
+
+    await testPage.goto(`/t/${seeded.task_id}`);
+    const session = new SessionPage(testPage);
+    await session.waitForLoad();
+
+    await testPage.getByTestId("mobile-session-menu").click();
+    await testPage.getByTestId("mobile-sheet-quick-chat").click();
+
+    const dialog = testPage.getByRole("dialog", { name: "Quick Chat" });
+    await expect(dialog.getByTestId("quick-chat-setup")).toBeVisible({ timeout: 10_000 });
+    await assertNoHorizontalOverflow(testPage);
+  });
+});

--- a/apps/web/e2e/tests/chat/mobile-quick-chat-entry.spec.ts
+++ b/apps/web/e2e/tests/chat/mobile-quick-chat-entry.spec.ts
@@ -12,26 +12,19 @@
  */
 import { test, expect } from "../../fixtures/test-base";
 import { SessionPage } from "../../pages/session-page";
-
-async function assertNoHorizontalOverflow(page: import("@playwright/test").Page) {
-  const dimensions = await page.evaluate(() => ({
-    scrollWidth: document.documentElement.scrollWidth,
-    clientWidth: document.documentElement.clientWidth,
-  }));
-  expect(dimensions.scrollWidth).toBeLessThanOrEqual(dimensions.clientWidth + 1);
-}
+import { assertNoDocumentHorizontalOverflow } from "../../helpers/layout-assertions";
 
 test.describe("Quick Chat entry points on mobile", () => {
   test("opens from the home header and closes with the touch control", async ({ testPage }) => {
     await testPage.goto("/");
     await testPage.waitForLoadState("networkidle");
-    await assertNoHorizontalOverflow(testPage);
+    await assertNoDocumentHorizontalOverflow(testPage);
 
     await testPage.getByTestId("mobile-quick-chat-button").click();
 
     const dialog = testPage.getByRole("dialog", { name: "Quick Chat" });
     await expect(dialog.getByTestId("quick-chat-setup")).toBeVisible({ timeout: 10_000 });
-    await assertNoHorizontalOverflow(testPage);
+    await assertNoDocumentHorizontalOverflow(testPage);
 
     await dialog.getByTestId("quick-chat-close").click();
     await expect(dialog).not.toBeVisible();
@@ -52,10 +45,14 @@ test.describe("Quick Chat entry points on mobile", () => {
     await session.waitForLoad();
 
     await testPage.getByTestId("mobile-session-menu").click();
+    const sheet = testPage.getByRole("dialog", { name: "Tasks" });
+    await expect(sheet).toBeVisible();
     await testPage.getByTestId("mobile-sheet-quick-chat").click();
 
     const dialog = testPage.getByRole("dialog", { name: "Quick Chat" });
     await expect(dialog.getByTestId("quick-chat-setup")).toBeVisible({ timeout: 10_000 });
-    await assertNoHorizontalOverflow(testPage);
+    // Opening quick chat dismisses the task switcher sheet.
+    await expect(sheet).not.toBeVisible();
+    await assertNoDocumentHorizontalOverflow(testPage);
   });
 });

--- a/apps/web/e2e/tests/chat/mobile-quick-chat-repository.spec.ts
+++ b/apps/web/e2e/tests/chat/mobile-quick-chat-repository.spec.ts
@@ -1,12 +1,5 @@
 import { test, expect } from "../../fixtures/test-base";
-
-async function assertNoHorizontalOverflow(page: import("@playwright/test").Page) {
-  const dimensions = await page.evaluate(() => ({
-    scrollWidth: document.documentElement.scrollWidth,
-    clientWidth: document.documentElement.clientWidth,
-  }));
-  expect(dimensions.scrollWidth).toBeLessThanOrEqual(dimensions.clientWidth + 1);
-}
+import { assertNoDocumentHorizontalOverflow } from "../../helpers/layout-assertions";
 
 test.describe("Quick Chat repository context on mobile", () => {
   test("selects an agent and repository branch without hidden actions", async ({ testPage }) => {
@@ -35,11 +28,11 @@ test.describe("Quick Chat repository context on mobile", () => {
     await expect(dialog.getByTestId("branch-chip-trigger")).toContainText("main", {
       timeout: 10_000,
     });
-    await assertNoHorizontalOverflow(testPage);
+    await assertNoDocumentHorizontalOverflow(testPage);
 
     await dialog.getByTestId("quick-chat-start").click();
     await expect(dialog.locator(".tiptap.ProseMirror")).toBeVisible({ timeout: 30_000 });
-    await assertNoHorizontalOverflow(testPage);
+    await assertNoDocumentHorizontalOverflow(testPage);
 
     await dialog.getByLabel("Start new chat").click();
     await expect(dialog.getByTestId("quick-chat-setup")).toBeVisible({ timeout: 5_000 });
@@ -64,6 +57,6 @@ test.describe("Quick Chat repository context on mobile", () => {
     await expect(restoredTabs).toHaveCount(2);
     await expect(restoredTabs.locator("span")).toHaveText(originalNames);
     await expect(restoredDialog.getByTestId("quick-chat-setup")).not.toBeVisible();
-    await assertNoHorizontalOverflow(testPage);
+    await assertNoDocumentHorizontalOverflow(testPage);
   });
 });


### PR DESCRIPTION
Quick chat had no touch-reachable trigger — every entry point was desktop-only (keyboard shortcut, command palette, app sidebar hidden below `md`) — and the full-screen dialog on mobile had no way to close an active chat (no Escape key, no tappable overlay). This adds touch entry points on every mobile surface plus an explicit close control, making quick chat fully usable on phones.

## Important Changes

- Quick chat icon button in the mobile kanban/tasks header and the tablet header (640–767px viewports also have no sidebar).
- Chat button in the mobile session task-switcher sheet header (closes the sheet, opens quick chat).
- Mobile-only close (X) control in the quick chat tab bar, `sm:hidden` so desktop behavior is unchanged.
- Extracted `TaskSwitcherSheetHeader` sub-component to stay under the function-length lint limit.

## Validation

- `make fmt`, `make typecheck`, `make test` (backend + web 4984 tests + CLI green; `test-scripts` fails only on a pre-existing sandbox cargo-version issue unrelated to this branch), `make lint`.
- New mobile Playwright spec `apps/web/e2e/tests/chat/mobile-quick-chat-entry.spec.ts`: opens from the home header and closes via the touch control; opens from the task-switcher sheet on a session page; both assert no horizontal overflow. Passed on `mobile-chrome` (Pixel 5) along with the existing `mobile-quick-chat-repository.spec.ts`.
- Unit tests for the header button (renders with a workspace, hidden without one, opens quick chat on tap).
- Manually verified against a live production build on a Pixel 5 viewport: opened quick chat from the header, started a mock-agent session, sent a message, closed via the X control.

## Possible Improvements

Low risk: purely additive UI affordances; the header button could crowd very narrow (<340px) viewports, though overflow assertions on Pixel 5 pass.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1751?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->