### PR TITLE
fix: ignore echoed user ACP chunks

### DIFF
--- a/apps/backend/internal/agent/runtime/lifecycle/manager_events.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_events.go
@@ -21,7 +21,7 @@ const (
 
 // handleMessageChunkEvent handles a "message_chunk" agent event, accumulating and flushing on newlines.
 func (m *Manager) handleMessageChunkEvent(execution *AgentExecution, event agentctl.AgentEvent) {
-	if event.Text == "" {
+	if event.Role == "user" || event.Text == "" {
 		return
 	}
 	execution.messageMu.Lock()

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_events_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_events_test.go
@@ -87,6 +87,35 @@ func createTestExecution(id, taskID, sessionID string) *AgentExecution {
 	}
 }
 
+func TestHandleAgentEvent_UserMessageChunkNotBufferedAsAssistant(t *testing.T) {
+	mgr, eventBus := createTestManagerWithTracking()
+	execution := createTestExecution("exec-1", "task-1", "session-1")
+	if err := mgr.executionStore.Add(execution); err != nil {
+		t.Fatalf("add execution: %v", err)
+	}
+
+	mgr.handleAgentEvent(execution, agentctl.AgentEvent{
+		Type: "message_chunk",
+		Text: "<hidden-system-prompt>\nhello",
+		Role: "user",
+	})
+	mgr.handleAgentEvent(execution, agentctl.AgentEvent{
+		Type: "message_chunk",
+		Text: "Hello.",
+	})
+	mgr.handleAgentEvent(execution, agentctl.AgentEvent{Type: "complete"})
+
+	var streamedText string
+	for _, event := range eventBus.getStreamEvents() {
+		if event.Data != nil && event.Data.Type == "message_streaming" {
+			streamedText += event.Data.Text
+		}
+	}
+	if streamedText != "Hello." {
+		t.Fatalf("streamed assistant text = %q, want %q", streamedText, "Hello.")
+	}
+}
+
 // TestHandleAgentEvent_StreamingThenComplete tests the normal flow:
 // message_chunk events followed by complete event - should NOT create duplicate
 func TestHandleAgentEvent_StreamingThenComplete(t *testing.T) {


### PR DESCRIPTION
Grok ACP echoes submitted prompts as user chunks, which were buffered as assistant output and produced blank or concatenated chat messages. Ignore role-tagged user chunks so the assistant stream contains only assistant output.

## Validation

- `make fmt`
- `make typecheck`
- `make test`
- `make lint`
- `go test -race ./internal/agent/runtime/lifecycle -run TestHandleAgentEvent_UserMessageChunkNotBufferedAsAssistant -count=1`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1804?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->