### PR TITLE
feat(plugins): richer frontend SDK — page chrome, nav icons, more host UI

### DIFF
--- a/apps/web/components/plugins/plugin-nav-items.test.tsx
+++ b/apps/web/components/plugins/plugin-nav-items.test.tsx
@@ -77,6 +77,24 @@ describe("PluginNavItems", () => {
     expect(container.innerHTML).toBe("");
   });
 
+  it("renders the named curated icon, falling back to the puzzle glyph", () => {
+    pluginRegistry
+      .forPlugin("plugin-a")
+      .registerNavItem({ id: "hello", label: "Hello", path: HELLO_PATH, icon: "ticket" });
+    pluginRegistry
+      .forPlugin("plugin-b")
+      .registerNavItem({ id: "other", label: "Other", path: "/plugins/other", icon: "nope" });
+
+    renderNavItems();
+
+    expect(
+      screen.getByTestId("plugin-nav-item-hello").querySelector("svg.tabler-icon-ticket"),
+    ).not.toBeNull();
+    expect(
+      screen.getByTestId("plugin-nav-item-other").querySelector("svg.tabler-icon-puzzle"),
+    ).not.toBeNull();
+  });
+
   it("navigates to item.path when clicked", () => {
     pluginRegistry
       .forPlugin("plugin-a")

--- a/apps/web/components/plugins/plugin-nav-items.tsx
+++ b/apps/web/components/plugins/plugin-nav-items.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { IconPuzzle } from "@tabler/icons-react";
 import { AppSidebarNavItem } from "@/components/app-sidebar/app-sidebar-nav-item";
 import { useFeature } from "@/hooks/domains/features/use-feature";
+import { resolvePluginIcon } from "@/lib/plugins/icons";
 import { usePluginRegistry } from "@/lib/plugins/registry";
 
 type PluginNavItemsProps = {
@@ -12,10 +12,10 @@ type PluginNavItemsProps = {
 /**
  * Renders every plugin-registered "main" section nav item
  * (`registry.registerNavItem(item)`) in the app sidebar, styled and behaving
- * like a first-party `AppSidebarNavItem`. Plugin nav items don't carry a
- * host icon component (only an opaque `icon` name string in the frozen
- * contract), so every entry uses a generic puzzle-piece glyph. Gated on the
- * "plugins" feature flag for consistency with the other plugin surfaces
+ * like a first-party `AppSidebarNavItem`. The contract's opaque `icon` name
+ * string resolves against the curated map in `lib/plugins/icons.ts`;
+ * unknown/missing names fall back to a generic puzzle-piece glyph. Gated on
+ * the "plugins" feature flag for consistency with the other plugin surfaces
  * (settings nav entry, /settings/plugins page) even though the registry is
  * empty and this already renders nothing when the flag is off.
  */
@@ -31,7 +31,7 @@ export function PluginNavItems({ collapsed }: PluginNavItemsProps) {
       {items.map((item) => (
         <AppSidebarNavItem
           key={item.id}
-          icon={IconPuzzle}
+          icon={resolvePluginIcon(item.icon)}
           label={item.label}
           href={item.path}
           collapsed={collapsed}

--- a/apps/web/components/plugins/plugin-page.test.tsx
+++ b/apps/web/components/plugins/plugin-page.test.tsx
@@ -1,0 +1,107 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { pluginRegistry } from "@/lib/plugins/registry";
+import type { PluginRouteRegistration } from "@/lib/plugins/registry";
+import { PluginPageFrame, resolvePluginPageChrome } from "./plugin-page";
+
+const PLUGIN_ID = "plugin-a";
+const PLUGIN_PATH = "/plugins/hello";
+const PLUGIN_NAME = "Hello Plugin";
+
+function Page() {
+  return null;
+}
+
+function registration(options?: PluginRouteRegistration["options"]): PluginRouteRegistration {
+  return { pluginId: PLUGIN_ID, path: PLUGIN_PATH, Component: Page, options };
+}
+
+describe("resolvePluginPageChrome", () => {
+  it("returns null when the registration opted out via topbar: false", () => {
+    expect(resolvePluginPageChrome(registration({ topbar: false }), [], "Hello")).toBeNull();
+  });
+
+  it("derives the title from the nav item registered for the same path", () => {
+    const chrome = resolvePluginPageChrome(
+      registration(),
+      [{ id: "nav", label: "Hello Nav", path: PLUGIN_PATH, icon: "ticket" }],
+      PLUGIN_NAME,
+    );
+    expect(chrome).toMatchObject({ title: "Hello Nav", icon: "ticket" });
+  });
+
+  it("falls back to the plugin display name, then the route path", () => {
+    expect(resolvePluginPageChrome(registration(), [], PLUGIN_NAME)?.title).toBe(PLUGIN_NAME);
+    expect(resolvePluginPageChrome(registration(), [], undefined)?.title).toBe(PLUGIN_PATH);
+  });
+
+  it("prefers explicit chrome config over every derived default", () => {
+    const chrome = resolvePluginPageChrome(
+      registration({
+        topbar: { title: "Custom", subtitle: "Sub", icon: "chart", backHref: "/x", backLabel: "X" },
+      }),
+      [{ id: "nav", label: "Nav Label", path: PLUGIN_PATH, icon: "ticket" }],
+      PLUGIN_NAME,
+    );
+    expect(chrome).toEqual({
+      title: "Custom",
+      subtitle: "Sub",
+      icon: "chart",
+      backHref: "/x",
+      backLabel: "X",
+      Actions: undefined,
+    });
+  });
+});
+
+describe("PluginPageFrame", () => {
+  afterEach(() => {
+    cleanup();
+    pluginRegistry.unregisterPlugin(PLUGIN_ID);
+  });
+
+  it("renders a kandev topbar with the derived title by default", () => {
+    pluginRegistry.forPlugin(PLUGIN_ID, PLUGIN_NAME);
+
+    render(
+      <PluginPageFrame registration={registration()}>
+        <div data-testid="plugin-content" />
+      </PluginPageFrame>,
+    );
+
+    expect(screen.getByRole("banner")).not.toBeNull();
+    expect(screen.getByText(PLUGIN_NAME)).not.toBeNull();
+    expect(screen.getByTestId("plugin-content")).not.toBeNull();
+  });
+
+  it("renders the children bare when the route opted out of the topbar", () => {
+    render(
+      <PluginPageFrame registration={registration({ topbar: false })}>
+        <div data-testid="plugin-content" />
+      </PluginPageFrame>,
+    );
+
+    expect(screen.queryByRole("banner")).toBeNull();
+    expect(screen.getByTestId("plugin-content")).not.toBeNull();
+  });
+
+  it("renders configured subtitle and a plugin-provided actions component", () => {
+    function Actions() {
+      return <button data-testid="plugin-topbar-action">Sync</button>;
+    }
+
+    render(
+      <PluginPageFrame
+        registration={registration({
+          topbar: { title: "Custom", subtitle: "Tickets", actions: Actions },
+        })}
+      >
+        <div />
+      </PluginPageFrame>,
+    );
+
+    expect(screen.getByText("Custom")).not.toBeNull();
+    expect(screen.getByText("Tickets")).not.toBeNull();
+    expect(screen.getByTestId("plugin-topbar-action")).not.toBeNull();
+  });
+});

--- a/apps/web/components/plugins/plugin-page.tsx
+++ b/apps/web/components/plugins/plugin-page.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import type { ComponentType, ReactNode } from "react";
+import { PageTopbar } from "@/components/page-topbar";
+import { lookupPluginIcon } from "@/lib/plugins/icons";
+import { pluginRegistry } from "@/lib/plugins/registry";
+import type { PluginRouteRegistration } from "@/lib/plugins/registry";
+import type { NavItem, PluginPageChrome } from "@/lib/plugins/types";
+
+export interface ResolvedPageChrome {
+  title: string;
+  subtitle?: string;
+  icon?: string;
+  backHref?: string;
+  backLabel?: string;
+  Actions?: ComponentType;
+}
+
+/**
+ * Resolves the topbar chrome for a plugin route registration
+ * (`registerRoute(path, Component, { topbar })`). Returns null when the
+ * plugin opted out (`topbar: false`). Title fallback order: explicit chrome
+ * title → the plugin's nav-item label registered for this path → the
+ * plugin's display name → the route path. The icon similarly falls back to
+ * the matching nav item's icon.
+ */
+export function resolvePluginPageChrome(
+  registration: PluginRouteRegistration,
+  navItems: NavItem[],
+  pluginName: string | undefined,
+): ResolvedPageChrome | null {
+  const topbar = registration.options?.topbar ?? true;
+  if (topbar === false) return null;
+  const chrome: PluginPageChrome = topbar === true ? {} : topbar;
+  const navItem = navItems.find((item) => item.path === registration.path);
+  return {
+    title: chrome.title ?? navItem?.label ?? pluginName ?? registration.path,
+    subtitle: chrome.subtitle,
+    icon: chrome.icon ?? navItem?.icon,
+    backHref: chrome.backHref,
+    backLabel: chrome.backLabel,
+    Actions: chrome.actions,
+  };
+}
+
+type PluginPageFrameProps = {
+  registration: PluginRouteRegistration;
+  children: ReactNode;
+};
+
+/**
+ * Wraps a plugin-registered route in the same page shell first-party pages
+ * use: a `PageTopbar` title bar above a scrollable content area. Renders the
+ * children bare (full-bleed) when the registration opted out via
+ * `topbar: false`.
+ */
+export function PluginPageFrame({ registration, children }: PluginPageFrameProps) {
+  const chrome = resolvePluginPageChrome(
+    registration,
+    pluginRegistry.getNavItems(),
+    pluginRegistry.getPluginName(registration.pluginId),
+  );
+  if (!chrome) return <>{children}</>;
+
+  const Icon = lookupPluginIcon(chrome.icon);
+  const Actions = chrome.Actions;
+  return (
+    <div className="flex h-screen w-full flex-col bg-background">
+      <PageTopbar
+        title={chrome.title}
+        subtitle={chrome.subtitle}
+        icon={Icon ? <Icon className="h-4 w-4" /> : undefined}
+        backHref={chrome.backHref}
+        backLabel={chrome.backLabel}
+        actions={Actions ? <Actions /> : undefined}
+      />
+      <div className="min-h-0 flex-1 overflow-auto">{children}</div>
+    </div>
+  );
+}

--- a/apps/web/lib/plugins/host-api.test.ts
+++ b/apps/web/lib/plugins/host-api.test.ts
@@ -3,6 +3,36 @@ import * as React from "react";
 import { createAppStore } from "@/lib/state/store";
 import { buildHostApi } from "./host-api";
 
+/** Curated primitives a plugin needs to build a full native-feeling page. */
+const EXPECTED_UI_PRIMITIVES = [
+  "Alert",
+  "Badge",
+  "Button",
+  "Card",
+  "Checkbox",
+  "Dialog",
+  "DropdownMenu",
+  "Input",
+  "Label",
+  "Pagination",
+  "ScrollArea",
+  "Select",
+  "Sheet",
+  "SheetClose",
+  "SheetContent",
+  "SheetDescription",
+  "SheetFooter",
+  "SheetHeader",
+  "SheetTitle",
+  "SheetTrigger",
+  "Spinner",
+  "Switch",
+  "Table",
+  "Tabs",
+  "Textarea",
+  "Tooltip",
+];
+
 describe("buildHostApi", () => {
   const originalFetch = global.fetch;
 
@@ -66,27 +96,7 @@ describe("buildHostApi", () => {
 
     expect(host.theme).toBe("dark");
     // Expanded primitive set for full native-feeling plugin pages.
-    for (const name of [
-      "Alert",
-      "Badge",
-      "Button",
-      "Card",
-      "Checkbox",
-      "Dialog",
-      "DropdownMenu",
-      "Input",
-      "Label",
-      "Pagination",
-      "ScrollArea",
-      "Select",
-      "Sheet",
-      "Spinner",
-      "Switch",
-      "Table",
-      "Tabs",
-      "Textarea",
-      "Tooltip",
-    ]) {
+    for (const name of EXPECTED_UI_PRIMITIVES) {
       expect(host.ui[name], `host.ui.${name}`).toBeDefined();
     }
   });

--- a/apps/web/lib/plugins/host-api.test.ts
+++ b/apps/web/lib/plugins/host-api.test.ts
@@ -65,9 +65,57 @@ describe("buildHostApi", () => {
     const host = buildHostApi("jira", createAppStore(), "dark");
 
     expect(host.theme).toBe("dark");
-    expect(host.ui.Button).toBeDefined();
-    expect(host.ui.Card).toBeDefined();
-    expect(host.ui.Badge).toBeDefined();
+    // Expanded primitive set for full native-feeling plugin pages.
+    for (const name of [
+      "Alert",
+      "Badge",
+      "Button",
+      "Card",
+      "Checkbox",
+      "Dialog",
+      "DropdownMenu",
+      "Input",
+      "Label",
+      "Pagination",
+      "ScrollArea",
+      "Select",
+      "Sheet",
+      "Spinner",
+      "Switch",
+      "Table",
+      "Tabs",
+      "Textarea",
+      "Tooltip",
+    ]) {
+      expect(host.ui[name], `host.ui.${name}`).toBeDefined();
+    }
+  });
+
+  it("exposes first-party app components for native flows and page chrome", () => {
+    const host = buildHostApi("jira", createAppStore(), "light");
+    expect(host.ui.PageTopbar).toBeDefined();
+    expect(host.ui.TaskCreateDialog).toBeDefined();
+    expect(host.ui.Combobox).toBeDefined();
+  });
+
+  it("exposes navigate() that soft-navigates via history push/replace", () => {
+    const host = buildHostApi("jira", createAppStore(), "light");
+    const pushSpy = vi.spyOn(window.history, "pushState");
+    const replaceSpy = vi.spyOn(window.history, "replaceState");
+
+    host.navigate("/somewhere");
+    expect(pushSpy).toHaveBeenCalledWith({}, "", "/somewhere");
+
+    host.navigate("/elsewhere", { replace: true });
+    expect(replaceSpy).toHaveBeenCalledWith({}, "", "/elsewhere");
+
+    pushSpy.mockRestore();
+    replaceSpy.mockRestore();
+  });
+
+  it("exposes the backend API origin on api.baseUrl", () => {
+    const host = buildHostApi("jira", createAppStore(), "light");
+    expect(typeof host.api.baseUrl).toBe("string");
   });
 
   it("sets pluginId on the returned host api", () => {

--- a/apps/web/lib/plugins/host-api.ts
+++ b/apps/web/lib/plugins/host-api.ts
@@ -48,7 +48,16 @@ import {
 import { ScrollArea } from "@kandev/ui/scroll-area";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@kandev/ui/select";
 import { Separator } from "@kandev/ui/separator";
-import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@kandev/ui/sheet";
+import {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@kandev/ui/sheet";
 import { Skeleton } from "@kandev/ui/skeleton";
 import { Spinner } from "@kandev/ui/spinner";
 import { Switch } from "@kandev/ui/switch";
@@ -117,9 +126,13 @@ const PLUGIN_UI: Record<string, unknown> = {
   SelectValue,
   Separator,
   Sheet,
+  SheetClose,
   SheetContent,
+  SheetDescription,
+  SheetFooter,
   SheetHeader,
   SheetTitle,
+  SheetTrigger,
   Skeleton,
   Spinner,
   Switch,

--- a/apps/web/lib/plugins/host-api.ts
+++ b/apps/web/lib/plugins/host-api.ts
@@ -4,6 +4,7 @@
  */
 import * as React from "react";
 import type { StoreApi } from "zustand";
+import { Alert, AlertDescription, AlertTitle } from "@kandev/ui/alert";
 import { Badge } from "@kandev/ui/badge";
 import { Button } from "@kandev/ui/button";
 import {
@@ -15,17 +16,69 @@ import {
   CardHeader,
   CardTitle,
 } from "@kandev/ui/card";
+import { Checkbox } from "@kandev/ui/checkbox";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@kandev/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@kandev/ui/dropdown-menu";
+import { Input } from "@kandev/ui/input";
+import { Label } from "@kandev/ui/label";
+import {
+  Pagination,
+  PaginationContent,
+  PaginationEllipsis,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from "@kandev/ui/pagination";
+import { ScrollArea } from "@kandev/ui/scroll-area";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@kandev/ui/select";
 import { Separator } from "@kandev/ui/separator";
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@kandev/ui/sheet";
 import { Skeleton } from "@kandev/ui/skeleton";
+import { Spinner } from "@kandev/ui/spinner";
+import { Switch } from "@kandev/ui/switch";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@kandev/ui/table";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@kandev/ui/tabs";
+import { Textarea } from "@kandev/ui/textarea";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
+import { Combobox } from "@/components/combobox";
+import { PageTopbar } from "@/components/page-topbar";
 import { TaskCreateDialog } from "@/components/task-create-dialog";
 import { getBackendConfig } from "@/lib/config";
+import { softNavigate } from "@/lib/routing/client-router";
 import type { AppState } from "@/lib/state/store";
 import type { PluginHostApi } from "./types";
 
-/** Curated `@kandev/ui` subset exposed on `host.ui`. */
+/**
+ * Curated `@kandev/ui` subset exposed on `host.ui`, plus a handful of
+ * first-party app components (bottom of the map). Plugins must use these
+ * host instances rather than bundling their own copies — bundling is not an
+ * option for anything that touches React context or portals (Radix), since
+ * the plugin shares the host React instance and a second copy would split
+ * context and break refs/asChild. Pure-React libs (e.g. icon sets) bundle
+ * fine.
+ */
 const PLUGIN_UI: Record<string, unknown> = {
-  Button,
+  Alert,
+  AlertDescription,
+  AlertTitle,
   Badge,
+  Button,
   Card,
   CardAction,
   CardContent,
@@ -33,12 +86,68 @@ const PLUGIN_UI: Record<string, unknown> = {
   CardFooter,
   CardHeader,
   CardTitle,
+  Checkbox,
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+  Input,
+  Label,
+  Pagination,
+  PaginationContent,
+  PaginationEllipsis,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+  ScrollArea,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
   Separator,
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
   Skeleton,
-  // First-party dialog: lets a plugin open kandev's real create-task modal,
-  // prefilled via initialValues. Unlike the primitives above this is app UI,
-  // not a shadcn primitive — exposed so plugins hand off task creation to the
-  // native flow instead of POSTing directly.
+  Spinner,
+  Switch,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+  Textarea,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+  // App UI (not shadcn primitives), exposed so plugins compose kandev-native
+  // surfaces instead of re-implementing them:
+  // - Combobox: the app's Command+Popover picker (used by native toolbars).
+  Combobox,
+  // - PageTopbar: the first-party title bar. Plugin routes get one by default
+  //   (registerRoute options.topbar); this export is for routes that opt out
+  //   (`topbar: false`) and render their own chrome.
+  PageTopbar,
+  // - TaskCreateDialog: kandev's real create-task modal, prefilled via
+  //   initialValues, so plugins hand off task creation to the native flow
+  //   instead of POSTing directly.
   TaskCreateDialog,
 };
 
@@ -58,9 +167,15 @@ export function buildHostApi(
     },
     api: {
       fetch: (path, init) => fetchPluginApi(pluginId, path, init),
+      // Getter so split-origin dev/desktop always sees the current backend
+      // origin, matching what fetchPluginApi resolves per call.
+      get baseUrl() {
+        return getBackendConfig().apiBaseUrl;
+      },
     },
     ui: PLUGIN_UI,
     theme,
+    navigate: (href, options) => softNavigate(href, options?.replace ? "replace" : "push"),
   };
 }
 

--- a/apps/web/lib/plugins/host.test.ts
+++ b/apps/web/lib/plugins/host.test.ts
@@ -30,9 +30,10 @@ function makeHostFactory(pluginId: string): PluginHostApi {
       setState: () => {},
       subscribe: () => () => {},
     },
-    api: { fetch: async () => new Response() },
+    api: { fetch: async () => new Response(), baseUrl: "" },
     ui: {},
     theme: "light",
+    navigate: () => {},
   };
 }
 

--- a/apps/web/lib/plugins/host.ts
+++ b/apps/web/lib/plugins/host.ts
@@ -119,7 +119,7 @@ async function loadPlugin(
       return;
     }
     const host = hostFactory(plugin.id);
-    const registry = pluginRegistry.forPlugin(plugin.id);
+    const registry = pluginRegistry.forPlugin(plugin.id, plugin.name);
     await raceTimeout(Promise.resolve(registered.initialize(registry, host)), initTimeoutMs, () => {
       console.warn(
         `[plugins] "${plugin.id}" initialize() timed out after ${initTimeoutMs}ms; continuing without it`,

--- a/apps/web/lib/plugins/icons.test.ts
+++ b/apps/web/lib/plugins/icons.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { IconPuzzle, IconTicket } from "@tabler/icons-react";
+import { lookupPluginIcon, resolvePluginIcon } from "./icons";
+
+describe("plugin icons", () => {
+  it("looks up a known icon name", () => {
+    expect(lookupPluginIcon("ticket")).toBe(IconTicket);
+    expect(resolvePluginIcon("ticket")).toBe(IconTicket);
+  });
+
+  it("returns undefined from lookupPluginIcon for unknown or missing names", () => {
+    expect(lookupPluginIcon("not-an-icon")).toBeUndefined();
+    expect(lookupPluginIcon(undefined)).toBeUndefined();
+  });
+
+  it("falls back to the puzzle glyph from resolvePluginIcon", () => {
+    expect(resolvePluginIcon("not-an-icon")).toBe(IconPuzzle);
+    expect(resolvePluginIcon(undefined)).toBe(IconPuzzle);
+  });
+});

--- a/apps/web/lib/plugins/icons.ts
+++ b/apps/web/lib/plugins/icons.ts
@@ -1,0 +1,62 @@
+/**
+ * Curated icon-name → Tabler icon map for plugin registrations.
+ *
+ * The frozen plugin contract (docs/plans/plugins/PLUGIN-API.md) only carries
+ * opaque string icon names (`NavItem.icon`, `PluginPageChrome.icon`) — plugins
+ * never hold host component values. The host maps known names onto first-party
+ * glyphs here; unknown or missing names fall back per surface (puzzle piece in
+ * the sidebar, no icon in the page topbar).
+ */
+import {
+  IconBell,
+  IconBolt,
+  IconBook,
+  IconBug,
+  IconCalendar,
+  IconChartBar,
+  IconChecklist,
+  IconCloud,
+  IconDatabase,
+  IconFlask,
+  IconGlobe,
+  IconMessage,
+  IconPuzzle,
+  IconRobot,
+  IconRocket,
+  IconSettings,
+  IconTicket,
+  IconUsers,
+} from "@tabler/icons-react";
+import type { Icon as TablerIcon } from "@tabler/icons-react";
+
+/** Icon names a plugin may reference from `NavItem.icon` / `PluginPageChrome.icon`. */
+export const PLUGIN_ICONS: Record<string, TablerIcon> = {
+  bell: IconBell,
+  bolt: IconBolt,
+  book: IconBook,
+  bug: IconBug,
+  calendar: IconCalendar,
+  chart: IconChartBar,
+  checklist: IconChecklist,
+  cloud: IconCloud,
+  database: IconDatabase,
+  flask: IconFlask,
+  globe: IconGlobe,
+  message: IconMessage,
+  puzzle: IconPuzzle,
+  robot: IconRobot,
+  rocket: IconRocket,
+  settings: IconSettings,
+  ticket: IconTicket,
+  users: IconUsers,
+};
+
+/** Strict lookup: the named icon, or undefined when the name is unknown/missing. */
+export function lookupPluginIcon(name?: string): TablerIcon | undefined {
+  return name ? PLUGIN_ICONS[name] : undefined;
+}
+
+/** Sidebar lookup: always renders something — unknown/missing names get the puzzle glyph. */
+export function resolvePluginIcon(name?: string): TablerIcon {
+  return lookupPluginIcon(name) ?? IconPuzzle;
+}

--- a/apps/web/lib/plugins/registry.test.ts
+++ b/apps/web/lib/plugins/registry.test.ts
@@ -22,7 +22,12 @@ describe("pluginRegistry", () => {
     scoped.registerRoute("/plugin-a", Page);
 
     const routes = pluginRegistry.getRoutes();
-    expect(routes).toContainEqual({ path: "/plugin-a", Component: Page });
+    expect(routes).toContainEqual({
+      pluginId: "plugin-a",
+      path: "/plugin-a",
+      Component: Page,
+      options: undefined,
+    });
   });
 
   it("registers and returns a nav item", () => {
@@ -91,7 +96,9 @@ describe("pluginRegistry", () => {
 
     pluginRegistry.unregisterPlugin("plugin-a");
 
-    expect(pluginRegistry.getRoutes()).toEqual([{ path: "/plugin-b", Component: PageB }]);
+    expect(pluginRegistry.getRoutes()).toEqual([
+      { pluginId: "plugin-b", path: "/plugin-b", Component: PageB, options: undefined },
+    ]);
     expect(pluginRegistry.getNavItems().find((item) => item.id === "nav-a")).toBeUndefined();
     expect(pluginRegistry.getSlotComponents(TASK_SIDEBAR_SLOT)).toEqual([]);
     expect(pluginRegistry.getWsHandlers(TASK_CREATED_ACTION)).toEqual([]);
@@ -120,5 +127,24 @@ describe("pluginRegistry", () => {
 
     unsubscribe();
     expect(notified).toBe(0);
+  });
+});
+
+describe("pluginRegistry — route options and plugin names", () => {
+  afterEach(() => {
+    cleanup("plugin-a");
+  });
+
+  it("stores route options and the plugin display name for page chrome", () => {
+    const scoped = pluginRegistry.forPlugin("plugin-a", "Plugin A");
+    function Page() {
+      return null;
+    }
+
+    scoped.registerRoute("/plugin-a", Page, { topbar: { title: "Custom", icon: "ticket" } });
+
+    const route = pluginRegistry.getRoutes().find((entry) => entry.path === "/plugin-a");
+    expect(route?.options).toEqual({ topbar: { title: "Custom", icon: "ticket" } });
+    expect(pluginRegistry.getPluginName("plugin-a")).toBe("Plugin A");
   });
 });

--- a/apps/web/lib/plugins/registry.test.ts
+++ b/apps/web/lib/plugins/registry.test.ts
@@ -147,4 +147,13 @@ describe("pluginRegistry — route options and plugin names", () => {
     expect(route?.options).toEqual({ topbar: { title: "Custom", icon: "ticket" } });
     expect(pluginRegistry.getPluginName("plugin-a")).toBe("Plugin A");
   });
+
+  it("clears the plugin display name on unregisterPlugin", () => {
+    pluginRegistry.forPlugin("plugin-a", "Plugin A");
+    expect(pluginRegistry.getPluginName("plugin-a")).toBe("Plugin A");
+
+    pluginRegistry.unregisterPlugin("plugin-a");
+
+    expect(pluginRegistry.getPluginName("plugin-a")).toBeUndefined();
+  });
 });

--- a/apps/web/lib/plugins/registry.ts
+++ b/apps/web/lib/plugins/registry.ts
@@ -11,7 +11,13 @@
  * methods) — this is what `host.ts` passes into a plugin's `initialize()`.
  */
 import { useSyncExternalStore } from "react";
-import type { NavItem, PluginRegistry, SlotComponent, WsHandler } from "./types";
+import type {
+  NavItem,
+  PluginRegistry,
+  PluginRouteOptions,
+  SlotComponent,
+  WsHandler,
+} from "./types";
 import type { ComponentType } from "react";
 
 interface Owned<T> {
@@ -19,9 +25,15 @@ interface Owned<T> {
   value: T;
 }
 
-interface RouteRegistration {
+export interface RouteRegistration {
   path: string;
   Component: ComponentType;
+  options?: PluginRouteOptions;
+}
+
+/** Route registration plus the owning pluginId — what `getRoutes()` returns. */
+export interface PluginRouteRegistration extends RouteRegistration {
+  pluginId: string;
 }
 
 interface SlotRegistration {
@@ -44,6 +56,8 @@ class PluginRegistryStore {
   private navItems: Owned<NavItem>[] = [];
   private slotComponents: Owned<SlotRegistration>[] = [];
   private wsHandlers: Owned<WsHandlerRegistration>[] = [];
+  /** Display names from the boot payload, used for derived page-chrome titles. */
+  private pluginNames = new Map<string, string>();
   private listeners = new Set<() => void>();
   private version = 0;
 
@@ -56,8 +70,13 @@ class PluginRegistryStore {
 
   getVersion = (): number => this.version;
 
-  registerRoute(pluginId: string, path: string, Component: ComponentType): void {
-    this.routes.push({ pluginId, value: { path, Component } });
+  registerRoute(
+    pluginId: string,
+    path: string,
+    Component: ComponentType,
+    options?: PluginRouteOptions,
+  ): void {
+    this.routes.push({ pluginId, value: { path, Component, options } });
     this.notify();
   }
 
@@ -92,8 +111,13 @@ class PluginRegistryStore {
     if (this.totalCount() !== before) this.notify();
   }
 
-  getRoutes(): RouteRegistration[] {
-    return this.routes.map((entry) => entry.value);
+  getRoutes(): PluginRouteRegistration[] {
+    return this.routes.map((entry) => ({ ...entry.value, pluginId: entry.pluginId }));
+  }
+
+  /** Display name recorded by `forPlugin` (boot payload `ActivePlugin.name`). */
+  getPluginName(pluginId: string): string | undefined {
+    return this.pluginNames.get(pluginId);
   }
 
   getSettingsRoutes(): RouteRegistration[] {
@@ -117,9 +141,11 @@ class PluginRegistryStore {
   }
 
   /** Registry view scoped to one plugin — matches the frozen `PluginRegistry` contract. */
-  forPlugin(pluginId: string): PluginRegistry {
+  forPlugin(pluginId: string, pluginName?: string): PluginRegistry {
+    if (pluginName) this.pluginNames.set(pluginId, pluginName);
     return {
-      registerRoute: (path, Component) => this.registerRoute(pluginId, path, Component),
+      registerRoute: (path, Component, options) =>
+        this.registerRoute(pluginId, path, Component, options),
       registerNavItem: (item) => this.registerNavItem(pluginId, item),
       registerSettingsRoute: (path, Component) =>
         this.registerSettingsRoute(pluginId, path, Component),

--- a/apps/web/lib/plugins/registry.ts
+++ b/apps/web/lib/plugins/registry.ts
@@ -108,6 +108,7 @@ class PluginRegistryStore {
     this.navItems = removeByPlugin(this.navItems, pluginId);
     this.slotComponents = removeByPlugin(this.slotComponents, pluginId);
     this.wsHandlers = removeByPlugin(this.wsHandlers, pluginId);
+    this.pluginNames.delete(pluginId);
     if (this.totalCount() !== before) this.notify();
   }
 

--- a/apps/web/lib/plugins/types.ts
+++ b/apps/web/lib/plugins/types.ts
@@ -19,8 +19,49 @@ export interface NavItem {
   id: string;
   label: string;
   path: string;
+  /** Curated icon name (see `lib/plugins/icons.ts`); unknown names render the puzzle glyph. */
   icon?: string;
   section?: "main" | "settings";
+}
+
+/**
+ * Configuration for the kandev-style title bar the host renders above a
+ * plugin route. Every field is optional — an empty object gets the same
+ * derived defaults as omitting options entirely.
+ */
+export interface PluginPageChrome {
+  /**
+   * Topbar title. Defaults to the plugin's nav-item label registered for the
+   * same path, else the plugin's display name.
+   */
+  title?: string;
+  /** Muted subtitle rendered next to the title. */
+  subtitle?: string;
+  /**
+   * Curated icon name (same set as `NavItem.icon`). Defaults to the matching
+   * nav item's icon; unknown/missing names render no icon.
+   */
+  icon?: string;
+  /** Where the topbar back link navigates (host default: "/"). */
+  backHref?: string;
+  /** Label for the back link (host default: "Kandev"). */
+  backLabel?: string;
+  /**
+   * Component rendered on the right side of the topbar — use for dynamic
+   * page actions (buttons, filters). Rendered with the host React instance.
+   */
+  actions?: ReactType.ComponentType;
+}
+
+/** Options accepted by `PluginRegistry.registerRoute`. */
+export interface PluginRouteOptions {
+  /**
+   * Kandev-style title bar above the page. Default: enabled with derived
+   * title. Pass a `PluginPageChrome` to configure it, or `false` to render
+   * the route full-bleed and own the chrome yourself (e.g. with
+   * `host.ui.PageTopbar`).
+   */
+  topbar?: boolean | PluginPageChrome;
 }
 
 /**
@@ -51,10 +92,22 @@ export interface PluginHostApi {
   api: {
     /** fetch scoped to `/api/plugins/{id}/...` via the kandev reverse proxy. */
     fetch(path: string, init?: RequestInit): Promise<Response>;
+    /**
+     * Backend API origin ("" when the SPA and API share an origin). Lets a
+     * plugin reach first-party kandev REST endpoints without re-deriving the
+     * split-origin dev/desktop base URL from window internals.
+     */
+    baseUrl: string;
   };
-  /** Curated subset of `@kandev/ui` components (Button, Card, Badge, ...). */
+  /**
+   * Curated subset of `@kandev/ui` components (Button, Card, Badge, Input,
+   * Tabs, Dialog, Table, ...) plus first-party app UI (PageTopbar,
+   * TaskCreateDialog). See `lib/plugins/host-api.ts` for the full list.
+   */
   ui: Record<string, unknown>;
   theme: "light" | "dark";
+  /** Soft SPA navigation (history push/replace + re-render), same as the app's router. */
+  navigate(href: string, options?: { replace?: boolean }): void;
 }
 
 /**
@@ -64,8 +117,16 @@ export interface PluginHostApi {
  * disable (see `apps/web/lib/plugins/registry.ts`).
  */
 export interface PluginRegistry {
-  /** Top-level SPA route, e.g. "/jira". Exact-match against window.location path. */
-  registerRoute(path: string, Component: ReactType.ComponentType): void;
+  /**
+   * Top-level SPA route, e.g. "/jira". Exact-match against window.location
+   * path. The host wraps the page in kandev chrome (title bar) by default —
+   * configure or opt out via `options.topbar`.
+   */
+  registerRoute(
+    path: string,
+    Component: ReactType.ComponentType,
+    options?: PluginRouteOptions,
+  ): void;
   /** Sidebar/main nav entry, rendered by `<PluginNavItems/>`. */
   registerNavItem(item: NavItem): void;
   /** Route under `/settings/plugins/{id}/...`, rendered inside the settings shell. */

--- a/apps/web/src/spa-routes.plugin.test.tsx
+++ b/apps/web/src/spa-routes.plugin.test.tsx
@@ -69,6 +69,43 @@ describe("SpaRoutes — plugin route rendering", () => {
     expect(screen.getByTestId("plugin-hello-page")).not.toBeNull();
   });
 
+  it("wraps a plugin route in the kandev title bar by default", () => {
+    function HelloPage() {
+      return <div data-testid="plugin-hello-page" />;
+    }
+    pluginRegistry.forPlugin(PLUGIN_ID, "Hello Plugin").registerRoute(PLUGIN_PATH, HelloPage);
+    window.history.pushState({}, "", PLUGIN_PATH);
+
+    render(
+      <StateProvider>
+        <SpaRoutes />
+      </StateProvider>,
+    );
+
+    expect(screen.getByRole("banner")).not.toBeNull();
+    expect(screen.getByText("Hello Plugin")).not.toBeNull();
+    expect(screen.getByTestId("plugin-hello-page")).not.toBeNull();
+  });
+
+  it("renders the route full-bleed when it opts out via topbar: false", () => {
+    function HelloPage() {
+      return <div data-testid="plugin-hello-page" />;
+    }
+    pluginRegistry
+      .forPlugin(PLUGIN_ID, "Hello Plugin")
+      .registerRoute(PLUGIN_PATH, HelloPage, { topbar: false });
+    window.history.pushState({}, "", PLUGIN_PATH);
+
+    render(
+      <StateProvider>
+        <SpaRoutes />
+      </StateProvider>,
+    );
+
+    expect(screen.queryByRole("banner")).toBeNull();
+    expect(screen.getByTestId("plugin-hello-page")).not.toBeNull();
+  });
+
   it("renders a fallback instead of white-screening when the plugin route component throws", () => {
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
     function ThrowingPage(): never {

--- a/apps/web/src/spa-routes.tsx
+++ b/apps/web/src/spa-routes.tsx
@@ -27,6 +27,7 @@ import {
   PluginErrorBoundary,
   PluginRouteFallback,
 } from "@/components/plugins/plugin-error-boundary";
+import { PluginPageFrame } from "@/components/plugins/plugin-page";
 import { mapWorkspaceItem, readActiveWorkspaceCookie } from "@/lib/routing/route-bootstrap";
 import { resolveActiveId } from "@/lib/ssr/resolve-active-id";
 import { mapUserSettingsResponse } from "@/lib/ssr/user-settings";
@@ -206,9 +207,10 @@ export function SpaRoutes({ routeData }: { routeData?: BootRouteData }) {
 
 /**
  * Renders the plugin-registered component for a `kind: "plugin"` route,
- * inside the normal app shell. Wrapped in a `PluginErrorBoundary` so a
- * throwing plugin route renders a fallback instead of white-screening the
- * rest of the SPA.
+ * inside the normal app shell. `PluginPageFrame` gives it the same title-bar
+ * chrome first-party pages have (configurable per registration), and the
+ * `PluginErrorBoundary` makes a throwing plugin route render a fallback
+ * instead of white-screening the rest of the SPA.
  */
 function PluginRoute({ path }: { path: string }) {
   const match = pluginRegistry.getRoutes().find((route) => route.path === path);
@@ -216,7 +218,9 @@ function PluginRoute({ path }: { path: string }) {
   const Component = match.Component;
   return (
     <PluginErrorBoundary context={`route "${path}"`} fallback={<PluginRouteFallback />}>
-      <Component />
+      <PluginPageFrame registration={match}>
+        <Component />
+      </PluginPageFrame>
     </PluginErrorBoundary>
   );
 }

--- a/docs/plans/plugins/PLUGIN-API.md
+++ b/docs/plans/plugins/PLUGIN-API.md
@@ -48,27 +48,73 @@ interface PluginHostApi {
     // fetch scoped to this plugin's backend via kandev proxy:
     // GET/POST {method} /api/plugins/{id}/... ; returns parsed JSON
     fetch(path: string, init?: RequestInit): Promise<Response>;
+    // Backend API origin ("" when SPA and API share an origin) — for reaching
+    // first-party kandev REST endpoints without re-deriving the split-origin
+    // dev/desktop base URL from window internals.
+    baseUrl: string;
   };
-  ui: Record<string, unknown>;              // curated @kandev/ui components (Button, Card, Badge...)
+  ui: Record<string, unknown>;              // curated @kandev/ui components + app UI (see below)
   theme: "light" | "dark";
+  // Soft SPA navigation (history push/replace + SPA re-render) — same code
+  // path as the app router, so plugin pages can link into native routes
+  // (e.g. /t/{taskId}) without a full reload.
+  navigate(href: string, options?: { replace?: boolean }): void;
 }
 ```
+
+`host.ui` contents: shadcn primitives (Alert*, Badge, Button, Card*, Checkbox,
+Dialog*, DropdownMenu*, Input, Label, Pagination*, ScrollArea, Select*,
+Separator, Sheet*, Skeleton, Spinner, Switch, Table*, Tabs*, Textarea,
+Tooltip*) plus first-party app UI: `PageTopbar` (the kandev title bar, for
+routes that opt out of the default chrome and own their layout),
+`TaskCreateDialog` (kandev's real create-task modal, prefilled via
+`initialValues`), and `Combobox` (the app's Command+Popover picker). The
+authoritative list is `apps/web/lib/plugins/host-api.ts` (`PLUGIN_UI`).
+
+Plugins must use these host instances — bundling copies of anything
+Radix/portal/context-based would split React context across instances and
+break refs/`asChild`. Pure-React libs (e.g. `@tabler/icons-react`) bundle
+fine.
 
 ## `registry: PluginRegistry`
 
 ```ts
+// icon: curated icon name (apps/web/lib/plugins/icons.ts — "ticket", "chart",
+// "robot", "database", ...); unknown/missing names render a puzzle glyph in
+// the sidebar.
 interface NavItem { id: string; label: string; path: string; icon?: string; section?: "main" | "settings"; }
+
+// Configuration for the kandev-style title bar the host renders above a plugin
+// route. All fields optional; defaults are derived (see registerRoute below).
+interface PluginPageChrome {
+  title?: string;      // default: nav-item label for the same path, else plugin name
+  subtitle?: string;   // muted text next to the title
+  icon?: string;       // curated icon name; default: matching nav item's icon
+  backHref?: string;   // back-link target (host default "/")
+  backLabel?: string;  // back-link label (host default "Kandev")
+  actions?: React.ComponentType; // rendered on the right side of the topbar
+}
+
+interface PluginRouteOptions {
+  // Default: enabled with derived title. Object → configure; false → render the
+  // route full-bleed and own the chrome (e.g. with host.ui.PageTopbar).
+  topbar?: boolean | PluginPageChrome;
+}
 
 interface PluginRegistry {
   // Top-level SPA route, e.g. "/jira". Component rendered by the SPA route resolver
   // when window.location path === path (exact match; trailing segments via ":param" not
-  // required for v1 — exact + startsWith("/plugins/{id}") allowed).
-  registerRoute(path: string, Component: React.ComponentType): void;
+  // required for v1 — exact + startsWith("/plugins/{id}") allowed). The host wraps the
+  // page in kandev chrome (PageTopbar + scrollable content area) by default —
+  // configure or opt out via options.topbar.
+  registerRoute(path: string, Component: React.ComponentType, options?: PluginRouteOptions): void;
 
-  // Sidebar/main nav entry. Rendered by <PluginNavItems/> in the app sidebar.
+  // Sidebar/main nav entry. Rendered by <PluginNavItems/> in the app sidebar,
+  // with item.icon resolved against the curated icon map (fallback: puzzle).
   registerNavItem(item: NavItem): void;
 
   // Route under /settings/plugins/{id}/... rendered inside settings shell.
+  // The settings shell already provides its own topbar chrome — no options here.
   registerSettingsRoute(path: string, Component: React.ComponentType): void;
 
   // Named slot injection. Host renders all components registered for a slot via
@@ -88,8 +134,15 @@ interface PluginRegistry {
 is reactive (a small zustand store or event emitter) so host React components
 re-render when registrations change. Every registration records the owning
 `pluginId` so the host can bulk-unregister on disable. Exposes read selectors:
-`getRoutes()`, `getNavItems()`, `getSettingsRoutes()`, `getSlotComponents(slot)`,
-`getWsHandlers(action)`.
+`getRoutes()` (each entry carries `pluginId` + `options`), `getNavItems()`,
+`getSettingsRoutes()`, `getSlotComponents(slot)`, `getWsHandlers(action)`, and
+`getPluginName(pluginId)` (display name recorded by `forPlugin(id, name)`, used
+for derived page-chrome titles).
+
+Plugin top-level routes render inside `PluginPageFrame`
+(`apps/web/components/plugins/plugin-page.tsx`): a `PageTopbar` title bar above
+a scrollable content area, resolved from `options.topbar` with derived
+defaults, or the bare component when the route opted out (`topbar: false`).
 
 ## Integration points the app must add (task-19)
 


### PR DESCRIPTION
Native UI plugins could register routes and nav items but rendered as bare components with no kandev chrome, ignored their declared `icon`, and only had a dozen `host.ui` primitives — not enough to build a page that feels first-party. This gives plugins the SDK surface to render kandev-native pages by default while staying fully configurable.

## Important Changes

- **Default page chrome** — `registerRoute` takes an options arg; plugin routes now get a first-party `PageTopbar` title bar by default, with the title/icon derived from the nav item registered for the same path. Configure via `{ topbar: { title, subtitle, icon, backHref, backLabel, actions } }`, or `{ topbar: false }` to render full-bleed and own the chrome.
- **Nav icons** — `NavItem.icon` resolves against a curated name map (`lib/plugins/icons.ts`); unknown/missing names fall back to the puzzle glyph.
- **Expanded `host.ui`** — adds the primitives a native-feeling page needs (Dialog, DropdownMenu, Pagination, Sheet, Select, Tabs, Table, Tooltip, …) plus first-party `PageTopbar`, `Combobox`, and `TaskCreateDialog`. Plugins must use these host instances — a bundled second copy of any Radix/portal component splits React context.
- **`host.navigate(href, { replace? })`** for soft SPA navigation into native routes, and **`host.api.baseUrl`** for reaching first-party REST without re-deriving the split-origin backend URL.

## Validation

- `cd apps/web && pnpm run typecheck` — pass
- `cd apps/web && pnpm run test` — pass (631 files, 5114 tests, 4 skipped)
- `cd apps/web && pnpm exec eslint lib/plugins components/plugins src/spa-routes.tsx` — pass
- Prettier format check via `cd apps && pnpm format` — no changes
- New/updated unit tests cover topbar chrome resolution and opt-out through the real SPA route resolver, icon lookup fallbacks, nav-item icon rendering, registry route options + plugin-name recording, and the expanded `host.ui` set / `navigate` push-replace / `baseUrl`.

## Possible Improvements

Low risk — additive to the existing plugin contract; existing plugins keep working (they just gain a derived title bar). Follow-ups noted but out of scope: a standardized SDK package to hide the import-time React-shim problem, a sanctioned `host.api.kandevFetch` for first-party REST, and codifying which store actions are public SDK surface.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1759?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->