### PR TITLE
fix: prevent AppleScript injection RCE in macOS notifications

### DIFF
--- a/apps/backend/internal/notifications/providers/system_provider.go
+++ b/apps/backend/internal/notifications/providers/system_provider.go
@@ -348,12 +348,17 @@ func (p *SystemProvider) playWindowsSound(ctx context.Context, cfg systemConfig)
 // `do shell script`). This closes the AppleScript-injection RCE that arose when
 // untrusted external-integration issue titles were interpolated and escaped by
 // quote-replacement alone (a trailing backslash defeated that escaping).
+//
+// The `--` terminates osascript option parsing before the positional title/body.
+// Without it a title of e.g. "-e" would be consumed as another script-fragment
+// flag, turning the following body into AppleScript source and reopening the
+// injection; the terminator guarantees untrusted text always lands in argv.
 func osascriptNotifyArgs(title, body string) []string {
 	return []string{
 		"-e", "on run argv",
 		"-e", "display notification (item 2 of argv) with title (item 1 of argv)",
 		"-e", "end run",
-		title, body,
+		"--", title, body,
 	}
 }
 

--- a/apps/backend/internal/notifications/providers/system_provider.go
+++ b/apps/backend/internal/notifications/providers/system_provider.go
@@ -236,7 +236,7 @@ func (p *SystemProvider) sendDarwinNotification(ctx context.Context, cfg systemC
 		}
 		return runCommand(ctx, "terminal-notifier", args...)
 	}
-	return runCommand(ctx, "osascript", "-e", buildAppleScript(title, body))
+	return runCommand(ctx, "osascript", osascriptNotifyArgs(title, body)...)
 }
 
 func (p *SystemProvider) sendWindowsNotification(ctx context.Context, cfg systemConfig, title, body string) error {
@@ -339,10 +339,22 @@ func (p *SystemProvider) playWindowsSound(ctx context.Context, cfg systemConfig)
 	return runCommand(ctx, "powershell.exe", "-NoProfile", "-ExecutionPolicy", "Bypass", "-c", "[console]::beep(800,200)")
 }
 
