### PR TITLE
perf: scale workspace git status for large worktrees

### DIFF
--- a/.agents/agents/verify.md
+++ b/.agents/agents/verify.md
@@ -46,7 +46,7 @@ Run the full verification pipeline for the monorepo, then fix any issues found.
    - For type, lint, or test failures, fix implementation behavior unless the test is demonstrably outdated.
    - For goleak failures after otherwise passing Go tests, loop the affected package with `go test -race -count=10 ./internal/<pkg>/...` and inspect cleanup ownership.
    - If Go tests fail because `httptest.NewServer` cannot bind loopback in a restricted sandbox, rerun the exact command with normal network/loopback escalation before diagnosing code.
-   - For `ENOSPC`, read-only cache, or cache-initialization failures, create invocation-specific writable `TMPDIR`, `GOCACHE`, and `GOLANGCI_LINT_CACHE` directories and rerun the exact command. Clean only those directories.
+   - For `ENOSPC`, read-only cache, or cache-initialization failures, preserve an existing absolute managed `GOCACHE` and existing lint cache. Move only invocation scratch (`TMPDIR` and quiet logs) to a writable filesystem. If a cache filesystem itself is unusable, relocate only that cache to a persistent agent-owned path outside every worktree; never use a repository-local fallback.
    - For Rust/Tauri changes, compare `rustc --version` with `apps/desktop/src-tauri/Cargo.toml`'s `rust-version`. Activate a matching installed toolchain without replacing `PATH`; report or request installation if unavailable.
    - After fixing, rerun only the failed command through `scripts/run-quiet`.
 

--- a/.agents/skills/verify/SKILL.md
+++ b/.agents/skills/verify/SKILL.md
@@ -66,25 +66,27 @@ inspect free space on the temp and cache filesystems before changing code:
 df -h /tmp /var/tmp "$PWD"
 ```
 
-Choose one writable filesystem with space, create one agent-owned root there,
-and use it consistently for the remaining verification commands. For example,
-replace `/var/tmp` below if a different filesystem has the available space:
+Keep reusable caches shared. In particular, preserve an existing absolute
+`GOCACHE` injected by Kandev's managed Go-cache provider, and preserve an
+existing `GOLANGCI_LINT_CACHE`. Create an invocation-owned directory only for
+scratch files and command logs. For example, replace `/var/tmp` below if a
+different filesystem has the available space:
 
 ```bash
