### PR TITLE
fix: hide workspace ownership marker from git status

### DIFF
--- a/apps/backend/internal/agent/runtime/lifecycle/manager_launch.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_launch.go
@@ -1344,14 +1344,14 @@ func (m *Manager) initializeAgentSession(ctx context.Context, execution *AgentEx
 
 // initGitRepo initializes a git repository in the given directory.
 // Creates an initial commit so the workspace has a clean git state.
-// This function is idempotent - it skips initialization if .git already exists.
+// Existing repositories are reused and keep Kandev metadata out of git status.
 func (m *Manager) initGitRepo(ctx context.Context, workspacePath string) error {
-	// Check if git repository already exists (idempotent)
 	gitDir := filepath.Join(workspacePath, ".git")
-	if info, err := os.Stat(gitDir); err == nil {
-		if info.IsDir() {
-			return nil // Already initialized
+	if info, err := os.Lstat(gitDir); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+			return fmt.Errorf("invalid git directory: %s", gitDir)
 		}
+		return excludeWorkspaceOwnershipMarker(gitDir)
 	} else if !os.IsNotExist(err) {
 		// Non-ENOENT error (permissions, I/O, etc.) - fail explicitly
 		return fmt.Errorf("failed to check for .git directory: %w", err)
@@ -1391,5 +1391,5 @@ func (m *Manager) initGitRepo(ctx context.Context, workspacePath string) error {
 		return fmt.Errorf("git commit failed: %w (output: %s)", err, string(output))
 	}
 
-	return nil
+	return excludeWorkspaceOwnershipMarker(gitDir)
 }

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_launch_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_launch_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -826,6 +827,50 @@ func TestLaunchResolveWorkspacePath_NonEphemeralRepoLessGetsScratchDir(t *testin
 	require.Equal(t, "task-xyz", marker.TaskID)
 	require.Equal(t, "ws-xyz", marker.WorkspaceID)
 	require.Equal(t, storageworkspaces.LayoutVersionScratch, marker.LayoutVersion)
+
+	statusCmd := exec.Command("git", "status", "--porcelain", "--", storageworkspaces.OwnershipMarkerFilename)
+	statusCmd.Dir = workspacePath
+	status, err := statusCmd.CombinedOutput()
+	require.NoError(t, err, "git status failed: %s", status)
+	require.Empty(t, status, "workspace ownership marker should be excluded from git status")
+}
+
+func TestInitGitRepoPreservesExistingLocalExcludes(t *testing.T) {
+	mgr := newTestManager(t)
+	workspacePath := t.TempDir()
+	require.NoError(t, mgr.initGitRepo(context.Background(), workspacePath))
+
+	excludePath := filepath.Join(workspacePath, ".git", "info", "exclude")
+	require.NoError(t, os.WriteFile(excludePath, []byte("custom.cache"), 0644))
+	require.NoError(t, mgr.initGitRepo(context.Background(), workspacePath))
+	require.NoError(t, mgr.initGitRepo(context.Background(), workspacePath))
+
+	exclude, err := os.ReadFile(excludePath)
+	require.NoError(t, err)
+	require.Contains(t, string(exclude), "custom.cache\n")
+	require.Equal(t, 1, strings.Count(string(exclude), "/"+storageworkspaces.OwnershipMarkerFilename))
+}
+
+func TestInitGitRepoRejectsSymlinkedGitDirectory(t *testing.T) {
+	mgr := newTestManager(t)
+	workspacePath := t.TempDir()
+	require.NoError(t, os.Symlink(t.TempDir(), filepath.Join(workspacePath, ".git")))
+
+	err := mgr.initGitRepo(context.Background(), workspacePath)
+	require.ErrorContains(t, err, "invalid git directory")
+}
+
+func TestInitGitRepoRejectsSymlinkedExcludeFile(t *testing.T) {
+	mgr := newTestManager(t)
+	workspacePath := t.TempDir()
+	require.NoError(t, mgr.initGitRepo(context.Background(), workspacePath))
+
+	excludePath := filepath.Join(workspacePath, ".git", "info", "exclude")
+	require.NoError(t, os.Remove(excludePath))
+	require.NoError(t, os.Symlink(filepath.Join(t.TempDir(), "external"), excludePath))
+
+	err := mgr.initGitRepo(context.Background(), workspacePath)
+	require.ErrorContains(t, err, "invalid git exclude file")
 }
 
 func TestLaunchResolveWorkspacePath_NonEphemeralWithoutWorkspaceIDReturnsEmpty(t *testing.T) {

--- a/apps/backend/internal/agent/runtime/lifecycle/scratch_git.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/scratch_git.go
@@ -2,6 +2,7 @@ package lifecycle
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -19,21 +20,21 @@ func excludeWorkspaceOwnershipMarker(gitDir string) error {
 		return err
 	}
 
-	existing, err := os.ReadFile(excludePath)
-	if err != nil && !os.IsNotExist(err) {
+	file, err := openGitExcludeNoFollow(gitDir)
+	if err != nil {
+		return fmt.Errorf("open git exclude file: %w", err)
+	}
+	existing, err := io.ReadAll(file)
+	if err != nil {
+		_ = file.Close()
 		return fmt.Errorf("read git exclude file: %w", err)
 	}
 
 	entry := "/" + storageworkspaces.OwnershipMarkerFilename
 	for line := range strings.SplitSeq(string(existing), "\n") {
 		if strings.TrimSpace(line) == entry {
-			return nil
+			return file.Close()
 		}
-	}
-
-	file, err := os.OpenFile(excludePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-	if err != nil {
-		return fmt.Errorf("open git exclude file: %w", err)
 	}
 
 	prefix := ""

--- a/apps/backend/internal/agent/runtime/lifecycle/scratch_git.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/scratch_git.go
@@ -1,0 +1,82 @@
+package lifecycle
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	storageworkspaces "github.com/kandev/kandev/internal/system/storage/workspaces"
+)
+
+func excludeWorkspaceOwnershipMarker(gitDir string) error {
+	excludePath := filepath.Join(gitDir, "info", "exclude")
+	infoDir := filepath.Dir(excludePath)
+	if err := ensureRealDirectory(infoDir, "git info directory"); err != nil {
+		return err
+	}
+	if err := validateRegularFileOrMissing(excludePath, "git exclude file"); err != nil {
+		return err
+	}
+
+	existing, err := os.ReadFile(excludePath)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("read git exclude file: %w", err)
+	}
+
+	entry := "/" + storageworkspaces.OwnershipMarkerFilename
+	for line := range strings.SplitSeq(string(existing), "\n") {
+		if strings.TrimSpace(line) == entry {
+			return nil
+		}
+	}
+
+	file, err := os.OpenFile(excludePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("open git exclude file: %w", err)
+	}
+
+	prefix := ""
+	if len(existing) > 0 && existing[len(existing)-1] != '\n' {
+		prefix = "\n"
+	}
+	if _, err := file.WriteString(prefix + entry + "\n"); err != nil {
+		_ = file.Close()
+		return fmt.Errorf("write git exclude file: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close git exclude file: %w", err)
+	}
+	return nil
+}
+
+func ensureRealDirectory(path, label string) error {
+	info, err := os.Lstat(path)
+	if os.IsNotExist(err) {
+		if err := os.MkdirAll(path, 0755); err != nil {
+			return fmt.Errorf("create %s: %w", label, err)
+		}
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("inspect %s: %w", label, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return fmt.Errorf("invalid %s: %s", label, path)
+	}
+	return nil
+}
+
+func validateRegularFileOrMissing(path, label string) error {
+	info, err := os.Lstat(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("inspect %s: %w", label, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		return fmt.Errorf("invalid %s: %s", label, path)
+	}
+	return nil
+}

--- a/apps/backend/internal/agent/runtime/lifecycle/scratch_git_unix.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/scratch_git_unix.go
@@ -1,0 +1,41 @@
+//go:build linux || darwin
+
+package lifecycle
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/unix"
+)
+
+func openGitExcludeNoFollow(gitDir string) (*os.File, error) {
+	gitFD, err := unix.Open(gitDir, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		return nil, fmt.Errorf("open git directory: %w", err)
+	}
+	defer func() { _ = unix.Close(gitFD) }()
+
+	infoFD, err := unix.Openat(gitFD, "info", unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		return nil, fmt.Errorf("open git info directory: %w", err)
+	}
+	defer func() { _ = unix.Close(infoFD) }()
+
+	fd, err := unix.Openat(
+		infoFD,
+		"exclude",
+		unix.O_RDWR|unix.O_APPEND|unix.O_CREAT|unix.O_CLOEXEC|unix.O_NOFOLLOW,
+		0644,
+	)
+	if err != nil {
+		return nil, err
+	}
+	file := os.NewFile(uintptr(fd), filepath.Join(gitDir, "info", "exclude"))
+	if file == nil {
+		_ = unix.Close(fd)
+		return nil, fmt.Errorf("create file from git exclude descriptor")
+	}
+	return file, nil
+}

--- a/apps/backend/internal/agent/runtime/lifecycle/scratch_git_unix_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/scratch_git_unix_test.go
@@ -1,0 +1,29 @@
+//go:build linux || darwin
+
+package lifecycle
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenGitExcludeNoFollowRejectsSymlink(t *testing.T) {
+	gitDir := t.TempDir()
+	infoDir := filepath.Join(gitDir, "info")
+	require.NoError(t, os.Mkdir(infoDir, 0755))
+	externalPath := filepath.Join(t.TempDir(), "external")
+	require.NoError(t, os.WriteFile(externalPath, []byte("unchanged"), 0644))
+	require.NoError(t, os.Symlink(externalPath, filepath.Join(infoDir, "exclude")))
+
+	file, err := openGitExcludeNoFollow(gitDir)
+	if file != nil {
+		require.NoError(t, file.Close())
+	}
+	require.Error(t, err)
+	external, readErr := os.ReadFile(externalPath)
+	require.NoError(t, readErr)
+	require.Equal(t, "unchanged", string(external))
+}

--- a/apps/backend/internal/agent/runtime/lifecycle/scratch_git_windows.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/scratch_git_windows.go
@@ -16,6 +16,8 @@ func openGitExcludeNoFollow(gitDir string) (*os.File, error) {
 	if err != nil {
 		return nil, err
 	}
+	// OPEN_REPARSE_POINT protects the final component. Intermediate junctions
+	// rely on the earlier Lstat checks; atomic traversal would require NtCreateFile.
 	handle, err := windows.CreateFile(
 		pathUTF16,
 		windows.GENERIC_READ|windows.FILE_APPEND_DATA,

--- a/apps/backend/internal/agent/runtime/lifecycle/scratch_git_windows.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/scratch_git_windows.go
@@ -1,0 +1,46 @@
+//go:build windows
+
+package lifecycle
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/windows"
+)
+
+func openGitExcludeNoFollow(gitDir string) (*os.File, error) {
+	path := filepath.Join(gitDir, "info", "exclude")
+	pathUTF16, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return nil, err
+	}
+	handle, err := windows.CreateFile(
+		pathUTF16,
+		windows.GENERIC_READ|windows.FILE_APPEND_DATA,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE,
+		nil,
+		windows.OPEN_ALWAYS,
+		windows.FILE_ATTRIBUTE_NORMAL|windows.FILE_FLAG_OPEN_REPARSE_POINT,
+		0,
+	)
+	if err != nil {
+		return nil, err
+	}
+	var info windows.ByHandleFileInformation
+	if err := windows.GetFileInformationByHandle(handle, &info); err != nil {
+		_ = windows.CloseHandle(handle)
+		return nil, err
+	}
+	if info.FileAttributes&windows.FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+		_ = windows.CloseHandle(handle)
+		return nil, fmt.Errorf("git exclude file is a reparse point")
+	}
+	file := os.NewFile(uintptr(handle), path)
+	if file == nil {
+		_ = windows.CloseHandle(handle)
+		return nil, fmt.Errorf("create file from git exclude handle")
+	}
+	return file, nil
+}


### PR DESCRIPTION
Kandev's ownership marker currently appears as an untracked file in persistent scratch workspaces.
Exclude the marker through local Git metadata while preserving its storage-maintenance role.

## Validation

- `make typecheck`
- `make test`
- `make -C apps/backend lint`
- `pnpm --filter @kandev/web lint`
- `go test -race ./internal/agent/runtime/lifecycle -count=1`
- Public docs review: no change required because this only hides internal metadata from Git status.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1783?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->