### PR TITLE
fix(installer): confine tarball extraction with os.Root

### DIFF
--- a/apps/backend/internal/tools/installer/github_tarball_strategy.go
+++ b/apps/backend/internal/tools/installer/github_tarball_strategy.go
@@ -227,8 +227,14 @@ func extractSymlinkEntry(root *os.Root, cleanName string, header *tar.Header) er
 		return fmt.Errorf("symlink target must not be absolute: %s -> %s", header.Name, header.Linkname)
 	}
 
+	if err := rejectSymlinkedParents(root, cleanName); err != nil {
+		return err
+	}
+
 	// Resolve the target relative to the symlink's own directory, both
 	// expressed relative to destDir. Anything that climbs to ".." has left it.
+	// Sound only because the parent check above pins the link's on-disk
+	// location to its archive path.
 	linkTarget := filepath.Join(filepath.Dir(cleanName), header.Linkname)
 	if linkTarget == ".." || strings.HasPrefix(linkTarget, ".."+string(os.PathSeparator)) {
 		return fmt.Errorf("symlink target escapes destination: %s -> %s", header.Name, header.Linkname)
@@ -237,6 +243,50 @@ func extractSymlinkEntry(root *os.Root, cleanName string, header *tar.Header) er
 	// Remove existing symlink/file before creating (handles re-installs)
 	_ = root.Remove(cleanName)
 	return root.Symlink(header.Linkname, cleanName)
+}
+
+// rejectSymlinkedParents requires every parent component of name to be a real
+// directory rather than a symlink.
+//
+// root.Symlink follows symlinked parents, so an entry named "a/x" lands at "x"
+// when "a" is itself a symlink to ".". The link is still created inside destDir
+// — root guarantees that much — but one directory level shallower than its
+// archive path, which changes what a relative target resolves to: "a/x" -> ".."
+// passes a check computed against parent "a" and then resolves to destDir's
+// parent from its real home. Nothing can be written through such a link during
+// extraction (root refuses to follow it), but it persists in the install tree
+// for any later consumer that walks it with ordinary os calls.
+//
+// Requiring real parents keeps an entry's archive path and its on-disk location
+// identical, which is the assumption the target check depends on.
+func rejectSymlinkedParents(root *os.Root, name string) error {
+	dir := filepath.Dir(name)
+	if dir == "." {
+		return nil
+	}
+
+	prefix := ""
+	for _, part := range strings.Split(filepath.ToSlash(dir), "/") {
+		if prefix == "" {
+			prefix = part
+		} else {
+			prefix += "/" + part
+		}
+
+		info, err := root.Lstat(prefix)
+		if os.IsNotExist(err) {
+			// Not created yet; root.Symlink will fail on the missing parent
+			// rather than resolving through anything unexpected.
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("failed to inspect symlink parent %s: %w", prefix, err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("symlink %s has a symlinked parent directory: %s", name, prefix)
+		}
+	}
+	return nil
 }
 
 func writeFileFromTar(tr *tar.Reader, root *os.Root, name string, mode os.FileMode) error {

--- a/apps/backend/internal/tools/installer/github_tarball_strategy.go
+++ b/apps/backend/internal/tools/installer/github_tarball_strategy.go
@@ -163,12 +163,24 @@ func (s *GithubTarballStrategy) download(ctx context.Context, url string) error 
 }
 
 // extractTarGz decompresses and extracts a tar.gz stream into destDir.
+//
+// Every write goes through an os.Root anchored at destDir, so containment is
+// enforced by the OS-level path walk rather than by lexical validation of the
+// entry name alone. Lexical checks are not sufficient on their own: an archive
+// can ship a symlink whose target passes containment (e.g. "a" -> ".") and then
+// write through it with a later entry that really resolves outside destDir.
 func extractTarGz(r io.Reader, destDir string) error {
 	gzReader, err := gzip.NewReader(r)
 	if err != nil {
 		return fmt.Errorf("failed to create gzip reader: %w", err)
 	}
 	defer func() { _ = gzReader.Close() }()
+
+	root, err := os.OpenRoot(destDir)
+	if err != nil {
+		return fmt.Errorf("failed to open destination %s: %w", destDir, err)
+	}
+	defer func() { _ = root.Close() }()
 
 	tarReader := tar.NewReader(gzReader)
 	for {
@@ -180,67 +192,70 @@ func extractTarGz(r io.Reader, destDir string) error {
 			return fmt.Errorf("tar read error: %w", err)
 		}
 
-		if err := extractTarEntry(tarReader, header, destDir); err != nil {
+		if err := extractTarEntry(tarReader, header, root); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func extractTarEntry(tr *tar.Reader, header *tar.Header, destDir string) error {
-	cleanName, err := sanitizeTarPath(header.Name, destDir)
+func extractTarEntry(tr *tar.Reader, header *tar.Header, root *os.Root) error {
+	cleanName, err := sanitizeTarPath(header.Name, root.Name())
 	if err != nil {
 		return err
 	}
 
-	target := filepath.Join(destDir, cleanName)
-
 	switch header.Typeflag {
 	case tar.TypeDir:
-		return os.MkdirAll(target, os.FileMode(header.Mode))
+		return root.MkdirAll(cleanName, os.FileMode(header.Mode))
 	case tar.TypeReg:
-		return writeFileFromTar(tr, target, os.FileMode(header.Mode))
+		return writeFileFromTar(tr, root, cleanName, os.FileMode(header.Mode))
 	case tar.TypeSymlink:
-		// Validate symlink target to prevent path traversal attacks
-		if filepath.IsAbs(header.Linkname) {
-			return fmt.Errorf("symlink target must not be absolute: %s -> %s", header.Name, header.Linkname)
-		}
-
-		// Resolve the symlink target path relative to the symlink's location
-		symlinkDir := filepath.Dir(target)
-		linkTarget := filepath.Join(symlinkDir, header.Linkname)
-
-		// Ensure the resolved symlink target is within destDir
-		cleanLinkTarget := filepath.Clean(linkTarget)
-		cleanDestDir := filepath.Clean(destDir)
-		if !strings.HasPrefix(cleanLinkTarget, cleanDestDir+string(os.PathSeparator)) && cleanLinkTarget != cleanDestDir {
-			return fmt.Errorf("symlink target escapes destination: %s -> %s", header.Name, header.Linkname)
-		}
-
-		// Remove existing symlink/file before creating (handles re-installs)
-		_ = os.Remove(target)
-		return os.Symlink(header.Linkname, target)
+		return extractSymlinkEntry(root, cleanName, header)
 	default:
 		// Skip unsupported types (block devices, char devices, etc.)
 		return nil
 	}
 }
 
-func writeFileFromTar(tr *tar.Reader, target string, mode os.FileMode) error {
-	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
-		return fmt.Errorf("failed to create parent directory: %w", err)
+// extractSymlinkEntry creates header's symlink under root. root.Symlink already
+// confines where the link itself lands, and root refuses to follow a link out of
+// the tree later; rejecting escaping targets up front keeps the archive honest
+// and surfaces a clear error instead of a confusing failure further along.
+func extractSymlinkEntry(root *os.Root, cleanName string, header *tar.Header) error {
+	if filepath.IsAbs(header.Linkname) {
+		return fmt.Errorf("symlink target must not be absolute: %s -> %s", header.Name, header.Linkname)
 	}
 
-	f, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
+	// Resolve the target relative to the symlink's own directory, both
+	// expressed relative to destDir. Anything that climbs to ".." has left it.
+	linkTarget := filepath.Join(filepath.Dir(cleanName), header.Linkname)
+	if linkTarget == ".." || strings.HasPrefix(linkTarget, ".."+string(os.PathSeparator)) {
+		return fmt.Errorf("symlink target escapes destination: %s -> %s", header.Name, header.Linkname)
+	}
+
+	// Remove existing symlink/file before creating (handles re-installs)
+	_ = root.Remove(cleanName)
+	return root.Symlink(header.Linkname, cleanName)
+}
+
+func writeFileFromTar(tr *tar.Reader, root *os.Root, name string, mode os.FileMode) error {
+	if dir := filepath.Dir(name); dir != "." {
+		if err := root.MkdirAll(dir, 0o755); err != nil {
+			return fmt.Errorf("failed to create parent directory: %w", err)
+		}
+	}
+
+	f, err := root.OpenFile(name, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
 	if err != nil {
-		return fmt.Errorf("failed to create file %s: %w", target, err)
+		return fmt.Errorf("failed to create file %s: %w", name, err)
 	}
 	defer func() { _ = f.Close() }()
 
 	// Limit copy size to prevent decompression bombs (1 GB)
 	const maxFileSize = 1 << 30
 	if _, err := io.Copy(f, io.LimitReader(tr, maxFileSize)); err != nil {
-		return fmt.Errorf("failed to write file %s: %w", target, err)
+		return fmt.Errorf("failed to write file %s: %w", name, err)
 	}
 	return nil
 }

--- a/apps/backend/internal/tools/installer/github_tarball_strategy_test.go
+++ b/apps/backend/internal/tools/installer/github_tarball_strategy_test.go
@@ -490,6 +490,49 @@ func TestExtractTarGz_WriteThroughSymlinkChainBlocked(t *testing.T) {
 	}
 }
 
+func TestExtractTarGz_SymlinkUnderSymlinkedParentRejected(t *testing.T) {
+	// A symlink entry whose parent is itself a symlink lands one level
+	// shallower than its archive path, so a relative target validated against
+	// the archive path resolves somewhere else on disk: "a/x" -> ".." checks
+	// out against parent "a" but really points at destDir's parent once it is
+	// created at "x". Nothing can be written through it (os.Root refuses to
+	// follow it), but it must not be left in the install tree either.
+	var buf bytes.Buffer
+	gzWriter := gzip.NewWriter(&buf)
+	tarWriter := tar.NewWriter(gzWriter)
+
+	_ = tarWriter.WriteHeader(&tar.Header{
+		Name:     "a",
+		Typeflag: tar.TypeSymlink,
+		Linkname: ".",
+	})
+	_ = tarWriter.WriteHeader(&tar.Header{
+		Name:     "a/x",
+		Typeflag: tar.TypeSymlink,
+		Linkname: "..",
+	})
+
+	_ = tarWriter.Close()
+	_ = gzWriter.Close()
+
+	parent := t.TempDir()
+	destDir := filepath.Join(parent, "install")
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
+		t.Fatalf("failed to create destDir: %v", err)
+	}
+
+	if err := extractTarGz(&buf, destDir); err == nil {
+		t.Error("expected error for symlink created under a symlinked parent, got nil")
+	}
+
+	// The link must not exist at its real (shallower) location either.
+	shallow := filepath.Join(destDir, "x")
+	if _, err := os.Lstat(shallow); !os.IsNotExist(err) {
+		target, _ := os.Readlink(shallow)
+		t.Errorf("escaping symlink left in install tree: %s -> %q (lstat err: %v)", shallow, target, err)
+	}
+}
+
 func TestResolveTarget_Unsupported(t *testing.T) {
 	s := &GithubTarballStrategy{
 		config: GithubTarballConfig{

--- a/apps/backend/internal/tools/installer/github_tarball_strategy_test.go
+++ b/apps/backend/internal/tools/installer/github_tarball_strategy_test.go
@@ -444,6 +444,52 @@ func TestExtractTarGz_SymlinkDotDotEscapeBlocked(t *testing.T) {
 	}
 }
 
+func TestExtractTarGz_WriteThroughSymlinkChainBlocked(t *testing.T) {
+	// Lexical containment alone lets an archive escape in two hops: "a" -> "."
+	// resolves to destDir itself (contained), so "a/x" -> ".." *looks* like it
+	// lands on destDir while it really lands on destDir's parent. A later entry
+	// written through a/x then escapes. Extraction must refuse the write.
+	var buf bytes.Buffer
+	gzWriter := gzip.NewWriter(&buf)
+	tarWriter := tar.NewWriter(gzWriter)
+
+	_ = tarWriter.WriteHeader(&tar.Header{
+		Name:     "a",
+		Typeflag: tar.TypeSymlink,
+		Linkname: ".",
+	})
+	_ = tarWriter.WriteHeader(&tar.Header{
+		Name:     "a/x",
+		Typeflag: tar.TypeSymlink,
+		Linkname: "..",
+	})
+	content := []byte("PWNED")
+	_ = tarWriter.WriteHeader(&tar.Header{
+		Name:     "a/x/pwned.txt",
+		Typeflag: tar.TypeReg,
+		Mode:     0o644,
+		Size:     int64(len(content)),
+	})
+	_, _ = tarWriter.Write(content)
+
+	_ = tarWriter.Close()
+	_ = gzWriter.Close()
+
+	parent := t.TempDir()
+	destDir := filepath.Join(parent, "install")
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
+		t.Fatalf("failed to create destDir: %v", err)
+	}
+
+	if err := extractTarGz(&buf, destDir); err == nil {
+		t.Error("expected error for write through an escaping symlink chain, got nil")
+	}
+
+	if _, err := os.Lstat(filepath.Join(parent, "pwned.txt")); !os.IsNotExist(err) {
+		t.Errorf("archive escaped destDir: pwned.txt written to %s (lstat err: %v)", parent, err)
+	}
+}
+
 func TestResolveTarget_Unsupported(t *testing.T) {
 	s := &GithubTarballStrategy{
 		config: GithubTarballConfig{


### PR DESCRIPTION
## Summary

Triage of all 11 open [code scanning alerts](https://github.com/kdlbs/kandev/security/code-scanning). One was a real, reproducible bug; the other ten were false positives or by-design and have been dismissed in the UI with per-alert reasoning.

## The real one: zip-slip in tarball tool installs (CodeQL #19, high)

`extractTarGz` validated tar entry paths **lexically only**. That is escapable in two hops:

1. entry `a` → symlink to `.` — resolves to `destDir` itself, so it passes containment
2. entry `a/x` → symlink to `..` — lexically "resolves" to `destDir` (allowed), but *really* lands on `destDir`'s **parent**, because `a` is `destDir`
3. entry `a/x/pwned.txt` — an ordinary file, no `..` anywhere in its name, written **through** the chain

Building that tarball and extracting it against the old code wrote `PWNED` outside `destDir`. Not theoretical.

The gap is that lexical validation resolves `a/x` as if `a` were a real directory. It isn't — it's a symlink, and the kernel resolves it at a shallower depth than the string math assumes.

### Fix

Anchor extraction at an `os.Root` opened on `destDir`, so containment is enforced by the OS-level path walk, which refuses to follow a link out of the tree. `os.Root` also permits the legitimate cases we already supported (npm-style `.bin/x -> ../pkg/bin/x.js` relative links). The lexical checks stay in place — they now serve to surface a clear error up front rather than being the sole defense.

Requires Go 1.24+ for `os.Root` and 1.25+ for `Root.MkdirAll`/`Root.Symlink`; the module is already on `go 1.26.0`.

### Reachability

Narrow — it needs a malicious or compromised asset on a pinned GitHub release that the tool installer pulls. Worth fixing regardless: the fix is small and the primitive is a full arbitrary-file-write outside the install directory.

## The ten dismissed alerts

| Alert(s) | Disposition |
|---|---|
| #245 `go/command-injection` (critical) | False positive — argv slice, no shell, flags allowlisted |
| #209 #204 #205 `go/path-injection` | Won't fix — the ADR-0016 read-only absolute-path read is intentional |
| #196 #189 #72 #70 #69 `go/path-injection` | False positive — all re-derive from a trusted root after a containment check |
| #6 `js/request-forgery` (critical) | False positive — stale Next.js-era alert; the module now runs in the browser, same-origin |

Each carries its reasoning in the dismissal comment on the alert itself.

## Test plan

- New regression test `TestExtractTarGz_WriteThroughSymlinkChainBlocked` reproduces the two-hop chain, asserts extraction errors **and** that nothing lands outside `destDir`. It fails against the pre-fix code.
- All 6 existing extraction tests still pass, including the legitimate-relative-symlink case.
- `make -C apps/backend test build`, `golangci-lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)