-VERIFY_CACHE_ROOT="$(mktemp -d /var/tmp/kandev-verify.XXXXXXXX)"
-mkdir -p "$VERIFY_CACHE_ROOT/tmp" "$VERIFY_CACHE_ROOT/go-cache" "$VERIFY_CACHE_ROOT/golangci-cache"
-export TMPDIR="$VERIFY_CACHE_ROOT/tmp"
-export GOCACHE="$VERIFY_CACHE_ROOT/go-cache"
-export GOLANGCI_LINT_CACHE="$VERIFY_CACHE_ROOT/golangci-cache"
+VERIFY_SCRATCH_ROOT="$(mktemp -d /var/tmp/kandev-verify.XXXXXXXX)"
+mkdir -p "$VERIFY_SCRATCH_ROOT/tmp" "$VERIFY_SCRATCH_ROOT/logs"
+export TMPDIR="$VERIFY_SCRATCH_ROOT/tmp"
+export KANDEV_RUN_QUIET_DIR="$VERIFY_SCRATCH_ROOT/logs"
 ```
 
 In a managed sandbox, request the normal filesystem escalation when the chosen
 root is outside the writable roots; do not work around sandbox permissions.
-`scripts/run-quiet` honors `KANDEV_RUN_QUIET_DIR`, then `TMPDIR`, so its logs
-move to the same filesystem. Re-run the original failing command before
-diagnosing source code and verify that the disk/cache errors are gone. After all
-verification finishes, remove only `$VERIFY_CACHE_ROOT`; do not clear shared
-caches or unrelated temp files.
+If the cache filesystem itself is full or unwritable, relocate only the affected
+cache to an explicit persistent, agent-owned path outside every worktree and
+reuse that path on later verification runs. Never fall back to `.verify-cache`,
+`.tmp`, or another directory inside the repository. Re-run the original failing
+command before diagnosing source code. After verification, remove only
+`$VERIFY_SCRATCH_ROOT`; do not clear shared caches or unrelated temp files.
 
 ### Restricted remote-environment failures
 

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,11 @@ tmp/
 temp/
 /workspaces/
 
+# Verification caches belong outside Git worktrees. Ignore this legacy/local
+# fallback so a misconfigured verification run cannot flood Git status.
+/.verify-cache/
+/.tmp/
+
 # Agent session files (local development)
 .augment/
 

--- a/apps/backend/internal/agentctl/server/api/git_status_fresh_concurrency_test.go
+++ b/apps/backend/internal/agentctl/server/api/git_status_fresh_concurrency_test.go
@@ -1,0 +1,332 @@
+//go:build !windows
+
+package api
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/agentctl/server/config"
+	"github.com/kandev/kandev/internal/agentctl/server/process"
+	"github.com/kandev/kandev/internal/common/logger"
+)
+
+const freshMultiStatusPath = "/api/v1/git/status/multi?fresh=true"
+
+func TestGitStatusMultiFreshCoalescesOverlappingHTTPRequests(t *testing.T) {
+	server, repoNames := newMultiRepoStatusServer(t)
+	gate := newGitStatusCommandGate(t)
+	router := server.Router()
+
+	firstResult := make(chan gitStatusHTTPResult, 1)
+	go serveFreshMultiStatus(router, httptest.NewRequest(http.MethodGet, freshMultiStatusPath, nil), firstResult)
+	started := gate.waitForStarts(t, len(repoNames))
+	assertRepoNames(t, started, repoNames)
+
+	peerObserved := make(chan struct{}, len(repoNames))
+	peerCtx := &doneObservedContext{Context: context.Background(), observed: peerObserved}
+	peerResult := make(chan gitStatusHTTPResult, 1)
+	peerReq := httptest.NewRequest(http.MethodGet, freshMultiStatusPath, nil).WithContext(peerCtx)
+	go serveFreshMultiStatus(router, peerReq, peerResult)
+	waitForContextObservations(t, peerObserved, len(repoNames), "successful peer")
+
+	cancelCtx, cancel := context.WithCancel(context.Background())
+	cancelObserved := make(chan struct{}, len(repoNames))
+	canceledResult := make(chan gitStatusHTTPResult, 1)
+	canceledReq := httptest.NewRequest(http.MethodGet, freshMultiStatusPath, nil).WithContext(
+		&doneObservedContext{Context: cancelCtx, observed: cancelObserved},
+	)
+	go serveFreshMultiStatus(router, canceledReq, canceledResult)
+	waitForContextObservations(t, cancelObserved, len(repoNames), "canceled waiter")
+	cancel()
+	assertCanceledMultiStatus(t, waitForGitStatusHTTPResult(t, canceledResult), repoNames)
+
+	gate.releaseAll(t, 32)
+	first := waitForGitStatusHTTPResult(t, firstResult)
+	peer := waitForGitStatusHTTPResult(t, peerResult)
+	assertSharedFreshStatuses(t, first, peer, repoNames)
+	gate.assertInvocationCounts(t, repoNames, 1)
+}
+
+func TestGitStatusMultiFreshKeepsInvalidRepoFailureLocal(t *testing.T) {
+	taskRoot := t.TempDir()
+	newStatusTestRepo(t, taskRoot, "healthy")
+	brokenPath := newStatusTestRepo(t, taskRoot, "broken")
+
+	log, _ := logger.NewLogger(logger.LoggingConfig{Level: "error"})
+	cfg := &config.InstanceConfig{WorkDir: taskRoot}
+	server := NewServer(cfg, process.NewManager(cfg, log), nil, nil, log)
+	if err := os.Rename(brokenPath, filepath.Join(taskRoot, ".broken")); err != nil {
+		t.Fatalf("invalidate repository: %v", err)
+	}
+
+	resultCh := make(chan gitStatusHTTPResult, 1)
+	serveFreshMultiStatus(
+		server.Router(),
+		httptest.NewRequest(http.MethodGet, freshMultiStatusPath, nil),
+		resultCh,
+	)
+	result := waitForGitStatusHTTPResult(t, resultCh)
+	if result.code != http.StatusOK || !result.body.Success {
+		t.Fatalf("multi status = %d, %+v", result.code, result.body)
+	}
+	statuses := statusesByRepo(t, result.body, []string{"broken", "healthy"})
+	if !statuses["healthy"].Success {
+		t.Fatalf("healthy repository failed: %+v", statuses["healthy"])
+	}
+	if statuses["broken"].Success || !strings.Contains(statuses["broken"].Error, "repo subpath not found") {
+		t.Fatalf("broken repository status = %+v, want local not-found failure", statuses["broken"])
+	}
+}
+
+type doneObservedContext struct {
+	context.Context
+	observed chan<- struct{}
+}
+
+func (c *doneObservedContext) Done() <-chan struct{} {
+	c.observed <- struct{}{}
+	return c.Context.Done()
+}
+
+type gitStatusHTTPResult struct {
+	code int
+	body MultiRepoGitStatusResult
+}
+
+func serveFreshMultiStatus(router http.Handler, req *http.Request, resultCh chan<- gitStatusHTTPResult) {
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, req)
+	var body MultiRepoGitStatusResult
+	err := json.Unmarshal(recorder.Body.Bytes(), &body)
+	if err != nil {
+		body = MultiRepoGitStatusResult{Error: err.Error()}
+	}
+	resultCh <- gitStatusHTTPResult{code: recorder.Code, body: body}
+}
+
+func waitForGitStatusHTTPResult(t *testing.T, resultCh <-chan gitStatusHTTPResult) gitStatusHTTPResult {
+	t.Helper()
+	select {
+	case result := <-resultCh:
+		return result
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for git status HTTP response")
+		return gitStatusHTTPResult{}
+	}
+}
+
+func waitForContextObservations(t *testing.T, observed <-chan struct{}, count int, label string) {
+	t.Helper()
+	for range count {
+		select {
+		case <-observed:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("timed out waiting for %s to join shared observations", label)
+		}
+	}
+}
+
+func assertCanceledMultiStatus(t *testing.T, result gitStatusHTTPResult, repoNames []string) {
+	t.Helper()
+	if result.code != http.StatusOK || !result.body.Success {
+		t.Fatalf("canceled multi status = %d, %+v", result.code, result.body)
+	}
+	for repo, status := range statusesByRepo(t, result.body, repoNames) {
+		if status.Success || !strings.Contains(status.Error, context.Canceled.Error()) {
+			t.Errorf("canceled status for %s = %+v", repo, status)
+		}
+	}
+}
+
+func assertSharedFreshStatuses(t *testing.T, first, peer gitStatusHTTPResult, repoNames []string) {
+	t.Helper()
+	if first.code != http.StatusOK || peer.code != http.StatusOK || !first.body.Success || !peer.body.Success {
+		t.Fatalf("fresh responses: first=%d %+v peer=%d %+v", first.code, first.body, peer.code, peer.body)
+	}
+	firstByRepo := statusesByRepo(t, first.body, repoNames)
+	peerByRepo := statusesByRepo(t, peer.body, repoNames)
+	for _, repo := range repoNames {
+		if !firstByRepo[repo].Success || !peerByRepo[repo].Success {
+			t.Errorf("repository %s failed: first=%+v peer=%+v", repo, firstByRepo[repo], peerByRepo[repo])
+			continue
+		}
+		if firstByRepo[repo].Timestamp == "" || firstByRepo[repo].Timestamp != peerByRepo[repo].Timestamp {
+			t.Errorf("repository %s timestamps differ: %q != %q", repo, firstByRepo[repo].Timestamp, peerByRepo[repo].Timestamp)
+		}
+	}
+}
+
+func statusesByRepo(t *testing.T, result MultiRepoGitStatusResult, wantRepos []string) map[string]GitStatusResult {
+	t.Helper()
+	if len(result.Repos) != len(wantRepos) {
+		t.Fatalf("repository entries = %d, want %d: %+v", len(result.Repos), len(wantRepos), result)
+	}
+	statuses := make(map[string]GitStatusResult, len(result.Repos))
+	for _, repo := range result.Repos {
+		statuses[repo.RepositoryName] = repo.Status
+	}
+	assertRepoNames(t, mapKeys(statuses), wantRepos)
+	return statuses
+}
+
+func mapKeys[V any](values map[string]V) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	return keys
+}
+
+func assertRepoNames(t *testing.T, got, want []string) {
+	t.Helper()
+	gotSet := make(map[string]bool, len(got))
+	for _, repo := range got {
+		gotSet[repo] = true
+	}
+	for _, repo := range want {
+		if !gotSet[repo] {
+			t.Errorf("repositories %v missing %q", got, repo)
+		}
+	}
+}
+
+func newMultiRepoStatusServer(t *testing.T) (*Server, []string) {
+	t.Helper()
+	taskRoot := t.TempDir()
+	repoNames := []string{"alpha", "beta"}
+	for _, repo := range repoNames {
+		newStatusTestRepo(t, taskRoot, repo)
+	}
+	log, _ := logger.NewLogger(logger.LoggingConfig{Level: "error"})
+	cfg := &config.InstanceConfig{WorkDir: taskRoot}
+	return NewServer(cfg, process.NewManager(cfg, log), nil, nil, log), repoNames
+}
+
+func newStatusTestRepo(t *testing.T, taskRoot, name string) string {
+	t.Helper()
+	repoDir := filepath.Join(taskRoot, name)
+	if err := os.Mkdir(repoDir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", name, err)
+	}
+	runGitAPI(t, repoDir, "init", "--initial-branch=main")
+	runGitAPI(t, repoDir, "config", "user.email", "test@test.com")
+	runGitAPI(t, repoDir, "config", "user.name", "Test User")
+	writeFileAPI(t, repoDir, "README.md", name+"\n")
+	runGitAPI(t, repoDir, "add", ".")
+	runGitAPI(t, repoDir, "commit", "-m", "initial")
+	return repoDir
+}
+
+type gitStatusCommandGate struct {
+	events  *os.File
+	release *os.File
+	logPath string
+}
+
+func newGitStatusCommandGate(t *testing.T) *gitStatusCommandGate {
+	t.Helper()
+	realGit, err := exec.LookPath("git")
+	if err != nil {
+		t.Fatalf("find git: %v", err)
+	}
+	root := t.TempDir()
+	eventPath := filepath.Join(root, "events")
+	releasePath := filepath.Join(root, "release")
+	for _, path := range []string{eventPath, releasePath} {
+		if output, err := exec.Command("mkfifo", path).CombinedOutput(); err != nil {
+			t.Fatalf("mkfifo %s: %v: %s", path, err, output)
+		}
+	}
+	events := openStatusFIFO(t, eventPath)
+	release := openStatusFIFO(t, releasePath)
+	binDir := filepath.Join(root, "bin")
+	if err := os.Mkdir(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir git shim bin: %v", err)
+	}
+	wrapperPath := filepath.Join(binDir, "git")
+	if err := os.WriteFile(wrapperPath, []byte(gitStatusWrapperScript), 0o755); err != nil {
+		t.Fatalf("write git shim: %v", err)
+	}
+	logPath := filepath.Join(root, "invocations.log")
+	t.Setenv("KANDEV_TEST_REAL_GIT", realGit)
+	t.Setenv("KANDEV_TEST_GIT_EVENTS", eventPath)
+	t.Setenv("KANDEV_TEST_GIT_RELEASE", releasePath)
+	t.Setenv("KANDEV_TEST_GIT_LOG", logPath)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return &gitStatusCommandGate{events: events, release: release, logPath: logPath}
+}
+
+func openStatusFIFO(t *testing.T, path string) *os.File {
+	t.Helper()
+	file, err := os.OpenFile(path, os.O_RDWR, 0o600)
+	if err != nil {
+		t.Fatalf("open fifo %s: %v", path, err)
+	}
+	t.Cleanup(func() { _ = file.Close() })
+	return file
+}
+
+func (g *gitStatusCommandGate) waitForStarts(t *testing.T, count int) []string {
+	t.Helper()
+	resultCh := make(chan []string, 1)
+	go func() {
+		scanner := bufio.NewScanner(g.events)
+		started := make([]string, 0, count)
+		for len(started) < count && scanner.Scan() {
+			started = append(started, scanner.Text())
+		}
+		resultCh <- started
+	}()
+	select {
+	case started := <-resultCh:
+		return started
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for gated git status commands")
+		return nil
+	}
+}
+
+func (g *gitStatusCommandGate) releaseAll(t *testing.T, count int) {
+	t.Helper()
+	if _, err := g.release.Write(bytes.Repeat([]byte("go\n"), count)); err != nil {
+		t.Fatalf("release git status commands: %v", err)
+	}
+}
+
+func (g *gitStatusCommandGate) assertInvocationCounts(t *testing.T, repos []string, want int) {
+	t.Helper()
+	content, err := os.ReadFile(g.logPath)
+	if err != nil {
+		t.Fatalf("read git shim log: %v", err)
+	}
+	counts := make(map[string]int)
+	for _, repo := range strings.Fields(string(content)) {
+		counts[repo]++
+	}
+	for _, repo := range repos {
+		if counts[repo] != want {
+			t.Errorf("primary observations for %s = %d, want %d (all counts: %v)", repo, counts[repo], want, counts)
+		}
+	}
+}
+
+const gitStatusWrapperScript = `#!/bin/sh
+if [ "$#" -ge 3 ] && [ "$1" = "rev-parse" ] && [ "$2" = "--abbrev-ref" ] && [ "$3" = "HEAD" ]; then
+	repo=${PWD##*/}
+	printf '%s\n' "$repo" >> "$KANDEV_TEST_GIT_LOG"
+	printf '%s\n' "$repo" > "$KANDEV_TEST_GIT_EVENTS"
+	IFS= read -r ignored < "$KANDEV_TEST_GIT_RELEASE"
+fi
+exec "$KANDEV_TEST_REAL_GIT" "$@"
+`

--- a/apps/backend/internal/agentctl/server/api/shell_terminal.go
+++ b/apps/backend/internal/agentctl/server/api/shell_terminal.go
@@ -38,8 +38,7 @@ func (s *Server) handleShellTerminalStart(c *gin.Context) {
 		cfg.Rows = req.Rows
 	}
 
-	mgr := s.procMgr.ShellManager()
-	if _, err := mgr.Start(req.TerminalID, cfg); err != nil {
+	if _, err := s.procMgr.StartTerminalShell(req.TerminalID, cfg); err != nil {
 		s.logger.Error("failed to start terminal shell",
 			zap.String("terminal_id", req.TerminalID),
 			zap.Error(err))

--- a/apps/backend/internal/agentctl/server/api/vscode_handlers.go
+++ b/apps/backend/internal/agentctl/server/api/vscode_handlers.go
@@ -24,7 +24,10 @@ func (s *Server) handleVscodeStart(c *gin.Context) {
 
 	// Start is non-blocking — it launches in a background goroutine.
 	// Port is allocated automatically using an OS-assigned random port.
-	s.procMgr.StartVscode(c.Request.Context(), req.Theme)
+	if err := s.procMgr.StartVscode(c.Request.Context(), req.Theme); err != nil {
+		c.JSON(http.StatusConflict, types.VscodeStartResponse{Error: err.Error()})
+		return
+	}
 	s.logger.Info("code-server start initiated", zap.String("theme", req.Theme))
 
 	// Return current status (will be "installing")

--- a/apps/backend/internal/agentctl/server/api/vscode_handlers.go
+++ b/apps/backend/internal/agentctl/server/api/vscode_handlers.go
@@ -1,9 +1,11 @@
 package api
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/kandev/kandev/internal/agentctl/server/process"
 	"github.com/kandev/kandev/internal/agentctl/types"
 	"go.uber.org/zap"
 )
@@ -25,7 +27,11 @@ func (s *Server) handleVscodeStart(c *gin.Context) {
 	// Start is non-blocking — it launches in a background goroutine.
 	// Port is allocated automatically using an OS-assigned random port.
 	if err := s.procMgr.StartVscode(c.Request.Context(), req.Theme); err != nil {
-		c.JSON(http.StatusConflict, types.VscodeStartResponse{Error: err.Error()})
+		status := http.StatusInternalServerError
+		if errors.Is(err, process.ErrManagerStopping) {
+			status = http.StatusConflict
+		}
+		c.JSON(status, types.VscodeStartResponse{Error: err.Error()})
 		return
 	}
 	s.logger.Info("code-server start initiated", zap.String("theme", req.Theme))

--- a/apps/backend/internal/agentctl/server/api/vscode_handlers_test.go
+++ b/apps/backend/internal/agentctl/server/api/vscode_handlers_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -53,6 +54,42 @@ func TestHandleVscodeStart_InvalidBody(t *testing.T) {
 
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandleVscodeStart_ManagerStopping(t *testing.T) {
+	s := newTestServer(t)
+	s.procMgr.CloseAdmission()
+
+	body, _ := json.Marshal(VscodeStartRequest{Theme: "dark"})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/vscode/start", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	s.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Errorf("expected 409, got %d", w.Code)
+	}
+}
+
+func TestHandleVscodeStart_TempSetupFailure(t *testing.T) {
+	tempFile := filepath.Join(t.TempDir(), "not-a-directory")
+	if err := os.WriteFile(tempFile, []byte("file"), 0o600); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+	t.Setenv("TMPDIR", tempFile)
+	s := newTestServer(t)
+
+	body, _ := json.Marshal(VscodeStartRequest{Theme: "dark"})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/vscode/start", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	s.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", w.Code)
 	}
 }
 

--- a/apps/backend/internal/agentctl/server/instance/instance.go
+++ b/apps/backend/internal/agentctl/server/instance/instance.go
@@ -4,11 +4,16 @@
 package instance
 
 import (
+	"context"
+	"sync"
 	"sync/atomic"
 	"time"
-
-	"github.com/kandev/kandev/internal/agentctl/server/process"
 )
+
+type processManager interface {
+	CloseAdmission()
+	StopForTeardown(context.Context) error
+}
 
 // Instance represents a single agent instance running as a subprocess.
 // Each instance has its own process manager, HTTP server, and configuration.
@@ -35,7 +40,7 @@ type Instance struct {
 	CreatedAt time.Time
 
 	// manager is the process manager handling the agent subprocess (unexported)
-	manager *process.Manager
+	manager processManager
 
 	// server is the HTTP server for this instance's API (unexported)
 	server instanceHTTPServer
@@ -53,6 +58,9 @@ type Instance struct {
 	// instance with an open WS as active even when no new HTTP request
 	// arrives. Maintained by the activity middleware.
 	inflightRequests atomic.Int32
+	stopMu           sync.Mutex
+	statusMu         sync.RWMutex
+	portReleased     bool
 }
 
 // MarkActivity stamps the current time as the most recent activity on this
@@ -210,6 +218,8 @@ type InstanceInfo struct {
 // This method creates an InstanceInfo struct containing only the exported,
 // serializable fields from the Instance.
 func (i *Instance) Info() *InstanceInfo {
+	i.statusMu.RLock()
+	defer i.statusMu.RUnlock()
 	// Create a copy of the environment map to prevent external modification
 	var envCopy map[string]string
 	if i.Env != nil {
@@ -228,4 +238,10 @@ func (i *Instance) Info() *InstanceInfo {
 		Env:           envCopy,
 		CreatedAt:     i.CreatedAt,
 	}
+}
+
+func (i *Instance) setStatus(status string) {
+	i.statusMu.Lock()
+	i.Status = status
+	i.statusMu.Unlock()
 }

--- a/apps/backend/internal/agentctl/server/instance/manager.go
+++ b/apps/backend/internal/agentctl/server/instance/manager.go
@@ -364,7 +364,7 @@ func (m *Manager) StopInstance(ctx context.Context, id string) error {
 	}
 
 	stopErr := errors.Join(httpStopErr, processStopErr)
-	if httpStopErr != nil || (processStopErr != nil && retainInstanceResources(processStopErr)) {
+	if httpStopErr != nil || (processStopErr != nil && !canReleaseInstanceResources(processStopErr)) {
 		return stopErr
 	}
 
@@ -388,13 +388,13 @@ func (m *Manager) StopInstance(ctx context.Context, id string) error {
 	return stopErr
 }
 
-type instanceResourceRetentionError interface {
-	RetainInstanceResources() bool
+type instanceResourceReleaseError interface {
+	CanReleaseInstanceResources() bool
 }
 
-func retainInstanceResources(err error) bool {
-	var classified instanceResourceRetentionError
-	return !errors.As(err, &classified) || classified.RetainInstanceResources()
+func canReleaseInstanceResources(err error) bool {
+	var classified instanceResourceReleaseError
+	return errors.As(err, &classified) && classified.CanReleaseInstanceResources()
 }
 
 type instanceHTTPServer interface {

--- a/apps/backend/internal/agentctl/server/instance/manager.go
+++ b/apps/backend/internal/agentctl/server/instance/manager.go
@@ -322,57 +322,79 @@ func (m *Manager) ListInstances() []*InstanceInfo {
 
 // StopInstance stops and removes an instance by ID.
 func (m *Manager) StopInstance(ctx context.Context, id string) error {
-	// Get instance and remove from map under lock (quick operation)
-	m.mu.Lock()
+	m.mu.RLock()
 	inst, ok := m.instances[id]
+	m.mu.RUnlock()
 	if !ok {
+		return fmt.Errorf("instance %s not found", id)
+	}
+	inst.stopMu.Lock()
+	defer inst.stopMu.Unlock()
+
+	// A concurrent successful stop may have removed the instance while this
+	// caller waited for the per-instance teardown lock.
+	m.mu.Lock()
+	if current, exists := m.instances[id]; !exists || current != inst {
 		m.mu.Unlock()
 		return fmt.Errorf("instance %s not found", id)
 	}
-	// Remove from map immediately so new instances aren't blocked
-	delete(m.instances, id)
+	inst.setStatus("stopping")
 	m.mu.Unlock()
 
 	m.logger.Debug("stopping instance", zap.String("instance_id", id))
-
-	// Stop the process manager (potentially slow, done without lock)
 	if inst.manager != nil {
-		if err := inst.manager.Stop(ctx); err != nil {
+		inst.manager.CloseAdmission()
+	}
+
+	// Quiesce HTTP before process teardown. CloseAdmission has already closed every
+	// process-start admission path, including handlers already in flight.
+	var httpStopErr error
+	if inst.server != nil {
+		httpStopErr = m.stopHTTPServer(ctx, id, inst.Port, inst.server)
+	}
+	// Stop the process manager (potentially slow, done without lock)
+	var processStopErr error
+	if inst.manager != nil {
+		if err := inst.manager.StopForTeardown(ctx); err != nil {
+			processStopErr = fmt.Errorf("stop process manager for instance %s: %w", id, err)
 			m.logger.Warn("error stopping process manager",
 				zap.String("instance_id", id),
 				zap.Error(err))
 		}
 	}
 
-	m.logger.Debug("StopInstance: shutting down HTTP server",
-		zap.String("instance_id", id),
-		zap.Int("port", inst.Port))
-
-	var stopErr error
-	if inst.server != nil {
-		if err := m.stopHTTPServer(ctx, id, inst.Port, inst.server); err != nil {
-			stopErr = err
-		}
+	stopErr := errors.Join(httpStopErr, processStopErr)
+	if httpStopErr != nil || (processStopErr != nil && retainInstanceResources(processStopErr)) {
+		return stopErr
 	}
 
 	m.logger.Debug("StopInstance: releasing port",
 		zap.String("instance_id", id),
 		zap.Int("port", inst.Port))
-
-	// Release port (quick operation, re-acquire lock)
 	m.mu.Lock()
-	m.portAlloc.Release(inst.Port)
-	m.mu.Unlock()
-
-	if stopErr != nil {
-		return stopErr
+	if !inst.portReleased {
+		m.portAlloc.Release(inst.Port)
+		inst.portReleased = true
 	}
+	if stopErr == nil {
+		delete(m.instances, id)
+	}
+	m.mu.Unlock()
 
 	m.logger.Info("StopInstance completed",
 		zap.String("instance_id", id),
 		zap.Int("port", inst.Port))
 
-	return nil
+	return stopErr
+}
+
+type instanceResourceRetentionError interface {
+	RetainInstanceResources() bool
+}
+
+func retainInstanceResources(err error) bool {
+	var classified instanceResourceRetentionError
+	return !errors.As(err, &classified) || classified.RetainInstanceResources()
 }
 
 type instanceHTTPServer interface {

--- a/apps/backend/internal/agentctl/server/instance/manager_shutdown_test.go
+++ b/apps/backend/internal/agentctl/server/instance/manager_shutdown_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net"
 	"net/http"
+	"sync"
 	"testing"
 	"time"
 
@@ -13,6 +14,30 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestInstanceInfoSynchronizesConcurrentStatusChanges(t *testing.T) {
+	inst := &Instance{ID: "instance-race", Status: "running"}
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for range 1_000 {
+			inst.setStatus("stopping")
+			inst.setStatus("running")
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for range 1_000 {
+			status := inst.Info().Status
+			if status != "running" && status != "stopping" {
+				t.Errorf("Info().Status = %q", status)
+				return
+			}
+		}
+	}()
+	wg.Wait()
+}
 
 func TestStopInstanceBoundsHTTPServerShutdown(t *testing.T) {
 	log := newTestLogger(t)
@@ -108,7 +133,7 @@ func TestStopHTTPServerReturnsCloseError(t *testing.T) {
 	require.True(t, server.closed)
 }
 
-func TestStopInstanceReleasesPortWhenHTTPServerCloseFails(t *testing.T) {
+func TestStopInstanceRetainsPortWhenHTTPServerCloseFails(t *testing.T) {
 	log := newTestLogger(t)
 	mgr := NewManager(&config.Config{
 		Ports:    config.PortConfig{Base: 12345, Max: 12345},
@@ -128,6 +153,7 @@ func TestStopInstanceReleasesPortWhenHTTPServerCloseFails(t *testing.T) {
 			shutdownErr: context.DeadlineExceeded,
 			closeErr:    closeErr,
 		},
+		manager: &fakeProcessManager{stopErr: cleanupOnlyError{err: errors.New("temp cleanup failed")}},
 	}
 
 	mgr.mu.Lock()
@@ -137,9 +163,50 @@ func TestStopInstanceReleasesPortWhenHTTPServerCloseFails(t *testing.T) {
 	err = mgr.StopInstance(context.Background(), inst.ID)
 	require.ErrorIs(t, err, closeErr)
 
+	_, err = mgr.portAlloc.Allocate("next-instance")
+	require.Error(t, err)
+}
+
+func TestStopInstanceReleasesPortAfterTempCleanupFailure(t *testing.T) {
+	log := newTestLogger(t)
+	mgr := NewManager(&config.Config{
+		Ports:    config.PortConfig{Base: 12345, Max: 12345},
+		Defaults: config.InstanceDefaults{Protocol: agent.ProtocolACP},
+	}, log)
+
+	port, err := mgr.portAlloc.Allocate("process-cleanup-failure")
+	require.NoError(t, err)
+	processErr := errors.New("agent temp cleanup failed")
+	procMgr := &fakeProcessManager{stopErr: cleanupOnlyError{err: processErr}}
+	server := &fakeHTTPServer{}
+	inst := &Instance{
+		ID:        "process-cleanup-failure",
+		Port:      port,
+		Status:    "running",
+		CreatedAt: time.Now(),
+		manager:   procMgr,
+		server:    server,
+	}
+	mgr.mu.Lock()
+	mgr.instances[inst.ID] = inst
+	mgr.mu.Unlock()
+
+	err = mgr.StopInstance(context.Background(), inst.ID)
+	require.ErrorIs(t, err, processErr)
+	require.True(t, procMgr.stopped)
+	require.True(t, server.shutdown)
+	_, ok := mgr.GetInstance(inst.ID)
+	require.True(t, ok, "cleanup-only failure must retain a retry tombstone")
 	reusedPort, err := mgr.portAlloc.Allocate("next-instance")
 	require.NoError(t, err)
 	require.Equal(t, port, reusedPort)
+
+	procMgr.stopErr = nil
+	require.NoError(t, mgr.StopInstance(context.Background(), inst.ID))
+	_, ok = mgr.GetInstance(inst.ID)
+	require.False(t, ok)
+	_, err = mgr.portAlloc.Allocate("third-instance")
+	require.Error(t, err, "retry must not release a port that was reassigned")
 }
 
 func TestStopHTTPServerTreatsCanceledShutdownAsStoppedAfterClose(t *testing.T) {
@@ -159,14 +226,38 @@ func TestStopHTTPServerTreatsCanceledShutdownAsStoppedAfterClose(t *testing.T) {
 type fakeHTTPServer struct {
 	shutdownErr error
 	closeErr    error
+	shutdown    bool
 	closed      bool
 }
 
 func (s *fakeHTTPServer) Shutdown(context.Context) error {
+	s.shutdown = true
 	return s.shutdownErr
 }
 
 func (s *fakeHTTPServer) Close() error {
 	s.closed = true
 	return s.closeErr
+}
+
+type fakeProcessManager struct {
+	stopErr error
+	stopped bool
+}
+
+type cleanupOnlyError struct {
+	err error
+}
+
+func (e cleanupOnlyError) Error() string { return e.err.Error() }
+func (e cleanupOnlyError) Unwrap() error { return e.err }
+func (e cleanupOnlyError) RetainInstanceResources() bool {
+	return false
+}
+
+func (m *fakeProcessManager) CloseAdmission() {}
+
+func (m *fakeProcessManager) StopForTeardown(context.Context) error {
+	m.stopped = true
+	return m.stopErr
 }

--- a/apps/backend/internal/agentctl/server/instance/manager_shutdown_test.go
+++ b/apps/backend/internal/agentctl/server/instance/manager_shutdown_test.go
@@ -251,8 +251,8 @@ type cleanupOnlyError struct {
 
 func (e cleanupOnlyError) Error() string { return e.err.Error() }
 func (e cleanupOnlyError) Unwrap() error { return e.err }
-func (e cleanupOnlyError) RetainInstanceResources() bool {
-	return false
+func (e cleanupOnlyError) CanReleaseInstanceResources() bool {
+	return true
 }
 
 func (m *fakeProcessManager) CloseAdmission() {}

--- a/apps/backend/internal/agentctl/server/process/command_cleanup.go
+++ b/apps/backend/internal/agentctl/server/process/command_cleanup.go
@@ -1,0 +1,27 @@
+package process
+
+import (
+	"fmt"
+	"os/exec"
+	"time"
+)
+
+const failedStartReapTimeout = 2 * time.Second
+
+func killAndWaitStartedCommand(cmd *exec.Cmd) error {
+	if cmd == nil || cmd.Process == nil {
+		return nil
+	}
+	_ = cmd.Process.Kill()
+	done := make(chan struct{})
+	go func() {
+		_ = cmd.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return nil
+	case <-time.After(failedStartReapTimeout):
+		return fmt.Errorf("process %d was not reaped after failed startup", cmd.Process.Pid)
+	}
+}

--- a/apps/backend/internal/agentctl/server/process/command_cleanup_test.go
+++ b/apps/backend/internal/agentctl/server/process/command_cleanup_test.go
@@ -1,0 +1,15 @@
+package process
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestKillAndWaitStartedCommandReapsProcess(t *testing.T) {
+	cmd := fixtureCmd("sleep 30")
+	require.NoError(t, cmd.Start())
+
+	require.NoError(t, killAndWaitStartedCommand(cmd))
+	require.NotNil(t, cmd.ProcessState)
+}

--- a/apps/backend/internal/agentctl/server/process/manager.go
+++ b/apps/backend/internal/agentctl/server/process/manager.go
@@ -210,13 +210,14 @@ type Manager struct {
 	managerWaitFn    func(context.Context, <-chan struct{}, time.Duration) bool
 }
 
-var errManagerStopping = errors.New("process manager is stopping")
+// ErrManagerStopping indicates that process admission is closed for teardown.
+var ErrManagerStopping = errors.New("process manager is stopping")
 
 func (m *Manager) admitStart() (func(), error) {
 	m.admissionMu.Lock()
 	if m.stopping {
 		m.admissionMu.Unlock()
-		return nil, errManagerStopping
+		return nil, ErrManagerStopping
 	}
 	if m.admissionCount == 0 {
 		m.admissionDrained = make(chan struct{})

--- a/apps/backend/internal/agentctl/server/process/manager.go
+++ b/apps/backend/internal/agentctl/server/process/manager.go
@@ -4,6 +4,7 @@ package process
 import (
 	"bufio"
 	"context"
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"io"
@@ -88,14 +89,15 @@ type Manager struct {
 	logger *logger.Logger
 
 	// Process state
-	cmd              *exec.Cmd
-	processLifecycle processLifecycleHandle
-	stdin            io.WriteCloser
-	stdout           io.ReadCloser
-	stderr           io.ReadCloser
-	status           atomic.Value // Status
-	exitCode         atomic.Int32
-	exitErr          atomic.Value // error
+	cmd                *exec.Cmd
+	processLifecycle   processLifecycleHandle
+	processLifecycleMu sync.Mutex
+	stdin              io.WriteCloser
+	stdout             io.ReadCloser
+	stderr             io.ReadCloser
+	status             atomic.Value // Status
+	exitCode           atomic.Int32
+	exitErr            atomic.Value // error
 
 	// Stderr buffering for error context
 	stderrBuffer []string
@@ -181,12 +183,93 @@ type Manager struct {
 	// Final command string (full command with all adapter args)
 	finalCommand string
 
+	// agentTempRoot and agentTempDir record the exact temporary directory
+	// created for this manager. The retained Root keeps cleanup anchored to the
+	// directory opened at creation even if its pathname is later replaced.
+	agentTempRoot       string
+	agentTempDir        string
+	agentTempChild      string
+	agentTempRootHandle *os.Root
+
 	// Synchronization
-	mu      sync.RWMutex
-	wg      sync.WaitGroup
-	stopCh  chan struct{}
-	doneCh  chan struct{}
-	startMu sync.Mutex
+	mu               sync.RWMutex
+	wg               sync.WaitGroup
+	stopCh           chan struct{}
+	doneCh           chan struct{}
+	startMu          sync.Mutex
+	admissionMu      sync.Mutex
+	admissionCount   int
+	admissionDrained chan struct{}
+	stopping         bool
+	mainReapPending  atomic.Bool
+	groupAliveFn     func(int) bool
+	terminateGroupFn func(int) error
+	killGroupFn      func(int) error
+	waitGroupExitFn  func(context.Context, int) bool
+	managerWaitFn    func(context.Context, <-chan struct{}, time.Duration) bool
+}
+
+var errManagerStopping = errors.New("process manager is stopping")
+
+func (m *Manager) admitStart() (func(), error) {
+	m.admissionMu.Lock()
+	if m.stopping {
+		m.admissionMu.Unlock()
+		return nil, errManagerStopping
+	}
+	if m.admissionCount == 0 {
+		m.admissionDrained = make(chan struct{})
+	}
+	m.admissionCount++
+	m.admissionMu.Unlock()
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			m.admissionMu.Lock()
+			m.admissionCount--
+			if m.admissionCount == 0 {
+				close(m.admissionDrained)
+			}
+			m.admissionMu.Unlock()
+		})
+	}, nil
+}
+
+// CloseAdmission rejects new process owners without waiting for in-flight
+// handlers. Instance teardown calls it before shutting down HTTP.
+func (m *Manager) CloseAdmission() {
+	m.admissionMu.Lock()
+	m.stopping = true
+	m.admissionMu.Unlock()
+	if m.processRunner != nil {
+		m.processRunner.BeginStop()
+	}
+	if m.shellMgr != nil {
+		m.shellMgr.BeginStop()
+	}
+}
+
+// WaitForAdmission waits for starts admitted before CloseAdmission to finish.
+func (m *Manager) WaitForAdmission(ctx context.Context) error {
+	m.admissionMu.Lock()
+	if m.admissionCount == 0 {
+		m.admissionMu.Unlock()
+		return nil
+	}
+	drained := m.admissionDrained
+	m.admissionMu.Unlock()
+	select {
+	case <-drained:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// BeginStop closes process admission and drains starts already in flight.
+func (m *Manager) BeginStop() {
+	m.CloseAdmission()
+	_ = m.WaitForAdmission(context.Background())
 }
 
 // NewManager creates a new process manager
@@ -509,6 +592,11 @@ func (m *Manager) refreshTrackersDetached(root *WorkspaceTracker, trackers []*Wo
 
 // StartProcess runs a script/process with isolated stdout/stderr.
 func (m *Manager) StartProcess(ctx context.Context, req StartProcessRequest) (*ProcessInfo, error) {
+	release, err := m.admitStart()
+	if err != nil {
+		return nil, err
+	}
+	defer release()
 	if m.processRunner == nil {
 		return nil, fmt.Errorf("process runner not available")
 	}
@@ -692,6 +780,11 @@ func (m *Manager) JoinRepoPath(subpath, path string) (string, error) {
 func (m *Manager) Start(ctx context.Context) error {
 	m.startMu.Lock()
 	defer m.startMu.Unlock()
+	release, err := m.admitStart()
+	if err != nil {
+		return err
+	}
+	defer release()
 
 	if m.Status() == StatusRunning || m.Status() == StatusStarting {
 		return fmt.Errorf("agent is already running")
@@ -748,23 +841,29 @@ func (m *Manager) Start(ctx context.Context) error {
 	}
 	processLifecycle, err := installProcessLifecycle(m.cmd)
 	if err != nil {
-		m.logger.Warn("failed to install agent process lifecycle; falling back to process-tree cleanup",
-			zap.Error(err))
-	} else {
-		m.processLifecycle = processLifecycle
+		reapErr := killAndWaitStartedCommand(m.cmd)
+		m.status.Store(StatusError)
+		return errors.Join(fmt.Errorf("failed to install agent process lifecycle: %w", err), reapErr)
 	}
+	m.processLifecycle = processLifecycle
 
 	m.stopCh = make(chan struct{})
 	m.doneCh = make(chan struct{})
 
 	// Connect adapter to the process stdin/stdout pipes
 	if err := m.adapter.Connect(m.stdin, m.stdout); err != nil {
-		releaseProcessLifecycle(m.processLifecycle)
-		m.processLifecycle = processLifecycleHandle{}
-		_ = m.cmd.Process.Kill()
-		_ = m.cmd.Wait()
+		reapErr, owned := m.reapMainProcessLifecycle()
+		switch {
+		case !owned:
+			reapErr = killAndWaitStartedCommand(m.cmd)
+		case reapErr != nil:
+			fallbackErr := killAndWaitStartedCommand(m.cmd)
+			reapErr = errors.Join(reapErr, fallbackErr)
+		default:
+			reapErr = killAndWaitStartedCommand(m.cmd)
+		}
 		m.status.Store(StatusError)
-		return fmt.Errorf("failed to connect adapter: %w", err)
+		return errors.Join(fmt.Errorf("failed to connect adapter: %w", err), reapErr)
 	}
 
 	// Start stderr reader and exit waiter
@@ -999,23 +1098,117 @@ func formatEnvEntrySizes(entries []envEntrySize) string {
 }
 
 func (m *Manager) ensureAgentTempEnv() error {
-	dir := filepath.Join(os.TempDir(), agentTempDirRoot, agentTempDirName(m.cfg.SessionID, m.cfg.Port))
-	if err := os.MkdirAll(dir, 0o700); err != nil {
+	root := filepath.Join(os.TempDir(), agentTempDirRoot)
+	child := agentTempDirName(m.cfg.SessionID, m.cfg.InstanceID, m.cfg.Port)
+	dir := filepath.Join(root, child)
+	if m.agentTempRootHandle != nil {
+		if m.agentTempRoot == root && m.agentTempDir == dir && m.agentTempChild == child {
+			for _, key := range []string{"TMPDIR", "TMP", "TEMP"} {
+				m.cfg.AgentEnv = upsertEnvValue(m.cfg.AgentEnv, key, dir)
+			}
+			return nil
+		}
+		return fmt.Errorf("agent temp ownership already initialized for %q", m.agentTempDir)
+	}
+	rootHandle, err := openOwnedTempRoot(root)
+	if err != nil {
+		return err
+	}
+	if err := ensureOwnedTempChild(rootHandle, child); err != nil {
+		_ = rootHandle.Close()
 		return fmt.Errorf("failed to create agent temp dir: %w", err)
 	}
+	m.agentTempRoot = root
+	m.agentTempDir = dir
+	m.agentTempChild = child
+	m.agentTempRootHandle = rootHandle
 	for _, key := range []string{"TMPDIR", "TMP", "TEMP"} {
 		m.cfg.AgentEnv = upsertEnvValue(m.cfg.AgentEnv, key, dir)
 	}
 	return nil
 }
 
-func agentTempDirName(sessionID string, port int) string {
+func openOwnedTempRoot(path string) (*os.Root, error) {
+	if err := os.Mkdir(path, 0o700); err != nil && !errors.Is(err, os.ErrExist) {
+		return nil, fmt.Errorf("failed to create agent temp root %q: %w", path, err)
+	}
+	pathInfo, err := os.Lstat(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to inspect agent temp root %q: %w", path, err)
+	}
+	if pathInfo.Mode()&os.ModeSymlink != 0 || !pathInfo.IsDir() {
+		return nil, fmt.Errorf("unsafe agent temp root %q: expected a directory, not a symlink", path)
+	}
+	root, err := os.OpenRoot(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open agent temp root %q: %w", path, err)
+	}
+	openedInfo, err := root.Stat(".")
+	if err != nil || !os.SameFile(pathInfo, openedInfo) {
+		_ = root.Close()
+		return nil, fmt.Errorf("unsafe agent temp root %q: path changed while opening", path)
+	}
+	if err := root.Chmod(".", 0o700); err != nil {
+		_ = root.Close()
+		return nil, fmt.Errorf("failed to secure agent temp root %q: %w", path, err)
+	}
+	return root, nil
+}
+
+func ensureOwnedTempChild(root *os.Root, name string) error {
+	if err := root.Mkdir(name, 0o700); err != nil && !errors.Is(err, os.ErrExist) {
+		return err
+	}
+	info, err := root.Lstat(name)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return fmt.Errorf("unsafe agent temp child %q: expected a directory, not a symlink", name)
+	}
+	return root.Chmod(name, 0o700)
+}
+
+func (m *Manager) cleanupAgentTempDir() error {
+	root := filepath.Clean(m.agentTempRoot)
+	target := filepath.Clean(m.agentTempDir)
+	if m.agentTempRoot == "" && m.agentTempDir == "" {
+		return nil
+	}
+	if m.agentTempRoot == "" || m.agentTempDir == "" || target == root {
+		return fmt.Errorf("refusing to clean invalid agent temp dir %q under root %q", m.agentTempDir, m.agentTempRoot)
+	}
+	rel, err := filepath.Rel(root, target)
+	if err != nil || filepath.IsAbs(rel) || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("refusing to clean agent temp dir outside root: target %q root %q", m.agentTempDir, m.agentTempRoot)
+	}
+	if rel != m.agentTempChild || strings.ContainsRune(rel, filepath.Separator) || m.agentTempRootHandle == nil {
+		return fmt.Errorf("refusing to clean unowned agent temp dir %q under root %q", m.agentTempDir, m.agentTempRoot)
+	}
+	if err := m.agentTempRootHandle.RemoveAll(rel); err != nil {
+		return fmt.Errorf("failed to remove agent temp dir %q: %w", target, err)
+	}
+	closeErr := m.agentTempRootHandle.Close()
+	m.agentTempRoot = ""
+	m.agentTempDir = ""
+	m.agentTempChild = ""
+	m.agentTempRootHandle = nil
+	if closeErr != nil {
+		return fmt.Errorf("failed to close agent temp root %q: %w", root, closeErr)
+	}
+	return nil
+}
+
+func agentTempDirName(sessionID, instanceID string, port int) string {
 	name := strings.TrimSpace(sessionID)
+	if name == "" {
+		name = strings.TrimSpace(instanceID)
+	}
 	if name == "" && port > 0 {
 		name = fmt.Sprintf("port-%d", port)
 	}
 	if name == "" {
-		return "default"
+		name = "default"
 	}
 
 	var b strings.Builder
@@ -1028,9 +1221,14 @@ func agentTempDirName(sessionID string, port int) string {
 	}
 	cleaned := strings.Trim(b.String(), "._-")
 	if cleaned == "" {
-		return "default"
+		cleaned = "default"
 	}
-	return cleaned
+	if len(cleaned) > 40 {
+		cleaned = cleaned[:40]
+	}
+	identity := fmt.Sprintf("%d:%s|%d:%s|%d", len(sessionID), sessionID, len(instanceID), instanceID, port)
+	digest := sha256.Sum256([]byte(identity))
+	return fmt.Sprintf("%s-%x", cleaned, digest[:12])
 }
 
 func isAgentTempDirRune(r rune) bool {
@@ -1256,6 +1454,20 @@ func (m *Manager) GetSessionID() string {
 
 // Stop stops the agent process
 func (m *Manager) Stop(ctx context.Context) error {
+	return m.stop(ctx, false)
+}
+
+// StopForTeardown permanently closes process admission, drains prior owners,
+// and removes the manager's temp directory after every owned process is reaped.
+func (m *Manager) StopForTeardown(ctx context.Context) error {
+	m.CloseAdmission()
+	if err := m.WaitForAdmission(ctx); err != nil {
+		return fmt.Errorf("wait for process admission to drain: %w", err)
+	}
+	return m.stop(ctx, true)
+}
+
+func (m *Manager) stop(ctx context.Context, terminalStop bool) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -1272,6 +1484,21 @@ func (m *Manager) Stop(ctx context.Context) error {
 		m.logger.Info("Stop called but already stopped/stopping",
 			zap.String("status", string(status)),
 			zap.Int("pid", m.agentPID()))
+		if status == StatusStopped {
+			if err := m.stopShellAndProcesses(ctx); err != nil {
+				return err
+			}
+			if m.mainReapPending.Load() {
+				if err := m.waitForProcessExit(ctx); err != nil {
+					return err
+				}
+				m.mainReapPending.Store(false)
+			}
+			if terminalStop {
+				return classifyTempCleanupError(m.cleanupAgentTempDir())
+			}
+			return nil
+		}
 		return nil
 	}
 
@@ -1283,14 +1510,39 @@ func (m *Manager) Stop(ctx context.Context) error {
 		zap.String("protocol", m.agentProtocol()))
 	m.status.Store(StatusStopping)
 
-	m.stopShellAndProcesses(ctx)
+	auxiliaryStopErr := m.stopShellAndProcesses(ctx)
 	m.closeAdapterAndStdin()
 	m.killProcessGroupIfRequired()
-	m.waitForProcessExit(ctx)
+	mainStopErr := m.waitForProcessExit(ctx)
 
 	m.status.Store(StatusStopped)
 	m.logger.Info("stopping agent process - COMPLETE")
+	if stopErr := errors.Join(auxiliaryStopErr, mainStopErr); stopErr != nil {
+		m.mainReapPending.Store(mainStopErr != nil)
+		return stopErr
+	}
+	m.mainReapPending.Store(false)
+	if terminalStop {
+		return classifyTempCleanupError(m.cleanupAgentTempDir())
+	}
 	return nil
+}
+
+type tempCleanupError struct {
+	err error
+}
+
+func (e tempCleanupError) Error() string { return e.err.Error() }
+func (e tempCleanupError) Unwrap() error { return e.err }
+func (e tempCleanupError) RetainInstanceResources() bool {
+	return false
+}
+
+func classifyTempCleanupError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return tempCleanupError{err: err}
 }
 
 func (m *Manager) agentPID() int {
@@ -1308,11 +1560,13 @@ func (m *Manager) agentProtocol() string {
 }
 
 // stopShellAndProcesses stops the shell session, VS Code, and workspace processes.
-func (m *Manager) stopShellAndProcesses(ctx context.Context) {
+func (m *Manager) stopShellAndProcesses(ctx context.Context) error {
+	var errs []error
 	// Stop VS Code server if running
 	m.logger.Debug("stopping vscode server")
 	if err := m.StopVscode(ctx); err != nil {
 		m.logger.Debug("failed to stop vscode server", zap.Error(err))
+		errs = append(errs, err)
 	}
 	m.logger.Debug("vscode server stopped")
 
@@ -1320,23 +1574,32 @@ func (m *Manager) stopShellAndProcesses(ctx context.Context) {
 	if m.shell != nil {
 		if err := m.shell.Stop(); err != nil {
 			m.logger.Debug("failed to stop shell session", zap.Error(err))
+			errs = append(errs, err)
+		} else {
+			m.shell = nil
 		}
-		m.shell = nil
 	}
 	m.logger.Debug("shell session stopped")
 
 	m.logger.Debug("stopping terminal shells")
-	m.shellMgr.StopAll()
+	if m.shellMgr != nil {
+		if err := m.shellMgr.StopAll(); err != nil {
+			m.logger.Debug("failed to stop terminal shells", zap.Error(err))
+			errs = append(errs, err)
+		}
+	}
 	m.logger.Debug("terminal shells stopped")
 
 	// Stop all running workspace processes (dev server, setup, cleanup, custom).
 	m.logger.Debug("stopping workspace processes")
 	if m.processRunner != nil {
-		if err := m.processRunner.StopAll(ctx); err != nil {
+		if err := m.processRunner.StopAllAndWait(ctx); err != nil {
 			m.logger.Debug("failed to stop workspace processes", zap.Error(err))
+			errs = append(errs, err)
 		}
 	}
 	m.logger.Debug("workspace processes stopped")
+	return errors.Join(errs...)
 }
 
 // closeAdapterAndStdin closes the protocol adapter, the stop channel, and stdin.
@@ -1382,7 +1645,7 @@ func (m *Manager) killProcessGroupIfRequired() {
 	m.logger.Debug("agent process group SIGKILL requested",
 		zap.Int("pgid", pid),
 		zap.String("reason", "adapter_requires_process_kill"))
-	if err := killProcessGroup(pid); err != nil {
+	if err := m.killProcessGroup(pid); err != nil {
 		m.logger.Debug("failed to kill process group, trying single process", zap.Error(err))
 		m.logger.Debug("agent process SIGKILL requested",
 			zap.Int("pid", pid),
@@ -1402,7 +1665,7 @@ func (m *Manager) killProcessGroupIfRequired() {
 // leader exits before its descendants do, we still terminate the remaining
 // process group before reporting shutdown complete. Falls back to a
 // single-process kill only if the process-group call fails.
-func (m *Manager) waitForProcessExit(ctx context.Context) {
+func (m *Manager) waitForProcessExit(ctx context.Context) error {
 	m.logger.Debug("waiting for process to exit")
 	done := make(chan struct{})
 	go func() {
@@ -1416,18 +1679,16 @@ func (m *Manager) waitForProcessExit(ctx context.Context) {
 	}
 
 	exitGrace := m.processExitGrace(ctx)
-	if waitForManagerDone(ctx, done, exitGrace) {
+	if m.waitForManagerDone(ctx, done, exitGrace) {
 		m.logger.Info("agent process stopped gracefully")
-		m.reapRemainingProcessGroup(ctx, pid)
-		return
+		return m.reapRemainingProcessGroup(ctx, pid)
 	}
 	if pid == 0 {
-		return
+		return fmt.Errorf("agent process goroutines were not reaped")
 	}
 	if ctx.Err() != nil {
 		m.logger.Warn("force killing agent process group", zap.Int("pgid", pid))
-		m.forceKillProcessGroupAndWait(done, pid)
-		return
+		return m.forceKillProcessGroupAndWait(done, pid)
 	}
 
 	m.logger.Warn("agent process did not exit after graceful wait; terminating process group",
@@ -1437,24 +1698,23 @@ func (m *Manager) waitForProcessExit(ctx context.Context) {
 		zap.Int("pgid", pid),
 		zap.String("reason", "graceful_wait_expired"),
 		zap.Duration("grace", exitGrace))
-	if err := terminateProcessGroup(pid); err != nil {
+	if err := m.terminateProcessGroup(pid); err != nil {
 		if !isProcessGroupMissing(err) {
 			m.logger.Warn("failed to terminate agent process group, force killing",
 				zap.Int("pgid", pid),
 				zap.Error(err))
-			m.forceKillProcessGroupAndWait(done, pid)
+			return m.forceKillProcessGroupAndWait(done, pid)
 		}
-		return
+		return m.verifyMainReaped(done, pid)
 	}
-	if waitForManagerDone(ctx, done, processGroupTerminateGrace) {
+	if m.waitForManagerDone(ctx, done, processGroupTerminateGrace) {
 		m.logger.Info("agent process stopped after process group termination",
 			zap.Int("pgid", pid))
-		m.reapRemainingProcessGroup(ctx, pid)
-		return
+		return m.reapRemainingProcessGroup(ctx, pid)
 	}
 	m.logger.Warn("agent process did not stop after termination; force killing process group",
 		zap.Int("pgid", pid))
-	m.forceKillProcessGroupAndWait(done, pid)
+	return m.forceKillProcessGroupAndWait(done, pid)
 }
 
 // processExitGrace returns the initial graceful wait before process-group
@@ -1488,9 +1748,12 @@ func waitForManagerDone(ctx context.Context, done <-chan struct{}, timeout time.
 	}
 }
 
-func (m *Manager) reapRemainingProcessGroup(ctx context.Context, pid int) {
-	if pid == 0 || !processGroupAlive(pid) {
-		return
+func (m *Manager) reapRemainingProcessGroup(ctx context.Context, pid int) error {
+	if err, owned := m.reapMainProcessLifecycle(); owned {
+		return err
+	}
+	if pid == 0 || !m.processGroupAlive(pid) {
+		return nil
 	}
 
 	m.logger.Warn("agent process group still alive after leader exit; terminating",
@@ -1498,35 +1761,47 @@ func (m *Manager) reapRemainingProcessGroup(ctx context.Context, pid int) {
 	m.logger.Debug("agent process group SIGTERM requested",
 		zap.Int("pgid", pid),
 		zap.String("reason", "leader_exited_with_live_descendants"))
-	if err := terminateProcessGroup(pid); err != nil {
+	if err := m.terminateProcessGroup(pid); err != nil {
 		if isProcessGroupMissing(err) {
-			return
+			return nil
 		}
 		m.logger.Warn("failed to terminate agent process group, force killing",
 			zap.Int("pgid", pid),
 			zap.Error(err))
-		m.forceKillProcessGroupAndWait(nil, pid)
-		return
+		return m.forceKillProcessGroupAndWait(nil, pid)
 	}
 
 	waitCtx, cancel := context.WithTimeout(ctx, processGroupTerminateGrace)
 	defer cancel()
-	if waitForProcessGroupExit(waitCtx, pid) {
+	if m.waitForProcessGroupExit(waitCtx, pid) {
 		m.logger.Info("agent process group stopped after termination",
 			zap.Int("pgid", pid))
-		return
+		return nil
 	}
 
 	m.logger.Warn("agent process group did not stop after termination; force killing",
 		zap.Int("pgid", pid))
-	m.forceKillProcessGroupAndWait(nil, pid)
+	return m.forceKillProcessGroupAndWait(nil, pid)
+}
+
+func (m *Manager) reapMainProcessLifecycle() (error, bool) {
+	m.processLifecycleMu.Lock()
+	defer m.processLifecycleMu.Unlock()
+	if !ownsProcessLifecycle(m.processLifecycle) {
+		return nil, false
+	}
+	if err := reapProcessLifecycle(m.processLifecycle); err != nil {
+		return err, true
+	}
+	m.processLifecycle = processLifecycleHandle{}
+	return nil, true
 }
 
 func (m *Manager) forceKillProcessGroup(pid int) {
 	m.logger.Debug("agent process group SIGKILL requested",
 		zap.Int("pgid", pid),
 		zap.String("reason", "force_kill"))
-	if err := killProcessGroup(pid); err != nil {
+	if err := m.killProcessGroup(pid); err != nil {
 		if isProcessGroupMissing(err) {
 			return
 		}
@@ -1545,25 +1820,89 @@ func (m *Manager) forceKillProcessGroup(pid int) {
 	}
 }
 
-func (m *Manager) forceKillProcessGroupAndWait(done <-chan struct{}, pid int) {
+func (m *Manager) forceKillProcessGroupAndWait(done <-chan struct{}, pid int) error {
 	m.forceKillProcessGroup(pid)
 
 	waitCtx, cancel := context.WithTimeout(context.Background(), processGroupTerminateGrace)
 	defer cancel()
-	if done != nil && waitForManagerDone(waitCtx, done, processGroupTerminateGrace) {
+	managerDone := done == nil || m.waitForManagerDone(waitCtx, done, processGroupTerminateGrace)
+	groupDone := m.waitForProcessGroupExit(waitCtx, pid)
+	if managerDone && groupDone {
 		m.logger.Info("agent process stopped after force kill",
 			zap.Int("pgid", pid))
-		m.reapRemainingProcessGroup(context.Background(), pid)
-		return
+		return nil
 	}
-	if waitForProcessGroupExit(waitCtx, pid) {
-		m.logger.Info("agent process group stopped after force kill",
-			zap.Int("pgid", pid))
-		return
+	var errs []error
+	if !managerDone {
+		errs = append(errs, fmt.Errorf("agent process goroutines were not reaped after force kill"))
 	}
-	m.logger.Warn("agent process group still alive after force kill wait",
-		zap.Int("pgid", pid),
-		zap.Duration("grace", processGroupTerminateGrace))
+	if !groupDone {
+		errs = append(errs, fmt.Errorf("agent process group %d remains alive after force kill", pid))
+	}
+	return errors.Join(errs...)
+}
+
+func (m *Manager) verifyMainReaped(done <-chan struct{}, pid int) error {
+	if done != nil {
+		select {
+		case <-done:
+		default:
+			return fmt.Errorf("agent process goroutines were not reaped")
+		}
+	}
+	if pid != 0 && m.processGroupAlive(pid) {
+		return fmt.Errorf("agent process group %d remains alive", pid)
+	}
+	return nil
+}
+
+func (m *Manager) processGroupAlive(pid int) bool {
+	if m.groupAliveFn != nil {
+		return m.groupAliveFn(pid)
+	}
+	return processGroupAlive(pid)
+}
+
+func (m *Manager) waitForManagerDone(ctx context.Context, done <-chan struct{}, timeout time.Duration) bool {
+	if m.managerWaitFn != nil {
+		return m.managerWaitFn(ctx, done, timeout)
+	}
+	return waitForManagerDone(ctx, done, timeout)
+}
+
+func (m *Manager) terminateProcessGroup(pid int) error {
+	if m.terminateGroupFn != nil {
+		return m.terminateGroupFn(pid)
+	}
+	return terminateProcessGroup(pid)
+}
+
+func (m *Manager) killProcessGroup(pid int) error {
+	if m.killGroupFn != nil {
+		return m.killGroupFn(pid)
+	}
+	return killProcessGroup(pid)
+}
+
+func (m *Manager) waitForProcessGroupExit(ctx context.Context, pid int) bool {
+	if m.waitGroupExitFn != nil {
+		return m.waitGroupExitFn(ctx, pid)
+	}
+	if !m.processGroupAlive(pid) {
+		return true
+	}
+	ticker := time.NewTicker(processGroupPollInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return !m.processGroupAlive(pid)
+		case <-ticker.C:
+			if !m.processGroupAlive(pid) {
+				return true
+			}
+		}
+	}
 }
 
 func waitForProcessGroupExit(ctx context.Context, pid int) bool {
@@ -1649,8 +1988,6 @@ func (m *Manager) waitForExit() {
 
 	pid := m.agentPID()
 	err := m.cmd.Wait()
-	releaseProcessLifecycle(m.processLifecycle)
-	m.processLifecycle = processLifecycleHandle{}
 
 	if err != nil {
 		m.exitErr.Store(errorWrapper{err: err})
@@ -1689,7 +2026,12 @@ func (m *Manager) waitForExit() {
 	}
 
 	if m.Status() != StatusStopping {
-		m.reapRemainingProcessGroup(context.Background(), pid)
+		if err := m.reapRemainingProcessGroup(context.Background(), pid); err != nil {
+			m.mainReapPending.Store(true)
+			m.logger.Warn("agent process group reap remains pending", zap.Error(err))
+		} else {
+			m.mainReapPending.Store(false)
+		}
 	}
 	m.status.Store(StatusStopped)
 }
@@ -1944,6 +2286,11 @@ func (m *Manager) ShellManager() *shell.Manager {
 // but we still need shell access for the workspace.
 // Returns nil if shell is already started or if ShellEnabled is false.
 func (m *Manager) StartShell() error {
+	release, err := m.admitStart()
+	if err != nil {
+		return err
+	}
+	defer release()
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -1972,14 +2319,26 @@ func (m *Manager) StartShell() error {
 // StartVscode starts the code-server process on a random OS-assigned port.
 // The VS Code server runs independently of the agent process.
 // Start is non-blocking — the caller should poll VscodeInfo() for status updates.
-func (m *Manager) StartVscode(_ context.Context, theme string) {
+func (m *Manager) StartVscode(_ context.Context, theme string) error {
+	release, err := m.admitStart()
+	if err != nil {
+		return err
+	}
+	defer release()
+	return m.startVscode(theme)
+}
+
+func (m *Manager) startVscode(theme string) error {
 	m.vscodeMu.Lock()
 	defer m.vscodeMu.Unlock()
 
 	if m.vscode != nil {
 		info := m.vscode.Info()
 		if info.Status == VscodeStatusRunning || info.Status == VscodeStatusStarting || info.Status == VscodeStatusInstalling {
-			return
+			return nil
+		}
+		if m.vscode.HasUnreapedOwnership() {
+			return fmt.Errorf("previous code-server process cleanup is incomplete")
 		}
 	}
 
@@ -1991,6 +2350,7 @@ func (m *Manager) StartVscode(_ context.Context, theme string) {
 	strategy := codeServerInstallStrategy(m.logger)
 	m.vscode = NewVscodeManager(command, m.cfg.WorkDir, theme, strategy, m.logger)
 	m.vscode.Start()
+	return nil
 }
 
 // codeServerInstallStrategy returns a tarball strategy that auto-installs code-server.
@@ -2026,7 +2386,9 @@ func (m *Manager) StopVscode(ctx context.Context) error {
 	}
 
 	err := m.vscode.Stop(ctx)
-	m.vscode = nil
+	if err == nil {
+		m.vscode = nil
+	}
 	return err
 }
 
@@ -2048,6 +2410,11 @@ func (m *Manager) VscodeInfo() VscodeInfo {
 // another goroutine could stop vscode in between. WaitForRunning handles this
 // correctly by returning an error for stopped/error states.
 func (m *Manager) VscodeOpenFile(ctx context.Context, path string, line, col int) error {
+	release, err := m.admitStart()
+	if err != nil {
+		return err
+	}
+	defer release()
 	m.vscodeMu.Lock()
 	needsStart := m.vscode == nil
 	if !needsStart {
@@ -2058,7 +2425,9 @@ func (m *Manager) VscodeOpenFile(ctx context.Context, path string, line, col int
 
 	if needsStart {
 		m.logger.Info("auto-starting code-server for open-file request")
-		m.StartVscode(ctx, "")
+		if err := m.startVscode(""); err != nil {
+			return err
+		}
 	}
 
 	m.vscodeMu.Lock()

--- a/apps/backend/internal/agentctl/server/process/manager.go
+++ b/apps/backend/internal/agentctl/server/process/manager.go
@@ -190,6 +190,7 @@ type Manager struct {
 	agentTempDir        string
 	agentTempChild      string
 	agentTempRootHandle *os.Root
+	agentTempMu         sync.Mutex
 
 	// Synchronization
 	mu               sync.RWMutex
@@ -600,6 +601,10 @@ func (m *Manager) StartProcess(ctx context.Context, req StartProcessRequest) (*P
 	if m.processRunner == nil {
 		return nil, fmt.Errorf("process runner not available")
 	}
+	if err := m.ensureAgentTempEnv(); err != nil {
+		return nil, err
+	}
+	req.Env = m.ownedProcessEnv(req.Env)
 	return m.processRunner.Start(ctx, req)
 }
 
@@ -1098,6 +1103,9 @@ func formatEnvEntrySizes(entries []envEntrySize) string {
 }
 
 func (m *Manager) ensureAgentTempEnv() error {
+	m.agentTempMu.Lock()
+	defer m.agentTempMu.Unlock()
+
 	root := filepath.Join(os.TempDir(), agentTempDirRoot)
 	child := agentTempDirName(m.cfg.SessionID, m.cfg.InstanceID, m.cfg.Port)
 	dir := filepath.Join(root, child)
@@ -1126,6 +1134,20 @@ func (m *Manager) ensureAgentTempEnv() error {
 		m.cfg.AgentEnv = upsertEnvValue(m.cfg.AgentEnv, key, dir)
 	}
 	return nil
+}
+
+func (m *Manager) ownedProcessEnv(env map[string]string) map[string]string {
+	m.agentTempMu.Lock()
+	defer m.agentTempMu.Unlock()
+
+	managed := make(map[string]string, len(env)+3)
+	for key, value := range env {
+		managed[key] = value
+	}
+	for _, key := range []string{"TMPDIR", "TMP", "TEMP"} {
+		managed[key] = m.agentTempDir
+	}
+	return managed
 }
 
 func openOwnedTempRoot(path string) (*os.Root, error) {
@@ -1170,6 +1192,9 @@ func ensureOwnedTempChild(root *os.Root, name string) error {
 }
 
 func (m *Manager) cleanupAgentTempDir() error {
+	m.agentTempMu.Lock()
+	defer m.agentTempMu.Unlock()
+
 	root := filepath.Clean(m.agentTempRoot)
 	target := filepath.Clean(m.agentTempDir)
 	if m.agentTempRoot == "" && m.agentTempDir == "" {
@@ -1288,6 +1313,7 @@ func (m *Manager) startAgentShell() {
 	}
 	shellCfg := shell.DefaultConfig(m.cfg.WorkDir)
 	shellCfg.ShellCommand = preferredShellCommand(m.cfg.AgentEnv)
+	shellCfg.Env = m.ownedProcessEnv(nil)
 	shellSession, err := shell.NewSession(shellCfg, m.logger)
 	if err != nil {
 		m.logger.Warn("failed to create shell session", zap.Error(err))
@@ -1534,8 +1560,8 @@ type tempCleanupError struct {
 
 func (e tempCleanupError) Error() string { return e.err.Error() }
 func (e tempCleanupError) Unwrap() error { return e.err }
-func (e tempCleanupError) RetainInstanceResources() bool {
-	return false
+func (e tempCleanupError) CanReleaseInstanceResources() bool {
+	return true
 }
 
 func classifyTempCleanupError(err error) error {
@@ -2303,9 +2329,13 @@ func (m *Manager) StartShell() error {
 	if !m.cfg.ShellEnabled {
 		return nil
 	}
+	if err := m.ensureAgentTempEnv(); err != nil {
+		return err
+	}
 
 	shellCfg := shell.DefaultConfig(m.cfg.WorkDir)
 	shellCfg.ShellCommand = preferredShellCommand(m.cfg.AgentEnv)
+	shellCfg.Env = m.ownedProcessEnv(nil)
 	shellSession, err := shell.NewSession(shellCfg, m.logger)
 	if err != nil {
 		return fmt.Errorf("failed to create shell session: %w", err)
@@ -2314,6 +2344,20 @@ func (m *Manager) StartShell() error {
 	m.shell = shellSession
 	m.logger.Info("shell session started independently")
 	return nil
+}
+
+// StartTerminalShell creates a managed per-terminal shell with the instance temp environment.
+func (m *Manager) StartTerminalShell(terminalID string, cfg shell.Config) (*shell.Session, error) {
+	release, err := m.admitStart()
+	if err != nil {
+		return nil, err
+	}
+	defer release()
+	if err := m.ensureAgentTempEnv(); err != nil {
+		return nil, err
+	}
+	cfg.Env = m.ownedProcessEnv(cfg.Env)
+	return m.shellMgr.Start(terminalID, cfg)
 }
 
 // StartVscode starts the code-server process on a random OS-assigned port.
@@ -2325,6 +2369,9 @@ func (m *Manager) StartVscode(_ context.Context, theme string) error {
 		return err
 	}
 	defer release()
+	if err := m.ensureAgentTempEnv(); err != nil {
+		return err
+	}
 	return m.startVscode(theme)
 }
 
@@ -2349,6 +2396,7 @@ func (m *Manager) startVscode(theme string) error {
 
 	strategy := codeServerInstallStrategy(m.logger)
 	m.vscode = NewVscodeManager(command, m.cfg.WorkDir, theme, strategy, m.logger)
+	m.vscode.setEnv(m.ownedProcessEnv(nil))
 	m.vscode.Start()
 	return nil
 }

--- a/apps/backend/internal/agentctl/server/process/manager_rescan.go
+++ b/apps/backend/internal/agentctl/server/process/manager_rescan.go
@@ -37,6 +37,12 @@ import (
 //
 // Idempotent: a rescan with no on-disk changes is a no-op.
 func (m *Manager) RescanRepositories(ctx context.Context, newWorkDir string) {
+	release, err := m.admitStart()
+	if err != nil {
+		m.logger.Debug("workspace rescan rejected during teardown")
+		return
+	}
+	defer release()
 	// Serialize the whole rescan body. Two concurrent calls could otherwise
 	// both observe existingTrackers == 0 between the write-lock snapshot
 	// and the bootstrap branch, both calling transitionToMultiRepoMode and

--- a/apps/backend/internal/agentctl/server/process/manager_temp_test.go
+++ b/apps/backend/internal/agentctl/server/process/manager_temp_test.go
@@ -375,6 +375,9 @@ func TestManager_TempNamesDoNotCollideAfterSanitization(t *testing.T) {
 	if data, err := os.ReadFile(secondSentinel); err != nil || string(data) != "owned by second" {
 		t.Fatalf("first cleanup changed second temp dir, data = %q, err = %v", data, err)
 	}
+	if err := second.StopForTeardown(context.Background()); err != nil {
+		t.Fatalf("second Stop() error = %v", err)
+	}
 }
 
 func TestManager_StoppedAgentKeepsTempUntilWorkspaceProcessReaped(t *testing.T) {

--- a/apps/backend/internal/agentctl/server/process/manager_temp_test.go
+++ b/apps/backend/internal/agentctl/server/process/manager_temp_test.go
@@ -437,16 +437,16 @@ func TestManager_BeginStopWaitsForInFlightTempOwnerAdmission(t *testing.T) {
 	release()
 	<-stopAdmissionDone
 
-	if err := mgr.Start(context.Background()); !errors.Is(err, errManagerStopping) {
+	if err := mgr.Start(context.Background()); !errors.Is(err, ErrManagerStopping) {
 		t.Fatalf("Start() error = %v, want manager-stopping error", err)
 	}
-	if _, err := mgr.StartProcess(context.Background(), StartProcessRequest{}); !errors.Is(err, errManagerStopping) {
+	if _, err := mgr.StartProcess(context.Background(), StartProcessRequest{}); !errors.Is(err, ErrManagerStopping) {
 		t.Fatalf("StartProcess() error = %v, want manager-stopping error", err)
 	}
-	if err := mgr.StartShell(); !errors.Is(err, errManagerStopping) {
+	if err := mgr.StartShell(); !errors.Is(err, ErrManagerStopping) {
 		t.Fatalf("StartShell() error = %v, want manager-stopping error", err)
 	}
-	if err := mgr.StartVscode(context.Background(), "dark"); !errors.Is(err, errManagerStopping) {
+	if err := mgr.StartVscode(context.Background(), "dark"); !errors.Is(err, ErrManagerStopping) {
 		t.Fatalf("StartVscode() error = %v, want manager-stopping error", err)
 	}
 	if _, err := mgr.ShellManager().Start("terminal", shell.DefaultConfig(t.TempDir())); err == nil {

--- a/apps/backend/internal/agentctl/server/process/manager_temp_test.go
+++ b/apps/backend/internal/agentctl/server/process/manager_temp_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -74,6 +75,7 @@ func TestManager_BuildFinalCommandInjectsIsolatedTempDir(t *testing.T) {
 		AgentEnv:  []string{"PATH=/usr/bin"},
 	}, newTestLogger(t))
 	mgr.adapter = stubAgentAdapter{}
+	t.Cleanup(func() { _ = mgr.StopForTeardown(context.Background()) })
 
 	if err := mgr.buildFinalCommand(); err != nil {
 		t.Fatalf("buildFinalCommand() error = %v", err)
@@ -88,7 +90,33 @@ func TestManager_BuildFinalCommandInjectsIsolatedTempDir(t *testing.T) {
 	if info, err := os.Stat(want); err != nil || !info.IsDir() {
 		t.Fatalf("expected temp dir %q to exist, stat=%v err=%v", want, info, err)
 	}
-	t.Cleanup(func() { _ = os.RemoveAll(want) })
+}
+
+func TestManager_OwnedProcessEnvOverridesRequestedTemp(t *testing.T) {
+	setAgentTempTestEnv(t)
+	mgr := NewManager(&config.InstanceConfig{
+		WorkDir:   t.TempDir(),
+		SessionID: "session-child-env",
+	}, newTestLogger(t))
+	if err := mgr.ensureAgentTempEnv(); err != nil {
+		t.Fatalf("ensureAgentTempEnv() error = %v", err)
+	}
+
+	env := mgr.ownedProcessEnv(map[string]string{
+		"TMPDIR": "unmanaged",
+		"CUSTOM": "preserved",
+	})
+	for _, key := range []string{"TMPDIR", "TMP", "TEMP"} {
+		if got := env[key]; got != mgr.agentTempDir {
+			t.Fatalf("%s = %q, want %q", key, got, mgr.agentTempDir)
+		}
+	}
+	if got := env["CUSTOM"]; got != "preserved" {
+		t.Fatalf("CUSTOM = %q, want preserved", got)
+	}
+	if err := mgr.StopForTeardown(context.Background()); err != nil {
+		t.Fatalf("StopForTeardown() error = %v", err)
+	}
 }
 
 func TestManager_StopRemovesAlreadyStoppedTempDirAndPreservesSibling(t *testing.T) {
@@ -280,6 +308,12 @@ func TestManager_StopUsesOpenedRootAfterPathIsReplaced(t *testing.T) {
 	root := filepath.Join(tempBase, agentTempDirRoot)
 	parkedRoot := filepath.Join(tempBase, "original-kandev-agent")
 	if err := os.Rename(root, parkedRoot); err != nil {
+		if runtime.GOOS == "windows" {
+			if stopErr := mgr.StopForTeardown(context.Background()); stopErr != nil {
+				t.Fatalf("StopForTeardown() after protected-root rename = %v", stopErr)
+			}
+			return
+		}
 		t.Fatalf("rename original temp root: %v", err)
 	}
 	outside := t.TempDir()
@@ -507,6 +541,11 @@ func TestManager_TempCleanupWaitsForMainProcessGroupReap(t *testing.T) {
 	mgr.terminateGroupFn = func(int) error { return nil }
 	mgr.killGroupFn = func(int) error { return nil }
 	mgr.waitGroupExitFn = func(context.Context, int) bool { return false }
+	t.Cleanup(func() {
+		mgr.groupAliveFn = func(int) bool { return false }
+		mgr.waitGroupExitFn = nil
+		_ = mgr.StopForTeardown(context.Background())
+	})
 	err := mgr.StopForTeardown(context.Background())
 	if err == nil || !strings.Contains(err.Error(), "remains alive") {
 		t.Fatalf("Stop() error = %v, want process-group reap failure", err)
@@ -530,7 +569,11 @@ func TestManager_TempCleanupWaitsForMainGoroutineReap(t *testing.T) {
 	mgr.cmd = &exec.Cmd{Process: &os.Process{Pid: 424243}}
 	mgr.status.Store(StatusRunning)
 	mgr.wg.Add(1)
-	defer mgr.wg.Done()
+	t.Cleanup(func() {
+		mgr.wg.Done()
+		mgr.managerWaitFn = nil
+		_ = mgr.StopForTeardown(context.Background())
+	})
 	mgr.groupAliveFn = func(int) bool { return false }
 	mgr.terminateGroupFn = func(int) error { return nil }
 	mgr.killGroupFn = func(int) error { return nil }

--- a/apps/backend/internal/agentctl/server/process/manager_temp_test.go
+++ b/apps/backend/internal/agentctl/server/process/manager_temp_test.go
@@ -2,18 +2,36 @@ package process
 
 import (
 	"context"
+	"errors"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/kandev/kandev/internal/agentctl/server/adapter"
 	"github.com/kandev/kandev/internal/agentctl/server/config"
+	"github.com/kandev/kandev/internal/agentctl/server/shell"
 	"github.com/kandev/kandev/internal/agentctl/types"
 	v1 "github.com/kandev/kandev/pkg/api/v1"
 )
 
 type stubAgentAdapter struct{}
+
+type notifyingCloser struct {
+	closed chan struct{}
+	once   sync.Once
+}
+
+func (c *notifyingCloser) Write(p []byte) (int, error) { return len(p), nil }
+
+func (c *notifyingCloser) Close() error {
+	c.once.Do(func() { close(c.closed) })
+	return nil
+}
 
 func (stubAgentAdapter) PrepareEnvironment() (map[string]string, error) { return nil, nil }
 func (stubAgentAdapter) PrepareCommandArgs() []string                   { return nil }
@@ -48,6 +66,7 @@ func envValue(env []string, key string) string {
 }
 
 func TestManager_BuildFinalCommandInjectsIsolatedTempDir(t *testing.T) {
+	setAgentTempTestEnv(t)
 	mgr := NewManager(&config.InstanceConfig{
 		WorkDir:   t.TempDir(),
 		SessionID: "session-123",
@@ -60,7 +79,7 @@ func TestManager_BuildFinalCommandInjectsIsolatedTempDir(t *testing.T) {
 		t.Fatalf("buildFinalCommand() error = %v", err)
 	}
 
-	want := filepath.Join(os.TempDir(), "kandev-agent", "session-123")
+	want := filepath.Join(os.TempDir(), "kandev-agent", agentTempDirName("session-123", "", 0))
 	for _, key := range []string{"TMPDIR", "TMP", "TEMP"} {
 		if got := envValue(mgr.cmd.Env, key); got != want {
 			t.Fatalf("%s = %q, want %q", key, got, want)
@@ -69,4 +88,467 @@ func TestManager_BuildFinalCommandInjectsIsolatedTempDir(t *testing.T) {
 	if info, err := os.Stat(want); err != nil || !info.IsDir() {
 		t.Fatalf("expected temp dir %q to exist, stat=%v err=%v", want, info, err)
 	}
+	t.Cleanup(func() { _ = os.RemoveAll(want) })
+}
+
+func TestManager_StopRemovesAlreadyStoppedTempDirAndPreservesSibling(t *testing.T) {
+	setAgentTempTestEnv(t)
+	mgr := NewManager(&config.InstanceConfig{
+		WorkDir:   t.TempDir(),
+		SessionID: "session-owned",
+	}, newTestLogger(t))
+
+	if err := mgr.ensureAgentTempEnv(); err != nil {
+		t.Fatalf("ensureAgentTempEnv() error = %v", err)
+	}
+	owned := envValue(mgr.cfg.AgentEnv, "TMPDIR")
+	sibling := filepath.Join(filepath.Dir(owned), "session-sibling")
+	if err := os.MkdirAll(sibling, 0o700); err != nil {
+		t.Fatalf("create sibling temp dir: %v", err)
+	}
+
+	if err := mgr.StopForTeardown(context.Background()); err != nil {
+		t.Fatalf("Stop() error = %v", err)
+	}
+	if _, err := os.Stat(owned); !os.IsNotExist(err) {
+		t.Fatalf("owned temp dir still exists after Stop(), err = %v", err)
+	}
+	if info, err := os.Stat(sibling); err != nil || !info.IsDir() {
+		t.Fatalf("sibling temp dir was changed, stat = %v, err = %v", info, err)
+	}
+	if info, err := os.Stat(filepath.Dir(owned)); err != nil || !info.IsDir() {
+		t.Fatalf("shared temp root was changed, stat = %v, err = %v", info, err)
+	}
+}
+
+func TestManager_StopRemovesTempOnlyAfterProcessTeardown(t *testing.T) {
+	setAgentTempTestEnv(t)
+	mgr := NewManager(&config.InstanceConfig{
+		WorkDir:   t.TempDir(),
+		SessionID: "session-running",
+	}, newTestLogger(t))
+	if err := mgr.ensureAgentTempEnv(); err != nil {
+		t.Fatalf("ensureAgentTempEnv() error = %v", err)
+	}
+	owned := envValue(mgr.cfg.AgentEnv, "TMPDIR")
+
+	stdin := &notifyingCloser{closed: make(chan struct{})}
+	mgr.stdin = stdin
+	mgr.status.Store(StatusRunning)
+	reap := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(reap) }) }
+	mgr.wg.Add(1)
+	go func() {
+		defer mgr.wg.Done()
+		<-reap
+	}()
+	t.Cleanup(release)
+
+	stopDone := make(chan error, 1)
+	go func() { stopDone <- mgr.StopForTeardown(context.Background()) }()
+	<-stdin.closed
+	if info, err := os.Stat(owned); err != nil || !info.IsDir() {
+		t.Fatalf("temp dir removed before process reap, stat = %v, err = %v", info, err)
+	}
+
+	release()
+	if err := <-stopDone; err != nil {
+		t.Fatalf("Stop() error = %v", err)
+	}
+	if _, err := os.Stat(owned); !os.IsNotExist(err) {
+		t.Fatalf("owned temp dir still exists after process reap, err = %v", err)
+	}
+}
+
+func TestManager_StopUsesStoredTempOwnershipInsteadOfMutableEnvironment(t *testing.T) {
+	setAgentTempTestEnv(t)
+	mgr := NewManager(&config.InstanceConfig{
+		WorkDir:   t.TempDir(),
+		SessionID: "session-stored",
+	}, newTestLogger(t))
+	if err := mgr.ensureAgentTempEnv(); err != nil {
+		t.Fatalf("ensureAgentTempEnv() error = %v", err)
+	}
+	owned := envValue(mgr.cfg.AgentEnv, "TMPDIR")
+	outside := filepath.Join(t.TempDir(), "must-remain")
+	if err := os.MkdirAll(outside, 0o700); err != nil {
+		t.Fatalf("create outside dir: %v", err)
+	}
+	mgr.cfg.AgentEnv = upsertEnvValue(mgr.cfg.AgentEnv, "TMPDIR", outside)
+
+	if err := mgr.StopForTeardown(context.Background()); err != nil {
+		t.Fatalf("Stop() error = %v", err)
+	}
+	if _, err := os.Stat(owned); !os.IsNotExist(err) {
+		t.Fatalf("stored owned temp dir still exists, err = %v", err)
+	}
+	if info, err := os.Stat(outside); err != nil || !info.IsDir() {
+		t.Fatalf("environment-selected outside dir was changed, stat = %v, err = %v", info, err)
+	}
+}
+
+func TestManager_StopRejectsInvalidTempCleanupTargets(t *testing.T) {
+	base := t.TempDir()
+	root := filepath.Join(base, agentTempDirRoot)
+	outside := filepath.Join(base, "outside")
+	for _, path := range []string{root, outside} {
+		if err := os.MkdirAll(path, 0o700); err != nil {
+			t.Fatalf("create fixture dir %q: %v", path, err)
+		}
+	}
+
+	tests := []struct {
+		name   string
+		root   string
+		target string
+	}{
+		{name: "empty target", root: root},
+		{name: "shared root", root: root, target: root},
+		{name: "outside root", root: root, target: outside},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mgr := NewManager(&config.InstanceConfig{WorkDir: t.TempDir()}, newTestLogger(t))
+			mgr.agentTempRoot = tt.root
+			mgr.agentTempDir = tt.target
+
+			err := mgr.StopForTeardown(context.Background())
+			if err == nil || !strings.Contains(err.Error(), "refusing to clean") {
+				t.Fatalf("Stop() error = %v, want fail-closed cleanup error", err)
+			}
+		})
+	}
+
+	for _, path := range []string{root, outside} {
+		if info, err := os.Stat(path); err != nil || !info.IsDir() {
+			t.Fatalf("invalid cleanup changed %q, stat = %v, err = %v", path, info, err)
+		}
+	}
+}
+
+func TestManager_StopRejectsTempCleanupWithoutOwnershipHandle(t *testing.T) {
+	base := t.TempDir()
+	root := filepath.Join(base, agentTempDirRoot)
+	if err := os.Mkdir(root, 0o700); err != nil {
+		t.Fatalf("create root dir: %v", err)
+	}
+	mgr := NewManager(&config.InstanceConfig{WorkDir: t.TempDir()}, newTestLogger(t))
+	mgr.agentTempRoot = root
+	mgr.agentTempDir = filepath.Join(root, "session\x00invalid")
+
+	err := mgr.StopForTeardown(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "refusing to clean unowned") {
+		t.Fatalf("Stop() error = %v, want fail-closed ownership error", err)
+	}
+	if mgr.agentTempDir == "" {
+		t.Fatal("cleanup ownership cleared after failed removal")
+	}
+}
+
+func TestManager_EnsureTempRejectsSymlinkedSharedRoot(t *testing.T) {
+	tempBase := setAgentTempTestEnv(t)
+	outside := t.TempDir()
+	root := filepath.Join(tempBase, agentTempDirRoot)
+	if err := os.Symlink(outside, root); err != nil {
+		t.Skipf("create symlink fixture: %v", err)
+	}
+	mgr := NewManager(&config.InstanceConfig{
+		WorkDir:   t.TempDir(),
+		SessionID: "session-symlink",
+	}, newTestLogger(t))
+
+	err := mgr.ensureAgentTempEnv()
+	if err == nil || !strings.Contains(err.Error(), "agent temp root") {
+		t.Fatalf("ensureAgentTempEnv() error = %v, want unsafe-root error", err)
+	}
+	if _, err := os.Stat(filepath.Join(outside, "session-symlink")); !os.IsNotExist(err) {
+		t.Fatalf("ensureAgentTempEnv() traversed symlinked root, err = %v", err)
+	}
+}
+
+func TestManager_StopUsesOpenedRootAfterPathIsReplaced(t *testing.T) {
+	tempBase := setAgentTempTestEnv(t)
+	mgr := NewManager(&config.InstanceConfig{
+		WorkDir:   t.TempDir(),
+		SessionID: "session-replaced-root",
+	}, newTestLogger(t))
+	if err := mgr.ensureAgentTempEnv(); err != nil {
+		t.Fatalf("ensureAgentTempEnv() error = %v", err)
+	}
+
+	root := filepath.Join(tempBase, agentTempDirRoot)
+	parkedRoot := filepath.Join(tempBase, "original-kandev-agent")
+	if err := os.Rename(root, parkedRoot); err != nil {
+		t.Fatalf("rename original temp root: %v", err)
+	}
+	outside := t.TempDir()
+	outsideSession := filepath.Join(outside, "session-replaced-root")
+	if err := os.MkdirAll(outsideSession, 0o700); err != nil {
+		t.Fatalf("create outside session dir: %v", err)
+	}
+	if err := os.Symlink(outside, root); err != nil {
+		t.Skipf("create replacement symlink fixture: %v", err)
+	}
+
+	ownedChild := mgr.agentTempChild
+	err := mgr.StopForTeardown(context.Background())
+	if err != nil {
+		t.Fatalf("Stop() error = %v", err)
+	}
+	if info, err := os.Stat(outsideSession); err != nil || !info.IsDir() {
+		t.Fatalf("cleanup traversed replaced root, stat = %v, err = %v", info, err)
+	}
+	if _, err := os.Stat(filepath.Join(parkedRoot, ownedChild)); !os.IsNotExist(err) {
+		t.Fatalf("owned child under original root remains after cleanup, err = %v", err)
+	}
+}
+
+func TestManager_TempNamesDoNotCollideAfterSanitization(t *testing.T) {
+	setAgentTempTestEnv(t)
+	first := NewManager(&config.InstanceConfig{
+		InstanceID: "instance-first",
+		WorkDir:    t.TempDir(),
+		SessionID:  "a/b",
+		Port:       41001,
+	}, newTestLogger(t))
+	second := NewManager(&config.InstanceConfig{
+		InstanceID: "instance-second",
+		WorkDir:    t.TempDir(),
+		SessionID:  "a_b",
+		Port:       41002,
+	}, newTestLogger(t))
+	for _, mgr := range []*Manager{first, second} {
+		if err := mgr.ensureAgentTempEnv(); err != nil {
+			t.Fatalf("ensureAgentTempEnv() error = %v", err)
+		}
+	}
+	if first.agentTempDir == second.agentTempDir {
+		t.Fatalf("distinct instance identities share temp dir %q", first.agentTempDir)
+	}
+	firstDir := first.agentTempDir
+	secondSentinel := filepath.Join(second.agentTempDir, "must-remain")
+	if err := os.WriteFile(secondSentinel, []byte("owned by second"), 0o600); err != nil {
+		t.Fatalf("create second sentinel: %v", err)
+	}
+
+	if err := first.StopForTeardown(context.Background()); err != nil {
+		t.Fatalf("first Stop() error = %v", err)
+	}
+	if _, err := os.Stat(firstDir); !os.IsNotExist(err) {
+		t.Fatalf("first temp dir still exists after Stop(), err = %v", err)
+	}
+	if data, err := os.ReadFile(secondSentinel); err != nil || string(data) != "owned by second" {
+		t.Fatalf("first cleanup changed second temp dir, data = %q, err = %v", data, err)
+	}
+}
+
+func TestManager_StoppedAgentKeepsTempUntilWorkspaceProcessReaped(t *testing.T) {
+	setAgentTempTestEnv(t)
+	mgr := NewManager(&config.InstanceConfig{
+		InstanceID: "instance-natural-exit",
+		WorkDir:    t.TempDir(),
+		SessionID:  "session-natural-exit",
+	}, newTestLogger(t))
+	if err := mgr.ensureAgentTempEnv(); err != nil {
+		t.Fatalf("ensureAgentTempEnv() error = %v", err)
+	}
+	owned := mgr.agentTempDir
+	proc := &commandProcess{
+		info:       ProcessInfo{ID: "workspace-blocked-reap"},
+		stopSignal: make(chan struct{}),
+		done:       make(chan struct{}),
+	}
+	mgr.processRunner.processes[proc.info.ID] = proc
+
+	stopDone := make(chan error, 1)
+	go func() { stopDone <- mgr.StopForTeardown(context.Background()) }()
+	select {
+	case <-proc.stopSignal:
+	case err := <-stopDone:
+		t.Fatalf("Stop() returned before workspace process stop/reap: %v", err)
+	}
+	if info, err := os.Stat(owned); err != nil || !info.IsDir() {
+		t.Fatalf("temp dir removed before workspace process reap, stat = %v, err = %v", info, err)
+	}
+
+	close(proc.done)
+	if err := <-stopDone; err != nil {
+		t.Fatalf("Stop() error = %v", err)
+	}
+	if _, err := os.Stat(owned); !os.IsNotExist(err) {
+		t.Fatalf("temp dir still exists after workspace process reap, err = %v", err)
+	}
+}
+
+func TestManager_BeginStopWaitsForInFlightTempOwnerAdmission(t *testing.T) {
+	mgr := NewManager(&config.InstanceConfig{WorkDir: t.TempDir()}, newTestLogger(t))
+	release, err := mgr.admitStart()
+	if err != nil {
+		t.Fatalf("admitStart() error = %v", err)
+	}
+	stopAdmissionDone := make(chan struct{})
+	go func() {
+		mgr.BeginStop()
+		close(stopAdmissionDone)
+	}()
+	select {
+	case <-stopAdmissionDone:
+		t.Fatal("BeginStop() returned before in-flight owner admission completed")
+	default:
+	}
+	release()
+	<-stopAdmissionDone
+
+	if err := mgr.Start(context.Background()); !errors.Is(err, errManagerStopping) {
+		t.Fatalf("Start() error = %v, want manager-stopping error", err)
+	}
+	if _, err := mgr.StartProcess(context.Background(), StartProcessRequest{}); !errors.Is(err, errManagerStopping) {
+		t.Fatalf("StartProcess() error = %v, want manager-stopping error", err)
+	}
+	if err := mgr.StartShell(); !errors.Is(err, errManagerStopping) {
+		t.Fatalf("StartShell() error = %v, want manager-stopping error", err)
+	}
+	if err := mgr.StartVscode(context.Background(), "dark"); !errors.Is(err, errManagerStopping) {
+		t.Fatalf("StartVscode() error = %v, want manager-stopping error", err)
+	}
+	if _, err := mgr.ShellManager().Start("terminal", shell.DefaultConfig(t.TempDir())); err == nil {
+		t.Fatal("terminal shell Start() succeeded after BeginStop()")
+	}
+}
+
+func TestManager_OrdinaryStopCannotCleanTempDuringTerminalAdmissionDrain(t *testing.T) {
+	setAgentTempTestEnv(t)
+	mgr := NewManager(&config.InstanceConfig{
+		WorkDir:   t.TempDir(),
+		SessionID: "session-concurrent-stop",
+	}, newTestLogger(t))
+	if err := mgr.ensureAgentTempEnv(); err != nil {
+		t.Fatalf("ensureAgentTempEnv() error = %v", err)
+	}
+	owned := mgr.agentTempDir
+	release, err := mgr.admitStart()
+	if err != nil {
+		t.Fatalf("admitStart() error = %v", err)
+	}
+	mgr.CloseAdmission()
+
+	if err := mgr.Stop(context.Background()); err != nil {
+		t.Fatalf("ordinary Stop() error = %v", err)
+	}
+	if info, err := os.Stat(owned); err != nil || !info.IsDir() {
+		t.Fatalf("ordinary Stop() removed terminal-owned temp dir, stat = %v, err = %v", info, err)
+	}
+
+	terminalDone := make(chan error, 1)
+	go func() { terminalDone <- mgr.StopForTeardown(context.Background()) }()
+	select {
+	case err := <-terminalDone:
+		t.Fatalf("terminal stop returned before admission drained: %v", err)
+	default:
+	}
+	release()
+	if err := <-terminalDone; err != nil {
+		t.Fatalf("StopForTeardown() error = %v", err)
+	}
+	if _, err := os.Stat(owned); !os.IsNotExist(err) {
+		t.Fatalf("terminal stop did not remove temp dir after drain, err = %v", err)
+	}
+}
+
+func TestManager_TerminalAdmissionDrainHonorsContextAndRetries(t *testing.T) {
+	setAgentTempTestEnv(t)
+	mgr := NewManager(&config.InstanceConfig{
+		WorkDir:   t.TempDir(),
+		SessionID: "session-drain-timeout",
+	}, newTestLogger(t))
+	if err := mgr.ensureAgentTempEnv(); err != nil {
+		t.Fatalf("ensureAgentTempEnv() error = %v", err)
+	}
+	owned := mgr.agentTempDir
+	release, err := mgr.admitStart()
+	if err != nil {
+		t.Fatalf("admitStart() error = %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err = mgr.StopForTeardown(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("StopForTeardown() error = %v, want %v", err, context.Canceled)
+	}
+	if info, statErr := os.Stat(owned); statErr != nil || !info.IsDir() {
+		t.Fatalf("canceled drain removed temp ownership, stat = %v, err = %v", info, statErr)
+	}
+
+	release()
+	if err := mgr.StopForTeardown(context.Background()); err != nil {
+		t.Fatalf("StopForTeardown() retry error = %v", err)
+	}
+	if _, err := os.Stat(owned); !os.IsNotExist(err) {
+		t.Fatalf("retry did not remove temp dir, err = %v", err)
+	}
+}
+
+func TestManager_TempCleanupWaitsForMainProcessGroupReap(t *testing.T) {
+	setAgentTempTestEnv(t)
+	mgr := NewManager(&config.InstanceConfig{
+		InstanceID: "instance-main-reap-failure",
+		WorkDir:    t.TempDir(),
+		SessionID:  "session-main-reap-failure",
+	}, newTestLogger(t))
+	if err := mgr.ensureAgentTempEnv(); err != nil {
+		t.Fatalf("ensureAgentTempEnv() error = %v", err)
+	}
+	owned := mgr.agentTempDir
+	mgr.cmd = &exec.Cmd{Process: &os.Process{Pid: 424242}}
+	mgr.status.Store(StatusRunning)
+	mgr.groupAliveFn = func(int) bool { return true }
+	mgr.terminateGroupFn = func(int) error { return nil }
+	mgr.killGroupFn = func(int) error { return nil }
+	mgr.waitGroupExitFn = func(context.Context, int) bool { return false }
+	err := mgr.StopForTeardown(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "remains alive") {
+		t.Fatalf("Stop() error = %v, want process-group reap failure", err)
+	}
+	if info, statErr := os.Stat(owned); statErr != nil || !info.IsDir() {
+		t.Fatalf("temp dir removed after failed main reap, stat = %v, err = %v", info, statErr)
+	}
+}
+
+func TestManager_TempCleanupWaitsForMainGoroutineReap(t *testing.T) {
+	setAgentTempTestEnv(t)
+	mgr := NewManager(&config.InstanceConfig{
+		InstanceID: "instance-main-wait-failure",
+		WorkDir:    t.TempDir(),
+		SessionID:  "session-main-wait-failure",
+	}, newTestLogger(t))
+	if err := mgr.ensureAgentTempEnv(); err != nil {
+		t.Fatalf("ensureAgentTempEnv() error = %v", err)
+	}
+	owned := mgr.agentTempDir
+	mgr.cmd = &exec.Cmd{Process: &os.Process{Pid: 424243}}
+	mgr.status.Store(StatusRunning)
+	mgr.wg.Add(1)
+	defer mgr.wg.Done()
+	mgr.groupAliveFn = func(int) bool { return false }
+	mgr.terminateGroupFn = func(int) error { return nil }
+	mgr.killGroupFn = func(int) error { return nil }
+	mgr.managerWaitFn = func(context.Context, <-chan struct{}, time.Duration) bool { return false }
+	err := mgr.StopForTeardown(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "goroutines were not reaped") {
+		t.Fatalf("Stop() error = %v, want manager reap failure", err)
+	}
+	if info, statErr := os.Stat(owned); statErr != nil || !info.IsDir() {
+		t.Fatalf("temp dir removed after failed manager reap, stat = %v, err = %v", info, statErr)
+	}
+}
+
+func setAgentTempTestEnv(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	for _, key := range []string{"TMPDIR", "TMP", "TEMP"} {
+		t.Setenv(key, root)
+	}
+	return root
 }

--- a/apps/backend/internal/agentctl/server/process/manager_test.go
+++ b/apps/backend/internal/agentctl/server/process/manager_test.go
@@ -262,7 +262,7 @@ func TestStartOneShotRestoresTempEnvAfterStrip(t *testing.T) {
 		m.workspaceTracker.Stop()
 	})
 
-	wantDir := filepath.Join(os.TempDir(), agentTempDirRoot, agentTempDirName("session-1", 0))
+	wantDir := filepath.Join(os.TempDir(), agentTempDirRoot, agentTempDirName("session-1", "", 0))
 	for _, key := range []string{"TMPDIR", "TMP", "TEMP"} {
 		if got := lookupEnvValue(m.adapterCfg.OneShotConfig.Env, key); got != wantDir {
 			t.Fatalf("OneShotConfig.Env %s = %q, want %q", key, got, wantDir)

--- a/apps/backend/internal/agentctl/server/process/procattr_linux.go
+++ b/apps/backend/internal/agentctl/server/process/procattr_linux.go
@@ -4,7 +4,10 @@ package process
 
 import (
 	"errors"
+	"os"
 	"os/exec"
+	"strconv"
+	"strings"
 	"syscall"
 )
 
@@ -55,6 +58,40 @@ func processGroupAlive(pid int) bool {
 	if pid <= 0 {
 		return false
 	}
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return processGroupResponds(pid)
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		memberPID, err := strconv.Atoi(entry.Name())
+		if err != nil {
+			continue
+		}
+		stat, err := os.ReadFile("/proc/" + strconv.Itoa(memberPID) + "/stat")
+		if err == nil && processStatMatchesLiveGroup(string(stat), pid) {
+			return true
+		}
+	}
+	return false
+}
+
+func processStatMatchesLiveGroup(stat string, pgid int) bool {
+	commandEnd := strings.LastIndex(stat, ") ")
+	if commandEnd < 0 {
+		return false
+	}
+	fields := strings.Fields(stat[commandEnd+2:])
+	if len(fields) < 3 || fields[0] == "Z" || fields[0] == "X" {
+		return false
+	}
+	group, err := strconv.Atoi(fields[2])
+	return err == nil && group == pgid
+}
+
+func processGroupResponds(pid int) bool {
 	err := syscall.Kill(-pid, 0)
 	return err == nil || errors.Is(err, syscall.EPERM)
 }

--- a/apps/backend/internal/agentctl/server/process/procattr_linux.go
+++ b/apps/backend/internal/agentctl/server/process/procattr_linux.go
@@ -23,6 +23,10 @@ func setAgentProcGroup(cmd *exec.Cmd) {
 	setProcGroup(cmd)
 }
 
+func setManagedProcGroup(cmd *exec.Cmd) {
+	setProcGroup(cmd)
+}
+
 type processLifecycleHandle struct{}
 
 func installProcessLifecycle(_ *exec.Cmd) (processLifecycleHandle, error) {
@@ -30,6 +34,10 @@ func installProcessLifecycle(_ *exec.Cmd) (processLifecycleHandle, error) {
 }
 
 func releaseProcessLifecycle(_ processLifecycleHandle) {}
+
+func reapProcessLifecycle(_ processLifecycleHandle) error { return nil }
+
+func ownsProcessLifecycle(_ processLifecycleHandle) bool { return false }
 
 // killProcessGroup kills the entire process group for the given PID.
 // Returns nil if successful, or an error if the kill failed.

--- a/apps/backend/internal/agentctl/server/process/procattr_linux_test.go
+++ b/apps/backend/internal/agentctl/server/process/procattr_linux_test.go
@@ -1,0 +1,26 @@
+//go:build linux
+
+package process
+
+import "testing"
+
+func TestProcessStatMatchesLiveGroup(t *testing.T) {
+	tests := []struct {
+		name string
+		stat string
+		want bool
+	}{
+		{name: "running member", stat: "123 (agent worker) S 1 42 42 0", want: true},
+		{name: "zombie member", stat: "123 (agent worker) Z 1 42 42 0", want: false},
+		{name: "dead member", stat: "123 (agent worker) X 1 42 42 0", want: false},
+		{name: "different group", stat: "123 (agent worker) S 1 41 41 0", want: false},
+		{name: "malformed", stat: "malformed", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := processStatMatchesLiveGroup(tt.stat, 42); got != tt.want {
+				t.Fatalf("processStatMatchesLiveGroup() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/apps/backend/internal/agentctl/server/process/procattr_unix.go
+++ b/apps/backend/internal/agentctl/server/process/procattr_unix.go
@@ -20,6 +20,10 @@ func setAgentProcGroup(cmd *exec.Cmd) {
 	setProcGroup(cmd)
 }
 
+func setManagedProcGroup(cmd *exec.Cmd) {
+	setProcGroup(cmd)
+}
+
 type processLifecycleHandle struct{}
 
 func installProcessLifecycle(_ *exec.Cmd) (processLifecycleHandle, error) {
@@ -27,6 +31,10 @@ func installProcessLifecycle(_ *exec.Cmd) (processLifecycleHandle, error) {
 }
 
 func releaseProcessLifecycle(_ processLifecycleHandle) {}
+
+func reapProcessLifecycle(_ processLifecycleHandle) error { return nil }
+
+func ownsProcessLifecycle(_ processLifecycleHandle) bool { return false }
 
 // killProcessGroup kills the entire process group for the given PID.
 // Returns nil if successful, or an error if the kill failed.

--- a/apps/backend/internal/agentctl/server/process/procattr_windows.go
+++ b/apps/backend/internal/agentctl/server/process/procattr_windows.go
@@ -3,10 +3,12 @@
 package process
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os/exec"
 	"syscall"
+	"time"
 
 	"github.com/kandev/kandev/internal/agentctl/server/winproc"
 	"golang.org/x/sys/windows"
@@ -23,6 +25,10 @@ func setProcGroup(cmd *exec.Cmd) {
 // cleanup. On Windows, agents start suspended so installProcessLifecycle can
 // bind them to a kill-on-close Job Object before they can spawn descendants.
 func setAgentProcGroup(cmd *exec.Cmd) {
+	setManagedProcGroup(cmd)
+}
+
+func setManagedProcGroup(cmd *exec.Cmd) {
 	setProcGroup(cmd)
 	cmd.SysProcAttr.CreationFlags |= windows.CREATE_SUSPENDED
 }
@@ -41,6 +47,16 @@ func installProcessLifecycle(cmd *exec.Cmd) (processLifecycleHandle, error) {
 
 func releaseProcessLifecycle(lifecycle processLifecycleHandle) {
 	_ = lifecycle.job.Close()
+}
+
+func reapProcessLifecycle(lifecycle processLifecycleHandle) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	return lifecycle.job.TerminateAndWait(ctx)
+}
+
+func ownsProcessLifecycle(lifecycle processLifecycleHandle) bool {
+	return lifecycle.job.Valid()
 }
 
 // killProcessGroup kills the entire process tree for the given PID.

--- a/apps/backend/internal/agentctl/server/process/procattr_windows_test.go
+++ b/apps/backend/internal/agentctl/server/process/procattr_windows_test.go
@@ -3,6 +3,7 @@
 package process
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -13,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kandev/kandev/internal/agentctl/types"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/windows"
 )
@@ -29,6 +31,15 @@ func TestWindowsSetProcGroupDoesNotSuspendSharedHelpers(t *testing.T) {
 func TestWindowsSetAgentProcGroupStartsSuspended(t *testing.T) {
 	cmd := exec.Command("kandev")
 	setAgentProcGroup(cmd)
+
+	require.NotNil(t, cmd.SysProcAttr)
+	require.NotZero(t, cmd.SysProcAttr.CreationFlags&syscall.CREATE_NEW_PROCESS_GROUP)
+	require.NotZero(t, cmd.SysProcAttr.CreationFlags&windows.CREATE_SUSPENDED)
+}
+
+func TestWindowsSetManagedProcGroupStartsSuspended(t *testing.T) {
+	cmd := exec.Command("kandev")
+	setManagedProcGroup(cmd)
 
 	require.NotNil(t, cmd.SysProcAttr)
 	require.NotZero(t, cmd.SysProcAttr.CreationFlags&syscall.CREATE_NEW_PROCESS_GROUP)
@@ -63,6 +74,77 @@ func TestWindowsProcessLifecycleJobKillsDescendants(t *testing.T) {
 		return !windowsProcessAlive(childPID)
 	}, 5*time.Second, 50*time.Millisecond,
 		"child process %d should be killed when the job handle is released", childPID)
+}
+
+func TestWindowsManagedLifecycleReapsDescendantAfterLeaderExit(t *testing.T) {
+	pidFile := filepath.Join(t.TempDir(), "child.pid")
+	cmd := fixtureCmd(fmt.Sprintf("exit-with-child %s 30", pidFile))
+	setManagedProcGroup(cmd)
+	require.NoError(t, cmd.Start())
+	parentPID := cmd.Process.Pid
+	waited := false
+	t.Cleanup(func() {
+		if waited {
+			return
+		}
+		_ = killProcessGroup(parentPID)
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	})
+
+	lifecycle, err := installProcessLifecycle(cmd)
+	require.NoError(t, err)
+	childPID := waitForWindowsChildPID(t, pidFile, 5*time.Second)
+	require.NoError(t, cmd.Wait())
+	waited = true
+	require.True(t, windowsProcessAlive(childPID), "descendant should outlive its leader before job reap")
+
+	require.NoError(t, reapProcessLifecycle(lifecycle))
+	require.Eventually(t, func() bool {
+		return !windowsProcessAlive(childPID)
+	}, 5*time.Second, 50*time.Millisecond,
+		"child process %d should be gone before job reap completes", childPID)
+}
+
+func TestWindowsProcessRunnerReapsDescendantAfterLeaderExit(t *testing.T) {
+	pidFile := filepath.Join(t.TempDir(), "runner-child.pid")
+	command, env := fixtureShellExec(fmt.Sprintf("exit-with-child %s 30", pidFile))
+	runner := NewProcessRunner(nil, newTestLogger(t), 1024)
+	info, err := runner.Start(context.Background(), StartProcessRequest{
+		SessionID: "windows-job-reap",
+		Kind:      types.ProcessKind("test"),
+		Command:   command,
+		Env:       env,
+	})
+	require.NoError(t, err)
+	childPID := waitForWindowsChildPID(t, pidFile, 5*time.Second)
+	t.Cleanup(func() {
+		_ = runProcessTaskkill("/F", "/T", "/PID", strconv.Itoa(childPID))
+	})
+
+	require.Eventually(t, func() bool {
+		_, ok := runner.Get(info.ID, false)
+		return !ok
+	}, 5*time.Second, 20*time.Millisecond, "runner should retain the process until job reap completes")
+	require.False(t, windowsProcessAlive(childPID), "runner returned ownership before its descendant exited")
+}
+
+func TestWindowsVscodeLifecycleReapsDescendantAfterLeaderExit(t *testing.T) {
+	pidFile := filepath.Join(t.TempDir(), "vscode-child.pid")
+	cmd := fixtureCmd(fmt.Sprintf("exit-with-child %s 30", pidFile))
+	setManagedProcGroup(cmd)
+	require.NoError(t, cmd.Start())
+	lifecycle, err := installProcessLifecycle(cmd)
+	require.NoError(t, err)
+	childPID := waitForWindowsChildPID(t, pidFile, 5*time.Second)
+	require.NoError(t, cmd.Wait())
+	t.Cleanup(func() {
+		_ = runProcessTaskkill("/F", "/T", "/PID", strconv.Itoa(childPID))
+	})
+
+	vscode := &VscodeManager{logger: newTestLogger(t), lifecycle: lifecycle}
+	require.NoError(t, vscode.ensureProcessGroupReaped(cmd.Process.Pid))
+	require.False(t, windowsProcessAlive(childPID), "VS Code returned ownership before its descendant exited")
 }
 
 func TestWindowsProcessLifecycleInstallFailsForInvalidPID(t *testing.T) {

--- a/apps/backend/internal/agentctl/server/process/runner.go
+++ b/apps/backend/internal/agentctl/server/process/runner.go
@@ -240,7 +240,7 @@ func (r *ProcessRunner) Start(ctx context.Context, req StartProcessRequest) (*Pr
 	r.admission.RLock()
 	defer r.admission.RUnlock()
 	if r.stopping {
-		return nil, errManagerStopping
+		return nil, ErrManagerStopping
 	}
 	if req.SessionID == "" {
 		return nil, fmt.Errorf("session_id is required")

--- a/apps/backend/internal/agentctl/server/process/runner.go
+++ b/apps/backend/internal/agentctl/server/process/runner.go
@@ -139,7 +139,11 @@ type commandProcess struct {
 	buffer     *ringBuffer   // Memory-bounded output storage
 	stopOnce   sync.Once     // Ensures stopSignal is only closed once
 	stopSignal chan struct{} // Signals output readers to exit before process termination
-	mu         sync.Mutex    // Protects info fields during updates
+	done       chan struct{} // Closed after cmd.Wait returns and lifecycle cleanup finishes
+	pgid       int
+	lifecycle  processLifecycleHandle
+	reapErr    error
+	mu         sync.Mutex // Protects info fields during updates
 }
 
 // ProcessRunner manages multiple background processes with output streaming.
@@ -167,8 +171,22 @@ type ProcessRunner struct {
 	workspaceTracker *WorkspaceTracker // WebSocket stream coordinator (can be nil)
 	bufferMaxBytes   int64             // Default output buffer size for new processes
 
-	mu        sync.RWMutex               // Protects processes map
-	processes map[string]*commandProcess // Active processes by ID
+	mu               sync.RWMutex               // Protects processes map
+	processes        map[string]*commandProcess // Active processes by ID
+	admission        sync.RWMutex
+	stopping         bool
+	groupAliveFn     func(int) bool
+	terminateGroupFn func(int) error
+	killGroupFn      func(int) error
+	waitGroupExitFn  func(context.Context, int) bool
+}
+
+// BeginStop closes process admission and waits for any in-flight spawn to
+// finish committing its process to the tracked set.
+func (r *ProcessRunner) BeginStop() {
+	r.admission.Lock()
+	r.stopping = true
+	r.admission.Unlock()
 }
 
 // NewProcessRunner creates a new process runner.
@@ -219,6 +237,11 @@ func NewProcessRunner(workspaceTracker *WorkspaceTracker, log *logger.Logger, bu
 //   - ProcessInfo with "running" status and unique process ID
 //   - Error if validation fails or process spawn fails
 func (r *ProcessRunner) Start(ctx context.Context, req StartProcessRequest) (*ProcessInfo, error) {
+	r.admission.RLock()
+	defer r.admission.RUnlock()
+	if r.stopping {
+		return nil, errManagerStopping
+	}
 	if req.SessionID == "" {
 		return nil, fmt.Errorf("session_id is required")
 	}
@@ -237,7 +260,7 @@ func (r *ProcessRunner) Start(ctx context.Context, req StartProcessRequest) (*Pr
 	}
 	cmd.Env = mergeEnv(req.Env)
 	// Create new process group for clean shutdown (allows killing entire subprocess tree)
-	setProcGroup(cmd)
+	setManagedProcGroup(cmd)
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
@@ -269,6 +292,7 @@ func (r *ProcessRunner) Start(ctx context.Context, req StartProcessRequest) (*Pr
 		cmd:        cmd,
 		buffer:     newRingBuffer(bufferMaxBytes),
 		stopSignal: make(chan struct{}),
+		done:       make(chan struct{}),
 	}
 
 	r.mu.Lock()
@@ -307,8 +331,29 @@ func (r *ProcessRunner) startAndActivate(proc *commandProcess, cmd *exec.Cmd, id
 		r.mu.Lock()
 		delete(r.processes, id)
 		r.mu.Unlock()
+		close(proc.done)
 		return fmt.Errorf("failed to start process: %w", err)
 	}
+	lifecycle, err := installProcessLifecycle(cmd)
+	if err != nil {
+		_ = stdout.Close()
+		_ = stderr.Close()
+		reapErr := killAndWaitStartedCommand(cmd)
+		proc.mu.Lock()
+		proc.info.Status = types.ProcessStatusFailed
+		proc.info.UpdatedAt = time.Now().UTC()
+		proc.mu.Unlock()
+		r.publishStatus(proc)
+		r.mu.Lock()
+		delete(r.processes, id)
+		r.mu.Unlock()
+		close(proc.done)
+		return errors.Join(fmt.Errorf("failed to install workspace process lifecycle: %w", err), reapErr)
+	}
+	proc.mu.Lock()
+	proc.pgid = cmd.Process.Pid
+	proc.lifecycle = lifecycle
+	proc.mu.Unlock()
 	proc.mu.Lock()
 	proc.info.Status = types.ProcessStatusRunning
 	proc.info.UpdatedAt = time.Now().UTC()
@@ -356,7 +401,10 @@ func (r *ProcessRunner) Stop(ctx context.Context, req StopProcessRequest) error 
 	if !ok {
 		return fmt.Errorf("process not found: %s", req.ProcessID)
 	}
+	return r.stopProcess(ctx, proc)
+}
 
+func (r *ProcessRunner) stopProcess(ctx context.Context, proc *commandProcess) error {
 	// Signal output readers to exit before attempting to terminate the process.
 	// This prevents goroutine leaks from blocked pipe reads.
 	proc.stopOnce.Do(func() {
@@ -368,7 +416,7 @@ func (r *ProcessRunner) Stop(ctx context.Context, req StopProcessRequest) error 
 		pid := proc.cmd.Process.Pid
 		info := proc.snapshot(false)
 		r.logger.Debug("workspace process stop requested",
-			zap.String("process_id", req.ProcessID),
+			zap.String("process_id", info.ID),
 			zap.Int("pid", pid),
 			zap.String("session_id", info.SessionID),
 			zap.String("kind", string(info.Kind)),
@@ -378,17 +426,19 @@ func (r *ProcessRunner) Stop(ctx context.Context, req StopProcessRequest) error 
 
 		// Phase 1: Graceful shutdown (SIGTERM on Unix, interrupt on Windows)
 		r.logger.Debug("workspace process interrupt requested",
-			zap.String("process_id", req.ProcessID),
+			zap.String("process_id", info.ID),
 			zap.Int("pid", pid),
 			zap.String("signal", fmt.Sprint(os.Interrupt)))
 		_ = proc.cmd.Process.Signal(os.Interrupt)
 
 		// Wait for graceful exit (2 seconds) or context cancellation
 		select {
+		case <-proc.done:
+			return r.ensureProcessGroupReaped(ctx, proc)
 		case <-ctx.Done():
 			// Context cancelled - force kill immediately
 			r.logger.Debug("workspace process group SIGKILL requested",
-				zap.String("process_id", req.ProcessID),
+				zap.String("process_id", info.ID),
 				zap.Int("pgid", pid),
 				zap.String("reason", "context_canceled"),
 				zap.Error(ctx.Err()))
@@ -396,7 +446,7 @@ func (r *ProcessRunner) Stop(ctx context.Context, req StopProcessRequest) error 
 		case <-time.After(2 * time.Second):
 			// Phase 2: Grace period expired - force kill entire process tree
 			r.logger.Debug("workspace process group SIGKILL requested",
-				zap.String("process_id", req.ProcessID),
+				zap.String("process_id", info.ID),
 				zap.Int("pgid", pid),
 				zap.String("reason", "grace_expired"))
 			_ = killProcessGroup(pid)
@@ -413,18 +463,45 @@ func (r *ProcessRunner) Stop(ctx context.Context, req StopProcessRequest) error 
 //
 // Typical usage: Shutdown cleanup when agentctl server is stopping.
 func (r *ProcessRunner) StopAll(ctx context.Context) error {
+	processes := r.snapshotProcesses()
+	return r.stopProcesses(ctx, processes)
+}
+
+// StopAllAndWait stops every tracked process and waits until each cmd.Wait
+// goroutine has reaped its process and removed it from runner state.
+func (r *ProcessRunner) StopAllAndWait(ctx context.Context) error {
+	processes := r.snapshotProcesses()
+	stopErr := r.stopProcesses(ctx, processes)
+	var waitErrs []error
+	for _, proc := range processes {
+		select {
+		case <-proc.done:
+			if err := r.ensureProcessGroupReaped(ctx, proc); err != nil {
+				waitErrs = append(waitErrs, err)
+			}
+		case <-ctx.Done():
+			waitErrs = append(waitErrs, fmt.Errorf("wait for workspace process %s: %w", proc.info.ID, ctx.Err()))
+		}
+	}
+	return errors.Join(stopErr, errors.Join(waitErrs...))
+}
+
+func (r *ProcessRunner) snapshotProcesses() []*commandProcess {
 	r.mu.RLock()
-	ids := make([]string, 0, len(r.processes))
-	for id := range r.processes {
-		ids = append(ids, id)
+	processes := make([]*commandProcess, 0, len(r.processes))
+	for _, proc := range r.processes {
+		processes = append(processes, proc)
 	}
 	r.mu.RUnlock()
+	return processes
+}
 
-	r.logger.Debug("workspace process stop all requested", zap.Int("processes", len(ids)))
+func (r *ProcessRunner) stopProcesses(ctx context.Context, processes []*commandProcess) error {
+	r.logger.Debug("workspace process stop all requested", zap.Int("processes", len(processes)))
 
 	var errs []error
-	for _, id := range ids {
-		if err := r.Stop(ctx, StopProcessRequest{ProcessID: id}); err != nil {
+	for _, proc := range processes {
+		if err := r.stopProcess(ctx, proc); err != nil {
 			errs = append(errs, err)
 		}
 	}
@@ -535,6 +612,7 @@ func (r *ProcessRunner) readOutput(proc *commandProcess, reader io.ReadCloser, s
 //   - wait() is the sole authority for final status updates
 //   - Cleanup happens after a delay to allow polling
 func (r *ProcessRunner) wait(proc *commandProcess) {
+	defer close(proc.done)
 	err := proc.cmd.Wait()
 	exitCode := 0
 	status := types.ProcessStatusExited
@@ -566,11 +644,73 @@ func (r *ProcessRunner) wait(proc *commandProcess) {
 	// Publish final status to WebSocket clients
 	r.publishStatus(proc)
 
-	// Remove from tracking map - process is no longer queryable
-	// Output buffer is lost after this point (not persisted)
+	if err := r.ensureProcessGroupReaped(context.Background(), proc); err != nil {
+		proc.mu.Lock()
+		proc.reapErr = err
+		proc.mu.Unlock()
+	}
+}
+
+func (r *ProcessRunner) ensureProcessGroupReaped(ctx context.Context, proc *commandProcess) error {
+	proc.mu.Lock()
+	pgid := proc.pgid
+	lifecycle := proc.lifecycle
+	proc.mu.Unlock()
+	if err := reapProcessLifecycle(lifecycle); err != nil {
+		return fmt.Errorf("reap workspace process job: %w", err)
+	}
+	if pgid != 0 && r.processGroupAlive(pgid) {
+		_ = r.terminateProcessGroup(pgid)
+		waitCtx, cancel := context.WithTimeout(ctx, processGroupTerminateGrace)
+		stopped := r.waitForProcessGroupExit(waitCtx, pgid)
+		cancel()
+		if !stopped {
+			_ = r.killProcessGroup(pgid)
+			killCtx, killCancel := context.WithTimeout(context.Background(), processGroupTerminateGrace)
+			stopped = r.waitForProcessGroupExit(killCtx, pgid)
+			killCancel()
+		}
+		if !stopped {
+			return fmt.Errorf("workspace process group %d remains alive", pgid)
+		}
+	}
+	proc.mu.Lock()
+	proc.reapErr = nil
+	proc.mu.Unlock()
 	r.mu.Lock()
-	delete(r.processes, proc.info.ID)
+	if r.processes[proc.info.ID] == proc {
+		delete(r.processes, proc.info.ID)
+	}
 	r.mu.Unlock()
+	return nil
+}
+
+func (r *ProcessRunner) processGroupAlive(pid int) bool {
+	if r.groupAliveFn != nil {
+		return r.groupAliveFn(pid)
+	}
+	return processGroupAlive(pid)
+}
+
+func (r *ProcessRunner) terminateProcessGroup(pid int) error {
+	if r.terminateGroupFn != nil {
+		return r.terminateGroupFn(pid)
+	}
+	return terminateProcessGroup(pid)
+}
+
+func (r *ProcessRunner) killProcessGroup(pid int) error {
+	if r.killGroupFn != nil {
+		return r.killGroupFn(pid)
+	}
+	return killProcessGroup(pid)
+}
+
+func (r *ProcessRunner) waitForProcessGroupExit(ctx context.Context, pid int) bool {
+	if r.waitGroupExitFn != nil {
+		return r.waitGroupExitFn(ctx, pid)
+	}
+	return waitForProcessGroupExit(ctx, pid)
 }
 
 func (r *ProcessRunner) publishOutput(proc *commandProcess, chunk ProcessOutputChunk) {

--- a/apps/backend/internal/agentctl/server/process/runner.go
+++ b/apps/backend/internal/agentctl/server/process/runner.go
@@ -474,6 +474,12 @@ func (r *ProcessRunner) StopAllAndWait(ctx context.Context) error {
 	for _, proc := range processes {
 		select {
 		case <-proc.done:
+			proc.mu.Lock()
+			reapErr := proc.reapErr
+			proc.mu.Unlock()
+			if reapErr == nil {
+				continue
+			}
 			if err := r.ensureProcessGroupReaped(ctx, proc); err != nil {
 				waitErrs = append(waitErrs, err)
 			}

--- a/apps/backend/internal/agentctl/server/process/runner.go
+++ b/apps/backend/internal/agentctl/server/process/runner.go
@@ -353,8 +353,6 @@ func (r *ProcessRunner) startAndActivate(proc *commandProcess, cmd *exec.Cmd, id
 	proc.mu.Lock()
 	proc.pgid = cmd.Process.Pid
 	proc.lifecycle = lifecycle
-	proc.mu.Unlock()
-	proc.mu.Lock()
 	proc.info.Status = types.ProcessStatusRunning
 	proc.info.UpdatedAt = time.Now().UTC()
 	proc.mu.Unlock()

--- a/apps/backend/internal/agentctl/server/process/runner_test.go
+++ b/apps/backend/internal/agentctl/server/process/runner_test.go
@@ -150,6 +150,64 @@ func TestProcessRunnerStopLogsSignalAttempts(t *testing.T) {
 	t.Fatal("process was not removed after stop")
 }
 
+func TestProcessRunnerStopAllAndWaitBlocksUntilReaped(t *testing.T) {
+	runner := NewProcessRunner(nil, newTestLogger(t), 1024)
+	proc := &commandProcess{
+		info:       ProcessInfo{ID: "blocked-reap"},
+		stopSignal: make(chan struct{}),
+		done:       make(chan struct{}),
+	}
+	runner.processes[proc.info.ID] = proc
+
+	stopDone := make(chan error, 1)
+	go func() { stopDone <- runner.StopAllAndWait(context.Background()) }()
+	<-proc.stopSignal
+	select {
+	case err := <-stopDone:
+		t.Fatalf("StopAllAndWait() returned before reap: %v", err)
+	default:
+	}
+
+	close(proc.done)
+	if err := <-stopDone; err != nil {
+		t.Fatalf("StopAllAndWait() error = %v", err)
+	}
+}
+
+func TestProcessRunnerStopAllAndWaitRetainsLiveProcessGroupForRetry(t *testing.T) {
+	runner := NewProcessRunner(nil, newTestLogger(t), 1024)
+	done := make(chan struct{})
+	close(done)
+	proc := &commandProcess{
+		info:       ProcessInfo{ID: "live-process-group"},
+		stopSignal: make(chan struct{}),
+		done:       done,
+		pgid:       424244,
+	}
+	runner.processes[proc.info.ID] = proc
+	groupAlive := true
+	runner.groupAliveFn = func(int) bool { return groupAlive }
+	runner.terminateGroupFn = func(int) error { return nil }
+	runner.killGroupFn = func(int) error { return nil }
+	runner.waitGroupExitFn = func(context.Context, int) bool { return !groupAlive }
+
+	err := runner.StopAllAndWait(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "remains alive") {
+		t.Fatalf("StopAllAndWait() error = %v, want live-group error", err)
+	}
+	if _, ok := runner.Get(proc.info.ID, false); !ok {
+		t.Fatal("runner discarded process-group ownership after reap failure")
+	}
+
+	groupAlive = false
+	if err := runner.StopAllAndWait(context.Background()); err != nil {
+		t.Fatalf("StopAllAndWait() retry error = %v", err)
+	}
+	if _, ok := runner.Get(proc.info.ID, false); ok {
+		t.Fatal("runner retained process after group reap succeeded")
+	}
+}
+
 func TestStripANSI(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/apps/backend/internal/agentctl/server/process/runner_test.go
+++ b/apps/backend/internal/agentctl/server/process/runner_test.go
@@ -2,6 +2,7 @@ package process
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -174,6 +175,31 @@ func TestProcessRunnerStopAllAndWaitBlocksUntilReaped(t *testing.T) {
 	}
 }
 
+func TestProcessRunnerStopAllAndWaitSkipsCompletedReap(t *testing.T) {
+	runner := NewProcessRunner(nil, newTestLogger(t), 1024)
+	done := make(chan struct{})
+	close(done)
+	proc := &commandProcess{
+		info:       ProcessInfo{ID: "completed-reap"},
+		stopSignal: make(chan struct{}),
+		done:       done,
+		pgid:       424243,
+	}
+	runner.processes[proc.info.ID] = proc
+	reapChecks := 0
+	runner.groupAliveFn = func(int) bool {
+		reapChecks++
+		return false
+	}
+
+	if err := runner.StopAllAndWait(context.Background()); err != nil {
+		t.Fatalf("StopAllAndWait() error = %v", err)
+	}
+	if reapChecks != 0 {
+		t.Fatalf("process group rechecked %d times after completed reap", reapChecks)
+	}
+}
+
 func TestProcessRunnerStopAllAndWaitRetainsLiveProcessGroupForRetry(t *testing.T) {
 	runner := NewProcessRunner(nil, newTestLogger(t), 1024)
 	done := make(chan struct{})
@@ -183,6 +209,7 @@ func TestProcessRunnerStopAllAndWaitRetainsLiveProcessGroupForRetry(t *testing.T
 		stopSignal: make(chan struct{}),
 		done:       done,
 		pgid:       424244,
+		reapErr:    errors.New("initial reap failed"),
 	}
 	runner.processes[proc.info.ID] = proc
 	groupAlive := true

--- a/apps/backend/internal/agentctl/server/process/vscode.go
+++ b/apps/backend/internal/agentctl/server/process/vscode.go
@@ -2,9 +2,9 @@
 package process
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -50,15 +50,27 @@ type VscodeManager struct {
 	logger          *logger.Logger
 
 	cmd          *exec.Cmd
+	lifecycle    processLifecycleHandle
+	reapErr      error
 	resolvedPath string // resolved code-server binary path (set after startup)
 	status       VscodeStatus
 	err          string
 	message      string
 	mu           sync.Mutex
 	cancelStart  context.CancelFunc // cancels startAsync goroutine
+	startDone    chan struct{}      // closes when the current start generation exits
 	stopCh       chan struct{}
 	doneCh       chan struct{}
 	stopped      bool // guards stopCh against double-close
+
+	resolveBinaryFn    func(context.Context) (string, error)
+	allocatePortFn     func() (int, error)
+	beforeProcessStart func()
+	afterStartCancel   func()
+	groupAliveFn       func(int) bool
+	terminateGroupFn   func(int) error
+	killGroupFn        func(int) error
+	waitGroupExitFn    func(context.Context, int) bool
 }
 
 // NewVscodeManager creates a new VS Code process manager.
@@ -98,50 +110,107 @@ func (v *VscodeManager) Start() {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	v.cancelStart = cancel
+	startDone := make(chan struct{})
+	v.startDone = startDone
 
-	go v.startAsync(ctx)
+	go v.startAsync(ctx, startDone)
 }
 
 // startAsync runs the full startup sequence in a background goroutine.
-func (v *VscodeManager) startAsync(ctx context.Context) {
+func (v *VscodeManager) startAsync(ctx context.Context, done chan struct{}) {
+	defer close(done)
 	// Write theme settings before starting
 	v.writeThemeSettings()
 
 	// Resolve the binary, auto-installing if needed (the slow part)
-	v.setMessage("Installing code-server (this may take a moment)...")
-	resolvedPath, err := tools.ResolveBinary(ctx, v.command, nil, v.installStrategy, v.logger)
-	if err != nil {
-		v.setError(fmt.Sprintf("code-server binary not available: %s", err))
+	if !v.commitStartState(ctx, done, func() {
+		v.message = "Installing code-server (this may take a moment)..."
+	}) {
 		return
 	}
-	v.mu.Lock()
-	v.resolvedPath = resolvedPath
-	v.mu.Unlock()
+	resolvedPath, err := v.resolveBinary(ctx)
+	if err != nil {
+		v.setStartError(ctx, done, fmt.Sprintf("code-server binary not available: %s", err))
+		return
+	}
+	if !v.commitStartState(ctx, done, func() { v.resolvedPath = resolvedPath }) {
+		return
+	}
 
 	// Allocate a random port via the OS to avoid collisions
 	// with other kandev instances or concurrent sessions.
-	port, err := allocatePort()
+	port, err := v.allocateStartupPort()
 	if err != nil {
-		v.setError(fmt.Sprintf("failed to allocate port: %s", err))
+		v.setStartError(ctx, done, fmt.Sprintf("failed to allocate port: %s", err))
+		return
+	}
+	if !v.commitStartState(ctx, done, func() {
+		v.port = port
+		v.status = VscodeStatusStarting
+		v.message = "Starting code-server..."
+	}) {
+		return
+	}
+	if v.beforeProcessStart != nil {
+		v.beforeProcessStart()
+	}
+	if ctx.Err() != nil {
+		return
+	}
+
+	if err := v.startProcess(ctx, done, resolvedPath); err != nil {
+		v.setStartError(ctx, done, fmt.Sprintf("code-server failed to start: %s", err))
+		return
+	}
+	if !v.commitStartState(ctx, done, func() {
+		v.status = VscodeStatusRunning
+		v.message = ""
+	}) {
 		return
 	}
 	v.mu.Lock()
-	v.port = port
-	v.mu.Unlock()
-
-	v.setStatus(VscodeStatusStarting)
-	v.setMessage("Starting code-server...")
-
-	if err := v.startProcess(ctx, resolvedPath); err != nil {
-		v.setError(fmt.Sprintf("code-server failed to start: %s", err))
-		return
+	pid := 0
+	startedPort := 0
+	if v.startDone == done && v.cmd != nil && v.cmd.Process != nil {
+		pid = v.cmd.Process.Pid
+		startedPort = v.port
 	}
-
-	v.setStatus(VscodeStatusRunning)
-	v.setMessage("")
+	v.mu.Unlock()
 	v.logger.Info("code-server started",
-		zap.Int("port", v.port),
-		zap.Int("pid", v.cmd.Process.Pid))
+		zap.Int("port", startedPort),
+		zap.Int("pid", pid))
+}
+
+func (v *VscodeManager) resolveBinary(ctx context.Context) (string, error) {
+	if v.resolveBinaryFn != nil {
+		return v.resolveBinaryFn(ctx)
+	}
+	return tools.ResolveBinary(ctx, v.command, nil, v.installStrategy, v.logger)
+}
+
+func (v *VscodeManager) allocateStartupPort() (int, error) {
+	if v.allocatePortFn != nil {
+		return v.allocatePortFn()
+	}
+	return allocatePort()
+}
+
+func (v *VscodeManager) commitStartState(ctx context.Context, done chan struct{}, commit func()) bool {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	if ctx.Err() != nil || v.startDone != done || v.status == VscodeStatusStopped {
+		return false
+	}
+	commit()
+	return true
+}
+
+func (v *VscodeManager) setStartError(ctx context.Context, done chan struct{}, message string) {
+	v.commitStartState(ctx, done, func() {
+		v.status = VscodeStatusError
+		v.err = message
+		v.message = ""
+	})
 }
 
 // allocatePort finds a free port using the OS.
@@ -156,7 +225,7 @@ func allocatePort() (int, error) {
 }
 
 // startProcess creates and starts the code-server subprocess.
-func (v *VscodeManager) startProcess(ctx context.Context, binaryPath string) error {
+func (v *VscodeManager) startProcess(ctx context.Context, generationDone chan struct{}, binaryPath string) error {
 	workDir := resolveExistingWorkDir(v.workDir, v.logger)
 	bindAddr := fmt.Sprintf("0.0.0.0:%d", v.port)
 	args := []string{
@@ -170,63 +239,69 @@ func (v *VscodeManager) startProcess(ctx context.Context, binaryPath string) err
 	args = append(args, workDir)
 
 	v.mu.Lock()
-	v.cmd = exec.Command(binaryPath, args...)
-	v.cmd.Dir = workDir
+	if ctx.Err() != nil || v.startDone != generationDone || v.status == VscodeStatusStopped {
+		v.mu.Unlock()
+		return context.Canceled
+	}
+	cmd := exec.Command(binaryPath, args...)
+	cmd.Dir = workDir
 	v.workDir = workDir
 	// Give code-server its own process group so Stop() can kill the entire
 	// process tree (main process + Node.js workers) without affecting agentctl.
-	setProcGroup(v.cmd)
+	setManagedProcGroup(cmd)
 
-	stderr, err := v.cmd.StderrPipe()
+	stderr, err := cmd.StderrPipe()
 	if err != nil {
 		v.mu.Unlock()
 		return fmt.Errorf("failed to create stderr pipe: %w", err)
 	}
 
-	if err := v.cmd.Start(); err != nil {
+	if err := cmd.Start(); err != nil {
 		v.mu.Unlock()
 		return fmt.Errorf("failed to start code-server: %w", err)
 	}
+	lifecycle, lifecycleErr := installProcessLifecycle(cmd)
+	if lifecycleErr != nil {
+		reapErr := killAndWaitStartedCommand(cmd)
+		v.mu.Unlock()
+		return errors.Join(fmt.Errorf("failed to install code-server process lifecycle: %w", lifecycleErr), reapErr)
+	}
 
+	doneCh := make(chan struct{})
+	v.cmd = cmd
+	v.lifecycle = lifecycle
+	v.reapErr = nil
 	v.stopCh = make(chan struct{})
-	v.doneCh = make(chan struct{})
+	v.doneCh = doneCh
 	v.mu.Unlock()
 
-	// Read stderr in background for logging
-	go func() {
-		scanner := bufio.NewScanner(stderr)
-		for scanner.Scan() {
-			v.logger.Debug("code-server", zap.String("line", scanner.Text()))
-		}
-	}()
-
-	// Wait for process exit in background
-	pid := v.cmd.Process.Pid
-	go func() {
-		defer close(v.doneCh)
-		waitErr := v.cmd.Wait()
-
-		v.mu.Lock()
-		defer v.mu.Unlock()
-
-		if waitErr != nil && v.status != VscodeStatusStopped {
-			v.status = VscodeStatusError
-			v.err = waitErr.Error()
-			v.logger.Error("code-server exited with error",
-				zap.Int("pid", pid), zap.Error(waitErr))
-		} else {
-			v.status = VscodeStatusStopped
-			v.logger.Info("code-server exited", zap.Int("pid", pid))
-		}
-	}()
+	go v.readProcessStderr(stderr)
+	go v.monitorProcess(cmd, doneCh)
 
 	// Wait for code-server to become ready
 	if err := v.waitForReady(ctx); err != nil {
-		_ = v.Stop(ctx)
+		v.stopProcessAfterStartupFailure()
 		return fmt.Errorf("code-server failed to become ready: %w", err)
 	}
 
 	return nil
+}
+
+func (v *VscodeManager) stopProcessAfterStartupFailure() {
+	v.mu.Lock()
+	cmd := v.cmd
+	doneCh := v.doneCh
+	v.mu.Unlock()
+	if cmd == nil || cmd.Process == nil {
+		return
+	}
+	_ = killProcessGroup(cmd.Process.Pid)
+	if doneCh != nil {
+		select {
+		case <-doneCh:
+		case <-time.After(2 * time.Second):
+		}
+	}
 }
 
 func resolveExistingWorkDir(workDir string, log *logger.Logger) string {
@@ -299,89 +374,6 @@ func (v *VscodeManager) waitForReady(ctx context.Context) error {
 			time.Sleep(500 * time.Millisecond)
 		}
 	}
-}
-
-// Stop stops the code-server process.
-func (v *VscodeManager) Stop(ctx context.Context) error {
-	v.mu.Lock()
-	if v.status == VscodeStatusStopped {
-		v.mu.Unlock()
-		return nil
-	}
-
-	v.logger.Info("stopping code-server")
-	v.status = VscodeStatusStopped
-
-	// Cancel any in-progress startAsync goroutine (e.g. slow binary download).
-	if v.cancelStart != nil {
-		v.cancelStart()
-		v.cancelStart = nil
-	}
-
-	if v.stopCh != nil && !v.stopped {
-		close(v.stopCh)
-		v.stopped = true
-	}
-
-	cmd := v.cmd
-	doneCh := v.doneCh
-	v.mu.Unlock()
-
-	if cmd != nil && cmd.Process != nil {
-		pid := cmd.Process.Pid
-		v.logger.Info("stopping code-server process group",
-			zap.Int("pid", pid), zap.Int("pgid", pid))
-		logChildProcesses(v.logger, pid)
-
-		// Phase 1: Graceful SIGTERM to the entire process group.
-		v.logger.Debug("code-server process group SIGTERM requested",
-			zap.Int("pgid", pid),
-			zap.String("reason", "stop_requested"))
-		if err := terminateProcessGroup(pid); err != nil {
-			v.logger.Warn("failed to send SIGTERM to code-server group",
-				zap.Int("pgid", pid), zap.Error(err))
-		}
-
-		// Phase 2: Wait for graceful exit, then escalate to SIGKILL.
-		if doneCh != nil {
-			select {
-			case <-doneCh:
-				v.logger.Info("code-server stopped gracefully", zap.Int("pid", pid))
-				return nil
-			case <-ctx.Done():
-				v.logger.Warn("context cancelled during SIGTERM wait, force killing",
-					zap.Int("pgid", pid))
-			case <-time.After(5 * time.Second):
-				v.logger.Warn("code-server did not exit after SIGTERM, force killing",
-					zap.Int("pgid", pid))
-			}
-
-			v.logger.Debug("code-server process group SIGKILL requested",
-				zap.Int("pgid", pid),
-				zap.String("reason", "grace_expired_or_context_canceled"))
-			if err := killProcessGroup(pid); err != nil {
-				v.logger.Warn("failed to force kill code-server group",
-					zap.Int("pgid", pid), zap.Error(err))
-			}
-			select {
-			case <-doneCh:
-			case <-ctx.Done():
-			case <-time.After(2 * time.Second):
-				v.logger.Error("code-server still alive after SIGKILL",
-					zap.Int("pid", pid))
-			}
-		}
-	} else if doneCh != nil {
-		// No process but doneCh exists (startup cancelled before process started)
-		select {
-		case <-doneCh:
-		case <-ctx.Done():
-		case <-time.After(2 * time.Second):
-		}
-	}
-
-	v.logger.Info("code-server stopped")
-	return nil
 }
 
 // WaitForRunning blocks until the code-server reaches "running" status.

--- a/apps/backend/internal/agentctl/server/process/vscode.go
+++ b/apps/backend/internal/agentctl/server/process/vscode.go
@@ -56,6 +56,7 @@ type VscodeManager struct {
 	status       VscodeStatus
 	err          string
 	message      string
+	env          map[string]string
 	mu           sync.Mutex
 	cancelStart  context.CancelFunc // cancels startAsync goroutine
 	startDone    chan struct{}      // closes when the current start generation exits
@@ -88,6 +89,15 @@ func NewVscodeManager(
 		installStrategy: strategy,
 		logger:          log.WithFields(zap.String("component", "vscode-manager")),
 		status:          VscodeStatusStopped,
+	}
+}
+
+func (v *VscodeManager) setEnv(env map[string]string) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	v.env = make(map[string]string, len(env))
+	for key, value := range env {
+		v.env[key] = value
 	}
 }
 
@@ -245,6 +255,10 @@ func (v *VscodeManager) startProcess(ctx context.Context, generationDone chan st
 	}
 	cmd := exec.Command(binaryPath, args...)
 	cmd.Dir = workDir
+	cmd.Env = append([]string(nil), os.Environ()...)
+	for key, value := range v.env {
+		cmd.Env = upsertEnvValue(cmd.Env, key, value)
+	}
 	v.workDir = workDir
 	// Give code-server its own process group so Stop() can kill the entire
 	// process tree (main process + Node.js workers) without affecting agentctl.

--- a/apps/backend/internal/agentctl/server/process/vscode_lifecycle.go
+++ b/apps/backend/internal/agentctl/server/process/vscode_lifecycle.go
@@ -43,7 +43,7 @@ func (v *VscodeManager) monitorProcess(cmd *exec.Cmd, doneCh chan struct{}) {
 // Stop stops the code-server process.
 func (v *VscodeManager) Stop(ctx context.Context) error {
 	startDone := v.beginStop()
-	if err := waitForVscodeStartGeneration(startDone); err != nil {
+	if err := waitForVscodeStartGeneration(ctx, startDone); err != nil {
 		return err
 	}
 	cmd, doneCh := v.snapshotStoppedProcess(startDone)
@@ -78,10 +78,12 @@ func (v *VscodeManager) beginStop() chan struct{} {
 	return startDone
 }
 
-func waitForVscodeStartGeneration(startDone <-chan struct{}) error {
+func waitForVscodeStartGeneration(ctx context.Context, startDone <-chan struct{}) error {
 	if startDone != nil {
 		select {
 		case <-startDone:
+		case <-ctx.Done():
+			return fmt.Errorf("wait for code-server startup generation: %w", ctx.Err())
 		case <-time.After(2 * time.Second):
 			return fmt.Errorf("code-server startup generation did not stop after cancellation")
 		}

--- a/apps/backend/internal/agentctl/server/process/vscode_lifecycle.go
+++ b/apps/backend/internal/agentctl/server/process/vscode_lifecycle.go
@@ -1,0 +1,227 @@
+package process
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os/exec"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+func (v *VscodeManager) readProcessStderr(stderr io.Reader) {
+	scanner := bufio.NewScanner(stderr)
+	for scanner.Scan() {
+		v.logger.Debug("code-server", zap.String("line", scanner.Text()))
+	}
+}
+
+func (v *VscodeManager) monitorProcess(cmd *exec.Cmd, doneCh chan struct{}) {
+	defer close(doneCh)
+	pid := cmd.Process.Pid
+	waitErr := cmd.Wait()
+	reapErr := v.ensureProcessGroupReaped(pid)
+
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	if reapErr != nil {
+		v.reapErr = reapErr
+		v.logger.Error("code-server process tree was not reaped", zap.Int("pid", pid), zap.Error(reapErr))
+	}
+	if waitErr != nil && v.status != VscodeStatusStopped {
+		v.status = VscodeStatusError
+		v.err = waitErr.Error()
+		v.logger.Error("code-server exited with error", zap.Int("pid", pid), zap.Error(waitErr))
+		return
+	}
+	v.status = VscodeStatusStopped
+	v.logger.Info("code-server exited", zap.Int("pid", pid))
+}
+
+// Stop stops the code-server process.
+func (v *VscodeManager) Stop(ctx context.Context) error {
+	startDone := v.beginStop()
+	if err := waitForVscodeStartGeneration(startDone); err != nil {
+		return err
+	}
+	cmd, doneCh := v.snapshotStoppedProcess(startDone)
+	if cmd != nil && cmd.Process != nil {
+		return v.stopRunningProcess(ctx, cmd.Process.Pid, doneCh)
+	}
+	if doneCh != nil {
+		return waitForVscodeStartupReap(ctx, doneCh)
+	}
+	v.logger.Info("code-server stopped")
+	return nil
+}
+
+func (v *VscodeManager) beginStop() chan struct{} {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	startDone := v.startDone
+	cancelStart := v.cancelStart
+	v.cancelStart = nil
+	if cancelStart != nil {
+		cancelStart()
+	}
+	if v.afterStartCancel != nil {
+		v.afterStartCancel()
+	}
+	v.logger.Info("stopping code-server")
+	v.status = VscodeStatusStopped
+	if v.stopCh != nil && !v.stopped {
+		close(v.stopCh)
+		v.stopped = true
+	}
+	return startDone
+}
+
+func waitForVscodeStartGeneration(startDone <-chan struct{}) error {
+	if startDone != nil {
+		select {
+		case <-startDone:
+		case <-time.After(2 * time.Second):
+			return fmt.Errorf("code-server startup generation did not stop after cancellation")
+		}
+	}
+	return nil
+}
+
+func (v *VscodeManager) snapshotStoppedProcess(startDone chan struct{}) (*exec.Cmd, <-chan struct{}) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	cmd := v.cmd
+	doneCh := v.doneCh
+	if v.startDone == startDone {
+		v.startDone = nil
+	}
+	v.status = VscodeStatusStopped
+	return cmd, doneCh
+}
+
+func (v *VscodeManager) stopRunningProcess(ctx context.Context, pid int, doneCh <-chan struct{}) error {
+	v.logger.Info("stopping code-server process group", zap.Int("pid", pid), zap.Int("pgid", pid))
+	logChildProcesses(v.logger, pid)
+	v.logger.Debug("code-server process group SIGTERM requested",
+		zap.Int("pgid", pid), zap.String("reason", "stop_requested"))
+	if err := v.terminateProcessGroup(pid); err != nil {
+		v.logger.Warn("failed to send SIGTERM to code-server group", zap.Int("pgid", pid), zap.Error(err))
+	}
+	if doneCh == nil {
+		return v.ensureProcessGroupReaped(pid)
+	}
+	select {
+	case <-doneCh:
+		v.logger.Info("code-server stopped gracefully", zap.Int("pid", pid))
+		return v.ensureProcessGroupReaped(pid)
+	case <-ctx.Done():
+		v.logger.Warn("context cancelled during SIGTERM wait, force killing", zap.Int("pgid", pid))
+	case <-time.After(5 * time.Second):
+		v.logger.Warn("code-server did not exit after SIGTERM, force killing", zap.Int("pgid", pid))
+	}
+	return v.forceStopRunningProcess(ctx, pid, doneCh)
+}
+
+func (v *VscodeManager) forceStopRunningProcess(ctx context.Context, pid int, doneCh <-chan struct{}) error {
+	v.logger.Debug("code-server process group SIGKILL requested",
+		zap.Int("pgid", pid), zap.String("reason", "grace_expired_or_context_canceled"))
+	if err := v.killProcessGroup(pid); err != nil {
+		v.logger.Warn("failed to force kill code-server group", zap.Int("pgid", pid), zap.Error(err))
+	}
+	select {
+	case <-doneCh:
+		return v.ensureProcessGroupReaped(pid)
+	case <-ctx.Done():
+		return fmt.Errorf("wait for code-server process reap: %w", ctx.Err())
+	case <-time.After(2 * time.Second):
+		v.logger.Error("code-server still alive after SIGKILL", zap.Int("pid", pid))
+		return fmt.Errorf("code-server process %d was not reaped after force kill", pid)
+	}
+}
+
+func waitForVscodeStartupReap(ctx context.Context, doneCh <-chan struct{}) error {
+	select {
+	case <-doneCh:
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("wait for code-server startup reap: %w", ctx.Err())
+	case <-time.After(2 * time.Second):
+		return fmt.Errorf("code-server startup process was not reaped after stop")
+	}
+}
+
+func (v *VscodeManager) ensureProcessGroupReaped(pid int) error {
+	v.mu.Lock()
+	lifecycle := v.lifecycle
+	v.mu.Unlock()
+	if err := reapProcessLifecycle(lifecycle); err != nil {
+		return fmt.Errorf("reap code-server process job: %w", err)
+	}
+	if !v.processGroupAlive(pid) {
+		v.clearReapedProcessOwnership(lifecycle)
+		return nil
+	}
+	_ = v.killProcessGroup(pid)
+	ctx, cancel := context.WithTimeout(context.Background(), processGroupTerminateGrace)
+	defer cancel()
+	if v.waitForProcessGroupExit(ctx, pid) {
+		v.clearReapedProcessOwnership(lifecycle)
+		return nil
+	}
+	return fmt.Errorf("code-server process group %d remains alive", pid)
+}
+
+func (v *VscodeManager) clearReapedProcessOwnership(lifecycle processLifecycleHandle) {
+	v.mu.Lock()
+	if v.lifecycle == lifecycle {
+		v.lifecycle = processLifecycleHandle{}
+		v.reapErr = nil
+	}
+	v.mu.Unlock()
+}
+
+func (v *VscodeManager) processGroupAlive(pid int) bool {
+	if v.groupAliveFn != nil {
+		return v.groupAliveFn(pid)
+	}
+	return processGroupAlive(pid)
+}
+
+func (v *VscodeManager) killProcessGroup(pid int) error {
+	if v.killGroupFn != nil {
+		return v.killGroupFn(pid)
+	}
+	return killProcessGroup(pid)
+}
+
+func (v *VscodeManager) terminateProcessGroup(pid int) error {
+	if v.terminateGroupFn != nil {
+		return v.terminateGroupFn(pid)
+	}
+	return terminateProcessGroup(pid)
+}
+
+func (v *VscodeManager) waitForProcessGroupExit(ctx context.Context, pid int) bool {
+	if v.waitGroupExitFn != nil {
+		return v.waitGroupExitFn(ctx, pid)
+	}
+	return waitForProcessGroupExit(ctx, pid)
+}
+
+func (v *VscodeManager) HasUnreapedOwnership() bool {
+	v.mu.Lock()
+	startDone := v.startDone
+	cmd := v.cmd
+	reapErr := v.reapErr
+	v.mu.Unlock()
+	if startDone != nil {
+		select {
+		case <-startDone:
+		default:
+			return true
+		}
+	}
+	return reapErr != nil || (cmd != nil && cmd.Process != nil && v.processGroupAlive(cmd.Process.Pid))
+}

--- a/apps/backend/internal/agentctl/server/process/vscode_test.go
+++ b/apps/backend/internal/agentctl/server/process/vscode_test.go
@@ -336,6 +336,21 @@ func TestVscodeManager_StopCancelsGenerationBeforeProcessCommit(t *testing.T) {
 	require.Nil(t, v.cmd, "canceled generation committed a process")
 }
 
+func TestVscodeManager_StopStartupWaitHonorsContext(t *testing.T) {
+	v := NewVscodeManager("code-server", t.TempDir(), "dark", nil, newTestLogger(t))
+	v.status = VscodeStatusInstalling
+	v.stopCh = make(chan struct{})
+	v.startDone = make(chan struct{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	started := time.Now()
+	err := v.Stop(ctx)
+
+	require.ErrorIs(t, err, context.Canceled)
+	require.Less(t, time.Since(started), 500*time.Millisecond)
+}
+
 func TestVscodeManager_StopReturnsLiveProcessGroupError(t *testing.T) {
 	v := NewVscodeManager("code-server", t.TempDir(), "dark", nil, newTestLogger(t))
 	done := make(chan struct{})

--- a/apps/backend/internal/agentctl/server/process/vscode_test.go
+++ b/apps/backend/internal/agentctl/server/process/vscode_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -301,6 +302,55 @@ func TestVscodeManager_Start_Idempotent(t *testing.T) {
 	// Start should be a no-op when already installing
 	v.Start()
 	assert.Equal(t, VscodeStatusInstalling, v.Info().Status)
+}
+
+func TestVscodeManager_StopCancelsGenerationBeforeProcessCommit(t *testing.T) {
+	v := NewVscodeManager("code-server", t.TempDir(), "dark", nil, newTestLogger(t))
+	v.resolveBinaryFn = func(context.Context) (string, error) { return "/unused/code-server", nil }
+	v.allocatePortFn = func() (int, error) { return 43210, nil }
+	beforeStart := make(chan struct{})
+	releaseStart := make(chan struct{})
+	startCanceled := make(chan struct{})
+	v.beforeProcessStart = func() {
+		close(beforeStart)
+		<-releaseStart
+	}
+	v.afterStartCancel = func() { close(startCanceled) }
+
+	v.Start()
+	<-beforeStart
+	stopDone := make(chan error, 1)
+	go func() { stopDone <- v.Stop(context.Background()) }()
+	<-startCanceled
+	select {
+	case err := <-stopDone:
+		t.Fatalf("Stop() returned before startup generation joined: %v", err)
+	default:
+	}
+
+	close(releaseStart)
+	require.NoError(t, <-stopDone)
+	require.Equal(t, VscodeStatusStopped, v.Info().Status)
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	require.Nil(t, v.cmd, "canceled generation committed a process")
+}
+
+func TestVscodeManager_StopReturnsLiveProcessGroupError(t *testing.T) {
+	v := NewVscodeManager("code-server", t.TempDir(), "dark", nil, newTestLogger(t))
+	done := make(chan struct{})
+	close(done)
+	v.status = VscodeStatusRunning
+	v.stopCh = make(chan struct{})
+	v.doneCh = done
+	v.cmd = &exec.Cmd{Process: &os.Process{Pid: 424245}}
+	v.groupAliveFn = func(int) bool { return true }
+	v.terminateGroupFn = func(int) error { return nil }
+	v.killGroupFn = func(int) error { return nil }
+	v.waitGroupExitFn = func(context.Context, int) bool { return false }
+
+	err := v.Stop(context.Background())
+	require.ErrorContains(t, err, "process group 424245 remains alive")
 }
 
 func TestVscodeInfo_JSON(t *testing.T) {

--- a/apps/backend/internal/agentctl/server/process/workspace_git_diff.go
+++ b/apps/backend/internal/agentctl/server/process/workspace_git_diff.go
@@ -56,14 +56,28 @@ const (
 // chance to populate fresh data. Running it inside enrichWithUnstagedDiff would
 // pre-fill fi.Diff for staged-only files, and enrichWithStagedDiff's
 // `if fileInfo.Diff == ""` guard would then skip the fresh staged diff fetch.
-func (wt *WorkspaceTracker) enrichWithDiffData(ctx context.Context, update *types.GitStatusUpdate, prior types.GitStatusUpdate) {
+func (wt *WorkspaceTracker) enrichWithDiffData(
+	ctx context.Context,
+	update *types.GitStatusUpdate,
+	prior types.GitStatusUpdate,
+) error {
+	budget, err := newDiffBudget(ctx, update)
+	if err != nil {
+		return err
+	}
 	// Always diff against HEAD for unstaged/staged content so that files committed
 	// locally (but not yet pushed) show only their uncommitted changes rather than
 	// the entire file as new. The remote branch is only relevant for ahead/behind counts.
-	wt.enrichWithUnstagedDiff(ctx, update, "HEAD", prior)
-	wt.enrichWithStagedDiff(ctx, update, "HEAD", prior)
-	wt.enrichUntrackedFileDiffs(ctx, update)
-	carryForwardFileDiffs(update, prior)
+	if err := wt.enrichWithUnstagedDiffBudget(ctx, update, "HEAD", prior, &budget); err != nil {
+		return err
+	}
+	if err := wt.enrichWithStagedDiffBudget(ctx, update, "HEAD", prior, &budget); err != nil {
+		return err
+	}
+	if err := wt.enrichUntrackedFileDiffsBudget(ctx, update, &budget); err != nil {
+		return err
+	}
+	return carryForwardFileDiffs(ctx, update, prior)
 }
 
 // enrichWithBranchDiff computes the total additions/deletions for the entire branch
@@ -74,9 +88,13 @@ func (wt *WorkspaceTracker) enrichWithDiffData(ctx context.Context, update *type
 // On numstat failure the totals are carried forward from prior when HEAD
 // hasn't moved, mirroring the per-command carry-forward used elsewhere in
 // getGitStatus to avoid a transient git timeout clearing the sidebar count.
-func (wt *WorkspaceTracker) enrichWithBranchDiff(ctx context.Context, update *types.GitStatusUpdate, prior types.GitStatusUpdate) {
+func (wt *WorkspaceTracker) enrichWithBranchDiff(
+	ctx context.Context,
+	update *types.GitStatusUpdate,
+	prior types.GitStatusUpdate,
+) error {
 	if update.BaseCommit == "" {
-		return
+		return nil
 	}
 
 	// BaseCommit was produced by an earlier `git merge-base / rev-parse`
@@ -87,19 +105,35 @@ func (wt *WorkspaceTracker) enrichWithBranchDiff(ctx context.Context, update *ty
 	// downstream `wt.runGitOutput` call and the value flowing into the
 	// next `git` invocation is provably a hex SHA, not user input.
 	if !sha1HexPattern.MatchString(update.BaseCommit) {
-		return
+		return nil
 	}
 
 	// git diff --numstat <merge-base> covers committed + staged + unstaged changes.
 	numstatOut, err := wt.runGitOutput(ctx, "diff", "--numstat", update.BaseCommit)
 	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
 		wt.logger.Debug("enrichWithBranchDiff: numstat failed, carrying forward", zap.Error(err))
 		carryBranchDiff(update, prior)
-		return
+		return nil
 	}
 
+	additions, deletions, err := branchDiffTotals(ctx, numstatOut, update.Files)
+	if err != nil {
+		return err
+	}
+	update.BranchAdditions = additions
+	update.BranchDeletions = deletions
+	return nil
+}
+
+func branchDiffTotals(ctx context.Context, numstatOut []byte, files map[string]types.FileInfo) (int, int, error) {
 	var additions, deletions int
 	for _, line := range strings.Split(string(numstatOut), "\n") {
+		if err := ctx.Err(); err != nil {
+			return 0, 0, err
+		}
 		line = strings.TrimSpace(line)
 		if line == "" {
 			continue
@@ -115,23 +149,45 @@ func (wt *WorkspaceTracker) enrichWithBranchDiff(ctx context.Context, update *ty
 	}
 
 	// Add untracked file line counts (not included in git diff output).
-	for _, fileInfo := range update.Files {
+	for _, fileInfo := range files {
+		if err := ctx.Err(); err != nil {
+			return 0, 0, err
+		}
 		if fileInfo.Status == fileStatusUntracked {
 			additions += fileInfo.Additions
 		}
 	}
 
-	update.BranchAdditions = additions
-	update.BranchDeletions = deletions
+	return additions, deletions, nil
 }
 
 // totalDiffBytes returns the cumulative size of all diff content in the update.
-func totalDiffBytes(update *types.GitStatusUpdate) int64 {
+func totalDiffBytes(ctx context.Context, update *types.GitStatusUpdate) (int64, error) {
 	var total int64
 	for _, fi := range update.Files {
+		if err := ctx.Err(); err != nil {
+			return 0, err
+		}
 		total += int64(len(fi.Diff))
 	}
-	return total
+	return total, nil
+}
+
+type diffBudget struct {
+	used int64
+}
+
+func newDiffBudget(ctx context.Context, update *types.GitStatusUpdate) (diffBudget, error) {
+	used, err := totalDiffBytes(ctx, update)
+	return diffBudget{used: used}, err
+}
+
+func (b *diffBudget) exhausted() bool {
+	return b.used >= maxTotalDiffBytes
+}
+
+func (b *diffBudget) replace(previous, current string) {
+	b.used += int64(len(current) - len(previous))
 }
 
 // carryBranchDiff copies prior.BranchAdditions/BranchDeletions onto update when
@@ -156,11 +212,14 @@ func carryBranchDiff(update *types.GitStatusUpdate, prior types.GitStatusUpdate)
 // files changed; we just can't compute fresh diffs this poll, so we keep the
 // last known diff data visible until the next successful poll. HEAD is
 // required to be unchanged so we don't show stale diffs after a reset/commit.
-func carryForwardFileDiffs(update *types.GitStatusUpdate, prior types.GitStatusUpdate) {
+func carryForwardFileDiffs(ctx context.Context, update *types.GitStatusUpdate, prior types.GitStatusUpdate) error {
 	if prior.HeadCommit == "" || prior.HeadCommit != update.HeadCommit {
-		return
+		return nil
 	}
 	for path, fi := range update.Files {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		// A non-empty Diff means an earlier enrichment pass already populated
 		// this entry (e.g. unstaged numstat succeeded, then staged numstat
 		// failed). Leave the freshly-computed entry alone — only fill in
@@ -189,6 +248,7 @@ func carryForwardFileDiffs(update *types.GitStatusUpdate, prior types.GitStatusU
 		}
 		update.Files[path] = fi
 	}
+	return nil
 }
 
 // carryForwardFileDiff fills fi.Diff/DiffSkipReason from prior for a single
@@ -280,136 +340,183 @@ func resolveNumstatPath(numstatPath string) string {
 	return numstatPath[arrowIdx+4:]
 }
 
-// enrichWithUnstagedDiff populates additions/deletions and diff content for files
-// with unstaged changes by comparing the worktree against baseRef. On numstat
-// failure the function returns early and leaves the carry-forward to
-// enrichWithDiffData — preventing a single git timeout from blanking the diffs
-// panel for files whose porcelain status still shows them as changed, while
-// keeping the staged phase free to populate fresh data for staged-only files.
-func (wt *WorkspaceTracker) enrichWithUnstagedDiff(ctx context.Context, update *types.GitStatusUpdate, baseRef string, prior types.GitStatusUpdate) {
+type numstatEntry struct {
+	path      string
+	additions int
+	deletions int
+}
+
+func parseNumstatEntry(line string) (numstatEntry, bool) {
+	line = strings.TrimSpace(line)
+	if line == "" {
+		return numstatEntry{}, false
+	}
+	parts := strings.SplitN(line, "\t", 3)
+	if len(parts) < 3 {
+		return numstatEntry{}, false
+	}
+	additions, _ := strconv.Atoi(parts[0])
+	deletions, _ := strconv.Atoi(parts[1])
+	return numstatEntry{
+		path:      resolveNumstatPath(parts[2]),
+		additions: additions,
+		deletions: deletions,
+	}, true
+}
+
+func (wt *WorkspaceTracker) enrichWithUnstagedDiffBudget(ctx context.Context, update *types.GitStatusUpdate, baseRef string, prior types.GitStatusUpdate, budget *diffBudget) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	numstatOut, err := wt.runGitOutput(ctx, "diff", "--numstat", baseRef)
 	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
 		// Carry-forward happens once at the end of enrichWithDiffData so the
 		// staged phase can still populate fresh diffs for staged-only files.
 		wt.logger.Debug("enrichWithUnstagedDiff: numstat failed", zap.Error(err))
-		return
+		return nil
 	}
 
 	lines := strings.Split(string(numstatOut), "\n")
 	for _, line := range lines {
-		line = strings.TrimSpace(line)
-		if line == "" {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		entry, ok := parseNumstatEntry(line)
+		if !ok {
 			continue
 		}
-		// numstat uses tab-separated values: <added>\t<deleted>\t<path>
-		// Split by tab (not whitespace) to preserve spaces in file paths.
-		parts := strings.SplitN(line, "\t", 3)
-		if len(parts) < 3 {
-			continue
+		if err := wt.enrichUnstagedFileDiff(ctx, update, baseRef, prior, budget, entry); err != nil {
+			return err
 		}
-		additions, _ := strconv.Atoi(parts[0])
-		deletions, _ := strconv.Atoi(parts[1])
-		numstatPath := parts[2]
-
-		// Resolve rename notation (e.g. "old => new") to the new path,
-		// which is the key used in the Files map.
-		filePath := resolveNumstatPath(numstatPath)
-
-		// Only update file info if it exists in status (uncommitted changes).
-		// Files that appear in diff but not in status are committed changes - we don't
-		// add them to the Files map as that would make git status show already-committed files.
-		fileInfo, exists := update.Files[filePath]
-		if !exists {
-			continue
-		}
-		fileInfo.Additions = additions
-		fileInfo.Deletions = deletions
-
-		if totalDiffBytes(update) >= maxTotalDiffBytes {
-			fileInfo.DiffSkipReason = diffSkipReasonBudgetExceeded
-			update.Files[filePath] = fileInfo
-			continue
-		}
-
-		diffOut, truncated := capDiffOutput(ctx, wt.workDir, "diff", baseRef, "--", filePath)
-		if diffOut != "" {
-			fileInfo.Diff = diffOut
-			if truncated {
-				fileInfo.DiffSkipReason = diffSkipReasonTruncated
-			}
-		} else {
-			fileInfo = carryForwardFileDiff(fileInfo, filePath, update, prior)
-		}
-
-		update.Files[filePath] = fileInfo
 	}
+	return ctx.Err()
+}
+
+func (wt *WorkspaceTracker) enrichUnstagedFileDiff(ctx context.Context, update *types.GitStatusUpdate, baseRef string, prior types.GitStatusUpdate, budget *diffBudget, entry numstatEntry) error {
+	fileInfo, exists := update.Files[entry.path]
+	if !exists {
+		return nil
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	fileInfo.Additions = entry.additions
+	fileInfo.Deletions = entry.deletions
+	if budget.exhausted() {
+		fileInfo.DiffSkipReason = diffSkipReasonBudgetExceeded
+		update.Files[entry.path] = fileInfo
+		return nil
+	}
+
+	previousDiff := fileInfo.Diff
+	diffOut, truncated := capDiffOutput(ctx, wt.workDir, "diff", baseRef, "--", entry.path)
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if diffOut != "" {
+		fileInfo.Diff = diffOut
+		if truncated {
+			fileInfo.DiffSkipReason = diffSkipReasonTruncated
+		}
+	} else {
+		fileInfo = carryForwardFileDiff(fileInfo, entry.path, update, prior)
+	}
+	budget.replace(previousDiff, fileInfo.Diff)
+	update.Files[entry.path] = fileInfo
+	return nil
 }
 
 // enrichWithStagedDiff populates additions/deletions and diff content for staged files
 // that have no additional unstaged changes, using git diff --cached. On --cached
 // numstat failure the function returns early; carry-forward happens once at the
 // end of enrichWithDiffData (same rationale as enrichWithUnstagedDiff).
-func (wt *WorkspaceTracker) enrichWithStagedDiff(ctx context.Context, update *types.GitStatusUpdate, baseRef string, prior types.GitStatusUpdate) {
+func (wt *WorkspaceTracker) enrichWithStagedDiff(
+	ctx context.Context,
+	update *types.GitStatusUpdate,
+	baseRef string,
+	prior types.GitStatusUpdate,
+) error {
+	budget, err := newDiffBudget(ctx, update)
+	if err != nil {
+		return err
+	}
+	return wt.enrichWithStagedDiffBudget(ctx, update, baseRef, prior, &budget)
+}
+
+func (wt *WorkspaceTracker) enrichWithStagedDiffBudget(ctx context.Context, update *types.GitStatusUpdate, baseRef string, prior types.GitStatusUpdate, budget *diffBudget) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	// For staged files that don't have unstaged changes, we need to get the diff from the index.
 	// The first diff (git diff baseRef) shows worktree vs baseRef, but if a file is staged
 	// and has no additional unstaged changes, its diff won't appear there.
 	stagedOut, err := wt.runGitOutput(ctx, "diff", "--cached", "--numstat", baseRef)
 	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
 		// Carry-forward happens at the end of enrichWithDiffData; running it
 		// here would mask the unstaged phase's fresh data.
 		wt.logger.Debug("enrichWithStagedDiff: --cached numstat failed", zap.Error(err))
-		return
+		return nil
 	}
 
 	lines := strings.Split(string(stagedOut), "\n")
 	for _, line := range lines {
-		line = strings.TrimSpace(line)
-		if line == "" {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		entry, ok := parseNumstatEntry(line)
+		if !ok {
 			continue
 		}
-		// numstat uses tab-separated values: <added>\t<deleted>\t<path>
-		parts := strings.SplitN(line, "\t", 3)
-		if len(parts) < 3 {
-			continue
+		if err := wt.enrichStagedFileDiff(ctx, update, baseRef, prior, budget, entry); err != nil {
+			return err
 		}
-		additions, _ := strconv.Atoi(parts[0])
-		deletions, _ := strconv.Atoi(parts[1])
-		numstatPath := parts[2]
-
-		// Resolve rename notation (e.g. "old => new") to the new path,
-		// which is the key used in the Files map.
-		filePath := resolveNumstatPath(numstatPath)
-
-		fileInfo, exists := update.Files[filePath]
-		if !exists {
-			continue
-		}
-		// Only set additions/deletions if they weren't already set by the unstaged diff.
-		// This prevents double-counting when changes appear in both diffs.
-		if fileInfo.Additions == 0 && fileInfo.Deletions == 0 {
-			fileInfo.Additions = additions
-			fileInfo.Deletions = deletions
-		}
-		// Get the staged diff content if we don't have diff content yet
-		if fileInfo.Diff == "" {
-			if totalDiffBytes(update) >= maxTotalDiffBytes {
-				fileInfo.DiffSkipReason = diffSkipReasonBudgetExceeded
-				update.Files[filePath] = fileInfo
-				continue
-			}
-
-			diffOut, truncated := capDiffOutput(ctx, wt.workDir, "diff", "--cached", baseRef, "--", filePath)
-			if diffOut != "" {
-				fileInfo.Diff = diffOut
-				if truncated {
-					fileInfo.DiffSkipReason = diffSkipReasonTruncated
-				}
-			} else {
-				fileInfo = carryForwardFileDiff(fileInfo, filePath, update, prior)
-			}
-		}
-		update.Files[filePath] = fileInfo
 	}
+	return ctx.Err()
+}
+
+func (wt *WorkspaceTracker) enrichStagedFileDiff(ctx context.Context, update *types.GitStatusUpdate, baseRef string, prior types.GitStatusUpdate, budget *diffBudget, entry numstatEntry) error {
+	fileInfo, exists := update.Files[entry.path]
+	if !exists {
+		return nil
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if fileInfo.Additions == 0 && fileInfo.Deletions == 0 {
+		fileInfo.Additions = entry.additions
+		fileInfo.Deletions = entry.deletions
+	}
+	if fileInfo.Diff != "" {
+		update.Files[entry.path] = fileInfo
+		return nil
+	}
+	if budget.exhausted() {
+		fileInfo.DiffSkipReason = diffSkipReasonBudgetExceeded
+		update.Files[entry.path] = fileInfo
+		return nil
+	}
+
+	diffOut, truncated := capDiffOutput(ctx, wt.workDir, "diff", "--cached", baseRef, "--", entry.path)
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if diffOut != "" {
+		fileInfo.Diff = diffOut
+		if truncated {
+			fileInfo.DiffSkipReason = diffSkipReasonTruncated
+		}
+	} else {
+		fileInfo = carryForwardFileDiff(fileInfo, entry.path, update, prior)
+	}
+	budget.replace("", fileInfo.Diff)
+	update.Files[entry.path] = fileInfo
+	return nil
 }
 
 // isBinaryContent checks for null bytes in the data, same heuristic git uses.
@@ -419,85 +526,151 @@ func isBinaryContent(data []byte) bool {
 
 // enrichUntrackedFileDiffs builds a synthetic git diff for untracked files showing all
 // lines as additions, so the diff viewer can display their full content.
-func (wt *WorkspaceTracker) enrichUntrackedFileDiffs(ctx context.Context, update *types.GitStatusUpdate) {
+func (wt *WorkspaceTracker) enrichUntrackedFileDiffs(ctx context.Context, update *types.GitStatusUpdate) error {
+	budget, err := newDiffBudget(ctx, update)
+	if err != nil {
+		return err
+	}
+	return wt.enrichUntrackedFileDiffsBudget(ctx, update, &budget)
+}
+
+func (wt *WorkspaceTracker) enrichUntrackedFileDiffsBudget(
+	ctx context.Context,
+	update *types.GitStatusUpdate,
+	budget *diffBudget,
+) error {
+	return enrichUntrackedFileDiffs(ctx, update, budget, wt.enrichUntrackedFile)
+}
+
+type untrackedFileEnricher func(context.Context, string, types.FileInfo) (types.FileInfo, error)
+
+func enrichUntrackedFileDiffs(
+	ctx context.Context,
+	update *types.GitStatusUpdate,
+	budget *diffBudget,
+	enrichFile untrackedFileEnricher,
+) error {
 	for filePath, fileInfo := range update.Files {
 		if fileInfo.Status != fileStatusUntracked {
 			continue
 		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 
-		if totalDiffBytes(update) >= maxTotalDiffBytes {
+		if budget.exhausted() {
 			fileInfo.DiffSkipReason = diffSkipReasonBudgetExceeded
 			update.Files[filePath] = fileInfo
 			continue
 		}
 
-		safePath, err := wt.sanitizePath(filePath)
+		previousDiff := fileInfo.Diff
+		var err error
+		fileInfo, err = enrichFile(ctx, filePath, fileInfo)
 		if err != nil {
-			continue
+			return err
 		}
-
-		info, err := os.Stat(filepath.Clean(safePath))
-		if err != nil {
-			continue
-		}
-		if info.Size() > maxDiffFileSize {
-			fileInfo.DiffSkipReason = diffSkipReasonTooLarge
-			update.Files[filePath] = fileInfo
-			continue
-		}
-
-		f, err := os.Open(filepath.Clean(safePath))
-		if err != nil {
-			continue
-		}
-
-		// Read first chunk to check for binary content.
-		header := make([]byte, binaryCheckSize)
-		n, _ := f.Read(header)
-		if n > 0 && isBinaryContent(header[:n]) {
-			_ = f.Close()
-			fileInfo.DiffSkipReason = diffSkipReasonBinary
-			update.Files[filePath] = fileInfo
-			continue
-		}
-
-		// Read only enough content to fill maxDiffOutputSize of diff output.
-		// No need to read the full file — any diff beyond maxDiffOutputSize gets truncated anyway.
-		var buf bytes.Buffer
-		buf.Write(header[:n])
-		remaining := int64(maxDiffOutputSize) - int64(n)
-		if remaining > 0 {
-			_, _ = io.Copy(&buf, io.LimitReader(f, remaining))
-		}
-		_ = f.Close()
-
-		content := buf.String()
-		lines := strings.Split(content, "\n")
-		// Trim trailing empty element from final newline so line count is accurate.
-		if len(lines) > 0 && lines[len(lines)-1] == "" {
-			lines = lines[:len(lines)-1]
-		}
-		fileInfo.Additions = len(lines)
-		fileInfo.Deletions = 0
-
-		var diffBuilder strings.Builder
-		diffBuilder.WriteString("diff --git a/" + filePath + " b/" + filePath + "\n")
-		diffBuilder.WriteString("new file mode 100644\n")
-		diffBuilder.WriteString("index 0000000..0000000\n")
-		diffBuilder.WriteString("--- /dev/null\n")
-		diffBuilder.WriteString("+++ b/" + filePath + "\n")
-		diffBuilder.WriteString("@@ -0,0 +1," + strconv.Itoa(len(lines)) + " @@\n")
-		for _, line := range lines {
-			diffBuilder.WriteString("+" + line + "\n")
-		}
-
-		diffContent := diffBuilder.String()
-		if len(diffContent) > maxDiffOutputSize {
-			diffContent = diffContent[:maxDiffOutputSize]
-			fileInfo.DiffSkipReason = diffSkipReasonTruncated
-		}
-
-		fileInfo.Diff = diffContent
+		budget.replace(previousDiff, fileInfo.Diff)
 		update.Files[filePath] = fileInfo
 	}
+	return ctx.Err()
+}
+
+func (wt *WorkspaceTracker) enrichUntrackedFile(ctx context.Context, filePath string, fileInfo types.FileInfo) (types.FileInfo, error) {
+	safePath, err := wt.sanitizePath(filePath)
+	if err != nil {
+		return fileInfo, nil
+	}
+	content, skipReason, err := readUntrackedFile(ctx, safePath)
+	if err != nil {
+		return fileInfo, err
+	}
+	if skipReason != "" {
+		fileInfo.DiffSkipReason = skipReason
+		return fileInfo, nil
+	}
+
+	diff, additions, truncated, err := buildUntrackedDiff(ctx, filePath, content)
+	if err != nil {
+		return fileInfo, err
+	}
+	fileInfo.Diff = diff
+	fileInfo.Additions = additions
+	fileInfo.Deletions = 0
+	if truncated {
+		fileInfo.DiffSkipReason = diffSkipReasonTruncated
+	}
+	return fileInfo, nil
+}
+
+func readUntrackedFile(ctx context.Context, safePath string) ([]byte, string, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, "", err
+	}
+	info, err := os.Stat(filepath.Clean(safePath))
+	if err != nil {
+		return nil, "", nil
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, "", err
+	}
+	if info.Size() > maxDiffFileSize {
+		return nil, diffSkipReasonTooLarge, nil
+	}
+
+	f, err := os.Open(filepath.Clean(safePath))
+	if err != nil {
+		return nil, "", nil
+	}
+	defer func() { _ = f.Close() }()
+
+	header := make([]byte, binaryCheckSize)
+	n, _ := f.Read(header)
+	if err := ctx.Err(); err != nil {
+		return nil, "", err
+	}
+	if n > 0 && isBinaryContent(header[:n]) {
+		return nil, diffSkipReasonBinary, nil
+	}
+
+	var buf bytes.Buffer
+	buf.Write(header[:n])
+	remaining := int64(maxDiffOutputSize) - int64(n)
+	if remaining > 0 {
+		if err := ctx.Err(); err != nil {
+			return nil, "", err
+		}
+		_, _ = io.Copy(&buf, io.LimitReader(f, remaining))
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, "", err
+	}
+	return buf.Bytes(), "", nil
+}
+
+func buildUntrackedDiff(ctx context.Context, filePath string, content []byte) (string, int, bool, error) {
+	lines := strings.Split(string(content), "\n")
+	if len(lines) > 0 && lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+
+	var diffBuilder strings.Builder
+	diffBuilder.WriteString("diff --git a/" + filePath + " b/" + filePath + "\n")
+	diffBuilder.WriteString("new file mode 100644\n")
+	diffBuilder.WriteString("index 0000000..0000000\n")
+	diffBuilder.WriteString("--- /dev/null\n")
+	diffBuilder.WriteString("+++ b/" + filePath + "\n")
+	diffBuilder.WriteString("@@ -0,0 +1," + strconv.Itoa(len(lines)) + " @@\n")
+	for _, line := range lines {
+		if err := ctx.Err(); err != nil {
+			return "", 0, false, err
+		}
+		diffBuilder.WriteString("+" + line + "\n")
+	}
+
+	diffContent := diffBuilder.String()
+	if len(diffContent) > maxDiffOutputSize {
+		return diffContent[:maxDiffOutputSize], len(lines), true, nil
+	}
+	return diffContent, len(lines), false, nil
 }

--- a/apps/backend/internal/agentctl/server/process/workspace_git_diff_test.go
+++ b/apps/backend/internal/agentctl/server/process/workspace_git_diff_test.go
@@ -2,12 +2,15 @@ package process
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/kandev/kandev/internal/agentctl/types/streams"
+	"github.com/kandev/kandev/internal/common/logger"
+	"go.uber.org/zap"
 )
 
 func TestIsBinaryContent(t *testing.T) {
@@ -40,9 +43,36 @@ func TestTotalDiffBytes(t *testing.T) {
 			"c.go": {Diff: ""},
 		},
 	}
-	got := totalDiffBytes(update)
+	got, err := totalDiffBytes(context.Background(), update)
+	if err != nil {
+		t.Fatalf("totalDiffBytes() error = %v", err)
+	}
 	if got != 8 {
 		t.Errorf("totalDiffBytes = %d, want 8", got)
+	}
+}
+
+func TestDiffBudget_TracksReplacedContentAtBoundary(t *testing.T) {
+	update := &streams.GitStatusUpdate{
+		Files: map[string]streams.FileInfo{
+			"existing.go": {Diff: strings.Repeat("x", maxTotalDiffBytes-1)},
+		},
+	}
+	budget, err := newDiffBudget(context.Background(), update)
+	if err != nil {
+		t.Fatalf("newDiffBudget() error = %v", err)
+	}
+
+	if budget.exhausted() {
+		t.Fatal("budget exhausted before reaching the total limit")
+	}
+	budget.replace("", "x")
+	if !budget.exhausted() {
+		t.Fatal("budget not exhausted at the total limit")
+	}
+	budget.replace("x", "")
+	if budget.exhausted() {
+		t.Fatal("budget remained exhausted after replacing content with an empty diff")
 	}
 }
 
@@ -218,6 +248,210 @@ func TestEnrichUntrackedFileDiffs_SmallTextFile(t *testing.T) {
 	}
 }
 
+func TestEnrichUntrackedFileDiffs_CanceledContextStopsBeforeEnrichment(t *testing.T) {
+	isolateTestGitEnv(t)
+	repoDir, cleanup := setupTestRepo(t)
+	defer cleanup()
+
+	writeFile(t, repoDir, "first.txt", "must not be read\n")
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	wt := NewWorkspaceTracker(repoDir, newTestLogger(t))
+	update := &streams.GitStatusUpdate{
+		Files: map[string]streams.FileInfo{
+			"first.txt": {Path: "first.txt", Status: fileStatusUntracked},
+		},
+	}
+
+	err := wt.enrichUntrackedFileDiffs(ctx, update)
+
+	got := update.Files["first.txt"]
+	if err != context.Canceled {
+		t.Fatalf("enrichUntrackedFileDiffs error = %v, want %v", err, context.Canceled)
+	}
+	if got.Diff != "" || got.Additions != 0 || got.DiffSkipReason != "" {
+		t.Fatalf("canceled enrichment mutated file info: %+v", got)
+	}
+}
+
+func TestEnrichWithDiffData_CanceledContextReturnsErrorForTrackedFiles(t *testing.T) {
+	isolateTestGitEnv(t)
+	repoDir, cleanup := setupTestRepo(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	wt := NewWorkspaceTracker(repoDir, newTestLogger(t))
+	update := &streams.GitStatusUpdate{
+		Files: map[string]streams.FileInfo{
+			"tracked.txt": {Path: "tracked.txt", Status: "modified"},
+		},
+	}
+
+	err := wt.enrichWithDiffData(ctx, update, streams.GitStatusUpdate{})
+	if err != context.Canceled {
+		t.Fatalf("enrichWithDiffData error = %v, want %v", err, context.Canceled)
+	}
+}
+
+type cancelAfterErrChecksContext struct {
+	context.Context
+	remaining int
+	cancel    context.CancelFunc
+}
+
+func (c *cancelAfterErrChecksContext) Err() error {
+	c.remaining--
+	if c.remaining <= 0 {
+		c.cancel()
+	}
+	return c.Context.Err()
+}
+
+func TestBuildUntrackedDiff_CancellationDuringLineConstruction(t *testing.T) {
+	baseCtx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	ctx := &cancelAfterErrChecksContext{Context: baseCtx, remaining: 2, cancel: cancel}
+
+	diff, additions, truncated, err := buildUntrackedDiff(ctx, "lines.txt", []byte("first\nsecond\nthird\n"))
+
+	if err != context.Canceled {
+		t.Fatalf("buildUntrackedDiff error = %v, want %v", err, context.Canceled)
+	}
+	if diff != "" || additions != 0 || truncated {
+		t.Fatalf("canceled diff = %q, additions = %d, truncated = %v", diff, additions, truncated)
+	}
+}
+
+func TestBranchDiffTotals_CancellationStopsNumstatLoop(t *testing.T) {
+	baseCtx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	ctx := &cancelAfterErrChecksContext{Context: baseCtx, remaining: 2, cancel: cancel}
+
+	additions, deletions, err := branchDiffTotals(
+		ctx,
+		[]byte("1\t2\tfirst.txt\n3\t4\tsecond.txt\n5\t6\tthird.txt\n"),
+		nil,
+	)
+
+	if err != context.Canceled {
+		t.Fatalf("branchDiffTotals() error = %v, want %v", err, context.Canceled)
+	}
+	if additions != 0 || deletions != 0 {
+		t.Fatalf("canceled totals = (%d, %d), want no publishable partial result", additions, deletions)
+	}
+}
+
+func TestDiffBudgetAndCarryForwardHonorCancellation(t *testing.T) {
+	files := map[string]streams.FileInfo{
+		"first.go":  {Path: "first.go", Diff: "first"},
+		"second.go": {Path: "second.go", Diff: "second"},
+		"third.go":  {Path: "third.go", Diff: "third"},
+	}
+
+	baseCtx, cancel := context.WithCancel(context.Background())
+	ctx := &cancelAfterErrChecksContext{Context: baseCtx, remaining: 2, cancel: cancel}
+	if _, err := newDiffBudget(ctx, &streams.GitStatusUpdate{Files: files}); err != context.Canceled {
+		t.Fatalf("newDiffBudget() error = %v, want %v", err, context.Canceled)
+	}
+
+	baseCtx, cancel = context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	ctx = &cancelAfterErrChecksContext{Context: baseCtx, remaining: 2, cancel: cancel}
+	update := &streams.GitStatusUpdate{
+		HeadCommit: "head",
+		Files: map[string]streams.FileInfo{
+			"first.go": {}, "second.go": {}, "third.go": {},
+		},
+	}
+	prior := streams.GitStatusUpdate{HeadCommit: "head", Files: files}
+	if err := carryForwardFileDiffs(ctx, update, prior); err != context.Canceled {
+		t.Fatalf("carryForwardFileDiffs() error = %v, want %v", err, context.Canceled)
+	}
+}
+
+func TestEnrichUntrackedFileDiffs_CancellationAfterFirstFileLeavesRemainingFilesUntouched(t *testing.T) {
+	isolateTestGitEnv(t)
+	repoDir, cleanup := setupTestRepo(t)
+	defer cleanup()
+
+	files := make(map[string]streams.FileInfo, 3)
+	for _, path := range []string{"first.txt", "second.txt", "third.txt"} {
+		writeFile(t, repoDir, path, path+" content\n")
+		files[path] = streams.FileInfo{Path: path, Status: fileStatusUntracked}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	wt := NewWorkspaceTracker(repoDir, newTestLogger(t))
+	update := &streams.GitStatusUpdate{Files: files}
+	budget, err := newDiffBudget(ctx, update)
+	if err != nil {
+		t.Fatalf("newDiffBudget() error = %v", err)
+	}
+	readCount := 0
+	enrichFile := func(ctx context.Context, path string, fileInfo streams.FileInfo) (streams.FileInfo, error) {
+		enriched, err := wt.enrichUntrackedFile(ctx, path, fileInfo)
+		if err == nil {
+			readCount++
+			cancel()
+		}
+		return enriched, err
+	}
+
+	err = enrichUntrackedFileDiffs(ctx, update, &budget, enrichFile)
+
+	if err != context.Canceled {
+		t.Fatalf("enrichUntrackedFileDiffs error = %v, want %v", err, context.Canceled)
+	}
+	if readCount != 1 {
+		t.Fatalf("filesystem enrichments = %d, want 1", readCount)
+	}
+	enrichedCount := 0
+	untouchedCount := 0
+	for _, fileInfo := range update.Files {
+		if fileInfo.Diff != "" && fileInfo.Additions == 1 {
+			enrichedCount++
+			continue
+		}
+		if fileInfo.Diff == "" && fileInfo.Additions == 0 && fileInfo.DiffSkipReason == "" {
+			untouchedCount++
+		}
+	}
+	if enrichedCount != 1 || untouchedCount != 2 {
+		t.Fatalf("enriched files = %d, untouched files = %d; want 1 and 2", enrichedCount, untouchedCount)
+	}
+}
+
+func BenchmarkEnrichUntrackedFileDiffs(b *testing.B) {
+	log, err := logger.NewFromZap(zap.NewNop())
+	if err != nil {
+		b.Fatalf("create logger: %v", err)
+	}
+
+	for _, fileCount := range []int{1_000, 10_000} {
+		b.Run(fmt.Sprintf("files-%d", fileCount), func(b *testing.B) {
+			files := make(map[string]streams.FileInfo, fileCount+1)
+			files["existing.go"] = streams.FileInfo{Diff: strings.Repeat("x", maxTotalDiffBytes)}
+			for i := 0; i < fileCount; i++ {
+				path := fmt.Sprintf("cache/%05d", i)
+				files[path] = streams.FileInfo{Path: path, Status: fileStatusUntracked}
+			}
+
+			wt := NewWorkspaceTracker(b.TempDir(), log)
+			update := &streams.GitStatusUpdate{Files: files}
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				if err := wt.enrichUntrackedFileDiffs(context.Background(), update); err != nil {
+					b.Fatalf("enrich untracked files: %v", err)
+				}
+			}
+		})
+	}
+}
+
 func TestResolveNumstatPath(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -356,7 +590,9 @@ func TestCarryForwardFileDiffs(t *testing.T) {
 				"foo.go": {Path: "foo.go"},
 			},
 		}
-		carryForwardFileDiffs(update, prior)
+		if err := carryForwardFileDiffs(context.Background(), update, prior); err != nil {
+			t.Fatalf("carryForwardFileDiffs() error = %v", err)
+		}
 		got := update.Files["foo.go"]
 		if got.Diff != priorDiff {
 			t.Errorf("Diff = %q, want %q", got.Diff, priorDiff)
@@ -379,7 +615,9 @@ func TestCarryForwardFileDiffs(t *testing.T) {
 				"foo.go": {Path: "foo.go"},
 			},
 		}
-		carryForwardFileDiffs(update, prior)
+		if err := carryForwardFileDiffs(context.Background(), update, prior); err != nil {
+			t.Fatalf("carryForwardFileDiffs() error = %v", err)
+		}
 		got := update.Files["foo.go"]
 		if got.Diff != "" || got.Additions != 0 || got.Deletions != 0 {
 			t.Errorf("expected zeroed FileInfo on head mismatch, got %+v", got)
@@ -392,7 +630,9 @@ func TestCarryForwardFileDiffs(t *testing.T) {
 			HeadCommit: head,
 			Files:      map[string]streams.FileInfo{"new.go": {Path: "new.go"}},
 		}
-		carryForwardFileDiffs(update, prior)
+		if err := carryForwardFileDiffs(context.Background(), update, prior); err != nil {
+			t.Fatalf("carryForwardFileDiffs() error = %v", err)
+		}
 		got := update.Files["new.go"]
 		if got.Diff != "" {
 			t.Errorf("expected no carry-forward for new file, got Diff=%q", got.Diff)
@@ -413,7 +653,9 @@ func TestCarryForwardFileDiffs(t *testing.T) {
 				"foo.go": {Path: "foo.go", Diff: newDiff, Additions: 1, Deletions: 0},
 			},
 		}
-		carryForwardFileDiffs(update, prior)
+		if err := carryForwardFileDiffs(context.Background(), update, prior); err != nil {
+			t.Fatalf("carryForwardFileDiffs() error = %v", err)
+		}
 		got := update.Files["foo.go"]
 		if got.Diff != newDiff {
 			t.Errorf("Diff overwritten; got %q, want %q", got.Diff, newDiff)
@@ -443,7 +685,9 @@ func TestCarryForwardFileDiffs(t *testing.T) {
 						"foo.go": {Path: "foo.go", DiffSkipReason: reason},
 					},
 				}
-				carryForwardFileDiffs(update, prior)
+				if err := carryForwardFileDiffs(context.Background(), update, prior); err != nil {
+					t.Fatalf("carryForwardFileDiffs() error = %v", err)
+				}
 				got := update.Files["foo.go"]
 				if got.Diff != "" {
 					t.Errorf("Diff carried forward despite skip reason %q; got %q", reason, got.Diff)

--- a/apps/backend/internal/agentctl/server/process/workspace_git_status.go
+++ b/apps/backend/internal/agentctl/server/process/workspace_git_status.go
@@ -2,6 +2,7 @@ package process
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"strconv"
 	"strings"
@@ -27,6 +28,9 @@ func (wt *WorkspaceTracker) updateGitStatus(ctx context.Context) {
 	status, err := wt.getGitStatus(ctx)
 	if err != nil {
 		wt.logger.Warn("updateGitStatus: getGitStatus failed", zap.Error(err))
+		return
+	}
+	if ctx.Err() != nil || wt.cancelCtx.Err() != nil {
 		return
 	}
 
@@ -58,16 +62,17 @@ func (wt *WorkspaceTracker) RefreshGitStatus(ctx context.Context) {
 	wt.updateGitStatus(ctx)
 }
 
-// GetCurrentGitStatus returns the current cached git status.
-// If no status has been cached yet, it fetches fresh status.
+// GetCurrentGitStatus returns the current cached git status. If no status has
+// been cached yet, it starts or joins a live observation without caching it.
 func (wt *WorkspaceTracker) GetCurrentGitStatus(ctx context.Context) (types.GitStatusUpdate, error) {
 	return wt.GetGitStatus(ctx, false)
 }
 
 // GetGitStatus returns git status. When fresh is false, the cached value is
-// returned (with a fresh fallback if no cache exists). When fresh is true, a
-// new git query is always executed, bypassing the cache. Callers that need
-// up-to-date data after the agent just committed changes should pass fresh=true.
+// returned (with a live fallback if no cache exists). When fresh is true, the
+// caller starts or joins a live observation while bypassing the cache. Callers
+// that need up-to-date data after the agent just committed changes should pass
+// fresh=true.
 func (wt *WorkspaceTracker) GetGitStatus(ctx context.Context, fresh bool) (types.GitStatusUpdate, error) {
 	if fresh {
 		return wt.getGitStatus(ctx)
@@ -84,13 +89,93 @@ func (wt *WorkspaceTracker) GetGitStatus(ctx context.Context, fresh bool) (types
 	return status, nil
 }
 
-// getGitStatus retrieves the current git status. Secondary commands
+// getGitStatus coalesces live status observations for this tracker. The
+// computation is owned by the tracker rather than the first caller, while each
+// waiter can still return promptly when its own context is canceled.
+func (wt *WorkspaceTracker) getGitStatus(ctx context.Context) (types.GitStatusUpdate, error) {
+	if err := ctx.Err(); err != nil {
+		return types.GitStatusUpdate{}, err
+	}
+
+	resultCh := wt.gitStatusGroup.DoChan("live", func() (interface{}, error) {
+		sharedCtx, finish, err := wt.beginGitStatusObservation()
+		if err != nil {
+			return types.GitStatusUpdate{}, err
+		}
+		defer finish()
+
+		observer := wt.gitStatusObserver
+		if observer == nil {
+			observer = wt.computeGitStatus
+		}
+		status, err := observer(sharedCtx)
+		if err != nil {
+			return types.GitStatusUpdate{}, err
+		}
+		if err := sharedCtx.Err(); err != nil {
+			return types.GitStatusUpdate{}, err
+		}
+		return status, nil
+	})
+	if wt.gitStatusWaiterJoined != nil {
+		wt.gitStatusWaiterJoined()
+	}
+
+	select {
+	case <-ctx.Done():
+		return types.GitStatusUpdate{}, ctx.Err()
+	case result := <-resultCh:
+		if err := ctx.Err(); err != nil {
+			return types.GitStatusUpdate{}, err
+		}
+		if result.Err != nil {
+			return types.GitStatusUpdate{}, result.Err
+		}
+		status, ok := result.Val.(types.GitStatusUpdate)
+		if !ok {
+			return types.GitStatusUpdate{}, fmt.Errorf("unexpected git status observation result %T", result.Val)
+		}
+		return status, nil
+	}
+}
+
+// beginGitStatusObservation admits one singleflight body into the tracker
+// lifecycle. Stop holds the same mutex while canceling tracker context, which
+// prevents WaitGroup Add from racing with shutdown's Wait.
+func (wt *WorkspaceTracker) beginGitStatusObservation() (context.Context, func(), error) {
+	wt.gitStatusObserveMu.Lock()
+	defer wt.gitStatusObserveMu.Unlock()
+
+	baseCtx := wt.cancelCtx
+	if baseCtx != nil {
+		if err := baseCtx.Err(); err != nil {
+			return nil, nil, err
+		}
+	} else {
+		// Preserve the pre-singleflight zero-value behavior for direct status
+		// reads. Constructed trackers always use their cancellable lifetime.
+		baseCtx = context.Background()
+	}
+
+	timeout := wt.gitStatusObserveTimeout
+	if timeout == 0 && wt.cancelCtx == nil {
+		timeout = workspaceGitStatusObserveTimeout
+	}
+	sharedCtx, cancel := context.WithTimeout(baseCtx, timeout)
+	wt.gitStatusObserveWG.Add(1)
+	return sharedCtx, func() {
+		cancel()
+		wt.gitStatusObserveWG.Done()
+	}, nil
+}
+
+// computeGitStatus retrieves the current git status. Secondary commands
 // (ahead/behind counts, diff enrichment) that fail or time out carry their
 // values forward from the prior cached status rather than overwriting them
 // with zero. The two primary commands (branch info and `git status
 // --porcelain`) still propagate errors upward; on those, updateGitStatus
 // skips the cache write entirely so the prior state stays visible to the UI.
-func (wt *WorkspaceTracker) getGitStatus(ctx context.Context) (types.GitStatusUpdate, error) {
+func (wt *WorkspaceTracker) computeGitStatus(ctx context.Context) (types.GitStatusUpdate, error) {
 	update := types.GitStatusUpdate{
 		Timestamp:      time.Now(),
 		RepositoryName: wt.repositoryName,
@@ -122,18 +207,37 @@ func (wt *WorkspaceTracker) getGitStatus(ctx context.Context) (types.GitStatusUp
 	if err := wt.getGitBranchInfo(ctx, &update); err != nil {
 		return update, err
 	}
+	if err := ctx.Err(); err != nil {
+		return update, err
+	}
 
 	wt.getAheadBehindCounts(ctx, &update, prior)
+	if err := ctx.Err(); err != nil {
+		return update, err
+	}
 
 	if err := wt.parseGitStatusOutput(ctx, &update); err != nil {
 		return update, err
 	}
+	if err := ctx.Err(); err != nil {
+		return update, err
+	}
 
 	// Enrich file info with diff data (additions, deletions, and actual diff content)
-	wt.enrichWithDiffData(ctx, &update, prior)
+	if err := wt.enrichWithDiffData(ctx, &update, prior); err != nil {
+		return update, err
+	}
+	if err := ctx.Err(); err != nil {
+		return update, err
+	}
 
 	// Compute full branch totals vs merge-base (committed + staged + unstaged + untracked)
-	wt.enrichWithBranchDiff(ctx, &update, prior)
+	if err := wt.enrichWithBranchDiff(ctx, &update, prior); err != nil {
+		return types.GitStatusUpdate{}, err
+	}
+	if err := ctx.Err(); err != nil {
+		return update, err
+	}
 
 	return update, nil
 }
@@ -386,11 +490,22 @@ func (wt *WorkspaceTracker) parseGitStatusOutput(ctx context.Context, update *ty
 		return err
 	}
 
+	return wt.applyPorcelainOutput(ctx, statusOut, update)
+}
+
+func (wt *WorkspaceTracker) applyPorcelainOutput(
+	ctx context.Context,
+	statusOut []byte,
+	update *types.GitStatusUpdate,
+) error {
 	// Git status --porcelain format: XY filename
 	// X = index (staged) status, Y = working tree (unstaged) status
 	// ' ' = unmodified, M = modified, A = added, D = deleted, R = renamed, ? = untracked
 	lines := strings.Split(string(statusOut), "\n")
 	for _, line := range lines {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		if len(line) < 3 {
 			continue
 		}

--- a/apps/backend/internal/agentctl/server/process/workspace_git_status_concurrency_test.go
+++ b/apps/backend/internal/agentctl/server/process/workspace_git_status_concurrency_test.go
@@ -1,0 +1,367 @@
+package process
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/agentctl/types"
+)
+
+func TestWorkspaceTrackerConcurrentFreshStatusSharesObservation(t *testing.T) {
+	wt := newStatusConcurrencyTracker(t)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	want := types.GitStatusUpdate{Timestamp: time.Unix(123, 0), Branch: "feature"}
+	const callers = 6
+	var observations atomic.Int32
+	wt.gitStatusObserver = func(context.Context) (types.GitStatusUpdate, error) {
+		if observations.Add(1) == 1 {
+			close(started)
+		}
+		<-release
+		return want, nil
+	}
+	joined := make(chan struct{}, callers)
+	wt.gitStatusWaiterJoined = func() { joined <- struct{}{} }
+
+	ready := make(chan struct{}, callers)
+	results := make(chan types.GitStatusUpdate, callers)
+	errs := make(chan error, callers)
+	launch := make(chan struct{})
+	for range callers {
+		go func() {
+			ready <- struct{}{}
+			<-launch
+			status, err := wt.GetGitStatus(context.Background(), true)
+			results <- status
+			errs <- err
+		}()
+	}
+	for range callers {
+		<-ready
+	}
+	close(launch)
+	waitForSignal(t, started, "first status observation")
+	waitForSignals(t, joined, callers, "fresh status waiters")
+	close(release)
+
+	for range callers {
+		if err := <-errs; err != nil {
+			t.Fatalf("GetGitStatus returned error: %v", err)
+		}
+		if got := <-results; got.Timestamp != want.Timestamp || got.Branch != want.Branch {
+			t.Fatalf("GetGitStatus = %+v, want shared result %+v", got, want)
+		}
+	}
+	if got := observations.Load(); got != 1 {
+		t.Fatalf("live observations = %d, want 1", got)
+	}
+}
+
+func TestWorkspaceTrackerStatusWaiterCancellationDoesNotCancelPeers(t *testing.T) {
+	wt := newStatusConcurrencyTracker(t)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	observerCanceled := make(chan struct{})
+	want := types.GitStatusUpdate{Timestamp: time.Unix(456, 0), Branch: "peer-result"}
+	wt.gitStatusObserver = func(ctx context.Context) (types.GitStatusUpdate, error) {
+		close(started)
+		select {
+		case <-release:
+			return want, nil
+		case <-ctx.Done():
+			close(observerCanceled)
+			return types.GitStatusUpdate{}, ctx.Err()
+		}
+	}
+	joined := make(chan struct{}, 2)
+	wt.gitStatusWaiterJoined = func() { joined <- struct{}{} }
+
+	peerResult := make(chan types.GitStatusUpdate, 1)
+	peerErr := make(chan error, 1)
+	go func() {
+		status, err := wt.GetGitStatus(context.Background(), true)
+		peerResult <- status
+		peerErr <- err
+	}()
+	waitForSignal(t, started, "shared status observation")
+	waitForSignal(t, joined, "peer waiter admission")
+
+	waiterCtx, cancelWaiter := context.WithCancel(context.Background())
+	waiterErr := make(chan error, 1)
+	go func() {
+		_, err := wt.GetGitStatus(waiterCtx, true)
+		waiterErr <- err
+	}()
+	waitForSignal(t, joined, "canceling waiter admission")
+	cancelWaiter()
+	err := <-waiterErr
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("canceled waiter error = %v, want context.Canceled", err)
+	}
+	select {
+	case <-observerCanceled:
+		t.Fatal("canceling one waiter canceled the shared observation")
+	default:
+	}
+
+	close(release)
+	if err := <-peerErr; err != nil {
+		t.Fatalf("peer waiter returned error: %v", err)
+	}
+	if got := <-peerResult; got.Timestamp != want.Timestamp {
+		t.Fatalf("peer timestamp = %v, want %v", got.Timestamp, want.Timestamp)
+	}
+}
+
+func TestWorkspaceTrackerCanceledCallerStartsNoObservation(t *testing.T) {
+	wt := newStatusConcurrencyTracker(t)
+	var observations atomic.Int32
+	wt.gitStatusObserver = func(context.Context) (types.GitStatusUpdate, error) {
+		observations.Add(1)
+		return types.GitStatusUpdate{}, nil
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := wt.GetGitStatus(ctx, true)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("GetGitStatus error = %v, want context.Canceled", err)
+	}
+	var probeCalls atomic.Int32
+	_, _, _ = wt.gitStatusGroup.Do("live", func() (interface{}, error) {
+		probeCalls.Add(1)
+		return types.GitStatusUpdate{}, nil
+	})
+	if got := observations.Load(); got != 0 {
+		t.Fatalf("live observations = %d, want 0", got)
+	}
+	if got := probeCalls.Load(); got != 1 {
+		t.Fatalf("probe observations = %d, want 1 independent flight", got)
+	}
+}
+
+func TestWorkspaceTrackerRefreshAndEmptyCacheReadShareObservation(t *testing.T) {
+	wt := newStatusConcurrencyTracker(t)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	want := types.GitStatusUpdate{Timestamp: time.Unix(654, 0), Branch: "shared-refresh"}
+	var observations atomic.Int32
+	wt.gitStatusObserver = func(context.Context) (types.GitStatusUpdate, error) {
+		if observations.Add(1) == 1 {
+			close(started)
+		}
+		<-release
+		return want, nil
+	}
+	joined := make(chan struct{}, 2)
+	wt.gitStatusWaiterJoined = func() { joined <- struct{}{} }
+
+	refreshDone := make(chan struct{})
+	go func() {
+		wt.RefreshGitStatus(context.Background())
+		close(refreshDone)
+	}()
+	waitForSignal(t, started, "refresh observation")
+
+	readResult := make(chan types.GitStatusUpdate, 1)
+	readErr := make(chan error, 1)
+	go func() {
+		status, err := wt.GetGitStatus(context.Background(), false)
+		readResult <- status
+		readErr <- err
+	}()
+	waitForSignals(t, joined, 2, "refresh and empty-cache waiters")
+	close(release)
+	waitForSignal(t, refreshDone, "refresh completion")
+
+	if err := <-readErr; err != nil {
+		t.Fatalf("empty-cache read returned error: %v", err)
+	}
+	if got := <-readResult; got.Timestamp != want.Timestamp {
+		t.Fatalf("empty-cache timestamp = %v, want %v", got.Timestamp, want.Timestamp)
+	}
+	if got := observations.Load(); got != 1 {
+		t.Fatalf("live observations = %d, want 1", got)
+	}
+	wt.mu.RLock()
+	cached := wt.currentStatus
+	wt.mu.RUnlock()
+	if cached.Timestamp != want.Timestamp {
+		t.Fatalf("refresh cached timestamp = %v, want %v", cached.Timestamp, want.Timestamp)
+	}
+}
+
+func TestWorkspaceTrackerDistinctRepositoriesObserveInParallel(t *testing.T) {
+	first := newStatusConcurrencyTracker(t)
+	second := newStatusConcurrencyTracker(t)
+	firstStarted := make(chan struct{})
+	secondStarted := make(chan struct{})
+	release := make(chan struct{})
+	first.gitStatusObserver = blockingStatusObserver(firstStarted, release, "first")
+	second.gitStatusObserver = blockingStatusObserver(secondStarted, release, "second")
+
+	var wg sync.WaitGroup
+	for _, tracker := range []*WorkspaceTracker{first, second} {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := tracker.GetGitStatus(context.Background(), true); err != nil {
+				t.Errorf("GetGitStatus returned error: %v", err)
+			}
+		}()
+	}
+	waitForSignal(t, firstStarted, "first repository observation")
+	waitForSignal(t, secondStarted, "second repository observation")
+	close(release)
+	wg.Wait()
+}
+
+func TestWorkspaceTrackerStopCancelsSharedObservationWithoutCaching(t *testing.T) {
+	wt := newStatusConcurrencyTracker(t)
+	started := make(chan struct{})
+	wt.gitStatusObserver = func(ctx context.Context) (types.GitStatusUpdate, error) {
+		close(started)
+		<-ctx.Done()
+		return types.GitStatusUpdate{Timestamp: time.Unix(789, 0), Branch: "partial"}, nil
+	}
+
+	done := make(chan struct{})
+	go func() {
+		wt.RefreshGitStatus(context.Background())
+		close(done)
+	}()
+	waitForSignal(t, started, "shared status observation")
+	wt.Stop()
+	waitForSignal(t, done, "refresh cancellation")
+
+	wt.mu.RLock()
+	cached := wt.currentStatus
+	wt.mu.RUnlock()
+	if !cached.Timestamp.IsZero() {
+		t.Fatalf("canceled observation cached partial status: %+v", cached)
+	}
+}
+
+func TestWorkspaceTrackerStopWaitsForSharedObservationExit(t *testing.T) {
+	wt := newStatusConcurrencyTracker(t)
+	started := make(chan struct{})
+	canceled := make(chan struct{})
+	allowExit := make(chan struct{})
+	wt.gitStatusObserver = func(ctx context.Context) (types.GitStatusUpdate, error) {
+		close(started)
+		<-ctx.Done()
+		close(canceled)
+		<-allowExit
+		return types.GitStatusUpdate{}, ctx.Err()
+	}
+
+	refreshDone := make(chan struct{})
+	go func() {
+		wt.RefreshGitStatus(context.Background())
+		close(refreshDone)
+	}()
+	waitForSignal(t, started, "shared status observation")
+
+	stopDone := make(chan struct{})
+	go func() {
+		wt.Stop()
+		close(stopDone)
+	}()
+	waitForSignal(t, canceled, "tracker cancellation")
+	select {
+	case <-stopDone:
+		t.Fatal("Stop returned before the shared observation exited")
+	default:
+	}
+
+	close(allowExit)
+	waitForSignal(t, stopDone, "tracker stop")
+	waitForSignal(t, refreshDone, "refresh exit")
+}
+
+func TestWorkspaceTrackerSharedObservationDeadlineDoesNotCachePartialStatus(t *testing.T) {
+	wt := newStatusConcurrencyTracker(t)
+	wt.gitStatusObserveTimeout = 0
+	wt.gitStatusObserver = func(ctx context.Context) (types.GitStatusUpdate, error) {
+		<-ctx.Done()
+		return types.GitStatusUpdate{Timestamp: time.Unix(987, 0), Branch: "partial"}, nil
+	}
+
+	_, err := wt.GetGitStatus(context.Background(), true)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("GetGitStatus error = %v, want context.DeadlineExceeded", err)
+	}
+
+	wt.mu.RLock()
+	cached := wt.currentStatus
+	wt.mu.RUnlock()
+	if !cached.Timestamp.IsZero() {
+		t.Fatalf("timed-out observation cached partial status: %+v", cached)
+	}
+}
+
+func TestWorkspaceTrackerZeroValueStatusRead(t *testing.T) {
+	var wt WorkspaceTracker
+
+	status, err := wt.GetGitStatus(context.Background(), true)
+	if err != nil {
+		t.Fatalf("zero-value GetGitStatus returned error: %v", err)
+	}
+	if status.Timestamp.IsZero() {
+		t.Fatal("zero-value GetGitStatus returned an empty observation")
+	}
+}
+
+func TestWorkspaceTrackerCachedStatusDoesNotObserveRepository(t *testing.T) {
+	wt := newStatusConcurrencyTracker(t)
+	want := types.GitStatusUpdate{Timestamp: time.Unix(246, 0), Branch: "cached"}
+	wt.currentStatus = want
+	wt.gitStatusObserver = func(context.Context) (types.GitStatusUpdate, error) {
+		t.Fatal("cached status started a live observation")
+		return types.GitStatusUpdate{}, nil
+	}
+
+	got, err := wt.GetGitStatus(context.Background(), false)
+	if err != nil {
+		t.Fatalf("GetGitStatus returned error: %v", err)
+	}
+	if got.Timestamp != want.Timestamp || got.Branch != want.Branch {
+		t.Fatalf("GetGitStatus = %+v, want cached status %+v", got, want)
+	}
+}
+
+func newStatusConcurrencyTracker(t *testing.T) *WorkspaceTracker {
+	t.Helper()
+	wt := NewWorkspaceTracker(t.TempDir(), newTestLogger(t))
+	t.Cleanup(wt.Stop)
+	return wt
+}
+
+func blockingStatusObserver(started chan struct{}, release <-chan struct{}, branch string) func(context.Context) (types.GitStatusUpdate, error) {
+	return func(context.Context) (types.GitStatusUpdate, error) {
+		close(started)
+		<-release
+		return types.GitStatusUpdate{Timestamp: time.Unix(1, 0), Branch: branch}, nil
+	}
+}
+
+func waitForSignal(t *testing.T, signal <-chan struct{}, description string) {
+	t.Helper()
+	select {
+	case <-signal:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("timed out waiting for %s", description)
+	}
+}
+
+func waitForSignals(t *testing.T, signals <-chan struct{}, count int, description string) {
+	t.Helper()
+	for range count {
+		waitForSignal(t, signals, description)
+	}
+}

--- a/apps/backend/internal/agentctl/server/process/workspace_git_status_test.go
+++ b/apps/backend/internal/agentctl/server/process/workspace_git_status_test.go
@@ -34,6 +34,26 @@ func TestUnquoteGitPath(t *testing.T) {
 	}
 }
 
