### PR TITLE
fix(web): show border-only highlight in PR picker dialog

### DIFF
--- a/apps/web/components/task/task-pr-picker-dialog.tsx
+++ b/apps/web/components/task/task-pr-picker-dialog.tsx
@@ -79,7 +79,7 @@ export function TaskPRPickerDialog({ open, onOpenChange, prs }: TaskPRPickerDial
               data-pr-row
               data-testid={`task-pr-picker-row-${pr.id}`}
               onClick={() => openPR(pr)}
-              className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-2 text-left text-sm transition-colors hover:bg-accent focus:bg-accent focus:outline-none"
+              className="flex cursor-pointer items-center gap-2 rounded-md border border-transparent px-2 py-2 text-left text-sm transition-colors hover:border-border hover:bg-accent/40 focus:border-primary/70 focus:outline-none"
             >
               <IconGitPullRequest className={cn("h-4 w-4 shrink-0", getPRStatusColor(pr))} />
               <span className="min-w-0 flex-1 truncate">


### PR DESCRIPTION
## Summary
- The Cmd/Ctrl+Shift+G multi-PR picker dialog highlighted the focused row by filling its whole background with the accent color, making it look "full purple".
- Switched to a border-only selection style (`border-primary/70`), matching the pattern already used in other Kandev pickers (e.g. `recent-task-switcher.tsx`).

## Screenshot

![PR picker modal with border-only selection](https://raw.githubusercontent.com/kdlbs/kandev/c088baa43feb0564f7fcd1eec19b8dfbf6f6bdea/pr-picker-modal.png)

## Test plan
- [x] `pnpm exec eslint components/task/task-pr-picker-dialog.tsx`
- [x] `pnpm run typecheck` (apps/web)
- [x] Re-ran `e2e/tests/pr/pr-open-shortcut.spec.ts` ("Cmd+Shift+G with several linked PRs...") against the built app to confirm the picker still opens, keyboard navigation works, and to capture the screenshot above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)