### PR TITLE
fix: reset office session state when execution profile changes

### DIFF
--- a/apps/backend/internal/orchestrator/executor/executor_mocks_test.go
+++ b/apps/backend/internal/orchestrator/executor/executor_mocks_test.go
@@ -406,6 +406,17 @@ func (m *mockRepository) UpdateTaskSessionIfCurrentState(
 	return true, nil
 }
 
+func (m *mockRepository) UpdateTaskSessionIfCurrentStateWithMetadata(
+	ctx context.Context,
+	session *models.TaskSession,
+	expected models.TaskSessionState,
+	metadata map[string]interface{},
+) (bool, error) {
+	updated := cloneMockTaskSession(session)
+	updated.Metadata = cloneMockSessionMap(metadata)
+	return m.UpdateTaskSessionIfCurrentState(ctx, updated, expected)
+}
+
 func cloneMockTaskSession(session *models.TaskSession) *models.TaskSession {
 	if session == nil {
 		return nil

--- a/apps/backend/internal/orchestrator/executor/executor_mocks_test.go
+++ b/apps/backend/internal/orchestrator/executor/executor_mocks_test.go
@@ -406,14 +406,16 @@ func (m *mockRepository) UpdateTaskSessionIfCurrentState(
 	return true, nil
 }
 
-func (m *mockRepository) UpdateTaskSessionIfCurrentStateWithMetadata(
+func (m *mockRepository) UpdateTaskSessionIfCurrentStateRemovingMetadataKeys(
 	ctx context.Context,
 	session *models.TaskSession,
 	expected models.TaskSessionState,
-	metadata map[string]interface{},
+	keys []string,
 ) (bool, error) {
 	updated := cloneMockTaskSession(session)
-	updated.Metadata = cloneMockSessionMap(metadata)
+	for _, key := range keys {
+		delete(updated.Metadata, key)
+	}
 	return m.UpdateTaskSessionIfCurrentState(ctx, updated, expected)
 }
 

--- a/apps/backend/internal/orchestrator/executor/executor_office.go
+++ b/apps/backend/internal/orchestrator/executor/executor_office.go
@@ -87,6 +87,19 @@ func (e *Executor) rebindOfficeSessionExecutionProfile(
 		updated.ExecutionProfileID = executionProfileID
 		updated.AgentProfileSnapshot = snapshot
 		updated.IsPassthrough = isPassthrough
+		// Provider-native state must not override the newly selected profile.
+		updated.Metadata = cloneMetadata(session.Metadata)
+		for _, key := range []string{
+			"acp_session_id",
+			models.SessionMetaKeySessionMode,
+			models.SessionMetaKeyRuntimeConfig,
+			models.SessionMetaKeyRuntimeConfigOverrides,
+			models.SessionMetaKeyACPConfigBaseline,
+			models.SessionMetaKeyACPModelState,
+			"context_window",
+		} {
+			delete(updated.Metadata, key)
+		}
 		changed, err := e.repo.UpdateTaskSessionIfCurrentState(ctx, &updated, expectedState)
 		if err != nil {
 			return fmt.Errorf("update office execution profile: %w", err)

--- a/apps/backend/internal/orchestrator/executor/executor_office.go
+++ b/apps/backend/internal/orchestrator/executor/executor_office.go
@@ -14,6 +14,15 @@ import (
 	"go.uber.org/zap"
 )
 
+type officeSessionMetadataUpdater interface {
+	UpdateTaskSessionIfCurrentStateWithMetadata(
+		ctx context.Context,
+		session *models.TaskSession,
+		expected models.TaskSessionState,
+		metadata map[string]interface{},
+	) (bool, error)
+}
+
 // EnsureSessionForAgent returns a persistent task session for the (task,
 // agent) pair, creating one when no row exists. This is the office run
 // entry point — every run for a participant agent ends up here. Distinct
@@ -97,10 +106,15 @@ func (e *Executor) rebindOfficeSessionExecutionProfile(
 			models.SessionMetaKeyACPConfigBaseline,
 			models.SessionMetaKeyACPModelState,
 			"context_window",
+			models.SessionMetaKeyLastAgentError,
 		} {
 			delete(updated.Metadata, key)
 		}
-		changed, err := e.repo.UpdateTaskSessionIfCurrentState(ctx, &updated, expectedState)
+		updater, ok := e.repo.(officeSessionMetadataUpdater)
+		if !ok {
+			return errors.New("office session rebind requires guarded metadata updates")
+		}
+		changed, err := updater.UpdateTaskSessionIfCurrentStateWithMetadata(ctx, &updated, expectedState, updated.Metadata)
 		if err != nil {
 			return fmt.Errorf("update office execution profile: %w", err)
 		}

--- a/apps/backend/internal/orchestrator/executor/executor_office.go
+++ b/apps/backend/internal/orchestrator/executor/executor_office.go
@@ -86,6 +86,10 @@ func (e *Executor) rebindOfficeSessionExecutionProfile(
 		return nil
 	}
 	snapshot, isPassthrough := e.resolveAgentProfileSnapshot(ctx, executionProfileID)
+	updater, ok := e.repo.(officeSessionMetadataUpdater)
+	if !ok {
+		return errors.New("office session rebind requires guarded metadata updates")
+	}
 	for {
 		if isStopTerminalSessionState(session.State) {
 			return nil
@@ -109,10 +113,6 @@ func (e *Executor) rebindOfficeSessionExecutionProfile(
 			models.SessionMetaKeyLastAgentError,
 		} {
 			delete(updated.Metadata, key)
-		}
-		updater, ok := e.repo.(officeSessionMetadataUpdater)
-		if !ok {
-			return errors.New("office session rebind requires guarded metadata updates")
 		}
 		changed, err := updater.UpdateTaskSessionIfCurrentStateWithMetadata(ctx, &updated, expectedState, updated.Metadata)
 		if err != nil {

--- a/apps/backend/internal/orchestrator/executor/executor_office.go
+++ b/apps/backend/internal/orchestrator/executor/executor_office.go
@@ -15,11 +15,11 @@ import (
 )
 
 type officeSessionMetadataUpdater interface {
-	UpdateTaskSessionIfCurrentStateWithMetadata(
+	UpdateTaskSessionIfCurrentStateRemovingMetadataKeys(
 		ctx context.Context,
 		session *models.TaskSession,
 		expected models.TaskSessionState,
-		metadata map[string]interface{},
+		keys []string,
 	) (bool, error)
 }
 
@@ -114,7 +114,16 @@ func (e *Executor) rebindOfficeSessionExecutionProfile(
 		} {
 			delete(updated.Metadata, key)
 		}
-		changed, err := updater.UpdateTaskSessionIfCurrentStateWithMetadata(ctx, &updated, expectedState, updated.Metadata)
+		changed, err := updater.UpdateTaskSessionIfCurrentStateRemovingMetadataKeys(ctx, &updated, expectedState, []string{
+			"acp_session_id",
+			models.SessionMetaKeySessionMode,
+			models.SessionMetaKeyRuntimeConfig,
+			models.SessionMetaKeyRuntimeConfigOverrides,
+			models.SessionMetaKeyACPConfigBaseline,
+			models.SessionMetaKeyACPModelState,
+			"context_window",
+			models.SessionMetaKeyLastAgentError,
+		})
 		if err != nil {
 			return fmt.Errorf("update office execution profile: %w", err)
 		}

--- a/apps/backend/internal/orchestrator/executor/executor_office_test.go
+++ b/apps/backend/internal/orchestrator/executor/executor_office_test.go
@@ -75,6 +75,16 @@ func TestEnsureSessionForAgent_RebindsExecutionProfileOnReuse(t *testing.T) {
 		ExecutionProfileID: "codex-profile",
 		State:              models.TaskSessionStateIdle,
 		StartedAt:          time.Now().UTC(),
+		Metadata: map[string]interface{}{
+			"acp_session_id":                            "codex-session",
+			models.SessionMetaKeySessionMode:            "default",
+			models.SessionMetaKeyRuntimeConfig:          models.SessionRuntimeConfig{Model: "codex-model"},
+			models.SessionMetaKeyRuntimeConfigOverrides: models.SessionRuntimeConfig{Mode: "default"},
+			models.SessionMetaKeyACPConfigBaseline:      map[string]string{"model": "codex-model"},
+			models.SessionMetaKeyACPModelState:          map[string]interface{}{"current_model_id": "codex-model"},
+			"context_window":                            map[string]interface{}{"size": int64(200000)},
+			models.SessionMetaKeyPendingStepCompletion:  true,
+		},
 	}
 	repo.sessions[existing.ID] = existing
 
@@ -89,6 +99,22 @@ func TestEnsureSessionForAgent_RebindsExecutionProfileOnReuse(t *testing.T) {
 	}
 	if got.ExecutionProfileID != "claude-profile" {
 		t.Fatalf("execution profile = %q, want claude-profile", got.ExecutionProfileID)
+	}
+	for _, key := range []string{
+		"acp_session_id",
+		models.SessionMetaKeySessionMode,
+		models.SessionMetaKeyRuntimeConfig,
+		models.SessionMetaKeyRuntimeConfigOverrides,
+		models.SessionMetaKeyACPConfigBaseline,
+		models.SessionMetaKeyACPModelState,
+		"context_window",
+	} {
+		if _, exists := got.Metadata[key]; exists {
+			t.Errorf("provider runtime metadata %q survived execution profile change", key)
+		}
+	}
+	if got.Metadata[models.SessionMetaKeyPendingStepCompletion] != true {
+		t.Fatal("unrelated Office session metadata was not preserved")
 	}
 }
 

--- a/apps/backend/internal/orchestrator/executor/executor_office_test.go
+++ b/apps/backend/internal/orchestrator/executor/executor_office_test.go
@@ -38,6 +38,20 @@ func (r *officeRebindRaceRepository) UpdateTaskSessionIfCurrentState(
 	return r.mockRepository.UpdateTaskSessionIfCurrentState(ctx, session, expected)
 }
 
+func (r *officeRebindRaceRepository) UpdateTaskSessionIfCurrentStateWithMetadata(
+	ctx context.Context,
+	session *models.TaskSession,
+	expected models.TaskSessionState,
+	metadata map[string]interface{},
+) (bool, error) {
+	if r.beforeGuardedUpdate != nil {
+		hook := r.beforeGuardedUpdate
+		r.beforeGuardedUpdate = nil
+		hook()
+	}
+	return r.mockRepository.UpdateTaskSessionIfCurrentStateWithMetadata(ctx, session, expected, metadata)
+}
+
 func TestEnsureSessionForAgent_CreatesWhenMissing(t *testing.T) {
 	repo := newMockRepository()
 	exec := newTestExecutor(t, &mockAgentManager{}, repo)
@@ -83,6 +97,7 @@ func TestEnsureSessionForAgent_RebindsExecutionProfileOnReuse(t *testing.T) {
 			models.SessionMetaKeyACPConfigBaseline:      map[string]string{"model": "codex-model"},
 			models.SessionMetaKeyACPModelState:          map[string]interface{}{"current_model_id": "codex-model"},
 			"context_window":                            map[string]interface{}{"size": int64(200000)},
+			models.SessionMetaKeyLastAgentError:         models.LastAgentError{Message: "old provider failed"},
 			models.SessionMetaKeyPendingStepCompletion:  true,
 		},
 	}
@@ -108,6 +123,7 @@ func TestEnsureSessionForAgent_RebindsExecutionProfileOnReuse(t *testing.T) {
 		models.SessionMetaKeyACPConfigBaseline,
 		models.SessionMetaKeyACPModelState,
 		"context_window",
+		models.SessionMetaKeyLastAgentError,
 	} {
 		if _, exists := got.Metadata[key]; exists {
 			t.Errorf("provider runtime metadata %q survived execution profile change", key)

--- a/apps/backend/internal/orchestrator/executor/executor_office_test.go
+++ b/apps/backend/internal/orchestrator/executor/executor_office_test.go
@@ -30,26 +30,21 @@ func (r *officeRebindRaceRepository) UpdateTaskSessionIfCurrentState(
 	session *models.TaskSession,
 	expected models.TaskSessionState,
 ) (bool, error) {
-	if r.beforeGuardedUpdate != nil {
-		hook := r.beforeGuardedUpdate
-		r.beforeGuardedUpdate = nil
-		hook()
-	}
 	return r.mockRepository.UpdateTaskSessionIfCurrentState(ctx, session, expected)
 }
 
-func (r *officeRebindRaceRepository) UpdateTaskSessionIfCurrentStateWithMetadata(
+func (r *officeRebindRaceRepository) UpdateTaskSessionIfCurrentStateRemovingMetadataKeys(
 	ctx context.Context,
 	session *models.TaskSession,
 	expected models.TaskSessionState,
-	metadata map[string]interface{},
+	keys []string,
 ) (bool, error) {
 	if r.beforeGuardedUpdate != nil {
 		hook := r.beforeGuardedUpdate
 		r.beforeGuardedUpdate = nil
 		hook()
 	}
-	return r.mockRepository.UpdateTaskSessionIfCurrentStateWithMetadata(ctx, session, expected, metadata)
+	return r.mockRepository.UpdateTaskSessionIfCurrentStateRemovingMetadataKeys(ctx, session, expected, keys)
 }
 
 func TestEnsureSessionForAgent_CreatesWhenMissing(t *testing.T) {

--- a/apps/backend/internal/task/repository/sqlite/session.go
+++ b/apps/backend/internal/task/repository/sqlite/session.go
@@ -452,6 +452,38 @@ func (r *Repository) UpdateTaskSessionIfCurrentState(
 	return r.updateTaskSessionWithStateGuard(ctx, r.db, session, &expected)
 }
 
+// UpdateTaskSessionIfCurrentStateWithMetadata persists a full session row and
+// metadata atomically while the stored state still matches expected. This is
+// used when a guarded row update must also reset provider-owned metadata.
+func (r *Repository) UpdateTaskSessionIfCurrentStateWithMetadata(
+	ctx context.Context,
+	session *models.TaskSession,
+	expected models.TaskSessionState,
+	metadata map[string]interface{},
+) (bool, error) {
+	session.UpdatedAt = time.Now().UTC()
+	metadataJSON, err := marshalSessionMetadata(metadata)
+	if err != nil {
+		return false, err
+	}
+	tx, err := r.db.BeginTxx(ctx, nil)
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = tx.Rollback() }()
+	changed, err := r.updateTaskSessionWithStateGuard(ctx, tx, session, &expected)
+	if err != nil || !changed {
+		return changed, err
+	}
+	if err := r.updateSessionMetadataJSON(ctx, tx, session.ID, metadataJSON, session.UpdatedAt); err != nil {
+		return false, err
+	}
+	if err := tx.Commit(); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
 // UpdateTaskSessionWithMetadata updates the session row and metadata column in
 // one transaction so callers cannot observe a partially-applied update.
 func (r *Repository) UpdateTaskSessionWithMetadata(

--- a/apps/backend/internal/task/repository/sqlite/session.go
+++ b/apps/backend/internal/task/repository/sqlite/session.go
@@ -452,20 +452,16 @@ func (r *Repository) UpdateTaskSessionIfCurrentState(
 	return r.updateTaskSessionWithStateGuard(ctx, r.db, session, &expected)
 }
 
-// UpdateTaskSessionIfCurrentStateWithMetadata persists a full session row and
-// metadata atomically while the stored state still matches expected. This is
-// used when a guarded row update must also reset provider-owned metadata.
-func (r *Repository) UpdateTaskSessionIfCurrentStateWithMetadata(
+// UpdateTaskSessionIfCurrentStateRemovingMetadataKeys persists a full session
+// row and removes provider-owned metadata atomically while the stored state
+// still matches expected. JSON removal preserves unrelated concurrent keys.
+func (r *Repository) UpdateTaskSessionIfCurrentStateRemovingMetadataKeys(
 	ctx context.Context,
 	session *models.TaskSession,
 	expected models.TaskSessionState,
-	metadata map[string]interface{},
+	keys []string,
 ) (bool, error) {
 	session.UpdatedAt = time.Now().UTC()
-	metadataJSON, err := marshalSessionMetadata(metadata)
-	if err != nil {
-		return false, err
-	}
 	tx, err := r.db.BeginTxx(ctx, nil)
 	if err != nil {
 		return false, err
@@ -475,13 +471,58 @@ func (r *Repository) UpdateTaskSessionIfCurrentStateWithMetadata(
 	if err != nil || !changed {
 		return changed, err
 	}
-	if err := r.updateSessionMetadataJSON(ctx, tx, session.ID, metadataJSON, session.UpdatedAt); err != nil {
+	if err := r.removeSessionMetadataKeys(ctx, tx, session.ID, keys, session.UpdatedAt); err != nil {
 		return false, err
 	}
 	if err := tx.Commit(); err != nil {
 		return false, err
 	}
 	return true, nil
+}
+
+func (r *Repository) removeSessionMetadataKeys(
+	ctx context.Context,
+	exec taskSessionExecutor,
+	sessionID string,
+	keys []string,
+	updatedAt time.Time,
+) error {
+	if len(keys) == 0 {
+		return nil
+	}
+	driver := r.db.DriverName()
+	var query string
+	args := make([]interface{}, 0, len(keys)+2)
+	if dialect.IsPostgres(driver) {
+		expr := "(CASE WHEN metadata IS NULL OR metadata = 'null' OR metadata = '' THEN '{}'::jsonb ELSE metadata::jsonb END)"
+		for range keys {
+			expr = fmt.Sprintf("(%s #- ARRAY[?]::text[])", expr)
+		}
+		for _, key := range keys {
+			args = append(args, key)
+		}
+		query = fmt.Sprintf("UPDATE task_sessions SET metadata = %s::text, updated_at = ? WHERE id = ?", expr)
+	} else {
+		paths := make([]string, len(keys))
+		for i, key := range keys {
+			paths[i] = "?"
+			args = append(args, "$."+key)
+		}
+		query = fmt.Sprintf(
+			"UPDATE task_sessions SET metadata = json_remove(CASE WHEN metadata IS NULL OR metadata = 'null' OR metadata = '' THEN '{}' ELSE metadata END, %s), updated_at = ? WHERE id = ?",
+			strings.Join(paths, ", "),
+		)
+	}
+	args = append(args, updatedAt, sessionID)
+	result, err := exec.ExecContext(ctx, r.db.Rebind(query), args...)
+	if err != nil {
+		return err
+	}
+	rows, _ := result.RowsAffected()
+	if rows == 0 {
+		return fmt.Errorf("agent session not found: %s", sessionID)
+	}
+	return nil
 }
 
 // UpdateTaskSessionWithMetadata updates the session row and metadata column in

--- a/apps/backend/internal/task/repository/sqlite/session_test.go
+++ b/apps/backend/internal/task/repository/sqlite/session_test.go
@@ -862,6 +862,54 @@ func TestUpdateTaskSessionWithMetadataRejectsInvalidMetadataBeforeStateWrite(t *
 	}
 }
 
+func TestUpdateTaskSessionIfCurrentStateRemovingMetadataKeys(t *testing.T) {
+	repo := newRepoForSessionTests(t)
+	ctx := context.Background()
+	seedForMsgTest(t, repo, "task-remove-metadata", "sess-remove-metadata", "turn-remove-metadata")
+	require.NoError(t, repo.UpdateSessionMetadata(ctx, "sess-remove-metadata", map[string]interface{}{
+		"provider_state": "stale",
+		"keep":           "newer",
+	}))
+	session, err := repo.GetTaskSession(ctx, "sess-remove-metadata")
+	require.NoError(t, err)
+	changed, err := repo.UpdateTaskSessionIfCurrentStateRemovingMetadataKeys(
+		ctx,
+		session,
+		models.TaskSessionStateCreated,
+		[]string{"provider_state"},
+	)
+	require.NoError(t, err)
+	require.True(t, changed)
+	stored, err := repo.GetTaskSession(ctx, "sess-remove-metadata")
+	require.NoError(t, err)
+	require.NotContains(t, stored.Metadata, "provider_state")
+	require.Equal(t, "newer", stored.Metadata["keep"])
+}
+
+func TestUpdateTaskSessionIfCurrentStateRemovingMetadataKeysStateMismatch(t *testing.T) {
+	repo := newRepoForSessionTests(t)
+	ctx := context.Background()
+	seedForMsgTest(t, repo, "task-remove-metadata-mismatch", "sess-remove-metadata-mismatch", "turn-remove-metadata-mismatch")
+	require.NoError(t, repo.UpdateSessionMetadata(ctx, "sess-remove-metadata-mismatch", map[string]interface{}{
+		"provider_state": "stale",
+		"keep":           "untouched",
+	}))
+	session, err := repo.GetTaskSession(ctx, "sess-remove-metadata-mismatch")
+	require.NoError(t, err)
+	changed, err := repo.UpdateTaskSessionIfCurrentStateRemovingMetadataKeys(
+		ctx,
+		session,
+		models.TaskSessionStateRunning,
+		[]string{"provider_state"},
+	)
+	require.NoError(t, err)
+	require.False(t, changed)
+	stored, err := repo.GetTaskSession(ctx, "sess-remove-metadata-mismatch")
+	require.NoError(t, err)
+	require.Equal(t, "stale", stored.Metadata["provider_state"])
+	require.Equal(t, "untouched", stored.Metadata["keep"])
+}
+
 func TestDismissLastAgentErrorDoesNotOverwriteNewerError(t *testing.T) {
 	repo := newRepoForSessionTests(t)
 	ctx := context.Background()


### PR DESCRIPTION
Reused Office sessions could retain the previous provider's permission mode and ACP runtime state after routing selected a new execution profile, causing the new profile's permission settings to be ignored. The rebind now clears provider-native session state while preserving Office metadata, with regression coverage for mode, runtime configuration, resume state, and metadata ownership.

## Validation

- `go test -race ./internal/orchestrator/executor -count=1`
- `make typecheck`
- `make test`
- `make -C apps/backend lint`
- `pnpm --filter @kandev/web lint`
- `python3 .github/scripts/lint-harness-files.py --all`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1846?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->