### PR TITLE
fix: indent multi-repo change trees

### DIFF
--- a/apps/web/components/task/changes-panel-tree.test.tsx
+++ b/apps/web/components/task/changes-panel-tree.test.tsx
@@ -14,7 +14,7 @@ vi.mock("@/lib/state/dockview-store", () => ({
   useDockviewStore: () => null,
 }));
 
-import { ChangesTree } from "./changes-panel-tree";
+import { ChangesTree, RepoTreeGroup } from "./changes-panel-tree";
 
 afterEach(cleanup);
 
@@ -103,5 +103,21 @@ describe("ChangesTree", () => {
     // Even without the attribute, the spy proves the parent's hook ran for
     // this file's path during render.
     expect(isSelected).toHaveBeenCalledWith(FOO_TS);
+  });
+
+  it("indents root files beneath a repository header", () => {
+    render(
+      <RepoTreeGroup
+        {...baseProps}
+        variant="unstaged"
+        repositoryName="frontend"
+        files={[file("README.md")]}
+        collapsed={false}
+        onToggle={vi.fn()}
+        primaryLabel="Stage all"
+      />,
+    );
+
+    expect(screen.getByTestId("file-row").getAttribute("data-indent")).toBe("12");
   });
 });

--- a/apps/web/components/task/changes-panel-tree.tsx
+++ b/apps/web/components/task/changes-panel-tree.tsx
@@ -201,7 +201,11 @@ export function RepoTreeGroup(props: RepoTreeGroupProps) {
   const label = displayName || repositoryName || "Repository";
   const stop = (e: React.MouseEvent) => e.stopPropagation();
   return (
-    <div data-testid="changes-repo-group" data-repository-name={repositoryName || ""}>
+    <div
+      className="-ml-2"
+      data-testid="changes-repo-group"
+      data-repository-name={repositoryName || ""}
+    >
       <div className="flex items-center justify-between gap-2 px-1 py-0.5">
         <button
           type="button"

--- a/apps/web/components/task/changes-panel-tree.tsx
+++ b/apps/web/components/task/changes-panel-tree.tsx
@@ -86,6 +86,8 @@ type ChangesTreeProps = {
   /** Shared with the parent FileListSection so the BulkActionBar reflects
    *  selections made in tree mode. */
   multiSelect: ReturnType<typeof useMultiSelect>;
+  /** Add one tree depth when the repository header is this tree's parent. */
+  nested?: boolean;
 };
 
 export function ChangesTree({
@@ -98,7 +100,9 @@ export function ChangesTree({
   onDiscard,
   variant,
   multiSelect,
+  nested = false,
 }: ChangesTreeProps) {
+  const baseIndentPx = nested ? 12 : 0;
   const tree = useMemo(() => buildChangesTree(files), [files]);
   const { visibleRows, toggle, setExpanded } = useTree<TreeNode>({
     nodes: tree,
@@ -132,7 +136,12 @@ export function ChangesTree({
     <ul data-testid={`${variant}-file-tree`} className="space-y-0.5">
       {visibleRows.map((row) =>
         row.isDir ? (
-          <TreeDirRow key={row.path} row={row} onToggle={() => toggle(row.path)} />
+          <TreeDirRow
+            key={row.path}
+            row={row}
+            baseIndentPx={baseIndentPx}
+            onToggle={() => toggle(row.path)}
+          />
         ) : (
           <FileRow
             key={`${row.node.file?.repositoryName ?? ""}:${row.path}`}
@@ -147,7 +156,7 @@ export function ChangesTree({
             onDiscard={onDiscard}
             onEditFile={onEditFile}
             treeMode
-            indentPx={row.depth * 12}
+            indentPx={baseIndentPx + row.depth * 12}
           />
         ),
       )}
@@ -249,19 +258,28 @@ export function RepoTreeGroup(props: RepoTreeGroupProps) {
           onDiscard={props.onDiscard}
           variant={variant}
           multiSelect={props.multiSelect}
+          nested
         />
       )}
     </div>
   );
 }
 
-function TreeDirRow({ row, onToggle }: { row: VisibleRow<TreeNode>; onToggle: () => void }) {
+function TreeDirRow({
+  row,
+  baseIndentPx,
+  onToggle,
+}: {
+  row: VisibleRow<TreeNode>;
+  baseIndentPx: number;
+  onToggle: () => void;
+}) {
   return (
     <li>
       <button
         type="button"
         className="flex items-center w-full gap-1 px-1 py-0.5 -mx-1 rounded-md hover:bg-muted/60 cursor-pointer text-xs text-foreground/70"
-        style={{ paddingLeft: row.depth * 12 + 4 }}
+        style={{ paddingLeft: baseIndentPx + row.depth * 12 + 4 }}
         onClick={onToggle}
         data-testid={`tree-dir-${row.path.replace(/[/\\]/g, "-")}`}
       >

--- a/apps/web/e2e/tests/git/changes-panel-multi-repo-indent.spec.ts
+++ b/apps/web/e2e/tests/git/changes-panel-multi-repo-indent.spec.ts
@@ -8,15 +8,19 @@ import { SessionPage } from "../../pages/session-page";
 
 async function expectTreeNestedUnderRepository(panel: Locator) {
   const group = panel.getByTestId("changes-repo-group").first();
+  const sectionHeader = panel.getByTestId("unstaged-files-section-collapse-toggle");
   const repositoryLabel = group.getByTestId("changes-repo-header").locator("span").first();
   const directoryLabel = group.locator("[data-testid^='tree-dir-'] span").first();
-  const [repositoryBox, directoryBox] = await Promise.all([
+  const [sectionHeaderBox, repositoryBox, directoryBox] = await Promise.all([
+    sectionHeader.boundingBox(),
     repositoryLabel.boundingBox(),
     directoryLabel.boundingBox(),
   ]);
 
+  expect(sectionHeaderBox).not.toBeNull();
   expect(repositoryBox).not.toBeNull();
   expect(directoryBox).not.toBeNull();
+  expect(repositoryBox!.x - sectionHeaderBox!.x).toBeLessThanOrEqual(14);
   expect(directoryBox!.x).toBeGreaterThan(repositoryBox!.x);
 }
 

--- a/apps/web/e2e/tests/git/changes-panel-multi-repo-indent.spec.ts
+++ b/apps/web/e2e/tests/git/changes-panel-multi-repo-indent.spec.ts
@@ -1,0 +1,80 @@
+import { expect, test } from "../../fixtures/test-base";
+import type { Locator } from "@playwright/test";
+import fs from "node:fs";
+import path from "node:path";
+import { execSync } from "node:child_process";
+import { GitHelper, makeGitEnv } from "../../helpers/git-helper";
+import { SessionPage } from "../../pages/session-page";
+
+async function expectTreeNestedUnderRepository(panel: Locator) {
+  const group = panel.getByTestId("changes-repo-group").first();
+  const repositoryLabel = group.getByTestId("changes-repo-header").locator("span").first();
+  const directoryLabel = group.locator("[data-testid^='tree-dir-'] span").first();
+  const [repositoryBox, directoryBox] = await Promise.all([
+    repositoryLabel.boundingBox(),
+    directoryLabel.boundingBox(),
+  ]);
+
+  expect(repositoryBox).not.toBeNull();
+  expect(directoryBox).not.toBeNull();
+  expect(directoryBox!.x).toBeGreaterThan(repositoryBox!.x);
+}
+
+test("nests multi-repository changes below each repository on desktop and mobile", async ({
+  testPage,
+  apiClient,
+  seedData,
+  backend,
+}) => {
+  test.setTimeout(120_000);
+
+  const gitEnv = makeGitEnv(backend.tmpDir);
+  const extraRepoDir = path.join(backend.tmpDir, "repos", "indent-extra-repo");
+  fs.mkdirSync(extraRepoDir, { recursive: true });
+  execSync("git init -b main", { cwd: extraRepoDir, env: gitEnv });
+  execSync('git commit --allow-empty -m "init"', { cwd: extraRepoDir, env: gitEnv });
+  const extraRepo = await apiClient.createRepository(seedData.workspaceId, extraRepoDir, "main", {
+    name: "indent-extra-repo",
+  });
+
+  const task = await apiClient.createTaskWithAgent(
+    seedData.workspaceId,
+    "Multi-Repo Changes Indentation",
+    seedData.agentProfileId,
+    {
+      description: "/e2e:simple-message",
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+      repository_ids: [seedData.repositoryId, extraRepo.id],
+      executor_profile_id: seedData.worktreeExecutorProfileId,
+    },
+  );
+
+  await testPage.goto(`/t/${task.id}`);
+  const session = new SessionPage(testPage);
+  await session.waitForLoad();
+  await session.waitForChatIdle({ timeout: 30_000 });
+
+  const sessionData = (await apiClient.listTaskSessions(task.id)) as {
+    sessions: Array<{ worktrees?: Array<{ worktree_path?: string }> }>;
+  };
+  const repoPaths = (sessionData.sessions[0]?.worktrees ?? []).flatMap((worktree) =>
+    worktree.worktree_path ? [worktree.worktree_path] : [],
+  );
+  expect(repoPaths).toHaveLength(2);
+  for (const [index, repoPath] of repoPaths.entries()) {
+    new GitHelper(repoPath, gitEnv).createFile(`src/repo-${index}.ts`, `repo ${index}\n`);
+  }
+
+  await session.clickTab("Changes");
+  await expect(session.changes.getByTestId("changes-repo-group")).toHaveCount(2, {
+    timeout: 30_000,
+  });
+  await expectTreeNestedUnderRepository(session.changes);
+
+  await testPage.setViewportSize({ width: 393, height: 851 });
+  await testPage.getByRole("button", { name: "Changes" }).click();
+  const mobilePanel = testPage.getByTestId("mobile-changes-panel");
+  await expect(mobilePanel).toBeVisible();
+  await expectTreeNestedUnderRepository(mobilePanel);
+});


### PR DESCRIPTION
Multi-repository change trees rendered repository headers and their root rows at the same depth, obscuring repository ownership. Repository contents now consistently nest beneath their header.

## Validation

- `make typecheck`
- `make test`
- `make lint`
- `pnpm e2e:run tests/git/changes-panel-multi-repo-indent.spec.ts`
- No public docs change needed: this is a visual indentation correction.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1779?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->