### PR TITLE
fix: scope walkthrough overlays to their task

### DIFF
--- a/apps/web/components/review/walkthrough-overlay.test.tsx
+++ b/apps/web/components/review/walkthrough-overlay.test.tsx
@@ -21,6 +21,7 @@ vi.mock("@/components/diff/walkthrough-floating-window", () => ({
 }));
 
 const TASK_ID = "task-1";
+const SECOND_TASK_ID = "task-2";
 
 function walkthrough(): TaskWalkthrough {
   return {
@@ -35,15 +36,22 @@ function walkthrough(): TaskWalkthrough {
 }
 
 let setConnectionStatus: ((status: ConnectionStatus) => void) | null = null;
+let setActiveTask: ((taskId: string) => void) | null = null;
 
 function StoreProbe() {
   setConnectionStatus = useAppStore((s) => s.setConnectionStatus);
+  setActiveTask = useAppStore((s) => s.setActiveTask);
   return null;
 }
 
-function renderOverlay() {
+function ActiveTaskOverlay() {
+  const taskId = useAppStore((s) => s.tasks.activeTaskId);
+  return <WalkthroughOverlay taskId={taskId} />;
+}
+
+function renderOverlay({ followActiveTask = false } = {}) {
   setConnectionStatus = null;
-  render(
+  return render(
     <StateProvider
       initialState={{
         tasks: {
@@ -55,7 +63,7 @@ function renderOverlay() {
       }}
     >
       <StoreProbe />
-      <WalkthroughOverlay taskId={TASK_ID} />
+      {followActiveTask ? <ActiveTaskOverlay /> : <WalkthroughOverlay taskId={TASK_ID} />}
     </StateProvider>,
   );
 }
@@ -99,5 +107,20 @@ describe("WalkthroughOverlay", () => {
     fireEvent.click(launcher);
 
     expect(getOpenWalkthroughTaskId()).toBeNull();
+  });
+
+  it("closes the walkthrough when the active task changes", async () => {
+    vi.mocked(getTaskWalkthrough).mockImplementation(async (taskId) =>
+      taskId === TASK_ID ? walkthrough() : null,
+    );
+    const view = renderOverlay({ followActiveTask: true });
+
+    act(() => setConnectionStatus?.("connected"));
+    fireEvent.click(await within(view.container).findByTestId("walkthrough-launcher"));
+    await waitFor(() => expect(getOpenWalkthroughTaskId()).toBe(TASK_ID));
+
+    act(() => setActiveTask?.(SECOND_TASK_ID));
+
+    await waitFor(() => expect(getOpenWalkthroughTaskId()).toBeNull());
   });
 });

--- a/apps/web/components/review/walkthrough-overlay.tsx
+++ b/apps/web/components/review/walkthrough-overlay.tsx
@@ -194,10 +194,11 @@ export function WalkthroughOverlay({ taskId, onSelectFile }: WalkthroughOverlayP
     taskId ? s.walkthroughs.lastSeenUpdatedAtByTaskId[taskId] : undefined,
   );
   const setWalkthrough = useAppStore((s) => s.setWalkthrough);
-  const [open, setOpen] = useState(false);
+  const [openTaskId, setOpenTaskId] = useState<string | null>(null);
   const [confirmDiscardOpen, setConfirmDiscardOpen] = useState(false);
   const [discarding, setDiscarding] = useState(false);
   const { toast } = useToast();
+  const open = taskId !== null && openTaskId === taskId;
 
   useWalkthroughBackfill({ connectionStatus, setWalkthrough, taskId, walkthrough });
 
@@ -220,11 +221,11 @@ export function WalkthroughOverlay({ taskId, onSelectFile }: WalkthroughOverlayP
         if (wt) setWalkthrough(taskId, wt);
       })
       .catch(() => {});
-    setOpen(true);
+    setOpenTaskId(taskId);
   };
   const closeTour = () => {
     clearOpenWalkthroughTaskId(taskId);
-    setOpen(false);
+    setOpenTaskId(null);
   };
   const confirmDiscard = async (event: MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
@@ -233,7 +234,7 @@ export function WalkthroughOverlay({ taskId, onSelectFile }: WalkthroughOverlayP
     try {
       await deleteTaskWalkthrough(taskId);
       clearOpenWalkthroughTaskId(taskId);
-      setOpen(false);
+      setOpenTaskId(null);
       setWalkthrough(taskId, null);
       setConfirmDiscardOpen(false);
       toast({ title: "Walkthrough discarded", variant: "success" });


### PR DESCRIPTION
Walkthrough overlays could remain open while deletion navigated to another task, causing the replacement task to inherit the floating walkthrough and file navigation. The overlay now scopes its open state to the task that opened it and adds regression coverage for task changes.

## Validation

- `pnpm exec vitest run components/review/walkthrough-overlay.test.tsx lib/walkthrough-open-state.test.ts lib/ws/handlers/tasks-walkthrough-cleanup.test.ts`
- `pnpm exec eslint components/review/walkthrough-overlay.tsx components/review/walkthrough-overlay.test.tsx`
- `pnpm exec prettier --check components/review/walkthrough-overlay.tsx components/review/walkthrough-overlay.test.tsx`
- `pnpm run typecheck`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.

<!-- kandev-screenshots-start -->
## Screenshots

![Desktop walkthrough](https://raw.githubusercontent.com/kdlbs/kandev/eca755827188957bd63943fe3488ada5f67731a5/desktop-walkthrough.png)

![Mobile walkthrough](https://raw.githubusercontent.com/kdlbs/kandev/eca755827188957bd63943fe3488ada5f67731a5/mobile-walkthrough.png)
<!-- kandev-screenshots-end -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1928?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->