### PR TITLE
fix(scripts): make pr-state work with native jq on Windows

### DIFF
--- a/scripts/pr-state
+++ b/scripts/pr-state
@@ -193,7 +193,7 @@ fi
 
 extract_checks_json() {
   local status_json=$1
-  jq -cn --slurpfile checks_in <(printf '%s\n' "$status_json") '
+  printf '%s\n' "$status_json" | jq -c '
     def lower_or_null:
       if . == null or . == "" then null else ascii_downcase end;
     def extract($re; $field):
@@ -205,8 +205,7 @@ extract_checks_json() {
         ((.state // "") | lower_or_null) as $state
         | if $state == "pending" or $state == "expected" then null else $state end
       end;
-    $checks_in[0]
-    | to_entries
+    to_entries
     | map(.value + {_index: .key} | {
       type: (.["__typename"] // null),
       name: (.name // .context // "unknown"),
@@ -242,9 +241,8 @@ extract_checks_json() {
 extract_issue_comments_json() {
   local comments_json=$1
   local since=$2
-  jq -cn --slurpfile comments <(printf '%s\n' "$comments_json") --arg since "$since" '
-    $comments[0]
-    | map(select($since == "" or ((.createdAt // .created_at // "") > $since)))
+  printf '%s\n' "$comments_json" | jq -c --arg since "$since" '
+    map(select($since == "" or ((.createdAt // .created_at // "") > $since)))
     | map({
       author: (.author.login // "unknown"),
       body: (.body // ""),
@@ -265,9 +263,8 @@ extract_issue_comments_json() {
 extract_reviews_json() {
   local reviews_api_json=$1
   local since=$2
-  jq -cn --slurpfile reviews <(printf '%s\n' "$reviews_api_json") --arg since "$since" '
-    $reviews[0]
-    | map(select($since == "" or ((.submitted_at // "") > $since)))
+  printf '%s\n' "$reviews_api_json" | jq -c --arg since "$since" '
+    map(select($since == "" or ((.submitted_at // "") > $since)))
     | map({
       author: (.user.login // "unknown"),
       state: ((.state // "unknown") | ascii_downcase),
@@ -287,10 +284,10 @@ review_evidence_json() {
   local reviews_api_json=$5
   local is_cross_repository=$6
   local trusted_workflow_json=$7
-  jq -cn --arg opening_head_oid "$opening_head_oid" --arg closing_head_oid "$closing_head_oid" --arg checks_head_oid "$checks_head_oid" --arg trusted_reviewer "$TRUSTED_REVIEWER" --argjson is_cross_repository "$is_cross_repository" --argjson reviews_known "$reviews_known" --argjson trusted_workflow "$trusted_workflow_json" \
-    --slurpfile reviews <(printf '%s\n' "$reviews_api_json") '
+  printf '%s\n' "$reviews_api_json" |
+    jq -c --arg opening_head_oid "$opening_head_oid" --arg closing_head_oid "$closing_head_oid" --arg checks_head_oid "$checks_head_oid" --arg trusted_reviewer "$TRUSTED_REVIEWER" --argjson is_cross_repository "$is_cross_repository" --argjson reviews_known "$reviews_known" --argjson trusted_workflow "$trusted_workflow_json" '
       def normalized_reviews:
-        $reviews[0] | map({
+        map({
           author: (.user.login // "unknown"),
           state: ((.state // "unknown") | ascii_downcase),
           commit_id: (.commit_id // null),
@@ -438,15 +435,14 @@ fetch_trusted_workflow_json() {
 extract_review_threads_json() {
   local threads_nodes_json=$1
   local since=$2
-  jq -cn --slurpfile threads <(printf '%s\n' "$threads_nodes_json") --arg since "$since" '
+  printf '%s\n' "$threads_nodes_json" | jq -c --arg since "$since" '
     def relevant_comments:
       if $since == "" then
         (.comments.nodes // [])
       else
         [(.comments.nodes // [])[] | select((.createdAt // "") > $since)]
       end;
-    $threads[0]
-    | map(. as $thread | (relevant_comments) as $comments | select($comments | length > 0) | {
+    map(. as $thread | (relevant_comments) as $comments | select($comments | length > 0) | {
       thread_id: .id,
       is_resolved: (.isResolved // false),
       path: (.path // ""),
@@ -622,10 +618,9 @@ fetch_review_threads_nodes_json() {
     page_nodes="$(jq -c '.data.repository.pullRequest.reviewThreads.nodes // []' <<<"$page_json")"
     local next_nodes_file
     next_nodes_file="$(mktemp)"
-    if ! jq -cn \
+    if ! printf '%s\n' "$page_nodes" | jq -cn \
       --slurpfile prev "$nodes_file" \
-      --slurpfile page <(printf '%s\n' "$page_nodes") \
-      '$prev[0] + $page[0]' >"$next_nodes_file"; then
+      '$prev[0] + input' >"$next_nodes_file"; then
       add_error "review_threads" "failed to merge paginated review threads"
       rm -f "$next_nodes_file" "$nodes_file"
       return 1
@@ -717,12 +712,11 @@ if [[ -n "$repo_owner" && -n "$repo_name" && -n "$resolved_pr_number" ]]; then
   if threads_nodes_json="$(fetch_review_threads_nodes_json "$repo_owner" "$repo_name" "$resolved_pr_number")"; then
     review_threads_json="$(extract_review_threads_json "$threads_nodes_json" "$since")"
     all_review_threads_json="$(extract_review_threads_json "$threads_nodes_json" "")"
-    hidden_unresolved_threads_json="$(jq -cn \
-      --slurpfile all <(printf '%s\n' "$all_review_threads_json") \
-      --slurpfile filtered <(printf '%s\n' "$review_threads_json") \
-      '
-        ($filtered[0] | map(.thread_id)) as $filtered_ids
-        | $all[0]
+    hidden_unresolved_threads_json="$(printf '%s\n%s\n' "$all_review_threads_json" "$review_threads_json" |
+      jq -cn '
+        [inputs] as [$all, $filtered]
+        | ($filtered | map(.thread_id)) as $filtered_ids
+        | $all
         | map(select(.is_resolved == false and (.thread_id as $id | $filtered_ids | index($id) | not)))
         | map({thread_id, comment_id, author, path, body_preview})
       ')"

--- a/scripts/pr-state.test.sh
+++ b/scripts/pr-state.test.sh
@@ -1263,6 +1263,17 @@ test_comment_mode_rejects_incompatible_flags() {
   pass "--comment rejects incompatible flags"
 }
 
+test_jq_file_args_avoid_process_substitution() {
+  local offenders
+  offenders="$(grep -nE '(--slurpfile|--rawfile|--argfile)[[:space:]]+[^[:space:]]+[[:space:]]+<\(' "$SCRIPT" || true)"
+  if [[ -n "$offenders" ]]; then
+    printf '%s\n' "$offenders" >&2
+    fail "jq file arguments must not come from process substitution (native jq cannot open /proc/<pid>/fd/<n>)"
+  fi
+  pass "jq file arguments avoid process substitution"
+}
+
+test_jq_file_args_avoid_process_substitution
 test_snapshot_happy_path
 test_old_head_review_does_not_qualify
 test_exact_head_selected_review_qualifies

--- a/scripts/pr-state.test.sh
+++ b/scripts/pr-state.test.sh
@@ -1263,9 +1263,39 @@ test_comment_mode_rejects_incompatible_flags() {
   pass "--comment rejects incompatible flags"
 }
 
+join_line_continuations() {
+  local file=$1
+  local line buffer='' lineno=0 start=1
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    lineno=$((lineno + 1))
+    [[ -n "$buffer" ]] || start=$lineno
+    if [[ "$line" == *\\ ]]; then
+      buffer+="${line%\\} "
+      continue
+    fi
+    printf '%s:%s\n' "$start" "$buffer$line"
+    buffer=''
+  done <"$file"
+  [[ -z "$buffer" ]] || printf '%s:%s\n' "$start" "$buffer"
+}
+
 test_jq_file_args_avoid_process_substitution() {
+  local pattern='(--slurpfile|--rawfile|--argfile)[[:space:]]+[^[:space:]]+[[:space:]]+<\('
+  local tmp
+  make_tmp_dir tmp
+
+  printf '%s\n' "jq -cn --slurpfile page <(printf x) '.'" >"$tmp/same_line.sh"
+  if ! join_line_continuations "$tmp/same_line.sh" | grep -qE "$pattern"; then
+    fail "guard misses process substitution on a single line"
+  fi
+
+  printf '%s\n' 'jq -cn \' '  --slurpfile page \' '  <(printf x)' >"$tmp/continued.sh"
+  if ! join_line_continuations "$tmp/continued.sh" | grep -qE "$pattern"; then
+    fail "guard misses process substitution split across a line continuation"
+  fi
+
   local offenders
-  offenders="$(grep -nE '(--slurpfile|--rawfile|--argfile)[[:space:]]+[^[:space:]]+[[:space:]]+<\(' "$SCRIPT" || true)"
+  offenders="$(join_line_continuations "$SCRIPT" | grep -E "$pattern" || true)"
   if [[ -n "$offenders" ]]; then
     printf '%s\n' "$offenders" >&2
     fail "jq file arguments must not come from process substitution (native jq cannot open /proc/<pid>/fd/<n>)"


### PR DESCRIPTION
`scripts/pr-state` dies on its first `jq` call under Git Bash on Windows, so the helper AGENTS.md points agents at first for PR review/fixup work dead-ends and every agent falls back to raw `gh`/GraphQL. Payloads now reach `jq` on stdin instead of through process-substitution paths, which fixes Windows and leaves behaviour everywhere else byte-identical.

## Important Changes

- Process substitution under MSYS yields `/proc/<pid>/fd/<n>`, a path only the MSYS runtime resolves. `jq` on Windows is a native PE32 binary — Git for Windows bundles none, so it comes from Chocolatey/winget/scoop — and cannot open it. Not a `jq` version issue; any native `jq` behaves this way. All 8 `--slurpfile <(...)` sites now pipe the payload in: single-payload helpers read it as `.`, the two multi-payload sites use `input` and `[inputs] as [$a, $b]`.
- **`--argjson` was rejected as the replacement**, although the issue proposes it as the closest drop-in. It moves the payload into `argv`, Windows caps a command line at 32 767 characters, and these payloads are unbounded — `reviews_api_json` and `comments_json` carry full review and comment bodies. Measured with the same native `jq` on a 768 KB payload, `--argjson` gives `Argument list too long` while the stdin form returns `20000`. `.agents/skills/pr-fixup/references/review-evidence.md` already documents an argument-list-limit fallback for this script, so argv pressure was a known concern.
- **The 10 `--slurpfile` reads of real `mktemp` files are deliberately left alone.** MSYS converts `/tmp/...` arguments to a Windows path, so native `jq` opens them fine; only `/proc` has no Windows equivalent. Same reason `scripts/pr-resolve` was never affected — its single `<(...)` feeds the bash builtin `read`, and bash keeps the descriptor rather than handing a path to another process.
- `scripts/pr-state.test.sh` gains a static guard rejecting `--slurpfile`/`--rawfile`/`--argfile` fed by `<(...)`. It runs first in the suite so it fails in a second rather than after a full run. **Correction to the first version of this description:** it is *not* wired into CI. `make test-scripts` covers `scripts/pr-state.test.sh`, but no workflow invokes that target and no pre-commit hook runs it either, so the whole suite - including the 34 pre-existing assertions - only executes when somebody runs it by hand. That gap predates this PR; happy to close it here if you want it in scope.

## Validation

- `scripts/pr-state.test.sh` run against the `main` script and against this branch's script on Linux (docker `debian:stable-slim`, bash 5.2.37, jq 1.7): both exit 0 at 34 assertions, and the two runs' output is **byte-identical**. The off-Windows behaviour is unchanged, not merely still-passing.
- Guard proven to fail, not just pass. It joins backslash-newline continuations before scanning, so both spellings are caught. Against the `main` script it exits 1 reporting 7 logical lines that cover all 8 occurrences. Against a copy of this branch's script mutated to split one `--slurpfile page` from its `<(...)` across a continuation it also exits 1 — the first version of this guard passed that mutation, which is the gap CodeRabbit flagged. Against this branch it passes, and the test asserts both spellings against synthetic fixtures so the guard cannot silently regress into same-line-only matching.
- Windows (Windows 11, Git Bash, native jq 1.8.1 from Chocolatey): full suite 35/35, exit 0. Before this change `scripts/pr-state --summary 1953` exited 2 with the `/proc/.../fd/63` error; after it returns a valid JSON summary at exit 0.
- Verified live against the GitHub API on Windows, not only against the mock: `--summary`, raw mode, `--all` and `--comment <id>` all exercised on PR #1953.
- Re-validated after rebasing onto `main` post-#1941, which added `successful_checks` to `summarize_state_json`. That hunk touches none of the changed call sites.

## Possible Improvements

Low risk — the emitted schema, the CLI surface and the control flow are untouched; only how JSON reaches `jq` changes. One gap worth naming rather than hiding:

- **macOS is unverified.** I have no macOS machine. The change uses only POSIX pipes and jq builtins (`input`/`inputs`, array destructuring, both available since jq 1.5), so I expect no platform-specific risk, but nobody has measured it.

## Related Issues

Closes #1954

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1958?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



