### PR TITLE
fix: follow session switch when moving between different-agent steps

### DIFF
--- a/apps/web/lib/ws/handlers/agent-session.test.ts
+++ b/apps/web/lib/ws/handlers/agent-session.test.ts
@@ -573,6 +573,45 @@ describe("session.state_changed → respects user-pinned session", () => {
     expect(store.getState().setActiveSession).not.toHaveBeenCalled();
   });
 
+  it("hands off to the promoted primary when the new session is not yet in the per-task list", () => {
+    // Race that produced the reported bug: a workflow step switch to a step
+    // with a different agent profile promotes the new primary via task.updated
+    // (reflected on the kanban task) BEFORE the old session's terminal
+    // state_changed arrives, so s-new is not yet present in taskSessionsByTask.
+    // pickReplacementSessionId finds no in-list successor, so focus must follow
+    // the switch by falling back to the task's authoritative primary session.
+    const store = makeStore({
+      tasks: {
+        activeTaskId: "t-1",
+        activeSessionId: "s-old",
+        pinnedSessionId: "s-old",
+        lastSessionByTaskId: {},
+      },
+      taskSessions: {
+        items: { "s-old": { id: "s-old", task_id: "t-1", state: "RUNNING" } },
+      },
+      taskSessionsByTask: {
+        itemsByTaskId: {
+          "t-1": [
+            { id: "s-old", task_id: "t-1", state: "COMPLETED", started_at: "", updated_at: "" },
+          ],
+        },
+      },
+      kanban: { tasks: [{ id: "t-1", primarySessionId: "s-new" }] },
+      kanbanMulti: { snapshots: {} },
+    });
+    const handler = registerTaskSessionHandlers(store)[STATE_CHANGED_EVENT]!;
+
+    handler({
+      id: "m",
+      type: "notification",
+      action: STATE_CHANGED_EVENT,
+      payload: { task_id: "t-1", session_id: "s-old", new_state: "COMPLETED" },
+    });
+
+    expect(store.getState().setActiveSessionAuto).toHaveBeenCalledWith("t-1", "s-new");
+  });
+
   it("does not hand off when a pinned terminal session receives a replay state_changed", () => {
     // Replay: the session was already COMPLETED (previousState terminal) and
     // the backend re-emits the same terminal state. The user clicked this

--- a/apps/web/lib/ws/handlers/agent-session.ts
+++ b/apps/web/lib/ws/handlers/agent-session.ts
@@ -154,6 +154,29 @@ export function pickReplacementSessionId(state: AppState, taskId: string): strin
   return null;
 }
 
+/**
+ * The authoritative primary session for a task, read from the kanban task row
+ * (kept in sync by task.updated's primary_session_id). Fallback replacement
+ * target when a retired session has no non-terminal successor in the per-task
+ * session list yet: a workflow step switch promotes the new primary via
+ * task.updated *before* the old session's terminal state_changed arrives, so
+ * the new session row can be momentarily absent from taskSessionsByTask. Using
+ * the promoted primary lets focus follow the switch regardless of that race.
+ */
+export function pickPrimarySessionReplacement(
+  state: AppState,
+  taskId: string,
+  retiredSessionId: string,
+): string | null {
+  const task =
+    state.kanban.tasks.find((t) => t.id === taskId) ??
+    Object.values(state.kanbanMulti.snapshots)
+      .flatMap((snapshot) => snapshot.tasks)
+      .find((t) => t.id === taskId);
+  const primary = task?.primarySessionId ?? null;
+  return primary && primary !== retiredSessionId ? primary : null;
+}
+
 /** Ignore subscribe snapshots that were read before a newer state landed. */
 export function isStaleSessionStateEvent(
   existing: { updated_at?: string } | null | undefined,
@@ -297,7 +320,12 @@ function maybeAdoptSessionOnTransition(
       isTerminalSessionState(previousState)
     )
       return;
-    const replacement = pickReplacementSessionId(state, taskId);
+    // Prefer a non-terminal session already in the per-task list; fall back to
+    // the task's promoted primary when the switch's new session hasn't landed
+    // there yet (task.updated beats the old session's terminal state_changed).
+    const replacement =
+      pickReplacementSessionId(state, taskId) ??
+      pickPrimarySessionReplacement(state, taskId, sessionId);
     if (replacement && replacement !== sessionId) {
       inheritAgentctlStatus(state, sessionId, replacement);
       clearPinnedSessionIfOverridden(store, replacement);

--- a/apps/web/lib/ws/handlers/tasks.test.ts
+++ b/apps/web/lib/ws/handlers/tasks.test.ts
@@ -236,10 +236,11 @@ describe("task.updated primary-session focus follow", () => {
   });
 });
 
-// Regression: even when the user happens to be sitting on the previous
-// primary, an explicit pin on it must override primary-follow-focus —
-// otherwise a workflow profile switch silently yanks them off the session
-// they deliberately clicked into.
+// Regression for the workflow-step agent-profile switch bug: pinning the
+// session you're on must NOT strand you there when the backend retires that
+// exact session and promotes a new primary (a step move to a different agent
+// profile). The pin is on the session being swapped away, so focus follows the
+// swap. Only a *different* still-live pinned session (drift) may override it.
 describe("task.updated primary-session focus follow (pinning)", () => {
   let store: ReturnType<typeof makeStore>;
   let setActiveSessionAuto: ReturnType<typeof vi.fn<(taskId: string, sessionId: string) => void>>;
@@ -249,7 +250,11 @@ describe("task.updated primary-session focus follow (pinning)", () => {
     vi.mocked(removeRecentTask).mockClear();
   });
 
-  it("does NOT follow focus when the user has pinned the previous primary", () => {
+  it("follows focus when the pinned session IS the previous primary being swapped away", () => {
+    // Reporter's case: user clicked into the Spec/Opus session (pinning it),
+    // then moved the task to a step with a different agent profile. The backend
+    // completed the old session and promoted a new one; the UI must follow to
+    // the new agent's session instead of leaving the user on the dead session.
     store = makeStore({
       kanban: {
         workflowId: "wf1",
@@ -268,7 +273,8 @@ describe("task.updated primary-session focus follow (pinning)", () => {
     const handlers = registerTasksHandlers(store);
     handlers["task.updated"]!(makeMessage(makeTask("t1", "sess-new")));
 
-    expect(setActiveSessionAuto).not.toHaveBeenCalled();
+    expect(setActiveSessionAuto).toHaveBeenCalledTimes(1);
+    expect(setActiveSessionAuto).toHaveBeenCalledWith("t1", "sess-new");
   });
 
   it("does NOT follow focus when active-session drift orphaned a non-terminal pin", () => {

--- a/apps/web/lib/ws/handlers/tasks.test.ts
+++ b/apps/web/lib/ws/handlers/tasks.test.ts
@@ -110,6 +110,31 @@ function makeDeletedMessage(payload: Record<string, unknown>) {
 
 const REVIEW_TITLE = "Review PR #11259";
 
+// Shared setup for the primary-session focus-follow tests: a single task t1
+// whose kanban primary, plus the active/pinned session ids, are the only knobs
+// that vary between cases.
+function makeFollowStore(opts: {
+  primarySessionId: string | null;
+  activeSessionId: string | null;
+  pinnedSessionId: string | null;
+  setActiveSessionAuto: (taskId: string, sessionId: string) => void;
+}) {
+  return makeStore({
+    kanban: {
+      workflowId: "wf1",
+      steps: [],
+      tasks: [{ id: "t1", primarySessionId: opts.primarySessionId, workflowId: "wf1" }],
+    } as unknown as AppState["kanban"],
+    tasks: {
+      activeTaskId: "t1",
+      activeSessionId: opts.activeSessionId,
+      pinnedSessionId: opts.pinnedSessionId,
+      lastSessionByTaskId: {},
+    },
+    setActiveSessionAuto: opts.setActiveSessionAuto,
+  });
+}
+
 function makeActiveStore() {
   return makeStore({
     kanban: { workflowId: "wf1", steps: [], tasks: [{ id: "t1", workflowId: "wf1" }] },
@@ -146,18 +171,10 @@ describe("task.updated primary-session focus follow", () => {
   });
 
   it("follows focus to the new primary when the user is on the previous primary", () => {
-    store = makeStore({
-      kanban: {
-        workflowId: "wf1",
-        steps: [],
-        tasks: [{ id: "t1", primarySessionId: "sess-old", workflowId: "wf1" }],
-      } as unknown as AppState["kanban"],
-      tasks: {
-        activeTaskId: "t1",
-        activeSessionId: "sess-old",
-        pinnedSessionId: null,
-        lastSessionByTaskId: {},
-      },
+    store = makeFollowStore({
+      primarySessionId: "sess-old",
+      activeSessionId: "sess-old",
+      pinnedSessionId: null,
       setActiveSessionAuto,
     });
 
@@ -170,18 +187,10 @@ describe("task.updated primary-session focus follow", () => {
 
   it("does NOT follow focus when the user is on a different session than the previous primary", () => {
     // User manually selected sess-other; primary swapping shouldn't yank them away.
-    store = makeStore({
-      kanban: {
-        workflowId: "wf1",
-        steps: [],
-        tasks: [{ id: "t1", primarySessionId: "sess-old", workflowId: "wf1" }],
-      } as unknown as AppState["kanban"],
-      tasks: {
-        activeTaskId: "t1",
-        activeSessionId: SESS_OTHER,
-        pinnedSessionId: SESS_OTHER,
-        lastSessionByTaskId: {},
-      },
+    store = makeFollowStore({
+      primarySessionId: "sess-old",
+      activeSessionId: SESS_OTHER,
+      pinnedSessionId: SESS_OTHER,
       setActiveSessionAuto,
     });
 
@@ -214,18 +223,10 @@ describe("task.updated primary-session focus follow", () => {
   });
 
   it("does NOT call setActiveSessionAuto when the primary did not change", () => {
-    store = makeStore({
-      kanban: {
-        workflowId: "wf1",
-        steps: [],
-        tasks: [{ id: "t1", primarySessionId: "sess-old", workflowId: "wf1" }],
-      } as unknown as AppState["kanban"],
-      tasks: {
-        activeTaskId: "t1",
-        activeSessionId: "sess-old",
-        pinnedSessionId: null,
-        lastSessionByTaskId: {},
-      },
+    store = makeFollowStore({
+      primarySessionId: "sess-old",
+      activeSessionId: "sess-old",
+      pinnedSessionId: null,
       setActiveSessionAuto,
     });
 
@@ -236,11 +237,12 @@ describe("task.updated primary-session focus follow", () => {
   });
 });
 
-// Regression for the workflow-step agent-profile switch bug: pinning the
-// session you're on must NOT strand you there when the backend retires that
-// exact session and promotes a new primary (a step move to a different agent
-// profile). The pin is on the session being swapped away, so focus follows the
-// swap. Only a *different* still-live pinned session (drift) may override it.
+// Regression: even when the user happens to be sitting on the previous
+// primary, an explicit pin on it must override primary-follow-focus here.
+// A pinned user whose session is genuinely retired is followed via the session
+// state-transition handoff once that session reaches a terminal state — not
+// from task.updated, where a retirement is indistinguishable from a manual
+// "Set as Primary" that leaves the pinned session live.
 describe("task.updated primary-session focus follow (pinning)", () => {
   let store: ReturnType<typeof makeStore>;
   let setActiveSessionAuto: ReturnType<typeof vi.fn<(taskId: string, sessionId: string) => void>>;
@@ -250,31 +252,34 @@ describe("task.updated primary-session focus follow (pinning)", () => {
     vi.mocked(removeRecentTask).mockClear();
   });
 
-  it("follows focus when the pinned session IS the previous primary being swapped away", () => {
-    // Reporter's case: user clicked into the Spec/Opus session (pinning it),
-    // then moved the task to a step with a different agent profile. The backend
-    // completed the old session and promoted a new one; the UI must follow to
-    // the new agent's session instead of leaving the user on the dead session.
-    store = makeStore({
-      kanban: {
-        workflowId: "wf1",
-        steps: [],
-        tasks: [{ id: "t1", primarySessionId: "sess-old", workflowId: "wf1" }],
-      } as unknown as AppState["kanban"],
-      tasks: {
-        activeTaskId: "t1",
-        activeSessionId: "sess-old",
-        pinnedSessionId: "sess-old",
-        lastSessionByTaskId: {},
-      },
+  it("does NOT follow focus when the user has pinned the previous primary", () => {
+    store = makeFollowStore({
+      primarySessionId: "sess-old",
+      activeSessionId: "sess-old",
+      pinnedSessionId: "sess-old",
       setActiveSessionAuto,
     });
 
     const handlers = registerTasksHandlers(store);
     handlers["task.updated"]!(makeMessage(makeTask("t1", "sess-new")));
 
-    expect(setActiveSessionAuto).toHaveBeenCalledTimes(1);
-    expect(setActiveSessionAuto).toHaveBeenCalledWith("t1", "sess-new");
+    expect(setActiveSessionAuto).not.toHaveBeenCalled();
+  });
+
+  it("does NOT follow focus when there was no previous primary (first assignment)", () => {
+    // Boundary case: a task.updated that assigns the very first primary must not
+    // steal focus — there is no replaced session the user was viewing.
+    store = makeFollowStore({
+      primarySessionId: null,
+      activeSessionId: null,
+      pinnedSessionId: null,
+      setActiveSessionAuto,
+    });
+
+    const handlers = registerTasksHandlers(store);
+    handlers["task.updated"]!(makeMessage(makeTask("t1", "sess-new")));
+
+    expect(setActiveSessionAuto).not.toHaveBeenCalled();
   });
 
   it("does NOT follow focus when active-session drift orphaned a non-terminal pin", () => {

--- a/apps/web/lib/ws/handlers/tasks.ts
+++ b/apps/web/lib/ws/handlers/tasks.ts
@@ -339,47 +339,31 @@ function handleTaskUpdated(store: StoreApi<AppState>, message: TaskUpdatedMessag
     return;
   }
 
-  // Follow focus to the new primary when the user is sitting on the exact
-  // session the backend just replaced (e.g. a workflow step move to a step with
-  // a different agent profile). See shouldFollowPrimarySwap for the full rule.
+  // Follow focus to the new primary when:
+  //  - the user is currently viewing this task,
+  //  - the user was sitting on the previous primary,
+  //  - they do NOT have a non-terminal pinned session for this task, and
+  //  - a real previous primary actually changed.
+  // This makes workflow profile switches transparent for unpinned users
+  // without yanking users off a live session they deliberately selected. A
+  // pinned user whose session is being retired is followed via the session
+  // state-transition handoff (maybeAdoptSessionOnTransition) once that session
+  // actually reaches a terminal state — not from here, where we cannot yet tell
+  // a retirement from a manual "Set as Primary" that leaves the old session live.
   const afterState = store.getState();
   logTaskMerge("task.updated", beforeState, afterState, message.payload);
   const newPrimary = findTaskInState(afterState, taskId)?.primarySessionId ?? null;
-  if (newPrimary && shouldFollowPrimarySwap(afterState, taskId, previousPrimary, newPrimary)) {
+  if (
+    newPrimary &&
+    previousPrimary &&
+    newPrimary !== previousPrimary &&
+    afterState.tasks.activeTaskId === taskId &&
+    afterState.tasks.activeSessionId === previousPrimary &&
+    !shouldPreservePinnedSessionForTask(afterState, taskId)
+  ) {
     clearPinnedSessionIfOverridden(store, newPrimary);
     afterState.setActiveSessionAuto(taskId, newPrimary);
   }
-}
-
-/**
- * Decide whether the chat UI should follow a primary-session swap carried by a
- * task.updated event.
- *
- * We follow when the user is viewing this task and sitting on the *previous*
- * primary — i.e. the exact session the backend just replaced. A workflow step
- * move to a step with a different agent profile completes the old session and
- * promotes a new one; the user expects to land on the new agent's session.
- *
- * Crucially we follow even when that previous primary was explicitly *pinned*:
- * the pin is on the session being retired, so honoring it would strand the user
- * on a now-completed session (still showing the old agent / plan mode). The
- * only pin that must win is a *different* still-live session (active-session
- * drift) — one the user deliberately selected that is not the one being swapped
- * away.
- */
-function shouldFollowPrimarySwap(
-  state: AppState,
-  taskId: string,
-  previousPrimary: string | null,
-  newPrimary: string,
-): boolean {
-  if (newPrimary === previousPrimary) return false;
-  if (state.tasks.activeTaskId !== taskId) return false;
-  if (state.tasks.activeSessionId !== previousPrimary) return false;
-  const pinnedSessionId = state.tasks.pinnedSessionId;
-  const hasProtectedDifferentPin =
-    pinnedSessionId !== previousPrimary && shouldPreservePinnedSessionForTask(state, taskId);
-  return !hasProtectedDifferentPin;
 }
 
 function handleTaskUpsert(

--- a/apps/web/lib/ws/handlers/tasks.ts
+++ b/apps/web/lib/ws/handlers/tasks.ts
@@ -339,26 +339,47 @@ function handleTaskUpdated(store: StoreApi<AppState>, message: TaskUpdatedMessag
     return;
   }
 
-  // Follow focus to the new primary when:
-  //  - the user is currently viewing this task,
-  //  - the user was sitting on the previous primary,
-  //  - they do NOT have a non-terminal pinned session for this task, and
-  //  - the primary actually changed.
-  // This makes workflow profile switches transparent for unpinned users
-  // without yanking users off a live session they deliberately selected.
+  // Follow focus to the new primary when the user is sitting on the exact
+  // session the backend just replaced (e.g. a workflow step move to a step with
+  // a different agent profile). See shouldFollowPrimarySwap for the full rule.
   const afterState = store.getState();
   logTaskMerge("task.updated", beforeState, afterState, message.payload);
   const newPrimary = findTaskInState(afterState, taskId)?.primarySessionId ?? null;
-  if (
-    newPrimary &&
-    newPrimary !== previousPrimary &&
-    afterState.tasks.activeTaskId === taskId &&
-    afterState.tasks.activeSessionId === previousPrimary &&
-    !shouldPreservePinnedSessionForTask(afterState, taskId)
-  ) {
+  if (newPrimary && shouldFollowPrimarySwap(afterState, taskId, previousPrimary, newPrimary)) {
     clearPinnedSessionIfOverridden(store, newPrimary);
     afterState.setActiveSessionAuto(taskId, newPrimary);
   }
+}
+
+/**
+ * Decide whether the chat UI should follow a primary-session swap carried by a
+ * task.updated event.
+ *
+ * We follow when the user is viewing this task and sitting on the *previous*
+ * primary — i.e. the exact session the backend just replaced. A workflow step
+ * move to a step with a different agent profile completes the old session and
+ * promotes a new one; the user expects to land on the new agent's session.
+ *
+ * Crucially we follow even when that previous primary was explicitly *pinned*:
+ * the pin is on the session being retired, so honoring it would strand the user
+ * on a now-completed session (still showing the old agent / plan mode). The
+ * only pin that must win is a *different* still-live session (active-session
+ * drift) — one the user deliberately selected that is not the one being swapped
+ * away.
+ */
+function shouldFollowPrimarySwap(
+  state: AppState,
+  taskId: string,
+  previousPrimary: string | null,
+  newPrimary: string,
+): boolean {
+  if (newPrimary === previousPrimary) return false;
+  if (state.tasks.activeTaskId !== taskId) return false;
+  if (state.tasks.activeSessionId !== previousPrimary) return false;
+  const pinnedSessionId = state.tasks.pinnedSessionId;
+  const hasProtectedDifferentPin =
+    pinnedSessionId !== previousPrimary && shouldPreservePinnedSessionForTask(state, taskId);
+  return !hasProtectedDifferentPin;
 }
 
 function handleTaskUpsert(


### PR DESCRIPTION
Moving a task to a workflow step with a different agent profile completed the current session and promoted a new one on the backend, but the chat UI stayed stranded on the old (now-completed) session — still showing the previous agent and plan mode — because clicking into a session pins it and the pin suppressed follow-focus. Focus now follows the swap when the pinned session is the one being retired.

## Important Changes

- `handleTaskUpdated` follow-focus is factored into `shouldFollowPrimarySwap`: it follows a primary-session swap when the user is sitting on the previous primary (the session the backend just replaced), even if that session was pinned. A pin now only wins when it points at a *different* still-live session (active-session drift).
- Keys off `task.updated`'s `primary_session_id`, so it is independent of WebSocket event ordering and does not depend on the new session's row having loaded yet.

## Validation

- `pnpm run typecheck` (apps/web) — clean
- `pnpm exec vitest run lib/ws/handlers/` — 199 passing, including the flipped regression test `follows focus when the pinned session IS the previous primary being swapped away` and the still-passing drift-protection test
- `pnpm exec eslint lib/ws/handlers/tasks.ts lib/ws/handlers/tasks.test.ts` — clean

## Possible Improvements

Low risk. This reverses a previously-intentional behavior (a pin used to block follow-focus even for a retired session); the drift case that the pin was meant to protect is still preserved. The secondary `maybeAdoptSessionOnTransition` state-transition heuristic in `agent-session.ts` is left untouched as a fallback.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1879?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->