### PR TITLE
chore(plugin-registry): add kandev-session-cost

### DIFF
--- a/plugin-registry/plugins.yaml
+++ b/plugin-registry/plugins.yaml
@@ -22,7 +22,10 @@
 # Entries are added by PR as plugins are published (see the template below).
 # An empty list builds a valid, empty index.json; the marketplace shows an
 # "no plugins yet" state until the first entry lands.
-plugins: []
+plugins:
+  - id: kandev-session-cost
+    repo: kdlbs/kandev-plugin-session-cost
+    categories: [analytics]
 # Example entry (copy, uncomment, and fill in when adding a plugin):
 #
 # plugins:


### PR DESCRIPTION
## Add `kandev-session-cost` to the official plugin registry

Adds one pointer entry to `plugin-registry/plugins.yaml` for the **Session Cost** plugin.

- **Plugin repo:** https://github.com/kdlbs/kandev-plugin-session-cost
- **Manifest id:** `kandev-session-cost` (matches the `id` in `plugins.yaml`)
- **Release:** [`v0.1.0`](https://github.com/kdlbs/kandev-plugin-session-cost/releases/tag/v0.1.0) — publishes `kandev-session-cost-0.1.0.tar.gz` (all 5 platforms) + `checksums.txt`, built by the repo's own release workflow.
- **Category:** `analytics`

### What the plugin does

Adds a coins icon to the chat composer toolbar (`chat-input-actions` slot) that shows the current session's spend on hover: colour-coded total (green/amber/red by configurable USD thresholds), **server-computed cost-per-turn**, token totals, and a per-model breakdown. The backend resolves the kandev session id → ACP transcript id via the Host data API (`api_read: ["sessions"]`) and reads spend from the [tokscale](https://github.com/junhoyeo/tokscale) CLI; a missing CLI degrades to setup guidance instead of erroring.

This is the first entry in the (previously empty) official catalog.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1815?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->