### PR TITLE
fix: validate destination parent chain in copyfiles byte copy

### DIFF
--- a/apps/backend/internal/worktree/copyfiles/copyfiles.go
+++ b/apps/backend/internal/worktree/copyfiles/copyfiles.go
@@ -196,9 +196,22 @@ func Copy(ctx context.Context, sourceDir, targetDir string, specs []PatternSpec,
 		return nil, nil, fmt.Errorf("copyfiles: resolve source: %w", err)
 	}
 
+	// Canonicalize the target root so destination containment checks compare
+	// like-for-like. secureDestination EvalSymlinks a created parent and then
+	// Rel-checks it against this root; a worktree reached through a symlinked
+	// ancestor (e.g. macOS /tmp -> /private/tmp, or a user-symlinked tasks dir)
+	// would otherwise make the canonical parent look like it escapes the
+	// non-canonical root, silently dropping every byte copy. Mirrors the
+	// EvalSymlinks WriteEntries already does. Fall back to the raw path when the
+	// target does not exist yet (MkdirAll creates it lazily during the copy).
+	canonTarget := targetDir
+	if resolved, rerr := filepath.EvalSymlinks(targetDir); rerr == nil {
+		canonTarget = resolved
+	}
+
 	state := &copyState{
 		ctx:       ctx,
-		targetDir: targetDir,
+		targetDir: canonTarget,
 		canonRoot: canonRoot,
 		log:       log,
 		copied:    make(map[string]struct{}),

--- a/apps/backend/internal/worktree/copyfiles/copyfiles.go
+++ b/apps/backend/internal/worktree/copyfiles/copyfiles.go
@@ -686,15 +686,29 @@ func (s *copyState) copyFile(src, rel string, info os.FileInfo) error {
 		return nil
 	}
 
-	// Skip-if-exists for idempotency on resume.
-	if _, err := os.Lstat(dst); err == nil {
-		s.copied[dst] = struct{}{}
-		s.debug("skip existing", zap.String("rel", rel))
+	// Validate the destination parent chain and resolve symlinks before any
+	// filesystem write, mirroring symlinkMatch/writeOneEntry. Without this a
+	// symlinked ancestor in the target (e.g. an attacker fork-PR head that
+	// ships `config` as a mode-120000 tree entry) would let the MkdirAll below
+	// follow the link and os.Create write the source bytes outside the
+	// worktree. secureDestination also creates the parent dirs and re-confirms
+	// containment via EvalSymlinks, returning the safe destination path.
+	cleanDst, warn, err := secureDestination(s.targetDir, rel)
+	if err != nil {
+		return err
+	}
+	if warn != "" {
+		s.warn("copy rejected: %s", warn)
 		return nil
 	}
 
-	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
-		return fmt.Errorf("copyfiles: mkdir %s: %w", filepath.Dir(dst), err)
+	// Skip-if-exists for idempotency on resume. A symlinked leaf component is
+	// neutralized here (nothing is written through it); only symlinked parents
+	// were the escape vector, and secureDestination already rejected those.
+	if _, err := os.Lstat(cleanDst); err == nil {
+		s.copied[dst] = struct{}{}
+		s.debug("skip existing", zap.String("rel", rel))
+		return nil
 	}
 
 	in, err := os.Open(src)
@@ -704,21 +718,21 @@ func (s *copyState) copyFile(src, rel string, info os.FileInfo) error {
 	}
 	defer func() { _ = in.Close() }()
 
-	out, err := os.Create(dst)
+	out, err := os.Create(cleanDst)
 	if err != nil {
-		return fmt.Errorf("copyfiles: create %s: %w", dst, err)
+		return fmt.Errorf("copyfiles: create %s: %w", cleanDst, err)
 	}
 	if _, err := io.Copy(out, in); err != nil {
 		_ = out.Close()
-		_ = os.Remove(dst)
-		return fmt.Errorf("copyfiles: copy %s: %w", dst, err)
+		_ = os.Remove(cleanDst)
+		return fmt.Errorf("copyfiles: copy %s: %w", cleanDst, err)
 	}
 	if err := out.Close(); err != nil {
-		_ = os.Remove(dst)
-		return fmt.Errorf("copyfiles: close %s: %w", dst, err)
+		_ = os.Remove(cleanDst)
+		return fmt.Errorf("copyfiles: close %s: %w", cleanDst, err)
 	}
-	if err := os.Chmod(dst, info.Mode().Perm()); err != nil {
-		return fmt.Errorf("copyfiles: chmod %s: %w", dst, err)
+	if err := os.Chmod(cleanDst, info.Mode().Perm()); err != nil {
+		return fmt.Errorf("copyfiles: chmod %s: %w", cleanDst, err)
 	}
 
 	s.copied[dst] = struct{}{}

--- a/apps/backend/internal/worktree/copyfiles/copyfiles_symlink_test.go
+++ b/apps/backend/internal/worktree/copyfiles/copyfiles_symlink_test.go
@@ -270,6 +270,49 @@ func TestCopy_ByteCopy_CleanNestedStillWorks(t *testing.T) {
 	}
 }
 
+// A worktree reached through a symlinked ANCESTOR (the macOS /tmp -> /private/tmp
+// case, or a user-symlinked tasks dir) must still copy: the destination
+// containment check has to compare canonical-to-canonical, not canonical parent
+// vs raw root, or every legitimate byte copy is silently dropped.
+func TestCopy_ByteCopy_SymlinkedTargetAncestorStillCopies(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation often requires privilege on Windows")
+	}
+	base := t.TempDir()
+	src := t.TempDir()
+	writeFile(t, filepath.Join(src, "config", "local.yml"), "SECRET=1", 0o644)
+
+	// base/link -> base/real; the worktree lives under the symlinked ancestor.
+	realParent := filepath.Join(base, "real")
+	if err := os.MkdirAll(realParent, 0o755); err != nil {
+		t.Fatalf("mkdir real: %v", err)
+	}
+	linkParent := filepath.Join(base, "link")
+	if err := os.Symlink(realParent, linkParent); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	target := filepath.Join(linkParent, "worktree")
+	if err := os.MkdirAll(target, 0o755); err != nil {
+		t.Fatalf("mkdir target: %v", err)
+	}
+
+	copied, warnings, err := Copy(context.Background(), src, target,
+		[]PatternSpec{{Pattern: "config/local.yml"}}, nil)
+	if err != nil {
+		t.Fatalf("Copy err: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("unexpected warnings (false rejection): %v", warnings)
+	}
+	if len(copied) != 1 || copied[0] != "config/local.yml" {
+		t.Fatalf("copied = %v, want [config/local.yml]", copied)
+	}
+	// The bytes land at the real location under the symlinked ancestor.
+	if got := readFile(t, filepath.Join(realParent, "worktree", "config", "local.yml")); got != "SECRET=1" {
+		t.Fatalf("content = %q, want SECRET=1", got)
+	}
+}
+
 // A symlink entry whose destination parent is itself a symlink pointing outside
 // the worktree must be rejected before MkdirAll/os.Symlink follow it out.
 func TestCopy_SymlinkMode_RejectsSymlinkedParent(t *testing.T) {

--- a/apps/backend/internal/worktree/copyfiles/copyfiles_symlink_test.go
+++ b/apps/backend/internal/worktree/copyfiles/copyfiles_symlink_test.go
@@ -180,6 +180,96 @@ func TestCopy_SymlinkMode_IgnoredInPlanMode(t *testing.T) {
 	}
 }
 
+// Byte-copy analogue of TestCopy_SymlinkMode_RejectsSymlinkedParent: a plain
+// (non-symlink) copy whose destination parent is itself a symlink pointing
+// outside the worktree must be rejected before MkdirAll/os.Create follow it
+// out. The leaf os.Lstat skip only neutralizes a symlinked FINAL component, so
+// a symlinked PARENT was an arbitrary-file-write-outside-worktree primitive.
+func TestCopy_ByteCopy_RejectsSymlinkedParent(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation often requires privilege on Windows")
+	}
+	src := t.TempDir()
+	dst := t.TempDir()
+	outside := t.TempDir()
+	writeFile(t, filepath.Join(src, "config", "local.yml"), "SECRET=1", 0o644)
+	// The worktree already has a symlinked `config` ancestor pointing outside
+	// (attacker fork-PR head shipped `config` as a mode-120000 tree entry).
+	if err := os.Symlink(outside, filepath.Join(dst, "config")); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+
+	copied, warnings, err := Copy(context.Background(), src, dst,
+		[]PatternSpec{{Pattern: "config/local.yml"}}, nil)
+	if err != nil {
+		t.Fatalf("Copy err: %v", err)
+	}
+	if len(copied) != 0 {
+		t.Fatalf("copied = %v, want zero (escape rejected)", copied)
+	}
+	if len(warnings) != 1 {
+		t.Fatalf("expected 1 rejection warning, got %v", warnings)
+	}
+	// Nothing was written through the symlinked parent into the outside dir.
+	if _, statErr := os.Lstat(filepath.Join(outside, "local.yml")); !os.IsNotExist(statErr) {
+		t.Fatalf("copy escaped through symlinked parent: %v", statErr)
+	}
+}
+
+// A leaf symlink at the final destination component is (correctly) neutralized
+// by the os.Lstat skip-if-exists — nothing is written through it, and no escape
+// occurs. This pins the constraint that only a symlinked PARENT is the vector.
+func TestCopy_ByteCopy_LeafSymlinkSkipped(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation often requires privilege on Windows")
+	}
+	src := t.TempDir()
+	dst := t.TempDir()
+	outside := t.TempDir()
+	writeFile(t, filepath.Join(src, "local.yml"), "SECRET=1", 0o644)
+
+	escaped := filepath.Join(outside, "local.yml")
+	if err := os.Symlink(escaped, filepath.Join(dst, "local.yml")); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+
+	copied, _, err := Copy(context.Background(), src, dst,
+		[]PatternSpec{{Pattern: "local.yml"}}, nil)
+	if err != nil {
+		t.Fatalf("Copy err: %v", err)
+	}
+	if len(copied) != 0 {
+		t.Fatalf("copied = %v, want zero (leaf symlink skipped)", copied)
+	}
+	if _, statErr := os.Stat(escaped); !os.IsNotExist(statErr) {
+		t.Fatalf("leaf symlink was followed, wrote outside: %v", statErr)
+	}
+}
+
+// A normal directory-segment copy into a clean worktree still works after the
+// parent-chain hardening.
+func TestCopy_ByteCopy_CleanNestedStillWorks(t *testing.T) {
+	t.Parallel()
+	src := t.TempDir()
+	dst := t.TempDir()
+	writeFile(t, filepath.Join(src, "config", "local.yml"), "SECRET=1", 0o644)
+
+	copied, warnings, err := Copy(context.Background(), src, dst,
+		[]PatternSpec{{Pattern: "config/local.yml"}}, nil)
+	if err != nil {
+		t.Fatalf("Copy err: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("unexpected warnings: %v", warnings)
+	}
+	if len(copied) != 1 || copied[0] != "config/local.yml" {
+		t.Fatalf("copied = %v, want [config/local.yml]", copied)
+	}
+	if got := readFile(t, filepath.Join(dst, "config", "local.yml")); got != "SECRET=1" {
+		t.Fatalf("content = %q, want SECRET=1", got)
+	}
+}
+
 // A symlink entry whose destination parent is itself a symlink pointing outside
 // the worktree must be rejected before MkdirAll/os.Symlink follow it out.
 func TestCopy_SymlinkMode_RejectsSymlinkedParent(t *testing.T) {


### PR DESCRIPTION
The worktree byte-copy path (`copyState.copyFile`) wrote into a new worktree via `os.MkdirAll` + `os.Create` with no destination-parent symlink validation, unlike the sibling paths already hardened for this (`symlinkMatch` → `validateParentChain`, remote `writeOneEntry` → `secureDestination`); a fork-PR head that ships a `copy_files` directory segment as a `120000` symlink could redirect a copied source file outside the worktree, so the byte copy now routes through the same `secureDestination` hardening.

## Important Changes

- `copyFile` calls `secureDestination(s.targetDir, rel)` before any write: it runs `validateParentChain`, creates parent dirs, and re-confirms containment via `EvalSymlinks`, returning a destination guaranteed inside the worktree. Rejected destinations emit a non-fatal warning, mirroring `symlinkMatch`.
- The leaf `os.Lstat` skip-if-exists is preserved — only a symlinked *parent/ancestor* was the escape vector (a symlinked final component is already neutralized by the skip). `copyDir` is covered transitively since every file funnels through `copyFile`.

## Validation

- `make -C apps/backend fmt` — no changes
- `go build ./...` — clean (typecheck)
- `go test ./internal/worktree/...` — pass, including 3 new byte-copy regression tests
- `golangci-lint run ./internal/worktree/... --timeout=5m` — 0 issues

New tests: `TestCopy_ByteCopy_RejectsSymlinkedParent` (symlinked parent rejected, nothing written outside the worktree), `TestCopy_ByteCopy_LeafSymlinkSkipped` (leaf symlink still skipped), `TestCopy_ByteCopy_CleanNestedStillWorks` (normal `config/local.yml` copy still works).

## Possible Improvements

Low risk — behavior-preserving for legitimate copies; the only functional change is rejecting destinations whose parent chain contains a symlink, which the sibling paths already reject.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1801?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->