### PR TITLE
feat(plugins): allow plugin nav items in the sidebar Integrations section

### DIFF
--- a/apps/web/components/app-sidebar/sections/integrations-section.test.tsx
+++ b/apps/web/components/app-sidebar/sections/integrations-section.test.tsx
@@ -40,6 +40,27 @@ vi.mock("@/components/integrations/integrations-menu", () => ({
   useConfiguredIntegrationLinks: linksMock,
 }));
 
+const pluginsMock = vi.hoisted(() => ({
+  enabled: true,
+  navItems: [] as Array<{
+    id: string;
+    label: string;
+    path: string;
+    icon?: string;
+    section?: string;
+  }>,
+}));
+
+vi.mock("@/hooks/domains/features/use-feature", () => ({
+  useFeature: () => pluginsMock.enabled,
+}));
+
+vi.mock("@/lib/plugins/registry", () => ({
+  usePluginRegistry: () => ({
+    getNavItems: () => pluginsMock.navItems,
+  }),
+}));
+
 vi.mock("@kandev/ui/collapsible", () => ({
   Collapsible: ({ children, open }: { children: ReactNode; open?: boolean }) => {
     collapsibleMock.open = !!open;
@@ -69,6 +90,8 @@ describe("IntegrationsSection", () => {
       { id: "github", label: "GitHub", href: "/github" },
       { id: "jira", label: "Jira", href: "/jira" },
     ]);
+    pluginsMock.enabled = true;
+    pluginsMock.navItems = [];
   });
 
   afterEach(() => cleanup());
@@ -114,5 +137,49 @@ describe("IntegrationsSection", () => {
 
     expect(screen.getAllByTestId("integration-header-shortcut")).toHaveLength(4);
     expect(screen.getByRole("link", { name: "Sentry" })).toBeTruthy();
+  });
+
+  const costPerModelItem = {
+    id: "cost-per-model",
+    label: "Cost per Model",
+    path: "/cost-per-model",
+    icon: "chart",
+    section: "integrations",
+  };
+  const costPerModelTestId = `plugin-nav-item-${costPerModelItem.id}`;
+
+  it("renders plugin nav items registered with section integrations after the first-party links", () => {
+    storeState.appSidebar.sectionExpanded.integrations = true;
+    pluginsMock.navItems = [
+      costPerModelItem,
+      { id: "hello", label: "Hello", path: "/hello", section: "main" },
+    ];
+
+    renderSection();
+
+    const pluginRow = screen.getByTestId(costPerModelTestId);
+    expect(pluginRow.getAttribute("href")).toBe(costPerModelItem.path);
+    expect(screen.queryByRole("link", { name: "Hello" })).toBeNull();
+  });
+
+  it("shows the section when only plugin integration items exist", () => {
+    storeState.appSidebar.sectionExpanded.integrations = true;
+    linksMock.mockReturnValue([]);
+    pluginsMock.navItems = [costPerModelItem];
+
+    renderSection();
+
+    expect(screen.getByTestId(costPerModelTestId)).toBeTruthy();
+  });
+
+  it("hides plugin items (and an otherwise empty section) when the plugins feature is off", () => {
+    storeState.appSidebar.sectionExpanded.integrations = true;
+    linksMock.mockReturnValue([]);
+    pluginsMock.enabled = false;
+    pluginsMock.navItems = [costPerModelItem];
+
+    const { container } = renderSection();
+
+    expect(container.textContent).toBe("");
   });
 });

--- a/apps/web/components/app-sidebar/sections/integrations-section.test.tsx
+++ b/apps/web/components/app-sidebar/sections/integrations-section.test.tsx
@@ -162,14 +162,18 @@ describe("IntegrationsSection", () => {
     expect(screen.queryByRole("link", { name: "Hello" })).toBeNull();
   });
 
