### PR TITLE
fix(executor): re-clone provider repos when local path is missing or not a git repo

### DIFF
--- a/apps/backend/internal/agent/runtime/lifecycle/env_preparer_worktree.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/env_preparer_worktree.go
@@ -459,6 +459,13 @@ func (p *WorktreePreparer) prepareOneRepo(
 		reportProgress(onProgress, validateStep, stepIdx, totalSteps)
 		return nil, steps, stepIdx + 1, fmt.Errorf("repo %q: no repository path", repoLabel)
 	}
+	if !isGitRepoPath(spec.RepositoryPath) {
+		errMsg := fmt.Sprintf("repository path is not a git repository: %s", spec.RepositoryPath)
+		completeStepError(&validateStep, errMsg)
+		steps = append(steps, validateStep)
+		reportProgress(onProgress, validateStep, stepIdx, totalSteps)
+		return nil, steps, stepIdx + 1, fmt.Errorf("repo %q: %s", repoLabel, errMsg)
+	}
 	completeStepSuccess(&validateStep)
 	steps = append(steps, validateStep)
 	reportProgress(onProgress, validateStep, stepIdx, totalSteps)

--- a/apps/backend/internal/agent/runtime/lifecycle/env_preparer_worktree.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/env_preparer_worktree.go
@@ -3,6 +3,7 @@ package lifecycle
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -11,6 +12,18 @@ import (
 	"github.com/kandev/kandev/internal/common/logger"
 	"github.com/kandev/kandev/internal/worktree"
 )
+
+// isGitRepoPath reports whether path has a ".git" entry that is either a
+// directory (regular repo) or a regular file (worktree gitdir pointer).
+// Mirrors worktree.Manager.isGitRepo in internal/worktree/manager_git.go;
+// kept local since that method is unexported on a different package's type.
+func isGitRepoPath(path string) bool {
+	info, err := os.Stat(filepath.Join(path, ".git"))
+	if err != nil {
+		return false
+	}
+	return info.IsDir() || info.Mode().IsRegular()
+}
 
 // copyFilesStep builds the "Copy N ignored files" prepare step shown after a
 // worktree's CopyFiles spec has been applied. repoLabel is appended for
@@ -143,6 +156,12 @@ func (p *WorktreePreparer) validateWorktreeRequest(
 	}
 	if p.worktreeMgr == nil {
 		completeStepError(&step, "worktree manager not available")
+		steps = append(steps, step)
+		reportProgress(onProgress, step, stepIdx, totalSteps)
+		return steps, false
+	}
+	if !isGitRepoPath(req.RepositoryPath) {
+		completeStepError(&step, fmt.Sprintf("repository path is not a git repository: %s", req.RepositoryPath))
 		steps = append(steps, step)
 		reportProgress(onProgress, step, stepIdx, totalSteps)
 		return steps, false

--- a/apps/backend/internal/agent/runtime/lifecycle/env_preparer_worktree_invalid_repo_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/env_preparer_worktree_invalid_repo_test.go
@@ -53,3 +53,44 @@ func TestWorktreePreparer_ValidateRepository_FailsOnNonGitPath(t *testing.T) {
 		t.Errorf("ErrorMessage = %q, want it to name the offending path %q", res.ErrorMessage, notAGitRepo)
 	}
 }
