### PR TITLE
feat: add external vcs file links

### DIFF
--- a/apps/backend/internal/task/dto/dto.go
+++ b/apps/backend/internal/task/dto/dto.go
@@ -54,6 +54,7 @@ type RepositoryDTO struct {
 	ProviderHost           string                `json:"provider_host"`
 	ProviderOwner          string                `json:"provider_owner"`
 	ProviderName           string                `json:"provider_name"`
+	RemoteURL              string                `json:"remote_url"`
 	DefaultBranch          string                `json:"default_branch"`
 	WorktreeBranchPrefix   string                `json:"worktree_branch_prefix"`
 	WorktreeBranchTemplate string                `json:"worktree_branch_template"`
@@ -476,6 +477,7 @@ func FromRepository(repository *models.Repository) RepositoryDTO {
 		ProviderHost:           repository.ProviderHost,
 		ProviderOwner:          repository.ProviderOwner,
 		ProviderName:           repository.ProviderName,
+		RemoteURL:              repository.RemoteURL,
 		DefaultBranch:          repository.DefaultBranch,
 		WorktreeBranchPrefix:   repository.WorktreeBranchPrefix,
 		WorktreeBranchTemplate: repository.WorktreeBranchTemplate,

--- a/apps/backend/internal/task/dto/repository_test.go
+++ b/apps/backend/internal/task/dto/repository_test.go
@@ -1,0 +1,25 @@
+package dto
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/kandev/kandev/internal/task/models"
+)
+
+func TestFromRepositoryIncludesRemoteURL(t *testing.T) {
+	payload, err := json.Marshal(FromRepository(&models.Repository{
+		ID:        "repo-1",
+		RemoteURL: "https://github.com/owner/repo.git",
+	}))
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(payload, &decoded); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if decoded["remote_url"] != "https://github.com/owner/repo.git" {
+		t.Errorf("remote_url = %v, want %q; payload = %s", decoded["remote_url"], "https://github.com/owner/repo.git", payload)
+	}
+}

--- a/apps/backend/internal/task/handlers/repository_handlers_test.go
+++ b/apps/backend/internal/task/handlers/repository_handlers_test.go
@@ -51,6 +51,66 @@ func TestHTTPCreateRepositoryRejectsInvalidLocalPathWithoutPersistence(t *testin
 	}
 }
 
+func TestHTTPCreateRepositoryIgnoresRemoteURL(t *testing.T) {
+	router, repo := newRepositoryHTTPTestRouter(t)
+	request := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/workspaces/ws-1/repositories",
+		strings.NewReader(`{"name":"owner/repo","source_type":"provider","remote_url":"https://github.com/owner/repo.git"}`),
+	)
+	request.Header.Set("Content-Type", "application/json")
+	response := httptest.NewRecorder()
+
+	router.ServeHTTP(response, request)
+
+	if response.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d; body = %s", response.Code, http.StatusCreated, response.Body.String())
+	}
+	repositories, err := repo.ListRepositories(context.Background(), "ws-1")
+	if err != nil {
+		t.Fatalf("ListRepositories: %v", err)
+	}
+	if len(repositories) != 1 {
+		t.Fatalf("repositories = %d, want 1", len(repositories))
+	}
+	if repositories[0].RemoteURL != "" {
+		t.Errorf("RemoteURL = %q, want empty; generic repository creation must not accept clone URLs", repositories[0].RemoteURL)
+	}
+}
+
+func TestHTTPUpdateRepositoryIgnoresRemoteURL(t *testing.T) {
+	router, repo := newRepositoryHTTPTestRouter(t)
+	if err := repo.CreateRepository(context.Background(), &models.Repository{
+		ID:          "provider-repo",
+		WorkspaceID: "ws-1",
+		Name:        "owner/repo",
+		SourceType:  "provider",
+		RemoteURL:   "https://github.com/owner/old.git",
+	}); err != nil {
+		t.Fatalf("CreateRepository: %v", err)
+	}
+	request := httptest.NewRequest(
+		http.MethodPatch,
+		"/api/v1/repositories/provider-repo",
+		strings.NewReader(`{"remote_url":"https://github.com/owner/repo.git"}`),
+	)
+	request.Header.Set("Content-Type", "application/json")
+	response := httptest.NewRecorder()
+
+	router.ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body = %s", response.Code, http.StatusOK, response.Body.String())
+	}
+	repository, err := repo.GetRepository(context.Background(), "provider-repo")
+	if err != nil {
+		t.Fatalf("GetRepository: %v", err)
+	}
+	if repository.RemoteURL != "https://github.com/owner/old.git" {
+		t.Errorf("RemoteURL = %q, want original value %q", repository.RemoteURL, "https://github.com/owner/old.git")
+	}
+}
+
 type repositoryHandlerRemoteLister struct {
 	calls int
 }

--- a/apps/backend/internal/task/service/service_requests_test.go
+++ b/apps/backend/internal/task/service/service_requests_test.go
@@ -1,0 +1,22 @@
+package service
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/kandev/kandev/internal/task/models"
+)
+
+func TestApplyRepositoryUpdates_IgnoresRemoteURLFromJSON(t *testing.T) {
+	repo := &models.Repository{RemoteURL: "https://github.com/owner/old.git"}
+	var updates UpdateRepositoryRequest
+	if err := json.Unmarshal([]byte(`{"remote_url":"https://github.com/owner/repo.git"}`), &updates); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if err := applyRepositoryUpdates(repo, &updates); err != nil {
+		t.Fatalf("applyRepositoryUpdates: %v", err)
+	}
+	if repo.RemoteURL != "https://github.com/owner/old.git" {
+		t.Errorf("RemoteURL = %q, want original value %q", repo.RemoteURL, "https://github.com/owner/old.git")
+	}
+}

--- a/apps/web/components/diff/diff-header-toolbar.test.tsx
+++ b/apps/web/components/diff/diff-header-toolbar.test.tsx
@@ -3,6 +3,16 @@ import { renderHook, render, screen, fireEvent, cleanup } from "@testing-library
 import { TooltipProvider } from "@kandev/ui/tooltip";
 import type { ReactElement } from "react";
 
+vi.mock("@/components/editors/external-vcs-file-link", () => ({
+  ExternalVcsFileLink: (props: Record<string, unknown>) => (
+    <span data-testid="external-vcs-file-link-props" data-props={JSON.stringify(props)} />
+  ),
+}));
+
+vi.mock("@/hooks/use-responsive-breakpoint", () => ({
+  useResponsiveBreakpoint: () => ({ isMobile: false }),
+}));
+
 import { useDiffHeaderToolbar } from "./diff-header-toolbar";
 
 const FILE = "src/foo.ts";
@@ -31,6 +41,10 @@ function renderToolbar(node: ReactElement) {
 function headerProp(name: string | undefined) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return (name === undefined ? {} : { name }) as any;
+}
+
+function externalLinkProps() {
+  return JSON.parse(screen.getByTestId("external-vcs-file-link-props").dataset.props ?? "{}");
 }
 
 const baseOpts = {
@@ -123,5 +137,38 @@ describe("useDiffHeaderToolbar", () => {
     const mdNode = result.current(headerProp("README.md"));
     renderToolbar(mdNode as ReactElement);
     expect(screen.getByLabelText("Preview markdown")).toBeTruthy();
+  });
+
+  it("forwards file, repository, revision, and rename context to the external action", () => {
+    const { result } = renderHook(() =>
+      useDiffHeaderToolbar({
+        ...baseOpts,
+        sessionId: "session-1",
+        taskId: "task-1",
+        repositoryId: "repo-1",
+        repo: "frontend",
+        status: "renamed",
+        publishedBranch: "feature/external-links",
+        baseBranch: "main",
+      }),
+    );
+    const node = result.current({
+      ...headerProp("src/new-name.ts"),
+      prevName: "src/old-name.ts",
+    });
+    renderToolbar(node as ReactElement);
+
+    expect(externalLinkProps()).toEqual({
+      filePath: "src/new-name.ts",
+      previousPath: "src/old-name.ts",
+      status: "renamed",
+      taskId: "task-1",
+      sessionId: "session-1",
+      repositoryId: "repo-1",
+      repositoryName: "frontend",
+      publishedBranch: "feature/external-links",
+      baseBranch: "main",
+      size: "xs",
+    });
   });
 });

--- a/apps/web/components/diff/diff-header-toolbar.tsx
+++ b/apps/web/components/diff/diff-header-toolbar.tsx
@@ -16,7 +16,9 @@ import {
   IconEye,
 } from "@tabler/icons-react";
 import type { FileDiffMetadata } from "@pierre/diffs";
+import { ExternalVcsFileLink } from "@/components/editors/external-vcs-file-link";
 import type { ViewMode } from "@/hooks/use-global-view-mode";
+import { useResponsiveBreakpoint } from "@/hooks/use-responsive-breakpoint";
 
 const iconBtn = "h-6 w-6 p-0 cursor-pointer opacity-60 hover:opacity-100";
 
@@ -61,6 +63,13 @@ interface DiffHeaderToolbarOptions {
   onRevert?: (filePath: string) => void;
   /** Multi-repo subpath (repository_name) so Edit opens under the right repo. */
   repo?: string;
+  taskId?: string | null;
+  sessionId?: string | null;
+  repositoryId?: string | null;
+  status?: string | null;
+  previousPath?: string | null;
+  publishedBranch?: string | null;
+  baseBranch?: string | null;
   expandUnchanged?: boolean;
   onToggleExpandUnchanged?: () => void;
 }
@@ -69,6 +78,8 @@ type ToolbarButtonsProps = Omit<DiffHeaderToolbarOptions, "filePath" | "diff"> &
   resolvedPath: string;
   onCopyDiff: () => void;
   isMarkdownFile: boolean;