-  it("shows the section when only plugin integration items exist", () => {
+  it("shows the section when only plugin integration items exist, with no empty header-action slot", () => {
     storeState.appSidebar.sectionExpanded.integrations = true;
     linksMock.mockReturnValue([]);
     pluginsMock.navItems = [costPerModelItem];
 
-    renderSection();
+    const { container } = renderSection();
 
     expect(screen.getByTestId(costPerModelTestId)).toBeTruthy();
+    // Regression for the empty headerAction slot: AppSidebarSection renders
+    // a "shrink-0 mr-1 flex items-center" wrapper whenever headerAction is
+    // non-null, even with zero shortcuts inside it.
+    expect(container.querySelector(".shrink-0.mr-1")).toBeNull();
   });
 
   it("hides plugin items (and an otherwise empty section) when the plugins feature is off", () => {

--- a/apps/web/components/app-sidebar/sections/integrations-section.test.tsx
+++ b/apps/web/components/app-sidebar/sections/integrations-section.test.tsx
@@ -52,7 +52,7 @@ const pluginsMock = vi.hoisted(() => ({
 }));
 
 vi.mock("@/hooks/domains/features/use-feature", () => ({
-  useFeature: () => pluginsMock.enabled,
+  useFeature: (flag: string) => flag === "plugins" && pluginsMock.enabled,
 }));
 
 vi.mock("@/lib/plugins/registry", () => ({

--- a/apps/web/components/app-sidebar/sections/integrations-section.tsx
+++ b/apps/web/components/app-sidebar/sections/integrations-section.tsx
@@ -108,7 +108,7 @@ export function IntegrationsSection({ collapsed }: IntegrationsSectionProps) {
       label="Integrations"
       collapsed={collapsed}
       icon={IconPlugConnected}
-      headerAction={<IntegrationHeaderShortcuts links={links} />}
+      headerAction={links.length > 0 ? <IntegrationHeaderShortcuts links={links} /> : undefined}
       headerActionVisibility="always"
     >
       {links.map(({ id, label, href }) => (

--- a/apps/web/components/app-sidebar/sections/integrations-section.tsx
+++ b/apps/web/components/app-sidebar/sections/integrations-section.tsx
@@ -12,6 +12,9 @@ import {
 import type { Icon as TablerIcon } from "@tabler/icons-react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
 import { useConfiguredIntegrationLinks } from "@/components/integrations/integrations-menu";
+import { useFeature } from "@/hooks/domains/features/use-feature";
+import { resolvePluginIcon } from "@/lib/plugins/icons";
+import { usePluginRegistry } from "@/lib/plugins/registry";
 import { cn } from "@/lib/utils";
 import {
   APP_SIDEBAR_SECTION_IDS,
@@ -60,11 +63,44 @@ function IntegrationHeaderShortcuts({ links }: { links: ConfiguredIntegrationLin
   );
 }
 
+type IntegrationRowProps = {
+  href: string;
+  label: string;
+  icon: TablerIcon;
+  active: boolean;
+  testId?: string;
+};
+
+function IntegrationRow({ href, label, icon: Icon, active, testId }: IntegrationRowProps) {
+  return (
+    <Link
+      href={href}
+      data-testid={testId}
+      className={cn(
+        "flex items-center gap-2.5 px-2.5 py-1.5 text-[13px] font-medium rounded-md cursor-pointer",
+        active ? SIDEBAR_ITEM_ACTIVE : SIDEBAR_ITEM_INACTIVE,
+      )}
+    >
+      <Icon className="h-4 w-4 shrink-0" />
+      <span className="flex-1 truncate">{label}</span>
+    </Link>
+  );
+}
+
 export function IntegrationsSection({ collapsed }: IntegrationsSectionProps) {
   const pathname = usePathname();
   const links = useConfiguredIntegrationLinks();
+  // Plugin-registered nav items that target this section
+  // (`registerNavItem({ section: "integrations" })`), rendered after the
+  // first-party links. Gated on the "plugins" feature flag like every other
+  // plugin surface.
+  const pluginsEnabled = useFeature("plugins");
+  const registry = usePluginRegistry();
+  const pluginItems = pluginsEnabled
+    ? registry.getNavItems().filter((item) => item.section === "integrations")
+    : [];
 
-  if (links.length === 0) return null;
+  if (links.length === 0 && pluginItems.length === 0) return null;
 
   return (
     <AppSidebarSection
@@ -75,23 +111,25 @@ export function IntegrationsSection({ collapsed }: IntegrationsSectionProps) {
       headerAction={<IntegrationHeaderShortcuts links={links} />}
       headerActionVisibility="always"
     >
-      {links.map(({ id, label, href }) => {
-        const Icon = INTEGRATION_ICONS[id] ?? IconPlugConnected;
-        const isActive = pathname === href || pathname.startsWith(`${href}/`);
-        return (
-          <Link
-            key={id}
-            href={href}
-            className={cn(
-              "flex items-center gap-2.5 px-2.5 py-1.5 text-[13px] font-medium rounded-md cursor-pointer",
-              isActive ? SIDEBAR_ITEM_ACTIVE : SIDEBAR_ITEM_INACTIVE,
-            )}
-          >
-            <Icon className="h-4 w-4 shrink-0" />
-            <span className="flex-1 truncate">{label}</span>
-          </Link>
-        );
-      })}
+      {links.map(({ id, label, href }) => (
+        <IntegrationRow
+          key={id}
+          href={href}
+          label={label}
+          icon={INTEGRATION_ICONS[id] ?? IconPlugConnected}
+          active={pathname === href || pathname.startsWith(`${href}/`)}
+        />
+      ))}
+      {pluginItems.map((item) => (
+        <IntegrationRow
+          key={`plugin-${item.id}`}
+          href={item.path}
+          label={item.label}
+          icon={resolvePluginIcon(item.icon)}
+          active={pathname === item.path || pathname.startsWith(`${item.path}/`)}
+          testId={`plugin-nav-item-${item.id}`}
+        />
+      ))}
     </AppSidebarSection>
   );
 }

--- a/apps/web/lib/plugins/types.ts
+++ b/apps/web/lib/plugins/types.ts
@@ -21,7 +21,12 @@ export interface NavItem {
   path: string;
   /** Curated icon name (see `lib/plugins/icons.ts`); unknown names render the puzzle glyph. */
   icon?: string;
-  section?: "main" | "settings";
+  /**
+   * Where the item renders: "main" (default) as a top-level sidebar entry,
+   * "integrations" inside the sidebar's Integrations section alongside the
+   * first-party integration links.
+   */
+  section?: "main" | "settings" | "integrations";
 }
 
 /**

--- a/docs/plans/plugins/PLUGIN-API.md
+++ b/docs/plans/plugins/PLUGIN-API.md
@@ -82,7 +82,11 @@ fine.
 // icon: curated icon name (apps/web/lib/plugins/icons.ts — "ticket", "chart",
 // "robot", "database", ...); unknown/missing names render a puzzle glyph in
 // the sidebar.
-interface NavItem { id: string; label: string; path: string; icon?: string; section?: "main" | "settings"; }
+// section: "main" (default) renders as a top-level sidebar entry;
+// "integrations" renders inside the sidebar's Integrations section alongside
+// the first-party integration links (GitHub, Jira, ...). Hosts predating a
+// section value simply don't render items targeting it (additive change).
+interface NavItem { id: string; label: string; path: string; icon?: string; section?: "main" | "settings" | "integrations"; }
 
 // Configuration for the kandev-style title bar the host renders above a plugin
 // route. All fields optional; defaults are derived (see registerRoute below).


### PR DESCRIPTION
## Summary
- Adds `"integrations"` to the plugin `NavItem.section` contract (previously `"main" | "settings"`) — plugin-registered nav items with that section render inside the sidebar's Integrations section, after the first-party integration links (GitHub, Jira, ...), gated on the `plugins` feature flag like every other plugin surface.
- The Integrations section now also renders when it has zero configured first-party integrations but at least one plugin item targeting it (previously it hid itself whenever `links.length === 0`).
- Updated `docs/plans/plugins/PLUGIN-API.md` (the frozen contract doc) to match. Additive change — hosts predating the `"integrations"` value simply don't render items targeting it.

Built while wiring up a reference plugin (`kandev-tokscale`, a "Cost per Model" page) that wanted its nav entry alongside GitHub/Jira rather than as a top-level sidebar item.

## Test plan
- [x] `pnpm vitest run components/app-sidebar/sections/integrations-section.test.tsx` — 5/5 passing (3 new: plugin items render after first-party links, section shows with plugin-only items, plugin items hidden when the `plugins` feature flag is off)
- [x] `pnpm vitest run components/plugins lib/plugins components/app-sidebar` — 175/175 passing
- [x] `pnpm run typecheck` clean
- [x] `pnpm exec eslint` on touched files clean
- [x] Verified live end-to-end in an isolated instance: installed the `kandev-tokscale` plugin with `registerNavItem({ section: "integrations" })`, confirmed the nav item renders inside the collapsible Integrations section (screenshot below) and routes correctly.

![Cost per Model nav item inside the sidebar Integrations section](https://github.com/user-attachments/assets/placeholder)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1767?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

## Screenshot

![Cost per Model nav item inside the sidebar Integrations section, next to GitHub](https://raw.githubusercontent.com/kdlbs/kandev/f6b82b8e508fa05cf9e1b0da448326d3aa3554a0/integrations-nav-item.png)
