### PR TITLE
fix: make model selector rows respond to pointer clicks

### DIFF
--- a/apps/web/components/model-config-selector.test.tsx
+++ b/apps/web/components/model-config-selector.test.tsx
@@ -36,6 +36,36 @@ describe("ModelConfigSelector", () => {
     );
   });
 
+  it("selects a model on pointer click, not just keyboard, and closes the popover", () => {
+    const onModelChange = vi.fn();
+
+    render(
+      <ModelConfigSelector
+        modelOptions={[
+          { id: "gpt-5.5", name: "GPT-5.5" },
+          { id: "gpt-5.6-sol", name: "GPT-5.6 Sol" },
+        ]}
+        currentModel="gpt-5.5"
+        onModelChange={onModelChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: modelSettingsButtonName }));
+
+    const otherRow = screen.getByRole("option", { name: /GPT-5\.6 Sol/ });
+    // Regression guard: cmdk's onSelect() (fired on click) only synthesizes a
+    // click from touch/pointer input in WebKit-based engines when the item
+    // looks interactive; a `cursor-default` item silently breaks pointer
+    // selection while leaving keyboard (Enter) selection unaffected.
+    expect(otherRow.className).toContain("cursor-pointer");
+    expect(otherRow.className).not.toContain("cursor-default");
+
+    fireEvent.click(otherRow);
+
+    expect(onModelChange).toHaveBeenCalledWith("gpt-5.6-sol");
+    expect(screen.queryByRole("option", { name: /GPT-5\.6 Sol/ })).toBeNull();
+  });
+
   it("opens extra config options from compact sub-selector rows", () => {
     const onConfigChange = vi.fn();
 

--- a/apps/web/components/model-config-selector.test.tsx
+++ b/apps/web/components/model-config-selector.test.tsx
@@ -261,3 +261,44 @@ describe("ModelConfigSelector provider descriptions", () => {
     expect(screen.queryByRole("tooltip")).toBeNull();
   });
 });
