### PR TITLE
fix: restore multi-repo review diffs

### DIFF
--- a/apps/backend/internal/agentctl/server/api/git.go
+++ b/apps/backend/internal/agentctl/server/api/git.go
@@ -848,8 +848,8 @@ func (s *Server) handleGitLogMultiRepo(
 		// branch (e.g. "main"). Both can be wrong for sibling repos — running
 		// `git log <foreign-sha>..HEAD` in lvc fails outright and the repo's
 		// commits silently disappear from the merged response. Compute a
-		// per-repo base via merge-base against `origin/main` (with
-		// `origin/master` fallback) so each repo's commits show up.
+		// per-repo base through the workspace tracker so the task's configured
+		// base branch and normal integration-branch fallbacks both work.
 		perRepoReq := req
 		perRepoReq.Since = ""
 		perRepoReq.TargetBranch = ""
@@ -975,10 +975,10 @@ func (s *Server) runGitCumulativeDiffForRepo(
 }
 
 // handleGitCumulativeDiffMultiRepo fans cumulative diff out across every
-// per-repo tracker. Each repo's base commit is computed locally via
-// merge-base against the integration branch — the caller-supplied base only
-// makes sense for one repo at a time, since each repo has its own commit
-// graph. Files from each repo are merged into a single map, keyed by
+// per-repo tracker. Each repo's base commit is resolved from its configured
+// task base branch — the caller-supplied base only makes sense for one repo at
+// a time, since each repo has its own commit graph. Files from each repo are
+// merged into a single map, keyed by
 // `<repoSubpath>/<path>` so paths that exist in multiple repos don't clash,
 // and tagged with `repository_name` so the frontend can group them.
 func (s *Server) handleGitCumulativeDiffMultiRepo(
@@ -998,7 +998,7 @@ func (s *Server) handleGitCumulativeDiffMultiRepo(
 				zap.String("repo", sub))
 			continue
 		}
-		// Multi-repo: base is already merge-base'd per-repo via resolvePerRepoBase,
+		// Multi-repo: base is already resolved per-repo via resolvePerRepoBase,
 		// so we pass empty target_branch to skip the second merge-base attempt.
 		result := s.runGitCumulativeDiffForRepo(c, base, "", sub)
 		if result == nil {
@@ -1021,21 +1021,15 @@ func (s *Server) handleGitCumulativeDiffMultiRepo(
 	c.JSON(http.StatusOK, merged)
 }
 
-// resolvePerRepoBase returns the merge-base of HEAD against the integration
-// branch (origin/main, with origin/master fallback). Multi-repo tasks share
-// no single base commit across repos, so each repo computes its own.
+// resolvePerRepoBase returns the comparison anchor owned by the repository's
+// workspace tracker. Multi-repo tasks share no single base commit across
+// repos, and each tracker carries that repository's configured task base.
 func (s *Server) resolvePerRepoBase(c *gin.Context, repo string) string {
-	gitOp, err := s.procMgr.GitOperatorFor(repo)
+	tracker, err := s.procMgr.GetWorkspaceTrackerFor(repo)
 	if err != nil {
 		return ""
 	}
-	for _, candidate := range []string{"origin/main", "origin/master"} {
-		base, mbErr := gitOp.GetMergeBase(c.Request.Context(), "HEAD", candidate)
-		if mbErr == nil && base != "" {
-			return base
-		}
-	}
-	return ""
+	return tracker.ResolveBaseCommit(c.Request.Context())
 }
 
 // mergeCumulativeFiles copies per-repo files into the merged map under a

--- a/apps/backend/internal/agentctl/server/api/git_multi_repo_review_test.go
+++ b/apps/backend/internal/agentctl/server/api/git_multi_repo_review_test.go
@@ -1,0 +1,88 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kandev/kandev/internal/agentctl/server/config"
+	"github.com/kandev/kandev/internal/agentctl/server/process"
+	"github.com/kandev/kandev/internal/common/logger"
+)
+
+func TestMultiRepoReviewEndpointsUseStoredBaseBranches(t *testing.T) {
+	taskRoot := t.TempDir()
+	bases := map[string]string{"frontend": "develop", "backend": "release"}
+	baseCommit := ""
+	for repo, baseBranch := range bases {
+		repoDir := filepath.Join(taskRoot, repo)
+		if err := os.Mkdir(repoDir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", repo, err)
+		}
+		runGitAPI(t, repoDir, "init", "--initial-branch="+baseBranch)
+		runGitAPI(t, repoDir, "config", "user.email", "test@test.com")
+		runGitAPI(t, repoDir, "config", "user.name", "Test User")
+		writeFileAPI(t, repoDir, "README.md", "base\n")
+		runGitAPI(t, repoDir, "add", ".")
+		runGitAPI(t, repoDir, "commit", "-m", "initial")
+		if baseCommit == "" {
+			baseCommit = strings.TrimSpace(runGitAPI(t, repoDir, "rev-parse", "HEAD"))
+		}
+		runGitAPI(t, repoDir, "checkout", "-b", "feature/review")
+		writeFileAPI(t, repoDir, "changed.txt", repo+" change\n")
+		runGitAPI(t, repoDir, "add", ".")
+		runGitAPI(t, repoDir, "commit", "-m", "feature change")
+	}
+
+	log, _ := logger.NewLogger(logger.LoggingConfig{Level: "error"})
+	cfg := &config.InstanceConfig{WorkDir: taskRoot, BaseBranches: bases}
+	mgr := process.NewManager(cfg, log)
+	srv := NewServer(cfg, mgr, nil, nil, log)
+
+	logResponse := httptest.NewRecorder()
+	srv.Router().ServeHTTP(
+		logResponse,
+		httptest.NewRequest(http.MethodGet, "/api/v1/git/log?limit=100", nil),
+	)
+	if logResponse.Code != http.StatusOK {
+		t.Fatalf("git log status = %d: %s", logResponse.Code, logResponse.Body.String())
+	}
+	var commits process.GitLogResult
+	if err := json.Unmarshal(logResponse.Body.Bytes(), &commits); err != nil {
+		t.Fatalf("decode git log: %v", err)
+	}
+	commitsByRepo := make(map[string]int)
+	for _, commit := range commits.Commits {
+		commitsByRepo[commit.RepositoryName]++
+	}
+	for repo := range bases {
+		if commitsByRepo[repo] != 1 {
+			t.Fatalf("commits for %s = %d, want 1: %s", repo, commitsByRepo[repo], logResponse.Body.String())
+		}
+	}
+
+	diffResponse := httptest.NewRecorder()
+	srv.Router().ServeHTTP(
+		diffResponse,
+		httptest.NewRequest(http.MethodGet, "/api/v1/git/cumulative-diff?base="+baseCommit, nil),
+	)
+	if diffResponse.Code != http.StatusOK {
+		t.Fatalf("cumulative diff status = %d: %s", diffResponse.Code, diffResponse.Body.String())
+	}
+	var diff process.CumulativeDiffResult
+	if err := json.Unmarshal(diffResponse.Body.Bytes(), &diff); err != nil {
+		t.Fatalf("decode cumulative diff: %v", err)
+	}
+	if len(diff.Files) != len(bases) {
+		t.Fatalf("cumulative diff files = %d, want %d: %s", len(diff.Files), len(bases), diffResponse.Body.String())
+	}
+	for repo := range bases {
+		if _, ok := diff.Files[repo+"\x00changed.txt"]; !ok {
+			t.Errorf("cumulative diff missing %s/changed.txt: %s", repo, diffResponse.Body.String())
+		}
+	}
+}

--- a/apps/backend/internal/agentctl/server/process/workspace_git_status.go
+++ b/apps/backend/internal/agentctl/server/process/workspace_git_status.go
@@ -174,10 +174,7 @@ func (wt *WorkspaceTracker) getGitBranchInfo(ctx context.Context, update *types.
 	// which the agentctl git-log handler used to silently translate into
 	// "last N commits of HEAD" (the symptom in the no-merge-base repro:
 	// `+1 -0` on the card vs. 100 unrelated commits in the panel).
-	baseBranch := wt.resolveBaseBranch(ctx)
-	if baseBranch != "" {
-		update.BaseCommit = wt.computeBaseCommit(ctx, baseBranch)
-	}
+	update.BaseCommit = wt.ResolveBaseCommit(ctx)
 
 	return nil
 }
@@ -210,6 +207,18 @@ func (wt *WorkspaceTracker) computeBaseCommit(ctx context.Context, baseBranch st
 		return strings.TrimSpace(string(out))
 	}
 	return ""
+}
+
+// ResolveBaseCommit returns the comparison anchor configured for this
+// repository. It shares the exact stored-base and fallback resolution used by
+// git status so API consumers such as commits and cumulative diff cannot drift
+// from the Changes panel's ahead/behind and branch-diff totals.
+func (wt *WorkspaceTracker) ResolveBaseCommit(ctx context.Context) string {
+	baseBranch := wt.resolveBaseBranch(ctx)
+	if baseBranch == "" {
+		return ""
+	}
+	return wt.computeBaseCommit(ctx, baseBranch)
 }
 
 // getAheadBehindCounts populates the Ahead/Behind fields relative to the base


### PR DESCRIPTION
Multi-repository review surfaces could lose all files when a repository used a
configured base branch other than `main` or `master`. Reuse each repository
tracker's comparison-base resolver so commits, cumulative diffs, Review, and
Walkthrough stay aligned.

## Validation

- `go test -race ./internal/agentctl/server/api -run 'TestMultiRepoReviewEndpointsUseStoredBaseBranches|TestComputeMergeBase|TestMergeGitLogResults' -count=1`
- `go test -race ./internal/agentctl/server/process -run 'TestGetGitStatus|TestManagerUpdateBaseBranches|TestManager_RepoSubpaths' -count=1`
- `make typecheck`
- `make test`
- `make -C apps/backend lint`
- `pnpm --filter @kandev/web lint`
- `python3 .github/scripts/lint-harness-files.py --all`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1795?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->