### PR TITLE
fix: point About documentation link to kandev.ai/docs

### DIFF
--- a/apps/web/components/settings/system/about-card.tsx
+++ b/apps/web/components/settings/system/about-card.tsx
@@ -67,7 +67,7 @@ export function AboutCard() {
           </Button>
           <Button asChild variant="outline" size="sm" className="cursor-pointer">
             <a
-              href="https://github.com/kdlbs/kandev#readme"
+              href="https://kandev.ai/docs"
               target="_blank"
               rel="noreferrer"
               data-testid="system-about-docs-link"


### PR DESCRIPTION
The About card's Documentation button linked to the GitHub readme instead of the product docs site; point it at the canonical docs URL.

## Validation

Static markup-only change (single link `href`); no logic touched, so no automated tests apply.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1786?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->