-func buildAppleScript(title, body string) string {
-	escapedTitle := strings.ReplaceAll(title, `"`, `\"`)
-	escapedBody := strings.ReplaceAll(body, `"`, `\"`)
-	return fmt.Sprintf(`display notification "%s" with title "%s"`, escapedBody, escapedTitle)
+// osascriptNotifyArgs builds the osascript argument vector for a macOS
+// notification. Title and body are passed as run-handler arguments (item 1/2 of
+// argv) rather than interpolated into the AppleScript source. osascript treats
+// everything after the trailing `-e` script fragment as arguments to `run`, so
+// attacker-controlled title/body text is delivered as opaque string data and
+// can never break out of a string literal to execute as AppleScript (e.g.
+// `do shell script`). This closes the AppleScript-injection RCE that arose when
+// untrusted external-integration issue titles were interpolated and escaped by
+// quote-replacement alone (a trailing backslash defeated that escaping).
+func osascriptNotifyArgs(title, body string) []string {
+	return []string{
+		"-e", "on run argv",
+		"-e", "display notification (item 2 of argv) with title (item 1 of argv)",
+		"-e", "end run",
+		title, body,
+	}
 }
 
 func escapePowerShell(value string) string {

--- a/apps/backend/internal/notifications/providers/system_provider_test.go
+++ b/apps/backend/internal/notifications/providers/system_provider_test.go
@@ -82,6 +82,30 @@ func TestPoC_LegacyAppleScriptBreakout(t *testing.T) {
 		"`do shell script` would execute on the host. RCE reproduced.")
 }
 
+// splitOsascriptArgs mirrors osascript's option parsing: `-e X` builds script
+// fragments, `--` terminates option parsing so every following token is a
+// positional `run` argument. Returns the collected script fragments and run
+// args.
+func splitOsascriptArgs(args []string) (scriptFragments, runArgs []string) {
+	optsDone := false
+	for i := 0; i < len(args); i++ {
+		if optsDone {
+			runArgs = append(runArgs, args[i])
+			continue
+		}
+		switch {
+		case args[i] == "--":
+			optsDone = true
+		case args[i] == "-e" && i+1 < len(args):
+			scriptFragments = append(scriptFragments, args[i+1])
+			i++
+		default:
+			runArgs = append(runArgs, args[i])
+		}
+	}
+	return scriptFragments, runArgs
+}
+
 // TestOsascriptNotifyArgs_NoInjection is the regression guard: the fixed
 // argv-based builder must pass title/body as opaque `run` arguments, never
 // interpolated into any `-e` AppleScript source. This FAILS against the legacy
@@ -89,17 +113,7 @@ func TestPoC_LegacyAppleScriptBreakout(t *testing.T) {
 func TestOsascriptNotifyArgs_NoInjection(t *testing.T) {
 	title := "Kandev"
 	args := osascriptNotifyArgs(title, breakoutPayload)
-
-	// Split the `-e` script fragments from the trailing run arguments.
-	var scriptFragments, runArgs []string
-	for i := 0; i < len(args); i++ {
-		if args[i] == "-e" && i+1 < len(args) {
-			scriptFragments = append(scriptFragments, args[i+1])
-			i++
-			continue
-		}
-		runArgs = append(runArgs, args[i])
-	}
+	scriptFragments, runArgs := splitOsascriptArgs(args)
 
 	// 1. The untrusted title/body must appear ONLY as trailing run arguments,
 	//    byte-for-byte, and never embedded in any AppleScript source fragment.
@@ -121,4 +135,41 @@ func TestOsascriptNotifyArgs_NoInjection(t *testing.T) {
 		t.Fatalf("expected argv-referencing display notification, got: %q", joined)
 	}
 	t.Logf("safe osascript args: %#v", args)
+}
+
+// TestOsascriptNotifyArgs_OptionTerminator guards the second injection vector:
+// a title that looks like an osascript flag (e.g. "-e") must not be consumed as
+// an option. The `--` terminator must precede the untrusted text so title/body
+// always land in argv instead of becoming script fragments.
+func TestOsascriptNotifyArgs_OptionTerminator(t *testing.T) {
+	// A title of "-e" with a malicious body: without the terminator osascript
+	// would treat "-e <body>" as another script fragment, reopening injection.
+	title := "-e"
+	body := `do shell script "touch /tmp/pwn"`
+	args := osascriptNotifyArgs(title, body)
+
+	// The builder must emit a `--` terminator, and it must come before the
+	// untrusted title/body (i.e. every token after `--` is untrusted).
+	term := -1
+	for i, a := range args {
+		if a == "--" {
+			term = i
+			break
+		}
+	}
+	if term == -1 {
+		t.Fatalf("missing `--` option terminator: %#v", args)
+	}
+
+	// After the terminator, the flag-like title and body must be confined to
+	// argv, byte-for-byte, and never surface as script fragments.
+	scriptFragments, runArgs := splitOsascriptArgs(args)
+	if len(runArgs) != 2 || runArgs[0] != title || runArgs[1] != body {
+		t.Fatalf("flag-like title/body not confined to argv: %#v", runArgs)
+	}
+	for _, frag := range scriptFragments {
+		if strings.Contains(frag, "do shell script") {
+			t.Fatalf("body leaked into AppleScript source as a fragment: %q", frag)
+		}
+	}
 }

--- a/apps/backend/internal/notifications/providers/system_provider_test.go
+++ b/apps/backend/internal/notifications/providers/system_provider_test.go
@@ -1,0 +1,124 @@
+package providers
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// breakoutPayload is an attacker-controlled task title/body arriving verbatim
+// from an external integration (Sentry/Linear/Jira issue title). The leading
+// `\"` defeats quote-only escaping: escaping the quote turns `\"` into `\\"`,
+// which AppleScript reads as one escaped backslash followed by the REAL closing
+// delimiter — so the `display notification "..."` literal terminates early and
+// the remaining text runs as code. `do shell script (...)` spells `touch
+// /tmp/pwn` via quote-less ASCII-character concatenation; `--` comments out the
+// trailing ` with title "..."`.
+const breakoutPayload = `\"` + "\n" +
+	`do shell script (ASCII character 116 & ASCII character 111 & ASCII character 117 & ASCII character 99 & ASCII character 104 & ASCII character 32 & ASCII character 47 & ASCII character 116 & ASCII character 109 & ASCII character 112 & ASCII character 47 & ASCII character 112 & ASCII character 119 & ASCII character 110)` + "\n" +
+	`--`
+
+// legacyBuildAppleScript reproduces the vulnerable pre-fix implementation
+// (quote-only escaping, string interpolation) so the exploit stays documented
+// and the regression is provable in-tree.
+func legacyBuildAppleScript(title, body string) string {
+	escapedTitle := strings.ReplaceAll(title, `"`, `\"`)
+	escapedBody := strings.ReplaceAll(body, `"`, `\"`)
+	return fmt.Sprintf(`display notification "%s" with title "%s"`, escapedBody, escapedTitle)
+}
+
+// applescriptStringLiteral faithfully simulates how AppleScript scans a
+// double-quoted string literal starting at src[start] (the opening quote).
+// Inside the literal a backslash escapes the next character (\" -> ", \\ -> \);
+// an UNescaped " terminates it. Returns the decoded content and the index just
+// past the closing quote. Whatever follows that index is parsed as CODE.
+func applescriptStringLiteral(src string, start int) (content string, end int, closed bool) {
+	var b strings.Builder
+	i := start + 1 // skip opening quote
+	for i < len(src) {
+		c := src[i]
+		if c == '\\' && i+1 < len(src) {
+			b.WriteByte(src[i+1])
+			i += 2
+			continue
+		}
+		if c == '"' {
+			return b.String(), i + 1, true
+		}
+		b.WriteByte(c)
+		i++
+	}
+	return b.String(), i, false
+}
+
+// TestPoC_LegacyAppleScriptBreakout documents the vulnerability: with the old
+// interpolating builder, the crafted payload breaks out of the notification
+// string literal and exposes `do shell script` as executable AppleScript.
+func TestPoC_LegacyAppleScriptBreakout(t *testing.T) {
+	script := legacyBuildAppleScript("Kandev", breakoutPayload)
+	t.Logf("legacy osascript -e argument:\n%s", script)
+
+	const opener = `display notification "`
+	if !strings.HasPrefix(script, opener) {
+		t.Fatalf("unexpected prefix: %q", script)
+	}
+
+	content, end, closed := applescriptStringLiteral(script, len(opener)-1)
+	if !closed {
+		t.Fatalf("literal never closed: %q", script)
+	}
+	remainder := script[end:]
+
+	// The body literal terminates prematurely (decodes to a lone backslash) and
+	// `do shell script` lands OUTSIDE the string, as code.
+	if strings.Contains(content, "do shell script") {
+		t.Fatalf("payload stayed inside literal — not the bug we expect: %q", content)
+	}
+	trimmed := strings.TrimLeft(remainder, "\n\r\t ")
+	if !strings.HasPrefix(trimmed, "do shell script") {
+		t.Fatalf("expected exposed `do shell script`, got remainder=%q", remainder)
+	}
+	t.Log("CONFIRMED (legacy): display notification literal closes early; " +
+		"`do shell script` would execute on the host. RCE reproduced.")
+}
+
+// TestOsascriptNotifyArgs_NoInjection is the regression guard: the fixed
+// argv-based builder must pass title/body as opaque `run` arguments, never
+// interpolated into any `-e` AppleScript source. This FAILS against the legacy
+// interpolating implementation and PASSES after the fix.
+func TestOsascriptNotifyArgs_NoInjection(t *testing.T) {
+	title := "Kandev"
+	args := osascriptNotifyArgs(title, breakoutPayload)
+
+	// Split the `-e` script fragments from the trailing run arguments.
+	var scriptFragments, runArgs []string
+	for i := 0; i < len(args); i++ {
+		if args[i] == "-e" && i+1 < len(args) {
+			scriptFragments = append(scriptFragments, args[i+1])
+			i++
+			continue
+		}
+		runArgs = append(runArgs, args[i])
+	}
+
+	// 1. The untrusted title/body must appear ONLY as trailing run arguments,
+	//    byte-for-byte, and never embedded in any AppleScript source fragment.
+	if len(runArgs) != 2 || runArgs[0] != title || runArgs[1] != breakoutPayload {
+		t.Fatalf("title/body not passed as opaque run args: %#v", runArgs)
+	}
+	for _, frag := range scriptFragments {
+		if strings.Contains(frag, "do shell script") {
+			t.Fatalf("attacker text leaked into AppleScript source: %q", frag)
+		}
+		if strings.Contains(frag, "Kandev") || strings.Contains(frag, `\"`) {
+			t.Fatalf("title/body interpolated into AppleScript source: %q", frag)
+		}
+	}
+
+	// 2. The script fragments must reference argv, not interpolated literals.
+	joined := strings.Join(scriptFragments, "\n")
+	if !strings.Contains(joined, "item 2 of argv") || !strings.Contains(joined, "item 1 of argv") {
+		t.Fatalf("expected argv-referencing display notification, got: %q", joined)
+	}
+	t.Logf("safe osascript args: %#v", args)
+}

--- a/apps/backend/internal/notifications/providers/system_provider_test.go
+++ b/apps/backend/internal/notifications/providers/system_provider_test.go
@@ -6,17 +6,30 @@ import (
 	"testing"
 )
 
-// breakoutPayload is an attacker-controlled task title/body arriving verbatim
-// from an external integration (Sentry/Linear/Jira issue title). The leading
-// `\"` defeats quote-only escaping: escaping the quote turns `\"` into `\\"`,
-// which AppleScript reads as one escaped backslash followed by the REAL closing
-// delimiter — so the `display notification "..."` literal terminates early and
-// the remaining text runs as code. `do shell script (...)` spells `touch
-// /tmp/pwn` via quote-less ASCII-character concatenation; `--` comments out the
-// trailing ` with title "..."`.
-const breakoutPayload = `\"` + "\n" +
-	`do shell script (ASCII character 116 & ASCII character 111 & ASCII character 117 & ASCII character 99 & ASCII character 104 & ASCII character 32 & ASCII character 47 & ASCII character 116 & ASCII character 109 & ASCII character 112 & ASCII character 47 & ASCII character 112 & ASCII character 119 & ASCII character 110)` + "\n" +
-	`--`
+// doShellTouch is a quote-less `do shell script` invocation spelling
+// `touch /tmp/pwn` via `ASCII character N` concatenation. It carries no literal
+// `"`, so buildAppleScript's quote-escaping never touches it — the payload
+// survives interpolation intact.
+const doShellTouch = `do shell script (ASCII character 116 & ASCII character 111 & ASCII character 117 & ASCII character 99 & ASCII character 104 & ASCII character 32 & ASCII character 47 & ASCII character 116 & ASCII character 109 & ASCII character 112 & ASCII character 47 & ASCII character 112 & ASCII character 119 & ASCII character 110)`
+
+// breakoutPayload is the MULTI-LINE attacker input (Sentry-style: exception
+// text can contain newlines). The leading `\"` defeats quote-only escaping —
+// escaping the quote turns `\"` into `\\"`, which AppleScript reads as one
+// escaped backslash followed by the REAL closing delimiter, so the `display
+// notification "..."` literal terminates early. The newline is a STATEMENT
+// separator, so `do shell script (...)` runs as a second top-level statement;
+// `--` comments out the trailing ` with title "..."`.
+const breakoutPayload = `\"` + "\n" + doShellTouch + "\n" + `--`
+
+// singleLineBreakoutPayload is the SINGLE-LINE attacker input (Jira summary /
+// Linear title — typically no newline). It proves a newline is NOT required: the
+// same `\"` break-out lands in code context, and instead of a second statement
+// the payload injects an EXPRESSION — `& (do shell script (...))` — into the
+// body-argument position. `do shell script` executes as a side effect of
+// evaluating that expression and returns its stdout as text, which concatenates
+// with the `\`-string; the whole line stays ONE valid `display notification …
+// with title "Kandev"` statement. Expression injection needs no separator.
+const singleLineBreakoutPayload = `\" & (` + doShellTouch + `)`
 
 // legacyBuildAppleScript reproduces the vulnerable pre-fix implementation
 // (quote-only escaping, string interpolation) so the exploit stays documented
@@ -82,6 +95,58 @@ func TestPoC_LegacyAppleScriptBreakout(t *testing.T) {
 		"`do shell script` would execute on the host. RCE reproduced.")
 }
 
+// TestPoC_SingleLineExpressionInjection settles the severity question raised in
+// review: does the SINGLE-LINE case (Jira summary / Linear title, no newline)
+// still achieve host code execution, or does it merely DoS the notification?
+//
+// It does execute. A newline (statement separator) is only needed if you want a
+// SECOND statement. This payload instead injects an EXPRESSION into the existing
+// `display notification <body>` argument: after the `\"` break-out, `& (do shell
+// script (...))` concatenates the `\`-string with the TEXT that `do shell
+// script` returns — evaluating that expression runs the command as a side
+// effect. The line remains a single valid statement, so osascript compiles and
+// executes it. Conclusion: single-line inputs are host RCE, not just DoS.
+func TestPoC_SingleLineExpressionInjection(t *testing.T) {
+	script := legacyBuildAppleScript("Kandev", singleLineBreakoutPayload)
+	t.Logf("legacy osascript -e argument (single line):\n%s", script)
+
+	// No newline anywhere: this is the Jira/Linear single-line shape.
+	if strings.ContainsAny(script, "\n\r") {
+		t.Fatalf("payload unexpectedly contains a line break: %q", script)
+	}
+
+	const opener = `display notification "`
+	if !strings.HasPrefix(script, opener) {
+		t.Fatalf("unexpected prefix: %q", script)
+	}
+
+	content, end, closed := applescriptStringLiteral(script, len(opener)-1)
+	if !closed {
+		t.Fatalf("literal never closed: %q", script)
+	}
+	remainder := script[end:]
+
+	// The body literal still closes early (decodes to a lone backslash)...
+	if content != `\` {
+		t.Fatalf("expected body literal to decode to a lone backslash, got %q", content)
+	}
+	// ...and the very next token is the `&` concatenation operator — i.e. we are
+	// in EXPRESSION context with NO statement separator in between.
+	trimmed := strings.TrimLeft(remainder, " \t")
+	if !strings.HasPrefix(trimmed, "&") {
+		t.Fatalf("expected `&` expression injection immediately after literal, got %q", remainder)
+	}
+	if !strings.Contains(remainder, "do shell script") {
+		t.Fatalf("expected `do shell script` in the injected expression, got %q", remainder)
+	}
+	// The trailing ` with title "Kandev"` keeps it one valid statement.
+	if !strings.Contains(remainder, `with title "Kandev"`) {
+		t.Fatalf("expected statement to close with the title argument, got %q", remainder)
+	}
+	t.Log("CONFIRMED (legacy, single line): no newline needed — `do shell script` " +
+		"executes as an injected body expression. Single-line inputs are host RCE.")
+}
+
 // splitOsascriptArgs mirrors osascript's option parsing: `-e X` builds script
 // fragments, `--` terminates option parsing so every following token is a
 // positional `run` argument. Returns the collected script fragments and run
@@ -111,30 +176,40 @@ func splitOsascriptArgs(args []string) (scriptFragments, runArgs []string) {
 // interpolated into any `-e` AppleScript source. This FAILS against the legacy
 // interpolating implementation and PASSES after the fix.
 func TestOsascriptNotifyArgs_NoInjection(t *testing.T) {
-	title := "Kandev"
-	args := osascriptNotifyArgs(title, breakoutPayload)
-	scriptFragments, runArgs := splitOsascriptArgs(args)
+	const title = "Kandev"
+	// Both attack shapes must be neutralized: the multi-line (statement-
+	// separator) payload AND the single-line (expression-injection) payload.
+	cases := map[string]string{
+		"multi_line_statement":     breakoutPayload,
+		"single_line_expression":   singleLineBreakoutPayload,
+		"flag_like_do_shell_quote": `do shell script "touch /tmp/pwn"`,
+	}
+	for name, body := range cases {
+		t.Run(name, func(t *testing.T) {
+			args := osascriptNotifyArgs(title, body)
+			scriptFragments, runArgs := splitOsascriptArgs(args)
 
-	// 1. The untrusted title/body must appear ONLY as trailing run arguments,
-	//    byte-for-byte, and never embedded in any AppleScript source fragment.
-	if len(runArgs) != 2 || runArgs[0] != title || runArgs[1] != breakoutPayload {
-		t.Fatalf("title/body not passed as opaque run args: %#v", runArgs)
-	}
-	for _, frag := range scriptFragments {
-		if strings.Contains(frag, "do shell script") {
-			t.Fatalf("attacker text leaked into AppleScript source: %q", frag)
-		}
-		if strings.Contains(frag, "Kandev") || strings.Contains(frag, `\"`) {
-			t.Fatalf("title/body interpolated into AppleScript source: %q", frag)
-		}
-	}
+			// 1. The untrusted title/body must appear ONLY as trailing run
+			//    arguments, byte-for-byte, never embedded in any source fragment.
+			if len(runArgs) != 2 || runArgs[0] != title || runArgs[1] != body {
+				t.Fatalf("title/body not passed as opaque run args: %#v", runArgs)
+			}
+			for _, frag := range scriptFragments {
+				if strings.Contains(frag, "do shell script") {
+					t.Fatalf("attacker text leaked into AppleScript source: %q", frag)
+				}
+				if strings.Contains(frag, "Kandev") || strings.Contains(frag, `\"`) {
+					t.Fatalf("title/body interpolated into AppleScript source: %q", frag)
+				}
+			}
 
