### PR TITLE
fix(web): keep plugin row action buttons pinned to the header

### DIFF
--- a/apps/web/components/settings/plugins/plugin-row.tsx
+++ b/apps/web/components/settings/plugins/plugin-row.tsx
@@ -68,18 +68,6 @@ export function PluginRow({
             </span>
             <PluginRepoLink url={plugin.repo_url} />
           </div>
-          {plugin.description && (
-            <div className="text-xs text-muted-foreground">{plugin.description}</div>
-          )}
-          {plugin.categories.length > 0 && (
-            <div className="flex flex-wrap gap-1 pt-1">
-              {plugin.categories.map((category) => (
-                <Badge key={category} variant="secondary" className="text-[11px]">
-                  {category}
-                </Badge>
-              ))}
-            </div>
-          )}
         </div>
 
         <PluginRowActions
@@ -94,6 +82,19 @@ export function PluginRow({
           onUpdate={onUpdate}
         />
       </div>
+
+      {plugin.description && (
+        <div className="text-xs text-muted-foreground">{plugin.description}</div>
+      )}
+      {plugin.categories.length > 0 && (
+        <div className="flex flex-wrap gap-1">
+          {plugin.categories.map((category) => (
+            <Badge key={category} variant="secondary" className="text-[11px]">
+              {category}
+            </Badge>
+          ))}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
The Disable/Uninstall buttons on the Installed Plugins list jumped from the top-right of the card to the bottom-left depending on how long the plugin's description text was, because the description and category badges shared the same flex-wrap row as the action buttons.

## Validation

- `make fmt-web typecheck-web lint-web` — pass
- `make test-web` — 712 test files / 5574 tests pass
- Rendered `PluginRow` standalone with the two plugin descriptions shown in the reported screenshot (long 2-line vs. short 1-line) and confirmed the action buttons now stay pinned to the top-right in both cases.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [x] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1833?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->