### PR TITLE
feat(plugins): add main-top-bar slot for the default app top bar

### DIFF
--- a/apps/backend/cmd/plugin-fixture/fixture-package/ui/bundle.js
+++ b/apps/backend/cmd/plugin-fixture/fixture-package/ui/bundle.js
@@ -4,7 +4,8 @@
  * imports, no bundled React — that calls `window.registerKandevPlugin(id,
  * plugin)` at evaluation time and, on `initialize(registry, host)`,
  * registers a nav item, a top-level route, a `task-sidebar` slot component,
- * and a `task.created` WS handler. Uses only host.React/host.jsx.
+ * a `main-top-bar` slot component, and a `task.created` WS handler. Uses
+ * only host.React/host.jsx.
  *
  * The task-created counter lives in module scope (not component state) with
  * a tiny listener set, so it survives across route navigations (the page
@@ -58,6 +59,11 @@
         return jsx("div", { id: "hello-sidebar" }, "Hello E2E sidebar");
       }
 
+      function MainTopBarSlot(props) {
+        var slotProps = props.slotProps || {};
+        return jsx("span", { id: "hello-main-top-bar" }, "Hello " + slotProps.currentPage);
+      }
+
       registry.registerNavItem({
         id: "e2e-hello",
         label: "Hello E2E",
@@ -66,6 +72,7 @@
       });
       registry.registerRoute("/plugins/e2e-hello", PluginPage);
       registry.registerComponent("task-sidebar", SidebarSlot);
+      registry.registerComponent("main-top-bar", MainTopBarSlot);
       registry.registerWsHandler("task.created", function () {
         incrementCount();
       });

