### PR TITLE
fix(web): improve queue scrolling and diff comment feedback

### DIFF
--- a/apps/web/components/diff/use-diff-comments.test.ts
+++ b/apps/web/components/diff/use-diff-comments.test.ts
@@ -1,0 +1,48 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useCommentsStore } from "@/lib/state/slices/comments";
+import { useDiffComments } from "./use-diff-comments";
+
+const toastSuccess = vi.hoisted(() => vi.fn());
+
+vi.mock("sonner", () => ({
+  toast: { success: toastSuccess },
+}));
+
+describe("useDiffComments", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    toastSuccess.mockReset();
+    useCommentsStore.setState({
+      byId: {},
+      bySession: {},
+      pendingForChat: [],
+      editingCommentId: null,
+    });
+  });
+
+  it("stores an added comment without emitting a redundant success toast", () => {
+    const { result } = renderHook(() =>
+      useDiffComments({
+        sessionId: "session-1",
+        filePath: "src/example.ts",
+        newContent: "first\nsecond\n",
+      }),
+    );
+
+    act(() => {
+      result.current.addComment({ start: 2, end: 2, side: "additions" }, "Tighten this");
+    });
+
+    expect({
+      comments: useCommentsStore
+        .getState()
+        .getCommentsForFile("session-1", "src/example.ts")
+        .map((comment) => comment.text),
+      successToastCalls: toastSuccess.mock.calls.length,
+    }).toEqual({
+      comments: ["Tighten this"],
+      successToastCalls: 0,
+    });
+  });
+});

--- a/apps/web/components/diff/use-diff-comments.ts
+++ b/apps/web/components/diff/use-diff-comments.ts
@@ -1,7 +1,6 @@
 "use client";
 
 import { useCallback, useMemo } from "react";
-import { toast } from "sonner";
 import type { SelectedLineRange } from "@pierre/diffs";
 import { useCommentsStore } from "@/lib/state/slices/comments";
 import { useDiffFileComments } from "@/hooks/domains/comments/use-diff-comments";
@@ -92,10 +91,6 @@ export function useDiffComments({
       };
 
       storeAddComment(comment);
-      toast.success("Comment added", {
-        description: "Your comment will be sent with your next message.",
-        duration: 2000,
-      });
       return comment;
     },
     [sessionId, filePath, diff, newContent, oldContent, storeAddComment],

