### PR TITLE
fix: show github review and issue watches after strictmode remount

### DIFF
--- a/apps/web/hooks/domains/github/use-issue-watches.test.ts
+++ b/apps/web/hooks/domains/github/use-issue-watches.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { createElement, StrictMode } from "react";
+import { StateProvider, useAppStore } from "@/components/state-provider";
+import type { IssueWatch } from "@/lib/types/github";
+import { useIssueWatches } from "./use-issue-watches";
+
+const mocks = vi.hoisted(() => ({ listIssueWatches: vi.fn() }));
+
+vi.mock("@/lib/api/domains/github-api", () => ({
+  listIssueWatches: mocks.listIssueWatches,
+  createIssueWatch: vi.fn(),
+  updateIssueWatch: vi.fn(),
+  deleteIssueWatch: vi.fn(),
+  triggerIssueWatch: vi.fn(),
+  triggerAllIssueWatches: vi.fn(),
+  previewResetIssueWatch: vi.fn(),
+  resetIssueWatch: vi.fn(),
+}));
+
+afterEach(() => {
+  cleanup();
+  mocks.listIssueWatches.mockReset();
+});
+
+function watch(id: string): IssueWatch {
+  return {
+    id,
+    workspace_id: "ws-1",
+    workflow_id: "wf-1",
+    workflow_step_id: "step-1",
+    repos: [{ owner: "acme", name: "" }],
+    agent_profile_id: "agent-1",
+    executor_profile_id: "exec-1",
+    prompt: "",
+    labels: [],
+    custom_query: "",
+    enabled: true,
+    poll_interval_seconds: 300,
+    cleanup_policy: "auto",
+    last_polled_at: null,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  };
+}
+
+// Probe renders the hook and mirrors the resulting store state into the DOM so
+// assertions can read it after StrictMode's mount -> cleanup -> mount cycle.
+function Probe() {
+  useIssueWatches("ws-1");
+  const iw = useAppStore((state) => state.issueWatches);
+  return createElement(
+    "div",
+    { "data-testid": "probe" },
+    JSON.stringify({ loaded: iw.loaded, loading: iw.loading, ids: iw.items.map((w) => w.id) }),
+  );
+}
+
+function NullProbe() {
+  useIssueWatches(null);
+  return null;
+}
+
+function readProbe(el: HTMLElement) {
+  return JSON.parse(el.textContent ?? "{}") as {
+    loaded: boolean;
+    loading: boolean;
+    ids: string[];
+  };
+}
+
+describe("useIssueWatches", () => {
+  it("loads watches into the store when the effect double-mounts (StrictMode)", async () => {
+    // The first mount's fetch never resolves; StrictMode cancels it. Only the
+    // re-mount's fetch resolves, so the watch reaches the store ONLY if cleanup
+    // cleared the scope guard and let the second effect re-issue the fetch.
+    mocks.listIssueWatches
+      .mockImplementationOnce(() => new Promise<{ watches: IssueWatch[] }>(() => {}))
+      .mockResolvedValue({ watches: [watch("w-1")] });
+
+    const { getByTestId } = render(
+      createElement(StrictMode, null, createElement(StateProvider, null, createElement(Probe))),
+    );
+
+    // StrictMode double-invokes the effect in dev, exercising the cleanup path.
+    await waitFor(() => expect(mocks.listIssueWatches.mock.calls.length).toBeGreaterThan(1));
+
+    await waitFor(() => {
+      const state = readProbe(getByTestId("probe"));
+      expect(state.loaded).toBe(true);
+      expect(state.ids).toEqual(["w-1"]);
+      expect(state.loading).toBe(false);
+    });
+  });
+
+  it("does not fetch when workspaceId is null", () => {
+    render(createElement(StateProvider, null, createElement(NullProbe)));
+    expect(mocks.listIssueWatches).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/hooks/domains/github/use-issue-watches.ts
+++ b/apps/web/hooks/domains/github/use-issue-watches.ts
@@ -55,6 +55,11 @@ export function useIssueWatches(workspaceId?: string | null) {
       });
     return () => {
       cancelled = true;
+      // Clear the scope guard so a same-scope re-mount (React StrictMode's
+      // double-invoke, or an effect re-run) re-issues the fetch. Without this,
+      // the cancelled first fetch drops its response while the guard blocks the
+      // second run, leaving the store stuck at loading with no items.
+      if (loadedScopeRef.current === scopeKey) loadedScopeRef.current = null;
     };
   }, [workspaceId, setIssueWatches, setIssueWatchesLoading]);
 

--- a/apps/web/hooks/domains/github/use-review-watches.test.ts
+++ b/apps/web/hooks/domains/github/use-review-watches.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { createElement, StrictMode } from "react";
+import { StateProvider, useAppStore } from "@/components/state-provider";
+import type { ReviewWatch } from "@/lib/types/github";
+import { useReviewWatches } from "./use-review-watches";
+
+const mocks = vi.hoisted(() => ({ listReviewWatches: vi.fn() }));
+
+vi.mock("@/lib/api/domains/github-api", () => ({
+  listReviewWatches: mocks.listReviewWatches,
+  createReviewWatch: vi.fn(),
+  updateReviewWatch: vi.fn(),
+  deleteReviewWatch: vi.fn(),
+  triggerReviewWatch: vi.fn(),
+  triggerAllReviewWatches: vi.fn(),
+  previewResetReviewWatch: vi.fn(),
+  resetReviewWatch: vi.fn(),
+}));
+
+afterEach(() => {
+  cleanup();
+  mocks.listReviewWatches.mockReset();
+});
+
+function watch(id: string): ReviewWatch {
+  return {
+    id,
+    workspace_id: "ws-1",
+    workflow_id: "wf-1",
+    workflow_step_id: "step-1",
+    repos: [{ owner: "acme", name: "" }],
+    agent_profile_id: "agent-1",
+    executor_profile_id: "exec-1",
+    prompt: "",
+    review_scope: "user_and_teams",
+    custom_query: "",
+    enabled: true,
+    poll_interval_seconds: 300,
+    cleanup_policy: "auto",
+    last_polled_at: null,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  };
+}
+
+// Probe renders the hook and mirrors the resulting store state into the DOM so
+// assertions can read it after StrictMode's mount -> cleanup -> mount cycle.
+function Probe() {
+  useReviewWatches("ws-1");
+  const rw = useAppStore((state) => state.reviewWatches);
+  return createElement(
+    "div",
+    { "data-testid": "probe" },
+    JSON.stringify({ loaded: rw.loaded, loading: rw.loading, ids: rw.items.map((w) => w.id) }),
+  );
+}
+
+function NullProbe() {
+  useReviewWatches(null);
+  return null;
+}
+
+function readProbe(el: HTMLElement) {
+  return JSON.parse(el.textContent ?? "{}") as {
+    loaded: boolean;
+    loading: boolean;
+    ids: string[];
+  };
+}
+
+describe("useReviewWatches", () => {
+  it("loads watches into the store when the effect double-mounts (StrictMode)", async () => {
+    // The first mount's fetch never resolves; StrictMode cancels it. Only the
+    // re-mount's fetch resolves, so the watch reaches the store ONLY if cleanup
+    // cleared the scope guard and let the second effect re-issue the fetch.
+    mocks.listReviewWatches
+      .mockImplementationOnce(() => new Promise<{ watches: ReviewWatch[] }>(() => {}))
+      .mockResolvedValue({ watches: [watch("w-1")] });
+
+    const { getByTestId } = render(
+      createElement(StrictMode, null, createElement(StateProvider, null, createElement(Probe))),
+    );
+
+    // StrictMode double-invokes the effect in dev, exercising the cleanup path.
+    await waitFor(() => expect(mocks.listReviewWatches.mock.calls.length).toBeGreaterThan(1));
+
+    await waitFor(() => {
+      const state = readProbe(getByTestId("probe"));
+      expect(state.loaded).toBe(true);
+      expect(state.ids).toEqual(["w-1"]);
+      expect(state.loading).toBe(false);
+    });
+  });
+
+  it("does not fetch when workspaceId is null", () => {
+    render(createElement(StateProvider, null, createElement(NullProbe)));
+    expect(mocks.listReviewWatches).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/hooks/domains/github/use-review-watches.ts
+++ b/apps/web/hooks/domains/github/use-review-watches.ts
@@ -51,6 +51,11 @@ export function useReviewWatches(workspaceId?: string | null) {
       });
     return () => {
       cancelled = true;
+      // Clear the scope guard so a same-scope re-mount (React StrictMode's
+      // double-invoke, or an effect re-run) re-issues the fetch. Without this,
+      // the cancelled first fetch drops its response while the guard blocks the
+      // second run, leaving the store stuck at loading with no items.
+      if (loadedScopeRef.current === scopeKey) loadedScopeRef.current = null;
     };
   }, [workspaceId, setReviewWatches, setReviewWatchesLoading]);
 


### PR DESCRIPTION
GitHub review and issue watches that existed in the database were served by the API but never rendered in workspace settings; clearing the hooks' scope guard on effect cleanup lets a StrictMode re-mount re-fetch, so the watches now appear.

## Important Changes

- `useReviewWatches` / `useIssueWatches` now reset `loadedScopeRef` on effect cleanup. Previously the guard survived React 19 StrictMode's mount → cleanup → mount cycle: the first fetch was cancelled and the second mount short-circuited on the stale guard, leaving the store stuck at `loading: true` with no items.

## Validation

- `cd apps/web && pnpm vitest run hooks/domains/github/use-review-watches.test.ts hooks/domains/github/use-issue-watches.test.ts` — new StrictMode regression tests, confirmed red without the fix and green with it.
- `cd apps/web && pnpm vitest run` — full web suite, 5501 passed / 4 skipped.
- `cd apps/web && pnpm run typecheck` — clean.
- `cd apps && pnpm --filter @kandev/web lint` — clean (`--max-warnings 0`).

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1823?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->