### PR TITLE
fix: prevent blank mobile task views (#1877)

### DIFF
--- a/apps/web/components/task/mobile/mobile-repo-pill.tsx
+++ b/apps/web/components/task/mobile/mobile-repo-pill.tsx
@@ -8,6 +8,7 @@ import { MobilePickerSheet } from "./mobile-picker-sheet";
 import { MobileReposSection, useTaskRepoCount } from "./mobile-repos-section";
 
 const COMPACT_VIEWPORT_PX = 360;
+const EMPTY_REPOSITORIES = Object.freeze([]);
 
 /** Returns true once the viewport is narrower than the compact threshold. */
 function useIsCompactViewport(): boolean {
@@ -24,7 +25,9 @@ function useIsCompactViewport(): boolean {
 
 function useTaskActiveRepoName(taskId: string | null, workspaceId: string | null): string | null {
   const workspaceRepos = useAppStore((s) =>
-    workspaceId ? (s.repositories.itemsByWorkspaceId[workspaceId] ?? []) : [],
+    workspaceId
+      ? (s.repositories.itemsByWorkspaceId[workspaceId] ?? EMPTY_REPOSITORIES)
+      : EMPTY_REPOSITORIES,
   );
   const activeSessionId = useAppStore((s) => s.tasks.activeSessionId);
   const activeRepoId = useAppStore((s) =>

--- a/apps/web/components/task/mobile/session-mobile-layout.tsx
+++ b/apps/web/components/task/mobile/session-mobile-layout.tsx
@@ -379,9 +379,14 @@ export function useMobilePanelHandlers({
 function useMobileMRSelection(
   activeTaskId: string | null,
   effectiveSessionId: string | null,
+  requestedPanel: MobileSessionPanel,
   changePanel: (panel: MobileSessionPanel) => void,
 ) {
   const mrs = useTaskMRs(activeTaskId);
+  const reviewSourcesResolved = useAppStore((state) => {
+    const workspaceId = state.workspaces.activeId;
+    return !!workspaceId && Object.hasOwn(state.taskMRs.byWorkspaceId, workspaceId);
+  });
   const reviewMRKey = useAppStore((state) =>
     effectiveSessionId
       ? (state.mobileSession.reviewMRKeyBySessionId?.[effectiveSessionId] ?? null)
@@ -391,10 +396,19 @@ function useMobileMRSelection(
   const selectedMR = selectExplicitPanelMR(mrs, reviewMRKey);
 
   useEffect(() => {
-    if (effectiveSessionId && reviewMRKey && !selectedMR) {
+    const hasInvalidReviewPreference =
+      requestedPanel === "review" && (!reviewMRKey || (reviewSourcesResolved && !selectedMR));
+    if (effectiveSessionId && hasInvalidReviewPreference) {
       setMobileSessionReview(effectiveSessionId, null);
     }
-  }, [effectiveSessionId, reviewMRKey, selectedMR, setMobileSessionReview]);
+  }, [
+    effectiveSessionId,
+    requestedPanel,
+    reviewMRKey,
+    reviewSourcesResolved,
+    selectedMR,
+    setMobileSessionReview,
+  ]);
 
   const handlePanelChange = useCallback(
     (panel: MobileSessionPanel) => {
@@ -436,8 +450,11 @@ export const SessionMobileLayout = memo(function SessionMobileLayout(
   const mobileMR = useMobileMRSelection(
     activeTaskId,
     effectiveSessionId,
+    currentMobilePanel,
     handlePanelChangeAndClearSheet,
   );
+  const effectiveMobilePanel =
+    currentMobilePanel === "review" && !mobileMR.selectedMR ? "chat" : currentMobilePanel;
 
   return (
     <div className="h-dvh relative bg-background">
@@ -451,7 +468,7 @@ export const SessionMobileLayout = memo(function SessionMobileLayout(
       />
 
       <MobilePanelArea
-        currentMobilePanel={currentMobilePanel}
+        currentMobilePanel={effectiveMobilePanel}
         activeTaskId={activeTaskId}
         isPassthroughMode={isPassthroughMode}
         effectiveSessionId={effectiveSessionId}
@@ -468,13 +485,13 @@ export const SessionMobileLayout = memo(function SessionMobileLayout(
 
       <MobileTerminalKeybar
         sessionId={effectiveSessionId ?? null}
-        visible={currentMobilePanel === "terminal"}
+        visible={effectiveMobilePanel === "terminal"}
         baseBottomOffset={BOTTOM_NAV_HEIGHT}
       />
 
       {/* Fixed Bottom Navigation */}
       <SessionMobileBottomNav
-        activePanel={currentMobilePanel}
+        activePanel={effectiveMobilePanel}
         onPanelChange={mobileMR.handlePanelChange}
         planBadge={hasUnseenPlanUpdate}
         changesBadge={totalChangesCount}

--- a/apps/web/e2e/tests/gitlab/mobile-gitlab-parity.spec.ts
+++ b/apps/web/e2e/tests/gitlab/mobile-gitlab-parity.spec.ts
@@ -71,6 +71,18 @@ test.describe("Mobile GitLab parity", () => {
 
     await panel.getByRole("button", { name: "Unlink merge request" }).tap();
     await expect(testPage.getByTestId("mr-topbar-button")).toHaveCount(0);
+    await expect(testPage.getByTestId("mobile-mr-review-panel")).toHaveCount(0);
+    await expect(testPage.getByTestId("session-chat")).toBeVisible();
+    await expect(testPage.getByRole("button", { name: "Chat", exact: true })).toHaveClass(
+      /text-primary/,
+    );
+    await expect
+      .poll(() =>
+        testPage.evaluate(
+          "window.__KANDEV_E2E_STORE__?.getState().mobileSession.activePanelBySessionId[window.__KANDEV_E2E_STORE__?.getState().tasks.activeSessionId ?? '']",
+        ),
+      )
+      .toBe("chat");
   });
 
   test("watch controls remain touch sized and persist a pause", async ({

--- a/apps/web/e2e/tests/task/mobile-sidebar-task-actions.spec.ts
+++ b/apps/web/e2e/tests/task/mobile-sidebar-task-actions.spec.ts
@@ -2,6 +2,77 @@ import { test, expect } from "../../fixtures/test-base";
 import { SessionPage } from "../../pages/session-page";
 
 test.describe("Mobile sidebar task actions", () => {
+  test("switches to the selected task and its chat from the phone task drawer", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    const sourceTitle = "Mobile drawer source task";
+    const destinationTitle = "Mobile drawer destination task";
+    const destinationResponse = "destination drawer session response";
+    const taskOptions = {
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+      repository_ids: [seedData.repositoryId],
+      executor_profile_id: seedData.worktreeExecutorProfileId,
+    };
+    const source = await apiClient.createTaskWithAgent(
+      seedData.workspaceId,
+      sourceTitle,
+      seedData.agentProfileId,
+      { ...taskOptions, description: 'e2e:message("source drawer session response")' },
+    );
+    const destination = await apiClient.createTaskWithAgent(
+      seedData.workspaceId,
+      destinationTitle,
+      seedData.agentProfileId,
+      { ...taskOptions, description: `e2e:message("${destinationResponse}")` },
+    );
+    if (!source.session_id || !destination.session_id) {
+      throw new Error("mobile drawer task setup did not create both sessions");
+    }
+    expect(source.session_id).not.toBe(destination.session_id);
+
+    // Wait for the destination's actual agent response before navigating, so
+    // the assertion below proves that the drawer selected its session rather
+    // than merely replacing the URL/title.
+    await expect
+      .poll(async () => {
+        const response = await apiClient.rawRequest(
+          "GET",
+          `/api/v1/task-sessions/${destination.session_id}/messages?limit=50`,
+        );
+        const body = (await response.json()) as { messages?: Array<{ content?: string }> };
+        return body.messages?.some((message) => message.content?.includes(destinationResponse));
+      })
+      .toBe(true);
+
+    await testPage.goto(`/t/${source.id}`);
+    const session = new SessionPage(testPage);
+    await session.waitForLoad();
+    await expect(session.chat.getByText("source drawer session response").last()).toBeVisible({
+      timeout: 30_000,
+    });
+
+    await testPage.getByTestId("mobile-session-menu").tap();
+    const drawer = testPage.getByRole("dialog", { name: "Tasks" });
+    const destinationRow = drawer
+      .getByTestId("sidebar-task-item")
+      .filter({ hasText: destinationTitle });
+    await expect(destinationRow).toBeVisible();
+    await destinationRow.tap();
+
+    await expect(drawer).toBeHidden();
+    await expect(testPage).toHaveURL(new RegExp(`/t/${destination.id}$`));
+    const mobileTopBar = testPage
+      .getByTestId("mobile-session-menu")
+      .locator("xpath=ancestor::header");
+    await expect(mobileTopBar.getByText(destinationTitle, { exact: true })).toBeVisible();
+    await expect(session.chat.getByText(destinationResponse).last()).toBeVisible({
+      timeout: 30_000,
+    });
+  });
+
   test("opens the phone task switcher as an inset bottom card", async ({
     testPage,
     apiClient,

--- a/apps/web/e2e/tests/task/mobile-task-loading-state.spec.ts
+++ b/apps/web/e2e/tests/task/mobile-task-loading-state.spec.ts
@@ -1,5 +1,7 @@
-import type { Page } from "@playwright/test";
+import type { Page, Route } from "@playwright/test";
 import { test, expect } from "../../fixtures/test-base";
+import { MobileKanbanPage } from "../../pages/mobile-kanban-page";
+import { SessionPage } from "../../pages/session-page";
 import { openBlockedTaskLoadingState } from "./task-loading-state-helpers";
 
 async function expectLoadingStateFitsViewport(testPage: Page) {
@@ -13,11 +15,13 @@ async function expectLoadingStateFitsViewport(testPage: Page) {
 
   await expect(loadingState).toBeInViewport();
   expect(box.x).toBeGreaterThanOrEqual(0);
+  expect(box.y).toBeGreaterThanOrEqual(0);
   expect(box.width).toBeLessThanOrEqual(viewport.width + 1);
+  expect(box.height).toBeLessThanOrEqual(viewport.height + 1);
 }
 
 test.describe("Mobile task loading state", () => {
-  test("shows a spinner instead of a blank task detail pane while task data loads", async ({
+  test("shows an inner loading state instead of a blank task detail pane", async ({
     testPage,
     apiClient,
     seedData,
@@ -36,6 +40,81 @@ test.describe("Mobile task loading state", () => {
       await expectLoadingStateFitsViewport(testPage);
     } finally {
       await unblockTaskDetailRequest();
+    }
+  });
+
+  test("shows route loading, then recovers the destination task when optional hydration fails", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    const title = "Mobile route hydration destination";
+    const responseText = "route hydration destination response";
+    const destination = await apiClient.createTaskWithAgent(
+      seedData.workspaceId,
+      title,
+      seedData.agentProfileId,
+      {
+        description: `e2e:message("${responseText}")`,
+        workflow_id: seedData.workflowId,
+        workflow_step_id: seedData.startStepId,
+        repository_ids: [seedData.repositoryId],
+        executor_profile_id: seedData.worktreeExecutorProfileId,
+      },
+    );
+    if (!destination.session_id) throw new Error("route hydration destination has no session");
+
+    const mobile = new MobileKanbanPage(testPage);
+    await mobile.goto();
+
+    let requestStarted = false;
+    let releaseRequest: () => void = () => {};
+    let markHandlerSettled: () => void = () => {};
+    const requestReleased = new Promise<void>((resolve) => {
+      releaseRequest = resolve;
+    });
+    const handlerSettled = new Promise<void>((resolve) => {
+      markHandlerSettled = resolve;
+    });
+    let markRequestStarted: () => void = () => {};
+    const requestObserved = new Promise<void>((resolve) => {
+      markRequestStarted = resolve;
+    });
+    const sessionPattern = `**/api/v1/task-sessions/${destination.session_id}`;
+    const sessionRoute = async (route: Route) => {
+      requestStarted = true;
+      markRequestStarted();
+      await requestReleased;
+      try {
+        await route.fulfill({ status: 503, contentType: "application/json", body: "{}" });
+      } finally {
+        markHandlerSettled();
+      }
+    };
+
+    await testPage.route(sessionPattern, sessionRoute);
+    try {
+      await mobile.taskCard(destination.id).tap();
+      await expect(testPage).toHaveURL(new RegExp(`/t/${destination.id}$`));
+      await requestObserved;
+      const routeLoading = testPage.getByRole("status").filter({ hasText: "Loading task…" });
+      await expect(routeLoading).toBeVisible();
+
+      releaseRequest();
+      await handlerSettled;
+      await expect(routeLoading).toBeHidden();
+      const session = new SessionPage(testPage);
+      const mobileTopBar = testPage
+        .getByTestId("mobile-session-menu")
+        .locator("xpath=ancestor::header");
+      await expect(mobileTopBar.getByText(title, { exact: true })).toBeVisible();
+      await expect(session.activeChat().getByText(responseText).last()).toBeVisible({
+        timeout: 30_000,
+      });
+    } finally {
+      releaseRequest();
+      if (requestStarted) await handlerSettled;
+      await testPage.unroute(sessionPattern, sessionRoute);
     }
   });
 });

--- a/apps/web/lib/ssr/session-page-state.test.ts
+++ b/apps/web/lib/ssr/session-page-state.test.ts
@@ -1,7 +1,8 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { mergeInitialState } from "@/lib/state/default-state";
 import type { AppState } from "@/lib/state/store";
+import { workflowId } from "@/lib/types/ids";
 import type { Task } from "@/lib/types/http";
 
 const mocks = vi.hoisted(() => ({
@@ -39,60 +40,79 @@ vi.mock("@/lib/api/domains/user-shell-api", () => ({
   fetchTerminals: vi.fn(),
 }));
 
-import { fetchSessionDataForTask } from "./session-page-state";
+import { fetchSessionDataForTask, OPTIONAL_HYDRATION_TIMEOUT_MS } from "./session-page-state";
 
 const NOW = "2026-07-16T12:00:00Z";
+const TASK_ID = "task-1";
+const SESSION_ID = "session-1";
+const WORKSPACE_ID = "workspace-office";
+const WORKFLOW_ID = "workflow-1";
 
-describe("fetchSessionDataForTask hydration", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mocks.fetchTask.mockResolvedValue({
-      id: "task-1",
-      workspace_id: "workspace-office",
-      workflow_id: "",
-      workflow_step_id: "",
-      position: 0,
-      title: "Office task",
-      description: "",
-      state: "TODO",
-      priority: 0,
-      created_at: NOW,
-      updated_at: NOW,
-    } as unknown as Task);
-    mocks.listTaskSessions.mockResolvedValue({ sessions: [] });
-    mocks.listAgents.mockResolvedValue({ agents: [] });
-    mocks.listRepositories.mockResolvedValue({ repositories: [] });
-    mocks.listWorkflows.mockResolvedValue({ workflows: [] });
-    mocks.fetchUserSettings.mockResolvedValue(null);
-    mocks.listWorkspaces.mockResolvedValue({
-      workspaces: [
-        {
-          id: "workspace-office",
-          name: "Office",
-          owner_id: "",
-          office_workflow_id: "workflow-office",
-          created_at: NOW,
-          updated_at: NOW,
-        },
-      ],
-    });
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: TASK_ID,
+    workspace_id: WORKSPACE_ID,
+    workflow_id: "",
+    workflow_step_id: "",
+    position: 0,
+    title: "Office task",
+    description: "",
+    state: "TODO",
+    priority: 0,
+    created_at: NOW,
+    updated_at: NOW,
+    ...overrides,
+  } as Task;
+}
+
+function mockDefaultHydrationData() {
+  vi.clearAllMocks();
+  mocks.fetchTask.mockResolvedValue(makeTask());
+  mocks.listTaskSessions.mockResolvedValue({ sessions: [] });
+  mocks.listAgents.mockResolvedValue({ agents: [] });
+  mocks.listRepositories.mockResolvedValue({ repositories: [] });
+  mocks.listWorkflows.mockResolvedValue({ workflows: [] });
+  mocks.fetchUserSettings.mockResolvedValue(null);
+  mocks.listWorkspaces.mockResolvedValue({
+    workspaces: [
+      {
+        id: WORKSPACE_ID,
+        name: "Office",
+        owner_id: "",
+        office_workflow_id: "workflow-office",
+        created_at: NOW,
+        updated_at: NOW,
+      },
+    ],
   });
+}
 
+function makeSession() {
+  return {
+    id: SESSION_ID,
+    task_id: TASK_ID,
+    state: "completed",
+    started_at: NOW,
+    updated_at: NOW,
+  };
+}
+
+beforeEach(mockDefaultHydrationData);
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("fetchSessionDataForTask initial hydration", () => {
   it("preserves the Office workflow ID in task-route state", async () => {
-    const result = await fetchSessionDataForTask("task-1");
+    const result = await fetchSessionDataForTask(TASK_ID);
     const initialState = result.initialState as unknown as Partial<AppState>;
 
     expect(initialState.workspaces?.items[0]?.office_workflow_id).toBe("workflow-office");
   });
 
   it("hydrates persisted per-turn runtime configuration after a page reload", async () => {
-    const session = {
-      id: "session-1",
-      task_id: "task-1",
-      state: "completed",
-      started_at: NOW,
-      updated_at: NOW,
-    };
+    const session = makeSession();
     const runtimeConfigSnapshot = {
       model: "gpt-5.6-sol",
       mode: "agent",
@@ -114,7 +134,7 @@ describe("fetchSessionDataForTask hydration", () => {
         {
           id: "turn-1",
           session_id: session.id,
-          task_id: "task-1",
+          task_id: TASK_ID,
           started_at: NOW,
           completed_at: NOW,
           metadata: { runtime_config_snapshot: runtimeConfigSnapshot },
@@ -126,11 +146,183 @@ describe("fetchSessionDataForTask hydration", () => {
     });
     mocks.listTaskSessionMessages.mockResolvedValue(null);
 
-    const result = await fetchSessionDataForTask("task-1");
+    const result = await fetchSessionDataForTask(TASK_ID);
     const hydratedState = mergeInitialState(result.initialState);
 
     expect(hydratedState.turns.bySession[session.id]?.[0]?.metadata).toEqual({
       runtime_config_snapshot: runtimeConfigSnapshot,
     });
+  });
+});
+
+describe("fetchSessionDataForTask agent hydration", () => {
+  it("renders core task and session state when optional agent hydration never settles", async () => {
+    vi.useFakeTimers();
+    const session = makeSession();
+    mocks.listTaskSessions.mockResolvedValue({ sessions: [session], total: 1 });
+    mocks.fetchTaskSession.mockResolvedValue({ session });
+    mocks.listAgents.mockReturnValue(new Promise(() => {}));
+    mocks.listSessionTurns.mockResolvedValue({ turns: [], total: 0 });
+    mocks.listTaskSessionMessages.mockResolvedValue(null);
+
+    let result: Awaited<ReturnType<typeof fetchSessionDataForTask>> | undefined;
+    void fetchSessionDataForTask(TASK_ID).then((next) => {
+      result = next;
+    });
+
+    await vi.advanceTimersByTimeAsync(OPTIONAL_HYDRATION_TIMEOUT_MS);
+
+    expect(result).toBeDefined();
+    const hydratedState = mergeInitialState(result!.initialState);
+
+    expect(hydratedState.taskSessionsByTask.itemsByTaskId[TASK_ID]?.[0]?.id).toBe(SESSION_ID);
+  });
+
+  it("renders core task state when optional agent hydration fails", async () => {
+    mocks.listAgents.mockRejectedValue(new Error("agents unavailable"));
+
+    const result = await fetchSessionDataForTask(TASK_ID);
+
+    expect(result.task.id).toBe(TASK_ID);
+  });
+});
+
+describe("fetchSessionDataForTask optional enrichment", () => {
+  it("omits failed optional workflow, agent, and repository state for client recovery", async () => {
+    mocks.fetchTask.mockResolvedValue(makeTask({ workflow_id: workflowId(WORKFLOW_ID) }));
+    mocks.fetchWorkflowSnapshot.mockRejectedValue(new Error("workflow unavailable"));
+    mocks.listAgents.mockRejectedValue(new Error("agents unavailable"));
+    mocks.listRepositories.mockRejectedValue(new Error("repositories unavailable"));
+
+    const result = await fetchSessionDataForTask(TASK_ID);
+    const initialState = result.initialState as Partial<AppState>;
+
+    expect(initialState.kanban).toBeUndefined();
+    expect(initialState.settingsData).toBeUndefined();
+    expect(initialState.repositories).toBeUndefined();
+  });
+
+  it("keeps the destination workspace active when workspace enrichment fails", async () => {
+    mocks.listWorkspaces.mockRejectedValue(new Error("workspaces unavailable"));
+
+    const result = await fetchSessionDataForTask(TASK_ID);
+    const initialState = result.initialState as Partial<AppState>;
+
+    expect(initialState.workspaces).toEqual({ activeId: WORKSPACE_ID });
+  });
+
+  it("keeps the destination workspace active without marking workspace items loaded after timeout", async () => {
+    vi.useFakeTimers();
+    mocks.listWorkspaces.mockReturnValue(new Promise(() => {}));
+
+    const resultPromise = fetchSessionDataForTask(TASK_ID);
+    await vi.advanceTimersByTimeAsync(OPTIONAL_HYDRATION_TIMEOUT_MS);
+
+    const result = await resultPromise;
+    const initialState = result.initialState as Partial<AppState>;
+
+    expect(initialState.workspaces).toEqual({ activeId: WORKSPACE_ID });
+  });
+
+  it("hydrates workspace items alongside the destination workspace when enrichment succeeds", async () => {
+    const result = await fetchSessionDataForTask(TASK_ID);
+    const initialState = result.initialState as Partial<AppState>;
+
+    expect(initialState.workspaces).toMatchObject({
+      activeId: WORKSPACE_ID,
+      items: [expect.objectContaining({ id: WORKSPACE_ID, name: "Office" })],
+    });
+  });
+
+  it("retains successful optional enrichment as authoritative initial state", async () => {
+    mocks.fetchTask.mockResolvedValue(makeTask({ workflow_id: workflowId(WORKFLOW_ID) }));
+    mocks.fetchWorkflowSnapshot.mockResolvedValue({
+      workflow: { id: "workflow-1" },
+      steps: [],
+      tasks: [],
+    });
+
+    const result = await fetchSessionDataForTask(TASK_ID);
+    const initialState = result.initialState as Partial<AppState>;
+
+    expect(initialState.kanban?.workflowId).toBe(WORKFLOW_ID);
+    expect(initialState.settingsData?.agentsLoaded).toBe(true);
+    expect(initialState.repositories?.loadedByWorkspaceId?.[WORKSPACE_ID]).toBe(true);
+  });
+
+  it("omits timed-out optional slices so client hooks can recover them", async () => {
+    vi.useFakeTimers();
+    mocks.fetchTask.mockResolvedValue(makeTask({ workflow_id: workflowId(WORKFLOW_ID) }));
+    mocks.fetchWorkflowSnapshot.mockReturnValue(new Promise(() => {}));
+    mocks.listAgents.mockReturnValue(new Promise(() => {}));
+    mocks.listRepositories.mockReturnValue(new Promise(() => {}));
+
+    const resultPromise = fetchSessionDataForTask(TASK_ID);
+    await vi.advanceTimersByTimeAsync(OPTIONAL_HYDRATION_TIMEOUT_MS);
+
+    const result = await resultPromise;
+    const initialState = result.initialState as Partial<AppState>;
+    const hydratedState = mergeInitialState(initialState);
+
+    expect(initialState.kanban).toBeUndefined();
+    expect(initialState.settingsData).toBeUndefined();
+    expect(initialState.repositories).toBeUndefined();
+    expect(hydratedState.settingsData.agentsLoaded).toBe(false);
+  });
+});
+
+describe("fetchSessionDataForTask timeout behavior", () => {
+  it("uses one deadline when active-session and enrichment requests both stall", async () => {
+    vi.useFakeTimers();
+    const session = makeSession();
+    let rejectAgentRequest!: (error: Error) => void;
+    const stalledAgentRequest = new Promise<never>((_, reject) => {
+      rejectAgentRequest = reject;
+    });
+    mocks.listTaskSessions.mockResolvedValue({ sessions: [session], total: 1 });
+    mocks.fetchTaskSession.mockReturnValue(new Promise(() => {}));
+    mocks.listAgents.mockReturnValue(stalledAgentRequest);
+    mocks.listSessionTurns.mockResolvedValue({ turns: [], total: 0 });
+    mocks.listTaskSessionMessages.mockResolvedValue(null);
+
+    let result: Awaited<ReturnType<typeof fetchSessionDataForTask>> | undefined;
+    const resultPromise = fetchSessionDataForTask(TASK_ID).then((next) => {
+      result = next;
+    });
+
+    await vi.advanceTimersByTimeAsync(OPTIONAL_HYDRATION_TIMEOUT_MS - 1);
+    expect(result).toBeUndefined();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(result).toBeDefined();
+
+    rejectAgentRequest(new Error("late agent failure"));
+    await Promise.resolve();
+    await resultPromise;
+  });
+
+  it("warns only once when an optional request rejects after timing out", async () => {
+    vi.useFakeTimers();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    let rejectWorkspaces!: (error: Error) => void;
+    mocks.listWorkspaces.mockReturnValue(
+      new Promise<never>((_, reject) => {
+        rejectWorkspaces = reject;
+      }),
+    );
+
+    const resultPromise = fetchSessionDataForTask(TASK_ID);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(rejectWorkspaces).toBeTypeOf("function");
+    await vi.advanceTimersByTimeAsync(OPTIONAL_HYDRATION_TIMEOUT_MS - 1);
+    await resultPromise;
+
+    rejectWorkspaces(new Error("late workspace failure"));
+    await vi.advanceTimersByTimeAsync(0);
+
+    const workspaceWarnings = warn.mock.calls.filter(([message]) =>
+      String(message).includes("optional workspaces"),
+    );
+    expect(workspaceWarnings).toHaveLength(1);
   });
 });

--- a/apps/web/lib/ssr/session-page-state.test.ts
+++ b/apps/web/lib/ssr/session-page-state.test.ts
@@ -100,6 +100,7 @@ function makeSession() {
 beforeEach(mockDefaultHydrationData);
 
 afterEach(() => {
+  vi.restoreAllMocks();
   vi.useRealTimers();
 });
 

--- a/apps/web/lib/ssr/session-page-state.ts
+++ b/apps/web/lib/ssr/session-page-state.ts
@@ -27,6 +27,66 @@ import type { SessionPrepareState } from "@/lib/state/slices/session-runtime/typ
 import type { AppState } from "@/lib/state/store";
 import { mapWorkspaceItem } from "@/lib/routing/route-bootstrap";
 
+export const OPTIONAL_HYDRATION_TIMEOUT_MS = 5_000;
+
+type OptionalHydrationResult<T> = { status: "fulfilled"; value: T } | { status: "unavailable" };
+
+function beginOptionalHydration() {
+  let deadlineTimer: ReturnType<typeof setTimeout>;
+  const deadline = new Promise<void>((resolve) => {
+    deadlineTimer = setTimeout(resolve, OPTIONAL_HYDRATION_TIMEOUT_MS);
+  });
+
+  return {
+    load<T>(label: string, operation: () => Promise<T>): Promise<OptionalHydrationResult<T>> {
+      return new Promise((resolve) => {
+        let settled = false;
+        const settle = (value: OptionalHydrationResult<T>) => {
+          if (settled) return;
+          settled = true;
+          resolve(value);
+        };
+
+        void Promise.resolve()
+          .then(operation)
+          .then(
+            (value) => settle({ status: "fulfilled", value }),
+            (error) => {
+              if (settled) return;
+              console.warn(
+                `[session-page-state] optional ${label} failed; continuing without it`,
+                error,
+              );
+              settle({ status: "unavailable" });
+            },
+          );
+        void deadline.then(() => {
+          if (!settled) {
+            console.warn(
+              `[session-page-state] optional ${label} timed out after ${OPTIONAL_HYDRATION_TIMEOUT_MS}ms; continuing without it`,
+            );
+            settle({ status: "unavailable" });
+          }
+        });
+      });
+    },
+    complete() {
+      clearTimeout(deadlineTimer);
+    },
+  };
+}
+
+function optionalValue<T>(result: OptionalHydrationResult<T>): T | undefined {
+  return result.status === "fulfilled" ? result.value : undefined;
+}
+
+function optionalState<T>(
+  value: T | undefined,
+  build: (resolved: T) => Partial<AppState>,
+): Partial<AppState> {
+  return value === undefined ? {} : build(value);
+}
+
 function buildWorktreeState(allSessions: TaskSession[]) {
   const sessionsWithWorktrees = allSessions.filter((s) => s.worktree_id);
   return {
@@ -55,9 +115,9 @@ function buildWorktreeState(allSessions: TaskSession[]) {
 type BuildSessionPageStateParams = {
   task: Task;
   sessionId: string | null;
-  snapshot: Awaited<ReturnType<typeof fetchWorkflowSnapshot>>;
-  agents: Awaited<ReturnType<typeof listAgents>>;
-  repositories: Awaited<ReturnType<typeof listRepositories>>["repositories"];
+  snapshot?: Awaited<ReturnType<typeof fetchWorkflowSnapshot>>;
+  agents?: Awaited<ReturnType<typeof listAgents>>;
+  repositories?: Awaited<ReturnType<typeof listRepositories>>["repositories"];
   allSessions: TaskSession[];
   // Full session payload (with agent_profile_snapshot) for the active sessionId,
   // when available. The list endpoint returns lightweight summaries without the
@@ -65,73 +125,90 @@ type BuildSessionPageStateParams = {
   // default model on SSR — visible as a brief flash of the wrong model before
   // the WS-driven cached state arrives.
   activeSession: TaskSession | null;
-  workspaces: Awaited<ReturnType<typeof listWorkspaces>>["workspaces"];
-  workflows: Awaited<ReturnType<typeof listWorkflows>>["workflows"];
-  turns: Awaited<ReturnType<typeof listSessionTurns>>["turns"];
-  userSettingsResponse: UserSettingsResponse | null;
-  messagesResponse: ListMessagesResponse | null;
+  workspaces?: Awaited<ReturnType<typeof listWorkspaces>>["workspaces"];
+  workflows?: Awaited<ReturnType<typeof listWorkflows>>["workflows"];
+  turns?: Awaited<ReturnType<typeof listSessionTurns>>["turns"];
+  userSettingsResponse?: UserSettingsResponse | null;
+  messagesResponse?: ListMessagesResponse | null;
 };
 
 function buildSessionPageState(p: BuildSessionPageStateParams) {
   const { task, sessionId, snapshot, agents, allSessions, messagesResponse } = p;
   const messages = messagesResponse?.messages ? [...messagesResponse.messages].reverse() : [];
-  const taskState = taskToState(task, sessionId, {
-    items: messages,
-    hasMore: messagesResponse?.has_more ?? false,
-    oldestCursor: messages[0]?.id ?? null,
-  });
+  const taskState =
+    messagesResponse === undefined
+      ? taskToState(task, sessionId)
+      : taskToState(task, sessionId, {
+          items: messages,
+          hasMore: messagesResponse?.has_more ?? false,
+          oldestCursor: messages[0]?.id ?? null,
+        });
 
   return {
-    ...snapshotToState(snapshot),
+    ...optionalState(snapshot, snapshotToState),
     ...taskState,
     ...buildResourceState(p),
     ...buildSessionState(p),
     ...buildWorktreeState(allSessions),
     ...buildPrepareProgressState(allSessions),
-    settingsAgents: { items: agents.agents },
-    settingsData: { agentsLoaded: true, executorsLoaded: false },
-    userSettings: mapUserSettingsResponse(p.userSettingsResponse),
+    ...optionalState(agents, (value) => ({
+      settingsAgents: { items: value.agents },
+      settingsData: { agentsLoaded: true, executorsLoaded: false },
+    })),
+    ...optionalState(p.userSettingsResponse, (value) => ({
+      userSettings: mapUserSettingsResponse(value),
+    })),
   };
 }
 
 function buildResourceState(p: BuildSessionPageStateParams) {
   const { task, agents, repositories, workspaces, workflows } = p;
   const repositoryId = task.repositories?.[0]?.repository_id;
-  const repository = repositories.find((r) => r.id === repositoryId);
+  const repository = repositories?.find((r) => r.id === repositoryId);
   const scripts = repository?.scripts ?? [];
   return {
     workspaces: {
-      items: workspaces.map(mapWorkspaceItem),
+      ...(workspaces ? { items: workspaces.map(mapWorkspaceItem) } : {}),
       activeId: task.workspace_id,
-    },
+    } as Partial<AppState>["workspaces"],
     // Don't write activeId — null means "All Workflows"; task context lives in kanban.workflowId.
-    workflows: {
-      items: workflows.map((w) => ({
-        id: w.id as string,
-        workspaceId: w.workspace_id as string,
-        name: w.name,
-        hidden: w.hidden,
-        style: w.style,
-      })),
-    } as Partial<AppState>["workflows"],
-    repositories: {
-      itemsByWorkspaceId: { [task.workspace_id]: repositories },
-      loadingByWorkspaceId: { [task.workspace_id]: false },
-      loadedByWorkspaceId: { [task.workspace_id]: true },
-    },
-    repositoryScripts: repositoryId
+    ...optionalState(workflows, (value) => ({
+      workflows: {
+        items: value.map((w) => ({
+          id: w.id as string,
+          workspaceId: w.workspace_id as string,
+          name: w.name,
+          hidden: w.hidden,
+          style: w.style,
+        })),
+      } as Partial<AppState>["workflows"],
+    })),
+    ...optionalState(repositories, (value) => ({
+      repositories: {
+        itemsByWorkspaceId: { [task.workspace_id]: value },
+        loadingByWorkspaceId: { [task.workspace_id]: false },
+        loadedByWorkspaceId: { [task.workspace_id]: true },
+      },
+    })),
+    ...(repositories
       ? {
-          itemsByRepositoryId: { [repositoryId]: scripts },
-          loadingByRepositoryId: { [repositoryId]: false },
-          loadedByRepositoryId: { [repositoryId]: true },
+          repositoryScripts: repositoryId
+            ? {
+                itemsByRepositoryId: { [repositoryId]: scripts },
+                loadingByRepositoryId: { [repositoryId]: false },
+                loadedByRepositoryId: { [repositoryId]: true },
+              }
+            : { itemsByRepositoryId: {}, loadingByRepositoryId: {}, loadedByRepositoryId: {} },
         }
-      : { itemsByRepositoryId: {}, loadingByRepositoryId: {}, loadedByRepositoryId: {} },
-    agentProfiles: {
-      items: agents.agents.flatMap((agent) =>
-        agent.profiles.map((profile) => toAgentProfileOption(agent, profile)),
-      ),
-      version: 0,
-    },
+      : {}),
+    ...optionalState(agents, (value) => ({
+      agentProfiles: {
+        items: value.agents.flatMap((agent) =>
+          agent.profiles.map((profile) => toAgentProfileOption(agent, profile)),
+        ),
+        version: 0,
+      },
+    })),
   };
 }
 
@@ -151,14 +228,18 @@ function buildSessionState(p: BuildSessionPageStateParams) {
       loadingByTaskId: { [task.id]: false },
       loadedByTaskId: { [task.id]: true },
     },
-    turns: sessionId
+    ...(turns !== undefined
       ? {
-          bySession: { [sessionId]: turns },
-          activeBySession: {
-            [sessionId]: turns.filter((t) => !t.completed_at).pop()?.id ?? null,
-          },
+          turns: sessionId
+            ? {
+                bySession: { [sessionId]: turns },
+                activeBySession: {
+                  [sessionId]: turns.filter((t) => !t.completed_at).pop()?.id ?? null,
+                },
+              }
+            : { bySession: {}, activeBySession: {} },
         }
-      : { bySession: {}, activeBySession: {} },
+      : {}),
     environmentIdBySessionId: Object.fromEntries(
       allSessions.filter((s) => s.task_environment_id).map((s) => [s.id, s.task_environment_id!]),
     ),
@@ -194,7 +275,14 @@ export async function fetchSessionData(sessionId: string): Promise<FetchedSessio
     listTaskSessions(activeSession.task_id, { cache: "no-store" }),
   ]);
 
-  return fetchSessionDataFromTask(task, sessionId, allSessionsResponse, activeSession);
+  const optionalHydration = beginOptionalHydration();
+  return fetchSessionDataFromTask(
+    task,
+    sessionId,
+    allSessionsResponse,
+    Promise.resolve({ status: "fulfilled", value: { session: activeSession } }),
+    optionalHydration,
+  );
 }
 
 export async function fetchSessionDataForTask(taskId: string): Promise<FetchedSessionData> {
@@ -214,22 +302,19 @@ export async function fetchSessionDataForTask(taskId: string): Promise<FetchedSe
   // Refetch the active session via the single-session endpoint to get
   // agent_profile_snapshot, which the list endpoint strips. See
   // BuildSessionPageStateParams.activeSession for the SSR-flicker rationale.
-  // A failure here (auth, 5xx, timeout) degrades gracefully to the original
-  // initial-flash behaviour but should surface in server logs so silent
-  // 401/500s are debuggable.
+  // All remaining enrichment shares this deadline so no optional request can
+  // extend route loading beyond the configured bound.
+  const optionalHydration = beginOptionalHydration();
   const { fetchTaskSession } = await import("@/lib/api");
-  const sessionResponse = await fetchTaskSession(sessionId, { cache: "no-store" }).catch((e) => {
-    console.warn(
-      "[session-page-state] failed to fetch active session snapshot; SSR will fall back to summary entry",
-      e,
-    );
-    return null;
-  });
+  const activeSessionResponse = optionalHydration.load("active session snapshot", () =>
+    fetchTaskSession(sessionId, { cache: "no-store" }),
+  );
   return fetchSessionDataFromTask(
     task,
     sessionId,
     allSessionsResponse,
-    sessionResponse?.session ?? null,
+    activeSessionResponse,
+    optionalHydration,
   );
 }
 
@@ -237,6 +322,26 @@ async function fetchTaskDataOnly(
   task: Task,
   allSessionsResponse: Awaited<ReturnType<typeof listTaskSessions>>,
 ): Promise<FetchedSessionData> {
+  const optionalHydration = beginOptionalHydration();
+  const results = await Promise.all([
+    // Only the task and its session list are essential to route recovery. These
+    // enrichment requests seed convenience state and must never strand the route.
+    optionalHydration.load("workflow snapshot", () =>
+      task.workflow_id
+        ? fetchWorkflowSnapshot(task.workflow_id, { cache: "no-store" })
+        : Promise.resolve({ steps: [], tasks: [] } as unknown as WorkflowSnapshot),
+    ),
+    optionalHydration.load("agents", () => listAgents({ cache: "no-store" })),
+    optionalHydration.load("repositories", () =>
+      listRepositories(task.workspace_id, { includeScripts: true }, { cache: "no-store" }),
+    ),
+    optionalHydration.load("workspaces", () => listWorkspaces({ cache: "no-store" })),
+    optionalHydration.load("workflows", () =>
+      listWorkflows(task.workspace_id, { cache: "no-store", includeHidden: true }),
+    ),
+    optionalHydration.load("user settings", () => fetchUserSettings({ cache: "no-store" })),
+  ]);
+  optionalHydration.complete();
   const [
     snapshot,
     agents,
@@ -244,36 +349,27 @@ async function fetchTaskDataOnly(
     workspacesResponse,
     workflowsResponse,
     userSettingsResponse,
-  ] = await Promise.all([
-    task.workflow_id
-      ? fetchWorkflowSnapshot(task.workflow_id, { cache: "no-store" })
-      : Promise.resolve({ steps: [], tasks: [] } as unknown as WorkflowSnapshot),
-    listAgents({ cache: "no-store" }),
-    listRepositories(task.workspace_id, { includeScripts: true }, { cache: "no-store" }),
-    listWorkspaces({ cache: "no-store" }).catch(() => ({ workspaces: [] })),
-    listWorkflows(task.workspace_id, { cache: "no-store", includeHidden: true }).catch(() => ({
-      workflows: [],
-    })),
-    fetchUserSettings({ cache: "no-store" }).catch(() => null),
-  ]);
+  ] = results;
 
   const allSessions = allSessionsResponse.sessions ?? [];
-  const repositories = repositoriesResponse.repositories ?? [];
-  const workspaces = workspacesResponse.workspaces ?? [];
-  const workflows = workflowsResponse.workflows ?? [];
+  const snapshotValue = optionalValue(snapshot);
+  const agentsValue = optionalValue(agents);
+  const repositories = optionalValue(repositoriesResponse)?.repositories;
+  const workspaces = optionalValue(workspacesResponse)?.workspaces;
+  const workflows = optionalValue(workflowsResponse)?.workflows;
 
   const initialState = buildSessionPageState({
     task,
     sessionId: null,
-    snapshot,
-    agents,
+    snapshot: snapshotValue,
+    agents: agentsValue,
     repositories,
     allSessions,
     activeSession: null,
     workspaces,
     workflows,
     turns: [],
-    userSettingsResponse,
+    userSettingsResponse: optionalValue(userSettingsResponse),
     messagesResponse: null,
   });
 
@@ -340,7 +436,8 @@ async function fetchSessionDataFromTask(
   task: Task,
   sessionId: string,
   allSessionsResponse: Awaited<ReturnType<typeof listTaskSessions>>,
-  activeSession: TaskSession | null,
+  activeSessionResponse: Promise<OptionalHydrationResult<{ session?: TaskSession | null }>>,
+  optionalHydration: ReturnType<typeof beginOptionalHydration>,
 ): Promise<FetchedSessionData> {
   // User shells are env-scoped — look up this session's task_environment_id
   // from the already-fetched session list. Sessions w/o env (legacy) skip
@@ -349,6 +446,34 @@ async function fetchSessionDataFromTask(
   const sessionEnvId =
     allSessionsResponse.sessions?.find((s) => s.id === sessionId)?.task_environment_id ?? "";
 
+  const results = await Promise.all([
+    // The required task and session list were fetched before this optional fan-out.
+    optionalHydration.load("workflow snapshot", () =>
+      task.workflow_id
+        ? fetchWorkflowSnapshot(task.workflow_id, { cache: "no-store" })
+        : Promise.resolve({ steps: [], tasks: [] } as unknown as WorkflowSnapshot),
+    ),
+    optionalHydration.load("agents", () => listAgents({ cache: "no-store" })),
+    optionalHydration.load("repositories", () =>
+      listRepositories(task.workspace_id, { includeScripts: true }, { cache: "no-store" }),
+    ),
+    optionalHydration.load("workspaces", () => listWorkspaces({ cache: "no-store" })),
+    optionalHydration.load("workflows", () =>
+      listWorkflows(task.workspace_id, { cache: "no-store", includeHidden: true }),
+    ),
+    optionalHydration.load("session turns", () =>
+      listSessionTurns(sessionId, { cache: "no-store" }),
+    ),
+    optionalHydration.load("user settings", () => fetchUserSettings({ cache: "no-store" })),
+    optionalHydration.load("terminals", () =>
+      sessionEnvId ? fetchTerminals(task.id, sessionEnvId) : Promise.resolve([]),
+    ),
+    optionalHydration.load("messages", () =>
+      listTaskSessionMessages(sessionId, { limit: 50, sort: "desc" }, { cache: "no-store" }),
+    ),
+    activeSessionResponse,
+  ]);
+  optionalHydration.complete();
   const [
     snapshot,
     agents,
@@ -359,47 +484,35 @@ async function fetchSessionDataFromTask(
     userSettingsResponse,
     terminalsResponse,
     messagesResponse,
-  ] = await Promise.all([
-    task.workflow_id
-      ? fetchWorkflowSnapshot(task.workflow_id, { cache: "no-store" })
-      : Promise.resolve({ steps: [], tasks: [] } as unknown as WorkflowSnapshot),
-    listAgents({ cache: "no-store" }),
-    listRepositories(task.workspace_id, { includeScripts: true }, { cache: "no-store" }),
-    listWorkspaces({ cache: "no-store" }).catch(() => ({ workspaces: [] })),
-    listWorkflows(task.workspace_id, { cache: "no-store", includeHidden: true }).catch(() => ({
-      workflows: [],
-    })),
-    listSessionTurns(sessionId, { cache: "no-store" }).catch(() => ({ turns: [], total: 0 })),
-    fetchUserSettings({ cache: "no-store" }).catch(() => null),
-    sessionEnvId ? fetchTerminals(task.id, sessionEnvId).catch(() => []) : Promise.resolve([]),
-    listTaskSessionMessages(sessionId, { limit: 50, sort: "desc" }, { cache: "no-store" }).catch(
-      () => null as ListMessagesResponse | null,
-    ),
-  ]);
+    activeSessionResult,
+  ] = results;
 
   const allSessions = allSessionsResponse.sessions ?? [];
-  const repositories = repositoriesResponse.repositories ?? [];
-  const workspaces = workspacesResponse.workspaces ?? [];
-  const workflows = workflowsResponse.workflows ?? [];
-  const turns = turnsResponse.turns ?? [];
+  const snapshotValue = optionalValue(snapshot);
+  const agentsValue = optionalValue(agents);
+  const repositories = optionalValue(repositoriesResponse)?.repositories;
+  const workspaces = optionalValue(workspacesResponse)?.workspaces;
+  const workflows = optionalValue(workflowsResponse)?.workflows;
+  const turns = optionalValue(turnsResponse)?.turns;
+  const terminals = optionalValue(terminalsResponse) ?? [];
+  const messages = optionalValue(messagesResponse);
+  const activeSession = optionalValue(activeSessionResult)?.session ?? null;
 
-  const initialTerminals: Terminal[] = terminalsResponse
-    .filter(shouldHydrateTerminal)
-    .map(hydrateTerminal);
+  const initialTerminals: Terminal[] = terminals.filter(shouldHydrateTerminal).map(hydrateTerminal);
 
   const initialState = buildSessionPageState({
     task,
     sessionId,
-    snapshot,
-    agents,
+    snapshot: snapshotValue,
+    agents: agentsValue,
     repositories,
     allSessions,
     activeSession,
     workspaces,
     workflows,
     turns,
-    userSettingsResponse,
-    messagesResponse,
+    userSettingsResponse: optionalValue(userSettingsResponse),
+    messagesResponse: messages,
   });
 
   return { task, sessionId, initialState, initialTerminals };

--- a/apps/web/src/task-detail-route.test.tsx
+++ b/apps/web/src/task-detail-route.test.tsx
@@ -69,13 +69,16 @@ afterEach(() => {
 });
 
 describe("TaskDetailRoute", () => {
-  it("waits for route data before mounting the task shell", async () => {
+  it("shows accessible task-loading progress while route data is pending", async () => {
     const routeData = deferred<FetchedSessionData>();
     mocks.fetchSessionDataForTask.mockReturnValueOnce(routeData.promise);
 
     render(<TaskDetailRoute taskId="task-1" />);
 
     expect(screen.queryByTestId("kanban-task-shell")).toBeNull();
+    expect(screen.getByRole("status").textContent).toContain("Loading task");
+    expect(screen.getByRole("status").parentElement?.className).toContain("h-dvh");
+    expect(screen.getByRole("status").parentElement?.className).not.toContain("h-screen");
 
     routeData.resolve(makeFetchedData());
 

--- a/apps/web/src/task-detail-route.tsx
+++ b/apps/web/src/task-detail-route.tsx
@@ -79,7 +79,13 @@ export function TaskDetailRoute({
   }, [initialData, taskId]);
 
   if (routeState.status === "loading") {
-    return <div className="h-screen w-full bg-background" />;
+    return (
+      <div className="flex h-dvh w-full items-center justify-center bg-background">
+        <p role="status" aria-live="polite" className="text-sm text-muted-foreground">
+          Loading task…
+        </p>
+      </div>
+    );
   }
 
   const data = routeState.data;

--- a/docs/specs/ui/mobile-task-navigation.md
+++ b/docs/specs/ui/mobile-task-navigation.md
@@ -22,8 +22,10 @@ Mobile users need the same task controls as desktop without relying on long pres
 - Search and live workflow/task updates choose a deterministic visible fallback if the focused workflow disappears.
 - Pipeline is not offered or rendered on mobile. A saved desktop Pipeline preference falls back to Kanban on mobile without overwriting that preference.
 - Tapping a mobile Home task opens that task directly. Task actions remain available from the card's explicit context menu; the intermediate task action sheet is absent.
+- Opening a task route shows visible, accessible loading feedback while required task data loads. Optional route enrichment is bounded and may recover client-side; it cannot leave the task route blank indefinitely or mark unavailable data as authoritatively empty.
 - Editing a task from a mobile context menu exposes its title even after work has started. The existing lock on a started task's prompt remains unchanged.
 - The mobile Home menu and Dockview task switcher open as inset, card-style bottom surfaces with internal vertical scrolling and safe-area spacing, rather than edge-to-edge side sheets.
+- Switching tasks from the mobile task switcher keeps the workbench usable while destination details hydrate. Transient placeholder data must not crash mobile chrome, and a remembered panel that is unavailable for the destination falls back to Chat.
 - The active-session control at the top of mobile Dockview shows the active agent's icon beside its session label.
 - Desktop and tablet Kanban, context menus, drag/drop, and workflow filtering retain their existing behavior.
 
@@ -39,8 +41,11 @@ Mobile users need the same task controls as desktop without relying on long pres
 - **GIVEN** the focused workflow no longer matches search/filter results, **WHEN** the visible workflow set updates, **THEN** mobile Kanban focuses the first visible workflow without leaving an empty stacked board.
 - **GIVEN** Pipeline is saved as the user's desktop view, **WHEN** Home opens on mobile, **THEN** Kanban renders, Pipeline is absent from the mobile view choices, and the saved preference remains Pipeline.
 - **GIVEN** a task card on mobile Home, **WHEN** the user taps the card body, **THEN** the task route opens immediately and no task action sheet appears.
+- **GIVEN** a mobile task route whose optional hydration is delayed or fails, **WHEN** the user opens the task, **THEN** visible loading feedback appears and the core task remains recoverable without an indefinite blank screen.
 - **GIVEN** a started task on mobile Home, **WHEN** the user chooses Edit from its context menu, **THEN** the title can be changed while the prompt remains locked.
 - **GIVEN** the mobile Home menu or Dockview task switcher is opened, **WHEN** its content exceeds the viewport, **THEN** an inset bottom card remains within the safe area and scrolls internally.
+- **GIVEN** two tasks with active sessions, **WHEN** the user selects the other task from the mobile task switcher, **THEN** the destination URL, title, and chat render without a blank screen or mobile-chrome crash.
+- **GIVEN** Review is remembered for a mobile session but its selected merge request is no longer available, **WHEN** the session becomes active, **THEN** Chat is rendered and selected instead of an empty center pane.
 - **GIVEN** a mobile Dockview task with an active session, **WHEN** its chat panel is visible, **THEN** the active-session control shows the session agent's icon and label.
 - **GIVEN** a desktop viewport, **WHEN** the same task menus and Kanban open, **THEN** their existing desktop interaction and layout remain unchanged.
 


### PR DESCRIPTION
Mobile task views could render blank while task-session hydration was delayed, leaving users without usable route feedback. The task route now retains an accessible loading state and preserves mobile task actions during hydration.

## Validation

- `make fmt`
- Release/changelog metadata generation
- `make typecheck`
- `make test` (full suite; web 58/58)
- `make lint` (backend, web ESLint, harness)
- Targeted mobile E2E (11/11) and repeat-pressure E2E (6/6)
- Screenshot capture E2E (2/2)

Closes #1877.

## Screenshots

Desktop viewport: delayed task-session hydration shows the accessible Loading task… route state instead of a blank task view.

![Desktop loading state](https://raw.githubusercontent.com/kdlbs/kandev/9acde1483818b7a1e05e5bbce8e7a9f7eaa125f9/mobile-task-loading-desktop.png)

Pixel 5 viewport: delayed task-session hydration shows the accessible Loading task… route state instead of a blank task view.

![Pixel 5 loading state](https://raw.githubusercontent.com/kdlbs/kandev/9acde1483818b7a1e05e5bbce8e7a9f7eaa125f9/mobile-task-loading-mobile.png)

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.