### PR TITLE
fix(web): preserve chat focus when restoring task layout

### DIFF
--- a/apps/web/components/task/dockview-session-tabs.test.ts
+++ b/apps/web/components/task/dockview-session-tabs.test.ts
@@ -30,6 +30,22 @@ type MoveToCall = {
   options: MoveToOptions;
 };
 
+type ReorderingPanel = {
+  id: string;
+  group: ReorderingGroup;
+  api: {
+    close: ReturnType<typeof vi.fn<() => void>>;
+    component: string;
+    moveTo: ReturnType<typeof vi.fn<(options: MoveToOptions) => void>>;
+    setActive: ReturnType<typeof vi.fn<() => void>>;
+  };
+};
+
+type ReorderingGroup = {
+  id: string;
+  panels: ReorderingPanel[];
+};
+
 const KEEP = "keep";
 const KEEP_PANEL = `session:${KEEP}`;
 const LEAKED_PANEL = "session:leaked";
@@ -163,6 +179,72 @@ function expectedMove(panelId: string, index: number): MoveToCall {
       skipSetActive: true,
     },
   };
+}
+
+/**
+ * Models Dockview 4.13.1's same-group move behavior: moving the active panel
+ * removes it first, which activates a remaining sibling, then reinserts the
+ * moved panel inactive when skipSetActive is true.
+ */
+function makeReorderingAutoSessionApi(): {
+  api: DockviewApi;
+  activePanelId: () => string | null;
+} {
+  const panels: ReorderingPanel[] = [];
+  const group: ReorderingGroup = { id: CENTER_GROUP, panels: [] };
+  let activePanel: ReorderingPanel | null = null;
+
+  const removePanel = (panel: ReorderingPanel) => {
+    const groupIndex = group.panels.indexOf(panel);
+    if (groupIndex !== -1) group.panels.splice(groupIndex, 1);
+    const panelIndex = panels.indexOf(panel);
+    if (panelIndex !== -1) panels.splice(panelIndex, 1);
+    if (activePanel === panel) activePanel = group.panels[0] ?? null;
+  };
+
+  const createPanel = (id: string, component: string): ReorderingPanel => {
+    const panel: ReorderingPanel = {
+      id,
+      group,
+      api: {
+        close: vi.fn(() => removePanel(panel)),
+        component,
+        moveTo: vi.fn((options: MoveToOptions) => {
+          const sourceIndex = group.panels.indexOf(panel);
+          if (sourceIndex !== -1) group.panels.splice(sourceIndex, 1);
+          if (activePanel === panel) activePanel = group.panels[0] ?? null;
+          group.panels.splice(options.index, 0, panel);
+          if (!options.skipSetActive) activePanel = panel;
+        }),
+        setActive: vi.fn(() => {
+          activePanel = panel;
+        }),
+      },
+    };
+    panels.push(panel);
+    group.panels.push(panel);
+    return panel;
+  };
+
+  activePanel = createPanel("chat", "chat");
+  createPanel("plan", "plan");
+
+  const api = {
+    get activePanel() {
+      return activePanel;
+    },
+    panels,
+    groups: [group],
+    getPanel: (id: string) => panels.find((panel) => panel.id === id) ?? null,
+    addPanel: (options: { id: string; component: string; inactive?: boolean }): ReorderingPanel => {
+      const panel = createPanel(options.id, options.component);
+      if (!options.inactive) activePanel = panel;
+      return panel;
+    },
+    removePanel,
+  } as unknown as DockviewApi;
+
+  return { api, activePanelId: () => activePanel?.id ?? null };
 }
 
 describe("reconcileRemovedSessionPanels", () => {
@@ -554,6 +636,19 @@ describe("resolveSessionTabSyncTarget", () => {
 });
 
 describe("runAutoSessionTabEffect", () => {
+  it("keeps chat active when replacing its placeholder beside a Plan tab", () => {
+    const sessionId = "session-current";
+    const { api, activePanelId } = makeReorderingAutoSessionApi();
+    const appStore = makeAutoSessionAppStore(AUTO_TASK_ID, [sessionId]);
+    const refs = makeAutoSessionRefs();
+
+    withDockviewState({ api, preMaximizeLayout: null }, () => {
+      runAutoSessionTabEffect(sessionId, appStore as never, refs as never);
+    });
+
+    expect(activePanelId()).toBe(`session:${sessionId}`);
+  });
+
   it("updates previous refs when panel ensure is skipped for an unhydrated session", () => {
     const api = {
       panels: [{ id: "chat" }],

--- a/apps/web/components/task/dockview-session-tabs.ts
+++ b/apps/web/components/task/dockview-session-tabs.ts
@@ -533,31 +533,35 @@ type AutoSessionTabRefs = {
 function activateSessionPanel(
   api: DockviewApi,
   effectiveSessionId: string,
-  sessionPanelExistedBefore: boolean,
+  activation: {
+    sessionPanelExistedBefore: boolean;
+    activePanelIdBeforeEnsure: string | null;
+  },
   refs: AutoSessionTabRefs,
   tid: string | null,
 ): ReturnType<DockviewApi["getPanel"]> {
   const activePanel = api.getPanel(`session:${effectiveSessionId}`);
   if (!activePanel) return activePanel;
 
-  const currentActivePanelId = api.activePanel?.id ?? null;
+  const activePanelIdAfterReorder = api.activePanel?.id ?? null;
   const shouldActivate = shouldActivateSessionPanel({
-    sessionPanelExistedBefore,
+    sessionPanelExistedBefore: activation.sessionPanelExistedBefore,
     prevTaskId: refs.prevTaskIdRef.current,
     prevSessionId: refs.prevSessionIdRef.current,
     currentTaskId: tid,
     currentSessionId: effectiveSessionId,
-    currentActivePanelId,
+    currentActivePanelId: activation.activePanelIdBeforeEnsure,
   });
   if (isDebug()) {
     debug("useAutoSessionTab: activation decision", {
       effectiveSessionId,
       shouldActivate,
-      sessionPanelExistedBefore,
+      sessionPanelExistedBefore: activation.sessionPanelExistedBefore,
       prevTaskId: refs.prevTaskIdRef.current,
       prevSessionId: refs.prevSessionIdRef.current,
       currentTaskId: tid,
-      currentActivePanelId,
+      activePanelIdBeforeEnsure: activation.activePanelIdBeforeEnsure,
+      activePanelIdAfterReorder,
       activeGroupId: activePanel.group.id,
     });
   }
@@ -763,6 +767,9 @@ export function runAutoSessionTabEffect(
 
   const initialPosition = resolveInitialPosition(api);
   const sessionPanelExistedBefore = !!api.getPanel(`session:${effectiveSessionId}`);
+  // Preserve the restored/user-selected panel before adding and reordering the
+  // session tab. Dockview's same-group move briefly activates a sibling even
+  // with skipSetActive, so reading api.activePanel afterward loses this intent.
   const activePanelIdBeforeEnsure = api.activePanel?.id ?? null;
   const preserveActivePanel = shouldPreserveActivePanel(
     sessionPanelExistedBefore,
@@ -788,7 +795,7 @@ export function runAutoSessionTabEffect(
   const activePanel = activateSessionPanel(
     api,
     effectiveSessionId,
-    sessionPanelExistedBefore,
+    { sessionPanelExistedBefore, activePanelIdBeforeEnsure },
     refs,
     tid,
   );


### PR DESCRIPTION
Restored task layouts can briefly shift focus to a neighboring Plan tab while Dockview replaces the generic Chat placeholder. The layout now preserves the panel active before that internal reorder, so returning to a task keeps Chat selected.

## Validation

- `cd apps && pnpm --filter @kandev/web test -- --run components/task/dockview-session-tabs.test.ts components/task/dockview-session-tab-activation.test.ts`
- `cd apps/web && pnpm run typecheck`
- `cd apps/web && pnpm exec eslint --max-warnings 0 components/task/dockview-session-tabs.ts components/task/dockview-session-tabs.test.ts`
- `cd apps && pnpm exec prettier --check web/components/task/dockview-session-tabs.ts web/components/task/dockview-session-tabs.test.ts`
- `cd apps/web && pnpm e2e:run tests/layout/plan-panel-indicator.spec.ts -- --grep "agent create reveals plan tab with indicator and keeps chat focused"`
- `cd apps/web && pnpm e2e:run --no-build tests/session/multi-session-ux.spec.ts -- --grep "switching between tasks preserves correct session context"`
- Final changed-scope verification: `make typecheck-web`, `make test-web`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1923?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- kandev-screenshots-start -->
## Screenshots

![Desktop task layout with active Chat and inactive Plan tab](https://raw.githubusercontent.com/kdlbs/kandev/50e79a92fb7ff2e37cb9c008b1f691f2690aa7e0/desktop-task-layout-chat-active-plan-tab.png)
<!-- kandev-screenshots-end -->