--- a/apps/web/components/kanban/kanban-header-mobile.tsx
+++ b/apps/web/components/kanban/kanban-header-mobile.tsx
@@ -48,7 +48,7 @@ function MobileHeaderActions({
 }: {
   workspaceId?: string;
   workspaceLabel: string;
-  currentPage: string;
+  currentPage: "kanban" | "tasks";
   onSearchChange?: (query: string) => void;
   isSearchOpen: boolean;
   handleOpenQuickChat: () => void;

--- a/apps/web/components/kanban/kanban-header-mobile.tsx
+++ b/apps/web/components/kanban/kanban-header-mobile.tsx
@@ -5,6 +5,7 @@ import { IconMenu2, IconMessageCircle, IconSearch } from "@tabler/icons-react";
 import Link from "@/components/routing/app-link";
 import { PageTopbar } from "@/components/page-topbar";
 import { TopbarMetrics } from "@/components/system-metrics/topbar-metrics";
+import { MainTopBarPluginActions } from "./main-top-bar-plugin-actions";
 import { MobileMenuSheet } from "./mobile-menu-sheet";
 import { useAppStore } from "@/components/state-provider";
 import { useQuickChatLauncher } from "@/hooks/use-quick-chat-launcher";
@@ -32,6 +33,71 @@ function MobileBrandLink({ workspaceId }: Pick<KanbanHeaderMobileProps, "workspa
     >
       Kandev
     </Link>
+  );
+}
+
+function MobileHeaderActions({
+  workspaceId,
+  workspaceLabel,
+  currentPage,
+  onSearchChange,
+  isSearchOpen,
+  handleOpenQuickChat,
+  toggleSearch,
+  setMenuOpen,
+}: {
+  workspaceId?: string;
+  workspaceLabel: string;
+  currentPage: string;
+  onSearchChange?: (query: string) => void;
+  isSearchOpen: boolean;
+  handleOpenQuickChat: () => void;
+  toggleSearch: () => void;
+  setMenuOpen: (open: boolean) => void;
+}) {
+  return (
+    <>
+      <MainTopBarPluginActions
+        workspaceId={workspaceId}
+        workspaceLabel={workspaceLabel}
+        currentPage={currentPage}
+      />
+      <TopbarMetrics size="lg" />
+      {workspaceId && (
+        <Button
+          variant="outline"
+          size="icon-lg"
+          onClick={handleOpenQuickChat}
+          className="cursor-pointer"
+          aria-label="Quick Chat"
+          data-testid="mobile-quick-chat-button"
+        >
+          <IconMessageCircle className="h-4 w-4" />
+        </Button>
+      )}
+      {onSearchChange && (
+        <Button
+          variant={isSearchOpen ? "secondary" : "outline"}
+          size="icon-lg"
+          onClick={toggleSearch}
+          className="cursor-pointer"
+          aria-pressed={isSearchOpen}
+          aria-label="Search tasks"
+          data-testid="mobile-search-toggle"
+        >
+          <IconSearch className="h-4 w-4" />
+        </Button>
+      )}
+      <Button
+        variant="outline"
+        size="icon-lg"
+        onClick={() => setMenuOpen(true)}
+        className="cursor-pointer"
+      >
+        <IconMenu2 className="h-4 w-4" />
+        <span className="sr-only">Open menu</span>
+      </Button>
+    </>
   );
 }
 
@@ -82,43 +148,16 @@ export function KanbanHeaderMobile({
         }
         actionsClassName="gap-2"
         actions={
-          <>
-            <TopbarMetrics size="lg" />
-            {workspaceId && (
-              <Button
-                variant="outline"
-                size="icon-lg"
-                onClick={handleOpenQuickChat}
-                className="cursor-pointer"
-                aria-label="Quick Chat"
-                data-testid="mobile-quick-chat-button"
-              >
-                <IconMessageCircle className="h-4 w-4" />
-              </Button>
-            )}
-            {onSearchChange && (
-              <Button
-                variant={isSearchOpen ? "secondary" : "outline"}
-                size="icon-lg"
-                onClick={toggleSearch}
-                className="cursor-pointer"
-                aria-pressed={isSearchOpen}
-                aria-label="Search tasks"
-                data-testid="mobile-search-toggle"
-              >
-                <IconSearch className="h-4 w-4" />
-              </Button>
-            )}
-            <Button
-              variant="outline"
-              size="icon-lg"
-              onClick={() => setMenuOpen(true)}
-              className="cursor-pointer"
-            >
-              <IconMenu2 className="h-4 w-4" />
-              <span className="sr-only">Open menu</span>
-            </Button>
-          </>
+          <MobileHeaderActions
+            workspaceId={workspaceId}
+            workspaceLabel={workspaceLabel}
+            currentPage={currentPage}
+            onSearchChange={onSearchChange}
+            isSearchOpen={isSearchOpen}
+            handleOpenQuickChat={handleOpenQuickChat}
+            toggleSearch={toggleSearch}
+            setMenuOpen={setMenuOpen}
+          />
         }
       />
       <MobileMenuSheet

--- a/apps/web/components/kanban/kanban-header.tsx
+++ b/apps/web/components/kanban/kanban-header.tsx
@@ -153,7 +153,7 @@ function TabletHeader({
   title: string;
   workspaceLabel: string;
   workspaceId?: string;
-  currentPage: string;
+  currentPage: "kanban" | "tasks";
   searchQuery: string;
   onSearchChange?: (query: string) => void;
   isSearchLoading: boolean;
@@ -245,7 +245,7 @@ function DesktopHeader({
   title: string;
   workspaceLabel: string;
   workspaceId?: string;
-  currentPage: string;
+  currentPage: "kanban" | "tasks";
   searchQuery: string;
   onSearchChange?: (query: string) => void;
   isSearchLoading: boolean;

--- a/apps/web/components/kanban/kanban-header.tsx
+++ b/apps/web/components/kanban/kanban-header.tsx
@@ -18,6 +18,7 @@ import { ReleaseNotesDialog } from "../release-notes/release-notes-dialog";
 import { HealthIndicatorButton, HealthIssuesDialog } from "../system-health/health-indicator";
 import { TaskSearchInput } from "./task-search-input";
 import { KanbanHeaderMobile } from "./kanban-header-mobile";
+import { MainTopBarPluginActions } from "./main-top-bar-plugin-actions";
 import { MobileMenuSheet } from "./mobile-menu-sheet";
 import { linkToTasks } from "@/lib/links";
 import { useResponsiveBreakpoint } from "@/hooks/use-responsive-breakpoint";
@@ -138,6 +139,7 @@ function TabletHeader({
   title,
   workspaceLabel,
   workspaceId,
+  currentPage,
   searchQuery,
   onSearchChange,
   isSearchLoading,
@@ -151,6 +153,7 @@ function TabletHeader({
   title: string;
   workspaceLabel: string;
   workspaceId?: string;
+  currentPage: string;
   searchQuery: string;
   onSearchChange?: (query: string) => void;
   isSearchLoading: boolean;
@@ -183,6 +186,11 @@ function TabletHeader({
               className="hidden md:flex w-48 lg:w-56 [&_input]:h-8"
             />
           )}
+          <MainTopBarPluginActions
+            workspaceId={workspaceId}
+            workspaceLabel={workspaceLabel}
+            currentPage={currentPage}
+          />
           <TopbarMetrics size="lg" />
           {workspaceId && (
             <Button
@@ -223,6 +231,8 @@ function TabletHeader({
 function DesktopHeader({
   title,
   workspaceLabel,
+  workspaceId,
+  currentPage,
   searchQuery,
   onSearchChange,
   isSearchLoading,
@@ -234,6 +244,8 @@ function DesktopHeader({
 }: {
   title: string;
   workspaceLabel: string;
+  workspaceId?: string;
+  currentPage: string;
   searchQuery: string;
   onSearchChange?: (query: string) => void;
   isSearchLoading: boolean;
@@ -271,6 +283,11 @@ function DesktopHeader({
       actions={
         <>
           {actionsSearch}
+          <MainTopBarPluginActions
+            workspaceId={workspaceId}
+            workspaceLabel={workspaceLabel}
+            currentPage={currentPage}
+          />
           <TopbarMetrics size="lg" />
           <TooltipProvider>
             <ViewToggleGroup toggleValue={toggleValue} onValueChange={handleViewChange} size="lg" />
@@ -353,6 +370,7 @@ export function KanbanHeader({
             title={title}
             workspaceLabel={workspaceLabel}
             workspaceId={workspaceId}
+            currentPage={currentPage}
             hideTitle={hideTitle}
             {...sharedSearch}
             toggleValue={toggleValue}
@@ -375,6 +393,8 @@ export function KanbanHeader({
       <DesktopHeader
         title={title}
         workspaceLabel={workspaceLabel}
+        workspaceId={workspaceId}
+        currentPage={currentPage}
         hideTitle={hideTitle}
         {...sharedSearch}
         toggleValue={toggleValue}

--- a/apps/web/components/kanban/main-top-bar-plugin-actions.test.tsx
+++ b/apps/web/components/kanban/main-top-bar-plugin-actions.test.tsx
@@ -1,0 +1,46 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { pluginRegistry } from "@/lib/plugins/registry";
+import { MainTopBarPluginActions, type MainTopBarSlotProps } from "./main-top-bar-plugin-actions";
+
+const SLOT = "main-top-bar";
+
+describe("MainTopBarPluginActions", () => {
+  afterEach(() => {
+    cleanup();
+    pluginRegistry.unregisterPlugin("plugin-a");
+  });
+
+  it("renders nothing when no plugin registered a main-top-bar component", () => {
+    const { container } = render(
+      <MainTopBarPluginActions workspaceId="w1" workspaceLabel="Acme" currentPage="kanban" />,
+    );
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("forwards the active workspace and current view as slotProps", () => {
+    pluginRegistry.forPlugin("plugin-a").registerComponent(SLOT, ({ slotProps }) => {
+      const ctx = slotProps as MainTopBarSlotProps;
+      return (
+        <div data-testid="plugin-app-bar">
+          {`${ctx.workspaceId}|${ctx.workspaceLabel}|${ctx.currentPage}`}
+        </div>
+      );
+    });
+
+    render(<MainTopBarPluginActions workspaceId="w1" workspaceLabel="Acme" currentPage="tasks" />);
+
+    expect(screen.getByTestId("plugin-app-bar").textContent).toBe("w1|Acme|tasks");
+  });
+
+  it("normalizes an absent workspace id to null", () => {
+    pluginRegistry.forPlugin("plugin-a").registerComponent(SLOT, ({ slotProps }) => {
+      const ctx = slotProps as MainTopBarSlotProps;
+      return <div data-testid="plugin-app-bar">{String(ctx.workspaceId)}</div>;
+    });
+
+    render(<MainTopBarPluginActions currentPage="kanban" />);
+
+    expect(screen.getByTestId("plugin-app-bar").textContent).toBe("null");
+  });
+});

--- a/apps/web/components/kanban/main-top-bar-plugin-actions.tsx
+++ b/apps/web/components/kanban/main-top-bar-plugin-actions.tsx
@@ -20,8 +20,8 @@ export type MainTopBarSlotProps = {
   workspaceId: string | null;
   /** Human-readable label of that workspace, when known. */
   workspaceLabel?: string;
-  /** Which listing the top bar belongs to ("kanban" | "tasks"). */
-  currentPage: string;
+  /** Which listing the top bar belongs to. */
+  currentPage: "kanban" | "tasks";
 };
 
 /**
@@ -35,7 +35,7 @@ export type MainTopBarSlotProps = {
 export function MainTopBarPluginActions(props: {
   workspaceId?: string;
   workspaceLabel?: string;
-  currentPage: string;
+  currentPage: "kanban" | "tasks";
 }) {
   const { workspaceId, workspaceLabel, currentPage } = props;
 

--- a/apps/web/components/kanban/main-top-bar-plugin-actions.tsx
+++ b/apps/web/components/kanban/main-top-bar-plugin-actions.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useMemo } from "react";
+import { PluginSlot } from "@/components/plugins/plugin-slot";
+
+/**
+ * Props forwarded to every plugin component registered for the `main-top-bar`
+ * slot (`registry.registerComponent("main-top-bar", Component)`). This is the
+ * default app top bar's right-hand cluster on the Home / Kanban / Tasks views,
+ * beside the CPU/DB metrics and the view/display controls — the place for
+ * at-a-glance status or an action a plugin wants to surface app-wide, as
+ * opposed to the per-session `chat-top-bar` slot.
+ *
+ * The bar is not scoped to a task, so no task/session ids are provided; the
+ * context a plugin gets is the active workspace and which listing view is
+ * showing.
+ */
+export type MainTopBarSlotProps = {
+  /** Workspace the top bar is currently showing, or null on the global home. */
+  workspaceId: string | null;
+  /** Human-readable label of that workspace, when known. */
+  workspaceLabel?: string;
+  /** Which listing the top bar belongs to ("kanban" | "tasks"). */
+  currentPage: string;
+};
+
+/**
+ * Plugin extension point in the default app top bar (Home / Kanban / Tasks),
+ * rendered alongside the first-party controls (metrics, view toggle, display
+ * menu, health indicator). Renders every plugin component registered for the
+ * `main-top-bar` slot (each isolated behind its own error boundary via
+ * `PluginSlot`) and forwards the active workspace and current view as
+ * `slotProps`.
+ */
+export function MainTopBarPluginActions(props: {
+  workspaceId?: string;
+  workspaceLabel?: string;
+  currentPage: string;
+}) {
+  const { workspaceId, workspaceLabel, currentPage } = props;
+
+  const slotProps = useMemo<MainTopBarSlotProps>(
+    () => ({ workspaceId: workspaceId ?? null, workspaceLabel, currentPage }),
+    [workspaceId, workspaceLabel, currentPage],
+  );
+
+  return <PluginSlot name="main-top-bar" slotProps={slotProps} />;
+}

--- a/apps/web/e2e/tests/plugins/plugins.spec.ts
+++ b/apps/web/e2e/tests/plugins/plugins.spec.ts
@@ -21,8 +21,9 @@
  *      and spawns it synchronously, so it comes back `active` in the same
  *      response. No signature was attached, so the unsigned badge shows.
  *   2. Reload the SPA — the boot payload now carries the active plugin — and
- *      confirm its nav item, top-level route, and `task-sidebar` slot render
- *      via the real `/api/plugins/:id/bundle` static-file proxy.
+ *      confirm its nav item, top-level route, `task-sidebar` slot, and
+ *      `main-top-bar` slot render via the real `/api/plugins/:id/bundle`
+ *      static-file proxy.
  *   3. Create a task while the plugin's own page stays mounted (no
  *      navigation in between) and prove BOTH real gRPC paths at once:
  *        - task.created -> Deliverer -> plugin subprocess OnEvent RPC,
@@ -141,6 +142,10 @@ test.describe("Plugins — gRPC plugin install/load/live-update/uninstall", () =
     const navItem = testPage.getByTestId(`plugin-nav-item-${NAV_ITEM_ID}`);
     await expect(navItem).toBeVisible({ timeout: 15_000 });
     await expect(navItem).toHaveText("Hello E2E");
+
+    // --- 2b. main-top-bar slot renders on the default app top bar (Home) ---
+    await expect(testPage.locator("#hello-main-top-bar")).toBeVisible();
+    await expect(testPage.locator("#hello-main-top-bar")).toHaveText("Hello kanban");
 
     await navItem.click();
     await expect(testPage).toHaveURL(new RegExp(`${PLUGIN_ROUTE}$`));

--- a/apps/web/lib/plugins/types.ts
+++ b/apps/web/lib/plugins/types.ts
@@ -76,7 +76,11 @@ export interface PluginRouteOptions {
  * send — receives `{ taskId, taskTitle, activeSessionId, sessionIds }` as
  * `slotProps`), "chat-top-bar" (status in the session top bar, beside the
  * CPU/DB metrics — receives `{ taskId, taskTitle, workspaceId, activeSessionId,
- * sessionIds }`), and "plugin-settings" (inline UI on a plugin's own settings
+ * sessionIds }`), "main-top-bar" (status/actions in the default app top bar on
+ * the Home / Kanban / Tasks views, beside the CPU/DB metrics and the
+ * view/display controls — the app-wide, task-agnostic counterpart to
+ * "chat-top-bar"; receives `{ workspaceId, workspaceLabel, currentPage }`), and
+ * "plugin-settings" (inline UI on a plugin's own settings
  * page, Settings > Plugins > <plugin>, at the top above the settings form —
  * receives `{ pluginId: string; status: PluginStatus }` as
  * `slotProps`). "plugin-settings" is owner-scoped: the host renders only the

--- a/docs/plans/plugins/PLUGIN-API.md
+++ b/docs/plans/plugins/PLUGIN-API.md
@@ -124,7 +124,7 @@ interface PluginRegistry {
   // Named slot injection. Host renders all components registered for a slot via
   // <PluginSlot name="..." props={...}/>. Initial slots: "task-sidebar",
   // "settings-nav", "main-nav-footer", "chat-input-actions", "chat-top-bar",
-  // "plugin-settings".
+  // "main-top-bar", "plugin-settings".
   // "chat-input-actions" renders icon buttons in the chat composer toolbar
   // (beside the model picker, mic, and send) and forwards
   // `{ taskId, taskTitle, activeSessionId, sessionIds }` as `slotProps`.
@@ -132,6 +132,11 @@ interface PluginRegistry {
   // metrics and the document/editor/debug controls) and forwards
   // `{ taskId, taskTitle, workspaceId, activeSessionId, sessionIds }`. Both
   // carry the active session plus every kandev session id on the task.
+  // "main-top-bar" renders status/actions in the default app top bar on the
+  // Home / Kanban / Tasks views (beside the CPU/DB metrics and the view/display
+  // controls) and forwards `{ workspaceId, workspaceLabel, currentPage }`. It is
+  // the app-wide, task-agnostic counterpart to "chat-top-bar", so it carries no
+  // task/session ids.
   // Resolving a session id to an agent/ACP transcript id (e.g. to key
   // tokscale cost data on a session) is the plugin's job, done server-side in
   // the plugin backend via the Host data API; the host only propagates ids.

--- a/docs/public/plugins-authoring.md
+++ b/docs/public/plugins-authoring.md
@@ -252,8 +252,8 @@ interface PluginRegistry {
   // Route under /settings/plugins/{id}/..., rendered inside the settings shell.
   registerSettingsRoute(path: string, Component: React.ComponentType): void;
   // Named slot injection. Initial slots: "task-sidebar", "settings-nav",
-  // "main-nav-footer", "chat-input-actions", "chat-top-bar", "plugin-settings"
-  // (see "Named slots" below).
+  // "main-nav-footer", "chat-input-actions", "chat-top-bar", "main-top-bar",
+  // "plugin-settings" (see "Named slots" below).
   registerComponent(slot: string, Component: React.ComponentType<{ slotProps?: unknown }>): void;
   // WS action handler, bridged into the existing lib/ws dispatch.
   registerWsHandler(action: string, handler: (payload: unknown) => void): void;
@@ -344,6 +344,7 @@ plugins at once. Available slots:
 | `main-nav-footer` | Footer of the main sidebar | — |
 | `chat-input-actions` | Chat composer toolbar, beside the model picker, mic, and send button | `{ taskId, taskTitle, activeSessionId, sessionIds }` |
 | `chat-top-bar` | Session top bar, beside the CPU/DB metrics and the document/editor/debug controls | `{ taskId, taskTitle, workspaceId, activeSessionId, sessionIds }` |
+| `main-top-bar` | Default app top bar (Home / Kanban / Tasks), beside the CPU/DB metrics and the view/display controls | `{ workspaceId, workspaceLabel, currentPage }` |
 | `plugin-settings` | A plugin's own settings page (**Settings > Plugins > `<plugin>`**), at the top above the settings form | `{ pluginId, status }` |
 
 `plugin-settings` is the one exception to "every plugin's component renders":
@@ -439,6 +440,32 @@ metric chips.
 ```js
 // inside initialize(registry, host):
 registry.registerComponent("chat-top-bar", makeTopBarStatus(host));
+```
+
+### Default app top bar
+
+Register a `main-top-bar` component to add status or a small action to the
+**default app top bar** — the strip across the Home, Kanban, and Tasks views,
+beside the CPU/DB metrics and the view/display controls. This is the app-wide,
+task-agnostic counterpart to `chat-top-bar`: use it for something that isn't
+tied to one session (a workspace-level indicator, a global quick action). The
+host passes:
+
+```ts
+type MainTopBarSlotProps = {
+  workspaceId: string | null;  // workspace the top bar is showing, null on global home
+  workspaceLabel?: string;     // human-readable workspace name, when known
+  currentPage: string;         // which listing is showing: "kanban" | "tasks"
+};
+```
+
+Because the bar is not scoped to a task, no task/session ids are provided. Like
+`chat-top-bar` it is a compact horizontal strip, so keep contributions to small
+badges or `h-7` buttons that match the native metric chips.
+
+```js
+// inside initialize(registry, host):
+registry.registerComponent("main-top-bar", makeAppBarStatus(host));
 ```
 
 ### Plugin settings page

--- a/docs/public/plugins-authoring.md
+++ b/docs/public/plugins-authoring.md
@@ -455,7 +455,7 @@ host passes:
 type MainTopBarSlotProps = {
   workspaceId: string | null;  // workspace the top bar is showing, null on global home
   workspaceLabel?: string;     // human-readable workspace name, when known
-  currentPage: string;         // which listing is showing: "kanban" | "tasks"
+  currentPage: "kanban" | "tasks";
 };
 ```
 


### PR DESCRIPTION
Plugins could only surface UI in the per-session chat top bar (`chat-top-bar`); there was no way to contribute to the default app top bar shown on Home / Kanban / Tasks, so this adds a matching `main-top-bar` slot there.

## Important Changes

- New `main-top-bar` plugin slot, mounted in all three responsive variants of the default top bar (`DesktopHeader`, `TabletHeader` in `kanban-header.tsx`, and `KanbanHeaderMobile`), passing `{ workspaceId, workspaceLabel, currentPage }` as `slotProps` — no task/session ids, since this bar isn't scoped to a task.
- Extracted `MobileHeaderActions` out of `KanbanHeaderMobile` to stay under the 100-line function lint limit after adding the new slot mount.
- Documented the new slot everywhere the existing slots are enumerated: `apps/web/lib/plugins/types.ts`, `docs/plans/plugins/PLUGIN-API.md`, and `docs/public/plugins-authoring.md` (including the Named Slots table and a worked example), and verified `plugin-settings` was already fully documented while auditing.
- Extended the `kandev-plugin-e2e` fixture bundle to also register a `main-top-bar` component, and added an assertion in `plugins.spec.ts` that it renders on the real Home page top bar.

## Validation

- `pnpm test components/kanban/` (`apps/web`) — all kanban header + new slot wrapper tests pass
- `pnpm run typecheck` / `pnpm run lint` (`apps/web`)
- Full repo `make fmt`, `make typecheck`, `make test`, `make lint` via the verify pipeline — all pass
- `apps/web/e2e/tests/plugins/plugins.spec.ts` run locally against a real built backend + web app (`make build-backend build-web e2e-plugin-package`), including the new `main-top-bar` assertion — passes

## Possible Improvements

Low risk: purely additive UI slot mirroring the existing `chat-top-bar` pattern.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have manually tested my changes and they work as expected.
- [x] My changes have tests that cover the new functionality and edge cases.
- [x] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [x] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.

## Screenshots

The `main-top-bar` slot rendering on the default app top bar (Home), via the real `kandev-plugin-e2e` fixture plugin (`e2e/tests/plugins/plugins.spec.ts`) — "Hello kanban" next to the view toggle/display controls:

![main-top-bar slot](https://raw.githubusercontent.com/kdlbs/kandev/ab49e73abe919342e3ca9157a84427f6abf45adc/main-top-bar-slot.png)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1841?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
