### PR TITLE
fix: stop async client component error on automations settings

### DIFF
--- a/apps/web/app/settings/workspace/[id]/automations/page.test.tsx
+++ b/apps/web/app/settings/workspace/[id]/automations/page.test.tsx
@@ -1,0 +1,49 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Regression coverage for the workspace-scoped
+// /settings/workspace/[id]/automations page.
+//
+// The original implementation was an async server-style component that awaited
+// a `params` promise in its render body (`async function AutomationsPage`).
+// Rendered on the client under <Suspense>, React logged two React errors:
+// "<AutomationsPage> is an async Client Component. Only Server Components can be
+// async" and "A component was suspended by an uncached promise". The page must
+// be a plain synchronous client component that takes `workspaceId` directly and
+// delegates data loading to <AutomationsListPage>.
+
+const { listPageSpy } = vi.hoisted(() => ({ listPageSpy: vi.fn() }));
+
+vi.mock("@/components/automations/automations-list-page", () => ({
+  AutomationsListPage: (props: { workspaceId: string }) => {
+    listPageSpy(props);
+    return <div data-testid="automations-list-page">{props.workspaceId}</div>;
+  },
+}));
+
+import AutomationsPage from "./page";
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("AutomationsPage (workspace-scoped)", () => {
+  it("is a synchronous component, not an async one", () => {
+    // An async function's constructor name is "AsyncFunction"; a plain one is
+    // "Function". This is the core regression: an async client component throws.
+    expect(AutomationsPage.constructor.name).toBe("Function");
+  });
+
+  it("renders the automations list for the given workspace without suspending", () => {
+    const element = render(<AutomationsPage workspaceId="ws-42" />);
+
+    // Renders synchronously (no thrown promise / suspense fallback) and forwards
+    // the workspace id straight through to the list page.
+    expect(screen.getByTestId("automations-list-page").textContent).toBe("ws-42");
+    expect(listPageSpy).toHaveBeenCalledTimes(1);
+    expect(listPageSpy).toHaveBeenCalledWith({ workspaceId: "ws-42" });
+
+    element.unmount();
+  });
+});

--- a/apps/web/app/settings/workspace/[id]/automations/page.tsx
+++ b/apps/web/app/settings/workspace/[id]/automations/page.tsx
@@ -1,10 +1,11 @@
+"use client";
+
 import { AutomationsListPage } from "@/components/automations/automations-list-page";
 
 type Props = {
-  params: Promise<{ id: string }>;
+  workspaceId: string;
 };
 
-export default async function AutomationsPage({ params }: Props) {
-  const { id } = await params;
-  return <AutomationsListPage workspaceId={id} />;
+export default function AutomationsPage({ workspaceId }: Props) {
+  return <AutomationsListPage workspaceId={workspaceId} />;
 }

--- a/apps/web/src/settings-routes.tsx
+++ b/apps/web/src/settings-routes.tsx
@@ -355,7 +355,7 @@ function renderWorkspaceSettingsRoute(pathname: string) {
     if (section === "workflows") {
       return <WorkspaceWorkflowsRoute workspaceId={id} />;
     }
-    return <AutomationsPage params={Promise.resolve({ id })} />;
+    return <AutomationsPage workspaceId={id} />;
   }
 
   const workspaceId = matchSingle(pathname, /^\/settings\/workspace\/([^/]+)$/);


### PR DESCRIPTION
The `/settings/automations` page logged three React errors on load because the workspace-scoped automations page it redirects to was a leftover Next.js async server component; converting it to a plain synchronous client component clears the console and lets the list UI render normally.

## Important Changes

- `app/settings/workspace/[id]/automations/page.tsx` is now a synchronous client component that takes a `workspaceId` prop and delegates data loading to `AutomationsListPage` (which already loads via the `useAutomations` hook), instead of `await`-ing a `params` promise in render.
- `src/settings-routes.tsx` passes `workspaceId={id}` directly, matching the sibling repositories/workflows routes, rather than `params={Promise.resolve({ id })}`.

## Validation

- Added `app/settings/workspace/[id]/automations/page.test.tsx` — asserts the component is non-async and forwards `workspaceId` to `AutomationsListPage` without suspending.
- Temporary Playwright capture spec drove `/settings/workspace/[id]/automations` and confirmed **zero** React console errors (`async Client Component` / `uncached promise`) on load; screenshots below.
- `make fmt`, `make typecheck`, `make test` (web: 662 files / 5360 tests pass, including the new regression test), `make lint` (`eslint --max-warnings 0`) — all green.

## Possible Improvements

Low risk. The sibling `new/` and `[automationId]/` automation routes still use the same async `Promise` params pattern and would throw the identical errors if visited; out of scope here but worth a follow-up.

## Screenshots

Desktop — the automations list renders with the New Automation button and empty-state table, console clean:

![automations desktop](https://raw.githubusercontent.com/kdlbs/kandev/1ed81ce7e1566c2c5e3bf67393f34a33f98a141a/automations-desktop.png)

Mobile:

![automations mobile](https://raw.githubusercontent.com/kdlbs/kandev/1ed81ce7e1566c2c5e3bf67393f34a33f98a141a/automations-mobile.png)

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/`, and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.
