### PR TITLE
docs: place Office warnings within feature sections

### DIFF
--- a/docs/public/README.md
+++ b/docs/public/README.md
@@ -34,15 +34,15 @@ The docs header renders a visible status callout from that frontmatter. To invok
 Use a section-level indicator when a stable guide contains one experimental capability. Keep this source syntax as Markdown so older renderers and GitHub still show an explicit callout; the publication layer upgrades it to the styled status component:
 
 ```markdown
-## Coordinate work
-
-Use named sessions for parallel work that shares one task environment.
+## Office dependencies
 
 > [!EXPERIMENTAL]
-> Office is disabled by default and its public workflow is not stable yet.
+> Office is feature-flagged and its dependency editor is not stable yet.
+
+When Office is enabled, it can record blocked-by relationships between tasks. Use parent/child structure and workflow gates for the supported regular-Kanban path.
 ```
 
-Place the indicator inside the substantive section it qualifies and explain the enabling condition, current limit, and supported alternative. Do not create a standalone status section whose only content is the warning. The publication pipeline converts the callout to `FeatureStatus` and opts the generated page into MDX automatically.
+Place the indicator immediately after a descriptive heading that names the experimental capability, then follow it with the instructions or behavior it qualifies. Explain the enabling condition, current limit, and supported alternative. Do not drop a warning between otherwise stable paragraphs or create a standalone status section whose only content is the warning. The publication pipeline converts the callout to `FeatureStatus` and opts the generated page into MDX automatically.
 
 ## Add a page
 

--- a/docs/public/README.md
+++ b/docs/public/README.md
@@ -34,13 +34,15 @@ The docs header renders a visible status callout from that frontmatter. To invok
 Use a section-level indicator when a stable guide contains one experimental capability. Keep this source syntax as Markdown so older renderers and GitHub still show an explicit callout; the publication layer upgrades it to the styled status component:
 
 ```markdown
-## Office status
+## Coordinate work
+
+Use named sessions for parallel work that shares one task environment.
 
 > [!EXPERIMENTAL]
 > Office is disabled by default and its public workflow is not stable yet.
 ```
 
-Keep the indicator next to the relevant heading and explain the enabling condition, current limit, and supported alternative. The publication pipeline converts the callout to `FeatureStatus` and opts the generated page into MDX automatically.
+Place the indicator inside the substantive section it qualifies and explain the enabling condition, current limit, and supported alternative. Do not create a standalone status section whose only content is the warning. The publication pipeline converts the callout to `FeatureStatus` and opts the generated page into MDX automatically.
 
 ## Add a page
 

--- a/docs/public/agents-and-profiles.md
+++ b/docs/public/agents-and-profiles.md
@@ -46,9 +46,6 @@ Select an agent, create a profile, then open **Settings > Agents > _Agent_ > _Pr
 
 Model, mode, command, and configuration choices are probed from the locally installed CLI and cached. Refresh the profile if an agent update changes them. Probe status can report **auth required**, **not installed**, **not configured**, or **failed**; a saved model name does not prove that the current provider account can use it.
 
-> [!EXPERIMENTAL]
-> Office team roles, reporting lines, budgets, concurrency, and governance add more fields to agent profiles only when the Office feature is enabled. Office is disabled by default and remains in progress; its coordinator routing and approval policy are not a stable public workflow. Regular profiles, workflow approval steps, and task-mode automation provide the supported human-gated path today.
-
 ### Monitor capability and subscription status
 
 Use the profile refresh control after installing, authenticating, or upgrading an agent. A manual refresh updates both the advertised models, modes, and commands and the visible capability status, so an old failure banner does not remain authoritative after the local CLI recovers.
@@ -121,7 +118,7 @@ Kandev does not validate a server-name syntax centrally, so blank or unusual nam
 Deleting a profile is irreversible. Kandev checks references before deletion:
 
 - active sessions and watcher references are soft conflicts; force bypasses the active-session check and soft-deletes the profile, while disabling affected watchers is best effort rather than guaranteed cleanup;
