### PR TITLE
fix(web): clarify task title editing

### DIFF
--- a/apps/web/components/task/task-top-bar-title.test.tsx
+++ b/apps/web/components/task/task-top-bar-title.test.tsx
@@ -7,7 +7,9 @@ const mockRename = vi.hoisted(() => vi.fn(() => Promise.resolve()));
 vi.mock("@kandev/ui/tooltip", () => ({
   Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => (
+    <div role="tooltip">{children}</div>
+  ),
 }));
 
 vi.mock("@/hooks/use-task-actions", () => ({
@@ -44,11 +46,20 @@ describe("TaskTopBarTitle — idle state", () => {
     expect(getTitle().getAttribute("tabindex")).toBe("0");
   });
 
+  it("shows the full title and edit hint in the tooltip when renameable", () => {
+    render(<TaskTopBarTitle taskId="task-1" taskTitle="My task" />);
+
+    expect(screen.getByRole("tooltip").textContent).toBe(
+      "My taskDouble-click to edit (or press Enter)",
+    );
+  });
+
   it("keeps the breadcrumb aria-disabled and unfocusable when the task is archived", () => {
     render(<TaskTopBarTitle taskId="task-1" taskTitle="My task" isArchived />);
 
     expect(getTitle().getAttribute("aria-disabled")).toBe("true");
     expect(getTitle().getAttribute("tabindex")).toBeNull();
+    expect(screen.getByRole("tooltip").textContent).toBe("My task");
   });
 
   it("does not enter edit mode when the task is archived", () => {
@@ -65,6 +76,7 @@ describe("TaskTopBarTitle — idle state", () => {
     fireEvent.doubleClick(getTitle());
 
     expect(queryInput()).toBeNull();
+    expect(screen.getByRole("tooltip").textContent).toBe("My task");
   });
 });
 

--- a/apps/web/components/task/task-top-bar-title.tsx
+++ b/apps/web/components/task/task-top-bar-title.tsx
@@ -110,7 +110,12 @@ export function TaskTopBarTitle({ taskId, taskTitle, isArchived }: TaskTopBarTit
                 {taskTitle ?? "Task details"}
               </BreadcrumbPage>
             </TooltipTrigger>
-            <TooltipContent>{taskTitle ?? "Task details"}</TooltipContent>
+            <TooltipContent className="max-w-sm whitespace-normal break-words">
+              <span className="block">{taskTitle ?? "Task details"}</span>
+              {canRename && (
+                <span className="mt-1 block">Double-click to edit (or press Enter)</span>
+              )}
+            </TooltipContent>
           </Tooltip>
         </BreadcrumbItem>
       </BreadcrumbList>

--- a/apps/web/e2e/tests/task/topbar-rename.spec.ts
+++ b/apps/web/e2e/tests/task/topbar-rename.spec.ts
@@ -2,16 +2,19 @@ import { test, expect } from "../../fixtures/test-base";
 import { SessionPage } from "../../pages/session-page";
 
 test.describe("Task topbar inline rename", () => {
-  test("renames the task by double-clicking the title and pressing Enter", async ({
+  test("hints at editing before renaming the task by double-clicking the title", async ({
     testPage,
     apiClient,
     seedData,
   }) => {
     test.setTimeout(90_000);
 
+    const originalTitle =
+      "Topbar rename original with a deliberately long title that is truncated in the task header";
+
     const task = await apiClient.createTaskWithAgent(
       seedData.workspaceId,
-      "Topbar rename original",
+      originalTitle,
       seedData.agentProfileId,
       {
         description: "/e2e:simple-message",
@@ -26,7 +29,15 @@ test.describe("Task topbar inline rename", () => {
     await session.waitForLoad();
 
     const title = testPage.locator('[data-testid="task-topbar"] [aria-current="page"]');
-    await expect(title).toHaveText("Topbar rename original", { timeout: 10_000 });
+    await expect(title).toHaveText(originalTitle, { timeout: 10_000 });
+
+    await title.hover();
+    const tooltip = testPage
+      .locator('[data-slot="tooltip-content"][data-state]')
+      .filter({ hasText: originalTitle });
+    await expect(tooltip).toBeVisible();
+    await expect(tooltip).toContainText(originalTitle);
+    await expect(tooltip).toContainText("Double-click to edit (or press Enter)");
 
     await title.dblclick();
     const input = testPage.getByTestId("task-title-rename-input");


### PR DESCRIPTION
Renameable desktop task titles now reveal their full text and a “Double-click to edit (or press Enter)” hint on hover, making an otherwise hidden action discoverable. Titles that cannot be renamed remain title-only; this UI-only change has no public documentation impact.

## Validation

- Focused component test: 17/17 passed.
- Focused production E2E test: 1/1 passed.
- Full format, typecheck, test, and lint passed.

## Screenshots

![Desktop title edit hint](https://raw.githubusercontent.com/kdlbs/kandev/05b4d9b74a297e1c82a7b67f6aa52abfab721bcf/desktop-title-edit-hint.png)

![Mobile task title](https://raw.githubusercontent.com/kdlbs/kandev/05b4d9b74a297e1c82a7b67f6aa52abfab721bcf/mobile-task-title.png)

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.