### PR TITLE
fix(web): collapse completed silent subagent cards

### DIFF
--- a/apps/web/components/task/chat/messages/tool-subagent-message.test.tsx
+++ b/apps/web/components/task/chat/messages/tool-subagent-message.test.tsx
@@ -1,0 +1,128 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { ToolSubagentMessage } from "@/components/task/chat/messages/tool-subagent-message";
+import type { Message } from "@/lib/types/http";
+
+// Guards the subagent card's expand/collapse behavior. Regression coverage for
+// "silent" subagents (a result_text with no child tool calls) rendering
+// permanently expanded: auto-expand must key on the running state alone, not on
+// result_text, so completed cards collapse to their header + metadata row like
+// subagents that stream child tool calls.
+
+function subagentMessage(opts: {
+  status: string;
+  result_text?: string;
+  description?: string;
+}): Message {
+  return {
+    id: "m1",
+    content: "Subagent",
+    metadata: {
+      status: opts.status,
+      normalized: {
+        kind: "subagent_task",
+        subagent_task: {
+          description: opts.description ?? "Summarize the repo",
+          subagent_type: "general-purpose",
+          status: opts.status,
+          result_text: opts.result_text,
+        },
+      },
+    },
+  } as unknown as Message;
+}
+
+const noopRenderChild = () => null;
+const SILENT_RESULT = "Found 42 files across 7 packages.";
+const RESULT_TEXT = "subagent-result-text";
+
+afterEach(cleanup);
+
+describe("ToolSubagentMessage expansion", () => {
+  it("collapses a completed subagent with child tool calls to its header", () => {
+    const child = { id: "c1", content: "sleep 30", metadata: {} } as unknown as Message;
+    render(
+      <ToolSubagentMessage
+        comment={subagentMessage({ status: "complete" })}
+        childMessages={[child]}
+        renderChild={() => <div data-testid="child-body">sleep 30</div>}
+      />,
+    );
+    expect(screen.queryByTestId("child-body")).toBeNull();
+  });
+
+  it("collapses a completed silent subagent (result_text, no children)", () => {
+    render(
+      <ToolSubagentMessage
+        comment={subagentMessage({
+          status: "complete",
+          result_text: SILENT_RESULT,
+        })}
+        childMessages={[]}
+        renderChild={noopRenderChild}
+      />,
+    );
+    // Completed and no longer running -> collapsed: result text stays hidden
+    // until the user opens the card. The metadata row remains visible.
+    expect(screen.queryByTestId(RESULT_TEXT)).toBeNull();
+    expect(screen.getByTestId("subagent-type")).toBeTruthy();
+  });
+
+  it("reveals the silent subagent's result text when expanded", () => {
+    render(
+      <ToolSubagentMessage
+        comment={subagentMessage({
+          status: "complete",
+          result_text: SILENT_RESULT,
+        })}
+        childMessages={[]}
+        renderChild={noopRenderChild}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button"));
+    expect(screen.getByTestId(RESULT_TEXT).textContent).toContain(SILENT_RESULT);
+  });
+
+  it("auto-expands while the subagent is running, then auto-collapses on completion", () => {
+    const running = subagentMessage({ status: "running" });
+    const { rerender } = render(
+      <ToolSubagentMessage comment={running} childMessages={[]} renderChild={noopRenderChild} />,
+    );
+    // Running -> auto-expanded working indicator is shown.
+    expect(screen.queryByText("Subagent working...")).not.toBeNull();
+
+    rerender(
+      <ToolSubagentMessage
+        comment={subagentMessage({ status: "complete", result_text: "Done." })}
+        childMessages={[]}
+        renderChild={noopRenderChild}
+      />,
+    );
+    // Completed without a manual override -> auto-collapsed.
+    expect(screen.queryByTestId(RESULT_TEXT)).toBeNull();
+  });
+
+  it("keeps a manual collapse after the subagent completes", () => {
+    const { rerender } = render(
+      <ToolSubagentMessage
+        comment={subagentMessage({ status: "running" })}
+        childMessages={[]}
+        renderChild={noopRenderChild}
+      />,
+    );
+    // User collapses the running card.
+    fireEvent.click(screen.getByRole("button"));
+    expect(screen.queryByText("Subagent working...")).toBeNull();
+
+    // Completion emits result_text; the manual collapse must survive (it used
+    // to be wiped, forcing the card back open).
+    rerender(
+      <ToolSubagentMessage
+        comment={subagentMessage({ status: "complete", result_text: "Final summary." })}
+        childMessages={[]}
+        renderChild={noopRenderChild}
+      />,
+    );
+    expect(screen.queryByTestId(RESULT_TEXT)).toBeNull();
+  });
+});

--- a/apps/web/components/task/chat/messages/tool-subagent-message.tsx
+++ b/apps/web/components/task/chat/messages/tool-subagent-message.tsx
@@ -182,23 +182,13 @@ export const ToolSubagentMessage = memo(function ToolSubagentMessage({
   // Track manual override state - null means "use auto behavior"
   const [manualExpandState, setManualExpandState] = useState<boolean | null>(null);
 
-  // Auto behavior: expand if active or if we have a result text to surface
-  // (silent Auggie-style subagents have no child messages, so we want the
-  // final summary visible without an extra click).
-  const autoExpanded = isActive || Boolean(resultText);
-
-  // Reset the manual override the first time a result_text arrives so a card
-  // the user collapsed while the subagent was running auto-opens to show the
-  // summary. "Adjust state during render" pattern (preferred over useEffect):
-  // https://react.dev/learn/you-might-not-need-an-effect — only fires on the
-  // empty -> non-empty transition; later user collapses persist.
-  const [prevResultText, setPrevResultText] = useState(resultText);
-  if (resultText !== prevResultText) {
-    setPrevResultText(resultText);
-    if (resultText && !prevResultText) {
-      setManualExpandState(null);
-    }
-  }
+  // Auto behavior: expand only while the subagent is active. On completion the
+  // card auto-collapses to its header + metadata row, matching subagents that
+  // stream child tool calls; the result text is one click away. Previously
+  // auto-expand was also keyed on result_text, which left silent (Auggie-style)
+  // subagents — the ones with no child messages — permanently expanded because
+  // result_text never clears.
+  const autoExpanded = isActive;
 
   // Derive expanded state: manual override takes precedence, otherwise use auto
   const isExpanded = manualExpandState ?? autoExpanded;


### PR DESCRIPTION
Silent subagent cards (an Auggie-style `result_text` with no streamed child tool calls) rendered permanently expanded because auto-expand was keyed on `result_text`, which never clears — unlike subagents that stream child tool calls and collapse to their header on completion. Auto-expand now keys on the running state alone, so every completed subagent collapses consistently and its result text is one click away.

## Important Changes

- `tool-subagent-message.tsx`: `autoExpanded` derives from `isActive` only (was `isActive || Boolean(resultText)`).
- Removed the render-phase reset that wiped a user's manual collapse the moment `result_text` arrived, so a deliberate collapse now persists through completion.

## Validation

- `pnpm run typecheck` (apps/web) — pass
- `pnpm exec vitest run components/task/chat/messages/tool-subagent-message.test.tsx` — 5/5 pass (new coverage: silent-subagent collapse, expand-on-click, running→completed auto-collapse, manual-collapse-persists, child-bearing baseline)
- `pnpm exec vitest run components/task/chat/messages` — 155/155 pass, no sibling regressions
- Pre-commit hooks (Prettier, web lint, commitlint) — pass

## Possible Improvements

Low risk — behavior-only change to local expand state in one component; no data or API surface touched. The mock agent has no silent-subagent scenario (it only emits child-bearing subagents, whose collapse behavior is unchanged), so this path is covered by component tests rather than E2E.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1901?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

