### PR TITLE
docs: require PR screenshots for UI changes in pr skill

### DIFF
--- a/.agents/skills/pr/SKILL.md
+++ b/.agents/skills/pr/SKILL.md
@@ -59,6 +59,7 @@ explicitly requests task tracking.
    - Remove all HTML comments/placeholders from the final body.
    - Do NOT add tool attribution footers.
    - Before creating the PR, self-check that the final body has no `<!--`, no empty required sections, and no placeholder text.
+   - If the diff touches user-visible UI, a `## Screenshots` section gets appended after the PR is created (step 6) — don't add a placeholder for it here.
    ```bash
    test -f .github/pull_request_template.md
    # Build /tmp/pr-body.md from the template, using comments as instructions
@@ -78,17 +79,38 @@ explicitly requests task tracking.
 
    A ready PR may still end with "CI pending" after fixup when no checks have failed and no review threads remain unresolved, especially after a late fixup push restarts CodeQL, E2E, or preview jobs. Continue fixing failed checks and unresolved review threads, but it is acceptable to report the PR as ready locally once full local verification is green, `failed_checks: []`, `unresolved_review_thread_count: 0`, and only queued/in-progress long-running checks remain. This includes CodeQL and preview deploy as well as E2E shards; do not wait indefinitely. Include the exact pending checks from the final re-check in the response, and stop immediately if a pending check fails or a new unresolved thread appears.
 
-6. **PR image preparation:** After creating the PR, check if `apps/web/.pr-assets/manifest.json` exists. If it does:
-   - Read the manifest to list available screenshots/GIFs
-   - Run `pnpm exec tsx apps/web/e2e/scripts/upload-pr-assets.ts <PR_NUMBER>` to validate local media and generate `apps/web/.pr-assets/embed.md`; despite its historical name, the helper does not upload files to GitHub
-   - Inspect `embed.md` before changing the PR body. Append it only when it contains an actual hosted image URL. If it contains only drag-and-drop placeholders, leave the PR body unchanged and report that manual GitHub attachment is required
-   - When hosted embed markdown is available, append it to the PR body using a body file and `gh pr edit <PR_NUMBER> --body-file <file>`
-   - If `gh pr edit --body-file` fails after PR creation, especially with the GitHub Projects classic deprecation GraphQL error, fall back to REST. Build the payload with `jq --rawfile`, never by hand-escaping shell strings:
-     ```bash
-     jq -n --rawfile body "<body-file>" '{body: $body}' > /tmp/pr-body-payload.json
-     gh api --method PATCH repos/:owner/:repo/pulls/<PR_NUMBER> --input /tmp/pr-body-payload.json
-     ```
-   - When placeholders remain, tell the user to drag and drop the image files from `.pr-assets/` into the PR description on GitHub for the images to render
+6. **Screenshots — required for any UI-visible change.** If the diff touches user-visible UI (typically under `apps/web/`, excluding e2e-only or backend-only edits), you must capture and embed screenshots that show the change actually working before treating the PR as complete — do not wait to be asked. Capture both desktop and mobile viewports whenever the change is responsive.
+
+   **Capture:**
+   - If `apps/web/.pr-assets/manifest.json` already has fresh entries for this change, reuse them.
+   - Otherwise drive the changed UI with Playwright and call the `PrAssetCapture` helper (`apps/web/e2e/helpers/pr-asset-capture.ts`, `.screenshot(name, { caption })`) from an existing or temporary spec, run with `CAPTURE_PR_ASSETS=1` so output lands in `apps/web/.pr-assets/`. Delete a purely-temporary spec after capturing.
+   - Compress PNGs before embedding: `pngquant --quality 65-90 --ext .png --force apps/web/.pr-assets/*.png`.
+
+   **Embed (GitHub only — image binaries must never merge into `main`):** GitHub has no public API to upload images into a PR body (drag-and-drop is web-UI only), so publish the images on an orphan commit that can never be merged and reference them with SHA-pinned raw URLs:
+   ```bash
+   blob=$(git hash-object -w apps/web/.pr-assets/shot.png)
+   printf '100644 blob %s\tshot.png\n' "$blob" > /tmp/tree
+   # repeat the hash-object + printf lines, appending one line per file to /tmp/tree
+   tree=$(git mktree < /tmp/tree)
+   commit=$(git commit-tree "$tree" -m "media: screenshots for PR #<N>")
+   git push origin "$commit:refs/heads/media/pr-<N>-screenshots"
+   ```
+   (A quoting glitch can make the first push report failure — retry with the literal commit SHA.) Reference each image in the PR body under a `## Screenshots` section using dash-named files (no spaces):
+   `https://raw.githubusercontent.com/<owner>/<repo>/<media-commit-sha>/shot.png`
+
+   Append the section to the PR body:
+   ```bash
+   gh pr edit <PR_NUMBER> --body-file <file>
+   ```
+   `gh pr edit` fails on this repo (GraphQL touches the deprecated Projects-classic API). Fall back to REST — build the payload with `jq --rawfile`, never by hand-escaping shell strings:
+   ```bash
+   jq -n --rawfile body "<body-file>" '{body: $body}' > /tmp/pr-body-payload.json
+   gh api --method PATCH repos/:owner/:repo/pulls/<PR_NUMBER> --input /tmp/pr-body-payload.json
+   ```
+
+   Never commit the screenshot binaries to the PR branch itself — only to the throwaway `media/pr-<N>-screenshots` ref (`git rm` them from the PR branch tip if they were committed there earlier; with squash-merge, deleting at tip is enough). The `docs/screenshots/` directory is for product/docs imagery that is meant to merge — don't confuse the two. The media branch must survive branch-cleanup sweeps; deleting it 404s the images in the PR body, so don't treat "unmerged branch" as automatically safe to delete.
+
+   If capture genuinely isn't possible in the environment (no browser, no dev server), fall back to `pnpm exec tsx apps/web/e2e/scripts/upload-pr-assets.ts <PR_NUMBER>` to generate `apps/web/.pr-assets/embed.md` with drag-and-drop placeholders, and tell the user to drag the files from `.pr-assets/` into the PR description manually.
 
 7. **Return the PR URL** when done.
 


### PR DESCRIPTION
Screenshots for UI-touching PRs were only ever embedded when a stale `.pr-assets` manifest happened to already exist, and even then the helper script only produced drag-and-drop placeholders that GitHub's API can't fill in — so PRs routinely shipped without working screenshots. This makes screenshot capture and embedding mandatory whenever a diff touches user-visible UI, and documents the orphan-commit + throwaway media-branch mechanism (already used successfully across several real PRs) as the primary embedding path.

## Important Changes

- Step 6 of `.agents/skills/pr/SKILL.md` now requires screenshots (desktop + mobile for responsive changes) for any PR touching user-visible UI, not just when a manifest already exists.
- Documents the working embed mechanism: orphan commit of images pushed to a `media/pr-<N>-screenshots` ref, referenced via SHA-pinned `raw.githubusercontent.com` URLs — since GitHub has no API to upload images into a PR body.
- The old `upload-pr-assets.ts` drag-and-drop-placeholder flow is now a last-resort fallback for when capture genuinely isn't possible.
- Step 4 gets a one-line pointer so the initial PR body doesn't try to pre-fill a screenshots placeholder.

## Validation

Docs-only change to a committed skill file; no code paths affected. Verified the referenced helper (`apps/web/e2e/helpers/pr-asset-capture.ts`) and script (`apps/web/e2e/scripts/upload-pr-assets.ts`) paths and APIs still match what's documented, and checked prior PRs (#1761, #1766, #1767, #1780) that already used the orphan-commit/media-branch mechanism successfully.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1782?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->