-- experimental Office routing-tier references are hard conflicts and cannot be forced;
+- feature-flagged Office routing-tier references are hard conflicts and cannot be forced;
 - Kandev attempts to clean every ephemeral task with a session using the profile, including matching Quick Chat, Configuration Chat, and Run-mode automation work. A cleanup failure is logged and does not prevent profile deletion, so audit leftover resources afterward.
 
 Only custom TUI agents can be deleted from the agent list. Built-in definitions remain registered even when their CLI is not installed.

--- a/docs/public/agents-and-profiles.md
+++ b/docs/public/agents-and-profiles.md
@@ -46,6 +46,9 @@ Select an agent, create a profile, then open **Settings > Agents > _Agent_ > _Pr
 
 Model, mode, command, and configuration choices are probed from the locally installed CLI and cached. Refresh the profile if an agent update changes them. Probe status can report **auth required**, **not installed**, **not configured**, or **failed**; a saved model name does not prove that the current provider account can use it.
 
+> [!EXPERIMENTAL]
+> Office team roles, reporting lines, budgets, concurrency, and governance add more fields to agent profiles only when the Office feature is enabled. Office is disabled by default and remains in progress; its coordinator routing and approval policy are not a stable public workflow. Regular profiles, workflow approval steps, and task-mode automation provide the supported human-gated path today.
+
 ### Monitor capability and subscription status
 
 Use the profile refresh control after installing, authenticating, or upgrading an agent. A manual refresh updates both the advertised models, modes, and commands and the visible capability status, so an old failure banner does not remain authoritative after the local CLI recovers.
@@ -122,11 +125,6 @@ Deleting a profile is irreversible. Kandev checks references before deletion:
 - Kandev attempts to clean every ephemeral task with a session using the profile, including matching Quick Chat, Configuration Chat, and Run-mode automation work. A cleanup failure is logged and does not prevent profile deletion, so audit leftover resources afterward.
 
 Only custom TUI agents can be deleted from the agent list. Built-in definitions remain registered even when their CLI is not installed.
-
-## Office status
-
-> [!EXPERIMENTAL]
-> Office team roles, reporting lines, budgets, concurrency, and governance add more fields to agent profiles only when the Office feature is enabled. Office is disabled by default and remains in progress; its coordinator routing and approval policy are not a stable public workflow. Regular profiles, workflow approval steps, and task-mode automation provide the supported human-gated path today.
 
 ## Troubleshooting
 

--- a/docs/public/automation-and-mcp.md
+++ b/docs/public/automation-and-mcp.md
@@ -23,9 +23,6 @@ Regular workflow entry actions can enable plan mode, reset agent context, or aut
 
 See [Tasks and workflows](tasks-and-workflows.md) for event configuration and defaults.
 
-> [!EXPERIMENTAL]
-> Office has separate coordinator agents, routines, governance approvals, and an Office MCP/agentctl interface only when its feature flag is enabled. Office is disabled by default and remains in progress; do not treat its coordinator-led automation as a stable public contract. Workspace automations plus workflow approval/review steps are the supported human-gated mechanism today.
-
 ## Create a workspace automation
 
 Open **Settings > Workspaces > _Workspace_ > Automations** (`/settings/workspace/{workspaceId}/automations`) and select **New Automation**. The top-level `/settings/automations` route redirects to, or asks you to select, a workspace.

--- a/docs/public/automation-and-mcp.md
+++ b/docs/public/automation-and-mcp.md
@@ -23,6 +23,9 @@ Regular workflow entry actions can enable plan mode, reset agent context, or aut
 
 See [Tasks and workflows](tasks-and-workflows.md) for event configuration and defaults.
 
+> [!EXPERIMENTAL]
+> Office has separate coordinator agents, routines, governance approvals, and an Office MCP/agentctl interface only when its feature flag is enabled. Office is disabled by default and remains in progress; do not treat its coordinator-led automation as a stable public contract. Workspace automations plus workflow approval/review steps are the supported human-gated mechanism today.
+
 ## Create a workspace automation
 
 Open **Settings > Workspaces > _Workspace_ > Automations** (`/settings/workspace/{workspaceId}/automations`) and select **New Automation**. The top-level `/settings/automations` route redirects to, or asks you to select, a workspace.
