### PR TITLE
fix: support long Git worktree paths on Windows

### DIFF
--- a/apps/backend/internal/agent/runtime/lifecycle/manager_execution.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_execution.go
@@ -181,10 +181,16 @@ func awaitCoalescedResult(
 	ctx context.Context,
 	result <-chan singleflight.Result,
 ) (interface{}, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	case completed := <-result:
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		if completed.Err != nil {
 			return nil, completed.Err
 		}

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_execution_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_execution_test.go
@@ -16,6 +16,8 @@ import (
 	"testing/synctest"
 	"time"
 
+	"golang.org/x/sync/singleflight"
+
 	"github.com/kandev/kandev/internal/agent/executor"
 	"github.com/kandev/kandev/internal/agent/runtime/activity"
 	agentctl "github.com/kandev/kandev/internal/agent/runtime/agentctl"
@@ -51,7 +53,7 @@ func TestErrSessionWorkspaceNotReady_UnrelatedError(t *testing.T) {
 }
 
 func TestGetOrEnsureExecutionLeaderCancellationDoesNotAbortLiveWaiter(t *testing.T) {
-	mgr, _ := newEnvironmentExecutionTestManager(t, &mockWorkspaceInfoProvider{
+	mgr, backend := newEnvironmentExecutionTestManager(t, &mockWorkspaceInfoProvider{
 		infos: map[string]*WorkspaceInfo{
 			"session-shared": {
 				TaskID: "task-1", SessionID: "session-shared", TaskEnvironmentID: "env-1",
@@ -59,41 +61,64 @@ func TestGetOrEnsureExecutionLeaderCancellationDoesNotAbortLiveWaiter(t *testing
 			},
 		},
 	})
-	coordinator := activity.NewCoordinator(activity.Options{})
-	mgr.SetActivityCoordinator(coordinator)
-	maintenance, _, err := coordinator.TryAcquireMaintenance(context.Background(), 0)
-	if err != nil {
-		t.Fatal(err)
-	}
+	backend.entered = make(chan struct{}, 1)
+	backend.barrier = make(chan struct{})
+	released := false
+	defer func() {
+		if !released {
+			close(backend.barrier)
+		}
+	}()
+
 	leaderCtx, cancelLeader := context.WithCancel(context.Background())
 	defer cancelLeader()
-	type result struct {
-		caller string
-		err    error
-	}
-	results := make(chan result, 2)
+	leaderResult := make(chan error, 1)
 	go func() {
 		_, err := mgr.GetOrEnsureExecution(leaderCtx, "session-shared")
-		results <- result{caller: "leader", err: err}
+		leaderResult <- err
 	}()
 	select {
-	case <-maintenance.Context().Done():
+	case <-backend.entered:
 	case <-time.After(time.Second):
-		t.Fatal("leader did not reach activity admission")
+		t.Fatal("leader did not reach CreateInstance")
 	}
+
+	followerCtx := &doneObservedContext{
+		Context:  context.Background(),
+		doneRead: make(chan struct{}),
+	}
+	followerResult := make(chan error, 1)
 	go func() {
-		_, err := mgr.GetOrEnsureExecution(context.Background(), "session-shared")
-		results <- result{caller: "follower", err: err}
+		_, err := mgr.GetOrEnsureExecution(followerCtx, "session-shared")
+		followerResult <- err
 	}()
+	select {
+	case <-followerCtx.doneRead:
+	case <-time.After(time.Second):
+		t.Fatal("follower did not join the coalesced execution")
+	}
+
 	cancelLeader()
-	maintenance.Release()
-	for range 2 {
-		got := <-results
-		if got.caller == "leader" && !errors.Is(got.err, context.Canceled) {
-			t.Fatalf("leader error = %v, want context cancellation", got.err)
-		}
-		if got.caller == "follower" && got.err != nil {
-			t.Fatalf("live follower failed after leader cancellation: %v", got.err)
+	if err := <-leaderResult; !errors.Is(err, context.Canceled) {
+		t.Fatalf("leader error = %v, want context cancellation", err)
+	}
+	close(backend.barrier)
+	released = true
+	if err := <-followerResult; err != nil {
+		t.Fatalf("live follower failed after leader cancellation: %v", err)
+	}
+}
+
+func TestAwaitCoalescedResultPrefersCanceledContext(t *testing.T) {
+	for range 100 {
+		ctx, cancel := context.WithCancel(context.Background())
+		result := make(chan singleflight.Result, 1)
+		result <- singleflight.Result{Val: "created"}
+		cancel()
+
+		_, err := awaitCoalescedResult(ctx, result)
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("await error = %v, want context cancellation", err)
 		}
 	}
 }
@@ -837,6 +862,17 @@ func TestCreateExecutionResolvesProfileOnceForEnvAndAutoApprove(t *testing.T) {
 }
 
 // --- test helpers ---
+
+type doneObservedContext struct {
+	context.Context
+	doneRead chan struct{}
+	once     sync.Once
+}
+
+func (c *doneObservedContext) Done() <-chan struct{} {
+	c.once.Do(func() { close(c.doneRead) })
+	return c.Context.Done()
+}
 
 type notifyingWorkspaceInfoProvider struct {
 	*mockWorkspaceInfoProvider

--- a/apps/backend/internal/worktree/errors.go
+++ b/apps/backend/internal/worktree/errors.go
@@ -113,14 +113,22 @@ func isRemoteRefMissingError(err error) bool {
 // based on the command output.
 func ClassifyGitError(output string, _ error) error {
 	trimmed := strings.TrimSpace(output)
+	lowerOutput := strings.ToLower(output)
 
 	switch {
 	case isBranchCheckedOutError(output):
 		return fmt.Errorf("%w: %s", ErrBranchCheckedOut, trimmed)
-	case containsAuthFailure(strings.ToLower(output)):
+	case containsAuthFailure(lowerOutput):
 		return fmt.Errorf("%w: %s", ErrAuthFailed, trimmed)
-	case strings.Contains(strings.ToLower(output), "non-fast-forward"):
+	case strings.Contains(lowerOutput, "non-fast-forward"):
 		return fmt.Errorf("%w: %s", ErrNonFastForward, trimmed)
+	case strings.Contains(lowerOutput, "filename too long"):
+		return fmt.Errorf(
+			"%w: Git could not materialize the worktree and may have hit a path-length limit. "+
+				"Kandev enabled Git long paths for this command; on Windows, enable Win32 long paths "+
+				"or use a shorter checkout path. Git output: %s",
+			ErrGitCommandFailed, trimmed,
+		)
 	default:
 		return fmt.Errorf("%w: %s", ErrGitCommandFailed, trimmed)
 	}

--- a/apps/backend/internal/worktree/errors_test.go
+++ b/apps/backend/internal/worktree/errors_test.go
@@ -3,6 +3,7 @@ package worktree
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 )
 
@@ -46,6 +47,32 @@ func TestClassifyGitError_GenericFailure(t *testing.T) {
 	err := ClassifyGitError(output, fmt.Errorf("exit status 1"))
 	if !errors.Is(err, ErrGitCommandFailed) {
 		t.Fatalf("expected ErrGitCommandFailed, got: %v", err)
+	}
+}
+
+func TestClassifyGitError_PathTooLongIncludesWindowsGuidanceAndGitOutput(t *testing.T) {
+	output := "error: unable to create file generated/very/long/project.csproj: Filename too long\n" +
+		"fatal: Could not reset index file to revision 'HEAD'."
+	err := ClassifyGitError(output, fmt.Errorf("exit status 128"))
+
+	if !errors.Is(err, ErrGitCommandFailed) {
+		t.Fatalf("expected ErrGitCommandFailed, got: %v", err)
+	}
+	for _, want := range []string{"Windows", "long paths", "Filename too long", "Could not reset index file"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("classified error %q does not contain %q", err, want)
+		}
+	}
+}
+
+func TestClassifyGitError_ResetIndexAloneDoesNotClaimPathLimit(t *testing.T) {
+	output := "fatal: Could not reset index file to revision 'HEAD'."
+	err := ClassifyGitError(output, fmt.Errorf("exit status 128"))
+
+	for _, misleading := range []string{"Windows", "path-length limit", "Win32 long paths"} {
+		if strings.Contains(err.Error(), misleading) {
+			t.Fatalf("generic reset-index error %q contains misleading guidance %q", err, misleading)
+		}
 	}
 }
 

--- a/apps/backend/internal/worktree/git_command.go
+++ b/apps/backend/internal/worktree/git_command.go
@@ -1,0 +1,17 @@
+package worktree
+
+import (
+	"context"
+	"os/exec"
+)
+
+// newGitCommand enables Git's long-path handling for this process only. Git
+// accepts the setting on every supported platform, so using the same command
+// shape everywhere keeps all package-owned Git invocations on one safe path
+// without mutating repository, global, or system configuration.
+func newGitCommand(ctx context.Context, args ...string) *exec.Cmd {
+	commandArgs := make([]string, 0, len(args)+2)
+	commandArgs = append(commandArgs, "-c", "core.longpaths=true")
+	commandArgs = append(commandArgs, args...)
+	return exec.CommandContext(ctx, "git", commandArgs...)
+}

--- a/apps/backend/internal/worktree/git_throttle_test.go
+++ b/apps/backend/internal/worktree/git_throttle_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os/exec"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -71,6 +72,15 @@ func TestRunGitCmd_RunsToCompletionWhenCapacityAvailable(t *testing.T) {
 		}()
 	}
 	wg.Wait()
+}
+
+func TestNewNonInteractiveGitCmd_EnablesLongPathsPerCommand(t *testing.T) {
+	cmd := (&Manager{}).newNonInteractiveGitCmd(context.Background(), t.TempDir(), "status", "--short")
+
+	want := []string{"git", "-c", "core.longpaths=true", "status", "--short"}
+	if !slices.Equal(cmd.Args, want) {
+		t.Fatalf("git command args = %q, want %q", cmd.Args, want)
+	}
 }
 
 // Cap parsing tests live in internal/common/subproc/shared_test.go now

--- a/apps/backend/internal/worktree/gitcrypt.go
+++ b/apps/backend/internal/worktree/gitcrypt.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -118,7 +117,7 @@ func (m *Manager) unlockGitCryptAndCheckout(ctx context.Context, worktreePath st
 		checkoutArgs = append(checkoutArgs, ":(literal,exclude)"+sp)
 	}
 
-	checkoutCmd := exec.CommandContext(ctx, "git", checkoutArgs...)
+	checkoutCmd := newGitCommand(ctx, checkoutArgs...)
 	checkoutCmd.Dir = worktreePath
 	if output, err := runGitCmdCombinedOutput(ctx, checkoutCmd); err != nil {
 		m.logger.Error("git checkout failed after git-crypt setup",
@@ -136,7 +135,7 @@ func (m *Manager) unlockGitCryptAndCheckout(ctx context.Context, worktreePath st
 	// Restore submodule entries in the index that were excluded from checkout.
 	// Without this, git status shows them as staged deletions.
 	for _, sp := range submodulePaths {
-		resetCmd := exec.CommandContext(ctx, "git", "reset", "HEAD", "--", sp)
+		resetCmd := newGitCommand(ctx, "reset", "HEAD", "--", sp)
 		resetCmd.Dir = worktreePath
 		if output, err := runGitCmdCombinedOutput(ctx, resetCmd); err != nil {
 			m.logger.Debug("failed to reset submodule index entry",
@@ -162,7 +161,7 @@ func (m *Manager) unlockGitCryptAndCheckout(ctx context.Context, worktreePath st
 // resolveGitDir runs git rev-parse with the given flag (e.g. --git-dir,
 // --git-common-dir) and returns the resolved absolute path.
 func resolveGitDir(ctx context.Context, worktreePath, flag string) (string, error) {
-	cmd := exec.CommandContext(ctx, "git", "rev-parse", flag)
+	cmd := newGitCommand(ctx, "rev-parse", flag)
 	cmd.Dir = worktreePath
 	out, err := runGitCmdOutput(ctx, cmd)
 	if err != nil {
@@ -204,7 +203,7 @@ func isGitCryptUnlocked(gitCryptDir string) bool {
 // enableWorktreeConfig enables the worktreeConfig extension so that
 // --worktree flag works with git config in linked worktrees.
 func enableWorktreeConfig(ctx context.Context, worktreePath string) error {
-	cmd := exec.CommandContext(ctx, "git", "config", "extensions.worktreeConfig", "true")
+	cmd := newGitCommand(ctx, "config", "extensions.worktreeConfig", "true")
 	cmd.Dir = worktreePath
 	if out, err := runGitCmdCombinedOutput(ctx, cmd); err != nil {
 		return fmt.Errorf("git config extensions.worktreeConfig: %s: %w", string(out), err)
@@ -226,7 +225,7 @@ func configureGitCryptFilters(ctx context.Context, worktreePath string) error {
 		{"diff.git-crypt.textconv", "git-crypt diff"},
 	}
 	for _, kv := range configs {
-		cmd := exec.CommandContext(ctx, "git", "config", "--worktree", kv[0], kv[1])
+		cmd := newGitCommand(ctx, "config", "--worktree", kv[0], kv[1])
 		cmd.Dir = worktreePath
 		if out, err := runGitCmdCombinedOutput(ctx, cmd); err != nil {
 			return fmt.Errorf("git config %s: %s: %w", kv[0], string(out), err)
@@ -260,7 +259,7 @@ func disableGitCryptFilters(ctx context.Context, worktreePath string) error {
 		{"diff.git-crypt.textconv", "cat"},
 	}
 	for _, kv := range configs {
-		cmd := exec.CommandContext(ctx, "git", "config", kv[0], kv[1])
+		cmd := newGitCommand(ctx, "config", kv[0], kv[1])
 		cmd.Dir = worktreePath
 		if out, err := runGitCmdCombinedOutput(ctx, cmd); err != nil {
 			return fmt.Errorf("git config %s: %s: %w", kv[0], string(out), err)

--- a/apps/backend/internal/worktree/manager_cleanup.go
+++ b/apps/backend/internal/worktree/manager_cleanup.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -76,24 +78,32 @@ func worktreeRegistrationExists(ctx context.Context, repoPath, worktreePath stri
 	return false, nil
 }
 
+type worktreeRegistrationOwnership uint8
+
+const (
+	worktreeRegistrationAbsent worktreeRegistrationOwnership = iota
+	worktreeRegistrationOwned
+	worktreeRegistrationCompeting
+)
+
 func inspectWorktreeRegistrationOwnership(
 	ctx context.Context, repoPath, worktreePath, branchRef, headOID string,
-) (bool, error) {
+) (worktreeRegistrationOwnership, error) {
 	cmd := newGitCommand(ctx, "worktree", "list", "--porcelain", "-z")
 	cmd.Dir = repoPath
 	output, err := runGitCmdCombinedOutput(ctx, cmd)
 	if err != nil {
-		return false, err
+		return worktreeRegistrationAbsent, err
 	}
 	wantPath, err := normalizedWorktreeTargetPath(worktreePath)
 	if err != nil {
-		return false, err
+		return worktreeRegistrationAbsent, err
 	}
-	var exactTarget, branchElsewhere bool
+	var exactTarget, branchElsewhere, targetClaimed bool
 	var normalizationErr error
 	var currentPath, currentHead, currentBranch string
 	inspectRegistration := func() {
-		if currentBranch != branchRef || normalizationErr != nil {
+		if currentPath == "" || normalizationErr != nil {
 			return
 		}
 		currentPathKey, normalizeErr := normalizedWorktreeTargetPath(currentPath)
@@ -101,11 +111,17 @@ func inspectWorktreeRegistrationOwnership(
 			normalizationErr = normalizeErr
 			return
 		}
-		if currentPathKey == wantPath && currentHead == headOID {
+		if currentPathKey != wantPath {
+			if currentBranch == branchRef {
+				branchElsewhere = true
+			}
+			return
+		}
+		if currentBranch == branchRef && currentHead == headOID {
 			exactTarget = true
 			return
 		}
-		branchElsewhere = true
+		targetClaimed = true
 	}
 	for _, field := range strings.Split(string(output), "\x00") {
 		switch {
@@ -122,9 +138,15 @@ func inspectWorktreeRegistrationOwnership(
 	}
 	inspectRegistration()
 	if normalizationErr != nil {
-		return false, normalizationErr
+		return worktreeRegistrationAbsent, normalizationErr
 	}
-	return exactTarget && !branchElsewhere, nil
+	if exactTarget && !branchElsewhere && !targetClaimed {
+		return worktreeRegistrationOwned, nil
+	}
+	if branchElsewhere || targetClaimed {
+		return worktreeRegistrationCompeting, nil
+	}
+	return worktreeRegistrationAbsent, nil
 }
 
 // RemoveByID removes a specific worktree by its ID and optionally its branch.
@@ -448,12 +470,15 @@ func (m *Manager) tryRemoveEmptyTaskDir(worktreePath string) {
 }
 
 // forceRemoveDir removes a directory, retrying transient filesystem failures.
-// It intentionally remains within Go's portable filesystem API so cleanup also
-// works in native Windows environments where a Unix rm binary is unavailable.
+// Native Windows cleanup intentionally stays within Go's portable filesystem
+// APIs. Unix hosts get a final non-shell rm fallback for persistent removal
+// failures caused by filesystems that reject os.RemoveAll while allowing rm.
 func (m *Manager) forceRemoveDir(dir string) error {
 	const maxRetries = 3
 	const retryDelay = 200 * time.Millisecond
-	return m.removeDirWithRetries(dir, maxRetries, retryDelay, os.RemoveAll)
+	return m.removeDirWithRetriesAndFallback(
+		dir, maxRetries, retryDelay, os.RemoveAll, forceRemoveDirUnix, isUnixLikeOS(runtime.GOOS),
+	)
 }
 
 func (m *Manager) removeDirWithRetries(
@@ -475,4 +500,40 @@ func (m *Manager) removeDirWithRetries(
 		}
 	}
 	return fmt.Errorf("remove directory %s after %d attempts: %w", dir, maxRetries, lastErr)
+}
+
+func (m *Manager) removeDirWithRetriesAndFallback(
+	dir string, maxRetries int, retryDelay time.Duration,
+	removeAll, fallback func(string) error,
+	useFallback bool,
+) error {
+	err := m.removeDirWithRetries(dir, maxRetries, retryDelay, removeAll)
+	if err == nil || !useFallback {
+		return err
+	}
+	if fallbackErr := fallback(dir); fallbackErr != nil {
+		return fmt.Errorf("remove directory %s with Unix fallback: %w", dir, errors.Join(err, fallbackErr))
+	}
+	return nil
+}
+
+func forceRemoveDirUnix(dir string) error {
+	if strings.TrimSpace(dir) == "" {
+		return errors.New("refusing to remove an empty directory path")
+	}
+	cmd := exec.Command("rm", "-rf", "--", dir)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("rm -rf -- %q: %w: %s", dir, err, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+func isUnixLikeOS(goos string) bool {
+	switch goos {
+	case "aix", "android", "darwin", "dragonfly", "freebsd", "illumos", "ios", "linux", "netbsd", "openbsd", "solaris":
+		return true
+	default:
+		return false
+	}
 }

--- a/apps/backend/internal/worktree/manager_cleanup.go
+++ b/apps/backend/internal/worktree/manager_cleanup.go
@@ -86,6 +86,12 @@ const (
 	worktreeRegistrationCompeting
 )
 
+type worktreeRegistration struct {
+	path   string
+	head   string
+	branch string
+}
+
 func inspectWorktreeRegistrationOwnership(
 	ctx context.Context, repoPath, worktreePath, branchRef, headOID string,
 ) (worktreeRegistrationOwnership, error) {
@@ -99,46 +105,53 @@ func inspectWorktreeRegistrationOwnership(
 	if err != nil {
 		return worktreeRegistrationAbsent, err
 	}
-	var exactTarget, branchElsewhere, targetClaimed bool
-	var normalizationErr error
-	var currentPath, currentHead, currentBranch string
-	inspectRegistration := func() {
-		if currentPath == "" || normalizationErr != nil {
-			return
-		}
-		currentPathKey, normalizeErr := normalizedWorktreeTargetPath(currentPath)
-		if normalizeErr != nil {
-			normalizationErr = normalizeErr
-			return
-		}
-		if currentPathKey != wantPath {
-			if currentBranch == branchRef {
-				branchElsewhere = true
-			}
-			return
-		}
-		if currentBranch == branchRef && currentHead == headOID {
-			exactTarget = true
-			return
-		}
-		targetClaimed = true
-	}
-	for _, field := range strings.Split(string(output), "\x00") {
+	return classifyWorktreeRegistrationOwnership(
+		parseWorktreeRegistrations(string(output)), wantPath, branchRef, headOID,
+	)
+}
+
+func parseWorktreeRegistrations(output string) []worktreeRegistration {
+	var registrations []worktreeRegistration
+	current := -1
+	for _, field := range strings.Split(output, "\x00") {
 		switch {
 		case strings.HasPrefix(field, "worktree "):
-			inspectRegistration()
-			currentPath = strings.TrimPrefix(field, "worktree ")
-			currentHead = ""
-			currentBranch = ""
-		case strings.HasPrefix(field, "HEAD "):
-			currentHead = strings.TrimPrefix(field, "HEAD ")
-		case strings.HasPrefix(field, "branch "):
-			currentBranch = strings.TrimPrefix(field, "branch ")
+			registrations = append(registrations, worktreeRegistration{
+				path: strings.TrimPrefix(field, "worktree "),
+			})
+			current = len(registrations) - 1
+		case current >= 0 && strings.HasPrefix(field, "HEAD "):
+			registrations[current].head = strings.TrimPrefix(field, "HEAD ")
+		case current >= 0 && strings.HasPrefix(field, "branch "):
+			registrations[current].branch = strings.TrimPrefix(field, "branch ")
 		}
 	}
-	inspectRegistration()
-	if normalizationErr != nil {
-		return worktreeRegistrationAbsent, normalizationErr
+	return registrations
+}
+
+func classifyWorktreeRegistrationOwnership(
+	registrations []worktreeRegistration, wantPath, branchRef, headOID string,
+) (worktreeRegistrationOwnership, error) {
+	var exactTarget, branchElsewhere, targetClaimed bool
+	for _, registration := range registrations {
+		if registration.path == "" {
+			continue
+		}
+		currentPath, err := normalizedWorktreeTargetPath(registration.path)
+		if err != nil {
+			return worktreeRegistrationAbsent, err
+		}
+		if currentPath != wantPath {
+			if registration.branch == branchRef {
+				branchElsewhere = true
+			}
+			continue
+		}
+		if registration.branch == branchRef && registration.head == headOID {
+			exactTarget = true
+			continue
+		}
+		targetClaimed = true
 	}
 	if exactTarget && !branchElsewhere && !targetClaimed {
 		return worktreeRegistrationOwned, nil

--- a/apps/backend/internal/worktree/manager_cleanup.go
+++ b/apps/backend/internal/worktree/manager_cleanup.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -47,7 +46,7 @@ func (m *Manager) pruneQuarantinedWorktree(ctx context.Context, wt *Worktree) er
 		m.releaseRepoLock(wt.RepositoryPath)
 	}()
 
-	cmd := exec.CommandContext(ctx, "git", "worktree", "remove", "--force", wt.Path)
+	cmd := newGitCommand(ctx, "worktree", "remove", "--force", wt.Path)
 	cmd.Dir = wt.RepositoryPath
 	if _, err := runGitCmdCombinedOutput(ctx, cmd); err != nil {
 		present, inspectErr := worktreeRegistrationExists(ctx, wt.RepositoryPath, wt.Path)
@@ -62,7 +61,7 @@ func (m *Manager) pruneQuarantinedWorktree(ctx context.Context, wt *Worktree) er
 }
 
 func worktreeRegistrationExists(ctx context.Context, repoPath, worktreePath string) (bool, error) {
-	cmd := exec.CommandContext(ctx, "git", "worktree", "list", "--porcelain", "-z")
+	cmd := newGitCommand(ctx, "worktree", "list", "--porcelain", "-z")
 	cmd.Dir = repoPath
 	output, err := runGitCmdCombinedOutput(ctx, cmd)
 	if err != nil {
@@ -75,6 +74,57 @@ func worktreeRegistrationExists(ctx context.Context, repoPath, worktreePath stri
 		}
 	}
 	return false, nil
+}
+
+func inspectWorktreeRegistrationOwnership(
+	ctx context.Context, repoPath, worktreePath, branchRef, headOID string,
+) (bool, error) {
+	cmd := newGitCommand(ctx, "worktree", "list", "--porcelain", "-z")
+	cmd.Dir = repoPath
+	output, err := runGitCmdCombinedOutput(ctx, cmd)
+	if err != nil {
+		return false, err
+	}
+	wantPath, err := normalizedWorktreeTargetPath(worktreePath)
+	if err != nil {
+		return false, err
+	}
+	var exactTarget, branchElsewhere bool
+	var normalizationErr error
+	var currentPath, currentHead, currentBranch string
+	inspectRegistration := func() {
+		if currentBranch != branchRef || normalizationErr != nil {
+			return
+		}
+		currentPathKey, normalizeErr := normalizedWorktreeTargetPath(currentPath)
+		if normalizeErr != nil {
+			normalizationErr = normalizeErr
+			return
+		}
+		if currentPathKey == wantPath && currentHead == headOID {
+			exactTarget = true
+			return
+		}
+		branchElsewhere = true
+	}
+	for _, field := range strings.Split(string(output), "\x00") {
+		switch {
+		case strings.HasPrefix(field, "worktree "):
+			inspectRegistration()
+			currentPath = strings.TrimPrefix(field, "worktree ")
+			currentHead = ""
+			currentBranch = ""
+		case strings.HasPrefix(field, "HEAD "):
+			currentHead = strings.TrimPrefix(field, "HEAD ")
+		case strings.HasPrefix(field, "branch "):
+			currentBranch = strings.TrimPrefix(field, "branch ")
+		}
+	}
+	inspectRegistration()
+	if normalizationErr != nil {
+		return false, normalizationErr
+	}
+	return exactTarget && !branchElsewhere, nil
 }
 
 // RemoveByID removes a specific worktree by its ID and optionally its branch.
@@ -126,7 +176,7 @@ func (m *Manager) removeWorktree(ctx context.Context, wt *Worktree, removeBranch
 			zap.String("branch", wt.Branch),
 			zap.String("repository_path", wt.RepositoryPath))
 
-		cmd := exec.CommandContext(ctx, "git", "branch", "-D", wt.Branch)
+		cmd := newGitCommand(ctx, "branch", "-D", wt.Branch)
 		cmd.Dir = wt.RepositoryPath
 		if output, err := runGitCmdCombinedOutput(ctx, cmd); err != nil {
 			m.logger.Warn("failed to delete branch from main repository",
@@ -343,19 +393,19 @@ func (m *Manager) OnTaskDeleted(ctx context.Context, taskID string) error {
 // still has siblings or contains workspace-scoped content.
 func (m *Manager) removeWorktreeDir(ctx context.Context, worktreePath, repoPath string) error {
 	// First try git worktree remove
-	cmd := exec.CommandContext(ctx, "git", "worktree", "remove", "--force", worktreePath)
+	cmd := newGitCommand(ctx, "worktree", "remove", "--force", worktreePath)
 	cmd.Dir = repoPath
 	if output, err := runGitCmdCombinedOutput(ctx, cmd); err != nil {
-		m.logger.Debug("git worktree remove failed, falling back to rm",
+		m.logger.Debug("git worktree remove failed, falling back to filesystem removal",
 			zap.String("output", string(output)),
 			zap.Error(err))
 
-		if err := m.forceRemoveDir(ctx, worktreePath); err != nil {
+		if err := m.forceRemoveDir(worktreePath); err != nil {
 			return err
 		}
 
 		// Prune stale worktree entries
-		pruneCmd := exec.CommandContext(ctx, "git", "worktree", "prune")
+		pruneCmd := newGitCommand(ctx, "worktree", "prune")
 		pruneCmd.Dir = repoPath
 		if err := runGitCmd(ctx, pruneCmd); err != nil {
 			m.logger.Debug("git worktree prune failed", zap.Error(err))
@@ -397,32 +447,32 @@ func (m *Manager) tryRemoveEmptyTaskDir(worktreePath string) {
 	}
 }
 
-// forceRemoveDir removes a directory, retrying on transient failures.
-// On macOS, os.RemoveAll can fail with "directory not empty" when files
-// have special attributes or were recently released by other processes
-// (e.g. .next/dev build cache). Falls back to rm -rf as a last resort.
-func (m *Manager) forceRemoveDir(ctx context.Context, dir string) error {
+// forceRemoveDir removes a directory, retrying transient filesystem failures.
+// It intentionally remains within Go's portable filesystem API so cleanup also
+// works in native Windows environments where a Unix rm binary is unavailable.
+func (m *Manager) forceRemoveDir(dir string) error {
 	const maxRetries = 3
 	const retryDelay = 200 * time.Millisecond
+	return m.removeDirWithRetries(dir, maxRetries, retryDelay, os.RemoveAll)
+}
+
+func (m *Manager) removeDirWithRetries(
+	dir string, maxRetries int, retryDelay time.Duration, removeAll func(string) error,
+) error {
+	var lastErr error
 
 	for i := range maxRetries {
-		err := os.RemoveAll(dir)
-		if err == nil {
+		lastErr = removeAll(dir)
+		if lastErr == nil {
 			return nil
 		}
 		if i < maxRetries-1 {
 			m.logger.Debug("os.RemoveAll failed, retrying",
 				zap.String("path", dir),
 				zap.Int("attempt", i+1),
-				zap.Error(err))
+				zap.Error(lastErr))
 			time.Sleep(retryDelay)
 		}
 	}
-
-	// Last resort: shell out to rm -rf which handles macOS edge cases better
-	cmd := exec.CommandContext(ctx, "rm", "-rf", dir)
-	if output, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("rm -rf failed: %w (output: %s)", err, string(output))
-	}
-	return nil
+	return fmt.Errorf("remove directory %s after %d attempts: %w", dir, maxRetries, lastErr)
 }

--- a/apps/backend/internal/worktree/manager_cleanup.go
+++ b/apps/backend/internal/worktree/manager_cleanup.go
@@ -435,7 +435,7 @@ func (m *Manager) removeWorktreeDir(ctx context.Context, worktreePath, repoPath 
 			zap.String("output", string(output)),
 			zap.Error(err))
 
-		if err := m.forceRemoveDir(worktreePath); err != nil {
+		if err := m.forceRemoveDir(ctx, worktreePath); err != nil {
 			return err
 		}
 
@@ -486,20 +486,23 @@ func (m *Manager) tryRemoveEmptyTaskDir(worktreePath string) {
 // Native Windows cleanup intentionally stays within Go's portable filesystem
 // APIs. Unix hosts get a final non-shell rm fallback for persistent removal
 // failures caused by filesystems that reject os.RemoveAll while allowing rm.
-func (m *Manager) forceRemoveDir(dir string) error {
+func (m *Manager) forceRemoveDir(ctx context.Context, dir string) error {
 	const maxRetries = 3
 	const retryDelay = 200 * time.Millisecond
 	return m.removeDirWithRetriesAndFallback(
-		dir, maxRetries, retryDelay, os.RemoveAll, forceRemoveDirUnix, isUnixLikeOS(runtime.GOOS),
+		ctx, dir, maxRetries, retryDelay, os.RemoveAll, forceRemoveDirUnix, isUnixLikeOS(runtime.GOOS),
 	)
 }
 
 func (m *Manager) removeDirWithRetries(
-	dir string, maxRetries int, retryDelay time.Duration, removeAll func(string) error,
+	ctx context.Context, dir string, maxRetries int, retryDelay time.Duration, removeAll func(string) error,
 ) error {
 	var lastErr error
 
 	for i := range maxRetries {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		lastErr = removeAll(dir)
 		if lastErr == nil {
 			return nil
@@ -509,32 +512,45 @@ func (m *Manager) removeDirWithRetries(
 				zap.String("path", dir),
 				zap.Int("attempt", i+1),
 				zap.Error(lastErr))
-			time.Sleep(retryDelay)
+			if err := waitForRetry(ctx, retryDelay); err != nil {
+				return err
+			}
 		}
 	}
 	return fmt.Errorf("remove directory %s after %d attempts: %w", dir, maxRetries, lastErr)
 }
 
+func waitForRetry(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
 func (m *Manager) removeDirWithRetriesAndFallback(
-	dir string, maxRetries int, retryDelay time.Duration,
-	removeAll, fallback func(string) error,
+	ctx context.Context, dir string, maxRetries int, retryDelay time.Duration,
+	removeAll func(string) error, fallback func(context.Context, string) error,
 	useFallback bool,
 ) error {
-	err := m.removeDirWithRetries(dir, maxRetries, retryDelay, removeAll)
-	if err == nil || !useFallback {
+	err := m.removeDirWithRetries(ctx, dir, maxRetries, retryDelay, removeAll)
+	if err == nil || !useFallback || ctx.Err() != nil {
 		return err
 	}
-	if fallbackErr := fallback(dir); fallbackErr != nil {
+	if fallbackErr := fallback(ctx, dir); fallbackErr != nil {
 		return fmt.Errorf("remove directory %s with Unix fallback: %w", dir, errors.Join(err, fallbackErr))
 	}
 	return nil
 }
 
-func forceRemoveDirUnix(dir string) error {
+func forceRemoveDirUnix(ctx context.Context, dir string) error {
 	if strings.TrimSpace(dir) == "" {
 		return errors.New("refusing to remove an empty directory path")
 	}
-	cmd := exec.Command("rm", "-rf", "--", dir)
+	cmd := exec.CommandContext(ctx, "rm", "-rf", "--", dir)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("rm -rf -- %q: %w: %s", dir, err, strings.TrimSpace(string(output)))

--- a/apps/backend/internal/worktree/manager_cleanup_portable_test.go
+++ b/apps/backend/internal/worktree/manager_cleanup_portable_test.go
@@ -21,3 +21,52 @@ func TestRemoveDirWithRetries_ReturnsPortableFilesystemError(t *testing.T) {
 		t.Fatalf("remove function calls = %d, want 3", removeCalls)
 	}
 }
+
+func TestRemoveDirWithRetriesAndUnixFallback_RetriesBeforeFallback(t *testing.T) {
+	mgr := &Manager{logger: newTestLogger()}
+	wantErr := errors.New("filesystem removal failed")
+	removeCalls := 0
+	fallbackCalls := 0
+
+	err := mgr.removeDirWithRetriesAndFallback("worktree", 3, 0,
+		func(string) error {
+			removeCalls++
+			return wantErr
+		},
+		func(string) error {
+			fallbackCalls++
+			return nil
+		},
+		true,
+	)
+	if err != nil {
+		t.Fatalf("removeDirWithRetriesAndFallback() error = %v, want nil", err)
+	}
+	if removeCalls != 3 {
+		t.Fatalf("remove function calls = %d, want 3", removeCalls)
+	}
+	if fallbackCalls != 1 {
+		t.Fatalf("Unix fallback calls = %d, want 1", fallbackCalls)
+	}
+}
+
+func TestRemoveDirWithRetriesAndUnixFallback_SkipsFallbackOnWindows(t *testing.T) {
+	mgr := &Manager{logger: newTestLogger()}
+	wantErr := errors.New("filesystem removal failed")
+	fallbackCalls := 0
+
+	err := mgr.removeDirWithRetriesAndFallback("worktree", 1, 0,
+		func(string) error { return wantErr },
+		func(string) error {
+			fallbackCalls++
+			return nil
+		},
+		false,
+	)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("removeDirWithRetriesAndFallback() error = %v, want wrapped filesystem error", err)
+	}
+	if fallbackCalls != 0 {
+		t.Fatalf("Unix fallback calls = %d, want 0", fallbackCalls)
+	}
+}

--- a/apps/backend/internal/worktree/manager_cleanup_portable_test.go
+++ b/apps/backend/internal/worktree/manager_cleanup_portable_test.go
@@ -1,6 +1,7 @@
 package worktree
 
 import (
+	"context"
 	"errors"
 	"testing"
 )
@@ -10,7 +11,7 @@ func TestRemoveDirWithRetries_ReturnsPortableFilesystemError(t *testing.T) {
 	wantErr := errors.New("filesystem removal failed")
 	removeCalls := 0
 
-	err := mgr.removeDirWithRetries("worktree", 3, 0, func(string) error {
+	err := mgr.removeDirWithRetries(context.Background(), "worktree", 3, 0, func(string) error {
 		removeCalls++
 		return wantErr
 	})
@@ -28,12 +29,12 @@ func TestRemoveDirWithRetriesAndUnixFallback_RetriesBeforeFallback(t *testing.T)
 	removeCalls := 0
 	fallbackCalls := 0
 
-	err := mgr.removeDirWithRetriesAndFallback("worktree", 3, 0,
+	err := mgr.removeDirWithRetriesAndFallback(context.Background(), "worktree", 3, 0,
 		func(string) error {
 			removeCalls++
 			return wantErr
 		},
-		func(string) error {
+		func(context.Context, string) error {
 			fallbackCalls++
 			return nil
 		},
@@ -55,9 +56,9 @@ func TestRemoveDirWithRetriesAndUnixFallback_SkipsFallbackOnWindows(t *testing.T
 	wantErr := errors.New("filesystem removal failed")
 	fallbackCalls := 0
 
-	err := mgr.removeDirWithRetriesAndFallback("worktree", 1, 0,
+	err := mgr.removeDirWithRetriesAndFallback(context.Background(), "worktree", 1, 0,
 		func(string) error { return wantErr },
-		func(string) error {
+		func(context.Context, string) error {
 			fallbackCalls++
 			return nil
 		},
@@ -65,6 +66,59 @@ func TestRemoveDirWithRetriesAndUnixFallback_SkipsFallbackOnWindows(t *testing.T
 	)
 	if !errors.Is(err, wantErr) {
 		t.Fatalf("removeDirWithRetriesAndFallback() error = %v, want wrapped filesystem error", err)
+	}
+	if fallbackCalls != 0 {
+		t.Fatalf("Unix fallback calls = %d, want 0", fallbackCalls)
+	}
+}
+
+func TestRemoveDirWithRetriesAndUnixFallback_PassesContextToFallback(t *testing.T) {
+	mgr := &Manager{logger: newTestLogger()}
+	ctx := context.Background()
+	fallbackCalled := false
+
+	err := mgr.removeDirWithRetriesAndFallback(ctx, "worktree", 1, 0,
+		func(string) error { return errors.New("filesystem removal failed") },
+		func(got context.Context, _ string) error {
+			if got != ctx {
+				t.Fatal("fallback received a different context")
+			}
+			fallbackCalled = true
+			return nil
+		},
+		true,
+	)
+	if err != nil {
+		t.Fatalf("removeDirWithRetriesAndFallback() error = %v, want nil", err)
+	}
+	if !fallbackCalled {
+		t.Fatal("fallback was not called")
+	}
+}
+
+func TestRemoveDirWithRetriesAndUnixFallback_CanceledContextSkipsRemoval(t *testing.T) {
+	mgr := &Manager{logger: newTestLogger()}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	removeCalls := 0
+	fallbackCalls := 0
+
+	err := mgr.removeDirWithRetriesAndFallback(ctx, "worktree", 1, 0,
+		func(string) error {
+			removeCalls++
+			return errors.New("filesystem removal failed")
+		},
+		func(context.Context, string) error {
+			fallbackCalls++
+			return nil
+		},
+		true,
+	)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("removeDirWithRetriesAndFallback() error = %v, want context cancellation", err)
+	}
+	if removeCalls != 0 {
+		t.Fatalf("remove function calls = %d, want 0", removeCalls)
 	}
 	if fallbackCalls != 0 {
 		t.Fatalf("Unix fallback calls = %d, want 0", fallbackCalls)

--- a/apps/backend/internal/worktree/manager_cleanup_portable_test.go
+++ b/apps/backend/internal/worktree/manager_cleanup_portable_test.go
@@ -1,0 +1,23 @@
+package worktree
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestRemoveDirWithRetries_ReturnsPortableFilesystemError(t *testing.T) {
+	mgr := &Manager{logger: newTestLogger()}
+	wantErr := errors.New("filesystem removal failed")
+	removeCalls := 0
+
+	err := mgr.removeDirWithRetries("worktree", 3, 0, func(string) error {
+		removeCalls++
+		return wantErr
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("removeDirWithRetries() error = %v, want wrapped filesystem error", err)
+	}
+	if removeCalls != 3 {
+		t.Fatalf("remove function calls = %d, want 3", removeCalls)
+	}
+}

--- a/apps/backend/internal/worktree/manager_cleanup_unix_test.go
+++ b/apps/backend/internal/worktree/manager_cleanup_unix_test.go
@@ -1,0 +1,29 @@
+//go:build aix || android || darwin || dragonfly || freebsd || illumos || ios || linux || netbsd || openbsd || solaris
+
+package worktree
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestForceRemoveDirUnix_CanceledContextDoesNotRunRm(t *testing.T) {
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "marker")
+	if err := os.WriteFile(marker, []byte("keep"), 0o600); err != nil {
+		t.Fatalf("write marker: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := forceRemoveDirUnix(ctx, dir)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("forceRemoveDirUnix() error = %v, want context cancellation", err)
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("marker removed by canceled fallback: %v", err)
+	}
+}

--- a/apps/backend/internal/worktree/manager_failed_add_rollback_test.go
+++ b/apps/backend/internal/worktree/manager_failed_add_rollback_test.go
@@ -171,6 +171,63 @@ func TestGitAddWorktree_FailurePreservesPreexistingBranchAndDirectory(t *testing
 	}
 }
 
+func TestGitAddWorktree_PreRegistrationFailureRollsBackOwnedBranch(t *testing.T) {
+	repoPath := initGitRepoForWorktreeTest(t)
+	mgr, err := NewManager(newTestConfig(t), newMockStore(), newTestLogger())
+	if err != nil {
+		t.Fatalf("NewManager failed: %v", err)
+	}
+	worktreePath := filepath.Join(t.TempDir(), "preexisting-target")
+	if err := os.Mkdir(worktreePath, 0755); err != nil {
+		t.Fatalf("create preexisting worktree target: %v", err)
+	}
+	marker := filepath.Join(worktreePath, "keep.txt")
+	if err := os.WriteFile(marker, []byte("keep"), 0600); err != nil {
+		t.Fatalf("create target marker: %v", err)
+	}
+
+	_, err = mgr.gitAddWorktree(context.Background(), repoPath, "feature/pre-registration-failure", worktreePath, "main")
+	if err == nil {
+		t.Fatal("gitAddWorktree() error = nil, want pre-registration failure")
+	}
+	exists, existsErr := mgr.branchExists(context.Background(), repoPath, "feature/pre-registration-failure")
+	if existsErr != nil {
+		t.Fatalf("check owned branch after pre-registration failure: %v", existsErr)
+	}
+	if exists {
+		t.Fatal("owned branch remains after pre-registration failure")
+	}
+	if got, readErr := os.ReadFile(marker); readErr != nil || string(got) != "keep" {
+		t.Fatalf("preexisting target was changed: contents=%q err=%v", got, readErr)
+	}
+}
+
+func TestGitAddWorktree_RegisteredCleanupFailureRestoresOwnedBranch(t *testing.T) {
+	branchState := filepath.Join(t.TempDir(), "branch-created")
+	registrationState := filepath.Join(t.TempDir(), "worktree-registered")
+	scriptDir := writeFakeGitScript(t, failedWorktreeAddGitScript)
+	t.Setenv("PATH", scriptDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("KD_BRANCH_STATE", branchState)
+	t.Setenv("KD_REGISTRATION_STATE", registrationState)
+	t.Setenv("KD_WORKTREE_REMOVE_FAIL", "1")
+
+	mgr, err := NewManager(newTestConfig(t), newMockStore(), newTestLogger())
+	if err != nil {
+		t.Fatalf("NewManager failed: %v", err)
+	}
+	worktreePath := filepath.Join(t.TempDir(), "registered-worktree")
+	_, err = mgr.gitAddWorktree(context.Background(), t.TempDir(), "feature/new", worktreePath, "main")
+	if err == nil {
+		t.Fatal("gitAddWorktree() error = nil, want checkout failure")
+	}
+	if _, statErr := os.Stat(registrationState); statErr != nil {
+		t.Fatalf("registered worktree unexpectedly removed: %v", statErr)
+	}
+	if _, statErr := os.Stat(branchState); statErr != nil {
+		t.Fatalf("registered worktree points at a deleted owned branch: %v", statErr)
+	}
+}
+
 const failedWorktreeAddGitScript = `
 while [ "${1:-}" = "-c" ]; do
   shift 2
@@ -229,6 +286,10 @@ case "${1:-} ${2:-}" in
     exit 128
     ;;
   "worktree remove")
+		if [ -n "${KD_WORKTREE_REMOVE_FAIL:-}" ]; then
+			echo "forced worktree remove failure" >&2
+			exit 1
+		fi
     rm -rf "${4:?}"
     rm -f "${KD_REGISTRATION_STATE:?}"
     exit 0

--- a/apps/backend/internal/worktree/manager_failed_add_rollback_test.go
+++ b/apps/backend/internal/worktree/manager_failed_add_rollback_test.go
@@ -1,0 +1,241 @@
+package worktree
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const fakeBranchOID = "1111111111111111111111111111111111111111"
+
+func TestGitAddWorktree_FailureRollsBackNewBranchAndPartialWorktree(t *testing.T) {
+	branchState := filepath.Join(t.TempDir(), "branch-created")
+	registrationState := filepath.Join(t.TempDir(), "worktree-registered")
+	scriptDir := writeFakeGitScript(t, failedWorktreeAddGitScript)
+	t.Setenv("PATH", scriptDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("KD_BRANCH_STATE", branchState)
+	t.Setenv("KD_REGISTRATION_STATE", registrationState)
+
+	mgr, err := NewManager(newTestConfig(t), newMockStore(), newTestLogger())
+	if err != nil {
+		t.Fatalf("NewManager failed: %v", err)
+	}
+	repoPath := t.TempDir()
+	worktreePath := filepath.Join(t.TempDir(), "partial-worktree")
+
+	_, err = mgr.gitAddWorktree(context.Background(), repoPath, "feature/new", worktreePath, "main")
+	if err == nil {
+		t.Fatal("gitAddWorktree() error = nil, want checkout failure")
+	}
+	if _, statErr := os.Stat(branchState); !os.IsNotExist(statErr) {
+		t.Fatalf("new branch state remains after rollback: %v", statErr)
+	}
+	if _, statErr := os.Stat(registrationState); !os.IsNotExist(statErr) {
+		t.Fatalf("worktree registration remains after rollback: %v", statErr)
+	}
+	if _, statErr := os.Stat(worktreePath); !os.IsNotExist(statErr) {
+		t.Fatalf("partial worktree remains after rollback: %v", statErr)
+	}
+}
+
+func TestGitAddWorktree_FailureUsesAtomicBranchOwnership(t *testing.T) {
+	branchState := filepath.Join(t.TempDir(), "branch-created")
+	registrationState := filepath.Join(t.TempDir(), "worktree-registered")
+	gitLog := filepath.Join(t.TempDir(), "git.log")
+	scriptDir := writeFakeGitScript(t, failedWorktreeAddGitScript)
+	t.Setenv("PATH", scriptDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("KD_BRANCH_STATE", branchState)
+	t.Setenv("KD_REGISTRATION_STATE", registrationState)
+	t.Setenv("KD_GIT_LOG", gitLog)
+
+	mgr, err := NewManager(newTestConfig(t), newMockStore(), newTestLogger())
+	if err != nil {
+		t.Fatalf("NewManager failed: %v", err)
+	}
+	_, err = mgr.gitAddWorktree(
+		context.Background(), t.TempDir(), "feature/new", filepath.Join(t.TempDir(), "worktree"), "main",
+	)
+	if err == nil {
+		t.Fatal("gitAddWorktree() error = nil, want checkout failure")
+	}
+
+	logBytes, readErr := os.ReadFile(gitLog)
+	if readErr != nil {
+		t.Fatalf("read fake git log: %v", readErr)
+	}
+	logOutput := string(logBytes)
+	zeroOID := strings.Repeat("0", len(fakeBranchOID))
+	for _, want := range []string{
+		"update-ref refs/heads/feature/new " + fakeBranchOID + " " + zeroOID,
+		"update-ref -d refs/heads/feature/new " + fakeBranchOID,
+	} {
+		if !strings.Contains(logOutput, want) {
+			t.Fatalf("git log %q does not contain atomic ref operation %q", logOutput, want)
+		}
+	}
+}
+
+func TestRollbackFailedNewBranchAdd_PreservesCompetingCreatorState(t *testing.T) {
+	repoPath := initGitRepoForWorktreeTest(t)
+	mgr, err := NewManager(newTestConfig(t), newMockStore(), newTestLogger())
+	if err != nil {
+		t.Fatalf("NewManager failed: %v", err)
+	}
+	branchName := "feature/concurrent-owner"
+	ownership, err := mgr.createNewBranchRef(context.Background(), repoPath, branchName, "main")
+	if err != nil {
+		t.Fatalf("createNewBranchRef() error: %v", err)
+	}
+	intendedPath := filepath.Join(t.TempDir(), "intended-worktree")
+	competitorPath := filepath.Join(t.TempDir(), "competing-worktree")
+	runGit(t, repoPath, "worktree", "add", competitorPath, branchName)
+	marker := filepath.Join(competitorPath, "competitor.txt")
+	if err := os.WriteFile(marker, []byte("competitor-owned"), 0600); err != nil {
+		t.Fatalf("write competitor marker: %v", err)
+	}
+
+	mgr.rollbackFailedNewBranchAdd(context.Background(), repoPath, branchName, intendedPath, ownership)
+
+	if got, readErr := os.ReadFile(marker); readErr != nil || string(got) != "competitor-owned" {
+		t.Fatalf("competing creator's worktree was changed: contents=%q err=%v", got, readErr)
+	}
+	branchOID := strings.TrimSpace(runGit(t, repoPath, "show-ref", "--hash", ownership.branchRef))
+	if branchOID != ownership.branchOID {
+		t.Fatalf("competing creator's branch OID = %q, want %q", branchOID, ownership.branchOID)
+	}
+}
+
+func TestRollbackFailedNewBranchAdd_PreservesAdvancedOwnedBranch(t *testing.T) {
+	repoPath := initGitRepoForWorktreeTest(t)
+	mgr, err := NewManager(newTestConfig(t), newMockStore(), newTestLogger())
+	if err != nil {
+		t.Fatalf("NewManager failed: %v", err)
+	}
+	branchName := "feature/advanced-owner"
+	ownership, err := mgr.createNewBranchRef(context.Background(), repoPath, branchName, "main")
+	if err != nil {
+		t.Fatalf("createNewBranchRef() error: %v", err)
+	}
+	treeOID := strings.TrimSpace(runGit(t, repoPath, "rev-parse", "main^{tree}"))
+	advancedOID := strings.TrimSpace(runGit(
+		t, repoPath, "commit-tree", treeOID, "-p", ownership.branchOID, "-m", "competitor advance",
+	))
+	runGit(t, repoPath, "update-ref", ownership.branchRef, advancedOID, ownership.branchOID)
+
+	mgr.rollbackFailedNewBranchAdd(
+		context.Background(), repoPath, branchName, filepath.Join(t.TempDir(), "absent-worktree"), ownership,
+	)
+
+	gotOID := strings.TrimSpace(runGit(t, repoPath, "show-ref", "--hash", ownership.branchRef))
+	if gotOID != advancedOID {
+		t.Fatalf("advanced branch OID = %q, want preserved %q", gotOID, advancedOID)
+	}
+}
+
+func TestGitAddWorktree_FailurePreservesPreexistingBranchAndDirectory(t *testing.T) {
+	branchState := filepath.Join(t.TempDir(), "branch-created")
+	registrationState := filepath.Join(t.TempDir(), "worktree-registered")
+	if err := os.WriteFile(branchState, []byte("preexisting"), 0600); err != nil {
+		t.Fatalf("create branch state: %v", err)
+	}
+	scriptDir := writeFakeGitScript(t, failedWorktreeAddGitScript)
+	t.Setenv("PATH", scriptDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("KD_BRANCH_STATE", branchState)
+	t.Setenv("KD_REGISTRATION_STATE", registrationState)
+
+	mgr, err := NewManager(newTestConfig(t), newMockStore(), newTestLogger())
+	if err != nil {
+		t.Fatalf("NewManager failed: %v", err)
+	}
+	repoPath := t.TempDir()
+	worktreePath := filepath.Join(t.TempDir(), "existing-directory")
+	if err := os.Mkdir(worktreePath, 0755); err != nil {
+		t.Fatalf("create existing worktree directory: %v", err)
+	}
+	marker := filepath.Join(worktreePath, "keep.txt")
+	if err := os.WriteFile(marker, []byte("keep"), 0600); err != nil {
+		t.Fatalf("create marker: %v", err)
+	}
+
+	_, err = mgr.gitAddWorktree(context.Background(), repoPath, "feature/existing", worktreePath, "main")
+	if err == nil {
+		t.Fatal("gitAddWorktree() error = nil, want existing branch failure")
+	}
+	if got, readErr := os.ReadFile(branchState); readErr != nil || string(got) != "preexisting" {
+		t.Fatalf("preexisting branch was changed: contents=%q err=%v", got, readErr)
+	}
+	if got, readErr := os.ReadFile(marker); readErr != nil || string(got) != "keep" {
+		t.Fatalf("preexisting directory was changed: contents=%q err=%v", got, readErr)
+	}
+}
+
+const failedWorktreeAddGitScript = `
+while [ "${1:-}" = "-c" ]; do
+  shift 2
+done
+
+if [ -n "${KD_GIT_LOG:-}" ]; then
+  printf "%s\n" "$*" >> "${KD_GIT_LOG}"
+fi
+
+case "${1:-} ${2:-}" in
+	"rev-parse --verify")
+		echo "1111111111111111111111111111111111111111"
+		exit 0
+		;;
+	"update-ref refs/heads/feature/new"|"update-ref refs/heads/feature/existing")
+		if [ -f "${KD_BRANCH_STATE:?}" ]; then
+			echo "fatal: cannot lock ref '${2:-}': reference already exists" >&2
+			exit 128
+		fi
+		printf "%s\n%s" "${3:?}" "${2:?}" > "${KD_BRANCH_STATE}"
+		exit 0
+		;;
+	"update-ref -d")
+		head_oid="$(sed -n '1p' "${KD_BRANCH_STATE:?}")"
+		branch_ref="$(sed -n '2p' "${KD_BRANCH_STATE:?}")"
+		if [ "${3:-}" = "${branch_ref}" ] && [ "${4:-}" = "${head_oid}" ]; then
+			rm -f "${KD_BRANCH_STATE}"
+			exit 0
+		fi
+		exit 1
+		;;
+  "show-ref --verify")
+    if [ -f "${KD_BRANCH_STATE:?}" ]; then exit 0; fi
+    exit 1
+    ;;
+  "worktree list")
+    if [ -f "${KD_REGISTRATION_STATE:?}" ]; then
+			head_oid="$(sed -n '1p' "${KD_BRANCH_STATE:?}")"
+			branch_ref="$(sed -n '2p' "${KD_BRANCH_STATE:?}")"
+			printf "worktree %s\\0HEAD %s\\0branch %s\\0\\0" \
+				"$(cat "${KD_REGISTRATION_STATE}")" "${head_oid}" "${branch_ref}"
+    fi
+    exit 0
+    ;;
+  "worktree add")
+		if [ "${3:-}" = "--no-checkout" ]; then
+			worktree_path="${4:?}"
+		else
+			worktree_path="${3:?}"
+		fi
+		printf "%s" "${worktree_path}" > "${KD_REGISTRATION_STATE}"
+		mkdir -p "${worktree_path}"
+		printf "partial" > "${worktree_path}/partial.txt"
+    echo "error: unable to create file generated/very/long/project.csproj: Filename too long" >&2
+    echo "fatal: Could not reset index file to revision 'HEAD'." >&2
+    exit 128
+    ;;
+  "worktree remove")
+    rm -rf "${4:?}"
+    rm -f "${KD_REGISTRATION_STATE:?}"
+    exit 0
+    ;;
+  *)
+    echo "unexpected fake git command: $*" >&2
+    exit 2
+    ;;
+esac
+`

--- a/apps/backend/internal/worktree/manager_git.go
+++ b/apps/backend/internal/worktree/manager_git.go
@@ -141,7 +141,7 @@ func (m *Manager) currentBranch(ctx context.Context, repoPath string) string {
 }
 
 func (m *Manager) newNonInteractiveGitCmd(ctx context.Context, repoPath string, args ...string) *exec.Cmd {
-	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd := newGitCommand(ctx, args...)
 	cmd.Dir = repoPath
 	cmd.Env = append(os.Environ(),
 		"GIT_TERMINAL_PROMPT=0",

--- a/apps/backend/internal/worktree/manager_lifecycle.go
+++ b/apps/backend/internal/worktree/manager_lifecycle.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -509,6 +508,15 @@ func (m *Manager) retryFetchAsRemoteTrackingRef(ctx context.Context, repoPath, b
 // it automatically prunes and retries. If the repository uses git-crypt, it creates
 // the worktree without checkout, then unlocks git-crypt and performs the checkout.
 func (m *Manager) gitAddWorktreeExisting(ctx context.Context, repoPath, branchName, worktreePath string) (string, error) {
+	release, err := acquireWorktreeTargetPath(ctx, worktreePath)
+	if err != nil {
+		return "", fmt.Errorf("acquire worktree target path: %w", err)
+	}
+	defer release()
+	return m.gitAddWorktreeExistingLocked(ctx, repoPath, branchName, worktreePath)
+}
+
+func (m *Manager) gitAddWorktreeExistingLocked(ctx context.Context, repoPath, branchName, worktreePath string) (string, error) {
 	worktreeID := uuid.New().String()
 	usesGitCrypt := m.usesGitCrypt(repoPath)
 
@@ -519,7 +527,7 @@ func (m *Manager) gitAddWorktreeExisting(ctx context.Context, repoPath, branchNa
 	}
 	args = append(args, worktreePath, branchName)
 
-	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd := newGitCommand(ctx, args...)
 	cmd.Dir = repoPath
 	output, err := runGitCmdCombinedOutput(ctx, cmd)
 	if err == nil {
@@ -569,7 +577,7 @@ func (m *Manager) retryWorktreeExisting(ctx context.Context, repoPath, branchNam
 	}
 	args = append(args, worktreePath, branchName)
 
-	retryCmd := exec.CommandContext(ctx, "git", args...)
+	retryCmd := newGitCommand(ctx, args...)
 	retryCmd.Dir = repoPath
 	retryOutput, retryErr := runGitCmdCombinedOutput(ctx, retryCmd)
 	if retryErr != nil {
@@ -600,7 +608,7 @@ func (m *Manager) retryWorktreeExisting(ctx context.Context, repoPath, branchNam
 func (m *Manager) gitAddWorktreeExistingWithGitCrypt(ctx context.Context, repoPath, branchName, worktreePath string) (string, error) {
 	worktreeID := uuid.New().String()
 
-	cmd := exec.CommandContext(ctx, "git", "worktree", "add", "--no-checkout", worktreePath, branchName)
+	cmd := newGitCommand(ctx, "worktree", "add", "--no-checkout", worktreePath, branchName)
 	cmd.Dir = repoPath
 	output, err := runGitCmdCombinedOutput(ctx, cmd)
 	if err != nil {
@@ -644,7 +652,7 @@ func (m *Manager) tryRecoverCheckedOutBranch(ctx context.Context, repoPath, bran
 		zap.String("branch", branchName),
 		zap.String("stale_path", checkedOutPath))
 
-	pruneCmd := exec.CommandContext(ctx, "git", "worktree", "prune")
+	pruneCmd := newGitCommand(ctx, "worktree", "prune")
 	pruneCmd.Dir = repoPath
 	if output, err := runGitCmdCombinedOutput(ctx, pruneCmd); err != nil {
 		m.logger.Error("git worktree prune failed",
@@ -702,46 +710,130 @@ func (m *Manager) buildWorktreeNames(req CreateRequest) (dirName, branchName str
 	return dirName, branchName
 }
 
+type newBranchAddSnapshot struct {
+	branchRef string
+	branchOID string
+}
+
+func (m *Manager) createNewBranchRef(
+	ctx context.Context, repoPath, branchName, baseRef string,
+) (newBranchAddSnapshot, error) {
+	resolveCmd := newGitCommand(ctx, "rev-parse", "--verify", baseRef+"^{commit}")
+	resolveCmd.Dir = repoPath
+	output, err := runGitCmdOutput(ctx, resolveCmd)
+	if err != nil {
+		return newBranchAddSnapshot{}, ClassifyGitError(string(output), err)
+	}
+	oid := strings.TrimSpace(string(output))
+	if oid == "" {
+		return newBranchAddSnapshot{}, fmt.Errorf("%w: base ref %q resolved to an empty object ID", ErrGitCommandFailed, baseRef)
+	}
+	ownership := newBranchAddSnapshot{branchRef: "refs/heads/" + branchName}
+	zeroOID := strings.Repeat("0", len(oid))
+	createCmd := newGitCommand(ctx, "update-ref", ownership.branchRef, oid, zeroOID)
+	createCmd.Dir = repoPath
+	createOutput, createErr := runGitCmdCombinedOutput(ctx, createCmd)
+	if createErr != nil {
+		if strings.Contains(strings.ToLower(string(createOutput)), "reference already exists") {
+			return newBranchAddSnapshot{}, fmt.Errorf("%w: %s", ErrBranchExists, strings.TrimSpace(string(createOutput)))
+		}
+		return newBranchAddSnapshot{}, ClassifyGitError(string(createOutput), createErr)
+	}
+	ownership.branchOID = oid
+	return ownership, nil
+}
+
+func deleteBranchRefIfOwned(ctx context.Context, repoPath string, snapshot newBranchAddSnapshot) ([]byte, error) {
+	cmd := newGitCommand(ctx, "update-ref", "-d", snapshot.branchRef, snapshot.branchOID)
+	cmd.Dir = repoPath
+	return runGitCmdCombinedOutput(ctx, cmd)
+}
+
+func (m *Manager) rollbackFailedNewBranchAdd(
+	ctx context.Context,
+	repoPath, branchName, worktreePath string,
+	snapshot newBranchAddSnapshot,
+) {
+	if snapshot.branchRef == "" || snapshot.branchOID == "" {
+		return
+	}
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), m.inspectTimeout)
+	defer cancel()
+	registrationOwned, inspectErr := inspectWorktreeRegistrationOwnership(
+		cleanupCtx, repoPath, worktreePath, snapshot.branchRef, snapshot.branchOID,
+	)
+	if inspectErr != nil {
+		m.logger.Warn("failed to verify partial worktree ownership; leaving path untouched",
+			zap.String("path", worktreePath), zap.Error(inspectErr))
+		return
+	}
+	if !registrationOwned {
+		return
+	}
+	// Delete the exact ref while the owned worktree registration still blocks
+	// ordinary competing checkouts. The expected old OID preserves an advanced
+	// or replaced ref; failure leaves both the ref and worktree untouched.
+	if output, err := deleteBranchRefIfOwned(cleanupCtx, repoPath, snapshot); err != nil {
+		m.logger.Warn("failed to roll back worktree branch",
+			zap.String("branch", branchName),
+			zap.String("output", string(output)),
+			zap.Error(err))
+		return
+	}
+	if err := m.removeWorktreeDir(cleanupCtx, worktreePath, repoPath); err != nil {
+		m.logger.Warn("failed to roll back partial worktree",
+			zap.String("path", worktreePath), zap.Error(err))
+	}
+}
+
 // gitAddWorktree runs "git worktree add" and returns the new worktree UUID.
 // If the repository uses git-crypt, it creates the worktree without checkout,
 // then unlocks git-crypt and performs the checkout separately.
 func (m *Manager) gitAddWorktree(ctx context.Context, repoPath, branchName, worktreePath, baseRef string) (string, error) {
+	release, err := acquireWorktreeTargetPath(ctx, worktreePath)
+	if err != nil {
+		return "", fmt.Errorf("acquire worktree target path: %w", err)
+	}
+	defer release()
+	return m.gitAddWorktreeLocked(ctx, repoPath, branchName, worktreePath, baseRef)
+}
+
+func (m *Manager) gitAddWorktreeLocked(ctx context.Context, repoPath, branchName, worktreePath, baseRef string) (string, error) {
 	worktreeID := uuid.New().String()
 	usesGitCrypt := m.usesGitCrypt(repoPath)
+	addSnapshot, err := m.createNewBranchRef(ctx, repoPath, branchName, baseRef)
+	if err != nil {
+		return "", err
+	}
 
-	// Build worktree add command.
-	// Use -c branch.autoSetupMerge=false to prevent git from automatically
-	// setting upstream tracking when the base ref is a remote-tracking branch
-	// (e.g. origin/feature/foo). New task branches should start with no
-	// upstream until the user explicitly pushes.
-	args := []string{"-c", "branch.autoSetupMerge=false", "worktree", "add", "-b", branchName}
+	args := []string{"worktree", "add"}
 	if usesGitCrypt {
 		args = append(args, "--no-checkout")
 	}
-	args = append(args, worktreePath, baseRef)
+	args = append(args, worktreePath, branchName)
 
-	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd := newGitCommand(ctx, args...)
 	cmd.Dir = repoPath
 	output, err := runGitCmdCombinedOutput(ctx, cmd)
 	if err != nil {
 		outStr := string(output)
+		m.rollbackFailedNewBranchAdd(ctx, repoPath, branchName, worktreePath, addSnapshot)
 		// Check if this is a git-crypt error we didn't anticipate
 		if isGitCryptSmudgeError(outStr) {
 			m.logger.Warn("git-crypt smudge error detected, retrying with --no-checkout",
 				zap.String("output", outStr))
-			return m.gitAddWorktreeWithGitCrypt(ctx, repoPath, branchName, worktreePath, baseRef)
+			return m.gitAddWorktreeWithGitCryptLocked(ctx, repoPath, branchName, worktreePath, baseRef)
 		}
 		m.logger.Error("git worktree add failed",
 			zap.String("output", outStr),
 			zap.Error(err))
-		return "", fmt.Errorf("%w: %s", ErrGitCommandFailed, outStr)
+		return "", ClassifyGitError(outStr, err)
 	}
 
 	// If we used --no-checkout, we need to unlock git-crypt and checkout
 	if usesGitCrypt {
 		if err := m.unlockGitCryptAndCheckout(ctx, worktreePath); err != nil {
-			// Cleanup the worktree on failure
-			_ = m.removeWorktreeDir(ctx, worktreePath, repoPath)
+			m.rollbackFailedNewBranchAdd(ctx, repoPath, branchName, worktreePath, addSnapshot)
 			return "", err
 		}
 	} else {
@@ -754,31 +846,31 @@ func (m *Manager) gitAddWorktree(ctx context.Context, repoPath, branchName, work
 // gitAddWorktreeWithGitCrypt creates a worktree using --no-checkout and then
 // unlocks git-crypt. This is used as a fallback when we detect a git-crypt
 // smudge filter error.
-func (m *Manager) gitAddWorktreeWithGitCrypt(ctx context.Context, repoPath, branchName, worktreePath, baseRef string) (string, error) {
+func (m *Manager) gitAddWorktreeWithGitCryptLocked(ctx context.Context, repoPath, branchName, worktreePath, baseRef string) (string, error) {
 	worktreeID := uuid.New().String()
+	addSnapshot, err := m.createNewBranchRef(ctx, repoPath, branchName, baseRef)
+	if err != nil {
+		return "", err
+	}
 
-	// Create worktree without checkout.
-	// Use -c branch.autoSetupMerge=false to prevent git from automatically
-	// setting upstream tracking when the base ref is a remote-tracking branch.
-	cmd := exec.CommandContext(ctx, "git",
-		"-c", "branch.autoSetupMerge=false",
+	cmd := newGitCommand(ctx,
 		"worktree", "add",
-		"-b", branchName,
 		"--no-checkout",
 		worktreePath,
-		baseRef)
+		branchName)
 	cmd.Dir = repoPath
 	output, err := runGitCmdCombinedOutput(ctx, cmd)
 	if err != nil {
+		m.rollbackFailedNewBranchAdd(ctx, repoPath, branchName, worktreePath, addSnapshot)
 		m.logger.Error("git worktree add (--no-checkout) failed",
 			zap.String("output", string(output)),
 			zap.Error(err))
-		return "", fmt.Errorf("%w: %s", ErrGitCommandFailed, string(output))
+		return "", ClassifyGitError(string(output), err)
 	}
 
 	// Unlock git-crypt and checkout
 	if err := m.unlockGitCryptAndCheckout(ctx, worktreePath); err != nil {
-		_ = m.removeWorktreeDir(ctx, worktreePath, repoPath)
+		m.rollbackFailedNewBranchAdd(ctx, repoPath, branchName, worktreePath, addSnapshot)
 		return "", err
 	}
 
@@ -790,6 +882,15 @@ func (m *Manager) gitAddWorktreeWithGitCrypt(ctx context.Context, repoPath, bran
 // error is detected. Returns the effective usesGitCrypt flag (forced to true
 // if the retry path was taken so the caller knows to unlock+checkout).
 func (m *Manager) gitAddWorktreeForRecreate(ctx context.Context, repoPath, branch, worktreePath string) (bool, error) {
+	release, err := acquireWorktreeTargetPath(ctx, worktreePath)
+	if err != nil {
+		return false, fmt.Errorf("acquire worktree target path: %w", err)
+	}
+	defer release()
+	return m.gitAddWorktreeForRecreateLocked(ctx, repoPath, branch, worktreePath)
+}
+
+func (m *Manager) gitAddWorktreeForRecreateLocked(ctx context.Context, repoPath, branch, worktreePath string) (bool, error) {
 	usesGitCrypt := m.usesGitCrypt(repoPath)
 	args := []string{"worktree", "add"}
 	if usesGitCrypt {
@@ -797,7 +898,7 @@ func (m *Manager) gitAddWorktreeForRecreate(ctx context.Context, repoPath, branc
 	}
 	args = append(args, worktreePath, branch)
 
-	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd := newGitCommand(ctx, args...)
 	cmd.Dir = repoPath
 	output, err := runGitCmdCombinedOutput(ctx, cmd)
 	if err == nil {
@@ -807,20 +908,20 @@ func (m *Manager) gitAddWorktreeForRecreate(ctx context.Context, repoPath, branc
 	if isGitCryptSmudgeError(outStr) && !usesGitCrypt {
 		m.logger.Warn("git-crypt smudge error during recreate, retrying with --no-checkout",
 			zap.String("output", outStr))
-		retryCmd := exec.CommandContext(ctx, "git", "worktree", "add", "--no-checkout", worktreePath, branch)
+		retryCmd := newGitCommand(ctx, "worktree", "add", "--no-checkout", worktreePath, branch)
 		retryCmd.Dir = repoPath
 		if retryOutput, retryErr := runGitCmdCombinedOutput(ctx, retryCmd); retryErr != nil {
 			m.logger.Error("failed to recreate worktree (--no-checkout)",
 				zap.String("output", string(retryOutput)),
 				zap.Error(retryErr))
-			return false, fmt.Errorf("%w: %s", ErrGitCommandFailed, string(retryOutput))
+			return false, ClassifyGitError(string(retryOutput), retryErr)
 		}
 		return true, nil // Force unlock/checkout
 	}
 	m.logger.Error("failed to recreate worktree",
 		zap.String("output", outStr),
 		zap.Error(err))
-	return false, fmt.Errorf("%w: %s", ErrGitCommandFailed, outStr)
+	return false, ClassifyGitError(outStr, err)
 }
 
 // copyConfiguredFiles copies user-specified files from the source repo into
@@ -873,7 +974,7 @@ func (m *Manager) recreate(ctx context.Context, existing *Worktree, req CreateRe
 	}
 
 	// Remove from git worktree list
-	cmd := exec.CommandContext(ctx, "git", "worktree", "prune")
+	cmd := newGitCommand(ctx, "worktree", "prune")
 	cmd.Dir = req.RepositoryPath
 	if err := runGitCmd(ctx, cmd); err != nil {
 		m.logger.Debug("git worktree prune failed", zap.Error(err))

--- a/apps/backend/internal/worktree/manager_lifecycle.go
+++ b/apps/backend/internal/worktree/manager_lifecycle.go
@@ -749,6 +749,12 @@ func deleteBranchRefIfOwned(ctx context.Context, repoPath string, snapshot newBr
 	return runGitCmdCombinedOutput(ctx, cmd)
 }
 
+func restoreBranchRefIfDeleted(ctx context.Context, repoPath string, snapshot newBranchAddSnapshot) ([]byte, error) {
+	cmd := newGitCommand(ctx, "update-ref", snapshot.branchRef, snapshot.branchOID, strings.Repeat("0", len(snapshot.branchOID)))
+	cmd.Dir = repoPath
+	return runGitCmdCombinedOutput(ctx, cmd)
+}
+
 func (m *Manager) rollbackFailedNewBranchAdd(
 	ctx context.Context,
 	repoPath, branchName, worktreePath string,
@@ -759,7 +765,7 @@ func (m *Manager) rollbackFailedNewBranchAdd(
 	}
 	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), m.inspectTimeout)
 	defer cancel()
-	registrationOwned, inspectErr := inspectWorktreeRegistrationOwnership(
+	registrationOwnership, inspectErr := inspectWorktreeRegistrationOwnership(
 		cleanupCtx, repoPath, worktreePath, snapshot.branchRef, snapshot.branchOID,
 	)
 	if inspectErr != nil {
@@ -767,7 +773,24 @@ func (m *Manager) rollbackFailedNewBranchAdd(
 			zap.String("path", worktreePath), zap.Error(inspectErr))
 		return
 	}
-	if !registrationOwned {
+	switch registrationOwnership {
+	case worktreeRegistrationAbsent:
+		// git may fail before it registers a worktree (for example when the
+		// target is non-empty). The branch was created with a zero-OID CAS, so
+		// this matching delete only removes our still-unmodified ref. Never
+		// touch the target path: it was not registered as ours.
+		if output, err := deleteBranchRefIfOwned(cleanupCtx, repoPath, snapshot); err != nil {
+			m.logger.Warn("failed to roll back unregistered worktree branch",
+				zap.String("branch", branchName),
+				zap.String("output", string(output)),
+				zap.Error(err))
+		}
+		return
+	case worktreeRegistrationCompeting:
+		return
+	case worktreeRegistrationOwned:
+		// Continue below.
+	default:
 		return
 	}
 	// Delete the exact ref while the owned worktree registration still blocks
@@ -780,9 +803,36 @@ func (m *Manager) rollbackFailedNewBranchAdd(
 			zap.Error(err))
 		return
 	}
-	if err := m.removeWorktreeDir(cleanupCtx, worktreePath, repoPath); err != nil {
+	removeErr := m.removeWorktreeDir(cleanupCtx, worktreePath, repoPath)
+	registrationOwnership, inspectErr = inspectWorktreeRegistrationOwnership(
+		cleanupCtx, repoPath, worktreePath, snapshot.branchRef, snapshot.branchOID,
+	)
+	// Git's removal command can report an error even when its filesystem/prune
+	// fallback completed the registration cleanup. The post-cleanup ownership
+	// inspection is authoritative for whether deleting the ref remains safe.
+	if inspectErr == nil && registrationOwnership == worktreeRegistrationAbsent {
+		return
+	}
+	if removeErr != nil {
 		m.logger.Warn("failed to roll back partial worktree",
-			zap.String("path", worktreePath), zap.Error(err))
+			zap.String("path", worktreePath), zap.Error(removeErr))
+	}
+	if inspectErr != nil {
+		m.logger.Warn("failed to verify worktree registration after partial cleanup",
+			zap.String("path", worktreePath), zap.Error(inspectErr))
+	} else {
+		m.logger.Warn("partial worktree registration remains after cleanup",
+			zap.String("path", worktreePath), zap.Uint8("registration_ownership", uint8(registrationOwnership)))
+	}
+	// A branch registration prevents ordinary worktree creation from adopting
+	// this ref while cleanup runs. If cleanup did not prove that registration
+	// is gone, restore the exact OID with a zero-OID CAS before returning so a
+	// registered worktree can never be left pointing at a missing branch.
+	if output, err := restoreBranchRefIfDeleted(cleanupCtx, repoPath, snapshot); err != nil {
+		m.logger.Warn("failed to restore branch after partial worktree cleanup",
+			zap.String("branch", branchName),
+			zap.String("output", string(output)),
+			zap.Error(err))
 	}
 }
 

--- a/apps/backend/internal/worktree/manager_test.go
+++ b/apps/backend/internal/worktree/manager_test.go
@@ -725,7 +725,9 @@ func writeFakeGitScript(t *testing.T, scriptBody string) string {
 
 	scriptDir := t.TempDir()
 	scriptPath := filepath.Join(scriptDir, "git")
-	content := "#!/bin/sh\nset -eu\n\n" + scriptBody + "\n"
+	content := "#!/bin/sh\nset -eu\n\n" +
+		"while [ \"${1:-}\" = \"-c\" ] && [ \"${2:-}\" = \"core.longpaths=true\" ]; do shift 2; done\n\n" +
+		scriptBody + "\n"
 	if err := os.WriteFile(scriptPath, []byte(content), 0755); err != nil {
 		t.Fatalf("failed to write fake git script: %v", err)
 	}

--- a/apps/backend/internal/worktree/submodule.go
+++ b/apps/backend/internal/worktree/submodule.go
@@ -69,7 +69,7 @@ func (m *Manager) newSubmoduleUpdateCmd(ctx context.Context, dir string) *exec.C
 // It reads from the git object store (git ls-tree), so it works in --no-checkout worktrees.
 // Returns nil (not an error) if there are no submodules.
 func getSubmodulePaths(ctx context.Context, dir string) ([]string, error) {
-	cmd := exec.CommandContext(ctx, "git", "ls-tree", "-r", "HEAD")
+	cmd := newGitCommand(ctx, "ls-tree", "-r", "HEAD")
 	cmd.Dir = dir
 	output, err := runGitCmdOutput(ctx, cmd)
 	if err != nil {

--- a/apps/backend/internal/worktree/target_path_lock.go
+++ b/apps/backend/internal/worktree/target_path_lock.go
@@ -1,0 +1,85 @@
+package worktree
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+)
+
+const windowsGOOS = "windows"
+
+type targetPathLockEntry struct {
+	token chan struct{}
+	refs  int
+}
+
+type targetPathLockRegistry struct {
+	mu      sync.Mutex
+	entries map[string]*targetPathLockEntry
+}
+
+var worktreeTargetPathLocks = targetPathLockRegistry{
+	entries: make(map[string]*targetPathLockEntry),
+}
+
+func acquireWorktreeTargetPath(ctx context.Context, path string) (func(), error) {
+	key, err := normalizedWorktreeTargetPath(path)
+	if err != nil {
+		return nil, err
+	}
+	entry := worktreeTargetPathLocks.reference(key)
+	select {
+	case <-entry.token:
+		var once sync.Once
+		return func() {
+			once.Do(func() {
+				entry.token <- struct{}{}
+				worktreeTargetPathLocks.unreference(key, entry)
+			})
+		}, nil
+	case <-ctx.Done():
+		worktreeTargetPathLocks.unreference(key, entry)
+		return nil, ctx.Err()
+	}
+}
+
+func normalizedWorktreeTargetPath(path string) (string, error) {
+	return normalizedWorktreeTargetPathForOS(path, runtime.GOOS)
+}
+
+func normalizedWorktreeTargetPathForOS(path, goos string) (string, error) {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("resolve worktree target path: %w", err)
+	}
+	key := filepath.Clean(absPath)
+	if goos == windowsGOOS {
+		key = strings.ToLower(key)
+	}
+	return key, nil
+}
+
+func (r *targetPathLockRegistry) reference(key string) *targetPathLockEntry {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	entry := r.entries[key]
+	if entry == nil {
+		entry = &targetPathLockEntry{token: make(chan struct{}, 1)}
+		entry.token <- struct{}{}
+		r.entries[key] = entry
+	}
+	entry.refs++
+	return entry
+}
+
+func (r *targetPathLockRegistry) unreference(key string, entry *targetPathLockEntry) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	entry.refs--
+	if entry.refs == 0 && r.entries[key] == entry {
+		delete(r.entries, key)
+	}
+}

--- a/apps/backend/internal/worktree/target_path_lock_test.go
+++ b/apps/backend/internal/worktree/target_path_lock_test.go
@@ -1,0 +1,72 @@
+package worktree
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+)
+
+func TestAcquireWorktreeTargetPath_SerializesNormalizedAliasesAndHonorsCancellation(t *testing.T) {
+	base := t.TempDir()
+	target := filepath.Join(base, "shared")
+	alias := filepath.Join(base, "nested", "..", "shared")
+	firstKey, err := normalizedWorktreeTargetPath(target)
+	if err != nil {
+		t.Fatalf("normalize target: %v", err)
+	}
+	aliasKey, err := normalizedWorktreeTargetPath(alias)
+	if err != nil {
+		t.Fatalf("normalize alias: %v", err)
+	}
+	if firstKey != aliasKey {
+		t.Fatalf("normalized keys differ: %q != %q", firstKey, aliasKey)
+	}
+
+	releaseFirst, err := acquireWorktreeTargetPath(context.Background(), target)
+	if err != nil {
+		t.Fatalf("acquire first target lock: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	started := make(chan struct{})
+	result := make(chan error)
+	go func() {
+		close(started)
+		release, acquireErr := acquireWorktreeTargetPath(ctx, alias)
+		if acquireErr == nil {
+			release()
+		}
+		result <- acquireErr
+	}()
+
+	<-started
+	cancel()
+	if acquireErr := <-result; !errors.Is(acquireErr, context.Canceled) {
+		t.Fatalf("competing acquire error = %v, want context.Canceled", acquireErr)
+	}
+	releaseFirst()
+
+	releaseAfterCancel, err := acquireWorktreeTargetPath(context.Background(), alias)
+	if err != nil {
+		t.Fatalf("target lock leaked after cancellation: %v", err)
+	}
+	releaseAfterCancel()
+}
+
+func TestNormalizedWorktreeTargetPathForOS_WindowsCaseAliases(t *testing.T) {
+	base := t.TempDir()
+	lowercasePath := filepath.Join(base, "shared", "worktree")
+	uppercasePath := filepath.Join(base, "SHARED", "WORKTREE")
+
+	lowercaseKey, err := normalizedWorktreeTargetPathForOS(lowercasePath, "windows")
+	if err != nil {
+		t.Fatalf("normalize lowercase Windows path: %v", err)
+	}
+	uppercaseKey, err := normalizedWorktreeTargetPathForOS(uppercasePath, "windows")
+	if err != nil {
+		t.Fatalf("normalize uppercase Windows path: %v", err)
+	}
+	if lowercaseKey != uppercaseKey {
+		t.Fatalf("Windows-equivalent ownership paths differ: %q != %q", lowercaseKey, uppercaseKey)
+	}
+}

--- a/apps/web/e2e/fixtures/backend.ts
+++ b/apps/web/e2e/fixtures/backend.ts
@@ -334,7 +334,24 @@ export const backendFixture = base.extend<object, { backend: BackendContext }>({
         fs.writeFileSync(
           shimPath,
           `#!/bin/sh
-if [ -f "$KANDEV_E2E_GIT_DELAY_FILE" ] && { [ "$1" = "fetch" ] || [ "$1" = "pull" ]; }; then
+# The worktree manager invokes Git with -c core.longpaths=true. Inspect the
+# subcommand in a subshell so skipping its option/value pair does not change
+# the original arguments passed through to the real Git binary below.
+git_subcommand=$(
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      -c)
+        shift
+        [ "$#" -gt 0 ] && shift
+        ;;
+      *)
+        printf '%s\\n' "$1"
+        exit 0
+        ;;
+    esac
+  done
+)
+if [ -f "$KANDEV_E2E_GIT_DELAY_FILE" ] && { [ "$git_subcommand" = "fetch" ] || [ "$git_subcommand" = "pull" ]; }; then
   delay_ms=$(cat "$KANDEV_E2E_GIT_DELAY_FILE" 2>/dev/null)
   case "$delay_ms" in
     ''|*[!0-9]*) ;;
@@ -347,7 +364,7 @@ if [ -f "$KANDEV_E2E_GIT_DELAY_FILE" ] && { [ "$1" = "fetch" ] || [ "$1" = "pull
       ;;
   esac
 fi
-if [ "$1" = "push" ] && [ -f "$KANDEV_E2E_GITLAB_PUSH_FILE" ]; then
+if [ "$git_subcommand" = "push" ] && [ -f "$KANDEV_E2E_GITLAB_PUSH_FILE" ]; then
   expected_remote=$(cat "$KANDEV_E2E_GITLAB_PUSH_FILE" 2>/dev/null)
   actual_remote=$(PATH="$KANDEV_E2E_ORIGINAL_PATH" git config --get remote.origin.url 2>/dev/null)
   if [ -n "$expected_remote" ] && [ "$actual_remote" = "$expected_remote" ]; then

--- a/docs/public/windows-support.md
+++ b/docs/public/windows-support.md
@@ -100,7 +100,9 @@ Kandev supports native Git repositories and worktrees. Windows still imposes fil
 - repository setup, cleanup, dev, and executor prepare scripts must use syntax available to their selected Windows shell; POSIX shell snippets do not become PowerShell automatically;
 - creating symbolic links often requires Windows Developer Mode or an elevated account;
 - a repository `copyFiles` entry using `:symlink` can therefore warn/fail on Windows—use a normal copy unless live linkage is required and symlinks are enabled; and
-- path-length errors remain dependent on Windows and Git configuration. Prefer short repository/Kandev-home roots; only enable Git's long-path support if allowed by local policy.
+- Kandev invokes its managed Git worktree commands with command-scoped `core.longpaths=true`. It does not change Git's system, global, or repository configuration.
+
+Windows long-path policy and each application's long-path awareness still apply. External Git clients and tools do not inherit Kandev's command-scoped setting. If Kandev still reports `Filename too long`, enable Win32 long paths when allowed by local policy or use a shorter `KANDEV_HOME_DIR`. Configure `core.longpaths` separately only when an external Git client needs it.
 
 Kandev uses Windows Job Objects and process-tree termination for managed child cleanup. An abruptly killed terminal or externally launched child can still outlive a session; inspect Task Manager and executor resources before deleting a worktree.
 


### PR DESCRIPTION
Windows users can create Git worktrees containing paths beyond the legacy limit, while failed creation attempts leave no Kandev-owned branch, filesystem, or Git metadata behind.

## Important Changes

- Run Kandev-managed Git operations with command-scoped long-path support and give filename-limit failures actionable Windows guidance.
- Make worktree creation rollback atomic and portable, with normalized target-path locking to prevent concurrent cleanup races.

## Validation

- `make fmt`
- `make typecheck test lint`
- Complete backend, web (5,824 passed; 4 skipped), CLI (280 passed), scripts, and desktop smoke suites
- Focused worktree race-detector suite
- Public docs validation (58/58 checks; 40 pages)

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.