### PR TITLE
fix: extend ACP session creation timeout

### DIFF
--- a/apps/backend/internal/agentctl/server/api/agent.go
+++ b/apps/backend/internal/agentctl/server/api/agent.go
@@ -354,7 +354,7 @@ func (s *Server) handleWSNewSession(ctx context.Context, msg *ws.Message) *ws.Me
 		return resp
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, constants.SessionNewTimeout)
 	defer cancel()
 
 	adapter := s.procMgr.GetAdapter()

--- a/apps/backend/internal/agentctl/server/api/agent_test.go
+++ b/apps/backend/internal/agentctl/server/api/agent_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/kandev/kandev/internal/agentctl/server/config"
 	"github.com/kandev/kandev/internal/agentctl/server/process"
 	"github.com/kandev/kandev/internal/agentctl/types"
-	"github.com/kandev/kandev/internal/common/constants"
 	"github.com/kandev/kandev/internal/common/logger"
 	mcpserver "github.com/kandev/kandev/internal/mcp/server"
 	v1 "github.com/kandev/kandev/pkg/api/v1"
@@ -259,8 +258,9 @@ func TestHandleWSNewSession_UsesExtendedDeadline(t *testing.T) {
 	if resp.Type != ws.MessageTypeResponse {
 		t.Fatalf("response type = %q, want %q", resp.Type, ws.MessageTypeResponse)
 	}
-	if capture.remaining < constants.SessionNewTimeout-time.Second {
-		t.Fatalf("session/new deadline = %v from now, want about %v", capture.remaining, constants.SessionNewTimeout)
+	const want = 2 * time.Minute
+	if capture.remaining < want-time.Second || capture.remaining > want {
+		t.Fatalf("session/new deadline = %v from now, want about %v", capture.remaining, want)
 	}
 }
 

--- a/apps/backend/internal/agentctl/server/api/agent_test.go
+++ b/apps/backend/internal/agentctl/server/api/agent_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kandev/kandev/internal/agentctl/server/config"
 	"github.com/kandev/kandev/internal/agentctl/server/process"
 	"github.com/kandev/kandev/internal/agentctl/types"
+	"github.com/kandev/kandev/internal/common/constants"
 	"github.com/kandev/kandev/internal/common/logger"
 	mcpserver "github.com/kandev/kandev/internal/mcp/server"
 	v1 "github.com/kandev/kandev/pkg/api/v1"
@@ -245,6 +246,24 @@ func TestHandleWSNewSession_NoAdapter(t *testing.T) {
 	}
 }
 
+func TestHandleWSNewSession_UsesExtendedDeadline(t *testing.T) {
+	s := newTestServer(t)
+	capture := &newSessionDeadlineCaptureAdapter{}
+	s.procMgr.SetAdapterForTest(capture)
+
+	msg, err := ws.NewRequest("req-1", "agent.session.new", NewSessionRequest{})
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	resp := s.handleWSNewSession(context.Background(), msg)
+	if resp.Type != ws.MessageTypeResponse {
+		t.Fatalf("response type = %q, want %q", resp.Type, ws.MessageTypeResponse)
+	}
+	if capture.remaining < constants.SessionNewTimeout-time.Second {
+		t.Fatalf("session/new deadline = %v from now, want about %v", capture.remaining, constants.SessionNewTimeout)
+	}
+}
+
 func TestHandleWSLoadSession_NoAdapter(t *testing.T) {
 	s := newTestServer(t)
 	ctx := context.Background()
@@ -380,6 +399,20 @@ type mcpCaptureAdapter struct {
 	promptErrorAdapter
 	newSessionServers  []types.McpServer
 	loadSessionServers []types.McpServer
+}
+
+type newSessionDeadlineCaptureAdapter struct {
+	promptErrorAdapter
+	remaining time.Duration
+}
+
+func (a *newSessionDeadlineCaptureAdapter) NewSession(ctx context.Context, _ []types.McpServer) (string, error) {
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return "", errors.New("session/new context has no deadline")
+	}
+	a.remaining = time.Until(deadline)
+	return "session-1", nil
 }
 
 func (a *mcpCaptureAdapter) NewSession(_ context.Context, servers []types.McpServer) (string, error) {

--- a/apps/backend/internal/common/constants/timeouts.go
+++ b/apps/backend/internal/common/constants/timeouts.go
@@ -19,6 +19,10 @@ const (
 	// including cleanup scripts and worktree removal.
 	TaskDeleteTimeout = 2 * time.Minute
 
+	// SessionNewTimeout is the maximum time for ACP session/new. Session creation
+	// can initialize providers, plugins, and MCP servers before the agent responds.
+	SessionNewTimeout = 2 * time.Minute
+
 	// SessionLoadTimeout is the maximum time for ACP session/load (resume).
 	// Session loading may involve deserializing large conversation histories.
 	SessionLoadTimeout = 2 * time.Minute


### PR DESCRIPTION
Slow OpenCode ACP startup could exceed Kandev's 30-second `session/new` deadline, causing intermittent `context deadline exceeded` failures on slower Windows workspaces. This raises the session creation budget to two minutes and adds a regression test for the handler deadline.

## Validation

- `go test -v -run TestHandleWSNewSession_UsesExtendedDeadline ./internal/agentctl/server/api`
- `go test ./internal/agentctl/server/api`
- `make fmt`
- `make typecheck`
- `make test`
- `make lint`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1949?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->