@@ -195,11 +198,6 @@ The backend's `/mcp`, `/mcp/sse`, and `/mcp/message` routes currently have no Ka
 - Do not publish the MCP routes or backend port directly to the internet.
 - Ensure the proxy protects both Streamable HTTP and SSE/message paths and permits long-lived requests.
 - Scope integration, Git, and agent credentials for the damage an unattended client could cause.
-
-## Office status
-
-> [!EXPERIMENTAL]
-> Office has separate coordinator agents, routines, governance approvals, and an Office MCP/agentctl interface only when its feature flag is enabled. Office is disabled by default and remains in progress; do not treat its coordinator-led automation as a stable public contract. Workspace automations plus workflow approval/review steps are the supported human-gated mechanism today.
 
 ## Troubleshooting
 

--- a/docs/public/coordination.md
+++ b/docs/public/coordination.md
@@ -18,9 +18,6 @@ Kandev can coordinate several agents without turning every unit of work into a s
 
 Shared files make handoff cheap but allow concurrent edits to collide. Separate environments isolate file state, but only the executor determines whether host processes and credentials are also isolated.
 
-> [!EXPERIMENTAL]
-> Office is in progress and feature-flagged. Persistent coordinator teams, arbitrary-depth task trees, dependency properties, labels, named documents, reviewer/approver quorum, routines, and budgets are not stable regular-Kanban capabilities.
-
 ## Run parallel sessions in one task
 
 Use an additional session when agents need the same task, repository attachments, and materialized environment.
@@ -195,11 +192,14 @@ The coordinator has only the tools, filesystem access, credentials, and permissi
 
 A human-led flow uses the same primitives but keeps **Do nothing** transitions at planning, review, or release steps. Humans can create each task, approve agent-proposed subtasks, restrict credentials to narrow profiles, and decide what merges or ships.
 
-### Dependencies and Office
+### Office dependencies and deeper coordination
+
+> [!EXPERIMENTAL]
+> Office is feature-flagged, disabled in the production profile by default, and still in progress. Its dependency editor, persistent coordinators, deeper task trees, quorum rules, and routines are not stable regular-Kanban features.
 
 Regular Kanban does not currently expose a dependency editor or blocker filter. Stored blocker data can appear through related-task MCP, but it is not a regular-board planning surface. For supported ordering, use parent/child structure, **When Child Tasks Complete**, explicit messages, workflow gates, and pull-request review.
 
-Office prototypes **Blocked by** and **Blocking** properties with same-workspace, self-reference, and cycle validation, plus persistent coordinators and deeper trees. Office remains in progress; do not rely on these properties or its advanced quorum/routine behavior for a stable Kanban workflow.
+When Office is enabled, it prototypes **Blocked by** and **Blocking** properties with same-workspace, self-reference, and cycle validation. Treat these as an evaluation surface rather than a production coordination contract.
 
 ## Troubleshooting
 

--- a/docs/public/coordination.md
+++ b/docs/public/coordination.md
@@ -18,8 +18,6 @@ Kandev can coordinate several agents without turning every unit of work into a s
 
 Shared files make handoff cheap but allow concurrent edits to collide. Separate environments isolate file state, but only the executor determines whether host processes and credentials are also isolated.
 
-## Office status
-
 > [!EXPERIMENTAL]
 > Office is in progress and feature-flagged. Persistent coordinator teams, arbitrary-depth task trees, dependency properties, labels, named documents, reviewer/approver quorum, routines, and budgets are not stable regular-Kanban capabilities.
 

--- a/docs/public/tasks-and-workflows.md
+++ b/docs/public/tasks-and-workflows.md
@@ -21,9 +21,6 @@ A task is the unit of work. A workflow is the ordered process that task follows.
 
 Workflow position and runtime state are different. Moving a card changes its workflow step; it does not prove that an agent ran, code was committed, review passed, or a pull request merged.
 
-> [!EXPERIMENTAL]
-> Office is in progress and feature-flagged. Its persistent agents, arbitrary-depth task trees, blocker and label properties, named task documents, reviewer/approver quorum, routines, and budgets are not stable features of the regular Kanban task experience.
-
 ## Prepare a workspace
 
 A new workspace created by a user does not automatically receive a workflow.