+
+// TestWorktreePreparer_MultiRepo_ValidateRepository_FailsOnNonGitPath is the
+// regression guard for the Greptile review finding that the multi-repo path
+// (prepareMultiRepo -> prepareOneRepo) didn't run the same non-git-path
+// validation as the single-repo Prepare. Previously a stale secondary repo
+// (RepositoryPath set but no ".git" inside) passed prepareOneRepo's
+// validation and failed later, deep inside worktree.Manager.Create, with the
+// less actionable ErrRepoNotGit. It should now fail fast during "Validate
+// <repo> repository" with the same clear message the single-repo path uses.
+func TestWorktreePreparer_MultiRepo_ValidateRepository_FailsOnNonGitPath(t *testing.T) {
+	repoA := initBareGitRepo(t, "primary")
+	staleSecondary := t.TempDir() // exists on disk, but has no .git inside
+
+	preparer, _ := newPreparerForTest(t)
+
+	req := &EnvPrepareRequest{
+		TaskID:       "task-multi-bad-secondary",
+		SessionID:    "sess-multi-bad-secondary",
+		TaskTitle:    "Multi Repo Stale Secondary",
+		ExecutorType: executor.NameStandalone,
+		TaskDirName:  "multi-bad-secondary_eee",
+		Repositories: []RepoPrepareSpec{
+			{RepositoryID: "repo-primary", RepositoryPath: repoA, RepoName: "primary", BaseBranch: "main"},
+			{RepositoryID: "repo-secondary", RepositoryPath: staleSecondary, RepoName: "secondary", BaseBranch: "main"},
+		},
+	}
+
+	res, err := preparer.Prepare(context.Background(), req, nil)
+	if err != nil {
+		t.Fatalf("prepare returned hard error: %v", err)
+	}
+	if res.Success {
+		t.Fatal("expected prepare to fail when the secondary repo path has no .git directory")
+	}
+	if !strings.Contains(res.ErrorMessage, "not a git repository") {
+		t.Errorf("ErrorMessage = %q, want it to mention the path is not a git repository", res.ErrorMessage)
+	}
+	if !strings.Contains(res.ErrorMessage, staleSecondary) {
+		t.Errorf("ErrorMessage = %q, want it to name the offending path %q", res.ErrorMessage, staleSecondary)
+	}
+}

--- a/apps/backend/internal/agent/runtime/lifecycle/env_preparer_worktree_invalid_repo_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/env_preparer_worktree_invalid_repo_test.go
@@ -1,0 +1,55 @@
+package lifecycle
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/kandev/kandev/internal/agent/executor"
+	"github.com/kandev/kandev/internal/worktree"
+)
+
+// TestWorktreePreparer_ValidateRepository_FailsOnNonGitPath guards against the
+// production bug where a provider-backed repository row ends up with a
+// non-empty LocalPath that points at a directory with no ".git" (e.g. a stale
+// path from a moved/deleted clone, or a placeholder directory that was never
+// actually cloned). Previously validateWorktreeRequest only checked that
+// RepositoryPath was non-empty, so this bad path sailed through "Validate
+// repository" and failed downstream inside the worktree manager with the
+// less actionable "repository is not a git repository" error. It should now
+// fail fast, at this step, with a clear message naming the offending path.
+func TestWorktreePreparer_ValidateRepository_FailsOnNonGitPath(t *testing.T) {
+	notAGitRepo := t.TempDir() // empty dir, no .git inside
+
+	repos := map[string]*worktree.Repository{
+		"repo-single": {ID: "repo-single"},
+	}
+	preparer, _, _ := newPreparerWithScriptHandler(t, repos)
+
+	req := &EnvPrepareRequest{
+		TaskID:         "task-bad-path",
+		SessionID:      "sess-bad-path",
+		TaskTitle:      "Bad Path Task",
+		ExecutorType:   executor.NameStandalone,
+		TaskDirName:    "bad-path_xxx",
+		UseWorktree:    true,
+		RepositoryID:   "repo-single",
+		RepositoryPath: notAGitRepo,
+		RepoName:       "single",
+		BaseBranch:     "main",
+	}
+
+	res, err := preparer.Prepare(context.Background(), req, nil)
+	if err != nil {
+		t.Fatalf("prepare returned hard error: %v", err)
+	}
+	if res.Success {
+		t.Fatal("expected prepare to fail for a repository path with no .git directory")
+	}
+	if !strings.Contains(res.ErrorMessage, "not a git repository") {
+		t.Errorf("ErrorMessage = %q, want it to mention the path is not a git repository", res.ErrorMessage)
+	}
+	if !strings.Contains(res.ErrorMessage, notAGitRepo) {
+		t.Errorf("ErrorMessage = %q, want it to name the offending path %q", res.ErrorMessage, notAGitRepo)
+	}
+}

--- a/apps/backend/internal/orchestrator/executor/executor_resume.go
+++ b/apps/backend/internal/orchestrator/executor/executor_resume.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/kandev/kandev/internal/agent/runtime/lifecycle"
@@ -13,6 +15,19 @@ import (
 	v1 "github.com/kandev/kandev/pkg/api/v1"
 	"go.uber.org/zap"
 )
