### PR TITLE
fix(web): retain enhanced prompt results

### DIFF
--- a/apps/web/components/prompt-result-recovery.test.tsx
+++ b/apps/web/components/prompt-result-recovery.test.tsx
@@ -1,0 +1,45 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { UtilityGenerationResult } from "@/hooks/use-utility-agent-generator";
+
+import { PromptResultRecovery } from "./prompt-result-recovery";
+
+const GENERATED_RESULT = {
+  content: "enhanced prompt output",
+  callId: "call-123",
+  durationMs: 1_200,
+} satisfies UtilityGenerationResult;
+
+describe("PromptResultRecovery", () => {
+  beforeEach(() => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+  });
+
+  it("offers apply and copy actions without exposing the raw enhanced prompt", async () => {
+    const onApply = vi.fn();
+    const onCopy = vi.fn(async () => {
+      await navigator.clipboard.writeText(GENERATED_RESULT.content);
+    });
+
+    render(
+      <PromptResultRecovery pendingResult={GENERATED_RESULT} onApply={onApply} onCopy={onCopy} />,
+    );
+
+    const recovery = screen.getByTestId("prompt-result-recovery");
+    expect(recovery.getAttribute("aria-live")).toBe("polite");
+    expect(recovery.textContent).toContain("An enhanced prompt is available.");
+    expect(recovery.textContent).not.toContain(GENERATED_RESULT.content);
+    expect(recovery.outerHTML).not.toContain(GENERATED_RESULT.content);
+
+    fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+    expect(onApply).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy" }));
+    expect(onCopy).toHaveBeenCalledTimes(1);
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(GENERATED_RESULT.content);
+  });
+});