--- a/apps/web/components/task/chat/queued-ghost-list.tsx
+++ b/apps/web/components/task/chat/queued-ghost-list.tsx
@@ -302,7 +302,8 @@ function QueuePanel({
       aria-label="Queued messages"
       data-testid="queued-ghost-list"
       className={cn(
-        "flex-shrink-0 px-3 pt-1.5 pb-1 border-t border-border/40",
+        "flex max-h-[min(40dvh,32rem)] flex-shrink-0 flex-col px-3 pt-1.5 pb-1",
+        "border-t border-border/40",
         "animate-in slide-in-from-bottom-2 fade-in-0 duration-200",
       )}
     >
@@ -316,7 +317,10 @@ function QueuePanel({
         onDrain={onDrain}
         onClose={onClose}
       />
-      <div className="space-y-1.5">
+      <div
+        data-testid="queue-scroll-region"
+        className="min-h-0 flex-1 space-y-1.5 overflow-y-auto overscroll-contain pr-1"
+      >
         {entries.map((entry, index) => (
           <QueuedGhostMessage
             key={entry.id}
@@ -355,7 +359,7 @@ function QueuePanelHeader({
 }: QueuePanelHeaderProps) {
   const capacityText = max > 0 ? `${count} of ${max}` : `${count}`;
   return (
-    <div className="flex items-center justify-between gap-3 py-1">
+    <div className="flex shrink-0 items-center justify-between gap-3 py-1">
       <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
         <IconLayoutList className="h-3.5 w-3.5" />
         <span className="uppercase tracking-wide">Queued</span>

--- a/apps/web/e2e/tests/chat/message-queue-scroll-helpers.ts
+++ b/apps/web/e2e/tests/chat/message-queue-scroll-helpers.ts
@@ -1,0 +1,75 @@
+import { expect, type Page } from "@playwright/test";
+import type { SeedData } from "../../fixtures/test-base";
+import type { ApiClient } from "../../helpers/api-client";
+import { SessionPage } from "../../pages/session-page";
+
+const FULL_QUEUE_SIZE = 10;
+
+export async function seedFullQueueTask(
+  page: Page,
+  apiClient: ApiClient,
+  seedData: SeedData,
+  title: string,
+): Promise<SessionPage> {
+  const task = await apiClient.createTask(seedData.workspaceId, title, {
+    description: "Queue scrolling regression",
+    workflow_id: seedData.workflowId,
+    workflow_step_id: seedData.startStepId,
+    agent_profile_id: seedData.agentProfileId,
+    repository_ids: [seedData.repositoryId],
+  });
+  const { session_id: sessionId } = await apiClient.seedTaskSession(task.id, {
+    state: "IDLE",
+    agentProfileId: seedData.agentProfileId,
+  });
+
+  for (let index = 0; index < FULL_QUEUE_SIZE; index++) {
+    await apiClient.queueMessage(
+      task.id,
+      sessionId,
+      `Queued item ${index + 1}\nSecond line keeps every queue row realistically tall.`,
+    );
+  }
+
+  await page.goto(`/t/${task.id}`);
+  const session = new SessionPage(page);
+  await session.waitForLoad();
+  return session;
+}
+
+export async function expectFullQueueScrolls(session: SessionPage): Promise<void> {
+  const chat = session.activeChat();
+  const chip = chat.getByTestId("queue-chip");
+  await expect(chip).toBeVisible({ timeout: 10_000 });
+  await chip.click();
+
+  const panel = chat.getByTestId("queued-ghost-list");
+  const entries = panel.getByTestId("queue-entry-text");
+  await expect(entries).toHaveCount(FULL_QUEUE_SIZE);
+
+  const scrollRegion = panel.getByTestId("queue-scroll-region");
+  await expect(scrollRegion).toBeVisible({ timeout: 5_000 });
+  const geometry = await scrollRegion.evaluate((element) => {
+    const style = getComputedStyle(element);
+    return {
+      clientHeight: element.clientHeight,
+      scrollHeight: element.scrollHeight,
+      overflowY: style.overflowY,
+    };
+  });
+  expect(geometry.scrollHeight).toBeGreaterThan(geometry.clientHeight);
+  expect(geometry.overflowY).toBe("auto");
+
+  const composer = chat.getByTestId("chat-input-editor-shell");
+  const [chatBox, composerBox] = await Promise.all([chat.boundingBox(), composer.boundingBox()]);
+  expect(chatBox).not.toBeNull();
+  expect(composerBox).not.toBeNull();
+  expect(composerBox!.y + composerBox!.height).toBeLessThanOrEqual(
+    chatBox!.y + chatBox!.height + 1,
+  );
+
+  await scrollRegion.evaluate((element) => {
+    element.scrollTop = element.scrollHeight;
+  });
+  await expect(entries.last()).toBeInViewport();
+}

--- a/apps/web/e2e/tests/chat/message-queue.spec.ts
+++ b/apps/web/e2e/tests/chat/message-queue.spec.ts
@@ -4,6 +4,7 @@ import type { SeedData } from "../../fixtures/test-base";
 import type { ApiClient } from "../../helpers/api-client";
 import { typeWhileBusy } from "../../helpers/type-while-busy";
 import { SessionPage } from "../../pages/session-page";
+import { expectFullQueueScrolls, seedFullQueueTask } from "./message-queue-scroll-helpers";
 
 // ---------------------------------------------------------------------------
 // Quick Chat queue tests
@@ -199,6 +200,21 @@ async function seedTaskAndWaitForIdle(
 
 test.describe("Task session queue", () => {
   test.describe.configure({ retries: 1 });
+
+  test("full queue scrolls internally without hiding the composer", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    const session = await seedFullQueueTask(
+      testPage,
+      apiClient,
+      seedData,
+      "Desktop full queue scrolling",
+    );
+
+    await expectFullQueueScrolls(session);
+  });
 
   test("queue message via submit button on task session page", async ({
     testPage,

--- a/apps/web/e2e/tests/chat/mobile-message-queue-scroll.spec.ts
+++ b/apps/web/e2e/tests/chat/mobile-message-queue-scroll.spec.ts
@@ -1,0 +1,17 @@
+import { test } from "../../fixtures/test-base";
+import { expectFullQueueScrolls, seedFullQueueTask } from "./message-queue-scroll-helpers";
+
+test("mobile full queue scrolls internally without hiding the composer", async ({
+  testPage,
+  apiClient,
+  seedData,
+}) => {
+  const session = await seedFullQueueTask(
+    testPage,
+    apiClient,
+    seedData,
+    "Mobile full queue scrolling",
+  );
+
+  await expectFullQueueScrolls(session);
+});


### PR DESCRIPTION
Long chat queues could grow beyond the visible chat area, making older queued items inaccessible, and adding a diff comment produced duplicate success notifications. The queue now scrolls within its own bounded panel on desktop and mobile, while diff comment additions rely on their inline annotation and delivery actions retain one global notification.

## Validation

- `make fmt`
- `make typecheck`
- `make test`
- `make lint`
- Focused desktop and Pixel 5 queue-scroll E2E: 2/2 passed
- 24 focused diff/comment tests passed
- Synthetic desktop and mobile screenshots captured and visually checked

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1932?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


<!-- kandev-screenshots-start -->
## Screenshots

![Desktop queue scroll](https://raw.githubusercontent.com/kdlbs/kandev/0e3763acda68a09bd831fc8e629792ffaa9864d5/desktop-queue-scroll.png)

![Mobile queue scroll](https://raw.githubusercontent.com/kdlbs/kandev/0e3763acda68a09bd831fc8e629792ffaa9864d5/mobile-queue-scroll.png)
<!-- kandev-screenshots-end -->