### PR TITLE
fix(plugins): align install-dialog footer actions

### DIFF
--- a/apps/web/app/settings/plugins/page.test.tsx
+++ b/apps/web/app/settings/plugins/page.test.tsx
@@ -88,6 +88,7 @@ const NEW_PLUGIN_ID = "new-plugin";
 const SYNC_BUTTON_TESTID = "plugins-sync-button";
 const INSTALL_TRIGGER_TESTID = "install-plugin-trigger";
 const NEW_PLUGIN_URL = "https://example.test/new-plugin-1.0.0.tar.gz";
+const UPLOAD_FILENAME = "new-plugin-1.0.0.tar.gz";
 
 function activePlugin(overrides: Partial<PluginRecord> = {}): PluginRecord {
   return {
@@ -264,7 +265,7 @@ describe("PluginsSettingsPage install dialog", () => {
 
   it("installs a plugin by uploading a file: calls the API and updates the store", async () => {
     setStoreState([]);
-    const file = new File([new Uint8Array([1, 2, 3])], "new-plugin-1.0.0.tar.gz", {
+    const file = new File([new Uint8Array([1, 2, 3])], UPLOAD_FILENAME, {
       type: "application/gzip",
     });
 
@@ -281,6 +282,38 @@ describe("PluginsSettingsPage install dialog", () => {
     await vi.waitFor(() => expect(installPluginUploadSpy).toHaveBeenCalledWith(file));
     const upsertPlugin = storeState.upsertPlugin as ReturnType<typeof vi.fn>;
     expect(upsertPlugin).toHaveBeenCalledWith(expect.objectContaining({ id: NEW_PLUGIN_ID }));
+  });
+});
+
+describe("PluginsSettingsPage install dialog state reset", () => {
+  it("clears the selected file after a successful upload install so reopening starts empty", async () => {
+    setStoreState([]);
+    const file = new File([new Uint8Array([1, 2, 3])], UPLOAD_FILENAME, {
+      type: "application/gzip",
+    });
+
+    render(<PluginsSettingsPage />);
+    fireEvent.click(screen.getByTestId(INSTALL_TRIGGER_TESTID));
+    fireEvent.mouseDown(screen.getByTestId("install-plugin-tab-upload"));
+    fireEvent.change(screen.getByTestId("install-plugin-file-input"), {
+      target: { files: [file] },
+    });
+    expect(screen.getByTestId("install-plugin-dropzone").textContent).toContain(UPLOAD_FILENAME);
+    fireEvent.click(screen.getByTestId("install-plugin-upload-submit"));
+
+    // afterInstall closes the dialog by flipping the controlled `open` prop
+    // directly (not via onOpenChange), so the lifted file state must still be
+    // reset — otherwise the stale file leaks into the next open.
+    await vi.waitFor(() => expect(screen.queryByTestId("install-plugin-dialog")).toBeNull());
+
+    fireEvent.click(screen.getByTestId(INSTALL_TRIGGER_TESTID));
+    fireEvent.mouseDown(screen.getByTestId("install-plugin-tab-upload"));
+    expect(screen.getByTestId("install-plugin-dropzone").textContent).not.toContain(
+      UPLOAD_FILENAME,
+    );
+    expect((screen.getByTestId("install-plugin-upload-submit") as HTMLButtonElement).disabled).toBe(
+      true,
+    );
   });
 
   it("shows a warning toast (not a bare success toast) when the package installed but failed to start", async () => {

--- a/apps/web/components/settings/plugins/install-plugin-dialog.tsx
+++ b/apps/web/components/settings/plugins/install-plugin-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Button } from "@kandev/ui/button";
 import {
   Dialog,
@@ -44,14 +44,19 @@ export function InstallPluginDialog({
   const [url, setUrl] = useState("");
   const [file, setFile] = useState<File | null>(null);
 
-  const handleOpenChange = (next: boolean) => {
-    if (!next) {
+  // Reset the lifted input state whenever the dialog closes. This keys off the
+  // `open` prop rather than `onOpenChange` because a successful install closes
+  // the dialog by flipping the controlled `open` prop directly
+  // (usePluginActions.afterInstall), which never routes through onOpenChange —
+  // so resetting only in an onOpenChange handler would leave a stale file/url
+  // selected the next time the dialog opens.
+  useEffect(() => {
+    if (!open) {
       setUrl("");
       setFile(null);
       setTab("url");
     }
-    onOpenChange(next);
-  };
+  }, [open]);
 
   const trimmedUrl = url.trim();
   // The single Install button submits whichever tab is active; its testid,
@@ -71,7 +76,7 @@ export function InstallPluginDialog({
         };
 
   return (
-    <Dialog open={open} onOpenChange={handleOpenChange}>
+    <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-lg" data-testid="install-plugin-dialog">
         <DialogHeader>
           <DialogTitle>Install plugin</DialogTitle>
@@ -115,7 +120,7 @@ export function InstallPluginDialog({
           <Button
             type="button"
             variant="outline"
-            onClick={() => handleOpenChange(false)}
+            onClick={() => onOpenChange(false)}
             className="cursor-pointer"
           >
             Cancel

--- a/apps/web/components/settings/plugins/install-plugin-dialog.tsx
+++ b/apps/web/components/settings/plugins/install-plugin-dialog.tsx
@@ -42,14 +42,33 @@ export function InstallPluginDialog({
 }: InstallPluginDialogProps) {
   const [tab, setTab] = useState<InstallTab>("url");
   const [url, setUrl] = useState("");
+  const [file, setFile] = useState<File | null>(null);
 
   const handleOpenChange = (next: boolean) => {
     if (!next) {
       setUrl("");
+      setFile(null);
       setTab("url");
     }
     onOpenChange(next);
   };
+
+  const trimmedUrl = url.trim();
+  // The single Install button submits whichever tab is active; its testid,
+  // handler, and disabled state all derive from `tab` so the e2e/unit selectors
+  // (install-plugin-url-submit / install-plugin-upload-submit) keep working.
+  const install =
+    tab === "url"
+      ? {
+          testId: "install-plugin-url-submit",
+          onClick: () => onSubmitUrl(trimmedUrl),
+          disabled: busy || trimmedUrl.length === 0,
+        }
+      : {
+          testId: "install-plugin-upload-submit",
+          onClick: () => file && onSubmitFile(file),
+          disabled: busy || !file,
+        };
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
@@ -79,10 +98,10 @@ export function InstallPluginDialog({
             </TabsTrigger>
           </TabsList>
           <TabsContent value="url" className="pt-3">
-            <UrlTab url={url} setUrl={setUrl} busy={busy} onSubmit={onSubmitUrl} />
+            <UrlTab url={url} setUrl={setUrl} />
           </TabsContent>
           <TabsContent value="upload" className="pt-3">
-            <UploadTab busy={busy} onSubmit={onSubmitFile} />
+            <UploadTab file={file} setFile={setFile} />
           </TabsContent>
         </Tabs>
 
@@ -101,52 +120,39 @@ export function InstallPluginDialog({
           >
             Cancel
           </Button>
+          <Button
+            type="button"
+            data-testid={install.testId}
+            onClick={install.onClick}
+            disabled={install.disabled}
+            className="cursor-pointer"
+          >
+            Install
+          </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>
   );
 }
 
-function UrlTab({
-  url,
-  setUrl,
-  busy,
-  onSubmit,
-}: {
-  url: string;
-  setUrl: (v: string) => void;
-  busy: boolean;
-  onSubmit: (url: string) => void;
-}) {
+function UrlTab({ url, setUrl }: { url: string; setUrl: (v: string) => void }) {
   return (
-    <div className="space-y-3">
-      <div className="space-y-1.5">
-        <Label htmlFor="install-plugin-url">Package URL</Label>
-        <Input
-          id="install-plugin-url"
-          data-testid="install-plugin-url-input"
-          value={url}
-          onChange={(e) => setUrl(e.target.value)}
-          placeholder="https://example.com/acme-tools-1.0.0.tar.gz"
-          className="font-mono text-sm"
-        />
-      </div>
-      <Button
-        type="button"
-        data-testid="install-plugin-url-submit"
-        onClick={() => onSubmit(url.trim())}
-        disabled={busy || url.trim().length === 0}
-        className="cursor-pointer"
-      >
-        Install
-      </Button>
+    <div className="space-y-1.5">
+      <Label htmlFor="install-plugin-url">Package URL</Label>
+      <Input
+        id="install-plugin-url"
+        data-testid="install-plugin-url-input"
+        value={url}
+        onChange={(e) => setUrl(e.target.value)}
+        placeholder="https://example.com/acme-tools-1.0.0.tar.gz"
+        className="font-mono text-sm"
+      />
     </div>
   );
 }
 
-function UploadTab({ busy, onSubmit }: { busy: boolean; onSubmit: (file: File) => void }) {
+function UploadTab({ file, setFile }: { file: File | null; setFile: (file: File | null) => void }) {
   const inputRef = useRef<HTMLInputElement>(null);
-  const [file, setFile] = useState<File | null>(null);
   const [isDragging, setIsDragging] = useState(false);
 
   const handleDragOver = (e: React.DragEvent) => {
@@ -175,44 +181,33 @@ function UploadTab({ busy, onSubmit }: { busy: boolean; onSubmit: (file: File) =
   };
 
   return (
-    <div className="space-y-3">
-      <div
-        data-testid="install-plugin-dropzone"
-        onDragOver={handleDragOver}
-        onDragEnter={handleDragEnter}
-        onDragLeave={handleDragLeave}
-        onDrop={handleDrop}
-        onClick={() => inputRef.current?.click()}
-        className={cn(
-          "flex flex-col items-center justify-center gap-2 rounded-lg border border-dashed border-border/70 p-6 text-center text-sm text-muted-foreground cursor-pointer",
-          isDragging && "border-primary bg-primary/5 ring-1 ring-primary/30",
+    <div
+      data-testid="install-plugin-dropzone"
+      onDragOver={handleDragOver}
+      onDragEnter={handleDragEnter}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
+      onClick={() => inputRef.current?.click()}
+      className={cn(
+        "flex flex-col items-center justify-center gap-2 rounded-lg border border-dashed border-border/70 p-6 text-center text-sm text-muted-foreground cursor-pointer",
+        isDragging && "border-primary bg-primary/5 ring-1 ring-primary/30",
+      )}
+    >
+      <span>
+        {file ? (
+          <span className="font-mono text-foreground">{file.name}</span>
+        ) : (
+          "Drag and drop a .tar.gz package here, or click to browse"
         )}
-      >
-        <span>
-          {file ? (
-            <span className="font-mono text-foreground">{file.name}</span>
-          ) : (
-            "Drag and drop a .tar.gz package here, or click to browse"
-          )}
-        </span>
-        <input
-          ref={inputRef}
-          type="file"
-          accept=".tar.gz,.tgz,application/gzip"
-          data-testid="install-plugin-file-input"
-          onChange={(e) => setFile(e.target.files?.[0] ?? null)}
-          className="hidden"
-        />
-      </div>
-      <Button
-        type="button"
-        data-testid="install-plugin-upload-submit"
-        onClick={() => file && onSubmit(file)}
-        disabled={busy || !file}
-        className="cursor-pointer"
-      >
-        Install
-      </Button>
+      </span>
+      <input
+        ref={inputRef}
+        type="file"
+        accept=".tar.gz,.tgz,application/gzip"
+        data-testid="install-plugin-file-input"
+        onChange={(e) => setFile(e.target.files?.[0] ?? null)}
+        className="hidden"
+      />
     </div>
   );
 }


### PR DESCRIPTION
## The bug

The "Install plugin" dialog's primary action was misaligned with Cancel. Each tab body (`UrlTab` / `UploadTab`) rendered its **own** left-aligned "Install" button inside the tab content, directly under the input/dropzone, while the `DialogFooter` held **only** the right-aligned Cancel button. The two actions ended up on different rows and looked broken — Install stranded bottom-left under the dropzone, Cancel in its own footer row bottom-right.

## The fix

Consolidated both actions into a single `DialogFooter` so they align as one right-aligned pair (shadcn convention: secondary Cancel, then primary Install last).

- Lifted the tab (`url` | `upload`), URL string, and selected `File` state up into `InstallPluginDialog`. The `UrlTab` / `UploadTab` bodies now hold only their input / dropzone.
- One Install button whose `data-testid`, `onClick`, and `disabled` derive from the active tab, so both selectors are preserved exactly:
  - URL tab → `install-plugin-url-submit`, submits the trimmed URL, disabled when `busy || url.trim() === ""`.
  - Upload tab → `install-plugin-upload-submit`, submits the file, disabled when `busy || !file`.
- Install is the sole primary (`data-variant="default"`) with Cancel as `outline`, so the base `DialogContent` fires Install on Enter.
- Unchanged: `install-plugin-dialog`, the tabs and their testids, `install-plugin-url-input`, `install-plugin-dropzone`, `install-plugin-file-input`, `install-plugin-error`, and the `busy`/`error`/`onSubmitUrl`/`onSubmitFile`/`onOpenChange` props.

## Screenshots

**Desktop — URL tab** (right-aligned Cancel + Install footer pair):

![Install dialog, URL tab, desktop](https://raw.githubusercontent.com/kdlbs/kandev/64f3070a52697aa5cf2922618aedd2bf530c9d23/install-dialog-desktop-url.png)

**Desktop — Upload tab** (same footer under the dropzone):

![Install dialog, Upload tab, desktop](https://raw.githubusercontent.com/kdlbs/kandev/64f3070a52697aa5cf2922618aedd2bf530c9d23/install-dialog-desktop-upload.png)

**Mobile** (`flex-col-reverse`: Install on top, Cancel below):

![Install dialog, mobile](https://raw.githubusercontent.com/kdlbs/kandev/64f3070a52697aa5cf2922618aedd2bf530c9d23/install-dialog-mobile.png)

## Verify

- `make -C apps/backend e2e-plugin-package` + `make build-backend build-web` ✅
- `apps/web`: `pnpm run typecheck` ✅, `pnpm run lint --max-warnings 0` ✅
- `pnpm vitest run app/settings/plugins/page.test.tsx` → 15 passed ✅
- `pnpm e2e --project=chromium tests/plugins/plugins.spec.ts` → 4 passed ✅ (upload-install-closes-dialog and corrupted-package-error flows both green)

## Out of scope

Did not touch `docs/public/**` or `docs/screenshots/**` — the plugin docs PR (#1774) owns the `plugin-install-dialog.png` regeneration after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)