+
+// isLocalGitRepo reports whether path looks like a valid local git checkout,
+// i.e. it has a ".git" entry that is either a directory (regular repo) or a
+// regular file (worktree gitdir pointer). Mirrors worktree.Manager.isGitRepo
+// in internal/worktree/manager_git.go; kept local since that method is
+// unexported on a different package's type.
+func isLocalGitRepo(path string) bool {
+	info, err := os.Stat(filepath.Join(path, ".git"))
+	if err != nil {
+		return false
+	}
+	return info.IsDir() || info.Mode().IsRegular()
+}
 
 // isAgentAlreadyRunningError checks whether LaunchAgent refused because the
 // lifecycle manager's in-memory store already has an execution for this session.
@@ -110,8 +125,12 @@ func (e *Executor) resolveTaskRepoInfo(ctx context.Context, tr *models.TaskRepos
 		return nil, err
 	}
 
-	// Clone provider-backed repos that have no local path yet
-	if repo.LocalPath == "" && repo.ProviderOwner != "" && repo.ProviderName != "" {
+	// Clone provider-backed repos that have no local path yet, or whose stored
+	// local path has gone stale (moved, deleted, or never actually a git repo
+	// — e.g. a leftover placeholder directory). Only overwrite repo.LocalPath
+	// when the clone actually returns a path; never blank an already-set one.
+	if repo.ProviderOwner != "" && repo.ProviderName != "" &&
+		(repo.LocalPath == "" || !isLocalGitRepo(repo.LocalPath)) {
 		if localPath, cloneErr := e.ensureRepoCloned(ctx, repo); cloneErr != nil {
 			return nil, cloneErr
 		} else if localPath != "" {

--- a/apps/backend/internal/orchestrator/executor/executor_resume.go
+++ b/apps/backend/internal/orchestrator/executor/executor_resume.go
@@ -29,6 +29,14 @@ func isLocalGitRepo(path string) bool {
 	return info.IsDir() || info.Mode().IsRegular()
 }
 
+// sourceTypeLocal is the Repository.SourceType value for on-machine repos.
+// Mirrors the constant of the same name in internal/task/service (unexported
+// there too) — a repo can carry a ProviderOwner/ProviderName (the origin it
+// was imported from) while still being SourceType "local", and such a repo's
+// on-disk checkout is the user's, not a managed clone we're allowed to
+// silently replace.
+const sourceTypeLocal = "local"
+
 // isAgentAlreadyRunningError checks whether LaunchAgent refused because the
 // lifecycle manager's in-memory store already has an execution for this session.
 // The error is ambiguous on its own — it fires both when the execution is live
@@ -125,17 +133,8 @@ func (e *Executor) resolveTaskRepoInfo(ctx context.Context, tr *models.TaskRepos
 		return nil, err
 	}
 
-	// Clone provider-backed repos that have no local path yet, or whose stored
-	// local path has gone stale (moved, deleted, or never actually a git repo
-	// — e.g. a leftover placeholder directory). Only overwrite repo.LocalPath
-	// when the clone actually returns a path; never blank an already-set one.
-	if repo.ProviderOwner != "" && repo.ProviderName != "" &&
-		(repo.LocalPath == "" || !isLocalGitRepo(repo.LocalPath)) {
-		if localPath, cloneErr := e.ensureRepoCloned(ctx, repo); cloneErr != nil {
-			return nil, cloneErr
-		} else if localPath != "" {
-			repo.LocalPath = localPath
-		}
+	if err := e.ensureRepoLocalPath(ctx, repo); err != nil {
+		return nil, err
 	}
 
 	// Backfill default_branch from the local clone when missing. This fires for
@@ -156,6 +155,33 @@ func (e *Executor) resolveTaskRepoInfo(ctx context.Context, tr *models.TaskRepos
 		info.BaseBranch = repo.DefaultBranch
 	}
 	return info, nil
+}
+
+// ensureRepoLocalPath re-clones a repo's local checkout in place when it's
+// missing or has gone stale (moved, deleted, or never actually a git repo —
+// e.g. a leftover placeholder directory), but ONLY for genuinely
+// provider-backed repositories: SourceType must not be "local" and both
+// ProviderOwner/ProviderName must be set. A repo can carry those provider
+// fields (the origin it was imported from) while still being a local
+// checkout the user manages themselves; re-cloning over such a repo would
+// silently redirect future launches away from the user's saved path. Mutates
+// repo.LocalPath only when the clone actually returns a path — never blanks
+// an already-set one.
+func (e *Executor) ensureRepoLocalPath(ctx context.Context, repo *models.Repository) error {
+	if repo.SourceType == sourceTypeLocal || repo.ProviderOwner == "" || repo.ProviderName == "" {
+		return nil
+	}
+	if repo.LocalPath != "" && isLocalGitRepo(repo.LocalPath) {
+		return nil
+	}
+	localPath, cloneErr := e.ensureRepoCloned(ctx, repo)
+	if cloneErr != nil {
+		return cloneErr
+	}
+	if localPath != "" {
+		repo.LocalPath = localPath
+	}
+	return nil
 }
 
 // ensureRepoCloned clones a provider-backed repository to local disk and updates its local path in the database.
@@ -719,6 +745,14 @@ func (e *Executor) applyResumeRepoConfig(ctx context.Context, task *v1.Task, ses
 			zap.String("task_id", task.ID),
 			zap.String("repository_id", repositoryID),
 			zap.Error(err))
+		return "", err
+	}
+
+	// Self-heal a stale/missing provider-backed local path before using it,
+	// mirroring the guard in resolveTaskRepoInfo — otherwise a single-repo
+	// resume with a stale path skips re-cloning and fails downstream in the
+	// worktree preparer.
+	if err := e.ensureRepoLocalPath(ctx, repository); err != nil {
 		return "", err
 	}
 

--- a/apps/backend/internal/orchestrator/executor/executor_resume_clone_default_branch_test.go
+++ b/apps/backend/internal/orchestrator/executor/executor_resume_clone_default_branch_test.go
@@ -213,6 +213,78 @@ func TestResolveTaskRepoInfo_BackfillIsBestEffortWhenLocalPathBroken(t *testing.
 	}
 }
 
+// TestResolveTaskRepoInfo_ReClonesWhenLocalPathIsNotAGitRepo is the regression
+// guard for the production bug where a provider-backed repository row ends up
+// with a non-empty LocalPath pointing at a directory with no ".git" (e.g. a
+// stale path left after a moved/deleted clone). Previously the clone guard
+// only fired when LocalPath == "", so this stale path sailed straight through
+// to the worktree preparer, which failed with "repository is not a git
+// repository". resolveTaskRepoInfo must detect the invalid path and re-clone.
+func TestResolveTaskRepoInfo_ReClonesWhenLocalPathIsNotAGitRepo(t *testing.T) {
+	staleLocalPath := t.TempDir() // exists on disk, but has no .git inside
+
+	originPath := initBareOriginWithMain(t)
+	freshClonePath := filepath.Join(t.TempDir(), "fresh-clone")
+	runGitInTest(t, "", "clone", originPath, freshClonePath)
+
+	repo := newMockRepository()
+	repo.repositories["repo-1"] = &models.Repository{
+		ID:            "repo-1",
+		Provider:      "github",
+		ProviderOwner: "acme",
+		ProviderName:  "thing",
+		LocalPath:     staleLocalPath, // set, but not a valid git checkout
+		DefaultBranch: "",
+	}
+	taskRepo := &models.TaskRepository{ID: "tr-1", TaskID: "task-1", RepositoryID: "repo-1"}
+
+	updater := &recordingRepoUpdater{}
+	exc := newTestExecutor(t, &mockAgentManager{}, repo)
+	exc.SetRepoCloner(&fakeRepoCloner{returnPath: freshClonePath}, updater)
+
+	info, err := exc.resolveTaskRepoInfo(context.Background(), taskRepo)
+	if err != nil {
+		t.Fatalf("resolveTaskRepoInfo: %v", err)
+	}
+	if info.RepositoryPath != freshClonePath {
+		t.Errorf("RepositoryPath: got %q, want re-cloned path %q", info.RepositoryPath, freshClonePath)
+	}
+	if info.BaseBranch != "main" {
+		t.Errorf("BaseBranch: got %q, want %q (detected from the fresh clone)", info.BaseBranch, "main")
+	}
+}
+
+// TestResolveTaskRepoInfo_KeepsStaleLocalPathWhenNoClonerConfigured guards the
+// "never blank a set path" contract: when the stored LocalPath is invalid but
+// no cloner is configured to fix it, resolveTaskRepoInfo must not wipe out the
+// existing (bad) path — it should be left as-is so the failure surfaces with
+// full context rather than silently becoming empty.
+func TestResolveTaskRepoInfo_KeepsStaleLocalPathWhenNoClonerConfigured(t *testing.T) {
+	staleLocalPath := t.TempDir()
+
+	repo := newMockRepository()
+	repo.repositories["repo-1"] = &models.Repository{
+		ID:            "repo-1",
+		Provider:      "github",
+		ProviderOwner: "acme",
+		ProviderName:  "thing",
+		LocalPath:     staleLocalPath,
+		DefaultBranch: "",
+	}
+	taskRepo := &models.TaskRepository{ID: "tr-1", TaskID: "task-1", RepositoryID: "repo-1"}
+
+	exc := newTestExecutor(t, &mockAgentManager{}, repo)
+	exc.SetRepoCloner(nil, &recordingRepoUpdater{})
+
+	info, err := exc.resolveTaskRepoInfo(context.Background(), taskRepo)
+	if err != nil {
+		t.Fatalf("resolveTaskRepoInfo: %v", err)
+	}
+	if info.RepositoryPath != staleLocalPath {
+		t.Errorf("RepositoryPath: got %q, want unchanged stale path %q", info.RepositoryPath, staleLocalPath)
+	}
+}
+
 // fakeRepoCloner returns a fixed local path for any clone request.
 type fakeRepoCloner struct{ returnPath string }
 

--- a/apps/backend/internal/orchestrator/executor/executor_resume_clone_default_branch_test.go
+++ b/apps/backend/internal/orchestrator/executor/executor_resume_clone_default_branch_test.go
@@ -285,6 +285,94 @@ func TestResolveTaskRepoInfo_KeepsStaleLocalPathWhenNoClonerConfigured(t *testin
 	}
 }
 
