### PR TITLE
fix: keep queued messages parked after agent cancellation

### DIFF
--- a/apps/backend/internal/agent/runtime/lifecycle/manager_interaction_cancel_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_interaction_cancel_test.go
@@ -218,8 +218,8 @@ func TestManager_CancelAgent_EscalationCleanupSurvivesCtxCancel(t *testing.T) {
 // bus.MemoryEventBus.publishToQueue's "deliver synchronously to preserve
 // ordering" comment). A synchronous inline publish here would have that
 // reentrant Lock() call block forever on the non-reentrant mutex, and
-// CancelAgent would never return — exactly what the E2E "a message queued
-// during a running turn is delivered when the turn is paused" test caught.
+// CancelAgent would never return — exactly what the pause/resume queue E2E
+// coverage caught while asserting the session settles after a forced stop.
 //
 // This test cannot reproduce the real cross-package reentrancy (it would
 // need the real bus.MemoryEventBus plus a real orchestrator.Service), so it

--- a/apps/backend/internal/mcp/handlers/message_task_test.go
+++ b/apps/backend/internal/mcp/handlers/message_task_test.go
@@ -648,8 +648,8 @@ func TestHandleMessageTask_ParentToChildRunningSession_InterruptFailure_KeepsMes
 // (false, nil) — no error, but nothing actually dispatched by this call,
 // e.g. because a concurrent cancel already owned the session — must still
 // report "queued" (not "sent"). Reporting "sent" here would tell the parent
-// its message was delivered immediately when it is still only sitting in
-// the queue for the in-flight cancel to deliver later.
+// its message was delivered immediately when it is still parked for a later
+// explicit drain or another valid delivery trigger.
 func TestHandleMessageTask_ParentToChildRunningSession_InterruptSkipped_KeepsQueuedStatus(t *testing.T) {
 	svc, repo := newTestTaskService(t)
 	parent, child, sess := seedChildTaskWithSession(t, svc, repo, models.TaskSessionStateRunning)

--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -1156,9 +1156,8 @@ func (s *Service) syncTaskStateForPendingMove(ctx context.Context, taskID, fromS
 // Callers must ensure the session is ready for input *before* calling this
 // — exactly as before this was guarded — but must not have already claimed
 // the guard themselves; use drainQueuedMessageForPromptableSessionLocked
-// instead when the guard is already held (e.g. inside CancelAgent,
-// cancelAndTakeForPeerMessage, handleAgentBootReady, handleAgentReady,
-// applyPendingMove).
+// instead when the guard is already held (e.g. inside
+// cancelAndTakeForPeerMessage, handleAgentReady, or applyPendingMove).
 //
 // Reloads the session and re-confirms promptability *after* acquiring the
 // guard rather than trusting the caller's own earlier check: callers like

--- a/apps/backend/internal/orchestrator/task_operations.go
+++ b/apps/backend/internal/orchestrator/task_operations.go
@@ -2841,30 +2841,11 @@ func (s *Service) CancelAgent(ctx context.Context, sessionID string) error {
 	// concurrent agent.complete event having already closed the turn.
 	s.completeTurnForSession(ctx, sessionID)
 
-	// Deliver any message the operator queued while the turn was running
-	// (#1597 pause→resume recovery) *while still holding the guard* — this
-	// used to release the guard early and drain unguarded, which let a
-	// concurrent QueueAndInterruptForPeerMessage (or another drain) race
-	// this exact take-and-dispatch decision for the same session; every
-	// take-and-dispatch decision must serialize through this one guard
-	// (see the Service.cancelInFlight field doc comment). On a normal
-	// cancel the agent emits complete(cancelled) → handleAgentReady →
-	// on_turn_complete, which drains the queue. But an escalated cancel
-	// (agent hung) or a dead-process cancel fires no agent.ready event, so
-	// nothing would drain it — leaving the operator's queued message
-	// stranded until a second manual send. Draining here after the turn is
-	// completed covers those paths. It is idempotent with the event-driven
-	// drain: drainQueuedMessageForPromptableSessionLocked pops via
-	// TakeQueued atomically, so a normal cancel that also fires
-	// handleAgentReady cannot double-deliver.
-	if session != nil {
-		s.drainQueuedMessageForPromptableSessionLocked(ctx, sessionID)
-	}
-
-	// Release the cancel/interrupt guard now that this session's
-	// cancel-and-drain decision is fully resolved. Both unlockGuard and
-	// release are idempotent, so the deferred calls above become safe
-	// no-op error-path safety nets once this fires.
+	// Release the cancel/interrupt guard now that this session's cancel is
+	// fully resolved. Do not drain here: a user cancellation must not itself
+	// start the next queued message. Both unlockGuard and release are
+	// idempotent, so the deferred calls above become safe no-op error-path
+	// safety nets once this fires.
 	unlockGuard()
 	release()
 
@@ -2999,8 +2980,8 @@ func (s *Service) cancelAndTakeForPeerMessage(ctx context.Context, taskID, sessi
 // only for the later interrupt's cancel to land on and kill that very turn,
 // orphaning the parent's message mid-delivery. Taking the lock before the
 // queue insert closes that: handleAgentReady and handleAgentBootReady's
-// take-decision claims (TryLock, not a passive peek) the exact same lock
-// before their own take, so neither can ever observe — and steal — an
+// take decisions claim the exact same lock before their own take, so neither
+// can ever observe — and steal — an
 // entry this call is still in the process of queueing-and-claiming.
 //
 // The lock is a genuine, blocking claim (Lock, mirroring

--- a/apps/backend/internal/orchestrator/task_operations_test.go
+++ b/apps/backend/internal/orchestrator/task_operations_test.go
@@ -601,64 +601,41 @@ func TestCancelAgent_TaskStateReconcile(t *testing.T) {
 	}
 }
 
-// TestCancelAgent_DeliversQueuedMessageOnResume pins the corrected pause→resume
-// contract (#1597 pause→resume recovery): a message queued while the agent was
-// running is DELIVERED once cancel settles the session to WAITING_FOR_INPUT, not
-// stranded on the queue for indefinite manual drain.
-//
-// This replaces the former TestCancelAgent_LeavesQueuedMessageForManualDrain,
-// which codified the wedge as expected. On a normal cancel the agent's
-// complete(cancelled) event fires handleAgentReady → on_turn_complete → drain,
-// but on an escalated / dead-process cancel no agent.ready event ever fires, so
-// nothing drained the queue and the operator's queued message was lost until a
-// second manual send. Cancel now drains directly after reconciling the session.
-//
-// Proof of delivery is the queue emptying: drainQueuedMessageForPromptableSession
-// pops the message synchronously (TakeQueued) before dispatching it, so a
-// Count==0 immediately after CancelAgent returns is deterministic. The actual
-// PromptTask dispatch runs in a goroutine (state may already be RUNNING by the
-// time we re-read), mirroring TestHandleAgentBootReady_DrainsOrphanedQueuedMessage.
-func TestCancelAgent_DeliversQueuedMessageOnResume(t *testing.T) {
-	ctx := context.Background()
-	repo := setupTestRepo(t)
-	// repoForExecutionLookup + isAgentRunning let the executeQueuedMessage
-	// goroutine's PromptTask → ensureSessionRunning → GetExecutionBySession land
-	// on a working path instead of nil-derefing s.executor under -race.
-	agentMgr := &mockAgentManager{isAgentRunning: true, repoForExecutionLookup: repo}
-	svc := createTestServiceWithAgent(repo, newMockStepGetter(), newMockTaskRepo(), agentMgr)
-	svc.executor = executor.NewExecutor(agentMgr, repo, testLogger(), executor.ExecutorConfig{})
-
-	seedTaskAndSession(t, repo, "task1", "session1", models.TaskSessionStateRunning)
-	seedExecutorRunning(t, repo, "session1", "task1", "exec-1")
-	if _, err := svc.messageQueue.QueueMessage(
-		ctx, "session1", "task1", "queued after cancel", "", messagequeue.QueuedByUser, false, nil,
-	); err != nil {
-		t.Fatalf("queue message: %v", err)
+// TestCancelAgent_LeavesQueuedMessageParked pins the user-cancel contract: a
+// forceful interruption stops the active turn without starting the next queued
+// message. Explicit draining remains available when processing should resume.
+func TestCancelAgent_LeavesQueuedMessageParked(t *testing.T) {
+	tests := []struct {
+		name      string
+		cancelErr error
+	}{
+		{name: "acknowledged"},
+		{name: "force escalated", cancelErr: lifecycle.ErrCancelEscalated},
+		{name: "execution missing", cancelErr: lifecycle.ErrNoExecutionForSession},
 	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			repo := setupTestRepo(t)
+			agentMgr := &mockAgentManager{cancelAgentErr: tt.cancelErr}
+			svc := createTestServiceWithAgent(repo, newMockStepGetter(), newMockTaskRepo(), agentMgr)
 
-	if err := svc.CancelAgent(ctx, "session1"); err != nil {
-		t.Fatalf("cancel agent: %v", err)
-	}
+			seedTaskAndSession(t, repo, "task1", "session1", models.TaskSessionStateRunning)
+			queued, err := svc.messageQueue.QueueMessage(
+				ctx, "session1", "task1", "queued after cancel", "", messagequeue.QueuedByUser, false, nil,
+			)
+			require.NoError(t, err)
+			require.NoError(t, svc.CancelAgent(ctx, "session1"))
 
-	// Cancel settles the session so a new prompt can land. The drain goroutine
-	// may already have moved it back to RUNNING; either state proves the wedge
-	// (stuck RUNNING with a full queue) is gone.
-	updated, err := repo.GetTaskSession(ctx, "session1")
-	if err != nil {
-		t.Fatalf("get updated session: %v", err)
-	}
-	if updated.State != models.TaskSessionStateWaitingForInput &&
-		updated.State != models.TaskSessionStateRunning {
-		t.Fatalf("expected session state WAITING_FOR_INPUT or RUNNING after cancel, got %q", updated.State)
-	}
-
-	status := svc.messageQueue.GetStatus(ctx, "session1")
-	if status.Count != 0 {
-		t.Fatalf("expected cancel to deliver the queued message on resume, count=%d entries=%+v", status.Count, status.Entries)
+			status := svc.messageQueue.GetStatus(ctx, "session1")
+			require.Equal(t, 1, status.Count)
+			require.Len(t, status.Entries, 1)
+			require.Equal(t, queued.ID, status.Entries[0].ID, "cancel must leave the same queued entry parked")
+		})
 	}
 }
 
-func TestCancelAgent_DrainsQueuedMessageAfterCancelGuardClears(t *testing.T) {
+func TestCancelAgent_QueuedMessageRunsAfterExplicitDrain(t *testing.T) {
 	ctx := context.Background()
 	repo := setupTestRepo(t)
 	promptDone := make(chan struct{})
@@ -687,6 +664,13 @@ func TestCancelAgent_DrainsQueuedMessageAfterCancelGuardClears(t *testing.T) {
 	if err := svc.CancelAgent(ctx, "session1"); err != nil {
 		t.Fatalf("cancel agent: %v", err)
 	}
+	drained, err := svc.DrainQueuedMessage(ctx, "session1")
+	if err != nil {
+		t.Fatalf("drain queued message: %v", err)
+	}
+	if !drained {
+		t.Fatal("expected explicit drain to run the parked queued message")
+	}
 
 	select {
 	case <-promptDone:
@@ -696,7 +680,7 @@ func TestCancelAgent_DrainsQueuedMessageAfterCancelGuardClears(t *testing.T) {
 
 	status := svc.messageQueue.GetStatus(ctx, "session1")
 	if status.Count != 0 {
-		t.Fatalf("expected queued prompt to stay drained after cancel guard clears, count=%d entries=%+v", status.Count, status.Entries)
+		t.Fatalf("expected explicit drain to remove the queued prompt, count=%d entries=%+v", status.Count, status.Entries)
 	}
 }
 
@@ -704,11 +688,10 @@ func TestCancelAgent_DrainsQueuedMessageAfterCancelGuardClears(t *testing.T) {
 
 // TestQueueAndInterruptForPeerMessage_DeliversQueuedMessageWithoutUserCancelSideEffects
 // pins the parent -> child steering contract: QueueAndInterruptForPeerMessage
-// cancels the child's in-flight turn and drains its queue like CancelAgent
-// does, but — unlike the user-facing cancel button — it must not write a
-// visible "Turn cancelled" message and must not move the task to REVIEW
-// (writeTaskReviewStateOnCancel). Those are user-cancel-specific side effects
-// that would misrepresent an internal steering signal from the parent task.
+// cancels the child's in-flight turn and immediately dispatches its targeted
+// message. Unlike that explicit steering path, the user-facing cancel button
+// parks queued messages. Peer steering also must not write a visible "Turn
+// cancelled" message or move the task to REVIEW (writeTaskReviewStateOnCancel).
 func TestQueueAndInterruptForPeerMessage_DeliversQueuedMessageWithoutUserCancelSideEffects(t *testing.T) {
 	ctx := context.Background()
 	repo := setupTestRepo(t)
@@ -1859,18 +1842,14 @@ func TestClarificationRecovery_ReleasesGuardAfterRetryDispatch(t *testing.T) {
 	require.Equal(t, 0, status.Count, "accepted parent message must be removed from the queue exactly once")
 }
 
-// TestCancelAgent_RacesHandleAgentReady_QueuedMessageStillDelivered covers a
+// TestCancelAgent_RacesHandleAgentReady_QueuedMessageStaysParked covers a
 // real cross-goroutine race at the orchestrator level: a user's Cancel-button
 // click (Service.CancelAgent) racing the same agent's own asynchronous
 // ready/complete event (handleAgentReady) for the same session, with a
-// message already queued while the turn was running. CancelAgent's own doc
-// comment claims its synchronous drainQueuedMessageForPromptableSessionLocked
-// call — made while still holding the per-session cancelInFlight guard —
-// delivers the queued message even when no agent.ready fires; this pins that
-// the queued message is *actually* delivered exactly once even when a real
-// handleAgentReady call for this exact cancellation *does* arrive
-// concurrently, mid-cancel, rather than being stranded because neither side
-// ends up taking it.
+// message already queued while the turn was running. Once CancelAgent settles
+// the session to WAITING_FOR_INPUT, the racing ready event must treat its old
+// completion as stale and leave the queue parked rather than starting a new
+// turn immediately after the user stopped one.
 //
 // This does NOT reproduce the #1653 E2E CI regression (a same-goroutine
 // reentrant deadlock inside the real agent lifecycle manager's escalation
@@ -1879,13 +1858,12 @@ func TestClarificationRecovery_ReleasesGuardAfterRetryDispatch(t *testing.T) {
 // that never triggers a reentrant handleAgentReady call on this same
 // goroutine the way the real lifecycle.Manager's escalateStuckCancel does;
 // handleAgentReady here always runs on its own, genuinely separate goroutine.
-func TestCancelAgent_RacesHandleAgentReady_QueuedMessageStillDelivered(t *testing.T) {
+func TestCancelAgent_RacesHandleAgentReady_QueuedMessageStaysParked(t *testing.T) {
 	ctx := context.Background()
 	repo := setupTestRepo(t)
 	agentMgr := &mockAgentManager{
 		isAgentRunning:         true,
 		repoForExecutionLookup: repo,
-		promptDone:             make(chan struct{}, 4),
 		cancelAgentBlock:       make(chan struct{}),
 		cancelAgentEntered:     make(chan struct{}, 1),
 	}
@@ -1956,14 +1934,11 @@ func TestCancelAgent_RacesHandleAgentReady_QueuedMessageStillDelivered(t *testin
 		t.Fatal("timed out waiting for handleAgentReady to finish once the guard was released")
 	}
 
-	require.Eventually(t, func() bool {
-		agentMgr.mu.Lock()
-		defer agentMgr.mu.Unlock()
-		return len(agentMgr.capturedPrompts) == 1
-	}, 2*time.Second, 10*time.Millisecond, "expected the queued message to be dispatched exactly once")
-
 	status := svc.messageQueue.GetStatus(ctx, "session1")
-	require.Equal(t, 0, status.Count, "the queued message must not be stranded when a concurrent agent.ready races the cancel button's own drain")
+	require.Equal(t, 1, status.Count, "the racing ready event must leave the queue parked after user cancel")
+	agentMgr.mu.Lock()
+	defer agentMgr.mu.Unlock()
+	require.Empty(t, agentMgr.capturedPrompts, "user cancel must not dispatch a queued prompt")
 }
 
 // TestAcquireCancelInFlightGuard_PrunesEntryWhenNoLongerReferenced pins the
@@ -1972,10 +1947,9 @@ func TestCancelAgent_RacesHandleAgentReady_QueuedMessageStillDelivered(t *testin
 // probed — including read-only isCancelInFlight peeks and every busy-skip
 // in handleAgentReady/handleAgentBootReady — with no path to remove it.
 // acquireCancelInFlightGuard/releaseCancelInFlightGuard must keep the
-// registry bounded by concurrently-active sessions instead: every acquire
-// (successful lock, failed TryLock, or a passive isCancelInFlight peek)
-// must be paired with a release that prunes the entry once nobody
-// references it anymore.
+// registry bounded by concurrently-active sessions instead: every acquire,
+// including a passive isCancelInFlight peek, must be paired with a release
+// that prunes the entry once nobody references it anymore.
 func TestAcquireCancelInFlightGuard_PrunesEntryWhenNoLongerReferenced(t *testing.T) {
 	repo := setupTestRepo(t)
 	svc := createTestServiceWithAgent(repo, newMockStepGetter(), newMockTaskRepo(), &mockAgentManager{})
@@ -1989,8 +1963,8 @@ func TestAcquireCancelInFlightGuard_PrunesEntryWhenNoLongerReferenced(t *testing
 		t.Fatalf("expected the registry to be pruned after a used-and-released claim, got %d entries", got)
 	}
 
-	// A losing TryLock — the busy-skip path every guard claim site takes —
-	// must still release its reference without ever calling Unlock.
+	// A losing TryLock, as used by the passive isCancelInFlight probe, must
+	// still release its reference without ever calling Unlock.
 	holderLock, holderRelease := svc.acquireCancelInFlightGuard("s2")
 	holderLock.Lock()
 	waiterLock, waiterRelease := svc.acquireCancelInFlightGuard("s2")

--- a/apps/backend/internal/orchestrator/workflow_e2e_test.go
+++ b/apps/backend/internal/orchestrator/workflow_e2e_test.go
@@ -428,6 +428,8 @@ func TestProcessOnTurnCompleteViaEngine_NonTerminalStepWritesTaskStateReview(t *
 		isAgentRunning:         true,
 	}
 	svc := createEngineService(t, repo, sg, agentMgr)
+	onEnterDone := make(chan struct{})
+	svc.onProcessOnEnterComplete = func() { close(onEnterDone) }
 	taskRepo := svc.taskRepo.(*mockTaskRepo)
 	seedMockTaskState(taskRepo, "t1", v1.TaskStateInProgress)
 
@@ -442,11 +444,23 @@ func TestProcessOnTurnCompleteViaEngine_NonTerminalStepWritesTaskStateReview(t *
 	}
 
 	assertStepByName(t, ctx, repo, "s1", "In Progress", nameToID)
+	select {
+	case <-onEnterDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for on_enter processing")
+	}
 	taskRepo.mu.Lock()
-	state, ok := taskRepo.updatedStates["t1"]
+	history := append([]v1.TaskState(nil), taskRepo.stateHistory["t1"]...)
 	taskRepo.mu.Unlock()
-	if !ok || state != v1.TaskStateReview {
-		t.Errorf("tasks.state = %q, want %q (ok=%v)", state, v1.TaskStateReview, ok)
+	wroteReview := false
+	for _, state := range history {
+		if state == v1.TaskStateReview {
+			wroteReview = true
+			break
+		}
+	}
+	if !wroteReview {
+		t.Errorf("tasks.state history = %v, want a %q write", history, v1.TaskStateReview)
 	}
 }
 

--- a/apps/web/e2e/tests/session/mobile-pause-resume-recovery.spec.ts
+++ b/apps/web/e2e/tests/session/mobile-pause-resume-recovery.spec.ts
@@ -1,0 +1,52 @@
+// Filename starts with "mobile-" so this runs on the mobile-chrome project.
+import { test, expect } from "../../fixtures/test-base";
+import { assertNoDocumentHorizontalOverflow } from "../../helpers/layout-assertions";
+import { seedIdleSession } from "../../helpers/session";
+import { typeWhileBusy } from "../../helpers/type-while-busy";
+
+test.describe("mobile: pause queue recovery", () => {
+  test.describe.configure({ retries: 1 });
+
+  test("force-stop parks the next message until Run next is tapped", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    test.setTimeout(90_000);
+
+    const session = await seedIdleSession(
+      testPage,
+      apiClient,
+      seedData,
+      "Mobile pause parks queue",
+    );
+    const chat = session.activeChat();
+
+    await session.sendMessageViaButton("/slow 8s");
+    await expect(session.agentStatus()).toBeVisible({ timeout: 15_000 });
+
+    const editor = chat.locator(".tiptap.ProseMirror");
+    await typeWhileBusy(testPage, editor, "/e2e:simple-message");
+    await chat.getByTestId("submit-message-button").tap();
+
+    const queueChip = chat.getByTestId("queue-chip");
+    await expect(queueChip).toBeVisible({ timeout: 10_000 });
+
+    await session.cancelAgentButton().tap();
+
+    await expect(session.agentStatus()).not.toBeVisible({ timeout: 30_000 });
+    await expect(session.idleInput()).toBeVisible({ timeout: 30_000 });
+    await expect(queueChip).toBeVisible();
+    await expect(chat.getByText("simple mock response", { exact: false }).nth(1)).not.toBeVisible();
+    await assertNoDocumentHorizontalOverflow(testPage);
+
+    await queueChip.tap();
+    const runNext = chat.getByTestId("queue-drain-next");
+    await expect(runNext).toBeVisible();
+    await expect(runNext).toBeInViewport();
+    await runNext.tap();
+
+    await expect(chat.getByTestId("queue-chip")).not.toBeVisible({ timeout: 30_000 });
+    await session.expectChatResponseVisible("simple mock response", 1, { timeout: 30_000 });
+  });
+});

--- a/apps/web/e2e/tests/session/pause-resume-recovery.spec.ts
+++ b/apps/web/e2e/tests/session/pause-resume-recovery.spec.ts
@@ -17,8 +17,8 @@ import { SessionPage } from "../../pages/session-page";
 //   1. Pausing a running turn returns the SAME session to an input-ready state;
 //      a newly typed message resumes it with prior context intact — no wedged
 //      "still running" composer, no service restart.
-//   2. A message queued while the turn was running is DELIVERED once the pause
-//      settles the session, rather than being stranded on the queue.
+//   2. A message queued while the turn was running stays parked when the pause
+//      settles the session, then runs only after the operator explicitly asks.
 // ---------------------------------------------------------------------------
 
 /** Seed an ACP task, open its session, and wait for the initial turn to idle. */
@@ -99,7 +99,7 @@ test.describe("Pause → resume recovery", () => {
     ).toBeVisible({ timeout: 15_000 });
   });
 
-  test("a message queued during a running turn is delivered when the turn is paused", async ({
+  test("a message queued during a running turn stays parked when the turn is paused", async ({
     testPage,
     apiClient,
     seedData,
@@ -110,7 +110,7 @@ test.describe("Pause → resume recovery", () => {
       testPage,
       apiClient,
       seedData,
-      "Pause drains queued message",
+      "Pause parks queued message",
     );
 
     // Keep the agent busy, then queue a follow-up while it is running.
@@ -125,13 +125,18 @@ test.describe("Pause → resume recovery", () => {
     // The queued message is parked while the turn runs.
     await expect(testPage.getByTestId("queue-chip")).toBeVisible({ timeout: 10_000 });
 
-    // Pause the running turn. Cancel must DELIVER the queued message rather than
-    // strand it: on an escalated / dead-process cancel no agent.ready fires, so
-    // CancelAgent drains the queue directly.
+    // Pause the running turn. Cancel must stop here rather than interpreting the
+    // queued follow-up as an instruction to begin another turn immediately.
     await session.cancelAgentButton().click();
 
-    // The queued message drains (chip clears) and its response arrives — proof
-    // the paused session accepted the queued input instead of losing it.
+    // Session is idle, but queued message remains visible until explicit resume.
+    await expect(session.agentStatus()).not.toBeVisible({ timeout: 30_000 });
+    await expect(session.idleInput()).toBeVisible({ timeout: 30_000 });
+    await expect(testPage.getByTestId("queue-chip")).toBeVisible({ timeout: 10_000 });
+
+    // Explicit "Run next" resumes queue processing and delivers the parked input.
+    await testPage.getByTestId("queue-chip").click();
+    await testPage.getByTestId("queue-drain-next").click();
     await expect(testPage.getByTestId("queue-chip")).not.toBeVisible({ timeout: 30_000 });
     await session.expectChatResponseVisible("simple mock response", 1, { timeout: 30_000 });
     await expect(session.idleInput()).toBeVisible({ timeout: 30_000 });

--- a/docs/public/sessions-and-review.md
+++ b/docs/public/sessions-and-review.md
@@ -57,6 +57,8 @@ Right-click an agent tab on desktop to manage it. Available actions depend on it
 
 Stopping is not deletion. Resume succeeds only while the executor still has the session record needed to continue. A removed worktree, expired remote environment, restarted executor, removed profile, or missing runtime record can force a fresh session instead. The failure banner offers **Start fresh** when continuation is unavailable.
 
+Stopping a turn does not itself run the next queued message. Expand the queue and select **Run next** when you want processing to continue.
+
 A CLI-passthrough profile displays the agent's native terminal interface in a PTY. It still belongs to the task, but it does not provide Kandev's structured chat messages and tool-call presentation.
 
 ## Let agents coordinate sessions


### PR DESCRIPTION
Force-stopping a running agent currently starts its next queued message, defeating the stop action. Keep queued work parked until **Run next** while preserving immediate parent steering.

## Validation

- `make fmt`
- `make typecheck`
- `make test`
- `make lint`
- `go test -race -count=1 ./internal/orchestrator`
- Desktop Playwright: `pause-resume-recovery.spec.ts` (2 passed)
- Mobile Playwright: `mobile-pause-resume-recovery.spec.ts` (1 passed)

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1796?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->