### PR TITLE
fix: gate gitlab/linear fetches on integration being configured

### DIFF
--- a/apps/web/app/gitlab/gitlab-page-client.tsx
+++ b/apps/web/app/gitlab/gitlab-page-client.tsx
@@ -121,7 +121,7 @@ function useProjectOptions(
   }, [knownProjects, projectFilter]);
 }
 
-function useGitLabPageState() {
+function useGitLabPageState(searchEnabled: boolean) {
   const [selection, setSelection] = useState<SidebarSelection>(() => ({
     kind: "mr",
     source: "preset",
@@ -143,13 +143,14 @@ function useGitLabPageState() {
   } = useSavedPresets();
 
   const presets = selection.kind === "mr" ? MR_PRESETS : ISSUE_PRESETS;
-  const search = useGitLabSearch(
-    selection.kind,
+  const search = useGitLabSearch({
+    kind: selection.kind,
     presets,
-    selection.source === "preset" ? selection.id : "",
-    committedQuery,
+    preset: selection.source === "preset" ? selection.id : "",
+    customQuery: committedQuery,
     projectFilter,
-  );
+    enabled: searchEnabled,
+  });
   const projectOptions = useProjectOptions(
     selection,
     committedQuery,
@@ -299,13 +300,12 @@ function useGitLabStatusFetch() {
 
 export function GitLabPageClient(_props: { workspaceId?: string } = {}) {
   const { status, loading: statusLoading } = useGitLabStatusFetch();
-  const state = useGitLabPageState();
+  const connected = !!(status?.authenticated || status?.token_configured);
+  const host = status?.host ?? "https://gitlab.com";
+  const state = useGitLabPageState(!statusLoading && connected);
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
 
   useEffect(() => resetKnownProjectsStore, []);
-
-  const connected = !!(status?.authenticated || status?.token_configured);
-  const host = status?.host ?? "https://gitlab.com";
 
   const onOpenMobileSidebar = useCallback(() => setMobileSidebarOpen(true), []);
   const { onSelect, onOpenSaveDialog } = state;

--- a/apps/web/app/linear/linear-page-client.tsx
+++ b/apps/web/app/linear/linear-page-client.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "@/components/routing/app-link";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { IconExternalLink, IconHexagon, IconPlus, IconSearch } from "@tabler/icons-react";
 import { Alert, AlertDescription } from "@kandev/ui/alert";
 import { Avatar, AvatarFallback, AvatarImage } from "@kandev/ui/avatar";
@@ -25,11 +25,13 @@ import {
 } from "@/components/linear/linear-issue-common";
 import { LinearIssueDialog } from "@/components/linear/linear-issue-dialog";
 import { LinearQuickTaskLauncher } from "@/components/linear/linear-quick-task-launcher";
-import { getLinearConfig, listLinearTeams, searchLinearIssues } from "@/lib/api/domains/linear-api";
+import { getLinearConfig, listLinearTeams } from "@/lib/api/domains/linear-api";
+import {
+  useLinearIssueSearch,
+  type LinearSearchState,
+} from "@/components/linear/use-linear-issue-search";
 import type { LinearIssue, LinearTeam } from "@/lib/types/linear";
 import type { Workflow, WorkflowStep } from "@/lib/types/http";
-
-const PAGE_SIZE = 25;
 
 type LinearPageClientProps = {
   workspaceId?: string;
@@ -92,103 +94,6 @@ function useLinearPageData(workspaceId?: string) {
   }, [workspaceId]);
 
   return { loaded, configured, teams };
-}
-
-type SearchState = {
-  items: LinearIssue[];
-  loading: boolean;
-  error: string | null;
-  page: number;
-  pageSize: number;
-  isLast: boolean;
-  goNext: () => void;
-  goPrev: () => void;
-};
-
-// useIssueSearch is page-based: it caches each page's cursor in `tokensRef` so
-// the user can step backward without re-querying from the first page. Linear
-// returns no total count, so the UI shows a row range plus a Page N indicator.
-function useIssueSearch(
-  workspaceId: string | undefined,
-  query: string,
-  teamKey: string,
-  assigned: string,
-): SearchState {
-  const [items, setItems] = useState<LinearIssue[]>([]);
-  const [page, setPage] = useState(1);
-  const [isLast, setIsLast] = useState(true);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  // tokens[i] is the page_token for page i+1; tokens[0] is always "".
-  const tokensRef = useRef<string[]>([""]);
-  const reqRef = useRef(0);
-
-  const fetchPage = useCallback(
-    (p: number) =>
-      searchLinearIssues(
-        {
-          query: query || undefined,
-          teamKey: teamKey || undefined,
-          assigned: assigned || undefined,
-          pageToken: tokensRef.current[p - 1] || undefined,
-          maxResults: PAGE_SIZE,
-        },
-        { workspaceId },
-      ),
-    [workspaceId, query, teamKey, assigned],
-  );
-
-  const run = useCallback(
-    async (p: number) => {
-      if (!workspaceId) return;
-      const reqId = ++reqRef.current;
-      setLoading(true);
-      setError(null);
-      try {
-        const res = await fetchPage(p);
-        if (reqId !== reqRef.current) return;
-        setItems(res.issues ?? []);
-        setIsLast(res.isLast ?? true);
-        if (!res.isLast && res.nextPageToken) {
-          tokensRef.current[p] = res.nextPageToken;
-        }
-      } catch (err) {
-        if (reqId !== reqRef.current) return;
-        setError(err instanceof Error ? err.message : String(err));
-      } finally {
-        if (reqId === reqRef.current) setLoading(false);
-      }
-    },
-    [workspaceId, fetchPage],
-  );
-
-  // Reset cursor stack and snap back to page 1 when filters change.
-  useEffect(() => {
-    tokensRef.current = [""];
-    setPage(1);
-  }, [workspaceId, query, teamKey, assigned]);
-
-  // 250ms debounce keeps the keyboard input from firing a request per char.
-  useEffect(() => {
-    if (!workspaceId) return;
-    const id = setTimeout(() => void run(page), 250);
-    return () => clearTimeout(id);
-  }, [run, page, workspaceId]);
-
-  return {
-    items,
-    loading,
-    error,
-    page,
-    pageSize: PAGE_SIZE,
-    isLast,
-    goNext: () => {
-      if (!isLast) setPage((p) => p + 1);
-    },
-    goPrev: () => {
-      setPage((p) => Math.max(1, p - 1));
-    },
-  };
 }
 
 function AssigneeCell({ issue }: { issue: LinearIssue }) {
@@ -414,7 +319,7 @@ function ResultsArea({
   onOpen,
   onStartTask,
 }: {
-  search: SearchState;
+  search: LinearSearchState;
   empty: boolean;
   onOpen: (issue: LinearIssue) => void;
   onStartTask: (issue: LinearIssue) => void;
@@ -448,7 +353,10 @@ export function LinearPageClient({ workspaceId, workflows, steps }: LinearPageCl
   const [query, setQuery] = useState("");
   const [teamKey, setTeamKey] = useState("");
   const [assigned, setAssigned] = useState("me");
-  const search = useIssueSearch(workspaceId, query, teamKey, assigned);
+  // Only fetch issues once the integration is configured and available — the
+  // same condition under which the results list (rather than a notice) renders.
+  const searchEnabled = loaded && configured && available;
+  const search = useLinearIssueSearch(workspaceId, query, teamKey, assigned, searchEnabled);
 
   const [openIssue, setOpenIssue] = useState<LinearIssue | null>(null);
   const [launchIssue, setLaunchIssue] = useState<LinearIssue | null>(null);

--- a/apps/web/components/gitlab/my-gitlab/use-gitlab-search.test.ts
+++ b/apps/web/components/gitlab/my-gitlab/use-gitlab-search.test.ts
@@ -126,7 +126,9 @@ describe("useGitLabSearch — fetch wiring", () => {
 
   it("forwards preset filter to MR API", async () => {
     searchUserMRsMock.mockResolvedValue(EMPTY_PAGE);
-    renderHook(() => useGitLabSearch("mr", PRESETS, PRESET_REVIEW, ""));
+    renderHook(() =>
+      useGitLabSearch({ kind: "mr", presets: PRESETS, preset: PRESET_REVIEW, customQuery: "" }),
+    );
     await waitFor(() => expect(searchUserMRsMock).toHaveBeenCalled());
     const args = searchUserMRsMock.mock.calls[0][0] as Record<string, unknown>;
     expect(args.filter).toBe(PRESET_REVIEW);
@@ -136,11 +138,56 @@ describe("useGitLabSearch — fetch wiring", () => {
 
   it("forwards custom query and drops preset filter", async () => {
     searchUserMRsMock.mockResolvedValue(EMPTY_PAGE);
-    renderHook(() => useGitLabSearch("mr", PRESETS, PRESET_REVIEW, CUSTOM_QUERY));
+    renderHook(() =>
+      useGitLabSearch({
+        kind: "mr",
+        presets: PRESETS,
+        preset: PRESET_REVIEW,
+        customQuery: CUSTOM_QUERY,
+      }),
+    );
     await waitFor(() => expect(searchUserMRsMock).toHaveBeenCalled());
     const args = searchUserMRsMock.mock.calls[0][0] as Record<string, unknown>;
     expect(args.filter).toBe("");
     expect(args.customQuery).toBe(CUSTOM_QUERY);
+  });
+
+  it("does not fetch while disabled (integration not connected)", async () => {
+    searchUserMRsMock.mockResolvedValue(EMPTY_PAGE);
+    const { result } = renderHook(() =>
+      useGitLabSearch({
+        kind: "mr",
+        presets: PRESETS,
+        preset: PRESET_REVIEW,
+        customQuery: "",
+        enabled: false,
+      }),
+    );
+    // Give any pending effect a chance to run before asserting no call.
+    await new Promise((r) => setTimeout(r, 10));
+    expect(searchUserMRsMock).not.toHaveBeenCalled();
+    expect(searchUserIssuesMock).not.toHaveBeenCalled();
+    expect(result.current.loading).toBe(false);
+    expect(result.current.items).toEqual([]);
+  });
+
+  it("fetches once enabled flips from false to true", async () => {
+    searchUserMRsMock.mockResolvedValue(EMPTY_PAGE);
+    const { rerender } = renderHook(
+      ({ enabled }: { enabled: boolean }) =>
+        useGitLabSearch({
+          kind: "mr",
+          presets: PRESETS,
+          preset: PRESET_REVIEW,
+          customQuery: "",
+          enabled,
+        }),
+      { initialProps: { enabled: false } },
+    );
+    await new Promise((r) => setTimeout(r, 10));
+    expect(searchUserMRsMock).not.toHaveBeenCalled();
+    rerender({ enabled: true });
+    await waitFor(() => expect(searchUserMRsMock).toHaveBeenCalled());
   });
 
   it("dispatches to issues endpoint when kind is issue", async () => {
@@ -151,7 +198,14 @@ describe("useGitLabSearch — fetch wiring", () => {
       page: 1,
       per_page: 25,
     });
-    const { result } = renderHook(() => useGitLabSearch("issue", PRESETS, PRESET_ASSIGNED, ""));
+    const { result } = renderHook(() =>
+      useGitLabSearch({
+        kind: "issue",
+        presets: PRESETS,
+        preset: PRESET_ASSIGNED,
+        customQuery: "",
+      }),
+    );
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.items).toEqual([issue]);
     expect(searchUserMRsMock).not.toHaveBeenCalled();
@@ -164,7 +218,9 @@ describe("useGitLabSearch — state", () => {
   it("populates items and total on success", async () => {
     const mr = fakeMR();
     searchUserMRsMock.mockResolvedValue({ mrs: [mr], total_count: 1, page: 1, per_page: 25 });
-    const { result } = renderHook(() => useGitLabSearch("mr", PRESETS, PRESET_ASSIGNED, ""));
+    const { result } = renderHook(() =>
+      useGitLabSearch({ kind: "mr", presets: PRESETS, preset: PRESET_ASSIGNED, customQuery: "" }),
+    );
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.items).toEqual([mr]);
     expect(result.current.total).toBe(1);
@@ -173,7 +229,9 @@ describe("useGitLabSearch — state", () => {
 
   it("surfaces error message without items", async () => {
     searchUserMRsMock.mockRejectedValue(new Error("boom"));
-    const { result } = renderHook(() => useGitLabSearch("mr", PRESETS, PRESET_ASSIGNED, ""));
+    const { result } = renderHook(() =>
+      useGitLabSearch({ kind: "mr", presets: PRESETS, preset: PRESET_ASSIGNED, customQuery: "" }),
+    );
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.error).toBe("boom");
     expect(result.current.items).toEqual([]);
@@ -184,7 +242,13 @@ describe("useGitLabSearch — state", () => {
     const b = fakeMR({ project_path: "acme/web" });
     searchUserMRsMock.mockResolvedValue({ mrs: [a, b], total_count: 99, page: 1, per_page: 25 });
     const { result } = renderHook(() =>
-      useGitLabSearch("mr", PRESETS, PRESET_ASSIGNED, "", "acme/web"),
+      useGitLabSearch({
+        kind: "mr",
+        presets: PRESETS,
+        preset: PRESET_ASSIGNED,
+        customQuery: "",
+        projectFilter: "acme/web",
+      }),
     );
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.items.map((m) => m.project_path)).toEqual(["acme/web"]);
@@ -202,7 +266,8 @@ describe("useGitLabSearch — pagination & sequencing", () => {
   it("resets page to 1 when preset changes", async () => {
     searchUserMRsMock.mockResolvedValue(EMPTY_PAGE);
     const { result, rerender } = renderHook(
-      ({ p }: { p: string }) => useGitLabSearch("mr", PRESETS, p, ""),
+      ({ p }: { p: string }) =>
+        useGitLabSearch({ kind: "mr", presets: PRESETS, preset: p, customQuery: "" }),
       { initialProps: { p: PRESET_ASSIGNED } },
     );
     await waitFor(() => expect(result.current.loading).toBe(false));
@@ -228,7 +293,8 @@ describe("useGitLabSearch — pagination & sequencing", () => {
     });
 
     const { result, rerender } = renderHook(
-      ({ p }: { p: string }) => useGitLabSearch("mr", PRESETS, p, ""),
+      ({ p }: { p: string }) =>
+        useGitLabSearch({ kind: "mr", presets: PRESETS, preset: p, customQuery: "" }),
       { initialProps: { p: PRESET_ASSIGNED } },
     );
     rerender({ p: PRESET_REVIEW });

--- a/apps/web/components/gitlab/my-gitlab/use-gitlab-search.ts
+++ b/apps/web/components/gitlab/my-gitlab/use-gitlab-search.ts
@@ -122,8 +122,12 @@ export function useGitLabSearch({
   );
 
   useEffect(() => {
+    // Gate at the effect level too (mirrors the Linear hook, which guards both
+    // its run callback and its debounce effect) so a disabled integration never
+    // schedules a fetch. The callback keeps its own guard to also cover refresh().
+    if (!enabled) return;
     void fetchData({ filter: resolved.filter, customQuery: resolved.customQuery, page });
-  }, [fetchData, resolved.filter, resolved.customQuery, page]);
+  }, [fetchData, enabled, resolved.filter, resolved.customQuery, page]);
 
   const refresh = useCallback(
     () => fetchData({ filter: resolved.filter, customQuery: resolved.customQuery, page }),

--- a/apps/web/components/gitlab/my-gitlab/use-gitlab-search.ts
+++ b/apps/web/components/gitlab/my-gitlab/use-gitlab-search.ts
@@ -24,6 +24,18 @@ type FetchArgs = {
   page: number;
 };
 
+type UseGitLabSearchOptions = {
+  kind: SearchKind;
+  presets: PresetOption[];
+  preset: string;
+  customQuery: string;
+  projectFilter?: string;
+  // Gate the network fetch on the integration being connected. When GitLab is
+  // not configured the page renders the connect notice instead of the list, so
+  // firing the search would only produce failing (500) requests in the console.
+  enabled?: boolean;
+};
+
 export function pickFilter(
   presets: PresetOption[],
   preset: string,
@@ -47,13 +59,14 @@ function filterByProject(items: Item[], project: string): Item[] {
   return items.filter((it) => it.project_path === project);
 }
 
-export function useGitLabSearch(
-  kind: SearchKind,
-  presets: PresetOption[],
-  preset: string,
-  customQuery: string,
-  projectFilter: string = "",
-) {
+export function useGitLabSearch({
+  kind,
+  presets,
+  preset,
+  customQuery,
+  projectFilter = "",
+  enabled = true,
+}: UseGitLabSearchOptions) {
   const [state, setState] = useState<SearchState>({
     items: [],
     loading: false,
@@ -70,6 +83,7 @@ export function useGitLabSearch(
 
   const fetchData = useCallback(
     async ({ filter: ef, customQuery: ec, page: epage }: FetchArgs) => {
+      if (!enabled) return;
       const seq = ++requestSeq.current;
       setState((s) => ({ ...s, loading: true, error: null }));
       try {
@@ -99,7 +113,7 @@ export function useGitLabSearch(
         }));
       }
     },
-    [kind],
+    [kind, enabled],
   );
 
   const resolved = useMemo(

--- a/apps/web/components/linear/use-linear-issue-search.test.ts
+++ b/apps/web/components/linear/use-linear-issue-search.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import type { LinearIssue, LinearSearchResult } from "@/lib/types/linear";
+
+const searchLinearIssuesMock =
+  vi.fn<(params: unknown, options?: unknown) => Promise<LinearSearchResult>>();
+
+vi.mock("@/lib/api/domains/linear-api", () => ({
+  searchLinearIssues: (params: unknown, options?: unknown) =>
+    searchLinearIssuesMock(params, options),
+}));
+
+import { useLinearIssueSearch } from "./use-linear-issue-search";
+
+afterEach(() => cleanup());
+
+const WORKSPACE = "ws-1";
+
+// Reset inline at the top of each test rather than in a beforeEach: a beforeEach
+// hook shifts Vitest's post-test unhandled-rejection check so the debounced
+// reject in the error case is mis-flagged.
+function resetSearchMock() {
+  searchLinearIssuesMock.mockReset();
+}
+
+function fakeIssue(overrides: Partial<LinearIssue> = {}): LinearIssue {
+  return {
+    id: "1",
+    identifier: "ENG-1",
+    title: "Issue",
+    description: "",
+    stateId: "s1",
+    stateName: "Todo",
+    stateType: "unstarted",
+    stateCategory: "new",
+    teamId: "t1",
+    teamKey: "ENG",
+    priority: 0,
+    url: "https://linear.app/eng-1",
+    states: [],
+    ...overrides,
+  };
+}
+
+function emptyResult(): LinearSearchResult {
+  return { issues: [], maxResults: 25, isLast: true };
+}
+
+describe("useLinearIssueSearch — gating", () => {
+  it("does not fetch while disabled (integration not configured)", async () => {
+    resetSearchMock();
+    searchLinearIssuesMock.mockResolvedValue(emptyResult());
+    const { result } = renderHook(() => useLinearIssueSearch(WORKSPACE, "", "", "me", false));
+    await new Promise((r) => setTimeout(r, 300));
+    expect(searchLinearIssuesMock).not.toHaveBeenCalled();
+    expect(result.current.loading).toBe(false);
+    expect(result.current.items).toEqual([]);
+  });
+
+  it("does not fetch when workspaceId is missing even if enabled", async () => {
+    resetSearchMock();
+    searchLinearIssuesMock.mockResolvedValue(emptyResult());
+    renderHook(() => useLinearIssueSearch(undefined, "", "", "me", true));
+    await new Promise((r) => setTimeout(r, 300));
+    expect(searchLinearIssuesMock).not.toHaveBeenCalled();
+  });
+
+  it("fetches once enabled flips from false to true", async () => {
+    resetSearchMock();
+    searchLinearIssuesMock.mockResolvedValue(emptyResult());
+    const { rerender } = renderHook(
+      ({ enabled }: { enabled: boolean }) => useLinearIssueSearch(WORKSPACE, "", "", "me", enabled),
+      { initialProps: { enabled: false } },
+    );
+    await new Promise((r) => setTimeout(r, 300));
+    expect(searchLinearIssuesMock).not.toHaveBeenCalled();
+    rerender({ enabled: true });
+    await waitFor(() => expect(searchLinearIssuesMock).toHaveBeenCalled());
+  });
+});
+
+describe("useLinearIssueSearch — fetch wiring", () => {
+  it("loads issues when enabled and forwards workspace + filters", async () => {
+    resetSearchMock();
+    const issue = fakeIssue();
+    searchLinearIssuesMock.mockResolvedValue({ issues: [issue], maxResults: 25, isLast: true });
+    const { result } = renderHook(() => useLinearIssueSearch(WORKSPACE, "bug", "ENG", "me", true));
+    await waitFor(() => expect(result.current.items).toEqual([issue]));
+    const [params, options] = searchLinearIssuesMock.mock.calls[0] as [
+      Record<string, unknown>,
+      Record<string, unknown>,
+    ];
+    expect(params.query).toBe("bug");
+    expect(params.teamKey).toBe("ENG");
+    expect(params.assigned).toBe("me");
+    expect(options.workspaceId).toBe(WORKSPACE);
+    expect(result.current.loading).toBe(false);
+  });
+
+  it("surfaces error message without items", async () => {
+    resetSearchMock();
+    // Pre-attach a catch so the rejected promise is never treated as an
+    // unhandled rejection during the debounce window; the hook still observes
+    // the rejection when it awaits the same promise.
+    const rejected = Promise.reject(new Error("boom"));
+    rejected.catch(() => {});
+    searchLinearIssuesMock.mockReturnValue(rejected);
+    const { result } = renderHook(() => useLinearIssueSearch(WORKSPACE, "", "", "me", true));
+    await waitFor(() => expect(result.current.error).toBe("boom"));
+    expect(result.current.items).toEqual([]);
+  });
+});

--- a/apps/web/components/linear/use-linear-issue-search.ts
+++ b/apps/web/components/linear/use-linear-issue-search.ts
@@ -1,0 +1,111 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { searchLinearIssues } from "@/lib/api/domains/linear-api";
+import type { LinearIssue } from "@/lib/types/linear";
+
+export const LINEAR_PAGE_SIZE = 25;
+
+export type LinearSearchState = {
+  items: LinearIssue[];
+  loading: boolean;
+  error: string | null;
+  page: number;
+  pageSize: number;
+  isLast: boolean;
+  goNext: () => void;
+  goPrev: () => void;
+};
+
+// useLinearIssueSearch is page-based: it caches each page's cursor in
+// `tokensRef` so the user can step backward without re-querying from the first
+// page. Linear returns no total count, so the UI shows a row range plus a
+// Page N indicator.
+//
+// `enabled` gates the network fetch on the integration being configured and
+// available. When Linear is not configured the page renders the connect notice
+// instead of the list, so firing the search would only produce failing (503)
+// requests in the console.
+export function useLinearIssueSearch(
+  workspaceId: string | undefined,
+  query: string,
+  teamKey: string,
+  assigned: string,
+  enabled: boolean,
+): LinearSearchState {
+  const [items, setItems] = useState<LinearIssue[]>([]);
+  const [page, setPage] = useState(1);
+  const [isLast, setIsLast] = useState(true);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  // tokens[i] is the page_token for page i+1; tokens[0] is always "".
+  const tokensRef = useRef<string[]>([""]);
+  const reqRef = useRef(0);
+
+  const fetchPage = useCallback(
+    (p: number) =>
+      searchLinearIssues(
+        {
+          query: query || undefined,
+          teamKey: teamKey || undefined,
+          assigned: assigned || undefined,
+          pageToken: tokensRef.current[p - 1] || undefined,
+          maxResults: LINEAR_PAGE_SIZE,
+        },
+        { workspaceId },
+      ),
+    [workspaceId, query, teamKey, assigned],
+  );
+
+  const run = useCallback(
+    async (p: number) => {
+      if (!workspaceId || !enabled) return;
+      const reqId = ++reqRef.current;
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await fetchPage(p);
+        if (reqId !== reqRef.current) return;
+        setItems(res.issues ?? []);
+        setIsLast(res.isLast ?? true);
+        if (!res.isLast && res.nextPageToken) {
+          tokensRef.current[p] = res.nextPageToken;
+        }
+      } catch (err) {
+        if (reqId !== reqRef.current) return;
+        setError(err instanceof Error ? err.message : String(err));
+      } finally {
+        if (reqId === reqRef.current) setLoading(false);
+      }
+    },
+    [workspaceId, enabled, fetchPage],
+  );
+
+  // Reset cursor stack and snap back to page 1 when filters change.
+  useEffect(() => {
+    tokensRef.current = [""];
+    setPage(1);
+  }, [workspaceId, query, teamKey, assigned]);
+
+  // 250ms debounce keeps the keyboard input from firing a request per char.
+  useEffect(() => {
+    if (!workspaceId || !enabled) return;
+    const id = setTimeout(() => void run(page), 250);
+    return () => clearTimeout(id);
+  }, [run, page, workspaceId, enabled]);
+
+  return {
+    items,
+    loading,
+    error,
+    page,
+    pageSize: LINEAR_PAGE_SIZE,
+    isLast,
+    goNext: () => {
+      if (!isLast) setPage((p) => p + 1);
+    },
+    goPrev: () => {
+      setPage((p) => Math.max(1, p - 1));
+    },
+  };
+}


### PR DESCRIPTION
Visiting `/gitlab` or `/linear` while the integration was unconfigured still fired merge-request/issue searches on mount, spraying console errors (two 500s on GitLab, one 503 on Linear) even though the pages already rendered a "not connected/configured" notice; the fetch is now gated on the same connected/configured state that decides whether the results list renders.

## Important Changes

- `useGitLabSearch` gains an `enabled` flag and is converted to an options-object signature (to stay within the 5-param lint limit, matching the `useGitHubSearch` reference); the page enables it only once status has loaded and GitLab is connected.
- Linear's inline issue-search hook is extracted to a testable `useLinearIssueSearch` with an `enabled` flag, enabled only when the workspace is loaded, configured, and available.

## Validation

- `make fmt-web`
- `pnpm --filter @kandev/web typecheck`
- `pnpm --filter @kandev/web lint` (0 warnings)
- `pnpm --filter @kandev/web test` — 662 files, 5365 passing / 4 skipped, including new gating and fetch-wiring tests for both hooks

## Possible Improvements

Low risk: purely a client-side gate. The backend still returns non-clean 500/503 responses if a search is ever issued while unconfigured; hardening those endpoints could be a follow-up but is unnecessary now that the client never fires the request.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1789?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->