+// TestResolveTaskRepoInfo_DoesNotReCloneLocalSourceTypeRepo is the regression
+// guard for the Codex review finding on the stale-path re-clone fix: a repo
+// can be SourceType "local" (the user picked a checkout on their own machine)
+// while still carrying ProviderOwner/ProviderName (the origin it was imported
+// from). If that local checkout is temporarily missing/unmounted, the guard
+// must NOT clone the remote into a managed path and overwrite the user's
+// saved LocalPath — only genuinely provider-backed repos (SourceType !=
+// "local") are eligible for the self-heal re-clone.
+func TestResolveTaskRepoInfo_DoesNotReCloneLocalSourceTypeRepo(t *testing.T) {
+	missingLocalPath := filepath.Join(t.TempDir(), "unmounted-checkout") // does not exist on disk
+
+	repo := newMockRepository()
+	repo.repositories["repo-1"] = &models.Repository{
+		ID:            "repo-1",
+		SourceType:    "local",
+		Provider:      "github",
+		ProviderOwner: "acme",
+		ProviderName:  "thing",
+		LocalPath:     missingLocalPath,
+		DefaultBranch: "",
+	}
+	taskRepo := &models.TaskRepository{ID: "tr-1", TaskID: "task-1", RepositoryID: "repo-1"}
+
+	updater := &recordingRepoUpdater{}
+	exc := newTestExecutor(t, &mockAgentManager{}, repo)
+	// A cloner IS configured; if the guard incorrectly fired, this would clone
+	// and overwrite LocalPath. The test asserts it does not fire.
+	exc.SetRepoCloner(&fakeRepoCloner{returnPath: filepath.Join(t.TempDir(), "should-not-be-used")}, updater)
+
+	info, err := exc.resolveTaskRepoInfo(context.Background(), taskRepo)
+	if err != nil {
+		t.Fatalf("resolveTaskRepoInfo: %v", err)
+	}
+	if info.RepositoryPath != missingLocalPath {
+		t.Errorf("RepositoryPath: got %q, want unchanged local path %q (must not be overwritten by a re-clone)", info.RepositoryPath, missingLocalPath)
+	}
+	if got := updater.getDefaultBranch("repo-1"); got != "" {
+		t.Errorf("UpdateRepositoryDefaultBranch should not be called for a local-sourced repo, got %q", got)
+	}
+}
+
+// TestApplyResumeRepoConfig_SelfHealsStaleProviderPath is the regression guard
+// for the Greptile review finding that the single-repo resume path
+// (applyResumeRepoConfig) read repository.LocalPath directly without running
+// it through the same stale-path re-clone guard as resolveTaskRepoInfo. A
+// RESUME of a session whose repo has a stale/missing provider-backed local
+// path must self-heal by re-cloning, just like a fresh launch does.
+func TestApplyResumeRepoConfig_SelfHealsStaleProviderPath(t *testing.T) {
+	staleLocalPath := t.TempDir() // exists on disk, but has no .git inside
+
+	originPath := initBareOriginWithMain(t)
+	freshClonePath := filepath.Join(t.TempDir(), "fresh-clone")
+	runGitInTest(t, "", "clone", originPath, freshClonePath)
+
+	repo := newMockRepository()
+	repo.repositories["repo-1"] = &models.Repository{
+		ID:            "repo-1",
+		Provider:      "github",
+		ProviderOwner: "acme",
+		ProviderName:  "thing",
+		LocalPath:     staleLocalPath,
+	}
+	repo.tasks["task-1"] = &models.Task{ID: "task-1"}
+	task := (&models.Task{ID: "task-1"}).ToAPI()
+	session := &models.TaskSession{
+		ID:           "sess-1",
+		TaskID:       "task-1",
+		RepositoryID: "repo-1",
+		BaseBranch:   "main",
+	}
+
+	updater := &recordingRepoUpdater{}
+	exc := newTestExecutor(t, &mockAgentManager{}, repo)
+	exc.SetRepoCloner(&fakeRepoCloner{returnPath: freshClonePath}, updater)
+
+	req := &LaunchAgentRequest{TaskID: "task-1", SessionID: "sess-1", ExecutorType: "worktree"}
+	if _, err := exc.applyResumeRepoConfig(context.Background(), task, session, req, nil); err != nil {
+		t.Fatalf("applyResumeRepoConfig: %v", err)
+	}
+
+	if repo.repositories["repo-1"].LocalPath != freshClonePath {
+		t.Errorf("Repository.LocalPath: got %q, want re-cloned path %q", repo.repositories["repo-1"].LocalPath, freshClonePath)
+	}
+	if req.RepositoryPath != freshClonePath {
+		t.Errorf("req.RepositoryPath: got %q, want re-cloned path %q", req.RepositoryPath, freshClonePath)
+	}
+}
+
 // fakeRepoCloner returns a fixed local path for any clone request.
 type fakeRepoCloner struct{ returnPath string }
 


