### PR TITLE
fix(web): polish clarification custom answer input

### DIFF
--- a/apps/web/components/task/chat/clarification-custom-input.test.tsx
+++ b/apps/web/components/task/chat/clarification-custom-input.test.tsx
@@ -17,6 +17,7 @@ afterEach(() => {
 });
 
 const INPUT_TESTID = "clarification-input";
+const ROW_TESTID = "clarification-custom-input";
 const TOUCH_SUBMIT_TESTID = "clarification-custom-submit";
 const MULTILINE = "line one\nline two";
 
@@ -55,17 +56,28 @@ function renderInPanel(overrides: Partial<Parameters<typeof ClarificationCustomI
 describe("ClarificationCustomInput row focus", () => {
   it("renders the editor as one flush, transparent input surface", () => {
     const { getByTestId } = renderInPanel();
-    const row = getByTestId("clarification-custom-input");
+    const row = getByTestId(ROW_TESTID);
     const input = getByTestId(INPUT_TESTID);
 
     expect(input.className).toContain("dark:bg-transparent");
     expect(row.textContent).not.toContain("↳");
   });
 
+  it("centers every direct row control without manual top offsets", () => {
+    const { getByTestId } = renderInPanel({ active: true });
+    const row = getByTestId(ROW_TESTID);
+
+    expect(row.className).toContain("items-center");
+    expect(row.className).not.toContain("items-start");
+    expect(Array.from(row.children).every((child) => !child.className.includes("mt-0.5"))).toBe(
+      true,
+    );
+  });
+
   it("focuses the textarea when the non-interactive row surface is pressed", () => {
     const { getByTestId } = renderInPanel();
 
-    const notDefaulted = fireEvent.mouseDown(getByTestId("clarification-custom-input"));
+    const notDefaulted = fireEvent.mouseDown(getByTestId(ROW_TESTID));
 
     expect(notDefaulted).toBe(false);
     expect(document.activeElement).toBe(getByTestId(INPUT_TESTID));
@@ -74,7 +86,7 @@ describe("ClarificationCustomInput row focus", () => {
   it("does not focus the disabled textarea from the row surface", () => {
     const { getByTestId } = renderInPanel({ isSubmitting: true });
 
-    fireEvent.mouseDown(getByTestId("clarification-custom-input"));
+    fireEvent.mouseDown(getByTestId(ROW_TESTID));
 
     expect(document.activeElement).not.toBe(getByTestId(INPUT_TESTID));
   });

--- a/apps/web/components/task/chat/clarification-custom-input.test.tsx
+++ b/apps/web/components/task/chat/clarification-custom-input.test.tsx
@@ -53,6 +53,15 @@ function renderInPanel(overrides: Partial<Parameters<typeof ClarificationCustomI
 }
 
 describe("ClarificationCustomInput row focus", () => {
+  it("renders the editor as one flush, transparent input surface", () => {
+    const { getByTestId } = renderInPanel();
+    const row = getByTestId("clarification-custom-input");
+    const input = getByTestId(INPUT_TESTID);
+
+    expect(input.className).toContain("dark:bg-transparent");
+    expect(row.textContent).not.toContain("↳");
+  });
+
   it("focuses the textarea when the non-interactive row surface is pressed", () => {
     const { getByTestId } = renderInPanel();
 

--- a/apps/web/components/task/chat/clarification-overlay-parts.tsx
+++ b/apps/web/components/task/chat/clarification-overlay-parts.tsx
@@ -181,7 +181,7 @@ function CustomInputControls({
 }) {
   if (isFinePointer) {
     return (
-      <div className="mt-0.5 flex flex-shrink-0 items-center gap-1">
+      <div className="flex flex-shrink-0 items-center gap-1">
         <kbd
           aria-hidden="true"
           className="select-none flex items-center gap-1 font-mono text-[10px] px-1.5 py-0.5 rounded border border-border bg-background text-muted-foreground"
@@ -204,7 +204,7 @@ function CustomInputControls({
       data-testid="clarification-custom-submit"
       aria-label="Send answer"
       className={cn(
-        "mt-0.5 flex flex-shrink-0 items-center gap-1 text-xs px-2 py-1 rounded font-medium transition-colors",
+        "flex flex-shrink-0 items-center gap-1 text-xs px-2 py-1 rounded font-medium transition-colors",
         canSend
           ? "bg-blue-500 text-white hover:bg-blue-500/90 cursor-pointer"
           : "bg-muted text-muted-foreground cursor-not-allowed",
@@ -254,7 +254,7 @@ export function ClarificationCustomInput({
         textareaRef.current?.focus({ preventScroll: true });
       }}
       className={cn(
-        "mt-2.5 flex min-h-11 items-start gap-2 px-3 py-2 rounded-lg border transition-colors",
+        "mt-2.5 flex min-h-11 items-center gap-2 px-3 py-2 rounded-lg border transition-colors",
         active
           ? "bg-blue-500/15 border-blue-500/50 text-foreground"
           : "border-dashed border-border/70 bg-muted/30",
@@ -306,7 +306,7 @@ export function ClarificationCustomInput({
         isSubmitting={isSubmitting}
         onSubmit={onSubmit}
       />
-      {active && <IconCheck className="mt-0.5 h-3.5 w-3.5 text-blue-500 flex-shrink-0" />}
+      {active && <IconCheck className="h-3.5 w-3.5 text-blue-500 flex-shrink-0" />}
     </div>
   );
 }

--- a/apps/web/components/task/chat/clarification-overlay-parts.tsx
+++ b/apps/web/components/task/chat/clarification-overlay-parts.tsx
@@ -261,12 +261,6 @@ export function ClarificationCustomInput({
         isSubmitting ? "cursor-not-allowed" : "cursor-text",
       )}
     >
-      <span
-        className={cn("mt-0.5 text-xs", active ? "text-blue-500" : "text-muted-foreground")}
-        aria-hidden="true"
-      >
-        ↳
-      </span>
       <Textarea
         ref={textareaRef}
         rows={1}
@@ -278,7 +272,7 @@ export function ClarificationCustomInput({
         disabled={isSubmitting}
         data-testid="clarification-input"
         style={{ maxHeight: MAX_CUSTOM_INPUT_HEIGHT }}
-        className="flex-1 min-h-0 resize-none overflow-y-auto border-0 bg-transparent p-0 text-sm shadow-none focus-visible:ring-0 placeholder:text-muted-foreground/60"
+        className="flex-1 min-h-0 resize-none overflow-y-auto border-0 bg-transparent p-0 text-sm shadow-none focus-visible:ring-0 dark:bg-transparent placeholder:text-muted-foreground/60"
         onKeyDown={(e) => {
           // Shift+Enter (and Alt+Enter) fall through so the textarea inserts a
           // newline instead of submitting. isComposing ignores the Enter that

--- a/apps/web/e2e/tests/chat/clarification.spec.ts
+++ b/apps/web/e2e/tests/chat/clarification.spec.ts
@@ -224,7 +224,7 @@ test.describe("Clarification flow", () => {
     if (!inputBox || !inputRowBox) {
       throw new Error("expected the custom answer input and row to have bounding boxes");
     }
-    expect(inputBox.x - inputRowBox.x).toBeLessThanOrEqual(16);
+    expect(Math.abs(inputBox.x - inputRowBox.x)).toBeLessThanOrEqual(16);
 
     await inputRow.click({ position: { x: 4, y: 4 } });
     await expect(input).toBeFocused();

--- a/apps/web/e2e/tests/chat/clarification.spec.ts
+++ b/apps/web/e2e/tests/chat/clarification.spec.ts
@@ -230,6 +230,17 @@ test.describe("Clarification flow", () => {
     await expect(input).toBeFocused();
     await input.pressSequentially("Use the embedded database for this task");
     await expect(input).toHaveValue("Use the embedded database for this task");
+    const [filledInputBox, filledInputRowBox] = await Promise.all([
+      input.boundingBox(),
+      inputRow.boundingBox(),
+    ]);
+    if (!filledInputBox || !filledInputRowBox) {
+      throw new Error("expected the filled custom answer input and row to have bounding boxes");
+    }
+    const inputCenter = filledInputBox.y + filledInputBox.height / 2;
+    const rowCenter = filledInputRowBox.y + filledInputRowBox.height / 2;
+    expect(Math.abs(inputCenter - rowCenter)).toBeLessThanOrEqual(1);
+
     await input.press("Enter");
     await expect(session.idleInput()).toBeVisible({ timeout: 30_000 });
     await expect(session.chat).toContainText("Use the embedded database for this task");

--- a/apps/web/e2e/tests/chat/clarification.spec.ts
+++ b/apps/web/e2e/tests/chat/clarification.spec.ts
@@ -214,8 +214,19 @@ test.describe("Clarification flow", () => {
     // Agent moved on; a late custom answer remains editable and goes through
     // the event fallback as a new prompt.
     const input = session.clarificationInput();
+    const inputRow = session.clarificationCustomInput();
     await expect(input).toBeEnabled();
-    await session.clarificationCustomInput().click({ position: { x: 4, y: 4 } });
+    await expect(input).toHaveCSS("background-color", "rgba(0, 0, 0, 0)");
+    const [inputBox, inputRowBox] = await Promise.all([
+      input.boundingBox(),
+      inputRow.boundingBox(),
+    ]);
+    if (!inputBox || !inputRowBox) {
+      throw new Error("expected the custom answer input and row to have bounding boxes");
+    }
+    expect(inputBox.x - inputRowBox.x).toBeLessThanOrEqual(16);
+
+    await inputRow.click({ position: { x: 4, y: 4 } });
     await expect(input).toBeFocused();
     await input.pressSequentially("Use the embedded database for this task");
     await expect(input).toHaveValue("Use the embedded database for this task");


### PR DESCRIPTION
The clarification custom-answer editor inherited a dark-mode textarea fill and an extra reply marker, making it appear as a nested field with uneven inset. The row now renders as one transparent editor surface with consistent desktop/mobile spacing and true vertical centering while preserving multiline entry and touch send behavior.

## Validation

- `pnpm test -- components/task/chat/clarification-custom-input.test.tsx` (19 passed)
- `make build-web`
- Chromium deferred clarification E2E (1 passed)
- Pixel 5 mobile clarification E2E (2 passed)
- Changed-scope verification: web typecheck and web test suite passed

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.

<!-- kandev-screenshots-start -->
## Screenshots

![Desktop deferred custom answer](https://raw.githubusercontent.com/kdlbs/kandev/5370ea5032f28b4cb767d8defa914070b75349ef/clarification--deferred-custom-answer.png)

![Pixel 5 multiline custom answer](https://raw.githubusercontent.com/kdlbs/kandev/5370ea5032f28b4cb767d8defa914070b75349ef/mobile-clarification--multiline-custom-answer.png)
<!-- kandev-screenshots-end -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1942?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
