### PR TITLE
fix: treat git-describe builds as ahead of latest release

### DIFF
--- a/apps/backend/internal/system/updates/semver.go
+++ b/apps/backend/internal/system/updates/semver.go
@@ -101,6 +101,13 @@ func parseSemver(s string) ([3]int, string, int, bool) {
 	return out, pre, 0, true
 }
 
+// minGitDescribeHashLen is the smallest abbreviated commit hash `git describe`
+// emits by default (core.abbrev = 7). Requiring at least this many hex digits
+// keeps a contrived pre-release such as "1.0.0-3-ga" from being mistaken for a
+// git-describe build; kandev's Makefile runs `git describe` with the default
+// abbreviation, so real builds always meet this floor.
+const minGitDescribeHashLen = 7
+
 // gitDescribeCommits recognises the "<N>-g<hash>[-dirty]" suffix that
 // `git describe --tags` appends when the build is N commits past the nearest
 // tag. It returns the commit count and ok=true for that shape; otherwise
@@ -118,7 +125,11 @@ func gitDescribeCommits(pre string) (int, bool) {
 		return 0, false
 	}
 	hash := parts[1]
-	if len(hash) < 2 || hash[0] != 'g' || !isHexString(hash[1:]) {
+	if len(hash) == 0 || hash[0] != 'g' {
+		return 0, false
+	}
+	digits := hash[1:]
+	if len(digits) < minGitDescribeHashLen || !isHexString(digits) {
 		return 0, false
 	}
 	return n, true

--- a/apps/backend/internal/system/updates/semver.go
+++ b/apps/backend/internal/system/updates/semver.go
@@ -15,8 +15,8 @@ import (
 // golang.org/x/mod/semver — see the package README for the dependency
 // constraint. Output matches semver.Compare on well-formed v1 inputs.
 func compareSemver(a, b string) int {
-	an, ap, aok := parseSemver(a)
-	bn, bp, bok := parseSemver(b)
+	an, ap, aAhead, aok := parseSemver(a)
+	bn, bp, bAhead, bok := parseSemver(b)
 	switch {
 	case !aok && !bok:
 		return strings.Compare(a, b)
@@ -33,7 +33,20 @@ func compareSemver(a, b string) int {
 			return 1
 		}
 	}
-	// Numeric segments equal; treat absence of pre-release as higher than any.
+	// Numeric segments equal. A git-describe build ("<tag>-<N>-g<hash>") is N
+	// commits AHEAD of its base tag, so it ranks at or above the plain tag and
+	// above any real pre-release. Order such builds by commit count first.
+	if aAhead > 0 || bAhead > 0 {
+		switch {
+		case aAhead > bAhead:
+			return 1
+		case aAhead < bAhead:
+			return -1
+		default:
+			return 0
+		}
+	}
+	// Neither is a git-describe build; absence of pre-release ranks higher.
 	switch {
 	case ap == "" && bp == "":
 		return 0
@@ -46,14 +59,17 @@ func compareSemver(a, b string) int {
 }
 
 // parseSemver returns the three numeric segments, the pre-release suffix (or
-// ""), and ok=false when the input is not a recognisable major.minor.patch
-// triple. The leading "v" is optional.
-func parseSemver(s string) ([3]int, string, bool) {
+// ""), the git-describe "commits ahead" count (0 when not a git-describe
+// build), and ok=false when the input is not a recognisable major.minor.patch
+// triple. The leading "v" is optional. When the suffix is a git-describe
+// "<N>-g<hash>[-dirty]" form, the pre-release is reported as "" and the commit
+// count is returned instead, so the build sorts above its base tag.
+func parseSemver(s string) ([3]int, string, int, bool) {
 	var out [3]int
 	s = strings.TrimSpace(s)
 	s = strings.TrimPrefix(s, "v")
 	if s == "" {
-		return out, "", false
+		return out, "", 0, false
 	}
 	// Strip build metadata (semver: build metadata does not affect
 	// precedence). The remaining string may still carry a `-pre` suffix.
@@ -68,20 +84,63 @@ func parseSemver(s string) ([3]int, string, bool) {
 	}
 	parts := strings.Split(s, ".")
 	if len(parts) != 3 {
-		return out, "", false
+		return out, "", 0, false
 	}
 	for i, p := range parts {
 		n, err := strconv.Atoi(p)
 		if err != nil || n < 0 {
-			return out, "", false
+			return out, "", 0, false
 		}
 		out[i] = n
 	}
-	return out, pre, true
+	// A git-describe suffix marks a build ahead of the base tag rather than a
+	// pre-release of it.
+	if ahead, ok := gitDescribeCommits(pre); ok {
+		return out, "", ahead, true
+	}
+	return out, pre, 0, true
+}
+
+// gitDescribeCommits recognises the "<N>-g<hash>[-dirty]" suffix that
+// `git describe --tags` appends when the build is N commits past the nearest
+// tag. It returns the commit count and ok=true for that shape; otherwise
+// ok=false so the suffix is treated as an ordinary pre-release.
+func gitDescribeCommits(pre string) (int, bool) {
+	if pre == "" {
+		return 0, false
+	}
+	parts := strings.SplitN(pre, "-", 3)
+	if len(parts) < 2 {
+		return 0, false
+	}
+	n, err := strconv.Atoi(parts[0])
+	if err != nil || n < 0 {
+		return 0, false
+	}
+	hash := parts[1]
+	if len(hash) < 2 || hash[0] != 'g' || !isHexString(hash[1:]) {
+		return 0, false
+	}
+	return n, true
+}
+
+// isHexString reports whether s is a non-empty run of hexadecimal digits.
+func isHexString(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, c := range s {
+		switch {
+		case c >= '0' && c <= '9', c >= 'a' && c <= 'f', c >= 'A' && c <= 'F':
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 // isValidSemver returns true when s parses as a major.minor.patch triple.
 func isValidSemver(s string) bool {
-	_, _, ok := parseSemver(s)
+	_, _, _, ok := parseSemver(s)
 	return ok
 }

--- a/apps/backend/internal/system/updates/semver_test.go
+++ b/apps/backend/internal/system/updates/semver_test.go
@@ -1,0 +1,71 @@
+package updates
+
+import "testing"
+
+func TestCompareSemver(t *testing.T) {
+	cases := []struct {
+		name string
+		a    string
+		b    string
+		want int
+	}{
+		{"equal", "v1.0.0", "v1.0.0", 0},
+		{"equal_no_prefix", "1.2.3", "v1.2.3", 0},
+		{"patch_less", "v1.0.0", "v1.0.1", -1},
+		{"minor_greater", "v1.2.0", "v1.1.9", 1},
+		{"major_greater", "v2.0.0", "v1.9.9", 1},
+		{"prerelease_below_release", "v1.0.0-rc.1", "v1.0.0", -1},
+		{"release_above_prerelease", "v1.0.0", "v1.0.0-rc.1", 1},
+
+		// git-describe "ahead" builds must sort ABOVE their base tag.
+		{"ahead_above_tag", "v0.79.0-60-g8fae44fb1", "v0.79.0", 1},
+		{"tag_below_ahead", "v0.79.0", "v0.79.0-60-g8fae44fb1", -1},
+		{"ahead_dirty_above_tag", "v0.79.0-60-g8fae44fb1-dirty", "v0.79.0", 1},
+		// An ahead build outranks a real pre-release of the same tag.
+		{"ahead_above_prerelease", "v1.0.0-3-gdeadbee", "v1.0.0-rc.1", 1},
+		// More commits ahead wins.
+		{"more_commits_ahead", "v1.0.0-10-gabc1234", "v1.0.0-2-gdef5678", 1},
+		{"fewer_commits_ahead", "v1.0.0-2-gdef5678", "v1.0.0-10-gabc1234", -1},
+		// A newer minor release still beats an ahead build of an older tag.
+		{"newer_minor_beats_ahead", "v0.80.0", "v0.79.0-60-g8fae44fb1", 1},
+		{"ahead_below_newer_minor", "v0.79.0-60-g8fae44fb1", "v0.80.0", -1},
+
+		// Invalid inputs sort below valid ones.
+		{"invalid_below_valid", "not-a-version", "v1.0.0", -1},
+		{"valid_above_invalid", "v1.0.0", "not-a-version", 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := compareSemver(tc.a, tc.b); got != tc.want {
+				t.Errorf("compareSemver(%q,%q)=%d want %d", tc.a, tc.b, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGitDescribeCommits(t *testing.T) {
+	cases := []struct {
+		name   string
+		pre    string
+		wantN  int
+		wantOK bool
+	}{
+		{"standard", "60-g8fae44fb1", 60, true},
+		{"dirty", "60-g8fae44fb1-dirty", 60, true},
+		{"single_commit", "1-gabc1234", 1, true},
+		{"empty", "", 0, false},
+		{"real_prerelease", "rc.1", 0, false},
+		{"prerelease_with_dot", "alpha.2", 0, false},
+		{"missing_g_prefix", "60-8fae44fb1", 0, false},
+		{"non_hex_hash", "60-gzzzzzz", 0, false},
+		{"non_numeric_count", "x-gabc1234", 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotN, gotOK := gitDescribeCommits(tc.pre)
+			if gotN != tc.wantN || gotOK != tc.wantOK {
+				t.Errorf("gitDescribeCommits(%q)=(%d,%v) want (%d,%v)", tc.pre, gotN, gotOK, tc.wantN, tc.wantOK)
+			}
+		})
+	}
+}

--- a/apps/backend/internal/system/updates/semver_test.go
+++ b/apps/backend/internal/system/updates/semver_test.go
@@ -52,13 +52,17 @@ func TestGitDescribeCommits(t *testing.T) {
 	}{
 		{"standard", "60-g8fae44fb1", 60, true},
 		{"dirty", "60-g8fae44fb1-dirty", 60, true},
-		{"single_commit", "1-gabc1234", 1, true},
+		{"min_length_hash", "1-gabc1234", 1, true},
 		{"empty", "", 0, false},
 		{"real_prerelease", "rc.1", 0, false},
 		{"prerelease_with_dot", "alpha.2", 0, false},
 		{"missing_g_prefix", "60-8fae44fb1", 0, false},
-		{"non_hex_hash", "60-gzzzzzz", 0, false},
+		{"non_hex_hash", "60-gzzzzzzz", 0, false},
 		{"non_numeric_count", "x-gabc1234", 0, false},
+		// Short hashes below git's default abbreviation are treated as ordinary
+		// pre-releases, not git-describe builds.
+		{"single_char_hash", "3-ga", 0, false},
+		{"below_min_hash", "3-gabc12", 0, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/apps/backend/internal/system/updates/service_test.go
+++ b/apps/backend/internal/system/updates/service_test.go
@@ -175,6 +175,11 @@ func TestService_UpdateAvailable_Cases(t *testing.T) {
 		{"empty_current", "", "v1.0.1", false},
 		{"invalid_latest", "v1.0.0", "not-a-version", false},
 		{"no_prefix", "1.0.0", "1.0.1", true},
+		// git-describe build 60 commits ahead of the latest release: not behind.
+		{"ahead_of_latest", "v0.79.0-60-g8fae44fb1", "v0.79.0", false},
+		{"ahead_of_latest_dirty", "v0.79.0-60-g8fae44fb1-dirty", "v0.79.0", false},
+		// A dev build of an older tag is still behind a newer release.
+		{"ahead_but_older_tag", "v0.79.0-60-g8fae44fb1", "v0.80.0", true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Local/dev builds identified by a `git describe` string such as `v0.79.0-60-g8fae44fb1` were shown as "Update available" on `/settings/system/status` even though the build is 60 commits *ahead* of the latest release — the version comparator parsed the `-60-g8fae44fb1` suffix as a pre-release of `0.79.0`, which sorts below the plain tag. The comparator now treats the git-describe "commits ahead" suffix as newer than its base tag, so an ahead-of-latest build is no longer flagged.

## Important Changes

- `parseSemver` recognizes the `-<N>-g<hash>[-dirty]` git-describe suffix as a commits-ahead marker instead of a pre-release, and `compareSemver` sorts such a build at or above its base tag (and above any real pre-release), ordering by commit count. Genuine pre-releases (`rc.1`, `alpha.2`) are unchanged.

## Validation

- `make -C apps/backend test` — full backend suite passes.
- `make -C apps/backend lint` — 0 issues.
- New `semver_test.go` covers ahead-of-latest, equal, behind, dirty, more/fewer commits ahead, newer-minor-beats-ahead, pre-release ordering, and git-describe suffix detection.
- Added `ahead_of_latest`, `ahead_of_latest_dirty`, and `ahead_but_older_tag` cases to `TestService_UpdateAvailable_Cases`.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1787?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->