### PR TITLE
fix(ci): don't attach Pages environment on registry PR validation runs

### DIFF
--- a/.github/workflows/plugin-registry-index.yml
+++ b/.github/workflows/plugin-registry-index.yml
@@ -42,9 +42,12 @@ jobs:
   build-and-deploy:
     name: Build index.json and deploy to Pages
     runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deploy.outputs.page_url }}
+    # Attach the github-pages environment only on deploy events. That
+    # environment restricts deployments to the default branch, so leaving it on
+    # for pull_request runs blocks the job at setup (before any step) on every PR
+    # branch that touches plugin-registry/**. On PRs we only validate (build +
+    # test); the deploy steps below are already gated to non-PR events.
+    environment: ${{ github.event_name != 'pull_request' && 'github-pages' || '' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6


### PR DESCRIPTION
Every PR that touches `plugin-registry/**` (e.g. the plugin-marketplace docs PR) failed the "Plugin Registry Index" check at job setup, before any step ran. Root cause: the job attaches `environment: github-pages` unconditionally, and that environment restricts deployments to the default branch — so on a PR branch GitHub rejects the job at the environment gate. PRs only need to validate (build + test); the actual Pages deploy steps were already gated to non-PR events. Gate the environment the same way so PR validation runs can execute.

## Validation

- `python3 -c "import yaml; yaml.safe_load(...)"` — workflow parses.
- `.github/scripts/lint-action-pinning.py` — all workflow action refs SHA-pinned.
- On a `pull_request` event the expression resolves to an empty environment (job runs, no gate); on push/schedule/dispatch it resolves to `github-pages` and deploys as before.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1806?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- kandev-preview-start -->
### Preview Environment

| | |
|---|---|
| **URL** | https://kandev-pr-1806-bwo7.sprites.app |
| **Commit** | `db198f7` |
| **Agent** | Mock agent |

> Updates automatically on each push. Destroyed when the PR is closed.
<!-- kandev-preview-end -->