### PR TITLE
fix(plugins): serialize empty sync-result arrays instead of null

### DIFF
--- a/apps/backend/internal/plugins/service_sync.go
+++ b/apps/backend/internal/plugins/service_sync.go
@@ -58,47 +58,35 @@ func (s *Service) sync(ctx context.Context, includeTarballs bool) *SyncResult {
 	s.syncMu.Lock()
 	defer s.syncMu.Unlock()
 
-	result := &SyncResult{}
+	// Slices start non-nil: encoding/json marshals a nil slice as JSON null,
+	// but SyncResult's fields are typed as non-nullable arrays on the
+	// frontend (apps/web/lib/types/plugins.ts) — a null there crashes
+	// summarizeSyncResult's unconditional `.length` reads. append()-ing a
+	// possibly-nil result onto these keeps them non-nil.
+	result := &SyncResult{
+		Added:     []string{},
+		Installed: []string{},
+		Missing:   []string{},
+		Errors:    []SyncError{},
+	}
 	if s.pluginsDir == "" {
-		normalizeSyncResult(result)
 		return result
 	}
 
 	added, sideloadErrs := s.scanDirSideloads()
-	result.Added = added
+	result.Added = append(result.Added, added...)
 	result.Errors = append(result.Errors, sideloadErrs...)
 
 	if includeTarballs {
 		installed, tarballErrs := s.scanTarballs(ctx)
-		result.Installed = installed
+		result.Installed = append(result.Installed, installed...)
 		result.Errors = append(result.Errors, tarballErrs...)
 	}
 
-	result.Missing = s.scanMissingInstalls()
+	result.Missing = append(result.Missing, s.scanMissingInstalls()...)
 
 	s.notifyDeliverer()
-	normalizeSyncResult(result)
 	return result
-}
-
-// normalizeSyncResult replaces any nil slice field with an empty slice.
-// encoding/json marshals a nil slice as JSON null, but SyncResult's fields
-// are typed as non-nullable arrays on the frontend
-// (apps/web/lib/types/plugins.ts) — a null there crashes
-// summarizeSyncResult's unconditional `.length` reads.
-func normalizeSyncResult(result *SyncResult) {
-	if result.Added == nil {
-		result.Added = []string{}
-	}
-	if result.Installed == nil {
-		result.Installed = []string{}
-	}
-	if result.Missing == nil {
-		result.Missing = []string{}
-	}
-	if result.Errors == nil {
-		result.Errors = []SyncError{}
-	}
 }
 
 // scanDirSideloads finds every <pluginsDir>/<id>/<version>/manifest.yaml

--- a/apps/backend/internal/plugins/service_sync.go
+++ b/apps/backend/internal/plugins/service_sync.go
@@ -60,6 +60,7 @@ func (s *Service) sync(ctx context.Context, includeTarballs bool) *SyncResult {
 
 	result := &SyncResult{}
 	if s.pluginsDir == "" {
+		normalizeSyncResult(result)
 		return result
 	}
 
@@ -76,7 +77,28 @@ func (s *Service) sync(ctx context.Context, includeTarballs bool) *SyncResult {
 	result.Missing = s.scanMissingInstalls()
 
 	s.notifyDeliverer()
+	normalizeSyncResult(result)
 	return result
+}
+
+// normalizeSyncResult replaces any nil slice field with an empty slice.
+// encoding/json marshals a nil slice as JSON null, but SyncResult's fields
+// are typed as non-nullable arrays on the frontend
+// (apps/web/lib/types/plugins.ts) — a null there crashes
+// summarizeSyncResult's unconditional `.length` reads.
+func normalizeSyncResult(result *SyncResult) {
+	if result.Added == nil {
+		result.Added = []string{}
+	}
+	if result.Installed == nil {
+		result.Installed = []string{}
+	}
+	if result.Missing == nil {
+		result.Missing = []string{}
+	}
+	if result.Errors == nil {
+		result.Errors = []SyncError{}
+	}
 }
 
 // scanDirSideloads finds every <pluginsDir>/<id>/<version>/manifest.yaml

--- a/apps/backend/internal/plugins/service_sync_test.go
+++ b/apps/backend/internal/plugins/service_sync_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	goruntime "runtime"
-	"strings"
 	"testing"
 	"time"
 )
@@ -274,8 +273,14 @@ func TestServiceSync_EmptyResultSerializesEmptyArraysNotNull(t *testing.T) {
 	if err != nil {
 		t.Fatalf("json.Marshal: %v", err)
 	}
-	if strings.Contains(string(data), "null") {
-		t.Fatalf("Sync() JSON contains null, want empty arrays: %s", data)
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	for _, key := range []string{"added", "installed", "missing", "errors"} {
+		if raw, ok := fields[key]; !ok || string(raw) == "null" {
+			t.Fatalf("Sync() JSON field %q = %s, want an empty array: %s", key, raw, data)
+		}
 	}
 }
 

--- a/apps/backend/internal/plugins/service_sync_test.go
+++ b/apps/backend/internal/plugins/service_sync_test.go
@@ -2,9 +2,11 @@ package plugins
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	goruntime "runtime"
+	"strings"
 	"testing"
 	"time"
 )
@@ -247,6 +249,33 @@ func TestServiceSync_MissingInstallAlreadyErrorIsIdempotent(t *testing.T) {
 	}
 	if got.Status != StatusError {
 		t.Fatalf("Status after second Sync() = %q, want %q", got.Status, StatusError)
+	}
+}
+
+// TestServiceSync_EmptyResultSerializesEmptyArraysNotNull proves that a
+// no-op Sync (nothing added/installed/missing/errored) round-trips through
+// JSON as `[]`, not `null`. The frontend's SyncResult type
+// (apps/web/lib/types/plugins.ts) declares these fields as non-nullable
+// arrays and reads result.added.length unconditionally
+// (apps/web/lib/plugins/sync-summary.ts) — a `null` there throws
+// "can't access property 'length', e.added is null".
+func TestServiceSync_EmptyResultSerializesEmptyArraysNotNull(t *testing.T) {
+	svc, _, _ := newTestService(t)
+
+	result, err := svc.Sync(context.Background())
+	if err != nil {
+		t.Fatalf("Sync() unexpected error: %v", err)
+	}
+	if result.Added == nil || result.Installed == nil || result.Missing == nil || result.Errors == nil {
+		t.Fatalf("Sync() left a nil slice field: %+v", result)
+	}
+
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	if strings.Contains(string(data), "null") {
+		t.Fatalf("Sync() JSON contains null, want empty arrays: %s", data)
 	}
 }
 


### PR DESCRIPTION
## Summary
- `POST /api/plugins/sync` returned `null` instead of `[]` for `added`/`installed`/`missing`/`errors` whenever a category was empty, because Go's `encoding/json` marshals a nil slice as `null` and `Sync()` only appends to these slices, leaving them nil when nothing changed.
- The frontend's `SyncResult` type declares these fields as non-nullable arrays, and `summarizeSyncResult()` reads `result.added.length` unconditionally — so a routine "everything up to date" sync crashed the Plugins settings page with `can't access property "length", e.added is null`.
- `Sync()`/`bootScan()` now normalize any nil slice field to an empty array before returning.

## Test plan
- [x] `go test ./internal/plugins/...` — added `TestServiceSync_EmptyResultSerializesEmptyArraysNotNull`, which JSON-marshals a no-op sync result and asserts it contains no `null`
- [x] `go build ./...` and `gofmt -l` clean on changed files

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1817?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->