### PR TITLE
fix: preserve custom layout proportions across screens

### DIFF
--- a/apps/web/lib/state/dockview-store.test.ts
+++ b/apps/web/lib/state/dockview-store.test.ts
@@ -3,6 +3,7 @@ import type { DockviewApi } from "dockview-react";
 import {
   useDockviewStore,
   resolvePresetPinnedWidths,
+  resolveCustomLayoutPinnedWidths,
   collectPinnedWidthUpdates,
 } from "./dockview-store";
 import { getGlobalSidebarWidth, setGlobalSidebarWidth } from "@/lib/local-storage";
@@ -201,6 +202,136 @@ describe("resolvePresetPinnedWidths", () => {
       expect(getGlobalSidebarWidth()).toBe(520);
       expect(getPinnedTarget("sidebar")).toBe(520);
     });
+  });
+});
+
+describe("applyCustomLayout", () => {
+  beforeEach(() => {
+    useDockviewStore.setState({
+      api: null,
+      currentLayoutEnvId: null,
+      isRestoringLayout: false,
+      pinnedWidths: new Map(),
+      preMaximizeLayout: null,
+      rightPanelsVisible: true,
+    });
+  });
+
+  it("uses the selected layout's saved right width instead of the live task width", () => {
+    const fromJSON = vi.fn();
+    const api = {
+      width: 1020,
+      height: 730,
+      fromJSON,
+      getPanel: () => undefined,
+      groups: [],
+      panels: [],
+      hasMaximizedGroup: () => false,
+      layout: vi.fn(),
+    } as unknown as DockviewApi;
+    useDockviewStore.setState({
+      api,
+      pinnedWidths: new Map([["right", 450]]),
+    });
+
+    useDockviewStore.getState().applyCustomLayout({
+      id: "layout-override-default",
+      name: "Default",
+      isDefault: false,
+      createdAt: "2026-07-22T00:00:00.000Z",
+      layout: {
+        columns: [
+          {
+            id: "center",
+            groups: [
+              {
+                id: "group-center",
+                panels: [{ id: "chat", component: "chat", title: "Chat" }],
+                activePanel: "chat",
+              },
+            ],
+          },
+          {
+            id: "right",
+            pinned: true,
+            width: 350,
+            groups: [
+              {
+                id: "group-right-top",
+                panels: [{ id: "files", component: "files", title: "Files" }],
+                activePanel: "files",
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const serialized = fromJSON.mock.calls[0]?.[0] as {
+      grid: { root: { data: Array<{ size: number }> } };
+    };
+    expect(serialized.grid.root.data[1].size).toBe(350);
+    expect(useDockviewStore.getState().pinnedWidths.get("right")).toBe(350);
+  });
+});
+
+describe("resolveCustomLayoutPinnedWidths", () => {
+  it("preserves complete saved column proportions across workbench sizes", () => {
+    const widths = resolveCustomLayoutPinnedWidths(
+      [
+        { id: "center", width: 1400, groups: [] },
+        { id: "right", pinned: true, width: 600, groups: [] },
+      ],
+      1000,
+    );
+
+    expect(widths.get("right")).toBe(300);
+  });
+
+  it("uses the resolved sidebar share when capping right regardless of column order", () => {
+    const widths = resolveCustomLayoutPinnedWidths(
+      [
+        { id: "right", pinned: true, width: 1000, groups: [] },
+        { id: "center", width: 300, groups: [] },
+        { id: "sidebar", pinned: true, width: 700, groups: [] },
+      ],
+      1000,
+    );
+
+    expect(widths.get("sidebar")).toBe(350);
+    expect(widths.get("right")).toBe(180);
+  });
+
+  it("clamps saved pinned geometry to the current workbench cap", () => {
+    const widths = resolveCustomLayoutPinnedWidths(
+      [{ id: "right", pinned: true, width: 900, groups: [] }],
+      1020,
+    );
+
+    expect(widths.get("right")).toBe(540);
+  });
+
+  it("uses layout defaults when saved pinned geometry is missing", () => {
+    const widths = resolveCustomLayoutPinnedWidths(
+      [{ id: "right", pinned: true, groups: [] }],
+      1020,
+    );
+
+    expect(widths.has("right")).toBe(false);
+  });
+
+  it("keeps valid pinned pixels but omits invalid geometry in an incomplete profile", () => {
+    const widths = resolveCustomLayoutPinnedWidths(
+      [
+        { id: "center", width: 1000, groups: [] },
+        { id: "right", pinned: true, width: 350, groups: [] },
+        { id: "sidebar", pinned: true, width: 0, groups: [] },
+      ],
+      1020,
+    );
+
+    expect(widths.get("right")).toBe(350);
+    expect(widths.has("sidebar")).toBe(false);
   });
 });
 

--- a/apps/web/lib/state/dockview-store.ts
+++ b/apps/web/lib/state/dockview-store.ts
@@ -19,8 +19,10 @@ import {
   TERMINAL_DEFAULT_ID,
   getPresetLayout,
   applyLayout,
+  computePinnedMaxPxFor,
   getPinnedWidth,
   getRootSplitview,
+  LAYOUT_PINNED_MIN_PX,
   fromDockviewApi,
   filterEphemeral,
   defaultLayout,
@@ -341,6 +343,52 @@ export function resolvePresetPinnedWidths(
   return cleaned;
 }
 
+/**
+ * Resolve pinned widths stored by a reusable/custom layout for the current
+ * workbench. Selecting a saved layout is an explicit geometry change, so its
+ * own widths take precedence over the task's currently live pinned widths. A
+ * complete snapshot is scaled proportionally to the current workbench before
+ * runtime caps apply. Incomplete snapshots retain valid absolute pinned widths;
+ * invalid/missing pinned widths are omitted so the normal ratio default applies.
+ */
+export function resolveCustomLayoutPinnedWidths(
+  columns: LayoutState["columns"],
+  totalWidth: number,
+): Map<string, number> {
+  const widths = new Map<string, number>();
+  const hasValidWidth = (column: LayoutState["columns"][number]): boolean =>
+    typeof column.width === "number" && Number.isFinite(column.width) && column.width > 0;
+  const hasCompleteGeometry =
+    columns.length > 0 && columns.every((column) => hasValidWidth(column));
+  const savedTotal = hasCompleteGeometry
+    ? columns.reduce((total, column) => total + (column.width ?? 0), 0)
+    : 0;
+
+  const resolveColumn = (column: LayoutState["columns"][number], sidebarWidth = 0): number => {
+    const savedWidth = column.width;
+    if (typeof savedWidth !== "number") return 0;
+    const requestedWidth = hasCompleteGeometry
+      ? Math.round((savedWidth / savedTotal) * totalWidth)
+      : savedWidth;
+    const min = column.minWidth ?? LAYOUT_PINNED_MIN_PX;
+    const max =
+      column.maxWidth ?? computePinnedMaxPxFor(column.id, totalWidth, sidebarWidth || undefined);
+    return Math.max(min, Math.min(requestedWidth, max));
+  };
+
+  const sidebar = columns.find(
+    (column) => column.id === "sidebar" && column.pinned && hasValidWidth(column),
+  );
+  const sidebarWidth = sidebar ? resolveColumn(sidebar) : 0;
+  if (sidebarWidth > 0) widths.set("sidebar", sidebarWidth);
+
+  for (const column of columns) {
+    if (column.id === "sidebar" || !column.pinned || !hasValidWidth(column)) continue;
+    widths.set(column.id, resolveColumn(column, sidebarWidth));
+  }
+  return widths;
+}
+
 /** Capture the live right pixel width into pinnedWidths before a layout rebuild. */
 function captureLiveWidths(api: DockviewApi, set: StoreSet): Map<string, number> {
   if (api.hasMaximizedGroup()) {
@@ -530,7 +578,7 @@ function buildPresetActions(set: StoreSet, get: StoreGet) {
     applyCustomLayout: (layout: SavedLayoutConfig, opts?: ApplyCustomLayoutOptions) => {
       const { api } = get();
       if (!api) return;
-      const liveWidths = captureLiveWidths(api, set);
+      captureLiveWidths(api, set);
       preserveChatScrollDuringLayout();
       const { width: safeWidth, height: safeHeight } = measureDockviewContainer(api);
       set({ isRestoringLayout: true });
@@ -538,7 +586,6 @@ function buildPresetActions(set: StoreSet, get: StoreGet) {
         api,
         layout,
         opts,
-        liveWidths,
         safeWidth,
         safeHeight,
         set,
@@ -569,7 +616,6 @@ type RestoreCustomLayoutParams = {
   api: DockviewApi;
   layout: SavedLayoutConfig;
   opts: ApplyCustomLayoutOptions | undefined;
-  liveWidths: Map<string, number>;
   safeWidth: number;
   safeHeight: number;
   set: StoreSet;
@@ -579,7 +625,6 @@ function restoreCustomLayout({
   api,
   layout,
   opts,
-  liveWidths,
   safeWidth,
   safeHeight,
   set,
@@ -593,7 +638,11 @@ function restoreCustomLayout({
       opts?.activeSessionId ?? null,
       opts?.sessionIds ?? [],
     );
-    set(applyLayout(api, activeState, liveWidths, safeWidth, safeHeight));
+    const savedWidths = resolveCustomLayoutPinnedWidths(activeState.columns, safeWidth);
+    set({
+      ...applyLayout(api, activeState, savedWidths, safeWidth, safeHeight),
+      pinnedWidths: savedWidths,
+    });
     return { appliedState: activeState, oldFormatRestoreFailed: false };
   }
 


### PR DESCRIPTION
Custom layouts could reuse stale panel widths after moving from a large monitor to a laptop, leaving the task-detail sidebar unnecessarily wide. Saved proportions now apply to the current workbench so one Default selection restores an appropriately sized pane.

## Validation

- `make fmt`
- `make typecheck test lint` (the aggregate test was rerun with `TMPDIR=/tmp` to avoid an unrelated Unix socket path-length limit)
- Verified the desktop customized Default layout restores the right pane from 450px to 350px in one selection.
- Verified the dedicated mobile task-detail composition remains usable without Dockview or horizontal overflow.
- No public documentation impact.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.

## Screenshots

Customized Default on a compact desktop restores the right Files/Changes pane to 350px after it had been 450px.

![Customized Default layout on compact desktop](https://raw.githubusercontent.com/kdlbs/kandev/7540fec0cbcf1351c9358394ac55e660e756e696/sidebar-width-default-desktop.png)

The dedicated mobile task-detail composition remains usable without the desktop Dockview layout or horizontal overflow.

![Mobile task-detail composition](https://raw.githubusercontent.com/kdlbs/kandev/7540fec0cbcf1351c9358394ac55e660e756e696/sidebar-width-mobile-task-detail.png)