### PR TITLE
fix(plugins): require per-boot operator token on state-changing plugin routes

### DIFF
--- a/apps/backend/internal/backendapp/helpers.go
+++ b/apps/backend/internal/backendapp/helpers.go
@@ -683,7 +683,7 @@ func webAppHandlerOptions(p routeParams) []webapp.HandlerOption {
 func bootPayload(ctx context.Context, req *http.Request, p routeParams, route webapp.RouteClassification) webapp.BootPayload {
 	payload := webapp.NewBootPayload(
 		route,
-		webapp.RuntimeConfig{APIPrefix: "/api/v1", WebSocketPath: "/ws", Debug: p.devMode, CSRFToken: p.bootToken},
+		webapp.RuntimeConfig{APIPrefix: "/api/v1", WebSocketPath: "/ws", Debug: p.devMode, BootToken: p.bootToken},
 		bootInitialState(ctx, req, p, route),
 	)
 	payload.RouteData = bootRouteData(ctx, req, p, route)

--- a/apps/backend/internal/backendapp/helpers.go
+++ b/apps/backend/internal/backendapp/helpers.go
@@ -483,9 +483,13 @@ type routeParams struct {
 	webInternalURL          string
 	devMode                 bool
 	httpPort                int
-	features                config.FeaturesConfig
-	voice                   config.VoiceConfig
-	log                     *logger.Logger
+	// bootToken is the per-boot operator token embedded in the SPA boot
+	// payload and required (via httpmw.RequireBootToken) on state-changing
+	// operator routes such as plugin install/enable.
+	bootToken string
+	features  config.FeaturesConfig
+	voice     config.VoiceConfig
+	log       *logger.Logger
 }
 
 // registerRoutes sets up all HTTP and WebSocket routes on the given router.
@@ -679,7 +683,7 @@ func webAppHandlerOptions(p routeParams) []webapp.HandlerOption {
 func bootPayload(ctx context.Context, req *http.Request, p routeParams, route webapp.RouteClassification) webapp.BootPayload {
 	payload := webapp.NewBootPayload(
 		route,
-		webapp.RuntimeConfig{APIPrefix: "/api/v1", WebSocketPath: "/ws", Debug: p.devMode},
+		webapp.RuntimeConfig{APIPrefix: "/api/v1", WebSocketPath: "/ws", Debug: p.devMode, CSRFToken: p.bootToken},
 		bootInitialState(ctx, req, p, route),
 	)
 	payload.RouteData = bootRouteData(ctx, req, p, route)
@@ -992,7 +996,7 @@ func registerSecondaryRoutes(
 	}
 
 	if p.features.Plugins && p.services.Plugins != nil {
-		plugins.RegisterRoutes(p.router, p.services.Plugins, p.services.Plugins.Deliverer(), p.log)
+		plugins.RegisterRoutes(p.router, p.services.Plugins, p.services.Plugins.Deliverer(), p.log, p.bootToken)
 		p.log.Debug("Registered Plugins handlers (HTTP)")
 	}
 

--- a/apps/backend/internal/backendapp/main.go
+++ b/apps/backend/internal/backendapp/main.go
@@ -1643,6 +1643,15 @@ func buildHTTPServer(
 		port = ports.Backend
 	}
 
+	// Per-boot operator token: embedded in the SPA boot payload and required
+	// on state-changing operator routes (see httpmw.RequireBootToken). A
+	// generation failure (crypto/rand exhausted — effectively impossible) is
+	// fatal rather than silently leaving those routes open.
+	bootToken, err := httpmw.NewBootToken()
+	if err != nil {
+		log.Fatal("failed to generate operator boot token", zap.Error(err))
+	}
+
 	registerRoutes(routeParams{
 		router:                  router,
 		gateway:                 gateway,
@@ -1677,6 +1686,7 @@ func buildHTTPServer(
 		webInternalURL:          cfg.Server.WebInternalURL,
 		devMode:                 cfg.Debug.DevMode || cfg.Debug.PprofEnabled,
 		httpPort:                port,
+		bootToken:               bootToken,
 		features:                cfg.Features,
 		voice:                   cfg.Voice,
 		log:                     log,

--- a/apps/backend/internal/backendapp/middleware.go
+++ b/apps/backend/internal/backendapp/middleware.go
@@ -29,7 +29,11 @@ func corsMiddleware() gin.HandlerFunc {
 			c.Header("Access-Control-Allow-Origin", "*")
 		}
 		c.Header("Access-Control-Allow-Methods", "GET, POST, PATCH, PUT, DELETE, OPTIONS")
-		c.Header("Access-Control-Allow-Headers", "Origin, Content-Type, Authorization, Upgrade, Connection, Sec-WebSocket-Key, Sec-WebSocket-Version, Sec-WebSocket-Protocol")
+		// httpmw.BootTokenHeader must be allowed so split-origin (Vite dev)
+		// plugin mutations — which the SPA now sends with this custom header —
+		// survive the browser's CORS preflight instead of being blocked before
+		// they reach the guarded routes.
+		c.Header("Access-Control-Allow-Headers", "Origin, Content-Type, Authorization, "+httpmw.BootTokenHeader+", Upgrade, Connection, Sec-WebSocket-Key, Sec-WebSocket-Version, Sec-WebSocket-Protocol")
 
 		if c.Request.Method == "OPTIONS" {
 			c.AbortWithStatus(http.StatusNoContent)

--- a/apps/backend/internal/backendapp/middleware_test.go
+++ b/apps/backend/internal/backendapp/middleware_test.go
@@ -3,10 +3,37 @@ package backendapp
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
+
+	"github.com/kandev/kandev/internal/common/httpmw"
 )
+
+// TestCORSMiddlewareAllowsBootTokenHeaderInPreflight pins that the operator
+// boot-token header is in Access-Control-Allow-Headers — without it, a
+// split-origin (Vite dev) plugin mutation carrying X-Kandev-Boot-Token is
+// blocked by the browser's CORS preflight before it reaches the guarded route.
+func TestCORSMiddlewareAllowsBootTokenHeaderInPreflight(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.Use(corsMiddleware())
+	router.POST("/api/plugins/install", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	req := httptest.NewRequest(http.MethodOptions, "/api/plugins/install", nil)
+	req.Host = "localhost:38429"
+	req.Header.Set("Origin", "http://localhost:37429")
+	req.Header.Set("Access-Control-Request-Method", http.MethodPost)
+	req.Header.Set("Access-Control-Request-Headers", httpmw.BootTokenHeader)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	allowed := rec.Header().Get("Access-Control-Allow-Headers")
+	if !strings.Contains(allowed, httpmw.BootTokenHeader) {
+		t.Fatalf("Access-Control-Allow-Headers = %q, want it to include %q", allowed, httpmw.BootTokenHeader)
+	}
+}
 
 func TestCORSMiddlewareEchoesOriginForCredentialedRequests(t *testing.T) {
 	gin.SetMode(gin.TestMode)

--- a/apps/backend/internal/common/httpmw/boottoken.go
+++ b/apps/backend/internal/common/httpmw/boottoken.go
@@ -1,0 +1,58 @@
+package httpmw
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// BootTokenHeader is the request header the SPA sends to prove it read the
+// same-origin boot payload. A cross-origin page cannot read another origin's
+// boot payload, and a CORS "simple" request cannot set a custom header without
+// triggering a preflight the CORS layer then blocks — so requiring this header
+// on state-changing routes defeats both the CSRF drive-by and the
+// unauthenticated LAN caller (who never sees the token).
+const BootTokenHeader = "X-Kandev-Boot-Token" //nolint:gosec // header name, not a credential
+
+// NewBootToken mints a fresh, unguessable per-boot token (256 bits of
+// crypto/rand, hex-encoded). Generated once per backend process and embedded
+// in the SPA boot payload; RequireBootToken validates inbound requests against
+// it.
+func NewBootToken() (string, error) {
+	buf := make([]byte, 32)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("generate boot token: %w", err)
+	}
+	return hex.EncodeToString(buf), nil
+}
+
+// RequireBootToken returns middleware that rejects any request whose
+// BootTokenHeader does not match token (constant-time compare). It is
+// deliberately fail-closed: an empty token means the process was misconfigured
+// (token generation should never fail), so every request is refused rather
+// than silently left open. Apply only to state-changing operator routes — not
+// to browser-native asset loads (dynamic import()/stylesheet fetches cannot
+// set custom headers) or to endpoints intended for external unauthenticated
+// callers (e.g. inbound webhook relays).
+func RequireBootToken(token string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if token == "" {
+			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
+				"error": "server missing operator token",
+			})
+			return
+		}
+		got := c.GetHeader(BootTokenHeader)
+		if got == "" || subtle.ConstantTimeCompare([]byte(got), []byte(token)) != 1 {
+			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{
+				"error": "missing or invalid operator token",
+			})
+			return
+		}
+		c.Next()
+	}
+}

--- a/apps/backend/internal/common/httpmw/boottoken.go
+++ b/apps/backend/internal/common/httpmw/boottoken.go
@@ -46,8 +46,12 @@ func RequireBootToken(token string) gin.HandlerFunc {
 			})
 			return
 		}
+		// No early-out on an empty/absent header: ConstantTimeCompare already
+		// returns 0 for a length mismatch, so folding both cases into one
+		// branch avoids an application-level timing distinguisher between
+		// "header absent" and "header present but wrong".
 		got := c.GetHeader(BootTokenHeader)
-		if got == "" || subtle.ConstantTimeCompare([]byte(got), []byte(token)) != 1 {
+		if subtle.ConstantTimeCompare([]byte(got), []byte(token)) != 1 {
 			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{
 				"error": "missing or invalid operator token",
 			})

--- a/apps/backend/internal/common/httpmw/boottoken_test.go
+++ b/apps/backend/internal/common/httpmw/boottoken_test.go
@@ -1,0 +1,84 @@
+package httpmw
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func newBootTokenRouter(token string) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.POST("/guarded", RequireBootToken(token), func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+	return r
+}
+
+func TestNewBootTokenIsRandomHex(t *testing.T) {
+	a, err := NewBootToken()
+	if err != nil {
+		t.Fatalf("NewBootToken: %v", err)
+	}
+	b, err := NewBootToken()
+	if err != nil {
+		t.Fatalf("NewBootToken: %v", err)
+	}
+	if a == "" || b == "" {
+		t.Fatal("NewBootToken returned empty token")
+	}
+	if a == b {
+		t.Fatal("NewBootToken returned identical tokens on successive calls")
+	}
+	if len(a) != 64 { // 32 bytes hex-encoded
+		t.Fatalf("token length = %d, want 64", len(a))
+	}
+}
+
+func TestRequireBootTokenValidTokenPasses(t *testing.T) {
+	r := newBootTokenRouter("secret")
+	req := httptest.NewRequest(http.MethodPost, "/guarded", nil)
+	req.Header.Set(BootTokenHeader, "secret")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+}
+
+func TestRequireBootTokenMissingHeaderRejected(t *testing.T) {
+	r := newBootTokenRouter("secret")
+	req := httptest.NewRequest(http.MethodPost, "/guarded", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", rec.Code)
+	}
+}
+
+func TestRequireBootTokenWrongTokenRejected(t *testing.T) {
+	r := newBootTokenRouter("secret")
+	req := httptest.NewRequest(http.MethodPost, "/guarded", nil)
+	req.Header.Set(BootTokenHeader, "nope")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", rec.Code)
+	}
+}
+
+// TestRequireBootTokenEmptyServerTokenFailsClosed pins the fail-closed
+// behavior: a misconfigured (empty) server token must refuse every request
+// rather than leave the route open.
+func TestRequireBootTokenEmptyServerTokenFailsClosed(t *testing.T) {
+	r := newBootTokenRouter("")
+	req := httptest.NewRequest(http.MethodPost, "/guarded", nil)
+	req.Header.Set(BootTokenHeader, "anything")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500 (fail-closed)", rec.Code)
+	}
+}

--- a/apps/backend/internal/plugins/handlers.go
+++ b/apps/backend/internal/plugins/handlers.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"go.uber.org/zap"
 
+	"github.com/kandev/kandev/internal/common/httpmw"
 	"github.com/kandev/kandev/internal/common/logger"
 	"github.com/kandev/kandev/internal/plugins/pkgtar"
 	"github.com/kandev/kandev/internal/plugins/store"
@@ -38,23 +39,34 @@ type Controller struct {
 // parity with the backendapp wiring (svc.SetDeliverer(deliverer) happens
 // alongside this call) — no handler in this file calls it directly, since
 // Service already notifies it on every install/status change.
-func RegisterRoutes(router *gin.Engine, svc *Service, _ Deliverer, log *logger.Logger) {
+//
+// bootToken is the per-boot operator token (see httpmw.RequireBootToken):
+// every state-changing route below is guarded by it, closing the
+// unauthenticated-RCE hole where a LAN peer or a cross-origin browser page
+// could POST /install (a CORS "simple" request that executes before the
+// response is withheld) and spawn a plugin's native binary. Read-only asset
+// serving (:id/bundle, :id/ui/*) is deliberately left ungated — the browser
+// loads those via dynamic import()/stylesheet fetches that cannot carry a
+// custom header — and so is the inbound webhook relay, which is
+// unauthenticated by design for external callers.
+func RegisterRoutes(router *gin.Engine, svc *Service, _ Deliverer, log *logger.Logger, bootToken string) {
 	ctrl := &Controller{svc: svc, log: log}
+	guard := httpmw.RequireBootToken(bootToken)
 
 	api := router.Group("/api/plugins")
-	api.POST("/install", ctrl.install)
-	api.POST("/sync", ctrl.sync)
+	api.POST("/install", guard, ctrl.install)
+	api.POST("/sync", guard, ctrl.sync)
 	// Register the static /marketplace routes before the /:id wildcard, matching
 	// the /install and /sync ordering — some gin/httprouter tree versions reject
 	// a static sibling added after an existing wildcard for the same method.
-	ctrl.registerMarketplaceRoutes(api)
+	ctrl.registerMarketplaceRoutes(api, guard)
 	api.GET("", ctrl.list)
 	api.GET("/:id", ctrl.get)
 	api.GET("/:id/config", ctrl.getConfig)
-	api.PATCH("/:id", ctrl.updateConfig)
-	api.DELETE("/:id", ctrl.uninstall)
-	api.POST("/:id/enable", ctrl.enable)
-	api.POST("/:id/disable", ctrl.disable)
+	api.PATCH("/:id", guard, ctrl.updateConfig)
+	api.DELETE("/:id", guard, ctrl.uninstall)
+	api.POST("/:id/enable", guard, ctrl.enable)
+	api.POST("/:id/disable", guard, ctrl.disable)
 
 	api.GET("/:id/bundle", ctrl.bundle)
 	api.GET("/:id/ui/*path", ctrl.ui)

--- a/apps/backend/internal/plugins/handlers_test.go
+++ b/apps/backend/internal/plugins/handlers_test.go
@@ -18,12 +18,19 @@ import (
 	"github.com/jmoiron/sqlx"
 	_ "github.com/mattn/go-sqlite3"
 
+	"github.com/kandev/kandev/internal/common/httpmw"
 	"github.com/kandev/kandev/internal/db"
 	"github.com/kandev/kandev/internal/plugins/pkgtar/pkgtartest"
 	"github.com/kandev/kandev/internal/plugins/state"
 	"github.com/kandev/kandev/internal/plugins/store"
 	"github.com/kandev/kandev/pkg/pluginsdk"
 )
+
+// testBootToken is the per-boot operator token the test routers register with;
+// doRequest / doMultipartInstall attach it in the X-Kandev-Boot-Token header so
+// the guarded state-changing routes accept them. Tests that assert the guard
+// itself build their own requests without the header.
+const testBootToken = "test-boot-token"
 
 // newTestStateStore returns an in-memory-sqlite-backed *state.Store, for
 // handler tests exercising plugins that declare the state capability.
@@ -53,12 +60,13 @@ func newTestRouter(t *testing.T) (*gin.Engine, *Service) {
 	// where Provide always attaches the shared vault.
 	svc.SetSecrets(newFakeSecretRevealer())
 	router := gin.New()
-	RegisterRoutes(router, svc, nil, testLogger(t))
+	RegisterRoutes(router, svc, nil, testLogger(t), testBootToken)
 	return router, svc
 }
 
 func doRequest(router *gin.Engine, method, path string, body string, headers map[string]string) *httptest.ResponseRecorder {
 	req := httptest.NewRequest(method, path, strings.NewReader(body))
+	req.Header.Set(httpmw.BootTokenHeader, testBootToken)
 	for k, v := range headers {
 		req.Header.Set(k, v)
 	}
@@ -84,6 +92,7 @@ func doMultipartInstall(t *testing.T, router *gin.Engine, pkg *bytes.Buffer) *ht
 
 	req := httptest.NewRequest(http.MethodPost, "/api/plugins/install", &body)
 	req.Header.Set("Content-Type", w.FormDataContentType())
+	req.Header.Set(httpmw.BootTokenHeader, testBootToken)
 	rec := httptest.NewRecorder()
 	router.ServeHTTP(rec, req)
 	return rec
@@ -440,6 +449,109 @@ func TestWriteWebhookResponse_ValidStatusRelaysHeadersAndBody(t *testing.T) {
 	}
 	if rec.Body.String() != `{"ok":true}` {
 		t.Fatalf("body = %q, want %q", rec.Body.String(), `{"ok":true}`)
+	}
+}
+
+// doMultipartInstallNoToken posts a multipart install WITHOUT the operator
+// boot-token header — the shape of a cross-origin CSRF drive-by or an
+// unauthenticated LAN caller.
+func doMultipartInstallNoToken(t *testing.T, router *gin.Engine, pkg *bytes.Buffer) *httptest.ResponseRecorder {
+	t.Helper()
+	var body bytes.Buffer
+	w := multipart.NewWriter(&body)
+	part, err := w.CreateFormFile("package", "plugin.tar.gz")
+	if err != nil {
+		t.Fatalf("CreateFormFile: %v", err)
+	}
+	if _, err := io.Copy(part, pkg); err != nil {
+		t.Fatalf("copy package into form: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close multipart writer: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/plugins/install", &body)
+	req.Header.Set("Content-Type", w.FormDataContentType())
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	return rec
+}
+
+// TestInstallHandlerMultipartRejectsMissingBootToken is the C1 regression: a
+// cross-origin multipart POST /api/plugins/install with no operator token must
+// be rejected with 403 AND must not execute the install (no plugin spawned).
+func TestInstallHandlerMultipartRejectsMissingBootToken(t *testing.T) {
+	router, svc := newTestRouter(t)
+
+	rec := doMultipartInstallNoToken(t, router, testPackage(t, "kandev-plugin-slack", "1.0.0", false))
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403, body=%s", rec.Code, rec.Body.String())
+	}
+	if len(svc.List()) != 0 {
+		t.Fatalf("install executed despite missing token: %d plugins registered", len(svc.List()))
+	}
+	if _, err := svc.Get("kandev-plugin-slack"); err == nil {
+		t.Fatal("plugin was installed despite missing operator token")
+	}
+}
+
+// TestStateChangingRoutesRejectMissingBootToken pins that every gated
+// state-changing route rejects a tokenless request with 403.
+func TestStateChangingRoutesRejectMissingBootToken(t *testing.T) {
+	router, _ := newTestRouter(t)
+
+	cases := []struct {
+		method string
+		path   string
+		body   string
+	}{
+		{http.MethodPost, "/api/plugins/install", `{"url":"http://x"}`},
+		{http.MethodPost, "/api/plugins/sync", ""},
+		{http.MethodPatch, "/api/plugins/some-id", `{"config":{}}`},
+		{http.MethodDelete, "/api/plugins/some-id", ""},
+		{http.MethodPost, "/api/plugins/some-id/enable", ""},
+		{http.MethodPost, "/api/plugins/some-id/disable", ""},
+		{http.MethodPost, "/api/plugins/marketplace/refresh", ""},
+		{http.MethodPost, "/api/plugins/marketplace/sources", `{"name":"x","url":"http://x"}`},
+		{http.MethodPatch, "/api/plugins/marketplace/sources/sid", `{"enabled":false}`},
+		{http.MethodDelete, "/api/plugins/marketplace/sources/sid", ""},
+	}
+	for _, tc := range cases {
+		req := httptest.NewRequest(tc.method, tc.path, strings.NewReader(tc.body))
+		if tc.body != "" {
+			req.Header.Set("Content-Type", "application/json")
+		}
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+		if rec.Code != http.StatusForbidden {
+			t.Errorf("%s %s: status = %d, want 403 (body=%s)", tc.method, tc.path, rec.Code, rec.Body.String())
+		}
+	}
+}
+
+// TestReadAndWebhookRoutesAllowedWithoutBootToken pins that the ungated
+// surface — read-only management GETs, browser-native asset loads, and the
+// external webhook relay — is NOT locked behind the operator token (a 403 here
+// would break plugin UI loading and inbound webhooks).
+func TestReadAndWebhookRoutesAllowedWithoutBootToken(t *testing.T) {
+	router, _ := newTestRouter(t)
+
+	// GET /api/plugins (list) must not require the token.
+	list := httptest.NewRequest(http.MethodGet, "/api/plugins", nil)
+	listRec := httptest.NewRecorder()
+	router.ServeHTTP(listRec, list)
+	if listRec.Code == http.StatusForbidden {
+		t.Fatalf("GET /api/plugins wrongly gated by operator token")
+	}
+
+	// Webhook relay must reach the handler (404 unknown plugin), not 403.
+	wh := httptest.NewRequest(http.MethodPost, "/api/plugins/missing/webhooks/key1", strings.NewReader("{}"))
+	whRec := httptest.NewRecorder()
+	router.ServeHTTP(whRec, wh)
+	if whRec.Code == http.StatusForbidden {
+		t.Fatalf("webhook relay wrongly gated by operator token; got 403")
+	}
+	if whRec.Code != http.StatusNotFound {
+		t.Fatalf("webhook relay status = %d, want 404 (unknown plugin)", whRec.Code)
 	}
 }
 

--- a/apps/backend/internal/plugins/handlers_test.go
+++ b/apps/backend/internal/plugins/handlers_test.go
@@ -543,6 +543,23 @@ func TestReadAndWebhookRoutesAllowedWithoutBootToken(t *testing.T) {
 		t.Fatalf("GET /api/plugins wrongly gated by operator token")
 	}
 
+	// The :id/bundle and :id/ui/* asset routes are the highest-risk
+	// intentionally-open routes — the browser loads them via dynamic
+	// import()/stylesheet fetches that cannot set a custom header, so gating
+	// them would silently break plugin UI loading. Pin that they never 403
+	// (an unknown plugin yields 404, not 403).
+	for _, path := range []string{
+		"/api/plugins/missing/bundle",
+		"/api/plugins/missing/ui/style.css",
+	} {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+		if rec.Code == http.StatusForbidden {
+			t.Fatalf("GET %s wrongly gated by operator token", path)
+		}
+	}
+
 	// Webhook relay must reach the handler (404 unknown plugin), not 403.
 	wh := httptest.NewRequest(http.MethodPost, "/api/plugins/missing/webhooks/key1", strings.NewReader("{}"))
 	whRec := httptest.NewRecorder()

--- a/apps/backend/internal/plugins/marketplace_handlers.go
+++ b/apps/backend/internal/plugins/marketplace_handlers.go
@@ -12,14 +12,16 @@ import (
 
 // registerMarketplaceRoutes wires the marketplace catalog + source-management
 // surface onto the /api/plugins group. Kept separate from RegisterRoutes so
-// the marketplace HTTP surface stays self-contained.
-func (c *Controller) registerMarketplaceRoutes(api *gin.RouterGroup) {
+// the marketplace HTTP surface stays self-contained. guard is the per-boot
+// operator-token middleware (see RegisterRoutes); every mutating route is
+// gated by it, while the read-only catalog/source lists stay open.
+func (c *Controller) registerMarketplaceRoutes(api *gin.RouterGroup, guard gin.HandlerFunc) {
 	api.GET("/marketplace", c.marketplaceCatalog)
-	api.POST("/marketplace/refresh", c.marketplaceRefresh)
+	api.POST("/marketplace/refresh", guard, c.marketplaceRefresh)
 	api.GET("/marketplace/sources", c.listSources)
-	api.POST("/marketplace/sources", c.addSource)
-	api.PATCH("/marketplace/sources/:sid", c.updateSource)
-	api.DELETE("/marketplace/sources/:sid", c.deleteSource)
+	api.POST("/marketplace/sources", guard, c.addSource)
+	api.PATCH("/marketplace/sources/:sid", guard, c.updateSource)
+	api.DELETE("/marketplace/sources/:sid", guard, c.deleteSource)
 }
 
 // addSourceRequest is the POST /api/plugins/marketplace/sources body.

--- a/apps/backend/internal/plugins/marketplace_handlers_test.go
+++ b/apps/backend/internal/plugins/marketplace_handlers_test.go
@@ -60,7 +60,7 @@ func TestMarketplaceCatalogReturnsAnnotatedEntries(t *testing.T) {
 	svc, _, _ := newTestService(t)
 	attachMarketplaceWithSource(t, svc, fixtureIndexServer(t).URL)
 	router := gin.New()
-	RegisterRoutes(router, svc, nil, testLogger(t))
+	RegisterRoutes(router, svc, nil, testLogger(t), testBootToken)
 
 	rec := doRequest(router, http.MethodGet, "/api/plugins/marketplace?category=analytics", "", nil)
 	if rec.Code != http.StatusOK {
@@ -86,7 +86,7 @@ func TestMarketplaceSourceCRUD(t *testing.T) {
 	svc, _, _ := newTestService(t)
 	attachMarketplaceWithSource(t, svc, "https://official.example/index.json")
 	router := gin.New()
-	RegisterRoutes(router, svc, nil, testLogger(t))
+	RegisterRoutes(router, svc, nil, testLogger(t), testBootToken)
 
 	// List returns the built-in source.
 	list := doRequest(router, http.MethodGet, "/api/plugins/marketplace/sources", "", nil)
@@ -125,7 +125,7 @@ func TestMarketplaceDeleteBuiltinReturns409(t *testing.T) {
 	svc, _, _ := newTestService(t)
 	attachMarketplaceWithSource(t, svc, "https://official.example/index.json")
 	router := gin.New()
-	RegisterRoutes(router, svc, nil, testLogger(t))
+	RegisterRoutes(router, svc, nil, testLogger(t), testBootToken)
 
 	sources, err := svc.Marketplace().Sources()
 	if err != nil {

--- a/apps/backend/internal/webapp/payload.go
+++ b/apps/backend/internal/webapp/payload.go
@@ -34,12 +34,13 @@ type RuntimeConfig struct {
 	APIPrefix     string `json:"apiPrefix"`
 	WebSocketPath string `json:"webSocketPath"`
 	Debug         bool   `json:"debug,omitempty"`
-	// CSRFToken is the per-boot operator token the SPA echoes back in the
+	// BootToken is the per-boot operator token the SPA echoes back in the
 	// X-Kandev-Boot-Token header on state-changing requests (see
-	// httpmw.RequireBootToken). It is same-origin readable only, so a
-	// cross-origin CSRF page cannot learn it, and a "simple" cross-origin
-	// request cannot forge the custom header.
-	CSRFToken string `json:"csrfToken,omitempty"`
+	// httpmw.RequireBootToken). It defends against the browser CSRF drive-by:
+	// it is same-origin readable only, so a cross-origin page cannot learn it,
+	// and a "simple" cross-origin request cannot forge the custom header. It is
+	// process-wide (per-boot), not per-session — hence "boot", not "csrf".
+	BootToken string `json:"bootToken,omitempty"`
 }
 
 // BootError is a serializable non-fatal boot-data error for partial hydration.

--- a/apps/backend/internal/webapp/payload.go
+++ b/apps/backend/internal/webapp/payload.go
@@ -34,6 +34,12 @@ type RuntimeConfig struct {
 	APIPrefix     string `json:"apiPrefix"`
 	WebSocketPath string `json:"webSocketPath"`
 	Debug         bool   `json:"debug,omitempty"`
+	// CSRFToken is the per-boot operator token the SPA echoes back in the
+	// X-Kandev-Boot-Token header on state-changing requests (see
+	// httpmw.RequireBootToken). It is same-origin readable only, so a
+	// cross-origin CSRF page cannot learn it, and a "simple" cross-origin
+	// request cannot forge the custom header.
+	CSRFToken string `json:"csrfToken,omitempty"`
 }
 
 // BootError is a serializable non-fatal boot-data error for partial hydration.

--- a/apps/web/lib/api/client.ts
+++ b/apps/web/lib/api/client.ts
@@ -1,4 +1,23 @@
 import { getBackendConfig } from "@/lib/config";
+import { readBootToken } from "@/src/boot-payload";
+
+// BOOT_TOKEN_HEADER carries the per-boot operator token on state-changing
+// requests. A cross-origin CSRF page cannot read the same-origin boot payload
+// to learn the token, and a CORS "simple" request cannot set a custom header
+// without triggering a preflight the backend's CORS layer then blocks — so
+// gating state-changing routes on this header defeats the CSRF drive-by and
+// the unauthenticated LAN caller. Must match httpmw.BootTokenHeader on the
+// backend.
+export const BOOT_TOKEN_HEADER = "X-Kandev-Boot-Token";
+
+// bootTokenHeaders returns the operator-token header when a token is present in
+// the boot payload, or an empty object otherwise. Merge it into a request's
+// headers for any state-changing operator call (plugin install/enable,
+// marketplace source mutations).
+export function bootTokenHeaders(): Record<string, string> {
+  const token = readBootToken();
+  return token ? { [BOOT_TOKEN_HEADER]: token } : {};
+}
 
 export type ApiRequestOptions = {
   baseUrl?: string;

--- a/apps/web/lib/api/client.ts
+++ b/apps/web/lib/api/client.ts
@@ -19,6 +19,24 @@ export function bootTokenHeaders(): Record<string, string> {
   return token ? { [BOOT_TOKEN_HEADER]: token } : {};
 }
 
+// mutationInit builds a fetchJson `init` for a state-changing operator request:
+// it spreads caller init, sets the method/body, and merges the boot-token
+// header LAST so the correct token always wins over any caller-supplied
+// headers (a caller passing a stale/wrong token must not silently 403). Shared
+// by the plugins and marketplace API domains so both use one merge strategy.
+export function mutationInit(
+  method: string,
+  options: ApiRequestOptions | undefined,
+  body?: BodyInit,
+): RequestInit {
+  return {
+    ...(options?.init ?? {}),
+    method,
+    headers: { ...(options?.init?.headers ?? {}), ...bootTokenHeaders() },
+    ...(body !== undefined ? { body } : {}),
+  };
+}
+
 export type ApiRequestOptions = {
   baseUrl?: string;
   cache?: RequestCache;

--- a/apps/web/lib/api/domains/marketplace-api.test.ts
+++ b/apps/web/lib/api/domains/marketplace-api.test.ts
@@ -171,7 +171,7 @@ describe("operator boot-token on state-changing marketplace calls", () => {
 
   beforeEach(() => {
     (window as unknown as { __KANDEV_BOOT_PAYLOAD__?: unknown }).__KANDEV_BOOT_PAYLOAD__ = {
-      runtime: { csrfToken: BOOT_TOKEN },
+      runtime: { bootToken: BOOT_TOKEN },
     };
   });
 

--- a/apps/web/lib/api/domains/marketplace-api.test.ts
+++ b/apps/web/lib/api/domains/marketplace-api.test.ts
@@ -165,3 +165,48 @@ describe("refreshMarketplace", () => {
     expect(result.refreshed).toBe(true);
   });
 });
+
+describe("operator boot-token on state-changing marketplace calls", () => {
+  const BOOT_TOKEN = "boot-token-mkt";
+
+  beforeEach(() => {
+    (window as unknown as { __KANDEV_BOOT_PAYLOAD__?: unknown }).__KANDEV_BOOT_PAYLOAD__ = {
+      runtime: { csrfToken: BOOT_TOKEN },
+    };
+  });
+
+  afterEach(() => {
+    delete (window as unknown as { __KANDEV_BOOT_PAYLOAD__?: unknown }).__KANDEV_BOOT_PAYLOAD__;
+  });
+
+  function tokenHeaderOf(init: FetchInit): string | undefined {
+    return (init?.headers as Record<string, string> | undefined)?.["X-Kandev-Boot-Token"];
+  }
+
+  it("attaches the token to source add/update/delete and refresh", async () => {
+    const calls: Array<() => Promise<unknown>> = [
+      () => addMarketplaceSource("Acme", "https://acme-csrf/index.json"),
+      () => updateMarketplaceSource("s1", { enabled: false }),
+      () => deleteMarketplaceSource("s1"),
+      () => refreshMarketplace(),
+    ];
+    for (const call of calls) {
+      fetchSpy.mockResolvedValueOnce(jsonResponse({ ok: true }));
+      await call();
+      const [, init] = fetchSpy.mock.calls.at(-1) ?? [];
+      expect(tokenHeaderOf(init)).toBe(BOOT_TOKEN);
+    }
+  });
+
+  it("does not attach the token to read-only catalog/source GETs", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ plugins: [], sources: [] }));
+    await getMarketplaceCatalog();
+    const [, catalogInit] = fetchSpy.mock.calls.at(-1) ?? [];
+    expect(tokenHeaderOf(catalogInit)).toBeUndefined();
+
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ sources: [] }));
+    await listMarketplaceSources();
+    const [, listInit] = fetchSpy.mock.calls.at(-1) ?? [];
+    expect(tokenHeaderOf(listInit)).toBeUndefined();
+  });
+});

--- a/apps/web/lib/api/domains/marketplace-api.ts
+++ b/apps/web/lib/api/domains/marketplace-api.ts
@@ -1,23 +1,7 @@
-import { bootTokenHeaders, fetchJson, type ApiRequestOptions } from "../client";
+import { fetchJson, mutationInit, type ApiRequestOptions } from "../client";
 import type { MarketplaceCatalog, MarketplaceSource } from "@/lib/types/plugins";
 
 const BASE = "/api/plugins/marketplace";
-
-// mutationInit merges the per-boot operator-token header into a state-changing
-// marketplace request, preserving caller-supplied init/headers. Source
-// add/update/delete and refresh are gated by httpmw.RequireBootToken.
-function mutationInit(
-  method: string,
-  options: ApiRequestOptions | undefined,
-  body?: BodyInit,
-): RequestInit {
-  return {
-    ...(options?.init ?? {}),
-    method,
-    headers: { ...bootTokenHeaders(), ...(options?.init?.headers ?? {}) },
-    ...(body !== undefined ? { body } : {}),
-  };
-}
 
 // CatalogQuery is the filter/sort applied server-side to the merged catalog.
 export type CatalogQuery = {

--- a/apps/web/lib/api/domains/marketplace-api.ts
+++ b/apps/web/lib/api/domains/marketplace-api.ts
@@ -1,7 +1,23 @@
-import { fetchJson, type ApiRequestOptions } from "../client";
+import { bootTokenHeaders, fetchJson, type ApiRequestOptions } from "../client";
 import type { MarketplaceCatalog, MarketplaceSource } from "@/lib/types/plugins";
 
 const BASE = "/api/plugins/marketplace";
+
+// mutationInit merges the per-boot operator-token header into a state-changing
+// marketplace request, preserving caller-supplied init/headers. Source
+// add/update/delete and refresh are gated by httpmw.RequireBootToken.
+function mutationInit(
+  method: string,
+  options: ApiRequestOptions | undefined,
+  body?: BodyInit,
+): RequestInit {
+  return {
+    ...(options?.init ?? {}),
+    method,
+    headers: { ...bootTokenHeaders(), ...(options?.init?.headers ?? {}) },
+    ...(body !== undefined ? { body } : {}),
+  };
+}
 
 // CatalogQuery is the filter/sort applied server-side to the merged catalog.
 export type CatalogQuery = {
@@ -54,7 +70,7 @@ export async function addMarketplaceSource(
 ): Promise<MarketplaceSource> {
   return fetchJson<MarketplaceSource>(`${BASE}/sources`, {
     ...options,
-    init: { ...(options?.init ?? {}), method: "POST", body: JSON.stringify({ name, url }) },
+    init: mutationInit("POST", options, JSON.stringify({ name, url })),
   });
 }
 
@@ -67,7 +83,7 @@ export async function updateMarketplaceSource(
 ): Promise<MarketplaceSource> {
   return fetchJson<MarketplaceSource>(`${BASE}/sources/${encodeURIComponent(id)}`, {
     ...options,
-    init: { ...(options?.init ?? {}), method: "PATCH", body: JSON.stringify(patch) },
+    init: mutationInit("PATCH", options, JSON.stringify(patch)),
   });
 }
 
@@ -80,7 +96,7 @@ export async function deleteMarketplaceSource(
 ): Promise<{ deleted: boolean }> {
   return fetchJson<{ deleted: boolean }>(`${BASE}/sources/${encodeURIComponent(id)}`, {
     ...options,
-    init: { ...(options?.init ?? {}), method: "DELETE" },
+    init: mutationInit("DELETE", options),
   });
 }
 
@@ -91,6 +107,6 @@ export async function refreshMarketplace(
 ): Promise<{ refreshed: boolean }> {
   return fetchJson<{ refreshed: boolean }>(`${BASE}/refresh`, {
     ...options,
-    init: { ...(options?.init ?? {}), method: "POST" },
+    init: mutationInit("POST", options),
   });
 }

--- a/apps/web/lib/api/domains/plugins-api.test.ts
+++ b/apps/web/lib/api/domains/plugins-api.test.ts
@@ -320,7 +320,7 @@ describe("operator boot-token (X-Kandev-Boot-Token) on state-changing calls", ()
 
   beforeEach(() => {
     (window as unknown as { __KANDEV_BOOT_PAYLOAD__?: unknown }).__KANDEV_BOOT_PAYLOAD__ = {
-      runtime: { csrfToken: BOOT_TOKEN },
+      runtime: { bootToken: BOOT_TOKEN },
     };
   });
 

--- a/apps/web/lib/api/domains/plugins-api.test.ts
+++ b/apps/web/lib/api/domains/plugins-api.test.ts
@@ -315,6 +315,63 @@ describe("syncPlugins", () => {
   });
 });
 
+describe("operator boot-token (X-Kandev-Boot-Token) on state-changing calls", () => {
+  const BOOT_TOKEN = "boot-token-xyz";
+
+  beforeEach(() => {
+    (window as unknown as { __KANDEV_BOOT_PAYLOAD__?: unknown }).__KANDEV_BOOT_PAYLOAD__ = {
+      runtime: { csrfToken: BOOT_TOKEN },
+    };
+  });
+
+  afterEach(() => {
+    delete (window as unknown as { __KANDEV_BOOT_PAYLOAD__?: unknown }).__KANDEV_BOOT_PAYLOAD__;
+  });
+
+  function tokenHeaderOf(init: FetchInit): string | undefined {
+    return (init?.headers as Record<string, string> | undefined)?.["X-Kandev-Boot-Token"];
+  }
+
+  it("attaches the token to a JSON install", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ plugin: plugin() }, 201));
+    await installPluginFromUrl("https://example.test/x.tar.gz");
+    const [, init] = fetchSpy.mock.calls.at(-1) ?? [];
+    expect(tokenHeaderOf(init)).toBe(BOOT_TOKEN);
+  });
+
+  it("attaches the token to a multipart install (the CSRF-RCE vector)", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ plugin: plugin() }, 201));
+    await installPluginUpload(new File([new Uint8Array([1])], "csrf-plugin.tar.gz"));
+    const [, init] = fetchSpy.mock.calls.at(-1) ?? [];
+    expect(tokenHeaderOf(init)).toBe(BOOT_TOKEN);
+    // Still no Content-Type, so the browser sets the multipart boundary.
+    expect((init?.headers as Record<string, string>)?.["Content-Type"]).toBeUndefined();
+  });
+
+  it("attaches the token to enable/disable/uninstall/sync/patch", async () => {
+    const calls: Array<() => Promise<unknown>> = [
+      () => enablePlugin(PLUGIN_ID),
+      () => disablePlugin(PLUGIN_ID),
+      () => uninstallPlugin(PLUGIN_ID),
+      () => syncPlugins(),
+      () => updatePluginConfig(PLUGIN_ID, { k: "v" }),
+    ];
+    for (const call of calls) {
+      fetchSpy.mockResolvedValueOnce(jsonResponse({ ok: true }));
+      await call();
+      const [, init] = fetchSpy.mock.calls.at(-1) ?? [];
+      expect(tokenHeaderOf(init)).toBe(BOOT_TOKEN);
+    }
+  });
+
+  it("does not attach the token to read-only GETs", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ plugins: [] }));
+    await listPlugins();
+    const [, init] = fetchSpy.mock.calls.at(-1) ?? [];
+    expect(tokenHeaderOf(init)).toBeUndefined();
+  });
+});
+
 describe("getPluginConfig", () => {
   it("fetches GET /api/plugins/:id/config and unwraps the config object", async () => {
     fetchSpy.mockResolvedValueOnce(jsonResponse({ config: { default_channel: "#dev" } }));

--- a/apps/web/lib/api/domains/plugins-api.ts
+++ b/apps/web/lib/api/domains/plugins-api.ts
@@ -1,25 +1,14 @@
-import { ApiError, bootTokenHeaders, fetchJson, type ApiRequestOptions } from "../client";
+import {
+  ApiError,
+  bootTokenHeaders,
+  fetchJson,
+  mutationInit,
+  type ApiRequestOptions,
+} from "../client";
 import { getBackendConfig } from "@/lib/config";
 import type { PluginRecord, SyncResult } from "@/lib/types/plugins";
 
 const BASE = "/api/plugins";
-
-// mutationInit merges the per-boot operator-token header into a state-changing
-// request's init, preserving any caller-supplied init/headers. Every gated
-// route (install/sync/enable/disable/uninstall/config) requires it — see
-// httpmw.RequireBootToken on the backend.
-function mutationInit(
-  method: string,
-  options: ApiRequestOptions | undefined,
-  body?: BodyInit,
-): RequestInit {
-  return {
-    ...(options?.init ?? {}),
-    method,
-    headers: { ...bootTokenHeaders(), ...(options?.init?.headers ?? {}) },
-    ...(body !== undefined ? { body } : {}),
-  };
-}
 
 // listPlugins fetches every registered plugin (GET /api/plugins).
 export async function listPlugins(options?: ApiRequestOptions) {

--- a/apps/web/lib/api/domains/plugins-api.ts
+++ b/apps/web/lib/api/domains/plugins-api.ts
@@ -1,8 +1,25 @@
-import { ApiError, fetchJson, type ApiRequestOptions } from "../client";
+import { ApiError, bootTokenHeaders, fetchJson, type ApiRequestOptions } from "../client";
 import { getBackendConfig } from "@/lib/config";
 import type { PluginRecord, SyncResult } from "@/lib/types/plugins";
 
 const BASE = "/api/plugins";
+
+// mutationInit merges the per-boot operator-token header into a state-changing
+// request's init, preserving any caller-supplied init/headers. Every gated
+// route (install/sync/enable/disable/uninstall/config) requires it — see
+// httpmw.RequireBootToken on the backend.
+function mutationInit(
+  method: string,
+  options: ApiRequestOptions | undefined,
+  body?: BodyInit,
+): RequestInit {
+  return {
+    ...(options?.init ?? {}),
+    method,
+    headers: { ...bootTokenHeaders(), ...(options?.init?.headers ?? {}) },
+    ...(body !== undefined ? { body } : {}),
+  };
+}
 
 // listPlugins fetches every registered plugin (GET /api/plugins).
 export async function listPlugins(options?: ApiRequestOptions) {
@@ -39,11 +56,7 @@ export async function installPluginFromUrl(
 ): Promise<InstallResult> {
   return fetchJson<InstallResult>(`${BASE}/install`, {
     ...options,
-    init: {
-      ...(options?.init ?? {}),
-      method: "POST",
-      body: JSON.stringify({ url }),
-    },
+    init: mutationInit("POST", options, JSON.stringify({ url })),
   });
 }
 
@@ -61,11 +74,18 @@ export async function installPluginUpload(
   formData.append("package", file);
 
   // Spread caller init *first* so method/body always win, matching the
-  // convention in lib/api/domains/voice-api.ts.
+  // convention in lib/api/domains/voice-api.ts. The operator-token header is
+  // merged last (after caller headers) so this multipart install — a CORS
+  // "simple" request and the C1 CSRF-RCE vector — carries it. Content-Type is
+  // deliberately never set here, so the browser sets the multipart boundary;
+  // headers stays absent entirely when there is neither a caller header nor a
+  // token to send.
+  const headers = { ...(options?.init?.headers ?? {}), ...bootTokenHeaders() };
   const response = await fetch(`${baseUrl}${BASE}/install`, {
     ...options?.init,
     method: "POST",
     body: formData,
+    ...(Object.keys(headers).length > 0 ? { headers } : {}),
   });
 
   if (!response.ok) await throwInstallError(response);
@@ -109,11 +129,7 @@ export async function updatePluginConfig(
 ) {
   return fetchJson<{ updated: boolean }>(`${BASE}/${encodeURIComponent(id)}`, {
     ...options,
-    init: {
-      ...(options?.init ?? {}),
-      method: "PATCH",
-      body: JSON.stringify({ config }),
-    },
+    init: mutationInit("PATCH", options, JSON.stringify({ config })),
   });
 }
 
@@ -121,7 +137,7 @@ export async function updatePluginConfig(
 export async function enablePlugin(id: string, options?: ApiRequestOptions) {
   return fetchJson<{ enabled: boolean }>(`${BASE}/${encodeURIComponent(id)}/enable`, {
     ...options,
-    init: { ...(options?.init ?? {}), method: "POST" },
+    init: mutationInit("POST", options),
   });
 }
 
@@ -129,7 +145,7 @@ export async function enablePlugin(id: string, options?: ApiRequestOptions) {
 export async function disablePlugin(id: string, options?: ApiRequestOptions) {
   return fetchJson<{ disabled: boolean }>(`${BASE}/${encodeURIComponent(id)}/disable`, {
     ...options,
-    init: { ...(options?.init ?? {}), method: "POST" },
+    init: mutationInit("POST", options),
   });
 }
 
@@ -137,7 +153,7 @@ export async function disablePlugin(id: string, options?: ApiRequestOptions) {
 export async function uninstallPlugin(id: string, options?: ApiRequestOptions) {
   return fetchJson<{ deleted: boolean }>(`${BASE}/${encodeURIComponent(id)}`, {
     ...options,
-    init: { ...(options?.init ?? {}), method: "DELETE" },
+    init: mutationInit("DELETE", options),
   });
 }
 
@@ -149,6 +165,6 @@ export async function uninstallPlugin(id: string, options?: ApiRequestOptions) {
 export async function syncPlugins(options?: ApiRequestOptions): Promise<SyncResult> {
   return fetchJson<SyncResult>(`${BASE}/sync`, {
     ...options,
-    init: { ...(options?.init ?? {}), method: "POST" },
+    init: mutationInit("POST", options),
   });
 }

--- a/apps/web/src/boot-payload.test.ts
+++ b/apps/web/src/boot-payload.test.ts
@@ -1,7 +1,39 @@
 import { describe, expect, it, vi } from "vitest";
-import { loadBootPayload, readBootPayload } from "./boot-payload";
+import { loadBootPayload, readBootPayload, readBootToken } from "./boot-payload";
 
 const JIRA_BUNDLE_URL = "/api/plugins/jira/bundle";
+
+describe("readBootToken", () => {
+  it("returns the per-boot operator token from runtime.csrfToken", () => {
+    const win = {
+      __KANDEV_BOOT_PAYLOAD__: {
+        version: 1,
+        runtime: { apiPrefix: "/api/v1", webSocketPath: "/ws", csrfToken: "boot-token-abc" },
+      },
+    } as unknown as Window;
+
+    expect(readBootToken(win)).toBe("boot-token-abc");
+  });
+
+  it("returns undefined when the payload or token is absent", () => {
+    expect(readBootToken({} as Window)).toBeUndefined();
+    expect(
+      readBootToken({
+        __KANDEV_BOOT_PAYLOAD__: { runtime: { apiPrefix: "/api/v1" } },
+      } as unknown as Window),
+    ).toBeUndefined();
+  });
+
+  it("also surfaces the token through readBootPayload's runtime", () => {
+    const win = {
+      __KANDEV_BOOT_PAYLOAD__: {
+        runtime: { apiPrefix: "/api/v1", webSocketPath: "/ws", csrfToken: "tok-1" },
+      },
+    } as unknown as Window;
+
+    expect(readBootPayload(win).runtime?.csrfToken).toBe("tok-1");
+  });
+});
 
 describe("readBootPayload", () => {
   it("returns an empty initial state when Go has not injected boot data yet", () => {

--- a/apps/web/src/boot-payload.test.ts
+++ b/apps/web/src/boot-payload.test.ts
@@ -4,11 +4,11 @@ import { loadBootPayload, readBootPayload, readBootToken } from "./boot-payload"
 const JIRA_BUNDLE_URL = "/api/plugins/jira/bundle";
 
 describe("readBootToken", () => {
-  it("returns the per-boot operator token from runtime.csrfToken", () => {
+  it("returns the per-boot operator token from runtime.bootToken", () => {
     const win = {
       __KANDEV_BOOT_PAYLOAD__: {
         version: 1,
-        runtime: { apiPrefix: "/api/v1", webSocketPath: "/ws", csrfToken: "boot-token-abc" },
+        runtime: { apiPrefix: "/api/v1", webSocketPath: "/ws", bootToken: "boot-token-abc" },
       },
     } as unknown as Window;
 
@@ -27,11 +27,11 @@ describe("readBootToken", () => {
   it("also surfaces the token through readBootPayload's runtime", () => {
     const win = {
       __KANDEV_BOOT_PAYLOAD__: {
-        runtime: { apiPrefix: "/api/v1", webSocketPath: "/ws", csrfToken: "tok-1" },
+        runtime: { apiPrefix: "/api/v1", webSocketPath: "/ws", bootToken: "tok-1" },
       },
     } as unknown as Window;
 
-    expect(readBootPayload(win).runtime?.csrfToken).toBe("tok-1");
+    expect(readBootPayload(win).runtime?.bootToken).toBe("tok-1");
   });
 });
 

--- a/apps/web/src/boot-payload.ts
+++ b/apps/web/src/boot-payload.ts
@@ -17,6 +17,11 @@ export type BootRuntime = {
   apiPrefix?: string;
   webSocketPath?: string;
   debug?: boolean;
+  // csrfToken is the per-boot operator token the backend embeds here; the API
+  // client echoes it back in the X-Kandev-Boot-Token header on state-changing
+  // requests so guarded routes (plugin install/enable, marketplace source
+  // mutations) accept them. See httpmw.RequireBootToken on the backend.
+  csrfToken?: string;
 };
 
 export type BootRouteData = {
@@ -126,7 +131,18 @@ function readRuntime(value: Record<string, unknown>): BootRuntime {
     apiPrefix: readString(value.apiPrefix),
     webSocketPath: readString(value.webSocketPath),
     debug: value.debug === true ? true : undefined,
+    csrfToken: readString(value.csrfToken),
   };
+}
+
+// readBootToken returns the per-boot operator token from the injected (prod)
+// or fetched-and-cached (split-origin dev) boot payload on `window`, or
+// undefined when absent. Read at call time — plugin actions fire long after
+// boot, so the global is always populated by then.
+export function readBootToken(win: Window = window): string | undefined {
+  const payload = (win as BootWindow).__KANDEV_BOOT_PAYLOAD__;
+  if (!isRecord(payload) || !isRecord(payload.runtime)) return undefined;
+  return readString(payload.runtime.csrfToken);
 }
 
 function readString(value: unknown): string | undefined {

--- a/apps/web/src/boot-payload.ts
+++ b/apps/web/src/boot-payload.ts
@@ -17,11 +17,11 @@ export type BootRuntime = {
   apiPrefix?: string;
   webSocketPath?: string;
   debug?: boolean;
-  // csrfToken is the per-boot operator token the backend embeds here; the API
+  // bootToken is the per-boot operator token the backend embeds here; the API
   // client echoes it back in the X-Kandev-Boot-Token header on state-changing
   // requests so guarded routes (plugin install/enable, marketplace source
   // mutations) accept them. See httpmw.RequireBootToken on the backend.
-  csrfToken?: string;
+  bootToken?: string;
 };
 
 export type BootRouteData = {
@@ -131,7 +131,7 @@ function readRuntime(value: Record<string, unknown>): BootRuntime {
     apiPrefix: readString(value.apiPrefix),
     webSocketPath: readString(value.webSocketPath),
     debug: value.debug === true ? true : undefined,
-    csrfToken: readString(value.csrfToken),
+    bootToken: readString(value.bootToken),
   };
 }
 
@@ -142,7 +142,7 @@ function readRuntime(value: Record<string, unknown>): BootRuntime {
 export function readBootToken(win: Window = window): string | undefined {
   const payload = (win as BootWindow).__KANDEV_BOOT_PAYLOAD__;
   if (!isRecord(payload) || !isRecord(payload.runtime)) return undefined;
-  return readString(payload.runtime.csrfToken);
+  return readString(payload.runtime.bootToken);
 }
 
 function readString(value: unknown): string | undefined {


### PR DESCRIPTION
## Security remediation — Critical C1 (plugin security audit)

### Problem
`/api/plugins/*` was registered on a bare `router.Group("/api/plugins")` with **no auth middleware**, while the backend binds `0.0.0.0` by default. `POST /api/plugins/install` runs `Install → activate → runtime.Start`, which immediately spawns the packaged native plugin binary. Net result: **unauthenticated remote code execution**, reachable two ways:

1. **Network:** any LAN peer can `curl -F package=@evil.tar.gz http://host:port/api/plugins/install` on self-hosted/server deployments.
2. **Browser CSRF drive-by:** `multipart/form-data` is a CORS "simple" request (no preflight). `corsMiddleware` only *withholds the ACAO header* for disallowed origins — it still calls `c.Next()`, so the handler executes and the RCE side-effect happens before the (unreadable) response is returned.

The only auth guard in the tree was `officeagents.AgentAuthMiddleware` on the agent-facing subgroup; nothing covered plugins, and no per-boot/operator token existed.

### Fix — per-boot operator token + custom header
- **`internal/common/httpmw/boottoken.go`** (new): `NewBootToken()` (256-bit crypto/rand, minted once per process) and `RequireBootToken(token)` middleware — fail-closed on an empty token, 403 on missing/mismatched `X-Kandev-Boot-Token`, constant-time compare.
- The token is generated in `buildHTTPServer` and embedded in the SPA boot payload (`RuntimeConfig.csrfToken`), which is **same-origin readable only** — a cross-origin CSRF page cannot learn it, and a "simple" cross-origin request cannot forge a custom header (doing so triggers a preflight the CORS layer then blocks).
- **`plugins.RegisterRoutes`** now guards every state-changing route: `POST /install`, `POST /sync`, `PATCH/DELETE /:id`, `POST /:id/enable|disable`, and the marketplace source mutations + `refresh`.
- The SPA reads the token from the boot payload (injected in prod, fetched via `/api/v1/app-state` in split-origin dev) and echoes it on state-changing plugin/marketplace API calls, including the multipart upload path.

### Deliberately **not** gated
- Read-only `GET`s (audit L2 — separate follow-up).
- `:id/bundle` and `:id/ui/*` asset serving — the browser loads these via dynamic `import()`/stylesheet fetches that **cannot set a custom header**; gating them would break plugin UI loading.
- The inbound webhook relay (`:id/webhooks/:key`) — unauthenticated by design for external callers.

CORS is **not** used as the CSRF control (simple requests still execute); no existing control was weakened.

### Acceptance criteria
- ✅ State-changing plugin routes reject requests lacking a valid token with 403 (`TestStateChangingRoutesRejectMissingBootToken`).
- ✅ A cross-origin multipart `POST /api/plugins/install` no longer executes an install (`TestInstallHandlerMultipartRejectsMissingBootToken` — asserts 403 **and** nothing registered).
- ✅ Read/asset/webhook routes stay open (`TestReadAndWebhookRoutesAllowedWithoutBootToken`).
- ✅ Legitimate SPA calls carry the token in same-origin prod, split-origin dev, and the Tauri desktop shell (frontend unit tests).

### Testing
- Backend: `go test ./...` green; changed-file `golangci-lint` clean.
- Frontend: `pnpm typecheck` + `pnpm lint` clean; new vitest coverage for `readBootToken`, header attachment on mutations, and header absence on reads.

Coordinated with the sibling subtask "Frontend isolation (C2)" — independent surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1808?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->




### Scope & known limitation (network path)
This PR closes the **browser CSRF drive-by** (the audit's emphasized "gap"): a cross-origin page cannot read the same-origin boot payload / `/api/v1/app-state` and cannot forge the custom header on a simple request.

It does **not** by itself close the **direct-network** path on `0.0.0.0` server deployments: because the token is served in the (unauthenticated) boot payload / SPA shell, a raw non-browser LAN client can read it and replay it. Same-origin policy is a browser-only constraint, so the token is a genuine CSRF defense but not authentication against arbitrary network callers. Desktop/CLI are unaffected — they force loopback bind. Closing the network path requires real operator auth or loopback-by-default and is tracked as a **follow-up** (flagged by Codex P1; see the review thread). No existing control is weakened here.