### PR TITLE
fix: repair incomplete code-server installations

### DIFF
--- a/apps/backend/internal/editors/service/service.go
+++ b/apps/backend/internal/editors/service/service.go
@@ -83,6 +83,9 @@ func (s *Service) OpenEditor(ctx context.Context, input OpenEditorInput) (string
 	if err != nil {
 		return "", err
 	}
+	if session == nil {
+		return "", ErrWorkspaceNotFound
+	}
 
 	settings, err := s.userSettings.GetUserSettings(ctx)
 	if err != nil {

--- a/apps/backend/internal/editors/service/service.go
+++ b/apps/backend/internal/editors/service/service.go
@@ -83,10 +83,6 @@ func (s *Service) OpenEditor(ctx context.Context, input OpenEditorInput) (string
 	if err != nil {
 		return "", err
 	}
-	worktreePath, err := s.resolveSessionPath(ctx, session, input.WorktreeID)
-	if err != nil {
-		return "", err
-	}
 
 	settings, err := s.userSettings.GetUserSettings(ctx)
 	if err != nil {
@@ -97,6 +93,17 @@ func (s *Service) OpenEditor(ctx context.Context, input OpenEditorInput) (string
 	}
 
 	editor, err := s.resolveEditor(ctx, input.EditorID, input.EditorType, settings.DefaultEditorID)
+	if err != nil {
+		return "", err
+	}
+	// Opening the embedded editor at folder level only needs a valid session.
+	// Repository-less sessions still have an executor workspace where code-server
+	// can run, but they intentionally have no task worktree to resolve here.
+	if editor.Kind == editorKindInternalVscode && input.FilePath == "" {
+		return buildInternalVscodeURL("", "", input.Line, input.Column), nil
+	}
+
+	worktreePath, err := s.resolveSessionPath(ctx, session, input.WorktreeID)
 	if err != nil {
 		return "", err
 	}

--- a/apps/backend/internal/editors/service/service_test.go
+++ b/apps/backend/internal/editors/service/service_test.go
@@ -70,6 +70,27 @@ func TestOpenEditor_InternalVscodeWithoutWorkspace(t *testing.T) {
 	}
 }
 
+func TestOpenEditor_InternalVscodeRejectsMissingSession(t *testing.T) {
+	const editorID = "embedded-vscode"
+	svc := NewService(
+		&openEditorRepository{editor: &editormodels.Editor{
+			ID:      editorID,
+			Kind:    editorKindInternalVscode,
+			Enabled: true,
+		}},
+		&openEditorTaskRepository{},
+		&openEditorUserSettings{defaultEditorID: editorID},
+	)
+
+	_, err := svc.OpenEditor(context.Background(), OpenEditorInput{
+		SessionID: "missing-session",
+		EditorID:  editorID,
+	})
+	if err != ErrWorkspaceNotFound {
+		t.Fatalf("OpenEditor() error = %v, want ErrWorkspaceNotFound", err)
+	}
+}
+
 func TestOpenFolder_EmptySessionID(t *testing.T) {
 	svc := &Service{}
 	err := svc.OpenFolder(context.Background(), "", "")

--- a/apps/backend/internal/editors/service/service_test.go
+++ b/apps/backend/internal/editors/service/service_test.go
@@ -4,8 +4,71 @@ import (
 	"context"
 	"testing"
 
+	editormodels "github.com/kandev/kandev/internal/editors/models"
+	editorstore "github.com/kandev/kandev/internal/editors/store"
 	taskmodels "github.com/kandev/kandev/internal/task/models"
+	usermodels "github.com/kandev/kandev/internal/user/models"
 )
+
+type openEditorRepository struct {
+	editorstore.Repository
+	editor *editormodels.Editor
+}
+
+func (r *openEditorRepository) GetEditorByID(_ context.Context, editorID string) (*editormodels.Editor, error) {
+	if r.editor != nil && r.editor.ID == editorID {
+		return r.editor, nil
+	}
+	return nil, nil
+}
+
+type openEditorTaskRepository struct {
+	session *taskmodels.TaskSession
+}
+
+func (r *openEditorTaskRepository) GetTaskSession(_ context.Context, _ string) (*taskmodels.TaskSession, error) {
+	return r.session, nil
+}
+
+func (r *openEditorTaskRepository) GetRepository(_ context.Context, _ string) (*taskmodels.Repository, error) {
+	return nil, nil
+}
+
+type openEditorUserSettings struct {
+	defaultEditorID string
+}
+
+func (s *openEditorUserSettings) GetUserSettings(_ context.Context) (*usermodels.UserSettings, error) {
+	return &usermodels.UserSettings{DefaultEditorID: s.defaultEditorID}, nil
+}
+
+func (s *openEditorUserSettings) ClearDefaultEditorID(_ context.Context, _ string) error {
+	return nil
+}
+
+func TestOpenEditor_InternalVscodeWithoutWorkspace(t *testing.T) {
+	const editorID = "embedded-vscode"
+	svc := NewService(
+		&openEditorRepository{editor: &editormodels.Editor{
+			ID:      editorID,
+			Kind:    editorKindInternalVscode,
+			Enabled: true,
+		}},
+		&openEditorTaskRepository{session: &taskmodels.TaskSession{ID: "session-1"}},
+		&openEditorUserSettings{defaultEditorID: editorID},
+	)
+
+	url, err := svc.OpenEditor(context.Background(), OpenEditorInput{
+		SessionID: "session-1",
+		EditorID:  editorID,
+	})
+	if err != nil {
+		t.Fatalf("OpenEditor() error = %v, want nil", err)
+	}
+	if url != "internal://vscode" {
+		t.Fatalf("OpenEditor() URL = %q, want internal://vscode", url)
+	}
+}
 
 func TestOpenFolder_EmptySessionID(t *testing.T) {
 	svc := &Service{}

--- a/apps/backend/internal/tools/installer/github_tarball_strategy.go
+++ b/apps/backend/internal/tools/installer/github_tarball_strategy.go
@@ -4,8 +4,10 @@ import (
 	"archive/tar"
 	"compress/gzip"
 	"context"
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -56,17 +58,25 @@ func (s *GithubTarballStrategy) Install(ctx context.Context) (*InstallResult, er
 
 	binaryPath := s.resolveBinaryPath(target)
 	completionMarker := binaryPath + ".install-complete"
+	binaryExists, err := pathExists(binaryPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to inspect installed binary %s: %w", binaryPath, err)
+	}
+	markerExists, err := pathExists(completionMarker)
+	if err != nil {
+		return nil, fmt.Errorf("failed to inspect install completion marker %s: %w", completionMarker, err)
+	}
 
 	// The archive's entrypoint can be extracted before its runtime dependencies.
 	// Only a marker written after the full extraction proves the install is usable.
-	if fileExists(binaryPath) && fileExists(completionMarker) {
+	if binaryExists && markerExists {
 		s.logger.Info("binary already installed, skipping download", zap.String("binary", binaryPath))
 		return &InstallResult{BinaryPath: binaryPath}, nil
 	}
-	if fileExists(binaryPath) {
+	if binaryExists {
 		s.logger.Warn("incomplete binary install found, reinstalling", zap.String("binary", binaryPath))
 	}
-	if err := os.Remove(completionMarker); err != nil && !os.IsNotExist(err) {
+	if err := os.Remove(completionMarker); err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return nil, fmt.Errorf("failed to clear install completion marker: %w", err)
 	}
 
@@ -90,9 +100,15 @@ func (s *GithubTarballStrategy) Install(ctx context.Context) (*InstallResult, er
 	return &InstallResult{BinaryPath: binaryPath}, nil
 }
 
-func fileExists(path string) bool {
+func pathExists(path string) (bool, error) {
 	_, err := os.Stat(path)
-	return err == nil
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, fs.ErrNotExist) {
+		return false, nil
+	}
+	return false, err
 }
 
 func (s *GithubTarballStrategy) resolveTarget() (string, error) {

--- a/apps/backend/internal/tools/installer/github_tarball_strategy.go
+++ b/apps/backend/internal/tools/installer/github_tarball_strategy.go
@@ -55,11 +55,19 @@ func (s *GithubTarballStrategy) Install(ctx context.Context) (*InstallResult, er
 	}
 
 	binaryPath := s.resolveBinaryPath(target)
+	completionMarker := binaryPath + ".install-complete"
 
-	// Skip download if the binary already exists from a previous install.
-	if _, err := os.Stat(binaryPath); err == nil {
+	// The archive's entrypoint can be extracted before its runtime dependencies.
+	// Only a marker written after the full extraction proves the install is usable.
+	if fileExists(binaryPath) && fileExists(completionMarker) {
 		s.logger.Info("binary already installed, skipping download", zap.String("binary", binaryPath))
 		return &InstallResult{BinaryPath: binaryPath}, nil
+	}
+	if fileExists(binaryPath) {
+		s.logger.Warn("incomplete binary install found, reinstalling", zap.String("binary", binaryPath))
+	}
+	if err := os.Remove(completionMarker); err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("failed to clear install completion marker: %w", err)
 	}
 
 	url := s.buildURL(target)
@@ -74,9 +82,17 @@ func (s *GithubTarballStrategy) Install(ctx context.Context) (*InstallResult, er
 	if _, err := os.Stat(binaryPath); err != nil {
 		return nil, fmt.Errorf("binary not found after extraction: %s", binaryPath)
 	}
+	if err := os.WriteFile(completionMarker, nil, 0o644); err != nil {
+		return nil, fmt.Errorf("failed to write install completion marker: %w", err)
+	}
 
 	s.logger.Info("tarball install completed", zap.String("binary", binaryPath))
 	return &InstallResult{BinaryPath: binaryPath}, nil
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
 }
 
 func (s *GithubTarballStrategy) resolveTarget() (string, error) {

--- a/apps/backend/internal/tools/installer/github_tarball_strategy.go
+++ b/apps/backend/internal/tools/installer/github_tarball_strategy.go
@@ -90,7 +90,7 @@ func (s *GithubTarballStrategy) Install(ctx context.Context) (*InstallResult, er
 	}
 
 	if _, err := os.Stat(binaryPath); err != nil {
-		return nil, fmt.Errorf("binary not found after extraction: %s", binaryPath)
+		return nil, fmt.Errorf("binary not found after extraction %s: %w", binaryPath, err)
 	}
 	if err := os.WriteFile(completionMarker, nil, 0o644); err != nil {
 		return nil, fmt.Errorf("failed to write install completion marker: %w", err)

--- a/apps/backend/internal/tools/installer/github_tarball_strategy_test.go
+++ b/apps/backend/internal/tools/installer/github_tarball_strategy_test.go
@@ -4,10 +4,102 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"io"
+	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestGithubTarballStrategyInstallRepairsPartialInstall(t *testing.T) {
+	installDir := t.TempDir()
+	target := runtime.GOOS + "-" + runtime.GOARCH
+	binaryPath := filepath.Join(installDir, "tool-1.0.0-"+target, "bin", "tool")
+	if err := os.MkdirAll(filepath.Dir(binaryPath), 0o755); err != nil {
+		t.Fatalf("create partial install: %v", err)
+	}
+	if err := os.WriteFile(binaryPath, []byte("partial"), 0o755); err != nil {
+		t.Fatalf("write partial binary: %v", err)
+	}
+
+	archive := tarGzWithFiles(t, map[string]string{
+		"tool-1.0.0-" + target + "/bin/tool":    "complete",
+		"tool-1.0.0-" + target + "/lib/runtime": "runtime",
+	})
+	requestCount := 0
+	originalClient := http.DefaultClient
+	http.DefaultClient = &http.Client{Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		requestCount++
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewReader(archive)),
+			Header:     make(http.Header),
+		}, nil
+	})}
+	t.Cleanup(func() { http.DefaultClient = originalClient })
+
+	strategy := NewGithubTarballStrategy(installDir, "tool", GithubTarballConfig{
+		Owner:        "owner",
+		Repo:         "repo",
+		Version:      "1.0.0",
+		AssetPattern: "tool-{version}-{os}-{arch}.tar.gz",
+		BinaryPath:   "tool-{version}-{os}-{arch}/bin/tool",
+		Targets: map[string]string{
+			runtime.GOOS + "/" + runtime.GOARCH: target,
+		},
+	}, testLogger())
+
+	if _, err := strategy.Install(t.Context()); err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+	if requestCount != 1 {
+		t.Fatalf("download request count = %d, want 1", requestCount)
+	}
+	if _, err := os.Stat(filepath.Join(installDir, "tool-1.0.0-"+target, "lib", "runtime")); err != nil {
+		t.Fatalf("partial install was not repaired: %v", err)
+	}
+
+	if _, err := strategy.Install(t.Context()); err != nil {
+		t.Fatalf("second Install() error = %v", err)
+	}
+	if requestCount != 1 {
+		t.Fatalf("download request count after completed install = %d, want 1", requestCount)
+	}
+}
+
+func tarGzWithFiles(t *testing.T, files map[string]string) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	gzWriter := gzip.NewWriter(&buf)
+	tarWriter := tar.NewWriter(gzWriter)
+	for name, content := range files {
+		if err := tarWriter.WriteHeader(&tar.Header{
+			Name: name,
+			Mode: 0o755,
+			Size: int64(len(content)),
+		}); err != nil {
+			t.Fatalf("write tar header: %v", err)
+		}
+		if _, err := tarWriter.Write([]byte(content)); err != nil {
+			t.Fatalf("write tar content: %v", err)
+		}
+	}
+	if err := tarWriter.Close(); err != nil {
+		t.Fatalf("close tar writer: %v", err)
+	}
+	if err := gzWriter.Close(); err != nil {
+		t.Fatalf("close gzip writer: %v", err)
+	}
+	return buf.Bytes()
+}
 
 func TestSanitizeTarPath(t *testing.T) {
 	destDir := "/install"

--- a/apps/backend/internal/tools/installer/github_tarball_strategy_test.go
+++ b/apps/backend/internal/tools/installer/github_tarball_strategy_test.go
@@ -4,7 +4,6 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
-	"context"
 	"io"
 	"net/http"
 	"os"
@@ -98,9 +97,7 @@ func TestGithubTarballStrategyInstallReportsCacheInspectionError(t *testing.T) {
 		},
 	}, testLogger())
 
-	ctx, cancel := context.WithCancel(t.Context())
-	cancel()
-	_, err := strategy.Install(ctx)
+	_, err := strategy.Install(t.Context())
 	if err == nil || !strings.Contains(err.Error(), "failed to inspect installed binary") {
 		t.Fatalf("Install() error = %v, want cache inspection error", err)
 	}

--- a/apps/backend/internal/tools/installer/github_tarball_strategy_test.go
+++ b/apps/backend/internal/tools/installer/github_tarball_strategy_test.go
@@ -4,7 +4,9 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"errors"
 	"io"
+	"io/fs"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -17,6 +19,22 @@ type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req)
+}
+
+func stubGithubTarballDownload(t *testing.T, archive []byte) func() int {
+	t.Helper()
+	requestCount := 0
+	originalClient := http.DefaultClient
+	http.DefaultClient = &http.Client{Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		requestCount++
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewReader(archive)),
+			Header:     make(http.Header),
+		}, nil
+	})}
+	t.Cleanup(func() { http.DefaultClient = originalClient })
+	return func() int { return requestCount }
 }
 
 func TestGithubTarballStrategyInstallRepairsPartialInstall(t *testing.T) {
@@ -34,17 +52,7 @@ func TestGithubTarballStrategyInstallRepairsPartialInstall(t *testing.T) {
 		"tool-1.0.0-" + target + "/bin/tool":    "complete",
 		"tool-1.0.0-" + target + "/lib/runtime": "runtime",
 	})