+
+function renderTwoModelSelector(onModelChange: (id: string) => void) {
+  render(
+    <ModelConfigSelector
+      modelOptions={[
+        { id: "gpt-5.5", name: "GPT-5.5" },
+        { id: providerModelId, name: "GPT-5.6 Sol" },
+      ]}
+      currentModel="gpt-5.5"
+      onModelChange={onModelChange}
+    />,
+  );
+  fireEvent.click(screen.getByRole("button", { name: modelSettingsButtonName }));
+  return screen.getByRole("option", { name: /GPT-5\.6 Sol/ });
+}
+
+describe("ModelConfigSelector pointer fallback", () => {
+  it("selects a model on a touch pointer-up fallback without double-invoking on the synthesized click", () => {
+    const onModelChange = vi.fn();
+    const otherRow = renderTwoModelSelector(onModelChange);
+
+    // Regression guard: some WebKit/embedded shells fail to synthesize a click
+    // from a touch tap even with cursor-pointer set, so ModelRow also selects
+    // on a touch/pen pointerup. Some engines still synthesize the click too;
+    // the handler must dedupe so a single tap doesn't fire onModelChange twice.
+    fireEvent.pointerUp(otherRow, { pointerType: "touch" });
+    fireEvent.click(otherRow);
+
+    expect(onModelChange).toHaveBeenCalledTimes(1);
+    expect(onModelChange).toHaveBeenCalledWith(providerModelId);
+  });
+
+  it("does not trigger selection on a mouse pointer-up (only click)", () => {
+    const onModelChange = vi.fn();
+    const otherRow = renderTwoModelSelector(onModelChange);
+
+    fireEvent.pointerUp(otherRow, { pointerType: "mouse" });
+
+    expect(onModelChange).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/components/model-config-selector.tsx
+++ b/apps/web/components/model-config-selector.tsx
@@ -175,11 +175,21 @@ function ModelRow({
   selected: boolean;
   onSelect: (value: string) => void;
 }) {
+  // Deduplicate rapid duplicate selects coming from both pointer fallbacks
+  // and cmdk's native onSelect; small time window prevents double-invokes.
+  const lastSelectAt = useRef<number>(0);
+  const handleSelect = (value: string) => {
+    const now = Date.now();
+    if (now - lastSelectAt.current < 300) return;
+    lastSelectAt.current = now;
+    onSelect(value);
+  };
+
   return (
     <CommandItem
       value={model.id}
       keywords={[model.name, model.description ?? "", model.id]}
-      onSelect={() => onSelect(model.id)}
+      onSelect={() => handleSelect(model.id)}
       // cursor-pointer overrides CommandItem's default cursor-default: WebKit-based
       // engines (iOS Safari, Tauri's WebKitGTK/WKWebView shell) only synthesize a
       // `click` event from a tap/pointer press when the element looks interactive,
@@ -187,6 +197,17 @@ function ModelRow({
       // synthesis. Without it, cmdk's onClick-driven onSelect() never fires on
       // pointer/touch — only keyboard (Enter) selection, which doesn't depend on a
       // synthesized click, keeps working.
+      // As a defensive fallback, synthesize a selection on touch/pen pointer up
+      // events so mobile WebKit and other embedded shells receive the selection
+      // even if their click synthesis path fails.
+      onPointerUp={(e) => {
+        if (e.pointerType === "touch" || e.pointerType === "pen") {
+          // Prevent any browser default that might interfere and call the
+          // de-duplicated handler.
+          e.preventDefault();
+          handleSelect(model.id);
+        }
+      }}
       className="relative cursor-pointer pr-7"
     >
       <div className="flex min-w-0 flex-1 items-center">

--- a/apps/web/components/model-config-selector.tsx
+++ b/apps/web/components/model-config-selector.tsx
@@ -180,7 +180,14 @@ function ModelRow({
       value={model.id}
       keywords={[model.name, model.description ?? "", model.id]}
       onSelect={() => onSelect(model.id)}
-      className="relative pr-7"
+      // cursor-pointer overrides CommandItem's default cursor-default: WebKit-based
+      // engines (iOS Safari, Tauri's WebKitGTK/WKWebView shell) only synthesize a
+      // `click` event from a tap/pointer press when the element looks interactive,
+      // and a non-pointer cursor is one of the signals that suppresses that
+      // synthesis. Without it, cmdk's onClick-driven onSelect() never fires on
+      // pointer/touch — only keyboard (Enter) selection, which doesn't depend on a
+      // synthesized click, keeps working.
+      className="relative cursor-pointer pr-7"
     >
       <div className="flex min-w-0 flex-1 items-center">
         <div className="min-w-0 flex-1">

--- a/apps/web/e2e/tests/chat/mobile-model-selector.spec.ts
+++ b/apps/web/e2e/tests/chat/mobile-model-selector.spec.ts
@@ -98,5 +98,13 @@ test.describe("Mobile chat model selector", () => {
     expect(popoverBox).not.toBeNull();
     expect(popoverBox!.x).toBeGreaterThanOrEqual(0);
     expect(popoverBox!.x + popoverBox!.width).toBeLessThanOrEqual(viewport!.width);
+
+    // Regression coverage: tapping a model row (a cmdk CommandItem) must select it,
+    // not just arrow-key + Enter. This closes the gap that let a WebKit/touch-only
+    // pointer-selection bug ship — the trigger label above and the config-option
+    // taps do not exercise selecting a model row itself. The popover stays open
+    // after a model tap because an extra config option (effort) is present.
+    await testPage.getByRole("option", { name: /Mock Smart/ }).tap();
+    await expect(trigger).toHaveText("Mock Smart / Low");
   });
 });


### PR DESCRIPTION
Clicking a model in the active-session model selector silently did nothing on pointer/touch (only keyboard arrow-keys + Enter worked), because WebKit-based engines (iOS Safari, Tauri's WebKitGTK/WKWebView shell) skip synthesizing a `click` from a tap/pointer press on elements that don't look interactive, and the cmdk row inherited `cursor-default` from the shared `Command` primitive.

## Important Changes

- Added `cursor-pointer` to `ModelRow` in `model-config-selector.tsx`, scoped to the model selector so other cmdk-based pickers (e.g. the command palette) are unaffected.
- Added a defensive `onPointerUp` fallback on `ModelRow` that selects the model directly when the pointer type is `touch` or `pen`, for WebKit/embedded shells that may still fail to synthesize a click even with `cursor-pointer` set. A 300ms time-based dedupe (`handleSelect`) prevents a double-invoke of `onModelChange` when both the fallback and cmdk's own click-driven `onSelect` fire for the same tap.

## Validation

- `cd apps/web && npx tsc --noEmit -p .`
- `cd apps/web && npx vitest run` (full suite, including regression tests asserting the model row is pointer-clickable, that a touch `pointerup` selects the model without double-invoking `onModelChange` on the synthesized click, and that a mouse `pointerup` does not trigger selection)
- `cd apps && pnpm --filter @kandev/web lint`
- `npx prettier --check` on changed files
- Added a mobile e2e assertion (`e2e/tests/chat/mobile-model-selector.spec.ts`) that taps a model row and asserts the trigger label updates; not runnable in this sandbox (no browser system libraries / root access available), but covered by lint/typecheck/unit tests and will run in CI.

## Possible Improvements

Low risk: the CSS change is scoped to one component, and the pointer-up fallback only activates for `touch`/`pen` pointer types (mouse/keyboard behavior is unchanged) with a dedupe guard against double-firing. Validated via unit tests and CSS-class assertions rather than a live WebKit/touch reproduction, since this sandbox cannot launch real browsers.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1912?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