### PR DESCRIPTION
## Problem
Launching a task against a provider-backed ("remote") repository could fail with **"repository is not a git repository"**, shown in the UI as a passing "Validate repository" step, then a failed "Sync base branch" (`sync interrupted by worktree creation failure`) and failed "Create worktree".

## Root cause
`resolveTaskRepoInfo` only (re)clones a provider-backed repo when `repo.LocalPath == ""`. When a repo row has a **non-empty but invalid** `local_path` (clone deleted/moved, or relocated by the #1832 provider clone-path/identity change to the `_providers/<provider>/<host>/…` scheme), cloning is skipped and the bad path is passed to the worktree preparer. `validateWorktreeRequest` only checks the path is non-empty, so "Validate repository" passes; `worktree.Manager.Create` then hits the missing `.git` and returns `ErrRepoNotGit`, mislabeled downstream as a sync interruption.

## Fix
- **Self-heal (primary):** the clone guard now re-clones when `LocalPath` is empty **or** not a valid git checkout (new `isLocalGitRepo` helper, mirroring `worktree.Manager.isGitRepo`). It still only overwrites `LocalPath` when a clone actually returns a path — a stale path is never blanked when no cloner is configured. Existing installs affected by #1832 now recover on next launch instead of hard-failing.
- **Honest validation (secondary):** the "Validate repository" step now fails with `repository path is not a git repository: <path>` when the path exists but has no `.git`, so the genuinely-unrecoverable case surfaces at the right step with an accurate message instead of the misleading "sync interrupted" cascade.

## Tests
- Re-clone fires and base branch backfills when `local_path` is a non-git dir; stale path preserved when no cloner is configured.
- `validateWorktreeRequest` fails with the new error naming the offending path.

## Verification
`make fmt`, `go build ./...`, `go test` on the executor / lifecycle / worktree packages (all `ok`), and `golangci-lint` on both changed packages (`0 issues`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1876?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->