### PR TITLE
fix(web): navigate to Settings on the first gear click from a session view

### DIFF
--- a/apps/web/components/app-sidebar/app-sidebar-footer.test.tsx
+++ b/apps/web/components/app-sidebar/app-sidebar-footer.test.tsx
@@ -20,9 +20,11 @@ const state = {
 };
 
 let officeEnabled = false;
+let pathname = "/tasks/session-1";
 
 vi.mock("@/lib/routing/client-router", () => ({
   useRouter: () => ({ push: mocks.routerPush }),
+  usePathname: () => pathname,
 }));
 
 vi.mock("@/components/state-provider", () => ({
@@ -71,6 +73,7 @@ function renderFooter() {
 describe("AppSidebarFooter", () => {
   beforeEach(() => {
     officeEnabled = false;
+    pathname = "/tasks/session-1";
     state.workspaces.activeId = "kanban-1";
     state.workspaces.items = [
       { id: "kanban-1", name: "Kanban", office_workflow_id: "" },
@@ -161,5 +164,37 @@ describe("AppSidebarFooter", () => {
 
     expect(document.cookie).toContain("office-active-workspace=office-2");
     expect(mocks.routerPush).toHaveBeenCalledWith("/?workspaceId=kanban-1");
+  });
+  it("navigates to /settings when the gear opens settings mode from a non-settings route", () => {
+    pathname = "/tasks/session-1";
+    state.appSidebar.settingsMode = false;
+
+    renderFooter();
+    fireEvent.click(screen.getByTestId("sidebar-settings-gear"));
+
+    expect(mocks.routerPush).toHaveBeenCalledWith("/settings");
+    expect(mocks.toggleSettingsMode).toHaveBeenCalledOnce();
+  });
+
+  it("does not navigate when the gear reopens settings mode while already on a settings route", () => {
+    pathname = "/settings/agents";
+    state.appSidebar.settingsMode = false;
+
+    renderFooter();
+    fireEvent.click(screen.getByTestId("sidebar-settings-gear"));
+
+    expect(mocks.routerPush).not.toHaveBeenCalled();
+    expect(mocks.toggleSettingsMode).toHaveBeenCalledOnce();
+  });
+
+  it("does not navigate when the gear closes an already-open settings mode", () => {
+    pathname = "/settings";
+    state.appSidebar.settingsMode = true;
+
+    renderFooter();
+    fireEvent.click(screen.getByTestId("sidebar-settings-gear"));
+
+    expect(mocks.routerPush).not.toHaveBeenCalled();
+    expect(mocks.toggleSettingsMode).toHaveBeenCalledOnce();
   });
 });

--- a/apps/web/components/app-sidebar/app-sidebar-footer.tsx
+++ b/apps/web/components/app-sidebar/app-sidebar-footer.tsx
@@ -29,7 +29,7 @@ import {
   resolveLastKanbanWorkspace,
   workspaceHomeHref,
 } from "./app-sidebar-workspace-navigation";
-import { isSettingsRoute } from "./app-sidebar";
+import { isSettingsRoute } from "./app-sidebar-route";
 
 type AppSidebarFooterProps = {
   collapsed: boolean;

--- a/apps/web/components/app-sidebar/app-sidebar-footer.tsx
+++ b/apps/web/components/app-sidebar/app-sidebar-footer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { useRouter } from "@/lib/routing/client-router";
+import { useRouter, usePathname } from "@/lib/routing/client-router";
 import {
   IconBuildings,
   IconChartBar,
@@ -29,6 +29,7 @@ import {
   resolveLastKanbanWorkspace,
   workspaceHomeHref,
 } from "./app-sidebar-workspace-navigation";
+import { isSettingsRoute } from "./app-sidebar";
 
 type AppSidebarFooterProps = {
   collapsed: boolean;
@@ -98,6 +99,7 @@ function FooterIconButton({
 
 export function AppSidebarFooter({ collapsed, onToggleSettingsMode }: AppSidebarFooterProps) {
   const router = useRouter();
+  const pathname = usePathname();
   const workspaces = useAppStore((s) => s.workspaces);
   const workspaceId = workspaces.activeId;
   const activeWorkspace = workspaces.items.find((workspace) => workspace.id === workspaceId);
@@ -106,6 +108,17 @@ export function AppSidebarFooter({ collapsed, onToggleSettingsMode }: AppSidebar
     ? resolveLastKanbanWorkspace(workspaces.items)
     : resolveLastOfficeWorkspace(workspaces.items);
   const settingsMode = useAppStore((s) => s.appSidebar.settingsMode);
+  const enterSettings = () => {
+    // The gear only swaps the sidebar's own content; without also
+    // navigating, the main panel keeps showing whatever the user was on
+    // (e.g. a task session), so the first click looks like a no-op and a
+    // second click (on a tree leaf) is what actually reaches Settings.
+    // Match the Stats/Office buttons: one click gets you there.
+    if (!settingsMode && !isSettingsRoute(pathname)) {
+      router.push("/settings");
+    }
+    onToggleSettingsMode();
+  };
   const officeEnabled = useFeature("office");
   const releaseNotes = useReleaseNotes();
   const [improveOpen, setImproveOpen] = useState(false);
@@ -121,7 +134,7 @@ export function AppSidebarFooter({ collapsed, onToggleSettingsMode }: AppSidebar
         icon={IconSettings}
         label={settingsMode ? "Close settings" : "Settings"}
         collapsed={collapsed}
-        onClick={onToggleSettingsMode}
+        onClick={enterSettings}
         active={settingsMode}
         testId="sidebar-settings-gear"
       />

--- a/apps/web/components/app-sidebar/app-sidebar-route.ts
+++ b/apps/web/components/app-sidebar/app-sidebar-route.ts
@@ -1,0 +1,3 @@
+export function isSettingsRoute(pathname: string | null): boolean {
+  return pathname === "/settings" || Boolean(pathname?.startsWith("/settings/"));
+}

--- a/apps/web/components/app-sidebar/app-sidebar.tsx
+++ b/apps/web/components/app-sidebar/app-sidebar.tsx
@@ -40,7 +40,7 @@ const SECTION_ROUTE_MAP: Array<{ id: string; matches: (path: string) => boolean 
   { id: APP_SIDEBAR_SECTION_IDS.agents, matches: (p) => p.startsWith("/office/agents") },
 ];
 
-function isSettingsRoute(pathname: string | null): boolean {
+export function isSettingsRoute(pathname: string | null): boolean {
   return pathname === "/settings" || Boolean(pathname?.startsWith("/settings/"));
 }
 

--- a/apps/web/components/app-sidebar/app-sidebar.tsx
+++ b/apps/web/components/app-sidebar/app-sidebar.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { usePathname } from "@/lib/routing/client-router";
+import { isSettingsRoute } from "./app-sidebar-route";
 import { useAppStore } from "@/components/state-provider";
 import { useEnsureWorkspaceWorkflows } from "@/hooks/use-workflows";
 import { useInOffice } from "@/hooks/use-in-office";
@@ -39,10 +40,6 @@ const SECTION_ROUTE_MAP: Array<{ id: string; matches: (path: string) => boolean 
   { id: APP_SIDEBAR_SECTION_IDS.projects, matches: (p) => p.startsWith("/office/projects") },
   { id: APP_SIDEBAR_SECTION_IDS.agents, matches: (p) => p.startsWith("/office/agents") },
 ];
-
-export function isSettingsRoute(pathname: string | null): boolean {
-  return pathname === "/settings" || Boolean(pathname?.startsWith("/settings/"));
-}
 
 type AppSidebarNavigationProps = {
   collapsed: boolean;

--- a/apps/web/e2e/tests/settings/settings-gear-only.spec.ts
+++ b/apps/web/e2e/tests/settings/settings-gear-only.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "../../fixtures/test-base";
+import { SessionPage } from "../../pages/session-page";
 
 // Settings has no nav "Settings" section; direct settings routes keep the
 // gear-gated tree open so a hard refresh preserves settings navigation context.
@@ -70,6 +71,34 @@ test.describe("Settings sidebar takeover", () => {
     // a collapsed rail can't host the settings tree.
     await testPage.getByTestId("sidebar-settings-gear").click();
     await expect(sidebar).toHaveAttribute("data-collapsed", "false");
+    await expect(takeover).toBeVisible();
+  });
+
+  test("the gear navigates to Settings in one click from a task session view", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    // Regression: from a session view the gear used to only swap the
+    // sidebar's own tree — the main panel kept showing the task, so the
+    // click looked like a no-op. A second click (on a tree leaf) was
+    // needed to actually reach Settings. The gear must now behave like
+    // the sibling Stats/Office footer buttons and navigate in one click.
+    const task = await apiClient.createTask(seedData.workspaceId, "Gear Nav Task", {
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+    });
+
+    await testPage.goto(`/t/${task.id}`);
+    const session = new SessionPage(testPage);
+    await session.waitForLoad();
+
+    const takeover = testPage.getByTestId("app-sidebar-settings-mode");
+    await expect(takeover).toHaveCount(0);
+
+    await testPage.getByTestId("sidebar-settings-gear").click();
+
+    await expect(testPage).toHaveURL(/\/settings$/);
     await expect(takeover).toBeVisible();
   });
 


### PR DESCRIPTION
The footer settings gear only toggled the sidebar's own takeover tree, never the main panel or URL, so from a task/session view the first click looked like a no-op and only a second click (on a tree leaf) actually reached Settings; the gear now navigates to `/settings` in the same click, matching its Stats/Office siblings.

## Validation

- Reproduced live against a real dev backend + Vite build: before the fix, a single gear click from a task session view opened the sidebar takeover but left `page.url()` on the task; after the fix it lands on `/settings`.
- `apps/web/components/app-sidebar/app-sidebar-footer.test.tsx` — 3 new unit tests (navigate on entry from a non-settings route, no navigation when reopening on an existing settings route, no navigation on close).
- `apps/web/e2e/tests/settings/settings-gear-only.spec.ts` — new Playwright test creates a real task, opens its session view, clicks the gear once, and asserts the URL becomes `/settings` with the takeover visible.
- `make fmt`
- `pnpm typecheck` (apps/web)
- `pnpm lint` (apps/web)
- `pnpm test` (apps/web) — 607 files / 4944 tests passed
- `pnpm exec playwright test --config e2e/playwright.config.ts tests/settings tests/kanban/kanban-topbar-utilities.spec.ts` — 84 passed, 2 skipped, 3 flaky-then-passed (unrelated MCP config-management tests)

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1775?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

