### PR TITLE
fix: restore line expansion for multi-repo diffs

### DIFF
--- a/apps/backend/internal/agentctl/server/api/git.go
+++ b/apps/backend/internal/agentctl/server/api/git.go
@@ -1012,7 +1012,7 @@ func (s *Server) handleGitCumulativeDiffMultiRepo(
 		}
 		anyOK = true
 		merged.TotalCommits += result.TotalCommits
-		mergeCumulativeFiles(merged.Files, result.Files, sub)
+		mergeCumulativeFiles(merged.Files, result.Files, sub, result.BaseCommit)
 	}
 	if !anyOK {
 		merged.Success = false
@@ -1034,13 +1034,14 @@ func (s *Server) resolvePerRepoBase(c *gin.Context, repo string) string {
 
 // mergeCumulativeFiles copies per-repo files into the merged map under a
 // `<repo> <path>` key (NUL-separated) and decorates each file payload
-// with `repository_name` + a `path` field carrying the repo-relative path.
+// with `repository_name`, the repo-relative `path`, and the exact old-side
+// `base_ref` used to produce its cumulative diff.
 // The composite key keeps `README.md` in two repos from clashing in the map;
 // the frontend reads `path` and `repository_name` off the payload so the
 // file tree groups under the repo header without the prefix bleeding into
 // the displayed path. NUL is impossible in real paths, so the key is
 // always uniquely splittable and the displayed path is unaffected.
-func mergeCumulativeFiles(dst, src map[string]interface{}, repo string) {
+func mergeCumulativeFiles(dst, src map[string]interface{}, repo, baseRef string) {
 	for path, payload := range src {
 		m, ok := payload.(map[string]interface{})
 		if !ok {
@@ -1050,16 +1051,19 @@ func mergeCumulativeFiles(dst, src map[string]interface{}, repo string) {
 			dst[fmt.Sprintf("%s\x00%s", repo, path)] = payload
 			continue
 		}
-		// Shallow-copy the per-file map before stamping repository_name +
-		// path so the caller's source map isn't mutated. Earlier code wrote
-		// directly to `m`, which permanently rewrote the per-repo result
+		// Shallow-copy the per-file map before stamping repository_name,
+		// path, and base_ref so the caller's source map isn't mutated. Earlier
+		// code wrote directly to `m`, which permanently rewrote the per-repo result
 		// before it could be reused (e.g. emitted to a second consumer).
-		copied := make(map[string]interface{}, len(m)+2)
+		copied := make(map[string]interface{}, len(m)+3)
 		for k, v := range m {
 			copied[k] = v
 		}
 		copied["repository_name"] = repo
 		copied["path"] = path
+		if baseRef != "" {
+			copied["base_ref"] = baseRef
+		}
 		dst[fmt.Sprintf("%s\x00%s", repo, path)] = copied
 	}
 }

--- a/apps/backend/internal/agentctl/server/api/git_multi_repo_review_test.go
+++ b/apps/backend/internal/agentctl/server/api/git_multi_repo_review_test.go
@@ -17,6 +17,7 @@ import (
 func TestMultiRepoReviewEndpointsUseStoredBaseBranches(t *testing.T) {
 	taskRoot := t.TempDir()
 	bases := map[string]string{"frontend": "develop", "backend": "release"}
+	baseCommits := make(map[string]string, len(bases))
 	baseCommit := ""
 	for repo, baseBranch := range bases {
 		repoDir := filepath.Join(taskRoot, repo)
@@ -29,8 +30,10 @@ func TestMultiRepoReviewEndpointsUseStoredBaseBranches(t *testing.T) {
 		writeFileAPI(t, repoDir, "README.md", "base\n")
 		runGitAPI(t, repoDir, "add", ".")
 		runGitAPI(t, repoDir, "commit", "-m", "initial")
+		repoBaseCommit := strings.TrimSpace(runGitAPI(t, repoDir, "rev-parse", "HEAD"))
+		baseCommits[repo] = repoBaseCommit
 		if baseCommit == "" {
-			baseCommit = strings.TrimSpace(runGitAPI(t, repoDir, "rev-parse", "HEAD"))
+			baseCommit = repoBaseCommit
 		}
 		runGitAPI(t, repoDir, "checkout", "-b", "feature/review")
 		writeFileAPI(t, repoDir, "changed.txt", repo+" change\n")
@@ -81,8 +84,44 @@ func TestMultiRepoReviewEndpointsUseStoredBaseBranches(t *testing.T) {
 		t.Fatalf("cumulative diff files = %d, want %d: %s", len(diff.Files), len(bases), diffResponse.Body.String())
 	}
 	for repo := range bases {
-		if _, ok := diff.Files[repo+"\x00changed.txt"]; !ok {
+		payload, ok := diff.Files[repo+"\x00changed.txt"]
+		if !ok {
 			t.Errorf("cumulative diff missing %s/changed.txt: %s", repo, diffResponse.Body.String())
+			continue
+		}
+		file, ok := payload.(map[string]interface{})
+		if !ok {
+			t.Fatalf("cumulative diff payload for %s has type %T", repo, payload)
+		}
+		if got := file["base_ref"]; got != baseCommits[repo] {
+			t.Errorf("cumulative diff base_ref for %s = %v, want %s", repo, got, baseCommits[repo])
+		}
+	}
+
+	for repo, baseBranch := range bases {
+		contentResponse := httptest.NewRecorder()
+		path := "/api/v1/workspace/file/content-at-ref?repo=" + repo +
+			"&path=README.md&ref=" + baseBranch
+		srv.Router().ServeHTTP(
+			contentResponse,
+			httptest.NewRequest(http.MethodGet, path, nil),
+		)
+		if contentResponse.Code != http.StatusOK {
+			t.Fatalf(
+				"file content at ref for %s status = %d: %s",
+				repo,
+				contentResponse.Code,
+				contentResponse.Body.String(),
+			)
+		}
+		var content struct {
+			Content string `json:"content"`
+		}
+		if err := json.Unmarshal(contentResponse.Body.Bytes(), &content); err != nil {
+			t.Fatalf("decode file content at ref for %s: %v", repo, err)
+		}
+		if content.Content != "base\n" {
+			t.Errorf("file content at ref for %s = %q, want %q", repo, content.Content, "base\n")
 		}
 	}
 }

--- a/apps/backend/internal/agentctl/server/api/git_multi_repo_review_test.go
+++ b/apps/backend/internal/agentctl/server/api/git_multi_repo_review_test.go
@@ -98,6 +98,23 @@ func TestMultiRepoReviewEndpointsUseStoredBaseBranches(t *testing.T) {
 		}
 	}
 
+	missingRepoResponse := httptest.NewRecorder()
+	srv.Router().ServeHTTP(
+		missingRepoResponse,
+		httptest.NewRequest(
+			http.MethodGet,
+			"/api/v1/workspace/file/content-at-ref?path=README.md&ref=HEAD",
+			nil,
+		),
+	)
+	if !strings.Contains(missingRepoResponse.Body.String(), "repo is required for multi-repo workspace") {
+		t.Fatalf(
+			"repo-less file content response = %d: %s",
+			missingRepoResponse.Code,
+			missingRepoResponse.Body.String(),
+		)
+	}
+
 	for repo, baseBranch := range bases {
 		contentResponse := httptest.NewRecorder()
 		path := "/api/v1/workspace/file/content-at-ref?repo=" + repo +

--- a/apps/backend/internal/agentctl/server/api/workspace.go
+++ b/apps/backend/internal/agentctl/server/api/workspace.go
@@ -154,7 +154,13 @@ func (s *Server) handleFileContentAtRef(c *gin.Context) {
 		return
 	}
 
-	tracker, err := s.procMgr.GetWorkspaceTrackerFor(c.Query("repo"))
+	repo := c.Query("repo")
+	if repo == "" && len(s.procMgr.RepoSubpaths()) > 0 {
+		c.JSON(400, types.FileContentResponse{Path: path, Error: "repo is required for multi-repo workspace"})
+		return
+	}
+
+	tracker, err := s.procMgr.GetWorkspaceTrackerFor(repo)
 	if err != nil {
 		c.JSON(400, types.FileContentResponse{Path: path, Error: err.Error()})
 		return

--- a/apps/backend/internal/agentctl/server/api/workspace.go
+++ b/apps/backend/internal/agentctl/server/api/workspace.go
@@ -154,13 +154,13 @@ func (s *Server) handleFileContentAtRef(c *gin.Context) {
 		return
 	}
 
-	scopedPath, err := s.procMgr.JoinRepoPath(c.Query("repo"), path)
+	tracker, err := s.procMgr.GetWorkspaceTrackerFor(c.Query("repo"))
 	if err != nil {
 		c.JSON(400, types.FileContentResponse{Path: path, Error: err.Error()})
 		return
 	}
 
-	content, size, isBinary, err := s.procMgr.GetWorkspaceTracker().GetFileContentAtRef(c.Request.Context(), scopedPath, ref)
+	content, size, isBinary, err := tracker.GetFileContentAtRef(c.Request.Context(), path, ref)
 	if err != nil {
 		c.JSON(400, types.FileContentResponse{Path: path, Error: err.Error(), Size: size})
 		return

--- a/apps/web/components/diff/diff-viewer.test.tsx
+++ b/apps/web/components/diff/diff-viewer.test.tsx
@@ -4,14 +4,31 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { DiffViewer } from "./diff-viewer";
 import type { FileDiffData } from "@/lib/diff/types";
 
-const fileDiffProps: Array<{ options?: { overflow?: string } }> = [];
+const expansionState = vi.hoisted(() => ({
+  isContentLoaded: true,
+  isLoading: false,
+  error: null as string | null,
+  loadContent: vi.fn(),
+  canExpand: true,
+}));
+
+vi.mock("./use-expandable-diff", () => ({
+  useExpandableDiff: (options: { fileDiffMetadata: unknown }) => ({
+    ...expansionState,
+    metadata: options.fileDiffMetadata,
+  }),
+}));
+
+const fileDiffProps: Array<{
+  options?: { overflow?: string; hunkSeparators?: string };
+}> = [];
 
 vi.mock("@/components/theme/app-theme", () => ({
   useTheme: () => ({ resolvedTheme: "dark" }),
 }));
 
 vi.mock("@pierre/diffs/react", () => ({
-  FileDiff: (props: { options?: { overflow?: string } }) => {
+  FileDiff: (props: { options?: { overflow?: string; hunkSeparators?: string } }) => {
     fileDiffProps.push(props);
     return <div data-testid="file-diff" />;
   },
@@ -29,6 +46,8 @@ const data: FileDiffData = {
 afterEach(() => {
   cleanup();
   fileDiffProps.length = 0;
+  expansionState.canExpand = true;
+  expansionState.loadContent.mockReset();
 });
 
 describe("DiffViewer", () => {
@@ -63,5 +82,14 @@ describe("DiffViewer", () => {
     rerender(<DiffViewer data={data} onCommentUpdate={secondUpdate} />);
 
     await waitFor(() => expect(fileDiffProps.length).toBeGreaterThan(renderCount));
+  });
+
+  it("keeps simple hunk separators when full-content reparse rejects expansion", async () => {
+    expansionState.canExpand = false;
+
+    render(<DiffViewer data={data} sessionId="session-1" enableExpansion />);
+
+    await waitFor(() => expect(fileDiffProps.length).toBeGreaterThan(0));
+    expect(fileDiffProps.at(-1)?.options?.hunkSeparators).toBe("simple");
   });
 });

--- a/apps/web/components/diff/diff-viewer.tsx
+++ b/apps/web/components/diff/diff-viewer.tsx
@@ -102,7 +102,7 @@ function useAutoLoadExpansion(
   const hasValidData = !!(
     state.fileDiffMetadata?.deletionLines?.length && state.fileDiffMetadata?.additionLines?.length
   );
-  return enableExpansion && isExpansionContentLoaded && hasValidData;
+  return enableExpansion && isExpansionContentLoaded && state.canExpand && hasValidData;
 }
 
 function arePropsEqual(prevProps: DiffViewerProps, nextProps: DiffViewerProps): boolean {

--- a/apps/web/components/diff/use-expandable-diff.test.ts
+++ b/apps/web/components/diff/use-expandable-diff.test.ts
@@ -21,6 +21,8 @@ vi.mock("@/lib/ws/workspace-files", () => ({
 type UseExpandableDiffFn = typeof import("./use-expandable-diff").useExpandableDiff;
 
 let useExpandableDiff: UseExpandableDiffFn;
+const FILE_PATH = "src/foo.ts";
+
 beforeEach(async () => {
   vi.resetModules();
   processFileMock.mockReset();
@@ -33,7 +35,7 @@ beforeEach(async () => {
 /** Build a minimal FileDiffMetadata where the trailing-context counts match. */
 function consistentMeta(overrides: Partial<FileDiffMetadata> = {}): FileDiffMetadata {
   return {
-    name: "src/foo.ts",
+    name: FILE_PATH,
     type: "modified" as FileDiffMetadata["type"],
     hunks: [
       {
@@ -71,7 +73,7 @@ const PARTIAL = consistentMeta({ isPartial: true });
 
 const baseProps = {
   sessionId: "sess-1",
-  filePath: "src/foo.ts",
+  filePath: FILE_PATH,
   baseRef: "HEAD",
   diff: "diff --git a/src/foo.ts b/src/foo.ts\n--- a/src/foo.ts\n+++ b/src/foo.ts\n@@ -1,3 +1,3 @@\n a\n-b\n+B\n c\n",
   enableExpansion: true,
@@ -103,6 +105,31 @@ describe("useExpandableDiff", () => {
     );
     await loadAndSettle(result.current.loadContent);
     expect(result.current.metadata).toBe(reparsed);
+  });
+
+  it("scopes both content requests to the file repository", async () => {
+    requestFileContentMock.mockResolvedValue({ content: "new", is_binary: false });
+    requestFileContentAtRefMock.mockResolvedValue({ content: "old", is_binary: false });
+    processFileMock.mockReturnValue(consistentMeta());
+
+    const { result } = renderHook(() =>
+      useExpandableDiff({ ...baseProps, fileDiffMetadata: PARTIAL, repo: "frontend" }),
+    );
+    await loadAndSettle(result.current.loadContent);
+
+    expect(requestFileContentMock).toHaveBeenCalledWith(
+      expect.anything(),
+      "sess-1",
+      FILE_PATH,
+      "frontend",
+    );
+    expect(requestFileContentAtRefMock).toHaveBeenCalledWith(
+      expect.anything(),
+      "sess-1",
+      FILE_PATH,
+      "HEAD",
+      "frontend",
+    );
   });
 
   it("falls back to the partial metadata when the reparse is inconsistent", async () => {

--- a/apps/web/components/review/review-dialog.build-files.test.ts
+++ b/apps/web/components/review/review-dialog.build-files.test.ts
@@ -72,7 +72,7 @@ describe("buildAllFiles (review dialog)", () => {
   });
 });
 
-describe("buildAllFiles cumulative diff composition", () => {
+describe("buildAllFiles", () => {
   // Multi-repo: `mergeCumulativeFiles` uses a `<repo>\x00<path>` composite map
   // key and stamps the clean repo-relative path on `file.path`. The displayed
   // path must come from the stamped value, never from the composite key.

--- a/apps/web/components/review/review-dialog.build-files.test.ts
+++ b/apps/web/components/review/review-dialog.build-files.test.ts
@@ -63,8 +63,16 @@ describe("buildAllFiles (review dialog)", () => {
     expect(paths).toEqual(["src/a.ts", "src/b.ts"]);
     expect(result.every((f) => f.source === "committed")).toBe(true);
     expect(result.every((f) => !f.repository_name)).toBe(true);
+    expect(result).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ path: "src/a.ts", base_ref: "abc" }),
+        expect.objectContaining({ path: "src/b.ts", base_ref: "abc" }),
+      ]),
+    );
   });
+});
 
+describe("buildAllFiles cumulative diff composition", () => {
   // Multi-repo: `mergeCumulativeFiles` uses a `<repo>\x00<path>` composite map
   // key and stamps the clean repo-relative path on `file.path`. The displayed
   // path must come from the stamped value, never from the composite key.
@@ -83,6 +91,7 @@ describe("buildAllFiles (review dialog)", () => {
           diff: "@@ -1 +1 @@\n-x\n+y\n",
           repository_name: "frontend",
           path: "src/app.tsx",
+          base_ref: "frontend-base-sha",
         },
         "backend\u0000main.go": {
           status: "modified",
@@ -92,6 +101,7 @@ describe("buildAllFiles (review dialog)", () => {
           diff: "@@ -1 +1,3 @@\n+a\n+b\n+c\n",
           repository_name: "backend",
           path: "main.go",
+          base_ref: "backend-base-sha",
         },
       },
     } as unknown as CumulativeDiff;
@@ -101,6 +111,8 @@ describe("buildAllFiles (review dialog)", () => {
     const byRepo = Object.fromEntries(result.map((f) => [f.repository_name, f]));
     expect(byRepo["frontend"]?.path).toBe("src/app.tsx");
     expect(byRepo["backend"]?.path).toBe("main.go");
+    expect(byRepo["frontend"]).toMatchObject({ base_ref: "frontend-base-sha" });
+    expect(byRepo["backend"]).toMatchObject({ base_ref: "backend-base-sha" });
     // No NUL or composite-key leakage into displayed paths.
     expect(result.every((f) => !f.path.includes("\u0000"))).toBe(true);
   });

--- a/apps/web/components/review/review-dialog.tsx
+++ b/apps/web/components/review/review-dialog.tsx
@@ -44,6 +44,7 @@ function addCumulativeDiffFiles(
   fileMap: Map<string, ReviewFile>,
   files: CumulativeDiff["files"],
   useRepositoryKeys: boolean,
+  defaultBaseRef?: string,
 ) {
   // Multi-repo: backend stamps each per-file payload with `repository_name`
   // + the repo-relative `path`, and uses a NUL-composite `<repo>\x00<path>`
@@ -70,6 +71,7 @@ function addCumulativeDiffFiles(
       old_path: file.old_path,
       diff_skip_reason: file.diff_skip_reason,
       repository_name: repoName,
+      base_ref: file.base_ref ?? defaultBaseRef,
     });
   }
 }
@@ -136,7 +138,12 @@ export function buildAllFiles(
   // content even though the cumulative-diff hook was successfully refetching.
   if (gitStatusFiles) addUncommittedFiles(fileMap, gitStatusFiles);
   if (cumulativeDiff?.files) {
-    addCumulativeDiffFiles(fileMap, cumulativeDiff.files, useRepositoryKeys);
+    addCumulativeDiffFiles(
+      fileMap,
+      cumulativeDiff.files,
+      useRepositoryKeys,
+      cumulativeDiff.base_commit,
+    );
   }
   if (prDiffFiles) addPRFiles(fileMap, prDiffFiles, prRepoName);
   return Array.from(fileMap.values()).sort((a, b) => {

--- a/apps/web/components/review/review-diff-expansion.test.ts
+++ b/apps/web/components/review/review-diff-expansion.test.ts
@@ -45,6 +45,17 @@ describe("resolveDiffExpansion", () => {
     });
   });
 
+  it("prefers the exact cumulative-diff base ref for a committed branch worktree", () => {
+    const f = {
+      ...file({ source: "committed", repository_name: "backend-feature-x" }),
+      base_ref: "4f5c2f7",
+    } as ReviewFile;
+    expect(resolveDiffExpansion(f, MULTI_REPO_BASES, "main")).toEqual({
+      enableExpansion: true,
+      baseRef: "4f5c2f7",
+    });
+  });
+
   // Multi-repo guard: a committed file whose repo isn't in the map must NOT
   // borrow the single-repo fallback (another repo's base branch) — that would
   // fetch the wrong "old" content and silently drop expansion. Disable instead.

--- a/apps/web/components/review/review-diff-list.tsx
+++ b/apps/web/components/review/review-diff-list.tsx
@@ -389,8 +389,9 @@ function useScrollIntoViewOnSelect(
  * (controls-less) render:
  *
  *  - uncommitted rows: diff is working-tree-vs-HEAD, so baseRef="HEAD".
- *  - committed rows: diff is base-branch-vs-HEAD, so baseRef is the repo's
- *    base branch. HEAD already contains the commits, so expanding against it
+ *  - committed rows: diff is base-vs-HEAD, so baseRef is the exact old-side
+ *    commit carried by the file. Legacy payloads fall back to the repo's base
+ *    branch. HEAD already contains the commits, so expanding against it
  *    pairs identical old/new content and yields no controls (the bug behind
  *    "expansion stopped working in the review screen"). With no known base
  *    branch we can't fetch the pre-change content, so expansion is disabled
@@ -405,7 +406,7 @@ function useScrollIntoViewOnSelect(
  * the renderer, so enabling expansion here is always safe.
  */
 export function resolveDiffExpansion(
-  file: Pick<ReviewFile, "source" | "status" | "repository_name">,
+  file: Pick<ReviewFile, "source" | "status" | "repository_name" | "base_ref">,
   baseBranchByRepo: Record<string, string>,
   fallbackBaseBranch?: string,
 ): { enableExpansion: boolean; baseRef: string } {
@@ -413,6 +414,7 @@ export function resolveDiffExpansion(
     return { enableExpansion: false, baseRef: "HEAD" };
   }
   if (file.source === "committed") {
+    if (file.base_ref) return { enableExpansion: true, baseRef: file.base_ref };
     const repoName = file.repository_name ?? "";
     // Exact per-repo base wins. Fall back to the task's sole base branch ONLY
     // for single-repo files (no repository_name) — a multi-repo file whose repo

--- a/apps/web/components/review/review-diff-list.tsx
+++ b/apps/web/components/review/review-diff-list.tsx
@@ -390,8 +390,8 @@ function useScrollIntoViewOnSelect(
  *
  *  - uncommitted rows: diff is working-tree-vs-HEAD, so baseRef="HEAD".
  *  - committed rows: diff is base-vs-HEAD, so baseRef is the exact old-side
- *    commit carried by the file. Legacy payloads fall back to the repo's base
- *    branch. HEAD already contains the commits, so expanding against it
+ *    commit carried by the file; payloads without that ref fall back to the
+ *    repo's base branch. HEAD already contains the commits, so expanding against it
  *    pairs identical old/new content and yields no controls (the bug behind
  *    "expansion stopped working in the review screen"). With no known base
  *    branch we can't fetch the pre-change content, so expansion is disabled

--- a/apps/web/components/review/types.ts
+++ b/apps/web/components/review/types.ts
@@ -19,6 +19,8 @@ export type ReviewFile = {
   repository_id?: string;
   /** Human-readable repo name for tree node labels (e.g. "frontend"). */
   repository_name?: string;
+  /** Exact git ref used as the old side when this committed patch was built. */
+  base_ref?: string;
 };
 
 /**

--- a/apps/web/hooks/domains/session/use-review-sources.test.ts
+++ b/apps/web/hooks/domains/session/use-review-sources.test.ts
@@ -42,23 +42,26 @@ describe("buildReviewSources", () => {
   });
 
   it("tags committed files from cumulativeDiff", () => {
+    const cumulativeDiff = {
+      base_commit: "single-repo-base-sha",
+      files: {
+        "src/b.ts": {
+          diff: "@@ -1 +1 @@\n-x\n+y\n",
+          status: "modified",
+          additions: 1,
+          deletions: 1,
+        },
+      },
+    };
     const result = buildReviewSources({
       gitStatus: undefined,
       statusByRepo: undefined,
-      cumulativeDiff: {
-        files: {
-          "src/b.ts": {
-            diff: "@@ -1 +1 @@\n-x\n+y\n",
-            status: "modified",
-            additions: 1,
-            deletions: 1,
-          },
-        },
-      },
+      cumulativeDiff,
       prDiffFiles: undefined,
     });
     expect(result.allFiles).toHaveLength(1);
     expect(result.allFiles[0].source).toBe("committed");
+    expect(result.allFiles[0]).toMatchObject({ base_ref: "single-repo-base-sha" });
     expect(result.sourceCounts).toEqual({ uncommitted: 0, committed: 1, pr: 0 });
   });
 
@@ -553,27 +556,30 @@ describe("buildReviewSources", () => {
   // the dedup key was `<repo>:<repo>\x00<path>` (mismatched against any
   // other source). Verify we now use `file.path` when present.
   it("multi-repo cumulative: NUL-composite map key + stamped path renders clean path", () => {
+    const cumulativeDiff = {
+      files: {
+        "frontend\u0000src/x.ts": {
+          diff: "@@x@@",
+          status: "modified",
+          additions: 1,
+          deletions: 0,
+          repository_name: "frontend",
+          path: "src/x.ts",
+          base_ref: "frontend-base-sha",
+        },
+      },
+    };
     const result = buildReviewSources({
       gitStatus: undefined,
       statusByRepo: undefined,
-      cumulativeDiff: {
-        files: {
-          "frontend\u0000src/x.ts": {
-            diff: "@@x@@",
-            status: "modified",
-            additions: 1,
-            deletions: 0,
-            repository_name: "frontend",
-            path: "src/x.ts",
-          },
-        },
-      },
+      cumulativeDiff,
       prDiffFiles: undefined,
     });
     expect(result.allFiles).toHaveLength(1);
     expect(result.allFiles[0].path).toBe("src/x.ts");
     expect(result.allFiles[0].repository_name).toBe("frontend");
     expect(result.allFiles[0].source).toBe("committed");
+    expect(result.allFiles[0]).toMatchObject({ base_ref: "frontend-base-sha" });
   });
 
   it("sorts files by repository_name then path", () => {

--- a/apps/web/hooks/domains/session/use-review-sources.ts
+++ b/apps/web/hooks/domains/session/use-review-sources.ts
@@ -43,6 +43,7 @@ type CumulativeFile = {
   additions?: number;
   deletions?: number;
   repository_name?: string;
+  base_ref?: string;
   /**
    * Repo-relative path. Stamped by the backend's multi-repo cumulative-diff
    * merge (`mergeCumulativeFiles` in agentctl); single-repo payloads omit
@@ -80,6 +81,7 @@ function addCumulativeFiles(
   files: Record<string, CumulativeFile>,
   uncommittedPaths: Set<string>,
   useRepositoryKeys: boolean,
+  defaultBaseRef?: string,
 ) {
   for (const [mapKey, file] of Object.entries(files)) {
     // Multi-repo cumulative payloads use a NUL-composite `<repo>\x00<path>`
@@ -104,6 +106,7 @@ function addCumulativeFiles(
       old_path: file.old_path,
       diff_skip_reason: file.diff_skip_reason,
       repository_name: repositoryName,
+      base_ref: file.base_ref ?? defaultBaseRef,
     });
   }
 }
@@ -172,7 +175,10 @@ export type BuildReviewSourcesInput = {
   statusByRepo:
     | Array<{ repository_name: string; status: { files?: Record<string, UncommittedFile> } }>
     | undefined;
-  cumulativeDiff: { files?: Record<string, CumulativeFile> } | null;
+  cumulativeDiff: {
+    base_commit?: string;
+    files?: Record<string, CumulativeFile>;
+  } | null;
   prDiffFiles: PRDiffFile[] | undefined;
   /** Repository name for the primary PR — used to composite-key PR files so
    *  same-named files in different repos are not incorrectly deduped. */
@@ -257,7 +263,13 @@ export function buildReviewSources(input: BuildReviewSourcesInput): BuildReviewS
   }
 
   if (cumulativeDiff?.files) {
-    addCumulativeFiles(fileMap, cumulativeDiff.files, uncommittedPaths, useRepositoryKeys);
+    addCumulativeFiles(
+      fileMap,
+      cumulativeDiff.files,
+      uncommittedPaths,
+      useRepositoryKeys,
+      cumulativeDiff.base_commit,
+    );
   }
 
   if (prDiffFiles && prDiffFiles.length > 0)
@@ -347,7 +359,7 @@ export function useReviewSources(sessionId: string | null | undefined): UseRevie
       buildReviewSources({
         gitStatus: normalizedGitStatus,
         statusByRepo: normalizedStatusByRepo,
-        cumulativeDiff: cumulativeDiff as { files?: Record<string, CumulativeFile> } | null,
+        cumulativeDiff,
         prDiffFiles: prDiffFiles.length > 0 ? prDiffFiles : undefined,
         prRepoName,
         useRepositoryKeys,

--- a/apps/web/lib/state/slices/session-runtime/types.ts
+++ b/apps/web/lib/state/slices/session-runtime/types.ts
@@ -49,6 +49,8 @@ export type FileInfo = {
   old_path?: string;
   diff?: string;
   diff_skip_reason?: "too_large" | "binary" | "truncated" | "budget_exceeded";
+  /** Exact old-side ref for cumulative committed diffs. */
+  base_ref?: string;
   /**
    * Repository this file belongs to in multi-repo task workspaces. Stamped
    * by useSessionGit when aggregating per-repo statuses; empty for single-


### PR DESCRIPTION
Multi-repo tasks fetched expansion context from the non-Git task root and branch worktrees could lose their exact base ref. Expansion now resolves content in the owning repository and preserves each cumulative diff's base SHA through both review surfaces.

## Important Changes

- Route old-content reads through the repository-specific workspace tracker.
- Carry exact per-file base refs into Review and Changes diff rendering.
- Hide expansion controls when full-content reparsing is rejected.

## Validation

- `make fmt`
- `make typecheck`
- `make test`
- `make lint`
- Playwright: expand-arrow click, cumulative Review diff, multi-repo grouping, and mobile Review smoke
- No public docs change: internal diff-loading fix with no new user-facing workflow or configuration

## Possible Improvements

Low risk; PR-source expansion remains intentionally disabled and multi-PR Review still loads only the primary PR.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.

## Screenshots

### Desktop

Expanded context between two diff hunks.

![Desktop line expansion](https://raw.githubusercontent.com/kdlbs/kandev/5da8e71ca2180070638b5d09174ea4646876569c/line-expansion-desktop.png)

### Mobile

Expanded context in the native mobile diff sheet.

![Mobile line expansion](https://raw.githubusercontent.com/kdlbs/kandev/5da8e71ca2180070638b5d09174ea4646876569c/line-expansion-mobile.png)