-	requestCount := 0
-	originalClient := http.DefaultClient
-	http.DefaultClient = &http.Client{Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
-		requestCount++
-		return &http.Response{
-			StatusCode: http.StatusOK,
-			Body:       io.NopCloser(bytes.NewReader(archive)),
-			Header:     make(http.Header),
-		}, nil
-	})}
-	t.Cleanup(func() { http.DefaultClient = originalClient })
+	requestCount := stubGithubTarballDownload(t, archive)
 
 	strategy := NewGithubTarballStrategy(installDir, "tool", GithubTarballConfig{
 		Owner:        "owner",
@@ -60,8 +68,8 @@ func TestGithubTarballStrategyInstallRepairsPartialInstall(t *testing.T) {
 	if _, err := strategy.Install(t.Context()); err != nil {
 		t.Fatalf("Install() error = %v", err)
 	}
-	if requestCount != 1 {
-		t.Fatalf("download request count = %d, want 1", requestCount)
+	if requestCount() != 1 {
+		t.Fatalf("download request count = %d, want 1", requestCount())
 	}
 	if _, err := os.Stat(filepath.Join(installDir, "tool-1.0.0-"+target, "lib", "runtime")); err != nil {
 		t.Fatalf("partial install was not repaired: %v", err)
@@ -70,8 +78,33 @@ func TestGithubTarballStrategyInstallRepairsPartialInstall(t *testing.T) {
 	if _, err := strategy.Install(t.Context()); err != nil {
 		t.Fatalf("second Install() error = %v", err)
 	}
-	if requestCount != 1 {
-		t.Fatalf("download request count after completed install = %d, want 1", requestCount)
+	if requestCount() != 1 {
+		t.Fatalf("download request count after completed install = %d, want 1", requestCount())
+	}
+}
+
+func TestGithubTarballStrategyInstallPreservesMissingBinaryError(t *testing.T) {
+	installDir := t.TempDir()
+	target := runtime.GOOS + "-" + runtime.GOARCH
+	archive := tarGzWithFiles(t, map[string]string{
+		"tool-1.0.0-" + target + "/lib/runtime": "runtime",
+	})
+	stubGithubTarballDownload(t, archive)
+
+	strategy := NewGithubTarballStrategy(installDir, "tool", GithubTarballConfig{
+		Owner:        "owner",
+		Repo:         "repo",
+		Version:      "1.0.0",
+		AssetPattern: "tool-{version}-{os}-{arch}.tar.gz",
+		BinaryPath:   "tool-{version}-{os}-{arch}/bin/tool",
+		Targets: map[string]string{
+			runtime.GOOS + "/" + runtime.GOARCH: target,
+		},
+	}, testLogger())
+
+	_, err := strategy.Install(t.Context())
+	if !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("Install() error = %v, want wrapped fs.ErrNotExist", err)
 	}
 }
 

--- a/apps/backend/internal/tools/installer/github_tarball_strategy_test.go
+++ b/apps/backend/internal/tools/installer/github_tarball_strategy_test.go
@@ -4,11 +4,13 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"context"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -71,6 +73,36 @@ func TestGithubTarballStrategyInstallRepairsPartialInstall(t *testing.T) {
 	}
 	if requestCount != 1 {
 		t.Fatalf("download request count after completed install = %d, want 1", requestCount)
+	}
+}
+
+func TestGithubTarballStrategyInstallReportsCacheInspectionError(t *testing.T) {
+	installDir := t.TempDir()
+	target := runtime.GOOS + "-" + runtime.GOARCH
+	binaryPath := filepath.Join(installDir, "tool-1.0.0-"+target, "bin", "tool")
+	if err := os.MkdirAll(filepath.Dir(binaryPath), 0o755); err != nil {
+		t.Fatalf("create install directory: %v", err)
+	}
+	if err := os.Symlink("tool", binaryPath); err != nil {
+		t.Fatalf("create symlink loop: %v", err)
+	}
+
+	strategy := NewGithubTarballStrategy(installDir, "tool", GithubTarballConfig{
+		Owner:        "owner",
+		Repo:         "repo",
+		Version:      "1.0.0",
+		AssetPattern: "tool-{version}-{os}-{arch}.tar.gz",
+		BinaryPath:   "tool-{version}-{os}-{arch}/bin/tool",
+		Targets: map[string]string{
+			runtime.GOOS + "/" + runtime.GOARCH: target,
+		},
+	}, testLogger())
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	_, err := strategy.Install(ctx)
+	if err == nil || !strings.Contains(err.Error(), "failed to inspect installed binary") {
+		t.Fatalf("Install() error = %v, want cache inspection error", err)
 	}
 }
 

--- a/apps/web/e2e/tests/settings/vscode-open-panel.spec.ts
+++ b/apps/web/e2e/tests/settings/vscode-open-panel.spec.ts
@@ -33,6 +33,7 @@ async function seedTaskWithSession(
   apiClient: ApiClient,
   seedData: SeedData,
   title: string,
+  repositoryIds: string[] = [seedData.repositoryId],
 ): Promise<{ session: SessionPage; sessionId: string }> {
   const task = await apiClient.createTaskWithAgent(
     seedData.workspaceId,
@@ -42,7 +43,7 @@ async function seedTaskWithSession(
       description: "/e2e:simple-message",
       workflow_id: seedData.workflowId,
       workflow_step_id: seedData.startStepId,
-      repository_ids: [seedData.repositoryId],
+      repository_ids: repositoryIds,
     },
   );
 
@@ -56,6 +57,26 @@ async function seedTaskWithSession(
 
   return { session, sessionId: task.session_id };
 }
+
+test.describe("VS Code toolbar open", () => {
+  test("adds the embedded editor tab for a repository-less session", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    const { session } = await seedTaskWithSession(
+      testPage,
+      apiClient,
+      seedData,
+      "Repository-less VSCode Open Test",
+      [],
+    );
+
+    await testPage.getByTestId("editors-menu-open").click();
+
+    await expect(session.vscodeTab()).toBeVisible({ timeout: 10_000 });
+  });
+});
 
 test.describe("VS Code open panel", () => {
   test.describe.configure({ retries: 1 });

--- a/apps/web/e2e/tests/settings/vscode-open-panel.spec.ts
+++ b/apps/web/e2e/tests/settings/vscode-open-panel.spec.ts
@@ -24,6 +24,46 @@ function findCodeServerInstall(): string | null {
   return null;
 }
 
+/** Mirror an existing code-server install without writing into the host cache. */
+function seedCodeServerInstall(sourceInstallDir: string, targetInstallDir: string): void {
+  if (fs.existsSync(targetInstallDir)) return;
+
+  fs.mkdirSync(targetInstallDir, { recursive: true });
+  for (const entry of fs.readdirSync(sourceInstallDir)) {
+    const sourceRoot = path.join(sourceInstallDir, entry);
+    const sourceBinDir = path.join(sourceRoot, "bin");
+    const sourceBinary = path.join(sourceBinDir, "code-server");
+    if (!fs.existsSync(sourceBinary)) continue;
+
+    const targetRoot = path.join(targetInstallDir, entry);
+    const targetBinDir = path.join(targetRoot, "bin");
+    fs.mkdirSync(targetBinDir, { recursive: true });
+    for (const child of fs.readdirSync(sourceRoot)) {
+      if (child === "bin") continue;
+      fs.symlinkSync(path.join(sourceRoot, child), path.join(targetRoot, child));
+    }
+    for (const child of fs.readdirSync(sourceBinDir)) {
+      if (child.endsWith(".install-complete")) continue;
+      fs.symlinkSync(path.join(sourceBinDir, child), path.join(targetBinDir, child));
+    }
+    fs.writeFileSync(path.join(targetBinDir, "code-server.install-complete"), "");
+  }
+}
+
+const codeServerDir = findCodeServerInstall();
+
+test.beforeEach(async ({ backend }) => {
+  if (!codeServerDir) {
+    test.skip(true, "code-server not installed — skipping VS Code e2e tests");
+    return;
+  }
+
+  seedCodeServerInstall(
+    codeServerDir,
+    path.join(backend.tmpDir, ".kandev", "tools", "code-server"),
+  );
+});
+
 /**
  * Seed a task + session via the API and navigate directly to the session page.
  * Waits for the mock agent to complete its turn (idle input visible).
@@ -80,23 +120,6 @@ test.describe("VS Code toolbar open", () => {
 
 test.describe("VS Code open panel", () => {
   test.describe.configure({ retries: 1 });
-
-  const codeServerDir = findCodeServerInstall();
-
-  test.beforeEach(async ({ backend }) => {
-    if (!codeServerDir) {
-      test.skip(true, "code-server not installed — skipping VS Code e2e tests");
-      return;
-    }
-
-    // Symlink the real code-server install into the e2e backend's HOME so
-    // ResolveBinary finds the pre-installed binary without re-downloading.
-    const targetDir = path.join(backend.tmpDir, ".kandev", "tools", "code-server");
-    if (!fs.existsSync(targetDir)) {
-      fs.mkdirSync(path.dirname(targetDir), { recursive: true });
-      fs.symlinkSync(codeServerDir, targetDir);
-    }
-  });
 
   /**
    * Regression test for VS Code panel placement.

--- a/apps/web/hooks/use-open-session-in-editor.test.ts
+++ b/apps/web/hooks/use-open-session-in-editor.test.ts
@@ -4,6 +4,11 @@ import { renderHook } from "@testing-library/react";
 const mockOpenSessionInEditor = vi.fn();
 const mockOpenFileInVscode = vi.fn();
 const mockOpenInternalVscode = vi.fn();
+const mockToast = vi.fn();
+
+vi.mock("@/components/toast-provider", () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
 
 vi.mock("@/lib/api", () => ({
   openSessionInEditor: (...args: unknown[]) => mockOpenSessionInEditor(...args),
@@ -62,5 +67,18 @@ describe("useOpenSessionInEditor", () => {
     await result.current.open({ editorId: "editor-1", worktreeId: "wt-2" });
 
     expect(mockOpenSessionInEditor).not.toHaveBeenCalled();
+  });
+
+  it("reports editor API failures instead of leaving the button silently idle", async () => {
+    mockOpenSessionInEditor.mockRejectedValueOnce(new Error("workspace path not found"));
+    const { result } = renderHook(() => useOpenSessionInEditor("session-1"));
+
+    await expect(result.current.open({ editorId: "editor-1" })).resolves.toBeNull();
+
+    expect(mockToast).toHaveBeenCalledWith({
+      title: "Failed to open editor",
+      description: "workspace path not found",
+      variant: "error",
+    });
   });
 });

--- a/apps/web/hooks/use-open-session-in-editor.ts
+++ b/apps/web/hooks/use-open-session-in-editor.ts
@@ -4,6 +4,7 @@ import { openSessionInEditor } from "@/lib/api";
 import { useRequest } from "@/lib/http/use-request";
 import { useDockviewStore } from "@/lib/state/dockview-store";
 import { openFileInVscode } from "@/lib/api/domains/vscode-api";
+import { useToast } from "@/components/toast-provider";
 
 type OpenEditorOptions = {
   filePath?: string;
@@ -35,6 +36,7 @@ function parseInternalVscodeURL(url: string): { file: string; line: number; col:
 }
 
 export function useOpenSessionInEditor(sessionId?: string | null) {
+  const { toast } = useToast();
   const request = useRequest(async (options?: OpenEditorOptions) => {
     if (!sessionId) {
       return null;
@@ -72,7 +74,18 @@ export function useOpenSessionInEditor(sessionId?: string | null) {
   });
 
   return {
-    open: (options?: OpenEditorOptions) => request.run(options),
+    open: async (options?: OpenEditorOptions) => {
+      try {
+        return await request.run(options);
+      } catch (error) {
+        toast({
+          title: "Failed to open editor",
+          description: error instanceof Error ? error.message : "Request failed",
+          variant: "error",
+        });
+        return null;
+      }
+    },
     status: request.status,
     isLoading: request.isLoading,
   };


### PR DESCRIPTION
Interrupted code-server extraction could leave a wrapper-only cache that every retry treated as valid. Completed installs now carry a post-extraction marker, allowing retries to repair partial caches while preserving normal cache reuse.

## Validation

- `go test -race ./internal/tools/installer`
- `make fmt`
- `make typecheck`
- `make test`
- `make lint`
- Reproduced the existing cached wrapper failure directly (`lib/node: not found`, exit 127)
- Public docs unchanged because this only corrects internal installer cache recovery

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1800?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->