### PR TITLE
chore(plugin-registry): add kandev-provider-usage

### DIFF
--- a/plugin-registry/plugins.yaml
+++ b/plugin-registry/plugins.yaml
@@ -27,7 +27,7 @@ plugins:
     repo: kdlbs/kandev-plugin-session-cost
     categories: [analytics]
   - id: kandev-provider-usage
-    repo: kdlbs/kandev-provider-usage
+    repo: kdlbs/kandev-plugin-provider-usage
     categories: [analytics]
 # Example entry (copy, uncomment, and fill in when adding a plugin):
 #

--- a/plugin-registry/plugins.yaml
+++ b/plugin-registry/plugins.yaml
@@ -26,6 +26,9 @@ plugins:
   - id: kandev-session-cost
     repo: kdlbs/kandev-plugin-session-cost
     categories: [analytics]
+  - id: kandev-provider-usage
+    repo: kdlbs/kandev-provider-usage
+    categories: [analytics]
 # Example entry (copy, uncomment, and fill in when adding a plugin):
 #
 # plugins:


### PR DESCRIPTION
## Summary
- Adds `kandev-provider-usage` to the official plugin marketplace catalog (`plugin-registry/plugins.yaml`).
- Subscription utilization for agent providers — how much of each rate-limit window (5-hour / weekly / monthly) is used, with reset times — surfaced as a hover panel in the session top bar (`chat-top-bar` slot).
- Data source: the [codexbar](https://github.com/steipete/codexbar) CLI (~60 providers: Claude, Codex/OpenAI, Gemini, Copilot, Cursor, Grok, …), plus Augment's own Analytics API (codexbar can't read Augment off macOS).
- Repo: https://github.com/kdlbs/kandev-plugin-provider-usage
- Release: https://github.com/kdlbs/kandev-plugin-provider-usage/releases/tag/v0.1.1 (assets: `kandev-provider-usage-0.1.1.tar.gz` + `checksums.txt`, all 5 platforms)

## Screenshots

![Top-bar pill](https://raw.githubusercontent.com/kdlbs/kandev-plugin-provider-usage/0cbed6cfb38b0e642a26158392b71f44170e686d/topbar-pill.png)

![Provider panel — Claude](https://raw.githubusercontent.com/kdlbs/kandev-plugin-provider-usage/0cbed6cfb38b0e642a26158392b71f44170e686d/panel-claude.png)

## Test plan

- [x] `plugin-registry/plugins.yaml` entry matches the schema shape (id pattern, repo pattern) and the existing `kandev-session-cost` entry's style.
- [x] `node --test plugin-registry/build-index.test.mjs` passes locally.
- [x] Ran `plugin-registry/build-index.mjs` locally against the live registry (incl. this PR's entry) — resolved the v0.1.1 release correctly:
  ```json
  {
    "id": "kandev-provider-usage",
    "name": "Provider Usage",
    "version": "0.1.1",
    "repo_url": "https://github.com/kdlbs/kandev-plugin-provider-usage",
    "package_url": "https://github.com/kdlbs/kandev-plugin-provider-usage/releases/download/v0.1.1/kandev-provider-usage-0.1.1.tar.gz",
    "categories": ["analytics"]
  }
  ```
- [x] Installed and verified the packaged plugin end-to-end on a local kandev instance (top-bar pill, hover panel with provider tabs, Augment card).
- [x] Repo renamed `kdlbs/kandev-provider-usage` → `kdlbs/kandev-plugin-provider-usage` to match the documented `kdlbs/kandev-plugin-<slug>` convention (AGENTS.md, `plugin-registry/README.md`), per review — v0.1.1 re-released with the corrected `manifest.yaml` `repo_url` baked into the packaged tarball, and this entry updated to match.