### PR TITLE
fix(web): stabilize sidebar toggle animation

### DIFF
--- a/.github/workflows/notify-docs.yml
+++ b/.github/workflows/notify-docs.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@a8198c4bff370c8506180b035930dea56dbd5288 # v5
         with:
-          version: 10.29.3
+          version: 9.15.9
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/apps/web/components/app-sidebar/app-sidebar.test.tsx
+++ b/apps/web/components/app-sidebar/app-sidebar.test.tsx
@@ -135,13 +135,15 @@ describe("AppSidebar", () => {
     cleanup();
   });
 
-  it("renders the nav sections when expanded (no Settings section — that's the footer gear)", () => {
+  it("renders the expanded nav inside a clipped animation layer", () => {
     render(<AppSidebar />);
     expect(screen.getByTestId("app-sidebar").getAttribute("data-collapsed")).toBe("false");
     expect(screen.getByTestId("tasks-section")).toBeTruthy();
     expect(screen.getByTestId("projects-section")).toBeTruthy();
     expect(screen.getByTestId("agents-section")).toBeTruthy();
     expect(screen.queryByTestId("settings-section")).toBeNull();
+    expect(screen.getByTestId("app-sidebar-content").classList).toContain("overflow-hidden");
+    expect(screen.getByTestId("app-sidebar").classList).not.toContain("overflow-hidden");
   });
 
   it("renders office navigation without kanban-only sections in office mode", () => {

--- a/apps/web/components/app-sidebar/app-sidebar.tsx
+++ b/apps/web/components/app-sidebar/app-sidebar.tsx
@@ -201,6 +201,8 @@ export function AppSidebar() {
           "absolute inset-y-0 left-0 flex min-h-0 flex-col border-r border-border bg-background",
           // The panel is outside root flex flow, so its transition cannot make
           // the workbench or Dockview reflow on intermediate animation frames.
+          // On collapse it briefly overdraws the snapped layout slot and stays
+          // interactive so the new rail can be expanded again immediately.
           isResizing
             ? "transition-none"
             : "transition-[width] duration-300 ease-out motion-reduce:transition-none",

--- a/apps/web/components/app-sidebar/app-sidebar.tsx
+++ b/apps/web/components/app-sidebar/app-sidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { usePathname } from "@/lib/routing/client-router";
 import { useAppStore } from "@/components/state-provider";
 import { useEnsureWorkspaceWorkflows } from "@/hooks/use-workflows";
@@ -94,9 +94,11 @@ function AppSidebarNavigation({ collapsed, inOffice, settingsMode }: AppSidebarN
  * Unified app sidebar mounted at the root layout. Replaces the legacy
  * WorkspaceRail + OfficeSidebar + dockview-embedded sidebar surfaces.
  *
- * Width: w-60 expanded / w-14 collapsed, smooth 300ms transition. Desktop-only
- * (`hidden md:flex`) — mobile surfaces carry their own nav (mobile headers and
- * menu sheets), so the global rail never overlays mobile content.
+ * Width: at least 320px expanded (user-resizable) / 56px collapsed. The flex
+ * reservation snaps between states so the workbench performs one layout pass,
+ * while the absolutely-positioned visual panel keeps the 300ms width animation.
+ * Desktop-only (`hidden md:block`) — mobile surfaces carry their own nav (mobile
+ * headers and menu sheets), so the global rail never overlays mobile content.
  */
 export function AppSidebar() {
   const collapsed = useAppStore((s) => s.appSidebar.collapsed);
@@ -110,6 +112,7 @@ export function AppSidebar() {
   const setWidth = useAppStore((s) => s.setAppSidebarWidth);
   const pathname = usePathname();
   const inOffice = useInOffice();
+  const [isResizing, setIsResizing] = useState(false);
 
   // Keep `state.workflows.items` in sync with the active workspace at the top
   // of the always-mounted sidebar. Downstream consumers (the workspace picker,
@@ -121,6 +124,7 @@ export function AppSidebar() {
   const handleResize = useCallback(
     (e: React.MouseEvent) => {
       e.preventDefault();
+      setIsResizing(true);
       const startX = e.clientX;
       const startWidth = storedWidth;
       const maxWidth = Math.floor(window.innerWidth * 0.3);
@@ -133,6 +137,7 @@ export function AppSidebar() {
         setWidth(next);
       };
       const onUp = () => {
+        setIsResizing(false);
         window.removeEventListener("mousemove", onMove);
         window.removeEventListener("mouseup", onUp);
       };
@@ -143,6 +148,7 @@ export function AppSidebar() {
   );
 
   const expandedWidth = Math.max(APP_SIDEBAR_EXPANDED_WIDTH, storedWidth);
+  const targetWidth = collapsed ? APP_SIDEBAR_COLLAPSED_WIDTH : expandedWidth;
   const settingsModeTogglePathnameRef = useRef<string | null>(null);
 
   const handleToggleSettingsMode = useCallback(() => {
@@ -183,29 +189,38 @@ export function AppSidebar() {
   }, [pathname]);
 
   return (
-    <aside
-      data-testid="app-sidebar"
-      data-collapsed={collapsed ? "true" : "false"}
-      className={cn(
-        // Desktop-only: mobile uses its own per-surface nav (mobile headers +
-        // menu sheets), so the global rail is hidden below md to avoid an
-        // always-on overlay covering page content. `md:relative` anchors the
-        // absolute resize handle.
-        "h-full min-h-0 border-r border-border bg-background hidden md:flex flex-col shrink-0",
-        "md:relative",
-        // Animate only the width: `transition-all` makes the browser watch
-        // every animatable property, and any incidental property change on the
-        // aside (border, background) would also animate during open/close.
-        "transition-[width] duration-300 ease-out",
-      )}
-      style={{
-        width: collapsed ? APP_SIDEBAR_COLLAPSED_WIDTH : expandedWidth,
-      }}
+    <div
+      data-testid="app-sidebar-layout"
+      className="relative z-30 hidden h-full min-h-0 shrink-0 overflow-visible md:block"
+      style={{ width: targetWidth }}
     >
-      <AppSidebarHeader collapsed={collapsed} onToggleCollapse={toggleCollapsed} />
-      <AppSidebarNavigation collapsed={collapsed} inOffice={inOffice} settingsMode={settingsMode} />
-      <AppSidebarFooter collapsed={collapsed} onToggleSettingsMode={handleToggleSettingsMode} />
-      {!collapsed && <AppSidebarResizeHandle onMouseDown={handleResize} />}
-    </aside>
+      <aside
+        data-testid="app-sidebar"
+        data-collapsed={collapsed ? "true" : "false"}
+        className={cn(
+          "absolute inset-y-0 left-0 flex min-h-0 flex-col border-r border-border bg-background",
+          // The panel is outside root flex flow, so its transition cannot make
+          // the workbench or Dockview reflow on intermediate animation frames.
+          isResizing
+            ? "transition-none"
+            : "transition-[width] duration-300 ease-out motion-reduce:transition-none",
+        )}
+        style={{ width: targetWidth }}
+      >
+        <div
+          data-testid="app-sidebar-content"
+          className="flex min-h-0 flex-1 flex-col overflow-hidden"
+        >
+          <AppSidebarHeader collapsed={collapsed} onToggleCollapse={toggleCollapsed} />
+          <AppSidebarNavigation
+            collapsed={collapsed}
+            inOffice={inOffice}
+            settingsMode={settingsMode}
+          />
+          <AppSidebarFooter collapsed={collapsed} onToggleSettingsMode={handleToggleSettingsMode} />
+        </div>
+        {!collapsed && <AppSidebarResizeHandle onMouseDown={handleResize} />}
+      </aside>
+    </div>
   );
 }

--- a/apps/web/components/task/dockview-desktop-layout.tsx
+++ b/apps/web/components/task/dockview-desktop-layout.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useCallback, useEffect, useRef, memo } from "react";
+import React, { useCallback, useEffect, useLayoutEffect, useRef, memo } from "react";
 import {
   DockviewReact,
   DockviewDefaultTab,
@@ -17,6 +17,7 @@ import {
   setupLayoutPersistence,
   setupPortalCleanup,
   setupSashDragCapToggle,
+  syncDockviewContainerSize,
 } from "./dockview-layout-setup";
 import { useAppStore, useAppStoreApi } from "@/components/state-provider";
 import { useLspFileOpener } from "@/hooks/use-lsp-file-opener";
@@ -347,7 +348,9 @@ export const DockviewDesktopLayout = memo(function DockviewDesktopLayout({
   compact = false,
 }: DockviewDesktopLayoutProps) {
   const setApi = useDockviewStore((s) => s.setApi);
+  const api = useDockviewStore((s) => s.api);
   const buildDefaultLayout = useDockviewStore((s) => s.buildDefaultLayout);
+  const layoutRootRef = useRef<HTMLDivElement>(null);
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const readyDisposersRef = useRef<Array<() => void>>([]);
   const appStore = useAppStoreApi();
@@ -355,6 +358,8 @@ export const DockviewDesktopLayout = memo(function DockviewDesktopLayout({
   const effectiveSessionId =
     useAppStore((state) => state.tasks.activeSessionId) ?? sessionId ?? null;
   const activeTaskId = useAppStore((state) => state.tasks.activeTaskId);
+  const appSidebarCollapsed = useAppStore((state) => state.appSidebar.collapsed);
+  const appSidebarWidth = useAppStore((state) => state.appSidebar.width);
   const effectiveEnvId = useAppStore((state) =>
     effectiveSessionId ? (state.environmentIdBySessionId[effectiveSessionId] ?? null) : null,
   );
@@ -373,6 +378,13 @@ export const DockviewDesktopLayout = memo(function DockviewDesktopLayout({
   useEffect(() => {
     envIdRef.current = effectiveEnvId;
   }, [effectiveEnvId]);
+
+  useLayoutEffect(() => {
+    if (!api) return;
+    const dockview = layoutRootRef.current?.querySelector<HTMLElement>(".dv-dockview");
+    const container = dockview?.parentElement;
+    if (container) syncDockviewContainerSize(api, container);
+  }, [api, appSidebarCollapsed, appSidebarWidth]);
 
   const onReady = useCallback(
     (event: DockviewReadyEvent) => {
@@ -404,6 +416,7 @@ export const DockviewDesktopLayout = memo(function DockviewDesktopLayout({
 
   return (
     <div
+      ref={layoutRootRef}
       data-testid="dockview-task-layout"
       className="flex-1 min-h-0 grid grid-rows-[1fr_auto]"
       aria-busy={isRestoringLayout}

--- a/apps/web/components/task/dockview-layout-setup.ts
+++ b/apps/web/components/task/dockview-layout-setup.ts
@@ -227,18 +227,31 @@ export function setupContainerResizeSync(api: DockviewReadyEvent["api"]): () => 
   const parent = dv?.parentElement;
   if (!parent) return () => {};
   const ro = new ResizeObserver(() => {
-    const w = parent.clientWidth;
-    const h = parent.clientHeight;
-    if (w <= 0 || h <= 0) return;
-    if (w === api.width && h === api.height) return;
-    api.layout(w, h);
-    // Dockview's direct `api.layout` path does not consistently emit
-    // `onDidLayoutChange`, so enforce immediately after the proportional
-    // rebalance instead of relying on the subscription above.
-    enforcePinnedTargets(api);
+    syncDockviewContainerSize(api, parent);
   });
   ro.observe(parent);
   return () => ro.disconnect();
+}
+
+/**
+ * Synchronize Dockview to its live container immediately.
+ *
+ * ResizeObserver normally owns this. Root-layout changes also call it from a
+ * React layout effect so stale group coordinates cannot reach a painted frame.
+ */
+export function syncDockviewContainerSize(
+  api: DockviewReadyEvent["api"],
+  container: HTMLElement,
+): void {
+  const width = container.clientWidth;
+  const height = container.clientHeight;
+  if (width <= 0 || height <= 0) return;
+  if (width === api.width && height === api.height) return;
+  api.layout(width, height);
+  // Dockview's direct `api.layout` path does not consistently emit
+  // `onDidLayoutChange`, so enforce immediately after the proportional
+  // rebalance instead of relying on the subscription above.
+  enforcePinnedTargets(api);
 }
 
 export function setupGroupTracking(api: DockviewReadyEvent["api"]): () => void {

--- a/apps/web/e2e/tests/kanban/kanban-topbar-utilities.spec.ts
+++ b/apps/web/e2e/tests/kanban/kanban-topbar-utilities.spec.ts
@@ -7,7 +7,7 @@ test.describe("Kanban topbar utilities", () => {
   // the AppSidebar footer gear, which toggles a full-height settings takeover
   // (the settings tree). From there each leaf navigates to a /settings/... page.
   test("settings is reachable from the AppSidebar footer gear", async ({ testPage }) => {
-    // Lock to desktop width — the AppSidebar is desktop-only (`hidden md:flex`).
+    // Lock to desktop width — the AppSidebar is hidden below the `md` breakpoint.
     await testPage.setViewportSize({ width: 1280, height: 800 });
     const kanban = new KanbanPage(testPage);
     await kanban.goto();

--- a/apps/web/e2e/tests/layout/toggle-sidebar-shortcut.spec.ts
+++ b/apps/web/e2e/tests/layout/toggle-sidebar-shortcut.spec.ts
@@ -1,7 +1,9 @@
 import { test, expect } from "../../fixtures/test-base";
 import type { Page, Locator } from "@playwright/test";
+import path from "node:path";
 import type { SeedData } from "../../fixtures/test-base";
 import type { ApiClient } from "../../helpers/api-client";
+import { GitHelper, makeGitEnv } from "../../helpers/git-helper";
 import { SessionPage } from "../../pages/session-page";
 
 // The TOGGLE_SIDEBAR shortcut lives on a global app-root listener (useAppShortcuts),
@@ -39,6 +41,158 @@ async function expectShortcutTogglesSidebar(page: Page, sidebar: Locator): Promi
   await expect(sidebar).toHaveAttribute("data-collapsed", initial);
 }
 
+type SidebarToggleFrame = {
+  layoutWidth: number;
+  panelWidth: number;
+  rightPaneLeft: number;
+  rightPaneWidth: number;
+  contentLeft: number;
+  contentWidth: number;
+};
+
+type SidebarToggleCapture = {
+  frames: SidebarToggleFrame[];
+  transitionDurationMs: number;
+  transitionProperties: string[];
+};
+
+type RightPaneTarget = {
+  panelTestId: "files-panel" | "changes-panel";
+  contentSelector?: string;
+};
+
+/** Capture painted layout frames while the visible sidebar toggle changes state. */
+async function captureSidebarToggleFrames(
+  page: Page,
+  buttonLabel: "Collapse sidebar" | "Expand sidebar",
+  target: RightPaneTarget,
+): Promise<SidebarToggleCapture> {
+  return page.evaluate(
+    async ({ label, paneTarget }) => {
+      const panel = document.querySelector('[data-testid="app-sidebar"]') as HTMLElement | null;
+      const layout =
+        (document.querySelector('[data-testid="app-sidebar-layout"]') as HTMLElement | null) ??
+        panel;
+      const rightPane = Array.from(
+        document.querySelectorAll<HTMLElement>(`[data-testid="${paneTarget.panelTestId}"]`),
+      ).find((candidate) => candidate.getBoundingClientRect().width > 0);
+      const content = paneTarget.contentSelector
+        ? rightPane?.querySelector<HTMLElement>(paneTarget.contentSelector)
+        : rightPane;
+      const button = panel?.querySelector<HTMLButtonElement>(`[aria-label="${label}"]`);
+      if (!layout || !panel || !rightPane || !content || !button) {
+        throw new Error(
+          `Missing sidebar, visible ${paneTarget.panelTestId} content, or ${label} button`,
+        );
+      }
+
+      const readFrame = (): SidebarToggleFrame => {
+        const layoutBox = layout.getBoundingClientRect();
+        const panelBox = panel.getBoundingClientRect();
+        const rightPaneBox = rightPane.getBoundingClientRect();
+        const contentBox = content.getBoundingClientRect();
+        return {
+          layoutWidth: layoutBox.width,
+          panelWidth: panelBox.width,
+          rightPaneLeft: rightPaneBox.left,
+          rightPaneWidth: rightPaneBox.width,
+          contentLeft: contentBox.left,
+          contentWidth: contentBox.width,
+        };
+      };
+
+      const panelStyle = getComputedStyle(panel);
+      const transitionDurationMs = Math.max(
+        ...panelStyle.transitionDuration.split(",").map((duration) => {
+          const value = Number.parseFloat(duration);
+          return duration.trim().endsWith("ms") ? value : value * 1000;
+        }),
+      );
+      const transitionProperties = panelStyle.transitionProperty
+        .split(",")
+        .map((property) => property.trim());
+      const frames = [readFrame()];
+      button.click();
+      const sampleUntil = performance.now() + 400;
+      do {
+        // rAF callbacks run before ResizeObserver delivery and paint. Hop through
+        // a timer so each measurement reflects geometry the user actually saw.
+        await new Promise<void>((resolve) => {
+          requestAnimationFrame(() => setTimeout(resolve, 0));
+        });
+        frames.push(readFrame());
+      } while (performance.now() < sampleUntil);
+      return { frames, transitionDurationMs, transitionProperties };
+    },
+    { label: buttonLabel, paneTarget: target },
+  );
+}
+
+function expectStableAnimatedToggle(capture: SidebarToggleCapture): void {
+  const { frames } = capture;
+  const changedFrames = (read: (frame: SidebarToggleFrame) => number): number[] => {
+    const changes: number[] = [];
+    for (let index = 1; index < frames.length; index += 1) {
+      if (Math.abs(read(frames[index]) - read(frames[index - 1])) > 1) changes.push(index);
+    }
+    return changes;
+  };
+
+  const expectStable = (label: string, read: (frame: SidebarToggleFrame) => number): void => {
+    const values = frames.map(read);
+    const span = Math.max(...values) - Math.min(...values);
+    expect(span, `${label} moved ${span.toFixed(2)}px across painted frames`).toBeLessThanOrEqual(
+      1,
+    );
+  };
+
+  expectStable("Right pane position", (frame) => frame.rightPaneLeft);
+  expectStable("Right pane width", (frame) => frame.rightPaneWidth);
+  expectStable("Right pane content position", (frame) => frame.contentLeft);
+  expectStable("Right pane content width", (frame) => frame.contentWidth);
+
+  expect(capture.transitionProperties).toContain("width");
+  expect(capture.transitionDurationMs).toBeGreaterThanOrEqual(290);
+  expect(capture.transitionDurationMs).toBeLessThanOrEqual(310);
+
+  const layoutChanges = changedFrames((frame) => frame.layoutWidth);
+  expect(
+    layoutChanges,
+    `Sidebar layout width changed on frames ${layoutChanges.join(", ")}`,
+  ).toHaveLength(1);
+
+  const panelChanges = changedFrames((frame) => frame.panelWidth);
+  const panelWidths = frames.map((frame) => frame.panelWidth);
+  const minimumPanelWidth = Math.min(...panelWidths);
+  const maximumPanelWidth = Math.max(...panelWidths);
+  expect(
+    maximumPanelWidth - minimumPanelWidth,
+    "Visual sidebar should travel between its expanded and collapsed widths",
+  ).toBeGreaterThan(200);
+  expect(
+    panelWidths
+      .slice(1, -1)
+      .some((width) => width > minimumPanelWidth + 1 && width < maximumPanelWidth - 1),
+    `Visual sidebar never painted an intermediate width: ${panelWidths.join(", ")}`,
+  ).toBe(true);
+  expect(
+    panelChanges.at(-1) ?? 0,
+    "Visual sidebar should keep animating after the layout shell settles",
+  ).toBeGreaterThan(layoutChanges[0]);
+  expect(Math.abs(frames.at(-1)!.panelWidth - frames.at(-1)!.layoutWidth)).toBeLessThanOrEqual(1);
+}
+
+async function expectStablePaneDuringSidebarToggle(
+  page: Page,
+  target: RightPaneTarget,
+): Promise<void> {
+  const collapseCapture = await captureSidebarToggleFrames(page, "Collapse sidebar", target);
+  expectStableAnimatedToggle(collapseCapture);
+
+  const expandCapture = await captureSidebarToggleFrames(page, "Expand sidebar", target);
+  expectStableAnimatedToggle(expandCapture);
+}
+
 test.describe("Toggle sidebar shortcut (global)", () => {
   test("toggles the AppSidebar on the Kanban board", async ({ testPage, apiClient, seedData }) => {
     await bindToggleSidebar(apiClient, seedData);
@@ -52,11 +206,13 @@ test.describe("Toggle sidebar shortcut (global)", () => {
     await expectShortcutTogglesSidebar(testPage, testPage.getByTestId("app-sidebar"));
   });
 
-  test("still toggles the AppSidebar on the dockview session page", async ({
+  test("animates the AppSidebar without moving Files or Changes", async ({
     testPage,
     apiClient,
     seedData,
+    backend,
   }) => {
+    await testPage.setViewportSize({ width: 1600, height: 900 });
     await bindToggleSidebar(apiClient, seedData);
 
     const task = await apiClient.createTaskWithAgent(
@@ -79,5 +235,29 @@ test.describe("Toggle sidebar shortcut (global)", () => {
     // Target the global rail (app-sidebar), not the dockview's per-session
     // sidebar (task-sidebar).
     await expectShortcutTogglesSidebar(testPage, testPage.getByTestId("app-sidebar"));
+
+    await session.waitForDockviewReady();
+    await session.clickTab("Files");
+    await expect(session.files).toBeVisible();
+    await expect(session.fileTreeNode("walkthrough_base.txt")).toBeVisible();
+
+    await expectStablePaneDuringSidebarToggle(testPage, {
+      panelTestId: "files-panel",
+      contentSelector: '[data-testid="file-tree-node"][data-path="walkthrough_base.txt"]',
+    });
+
+    const git = new GitHelper(
+      path.join(backend.tmpDir, "repos", "e2e-repo"),
+      makeGitEnv(backend.tmpDir),
+    );
+    git.modifyFile("walkthrough_base.txt", "changed while checking sidebar stability\n");
+
+    await session.clickTab("Changes");
+    await expect(session.changes).toBeVisible();
+    await expect(session.changesFileRow("walkthrough_base.txt")).toBeVisible({ timeout: 15_000 });
+    await expectStablePaneDuringSidebarToggle(testPage, {
+      panelTestId: "changes-panel",
+      contentSelector: '[data-changes-file="walkthrough_base.txt"]',
+    });
   });
 });

--- a/apps/web/e2e/tests/layout/toggle-sidebar-shortcut.spec.ts
+++ b/apps/web/e2e/tests/layout/toggle-sidebar-shortcut.spec.ts
@@ -52,7 +52,7 @@ type SidebarToggleFrame = {
 
 type SidebarToggleCapture = {
   frames: SidebarToggleFrame[];
-  transitionDurationMs: number;
+  widthTransitionDurationMs: number;
   transitionProperties: string[];
 };
 
@@ -102,15 +102,18 @@ async function captureSidebarToggleFrames(
       };
 
       const panelStyle = getComputedStyle(panel);
-      const transitionDurationMs = Math.max(
-        ...panelStyle.transitionDuration.split(",").map((duration) => {
-          const value = Number.parseFloat(duration);
-          return duration.trim().endsWith("ms") ? value : value * 1000;
-        }),
-      );
       const transitionProperties = panelStyle.transitionProperty
         .split(",")
         .map((property) => property.trim());
+      const transitionDurationsMs = panelStyle.transitionDuration.split(",").map((duration) => {
+        const value = Number.parseFloat(duration);
+        return duration.trim().endsWith("ms") ? value : value * 1000;
+      });
+      const widthTransitionIndex = transitionProperties.indexOf("width");
+      const widthTransitionDurationMs =
+        widthTransitionIndex < 0
+          ? 0
+          : (transitionDurationsMs[widthTransitionIndex % transitionDurationsMs.length] ?? 0);
       const frames = [readFrame()];
       button.click();
       const sampleUntil = performance.now() + 400;
@@ -122,7 +125,7 @@ async function captureSidebarToggleFrames(
         });
         frames.push(readFrame());
       } while (performance.now() < sampleUntil);
-      return { frames, transitionDurationMs, transitionProperties };
+      return { frames, widthTransitionDurationMs, transitionProperties };
     },
     { label: buttonLabel, paneTarget: target },
   );
@@ -152,8 +155,8 @@ function expectStableAnimatedToggle(capture: SidebarToggleCapture): void {
   expectStable("Right pane content width", (frame) => frame.contentWidth);
 
   expect(capture.transitionProperties).toContain("width");
-  expect(capture.transitionDurationMs).toBeGreaterThanOrEqual(290);
-  expect(capture.transitionDurationMs).toBeLessThanOrEqual(310);
+  expect(capture.widthTransitionDurationMs).toBeGreaterThanOrEqual(290);
+  expect(capture.widthTransitionDurationMs).toBeLessThanOrEqual(310);
 
   const layoutChanges = changedFrames((frame) => frame.layoutWidth);
   expect(
@@ -250,14 +253,18 @@ test.describe("Toggle sidebar shortcut (global)", () => {
       path.join(backend.tmpDir, "repos", "e2e-repo"),
       makeGitEnv(backend.tmpDir),
     );
-    git.modifyFile("walkthrough_base.txt", "changed while checking sidebar stability\n");
+    try {
+      git.modifyFile("walkthrough_base.txt", "changed while checking sidebar stability\n");
 
-    await session.clickTab("Changes");
-    await expect(session.changes).toBeVisible();
-    await expect(session.changesFileRow("walkthrough_base.txt")).toBeVisible({ timeout: 15_000 });
-    await expectStablePaneDuringSidebarToggle(testPage, {
-      panelTestId: "changes-panel",
-      contentSelector: '[data-changes-file="walkthrough_base.txt"]',
-    });
+      await session.clickTab("Changes");
+      await expect(session.changes).toBeVisible();
+      await expect(session.changesFileRow("walkthrough_base.txt")).toBeVisible({ timeout: 15_000 });
+      await expectStablePaneDuringSidebarToggle(testPage, {
+        panelTestId: "changes-panel",
+        contentSelector: '[data-changes-file="walkthrough_base.txt"]',
+      });
+    } finally {
+      git.exec('git checkout -- "walkthrough_base.txt"');
+    }
   });
 });

--- a/apps/web/e2e/tests/layout/topbar-alignment.spec.ts
+++ b/apps/web/e2e/tests/layout/topbar-alignment.spec.ts
@@ -67,22 +67,14 @@ test.describe("Sidebar header / top bar alignment", () => {
     const topbar = testPage.getByTestId("task-topbar");
     await expect(topbar).toBeVisible({ timeout: 30_000 });
 
-    // The sidebar header is the first child of the sidebar aside; tag-agnostic,
-    // we measure the aside-relative header via its testid-less first row by
-    // reading the task-topbar against the sidebar header height (both 40px).
-    const headerBottom = await testPage.evaluate(() => {
-      const aside = document.querySelector('[data-testid="app-sidebar"]');
-      const header = aside?.firstElementChild as HTMLElement | null;
-      if (!header) return null;
-      const r = header.getBoundingClientRect();
-      return r.y + r.height;
-    });
-    expect(headerBottom).not.toBeNull();
-
+    // Read the named header directly so layout wrappers can change without
+    // weakening the alignment check (both top bars are 40px high).
+    await expect(testPage.getByTestId("app-sidebar-header")).toBeVisible();
+    const headerBottom = await bottomOf(testPage, "app-sidebar-header");
     const topbarBottom = await bottomOf(testPage, "task-topbar");
 
     // Allow 1px for sub-pixel rounding of the shared border line.
-    expect(Math.abs((headerBottom as number) - topbarBottom)).toBeLessThanOrEqual(1);
+    expect(Math.abs(headerBottom - topbarBottom)).toBeLessThanOrEqual(1);
   });
 
   test("task metrics match the height of the task action controls", async ({

--- a/apps/web/hooks/use-app-shortcuts.ts
+++ b/apps/web/hooks/use-app-shortcuts.ts
@@ -23,7 +23,7 @@ function isEditableTarget(e: KeyboardEvent): boolean {
  * task list, Office, Settings, etc. Mount this once near the app root (it has
  * no dockview dependency) so the binding works everywhere.
  *
- * The AppSidebar is desktop-only (`hidden md:flex`); on mobile the toggle still
+ * The AppSidebar is hidden below the `md` breakpoint; on mobile the toggle still
  * flips store state but has no visible effect, which is fine.
  */
 export function useAppShortcuts() {

--- a/apps/web/lib/state/dockview-measure.test.ts
+++ b/apps/web/lib/state/dockview-measure.test.ts
@@ -23,16 +23,16 @@ describe("measureDockviewContainer", () => {
     expect(measureDockviewContainer(fakeApi(0, 0))).toEqual({ width: 1500, height: 700 });
   });
 
-  it("ignores an implausibly-narrow live width (sidebar mid-transition) but keeps the live height", () => {
-    // Regression (post unified-sidebar #1165): the AppSidebar is a root-layout
-    // flex sibling with `transition-all duration-300`, so the dockview content
-    // container can be measured mid-animation at a tiny positive width. Building
-    // the default layout at that width collapses the horizontal columns into a
+  it("ignores an implausibly-narrow live width during root layout but keeps the live height", () => {
+    // Regression (post unified-sidebar #1165): while the AppSidebar root-flex
+    // width was animated, the dockview content container could be measured at a
+    // tiny positive width. Keep rejecting that transient during initial layout:
+    // building the default at it collapses the horizontal columns into a
     // vertical stack (chat / files+changes / terminal). On desktop the sidebar
     // maxes at 30vw, so content is always >= ~70vw — a sub-half-viewport read is
     // definitionally a transient: fall back the width to the viewport so the
     // build stays horizontal (the resize observer then snaps to the exact size).
-    // The animation is horizontal, so the live height is reliable and is kept.
+    // Root flex layout changes are horizontal, so the live height is reliable.
     const parent = document.createElement("div");
     Object.defineProperty(parent, "clientWidth", { value: 80, configurable: true });
     Object.defineProperty(parent, "clientHeight", { value: 700, configurable: true });

--- a/apps/web/lib/state/dockview-measure.ts
+++ b/apps/web/lib/state/dockview-measure.ts
@@ -25,13 +25,12 @@ export function measureDockviewContainer(api: DockviewApi): { width: number; hei
   };
 }
 
-// The dockview content area sits next to the unified AppSidebar (#1165), whose
-// width animates over 300ms (`transition-all`). During that animation `onReady`
-// can read the parent at a tiny positive width — building the default layout at
-// that width collapses the horizontal columns into a vertical stack. The
-// sidebar maxes at 30vw (desktop-only surface), so a healthy content width is
-// always >= ~70vw; anything below half the viewport is a mid-transition
-// transient and must be treated like a not-yet-laid-out (0-width) container.
+// The dockview content area sits next to the unified AppSidebar (#1165). During
+// initial root layout, `onReady` can read the parent at a tiny positive width —
+// building the default layout at that width collapses the horizontal columns
+// into a vertical stack. The sidebar maxes at 30vw (desktop-only surface), so a
+// healthy content width is always >= ~70vw; anything below half the viewport is
+// a transient and must be treated like a not-yet-laid-out (0-width) container.
 const MIN_PLAUSIBLE_WIDTH_RATIO = 0.5;
 
 function liveContainerSize(): { width: number; height: number } | null {
@@ -39,10 +38,11 @@ function liveContainerSize(): { width: number; height: number } | null {
   const dv = document.querySelector(".dv-dockview") as HTMLElement | null;
   const parent = dv?.parentElement;
   if (!parent || parent.clientWidth <= 0 || parent.clientHeight <= 0) return null;
-  // The sidebar animation is horizontal, so only the width can be a transient —
-  // the live height is reliable. Fall back just the width to the viewport so the
-  // build stays horizontal; keep the real height to avoid a needless vertical
-  // transient. The resize observer then snaps the width to the exact size.
+  // Root flex layout changes are horizontal, so only the width can be a
+  // transient — the live height is reliable. Fall back just the width to the
+  // viewport so the build stays horizontal; keep the real height to avoid a
+  // needless vertical transient. The resize observer then snaps the width to
+  // the exact size.
   const plausibleWidth = parent.clientWidth >= viewportWidth() * MIN_PLAUSIBLE_WIDTH_RATIO;
   return {
     width: plausibleWidth ? parent.clientWidth : viewportWidth(),


### PR DESCRIPTION
Sidebar collapse/expand made stable Dockview panes shake because they relaid out throughout the animation. Sidebar chrome now keeps its 300 ms motion while Dockview receives one size update; the docs workflow's stale pnpm pin is also aligned with the workspace after the latest-main rebase.

## Validation

- `make fmt`
- `make typecheck`
- `make test`
- `make lint`
- `cd apps/web && pnpm e2e:run --no-build tests/layout/toggle-sidebar-shortcut.spec.ts tests/layout/topbar-alignment.spec.ts -- --project=chromium` (6 passed)

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.