+  externalLink: Omit<React.ComponentProps<typeof ExternalVcsFileLink>, "filePath" | "size">;
+  externalLinkSize: "xs" | "touch";
 };
 
 function DiffHeaderToolbarButtons({
@@ -85,12 +96,16 @@ function DiffHeaderToolbarButtons({
   onPreviewMarkdown,
   repo,
   isMarkdownFile,
+  externalLink,
+  externalLinkSize,
 }: ToolbarButtonsProps) {
   return (
     <div className="flex items-center gap-1">
       <ToolbarBtn onClick={onCopyDiff} tooltip="Copy diff">
         <IconCopy className="h-3.5 w-3.5" />
       </ToolbarBtn>
+
+      <ExternalVcsFileLink {...externalLink} filePath={resolvedPath} size={externalLinkSize} />
 
       {onRevert && (
         <ToolbarBtn onClick={() => onRevert(resolvedPath)} tooltip="Revert changes">
@@ -169,7 +184,15 @@ export function useDiffHeaderToolbar(opts: DiffHeaderToolbarOptions) {
     repo,
     expandUnchanged,
     onToggleExpandUnchanged,
+    taskId,
+    sessionId,
+    repositoryId,
+    status,
+    previousPath,
+    publishedBranch,
+    baseBranch,
   } = opts;
+  const { isMobile } = useResponsiveBreakpoint();
 
   return useCallback(
     (fileDiff: FileDiffMetadata): ReactNode => {
@@ -189,6 +212,17 @@ export function useDiffHeaderToolbar(opts: DiffHeaderToolbarOptions) {
           repo={repo}
           expandUnchanged={expandUnchanged}
           onToggleExpandUnchanged={onToggleExpandUnchanged}
+          externalLink={{
+            taskId,
+            sessionId,
+            repositoryId,
+            repositoryName: repo,
+            status,
+            publishedBranch,
+            baseBranch,
+            previousPath: fileDiff.prevName ?? previousPath,
+          }}
+          externalLinkSize={isMobile ? "touch" : "xs"}
         />
       );
     },
@@ -205,6 +239,14 @@ export function useDiffHeaderToolbar(opts: DiffHeaderToolbarOptions) {
       repo,
       expandUnchanged,
       onToggleExpandUnchanged,
+      taskId,
+      sessionId,
+      repositoryId,
+      status,
+      previousPath,
+      publishedBranch,
+      baseBranch,
+      isMobile,
     ],
   );
 }

--- a/apps/web/components/diff/diff-viewer-resolver.test.tsx
+++ b/apps/web/components/diff/diff-viewer-resolver.test.tsx
@@ -1,0 +1,63 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/hooks/use-editor-resolver", () => ({
+  useEditorProvider: () => "monaco",
+}));
+
+vi.mock("@/components/editors/monaco/monaco-diff-viewer", () => ({
+  MonacoDiffViewer: (props: Record<string, unknown>) => (
+    <span data-testid="monaco-diff-props" data-props={JSON.stringify(props)} />
+  ),
+}));
+
+vi.mock("./diff-viewer", () => ({
+  DiffViewer: () => null,
+  DiffViewInline: () => null,
+}));
+
+import { DiffViewerResolved } from "./diff-viewer-resolver";
+
+afterEach(cleanup);
+
+describe("DiffViewerResolved Monaco context", () => {
+  it("preserves external-link context while stripping Pierre-only props", () => {
+    render(
+      <DiffViewerResolved
+        data={{
+          filePath: "src/app.ts",
+          oldContent: "old",
+          newContent: "new",
+          additions: 1,
+          deletions: 1,
+        }}
+        enableComments
+        enableExpansion
+        baseRef="HEAD"
+        repo="frontend"
+        taskId="task-1"
+        sessionId="session-1"
+        repositoryId="repo-1"
+        status="modified"
+        previousPath="src/old.ts"
+        publishedBranch="feature/external-links"
+        externalBaseBranch="main"
+      />,
+    );
+
+    const props = JSON.parse(screen.getByTestId("monaco-diff-props").dataset.props ?? "{}");
+    expect(props).toMatchObject({
+      repo: "frontend",
+      taskId: "task-1",
+      sessionId: "session-1",
+      repositoryId: "repo-1",
+      status: "modified",
+      previousPath: "src/old.ts",
+      publishedBranch: "feature/external-links",
+      externalBaseBranch: "main",
+    });
+    expect(props).not.toHaveProperty("enableComments");
+    expect(props).not.toHaveProperty("enableExpansion");
+    expect(props).not.toHaveProperty("baseRef");
+  });
+});

--- a/apps/web/components/diff/diff-viewer-resolver.tsx
+++ b/apps/web/components/diff/diff-viewer-resolver.tsx
@@ -41,6 +41,12 @@ interface DiffViewerResolverProps {
   onToggleExpandUnchanged?: () => void;
   /** Multi-repo subpath for the file (e.g. "kandev"); empty for single-repo. */
   repo?: string;
+  taskId?: string | null;
+  repositoryId?: string | null;
+  status?: string | null;
+  previousPath?: string | null;
+  publishedBranch?: string | null;
+  externalBaseBranch?: string | null;
 }
 
 export const DiffViewerResolved = memo(function DiffViewerResolved(props: DiffViewerResolverProps) {
@@ -55,7 +61,6 @@ export const DiffViewerResolved = memo(function DiffViewerResolved(props: DiffVi
       expandUnchanged,
       onToggleExpandUnchanged,
       onPreviewMarkdown,
-      repo,
       ...rest
     } = props;
     /* eslint-enable @typescript-eslint/no-unused-vars */

--- a/apps/web/components/diff/diff-viewer.tsx
+++ b/apps/web/components/diff/diff-viewer.tsx
@@ -47,6 +47,12 @@ interface DiffViewerProps {
   onToggleExpandUnchanged?: () => void;
   /** Multi-repo subpath for the file (e.g. "kandev"); empty for single-repo. */
   repo?: string;
+  taskId?: string | null;
+  repositoryId?: string | null;
+  status?: string | null;
+  previousPath?: string | null;
+  publishedBranch?: string | null;
+  externalBaseBranch?: string | null;
 }
 
 const SCALAR_PROP_KEYS: (keyof DiffViewerProps)[] = [
@@ -68,6 +74,12 @@ const SCALAR_PROP_KEYS: (keyof DiffViewerProps)[] = [
   "expandUnchanged",
   "onToggleExpandUnchanged",
   "repo",
+  "taskId",
+  "repositoryId",
+  "status",
+  "previousPath",
+  "publishedBranch",
+  "externalBaseBranch",
 ];
 
 const DATA_KEYS: (keyof FileDiffData)[] = ["filePath", "diff", "oldContent", "newContent"];
@@ -166,6 +178,13 @@ type WiringArgs = {
   toggleExpandUnchanged: () => void;
   wrapperRef: React.RefObject<HTMLDivElement | null>;
   repo?: string;
+  taskId?: string | null;
+  sessionId?: string | null;
+  repositoryId?: string | null;
+  status?: string | null;
+  previousPath?: string | null;
+  publishedBranch?: string | null;
+  externalBaseBranch?: string | null;
 };
 
 /**
@@ -212,34 +231,53 @@ function useDiffViewerWiring(args: WiringArgs) {
     expandUnchanged: args.expandUnchanged,
     onToggleExpandUnchanged: canUseExpansion ? args.toggleExpandUnchanged : undefined,
     repo: args.repo,
+    taskId: args.taskId,
+    sessionId: args.sessionId,
+    repositoryId: args.repositoryId,
+    status: args.status,
+    previousPath: args.previousPath,
+    publishedBranch: args.publishedBranch,
+    baseBranch: args.externalBaseBranch,
   });
   return { ...opts, renderAnnotation };
 }
 
-export const DiffViewer = memo(function DiffViewer({
-  data,
-  enableComments = false,
-  sessionId,
-  onCommentAdd,
-  onCommentDelete,
-  onCommentUpdate,
-  onCommentRun,
-  comments: externalComments,
-  className,
-  compact = false,
-  hideHeader = false,
-  onOpenFile,
-  onPreviewMarkdown,
-  onRevert,
-  enableAcceptReject = false,
-  onRevertBlock,
-  wordWrap: wordWrapProp,
-  enableExpansion = false,
-  baseRef,
-  expandUnchanged: expandUnchangedProp,
-  onToggleExpandUnchanged: onToggleExpandUnchangedProp,
-  repo,
-}: DiffViewerProps) {
+function externalLinkContext(props: DiffViewerProps) {
+  return {
+    taskId: props.taskId,
+    repositoryId: props.repositoryId,
+    status: props.status,
+    previousPath: props.previousPath,
+    publishedBranch: props.publishedBranch,
+    externalBaseBranch: props.externalBaseBranch,
+  };
+}
+
+export const DiffViewer = memo(function DiffViewer(props: DiffViewerProps) {
+  const {
+    data,
+    enableComments = false,
+    sessionId,
+    onCommentAdd,
+    onCommentDelete,
+    onCommentUpdate,
+    onCommentRun,
+    comments: externalComments,
+    className,
+    compact = false,
+    hideHeader = false,
+    onOpenFile,
+    onPreviewMarkdown,
+    onRevert,
+    enableAcceptReject = false,
+    onRevertBlock,
+    wordWrap: wordWrapProp,
+    enableExpansion = false,
+    baseRef,
+    expandUnchanged: expandUnchangedProp,
+    onToggleExpandUnchanged: onToggleExpandUnchangedProp,
+    repo,
+  } = props;
   const [wordWrapLocal, setWordWrap] = useState(DEFAULT_DIFF_WORD_WRAP);
   const wordWrap = wordWrapProp ?? wordWrapLocal;
   const [expandUnchangedLocal, setExpandUnchangedLocal] = useState(false);
@@ -285,6 +323,8 @@ export const DiffViewer = memo(function DiffViewer({
       toggleExpandUnchanged,
       wrapperRef,
       repo,
+      sessionId,
+      ...externalLinkContext(props),
     });
 
   const controlledSelection = state.showCommentForm

--- a/apps/web/components/diff/file-diff-viewer.tsx
+++ b/apps/web/components/diff/file-diff-viewer.tsx
@@ -36,6 +36,11 @@ interface FileDiffViewerProps {
   onToggleExpandUnchanged?: () => void;
   /** Multi-repo subpath for the file (e.g. "kandev"); empty for single-repo. */
   repo?: string;
+  taskId?: string | null;
+  repositoryId?: string | null;
+  previousPath?: string | null;
+  publishedBranch?: string | null;
+  externalBaseBranch?: string | null;
 }
 
 /**
@@ -72,6 +77,11 @@ export const FileDiffViewer = memo(function FileDiffViewer({
   expandUnchanged,
   onToggleExpandUnchanged,
   repo,
+  taskId,
+  repositoryId,
+  previousPath,
+  publishedBranch,
+  externalBaseBranch,
 }: FileDiffViewerProps) {
   const data = useMemo(() => transformGitDiff(filePath, diff, status), [filePath, diff, status]);
 
@@ -99,6 +109,12 @@ export const FileDiffViewer = memo(function FileDiffViewer({
       expandUnchanged={expandUnchanged}
       onToggleExpandUnchanged={onToggleExpandUnchanged}
       repo={repo}
+      taskId={taskId}
+      repositoryId={repositoryId}
+      status={status}
+      previousPath={previousPath}
+      publishedBranch={publishedBranch}
+      externalBaseBranch={externalBaseBranch}
     />
   );
 });

--- a/apps/web/components/diff/use-diff-options.tsx
+++ b/apps/web/components/diff/use-diff-options.tsx
@@ -98,6 +98,13 @@ type UseDiffOptionsArgs = {
   onRevert?: (filePath: string) => void;
   /** Multi-repo subpath (repository_name) so Edit opens under the right repo. */
   repo?: string;
+  taskId?: string | null;
+  sessionId?: string | null;
+  repositoryId?: string | null;
+  status?: string | null;
+  previousPath?: string | null;
+  publishedBranch?: string | null;
+  baseBranch?: string | null;
   /** Enable diff expansion (requires full deletionLines/additionLines in metadata) */
   enableExpansion?: boolean;
   /** Number of lines to expand per click (default: 20) */
@@ -157,6 +164,13 @@ export function useDiffOptions(args: UseDiffOptionsArgs): UseDiffOptionsResult {
     onPreviewMarkdown,
     onRevert,
     repo,
+    taskId: args.taskId,
+    sessionId: args.sessionId,
+    repositoryId: args.repositoryId,
+    status: args.status,
+    previousPath: args.previousPath,
+    publishedBranch: args.publishedBranch,
+    baseBranch: args.baseBranch,
     expandUnchanged,
     onToggleExpandUnchanged,
   });

--- a/apps/web/components/editors/codemirror/codemirror-code-editor.external-link.test.tsx
+++ b/apps/web/components/editors/codemirror/codemirror-code-editor.external-link.test.tsx
@@ -1,0 +1,86 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { TooltipProvider } from "@kandev/ui/tooltip";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@uiw/react-codemirror", () => ({
+  default: () => <div data-testid="codemirror" />,
+}));
+
+vi.mock("./use-codemirror-editor-state", () => ({
+  useCodeMirrorEditorState: () => ({
+    comments: [],
+    diffStats: null,
+    extensions: [],
+    floatingButtonPos: null,
+    textSelection: null,
+    commentView: null,
+    wrapEnabled: false,
+    setWrapEnabled: vi.fn(),
+    handleChange: vi.fn(),
+  }),
+}));
+
+vi.mock("./use-codemirror-walkthrough-range", () => ({
+  useCodeMirrorWalkthroughRange: () => null,
+}));
+
+vi.mock("@/components/editors/external-vcs-file-link", () => ({
+  ExternalVcsFileLink: (props: Record<string, unknown>) =>
+    props.sessionId ? (
+      <span data-testid="external-vcs-file-link-props" data-props={JSON.stringify(props)} />
+    ) : null,
+  useExternalVcsFileStatus: () => ({ status: "renamed", old_path: "docs/old.md" }),
+}));
+
+import { CodeMirrorCodeEditor } from "./codemirror-code-editor";
+
+afterEach(cleanup);
+
+const baseProps = {
+  path: "docs/new.md",
+  content: "# New",
+  originalContent: "# Old",
+  isDirty: false,
+  isSaving: false,
+  onChange: vi.fn(),
+  onSave: vi.fn(),
+};
+
+describe("CodeMirrorCodeEditor external file action", () => {
+  it("forwards the editor's repository and live rename context", () => {
+    render(
+      <TooltipProvider>
+        <CodeMirrorCodeEditor
+          {...baseProps}
+          sessionId="session-1"
+          taskId="task-1"
+          repositoryId="repo-1"
+          repo="frontend"
+        />
+      </TooltipProvider>,
+    );
+
+    const props = JSON.parse(
+      screen.getByTestId("external-vcs-file-link-props").dataset.props ?? "{}",
+    );
+    expect(props).toEqual({
+      filePath: "docs/new.md",
+      previousPath: "docs/old.md",
+      status: "renamed",
+      taskId: "task-1",
+      sessionId: "session-1",
+      repositoryName: "frontend",
+      size: "sm",
+    });
+  });
+
+  it("omits the action without external repository context", () => {
+    render(
+      <TooltipProvider>
+        <CodeMirrorCodeEditor {...baseProps} />
+      </TooltipProvider>,
+    );
+
+    expect(screen.queryByTestId("external-vcs-file-link-props")).toBeNull();
+  });
+});

--- a/apps/web/components/editors/codemirror/codemirror-code-editor.tsx
+++ b/apps/web/components/editors/codemirror/codemirror-code-editor.tsx
@@ -22,6 +22,10 @@ import { vscodeDark } from "@uiw/codemirror-theme-vscode";
 import { EditorCommentPopover } from "@/components/task/editor-comment-popover";
 import { CommentViewPopover } from "@/components/task/comment-view-popover";
 import { PanelHeaderBarSplit } from "@/components/task/panel-primitives";
+import {
+  ExternalVcsFileLink,
+  useExternalVcsFileStatus,
+} from "@/components/editors/external-vcs-file-link";
 import { useCodeMirrorEditorState } from "./use-codemirror-editor-state";
 import { useCodeMirrorWalkthroughRange } from "./use-codemirror-walkthrough-range";
 
@@ -37,6 +41,8 @@ type FileEditorContentProps = {
   vcsDiff?: string;
   isSaving: boolean;
   sessionId?: string;
+  taskId?: string | null;
+  repositoryId?: string | null;
   worktreePath?: string;
   repo?: string;
   enableComments?: boolean;
@@ -205,6 +211,9 @@ function CodeMirrorToolbar({
   wrapEnabled,
   enableComments,
   sessionId,
+  taskId,
+  repositoryId,
+  repositoryName,
   commentCount,
   hasRemoteUpdate,
   onToggleWrap,
@@ -221,6 +230,9 @@ function CodeMirrorToolbar({
   wrapEnabled: boolean;
   enableComments: boolean;
   sessionId?: string;
+  taskId?: string | null;
+  repositoryId?: string | null;
+  repositoryName?: string;
   commentCount: number;
   hasRemoteUpdate?: boolean;
   onToggleWrap: () => void;
@@ -229,6 +241,7 @@ function CodeMirrorToolbar({
   onDelete?: () => void;
   onToggleMarkdownPreview?: () => void;
 }) {
+  const fileStatus = useExternalVcsFileStatus(path, sessionId, repositoryName);
   return (
     <PanelHeaderBarSplit
       left={
@@ -257,6 +270,16 @@ function CodeMirrorToolbar({
           <CodeMirrorReloadButton
             hasRemoteUpdate={hasRemoteUpdate}
             onReloadFromAgent={onReloadFromAgent}
+          />
+          <ExternalVcsFileLink
+            filePath={path}
+            previousPath={fileStatus?.old_path}
+            status={fileStatus?.status}
+            taskId={taskId}
+            sessionId={sessionId}
+            repositoryId={repositoryName ? undefined : repositoryId}
+            repositoryName={repositoryName}
+            size="sm"
           />
           <CodeMirrorDeleteButton onDelete={onDelete} />
           <CodeMirrorSaveButton isDirty={isDirty} isSaving={isSaving} onSave={onSave} />
@@ -307,23 +330,9 @@ function CodeMirrorOverlays({ state }: { state: CodeMirrorEditorState }) {
   );
 }
 
-export function CodeMirrorCodeEditor({
-  path,
-  content,
-  originalContent,
-  isDirty,
-  hasRemoteUpdate = false,
-  isSaving,
-  sessionId,
-  worktreePath,
-  repo,
-  enableComments = false,
-  onToggleMarkdownPreview,
-  onChange,
-  onSave,
-  onReloadFromAgent,
-  onDelete,
-}: FileEditorContentProps) {
+function useCodeMirrorCodeEditorSetup(props: FileEditorContentProps) {
+  const { path, content, originalContent, isDirty, isSaving, sessionId, repo, enableComments } =
+    props;
   const wrapperRef = useRef<HTMLDivElement>(null);
   const editorAreaRef = useRef<HTMLDivElement>(null);
   const editorRef = useRef<ReactCodeMirrorRef>(null);
@@ -335,9 +344,9 @@ export function CodeMirrorCodeEditor({
     isDirty,
     isSaving,
     sessionId,
-    enableComments,
-    onChange,
-    onSave,
+    enableComments: enableComments ?? false,
+    onChange: props.onChange,
+    onSave: props.onSave,
     wrapperRef,
     editorRef,
   });
@@ -347,9 +356,30 @@ export function CodeMirrorCodeEditor({
     path,
     repo,
   });
-  const handleCreateEditor = useCallback((view: EditorView) => {
-    setEditorView(view);
-  }, []);
+  const handleCreateEditor = useCallback((view: EditorView) => setEditorView(view), []);
+  return { wrapperRef, editorAreaRef, editorRef, state, walkthroughRange, handleCreateEditor };
+}
+
+export function CodeMirrorCodeEditor(props: FileEditorContentProps) {
+  const {
+    path,
+    content,
+    isDirty,
+    hasRemoteUpdate = false,
+    isSaving,
+    sessionId,
+    taskId,
+    repositoryId,
+    worktreePath,
+    repo,
+    enableComments = false,
+    onToggleMarkdownPreview,
+    onSave,
+    onReloadFromAgent,
+    onDelete,
+  } = props;
+  const { wrapperRef, editorAreaRef, editorRef, state, walkthroughRange, handleCreateEditor } =
+    useCodeMirrorCodeEditorSetup(props);
 
   return (
     <div ref={wrapperRef} className="flex h-full flex-col rounded-lg">
@@ -362,6 +392,9 @@ export function CodeMirrorCodeEditor({
         wrapEnabled={state.wrapEnabled}
         enableComments={enableComments}
         sessionId={sessionId}
+        taskId={taskId}
+        repositoryId={repositoryId}
+        repositoryName={repo}
         commentCount={state.comments.length}
         hasRemoteUpdate={hasRemoteUpdate}
         onToggleWrap={() => state.setWrapEnabled(!state.wrapEnabled)}

--- a/apps/web/components/editors/external-vcs-file-link.test.tsx
+++ b/apps/web/components/editors/external-vcs-file-link.test.tsx
@@ -1,0 +1,91 @@
+import { cleanup, render, renderHook, screen } from "@testing-library/react";
+import { TooltipProvider } from "@kandev/ui/tooltip";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ExternalVcsFileURL } from "@/lib/utils/external-vcs-file-url";
+
+const mocks = vi.hoisted(() => ({
+  link: null as ExternalVcsFileURL | null,
+}));
+
+vi.mock("@/hooks/domains/workspace/use-external-vcs-file-link", () => ({
+  useExternalVcsFileLink: () => mocks.link,
+}));
+
+vi.mock("@/hooks/domains/session/use-session-git-status", () => ({
+  useSessionGitStatus: () => ({ files: { "src/app.ts": { status: "modified" } } }),
+  useSessionGitStatusByRepo: () => [
+    {
+      repository_name: "frontend",
+      status: { files: { "src/app.ts": { status: "renamed", old_path: "src/old.ts" } } },
+    },
+  ],
+}));
+
+import { ExternalVcsFileLink, useExternalVcsFileStatus } from "./external-vcs-file-link";
+
+function renderLink(size: "xs" | "sm" | "touch" = "xs") {
+  return render(
+    <TooltipProvider>
+      <ExternalVcsFileLink filePath="src/app.ts" size={size} />
+    </TooltipProvider>,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  mocks.link = null;
+});
+
+describe("ExternalVcsFileLink", () => {
+  it("selects file status from the exact repository", () => {
+    const { result } = renderHook(() =>
+      useExternalVcsFileStatus("src/app.ts", "session-1", "frontend"),
+    );
+
+    expect(result.current).toEqual({ status: "renamed", old_path: "src/old.ts" });
+  });
+
+  it.each([
+    ["github", "GitHub", "github-provider-icon"],
+    ["gitlab", "GitLab", "gitlab-provider-icon"],
+    ["azure_devops", "Azure DevOps", "azure-devops-icon"],
+  ] as const)("renders a branded, safe new-tab action for %s", (provider, label, iconTestId) => {
+    mocks.link = {
+      provider,
+      url: `https://example.com/${provider}/file`,
+      revision: "main",
+      path: "src/app.ts",
+    };
+
+    renderLink();
+
+    const link = screen.getByRole("link", { name: `Open file in ${label}` });
+    expect(link.getAttribute("href")).toBe(mocks.link.url);
+    expect(link.getAttribute("target")).toBe("_blank");
+    expect(link.getAttribute("rel")).toBe("noopener noreferrer");
+    expect(link.getAttribute("title")).toBe(`Open file in ${label}`);
+    expect(screen.getByTestId(iconTestId)).not.toBeNull();
+  });
+
+  it.each([
+    ["xs", "size-5"],
+    ["sm", "size-6"],
+    ["touch", "size-11"],
+  ] as const)("uses the %s action size", (size, expectedClass) => {
+    mocks.link = {
+      provider: "github",
+      url: "https://github.com/acme/web/blob/main/src/app.ts",
+      revision: "main",
+      path: "src/app.ts",
+    };
+
+    renderLink(size);
+
+    expect(screen.getByRole("link").classList.contains(expectedClass)).toBe(true);
+  });
+
+  it("renders nothing when no safe external URL resolves", () => {
+    renderLink();
+    expect(screen.queryByRole("link")).toBeNull();
+  });
+});

--- a/apps/web/components/editors/external-vcs-file-link.tsx
+++ b/apps/web/components/editors/external-vcs-file-link.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { IconBrandGithub, IconBrandGitlab } from "@tabler/icons-react";
+import { Button } from "@kandev/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
+import { AzureDevOpsIcon } from "@/components/icons/azure-devops-icon";
+import { useExternalVcsFileLink } from "@/hooks/domains/workspace/use-external-vcs-file-link";
+import type { UseExternalVcsFileLinkInput } from "@/hooks/domains/workspace/use-external-vcs-file-link";
+import {
+  useSessionGitStatus,
+  useSessionGitStatusByRepo,
+} from "@/hooks/domains/session/use-session-git-status";
+import type { ExternalVcsProvider } from "@/lib/utils/external-vcs-file-url";
+
+export type ExternalVcsFileLinkProps = UseExternalVcsFileLinkInput & {
+  size?: "xs" | "sm" | "touch";
+};
+
+const providerNames: Record<ExternalVcsProvider, string> = {
+  github: "GitHub",
+  gitlab: "GitLab",
+  azure_devops: "Azure DevOps",
+};
+
+const sizeClasses = {
+  xs: "size-5",
+  sm: "size-6",
+  touch: "size-11",
+} as const;
+
+function ProviderIcon({ provider }: { provider: ExternalVcsProvider }) {
+  if (provider === "github") {
+    return <IconBrandGithub data-testid="github-provider-icon" aria-hidden="true" />;
+  }
+  if (provider === "gitlab") {
+    return <IconBrandGitlab data-testid="gitlab-provider-icon" aria-hidden="true" />;
+  }
+  return <AzureDevOpsIcon />;
+}
+
+function buttonSize(size: NonNullable<ExternalVcsFileLinkProps["size"]>) {
+  if (size === "touch") return "icon" as const;
+  if (size === "xs") return "icon-xs" as const;
+  return "icon-sm" as const;
+}
+
+export function useExternalVcsFileStatus(
+  filePath: string,
+  sessionId?: string | null,
+  repositoryName?: string,
+) {
+  const gitStatus = useSessionGitStatus(sessionId ?? null);
+  const statusesByRepo = useSessionGitStatusByRepo(sessionId ?? null);
+  const status = repositoryName
+    ? statusesByRepo.find((entry) => entry.repository_name === repositoryName)?.status
+    : gitStatus;
+  return status?.files?.[filePath];
+}
+
+export function ExternalVcsFileLink({ size = "xs", ...input }: ExternalVcsFileLinkProps) {
+  const link = useExternalVcsFileLink(input);
+  if (!link) return null;
+
+  const label = `Open file in ${providerNames[link.provider]}`;
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          asChild
+          variant="ghost"
+          size={buttonSize(size)}
+          className={`${sizeClasses[size]} cursor-pointer text-muted-foreground hover:text-foreground`}
+        >
+          <a
+            href={link.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label={label}
+            title={label}
+          >
+            <ProviderIcon provider={link.provider} />
+          </a>
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>{label}</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/apps/web/components/editors/monaco/diff-viewer-toolbar.test.tsx
+++ b/apps/web/components/editors/monaco/diff-viewer-toolbar.test.tsx
@@ -1,0 +1,101 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { TooltipProvider } from "@kandev/ui/tooltip";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({ isMobile: false }));
+
+vi.mock("@/components/editors/external-vcs-file-link", () => ({
+  ExternalVcsFileLink: (props: Record<string, unknown>) => (
+    <span data-testid="external-vcs-file-link-props" data-props={JSON.stringify(props)} />
+  ),
+}));
+
+vi.mock("@/hooks/use-responsive-breakpoint", () => ({
+  useResponsiveBreakpoint: () => ({ isMobile: mocks.isMobile }),
+}));
+
+import { DiffViewerToolbar } from "./diff-viewer-toolbar";
+
+afterEach(() => {
+  cleanup();
+  mocks.isMobile = false;
+});
+
+describe("DiffViewerToolbar external file action", () => {
+  it("forwards Monaco diff repository, revision, and rename context", () => {
+    render(
+      <TooltipProvider>
+        <DiffViewerToolbar
+          data={{
+            filePath: "src/new-name.ts",
+            oldContent: "old",
+            newContent: "new",
+            additions: 1,
+            deletions: 1,
+          }}
+          sessionId="session-1"
+          taskId="task-1"
+          repositoryId="repo-1"
+          repositoryName="frontend"
+          status="renamed"
+          previousPath="src/old-name.ts"
+          publishedBranch="feature/external-links"
+          baseBranch="main"
+          foldUnchanged={false}
+          setFoldUnchanged={vi.fn()}
+          wordWrap={false}
+          setWordWrap={vi.fn()}
+          globalViewMode="split"
+          setGlobalViewMode={vi.fn()}
+          onCopyDiff={vi.fn()}
+        />
+      </TooltipProvider>,
+    );
+
+    const props = JSON.parse(
+      screen.getByTestId("external-vcs-file-link-props").dataset.props ?? "{}",
+    );
+    expect(props).toEqual({
+      filePath: "src/new-name.ts",
+      previousPath: "src/old-name.ts",
+      status: "renamed",
+      taskId: "task-1",
+      sessionId: "session-1",
+      repositoryId: "repo-1",
+      repositoryName: "frontend",
+      publishedBranch: "feature/external-links",
+      baseBranch: "main",
+      size: "xs",
+    });
+  });
+
+  it("uses the 44px touch action at the mobile breakpoint", () => {
+    mocks.isMobile = true;
+    render(
+      <TooltipProvider>
+        <DiffViewerToolbar
+          data={{
+            filePath: "src/app.ts",
+            oldContent: "old",
+            newContent: "new",
+            additions: 1,
+            deletions: 1,
+          }}
+          sessionId="session-1"
+          foldUnchanged={false}
+          setFoldUnchanged={vi.fn()}
+          wordWrap={false}
+          setWordWrap={vi.fn()}
+          globalViewMode="split"
+          setGlobalViewMode={vi.fn()}
+          onCopyDiff={vi.fn()}
+        />
+      </TooltipProvider>,
+    );
+
+    const props = JSON.parse(
+      screen.getByTestId("external-vcs-file-link-props").dataset.props ?? "{}",
+    );
+    expect(props.size).toBe("touch");
+  });
+});

--- a/apps/web/components/editors/monaco/diff-viewer-toolbar.tsx
+++ b/apps/web/components/editors/monaco/diff-viewer-toolbar.tsx
@@ -13,6 +13,8 @@ import {
 } from "@tabler/icons-react";
 import type { FileDiffData } from "@/lib/diff/types";
 import type { ViewMode } from "@/hooks/use-global-view-mode";
+import { ExternalVcsFileLink } from "@/components/editors/external-vcs-file-link";
+import { useResponsiveBreakpoint } from "@/hooks/use-responsive-breakpoint";
 
 interface DiffViewerToolbarProps {
   data: FileDiffData;
@@ -25,6 +27,14 @@ interface DiffViewerToolbarProps {
   onCopyDiff: () => void;
   onOpenFile?: (filePath: string) => void;
   onRevert?: (filePath: string) => void;
+  sessionId?: string;
+  taskId?: string | null;
+  repositoryId?: string | null;
+  repositoryName?: string;
+  status?: string | null;
+  previousPath?: string | null;
+  publishedBranch?: string | null;
+  baseBranch?: string | null;
 }
 
 const iconBtn = "h-6 w-6 p-0 cursor-pointer opacity-60 hover:opacity-100";
@@ -113,9 +123,30 @@ function DiffViewerActions({
   onCopyDiff,
   onOpenFile,
   onRevert,
+  sessionId,
+  taskId,
+  repositoryId,
+  repositoryName,
+  status,
+  previousPath,
+  publishedBranch,
+  baseBranch,
 }: DiffViewerActionsProps) {
+  const { isMobile } = useResponsiveBreakpoint();
   return (
     <div className="flex items-center gap-1">
+      <ExternalVcsFileLink
+        filePath={filePath}
+        previousPath={previousPath}
+        status={status}
+        taskId={taskId}
+        sessionId={sessionId}
+        repositoryId={repositoryId}
+        repositoryName={repositoryName}
+        publishedBranch={publishedBranch}
+        baseBranch={baseBranch}
+        size={isMobile ? "touch" : "xs"}
+      />
       <Tooltip>
         <TooltipTrigger asChild>
           <Button variant="ghost" size="sm" className={iconBtn} onClick={onCopyDiff}>
@@ -177,6 +208,14 @@ export function DiffViewerToolbar({
   onCopyDiff,
   onOpenFile,
   onRevert,
+  sessionId,
+  taskId,
+  repositoryId,
+  repositoryName,
+  status,
+  previousPath,
+  publishedBranch,
+  baseBranch,
 }: DiffViewerToolbarProps) {
   return (
     <div className="flex items-center justify-between px-3 py-1.5 border-b border-border/50 bg-card/50 rounded-t-md text-xs text-muted-foreground">
@@ -192,6 +231,14 @@ export function DiffViewerToolbar({
         onCopyDiff={onCopyDiff}
         onOpenFile={onOpenFile}
         onRevert={onRevert}
+        sessionId={sessionId}
+        taskId={taskId}
+        repositoryId={repositoryId}
+        repositoryName={repositoryName}
+        status={status}
+        previousPath={previousPath}
+        publishedBranch={publishedBranch}
+        baseBranch={baseBranch}
       />
     </div>
   );

--- a/apps/web/components/editors/monaco/monaco-code-editor.tsx
+++ b/apps/web/components/editors/monaco/monaco-code-editor.tsx
@@ -181,10 +181,6 @@ export function MonacoCodeEditor(props: MonacoCodeEditorProps) {
     worktreePath,
     repo,
     enableComments = false,
-    onToggleMarkdownPreview,
-    onSave,
-    onReloadFromAgent,
-    onDelete,
   } = props;
   const { resolvedTheme } = useTheme();
   const { wrapperRef, language, state, lsp, diffStats, options } = useMonacoCodeEditorSetup(props);
@@ -200,6 +196,7 @@ export function MonacoCodeEditor(props: MonacoCodeEditorProps) {
     <div ref={wrapperRef} className="flex h-full flex-col rounded-lg">
       <MonacoEditorToolbar
         path={path}
+        repositoryName={repo}
         worktreePath={worktreePath}
         isDirty={isDirty}
         isSaving={isSaving}
@@ -216,10 +213,10 @@ export function MonacoCodeEditor(props: MonacoCodeEditorProps) {
         onToggleLsp={lsp.toggleLsp}
         onToggleWrap={() => state.setWrapEnabled(!state.wrapEnabled)}
         onToggleDiffIndicators={() => state.setShowDiffIndicators(!state.showDiffIndicators)}
-        onSave={onSave}
-        onReloadFromAgent={onReloadFromAgent}
-        onDelete={onDelete}
-        onToggleMarkdownPreview={onToggleMarkdownPreview}
+        onSave={props.onSave}
+        onReloadFromAgent={props.onReloadFromAgent}
+        onDelete={props.onDelete}
+        onToggleMarkdownPreview={props.onToggleMarkdownPreview}
       />
       <div className="flex-1 overflow-hidden relative" ref={editorAreaRef}>
         <Editor

--- a/apps/web/components/editors/monaco/monaco-diff-viewer.tsx
+++ b/apps/web/components/editors/monaco/monaco-diff-viewer.tsx
@@ -39,6 +39,13 @@ interface MonacoDiffViewerProps {
   wordWrap?: boolean;
   editable?: boolean;
   onModifiedContentChange?: (filePath: string, content: string) => void;
+  repo?: string;
+  taskId?: string | null;
+  repositoryId?: string | null;
+  status?: string | null;
+  previousPath?: string | null;
+  publishedBranch?: string | null;
+  externalBaseBranch?: string | null;
 }
 
 function useMonacoDiffViewerState(props: MonacoDiffViewerProps) {
@@ -170,6 +177,14 @@ export function MonacoDiffViewer(props: MonacoDiffViewerProps) {
           onCopyDiff={() => navigator.clipboard.writeText(state.diff ?? "")}
           onOpenFile={onOpenFile}
           onRevert={onRevert}
+          sessionId={props.sessionId}
+          taskId={props.taskId}
+          repositoryId={props.repositoryId}
+          repositoryName={props.repo}
+          status={props.status}
+          previousPath={props.previousPath}
+          publishedBranch={props.publishedBranch}
+          baseBranch={props.externalBaseBranch}
         />
       )}
       <div

--- a/apps/web/components/editors/monaco/monaco-editor-toolbar.test.tsx
+++ b/apps/web/components/editors/monaco/monaco-editor-toolbar.test.tsx
@@ -1,0 +1,62 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { TooltipProvider } from "@kandev/ui/tooltip";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/components/editors/external-vcs-file-link", () => ({
+  ExternalVcsFileLink: (props: Record<string, unknown>) => (
+    <span data-testid="external-vcs-file-link-props" data-props={JSON.stringify(props)} />
+  ),
+  useExternalVcsFileStatus: () => ({ status: "renamed", old_path: "src/old-name.ts" }),
+}));
+
+vi.mock("@/components/editors/file-actions-dropdown", () => ({
+  FileActionsDropdown: () => <span data-testid="file-actions-dropdown" />,
+}));
+
+vi.mock("@/components/editors/lsp-status-button", () => ({
+  LspStatusButton: () => <span data-testid="lsp-status" />,
+}));
+
+import { MonacoEditorToolbar } from "./monaco-editor-toolbar";
+
+afterEach(cleanup);
+
+describe("MonacoEditorToolbar external file action", () => {
+  it("uses the editor's exact repository and live file status", () => {
+    render(
+      <TooltipProvider>
+        <MonacoEditorToolbar
+          path="src/new-name.ts"
+          repositoryName="frontend"
+          isDirty={false}
+          isSaving={false}
+          diffStats={null}
+          wrapEnabled={false}
+          showDiffIndicators={false}
+          enableComments={false}
+          sessionId="session-1"
+          commentCount={0}
+          lspStatus={{ state: "disabled" }}
+          lspLanguage={null}
+          onToggleLsp={vi.fn()}
+          onToggleWrap={vi.fn()}
+          onToggleDiffIndicators={vi.fn()}
+          onSave={vi.fn()}
+        />
+      </TooltipProvider>,
+    );
+
+    const props = JSON.parse(
+      screen.getByTestId("external-vcs-file-link-props").dataset.props ?? "{}",
+    );
+    expect(props).toEqual({
+      filePath: "src/new-name.ts",
+      previousPath: "src/old-name.ts",
+      status: "renamed",
+      sessionId: "session-1",
+      repositoryName: "frontend",
+      size: "sm",
+    });
+    expect(screen.getByTestId("file-actions-dropdown")).toBeTruthy();
+  });
+});

--- a/apps/web/components/editors/monaco/monaco-editor-toolbar.tsx
+++ b/apps/web/components/editors/monaco/monaco-editor-toolbar.tsx
@@ -17,6 +17,10 @@ import {
 import { formatDiffStats } from "@/lib/utils/file-diff";
 import { toRelativePath } from "@/lib/utils";
 import { FileActionsDropdown } from "@/components/editors/file-actions-dropdown";
+import {
+  ExternalVcsFileLink,
+  useExternalVcsFileStatus,
+} from "@/components/editors/external-vcs-file-link";
 import { PanelHeaderBarSplit } from "@/components/task/panel-primitives";
 import { LspStatusButton } from "@/components/editors/lsp-status-button";
 import type { LspStatus } from "@/lib/lsp/lsp-client-manager";
@@ -218,6 +222,7 @@ function MarkdownPreviewButton({ onTogglePreview }: { onTogglePreview: () => voi
 
 interface MonacoEditorToolbarProps {
   path: string;
+  repositoryName?: string;
   worktreePath?: string;
   isDirty: boolean;
   isSaving: boolean;
@@ -242,6 +247,7 @@ interface MonacoEditorToolbarProps {
 
 export function MonacoEditorToolbar({
   path,
+  repositoryName,
   worktreePath,
   isDirty,
   isSaving,
@@ -263,6 +269,7 @@ export function MonacoEditorToolbar({
   onDelete,
   onToggleMarkdownPreview,
 }: MonacoEditorToolbarProps) {
+  const fileStatus = useExternalVcsFileStatus(path, sessionId, repositoryName);
   return (
     <PanelHeaderBarSplit
       left={
@@ -294,6 +301,14 @@ export function MonacoEditorToolbar({
           <ReloadFromAgentButton
             hasRemoteUpdate={hasRemoteUpdate}
             onReloadFromAgent={onReloadFromAgent}
+          />
+          <ExternalVcsFileLink
+            filePath={path}
+            previousPath={fileStatus?.old_path}
+            status={fileStatus?.status}
+            sessionId={sessionId}
+            repositoryName={repositoryName}
+            size="sm"
           />
           <FileActionsDropdown filePath={path} sessionId={sessionId} size="sm" />
           <DeleteButton onDelete={onDelete} />

--- a/apps/web/components/review/review-diff-header.test.tsx
+++ b/apps/web/components/review/review-diff-header.test.tsx
@@ -1,0 +1,60 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ReviewFile } from "./types";
+
+vi.mock("./review-diff-toolbar", () => ({
+  FileDiffToolbar: (props: Record<string, unknown>) => (
+    <span data-testid="review-toolbar-props" data-props={JSON.stringify(props)} />
+  ),
+}));
+
+import { ReviewDiffHeader } from "./review-diff-header";
+
+afterEach(cleanup);
+
+const file: ReviewFile = {
+  path: "src/app.ts",
+  diff: "@@ -1 +1 @@",
+  status: "modified",
+  additions: 1,
+  deletions: 1,
+  staged: false,
+  source: "pr",
+  repository_id: "repo-2",
+  repository_name: "frontend",
+};
+
+describe("ReviewDiffHeader external context", () => {
+  it("keeps the exact repo base and rejects a published branch from another repo", () => {
+    render(
+      <ReviewDiffHeader
+        file={file}
+        isReviewed={false}
+        isStale={false}
+        sessionId="session-1"
+        collapsed={false}
+        wordWrap={false}
+        expandUnchanged={false}
+        baseBranchByRepo={{ frontend: "develop" }}
+        taskId="task-1"
+        publishedPRBranch="feature/other-repo"
+        publishedPRRepositoryId="repo-1"
+        onCheckboxChange={vi.fn()}
+        onDiscard={vi.fn()}
+        onToggleCollapse={vi.fn()}
+        onToggleExpandUnchanged={vi.fn()}
+        onToggleWordWrap={vi.fn()}
+      />,
+    );
+
+    const props = JSON.parse(screen.getByTestId("review-toolbar-props").dataset.props ?? "{}");
+    expect(props).toMatchObject({
+      filePath: "src/app.ts",
+      repositoryId: "repo-2",
+      repo: "frontend",
+      baseBranch: "develop",
+      taskId: "task-1",
+    });
+    expect(props).not.toHaveProperty("publishedBranch");
+  });
+});

--- a/apps/web/components/review/review-diff-header.test.tsx
+++ b/apps/web/components/review/review-diff-header.test.tsx
@@ -58,6 +58,33 @@ describe("ReviewDiffHeader external context", () => {
     expect(props).not.toHaveProperty("publishedBranch");
   });
 
+  it("does not inherit a published PR without a matching published repository", () => {
+    render(
+      <ReviewDiffHeader
+        file={file}
+        isReviewed={false}
+        isStale={false}
+        sessionId="session-1"
+        collapsed={false}
+        wordWrap={false}
+        expandUnchanged={false}
+        baseBranchByRepo={{ frontend: "develop" }}
+        taskId="task-1"
+        publishedPRBranch="feature/unknown-repository"
+        publishedPRNumber={42}
+        onCheckboxChange={vi.fn()}
+        onDiscard={vi.fn()}
+        onToggleCollapse={vi.fn()}
+        onToggleExpandUnchanged={vi.fn()}
+        onToggleWordWrap={vi.fn()}
+      />,
+    );
+
+    const props = JSON.parse(screen.getByTestId("review-toolbar-props").dataset.props ?? "{}");
+    expect(props).not.toHaveProperty("publishedBranch");
+    expect(props).not.toHaveProperty("publishedPullRequestNumber");
+  });
+
   it("forwards the GitHub PR number with its published branch", () => {
     render(
       <ReviewDiffHeader

--- a/apps/web/components/review/review-diff-header.test.tsx
+++ b/apps/web/components/review/review-diff-header.test.tsx
@@ -57,4 +57,34 @@ describe("ReviewDiffHeader external context", () => {
     });
     expect(props).not.toHaveProperty("publishedBranch");
   });
+
+  it("forwards the GitHub PR number with its published branch", () => {
+    render(
+      <ReviewDiffHeader
+        file={{ ...file, repository_id: "repo-1" }}
+        isReviewed={false}
+        isStale={false}
+        sessionId="session-1"
+        collapsed={false}
+        wordWrap={false}
+        expandUnchanged={false}
+        baseBranchByRepo={{ frontend: "main" }}
+        taskId="task-1"
+        publishedPRBranch="contributor:feature/share"
+        publishedPRNumber={42}
+        publishedPRRepositoryId="repo-1"
+        onCheckboxChange={vi.fn()}
+        onDiscard={vi.fn()}
+        onToggleCollapse={vi.fn()}
+        onToggleExpandUnchanged={vi.fn()}
+        onToggleWordWrap={vi.fn()}
+      />,
+    );
+
+    const props = JSON.parse(screen.getByTestId("review-toolbar-props").dataset.props ?? "{}");
+    expect(props).toMatchObject({
+      publishedBranch: "contributor:feature/share",
+      publishedPullRequestNumber: 42,
+    });
+  });
 });

--- a/apps/web/components/review/review-diff-header.test.tsx
+++ b/apps/web/components/review/review-diff-header.test.tsx
@@ -71,7 +71,6 @@ describe("ReviewDiffHeader external context", () => {
         baseBranchByRepo={{ frontend: "develop" }}
         taskId="task-1"
         publishedPRBranch="feature/unknown-repository"
-        publishedPRNumber={42}
         onCheckboxChange={vi.fn()}
         onDiscard={vi.fn()}
         onToggleCollapse={vi.fn()}
@@ -85,7 +84,7 @@ describe("ReviewDiffHeader external context", () => {
     expect(props).not.toHaveProperty("publishedPullRequestNumber");
   });
 
-  it("forwards the GitHub PR number with its published branch", () => {
+  it("forwards the published branch without guessing a fork PR ref", () => {
     render(
       <ReviewDiffHeader
         file={{ ...file, repository_id: "repo-1" }}
@@ -98,7 +97,6 @@ describe("ReviewDiffHeader external context", () => {
         baseBranchByRepo={{ frontend: "main" }}
         taskId="task-1"
         publishedPRBranch="contributor:feature/share"
-        publishedPRNumber={42}
         publishedPRRepositoryId="repo-1"
         onCheckboxChange={vi.fn()}
         onDiscard={vi.fn()}
@@ -111,7 +109,7 @@ describe("ReviewDiffHeader external context", () => {
     const props = JSON.parse(screen.getByTestId("review-toolbar-props").dataset.props ?? "{}");
     expect(props).toMatchObject({
       publishedBranch: "contributor:feature/share",
-      publishedPullRequestNumber: 42,
     });
+    expect(props).not.toHaveProperty("publishedPullRequestNumber");
   });
 });

--- a/apps/web/components/review/review-diff-header.tsx
+++ b/apps/web/components/review/review-diff-header.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { IconAlertTriangle, IconChevronDown, IconChevronRight } from "@tabler/icons-react";
+import { Checkbox } from "@kandev/ui/checkbox";
+import { FileStatusIcon } from "@/components/shared/file-status-icon";
+import type { ReviewFile } from "./types";
+import { FileDiffToolbar } from "./review-diff-toolbar";
+
+export type ReviewExternalLinkContext = {
+  baseBranchByRepo: Record<string, string>;
+  fallbackBaseBranch?: string;
+  taskId?: string | null;
+  publishedPRBranch?: string;
+  publishedPRRepositoryId?: string;
+};
+
+type ReviewDiffHeaderProps = ReviewExternalLinkContext & {
+  file: ReviewFile;
+  isReviewed: boolean;
+  isStale: boolean;
+  sessionId: string;
+  collapsed: boolean;
+  wordWrap: boolean;
+  expandUnchanged: boolean;
+  onCheckboxChange: (checked: boolean | "indeterminate") => void;
+  onDiscard: () => void;
+  onOpenFile?: (filePath: string, repo?: string) => void;
+  onPreviewMarkdown?: (filePath: string) => void;
+  onToggleCollapse: () => void;
+  onToggleExpandUnchanged: () => void;
+  onToggleWordWrap: () => void;
+};
+
+export function ReviewDiffHeader({
+  file,
+  isReviewed,
+  isStale,
+  collapsed,
+  wordWrap,
+  expandUnchanged,
+  sessionId,
+  onCheckboxChange,
+  onDiscard,
+  onOpenFile,
+  onPreviewMarkdown,
+  onToggleCollapse,
+  onToggleExpandUnchanged,
+  onToggleWordWrap,
+  baseBranchByRepo,
+  fallbackBaseBranch,
+  taskId,
+  publishedPRBranch,
+  publishedPRRepositoryId,
+}: ReviewDiffHeaderProps) {
+  const publishedBranch =
+    file.source === "pr" &&
+    (!file.repository_id ||
+      !publishedPRRepositoryId ||
+      file.repository_id === publishedPRRepositoryId)
+      ? publishedPRBranch
+      : undefined;
+  const baseBranch =
+    baseBranchByRepo[file.repository_name ?? ""] ??
+    (file.repository_name ? undefined : fallbackBaseBranch);
+
+  return (
+    <div
+      data-testid="review-file-header"
+      data-file-path={file.path}
+      className="sticky top-0 z-10 flex items-center gap-2 px-4 py-2 bg-card/95 backdrop-blur-sm border-b border-border/50"
+    >
+      <Checkbox
+        checked={isReviewed}
+        onCheckedChange={onCheckboxChange}
+        className="h-4 w-4 cursor-pointer"
+      />
+      <button
+        onClick={onToggleCollapse}
+        className="flex items-center gap-1.5 flex-1 min-w-0 cursor-pointer text-left hover:text-foreground"
+      >
+        {collapsed ? (
+          <IconChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+        ) : (
+          <IconChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+        )}
+        <span className="text-[13px] font-medium truncate">{file.path}</span>
+      </button>
+      <FileStatusIcon status={file.status} oldPath={file.old_path} className="sm:hidden" />
+      {isStale && (
+        <span className="flex items-center gap-1 text-xs text-yellow-500">
+          <IconAlertTriangle className="h-3.5 w-3.5" />
+          changed
+        </span>
+      )}
+      <span className="text-xs text-muted-foreground">
+        {file.additions > 0 && <span className="text-emerald-500">+{file.additions}</span>}
+        {file.additions > 0 && file.deletions > 0 && " / "}
+        {file.deletions > 0 && <span className="text-rose-500">-{file.deletions}</span>}
+      </span>
+      <FileDiffToolbar
+        diff={file.diff}
+        filePath={file.path}
+        sessionId={sessionId}
+        source={file.source}
+        previousPath={file.old_path}
+        status={file.status}
+        taskId={taskId}
+        repositoryId={file.repository_id}
+        publishedBranch={publishedBranch}
+        baseBranch={baseBranch}
+        wordWrap={wordWrap}
+        expandUnchanged={expandUnchanged}
+        onDiscard={onDiscard}
+        onOpenFile={onOpenFile}
+        onPreviewMarkdown={onPreviewMarkdown}
+        onToggleExpandUnchanged={onToggleExpandUnchanged}
+        onToggleWordWrap={onToggleWordWrap}
+        repo={file.repository_name}
+      />
+    </div>
+  );
+}

--- a/apps/web/components/review/review-diff-header.tsx
+++ b/apps/web/components/review/review-diff-header.tsx
@@ -55,10 +55,7 @@ export function ReviewDiffHeader({
   publishedPRRepositoryId,
 }: ReviewDiffHeaderProps) {
   const hasPublishedPR =
-    file.source === "pr" &&
-    (!file.repository_id ||
-      !publishedPRRepositoryId ||
-      file.repository_id === publishedPRRepositoryId);
+    file.source === "pr" && (!file.repository_id || file.repository_id === publishedPRRepositoryId);
   const publishedBranch = hasPublishedPR ? publishedPRBranch : undefined;
   const publishedPullRequestNumber = hasPublishedPR ? publishedPRNumber : undefined;
   const baseBranch =

--- a/apps/web/components/review/review-diff-header.tsx
+++ b/apps/web/components/review/review-diff-header.tsx
@@ -11,6 +11,7 @@ export type ReviewExternalLinkContext = {
   fallbackBaseBranch?: string;
   taskId?: string | null;
   publishedPRBranch?: string;
+  publishedPRNumber?: number;
   publishedPRRepositoryId?: string;
 };
 
@@ -50,15 +51,16 @@ export function ReviewDiffHeader({
   fallbackBaseBranch,
   taskId,
   publishedPRBranch,
+  publishedPRNumber,
   publishedPRRepositoryId,
 }: ReviewDiffHeaderProps) {
-  const publishedBranch =
+  const hasPublishedPR =
     file.source === "pr" &&
     (!file.repository_id ||
       !publishedPRRepositoryId ||
-      file.repository_id === publishedPRRepositoryId)
-      ? publishedPRBranch
-      : undefined;
+      file.repository_id === publishedPRRepositoryId);
+  const publishedBranch = hasPublishedPR ? publishedPRBranch : undefined;
+  const publishedPullRequestNumber = hasPublishedPR ? publishedPRNumber : undefined;
   const baseBranch =
     baseBranchByRepo[file.repository_name ?? ""] ??
     (file.repository_name ? undefined : fallbackBaseBranch);
@@ -107,6 +109,7 @@ export function ReviewDiffHeader({
         taskId={taskId}
         repositoryId={file.repository_id}
         publishedBranch={publishedBranch}
+        publishedPullRequestNumber={publishedPullRequestNumber}
         baseBranch={baseBranch}
         wordWrap={wordWrap}
         expandUnchanged={expandUnchanged}

--- a/apps/web/components/review/review-diff-header.tsx
+++ b/apps/web/components/review/review-diff-header.tsx
@@ -11,7 +11,6 @@ export type ReviewExternalLinkContext = {
   fallbackBaseBranch?: string;
   taskId?: string | null;
   publishedPRBranch?: string;
-  publishedPRNumber?: number;
   publishedPRRepositoryId?: string;
 };
 
@@ -51,13 +50,11 @@ export function ReviewDiffHeader({
   fallbackBaseBranch,
   taskId,
   publishedPRBranch,
-  publishedPRNumber,
   publishedPRRepositoryId,
 }: ReviewDiffHeaderProps) {
   const hasPublishedPR =
     file.source === "pr" && (!file.repository_id || file.repository_id === publishedPRRepositoryId);
   const publishedBranch = hasPublishedPR ? publishedPRBranch : undefined;
-  const publishedPullRequestNumber = hasPublishedPR ? publishedPRNumber : undefined;
   const baseBranch =
     baseBranchByRepo[file.repository_name ?? ""] ??
     (file.repository_name ? undefined : fallbackBaseBranch);
@@ -106,7 +103,6 @@ export function ReviewDiffHeader({
         taskId={taskId}
         repositoryId={file.repository_id}
         publishedBranch={publishedBranch}
-        publishedPullRequestNumber={publishedPullRequestNumber}
         baseBranch={baseBranch}
         wordWrap={wordWrap}
         expandUnchanged={expandUnchanged}

--- a/apps/web/components/review/review-diff-list-grouping.test.tsx
+++ b/apps/web/components/review/review-diff-list-grouping.test.tsx
@@ -16,6 +16,12 @@ vi.mock("@/components/editors/file-actions-dropdown", () => ({
   FileActionsDropdown: () => null,
 }));
 
+// External link resolution is unrelated to grouping and requires a fully
+// hydrated repository store, which this focused test intentionally omits.
+vi.mock("@/components/editors/external-vcs-file-link", () => ({
+  ExternalVcsFileLink: () => null,
+}));
+
 vi.mock("@/lib/ws/connection", () => ({ getWebSocketClient: () => null }));
 vi.mock("@/lib/ws/workspace-files", () => ({
   requestFileContent: vi.fn(),

--- a/apps/web/components/review/review-diff-list.tsx
+++ b/apps/web/components/review/review-diff-list.tsx
@@ -1,10 +1,7 @@
 "use client";
 
 import { memo, useEffect, useMemo, useRef, useState, useCallback } from "react";
-import { IconAlertTriangle, IconChevronDown, IconChevronRight } from "@tabler/icons-react";
-import { Checkbox } from "@kandev/ui/checkbox";
 import { FileDiffViewer, DiffErrorBoundary } from "@/components/diff";
-import { FileStatusIcon } from "@/components/shared/file-status-icon";
 import type { RevertBlockInfo } from "@/components/diff";
 import { getWebSocketClient } from "@/lib/ws/connection";
 import { requestFileContent, updateFileContent } from "@/lib/ws/workspace-files";
@@ -22,8 +19,9 @@ import {
 } from "./types";
 import type { ReviewFile } from "./types";
 import { RepoGroupHeader } from "./review-diff-list-groups";
-import { FileDiffToolbar } from "./review-diff-toolbar";
+import { ReviewDiffHeader, type ReviewExternalLinkContext } from "./review-diff-header";
 import { groupByRepositoryName } from "@/lib/group-by-repo";
+import { useActiveTaskPR } from "@/hooks/domains/github/use-task-pr";
 
 type ReviewDiffListProps = {
   files: ReviewFile[];
@@ -60,6 +58,7 @@ export const ReviewDiffList = memo(function ReviewDiffList({
   // multiple repos a committed file lacking `repository_name` must NOT borrow
   // an arbitrary repo's base branch, so the fallback stays undefined there.
   const activeTaskId = useAppStore((state) => state.tasks.activeTaskId);
+  const activeTaskPR = useActiveTaskPR();
   const baseBranchByRepo = useBaseBranchByRepo(activeTaskId);
   const fallbackBaseBranch = useMemo(() => {
     const branches = Object.values(baseBranchByRepo);
@@ -109,8 +108,13 @@ export const ReviewDiffList = memo(function ReviewDiffList({
                 onPreviewMarkdown={onPreviewMarkdown}
                 sectionRef={fileRefs.get(key)}
                 scrollContainer={scrollContainerRef}
-                baseBranchByRepo={baseBranchByRepo}
-                fallbackBaseBranch={fallbackBaseBranch}
+                externalLinkContext={{
+                  baseBranchByRepo,
+                  fallbackBaseBranch,
+                  taskId: activeTaskId,
+                  publishedPRBranch: activeTaskPR?.head_branch,
+                  publishedPRRepositoryId: activeTaskPR?.repository_id,
+                }}
               />
             );
           })}
@@ -144,8 +148,7 @@ type FileDiffSectionProps = {
   scrollContainer: React.RefObject<HTMLDivElement | null>;
   /** Per-repo base branches + single-repo fallback, resolved once by the list
    *  and shared across rows so diff expansion can fetch the correct old side. */
-  baseBranchByRepo: Record<string, string>;
-  fallbackBaseBranch?: string;
+  externalLinkContext: ReviewExternalLinkContext;
 };
 
 function useLazyVisible(scrollContainer: React.RefObject<HTMLDivElement | null>) {
@@ -215,91 +218,6 @@ function useAutoMarkOnScroll({
     return () => observer.disconnect();
   }, [autoMarkOnScroll, fileKey, isReviewed, isStale, onToggleReviewed, scrollContainer]);
   return scrollSentinelRef;
-}
-
-type FileDiffHeaderProps = {
-  file: ReviewFile;
-  isReviewed: boolean;
-  isStale: boolean;
-  sessionId: string;
-  collapsed: boolean;
-  wordWrap: boolean;
-  expandUnchanged: boolean;
-  onCheckboxChange: (checked: boolean | "indeterminate") => void;
-  onDiscard: () => void;
-  onOpenFile?: (filePath: string, repo?: string) => void;
-  onPreviewMarkdown?: (filePath: string) => void;
-  onToggleCollapse: () => void;
-  onToggleExpandUnchanged: () => void;
-  onToggleWordWrap: () => void;
-};
-
-function FileDiffHeader({
-  file,
-  isReviewed,
-  isStale,
-  collapsed,
-  wordWrap,
-  expandUnchanged,
-  sessionId,
-  onCheckboxChange,
-  onDiscard,
-  onOpenFile,
-  onPreviewMarkdown,
-  onToggleCollapse,
-  onToggleExpandUnchanged,
-  onToggleWordWrap,
-}: FileDiffHeaderProps) {
-  return (
-    <div
-      data-testid="review-file-header"
-      data-file-path={file.path}
-      className="sticky top-0 z-10 flex items-center gap-2 px-4 py-2 bg-card/95 backdrop-blur-sm border-b border-border/50"
-    >
-      <Checkbox
-        checked={isReviewed}
-        onCheckedChange={onCheckboxChange}
-        className="h-4 w-4 cursor-pointer"
-      />
-      <button
-        onClick={onToggleCollapse}
-        className="flex items-center gap-1.5 flex-1 min-w-0 cursor-pointer text-left hover:text-foreground"
-      >
-        {collapsed ? (
-          <IconChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-        ) : (
-          <IconChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-        )}
-        <span className="text-[13px] font-medium truncate">{file.path}</span>
-      </button>
-      <FileStatusIcon status={file.status} oldPath={file.old_path} className="sm:hidden" />
-      {isStale && (
-        <span className="flex items-center gap-1 text-xs text-yellow-500">
-          <IconAlertTriangle className="h-3.5 w-3.5" />
-          changed
-        </span>
-      )}
-      <span className="text-xs text-muted-foreground">
-        {file.additions > 0 && <span className="text-emerald-500">+{file.additions}</span>}
-        {file.additions > 0 && file.deletions > 0 && " / "}
-        {file.deletions > 0 && <span className="text-rose-500">-{file.deletions}</span>}
-      </span>
-      <FileDiffToolbar
-        diff={file.diff}
-        filePath={file.path}
-        sessionId={sessionId}
-        source={file.source}
-        wordWrap={wordWrap}
-        expandUnchanged={expandUnchanged}
-        onDiscard={onDiscard}
-        onOpenFile={onOpenFile}
-        onPreviewMarkdown={onPreviewMarkdown}
-        onToggleExpandUnchanged={onToggleExpandUnchanged}
-        onToggleWordWrap={onToggleWordWrap}
-        repo={file.repository_name}
-      />
-    </div>
-  );
 }
 
 function useCommentRunHandler(sessionId: string) {
@@ -508,8 +426,7 @@ function FileDiffSection({
   onPreviewMarkdown,
   sectionRef,
   scrollContainer,
-  baseBranchByRepo,
-  fallbackBaseBranch,
+  externalLinkContext,
 }: FileDiffSectionProps) {
   const [collapsed, setCollapsed] = useState(false);
   const [expandUnchanged, setExpandUnchanged] = useState(false);
@@ -556,14 +473,14 @@ function FileDiffSection({
 
   const { enableExpansion, baseRef } = resolveDiffExpansion(
     file,
-    baseBranchByRepo,
-    fallbackBaseBranch,
+    externalLinkContext.baseBranchByRepo,
+    externalLinkContext.fallbackBaseBranch,
   );
 
   return (
     <div ref={sectionRef} className="border-b border-border">
       <div ref={scrollSentinelRef} className="h-0" />
-      <FileDiffHeader
+      <ReviewDiffHeader
         file={file}
         isReviewed={isReviewed}
         isStale={isStale}
@@ -578,6 +495,7 @@ function FileDiffSection({
         onToggleCollapse={handleToggleCollapse}
         onToggleExpandUnchanged={handleToggleExpandUnchanged}
         onToggleWordWrap={handleToggleWordWrap}
+        {...externalLinkContext}
       />
       <div ref={sentinelRef} />
       {!collapsed &&

--- a/apps/web/components/review/review-diff-list.tsx
+++ b/apps/web/components/review/review-diff-list.tsx
@@ -113,6 +113,7 @@ export const ReviewDiffList = memo(function ReviewDiffList({
                   fallbackBaseBranch,
                   taskId: activeTaskId,
                   publishedPRBranch: activeTaskPR?.head_branch,
+                  publishedPRNumber: activeTaskPR?.pr_number,
                   publishedPRRepositoryId: activeTaskPR?.repository_id,
                 }}
               />

--- a/apps/web/components/review/review-diff-list.tsx
+++ b/apps/web/components/review/review-diff-list.tsx
@@ -113,7 +113,6 @@ export const ReviewDiffList = memo(function ReviewDiffList({
                   fallbackBaseBranch,
                   taskId: activeTaskId,
                   publishedPRBranch: activeTaskPR?.head_branch,
-                  publishedPRNumber: activeTaskPR?.pr_number,
                   publishedPRRepositoryId: activeTaskPR?.repository_id,
                 }}
               />

--- a/apps/web/components/review/review-diff-toolbar.test.tsx
+++ b/apps/web/components/review/review-diff-toolbar.test.tsx
@@ -47,6 +47,7 @@ describe("FileDiffToolbar", () => {
           repositoryId="repo-1"
           source="pr"
           publishedBranch="feature/review-link"
+          publishedPullRequestNumber={42}
           baseBranch="main"
           wordWrap={false}
           expandUnchanged={false}
@@ -67,6 +68,7 @@ describe("FileDiffToolbar", () => {
       repositoryId: "repo-1",
       repositoryName: "frontend",
       publishedBranch: "feature/review-link",
+      publishedPullRequestNumber: 42,
       baseBranch: "main",
       size: "xs",
     });

--- a/apps/web/components/review/review-diff-toolbar.test.tsx
+++ b/apps/web/components/review/review-diff-toolbar.test.tsx
@@ -47,7 +47,6 @@ describe("FileDiffToolbar", () => {
           repositoryId="repo-1"
           source="pr"
           publishedBranch="feature/review-link"
-          publishedPullRequestNumber={42}
           baseBranch="main"
           wordWrap={false}
           expandUnchanged={false}
@@ -68,7 +67,6 @@ describe("FileDiffToolbar", () => {
       repositoryId: "repo-1",
       repositoryName: "frontend",
       publishedBranch: "feature/review-link",
-      publishedPullRequestNumber: 42,
       baseBranch: "main",
       size: "xs",
     });

--- a/apps/web/components/review/review-diff-toolbar.test.tsx
+++ b/apps/web/components/review/review-diff-toolbar.test.tsx
@@ -1,0 +1,96 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { TooltipProvider } from "@kandev/ui/tooltip";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({ isMobile: false }));
+
+vi.mock("@/components/editors/external-vcs-file-link", () => ({
+  ExternalVcsFileLink: (props: Record<string, unknown>) => (
+    <span data-testid="external-vcs-file-link-props" data-props={JSON.stringify(props)} />
+  ),
+}));
+
+vi.mock("@/components/editors/file-actions-dropdown", () => ({
+  FileActionsDropdown: () => <span data-testid="file-actions-dropdown" />,
+}));
+
+vi.mock("@/hooks/use-global-view-mode", () => ({
+  useGlobalViewMode: () => ["split", vi.fn()],
+}));
+
+vi.mock("@/hooks/use-responsive-breakpoint", () => ({
+  useResponsiveBreakpoint: () => ({ isMobile: mocks.isMobile }),
+}));
+
+import { FileDiffToolbar } from "./review-diff-toolbar";
+
+afterEach(() => {
+  cleanup();
+  mocks.isMobile = false;
+});
+
+function externalLinkProps() {
+  return JSON.parse(screen.getByTestId("external-vcs-file-link-props").dataset.props ?? "{}");
+}
+
+describe("FileDiffToolbar", () => {
+  it("forwards exact review file and PR revision context to the external action", () => {
+    render(
+      <TooltipProvider>
+        <FileDiffToolbar
+          diff="@@ -1 +1 @@"
+          filePath="src/new-name.ts"
+          previousPath="src/old-name.ts"
+          status="renamed"
+          taskId="task-1"
+          sessionId="session-1"
+          repositoryId="repo-1"
+          source="pr"
+          publishedBranch="feature/review-link"
+          baseBranch="main"
+          wordWrap={false}
+          expandUnchanged={false}
+          onDiscard={vi.fn()}
+          onToggleExpandUnchanged={vi.fn()}
+          onToggleWordWrap={vi.fn()}
+          repo="frontend"
+        />
+      </TooltipProvider>,
+    );
+
+    expect(externalLinkProps()).toEqual({
+      filePath: "src/new-name.ts",
+      previousPath: "src/old-name.ts",
+      status: "renamed",
+      taskId: "task-1",
+      sessionId: "session-1",
+      repositoryId: "repo-1",
+      repositoryName: "frontend",
+      publishedBranch: "feature/review-link",
+      baseBranch: "main",
+      size: "xs",
+    });
+    expect(screen.getByTestId("file-actions-dropdown")).toBeTruthy();
+  });
+
+  it("uses the 44px touch action in the mobile diff drawer", () => {
+    mocks.isMobile = true;
+    render(
+      <TooltipProvider>
+        <FileDiffToolbar
+          diff="@@ -1 +1 @@"
+          filePath="src/app.ts"
+          sessionId="session-1"
+          source="uncommitted"
+          wordWrap={false}
+          expandUnchanged={false}
+          onDiscard={vi.fn()}
+          onToggleExpandUnchanged={vi.fn()}
+          onToggleWordWrap={vi.fn()}
+        />
+      </TooltipProvider>,
+    );
+
+    expect(externalLinkProps().size).toBe("touch");
+  });
+});

--- a/apps/web/components/review/review-diff-toolbar.tsx
+++ b/apps/web/components/review/review-diff-toolbar.tsx
@@ -37,6 +37,7 @@ export type FileDiffToolbarProps = {
   repositoryId?: string | null;
   source: string;
   publishedBranch?: string | null;
+  publishedPullRequestNumber?: number | null;
   baseBranch?: string | null;
   wordWrap: boolean;
   expandUnchanged: boolean;
@@ -94,6 +95,7 @@ export function FileDiffToolbar(props: FileDiffToolbarProps) {
     repositoryId,
     source,
     publishedBranch,
+    publishedPullRequestNumber,
     baseBranch,
     wordWrap,
     expandUnchanged,
@@ -127,6 +129,7 @@ export function FileDiffToolbar(props: FileDiffToolbarProps) {
         repositoryId={repositoryId}
         repositoryName={repo}
         publishedBranch={publishedBranch}
+        publishedPullRequestNumber={publishedPullRequestNumber}
         baseBranch={baseBranch}
         size={isMobile ? "touch" : "xs"}
       />

--- a/apps/web/components/review/review-diff-toolbar.tsx
+++ b/apps/web/components/review/review-diff-toolbar.tsx
@@ -15,7 +15,9 @@ import {
 import { Button } from "@kandev/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
 import { FileActionsDropdown } from "@/components/editors/file-actions-dropdown";
+import { ExternalVcsFileLink } from "@/components/editors/external-vcs-file-link";
 import { useGlobalViewMode } from "@/hooks/use-global-view-mode";
+import { useResponsiveBreakpoint } from "@/hooks/use-responsive-breakpoint";
 
 const iconBtn = "h-6 w-6 p-0 cursor-pointer opacity-60 hover:opacity-100";
 const iconBtnActive = "h-6 w-6 p-0 cursor-pointer opacity-100 bg-muted";
@@ -28,8 +30,14 @@ function isMarkdownPath(filePath: string): boolean {
 export type FileDiffToolbarProps = {
   diff: string;
   filePath: string;
+  previousPath?: string | null;
+  status?: string | null;
+  taskId?: string | null;
   sessionId: string;
+  repositoryId?: string | null;
   source: string;
+  publishedBranch?: string | null;
+  baseBranch?: string | null;
   wordWrap: boolean;
   expandUnchanged: boolean;
   onDiscard: () => void;
@@ -79,8 +87,14 @@ export function FileDiffToolbar(props: FileDiffToolbarProps) {
   const {
     diff,
     filePath,
+    previousPath,
+    status,
+    taskId,
     sessionId,
+    repositoryId,
     source,
+    publishedBranch,
+    baseBranch,
     wordWrap,
     expandUnchanged,
     onDiscard,
@@ -90,6 +104,7 @@ export function FileDiffToolbar(props: FileDiffToolbarProps) {
     onToggleWordWrap,
     repo,
   } = props;
+  const { isMobile } = useResponsiveBreakpoint();
   const [globalViewMode, setGlobalViewMode] = useGlobalViewMode();
   const handleCopyDiff = useCallback(() => {
     navigator.clipboard.writeText(diff || "");
@@ -103,6 +118,18 @@ export function FileDiffToolbar(props: FileDiffToolbarProps) {
       <ToolbarIconBtn onClick={handleCopyDiff} tooltip="Copy diff">
         <IconCopy className="h-3.5 w-3.5" />
       </ToolbarIconBtn>
+      <ExternalVcsFileLink
+        filePath={filePath}
+        previousPath={previousPath}
+        status={status}
+        taskId={taskId}
+        sessionId={sessionId}
+        repositoryId={repositoryId}
+        repositoryName={repo}
+        publishedBranch={publishedBranch}
+        baseBranch={baseBranch}
+        size={isMobile ? "touch" : "xs"}
+      />
       <ToolbarIconBtn
         onClick={onToggleExpandUnchanged}
         tooltip={expandUnchanged ? "Collapse unchanged" : "Expand all"}

--- a/apps/web/components/review/review-diff-toolbar.tsx
+++ b/apps/web/components/review/review-diff-toolbar.tsx
@@ -37,7 +37,6 @@ export type FileDiffToolbarProps = {
   repositoryId?: string | null;
   source: string;
   publishedBranch?: string | null;
-  publishedPullRequestNumber?: number | null;
   baseBranch?: string | null;
   wordWrap: boolean;
   expandUnchanged: boolean;
@@ -95,7 +94,6 @@ export function FileDiffToolbar(props: FileDiffToolbarProps) {
     repositoryId,
     source,
     publishedBranch,
-    publishedPullRequestNumber,
     baseBranch,
     wordWrap,
     expandUnchanged,
@@ -129,7 +127,6 @@ export function FileDiffToolbar(props: FileDiffToolbarProps) {
         repositoryId={repositoryId}
         repositoryName={repo}
         publishedBranch={publishedBranch}
-        publishedPullRequestNumber={publishedPullRequestNumber}
         baseBranch={baseBranch}
         size={isMobile ? "touch" : "xs"}
       />

--- a/apps/web/components/task/file-binary-viewer.tsx
+++ b/apps/web/components/task/file-binary-viewer.tsx
@@ -1,21 +1,19 @@
 "use client";
 
 import { IconFileOff } from "@tabler/icons-react";
-import { toRelativePath } from "@/lib/utils";
+import type { ReactNode } from "react";
+import { FileViewerHeader } from "./file-viewer-header";
 
 type FileBinaryViewerProps = {
   path: string;
   worktreePath?: string;
+  headerActions?: ReactNode;
 };
 
-export function FileBinaryViewer({ path, worktreePath }: FileBinaryViewerProps) {
+export function FileBinaryViewer({ path, worktreePath, headerActions }: FileBinaryViewerProps) {
   return (
     <div className="flex flex-col h-full">
-      <div className="flex items-center px-2 border-foreground/10 border-b">
-        <div className="flex items-center gap-2 text-xs text-muted-foreground py-2">
-          <span className="font-mono">{toRelativePath(path, worktreePath)}</span>
-        </div>
-      </div>
+      <FileViewerHeader path={path} worktreePath={worktreePath} actions={headerActions} />
       <div className="flex-1 flex flex-col items-center justify-center gap-3 text-muted-foreground">
         <IconFileOff size={48} strokeWidth={1.2} />
         <div className="text-sm font-medium">Cannot preview this file</div>

--- a/apps/web/components/task/file-editor-content.tsx
+++ b/apps/web/components/task/file-editor-content.tsx
@@ -40,6 +40,7 @@ export const FileEditorContent = memo(function FileEditorContent(props: FileEdit
         sessionId={props.sessionId}
         taskId={props.taskId}
         repositoryId={props.repositoryId}
+        repositoryName={props.repo}
         enableComments={props.enableComments}
         onTogglePreview={props.onToggleMarkdownPreview}
       />

--- a/apps/web/components/task/file-editor-panel.image.test.tsx
+++ b/apps/web/components/task/file-editor-panel.image.test.tsx
@@ -4,18 +4,38 @@ import { useDockviewStore, type FileEditorState } from "@/lib/state/dockview-sto
 import { buildRepoScopedItemId } from "@/lib/state/dockview-panel-actions";
 
 vi.mock("./file-image-viewer", () => ({
-  FileImageViewer: ({ path, content }: { path: string; content: string }) => (
+  FileImageViewer: ({
+    path,
+    content,
+    headerActions,
+  }: {
+    path: string;
+    content: string;
+    headerActions?: React.ReactNode;
+  }) => (
     <div data-testid="image-viewer" data-path={path}>
       {content}
+      {headerActions}
     </div>
   ),
+}));
+
+vi.mock("@/components/editors/external-vcs-file-link", () => ({
+  ExternalVcsFileLink: (props: Record<string, unknown>) => (
+    <span data-testid="external-vcs-file-link-props" data-props={JSON.stringify(props)} />
+  ),
+  useExternalVcsFileStatus: () => ({ status: "modified" }),
 }));
 
 vi.mock("@/components/state-provider", () => ({
   useAppStore: (selector: (state: Record<string, unknown>) => unknown) =>
     selector({
-      tasks: { activeSessionId: null },
-      taskSessions: { items: {} },
+      tasks: { activeSessionId: "session-1", activeTaskId: "task-1" },
+      taskSessions: {
+        items: {
+          "session-1": { worktree_path: "/tmp/worktree", repository_id: "repo-1" },
+        },
+      },
     }),
 }));
 
@@ -104,5 +124,28 @@ describe("FileEditorPanel image preview", () => {
     );
 
     expect(screen.getByTestId(IMAGE_VIEWER_TEST_ID).textContent).toBe("content-from-repo-b");
+  });
+
+  it("shows the shared external action in the docked desktop image header", () => {
+    act(() => seedImage(SHARED_IMAGE_PATH, "content-from-repo-a", "repo-a"));
+
+    render(
+      <FileEditorPanel
+        panelId={PREVIEW_PANEL_ID}
+        params={{ path: SHARED_IMAGE_PATH, repo: "repo-a" }}
+      />,
+    );
+
+    const props = JSON.parse(
+      screen.getByTestId("external-vcs-file-link-props").dataset.props ?? "{}",
+    );
+    expect(props).toEqual({
+      filePath: SHARED_IMAGE_PATH,
+      status: "modified",
+      taskId: "task-1",
+      sessionId: "session-1",
+      repositoryName: "repo-a",
+      size: "sm",
+    });
   });
 });

--- a/apps/web/components/task/file-editor-panel.tsx
+++ b/apps/web/components/task/file-editor-panel.tsx
@@ -16,6 +16,7 @@ import { calculateHash } from "@/lib/utils/file-diff";
 import { panelPortalManager } from "@/lib/layout/panel-portal-manager";
 import { syncOpenFileFromWorkspace } from "@/hooks/file-editors-sync";
 import { buildRepoScopedItemId } from "@/lib/state/dockview-panel-actions";
+import { FileViewerExternalLink } from "./file-viewer-header";
 
 type FileCategory = "image" | "binary" | "text";
 
@@ -33,16 +34,72 @@ function ImagePanel({
   fileKey,
   path,
   worktreePath,
+  headerActions,
 }: {
   fileKey: string;
   path: string;
   worktreePath: string | undefined;
+  headerActions?: React.ReactNode;
 }) {
   const content = useDockviewStore((s) => s.openFiles.get(fileKey)?.content ?? "");
   return (
     <PanelRoot>
       <PanelBody padding={false} scroll={false}>
-        <FileImageViewer path={path} content={content} worktreePath={worktreePath} />
+        <FileImageViewer
+          path={path}
+          content={content}
+          worktreePath={worktreePath}
+          headerActions={headerActions}
+        />
+      </PanelBody>
+    </PanelRoot>
+  );
+}
+
+type StaticFilePanelProps = {
+  category: Exclude<FileCategory, "text">;
+  fileKey: string;
+  path: string;
+  worktreePath?: string;
+  sessionId: string | null;
+  taskId: string | null;
+  repositoryId?: string;
+  repositoryName?: string;
+};
+
+function StaticFilePanel({
+  category,
+  fileKey,
+  path,
+  worktreePath,
+  sessionId,
+  taskId,
+  repositoryId,
+  repositoryName,
+}: StaticFilePanelProps) {
+  const headerActions = (
+    <FileViewerExternalLink
+      path={path}
+      sessionId={sessionId}
+      taskId={taskId}
+      repositoryId={repositoryId}
+      repositoryName={repositoryName}
+    />
+  );
+  if (category === "image") {
+    return (
+      <ImagePanel
+        fileKey={fileKey}
+        path={path}
+        worktreePath={worktreePath}
+        headerActions={headerActions}
+      />
+    );
+  }
+  return (
+    <PanelRoot>
+      <PanelBody padding={false} scroll={false}>
+        <FileBinaryViewer path={path} worktreePath={worktreePath} headerActions={headerActions} />
       </PanelBody>
     </PanelRoot>
   );
@@ -278,17 +335,18 @@ export const FileEditorPanel = memo(function FileEditorPanel({
   const worktreePath = activeSession?.worktree_path ?? undefined;
   const repositoryId = activeSession?.repository_id ?? undefined;
   const category = resolveFileCategory(isBinary, path);
-
-  if (category === "image")
-    return <ImagePanel fileKey={fileKey} path={path} worktreePath={worktreePath} />;
-
-  if (category === "binary") {
+  if (category !== "text") {
     return (
-      <PanelRoot>
-        <PanelBody padding={false} scroll={false}>
-          <FileBinaryViewer path={path} worktreePath={worktreePath} />
-        </PanelBody>
-      </PanelRoot>
+      <StaticFilePanel
+        category={category}
+        fileKey={fileKey}
+        path={path}
+        worktreePath={worktreePath}
+        sessionId={activeSessionId}
+        taskId={activeTaskId}
+        repositoryId={repositoryId}
+        repositoryName={repo}
+      />
     );
   }
 

--- a/apps/web/components/task/file-image-viewer.tsx
+++ b/apps/web/components/task/file-image-viewer.tsx
@@ -1,25 +1,28 @@
 "use client";
 
-import { toRelativePath } from "@/lib/utils";
+import type { ReactNode } from "react";
 import { getImageMimeType } from "@/lib/utils/file-types";
+import { FileViewerHeader } from "./file-viewer-header";
 
 type FileImageViewerProps = {
   path: string;
   content: string; // base64-encoded
   worktreePath?: string;
+  headerActions?: ReactNode;
 };
 
-export function FileImageViewer({ path, content, worktreePath }: FileImageViewerProps) {
+export function FileImageViewer({
+  path,
+  content,
+  worktreePath,
+  headerActions,
+}: FileImageViewerProps) {
   const mime = getImageMimeType(path);
   const src = `data:${mime};base64,${content}`;
 
   return (
     <div className="flex flex-col h-full">
-      <div className="flex items-center px-2 border-foreground/10 border-b">
-        <div className="flex items-center gap-2 text-xs text-muted-foreground py-2">
-          <span className="font-mono">{toRelativePath(path, worktreePath)}</span>
-        </div>
-      </div>
+      <FileViewerHeader path={path} worktreePath={worktreePath} actions={headerActions} />
       <div className="flex-1 flex items-center justify-center overflow-auto p-6">
         <img
           src={src}

--- a/apps/web/components/task/file-tab-content.external-link.test.tsx
+++ b/apps/web/components/task/file-tab-content.external-link.test.tsx
@@ -1,0 +1,75 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@kandev/ui/tabs", () => ({
+  TabsContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("./file-image-viewer", () => ({
+  FileImageViewer: ({ headerActions }: { headerActions?: React.ReactNode }) => (
+    <div data-testid="image-viewer">{headerActions}</div>
+  ),
+}));
+
+vi.mock("./file-binary-viewer", () => ({
+  FileBinaryViewer: ({ headerActions }: { headerActions?: React.ReactNode }) => (
+    <div data-testid="binary-viewer">{headerActions}</div>
+  ),
+}));
+
+vi.mock("./file-editor-content", () => ({ FileEditorContent: () => null }));
+
+vi.mock("@/components/editors/external-vcs-file-link", () => ({
+  ExternalVcsFileLink: (props: Record<string, unknown>) => (
+    <span data-testid="external-vcs-file-link-props" data-props={JSON.stringify(props)} />
+  ),
+  useExternalVcsFileStatus: () => ({ status: "modified" }),
+}));
+
+import { FileTabContent } from "./file-tab-content";
+
+afterEach(cleanup);
+
+const activeSession = { worktree_path: "/tmp/worktree", repository_id: "repo-1" };
+
+describe("FileTabContent external file action", () => {
+  it.each([
+    ["image", "assets/logo.png", "image/png", "image-viewer"],
+    ["binary", "dist/archive.zip", "binary", "binary-viewer"],
+  ])("shows the shared action for a desktop %s viewer", (_kind, path, content, viewerId) => {
+    render(
+      <FileTabContent
+        tab={{
+          path,
+          name: path.split("/").pop() ?? path,
+          repo: "frontend",
+          content,
+          originalContent: content,
+          originalHash: "hash",
+          isDirty: false,
+          isBinary: true,
+        }}
+        activeSession={activeSession}
+        activeSessionId="session-1"
+        taskId="task-1"
+        isSaving={false}
+        onFileChange={vi.fn()}
+        onFileSave={vi.fn()}
+        onFileDelete={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId(viewerId)).toBeTruthy();
+    const props = JSON.parse(
+      screen.getByTestId("external-vcs-file-link-props").dataset.props ?? "{}",
+    );
+    expect(props).toEqual({
+      filePath: path,
+      status: "modified",
+      taskId: "task-1",
+      sessionId: "session-1",
+      repositoryName: "frontend",
+      size: "sm",
+    });
+  });
+});

--- a/apps/web/components/task/file-tab-content.tsx
+++ b/apps/web/components/task/file-tab-content.tsx
@@ -6,6 +6,12 @@ import { FileImageViewer } from "./file-image-viewer";
 import { FileBinaryViewer } from "./file-binary-viewer";
 import type { OpenFileTab } from "@/lib/types/backend";
 import { getFileCategory } from "@/lib/utils/file-types";
+import { FileViewerExternalLink } from "./file-viewer-header";
+
+function resolveTabCategory(tab: OpenFileTab): "image" | "binary" | "text" {
+  if (!tab.isBinary) return "text";
+  return getFileCategory(tab.path) === "image" ? "image" : "binary";
+}
 
 export function FileTabContent({
   tab,
@@ -26,9 +32,16 @@ export function FileTabContent({
   onFileSave: (path: string) => void;
   onFileDelete: (path: string) => void;
 }) {
-  const extCategory = getFileCategory(tab.path);
-  let category: "image" | "binary" | "text" = "text";
-  if (tab.isBinary) category = extCategory === "image" ? "image" : "binary";
+  const category = resolveTabCategory(tab);
+  const externalLink = (
+    <FileViewerExternalLink
+      path={tab.path}
+      sessionId={activeSessionId}
+      taskId={taskId}
+      repositoryId={activeSession?.repository_id}
+      repositoryName={tab.repo}
+    />
+  );
 
   return (
     <TabsContent value={`file:${tab.path}`} className="flex-1 min-h-0">
@@ -37,12 +50,14 @@ export function FileTabContent({
           path={tab.path}
           content={tab.content}
           worktreePath={activeSession?.worktree_path ?? undefined}
+          headerActions={externalLink}
         />
       )}
       {category === "binary" && (
         <FileBinaryViewer
           path={tab.path}
           worktreePath={activeSession?.worktree_path ?? undefined}
+          headerActions={externalLink}
         />
       )}
       {category === "text" && (
@@ -56,6 +71,7 @@ export function FileTabContent({
           taskId={taskId}
           repositoryId={activeSession?.repository_id ?? undefined}
           worktreePath={activeSession?.worktree_path ?? undefined}
+          repo={tab.repo}
           enableComments={!!activeSessionId}
           onChange={(newContent) => onFileChange(tab.path, newContent)}
           onSave={() => onFileSave(tab.path)}

--- a/apps/web/components/task/file-viewer-header.tsx
+++ b/apps/web/components/task/file-viewer-header.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { toRelativePath } from "@/lib/utils";
+import {
+  ExternalVcsFileLink,
+  useExternalVcsFileStatus,
+} from "@/components/editors/external-vcs-file-link";
+
+type FileViewerHeaderProps = {
+  path: string;
+  worktreePath?: string;
+  actions?: ReactNode;
+};
+
+export function FileViewerHeader({ path, worktreePath, actions }: FileViewerHeaderProps) {
+  const label = toRelativePath(path, worktreePath);
+  if (!actions) {
+    return (
+      <div className="flex items-center px-2 border-foreground/10 border-b">
+        <div className="flex items-center gap-2 text-xs text-muted-foreground py-2">
+          <span className="font-mono">{label}</span>
+        </div>
+      </div>
+    );
+  }
+  return (
+    <div className="flex items-center px-2 border-foreground/10 border-b">
+      <div className="flex min-w-0 flex-1 items-center gap-2 py-2 text-xs text-muted-foreground">
+        <span className="truncate font-mono">{label}</span>
+      </div>
+      <div className="ml-auto flex shrink-0 items-center gap-1">{actions}</div>
+    </div>
+  );
+}
+
+type FileViewerExternalLinkProps = {
+  path: string;
+  sessionId?: string | null;
+  taskId?: string | null;
+  repositoryId?: string | null;
+  repositoryName?: string;
+};
+
+export function FileViewerExternalLink({
+  path,
+  sessionId,
+  taskId,
+  repositoryId,
+  repositoryName,
+}: FileViewerExternalLinkProps) {
+  const fileStatus = useExternalVcsFileStatus(path, sessionId, repositoryName);
+  return (
+    <ExternalVcsFileLink
+      filePath={path}
+      previousPath={fileStatus?.old_path}
+      status={fileStatus?.status}
+      taskId={taskId}
+      sessionId={sessionId}
+      repositoryId={repositoryName ? undefined : repositoryId}
+      repositoryName={repositoryName}
+      size="sm"
+    />
+  );
+}

--- a/apps/web/components/task/markdown-preview-content.external-link.test.tsx
+++ b/apps/web/components/task/markdown-preview-content.external-link.test.tsx
@@ -1,0 +1,62 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { TooltipProvider } from "@kandev/ui/tooltip";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/components/editors/external-vcs-file-link", () => ({
+  ExternalVcsFileLink: (props: Record<string, unknown>) => (
+    <span data-testid="external-vcs-file-link-props" data-props={JSON.stringify(props)} />
+  ),
+  useExternalVcsFileStatus: () => ({ status: "modified" }),
+}));
+
+vi.mock("@/hooks/domains/comments/use-markdown-preview-comments", () => ({
+  useMarkdownPreviewComments: () => ({
+    comments: [],
+    commentView: null,
+    currentSelection: null,
+    textSelection: null,
+    dismissOverlays: vi.fn(),
+    showCommentsForRange: vi.fn(),
+    closeCommentView: vi.fn(),
+    closeComposer: vi.fn(),
+    openComposer: vi.fn(),
+    removeComment: vi.fn(),
+    submitAndRunComment: vi.fn(),
+    submitComment: vi.fn(),
+    updateComment: vi.fn(),
+  }),
+}));
+
+import { MarkdownPreviewContent } from "./markdown-preview-content";
+
+afterEach(cleanup);
+
+describe("MarkdownPreviewContent external file action", () => {
+  it("keeps the desktop external action available while previewing", () => {
+    render(
+      <TooltipProvider>
+        <MarkdownPreviewContent
+          path="README.md"
+          content="# Hello"
+          sessionId="session-1"
+          taskId="task-1"
+          repositoryId="repo-1"
+          repositoryName="frontend"
+          onTogglePreview={vi.fn()}
+        />
+      </TooltipProvider>,
+    );
+
+    const props = JSON.parse(
+      screen.getByTestId("external-vcs-file-link-props").dataset.props ?? "{}",
+    );
+    expect(props).toEqual({
+      filePath: "README.md",
+      status: "modified",
+      taskId: "task-1",
+      sessionId: "session-1",
+      repositoryName: "frontend",
+      size: "sm",
+    });
+  });
+});

--- a/apps/web/components/task/markdown-preview-content.tsx
+++ b/apps/web/components/task/markdown-preview-content.tsx
@@ -32,12 +32,21 @@ import {
 } from "@/lib/markdown/source-line-ranges";
 import { commentsBeginInRange, commentsOverlapRange } from "@/lib/markdown/preview-comments";
 import type { DiffComment } from "@/lib/state/slices/comments";
+import {
+  ExternalVcsFileLink,
+  useExternalVcsFileStatus,
+} from "@/components/editors/external-vcs-file-link";
 
 interface MarkdownPreviewToolbarProps {
   path: string;
   worktreePath?: string;
   commentCount: number;
   commentsEnabled: boolean;
+  taskId?: string | null;
+  sessionId?: string;
+  repositoryId?: string | null;
+  repositoryName?: string;
+  showExternalVcsLink: boolean;
   onTogglePreview: () => void;
 }
 
@@ -46,8 +55,14 @@ function MarkdownPreviewToolbar({
   worktreePath,
   commentCount,
   commentsEnabled,
+  taskId,
+  sessionId,
+  repositoryId,
+  repositoryName,
+  showExternalVcsLink,
   onTogglePreview,
 }: MarkdownPreviewToolbarProps) {
+  const fileStatus = useExternalVcsFileStatus(path, sessionId, repositoryName);
   return (
     <PanelHeaderBarSplit
       left={
@@ -58,6 +73,18 @@ function MarkdownPreviewToolbar({
       }
       right={
         <div className="flex items-center gap-1">
+          {showExternalVcsLink && (
+            <ExternalVcsFileLink
+              filePath={path}
+              previousPath={fileStatus?.old_path}
+              status={fileStatus?.status}
+              taskId={taskId}
+              sessionId={sessionId}
+              repositoryId={repositoryName ? undefined : repositoryId}
+              repositoryName={repositoryName}
+              size="sm"
+            />
+          )}
           {commentsEnabled && commentCount > 0 && (
             <div className="flex items-center gap-1 px-2 py-1 text-xs text-primary">
               <IconMessagePlus className="h-3.5 w-3.5" />
@@ -93,7 +120,9 @@ interface MarkdownPreviewContentProps {
   sessionId?: string;
   taskId?: string | null;
   repositoryId?: string | null;
+  repositoryName?: string;
   enableComments?: boolean;
+  showExternalVcsLink?: boolean;
   onTogglePreview: () => void;
 }
 
@@ -304,7 +333,9 @@ export const MarkdownPreviewContent = memo(function MarkdownPreviewContent({
   sessionId,
   taskId,
   repositoryId,
+  repositoryName,
   enableComments = false,
+  showExternalVcsLink = true,
   onTogglePreview,
 }: MarkdownPreviewContentProps) {
   const rootRef = useRef<HTMLDivElement>(null);
@@ -352,6 +383,11 @@ export const MarkdownPreviewContent = memo(function MarkdownPreviewContent({
         worktreePath={worktreePath}
         commentCount={commentState.comments.length}
         commentsEnabled={commentsEnabled}
+        taskId={taskId}
+        sessionId={sessionId}
+        repositoryId={repositoryId}
+        repositoryName={repositoryName}
+        showExternalVcsLink={showExternalVcsLink}
         onTogglePreview={onTogglePreview}
       />
       <div ref={scrollRef} className="flex-1 overflow-auto p-6">

--- a/apps/web/components/task/mobile/mobile-file-viewer-panel.test.tsx
+++ b/apps/web/components/task/mobile/mobile-file-viewer-panel.test.tsx
@@ -1,0 +1,70 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const state = {
+  taskSessions: {
+    items: {
+      "session-1": {
+        id: "session-1",
+        task_id: "task-1",
+        repository_id: "primary-repo",
+        worktree_path: "/tmp/task",
+      },
+    },
+  },
+  tasks: { activeTaskId: "task-1" },
+};
+
+vi.mock("@/components/state-provider", () => ({
+  useAppStore: (selector: (value: typeof state) => unknown) => selector(state),
+}));
+
+vi.mock("@/components/editors/external-vcs-file-link", () => ({
+  ExternalVcsFileLink: (props: Record<string, unknown>) => (
+    <span data-testid="external-vcs-file-link-props" data-props={JSON.stringify(props)} />
+  ),
+  useExternalVcsFileStatus: () => ({ status: "untracked" }),
+}));
+
+vi.mock("../file-viewer-content", () => ({
+  FileViewerContent: () => <span data-testid="file-content" />,
+}));
+vi.mock("../markdown-preview-content", () => ({ MarkdownPreviewContent: () => null }));
+vi.mock("../file-image-viewer", () => ({ FileImageViewer: () => null }));
+vi.mock("../file-binary-viewer", () => ({ FileBinaryViewer: () => null }));
+
+import { MobileFileViewerPanel } from "./mobile-file-viewer-panel";
+
+afterEach(cleanup);
+
+describe("MobileFileViewerPanel external file action", () => {
+  it("renders a touch-sized action scoped to the open file's repository", () => {
+    render(
+      <MobileFileViewerPanel
+        file={{
+          path: "src/new.ts",
+          name: "new.ts",
+          repo: "frontend",
+          content: "",
+          originalContent: "",
+          originalHash: "hash",
+          isDirty: false,
+        }}
+        sessionId="session-1"
+        onClose={vi.fn()}
+      />,
+    );
+
+    const props = JSON.parse(
+      screen.getByTestId("external-vcs-file-link-props").dataset.props ?? "{}",
+    );
+    expect(props).toEqual({
+      filePath: "src/new.ts",
+      status: "untracked",
+      taskId: "task-1",
+      sessionId: "session-1",
+      repositoryName: "frontend",
+      size: "touch",
+    });
+  });
+});

--- a/apps/web/components/task/mobile/mobile-file-viewer-panel.tsx
+++ b/apps/web/components/task/mobile/mobile-file-viewer-panel.tsx
@@ -11,6 +11,10 @@ import { FileBinaryViewer } from "../file-binary-viewer";
 import { getFileCategory } from "@/lib/utils/file-types";
 import { useAppStore } from "@/components/state-provider";
 import type { OpenFileTab } from "@/lib/types/backend";
+import {
+  ExternalVcsFileLink,
+  useExternalVcsFileStatus,
+} from "@/components/editors/external-vcs-file-link";
 
 type MobileFileViewerPanelProps = {
   file: OpenFileTab;
@@ -28,6 +32,54 @@ function resolveViewerKind(file: OpenFileTab): "image" | "binary" | "text" {
   return getFileCategory(file.path) === "image" ? "image" : "binary";
 }
 
+function MobileViewerBody({
+  file,
+  viewerKind,
+  markdownFile,
+  markdownPreview,
+  worktreePath,
+  sessionId,
+  taskId,
+  repositoryId,
+  onToggleMarkdownPreview,
+}: {
+  file: OpenFileTab;
+  viewerKind: "image" | "binary" | "text";
+  markdownFile: boolean;
+  markdownPreview: boolean;
+  worktreePath?: string;
+  sessionId: string | null;
+  taskId: string | null;
+  repositoryId?: string;
+  onToggleMarkdownPreview: () => void;
+}) {
+  return (
+    <div className="flex h-full min-h-0 flex-col" data-testid="mobile-file-viewer-content">
+      {viewerKind === "image" && (
+        <FileImageViewer path={file.path} content={file.content} worktreePath={worktreePath} />
+      )}
+      {viewerKind === "binary" && <FileBinaryViewer path={file.path} worktreePath={worktreePath} />}
+      {viewerKind === "text" &&
+        (markdownFile && markdownPreview ? (
+          <MarkdownPreviewContent
+            path={file.path}
+            content={file.content}
+            worktreePath={worktreePath}
+            sessionId={sessionId ?? undefined}
+            taskId={taskId}
+            repositoryId={repositoryId}
+            repositoryName={file.repo}
+            enableComments={!!sessionId}
+            showExternalVcsLink={false}
+            onTogglePreview={onToggleMarkdownPreview}
+          />
+        ) : (
+          <FileViewerContent path={file.path} repo={file.repo} content={file.content} />
+        ))}
+    </div>
+  );
+}
+
 export function MobileFileViewerPanel({ file, sessionId, onClose }: MobileFileViewerPanelProps) {
   const activeSession = useAppStore((state) =>
     sessionId ? (state.taskSessions.items[sessionId] ?? null) : null,
@@ -35,12 +87,12 @@ export function MobileFileViewerPanel({ file, sessionId, onClose }: MobileFileVi
   const activeTaskId = useAppStore((state) => state.tasks.activeTaskId);
   const worktreePath = activeSession?.worktree_path ?? undefined;
   const repositoryId = activeSession?.repository_id ?? undefined;
+  const fileStatus = useExternalVcsFileStatus(file.path, sessionId, file.repo);
   const viewerKind = useMemo(() => resolveViewerKind(file), [file]);
   const markdownFile = isMarkdownFile(file.path);
 
   const [markdownPreview, setMarkdownPreview] = useState(false);
   const [lastPath, setLastPath] = useState(file.path);
-  const content = file.content;
 
   // Reset preview mode when the file changes so reopening a markdown file
   // always starts in editor view, not the previous preview state.
@@ -53,9 +105,20 @@ export function MobileFileViewerPanel({ file, sessionId, onClose }: MobileFileVi
   return (
     <PanelRoot data-testid="mobile-file-viewer-panel">
       <PanelHeaderBarSplit
+        className="h-11 px-2"
         left={<span className="truncate font-mono text-xs">{file.path}</span>}
         right={
           <div className="flex items-center gap-1">
+            <ExternalVcsFileLink
+              filePath={file.path}
+              previousPath={fileStatus?.old_path}
+              status={fileStatus?.status}
+              taskId={activeTaskId}
+              sessionId={sessionId}
+              repositoryId={file.repo ? undefined : repositoryId}
+              repositoryName={file.repo}
+              size="touch"
+            />
             {markdownFile && !markdownPreview && (
               <Button
                 variant="ghost"
@@ -75,29 +138,17 @@ export function MobileFileViewerPanel({ file, sessionId, onClose }: MobileFileVi
         }
       />
       <PanelBody padding={false} scroll={false} className="overflow-hidden">
-        <div className="flex h-full min-h-0 flex-col" data-testid="mobile-file-viewer-content">
-          {viewerKind === "image" && (
-            <FileImageViewer path={file.path} content={file.content} worktreePath={worktreePath} />
-          )}
-          {viewerKind === "binary" && (
-            <FileBinaryViewer path={file.path} worktreePath={worktreePath} />
-          )}
-          {viewerKind === "text" &&
-            (markdownFile && markdownPreview ? (
-              <MarkdownPreviewContent
-                path={file.path}
-                content={content}
-                worktreePath={worktreePath}
-                sessionId={sessionId ?? undefined}
-                taskId={activeTaskId}
-                repositoryId={repositoryId}
-                enableComments={!!sessionId}
-                onTogglePreview={() => setMarkdownPreview((current) => !current)}
-              />
-            ) : (
-              <FileViewerContent path={file.path} repo={file.repo} content={content} />
-            ))}
-        </div>
+        <MobileViewerBody
+          file={file}
+          viewerKind={viewerKind}
+          markdownFile={markdownFile}
+          markdownPreview={markdownPreview}
+          worktreePath={worktreePath}
+          sessionId={sessionId}
+          taskId={activeTaskId}
+          repositoryId={repositoryId}
+          onToggleMarkdownPreview={() => setMarkdownPreview((current) => !current)}
+        />
       </PanelBody>
     </PanelRoot>
   );

--- a/apps/web/components/task/task-page-content.tsx
+++ b/apps/web/components/task/task-page-content.tsx
@@ -12,6 +12,7 @@ import { useSessionAgentctl } from "@/hooks/domains/session/use-session-agentctl
 import { useTaskFocus } from "@/hooks/domains/session/use-task-focus";
 import { useAppStore } from "@/components/state-provider";
 import { useEnsureTaskSession } from "@/hooks/domains/session/use-ensure-task-session";
+import { useExternalVcsFileLinkHydration } from "@/hooks/domains/workspace/use-external-vcs-file-link";
 import { fetchTask } from "@/lib/api";
 import { useTasks } from "@/hooks/use-tasks";
 import { useResponsiveBreakpoint } from "@/hooks/use-responsive-breakpoint";
@@ -283,6 +284,7 @@ function useTaskPageData(
     agent,
     effectiveSessionId,
     repository,
+    repositories: effectiveRepositories,
     ensureSession,
     onTaskUnarchived,
   };
@@ -310,9 +312,11 @@ export function TaskPageContent({
     agent,
     effectiveSessionId,
     repository,
+    repositories,
     ensureSession,
     onTaskUnarchived,
   } = useTaskPageData(initialTask, initialTaskId, sessionId, initialRepositories);
+  useExternalVcsFileLinkHydration(task, repositories);
 
   const workflowSteps = useWorkflowStepsMapped();
   const sessionPanel = useSessionPanelState(effectiveSessionId);

--- a/apps/web/e2e/helpers/api-client.ts
+++ b/apps/web/e2e/helpers/api-client.ts
@@ -115,13 +115,24 @@ type CreateTaskOpts = {
   workflow_step_id?: string;
   agent_profile_id?: string;
   repository_ids?: string[];
-  repositories?: Array<{ repository_id: string; base_branch?: string; checkout_branch?: string }>;
+  repositories?: TaskRepositoryInput[];
   plan_mode?: boolean;
   metadata?: Record<string, unknown>;
   parent_id?: string;
   workspace_mode?: "inherit_parent" | "new_workspace" | "shared_group";
   workspace_group_id?: string;
   attachments?: MessageAttachmentInput[];
+};
+
+type TaskRepositoryInput = {
+  repository_id?: string;
+  base_branch?: string;
+  checkout_branch?: string;
+  remote_url?: string;
+  provider?: string;
+  provider_repo_id?: string;
+  provider_owner?: string;
+  provider_name?: string;
 };
 
 function buildTaskMetadata(opts: CreateTaskOpts): Record<string, unknown> | undefined {
@@ -171,7 +182,7 @@ type OptionalAgentTaskOpts = {
   workflow_id?: string;
   workflow_step_id?: string;
   repository_ids?: string[];
-  repositories?: Array<{ repository_id: string; base_branch?: string; checkout_branch?: string }>;
+  repositories?: TaskRepositoryInput[];
   executor_id?: string;
   executor_profile_id?: string;
   metadata?: Record<string, unknown>;
@@ -336,11 +347,7 @@ export class ApiClient {
       /** Repository IDs to associate with the task (required for agent execution). */
       repository_ids?: string[];
       /** Full repository entries with optional checkout_branch / base_branch. */
-      repositories?: Array<{
-        repository_id: string;
-        base_branch?: string;
-        checkout_branch?: string;
-      }>;
+      repositories?: TaskRepositoryInput[];
       /** When true, task is placed at position 0 regardless of is_start_step. */
       plan_mode?: boolean;
       /** Extra metadata to store on the task. */
@@ -490,11 +497,7 @@ export class ApiClient {
       workflow_step_id?: string;
       repository_ids?: string[];
       /** Full repository entries with optional checkout_branch / base_branch. */
-      repositories?: Array<{
-        repository_id: string;
-        base_branch?: string;
-        checkout_branch?: string;
-      }>;
+      repositories?: TaskRepositoryInput[];
       executor_id?: string;
       executor_profile_id?: string;
       metadata?: Record<string, unknown>;
@@ -1468,6 +1471,7 @@ export class ApiClient {
       task_environment_id?: string;
       worktree_path?: string;
       worktree_branch?: string;
+      worktrees?: Array<{ repository_id?: string; worktree_path?: string }>;
       error_message?: string;
       metadata?: Record<string, unknown>;
     }>;

--- a/apps/web/e2e/tests/review/external-vcs-file-link.spec.ts
+++ b/apps/web/e2e/tests/review/external-vcs-file-link.spec.ts
@@ -1,0 +1,212 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import type { Locator, Page } from "@playwright/test";
+import { test, expect } from "../../fixtures/test-base";
+import type { BackendContext } from "../../fixtures/backend";
+import type { ApiClient } from "../../helpers/api-client";
+import { makeGitEnv } from "../../helpers/git-helper";
+import { SessionPage } from "../../pages/session-page";
+
+const GITHUB_OWNER = "testorg";
+const GITHUB_REPOSITORY = "external-file-links";
+const BASE_GITHUB_REPOSITORY = "external-file-links-base";
+const PUBLISHED_FILE = "published-link.ts";
+const EXISTING_FILE = "base-link.ts";
+const UNTRACKED_FILE = "local-only-link.ts";
+
+function initializeRepository(backend: BackendContext, slug: string): string {
+  const repositoryPath = path.join(backend.tmpDir, "repos", slug);
+  fs.mkdirSync(repositoryPath, { recursive: true });
+  const gitEnvironment = makeGitEnv(backend.tmpDir);
+  execFileSync("git", ["init", "-b", "main"], { cwd: repositoryPath, env: gitEnvironment });
+  fs.writeFileSync(path.join(repositoryPath, EXISTING_FILE), "export const base = true;\n");
+  execFileSync("git", ["add", "-A"], { cwd: repositoryPath, env: gitEnvironment });
+  execFileSync("git", ["commit", "-m", "seed provider repository"], {
+    cwd: repositoryPath,
+    env: gitEnvironment,
+  });
+  return repositoryPath;
+}
+
+async function createGitHubRepository(
+  apiClient: ApiClient,
+  workspaceId: string,
+  repositoryPath: string,
+  repositoryName = GITHUB_REPOSITORY,
+) {
+  const options = {
+    name: repositoryName,
+    provider: "github",
+    provider_host: "https://github.com",
+    provider_owner: GITHUB_OWNER,
+    provider_name: repositoryName,
+  };
+  return apiClient.createRepository(workspaceId, repositoryPath, "main", options);
+}
+
+function trustedGitHubTaskRepository(repositoryName = GITHUB_REPOSITORY) {
+  return {
+    remote_url: `https://github.com/${GITHUB_OWNER}/${repositoryName}.git`,
+    provider: "github",
+    provider_owner: GITHUB_OWNER,
+    provider_name: repositoryName,
+    base_branch: "main",
+  };
+}
+
+async function openExternalLink(page: Page, link: Locator, expectedURL: string): Promise<void> {
+  await page.context().route("https://github.com/**", async (route) => {
+    await route.fulfill({ status: 200, contentType: "text/html", body: "external file" });
+  });
+  const popupPromise = page.waitForEvent("popup");
+  await link.click();
+  const popup = await popupPromise;
+  await popup.waitForLoadState("domcontentloaded");
+  expect(popup.url()).toBe(expectedURL);
+  await popup.close();
+}
+
+test.describe("External VCS file links", () => {
+  test.describe.configure({ timeout: 120_000 });
+
+  test("opens a linked pull request file on the published head branch", async ({
+    testPage,
+    apiClient,
+    seedData,
+    backend,
+  }) => {
+    const repositoryPath = initializeRepository(backend, `external-link-pr-${Date.now()}`);
+    await createGitHubRepository(apiClient, seedData.workspaceId, repositoryPath);
+    await apiClient.mockGitHubReset();
+    await apiClient.mockGitHubSetUser("reviewer");
+    await apiClient.mockGitHubAddPRs([
+      {
+        number: 81,
+        title: "External file link",
+        state: "open",
+        head_branch: "feature/external-file-link",
+        base_branch: "main",
+        author_login: "reviewer",
+        repo_owner: GITHUB_OWNER,
+        repo_name: GITHUB_REPOSITORY,
+      },
+    ]);
+    await apiClient.mockGitHubAddPRFiles(GITHUB_OWNER, GITHUB_REPOSITORY, 81, [
+      {
+        filename: PUBLISHED_FILE,
+        status: "modified",
+        additions: 1,
+        deletions: 1,
+        patch: "@@ -1 +1 @@\n-export const published = false;\n+export const published = true;",
+      },
+    ]);
+
+    const task = await apiClient.createTaskWithAgent(
+      seedData.workspaceId,
+      "Published external file link",
+      seedData.agentProfileId,
+      {
+        description: "/e2e:simple-message",
+        workflow_id: seedData.workflowId,
+        workflow_step_id: seedData.startStepId,
+        repositories: [trustedGitHubTaskRepository()],
+      },
+    );
+    await apiClient.mockGitHubAssociateTaskPR({
+      task_id: task.id,
+      owner: GITHUB_OWNER,
+      repo: GITHUB_REPOSITORY,
+      pr_number: 81,
+      pr_url: `https://github.com/${GITHUB_OWNER}/${GITHUB_REPOSITORY}/pull/81`,
+      pr_title: "External file link",
+      head_branch: "feature/external-file-link",
+      base_branch: "main",
+      author_login: "reviewer",
+    });
+
+    await testPage.goto(`/t/${task.id}`);
+    const session = new SessionPage(testPage);
+    await session.waitForLoad();
+    await session.waitForChatIdle();
+    await session.clickTab("Changes");
+    await expect(
+      session.changes.getByRole("button", { name: new RegExp(PUBLISHED_FILE) }),
+    ).toBeVisible({ timeout: 20_000 });
+    await session.changes.getByRole("button", { name: "Review", exact: true }).click();
+
+    const review = testPage.getByRole("dialog", { name: "Review Changes" });
+    await expect(review).toBeVisible();
+    const fileHeader = review.getByTestId("review-file-header").filter({ hasText: PUBLISHED_FILE });
+    const link = fileHeader.getByRole("link", { name: "Open file in GitHub" });
+    const expectedURL =
+      "https://github.com/testorg/external-file-links/blob/feature%2Fexternal-file-link/published-link.ts";
+    await expect(link).toHaveAttribute("href", expectedURL);
+    await expect(link).toHaveAttribute("target", "_blank");
+    await openExternalLink(testPage, link, expectedURL);
+  });
+
+  test("uses the base branch for an existing file and omits an unpublished untracked file", async ({
+    testPage,
+    apiClient,
+    seedData,
+    backend,
+  }) => {
+    const repositoryPath = initializeRepository(backend, `external-link-base-${Date.now()}`);
+    await createGitHubRepository(
+      apiClient,
+      seedData.workspaceId,
+      repositoryPath,
+      BASE_GITHUB_REPOSITORY,
+    );
+    const task = await apiClient.createTaskWithAgent(
+      seedData.workspaceId,
+      "Base external file link",
+      seedData.agentProfileId,
+      {
+        description: "/e2e:simple-message",
+        workflow_id: seedData.workflowId,
+        workflow_step_id: seedData.startStepId,
+        repositories: [trustedGitHubTaskRepository(BASE_GITHUB_REPOSITORY)],
+      },
+    );
+
+    await testPage.goto(`/t/${task.id}`);
+    const session = new SessionPage(testPage);
+    await session.waitForLoad();
+    await session.waitForChatIdle();
+    const sessions = await apiClient.listTaskSessions(task.id);
+    const taskCheckout =
+      sessions.sessions[0]?.worktrees?.[0]?.worktree_path ||
+      sessions.sessions[0]?.worktree_path ||
+      repositoryPath;
+    fs.writeFileSync(path.join(taskCheckout, UNTRACKED_FILE), "export const local = true;\n");
+
+    await session.clickTab("Changes");
+    await expect(
+      testPage.getByTestId(`file-row-${UNTRACKED_FILE.replaceAll("/", "-")}`),
+    ).toBeVisible({
+      timeout: 20_000,
+    });
+    await session.clickTab("Files");
+    const existingNode = session.files.locator(
+      `[data-testid="file-tree-node"][data-path="${EXISTING_FILE}"]`,
+    );
+    await expect(existingNode).toBeVisible({ timeout: 15_000 });
+    await existingNode.click();
+
+    const baseLink = testPage.getByRole("link", { name: "Open file in GitHub" });
+    const expectedBaseURL =
+      "https://github.com/testorg/external-file-links-base/blob/main/base-link.ts";
+    await expect(baseLink).toHaveAttribute("href", expectedBaseURL);
+    await openExternalLink(testPage, baseLink, expectedBaseURL);
+
+    await session.clickTab("Files");
+    const untrackedNode = session.files.locator(
+      `[data-testid="file-tree-node"][data-path="${UNTRACKED_FILE}"]`,
+    );
+    await expect(untrackedNode).toBeVisible({ timeout: 15_000 });
+    await untrackedNode.click();
+    await expect(testPage.getByRole("link", { name: "Open file in GitHub" })).toHaveCount(0);
+  });
+});

--- a/apps/web/e2e/tests/task/mobile-external-vcs-file-link.spec.ts
+++ b/apps/web/e2e/tests/task/mobile-external-vcs-file-link.spec.ts
@@ -1,0 +1,111 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import type { BackendContext } from "../../fixtures/backend";
+import { test, expect } from "../../fixtures/test-base";
+import type { ApiClient } from "../../helpers/api-client";
+import { makeGitEnv } from "../../helpers/git-helper";
+import { SessionPage } from "../../pages/session-page";
+
+const MOBILE_FILE = "mobile-external-link.ts";
+const MOBILE_REMOTE = "https://github.com/testorg/mobile-external-links.git";
+
+function initializeMobileRepository(backend: BackendContext): string {
+  const repositoryPath = path.join(backend.tmpDir, "repos", `mobile-link-${Date.now()}`);
+  fs.mkdirSync(repositoryPath, { recursive: true });
+  const gitEnvironment = makeGitEnv(backend.tmpDir);
+  execFileSync("git", ["init", "-b", "main"], { cwd: repositoryPath, env: gitEnvironment });
+  fs.writeFileSync(path.join(repositoryPath, MOBILE_FILE), "export const mobile = true;\n");
+  execFileSync("git", ["add", "-A"], { cwd: repositoryPath, env: gitEnvironment });
+  execFileSync("git", ["commit", "-m", "seed mobile provider repository"], {
+    cwd: repositoryPath,
+    env: gitEnvironment,
+  });
+  return repositoryPath;
+}
+
+async function createMobileRepository(
+  apiClient: ApiClient,
+  workspaceId: string,
+  repositoryPath: string,
+) {
+  const options = {
+    name: "mobile-external-links",
+    provider: "github",
+    provider_host: "https://github.com",
+    provider_owner: "testorg",
+    provider_name: "mobile-external-links",
+  };
+  return apiClient.createRepository(workspaceId, repositoryPath, "main", options);
+}
+
+function trustedMobileTaskRepository() {
+  return {
+    remote_url: MOBILE_REMOTE,
+    provider: "github",
+    provider_owner: "testorg",
+    provider_name: "mobile-external-links",
+    base_branch: "main",
+  };
+}
+
+test.describe("Mobile external VCS file link", () => {
+  test.describe.configure({ timeout: 120_000 });
+
+  test("opens the provider file with a touch-sized action and no horizontal overflow", async ({
+    testPage,
+    apiClient,
+    seedData,
+    backend,
+  }) => {
+    const repositoryPath = initializeMobileRepository(backend);
+    await createMobileRepository(apiClient, seedData.workspaceId, repositoryPath);
+    const task = await apiClient.createTaskWithAgent(
+      seedData.workspaceId,
+      "Mobile external file link",
+      seedData.agentProfileId,
+      {
+        description: "/e2e:simple-message",
+        workflow_id: seedData.workflowId,
+        workflow_step_id: seedData.startStepId,
+        repositories: [trustedMobileTaskRepository()],
+      },
+    );
+
+    await testPage.goto(`/t/${task.id}`);
+    const session = new SessionPage(testPage);
+    await session.waitForLoad();
+    await session.waitForChatIdle();
+    await testPage.getByRole("button", { name: "Files" }).tap();
+    const fileNode = testPage.locator(`[data-testid="file-tree-node"][data-path="${MOBILE_FILE}"]`);
+    await expect(fileNode).toBeVisible({ timeout: 15_000 });
+    await fileNode.tap();
+
+    const viewer = testPage.getByTestId("mobile-file-viewer-panel");
+    await expect(viewer).toBeVisible();
+    const link = viewer.getByRole("link", { name: "Open file in GitHub" });
+    const expectedURL =
+      "https://github.com/testorg/mobile-external-links/blob/main/mobile-external-link.ts";
+    await expect(link).toHaveAttribute("href", expectedURL);
+
+    const bounds = await link.boundingBox();
+    expect(bounds).not.toBeNull();
+    expect(bounds!.width).toBeGreaterThanOrEqual(44);
+    expect(bounds!.height).toBeGreaterThanOrEqual(44);
+    const overflow = await testPage.evaluate(() => ({
+      viewportWidth: window.innerWidth,
+      documentWidth: document.documentElement.scrollWidth,
+    }));
+    expect(overflow.documentWidth).toBeLessThanOrEqual(overflow.viewportWidth + 1);
+
+    await testPage.context().route("https://github.com/**", async (route) => {
+      await route.fulfill({ status: 200, contentType: "text/html", body: "external file" });
+    });
+    const popupPromise = testPage.waitForEvent("popup");
+    await link.tap();
+    const popup = await popupPromise;
+    await popup.waitForLoadState("domcontentloaded");
+    expect(popup.url()).toBe(expectedURL);
+    await popup.close();
+  });
+});

--- a/apps/web/hooks/domains/workspace/use-external-vcs-file-link.gitlab-host.test.tsx
+++ b/apps/web/hooks/domains/workspace/use-external-vcs-file-link.gitlab-host.test.tsx
@@ -1,0 +1,151 @@
+import { createElement, type ReactNode } from "react";
+import { cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { StateProvider } from "@/components/state-provider";
+import { defaultState } from "@/lib/state/default-state";
+import { repositoryId, sessionId, taskId, workspaceId, type Repository } from "@/lib/types/http";
+import type { TaskMR } from "@/lib/types/gitlab";
+import * as externalVcsFileURL from "@/lib/utils/external-vcs-file-url";
+
+vi.mock("@/hooks/domains/github/use-task-pr", () => ({ useTaskPR: vi.fn() }));
+vi.mock("@/hooks/domains/gitlab/use-task-mr", () => ({ useWorkspaceMRs: vi.fn() }));
+vi.mock("@/hooks/domains/azure-devops/use-azure-devops-task-pull-requests", () => ({
+  useAzureDevOpsTaskPullRequests: vi.fn(),
+}));
+
+import { useExternalVcsFileLink } from "./use-external-vcs-file-link";
+
+const WORKSPACE_ID = workspaceId("workspace-1");
+const TASK_ID = taskId("task-1");
+const SESSION_ID = sessionId("session-1");
+const GITLAB_REPOSITORY_ID = "repo-gitlab";
+
+function gitlabRepository(providerHost: string): Repository {
+  return {
+    id: repositoryId(GITLAB_REPOSITORY_ID),
+    workspace_id: WORKSPACE_ID,
+    name: "api",
+    source_type: "remote",
+    local_path: "",
+    provider: "gitlab",
+    provider_repo_id: "gitlab-api",
+    provider_host: providerHost,
+    provider_owner: "platform",
+    provider_name: "api",
+    remote_url: "https://gitlab.example.com/platform/api.git",
+    default_branch: "trunk",
+    worktree_branch_prefix: "kandev/",
+    pull_before_worktree: false,
+    setup_script: "",
+    cleanup_script: "",
+    dev_script: "",
+    copy_files: "",
+    created_at: "",
+    updated_at: "",
+  };
+}
+
+function legacyMergeRequest(host: string): TaskMR {
+  return {
+    id: "mr-link-1",
+    task_id: TASK_ID,
+    repository_id: undefined,
+    host,
+    project_path: "platform/api",
+    mr_iid: 7,
+    mr_url: "https://gitlab.example.com/platform/api/-/merge_requests/7",
+    mr_title: "Share links",
+    head_branch: "feature/gitlab",
+    base_branch: "trunk",
+    author_username: "ada",
+    state: "open",
+    approval_state: "",
+    pipeline_state: "",
+    merge_status: "",
+    draft: false,
+    approval_count: 0,
+    required_approvals: 0,
+    pipeline_jobs_total: 0,
+    pipeline_jobs_pass: 0,
+    created_at: "",
+    updated_at: "",
+  };
+}
+
+function wrapper(repository: Repository, mr: TaskMR) {
+  const initialState = {
+    ...defaultState,
+    tasks: { ...defaultState.tasks, activeTaskId: TASK_ID, activeSessionId: SESSION_ID },
+    kanban: {
+      ...defaultState.kanban,
+      tasks: [
+        {
+          id: TASK_ID,
+          workflowStepId: "step-1",
+          title: "External links",
+          position: 0,
+          repositories: [
+            {
+              id: "task-repo-api",
+              repository_id: GITLAB_REPOSITORY_ID,
+              base_branch: "trunk",
+              position: 0,
+            },
+          ],
+        },
+      ],
+    },
+    repositories: {
+      ...defaultState.repositories,
+      itemsByWorkspaceId: { [WORKSPACE_ID]: [repository] },
+    },
+    taskSessions: {
+      items: {
+        [SESSION_ID]: {
+          id: SESSION_ID,
+          task_id: TASK_ID,
+          state: "RUNNING" as const,
+          started_at: "",
+          updated_at: "",
+        },
+      },
+    },
+    taskMRs: { ...defaultState.taskMRs, byWorkspaceId: { [WORKSPACE_ID]: { [TASK_ID]: [mr] } } },
+  };
+  return ({ children }: { children: ReactNode }) =>
+    createElement(StateProvider, { initialState, children });
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("useExternalVcsFileLink legacy GitLab identity", () => {
+  it.each([
+    ["", ""],
+    ["gitlab.example.com", "gitlab.example.com"],
+    ["not a valid URL", "not a valid URL"],
+  ])("rejects a legacy association with non-origin hosts %j and %j", (mrHost, repositoryHost) => {
+    vi.spyOn(externalVcsFileURL, "resolveExternalVcsFileURL").mockImplementation((input) =>
+      input.publishedBranch
+        ? {
+            provider: "gitlab",
+            url: "https://example.com",
+            path: input.path,
+            revision: input.publishedBranch,
+          }
+        : null,
+    );
+    const { result } = renderHook(
+      () =>
+        useExternalVcsFileLink({
+          filePath: "src/legacy.ts",
+          sessionId: SESSION_ID,
+          repositoryId: GITLAB_REPOSITORY_ID,
+        }),
+      { wrapper: wrapper(gitlabRepository(repositoryHost), legacyMergeRequest(mrHost)) },
+    );
+    expect(result.current).toBeNull();
+  });
+});

--- a/apps/web/hooks/domains/workspace/use-external-vcs-file-link.test.tsx
+++ b/apps/web/hooks/domains/workspace/use-external-vcs-file-link.test.tsx
@@ -263,8 +263,8 @@ describe("useExternalVcsFileLink repository and revision resolution", () => {
 
     expect(result.current).toMatchObject({
       provider: "github",
-      revision: "feature/share",
-      url: "https://github.com/acme/web/blob/feature%2Fshare/src/app.ts",
+      revision: "refs/pull/42/head",
+      url: "https://github.com/acme/web/blob/refs%2Fpull%2F42%2Fhead/src/app.ts",
     });
   });
 
@@ -340,6 +340,29 @@ describe("useExternalVcsFileLink repository and revision resolution", () => {
   });
 });
 
+describe("useExternalVcsFileLink GitHub pull-head revisions", () => {
+  it("uses the base repository's pull-head ref for a published GitHub fork PR", () => {
+    const { result } = renderHook(
+      () =>
+        useExternalVcsFileLink({
+          filePath: "src/app.ts",
+          sessionId: SESSION_ID,
+          repositoryId: GITHUB_REPOSITORY_ID,
+        }),
+      {
+        wrapper: wrapper({
+          prs: [githubPR({ head_branch: "contributor:feature/share", pr_number: 42 })],
+        }),
+      },
+    );
+
+    expect(result.current).toMatchObject({
+      revision: "refs/pull/42/head",
+      url: "https://github.com/acme/web/blob/refs%2Fpull%2F42%2Fhead/src/app.ts",
+    });
+  });
+});
+
 describe("useExternalVcsFileLink repeated repository matching", () => {
   it("matches a repeated repository through the named worktree's active branch", () => {
     const { result } = renderHook(
@@ -367,7 +390,7 @@ describe("useExternalVcsFileLink repeated repository matching", () => {
       },
     );
 
-    expect(result.current).toMatchObject({ revision: SECOND_BRANCH });
+    expect(result.current).toMatchObject({ revision: "refs/pull/43/head" });
   });
 
   it("does not reuse a sibling worktree's published branch", () => {
@@ -418,8 +441,8 @@ describe("useExternalVcsFileLink repeated repository matching", () => {
 
     expect(result.current).toMatchObject({
       provider: "github",
-      revision: SECOND_BRANCH,
-      url: "https://github.com/acme/web/blob/feature%2Ftwo/src/editor.ts",
+      revision: "refs/pull/43/head",
+      url: "https://github.com/acme/web/blob/refs%2Fpull%2F43%2Fhead/src/editor.ts",
     });
   });
 });
@@ -539,7 +562,7 @@ describe("useExternalVcsFileLink legacy provider identity", () => {
       { wrapper: wrapper({ prs: [githubPR({ repository_id: undefined })] }) },
     );
 
-    expect(result.current?.revision).toBe("feature/share");
+    expect(result.current?.revision).toBe("refs/pull/42/head");
   });
 });
 

--- a/apps/web/hooks/domains/workspace/use-external-vcs-file-link.test.tsx
+++ b/apps/web/hooks/domains/workspace/use-external-vcs-file-link.test.tsx
@@ -1,0 +1,599 @@
+import { createElement, type ReactNode } from "react";
+import { cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { StateProvider } from "@/components/state-provider";
+import { defaultState } from "@/lib/state/default-state";
+import { repositoryId, sessionId, taskId, workspaceId, type Repository } from "@/lib/types/http";
+import type { TaskPR } from "@/lib/types/github";
+import type { TaskMR } from "@/lib/types/gitlab";
+
+const loaderMocks = vi.hoisted(() => ({
+  github: vi.fn(),
+  gitlab: vi.fn(),
+  azure: vi.fn(),
+}));
+
+vi.mock("@/hooks/domains/github/use-task-pr", () => ({
+  useTaskPR: (value: string | null) => loaderMocks.github(value),
+}));
+vi.mock("@/hooks/domains/gitlab/use-task-mr", () => ({
+  useWorkspaceMRs: (value: string | null) => loaderMocks.gitlab(value),
+}));
+vi.mock("@/hooks/domains/azure-devops/use-azure-devops-task-pull-requests", () => ({
+  useAzureDevOpsTaskPullRequests: (workspace: string | null, task: string | null) =>
+    loaderMocks.azure(workspace, task),
+}));
+
+import {
+  useExternalVcsFileLink,
+  useExternalVcsFileLinkHydration,
+} from "./use-external-vcs-file-link";
+
+const WORKSPACE_ID = workspaceId("workspace-1");
+const TASK_ID = taskId("task-1");
+const SESSION_ID = sessionId("session-1");
+const GITHUB_REPOSITORY_ID = "repo-github";
+const GITLAB_REPOSITORY_ID = "repo-gitlab";
+const FIRST_BRANCH = "feature/one";
+const SECOND_BRANCH = "feature/two";
+
+function repository(overrides: Partial<Repository> = {}): Repository {
+  return {
+    id: repositoryId(GITHUB_REPOSITORY_ID),
+    workspace_id: WORKSPACE_ID,
+    name: "web",
+    source_type: "remote",
+    local_path: "",
+    provider: "github",
+    provider_repo_id: "provider-repo-1",
+    provider_host: "https://github.com",
+    provider_owner: "acme",
+    provider_name: "web",
+    remote_url: "https://github.com/acme/web.git",
+    default_branch: "main",
+    worktree_branch_prefix: "kandev/",
+    pull_before_worktree: false,
+    setup_script: "",
+    cleanup_script: "",
+    dev_script: "",
+    copy_files: "",
+    created_at: "",
+    updated_at: "",
+    ...overrides,
+  };
+}
+
+function githubPR(overrides: Partial<TaskPR> = {}): TaskPR {
+  return {
+    id: "pr-link-1",
+    task_id: TASK_ID,
+    repository_id: GITHUB_REPOSITORY_ID,
+    owner: "acme",
+    repo: "web",
+    pr_number: 42,
+    pr_url: "https://github.com/acme/web/pull/42",
+    pr_title: "Share links",
+    head_branch: "feature/share",
+    base_branch: "main",
+    author_login: "ada",
+    state: "open",
+    review_state: "",
+    checks_state: "",
+    mergeable_state: "",
+    review_count: 0,
+    pending_review_count: 0,
+    comment_count: 0,
+    unresolved_review_threads: 0,
+    checks_total: 0,
+    checks_passing: 0,
+    additions: 0,
+    deletions: 0,
+    created_at: "",
+    merged_at: null,
+    closed_at: null,
+    last_synced_at: null,
+    updated_at: "",
+    ...overrides,
+  };
+}
+
+function gitlabMR(overrides: Partial<TaskMR> = {}): TaskMR {
+  return {
+    id: "mr-link-1",
+    task_id: TASK_ID,
+    repository_id: GITLAB_REPOSITORY_ID,
+    host: "https://gitlab.example.com",
+    project_path: "platform/api",
+    mr_iid: 7,
+    mr_url: "https://gitlab.example.com/platform/api/-/merge_requests/7",
+    mr_title: "Share links",
+    head_branch: "feature/gitlab",
+    base_branch: "trunk",
+    author_username: "ada",
+    state: "open",
+    approval_state: "",
+    pipeline_state: "",
+    merge_status: "",
+    draft: false,
+    approval_count: 0,
+    required_approvals: 0,
+    pipeline_jobs_total: 0,
+    pipeline_jobs_pass: 0,
+    created_at: "",
+    updated_at: "",
+    ...overrides,
+  };
+}
+
+type InitialOptions = {
+  repositories?: Repository[];
+  taskRepositories?: Array<{
+    id: string;
+    repository_id: string;
+    base_branch: string;
+    checkout_branch?: string;
+    position: number;
+  }>;
+  prs?: TaskPR[];
+  mrs?: TaskMR[];
+  sessionRepositoryId?: string;
+  sessionWorktrees?: Array<{
+    id: string;
+    worktree_id: string;
+    repository_id: ReturnType<typeof repositoryId>;
+    position: number;
+    worktree_path: string;
+    worktree_branch: string;
+    session_id: ReturnType<typeof sessionId>;
+  }>;
+};
+
+function repeatedTaskRepositories() {
+  return [
+    {
+      id: "task-repo-one",
+      repository_id: GITHUB_REPOSITORY_ID,
+      base_branch: "main",
+      checkout_branch: FIRST_BRANCH,
+      position: 0,
+    },
+    {
+      id: "task-repo-two",
+      repository_id: GITHUB_REPOSITORY_ID,
+      base_branch: "release",
+      checkout_branch: SECOND_BRANCH,
+      position: 1,
+    },
+  ];
+}
+
+function repeatedSessionWorktrees(): NonNullable<InitialOptions["sessionWorktrees"]> {
+  return [
+    {
+      id: "session-worktree-one",
+      session_id: SESSION_ID,
+      worktree_id: "worktree-one",
+      repository_id: repositoryId(GITHUB_REPOSITORY_ID),
+      position: 0,
+      worktree_path: "/tmp/web-feature-one",
+      worktree_branch: FIRST_BRANCH,
+    },
+    {
+      id: "session-worktree-two",
+      session_id: SESSION_ID,
+      worktree_id: "worktree-two",
+      repository_id: repositoryId(GITHUB_REPOSITORY_ID),
+      position: 1,
+      worktree_path: "/tmp/web-feature-two",
+      worktree_branch: SECOND_BRANCH,
+    },
+  ];
+}
+
+function wrapper(options: InitialOptions = {}) {
+  const repositories = options.repositories ?? [repository()];
+  const taskRepositories = options.taskRepositories ?? [
+    {
+      id: "task-repo-1",
+      repository_id: GITHUB_REPOSITORY_ID,
+      base_branch: "main",
+      position: 0,
+    },
+  ];
+  const initialState = {
+    ...defaultState,
+    tasks: { ...defaultState.tasks, activeTaskId: TASK_ID, activeSessionId: SESSION_ID },
+    kanban: {
+      ...defaultState.kanban,
+      tasks: [
+        {
+          id: TASK_ID,
+          workflowStepId: "step-1",
+          title: "External links",
+          position: 0,
+          repositories: taskRepositories,
+        },
+      ],
+    },
+    repositories: {
+      ...defaultState.repositories,
+      itemsByWorkspaceId: { [WORKSPACE_ID]: repositories },
+    },
+    taskSessions: {
+      items: {
+        [SESSION_ID]: {
+          id: SESSION_ID,
+          task_id: TASK_ID,
+          repository_id: options.sessionRepositoryId
+            ? repositoryId(options.sessionRepositoryId)
+            : undefined,
+          worktrees: options.sessionWorktrees,
+          state: "RUNNING" as const,
+          started_at: "",
+          updated_at: "",
+        },
+      },
+    },
+    taskPRs: { ...defaultState.taskPRs, byTaskId: { [TASK_ID]: options.prs ?? [] } },
+    taskMRs: {
+      ...defaultState.taskMRs,
+      byWorkspaceId: { [WORKSPACE_ID]: { [TASK_ID]: options.mrs ?? [] } },
+    },
+  };
+  return ({ children }: { children: ReactNode }) =>
+    createElement(StateProvider, { initialState, children });
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("useExternalVcsFileLink repository and revision resolution", () => {
+  it("uses an explicit repository id and its published review branch", () => {
+    const { result } = renderHook(
+      () =>
+        useExternalVcsFileLink({
+          filePath: "src/app.ts",
+          sessionId: SESSION_ID,
+          repositoryId: GITHUB_REPOSITORY_ID,
+        }),
+      { wrapper: wrapper({ prs: [githubPR()] }) },
+    );
+
+    expect(result.current).toMatchObject({
+      provider: "github",
+      revision: "feature/share",
+      url: "https://github.com/acme/web/blob/feature%2Fshare/src/app.ts",
+    });
+  });
+
+  it("resolves a multi-repository file by repository name without crossing providers", () => {
+    const gitlab = repository({
+      id: repositoryId(GITLAB_REPOSITORY_ID),
+      name: "api",
+      provider: "gitlab",
+      provider_repo_id: "gitlab-api",
+      provider_host: "https://gitlab.example.com",
+      provider_owner: "platform",
+      provider_name: "api",
+      remote_url: "https://gitlab.example.com/platform/api.git",
+      default_branch: "trunk",
+    });
+    const { result } = renderHook(
+      () =>
+        useExternalVcsFileLink({
+          filePath: "cmd/main.go",
+          sessionId: SESSION_ID,
+          repositoryName: "api",
+        }),
+      {
+        wrapper: wrapper({
+          repositories: [repository(), gitlab],
+          taskRepositories: [
+            {
+              id: "task-repo-web",
+              repository_id: GITHUB_REPOSITORY_ID,
+              base_branch: "main",
+              position: 0,
+            },
+            {
+              id: "task-repo-api",
+              repository_id: GITLAB_REPOSITORY_ID,
+              base_branch: "trunk",
+              position: 1,
+            },
+          ],
+          prs: [githubPR()],
+          mrs: [gitlabMR()],
+        }),
+      },
+    );
+
+    expect(result.current).toMatchObject({
+      provider: "gitlab",
+      revision: "feature/gitlab",
+      url: "https://gitlab.example.com/platform/api/-/blob/feature%2Fgitlab/cmd/main.go",
+    });
+  });
+
+  it("uses the sole legacy session repository and falls back to its task base branch", () => {
+    const { result } = renderHook(
+      () => useExternalVcsFileLink({ filePath: "README.md", sessionId: SESSION_ID }),
+      { wrapper: wrapper({ sessionRepositoryId: GITHUB_REPOSITORY_ID }) },
+    );
+
+    expect(result.current).toMatchObject({ provider: "github", revision: "main" });
+  });
+
+  it("uses the sole linked task repository when commit detail has no session identity", () => {
+    const { result } = renderHook(
+      () => useExternalVcsFileLink({ filePath: "src/commit-detail.ts" }),
+      { wrapper: wrapper() },
+    );
+
+    expect(result.current).toMatchObject({
+      provider: "github",
+      revision: "main",
+      url: "https://github.com/acme/web/blob/main/src/commit-detail.ts",
+    });
+  });
+});
+
+describe("useExternalVcsFileLink repeated repository matching", () => {
+  it("matches a repeated repository through the named worktree's active branch", () => {
+    const { result } = renderHook(
+      () =>
+        useExternalVcsFileLink({
+          filePath: "src/repeated.ts",
+          sessionId: SESSION_ID,
+          repositoryId: GITHUB_REPOSITORY_ID,
+          repositoryName: "web-feature-two",
+        }),
+      {
+        wrapper: wrapper({
+          taskRepositories: repeatedTaskRepositories(),
+          prs: [
+            githubPR({ id: "pr-one", head_branch: FIRST_BRANCH, base_branch: "main" }),
+            githubPR({
+              id: "pr-two",
+              pr_number: 43,
+              head_branch: SECOND_BRANCH,
+              base_branch: "release",
+            }),
+          ],
+          sessionWorktrees: repeatedSessionWorktrees(),
+        }),
+      },
+    );
+
+    expect(result.current).toMatchObject({ revision: SECOND_BRANCH });
+  });
+
+  it("does not reuse a sibling worktree's published branch", () => {
+    const { result } = renderHook(
+      () =>
+        useExternalVcsFileLink({
+          filePath: "src/repeated.ts",
+          sessionId: SESSION_ID,
+          repositoryId: GITHUB_REPOSITORY_ID,
+          repositoryName: "web-feature-two",
+        }),
+      {
+        wrapper: wrapper({
+          taskRepositories: repeatedTaskRepositories(),
+          prs: [githubPR({ head_branch: FIRST_BRANCH })],
+          sessionWorktrees: repeatedSessionWorktrees(),
+        }),
+      },
+    );
+
+    expect(result.current?.revision).toBe("release");
+  });
+
+  it("resolves a production-shaped named worktree before repository metadata", () => {
+    const { result } = renderHook(
+      () =>
+        useExternalVcsFileLink({
+          filePath: "src/editor.ts",
+          sessionId: SESSION_ID,
+          repositoryName: "web-feature-two",
+        }),
+      {
+        wrapper: wrapper({
+          taskRepositories: repeatedTaskRepositories(),
+          prs: [
+            githubPR({ id: "pr-one", head_branch: FIRST_BRANCH, base_branch: "main" }),
+            githubPR({
+              id: "pr-two",
+              pr_number: 43,
+              head_branch: SECOND_BRANCH,
+              base_branch: "release",
+            }),
+          ],
+          sessionWorktrees: repeatedSessionWorktrees(),
+        }),
+      },
+    );
+
+    expect(result.current).toMatchObject({
+      provider: "github",
+      revision: SECOND_BRANCH,
+      url: "https://github.com/acme/web/blob/feature%2Ftwo/src/editor.ts",
+    });
+  });
+});
+
+describe("useExternalVcsFileLink ambiguity and legacy identity", () => {
+  it("fails closed when repeated repository rows cannot be disambiguated", () => {
+    const { result } = renderHook(
+      () =>
+        useExternalVcsFileLink({
+          filePath: "src/ambiguous.ts",
+          sessionId: SESSION_ID,
+          repositoryId: GITHUB_REPOSITORY_ID,
+        }),
+      {
+        wrapper: wrapper({
+          taskRepositories: [
+            { id: "one", repository_id: GITHUB_REPOSITORY_ID, base_branch: "main", position: 0 },
+            {
+              id: "two",
+              repository_id: GITHUB_REPOSITORY_ID,
+              base_branch: "release",
+              position: 1,
+            },
+          ],
+        }),
+      },
+    );
+
+    expect(result.current).toBeNull();
+  });
+
+  it("fails closed when a repository name is ambiguous", () => {
+    const duplicate = repository({
+      id: repositoryId("repo-other"),
+      provider_owner: "other",
+      remote_url: "https://github.com/other/web.git",
+    });
+    const { result } = renderHook(
+      () => useExternalVcsFileLink({ filePath: "src/app.ts", repositoryName: "web" }),
+      {
+        wrapper: wrapper({
+          repositories: [repository(), duplicate],
+          taskRepositories: [
+            { id: "one", repository_id: GITHUB_REPOSITORY_ID, base_branch: "main", position: 0 },
+            { id: "two", repository_id: "repo-other", base_branch: "main", position: 1 },
+          ],
+        }),
+      },
+    );
+
+    expect(result.current).toBeNull();
+  });
+});
+
+describe("useExternalVcsFileLink named worktree ambiguity", () => {
+  it("fails closed when a named session worktree is ambiguous across repositories", () => {
+    const otherRepositoryId = "repo-other";
+    const duplicate = repository({
+      id: repositoryId(otherRepositoryId),
+      name: "api",
+      provider_owner: "other",
+      provider_name: "api",
+      remote_url: "https://github.com/other/api.git",
+    });
+    const sharedPath = "/tmp/shared-feature";
+    const { result } = renderHook(
+      () =>
+        useExternalVcsFileLink({
+          filePath: "src/ambiguous.ts",
+          sessionId: SESSION_ID,
+          repositoryName: "shared-feature",
+        }),
+      {
+        wrapper: wrapper({
+          repositories: [repository(), duplicate],
+          taskRepositories: [
+            { id: "one", repository_id: GITHUB_REPOSITORY_ID, base_branch: "main", position: 0 },
+            { id: "two", repository_id: otherRepositoryId, base_branch: "main", position: 1 },
+          ],
+          sessionWorktrees: [
+            {
+              id: "worktree-one",
+              worktree_id: "worktree-one",
+              repository_id: repositoryId(GITHUB_REPOSITORY_ID),
+              position: 0,
+              worktree_path: sharedPath,
+              worktree_branch: FIRST_BRANCH,
+              session_id: SESSION_ID,
+            },
+            {
+              id: "worktree-two",
+              worktree_id: "worktree-two",
+              repository_id: repositoryId(otherRepositoryId),
+              position: 1,
+              worktree_path: sharedPath,
+              worktree_branch: SECOND_BRANCH,
+              session_id: SESSION_ID,
+            },
+          ],
+        }),
+      },
+    );
+
+    expect(result.current).toBeNull();
+  });
+});
+
+describe("useExternalVcsFileLink legacy provider identity", () => {
+  it("accepts a legacy GitHub association only when provider identity matches", () => {
+    const { result } = renderHook(
+      () =>
+        useExternalVcsFileLink({
+          filePath: "src/legacy.ts",
+          sessionId: SESSION_ID,
+          repositoryId: GITHUB_REPOSITORY_ID,
+        }),
+      { wrapper: wrapper({ prs: [githubPR({ repository_id: undefined })] }) },
+    );
+
+    expect(result.current?.revision).toBe("feature/share");
+  });
+});
+
+describe("useExternalVcsFileLinkHydration", () => {
+  it("enables only providers attached to the task", () => {
+    const gitlab = repository({
+      id: repositoryId(GITLAB_REPOSITORY_ID),
+      provider: "gitlab",
+      provider_host: "https://gitlab.example.com",
+      provider_owner: "platform",
+      provider_name: "api",
+      remote_url: "https://gitlab.example.com/platform/api.git",
+    });
+    const azure = repository({
+      id: repositoryId("repo-azure"),
+      provider: "azure_devops",
+      provider_host: "",
+      provider_owner: "Platform",
+      provider_name: "api",
+      remote_url: "https://dev.azure.com/acme/Platform/_git/api",
+    });
+    const task = {
+      id: TASK_ID,
+      workspace_id: WORKSPACE_ID,
+      repositories: [
+        {
+          id: "one",
+          task_id: TASK_ID,
+          repository_id: repositoryId(GITHUB_REPOSITORY_ID),
+          base_branch: "main",
+          position: 0,
+          created_at: "",
+          updated_at: "",
+        },
+        {
+          id: "two",
+          task_id: TASK_ID,
+          repository_id: repositoryId("repo-azure"),
+          base_branch: "main",
+          position: 1,
+          created_at: "",
+          updated_at: "",
+        },
+      ],
+    };
+
+    const { rerender } = renderHook(
+      () => useExternalVcsFileLinkHydration(task, [repository(), gitlab, azure]),
+      { wrapper: wrapper() },
+    );
+    rerender();
+
+    expect(loaderMocks.github).toHaveBeenLastCalledWith(TASK_ID);
+    expect(loaderMocks.gitlab).toHaveBeenLastCalledWith(null);
+    expect(loaderMocks.azure).toHaveBeenLastCalledWith(WORKSPACE_ID, TASK_ID);
+  });
+});

--- a/apps/web/hooks/domains/workspace/use-external-vcs-file-link.test.tsx
+++ b/apps/web/hooks/domains/workspace/use-external-vcs-file-link.test.tsx
@@ -263,8 +263,8 @@ describe("useExternalVcsFileLink repository and revision resolution", () => {
 
     expect(result.current).toMatchObject({
       provider: "github",
-      revision: "refs/pull/42/head",
-      url: "https://github.com/acme/web/blob/refs%2Fpull%2F42%2Fhead/src/app.ts",
+      revision: "feature/share",
+      url: "https://github.com/acme/web/blob/feature%2Fshare/src/app.ts",
     });
   });
 
@@ -340,8 +340,8 @@ describe("useExternalVcsFileLink repository and revision resolution", () => {
   });
 });
 
-describe("useExternalVcsFileLink GitHub pull-head revisions", () => {
-  it("uses the base repository's pull-head ref for a published GitHub fork PR", () => {
+describe("useExternalVcsFileLink GitHub published revisions", () => {
+  it("keeps the published branch when fork provenance is unavailable", () => {
     const { result } = renderHook(
       () =>
         useExternalVcsFileLink({
@@ -357,8 +357,8 @@ describe("useExternalVcsFileLink GitHub pull-head revisions", () => {
     );
 
     expect(result.current).toMatchObject({
-      revision: "refs/pull/42/head",
-      url: "https://github.com/acme/web/blob/refs%2Fpull%2F42%2Fhead/src/app.ts",
+      revision: "contributor:feature/share",
+      url: "https://github.com/acme/web/blob/contributor%3Afeature%2Fshare/src/app.ts",
     });
   });
 });
@@ -390,7 +390,7 @@ describe("useExternalVcsFileLink repeated repository matching", () => {
       },
     );
 
-    expect(result.current).toMatchObject({ revision: "refs/pull/43/head" });
+    expect(result.current).toMatchObject({ revision: SECOND_BRANCH });
   });
 
   it("does not reuse a sibling worktree's published branch", () => {
@@ -441,8 +441,8 @@ describe("useExternalVcsFileLink repeated repository matching", () => {
 
     expect(result.current).toMatchObject({
       provider: "github",
-      revision: "refs/pull/43/head",
-      url: "https://github.com/acme/web/blob/refs%2Fpull%2F43%2Fhead/src/editor.ts",
+      revision: SECOND_BRANCH,
+      url: "https://github.com/acme/web/blob/feature%2Ftwo/src/editor.ts",
     });
   });
 });
@@ -562,7 +562,7 @@ describe("useExternalVcsFileLink legacy provider identity", () => {
       { wrapper: wrapper({ prs: [githubPR({ repository_id: undefined })] }) },
     );
 
-    expect(result.current?.revision).toBe("refs/pull/42/head");
+    expect(result.current?.revision).toBe("feature/share");
   });
 });
 

--- a/apps/web/hooks/domains/workspace/use-external-vcs-file-link.ts
+++ b/apps/web/hooks/domains/workspace/use-external-vcs-file-link.ts
@@ -23,7 +23,6 @@ export type UseExternalVcsFileLinkInput = {
   repositoryId?: string | null;
   repositoryName?: string | null;
   publishedBranch?: string | null;
-  publishedPullRequestNumber?: number | null;
   baseBranch?: string | null;
 };
 
@@ -229,6 +228,9 @@ function resolvePublishedBranch(
   activeBranch: string | null,
   snapshot: LinkSnapshot,
 ): string | null {
+  // TaskPR supplies a branch and PR number, but not the head repository or a
+  // fork discriminator. Preserve the published branch until that provenance is
+  // available instead of guessing a base-repository pull ref.
   if (input.publishedBranch) return input.publishedBranch;
   const branches = Array.from(new Set(publishedBranches(repository, snapshot)));
   if (activeBranch && branches.includes(activeBranch)) return activeBranch;
@@ -237,27 +239,6 @@ function resolvePublishedBranch(
   ).length;
   if (repositoryLinkCount > 1) return null;
   return branches.length === 1 ? branches[0] : null;
-}
-
-function resolvePublishedRevision(
-  input: UseExternalVcsFileLinkInput,
-  repository: Repository,
-  activeBranch: string | null,
-  snapshot: LinkSnapshot,
-): { branch: string; githubPullRequestNumber?: number } | null {
-  const branch = resolvePublishedBranch(input, repository, activeBranch, snapshot);
-  if (!branch) return null;
-  if (input.publishedBranch) {
-    return { branch, githubPullRequestNumber: input.publishedPullRequestNumber ?? undefined };
-  }
-  if (repository.provider !== "github") return { branch };
-  const matchingPRs = snapshot.githubPRs.filter(
-    (pr) => githubPRMatches(pr, repository) && pr.head_branch === branch,
-  );
-  return {
-    branch,
-    githubPullRequestNumber: matchingPRs.length === 1 ? matchingPRs[0].pr_number : undefined,
-  };
 }
 
 function resolveLink(
@@ -269,14 +250,13 @@ function resolveLink(
   const activeBranch = resolveActiveBranch(input, repository, snapshot);
   const taskRepository = resolveTaskRepositoryLink(repository, activeBranch, snapshot);
   if (!taskRepository) return null;
-  const publishedRevision = resolvePublishedRevision(input, repository, activeBranch, snapshot);
+  const publishedBranch = resolvePublishedBranch(input, repository, activeBranch, snapshot);
   return resolveExternalVcsFileURL({
     repository,
     path: input.filePath,
     previousPath: input.previousPath,
     status: input.status,
-    publishedBranch: publishedRevision?.branch,
-    publishedPullRequestNumber: publishedRevision?.githubPullRequestNumber,
+    publishedBranch,
     baseBranch: input.baseBranch || taskRepository.base_branch,
   });
 }

--- a/apps/web/hooks/domains/workspace/use-external-vcs-file-link.ts
+++ b/apps/web/hooks/domains/workspace/use-external-vcs-file-link.ts
@@ -23,6 +23,7 @@ export type UseExternalVcsFileLinkInput = {
   repositoryId?: string | null;
   repositoryName?: string | null;
   publishedBranch?: string | null;
+  publishedPullRequestNumber?: number | null;
   baseBranch?: string | null;
 };
 
@@ -235,6 +236,27 @@ function resolvePublishedBranch(
   return branches.length === 1 ? branches[0] : null;
 }
 
+function resolvePublishedRevision(
+  input: UseExternalVcsFileLinkInput,
+  repository: Repository,
+  activeBranch: string | null,
+  snapshot: LinkSnapshot,
+): { branch: string; githubPullRequestNumber?: number } | null {
+  const branch = resolvePublishedBranch(input, repository, activeBranch, snapshot);
+  if (!branch) return null;
+  if (input.publishedBranch) {
+    return { branch, githubPullRequestNumber: input.publishedPullRequestNumber ?? undefined };
+  }
+  if (repository.provider !== "github") return { branch };
+  const matchingPRs = snapshot.githubPRs.filter(
+    (pr) => githubPRMatches(pr, repository) && pr.head_branch === branch,
+  );
+  return {
+    branch,
+    githubPullRequestNumber: matchingPRs.length === 1 ? matchingPRs[0].pr_number : undefined,
+  };
+}
+
 function resolveLink(
   input: UseExternalVcsFileLinkInput,
   snapshot: LinkSnapshot,
@@ -244,12 +266,14 @@ function resolveLink(
   const activeBranch = resolveActiveBranch(input, repository, snapshot);
   const taskRepository = resolveTaskRepositoryLink(repository, activeBranch, snapshot);
   if (!taskRepository) return null;
+  const publishedRevision = resolvePublishedRevision(input, repository, activeBranch, snapshot);
   return resolveExternalVcsFileURL({
     repository,
     path: input.filePath,
     previousPath: input.previousPath,
     status: input.status,
-    publishedBranch: resolvePublishedBranch(input, repository, activeBranch, snapshot),
+    publishedBranch: publishedRevision?.branch,
+    publishedPullRequestNumber: publishedRevision?.githubPullRequestNumber,
     baseBranch: input.baseBranch || taskRepository.base_branch,
   });
 }

--- a/apps/web/hooks/domains/workspace/use-external-vcs-file-link.ts
+++ b/apps/web/hooks/domains/workspace/use-external-vcs-file-link.ts
@@ -1,0 +1,339 @@
+"use client";
+
+import { useMemo } from "react";
+import { useAppStore } from "@/components/state-provider";
+import type { Repository, Task } from "@/lib/types/http";
+import type { KanbanState } from "@/lib/state/slices";
+import type { Worktree } from "@/lib/state/slices/session/types";
+import type { TaskPR } from "@/lib/types/github";
+import type { TaskMR } from "@/lib/types/gitlab";
+import type { AzureDevOpsTaskPullRequest } from "@/lib/types/azure-devops";
+import type { ExternalVcsFileURL } from "@/lib/utils/external-vcs-file-url";
+import { resolveExternalVcsFileURL } from "@/lib/utils/external-vcs-file-url";
+import { useTaskPR } from "@/hooks/domains/github/use-task-pr";
+import { useWorkspaceMRs } from "@/hooks/domains/gitlab/use-task-mr";
+import { useAzureDevOpsTaskPullRequests } from "@/hooks/domains/azure-devops/use-azure-devops-task-pull-requests";
+
+export type UseExternalVcsFileLinkInput = {
+  filePath: string;
+  previousPath?: string | null;
+  status?: string | null;
+  taskId?: string | null;
+  sessionId?: string | null;
+  repositoryId?: string | null;
+  repositoryName?: string | null;
+  publishedBranch?: string | null;
+  baseBranch?: string | null;
+};
+
+type TaskRepositoryLink = NonNullable<KanbanState["tasks"][number]["repositories"]>[number];
+
+const EMPTY_TASK_REPOSITORIES: TaskRepositoryLink[] = [];
+const EMPTY_GITHUB_PRS: TaskPR[] = [];
+const EMPTY_GITLAB_MRS: TaskMR[] = [];
+const EMPTY_AZURE_PRS: AzureDevOpsTaskPullRequest[] = [];
+
+type LinkSnapshot = {
+  repositories: Repository[];
+  taskRepositories: TaskRepositoryLink[];
+  sessionRepositoryId?: string;
+  sessionWorktreeBranch?: string;
+  sessionWorktrees: Worktree[];
+  githubPRs: TaskPR[];
+  gitlabMRs: TaskMR[];
+  azurePRs: AzureDevOpsTaskPullRequest[];
+};
+
+function sanitizedRepositoryName(value: string): string {
+  return value
+    .replace(/[^A-Za-z0-9_.-]/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^[-.]+|[-.]+$/g, "");
+}
+
+function repositoryMatchesName(repository: Repository, requestedName: string): boolean {
+  const requested = sanitizedRepositoryName(requestedName);
+  return [repository.name, repository.provider_name].some(
+    (name) => name === requestedName || sanitizedRepositoryName(name) === requested,
+  );
+}
+
+function linkedRepositoryIds(taskRepositories: TaskRepositoryLink[]): Set<string> {
+  return new Set(taskRepositories.map((link) => link.repository_id));
+}
+
+function linkedRepositoryById(
+  repositoryId: string | undefined,
+  snapshot: LinkSnapshot,
+  linkedIds: Set<string>,
+): Repository | null {
+  return (
+    snapshot.repositories.find(
+      (repository) => repository.id === repositoryId && linkedIds.has(repository.id),
+    ) ?? null
+  );
+}
+
+function resolveNamedRepository(
+  repositoryName: string,
+  snapshot: LinkSnapshot,
+  linkedIds: Set<string>,
+): Repository | null {
+  const namedWorktrees = snapshot.sessionWorktrees.filter(
+    (worktree) => basename(worktree.path) === repositoryName,
+  );
+  if (namedWorktrees.length > 0) {
+    return namedWorktrees.length === 1
+      ? linkedRepositoryById(namedWorktrees[0].repositoryId, snapshot, linkedIds)
+      : null;
+  }
+  const matches = snapshot.repositories.filter(
+    (repository) =>
+      linkedIds.has(repository.id) && repositoryMatchesName(repository, repositoryName),
+  );
+  return matches.length === 1 ? matches[0] : null;
+}
+
+function resolveRepository(
+  input: UseExternalVcsFileLinkInput,
+  snapshot: LinkSnapshot,
+): Repository | null {
+  const linkedIds = linkedRepositoryIds(snapshot.taskRepositories);
+  if (input.repositoryId) {
+    return linkedRepositoryById(input.repositoryId, snapshot, linkedIds);
+  }
+  if (input.repositoryName) {
+    return resolveNamedRepository(input.repositoryName, snapshot, linkedIds);
+  }
+
+  const worktreeRepositoryIds = new Set(
+    snapshot.sessionWorktrees.map((worktree) => worktree.repositoryId).filter(Boolean),
+  );
+  if (worktreeRepositoryIds.size === 1) {
+    const id = Array.from(worktreeRepositoryIds)[0];
+    return linkedRepositoryById(id, snapshot, linkedIds);
+  }
+  if (worktreeRepositoryIds.size === 0 && snapshot.sessionRepositoryId) {
+    return linkedRepositoryById(snapshot.sessionRepositoryId, snapshot, linkedIds);
+  }
+  if (worktreeRepositoryIds.size === 0 && !snapshot.sessionRepositoryId && linkedIds.size === 1) {
+    const id = Array.from(linkedIds)[0];
+    return snapshot.repositories.find((repository) => repository.id === id) ?? null;
+  }
+  return null;
+}
+
+function basename(path: string | undefined): string {
+  return (
+    path
+      ?.replace(/[\\/]+$/, "")
+      .split(/[\\/]/)
+      .pop() ?? ""
+  );
+}
+
+function resolveActiveBranch(
+  input: UseExternalVcsFileLinkInput,
+  repository: Repository,
+  snapshot: LinkSnapshot,
+): string | null {
+  const repositoryWorktrees = snapshot.sessionWorktrees.filter(
+    (worktree) => worktree.repositoryId === repository.id,
+  );
+  if (input.repositoryName) {
+    const named = repositoryWorktrees.filter(
+      (worktree) => basename(worktree.path) === input.repositoryName,
+    );
+    if (named.length === 1) return named[0].branch ?? null;
+  }
+  if (repositoryWorktrees.length === 1) return repositoryWorktrees[0].branch ?? null;
+  if (
+    repositoryWorktrees.length === 0 &&
+    snapshot.sessionRepositoryId === repository.id &&
+    snapshot.sessionWorktreeBranch
+  ) {
+    return snapshot.sessionWorktreeBranch;
+  }
+  return null;
+}
+
+function resolveTaskRepositoryLink(
+  repository: Repository,
+  activeBranch: string | null,
+  snapshot: LinkSnapshot,
+): TaskRepositoryLink | null {
+  const links = snapshot.taskRepositories.filter((link) => link.repository_id === repository.id);
+  if (links.length === 1) return links[0];
+  if (!activeBranch) return null;
+  const matches = links.filter(
+    (link) => (link.checkout_branch || link.base_branch) === activeBranch,
+  );
+  return matches.length === 1 ? matches[0] : null;
+}
+
+function normalizeOrigin(value: string | undefined): string {
+  try {
+    return new URL(value ?? "").origin.toLowerCase();
+  } catch {
+    return "";
+  }
+}
+
+function githubPRMatches(pr: TaskPR, repository: Repository): boolean {
+  if (pr.repository_id) return pr.repository_id === repository.id;
+  return (
+    repository.provider === "github" &&
+    pr.owner === repository.provider_owner &&
+    pr.repo === repository.provider_name
+  );
+}
+
+function gitlabMRMatches(mr: TaskMR, repository: Repository): boolean {
+  if (mr.repository_id) return mr.repository_id === repository.id;
+  return (
+    repository.provider === "gitlab" &&
+    normalizeOrigin(mr.host) === normalizeOrigin(repository.provider_host) &&
+    mr.project_path === `${repository.provider_owner}/${repository.provider_name}`
+  );
+}
+
+function publishedBranches(repository: Repository, snapshot: LinkSnapshot): string[] {
+  if (repository.provider === "github") {
+    return snapshot.githubPRs
+      .filter((pr) => githubPRMatches(pr, repository))
+      .map((pr) => pr.head_branch)
+      .filter(Boolean);
+  }
+  if (repository.provider === "gitlab") {
+    return snapshot.gitlabMRs
+      .filter((mr) => gitlabMRMatches(mr, repository))
+      .map((mr) => mr.head_branch)
+      .filter(Boolean);
+  }
+  if (repository.provider === "azure_devops") {
+    return snapshot.azurePRs
+      .filter((pr) => pr.repositoryId === repository.id)
+      .map((pr) => pr.sourceBranch)
+      .filter(Boolean);
+  }
+  return [];
+}
+
+function resolvePublishedBranch(
+  input: UseExternalVcsFileLinkInput,
+  repository: Repository,
+  activeBranch: string | null,
+  snapshot: LinkSnapshot,
+): string | null {
+  if (input.publishedBranch) return input.publishedBranch;
+  const branches = Array.from(new Set(publishedBranches(repository, snapshot)));
+  if (activeBranch && branches.includes(activeBranch)) return activeBranch;
+  const repositoryLinkCount = snapshot.taskRepositories.filter(
+    (link) => link.repository_id === repository.id,
+  ).length;
+  if (repositoryLinkCount > 1) return null;
+  return branches.length === 1 ? branches[0] : null;
+}
+
+function resolveLink(
+  input: UseExternalVcsFileLinkInput,
+  snapshot: LinkSnapshot,
+): ExternalVcsFileURL | null {
+  const repository = resolveRepository(input, snapshot);
+  if (!repository) return null;
+  const activeBranch = resolveActiveBranch(input, repository, snapshot);
+  const taskRepository = resolveTaskRepositoryLink(repository, activeBranch, snapshot);
+  if (!taskRepository) return null;
+  return resolveExternalVcsFileURL({
+    repository,
+    path: input.filePath,
+    previousPath: input.previousPath,
+    status: input.status,
+    publishedBranch: resolvePublishedBranch(input, repository, activeBranch, snapshot),
+    baseBranch: input.baseBranch || taskRepository.base_branch,
+  });
+}
+
+export function useExternalVcsFileLink(
+  input: UseExternalVcsFileLinkInput,
+): ExternalVcsFileURL | null {
+  const activeTaskId = useAppStore((state) => state.tasks.activeTaskId);
+  const session = useAppStore((state) =>
+    input.sessionId ? state.taskSessions.items[input.sessionId] : undefined,
+  );
+  const resolvedTaskId = input.taskId ?? session?.task_id ?? activeTaskId;
+  const taskRepositories = useAppStore(
+    (state) =>
+      state.kanban.tasks.find((task) => task.id === resolvedTaskId)?.repositories ??
+      EMPTY_TASK_REPOSITORIES,
+  );
+  const repositoriesByWorkspace = useAppStore((state) => state.repositories.itemsByWorkspaceId);
+  const worktrees = useAppStore((state) => state.worktrees.items);
+  const sessionWorktreeIds = useAppStore((state) =>
+    input.sessionId
+      ? state.sessionWorktreesBySessionId.itemsBySessionId[input.sessionId]
+      : undefined,
+  );
+  const githubPRs = useAppStore((state) =>
+    resolvedTaskId
+      ? (state.taskPRs.byTaskId[resolvedTaskId] ?? EMPTY_GITHUB_PRS)
+      : EMPTY_GITHUB_PRS,
+  );
+  const taskMRsByWorkspace = useAppStore((state) => state.taskMRs.byWorkspaceId);
+  const azurePRs = useAppStore((state) =>
+    resolvedTaskId
+      ? (state.azureDevOpsTaskPullRequests.byTaskId[resolvedTaskId] ?? EMPTY_AZURE_PRS)
+      : EMPTY_AZURE_PRS,
+  );
+
+  const apiWorktrees: Worktree[] = session
+    ? (session.worktrees ?? []).map((worktree) => ({
+        id: worktree.worktree_id || worktree.id,
+        sessionId: session.id,
+        repositoryId: worktree.repository_id,
+        path: worktree.worktree_path,
+        branch: worktree.worktree_branch,
+      }))
+    : [];
+  const seen = new Set(apiWorktrees.map((worktree) => worktree.id));
+  const liveWorktrees = (sessionWorktreeIds ?? [])
+    .map((id) => worktrees[id])
+    .filter((worktree): worktree is Worktree => Boolean(worktree) && !seen.has(worktree.id));
+  const gitlabMRs = resolvedTaskId
+    ? Object.values(taskMRsByWorkspace).flatMap(
+        (taskMRs) => taskMRs[resolvedTaskId] ?? EMPTY_GITLAB_MRS,
+      )
+    : EMPTY_GITLAB_MRS;
+  return resolveLink(input, {
+    repositories: Object.values(repositoriesByWorkspace).flat(),
+    taskRepositories,
+    sessionRepositoryId: session?.repository_id,
+    sessionWorktreeBranch: session?.worktree_branch,
+    sessionWorktrees: apiWorktrees.concat(liveWorktrees),
+    githubPRs,
+    gitlabMRs,
+    azurePRs,
+  });
+}
+
+export function useExternalVcsFileLinkHydration(
+  task: Pick<Task, "id" | "workspace_id" | "repositories"> | null,
+  repositories: Repository[],
+): void {
+  const providers = useMemo(() => {
+    const repositoryIds = new Set(task?.repositories?.map((link) => link.repository_id) ?? []);
+    return new Set(
+      repositories
+        .filter((repository) => repositoryIds.has(repository.id))
+        .map((repository) => repository.provider),
+    );
+  }, [repositories, task?.repositories]);
+  const taskId = task?.id ?? null;
+  const workspaceId = task?.workspace_id ?? null;
+  useTaskPR(providers.has("github") ? taskId : null);
+  useWorkspaceMRs(providers.has("gitlab") ? workspaceId : null);
+  useAzureDevOpsTaskPullRequests(
+    providers.has("azure_devops") ? workspaceId : null,
+    providers.has("azure_devops") ? taskId : null,
+  );
+}

--- a/apps/web/hooks/domains/workspace/use-external-vcs-file-link.ts
+++ b/apps/web/hooks/domains/workspace/use-external-vcs-file-link.ts
@@ -191,9 +191,12 @@ function githubPRMatches(pr: TaskPR, repository: Repository): boolean {
 
 function gitlabMRMatches(mr: TaskMR, repository: Repository): boolean {
   if (mr.repository_id) return mr.repository_id === repository.id;
+  const mergeRequestOrigin = normalizeOrigin(mr.host);
+  const repositoryOrigin = normalizeOrigin(repository.provider_host);
   return (
     repository.provider === "gitlab" &&
-    normalizeOrigin(mr.host) === normalizeOrigin(repository.provider_host) &&
+    Boolean(mergeRequestOrigin && repositoryOrigin) &&
+    mergeRequestOrigin === repositoryOrigin &&
     mr.project_path === `${repository.provider_owner}/${repository.provider_name}`
   );
 }

--- a/apps/web/lib/types/http.ts
+++ b/apps/web/lib/types/http.ts
@@ -206,6 +206,8 @@ export type Repository = {
   provider_host?: string;
   provider_owner: string;
   provider_name: string;
+  /** Canonical credential-free clone URL for provider-backed repositories. */
+  remote_url?: string;
   default_branch: string;
   scripts?: RepositoryScript[];
   worktree_branch_prefix: string;

--- a/apps/web/lib/utils/external-vcs-file-url.test.ts
+++ b/apps/web/lib/utils/external-vcs-file-url.test.ts
@@ -12,6 +12,7 @@ const renamedPath = "src/new.ts";
 const previousRenamedPath = "src/old.ts";
 const gitlabOwner = "platform/tools";
 const currentPath = "src/app.ts";
+const featureShareBranch = "feature/share";
 
 function resolve(overrides: Partial<ExternalVcsFileURLInput> = {}) {
   return resolveExternalVcsFileURL({
@@ -55,12 +56,12 @@ describe("resolveExternalVcsFileURL provider routes", () => {
     },
   ])("builds the $name URL from credential-free metadata", ({ repository, expected }) => {
     expect(
-      resolve({ repository, path: "src/a file.ts", publishedBranch: "feature/share" }),
+      resolve({ repository, path: "src/a file.ts", publishedBranch: featureShareBranch }),
     ).toEqual({
       provider: repository.provider,
       url: expected,
       path: "src/a file.ts",
-      revision: "feature/share",
+      revision: featureShareBranch,
     });
   });
 
@@ -117,7 +118,41 @@ describe("resolveExternalVcsFileURL provider routes", () => {
         "https://dev.azure.com/acme/Platform/_git/api?path=%2Fsrc%2Fapp.ts&version=GBfeature%2Fshare",
     },
   ])("builds a credential-free HTTPS URL from a $name", ({ repository, expected }) => {
-    expect(resolve({ repository, publishedBranch: "feature/share" })?.url).toBe(expected);
+    expect(resolve({ repository, publishedBranch: featureShareBranch })?.url).toBe(expected);
+  });
+});
+
+describe("resolveExternalVcsFileURL review revisions", () => {
+  it("uses a GitHub pull-head ref when Review supplies its published PR number", () => {
+    expect(
+      resolve({
+        publishedBranch: "contributor:feature/share",
+        publishedPullRequestNumber: 42,
+      }),
+    ).toMatchObject({
+      revision: "refs/pull/42/head",
+      url: "https://github.com/acme/web/blob/refs%2Fpull%2F42%2Fhead/src/app.ts",
+    });
+  });
+});
+
+describe("resolveExternalVcsFileURL Azure DevOps clone normalization", () => {
+  it("strips Azure DevOps's clone-only .git suffix before building a file URL", () => {
+    expect(
+      resolve({
+        repository: {
+          provider: "azure_devops",
+          provider_host: "",
+          provider_owner: "Platform",
+          provider_name: "api",
+          remote_url: "https://dev.azure.com/acme/Platform/_git/api.git",
+        },
+        path: currentPath,
+        publishedBranch: featureShareBranch,
+      })?.url,
+    ).toBe(
+      "https://dev.azure.com/acme/Platform/_git/api?path=%2Fsrc%2Fapp.ts&version=GBfeature%2Fshare",
+    );
   });
 });
 

--- a/apps/web/lib/utils/external-vcs-file-url.test.ts
+++ b/apps/web/lib/utils/external-vcs-file-url.test.ts
@@ -1,0 +1,306 @@
+import { describe, expect, it } from "vitest";
+import { resolveExternalVcsFileURL, type ExternalVcsFileURLInput } from "./external-vcs-file-url";
+
+const githubRepository = {
+  provider: "github",
+  provider_host: "https://github.com",
+  provider_owner: "acme",
+  provider_name: "web",
+  remote_url: "https://github.com/acme/web.git",
+};
+const renamedPath = "src/new.ts";
+const previousRenamedPath = "src/old.ts";
+const gitlabOwner = "platform/tools";
+const currentPath = "src/app.ts";
+
+function resolve(overrides: Partial<ExternalVcsFileURLInput> = {}) {
+  return resolveExternalVcsFileURL({
+    repository: githubRepository,
+    path: currentPath,
+    baseBranch: "main",
+    ...overrides,
+  });
+}
+
+describe("resolveExternalVcsFileURL provider routes", () => {
+  it.each([
+    {
+      name: "GitHub",
+      repository: githubRepository,
+      expected: "https://github.com/acme/web/blob/feature%2Fshare/src/a%20file.ts",
+    },
+    {
+      name: "self-hosted GitLab",
+      repository: {
+        provider: "gitlab",
+        provider_host: "https://gitlab.example.com:8443",
+        provider_owner: gitlabOwner,
+        provider_name: "api",
+        remote_url: "https://gitlab.example.com:8443/platform/tools/api.git",
+      },
+      expected:
+        "https://gitlab.example.com:8443/platform/tools/api/-/blob/feature%2Fshare/src/a%20file.ts",
+    },
+    {
+      name: "Azure DevOps",
+      repository: {
+        provider: "azure_devops",
+        provider_host: "",
+        provider_owner: "Platform",
+        provider_name: "api",
+        remote_url: "https://dev.azure.com/acme/Platform/_git/api",
+      },
+      expected:
+        "https://dev.azure.com/acme/Platform/_git/api?path=%2Fsrc%2Fa+file.ts&version=GBfeature%2Fshare",
+    },
+  ])("builds the $name URL from credential-free metadata", ({ repository, expected }) => {
+    expect(
+      resolve({ repository, path: "src/a file.ts", publishedBranch: "feature/share" }),
+    ).toEqual({
+      provider: repository.provider,
+      url: expected,
+      path: "src/a file.ts",
+      revision: "feature/share",
+    });
+  });
+
+  it("encodes every path segment without turning a filename into a route", () => {
+    expect(resolve({ path: "docs/a#b?/100%.md", publishedBranch: "release #1" })?.url).toBe(
+      "https://github.com/acme/web/blob/release%20%231/docs/a%23b%3F/100%25.md",
+    );
+  });
+
+  it.each([
+    {
+      name: "GitHub SCP clone identity",
+      repository: { ...githubRepository, remote_url: "git@github.com:acme/web.git" },
+      expected: "https://github.com/acme/web/blob/feature%2Fshare/src/app.ts",
+    },
+    {
+      name: "GitHub SSH URL clone identity",
+      repository: { ...githubRepository, remote_url: "ssh://git@github.com/acme/web.git" },
+      expected: "https://github.com/acme/web/blob/feature%2Fshare/src/app.ts",
+    },
+    {
+      name: "self-hosted GitLab SCP clone identity",
+      repository: {
+        provider: "gitlab",
+        provider_host: "https://gitlab.example.com",
+        provider_owner: gitlabOwner,
+        provider_name: "api",
+        remote_url: "git@gitlab.example.com:platform/tools/api.git",
+      },
+      expected: "https://gitlab.example.com/platform/tools/api/-/blob/feature%2Fshare/src/app.ts",
+    },
+    {
+      name: "self-hosted GitLab SSH URL with a custom SSH port",
+      repository: {
+        provider: "gitlab",
+        provider_host: "https://gitlab.example.com:8443",
+        provider_owner: gitlabOwner,
+        provider_name: "api",
+        remote_url: "ssh://git@gitlab.example.com:2222/platform/tools/api.git",
+      },
+      expected:
+        "https://gitlab.example.com:8443/platform/tools/api/-/blob/feature%2Fshare/src/app.ts",
+    },
+    {
+      name: "Azure DevOps SCP clone identity",
+      repository: {
+        provider: "azure_devops",
+        provider_host: "",
+        provider_owner: "Platform",
+        provider_name: "api",
+        remote_url: "git@ssh.dev.azure.com:v3/acme/Platform/api",
+      },
+      expected:
+        "https://dev.azure.com/acme/Platform/_git/api?path=%2Fsrc%2Fapp.ts&version=GBfeature%2Fshare",
+    },
+  ])("builds a credential-free HTTPS URL from a $name", ({ repository, expected }) => {
+    expect(resolve({ repository, publishedBranch: "feature/share" })?.url).toBe(expected);
+  });
+});
+
+describe("resolveExternalVcsFileURL revision and path selection", () => {
+  it("prefers a published review branch for an existing file", () => {
+    expect(resolve({ publishedBranch: "feature/published" })?.revision).toBe("feature/published");
+  });
+
+  it.each(["added", "untracked"] as const)(
+    "omits an %s file when only the base branch is known",
+    (status) => {
+      expect(resolve({ status })).toBeNull();
+    },
+  );
+
+  it("targets a deleted file on the base branch", () => {
+    expect(resolve({ status: "deleted", publishedBranch: "feature/deleted" })).toMatchObject({
+      revision: "main",
+      path: currentPath,
+    });
+  });
+
+  it("targets a renamed file's new path on a published branch", () => {
+    expect(
+      resolve({
+        status: "renamed",
+        path: renamedPath,
+        previousPath: previousRenamedPath,
+        publishedBranch: "feature/rename",
+      }),
+    ).toMatchObject({ revision: "feature/rename", path: renamedPath });
+  });
+
+  it("targets a renamed file's previous path on the base branch", () => {
+    expect(
+      resolve({ status: "renamed", path: renamedPath, previousPath: previousRenamedPath }),
+    ).toMatchObject({ revision: "main", path: previousRenamedPath });
+  });
+
+  it("omits a base-only rename when the previous path is unknown", () => {
+    expect(resolve({ status: "renamed", path: renamedPath })).toBeNull();
+  });
+
+  it("preserves leading and trailing spaces in the current Git path", () => {
+    expect(resolve({ path: " src/app.ts " })).toMatchObject({
+      path: " src/app.ts ",
+      url: "https://github.com/acme/web/blob/main/%20src/app.ts%20",
+    });
+  });
+
+  it("preserves leading and trailing spaces in a renamed file's previous Git path", () => {
+    expect(
+      resolve({
+        status: "renamed",
+        path: renamedPath,
+        previousPath: " src/old.ts ",
+      }),
+    ).toMatchObject({
+      path: " src/old.ts ",
+      url: "https://github.com/acme/web/blob/main/%20src/old.ts%20",
+    });
+  });
+});
+
+describe("resolveExternalVcsFileURL security and completeness", () => {
+  it.each([
+    ["non-HTTPS remote", { remote_url: "http://github.com/acme/web.git" }],
+    ["embedded username", { remote_url: "https://alice@github.com/acme/web.git" }],
+    ["embedded password", { remote_url: "https://alice:secret@github.com/acme/web.git" }],
+    ["unsupported provider", { provider: "bitbucket" }],
+    ["mismatched repository path", { remote_url: "https://github.com/other/web.git" }],
+    ["missing provider owner", { provider_owner: "" }],
+  ])("fails closed for a %s", (_name, repositoryOverrides) => {
+    expect(resolve({ repository: { ...githubRepository, ...repositoryOverrides } })).toBeNull();
+  });
+
+  it.each(["/etc/passwd", "../secret.txt", "src/../../secret.txt", "C:\\secret.txt"])(
+    "does not expose a local or escaping path: %s",
+    (path) => {
+      expect(resolve({ path })).toBeNull();
+    },
+  );
+
+  it("requires the persisted GitLab provider host to match the remote origin", () => {
+    expect(
+      resolve({
+        repository: {
+          provider: "gitlab",
+          provider_host: "https://gitlab.internal.example",
+          provider_owner: "acme",
+          provider_name: "web",
+          remote_url: "https://gitlab.example.com/acme/web.git",
+        },
+      }),
+    ).toBeNull();
+  });
+
+  it.each([
+    "javascript:alert(1)",
+    "data:text/plain,repository",
+    "blob:https://github.com/id",
+    "file:///tmp/repository",
+    "//github.com/acme/web.git",
+    "https://github.com/acme/web.git?token=secret",
+    "https://github.com/acme/web.git#fragment",
+    "https://github.com/acme/web.git\u0000suffix",
+  ])("rejects an unsafe remote URL: %s", (remote_url) => {
+    expect(resolve({ repository: { ...githubRepository, remote_url } })).toBeNull();
+  });
+});
+
+describe("resolveExternalVcsFileURL literal and unsafe file paths", () => {
+  it.each([
+    ["src/%2e%2e/secret.ts", "src/%252e%252e/secret.ts"],
+    ["src/%252e%252e/secret.ts", "src/%25252e%25252e/secret.ts"],
+    ["src/%2Fsecret.ts", "src/%252Fsecret.ts"],
+    ["src/%255csecret.ts", "src/%25255csecret.ts"],
+  ])("treats percent-escape-looking text as a literal filename: %s", (path, encodedPath) => {
+    expect(resolve({ path })?.url).toBe(`https://github.com/acme/web/blob/main/${encodedPath}`);
+  });
+
+  it("rejects a control character in a file path", () => {
+    expect(resolve({ path: "src/control\u0000.ts" })).toBeNull();
+  });
+});
+
+describe("resolveExternalVcsFileURL SSH identity validation", () => {
+  it.each([
+    "git@github.com/acme/web.git",
+    "git@github.com:other/web.git",
+    "alice@github.com:acme/web.git",
+    "git@github.com:acme/web.git?token=secret",
+    "ssh://git:secret@github.com/acme/web.git",
+    "ssh://git@github.com:22/acme/web.git#fragment",
+    "git@github.com:acme/%252e%252e.git",
+    "git@github.example.com:acme/web.git",
+  ])("rejects a malformed or mismatched GitHub SSH identity: %s", (remote_url) => {
+    expect(resolve({ repository: { ...githubRepository, remote_url } })).toBeNull();
+  });
+
+  it("rejects a self-hosted GitLab SSH host that differs from provider metadata", () => {
+    expect(
+      resolve({
+        repository: {
+          provider: "gitlab",
+          provider_host: "https://gitlab.example.com",
+          provider_owner: gitlabOwner,
+          provider_name: "api",
+          remote_url: "git@gitlab.attacker.example:platform/tools/api.git",
+        },
+      }),
+    ).toBeNull();
+  });
+
+  it.each([
+    "ssh://git@gitlab.example.com:/platform/tools/api.git",
+    "ssh://git@gitlab.example.com:0/platform/tools/api.git",
+    "ssh://git@gitlab.example.com:65536/platform/tools/api.git",
+  ])("rejects a malformed GitLab SSH port: %s", (remote_url) => {
+    expect(
+      resolve({
+        repository: {
+          provider: "gitlab",
+          provider_host: "https://gitlab.example.com",
+          provider_owner: gitlabOwner,
+          provider_name: "api",
+          remote_url,
+        },
+      }),
+    ).toBeNull();
+  });
+
+  it("rejects an Azure DevOps SSH identity with mismatched provider metadata", () => {
+    expect(
+      resolve({
+        repository: {
+          provider: "azure_devops",
+          provider_host: "",
+          provider_owner: "OtherProject",
+          provider_name: "api",
+          remote_url: "git@ssh.dev.azure.com:v3/acme/Platform/api",
+        },
+      }),
+    ).toBeNull();
+  });
+});

--- a/apps/web/lib/utils/external-vcs-file-url.test.ts
+++ b/apps/web/lib/utils/external-vcs-file-url.test.ts
@@ -123,15 +123,14 @@ describe("resolveExternalVcsFileURL provider routes", () => {
 });
 
 describe("resolveExternalVcsFileURL review revisions", () => {
-  it("uses a GitHub pull-head ref when Review supplies its published PR number", () => {
+  it("keeps the published GitHub branch", () => {
     expect(
       resolve({
-        publishedBranch: "contributor:feature/share",
-        publishedPullRequestNumber: 42,
+        publishedBranch: "feature/share",
       }),
     ).toMatchObject({
-      revision: "refs/pull/42/head",
-      url: "https://github.com/acme/web/blob/refs%2Fpull%2F42%2Fhead/src/app.ts",
+      revision: "feature/share",
+      url: "https://github.com/acme/web/blob/feature%2Fshare/src/app.ts",
     });
   });
 });

--- a/apps/web/lib/utils/external-vcs-file-url.ts
+++ b/apps/web/lib/utils/external-vcs-file-url.ts
@@ -1,0 +1,356 @@
+export type ExternalVcsProvider = "github" | "gitlab" | "azure_devops";
+
+export type ExternalVcsRepository = {
+  provider: string;
+  provider_host?: string;
+  provider_owner: string;
+  provider_name: string;
+  remote_url?: string;
+};
+
+export type ExternalVcsFileURLInput = {
+  repository: ExternalVcsRepository;
+  path: string;
+  previousPath?: string | null;
+  status?: string | null;
+  publishedBranch?: string | null;
+  baseBranch?: string | null;
+};
+
+export type ExternalVcsFileURL = {
+  provider: ExternalVcsProvider;
+  url: string;
+  path: string;
+  revision: string;
+};
+
+type ResolvedTarget = { path: string; revision: string };
+type SSHCloneIdentity = { hostname: string; parts: string[] };
+
+function cleanValue(value: string | null | undefined): string {
+  return value?.trim() ?? "";
+}
+
+function isSafeRef(value: string): boolean {
+  return value.length > 0 && !/[\u0000-\u001f\u007f]/.test(value);
+}
+
+function isSafeRepositoryPath(value: string): boolean {
+  if (
+    !value ||
+    value.startsWith("/") ||
+    value.startsWith("\\") ||
+    value.includes("\\") ||
+    /[\u0000-\u001f\u007f]/.test(value)
+  ) {
+    return false;
+  }
+  const segments = value.split("/");
+  return segments.every((segment) => segment !== "" && segment !== "." && segment !== "..");
+}
+
+function selectTarget(input: ExternalVcsFileURLInput): ResolvedTarget | null {
+  const publishedBranch = cleanValue(input.publishedBranch);
+  const baseBranch = cleanValue(input.baseBranch);
+  const currentPath = input.path;
+  const previousPath = input.previousPath ?? "";
+  const status = cleanValue(input.status).toLowerCase();
+
+  if (status === "deleted") {
+    return baseBranch ? { path: currentPath, revision: baseBranch } : null;
+  }
+  if (status === "renamed") {
+    if (publishedBranch) return { path: currentPath, revision: publishedBranch };
+    return baseBranch && previousPath ? { path: previousPath, revision: baseBranch } : null;
+  }
+  if ((status === "added" || status === "untracked") && !publishedBranch) return null;
+  const revision = publishedBranch || baseBranch;
+  return revision ? { path: currentPath, revision } : null;
+}
+
+function parseHTTPSRemote(rawRemoteURL: string | undefined): URL | null {
+  if (!rawRemoteURL || /[\u0000-\u001f\u007f]/.test(rawRemoteURL)) return null;
+  try {
+    const remote = new URL(cleanValue(rawRemoteURL));
+    if (
+      remote.protocol !== "https:" ||
+      remote.username ||
+      remote.password ||
+      remote.search ||
+      remote.hash
+    ) {
+      return null;
+    }
+    return remote;
+  } catch {
+    return null;
+  }
+}
+
+function decodeSSHPath(rawPath: string): string[] | null {
+  try {
+    const rawParts = rawPath.replace(/^\/+/, "").split("/");
+    if (rawParts.some((part) => !part)) return null;
+    const parts = rawParts.map((part) => decodeURIComponent(part));
+    const lastIndex = parts.length - 1;
+    parts[lastIndex] = parts[lastIndex].replace(/\.git$/, "");
+    if (
+      parts.some(
+        (part) =>
+          !part ||
+          part === "." ||
+          part === ".." ||
+          /[\\/\u0000-\u001f\u007f]/.test(part) ||
+          /%[0-9a-f]{2}/i.test(part),
+      )
+    ) {
+      return null;
+    }
+    return parts;
+  } catch {
+    return null;
+  }
+}
+
+function hasValidSSHPort(value: string): boolean {
+  const authorityEnd = value.indexOf("/", "ssh://".length);
+  if (authorityEnd < 0) return false;
+  const authority = value.slice("ssh://".length, authorityEnd);
+  const hostnameAndPort = authority.slice(authority.lastIndexOf("@") + 1);
+  const separator = hostnameAndPort.lastIndexOf(":");
+  if (separator < 0) return true;
+  const port = hostnameAndPort.slice(separator + 1);
+  if (!/^\d+$/.test(port)) return false;
+  const numericPort = Number(port);
+  return numericPort >= 1 && numericPort <= 65535;
+}
+
+function parseSSHCloneIdentity(rawRemoteURL: string | undefined): SSHCloneIdentity | null {
+  if (!rawRemoteURL || /[\u0000-\u001f\u007f]/.test(rawRemoteURL)) return null;
+  const value = cleanValue(rawRemoteURL);
+  const scpMatch = /^git@([A-Za-z0-9.-]+):([^?#]+)$/.exec(value);
+  if (scpMatch) {
+    const parts = decodeSSHPath(scpMatch[2]);
+    return parts ? { hostname: scpMatch[1].toLowerCase(), parts } : null;
+  }
+
+  try {
+    const remote = new URL(value);
+    if (
+      remote.protocol !== "ssh:" ||
+      remote.username !== "git" ||
+      remote.password ||
+      remote.search ||
+      remote.hash ||
+      !hasValidSSHPort(value)
+    ) {
+      return null;
+    }
+    const parts = decodeSSHPath(remote.pathname);
+    return parts ? { hostname: remote.hostname.toLowerCase(), parts } : null;
+  } catch {
+    return null;
+  }
+}
+
+function decodedRemoteParts(remote: URL): string[] | null {
+  try {
+    const path = remote.pathname.replace(/\/+$/, "").replace(/\.git$/, "");
+    return path
+      .split("/")
+      .filter(Boolean)
+      .map((part) => decodeURIComponent(part));
+  } catch {
+    return null;
+  }
+}
+
+function parseProviderOrigin(rawProviderHost: string | undefined): string | null {
+  if (!rawProviderHost || /[\u0000-\u001f\u007f]/.test(rawProviderHost)) return null;
+  try {
+    const host = new URL(cleanValue(rawProviderHost));
+    if (
+      host.protocol !== "https:" ||
+      host.username ||
+      host.password ||
+      host.search ||
+      host.hash ||
+      !/^\/?$/.test(host.pathname)
+    ) {
+      return null;
+    }
+    return host.origin;
+  } catch {
+    return null;
+  }
+}
+
+function repositoryPathMatches(parts: string[], owner: string, name: string): boolean {
+  const expected = owner.split("/").concat(name);
+  return (
+    expected.every(
+      (part) =>
+        part &&
+        part !== "." &&
+        part !== ".." &&
+        !/[\\\u0000-\u001f\u007f]/.test(part) &&
+        !/%[0-9a-f]{2}/i.test(part),
+    ) &&
+    parts.length === expected.length &&
+    parts.every((part, index) => part === expected[index])
+  );
+}
+
+function sshRemoteForRepository(repository: ExternalVcsRepository): URL | null {
+  const identity = parseSSHCloneIdentity(repository.remote_url);
+  if (!identity) return null;
+  const provider = repository.provider.toLowerCase();
+
+  if (
+    provider === "github" &&
+    identity.hostname === "github.com" &&
+    repositoryPathMatches(identity.parts, repository.provider_owner, repository.provider_name)
+  ) {
+    return new URL(
+      `https://github.com/${encodeRepositoryPath(repository.provider_owner, repository.provider_name)}`,
+    );
+  }
+
+  if (provider === "gitlab") {
+    const origin = parseProviderOrigin(repository.provider_host);
+    if (
+      origin &&
+      identity.hostname === new URL(origin).hostname.toLowerCase() &&
+      repositoryPathMatches(identity.parts, repository.provider_owner, repository.provider_name)
+    ) {
+      return new URL(
+        `${origin}/${encodeRepositoryPath(repository.provider_owner, repository.provider_name)}`,
+      );
+    }
+  }
+
+  if (
+    provider === "azure_devops" &&
+    identity.hostname === "ssh.dev.azure.com" &&
+    identity.parts.length === 4 &&
+    identity.parts[0] === "v3" &&
+    identity.parts[2] === repository.provider_owner &&
+    identity.parts[3] === repository.provider_name
+  ) {
+    const organization = encodeURIComponent(identity.parts[1]);
+    const project = encodeURIComponent(repository.provider_owner);
+    const name = encodeURIComponent(repository.provider_name);
+    return new URL(`https://dev.azure.com/${organization}/${project}/_git/${name}`);
+  }
+  return null;
+}
+
+function parseRepositoryRemote(repository: ExternalVcsRepository): URL | null {
+  return parseHTTPSRemote(repository.remote_url) ?? sshRemoteForRepository(repository);
+}
+
+function githubRemoteMatches(
+  repository: ExternalVcsRepository,
+  remote: URL,
+  parts: string[],
+): boolean {
+  const origin = parseProviderOrigin(repository.provider_host) ?? "https://github.com";
+  return (
+    remote.origin === origin &&
+    origin === "https://github.com" &&
+    repositoryPathMatches(parts, repository.provider_owner, repository.provider_name)
+  );
+}
+
+function gitlabRemoteMatches(
+  repository: ExternalVcsRepository,
+  remote: URL,
+  parts: string[],
+): boolean {
+  const origin = parseProviderOrigin(repository.provider_host);
+  return Boolean(
+    origin &&
+    remote.origin === origin &&
+    repositoryPathMatches(parts, repository.provider_owner, repository.provider_name),
+  );
+}
+
+function azureRemoteMatches(
+  repository: ExternalVcsRepository,
+  remote: URL,
+  parts: string[],
+): boolean {
+  return (
+    remote.hostname === "dev.azure.com" &&
+    parts.length === 4 &&
+    parts[1] === repository.provider_owner &&
+    parts[2] === "_git" &&
+    parts[3] === repository.provider_name
+  );
+}
+
+function resolveProvider(
+  repository: ExternalVcsRepository,
+  remote: URL,
+): ExternalVcsProvider | null {
+  const provider = repository.provider.toLowerCase();
+  const parts = decodedRemoteParts(remote);
+  if (!parts || !repository.provider_owner || !repository.provider_name) return null;
+
+  if (provider === "github" && githubRemoteMatches(repository, remote, parts)) return "github";
+  if (provider === "gitlab" && gitlabRemoteMatches(repository, remote, parts)) return "gitlab";
+  if (provider === "azure_devops" && azureRemoteMatches(repository, remote, parts)) {
+    return "azure_devops";
+  }
+  return null;
+}
+
+function encodeRepositoryPath(owner: string, name: string): string {
+  return owner
+    .split("/")
+    .concat(name)
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+}
+
+function buildFileURL(
+  provider: ExternalVcsProvider,
+  repository: ExternalVcsRepository,
+  remote: URL,
+  target: ResolvedTarget,
+): string {
+  if (provider === "azure_devops") {
+    const url = new URL(remote.toString());
+    url.pathname = url.pathname.replace(/\/+$/, "");
+    url.searchParams.set("path", `/${target.path}`);
+    url.searchParams.set("version", `GB${target.revision}`);
+    return url.toString();
+  }
+  const repositoryPath = encodeRepositoryPath(repository.provider_owner, repository.provider_name);
+  const route = provider === "gitlab" ? "-/blob" : "blob";
+  const filePath = target.path.split("/").map(encodeURIComponent).join("/");
+  return `${remote.origin}/${repositoryPath}/${route}/${encodeURIComponent(target.revision)}/${filePath}`;
+}
+
+export function resolveExternalVcsFileURL(
+  input: ExternalVcsFileURLInput,
+): ExternalVcsFileURL | null {
+  const remote = parseRepositoryRemote(input.repository);
+  const provider = remote ? resolveProvider(input.repository, remote) : null;
+  const target = selectTarget(input);
+  if (
+    !remote ||
+    !provider ||
+    !target ||
+    !isSafeRepositoryPath(target.path) ||
+    !isSafeRef(target.revision)
+  ) {
+    return null;
+  }
+  return {
+    provider,
+    url: buildFileURL(provider, input.repository, remote, target),
+    path: target.path,
+    revision: target.revision,
+  };
+}

--- a/apps/web/lib/utils/external-vcs-file-url.ts
+++ b/apps/web/lib/utils/external-vcs-file-url.ts
@@ -14,6 +14,7 @@ export type ExternalVcsFileURLInput = {
   previousPath?: string | null;
   status?: string | null;
   publishedBranch?: string | null;
+  publishedPullRequestNumber?: number | null;
   baseBranch?: string | null;
 };
 
@@ -24,7 +25,7 @@ export type ExternalVcsFileURL = {
   revision: string;
 };
 
-type ResolvedTarget = { path: string; revision: string };
+type ResolvedTarget = { path: string; revision: string; usesPublishedRevision: boolean };
 type SSHCloneIdentity = { hostname: string; parts: string[] };
 
 function cleanValue(value: string | null | undefined): string {
@@ -57,15 +58,23 @@ function selectTarget(input: ExternalVcsFileURLInput): ResolvedTarget | null {
   const status = cleanValue(input.status).toLowerCase();
 
   if (status === "deleted") {
-    return baseBranch ? { path: currentPath, revision: baseBranch } : null;
+    return baseBranch
+      ? { path: currentPath, revision: baseBranch, usesPublishedRevision: false }
+      : null;
   }
   if (status === "renamed") {
-    if (publishedBranch) return { path: currentPath, revision: publishedBranch };
-    return baseBranch && previousPath ? { path: previousPath, revision: baseBranch } : null;
+    if (publishedBranch) {
+      return { path: currentPath, revision: publishedBranch, usesPublishedRevision: true };
+    }
+    return baseBranch && previousPath
+      ? { path: previousPath, revision: baseBranch, usesPublishedRevision: false }
+      : null;
   }
   if ((status === "added" || status === "untracked") && !publishedBranch) return null;
   const revision = publishedBranch || baseBranch;
-  return revision ? { path: currentPath, revision } : null;
+  return revision
+    ? { path: currentPath, revision, usesPublishedRevision: Boolean(publishedBranch) }
+    : null;
 }
 
 function parseHTTPSRemote(rawRemoteURL: string | undefined): URL | null {
@@ -321,7 +330,7 @@ function buildFileURL(
 ): string {
   if (provider === "azure_devops") {
     const url = new URL(remote.toString());
-    url.pathname = url.pathname.replace(/\/+$/, "");
+    url.pathname = url.pathname.replace(/\/+$/, "").replace(/\.git$/, "");
     url.searchParams.set("path", `/${target.path}`);
     url.searchParams.set("version", `GB${target.revision}`);
     return url.toString();
@@ -330,6 +339,23 @@ function buildFileURL(
   const route = provider === "gitlab" ? "-/blob" : "blob";
   const filePath = target.path.split("/").map(encodeURIComponent).join("/");
   return `${remote.origin}/${repositoryPath}/${route}/${encodeURIComponent(target.revision)}/${filePath}`;
+}
+
+function githubPullHeadRevision(
+  provider: ExternalVcsProvider,
+  target: ResolvedTarget,
+  pullRequestNumber: number | null | undefined,
+): string {
+  if (
+    provider !== "github" ||
+    !target.usesPublishedRevision ||
+    !Number.isSafeInteger(pullRequestNumber) ||
+    !pullRequestNumber ||
+    pullRequestNumber < 1
+  ) {
+    return target.revision;
+  }
+  return `refs/pull/${pullRequestNumber}/head`;
 }
 
 export function resolveExternalVcsFileURL(
@@ -347,10 +373,14 @@ export function resolveExternalVcsFileURL(
   ) {
     return null;
   }
+  const resolvedTarget = {
+    ...target,
+    revision: githubPullHeadRevision(provider, target, input.publishedPullRequestNumber),
+  };
   return {
     provider,
-    url: buildFileURL(provider, input.repository, remote, target),
-    path: target.path,
-    revision: target.revision,
+    url: buildFileURL(provider, input.repository, remote, resolvedTarget),
+    path: resolvedTarget.path,
+    revision: resolvedTarget.revision,
   };
 }

--- a/apps/web/lib/utils/external-vcs-file-url.ts
+++ b/apps/web/lib/utils/external-vcs-file-url.ts
@@ -14,7 +14,6 @@ export type ExternalVcsFileURLInput = {
   previousPath?: string | null;
   status?: string | null;
   publishedBranch?: string | null;
-  publishedPullRequestNumber?: number | null;
   baseBranch?: string | null;
 };
 
@@ -25,7 +24,7 @@ export type ExternalVcsFileURL = {
   revision: string;
 };
 
-type ResolvedTarget = { path: string; revision: string; usesPublishedRevision: boolean };
+type ResolvedTarget = { path: string; revision: string };
 type SSHCloneIdentity = { hostname: string; parts: string[] };
 
 function cleanValue(value: string | null | undefined): string {
@@ -58,23 +57,17 @@ function selectTarget(input: ExternalVcsFileURLInput): ResolvedTarget | null {
   const status = cleanValue(input.status).toLowerCase();
 
   if (status === "deleted") {
-    return baseBranch
-      ? { path: currentPath, revision: baseBranch, usesPublishedRevision: false }
-      : null;
+    return baseBranch ? { path: currentPath, revision: baseBranch } : null;
   }
   if (status === "renamed") {
     if (publishedBranch) {
-      return { path: currentPath, revision: publishedBranch, usesPublishedRevision: true };
+      return { path: currentPath, revision: publishedBranch };
     }
-    return baseBranch && previousPath
-      ? { path: previousPath, revision: baseBranch, usesPublishedRevision: false }
-      : null;
+    return baseBranch && previousPath ? { path: previousPath, revision: baseBranch } : null;
   }
   if ((status === "added" || status === "untracked") && !publishedBranch) return null;
   const revision = publishedBranch || baseBranch;
-  return revision
-    ? { path: currentPath, revision, usesPublishedRevision: Boolean(publishedBranch) }
-    : null;
+  return revision ? { path: currentPath, revision } : null;
 }
 
 function parseHTTPSRemote(rawRemoteURL: string | undefined): URL | null {
@@ -341,23 +334,6 @@ function buildFileURL(
   return `${remote.origin}/${repositoryPath}/${route}/${encodeURIComponent(target.revision)}/${filePath}`;
 }
 
-function githubPullHeadRevision(
-  provider: ExternalVcsProvider,
-  target: ResolvedTarget,
-  pullRequestNumber: number | null | undefined,
-): string {
-  if (
-    provider !== "github" ||
-    !target.usesPublishedRevision ||
-    !Number.isSafeInteger(pullRequestNumber) ||
-    !pullRequestNumber ||
-    pullRequestNumber < 1
-  ) {
-    return target.revision;
-  }
-  return `refs/pull/${pullRequestNumber}/head`;
-}
-
 export function resolveExternalVcsFileURL(
   input: ExternalVcsFileURLInput,
 ): ExternalVcsFileURL | null {
@@ -373,14 +349,10 @@ export function resolveExternalVcsFileURL(
   ) {
     return null;
   }
-  const resolvedTarget = {
-    ...target,
-    revision: githubPullHeadRevision(provider, target, input.publishedPullRequestNumber),
-  };
   return {
     provider,
-    url: buildFileURL(provider, input.repository, remote, resolvedTarget),
-    path: resolvedTarget.path,
-    revision: resolvedTarget.revision,
+    url: buildFileURL(provider, input.repository, remote, target),
+    path: target.path,
+    revision: target.revision,
   };
 }

--- a/docs/plans/external-vcs-file-links/plan.md
+++ b/docs/plans/external-vcs-file-links/plan.md
@@ -1,0 +1,103 @@
+---
+spec: docs/specs/ui/external-vcs-file-links.md
+created: 2026-07-22
+status: complete
+---
+
+# Implementation Plan: External VCS File Links
+
+## Overview
+
+Add one shared, fail-closed external-file URL resolver and one provider-aware link control, hydrate the linked-review metadata once per task, then reuse the control across all existing diff/file toolbar families. The backend exposes the already-persisted repository `remote_url` through its shared read-only DTO; generic repository settings must not gain a new clone-URL write path. Linked GitHub PR, GitLab MR, and Azure DevOps PR branches already have frontend stores and loaders.
+
+## Backend
+
+`task.Repository` already persists `remote_url`, but the shared repository DTO did not emit it. Add read-only DTO serialization and focused regression coverage. Do not accept `remote_url` through generic repository create/update settings because the same field is a clone target; repository creation continues to populate it through the existing provider/task resolution path. GitHub `TaskPR.head_branch`, GitLab `TaskMR.head_branch`, and Azure DevOps `TaskPR.sourceBranch` already expose published review branches.
+
+## Frontend
+
+### External URL contract and task metadata
+
+- `apps/web/lib/types/http.ts`: add the existing backend `remote_url` field to the `Repository` TypeScript contract.
+- `apps/web/lib/utils/external-vcs-file-url.ts`: add a pure `resolveExternalVcsFileURL` helper. It validates credential-free HTTPS origins, safely derives canonical web origins from supported HTTPS or SSH clone identities, produces GitHub `blob`, GitLab `-/blob`, and Azure DevOps `path`/`version=GB...` URLs, and applies added/deleted/renamed revision/path rules from the spec.
+- `apps/web/hooks/domains/workspace/use-external-vcs-file-link.ts`: resolve the file's task repository from explicit repository ID first, repository name second, and the session's sole repository only when unambiguous. Match published branches by provider + repository and, for repeated-repository/multi-branch tasks, the active worktree branch; otherwise use the exact task/session base branch. Return `null` for ambiguous or incomplete contexts.
+- The same hook exposes a task-level hydration helper used once by `apps/web/components/task/task-page-content.tsx`. It enables only the applicable existing loaders: `useTaskPR`, `useWorkspaceMRs`, and `useAzureDevOpsTaskPullRequests`, so per-file controls read stores without issuing duplicate requests.
+- `apps/web/components/editors/external-vcs-file-link.tsx`: render a provider-brand semantic anchor styled as an icon button, with `target="_blank"`, `rel="noopener noreferrer"`, and provider-specific accessible name/tooltip. Support compact desktop (`xs`/`sm`) and 44px touch sizing.
+
+### Toolbar integrations
+
+- `apps/web/components/diff/{file-diff-viewer.tsx,diff-viewer.tsx,use-diff-options.tsx,diff-header-toolbar.tsx}`: carry session/repository/status/previous-path context into the common Pierre diff header and place the shared action beside existing file actions. This covers Changes and commit-detail diff headers on desktop and in the mobile diff drawer.
+- `apps/web/components/review/{review-diff-list.tsx,review-diff-toolbar.tsx}`: pass the `ReviewFile` source/status/old-path/repository identity into the sticky Review toolbar and render the same action. Explicit PR-source context wins over inferred local state.
+- Built-in editor/viewer toolbars: render the action beside existing file actions for Monaco and CodeMirror text/Markdown editors, Monaco and Pierre diff headers, and desktop image/binary viewers.
+- `apps/web/components/task/mobile/mobile-file-viewer-panel.tsx`: render the touch-sized action in the dedicated mobile file-viewer header for text, Markdown, image, and binary viewers.
+
+### Mobile design contract
+
+- **Desktop outcome:** a compact provider icon in each existing diff/file toolbar opens the externally hosted file without leaving Kandev.
+- **Mobile entry point:** the existing `MobileFileViewerPanel` header and Review sticky file header expose the same action directly; the full-height `MobileDiffSheet` inherits it through the shared diff toolbar.
+- **Nearest exemplars:** `mobile-file-viewer-panel.tsx` supplies the dedicated dense-file header; `mobile-review-file-status.spec.ts` supplies the sticky Review header and no-horizontal-overflow contract.
+- **Hierarchy/presentation:** this is one immediate secondary action, so it stays inline rather than opening a drawer or menu. File content remains the focal surface.
+- **Geometry:** existing CodeMirror/Pierre content remains the single scroll owner. The new mobile control has a 44px active dimension; no fixed positioning or new safe-area owner is introduced.
+- **Shared logic:** URL, repository, revision, and status resolution are identical across viewports; only the control size changes.
+
+## Tests
+
+- **Provider URL construction and security:** `apps/web/lib/utils/external-vcs-file-url.test.ts` uses table-driven cases for GitHub, self-hosted GitLab, Azure DevOps, encoded refs/paths, clone suffix removal, non-HTTPS/credential rejection, and unsupported providers.
+- **Revision/path selection:** the same utility tests cover published-head preference, base fallback, added/untracked suppression, deleted-base targeting, and renamed old/new path behavior.
+- **Repository and branch resolution:** `apps/web/hooks/domains/workspace/use-external-vcs-file-link.test.tsx` covers single repo, multi-repo, repeated-repository/multi-branch matching, legacy unambiguous fallback, and fail-closed ambiguity.
+- **Semantic action:** `apps/web/components/editors/external-vcs-file-link.test.tsx` verifies provider label/icon, new-tab/rel attributes, compact/touch sizing, and omission when the hook returns no URL.
+- **Diff toolbar wiring:** extend `apps/web/components/diff/diff-header-toolbar.test.tsx` and add/extend `apps/web/components/review/review-diff-toolbar.test.tsx` to prove file/repository/status context reaches the shared action without regressing existing controls.
+- **Editor/mobile wiring:** add focused component coverage for Monaco and CodeMirror editors/diffs, desktop image/binary viewers, and `mobile-file-viewer-panel.tsx` for link presence and omission.
+
+Focused backend DTO coverage proves persisted `remote_url` is serialized without introducing a generic write path. Rendered component tests plus real browser E2E cover the complete existing-state-to-anchor path.
+
+## E2E Tests
+
+- **Desktop published branch:** `apps/web/e2e/tests/review/external-vcs-file-link.spec.ts` configures a GitHub repository and linked PR, opens Review/Changes, activates `Open file in GitHub`, and asserts the new tab targets the PR head file URL.
+- **Desktop base fallback and unavailable added file:** the same spec verifies an existing file links to base when no PR is linked and an added/untracked file does not offer the action.
+- **Mobile parity:** `apps/web/e2e/tests/task/mobile-external-vcs-file-link.spec.ts` opens a supported file through Files, verifies the 44px provider action and target URL, activates it in a new tab, and asserts no document-level horizontal overflow.
+
+## Implementation Waves
+
+Wave 1:
+
+- [x] [task-01-link-foundation](task-01-link-foundation.md) — done; implementer, balanced model
+
+Wave 2:
+
+- [x] [task-02-toolbar-wiring](task-02-toolbar-wiring.md) — implementer, balanced model; depends on task 01 — done
+
+Wave 3:
+
+- [x] [task-04-repository-remote-url-contract](task-04-repository-remote-url-contract.md) — implementer, balanced model; unblocked browser coverage after the real HTTP contract omitted `remote_url` — done
+- [x] [task-03-browser-coverage](task-03-browser-coverage.md) — test-engineer, balanced model; depends on tasks 01-02 and task 04 — done
+
+After Wave 3, run delegated simplification, security review, QA, and full verification in that order.
+
+Review remediation:
+
+- [x] [task-05-safe-remote-url-exposure](task-05-safe-remote-url-exposure.md) — removed the unsafe generic write-through, retained read-only DTO exposure, and seeded E2E through the existing provider/task flow — done
+- [x] [task-06-resolver-correctness](task-06-resolver-correctness.md) — fixed single/repeated repository resolution and added safe SSH clone identities — done
+- [x] [task-07-toolbar-completeness](task-07-toolbar-completeness.md) — completed CodeMirror, Monaco diff, image/binary toolbar coverage and restored the TS file-size limit — done
+
+## Verification
+
+Targeted commands are recorded in each task file. Final verification runs from the repository root in the required order:
+
+```bash
+make fmt
+make typecheck test lint
+```
+
+Focused browser verification runs the two new Playwright specs against rebuilt production assets:
+
+```bash
+cd apps/web && pnpm e2e -- tests/review/external-vcs-file-link.spec.ts --project=chromium
+cd apps/web && pnpm e2e -- tests/task/mobile-external-vcs-file-link.spec.ts --project=mobile-chrome
+```
+
+## Risks
+
+- Repeated-repository tasks can have several linked reviews for one repository ID. Resolution must include active branch context and fail closed when no unique review branch can be selected.
+- Provider clone URLs may contain `.git`, nested GitLab namespaces, ports, or credentials. The resolver must preserve valid host/path identity while rejecting any URL that could expose credentials.
+- Dense Pierre/Review headers can overflow on narrow viewports. The mobile test must prove action reachability and unchanged scroll ownership.

--- a/docs/plans/external-vcs-file-links/task-01-link-foundation.md
+++ b/docs/plans/external-vcs-file-links/task-01-link-foundation.md
@@ -1,0 +1,50 @@
+---
+id: "01-link-foundation"
+title: "External VCS link foundation"
+status: done
+wave: 1
+depends_on: []
+plan: "plan.md"
+spec: "../../specs/ui/external-vcs-file-links.md"
+---
+
+# Task 01: External VCS link foundation
+
+## Acceptance
+
+- GitHub, self-hosted GitLab, and Azure DevOps file URLs are built from credential-free repository metadata with correct provider routing and URL encoding.
+- Published review branches, base fallback, added/deleted/renamed rules, multi-repo identity, and repeated-repository ambiguity match the approved spec.
+- A reusable provider-branded semantic link control is available in compact desktop and 44px touch sizes, while applicable linked-review metadata hydrates once per task rather than once per file.
+
+## Verification
+
+```bash
+cd apps && pnpm --filter @kandev/web test -- lib/utils/external-vcs-file-url.test.ts hooks/domains/workspace/use-external-vcs-file-link.test.tsx components/editors/external-vcs-file-link.test.tsx
+cd apps/web && pnpm run typecheck
+```
+
+## Files likely touched
+
+- `apps/web/lib/types/http.ts`
+- `apps/web/lib/utils/external-vcs-file-url.ts`
+- `apps/web/lib/utils/external-vcs-file-url.test.ts`
+- `apps/web/hooks/domains/workspace/use-external-vcs-file-link.ts`
+- `apps/web/hooks/domains/workspace/use-external-vcs-file-link.test.tsx`
+- `apps/web/components/editors/external-vcs-file-link.tsx`
+- `apps/web/components/editors/external-vcs-file-link.test.tsx`
+- `apps/web/components/task/task-page-content.tsx`
+
+## Dependencies
+
+None.
+
+## Inputs
+
+- Spec: `What`, `Failure modes`, and all provider/revision scenarios.
+- Plan: `External URL contract and task metadata` and `Mobile design contract`.
+- Architecture: ADR `2026-07-20-provider-neutral-remote-repositories`, ADR `2026-07-20-repository-provider-origin-identity`, and ADR `0013-multi-branch-tasks`.
+- Patterns: `useRepository`, `useTaskPR`, `useWorkspaceMRs`, `useAzureDevOpsTaskPullRequests`, and existing external anchors with `noopener noreferrer`.
+
+## Output contract
+
+Report summary, files changed, tests/commands with results, blockers, security risks, and any divergence. Update only this task file's `status` to `in_progress` at start and `done` after acceptance and verification pass; do not edit `plan.md`.

--- a/docs/plans/external-vcs-file-links/task-02-toolbar-wiring.md
+++ b/docs/plans/external-vcs-file-links/task-02-toolbar-wiring.md
@@ -19,8 +19,8 @@ spec: "../../specs/ui/external-vcs-file-links.md"
 ## Verification
 
 ```bash
-cd apps && pnpm --filter @kandev/web test -- components/diff/diff-header-toolbar.test.tsx components/review/review-diff-toolbar.test.tsx components/editors/external-vcs-file-link.test.tsx
-cd apps/web && pnpm run typecheck
+(cd apps && pnpm --filter @kandev/web test -- components/diff/diff-header-toolbar.test.tsx components/review/review-diff-toolbar.test.tsx components/editors/external-vcs-file-link.test.tsx)
+(cd apps/web && pnpm run typecheck)
 ```
 
 ## Files likely touched
@@ -50,3 +50,10 @@ cd apps/web && pnpm run typecheck
 ## Output contract
 
 Report summary, files changed, tests/commands with results, blockers, visual/mobile risks, and any divergence. Update only this task file's `status` to `in_progress` at start and `done` after acceptance and verification pass; do not edit `plan.md`.
+
+## Completion report
+
+- **Summary:** Wired the shared provider action into Pierre Changes/commit and Review diffs, Monaco editing, Markdown preview, and the dedicated mobile file viewer. File status, old path, repository, session, and published-branch context now reach the resolver without cross-repository fallback.
+- **Changed scope:** Diff context/header wiring; Review file toolbar/context; Monaco, Markdown, and mobile file-viewer toolbars; adjacent component tests.
+- **Focused verification:** `(cd apps && pnpm --filter @kandev/web test -- components/diff/diff-header-toolbar.test.tsx components/review/review-diff-toolbar.test.tsx components/editors/external-vcs-file-link.test.tsx)` passed with the adjacent toolbar coverage (32 tests total); `(cd apps/web && pnpm run typecheck)` passed; targeted ESLint and `git diff --check` also passed.
+- **Risks/divergence:** Dense mobile headers retained a touch-sized action, but real-browser overflow/reachability remained the follow-up risk addressed by browser coverage.

--- a/docs/plans/external-vcs-file-links/task-02-toolbar-wiring.md
+++ b/docs/plans/external-vcs-file-links/task-02-toolbar-wiring.md
@@ -1,0 +1,52 @@
+---
+id: "02-toolbar-wiring"
+title: "Toolbar action wiring"
+status: done
+wave: 2
+depends_on: ["01-link-foundation"]
+plan: "plan.md"
+spec: "../../specs/ui/external-vcs-file-links.md"
+---
+
+# Task 02: Toolbar action wiring
+
+## Acceptance
+
+- Changes/commit diffs, Review diffs, desktop Monaco file editing/preview, and the mobile file viewer expose the shared action whenever their file context resolves.
+- File status, previous path, repository ID/name, session, and explicit PR-source revision flow through without cross-repository or cross-branch fallback.
+- Existing toolbar actions, desktop density, mobile 44px reachability, and file/diff scroll ownership remain intact.
+
+## Verification
+
+```bash
+cd apps && pnpm --filter @kandev/web test -- components/diff/diff-header-toolbar.test.tsx components/review/review-diff-toolbar.test.tsx components/editors/external-vcs-file-link.test.tsx
+cd apps/web && pnpm run typecheck
+```
+
+## Files likely touched
+
+- `apps/web/components/diff/file-diff-viewer.tsx`
+- `apps/web/components/diff/diff-viewer.tsx`
+- `apps/web/components/diff/use-diff-options.tsx`
+- `apps/web/components/diff/diff-header-toolbar.tsx`
+- `apps/web/components/diff/diff-header-toolbar.test.tsx`
+- `apps/web/components/review/review-diff-list.tsx`
+- `apps/web/components/review/review-diff-toolbar.tsx`
+- `apps/web/components/review/review-diff-toolbar.test.tsx`
+- `apps/web/components/editors/monaco/monaco-editor-toolbar.tsx`
+- `apps/web/components/task/mobile/mobile-file-viewer-panel.tsx`
+- Focused component tests adjacent to the editor/mobile surfaces if existing coverage does not exercise the new control.
+
+## Dependencies
+
+- `01-link-foundation` complete.
+
+## Inputs
+
+- Spec: cross-surface, status/path, new-tab, accessibility, and mobile scenarios.
+- Plan: `Toolbar integrations` and `Mobile design contract`.
+- Patterns: existing `ToolbarBtn`/`ToolbarIconBtn`, `FileActionsDropdown`, `PanelHeaderBarSplit`, `MobileFileViewerPanel`, and `ReviewFile` identity fields.
+
+## Output contract
+
+Report summary, files changed, tests/commands with results, blockers, visual/mobile risks, and any divergence. Update only this task file's `status` to `in_progress` at start and `done` after acceptance and verification pass; do not edit `plan.md`.

--- a/docs/plans/external-vcs-file-links/task-03-browser-coverage.md
+++ b/docs/plans/external-vcs-file-links/task-03-browser-coverage.md
@@ -3,7 +3,7 @@ id: "03-browser-coverage"
 title: "Browser coverage"
 status: done
 wave: 3
-depends_on: ["01-link-foundation", "02-toolbar-wiring", "04-repository-remote-url-contract"]
+depends_on: ["01-link-foundation", "02-toolbar-wiring"]
 plan: "plan.md"
 spec: "../../specs/ui/external-vcs-file-links.md"
 ---
@@ -19,8 +19,8 @@ spec: "../../specs/ui/external-vcs-file-links.md"
 ## Verification
 
 ```bash
-cd apps/web && pnpm e2e -- tests/review/external-vcs-file-link.spec.ts --project=chromium
-cd apps/web && pnpm e2e -- tests/task/mobile-external-vcs-file-link.spec.ts --project=mobile-chrome
+(cd apps/web && pnpm e2e -- tests/review/external-vcs-file-link.spec.ts --project=chromium)
+(cd apps/web && pnpm e2e -- tests/task/mobile-external-vcs-file-link.spec.ts --project=mobile-chrome)
 ```
 
 ## Files likely touched
@@ -42,3 +42,10 @@ cd apps/web && pnpm e2e -- tests/task/mobile-external-vcs-file-link.spec.ts --pr
 ## Output contract
 
 Report summary, files changed, exact Playwright results, screenshots/geometry observations when useful, blockers, flakes, and any divergence. Update only this task file's `status` to `in_progress` at start and `done` after acceptance and verification pass; do not edit `plan.md`.
+
+## Completion report
+
+- **Summary:** Added isolated desktop and mobile browser coverage for a provider-backed file link, including published-head, base fallback, and unavailable added-file behavior.
+- **Changed scope:** `apps/web/e2e/tests/review/external-vcs-file-link.spec.ts`, `apps/web/e2e/tests/task/mobile-external-vcs-file-link.spec.ts`, and E2E repository setup helpers needed to seed trusted provider/task metadata.
+- **Focused verification:** `(cd apps/web && pnpm e2e -- tests/review/external-vcs-file-link.spec.ts --project=chromium)` passed (2 tests); `(cd apps/web && pnpm e2e -- tests/task/mobile-external-vcs-file-link.spec.ts --project=mobile-chrome)` passed (1 test). The mobile scenario asserted a 44px control, same new-tab target, and no document horizontal overflow.
+- **Blockers/risks:** No provider credentials or developer-instance dependency was introduced. The generic repository HTTP write path was later deliberately excluded by the security remediation; fixture setup uses the trusted provider/task path.

--- a/docs/plans/external-vcs-file-links/task-03-browser-coverage.md
+++ b/docs/plans/external-vcs-file-links/task-03-browser-coverage.md
@@ -1,0 +1,44 @@
+---
+id: "03-browser-coverage"
+title: "Browser coverage"
+status: done
+wave: 3
+depends_on: ["01-link-foundation", "02-toolbar-wiring", "04-repository-remote-url-contract"]
+plan: "plan.md"
+spec: "../../specs/ui/external-vcs-file-links.md"
+---
+
+# Task 03: Browser coverage
+
+## Acceptance
+
+- Desktop Playwright proves a GitHub linked-PR file action opens the head-branch file in a new tab, base fallback works, and an unpublished added file has no action.
+- Mobile Playwright proves the Files viewer exposes the same target through a 44px control, opens a new tab, and does not create document horizontal overflow.
+- Tests configure provider metadata through existing E2E APIs and do not rely on a developer instance or external provider credentials.
+
+## Verification
+
+```bash
+cd apps/web && pnpm e2e -- tests/review/external-vcs-file-link.spec.ts --project=chromium
+cd apps/web && pnpm e2e -- tests/task/mobile-external-vcs-file-link.spec.ts --project=mobile-chrome
+```
+
+## Files likely touched
+
+- `apps/web/e2e/tests/review/external-vcs-file-link.spec.ts`
+- `apps/web/e2e/tests/task/mobile-external-vcs-file-link.spec.ts`
+- `apps/web/e2e/helpers/api-client.ts` only if existing repository setup helpers cannot express the provider metadata needed by these isolated tests.
+
+## Dependencies
+
+- `01-link-foundation` and `02-toolbar-wiring` complete.
+
+## Inputs
+
+- Spec: desktop published/base/unavailable scenarios and mobile parity scenario.
+- Plan: `E2E Tests` and `Mobile design contract`.
+- Patterns: `mobile-file-viewer.spec.ts`, `mobile-review-file-status.spec.ts`, `SessionPage`, and existing mock GitHub association helpers.
+
+## Output contract
+
+Report summary, files changed, exact Playwright results, screenshots/geometry observations when useful, blockers, flakes, and any divergence. Update only this task file's `status` to `in_progress` at start and `done` after acceptance and verification pass; do not edit `plan.md`.

--- a/docs/plans/external-vcs-file-links/task-04-repository-remote-url-contract.md
+++ b/docs/plans/external-vcs-file-links/task-04-repository-remote-url-contract.md
@@ -1,0 +1,44 @@
+---
+id: "04-repository-remote-url-contract"
+title: "Repository remote URL HTTP contract"
+status: superseded
+wave: 3
+depends_on: ["01-link-foundation", "02-toolbar-wiring"]
+plan: "plan.md"
+spec: "../../specs/ui/external-vcs-file-links.md"
+---
+
+# Task 04: Repository remote URL HTTP contract
+
+> Superseded by task 05 after security review found that a generic write-through would create an unsafe clone-target input. Only read-only DTO exposure is retained.
+
+## Acceptance
+
+- Repository create and update HTTP requests accept `remote_url` and pass it through the existing service request boundary.
+- Repository HTTP and boot/list responses include the persisted `remote_url` through the shared repository DTO.
+- Regression tests fail before the contract fix and pass afterward for create, update, and DTO serialization.
+- Existing repository validation and persistence behavior is unchanged.
+
+## Verification
+
+```bash
+cd apps/backend && go test ./internal/task/handlers ./internal/task/dto ./internal/task/service
+```
+
+## Files likely touched
+
+- `apps/backend/internal/task/handlers/repository_handlers.go`
+- `apps/backend/internal/task/handlers/repository_handlers_test.go`
+- `apps/backend/internal/task/dto/dto.go`
+- `apps/backend/internal/task/dto/dto_test.go` if a focused DTO test is needed
+- `apps/backend/internal/task/service/service_requests.go`
+- `apps/backend/internal/task/service/service_resources.go`
+- Existing focused service tests only if required for update pass-through coverage.
+
+## Dependencies
+
+- Browser RED evidence from task 03 proves the production payload omission.
+
+## Output contract
+
+Report the failing regression test, minimal fix, exact Go test results, changed files, and any similar HTTP/WS contract gaps discovered. Update only this task file's `status` to `in_progress` at start and `done` after targeted verification passes; do not edit `plan.md`.

--- a/docs/plans/external-vcs-file-links/task-04-repository-remote-url-contract.md
+++ b/docs/plans/external-vcs-file-links/task-04-repository-remote-url-contract.md
@@ -10,35 +10,8 @@ spec: "../../specs/ui/external-vcs-file-links.md"
 
 # Task 04: Repository remote URL HTTP contract
 
-> Superseded by task 05 after security review found that a generic write-through would create an unsafe clone-target input. Only read-only DTO exposure is retained.
+## Historical supersession
 
-## Acceptance
+This task is superseded by [task 05](task-05-safe-remote-url-exposure.md). Security review rejected its proposed generic `remote_url` create/update write-through because that field is a clone target and must not become a broad user-controlled input.
 
-- Repository create and update HTTP requests accept `remote_url` and pass it through the existing service request boundary.
-- Repository HTTP and boot/list responses include the persisted `remote_url` through the shared repository DTO.
-- Regression tests fail before the contract fix and pass afterward for create, update, and DTO serialization.
-- Existing repository validation and persistence behavior is unchanged.
-
-## Verification
-
-```bash
-cd apps/backend && go test ./internal/task/handlers ./internal/task/dto ./internal/task/service
-```
-
-## Files likely touched
-
-- `apps/backend/internal/task/handlers/repository_handlers.go`
-- `apps/backend/internal/task/handlers/repository_handlers_test.go`
-- `apps/backend/internal/task/dto/dto.go`
-- `apps/backend/internal/task/dto/dto_test.go` if a focused DTO test is needed
-- `apps/backend/internal/task/service/service_requests.go`
-- `apps/backend/internal/task/service/service_resources.go`
-- Existing focused service tests only if required for update pass-through coverage.
-
-## Dependencies
-
-- Browser RED evidence from task 03 proves the production payload omission.
-
-## Output contract
-
-Report the failing regression test, minimal fix, exact Go test results, changed files, and any similar HTTP/WS contract gaps discovered. Update only this task file's `status` to `in_progress` at start and `done` after targeted verification passes; do not edit `plan.md`.
+There is no active acceptance, output, or verification contract for this task. Its safe read-only DTO portion continues through task 05: already-persisted `remote_url` is serialized for consumers, while generic repository create/update requests ignore submitted clone URLs. Provider/task resolution remains the trusted source of clone-target data.

--- a/docs/plans/external-vcs-file-links/task-05-safe-remote-url-exposure.md
+++ b/docs/plans/external-vcs-file-links/task-05-safe-remote-url-exposure.md
@@ -1,0 +1,22 @@
+---
+id: "05-safe-remote-url-exposure"
+title: "Safe remote URL exposure"
+status: done
+wave: remediation
+depends_on: ["04-repository-remote-url-contract"]
+plan: "plan.md"
+spec: "../../specs/ui/external-vcs-file-links.md"
+---
+
+# Task 05: Safe remote URL exposure
+
+## Acceptance
+
+- Generic repository create/update HTTP and service requests do not accept or persist a new `remote_url` clone target.
+- The shared repository DTO continues to expose the already-persisted value read-only.
+- Browser fixtures seed provider repositories through an existing provider/task path, not the generic settings API.
+- Focused backend and desktop/mobile browser regressions pass.
+
+## Output contract
+
+Report RED/GREEN evidence, changed files, exact focused results, and any remaining clone-URL trust boundary.

--- a/docs/plans/external-vcs-file-links/task-05-safe-remote-url-exposure.md
+++ b/docs/plans/external-vcs-file-links/task-05-safe-remote-url-exposure.md
@@ -3,7 +3,7 @@ id: "05-safe-remote-url-exposure"
 title: "Safe remote URL exposure"
 status: done
 wave: remediation
-depends_on: ["04-repository-remote-url-contract"]
+depends_on: []
 plan: "plan.md"
 spec: "../../specs/ui/external-vcs-file-links.md"
 ---
@@ -20,3 +20,10 @@ spec: "../../specs/ui/external-vcs-file-links.md"
 ## Output contract
 
 Report RED/GREEN evidence, changed files, exact focused results, and any remaining clone-URL trust boundary.
+
+## Completion report
+
+- **Summary:** Replaced the rejected generic write-through with a read-only repository DTO contract and a trusted provider/task fixture path for browser setup.
+- **Changed scope:** Repository DTO serialization and regression tests; generic repository handler/service request regression tests; E2E provider/task repository setup used by the desktop and mobile specs.
+- **Focused verification:** `(cd apps/backend && go test ./internal/task/handlers ./internal/task/dto ./internal/task/service)` passed; the external-file-link desktop and mobile Playwright specs passed using provider/task-seeded repositories.
+- **Trusted clone-URL boundary:** Generic repository create/update JSON ignores `remote_url`; only already-persisted values are exposed through the DTO. Provider/task resolution remains the trusted writer, so this work intentionally does not create a generic clone-target update API.

--- a/docs/plans/external-vcs-file-links/task-06-resolver-correctness.md
+++ b/docs/plans/external-vcs-file-links/task-06-resolver-correctness.md
@@ -1,0 +1,22 @@
+---
+id: "06-resolver-correctness"
+title: "Resolver correctness"
+status: done
+wave: remediation
+depends_on: ["01-link-foundation"]
+plan: "plan.md"
+spec: "../../specs/ui/external-vcs-file-links.md"
+---
+
+# Task 06: Resolver correctness
+
+## Acceptance
+
+- A single linked task repository resolves in commit-detail context without explicit session/repository identity.
+- A unique named session worktree resolves before metadata-name matching, including repeated-repository production-shaped inputs.
+- Supported GitHub, self-hosted GitLab, and Azure DevOps SSH clone identities produce credential-free HTTPS file URLs.
+- Unsafe schemes, credentials, malformed identities, traversal, and ambiguous context remain fail-closed with explicit tests.
+
+## Output contract
+
+Report RED/GREEN tests, changed files, exact focused checks, and residual provider-shape risks.

--- a/docs/plans/external-vcs-file-links/task-06-resolver-correctness.md
+++ b/docs/plans/external-vcs-file-links/task-06-resolver-correctness.md
@@ -20,3 +20,10 @@ spec: "../../specs/ui/external-vcs-file-links.md"
 ## Output contract
 
 Report RED/GREEN tests, changed files, exact focused checks, and residual provider-shape risks.
+
+## Completion report
+
+- **Summary:** Corrected repository/revision selection for commit-detail and repeated-repository worktrees, and completed safe SSH clone normalization for GitHub, self-hosted GitLab, and Azure DevOps.
+- **Changed scope:** `use-external-vcs-file-link` resolver and tests; `external-vcs-file-url` resolver and tests; Review published-PR context where the resolver needs the GitHub pull-head revision.
+- **Focused verification:** `(cd apps && pnpm --filter @kandev/web test -- lib/utils/external-vcs-file-url.test.ts hooks/domains/workspace/use-external-vcs-file-link.test.tsx)` passed; `(cd apps/web && pnpm run typecheck)` and targeted ESLint passed.
+- **Residual risk:** Provider clone shapes outside the supported GitHub, GitLab, and Azure DevOps HTTPS/SSH identities remain intentionally unavailable; malformed, credential-bearing, traversal, and ambiguous inputs fail closed.

--- a/docs/plans/external-vcs-file-links/task-07-toolbar-completeness.md
+++ b/docs/plans/external-vcs-file-links/task-07-toolbar-completeness.md
@@ -1,0 +1,22 @@
+---
+id: "07-toolbar-completeness"
+title: "Toolbar completeness"
+status: done
+wave: remediation
+depends_on: ["02-toolbar-wiring", "06-resolver-correctness"]
+plan: "plan.md"
+spec: "../../specs/ui/external-vcs-file-links.md"
+---
+
+# Task 07: Toolbar completeness
+
+## Acceptance
+
+- CodeMirror editor, Monaco diff, and desktop image/binary viewer toolbars expose the shared action when context is valid.
+- Existing Pierre, Monaco editor, Review, and mobile coverage remains intact.
+- Focused tests cover each newly wired provider family and omission behavior.
+- Changed TypeScript files remain within the repository's 600-line file limit; extract the Review file header/context cohesively.
+
+## Output contract
+
+Report RED/GREEN tests, changed files, typecheck/lint results, and any surface intentionally excluded by the spec.

--- a/docs/plans/external-vcs-file-links/task-07-toolbar-completeness.md
+++ b/docs/plans/external-vcs-file-links/task-07-toolbar-completeness.md
@@ -20,3 +20,10 @@ spec: "../../specs/ui/external-vcs-file-links.md"
 ## Output contract
 
 Report RED/GREEN tests, changed files, typecheck/lint results, and any surface intentionally excluded by the spec.
+
+## Completion report
+
+- **Summary:** Completed the missing CodeMirror editor, Monaco diff, and desktop image/binary toolbar integrations, while extracting Review header/context to keep changed TypeScript within the repository file-size limit.
+- **Changed scope:** CodeMirror and Monaco editor/diff toolbar components and tests; desktop file viewer header/image/binary integrations and tests; Review header/context extraction and focused coverage.
+- **Focused verification:** `(cd apps && pnpm --filter @kandev/web test -- components/editors/codemirror/codemirror-code-editor.external-link.test.tsx components/editors/monaco/diff-viewer-toolbar.test.tsx components/task/file-editor-panel.image.test.tsx components/task/file-tab-content.external-link.test.tsx components/review/review-diff-header.test.tsx)` passed; `(cd apps/web && pnpm run typecheck)` and targeted ESLint passed.
+- **Intentional exclusion:** Mobile nested desktop-style file headers do not render a duplicate action. `MobileFileViewerPanel` remains the single touch-sized mobile entry point, preserving its 44px control and avoiding competing nested headers.

--- a/docs/public/sessions-and-review.md
+++ b/docs/public/sessions-and-review.md
@@ -107,6 +107,14 @@ Changes are grouped by repository and then by state:
 
 From this panel you can stage or unstage files, discard working-tree changes, commit, amend, reset or revert commits, pull, rebase, merge, push, force-push, rename the task branch, choose a base branch, and create or open a pull request or merge request. Operations apply to the selected repository. Discarding a file is permanent, and history-changing operations can lose work or invalidate review; read [Git operations](git-operations.md) before using them.
 
+### Open a file in its external repository
+
+When Kandev has unambiguous repository context, file toolbars in Changes, Review, built-in viewers and editors, and their mobile layouts show **Open file in GitHub**, **Open file in GitLab**, or **Open file in Azure DevOps**. The action opens the provider page in a new browser tab. GitLab links support both `gitlab.com` and configured self-managed hosts.
+
+The link uses the published source branch from a linked pull or merge request for that repository when available; otherwise it uses the task repository's base branch. Added or untracked files do not show the action until they exist on a published source branch. Deleted files open their base-branch version, while renamed files open the new path on a published source branch or the previous path on the base branch.
+
+Kandev hides the action instead of guessing when a repository is local-only, unsupported, incompletely configured, or ambiguous. If a colleague cannot open the resulting page, check their permissions on the external repository; opening a link does not change provider access.
+
 ## Review a diff
 
 Select **Review** in the Changes header. Kandev builds a repository-aware file list by merging available uncommitted, cumulative committed, and linked-PR files. When a path occurs in more than one source, the uncommitted version wins deduplication.

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -121,6 +121,7 @@ Subscription quota tracking and per-agent cheap-model profile routing.
 | [mobile-task-navigation](ui/mobile-task-navigation.md) | shipped |
 | [task-layout-profiles](ui/task-layout-profiles.md) | draft |
 | [agent-message-comments](ui/agent-message-comments.md) | shipped |
+| [external-vcs-file-links](ui/external-vcs-file-links.md) | shipped |
 
 ## system-page/ — operational diagnostics & maintenance UI
 

--- a/docs/specs/ui/external-vcs-file-links.md
+++ b/docs/specs/ui/external-vcs-file-links.md
@@ -1,0 +1,56 @@
+---
+status: shipped
+created: 2026-07-22
+owner: kandev
+---
+
+# External VCS File Links
+
+## Why
+
+People reviewing or editing task files need a quick way to open the same file in its external repository and share that provider page with colleagues. Local worktree paths and Kandev-only diff views do not provide a portable collaboration link.
+
+## What
+
+- Task file and diff toolbars expose an `Open file in <provider>` action whenever Kandev can construct a valid external file URL for the file's repository and revision.
+- The action appears across task Changes diffs, built-in file viewers and editors, mobile equivalents, and Review diffs. It opens the external provider page in a new browser tab without replacing the Kandev task.
+- The first version supports GitHub, GitLab, and Azure DevOps. GitLab links preserve the configured host for self-hosted installations.
+- The external URL targets the linked pull-request or merge-request source branch for the same repository when that published branch is known. Otherwise it targets that task repository's base branch.
+- Multi-repository tasks resolve the repository, revision, and repository-relative file path from the file's own repository context. A file in one repository never links through another repository's provider metadata or published branch.
+- GitHub links use the repository's web origin and `blob` route. GitLab links use the repository's configured web origin and `-/blob` route. Azure DevOps links use the repository web URL with its file `path` and Git branch `version` query parameters.
+- Provider URL components, revisions, and file paths are encoded without changing their semantic values. Generated links contain no embedded credentials, access tokens, or local filesystem paths.
+- Added or untracked files require a known published source branch; Kandev does not link them to a base revision where they do not exist. Deleted files link to their base-branch version. Renamed files use the published new path when available, otherwise the base revision's previous path when that path is known.
+- The action is unavailable when the repository is local-only, its provider is unsupported, required provider metadata is missing, the repository context is ambiguous, or no revision/path combination is expected to exist externally. Kandev does not guess an unknown provider's web URL shape.
+- The action has an accessible provider-specific name and tooltip. On touch layouts it remains directly reachable, has at least a 44 px active dimension, and does not introduce document-level horizontal overflow.
+
+## Failure modes
+
+- If published-review metadata is absent or incomplete, the action falls back to the task repository's base branch when the file is expected to exist there.
+- If provider or repository metadata cannot produce a credential-free HTTPS web URL, the action is omitted rather than opening a malformed or sensitive URL.
+- If a popup blocker prevents the new tab, Kandev remains on the current task surface and does not lose local state.
+
+## Scenarios
+
+- **GIVEN** a GitHub task with a linked pull request for the file's repository, **WHEN** the user activates the file action, **THEN** a new tab opens the file on the pull request's head branch.
+- **GIVEN** a self-hosted GitLab task with a linked merge request, **WHEN** the user activates the file action, **THEN** a new tab opens the `-/blob` file route on the configured GitLab host and merge-request head branch.
+- **GIVEN** an Azure DevOps task with no linked pull request, **WHEN** the user activates the file action for an existing file, **THEN** a new tab opens that file using the task repository's base branch.
+- **GIVEN** a multi-repository task whose repositories have different providers and base branches, **WHEN** the user opens a file from each repository, **THEN** each action uses that file's repository, repository-relative path, provider URL shape, and revision.
+- **GIVEN** an added or untracked file with no published source branch, **WHEN** its toolbar renders, **THEN** no external-file action is offered.
+- **GIVEN** a deleted file on a published task branch, **WHEN** the user activates its file action, **THEN** the external provider opens the file's base-branch version instead of a missing head-branch path.
+- **GIVEN** a renamed file with a published source branch, **WHEN** the user activates its file action, **THEN** the external provider opens the new path on that published branch.
+- **GIVEN** a renamed file without a published source branch but with a known previous path, **WHEN** the user activates its file action, **THEN** the external provider opens the previous path on the base branch.
+- **GIVEN** an unsupported, local-only, ambiguous, or incompletely configured repository, **WHEN** a file or diff toolbar renders, **THEN** it does not show an external-file action or expose credentials/local paths.
+- **GIVEN** a supported task file on a phone viewport, **WHEN** the user opens its file or diff surface, **THEN** the provider-specific action is visible, touch-reachable, opens the same external file target as desktop, and causes no horizontal page overflow.
+- **GIVEN** a supported file in Changes, a built-in editor/viewer, and Review, **WHEN** each toolbar renders, **THEN** each surface offers the same provider-specific open action for that file context.
+
+## Out of scope
+
+- Copying the external URL directly from Kandev.
+- Guessing routes for generic or unknown Git hosting providers.
+- Publishing, pushing, or creating a pull request or merge request so a local-only file can be linked.
+- Adding line-range anchors or linking directly to a diff hunk.
+- Changing external repository permissions or making a private repository accessible to a colleague.
+
+## Implementation plan
+
+[External VCS file links](../../plans/external-vcs-file-links/plan.md)


### PR DESCRIPTION
Make task-file changes easy to share with colleagues by opening the relevant file and revision in its external VCS. The action is provider-aware, safe by default, and available across desktop and mobile task file surfaces.

## Important Changes

- Adds GitHub, self-hosted GitLab, and Azure DevOps file links, including safe SSH remote and custom GitLab port handling.
- Uses a published branch when available and otherwise falls back to the base revision, with status-aware rules for added, deleted, and renamed files.
- Exposes repository `remote_url` read-only while preventing generic repository settings from changing clone targets.
- Adds desktop and mobile action coverage across diff, review, editor, image, binary, and file viewer toolbars; updates public documentation.

## Validation

- `make fmt`
- `make typecheck`
- `make test`
- `make lint`
- Desktop E2E: 2/2 passed
- Mobile E2E: 1/1 passed
- Security review, code review, and QA passed.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1883?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->