### PR TITLE
feat: move subtask action to task context menu

### DIFF
--- a/apps/web/components/app-sidebar/app-sidebar-new-task-item.test.tsx
+++ b/apps/web/components/app-sidebar/app-sidebar-new-task-item.test.tsx
@@ -24,9 +24,7 @@ const state = {
   kanban: {
     workflowId: "wf-1" as string | null,
     steps: [{ id: "s1", title: "Todo" }],
-    tasks: [{ id: "t-1", title: "Parent task" }] as Array<{ id: string; title: string }>,
   },
-  tasks: { activeTaskId: null as string | null },
   setActiveTask: mocks.setActiveTask,
   setActiveSession: mocks.setActiveSession,
 };
@@ -76,14 +74,9 @@ vi.mock("@/components/task-create-dialog", () => ({
     </button>
   ),
 }));
-vi.mock("@/components/task/new-subtask-dialog", () => ({
-  NewSubtaskDialog: () => <div data-testid="new-subtask-dialog" />,
-}));
-
 import { AppSidebarNewTaskItem } from "./app-sidebar-new-task-item";
 import { requestNewTaskCreation } from "@/lib/desktop/new-task-request";
 
-const SUBTASK_TESTID = "sidebar-new-subtask";
 const OFFICE_DIALOG_TESTID = "office-new-task-dialog";
 const REGULAR_DIALOG_TESTID = "regular-task-create-dialog";
 
@@ -91,8 +84,6 @@ function resetTestState() {
   state.workspaces.activeId = "ws-1";
   state.kanban.workflowId = "wf-1";
   state.kanban.steps = [{ id: "s1", title: "Todo" }];
-  state.kanban.tasks = [{ id: "t-1", title: "Parent task" }];
-  state.tasks.activeTaskId = null;
   mocks.routerPush.mockClear();
   mocks.setActiveTask.mockClear();
   mocks.setActiveSession.mockClear();
@@ -173,37 +164,6 @@ describe("AppSidebarNewTaskItem row actions", () => {
     state.workspaces.activeId = null;
     renderItem(false);
     expect(screen.queryByTestId("sidebar-quick-chat-shortcut")).toBeNull();
-  });
-
-  it("offers a subtask affordance when a task is active in regular mode", () => {
-    state.tasks.activeTaskId = "t-1";
-    renderItem(false);
-    expect(screen.getByTestId(SUBTASK_TESTID)).toBeTruthy();
-    expect(screen.getByTestId("new-subtask-dialog")).toBeTruthy();
-  });
-
-  it("hides the subtask affordance when no task is active", () => {
-    state.tasks.activeTaskId = null;
-    renderItem(false);
-    expect(screen.queryByTestId(SUBTASK_TESTID)).toBeNull();
-  });
-
-  it("offers the subtask affordance in office mode too (compact subtask dialog)", async () => {
-    officeEnabled = true;
-    pathname = "/office";
-    state.tasks.activeTaskId = "t-1";
-    renderItem(false);
-    // Primary New Task uses the office dialog (lazy-loaded), but subtasks still
-    // go through the compact NewSubtaskDialog regardless of mode.
-    expect(await screen.findByTestId(OFFICE_DIALOG_TESTID)).toBeTruthy();
-    expect(screen.getByTestId(SUBTASK_TESTID)).toBeTruthy();
-    expect(screen.getByTestId("new-subtask-dialog")).toBeTruthy();
-  });
-
-  it("hides the subtask affordance when the rail is collapsed", () => {
-    state.tasks.activeTaskId = "t-1";
-    renderItem(true);
-    expect(screen.queryByTestId(SUBTASK_TESTID)).toBeNull();
   });
 });
 

--- a/apps/web/components/app-sidebar/app-sidebar-new-task-item.tsx
+++ b/apps/web/components/app-sidebar/app-sidebar-new-task-item.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useState, type Dispatch, type SetStateAction } from "react";
 import dynamic from "@/lib/routing/client-dynamic";
 import { useRouter } from "@/lib/routing/client-router";
-import { IconMessageCircle, IconSquarePlus, IconSubtask } from "@tabler/icons-react";
+import { IconMessageCircle, IconSquarePlus } from "@tabler/icons-react";
 import type { Icon as TablerIcon } from "@tabler/icons-react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
 import { useAppStore } from "@/components/state-provider";
@@ -21,7 +21,6 @@ const NewTaskDialog = dynamic(
   () => import("@/app/office/components/new-task-dialog").then((m) => m.NewTaskDialog),
   { ssr: false },
 );
-import { NewSubtaskDialog } from "@/components/task/new-subtask-dialog";
 import { AppSidebarNavItem } from "./app-sidebar-nav-item";
 
 type AppSidebarNewTaskItemProps = {
@@ -39,8 +38,6 @@ function useNewTaskCreationRequest(
 }
 
 const ONE_ROW_ACTION_INSET_CLASS = "pr-10";
-const TWO_ROW_ACTIONS_INSET_CLASS = "pr-16";
-
 type RowActionButtonProps = {
   icon: TablerIcon;
   label: string;
@@ -75,44 +72,23 @@ function RowActionButton({ icon: Icon, label, testId, onClick }: RowActionButton
  * workflow. Gate on `useInOffice()` (route), not the bare `office` flag, so the
  * Office dialog never leaks into Kanban mode.
  *
- * When the user is inside a task (an active task in regular mode), a trailing
- * subtask affordance appears so a child task can be created against the current
- * one — restoring the contextual action the retired dockview header dropdown
- * used to provide.
+ * Task-specific actions live on each task row's context menu, keeping this
+ * global navigation item focused on creating top-level tasks and quick chats.
  */
 export function AppSidebarNewTaskItem({ collapsed }: AppSidebarNewTaskItemProps) {
   const router = useRouter();
   const workspaceId = useAppStore((s) => s.workspaces.activeId);
   const workflowId = useAppStore((s) => s.kanban.workflowId);
   const steps = useAppStore((s) => s.kanban.steps);
-  const activeTaskId = useAppStore((s) => s.tasks.activeTaskId);
   const setActiveTask = useAppStore((s) => s.setActiveTask);
   const setActiveSession = useAppStore((s) => s.setActiveSession);
-  const activeTaskTitle = useAppStore((s) => {
-    const id = s.tasks.activeTaskId;
-    if (!id) return "";
-    return s.kanban.tasks.find((t) => t.id === id)?.title ?? "";
-  });
   const inOffice = useInOffice();
   const handleOpenQuickChat = useQuickChatLauncher(workspaceId);
   const [open, setOpen] = useState(false);
-  const [subtaskOpen, setSubtaskOpen] = useState(false);
   useNewTaskCreationRequest(workspaceId, setOpen);
 
-  // The subtask affordance is available in both modes (office uses the richer
-  // dialog for the primary New Task, but subtasks always go through the compact
-  // NewSubtaskDialog, matching the retired dropdown). It needs an active task
-  // and the expanded rail to host the trailing button.
   const canOpenQuickChat = !collapsed && !!workspaceId;
-  const canCreateSubtask = !collapsed && !!workspaceId && !!activeTaskId;
-  let actionInsetClass: string | undefined;
-  // Keep the label clear of the absolute action cluster:
-  // pr-10 covers one w-6 button + right-1.5 inset; pr-16 covers two buttons + gap-1.
-  if (canCreateSubtask) {
-    actionInsetClass = TWO_ROW_ACTIONS_INSET_CLASS;
-  } else if (canOpenQuickChat) {
-    actionInsetClass = ONE_ROW_ACTION_INSET_CLASS;
-  }
+  const actionInsetClass = canOpenQuickChat ? ONE_ROW_ACTION_INSET_CLASS : undefined;
   const handleRegularTaskCreated = useCallback(
     (
       task: Task,
@@ -151,14 +127,6 @@ export function AppSidebarNewTaskItem({ collapsed }: AppSidebarNewTaskItemProps)
               testId="sidebar-quick-chat-shortcut"
               onClick={handleOpenQuickChat}
             />
-            {canCreateSubtask && (
-              <RowActionButton
-                icon={IconSubtask}
-                label="New subtask of current task"
-                testId="sidebar-new-subtask"
-                onClick={() => setSubtaskOpen(true)}
-              />
-            )}
           </div>
         )}
       </div>
@@ -177,14 +145,6 @@ export function AppSidebarNewTaskItem({ collapsed }: AppSidebarNewTaskItemProps)
             onSuccess={handleRegularTaskCreated}
           />
         ))}
-      {canCreateSubtask && (
-        <NewSubtaskDialog
-          open={subtaskOpen}
-          onOpenChange={setSubtaskOpen}
-          parentTaskId={activeTaskId}
-          parentTaskTitle={activeTaskTitle}
-        />
-      )}
     </>
   );
 }

