### PR TITLE
docs: add missing periods to bullet items in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,9 +21,9 @@ You must understand the code you submit. You're welcome to use AI tools to help 
 
 Search [existing issues](https://github.com/kdlbs/kandev/issues) first. If your bug isn't already reported, open one with:
 
-- Steps to reproduce
-- Expected vs actual behavior
-- Environment details (OS, browser, agent type)
+- Steps to reproduce.
+- Expected vs actual behavior.
+- Environment details (OS, browser, agent type).
 
 ## Feature Ideas
 


### PR DESCRIPTION
## Description
This PR fixes list item punctuation consistency in `CONTRIBUTING.md`.

## Details
Added trailing periods to bullet items under the Bug Reports section.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1909?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