--- a/apps/web/components/prompt-result-recovery.tsx
+++ b/apps/web/components/prompt-result-recovery.tsx
@@ -27,7 +27,12 @@ export function PromptResultRecovery({
     >
       <p className="text-sm text-muted-foreground">An enhanced prompt is available.</p>
       <div className="flex flex-wrap items-center gap-2">
-        <Button type="button" variant="outline" className="cursor-pointer" onClick={() => void onCopy()}>
+        <Button
+          type="button"
+          variant="outline"
+          className="cursor-pointer"
+          onClick={() => void onCopy()}
+        >
           Copy
         </Button>
         <Button type="button" className="cursor-pointer" onClick={onApply}>

--- a/apps/web/components/prompt-result-recovery.tsx
+++ b/apps/web/components/prompt-result-recovery.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { Button } from "@kandev/ui/button";
+
+import type { UtilityGenerationResult } from "@/hooks/use-utility-agent-generator";
+
+type PromptResultRecoveryProps = {
+  pendingResult: UtilityGenerationResult | null;
+  onApply: () => void;
+  onCopy: () => Promise<void> | void;
+};
+
+export function PromptResultRecovery({
+  pendingResult,
+  onApply,
+  onCopy,
+}: PromptResultRecoveryProps) {
+  if (!pendingResult) {
+    return null;
+  }
+
+  return (
+    <div
+      aria-live="polite"
+      data-testid="prompt-result-recovery"
+      className="flex flex-col gap-2 rounded-md border border-border/60 bg-muted/30 p-3"
+    >
+      <p className="text-sm text-muted-foreground">An enhanced prompt is available.</p>
+      <div className="flex flex-wrap items-center gap-2">
+        <Button type="button" variant="outline" className="cursor-pointer" onClick={() => void onCopy()}>
+          Copy
+        </Button>
+        <Button type="button" className="cursor-pointer" onClick={onApply}>
+          Apply
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/task-create-dialog-form-body.tsx
+++ b/apps/web/components/task-create-dialog-form-body.tsx
@@ -7,8 +7,10 @@ import type { WorkflowSnapshotData } from "@/lib/state/slices/kanban/types";
 import { WorkflowSelectorRow } from "@/components/workflow-selector-row";
 import { AgentLogo } from "@/components/agent-logo";
 import type { DialogFormState } from "@/components/task-create-dialog-types";
+import type { DialogPromptEnhance } from "@/components/task-create-dialog-types";
 import type { useKeyboardShortcutHandler } from "@/hooks/use-keyboard-shortcut";
 import { TaskFormInputs } from "@/components/task-create-dialog-selectors";
+import { PromptResultRecovery } from "@/components/prompt-result-recovery";
 import type { JiraTicket } from "@/lib/types/jira";
 import type { LinearIssue } from "@/lib/types/linear";
 
@@ -361,7 +363,7 @@ export type DialogPromptSectionProps = {
   initialDescription: string;
   fs: DialogFormState;
   handleKeyDown: ReturnType<typeof useKeyboardShortcutHandler>;
-  enhance?: { onEnhance: () => void; isLoading: boolean; isConfigured: boolean };
+  enhance?: DialogPromptEnhance;
   workspaceId?: string | null;
   onJiraImport?: (ticket: JiraTicket) => void;
   onLinearImport?: (issue: LinearIssue) => void;
@@ -432,6 +434,11 @@ export function DialogPromptSection({
         jiraImport={importBindings(importsEnabled, ws, onJiraImport)}
         linearImport={importBindings(importsEnabled, ws, onLinearImport)}
         onVoiceAutoSend={onVoiceAutoSend}
+      />
+      <PromptResultRecovery
+        pendingResult={enhance?.pendingResult ?? null}
+        onApply={enhance?.onApplyPending ?? (() => undefined)}
+        onCopy={enhance?.onCopyPending ?? (() => undefined)}
       />
       {extraFormSlot}
     </>

--- a/apps/web/components/task-create-dialog-selectors.tsx
+++ b/apps/web/components/task-create-dialog-selectors.tsx
@@ -477,25 +477,34 @@ function useDescriptionInput(
   attachments: FileAttachment[],
 ) {
   const [description, setDescription] = useState(initialDescription);
+  const descriptionRef = useRef(initialDescription);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   // Caret offset to restore after a non-typed value mutation (e.g. voice
   // transcript splice). Consumed inside useLayoutEffect so the cursor lands
   // before the next paint and the user sees no jump.
   const pendingCursorRef = useRef<number | null>(null);
 
+  const setDescriptionValue = useCallback(
+    (newValue: string) => {
+      const hadContent = descriptionRef.current.trim().length > 0;
+      const hasContent = newValue.trim().length > 0;
+      descriptionRef.current = newValue;
+      setDescription(newValue);
+      if (hadContent !== hasContent) onDescriptionChange(hasContent);
+    },
+    [onDescriptionChange],
+  );
+
   useEffect(() => {
     const ref = descriptionValueRef as React.MutableRefObject<TaskFormInputsHandle | null>;
     if (ref) {
       ref.current = {
-        getValue: () => description,
-        setValue: (v: string) => {
-          setDescription(v);
-          onDescriptionChange(v.trim().length > 0);
-        },
+        getValue: () => descriptionRef.current,
+        setValue: setDescriptionValue,
         getAttachments: () => attachments,
       };
     }
-  }, [description, attachments, descriptionValueRef, onDescriptionChange]);
+  }, [attachments, descriptionValueRef, setDescriptionValue]);
 
   useEffect(() => {
     const textarea = textareaRef.current;
@@ -521,16 +530,6 @@ function useDescriptionInput(
     textarea.focus();
     textarea.setSelectionRange(textarea.value.length, textarea.value.length);
   }, [autoFocus]);
-
-  const setDescriptionValue = useCallback(
-    (newValue: string) => {
-      const hadContent = description.trim().length > 0;
-      const hasContent = newValue.trim().length > 0;
-      setDescription(newValue);
-      if (hadContent !== hasContent) onDescriptionChange(hasContent);
-    },
-    [description, onDescriptionChange],
-  );
 
   const insertAtCursor = useCallback(
     (text: string) => {

--- a/apps/web/components/task-create-dialog-types.ts
+++ b/apps/web/components/task-create-dialog-types.ts
@@ -2,6 +2,7 @@ import type React from "react";
 import type { LocalRepository, Repository, Executor, Task } from "@/lib/types/http";
 import type { UseBranchesByURLResult } from "@/hooks/domains/github/use-branches-by-url";
 import type { UsePRInfoByURLResult } from "@/hooks/domains/github/use-pr-info-by-url";
+import type { UtilityGenerationResult } from "@/hooks/use-utility-agent-generator";
 import type { AgentProfileOption, WorkspaceState } from "@/lib/state/slices";
 import type {
   KanbanMultiState,
@@ -17,6 +18,15 @@ import type {
   useExecutorProfileOptions,
 } from "@/components/task-create-dialog-options";
 import type { useToast } from "@/components/toast-provider";
+
+export type DialogPromptEnhance = {
+  onEnhance: () => void;
+  isLoading: boolean;
+  isConfigured: boolean;
+  pendingResult: UtilityGenerationResult | null;
+  onApplyPending: () => void;
+  onCopyPending: () => Promise<void> | void;
+};
 
 /**
  * One repository row in the task-create form. The form tracks every repo
@@ -423,7 +433,7 @@ export type DialogFormBodyProps = {
   onToggleFreshBranch: (enabled: boolean) => void;
   onToggleNoRepository?: () => void;
   onWorkspacePathChange: (value: string) => void;
-  enhance?: { onEnhance: () => void; isLoading: boolean; isConfigured: boolean };
+  enhance?: DialogPromptEnhance;
   workflowAgentLocked: boolean;
   /** Workspace repositories — driven into the chip row for repo + branch picks. */
   repositories: Repository[];

--- a/apps/web/components/task-create-dialog.test.tsx
+++ b/apps/web/components/task-create-dialog.test.tsx
@@ -12,6 +12,7 @@ const ORIGINAL_PROMPT = "Original prompt";
 const IMPROVED_PROMPT = "Improved prompt";
 const USER_EDIT = "User edit";
 const PROMPT_RESULT_RECOVERY_TEST_ID = "prompt-result-recovery";
+const ENHANCE_PROMPT_BUTTON_TEST_ID = "enhance-prompt-button";
 
 let allowProgrammaticSet = true;
 let mockFs: DialogFormState;
@@ -338,7 +339,7 @@ describe("TaskCreateDialog prompt enhancement", () => {
     renderDialog();
 
     const textarea = screen.getByTestId("task-description-input") as HTMLTextAreaElement;
-    fireEvent.click(screen.getByTestId("enhance-prompt-button"));
+    fireEvent.click(screen.getByTestId(ENHANCE_PROMPT_BUTTON_TEST_ID));
 
     expect(enhancePromptMock).toHaveBeenCalledWith(ORIGINAL_PROMPT, expect.any(Function));
 
@@ -362,7 +363,7 @@ describe("TaskCreateDialog prompt enhancement", () => {
     renderDialog();
 
     const textarea = screen.getByTestId("task-description-input") as HTMLTextAreaElement;
-    fireEvent.click(screen.getByTestId("enhance-prompt-button"));
+    fireEvent.click(screen.getByTestId(ENHANCE_PROMPT_BUTTON_TEST_ID));
     fireEvent.change(textarea, { target: { value: USER_EDIT } });
 
     await act(async () => {
@@ -388,13 +389,34 @@ describe("TaskCreateDialog prompt enhancement", () => {
 
     renderDialog();
 
-    fireEvent.click(screen.getByTestId("enhance-prompt-button"));
+    fireEvent.click(screen.getByTestId(ENHANCE_PROMPT_BUTTON_TEST_ID));
     mockFs.descriptionInputRef.current = null;
 
     await act(async () => {
       await deliver?.({ content: IMPROVED_PROMPT });
     });
 
+    expect(screen.getByTestId(PROMPT_RESULT_RECOVERY_TEST_ID)).toBeTruthy();
+  });
+
+  it("keeps the generated result behind recovery when the editor rejects a write", async () => {
+    let deliver: ((result: { content: string }) => boolean | Promise<boolean>) | undefined;
+    enhancePromptMock.mockImplementation(
+      (_source: string, onSuccess: (result: { content: string }) => boolean | Promise<boolean>) => {
+        deliver = onSuccess;
+      },
+    );
+
+    renderDialog();
+
+    fireEvent.click(screen.getByTestId(ENHANCE_PROMPT_BUTTON_TEST_ID));
+    allowProgrammaticSet = false;
+
+    await act(async () => {
+      await deliver?.({ content: IMPROVED_PROMPT });
+    });
+
+    expect(setHasDescriptionMock).not.toHaveBeenCalled();
     expect(screen.getByTestId(PROMPT_RESULT_RECOVERY_TEST_ID)).toBeTruthy();
   });
 });

--- a/apps/web/components/task-create-dialog.test.tsx
+++ b/apps/web/components/task-create-dialog.test.tsx
@@ -1,0 +1,398 @@
+import { createRef, type ReactNode, useEffect, useImperativeHandle, useRef } from "react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { TaskCreateDialog } from "./task-create-dialog";
+import type { DialogFormState, TaskFormInputsHandle } from "./task-create-dialog-types";
+
+const enhancePromptMock = vi.fn();
+const toastMock = vi.fn();
+const setHasDescriptionMock = vi.fn();
+
+let allowProgrammaticSet = true;
+let mockFs: DialogFormState;
+
+vi.mock("@kandev/ui/dialog", () => ({
+  Dialog: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogFooter: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@kandev/ui/button", () => ({
+  Button: ({ children, ...rest }: { children: ReactNode } & Record<string, unknown>) => (
+    <button {...rest}>{children}</button>
+  ),
+}));
+
+vi.mock("@/components/routing/app-link", () => ({
+  default: ({ children, href }: { children: ReactNode; href: string }) => <a href={href}>{children}</a>,
+}));
+
+vi.mock("@/components/workflow-selector-row", () => ({
+  WorkflowSelectorRow: () => null,
+}));
+
+vi.mock("@/components/agent-logo", () => ({
+  AgentLogo: () => null,
+}));
+
+vi.mock("@/hooks/use-is-utility-configured", () => ({
+  useIsUtilityConfigured: () => true,
+}));
+
+vi.mock("@/hooks/use-utility-agent-generator", () => ({
+  useUtilityAgentGenerator: () => ({
+    enhancePrompt: enhancePromptMock,
+    isEnhancingPrompt: false,
+  }),
+}));
+
+vi.mock("@/components/toast-provider", () => ({
+  useToast: () => ({ toast: toastMock }),
+}));
+
+vi.mock("@/hooks/use-keyboard-shortcut", () => ({
+  useKeyboardShortcutHandler: () => () => undefined,
+}));
+
+vi.mock("@/components/task-create-dialog-footer", () => ({
+  TaskCreateDialogFooter: () => null,
+}));
+
+vi.mock("@/components/discard-local-changes-dialog", () => ({
+  DiscardLocalChangesDialog: () => null,
+}));
+
+vi.mock("@/components/task-create-dialog-header", () => ({
+  DialogHeaderContent: () => null,
+}));
+
+vi.mock("@/components/task-create-dialog-create-mode-selectors", () => ({
+  CreateModeSelectors: () => null,
+}));
+
+vi.mock("@/components/task-create-dialog-repo-chips", () => ({
+  RepoChipsRow: () => null,
+}));
+
+vi.mock("@/hooks/use-task-create-dialog-popover-container", () => ({
+  TaskCreateDialogPopoverContainerProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/components/task-create-dialog-handlers", () => ({
+  resetTaskCreateLastUsedSync: () => undefined,
+}));
+
+vi.mock("@/components/state-provider", () => ({
+  useAppStore: (selector: (state: { userSettings: { taskCreateLastUsed: null } }) => unknown) =>
+    selector({ userSettings: { taskCreateLastUsed: null } }),
+}));
+
+vi.mock("@/components/task-create-dialog-submit", () => ({
+  useTaskSubmitHandlers: () => ({
+    handleSubmit: () => undefined,
+    handleCancel: () => undefined,
+    handleUpdateWithoutAgent: () => undefined,
+    handleCreateWithoutAgent: () => undefined,
+    handleCreateWithPlanMode: () => undefined,
+    pendingDiscard: null,
+  }),
+}));
+
+vi.mock("@/components/task-create-dialog-selectors", () => ({
+  InlineTaskName: () => null,
+  AgentSelector: () => null,
+  ExecutorProfileSelector: () => null,
+  TaskFormInputs: ({
+    initialDescription,
+    descriptionValueRef,
+    onDescriptionChange,
+    onEnhancePrompt,
+  }: {
+    initialDescription: string;
+    descriptionValueRef: React.RefObject<TaskFormInputsHandle | null>;
+    onDescriptionChange: (hasDescription: boolean) => void;
+    onEnhancePrompt?: () => void;
+  }) => {
+    const textareaRef = useRef<HTMLTextAreaElement>(null);
+    const latestValueRef = useRef(initialDescription);
+
+    useEffect(() => {
+      latestValueRef.current = initialDescription;
+      if (textareaRef.current) {
+        textareaRef.current.value = initialDescription;
+      }
+    }, [initialDescription]);
+
+    useImperativeHandle(
+      descriptionValueRef,
+      () => ({
+        getValue: () => latestValueRef.current,
+        setValue: (next: string) => {
+          if (allowProgrammaticSet) {
+            latestValueRef.current = next;
+            if (textareaRef.current) {
+              textareaRef.current.value = next;
+            }
+          }
+        },
+        getAttachments: () => [],
+      }),
+      [],
+    );
+
+    return (
+      <div>
+        <textarea
+          ref={textareaRef}
+          data-testid="task-description-input"
+          defaultValue={initialDescription}
+          onChange={(event) => {
+            const next = event.target.value;
+            latestValueRef.current = next;
+            onDescriptionChange(next.trim().length > 0);
+          }}
+        />
+        <button type="button" data-testid="enhance-prompt-button" onClick={onEnhancePrompt}>
+          Enhance
+        </button>
+      </div>
+    );
+  },
+}));
+
+vi.mock("@/components/task-create-dialog-state", () => ({
+  useDialogFormState: () => mockFs,
+  useTaskCreateDialogEffects: () => undefined,
+  useDialogHandlers: () => ({
+    handleTaskNameChange: () => undefined,
+    handleRowRepositoryChange: () => undefined,
+    handleRowBranchChange: () => undefined,
+    handleAgentProfileChange: () => undefined,
+    handleExecutorProfileChange: () => undefined,
+    handleWorkflowChange: () => undefined,
+    handleToggleRemote: () => undefined,
+    handleToggleFreshBranch: () => undefined,
+    handleToggleNoRepository: () => undefined,
+    handleWorkspacePathChange: () => undefined,
+  }),
+  useLockedFieldSync: () => undefined,
+  useSessionRepoName: () => "",
+  useTaskCreateDialogData: () => ({
+    workflows: [],
+    agentProfiles: [],
+    executors: [],
+    snapshots: {},
+    repositories: [],
+    repositoriesLoading: false,
+    taskCreateLastUsed: {
+      branch: null,
+      repositoryId: null,
+      agentProfileId: null,
+      executorProfileId: null,
+    },
+    userSettingsLoaded: true,
+    computed: {
+      isPassthroughProfile: false,
+      effectiveWorkflowId: null,
+      effectiveDefaultStepId: null,
+      workspaceDefaults: null,
+      hasRepositorySelection: true,
+      branchOptions: [],
+      agentProfileOptions: [],
+      executorProfileOptions: [],
+      executorHint: null,
+      isLocalExecutor: false,
+      headerRepositoryOptions: [],
+      agentProfilesLoading: false,
+      executorsLoading: false,
+      workflowAgentLocked: false,
+      workflowAgentProfileId: "",
+      effectiveAgentProfileId: "agent-1",
+      selectedExecutorProfileName: null,
+      noCompatibleAgent: false,
+      compatibleAgentProfiles: [],
+      authLoaded: true,
+    },
+  }),
+  computeIsTaskStarted: () => false,
+}));
+
+function buildMockFs(initialDescription = "Original prompt"): DialogFormState {
+  return {
+    taskName: "Task title",
+    setTaskName: () => undefined,
+    hasTitle: true,
+    setHasTitle: () => undefined,
+    hasDescription: true,
+    setHasDescription: setHasDescriptionMock,
+    draftDescription: initialDescription,
+    openCycle: 0,
+    currentDefaults: { name: "Task title", description: initialDescription },
+    descriptionInputRef: createRef<TaskFormInputsHandle>(),
+    repositories: [],
+    setRepositories: () => undefined,
+    addRepository: () => undefined,
+    removeRepository: () => undefined,
+    updateRepository: () => undefined,
+    agentProfileId: "agent-1",
+    setAgentProfileId: () => undefined,
+    executorId: "executor-1",
+    setExecutorId: () => undefined,
+    executorProfileId: "executor-profile-1",
+    setExecutorProfileId: () => undefined,
+    discoveredRepositories: [],
+    setDiscoveredRepositories: () => undefined,
+    discoverReposLoading: false,
+    setDiscoverReposLoading: () => undefined,
+    discoverReposLoaded: true,
+    setDiscoverReposLoaded: () => undefined,
+    selectedWorkflowId: null,
+    setSelectedWorkflowId: () => undefined,
+    fetchedSteps: null,
+    setFetchedSteps: () => undefined,
+    isCreatingSession: false,
+    setIsCreatingSession: () => undefined,
+    isCreatingTask: false,
+    setIsCreatingTask: () => undefined,
+    useRemote: false,
+    setUseRemote: () => undefined,
+    remoteRepos: [],
+    setRemoteRepos: () => undefined,
+    addRemoteRepo: () => undefined,
+    removeRemoteRepo: () => undefined,
+    updateRemoteRepo: () => undefined,
+    branchesByUrl: {
+      branches: () => [],
+      loading: () => false,
+      ensure: () => undefined,
+      clear: () => undefined,
+    },
+    prInfoByUrl: {
+      info: () => undefined,
+      loading: () => false,
+      ensure: () => undefined,
+      clear: () => undefined,
+    },
+    githubUrlError: null,
+    setGitHubUrlError: () => undefined,
+    workflowAgentProfileId: "",
+    setWorkflowAgentProfileId: () => undefined,
+    clearDraft: () => undefined,
+    freshBranchEnabled: false,
+    setFreshBranchEnabled: () => undefined,
+    currentLocalBranch: "",
+    setCurrentLocalBranch: () => undefined,
+    currentLocalBranchLoading: false,
+    setCurrentLocalBranchLoading: () => undefined,
+    noRepository: false,
+    setNoRepository: () => undefined,
+    workspacePath: "",
+    setWorkspacePath: () => undefined,
+  };
+}
+
+function renderDialog() {
+  return render(
+    <TaskCreateDialog
+      open
+      onOpenChange={() => undefined}
+      workspaceId="workspace-1"
+      workflowId={null}
+      defaultStepId={null}
+      steps={[]}
+    />,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+beforeEach(() => {
+  allowProgrammaticSet = true;
+  enhancePromptMock.mockReset();
+  toastMock.mockReset();
+  setHasDescriptionMock.mockReset();
+  mockFs = buildMockFs();
+});
+
+describe("TaskCreateDialog prompt enhancement", () => {
+  it("applies the enhanced prompt immediately when the description is unchanged", async () => {
+    let deliver:
+      | ((result: { content: string }) => boolean | Promise<boolean>)
+      | undefined;
+    enhancePromptMock.mockImplementation(
+      (_source: string, onSuccess: (result: { content: string }) => boolean | Promise<boolean>) => {
+        deliver = onSuccess;
+      },
+    );
+
+    renderDialog();
+
+    const textarea = screen.getByTestId("task-description-input") as HTMLTextAreaElement;
+    fireEvent.click(screen.getByTestId("enhance-prompt-button"));
+
+    expect(enhancePromptMock).toHaveBeenCalledWith("Original prompt", expect.any(Function));
+
+    await act(async () => {
+      await deliver?.({ content: "Improved prompt" });
+    });
+
+    await waitFor(() => expect(textarea.value).toBe("Improved prompt"));
+    expect(setHasDescriptionMock).toHaveBeenCalledWith(true);
+    expect(screen.queryByTestId("prompt-result-recovery")).toBeNull();
+  });
+
+  it("keeps the user's edited description and offers recovery", async () => {
+    let deliver:
+      | ((result: { content: string }) => boolean | Promise<boolean>)
+      | undefined;
+    enhancePromptMock.mockImplementation(
+      (_source: string, onSuccess: (result: { content: string }) => boolean | Promise<boolean>) => {
+        deliver = onSuccess;
+      },
+    );
+
+    renderDialog();
+
+    const textarea = screen.getByTestId("task-description-input") as HTMLTextAreaElement;
+    fireEvent.click(screen.getByTestId("enhance-prompt-button"));
+    fireEvent.change(textarea, { target: { value: "User edit" } });
+
+    await act(async () => {
+      await deliver?.({ content: "Improved prompt" });
+    });
+
+    await waitFor(() => expect(textarea.value).toBe("User edit"));
+    expect(screen.getByTestId("prompt-result-recovery")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+
+    await waitFor(() => expect(textarea.value).toBe("Improved prompt"));
+    expect(screen.queryByTestId("prompt-result-recovery")).toBeNull();
+  });
+
+  it("keeps the generated result behind recovery when the editor handle is gone", async () => {
+    let deliver:
+      | ((result: { content: string }) => boolean | Promise<boolean>)
+      | undefined;
+    enhancePromptMock.mockImplementation(
+      (_source: string, onSuccess: (result: { content: string }) => boolean | Promise<boolean>) => {
+        deliver = onSuccess;
+      },
+    );
+
+    renderDialog();
+
+    fireEvent.click(screen.getByTestId("enhance-prompt-button"));
+    mockFs.descriptionInputRef.current = null;
+
+    await act(async () => {
+      await deliver?.({ content: "Improved prompt" });
+    });
+
+    expect(screen.getByTestId("prompt-result-recovery")).toBeTruthy();
+  });
+});

--- a/apps/web/components/task-create-dialog.test.tsx
+++ b/apps/web/components/task-create-dialog.test.tsx
@@ -8,6 +8,10 @@ import type { DialogFormState, TaskFormInputsHandle } from "./task-create-dialog
 const enhancePromptMock = vi.fn();
 const toastMock = vi.fn();
 const setHasDescriptionMock = vi.fn();
+const ORIGINAL_PROMPT = "Original prompt";
+const IMPROVED_PROMPT = "Improved prompt";
+const USER_EDIT = "User edit";
+const PROMPT_RESULT_RECOVERY_TEST_ID = "prompt-result-recovery";
 
 let allowProgrammaticSet = true;
 let mockFs: DialogFormState;
@@ -26,7 +30,9 @@ vi.mock("@kandev/ui/button", () => ({
 }));
 
 vi.mock("@/components/routing/app-link", () => ({
-  default: ({ children, href }: { children: ReactNode; href: string }) => <a href={href}>{children}</a>,
+  default: ({ children, href }: { children: ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
 }));
 
 vi.mock("@/components/workflow-selector-row", () => ({
@@ -77,7 +83,9 @@ vi.mock("@/components/task-create-dialog-repo-chips", () => ({
 }));
 
 vi.mock("@/hooks/use-task-create-dialog-popover-container", () => ({
-  TaskCreateDialogPopoverContainerProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TaskCreateDialogPopoverContainerProvider: ({ children }: { children: ReactNode }) => (
+    <>{children}</>
+  ),
 }));
 
 vi.mock("@/components/task-create-dialog-handlers", () => ({
@@ -219,7 +227,7 @@ vi.mock("@/components/task-create-dialog-state", () => ({
   computeIsTaskStarted: () => false,
 }));
 
-function buildMockFs(initialDescription = "Original prompt"): DialogFormState {
+function buildMockFs(initialDescription = ORIGINAL_PROMPT): DialogFormState {
   return {
     taskName: "Task title",
     setTaskName: () => undefined,
@@ -320,9 +328,7 @@ beforeEach(() => {
 
 describe("TaskCreateDialog prompt enhancement", () => {
   it("applies the enhanced prompt immediately when the description is unchanged", async () => {
-    let deliver:
-      | ((result: { content: string }) => boolean | Promise<boolean>)
-      | undefined;
+    let deliver: ((result: { content: string }) => boolean | Promise<boolean>) | undefined;
     enhancePromptMock.mockImplementation(
       (_source: string, onSuccess: (result: { content: string }) => boolean | Promise<boolean>) => {
         deliver = onSuccess;
@@ -334,21 +340,19 @@ describe("TaskCreateDialog prompt enhancement", () => {
     const textarea = screen.getByTestId("task-description-input") as HTMLTextAreaElement;
     fireEvent.click(screen.getByTestId("enhance-prompt-button"));
 
-    expect(enhancePromptMock).toHaveBeenCalledWith("Original prompt", expect.any(Function));
+    expect(enhancePromptMock).toHaveBeenCalledWith(ORIGINAL_PROMPT, expect.any(Function));
 
     await act(async () => {
-      await deliver?.({ content: "Improved prompt" });
+      await deliver?.({ content: IMPROVED_PROMPT });
     });
 
-    await waitFor(() => expect(textarea.value).toBe("Improved prompt"));
+    await waitFor(() => expect(textarea.value).toBe(IMPROVED_PROMPT));
     expect(setHasDescriptionMock).toHaveBeenCalledWith(true);
-    expect(screen.queryByTestId("prompt-result-recovery")).toBeNull();
+    expect(screen.queryByTestId(PROMPT_RESULT_RECOVERY_TEST_ID)).toBeNull();
   });
 
   it("keeps the user's edited description and offers recovery", async () => {
-    let deliver:
-      | ((result: { content: string }) => boolean | Promise<boolean>)
-      | undefined;
+    let deliver: ((result: { content: string }) => boolean | Promise<boolean>) | undefined;
     enhancePromptMock.mockImplementation(
       (_source: string, onSuccess: (result: { content: string }) => boolean | Promise<boolean>) => {
         deliver = onSuccess;
@@ -359,25 +363,23 @@ describe("TaskCreateDialog prompt enhancement", () => {
 
     const textarea = screen.getByTestId("task-description-input") as HTMLTextAreaElement;
     fireEvent.click(screen.getByTestId("enhance-prompt-button"));
-    fireEvent.change(textarea, { target: { value: "User edit" } });
+    fireEvent.change(textarea, { target: { value: USER_EDIT } });
 
     await act(async () => {
-      await deliver?.({ content: "Improved prompt" });
+      await deliver?.({ content: IMPROVED_PROMPT });
     });
 
-    await waitFor(() => expect(textarea.value).toBe("User edit"));
-    expect(screen.getByTestId("prompt-result-recovery")).toBeTruthy();
+    await waitFor(() => expect(textarea.value).toBe(USER_EDIT));
+    expect(screen.getByTestId(PROMPT_RESULT_RECOVERY_TEST_ID)).toBeTruthy();
 
     fireEvent.click(screen.getByRole("button", { name: "Apply" }));
 
-    await waitFor(() => expect(textarea.value).toBe("Improved prompt"));
-    expect(screen.queryByTestId("prompt-result-recovery")).toBeNull();
+    await waitFor(() => expect(textarea.value).toBe(IMPROVED_PROMPT));
+    expect(screen.queryByTestId(PROMPT_RESULT_RECOVERY_TEST_ID)).toBeNull();
   });
 
   it("keeps the generated result behind recovery when the editor handle is gone", async () => {
-    let deliver:
-      | ((result: { content: string }) => boolean | Promise<boolean>)
-      | undefined;
+    let deliver: ((result: { content: string }) => boolean | Promise<boolean>) | undefined;
     enhancePromptMock.mockImplementation(
       (_source: string, onSuccess: (result: { content: string }) => boolean | Promise<boolean>) => {
         deliver = onSuccess;
@@ -390,9 +392,9 @@ describe("TaskCreateDialog prompt enhancement", () => {
     mockFs.descriptionInputRef.current = null;
 
     await act(async () => {
-      await deliver?.({ content: "Improved prompt" });
+      await deliver?.({ content: IMPROVED_PROMPT });
     });
 
-    expect(screen.getByTestId("prompt-result-recovery")).toBeTruthy();
+    expect(screen.getByTestId(PROMPT_RESULT_RECOVERY_TEST_ID)).toBeTruthy();
   });
 });

--- a/apps/web/components/task-create-dialog.tsx
+++ b/apps/web/components/task-create-dialog.tsx
@@ -47,6 +47,9 @@ import { resetTaskCreateLastUsedSync } from "@/components/task-create-dialog-han
 import { useAppStore } from "@/components/state-provider";
 import { TaskCreateDialogPopoverContainerProvider } from "@/hooks/use-task-create-dialog-popover-container";
 import { shouldShowTaskTitleField } from "@/components/task-create-dialog-helpers";
+import { usePromptResultDelivery } from "@/hooks/use-prompt-result-delivery";
+
+const PROMPT_INSERTED_MESSAGE = "Enhanced prompt inserted.";
 
 export interface TaskCreateDialogProps {
   open: boolean;
@@ -249,19 +252,49 @@ function DialogFormBody(props: DialogFormBodyProps) {
 
 function useEnhanceForDialog(fs: DialogFormState) {
   const isConfigured = useIsUtilityConfigured();
+  const { toast } = useToast();
   const { enhancePrompt, isEnhancingPrompt } = useUtilityAgentGenerator({
     sessionId: null,
     taskTitle: fs.taskName,
   });
+  const applyDescription = useCallback(
+    (value: string) => {
+      const input = fs.descriptionInputRef.current;
+      if (!input) {
+        return false;
+      }
+      input.setValue(value);
+      const applied = input.getValue() === value;
+      if (applied) {
+        fs.setHasDescription(true);
+      }
+      return applied;
+    },
+    [fs],
+  );
+  const promptDelivery = usePromptResultDelivery({
+    getCurrent: () => fs.descriptionInputRef.current?.getValue() ?? null,
+    apply: applyDescription,
+  });
   const onEnhance = useCallback(() => {
-    const current = fs.descriptionInputRef.current?.getValue()?.trim();
-    if (!current) return;
-    enhancePrompt(current, (enhanced) => {
-      fs.descriptionInputRef.current?.setValue(enhanced);
-      fs.setHasDescription(true);
+    const current = fs.descriptionInputRef.current?.getValue() ?? "";
+    if (!current.trim()) return;
+    void enhancePrompt(current, (result) => {
+      const inserted = promptDelivery.deliver(current, result);
+      if (inserted) {
+        toast({ description: PROMPT_INSERTED_MESSAGE, variant: "success" });
+      }
+      return inserted;
     });
-  }, [enhancePrompt, fs]);
-  return { onEnhance, isLoading: isEnhancingPrompt, isConfigured };
+  }, [enhancePrompt, fs.descriptionInputRef, promptDelivery, toast]);
+  return {
+    onEnhance,
+    isLoading: isEnhancingPrompt,
+    isConfigured,
+    pendingResult: promptDelivery.pendingResult,
+    onApplyPending: promptDelivery.applyPending,
+    onCopyPending: promptDelivery.copyPending,
+  };
 }
 
 function useJiraImportHandler(fs: DialogFormState) {

--- a/apps/web/components/task-create-dialog.tsx
+++ b/apps/web/components/task-create-dialog.tsx
@@ -264,11 +264,8 @@ function useEnhanceForDialog(fs: DialogFormState) {
         return false;
       }
       input.setValue(value);
-      const applied = input.getValue() === value;
-      if (applied) {
-        fs.setHasDescription(true);
-      }
-      return applied;
+      fs.setHasDescription(value.trim().length > 0);
+      return true;
     },
     [fs],
   );

--- a/apps/web/components/task-create-dialog.tsx
+++ b/apps/web/components/task-create-dialog.tsx
@@ -264,8 +264,11 @@ function useEnhanceForDialog(fs: DialogFormState) {
         return false;
       }
       input.setValue(value);
-      fs.setHasDescription(value.trim().length > 0);
-      return true;
+      const applied = input.getValue() === value;
+      if (applied) {
+        fs.setHasDescription(value.trim().length > 0);
+      }
+      return applied;
     },
     [fs],
   );

--- a/apps/web/components/task-create-dialog.tsx
+++ b/apps/web/components/task-create-dialog.tsx
@@ -250,7 +250,11 @@ function DialogFormBody(props: DialogFormBodyProps) {
   );
 }
 
-function useEnhanceForDialog(fs: DialogFormState) {
+function useEnhanceForDialog(
+  fs: DialogFormState,
+  taskId: string | null | undefined,
+  open: boolean,
+) {
   const isConfigured = useIsUtilityConfigured();
   const { toast } = useToast();
   const { enhancePrompt, isEnhancingPrompt } = useUtilityAgentGenerator({
@@ -273,14 +277,16 @@ function useEnhanceForDialog(fs: DialogFormState) {
     [fs],
   );
   const promptDelivery = usePromptResultDelivery({
+    scopeKey: `task-create:${open}:${fs.openCycle}:${taskId ?? ""}`,
     getCurrent: () => fs.descriptionInputRef.current?.getValue() ?? null,
     apply: applyDescription,
   });
   const onEnhance = useCallback(() => {
     const current = fs.descriptionInputRef.current?.getValue() ?? "";
     if (!current.trim()) return;
+    const generation = promptDelivery.captureScope();
     void enhancePrompt(current, (result) => {
-      const inserted = promptDelivery.deliver(current, result);
+      const inserted = promptDelivery.deliver(current, result, generation);
       if (inserted) {
         toast({ description: PROMPT_INSERTED_MESSAGE, variant: "success" });
       }
@@ -504,7 +510,7 @@ export function useTaskCreateDialogSetup(
     taskCreateLastUsed,
     userSettingsLoaded,
     guardedHandleSubmit,
-    enhance: useEnhanceForDialog(fs),
+    enhance: useEnhanceForDialog(fs, props.taskId, props.open),
     handleJiraImport: useJiraImportHandler(fs),
     handleLinearImport: useLinearImportHandler(fs),
   };

--- a/apps/web/components/task/chat/chat-input-body.tsx
+++ b/apps/web/components/task/chat/chat-input-body.tsx
@@ -237,7 +237,13 @@ export type ChatInputBodyProps = {
   addFiles: (files: File[]) => Promise<void>;
   contextAreaProps: ChatInputContextAreaProps;
   editorAreaProps: ChatInputEditorAreaProps;
+  promptResultRecovery?: React.ReactNode;
 };
+
+function PromptResultRecoveryArea({ children }: { children?: React.ReactNode }) {
+  if (!children) return null;
+  return <div className="mt-2">{children}</div>;
+}
 
 /** Glow class for the outer wrapper. The pulsing glow lives on the wrapper
  * (not the inner box) because the inner box has `overflow-hidden`, which would
@@ -263,6 +269,7 @@ export function ChatInputBody({
   addFiles,
   contextAreaProps,
   editorAreaProps,
+  promptResultRecovery,
 }: ChatInputBodyProps) {
   const [isDragging, setIsDragging] = useState(false);
 
@@ -349,6 +356,7 @@ export function ChatInputBody({
           />
         </div>
       </div>
+      <PromptResultRecoveryArea>{promptResultRecovery}</PromptResultRecoveryArea>
     </div>
   );
 }

--- a/apps/web/components/task/chat/chat-input-container.tsx
+++ b/apps/web/components/task/chat/chat-input-container.tsx
@@ -466,11 +466,13 @@ export const ChatInputContainer = forwardRef<ChatInputContainerHandle, ChatInput
         addFiles={s.addFiles}
         contextAreaProps={buildContextAreaProps(s, p)}
         promptResultRecovery={
-          <PromptResultRecovery
-            pendingResult={promptEnhancement.promptDelivery.pendingResult}
-            onApply={promptEnhancement.promptDelivery.applyPending}
-            onCopy={promptEnhancement.promptDelivery.copyPending}
-          />
+          promptEnhancement.promptDelivery.pendingResult ? (
+            <PromptResultRecovery
+              pendingResult={promptEnhancement.promptDelivery.pendingResult}
+              onApply={promptEnhancement.promptDelivery.applyPending}
+              onCopy={promptEnhancement.promptDelivery.copyPending}
+            />
+          ) : null
         }
         editorAreaProps={buildEditorAreaProps(s, p, {
           onEnhancePrompt: promptEnhancement.handleEnhancePrompt,

--- a/apps/web/components/task/chat/chat-input-container.tsx
+++ b/apps/web/components/task/chat/chat-input-container.tsx
@@ -19,6 +19,8 @@ import {
 import type { ContextItem } from "@/lib/types/context";
 import { useUtilityAgentGenerator } from "@/hooks/use-utility-agent-generator";
 import { useIsUtilityConfigured } from "@/hooks/use-is-utility-configured";
+import { usePromptResultDelivery } from "@/hooks/use-prompt-result-delivery";
+import { PromptResultRecovery } from "@/components/prompt-result-recovery";
 
 // Re-export ImageAttachment type for consumers
 export type { ImageAttachment } from "./image-attachment-preview";
@@ -319,17 +321,50 @@ function buildStoppedBannerProps(p: ChatInputContainerProps) {
   };
 }
 
-function applyEnhancedPromptToEditor(
-  inputRef: ContainerState["inputRef"],
-  result: { content: string },
-): boolean {
+function applyEnhancedPromptToEditor(inputRef: ContainerState["inputRef"], value: string): boolean {
   const input = inputRef.current;
   if (!input) {
     return false;
   }
 
-  input.setValue(result.content);
-  return true;
+  input.setValue(value);
+  return input.getValue() === value;
+}
+
+function useChatPromptEnhancement({
+  inputRef,
+  sessionId,
+  taskTitle,
+  taskDescription,
+}: {
+  inputRef: ContainerState["inputRef"];
+  sessionId: string | null;
+  taskTitle?: string;
+  taskDescription: string;
+}) {
+  const isUtilityConfigured = useIsUtilityConfigured();
+  const { enhancePrompt, isEnhancingPrompt } = useUtilityAgentGenerator({
+    sessionId,
+    taskTitle,
+    taskDescription,
+  });
+  const getCurrentEditorValue = useCallback(() => inputRef.current?.getValue() ?? null, [inputRef]);
+  const applyEnhancedPrompt = useCallback(
+    (nextValue: string) => applyEnhancedPromptToEditor(inputRef, nextValue),
+    [inputRef],
+  );
+  const promptDelivery = usePromptResultDelivery({
+    getCurrent: getCurrentEditorValue,
+    apply: applyEnhancedPrompt,
+  });
+  const handleEnhancePrompt = useCallback(() => {
+    const currentValue = getCurrentEditorValue();
+    if (currentValue === null) return;
+    if (!currentValue.trim()) return;
+    void enhancePrompt(currentValue, (result) => promptDelivery.deliver(currentValue, result));
+  }, [getCurrentEditorValue, enhancePrompt, promptDelivery]);
+
+  return { handleEnhancePrompt, isEnhancingPrompt, isUtilityConfigured, promptDelivery };
 }
 
 function insertVoiceTranscript(inputRef: ContainerState["inputRef"], text: string): void {
@@ -379,18 +414,12 @@ export const ChatInputContainer = forwardRef<ChatInputContainerHandle, ChatInput
       onSubmit: props.onSubmit,
     });
 
-    const isUtilityConfigured = useIsUtilityConfigured();
-    const { enhancePrompt, isEnhancingPrompt } = useUtilityAgentGenerator({
+    const promptEnhancement = useChatPromptEnhancement({
+      inputRef: s.inputRef,
       sessionId,
       taskTitle,
       taskDescription,
     });
-
-    const handleEnhancePrompt = useCallback(() => {
-      const currentValue = s.value?.trim();
-      if (!currentValue) return;
-      void enhancePrompt(currentValue, (result) => applyEnhancedPromptToEditor(s.inputRef, result));
-    }, [s.inputRef, s.value, enhancePrompt]);
 
     const handleVoiceTranscript = useCallback(
       (text: string) => {
@@ -436,10 +465,17 @@ export const ChatInputContainer = forwardRef<ChatInputContainerHandle, ChatInput
         needsRecovery={(props.needsRecovery ?? false) || executorUnavailable}
         addFiles={s.addFiles}
         contextAreaProps={buildContextAreaProps(s, p)}
+        promptResultRecovery={
+          <PromptResultRecovery
+            pendingResult={promptEnhancement.promptDelivery.pendingResult}
+            onApply={promptEnhancement.promptDelivery.applyPending}
+            onCopy={promptEnhancement.promptDelivery.copyPending}
+          />
+        }
         editorAreaProps={buildEditorAreaProps(s, p, {
-          onEnhancePrompt: handleEnhancePrompt,
-          isEnhancingPrompt,
-          isUtilityConfigured,
+          onEnhancePrompt: promptEnhancement.handleEnhancePrompt,
+          isEnhancingPrompt: promptEnhancement.isEnhancingPrompt,
+          isUtilityConfigured: promptEnhancement.isUtilityConfigured,
           onVoiceTranscript: handleVoiceTranscript,
           onVoiceAutoSend: handleVoiceAutoSend,
         })}

--- a/apps/web/components/task/chat/chat-input-container.tsx
+++ b/apps/web/components/task/chat/chat-input-container.tsx
@@ -319,6 +319,34 @@ function buildStoppedBannerProps(p: ChatInputContainerProps) {
   };
 }
 
+function applyEnhancedPromptToEditor(
+  inputRef: ContainerState["inputRef"],
+  result: { content: string },
+): boolean {
+  const input = inputRef.current;
+  if (!input) {
+    return false;
+  }
+
+  input.setValue(result.content);
+  return true;
+}
+
+function insertVoiceTranscript(inputRef: ContainerState["inputRef"], text: string): void {
+  const editor = inputRef.current;
+  if (!editor) return;
+
+  const trimmed = text.trim();
+  if (!trimmed) return;
+
+  const cursor = editor.getSelectionStart();
+  const current = editor.getValue();
+  const charBefore = cursor > 0 ? current.charAt(cursor - 1) : "";
+  const needsLeadingSpace = charBefore !== "" && !/\s/.test(charBefore);
+  const insert = needsLeadingSpace ? ` ${trimmed}` : trimmed;
+  editor.insertText(insert, cursor, cursor);
+}
+
 export const ChatInputContainer = forwardRef<ChatInputContainerHandle, ChatInputContainerProps>(
   function ChatInputContainer(props, ref) {
     const { sessionId, taskId, taskTitle, taskDescription, isAgentBusy, isStarting, isSending } =
@@ -361,31 +389,12 @@ export const ChatInputContainer = forwardRef<ChatInputContainerHandle, ChatInput
     const handleEnhancePrompt = useCallback(() => {
       const currentValue = s.value?.trim();
       if (!currentValue) return;
-      void enhancePrompt(currentValue, (result) => {
-        // Use setValue to directly update TipTap editor (handleChange only updates React state)
-        const input = s.inputRef.current;
-        if (!input) {
-          return false;
-        }
-        input.setValue(result.content);
-        return true;
-      });
-    }, [s, enhancePrompt]);
+      void enhancePrompt(currentValue, (result) => applyEnhancedPromptToEditor(s.inputRef, result));
+    }, [s.inputRef, s.value, enhancePrompt]);
 
     const handleVoiceTranscript = useCallback(
       (text: string) => {
-        const editor = s.inputRef.current;
-        if (!editor) return;
-        const trimmed = text.trim();
-        if (!trimmed) return;
-        const cursor = editor.getSelectionStart();
-        const current = editor.getValue();
-        // Prepend a space when inserting after existing non-whitespace content
-        // so transcripts flow naturally without running into the previous word.
-        const charBefore = cursor > 0 ? current.charAt(cursor - 1) : "";
-        const needsLeadingSpace = charBefore !== "" && !/\s/.test(charBefore);
-        const insert = needsLeadingSpace ? ` ${trimmed}` : trimmed;
-        editor.insertText(insert, cursor, cursor);
+        insertVoiceTranscript(s.inputRef, text);
       },
       [s.inputRef],
     );

--- a/apps/web/components/task/chat/chat-input-container.tsx
+++ b/apps/web/components/task/chat/chat-input-container.tsx
@@ -333,11 +333,13 @@ function applyEnhancedPromptToEditor(inputRef: ContainerState["inputRef"], value
 
 function useChatPromptEnhancement({
   inputRef,
+  taskId,
   sessionId,
   taskTitle,
   taskDescription,
 }: {
   inputRef: ContainerState["inputRef"];
+  taskId: string | null;
   sessionId: string | null;
   taskTitle?: string;
   taskDescription: string;
@@ -354,6 +356,7 @@ function useChatPromptEnhancement({
     [inputRef],
   );
   const promptDelivery = usePromptResultDelivery({
+    scopeKey: `chat:${taskId ?? ""}:${sessionId ?? ""}`,
     getCurrent: getCurrentEditorValue,
     apply: applyEnhancedPrompt,
   });
@@ -361,7 +364,10 @@ function useChatPromptEnhancement({
     const currentValue = getCurrentEditorValue();
     if (currentValue === null) return;
     if (!currentValue.trim()) return;
-    void enhancePrompt(currentValue, (result) => promptDelivery.deliver(currentValue, result));
+    const generation = promptDelivery.captureScope();
+    void enhancePrompt(currentValue, (result) =>
+      promptDelivery.deliver(currentValue, result, generation),
+    );
   }, [getCurrentEditorValue, enhancePrompt, promptDelivery]);
 
   return { handleEnhancePrompt, isEnhancingPrompt, isUtilityConfigured, promptDelivery };
@@ -416,6 +422,7 @@ export const ChatInputContainer = forwardRef<ChatInputContainerHandle, ChatInput
 
     const promptEnhancement = useChatPromptEnhancement({
       inputRef: s.inputRef,
+      taskId,
       sessionId,
       taskTitle,
       taskDescription,

--- a/apps/web/components/task/chat/chat-input-container.tsx
+++ b/apps/web/components/task/chat/chat-input-container.tsx
@@ -361,9 +361,14 @@ export const ChatInputContainer = forwardRef<ChatInputContainerHandle, ChatInput
     const handleEnhancePrompt = useCallback(() => {
       const currentValue = s.value?.trim();
       if (!currentValue) return;
-      enhancePrompt(currentValue, (enhanced) => {
+      void enhancePrompt(currentValue, (result) => {
         // Use setValue to directly update TipTap editor (handleChange only updates React state)
-        s.inputRef.current?.setValue(enhanced);
+        const input = s.inputRef.current;
+        if (!input) {
+          return false;
+        }
+        input.setValue(result.content);
+        return true;
       });
     }, [s, enhancePrompt]);
 

--- a/apps/web/components/task/new-session-dialog.test.tsx
+++ b/apps/web/components/task/new-session-dialog.test.tsx
@@ -1,0 +1,194 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockToast = vi.fn();
+const mockSummarize = vi.fn();
+
+const mockState = {
+  kanban: {
+    tasks: [{ id: "task-1", title: "Task title" }],
+  },
+  agentProfiles: {
+    items: [
+      {
+        id: "profile-1",
+        label: "Profile 1",
+        agent_name: "agent-1",
+        agent_id: "agent-id-1",
+        cli_passthrough: false,
+      },
+    ],
+  },
+  tasks: {
+    activeSessionId: "session-1",
+  },
+  taskSessions: {
+    items: {
+      "session-1": {
+        id: "session-1",
+        agent_profile_id: "profile-1",
+        executor_id: "executor-1",
+      },
+    },
+  },
+  sessionWorktreesBySessionId: {
+    itemsBySessionId: {},
+  },
+  worktrees: {
+    items: {},
+  },
+  messages: {
+    bySession: {
+      "session-1": [{ id: "message-1", author_type: "user", content: "seed prompt" }],
+    },
+  },
+  executors: {
+    items: [{ id: "executor-1", name: "Executor 1" }],
+  },
+};
+
+vi.mock("@kandev/ui/dialog", () => ({
+  Dialog: ({ open, children }: { open: boolean; children: React.ReactNode }) =>
+    open ? <div>{children}</div> : null,
+  DialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/state-provider", () => ({
+  useAppStore: (selector: (state: typeof mockState) => unknown) => selector(mockState),
+}));
+
+vi.mock("@/components/toast-provider", () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
+
+vi.mock("@/lib/state/dockview-store", () => ({
+  useDockviewStore: {
+    getState: () => ({ api: null, centerGroupId: "center-group" }),
+  },
+}));
+
+vi.mock("@/lib/state/dockview-panel-actions", () => ({
+  addSessionPanel: vi.fn(),
+}));
+
+vi.mock("@/components/task-create-dialog-selectors", () => ({
+  AgentSelector: () => null,
+}));
+
+vi.mock("@/components/task-create-dialog-options", () => ({
+  useAgentProfileOptions: (profiles: Array<{ id: string; label: string }>) =>
+    profiles.map((profile) => ({ value: profile.id, label: profile.label })),
+}));
+
+vi.mock("@/hooks/use-summarize-session", () => ({
+  useSummarizeSession: () => ({
+    summarize: mockSummarize,
+    isSummarizing: false,
+  }),
+}));
+
+vi.mock("@/hooks/use-task-sessions", () => ({
+  useTaskSessions: () => ({
+    sessions: [],
+    loadSessions: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/domains/settings/use-remote-auth-specs", () => ({
+  useRemoteAuthSpecs: () => ({
+    specs: [],
+    loaded: true,
+  }),
+}));
+
+vi.mock("@/hooks/domains/session/use-task-executor-profile", () => ({
+  useTaskExecutorProfile: () => null,
+}));
+
+vi.mock("@/hooks/use-is-utility-configured", () => ({
+  useIsUtilityConfigured: () => true,
+}));
+
+vi.mock("@/hooks/use-utility-agent-generator", () => ({
+  useUtilityAgentGenerator: () => ({
+    enhancePrompt: vi.fn(),
+    isEnhancingPrompt: false,
+  }),
+}));
+
+vi.mock("@/components/enhance-prompt-button", () => ({
+  EnhancePromptButton: () => null,
+}));
+
+vi.mock("./session-dialog-shared", () => ({
+  EnvironmentBadges: () => null,
+  AttachButton: () => null,
+  ContextSelect: ({ onValueChange }: { onValueChange: (value: string) => void }) => (
+    <div>
+      <button type="button" onClick={() => void onValueChange("copy_prompt")}>
+        Copy initial prompt
+      </button>
+    </div>
+  ),
+  useDialogAttachments: () => ({
+    attachments: [],
+    isDragging: false,
+    fileInputRef: { current: null },
+    handleRemoveAttachment: vi.fn(),
+    handlePaste: vi.fn(),
+    handleDragOver: vi.fn(),
+    handleDragLeave: vi.fn(),
+    handleDrop: vi.fn(),
+    handleAttachClick: vi.fn(),
+    handleFileInputChange: vi.fn(),
+  }),
+  toContextItems: () => [],
+}));
+
+import { NewSessionDialog } from "./new-session-dialog";
+
+describe("NewSessionDialog", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSummarize.mockResolvedValue({ summary: "summary text" });
+  });
+
+  it("copies the initial prompt on the first copy_prompt action after opening", async () => {
+    render(<NewSessionDialog open={true} onOpenChange={vi.fn()} taskId="task-1" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy initial prompt" }));
+
+    await waitFor(() =>
+      expect(
+        (screen.getByPlaceholderText("What should the agent work on?") as HTMLTextAreaElement)
+          .value,
+      ).toBe("seed prompt"),
+    );
+  });
+
+  it("writes the handoff summary into the fresh-open dialog prompt", async () => {
+    render(
+      <NewSessionDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        taskId="task-1"
+        handoff={{ sourceSessionId: "session-9", targetProfileId: "profile-1" }}
+      />,
+    );
+
+    await waitFor(() => expect(mockSummarize).toHaveBeenCalledWith("session-9"));
+    await waitFor(() =>
+      expect(
+        (screen.getByPlaceholderText("What should the agent work on?") as HTMLTextAreaElement)
+          .value,
+      ).toBe("summary text"),
+    );
+  });
+});

--- a/apps/web/components/task/new-session-dialog.tsx
+++ b/apps/web/components/task/new-session-dialog.tsx
@@ -18,6 +18,7 @@ import { useTaskExecutorProfile } from "@/hooks/domains/session/use-task-executo
 import { isAgentConfiguredOnExecutor } from "@/lib/agent-executor-compat";
 import type { AgentProfileOption } from "@/lib/state/slices";
 import type { ExecutorProfile } from "@/lib/types/http";
+import { usePromptResultDelivery } from "@/hooks/use-prompt-result-delivery";
 import { buildHandoffInitialState, type HandoffPreset } from "./handoff-types";
 import { useIsUtilityConfigured } from "@/hooks/use-is-utility-configured";
 import { useUtilityAgentGenerator } from "@/hooks/use-utility-agent-generator";
@@ -166,25 +167,50 @@ function useHandoffAutoSummarize(
   }, [handoff, contextValue, onContextChange]);
 }
 
-function useSessionPromptEnhancer(
+export function useSessionPromptController(
   promptRef: RefObject<HTMLTextAreaElement | null>,
+  promptValue: string,
+  setPromptValue: (value: string) => void,
   setHasPrompt: (value: boolean) => void,
 ) {
+  const { toast } = useToast();
   const { enhancePrompt, isEnhancingPrompt } = useUtilityAgentGenerator({ sessionId: null });
+  const latestPromptValueRef = useRef(promptValue);
+  latestPromptValueRef.current = promptValue;
+  const promptResultDelivery = usePromptResultDelivery({
+    getCurrent: () => (promptRef.current ? latestPromptValueRef.current.trim() : null),
+    apply: (value) => {
+      if (!promptRef.current) {
+        return false;
+      }
 
-  const handleEnhancePrompt = useCallback(() => {
-    const current = promptRef.current?.value?.trim();
+      setPromptValue(value);
+      setHasPrompt(value.trim().length > 0);
+      return true;
+    },
+  });
+
+  const handleEnhancePrompt = useCallback(async () => {
+    const current = latestPromptValueRef.current.trim();
     if (!current) return;
 
-    enhancePrompt(current, (enhanced) => {
-      if (promptRef.current) {
-        promptRef.current.value = enhanced;
-        setHasPrompt(true);
+    await enhancePrompt(current, (enhanced) => {
+      const delivered = promptResultDelivery.deliver(current, enhanced);
+      if (delivered) {
+        toast({ description: "Enhanced prompt applied.", variant: "success" });
       }
-    });
-  }, [enhancePrompt, promptRef, setHasPrompt]);
 
-  return { handleEnhancePrompt, isEnhancingPrompt };
+      return delivered;
+    });
+  }, [enhancePrompt, promptResultDelivery, toast]);
+
+  return {
+    handleEnhancePrompt,
+    isEnhancingPrompt,
+    pendingResult: promptResultDelivery.pendingResult,
+    applyPending: promptResultDelivery.applyPending,
+    copyPending: promptResultDelivery.copyPending,
+  };
 }
 
 function shouldDisableSubmit(
@@ -338,6 +364,22 @@ function NewSessionForm({
   const [hasPrompt, setHasPrompt] = useState(false);
   const [isCreating, setIsCreating] = useState(false);
   const promptRef = useRef<HTMLTextAreaElement>(null);
+  const [promptValue, setPromptValue] = useState("");
+  const controlledPromptRef = useMemo<RefObject<HTMLTextAreaElement | null>>(
+    () => ({
+      current: promptRef.current
+        ? ({
+            get value() {
+              return promptValue;
+            },
+            set value(value: string) {
+              setPromptValue(value);
+            },
+          } as HTMLTextAreaElement)
+        : null,
+    }),
+    [promptValue],
+  );
   const busySignal = Number(isCreating) + Number(isSummarizing);
   const isBusyState = busySignal > 0;
   const {
@@ -365,12 +407,20 @@ function NewSessionForm({
     selectedProfileId,
     setSelectedProfileId,
   });
-  const { handleEnhancePrompt, isEnhancingPrompt } = useSessionPromptEnhancer(
+  const {
+    handleEnhancePrompt,
+    isEnhancingPrompt,
+    pendingResult,
+    applyPending,
+    copyPending,
+  } = useSessionPromptController(
     promptRef,
+    promptValue,
+    setPromptValue,
     setHasPrompt,
   );
   const handleContextChange = useSessionContextChange({
-    promptRef,
+    promptRef: controlledPromptRef,
     initialPrompt,
     summarize,
     toast,
@@ -380,7 +430,7 @@ function NewSessionForm({
   useHandoffAutoSummarize(handoff, handoffInitial?.contextValue ?? "blank", handleContextChange);
 
   const handleSubmit = useSessionLaunchSubmit({
-    promptRef,
+    promptRef: controlledPromptRef,
     taskId,
     selectedProfileId,
     executorId,
@@ -425,6 +475,7 @@ function NewSessionForm({
       />
       <SessionPromptField
         promptRef={promptRef}
+        promptValue={promptValue}
         contextItems={contextItems}
         isBusy={isBusyState}
         isDragging={isDragging}
@@ -433,12 +484,18 @@ function NewSessionForm({
         hasProfiles={profileSelection.hasProfiles}
         isUtilityConfigured={isUtilityConfigured}
         isEnhancingPrompt={isEnhancingPrompt}
+        pendingResult={pendingResult}
         fileInputRef={fileInputRef}
-        onPromptInput={() => setHasPrompt(!!promptRef.current?.value?.trim())}
+        onPromptChange={(value) => {
+          setPromptValue(value);
+          setHasPrompt(value.trim().length > 0);
+        }}
         onPaste={handlePaste}
         onSubmit={handleSubmit}
         onAttachClick={handleAttachClick}
         onEnhancePrompt={handleEnhancePrompt}
+        onApplyPending={applyPending}
+        onCopyPending={copyPending}
         onDragOver={handleDragOver}
         onDragLeave={handleDragLeave}
         onDrop={handleDrop}

--- a/apps/web/components/task/new-session-dialog.tsx
+++ b/apps/web/components/task/new-session-dialog.tsx
@@ -407,18 +407,8 @@ function NewSessionForm({
     selectedProfileId,
     setSelectedProfileId,
   });
-  const {
-    handleEnhancePrompt,
-    isEnhancingPrompt,
-    pendingResult,
-    applyPending,
-    copyPending,
-  } = useSessionPromptController(
-    promptRef,
-    promptValue,
-    setPromptValue,
-    setHasPrompt,
-  );
+  const { handleEnhancePrompt, isEnhancingPrompt, pendingResult, applyPending, copyPending } =
+    useSessionPromptController(promptRef, promptValue, setPromptValue, setHasPrompt);
   const handleContextChange = useSessionContextChange({
     promptRef: controlledPromptRef,
     initialPrompt,

--- a/apps/web/components/task/new-session-dialog.tsx
+++ b/apps/web/components/task/new-session-dialog.tsx
@@ -178,7 +178,7 @@ export function useSessionPromptController(
   const latestPromptValueRef = useRef(promptValue);
   latestPromptValueRef.current = promptValue;
   const promptResultDelivery = usePromptResultDelivery({
-    getCurrent: () => (promptRef.current ? latestPromptValueRef.current.trim() : null),
+    getCurrent: () => latestPromptValueRef.current,
     apply: (value) => {
       if (!promptRef.current) {
         return false;
@@ -191,8 +191,8 @@ export function useSessionPromptController(
   });
 
   const handleEnhancePrompt = useCallback(async () => {
-    const current = latestPromptValueRef.current.trim();
-    if (!current) return;
+    const current = latestPromptValueRef.current;
+    if (!current.trim()) return;
 
     await enhancePrompt(current, (enhanced) => {
       const delivered = promptResultDelivery.deliver(current, enhanced);
@@ -365,20 +365,26 @@ function NewSessionForm({
   const [isCreating, setIsCreating] = useState(false);
   const promptRef = useRef<HTMLTextAreaElement>(null);
   const [promptValue, setPromptValue] = useState("");
+  const latestPromptValueRef = useRef(promptValue);
+  latestPromptValueRef.current = promptValue;
   const controlledPromptRef = useMemo<RefObject<HTMLTextAreaElement | null>>(
     () => ({
-      current: promptRef.current
-        ? ({
-            get value() {
-              return promptValue;
-            },
-            set value(value: string) {
-              setPromptValue(value);
-            },
-          } as HTMLTextAreaElement)
-        : null,
+      get current() {
+        if (!promptRef.current) {
+          return null;
+        }
+
+        return {
+          get value() {
+            return latestPromptValueRef.current;
+          },
+          set value(value: string) {
+            setPromptValue(value);
+          },
+        } as HTMLTextAreaElement;
+      },
     }),
-    [promptValue],
+    [],
   );
   const busySignal = Number(isCreating) + Number(isSummarizing);
   const isBusyState = busySignal > 0;

--- a/apps/web/components/task/new-session-dialog.tsx
+++ b/apps/web/components/task/new-session-dialog.tsx
@@ -172,12 +172,14 @@ export function useSessionPromptController(
   promptValue: string,
   setPromptValue: (value: string) => void,
   setHasPrompt: (value: boolean) => void,
+  taskId: string,
 ) {
   const { toast } = useToast();
   const { enhancePrompt, isEnhancingPrompt } = useUtilityAgentGenerator({ sessionId: null });
   const latestPromptValueRef = useRef(promptValue);
   latestPromptValueRef.current = promptValue;
   const promptResultDelivery = usePromptResultDelivery({
+    scopeKey: `new-session:${taskId}`,
     getCurrent: () => latestPromptValueRef.current,
     apply: (value) => {
       if (!promptRef.current) {
@@ -193,9 +195,10 @@ export function useSessionPromptController(
   const handleEnhancePrompt = useCallback(async () => {
     const current = latestPromptValueRef.current;
     if (!current.trim()) return;
+    const generation = promptResultDelivery.captureScope();
 
     await enhancePrompt(current, (enhanced) => {
-      const delivered = promptResultDelivery.deliver(current, enhanced);
+      const delivered = promptResultDelivery.deliver(current, enhanced, generation);
       if (delivered) {
         toast({ description: "Enhanced prompt applied.", variant: "success" });
       }
@@ -414,7 +417,7 @@ function NewSessionForm({
     setSelectedProfileId,
   });
   const { handleEnhancePrompt, isEnhancingPrompt, pendingResult, applyPending, copyPending } =
-    useSessionPromptController(promptRef, promptValue, setPromptValue, setHasPrompt);
+    useSessionPromptController(promptRef, promptValue, setPromptValue, setHasPrompt, taskId);
   const handleContextChange = useSessionContextChange({
     promptRef: controlledPromptRef,
     initialPrompt,
@@ -573,8 +576,8 @@ export function NewSessionDialog({
   const executorProfile = useTaskExecutorProfile(taskId, open);
   const handoffLabel = handoffProfileLabel(agentProfiles, handoff);
   const formKey = handoff
-    ? `${open}-${handoff.sourceSessionId}-${handoff.targetProfileId}`
-    : `${open}`;
+    ? `${taskId}-${open}-${handoff.sourceSessionId}-${handoff.targetProfileId}`
+    : `${taskId}-${open}`;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>

--- a/apps/web/components/task/new-session-form-prompt.test.tsx
+++ b/apps/web/components/task/new-session-form-prompt.test.tsx
@@ -44,10 +44,17 @@ const GENERATED_RESULT = {
 } satisfies UtilityGenerationResult;
 
 function useSessionPromptHarness(initialPrompt = "original prompt") {
-  const promptRef = useRef<HTMLTextAreaElement | null>({ value: initialPrompt } as HTMLTextAreaElement);
+  const promptRef = useRef<HTMLTextAreaElement | null>({
+    value: initialPrompt,
+  } as HTMLTextAreaElement);
   const [promptValue, setPromptValue] = useState(initialPrompt);
   const [hasPrompt, setHasPrompt] = useState(Boolean(initialPrompt.trim()));
-  const controller = useSessionPromptController(promptRef, promptValue, setPromptValue, setHasPrompt);
+  const controller = useSessionPromptController(
+    promptRef,
+    promptValue,
+    setPromptValue,
+    setHasPrompt,
+  );
 
   return {
     ...controller,

--- a/apps/web/components/task/new-session-form-prompt.test.tsx
+++ b/apps/web/components/task/new-session-form-prompt.test.tsx
@@ -55,6 +55,7 @@ function useSessionPromptHarness(initialPrompt = ORIGINAL_PROMPT, hasTarget = tr
     promptValue,
     setPromptValue,
     setHasPrompt,
+    "task-1",
   );
 
   return {

--- a/apps/web/components/task/new-session-form-prompt.test.tsx
+++ b/apps/web/components/task/new-session-form-prompt.test.tsx
@@ -42,11 +42,12 @@ const GENERATED_RESULT = {
   callId: "call-123",
   durationMs: 1_200,
 } satisfies UtilityGenerationResult;
+const ORIGINAL_PROMPT = "original prompt";
 
-function useSessionPromptHarness(initialPrompt = "original prompt") {
-  const promptRef = useRef<HTMLTextAreaElement | null>({
-    value: initialPrompt,
-  } as HTMLTextAreaElement);
+function useSessionPromptHarness(initialPrompt = ORIGINAL_PROMPT, hasTarget = true) {
+  const promptRef = useRef<HTMLTextAreaElement | null>(
+    hasTarget ? ({ value: initialPrompt } as HTMLTextAreaElement) : null,
+  );
   const [promptValue, setPromptValue] = useState(initialPrompt);
   const [hasPrompt, setHasPrompt] = useState(Boolean(initialPrompt.trim()));
   const controller = useSessionPromptController(
@@ -77,7 +78,7 @@ describe("SessionPromptField", () => {
     const { rerender } = render(
       <SessionPromptField
         promptRef={{ current: null }}
-        promptValue="original prompt"
+        promptValue={ORIGINAL_PROMPT}
         contextItems={[]}
         isBusy={false}
         isDragging={false}
@@ -107,7 +108,7 @@ describe("SessionPromptField", () => {
     rerender(
       <SessionPromptField
         promptRef={{ current: null }}
-        promptValue="original prompt"
+        promptValue={ORIGINAL_PROMPT}
         contextItems={[]}
         isBusy={false}
         isDragging={false}
@@ -159,7 +160,7 @@ describe("useSessionPromptController", () => {
       await result.current.handleEnhancePrompt();
     });
 
-    expect(result.current.promptValue).toBe("improved prompt");
+    expect(result.current.promptValue).toBe(GENERATED_RESULT.content);
     expect(result.current.hasPrompt).toBe(true);
     expect(result.current.pendingResult).toBeNull();
     expect(mockToast).toHaveBeenCalledWith(
@@ -196,7 +197,7 @@ describe("useSessionPromptController", () => {
       result.current.applyPending();
     });
 
-    expect(result.current.promptValue).toBe("improved prompt");
+    expect(result.current.promptValue).toBe(GENERATED_RESULT.content);
     expect(result.current.pendingResult).toBeNull();
   });
 
@@ -228,5 +229,24 @@ describe("useSessionPromptController", () => {
 
     expect(result.current.promptValue).toBe(editedPrompt);
     expect(result.current.pendingResult).toEqual(GENERATED_RESULT);
+  });
+
+  it("retains the enhanced prompt when the target is unavailable", async () => {
+    mockEnhancePrompt.mockImplementation(
+      async (_source: string, deliver: (result: UtilityGenerationResult) => Promise<boolean>) =>
+        deliver(GENERATED_RESULT),
+    );
+
+    const { result } = renderHook(() => useSessionPromptHarness(ORIGINAL_PROMPT, false));
+
+    await act(async () => {
+      await result.current.handleEnhancePrompt();
+    });
+
+    expect(result.current.promptValue).toBe(ORIGINAL_PROMPT);
+    expect(result.current.pendingResult).toEqual(GENERATED_RESULT);
+    expect(mockToast).not.toHaveBeenCalledWith(
+      expect.objectContaining({ description: "Enhanced prompt applied.", variant: "success" }),
+    );
   });
 });

--- a/apps/web/components/task/new-session-form-prompt.test.tsx
+++ b/apps/web/components/task/new-session-form-prompt.test.tsx
@@ -199,4 +199,34 @@ describe("useSessionPromptController", () => {
     expect(result.current.promptValue).toBe("improved prompt");
     expect(result.current.pendingResult).toBeNull();
   });
+
+  it("preserves exact source text and retains the result after a whitespace-only edit", async () => {
+    let deliverResult: ((result: UtilityGenerationResult) => Promise<boolean>) | undefined;
+    mockEnhancePrompt.mockImplementation(
+      async (_source: string, deliver: (result: UtilityGenerationResult) => Promise<boolean>) => {
+        deliverResult = deliver;
+      },
+    );
+
+    const initialPrompt = "  original prompt  ";
+    const editedPrompt = "  original prompt   ";
+    const { result } = renderHook(() => useSessionPromptHarness(initialPrompt));
+
+    await act(async () => {
+      await result.current.handleEnhancePrompt();
+    });
+
+    expect(mockEnhancePrompt).toHaveBeenCalledWith(initialPrompt, expect.any(Function));
+
+    act(() => {
+      result.current.setPromptValue(editedPrompt);
+    });
+
+    await act(async () => {
+      await deliverResult?.(GENERATED_RESULT);
+    });
+
+    expect(result.current.promptValue).toBe(editedPrompt);
+    expect(result.current.pendingResult).toEqual(GENERATED_RESULT);
+  });
 });

--- a/apps/web/components/task/new-session-form-prompt.test.tsx
+++ b/apps/web/components/task/new-session-form-prompt.test.tsx
@@ -1,0 +1,195 @@
+import { act, fireEvent, render, renderHook, screen } from "@testing-library/react";
+import { useRef, useState } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { UtilityGenerationResult } from "@/hooks/use-utility-agent-generator";
+
+const mockToast = vi.fn();
+const mockEnhancePrompt = vi.fn();
+
+vi.mock("@/components/toast-provider", () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
+
+vi.mock("@/hooks/use-utility-agent-generator", () => ({
+  useUtilityAgentGenerator: () => ({
+    enhancePrompt: mockEnhancePrompt,
+    isEnhancingPrompt: false,
+  }),
+}));
+
+vi.mock("@/components/enhance-prompt-button", () => ({
+  EnhancePromptButton: ({ onClick }: { onClick: () => void }) => (
+    <button type="button" onClick={onClick}>
+      Enhance
+    </button>
+  ),
+}));
+
+vi.mock("./session-dialog-shared", () => ({
+  AttachButton: ({ onClick }: { onClick: () => void }) => (
+    <button type="button" onClick={onClick}>
+      Attach
+    </button>
+  ),
+}));
+
+import { SessionPromptField } from "./new-session-form-prompt";
+import { useSessionPromptController } from "./new-session-dialog";
+
+const GENERATED_RESULT = {
+  content: "improved prompt",
+  callId: "call-123",
+  durationMs: 1_200,
+} satisfies UtilityGenerationResult;
+
+function useSessionPromptHarness(initialPrompt = "original prompt") {
+  const promptRef = useRef<HTMLTextAreaElement | null>({ value: initialPrompt } as HTMLTextAreaElement);
+  const [promptValue, setPromptValue] = useState(initialPrompt);
+  const [hasPrompt, setHasPrompt] = useState(Boolean(initialPrompt.trim()));
+  const controller = useSessionPromptController(promptRef, promptValue, setPromptValue, setHasPrompt);
+
+  return {
+    ...controller,
+    promptRef,
+    promptValue,
+    setPromptValue,
+    hasPrompt,
+  };
+}
+
+describe("SessionPromptField", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows inline recovery controls only when an enhanced prompt is pending", async () => {
+    const onApplyPending = vi.fn();
+    const onCopyPending = vi.fn();
+
+    const { rerender } = render(
+      <SessionPromptField
+        promptRef={{ current: null }}
+        promptValue="original prompt"
+        contextItems={[]}
+        isBusy={false}
+        isDragging={false}
+        isSummarizing={false}
+        hasPrompt={true}
+        hasProfiles={true}
+        isUtilityConfigured={true}
+        isEnhancingPrompt={false}
+        pendingResult={null}
+        fileInputRef={{ current: null }}
+        onPromptChange={vi.fn()}
+        onPaste={vi.fn()}
+        onSubmit={vi.fn()}
+        onAttachClick={vi.fn()}
+        onEnhancePrompt={vi.fn()}
+        onApplyPending={onApplyPending}
+        onCopyPending={onCopyPending}
+        onDragOver={vi.fn()}
+        onDragLeave={vi.fn()}
+        onDrop={vi.fn()}
+        onFileInputChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByTestId("prompt-result-recovery")).toBeNull();
+
+    rerender(
+      <SessionPromptField
+        promptRef={{ current: null }}
+        promptValue="original prompt"
+        contextItems={[]}
+        isBusy={false}
+        isDragging={false}
+        isSummarizing={false}
+        hasPrompt={true}
+        hasProfiles={true}
+        isUtilityConfigured={true}
+        isEnhancingPrompt={false}
+        pendingResult={GENERATED_RESULT}
+        fileInputRef={{ current: null }}
+        onPromptChange={vi.fn()}
+        onPaste={vi.fn()}
+        onSubmit={vi.fn()}
+        onAttachClick={vi.fn()}
+        onEnhancePrompt={vi.fn()}
+        onApplyPending={onApplyPending}
+        onCopyPending={onCopyPending}
+        onDragOver={vi.fn()}
+        onDragLeave={vi.fn()}
+        onDrop={vi.fn()}
+        onFileInputChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("prompt-result-recovery")).not.toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+    fireEvent.click(screen.getByRole("button", { name: "Copy" }));
+
+    expect(onApplyPending).toHaveBeenCalledTimes(1);
+    expect(onCopyPending).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("useSessionPromptController", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("applies the enhanced prompt immediately when the source text is unchanged", async () => {
+    mockEnhancePrompt.mockImplementation(
+      async (_source: string, deliver: (result: UtilityGenerationResult) => Promise<boolean>) =>
+        deliver(GENERATED_RESULT),
+    );
+
+    const { result } = renderHook(() => useSessionPromptHarness());
+
+    await act(async () => {
+      await result.current.handleEnhancePrompt();
+    });
+
+    expect(result.current.promptValue).toBe("improved prompt");
+    expect(result.current.hasPrompt).toBe(true);
+    expect(result.current.pendingResult).toBeNull();
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({ description: "Enhanced prompt applied.", variant: "success" }),
+    );
+  });
+
+  it("retains the enhanced prompt when the user edits the text before delivery and applies it on demand", async () => {
+    let deliverResult: ((result: UtilityGenerationResult) => Promise<boolean>) | undefined;
+    mockEnhancePrompt.mockImplementation(
+      async (_source: string, deliver: (result: UtilityGenerationResult) => Promise<boolean>) => {
+        deliverResult = deliver;
+      },
+    );
+
+    const { result } = renderHook(() => useSessionPromptHarness());
+
+    await act(async () => {
+      await result.current.handleEnhancePrompt();
+    });
+
+    act(() => {
+      result.current.setPromptValue("edited prompt");
+    });
+
+    await act(async () => {
+      await deliverResult?.(GENERATED_RESULT);
+    });
+
+    expect(result.current.promptValue).toBe("edited prompt");
+    expect(result.current.pendingResult).toEqual(GENERATED_RESULT);
+
+    act(() => {
+      result.current.applyPending();
+    });
+
+    expect(result.current.promptValue).toBe("improved prompt");
+    expect(result.current.pendingResult).toBeNull();
+  });
+});

--- a/apps/web/components/task/new-session-form-prompt.tsx
+++ b/apps/web/components/task/new-session-form-prompt.tsx
@@ -3,13 +3,16 @@
 import type { RefObject } from "react";
 import { Textarea } from "@kandev/ui/textarea";
 import { IconLoader2 } from "@tabler/icons-react";
+import { PromptResultRecovery } from "@/components/prompt-result-recovery";
 import { EnhancePromptButton } from "@/components/enhance-prompt-button";
+import type { UtilityGenerationResult } from "@/hooks/use-utility-agent-generator";
 import { ContextZone } from "./chat/context-items/context-zone";
 import { AttachButton } from "./session-dialog-shared";
 import type { ContextItem } from "@/lib/types/context";
 
 type SessionPromptFieldProps = {
   promptRef: RefObject<HTMLTextAreaElement | null>;
+  promptValue: string;
   contextItems: ContextItem[];
   isBusy: boolean;
   isDragging: boolean;
@@ -18,12 +21,15 @@ type SessionPromptFieldProps = {
   hasProfiles: boolean;
   isUtilityConfigured: boolean;
   isEnhancingPrompt: boolean;
+  pendingResult: UtilityGenerationResult | null;
   fileInputRef: RefObject<HTMLInputElement | null>;
-  onPromptInput: () => void;
+  onPromptChange: (value: string) => void;
   onPaste: (e: React.ClipboardEvent<HTMLTextAreaElement>) => void;
   onSubmit: (e: React.FormEvent) => void;
   onAttachClick: () => void;
   onEnhancePrompt: () => void;
+  onApplyPending: () => void;
+  onCopyPending: () => Promise<void> | void;
   onDragOver: (e: React.DragEvent) => void;
   onDragLeave: (e: React.DragEvent) => void;
   onDrop: (e: React.DragEvent) => void;
@@ -32,6 +38,7 @@ type SessionPromptFieldProps = {
 
 export function SessionPromptField({
   promptRef,
+  promptValue,
   contextItems,
   isBusy,
   isDragging,
@@ -40,12 +47,15 @@ export function SessionPromptField({
   hasProfiles,
   isUtilityConfigured,
   isEnhancingPrompt,
+  pendingResult,
   fileInputRef,
-  onPromptInput,
+  onPromptChange,
   onPaste,
   onSubmit,
   onAttachClick,
   onEnhancePrompt,
+  onApplyPending,
+  onCopyPending,
   onDragOver,
   onDragLeave,
   onDrop,
@@ -62,11 +72,12 @@ export function SessionPromptField({
         <ContextZone items={contextItems} />
         <Textarea
           ref={promptRef}
+          value={promptValue}
           placeholder="What should the agent work on?"
           className="min-w-0 max-w-full field-sizing-fixed wrap-anywhere border-0 focus-visible:ring-0 focus-visible:ring-offset-0 min-h-[120px] max-h-[240px] resize-none overflow-auto text-[13px]"
           autoFocus
           disabled={isBusy}
-          onInput={onPromptInput}
+          onChange={(event) => onPromptChange(event.target.value)}
           onPaste={onPaste}
           onKeyDown={(e) => {
             if (
@@ -98,6 +109,11 @@ export function SessionPromptField({
           tabIndex={-1}
         />
       </div>
+      <PromptResultRecovery
+        pendingResult={pendingResult}
+        onApply={onApplyPending}
+        onCopy={onCopyPending}
+      />
       {isDragging && (
         <div className="absolute inset-0 flex items-center justify-center bg-primary/10 border-2 border-dashed border-primary rounded-md pointer-events-none">
           <span className="text-sm text-primary font-medium">Drop files here</span>

--- a/apps/web/components/task/new-subtask-dialog.tsx
+++ b/apps/web/components/task/new-subtask-dialog.tsx
@@ -358,6 +358,8 @@ function NewSubtaskForm({
         setPromptValue(value);
         setHasPrompt(value.trim().length > 0);
       },
+      onApplyPending: promptZone.applyPending,
+      onCopyPending: promptZone.copyPending,
       onSubmitShortcut: handleSubmit,
     },
     isCreating,

--- a/apps/web/components/task/new-subtask-dialog.tsx
+++ b/apps/web/components/task/new-subtask-dialog.tsx
@@ -298,6 +298,7 @@ function NewSubtaskForm({
   const executorProfileOptions = useExecutorProfileOptions(allExecutorProfiles);
   useExecutorDefault(allExecutorProfiles, fs.executorProfileId, fs.setExecutorProfileId);
   const promptZone = useSubtaskPromptZone({
+    parentTaskId,
     taskTitle: title,
     inputDisabled: isCreating || isSummarizing,
     contextValue,
@@ -421,7 +422,7 @@ export function NewSubtaskDialog({
           </DialogTitle>
         </DialogHeader>
         <NewSubtaskForm
-          key={`${open}`}
+          key={`${parentTaskId}-${open}`}
           parentTaskId={parentTaskId}
           defaultTitle={defaultTitle}
           defaultProfileId={currentSession?.agent_profile_id ?? ""}

--- a/apps/web/components/task/new-subtask-dialog.tsx
+++ b/apps/web/components/task/new-subtask-dialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
+import type { RefObject } from "react";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@kandev/ui/dialog";
 import { useAppStore } from "@/components/state-provider";
 import { useToast } from "@/components/toast-provider";
@@ -169,33 +170,70 @@ function useContextChangeHandler(opts: {
   setContextValue: (v: string) => void;
   setHasPrompt: (v: boolean) => void;
   promptRef: React.RefObject<HTMLTextAreaElement | null>;
+  promptValue: string;
+  setPromptValue: (value: string) => void;
   initialPrompt: string | null;
   summarize: (sessionId: string) => Promise<SummarizeSessionResult>;
   toast: SummaryToastFn;
 }) {
-  const { setContextValue, setHasPrompt, promptRef, initialPrompt, summarize, toast } = opts;
+  const {
+    setContextValue,
+    setHasPrompt,
+    promptRef,
+    promptValue,
+    setPromptValue,
+    initialPrompt,
+    summarize,
+    toast,
+  } = opts;
   return useCallback(
     async (value: string) => {
       if (!value) return;
       setContextValue(value);
-      const ta = promptRef.current;
-      if (!ta) return;
+      if (!promptRef.current) return;
       if (value === "copy_prompt" && initialPrompt) {
-        ta.value = initialPrompt;
+        setPromptValue(initialPrompt);
         setHasPrompt(true);
         return;
       }
       if (value === "blank") {
-        ta.value = "";
+        setPromptValue("");
         setHasPrompt(false);
         return;
       }
       if (value.startsWith("summarize:")) {
+        const controlledPromptRef: RefObject<HTMLTextAreaElement | null> = {
+          current: promptRef.current
+            ? ({
+                get value() {
+                  return promptValue;
+                },
+                set value(value: string) {
+                  setPromptValue(value);
+                },
+              } as HTMLTextAreaElement)
+            : null,
+        };
         const result = await summarize(value.slice("summarize:".length));
-        applySummarizeSessionResult({ result, promptRef, setContextValue, setHasPrompt, toast });
+        applySummarizeSessionResult({
+          result,
+          promptRef: controlledPromptRef,
+          setContextValue,
+          setHasPrompt,
+          toast,
+        });
       }
     },
-    [setContextValue, setHasPrompt, promptRef, initialPrompt, summarize, toast],
+    [
+      initialPrompt,
+      promptRef,
+      promptValue,
+      setContextValue,
+      setHasPrompt,
+      setPromptValue,
+      summarize,
+      toast,
+    ],
   );
 }
 
@@ -219,6 +257,7 @@ type SubtaskFormProps = {
   onClose: () => void;
 };
 
+// eslint-disable-next-line max-lines-per-function
 function NewSubtaskForm({
   parentTaskId,
   defaultTitle,
@@ -241,6 +280,7 @@ function NewSubtaskForm({
   const [isCreating, setIsCreating] = useState(false);
   const [title, setTitle] = useState(defaultTitle);
   const [hasPrompt, setHasPrompt] = useState(false);
+  const [promptValue, setPromptValue] = useState("");
   const [contextValue, setContextValue] = useState("blank");
   const [workspaceMode, setWorkspaceMode] = useState<SubtaskWorkspaceMode>(() =>
     defaultSubtaskWorkspaceMode(worktreeBranch),
@@ -262,12 +302,16 @@ function NewSubtaskForm({
     inputDisabled: isCreating || isSummarizing,
     contextValue,
     initialPrompt,
+    promptValue,
+    setPromptValue,
     setHasPrompt,
   });
   const handleContextChange = useContextChangeHandler({
     setContextValue,
     setHasPrompt,
     promptRef: promptZone.promptRef,
+    promptValue,
+    setPromptValue,
     initialPrompt,
     summarize,
     toast,
@@ -306,10 +350,14 @@ function NewSubtaskForm({
     sessionOptions: isUtilityConfigured ? sessionOptions : [],
     promptZoneProps: {
       ...promptZone,
+      promptValue,
       isCreating,
       isSummarizing,
       isUtilityConfigured,
-      setHasPrompt,
+      onPromptChange: (value: string) => {
+        setPromptValue(value);
+        setHasPrompt(value.trim().length > 0);
+      },
       onSubmitShortcut: handleSubmit,
     },
     isCreating,

--- a/apps/web/components/task/new-subtask-form-parts.test.tsx
+++ b/apps/web/components/task/new-subtask-form-parts.test.tsx
@@ -1,0 +1,77 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { UtilityGenerationResult } from "@/hooks/use-utility-agent-generator";
+
+vi.mock("@/components/enhance-prompt-button", () => ({
+  EnhancePromptButton: ({ onClick }: { onClick: () => void }) => (
+    <button type="button" onClick={onClick}>
+      Enhance
+    </button>
+  ),
+}));
+
+vi.mock("./session-dialog-shared", () => ({
+  AttachButton: ({ onClick }: { onClick: () => void }) => (
+    <button type="button" onClick={onClick}>
+      Attach
+    </button>
+  ),
+}));
+
+import { PromptZone } from "./new-subtask-form-parts";
+
+const GENERATED_RESULT = {
+  content: "improved prompt",
+  callId: "call-123",
+  durationMs: 1_200,
+} satisfies UtilityGenerationResult;
+
+describe("PromptZone", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows inline recovery controls for retained enhanced prompts", async () => {
+    const onApplyPending = vi.fn();
+    const onCopyPending = vi.fn();
+
+    render(
+      <PromptZone
+        promptRef={{ current: null }}
+        promptValue="original prompt"
+        contextItems={[]}
+        attachments={{
+          attachments: [],
+          isDragging: false,
+          fileInputRef: { current: null },
+          handleRemoveAttachment: vi.fn(),
+          handlePaste: vi.fn(),
+          handleDragOver: vi.fn(),
+          handleDragLeave: vi.fn(),
+          handleDrop: vi.fn(),
+          handleAttachClick: vi.fn(),
+          handleFileInputChange: vi.fn(),
+        }}
+        isCreating={false}
+        isSummarizing={false}
+        isEnhancingPrompt={false}
+        isUtilityConfigured={true}
+        handleEnhancePrompt={vi.fn()}
+        pendingResult={GENERATED_RESULT}
+        onPromptChange={vi.fn()}
+        onApplyPending={onApplyPending}
+        onCopyPending={onCopyPending}
+        onSubmitShortcut={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("prompt-result-recovery")).not.toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+    fireEvent.click(screen.getByRole("button", { name: "Copy" }));
+
+    expect(onApplyPending).toHaveBeenCalledTimes(1);
+    expect(onCopyPending).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/components/task/new-subtask-form-parts.tsx
+++ b/apps/web/components/task/new-subtask-form-parts.tsx
@@ -6,6 +6,7 @@ import { DialogFooter } from "@kandev/ui/dialog";
 import { Input } from "@kandev/ui/input";
 import { Textarea } from "@kandev/ui/textarea";
 import { IconGitBranch, IconLoader2 } from "@tabler/icons-react";
+import { PromptResultRecovery } from "@/components/prompt-result-recovery";
 import { AgentSelector, ExecutorProfileSelector } from "@/components/task-create-dialog-selectors";
 import type {
   useAgentProfileOptions,
@@ -14,6 +15,7 @@ import type {
 import { EnhancePromptButton } from "@/components/enhance-prompt-button";
 import { RepoChipsRow } from "@/components/task-create-dialog-repo-chips";
 import type { useDialogHandlers } from "@/components/task-create-dialog-handlers";
+import type { UtilityGenerationResult } from "@/hooks/use-utility-agent-generator";
 import type { Repository } from "@/lib/types/http";
 import type { SubtaskWorkspaceMode, useSubtaskFormState } from "./new-subtask-form-state";
 import {
@@ -94,6 +96,7 @@ export function SelectorsRow({
 
 type PromptZoneProps = {
   promptRef: React.RefObject<HTMLTextAreaElement | null>;
+  promptValue: string;
   contextItems: ReturnType<typeof toContextItems>;
   attachments: ReturnType<typeof useDialogAttachments>;
   isCreating: boolean;
@@ -101,12 +104,16 @@ type PromptZoneProps = {
   isEnhancingPrompt: boolean;
   isUtilityConfigured: boolean;
   handleEnhancePrompt: () => void;
-  setHasPrompt: (v: boolean) => void;
+  pendingResult: UtilityGenerationResult | null;
+  onPromptChange: (value: string) => void;
+  onApplyPending: () => void;
+  onCopyPending: () => Promise<void> | void;
   onSubmitShortcut: (e: React.FormEvent) => void;
 };
 
 export function PromptZone({
   promptRef,
+  promptValue,
   contextItems,
   attachments,
   isCreating,
@@ -114,7 +121,10 @@ export function PromptZone({
   isEnhancingPrompt,
   isUtilityConfigured,
   handleEnhancePrompt,
-  setHasPrompt,
+  pendingResult,
+  onPromptChange,
+  onApplyPending,
+  onCopyPending,
   onSubmitShortcut,
 }: PromptZoneProps) {
   const {
@@ -139,12 +149,13 @@ export function PromptZone({
         <ContextZone items={contextItems} />
         <Textarea
           ref={promptRef}
+          value={promptValue}
           placeholder="What should the agent work on?"
           className="min-w-0 max-w-full field-sizing-fixed wrap-anywhere border-0 focus-visible:ring-0 focus-visible:ring-offset-0 min-h-[120px] max-h-[240px] resize-none overflow-auto text-[13px]"
           autoFocus
           disabled={inputDisabled}
           data-testid="subtask-prompt-input"
-          onInput={(e) => setHasPrompt((e.target as HTMLTextAreaElement).value.trim().length > 0)}
+          onChange={(event) => onPromptChange(event.target.value)}
           onPaste={handlePaste}
           onKeyDown={(e) => {
             if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
@@ -170,6 +181,11 @@ export function PromptZone({
           tabIndex={-1}
         />
       </div>
+      <PromptResultRecovery
+        pendingResult={pendingResult}
+        onApply={onApplyPending}
+        onCopy={onCopyPending}
+      />
       {isDragging && (
         <div className="absolute inset-0 flex items-center justify-center bg-primary/10 border-2 border-dashed border-primary rounded-md pointer-events-none">
           <span className="text-sm text-primary font-medium">Drop files here</span>

--- a/apps/web/components/task/simple/synchronize-input-value.ts
+++ b/apps/web/components/task/simple/synchronize-input-value.ts
@@ -1,0 +1,11 @@
+import type { Dispatch, SetStateAction } from "react";
+
+export function synchronizeInputValue(
+  inputValueRef: { current: string },
+  setInput: Dispatch<SetStateAction<string>>,
+  next: SetStateAction<string>,
+) {
+  const nextValue = typeof next === "function" ? next(inputValueRef.current) : next;
+  inputValueRef.current = nextValue;
+  setInput(nextValue);
+}

--- a/apps/web/components/task/simple/task-chat.test.tsx
+++ b/apps/web/components/task/simple/task-chat.test.tsx
@@ -19,17 +19,14 @@ vi.mock("@/app/office/tasks/[id]/advanced-panels/chat-panel", () => ({
   ),
 }));
 
-const {
-  enhancePromptMock,
-  toastSuccessMock,
-  toastErrorMock,
-  deliveryToastMock,
-} = vi.hoisted(() => ({
-  enhancePromptMock: vi.fn(),
-  toastSuccessMock: vi.fn(),
-  toastErrorMock: vi.fn(),
-  deliveryToastMock: vi.fn(),
-}));
+const { enhancePromptMock, toastSuccessMock, toastErrorMock, deliveryToastMock } = vi.hoisted(
+  () => ({
+    enhancePromptMock: vi.fn(),
+    toastSuccessMock: vi.fn(),
+    toastErrorMock: vi.fn(),
+    deliveryToastMock: vi.fn(),
+  }),
+);
 
 vi.mock("sonner", () => ({
   toast: {
@@ -127,6 +124,10 @@ beforeEach(() => {
 const T_10 = "2026-05-01T10:00:00Z";
 const T_11 = "2026-05-01T11:00:00Z";
 const T_AGENT_A1 = "2026-05-01T10:30:00Z";
+const ORIGINAL_PROMPT = "Original prompt";
+const IMPROVED_PROMPT = "Improved prompt";
+const USER_EDIT = "User edit";
+const COMMENT_PLACEHOLDER = "Add a comment...";
 
 function makeComment(id: string, createdAt: string, content = `c-${id}`): TaskComment {
   return {
@@ -227,12 +228,12 @@ describe("TaskChat unified timeline", () => {
 
   it("renders the input area when not read-only", () => {
     render(wrap(<TaskChat taskId="task-1" comments={[]} sessions={[]} />));
-    expect(screen.getByPlaceholderText("Add a comment...")).toBeTruthy();
+    expect(screen.getByPlaceholderText(COMMENT_PLACEHOLDER)).toBeTruthy();
   });
 
   it("hides the input area when read-only", () => {
     render(wrap(<TaskChat taskId="task-1" comments={[]} sessions={[]} readOnly />));
-    expect(screen.queryByPlaceholderText("Add a comment...")).toBeNull();
+    expect(screen.queryByPlaceholderText(COMMENT_PLACEHOLDER)).toBeNull();
   });
 });
 
@@ -339,9 +340,7 @@ describe("TaskChat decisions in timeline", () => {
 
 describe("TaskChat prompt enhancement", () => {
   it("applies the enhanced prompt immediately when the input is unchanged", async () => {
-    let deliver:
-      | ((result: { content: string }) => boolean | Promise<boolean>)
-      | undefined;
+    let deliver: ((result: { content: string }) => boolean | Promise<boolean>) | undefined;
     enhancePromptMock.mockImplementation(
       (_source: string, onSuccess: (result: { content: string }) => boolean | Promise<boolean>) => {
         deliver = onSuccess;
@@ -350,25 +349,23 @@ describe("TaskChat prompt enhancement", () => {
 
     render(wrap(<TaskChat taskId="task-1" comments={[]} sessions={[]} />));
 
-    const textarea = screen.getByPlaceholderText("Add a comment...") as HTMLTextAreaElement;
-    fireEvent.change(textarea, { target: { value: "Original prompt" } });
+    const textarea = screen.getByPlaceholderText(COMMENT_PLACEHOLDER) as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: ORIGINAL_PROMPT } });
     fireEvent.click(screen.getByTestId("enhance-prompt-button"));
 
-    expect(enhancePromptMock).toHaveBeenCalledWith("Original prompt", expect.any(Function));
+    expect(enhancePromptMock).toHaveBeenCalledWith(ORIGINAL_PROMPT, expect.any(Function));
 
     await act(async () => {
-      await deliver?.({ content: "Improved prompt" });
+      await deliver?.({ content: IMPROVED_PROMPT });
     });
 
-    await waitFor(() => expect(textarea.value).toBe("Improved prompt"));
+    await waitFor(() => expect(textarea.value).toBe(IMPROVED_PROMPT));
     expect(screen.queryByTestId("prompt-result-recovery")).toBeNull();
     expect(toastSuccessMock).toHaveBeenCalledWith("Enhanced prompt inserted.");
   });
 
   it("retains a user edit and offers recovery until Apply is clicked", async () => {
-    let deliver:
-      | ((result: { content: string }) => boolean | Promise<boolean>)
-      | undefined;
+    let deliver: ((result: { content: string }) => boolean | Promise<boolean>) | undefined;
     enhancePromptMock.mockImplementation(
       (_source: string, onSuccess: (result: { content: string }) => boolean | Promise<boolean>) => {
         deliver = onSuccess;
@@ -377,21 +374,21 @@ describe("TaskChat prompt enhancement", () => {
 
     render(wrap(<TaskChat taskId="task-1" comments={[]} sessions={[]} />));
 
-    const textarea = screen.getByPlaceholderText("Add a comment...") as HTMLTextAreaElement;
-    fireEvent.change(textarea, { target: { value: "Original prompt" } });
+    const textarea = screen.getByPlaceholderText(COMMENT_PLACEHOLDER) as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: ORIGINAL_PROMPT } });
     fireEvent.click(screen.getByTestId("enhance-prompt-button"));
-    fireEvent.change(textarea, { target: { value: "User edit" } });
+    fireEvent.change(textarea, { target: { value: USER_EDIT } });
 
     await act(async () => {
-      await deliver?.({ content: "Improved prompt" });
+      await deliver?.({ content: IMPROVED_PROMPT });
     });
 
-    await waitFor(() => expect(textarea.value).toBe("User edit"));
+    await waitFor(() => expect(textarea.value).toBe(USER_EDIT));
     expect(screen.getByTestId("prompt-result-recovery")).toBeTruthy();
 
     fireEvent.click(screen.getByRole("button", { name: "Apply" }));
 
-    await waitFor(() => expect(textarea.value).toBe("Improved prompt"));
+    await waitFor(() => expect(textarea.value).toBe(IMPROVED_PROMPT));
     expect(screen.queryByTestId("prompt-result-recovery")).toBeNull();
   });
 });

--- a/apps/web/components/task/simple/task-chat.test.tsx
+++ b/apps/web/components/task/simple/task-chat.test.tsx
@@ -110,6 +110,7 @@ vi.mock("@kandev/ui/button", () => ({
 }));
 
 import { TaskChat } from "./task-chat";
+import { synchronizeInputValue } from "./synchronize-input-value";
 import { ActiveSessionRefProvider } from "./components/active-session-ref-context";
 
 afterEach(() => cleanup());
@@ -128,6 +129,7 @@ const ORIGINAL_PROMPT = "Original prompt";
 const IMPROVED_PROMPT = "Improved prompt";
 const USER_EDIT = "User edit";
 const COMMENT_PLACEHOLDER = "Add a comment...";
+const PROMPT_RESULT_RECOVERY_TEST_ID = "prompt-result-recovery";
 
 function makeComment(id: string, createdAt: string, content = `c-${id}`): TaskComment {
   return {
@@ -339,6 +341,18 @@ describe("TaskChat decisions in timeline", () => {
 });
 
 describe("TaskChat prompt enhancement", () => {
+  it("synchronizes an edit before scheduling the state update", () => {
+    const inputValueRef = { current: ORIGINAL_PROMPT };
+    const setInput = vi.fn(() => {
+      expect(inputValueRef.current).toBe(USER_EDIT);
+    });
+
+    synchronizeInputValue(inputValueRef, setInput, USER_EDIT);
+
+    expect(setInput).toHaveBeenCalledWith(USER_EDIT);
+    expect(inputValueRef.current).toBe(USER_EDIT);
+  });
+
   it("applies the enhanced prompt immediately when the input is unchanged", async () => {
     let deliver: ((result: { content: string }) => boolean | Promise<boolean>) | undefined;
     enhancePromptMock.mockImplementation(
@@ -360,7 +374,7 @@ describe("TaskChat prompt enhancement", () => {
     });
 
     await waitFor(() => expect(textarea.value).toBe(IMPROVED_PROMPT));
-    expect(screen.queryByTestId("prompt-result-recovery")).toBeNull();
+    expect(screen.queryByTestId(PROMPT_RESULT_RECOVERY_TEST_ID)).toBeNull();
     expect(toastSuccessMock).toHaveBeenCalledWith("Enhanced prompt inserted.");
   });
 
@@ -384,12 +398,35 @@ describe("TaskChat prompt enhancement", () => {
     });
 
     await waitFor(() => expect(textarea.value).toBe(USER_EDIT));
-    expect(screen.getByTestId("prompt-result-recovery")).toBeTruthy();
+    expect(screen.getByTestId(PROMPT_RESULT_RECOVERY_TEST_ID)).toBeTruthy();
 
     fireEvent.click(screen.getByRole("button", { name: "Apply" }));
 
     await waitFor(() => expect(textarea.value).toBe(IMPROVED_PROMPT));
-    expect(screen.queryByTestId("prompt-result-recovery")).toBeNull();
+    expect(screen.queryByTestId(PROMPT_RESULT_RECOVERY_TEST_ID)).toBeNull();
+  });
+
+  it("retains an edit made in the same turn as result delivery", async () => {
+    let deliver: ((result: { content: string }) => boolean | Promise<boolean>) | undefined;
+    enhancePromptMock.mockImplementation(
+      (_source: string, onSuccess: (result: { content: string }) => boolean | Promise<boolean>) => {
+        deliver = onSuccess;
+      },
+    );
+
+    render(wrap(<TaskChat taskId="task-1" comments={[]} sessions={[]} />));
+
+    const textarea = screen.getByPlaceholderText(COMMENT_PLACEHOLDER) as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: ORIGINAL_PROMPT } });
+    fireEvent.click(screen.getByTestId("enhance-prompt-button"));
+
+    await act(async () => {
+      fireEvent.change(textarea, { target: { value: USER_EDIT } });
+      await deliver?.({ content: IMPROVED_PROMPT });
+    });
+
+    expect(textarea.value).toBe(USER_EDIT);
+    expect(screen.getByTestId(PROMPT_RESULT_RECOVERY_TEST_ID)).toBeTruthy();
   });
 });
 

--- a/apps/web/components/task/simple/task-chat.test.tsx
+++ b/apps/web/components/task/simple/task-chat.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, afterEach, vi } from "vitest";
-import { render, screen, cleanup, fireEvent, within } from "@testing-library/react";
+import { describe, it, expect, afterEach, vi, beforeEach } from "vitest";
+import { render, screen, cleanup, fireEvent, within, act, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { StateProvider } from "@/components/state-provider";
 import type {
@@ -19,16 +19,46 @@ vi.mock("@/app/office/tasks/[id]/advanced-panels/chat-panel", () => ({
   ),
 }));
 
+const {
+  enhancePromptMock,
+  toastSuccessMock,
+  toastErrorMock,
+  deliveryToastMock,
+} = vi.hoisted(() => ({
+  enhancePromptMock: vi.fn(),
+  toastSuccessMock: vi.fn(),
+  toastErrorMock: vi.fn(),
+  deliveryToastMock: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: toastSuccessMock,
+    error: toastErrorMock,
+  },
+}));
+
 vi.mock("@/components/enhance-prompt-button", () => ({
-  EnhancePromptButton: () => null,
+  EnhancePromptButton: ({ onClick }: { onClick: () => void }) => (
+    <button type="button" data-testid="enhance-prompt-button" onClick={onClick}>
+      Enhance
+    </button>
+  ),
 }));
 
 vi.mock("@/hooks/use-is-utility-configured", () => ({
-  useIsUtilityConfigured: () => false,
+  useIsUtilityConfigured: () => true,
 }));
 
 vi.mock("@/hooks/use-utility-agent-generator", () => ({
-  useUtilityAgentGenerator: () => ({ enhancePrompt: () => {}, isEnhancingPrompt: false }),
+  useUtilityAgentGenerator: () => ({
+    enhancePrompt: enhancePromptMock,
+    isEnhancingPrompt: false,
+  }),
+}));
+
+vi.mock("@/components/toast-provider", () => ({
+  useToast: () => ({ toast: deliveryToastMock }),
 }));
 
 vi.mock("./markdown-comment", () => ({
@@ -86,6 +116,13 @@ import { TaskChat } from "./task-chat";
 import { ActiveSessionRefProvider } from "./components/active-session-ref-context";
 
 afterEach(() => cleanup());
+
+beforeEach(() => {
+  enhancePromptMock.mockReset();
+  toastSuccessMock.mockReset();
+  toastErrorMock.mockReset();
+  deliveryToastMock.mockReset();
+});
 
 const T_10 = "2026-05-01T10:00:00Z";
 const T_11 = "2026-05-01T11:00:00Z";
@@ -297,6 +334,65 @@ describe("TaskChat decisions in timeline", () => {
     expect(engIdx).toBeGreaterThan(ceoIdx);
     expect(lateIdx).toBeGreaterThan(engIdx);
     expect(html).toContain("please update the docs");
+  });
+});
+
+describe("TaskChat prompt enhancement", () => {
+  it("applies the enhanced prompt immediately when the input is unchanged", async () => {
+    let deliver:
+      | ((result: { content: string }) => boolean | Promise<boolean>)
+      | undefined;
+    enhancePromptMock.mockImplementation(
+      (_source: string, onSuccess: (result: { content: string }) => boolean | Promise<boolean>) => {
+        deliver = onSuccess;
+      },
+    );
+
+    render(wrap(<TaskChat taskId="task-1" comments={[]} sessions={[]} />));
+
+    const textarea = screen.getByPlaceholderText("Add a comment...") as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: "Original prompt" } });
+    fireEvent.click(screen.getByTestId("enhance-prompt-button"));
+
+    expect(enhancePromptMock).toHaveBeenCalledWith("Original prompt", expect.any(Function));
+
+    await act(async () => {
+      await deliver?.({ content: "Improved prompt" });
+    });
+
+    await waitFor(() => expect(textarea.value).toBe("Improved prompt"));
+    expect(screen.queryByTestId("prompt-result-recovery")).toBeNull();
+    expect(toastSuccessMock).toHaveBeenCalledWith("Enhanced prompt inserted.");
+  });
+
+  it("retains a user edit and offers recovery until Apply is clicked", async () => {
+    let deliver:
+      | ((result: { content: string }) => boolean | Promise<boolean>)
+      | undefined;
+    enhancePromptMock.mockImplementation(
+      (_source: string, onSuccess: (result: { content: string }) => boolean | Promise<boolean>) => {
+        deliver = onSuccess;
+      },
+    );
+
+    render(wrap(<TaskChat taskId="task-1" comments={[]} sessions={[]} />));
+
+    const textarea = screen.getByPlaceholderText("Add a comment...") as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: "Original prompt" } });
+    fireEvent.click(screen.getByTestId("enhance-prompt-button"));
+    fireEvent.change(textarea, { target: { value: "User edit" } });
+
+    await act(async () => {
+      await deliver?.({ content: "Improved prompt" });
+    });
+
+    await waitFor(() => expect(textarea.value).toBe("User edit"));
+    expect(screen.getByTestId("prompt-result-recovery")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+
+    await waitFor(() => expect(textarea.value).toBe("Improved prompt"));
+    expect(screen.queryByTestId("prompt-result-recovery")).toBeNull();
   });
 });
 

--- a/apps/web/components/task/simple/task-chat.tsx
+++ b/apps/web/components/task/simple/task-chat.tsx
@@ -281,6 +281,89 @@ type ChatInputProps = {
   onSubmitted?: () => void;
 };
 
+type CommentComposerFooterProps = {
+  fileInputRef: React.RefObject<HTMLInputElement | null>;
+  handleFileSelect: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  handleEnhance: () => void;
+  isEnhancingPrompt: boolean;
+  isUtilityConfigured: boolean;
+  submitting: boolean;
+  input: string;
+  handleSubmit: () => Promise<void>;
+  pendingResult: ReturnType<typeof usePromptResultDelivery>["pendingResult"];
+  applyPending: () => void;
+  copyPending: () => Promise<void>;
+};
+
+function CommentComposerFooter({
+  fileInputRef,
+  handleFileSelect,
+  handleEnhance,
+  isEnhancingPrompt,
+  isUtilityConfigured,
+  submitting,
+  input,
+  handleSubmit,
+  pendingResult,
+  applyPending,
+  copyPending,
+}: CommentComposerFooterProps) {
+  return (
+    <>
+      <div className="flex items-center gap-1 px-2 pb-2">
+        <input
+          ref={fileInputRef}
+          type="file"
+          multiple
+          className="hidden"
+          onChange={handleFileSelect}
+        />
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              size="icon"
+              variant="ghost"
+              className="h-7 w-7 cursor-pointer"
+              onClick={() => fileInputRef.current?.click()}
+            >
+              <IconPaperclip className="h-3.5 w-3.5" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Attach files</TooltipContent>
+        </Tooltip>
+        <EnhancePromptButton
+          onClick={handleEnhance}
+          isLoading={isEnhancingPrompt}
+          isConfigured={isUtilityConfigured}
+        />
+        <span className="flex-1" />
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              size="icon"
+              className="h-7 w-7 cursor-pointer"
+              disabled={submitting || !input.trim()}
+              onClick={() => void handleSubmit()}
+            >
+              <IconSend className="h-3.5 w-3.5" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Send comment</TooltipContent>
+        </Tooltip>
+      </div>
+      <div className="px-2 pb-2">
+        <PromptResultRecovery
+          pendingResult={pendingResult}
+          onApply={applyPending}
+          onCopy={copyPending}
+        />
+      </div>
+    </>
+  );
+}
+
 function ChatInput({ taskId, taskTitle, taskDescription, onSubmitted }: ChatInputProps) {
   const [input, setInput] = useState("");
   const [submitting, setSubmitting] = useState(false);
@@ -351,56 +434,19 @@ function ChatInput({ taskId, taskTitle, taskDescription, onSubmitted }: ChatInpu
           rows={2}
           className="w-full bg-transparent px-3 py-2 text-sm outline-none resize-none"
         />
-        <div className="flex items-center gap-1 px-2 pb-2">
-          <input
-            ref={fileInputRef}
-            type="file"
-            multiple
-            className="hidden"
-            onChange={handleFileSelect}
-          />
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                type="button"
-                size="icon"
-                variant="ghost"
-                className="h-7 w-7 cursor-pointer"
-                onClick={() => fileInputRef.current?.click()}
-              >
-                <IconPaperclip className="h-3.5 w-3.5" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>Attach files</TooltipContent>
-          </Tooltip>
-          <EnhancePromptButton
-            onClick={handleEnhance}
-            isLoading={isEnhancingPrompt}
-            isConfigured={isUtilityConfigured}
-          />
-          <span className="flex-1" />
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                type="button"
-                size="icon"
-                className="h-7 w-7 cursor-pointer"
-                disabled={submitting || !input.trim()}
-                onClick={() => void handleSubmit()}
-              >
-                <IconSend className="h-3.5 w-3.5" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>Send comment</TooltipContent>
-          </Tooltip>
-        </div>
-        <div className="px-2 pb-2">
-          <PromptResultRecovery
-            pendingResult={promptDelivery.pendingResult}
-            onApply={promptDelivery.applyPending}
-            onCopy={promptDelivery.copyPending}
-          />
-        </div>
+        <CommentComposerFooter
+          fileInputRef={fileInputRef}
+          handleFileSelect={handleFileSelect}
+          handleEnhance={handleEnhance}
+          isEnhancingPrompt={isEnhancingPrompt}
+          isUtilityConfigured={isUtilityConfigured}
+          submitting={submitting}
+          input={input}
+          handleSubmit={handleSubmit}
+          pendingResult={promptDelivery.pendingResult}
+          applyPending={promptDelivery.applyPending}
+          copyPending={promptDelivery.copyPending}
+        />
       </div>
     </div>
   );

--- a/apps/web/components/task/simple/task-chat.tsx
+++ b/apps/web/components/task/simple/task-chat.tsx
@@ -9,6 +9,8 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@kandev/ui/collapsible";
 import { EnhancePromptButton } from "@/components/enhance-prompt-button";
 import { useIsUtilityConfigured } from "@/hooks/use-is-utility-configured";
+import { PromptResultRecovery } from "@/components/prompt-result-recovery";
+import { usePromptResultDelivery } from "@/hooks/use-prompt-result-delivery";
 import { useUtilityAgentGenerator } from "@/hooks/use-utility-agent-generator";
 import { useAppStore } from "@/components/state-provider";
 import { selectCommandCount } from "@/lib/state/slices/session/selectors";
@@ -35,6 +37,7 @@ import {
 
 const MAX_INLINE_SESSIONS = 50;
 const AUTOSCROLL_THRESHOLD_PX = 80;
+const PROMPT_INSERTED_MESSAGE = "Enhanced prompt inserted.";
 
 type TaskChatProps = {
   taskId: string;
@@ -282,6 +285,7 @@ function ChatInput({ taskId, taskTitle, taskDescription, onSubmitted }: ChatInpu
   const [input, setInput] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const inputValueRef = useRef(input);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const isUtilityConfigured = useIsUtilityConfigured();
   const { enhancePrompt, isEnhancingPrompt } = useUtilityAgentGenerator({
@@ -289,7 +293,19 @@ function ChatInput({ taskId, taskTitle, taskDescription, onSubmitted }: ChatInpu
     taskTitle: taskTitle ?? "",
     taskDescription: taskDescription ?? "",
   });
+  const promptDelivery = usePromptResultDelivery({
+    getCurrent: () => inputValueRef.current,
+    apply: (value) => {
+      inputValueRef.current = value;
+      setInput(value);
+      return true;
+    },
+  });
   const { handleFileSelect, handlePaste } = useChatInputHandlers(setInput);
+
+  useEffect(() => {
+    inputValueRef.current = input;
+  }, [input]);
 
   const handleSubmit = useCallback(async () => {
     if (!input.trim() || submitting) return;
@@ -306,9 +322,16 @@ function ChatInput({ taskId, taskTitle, taskDescription, onSubmitted }: ChatInpu
   }, [input, submitting, taskId, onSubmitted]);
 
   const handleEnhance = useCallback(() => {
-    if (!input.trim()) return;
-    enhancePrompt(input, (enhanced: string) => setInput(enhanced));
-  }, [input, enhancePrompt]);
+    const current = input;
+    if (!current.trim()) return;
+    void enhancePrompt(current, (result) => {
+      const inserted = promptDelivery.deliver(current, result);
+      if (inserted) {
+        toast.success(PROMPT_INSERTED_MESSAGE);
+      }
+      return inserted;
+    });
+  }, [input, enhancePrompt, promptDelivery]);
 
   return (
     <div className="mt-4 pt-4 border-t border-border">
@@ -370,6 +393,13 @@ function ChatInput({ taskId, taskTitle, taskDescription, onSubmitted }: ChatInpu
             </TooltipTrigger>
             <TooltipContent>Send comment</TooltipContent>
           </Tooltip>
+        </div>
+        <div className="px-2 pb-2">
+          <PromptResultRecovery
+            pendingResult={promptDelivery.pendingResult}
+            onApply={promptDelivery.applyPending}
+            onCopy={promptDelivery.copyPending}
+          />
         </div>
       </div>
     </div>

--- a/apps/web/components/task/simple/task-chat.tsx
+++ b/apps/web/components/task/simple/task-chat.tsx
@@ -22,6 +22,7 @@ import { RunErrorEntry } from "./components/run-error-entry";
 import { UserCommentRunBadge } from "./components/user-comment-run-badge";
 import { buildCommentTurnContext, type CommentTurnContext } from "./turn-context";
 import { groupSessionsForTimeline, groupSortKey, type SessionGroup } from "./session-groups";
+import { synchronizeInputValue } from "./synchronize-input-value";
 import type {
   TaskComment,
   TaskDecision,
@@ -308,6 +309,8 @@ function CommentComposerFooter({
   applyPending,
   copyPending,
 }: CommentComposerFooterProps) {
+  const isSendDisabled = submitting || !input.trim();
+
   return (
     <>
       <div className="flex items-center gap-1 px-2 pb-2">
@@ -340,15 +343,17 @@ function CommentComposerFooter({
         <span className="flex-1" />
         <Tooltip>
           <TooltipTrigger asChild>
-            <Button
-              type="button"
-              size="icon"
-              className="h-7 w-7 cursor-pointer"
-              disabled={submitting || !input.trim()}
-              onClick={() => void handleSubmit()}
-            >
-              <IconSend className="h-3.5 w-3.5" />
-            </Button>
+            <span tabIndex={isSendDisabled ? 0 : -1} className="inline-flex">
+              <Button
+                type="button"
+                size="icon"
+                className="h-7 w-7 cursor-pointer"
+                disabled={isSendDisabled}
+                onClick={() => void handleSubmit()}
+              >
+                <IconSend className="h-3.5 w-3.5" />
+              </Button>
+            </span>
           </TooltipTrigger>
           <TooltipContent>Send comment</TooltipContent>
         </Tooltip>
@@ -370,6 +375,9 @@ function ChatInput({ taskId, taskTitle, taskDescription, onSubmitted }: ChatInpu
   const fileInputRef = useRef<HTMLInputElement>(null);
   const inputValueRef = useRef(input);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const setInputAndSync = useCallback((next: React.SetStateAction<string>) => {
+    synchronizeInputValue(inputValueRef, setInput, next);
+  }, []);
   const isUtilityConfigured = useIsUtilityConfigured();
   const { enhancePrompt, isEnhancingPrompt } = useUtilityAgentGenerator({
     sessionId: null,
@@ -379,33 +387,29 @@ function ChatInput({ taskId, taskTitle, taskDescription, onSubmitted }: ChatInpu
   const promptDelivery = usePromptResultDelivery({
     getCurrent: () => inputValueRef.current,
     apply: (value) => {
-      inputValueRef.current = value;
-      setInput(value);
+      setInputAndSync(value);
       return true;
     },
   });
-  const { handleFileSelect, handlePaste } = useChatInputHandlers(setInput);
-
-  useEffect(() => {
-    inputValueRef.current = input;
-  }, [input]);
+  const { handleFileSelect, handlePaste } = useChatInputHandlers(setInputAndSync);
 
   const handleSubmit = useCallback(async () => {
-    if (!input.trim() || submitting) return;
+    const current = inputValueRef.current;
+    if (!current.trim() || submitting) return;
     setSubmitting(true);
     try {
-      await createComment(taskId, { body: input.trim(), author_type: "user" });
-      setInput("");
+      await createComment(taskId, { body: current.trim(), author_type: "user" });
+      setInputAndSync("");
       onSubmitted?.();
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "Failed to send comment");
     } finally {
       setSubmitting(false);
     }
-  }, [input, submitting, taskId, onSubmitted]);
+  }, [submitting, taskId, onSubmitted, setInputAndSync]);
 
   const handleEnhance = useCallback(() => {
-    const current = input;
+    const current = inputValueRef.current;
     if (!current.trim()) return;
     void enhancePrompt(current, (result) => {
       const inserted = promptDelivery.deliver(current, result);
@@ -414,7 +418,7 @@ function ChatInput({ taskId, taskTitle, taskDescription, onSubmitted }: ChatInpu
       }
       return inserted;
     });
-  }, [input, enhancePrompt, promptDelivery]);
+  }, [enhancePrompt, promptDelivery]);
 
   return (
     <div className="mt-4 pt-4 border-t border-border">
@@ -422,7 +426,7 @@ function ChatInput({ taskId, taskTitle, taskDescription, onSubmitted }: ChatInpu
         <textarea
           ref={textareaRef}
           value={input}
-          onChange={(e) => setInput(e.target.value)}
+          onChange={(e) => setInputAndSync(e.target.value)}
           onKeyDown={(e) => {
             if (e.key === "Enter" && !e.shiftKey) {
               e.preventDefault();

--- a/apps/web/components/task/simple/task-chat.tsx
+++ b/apps/web/components/task/simple/task-chat.tsx
@@ -385,6 +385,7 @@ function ChatInput({ taskId, taskTitle, taskDescription, onSubmitted }: ChatInpu
     taskDescription: taskDescription ?? "",
   });
   const promptDelivery = usePromptResultDelivery({
+    scopeKey: `task-comment:${taskId}`,
     getCurrent: () => inputValueRef.current,
     apply: (value) => {
       setInputAndSync(value);
@@ -411,8 +412,9 @@ function ChatInput({ taskId, taskTitle, taskDescription, onSubmitted }: ChatInpu
   const handleEnhance = useCallback(() => {
     const current = inputValueRef.current;
     if (!current.trim()) return;
+    const generation = promptDelivery.captureScope();
     void enhancePrompt(current, (result) => {
-      const inserted = promptDelivery.deliver(current, result);
+      const inserted = promptDelivery.deliver(current, result, generation);
       if (inserted) {
         toast.success(PROMPT_INSERTED_MESSAGE);
       }

--- a/apps/web/components/task/use-subtask-submit.test.ts
+++ b/apps/web/components/task/use-subtask-submit.test.ts
@@ -134,6 +134,40 @@ describe("useSubtaskPromptZone", () => {
     expect(result.current.pendingResult).toEqual(GENERATED_RESULT);
   });
 
+  it("preserves exact source text and retains the result after a whitespace-only edit", async () => {
+    let deliverResult: ((result: UtilityGenerationResult) => Promise<boolean>) | undefined;
+    mockEnhancePrompt.mockImplementation(
+      async (_source: string, deliver: (result: UtilityGenerationResult) => Promise<boolean>) => {
+        deliverResult = deliver;
+      },
+    );
+
+    const initialPrompt = "  original prompt  ";
+    const editedPrompt = "  original prompt   ";
+    const { result } = renderHook(() => useSubtaskPromptHarness(initialPrompt));
+
+    act(() => {
+      result.current.promptRef.current = { value: initialPrompt } as HTMLTextAreaElement;
+    });
+
+    await act(async () => {
+      await result.current.handleEnhancePrompt();
+    });
+
+    expect(mockEnhancePrompt).toHaveBeenCalledWith(initialPrompt, expect.any(Function));
+
+    act(() => {
+      result.current.setPromptValue(editedPrompt);
+    });
+
+    await act(async () => {
+      await deliverResult?.(GENERATED_RESULT);
+    });
+
+    expect(result.current.promptValue).toBe(editedPrompt);
+    expect(result.current.pendingResult).toEqual(GENERATED_RESULT);
+  });
+
   it("resolves submission prompts from the same controlled prompt state", () => {
     const { result } = renderHook(() => useSubtaskPromptHarness());
 

--- a/apps/web/components/task/use-subtask-submit.test.ts
+++ b/apps/web/components/task/use-subtask-submit.test.ts
@@ -1,0 +1,146 @@
+import { act, renderHook } from "@testing-library/react";
+import { useState } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { UtilityGenerationResult } from "@/hooks/use-utility-agent-generator";
+
+const mockToast = vi.fn();
+const mockEnhancePrompt = vi.fn();
+
+vi.mock("@/components/toast-provider", () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
+
+vi.mock("@/hooks/use-utility-agent-generator", () => ({
+  useUtilityAgentGenerator: () => ({
+    enhancePrompt: mockEnhancePrompt,
+    isEnhancingPrompt: false,
+  }),
+}));
+
+import { useSubtaskPromptZone } from "./use-subtask-submit";
+
+const GENERATED_RESULT = {
+  content: "improved prompt",
+  callId: "call-123",
+  durationMs: 1_200,
+} satisfies UtilityGenerationResult;
+const ORIGINAL_PROMPT = "original prompt";
+
+function useSubtaskPromptHarness(initialPrompt = ORIGINAL_PROMPT) {
+  const [promptValue, setPromptValue] = useState(initialPrompt);
+  const [hasPrompt, setHasPrompt] = useState(Boolean(initialPrompt.trim()));
+  const promptZone = useSubtaskPromptZone({
+    taskTitle: "Parent task",
+    inputDisabled: false,
+    contextValue: "blank",
+    initialPrompt: null,
+    promptValue,
+    setPromptValue,
+    setHasPrompt,
+  });
+
+  return {
+    ...promptZone,
+    promptValue,
+    setPromptValue,
+    hasPrompt,
+  };
+}
+
+describe("useSubtaskPromptZone", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("applies an enhanced prompt immediately when the source text is unchanged", async () => {
+    mockEnhancePrompt.mockImplementation(
+      async (_source: string, deliver: (result: UtilityGenerationResult) => Promise<boolean>) =>
+        deliver(GENERATED_RESULT),
+    );
+
+    const { result } = renderHook(() => useSubtaskPromptHarness());
+
+    act(() => {
+      result.current.promptRef.current = { value: ORIGINAL_PROMPT } as HTMLTextAreaElement;
+    });
+
+    await act(async () => {
+      await result.current.handleEnhancePrompt();
+    });
+
+    expect(result.current.promptValue).toBe("improved prompt");
+    expect(result.current.hasPrompt).toBe(true);
+    expect(result.current.pendingResult).toBeNull();
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({ description: "Enhanced prompt applied.", variant: "success" }),
+    );
+  });
+
+  it("retains the enhanced prompt when the user changes the source text before delivery", async () => {
+    let deliverResult: ((result: UtilityGenerationResult) => Promise<boolean>) | undefined;
+    mockEnhancePrompt.mockImplementation(
+      async (_source: string, deliver: (result: UtilityGenerationResult) => Promise<boolean>) => {
+        deliverResult = deliver;
+      },
+    );
+
+    const { result } = renderHook(() => useSubtaskPromptHarness());
+
+    act(() => {
+      result.current.promptRef.current = { value: ORIGINAL_PROMPT } as HTMLTextAreaElement;
+    });
+
+    await act(async () => {
+      await result.current.handleEnhancePrompt();
+    });
+
+    act(() => {
+      result.current.setPromptValue("edited prompt");
+    });
+
+    await act(async () => {
+      await deliverResult?.(GENERATED_RESULT);
+    });
+
+    expect(result.current.promptValue).toBe("edited prompt");
+    expect(result.current.pendingResult).toEqual(GENERATED_RESULT);
+
+    act(() => {
+      result.current.applyPending();
+    });
+
+    expect(result.current.promptValue).toBe("improved prompt");
+    expect(result.current.pendingResult).toBeNull();
+  });
+
+  it("retains the enhanced prompt when the input target is unavailable", async () => {
+    mockEnhancePrompt.mockImplementation(
+      async (_source: string, deliver: (result: UtilityGenerationResult) => Promise<boolean>) =>
+        deliver(GENERATED_RESULT),
+    );
+
+    const { result } = renderHook(() => useSubtaskPromptHarness());
+
+    act(() => {
+      result.current.promptRef.current = null;
+    });
+
+    await act(async () => {
+      await result.current.handleEnhancePrompt();
+    });
+
+    expect(result.current.promptValue).toBe(ORIGINAL_PROMPT);
+    expect(result.current.pendingResult).toEqual(GENERATED_RESULT);
+  });
+
+  it("resolves submission prompts from the same controlled prompt state", () => {
+    const { result } = renderHook(() => useSubtaskPromptHarness());
+
+    act(() => {
+      result.current.setPromptValue("next prompt");
+    });
+
+    expect(result.current.resolvePrompt()).toBe("next prompt");
+  });
+});

--- a/apps/web/components/task/use-subtask-submit.test.ts
+++ b/apps/web/components/task/use-subtask-submit.test.ts
@@ -31,6 +31,7 @@ function useSubtaskPromptHarness(initialPrompt = ORIGINAL_PROMPT) {
   const [promptValue, setPromptValue] = useState(initialPrompt);
   const [hasPrompt, setHasPrompt] = useState(Boolean(initialPrompt.trim()));
   const promptZone = useSubtaskPromptZone({
+    parentTaskId: "task-1",
     taskTitle: "Parent task",
     inputDisabled: false,
     contextValue: "blank",

--- a/apps/web/components/task/use-subtask-submit.ts
+++ b/apps/web/components/task/use-subtask-submit.ts
@@ -177,7 +177,7 @@ export function useSubtaskPromptZone(opts: {
     taskTitle,
   });
   const promptResultDelivery = usePromptResultDelivery({
-    getCurrent: () => (promptRef.current ? latestPromptValueRef.current.trim() : null),
+    getCurrent: () => latestPromptValueRef.current,
     apply: (value) => {
       if (!promptRef.current) {
         return false;
@@ -189,8 +189,8 @@ export function useSubtaskPromptZone(opts: {
     },
   });
   const handleEnhancePrompt = useCallback(async () => {
-    const current = latestPromptValueRef.current.trim();
-    if (!current) return;
+    const current = latestPromptValueRef.current;
+    if (!current.trim()) return;
 
     await enhancePrompt(current, (enhanced) => {
       const delivered = promptResultDelivery.deliver(current, enhanced);

--- a/apps/web/components/task/use-subtask-submit.ts
+++ b/apps/web/components/task/use-subtask-submit.ts
@@ -150,6 +150,7 @@ export function useSubtaskSubmit(opts: UseSubtaskSubmitOpts) {
  * needs without spreading hook/state plumbing across the parent component.
  */
 export function useSubtaskPromptZone(opts: {
+  parentTaskId: string;
   taskTitle: string;
   inputDisabled: boolean;
   contextValue: string;
@@ -159,6 +160,7 @@ export function useSubtaskPromptZone(opts: {
   setHasPrompt: (v: boolean) => void;
 }) {
   const {
+    parentTaskId,
     taskTitle,
     inputDisabled,
     contextValue,
@@ -177,6 +179,7 @@ export function useSubtaskPromptZone(opts: {
     taskTitle,
   });
   const promptResultDelivery = usePromptResultDelivery({
+    scopeKey: `new-subtask:${parentTaskId}`,
     getCurrent: () => latestPromptValueRef.current,
     apply: (value) => {
       if (!promptRef.current) {
@@ -191,9 +194,10 @@ export function useSubtaskPromptZone(opts: {
   const handleEnhancePrompt = useCallback(async () => {
     const current = latestPromptValueRef.current;
     if (!current.trim()) return;
+    const generation = promptResultDelivery.captureScope();
 
     await enhancePrompt(current, (enhanced) => {
-      const delivered = promptResultDelivery.deliver(current, enhanced);
+      const delivered = promptResultDelivery.deliver(current, enhanced, generation);
       if (delivered) {
         toast({ description: "Enhanced prompt applied.", variant: "success" });
       }

--- a/apps/web/components/task/use-subtask-submit.ts
+++ b/apps/web/components/task/use-subtask-submit.ts
@@ -9,6 +9,7 @@ import {
   toMessageAttachments,
 } from "@/components/task-create-dialog-helpers";
 import { useToast } from "@/components/toast-provider";
+import { usePromptResultDelivery } from "@/hooks/use-prompt-result-delivery";
 import { useUtilityAgentGenerator } from "@/hooks/use-utility-agent-generator";
 import type { Repository } from "@/lib/types/http";
 import type { SubtaskWorkspaceMode, useSubtaskFormState } from "./new-subtask-form-state";
@@ -153,40 +154,71 @@ export function useSubtaskPromptZone(opts: {
   inputDisabled: boolean;
   contextValue: string;
   initialPrompt: string | null;
+  promptValue: string;
+  setPromptValue: (value: string) => void;
   setHasPrompt: (v: boolean) => void;
 }) {
-  const { taskTitle, inputDisabled, contextValue, initialPrompt, setHasPrompt } = opts;
+  const {
+    taskTitle,
+    inputDisabled,
+    contextValue,
+    initialPrompt,
+    promptValue,
+    setPromptValue,
+    setHasPrompt,
+  } = opts;
   const promptRef = useRef<HTMLTextAreaElement>(null);
+  const latestPromptValueRef = useRef(promptValue);
+  latestPromptValueRef.current = promptValue;
+  const { toast } = useToast();
   const attachments = useDialogAttachments(inputDisabled);
   const { enhancePrompt, isEnhancingPrompt } = useUtilityAgentGenerator({
     sessionId: null,
     taskTitle,
   });
-  const handleEnhancePrompt = useCallback(() => {
-    const current = promptRef.current?.value?.trim();
-    if (!current) return;
-    enhancePrompt(current, (enhanced) => {
-      if (promptRef.current) {
-        promptRef.current.value = enhanced;
-        setHasPrompt(true);
+  const promptResultDelivery = usePromptResultDelivery({
+    getCurrent: () => (promptRef.current ? latestPromptValueRef.current.trim() : null),
+    apply: (value) => {
+      if (!promptRef.current) {
+        return false;
       }
+
+      setPromptValue(value);
+      setHasPrompt(value.trim().length > 0);
+      return true;
+    },
+  });
+  const handleEnhancePrompt = useCallback(async () => {
+    const current = latestPromptValueRef.current.trim();
+    if (!current) return;
+
+    await enhancePrompt(current, (enhanced) => {
+      const delivered = promptResultDelivery.deliver(current, enhanced);
+      if (delivered) {
+        toast({ description: "Enhanced prompt applied.", variant: "success" });
+      }
+
+      return delivered;
     });
-  }, [enhancePrompt, setHasPrompt]);
+  }, [enhancePrompt, promptResultDelivery, toast]);
   const contextItems = useMemo(
     () => toContextItems(attachments.attachments, attachments.handleRemoveAttachment),
     [attachments.attachments, attachments.handleRemoveAttachment],
   );
   const resolvePrompt = useCallback(() => {
-    const typed = promptRef.current?.value?.trim() ?? "";
+    const typed = promptValue.trim();
     if (contextValue === "copy_prompt" && !typed && initialPrompt) return initialPrompt;
     return typed;
-  }, [contextValue, initialPrompt]);
+  }, [contextValue, initialPrompt, promptValue]);
   return {
     promptRef,
     attachments,
     contextItems,
     handleEnhancePrompt,
     isEnhancingPrompt,
+    pendingResult: promptResultDelivery.pendingResult,
+    applyPending: promptResultDelivery.applyPending,
+    copyPending: promptResultDelivery.copyPending,
     resolvePrompt,
   };
 }

--- a/apps/web/e2e/tests/chat/quick-chat.spec.ts
+++ b/apps/web/e2e/tests/chat/quick-chat.spec.ts
@@ -363,6 +363,55 @@ test.describe("Quick Chat", () => {
     );
   });
 
+  test("keeps an edited active-session prompt and offers recovery", async ({
+    testPage,
+    apiClient,
+  }) => {
+    const initialPrompt = "Fix the original bug";
+    const editedPrompt = "Fix the original bug with an added constraint";
+    const generatedPrompt = "Enhanced: fix the original bug with an added constraint and tests";
+    let requestStarted: (() => void) | undefined;
+    let releaseResponse: (() => void) | undefined;
+    const requestGate = new Promise<void>((resolve) => {
+      requestStarted = resolve;
+    });
+    const responseGate = new Promise<void>((resolve) => {
+      releaseResponse = resolve;
+    });
+
+    await apiClient.saveUserSettings({
+      default_utility_agent_id: "mock",
+      default_utility_model: "mock-fast",
+    });
+    await testPage.route("**/api/v1/utility/execute", async (route) => {
+      requestStarted?.();
+      await responseGate;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ success: true, response: generatedPrompt }),
+      });
+    });
+
+    const dialog = await openQuickChatWithAgent(testPage);
+    const editor = dialog.locator(".tiptap.ProseMirror");
+    await expect(editor).toHaveAttribute("contenteditable", "true", { timeout: 30_000 });
+    await editor.fill(initialPrompt);
+    await dialog.getByLabel("Enhance prompt with AI").click();
+    await requestGate;
+    await editor.focus();
+    await editor.pressSequentially(" with an added constraint");
+    await expect(editor).toHaveText(editedPrompt);
+    releaseResponse?.();
+
+    const recovery = dialog.getByTestId("prompt-result-recovery");
+    await expect(recovery).toBeVisible();
+    await expect(editor).toHaveText(editedPrompt);
+
+    await recovery.getByRole("button", { name: "Apply" }).click();
+    await expect(editor).toHaveText(generatedPrompt);
+  });
+
   test("slash command menu populates before first message (eager agent init)", async ({
     testPage,
   }) => {

--- a/apps/web/e2e/tests/task/enhance-prompt.spec.ts
+++ b/apps/web/e2e/tests/task/enhance-prompt.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from "../../fixtures/test-base";
 import { useRegularMode } from "../../helpers/regular-mode";
 import { KanbanPage } from "../../pages/kanban-page";
+import type { ExecutePromptRequest } from "@/lib/api/domains/utility-api";
 
 // Exercises the regular task-create dialog (New Task in the sidebar); run with office off.
 useRegularMode();
@@ -11,9 +12,21 @@ test.describe("Enhance prompt button in task creation", () => {
     apiClient,
     seedData,
   }) => {
+    let executeBody: ExecutePromptRequest | null = null;
+    await testPage.route("**/api/v1/utility/execute", async (route) => {
+      executeBody = route.request().postDataJSON() as ExecutePromptRequest;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: true,
+          call_id: "call-stub",
+          response: "Stubbed enhanced task description.",
+        }),
+      });
+    });
+
     // Seed a default utility agent pointing at mock-agent (by name, not UUID).
-    // The mock agent isn't inference-capable so the actual enhance call won't
-    // succeed, but the button should render as enabled.
     const { agents } = await apiClient.listAgents();
     const mockAgent = agents.find((a) => a.name === "mock-agent");
     expect(mockAgent, "mock-agent must be registered").toBeTruthy();
@@ -30,12 +43,20 @@ test.describe("Enhance prompt button in task creation", () => {
 
     // Fill the description textarea
     const textarea = testPage.getByTestId("task-description-input");
-    await textarea.fill("fix the login bug");
+    await textarea.fill("Draft task description.");
 
     // The enhance button should be visible and enabled
     const enhanceBtn = testPage.getByTestId("enhance-prompt-button");
     await expect(enhanceBtn).toBeVisible();
     await expect(enhanceBtn).toBeEnabled();
+
+    await enhanceBtn.click();
+
+    await expect(textarea).toHaveValue("Stubbed enhanced task description.");
+    expect(executeBody).toMatchObject({
+      utility_agent_id: "builtin-enhance-prompt",
+      session_id: "",
+    });
   });
 
   test("enhance button is disabled when no utility agent is configured", async ({

--- a/apps/web/e2e/tests/task/enhance-prompt.spec.ts
+++ b/apps/web/e2e/tests/task/enhance-prompt.spec.ts
@@ -6,6 +6,31 @@ import type { ExecutePromptRequest } from "@/lib/api/domains/utility-api";
 // Exercises the regular task-create dialog (New Task in the sidebar); run with office off.
 useRegularMode();
 
+async function configureDefaultUtilityAgent(apiClient: {
+  listAgents: () => Promise<{ agents: Array<{ name: string }> }>;
+  saveUserSettings: (settings: { default_utility_agent_id: string }) => Promise<void>;
+}) {
+  const { agents } = await apiClient.listAgents();
+  const mockAgent = agents.find((a) => a.name === "mock-agent");
+  expect(mockAgent, "mock-agent must be registered").toBeTruthy();
+  await apiClient.saveUserSettings({
+    default_utility_agent_id: mockAgent!.name,
+  });
+}
+
+async function openCreateTaskDialog(
+  testPage: Parameters<typeof test>[0]["testPage"],
+  workspaceId: string,
+) {
+  const kanban = new KanbanPage(testPage);
+  await kanban.goto(workspaceId);
+  await kanban.createTaskButton.first().click();
+
+  const dialog = testPage.getByTestId("create-task-dialog");
+  await expect(dialog).toBeVisible();
+  return dialog;
+}
+
 test.describe("Enhance prompt button in task creation", () => {
   test("enhance button is visible and enabled when utility agent is configured", async ({
     testPage,
@@ -26,20 +51,8 @@ test.describe("Enhance prompt button in task creation", () => {
       });
     });
 
-    // Seed a default utility agent pointing at mock-agent (by name, not UUID).
-    const { agents } = await apiClient.listAgents();
-    const mockAgent = agents.find((a) => a.name === "mock-agent");
-    expect(mockAgent, "mock-agent must be registered").toBeTruthy();
-    await apiClient.saveUserSettings({
-      default_utility_agent_id: mockAgent!.name,
-    });
-
-    const kanban = new KanbanPage(testPage);
-    await kanban.goto(seedData.workspaceId);
-    await kanban.createTaskButton.first().click();
-
-    const dialog = testPage.getByTestId("create-task-dialog");
-    await expect(dialog).toBeVisible();
+    await configureDefaultUtilityAgent(apiClient);
+    await openCreateTaskDialog(testPage, seedData.workspaceId);
 
     // Fill the description textarea
     const textarea = testPage.getByTestId("task-description-input");
@@ -57,6 +70,106 @@ test.describe("Enhance prompt button in task creation", () => {
       utility_agent_id: "builtin-enhance-prompt",
       session_id: "",
     });
+  });
+
+  test("keeps a mid-flight edit, offers recovery, and applies only when requested", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    const initialPrompt = "Synthetic initial enhancement request.";
+    const editedPrompt = "Synthetic mid-flight edited request.";
+    const generatedPrompt = "Synthetic generated enhancement result.";
+    const syntheticCallId = "synthetic-call-id";
+
+    let executeBody: ExecutePromptRequest | null = null;
+    let releaseResponse: (() => void) | null = null;
+    const responseGate = new Promise<void>((resolve) => {
+      releaseResponse = resolve;
+    });
+
+    await testPage.route("**/api/v1/utility/execute", async (route) => {
+      executeBody = route.request().postDataJSON() as ExecutePromptRequest;
+      await responseGate;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: true,
+          call_id: syntheticCallId,
+          response: generatedPrompt,
+        }),
+      });
+    });
+
+    await testPage.context().grantPermissions(["clipboard-read", "clipboard-write"]);
+    await configureDefaultUtilityAgent(apiClient);
+    const dialog = await openCreateTaskDialog(testPage, seedData.workspaceId);
+
+    const textarea = testPage.getByTestId("task-description-input");
+    const enhanceBtn = testPage.getByTestId("enhance-prompt-button");
+
+    await textarea.fill(initialPrompt);
+    await enhanceBtn.click();
+
+    await expect
+      .poll(() => executeBody?.user_prompt ?? null, { timeout: 5_000 })
+      .toBe(initialPrompt);
+
+    await textarea.fill(editedPrompt);
+    releaseResponse?.();
+
+    const recovery = testPage.getByTestId("prompt-result-recovery");
+    await expect(recovery).toBeVisible();
+    await expect(textarea).toHaveValue(editedPrompt);
+    await expect(dialog).not.toContainText(generatedPrompt);
+    await expect(dialog).not.toContainText(syntheticCallId);
+
+    await recovery.getByRole("button", { name: "Copy" }).click();
+    await expect
+      .poll(() => testPage.evaluate(() => navigator.clipboard.readText()), { timeout: 5_000 })
+      .toBe(generatedPrompt);
+    await expect(textarea).toHaveValue(editedPrompt);
+
+    await recovery.getByRole("button", { name: "Apply" }).click();
+    await expect(textarea).toHaveValue(generatedPrompt);
+    await expect(recovery).toHaveCount(0);
+  });
+
+  test("keeps the description unchanged and shows the existing failure toast when enhancement fails", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    const initialPrompt = "Synthetic failure-path prompt.";
+    const utilityError = "Synthetic utility failure.";
+
+    await testPage.route("**/api/v1/utility/execute", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: false,
+          error: utilityError,
+        }),
+      });
+    });
+
+    await configureDefaultUtilityAgent(apiClient);
+    await openCreateTaskDialog(testPage, seedData.workspaceId);
+
+    const textarea = testPage.getByTestId("task-description-input");
+    const enhanceBtn = testPage.getByTestId("enhance-prompt-button");
+
+    await textarea.fill(initialPrompt);
+    await enhanceBtn.click();
+
+    await expect(textarea).toHaveValue(initialPrompt);
+    const toast = testPage.getByTestId("toast-message");
+    await expect(toast).toBeVisible({ timeout: 5_000 });
+    await expect(toast).toContainText("Generation failed");
+    await expect(toast).toContainText(utilityError);
+    await expect(testPage.getByTestId("prompt-result-recovery")).toHaveCount(0);
   });
 
   test("enhance button is disabled when no utility agent is configured", async ({

--- a/apps/web/e2e/tests/task/enhance-prompt.spec.ts
+++ b/apps/web/e2e/tests/task/enhance-prompt.spec.ts
@@ -136,6 +136,61 @@ test.describe("Enhance prompt button in task creation", () => {
     await expect(recovery).toHaveCount(0);
   });
 
+  test("ignores a delayed result after closing and reopening the dialog", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    const prompt = "Synthetic prompt reused after reopening.";
+    const generatedPrompt = "Synthetic delayed enhancement result.";
+    let requestStarted: (() => void) | null = null;
+    let releaseResponse: (() => void) | null = null;
+    const requestGate = new Promise<void>((resolve) => {
+      requestStarted = resolve;
+    });
+    const responseGate = new Promise<void>((resolve) => {
+      releaseResponse = resolve;
+    });
+
+    await testPage.route("**/api/v1/utility/execute", async (route) => {
+      requestStarted?.();
+      await responseGate;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: true,
+          call_id: "delayed-call-id",
+          response: generatedPrompt,
+        }),
+      });
+    });
+
+    await configureDefaultUtilityAgent(apiClient);
+    const dialog = await openCreateTaskDialog(testPage, seedData.workspaceId);
+    const textarea = testPage.getByTestId("task-description-input");
+    const enhanceBtn = testPage.getByTestId("enhance-prompt-button");
+
+    await textarea.fill(prompt);
+    await enhanceBtn.click();
+    await requestGate;
+    await testPage.keyboard.press("Escape");
+    await expect(dialog).not.toBeVisible();
+
+    await openCreateTaskDialog(testPage, seedData.workspaceId);
+    await textarea.fill(prompt);
+    releaseResponse?.();
+    await testPage.evaluate(
+      () =>
+        new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve))),
+    );
+
+    await expect(enhanceBtn).toBeEnabled();
+    await expect(textarea).toHaveValue(prompt);
+    await expect(testPage.getByTestId("prompt-result-recovery")).toHaveCount(0);
+    await expect(testPage.getByTestId("toast-message")).toHaveCount(0);
+  });
+
   test("keeps the description unchanged and shows the existing failure toast when enhancement fails", async ({
     testPage,
     apiClient,

--- a/apps/web/hooks/use-prompt-result-delivery.test.ts
+++ b/apps/web/hooks/use-prompt-result-delivery.test.ts
@@ -130,6 +130,8 @@ it("copyPending reports clipboard failure without clearing the result", async ()
     configurable: true,
     value: { writeText },
   });
+  const appendChild = vi.spyOn(document.body, "appendChild");
+  const createElement = vi.spyOn(document, "createElement");
   const { result } = renderHook(() =>
     usePromptResultDelivery({ getCurrent: () => "edited", apply: vi.fn(() => true) }),
   );
@@ -151,6 +153,39 @@ it("copyPending reports clipboard failure without clearing the result", async ()
     }),
   );
   expect(result.current.pendingResult).toEqual(GENERATED_RESULT);
+  expect(appendChild).not.toHaveBeenCalled();
+  expect(createElement).not.toHaveBeenCalledWith("textarea");
+});
+
+it("copyPending reports failure without DOM fallback when clipboard is unavailable", async () => {
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: undefined,
+  });
+  const appendChild = vi.spyOn(document.body, "appendChild");
+  const createElement = vi.spyOn(document, "createElement");
+  const { result } = renderHook(() =>
+    usePromptResultDelivery({ getCurrent: () => "edited", apply: vi.fn(() => true) }),
+  );
+
+  act(() => {
+    result.current.deliver("original", GENERATED_RESULT);
+  });
+  vi.clearAllMocks();
+
+  await act(async () => {
+    await result.current.copyPending();
+  });
+
+  expect(mockToast).toHaveBeenCalledWith(
+    expect.objectContaining({
+      description: "Enhanced prompt could not be copied.",
+      variant: "error",
+    }),
+  );
+  expect(result.current.pendingResult).toEqual(GENERATED_RESULT);
+  expect(appendChild).not.toHaveBeenCalled();
+  expect(createElement).not.toHaveBeenCalledWith("textarea");
 });
 
 it("dismissPending clears the retained result", () => {

--- a/apps/web/hooks/use-prompt-result-delivery.test.ts
+++ b/apps/web/hooks/use-prompt-result-delivery.test.ts
@@ -32,7 +32,9 @@ it.each([
   ["original", null, false, "retains result after target disappears"],
 ])("%s", (source, current, expectedApplied, _label) => {
   const apply = vi.fn(() => true);
-  const { result } = renderHook(() => usePromptResultDelivery({ getCurrent: () => current, apply }));
+  const { result } = renderHook(() =>
+    usePromptResultDelivery({ getCurrent: () => current, apply }),
+  );
 
   let delivered = false;
   act(() => {
@@ -75,7 +77,9 @@ it("retains the result when insertion rejects unchanged input", () => {
 
 it("applyPending clears only after apply succeeds", () => {
   const apply = vi.fn(() => false);
-  const { result } = renderHook(() => usePromptResultDelivery({ getCurrent: () => "edited", apply }));
+  const { result } = renderHook(() =>
+    usePromptResultDelivery({ getCurrent: () => "edited", apply }),
+  );
 
   act(() => {
     result.current.deliver("original", GENERATED_RESULT);

--- a/apps/web/hooks/use-prompt-result-delivery.test.ts
+++ b/apps/web/hooks/use-prompt-result-delivery.test.ts
@@ -96,6 +96,7 @@ it("applyPending clears only after apply succeeds", () => {
   act(() => {
     result.current.applyPending();
   });
+  expect(apply).toHaveBeenCalledTimes(2);
   expect(result.current.pendingResult).toBeNull();
 });
 

--- a/apps/web/hooks/use-prompt-result-delivery.test.ts
+++ b/apps/web/hooks/use-prompt-result-delivery.test.ts
@@ -1,0 +1,172 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, expect, it, vi } from "vitest";
+
+import type { UtilityGenerationResult } from "./use-utility-agent-generator";
+import { usePromptResultDelivery } from "./use-prompt-result-delivery";
+
+const mockToast = vi.fn();
+
+vi.mock("@/components/toast-provider", () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
+
+const GENERATED_RESULT = {
+  content: "enhanced prompt output",
+  callId: "call-123",
+  durationMs: 1_200,
+} satisfies UtilityGenerationResult;
+
+const INSERT_FAILURE_MESSAGE = "Enhanced prompt was generated but could not be inserted.";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: { writeText: vi.fn().mockResolvedValue(undefined) },
+  });
+});
+
+it.each([
+  ["original", "original", true, "applies unchanged input"],
+  ["original", "edited", false, "retains result after user edit"],
+  ["original", null, false, "retains result after target disappears"],
+])("%s", (source, current, expectedApplied, _label) => {
+  const apply = vi.fn(() => true);
+  const { result } = renderHook(() => usePromptResultDelivery({ getCurrent: () => current, apply }));
+
+  let delivered = false;
+  act(() => {
+    delivered = result.current.deliver(source, GENERATED_RESULT);
+  });
+  expect(delivered).toBe(expectedApplied);
+  expect(apply).toHaveBeenCalledTimes(expectedApplied ? 1 : 0);
+
+  if (expectedApplied) {
+    expect(apply).toHaveBeenCalledWith(GENERATED_RESULT.content);
+    expect(result.current.pendingResult).toBeNull();
+    expect(mockToast).not.toHaveBeenCalled();
+    return;
+  }
+
+  expect(result.current.pendingResult).toEqual(GENERATED_RESULT);
+  expect(mockToast).toHaveBeenCalledWith(
+    expect.objectContaining({ description: INSERT_FAILURE_MESSAGE, variant: "error" }),
+  );
+});
+
+it("retains the result when insertion rejects unchanged input", () => {
+  const apply = vi.fn(() => false);
+  const { result } = renderHook(() =>
+    usePromptResultDelivery({ getCurrent: () => "original", apply }),
+  );
+
+  let delivered = true;
+  act(() => {
+    delivered = result.current.deliver("original", GENERATED_RESULT);
+  });
+  expect(delivered).toBe(false);
+
+  expect(apply).toHaveBeenCalledWith(GENERATED_RESULT.content);
+  expect(result.current.pendingResult).toEqual(GENERATED_RESULT);
+  expect(mockToast).toHaveBeenCalledWith(
+    expect.objectContaining({ description: INSERT_FAILURE_MESSAGE, variant: "error" }),
+  );
+});
+
+it("applyPending clears only after apply succeeds", () => {
+  const apply = vi.fn(() => false);
+  const { result } = renderHook(() => usePromptResultDelivery({ getCurrent: () => "edited", apply }));
+
+  act(() => {
+    result.current.deliver("original", GENERATED_RESULT);
+  });
+  vi.clearAllMocks();
+
+  act(() => {
+    result.current.applyPending();
+  });
+  expect(apply).toHaveBeenCalledWith(GENERATED_RESULT.content);
+  expect(result.current.pendingResult).toEqual(GENERATED_RESULT);
+
+  apply.mockReturnValue(true);
+  act(() => {
+    result.current.applyPending();
+  });
+  expect(result.current.pendingResult).toBeNull();
+});
+
+it("copyPending writes the pending result and reports success", async () => {
+  const writeText = vi.fn().mockResolvedValue(undefined);
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: { writeText },
+  });
+  const { result } = renderHook(() =>
+    usePromptResultDelivery({ getCurrent: () => "edited", apply: vi.fn(() => true) }),
+  );
+
+  act(() => {
+    result.current.deliver("original", GENERATED_RESULT);
+  });
+  vi.clearAllMocks();
+
+  await act(async () => {
+    await result.current.copyPending();
+  });
+
+  expect(writeText).toHaveBeenCalledWith(GENERATED_RESULT.content);
+  expect(mockToast).toHaveBeenCalledWith(
+    expect.objectContaining({
+      description: "Enhanced prompt copied to clipboard.",
+      variant: "success",
+    }),
+  );
+  expect(result.current.pendingResult).toEqual(GENERATED_RESULT);
+});
+
+it("copyPending reports clipboard failure without clearing the result", async () => {
+  const writeText = vi.fn().mockRejectedValue(new Error("denied"));
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: { writeText },
+  });
+  const { result } = renderHook(() =>
+    usePromptResultDelivery({ getCurrent: () => "edited", apply: vi.fn(() => true) }),
+  );
+
+  act(() => {
+    result.current.deliver("original", GENERATED_RESULT);
+  });
+  vi.clearAllMocks();
+
+  await act(async () => {
+    await result.current.copyPending();
+  });
+
+  expect(writeText).toHaveBeenCalledWith(GENERATED_RESULT.content);
+  expect(mockToast).toHaveBeenCalledWith(
+    expect.objectContaining({
+      description: "Enhanced prompt could not be copied.",
+      variant: "error",
+    }),
+  );
+  expect(result.current.pendingResult).toEqual(GENERATED_RESULT);
+});
+
+it("dismissPending clears the retained result", () => {
+  const { result } = renderHook(() =>
+    usePromptResultDelivery({ getCurrent: () => "edited", apply: vi.fn(() => true) }),
+  );
+
+  act(() => {
+    result.current.deliver("original", GENERATED_RESULT);
+  });
+
+  expect(result.current.pendingResult).toEqual(GENERATED_RESULT);
+
+  act(() => {
+    result.current.dismissPending();
+  });
+
+  expect(result.current.pendingResult).toBeNull();
+});

--- a/apps/web/hooks/use-prompt-result-delivery.test.ts
+++ b/apps/web/hooks/use-prompt-result-delivery.test.ts
@@ -33,12 +33,12 @@ it.each([
 ])("%s", (source, current, expectedApplied, _label) => {
   const apply = vi.fn(() => true);
   const { result } = renderHook(() =>
-    usePromptResultDelivery({ getCurrent: () => current, apply }),
+    usePromptResultDelivery({ scopeKey: "test", getCurrent: () => current, apply }),
   );
 
   let delivered = false;
   act(() => {
-    delivered = result.current.deliver(source, GENERATED_RESULT);
+    delivered = result.current.deliver(source, GENERATED_RESULT, result.current.captureScope());
   });
   expect(delivered).toBe(expectedApplied);
   expect(apply).toHaveBeenCalledTimes(expectedApplied ? 1 : 0);
@@ -59,12 +59,12 @@ it.each([
 it("retains the result when insertion rejects unchanged input", () => {
   const apply = vi.fn(() => false);
   const { result } = renderHook(() =>
-    usePromptResultDelivery({ getCurrent: () => "original", apply }),
+    usePromptResultDelivery({ scopeKey: "test", getCurrent: () => "original", apply }),
   );
 
   let delivered = true;
   act(() => {
-    delivered = result.current.deliver("original", GENERATED_RESULT);
+    delivered = result.current.deliver("original", GENERATED_RESULT, result.current.captureScope());
   });
   expect(delivered).toBe(false);
 
@@ -78,11 +78,11 @@ it("retains the result when insertion rejects unchanged input", () => {
 it("applyPending clears only after apply succeeds", () => {
   const apply = vi.fn(() => false);
   const { result } = renderHook(() =>
-    usePromptResultDelivery({ getCurrent: () => "edited", apply }),
+    usePromptResultDelivery({ scopeKey: "test", getCurrent: () => "edited", apply }),
   );
 
   act(() => {
-    result.current.deliver("original", GENERATED_RESULT);
+    result.current.deliver("original", GENERATED_RESULT, result.current.captureScope());
   });
   vi.clearAllMocks();
 
@@ -107,11 +107,15 @@ it("copyPending writes the pending result and reports success", async () => {
     value: { writeText },
   });
   const { result } = renderHook(() =>
-    usePromptResultDelivery({ getCurrent: () => "edited", apply: vi.fn(() => true) }),
+    usePromptResultDelivery({
+      scopeKey: "test",
+      getCurrent: () => "edited",
+      apply: vi.fn(() => true),
+    }),
   );
 
   act(() => {
-    result.current.deliver("original", GENERATED_RESULT);
+    result.current.deliver("original", GENERATED_RESULT, result.current.captureScope());
   });
   vi.clearAllMocks();
 
@@ -138,11 +142,15 @@ it("copyPending reports clipboard failure without clearing the result", async ()
   const appendChild = vi.spyOn(document.body, "appendChild");
   const createElement = vi.spyOn(document, "createElement");
   const { result } = renderHook(() =>
-    usePromptResultDelivery({ getCurrent: () => "edited", apply: vi.fn(() => true) }),
+    usePromptResultDelivery({
+      scopeKey: "test",
+      getCurrent: () => "edited",
+      apply: vi.fn(() => true),
+    }),
   );
 
   act(() => {
-    result.current.deliver("original", GENERATED_RESULT);
+    result.current.deliver("original", GENERATED_RESULT, result.current.captureScope());
   });
   vi.clearAllMocks();
 
@@ -170,11 +178,15 @@ it("copyPending reports failure without DOM fallback when clipboard is unavailab
   const appendChild = vi.spyOn(document.body, "appendChild");
   const createElement = vi.spyOn(document, "createElement");
   const { result } = renderHook(() =>
-    usePromptResultDelivery({ getCurrent: () => "edited", apply: vi.fn(() => true) }),
+    usePromptResultDelivery({
+      scopeKey: "test",
+      getCurrent: () => "edited",
+      apply: vi.fn(() => true),
+    }),
   );
 
   act(() => {
-    result.current.deliver("original", GENERATED_RESULT);
+    result.current.deliver("original", GENERATED_RESULT, result.current.captureScope());
   });
   vi.clearAllMocks();
 
@@ -195,11 +207,15 @@ it("copyPending reports failure without DOM fallback when clipboard is unavailab
 
 it("dismissPending clears the retained result", () => {
   const { result } = renderHook(() =>
-    usePromptResultDelivery({ getCurrent: () => "edited", apply: vi.fn(() => true) }),
+    usePromptResultDelivery({
+      scopeKey: "test",
+      getCurrent: () => "edited",
+      apply: vi.fn(() => true),
+    }),
   );
 
   act(() => {
-    result.current.deliver("original", GENERATED_RESULT);
+    result.current.deliver("original", GENERATED_RESULT, result.current.captureScope());
   });
 
   expect(result.current.pendingResult).toEqual(GENERATED_RESULT);
@@ -209,4 +225,46 @@ it("dismissPending clears the retained result", () => {
   });
 
   expect(result.current.pendingResult).toBeNull();
+});
+
+it("ignores a delayed result after the dialog closes and reopens with the same text", () => {
+  const apply = vi.fn(() => true);
+  const { result, rerender } = renderHook(
+    ({ scopeKey }) => usePromptResultDelivery({ scopeKey, getCurrent: () => "original", apply }),
+    { initialProps: { scopeKey: "dialog:task-1:open-1" } },
+  );
+  const generation = result.current.captureScope();
+
+  rerender({ scopeKey: "dialog:task-1:open-2" });
+
+  let delivered = true;
+  act(() => {
+    delivered = result.current.deliver("original", GENERATED_RESULT, generation);
+  });
+
+  expect(delivered).toBe(false);
+  expect(apply).not.toHaveBeenCalled();
+  expect(result.current.pendingResult).toBeNull();
+  expect(mockToast).not.toHaveBeenCalled();
+});
+
+it("ignores a delayed result after switching task or session with the same text", () => {
+  const apply = vi.fn(() => true);
+  const { result, rerender } = renderHook(
+    ({ scopeKey }) => usePromptResultDelivery({ scopeKey, getCurrent: () => "original", apply }),
+    { initialProps: { scopeKey: "task-1:session-1" } },
+  );
+  const generation = result.current.captureScope();
+
+  rerender({ scopeKey: "task-2:session-2" });
+
+  let delivered = true;
+  act(() => {
+    delivered = result.current.deliver("original", GENERATED_RESULT, generation);
+  });
+
+  expect(delivered).toBe(false);
+  expect(apply).not.toHaveBeenCalled();
+  expect(result.current.pendingResult).toBeNull();
+  expect(mockToast).not.toHaveBeenCalled();
 });

--- a/apps/web/hooks/use-prompt-result-delivery.ts
+++ b/apps/web/hooks/use-prompt-result-delivery.ts
@@ -1,0 +1,121 @@
+"use client";
+
+import { useCallback, useState } from "react";
+
+import { useToast } from "@/components/toast-provider";
+
+import type { UtilityGenerationResult } from "./use-utility-agent-generator";
+
+type UsePromptResultDeliveryOptions = {
+  getCurrent: () => string | null;
+  apply: (value: string) => boolean;
+};
+
+export type PromptResultDelivery = {
+  deliver: (source: string, result: UtilityGenerationResult) => boolean;
+  pendingResult: UtilityGenerationResult | null;
+  applyPending: () => void;
+  copyPending: () => Promise<void>;
+  dismissPending: () => void;
+};
+
+const INSERT_FAILURE_MESSAGE = "Enhanced prompt was generated but could not be inserted.";
+const COPY_SUCCESS_MESSAGE = "Enhanced prompt copied to clipboard.";
+const COPY_FAILURE_MESSAGE = "Enhanced prompt could not be copied.";
+
+function fallbackCopy(text: string): boolean {
+  if (typeof document === "undefined") {
+    return false;
+  }
+
+  const textArea = document.createElement("textarea");
+  textArea.value = text;
+  textArea.style.position = "fixed";
+  textArea.style.opacity = "0";
+  document.body.appendChild(textArea);
+  textArea.focus();
+  textArea.select();
+
+  try {
+    return document.execCommand("copy");
+  } catch {
+    return false;
+  } finally {
+    document.body.removeChild(textArea);
+  }
+}
+
+async function copyText(text: string): Promise<boolean> {
+  if (navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      return fallbackCopy(text);
+    }
+  }
+
+  return fallbackCopy(text);
+}
+
+export function usePromptResultDelivery({
+  getCurrent,
+  apply,
+}: UsePromptResultDeliveryOptions): PromptResultDelivery {
+  const [pendingResult, setPendingResult] = useState<UtilityGenerationResult | null>(null);
+  const { toast } = useToast();
+
+  const retainPendingResult = useCallback(
+    (result: UtilityGenerationResult) => {
+      setPendingResult(result);
+      toast({ description: INSERT_FAILURE_MESSAGE, variant: "error" });
+    },
+    [toast],
+  );
+
+  const deliver = useCallback(
+    (source: string, result: UtilityGenerationResult) => {
+      if (getCurrent() !== source) {
+        retainPendingResult(result);
+        return false;
+      }
+
+      if (apply(result.content)) {
+        setPendingResult(null);
+        return true;
+      }
+
+      retainPendingResult(result);
+      return false;
+    },
+    [apply, getCurrent, retainPendingResult],
+  );
+
+  const applyPending = useCallback(() => {
+    setPendingResult((current) => {
+      if (!current) {
+        return null;
+      }
+
+      return apply(current.content) ? null : current;
+    });
+  }, [apply]);
+
+  const copyPending = useCallback(async () => {
+    if (!pendingResult) {
+      return;
+    }
+
+    const copied = await copyText(pendingResult.content);
+    toast({
+      description: copied ? COPY_SUCCESS_MESSAGE : COPY_FAILURE_MESSAGE,
+      variant: copied ? "success" : "error",
+    });
+  }, [pendingResult, toast]);
+
+  const dismissPending = useCallback(() => {
+    setPendingResult(null);
+  }, []);
+
+  return { deliver, pendingResult, applyPending, copyPending, dismissPending };
+}

--- a/apps/web/hooks/use-prompt-result-delivery.ts
+++ b/apps/web/hooks/use-prompt-result-delivery.ts
@@ -23,39 +23,17 @@ const INSERT_FAILURE_MESSAGE = "Enhanced prompt was generated but could not be i
 const COPY_SUCCESS_MESSAGE = "Enhanced prompt copied to clipboard.";
 const COPY_FAILURE_MESSAGE = "Enhanced prompt could not be copied.";
 
-function fallbackCopy(text: string): boolean {
-  if (typeof document === "undefined") {
-    return false;
-  }
-
-  const textArea = document.createElement("textarea");
-  textArea.value = text;
-  textArea.style.position = "fixed";
-  textArea.style.opacity = "0";
-  document.body.appendChild(textArea);
-  textArea.focus();
-  textArea.select();
-
-  try {
-    return document.execCommand("copy");
-  } catch {
-    return false;
-  } finally {
-    document.body.removeChild(textArea);
-  }
-}
-
 async function copyText(text: string): Promise<boolean> {
   if (navigator.clipboard?.writeText) {
     try {
       await navigator.clipboard.writeText(text);
       return true;
     } catch {
-      return fallbackCopy(text);
+      return false;
     }
   }
 
-  return fallbackCopy(text);
+  return false;
 }
 
 export function usePromptResultDelivery({

--- a/apps/web/hooks/use-prompt-result-delivery.ts
+++ b/apps/web/hooks/use-prompt-result-delivery.ts
@@ -70,14 +70,10 @@ export function usePromptResultDelivery({
   );
 
   const applyPending = useCallback(() => {
-    setPendingResult((current) => {
-      if (!current) {
-        return null;
-      }
-
-      return apply(current.content) ? null : current;
-    });
-  }, [apply]);
+    if (pendingResult && apply(pendingResult.content)) {
+      setPendingResult(null);
+    }
+  }, [apply, pendingResult]);
 
   const copyPending = useCallback(async () => {
     if (!pendingResult) {

--- a/apps/web/hooks/use-prompt-result-delivery.ts
+++ b/apps/web/hooks/use-prompt-result-delivery.ts
@@ -1,18 +1,20 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { useToast } from "@/components/toast-provider";
 
 import type { UtilityGenerationResult } from "./use-utility-agent-generator";
 
 type UsePromptResultDeliveryOptions = {
+  scopeKey: string;
   getCurrent: () => string | null;
   apply: (value: string) => boolean;
 };
 
 export type PromptResultDelivery = {
-  deliver: (source: string, result: UtilityGenerationResult) => boolean;
+  captureScope: () => number;
+  deliver: (source: string, result: UtilityGenerationResult, generation: number) => boolean;
   pendingResult: UtilityGenerationResult | null;
   applyPending: () => void;
   copyPending: () => Promise<void>;
@@ -22,6 +24,11 @@ export type PromptResultDelivery = {
 const INSERT_FAILURE_MESSAGE = "Enhanced prompt was generated but could not be inserted.";
 const COPY_SUCCESS_MESSAGE = "Enhanced prompt copied to clipboard.";
 const COPY_FAILURE_MESSAGE = "Enhanced prompt could not be copied.";
+
+type PendingResult = {
+  result: UtilityGenerationResult;
+  generation: number;
+};
 
 async function copyText(text: string): Promise<boolean> {
   if (navigator.clipboard?.writeText) {
@@ -37,24 +44,44 @@ async function copyText(text: string): Promise<boolean> {
 }
 
 export function usePromptResultDelivery({
+  scopeKey,
   getCurrent,
   apply,
 }: UsePromptResultDeliveryOptions): PromptResultDelivery {
-  const [pendingResult, setPendingResult] = useState<UtilityGenerationResult | null>(null);
+  const [pendingResult, setPendingResult] = useState<PendingResult | null>(null);
+  const scopeKeyRef = useRef(scopeKey);
+  const generationRef = useRef(0);
+  if (scopeKeyRef.current !== scopeKey) {
+    scopeKeyRef.current = scopeKey;
+    generationRef.current += 1;
+  }
   const { toast } = useToast();
 
+  useEffect(
+    () => () => {
+      generationRef.current += 1;
+    },
+    [],
+  );
+
   const retainPendingResult = useCallback(
-    (result: UtilityGenerationResult) => {
-      setPendingResult(result);
+    (result: UtilityGenerationResult, generation: number) => {
+      setPendingResult({ result, generation });
       toast({ description: INSERT_FAILURE_MESSAGE, variant: "error" });
     },
     [toast],
   );
 
+  const captureScope = useCallback(() => generationRef.current, []);
+
   const deliver = useCallback(
-    (source: string, result: UtilityGenerationResult) => {
+    (source: string, result: UtilityGenerationResult, generation: number) => {
+      if (generation !== generationRef.current) {
+        return false;
+      }
+
       if (getCurrent() !== source) {
-        retainPendingResult(result);
+        retainPendingResult(result, generation);
         return false;
       }
 
@@ -63,24 +90,28 @@ export function usePromptResultDelivery({
         return true;
       }
 
-      retainPendingResult(result);
+      retainPendingResult(result, generation);
       return false;
     },
     [apply, getCurrent, retainPendingResult],
   );
 
   const applyPending = useCallback(() => {
-    if (pendingResult && apply(pendingResult.content)) {
+    if (
+      pendingResult &&
+      pendingResult.generation === generationRef.current &&
+      apply(pendingResult.result.content)
+    ) {
       setPendingResult(null);
     }
   }, [apply, pendingResult]);
 
   const copyPending = useCallback(async () => {
-    if (!pendingResult) {
+    if (!pendingResult || pendingResult.generation !== generationRef.current) {
       return;
     }
 
-    const copied = await copyText(pendingResult.content);
+    const copied = await copyText(pendingResult.result.content);
     toast({
       description: copied ? COPY_SUCCESS_MESSAGE : COPY_FAILURE_MESSAGE,
       variant: copied ? "success" : "error",
@@ -91,5 +122,15 @@ export function usePromptResultDelivery({
     setPendingResult(null);
   }, []);
 
-  return { deliver, pendingResult, applyPending, copyPending, dismissPending };
+  const visiblePendingResult =
+    pendingResult?.generation === generationRef.current ? pendingResult.result : null;
+
+  return {
+    captureScope,
+    deliver,
+    pendingResult: visiblePendingResult,
+    applyPending,
+    copyPending,
+    dismissPending,
+  };
 }

--- a/apps/web/hooks/use-utility-agent-generator.test.tsx
+++ b/apps/web/hooks/use-utility-agent-generator.test.tsx
@@ -37,7 +37,11 @@ describe("useUtilityAgentGenerator enhancePrompt", () => {
     let pending!: Promise<void>;
     act(() => {
       pending = result.current.enhancePrompt("original", async (value) => {
-        expect(value).toEqual({ content: "improved prompt", callId: "call-123", durationMs: 80_000 });
+        expect(value).toEqual({
+          content: "improved prompt",
+          callId: "call-123",
+          durationMs: 80_000,
+        });
         expect(result.current.isEnhancingPrompt).toBe(true);
         return delivered;
       });

--- a/apps/web/hooks/use-utility-agent-generator.test.tsx
+++ b/apps/web/hooks/use-utility-agent-generator.test.tsx
@@ -1,0 +1,92 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockExecuteUtilityPrompt = vi.fn();
+const mockToast = vi.fn();
+
+vi.mock("@/lib/api/domains/utility-api", () => ({
+  executeUtilityPrompt: (...args: unknown[]) => mockExecuteUtilityPrompt(...args),
+}));
+vi.mock("@/components/toast-provider", () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
+vi.mock("@/hooks/domains/session/use-session-git-status", () => ({
+  useSessionGitStatus: () => undefined,
+}));
+
+import { useUtilityAgentGenerator } from "./use-utility-agent-generator";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useUtilityAgentGenerator enhancePrompt", () => {
+  it("keeps enhance loading until the successful result is delivered", async () => {
+    mockExecuteUtilityPrompt.mockResolvedValue({
+      success: true,
+      response: "improved prompt",
+      call_id: "call-123",
+      duration_ms: 80_000,
+    });
+    let releaseDelivery!: () => void;
+    const delivered = new Promise<boolean>((resolve) => {
+      releaseDelivery = () => resolve(true);
+    });
+    const { result } = renderHook(() => useUtilityAgentGenerator({ sessionId: null }));
+
+    let pending!: Promise<void>;
+    act(() => {
+      pending = result.current.enhancePrompt("original", async (value) => {
+        expect(value).toEqual({ content: "improved prompt", callId: "call-123", durationMs: 80_000 });
+        expect(result.current.isEnhancingPrompt).toBe(true);
+        return delivered;
+      });
+    });
+    expect(result.current.isEnhancingPrompt).toBe(true);
+    releaseDelivery();
+    await act(async () => {
+      await pending;
+    });
+
+    expect(result.current.isEnhancingPrompt).toBe(false);
+  });
+
+  it("does not toast when delivery declines the result", async () => {
+    mockExecuteUtilityPrompt.mockResolvedValue({ success: true, response: "improved" });
+    const { result } = renderHook(() => useUtilityAgentGenerator({ sessionId: null }));
+
+    await act(async () => {
+      await result.current.enhancePrompt("original", () => false);
+    });
+
+    expect(mockToast).not.toHaveBeenCalled();
+  });
+
+  it("retains API rejection toast behavior", async () => {
+    mockExecuteUtilityPrompt.mockRejectedValue(new Error("network down"));
+    const { result } = renderHook(() => useUtilityAgentGenerator({ sessionId: null }));
+
+    await act(async () => {
+      await result.current.enhancePrompt("original", () => true);
+    });
+
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Generation failed", description: "network down" }),
+    );
+    expect(result.current.isEnhancingPrompt).toBe(false);
+  });
+
+  it("retains unsuccessful response toast behavior", async () => {
+    mockExecuteUtilityPrompt.mockResolvedValue({ success: false, error: "bad response" });
+    const { result } = renderHook(() => useUtilityAgentGenerator({ sessionId: null }));
+
+    await act(async () => {
+      await result.current.enhancePrompt("original", () => true);
+    });
+
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Generation failed", description: "bad response" }),
+    );
+    expect(result.current.isEnhancingPrompt).toBe(false);
+  });
+});

--- a/apps/web/hooks/use-utility-agent-generator.ts
+++ b/apps/web/hooks/use-utility-agent-generator.ts
@@ -29,8 +29,16 @@ type UseUtilityAgentGeneratorOptions = {
   taskDescription?: string;
 };
 
+export type UtilityGenerationResult = {
+  content: string;
+  callId?: string;
+  durationMs?: number;
+};
+
+type ResultDelivery = (result: UtilityGenerationResult) => boolean | Promise<boolean>;
+
 type GenerateOptions = {
-  onSuccess?: (content: string) => void;
+  onSuccess?: ResultDelivery;
   // Additional context for PR description
   commitLog?: string;
   diffSummary?: string;
@@ -105,24 +113,27 @@ export function useUtilityAgentGenerator({
       setGenerating((prev) => new Set(prev).add(type));
       try {
         const resp = await executeUtilityPrompt(buildRequest(type, options));
-        clearType(type);
-        if (resp.success && resp.response) {
-          const response = resp.response;
-          requestAnimationFrame(() => options?.onSuccess?.(response));
-        } else {
+        if (!resp.success || !resp.response) {
           toast({
             title: "Generation failed",
             description: resp.error || "Failed to generate content",
             variant: "error",
           });
+          return;
         }
+        await options?.onSuccess?.({
+          content: resp.response,
+          callId: resp.call_id,
+          durationMs: resp.duration_ms,
+        });
       } catch (error) {
-        clearType(type);
         toast({
           title: "Generation failed",
           description: error instanceof Error ? error.message : "Unknown error",
           variant: "error",
         });
+      } finally {
+        clearType(type);
       }
     },
     [sessionId, buildRequest, clearType, toast],
@@ -136,18 +147,36 @@ function useGeneratorCallbacks(
   generating: Set<GeneratorType>,
 ) {
   const generateCommitMessage = useCallback(
-    (onSuccess: (message: string) => void) => generate("commit-message", { onSuccess }),
+    (onSuccess: (message: string) => void) =>
+      generate("commit-message", {
+        onSuccess: (result) => {
+          onSuccess(result.content);
+          return true;
+        },
+      }),
     [generate],
   );
 
   const generateCommitDescription = useCallback(
-    (onSuccess: (description: string) => void) => generate("commit-description", { onSuccess }),
+    (onSuccess: (description: string) => void) =>
+      generate("commit-description", {
+        onSuccess: (result) => {
+          onSuccess(result.content);
+          return true;
+        },
+      }),
     [generate],
   );
 
   const generatePRTitle = useCallback(
     (onSuccess: (title: string) => void, extra?: { commitLog?: string; diffSummary?: string }) =>
-      generate("pr-title", { onSuccess, ...extra }),
+      generate("pr-title", {
+        ...extra,
+        onSuccess: (result) => {
+          onSuccess(result.content);
+          return true;
+        },
+      }),
     [generate],
   );
 
@@ -155,12 +184,19 @@ function useGeneratorCallbacks(
     (
       onSuccess: (description: string) => void,
       extra?: { commitLog?: string; diffSummary?: string },
-    ) => generate("pr-description", { onSuccess, ...extra }),
+    ) =>
+      generate("pr-description", {
+        ...extra,
+        onSuccess: (result) => {
+          onSuccess(result.content);
+          return true;
+        },
+      }),
     [generate],
   );
 
   const enhancePrompt = useCallback(
-    (userPrompt: string, onSuccess: (enhanced: string) => void) =>
+    (userPrompt: string, onSuccess: ResultDelivery) =>
       generate(ENHANCE_PROMPT, { onSuccess, userPrompt }),
     [generate],
   );

--- a/docs/plans/enhance-prompt-result-delivery/plan.md
+++ b/docs/plans/enhance-prompt-result-delivery/plan.md
@@ -385,11 +385,16 @@ small shared recovery control gives the user explicit Apply and Copy choices.
 
 - [ ] **Step 3: Run full affected-package validation**
 
-  Run in order:
+   Run in order:
 
-  ```zsh
-  cd apps
-  pnpm --filter @kandev/web test -- --run hooks/use-utility-agent-generator.test.tsx hooks/use-prompt-result-delivery.test.ts components/prompt-result-recovery.test.tsx components/task/simple/task-chat.test.tsx
+   ```zsh
+   make fmt
+   make typecheck
+   make test
+   make lint
+
+   cd apps
+   pnpm --filter @kandev/web test -- --run hooks/use-utility-agent-generator.test.tsx hooks/use-prompt-result-delivery.test.ts components/prompt-result-recovery.test.tsx components/task/simple/task-chat.test.tsx
   pnpm --filter @kandev/web typecheck
   pnpm --filter @kandev/web lint
   cd web && pnpm e2e -- e2e/tests/task/enhance-prompt.spec.ts

--- a/docs/plans/enhance-prompt-result-delivery/plan.md
+++ b/docs/plans/enhance-prompt-result-delivery/plan.md
@@ -1,0 +1,435 @@
+# Enhance Prompt Result Delivery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every successful sessionless Improve prompt with AI request visibly
+apply its result or retain it for an explicit Apply or Copy action.
+
+**Architecture:** Keep the sessionless host-utility API unchanged. Refactor the
+shared web generator so a caller's result-delivery callback is awaited before its
+loading flag clears. A focused frontend helper will compare the source snapshot
+with the current editor value, apply only unchanged targets through each editor's
+normal update API, and retain changed or unavailable results in local state. A
+small shared recovery control gives the user explicit Apply and Copy choices.
+
+**Tech Stack:** React, TypeScript, Vitest, React Testing Library, existing
+`@kandev/ui` components and `useToast`.
+
+## Global Constraints
+
+- Scope only sessionless `enhance-prompt` delivery plus shared-hook regression
+  compatibility; do not change the backend utility architecture, retries,
+  provider authentication, or model choice.
+- Never write a generated result over input changed after generation started.
+- Do not expose raw prompt or generated text in diagnostics or logs.
+- A completed result must be applied or retained behind an explicit Apply or
+  Copy control; a toast alone is not recovery.
+- Keep existing failed HTTP/provider error toasts and VCS generator behavior.
+- Use native `@kandev/ui` components and keep every action button
+  `cursor-pointer`.
+
+---
+
+## Planned file structure
+
+| File | Responsibility |
+| --- | --- |
+| `apps/web/hooks/use-utility-agent-generator.ts` | Await result delivery and expose a typed generated-result payload. |
+| `apps/web/hooks/use-utility-agent-generator.test.tsx` | Prove success ordering, rejected application, and API failures. |
+| `apps/web/hooks/use-prompt-result-delivery.ts` | Keep pending result, prevent stale overwrite, and provide explicit apply/copy operations. |
+| `apps/web/hooks/use-prompt-result-delivery.test.ts` | Prove unchanged, changed, and missing-target delivery outcomes. |
+| `apps/web/components/prompt-result-recovery.tsx` | Render the generic inline Apply/Copy control without rendering raw prompt text. |
+| `apps/web/components/prompt-result-recovery.test.tsx` | Prove the user can apply or copy the retained result. |
+| `apps/web/components/task-create-dialog.tsx` | Deliver task description enhancements through the TipTap state API. |
+| `apps/web/components/task/new-session-dialog.tsx` | Deliver new-session enhancements safely and render recovery next to its textarea. |
+| `apps/web/components/task/new-session-form-prompt.tsx` | Accept the new recovery slot beside the session prompt controls. |
+| `apps/web/components/task/use-subtask-submit.ts` | Deliver subtask enhancements safely through the subtask prompt state. |
+| `apps/web/components/task/new-subtask-form-parts.tsx` | Render the recovery slot beside the subtask prompt controls. |
+| `apps/web/components/task/simple/task-chat.tsx` | Preserve simple-task chat edits made during generation. |
+| focused existing component tests | Prove each wired surface receives the same guarded-delivery contract. |
+| `apps/web/e2e/tests/task/enhance-prompt.spec.ts` | Stub one successful API response and assert a visible editor result. |
+
+### Task 1: Make shared generator delivery explicit and awaited
+
+**Files:**
+
+- Modify: `apps/web/hooks/use-utility-agent-generator.ts:26-181`
+- Create: `apps/web/hooks/use-utility-agent-generator.test.tsx`
+
+**Interfaces:**
+
+- Consumes: `executeUtilityPrompt(request)` returning `success`, `response`,
+  optional `call_id`, and optional `duration_ms`.
+- Produces:
+
+  ```ts
+  export type UtilityGenerationResult = {
+    content: string;
+    callId?: string;
+    durationMs?: number;
+  };
+
+  type ResultDelivery = (result: UtilityGenerationResult) => boolean | Promise<boolean>;
+  enhancePrompt: (userPrompt: string, deliver: ResultDelivery) => Promise<void>;
+  ```
+
+- Preserves: `generateCommitMessage`, `generateCommitDescription`,
+  `generatePRTitle`, and `generatePRDescription` accepting their existing
+  string callbacks.
+
+- [ ] **Step 1: Write the failing shared-hook tests**
+
+  Create `apps/web/hooks/use-utility-agent-generator.test.tsx` using
+  `renderHook`, mocked `executeUtilityPrompt`, `useSessionGitStatus`, and
+  `useToast`. Cover the observable contract rather than the animation-frame
+  implementation:
+
+  ```tsx
+  it("keeps enhance loading until the successful result is delivered", async () => {
+    mockExecuteUtilityPrompt.mockResolvedValue({
+      success: true,
+      response: "improved prompt",
+      call_id: "call-123",
+      duration_ms: 80_000,
+    });
+    let releaseDelivery!: () => void;
+    const delivered = new Promise<boolean>((resolve) => {
+      releaseDelivery = () => resolve(true);
+    });
+    const { result } = renderHook(() => useUtilityAgentGenerator({ sessionId: null }));
+
+    await act(async () => {
+      const pending = result.current.enhancePrompt("original", async (value) => {
+        expect(value).toEqual({ content: "improved prompt", callId: "call-123", durationMs: 80_000 });
+        expect(result.current.isEnhancingPrompt).toBe(true);
+        return delivered;
+      });
+      releaseDelivery();
+      await pending;
+    });
+
+    expect(result.current.isEnhancingPrompt).toBe(false);
+  });
+  ```
+
+  Add one test for a delivery callback returning `false` (it must not produce a
+  success toast or replace input itself), plus API-rejection and
+  `{ success: false, error }` tests that retain the existing error-toast
+  behavior and reset loading.
+
+- [ ] **Step 2: Run the new test and verify the expected red state**
+
+  Run:
+
+  ```zsh
+  cd apps && pnpm --filter @kandev/web test -- --run hooks/use-utility-agent-generator.test.tsx
+  ```
+
+  Expected: failure because the current callback receives only a string and
+  loading clears before that callback runs.
+
+- [ ] **Step 3: Implement the typed awaited delivery contract**
+
+  In `use-utility-agent-generator.ts`, replace the deferred
+  `requestAnimationFrame` handoff with an awaited callback. Build the typed
+  payload from the API response, await `options.onSuccess(payload)`, and move
+  `clearType(type)` to the `finally` block.
+
+  The essential branch must be equivalent to:
+
+  ```ts
+  try {
+    const resp = await executeUtilityPrompt(buildRequest(type, options));
+    if (!resp.success || !resp.response) {
+      toast({ title: "Generation failed", description: resp.error || "Failed to generate content", variant: "error" });
+      return;
+    }
+    await options?.onSuccess?.({
+      content: resp.response,
+      callId: resp.call_id,
+      durationMs: resp.duration_ms,
+    });
+  } catch (error) {
+    toast({ title: "Generation failed", description: error instanceof Error ? error.message : "Unknown error", variant: "error" });
+  } finally {
+    clearType(type);
+  }
+  ```
+
+  Adapt the four non-enhance wrapper callbacks to forward `result.content` and
+  return `true`; define `enhancePrompt` to require the outcome-bearing
+  delivery callback. Do not let a `false` delivery outcome create a second,
+  generic failure toast because the caller owns the recovery UI.
+
+- [ ] **Step 4: Run the hook test and verify green**
+
+  Run the command from Step 2.
+
+  Expected: PASS; success application is awaited, API failure behavior remains
+  visible, and no test requires `requestAnimationFrame`.
+
+- [ ] **Step 5: Commit the focused hook change**
+
+  ```zsh
+  git add apps/web/hooks/use-utility-agent-generator.ts apps/web/hooks/use-utility-agent-generator.test.tsx
+  git commit -m "fix(web): await utility prompt delivery"
+  ```
+
+### Task 2: Add reusable guarded delivery and recovery UI
+
+**Files:**
+
+- Create: `apps/web/hooks/use-prompt-result-delivery.ts`
+- Create: `apps/web/hooks/use-prompt-result-delivery.test.ts`
+- Create: `apps/web/components/prompt-result-recovery.tsx`
+- Create: `apps/web/components/prompt-result-recovery.test.tsx`
+
+**Interfaces:**
+
+- Consumes: source text captured before generation; `getCurrent(): string | null`;
+  `apply(value: string): boolean`; and `UtilityGenerationResult` from Task 1.
+- Produces:
+
+  ```ts
+  type PromptResultDelivery = {
+    deliver: (source: string, result: UtilityGenerationResult) => boolean;
+    pendingResult: UtilityGenerationResult | null;
+    applyPending: () => void;
+    copyPending: () => Promise<void>;
+    dismissPending: () => void;
+  };
+  ```
+
+- [ ] **Step 1: Write failing helper and component tests**
+
+  Test the helper with ordinary functions rather than a DOM ref:
+
+  ```ts
+  it.each([
+    ["original", "original", true, "applies unchanged input"],
+    ["original", "edited", false, "retains result after user edit"],
+    ["original", null, false, "retains result after target disappears"],
+  ])("%s", (source, current, expectedApplied) => {
+    const apply = vi.fn(() => true);
+    const { result } = renderHook(() => usePromptResultDelivery({ getCurrent: () => current, apply }));
+    expect(result.current.deliver(source, GENERATED_RESULT)).toBe(expectedApplied);
+    expect(apply).toHaveBeenCalledTimes(expectedApplied ? 1 : 0);
+  });
+  ```
+
+  Add a component test that renders `PromptResultRecovery` with a pending
+  result, clicks Apply and verifies its callback, then clicks Copy and verifies
+  `navigator.clipboard.writeText` receives the exact result. Assert user-facing
+  copy says only that an enhanced prompt is available; do not render the raw
+  result in the alert text.
+
+- [ ] **Step 2: Run the new tests and verify red**
+
+  Run:
+
+  ```zsh
+  cd apps && pnpm --filter @kandev/web test -- --run hooks/use-prompt-result-delivery.test.ts components/prompt-result-recovery.test.tsx
+  ```
+
+  Expected: failure because neither guarded-delivery helper nor recovery
+  component exists.
+
+- [ ] **Step 3: Implement the helper and recovery control**
+
+  Implement the helper as local React state. `deliver` must only call `apply`
+  when `getCurrent()` exactly equals the captured source and `apply` returns
+  true. Otherwise retain the typed result, show the existing error toast text
+  `"Enhanced prompt was generated but could not be inserted."`, and return
+  false. `applyPending` is an explicit user action, may replace the current
+  editor text, and clears only after `apply` succeeds. `copyPending` writes the
+  result to the clipboard, reports copy success/failure through the existing
+  toast, and does not log content.
+
+  Render the recovery control with a concise status plus outline `Copy` and
+  primary `Apply` buttons; use `aria-live="polite"`, `cursor-pointer` classes,
+  and `data-testid="prompt-result-recovery"`. It must not put raw generated
+  text into diagnostics, data attributes, or visible prose.
+
+- [ ] **Step 4: Run the helper and component tests and verify green**
+
+  Run the command from Step 2.
+
+  Expected: PASS; changed and unavailable targets retain a recoverable result,
+  and Apply/Copy works only after user action.
+
+- [ ] **Step 5: Commit the reusable recovery layer**
+
+  ```zsh
+  git add apps/web/hooks/use-prompt-result-delivery.ts apps/web/hooks/use-prompt-result-delivery.test.ts apps/web/components/prompt-result-recovery.tsx apps/web/components/prompt-result-recovery.test.tsx
+  git commit -m "fix(web): retain unavailable enhanced prompts"
+  ```
+
+### Task 3: Wire every sessionless editor through the guarded delivery contract
+
+**Files:**
+
+- Modify: `apps/web/components/task-create-dialog.tsx:250-265`
+- Modify: `apps/web/components/task/new-session-dialog.tsx:169-188,303-463`
+- Modify: `apps/web/components/task/new-session-form-prompt.tsx`
+- Modify: `apps/web/components/task/use-subtask-submit.ts:151-191`
+- Modify: `apps/web/components/task/new-subtask-form-parts.tsx`
+- Modify: `apps/web/components/task/simple/task-chat.tsx:281-377`
+- Modify/Create: the smallest matching `*.test.tsx` files beside the changed
+  session and subtask prompt forms.
+
+**Interfaces:**
+
+- Consumes: `enhancePrompt(source, deliver)` from Task 1 and
+  `usePromptResultDelivery` from Task 2.
+- Produces: each sessionless Improve prompt button captures its exact source,
+  delegates safe application to the helper, shows success acknowledgement after
+  immediate insertion, and renders `PromptResultRecovery` when needed.
+
+- [ ] **Step 1: Write failing surface tests**
+
+  Add focused tests that mock a successful utility response and assert each
+  surface's editor state, not merely spinner state:
+
+  ```tsx
+  await user.click(screen.getByTestId("enhance-prompt-button"));
+  await waitFor(() => expect(screen.getByRole("textbox")).toHaveValue("improved prompt"));
+  expect(screen.queryByTestId("prompt-result-recovery")).not.toBeInTheDocument();
+  ```
+
+  For the changed-input path, resolve the mocked utility promise only after
+  changing the editor value. Assert the changed value remains, the recovery
+  control appears, and clicking Apply replaces it with the generated result.
+  Add one ref-null test through the extracted delivery helper or the relevant
+  prompt-zone hook. Retain existing API-failure coverage and assert it never
+  replaces editor content.
+
+- [ ] **Step 2: Run the surface tests and verify red**
+
+  Run the exact focused file list selected during Step 1, for example:
+
+  ```zsh
+  cd apps && pnpm --filter @kandev/web test -- --run components/task/simple/task-chat.test.tsx components/task/new-session-form-prompt.test.tsx components/task/new-subtask-form-parts.test.tsx
+  ```
+
+  Expected: failure because the current callback is deferred and all but simple
+  chat silently drop a missing ref; simple chat overwrites changed text.
+
+- [ ] **Step 3: Wire each canonical editor update path**
+
+  At every caller, capture the exact text before starting generation and call
+  the shared helper from the awaited delivery callback. Update editor state only
+  through its owning API:
+
+  - Task create: `descriptionInputRef.current.getValue()` and `.setValue()`;
+    set `hasDescription` only when the setter succeeds.
+  - New session: promote the textarea value to the form's prompt state so the
+    controlled setter, submit resolver, and `hasPrompt` stay consistent; pass
+    the recovery control through `SessionPromptField`.
+  - New subtask: use the existing task-form prompt input handle rather than a
+    raw textarea assignment; pass the recovery control through the subtask
+    prompt form part and make `resolvePrompt` read the same state.
+  - Simple task chat: use `input` and `setInput`; a different current value
+    must retain, not overwrite, the generated result.
+
+  Immediately applied results show a concise success toast. Changed or absent
+  targets render the local recovery control; no raw prompt content goes into
+  toast text. Keep active-session TipTap and VCS behavior compiling against the
+  shared-hook contract; do not add sessionless recovery UI to unrelated VCS
+  generators.
+
+- [ ] **Step 4: Run surface tests and verify green**
+
+  Re-run the exact command from Step 2 after each caller is wired.
+
+  Expected: PASS; all four sessionless surfaces safely apply unchanged text and
+  expose recovery when the source no longer matches or the target is absent.
+
+- [ ] **Step 5: Commit the editor wiring**
+
+  ```zsh
+  git add apps/web/components/task-create-dialog.tsx apps/web/components/task/new-session-dialog.tsx apps/web/components/task/new-session-form-prompt.tsx apps/web/components/task/use-subtask-submit.ts apps/web/components/task/new-subtask-form-parts.tsx apps/web/components/task/simple/task-chat.tsx apps/web/components/task/*.test.tsx apps/web/components/task/simple/task-chat.test.tsx
+  git commit -m "fix(web): recover enhanced prompt results"
+  ```
+
+### Task 4: Prove the user path and complete validation
+
+**Files:**
+
+- Modify: `apps/web/e2e/tests/task/enhance-prompt.spec.ts`
+- Modify: `docs/enhance-prompt-result-delivery.md` only if implementation
+  evidence changes a stated open question or verification command.
+
+**Interfaces:**
+
+- Consumes: sessionless API response with `success`, `call_id`, and `response`.
+- Produces: a browser guard proving successful enhancement changes a visible
+  editor plus an implementation audit against the investigation requirements.
+
+- [ ] **Step 1: Write the failing browser assertion**
+
+  Add a single route stub to the existing enhancement spec and exercise the
+  task-create prompt. Assert the utility request receives the sessionless
+  utility agent id and the description field visibly changes to the stubbed
+  response. Do not include real user prompt or generated content in test logs.
+
+- [ ] **Step 2: Run the browser assertion and verify red**
+
+  Run:
+
+  ```zsh
+  cd apps/web && pnpm e2e -- e2e/tests/task/enhance-prompt.spec.ts
+  ```
+
+  Expected before wiring: the test observes spinner completion without the
+  expected editor value.
+
+- [ ] **Step 3: Run full affected-package validation**
+
+  Run in order:
+
+  ```zsh
+  cd apps
+  pnpm --filter @kandev/web test -- --run hooks/use-utility-agent-generator.test.tsx hooks/use-prompt-result-delivery.test.ts components/prompt-result-recovery.test.tsx components/task/simple/task-chat.test.tsx
+  pnpm --filter @kandev/web typecheck
+  pnpm --filter @kandev/web lint
+  cd web && pnpm e2e -- e2e/tests/task/enhance-prompt.spec.ts
+  ```
+
+  If `apps/node_modules` is absent, run `pnpm install --frozen-lockfile` from
+  `apps/` first, then repeat the same commands. Fix every failure before
+  proceeding; do not treat an unavailable test runner as proof.
+
+- [ ] **Step 4: Run the manual smoke check**
+
+  Start the local web app against the released/local service, submit a
+  representative large prompt, and verify all of the following:
+
+  1. An unchanged target receives the generated text and a success
+     acknowledgement after loading stops.
+  2. Editing the target while the request is pending preserves the edit and
+     reveals Apply/Copy.
+  3. Copy copies the generated text; Apply replaces only after the explicit
+     click.
+  4. A failed API response leaves the editor unchanged and keeps the existing
+     error toast.
+  5. No UI diagnostics reveal raw prompt content or utility-call history.
+
+- [ ] **Step 5: Commit the tests and audit-aligned documentation**
+
+  ```zsh
+  git add apps/web/e2e/tests/task/enhance-prompt.spec.ts docs/enhance-prompt-result-delivery.md
+  git commit -m "test(web): cover enhanced prompt delivery"
+  ```
+
+## Plan self-review
+
+- **Spec coverage:** Tasks 1–3 cover awaited delivery, explicit result outcome,
+  all four sessionless callers, success acknowledgement, changed/missing target
+  recovery, and error preservation. Task 4 covers the required focused tests,
+  package checks, browser guard, and manual smoke path. Backend architecture,
+  retries, model choice, and raw call history remain explicitly out of scope.
+- **Placeholder scan:** no TBD/TODO or unspecified test action remains; every
+  task lists exact files, interfaces, red/green commands, and expected behavior.
+- **Type consistency:** Task 1's `UtilityGenerationResult` and callback are the
+  sole payload consumed by Task 2 and supplied by Task 3; non-enhance wrappers
+  preserve their string callback API.


### PR DESCRIPTION
Enhanced prompts now reach their intended task inputs without overwriting edits made while generation is running. When an input has changed or disappeared, the completed result remains available to apply or copy instead of being discarded.

## Important Changes

- Make result delivery outcome-aware across new tasks, sessions, subtasks, and simple task chat.
- Preserve unavailable or changed-target results in reusable Apply/Copy recovery controls.
- Extend unit and Playwright coverage, including active-session quick-chat compatibility.

## Validation

- `make fmt`
- `make typecheck`
- `make lint` with Go 1.26.5 and golangci-lint v2.12.2
- Focused web unit and enhancement end-to-end tests
- `make test` remains blocked in this environment by unrelated backend path, loopback, SQLite, and repository fixture failures.

Closes #1853

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have manually tested my changes and they work as expected.
- [x] My changes have tests that cover the new functionality and edge cases.
- [x] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [x] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.

## Screenshots

Desktop — recovery controls preserve the edited prompt.

![Desktop recovery controls](https://raw.githubusercontent.com/ASRagab/kandev/47346d5de7eb1c9507d5defe7433fd01f2494fb7/prompt-result-recovery-desktop.png)

Mobile — recovery controls remain usable in the responsive task dialog.

![Mobile recovery controls](https://raw.githubusercontent.com/ASRagab/kandev/47346d5de7eb1c9507d5defe7433fd01f2494fb7/prompt-result-recovery-mobile.png)
