### PR TITLE
fix: hide workspace ownership marker

### DIFF
--- a/apps/backend/internal/agentctl/server/process/vscode.go
+++ b/apps/backend/internal/agentctl/server/process/vscode.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/kandev/kandev/internal/common/logger"
+	storageworkspaces "github.com/kandev/kandev/internal/system/storage/workspaces"
 	tools "github.com/kandev/kandev/internal/tools/installer"
 	"go.uber.org/zap"
 )
@@ -479,6 +480,15 @@ func (v *VscodeManager) writeThemeSettings() {
 	}
 	for k, v := range managed {
 		settings[k] = v
+	}
+	markerPattern := storageworkspaces.OwnershipMarkerFilename
+	for _, key := range []string{"files.exclude", "search.exclude"} {
+		excludes, ok := settings[key].(map[string]any)
+		if !ok {
+			excludes = map[string]any{}
+			settings[key] = excludes
+		}
+		excludes[markerPattern] = true
 	}
 
 	data, err := json.MarshalIndent(settings, "", "  ")

--- a/apps/backend/internal/agentctl/server/process/vscode_test.go
+++ b/apps/backend/internal/agentctl/server/process/vscode_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	storageworkspaces "github.com/kandev/kandev/internal/system/storage/workspaces"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -214,6 +215,77 @@ func TestWriteThemeSettings_DarkTheme(t *testing.T) {
 	assert.Equal(t, float64(14), settings["editor.fontSize"])
 	assert.Equal(t, "Default Dark Modern", settings["workbench.colorTheme"])
 	assert.Equal(t, true, settings["editor.minimap.autohide"])
+}
+
+func TestVscodeManager_WriteSettings_MergesWorkspaceExcludes(t *testing.T) {
+	tests := []struct {
+		name             string
+		existing         map[string]any
+		preservedEntries map[string]string
+	}{
+		{
+			name: "adds missing exclude settings",
+			existing: map[string]any{
+				"editor.fontSize": 14,
+			},
+		},
+		{
+			name: "preserves existing exclude entries and overrides the marker",
+			existing: map[string]any{
+				"editor.fontSize": 14,
+				"files.exclude": map[string]any{
+					"**/*.tmp": true,
+					storageworkspaces.OwnershipMarkerFilename: false,
+				},
+				"search.exclude": map[string]any{
+					"**/vendor": true,
+					storageworkspaces.OwnershipMarkerFilename: false,
+				},
+			},
+			preservedEntries: map[string]string{
+				"files.exclude":  "**/*.tmp",
+				"search.exclude": "**/vendor",
+			},
+		},
+		{
+			name: "replaces non-object exclude settings",
+			existing: map[string]any{
+				"editor.fontSize": 14,
+				"files.exclude":   "invalid",
+				"search.exclude":  []any{"invalid"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("HOME", t.TempDir())
+			v := NewVscodeManager("code-server", "/workspace", "dark", nil, newTestLogger(t))
+			settingsPath := filepath.Join(v.userDataDir(), "User", "settings.json")
+			require.NoError(t, os.MkdirAll(filepath.Dir(settingsPath), 0o755))
+			data, err := json.Marshal(tt.existing)
+			require.NoError(t, err)
+			require.NoError(t, os.WriteFile(settingsPath, data, 0o644))
+
+			v.writeThemeSettings()
+
+			written, err := os.ReadFile(settingsPath)
+			require.NoError(t, err)
+			var settings map[string]any
+			require.NoError(t, json.Unmarshal(written, &settings))
+			assert.Equal(t, float64(14), settings["editor.fontSize"])
+
+			for _, key := range []string{"files.exclude", "search.exclude"} {
+				excludes, ok := settings[key].(map[string]any)
+				require.True(t, ok, "%s should be an object", key)
+				assert.Equal(t, true, excludes[storageworkspaces.OwnershipMarkerFilename])
+				assert.NotContains(t, excludes, "**/"+storageworkspaces.OwnershipMarkerFilename)
+				if pattern := tt.preservedEntries[key]; pattern != "" {
+					assert.Equal(t, true, excludes[pattern])
+				}
+			}
+		})
+	}
 }
 
 func TestVscodeManager_InitialState(t *testing.T) {

--- a/apps/backend/internal/agentctl/server/process/workspace_files.go
+++ b/apps/backend/internal/agentctl/server/process/workspace_files.go
@@ -21,6 +21,7 @@ import (
 	"github.com/kandev/kandev/internal/agentctl/types"
 	"github.com/kandev/kandev/internal/common/readselector"
 	"github.com/kandev/kandev/internal/common/subproc"
+	storageworkspaces "github.com/kandev/kandev/internal/system/storage/workspaces"
 	"go.uber.org/zap"
 )
 
@@ -34,6 +35,10 @@ const (
 const maxFileSize = 10 * 1024 * 1024 // 10MB
 
 var errPathTraversal = errors.New("path traversal detected")
+
+func isRootOwnershipMarkerPath(path string) bool {
+	return filepath.Clean(filepath.FromSlash(path)) == storageworkspaces.OwnershipMarkerFilename
+}
 
 // updateFiles updates the file listing
 func (wt *WorkspaceTracker) updateFiles(ctx context.Context) {
@@ -70,7 +75,7 @@ func (wt *WorkspaceTracker) getFileList(ctx context.Context) (types.FileListUpda
 	lines := strings.Split(string(out), "\n")
 	for _, line := range lines {
 		line = strings.TrimSpace(line)
-		if line == "" {
+		if line == "" || isRootOwnershipMarkerPath(line) {
 			continue
 		}
 		update.Files = append(update.Files, types.FileEntry{
@@ -131,12 +136,15 @@ func (wt *WorkspaceTracker) buildFileTreeNode(safePath, relPath string, info os.
 	for _, entry := range entries {
 		// Skip specific directories that should be ignored
 		name := entry.Name()
+		childRelPath := filepath.Join(relPath, name)
+		if isRootOwnershipMarkerPath(childRelPath) {
+			continue
+		}
 		if name == ".git" || name == "node_modules" || name == ".next" || name == "dist" || name == "build" {
 			continue
 		}
 
 		childFullPath := filepath.Join(safePath, name)
-		childRelPath := filepath.Join(relPath, name)
 
 		isSymlink := entry.Type()&os.ModeSymlink != 0
 		var childInfo os.FileInfo
@@ -844,6 +852,9 @@ func (wt *WorkspaceTracker) SearchFiles(query string, limit int) []string {
 
 	for _, file := range files {
 		path := file.Path
+		if isRootOwnershipMarkerPath(path) {
+			continue
+		}
 		lowerPath := strings.ToLower(path)
 		name := filepath.Base(lowerPath)
 

--- a/apps/backend/internal/agentctl/server/process/workspace_files_test.go
+++ b/apps/backend/internal/agentctl/server/process/workspace_files_test.go
@@ -1,12 +1,14 @@
 package process
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
 
 	"github.com/kandev/kandev/internal/agentctl/types"
+	storageworkspaces "github.com/kandev/kandev/internal/system/storage/workspaces"
 )
 
 func TestResolveNonExistentPath(t *testing.T) {
@@ -145,6 +147,80 @@ func findChild(node *types.FileTreeNode, name string) *types.FileTreeNode {
 		}
 	}
 	return nil
+}
+
+func createOwnershipMarkerFixture(t *testing.T) string {
+	t.Helper()
+	taskRoot := t.TempDir()
+	repositoryDir := filepath.Join(taskRoot, "repository")
+	if err := os.Mkdir(repositoryDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range []string{
+		filepath.Join(taskRoot, storageworkspaces.OwnershipMarkerFilename),
+		filepath.Join(taskRoot, "visible.txt"),
+		filepath.Join(repositoryDir, storageworkspaces.OwnershipMarkerFilename),
+	} {
+		if err := os.WriteFile(path, []byte("fixture"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return taskRoot
+}
+
+func TestGetFileTree_HidesOnlyRootOwnershipMarker(t *testing.T) {
+	taskRoot := createOwnershipMarkerFixture(t)
+
+	tree, err := (&WorkspaceTracker{workDir: taskRoot}).GetFileTree("", 2)
+	if err != nil {
+		t.Fatalf("GetFileTree failed: %v", err)
+	}
+	if findChild(tree, storageworkspaces.OwnershipMarkerFilename) != nil {
+		t.Errorf("root ownership marker %q should be hidden", storageworkspaces.OwnershipMarkerFilename)
+	}
+	if findChild(tree, "visible.txt") == nil {
+		t.Error("ordinary root file should remain visible")
+	}
+	repository := requireChild(t, tree, "repository")
+	if findChild(repository, storageworkspaces.OwnershipMarkerFilename) == nil {
+		t.Errorf("nested repository file %q should remain visible", storageworkspaces.OwnershipMarkerFilename)
+	}
+}
+
+func TestGetFileList_HidesOnlyRootOwnershipMarker(t *testing.T) {
+	taskRoot := createOwnershipMarkerFixture(t)
+	initGitRepoAt(t, taskRoot)
+
+	files, err := (&WorkspaceTracker{workDir: taskRoot}).getFileList(context.Background())
+	if err != nil {
+		t.Fatalf("getFileList failed: %v", err)
+	}
+	paths := make(map[string]bool, len(files.Files))
+	for _, file := range files.Files {
+		paths[filepath.ToSlash(file.Path)] = true
+	}
+	if paths[storageworkspaces.OwnershipMarkerFilename] {
+		t.Errorf("root ownership marker %q should be hidden", storageworkspaces.OwnershipMarkerFilename)
+	}
+	if !paths["visible.txt"] {
+		t.Error("ordinary root file should remain visible")
+	}
+	if !paths["repository/"+storageworkspaces.OwnershipMarkerFilename] {
+		t.Errorf("nested repository file %q should remain visible", storageworkspaces.OwnershipMarkerFilename)
+	}
+}
+
+func TestSearchFiles_HidesOnlyRootOwnershipMarker(t *testing.T) {
+	marker := storageworkspaces.OwnershipMarkerFilename
+	wt := &WorkspaceTracker{currentFiles: types.FileListUpdate{Files: []types.FileEntry{
+		{Path: marker},
+		{Path: filepath.Join("repository", marker)},
+	}}}
+
+	matches := wt.SearchFiles("kandev-workspace", 20)
+	if len(matches) != 1 || matches[0] != filepath.Join("repository", marker) {
+		t.Fatalf("SearchFiles matches = %v, want only nested marker", matches)
+	}
 }
 
 func TestGetFileTree_Symlinks(t *testing.T) {


### PR DESCRIPTION
Task workspaces need an internal ownership marker without exposing it as a user file; root-level filtering now hides it across the Files tree, file list/search, and embedded VS Code while preserving nested same-named files.

## Validation

- `make fmt`
- `make generate-metadata`
- `make typecheck`
- `make test` (passed after retrying from `/tmp`; the initial failure was the known environment-only Unix-socket path-length limit)
- `make lint`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1874?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->