### PR TITLE
fix(tasks): preserve inherited workspaces on subtask deletion

### DIFF
--- a/apps/backend/internal/task/service/handoff_cascade.go
+++ b/apps/backend/internal/task/service/handoff_cascade.go
@@ -196,9 +196,6 @@ func (s *HandoffService) ArchiveTaskTree(ctx context.Context, rootID string, cas
 	} else {
 		all = []string{rootID}
 	}
-	if err := s.transferSharedWorkspaceEnvironmentOwnership(ctx, all); err != nil {
-		return out, err
-	}
 	cleanupOps, err := s.prepareCascadeResourceCleanup(ctx, all, cascadeID, models.TaskResourceCleanupTriggerCascadeArchive)
 	if err != nil {
 		return out, err

--- a/apps/backend/internal/task/service/handoff_cascade.go
+++ b/apps/backend/internal/task/service/handoff_cascade.go
@@ -408,6 +408,8 @@ func (s *HandoffService) transferWorkspaceGroupEnvironmentOwnership(
 	}
 	candidates := survivingWorkspaceMemberIDs(group.OwnerTaskID, members, departing)
 	if len(candidates) == 0 {
+		// Every active member is departing, so last-member cleanup owns the
+		// environment teardown and no ownership transfer is needed.
 		return nil
 	}
 	newOwner, err := availableWorkspaceEnvironmentOwner(ctx, environments, env.ID, candidates)

--- a/apps/backend/internal/task/service/handoff_cascade.go
+++ b/apps/backend/internal/task/service/handoff_cascade.go
@@ -21,6 +21,13 @@ type workspaceEnvironmentRepository interface {
 	GetTaskEnvironmentByTaskID(ctx context.Context, taskID string) (*models.TaskEnvironment, error)
 }
 
+type workspaceEnvironmentOwnershipTransfer struct {
+	groupID        string
+	environmentID  string
+	oldOwnerTaskID string
+	newOwnerTaskID string
+}
+
 // publishUpdatedTask re-reads the task row and forwards it to the event
 // publisher. Used by ArchiveTaskTree after stamping archived_at so the
 // WS payload reflects the new column value (the frontend keys off
@@ -284,12 +291,13 @@ func (s *HandoffService) DeleteTaskTree(ctx context.Context, rootID string, casc
 	if err != nil {
 		return nil, err
 	}
-	if err := s.transferSharedWorkspaceEnvironmentOwnership(ctx, all); err != nil {
+	ownershipTransfers, err := s.transferSharedWorkspaceEnvironmentOwnership(ctx, all)
+	if err != nil {
 		return out, err
 	}
 	cleanupOps, err := s.prepareCascadeResourceCleanup(ctx, all, cascadeID, models.TaskResourceCleanupTriggerCascadeDelete)
 	if err != nil {
-		return out, err
+		return out, s.rollbackWorkspaceEnvironmentOwnershipAfterFailure(ctx, ownershipTransfers, err)
 	}
 
 	s.cancelActiveRuns(ctx, all, "task tree deleted")
@@ -301,7 +309,7 @@ func (s *HandoffService) DeleteTaskTree(ctx context.Context, rootID string, casc
 	groupIDs, err := s.releaseMembershipsForCascade(ctx, all, orchmodels.WorkspaceReleaseReasonDeleted, cascadeID)
 	if err != nil {
 		s.cancelCascadeResourceCleanupRange(ctx, all, cleanupOps)
-		return out, err
+		return out, s.rollbackWorkspaceEnvironmentOwnershipAfterFailure(ctx, ownershipTransfers, err)
 	}
 	out.ReleasedGroupIDs = groupIDs
 
@@ -323,7 +331,11 @@ func (s *HandoffService) DeleteTaskTree(ctx context.Context, rootID string, casc
 		// runs async after this returns. Delete cascade removes the env row.
 		if err := s.tasks.DeleteTask(ctx, all[i]); err != nil {
 			s.cancelCascadeResourceCleanupRange(ctx, all[:i+1], cleanupOps)
-			return out, fmt.Errorf("delete %s: %w", all[i], err)
+			deleteErr := fmt.Errorf("delete %s: %w", all[i], err)
+			if len(out.ArchivedTaskIDs) == 0 {
+				deleteErr = s.rollbackWorkspaceEnvironmentOwnershipAfterFailure(ctx, ownershipTransfers, deleteErr)
+			}
+			return out, deleteErr
 		}
 		if operationID := cleanupOps[all[i]]; operationID != "" {
 			s.startCascadeResourceCleanup(ctx, operationID)
@@ -350,19 +362,24 @@ func (s *HandoffService) DeleteTaskTree(ctx context.Context, rootID string, casc
 // remain. Task deletion cascades task_environments by task_id, so leaving the
 // environment attached to the departing member would destroy shared workspace
 // state before group cleanup gets a chance to enforce its last-member rule.
-func (s *HandoffService) transferSharedWorkspaceEnvironmentOwnership(ctx context.Context, taskIDs []string) error {
+func (s *HandoffService) transferSharedWorkspaceEnvironmentOwnership(
+	ctx context.Context,
+	taskIDs []string,
+) ([]workspaceEnvironmentOwnershipTransfer, error) {
 	if s.wsGroups == nil || len(taskIDs) == 0 {
-		return nil
+		return nil, nil
 	}
 	departing := make(map[string]struct{}, len(taskIDs))
 	for _, taskID := range taskIDs {
 		departing[taskID] = struct{}{}
 	}
 	seenGroups := make(map[string]struct{})
+	transfers := make([]workspaceEnvironmentOwnershipTransfer, 0)
 	for _, taskID := range taskIDs {
 		group, err := s.wsGroups.GetWorkspaceGroupForTask(ctx, taskID)
 		if err != nil {
-			return fmt.Errorf("lookup workspace group for task %s: %w", taskID, err)
+			cause := fmt.Errorf("lookup workspace group for task %s: %w", taskID, err)
+			return nil, s.rollbackWorkspaceEnvironmentOwnershipAfterFailure(ctx, transfers, cause)
 		}
 		if group == nil || group.MaterializedEnvironmentID == "" {
 			continue
@@ -371,63 +388,126 @@ func (s *HandoffService) transferSharedWorkspaceEnvironmentOwnership(ctx context
 			continue
 		}
 		seenGroups[group.ID] = struct{}{}
-		if err := s.transferWorkspaceGroupEnvironmentOwnership(ctx, group, departing); err != nil {
-			return err
+		transfer, err := s.transferWorkspaceGroupEnvironmentOwnership(ctx, group, departing)
+		if err != nil {
+			return nil, s.rollbackWorkspaceEnvironmentOwnershipAfterFailure(ctx, transfers, err)
+		}
+		if transfer != nil {
+			transfers = append(transfers, *transfer)
 		}
 	}
-	return nil
+	return transfers, nil
 }
 
 func (s *HandoffService) transferWorkspaceGroupEnvironmentOwnership(
 	ctx context.Context,
 	group *orchmodels.WorkspaceGroup,
 	departing map[string]struct{},
-) error {
+) (*workspaceEnvironmentOwnershipTransfer, error) {
 	mu := s.workspaceGroupLock.lockFor(group.ID)
 	mu.Lock()
 	defer mu.Unlock()
 	environments, ok := s.tasks.(workspaceEnvironmentRepository)
 	if !ok {
-		return fmt.Errorf("preserve workspace group %s: task environment repository unavailable", group.ID)
+		return nil, fmt.Errorf("preserve workspace group %s: task environment repository unavailable", group.ID)
 	}
 	env, err := environments.GetTaskEnvironment(ctx, group.MaterializedEnvironmentID)
 	if err != nil {
-		return fmt.Errorf("load materialized environment %s for workspace group %s: %w",
+		return nil, fmt.Errorf("load materialized environment %s for workspace group %s: %w",
 			group.MaterializedEnvironmentID, group.ID, err)
 	}
 	if env == nil {
-		return fmt.Errorf("materialized environment %s for workspace group %s not found",
+		return nil, fmt.Errorf("materialized environment %s for workspace group %s not found",
 			group.MaterializedEnvironmentID, group.ID)
 	}
 	if _, leaving := departing[env.TaskID]; !leaving {
-		return nil
+		return nil, nil
 	}
 	members, err := s.wsGroups.ListActiveWorkspaceGroupMembers(ctx, group.ID)
 	if err != nil {
-		return fmt.Errorf("list active workspace group members for %s: %w", group.ID, err)
+		return nil, fmt.Errorf("list active workspace group members for %s: %w", group.ID, err)
 	}
 	candidates := survivingWorkspaceMemberIDs(group.OwnerTaskID, members, departing)
 	if len(candidates) == 0 {
 		// Every active member is departing, so last-member cleanup owns the
 		// environment teardown and no ownership transfer is needed.
-		return nil
+		return nil, nil
 	}
 	newOwner, err := availableWorkspaceEnvironmentOwner(ctx, environments, env.ID, candidates)
 	if err != nil {
-		return fmt.Errorf("select workspace environment owner for group %s: %w", group.ID, err)
+		return nil, fmt.Errorf("select workspace environment owner for group %s: %w", group.ID, err)
 	}
 	if newOwner == "" {
-		return fmt.Errorf("preserve workspace group %s: no surviving member can own environment %s", group.ID, env.ID)
+		return nil, fmt.Errorf("preserve workspace group %s: no surviving member can own environment %s", group.ID, env.ID)
 	}
 	if err := environments.TransferTaskEnvironmentToTask(ctx, env.ID, newOwner); err != nil {
-		return fmt.Errorf("transfer workspace environment %s to task %s: %w", env.ID, newOwner, err)
+		return nil, fmt.Errorf("transfer workspace environment %s to task %s: %w", env.ID, newOwner, err)
 	}
 	s.logf().Info("transferred shared workspace environment before task lifecycle cleanup",
 		zap.String("group_id", group.ID),
 		zap.String("environment_id", env.ID),
 		zap.String("old_owner_task_id", env.TaskID),
 		zap.String("new_owner_task_id", newOwner))
-	return nil
+	return &workspaceEnvironmentOwnershipTransfer{
+		groupID:        group.ID,
+		environmentID:  env.ID,
+		oldOwnerTaskID: env.TaskID,
+		newOwnerTaskID: newOwner,
+	}, nil
+}
+
+func (s *HandoffService) rollbackWorkspaceEnvironmentOwnershipAfterFailure(
+	ctx context.Context,
+	transfers []workspaceEnvironmentOwnershipTransfer,
+	cause error,
+) error {
+	rollbackErr := s.rollbackWorkspaceEnvironmentOwnershipTransfers(context.WithoutCancel(ctx), transfers)
+	if rollbackErr == nil {
+		return cause
+	}
+	return errors.Join(cause, fmt.Errorf("rollback shared workspace environment ownership: %w", rollbackErr))
+}
+
+func (s *HandoffService) rollbackWorkspaceEnvironmentOwnershipTransfers(
+	ctx context.Context,
+	transfers []workspaceEnvironmentOwnershipTransfer,
+) error {
+	if len(transfers) == 0 {
+		return nil
+	}
+	environments, ok := s.tasks.(workspaceEnvironmentRepository)
+	if !ok {
+		return errors.New("task environment repository unavailable")
+	}
+	var errs []error
+	for i := len(transfers) - 1; i >= 0; i-- {
+		transfer := transfers[i]
+		mu := s.workspaceGroupLock.lockFor(transfer.groupID)
+		mu.Lock()
+		env, err := environments.GetTaskEnvironment(ctx, transfer.environmentID)
+		if err == nil {
+			switch {
+			case env == nil:
+				err = errors.New("environment not found")
+			case env.TaskID == transfer.oldOwnerTaskID:
+				// A concurrent retry already restored this transfer.
+			case env.TaskID != transfer.newOwnerTaskID:
+				err = fmt.Errorf("owner changed from rollback target %s to %s", transfer.newOwnerTaskID, env.TaskID)
+			default:
+				err = environments.TransferTaskEnvironmentToTask(ctx, transfer.environmentID, transfer.oldOwnerTaskID)
+			}
+		}
+		mu.Unlock()
+		if err != nil {
+			errs = append(errs, fmt.Errorf("environment %s: %w", transfer.environmentID, err))
+			continue
+		}
+		s.logf().Info("restored shared workspace environment ownership after aborted task deletion",
+			zap.String("group_id", transfer.groupID),
+			zap.String("environment_id", transfer.environmentID),
+			zap.String("owner_task_id", transfer.oldOwnerTaskID))
+	}
+	return errors.Join(errs...)
 }
 
 func survivingWorkspaceMemberIDs(

--- a/apps/backend/internal/task/service/handoff_cascade.go
+++ b/apps/backend/internal/task/service/handoff_cascade.go
@@ -383,14 +383,9 @@ func (s *HandoffService) transferWorkspaceGroupEnvironmentOwnership(
 	group *orchmodels.WorkspaceGroup,
 	departing map[string]struct{},
 ) error {
-	members, err := s.wsGroups.ListActiveWorkspaceGroupMembers(ctx, group.ID)
-	if err != nil {
-		return fmt.Errorf("list active workspace group members for %s: %w", group.ID, err)
-	}
-	candidates := survivingWorkspaceMemberIDs(group.OwnerTaskID, members, departing)
-	if len(candidates) == 0 {
-		return nil
-	}
+	mu := s.workspaceGroupLock.lockFor(group.ID)
+	mu.Lock()
+	defer mu.Unlock()
 	environments, ok := s.tasks.(workspaceEnvironmentRepository)
 	if !ok {
 		return fmt.Errorf("preserve workspace group %s: task environment repository unavailable", group.ID)
@@ -405,6 +400,14 @@ func (s *HandoffService) transferWorkspaceGroupEnvironmentOwnership(
 			group.MaterializedEnvironmentID, group.ID)
 	}
 	if _, leaving := departing[env.TaskID]; !leaving {
+		return nil
+	}
+	members, err := s.wsGroups.ListActiveWorkspaceGroupMembers(ctx, group.ID)
+	if err != nil {
+		return fmt.Errorf("list active workspace group members for %s: %w", group.ID, err)
+	}
+	candidates := survivingWorkspaceMemberIDs(group.OwnerTaskID, members, departing)
+	if len(candidates) == 0 {
 		return nil
 	}
 	newOwner, err := availableWorkspaceEnvironmentOwner(ctx, environments, env.ID, candidates)

--- a/apps/backend/internal/task/service/handoff_cascade.go
+++ b/apps/backend/internal/task/service/handoff_cascade.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/google/uuid"
@@ -13,6 +14,12 @@ import (
 	orchmodels "github.com/kandev/kandev/internal/office/models"
 	"github.com/kandev/kandev/internal/task/models"
 )
+
+type workspaceEnvironmentRepository interface {
+	taskEnvironmentOwnerTransferer
+	GetTaskEnvironment(ctx context.Context, id string) (*models.TaskEnvironment, error)
+	GetTaskEnvironmentByTaskID(ctx context.Context, taskID string) (*models.TaskEnvironment, error)
+}
 
 // publishUpdatedTask re-reads the task row and forwards it to the event
 // publisher. Used by ArchiveTaskTree after stamping archived_at so the
@@ -189,6 +196,9 @@ func (s *HandoffService) ArchiveTaskTree(ctx context.Context, rootID string, cas
 	} else {
 		all = []string{rootID}
 	}
+	if err := s.transferSharedWorkspaceEnvironmentOwnership(ctx, all); err != nil {
+		return out, err
+	}
 	cleanupOps, err := s.prepareCascadeResourceCleanup(ctx, all, cascadeID, models.TaskResourceCleanupTriggerCascadeArchive)
 	if err != nil {
 		return out, err
@@ -277,6 +287,9 @@ func (s *HandoffService) DeleteTaskTree(ctx context.Context, rootID string, casc
 	if err != nil {
 		return nil, err
 	}
+	if err := s.transferSharedWorkspaceEnvironmentOwnership(ctx, all); err != nil {
+		return out, err
+	}
 	cleanupOps, err := s.prepareCascadeResourceCleanup(ctx, all, cascadeID, models.TaskResourceCleanupTriggerCascadeDelete)
 	if err != nil {
 		return out, err
@@ -333,6 +346,129 @@ func (s *HandoffService) DeleteTaskTree(ctx context.Context, rootID string, casc
 		}
 	}
 	return out, nil
+}
+
+// transferSharedWorkspaceEnvironmentOwnership moves a materialized environment
+// off a task about to leave its workspace group when another active member will
+// remain. Task deletion cascades task_environments by task_id, so leaving the
+// environment attached to the departing member would destroy shared workspace
+// state before group cleanup gets a chance to enforce its last-member rule.
+func (s *HandoffService) transferSharedWorkspaceEnvironmentOwnership(ctx context.Context, taskIDs []string) error {
+	if s.wsGroups == nil || len(taskIDs) == 0 {
+		return nil
+	}
+	departing := make(map[string]struct{}, len(taskIDs))
+	for _, taskID := range taskIDs {
+		departing[taskID] = struct{}{}
+	}
+	seenGroups := make(map[string]struct{})
+	for _, taskID := range taskIDs {
+		group, err := s.wsGroups.GetWorkspaceGroupForTask(ctx, taskID)
+		if err != nil {
+			return fmt.Errorf("lookup workspace group for task %s: %w", taskID, err)
+		}
+		if group == nil || group.MaterializedEnvironmentID == "" {
+			continue
+		}
+		if _, seen := seenGroups[group.ID]; seen {
+			continue
+		}
+		seenGroups[group.ID] = struct{}{}
+		if err := s.transferWorkspaceGroupEnvironmentOwnership(ctx, group, departing); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *HandoffService) transferWorkspaceGroupEnvironmentOwnership(
+	ctx context.Context,
+	group *orchmodels.WorkspaceGroup,
+	departing map[string]struct{},
+) error {
+	members, err := s.wsGroups.ListActiveWorkspaceGroupMembers(ctx, group.ID)
+	if err != nil {
+		return fmt.Errorf("list active workspace group members for %s: %w", group.ID, err)
+	}
+	candidates := survivingWorkspaceMemberIDs(group.OwnerTaskID, members, departing)
+	if len(candidates) == 0 {
+		return nil
+	}
+	environments, ok := s.tasks.(workspaceEnvironmentRepository)
+	if !ok {
+		return fmt.Errorf("preserve workspace group %s: task environment repository unavailable", group.ID)
+	}
+	env, err := environments.GetTaskEnvironment(ctx, group.MaterializedEnvironmentID)
+	if err != nil {
+		return fmt.Errorf("load materialized environment %s for workspace group %s: %w",
+			group.MaterializedEnvironmentID, group.ID, err)
+	}
+	if env == nil {
+		return fmt.Errorf("materialized environment %s for workspace group %s not found",
+			group.MaterializedEnvironmentID, group.ID)
+	}
+	if _, leaving := departing[env.TaskID]; !leaving {
+		return nil
+	}
+	newOwner, err := availableWorkspaceEnvironmentOwner(ctx, environments, env.ID, candidates)
+	if err != nil {
+		return fmt.Errorf("select workspace environment owner for group %s: %w", group.ID, err)
+	}
+	if newOwner == "" {
+		return fmt.Errorf("preserve workspace group %s: no surviving member can own environment %s", group.ID, env.ID)
+	}
+	if err := environments.TransferTaskEnvironmentToTask(ctx, env.ID, newOwner); err != nil {
+		return fmt.Errorf("transfer workspace environment %s to task %s: %w", env.ID, newOwner, err)
+	}
+	s.logf().Info("transferred shared workspace environment before task lifecycle cleanup",
+		zap.String("group_id", group.ID),
+		zap.String("environment_id", env.ID),
+		zap.String("old_owner_task_id", env.TaskID),
+		zap.String("new_owner_task_id", newOwner))
+	return nil
+}
+
+func survivingWorkspaceMemberIDs(
+	ownerTaskID string,
+	members []orchmodels.WorkspaceGroupMember,
+	departing map[string]struct{},
+) []string {
+	ids := make([]string, 0, len(members))
+	for _, member := range members {
+		if member.TaskID == "" {
+			continue
+		}
+		if _, leaving := departing[member.TaskID]; leaving {
+			continue
+		}
+		ids = append(ids, member.TaskID)
+	}
+	sort.Strings(ids)
+	for i, taskID := range ids {
+		if taskID == ownerTaskID {
+			ids[0], ids[i] = ids[i], ids[0]
+			break
+		}
+	}
+	return ids
+}
+
+func availableWorkspaceEnvironmentOwner(
+	ctx context.Context,
+	environments workspaceEnvironmentRepository,
+	environmentID string,
+	candidates []string,
+) (string, error) {
+	for _, taskID := range candidates {
+		owned, err := environments.GetTaskEnvironmentByTaskID(ctx, taskID)
+		if err != nil {
+			return "", err
+		}
+		if owned == nil || owned.ID == environmentID {
+			return taskID, nil
+		}
+	}
+	return "", nil
 }
 
 func (s *HandoffService) prepareCascadeResourceCleanup(

--- a/apps/backend/internal/task/service/handoff_cascade_test.go
+++ b/apps/backend/internal/task/service/handoff_cascade_test.go
@@ -118,6 +118,7 @@ func (f *fakeWSGroupRepoCascade) ReleaseWorkspaceGroupMember(_ context.Context, 
 
 type recordingCleanupCoordinator struct {
 	mu                    sync.Mutex
+	prepareErr            error
 	prepared              []string
 	deleteEnvironmentRows []bool
 	started               []string
@@ -142,7 +143,7 @@ func (c *recordingCleanupCoordinator) PrepareTaskResourceCleanup(
 	defer c.mu.Unlock()
 	c.prepared = append(c.prepared, operationID)
 	c.deleteEnvironmentRows = append(c.deleteEnvironmentRows, deleteEnvironmentRow)
-	return nil
+	return c.prepareErr
 }
 
 func TestDeleteTaskTreePreparedCleanupDeletesEnvironmentRow(t *testing.T) {

--- a/apps/backend/internal/task/service/handoff_service.go
+++ b/apps/backend/internal/task/service/handoff_service.go
@@ -172,18 +172,19 @@ type RelatedTasks struct {
 // than reaching into the repos directly so document writes still go
 // through DocumentService and emit the same revision/event side effects.
 type HandoffService struct {
-	tasks           repository.TaskRepository
-	docs            *DocumentService
-	docsRepo        repository.DocumentRepository
-	blockers        BlockerRepository
-	wsGroups        WorkspaceGroupRepo
-	sessions        SessionWorktreeReader
-	cleaner         WorkspaceCleaner
-	runCanceller    RunCanceller
-	eventPublisher  TaskEventPublisher
-	resourceCleaner TaskResourceCleaner
-	logger          *logger.Logger
-	parentLock      parentMutex
+	tasks              repository.TaskRepository
+	docs               *DocumentService
+	docsRepo           repository.DocumentRepository
+	blockers           BlockerRepository
+	wsGroups           WorkspaceGroupRepo
+	sessions           SessionWorktreeReader
+	cleaner            WorkspaceCleaner
+	runCanceller       RunCanceller
+	eventPublisher     TaskEventPublisher
+	resourceCleaner    TaskResourceCleaner
+	logger             *logger.Logger
+	parentLock         parentMutex
+	workspaceGroupLock parentMutex
 }
 
 // TaskEventPublisher abstracts the side-effect of broadcasting task
@@ -280,6 +281,7 @@ func NewHandoffService(
 		parentLock: parentMutex{
 			locks: make(map[string]*sync.Mutex),
 		},
+		workspaceGroupLock: parentMutex{locks: make(map[string]*sync.Mutex)},
 	}
 }
 

--- a/apps/backend/internal/task/service/resource_cleanup_jobs_test.go
+++ b/apps/backend/internal/task/service/resource_cleanup_jobs_test.go
@@ -691,6 +691,40 @@ func TestDeleteInheritedSubtaskPreservesChildMaterializedWorkspaceForParent(t *t
 	}
 }
 
+func TestDeleteInheritedSubtaskBlockedWhenNoSurvivorCanOwnSharedEnvironment(t *testing.T) {
+	_, repo := setupOfficeTest(t)
+	ctx := context.Background()
+	seedParentChildWorkspace(t, repo, "ws-shared-blocked", "wf-shared-blocked", "task-parent", "task-child")
+	for _, env := range []*models.TaskEnvironment{
+		{ID: "env-parent", TaskID: "task-parent", Status: models.TaskEnvironmentStatusReady},
+		{ID: "env-shared", TaskID: "task-child", Status: models.TaskEnvironmentStatusReady},
+	} {
+		if err := repo.CreateTaskEnvironment(ctx, env); err != nil {
+			t.Fatalf("create task environment %s: %v", env.ID, err)
+		}
+	}
+
+	groups := newFakeWSGroupRepo()
+	groups.groups["group-shared"] = &orchmodels.WorkspaceGroup{
+		ID: "group-shared", OwnerTaskID: "task-parent", MaterializedEnvironmentID: "env-shared",
+	}
+	groups.members["group-shared"] = map[string]string{
+		"task-parent": orchmodels.WorkspaceMemberRoleOwner,
+		"task-child":  orchmodels.WorkspaceMemberRoleMember,
+	}
+	handoff := NewHandoffService(repo, repo, nil, nil, groups, nil)
+
+	if _, err := handoff.DeleteTaskTree(ctx, "task-child", false); err == nil {
+		t.Fatal("DeleteTaskTree should fail when no surviving member can own the shared environment")
+	}
+	if task, err := repo.GetTask(ctx, "task-child"); err != nil || task == nil {
+		t.Fatalf("blocked deletion removed child task: task=%#v err=%v", task, err)
+	}
+	if env, err := repo.GetTaskEnvironment(ctx, "env-shared"); err != nil || env.TaskID != "task-child" {
+		t.Fatalf("blocked deletion changed shared environment: env=%#v err=%v", env, err)
+	}
+}
+
 func TestPreparedCleanupIsNotRunnableUntilStarted(t *testing.T) {
 	taskSvc, repo := setupOfficeTest(t)
 	ctx := context.Background()

--- a/apps/backend/internal/task/service/resource_cleanup_jobs_test.go
+++ b/apps/backend/internal/task/service/resource_cleanup_jobs_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/kandev/kandev/internal/agent/runtime/activity"
 	"github.com/kandev/kandev/internal/agentruntime"
+	orchmodels "github.com/kandev/kandev/internal/office/models"
 	"github.com/kandev/kandev/internal/task/models"
 	"github.com/kandev/kandev/internal/task/repository"
 	"github.com/kandev/kandev/internal/worktree"
@@ -627,6 +628,66 @@ func TestCascadeDeletePersistsCleanupBeforeTaskMutation(t *testing.T) {
 	handoff.SetTaskResourceCleaner(taskSvc)
 	if _, err := handoff.DeleteTaskTree(ctx, task.ID, false); err != nil {
 		t.Fatalf("DeleteTaskTree: %v", err)
+	}
+}
+
+func TestDeleteInheritedSubtaskPreservesChildMaterializedWorkspaceForParent(t *testing.T) {
+	taskSvc, repo := setupOfficeTest(t)
+	ctx := context.Background()
+	seedParentChildWorkspace(t, repo, "ws-shared-delete", "wf-shared-delete", "task-parent", "task-child")
+	if err := repo.CreateTaskEnvironment(ctx, &models.TaskEnvironment{
+		ID:           "env-shared",
+		TaskID:       "task-child",
+		Status:       models.TaskEnvironmentStatusReady,
+		WorktreeID:   "worktree-shared",
+		WorktreePath: "/tmp/worktree-shared",
+	}); err != nil {
+		t.Fatalf("create child-materialized environment: %v", err)
+	}
+	if err := repo.CreateTaskSession(ctx, &models.TaskSession{
+		ID:                "session-child",
+		TaskID:            "task-child",
+		State:             models.TaskSessionStateCompleted,
+		TaskEnvironmentID: "env-shared",
+	}); err != nil {
+		t.Fatalf("create child session: %v", err)
+	}
+
+	groups := newFakeWSGroupRepo()
+	groups.groups["group-shared"] = &orchmodels.WorkspaceGroup{
+		ID:                        "group-shared",
+		WorkspaceID:               "ws-shared-delete",
+		OwnerTaskID:               "task-parent",
+		MaterializedEnvironmentID: "env-shared",
+		MaterializedKind:          orchmodels.WorkspaceGroupKindSingleRepo,
+		OwnedByKandev:             true,
+		CleanupPolicy:             orchmodels.WorkspaceCleanupPolicyDeleteWhenLastMemberArchivedOrDel,
+		CleanupStatus:             orchmodels.WorkspaceCleanupStatusActive,
+	}
+	groups.members["group-shared"] = map[string]string{
+		"task-parent": orchmodels.WorkspaceMemberRoleOwner,
+		"task-child":  orchmodels.WorkspaceMemberRoleMember,
+	}
+	destroyer := &stubDestroyer{}
+	taskSvc.SetEnvironmentDestroyer(destroyer)
+	taskSvc.setCleanupDoneForTestHook(make(chan struct{}, 1))
+	handoff := NewHandoffService(repo, repo, nil, nil, groups, nil)
+	handoff.SetTaskResourceCleaner(taskSvc)
+
+	if _, err := handoff.DeleteTaskTree(ctx, "task-child", false); err != nil {
+		t.Fatalf("DeleteTaskTree: %v", err)
+	}
+	waitForCleanupDone(t, taskSvc)
+
+	env, err := repo.GetTaskEnvironment(ctx, "env-shared")
+	if err != nil {
+		t.Fatalf("shared environment should survive child deletion: %v", err)
+	}
+	if env.TaskID != "task-parent" {
+		t.Fatalf("shared environment owner = %q, want task-parent", env.TaskID)
+	}
+	if len(destroyer.worktreeCalls) != 0 {
+		t.Fatalf("child cleanup destroyed shared worktree: %v", destroyer.worktreeCalls)
 	}
 }
 

--- a/apps/backend/internal/task/service/resource_cleanup_jobs_test.go
+++ b/apps/backend/internal/task/service/resource_cleanup_jobs_test.go
@@ -725,6 +725,68 @@ func TestDeleteInheritedSubtaskBlockedWhenNoSurvivorCanOwnSharedEnvironment(t *t
 	}
 }
 
+func TestDeleteInheritedSubtaskRestoresSharedEnvironmentOwnershipOnEarlyAbort(t *testing.T) {
+	tests := []struct {
+		name         string
+		prepareErr   error
+		releaseErr   error
+		rejectDelete bool
+	}{
+		{name: "cleanup preparation fails", prepareErr: errors.New("prepare cleanup")},
+		{name: "membership release fails", releaseErr: errors.New("release membership")},
+		{name: "first task deletion fails", rejectDelete: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, repo := setupOfficeTest(t)
+			ctx := context.Background()
+			seedParentChildWorkspace(t, repo, "ws-shared-abort", "wf-shared-abort", "task-parent", "task-child")
+			if err := repo.CreateTaskEnvironment(ctx, &models.TaskEnvironment{
+				ID: "env-shared", TaskID: "task-child", Status: models.TaskEnvironmentStatusReady,
+			}); err != nil {
+				t.Fatalf("create shared environment: %v", err)
+			}
+
+			groups := newCascadeWSGroupRepo()
+			groups.groups["group-shared"] = &orchmodels.WorkspaceGroup{
+				ID: "group-shared", OwnerTaskID: "task-parent", MaterializedEnvironmentID: "env-shared",
+			}
+			groups.members["group-shared"] = map[string]string{
+				"task-parent": orchmodels.WorkspaceMemberRoleOwner,
+				"task-child":  orchmodels.WorkspaceMemberRoleMember,
+			}
+			groups.releaseErr = tt.releaseErr
+			coordinator := &recordingCleanupCoordinator{prepareErr: tt.prepareErr}
+			handoff := NewHandoffService(repo, repo, nil, nil, groups, nil)
+			handoff.SetTaskResourceCleaner(coordinator)
+			if tt.rejectDelete {
+				if _, err := repo.DB().Exec(`
+					CREATE TRIGGER reject_shared_owner_delete BEFORE DELETE ON tasks
+					WHEN OLD.id = 'task-child'
+					BEGIN SELECT RAISE(ABORT, 'reject task deletion'); END
+				`); err != nil {
+					t.Fatalf("create delete rejection trigger: %v", err)
+				}
+			}
+
+			wantErr := tt.prepareErr
+			if wantErr == nil {
+				wantErr = tt.releaseErr
+			}
+			_, err := handoff.DeleteTaskTree(ctx, "task-child", false)
+			if err == nil || (wantErr != nil && !errors.Is(err, wantErr)) {
+				t.Fatalf("DeleteTaskTree error = %v, want non-nil matching %v", err, wantErr)
+			}
+			if task, err := repo.GetTask(ctx, "task-child"); err != nil || task == nil {
+				t.Fatalf("aborted deletion removed child task: task=%#v err=%v", task, err)
+			}
+			if env, err := repo.GetTaskEnvironment(ctx, "env-shared"); err != nil || env.TaskID != "task-child" {
+				t.Fatalf("aborted deletion stranded environment ownership: env=%#v err=%v", env, err)
+			}
+		})
+	}
+}
+
 func TestCascadeDeleteAllWorkspaceGroupMembersDestroysSharedEnvironment(t *testing.T) {
 	_, repo := setupOfficeTest(t)
 	ctx := context.Background()

--- a/apps/backend/internal/task/service/resource_cleanup_jobs_test.go
+++ b/apps/backend/internal/task/service/resource_cleanup_jobs_test.go
@@ -725,6 +725,34 @@ func TestDeleteInheritedSubtaskBlockedWhenNoSurvivorCanOwnSharedEnvironment(t *t
 	}
 }
 
+func TestCascadeDeleteAllWorkspaceGroupMembersDestroysSharedEnvironment(t *testing.T) {
+	_, repo := setupOfficeTest(t)
+	ctx := context.Background()
+	seedParentChildWorkspace(t, repo, "ws-shared-cascade", "wf-shared-cascade", "task-parent", "task-child")
+	if err := repo.CreateTaskEnvironment(ctx, &models.TaskEnvironment{
+		ID: "env-shared", TaskID: "task-child", Status: models.TaskEnvironmentStatusReady,
+	}); err != nil {
+		t.Fatalf("create shared environment: %v", err)
+	}
+
+	groups := newFakeWSGroupRepo()
+	groups.groups["group-shared"] = &orchmodels.WorkspaceGroup{
+		ID: "group-shared", OwnerTaskID: "task-parent", MaterializedEnvironmentID: "env-shared",
+	}
+	groups.members["group-shared"] = map[string]string{
+		"task-parent": orchmodels.WorkspaceMemberRoleOwner,
+		"task-child":  orchmodels.WorkspaceMemberRoleMember,
+	}
+	handoff := NewHandoffService(repo, repo, nil, nil, groups, nil)
+
+	if _, err := handoff.DeleteTaskTree(ctx, "task-parent", true); err != nil {
+		t.Fatalf("DeleteTaskTree: %v", err)
+	}
+	if env, err := repo.GetTaskEnvironment(ctx, "env-shared"); err == nil || env != nil {
+		t.Fatalf("shared environment survived last-member cascade: env=%#v err=%v", env, err)
+	}
+}
+
 func TestPreparedCleanupIsNotRunnableUntilStarted(t *testing.T) {
 	taskSvc, repo := setupOfficeTest(t)
 	ctx := context.Background()

--- a/apps/backend/internal/worktree/manager.go
+++ b/apps/backend/internal/worktree/manager.go
@@ -100,7 +100,7 @@ type Store interface {
 	// non-deleted worktree row that has a non-empty path. Used by the
 	// office GC to identify live worktrees that must not be swept.
 	ListActiveWorktreePaths(ctx context.Context) ([]string, error)
-	// CountActiveWorktreeReferences counts non-terminal session associations
+	// CountActiveWorktreeReferences counts non-deleted session associations
 	// for a physical worktree, excluding associations owned by the caller.
 	CountActiveWorktreeReferences(ctx context.Context, worktreeID string, excludeSessionIDs []string) (int, error)
 }
@@ -179,7 +179,7 @@ func (m *Manager) ListActiveWorktreePaths(ctx context.Context) ([]string, error)
 	return m.store.ListActiveWorktreePaths(ctx)
 }
 
-// CountActiveWorktreeReferences returns the number of live session
+// CountActiveWorktreeReferences returns the number of non-deleted session
 // associations for a physical worktree outside the supplied sessions.
 func (m *Manager) CountActiveWorktreeReferences(
 	ctx context.Context,

--- a/apps/backend/internal/worktree/manager_cleanup.go
+++ b/apps/backend/internal/worktree/manager_cleanup.go
@@ -106,7 +106,7 @@ func (m *Manager) removeWorktree(ctx context.Context, wt *Worktree, removeBranch
 		m.logger.Info("preserved worktree still referenced by another task session",
 			zap.String("worktree_id", wt.ID),
 			zap.String("session_id", wt.SessionID),
-			zap.Int("active_references", activeReferences))
+			zap.Int("non_deleted_references", activeReferences))
 		return nil
 	}
 

--- a/apps/backend/internal/worktree/manager_cleanup.go
+++ b/apps/backend/internal/worktree/manager_cleanup.go
@@ -103,7 +103,7 @@ func (m *Manager) removeWorktree(ctx context.Context, wt *Worktree, removeBranch
 		if err := m.ReleaseWorktreeReference(ctx, wt); err != nil {
 			return fmt.Errorf("release shared worktree reference %s: %w", wt.ID, err)
 		}
-		m.logger.Info("preserved worktree still referenced by another active session",
+		m.logger.Info("preserved worktree still referenced by another task session",
 			zap.String("worktree_id", wt.ID),
 			zap.String("session_id", wt.SessionID),
 			zap.Int("active_references", activeReferences))

--- a/apps/backend/internal/worktree/manager_cleanup_shared_reference_test.go
+++ b/apps/backend/internal/worktree/manager_cleanup_shared_reference_test.go
@@ -45,6 +45,43 @@ func TestCleanupWorktrees_PreservesSharedActiveReference(t *testing.T) {
 	assertWorktreeReferenceStatus(t, store, wt.ID, "session-borrower", StatusActive)
 }
 
+func TestCleanupWorktrees_PreservesParentWorkspaceWhenInheritedSubtaskDeleted(t *testing.T) {
+	mgr, store := newReferenceCleanupTestManager(t)
+	ctx := context.Background()
+	seedReferenceCleanupSession(t, store, "task-parent", "session-parent", models.TaskSessionStateCompleted)
+	seedReferenceCleanupSession(t, store, "task-child", "session-child", models.TaskSessionStateCancelled)
+	if _, err := store.db.ExecContext(ctx, `UPDATE tasks SET parent_id = ? WHERE id = ?`, "task-parent", "task-child"); err != nil {
+		t.Fatalf("link inherited subtask: %v", err)
+	}
+
+	parent := createReferenceCleanupWorktree(t, mgr, "task-parent", "session-parent")
+	child := *parent
+	child.TaskID = "task-child"
+	child.SessionID = "session-child"
+	if err := store.CreateWorktree(ctx, &child); err != nil {
+		t.Fatalf("create inherited subtask worktree reference: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx, `DELETE FROM tasks WHERE id = ?`, "task-child"); err != nil {
+		t.Fatalf("delete inherited subtask: %v", err)
+	}
+
+	if err := mgr.CleanupWorktrees(ctx, []*Worktree{&child}); err != nil {
+		t.Fatalf("cleanup inherited subtask worktree: %v", err)
+	}
+
+	if _, err := os.Stat(parent.Path); err != nil {
+		t.Fatalf("parent workspace should survive inherited subtask deletion: %v", err)
+	}
+	assertWorktreeReferenceStatus(t, store, parent.ID, "session-parent", StatusActive)
+	var parentTasks int
+	if err := store.ro.QueryRowContext(ctx, `SELECT COUNT(*) FROM tasks WHERE id = ?`, "task-parent").Scan(&parentTasks); err != nil {
+		t.Fatalf("count surviving parent task: %v", err)
+	}
+	if parentTasks != 1 {
+		t.Fatalf("surviving parent tasks = %d, want 1", parentTasks)
+	}
+}
+
 func TestCleanupWorktrees_RemovesLastActiveReference(t *testing.T) {
 	mgr, store := newReferenceCleanupTestManager(t)
 	seedReferenceCleanupSession(t, store, "task-owner", "session-owner", models.TaskSessionStateCompleted)

--- a/apps/backend/internal/worktree/store.go
+++ b/apps/backend/internal/worktree/store.go
@@ -10,7 +10,6 @@ import (
 	"github.com/jmoiron/sqlx"
 
 	"github.com/kandev/kandev/internal/db"
-	"github.com/kandev/kandev/internal/task/models"
 )
 
 // SQLiteStore implements Store interface using SQLite.
@@ -453,8 +452,9 @@ func (s *SQLiteStore) ListActiveWorktreePaths(ctx context.Context) ([]string, er
 	return paths, rows.Err()
 }
 
-// CountActiveWorktreeReferences counts non-deleted worktree associations whose
-// sessions are not terminal, excluding associations owned by the caller.
+// CountActiveWorktreeReferences counts non-deleted worktree associations,
+// excluding associations owned by the caller. A terminal session still protects
+// its task workspace until that task's own cleanup releases the association.
 func (s *SQLiteStore) CountActiveWorktreeReferences(
 	ctx context.Context,
 	worktreeID string,
@@ -467,14 +467,10 @@ func (s *SQLiteStore) CountActiveWorktreeReferences(
 		WHERE tsw.worktree_id = ?
 		  AND tsw.status <> ?
 		  AND tsw.deleted_at IS NULL
-		  AND s.state NOT IN (?, ?, ?)
 	`
 	args := []interface{}{
 		worktreeID,
 		StatusDeleted,
-		models.TaskSessionStateCompleted,
-		models.TaskSessionStateFailed,
-		models.TaskSessionStateCancelled,
 	}
 	if len(excludeSessionIDs) > 0 {
 		query += ` AND tsw.session_id NOT IN (?)`

--- a/apps/backend/internal/worktree/store.go
+++ b/apps/backend/internal/worktree/store.go
@@ -463,7 +463,6 @@ func (s *SQLiteStore) CountActiveWorktreeReferences(
 	query := `
 		SELECT COUNT(*)
 		FROM task_session_worktrees tsw
-		INNER JOIN task_sessions s ON s.id = tsw.session_id
 		WHERE tsw.worktree_id = ?
 		  AND tsw.status <> ?
 		  AND tsw.deleted_at IS NULL


### PR DESCRIPTION
Deleting an inherited subtask could remove a workspace still needed by its parent. Terminal references now remain protective, and shared environment ownership moves to a surviving member before lifecycle cleanup.

## Validation

- `make fmt`
- `make typecheck`
- `make test`
- `make lint`
- `go test -race ./internal/worktree ./internal/task/service`
- Confirmed existing specs already require this behavior; no public docs change.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1840?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->