+func TestApplyPorcelainOutput_CancellationStopsLargeLoop(t *testing.T) {
+	baseCtx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	ctx := &cancelAfterErrChecksContext{Context: baseCtx, remaining: 2, cancel: cancel}
+	wt := NewWorkspaceTracker(t.TempDir(), newTestLogger(t))
+	update := &types.GitStatusUpdate{Files: make(map[string]types.FileInfo)}
+
+	err := wt.applyPorcelainOutput(ctx, []byte("?? first.txt\n?? second.txt\n?? third.txt\n"), update)
+
+	if err != context.Canceled {
+		t.Fatalf("applyPorcelainOutput() error = %v, want %v", err, context.Canceled)
+	}
+	if _, ok := update.Files["first.txt"]; !ok {
+		t.Fatal("first entry was not parsed before cancellation")
+	}
+	if _, ok := update.Files["second.txt"]; ok {
+		t.Fatal("entry parsed after cancellation")
+	}
+}
+
 func TestGetGitStatus_PathsWithSpaces(t *testing.T) {
 	repoDir, cleanup := setupTestRepo(t)
 	defer cleanup()

--- a/apps/backend/internal/agentctl/server/process/workspace_tracker.go
+++ b/apps/backend/internal/agentctl/server/process/workspace_tracker.go
@@ -14,10 +14,15 @@ import (
 	"github.com/kandev/kandev/internal/common/securityutil"
 	"github.com/kandev/kandev/internal/common/subproc"
 	"go.uber.org/zap"
+	"golang.org/x/sync/singleflight"
 )
 
 // DefaultGitPollInterval is the default interval for polling git status
 const DefaultGitPollInterval = 3 * time.Second
+
+// workspaceGitStatusObserveTimeout bounds a shared live status observation so
+// a wedged Git process cannot retain the tracker flight indefinitely.
+const workspaceGitStatusObserveTimeout = 60 * time.Second
 
 // fileStatus constants for FileInfo.Status values.
 const (
@@ -84,6 +89,16 @@ type WorkspaceTracker struct {
 	// updateMu prevents concurrent updateGitStatus calls from the two polling loops.
 	// Polling loops use TryLock (skip if busy); RefreshGitStatus uses Lock (always completes).
 	updateMu sync.Mutex
+
+	// gitStatusObserver is the expensive live repository observation. Keeping it
+	// as a dependency makes the concurrency contract deterministic to test while
+	// production uses computeGitStatus.
+	gitStatusObserver       func(context.Context) (types.GitStatusUpdate, error)
+	gitStatusObserveTimeout time.Duration
+	gitStatusGroup          singleflight.Group
+	gitStatusObserveMu      sync.Mutex
+	gitStatusObserveWG      sync.WaitGroup
+	gitStatusWaiterJoined   func() // Optional test synchronization hook; nil in production.
 
 	// Control
 	stopCh          chan struct{}
@@ -211,7 +226,7 @@ func newWorkspaceTracker(resolvedWorkDir, repositoryName string, log *logger.Log
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	return &WorkspaceTracker{
+	tracker := &WorkspaceTracker{
 		workDir:                    resolvedWorkDir,
 		gitIndexPath:               gitIndexPath,
 		repositoryName:             repositoryName,
@@ -227,15 +242,18 @@ func newWorkspaceTracker(resolvedWorkDir, repositoryName string, log *logger.Log
 		// about to be used by someone, historically). Retained-task CPU
 		// savings still apply because those instances eventually receive a
 		// slow or paused mode push.
-		pollMode:           PollModeFast,
-		monitorModeChanged: make(chan struct{}, 1),
-		gitPollModeChanged: make(chan struct{}, 1),
-		stopCh:             make(chan struct{}),
-		initialScanDone:    make(chan struct{}),
-		tickDone:           make(chan struct{}, 1),
-		cancelCtx:          ctx,
-		cancelFunc:         cancel,
+		pollMode:                PollModeFast,
+		monitorModeChanged:      make(chan struct{}, 1),
+		gitPollModeChanged:      make(chan struct{}, 1),
+		stopCh:                  make(chan struct{}),
+		initialScanDone:         make(chan struct{}),
+		tickDone:                make(chan struct{}, 1),
+		cancelCtx:               ctx,
+		cancelFunc:              cancel,
+		gitStatusObserveTimeout: workspaceGitStatusObserveTimeout,
 	}
+	tracker.gitStatusObserver = tracker.computeGitStatus
+	return tracker
 }
 
 // preferGitRepoChildIfRootIsBare returns workDir unchanged when it's already a
@@ -377,12 +395,19 @@ const stopTimeout = 5 * time.Second
 // up to 5 seconds for goroutines to exit before proceeding.
 func (wt *WorkspaceTracker) Stop() {
 	wt.stopOnce.Do(func() {
-		wt.cancelFunc() // Kill in-flight git commands immediately
+		// Synchronize cancellation with shared-observation admission. Once this
+		// lock is released, no observation can Add to gitStatusObserveWG.
+		wt.gitStatusObserveMu.Lock()
+		if wt.cancelFunc != nil {
+			wt.cancelFunc() // Kill in-flight git commands immediately
+		}
+		wt.gitStatusObserveMu.Unlock()
 		close(wt.stopCh)
 
 		done := make(chan struct{})
 		go func() {
 			wt.wg.Wait()
+			wt.gitStatusObserveWG.Wait()
 			close(done)
 		}()
 		select {

--- a/apps/backend/internal/agentctl/server/shell/manager.go
+++ b/apps/backend/internal/agentctl/server/shell/manager.go
@@ -1,6 +1,7 @@
 package shell
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 
@@ -14,6 +15,15 @@ type Manager struct {
 	logger    *logger.Logger
 	terminals map[string]*Session
 	mu        sync.RWMutex
+	stopping  bool
+}
+
+// BeginStop closes terminal admission after any start already holding the
+// manager lock has either committed or failed.
+func (m *Manager) BeginStop() {
+	m.mu.Lock()
+	m.stopping = true
+	m.mu.Unlock()
 }
 
 // NewManager creates a new shell session manager.
@@ -30,6 +40,9 @@ func NewManager(workDir string, log *logger.Logger) *Manager {
 func (m *Manager) Start(terminalID string, cfg Config) (*Session, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	if m.stopping {
+		return nil, fmt.Errorf("shell manager is stopping")
+	}
 
 	if s, ok := m.terminals[terminalID]; ok {
 		return s, nil
@@ -59,17 +72,23 @@ func (m *Manager) Get(terminalID string) (*Session, bool) {
 
 // Stop stops and removes the shell session for the given terminal ID.
 func (m *Manager) Stop(terminalID string) error {
-	m.mu.Lock()
+	m.mu.RLock()
 	s, ok := m.terminals[terminalID]
+	m.mu.RUnlock()
 	if !ok {
-		m.mu.Unlock()
 		return nil
 	}
-	delete(m.terminals, terminalID)
-	m.mu.Unlock()
 
 	m.logger.Info("stopping terminal shell", zap.String("terminal_id", terminalID))
-	return s.Stop()
+	if err := s.Stop(); err != nil {
+		return err
+	}
+	m.mu.Lock()
+	if m.terminals[terminalID] == s {
+		delete(m.terminals, terminalID)
+	}
+	m.mu.Unlock()
+	return nil
 }
 
 // Buffer returns the buffered output for the given terminal ID.
@@ -85,17 +104,26 @@ func (m *Manager) Buffer(terminalID string) ([]byte, error) {
 }
 
 // StopAll stops all terminal shell sessions.
-func (m *Manager) StopAll() {
+func (m *Manager) StopAll() error {
 	m.mu.Lock()
 	terminals := make(map[string]*Session, len(m.terminals))
 	for id, s := range m.terminals {
 		terminals[id] = s
 	}
-	m.terminals = make(map[string]*Session)
 	m.mu.Unlock()
 
+	var errs []error
 	for id, s := range terminals {
 		m.logger.Info("stopping terminal shell (shutdown)", zap.String("terminal_id", id))
-		_ = s.Stop()
+		if err := s.Stop(); err != nil {
+			errs = append(errs, fmt.Errorf("stop terminal %s: %w", id, err))
+			continue
+		}
+		m.mu.Lock()
+		if m.terminals[id] == s {
+			delete(m.terminals, id)
+		}
+		m.mu.Unlock()
 	}
+	return errors.Join(errs...)
 }

--- a/apps/backend/internal/agentctl/server/shell/process_group_linux.go
+++ b/apps/backend/internal/agentctl/server/shell/process_group_linux.go
@@ -1,4 +1,4 @@
-//go:build unix && !linux
+//go:build linux
 
 package shell
 
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"os"
 	"os/exec"
+	"strconv"
+	"strings"
 	"syscall"
 )
 
@@ -41,6 +43,40 @@ func shellProcessGroupAlive(p *os.Process) bool {
 	if p == nil || p.Pid <= 0 {
 		return false
 	}
-	err := syscall.Kill(-p.Pid, 0)
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return processGroupResponds(p.Pid)
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		pid, err := strconv.Atoi(entry.Name())
+		if err != nil {
+			continue
+		}
+		stat, err := os.ReadFile("/proc/" + strconv.Itoa(pid) + "/stat")
+		if err == nil && processStatMatchesLiveGroup(string(stat), p.Pid) {
+			return true
+		}
+	}
+	return false
+}
+
+func processStatMatchesLiveGroup(stat string, pgid int) bool {
+	commandEnd := strings.LastIndex(stat, ") ")
+	if commandEnd < 0 {
+		return false
+	}
+	fields := strings.Fields(stat[commandEnd+2:])
+	if len(fields) < 3 || fields[0] == "Z" || fields[0] == "X" {
+		return false
+	}
+	group, err := strconv.Atoi(fields[2])
+	return err == nil && group == pgid
+}
+
+func processGroupResponds(pid int) bool {
+	err := syscall.Kill(-pid, 0)
 	return err == nil || errors.Is(err, syscall.EPERM)
 }

--- a/apps/backend/internal/agentctl/server/shell/process_group_linux_test.go
+++ b/apps/backend/internal/agentctl/server/shell/process_group_linux_test.go
@@ -1,0 +1,26 @@
+//go:build linux
+
+package shell
+
+import "testing"
+
+func TestProcessStatMatchesLiveGroup(t *testing.T) {
+	tests := []struct {
+		name string
+		stat string
+		want bool
+	}{
+		{name: "running member", stat: "123 (shell worker) S 1 42 42 0", want: true},
+		{name: "zombie member", stat: "123 (shell worker) Z 1 42 42 0", want: false},
+		{name: "dead member", stat: "123 (shell worker) X 1 42 42 0", want: false},
+		{name: "different group", stat: "123 (shell worker) S 1 41 41 0", want: false},
+		{name: "malformed", stat: "malformed", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := processStatMatchesLiveGroup(tt.stat, 42); got != tt.want {
+				t.Fatalf("processStatMatchesLiveGroup() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/apps/backend/internal/agentctl/server/shell/process_group_unix.go
+++ b/apps/backend/internal/agentctl/server/shell/process_group_unix.go
@@ -11,6 +11,16 @@ import (
 
 func configureShellProcess(_ *exec.Cmd) {}
 
+type shellProcessLifecycleHandle struct{}
+
+func installShellProcessLifecycle(_ *exec.Cmd) (shellProcessLifecycleHandle, error) {
+	return shellProcessLifecycleHandle{}, nil
+}
+
+func reapShellProcessLifecycle(_ shellProcessLifecycleHandle) error { return nil }
+
+func ownsShellProcessLifecycle(_ shellProcessLifecycleHandle) bool { return false }
+
 func killShellProcessGroup(p *os.Process) error {
 	if p == nil {
 		return nil
@@ -25,4 +35,12 @@ func killShellProcessGroup(p *os.Process) error {
 		return err
 	}
 	return nil
+}
+
+func shellProcessGroupAlive(p *os.Process) bool {
+	if p == nil || p.Pid <= 0 {
+		return false
+	}
+	err := syscall.Kill(-p.Pid, 0)
+	return err == nil || errors.Is(err, syscall.EPERM)
 }

--- a/apps/backend/internal/agentctl/server/shell/process_group_windows.go
+++ b/apps/backend/internal/agentctl/server/shell/process_group_windows.go
@@ -3,18 +3,44 @@
 package shell
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
 	"os/exec"
-	"strings"
 	"syscall"
+	"time"
+
+	"github.com/kandev/kandev/internal/agentctl/server/winproc"
+	"golang.org/x/sys/windows"
 )
 
 func configureShellProcess(cmd *exec.Cmd) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{
-		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP,
+		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP | windows.CREATE_SUSPENDED,
 	}
+}
+
+type shellProcessLifecycleHandle struct {
+	job winproc.KillOnCloseJob
+}
+
+func installShellProcessLifecycle(cmd *exec.Cmd) (shellProcessLifecycleHandle, error) {
+	job, err := winproc.InstallKillOnCloseJobForSuspendedCommand(cmd)
+	if err != nil {
+		return shellProcessLifecycleHandle{}, err
+	}
+	return shellProcessLifecycleHandle{job: job}, nil
+}
+
+func reapShellProcessLifecycle(lifecycle shellProcessLifecycleHandle) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	return lifecycle.job.TerminateAndWait(ctx)
+}
+
+func ownsShellProcessLifecycle(lifecycle shellProcessLifecycleHandle) bool {
+	return lifecycle.job.Valid()
 }
 
 func killShellProcessGroup(p *os.Process) error {
@@ -30,14 +56,10 @@ func killShellProcessGroup(p *os.Process) error {
 	return nil
 }
 
+// taskkill /T waits for the requested process tree termination before it
+// returns; Windows does not expose Unix-style process-group liveness here.
+func shellProcessGroupAlive(_ *os.Process) bool { return false }
+
 func runShellTaskkill(args ...string) error {
-	output, err := exec.Command("taskkill", args...).CombinedOutput()
-	if err == nil {
-		return nil
-	}
-	msg := strings.TrimSpace(string(output))
-	if msg == "" {
-		return err
-	}
-	return fmt.Errorf("%w: %s", err, msg)
+	return winproc.RunTaskkill(args...)
 }

--- a/apps/backend/internal/agentctl/server/shell/process_group_windows_test.go
+++ b/apps/backend/internal/agentctl/server/shell/process_group_windows_test.go
@@ -1,0 +1,22 @@
+//go:build windows
+
+package shell
+
+import (
+	"os/exec"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/windows"
+)
+
+func TestConfigureShellProcessStartsSuspendedForJobAssignment(t *testing.T) {
+	cmd := exec.Command("cmd.exe")
+
+	configureShellProcess(cmd)
+
+	require.NotNil(t, cmd.SysProcAttr)
+	require.NotZero(t, cmd.SysProcAttr.CreationFlags&syscall.CREATE_NEW_PROCESS_GROUP)
+	require.NotZero(t, cmd.SysProcAttr.CreationFlags&windows.CREATE_SUSPENDED)
+}

--- a/apps/backend/internal/agentctl/server/shell/session.go
+++ b/apps/backend/internal/agentctl/server/shell/session.go
@@ -3,6 +3,7 @@
 package shell
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -27,8 +28,10 @@ type Session struct {
 	config    Config   // Stored config for respawn
 
 	// PTY and process
-	pty *os.File
-	cmd *exec.Cmd
+	pty       *os.File
+	cmd       *exec.Cmd
+	lifecycle shellProcessLifecycleHandle
+	reapErr   error
 
 	// State
 	running   bool
@@ -47,11 +50,35 @@ type Session struct {
 	stopCh   chan struct{}
 	doneCh   chan struct{}
 	stopping bool // true when Stop() has been called (don't respawn)
+
+	killGroupFn     func(*os.Process) error
+	waitGroupExitFn func(*os.Process) bool
+	beforeRespawn   func()
+	afterStopClaim  func()
 }
 
 // Maximum size of output buffer (16KB should be enough for recent history)
 const maxOutputBufferSize = 16 * 1024
 const shellStopGrace = 250 * time.Millisecond
+const shellReapGrace = 2 * time.Second
+
+func killAndWaitShellCommand(cmd *exec.Cmd) error {
+	if cmd == nil || cmd.Process == nil {
+		return nil
+	}
+	_ = cmd.Process.Kill()
+	done := make(chan struct{})
+	go func() {
+		_ = cmd.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return nil
+	case <-time.After(shellReapGrace):
+		return fmt.Errorf("shell process %d was not reaped after failed startup", cmd.Process.Pid)
+	}
+}
 
 // Config holds shell session configuration
 type Config struct {
@@ -163,6 +190,7 @@ func defaultShellArgs(shellCommand string) []string {
 func (s *Session) start(cfg Config) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	doneCh := make(chan struct{})
 
 	s.cmd = exec.Command(s.shell, s.shellArgs...)
 	s.cmd.Dir = cfg.WorkDir
@@ -178,9 +206,18 @@ func (s *Session) start(cfg Config) error {
 	if err != nil {
 		return fmt.Errorf("failed to start PTY: %w", err)
 	}
+	lifecycle, lifecycleErr := installShellProcessLifecycle(s.cmd)
+	if lifecycleErr != nil {
+		_ = s.pty.Close()
+		reapErr := killAndWaitShellCommand(s.cmd)
+		return errors.Join(fmt.Errorf("failed to install shell process lifecycle: %w", lifecycleErr), reapErr)
+	}
 
 	s.running = true
 	s.startedAt = time.Now()
+	s.doneCh = doneCh
+	s.lifecycle = lifecycle
+	s.reapErr = nil
 
 	s.logger.Info("shell session started",
 		zap.String("shell", s.shell),
@@ -191,7 +228,7 @@ func (s *Session) start(cfg Config) error {
 	go s.readOutput()
 
 	// Wait for process exit
-	go s.waitForExit()
+	go s.waitForExit(s.cmd, doneCh, lifecycle)
 
 	return nil
 }
@@ -200,18 +237,38 @@ func (s *Session) start(cfg Config) error {
 // Called automatically when agentctl stops.
 func (s *Session) Stop() error {
 	s.mu.Lock()
+	cmd := s.cmd
+	doneCh := s.doneCh
+	var process *os.Process
+	if cmd != nil {
+		process = cmd.Process
+	}
+	pid := 0
+	if process != nil {
+		pid = process.Pid
+	}
+	lifecycle := s.lifecycle
 	if !s.running {
+		s.stopping = true
+		doneCh := s.doneCh
 		s.mu.Unlock()
+		if s.afterStopClaim != nil {
+			s.afterStopClaim()
+		}
+		if doneCh != nil {
+			select {
+			case <-doneCh:
+				return s.cleanupShellProcessGroup(process, pid, "stop_retry", lifecycle)
+			case <-time.After(shellReapGrace):
+				return fmt.Errorf("shell process was not reaped after stop")
+			}
+		}
 		return nil
 	}
 	s.running = false
 	s.stopping = true // Mark as stopping to prevent respawn
 	s.mu.Unlock()
 
-	pid := 0
-	if s.cmd != nil && s.cmd.Process != nil {
-		pid = s.cmd.Process.Pid
-	}
 	s.logger.Info("stopping shell session",
 		zap.String("shell", s.shell),
 		zap.String("cwd", s.workDir),
@@ -233,32 +290,82 @@ func (s *Session) Stop() error {
 
 	// Wait for exit with timeout
 	select {
-	case <-s.doneCh:
+	case <-doneCh:
 		s.logger.Info("shell session stopped gracefully")
-		s.cleanupShellProcessGroup(pid, "leader_exited")
+		return s.cleanupShellProcessGroup(process, pid, "leader_exited", lifecycle)
 	case <-time.After(shellStopGrace):
 		s.logger.Warn("shell session stop timeout, force killing",
 			zap.Int("pid", pid),
 			zap.Duration("grace", shellStopGrace))
-		s.cleanupShellProcessGroup(pid, "stop_timeout")
+		if err := s.cleanupShellProcessGroup(process, pid, "stop_timeout", lifecycle); err != nil {
+			return err
+		}
+	}
+	if pid == 0 {
+		return nil
 	}
 
-	return nil
+	select {
+	case <-doneCh:
+		return nil
+	case <-time.After(shellReapGrace):
+		return fmt.Errorf("shell process %d was not reaped after force kill", pid)
+	}
 }
 
-func (s *Session) cleanupShellProcessGroup(pid int, reason string) {
-	if s.cmd == nil || s.cmd.Process == nil {
-		return
+func (s *Session) cleanupShellProcessGroup(
+	process *os.Process,
+	pid int,
+	reason string,
+	lifecycle shellProcessLifecycleHandle,
+) error {
+	if process == nil {
+		return nil
 	}
 	s.logger.Debug("shell session process group cleanup requested",
 		zap.Int("pid", pid),
 		zap.String("reason", reason))
-	if err := killShellProcessGroup(s.cmd.Process); err != nil {
+	if ownsShellProcessLifecycle(lifecycle) {
+		if err := reapShellProcessLifecycle(lifecycle); err != nil {
+			return fmt.Errorf("reap shell process job: %w", err)
+		}
+		s.mu.Lock()
+		if s.lifecycle == lifecycle {
+			s.lifecycle = shellProcessLifecycleHandle{}
+			s.reapErr = nil
+		}
+		s.mu.Unlock()
+		return nil
+	}
+	killGroup := killShellProcessGroup
+	if s.killGroupFn != nil {
+		killGroup = s.killGroupFn
+	}
+	if err := killGroup(process); err != nil {
 		s.logger.Debug("shell session process group cleanup failed",
 			zap.Int("pid", pid),
 			zap.String("reason", reason),
 			zap.Error(err))
+		return err
 	}
+	if s.waitGroupExitFn != nil {
+		if !s.waitGroupExitFn(process) {
+			return fmt.Errorf("shell process group %d remains alive after force kill", pid)
+		}
+		return nil
+	}
+	deadline := time.NewTimer(shellReapGrace)
+	defer deadline.Stop()
+	ticker := time.NewTicker(20 * time.Millisecond)
+	defer ticker.Stop()
+	for shellProcessGroupAlive(process) {
+		select {
+		case <-deadline.C:
+			return fmt.Errorf("shell process group %d remains alive after force kill", pid)
+		case <-ticker.C:
+		}
+	}
+	return nil
 }
 
 // Write sends input to the shell
@@ -395,32 +502,58 @@ func (s *Session) GetBufferedOutput() []byte {
 }
 
 // waitForExit waits for the shell process to exit and respawns if not stopping
-func (s *Session) waitForExit() {
-	if s.cmd != nil {
-		_ = s.cmd.Wait()
+func (s *Session) waitForExit(cmd *exec.Cmd, doneCh chan struct{}, lifecycle shellProcessLifecycleHandle) {
+	if cmd != nil {
+		_ = cmd.Wait()
 	}
+	pid := 0
+	var process *os.Process
+	if cmd != nil {
+		process = cmd.Process
+	}
+	if process != nil {
+		pid = process.Pid
+	}
+	reapErr := s.cleanupShellProcessGroup(process, pid, "leader_exited", lifecycle)
 
 	s.mu.Lock()
 	stopping := s.stopping
 	s.running = false
+	s.reapErr = reapErr
 	s.mu.Unlock()
+	if reapErr != nil {
+		s.logger.Error("shell process tree was not reaped", zap.Int("pid", pid), zap.Error(reapErr))
+		close(doneCh)
+		return
+	}
 
 	// If Stop() was called, don't respawn - just signal done
 	if stopping {
 		s.logger.Info("shell process exited (stopping)")
-		close(s.doneCh)
+		close(doneCh)
 		return
 	}
 
 	s.logger.Info("shell process exited unexpectedly, respawning...")
 
-	// Small delay before respawn to avoid tight loop on repeated failures
-	time.Sleep(100 * time.Millisecond)
+	// Small delay before respawn to avoid tight loop on repeated failures.
+	if s.beforeRespawn != nil {
+		s.beforeRespawn()
+	} else {
+		time.Sleep(100 * time.Millisecond)
+	}
 
 	// Respawn the shell
 	if err := s.respawn(); err != nil {
 		s.logger.Error("failed to respawn shell", zap.Error(err))
-		close(s.doneCh)
+		close(doneCh)
+		return
+	}
+	s.mu.Lock()
+	stoppedBeforeRespawn := s.stopping && !s.running
+	s.mu.Unlock()
+	if stoppedBeforeRespawn {
+		close(doneCh)
 	}
 }
 
@@ -442,9 +575,11 @@ func (s *Session) respawn() error {
 		_ = s.pty.Close()
 	}
 
+	doneCh := make(chan struct{})
 	s.cmd = exec.Command(s.shell, s.shellArgs...)
 	s.cmd.Dir = s.workDir
 	s.cmd.Env = buildShellEnv(s.workDir)
+	configureShellProcess(s.cmd)
 
 	// Start with PTY
 	var err error
@@ -455,9 +590,18 @@ func (s *Session) respawn() error {
 	if err != nil {
 		return fmt.Errorf("failed to start PTY: %w", err)
 	}
+	lifecycle, lifecycleErr := installShellProcessLifecycle(s.cmd)
+	if lifecycleErr != nil {
+		_ = s.pty.Close()
+		reapErr := killAndWaitShellCommand(s.cmd)
+		return errors.Join(fmt.Errorf("failed to install shell process lifecycle: %w", lifecycleErr), reapErr)
+	}
 
 	s.running = true
 	s.startedAt = time.Now()
+	s.doneCh = doneCh
+	s.lifecycle = lifecycle
+	s.reapErr = nil
 
 	s.logger.Info("shell session respawned",
 		zap.String("shell", s.shell),
@@ -468,7 +612,7 @@ func (s *Session) respawn() error {
 	go s.readOutput()
 
 	// Wait for process exit (recursive respawn on exit)
-	go s.waitForExit()
+	go s.waitForExit(s.cmd, doneCh, lifecycle)
 
 	return nil
 }

--- a/apps/backend/internal/agentctl/server/shell/session.go
+++ b/apps/backend/internal/agentctl/server/shell/session.go
@@ -82,11 +82,12 @@ func killAndWaitShellCommand(cmd *exec.Cmd) error {
 
 // Config holds shell session configuration
 type Config struct {
-	WorkDir      string   // Working directory (default: workspace)
-	Cols         int      // Initial terminal columns (default: 80)
-	Rows         int      // Initial terminal rows (default: 24)
-	ShellCommand string   // Optional shell command override
-	ShellArgs    []string // Optional shell args override
+	WorkDir      string            // Working directory (default: workspace)
+	Cols         int               // Initial terminal columns (default: 80)
+	Rows         int               // Initial terminal rows (default: 24)
+	ShellCommand string            // Optional shell command override
+	ShellArgs    []string          // Optional shell args override
+	Env          map[string]string // Optional environment overrides
 }
 
 // DefaultConfig returns the default shell configuration
@@ -194,7 +195,7 @@ func (s *Session) start(cfg Config) error {
 
 	s.cmd = exec.Command(s.shell, s.shellArgs...)
 	s.cmd.Dir = cfg.WorkDir
-	s.cmd.Env = buildShellEnv(cfg.WorkDir)
+	s.cmd.Env = buildShellEnv(cfg.WorkDir, cfg.Env)
 	configureShellProcess(s.cmd)
 
 	// Start with PTY
@@ -578,7 +579,7 @@ func (s *Session) respawn() error {
 	doneCh := make(chan struct{})
 	s.cmd = exec.Command(s.shell, s.shellArgs...)
 	s.cmd.Dir = s.workDir
-	s.cmd.Env = buildShellEnv(s.workDir)
+	s.cmd.Env = buildShellEnv(s.workDir, s.config.Env)
 	configureShellProcess(s.cmd)
 
 	// Start with PTY
@@ -618,8 +619,11 @@ func (s *Session) respawn() error {
 }
 
 // buildShellEnv creates the environment for the shell process
-func buildShellEnv(workDir string) []string {
+func buildShellEnv(workDir string, overrides map[string]string) []string {
 	env := os.Environ()
+	for key, value := range overrides {
+		env = upsertShellEnv(env, key, value)
+	}
 
 	// Set working directory related vars
 	env = append(env, "PWD="+workDir)
@@ -630,4 +634,24 @@ func buildShellEnv(workDir string) []string {
 	env = append(env, "LC_ALL=C.UTF-8")
 
 	return env
+}
+
+func upsertShellEnv(env []string, key, value string) []string {
+	prefix := key + "="
+	result := make([]string, 0, len(env)+1)
+	found := false
+	for _, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			if !found {
+				result = append(result, prefix+value)
+				found = true
+			}
+			continue
+		}
+		result = append(result, entry)
+	}
+	if !found {
+		result = append(result, prefix+value)
+	}
+	return result
 }

--- a/apps/backend/internal/agentctl/server/shell/session_stop_unix_test.go
+++ b/apps/backend/internal/agentctl/server/shell/session_stop_unix_test.go
@@ -16,6 +16,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestKillAndWaitShellCommandReapsProcess(t *testing.T) {
+	cmd := exec.Command("sh", "-c", "sleep 30")
+	require.NoError(t, cmd.Start())
+
+	require.NoError(t, killAndWaitShellCommand(cmd))
+	require.NotNil(t, cmd.ProcessState)
+}
+
 func TestStopKillsShellProcessGroupOnTimeout(t *testing.T) {
 	sh, err := exec.LookPath("sh")
 	require.NoError(t, err)
@@ -31,9 +39,7 @@ func TestStopKillsShellProcessGroupOnTimeout(t *testing.T) {
 
 	childPID := waitForShellChildPID(t, pidFile)
 	require.NoError(t, session.Stop())
-	require.Eventually(t, func() bool {
-		return !shellProcessAlive(childPID)
-	}, 5*time.Second, 50*time.Millisecond, "shell child process %d should be killed", childPID)
+	require.False(t, shellProcessAlive(childPID), "shell child process %d should be gone when Stop returns", childPID)
 }
 
 func TestStopKillsShellProcessGroupAfterLeaderExits(t *testing.T) {
@@ -51,9 +57,8 @@ func TestStopKillsShellProcessGroupAfterLeaderExits(t *testing.T) {
 
 	childPID := waitForShellChildPID(t, pidFile)
 	require.NoError(t, session.Stop())
-	require.Eventually(t, func() bool {
-		return !shellProcessAlive(childPID)
-	}, 5*time.Second, 50*time.Millisecond, "shell child process %d should be killed after shell leader exits", childPID)
+	require.False(t, shellProcessAlive(childPID),
+		"shell child process %d should be gone when Stop returns after leader exit", childPID)
 }
 
 func waitForShellChildPID(t *testing.T, pidFile string) int {

--- a/apps/backend/internal/agentctl/server/shell/session_test.go
+++ b/apps/backend/internal/agentctl/server/shell/session_test.go
@@ -2,6 +2,7 @@ package shell
 
 import (
 	"os"
+	"os/exec"
 	"runtime"
 	"sync"
 	"testing"
@@ -223,6 +224,111 @@ func TestSessionStopTimeoutIsShortForShutdown(t *testing.T) {
 
 	if elapsed > 700*time.Millisecond {
 		t.Fatalf("Stop took %s, want less than 700ms for shutdown fallback", elapsed)
+	}
+}
+
+func TestSessionStopRetriesFailedProcessGroupReap(t *testing.T) {
+	done := make(chan struct{})
+	close(done)
+	groupAlive := true
+	session := &Session{
+		logger:          newTestLogger(),
+		running:         true,
+		cmd:             &exec.Cmd{Process: &os.Process{Pid: 424246}},
+		stopCh:          make(chan struct{}),
+		doneCh:          done,
+		killGroupFn:     func(*os.Process) error { return nil },
+		waitGroupExitFn: func(*os.Process) bool { return !groupAlive },
+	}
+
+	if err := session.Stop(); err == nil {
+		t.Fatal("Stop() succeeded while the owned process group remained alive")
+	}
+	groupAlive = false
+	if err := session.Stop(); err != nil {
+		t.Fatalf("Stop() retry error = %v", err)
+	}
+}
+
+func TestSessionStopPreventsRespawnAfterLeaderExit(t *testing.T) {
+	cmd := exec.Command("true")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start fixture command: %v", err)
+	}
+	beforeRespawn := make(chan struct{})
+	releaseRespawn := make(chan struct{})
+	stopClaimed := make(chan struct{})
+	done := make(chan struct{})
+	session := &Session{
+		logger:  newTestLogger(),
+		running: true,
+		cmd:     cmd,
+		stopCh:  make(chan struct{}),
+		doneCh:  done,
+		beforeRespawn: func() {
+			close(beforeRespawn)
+			<-releaseRespawn
+		},
+		afterStopClaim: func() { close(stopClaimed) },
+	}
+	go session.waitForExit(cmd, done, shellProcessLifecycleHandle{})
+	<-beforeRespawn
+
+	stopDone := make(chan error, 1)
+	go func() { stopDone <- session.Stop() }()
+	<-stopClaimed
+	session.mu.RLock()
+	stopping := session.stopping
+	session.mu.RUnlock()
+	if !stopping {
+		t.Fatal("Stop() did not claim shell lifecycle during respawn delay")
+	}
+	close(releaseRespawn)
+	if err := <-stopDone; err != nil {
+		t.Fatalf("Stop() error = %v", err)
+	}
+	session.mu.RLock()
+	defer session.mu.RUnlock()
+	if session.running {
+		t.Fatal("shell respawned after teardown claimed lifecycle")
+	}
+	if session.cmd != cmd {
+		t.Fatal("shell command generation changed after teardown")
+	}
+}
+
+func TestSessionRespawnUsesGenerationCompletionChannel(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("PTY is not supported on Windows")
+	}
+	oldDone := make(chan struct{})
+	session := &Session{
+		logger:        newTestLogger(),
+		workDir:       t.TempDir(),
+		shell:         "/bin/sh",
+		config:        DefaultConfig(t.TempDir()),
+		stopCh:        make(chan struct{}),
+		doneCh:        oldDone,
+		beforeRespawn: func() {},
+	}
+	session.config.WorkDir = session.workDir
+	if err := session.respawn(); err != nil {
+		t.Fatalf("respawn() error = %v", err)
+	}
+	session.mu.RLock()
+	currentDone := session.doneCh
+	session.mu.RUnlock()
+	if currentDone == oldDone {
+		t.Fatal("respawn reused the prior generation completion channel")
+	}
+	close(oldDone)
+	select {
+	case <-currentDone:
+		t.Fatal("prior generation completion signaled the current generation")
+	default:
+	}
+	if err := session.Stop(); err != nil {
+		t.Fatalf("Stop() error = %v", err)
 	}
 }
 

--- a/apps/backend/internal/agentctl/server/shell/session_test.go
+++ b/apps/backend/internal/agentctl/server/shell/session_test.go
@@ -555,7 +555,7 @@ func TestSessionStatusAfterStop(t *testing.T) {
 // TestBuildShellEnv tests the buildShellEnv function
 func TestBuildShellEnv(t *testing.T) {
 	workDir := "/test/workspace"
-	env := buildShellEnv(workDir)
+	env := buildShellEnv(workDir, nil)
 
 	// Check that env is not empty
 	if len(env) == 0 {
@@ -579,6 +579,30 @@ func TestBuildShellEnv(t *testing.T) {
 	}
 	if !termFound {
 		t.Error("expected TERM to be set in environment")
+	}
+}
+
+func TestBuildShellEnvOverridesManagedTemp(t *testing.T) {
+	workDir := t.TempDir()
+	t.Setenv("TMPDIR", "unmanaged")
+	env := buildShellEnv(workDir, map[string]string{
+		"TMPDIR": "/tmp/kandev-agent/session",
+		"TMP":    "/tmp/kandev-agent/session",
+		"TEMP":   "/tmp/kandev-agent/session",
+	})
+
+	for _, key := range []string{"TMPDIR", "TMP", "TEMP"} {
+		want := key + "=/tmp/kandev-agent/session"
+		found := false
+		for _, entry := range env {
+			if entry == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("environment does not contain %q", want)
+		}
 	}
 }
 

--- a/apps/backend/internal/agentctl/server/winproc/lifecycle_windows.go
+++ b/apps/backend/internal/agentctl/server/winproc/lifecycle_windows.go
@@ -3,11 +3,14 @@
 package winproc
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os/exec"
 	"strings"
+	"sync"
 	"syscall"
+	"time"
 	"unsafe"
 
 	"golang.org/x/sys/windows"
@@ -16,12 +19,17 @@ import (
 // KillOnCloseJob owns a Windows Job Object configured to terminate all assigned
 // processes when the handle is closed.
 type KillOnCloseJob struct {
+	state *killOnCloseJobState
+}
+
+type killOnCloseJobState struct {
+	mu     sync.Mutex
 	handle windows.Handle
 }
 
 // InstallKillOnCloseJobForSuspendedCommand assigns a suspended child process to
-// a kill-on-close Job Object before resuming it. If job setup fails, the child
-// is still resumed so callers can fall back to explicit taskkill cleanup.
+// a kill-on-close Job Object before resuming it. If job setup fails, the
+// suspended child is terminated before it can create unowned descendants.
 func InstallKillOnCloseJobForSuspendedCommand(cmd *exec.Cmd) (KillOnCloseJob, error) {
 	if cmd == nil || cmd.Process == nil {
 		return KillOnCloseJob{}, fmt.Errorf("process not started")
@@ -48,37 +56,142 @@ func InstallKillOnCloseJobForProcess(pid int) (KillOnCloseJob, error) {
 		_ = windows.CloseHandle(job)
 		return KillOnCloseJob{}, err
 	}
-	return KillOnCloseJob{handle: job}, nil
+	return newKillOnCloseJob(job), nil
 }
 
 func InstallKillOnCloseJobForSuspendedProcess(pid int) (KillOnCloseJob, error) {
 	job, err := createKillOnCloseJob()
 	if err != nil {
-		return KillOnCloseJob{}, errors.Join(err, ResumeSuspendedProcess(pid))
+		return KillOnCloseJob{}, errors.Join(err, terminateSuspendedProcess(pid))
 	}
 	if err := assignProcessToJob(job, pid); err != nil {
 		_ = windows.CloseHandle(job)
 		return KillOnCloseJob{}, errors.Join(
 			err,
-			ResumeSuspendedProcess(pid),
+			terminateSuspendedProcess(pid),
 		)
 	}
 	if err := ResumeSuspendedProcess(pid); err != nil {
 		_ = windows.CloseHandle(job)
 		return KillOnCloseJob{}, err
 	}
-	return KillOnCloseJob{handle: job}, nil
+	return newKillOnCloseJob(job), nil
+}
+
+func terminateSuspendedProcess(pid int) error {
+	process, err := windows.OpenProcess(windows.PROCESS_TERMINATE, false, uint32(pid))
+	if err != nil {
+		return fmt.Errorf("OpenProcess(pid=%d) for suspended cleanup: %w", pid, err)
+	}
+	defer windows.CloseHandle(process)
+	if err := windows.TerminateProcess(process, 1); err != nil {
+		return fmt.Errorf("TerminateProcess(pid=%d): %w", pid, err)
+	}
+	return nil
 }
 
 func (j KillOnCloseJob) Close() error {
-	if j.handle == 0 {
+	if j.state == nil {
 		return nil
 	}
-	return windows.CloseHandle(j.handle)
+	j.state.mu.Lock()
+	defer j.state.mu.Unlock()
+	if j.state.handle == 0 {
+		return nil
+	}
+	if err := windows.CloseHandle(j.state.handle); err != nil {
+		return err
+	}
+	j.state.handle = 0
+	return nil
 }
 
 func (j KillOnCloseJob) RawHandle() uintptr {
-	return uintptr(j.handle)
+	if j.state == nil {
+		return 0
+	}
+	j.state.mu.Lock()
+	defer j.state.mu.Unlock()
+	return uintptr(j.state.handle)
+}
+
+// Valid reports whether this value refers to a job lifecycle, including one
+// already reaped through another copy of the handle.
+func (j KillOnCloseJob) Valid() bool {
+	return j.state != nil
+}
+
+// TerminateAndWait terminates every process assigned to the job and waits
+// until Windows reports that the job is empty before releasing its handle.
+// On failure the handle remains owned so teardown can retry safely.
+func (j KillOnCloseJob) TerminateAndWait(ctx context.Context) error {
+	if j.state == nil {
+		return nil
+	}
+	j.state.mu.Lock()
+	defer j.state.mu.Unlock()
+	if j.state.handle == 0 {
+		return nil
+	}
+
+	active, err := activeJobProcesses(j.state.handle)
+	if err != nil {
+		return err
+	}
+	if active > 0 {
+		if err := windows.TerminateJobObject(j.state.handle, 1); err != nil {
+			return fmt.Errorf("TerminateJobObject: %w", err)
+		}
+	}
+
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for active > 0 {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("wait for job processes: %w", ctx.Err())
+		case <-ticker.C:
+		}
+		active, err = activeJobProcesses(j.state.handle)
+		if err != nil {
+			return err
+		}
+	}
+
+	if err := windows.CloseHandle(j.state.handle); err != nil {
+		return err
+	}
+	j.state.handle = 0
+	return nil
+}
+
+type basicJobAccountingInformation struct {
+	TotalUserTime             int64
+	TotalKernelTime           int64
+	ThisPeriodTotalUserTime   int64
+	ThisPeriodTotalKernelTime int64
+	TotalPageFaultCount       uint32
+	TotalProcesses            uint32
+	ActiveProcesses           uint32
+	TotalTerminatedProcesses  uint32
+}
+
+func newKillOnCloseJob(handle windows.Handle) KillOnCloseJob {
+	return KillOnCloseJob{state: &killOnCloseJobState{handle: handle}}
+}
+
+func activeJobProcesses(job windows.Handle) (uint32, error) {
+	var info basicJobAccountingInformation
+	if err := windows.QueryInformationJobObject(
+		job,
+		windows.JobObjectBasicAccountingInformation,
+		uintptr(unsafe.Pointer(&info)),
+		uint32(unsafe.Sizeof(info)),
+		nil,
+	); err != nil {
+		return 0, fmt.Errorf("QueryInformationJobObject: %w", err)
+	}
+	return info.ActiveProcesses, nil
 }
 
 func createKillOnCloseJob() (windows.Handle, error) {

--- a/docs/decisions/0045-install-wide-storage-maintenance.md
+++ b/docs/decisions/0045-install-wide-storage-maintenance.md
@@ -1,6 +1,6 @@
 # 0045: Install-wide storage maintenance uses typed ownership providers and quarantine
 
-**Status:** accepted
+**Status:** accepted (amended 2026-07-19)
 **Date:** 2026-07-14
 **Area:** backend, frontend, infra
 
@@ -44,6 +44,21 @@ pending archive job and restores a matching quarantined workspace when possible.
 does not delete historical archived-task worktree rows or branch metadata used by PR #1687's branch
 recovery.
 
+Agentctl session temporary roots are a separate lifecycle-owned resource. They remain beneath the
+operating system's temporary directory under a readable, collision-resistant digest of the raw
+session and instance identity so concurrent sessions have isolated sockets, compiler work files,
+and command scratch space without mixing ephemeral data into `KANDEV_HOME_DIR`. After agent, shell,
+VS Code, and workspace subprocesses are reaped during permanent instance teardown, agentctl deletes
+only that instance's validated owned root. A later session resume creates a replacement instance
+and does not depend on the prior instance's scratch. Session temp data is not quarantined because it
+is explicitly ephemeral and contains no task recovery state.
+
+Terminal instance teardown closes process admission before its ownership sweep. A failed HTTP
+shutdown or process-tree reap retains a stopping instance tombstone and its allocated port so a
+replacement cannot adopt unresolved runtime resources. A temporary-directory-only deletion failure
+is reported but does not retain the execution port. Ordinary agent stop/start remains restartable;
+the irreversible admission close belongs to instance teardown.
+
 ## Consequences
 
 - Operators can configure and inspect cleanup from Kandev without host cron or systemd overrides.
@@ -57,6 +72,8 @@ recovery.
   reclaimable bytes for the operator.
 - The existing Office GC package and startup wiring are removed or reduced to adapters over the
   System storage service to avoid two competing sweepers.
+- Session teardown reclaims its temporary storage immediately and independently of scheduled
+  maintenance, while path containment prevents removal of the shared temp root or sibling sessions.
 
 ## Alternatives Considered
 
@@ -73,3 +90,8 @@ recovery.
   failed-cleanup directories forever.
 - **Make systemd installation enable cleanup automatically.** Rejected because process supervision
   does not imply user consent for destructive host maintenance.
+- **Store session scratch data under `KANDEV_HOME_DIR`.** Rejected because it mixes transient
+  process data with persistent application state and makes backups, retention, and disk accounting
+  retain data that should disappear at teardown or reboot.
+- **Share one temporary directory across agent sessions.** Rejected because filenames, sockets, and
+  compiler work directories can collide and teardown cannot safely determine which files it owns.

--- a/docs/decisions/INDEX.md
+++ b/docs/decisions/INDEX.md
@@ -52,7 +52,7 @@ Read individual ADRs for full context. Create new ones via `/record decision` or
 | 2026-07-14-typed-utility-chat-sessions | [Typed Utility Chats Share the Quick Chat Session Model](2026-07-14-typed-utility-chat-sessions.md) | accepted   | backend, frontend           | 2026-07-14 |
 | 2026-07-15-office-agent-execution-profile-routing | [Separate Office identity from routed execution profiles](2026-07-15-office-agent-execution-profile-routing.md) | proposed | backend, frontend | 2026-07-15 |
 | 0044 | [ACP agent compatibility dialects](0044-acp-agent-compatibility-dialects.md)                                                        | accepted   | backend, protocol           | 2026-07-16 |
-| 0045 | [Install-wide storage maintenance uses typed ownership providers and quarantine](0045-install-wide-storage-maintenance.md)          | accepted   | backend, frontend, infra    | 2026-07-14 |
+| 0045 | [Install-wide storage maintenance uses typed ownership providers and quarantine](0045-install-wide-storage-maintenance.md)          | accepted (amended 2026-07-19) | backend, frontend, infra | 2026-07-14 |
 | 0046 | [Settings route save coordinator](0046-settings-route-save-coordinator.md)                                                          | accepted   | frontend                    | 2026-07-14 |
 | 2026-07-18-turn-configuration-snapshots | [Attribute runtime configuration to turns](2026-07-18-turn-configuration-snapshots.md) | accepted | backend, frontend | 2026-07-18 |
 | 2026-07-19-reject-mcp-actions-on-raw-websocket | [Reject MCP Actions on the Raw WebSocket](2026-07-19-reject-mcp-actions-on-raw-websocket.md) | accepted | backend, protocol | 2026-07-19 |

--- a/docs/plans/workspace-git-status-scalability/plan.md
+++ b/docs/plans/workspace-git-status-scalability/plan.md
@@ -1,0 +1,143 @@
+---
+spec: docs/specs/platform/workspace-git-status.md
+created: 2026-07-19
+status: done
+---
+
+# Implementation Plan: Workspace Git Status Scalability
+
+## Overview
+
+First keep reusable verification caches shared and all verification storage outside Git worktrees, ignore legacy worktree-local cache paths, and reclaim each owned agent temp root during permanent instance teardown. Then make diff enrichment linear and context-aware while preserving complete changed-path metadata and all existing limits. Next coalesce overlapping live observations through the workspace tracker using Kandev's established detached, bounded singleflight pattern. Finish with HTTP-boundary concurrency and multi-repository regression coverage.
+
+The incident that motivated this work involved 13,869 untracked Go cache files. Diff enrichment repeatedly recomputed total diff bytes by scanning the complete file map inside per-file loops, producing quadratic work. Six concurrent fresh multi-repository requests then repeated that computation and held agentctl near full CPU for roughly three minutes.
+
+## Backend
+
+### Verification cache safeguard
+
+- Add `/.verify-cache/` and `/.tmp/` to the repository root `.gitignore` so legacy or misconfigured local verification runs cannot add thousands of cache entries to Git status.
+- Strengthen `.agents/skills/verify/SKILL.md` to preserve shared managed caches, isolate only invocation scratch, and keep every fallback outside the repository and all worktrees.
+- Keep the ignore pattern root-scoped; do not hide similarly named paths that a fixture or nested repository may intentionally track.
+- Verify the rule with `git check-ignore` and confirm the guidance still uses an external `mktemp` root.
+
+### Agent temp teardown
+
+- Track the exact session temp directory created by `ensureAgentTempEnv` on `process.Manager`.
+- After shell, VS Code, workspace, adapter, and agent process teardown completes for permanent
+  instance deletion, remove only that validated session directory. A later resume creates a new
+  instance and does not depend on prior scratch. Apply the same cleanup when teardown finds the main
+  agent already stopped so natural process exit cannot strand the directory.
+- Reject cleanup targets that are empty, equal to the shared `kandev-agent` root, or outside that
+  root. Preserve sibling session directories.
+- Return cleanup failures to the instance teardown caller and add deterministic tests using an
+  isolated test `TMPDIR`.
+
+### Linear and cancellable diff enrichment
+
+- Replace repeated `totalDiffBytes(update)` scans in the unstaged, staged, and untracked loops in `workspace_git_diff.go` with one request-local diff-budget accumulator initialized once and incremented whenever diff content is stored.
+- Preserve the existing 10 MiB source-file limit, 256 KiB per-file output limit, 2 MiB per-status limit, overshoot semantics, binary handling, and skip reasons.
+- Continue retaining every changed path after the total budget is exhausted. Avoid further file reads or diff synthesis for paths marked `budget_exceeded`.
+- Check `ctx.Err()` before each per-file filesystem or diff operation and propagate cancellation so callers cannot publish or cache a partial successful snapshot.
+- Add deterministic accumulator and cancellation tests. Use budget state plus structural review to guard the request-local accounting, and benchmark representative input sizes rather than asserting filesystem wall-clock thresholds in unit tests.
+
+### Coalesced live observations
+
+- Add a per-`WorkspaceTracker` `singleflight.Group`; `golang.org/x/sync/singleflight` is already used in the repository.
+- Route fresh reads, empty-cache fallback, and poll or explicit refresh computation through the same per-tracker flight so no live path bypasses the overlap guard.
+- Keep `updateMu` for the existing polling-skip versus explicit-refresh blocking policy. Only the expensive observation is shared.
+- Use `DoChan` and let each caller select on its own context. A cancelled caller exits promptly without cancelling work needed by other callers.
+- Run the shared body on a tracker-owned context with an independent deadline no greater than 60 seconds, matching the established detached-singleflight pattern in `internal/agent/handlers/git_handlers.go`. Root it in tracker lifetime so `WorkspaceTracker.Stop` cancels it.
+- Check and propagate the shared context error at observation phase boundaries. A cancelled or timed-out computation must not return, publish, or cache partial success.
+- Preserve cache ownership: a standalone fresh read does not update `currentStatus`; a poll that joins or initiates the shared observation may cache the completed result through its existing update path.
+
+### API regression coverage
+
+- Exercise concurrent `GET /api/v1/git/status/multi?fresh=true` requests against the same manager and tracker.
+- Assert one underlying observation per repository, shared capture data for overlapping callers, independent waiter cancellation, and repository-scoped results.
+- Retain partial success when one repository is invalid and other repositories succeed.
+- Prefer channel-synchronized Git shims or a focused unexported loader seam over elapsed-time assertions.
+
+## Frontend
+
+No frontend changes. Existing Git-status response shapes and Changes/Review rendering remain unchanged.
+
+## Tests
+
+- **What:** Diff budget accounting is constant-time per changed entry and preserves existing output and skip semantics.
+  **File:** `apps/backend/internal/agentctl/server/process/workspace_git_diff_test.go`
+  **How:** Test accumulator boundaries, content accounting, and behavior after budget exhaustion. Retain existing oversized, binary, truncated, and budget tests.
+- **What:** Cancellation stops untracked enrichment before remaining filesystem operations.
+  **File:** `apps/backend/internal/agentctl/server/process/workspace_git_diff_test.go`
+  **How:** Cancel a context at a deterministic operation boundary and assert no later files are opened or enriched.
+- **What:** Same-repository live observations coalesce without coupling caller cancellation.
+  **File:** `apps/backend/internal/agentctl/server/process/workspace_git_status_concurrency_test.go`
+  **How:** Coordinate callers with channels; assert one loader invocation and identical completed results, while one cancelled waiter exits independently.
+- **What:** Tracker shutdown or the shared deadline stops the underlying observation without updating the cache.
+  **File:** `apps/backend/internal/agentctl/server/process/workspace_git_status_concurrency_test.go`
+  **How:** Block at a controlled phase, cancel tracker lifetime or expire an injected deadline, and assert cancellation plus unchanged cached state.
+- **What:** Existing fresh-versus-cached semantics remain unchanged.
+  **File:** `apps/backend/internal/agentctl/server/process/workspace_git_status_test.go`
+  **How:** Keep `TestGetGitStatus_FreshBypassesStaleCache` passing and cover empty-cache fallback through the shared observation path.
+- **What:** Concurrent fresh HTTP requests preserve coalescing, repository identity, and partial success.
+  **File:** `apps/backend/internal/agentctl/server/api/git_status_fresh_concurrency_test.go`
+  **How:** Issue overlapping multi-repository requests through the handler and assert invocation counts and response entries rather than timing alone.
+- **What:** Large untracked-set enrichment scales linearly.
+  **File:** `apps/backend/internal/agentctl/server/process/workspace_git_diff_test.go`
+  **How:** Add a benchmark at representative 1,000- and 10,000-entry sizes, deterministic unit assertions for request-local budget accounting, and structurally verify no whole-map scan occurs inside a per-file loop. Do not impose a filesystem wall-clock threshold in unit tests.
+- **What:** Verification storage cannot appear as root-level Git-status entries and managed caches remain shared.
+  **Files:** `.gitignore`, `.agents/skills/verify/SKILL.md`
+  **How:** Assert `git check-ignore -q .verify-cache/go-cache/probe` and `git check-ignore -q .tmp/gocache/probe`, then inspect the verification skill for shared-cache preservation and external scratch requirements.
+- **What:** Permanent instance teardown removes only its owned agent temp directory after subprocess teardown.
+  **Files:** `apps/backend/internal/agentctl/server/process/manager.go`, `manager_temp_test.go`
+  **How:** Use an isolated temporary root; create session and sibling sentinels, stop an already-stopped manager and a normally stopping manager, and assert only the owned session directory is removed. Cover invalid/root targets and cleanup errors.
+
+## E2E Tests
+
+No browser E2E changes. The API payload and user-visible rendering are unchanged; focused process and handler tests cover the affected behavior.
+
+## Implementation Waves
+
+Wave 0:
+
+- [x] [task-00-verification-cache-safeguard](task-00-verification-cache-safeguard.md) - done
+
+Wave 1 (parallel):
+
+- [x] [task-01-linear-diff-enrichment](task-01-linear-diff-enrichment.md) - done
+- [x] [task-04-agent-temp-teardown](task-04-agent-temp-teardown.md) - done
+
+Wave 2 (depends on Wave 1):
+
+- [x] [task-02-coalesce-fresh-status](task-02-coalesce-fresh-status.md) - done
+
+Wave 3 (depends on Wave 2):
+
+- [x] [task-03-api-regression-verification](task-03-api-regression-verification.md) - done
+
+## Verification
+
+```bash
+rtk git check-ignore -q .verify-cache/go-cache/probe
+rtk git check-ignore -q .tmp/gocache/probe
+rtk go test ./internal/agentctl/server/process -run 'TestManager_.*Temp'
+rtk go test ./internal/agentctl/server/process -run 'Test(DiffBudget|EnrichUntrackedFileDiffs|GetGitStatus)'
+rtk go test ./internal/agentctl/server/api -run 'Test.*GitStatus.*Fresh'
+rtk go test -race ./internal/agentctl/server/process ./internal/agentctl/server/api
+rtk make -C apps/backend fmt
+rtk make -C apps/backend test
+rtk make -C apps/backend lint
+```
+
+Run the `go test` commands from `apps/backend`. Run formatting before the full test and lint commands.
+
+## Risks
+
+- The shared body cannot inherit the first caller's context; otherwise that caller can cancel results still needed by peers.
+- Detached work needs both tracker-lifetime cancellation and a bounded deadline so a timed-out HTTP caller cannot leave unbounded work behind.
+- Pollers and fresh readers share computation but retain different cache-write behavior. Coalescing must not make fresh reads cache owners.
+- Map iteration order determines which files receive the remaining diff budget today. The change must preserve semantics without claiming stable ordering.
+
+## Open Questions
+
+None.

--- a/docs/plans/workspace-git-status-scalability/task-00-verification-cache-safeguard.md
+++ b/docs/plans/workspace-git-status-scalability/task-00-verification-cache-safeguard.md
@@ -21,6 +21,8 @@ spec: "../../specs/platform/workspace-git-status.md"
 ```bash
 rtk git check-ignore -q .verify-cache/go-cache/probe
 rtk git check-ignore -q .tmp/gocache/probe
+! rtk git check-ignore -q nested/.verify-cache/probe
+! rtk git check-ignore -q nested/.tmp/probe
 rtk rg -n 'outside the repository|/\.verify-cache/' .agents/skills/verify/SKILL.md .gitignore
 ```
 

--- a/docs/plans/workspace-git-status-scalability/task-00-verification-cache-safeguard.md
+++ b/docs/plans/workspace-git-status-scalability/task-00-verification-cache-safeguard.md
@@ -1,0 +1,46 @@
+---
+id: "00-verification-cache-safeguard"
+title: "Verification cache safeguard"
+status: done
+wave: 0
+depends_on: []
+plan: "plan.md"
+spec: "../../specs/platform/workspace-git-status.md"
+---
+
+# Task 00: Verification cache safeguard
+
+## Acceptance
+
+- Root-level `.verify-cache` and `.tmp` are ignored without hiding similarly named nested fixture paths.
+- Verification guidance preserves shared Go and lint caches while requiring scratch and command output to live outside the repository and all Git worktrees.
+- The safeguard is documented in the Workspace Git Status capability spec.
+
+## Verification
+
+```bash
+rtk git check-ignore -q .verify-cache/go-cache/probe
+rtk git check-ignore -q .tmp/gocache/probe
+rtk rg -n 'outside the repository|/\.verify-cache/' .agents/skills/verify/SKILL.md .gitignore
+```
+
+## Files touched
+
+- `.gitignore`
+- `.agents/skills/verify/SKILL.md`
+- `docs/specs/platform/workspace-git-status.md`
+- `docs/plans/workspace-git-status-scalability/plan.md`
+
+## Dependencies
+
+None.
+
+## Inputs
+
+- Spec requirement that verification caches remain outside worktrees.
+- Existing disk-constrained verification guidance using an external `mktemp` scratch root.
+- The `.verify-cache` incident containing 13,869 untracked Go cache files.
+
+## Output contract
+
+Implemented directly as an incident safeguard. The root ignore rule and external-scratch guidance are present, shared caches remain reusable, their targeted checks pass, and no production API behavior changed.

--- a/docs/plans/workspace-git-status-scalability/task-01-linear-diff-enrichment.md
+++ b/docs/plans/workspace-git-status-scalability/task-01-linear-diff-enrichment.md
@@ -1,0 +1,44 @@
+---
+id: "01-linear-diff-enrichment"
+title: "Linear diff enrichment"
+status: done
+wave: 1
+depends_on: []
+plan: "plan.md"
+spec: "../../specs/platform/workspace-git-status.md"
+---
+
+# Task 01: Linear diff enrichment
+
+## Acceptance
+
+- One request-local accumulator tracks emitted diff bytes across unstaged, staged, and untracked enrichment without rescanning the complete files map inside per-file loops.
+- Every changed path remains in the result after total-budget exhaustion, and files not enriched retain `budget_exceeded`.
+- Per-file filesystem and diff work stops when the context is cancelled, returning cancellation rather than successful partial status.
+- Existing file-size, per-file output, total output, binary, truncation, overshoot, and carry-forward behavior remains unchanged.
+
+## Verification
+
+```bash
+cd apps/backend
+rtk go test ./internal/agentctl/server/process -run 'Test(DiffBudget|EnrichUntrackedFileDiffs|GetGitStatus)'
+rtk go test ./internal/agentctl/server/process -run '^$' -bench 'BenchmarkEnrichUntrackedFileDiffs' -benchmem
+```
+
+## Files likely touched
+
+- `apps/backend/internal/agentctl/server/process/workspace_git_diff.go`
+- `apps/backend/internal/agentctl/server/process/workspace_git_diff_test.go`
+
+## Dependencies
+
+None.
+
+## Inputs
+
+- Spec requirements for complete metadata, bounded diff content, linear enrichment, and prompt cancellation.
+- Existing diff-limit and skip-reason tests in `workspace_git_diff_test.go`.
+
+## Output contract
+
+Report the budget representation, cancellation checkpoints, benchmark or operation-count evidence, changed files, targeted test results, and remaining risks. Do not truncate the changed-path list or alter API payloads.

--- a/docs/plans/workspace-git-status-scalability/task-02-coalesce-fresh-status.md
+++ b/docs/plans/workspace-git-status-scalability/task-02-coalesce-fresh-status.md
@@ -1,0 +1,50 @@
+---
+id: "02-coalesce-fresh-status"
+title: "Coalesce live workspace status observations"
+status: done
+wave: 2
+depends_on:
+  - "01-linear-diff-enrichment"
+plan: "plan.md"
+spec: "../../specs/platform/workspace-git-status.md"
+---
+
+# Task 02: Coalesce live workspace status observations
+
+## Acceptance
+
+- Fresh reads, empty-cache fallback, polling, and explicit refresh share at most one underlying observation per workspace tracker.
+- Different workspace trackers may observe repositories in parallel.
+- Each caller can return on its own context cancellation without cancelling or poisoning other waiters.
+- The shared observation is rooted in tracker lifetime, has an independent bounded deadline, and stops when the tracker stops or the deadline expires.
+- Cancelled shared work returns no partial success and does not update cached status.
+- Fresh reads remain non-cache-owning; existing poll and explicit-refresh overlap policy remains intact.
+
+## Verification
+
+```bash
+cd apps/backend
+rtk go test ./internal/agentctl/server/process -run 'Test(GetGitStatus|WorkspaceTracker.*Concurrent|WorkspaceTracker.*Cancel)'
+rtk go test -race ./internal/agentctl/server/process
+```
+
+## Files likely touched
+
+- `apps/backend/internal/agentctl/server/process/workspace_tracker.go`
+- `apps/backend/internal/agentctl/server/process/workspace_git_status.go`
+- `apps/backend/internal/agentctl/server/process/workspace_git_status_test.go`
+- `apps/backend/internal/agentctl/server/process/workspace_git_status_concurrency_test.go`
+
+## Dependencies
+
+- `01-linear-diff-enrichment`
+
+## Inputs
+
+- Existing `updateMu` polling and explicit-refresh policy in `workspace_tracker.go`.
+- Existing detached `singleflight.DoChan` cancellation pattern in `apps/backend/internal/agent/handlers/git_handlers.go`.
+- Existing fresh-cache regression and workspace-overlap tests.
+
+## Output contract
+
+Report the shared-context lifetime and deadline, all observation entry points routed through the flight, cache-write ownership, deterministic concurrency test results, changed files, and remaining risks. Do not make the first caller's context own shared work.

--- a/docs/plans/workspace-git-status-scalability/task-03-api-regression-verification.md
+++ b/docs/plans/workspace-git-status-scalability/task-03-api-regression-verification.md
@@ -1,0 +1,51 @@
+---
+id: "03-api-regression-verification"
+title: "API regression verification"
+status: done
+wave: 3
+depends_on:
+  - "02-coalesce-fresh-status"
+plan: "plan.md"
+spec: "../../specs/platform/workspace-git-status.md"
+---
+
+# Task 03: API regression verification
+
+## Acceptance
+
+- Overlapping fresh multi-repository HTTP requests perform one underlying observation per repository and return consistent repository-scoped snapshots.
+- One cancelled HTTP waiter does not prevent peers from receiving the shared completed result.
+- An invalid repository remains a local failure while healthy repository entries succeed.
+- Focused race tests and the backend format, test, and lint suites pass.
+- No frontend, payload-shape, ignore-policy, or public-documentation changes are introduced.
+
+## Verification
+
+```bash
+cd apps/backend
+rtk go test ./internal/agentctl/server/api -run 'Test.*GitStatus.*Fresh'
+rtk go test -race ./internal/agentctl/server/process ./internal/agentctl/server/api
+cd ../../
+rtk make -C apps/backend fmt
+rtk make -C apps/backend test
+rtk make -C apps/backend lint
+```
+
+## Files likely touched
+
+- `apps/backend/internal/agentctl/server/api/git_status_fresh_concurrency_test.go`
+- Process-package files only if handler coverage exposes a correctness defect from Task 02.
+
+## Dependencies
+
+- `02-coalesce-fresh-status`
+
+## Inputs
+
+- Existing Git-status single and multi handlers and response types.
+- Existing multi-repository partial-success tests.
+- Task 02's deterministic observation-count seam or blocking Git shim.
+
+## Output contract
+
+Report handler scenarios, underlying observation counts, cancellation behavior, multi-repository results, race and full-suite verification, changed files, and remaining risks. Keep assertions synchronization-based rather than elapsed-time-based.

--- a/docs/plans/workspace-git-status-scalability/task-04-agent-temp-teardown.md
+++ b/docs/plans/workspace-git-status-scalability/task-04-agent-temp-teardown.md
@@ -1,0 +1,67 @@
+---
+id: "04-agent-temp-teardown"
+title: "Agent temp teardown"
+status: done
+wave: 1
+depends_on: []
+plan: "plan.md"
+spec: "../../specs/system-page/storage-maintenance.md"
+---
+
+# Task 04: Agent temp teardown
+
+## Acceptance
+
+- Agent instance teardown removes its exact collision-resistant `<system-temp>/kandev-agent/<readable-prefix>-<identity-digest>` directory only after owned subprocesses are stopped and reaped.
+- Cleanup also occurs when `Stop` observes an already-stopped main process, while sibling session directories and the shared agent-temp root remain intact.
+- Empty, root-equal, or out-of-root cleanup targets fail closed; cleanup errors are returned to the teardown caller.
+- Terminal teardown closes all process admission, joins VS Code startup generations, and verifies process-tree reaping before cleanup.
+- Failed HTTP or process-tree teardown retains the stopping instance and port for retry. A
+  temporary-directory-only failure retains a retry tombstone but releases the port, and a later
+  retry cannot release a port that has already been reassigned.
+
+## Verification
+
+```bash
+cd apps/backend
+rtk go test ./internal/agentctl/server/process -run 'TestManager_.*Temp'
+rtk go test -race ./internal/agentctl/server/process -run 'TestManager_.*Temp'
+rtk go test ./internal/agentctl/server/process -run 'TestProcessRunnerStopAllAndWait'
+rtk go test -race ./internal/agentctl/server/process -run 'TestProcessRunnerStopAllAndWait'
+rtk go test ./internal/agentctl/server/instance -run 'TestStopInstance.*(CleanupFailure|CloseFails)'
+rtk go test -race ./internal/agentctl/server/instance -run 'TestStopInstance.*(CleanupFailure|CloseFails)'
+```
+
+## Files likely touched
+
+- `apps/backend/internal/agentctl/server/process/manager.go`
+- `apps/backend/internal/agentctl/server/process/manager_temp_test.go`
+- `apps/backend/internal/agentctl/server/process/manager_test.go`
+- `apps/backend/internal/agentctl/server/process/runner.go`
+- `apps/backend/internal/agentctl/server/process/runner_test.go`
+- `apps/backend/internal/agentctl/server/process/vscode.go`
+- `apps/backend/internal/agentctl/server/process/vscode_test.go`
+- `apps/backend/internal/agentctl/server/process/manager_rescan.go`
+- `apps/backend/internal/agentctl/server/api/vscode_handlers.go`
+- `apps/backend/internal/agentctl/server/shell/manager.go`
+- `apps/backend/internal/agentctl/server/shell/session.go`
+- `apps/backend/internal/agentctl/server/shell/process_group_unix.go`
+- `apps/backend/internal/agentctl/server/shell/process_group_windows.go`
+- `apps/backend/internal/agentctl/server/shell/session_stop_unix_test.go`
+- `apps/backend/internal/agentctl/server/instance/instance.go`
+- `apps/backend/internal/agentctl/server/instance/manager.go`
+- `apps/backend/internal/agentctl/server/instance/manager_shutdown_test.go`
+
+## Dependencies
+
+None.
+
+## Inputs
+
+- Agent-session temporary-data requirements in `docs/specs/system-page/storage-maintenance.md`.
+- ADR 0045's lifecycle-owned ephemeral-resource amendment.
+- Existing `ensureAgentTempEnv`, `Manager.Stop`, and process-group teardown order.
+
+## Output contract
+
+Report the stored ownership path, containment validation, teardown ordering, already-stopped behavior, cleanup error propagation, changed files, and targeted race-test results. Do not delete the shared temp root, sibling sessions, or any path derived solely from mutable child environment variables.

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -38,6 +38,7 @@ Product-wide capabilities that are not tied to a single feature area.
 |---|---|
 | [plugins](plugins/spec.md) | draft |
 | [plugins — marketplace](plugins/marketplace.md) | building |
+| [workspace-git-status](platform/workspace-git-status.md) | shipped |
 
 ## tasks/ — task & workflow model
 

--- a/docs/specs/platform/workspace-git-status.md
+++ b/docs/specs/platform/workspace-git-status.md
@@ -1,0 +1,65 @@
+---
+status: shipped
+created: 2026-07-19
+owner: kandev
+---
+
+# Workspace Git Status
+
+## Why
+
+Users opening or focusing Changes and Review need a current workspace snapshot without a large generated or untracked tree monopolizing agentctl. Repeated requests for the same repository must not amplify expensive Git and filesystem work, and the initial session-hydration path must remain within its two-second live-status budget by falling back when necessary.
+
+## What
+
+- Cached reads return the latest workspace-tracker snapshot. When no cached snapshot exists, the tracker performs a live observation.
+- Fresh reads observe the live worktree and do not themselves replace the polling cache.
+- Overlapping live observations for the same repository share one underlying observation. Different repositories in a multi-repository task may still be observed in parallel.
+- Every non-cancelled caller receives the same completed snapshot or error from a shared observation. A caller whose own context is cancelled returns promptly without cancelling or otherwise poisoning the result for other callers.
+- Tracker shutdown or the bounded shared-observation deadline cancels the underlying work. Cancelled work does not publish or cache a partial snapshot.
+- After Git output is parsed, changed-file and synthetic untracked-diff enrichment performs work proportional to the number of changed entries plus the bounded content processed.
+- Existing diff limits remain in force: 10 MiB maximum source file size, 256 KiB maximum emitted diff per file, and a 2 MiB enrichment threshold per status snapshot. Because the threshold is checked before enriching each file, the final accepted file may preserve the existing overshoot of up to the 256 KiB per-file cap. Existing skip reasons remain unchanged.
+- Large changed sets retain every path and its status metadata. Once the total diff budget is exhausted, files that are not enriched retain `budget_exceeded` as their diff skip reason.
+- Multi-repository responses retain repository identity and partial-success behavior.
+- Verification tooling preserves shared managed Go and lint caches for reuse while keeping invocation scratch and command output outside repository worktrees. The root-level `.verify-cache` and `.tmp` paths are ignored as safeguards against legacy or misconfigured verification runs.
+
+## API surface
+
+No route or payload shape changes.
+
+- `GET /api/v1/git/status?repo=<subpath>&fresh=<bool>` returns the existing `GitStatusResult` shape.
+- `GET /api/v1/git/status/multi?fresh=<bool>` returns the existing `MultiRepoGitStatusResult` shape containing `PerRepoGitStatus` entries.
+- The `fresh` query parameter continues to select a live observation rather than a cached tracker snapshot.
+
+## Failure modes
+
+| Scenario | Observable behavior |
+|---|---|
+| Primary branch or porcelain observation fails | The live observation fails and the prior cached snapshot remains available. |
+| Secondary diff enrichment fails | The established same-HEAD carry-forward behavior is preserved. |
+| One caller cancels while a shared observation is running | That caller returns its context cancellation promptly; other callers remain eligible to receive the shared result. |
+| The tracker stops or the shared deadline expires | Underlying work is cancelled and no partial result is published or cached. |
+| One repository fails during a multi-repository request | Successful repository entries remain available and the failure is reported on its repository entry. |
+
+## Scenarios
+
+- **GIVEN** a stale cached snapshot after a commit, **WHEN** a caller requests `fresh=true`, **THEN** the response reflects the live clean tree and a later cached read still returns the prior cached snapshot.
+- **GIVEN** six simultaneous fresh requests for one repository, **WHEN** their observations overlap, **THEN** exactly one underlying status observation runs and all non-cancelled callers receive the same capture timestamp and result.
+- **GIVEN** simultaneous fresh requests for two repositories, **WHEN** multi-repository status runs, **THEN** one observation per repository may run in parallel and each response remains identified with its repository.
+- **GIVEN** one waiter cancels during a shared observation, **WHEN** other waiters remain, **THEN** the cancelled waiter returns promptly and the remaining waiters receive the completed result.
+- **GIVEN** tracker shutdown or the shared-observation deadline while enrichment is running, **WHEN** cancellation reaches the observation, **THEN** filesystem iteration stops and no partial snapshot is cached.
+- **GIVEN** approximately 15,000 untracked text files, **WHEN** fresh status is computed, **THEN** every path is present, emitted diff content obeys the existing limits, files not enriched after total-budget exhaustion have `budget_exceeded`, and post-porcelain enrichment remains linear in the number of entries.
+- **GIVEN** one invalid repository in a multi-repository request, **WHEN** other repositories succeed, **THEN** the response retains the successful entries and reports the failure only on the invalid repository.
+- **GIVEN** verification needs writable scratch space, **WHEN** it selects a location, **THEN** the location is outside every Git worktree and existing shared caches remain reusable; if a legacy run creates root-level `.verify-cache` or `.tmp`, Git status ignores it.
+
+## Out of scope
+
+- Changing Git-status API routes, response shapes, or frontend rendering.
+- Raising or removing existing diff-content limits.
+- Changing multi-repository fan-out behavior.
+- Making fresh reads owners of the polling cache.
+- Replacing Git subprocesses with a native Git implementation.
+
+## Implementation plan
+
+See [Workspace Git Status Scalability plan](../../plans/workspace-git-status-scalability/plan.md).

--- a/docs/specs/system-page/storage-maintenance.md
+++ b/docs/specs/system-page/storage-maintenance.md
@@ -138,6 +138,29 @@ Decision: [ADR-2026-07-19-workspace-symlink-entries](../../decisions/2026-07-19-
   previously managed cache. Scheduled cleanup and a global manual run with no resource selection
   leave it untouched; only a manual run whose non-empty selection includes `go_cache` may rotate it.
 
+### Agent session temporary data
+
+- Each agent instance receives an isolated operating-system temporary directory at
+  `<system-temp>/kandev-agent/<readable-prefix>-<identity-digest>` through `TMPDIR`, `TMP`, and
+  `TEMP`. The deterministic name includes the raw session ID, instance ID, and port so distinct
+  instance identities cannot collide after unsafe characters are sanitized.
+- The directory is owned by that agent instance and remains available while its agent, shell,
+  VS Code, or workspace subprocesses may still be running.
+- Instance teardown first closes every process-start admission path, including requests already in
+  flight, then removes the owned session directory only after each process leader and its owned
+  process tree are reaped. On Unix this includes verified process-group disappearance; Windows uses
+  the executor's existing process-tree termination primitive.
+  Teardown validates that the target is a non-root child of the Kandev agent-temp root and never
+  removes the shared root or a sibling session directory.
+- Cleanup runs whenever the owning agentctl instance is permanently deleted, including task/session
+  archive and delete stops and when teardown observes that the main agent process has already
+  stopped. A later resume creates a new instance and does not depend on the prior instance's scratch
+  files. A cleanup failure is reported without broadening deletion to another path. The instance
+  and port remain reserved only when HTTP shutdown or process reaping is unresolved; a
+  temporary-directory-only failure retains a retry tombstone but releases the execution port.
+- Session temporary data is ephemeral and is not quarantined, restored, or included in task
+  recovery. See [ADR 0045](../../decisions/0045-install-wide-storage-maintenance.md).
+
 ### Docker storage
 
 - Kandev-owned container cleanup lists only containers labeled `kandev.managed=true`. It removes


### PR DESCRIPTION
Large generated worktrees made fresh Git status requests perform quadratic diff accounting and repeat the same expensive observation for concurrent callers. Git status enrichment is now linear and coalesced, while agent scratch cleanup prevents temporary data from accumulating outside the workspace.

## Important Changes

- Track diff-budget consumption incrementally and stop enrichment promptly on cancellation.
- Coalesce overlapping live observations per repository without coupling caller cancellation or changing cache ownership.
- Keep reusable Go and lint caches shared outside worktrees while isolating and reclaiming per-instance scratch data.
- Quiesce process admission and reap agent, shell, VS Code, and workspace process trees before deleting owned temp roots on Unix and Windows.
- Retain instance ports only while HTTP or process ownership is unresolved; temp-only cleanup failures keep a retry tombstone without reserving the port.

## Validation

- `make fmt`
- `node apps/web/scripts/generate-release-notes.mjs`
- `node apps/web/scripts/generate-changelog.mjs`
- `make typecheck`
- `make test`
- `make lint`
- `go test -race ./internal/agentctl/server/process ./internal/agentctl/server/instance ./internal/agentctl/server/api`
- `node --test scripts/validate-public-docs.test.mjs`
- `node scripts/validate-public-docs.mjs`
- `git check-ignore -v .verify-cache/go-cache/probe .tmp/gocache/probe`

## Possible Improvements

Low risk: orphaned temp roots from abrupt host termination still rely on operating-system temp maintenance rather than a durable storage-provider sweep.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1814?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->