### PR TITLE
feat(plugins): host-side conversation reads + utility-agent invoke

### DIFF
--- a/apps/backend/internal/backendapp/boot_state_routes.go
+++ b/apps/backend/internal/backendapp/boot_state_routes.go
@@ -468,6 +468,7 @@ func mapUserSettingsState(response userdto.UserSettingsResponse, workspaceID str
 		"sidebarTaskPrefs":            mapSidebarTaskPrefs(settings.SidebarTaskPrefs),
 		"taskCreateLastUsed":          mapTaskCreateLastUsed(settings.TaskCreateLastUsed),
 		"defaultUtilityAgentId":       nullString(settings.DefaultUtilityAgentID),
+		"utilityAgentProfileId":       nullString(settings.UtilityAgentProfileID),
 		"keyboardShortcuts":           mapStringAny(settings.KeyboardShortcuts),
 		"terminalLinkBehavior":        terminalLinkBehavior(settings.TerminalLinkBehavior),
 		"terminalFontFamily":          nullString(settings.TerminalFontFamily),

--- a/apps/backend/internal/backendapp/main.go
+++ b/apps/backend/internal/backendapp/main.go
@@ -714,6 +714,14 @@ func startGatewayAndServe(
 		services.Slack.SetRunner(slackRunner)
 	}
 
+	// Wire Host.InvokeUtilityAgent (ADR 0048): plugins delegate one-shot LLM
+	// calls to the operator-configured utility agent (Settings > System),
+	// resolved from user settings and run via the sessionless host-utility
+	// tier. Same landing point as the Slack runner — hostUtilityMgr is live.
+	if services.Plugins != nil && services.User != nil {
+		services.Plugins.SetUtilityAgent(services.User, pluginsHostUtilityAdapter{mgr: hostUtilityMgr})
+	}
+
 	if err := orchestratorSvc.Start(ctx); err != nil {
 		log.Error("Failed to start orchestrator", zap.Error(err))
 		return false

--- a/apps/backend/internal/backendapp/services.go
+++ b/apps/backend/internal/backendapp/services.go
@@ -547,6 +547,23 @@ func (a slackHostUtilityAdapter) ExecutePromptWithMCP(
 	}, nil
 }
 
+// pluginsHostUtilityAdapter adapts *hostutility.Manager to the plugins
+// package's utilityRunner interface (Host.InvokeUtilityAgent, ADR 0048),
+// returning just the response text. Lives here for the same cycle-avoidance
+// reason as slackHostUtilityAdapter — internal/plugins must not import the
+// agent runtime.
+type pluginsHostUtilityAdapter struct {
+	mgr *hostutility.Manager
+}
+
+func (a pluginsHostUtilityAdapter) ExecutePrompt(ctx context.Context, agentType, model, mode, prompt string) (string, error) {
+	res, err := a.mgr.ExecutePrompt(ctx, agentType, model, mode, prompt)
+	if err != nil {
+		return "", err
+	}
+	return res.Response, nil
+}
+
 // workflowProviderAdapter adapts task service to workflow service's WorkflowProvider interface.
 type workflowProviderAdapter struct {
 	svc *taskservice.Service

--- a/apps/backend/internal/backendapp/services.go
+++ b/apps/backend/internal/backendapp/services.go
@@ -118,7 +118,7 @@ func provideServices(cfg *config.Config, log *logger.Logger, repos *Repositories
 	workflowSyncSvc := initWorkflowSyncService(dbPool, githubSvc, workflowSvc, taskSvc, log)
 	pluginsSvc := initPluginsService(cfg, dbPool, eventBus, repos.Secrets, log)
 	if pluginsSvc != nil {
-		pluginsSvc.SetDataSources(taskSvc, taskSvc, workflowSvc, agentSettingsController, analyticsservice.New(repos.Analytics))
+		pluginsSvc.SetDataSources(taskSvc, taskSvc, workflowSvc, agentSettingsController, analyticsservice.New(repos.Analytics), taskSvc)
 	}
 	shareHTTP := initShareHandlers(dbPool, repos.Task, githubSvc, log, version)
 

--- a/apps/backend/internal/orchestrator/executor/executor_mocks_test.go
+++ b/apps/backend/internal/orchestrator/executor/executor_mocks_test.go
@@ -744,6 +744,9 @@ func (m *mockRepository) ListMessages(ctx context.Context, sessionID string) ([]
 func (m *mockRepository) ListMessagesPaginated(ctx context.Context, sessionID string, opts models.ListMessagesOptions) ([]*models.Message, bool, error) {
 	return nil, false, nil
 }
+func (m *mockRepository) ListMessagesForPlugin(ctx context.Context, filter models.PluginMessageFilter) ([]*models.Message, error) {
+	return nil, nil
+}
 func (m *mockRepository) SearchMessages(ctx context.Context, sessionID string, opts models.SearchMessagesOptions) ([]*models.Message, error) {
 	return nil, nil
 }

--- a/apps/backend/internal/plugins/host.go
+++ b/apps/backend/internal/plugins/host.go
@@ -61,6 +61,7 @@ type pluginHost struct {
 	workflowSteps    workflowStepLister
 	agentProfiles    agentProfileDataSource
 	sessionCodeStats sessionCodeStatsSource
+	messageData      messageDataSource
 }
 
 var _ pluginsdk.Host = (*pluginHost)(nil)
@@ -79,6 +80,12 @@ func permissionDenied(capability string) error {
 // (nil, nil) success for a missing task.
 func taskNotFound(id string) error {
 	return status.Errorf(codes.NotFound, "task %q not found", id)
+}
+
+// invalidArgument builds the gRPC error a Host data reader returns when a
+// plugin passes a malformed filter value (e.g. a non-RFC3339 time bound).
+func invalidArgument(msg string) error {
+	return status.Error(codes.InvalidArgument, msg)
 }
 
 func (h *pluginHost) GetState(ctx context.Context, scope, scopeID, key string) (map[string]any, bool, error) {

--- a/apps/backend/internal/plugins/host.go
+++ b/apps/backend/internal/plugins/host.go
@@ -63,10 +63,15 @@ type pluginHost struct {
 	sessionCodeStats sessionCodeStatsSource
 	messageData      messageDataSource
 
-	// Utility agent invocation (ADR 0048), wired by Service.SetUtilityAgent.
+	// utilityDeps returns the live utility-agent dependencies (ADR 0048) at
+	// call time rather than a spawn-time snapshot. hostUtilityMgr is
+	// constructed late in boot — after StartActivePlugins has already spawned
+	// boot-active plugins — so snapshotting here would strand those hosts with
+	// nil deps and make InvokeUtilityAgent return Unimplemented for their whole
+	// lifetime. Reading live (under Service.mu) lets the later SetUtilityAgent
+	// wiring take effect without a plugin restart. nil on a bare test host.
 	// See host_utility.go.
-	utilitySettings utilitySettingsSource
-	utilityRunner   utilityRunner
+	utilityDeps func() (utilitySettingsSource, utilityRunner)
 }
 
 var _ pluginsdk.Host = (*pluginHost)(nil)

--- a/apps/backend/internal/plugins/host.go
+++ b/apps/backend/internal/plugins/host.go
@@ -62,6 +62,11 @@ type pluginHost struct {
 	agentProfiles    agentProfileDataSource
 	sessionCodeStats sessionCodeStatsSource
 	messageData      messageDataSource
+
+	// Utility agent invocation (ADR 0048), wired by Service.SetUtilityAgent.
+	// See host_utility.go.
+	utilitySettings utilitySettingsSource
+	utilityRunner   utilityRunner
 }
 
 var _ pluginsdk.Host = (*pluginHost)(nil)

--- a/apps/backend/internal/plugins/host_data.go
+++ b/apps/backend/internal/plugins/host_data.go
@@ -62,6 +62,12 @@ const (
 	maxPageLimit     = 200
 )
 
+// maxMessageFilterValues bounds the combined number of session/task/type
+// values a ListMessages filter may carry, keeping the resulting IN(...) bind
+// parameters comfortably under SQLite's SQLITE_MAX_VARIABLE_NUMBER (999 on
+// older builds) with headroom for the since/until/limit/offset params.
+const maxMessageFilterValues = 400
+
 // normalizePageLimit clamps limit to [1, maxPageLimit], defaulting to
 // defaultPageLimit when unset or invalid.
 func normalizePageLimit(limit int32) int {
@@ -494,6 +500,13 @@ type messageReader struct{ host *pluginHost }
 // messageModelToDTO (kandev-system blocks stripped) before it reaches the
 // plugin.
 func (r messageReader) List(ctx context.Context, filter pluginsdk.MessageFilter, page pluginsdk.Page) ([]pluginsdk.Message, *pluginsdk.PageInfo, error) {
+	// Each session/task/type value becomes its own SQL bind parameter; cap
+	// their combined count well under SQLite's host-parameter limit
+	// (~500-999) so a large filter fails fast with a clear InvalidArgument
+	// instead of a cryptic "too many SQL variables" at query execution.
+	if n := len(filter.SessionIDs) + len(filter.TaskIDs) + len(filter.Types); n > maxMessageFilterValues {
+		return nil, nil, invalidArgument(fmt.Sprintf("message filter has %d session/task/type values, max %d", n, maxMessageFilterValues))
+	}
 	since, err := parseFilterTime(filter.Since, "since")
 	if err != nil {
 		return nil, nil, err

--- a/apps/backend/internal/plugins/host_data.go
+++ b/apps/backend/internal/plugins/host_data.go
@@ -27,6 +27,7 @@ import (
 
 	agentsettingsdto "github.com/kandev/kandev/internal/agent/settings/dto"
 	analyticsmodels "github.com/kandev/kandev/internal/analytics/models"
+	"github.com/kandev/kandev/internal/sysprompt"
 	"github.com/kandev/kandev/internal/task/repository/repoerrors"
 
 	taskmodels "github.com/kandev/kandev/internal/task/models"
@@ -43,6 +44,7 @@ const (
 	resourceWorkflows     = "workflows"
 	resourceAgentProfiles = "agent_profiles"
 	resourceRepositories  = "repositories"
+	resourceMessages      = "messages"
 )
 
 // apiReadCapability formats resource as the api_read:<resource> capability
@@ -154,6 +156,15 @@ type sessionCodeStatsSource interface {
 	ListSessionCodeStats(ctx context.Context, filter analyticsmodels.SessionCodeStatsFilter) ([]*analyticsmodels.SessionCodeStats, error)
 }
 
+// messageDataSource is the narrow slice of internal/task/service.Service the
+// Messages().List RPC needs. ListMessagesForPlugin filters by session/task
+// ids and a created_at time range, returning oldest-first with SQL-level
+// limit/offset (Limit is requested as page-limit+1 so the reader can derive
+// HasMore without a second count query).
+type messageDataSource interface {
+	ListMessagesForPlugin(ctx context.Context, filter taskmodels.PluginMessageFilter) ([]*taskmodels.Message, error)
+}
+
 // ── pluginHost accessors ────────────────────────────────────────────────
 //
 // These shadow the Unimplemented* defaults embedded via
@@ -225,6 +236,16 @@ func (h *pluginHost) Repositories() pluginsdk.RepositoryReader {
 	return repositoryReader{host: h}
 }
 
+func (h *pluginHost) Messages() pluginsdk.MessageReader {
+	if !h.capabilities.CanRead(resourceMessages) {
+		return deniedMessageReader{}
+	}
+	if h.messageData == nil {
+		return h.UnimplementedHostData.Messages()
+	}
+	return messageReader{host: h}
+}
+
 // ── Denied readers ──────────────────────────────────────────────────────
 
 type deniedTaskReader struct{}
@@ -273,6 +294,12 @@ type deniedRepositoryReader struct{}
 
 func (deniedRepositoryReader) List(context.Context, string, pluginsdk.Page) ([]pluginsdk.Repository, *pluginsdk.PageInfo, error) {
 	return nil, nil, permissionDenied(apiReadCapability(resourceRepositories))
+}
+
+type deniedMessageReader struct{}
+
+func (deniedMessageReader) List(context.Context, pluginsdk.MessageFilter, pluginsdk.Page) ([]pluginsdk.Message, *pluginsdk.PageInfo, error) {
+	return nil, nil, permissionDenied(apiReadCapability(resourceMessages))
 }
 
 // ── Real readers ────────────────────────────────────────────────────────
@@ -456,6 +483,67 @@ func (r repositoryReader) List(ctx context.Context, workspaceID string, page plu
 	}
 	items, info := paginate(dtos, page)
 	return items, info, nil
+}
+
+type messageReader struct{ host *pluginHost }
+
+// List paginates conversation content at the SQL layer (limit/offset, like
+// sessionReader.CodeStats) rather than fetching everything into memory — a
+// task's transcript can be very large. Since/Until are RFC3339; an
+// unparseable value is a gRPC InvalidArgument. Content is sanitized by
+// messageModelToDTO (kandev-system blocks stripped) before it reaches the
+// plugin.
+func (r messageReader) List(ctx context.Context, filter pluginsdk.MessageFilter, page pluginsdk.Page) ([]pluginsdk.Message, *pluginsdk.PageInfo, error) {
+	since, err := parseFilterTime(filter.Since, "since")
+	if err != nil {
+		return nil, nil, err
+	}
+	until, err := parseFilterTime(filter.Until, "until")
+	if err != nil {
+		return nil, nil, err
+	}
+	limit := normalizePageLimit(page.Limit)
+	offset := pageOffset(page.Cursor)
+
+	messages, err := r.host.messageData.ListMessagesForPlugin(ctx, taskmodels.PluginMessageFilter{
+		SessionIDs: filter.SessionIDs,
+		TaskIDs:    filter.TaskIDs,
+		Types:      filter.Types,
+		Since:      since,
+		Until:      until,
+		Limit:      limit + 1,
+		Offset:     offset,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	hasMore := len(messages) > limit
+	if hasMore {
+		messages = messages[:limit]
+	}
+	dtos := make([]pluginsdk.Message, len(messages))
+	for i, m := range messages {
+		dtos[i] = messageModelToDTO(m)
+	}
+	info := &pluginsdk.PageInfo{HasMore: hasMore}
+	if hasMore {
+		info.NextCursor = strconv.Itoa(offset + limit)
+	}
+	return dtos, info, nil
+}
+
+// parseFilterTime parses an optional RFC3339 filter bound, returning a gRPC
+// InvalidArgument error naming the field when a non-nil value doesn't parse.
+func parseFilterTime(value *string, field string) (*time.Time, error) {
+	if value == nil || *value == "" {
+		return nil, nil
+	}
+	t, err := time.Parse(time.RFC3339, *value)
+	if err != nil {
+		return nil, invalidArgument(fmt.Sprintf("%s must be RFC3339: %v", field, err))
+	}
+	return &t, nil
 }
 
 // ── Fetch/filter/sort helpers (v1 scoping: ADR 0043(a) "global-with-hook") ─
@@ -855,6 +943,28 @@ func agentProfileDTOToSDK(p agentsettingsdto.AgentProfileDTO) pluginsdk.AgentPro
 		Name:        p.Name,
 		Model:       p.Model,
 		Mode:        p.Mode,
+	}
+}
+
+// messageModelToDTO maps a stored message to the Go-native Message DTO. It
+// strips kandev-injected <kandev-system> blocks from content via
+// sysprompt.StripSystemContent — the same sanitization the message.added bus
+// event applies — so a plugin never sees raw system prompts. Type defaults to
+// "message" (matching Message.ToAPI and the repository) when empty.
+func messageModelToDTO(m *taskmodels.Message) pluginsdk.Message {
+	msgType := string(m.Type)
+	if msgType == "" {
+		msgType = string(taskmodels.MessageTypeMessage)
+	}
+	return pluginsdk.Message{
+		ID:         m.ID,
+		SessionID:  m.TaskSessionID,
+		TaskID:     m.TaskID,
+		TurnID:     m.TurnID,
+		AuthorType: string(m.AuthorType),
+		Content:    sysprompt.StripSystemContent(m.Content),
+		Type:       msgType,
+		CreatedAt:  m.CreatedAt.UTC().Format(time.RFC3339),
 	}
 }
 

--- a/apps/backend/internal/plugins/host_data_test.go
+++ b/apps/backend/internal/plugins/host_data_test.go
@@ -137,6 +137,24 @@ func (f *fakeSessionCodeStatsSource) ListSessionCodeStats(
 	return f.stats, nil
 }
 
+type fakeMessageDataSource struct {
+	calls      int
+	lastFilter taskmodels.PluginMessageFilter
+	messages   []*taskmodels.Message
+	err        error
+}
+
+func (f *fakeMessageDataSource) ListMessagesForPlugin(
+	_ context.Context, filter taskmodels.PluginMessageFilter,
+) ([]*taskmodels.Message, error) {
+	f.calls++
+	f.lastFilter = filter
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.messages, nil
+}
+
 // testDataHost bundles a pluginHost with every fake it was wired from, so
 // tests can both drive Host calls and assert against the fakes' recorded
 // state.
@@ -147,6 +165,7 @@ type testDataHost struct {
 	steps     *fakeWorkflowStepLister
 	profiles  *fakeAgentProfileDataSource
 	codeStats *fakeSessionCodeStatsSource
+	messages  *fakeMessageDataSource
 }
 
 // newTestDataHost builds a fully-wired pluginHost (every Host data API
@@ -159,6 +178,7 @@ func newTestDataHost(caps manifest.Capabilities) *testDataHost {
 		steps:     &fakeWorkflowStepLister{},
 		profiles:  &fakeAgentProfileDataSource{resp: &agentsettingsdto.ListAgentsResponse{}},
 		codeStats: &fakeSessionCodeStatsSource{},
+		messages:  &fakeMessageDataSource{},
 	}
 	d.host = &pluginHost{
 		pluginID:         "p1",
@@ -168,6 +188,7 @@ func newTestDataHost(caps manifest.Capabilities) *testDataHost {
 		workflowSteps:    d.steps,
 		agentProfiles:    d.profiles,
 		sessionCodeStats: d.codeStats,
+		messageData:      d.messages,
 	}
 	return d
 }
@@ -217,6 +238,12 @@ func TestPluginHost_Repositories_DeniedWithoutCapability(t *testing.T) {
 	d := newTestDataHost(manifest.Capabilities{})
 	_, _, err := d.host.Repositories().List(context.Background(), "ws-1", pluginsdk.Page{})
 	assertPermissionDenied(t, err, "api_read:repositories")
+}
+
+func TestPluginHost_Messages_DeniedWithoutCapability(t *testing.T) {
+	d := newTestDataHost(manifest.Capabilities{})
+	_, _, err := d.host.Messages().List(context.Background(), pluginsdk.MessageFilter{}, pluginsdk.Page{})
+	assertPermissionDenied(t, err, "api_read:messages")
 }
 
 // ── capability gating: succeeds with api_read:<resource> ───────────────
@@ -724,5 +751,131 @@ func TestPluginHost_ArchivedTaskFetchFlags(t *testing.T) {
 	if len(d.tasks.gotIncludeArchived) != 2 ||
 		d.tasks.gotIncludeArchived[0] != want[0] || d.tasks.gotIncludeArchived[1] != want[1] {
 		t.Fatalf("includeArchived per call = %v, want %v", d.tasks.gotIncludeArchived, want)
+	}
+}
+
+// ── Messages reader ─────────────────────────────────────────────────────
+
+func TestPluginHost_Messages_SucceedsAndStripsSystemContent(t *testing.T) {
+	d := newTestDataHost(manifest.Capabilities{APIRead: []string{"messages"}})
+	created := time.Date(2026, 7, 20, 9, 30, 0, 0, time.UTC)
+	d.messages.messages = []*taskmodels.Message{
+		{
+			ID:            "m1",
+			TaskSessionID: "s1",
+			TaskID:        "t1",
+			TurnID:        "turn1",
+			AuthorType:    taskmodels.MessageAuthorUser,
+			Content:       "<kandev-system>secret prompt</kandev-system>Please summarize yesterday.",
+			Type:          taskmodels.MessageTypeMessage,
+			CreatedAt:     created,
+		},
+		{
+			ID:            "m2",
+			TaskSessionID: "s1",
+			TaskID:        "t1",
+			TurnID:        "turn1",
+			AuthorType:    taskmodels.MessageAuthorAgent,
+			Content:       "Here is the summary.",
+			Type:          "", // empty type must default to "message"
+			CreatedAt:     created.Add(time.Minute),
+		},
+	}
+
+	msgs, info, err := d.host.Messages().List(context.Background(), pluginsdk.MessageFilter{
+		SessionIDs: []string{"s1"},
+	}, pluginsdk.Page{Limit: 50})
+	if err != nil {
+		t.Fatalf("List() unexpected error: %v", err)
+	}
+	if len(msgs) != 2 {
+		t.Fatalf("List() len = %d, want 2", len(msgs))
+	}
+	if msgs[0].Content != "Please summarize yesterday." {
+		t.Fatalf("content[0] = %q, want system block stripped", msgs[0].Content)
+	}
+	if msgs[0].AuthorType != "user" || msgs[1].AuthorType != "agent" {
+		t.Fatalf("author types = %q/%q, want user/agent", msgs[0].AuthorType, msgs[1].AuthorType)
+	}
+	if msgs[1].Type != "message" {
+		t.Fatalf("type[1] = %q, want defaulted to message", msgs[1].Type)
+	}
+	if msgs[0].SessionID != "s1" || msgs[0].TaskID != "t1" || msgs[0].TurnID != "turn1" {
+		t.Fatalf("ids = %+v, want session/task/turn set", msgs[0])
+	}
+	if msgs[0].CreatedAt != "2026-07-20T09:30:00Z" {
+		t.Fatalf("created_at = %q, want RFC3339", msgs[0].CreatedAt)
+	}
+	if info == nil || info.HasMore {
+		t.Fatalf("PageInfo = %+v, want HasMore=false", info)
+	}
+}
+
+func TestPluginHost_Messages_PassesFilterAndTimeRange(t *testing.T) {
+	d := newTestDataHost(manifest.Capabilities{APIRead: []string{"messages"}})
+	since := "2026-07-20T00:00:00Z"
+	until := "2026-07-21T00:00:00Z"
+
+	_, _, err := d.host.Messages().List(context.Background(), pluginsdk.MessageFilter{
+		SessionIDs: []string{"s1", "s2"},
+		TaskIDs:    []string{"t1"},
+		Types:      []string{"message", "content"},
+		Since:      &since,
+		Until:      &until,
+	}, pluginsdk.Page{Limit: 10})
+	if err != nil {
+		t.Fatalf("List() unexpected error: %v", err)
+	}
+	got := d.messages.lastFilter
+	if len(got.SessionIDs) != 2 || len(got.TaskIDs) != 1 || len(got.Types) != 2 {
+		t.Fatalf("filter passthrough = %+v", got)
+	}
+	if got.Since == nil || !got.Since.Equal(time.Date(2026, 7, 20, 0, 0, 0, 0, time.UTC)) {
+		t.Fatalf("since = %v, want parsed 2026-07-20", got.Since)
+	}
+	if got.Until == nil || !got.Until.Equal(time.Date(2026, 7, 21, 0, 0, 0, 0, time.UTC)) {
+		t.Fatalf("until = %v, want parsed 2026-07-21", got.Until)
+	}
+	// Reader requests one extra row past the page limit to derive HasMore.
+	if got.Limit != 11 {
+		t.Fatalf("data-source Limit = %d, want page-limit+1 (11)", got.Limit)
+	}
+}
+
+func TestPluginHost_Messages_PaginatesWithHasMore(t *testing.T) {
+	d := newTestDataHost(manifest.Capabilities{APIRead: []string{"messages"}})
+	base := time.Date(2026, 7, 20, 9, 0, 0, 0, time.UTC)
+	// Data source returns limit+1 rows (3) for a page limit of 2 → HasMore.
+	for i := 0; i < 3; i++ {
+		d.messages.messages = append(d.messages.messages, &taskmodels.Message{
+			ID:         fmt.Sprintf("m%d", i),
+			AuthorType: taskmodels.MessageAuthorUser,
+			Content:    "hi",
+			CreatedAt:  base.Add(time.Duration(i) * time.Minute),
+		})
+	}
+
+	msgs, info, err := d.host.Messages().List(context.Background(), pluginsdk.MessageFilter{}, pluginsdk.Page{Limit: 2})
+	if err != nil {
+		t.Fatalf("List() unexpected error: %v", err)
+	}
+	if len(msgs) != 2 {
+		t.Fatalf("page len = %d, want 2 (trimmed from 3)", len(msgs))
+	}
+	if info == nil || !info.HasMore || info.NextCursor != "2" {
+		t.Fatalf("PageInfo = %+v, want HasMore=true NextCursor=2", info)
+	}
+}
+
+func TestPluginHost_Messages_InvalidTimeIsInvalidArgument(t *testing.T) {
+	d := newTestDataHost(manifest.Capabilities{APIRead: []string{"messages"}})
+	bad := "not-a-timestamp"
+	_, _, err := d.host.Messages().List(context.Background(), pluginsdk.MessageFilter{Since: &bad}, pluginsdk.Page{})
+	st, ok := status.FromError(err)
+	if !ok || st.Code() != codes.InvalidArgument {
+		t.Fatalf("err = %v, want InvalidArgument", err)
+	}
+	if d.messages.calls != 0 {
+		t.Fatalf("data source called %d times, want 0 (rejected before query)", d.messages.calls)
 	}
 }

--- a/apps/backend/internal/plugins/host_data_test.go
+++ b/apps/backend/internal/plugins/host_data_test.go
@@ -193,8 +193,9 @@ func newTestDataHost(caps manifest.Capabilities) *testDataHost {
 		agentProfiles:    d.profiles,
 		sessionCodeStats: d.codeStats,
 		messageData:      d.messages,
-		utilitySettings:  d.utilCfg,
-		utilityRunner:    d.utilRun,
+		utilityDeps: func() (utilitySettingsSource, utilityRunner) {
+			return d.utilCfg, d.utilRun
+		},
 	}
 	return d
 }
@@ -870,6 +871,22 @@ func TestPluginHost_Messages_PaginatesWithHasMore(t *testing.T) {
 	}
 	if info == nil || !info.HasMore || info.NextCursor != "2" {
 		t.Fatalf("PageInfo = %+v, want HasMore=true NextCursor=2", info)
+	}
+}
+
+func TestPluginHost_Messages_TooManyFilterValuesIsInvalidArgument(t *testing.T) {
+	d := newTestDataHost(manifest.Capabilities{APIRead: []string{"messages"}})
+	sessionIDs := make([]string, maxMessageFilterValues+1)
+	for i := range sessionIDs {
+		sessionIDs[i] = fmt.Sprintf("s%d", i)
+	}
+	_, _, err := d.host.Messages().List(context.Background(), pluginsdk.MessageFilter{SessionIDs: sessionIDs}, pluginsdk.Page{})
+	st, ok := status.FromError(err)
+	if !ok || st.Code() != codes.InvalidArgument {
+		t.Fatalf("err = %v, want InvalidArgument", err)
+	}
+	if d.messages.calls != 0 {
+		t.Fatalf("data source called %d times, want 0 (rejected before query)", d.messages.calls)
 	}
 }
 

--- a/apps/backend/internal/plugins/host_data_test.go
+++ b/apps/backend/internal/plugins/host_data_test.go
@@ -166,6 +166,8 @@ type testDataHost struct {
 	profiles  *fakeAgentProfileDataSource
 	codeStats *fakeSessionCodeStatsSource
 	messages  *fakeMessageDataSource
+	utilCfg   *fakeUtilitySettingsSource
+	utilRun   *fakeUtilityRunner
 }
 
 // newTestDataHost builds a fully-wired pluginHost (every Host data API
@@ -179,6 +181,8 @@ func newTestDataHost(caps manifest.Capabilities) *testDataHost {
 		profiles:  &fakeAgentProfileDataSource{resp: &agentsettingsdto.ListAgentsResponse{}},
 		codeStats: &fakeSessionCodeStatsSource{},
 		messages:  &fakeMessageDataSource{},
+		utilCfg:   &fakeUtilitySettingsSource{},
+		utilRun:   &fakeUtilityRunner{text: "ok"},
 	}
 	d.host = &pluginHost{
 		pluginID:         "p1",
@@ -189,6 +193,8 @@ func newTestDataHost(caps manifest.Capabilities) *testDataHost {
 		agentProfiles:    d.profiles,
 		sessionCodeStats: d.codeStats,
 		messageData:      d.messages,
+		utilitySettings:  d.utilCfg,
+		utilityRunner:    d.utilRun,
 	}
 	return d
 }

--- a/apps/backend/internal/plugins/host_data_wire_test.go
+++ b/apps/backend/internal/plugins/host_data_wire_test.go
@@ -254,6 +254,38 @@ func TestPluginHostData_Wire_Messages(t *testing.T) {
 	})
 }
 
+// TestPluginHostData_Wire_InvokeUtilityAgent proves the agent_invoke gate and
+// the one-shot completion round-trip over the real transport: an undeclared
+// manifest is PermissionDenied, and a declared one resolves the configured
+// profile and returns the runner's text.
+func TestPluginHostData_Wire_InvokeUtilityAgent(t *testing.T) {
+	t.Run("DeniedWithoutCapability", func(t *testing.T) {
+		d := newTestDataHost(manifest.Capabilities{})
+		host := dialPluginHostOverWire(t, d.host)
+
+		_, err := host.InvokeUtilityAgent(context.Background(), "hi")
+		require.Error(t, err)
+		st, ok := status.FromError(err)
+		require.True(t, ok, "expected a gRPC status error, got %v", err)
+		require.Equal(t, codes.PermissionDenied, st.Code())
+		require.Equal(t, "capability 'agent_invoke' not declared", st.Message())
+	})
+
+	t.Run("Succeeds", func(t *testing.T) {
+		d := newTestDataHost(manifest.Capabilities{AgentInvoke: true})
+		d.utilCfg.profileID = "p-1"
+		d.profileFixture("p-1", "claude-acp", "claude-opus-4-8")
+		d.utilRun.text = "summary text"
+		host := dialPluginHostOverWire(t, d.host)
+
+		got, err := host.InvokeUtilityAgent(context.Background(), "summarize")
+		require.NoError(t, err)
+		require.Equal(t, "summary text", got)
+		require.Equal(t, "claude-acp", d.utilRun.gotAgentType)
+		require.Equal(t, "claude-opus-4-8", d.utilRun.gotModel)
+	})
+}
+
 // TestPluginHostData_Wire_SessionsPagination seeds three sessions and drives
 // two Sessions().List calls over the real broker connection: Page{Limit: 2}
 // must return exactly 2 items plus a non-empty PageInfo.NextCursor, and a

--- a/apps/backend/internal/plugins/host_data_wire_test.go
+++ b/apps/backend/internal/plugins/host_data_wire_test.go
@@ -216,6 +216,44 @@ func TestPluginHostData_Wire_PermissionDeniedPerResource(t *testing.T) {
 	})
 }
 
+// TestPluginHostData_Wire_Messages proves the api_read:messages gate and the
+// content sanitization travel intact over the real transport: an undeclared
+// manifest is denied with the exact wire message, and a declared one reads
+// back conversation content with <kandev-system> blocks stripped.
+func TestPluginHostData_Wire_Messages(t *testing.T) {
+	t.Run("DeniedWithoutCapability", func(t *testing.T) {
+		d := newTestDataHost(manifest.Capabilities{})
+		host := dialPluginHostOverWire(t, d.host)
+
+		_, _, err := host.Messages().List(context.Background(), pluginsdk.MessageFilter{}, pluginsdk.Page{})
+		require.Error(t, err)
+		st, ok := status.FromError(err)
+		require.True(t, ok, "expected a gRPC status error, got %v", err)
+		require.Equal(t, codes.PermissionDenied, st.Code())
+		require.Equal(t, "capability 'api_read:messages' not declared", st.Message())
+	})
+
+	t.Run("SucceedsAndStripsSystemContent", func(t *testing.T) {
+		d := newTestDataHost(manifest.Capabilities{APIRead: []string{"messages"}})
+		d.messages.messages = []*taskmodels.Message{{
+			ID:            "m1",
+			TaskSessionID: "s1",
+			TaskID:        "t1",
+			AuthorType:    taskmodels.MessageAuthorUser,
+			Content:       "<kandev-system>hidden</kandev-system>Visible text.",
+			Type:          taskmodels.MessageTypeMessage,
+			CreatedAt:     time.Date(2026, 7, 20, 9, 0, 0, 0, time.UTC),
+		}}
+		host := dialPluginHostOverWire(t, d.host)
+
+		msgs, _, err := host.Messages().List(context.Background(), pluginsdk.MessageFilter{SessionIDs: []string{"s1"}}, pluginsdk.Page{Limit: 10})
+		require.NoError(t, err)
+		require.Len(t, msgs, 1)
+		require.Equal(t, "Visible text.", msgs[0].Content)
+		require.Equal(t, "user", msgs[0].AuthorType)
+	})
+}
+
 // TestPluginHostData_Wire_SessionsPagination seeds three sessions and drives
 // two Sessions().List calls over the real broker connection: Page{Limit: 2}
 // must return exactly 2 items plus a non-empty PageInfo.NextCursor, and a

--- a/apps/backend/internal/plugins/host_utility.go
+++ b/apps/backend/internal/plugins/host_utility.go
@@ -1,0 +1,88 @@
+// host_utility.go implements pluginHost.InvokeUtilityAgent — the agent_invoke
+// Host capability (ADR 0048). A plugin delegates a one-shot, non-interactive
+// LLM step to the operator-configured "utility agent" (Settings > System), so
+// it needs no API key of its own. The heavy lifting reuses the sessionless
+// host-utility inference tier (ADR 0002) via a narrow utilityRunner interface,
+// wired by backendapp so this package never imports the agent runtime.
+package plugins
+
+import (
+	"context"
+	"fmt"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const capabilityAgentInvoke = "agent_invoke"
+
+// utilitySettingsSource reads the operator-configured utility agent profile id
+// (internal/user's UtilityAgentProfileID). Empty means "no utility agent
+// configured".
+type utilitySettingsSource interface {
+	UtilityAgentProfileID(ctx context.Context) (string, error)
+}
+
+// utilityRunner runs a one-shot completion for an agent type + model and
+// returns the response text. Satisfied by a thin adapter over
+// internal/agent/hostutility.Manager (ADR 0002), wired in backendapp so
+// internal/plugins does not import the agent runtime.
+type utilityRunner interface {
+	ExecutePrompt(ctx context.Context, agentType, model, mode, prompt string) (string, error)
+}
+
+// InvokeUtilityAgent runs a one-shot, non-interactive completion using the
+// operator-configured utility agent, gated by the agent_invoke capability. It
+// resolves the configured profile to its agent type + model and delegates to
+// the sessionless host-utility runner. A missing capability is
+// PermissionDenied; an unconfigured (or since-deleted) utility agent is
+// FailedPrecondition — never a silent empty completion.
+func (h *pluginHost) InvokeUtilityAgent(ctx context.Context, prompt string) (string, error) {
+	if !h.capabilities.AgentInvoke {
+		return "", permissionDenied(capabilityAgentInvoke)
+	}
+	if h.utilitySettings == nil || h.utilityRunner == nil || h.agentProfiles == nil {
+		// Not wired (e.g. a bare test pluginHost) — fall back to the embedded
+		// Unimplemented default rather than nil-dereferencing.
+		return h.UnimplementedHostData.InvokeUtilityAgent(ctx, prompt)
+	}
+
+	profileID, err := h.utilitySettings.UtilityAgentProfileID(ctx)
+	if err != nil {
+		return "", fmt.Errorf("plugins: read utility agent setting: %w", err)
+	}
+	if profileID == "" {
+		return "", errNoUtilityAgent()
+	}
+
+	agentType, model, err := h.resolveUtilityAgentProfile(ctx, profileID)
+	if err != nil {
+		return "", err
+	}
+	return h.utilityRunner.ExecutePrompt(ctx, agentType, model, "", prompt)
+}
+
+// resolveUtilityAgentProfile finds the configured profile id among the
+// instance's agent profiles and returns its agent type + model. A profile id
+// that no longer resolves is FailedPrecondition (treated like "unconfigured"),
+// not an internal error — the operator's selection has simply gone stale.
+func (h *pluginHost) resolveUtilityAgentProfile(ctx context.Context, profileID string) (agentType, model string, err error) {
+	resp, err := h.agentProfiles.ListAgents(ctx)
+	if err != nil {
+		return "", "", fmt.Errorf("plugins: list agent profiles: %w", err)
+	}
+	for _, agent := range resp.Agents {
+		for _, profile := range agent.Profiles {
+			if profile.ID == profileID {
+				return profile.AgentID, profile.Model, nil
+			}
+		}
+	}
+	return "", "", status.Errorf(codes.FailedPrecondition, "configured utility agent profile %q not found", profileID)
+}
+
+// errNoUtilityAgent is the typed error a plugin gets when the operator has not
+// selected a utility agent in Settings > System.
+func errNoUtilityAgent() error {
+	return status.Error(codes.FailedPrecondition, "no utility agent configured")
+}

--- a/apps/backend/internal/plugins/host_utility.go
+++ b/apps/backend/internal/plugins/host_utility.go
@@ -41,13 +41,18 @@ func (h *pluginHost) InvokeUtilityAgent(ctx context.Context, prompt string) (str
 	if !h.capabilities.AgentInvoke {
 		return "", permissionDenied(capabilityAgentInvoke)
 	}
-	if h.utilitySettings == nil || h.utilityRunner == nil || h.agentProfiles == nil {
-		// Not wired (e.g. a bare test pluginHost) — fall back to the embedded
-		// Unimplemented default rather than nil-dereferencing.
+	var settings utilitySettingsSource
+	var runner utilityRunner
+	if h.utilityDeps != nil {
+		settings, runner = h.utilityDeps()
+	}
+	if settings == nil || runner == nil || h.agentProfiles == nil {
+		// Not wired yet (e.g. a bare test pluginHost) — fall back to the
+		// embedded Unimplemented default rather than nil-dereferencing.
 		return h.UnimplementedHostData.InvokeUtilityAgent(ctx, prompt)
 	}
 
-	profileID, err := h.utilitySettings.UtilityAgentProfileID(ctx)
+	profileID, err := settings.UtilityAgentProfileID(ctx)
 	if err != nil {
 		return "", fmt.Errorf("plugins: read utility agent setting: %w", err)
 	}
@@ -59,7 +64,7 @@ func (h *pluginHost) InvokeUtilityAgent(ctx context.Context, prompt string) (str
 	if err != nil {
 		return "", err
 	}
-	return h.utilityRunner.ExecutePrompt(ctx, agentType, model, "", prompt)
+	return runner.ExecutePrompt(ctx, agentType, model, "", prompt)
 }
 
 // resolveUtilityAgentProfile finds the configured profile id among the

--- a/apps/backend/internal/plugins/host_utility_test.go
+++ b/apps/backend/internal/plugins/host_utility_test.go
@@ -110,6 +110,46 @@ func TestPluginHost_InvokeUtilityAgent_ProfileMissing(t *testing.T) {
 	}
 }
 
+// TestPluginHost_InvokeUtilityAgent_LateWiringReachesSpawnedHost proves the
+// boot-ordering fix: a host built before SetUtilityAgent runs (as happens for
+// boot-active plugins, spawned before hostUtilityMgr exists) still resolves the
+// utility deps once they are wired, because utilityDeps reads them live from the
+// Service rather than snapshotting at spawn time.
+func TestPluginHost_InvokeUtilityAgent_LateWiringReachesSpawnedHost(t *testing.T) {
+	svc, _, _ := newTestService(t)
+	profiles := &fakeAgentProfileDataSource{resp: &agentsettingsdto.ListAgentsResponse{
+		Agents: []agentsettingsdto.AgentDTO{{
+			ID:       "agent-1",
+			Profiles: []agentsettingsdto.AgentProfileDTO{{ID: "p1", AgentID: "claude-acp", Model: "m"}},
+		}},
+	}}
+	// A host as hostForPlugin would build it: utilityDeps bound to the service,
+	// which has NOT been wired with a utility agent yet.
+	host := &pluginHost{
+		capabilities:  manifest.Capabilities{AgentInvoke: true},
+		agentProfiles: profiles,
+		utilityDeps:   svc.utilityAgentDeps,
+	}
+
+	// Before wiring: Unimplemented (deps still nil on the service).
+	if _, err := host.InvokeUtilityAgent(context.Background(), "hi"); status.Code(err) != codes.Unimplemented {
+		t.Fatalf("pre-wiring code = %v, want Unimplemented", status.Code(err))
+	}
+
+	// Wire late, exactly as backendapp does after plugins have already spawned.
+	runner := &fakeUtilityRunner{text: "done"}
+	svc.SetUtilityAgent(&fakeUtilitySettingsSource{profileID: "p1"}, runner)
+
+	// The already-built host now resolves the freshly-wired deps.
+	got, err := host.InvokeUtilityAgent(context.Background(), "hi")
+	if err != nil {
+		t.Fatalf("post-wiring error: %v", err)
+	}
+	if got != "done" || runner.gotAgentType != "claude-acp" {
+		t.Fatalf("got %q via %q, want done via claude-acp", got, runner.gotAgentType)
+	}
+}
+
 func TestPluginHost_InvokeUtilityAgent_SettingError(t *testing.T) {
 	d := newTestDataHost(manifest.Capabilities{AgentInvoke: true})
 	d.utilCfg.err = errors.New("db down")

--- a/apps/backend/internal/plugins/host_utility_test.go
+++ b/apps/backend/internal/plugins/host_utility_test.go
@@ -1,0 +1,124 @@
+package plugins
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	agentsettingsdto "github.com/kandev/kandev/internal/agent/settings/dto"
+	"github.com/kandev/kandev/internal/plugins/manifest"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+type fakeUtilitySettingsSource struct {
+	profileID string
+	err       error
+}
+
+func (f *fakeUtilitySettingsSource) UtilityAgentProfileID(context.Context) (string, error) {
+	return f.profileID, f.err
+}
+
+type fakeUtilityRunner struct {
+	calls        int
+	gotAgentType string
+	gotModel     string
+	gotMode      string
+	gotPrompt    string
+	text         string
+	err          error
+}
+
+func (f *fakeUtilityRunner) ExecutePrompt(_ context.Context, agentType, model, mode, prompt string) (string, error) {
+	f.calls++
+	f.gotAgentType, f.gotModel, f.gotMode, f.gotPrompt = agentType, model, mode, prompt
+	return f.text, f.err
+}
+
+// profileFixture wires the agent-profiles data source to hold one profile with
+// the given id, agent type, and model — the shape resolveUtilityAgentProfile
+// scans.
+func (d *testDataHost) profileFixture(profileID, agentType, model string) {
+	d.profiles.resp = &agentsettingsdto.ListAgentsResponse{
+		Agents: []agentsettingsdto.AgentDTO{{
+			ID: "agent-1",
+			Profiles: []agentsettingsdto.AgentProfileDTO{{
+				ID: profileID, AgentID: agentType, Model: model,
+			}},
+		}},
+	}
+}
+
+func TestPluginHost_InvokeUtilityAgent_DeniedWithoutCapability(t *testing.T) {
+	d := newTestDataHost(manifest.Capabilities{})
+	_, err := d.host.InvokeUtilityAgent(context.Background(), "hi")
+	assertPermissionDenied(t, err, "agent_invoke")
+	if d.utilRun.calls != 0 {
+		t.Fatalf("runner called %d times, want 0 when capability denied", d.utilRun.calls)
+	}
+}
+
+func TestPluginHost_InvokeUtilityAgent_UsesConfiguredProfile(t *testing.T) {
+	d := newTestDataHost(manifest.Capabilities{AgentInvoke: true})
+	d.utilCfg.profileID = "profile-42"
+	d.profileFixture("profile-42", "claude-acp", "claude-opus-4-8")
+	d.utilRun.text = "the summary"
+
+	got, err := d.host.InvokeUtilityAgent(context.Background(), "summarize yesterday")
+	if err != nil {
+		t.Fatalf("InvokeUtilityAgent() unexpected error: %v", err)
+	}
+	if got != "the summary" {
+		t.Fatalf("text = %q, want %q", got, "the summary")
+	}
+	// The configured profile's agent type + model must reach the runner.
+	if d.utilRun.gotAgentType != "claude-acp" || d.utilRun.gotModel != "claude-opus-4-8" {
+		t.Fatalf("runner got (%q, %q), want (claude-acp, claude-opus-4-8)", d.utilRun.gotAgentType, d.utilRun.gotModel)
+	}
+	if d.utilRun.gotPrompt != "summarize yesterday" {
+		t.Fatalf("runner prompt = %q", d.utilRun.gotPrompt)
+	}
+}
+
+func TestPluginHost_InvokeUtilityAgent_NotConfigured(t *testing.T) {
+	d := newTestDataHost(manifest.Capabilities{AgentInvoke: true})
+	d.utilCfg.profileID = "" // no utility agent selected
+
+	_, err := d.host.InvokeUtilityAgent(context.Background(), "hi")
+	st, ok := status.FromError(err)
+	if !ok || st.Code() != codes.FailedPrecondition {
+		t.Fatalf("err = %v, want FailedPrecondition", err)
+	}
+	if d.utilRun.calls != 0 {
+		t.Fatalf("runner called %d times, want 0 when unconfigured", d.utilRun.calls)
+	}
+}
+
+func TestPluginHost_InvokeUtilityAgent_ProfileMissing(t *testing.T) {
+	d := newTestDataHost(manifest.Capabilities{AgentInvoke: true})
+	d.utilCfg.profileID = "profile-gone"
+	d.profileFixture("profile-still-here", "claude-acp", "m") // different id
+
+	_, err := d.host.InvokeUtilityAgent(context.Background(), "hi")
+	st, ok := status.FromError(err)
+	if !ok || st.Code() != codes.FailedPrecondition {
+		t.Fatalf("err = %v, want FailedPrecondition for a stale profile id", err)
+	}
+	if d.utilRun.calls != 0 {
+		t.Fatalf("runner called %d times, want 0 when profile missing", d.utilRun.calls)
+	}
+}
+
+func TestPluginHost_InvokeUtilityAgent_SettingError(t *testing.T) {
+	d := newTestDataHost(manifest.Capabilities{AgentInvoke: true})
+	d.utilCfg.err = errors.New("db down")
+
+	_, err := d.host.InvokeUtilityAgent(context.Background(), "hi")
+	if err == nil {
+		t.Fatal("expected error when settings read fails")
+	}
+	if d.utilRun.calls != 0 {
+		t.Fatalf("runner called %d times, want 0 when settings read fails", d.utilRun.calls)
+	}
+}

--- a/apps/backend/internal/plugins/manifest/manifest.go
+++ b/apps/backend/internal/plugins/manifest/manifest.go
@@ -72,6 +72,9 @@ type Capabilities struct {
 	APIWrite []string `yaml:"api_write,omitempty" json:"api_write,omitempty"`
 	State    bool     `yaml:"state,omitempty" json:"state,omitempty"`
 	Secrets  bool     `yaml:"secrets,omitempty" json:"secrets,omitempty"`
+	// AgentInvoke gates Host.InvokeUtilityAgent (ADR 0048): a one-shot,
+	// non-interactive completion run by the operator-configured utility agent.
+	AgentInvoke bool `yaml:"agent_invoke,omitempty" json:"agent_invoke,omitempty"`
 }
 
 // Webhook is a proxied external webhook endpoint the plugin declares.

--- a/apps/backend/internal/plugins/service.go
+++ b/apps/backend/internal/plugins/service.go
@@ -95,6 +95,10 @@ type Service struct {
 	sessionCodeStats sessionCodeStatsSource
 	messageData      messageDataSource
 
+	// Utility agent invocation (ADR 0048), wired via SetUtilityAgent.
+	utilitySettings utilitySettingsSource
+	utilityRunner   utilityRunner
+
 	// kandevVersion is the currently running kandev build version, used to
 	// enforce a package's manifest.min_kandev_version at Install (see
 	// SetKandevVersion / checkMinKandevVersion). Empty (the default) means
@@ -215,6 +219,18 @@ func (s *Service) SetDataSources(
 	s.messageData = messages
 }
 
+// SetUtilityAgent wires the dependencies behind Host.InvokeUtilityAgent
+// (ADR 0048): the settings source that reads the operator-configured utility
+// agent profile id, and the sessionless runner that executes a one-shot
+// completion. Wired by backendapp (not Provide) for the same import-cycle
+// reason as SetDataSources; a pluginHost built before this call falls back to
+// Unimplemented for InvokeUtilityAgent regardless of the agent_invoke
+// capability.
+func (s *Service) SetUtilityAgent(settings utilitySettingsSource, runner utilityRunner) {
+	s.utilitySettings = settings
+	s.utilityRunner = runner
+}
+
 // SetKandevVersion wires the currently running kandev build version,
 // enabling Install to enforce a package's manifest.min_kandev_version
 // (checkMinKandevVersion): a package requiring a newer kandev is rejected
@@ -313,6 +329,8 @@ func (s *Service) hostForPlugin(pluginID string) pluginsdk.Host {
 		agentProfiles:    s.agentProfiles,
 		sessionCodeStats: s.sessionCodeStats,
 		messageData:      s.messageData,
+		utilitySettings:  s.utilitySettings,
+		utilityRunner:    s.utilityRunner,
 	}
 }
 

--- a/apps/backend/internal/plugins/service.go
+++ b/apps/backend/internal/plugins/service.go
@@ -223,12 +223,26 @@ func (s *Service) SetDataSources(
 // (ADR 0048): the settings source that reads the operator-configured utility
 // agent profile id, and the sessionless runner that executes a one-shot
 // completion. Wired by backendapp (not Provide) for the same import-cycle
-// reason as SetDataSources; a pluginHost built before this call falls back to
-// Unimplemented for InvokeUtilityAgent regardless of the agent_invoke
-// capability.
+// reason as SetDataSources. Unlike the data sources, this is wired LATE in boot
+// (hostUtilityMgr is only available after agentctl control is healthy, by which
+// point StartActivePlugins has already spawned boot-active plugins), so hosts
+// read these live via utilityAgentDeps rather than snapshotting them — the
+// write here is mutex-guarded against those concurrent reads.
 func (s *Service) SetUtilityAgent(settings utilitySettingsSource, runner utilityRunner) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.utilitySettings = settings
 	s.utilityRunner = runner
+}
+
+// utilityAgentDeps returns the currently-wired utility-agent dependencies. Read
+// live (not snapshotted at hostForPlugin time) so a plugin spawned before
+// SetUtilityAgent still resolves them once it is called. Guarded by s.mu against
+// the SetUtilityAgent write.
+func (s *Service) utilityAgentDeps() (utilitySettingsSource, utilityRunner) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.utilitySettings, s.utilityRunner
 }
 
 // SetKandevVersion wires the currently running kandev build version,
@@ -329,8 +343,7 @@ func (s *Service) hostForPlugin(pluginID string) pluginsdk.Host {
 		agentProfiles:    s.agentProfiles,
 		sessionCodeStats: s.sessionCodeStats,
 		messageData:      s.messageData,
-		utilitySettings:  s.utilitySettings,
-		utilityRunner:    s.utilityRunner,
+		utilityDeps:      s.utilityAgentDeps,
 	}
 }
 

--- a/apps/backend/internal/plugins/service.go
+++ b/apps/backend/internal/plugins/service.go
@@ -93,6 +93,7 @@ type Service struct {
 	workflowSteps    workflowStepLister
 	agentProfiles    agentProfileDataSource
 	sessionCodeStats sessionCodeStatsSource
+	messageData      messageDataSource
 
 	// kandevVersion is the currently running kandev build version, used to
 	// enforce a package's manifest.min_kandev_version at Install (see
@@ -204,12 +205,14 @@ func (s *Service) SetDataSources(
 	workflowSteps workflowStepLister,
 	agentProfiles agentProfileDataSource,
 	sessionCodeStats sessionCodeStatsSource,
+	messages messageDataSource,
 ) {
 	s.taskData = tasks
 	s.workflows = workflows
 	s.workflowSteps = workflowSteps
 	s.agentProfiles = agentProfiles
 	s.sessionCodeStats = sessionCodeStats
+	s.messageData = messages
 }
 
 // SetKandevVersion wires the currently running kandev build version,
@@ -309,6 +312,7 @@ func (s *Service) hostForPlugin(pluginID string) pluginsdk.Host {
 		workflowSteps:    s.workflowSteps,
 		agentProfiles:    s.agentProfiles,
 		sessionCodeStats: s.sessionCodeStats,
+		messageData:      s.messageData,
 	}
 }
 

--- a/apps/backend/internal/task/handlers/process_handlers_test.go
+++ b/apps/backend/internal/task/handlers/process_handlers_test.go
@@ -229,6 +229,9 @@ func (m *mockRepository) ListMessagesByTurnID(ctx context.Context, turnID string
 func (m *mockRepository) ListMessagesPaginated(ctx context.Context, sessionID string, opts models.ListMessagesOptions) ([]*models.Message, bool, error) {
 	return nil, false, nil
 }
+func (m *mockRepository) ListMessagesForPlugin(ctx context.Context, filter models.PluginMessageFilter) ([]*models.Message, error) {
+	return nil, nil
+}
 func (m *mockRepository) SearchMessages(ctx context.Context, sessionID string, opts models.SearchMessagesOptions) ([]*models.Message, error) {
 	return nil, nil
 }

--- a/apps/backend/internal/task/models/models.go
+++ b/apps/backend/internal/task/models/models.go
@@ -64,6 +64,24 @@ type SearchMessagesOptions struct {
 	Limit int
 }
 
+// PluginMessageFilter defines the filters for the plugin Host data API's
+// message reader (ADR 0047). SessionIDs and TaskIDs narrow by session/task
+// (ORed within each, ANDed across the two — a message must match any
+// requested session AND any requested task when both are set); empty means
+// unconstrained on that axis. Since/Until bound created_at (Since inclusive,
+// Until exclusive); nil means unbounded. Types narrows by message type; empty
+// means all types. Results are ordered oldest-first by (created_at, id) with
+// SQL Limit/Offset pagination.
+type PluginMessageFilter struct {
+	SessionIDs []string
+	TaskIDs    []string
+	Types      []string
+	Since      *time.Time
+	Until      *time.Time
+	Limit      int
+	Offset     int
+}
+
 // Task metadata keys used for deferred agent start (e.g., task.moved → handleTaskMovedNoSession).
 const (
 	MetaKeyAgentProfileID    = "agent_profile_id"

--- a/apps/backend/internal/task/repository/interface.go
+++ b/apps/backend/internal/task/repository/interface.go
@@ -154,6 +154,7 @@ type MessageRepository interface {
 	ListMessages(ctx context.Context, sessionID string) ([]*models.Message, error)
 	ListMessagesByTurnID(ctx context.Context, turnID string) ([]*models.Message, error)
 	ListMessagesPaginated(ctx context.Context, sessionID string, opts models.ListMessagesOptions) ([]*models.Message, bool, error)
+	ListMessagesForPlugin(ctx context.Context, filter models.PluginMessageFilter) ([]*models.Message, error)
 	SearchMessages(ctx context.Context, sessionID string, opts models.SearchMessagesOptions) ([]*models.Message, error)
 	DeleteMessage(ctx context.Context, id string) error
 }

--- a/apps/backend/internal/task/repository/sqlite/message.go
+++ b/apps/backend/internal/task/repository/sqlite/message.go
@@ -139,6 +139,75 @@ func (r *Repository) ListMessagesPaginated(ctx context.Context, sessionID string
 	return scanMessageRows(rows, limit)
 }
 
+// ListMessagesForPlugin returns messages matching the plugin Host data API
+// filter (ADR 0047): session/task ids, a created_at time range, and message
+// types, ordered oldest-first by (created_at, id) with SQL Limit/Offset. It
+// backs internal/plugins' capability-gated Messages().List reader — always via
+// the service layer, never called directly by a plugin.
+func (r *Repository) ListMessagesForPlugin(ctx context.Context, filter models.PluginMessageFilter) ([]*models.Message, error) {
+	ctx, span := tracing.Tracer("kandev-db").Start(ctx, "db.ListMessagesForPlugin")
+	defer span.End()
+
+	query, args := buildPluginMessageQuery(filter)
+	rows, err := r.ro.QueryContext(ctx, r.ro.Rebind(query), args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	msgs, _, err := scanMessageRows(rows, 0)
+	return msgs, err
+}
+
+// buildPluginMessageQuery assembles the WHERE/ORDER/LIMIT/OFFSET clauses for
+// ListMessagesForPlugin. session_ids and task_ids each become an IN (...)
+// clause (ANDed together when both are set); Since is an inclusive and Until
+// an exclusive created_at bound; types filters by message type. A zero/negative
+// Limit yields no LIMIT clause (returns all matching rows from the offset).
+func buildPluginMessageQuery(filter models.PluginMessageFilter) (string, []interface{}) {
+	query := `
+		SELECT id, task_session_id, task_id, turn_id, author_type, author_id, content, requests_input, type, metadata, created_at, updated_at
+		FROM task_session_messages`
+	var conditions []string
+	var args []interface{}
+
+	if ph, inArgs := buildInPlaceholders(filter.SessionIDs); ph != "" {
+		conditions = append(conditions, "task_session_id IN ("+ph+")")
+		args = append(args, inArgs...)
+	}
+	if ph, inArgs := buildInPlaceholders(filter.TaskIDs); ph != "" {
+		conditions = append(conditions, "task_id IN ("+ph+")")
+		args = append(args, inArgs...)
+	}
+	if ph, inArgs := buildInPlaceholders(filter.Types); ph != "" {
+		conditions = append(conditions, "type IN ("+ph+")")
+		args = append(args, inArgs...)
+	}
+	if filter.Since != nil {
+		conditions = append(conditions, "created_at >= ?")
+		args = append(args, *filter.Since)
+	}
+	if filter.Until != nil {
+		conditions = append(conditions, "created_at < ?")
+		args = append(args, *filter.Until)
+	}
+	if len(conditions) > 0 {
+		query += " WHERE " + strings.Join(conditions, " AND ")
+	}
+	query += " ORDER BY created_at ASC, id ASC"
+	// OFFSET is only emitted alongside a LIMIT: standalone OFFSET is a syntax
+	// error in SQLite, and the only caller (the plugin message reader) always
+	// requests a positive Limit (page-limit+1), so Offset never travels alone.
+	if filter.Limit > 0 {
+		query += sqlLimitClause
+		args = append(args, filter.Limit)
+		if filter.Offset > 0 {
+			query += " OFFSET ?"
+			args = append(args, filter.Offset)
+		}
+	}
+	return query, args
+}
+
 func (r *Repository) resolveMessageCursor(ctx context.Context, sessionID string, opts models.ListMessagesOptions) (*models.Message, error) {
 	if opts.Before != "" {
 		cursor, err := r.GetMessage(ctx, opts.Before)

--- a/apps/backend/internal/task/repository/sqlite/message_test.go
+++ b/apps/backend/internal/task/repository/sqlite/message_test.go
@@ -247,3 +247,103 @@ func TestGetPendingActionsBySessionIDs(t *testing.T) {
 		t.Fatalf("sess-missing should not have a pending action: %#v", got["sess-missing"])
 	}
 }
+
+// insertPluginMsg inserts a fully-specified message row (task_id, type,
+// author, content, created_at all controllable) for ListMessagesForPlugin
+// filter tests.
+func insertPluginMsg(t *testing.T, repo *Repository, id, sessionID, taskID, turnID, authorType, msgType, content string, ts time.Time) {
+	t.Helper()
+	_, err := repo.db.Exec(repo.db.Rebind(`
+		INSERT INTO task_session_messages
+			(id, task_session_id, task_id, turn_id, author_type, author_id, content, requests_input, type, metadata, created_at)
+		VALUES (?, ?, ?, ?, ?, '', ?, 0, ?, '{}', ?)
+	`), id, sessionID, taskID, turnID, authorType, content, msgType, ts)
+	if err != nil {
+		t.Fatalf("insert plugin message %s: %v", id, err)
+	}
+}
+
+func TestListMessagesForPlugin(t *testing.T) {
+	repo := newRepoForSessionTests(t)
+	ctx := context.Background()
+	base := time.Date(2026, 7, 20, 9, 0, 0, 0, time.UTC)
+
+	seedForMsgTest(t, repo, "task-A", "sess-A", "turn-A")
+	seedForMsgTest(t, repo, "task-B", "sess-B", "turn-B")
+
+	// sess-A / task-A: three messages across three days.
+	insertPluginMsg(t, repo, "a1", "sess-A", "task-A", "turn-A", "user", "message", "day one", base)
+	insertPluginMsg(t, repo, "a2", "sess-A", "task-A", "turn-A", "agent", "message", "day two", base.Add(24*time.Hour))
+	insertPluginMsg(t, repo, "a3", "sess-A", "task-A", "turn-A", "agent", "thinking", "day three", base.Add(48*time.Hour))
+	// sess-B / task-B: one message on day one.
+	insertPluginMsg(t, repo, "b1", "sess-B", "task-B", "turn-B", "user", "message", "other session", base)
+
+	t.Run("by session id", func(t *testing.T) {
+		got, err := repo.ListMessagesForPlugin(ctx, models.PluginMessageFilter{SessionIDs: []string{"sess-A"}})
+		if err != nil {
+			t.Fatalf("ListMessagesForPlugin: %v", err)
+		}
+		if len(got) != 3 || got[0].ID != "a1" || got[2].ID != "a3" {
+			t.Fatalf("got %d messages ordered %v, want a1,a2,a3", len(got), ids(got))
+		}
+	})
+
+	t.Run("by task id", func(t *testing.T) {
+		got, err := repo.ListMessagesForPlugin(ctx, models.PluginMessageFilter{TaskIDs: []string{"task-B"}})
+		if err != nil {
+			t.Fatalf("ListMessagesForPlugin: %v", err)
+		}
+		if len(got) != 1 || got[0].ID != "b1" {
+			t.Fatalf("got %v, want [b1]", ids(got))
+		}
+	})
+
+	t.Run("time range excludes out-of-window", func(t *testing.T) {
+		since := base.Add(24 * time.Hour) // inclusive → a2 kept
+		until := base.Add(48 * time.Hour) // exclusive → a3 dropped
+		got, err := repo.ListMessagesForPlugin(ctx, models.PluginMessageFilter{
+			SessionIDs: []string{"sess-A"}, Since: &since, Until: &until,
+		})
+		if err != nil {
+			t.Fatalf("ListMessagesForPlugin: %v", err)
+		}
+		if len(got) != 1 || got[0].ID != "a2" {
+			t.Fatalf("got %v, want [a2] (since inclusive, until exclusive)", ids(got))
+		}
+	})
+
+	t.Run("type filter", func(t *testing.T) {
+		got, err := repo.ListMessagesForPlugin(ctx, models.PluginMessageFilter{Types: []string{"thinking"}})
+		if err != nil {
+			t.Fatalf("ListMessagesForPlugin: %v", err)
+		}
+		if len(got) != 1 || got[0].ID != "a3" {
+			t.Fatalf("got %v, want [a3]", ids(got))
+		}
+	})
+
+	t.Run("limit and offset paginate in order", func(t *testing.T) {
+		page1, err := repo.ListMessagesForPlugin(ctx, models.PluginMessageFilter{SessionIDs: []string{"sess-A"}, Limit: 2, Offset: 0})
+		if err != nil {
+			t.Fatalf("page1: %v", err)
+		}
+		if len(page1) != 2 || page1[0].ID != "a1" || page1[1].ID != "a2" {
+			t.Fatalf("page1 = %v, want [a1 a2]", ids(page1))
+		}
+		page2, err := repo.ListMessagesForPlugin(ctx, models.PluginMessageFilter{SessionIDs: []string{"sess-A"}, Limit: 2, Offset: 2})
+		if err != nil {
+			t.Fatalf("page2: %v", err)
+		}
+		if len(page2) != 1 || page2[0].ID != "a3" {
+			t.Fatalf("page2 = %v, want [a3]", ids(page2))
+		}
+	})
+}
+
+func ids(msgs []*models.Message) []string {
+	out := make([]string, len(msgs))
+	for i, m := range msgs {
+		out[i] = m.ID
+	}
+	return out
+}

--- a/apps/backend/internal/task/service/service_messages.go
+++ b/apps/backend/internal/task/service/service_messages.go
@@ -285,6 +285,14 @@ func (s *Service) ListMessagesPaginated(ctx context.Context, req ListMessagesReq
 	})
 }
 
+// ListMessagesForPlugin returns messages matching the plugin Host data API
+// filter (ADR 0047), backing internal/plugins' capability-gated
+// Messages().List reader. Reads go through the service layer, never a
+// repository directly, per ADR 0043.
+func (s *Service) ListMessagesForPlugin(ctx context.Context, filter models.PluginMessageFilter) ([]*models.Message, error) {
+	return s.messages.ListMessagesForPlugin(ctx, filter)
+}
+
 // SearchMessages returns messages whose content matches the query in the given session.
 func (s *Service) SearchMessages(ctx context.Context, sessionID, query string, limit int) ([]*models.Message, error) {
 	return s.messages.SearchMessages(ctx, sessionID, models.SearchMessagesOptions{

--- a/apps/backend/internal/user/controller/controller.go
+++ b/apps/backend/internal/user/controller/controller.go
@@ -76,6 +76,7 @@ func (c *Controller) UpdateUserSettings(ctx context.Context, req dto.UpdateUserS
 		GitLabSavedPresets:          req.GitLabSavedPresets.ServiceValue(),
 		DefaultUtilityAgentID:       req.DefaultUtilityAgentID,
 		DefaultUtilityModel:         req.DefaultUtilityModel,
+		UtilityAgentProfileID:       req.UtilityAgentProfileID,
 		KeyboardShortcuts:           req.KeyboardShortcuts,
 		TerminalLinkBehavior:        req.TerminalLinkBehavior,
 		TerminalFontFamily:          req.TerminalFontFamily,

--- a/apps/backend/internal/user/dto/dto.go
+++ b/apps/backend/internal/user/dto/dto.go
@@ -48,6 +48,7 @@ type UserSettingsDTO struct {
 	GitLabSavedPresets          json.RawMessage                     `json:"gitlab_saved_presets,omitempty"`
 	DefaultUtilityAgentID       string                              `json:"default_utility_agent_id"`
 	DefaultUtilityModel         string                              `json:"default_utility_model"`
+	UtilityAgentProfileID       string                              `json:"utility_agent_profile_id"`
 	KeyboardShortcuts           map[string]interface{}              `json:"keyboard_shortcuts,omitempty"`
 	TerminalLinkBehavior        string                              `json:"terminal_link_behavior"`
 	TerminalFontFamily          string                              `json:"terminal_font_family"`
@@ -106,6 +107,7 @@ type UpdateUserSettingsRequest struct {
 	GitLabSavedPresets          NullableRawMessage                   `json:"gitlab_saved_presets,omitempty"`
 	DefaultUtilityAgentID       *string                              `json:"default_utility_agent_id,omitempty"`
 	DefaultUtilityModel         *string                              `json:"default_utility_model,omitempty"`
+	UtilityAgentProfileID       *string                              `json:"utility_agent_profile_id,omitempty"`
 	KeyboardShortcuts           *map[string]interface{}              `json:"keyboard_shortcuts,omitempty"`
 	TerminalLinkBehavior        *string                              `json:"terminal_link_behavior,omitempty"`
 	TerminalFontFamily          *string                              `json:"terminal_font_family,omitempty"`
@@ -220,6 +222,7 @@ func FromUserSettings(settings *models.UserSettings) UserSettingsDTO {
 		GitLabSavedPresets:          settings.GitLabSavedPresets,
 		DefaultUtilityAgentID:       settings.DefaultUtilityAgentID,
 		DefaultUtilityModel:         settings.DefaultUtilityModel,
+		UtilityAgentProfileID:       settings.UtilityAgentProfileID,
 		KeyboardShortcuts:           settings.KeyboardShortcuts,
 		TerminalLinkBehavior:        settings.TerminalLinkBehavior,
 		TerminalFontFamily:          settings.TerminalFontFamily,

--- a/apps/backend/internal/user/models/models.go
+++ b/apps/backend/internal/user/models/models.go
@@ -58,6 +58,7 @@ type UserSettings struct {
 	GitLabSavedPresets          json.RawMessage                   `json:"gitlab_saved_presets"`
 	DefaultUtilityAgentID       string                            `json:"default_utility_agent_id"` // Default inference agent for utility agents
 	DefaultUtilityModel         string                            `json:"default_utility_model"`    // Default model for utility agents
+	UtilityAgentProfileID       string                            `json:"utility_agent_profile_id"` // Agent profile plugins delegate one-shot LLM calls to (ADR 0048)
 	KeyboardShortcuts           map[string]interface{}            `json:"keyboard_shortcuts"`       // User-configured keyboard shortcut overrides
 	TerminalLinkBehavior        string                            `json:"terminal_link_behavior"`   // "new_tab" | "browser_panel"
 	TerminalFontFamily          string                            `json:"terminal_font_family"`

--- a/apps/backend/internal/user/service/service.go
+++ b/apps/backend/internal/user/service/service.go
@@ -67,6 +67,7 @@ type UpdateUserSettingsRequest struct {
 	GitLabSavedPresets          **json.RawMessage
 	DefaultUtilityAgentID       *string
 	DefaultUtilityModel         *string
+	UtilityAgentProfileID       *string
 	KeyboardShortcuts           *map[string]interface{}
 	TerminalLinkBehavior        *string
 	TerminalFontFamily          *string
@@ -116,6 +117,17 @@ func (s *Service) GetDefaultUtilitySettings(ctx context.Context) (agentID, model
 		return "", "", err
 	}
 	return settings.DefaultUtilityAgentID, settings.DefaultUtilityModel, nil
+}
+
+// UtilityAgentProfileID returns the agent profile id plugins delegate one-shot
+// LLM calls to (Host.InvokeUtilityAgent, ADR 0048). Empty means no utility
+// agent has been configured in Settings > System.
+func (s *Service) UtilityAgentProfileID(ctx context.Context) (string, error) {
+	settings, err := s.repo.GetUserSettings(ctx, s.defaultUser)
+	if err != nil {
+		return "", err
+	}
+	return settings.UtilityAgentProfileID, nil
 }
 
 func (s *Service) UpdateUserSettings(ctx context.Context, req *UpdateUserSettingsRequest) (*models.UserSettings, error) {
@@ -232,6 +244,9 @@ func applyBasicSettings(settings *models.UserSettings, req *UpdateUserSettingsRe
 	}
 	if req.DefaultUtilityModel != nil {
 		settings.DefaultUtilityModel = strings.TrimSpace(*req.DefaultUtilityModel)
+	}
+	if req.UtilityAgentProfileID != nil {
+		settings.UtilityAgentProfileID = strings.TrimSpace(*req.UtilityAgentProfileID)
 	}
 	if req.KeyboardShortcuts != nil {
 		if err := validateKeyboardShortcuts(*req.KeyboardShortcuts); err != nil {
@@ -601,6 +616,7 @@ func (s *Service) publishUserSettingsEvent(ctx context.Context, settings *models
 		"gitlab_saved_presets":            settings.GitLabSavedPresets,
 		"default_utility_agent_id":        settings.DefaultUtilityAgentID,
 		"default_utility_model":           settings.DefaultUtilityModel,
+		"utility_agent_profile_id":        settings.UtilityAgentProfileID,
 		"keyboard_shortcuts":              settings.KeyboardShortcuts,
 		"terminal_link_behavior":          settings.TerminalLinkBehavior,
 		"terminal_font_family":            settings.TerminalFontFamily,

--- a/apps/backend/internal/user/service/service_test.go
+++ b/apps/backend/internal/user/service/service_test.go
@@ -140,6 +140,38 @@ func TestApplyBasicSettings_ConfirmTaskArchive(t *testing.T) {
 	})
 }
 
+func TestApplyBasicSettingsUtilityAgentProfileID(t *testing.T) {
+	t.Run("omission preserves saved value", func(t *testing.T) {
+		settings := &models.UserSettings{UtilityAgentProfileID: "profile-1"}
+		if err := applyBasicSettings(settings, &UpdateUserSettingsRequest{}); err != nil {
+			t.Fatalf("apply settings: %v", err)
+		}
+		if settings.UtilityAgentProfileID != "profile-1" {
+			t.Fatalf("UtilityAgentProfileID = %q, want profile-1", settings.UtilityAgentProfileID)
+		}
+	})
+
+	t.Run("explicit value is trimmed and set", func(t *testing.T) {
+		settings := &models.UserSettings{}
+		if err := applyBasicSettings(settings, &UpdateUserSettingsRequest{UtilityAgentProfileID: ptr("  profile-42  ")}); err != nil {
+			t.Fatalf("apply settings: %v", err)
+		}
+		if settings.UtilityAgentProfileID != "profile-42" {
+			t.Fatalf("UtilityAgentProfileID = %q, want profile-42 (trimmed)", settings.UtilityAgentProfileID)
+		}
+	})
+
+	t.Run("explicit empty clears the selection", func(t *testing.T) {
+		settings := &models.UserSettings{UtilityAgentProfileID: "profile-1"}
+		if err := applyBasicSettings(settings, &UpdateUserSettingsRequest{UtilityAgentProfileID: ptr("")}); err != nil {
+			t.Fatalf("apply settings: %v", err)
+		}
+		if settings.UtilityAgentProfileID != "" {
+			t.Fatalf("UtilityAgentProfileID = %q, want empty", settings.UtilityAgentProfileID)
+		}
+	})
+}
+
 func TestApplyBasicSettingsMCPTaskAgentProfileDefault(t *testing.T) {
 	t.Run("omission preserves saved value", func(t *testing.T) {
 		settings := &models.UserSettings{MCPTaskAgentProfileDefault: models.MCPTaskAgentProfileDefaultWorkspaceDefault}

--- a/apps/backend/internal/user/store/sqlite.go
+++ b/apps/backend/internal/user/store/sqlite.go
@@ -357,6 +357,7 @@ func marshalUserSettingsPayload(settings *models.UserSettings) ([]byte, error) {
 		"gitlab_saved_presets":            settings.GitLabSavedPresets,
 		"default_utility_agent_id":        settings.DefaultUtilityAgentID,
 		"default_utility_model":           settings.DefaultUtilityModel,
+		"utility_agent_profile_id":        settings.UtilityAgentProfileID,
 		"keyboard_shortcuts":              keyboardShortcuts,
 		"terminal_link_behavior":          settings.TerminalLinkBehavior,
 		"terminal_font_family":            settings.TerminalFontFamily,
@@ -499,6 +500,7 @@ func scanUserSettings(scanner interface{ Scan(dest ...any) error }, userID strin
 		GitLabSavedPresets          json.RawMessage                     `json:"gitlab_saved_presets"`
 		DefaultUtilityAgentID       string                              `json:"default_utility_agent_id"`
 		DefaultUtilityModel         string                              `json:"default_utility_model"`
+		UtilityAgentProfileID       string                              `json:"utility_agent_profile_id"`
 		KeyboardShortcuts           map[string]interface{}              `json:"keyboard_shortcuts"`
 		TerminalLinkBehavior        string                              `json:"terminal_link_behavior"`
 		TerminalFontFamily          string                              `json:"terminal_font_family"`
@@ -571,6 +573,7 @@ func scanUserSettings(scanner interface{ Scan(dest ...any) error }, userID strin
 	settings.GitLabSavedPresets = payload.GitLabSavedPresets
 	settings.DefaultUtilityAgentID = payload.DefaultUtilityAgentID
 	settings.DefaultUtilityModel = payload.DefaultUtilityModel
+	settings.UtilityAgentProfileID = payload.UtilityAgentProfileID
 	settings.KeyboardShortcuts = payload.KeyboardShortcuts
 	if settings.KeyboardShortcuts == nil {
 		settings.KeyboardShortcuts = map[string]interface{}{}

--- a/apps/backend/pkg/pluginsdk/data_types.go
+++ b/apps/backend/pkg/pluginsdk/data_types.go
@@ -675,3 +675,102 @@ func sessionCodeStatsSliceToProto(items []SessionCodeStats) []*pluginv1.SessionC
 	}
 	return out
 }
+
+// Message is the Go-native mirror of kandev.plugin.v1.Message — one
+// user/agent message in a session transcript. Content has kandev's injected
+// <kandev-system> blocks stripped; raw system content is never exposed.
+type Message struct {
+	ID         string
+	SessionID  string
+	TaskID     string
+	TurnID     string
+	AuthorType string // "user" | "agent"
+	Content    string
+	Type       string // "message" default; see the MessageType vocabulary
+	CreatedAt  string // RFC3339
+}
+
+func (m Message) toProto() *pluginv1.Message {
+	return &pluginv1.Message{
+		Id:         m.ID,
+		SessionId:  m.SessionID,
+		TaskId:     m.TaskID,
+		TurnId:     m.TurnID,
+		AuthorType: m.AuthorType,
+		Content:    m.Content,
+		Type:       m.Type,
+		CreatedAt:  m.CreatedAt,
+	}
+}
+
+func messageFromProto(p *pluginv1.Message) Message {
+	if p == nil {
+		return Message{}
+	}
+	return Message{
+		ID:         p.GetId(),
+		SessionID:  p.GetSessionId(),
+		TaskID:     p.GetTaskId(),
+		TurnID:     p.GetTurnId(),
+		AuthorType: p.GetAuthorType(),
+		Content:    p.GetContent(),
+		Type:       p.GetType(),
+		CreatedAt:  p.GetCreatedAt(),
+	}
+}
+
+func messagesFromProto(items []*pluginv1.Message) []Message {
+	if len(items) == 0 {
+		return nil
+	}
+	out := make([]Message, len(items))
+	for i, item := range items {
+		out[i] = messageFromProto(item)
+	}
+	return out
+}
+
+func messagesToProto(items []Message) []*pluginv1.Message {
+	if len(items) == 0 {
+		return nil
+	}
+	out := make([]*pluginv1.Message, len(items))
+	for i := range items {
+		out[i] = items[i].toProto()
+	}
+	return out
+}
+
+// MessageFilter is the Go-native mirror of kandev.plugin.v1.MessageFilter.
+// Since/Until are RFC3339 strings bounding created_at (Since inclusive, Until
+// exclusive); nil means unbounded on that end.
+type MessageFilter struct {
+	SessionIDs []string
+	TaskIDs    []string
+	Since      *string
+	Until      *string
+	Types      []string
+}
+
+func (f MessageFilter) toProto() *pluginv1.MessageFilter {
+	return &pluginv1.MessageFilter{
+		SessionIds: f.SessionIDs,
+		TaskIds:    f.TaskIDs,
+		Since:      f.Since,
+		Until:      f.Until,
+		Types:      f.Types,
+	}
+}
+
+func messageFilterFromProto(p *pluginv1.MessageFilter) MessageFilter {
+	if p == nil {
+		return MessageFilter{}
+	}
+	return MessageFilter{
+		SessionIDs: p.GetSessionIds(),
+		TaskIDs:    p.GetTaskIds(),
+		Since:      p.Since,
+		Until:      p.Until,
+		Types:      p.GetTypes(),
+	}
+}

--- a/apps/backend/pkg/pluginsdk/host.go
+++ b/apps/backend/pkg/pluginsdk/host.go
@@ -104,6 +104,11 @@ type Host interface {
 	// Repositories returns the reader for the Host data API's repository
 	// RPCs (capability api_read:repositories).
 	Repositories() RepositoryReader
+
+	// Messages returns the reader for the Host data API's message RPC
+	// (capability api_read:messages). It reads historical user/agent
+	// conversation content; kandev-injected system blocks are stripped.
+	Messages() MessageReader
 }
 
 // TaskReader is the read-only accessor behind Host.Tasks(), mirroring the
@@ -157,6 +162,14 @@ type AgentProfileReader interface {
 type RepositoryReader interface {
 	// List returns repositories for workspaceID.
 	List(ctx context.Context, workspaceID string, page Page) ([]Repository, *PageInfo, error)
+}
+
+// MessageReader is the read-only accessor behind Host.Messages(), mirroring
+// the Host data API's ListMessages RPC. It reads historical conversation
+// content filtered by session, task, and/or time range.
+type MessageReader interface {
+	// List returns messages matching filter, oldest first within a page.
+	List(ctx context.Context, filter MessageFilter, page Page) ([]Message, *PageInfo, error)
 }
 
 // newHostClient wraps a *grpc.ClientConn (dialed over the go-plugin broker)
@@ -275,6 +288,8 @@ func (h *grpcHostClient) Repositories() RepositoryReader {
 	return grpcRepositoryReader{client: h.client}
 }
 
+func (h *grpcHostClient) Messages() MessageReader { return grpcMessageReader{client: h.client} }
+
 var _ Host = (*grpcHostClient)(nil)
 
 // grpcTaskReader implements TaskReader on the plugin side, calling the
@@ -386,6 +401,19 @@ func (r grpcRepositoryReader) List(ctx context.Context, workspaceID string, page
 		return nil, nil, err
 	}
 	return repositoriesFromProto(resp.GetRepositories()), pageInfoFromProto(resp.GetPageInfo()), nil
+}
+
+// grpcMessageReader implements MessageReader on the plugin side.
+type grpcMessageReader struct {
+	client pluginv1.HostClient
+}
+
+func (r grpcMessageReader) List(ctx context.Context, filter MessageFilter, page Page) ([]Message, *PageInfo, error) {
+	resp, err := r.client.ListMessages(ctx, &pluginv1.ListMessagesRequest{Filter: filter.toProto(), Page: page.toProto()})
+	if err != nil {
+		return nil, nil, err
+	}
+	return messagesFromProto(resp.GetMessages()), pageInfoFromProto(resp.GetPageInfo()), nil
 }
 
 // registerHostServer registers a grpc server that dispatches
@@ -613,6 +641,16 @@ func (s *grpcHostServer) ListSessionCodeStats(ctx context.Context, req *pluginv1
 	return &pluginv1.ListSessionCodeStatsResponse{Stats: sessionCodeStatsSliceToProto(stats), PageInfo: pageInfo.toProto()}, nil
 }
 
+func (s *grpcHostServer) ListMessages(ctx context.Context, req *pluginv1.ListMessagesRequest) (*pluginv1.ListMessagesResponse, error) {
+	filter := messageFilterFromProto(req.GetFilter())
+	page := pageFromProto(req.GetPage())
+	messages, pageInfo, err := s.impl.Messages().List(ctx, filter, page)
+	if err != nil {
+		return nil, err
+	}
+	return &pluginv1.ListMessagesResponse{Messages: messagesToProto(messages), PageInfo: pageInfo.toProto()}, nil
+}
+
 var _ pluginv1.HostServer = (*grpcHostServer)(nil)
 
 // UnimplementedHostData is an embeddable default for the Host data API
@@ -636,6 +674,7 @@ func (UnimplementedHostData) AgentProfiles() AgentProfileReader {
 func (UnimplementedHostData) Repositories() RepositoryReader {
 	return unimplementedRepositoryReader{}
 }
+func (UnimplementedHostData) Messages() MessageReader { return unimplementedMessageReader{} }
 
 func errUnimplementedHostData(resource string) error {
 	return status.Errorf(codes.Unimplemented, "pluginsdk: Host data API %q not implemented", resource)
@@ -687,4 +726,10 @@ type unimplementedRepositoryReader struct{}
 
 func (unimplementedRepositoryReader) List(context.Context, string, Page) ([]Repository, *PageInfo, error) {
 	return nil, nil, errUnimplementedHostData("repositories")
+}
+
+type unimplementedMessageReader struct{}
+
+func (unimplementedMessageReader) List(context.Context, MessageFilter, Page) ([]Message, *PageInfo, error) {
+	return nil, nil, errUnimplementedHostData("messages")
 }

--- a/apps/backend/pkg/pluginsdk/host.go
+++ b/apps/backend/pkg/pluginsdk/host.go
@@ -109,6 +109,13 @@ type Host interface {
 	// (capability api_read:messages). It reads historical user/agent
 	// conversation content; kandev-injected system blocks are stripped.
 	Messages() MessageReader
+
+	// InvokeUtilityAgent runs a one-shot, non-interactive completion using
+	// the operator-configured "utility agent" (Settings > System) and returns
+	// its text. Requires the `agent_invoke` capability. Returns a gRPC
+	// FailedPrecondition error when no utility agent is configured, so a
+	// plugin needs no API key of its own.
+	InvokeUtilityAgent(ctx context.Context, prompt string) (string, error)
 }
 
 // TaskReader is the read-only accessor behind Host.Tasks(), mirroring the
@@ -289,6 +296,14 @@ func (h *grpcHostClient) Repositories() RepositoryReader {
 }
 
 func (h *grpcHostClient) Messages() MessageReader { return grpcMessageReader{client: h.client} }
+
+func (h *grpcHostClient) InvokeUtilityAgent(ctx context.Context, prompt string) (string, error) {
+	resp, err := h.client.InvokeUtilityAgent(ctx, &pluginv1.InvokeUtilityAgentRequest{Prompt: prompt})
+	if err != nil {
+		return "", err
+	}
+	return resp.GetText(), nil
+}
 
 var _ Host = (*grpcHostClient)(nil)
 
@@ -530,6 +545,14 @@ func (s *grpcHostServer) EmitEvent(ctx context.Context, req *pluginv1.EmitEventR
 	return &pluginv1.EmitEventResponse{}, nil
 }
 
+func (s *grpcHostServer) InvokeUtilityAgent(ctx context.Context, req *pluginv1.InvokeUtilityAgentRequest) (*pluginv1.InvokeUtilityAgentResponse, error) {
+	text, err := s.impl.InvokeUtilityAgent(ctx, req.GetPrompt())
+	if err != nil {
+		return nil, err
+	}
+	return &pluginv1.InvokeUtilityAgentResponse{Text: text}, nil
+}
+
 // ── Host data API reads (ADR 0043) ──────────────────────────────────────
 //
 // Each method below dispatches to the injected Go-native impl's resource
@@ -675,6 +698,15 @@ func (UnimplementedHostData) Repositories() RepositoryReader {
 	return unimplementedRepositoryReader{}
 }
 func (UnimplementedHostData) Messages() MessageReader { return unimplementedMessageReader{} }
+
+// InvokeUtilityAgent is the embeddable default for the agent_invoke Host
+// method (ADR 0048). It lives on UnimplementedHostData — the shared
+// "unimplemented Host extensions" embed both real Host implementations use —
+// so a Host that hasn't wired a utility agent (e.g. a test double) still
+// satisfies the interface, returning gRPC Unimplemented until overridden.
+func (UnimplementedHostData) InvokeUtilityAgent(context.Context, string) (string, error) {
+	return "", errUnimplementedHostData("utility_agent")
+}
 
 func errUnimplementedHostData(resource string) error {
 	return status.Errorf(codes.Unimplemented, "pluginsdk: Host data API %q not implemented", resource)

--- a/apps/backend/pkg/pluginsdk/host_data_test.go
+++ b/apps/backend/pkg/pluginsdk/host_data_test.go
@@ -29,9 +29,12 @@ type dataRecordingHost struct {
 	workflowSteps []WorkflowStep
 	agentProfiles []AgentProfile
 	repositories  []Repository
+	messages      []Message
+	messagePage   *PageInfo
 
 	lastTaskFilter    TaskFilter
 	lastSessionFilter SessionFilter
+	lastMessageFilter MessageFilter
 	lastWorkspaceID   string
 	lastWorkflowID    string
 }
@@ -67,6 +70,7 @@ func (h *dataRecordingHost) AgentProfiles() AgentProfileReader {
 func (h *dataRecordingHost) Repositories() RepositoryReader {
 	return dataRecordingRepositoryReader{h}
 }
+func (h *dataRecordingHost) Messages() MessageReader { return dataRecordingMessageReader{h} }
 
 type dataRecordingTaskReader struct{ h *dataRecordingHost }
 
@@ -126,6 +130,13 @@ func (r dataRecordingRepositoryReader) List(_ context.Context, workspaceID strin
 	return r.h.repositories, nil, nil
 }
 
+type dataRecordingMessageReader struct{ h *dataRecordingHost }
+
+func (r dataRecordingMessageReader) List(_ context.Context, filter MessageFilter, _ Page) ([]Message, *PageInfo, error) {
+	r.h.lastMessageFilter = filter
+	return r.h.messages, r.h.messagePage, nil
+}
+
 func TestHostData_TasksListAndGet(t *testing.T) {
 	impl := &dataRecordingHost{
 		tasks: map[string]Task{
@@ -175,6 +186,28 @@ func TestHostData_Workspaces(t *testing.T) {
 	workspaces, _, err := host.Workspaces().List(context.Background(), Page{})
 	require.NoError(t, err)
 	require.Equal(t, impl.workspaces, workspaces)
+}
+
+func TestHostData_Messages(t *testing.T) {
+	impl := &dataRecordingHost{
+		messages: []Message{{
+			ID: "m1", SessionID: "s1", TaskID: "t1", TurnID: "turn1",
+			AuthorType: "user", Content: "hello", Type: "message", CreatedAt: "2026-07-20T09:00:00Z",
+		}},
+		messagePage: &PageInfo{NextCursor: "2", HasMore: true},
+	}
+	host := dialHostOverBufconn(t, impl)
+
+	since := "2026-07-20T00:00:00Z"
+	filter := MessageFilter{SessionIDs: []string{"s1"}, TaskIDs: []string{"t1"}, Since: &since, Types: []string{"message"}}
+	messages, pageInfo, err := host.Messages().List(context.Background(), filter, Page{Limit: 10})
+	require.NoError(t, err)
+	require.Equal(t, impl.messages, messages)
+	require.Equal(t, &PageInfo{NextCursor: "2", HasMore: true}, pageInfo)
+	// Filter (including the optional Since pointer) round-trips through proto.
+	require.Equal(t, filter, impl.lastMessageFilter)
+	require.NotNil(t, impl.lastMessageFilter.Since)
+	require.Equal(t, since, *impl.lastMessageFilter.Since)
 }
 
 func TestHostData_WorkflowsAndSteps(t *testing.T) {

--- a/apps/backend/pkg/pluginsdk/host_data_test.go
+++ b/apps/backend/pkg/pluginsdk/host_data_test.go
@@ -31,12 +31,14 @@ type dataRecordingHost struct {
 	repositories  []Repository
 	messages      []Message
 	messagePage   *PageInfo
+	utilityText   string
 
 	lastTaskFilter    TaskFilter
 	lastSessionFilter SessionFilter
 	lastMessageFilter MessageFilter
 	lastWorkspaceID   string
 	lastWorkflowID    string
+	lastUtilityPrompt string
 }
 
 func (h *dataRecordingHost) GetState(context.Context, string, string, string) (map[string]any, bool, error) {
@@ -71,6 +73,10 @@ func (h *dataRecordingHost) Repositories() RepositoryReader {
 	return dataRecordingRepositoryReader{h}
 }
 func (h *dataRecordingHost) Messages() MessageReader { return dataRecordingMessageReader{h} }
+func (h *dataRecordingHost) InvokeUtilityAgent(_ context.Context, prompt string) (string, error) {
+	h.lastUtilityPrompt = prompt
+	return h.utilityText, nil
+}
 
 type dataRecordingTaskReader struct{ h *dataRecordingHost }
 
@@ -186,6 +192,16 @@ func TestHostData_Workspaces(t *testing.T) {
 	workspaces, _, err := host.Workspaces().List(context.Background(), Page{})
 	require.NoError(t, err)
 	require.Equal(t, impl.workspaces, workspaces)
+}
+
+func TestHostData_InvokeUtilityAgent(t *testing.T) {
+	impl := &dataRecordingHost{utilityText: "the completion"}
+	host := dialHostOverBufconn(t, impl)
+
+	text, err := host.InvokeUtilityAgent(context.Background(), "do the thing")
+	require.NoError(t, err)
+	require.Equal(t, "the completion", text)
+	require.Equal(t, "do the thing", impl.lastUtilityPrompt)
 }
 
 func TestHostData_Messages(t *testing.T) {

--- a/apps/backend/proto/kandev/plugin/v1/plugin.pb.go
+++ b/apps/backend/proto/kandev/plugin/v1/plugin.pb.go
@@ -3265,6 +3265,292 @@ func (x *ListSessionCodeStatsResponse) GetPageInfo() *PageInfo {
 	return nil
 }
 
+// ── Messages (conversation content) ──────────────────────────────────────────
+// One user/agent message in a session's transcript. content has kandev's
+// injected <kandev-system> blocks stripped; raw system content is never sent.
+// author_type is "user" or "agent" (there is no "system" author — system
+// context is inline markup that is removed at read time). type is the message
+// kind ("message", "content", "tool_call", "thinking", ...).
+type Message struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	SessionId     string                 `protobuf:"bytes,2,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
+	TaskId        string                 `protobuf:"bytes,3,opt,name=task_id,json=taskId,proto3" json:"task_id,omitempty"`
+	TurnId        string                 `protobuf:"bytes,4,opt,name=turn_id,json=turnId,proto3" json:"turn_id,omitempty"`
+	AuthorType    string                 `protobuf:"bytes,5,opt,name=author_type,json=authorType,proto3" json:"author_type,omitempty"` // "user" | "agent"
+	Content       string                 `protobuf:"bytes,6,opt,name=content,proto3" json:"content,omitempty"`                         // <kandev-system> blocks stripped
+	Type          string                 `protobuf:"bytes,7,opt,name=type,proto3" json:"type,omitempty"`                               // "message" default; see MessageType
+	CreatedAt     string                 `protobuf:"bytes,8,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`    // RFC3339
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Message) Reset() {
+	*x = Message{}
+	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[56]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Message) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Message) ProtoMessage() {}
+
+func (x *Message) ProtoReflect() protoreflect.Message {
+	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[56]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Message.ProtoReflect.Descriptor instead.
+func (*Message) Descriptor() ([]byte, []int) {
+	return file_kandev_plugin_v1_plugin_proto_rawDescGZIP(), []int{56}
+}
+
+func (x *Message) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *Message) GetSessionId() string {
+	if x != nil {
+		return x.SessionId
+	}
+	return ""
+}
+
+func (x *Message) GetTaskId() string {
+	if x != nil {
+		return x.TaskId
+	}
+	return ""
+}
+
+func (x *Message) GetTurnId() string {
+	if x != nil {
+		return x.TurnId
+	}
+	return ""
+}
+
+func (x *Message) GetAuthorType() string {
+	if x != nil {
+		return x.AuthorType
+	}
+	return ""
+}
+
+func (x *Message) GetContent() string {
+	if x != nil {
+		return x.Content
+	}
+	return ""
+}
+
+func (x *Message) GetType() string {
+	if x != nil {
+		return x.Type
+	}
+	return ""
+}
+
+func (x *Message) GetCreatedAt() string {
+	if x != nil {
+		return x.CreatedAt
+	}
+	return ""
+}
+
+type MessageFilter struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	SessionIds    []string               `protobuf:"bytes,1,rep,name=session_ids,json=sessionIds,proto3" json:"session_ids,omitempty"` // empty → not constrained by session
+	TaskIds       []string               `protobuf:"bytes,2,rep,name=task_ids,json=taskIds,proto3" json:"task_ids,omitempty"`          // empty → not constrained by task
+	Since         *string                `protobuf:"bytes,3,opt,name=since,proto3,oneof" json:"since,omitempty"`                       // RFC3339 inclusive lower bound on created_at
+	Until         *string                `protobuf:"bytes,4,opt,name=until,proto3,oneof" json:"until,omitempty"`                       // RFC3339 exclusive upper bound on created_at
+	Types         []string               `protobuf:"bytes,5,rep,name=types,proto3" json:"types,omitempty"`                             // empty → all message types
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MessageFilter) Reset() {
+	*x = MessageFilter{}
+	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[57]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MessageFilter) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MessageFilter) ProtoMessage() {}
+
+func (x *MessageFilter) ProtoReflect() protoreflect.Message {
+	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[57]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MessageFilter.ProtoReflect.Descriptor instead.
+func (*MessageFilter) Descriptor() ([]byte, []int) {
+	return file_kandev_plugin_v1_plugin_proto_rawDescGZIP(), []int{57}
+}
+
+func (x *MessageFilter) GetSessionIds() []string {
+	if x != nil {
+		return x.SessionIds
+	}
+	return nil
+}
+
+func (x *MessageFilter) GetTaskIds() []string {
+	if x != nil {
+		return x.TaskIds
+	}
+	return nil
+}
+
+func (x *MessageFilter) GetSince() string {
+	if x != nil && x.Since != nil {
+		return *x.Since
+	}
+	return ""
+}
+
+func (x *MessageFilter) GetUntil() string {
+	if x != nil && x.Until != nil {
+		return *x.Until
+	}
+	return ""
+}
+
+func (x *MessageFilter) GetTypes() []string {
+	if x != nil {
+		return x.Types
+	}
+	return nil
+}
+
+type ListMessagesRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Filter        *MessageFilter         `protobuf:"bytes,1,opt,name=filter,proto3" json:"filter,omitempty"`
+	Page          *Page                  `protobuf:"bytes,2,opt,name=page,proto3" json:"page,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListMessagesRequest) Reset() {
+	*x = ListMessagesRequest{}
+	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[58]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListMessagesRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListMessagesRequest) ProtoMessage() {}
+
+func (x *ListMessagesRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[58]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListMessagesRequest.ProtoReflect.Descriptor instead.
+func (*ListMessagesRequest) Descriptor() ([]byte, []int) {
+	return file_kandev_plugin_v1_plugin_proto_rawDescGZIP(), []int{58}
+}
+
+func (x *ListMessagesRequest) GetFilter() *MessageFilter {
+	if x != nil {
+		return x.Filter
+	}
+	return nil
+}
+
+func (x *ListMessagesRequest) GetPage() *Page {
+	if x != nil {
+		return x.Page
+	}
+	return nil
+}
+
+type ListMessagesResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Messages      []*Message             `protobuf:"bytes,1,rep,name=messages,proto3" json:"messages,omitempty"`
+	PageInfo      *PageInfo              `protobuf:"bytes,2,opt,name=page_info,json=pageInfo,proto3" json:"page_info,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListMessagesResponse) Reset() {
+	*x = ListMessagesResponse{}
+	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[59]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListMessagesResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListMessagesResponse) ProtoMessage() {}
+
+func (x *ListMessagesResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[59]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListMessagesResponse.ProtoReflect.Descriptor instead.
+func (*ListMessagesResponse) Descriptor() ([]byte, []int) {
+	return file_kandev_plugin_v1_plugin_proto_rawDescGZIP(), []int{59}
+}
+
+func (x *ListMessagesResponse) GetMessages() []*Message {
+	if x != nil {
+		return x.Messages
+	}
+	return nil
+}
+
+func (x *ListMessagesResponse) GetPageInfo() *PageInfo {
+	if x != nil {
+		return x.PageInfo
+	}
+	return nil
+}
+
 // ── Writes (phase 2; api_write) ──────────────────────────────────────────────
 type CreateTaskRequest struct {
 	state          protoimpl.MessageState `protogen:"open.v1"`
@@ -3281,7 +3567,7 @@ type CreateTaskRequest struct {
 
 func (x *CreateTaskRequest) Reset() {
 	*x = CreateTaskRequest{}
-	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[56]
+	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3293,7 +3579,7 @@ func (x *CreateTaskRequest) String() string {
 func (*CreateTaskRequest) ProtoMessage() {}
 
 func (x *CreateTaskRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[56]
+	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3306,7 +3592,7 @@ func (x *CreateTaskRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateTaskRequest.ProtoReflect.Descriptor instead.
 func (*CreateTaskRequest) Descriptor() ([]byte, []int) {
-	return file_kandev_plugin_v1_plugin_proto_rawDescGZIP(), []int{56}
+	return file_kandev_plugin_v1_plugin_proto_rawDescGZIP(), []int{60}
 }
 
 func (x *CreateTaskRequest) GetWorkspaceId() string {
@@ -3367,7 +3653,7 @@ type CreateTaskResponse struct {
 
 func (x *CreateTaskResponse) Reset() {
 	*x = CreateTaskResponse{}
-	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[57]
+	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3379,7 +3665,7 @@ func (x *CreateTaskResponse) String() string {
 func (*CreateTaskResponse) ProtoMessage() {}
 
 func (x *CreateTaskResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[57]
+	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3392,7 +3678,7 @@ func (x *CreateTaskResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateTaskResponse.ProtoReflect.Descriptor instead.
 func (*CreateTaskResponse) Descriptor() ([]byte, []int) {
-	return file_kandev_plugin_v1_plugin_proto_rawDescGZIP(), []int{57}
+	return file_kandev_plugin_v1_plugin_proto_rawDescGZIP(), []int{61}
 }
 
 func (x *CreateTaskResponse) GetTask() *Task {
@@ -3415,7 +3701,7 @@ type UpdateTaskRequest struct {
 
 func (x *UpdateTaskRequest) Reset() {
 	*x = UpdateTaskRequest{}
-	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[58]
+	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3427,7 +3713,7 @@ func (x *UpdateTaskRequest) String() string {
 func (*UpdateTaskRequest) ProtoMessage() {}
 
 func (x *UpdateTaskRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[58]
+	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3440,7 +3726,7 @@ func (x *UpdateTaskRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateTaskRequest.ProtoReflect.Descriptor instead.
 func (*UpdateTaskRequest) Descriptor() ([]byte, []int) {
-	return file_kandev_plugin_v1_plugin_proto_rawDescGZIP(), []int{58}
+	return file_kandev_plugin_v1_plugin_proto_rawDescGZIP(), []int{62}
 }
 
 func (x *UpdateTaskRequest) GetId() string {
@@ -3487,7 +3773,7 @@ type UpdateTaskResponse struct {
 
 func (x *UpdateTaskResponse) Reset() {
 	*x = UpdateTaskResponse{}
-	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[59]
+	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3499,7 +3785,7 @@ func (x *UpdateTaskResponse) String() string {
 func (*UpdateTaskResponse) ProtoMessage() {}
 
 func (x *UpdateTaskResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[59]
+	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3512,7 +3798,7 @@ func (x *UpdateTaskResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateTaskResponse.ProtoReflect.Descriptor instead.
 func (*UpdateTaskResponse) Descriptor() ([]byte, []int) {
-	return file_kandev_plugin_v1_plugin_proto_rawDescGZIP(), []int{59}
+	return file_kandev_plugin_v1_plugin_proto_rawDescGZIP(), []int{63}
 }
 
 func (x *UpdateTaskResponse) GetTask() *Task {
@@ -3535,7 +3821,7 @@ type Comment struct {
 
 func (x *Comment) Reset() {
 	*x = Comment{}
-	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[60]
+	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3547,7 +3833,7 @@ func (x *Comment) String() string {
 func (*Comment) ProtoMessage() {}
 
 func (x *Comment) ProtoReflect() protoreflect.Message {
-	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[60]
+	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3560,7 +3846,7 @@ func (x *Comment) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Comment.ProtoReflect.Descriptor instead.
 func (*Comment) Descriptor() ([]byte, []int) {
-	return file_kandev_plugin_v1_plugin_proto_rawDescGZIP(), []int{60}
+	return file_kandev_plugin_v1_plugin_proto_rawDescGZIP(), []int{64}
 }
 
 func (x *Comment) GetId() string {
@@ -3608,7 +3894,7 @@ type CreateCommentRequest struct {
 
 func (x *CreateCommentRequest) Reset() {
 	*x = CreateCommentRequest{}
-	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[61]
+	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3620,7 +3906,7 @@ func (x *CreateCommentRequest) String() string {
 func (*CreateCommentRequest) ProtoMessage() {}
 
 func (x *CreateCommentRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[61]
+	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3633,7 +3919,7 @@ func (x *CreateCommentRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateCommentRequest.ProtoReflect.Descriptor instead.
 func (*CreateCommentRequest) Descriptor() ([]byte, []int) {
-	return file_kandev_plugin_v1_plugin_proto_rawDescGZIP(), []int{61}
+	return file_kandev_plugin_v1_plugin_proto_rawDescGZIP(), []int{65}
 }
 
 func (x *CreateCommentRequest) GetTaskId() string {
@@ -3659,7 +3945,7 @@ type CreateCommentResponse struct {
 
 func (x *CreateCommentResponse) Reset() {
 	*x = CreateCommentResponse{}
-	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[62]
+	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3671,7 +3957,7 @@ func (x *CreateCommentResponse) String() string {
 func (*CreateCommentResponse) ProtoMessage() {}
 
 func (x *CreateCommentResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[62]
+	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3684,7 +3970,7 @@ func (x *CreateCommentResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateCommentResponse.ProtoReflect.Descriptor instead.
 func (*CreateCommentResponse) Descriptor() ([]byte, []int) {
-	return file_kandev_plugin_v1_plugin_proto_rawDescGZIP(), []int{62}
+	return file_kandev_plugin_v1_plugin_proto_rawDescGZIP(), []int{66}
 }
 
 func (x *CreateCommentResponse) GetComment() *Comment {
@@ -3955,6 +4241,33 @@ const file_kandev_plugin_v1_plugin_proto_rawDesc = "" +
 	"\x04page\x18\x02 \x01(\v2\x16.kandev.plugin.v1.PageR\x04page\"\x91\x01\n" +
 	"\x1cListSessionCodeStatsResponse\x128\n" +
 	"\x05stats\x18\x01 \x03(\v2\".kandev.plugin.v1.SessionCodeStatsR\x05stats\x127\n" +
+	"\tpage_info\x18\x02 \x01(\v2\x1a.kandev.plugin.v1.PageInfoR\bpageInfo\"\xd8\x01\n" +
+	"\aMessage\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1d\n" +
+	"\n" +
+	"session_id\x18\x02 \x01(\tR\tsessionId\x12\x17\n" +
+	"\atask_id\x18\x03 \x01(\tR\x06taskId\x12\x17\n" +
+	"\aturn_id\x18\x04 \x01(\tR\x06turnId\x12\x1f\n" +
+	"\vauthor_type\x18\x05 \x01(\tR\n" +
+	"authorType\x12\x18\n" +
+	"\acontent\x18\x06 \x01(\tR\acontent\x12\x12\n" +
+	"\x04type\x18\a \x01(\tR\x04type\x12\x1d\n" +
+	"\n" +
+	"created_at\x18\b \x01(\tR\tcreatedAt\"\xab\x01\n" +
+	"\rMessageFilter\x12\x1f\n" +
+	"\vsession_ids\x18\x01 \x03(\tR\n" +
+	"sessionIds\x12\x19\n" +
+	"\btask_ids\x18\x02 \x03(\tR\ataskIds\x12\x19\n" +
+	"\x05since\x18\x03 \x01(\tH\x00R\x05since\x88\x01\x01\x12\x19\n" +
+	"\x05until\x18\x04 \x01(\tH\x01R\x05until\x88\x01\x01\x12\x14\n" +
+	"\x05types\x18\x05 \x03(\tR\x05typesB\b\n" +
+	"\x06_sinceB\b\n" +
+	"\x06_until\"z\n" +
+	"\x13ListMessagesRequest\x127\n" +
+	"\x06filter\x18\x01 \x01(\v2\x1f.kandev.plugin.v1.MessageFilterR\x06filter\x12*\n" +
+	"\x04page\x18\x02 \x01(\v2\x16.kandev.plugin.v1.PageR\x04page\"\x86\x01\n" +
+	"\x14ListMessagesResponse\x125\n" +
+	"\bmessages\x18\x01 \x03(\v2\x19.kandev.plugin.v1.MessageR\bmessages\x127\n" +
 	"\tpage_info\x18\x02 \x01(\v2\x1a.kandev.plugin.v1.PageInfoR\bpageInfo\"\xa4\x02\n" +
 	"\x11CreateTaskRequest\x12!\n" +
 	"\fworkspace_id\x18\x01 \x01(\tR\vworkspaceId\x12\x1f\n" +
@@ -3997,7 +4310,7 @@ const file_kandev_plugin_v1_plugin_proto_rawDesc = "" +
 	"\acomment\x18\x01 \x01(\v2\x19.kandev.plugin.v1.CommentR\acomment2\xa3\x01\n" +
 	"\x06Plugin\x12C\n" +
 	"\fDeliverEvent\x12\x17.kandev.plugin.v1.Event\x1a\x1a.kandev.plugin.v1.EventAck\x12T\n" +
-	"\rHandleWebhook\x12 .kandev.plugin.v1.WebhookRequest\x1a!.kandev.plugin.v1.WebhookResponse2\x92\x10\n" +
+	"\rHandleWebhook\x12 .kandev.plugin.v1.WebhookRequest\x1a!.kandev.plugin.v1.WebhookResponse2\xf1\x10\n" +
 	"\x04Host\x12Q\n" +
 	"\bGetState\x12!.kandev.plugin.v1.GetStateRequest\x1a\".kandev.plugin.v1.GetStateResponse\x12Q\n" +
 	"\bSetState\x12!.kandev.plugin.v1.SetStateRequest\x1a\".kandev.plugin.v1.SetStateResponse\x12Z\n" +
@@ -4017,7 +4330,8 @@ const file_kandev_plugin_v1_plugin_proto_rawDesc = "" +
 	"\x11ListAgentProfiles\x12*.kandev.plugin.v1.ListAgentProfilesRequest\x1a+.kandev.plugin.v1.ListAgentProfilesResponse\x12i\n" +
 	"\x10ListRepositories\x12).kandev.plugin.v1.ListRepositoriesRequest\x1a*.kandev.plugin.v1.ListRepositoriesResponse\x12]\n" +
 	"\fListSessions\x12%.kandev.plugin.v1.ListSessionsRequest\x1a&.kandev.plugin.v1.ListSessionsResponse\x12u\n" +
-	"\x14ListSessionCodeStats\x12-.kandev.plugin.v1.ListSessionCodeStatsRequest\x1a..kandev.plugin.v1.ListSessionCodeStatsResponse\x12W\n" +
+	"\x14ListSessionCodeStats\x12-.kandev.plugin.v1.ListSessionCodeStatsRequest\x1a..kandev.plugin.v1.ListSessionCodeStatsResponse\x12]\n" +
+	"\fListMessages\x12%.kandev.plugin.v1.ListMessagesRequest\x1a&.kandev.plugin.v1.ListMessagesResponse\x12W\n" +
 	"\n" +
 	"CreateTask\x12#.kandev.plugin.v1.CreateTaskRequest\x1a$.kandev.plugin.v1.CreateTaskResponse\x12W\n" +
 	"\n" +
@@ -4036,7 +4350,7 @@ func file_kandev_plugin_v1_plugin_proto_rawDescGZIP() []byte {
 	return file_kandev_plugin_v1_plugin_proto_rawDescData
 }
 
-var file_kandev_plugin_v1_plugin_proto_msgTypes = make([]protoimpl.MessageInfo, 65)
+var file_kandev_plugin_v1_plugin_proto_msgTypes = make([]protoimpl.MessageInfo, 69)
 var file_kandev_plugin_v1_plugin_proto_goTypes = []any{
 	(*Event)(nil),                        // 0: kandev.plugin.v1.Event
 	(*EventAck)(nil),                     // 1: kandev.plugin.v1.EventAck
@@ -4094,29 +4408,33 @@ var file_kandev_plugin_v1_plugin_proto_goTypes = []any{
 	(*SessionCodeStats)(nil),             // 53: kandev.plugin.v1.SessionCodeStats
 	(*ListSessionCodeStatsRequest)(nil),  // 54: kandev.plugin.v1.ListSessionCodeStatsRequest
 	(*ListSessionCodeStatsResponse)(nil), // 55: kandev.plugin.v1.ListSessionCodeStatsResponse
-	(*CreateTaskRequest)(nil),            // 56: kandev.plugin.v1.CreateTaskRequest
-	(*CreateTaskResponse)(nil),           // 57: kandev.plugin.v1.CreateTaskResponse
-	(*UpdateTaskRequest)(nil),            // 58: kandev.plugin.v1.UpdateTaskRequest
-	(*UpdateTaskResponse)(nil),           // 59: kandev.plugin.v1.UpdateTaskResponse
-	(*Comment)(nil),                      // 60: kandev.plugin.v1.Comment
-	(*CreateCommentRequest)(nil),         // 61: kandev.plugin.v1.CreateCommentRequest
-	(*CreateCommentResponse)(nil),        // 62: kandev.plugin.v1.CreateCommentResponse
-	nil,                                  // 63: kandev.plugin.v1.WebhookRequest.HeadersEntry
-	nil,                                  // 64: kandev.plugin.v1.WebhookResponse.HeadersEntry
-	(*structpb.Struct)(nil),              // 65: google.protobuf.Struct
+	(*Message)(nil),                      // 56: kandev.plugin.v1.Message
+	(*MessageFilter)(nil),                // 57: kandev.plugin.v1.MessageFilter
+	(*ListMessagesRequest)(nil),          // 58: kandev.plugin.v1.ListMessagesRequest
+	(*ListMessagesResponse)(nil),         // 59: kandev.plugin.v1.ListMessagesResponse
+	(*CreateTaskRequest)(nil),            // 60: kandev.plugin.v1.CreateTaskRequest
+	(*CreateTaskResponse)(nil),           // 61: kandev.plugin.v1.CreateTaskResponse
+	(*UpdateTaskRequest)(nil),            // 62: kandev.plugin.v1.UpdateTaskRequest
+	(*UpdateTaskResponse)(nil),           // 63: kandev.plugin.v1.UpdateTaskResponse
+	(*Comment)(nil),                      // 64: kandev.plugin.v1.Comment
+	(*CreateCommentRequest)(nil),         // 65: kandev.plugin.v1.CreateCommentRequest
+	(*CreateCommentResponse)(nil),        // 66: kandev.plugin.v1.CreateCommentResponse
+	nil,                                  // 67: kandev.plugin.v1.WebhookRequest.HeadersEntry
+	nil,                                  // 68: kandev.plugin.v1.WebhookResponse.HeadersEntry
+	(*structpb.Struct)(nil),              // 69: google.protobuf.Struct
 }
 var file_kandev_plugin_v1_plugin_proto_depIdxs = []int32{
-	65, // 0: kandev.plugin.v1.Event.payload:type_name -> google.protobuf.Struct
-	63, // 1: kandev.plugin.v1.WebhookRequest.headers:type_name -> kandev.plugin.v1.WebhookRequest.HeadersEntry
-	64, // 2: kandev.plugin.v1.WebhookResponse.headers:type_name -> kandev.plugin.v1.WebhookResponse.HeadersEntry
-	65, // 3: kandev.plugin.v1.GetStateResponse.value:type_name -> google.protobuf.Struct
-	65, // 4: kandev.plugin.v1.SetStateRequest.value:type_name -> google.protobuf.Struct
+	69, // 0: kandev.plugin.v1.Event.payload:type_name -> google.protobuf.Struct
+	67, // 1: kandev.plugin.v1.WebhookRequest.headers:type_name -> kandev.plugin.v1.WebhookRequest.HeadersEntry
+	68, // 2: kandev.plugin.v1.WebhookResponse.headers:type_name -> kandev.plugin.v1.WebhookResponse.HeadersEntry
+	69, // 3: kandev.plugin.v1.GetStateResponse.value:type_name -> google.protobuf.Struct
+	69, // 4: kandev.plugin.v1.SetStateRequest.value:type_name -> google.protobuf.Struct
 	12, // 5: kandev.plugin.v1.ListStateResponse.entries:type_name -> kandev.plugin.v1.StateEntry
-	65, // 6: kandev.plugin.v1.StateEntry.value:type_name -> google.protobuf.Struct
-	65, // 7: kandev.plugin.v1.GetConfigResponse.config:type_name -> google.protobuf.Struct
-	65, // 8: kandev.plugin.v1.EmitEventRequest.payload:type_name -> google.protobuf.Struct
+	69, // 6: kandev.plugin.v1.StateEntry.value:type_name -> google.protobuf.Struct
+	69, // 7: kandev.plugin.v1.GetConfigResponse.config:type_name -> google.protobuf.Struct
+	69, // 8: kandev.plugin.v1.EmitEventRequest.payload:type_name -> google.protobuf.Struct
 	28, // 9: kandev.plugin.v1.Task.repositories:type_name -> kandev.plugin.v1.TaskRepository
-	65, // 10: kandev.plugin.v1.Task.metadata:type_name -> google.protobuf.Struct
+	69, // 10: kandev.plugin.v1.Task.metadata:type_name -> google.protobuf.Struct
 	29, // 11: kandev.plugin.v1.ListTasksRequest.filter:type_name -> kandev.plugin.v1.TaskFilter
 	25, // 12: kandev.plugin.v1.ListTasksRequest.page:type_name -> kandev.plugin.v1.Page
 	27, // 13: kandev.plugin.v1.ListTasksResponse.tasks:type_name -> kandev.plugin.v1.Task
@@ -4143,62 +4461,68 @@ var file_kandev_plugin_v1_plugin_proto_depIdxs = []int32{
 	25, // 34: kandev.plugin.v1.ListSessionCodeStatsRequest.page:type_name -> kandev.plugin.v1.Page
 	53, // 35: kandev.plugin.v1.ListSessionCodeStatsResponse.stats:type_name -> kandev.plugin.v1.SessionCodeStats
 	26, // 36: kandev.plugin.v1.ListSessionCodeStatsResponse.page_info:type_name -> kandev.plugin.v1.PageInfo
-	27, // 37: kandev.plugin.v1.CreateTaskResponse.task:type_name -> kandev.plugin.v1.Task
-	27, // 38: kandev.plugin.v1.UpdateTaskResponse.task:type_name -> kandev.plugin.v1.Task
-	60, // 39: kandev.plugin.v1.CreateCommentResponse.comment:type_name -> kandev.plugin.v1.Comment
-	0,  // 40: kandev.plugin.v1.Plugin.DeliverEvent:input_type -> kandev.plugin.v1.Event
-	2,  // 41: kandev.plugin.v1.Plugin.HandleWebhook:input_type -> kandev.plugin.v1.WebhookRequest
-	4,  // 42: kandev.plugin.v1.Host.GetState:input_type -> kandev.plugin.v1.GetStateRequest
-	6,  // 43: kandev.plugin.v1.Host.SetState:input_type -> kandev.plugin.v1.SetStateRequest
-	8,  // 44: kandev.plugin.v1.Host.DeleteState:input_type -> kandev.plugin.v1.DeleteStateRequest
-	10, // 45: kandev.plugin.v1.Host.ListState:input_type -> kandev.plugin.v1.ListStateRequest
-	21, // 46: kandev.plugin.v1.Host.RevealSecret:input_type -> kandev.plugin.v1.RevealSecretRequest
-	23, // 47: kandev.plugin.v1.Host.EmitEvent:input_type -> kandev.plugin.v1.EmitEventRequest
-	15, // 48: kandev.plugin.v1.Host.GetSecret:input_type -> kandev.plugin.v1.GetSecretRequest
-	17, // 49: kandev.plugin.v1.Host.SetSecret:input_type -> kandev.plugin.v1.SetSecretRequest
-	19, // 50: kandev.plugin.v1.Host.DeleteSecret:input_type -> kandev.plugin.v1.DeleteSecretRequest
-	13, // 51: kandev.plugin.v1.Host.GetConfig:input_type -> kandev.plugin.v1.GetConfigRequest
-	30, // 52: kandev.plugin.v1.Host.ListTasks:input_type -> kandev.plugin.v1.ListTasksRequest
-	32, // 53: kandev.plugin.v1.Host.GetTask:input_type -> kandev.plugin.v1.GetTaskRequest
-	35, // 54: kandev.plugin.v1.Host.ListWorkspaces:input_type -> kandev.plugin.v1.ListWorkspacesRequest
-	38, // 55: kandev.plugin.v1.Host.ListWorkflows:input_type -> kandev.plugin.v1.ListWorkflowsRequest
-	41, // 56: kandev.plugin.v1.Host.ListWorkflowSteps:input_type -> kandev.plugin.v1.ListWorkflowStepsRequest
-	44, // 57: kandev.plugin.v1.Host.ListAgentProfiles:input_type -> kandev.plugin.v1.ListAgentProfilesRequest
-	47, // 58: kandev.plugin.v1.Host.ListRepositories:input_type -> kandev.plugin.v1.ListRepositoriesRequest
-	51, // 59: kandev.plugin.v1.Host.ListSessions:input_type -> kandev.plugin.v1.ListSessionsRequest
-	54, // 60: kandev.plugin.v1.Host.ListSessionCodeStats:input_type -> kandev.plugin.v1.ListSessionCodeStatsRequest
-	56, // 61: kandev.plugin.v1.Host.CreateTask:input_type -> kandev.plugin.v1.CreateTaskRequest
-	58, // 62: kandev.plugin.v1.Host.UpdateTask:input_type -> kandev.plugin.v1.UpdateTaskRequest
-	61, // 63: kandev.plugin.v1.Host.CreateComment:input_type -> kandev.plugin.v1.CreateCommentRequest
-	1,  // 64: kandev.plugin.v1.Plugin.DeliverEvent:output_type -> kandev.plugin.v1.EventAck
-	3,  // 65: kandev.plugin.v1.Plugin.HandleWebhook:output_type -> kandev.plugin.v1.WebhookResponse
-	5,  // 66: kandev.plugin.v1.Host.GetState:output_type -> kandev.plugin.v1.GetStateResponse
-	7,  // 67: kandev.plugin.v1.Host.SetState:output_type -> kandev.plugin.v1.SetStateResponse
-	9,  // 68: kandev.plugin.v1.Host.DeleteState:output_type -> kandev.plugin.v1.DeleteStateResponse
-	11, // 69: kandev.plugin.v1.Host.ListState:output_type -> kandev.plugin.v1.ListStateResponse
-	22, // 70: kandev.plugin.v1.Host.RevealSecret:output_type -> kandev.plugin.v1.RevealSecretResponse
-	24, // 71: kandev.plugin.v1.Host.EmitEvent:output_type -> kandev.plugin.v1.EmitEventResponse
-	16, // 72: kandev.plugin.v1.Host.GetSecret:output_type -> kandev.plugin.v1.GetSecretResponse
-	18, // 73: kandev.plugin.v1.Host.SetSecret:output_type -> kandev.plugin.v1.SetSecretResponse
-	20, // 74: kandev.plugin.v1.Host.DeleteSecret:output_type -> kandev.plugin.v1.DeleteSecretResponse
-	14, // 75: kandev.plugin.v1.Host.GetConfig:output_type -> kandev.plugin.v1.GetConfigResponse
-	31, // 76: kandev.plugin.v1.Host.ListTasks:output_type -> kandev.plugin.v1.ListTasksResponse
-	33, // 77: kandev.plugin.v1.Host.GetTask:output_type -> kandev.plugin.v1.GetTaskResponse
-	36, // 78: kandev.plugin.v1.Host.ListWorkspaces:output_type -> kandev.plugin.v1.ListWorkspacesResponse
-	39, // 79: kandev.plugin.v1.Host.ListWorkflows:output_type -> kandev.plugin.v1.ListWorkflowsResponse
-	42, // 80: kandev.plugin.v1.Host.ListWorkflowSteps:output_type -> kandev.plugin.v1.ListWorkflowStepsResponse
-	45, // 81: kandev.plugin.v1.Host.ListAgentProfiles:output_type -> kandev.plugin.v1.ListAgentProfilesResponse
-	48, // 82: kandev.plugin.v1.Host.ListRepositories:output_type -> kandev.plugin.v1.ListRepositoriesResponse
-	52, // 83: kandev.plugin.v1.Host.ListSessions:output_type -> kandev.plugin.v1.ListSessionsResponse
-	55, // 84: kandev.plugin.v1.Host.ListSessionCodeStats:output_type -> kandev.plugin.v1.ListSessionCodeStatsResponse
-	57, // 85: kandev.plugin.v1.Host.CreateTask:output_type -> kandev.plugin.v1.CreateTaskResponse
-	59, // 86: kandev.plugin.v1.Host.UpdateTask:output_type -> kandev.plugin.v1.UpdateTaskResponse
-	62, // 87: kandev.plugin.v1.Host.CreateComment:output_type -> kandev.plugin.v1.CreateCommentResponse
-	64, // [64:88] is the sub-list for method output_type
-	40, // [40:64] is the sub-list for method input_type
-	40, // [40:40] is the sub-list for extension type_name
-	40, // [40:40] is the sub-list for extension extendee
-	0,  // [0:40] is the sub-list for field type_name
+	57, // 37: kandev.plugin.v1.ListMessagesRequest.filter:type_name -> kandev.plugin.v1.MessageFilter
+	25, // 38: kandev.plugin.v1.ListMessagesRequest.page:type_name -> kandev.plugin.v1.Page
+	56, // 39: kandev.plugin.v1.ListMessagesResponse.messages:type_name -> kandev.plugin.v1.Message
+	26, // 40: kandev.plugin.v1.ListMessagesResponse.page_info:type_name -> kandev.plugin.v1.PageInfo
+	27, // 41: kandev.plugin.v1.CreateTaskResponse.task:type_name -> kandev.plugin.v1.Task
+	27, // 42: kandev.plugin.v1.UpdateTaskResponse.task:type_name -> kandev.plugin.v1.Task
+	64, // 43: kandev.plugin.v1.CreateCommentResponse.comment:type_name -> kandev.plugin.v1.Comment
+	0,  // 44: kandev.plugin.v1.Plugin.DeliverEvent:input_type -> kandev.plugin.v1.Event
+	2,  // 45: kandev.plugin.v1.Plugin.HandleWebhook:input_type -> kandev.plugin.v1.WebhookRequest
+	4,  // 46: kandev.plugin.v1.Host.GetState:input_type -> kandev.plugin.v1.GetStateRequest
+	6,  // 47: kandev.plugin.v1.Host.SetState:input_type -> kandev.plugin.v1.SetStateRequest
+	8,  // 48: kandev.plugin.v1.Host.DeleteState:input_type -> kandev.plugin.v1.DeleteStateRequest
+	10, // 49: kandev.plugin.v1.Host.ListState:input_type -> kandev.plugin.v1.ListStateRequest
+	21, // 50: kandev.plugin.v1.Host.RevealSecret:input_type -> kandev.plugin.v1.RevealSecretRequest
+	23, // 51: kandev.plugin.v1.Host.EmitEvent:input_type -> kandev.plugin.v1.EmitEventRequest
+	15, // 52: kandev.plugin.v1.Host.GetSecret:input_type -> kandev.plugin.v1.GetSecretRequest
+	17, // 53: kandev.plugin.v1.Host.SetSecret:input_type -> kandev.plugin.v1.SetSecretRequest
+	19, // 54: kandev.plugin.v1.Host.DeleteSecret:input_type -> kandev.plugin.v1.DeleteSecretRequest
+	13, // 55: kandev.plugin.v1.Host.GetConfig:input_type -> kandev.plugin.v1.GetConfigRequest
+	30, // 56: kandev.plugin.v1.Host.ListTasks:input_type -> kandev.plugin.v1.ListTasksRequest
+	32, // 57: kandev.plugin.v1.Host.GetTask:input_type -> kandev.plugin.v1.GetTaskRequest
+	35, // 58: kandev.plugin.v1.Host.ListWorkspaces:input_type -> kandev.plugin.v1.ListWorkspacesRequest
+	38, // 59: kandev.plugin.v1.Host.ListWorkflows:input_type -> kandev.plugin.v1.ListWorkflowsRequest
+	41, // 60: kandev.plugin.v1.Host.ListWorkflowSteps:input_type -> kandev.plugin.v1.ListWorkflowStepsRequest
+	44, // 61: kandev.plugin.v1.Host.ListAgentProfiles:input_type -> kandev.plugin.v1.ListAgentProfilesRequest
+	47, // 62: kandev.plugin.v1.Host.ListRepositories:input_type -> kandev.plugin.v1.ListRepositoriesRequest
+	51, // 63: kandev.plugin.v1.Host.ListSessions:input_type -> kandev.plugin.v1.ListSessionsRequest
+	54, // 64: kandev.plugin.v1.Host.ListSessionCodeStats:input_type -> kandev.plugin.v1.ListSessionCodeStatsRequest
+	58, // 65: kandev.plugin.v1.Host.ListMessages:input_type -> kandev.plugin.v1.ListMessagesRequest
+	60, // 66: kandev.plugin.v1.Host.CreateTask:input_type -> kandev.plugin.v1.CreateTaskRequest
+	62, // 67: kandev.plugin.v1.Host.UpdateTask:input_type -> kandev.plugin.v1.UpdateTaskRequest
+	65, // 68: kandev.plugin.v1.Host.CreateComment:input_type -> kandev.plugin.v1.CreateCommentRequest
+	1,  // 69: kandev.plugin.v1.Plugin.DeliverEvent:output_type -> kandev.plugin.v1.EventAck
+	3,  // 70: kandev.plugin.v1.Plugin.HandleWebhook:output_type -> kandev.plugin.v1.WebhookResponse
+	5,  // 71: kandev.plugin.v1.Host.GetState:output_type -> kandev.plugin.v1.GetStateResponse
+	7,  // 72: kandev.plugin.v1.Host.SetState:output_type -> kandev.plugin.v1.SetStateResponse
+	9,  // 73: kandev.plugin.v1.Host.DeleteState:output_type -> kandev.plugin.v1.DeleteStateResponse
+	11, // 74: kandev.plugin.v1.Host.ListState:output_type -> kandev.plugin.v1.ListStateResponse
+	22, // 75: kandev.plugin.v1.Host.RevealSecret:output_type -> kandev.plugin.v1.RevealSecretResponse
+	24, // 76: kandev.plugin.v1.Host.EmitEvent:output_type -> kandev.plugin.v1.EmitEventResponse
+	16, // 77: kandev.plugin.v1.Host.GetSecret:output_type -> kandev.plugin.v1.GetSecretResponse
+	18, // 78: kandev.plugin.v1.Host.SetSecret:output_type -> kandev.plugin.v1.SetSecretResponse
+	20, // 79: kandev.plugin.v1.Host.DeleteSecret:output_type -> kandev.plugin.v1.DeleteSecretResponse
+	14, // 80: kandev.plugin.v1.Host.GetConfig:output_type -> kandev.plugin.v1.GetConfigResponse
+	31, // 81: kandev.plugin.v1.Host.ListTasks:output_type -> kandev.plugin.v1.ListTasksResponse
+	33, // 82: kandev.plugin.v1.Host.GetTask:output_type -> kandev.plugin.v1.GetTaskResponse
+	36, // 83: kandev.plugin.v1.Host.ListWorkspaces:output_type -> kandev.plugin.v1.ListWorkspacesResponse
+	39, // 84: kandev.plugin.v1.Host.ListWorkflows:output_type -> kandev.plugin.v1.ListWorkflowsResponse
+	42, // 85: kandev.plugin.v1.Host.ListWorkflowSteps:output_type -> kandev.plugin.v1.ListWorkflowStepsResponse
+	45, // 86: kandev.plugin.v1.Host.ListAgentProfiles:output_type -> kandev.plugin.v1.ListAgentProfilesResponse
+	48, // 87: kandev.plugin.v1.Host.ListRepositories:output_type -> kandev.plugin.v1.ListRepositoriesResponse
+	52, // 88: kandev.plugin.v1.Host.ListSessions:output_type -> kandev.plugin.v1.ListSessionsResponse
+	55, // 89: kandev.plugin.v1.Host.ListSessionCodeStats:output_type -> kandev.plugin.v1.ListSessionCodeStatsResponse
+	59, // 90: kandev.plugin.v1.Host.ListMessages:output_type -> kandev.plugin.v1.ListMessagesResponse
+	61, // 91: kandev.plugin.v1.Host.CreateTask:output_type -> kandev.plugin.v1.CreateTaskResponse
+	63, // 92: kandev.plugin.v1.Host.UpdateTask:output_type -> kandev.plugin.v1.UpdateTaskResponse
+	66, // 93: kandev.plugin.v1.Host.CreateComment:output_type -> kandev.plugin.v1.CreateCommentResponse
+	69, // [69:94] is the sub-list for method output_type
+	44, // [44:69] is the sub-list for method input_type
+	44, // [44:44] is the sub-list for extension type_name
+	44, // [44:44] is the sub-list for extension extendee
+	0,  // [0:44] is the sub-list for field type_name
 }
 
 func init() { file_kandev_plugin_v1_plugin_proto_init() }
@@ -4212,15 +4536,16 @@ func file_kandev_plugin_v1_plugin_proto_init() {
 	file_kandev_plugin_v1_plugin_proto_msgTypes[37].OneofWrappers = []any{}
 	file_kandev_plugin_v1_plugin_proto_msgTypes[46].OneofWrappers = []any{}
 	file_kandev_plugin_v1_plugin_proto_msgTypes[49].OneofWrappers = []any{}
-	file_kandev_plugin_v1_plugin_proto_msgTypes[56].OneofWrappers = []any{}
-	file_kandev_plugin_v1_plugin_proto_msgTypes[58].OneofWrappers = []any{}
+	file_kandev_plugin_v1_plugin_proto_msgTypes[57].OneofWrappers = []any{}
+	file_kandev_plugin_v1_plugin_proto_msgTypes[60].OneofWrappers = []any{}
+	file_kandev_plugin_v1_plugin_proto_msgTypes[62].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_kandev_plugin_v1_plugin_proto_rawDesc), len(file_kandev_plugin_v1_plugin_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   65,
+			NumMessages:   69,
 			NumExtensions: 0,
 			NumServices:   2,
 		},

--- a/apps/backend/proto/kandev/plugin/v1/plugin.pb.go
+++ b/apps/backend/proto/kandev/plugin/v1/plugin.pb.go
@@ -3551,6 +3551,98 @@ func (x *ListMessagesResponse) GetPageInfo() *PageInfo {
 	return nil
 }
 
+// ── Utility agent invocation (agent_invoke) ──────────────────────────────────
+// A one-shot completion delegated to the operator-configured utility agent.
+// Adding fields here (e.g. a future system_prompt or max_tokens) is the
+// forward-compatible extension path — the SDK method stays source-stable.
+type InvokeUtilityAgentRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Prompt        string                 `protobuf:"bytes,1,opt,name=prompt,proto3" json:"prompt,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *InvokeUtilityAgentRequest) Reset() {
+	*x = InvokeUtilityAgentRequest{}
+	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[60]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *InvokeUtilityAgentRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*InvokeUtilityAgentRequest) ProtoMessage() {}
+
+func (x *InvokeUtilityAgentRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[60]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use InvokeUtilityAgentRequest.ProtoReflect.Descriptor instead.
+func (*InvokeUtilityAgentRequest) Descriptor() ([]byte, []int) {
+	return file_kandev_plugin_v1_plugin_proto_rawDescGZIP(), []int{60}
+}
+
+func (x *InvokeUtilityAgentRequest) GetPrompt() string {
+	if x != nil {
+		return x.Prompt
+	}
+	return ""
+}
+
+type InvokeUtilityAgentResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Text          string                 `protobuf:"bytes,1,opt,name=text,proto3" json:"text,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *InvokeUtilityAgentResponse) Reset() {
+	*x = InvokeUtilityAgentResponse{}
+	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[61]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *InvokeUtilityAgentResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*InvokeUtilityAgentResponse) ProtoMessage() {}
+
+func (x *InvokeUtilityAgentResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[61]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use InvokeUtilityAgentResponse.ProtoReflect.Descriptor instead.
+func (*InvokeUtilityAgentResponse) Descriptor() ([]byte, []int) {
+	return file_kandev_plugin_v1_plugin_proto_rawDescGZIP(), []int{61}
+}
+
+func (x *InvokeUtilityAgentResponse) GetText() string {
+	if x != nil {
+		return x.Text
+	}
+	return ""
+}
+
 // ── Writes (phase 2; api_write) ──────────────────────────────────────────────
 type CreateTaskRequest struct {
 	state          protoimpl.MessageState `protogen:"open.v1"`
@@ -3567,7 +3659,7 @@ type CreateTaskRequest struct {
 
 func (x *CreateTaskRequest) Reset() {
 	*x = CreateTaskRequest{}
-	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[60]
+	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3579,7 +3671,7 @@ func (x *CreateTaskRequest) String() string {
 func (*CreateTaskRequest) ProtoMessage() {}
 
 func (x *CreateTaskRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[60]
+	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3592,7 +3684,7 @@ func (x *CreateTaskRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateTaskRequest.ProtoReflect.Descriptor instead.
 func (*CreateTaskRequest) Descriptor() ([]byte, []int) {
-	return file_kandev_plugin_v1_plugin_proto_rawDescGZIP(), []int{60}
+	return file_kandev_plugin_v1_plugin_proto_rawDescGZIP(), []int{62}
 }
 
 func (x *CreateTaskRequest) GetWorkspaceId() string {
@@ -3653,7 +3745,7 @@ type CreateTaskResponse struct {
 
 func (x *CreateTaskResponse) Reset() {
 	*x = CreateTaskResponse{}
-	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[61]
+	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3665,7 +3757,7 @@ func (x *CreateTaskResponse) String() string {
 func (*CreateTaskResponse) ProtoMessage() {}
 
 func (x *CreateTaskResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[61]
+	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3678,7 +3770,7 @@ func (x *CreateTaskResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateTaskResponse.ProtoReflect.Descriptor instead.
 func (*CreateTaskResponse) Descriptor() ([]byte, []int) {
-	return file_kandev_plugin_v1_plugin_proto_rawDescGZIP(), []int{61}
+	return file_kandev_plugin_v1_plugin_proto_rawDescGZIP(), []int{63}
 }
 
 func (x *CreateTaskResponse) GetTask() *Task {
@@ -3701,7 +3793,7 @@ type UpdateTaskRequest struct {
 
 func (x *UpdateTaskRequest) Reset() {
 	*x = UpdateTaskRequest{}
-	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[62]
+	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3713,7 +3805,7 @@ func (x *UpdateTaskRequest) String() string {
 func (*UpdateTaskRequest) ProtoMessage() {}
 
 func (x *UpdateTaskRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[62]
+	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3726,7 +3818,7 @@ func (x *UpdateTaskRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateTaskRequest.ProtoReflect.Descriptor instead.
 func (*UpdateTaskRequest) Descriptor() ([]byte, []int) {
-	return file_kandev_plugin_v1_plugin_proto_rawDescGZIP(), []int{62}
+	return file_kandev_plugin_v1_plugin_proto_rawDescGZIP(), []int{64}
 }
 
 func (x *UpdateTaskRequest) GetId() string {
@@ -3773,7 +3865,7 @@ type UpdateTaskResponse struct {
 
 func (x *UpdateTaskResponse) Reset() {
 	*x = UpdateTaskResponse{}
-	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[63]
+	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3785,7 +3877,7 @@ func (x *UpdateTaskResponse) String() string {
 func (*UpdateTaskResponse) ProtoMessage() {}
 
 func (x *UpdateTaskResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[63]
+	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3798,7 +3890,7 @@ func (x *UpdateTaskResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateTaskResponse.ProtoReflect.Descriptor instead.
 func (*UpdateTaskResponse) Descriptor() ([]byte, []int) {
-	return file_kandev_plugin_v1_plugin_proto_rawDescGZIP(), []int{63}
+	return file_kandev_plugin_v1_plugin_proto_rawDescGZIP(), []int{65}
 }
 
 func (x *UpdateTaskResponse) GetTask() *Task {
@@ -3821,7 +3913,7 @@ type Comment struct {
 
 func (x *Comment) Reset() {
 	*x = Comment{}
-	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[64]
+	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3833,7 +3925,7 @@ func (x *Comment) String() string {
 func (*Comment) ProtoMessage() {}
 
 func (x *Comment) ProtoReflect() protoreflect.Message {
-	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[64]
+	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3846,7 +3938,7 @@ func (x *Comment) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Comment.ProtoReflect.Descriptor instead.
 func (*Comment) Descriptor() ([]byte, []int) {
-	return file_kandev_plugin_v1_plugin_proto_rawDescGZIP(), []int{64}
+	return file_kandev_plugin_v1_plugin_proto_rawDescGZIP(), []int{66}
 }
 
 func (x *Comment) GetId() string {
@@ -3894,7 +3986,7 @@ type CreateCommentRequest struct {
 
 func (x *CreateCommentRequest) Reset() {
 	*x = CreateCommentRequest{}
-	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[65]
+	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[67]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3906,7 +3998,7 @@ func (x *CreateCommentRequest) String() string {
 func (*CreateCommentRequest) ProtoMessage() {}
 
 func (x *CreateCommentRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[65]
+	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[67]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3919,7 +4011,7 @@ func (x *CreateCommentRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateCommentRequest.ProtoReflect.Descriptor instead.
 func (*CreateCommentRequest) Descriptor() ([]byte, []int) {
-	return file_kandev_plugin_v1_plugin_proto_rawDescGZIP(), []int{65}
+	return file_kandev_plugin_v1_plugin_proto_rawDescGZIP(), []int{67}
 }
 
 func (x *CreateCommentRequest) GetTaskId() string {
@@ -3945,7 +4037,7 @@ type CreateCommentResponse struct {
 
 func (x *CreateCommentResponse) Reset() {
 	*x = CreateCommentResponse{}
-	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[66]
+	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3957,7 +4049,7 @@ func (x *CreateCommentResponse) String() string {
 func (*CreateCommentResponse) ProtoMessage() {}
 
 func (x *CreateCommentResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[66]
+	mi := &file_kandev_plugin_v1_plugin_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3970,7 +4062,7 @@ func (x *CreateCommentResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateCommentResponse.ProtoReflect.Descriptor instead.
 func (*CreateCommentResponse) Descriptor() ([]byte, []int) {
-	return file_kandev_plugin_v1_plugin_proto_rawDescGZIP(), []int{66}
+	return file_kandev_plugin_v1_plugin_proto_rawDescGZIP(), []int{68}
 }
 
 func (x *CreateCommentResponse) GetComment() *Comment {
@@ -4268,7 +4360,11 @@ const file_kandev_plugin_v1_plugin_proto_rawDesc = "" +
 	"\x04page\x18\x02 \x01(\v2\x16.kandev.plugin.v1.PageR\x04page\"\x86\x01\n" +
 	"\x14ListMessagesResponse\x125\n" +
 	"\bmessages\x18\x01 \x03(\v2\x19.kandev.plugin.v1.MessageR\bmessages\x127\n" +
-	"\tpage_info\x18\x02 \x01(\v2\x1a.kandev.plugin.v1.PageInfoR\bpageInfo\"\xa4\x02\n" +
+	"\tpage_info\x18\x02 \x01(\v2\x1a.kandev.plugin.v1.PageInfoR\bpageInfo\"3\n" +
+	"\x19InvokeUtilityAgentRequest\x12\x16\n" +
+	"\x06prompt\x18\x01 \x01(\tR\x06prompt\"0\n" +
+	"\x1aInvokeUtilityAgentResponse\x12\x12\n" +
+	"\x04text\x18\x01 \x01(\tR\x04text\"\xa4\x02\n" +
 	"\x11CreateTaskRequest\x12!\n" +
 	"\fworkspace_id\x18\x01 \x01(\tR\vworkspaceId\x12\x1f\n" +
 	"\vworkflow_id\x18\x02 \x01(\tR\n" +
@@ -4310,7 +4406,7 @@ const file_kandev_plugin_v1_plugin_proto_rawDesc = "" +
 	"\acomment\x18\x01 \x01(\v2\x19.kandev.plugin.v1.CommentR\acomment2\xa3\x01\n" +
 	"\x06Plugin\x12C\n" +
 	"\fDeliverEvent\x12\x17.kandev.plugin.v1.Event\x1a\x1a.kandev.plugin.v1.EventAck\x12T\n" +
-	"\rHandleWebhook\x12 .kandev.plugin.v1.WebhookRequest\x1a!.kandev.plugin.v1.WebhookResponse2\xf1\x10\n" +
+	"\rHandleWebhook\x12 .kandev.plugin.v1.WebhookRequest\x1a!.kandev.plugin.v1.WebhookResponse2\xe2\x11\n" +
 	"\x04Host\x12Q\n" +
 	"\bGetState\x12!.kandev.plugin.v1.GetStateRequest\x1a\".kandev.plugin.v1.GetStateResponse\x12Q\n" +
 	"\bSetState\x12!.kandev.plugin.v1.SetStateRequest\x1a\".kandev.plugin.v1.SetStateResponse\x12Z\n" +
@@ -4331,7 +4427,8 @@ const file_kandev_plugin_v1_plugin_proto_rawDesc = "" +
 	"\x10ListRepositories\x12).kandev.plugin.v1.ListRepositoriesRequest\x1a*.kandev.plugin.v1.ListRepositoriesResponse\x12]\n" +
 	"\fListSessions\x12%.kandev.plugin.v1.ListSessionsRequest\x1a&.kandev.plugin.v1.ListSessionsResponse\x12u\n" +
 	"\x14ListSessionCodeStats\x12-.kandev.plugin.v1.ListSessionCodeStatsRequest\x1a..kandev.plugin.v1.ListSessionCodeStatsResponse\x12]\n" +
-	"\fListMessages\x12%.kandev.plugin.v1.ListMessagesRequest\x1a&.kandev.plugin.v1.ListMessagesResponse\x12W\n" +
+	"\fListMessages\x12%.kandev.plugin.v1.ListMessagesRequest\x1a&.kandev.plugin.v1.ListMessagesResponse\x12o\n" +
+	"\x12InvokeUtilityAgent\x12+.kandev.plugin.v1.InvokeUtilityAgentRequest\x1a,.kandev.plugin.v1.InvokeUtilityAgentResponse\x12W\n" +
 	"\n" +
 	"CreateTask\x12#.kandev.plugin.v1.CreateTaskRequest\x1a$.kandev.plugin.v1.CreateTaskResponse\x12W\n" +
 	"\n" +
@@ -4350,7 +4447,7 @@ func file_kandev_plugin_v1_plugin_proto_rawDescGZIP() []byte {
 	return file_kandev_plugin_v1_plugin_proto_rawDescData
 }
 
-var file_kandev_plugin_v1_plugin_proto_msgTypes = make([]protoimpl.MessageInfo, 69)
+var file_kandev_plugin_v1_plugin_proto_msgTypes = make([]protoimpl.MessageInfo, 71)
 var file_kandev_plugin_v1_plugin_proto_goTypes = []any{
 	(*Event)(nil),                        // 0: kandev.plugin.v1.Event
 	(*EventAck)(nil),                     // 1: kandev.plugin.v1.EventAck
@@ -4412,29 +4509,31 @@ var file_kandev_plugin_v1_plugin_proto_goTypes = []any{
 	(*MessageFilter)(nil),                // 57: kandev.plugin.v1.MessageFilter
 	(*ListMessagesRequest)(nil),          // 58: kandev.plugin.v1.ListMessagesRequest
 	(*ListMessagesResponse)(nil),         // 59: kandev.plugin.v1.ListMessagesResponse
-	(*CreateTaskRequest)(nil),            // 60: kandev.plugin.v1.CreateTaskRequest
-	(*CreateTaskResponse)(nil),           // 61: kandev.plugin.v1.CreateTaskResponse
-	(*UpdateTaskRequest)(nil),            // 62: kandev.plugin.v1.UpdateTaskRequest
-	(*UpdateTaskResponse)(nil),           // 63: kandev.plugin.v1.UpdateTaskResponse
-	(*Comment)(nil),                      // 64: kandev.plugin.v1.Comment
-	(*CreateCommentRequest)(nil),         // 65: kandev.plugin.v1.CreateCommentRequest
-	(*CreateCommentResponse)(nil),        // 66: kandev.plugin.v1.CreateCommentResponse
-	nil,                                  // 67: kandev.plugin.v1.WebhookRequest.HeadersEntry
-	nil,                                  // 68: kandev.plugin.v1.WebhookResponse.HeadersEntry
-	(*structpb.Struct)(nil),              // 69: google.protobuf.Struct
+	(*InvokeUtilityAgentRequest)(nil),    // 60: kandev.plugin.v1.InvokeUtilityAgentRequest
+	(*InvokeUtilityAgentResponse)(nil),   // 61: kandev.plugin.v1.InvokeUtilityAgentResponse
+	(*CreateTaskRequest)(nil),            // 62: kandev.plugin.v1.CreateTaskRequest
+	(*CreateTaskResponse)(nil),           // 63: kandev.plugin.v1.CreateTaskResponse
+	(*UpdateTaskRequest)(nil),            // 64: kandev.plugin.v1.UpdateTaskRequest
+	(*UpdateTaskResponse)(nil),           // 65: kandev.plugin.v1.UpdateTaskResponse
+	(*Comment)(nil),                      // 66: kandev.plugin.v1.Comment
+	(*CreateCommentRequest)(nil),         // 67: kandev.plugin.v1.CreateCommentRequest
+	(*CreateCommentResponse)(nil),        // 68: kandev.plugin.v1.CreateCommentResponse
+	nil,                                  // 69: kandev.plugin.v1.WebhookRequest.HeadersEntry
+	nil,                                  // 70: kandev.plugin.v1.WebhookResponse.HeadersEntry
+	(*structpb.Struct)(nil),              // 71: google.protobuf.Struct
 }
 var file_kandev_plugin_v1_plugin_proto_depIdxs = []int32{
-	69, // 0: kandev.plugin.v1.Event.payload:type_name -> google.protobuf.Struct
-	67, // 1: kandev.plugin.v1.WebhookRequest.headers:type_name -> kandev.plugin.v1.WebhookRequest.HeadersEntry
-	68, // 2: kandev.plugin.v1.WebhookResponse.headers:type_name -> kandev.plugin.v1.WebhookResponse.HeadersEntry
-	69, // 3: kandev.plugin.v1.GetStateResponse.value:type_name -> google.protobuf.Struct
-	69, // 4: kandev.plugin.v1.SetStateRequest.value:type_name -> google.protobuf.Struct
+	71, // 0: kandev.plugin.v1.Event.payload:type_name -> google.protobuf.Struct
+	69, // 1: kandev.plugin.v1.WebhookRequest.headers:type_name -> kandev.plugin.v1.WebhookRequest.HeadersEntry
+	70, // 2: kandev.plugin.v1.WebhookResponse.headers:type_name -> kandev.plugin.v1.WebhookResponse.HeadersEntry
+	71, // 3: kandev.plugin.v1.GetStateResponse.value:type_name -> google.protobuf.Struct
+	71, // 4: kandev.plugin.v1.SetStateRequest.value:type_name -> google.protobuf.Struct
 	12, // 5: kandev.plugin.v1.ListStateResponse.entries:type_name -> kandev.plugin.v1.StateEntry
-	69, // 6: kandev.plugin.v1.StateEntry.value:type_name -> google.protobuf.Struct
-	69, // 7: kandev.plugin.v1.GetConfigResponse.config:type_name -> google.protobuf.Struct
-	69, // 8: kandev.plugin.v1.EmitEventRequest.payload:type_name -> google.protobuf.Struct
+	71, // 6: kandev.plugin.v1.StateEntry.value:type_name -> google.protobuf.Struct
+	71, // 7: kandev.plugin.v1.GetConfigResponse.config:type_name -> google.protobuf.Struct
+	71, // 8: kandev.plugin.v1.EmitEventRequest.payload:type_name -> google.protobuf.Struct
 	28, // 9: kandev.plugin.v1.Task.repositories:type_name -> kandev.plugin.v1.TaskRepository
-	69, // 10: kandev.plugin.v1.Task.metadata:type_name -> google.protobuf.Struct
+	71, // 10: kandev.plugin.v1.Task.metadata:type_name -> google.protobuf.Struct
 	29, // 11: kandev.plugin.v1.ListTasksRequest.filter:type_name -> kandev.plugin.v1.TaskFilter
 	25, // 12: kandev.plugin.v1.ListTasksRequest.page:type_name -> kandev.plugin.v1.Page
 	27, // 13: kandev.plugin.v1.ListTasksResponse.tasks:type_name -> kandev.plugin.v1.Task
@@ -4467,7 +4566,7 @@ var file_kandev_plugin_v1_plugin_proto_depIdxs = []int32{
 	26, // 40: kandev.plugin.v1.ListMessagesResponse.page_info:type_name -> kandev.plugin.v1.PageInfo
 	27, // 41: kandev.plugin.v1.CreateTaskResponse.task:type_name -> kandev.plugin.v1.Task
 	27, // 42: kandev.plugin.v1.UpdateTaskResponse.task:type_name -> kandev.plugin.v1.Task
-	64, // 43: kandev.plugin.v1.CreateCommentResponse.comment:type_name -> kandev.plugin.v1.Comment
+	66, // 43: kandev.plugin.v1.CreateCommentResponse.comment:type_name -> kandev.plugin.v1.Comment
 	0,  // 44: kandev.plugin.v1.Plugin.DeliverEvent:input_type -> kandev.plugin.v1.Event
 	2,  // 45: kandev.plugin.v1.Plugin.HandleWebhook:input_type -> kandev.plugin.v1.WebhookRequest
 	4,  // 46: kandev.plugin.v1.Host.GetState:input_type -> kandev.plugin.v1.GetStateRequest
@@ -4490,36 +4589,38 @@ var file_kandev_plugin_v1_plugin_proto_depIdxs = []int32{
 	51, // 63: kandev.plugin.v1.Host.ListSessions:input_type -> kandev.plugin.v1.ListSessionsRequest
 	54, // 64: kandev.plugin.v1.Host.ListSessionCodeStats:input_type -> kandev.plugin.v1.ListSessionCodeStatsRequest
 	58, // 65: kandev.plugin.v1.Host.ListMessages:input_type -> kandev.plugin.v1.ListMessagesRequest
-	60, // 66: kandev.plugin.v1.Host.CreateTask:input_type -> kandev.plugin.v1.CreateTaskRequest
-	62, // 67: kandev.plugin.v1.Host.UpdateTask:input_type -> kandev.plugin.v1.UpdateTaskRequest
-	65, // 68: kandev.plugin.v1.Host.CreateComment:input_type -> kandev.plugin.v1.CreateCommentRequest
-	1,  // 69: kandev.plugin.v1.Plugin.DeliverEvent:output_type -> kandev.plugin.v1.EventAck
-	3,  // 70: kandev.plugin.v1.Plugin.HandleWebhook:output_type -> kandev.plugin.v1.WebhookResponse
-	5,  // 71: kandev.plugin.v1.Host.GetState:output_type -> kandev.plugin.v1.GetStateResponse
-	7,  // 72: kandev.plugin.v1.Host.SetState:output_type -> kandev.plugin.v1.SetStateResponse
-	9,  // 73: kandev.plugin.v1.Host.DeleteState:output_type -> kandev.plugin.v1.DeleteStateResponse
-	11, // 74: kandev.plugin.v1.Host.ListState:output_type -> kandev.plugin.v1.ListStateResponse
-	22, // 75: kandev.plugin.v1.Host.RevealSecret:output_type -> kandev.plugin.v1.RevealSecretResponse
-	24, // 76: kandev.plugin.v1.Host.EmitEvent:output_type -> kandev.plugin.v1.EmitEventResponse
-	16, // 77: kandev.plugin.v1.Host.GetSecret:output_type -> kandev.plugin.v1.GetSecretResponse
-	18, // 78: kandev.plugin.v1.Host.SetSecret:output_type -> kandev.plugin.v1.SetSecretResponse
-	20, // 79: kandev.plugin.v1.Host.DeleteSecret:output_type -> kandev.plugin.v1.DeleteSecretResponse
-	14, // 80: kandev.plugin.v1.Host.GetConfig:output_type -> kandev.plugin.v1.GetConfigResponse
-	31, // 81: kandev.plugin.v1.Host.ListTasks:output_type -> kandev.plugin.v1.ListTasksResponse
-	33, // 82: kandev.plugin.v1.Host.GetTask:output_type -> kandev.plugin.v1.GetTaskResponse
-	36, // 83: kandev.plugin.v1.Host.ListWorkspaces:output_type -> kandev.plugin.v1.ListWorkspacesResponse
-	39, // 84: kandev.plugin.v1.Host.ListWorkflows:output_type -> kandev.plugin.v1.ListWorkflowsResponse
-	42, // 85: kandev.plugin.v1.Host.ListWorkflowSteps:output_type -> kandev.plugin.v1.ListWorkflowStepsResponse
-	45, // 86: kandev.plugin.v1.Host.ListAgentProfiles:output_type -> kandev.plugin.v1.ListAgentProfilesResponse
-	48, // 87: kandev.plugin.v1.Host.ListRepositories:output_type -> kandev.plugin.v1.ListRepositoriesResponse
-	52, // 88: kandev.plugin.v1.Host.ListSessions:output_type -> kandev.plugin.v1.ListSessionsResponse
-	55, // 89: kandev.plugin.v1.Host.ListSessionCodeStats:output_type -> kandev.plugin.v1.ListSessionCodeStatsResponse
-	59, // 90: kandev.plugin.v1.Host.ListMessages:output_type -> kandev.plugin.v1.ListMessagesResponse
-	61, // 91: kandev.plugin.v1.Host.CreateTask:output_type -> kandev.plugin.v1.CreateTaskResponse
-	63, // 92: kandev.plugin.v1.Host.UpdateTask:output_type -> kandev.plugin.v1.UpdateTaskResponse
-	66, // 93: kandev.plugin.v1.Host.CreateComment:output_type -> kandev.plugin.v1.CreateCommentResponse
-	69, // [69:94] is the sub-list for method output_type
-	44, // [44:69] is the sub-list for method input_type
+	60, // 66: kandev.plugin.v1.Host.InvokeUtilityAgent:input_type -> kandev.plugin.v1.InvokeUtilityAgentRequest
+	62, // 67: kandev.plugin.v1.Host.CreateTask:input_type -> kandev.plugin.v1.CreateTaskRequest
+	64, // 68: kandev.plugin.v1.Host.UpdateTask:input_type -> kandev.plugin.v1.UpdateTaskRequest
+	67, // 69: kandev.plugin.v1.Host.CreateComment:input_type -> kandev.plugin.v1.CreateCommentRequest
+	1,  // 70: kandev.plugin.v1.Plugin.DeliverEvent:output_type -> kandev.plugin.v1.EventAck
+	3,  // 71: kandev.plugin.v1.Plugin.HandleWebhook:output_type -> kandev.plugin.v1.WebhookResponse
+	5,  // 72: kandev.plugin.v1.Host.GetState:output_type -> kandev.plugin.v1.GetStateResponse
+	7,  // 73: kandev.plugin.v1.Host.SetState:output_type -> kandev.plugin.v1.SetStateResponse
+	9,  // 74: kandev.plugin.v1.Host.DeleteState:output_type -> kandev.plugin.v1.DeleteStateResponse
+	11, // 75: kandev.plugin.v1.Host.ListState:output_type -> kandev.plugin.v1.ListStateResponse
+	22, // 76: kandev.plugin.v1.Host.RevealSecret:output_type -> kandev.plugin.v1.RevealSecretResponse
+	24, // 77: kandev.plugin.v1.Host.EmitEvent:output_type -> kandev.plugin.v1.EmitEventResponse
+	16, // 78: kandev.plugin.v1.Host.GetSecret:output_type -> kandev.plugin.v1.GetSecretResponse
+	18, // 79: kandev.plugin.v1.Host.SetSecret:output_type -> kandev.plugin.v1.SetSecretResponse
+	20, // 80: kandev.plugin.v1.Host.DeleteSecret:output_type -> kandev.plugin.v1.DeleteSecretResponse
+	14, // 81: kandev.plugin.v1.Host.GetConfig:output_type -> kandev.plugin.v1.GetConfigResponse
+	31, // 82: kandev.plugin.v1.Host.ListTasks:output_type -> kandev.plugin.v1.ListTasksResponse
+	33, // 83: kandev.plugin.v1.Host.GetTask:output_type -> kandev.plugin.v1.GetTaskResponse
+	36, // 84: kandev.plugin.v1.Host.ListWorkspaces:output_type -> kandev.plugin.v1.ListWorkspacesResponse
+	39, // 85: kandev.plugin.v1.Host.ListWorkflows:output_type -> kandev.plugin.v1.ListWorkflowsResponse
+	42, // 86: kandev.plugin.v1.Host.ListWorkflowSteps:output_type -> kandev.plugin.v1.ListWorkflowStepsResponse
+	45, // 87: kandev.plugin.v1.Host.ListAgentProfiles:output_type -> kandev.plugin.v1.ListAgentProfilesResponse
+	48, // 88: kandev.plugin.v1.Host.ListRepositories:output_type -> kandev.plugin.v1.ListRepositoriesResponse
+	52, // 89: kandev.plugin.v1.Host.ListSessions:output_type -> kandev.plugin.v1.ListSessionsResponse
+	55, // 90: kandev.plugin.v1.Host.ListSessionCodeStats:output_type -> kandev.plugin.v1.ListSessionCodeStatsResponse
+	59, // 91: kandev.plugin.v1.Host.ListMessages:output_type -> kandev.plugin.v1.ListMessagesResponse
+	61, // 92: kandev.plugin.v1.Host.InvokeUtilityAgent:output_type -> kandev.plugin.v1.InvokeUtilityAgentResponse
+	63, // 93: kandev.plugin.v1.Host.CreateTask:output_type -> kandev.plugin.v1.CreateTaskResponse
+	65, // 94: kandev.plugin.v1.Host.UpdateTask:output_type -> kandev.plugin.v1.UpdateTaskResponse
+	68, // 95: kandev.plugin.v1.Host.CreateComment:output_type -> kandev.plugin.v1.CreateCommentResponse
+	70, // [70:96] is the sub-list for method output_type
+	44, // [44:70] is the sub-list for method input_type
 	44, // [44:44] is the sub-list for extension type_name
 	44, // [44:44] is the sub-list for extension extendee
 	0,  // [0:44] is the sub-list for field type_name
@@ -4537,15 +4638,15 @@ func file_kandev_plugin_v1_plugin_proto_init() {
 	file_kandev_plugin_v1_plugin_proto_msgTypes[46].OneofWrappers = []any{}
 	file_kandev_plugin_v1_plugin_proto_msgTypes[49].OneofWrappers = []any{}
 	file_kandev_plugin_v1_plugin_proto_msgTypes[57].OneofWrappers = []any{}
-	file_kandev_plugin_v1_plugin_proto_msgTypes[60].OneofWrappers = []any{}
 	file_kandev_plugin_v1_plugin_proto_msgTypes[62].OneofWrappers = []any{}
+	file_kandev_plugin_v1_plugin_proto_msgTypes[64].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_kandev_plugin_v1_plugin_proto_rawDesc), len(file_kandev_plugin_v1_plugin_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   69,
+			NumMessages:   71,
 			NumExtensions: 0,
 			NumServices:   2,
 		},

--- a/apps/backend/proto/kandev/plugin/v1/plugin.proto
+++ b/apps/backend/proto/kandev/plugin/v1/plugin.proto
@@ -85,6 +85,12 @@ service Host {
   // event — raw system prompts are never exposed to plugins.
   rpc ListMessages(ListMessagesRequest) returns (ListMessagesResponse);
 
+  // Utility agent — capability agent_invoke. Runs a one-shot, non-interactive
+  // completion using the operator-configured "utility agent" profile (Settings
+  // > System), so a plugin can delegate a lightweight LLM step without holding
+  // its own API key. FailedPrecondition when no utility agent is configured.
+  rpc InvokeUtilityAgent(InvokeUtilityAgentRequest) returns (InvokeUtilityAgentResponse);
+
   // Writes — capability api_write:<resource>. Declared now for a stable
   // contract; handlers land in a later phase (not implemented by this RPC
   // addition). Route through service methods so the corresponding task.*
@@ -421,6 +427,17 @@ message ListMessagesRequest {
 message ListMessagesResponse {
   repeated Message messages = 1;
   PageInfo page_info = 2;
+}
+
+// ── Utility agent invocation (agent_invoke) ──────────────────────────────────
+// A one-shot completion delegated to the operator-configured utility agent.
+// Adding fields here (e.g. a future system_prompt or max_tokens) is the
+// forward-compatible extension path — the SDK method stays source-stable.
+message InvokeUtilityAgentRequest {
+  string prompt = 1;
+}
+message InvokeUtilityAgentResponse {
+  string text = 1;
 }
 
 // ── Writes (phase 2; api_write) ──────────────────────────────────────────────

--- a/apps/backend/proto/kandev/plugin/v1/plugin.proto
+++ b/apps/backend/proto/kandev/plugin/v1/plugin.proto
@@ -78,6 +78,13 @@ service Host {
   rpc ListSessions(ListSessionsRequest) returns (ListSessionsResponse);
   rpc ListSessionCodeStats(ListSessionCodeStatsRequest) returns (ListSessionCodeStatsResponse);
 
+  // Conversation content — capability api_read:messages. Historical
+  // user/agent message content for a session or task, filterable by a time
+  // range (e.g. "yesterday"). Content is sanitized: kandev-injected
+  // <kandev-system> blocks are stripped, exactly like the message.added bus
+  // event — raw system prompts are never exposed to plugins.
+  rpc ListMessages(ListMessagesRequest) returns (ListMessagesResponse);
+
   // Writes — capability api_write:<resource>. Declared now for a stable
   // contract; handlers land in a later phase (not implemented by this RPC
   // addition). Route through service methods so the corresponding task.*
@@ -381,6 +388,38 @@ message ListSessionCodeStatsRequest {
 }
 message ListSessionCodeStatsResponse {
   repeated SessionCodeStats stats = 1;
+  PageInfo page_info = 2;
+}
+
+// ── Messages (conversation content) ──────────────────────────────────────────
+// One user/agent message in a session's transcript. content has kandev's
+// injected <kandev-system> blocks stripped; raw system content is never sent.
+// author_type is "user" or "agent" (there is no "system" author — system
+// context is inline markup that is removed at read time). type is the message
+// kind ("message", "content", "tool_call", "thinking", ...).
+message Message {
+  string id = 1;
+  string session_id = 2;
+  string task_id = 3;
+  string turn_id = 4;
+  string author_type = 5; // "user" | "agent"
+  string content = 6;     // <kandev-system> blocks stripped
+  string type = 7;        // "message" default; see MessageType
+  string created_at = 8;  // RFC3339
+}
+message MessageFilter {
+  repeated string session_ids = 1; // empty → not constrained by session
+  repeated string task_ids = 2;    // empty → not constrained by task
+  optional string since = 3;       // RFC3339 inclusive lower bound on created_at
+  optional string until = 4;       // RFC3339 exclusive upper bound on created_at
+  repeated string types = 5;       // empty → all message types
+}
+message ListMessagesRequest {
+  MessageFilter filter = 1;
+  Page page = 2;
+}
+message ListMessagesResponse {
+  repeated Message messages = 1;
   PageInfo page_info = 2;
 }
 

--- a/apps/backend/proto/kandev/plugin/v1/plugin_grpc.pb.go
+++ b/apps/backend/proto/kandev/plugin/v1/plugin_grpc.pb.go
@@ -183,6 +183,7 @@ const (
 	Host_ListSessions_FullMethodName         = "/kandev.plugin.v1.Host/ListSessions"
 	Host_ListSessionCodeStats_FullMethodName = "/kandev.plugin.v1.Host/ListSessionCodeStats"
 	Host_ListMessages_FullMethodName         = "/kandev.plugin.v1.Host/ListMessages"
+	Host_InvokeUtilityAgent_FullMethodName   = "/kandev.plugin.v1.Host/InvokeUtilityAgent"
 	Host_CreateTask_FullMethodName           = "/kandev.plugin.v1.Host/CreateTask"
 	Host_UpdateTask_FullMethodName           = "/kandev.plugin.v1.Host/UpdateTask"
 	Host_CreateComment_FullMethodName        = "/kandev.plugin.v1.Host/CreateComment"
@@ -259,6 +260,11 @@ type HostClient interface {
 	// <kandev-system> blocks are stripped, exactly like the message.added bus
 	// event — raw system prompts are never exposed to plugins.
 	ListMessages(ctx context.Context, in *ListMessagesRequest, opts ...grpc.CallOption) (*ListMessagesResponse, error)
+	// Utility agent — capability agent_invoke. Runs a one-shot, non-interactive
+	// completion using the operator-configured "utility agent" profile (Settings
+	// > System), so a plugin can delegate a lightweight LLM step without holding
+	// its own API key. FailedPrecondition when no utility agent is configured.
+	InvokeUtilityAgent(ctx context.Context, in *InvokeUtilityAgentRequest, opts ...grpc.CallOption) (*InvokeUtilityAgentResponse, error)
 	// Writes — capability api_write:<resource>. Declared now for a stable
 	// contract; handlers land in a later phase (not implemented by this RPC
 	// addition). Route through service methods so the corresponding task.*
@@ -476,6 +482,16 @@ func (c *hostClient) ListMessages(ctx context.Context, in *ListMessagesRequest, 
 	return out, nil
 }
 
+func (c *hostClient) InvokeUtilityAgent(ctx context.Context, in *InvokeUtilityAgentRequest, opts ...grpc.CallOption) (*InvokeUtilityAgentResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(InvokeUtilityAgentResponse)
+	err := c.cc.Invoke(ctx, Host_InvokeUtilityAgent_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *hostClient) CreateTask(ctx context.Context, in *CreateTaskRequest, opts ...grpc.CallOption) (*CreateTaskResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(CreateTaskResponse)
@@ -577,6 +593,11 @@ type HostServer interface {
 	// <kandev-system> blocks are stripped, exactly like the message.added bus
 	// event — raw system prompts are never exposed to plugins.
 	ListMessages(context.Context, *ListMessagesRequest) (*ListMessagesResponse, error)
+	// Utility agent — capability agent_invoke. Runs a one-shot, non-interactive
+	// completion using the operator-configured "utility agent" profile (Settings
+	// > System), so a plugin can delegate a lightweight LLM step without holding
+	// its own API key. FailedPrecondition when no utility agent is configured.
+	InvokeUtilityAgent(context.Context, *InvokeUtilityAgentRequest) (*InvokeUtilityAgentResponse, error)
 	// Writes — capability api_write:<resource>. Declared now for a stable
 	// contract; handlers land in a later phase (not implemented by this RPC
 	// addition). Route through service methods so the corresponding task.*
@@ -653,6 +674,9 @@ func (UnimplementedHostServer) ListSessionCodeStats(context.Context, *ListSessio
 }
 func (UnimplementedHostServer) ListMessages(context.Context, *ListMessagesRequest) (*ListMessagesResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ListMessages not implemented")
+}
+func (UnimplementedHostServer) InvokeUtilityAgent(context.Context, *InvokeUtilityAgentRequest) (*InvokeUtilityAgentResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method InvokeUtilityAgent not implemented")
 }
 func (UnimplementedHostServer) CreateTask(context.Context, *CreateTaskRequest) (*CreateTaskResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method CreateTask not implemented")
@@ -1044,6 +1068,24 @@ func _Host_ListMessages_Handler(srv interface{}, ctx context.Context, dec func(i
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Host_InvokeUtilityAgent_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(InvokeUtilityAgentRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(HostServer).InvokeUtilityAgent(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Host_InvokeUtilityAgent_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(HostServer).InvokeUtilityAgent(ctx, req.(*InvokeUtilityAgentRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _Host_CreateTask_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(CreateTaskRequest)
 	if err := dec(in); err != nil {
@@ -1184,6 +1226,10 @@ var Host_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ListMessages",
 			Handler:    _Host_ListMessages_Handler,
+		},
+		{
+			MethodName: "InvokeUtilityAgent",
+			Handler:    _Host_InvokeUtilityAgent_Handler,
 		},
 		{
 			MethodName: "CreateTask",

--- a/apps/backend/proto/kandev/plugin/v1/plugin_grpc.pb.go
+++ b/apps/backend/proto/kandev/plugin/v1/plugin_grpc.pb.go
@@ -182,6 +182,7 @@ const (
 	Host_ListRepositories_FullMethodName     = "/kandev.plugin.v1.Host/ListRepositories"
 	Host_ListSessions_FullMethodName         = "/kandev.plugin.v1.Host/ListSessions"
 	Host_ListSessionCodeStats_FullMethodName = "/kandev.plugin.v1.Host/ListSessionCodeStats"
+	Host_ListMessages_FullMethodName         = "/kandev.plugin.v1.Host/ListMessages"
 	Host_CreateTask_FullMethodName           = "/kandev.plugin.v1.Host/CreateTask"
 	Host_UpdateTask_FullMethodName           = "/kandev.plugin.v1.Host/UpdateTask"
 	Host_CreateComment_FullMethodName        = "/kandev.plugin.v1.Host/CreateComment"
@@ -252,6 +253,12 @@ type HostClient interface {
 	// not the raw commit/snapshot rows, whose JSON schema churns.
 	ListSessions(ctx context.Context, in *ListSessionsRequest, opts ...grpc.CallOption) (*ListSessionsResponse, error)
 	ListSessionCodeStats(ctx context.Context, in *ListSessionCodeStatsRequest, opts ...grpc.CallOption) (*ListSessionCodeStatsResponse, error)
+	// Conversation content — capability api_read:messages. Historical
+	// user/agent message content for a session or task, filterable by a time
+	// range (e.g. "yesterday"). Content is sanitized: kandev-injected
+	// <kandev-system> blocks are stripped, exactly like the message.added bus
+	// event — raw system prompts are never exposed to plugins.
+	ListMessages(ctx context.Context, in *ListMessagesRequest, opts ...grpc.CallOption) (*ListMessagesResponse, error)
 	// Writes — capability api_write:<resource>. Declared now for a stable
 	// contract; handlers land in a later phase (not implemented by this RPC
 	// addition). Route through service methods so the corresponding task.*
@@ -459,6 +466,16 @@ func (c *hostClient) ListSessionCodeStats(ctx context.Context, in *ListSessionCo
 	return out, nil
 }
 
+func (c *hostClient) ListMessages(ctx context.Context, in *ListMessagesRequest, opts ...grpc.CallOption) (*ListMessagesResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListMessagesResponse)
+	err := c.cc.Invoke(ctx, Host_ListMessages_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *hostClient) CreateTask(ctx context.Context, in *CreateTaskRequest, opts ...grpc.CallOption) (*CreateTaskResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(CreateTaskResponse)
@@ -554,6 +571,12 @@ type HostServer interface {
 	// not the raw commit/snapshot rows, whose JSON schema churns.
 	ListSessions(context.Context, *ListSessionsRequest) (*ListSessionsResponse, error)
 	ListSessionCodeStats(context.Context, *ListSessionCodeStatsRequest) (*ListSessionCodeStatsResponse, error)
+	// Conversation content — capability api_read:messages. Historical
+	// user/agent message content for a session or task, filterable by a time
+	// range (e.g. "yesterday"). Content is sanitized: kandev-injected
+	// <kandev-system> blocks are stripped, exactly like the message.added bus
+	// event — raw system prompts are never exposed to plugins.
+	ListMessages(context.Context, *ListMessagesRequest) (*ListMessagesResponse, error)
 	// Writes — capability api_write:<resource>. Declared now for a stable
 	// contract; handlers land in a later phase (not implemented by this RPC
 	// addition). Route through service methods so the corresponding task.*
@@ -627,6 +650,9 @@ func (UnimplementedHostServer) ListSessions(context.Context, *ListSessionsReques
 }
 func (UnimplementedHostServer) ListSessionCodeStats(context.Context, *ListSessionCodeStatsRequest) (*ListSessionCodeStatsResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ListSessionCodeStats not implemented")
+}
+func (UnimplementedHostServer) ListMessages(context.Context, *ListMessagesRequest) (*ListMessagesResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListMessages not implemented")
 }
 func (UnimplementedHostServer) CreateTask(context.Context, *CreateTaskRequest) (*CreateTaskResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method CreateTask not implemented")
@@ -1000,6 +1026,24 @@ func _Host_ListSessionCodeStats_Handler(srv interface{}, ctx context.Context, de
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Host_ListMessages_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListMessagesRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(HostServer).ListMessages(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Host_ListMessages_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(HostServer).ListMessages(ctx, req.(*ListMessagesRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _Host_CreateTask_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(CreateTaskRequest)
 	if err := dec(in); err != nil {
@@ -1136,6 +1180,10 @@ var Host_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ListSessionCodeStats",
 			Handler:    _Host_ListSessionCodeStats_Handler,
+		},
+		{
+			MethodName: "ListMessages",
+			Handler:    _Host_ListMessages_Handler,
 		},
 		{
 			MethodName: "CreateTask",

--- a/apps/web/app/settings/system/utility-agent/page.tsx
+++ b/apps/web/app/settings/system/utility-agent/page.tsx
@@ -1,0 +1,13 @@
+import { SystemPageShell } from "@/components/settings/system/system-page-shell";
+import { UtilityAgentProfileSettings } from "@/components/settings/utility-agent-profile-settings";
+
+export default function UtilityAgentPage() {
+  return (
+    <SystemPageShell
+      title="Utility Agent"
+      description="Choose the agent profile plugins use for lightweight, one-shot LLM calls."
+    >
+      <UtilityAgentProfileSettings />
+    </SystemPageShell>
+  );
+}

--- a/apps/web/components/app-sidebar/sections/settings/system-group.tsx
+++ b/apps/web/components/app-sidebar/sections/settings/system-group.tsx
@@ -8,6 +8,7 @@ import {
   IconFlask,
   IconInfoCircle,
   IconRefresh,
+  IconRobot,
   IconScale,
   IconServerCog,
   IconTrash,
@@ -21,6 +22,7 @@ const DEFAULT_HREF = `${ROOT_HREF}/status`;
 const ITEMS: Array<{ href: string; label: string; icon: TablerIcon }> = [
   { href: `${ROOT_HREF}/status`, label: "Status", icon: IconActivity },
   { href: `${ROOT_HREF}/feature-toggles`, label: "Feature Toggles", icon: IconFlask },
+  { href: `${ROOT_HREF}/utility-agent`, label: "Utility Agent", icon: IconRobot },
   { href: `${ROOT_HREF}/database`, label: "Database", icon: IconDatabase },
   { href: `${ROOT_HREF}/backups`, label: "Backups", icon: IconArchive },
   { href: `${ROOT_HREF}/storage`, label: "Storage", icon: IconTrash },

--- a/apps/web/components/settings/editors-settings-state.tsx
+++ b/apps/web/components/settings/editors-settings-state.tsx
@@ -309,6 +309,7 @@ function buildUserSettingsFromResponse(
     defaultEditorId: s.default_editor_id || null,
     enablePreviewOnClick: s.enable_preview_on_click ?? false,
     defaultUtilityAgentId: s.default_utility_agent_id || null,
+    utilityAgentProfileId: s.utility_agent_profile_id || null,
     keyboardShortcuts: s.keyboard_shortcuts ?? {},
     terminalLinkBehavior: parseTerminalLinkBehavior(s.terminal_link_behavior),
     terminalFontFamily: s.terminal_font_family || null,

--- a/apps/web/components/settings/utility-agent-profile-settings.test.tsx
+++ b/apps/web/components/settings/utility-agent-profile-settings.test.tsx
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { StateProvider } from "@/components/state-provider";
+import { defaultState } from "@/lib/state/default-state";
+import type { AgentProfileOption } from "@/lib/state/slices";
+import { TooltipProvider } from "@kandev/ui/tooltip";
+import { SettingsSaveProvider } from "./settings-save-provider";
+
+const updateUserSettings = vi.fn();
+const SELECT_TESTID = "utility-agent-profile-select";
+const CLAUDE_FAST_LABEL = "Claude • Fast";
+
+vi.mock("@/lib/api", () => ({
+  updateUserSettings: (...args: unknown[]) => updateUserSettings(...args),
+}));
+
+import { UtilityAgentProfileSettings } from "./utility-agent-profile-settings";
+
+const PROFILES: AgentProfileOption[] = [
+  {
+    id: "profile-1",
+    label: CLAUDE_FAST_LABEL,
+    agent_id: "agent-1",
+    agent_name: "Claude",
+    cli_passthrough: false,
+  },
+  {
+    id: "profile-2",
+    label: "Codex • Thorough",
+    agent_id: "agent-2",
+    agent_name: "Codex",
+    cli_passthrough: false,
+  },
+];
+
+function renderSettings(utilityAgentProfileId: string | null = null) {
+  return render(
+    <StateProvider
+      initialState={{
+        userSettings: {
+          ...defaultState.userSettings,
+          workspaceId: "workspace-1",
+          utilityAgentProfileId,
+        },
+        agentProfiles: { items: PROFILES, version: 0 },
+      }}
+    >
+      <TooltipProvider delayDuration={0}>
+        <SettingsSaveProvider>
+          <UtilityAgentProfileSettings />
+        </SettingsSaveProvider>
+      </TooltipProvider>
+    </StateProvider>,
+  );
+}
+
+beforeEach(() => {
+  updateUserSettings.mockReset().mockResolvedValue({ settings: {} });
+});
+
+afterEach(cleanup);
+
+describe("UtilityAgentProfileSettings", () => {
+  it("renders the heading, description, and available profiles", () => {
+    renderSettings();
+
+    screen.getByRole("heading", { name: "Utility agent" });
+    screen.getByText(/lightweight one-shot LLM calls that plugins delegate to/i);
+    screen.getByText("agent_invoke");
+    const trigger = screen.getByTestId(SELECT_TESTID);
+    expect(trigger.textContent).toContain("None");
+  });
+
+  it("defaults to None when no profile is configured", () => {
+    renderSettings(null);
+    expect(screen.getByTestId(SELECT_TESTID).textContent).toContain("None");
+  });
+
+  it("shows the currently configured profile label", () => {
+    renderSettings("profile-2");
+    expect(screen.getByTestId(SELECT_TESTID).textContent).toContain("Codex • Thorough");
+  });
+
+  it("persists the selected profile only after Save changes is pressed", async () => {
+    renderSettings();
+    const trigger = screen.getByTestId(SELECT_TESTID);
+
+    fireEvent.click(trigger);
+    fireEvent.click(await screen.findByText(CLAUDE_FAST_LABEL));
+
+    expect(updateUserSettings).not.toHaveBeenCalled();
+    expect(trigger.getAttribute("data-settings-dirty")).toBe("true");
+
+    fireEvent.click(await screen.findByRole("button", { name: "Save changes" }));
+
+    await waitFor(() =>
+      expect(updateUserSettings).toHaveBeenCalledWith({
+        utility_agent_profile_id: "profile-1",
+      }),
+    );
+    await waitFor(() => expect(trigger.getAttribute("data-settings-dirty")).toBe("false"));
+  });
+
+  it("clears the setting when None is chosen after a profile was configured", async () => {
+    renderSettings("profile-1");
+    const trigger = screen.getByTestId(SELECT_TESTID);
+
+    fireEvent.click(trigger);
+    fireEvent.click(await screen.findByText("None"));
+    fireEvent.click(await screen.findByRole("button", { name: "Save changes" }));
+
+    await waitFor(() =>
+      expect(updateUserSettings).toHaveBeenCalledWith({ utility_agent_profile_id: "" }),
+    );
+  });
+
+  it("keeps the draft selected when saving fails", async () => {
+    updateUserSettings.mockRejectedValueOnce(new Error("save failed"));
+    renderSettings();
+    const trigger = screen.getByTestId(SELECT_TESTID);
+
+    fireEvent.click(trigger);
+    fireEvent.click(await screen.findByText(CLAUDE_FAST_LABEL));
+    fireEvent.click(await screen.findByRole("button", { name: "Save changes" }));
+
+    await waitFor(() => expect(trigger.textContent).toContain(CLAUDE_FAST_LABEL));
+    await waitFor(() => expect(screen.getByText("Couldn't save")).toBeTruthy());
+  });
+});

--- a/apps/web/components/settings/utility-agent-profile-settings.tsx
+++ b/apps/web/components/settings/utility-agent-profile-settings.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { CardContent, CardDescription, CardHeader, CardTitle } from "@kandev/ui/card";
+import { Label } from "@kandev/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@kandev/ui/select";
+import { useAppStore, useAppStoreApi } from "@/components/state-provider";
+import { updateUserSettings } from "@/lib/api";
+import { useHealthyAgentProfiles } from "@/hooks/domains/settings/use-healthy-agent-profiles";
+import { SettingsCard } from "./settings-card";
+import { useSettingsSaveContributor } from "./settings-save-provider";
+
+const NONE_VALUE = "none";
+
+export function UtilityAgentProfileSettings() {
+  const preference = useAppStore((state) => state.userSettings.utilityAgentProfileId) ?? "";
+  const setUserSettings = useAppStore((state) => state.setUserSettings);
+  const storeApi = useAppStoreApi();
+  const healthyProfiles = useHealthyAgentProfiles(preference || undefined);
+  const [saved, setSaved] = useState(preference);
+  const [draft, setDraft] = useState(preference);
+  const draftRef = useRef(draft);
+  draftRef.current = draft;
+  const isDirty = draft !== saved;
+
+  useEffect(() => {
+    setSaved((previous) => {
+      if (draftRef.current === previous) setDraft(preference);
+      return preference;
+    });
+  }, [preference]);
+
+  useSettingsSaveContributor({
+    id: "general-utility-agent-profile",
+    order: 20,
+    revision: draft,
+    isDirty,
+    save: async (revision) => {
+      const submitted = revision as string;
+      await updateUserSettings({ utility_agent_profile_id: submitted });
+      setSaved(submitted);
+      setUserSettings({
+        ...storeApi.getState().userSettings,
+        utilityAgentProfileId: submitted || null,
+      });
+    },
+    discard: () => setDraft(saved),
+  });
+
+  return (
+    <SettingsCard isDirty={isDirty} data-testid="utility-agent-profile-card">
+      <CardHeader>
+        <CardTitle className="text-base">
+          <h3>Utility agent</h3>
+        </CardTitle>
+        <CardDescription>
+          Agent profile used for lightweight one-shot LLM calls that plugins delegate to (e.g.
+          summaries). Plugins with the <code>agent_invoke</code> capability call this agent so they
+          need no API key of their own. Choose &quot;None&quot; to leave delegated calls unavailable
+          until an agent profile is selected.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="w-full max-w-sm space-y-1.5">
+          <Label htmlFor="utility-agent-profile-select">Agent profile</Label>
+          <Select
+            value={draft || NONE_VALUE}
+            onValueChange={(value) => setDraft(value === NONE_VALUE ? "" : value)}
+          >
+            <SelectTrigger
+              id="utility-agent-profile-select"
+              className="w-full cursor-pointer"
+              data-testid="utility-agent-profile-select"
+              data-settings-dirty={isDirty}
+            >
+              <SelectValue placeholder="None" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={NONE_VALUE} className="cursor-pointer">
+                None
+              </SelectItem>
+              {healthyProfiles.map((profile) => (
+                <SelectItem key={profile.id} value={profile.id} className="cursor-pointer">
+                  {profile.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </CardContent>
+    </SettingsCard>
+  );
+}

--- a/apps/web/hooks/use-ensure-user-settings.test.ts
+++ b/apps/web/hooks/use-ensure-user-settings.test.ts
@@ -79,6 +79,7 @@ function makeUnloadedSettings(): UserSettingsState {
     githubDefaultQueryPresets: undefined,
     gitlabSavedPresets: undefined,
     defaultUtilityAgentId: null,
+    utilityAgentProfileId: null,
     keyboardShortcuts: {},
     terminalLinkBehavior: "new_tab",
     terminalFontFamily: null,

--- a/apps/web/hooks/use-user-display-settings.ts
+++ b/apps/web/hooks/use-user-display-settings.ts
@@ -49,6 +49,14 @@ function carryForwardLspSettings(current: DisplaySettings) {
   };
 }
 
+function carryForwardUtilitySettings(current: DisplaySettings) {
+  return {
+    defaultUtilityAgentId: current.defaultUtilityAgentId ?? null,
+    utilityAgentProfileId: current.utilityAgentProfileId ?? null,
+    keyboardShortcuts: current.keyboardShortcuts ?? {},
+  };
+}
+
 function carryForwardCoreSettings(current: DisplaySettings) {
   return {
     shellOptions: current.shellOptions ?? [],
@@ -58,8 +66,7 @@ function carryForwardCoreSettings(current: DisplaySettings) {
     showReleaseNotification: current.showReleaseNotification ?? true,
     releaseNotesLastSeenVersion: current.releaseNotesLastSeenVersion ?? null,
     savedLayouts: current.savedLayouts ?? [],
-    defaultUtilityAgentId: current.defaultUtilityAgentId ?? null,
-    keyboardShortcuts: current.keyboardShortcuts ?? {},
+    ...carryForwardUtilitySettings(current),
     tasksListSort: current.tasksListSort ?? DEFAULT_TASKS_LIST_SORT,
     tasksListGroup: current.tasksListGroup ?? DEFAULT_TASKS_LIST_GROUP,
     changesPanelLayout: current.changesPanelLayout ?? "tree",

--- a/apps/web/lib/ssr/user-settings.ts
+++ b/apps/web/lib/ssr/user-settings.ts
@@ -106,6 +106,7 @@ function buildIdentityFields(s: UserSettingsData) {
     preferredShell: s.preferred_shell || null,
     defaultEditorId: s.default_editor_id || null,
     defaultUtilityAgentId: s.default_utility_agent_id || null,
+    utilityAgentProfileId: s.utility_agent_profile_id || null,
   };
 }
 
@@ -190,6 +191,7 @@ export function mapUserSettingsResponse(response: UserSettingsResponse | null) {
       githubDefaultQueryPresets: undefined,
       gitlabSavedPresets: undefined,
       defaultUtilityAgentId: null,
+      utilityAgentProfileId: null,
       keyboardShortcuts: {} as Record<string, { key: string; modifiers?: Record<string, boolean> }>,
       terminalLinkBehavior: "new_tab" as const,
       terminalFontFamily: null,

--- a/apps/web/lib/state/slices/settings/settings-slice.ts
+++ b/apps/web/lib/state/slices/settings/settings-slice.ts
@@ -60,6 +60,7 @@ export const defaultSettingsState: SettingsSliceState = {
     githubDefaultQueryPresets: undefined,
     gitlabSavedPresets: undefined,
     defaultUtilityAgentId: null,
+    utilityAgentProfileId: null,
     keyboardShortcuts: {},
     terminalFontFamily: null,
     terminalFontSize: null,

--- a/apps/web/lib/state/slices/settings/types.ts
+++ b/apps/web/lib/state/slices/settings/types.ts
@@ -172,6 +172,7 @@ export type UserSettingsState = {
   githubDefaultQueryPresets: unknown;
   gitlabSavedPresets: unknown;
   defaultUtilityAgentId: string | null;
+  utilityAgentProfileId: string | null;
   keyboardShortcuts: Record<string, { key: string; modifiers?: Record<string, boolean> }>;
   terminalLinkBehavior: "new_tab" | "browser_panel";
   terminalFontFamily: string | null;

--- a/apps/web/lib/types/backend.ts
+++ b/apps/web/lib/types/backend.ts
@@ -359,6 +359,7 @@ export type UserSettingsUpdatedPayload = {
   github_default_query_presets?: object | null;
   gitlab_saved_presets?: unknown[] | null;
   default_utility_agent_id?: string;
+  utility_agent_profile_id?: string;
   keyboard_shortcuts?: Record<string, { key: string; modifiers?: Record<string, boolean> }>;
   terminal_link_behavior?: string;
   changes_panel_layout?: "flat" | "tree";

--- a/apps/web/lib/types/http-user-settings.ts
+++ b/apps/web/lib/types/http-user-settings.ts
@@ -74,6 +74,7 @@ export type UserSettings = {
   gitlab_saved_presets?: unknown;
   default_utility_agent_id?: string;
   default_utility_model?: string;
+  utility_agent_profile_id?: string;
   keyboard_shortcuts?: Record<string, { key: string; modifiers?: Record<string, boolean> }>;
   terminal_link_behavior?: string;
   terminal_font_family?: string;
@@ -121,6 +122,7 @@ export type UserSettingsUpdatePayload = {
   gitlab_saved_presets?: unknown[] | null;
   default_utility_agent_id?: string;
   default_utility_model?: string;
+  utility_agent_profile_id?: string;
   keyboard_shortcuts?: Record<string, { key: string; modifiers?: Record<string, boolean> }>;
   terminal_link_behavior?: "new_tab" | "browser_panel";
   terminal_font_family?: string;

--- a/apps/web/lib/ws/handlers/users.ts
+++ b/apps/web/lib/ws/handlers/users.ts
@@ -33,6 +33,7 @@ function buildUserSettingsState(state: AppState, payload: UserSettingsUpdatedPay
     ...buildLspSettings(payload),
     ...buildSyncedLocalSettings(state, payload),
     defaultUtilityAgentId: payload.default_utility_agent_id || null,
+    utilityAgentProfileId: payload.utility_agent_profile_id || null,
     keyboardShortcuts: payload.keyboard_shortcuts ?? {},
     changesPanelLayout: parseChangesPanelLayout(payload.changes_panel_layout),
     systemMetricsDisplay: parseSystemMetricsDisplay(payload.system_metrics_display),

--- a/apps/web/src/settings-routes.tsx
+++ b/apps/web/src/settings-routes.tsx
@@ -22,6 +22,7 @@ import IntegrationsSlackPage from "@/app/settings/integrations/slack/page";
 import PluginsSettingsPage from "@/app/settings/plugins/page";
 import PluginDetailPage from "@/app/settings/plugins/[pluginId]/page";
 import StoragePage from "@/app/settings/system/storage/page";
+import UtilityAgentPage from "@/app/settings/system/utility-agent/page";
 import UtilityAgentsSettingsPage from "@/app/settings/utility-agents/page";
 import AutomationsPage from "@/app/settings/workspace/[id]/automations/page";
 import AutomationEditorPage from "@/app/settings/workspace/[id]/automations/[automationId]/page";
@@ -216,6 +217,7 @@ const SETTINGS_ROUTES: Record<string, RouteRenderer> = {
   ),
   "/settings/system/storage": () => <StoragePage />,
   "/settings/system/updates": renderUpdatesRoute,
+  "/settings/system/utility-agent": () => <UtilityAgentPage />,
   "/settings/changelog": () => <SettingsRedirect to="/settings/system/updates" />,
 };
 

--- a/docs/decisions/0047-plugin-host-conversation-reads.md
+++ b/docs/decisions/0047-plugin-host-conversation-reads.md
@@ -1,0 +1,104 @@
+# 0047 — Plugins read conversation content via a capability-gated Host RPC
+
+- Status: accepted
+- Date: 2026-07-21
+- Area: backend, protocol
+- Related: [0043 — Plugin host data API](0043-plugin-host-data-api.md) (the pattern
+  this extends), [docs/specs/plugins/spec.md](../specs/plugins/spec.md) ("Host data API")
+
+## Context
+
+The Host data API (ADR 0043) lets a plugin read kandev's domain data — tasks,
+sessions, workspaces, workflows, agent profiles, repositories — over a
+capability-gated `Host` gRPC channel. It deliberately stopped short of message
+content: `Sessions()` exposes session *metadata* (identity, agent, timestamps,
+`acp_session_id`, code stats) but no transcript.
+
+A downstream "My Daily Standup" plugin needs to summarize yesterday's
+user/agent conversations and surface issues worth mentioning. Today a plugin
+**cannot** read historical message content at all:
+
+- The only place message content is exposed is the `message.added` bus event
+  (`internal/task/service/service_events.go` `publishMessageEvent`). Live event
+  capture is a poor fit for "summarize yesterday" — a plugin would have to be
+  running and recording continuously, and gets nothing for the window before it
+  was installed.
+- The message repository has no task-scoped or time-range query. `ListMessages`
+  is session-scoped only; nothing filters by task id or a `created_at` window.
+
+Reusing the ADR 0043 escape hatch (open the SQLite file directly) is the exact
+failure ADR 0043 exists to close: schema coupling, breaks on Postgres, no
+scoping, only possible because the subprocess is unsandboxed.
+
+## Decision
+
+Add one read RPC to the existing `service Host`, following ADR 0043 exactly.
+
+1. **New RPC + DTO.** `ListMessages(ListMessagesRequest) returns
+   (ListMessagesResponse)` on `service Host` in
+   `apps/backend/proto/kandev/plugin/v1/plugin.proto`. `Message` DTO fields:
+   `id`, `session_id`, `task_id`, `turn_id`, `author_type`, `content`, `type`,
+   `created_at` (RFC3339). `MessageFilter`: `session_ids`, `task_ids`, `since`,
+   `until` (RFC3339, `since` inclusive / `until` exclusive), `types`. Opaque
+   cursor pagination (`Page`/`PageInfo`) like every other reader.
+
+2. **SDK accessor.** `Host.Messages() MessageReader` with
+   `List(ctx, MessageFilter, Page) ([]Message, *PageInfo, error)`, plus
+   Go-native `Message`/`MessageFilter` mirrors in `pkg/pluginsdk/data_types.go`
+   and an `UnimplementedHostData.Messages()` default. No proto types leak past
+   the package boundary.
+
+3. **Capability gate `api_read:messages`.** A new `resourceMessages` const and a
+   `Messages()` accessor in `internal/plugins/host_data.go` that returns a real,
+   service-backed reader when the manifest declares `api_read:messages`, else a
+   denied reader whose `List` returns gRPC `PermissionDenied` with
+   `capability 'api_read:messages' not declared` — identical to the other
+   resources. A non-RFC3339 `since`/`until` returns gRPC `InvalidArgument`.
+
+4. **Content is sanitized; system prompts never leave kandev.** The reader maps
+   `models.Message` → DTO through `messageModelToDTO`, which runs
+   `sysprompt.StripSystemContent` on `content` — the same `<kandev-system>`
+   stripping the `message.added` event applies. Raw system content and the
+   event path's `raw_content`/`has_hidden_prompts` are **not** exposed.
+   `author_type` is only ever `user` or `agent`: there is no `system` author in
+   kandev's model — system context is inline markup inside an otherwise
+   user/agent message, and it is stripped at read time.
+
+5. **Reads go through the service layer.** A new
+   `Service.ListMessagesForPlugin(ctx, models.PluginMessageFilter)` on the task
+   service delegates to a new `MessageRepository.ListMessagesForPlugin` /
+   SQLite `ListMessagesForPlugin` — a single filtered query
+   (`task_session_id IN`, `task_id IN`, `type IN`, `created_at >= since`,
+   `created_at < until`), ordered `created_at ASC, id ASC`, with SQL
+   `LIMIT`/`OFFSET`. The reader requests `page-limit+1` rows to derive
+   `HasMore` without a second count query; `NextCursor` is `offset+limit`,
+   matching the other readers' opaque-offset cursor. The `internal/plugins`
+   package reaches this via a narrow `messageDataSource` interface wired by
+   `Service.SetDataSources`, never importing the task service directly (the same
+   import-cycle avoidance the existing readers use).
+
+## Consequences
+
+- A plugin can read a window of conversation content (e.g. "everything on this
+  workspace's tasks since yesterday 00:00") without touching the DB file, and
+  without the plugin having to be running when the messages were created.
+- The `Message` proto is a public contract: fields are additive-only thereafter.
+- The new query is the one net-new piece of data access; every other layer is
+  the established ADR 0043 pattern (accessor + denied reader + narrow data
+  source + DTO mapper + in-process/wire capability tests).
+- Scoping stays ADR 0043 v1: reads are global to the instance, filters narrow
+  results, and the single server-side data-source hook remains the place a
+  future per-plugin/per-user restriction would attach.
+
+## Alternatives considered
+
+- **Subscribe to `message.added` and accumulate.** Rejected: only captures
+  messages created while the plugin runs, needs durable plugin-side storage, and
+  gives nothing for the pre-install / "yesterday" window the feature is about.
+- **Expose the raw message row (including `raw_content`).** Rejected: leaks
+  kandev's injected system prompts to plugins. The event path already strips
+  them; the read path must match.
+- **A session-only reader (reuse `ListMessages`).** Rejected: the standup use
+  case is task/time scoped ("yesterday, across these tasks"), which the
+  session-only query cannot express without an N+1 fan-out and client-side time
+  filtering. One filtered query is simpler and cheaper.

--- a/docs/decisions/0048-plugin-host-utility-agent-invoke.md
+++ b/docs/decisions/0048-plugin-host-utility-agent-invoke.md
@@ -1,0 +1,98 @@
+# 0048 — Plugins invoke a settings-selectable utility agent
+
+- Status: accepted
+- Date: 2026-07-21
+- Area: backend, frontend, protocol
+- Related: [0043 — Plugin host data API](0043-plugin-host-data-api.md),
+  [0002 — Host utility agentctl for sessionless ACP flows](0002-host-utility-agentctl-for-sessionless-flows.md)
+  (the inference tier this reuses),
+  [0018 — Runtime settings overrides](0018-runtime-settings-overrides.md)
+
+## Context
+
+A plugin that wants to do an LLM step (summarize a conversation, classify an
+issue) has no sanctioned way to run a completion: it would need to ship and
+manage its own provider API key. Kandev already runs LLM completions on the
+operator's configured agents; a plugin should be able to borrow one.
+
+Kandev also already has the right primitive. ADR 0002's **host-utility tier**
+(`internal/agent/hostutility.Manager.ExecutePrompt`) runs a one-shot,
+non-interactive, sessionless completion against a warm agentctl instance —
+exactly what title generation, commit messages, and the Slack assistant use.
+There is no need for a new agent loop, and the interactive agent runtime
+(`internal/agent/runtime`, `internal/office`) is the wrong tool: it is
+streaming, stateful, and requires an executor + workspace + worktree.
+
+## Decision
+
+Add a capability-gated `Host.InvokeUtilityAgent`, backed by a new operator
+setting and the existing host-utility tier.
+
+1. **New setting: `utility_agent_profile_id`.** A string user setting (kandev is
+   single-user, so per-user *is* system-wide) selecting one of the existing
+   agent profiles, cloned end-to-end from the existing `default_utility_agent_id`
+   path (`internal/user` model → store → service → dto → controller → boot
+   state). It is chosen in **Settings > System > Utility Agent**, a profile
+   dropdown mirroring the `mcp_task_agent_profile_default` selector (populated
+   from healthy agent profiles, persisted through the shared settings save
+   coordinator). It is deliberately **separate** from `default_utility_agent_id`
+   (an internal agent-*type*+model default for kandev's own utility features):
+   the plugin-facing selection is an explicit, operator-visible agent *profile*,
+   so an operator can grant plugins a specific (and cheap) model without
+   changing kandev's internal utility defaults.
+
+2. **New capability `agent_invoke`.** A boolean `Capabilities.AgentInvoke`,
+   enforced exactly like `state`/`secrets`: `Host.InvokeUtilityAgent` returns
+   gRPC `PermissionDenied` (`capability 'agent_invoke' not declared`) when the
+   manifest doesn't declare it.
+
+3. **New RPC + SDK method.**
+   `InvokeUtilityAgent(InvokeUtilityAgentRequest{prompt}) returns
+   (InvokeUtilityAgentResponse{text})` on `service Host`; SDK
+   `Host.InvokeUtilityAgent(ctx, prompt string) (string, error)`. The request
+   message is the forward-compatible extension point (a future `system_prompt`
+   or `max_tokens` is an added proto field, no SDK signature change).
+
+4. **Reuse the host-utility tier (ADR 0002).** The kandev-side handler:
+   gate `agent_invoke` → read `utility_agent_profile_id` → resolve the profile
+   to its agent type + model (scanning the already-wired agent-profiles data
+   source) → call a narrow `utilityRunner.ExecutePrompt(ctx, agentType, model,
+   "", prompt)` and return the text. `utilityRunner` is a thin
+   `pluginsHostUtilityAdapter` over `hostutility.Manager` wired in `backendapp`,
+   so `internal/plugins` never imports the agent runtime (the same
+   cycle-avoidance as the Slack assistant's adapter and ADR 0043's data
+   sources). No task, session, workspace, or worktree is involved.
+
+5. **Typed "not configured" failure.** If no utility agent is selected — or the
+   selected profile has since been deleted — the handler returns gRPC
+   `FailedPrecondition` (`no utility agent configured` /
+   `configured utility agent profile "<id>" not found`), never a silent empty
+   completion. A stale profile id is treated as "unconfigured", not an internal
+   error.
+
+## Consequences
+
+- A plugin declares `capabilities.agent_invoke: true` and calls
+  `host.InvokeUtilityAgent(ctx, prompt)` — no API key, no provider wiring. This
+  is what unblocks the "My Daily Standup" plugin's summarization step.
+- The operator stays in control: nothing runs until they pick a utility agent,
+  and they pick which (cheap) profile plugins may spend on.
+- We reused the sessionless inference path instead of building an agent loop;
+  the only net-new machinery is one setting and one gated RPC handler.
+- The `InvokeUtilityAgentRequest`/`Response` proto is a public contract, extended
+  additively.
+
+## Alternatives considered
+
+- **Let plugins bring their own API key.** Rejected: every plugin re-implements
+  key management and secret storage, and the operator loses cost control. The
+  whole point is to delegate to kandev's already-configured agent.
+- **Run the completion through `internal/agent/runtime` / `office`.** Rejected:
+  both are streaming, stateful, and require an executor + workspace; neither
+  offers a synchronous prompt→text call. ADR 0002's host-utility tier already
+  does exactly this, sessionlessly.
+- **Reuse `default_utility_agent_id` instead of a new setting.** Rejected: that
+  is an agent-*type*+model default for kandev's internal utility calls, not an
+  operator-visible agent-*profile* selection scoped to "what plugins may
+  invoke". Keeping them separate lets an operator expose a specific cheap
+  profile to plugins without disturbing internal defaults.

--- a/docs/decisions/INDEX.md
+++ b/docs/decisions/INDEX.md
@@ -55,6 +55,7 @@ Read individual ADRs for full context. Create new ones via `/record decision` or
 | 0045 | [Install-wide storage maintenance uses typed ownership providers and quarantine](0045-install-wide-storage-maintenance.md)          | accepted (amended 2026-07-19) | backend, frontend, infra | 2026-07-14 |
 | 0046 | [Settings route save coordinator](0046-settings-route-save-coordinator.md)                                                          | accepted   | frontend                    | 2026-07-14 |
 | 0047 | [Plugins read conversation content via a capability-gated Host RPC](0047-plugin-host-conversation-reads.md)                          | accepted   | backend, protocol           | 2026-07-21 |
+| 0048 | [Plugins invoke a settings-selectable utility agent](0048-plugin-host-utility-agent-invoke.md)                                       | accepted   | backend, frontend, protocol | 2026-07-21 |
 | 2026-07-18-turn-configuration-snapshots | [Attribute runtime configuration to turns](2026-07-18-turn-configuration-snapshots.md) | accepted | backend, frontend | 2026-07-18 |
 | 2026-07-19-reject-mcp-actions-on-raw-websocket | [Reject MCP Actions on the Raw WebSocket](2026-07-19-reject-mcp-actions-on-raw-websocket.md) | accepted | backend, protocol | 2026-07-19 |
 | 2026-07-19-workspace-symlink-entries | [Treat Nested Workspace Symlinks as Entries](2026-07-19-workspace-symlink-entries.md) | accepted | backend, infra | 2026-07-19 |

--- a/docs/decisions/INDEX.md
+++ b/docs/decisions/INDEX.md
@@ -54,6 +54,7 @@ Read individual ADRs for full context. Create new ones via `/record decision` or
 | 0044 | [ACP agent compatibility dialects](0044-acp-agent-compatibility-dialects.md)                                                        | accepted   | backend, protocol           | 2026-07-16 |
 | 0045 | [Install-wide storage maintenance uses typed ownership providers and quarantine](0045-install-wide-storage-maintenance.md)          | accepted (amended 2026-07-19) | backend, frontend, infra | 2026-07-14 |
 | 0046 | [Settings route save coordinator](0046-settings-route-save-coordinator.md)                                                          | accepted   | frontend                    | 2026-07-14 |
+| 0047 | [Plugins read conversation content via a capability-gated Host RPC](0047-plugin-host-conversation-reads.md)                          | accepted   | backend, protocol           | 2026-07-21 |
 | 2026-07-18-turn-configuration-snapshots | [Attribute runtime configuration to turns](2026-07-18-turn-configuration-snapshots.md) | accepted | backend, frontend | 2026-07-18 |
 | 2026-07-19-reject-mcp-actions-on-raw-websocket | [Reject MCP Actions on the Raw WebSocket](2026-07-19-reject-mcp-actions-on-raw-websocket.md) | accepted | backend, protocol | 2026-07-19 |
 | 2026-07-19-workspace-symlink-entries | [Treat Nested Workspace Symlinks as Entries](2026-07-19-workspace-symlink-entries.md) | accepted | backend, infra | 2026-07-19 |

--- a/docs/public/coverage.json
+++ b/docs/public/coverage.json
@@ -267,7 +267,8 @@
         "/settings/system/logs",
         "/settings/system/status",
         "/settings/system/storage",
-        "/settings/system/updates"
+        "/settings/system/updates",
+        "/settings/system/utility-agent"
       ]
     },
     {

--- a/docs/public/plugins-authoring.md
+++ b/docs/public/plugins-authoring.md
@@ -161,6 +161,11 @@ type Host interface {
 	Workflows() WorkflowReader
 	AgentProfiles() AgentProfileReader
 	Repositories() RepositoryReader
+
+	// Messages reads historical user/agent conversation content
+	// (capability api_read:messages). kandev-injected system blocks are
+	// stripped; raw system prompts are never returned.
+	Messages() MessageReader
 }
 ```
 
@@ -191,7 +196,16 @@ The data-reader accessors return typed, paginated readers — e.g.
 `([]Task, *PageInfo, error)` with an opaque `PageInfo.NextCursor` for the
 next page. See `pkg/pluginsdk/data_types.go` for the full `Task`,
 `Workspace`, `Workflow`, `WorkflowStep`, `AgentProfile`, `Repository`,
-`Session`, and filter/page types.
+`Session`, `Message`, and filter/page types.
+
+`host.Messages().List(ctx, MessageFilter{...}, Page{...})` reads historical
+conversation content (capability `api_read:messages`). Filter by `SessionIDs`,
+`TaskIDs`, a `Since`/`Until` `created_at` window (RFC3339; `Since` inclusive,
+`Until` exclusive — the natural way to fetch "yesterday"), and message
+`Types`. Each `Message` carries `id`, `session_id`, `task_id`, `turn_id`,
+`author_type` (`user` or `agent`), `content`, `type`, and `created_at`.
+`content` has kandev's injected `<kandev-system>` blocks stripped — a plugin
+never sees raw system prompts.
 
 **Capability gating.** Every Host RPC except `GetConfig` and `EmitEvent` is
 checked against your manifest's `capabilities` before the handler runs:
@@ -199,7 +213,8 @@ checked against your manifest's `capabilities` before the handler runs:
 `capabilities.state: true`; `GetSecret`/`SetSecret`/`DeleteSecret`/
 `RevealSecret` require `capabilities.secrets: true`; each data-reader
 accessor requires its resource in `capabilities.api_read` (e.g. `tasks`,
-`sessions`, `workspaces`, `workflows`, `agent_profiles`, `repositories`).
+`sessions`, `messages`, `workspaces`, `workflows`, `agent_profiles`,
+`repositories`).
 Calling one without the declared capability returns gRPC `PermissionDenied`
 with a message naming the missing capability — declare what you use.
 

--- a/docs/public/plugins-authoring.md
+++ b/docs/public/plugins-authoring.md
@@ -166,6 +166,11 @@ type Host interface {
 	// (capability api_read:messages). kandev-injected system blocks are
 	// stripped; raw system prompts are never returned.
 	Messages() MessageReader
+
+	// InvokeUtilityAgent runs a one-shot completion using the
+	// operator-configured utility agent (capability agent_invoke). No API
+	// key of your own; FailedPrecondition when no utility agent is set.
+	InvokeUtilityAgent(ctx context.Context, prompt string) (string, error)
 }
 ```
 
@@ -207,14 +212,24 @@ conversation content (capability `api_read:messages`). Filter by `SessionIDs`,
 `content` has kandev's injected `<kandev-system>` blocks stripped — a plugin
 never sees raw system prompts.
 
+`host.InvokeUtilityAgent(ctx, prompt)` runs a one-shot, non-interactive LLM
+completion using the **utility agent** the operator selects in **Settings >
+System > Utility Agent** (capability `agent_invoke`), and returns its text. Your
+plugin needs no provider API key — it delegates to a kandev-configured agent.
+If the operator has not selected a utility agent (or the selected profile was
+deleted), the call returns a gRPC `FailedPrecondition` error, so handle that as
+"ask the operator to configure one" rather than a transient failure. This is the
+LLM step behind, e.g., a "summarize yesterday" plugin: read the conversation
+with `host.Messages()`, then summarize it with `host.InvokeUtilityAgent(...)`.
+
 **Capability gating.** Every Host RPC except `GetConfig` and `EmitEvent` is
 checked against your manifest's `capabilities` before the handler runs:
 `GetState`/`SetState`/`DeleteState`/`ListState` require
 `capabilities.state: true`; `GetSecret`/`SetSecret`/`DeleteSecret`/
-`RevealSecret` require `capabilities.secrets: true`; each data-reader
-accessor requires its resource in `capabilities.api_read` (e.g. `tasks`,
-`sessions`, `messages`, `workspaces`, `workflows`, `agent_profiles`,
-`repositories`).
+`RevealSecret` require `capabilities.secrets: true`; `InvokeUtilityAgent`
+requires `capabilities.agent_invoke: true`; each data-reader accessor requires
+its resource in `capabilities.api_read` (e.g. `tasks`, `sessions`, `messages`,
+`workspaces`, `workflows`, `agent_profiles`, `repositories`).
 Calling one without the declared capability returns gRPC `PermissionDenied`
 with a message naming the missing capability — declare what you use.
 

--- a/docs/public/plugins-manifest.md
+++ b/docs/public/plugins-manifest.md
@@ -78,7 +78,7 @@ ui:                                           # optional native frontend plugin
 | `runtime.executables` | required when `runtime.type: binary` | map\<string,string\> | Key is `<goos>-<goarch>` (e.g. `linux-amd64`, `darwin-arm64`, `windows-amd64`); value is a clean, package-relative path under `server/` (no leading `/`, no `..` segments). At least one entry required; the running host's key must be present at install time. Windows values end in `.exe`. |
 | `min_kandev_version` | no | string | Optional advisory; not currently enforced by the installer. |
 | `capabilities.events` | no | string[] | Bus subjects (or wildcard patterns) this plugin subscribes to. See "Event subscription vocabulary" below. |
-| `capabilities.api_read` | no | string[] | Gates the Host data API's read-only accessors. Each entry is a resource name: `tasks`, `sessions`, `workspaces`, `workflows`, `agent_profiles`, `repositories`. Calling the matching `Host` accessor (e.g. `Tasks()`) without its resource declared returns gRPC `PermissionDenied`. See "Host data API resource vocabulary" below. |
+| `capabilities.api_read` | no | string[] | Gates the Host data API's read-only accessors. Each entry is a resource name: `tasks`, `sessions`, `messages`, `workspaces`, `workflows`, `agent_profiles`, `repositories`. Calling the matching `Host` accessor (e.g. `Tasks()`) without its resource declared returns gRPC `PermissionDenied`. See "Host data API resource vocabulary" below. |
 | `capabilities.api_write` | no | string[] | **Reserved for future Host RPCs.** Declared but not enforced by anything today — no Host RPC currently writes kandev's own data. |
 | `capabilities.state` | no | bool | Gates `Host.GetState`/`SetState`/`DeleteState`/`ListState`. Calling any of them without this set to `true` returns gRPC `PermissionDenied`. |
 | `capabilities.secrets` | no | bool | Gates `Host.RevealSecret`/`GetSecret`/`SetSecret`/`DeleteSecret`. Calling any of them without this set to `true` returns gRPC `PermissionDenied`. |
@@ -119,15 +119,24 @@ recognizes its shape.
 
 ## Host data API resource vocabulary
 
-`capabilities.api_read` gates the read-only Host data accessors (ADR 0043):
-each entry must be one of `tasks`, `sessions`, `workspaces`, `workflows`,
-`agent_profiles`, `repositories`. Declaring a resource grants the matching
-`Host` accessor (`Tasks()`, `Sessions()`, `Workspaces()`, `Workflows()`,
-`AgentProfiles()`, `Repositories()` — see [Authoring a
-plugin](plugins-authoring.md)); calling an accessor for an undeclared
-resource returns gRPC `PermissionDenied`. `capabilities.api_write` reserves
-the same resource names for a future write path — no write RPC exists yet,
-so declaring it currently has no effect.
+`capabilities.api_read` gates the read-only Host data accessors (ADR 0043,
+ADR 0047): each entry must be one of `tasks`, `sessions`, `messages`,
+`workspaces`, `workflows`, `agent_profiles`, `repositories`. Declaring a
+resource grants the matching `Host` accessor (`Tasks()`, `Sessions()`,
+`Messages()`, `Workspaces()`, `Workflows()`, `AgentProfiles()`,
+`Repositories()` — see [Authoring a plugin](plugins-authoring.md)); calling an
+accessor for an undeclared resource returns gRPC `PermissionDenied`.
+`capabilities.api_write` reserves the same resource names for a future write
+path — no write RPC exists yet, so declaring it currently has no effect.
+
+`messages` reads historical **conversation content** (`Messages().List`):
+one user/agent message per row (`id`, `session_id`, `task_id`, `turn_id`,
+`author_type`, `content`, `type`, `created_at`), filterable by session ids,
+task ids, a `created_at` time range (`since` inclusive / `until` exclusive,
+RFC3339), and message `types`. Content is sanitized — kandev-injected
+`<kandev-system>` blocks are stripped, exactly like the `message.added` bus
+event, so raw system prompts are never exposed. `author_type` is `user` or
+`agent` (there is no `system` author).
 
 ## Config schema validation and secret fields
 

--- a/docs/public/plugins-manifest.md
+++ b/docs/public/plugins-manifest.md
@@ -42,6 +42,7 @@ capabilities:
   api_write: ["tasks"]                       # reserved, no Host RPC enforces this yet
   state: true
   secrets: true
+  agent_invoke: true                         # gates Host.InvokeUtilityAgent
 
 webhooks:
   - key: "slack-events"
@@ -82,6 +83,7 @@ ui:                                           # optional native frontend plugin
 | `capabilities.api_write` | no | string[] | **Reserved for future Host RPCs.** Declared but not enforced by anything today — no Host RPC currently writes kandev's own data. |
 | `capabilities.state` | no | bool | Gates `Host.GetState`/`SetState`/`DeleteState`/`ListState`. Calling any of them without this set to `true` returns gRPC `PermissionDenied`. |
 | `capabilities.secrets` | no | bool | Gates `Host.RevealSecret`/`GetSecret`/`SetSecret`/`DeleteSecret`. Calling any of them without this set to `true` returns gRPC `PermissionDenied`. |
+| `capabilities.agent_invoke` | no | bool | Gates `Host.InvokeUtilityAgent` — a one-shot completion run by the operator-configured utility agent (Settings > System). Calling it without this set to `true` returns gRPC `PermissionDenied`; calling it when no utility agent is configured returns gRPC `FailedPrecondition`. See ADR 0048. |
 | `webhooks[].key` | yes | string | Must be unique within the manifest. Used in the relay path `POST /api/plugins/{id}/webhooks/{key}`. |
 | `webhooks[].description` | no | string | Free-form. |
 | `webhooks[].method` | no | string | **Informational only** — kandev does not validate or enforce the inbound HTTP method against this value. |

--- a/docs/specs/plugins/spec.md
+++ b/docs/specs/plugins/spec.md
@@ -306,6 +306,7 @@ service Host {
   rpc ListState(ListStateRequest) returns (ListStateResponse);
   rpc RevealSecret(RevealSecretRequest) returns (RevealSecretResponse);
   rpc EmitEvent(EmitEventRequest) returns (EmitEventResponse);
+  rpc InvokeUtilityAgent(InvokeUtilityAgentRequest) returns (InvokeUtilityAgentResponse);
 }
 ```
 
@@ -319,13 +320,23 @@ service Host {
 - `EmitEvent(event_name, payload)` publishes `plugin.<plugin_id>.<event_name>` on the
   internal event bus for delivery to subscribers (replaces the old
   `POST /api/plugins/{plugin_id}/events/emit` HTTP endpoint).
+- `InvokeUtilityAgent(prompt)` runs a one-shot, non-interactive completion using
+  the operator-configured **utility agent** (an agent profile chosen in Settings
+  > System, stored as the `utility_agent_profile_id` user setting) and returns
+  its text. Requires `capabilities.agent_invoke: true`. It reuses kandev's
+  sessionless host-utility inference tier (ADR 0002) — no task, session, or
+  workspace — so a plugin can delegate a lightweight LLM step without holding a
+  provider API key. Returns gRPC `FailedPrecondition` when no utility agent is
+  configured (or the selected profile was deleted). See
+  [ADR 0048](../../decisions/0048-plugin-host-utility-agent-invoke.md).
 
 Every Host RPC is capability-gated: `GetState`/`SetState`/`DeleteState`/`ListState`
-check `capabilities.state`, `RevealSecret` checks `capabilities.secrets`, and each
-Host data API read RPC checks `capabilities.api_read` for its resource (see "Host
-data API" below) — all before the handler runs, returning gRPC status
-`PermissionDenied` with message `capability '<name>' not declared` on a miss.
-`EmitEvent` is ungated (no boolean capability applies). The Host data API write
+check `capabilities.state`, `RevealSecret` checks `capabilities.secrets`,
+`InvokeUtilityAgent` checks `capabilities.agent_invoke`, and each Host data API
+read RPC checks `capabilities.api_read` for its resource (see "Host data API"
+below) — all before the handler runs, returning gRPC status `PermissionDenied`
+with message `capability '<name>' not declared` on a miss. `EmitEvent` is
+ungated (no boolean capability applies). The Host data API write
 RPCs are not implemented yet, so they return gRPC `Unimplemented` unconditionally
 and never reach an `api_write` capability check (see "Write phase (deferred)").
 

--- a/docs/specs/plugins/spec.md
+++ b/docs/specs/plugins/spec.md
@@ -137,9 +137,10 @@ restart_count: 0
 
 `capabilities.api_read` / `capabilities.api_write` gate the **Host data API** Host
 RPCs (read RPCs live now; write RPCs are deferred) — the vocabulary is a list of
-resource names: `tasks`, `sessions`, `workspaces`, `workflows`, `agent_profiles`,
-`repositories` for `api_read`, plus `comments` for `api_write` only (there is no
-`ListComments` read RPC). They are unrelated to office. See "Host data API".
+resource names: `tasks`, `sessions`, `messages`, `workspaces`, `workflows`,
+`agent_profiles`, `repositories` for `api_read`, plus `comments` for `api_write`
+only (there is no `ListComments` read RPC). They are unrelated to office. See
+"Host data API".
 
 **Declaring data access.** Listing a resource under `api_read` grants the
 corresponding Host data reads for that resource only — e.g. `api_read:
@@ -350,6 +351,7 @@ domain structs. See [ADR 0043](../../decisions/0043-plugin-host-data-api.md) and
 | `ListRepositories` | `api_read:repositories` | Repositories for a workspace (id, name, default branch) |
 | `ListSessions` | `api_read:sessions` | Session identity + agent context (id, task, agent profile, resolved display name + model, `acp_session_id`, state, timestamps) |
 | `ListSessionCodeStats` | `api_read:sessions` | **Computed** per-session code metrics: committed lines added/deleted, peak pending-diff lines added/deleted |
+| `ListMessages` | `api_read:messages` | Historical conversation content (id, session, task, turn, `author_type` (user/agent), `content`, `type`, `created_at`), filterable by session ids, task ids, a `created_at` range (`since`/`until`), and types. See "Conversation content" below. |
 
 `acp_session_id` on a session is the external usage-attribution join key (e.g.
 `tokscale`): kandev exposes the session identity and code stats but stays out of
@@ -357,6 +359,20 @@ the token business. `SessionCodeStats` is a deliberately computed shape — the
 aggregate the agent-stats plugin previously re-derived by hand from
 `task_session_commits` and `task_session_git_snapshots` — so plugins never touch
 those raw rows.
+
+**Conversation content (`api_read:messages`, ADR 0047).** `ListMessages` reads
+historical user/agent message content — the data a "summarize yesterday"
+plugin needs, which the `message.added` bus event alone (live-only,
+post-install-only) cannot provide. `MessageFilter` narrows by `session_ids`,
+`task_ids`, a `created_at` window (`since` inclusive / `until` exclusive,
+RFC3339), and message `types`; results are ordered oldest-first with opaque
+cursor pagination. `content` is sanitized the same way the event path is —
+kandev-injected `<kandev-system>` blocks are stripped via
+`sysprompt.StripSystemContent`, and raw system content is never exposed.
+`author_type` is only `user` or `agent`: kandev has no `system` author, since
+system context is inline markup removed at read time. Reads route through the
+task service's `ListMessagesForPlugin` (a single filtered
+session/task/time/type query), never a repository or the DB file directly.
 
 **Write phase (deferred).** `CreateTask`, `UpdateTask`, and `CreateComment` are
 specified in the proto but not implemented in this phase. When added, each is


### PR DESCRIPTION
## What

Adds two **host-side** plugin capabilities to the Kandev plugin Host API,
following the ADR 0043 pattern. These unblock a downstream "My Daily Standup"
plugin (out of scope here) that summarizes yesterday's session conversations.

Two clearly-separated commits, one per capability.

### 1. Read conversation content — `api_read:messages` (ADR 0047)
- New `ListMessages` RPC on `service Host`; SDK `Host.Messages() MessageReader`.
- `Message` DTO: `id, session_id, task_id, turn_id, author_type (user|agent), content, type, created_at`.
- Filter by session ids, task ids, a `created_at` range (`since` inclusive / `until` exclusive, RFC3339), and types; opaque cursor pagination.
- Content sanitized via `sysprompt.StripSystemContent` — kandev-injected `<kandev-system>` blocks are stripped, raw system prompts never exposed (matches the `message.added` event).
- New filtered `ListMessagesForPlugin` query through the task service (none existed for task/time scope). Reads never touch the DB file.

### 2. Invoke a settings-selectable utility agent — `agent_invoke` (ADR 0048)
- New boolean capability `agent_invoke`; SDK `Host.InvokeUtilityAgent(ctx, prompt) (string, error)` / `InvokeUtilityAgent` RPC.
- New `utility_agent_profile_id` user setting, selectable in **Settings > System > Utility Agent** (profile dropdown, cloned from the existing utility-agent path).
- Reuses the sessionless host-utility inference tier (ADR 0002) via a thin adapter — no new agent loop, no task/session/workspace. Resolves the configured profile to `(agent type, model)`.
- Unconfigured or since-deleted profile → gRPC `FailedPrecondition`; missing capability → `PermissionDenied`.

## Host API shape (for the downstream plugin)
- `Host.Messages().List(ctx, MessageFilter{SessionIDs, TaskIDs, Since, Until, Types}, Page) ([]Message, *PageInfo, error)` — capability `api_read:messages`.
- `Host.InvokeUtilityAgent(ctx, prompt string) (string, error)` — capability `agent_invoke`.

## Tests
- In-process + real-transport (wire) capability gating for both (`PermissionDenied`).
- Messages: content stripping, filter/time-range passthrough, pagination, invalid-time `InvalidArgument`, and the SQLite query (session/task/time/type filters, limit/offset).
- Utility agent: completion path asserts the configured profile's type+model reach the runner and text is returned; no-utility-agent and stale-profile `FailedPrecondition` paths; SDK/wire round-trips; settings apply/trim.
- Frontend: component RTL tests + web typecheck/lint clean.

## Verification
- `make fmt` clean; `go build ./...` clean; changed-file `golangci-lint` → 0 issues.
- Touched backend packages + `internal/backendapp` tests green.
- `pnpm --filter @kandev/web typecheck` and `lint` clean.
- Note: `internal/launcher`'s `TestListenControlSocketUsesOwnerOnlyMode` fails in this sandbox (unix-socket `bind: invalid argument`) — a pre-existing environment limitation in a package this branch does not touch.

## Delivery note
Shipped as one PR because both capabilities share the proto file,
`pkg/pluginsdk/host.go`, `internal/plugins/host.go`, and the public docs;
parallel PRs would conflict heavily on that surface. The two commits are
independently reviewable and could be split if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1852?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->