### PR TITLE
fix(settings): order plugins before system

### DIFF
--- a/apps/web/components/app-sidebar/sections/settings/settings-tree-render.test.tsx
+++ b/apps/web/components/app-sidebar/sections/settings/settings-tree-render.test.tsx
@@ -222,7 +222,10 @@ describe("SettingsTree integration status", () => {
 });
 
 describe("SettingsTree standalone leaves", () => {
-  afterEach(() => cleanup());
+  afterEach(() => {
+    cleanup();
+    state.features.plugins = false;
+  });
 
   it("keeps Voice Mode in the settings tree as a standalone active leaf", () => {
     render(<SettingsTree pathname="/settings" />);
@@ -239,6 +242,19 @@ describe("SettingsTree standalone leaves", () => {
       "before:bg-primary",
     );
     expect(screen.queryByRole("link", { name: "Appearance" })).toBeNull();
+  });
+
+  it("puts Plugins immediately before System when plugins are enabled", () => {
+    state.features.plugins = true;
+
+    render(<SettingsTree pathname="/settings" />);
+
+    expect(
+      screen
+        .getAllByRole("link")
+        .slice(-2)
+        .map((link) => link.textContent),
+    ).toEqual(["Plugins", "System"]);
   });
 });
 

--- a/apps/web/components/app-sidebar/sections/settings/settings-tree.tsx
+++ b/apps/web/components/app-sidebar/sections/settings/settings-tree.tsx
@@ -108,7 +108,7 @@ export function SettingsTree({ pathname }: { pathname: string }) {
         icon={IconPlugConnected}
         isActive={pathname === EXT_MCP_HREF}
       />
-      <SystemGroup pathname={pathname} {...groupProps("system")} />
+      <PluginSlot name="settings-nav" />
       {pluginsEnabled && (
         <SettingsLeaf
           href={PLUGINS_HREF}
@@ -117,7 +117,7 @@ export function SettingsTree({ pathname }: { pathname: string }) {
           isActive={pathname === PLUGINS_HREF}
         />
       )}
-      <PluginSlot name="settings-nav" />
+      <SystemGroup pathname={pathname} {...groupProps("system")} />
     </>
   );
 }


### PR DESCRIPTION
Settings navigation now keeps Plugins immediately before System when enabled, so System remains final.

## Validation

- `make fmt`
- `make typecheck`
- `TMPDIR=/tmp make test`
- `pnpm --filter @kandev/web test`
- `make lint`
- No docs change: public docs do not prescribe settings navigation order.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.

## Screenshots

![Desktop settings navigation](https://raw.githubusercontent.com/kdlbs/kandev/02736b794db0f274a8c081f7cd41480841405926/settings-nav-desktop.png)

![Mobile settings navigation](https://raw.githubusercontent.com/kdlbs/kandev/02736b794db0f274a8c081f7cd41480841405926/settings-nav-mobile.png)