@@ -194,7 +191,10 @@ Agents use `create_task_plan_kandev`, `get_task_plan_kandev`, `update_task_plan_
 
 Revision history is not an immutable record of every autosave. Consecutive writes from the same author name and author kind coalesce into the latest revision for five minutes by default. Operators can set `KANDEV_PLAN_COALESCE_WINDOW_MS`; `0` disables coalescing, while an invalid or negative value falls back to five minutes.
 
-### Current availability of documents, labels, and blockers
+## Office documents, labels, and blockers
+
+> [!EXPERIMENTAL]
+> Office is feature-flagged, disabled in the production profile by default, and still in progress. Its named documents, labels, and blocker controls are not stable regular-Kanban features.
 
 | Capability | Regular Kanban | Office |
 |---|---|---|

--- a/docs/public/tasks-and-workflows.md
+++ b/docs/public/tasks-and-workflows.md
@@ -21,8 +21,6 @@ A task is the unit of work. A workflow is the ordered process that task follows.
 
 Workflow position and runtime state are different. Moving a card changes its workflow step; it does not prove that an agent ran, code was committed, review passed, or a pull request merged.
 
-## Office status
-
 > [!EXPERIMENTAL]
 > Office is in progress and feature-flagged. Its persistent agents, arbitrary-depth task trees, blocker and label properties, named task documents, reviewer/approver quorum, routines, and budgets are not stable features of the regular Kanban task experience.
 

--- a/scripts/validate-public-docs.mjs
+++ b/scripts/validate-public-docs.mjs
@@ -29,7 +29,7 @@ export async function validatePublicDocs(docsDir = defaultDocsDir) {
 
     assertFrontmatter(file, markdown);
     assertDocumentStructure(file, markdown);
-    assertExperimentalSectionContent(file, markdown);
+    assertExperimentalCalloutPlacement(file, markdown);
 
     const slug = file.replace(/\.mdx?$/, "").replace(/\/index$/, "");
     const existing = pagesBySlug.get(slug);
@@ -837,40 +837,55 @@ function assertDocumentStructure(file, markdown) {
 }
 
 /**
- * Prevent a status heading from existing only to contain an experimental
- * warning. Experimental context belongs inside the substantive section it
- * qualifies, unless the section also explains the feature itself.
+ * Keep experimental callouts attached to an explicit feature section.
+ * A section-level indicator is the first content under its heading, followed
+ * by the documentation it qualifies.
  *
  * @param {string} file Relative page path used in validation errors.
  * @param {string} markdown Page source.
  * @returns {void}
  */
-function assertExperimentalSectionContent(file, markdown) {
+function assertExperimentalCalloutPlacement(file, markdown) {
   const source = stripMarkdownCode(markdown);
   const headings = [...source.matchAll(/^(#{2,6})\s+([^\n]+?)\s*$/gm)];
+  const callouts = [...source.matchAll(/^>\s*\[!EXPERIMENTAL\]\s*$/gim)];
 
-  for (const [index, heading] of headings.entries()) {
+  for (const callout of callouts) {
+    const headingIndex = headings.findLastIndex(
+      (candidate) => candidate.index < callout.index,
+    );
+    const heading = headings[headingIndex];
+    if (
+      !heading ||
+      source
+        .slice(heading.index + heading[0].length, callout.index)
+        .trim()
+    ) {
+      throw new Error(
+        `${file} experimental callouts must immediately follow a descriptive heading`,
+      );
+    }
+
     const title = heading[2].trim();
-    if (!/\bstatus$/i.test(title)) continue;
-
     const level = heading[1].length;
-    const sectionStart = heading.index + heading[0].length;
     const nextHeading = headings
-      .slice(index + 1)
+      .slice(headingIndex + 1)
       .find((candidate) => candidate[1].length <= level);
     const sectionEnd = nextHeading?.index ?? source.length;
-    const section = source.slice(sectionStart, sectionEnd);
-    if (!/^>\s*\[!EXPERIMENTAL\]\s*$/im.test(section)) continue;
-
-    const withoutCallout = section
-      .replace(
-        /^>\s*\[!EXPERIMENTAL\]\s*\r?\n(?:^>.*(?:\r?\n|$))*/gim,
-        "",
+    const calloutBlock = source
+      .slice(callout.index)
+      .match(
+        /^>\s*\[!EXPERIMENTAL\]\s*\r?\n(?:^>.*(?:\r?\n|$))*/im,
+      )?.[0];
+    const sectionContent = source
+      .slice(
+        callout.index + (calloutBlock?.length ?? callout[0].length),
+        sectionEnd,
       )
       .trim();
-    if (!withoutCallout) {
+    if (!sectionContent) {
       throw new Error(
-        `${file} has a warning-only experimental status section: ${title}`,
+        `${file} has an experimental callout without substantive section content: ${title}`,
       );
     }
   }

--- a/scripts/validate-public-docs.mjs
+++ b/scripts/validate-public-docs.mjs
@@ -29,6 +29,7 @@ export async function validatePublicDocs(docsDir = defaultDocsDir) {
 
     assertFrontmatter(file, markdown);
     assertDocumentStructure(file, markdown);
+    assertExperimentalSectionContent(file, markdown);
 
     const slug = file.replace(/\.mdx?$/, "").replace(/\/index$/, "");
     const existing = pagesBySlug.get(slug);
@@ -832,6 +833,46 @@ function assertDocumentStructure(file, markdown) {
     throw new Error(
       `${file} must begin with exactly one level-one heading after frontmatter`,
     );
+  }
+}
+
+/**
+ * Prevent a status heading from existing only to contain an experimental
+ * warning. Experimental context belongs inside the substantive section it
+ * qualifies, unless the section also explains the feature itself.
+ *
+ * @param {string} file Relative page path used in validation errors.
+ * @param {string} markdown Page source.
+ * @returns {void}
+ */
+function assertExperimentalSectionContent(file, markdown) {
+  const source = stripMarkdownCode(markdown);
+  const headings = [...source.matchAll(/^(#{2,6})\s+([^\n]+?)\s*$/gm)];
+
+  for (const [index, heading] of headings.entries()) {
+    const title = heading[2].trim();
+    if (!/\bstatus$/i.test(title)) continue;
+
+    const level = heading[1].length;
+    const sectionStart = heading.index + heading[0].length;
+    const nextHeading = headings
+      .slice(index + 1)
+      .find((candidate) => candidate[1].length <= level);
+    const sectionEnd = nextHeading?.index ?? source.length;
+    const section = source.slice(sectionStart, sectionEnd);
+    if (!/^>\s*\[!EXPERIMENTAL\]\s*$/im.test(section)) continue;
+
+    const withoutCallout = section
+      .replace(
+        /^>\s*\[!EXPERIMENTAL\]\s*\r?\n(?:^>.*(?:\r?\n|$))*/gim,
+        "",
+      )
+      .trim();
+    if (!withoutCallout) {
+      throw new Error(
+        `${file} has a warning-only experimental status section: ${title}`,
+      );
+    }
   }
 }
 

--- a/scripts/validate-public-docs.test.mjs
+++ b/scripts/validate-public-docs.test.mjs
@@ -322,6 +322,20 @@ test("accepts experimental page status frontmatter", async () => {
   await assert.doesNotReject(validatePublicDocs(dir));
 });
 
+test("rejects an experimental warning as the only content in a status section", async () => {
+  const dir = await createDocs(
+    {
+      "index.md": `${validPage}\n## Office status\n\n> [!EXPERIMENTAL]\n> Office is disabled by default.\n`,
+    },
+    { pages: ["index"] },
+  );
+
+  await assert.rejects(
+    validatePublicDocs(dir),
+    /index.md has a warning-only experimental status section: Office status/,
+  );
+});
+
 test("rejects published pages without title and description frontmatter", async () => {
   const dir = await createDocs(
     { "index.md": "# Kandev\n" },

--- a/scripts/validate-public-docs.test.mjs
+++ b/scripts/validate-public-docs.test.mjs
@@ -361,6 +361,20 @@ test("rejects an experimental callout dropped after unrelated section content", 
   );
 });
 
+test("rejects an experimental callout not under a descriptive section heading", async () => {
+  const dir = await createDocs(
+    {
+      "index.md": `${validPage}\n> [!EXPERIMENTAL]\n> Office is disabled by default.\n\nSome content.\n`,
+    },
+    { pages: ["index"] },
+  );
+
+  await assert.rejects(
+    validatePublicDocs(dir),
+    /index.md experimental callouts must immediately follow a descriptive heading/,
+  );
+});
+
 test("rejects published pages without title and description frontmatter", async () => {
   const dir = await createDocs(
     { "index.md": "# Kandev\n" },

--- a/scripts/validate-public-docs.test.mjs
+++ b/scripts/validate-public-docs.test.mjs
@@ -322,29 +322,43 @@ test("accepts experimental page status frontmatter", async () => {
   await assert.doesNotReject(validatePublicDocs(dir));
 });
 
-test("rejects an experimental warning as the only content in a status section", async () => {
+test("rejects an experimental callout with no substantive section content", async () => {
   const dir = await createDocs(
     {
-      "index.md": `${validPage}\n## Office status\n\n> [!EXPERIMENTAL]\n> Office is disabled by default.\n`,
+      "index.md": `${validPage}\n## Office dependencies\n\n> [!EXPERIMENTAL]\n> Office is disabled by default.\n`,
     },
     { pages: ["index"] },
   );
 
   await assert.rejects(
     validatePublicDocs(dir),
-    /index.md has a warning-only experimental status section: Office status/,
+    /index.md has an experimental callout without substantive section content: Office dependencies/,
   );
 });
 
-test("accepts an experimental status section with substantive content", async () => {
+test("accepts a feature-specific experimental section with substantive content", async () => {
   const dir = await createDocs(
     {
-      "index.md": `${validPage}\n## Office status\n\n> [!EXPERIMENTAL]\n> Office is disabled by default.\n\nUse workflow approval steps for the supported human-gated path.\n`,
+      "index.md": `${validPage}\n## Office dependencies\n\n> [!EXPERIMENTAL]\n> Office is disabled by default.\n\nUse workflow approval steps for the supported human-gated path.\n`,
     },
     { pages: ["index"] },
   );
 
   await assert.doesNotReject(validatePublicDocs(dir));
+});
+
+test("rejects an experimental callout dropped after unrelated section content", async () => {
+  const dir = await createDocs(
+    {
+      "index.md": `${validPage}\n## Configure workflows\n\nRegular workflows support human review gates.\n\n> [!EXPERIMENTAL]\n> Office is disabled by default.\n\nUse workflow approval steps for stable human gates.\n`,
+    },
+    { pages: ["index"] },
+  );
+
+  await assert.rejects(
+    validatePublicDocs(dir),
+    /index.md experimental callouts must immediately follow a descriptive heading/,
+  );
 });
 
 test("rejects published pages without title and description frontmatter", async () => {

--- a/scripts/validate-public-docs.test.mjs
+++ b/scripts/validate-public-docs.test.mjs
@@ -336,6 +336,17 @@ test("rejects an experimental warning as the only content in a status section", 
   );
 });
 
+test("accepts an experimental status section with substantive content", async () => {
+  const dir = await createDocs(
+    {
+      "index.md": `${validPage}\n## Office status\n\n> [!EXPERIMENTAL]\n> Office is disabled by default.\n\nUse workflow approval steps for the supported human-gated path.\n`,
+    },
+    { pages: ["index"] },
+  );
+
+  await assert.doesNotReject(validatePublicDocs(dir));
+});
+
 test("rejects published pages without title and description frontmatter", async () => {
   const dir = await createDocs(
     { "index.md": "# Kandev\n" },


### PR DESCRIPTION
Experimental Office badges were interrupting otherwise stable setup flows without introducing an Office feature. Badges now appear only in two Office-specific sections with real explanatory content, and source validation prevents future callouts from being dropped into unrelated prose.

## Validation

- `node --test scripts/validate-public-docs.test.mjs` (58 tests)
- `node scripts/validate-public-docs.mjs` (34 published pages)
- `make test-scripts`
- Fumadocs static export from the local Kandev source (37 docs routes)
- Generated MDX audited across every experimental marker

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1764?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->