### PR TITLE
chore(make): add cmd.exe-safe start-windows target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,7 @@ help:
 	@echo "  start            Install deps, build, and start backend + web in production mode"
 	@echo "  start-verbose    Start in production mode with info logs from backend + web"
 	@echo "  start VERBOSE=1  Same as start-verbose"
+	@echo "  start-windows    cmd.exe-safe start for native Windows (no printf/find/cp/exec)"
 	@echo ""
 	@echo "Service Commands:"
 	@echo "  service-install          Install deps, build current checkout, install user service"
@@ -252,6 +253,26 @@ start-verbose:
 start-debug:
 	@$(MAKE) start DEBUG=1
 
+# Windows-native production start. Mirrors `start` but avoids the Unix-only
+# tooling that target relies on (printf, find, cp, exec) and would break under
+# cmd.exe. Run it from a shell where GNU Make invokes cmd.exe — the default on
+# Windows when sh.exe is not on PATH — because the backend build uses cmd's
+# `set VAR=VAL&` env-var syntax. Skips the Playwright browser install (only
+# needed for e2e, not to run the server).
+.PHONY: start-windows
+start-windows:
+	@echo Installing backend dependencies...
+	@$(MAKE) -s -C $(BACKEND_DIR) deps
+	@echo Installing web dependencies...
+	@cd $(APPS_DIR) && $(PNPM) install
+	@echo Building web app...
+	@cd $(APPS_DIR) && set "VITE_KANDEV_API_PORT=" && set "VITE_KANDEV_DEBUG=" && $(PNPM) --filter @kandev/web build
+	@$(MAKE) -s sync-embedded-web-windows
+	@echo Building backend...
+	@$(MAKE) -s -C $(BACKEND_DIR) build
+	@echo Starting server...
+	@"$(subst /,\,$(BACKEND_DIR)/bin/kandev.exe)" start $(if $(filter 1 true yes,$(VERBOSE)),--verbose,) $(if $(filter 1 true yes,$(DEBUG)),--debug,)
+
 #
 # Service
 #
@@ -357,6 +378,17 @@ sync-embedded-web:
 	@find "$(EMBEDDED_WEB_DIR)" -mindepth 1 ! -name .gitignore ! -name keep.txt -exec rm -rf {} +
 	@cp -R "$(WEB_DIR)/dist/." "$(EMBEDDED_WEB_DIR)/"
 	@printf "  $(DIM)Embedded web assets$(RESET)\n"
+
+# cmd.exe-safe counterpart of sync-embedded-web (used by start-windows).
+# robocopy /MIR mirrors the Vite dist into the embedded dir; /XF keeps the
+# committed .gitignore and keep.txt while purging stale generated assets.
+# robocopy exit codes below 8 all mean success, so normalize them to 0 —
+# otherwise make reads robocopy's "files copied" code (1) as a failure.
+.PHONY: sync-embedded-web-windows
+sync-embedded-web-windows:
+	@if not exist "$(subst /,\,$(WEB_DIR)/dist/index.html)" (echo Missing $(WEB_DIR)/dist/index.html - run 'make start-windows' to build everything. & exit /b 1)
+	@robocopy "$(subst /,\,$(WEB_DIR)/dist)" "$(subst /,\,$(EMBEDDED_WEB_DIR))" /MIR /XF .gitignore keep.txt /NFL /NDL /NJH /NJS /NC /NS >nul & if errorlevel 8 (exit /b 1) else (exit /b 0)
+	@echo   Embedded web assets synced.
 
 #
 # Installation


### PR DESCRIPTION
On native Windows `make start` fails — the root target relies on `printf`, `find`, `cp`, and `exec` (absent under cmd.exe), while the backend build needs cmd.exe for its `set VAR=VAL&` env syntax, so no single shell satisfies both. A cmd.exe-safe `start-windows` target, following the existing `test-windows` pattern, lets Windows users build and run from source.

## Important Changes

- `start-windows`: installs deps, builds web, syncs embedded assets, builds the backend, and starts the server using only cmd.exe-safe commands.
- `sync-embedded-web-windows`: mirrors the Vite `dist` with `robocopy /MIR` (`/XF` keeps the committed `.gitignore` and `keep.txt`) instead of `find`/`cp`; robocopy's sub-8 "success" exit codes are normalized to 0 so make does not read them as failures.

## Validation

- Windows 11, GNU Make via cmd.exe: `make start-windows` builds and boots the backend end-to-end (confirmed against `/api/v1/workspaces`).
- `make sync-embedded-web-windows`: preserves `.gitignore`/`keep.txt`, purges stale assets, and is idempotent across re-runs; the missing-`dist` guard fails the build cleanly.
- `make help` lists the target; `python3 .github/scripts/lint-harness-files.py --all` passes.

## Possible Improvements

Low risk — purely additive and Windows-only; no existing target is modified. Adjacent and out of scope: the backend Makefile's `adhoc_sign_darwin` (Windows branch) uses `echo (…)`, valid under cmd.exe but a syntax error under sh, so building under Git bash breaks — which is why this target must run where Make invokes cmd.exe. It could be hardened to work under both shells independently.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1829?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->