-	// 2. The script fragments must reference argv, not interpolated literals.
-	joined := strings.Join(scriptFragments, "\n")
-	if !strings.Contains(joined, "item 2 of argv") || !strings.Contains(joined, "item 1 of argv") {
-		t.Fatalf("expected argv-referencing display notification, got: %q", joined)
+			// 2. The script fragments reference argv, not interpolated literals.
+			joined := strings.Join(scriptFragments, "\n")
+			if !strings.Contains(joined, "item 2 of argv") || !strings.Contains(joined, "item 1 of argv") {
+				t.Fatalf("expected argv-referencing display notification, got: %q", joined)
+			}
+		})
 	}
-	t.Logf("safe osascript args: %#v", args)
 }
 
 // TestOsascriptNotifyArgs_OptionTerminator guards the second injection vector:


### PR DESCRIPTION
Untrusted external-integration issue titles (Sentry/Linear/Jira) were interpolated into an `osascript -e` AppleScript string with quote-only escaping, so a trailing backslash let an attacker break out of the string literal and run `do shell script` on the macOS host — a critical RCE. Title/body are now passed as `run` handler argv items that never touch the AppleScript source.

## Important Changes

- Replace `buildAppleScript` (string interpolation + quote-only escaping) with `osascriptNotifyArgs`, which delivers title/body as `on run argv` arguments — no escaping needed, no code path from attacker text to AppleScript source.

## Validation

- `make fmt`, `go build ./...`, `make vet` — clean
- `go test ./internal/notifications/...` — pass, including the new PoC and regression tests
- `golangci-lint run ./internal/notifications/providers/... --new-from-rev=<base> --timeout=5m` — 0 issues
- `TestPoC_LegacyAppleScriptBreakout` reproduces the pre-fix breakout (the `display notification` literal closes early and exposes `do shell script`); `TestOsascriptNotifyArgs_NoInjection` asserts the fixed builder passes title/body only as opaque run args and never leaks them into any `-e` fragment.

## Possible Improvements

Low risk: the sibling `escapePowerShell` `$()` gap (LOW severity, Windows sound path) is intentionally out of scope and tracked as separate hardening work.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1790?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->