--- a/apps/web/components/task/mobile/session-task-switcher-sheet.tsx
+++ b/apps/web/components/task/mobile/session-task-switcher-sheet.tsx
@@ -17,6 +17,7 @@ import { useSidebarTaskPrefs } from "@/hooks/domains/sidebar/use-sidebar-task-pr
 import { useRepositories } from "@/hooks/domains/workspace/use-repositories";
 import { WorkspaceSwitcher } from "../workspace-switcher";
 import { TaskCreateDialog } from "@/components/task-create-dialog";
+import { NewSubtaskDialog } from "../new-subtask-dialog";
 import { TaskArchiveConfirmDialog } from "../task-archive-confirm-dialog";
 import { TaskDeleteConfirmDialog } from "../task-delete-confirm-dialog";
 import { TaskDetachTargetConfirmDialog } from "../task-detach-confirm-dialog";
@@ -57,6 +58,7 @@ export function MobileTaskList({
   selectedTaskId,
   onSelectTask,
   onRenameTask,
+  onCreateSubtask,
   onArchiveTask,
   onDeleteTask,
   onDetachTask,
@@ -76,6 +78,7 @@ export function MobileTaskList({
   selectedTaskId: string | null;
   onSelectTask: (taskId: string) => void;
   onRenameTask?: (taskId: string, currentTitle: string) => void;
+  onCreateSubtask?: (taskId: string, taskTitle: string) => void;
   onArchiveTask: (taskId: string) => void;
   onDeleteTask: (taskId: string) => Promise<void> | void;
   onDetachTask: (taskId: string) => Promise<void> | void;
@@ -126,6 +129,7 @@ export function MobileTaskList({
       onToggleSubtasks={toggleSubtaskCollapsed}
       onSelectTask={onSelectTask}
       onRenameTask={onRenameTask}
+      onCreateSubtask={onCreateSubtask}
       onArchiveTask={onArchiveTask}
       onDeleteTask={onDeleteTask}
       onDetachTask={onDetachTask}
@@ -240,11 +244,31 @@ type TaskSwitcherSurfaceContentProps = {
   onOpenChange: (open: boolean) => void;
   onQuickChat: () => void;
   onNewTask: () => void;
+  onCreateSubtask: (taskId: string, taskTitle: string) => void;
   data: ReturnType<typeof useSheetData>;
   actions: ReturnType<typeof useSheetActions>;
   rename: ReturnType<typeof useMobileTaskRename>;
   linking: ReturnType<typeof useMobileTaskLinking>;
 };
+
+function MobileSubtaskDialog({
+  target,
+  onTargetChange,
+}: {
+  target: { id: string; title: string } | null;
+  onTargetChange: (next: { id: string; title: string } | null) => void;
+}) {
+  return (
+    <NewSubtaskDialog
+      open={target !== null}
+      onOpenChange={(open) => {
+        if (!open) onTargetChange(null);
+      }}
+      parentTaskId={target?.id ?? ""}
+      parentTaskTitle={target?.title ?? ""}
+    />
+  );
+}
 
 function TaskSwitcherSurfaceContent({
   presentation,
@@ -252,6 +276,7 @@ function TaskSwitcherSurfaceContent({
   onOpenChange,
   onQuickChat,
   onNewTask,
+  onCreateSubtask,
   data,
   actions,
   rename,
@@ -279,6 +304,7 @@ function TaskSwitcherSurfaceContent({
           selectedTaskId={data.selectedTaskId}
           onSelectTask={actions.handleSelectTask}
           onRenameTask={surfaceAction(presentation, onOpenChange, rename.handleRenameTask)}
+          onCreateSubtask={onCreateSubtask}
           onArchiveTask={surfaceAction(presentation, onOpenChange, actions.handleArchiveTask)}
           onDeleteTask={surfaceAction(presentation, onOpenChange, actions.handleDeleteTask)}
           onDetachTask={surfaceAction(presentation, onOpenChange, actions.handleDetachTask)}
@@ -329,6 +355,8 @@ function TaskSwitcherDialogs({
   actions,
   rename,
   linking,
+  subtaskTarget,
+  onSubtaskTargetChange,
 }: {
   dialogOpen: boolean;
   onDialogOpenChange: (open: boolean) => void;
@@ -338,6 +366,8 @@ function TaskSwitcherDialogs({
   actions: ReturnType<typeof useSheetActions>;
   rename: ReturnType<typeof useMobileTaskRename>;
   linking: ReturnType<typeof useMobileTaskLinking>;
+  subtaskTarget: { id: string; title: string } | null;
+  onSubtaskTargetChange: (target: { id: string; title: string } | null) => void;
 }) {
   return (
     <>
@@ -351,6 +381,7 @@ function TaskSwitcherDialogs({
         steps={data.dialogSteps}
         onSuccess={actions.handleTaskCreated}
       />
+      <MobileSubtaskDialog target={subtaskTarget} onTargetChange={onSubtaskTargetChange} />
       <TaskArchiveConfirmDialog
         open={actions.archivingTask !== null}
         onOpenChange={(open) => {
@@ -404,6 +435,7 @@ export const SessionTaskSwitcherSheet = memo(function SessionTaskSwitcherSheet({
   presentation = "sheet",
 }: SessionTaskSwitcherSheetProps) {
   const [dialogOpen, setDialogOpen] = useState(false);
+  const [subtaskTarget, setSubtaskTarget] = useState<{ id: string; title: string } | null>(null);
   const data = useSheetData(workspaceId);
   const actions = useSheetActions(workspaceId, onOpenChange);
   const rename = useMobileTaskRename();
@@ -413,6 +445,13 @@ export const SessionTaskSwitcherSheet = memo(function SessionTaskSwitcherSheet({
     onOpenChange(false);
     openQuickChat();
   }, [onOpenChange, openQuickChat]);
+  const handleCreateSubtask = useCallback(
+    (taskId: string, taskTitle: string) => {
+      onOpenChange(false);
+      setSubtaskTarget({ id: taskId, title: taskTitle });
+    },
+    [onOpenChange],
+  );
 
   const surfaceContent = (
     <TaskSwitcherSurfaceContent
@@ -420,6 +459,7 @@ export const SessionTaskSwitcherSheet = memo(function SessionTaskSwitcherSheet({
       workspaceId={workspaceId}
       onOpenChange={onOpenChange}
       onQuickChat={handleQuickChat}
+      onCreateSubtask={handleCreateSubtask}
       onNewTask={() => {
         if (presentation === "drawer") onOpenChange(false);
         setDialogOpen(true);
@@ -462,6 +502,8 @@ export const SessionTaskSwitcherSheet = memo(function SessionTaskSwitcherSheet({
         actions={actions}
         rename={rename}
         linking={linking}
+        subtaskTarget={subtaskTarget}
+        onSubtaskTargetChange={setSubtaskTarget}
       />
     </>
   );

--- a/apps/web/components/task/new-subtask-dialog-context.test.ts
+++ b/apps/web/components/task/new-subtask-dialog-context.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { resolveSubtaskParentContext } from "./new-subtask-dialog";
+import type { KanbanState } from "@/lib/state/slices/kanban/types";
+import type { Message, TaskSession } from "@/lib/types/http";
+
+const parentTask = {
+  id: "parent-b",
+  primarySessionId: "session-b",
+  repositories: [
+    { id: "task-repo-b", repository_id: "repo-b", base_branch: "release", position: 0 },
+  ],
+} as KanbanState["tasks"][number];
+
+const parentSession = {
+  id: "session-b",
+  task_id: "parent-b",
+  agent_profile_id: "profile-b",
+  repository_id: "repo-b",
+  base_branch: "main",
+  worktree_branch: "parent-b-branch",
+  is_primary: true,
+} as TaskSession;
+
+const parentMessage = {
+  id: "message-b",
+  session_id: "session-b",
+  task_id: "parent-b",
+  author_type: "user",
+  content: "parent B prompt",
+  type: "message",
+} as Message;
+
+const activeSession = {
+  ...parentSession,
+  id: "session-a",
+  task_id: "parent-a",
+  agent_profile_id: "profile-a",
+} as TaskSession;
+
+describe("resolveSubtaskParentContext", () => {
+  it("uses the selected parent instead of the active session", () => {
+    expect(
+      resolveSubtaskParentContext({
+        task: parentTask,
+        sessionsById: {
+          "session-a": activeSession,
+          "session-b": parentSession,
+        },
+        sessionsByTaskId: { "parent-b": [parentSession] },
+        worktreeIdsBySessionId: { "session-b": ["worktree-b"] },
+        worktrees: { "worktree-b": { branch: "parent-b-worktree" } },
+        messagesBySession: { "session-b": [parentMessage] },
+      }),
+    ).toMatchObject({
+      session: parentSession,
+      worktreeBranch: "parent-b-worktree",
+      initialPrompt: "parent B prompt",
+      parentRepositoryId: "repo-b",
+      baseBranch: "release",
+    });
+  });
+});

--- a/apps/web/components/task/new-subtask-dialog-context.test.ts
+++ b/apps/web/components/task/new-subtask-dialog-context.test.ts
@@ -59,4 +59,23 @@ describe("resolveSubtaskParentContext", () => {
       baseBranch: "release",
     });
   });
+
+  it("handles a parent task without repositories", () => {
+    expect(
+      resolveSubtaskParentContext({
+        task: { id: "repo-less-parent" } as KanbanState["tasks"][number],
+        sessionsById: {},
+        sessionsByTaskId: {},
+        worktreeIdsBySessionId: {},
+        worktrees: {},
+        messagesBySession: {},
+      }),
+    ).toMatchObject({
+      session: null,
+      worktreeBranch: null,
+      initialPrompt: null,
+      parentRepositoryId: null,
+      baseBranch: null,
+    });
+  });
 });

--- a/apps/web/components/task/new-subtask-dialog.tsx
+++ b/apps/web/components/task/new-subtask-dialog.tsx
@@ -30,6 +30,8 @@ import {
 import { PromptZone, SubtaskFormBody } from "./new-subtask-form-parts";
 import { applySummarizeSessionResult, type SummaryToastFn } from "./session-context-summary";
 import { useSubtaskPromptZone, useSubtaskSubmit } from "./use-subtask-submit";
+import type { KanbanState } from "@/lib/state/slices/kanban/types";
+import type { Message, TaskSession } from "@/lib/types/http";
 
 type NewSubtaskDialogProps = {
   open: boolean;
@@ -38,43 +40,129 @@ type NewSubtaskDialogProps = {
   parentTaskTitle: string;
 };
 
-function useSubtaskDialogState() {
+type ParentTaskContext = {
+  task: KanbanState["tasks"][number] | null;
+  session: TaskSession | null;
+  worktreeBranch: string | null;
+  initialPrompt: string | null;
+  parentRepositoryId: string | null;
+  baseBranch: string | null;
+};
+
+export function resolveSubtaskParentContext({
+  task,
+  sessionsById,
+  sessionsByTaskId,
+  worktreeIdsBySessionId,
+  worktrees,
+  messagesBySession,
+}: {
+  task: KanbanState["tasks"][number] | null;
+  sessionsById: Record<string, TaskSession>;
+  sessionsByTaskId: Record<string, TaskSession[]>;
+  worktreeIdsBySessionId: Record<string, string[]>;
+  worktrees: Record<string, { branch?: string }>;
+  messagesBySession: Record<string, Message[]>;
+}): ParentTaskContext {
+  const session = resolveParentSession(task, sessionsById, sessionsByTaskId);
+  const primaryRepository = resolvePrimaryRepository(task);
+
+  return {
+    task,
+    session,
+    worktreeBranch: resolveWorktreeBranch(session, worktreeIdsBySessionId, worktrees),
+    initialPrompt: resolveInitialPrompt(session, messagesBySession),
+    parentRepositoryId: primaryRepository?.repository_id ?? session?.repository_id ?? null,
+    baseBranch: primaryRepository?.base_branch ?? session?.base_branch ?? null,
+  };
+}
+
+function resolveParentSession(
+  task: KanbanState["tasks"][number] | null,
+  sessionsById: Record<string, TaskSession>,
+  sessionsByTaskId: Record<string, TaskSession[]>,
+) {
+  const taskSessions = task ? (sessionsByTaskId[task.id] ?? []) : [];
+  const sessionId = task?.primarySessionId ?? taskSessions.find((s) => s.is_primary)?.id;
+  return sessionId
+    ? (sessionsById[sessionId] ?? taskSessions.find((s) => s.id === sessionId) ?? null)
+    : null;
+}
+
+function resolvePrimaryRepository(task: KanbanState["tasks"][number] | null) {
+  return task?.repositories?.reduce((current, repository) =>
+    !current || repository.position < current.position ? repository : current,
+  );
+}
+
+function resolveWorktreeBranch(
+  session: TaskSession | null,
+  worktreeIdsBySessionId: Record<string, string[]>,
+  worktrees: Record<string, { branch?: string }>,
+) {
+  if (!session) return null;
+  const worktreeBranch = (worktreeIdsBySessionId[session.id] ?? [])
+    .map((id) => worktrees[id]?.branch)
+    .find((branch): branch is string => Boolean(branch));
+  return worktreeBranch ?? session.worktree_branch ?? null;
+}
+
+function resolveInitialPrompt(
+  session: TaskSession | null,
+  messagesBySession: Record<string, Message[]>,
+) {
+  if (!session) return null;
+  return (
+    messagesBySession[session.id]?.find((message) => message.author_type === "user")?.content ??
+    null
+  );
+}
+
+function useSubtaskDialogState(parentTaskId: string, parentSessions: TaskSession[]) {
   const agentProfiles = useAppStore((s) => s.agentProfiles.items);
-  const activeSessionId = useAppStore((s) => s.tasks.activeSessionId);
   const workspaceId = useAppStore((s) => s.workspaces.activeId);
   const workflowId = useAppStore((s) => s.kanban.workflowId);
   const executors = useAppStore((s) => s.executors.items);
-
-  const currentSession = useAppStore((s) =>
-    activeSessionId ? (s.taskSessions.items[activeSessionId] ?? null) : null,
+  const parentTask = useAppStore(
+    (s) => s.kanban.tasks.find((task) => task.id === parentTaskId) ?? null,
   );
-
-  const worktreeBranch = useAppStore((s) => {
-    if (!activeSessionId) return null;
-    const wtIds = s.sessionWorktreesBySessionId.itemsBySessionId[activeSessionId];
-    if (wtIds?.length) {
-      const wt = s.worktrees.items[wtIds[0]];
-      if (wt?.branch) return wt.branch;
-    }
-    return currentSession?.worktree_branch ?? null;
-  });
-
-  const initialPrompt = useAppStore((s) => {
-    if (!activeSessionId) return null;
-    const msgs = s.messages.bySession[activeSessionId];
-    if (!msgs?.length) return null;
-    const first = msgs.find((m: { author_type?: string }) => m.author_type === "user");
-    return first ? ((first as { content?: string }).content ?? null) : null;
-  });
+  const sessionsById = useAppStore((s) => s.taskSessions.items);
+  const sessionsByTaskId = useAppStore((s) => s.taskSessionsByTask.itemsByTaskId);
+  const worktreeIdsBySessionId = useAppStore((s) => s.sessionWorktreesBySessionId.itemsBySessionId);
+  const worktrees = useAppStore((s) => s.worktrees.items);
+  const messagesBySession = useAppStore((s) => s.messages.bySession);
+  const parentContext = useMemo(
+    () =>
+      resolveSubtaskParentContext({
+        task: parentTask,
+        sessionsById,
+        sessionsByTaskId: {
+          ...sessionsByTaskId,
+          [parentTaskId]: parentSessions.length
+            ? parentSessions
+            : (sessionsByTaskId[parentTaskId] ?? []),
+        },
+        worktreeIdsBySessionId,
+        worktrees,
+        messagesBySession,
+      }),
+    [
+      messagesBySession,
+      parentTask,
+      parentSessions,
+      sessionsById,
+      sessionsByTaskId,
+      worktreeIdsBySessionId,
+      worktrees,
+    ],
+  );
 
   return {
     agentProfiles,
     workspaceId,
     workflowId,
     executors,
-    currentSession,
-    worktreeBranch,
-    initialPrompt,
+    ...parentContext,
   };
 }
 
@@ -386,15 +474,18 @@ export function NewSubtaskDialog({
   parentTaskId,
   parentTaskTitle,
 }: NewSubtaskDialogProps) {
+  const { sessions: parentSessions } = useTaskSessions(parentTaskId);
   const {
     agentProfiles,
     workspaceId,
     workflowId,
     executors,
-    currentSession,
+    session: parentSession,
     worktreeBranch,
     initialPrompt,
-  } = useSubtaskDialogState();
+    parentRepositoryId,
+    baseBranch,
+  } = useSubtaskDialogState(parentTaskId, parentSessions);
 
   // Ensure executor/agent data is loaded when dialog opens
   useSettingsData(open);
@@ -425,15 +516,15 @@ export function NewSubtaskDialog({
           key={`${parentTaskId}-${open}`}
           parentTaskId={parentTaskId}
           defaultTitle={defaultTitle}
-          defaultProfileId={currentSession?.agent_profile_id ?? ""}
+          defaultProfileId={parentSession?.agent_profile_id ?? ""}
           worktreeBranch={worktreeBranch}
           initialPrompt={initialPrompt}
           agentProfiles={agentProfiles}
           executors={executors}
           workspaceId={workspaceId}
           workflowId={workflowId}
-          parentRepositoryId={currentSession?.repository_id ?? null}
-          baseBranch={currentSession?.base_branch ?? null}
+          parentRepositoryId={parentRepositoryId}
+          baseBranch={baseBranch}
           availableRepositories={availableRepositories}
           isOpen={open}
           onClose={() => onOpenChange(false)}

--- a/apps/web/components/task/new-subtask-dialog.tsx
+++ b/apps/web/components/task/new-subtask-dialog.tsx
@@ -90,7 +90,9 @@ function resolveParentSession(
 }
 
 function resolvePrimaryRepository(task: KanbanState["tasks"][number] | null) {
-  return task?.repositories?.reduce((current, repository) =>
+  const repositories = task?.repositories ?? [];
+  if (repositories.length === 0) return undefined;
+  return repositories.reduce((current, repository) =>
     !current || repository.position < current.position ? repository : current,
   );
 }

--- a/apps/web/components/task/task-session-sidebar-dialogs.tsx
+++ b/apps/web/components/task/task-session-sidebar-dialogs.tsx
@@ -4,6 +4,7 @@ import { TaskRenameDialog } from "./task-rename-dialog";
 import { TaskArchiveConfirmDialog } from "./task-archive-confirm-dialog";
 import { TaskDeleteConfirmDialog } from "./task-delete-confirm-dialog";
 import { TaskDetachTargetConfirmDialog } from "./task-detach-confirm-dialog";
+import { NewSubtaskDialog } from "./new-subtask-dialog";
 import { TaskExternalLinkDialog } from "./task-external-link-dialog";
 import { TaskGitHubIssueDialog } from "./task-github-issue-dialog";
 import { TaskGitHubPRDialog } from "./task-github-pr-dialog";
@@ -26,6 +27,9 @@ export type SidebarDialogsActions = {
   renamingTask: Target;
   setRenamingTask: (next: Target) => void;
   handleRenameSubmit: (newTitle: string) => Promise<void> | void;
+  creatingSubtask: Target;
+  setCreatingSubtask: (next: Target) => void;
+  handleCreateSubtask: (taskId: string, taskTitle: string) => void;
   archivingTask: Target;
   setArchivingTask: (next: Target) => void;
   archivingTaskId: string | null;
@@ -49,6 +53,25 @@ export type SidebarDialogsActions = {
   setLinkingExternalIssueTask: (next: SidebarExternalLinkTarget | null) => void;
 };
 
+function SidebarSubtaskDialog({
+  target,
+  onTargetChange,
+}: {
+  target: Target;
+  onTargetChange: (next: Target) => void;
+}) {
+  return (
+    <NewSubtaskDialog
+      open={target !== null}
+      onOpenChange={(open) => {
+        if (!open) onTargetChange(null);
+      }}
+      parentTaskId={target?.id ?? ""}
+      parentTaskTitle={target?.title ?? ""}
+    />
+  );
+}
+
 export function SidebarDialogs({
   actions,
   repositories,
@@ -62,6 +85,8 @@ export function SidebarDialogs({
     renamingTask,
     setRenamingTask,
     handleRenameSubmit,
+    creatingSubtask,
+    setCreatingSubtask,
     archivingTask,
     setArchivingTask,
     archivingTaskId,
@@ -86,6 +111,7 @@ export function SidebarDialogs({
         currentTitle={renamingTask?.title ?? ""}
         onSubmit={handleRenameSubmit}
       />
+      <SidebarSubtaskDialog target={creatingSubtask} onTargetChange={setCreatingSubtask} />
       <TaskArchiveConfirmDialog
         open={archivingTask !== null}
         onOpenChange={(open) => {

--- a/apps/web/components/task/task-session-sidebar-switcher-props.ts
+++ b/apps/web/components/task/task-session-sidebar-switcher-props.ts
@@ -43,6 +43,7 @@ export function buildTaskSwitcherProps(args: {
     onToggleSubtasks: args.toggleSubtaskCollapsed,
     onSelectTask: args.sidebarActions.handleSelectTask,
     onRenameTask: args.sidebarActions.handleRenameTask,
+    onCreateSubtask: args.sidebarActions.handleCreateSubtask,
     onArchiveTask: args.sidebarActions.handleArchiveTask,
     onDeleteTask: args.sidebarActions.handleDeleteTask,
     onDetachTask: args.sidebarActions.handleDetachTask,

--- a/apps/web/components/task/task-session-sidebar.tsx
+++ b/apps/web/components/task/task-session-sidebar.tsx
@@ -493,9 +493,16 @@ export function useSidebarActions(store: StoreApi) {
   const linkActions = useSidebarLinkActions(store);
 
   const [renamingTask, setRenamingTask] = useState<{ id: string; title: string } | null>(null);
+  const [creatingSubtask, setCreatingSubtask] = useState<{ id: string; title: string } | null>(
+    null,
+  );
 
   const handleRenameTask = useCallback((taskId: string, currentTitle: string) => {
     setRenamingTask({ id: taskId, title: currentTitle });
+  }, []);
+
+  const handleCreateSubtask = useCallback((taskId: string, taskTitle: string) => {
+    setCreatingSubtask({ id: taskId, title: taskTitle });
   }, []);
 
   const handleRenameSubmit = useCallback(
@@ -521,6 +528,9 @@ export function useSidebarActions(store: StoreApi) {
     setRenamingTask,
     handleRenameTask,
     handleRenameSubmit,
+    creatingSubtask,
+    setCreatingSubtask,
+    handleCreateSubtask,
     ...linkActions,
     ...archiveActions,
     ...deleteActions,

--- a/apps/web/components/task/task-switcher-action-items.tsx
+++ b/apps/web/components/task/task-switcher-action-items.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { IconArchive, IconLoader, IconTrash, IconUnlink } from "@tabler/icons-react";
+import { IconArchive, IconLoader, IconSubtask, IconTrash, IconUnlink } from "@tabler/icons-react";
 import { ContextMenuItem, ContextMenuSeparator } from "@kandev/ui/context-menu";
 
 export function TaskArchiveItem({
@@ -32,6 +32,28 @@ export function TaskArchiveItem({
     <ContextMenuItem disabled={disabled} onSelect={() => onArchiveTask(taskId)}>
       <IconArchive className="mr-2 h-4 w-4" />
       Archive
+    </ContextMenuItem>
+  );
+}
+
+export function TaskCreateSubtaskItem({
+  task,
+  disabled,
+  onCreateSubtask,
+}: {
+  task: { id: string; title: string };
+  disabled?: boolean;
+  onCreateSubtask?: (taskId: string, taskTitle: string) => void;
+}) {
+  if (!onCreateSubtask) return null;
+  return (
+    <ContextMenuItem
+      data-testid="task-context-create-subtask"
+      disabled={disabled}
+      onSelect={() => onCreateSubtask(task.id, task.title)}
+    >
+      <IconSubtask className="mr-2 h-4 w-4" />
+      Create Subtask
     </ContextMenuItem>
   );
 }

--- a/apps/web/components/task/task-switcher-context-menu.tsx
+++ b/apps/web/components/task/task-switcher-context-menu.tsx
@@ -30,7 +30,12 @@ import {
 } from "@/components/task/task-move-context-menu";
 import { useTaskWorkflowMove } from "@/hooks/use-task-workflow-move";
 import { TaskColorMenu } from "./task-switcher-color-menu";
-import { TaskArchiveItem, TaskDeleteItem, TaskDetachItem } from "./task-switcher-action-items";
+import {
+  TaskArchiveItem,
+  TaskCreateSubtaskItem,
+  TaskDeleteItem,
+  TaskDetachItem,
+} from "./task-switcher-action-items";
 import type { TaskSwitcherItem } from "./task-switcher";
 
 export type StepDef = {
@@ -48,6 +53,7 @@ type ContextMenuProps = {
   children: React.ReactElement<{ menuOpen?: boolean }>;
   onRenameTask?: (taskId: string, currentTitle: string) => void;
   onArchiveTask?: (taskId: string) => void;
+  onCreateSubtask?: (taskId: string, taskTitle: string) => void;
   onDeleteTask?: (taskId: string) => void;
   onDetachTask?: (taskId: string) => void;
   onLinkPullRequest?: (taskId: string, taskTitle?: string) => void;
@@ -80,6 +86,7 @@ export function TaskItemWithContextMenu({
   children,
   onRenameTask,
   onArchiveTask,
+  onCreateSubtask,
   onDeleteTask,
   onDetachTask,
   onLinkPullRequest,
@@ -122,6 +129,7 @@ export function TaskItemWithContextMenu({
           steps={steps}
           onRenameTask={onRenameTask}
           onArchiveTask={onArchiveTask}
+          onCreateSubtask={onCreateSubtask}
           onDeleteTask={onDeleteTask}
           onDetachTask={onDetachTask}
           onLinkPullRequest={onLinkPullRequest}
@@ -163,6 +171,7 @@ function TaskContextMenuItems(props: TaskContextMenuItemsProps) {
     steps,
     onRenameTask,
     onArchiveTask,
+    onCreateSubtask,
     onDeleteTask,
     onDetachTask,
     onMoveToStep,
@@ -229,6 +238,7 @@ function TaskContextMenuItems(props: TaskContextMenuItemsProps) {
         onTogglePin={withClear(onTogglePin)}
       />
       <TaskRenameItem task={task} disabled={isDeleting} onRenameTask={onRenameTask} />
+      <TaskCreateSubtaskItem task={task} disabled={isDeleting} onCreateSubtask={onCreateSubtask} />
       <ContextMenuItem disabled>
         <IconCopy className="mr-2 h-4 w-4" />
         Duplicate

--- a/apps/web/components/task/task-switcher.test.tsx
+++ b/apps/web/components/task/task-switcher.test.tsx
@@ -219,6 +219,28 @@ describe("TaskSwitcher — detach menu", () => {
   });
 });
 
+describe("TaskSwitcher — create subtask menu", () => {
+  it("passes the right-clicked task to the create-subtask action", () => {
+    const onCreateSubtask = vi.fn();
+    render(
+      <Providers>
+        <TaskSwitcher
+          grouped={grouped()}
+          activeTaskId={null}
+          selectedTaskId={null}
+          onSelectTask={vi.fn()}
+          onCreateSubtask={onCreateSubtask}
+        />
+      </Providers>,
+    );
+
+    fireEvent.contextMenu(screen.getByText(CHILD.title));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Create Subtask" }));
+
+    expect(onCreateSubtask).toHaveBeenCalledWith(CHILD.id, CHILD.title);
+  });
+});
+
 describe("TaskSwitcher — external issue link menu", () => {
   it("offers configured external issue providers from the task context menu", async () => {
     const onLinkMergeRequest = vi.fn();

--- a/apps/web/components/task/task-switcher.tsx
+++ b/apps/web/components/task/task-switcher.tsx
@@ -58,6 +58,7 @@ type TaskSwitcherProps = {
   onSelectTask: (taskId: string) => void;
   onRenameTask?: (taskId: string, currentTitle: string) => void;
   onArchiveTask?: (taskId: string) => void;
+  onCreateSubtask?: (taskId: string, taskTitle: string) => void;
   onDeleteTask?: (taskId: string) => void;
   onDetachTask?: (taskId: string) => void;
   onLinkPullRequest?: TaskLinkHandler;
@@ -143,6 +144,7 @@ type TaskRowProps = {
   onSelectTask: (taskId: string) => void;
   onRenameTask?: (taskId: string, currentTitle: string) => void;
   onArchiveTask?: (taskId: string) => void;
+  onCreateSubtask?: (taskId: string, taskTitle: string) => void;
   onDeleteTask?: (taskId: string) => void;
   onDetachTask?: (taskId: string) => void;
   onLinkPullRequest?: TaskLinkHandler;
@@ -199,6 +201,7 @@ function TaskRow({
   onSelectTask,
   onRenameTask,
   onArchiveTask,
+  onCreateSubtask,
   onDeleteTask,
   onDetachTask,
   onMoveToStep,
@@ -229,6 +232,7 @@ function TaskRow({
       steps={taskSteps}
       onRenameTask={onRenameTask}
       onArchiveTask={onArchiveTask}
+      onCreateSubtask={onCreateSubtask}
       onDeleteTask={onDeleteTask}
       onDetachTask={onDetachTask}
       {...taskLinkHandlerProps(props)}
@@ -404,6 +408,7 @@ type GroupSectionProps = {
   onSelectTask: (taskId: string) => void;
   onRenameTask?: (taskId: string, currentTitle: string) => void;
   onArchiveTask?: (taskId: string) => void;
+  onCreateSubtask?: (taskId: string, taskTitle: string) => void;
   onDeleteTask?: (taskId: string) => void;
   onDetachTask?: (taskId: string) => void;
   onLinkPullRequest?: TaskLinkHandler;
@@ -445,6 +450,7 @@ function GroupSection({
   onSelectTask,
   onRenameTask,
   onArchiveTask,
+  onCreateSubtask,
   onDeleteTask,
   onDetachTask,
   onLinkPullRequest,
@@ -484,6 +490,7 @@ function GroupSection({
       onSelectTask,
       onRenameTask,
       onArchiveTask,
+      onCreateSubtask,
       onDeleteTask,
       onDetachTask,
       onLinkPullRequest,
@@ -541,6 +548,7 @@ export const TaskSwitcher = memo(function TaskSwitcher({
   onSelectTask,
   onRenameTask,
   onArchiveTask,
+  onCreateSubtask,
   onDeleteTask,
   onDetachTask,
   onLinkPullRequest,
@@ -598,6 +606,7 @@ export const TaskSwitcher = memo(function TaskSwitcher({
           onSelectTask={onSelectTask}
           onRenameTask={onRenameTask}
           onArchiveTask={onArchiveTask}
+          onCreateSubtask={onCreateSubtask}
           onDeleteTask={onDeleteTask}
           onDetachTask={onDetachTask}
           onLinkPullRequest={onLinkPullRequest}

--- a/apps/web/e2e/pages/session-page.ts
+++ b/apps/web/e2e/pages/session-page.ts
@@ -266,6 +266,10 @@ export class SessionPage {
     await taskRow.click({ button: "right" });
   }
 
+  async openCreateSubtaskForSidebarTask(title: string): Promise<void> {
+    await this.openSidebarMenuAndClick(title, "Create Subtask");
+  }
+
   async sendSidebarTaskToWorkflow(
     title: string,
     workflowId: string,

--- a/apps/web/e2e/tests/task/dialog-long-text-overflow.spec.ts
+++ b/apps/web/e2e/tests/task/dialog-long-text-overflow.spec.ts
@@ -89,7 +89,7 @@ test.describe("Dialog long text layout", () => {
     await newSessionDialog.getByRole("button", { name: "Cancel" }).click();
     await expect(newSessionDialog).not.toBeVisible();
 
-    await testPage.getByTestId("sidebar-new-subtask").click();
+    await session.openCreateSubtaskForSidebarTask("Long Text Dialog Parent");
     const subtaskDialog = testPage.getByTestId("new-subtask-dialog");
     await expect(subtaskDialog).toBeVisible();
     await testPage.getByTestId("subtask-title-input").fill(LONG_UNBROKEN_TEXT);

--- a/apps/web/e2e/tests/task/mobile-sidebar-task-actions.spec.ts
+++ b/apps/web/e2e/tests/task/mobile-sidebar-task-actions.spec.ts
@@ -250,6 +250,7 @@ test.describe("Mobile sidebar task actions", () => {
       "Rename",
       "Duplicate",
       "Archive",
+      "Create Subtask",
       "Color",
       "Link",
       "Move to",
@@ -260,6 +261,44 @@ test.describe("Mobile sidebar task actions", () => {
     await archiveItem.scrollIntoViewIfNeeded();
     await expect(archiveItem).toBeInViewport();
     await expect(diffStats).toBeVisible();
+  });
+
+  test("opens create subtask from the mobile task actions menu", async ({
+    testPage,
+    apiClient,
+    seedData,
+    prCapture,
+  }) => {
+    const parentTitle = "Mobile create subtask parent";
+    const task = await apiClient.seedTask(seedData.workspaceId, parentTitle, {
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+      repository_ids: [seedData.repositoryId],
+    });
+
+    await testPage.goto(`/t/${task.task_id}`);
+    const session = new SessionPage(testPage);
+    await session.waitForLoad();
+    await testPage.getByTestId("mobile-session-menu").click();
+
+    const taskSheet = testPage.getByRole("dialog", { name: "Tasks" });
+    const taskRow = taskSheet.getByTestId("sidebar-task-item").filter({ hasText: parentTitle });
+    await taskRow.getByRole("button", { name: "Task actions" }).click();
+
+    const createSubtask = testPage.getByRole("menuitem", { name: "Create Subtask", exact: true });
+    await expect(createSubtask).toBeVisible();
+    await prCapture.screenshot("mobile-create-subtask-context-menu", {
+      caption: "Mobile task actions menu with Create Subtask",
+    });
+    await createSubtask.click();
+
+    const dialog = testPage.getByTestId("new-subtask-dialog");
+    await expect(dialog).toBeVisible();
+    await expect(testPage.getByTestId("subtask-title-input")).toHaveValue(
+      /Mobile create subtask parent \/ Subtask 1/,
+    );
+    await dialog.getByRole("button", { name: "Cancel", exact: true }).click();
+    await expect(dialog).toBeHidden();
   });
 
   test("moves a task to another step from the mobile task drawer", async ({

--- a/apps/web/e2e/tests/task/mobile-sidebar-task-actions.spec.ts
+++ b/apps/web/e2e/tests/task/mobile-sidebar-task-actions.spec.ts
@@ -1,4 +1,8 @@
+import { execSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
 import { test, expect } from "../../fixtures/test-base";
+import { makeGitEnv } from "../../helpers/git-helper";
 import { SessionPage } from "../../pages/session-page";
 
 test.describe("Mobile sidebar task actions", () => {
@@ -299,6 +303,67 @@ test.describe("Mobile sidebar task actions", () => {
     );
     await dialog.getByRole("button", { name: "Cancel", exact: true }).click();
     await expect(dialog).toBeHidden();
+  });
+
+  test("uses the selected non-active parent defaults for mobile subtasks", async ({
+    testPage,
+    apiClient,
+    seedData,
+    backend,
+  }) => {
+    const parentRepoDir = path.join(backend.tmpDir, "repos", "mobile-parent-repo");
+    fs.mkdirSync(parentRepoDir, { recursive: true });
+    const gitEnv = makeGitEnv(backend.tmpDir);
+    execSync("git init -b main", { cwd: parentRepoDir, env: gitEnv });
+    execSync('git commit --allow-empty -m "init"', { cwd: parentRepoDir, env: gitEnv });
+    const parentRepo = await apiClient.createRepository(
+      seedData.workspaceId,
+      parentRepoDir,
+      "main",
+      { name: "Mobile parent repo" },
+    );
+    const activeTask = await apiClient.createTaskWithAgent(
+      seedData.workspaceId,
+      "Mobile active task",
+      seedData.agentProfileId,
+      {
+        description: "/e2e:simple-message",
+        workflow_id: seedData.workflowId,
+        workflow_step_id: seedData.startStepId,
+        repository_ids: [seedData.repositoryId],
+      },
+    );
+    await apiClient.createTaskWithAgent(
+      seedData.workspaceId,
+      "Mobile non-active parent",
+      seedData.agentProfileId,
+      {
+        description: "/e2e:simple-message",
+        workflow_id: seedData.workflowId,
+        workflow_step_id: seedData.startStepId,
+        repository_ids: [parentRepo.id],
+      },
+    );
+
+    await testPage.goto(`/t/${activeTask.id}`);
+    const session = new SessionPage(testPage);
+    await session.waitForLoad();
+    await testPage.getByTestId("mobile-session-menu").click();
+
+    const taskSheet = testPage.getByRole("dialog", { name: "Tasks" });
+    const parentRow = taskSheet
+      .getByTestId("sidebar-task-item")
+      .filter({ hasText: "Mobile non-active parent" });
+    await parentRow.getByRole("button", { name: "Task actions" }).click();
+    await testPage.getByRole("menuitem", { name: "Create Subtask", exact: true }).click();
+
+    const dialog = testPage.getByTestId("new-subtask-dialog");
+    await expect(dialog).toBeVisible();
+    await expect(testPage.getByTestId("repo-chip-trigger")).toContainText("Mobile parent repo");
+    await expect(testPage.getByTestId("subtask-title-input")).toHaveValue(
+      /Mobile non-active parent \/ Subtask 1/,
+    );
+    await dialog.getByRole("button", { name: "Cancel", exact: true }).click();
   });
 
   test("moves a task to another step from the mobile task drawer", async ({

--- a/apps/web/e2e/tests/task/sidebar-layout.spec.ts
+++ b/apps/web/e2e/tests/task/sidebar-layout.spec.ts
@@ -5,7 +5,7 @@
  *   - Repo group headers: letter avatar, task count, collapsible
  *   - Subtasks (parent_id): nested under parent with arrow indicator
  *   - Unassigned group: tasks with no repo
- *   - Context menu: Rename, Archive, Delete options via right-click
+ *   - Context menu: Create Subtask, Rename, Archive, Delete options via right-click
  *   - Active task highlight: selected task has aria/visual selection state
  */
 import { test, expect } from "../../fixtures/test-base";
@@ -191,6 +191,7 @@ test.describe("Sidebar layout — context menu", () => {
     testPage,
     apiClient,
     seedData,
+    prCapture,
   }) => {
     await apiClient.createTask(seedData.workspaceId, "Context Menu Task", {
       workflow_id: seedData.workflowId,
@@ -217,11 +218,17 @@ test.describe("Sidebar layout — context menu", () => {
     await expect(testPage.getByRole("menuitem", { name: "Rename" })).toBeVisible({
       timeout: 5_000,
     });
+    await expect(testPage.getByRole("menuitem", { name: "Create Subtask" })).toBeVisible({
+      timeout: 5_000,
+    });
     await expect(testPage.getByRole("menuitem", { name: "Archive" })).toBeVisible({
       timeout: 5_000,
     });
     await expect(testPage.getByRole("menuitem", { name: "Delete" })).toBeVisible({
       timeout: 5_000,
+    });
+    await prCapture.screenshot("desktop-create-subtask-context-menu", {
+      caption: "Desktop task context menu with Create Subtask",
     });
 
     // Dismiss

--- a/apps/web/e2e/tests/task/subtask.spec.ts
+++ b/apps/web/e2e/tests/task/subtask.spec.ts
@@ -57,7 +57,11 @@ test.describe("Subtask basics", () => {
     await expect(subtaskCard.getByText("Parent Task")).toBeVisible();
   });
 
-  test("create subtask from sidebar header button", async ({ testPage, apiClient, seedData }) => {
+  test("create subtask from the sidebar task context menu", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
     // Create a task with an agent so we have a session to navigate to
     const task = await apiClient.createTaskWithAgent(
       seedData.workspaceId,
@@ -78,11 +82,7 @@ test.describe("Subtask basics", () => {
     // Wait for agent to complete
     await session.waitForChatIdle({ timeout: 30_000 });
 
-    // Open the New Subtask dialog from the sidebar New Task row's trailing
-    // subtask affordance (shown while viewing a task).
-    const subtaskButton = testPage.getByTestId("sidebar-new-subtask");
-    await expect(subtaskButton).toBeVisible({ timeout: 5_000 });
-    await subtaskButton.click();
+    await session.openCreateSubtaskForSidebarTask("Subtask Parent");
 
     // The compact NewSubtaskDialog should open with pre-filled title containing numeric suffix
     const titleInput = testPage.getByTestId("subtask-title-input");
@@ -222,7 +222,7 @@ test.describe("MCP subtask creation", () => {
     ).toBe(seedData.repositoryId);
   });
 
-  test("user creates subtask via sidebar button", async ({ testPage }) => {
+  test("user creates subtask via the sidebar task context menu", async ({ testPage }) => {
     // 1. Create parent task via UI dialog with a simple agent script
     const kanban = new KanbanPage(testPage);
     await kanban.goto();
@@ -247,8 +247,8 @@ test.describe("MCP subtask creation", () => {
     await session.waitForLoad();
     await expect(session.idleInput()).toBeVisible({ timeout: 30_000 });
 
-    // 4. Open the New Subtask dialog from the sidebar New Task subtask affordance.
-    await testPage.getByTestId("sidebar-new-subtask").click();
+    // 4. Open the New Subtask dialog from the parent task's context menu.
+    await session.openCreateSubtaskForSidebarTask("Subtask Button Parent");
     const subtaskTitleInput = testPage.getByTestId("subtask-title-input");
     await expect(subtaskTitleInput).toBeVisible();
 
@@ -290,7 +290,7 @@ test.describe("MCP subtask creation", () => {
     });
 
     // 2. Create a parent task on repo A with a simple agent script so we can
-    //    open its session and reach the subtask split-button.
+    //    open its session and reach the task context menu.
     const parentTask = await apiClient.createTaskWithAgent(
       seedData.workspaceId,
       "UI Override Parent",
@@ -308,8 +308,8 @@ test.describe("MCP subtask creation", () => {
     await session.waitForLoad();
     await session.waitForChatIdle({ timeout: 30_000 });
 
-    // 3. Open the New Subtask dialog from the sidebar New Task subtask affordance.
-    await testPage.getByTestId("sidebar-new-subtask").click();
+    // 3. Open the New Subtask dialog from the parent task's context menu.
+    await session.openCreateSubtaskForSidebarTask("UI Override Parent");
 
     const titleInput = testPage.getByTestId("subtask-title-input");
     await expect(titleInput).toBeVisible({ timeout: 5_000 });
@@ -643,7 +643,7 @@ test.describe("Subtask dialog feature parity", () => {
     await session.waitForChatIdle({ timeout: 30_000 });
 
     // 3. Open the subtask dialog and toggle to GitHub URL mode.
-    await testPage.getByTestId("sidebar-new-subtask").click();
+    await session.openCreateSubtaskForSidebarTask("Subtask GH URL Parent");
     const titleInput = testPage.getByTestId("subtask-title-input");
     await expect(titleInput).toBeVisible({ timeout: 5_000 });
 
@@ -758,7 +758,7 @@ test.describe("Subtask dialog feature parity", () => {
     //    reopening the popover each tick because cmdk's listbox snapshots
     //    options at open time and won't update if discovery resolves while
     //    the popover is already showing.
-    await testPage.getByTestId("sidebar-new-subtask").click();
+    await session.openCreateSubtaskForSidebarTask("Subtask Discovered Parent");
     await expect(testPage.getByTestId("subtask-title-input")).toBeVisible({ timeout: 5_000 });
 
     const discoveredOption = testPage
@@ -822,7 +822,7 @@ test.describe("Subtask dialog feature parity", () => {
     // 3. Open the subtask dialog. The first chip is seeded with the parent's
     //    repo. Click the "+ add repository" button to append a second chip,
     //    then point that chip at repo B.
-    await testPage.getByTestId("sidebar-new-subtask").click();
+    await session.openCreateSubtaskForSidebarTask("Subtask MultiRepo Parent");
     const titleInput = testPage.getByTestId("subtask-title-input");
     await expect(titleInput).toBeVisible({ timeout: 5_000 });
 


### PR DESCRIPTION
Because subtask creation applies to a selected parent task, the action now lives in each task’s context menu instead of the global New Task row, making it easier to discover on desktop and mobile.

## Validation

- `corepack pnpm run typecheck`
- Focused Vitest: 25 tests in task switcher and New Task item suites
- Changed-file ESLint and commit hooks
- `corepack pnpm run build:vite`
- Desktop Playwright context-menu flow
- Mobile Playwright task-actions flow

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.

## Screenshots

**Desktop task context menu**

![Desktop task context menu](https://raw.githubusercontent.com/kdlbs/kandev/9fd0bb5798f1cb824791758e412e18d2a06bcff0/sidebar-layout--desktop-create-subtask-context-menu.png)

**Mobile task actions menu**

![Mobile task actions menu](https://raw.githubusercontent.com/kdlbs/kandev/9fd0bb5798f1cb824791758e412e18d2a06bcff0/mobile-sidebar-task-actions--mobile-create-subtask-context-menu.png)