### PR TITLE
feat(web): surface Integrations section in mobile nav

### DIFF
--- a/apps/web/components/integrations/integrations-menu.test.ts
+++ b/apps/web/components/integrations/integrations-menu.test.ts
@@ -9,6 +9,7 @@ import {
   MobileIntegrationsSection,
 } from "./integrations-menu";
 import { pluginRegistry } from "@/lib/plugins/registry";
+import type { NavItem } from "@/lib/plugins/types";
 import type { GitHubStatus } from "@/lib/types/github";
 import { TooltipProvider } from "@kandev/ui/tooltip";
 
@@ -89,8 +90,6 @@ afterEach(() => {
   vi.clearAllMocks();
   activeWorkspaceRef.id = null;
   activeWorkspaceRef.items = [];
-  pluginRegistry.unregisterPlugin("plugin-a");
-  pluginRegistry.unregisterPlugin("plugin-b");
 });
 
 describe("getGitHubIntegrationStatus", () => {
@@ -232,14 +231,29 @@ describe("MobileIntegrationsSection", () => {
   const HELLO_LABEL = "Hello Integration";
   const HELLO_PATH = "/plugins/hello";
 
+  // Track every plugin registered through this suite so the singleton
+  // pluginRegistry is fully cleared after each test — a new test adding a new
+  // plugin id can't leak nav items into the ones that follow.
+  const registeredPluginIds: string[] = [];
+
+  function registerNavItem(pluginId: string, item: NavItem) {
+    registeredPluginIds.push(pluginId);
+    pluginRegistry.forPlugin(pluginId).registerNavItem(item);
+  }
+
   function registerHelloIntegrationItem() {
-    pluginRegistry.forPlugin("plugin-a").registerNavItem({
+    registerNavItem("plugin-a", {
       id: "hello",
       label: HELLO_LABEL,
       path: HELLO_PATH,
       section: "integrations",
     });
   }
+
+  afterEach(() => {
+    for (const id of registeredPluginIds) pluginRegistry.unregisterPlugin(id);
+    registeredPluginIds.length = 0;
+  });
 
   function renderMobileSection(onNavigate = vi.fn()) {
     return {
@@ -267,7 +281,7 @@ describe("MobileIntegrationsSection", () => {
     useFeatureMock.mockImplementation((flag: string) => flag === "plugins");
     mockAvailability({ githubReady: false, jiraAvailable: false, linearAvailable: false });
     registerHelloIntegrationItem();
-    pluginRegistry.forPlugin("plugin-b").registerNavItem({
+    registerNavItem("plugin-b", {
       id: "main-item",
       label: "Main Item",
       path: "/plugins/main",

--- a/apps/web/components/integrations/integrations-menu.test.ts
+++ b/apps/web/components/integrations/integrations-menu.test.ts
@@ -6,7 +6,9 @@ import {
   getGitHubIntegrationStatus,
   IntegrationsMenu,
   IntegrationsTopbarLinks,
+  MobileIntegrationsSection,
 } from "./integrations-menu";
+import { pluginRegistry } from "@/lib/plugins/registry";
 import type { GitHubStatus } from "@/lib/types/github";
 import { TooltipProvider } from "@kandev/ui/tooltip";
 
@@ -14,6 +16,7 @@ const useGitHubStatusMock = vi.hoisted(() => vi.fn());
 const useGitLabAvailableMock = vi.hoisted(() => vi.fn());
 const useJiraAvailableMock = vi.hoisted(() => vi.fn());
 const useLinearAvailableMock = vi.hoisted(() => vi.fn());
+const useFeatureMock = vi.hoisted(() => vi.fn());
 const activeWorkspaceRef = vi.hoisted(() => ({
   id: null as string | null,
   items: [] as Array<{ id: string }>,
@@ -33,6 +36,10 @@ vi.mock("@/hooks/domains/jira/use-jira-availability", () => ({
 
 vi.mock("@/hooks/domains/linear/use-linear-availability", () => ({
   useLinearAvailable: useLinearAvailableMock,
+}));
+
+vi.mock("@/hooks/domains/features/use-feature", () => ({
+  useFeature: useFeatureMock,
 }));
 
 vi.mock("@/components/state-provider", () => ({
@@ -82,6 +89,8 @@ afterEach(() => {
   vi.clearAllMocks();
   activeWorkspaceRef.id = null;
   activeWorkspaceRef.items = [];
+  pluginRegistry.unregisterPlugin("plugin-a");
+  pluginRegistry.unregisterPlugin("plugin-b");
 });
 
 describe("getGitHubIntegrationStatus", () => {
@@ -215,6 +224,93 @@ describe("IntegrationsTopbarLinks", () => {
     mockAvailability({ githubReady: false, jiraAvailable: false, linearAvailable: false });
 
     const { container } = renderWithTooltip(createElement(IntegrationsTopbarLinks, {}));
+    expect(container.firstChild).toBeNull();
+  });
+});
+
+describe("MobileIntegrationsSection", () => {
+  const HELLO_LABEL = "Hello Integration";
+  const HELLO_PATH = "/plugins/hello";
+
+  function registerHelloIntegrationItem() {
+    pluginRegistry.forPlugin("plugin-a").registerNavItem({
+      id: "hello",
+      label: HELLO_LABEL,
+      path: HELLO_PATH,
+      section: "integrations",
+    });
+  }
+
+  function renderMobileSection(onNavigate = vi.fn()) {
+    return {
+      onNavigate,
+      ...render(createElement(MobileIntegrationsSection, { onNavigate })),
+    };
+  }
+
+  it("renders a touch row for each configured first-party link and closes the sheet on click", () => {
+    useFeatureMock.mockReturnValue(false);
+    mockAvailability({ githubReady: true, jiraAvailable: false, linearAvailable: true });
+
+    const { onNavigate } = renderMobileSection();
+
+    const githubLink = screen.getByRole("link", { name: "GitHub" });
+    expect(githubLink.getAttribute("href")).toBe("/github");
+    expect(screen.getByRole("link", { name: "Linear" }).getAttribute("href")).toBe("/linear");
+    expect(screen.queryByRole("link", { name: "Jira" })).toBeNull();
+
+    fireEvent.click(githubLink);
+    expect(onNavigate).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders plugin nav items targeting the integrations section, gated on the plugins flag", () => {
+    useFeatureMock.mockImplementation((flag: string) => flag === "plugins");
+    mockAvailability({ githubReady: false, jiraAvailable: false, linearAvailable: false });
+    registerHelloIntegrationItem();
+    pluginRegistry.forPlugin("plugin-b").registerNavItem({
+      id: "main-item",
+      label: "Main Item",
+      path: "/plugins/main",
+      section: "main",
+    });
+
+    renderMobileSection();
+
+    const pluginLink = screen.getByTestId("plugin-nav-item-hello");
+    expect(pluginLink.getAttribute("href")).toBe(HELLO_PATH);
+    expect(screen.getByText(HELLO_LABEL)).toBeTruthy();
+    // A "main" section plugin item belongs to the top-level nav, not here.
+    expect(screen.queryByTestId("plugin-nav-item-main-item")).toBeNull();
+  });
+
+  it("hides plugin nav items when the plugins feature flag is off", () => {
+    useFeatureMock.mockReturnValue(false);
+    mockAvailability({ githubReady: true, jiraAvailable: false, linearAvailable: false });
+    registerHelloIntegrationItem();
+
+    renderMobileSection();
+
+    expect(screen.getByRole("link", { name: "GitHub" })).toBeTruthy();
+    expect(screen.queryByTestId("plugin-nav-item-hello")).toBeNull();
+  });
+
+  it("renders when only plugin items exist and no first-party links are configured", () => {
+    useFeatureMock.mockImplementation((flag: string) => flag === "plugins");
+    mockAvailability({ githubReady: false, jiraAvailable: false, linearAvailable: false });
+    registerHelloIntegrationItem();
+
+    renderMobileSection();
+
+    expect(screen.getByText("Integrations")).toBeTruthy();
+    expect(screen.getByTestId("plugin-nav-item-hello")).toBeTruthy();
+  });
+
+  it("renders nothing when there are no links and no plugin items", () => {
+    useFeatureMock.mockImplementation((flag: string) => flag === "plugins");
+    mockAvailability({ githubReady: false, jiraAvailable: false, linearAvailable: false });
+
+    const { container } = renderMobileSection();
+
     expect(container.firstChild).toBeNull();
   });
 });

--- a/apps/web/components/integrations/integrations-menu.tsx
+++ b/apps/web/components/integrations/integrations-menu.tsx
@@ -23,6 +23,10 @@ import { useLinearAvailable } from "@/hooks/domains/linear/use-linear-availabili
 import { useGitHubStatus } from "@/hooks/domains/github/use-github-status";
 import { useGitLabAvailable } from "@/hooks/domains/gitlab/use-task-mr";
 import { useAppStore } from "@/components/state-provider";
+import type { Icon as TablerIcon } from "@tabler/icons-react";
+import { useFeature } from "@/hooks/domains/features/use-feature";
+import { resolvePluginIcon } from "@/lib/plugins/icons";
+import { usePluginRegistry } from "@/lib/plugins/registry";
 import type { GitHubStatus } from "@/lib/types/github";
 
 type MobileIntegrationsSectionProps = {
@@ -210,30 +214,68 @@ export function IntegrationsTopbarLinks() {
   );
 }
 
+function MobileIntegrationRow({
+  href,
+  label,
+  icon: Icon,
+  testId,
+  onNavigate,
+}: {
+  href: string;
+  label: string;
+  icon: TablerIcon;
+  testId?: string;
+  onNavigate: () => void;
+}) {
+  return (
+    <Button asChild variant="outline" className="w-full cursor-pointer justify-start gap-2">
+      <Link href={href} onClick={onNavigate} data-testid={testId}>
+        <Icon className="h-4 w-4" />
+        <span className="flex-1 truncate text-left">{label}</span>
+      </Link>
+    </Button>
+  );
+}
+
+/**
+ * Mobile counterpart to the desktop sidebar Integrations section: the
+ * hamburger-sheet surface that exposes the first-party integration links plus
+ * any plugin-registered nav items targeting this section
+ * (`registerNavItem({ section: "integrations" })`). Plugin items are gated on
+ * the "plugins" feature flag, matching the desktop `IntegrationsSection`.
+ */
 export function MobileIntegrationsSection({ onNavigate }: MobileIntegrationsSectionProps) {
   const links = useConfiguredIntegrationLinks();
+  const pluginsEnabled = useFeature("plugins");
+  const registry = usePluginRegistry();
+  const pluginItems = pluginsEnabled
+    ? registry.getNavItems().filter((item) => item.section === "integrations")
+    : [];
 
-  if (links.length === 0) return null;
+  if (links.length === 0 && pluginItems.length === 0) return null;
 
   return (
     <div className="space-y-3">
       <div className="text-sm font-medium">Integrations</div>
-      {links.map((link) => {
-        const Icon = INTEGRATION_ICONS[link.id];
-        return (
-          <Button
-            key={link.id}
-            asChild
-            variant="outline"
-            className="w-full cursor-pointer justify-start gap-2"
-          >
-            <Link href={link.href} onClick={onNavigate}>
-              <Icon className="h-4 w-4" />
-              <span className="flex-1 text-left">{link.label}</span>
-            </Link>
-          </Button>
-        );
-      })}
+      {links.map((link) => (
+        <MobileIntegrationRow
+          key={link.id}
+          href={link.href}
+          label={link.label}
+          icon={INTEGRATION_ICONS[link.id]}
+          onNavigate={onNavigate}
+        />
+      ))}
+      {pluginItems.map((item) => (
+        <MobileIntegrationRow
+          key={`plugin-${item.id}`}
+          href={item.path}
+          label={item.label}
+          icon={resolvePluginIcon(item.icon)}
+          testId={`plugin-nav-item-${item.id}`}
+          onNavigate={onNavigate}
+        />
+      ))}
     </div>
   );
 }

--- a/apps/web/components/kanban/mobile-menu-sheet.tsx
+++ b/apps/web/components/kanban/mobile-menu-sheet.tsx
@@ -16,6 +16,7 @@ import {
   IconTimeline,
 } from "@tabler/icons-react";
 import { AppSidebarWorkspacePicker } from "@/components/app-sidebar/app-sidebar-workspace-picker";
+import { MobileIntegrationsSection } from "@/components/integrations/integrations-menu";
 import { TaskSearchInput } from "./task-search-input";
 import { useKanbanDisplaySettings } from "@/hooks/use-kanban-display-settings";
 import { linkToTasks } from "@/lib/links";
@@ -354,6 +355,8 @@ export function MobileMenuSheet({
             enablePreviewOnClick={enablePreviewOnClick}
             onTogglePreviewOnClick={onTogglePreviewOnClick}
           />
+
+          <MobileIntegrationsSection onNavigate={() => onOpenChange(false)} />
 
           <MobileUtilityActions
             showHealthIndicator={showHealthIndicator}

--- a/apps/web/e2e/tests/integrations/mobile-integrations-nav.spec.ts
+++ b/apps/web/e2e/tests/integrations/mobile-integrations-nav.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from "../../fixtures/test-base";
+import { MobileKanbanPage } from "../../pages/mobile-kanban-page";
+
+/**
+ * Mobile parity for the sidebar Integrations section. The global AppSidebar is
+ * desktop-only (`hidden md:block`), so on a phone viewport the configured
+ * integration links (GitHub/Jira/Linear/GitLab) and any plugin nav items with
+ * `section: "integrations"` are only reachable through the kanban hamburger
+ * sheet's Integrations section. This proves a first-party link surfaces there
+ * and navigates. Plugin-item filtering is covered by the component test
+ * (`components/integrations/integrations-menu.test.ts`), which does not need a
+ * real plugin subprocess.
+ */
+test.describe("Integrations section on mobile", () => {
+  test("exposes a configured integration link in the hamburger sheet and navigates", async ({
+    testPage,
+    apiClient,
+  }) => {
+    // Make GitHub report authenticated so useConfiguredIntegrationLinks yields
+    // the GitHub link before the page loads its status.
+    await apiClient.mockGitHubReset();
+    await apiClient.mockGitHubSetUser("test-user");
+
+    const kanban = new MobileKanbanPage(testPage);
+    await kanban.goto();
+
+    await kanban.mobileMenuButton.click();
+
+    // Scope to the open menu sheet so we never match the display:none desktop
+    // sidebar that shares the same "GitHub" link accessible name.
+    const sheet = testPage.getByRole("dialog");
+    await expect(sheet.getByText("Integrations", { exact: true })).toBeVisible();
+
+    const githubLink = sheet.getByRole("link", { name: "GitHub" });
+    await expect(githubLink).toBeVisible({ timeout: 10_000 });
+    expect(await githubLink.getAttribute("href")).toBe("/github");
+
+    await githubLink.click();
+
+    // Navigating closes the sheet and lands on the GitHub integration page.
+    await expect(testPage).toHaveURL(/\/github$/);
+    await expect(sheet).toBeHidden();
+    await expect(testPage.getByTestId("github-mobile-menu-button")).toBeVisible({
+      timeout: 15_000,
+    });
+  });
+});


### PR DESCRIPTION
## What

Adds a mobile-reachable entry point for the sidebar **Integrations** section. The global `AppSidebar` is desktop-only (`hidden md:block`), so on a phone viewport neither the first-party integration links (GitHub/Jira/Linear/GitLab) nor plugin nav items registered with `section: "integrations"` were reachable at all. This wires the (previously unused) `MobileIntegrationsSection` into the kanban hamburger sheet and extends it to render plugin items too.

Follow-up to #1767, which landed the `section: "integrations"` contract and the desktop `IntegrationsSection` rendering. This brings the mobile surface to parity.

## Changes

- **`integrations-menu.tsx`** — `MobileIntegrationsSection` now renders first-party links **plus** plugin nav items filtered by `section === "integrations"`, gated on the `plugins` feature flag (mirroring the desktop `IntegrationsSection`). Extracted a shared `MobileIntegrationRow`. This component existed but was dead code (exported, never imported); it's now live.
- **`mobile-menu-sheet.tsx`** — renders the section between Display Options and Utilities; tapping a link closes the sheet.
- **Tests** — 5 new component tests (first-party rows + sheet-close, plugin-item filtering, flag gating, plugin-only rendering, empty state) and a mobile Playwright spec that opens the hamburger sheet on a phone viewport and navigates via the GitHub link.

## Verification

- Mobile E2E: `1 passed` (`pnpm e2e:run --host … --project=mobile-chrome`)
- Component tests: 26 passed (integrations-menu, integrations-section, kanban-header-mobile)
- `tsc --noEmit`, ESLint (`--max-warnings 0`), Prettier: clean

## Notes

Plugin-item filtering is covered at the component level rather than E2E, since exercising it end-to-end would require the real Go plugin fixture to register an `integrations`-section nav item (the existing fixture only registers a `main`-section item). The E2E covers the first-party path, which is the primary mobile-reachability guarantee.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1771?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->