### PR TITLE
fix(web): refresh walkthrough ranges on Monaco model changes

### DIFF
--- a/apps/backend/cmd/mock-agent/scenarios.go
+++ b/apps/backend/cmd/mock-agent/scenarios.go
@@ -856,7 +856,7 @@ func walkthroughDemoArgs() map[string]interface{} {
 			wtStep("The change in A", "walkthrough_a.txt",
 				"Step 2: this is WALKTHROUGH_CHANGE_A the tour narrates.", 2, 3),
 			wtStep("File B", "walkthrough_b.txt",
-				"Step 3: WALKTHROUGH_CHANGE_B lives in file B.", 2, 0),
+				"Step 3: WALKTHROUGH_CHANGE_B lives in file B.", 4, 5),
 			wtStep("File C", "walkthrough_c.txt",
 				"Step 4: WALKTHROUGH_CHANGE_C lives in file C.", 2, 0),
 			wtStep("Unchanged file", "walkthrough_base.txt",
@@ -907,7 +907,8 @@ func setupWalkthroughFiles(e *emitter, prefix string) bool {
 		"line 1: ENTRY\nline 2: BASE\nline 3: BASE\n",
 		"line 1: ENTRY\nline 2: WALKTHROUGH_CHANGE_A\nline 3: WALKTHROUGH_CHANGE_A\n")
 	ok = ok && writeWalkthroughFile(e, runGitCmd, prefix, "walkthrough_b.txt",
-		"line 1: B\nline 2: BASE\n", "line 1: B\nline 2: WALKTHROUGH_CHANGE_B\n")
+		"line 1: B\nline 2: BASE\nline 3: BASE\nline 4: BASE\nline 5: BASE\n",
+		"line 1: B\nline 2: BASE\nline 3: BASE\nline 4: WALKTHROUGH_CHANGE_B\nline 5: WALKTHROUGH_CHANGE_B\n")
 	ok = ok && writeWalkthroughFile(e, runGitCmd, prefix, "walkthrough_c.txt",
 		"line 1: C\nline 2: BASE\n", "line 1: C\nline 2: WALKTHROUGH_CHANGE_C\n")
 	ok = ok && writeWalkthroughFile(e, runGitCmd, prefix, "walkthrough_base.txt",

--- a/apps/backend/internal/orchestrator/executor/executor_mocks_test.go
+++ b/apps/backend/internal/orchestrator/executor/executor_mocks_test.go
@@ -2,6 +2,7 @@ package executor
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sync"
 	"testing"
@@ -410,7 +411,41 @@ func cloneMockTaskSession(session *models.TaskSession) *models.TaskSession {
 		return nil
 	}
 	clone := *session
+	clone.Metadata = cloneMockSessionMap(session.Metadata)
+	clone.AgentProfileSnapshot = cloneMockSessionMap(session.AgentProfileSnapshot)
+	clone.ExecutorSnapshot = cloneMockSessionMap(session.ExecutorSnapshot)
+	clone.EnvironmentSnapshot = cloneMockSessionMap(session.EnvironmentSnapshot)
+	clone.RepositorySnapshot = cloneMockSessionMap(session.RepositorySnapshot)
+	if session.Worktrees != nil {
+		clone.Worktrees = make([]*models.TaskSessionWorktree, len(session.Worktrees))
+		for i, worktree := range session.Worktrees {
+			if worktree == nil {
+				continue
+			}
+			worktreeClone := *worktree
+			clone.Worktrees[i] = &worktreeClone
+		}
+	}
+	if session.CompletedAt != nil {
+		completedAt := *session.CompletedAt
+		clone.CompletedAt = &completedAt
+	}
 	return &clone
+}
+
+func cloneMockSessionMap(values map[string]interface{}) map[string]interface{} {
+	if values == nil {
+		return nil
+	}
+	encoded, err := json.Marshal(values)
+	if err != nil {
+		panic(fmt.Sprintf("marshal mock task session map: %v", err))
+	}
+	var clone map[string]interface{}
+	if err := json.Unmarshal(encoded, &clone); err != nil {
+		panic(fmt.Sprintf("unmarshal mock task session map: %v", err))
+	}
+	return clone
 }
 
 func (m *mockRepository) UpdateTaskSessionAgentProfileSnapshot(

--- a/apps/backend/internal/orchestrator/executor/executor_mocks_test.go
+++ b/apps/backend/internal/orchestrator/executor/executor_mocks_test.go
@@ -371,7 +371,9 @@ func (m *mockRepository) GetTaskSession(ctx context.Context, id string) (*models
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if session, ok := m.sessions[id]; ok {
-		return session, nil
+		// SQLite scans each query into a fresh value. Match that ownership
+		// boundary so concurrent executor paths cannot share mutable rows.
+		return cloneMockTaskSession(session), nil
 	}
 	return nil, nil
 }
@@ -401,6 +403,14 @@ func (m *mockRepository) UpdateTaskSessionIfCurrentState(
 	m.updateTaskSessionCalls = append(m.updateTaskSessionCalls, session)
 	m.sessions[session.ID] = session
 	return true, nil
+}
+
+func cloneMockTaskSession(session *models.TaskSession) *models.TaskSession {
+	if session == nil {
+		return nil
+	}
+	clone := *session
+	return &clone
 }
 
 func (m *mockRepository) UpdateTaskSessionAgentProfileSnapshot(

--- a/apps/backend/internal/orchestrator/executor/executor_test.go
+++ b/apps/backend/internal/orchestrator/executor/executor_test.go
@@ -335,8 +335,12 @@ func TestLaunchPreparedSession_Success(t *testing.T) {
 	if execution.SessionState != v1.TaskSessionStateStarting {
 		t.Errorf("Expected session state STARTING, got %s", execution.SessionState)
 	}
-	if session.TaskEnvironmentID != launchedEnvID {
-		t.Errorf("Expected session TaskEnvironmentID %q, got %q", launchedEnvID, session.TaskEnvironmentID)
+	storedSession, err := repo.GetTaskSession(context.Background(), session.ID)
+	if err != nil {
+		t.Fatalf("GetTaskSession failed: %v", err)
+	}
+	if storedSession.TaskEnvironmentID != launchedEnvID {
+		t.Errorf("Expected session TaskEnvironmentID %q, got %q", launchedEnvID, storedSession.TaskEnvironmentID)
 	}
 	if len(repo.createTaskEnvironmentCalls) != 1 {
 		t.Fatalf("Expected 1 CreateTaskEnvironment call, got %d", len(repo.createTaskEnvironmentCalls))

--- a/apps/backend/internal/orchestrator/executor/executor_test.go
+++ b/apps/backend/internal/orchestrator/executor/executor_test.go
@@ -65,6 +65,70 @@ func TestResumeTokenForExecutionProfile(t *testing.T) {
 	}
 }
 
+func TestMockRepositoryGetTaskSessionReturnsDetachedMutableFields(t *testing.T) {
+	completedAt := time.Now().UTC()
+	wantCompletedAt := completedAt
+	newSnapshot := func() map[string]interface{} {
+		return map[string]interface{}{
+			"top":    "original",
+			"nested": map[string]interface{}{"value": "original"},
+		}
+	}
+	session := &models.TaskSession{
+		ID:                   "session-snapshot",
+		Metadata:             newSnapshot(),
+		AgentProfileSnapshot: newSnapshot(),
+		ExecutorSnapshot:     newSnapshot(),
+		EnvironmentSnapshot:  newSnapshot(),
+		RepositorySnapshot:   newSnapshot(),
+		Worktrees: []*models.TaskSessionWorktree{
+			{ID: "worktree-1", WorktreePath: "/original"},
+			nil,
+		},
+		CompletedAt: &completedAt,
+	}
+	repo := newMockRepository()
+	repo.sessions[session.ID] = session
+
+	snapshot, err := repo.GetTaskSession(context.Background(), session.ID)
+	if err != nil {
+		t.Fatalf("GetTaskSession failed: %v", err)
+	}
+	for _, values := range []map[string]interface{}{
+		snapshot.Metadata,
+		snapshot.AgentProfileSnapshot,
+		snapshot.ExecutorSnapshot,
+		snapshot.EnvironmentSnapshot,
+		snapshot.RepositorySnapshot,
+	} {
+		values["top"] = "changed"
+		values["nested"].(map[string]interface{})["value"] = "changed"
+	}
+	snapshot.Worktrees[0].WorktreePath = "/changed"
+	*snapshot.CompletedAt = wantCompletedAt.Add(time.Hour)
+
+	for name, values := range map[string]map[string]interface{}{
+		"metadata":      session.Metadata,
+		"agent profile": session.AgentProfileSnapshot,
+		"executor":      session.ExecutorSnapshot,
+		"environment":   session.EnvironmentSnapshot,
+		"repository":    session.RepositorySnapshot,
+	} {
+		if values["top"] != "original" {
+			t.Errorf("%s snapshot top-level value changed: %#v", name, values)
+		}
+		if values["nested"].(map[string]interface{})["value"] != "original" {
+			t.Errorf("%s snapshot nested value changed: %#v", name, values)
+		}
+	}
+	if session.Worktrees[0].WorktreePath != "/original" {
+		t.Errorf("stored worktree path = %q, want /original", session.Worktrees[0].WorktreePath)
+	}
+	if !session.CompletedAt.Equal(wantCompletedAt) {
+		t.Errorf("stored completed time = %s, want %s", session.CompletedAt, wantCompletedAt)
+	}
+}
+
 func TestPrepareSession_Success(t *testing.T) {
 	repo := newMockRepository()
 	agentManager := &mockAgentManager{}

--- a/apps/web/components/editors/monaco/use-monaco-walkthrough-range.test.ts
+++ b/apps/web/components/editors/monaco/use-monaco-walkthrough-range.test.ts
@@ -1,9 +1,98 @@
-import { describe, expect, it } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import type { editor as monacoEditor } from "monaco-editor";
+import { describe, expect, it, vi } from "vitest";
+
+const hookState = vi.hoisted(() => ({
+  tasks: { activeTaskId: "task-1" },
+  walkthroughs: {
+    activeStepByTaskId: { "task-1": 0 },
+    byTaskId: {
+      "task-1": {
+        steps: [
+          {
+            file: "walkthrough_a.txt",
+            line: 2,
+            line_end: 3,
+            text: "Explain this range",
+          },
+        ],
+      },
+    },
+  },
+}));
+
+vi.mock("@/components/state-provider", () => ({
+  useAppStore: (selector: (state: typeof hookState) => unknown) => selector(hookState),
+}));
+
+vi.mock("@/lib/walkthrough-open-state", () => ({
+  useIsWalkthroughOpenForTask: () => true,
+}));
+
+const WALKTHROUGH_FILE = "walkthrough_a.txt";
+
 import {
   buildWalkthroughRangeDecorations,
   clampWalkthroughRangeToLineCount,
   getWalkthroughEditorRange,
+  useMonacoWalkthroughRange,
 } from "./use-monaco-walkthrough-range";
+
+function createModelSwitchingEditor(initialLineCount: number) {
+  let lineCount = initialLineCount;
+  let modelRevision = 0;
+  let model = { id: "model-0", getLineCount: () => lineCount };
+  const contentListeners = new Set<() => void>();
+  const modelListeners = new Set<() => void>();
+  const setDecorations = vi.fn();
+  const revealLinesInCenter = vi.fn();
+  const editor = {
+    createDecorationsCollection: () => ({ set: setDecorations }),
+    getModel: () => model,
+    onDidChangeModel: (listener: () => void) => {
+      modelListeners.add(listener);
+      return {
+        dispose: () => {
+          modelListeners.delete(listener);
+        },
+      };
+    },
+    onDidChangeModelContent: (listener: () => void) => {
+      contentListeners.add(listener);
+      return {
+        dispose: () => {
+          contentListeners.delete(listener);
+        },
+      };
+    },
+    revealLinesInCenter,
+  } as unknown as monacoEditor.IStandaloneCodeEditor;
+
+  return {
+    editor,
+    revealLinesInCenter,
+    setDecorations,
+    decoratedLines() {
+      const decorations = setDecorations.mock.lastCall?.[0] ?? [];
+      return decorations.map(
+        (decoration: monacoEditor.IModelDeltaDecoration) => decoration.range.startLineNumber,
+      );
+    },
+    listenerCounts() {
+      return { content: contentListeners.size, model: modelListeners.size };
+    },
+    changeLineCount(nextLineCount: number) {
+      lineCount = nextLineCount;
+      for (const listener of contentListeners) listener();
+    },
+    switchModel(nextLineCount: number) {
+      lineCount = nextLineCount;
+      modelRevision += 1;
+      model = { id: `model-${modelRevision}`, getLineCount: () => lineCount };
+      for (const listener of modelListeners) listener();
+    },
+  };
+}
 
 describe("getWalkthroughEditorRange", () => {
   it("returns the active walkthrough range for a matching editor file", () => {
@@ -42,5 +131,72 @@ describe("clampWalkthroughRangeToLineCount", () => {
       startLine: 12,
       endLine: 12,
     });
+  });
+});
+
+describe("useMonacoWalkthroughRange", () => {
+  it("reclamps the active range after Monaco switches models", () => {
+    const fake = createModelSwitchingEditor(2);
+    renderHook(() =>
+      useMonacoWalkthroughRange({
+        editor: fake.editor,
+        editorAreaRef: { current: null },
+        path: WALKTHROUGH_FILE,
+      }),
+    );
+    expect(fake.decoratedLines()).toEqual([2]);
+
+    act(() => fake.switchModel(3));
+
+    expect(fake.decoratedLines()).toEqual([2, 3]);
+    expect(fake.revealLinesInCenter).toHaveBeenLastCalledWith(2, 3);
+  });
+
+  it("reclamps when the current Monaco model line count changes", () => {
+    const fake = createModelSwitchingEditor(3);
+    renderHook(() =>
+      useMonacoWalkthroughRange({
+        editor: fake.editor,
+        editorAreaRef: { current: null },
+        path: WALKTHROUGH_FILE,
+      }),
+    );
+
+    act(() => fake.changeLineCount(2));
+
+    expect(fake.decoratedLines()).toEqual([2]);
+    expect(fake.revealLinesInCenter).toHaveBeenLastCalledWith(2, 2);
+  });
+
+  it("reapplies the range after switching to a model with the same line count", () => {
+    const fake = createModelSwitchingEditor(3);
+    renderHook(() =>
+      useMonacoWalkthroughRange({
+        editor: fake.editor,
+        editorAreaRef: { current: null },
+        path: WALKTHROUGH_FILE,
+      }),
+    );
+    fake.setDecorations.mockClear();
+
+    act(() => fake.switchModel(3));
+
+    expect(fake.decoratedLines()).toEqual([2, 3]);
+  });
+
+  it("unsubscribes from Monaco model events on unmount", () => {
+    const fake = createModelSwitchingEditor(3);
+    const { unmount } = renderHook(() =>
+      useMonacoWalkthroughRange({
+        editor: fake.editor,
+        editorAreaRef: { current: null },
+        path: WALKTHROUGH_FILE,
+      }),
+    );
+    expect(fake.listenerCounts()).toEqual({ content: 1, model: 1 });
+
+    unmount();
+
+    expect(fake.listenerCounts()).toEqual({ content: 0, model: 0 });
   });
 });

--- a/apps/web/components/editors/monaco/use-monaco-walkthrough-range.test.ts
+++ b/apps/web/components/editors/monaco/use-monaco-walkthrough-range.test.ts
@@ -168,6 +168,22 @@ describe("useMonacoWalkthroughRange", () => {
     expect(fake.revealLinesInCenter).toHaveBeenLastCalledWith(2, 2);
   });
 
+  it("does not recenter for same-model line count changes outside the active range", () => {
+    const fake = createModelSwitchingEditor(3);
+    renderHook(() =>
+      useMonacoWalkthroughRange({
+        editor: fake.editor,
+        editorAreaRef: { current: null },
+        path: WALKTHROUGH_FILE,
+      }),
+    );
+    fake.revealLinesInCenter.mockClear();
+
+    act(() => fake.changeLineCount(4));
+
+    expect(fake.revealLinesInCenter).not.toHaveBeenCalled();
+  });
+
   it("reapplies the range after switching to a model with the same line count", () => {
     const fake = createModelSwitchingEditor(3);
     renderHook(() =>
@@ -178,10 +194,12 @@ describe("useMonacoWalkthroughRange", () => {
       }),
     );
     fake.setDecorations.mockClear();
+    fake.revealLinesInCenter.mockClear();
 
     act(() => fake.switchModel(3));
 
     expect(fake.decoratedLines()).toEqual([2, 3]);
+    expect(fake.revealLinesInCenter).toHaveBeenLastCalledWith(2, 3);
   });
 
   it("unsubscribes from Monaco model events on unmount", () => {

--- a/apps/web/components/editors/monaco/use-monaco-walkthrough-range.ts
+++ b/apps/web/components/editors/monaco/use-monaco-walkthrough-range.ts
@@ -1,4 +1,12 @@
-import { useEffect, useMemo, useRef, useState, type RefObject } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+  type RefObject,
+} from "react";
 import type { editor as monacoEditor } from "monaco-editor";
 import { useAppStore } from "@/components/state-provider";
 import {
@@ -97,6 +105,26 @@ function useActiveWalkthroughStep() {
   return { taskId, stepIndex, step: isOpen ? step : null };
 }
 
+function useMonacoModelSnapshot(editor: monacoEditor.IStandaloneCodeEditor | null): string {
+  const subscribe = useCallback(
+    (onStoreChange: () => void) => {
+      if (!editor) return () => {};
+      const modelSubscription = editor.onDidChangeModel(onStoreChange);
+      const contentSubscription = editor.onDidChangeModelContent(onStoreChange);
+      return () => {
+        modelSubscription.dispose();
+        contentSubscription.dispose();
+      };
+    },
+    [editor],
+  );
+  const getSnapshot = useCallback(() => {
+    const model = editor?.getModel();
+    return model ? `${model.id}:${model.getLineCount()}` : "";
+  }, [editor]);
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}
+
 export function useMonacoWalkthroughRange({
   editor,
   editorAreaRef,
@@ -106,6 +134,7 @@ export function useMonacoWalkthroughRange({
   const decorationsRef = useRef<monacoEditor.IEditorDecorationsCollection | null>(null);
   const [box, setBox] = useState<WalkthroughRangeBox | null>(null);
   const { taskId, stepIndex, step } = useActiveWalkthroughStep();
+  const modelSnapshot = useMonacoModelSnapshot(editor);
   const range = useMemo(
     () => getWalkthroughEditorRange({ path, repository_name: repo }, step),
     [path, repo, step],
@@ -113,7 +142,7 @@ export function useMonacoWalkthroughRange({
   const clampedRange = useMemo(
     () =>
       range ? clampWalkthroughRangeToLineCount(range, editor?.getModel()?.getLineCount()) : null,
-    [editor, range],
+    [editor, modelSnapshot, range],
   );
   const anchorKey = taskId ? `${taskId}:${stepIndex}:${repo ?? ""}:${path}` : "";
 

--- a/apps/web/components/editors/monaco/use-monaco-walkthrough-range.ts
+++ b/apps/web/components/editors/monaco/use-monaco-walkthrough-range.ts
@@ -125,13 +125,59 @@ function useMonacoModelSnapshot(editor: monacoEditor.IStandaloneCodeEditor | nul
   return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 }
 
+function useMonacoWalkthroughDecorations(
+  editor: monacoEditor.IStandaloneCodeEditor | null,
+  range: WalkthroughEditorRange | null,
+  anchorKey: string,
+  modelSnapshot: string,
+) {
+  const decorationsRef = useRef<monacoEditor.IEditorDecorationsCollection | null>(null);
+  const revealedRef = useRef<{
+    editor: monacoEditor.IStandaloneCodeEditor;
+    model: monacoEditor.ITextModel | null;
+    anchorKey: string;
+    startLine: number;
+    endLine: number;
+  } | null>(null);
+
+  useEffect(() => {
+    if (!editor) return;
+    decorationsRef.current = editor.createDecorationsCollection([]);
+    return () => {
+      decorationsRef.current?.set([]);
+      decorationsRef.current = null;
+    };
+  }, [editor]);
+
+  useEffect(() => {
+    decorationsRef.current?.set(buildWalkthroughRangeDecorations(range));
+    if (!editor || !range) {
+      revealedRef.current = null;
+      return;
+    }
+
+    const next = { editor, model: editor.getModel(), anchorKey, ...range };
+    const previous = revealedRef.current;
+    if (
+      previous?.editor === next.editor &&
+      previous.model === next.model &&
+      previous.anchorKey === next.anchorKey &&
+      previous.startLine === next.startLine &&
+      previous.endLine === next.endLine
+    ) {
+      return;
+    }
+    revealedRef.current = next;
+    editor.revealLinesInCenter(range.startLine, range.endLine);
+  }, [anchorKey, editor, modelSnapshot, range]);
+}
+
 export function useMonacoWalkthroughRange({
   editor,
   editorAreaRef,
   path,
   repo,
 }: UseMonacoWalkthroughRangeOpts): WalkthroughRangeBox | null {
-  const decorationsRef = useRef<monacoEditor.IEditorDecorationsCollection | null>(null);
   const [box, setBox] = useState<WalkthroughRangeBox | null>(null);
   const { taskId, stepIndex, step } = useActiveWalkthroughStep();
   const modelSnapshot = useMonacoModelSnapshot(editor);
@@ -145,22 +191,7 @@ export function useMonacoWalkthroughRange({
     [editor, modelSnapshot, range],
   );
   const anchorKey = taskId ? `${taskId}:${stepIndex}:${repo ?? ""}:${path}` : "";
-
-  useEffect(() => {
-    if (!editor) return;
-    decorationsRef.current = editor.createDecorationsCollection([]);
-    return () => {
-      decorationsRef.current?.set([]);
-      decorationsRef.current = null;
-    };
-  }, [editor]);
-
-  useEffect(() => {
-    decorationsRef.current?.set(buildWalkthroughRangeDecorations(clampedRange));
-    if (editor && clampedRange) {
-      editor.revealLinesInCenter(clampedRange.startLine, clampedRange.endLine);
-    }
-  }, [clampedRange, editor]);
+  useMonacoWalkthroughDecorations(editor, clampedRange, anchorKey, modelSnapshot);
 
   useEffect(() => {
     const area = editorAreaRef.current;

--- a/apps/web/e2e/tests/review/walkthrough.spec.ts
+++ b/apps/web/e2e/tests/review/walkthrough.spec.ts
@@ -228,6 +228,30 @@ test.describe("Code walkthrough", () => {
       { timeout: 15_000 },
     );
 
+    // Move from shorter file A to longer file B. The shared Monaco preview
+    // switches models after the walkthrough step changes; B's 4-5 range must
+    // be clamped against B, not A's previous model.
+    await card.getByTestId("walkthrough-next").click();
+    await expect(card.getByTestId("walkthrough-step-header")).toContainText("Step 3 / 5");
+    await expect(testPage.locator(".monaco-editor:visible .view-lines")).toContainText(
+      "WALKTHROUGH_CHANGE_B",
+    );
+    await expect(testPage.getByTestId("walkthrough-editor-range")).toHaveAttribute(
+      "data-line-range",
+      "4-5",
+    );
+
+    // Returning to A must also restore its original multi-line range.
+    await card.getByTestId("walkthrough-prev").click();
+    await expect(card.getByTestId("walkthrough-step-header")).toContainText("Step 2 / 5");
+    await expect(testPage.locator(".monaco-editor:visible .view-lines")).toContainText(
+      "WALKTHROUGH_CHANGE_A",
+    );
+    await expect(testPage.getByTestId("walkthrough-editor-range")).toHaveAttribute(
+      "data-line-range",
+      "2-3",
+    );
+
     const before = await card.boundingBox();
     if (!before) throw new Error("walkthrough card missing before drag");
     const dragHandle = card.getByTestId("walkthrough-drag-handle");


### PR DESCRIPTION
Walkthrough ranges could clamp against the previously open Monaco model, showing the wrong highlight until reopened. Track model identity and line-count changes so ranges update immediately across files.

## Validation

- `make fmt`
- `make typecheck`
- `make test`
- `make lint`
- `make build-web`
- `cd apps/web && pnpm e2e:run --no-build tests/review/walkthrough.spec.ts -- --grep "editor walkthrough shows range marker"`
- Public docs unaffected; behavior now matches existing walkthrough contract.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.

## Screenshots

Correct lines 4–5 highlight after switching from a shorter Monaco model:

![Walkthrough highlighting lines 4–5](https://raw.githubusercontent.com/kdlbs/kandev/3bb5d3722db3178f3e0921aeb4a467d8fb058b83/walkthrough-range-after-model-switch.png)