### PR TITLE
fix(lifecycle): don't split streaming messages on subagent tool calls

### DIFF
--- a/apps/backend/internal/agent/runtime/lifecycle/manager_events.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_events.go
@@ -322,14 +322,14 @@ func (m *Manager) handleCompleteEvent(execution *AgentExecution, event *agentctl
 // handleToolCallEvent processes the "tool_call" agent event: flushes the message buffer
 // and stores the tool call in session history.
 // Returns the (possibly updated) event.
+//
+// Subagent-internal tool calls (ParentToolCallID set) stream on the same session
+// concurrently with the parent agent's own text, so they must NOT flush the
+// buffer — flushing would split the parent's in-flight streaming message into
+// separate DB rows mid-sentence, breaking markdown that spans the boundary.
 func (m *Manager) handleToolCallEvent(execution *AgentExecution, event agentctl.AgentEvent) agentctl.AgentEvent {
-	if flushedText := m.flushMessageBuffer(execution); flushedText != "" {
-		event.Text = flushedText
-		if m.historyManager != nil && execution.historyEnabled && execution.SessionID != "" {
-			if err := m.historyManager.AppendAgentMessage(execution.SessionID, flushedText); err != nil {
-				m.logger.Warn("failed to store agent message to history", zap.Error(err))
-			}
-		}
+	if event.ParentToolCallID == "" {
+		event = m.flushBufferIntoEvent(execution, event)
 	}
 	if m.historyManager != nil && execution.historyEnabled && execution.SessionID != "" {
 		if err := m.historyManager.AppendToolCall(execution.SessionID, event); err != nil {
@@ -340,6 +340,22 @@ func (m *Manager) handleToolCallEvent(execution *AgentExecution, event agentctl.
 		zap.String("execution_id", execution.ID),
 		zap.String("tool_call_id", event.ToolCallID),
 		zap.String("tool_name", event.ToolName))
+	return event
+}
+
+// flushBufferIntoEvent flushes the streaming message buffer and, when it held
+// remaining text, carries that text on the event and stores it in session history.
+func (m *Manager) flushBufferIntoEvent(execution *AgentExecution, event agentctl.AgentEvent) agentctl.AgentEvent {
+	flushedText := m.flushMessageBuffer(execution)
+	if flushedText == "" {
+		return event
+	}
+	event.Text = flushedText
+	if m.historyManager != nil && execution.historyEnabled && execution.SessionID != "" {
+		if err := m.historyManager.AppendAgentMessage(execution.SessionID, flushedText); err != nil {
+			m.logger.Warn("failed to store agent message to history", zap.Error(err))
+		}
+	}
 	return event
 }
 

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_events.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_events.go
@@ -329,7 +329,9 @@ func (m *Manager) handleCompleteEvent(execution *AgentExecution, event *agentctl
 // separate DB rows mid-sentence, breaking markdown that spans the boundary.
 func (m *Manager) handleToolCallEvent(execution *AgentExecution, event agentctl.AgentEvent) agentctl.AgentEvent {
 	if event.ParentToolCallID == "" {
-		event = m.flushBufferIntoEvent(execution, event)
+		// flushMessageBuffer publishes any remaining buffered content through
+		// the streaming path itself and always returns "".
+		m.flushMessageBuffer(execution)
 	}
 	if m.historyManager != nil && execution.historyEnabled && execution.SessionID != "" {
 		if err := m.historyManager.AppendToolCall(execution.SessionID, event); err != nil {
@@ -340,22 +342,6 @@ func (m *Manager) handleToolCallEvent(execution *AgentExecution, event agentctl.
 		zap.String("execution_id", execution.ID),
 		zap.String("tool_call_id", event.ToolCallID),
 		zap.String("tool_name", event.ToolName))
-	return event
-}
-
-// flushBufferIntoEvent flushes the streaming message buffer and, when it held
-// remaining text, carries that text on the event and stores it in session history.
-func (m *Manager) flushBufferIntoEvent(execution *AgentExecution, event agentctl.AgentEvent) agentctl.AgentEvent {
-	flushedText := m.flushMessageBuffer(execution)
-	if flushedText == "" {
-		return event
-	}
-	event.Text = flushedText
-	if m.historyManager != nil && execution.historyEnabled && execution.SessionID != "" {
-		if err := m.historyManager.AppendAgentMessage(execution.SessionID, flushedText); err != nil {
-			m.logger.Warn("failed to store agent message to history", zap.Error(err))
-		}
-	}
 	return event
 }
 

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_events_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_events_test.go
@@ -208,6 +208,88 @@ func TestHandleAgentEvent_StreamingThenToolCallThenComplete(t *testing.T) {
 	}
 }
 
+// TestHandleAgentEvent_SubagentToolCallDoesNotSplitStreaming is the regression test
+// for streaming messages being shattered into multiple DB rows: a subagent (Task tool)
+// streams its internal tool calls (tagged with ParentToolCallID) on the same session
+// while the parent agent is still streaming text. Those tool calls must NOT flush the
+// message buffer — otherwise every subagent tool call starts a new message row,
+// splitting the parent's message mid-sentence and breaking markdown across rows.
+func TestHandleAgentEvent_SubagentToolCallDoesNotSplitStreaming(t *testing.T) {
+	mgr, eventBus := createTestManagerWithTracking()
+	execution := createTestExecution("exec-1", "task-1", "session-1")
+	if err := mgr.executionStore.Add(execution); err != nil {
+		t.Fatalf("add execution: %v", err)
+	}
+
+	// Parent agent starts streaming its message
+	mgr.handleAgentEvent(execution, agentctl.AgentEvent{
+		Type: "message_chunk",
+		Text: "Here's the CI picture\n",
+	})
+
+	execution.messageMu.Lock()
+	msgIDBefore := execution.currentMessageID
+	execution.messageMu.Unlock()
+	if msgIDBefore == "" {
+		t.Fatal("currentMessageID should be set after message_chunk")
+	}
+
+	// A subagent's internal tool call arrives mid-stream (ParentToolCallID set)
+	mgr.handleAgentEvent(execution, agentctl.AgentEvent{
+		Type:             "tool_call",
+		ToolCallID:       "subagent-tool-1",
+		ParentToolCallID: "parent-task-tool",
+		ToolName:         "execute",
+	})
+
+	// The parent's streaming message must survive the subagent tool call
+	execution.messageMu.Lock()
+	msgIDAfter := execution.currentMessageID
+	execution.messageMu.Unlock()
+	if msgIDAfter != msgIDBefore {
+		t.Errorf("subagent tool_call must not close the streaming message: message ID changed from %q to %q",
+			msgIDBefore, msgIDAfter)
+	}
+
+	// More parent text — must APPEND to the same message, not create a new one
+	mgr.handleAgentEvent(execution, agentctl.AgentEvent{
+		Type: "message_chunk",
+		Text: "on the new PR.\n",
+	})
+
+	var streamingEvents []AgentStreamEventPayload
+	for _, e := range eventBus.getStreamEvents() {
+		if e.Data != nil && e.Data.Type == "message_streaming" {
+			streamingEvents = append(streamingEvents, e)
+		}
+	}
+	if len(streamingEvents) < 2 {
+		t.Fatalf("expected at least 2 message_streaming events, got %d", len(streamingEvents))
+	}
+	last := streamingEvents[len(streamingEvents)-1]
+	if !last.Data.IsAppend {
+		t.Error("text after a subagent tool_call should append to the existing message, got IsAppend=false")
+	}
+	if last.Data.MessageID != msgIDBefore {
+		t.Errorf("text after a subagent tool_call should keep message ID %q, got %q",
+			msgIDBefore, last.Data.MessageID)
+	}
+
+	// A top-level tool call (no ParentToolCallID) must still flush as before
+	mgr.handleAgentEvent(execution, agentctl.AgentEvent{
+		Type:       "tool_call",
+		ToolCallID: "tool-1",
+		ToolName:   "read_file",
+	})
+
+	execution.messageMu.Lock()
+	msgIDAfterTopLevel := execution.currentMessageID
+	execution.messageMu.Unlock()
+	if msgIDAfterTopLevel != "" {
+		t.Errorf("currentMessageID should be cleared after a top-level tool_call, got %q", msgIDAfterTopLevel)
+	}
+}
+
 // TestHandleAgentEvent_CompleteWithoutStreaming verifies that complete events are
 // properly handled when no streaming was used (buffer is empty).
 // All adapters now send text via message_chunk events, so this tests the empty buffer case.


### PR DESCRIPTION
Streamed agent messages were shattered into multiple `task_session_messages` rows whenever a delegated subagent ran concurrently: the subagent's internal tool calls (tagged with `ParentToolCallID`) flushed the parent's message buffer, so each one closed the in-flight streaming message and the next text delta started a new row — splitting one logical message mid-sentence and rendering markdown spans as literal `**` across fragments. `handleToolCallEvent` now flushes only for top-level tool calls, keeping the parent's streaming segment open across subagent activity.

## Validation

- Root cause confirmed against a live DB: a single assistant message stored as 7 rows, each fragment boundary sub-millisecond after a subagent tool event carrying `parent_tool_call_id`.
- New regression test `TestHandleAgentEvent_SubagentToolCallDoesNotSplitStreaming` reproduces the sequence (stream → subagent tool_call → stream) and asserts the message ID survives and subsequent text appends; also asserts top-level tool calls still flush.
- `make -C apps/backend fmt` — clean
- `cd apps/backend && go build ./...` — pass
- `cd apps/backend && go test ./...` — full suite pass
- `cd apps/backend && golangci-lint run ./... --timeout=10m` — 0 issues

## Possible Improvements

Low risk (Claude-only path today — Cursor doesn't emit subagent tool calls over ACP, OpenCode uses a child session); already-persisted fragmented messages are not repaired by this change.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1756?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->