### PR TITLE
fix(orchestrator): retire execution activity on teardown

### DIFF
--- a/apps/backend/internal/orchestrator/background_work_accounting_test.go
+++ b/apps/backend/internal/orchestrator/background_work_accounting_test.go
@@ -649,6 +649,7 @@ func TestExecutionCleanup_PublicationDeliveryIsOrderedAcrossRecordGenerations(t 
 	// a different turnActivity record.
 	select {
 	case <-successorDone:
+		t.Fatal("successor publication completed before predecessor delivery was released — publication guard is not serializing")
 	case <-time.After(100 * time.Millisecond):
 	}
 	close(blocking.releaseRetirement)

--- a/apps/backend/internal/orchestrator/background_work_accounting_test.go
+++ b/apps/backend/internal/orchestrator/background_work_accounting_test.go
@@ -2,16 +2,46 @@ package orchestrator
 
 import (
 	"context"
+	"errors"
 	"slices"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/kandev/kandev/internal/agent/runtime/lifecycle"
 	"github.com/kandev/kandev/internal/agentctl/types/streams"
 	eventtypes "github.com/kandev/kandev/internal/events"
+	"github.com/kandev/kandev/internal/events/bus"
+	"github.com/kandev/kandev/internal/orchestrator/executor"
 	"github.com/kandev/kandev/internal/orchestrator/watcher"
 	"github.com/kandev/kandev/internal/task/models"
 	v1 "github.com/kandev/kandev/pkg/api/v1"
 )
+
+type blockingRetirementEventBus struct {
+	*recordingEventBus
+	mu                sync.Mutex
+	retirementEntered chan struct{}
+	releaseRetirement chan struct{}
+	once              sync.Once
+}
+
+func (b *blockingRetirementEventBus) Publish(
+	ctx context.Context,
+	subject string,
+	event *bus.Event,
+) error {
+	if subject == eventtypes.TaskSessionActivityChanged {
+		data, _ := event.Data.(map[string]interface{})
+		if value, present := data["foreground_activity"]; present && value == nil {
+			b.once.Do(func() { close(b.retirementEntered) })
+			<-b.releaseRetirement
+		}
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.recordingEventBus.Publish(ctx, subject, event)
+}
 
 func registerAsyncWorkForExecution(
 	t *testing.T,
@@ -32,6 +62,14 @@ func registerAsyncWorkForExecution(
 			Normalized: payload,
 		},
 	})
+}
+
+func turnActivityRecord(t *testing.T, svc *Service, sessionID string) (*turnActivity, bool) {
+	t.Helper()
+	svc.foregroundActivityMu.Lock()
+	defer svc.foregroundActivityMu.Unlock()
+	activity, ok := svc.foregroundActivity[sessionID]
+	return activity, ok
 }
 
 func TestActiveSubagentCount_DerivesOnlyLiveSubagentRegistrations(t *testing.T) {
@@ -302,6 +340,56 @@ func TestDelayedOldExecutionToolCompletionPreservesSuccessorRegistration(t *test
 	}
 }
 
+func TestExecutionTeardown_StaleToolOwnershipIsNotVisibleToReusedSuccessorID(t *testing.T) {
+	repo := setupTestRepo(t)
+	const (
+		taskID       = "task-tool-collision"
+		sessionID    = "session-tool-collision"
+		oldExecution = "execution-old"
+		newExecution = "execution-new"
+		toolCallID   = "provider-reused-tool-id"
+	)
+	seedTaskAndSession(t, repo, taskID, sessionID, models.TaskSessionStateRunning)
+	manager := &mockAgentManager{
+		getExecutionIDForSessionFunc: func(context.Context, string) (string, error) {
+			return newExecution, nil
+		},
+	}
+	svc := createTestServiceWithAgent(repo, newMockStepGetter(), newMockTaskRepo(), manager)
+	svc.messageCreator = &mockMessageCreator{}
+
+	// The predecessor never emits a terminal update for this foreground tool.
+	svc.recordToolOwnership(sessionID, toolCallID, oldExecution, toolOwnershipForeground)
+
+	// The successor is already background-idle when delayed predecessor teardown
+	// arrives. Its later update reuses the provider-local tool-call ID but carries
+	// no positive ownership metadata.
+	svc.registerBackgroundWork(sessionID, "successor-work", newExecution, "work-new")
+	svc.markForegroundIdle(sessionID)
+	svc.handleAgentStopped(t.Context(), watcher.AgentEventData{
+		TaskID: taskID, SessionID: sessionID, AgentExecutionID: oldExecution,
+	})
+	svc.handleAgentStreamEvent(t.Context(), &lifecycle.AgentStreamEventPayload{
+		TaskID: taskID, SessionID: sessionID, ExecutionID: newExecution,
+		Data: &lifecycle.AgentStreamEventData{
+			Type:       "tool_update",
+			ToolCallID: toolCallID,
+			ToolStatus: agentEventCompleted,
+			ToolCallContents: []streams.ToolCallContentItem{{
+				Type: "content",
+				Content: &streams.ContentBlock{
+					Type: "text",
+					Text: "successor update",
+				},
+			}},
+		},
+	})
+
+	if got := svc.ForegroundActivity(sessionID); got != v1.ForegroundActivityBackground {
+		t.Fatalf("stale predecessor tool ownership changed successor activity to %q", got)
+	}
+}
+
 func TestExecutionStop_RetiresOnlyOwnedBackgroundWorkAndPublishesFinalTransition(t *testing.T) {
 	ctx := context.Background()
 	repo := setupTestRepo(t)
@@ -312,16 +400,45 @@ func TestExecutionStop_RetiresOnlyOwnedBackgroundWorkAndPublishesFinalTransition
 
 	registerAsyncWorkForExecution(t, svc, "task-stop-accounting", "session-stop-accounting", "execution-old", "tool-old", "work-old")
 	registerAsyncWorkForExecution(t, svc, "task-stop-accounting", "session-stop-accounting", "execution-new", "tool-new", "work-new")
+	svc.recordToolOwnership(
+		"session-stop-accounting",
+		"foreground-old",
+		"execution-old",
+		toolOwnershipForeground,
+	)
+	svc.recordToolOwnership(
+		"session-stop-accounting",
+		"child-new",
+		"execution-new",
+		toolOwnershipChild,
+	)
 	svc.markForegroundIdle("session-stop-accounting")
 
 	svc.handleAgentStopped(ctx, watcher.AgentEventData{
 		TaskID: "task-stop-accounting", SessionID: "session-stop-accounting", AgentExecutionID: "execution-old",
 	})
+	if _, ok := turnActivityRecord(t, svc, "session-stop-accounting"); !ok {
+		t.Fatal("predecessor cleanup retired activity already owned by the successor execution")
+	}
 	if svc.hasBackgroundTask("session-stop-accounting", "tool-old") {
 		t.Fatal("stopped execution left its background registration behind")
 	}
 	if !svc.hasBackgroundTask("session-stop-accounting", "tool-new") {
 		t.Fatal("old execution cleanup removed successor execution background work")
+	}
+	if got := svc.toolOwnership(
+		"session-stop-accounting",
+		"foreground-old",
+		"execution-old",
+	); got != toolOwnershipUnknown {
+		t.Fatalf("predecessor tool ownership survived teardown: %d", got)
+	}
+	if got := svc.toolOwnership(
+		"session-stop-accounting",
+		"child-new",
+		"execution-new",
+	); got != toolOwnershipChild {
+		t.Fatalf("successor tool ownership = %d, want child", got)
 	}
 	if got := svc.ForegroundActivity("session-stop-accounting"); got != v1.ForegroundActivityBackground {
 		t.Fatalf("successor background work should remain visible, got %q", got)
@@ -335,6 +452,9 @@ func TestExecutionStop_RetiresOnlyOwnedBackgroundWorkAndPublishesFinalTransition
 	}
 	if got := svc.ForegroundActivity("session-stop-accounting"); got != v1.ForegroundActivityGenerating {
 		t.Fatalf("final execution cleanup left stale background activity: %q", got)
+	}
+	if _, ok := turnActivityRecord(t, svc, "session-stop-accounting"); ok {
+		t.Fatal("final stopped execution retained the session activity record")
 	}
 
 	var activityValues []interface{}
@@ -359,6 +479,34 @@ func TestExecutionStop_RetiresOnlyOwnedBackgroundWorkAndPublishesFinalTransition
 	}
 }
 
+func TestExecutionStop_DropsLateFramesAfterActivityRetirement(t *testing.T) {
+	const (
+		taskID      = "task-stopped-late-frame"
+		sessionID   = "session-stopped-late-frame"
+		executionID = "execution-stopped-late-frame"
+	)
+	repo := setupTestRepo(t)
+	seedTaskAndSession(t, repo, taskID, sessionID, models.TaskSessionStateWaitingForInput)
+	svc := createTestService(repo, newMockStepGetter(), newMockTaskRepo())
+	svc.registerBackgroundWork(sessionID, "background-old", executionID, "work-old")
+
+	svc.handleAgentStopped(t.Context(), watcher.AgentEventData{
+		TaskID: taskID, SessionID: sessionID, AgentExecutionID: executionID,
+	})
+	svc.handleAgentStreamEvent(t.Context(), &lifecycle.AgentStreamEventPayload{
+		TaskID: taskID, SessionID: sessionID, ExecutionID: executionID,
+		Data: &lifecycle.AgentStreamEventData{
+			Type:       agentEventToolCall,
+			ToolCallID: "late-tool",
+			ToolStatus: "in_progress",
+		},
+	})
+
+	if _, ok := turnActivityRecord(t, svc, sessionID); ok {
+		t.Fatal("late stopped-execution frame recreated retired activity")
+	}
+}
+
 func TestExecutionCleanup_DelayedPublicationCannotOverwriteSuccessorActivity(t *testing.T) {
 	repo := setupTestRepo(t)
 	const taskID, sessionID = "task-cleanup-race", "session-cleanup-race"
@@ -374,8 +522,10 @@ func TestExecutionCleanup_DelayedPublicationCannotOverwriteSuccessorActivity(t *
 	cleanupMutated := make(chan struct{})
 	releaseCleanupPublish := make(chan struct{})
 	cleanupDone := make(chan struct{})
+	retiredActivity := make(chan *turnActivity, 1)
 	go func() {
-		publication, changed := svc.clearExecutionBackgroundWorkSnapshot(sessionID, "execution-old")
+		publication, changed := svc.retireExecutionActivitySnapshot(sessionID, "execution-old")
+		retiredActivity <- publication.activity
 		if !changed {
 			close(cleanupMutated)
 			close(cleanupDone)
@@ -390,6 +540,13 @@ func TestExecutionCleanup_DelayedPublicationCannotOverwriteSuccessorActivity(t *
 
 	svc.registerBackgroundWork(sessionID, "tool-new", "execution-new", "work-new")
 	svc.markForegroundIdle(sessionID)
+	current, ok := turnActivityRecord(t, svc, sessionID)
+	if !ok {
+		t.Fatal("successor registration did not create an activity record")
+	}
+	if current == <-retiredActivity {
+		t.Fatal("successor mutated the predecessor activity record after it was retired")
+	}
 	svc.publishForegroundActivityChanged(t.Context(), taskID, sessionID)
 	close(releaseCleanupPublish)
 	<-cleanupDone
@@ -410,6 +567,179 @@ func TestExecutionCleanup_DelayedPublicationCannotOverwriteSuccessorActivity(t *
 	}
 }
 
+func TestExecutionCleanup_PublicationDeliveryIsOrderedAcrossRecordGenerations(t *testing.T) {
+	repo := setupTestRepo(t)
+	const taskID, sessionID = "task-delivery-race", "session-delivery-race"
+	seedTaskAndSession(t, repo, taskID, sessionID, models.TaskSessionStateWaitingForInput)
+	svc := createTestService(repo, newMockStepGetter(), newMockTaskRepo())
+	recorded := &recordingEventBus{}
+	blocking := &blockingRetirementEventBus{
+		recordingEventBus: recorded,
+		retirementEntered: make(chan struct{}),
+		releaseRetirement: make(chan struct{}),
+	}
+	svc.eventBus = blocking
+	svc.registerBackgroundWork(sessionID, "tool-old", "execution-old", "work-old")
+	svc.markForegroundIdle(sessionID)
+
+	publication, changed := svc.retireExecutionActivitySnapshot(sessionID, "execution-old")
+	if !changed {
+		t.Fatal("final execution retirement did not create a publication")
+	}
+	retirementDone := make(chan struct{})
+	go func() {
+		svc.publishForegroundActivitySnapshot(t.Context(), taskID, sessionID, publication)
+		close(retirementDone)
+	}()
+	<-blocking.retirementEntered
+
+	svc.registerBackgroundWorkKind(
+		sessionID,
+		"tool-new",
+		"execution-new",
+		"work-new",
+		streams.BackgroundWorkKindSubagent,
+	)
+	svc.markForegroundIdle(sessionID)
+	successorDone := make(chan struct{})
+	go func() {
+		svc.publishForegroundActivityChanged(t.Context(), taskID, sessionID)
+		close(successorDone)
+	}()
+
+	// The predecessor has passed identity validation and is blocked in delivery.
+	// A successor publication must queue behind that delivery even though it owns
+	// a different turnActivity record.
+	select {
+	case <-successorDone:
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(blocking.releaseRetirement)
+	<-retirementDone
+	<-successorDone
+
+	var values []interface{}
+	var counts []int
+	for _, record := range recorded.events {
+		if record.subject != eventtypes.TaskSessionActivityChanged {
+			continue
+		}
+		data, _ := record.event.Data.(map[string]interface{})
+		values = append(values, data["foreground_activity"])
+		counts = append(counts, data["active_subagent_count"].(int))
+	}
+	want := []interface{}{nil, string(v1.ForegroundActivityBackground)}
+	if !slices.Equal(values, want) {
+		t.Fatalf("cross-generation publications = %#v, want %#v", values, want)
+	}
+	if !slices.Equal(counts, []int{0, 1}) {
+		t.Fatalf("cross-generation subagent counts = %v, want [0 1]", counts)
+	}
+	svc.activityPublicationGuardsMu.Lock()
+	guardCount := len(svc.activityPublicationGuards)
+	svc.activityPublicationGuardsMu.Unlock()
+	if guardCount != 0 {
+		t.Fatalf("publication guard registry retained %d idle entries", guardCount)
+	}
+}
+
+func TestExecutionCleanup_PreservesSuccessorPromptClaimAndGeneration(t *testing.T) {
+	const (
+		sessionID    = "session-successor-claim"
+		oldExecution = "execution-old"
+		newExecution = "execution-new"
+	)
+	svc := createTestService(setupTestRepo(t), newMockStepGetter(), newMockTaskRepo())
+	svc.registerBackgroundWork(sessionID, "old-work", oldExecution, "work-old")
+	svc.markForegroundIdle(sessionID)
+
+	claim := svc.claimForegroundTurn(sessionID)
+	if claim == nil {
+		t.Fatal("successor prompt did not claim predecessor background-idle activity")
+	}
+	svc.retireExecutionActivitySnapshot(sessionID, oldExecution)
+	if !svc.isForegroundClaimCurrent(sessionID, claim) {
+		t.Fatal("predecessor cleanup invalidated the successor prompt claim")
+	}
+
+	dispatch := svc.beginForegroundDispatch(sessionID, claim, newExecution)
+	if dispatch == nil {
+		t.Fatal("successor prompt claim could not establish its prompt generation")
+	}
+	if dispatch.generation == 0 {
+		t.Fatal("successor prompt generation was not advanced")
+	}
+	svc.acceptForegroundDispatch(dispatch)
+
+	ta := svc.lockTurnActivity(sessionID, false)
+	if ta == nil {
+		t.Fatal("predecessor cleanup retired the successor-owned activity record")
+	}
+	defer ta.mu.Unlock()
+	if _, ok := ta.executionClaims[newExecution]; !ok {
+		t.Fatalf("successor execution %q did not retain its activity claim", newExecution)
+	}
+	if ta.promptCycleGeneration != dispatch.generation {
+		t.Fatalf("prompt generation = %d, want %d", ta.promptCycleGeneration, dispatch.generation)
+	}
+}
+
+func TestExecutionCleanup_RetiresRecordAfterSuccessorClaimIsAbandoned(t *testing.T) {
+	const (
+		sessionID    = "session-abandoned-successor-claim"
+		oldExecution = "execution-old"
+	)
+	svc := createTestService(setupTestRepo(t), newMockStepGetter(), newMockTaskRepo())
+	svc.registerBackgroundWork(sessionID, "old-work", oldExecution, "work-old")
+	svc.markForegroundIdle(sessionID)
+
+	claim := svc.claimForegroundTurn(sessionID)
+	if claim == nil {
+		t.Fatal("successor prompt did not claim predecessor background-idle activity")
+	}
+	svc.retireExecutionActivitySnapshot(sessionID, oldExecution)
+	if svc.releaseForegroundClaim(claim) {
+		t.Fatal("abandoned claim reopened background-idle without live background work")
+	}
+	if _, ok := turnActivityRecord(t, svc, sessionID); ok {
+		t.Fatal("abandoned successor claim retained an otherwise unused activity record")
+	}
+}
+
+func TestExecutionCleanup_RetiresRecordAfterDispatchAcceptReleasesLastToken(t *testing.T) {
+	const sessionID = "session-dispatch-accept-retirement"
+	svc := createTestService(setupTestRepo(t), newMockStepGetter(), newMockTaskRepo())
+	svc.registerBackgroundWork(sessionID, "old-work", "execution-old", "work-old")
+	dispatch := svc.beginForegroundDispatch(sessionID, nil)
+	if dispatch == nil {
+		t.Fatal("failed to begin successor dispatch")
+	}
+
+	svc.retireExecutionActivitySnapshot(sessionID, "execution-old")
+	svc.acceptForegroundDispatch(dispatch)
+
+	if _, ok := turnActivityRecord(t, svc, sessionID); ok {
+		t.Fatal("dispatch accept retained an ownerless record after terminal teardown")
+	}
+}
+
+func TestExecutionCleanup_RetiresRecordAfterDispatchRollbackReleasesLastToken(t *testing.T) {
+	const sessionID = "session-dispatch-rollback-retirement"
+	svc := createTestService(setupTestRepo(t), newMockStepGetter(), newMockTaskRepo())
+	svc.registerBackgroundWork(sessionID, "old-work", "execution-old", "work-old")
+	dispatch := svc.beginForegroundDispatch(sessionID, nil)
+	if dispatch == nil {
+		t.Fatal("failed to begin successor dispatch")
+	}
+
+	svc.retireExecutionActivitySnapshot(sessionID, "execution-old")
+	svc.rollbackForegroundDispatch(dispatch)
+
+	if _, ok := turnActivityRecord(t, svc, sessionID); ok {
+		t.Fatal("dispatch rollback retained an ownerless record after terminal teardown")
+	}
+}
+
 func TestExecutionCleanup_DelayedNullCannotOverwriteClaimlessSuccessorStart(t *testing.T) {
 	repo := setupTestRepo(t)
 	const taskID, sessionID = "task-cleanup-claimless-race", "session-cleanup-claimless-race"
@@ -424,7 +754,7 @@ func TestExecutionCleanup_DelayedNullCannotOverwriteClaimlessSuccessorStart(t *t
 	releaseCleanupPublish := make(chan struct{})
 	cleanupDone := make(chan struct{})
 	go func() {
-		publication, changed := svc.clearExecutionBackgroundWorkSnapshot(sessionID, "execution-old")
+		publication, changed := svc.retireExecutionActivitySnapshot(sessionID, "execution-old")
 		close(cleanupMutated)
 		if changed {
 			<-releaseCleanupPublish
@@ -516,7 +846,7 @@ func TestExecutionCleanup_AfterClaimlessBeginCannotCreateSuccessorNull(t *testin
 	releaseCleanupPublish := make(chan struct{})
 	cleanupDone := make(chan struct{})
 	go func() {
-		publication, changed := svc.clearExecutionBackgroundWorkSnapshot(sessionID, "execution-old")
+		publication, changed := svc.retireExecutionActivitySnapshot(sessionID, "execution-old")
 		close(cleanupMutated)
 		<-releaseCleanupPublish
 		if changed {
@@ -730,6 +1060,9 @@ func TestExecutionTerminalEvents_ReconcileMissingBackgroundCompletion(t *testing
 			if svc.hasBackgroundTask(sessionID, "tool-terminal") {
 				t.Fatal("terminal execution event left missing-completion registration behind")
 			}
+			if _, ok := turnActivityRecord(t, svc, sessionID); ok {
+				t.Fatal("terminal execution event retained the session activity record")
+			}
 			if got := countActivityClears(recorded); got != 1 {
 				t.Fatalf("terminal session activity clears = %d, want exactly one", got)
 			}
@@ -814,8 +1147,117 @@ func TestCleanupAgentExecution_ForcedPathIsOwnedAndIdempotent(t *testing.T) {
 	if got := countActivityClears(recorded); got != 1 {
 		t.Fatalf("forced final cleanup clears = %d, want exactly one", got)
 	}
+	if _, ok := turnActivityRecord(t, svc, sessionID); ok {
+		t.Fatal("forced final cleanup retained the session activity record")
+	}
 	if len(taskEvents.activityTaskIDs) != 1 || taskEvents.activityTaskIDs[0] != taskID {
 		t.Fatalf("forced cleanup task recomputes = %v, want [%s]", taskEvents.activityTaskIDs, taskID)
+	}
+	svc.handleAgentStreamEvent(t.Context(), &lifecycle.AgentStreamEventPayload{
+		TaskID: taskID, SessionID: sessionID, ExecutionID: "execution-new",
+		Data: &lifecycle.AgentStreamEventData{
+			Type: agentEventToolCall, ToolCallID: "late-forced-tool", ToolStatus: "in_progress",
+		},
+	})
+	if _, ok := turnActivityRecord(t, svc, sessionID); ok {
+		t.Fatal("late forced-cleanup frame recreated the retired activity record")
+	}
+}
+
+func TestClearTurnActivity_InvalidatesOutstandingTokensAndIsIdempotent(t *testing.T) {
+	const sessionID = "session-delete-activity"
+	svc := createTestService(setupTestRepo(t), newMockStepGetter(), newMockTaskRepo())
+	svc.registerBackgroundWork(sessionID, "work", "execution", "work")
+	svc.markForegroundIdle(sessionID)
+	claim := svc.claimForegroundTurn(sessionID)
+	if claim == nil {
+		t.Fatal("failed to create foreground claim")
+	}
+
+	svc.clearTurnActivity(sessionID)
+	svc.clearTurnActivity(sessionID)
+
+	if svc.releaseForegroundClaim(claim) {
+		t.Fatal("deleted activity record accepted a stale foreground claim")
+	}
+	if _, ok := turnActivityRecord(t, svc, sessionID); ok {
+		t.Fatal("repeated activity deletion recreated the record")
+	}
+}
+
+func TestDeleteSession_StopsLiveExecutionAndDropsLateFrames(t *testing.T) {
+	const (
+		taskID      = "task-delete-live"
+		sessionID   = "session-delete-live"
+		executionID = "execution-delete-live"
+	)
+	repo := setupTestRepo(t)
+	seedTaskAndSession(t, repo, taskID, sessionID, models.TaskSessionStateWaitingForInput)
+	manager := &mockAgentManager{
+		getExecutionIDForSessionFunc: func(context.Context, string) (string, error) {
+			return executionID, nil
+		},
+	}
+	svc := createTestServiceWithAgent(repo, newMockStepGetter(), newMockTaskRepo(), manager)
+	svc.executor = executor.NewExecutor(manager, repo, testLogger(), executor.ExecutorConfig{})
+	svc.registerBackgroundWork(sessionID, "background-live", executionID, "work-live")
+
+	if err := svc.DeleteSession(t.Context(), sessionID); err != nil {
+		t.Fatalf("DeleteSession: %v", err)
+	}
+	manager.mu.Lock()
+	stopCalls := append([]stopAgentCall(nil), manager.stopAgentWithReasonArgs...)
+	manager.mu.Unlock()
+	if len(stopCalls) != 1 || stopCalls[0] != (stopAgentCall{
+		ExecutionID: executionID,
+		Reason:      "session deleted",
+		Force:       true,
+	}) {
+		t.Fatalf("session deletion stop calls = %#v", stopCalls)
+	}
+
+	svc.handleAgentStreamEvent(t.Context(), &lifecycle.AgentStreamEventPayload{
+		TaskID: taskID, SessionID: sessionID, ExecutionID: executionID,
+		Data: &lifecycle.AgentStreamEventData{
+			Type:       agentEventToolCall,
+			ToolCallID: "late-tool",
+			ToolStatus: "in_progress",
+		},
+	})
+	if _, ok := turnActivityRecord(t, svc, sessionID); ok {
+		t.Fatal("late deleted-session frame recreated activity")
+	}
+}
+
+func TestDeleteSession_StopFailurePreservesSessionAndActivity(t *testing.T) {
+	const (
+		taskID      = "task-delete-stop-failure"
+		sessionID   = "session-delete-stop-failure"
+		executionID = "execution-delete-stop-failure"
+	)
+	repo := setupTestRepo(t)
+	seedTaskAndSession(t, repo, taskID, sessionID, models.TaskSessionStateWaitingForInput)
+	manager := &mockAgentManager{
+		getExecutionIDForSessionFunc: func(context.Context, string) (string, error) {
+			return executionID, nil
+		},
+		stopAgentWithReasonErr: errors.New("runtime still active"),
+	}
+	svc := createTestServiceWithAgent(repo, newMockStepGetter(), newMockTaskRepo(), manager)
+	svc.executor = executor.NewExecutor(manager, repo, testLogger(), executor.ExecutorConfig{})
+	svc.registerBackgroundWork(sessionID, "background-live", executionID, "work-live")
+
+	if err := svc.DeleteSession(t.Context(), sessionID); err == nil {
+		t.Fatal("DeleteSession succeeded while its live execution could not be stopped")
+	}
+	if _, err := repo.GetTaskSession(t.Context(), sessionID); err != nil {
+		t.Fatalf("session was deleted after stop failure: %v", err)
+	}
+	if !svc.hasBackgroundTask(sessionID, "background-live") {
+		t.Fatal("stop failure retired activity still owned by the live execution")
+	}
+	if svc.isExecutionCompleted(sessionID, executionID) {
+		t.Fatal("stop failure terminal-marked a still-live execution")
 	}
 }
 
@@ -916,7 +1358,7 @@ func TestBackgroundActivity_UnknownToolUpdatePreservesActivity(t *testing.T) {
 // initial tool_call is the only frame handleToolCallEvent sees before
 // hasBackgroundTask starts short-circuiting later updates, so it must carry
 // the launching execution ID itself. Without that, execution teardown
-// (clearExecutionBackgroundWorkSnapshot, keyed by executionID) can never
+// (retireExecutionActivitySnapshot, keyed by executionID) can never
 // match this registration, and the session reports background-running
 // forever even after its execution has died.
 func TestBackgroundWork_RegisteredFromInitialToolCallIsRetiredOnExecutionTeardown(t *testing.T) {

--- a/apps/backend/internal/orchestrator/background_work_accounting_test.go
+++ b/apps/backend/internal/orchestrator/background_work_accounting_test.go
@@ -390,6 +390,43 @@ func TestExecutionTeardown_StaleToolOwnershipIsNotVisibleToReusedSuccessorID(t *
 	}
 }
 
+func TestToolOwnership_EmptyIDDoesNotLeakActivityLock(t *testing.T) {
+	for _, testCase := range []struct {
+		name string
+		call func(*Service, string)
+	}{
+		{
+			name: "lookup",
+			call: func(svc *Service, sessionID string) {
+				svc.toolOwnership(sessionID, "", "execution")
+			},
+		},
+		{
+			name: "clear",
+			call: func(svc *Service, sessionID string) {
+				svc.clearToolOwnership(sessionID, "", "execution")
+			},
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			const sessionID = "session-empty-tool-id"
+			svc := createTestService(setupTestRepo(t), newMockStepGetter(), newMockTaskRepo())
+			svc.recordToolOwnership(sessionID, "real-tool", "execution", toolOwnershipForeground)
+
+			testCase.call(svc, sessionID)
+
+			activity, ok := turnActivityRecord(t, svc, sessionID)
+			if !ok {
+				t.Fatal("tool ownership precondition did not create activity")
+			}
+			if !activity.mu.TryLock() {
+				t.Fatal("empty tool ID returned while retaining the activity lock")
+			}
+			activity.mu.Unlock()
+		})
+	}
+}
+
 func TestExecutionStop_RetiresOnlyOwnedBackgroundWorkAndPublishesFinalTransition(t *testing.T) {
 	ctx := context.Background()
 	repo := setupTestRepo(t)
@@ -1258,6 +1295,38 @@ func TestDeleteSession_StopFailurePreservesSessionAndActivity(t *testing.T) {
 	}
 	if svc.isExecutionCompleted(sessionID, executionID) {
 		t.Fatal("stop failure terminal-marked a still-live execution")
+	}
+}
+
+func TestDeleteSession_AlreadyMissingRuntimeStillDeletesSession(t *testing.T) {
+	const (
+		taskID      = "task-delete-runtime-gone"
+		sessionID   = "session-delete-runtime-gone"
+		executionID = "execution-delete-runtime-gone"
+	)
+	repo := setupTestRepo(t)
+	seedTaskAndSession(t, repo, taskID, sessionID, models.TaskSessionStateWaitingForInput)
+	manager := &mockAgentManager{
+		getExecutionIDForSessionFunc: func(context.Context, string) (string, error) {
+			return executionID, nil
+		},
+		stopAgentWithReasonErr: lifecycle.ErrExecutionNotFound,
+	}
+	svc := createTestServiceWithAgent(repo, newMockStepGetter(), newMockTaskRepo(), manager)
+	svc.executor = executor.NewExecutor(manager, repo, testLogger(), executor.ExecutorConfig{})
+	svc.registerBackgroundWork(sessionID, "background-stale", executionID, "work-stale")
+
+	if err := svc.DeleteSession(t.Context(), sessionID); err != nil {
+		t.Fatalf("DeleteSession with already-missing runtime: %v", err)
+	}
+	if _, err := repo.GetTaskSession(t.Context(), sessionID); err == nil {
+		t.Fatal("session remained after its runtime was already gone")
+	}
+	if _, ok := turnActivityRecord(t, svc, sessionID); ok {
+		t.Fatal("already-missing runtime left stale activity after session deletion")
+	}
+	if !svc.isExecutionCompleted(sessionID, executionID) {
+		t.Fatal("already-missing runtime was not terminal-marked before deletion")
 	}
 }
 

--- a/apps/backend/internal/orchestrator/event_handlers_agent.go
+++ b/apps/backend/internal/orchestrator/event_handlers_agent.go
@@ -636,10 +636,9 @@ func (s *Service) handleAgentCompletedLocked(ctx context.Context, data watcher.A
 		zap.String("agent_execution_id", data.AgentExecutionID))
 
 	s.markExecutionCompleted(data.SessionID, data.AgentExecutionID)
-	// agent.completed is terminal for this lifecycle execution. Any detached
-	// registrations it still owns can no longer produce a trustworthy completion
-	// frame, so reconcile them before evaluating successor workflow state.
-	s.clearExecutionBackgroundWorkAndPublish(
+	// agent.completed is terminal for this lifecycle execution. Retire its
+	// activity ownership before evaluating successor workflow state.
+	s.retireExecutionActivityAndPublish(
 		context.WithoutCancel(ctx), data.TaskID, data.SessionID, data.AgentExecutionID,
 	)
 
@@ -761,16 +760,16 @@ func (s *Service) handleAgentFailedLocked(ctx context.Context, data watcher.Agen
 		zap.String("agent_execution_id", data.AgentExecutionID),
 		zap.String("error_message", data.ErrorMessage))
 
+	s.markExecutionFailed(data.SessionID, data.AgentExecutionID)
 	if drop, _ := s.shouldDropSessionFailure(ctx, data, "agent.failed", true); drop {
 		// A dropped failure is still terminal for the execution named by the
-		// lifecycle event (commonly a rotated predecessor). Clear only that
-		// execution's detached registrations; successor work remains untouched.
-		s.clearExecutionBackgroundWorkAndPublish(
+		// lifecycle event (commonly a rotated predecessor). Retire only that
+		// execution's activity; successor ownership remains untouched.
+		s.retireExecutionActivityAndPublish(
 			context.WithoutCancel(ctx), data.TaskID, data.SessionID, data.AgentExecutionID,
 		)
 		return
 	}
-	s.markExecutionFailed(data.SessionID, data.AgentExecutionID)
 
 	// Transient provider errors (529 Overloaded) get a paced, visible
 	// retry-with-backoff before any red banner. This is the ONLY non-terminal
@@ -784,9 +783,9 @@ func (s *Service) handleAgentFailedLocked(ctx context.Context, data watcher.Agen
 	}
 
 	// All paths below are terminal for this execution (resume recovery included).
-	// A transient retry returned above and retains its registrations until its
-	// execution is actually stopped.
-	s.clearExecutionBackgroundWorkAndPublish(
+	// A transient retry returned above and retains activity until its execution
+	// is actually stopped.
+	s.retireExecutionActivityAndPublish(
 		context.WithoutCancel(ctx), data.TaskID, data.SessionID, data.AgentExecutionID,
 	)
 
@@ -1342,10 +1341,14 @@ func (s *Service) handleAgentStopped(ctx context.Context, data watcher.AgentEven
 		zap.String("session_id", data.SessionID),
 		zap.String("agent_execution_id", data.AgentExecutionID))
 
+	// Stopped executions never own a valid trailing stream completion. Mark the
+	// exact lifecycle terminal before detaching activity so buffered frames
+	// cannot recreate ownership after teardown.
+	s.markExecutionFailed(data.SessionID, data.AgentExecutionID)
 	// Reconcile before the rotated-execution guard: a late stop from an old
-	// execution must clear only that execution's registrations while preserving
-	// background work already registered by its successor.
-	s.clearExecutionBackgroundWorkAndPublish(
+	// execution must retire only that execution's activity while preserving
+	// ownership already claimed by its successor.
+	s.retireExecutionActivityAndPublish(
 		context.WithoutCancel(ctx), data.TaskID, data.SessionID, data.AgentExecutionID,
 	)
 
@@ -1420,9 +1423,15 @@ func (s *Service) cleanupAgentExecution(executionID, taskID, sessionID string) {
 		return
 	}
 	ctx := context.Background()
-	// Defensive terminal-boundary reconciliation. Normal lifecycle events clear
-	// first; this covers direct forced cleanup paths and is idempotent.
-	s.clearExecutionBackgroundWorkAndPublish(ctx, taskID, sessionID, executionID)
+	if !s.isExecutionCompleted(sessionID, executionID) {
+		// Direct crash/forced-cleanup callers may reach this boundary without a
+		// preceding lifecycle event. Preserve an existing completed marker (and
+		// its allowed terminal stream), otherwise tombstone trailing frames.
+		s.markExecutionFailed(sessionID, executionID)
+	}
+	// Defensive terminal-boundary retirement. Normal lifecycle events run this
+	// first; the repeated forced-cleanup call is idempotent.
+	s.retireExecutionActivityAndPublish(ctx, taskID, sessionID, executionID)
 	if err := s.executor.StopExecution(ctx, executionID, "agent completed", true); err != nil {
 		s.logger.Debug("agent execution cleanup after terminal state",
 			zap.String("execution_id", executionID),

--- a/apps/backend/internal/orchestrator/event_handlers_streaming.go
+++ b/apps/backend/internal/orchestrator/event_handlers_streaming.go
@@ -1198,11 +1198,33 @@ func (s *Service) markTerminalExecution(sessionID, executionID string, allowComp
 	}
 	key := terminalExecutionKey(sessionID, executionID)
 	expiresAt := time.Now().Add(completedExecutionRetention)
-	s.completedExecutions.Store(key, terminalExecutionMarker{
+	candidate := terminalExecutionMarker{
 		expiresAt:           expiresAt,
 		allowCompleteStream: allowCompleteStream,
 		turnID:              s.currentTurnIDForSession(context.Background(), sessionID),
-	})
+	}
+	for {
+		value, loaded := s.completedExecutions.LoadOrStore(key, candidate)
+		if !loaded {
+			break
+		}
+		current, ok := value.(terminalExecutionMarker)
+		if !ok || time.Now().After(current.expiresAt) {
+			s.completedExecutions.CompareAndDelete(key, value)
+			continue
+		}
+		merged := candidate
+		if current.allowCompleteStream {
+			// Terminal stream permission is monotonic for an execution:
+			// StopExecution may emit agent.stopped after agent.completed but
+			// before the successful execution's buffered complete stream.
+			merged.allowCompleteStream = true
+			merged.turnID = current.turnID
+		}
+		if s.completedExecutions.CompareAndSwap(key, value, merged) {
+			break
+		}
+	}
 	time.AfterFunc(completedExecutionRetention, func() {
 		s.deleteCompletedExecutionIfExpired(key, expiresAt)
 	})

--- a/apps/backend/internal/orchestrator/event_handlers_streaming.go
+++ b/apps/backend/internal/orchestrator/event_handlers_streaming.go
@@ -316,14 +316,19 @@ func (s *Service) handleToolCallEvent(ctx context.Context, payload *lifecycle.Ag
 	} else if normalizedIsBackgroundTask(payload.Data.Normalized) {
 		ownership = toolOwnershipBackground
 	}
-	s.recordToolOwnership(payload.SessionID, payload.Data.ToolCallID, ownership)
+	s.recordToolOwnership(
+		payload.SessionID,
+		payload.Data.ToolCallID,
+		payload.ExecutionID,
+		ownership,
+	)
 
 	// A top-level spawned background task (subagent / run-in-background shell)
 	// holds the turn open while the foreground goes idle. A tool_call that
 	// already arrives terminal is not outstanding work — clearing is driven by
 	// tool_update, so registering it would leak into the hold and never clear.
 	if isTerminalToolStatus(payload.Data.ToolStatus) {
-		s.clearToolOwnership(payload.SessionID, payload.Data.ToolCallID)
+		s.clearToolOwnership(payload.SessionID, payload.Data.ToolCallID, payload.ExecutionID)
 		return
 	}
 	switch ownership {
@@ -332,7 +337,7 @@ func (s *Service) handleToolCallEvent(ctx context.Context, payload *lifecycle.Ag
 		// later tool_update path to backfill them never happens, because
 		// hasBackgroundTask short-circuits registration once the tool_call_id is
 		// already tracked. Without the execution ID here,
-		// clearExecutionBackgroundWorkSnapshot can never match this entry on
+		// retireExecutionActivitySnapshot can never match this entry on
 		// execution teardown, orphaning it if the execution dies before a
 		// terminal tool frame arrives.
 		kind := backgroundWorkKind(payload.Data.Normalized)
@@ -346,7 +351,7 @@ func (s *Service) handleToolCallEvent(ctx context.Context, payload *lifecycle.Ag
 			s.publishForegroundActivityChanged(ctx, payload.TaskID, payload.SessionID)
 		}
 	case toolOwnershipForeground:
-		if s.markForegroundGenerating(payload.SessionID) {
+		if s.markForegroundGenerating(payload.SessionID, payload.ExecutionID) {
 			s.publishForegroundActivityChanged(ctx, payload.TaskID, payload.SessionID)
 		}
 	}
@@ -455,7 +460,7 @@ func (s *Service) handleMessageStreamingEvent(ctx context.Context, payload *life
 	// even if a background task is still outstanding — narrows the busy signal.
 	// Only genuine output flips the state: an empty/invalid frame is discarded by
 	// handleStreamingEventKind, so it must not spuriously reclose the prompt gate.
-	if payload.Data.Text != "" && s.markForegroundGenerating(payload.SessionID) {
+	if payload.Data.Text != "" && s.markForegroundGenerating(payload.SessionID, payload.ExecutionID) {
 		s.publishForegroundActivityChanged(ctx, payload.TaskID, payload.SessionID)
 	}
 	s.handleStreamingEventKind(ctx, payload, "message",
@@ -469,7 +474,7 @@ func (s *Service) handleThinkingStreamingEvent(ctx context.Context, payload *lif
 	// Streamed foreground reasoning means the agent is actively generating again.
 	// Only genuine output flips the state — an empty/invalid frame is discarded
 	// downstream, so it must not spuriously reclose the prompt gate.
-	if payload.Data.Text != "" && s.markForegroundGenerating(payload.SessionID) {
+	if payload.Data.Text != "" && s.markForegroundGenerating(payload.SessionID, payload.ExecutionID) {
 		s.publishForegroundActivityChanged(ctx, payload.TaskID, payload.SessionID)
 	}
 	s.handleStreamingEventKind(ctx, payload, "thinking message",
@@ -490,7 +495,11 @@ func (s *Service) handleToolUpdateEvent(ctx context.Context, payload *lifecycle.
 	}
 	ownership := s.resolveToolUpdateOwnership(payload)
 	if isTerminalToolStatus(payload.Data.ToolStatus) {
-		defer s.clearToolOwnership(payload.SessionID, payload.Data.ToolCallID)
+		defer s.clearToolOwnership(
+			payload.SessionID,
+			payload.Data.ToolCallID,
+			payload.ExecutionID,
+		)
 	}
 	// A terminal update from a foreground tool can be the last substantive frame
 	// after the provider has already announced foreground-idle. Its output still
@@ -501,7 +510,7 @@ func (s *Service) handleToolUpdateEvent(ctx context.Context, payload *lifecycle.
 	if isTerminalToolStatus(payload.Data.ToolStatus) &&
 		len(payload.Data.ToolCallContents) > 0 &&
 		ownership == toolOwnershipForeground &&
-		s.markForegroundGenerating(payload.SessionID) {
+		s.markForegroundGenerating(payload.SessionID, payload.ExecutionID) {
 		s.publishForegroundActivityChanged(ctx, payload.TaskID, payload.SessionID)
 	}
 
@@ -630,11 +639,15 @@ func (s *Service) trackBackgroundToolUpdate(
 		}
 		return
 	}
-	if s.hasBackgroundTask(payload.SessionID, payload.Data.ToolCallID) {
+	if s.hasBackgroundTask(
+		payload.SessionID,
+		payload.Data.ToolCallID,
+		payload.ExecutionID,
+	) {
 		return
 	}
 	if ownership == toolOwnershipForeground {
-		if s.markForegroundGenerating(payload.SessionID) {
+		if s.markForegroundGenerating(payload.SessionID, payload.ExecutionID) {
 			s.publishForegroundActivityChanged(ctx, payload.TaskID, payload.SessionID)
 		}
 		return
@@ -666,14 +679,24 @@ func (s *Service) trackBackgroundToolUpdate(
 // preserves the current activity.
 func (s *Service) resolveToolUpdateOwnership(payload *lifecycle.AgentStreamEventPayload) toolOwnership {
 	if payload.Data.ParentToolCallID != "" {
-		s.recordToolOwnership(payload.SessionID, payload.Data.ToolCallID, toolOwnershipChild)
+		s.recordToolOwnership(
+			payload.SessionID,
+			payload.Data.ToolCallID,
+			payload.ExecutionID,
+			toolOwnershipChild,
+		)
 		return toolOwnershipChild
 	}
 	if normalizedIsBackgroundTask(payload.Data.Normalized) {
-		s.recordToolOwnership(payload.SessionID, payload.Data.ToolCallID, toolOwnershipBackground)
+		s.recordToolOwnership(
+			payload.SessionID,
+			payload.Data.ToolCallID,
+			payload.ExecutionID,
+			toolOwnershipBackground,
+		)
 		return toolOwnershipBackground
 	}
-	return s.toolOwnership(payload.SessionID, payload.Data.ToolCallID)
+	return s.toolOwnership(payload.SessionID, payload.Data.ToolCallID, payload.ExecutionID)
 }
 
 func backgroundWorkID(payload *streams.NormalizedPayload) string {

--- a/apps/backend/internal/orchestrator/event_handlers_streaming_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_streaming_test.go
@@ -1006,6 +1006,10 @@ func TestCompleteStreamFromCompletedExecutionFlushesAgentText(t *testing.T) {
 	firstTurn, err := svc.turnService.StartTurn(ctx, "s1")
 	require.NoError(t, err)
 	svc.markExecutionCompleted("s1", "exec-1")
+	// StopExecution can emit agent.stopped after agent.completed but before this
+	// buffered terminal stream. The stopped marker must not downgrade permission
+	// to flush the successful execution's final text and metadata.
+	svc.markExecutionFailed("s1", "exec-1")
 	svc.completeTurnForSession(ctx, "s1")
 	nextTurn, err := svc.turnService.StartTurn(ctx, "s1")
 	require.NoError(t, err)
@@ -1736,6 +1740,35 @@ func TestCompletedExecutionMarkerExpiresAndDeletes(t *testing.T) {
 	svc.deleteCompletedExecutionIfExpired(currentKey, laterExpiry)
 	_, ok = svc.completedExecutions.Load(currentKey)
 	require.False(t, ok, "matching expiry callback should delete the marker")
+}
+
+func TestTerminalExecutionMarker_CompletionPermissionIsMonotonic(t *testing.T) {
+	svc := &Service{}
+	const sessionID, executionID = "session-terminal-race", "execution-terminal-race"
+	key := terminalExecutionKey(sessionID, executionID)
+
+	for range 25 {
+		svc.completedExecutions.Delete(key)
+		start := make(chan struct{})
+		var wait sync.WaitGroup
+		wait.Add(2)
+		go func() {
+			defer wait.Done()
+			<-start
+			svc.markExecutionCompleted(sessionID, executionID)
+		}()
+		go func() {
+			defer wait.Done()
+			<-start
+			svc.markExecutionFailed(sessionID, executionID)
+		}()
+		close(start)
+		wait.Wait()
+
+		marker, ok := svc.terminalCompleteStreamMarker(sessionID, executionID)
+		require.True(t, ok, "concurrent stopped marker downgraded successful completion")
+		require.True(t, marker.allowCompleteStream)
+	}
 }
 
 // TestSetSessionRunning_NoRedundantTaskWrites locks in the dedup: when the

--- a/apps/backend/internal/orchestrator/event_handlers_transient.go
+++ b/apps/backend/internal/orchestrator/event_handlers_transient.go
@@ -238,6 +238,13 @@ func (s *Service) retryTransientPrompt(ctx context.Context, taskID, sessionID, e
 				zap.String("session_id", sessionID),
 				zap.String("execution_id", execID),
 				zap.Error(err))
+		} else {
+			s.retireExecutionActivityAndPublish(
+				context.WithoutCancel(ctx),
+				taskID,
+				sessionID,
+				execID,
+			)
 		}
 	}
 	if ctx.Err() != nil {

--- a/apps/backend/internal/orchestrator/event_handlers_transient.go
+++ b/apps/backend/internal/orchestrator/event_handlers_transient.go
@@ -238,14 +238,17 @@ func (s *Service) retryTransientPrompt(ctx context.Context, taskID, sessionID, e
 				zap.String("session_id", sessionID),
 				zap.String("execution_id", execID),
 				zap.Error(err))
-		} else {
-			s.retireExecutionActivityAndPublish(
-				context.WithoutCancel(ctx),
-				taskID,
-				sessionID,
-				execID,
-			)
 		}
+		// handleAgentFailed terminal-marked this exact execution before the
+		// retry was scheduled, so no later frame may reclaim activity even when
+		// runtime teardown times out. Retirement is safe and idempotent on both
+		// stop outcomes.
+		s.retireExecutionActivityAndPublish(
+			context.WithoutCancel(ctx),
+			taskID,
+			sessionID,
+			execID,
+		)
 	}
 	if ctx.Err() != nil {
 		return

--- a/apps/backend/internal/orchestrator/event_handlers_transient_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_transient_test.go
@@ -383,6 +383,13 @@ func TestRetryTransientPrompt_OwningStopSurvivesCoordinatorCancellation(t *testi
 	svc := newCoordinatorStopTestService(repo, taskRepo, agentManager)
 	retryCtx, cancelRetry := context.WithCancel(ctx)
 	svc.rememberTurnPrompt("session-retry-race", "retry me", "", false, nil)
+	svc.registerBackgroundWork(
+		"session-retry-race",
+		"orphaned-work",
+		"execution-retry-race",
+		"work",
+	)
+	svc.markForegroundIdle("session-retry-race")
 	svc.transientRetries.Store("session-retry-race", &transientRetryEntry{
 		attempt: 1,
 		cancel:  cancelRetry,
@@ -411,6 +418,8 @@ func TestRetryTransientPrompt_OwningStopSurvivesCoordinatorCancellation(t *testi
 	coordinatorStopAwaitSignal(t, retryDone, "transient retry completion")
 	require.Equal(t, int32(1), stopCalls.Load())
 	require.Empty(t, agentManager.capturedPromptCalls, "cancelled retry must not relaunch")
+	_, activityPresent := turnActivityRecord(t, svc, "session-retry-race")
+	require.False(t, activityPresent, "forced retry teardown retained predecessor activity")
 }
 
 func TestTransientRetryEntryClaimPreventsDoubleFire(t *testing.T) {

--- a/apps/backend/internal/orchestrator/event_handlers_transient_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_transient_test.go
@@ -422,6 +422,37 @@ func TestRetryTransientPrompt_OwningStopSurvivesCoordinatorCancellation(t *testi
 	require.False(t, activityPresent, "forced retry teardown retained predecessor activity")
 }
 
+func TestRetryTransientPrompt_StopFailureStillRetiresTerminalActivity(t *testing.T) {
+	repo := setupTestRepo(t)
+	const (
+		taskID      = "task-retry-stop-failure"
+		sessionID   = "session-retry-stop-failure"
+		executionID = "execution-retry-stop-failure"
+	)
+	seedTaskAndSession(t, repo, taskID, sessionID, models.TaskSessionStateWaitingForInput)
+	taskRepo := newMockTaskRepo()
+	seedMockTaskState(taskRepo, taskID, v1.TaskStateInProgress)
+	retryCtx, cancelRetry := context.WithCancel(t.Context())
+	agentManager := &mockAgentManager{
+		stopAgentWithReasonFunc: func(context.Context, string, string, bool) error {
+			cancelRetry()
+			return errors.New("runtime did not acknowledge stop")
+		},
+	}
+	svc := newCoordinatorStopTestService(repo, taskRepo, agentManager)
+	svc.rememberTurnPrompt(sessionID, "retry me", "", false, nil)
+	svc.registerBackgroundWork(sessionID, "orphaned-work", executionID, "work")
+	svc.markForegroundIdle(sessionID)
+	svc.markExecutionFailed(sessionID, executionID)
+
+	svc.retryTransientPrompt(retryCtx, taskID, sessionID, executionID)
+
+	if _, ok := turnActivityRecord(t, svc, sessionID); ok {
+		t.Fatal("failed transient stop retained terminal execution activity")
+	}
+	require.Empty(t, agentManager.capturedPromptCalls, "cancelled retry must not relaunch")
+}
+
 func TestTransientRetryEntryClaimPreventsDoubleFire(t *testing.T) {
 	entry := &transientRetryEntry{}
 	if !entry.claim() {

--- a/apps/backend/internal/orchestrator/execution_teardown_ownership_test.go
+++ b/apps/backend/internal/orchestrator/execution_teardown_ownership_test.go
@@ -119,6 +119,37 @@ func TestReapPromptUnreadyExecution_StopsOnlyWhenRecoveryOwnsExecution(t *testin
 	require.Zero(t, stopCalls.Load(), "recovery must not duplicate coordinator-owned teardown")
 }
 
+func TestReapPromptUnreadyExecution_RetiresActivityAfterForcedStop(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	const (
+		taskID      = "task-recovery-activity"
+		sessionID   = "session-recovery-activity"
+		executionID = "execution-recovery-activity"
+	)
+	seedTaskAndSession(t, repo, taskID, sessionID, models.TaskSessionStateWaitingForInput)
+
+	manager := &mockAgentManager{
+		getExecutionIDForSessionFunc: func(context.Context, string) (string, error) {
+			return executionID, nil
+		},
+		stopAgentWithReasonFunc: func(context.Context, string, string, bool) error {
+			return nil
+		},
+	}
+	svc := newCoordinatorStopTestService(repo, newMockTaskRepo(), manager)
+	svc.registerBackgroundWork(sessionID, "orphaned-work", executionID, "work")
+	svc.markForegroundIdle(sessionID)
+
+	require.NoError(t, svc.reapPromptUnreadyExecution(
+		ctx,
+		sessionID,
+		errors.New("agent never became prompt-ready"),
+	))
+	_, ok := turnActivityRecord(t, svc, sessionID)
+	require.False(t, ok, "forced prompt-readiness teardown retained activity")
+}
+
 func TestReapPromptUnreadyExecution_DoesNotResumeAfterConcurrentCancellation(t *testing.T) {
 	ctx := context.Background()
 	repo := setupTestRepo(t)

--- a/apps/backend/internal/orchestrator/service.go
+++ b/apps/backend/internal/orchestrator/service.go
@@ -450,7 +450,16 @@ type Service struct {
 	// (subagent / run-in-background shell). Keyed sessionID -> *turnActivity;
 	// see turn_activity.go. Consulted by checkSessionPromptable so a session
 	// that kicked off background work still accepts operator input.
-	foregroundActivity sync.Map
+	// foregroundActivityMu protects record identity: lookups lock the selected
+	// record before releasing it, and execution teardown uses the same order
+	// before detaching an unused record.
+	foregroundActivityMu sync.Mutex
+	foregroundActivity   map[string]*turnActivity
+	// activityPublicationGuards serialize validation and event delivery by
+	// session across turnActivity record generations. Entries are reference
+	// counted and reclaimed when the last publisher/retirer releases them.
+	activityPublicationGuardsMu sync.Mutex
+	activityPublicationGuards   map[string]*activityPublicationGuard
 
 	// taskRuntimeStateMu serializes task-state flips derived from session
 	// runtime state. Without it, a completion/cancel path can check for active

--- a/apps/backend/internal/orchestrator/task_operations.go
+++ b/apps/backend/internal/orchestrator/task_operations.go
@@ -2234,26 +2234,9 @@ func (s *Service) DeleteSession(ctx context.Context, sessionID string) error {
 	wasPrimary := session.IsPrimary
 
 	// A settled DB state can still own a workspace execution or detached
-	// background work. Quiesce the live lifecycle execution before removing the
-	// row, then tombstone its exact ID so buffered frames cannot recreate
-	// activity after deletion.
-	if s.agentManager != nil {
-		executionID, executionErr := s.agentManager.GetExecutionIDForSession(ctx, sessionID)
-		if executionErr == nil && executionID != "" {
-			if err := s.executor.StopExecution(ctx, executionID, "session deleted", true); err != nil {
-				if !errors.Is(err, agentruntime.ErrNotFound) {
-					return fmt.Errorf("failed to stop session execution before deletion: %w", err)
-				}
-				s.logger.Debug("session execution already absent during deletion",
-					zap.String("session_id", sessionID),
-					zap.String("agent_execution_id", executionID),
-					zap.Error(err))
-			}
-			s.markExecutionFailed(sessionID, executionID)
-			s.retireExecutionActivityAndPublish(
-				context.WithoutCancel(ctx), taskID, sessionID, executionID,
-			)
-		}
+	// background work. Quiesce that runtime boundary before removing the row.
+	if err := s.quiesceSessionExecutionBeforeDeletion(ctx, taskID, sessionID); err != nil {
+		return err
 	}
 
 	s.logger.Info("deleting session",
@@ -2285,6 +2268,39 @@ func (s *Service) DeleteSession(ctx context.Context, sessionID string) error {
 		s.promoteNextPrimaryAfterRemoval(ctx, taskID, sessionID)
 	}
 
+	return nil
+}
+
+// quiesceSessionExecutionBeforeDeletion stops the in-memory lifecycle
+// execution, if one exists, before a session row is removed. A runtime that
+// explicitly reports the exact execution as absent is already quiesced; other
+// stop failures preserve the row because detaching a possibly-live execution
+// would let trailing frames recreate activity after deletion.
+func (s *Service) quiesceSessionExecutionBeforeDeletion(
+	ctx context.Context,
+	taskID, sessionID string,
+) error {
+	if s.agentManager == nil {
+		return nil
+	}
+	executionID, executionErr := s.agentManager.GetExecutionIDForSession(ctx, sessionID)
+	if executionErr != nil || executionID == "" {
+		return nil
+	}
+	stopErr := s.executor.StopExecution(ctx, executionID, "session deleted", true)
+	if stopErr != nil && !errors.Is(stopErr, agentruntime.ErrNotFound) {
+		return fmt.Errorf("failed to stop session execution before deletion: %w", stopErr)
+	}
+	if stopErr != nil {
+		s.logger.Debug("session execution already absent during deletion",
+			zap.String("session_id", sessionID),
+			zap.String("agent_execution_id", executionID),
+			zap.Error(stopErr))
+	}
+	s.markExecutionFailed(sessionID, executionID)
+	s.retireExecutionActivityAndPublish(
+		context.WithoutCancel(ctx), taskID, sessionID, executionID,
+	)
 	return nil
 }
 

--- a/apps/backend/internal/orchestrator/task_operations.go
+++ b/apps/backend/internal/orchestrator/task_operations.go
@@ -1608,7 +1608,18 @@ func (s *Service) reapPromptUnreadyExecution(ctx context.Context, sessionID stri
 	if err := s.executor.StopExecution(ctx, executionID, promptReadinessRecoveryStopReason, true); err != nil {
 		return err
 	}
+	s.markExecutionFailed(sessionID, executionID)
 	refreshed, err := s.repo.GetTaskSession(ctx, sessionID)
+	taskID := ""
+	if refreshed != nil {
+		taskID = refreshed.TaskID
+	}
+	s.retireExecutionActivityAndPublish(
+		context.WithoutCancel(ctx),
+		taskID,
+		sessionID,
+		executionID,
+	)
 	if err != nil {
 		return fmt.Errorf("reload session after prompt-readiness teardown: %w", err)
 	}
@@ -2202,6 +2213,10 @@ func (s *Service) DeleteSession(ctx context.Context, sessionID string) error {
 	if err := s.authorizeSession(ctx, sessionID); err != nil {
 		return err
 	}
+	lock, release := s.acquireCancelInFlightGuard(sessionID)
+	defer release()
+	lock.Lock()
+	defer lock.Unlock()
 
 	session, err := s.repo.GetTaskSession(ctx, sessionID)
 	if err != nil {
@@ -2216,6 +2231,23 @@ func (s *Service) DeleteSession(ctx context.Context, sessionID string) error {
 
 	taskID := session.TaskID
 	wasPrimary := session.IsPrimary
+
+	// A settled DB state can still own a workspace execution or detached
+	// background work. Quiesce the live lifecycle execution before removing the
+	// row, then tombstone its exact ID so buffered frames cannot recreate
+	// activity after deletion.
+	if s.agentManager != nil {
+		executionID, executionErr := s.agentManager.GetExecutionIDForSession(ctx, sessionID)
+		if executionErr == nil && executionID != "" {
+			if err := s.executor.StopExecution(ctx, executionID, "session deleted", true); err != nil {
+				return fmt.Errorf("failed to stop session execution before deletion: %w", err)
+			}
+			s.markExecutionFailed(sessionID, executionID)
+			s.retireExecutionActivityAndPublish(
+				context.WithoutCancel(ctx), taskID, sessionID, executionID,
+			)
+		}
+	}
 
 	s.logger.Info("deleting session",
 		zap.String("session_id", sessionID),
@@ -2235,10 +2267,10 @@ func (s *Service) DeleteSession(ctx context.Context, sessionID string) error {
 	// Same reasoning for the push-detection tracker. Multi-repo sessions
 	// accumulate one entry per repo; pushTrackerForget walks them all.
 	s.pushTrackerForget(sessionID)
-	// And the foreground/background turn-activity signal. It is normally cleared
-	// at turn close, but a trailing stream event can re-create the entry after
-	// the last turn completed; forget it here so a deleted session leaves no
-	// orphaned map slot.
+	// And the foreground/background turn-activity signal. Execution teardown
+	// normally retires it after the final owner exits; deletion forcibly
+	// invalidates any trailing token so the removed session cannot be recreated
+	// through a stale activity pointer.
 	s.clearTurnActivity(sessionID)
 
 	// Auto-promote another session if we deleted the primary
@@ -2704,7 +2736,12 @@ func (s *Service) promptTask(ctx context.Context, taskID, sessionID string, prom
 		// Re-apply transforms in case metadata changed during ensureSessionRunning.
 		effectivePrompt = s.effectivePromptForSession(sessionID, prompt, planMode, session)
 	}
-	foregroundDispatch := s.beginForegroundDispatch(sessionID, foregroundClaim)
+	activityExecutionID, _ := s.agentManager.GetExecutionIDForSession(ctx, sessionID)
+	foregroundDispatch := s.beginForegroundDispatch(
+		sessionID,
+		foregroundClaim,
+		activityExecutionID,
+	)
 	if foregroundDispatch == nil {
 		s.releaseForegroundClaimOnFailure(ctx, taskID, sessionID, foregroundClaim)
 		return nil, fmt.Errorf("%w, please wait for completion", ErrAgentPromptInProgress)

--- a/apps/backend/internal/orchestrator/task_operations.go
+++ b/apps/backend/internal/orchestrator/task_operations.go
@@ -14,6 +14,7 @@ import (
 
 	"go.uber.org/zap"
 
+	agentruntime "github.com/kandev/kandev/internal/agent/runtime"
 	"github.com/kandev/kandev/internal/agent/runtime/agentctl"
 	"github.com/kandev/kandev/internal/agent/runtime/lifecycle"
 	"github.com/kandev/kandev/internal/agent/runtime/routingerr"
@@ -2240,7 +2241,13 @@ func (s *Service) DeleteSession(ctx context.Context, sessionID string) error {
 		executionID, executionErr := s.agentManager.GetExecutionIDForSession(ctx, sessionID)
 		if executionErr == nil && executionID != "" {
 			if err := s.executor.StopExecution(ctx, executionID, "session deleted", true); err != nil {
-				return fmt.Errorf("failed to stop session execution before deletion: %w", err)
+				if !errors.Is(err, agentruntime.ErrNotFound) {
+					return fmt.Errorf("failed to stop session execution before deletion: %w", err)
+				}
+				s.logger.Debug("session execution already absent during deletion",
+					zap.String("session_id", sessionID),
+					zap.String("agent_execution_id", executionID),
+					zap.Error(err))
 			}
 			s.markExecutionFailed(sessionID, executionID)
 			s.retireExecutionActivityAndPublish(

--- a/apps/backend/internal/orchestrator/turn_activity.go
+++ b/apps/backend/internal/orchestrator/turn_activity.go
@@ -261,8 +261,11 @@ func (s *Service) recordToolOwnership(
 }
 
 func (s *Service) toolOwnership(sessionID, toolCallID, executionID string) toolOwnership {
+	if toolCallID == "" {
+		return toolOwnershipUnknown
+	}
 	ta := s.lockTurnActivity(sessionID, false)
-	if ta == nil || toolCallID == "" {
+	if ta == nil {
 		return toolOwnershipUnknown
 	}
 	defer ta.mu.Unlock()
@@ -274,8 +277,11 @@ func (s *Service) toolOwnership(sessionID, toolCallID, executionID string) toolO
 }
 
 func (s *Service) clearToolOwnership(sessionID, toolCallID, executionID string) {
+	if toolCallID == "" {
+		return
+	}
 	ta := s.lockTurnActivity(sessionID, false)
-	if ta == nil || toolCallID == "" {
+	if ta == nil {
 		return
 	}
 	defer ta.mu.Unlock()

--- a/apps/backend/internal/orchestrator/turn_activity.go
+++ b/apps/backend/internal/orchestrator/turn_activity.go
@@ -30,12 +30,27 @@ import (
 // session that has no background work outstanding.
 type turnActivity struct {
 	mu            sync.Mutex
-	publishMu     sync.Mutex                // serializes event/task publication for this session
 	revision      uint64                    // invalidates delayed publications after newer mutations
 	background    map[string]backgroundWork // outstanding work keyed by launch tool-call ID
-	tools         map[string]toolOwnership  // activity ownership established by the initial tool call
-	yielded       bool                      // foreground handed off to background work
-	backgroundSeq uint64                    // next sequence number for a new background registration
+	tools         map[string]toolOwnershipRecord
+	yielded       bool   // foreground handed off to background work
+	backgroundSeq uint64 // next sequence number for a new background registration
+
+	// executionClaims records every execution that has positively claimed this
+	// record through prompt dispatch, tool ownership, or background registration.
+	// Terminal cleanup removes its own claim and detaches the record only when no
+	// other execution or in-flight prompt token still uses it.
+	executionClaims map[string]struct{}
+
+	// dispatchInFlight protects the record between prompt-cycle creation and
+	// agentctl's accept/rollback callback. A successor can hold this pointer
+	// before its execution emits a stream frame; teardown must treat that token
+	// as live use even when no execution ID was available at admission time.
+	dispatchInFlightGeneration uint64
+	// retireWhenUnused records that terminal teardown found no execution-owned
+	// state but could not detach this record because an admission/dispatch token
+	// still held its pointer. Releasing the last token must finish retirement.
+	retireWhenUnused bool
 
 	// promptInFlight marks an admitted prompt that has claimed the foreground turn
 	// but has not yet been handed to the agent. It is deliberately independent of
@@ -86,10 +101,32 @@ const (
 	toolOwnershipChild
 )
 
+// toolOwnershipRecord binds the initial tool-call classification to the
+// execution that supplied it. Provider-local tool IDs may be reused after an
+// execution rotates, so lookups and terminal clears must match both identities.
+type toolOwnershipRecord struct {
+	executionID string
+	ownership   toolOwnership
+}
+
 type activityPublication struct {
-	activity *turnActivity
-	revision uint64
-	value    interface{}
+	activity            *turnActivity
+	revision            uint64
+	value               interface{}
+	activeSubagentCount int
+	retired             bool
+}
+
+type activityPublicationGuard struct {
+	mu   sync.Mutex
+	refs int
+}
+
+type executionActivityRetirement struct {
+	removed         bool
+	removedSubagent bool
+	finalTransition bool
+	retireRecord    bool
 }
 
 type foregroundYieldSource uint8
@@ -103,6 +140,7 @@ const (
 // it claimed. The foreground epoch separately detects output that makes a failed
 // prompt's background-idle restoration stale.
 type foregroundClaim struct {
+	sessionID       string
 	activity        *turnActivity
 	claimGeneration uint64
 	foregroundEpoch uint64
@@ -113,6 +151,7 @@ type foregroundClaim struct {
 // dispatch may restore the predecessor only while this exact, unobserved cycle
 // is still current.
 type foregroundDispatch struct {
+	sessionID             string
 	activity              *turnActivity
 	generation            uint64
 	foregroundEpoch       uint64
@@ -122,54 +161,146 @@ type foregroundDispatch struct {
 	accepted              bool
 }
 
-// turnActivityFor returns the per-session activity record, creating it when
-// create is true. Returns nil when the record is absent and create is false.
-func (s *Service) turnActivityFor(sessionID string, create bool) *turnActivity {
-	if v, ok := s.foregroundActivity.Load(sessionID); ok {
-		return v.(*turnActivity)
+// lockTurnActivity couples record lookup with the record lock. The map guard is
+// not released until the selected record is locked, so execution retirement
+// cannot detach a record after a successor loaded its pointer but before that
+// successor begins mutating it. Every mapped-record access must use this helper
+// (or lockTurnActivityToken for a previously-issued claim/dispatch token).
+func (s *Service) lockTurnActivity(sessionID string, create bool) *turnActivity {
+	s.foregroundActivityMu.Lock()
+	if ta, ok := s.foregroundActivity[sessionID]; ok {
+		ta.mu.Lock()
+		s.foregroundActivityMu.Unlock()
+		return ta
 	}
 	if !create {
+		s.foregroundActivityMu.Unlock()
 		return nil
 	}
 	ta := &turnActivity{
-		background: make(map[string]backgroundWork),
-		tools:      make(map[string]toolOwnership),
+		background:      make(map[string]backgroundWork),
+		tools:           make(map[string]toolOwnershipRecord),
+		executionClaims: make(map[string]struct{}),
 	}
-	actual, _ := s.foregroundActivity.LoadOrStore(sessionID, ta)
-	return actual.(*turnActivity)
+	if s.foregroundActivity == nil {
+		s.foregroundActivity = make(map[string]*turnActivity)
+	}
+	s.foregroundActivity[sessionID] = ta
+	ta.mu.Lock()
+	s.foregroundActivityMu.Unlock()
+	return ta
 }
 
-func (s *Service) recordToolOwnership(sessionID, toolCallID string, ownership toolOwnership) {
+func (s *Service) lockTurnActivityToken(sessionID string, ta *turnActivity) bool {
+	if sessionID == "" || ta == nil {
+		return false
+	}
+	s.foregroundActivityMu.Lock()
+	current, ok := s.foregroundActivity[sessionID]
+	if !ok || current != ta {
+		s.foregroundActivityMu.Unlock()
+		return false
+	}
+	ta.mu.Lock()
+	s.foregroundActivityMu.Unlock()
+	return true
+}
+
+// acquireActivityPublicationGuard returns a stable per-session publication
+// mutex whose identity outlives any individual turnActivity record. Holding it
+// across snapshot validation and synchronous event delivery gives publications
+// from predecessor and successor record generations one linearization boundary:
+// either predecessor delivery completes first, or successor mutation invalidates
+// it before it can publish. The registry itself stays bounded by active users.
+func (s *Service) acquireActivityPublicationGuard(sessionID string) (*sync.Mutex, func()) {
+	s.activityPublicationGuardsMu.Lock()
+	guard, ok := s.activityPublicationGuards[sessionID]
+	if !ok {
+		guard = &activityPublicationGuard{}
+		if s.activityPublicationGuards == nil {
+			s.activityPublicationGuards = make(map[string]*activityPublicationGuard)
+		}
+		s.activityPublicationGuards[sessionID] = guard
+	}
+	guard.refs++
+	s.activityPublicationGuardsMu.Unlock()
+
+	var released bool
+	release := func() {
+		if released {
+			return
+		}
+		released = true
+		s.activityPublicationGuardsMu.Lock()
+		guard.refs--
+		if guard.refs == 0 {
+			delete(s.activityPublicationGuards, sessionID)
+		}
+		s.activityPublicationGuardsMu.Unlock()
+	}
+	return &guard.mu, release
+}
+
+func (s *Service) recordToolOwnership(
+	sessionID, toolCallID, executionID string,
+	ownership toolOwnership,
+) {
 	if sessionID == "" || toolCallID == "" || ownership == toolOwnershipUnknown {
 		return
 	}
-	ta := s.turnActivityFor(sessionID, true)
-	ta.mu.Lock()
+	ta := s.lockTurnActivity(sessionID, true)
+	defer ta.mu.Unlock()
 	if ta.tools == nil {
-		ta.tools = make(map[string]toolOwnership)
+		ta.tools = make(map[string]toolOwnershipRecord)
 	}
-	ta.tools[toolCallID] = ownership
-	ta.mu.Unlock()
+	ta.claimExecutionLocked(executionID)
+	ta.tools[toolCallID] = toolOwnershipRecord{
+		executionID: executionID,
+		ownership:   ownership,
+	}
 }
 
-func (s *Service) toolOwnership(sessionID, toolCallID string) toolOwnership {
-	ta := s.turnActivityFor(sessionID, false)
+func (s *Service) toolOwnership(sessionID, toolCallID, executionID string) toolOwnership {
+	ta := s.lockTurnActivity(sessionID, false)
 	if ta == nil || toolCallID == "" {
 		return toolOwnershipUnknown
 	}
-	ta.mu.Lock()
 	defer ta.mu.Unlock()
-	return ta.tools[toolCallID]
+	record := ta.tools[toolCallID]
+	if record.executionID != executionID {
+		return toolOwnershipUnknown
+	}
+	return record.ownership
 }
 
-func (s *Service) clearToolOwnership(sessionID, toolCallID string) {
-	ta := s.turnActivityFor(sessionID, false)
+func (s *Service) clearToolOwnership(sessionID, toolCallID, executionID string) {
+	ta := s.lockTurnActivity(sessionID, false)
 	if ta == nil || toolCallID == "" {
 		return
 	}
-	ta.mu.Lock()
-	delete(ta.tools, toolCallID)
-	ta.mu.Unlock()
+	defer ta.mu.Unlock()
+	if record := ta.tools[toolCallID]; record.executionID == executionID {
+		delete(ta.tools, toolCallID)
+	}
+}
+
+func (ta *turnActivity) claimExecutionLocked(executionID string) {
+	if executionID == "" {
+		return
+	}
+	if _, exists := ta.executionClaims[executionID]; exists {
+		return
+	}
+	ta.executionClaims[executionID] = struct{}{}
+	ta.revision++
+}
+
+func (ta *turnActivity) retireExecutionClaimLocked(executionID string) bool {
+	if _, exists := ta.executionClaims[executionID]; !exists {
+		return false
+	}
+	delete(ta.executionClaims, executionID)
+	return true
 }
 
 // markForegroundGenerating records that the foreground agent produced output
@@ -178,12 +309,15 @@ func (s *Service) clearToolOwnership(sessionID, toolCallID string) {
 // background task is still outstanding. It returns true when this call actually
 // flipped the session out of the background-idle substate, so the caller can
 // publish the operator-facing activity signal only on a real transition.
-func (s *Service) markForegroundGenerating(sessionID string) bool {
+func (s *Service) markForegroundGenerating(sessionID string, executionIDs ...string) bool {
 	if sessionID == "" {
 		return false
 	}
-	ta := s.turnActivityFor(sessionID, true)
-	ta.mu.Lock()
+	ta := s.lockTurnActivity(sessionID, true)
+	defer ta.mu.Unlock()
+	if len(executionIDs) > 0 {
+		ta.claimExecutionLocked(executionIDs[0])
+	}
 	changed := ta.yielded
 	ta.yielded = false
 	if changed {
@@ -193,7 +327,6 @@ func (s *Service) markForegroundGenerating(sessionID string) bool {
 	// outstanding claim's epoch, so a prompt that later fails cannot release the
 	// gate back open on top of a foreground that is now genuinely generating.
 	ta.foregroundEpoch++
-	ta.mu.Unlock()
 	return changed
 }
 
@@ -204,11 +337,10 @@ func (s *Service) markForegroundIdle(sessionID string) bool {
 	if sessionID == "" {
 		return false
 	}
-	ta := s.turnActivityFor(sessionID, false)
+	ta := s.lockTurnActivity(sessionID, false)
 	if ta == nil {
 		return false
 	}
-	ta.mu.Lock()
 	defer ta.mu.Unlock()
 	return ta.markForegroundIdleLocked()
 }
@@ -238,9 +370,11 @@ func (s *Service) yieldForegroundAndPublish(
 	// for an untracked session would otherwise pay a wasted GetTaskSession read
 	// (and risk a spurious Warn on failure) for a transition that can never
 	// publish. Bail before that read.
-	if s.turnActivityFor(sessionID, false) == nil {
+	ta := s.lockTurnActivity(sessionID, false)
+	if ta == nil {
 		return
 	}
+	ta.mu.Unlock()
 	if taskID == "" {
 		session, err := s.repo.GetTaskSession(ctx, sessionID)
 		if err != nil || session == nil {
@@ -258,11 +392,10 @@ func (s *Service) yieldForegroundAndPublish(
 }
 
 func (s *Service) transitionForegroundToBackground(sessionID string, source foregroundYieldSource) bool {
-	ta := s.turnActivityFor(sessionID, false)
+	ta := s.lockTurnActivity(sessionID, false)
 	if ta == nil {
 		return false
 	}
-	ta.mu.Lock()
 	defer ta.mu.Unlock()
 
 	if source == foregroundYieldProviderIdle {
@@ -299,7 +432,7 @@ func (s *Service) transitionForegroundToBackground(sessionID string, source fore
 // already known (e.g. from the initial tool_call event) rather than relying on
 // a later update to backfill them: hasBackgroundTask short-circuits
 // registration once the tool_call_id is tracked, so an empty executionID can
-// never be filled in afterward, and clearExecutionBackgroundWorkSnapshot can
+// never be filled in afterward, and retireExecutionActivitySnapshot can
 // then never retire the entry on execution teardown.
 func (s *Service) registerBackgroundWork(sessionID, toolCallID, executionID, workID string) {
 	s.registerBackgroundWorkKind(sessionID, toolCallID, executionID, workID, "")
@@ -312,8 +445,9 @@ func (s *Service) registerBackgroundWorkKind(
 	if sessionID == "" || toolCallID == "" {
 		return false
 	}
-	ta := s.turnActivityFor(sessionID, true)
-	ta.mu.Lock()
+	ta := s.lockTurnActivity(sessionID, true)
+	defer ta.mu.Unlock()
+	ta.claimExecutionLocked(executionID)
 	current, exists := ta.background[toolCallID]
 	updated := current
 	if executionID != "" {
@@ -338,7 +472,6 @@ func (s *Service) registerBackgroundWorkKind(
 		ta.revision++
 	}
 	ta.background[toolCallID] = updated
-	ta.mu.Unlock()
 	return changed
 }
 
@@ -346,12 +479,15 @@ func (s *Service) registerBackgroundWorkKind(
 // from the registration map. It is not maintained as an independent counter,
 // so duplicate and out-of-order completion cannot make it drift.
 func (s *Service) ActiveSubagentCount(sessionID string) int {
-	ta := s.turnActivityFor(sessionID, false)
+	ta := s.lockTurnActivity(sessionID, false)
 	if ta == nil {
 		return 0
 	}
-	ta.mu.Lock()
 	defer ta.mu.Unlock()
+	return ta.activeSubagentCountLocked()
+}
+
+func (ta *turnActivity) activeSubagentCountLocked() int {
 	count := 0
 	for _, work := range ta.background {
 		if work.kind == streams.BackgroundWorkKindSubagent {
@@ -366,15 +502,17 @@ func (s *Service) ActiveSubagentCount(sessionID string) int {
 // registration path fire only on the first recognizable frame: re-registering
 // on later updates would re-set `yielded` and clobber a foreground stream that
 // marked the turn generating again (see markForegroundGenerating).
-func (s *Service) hasBackgroundTask(sessionID, toolCallID string) bool {
-	ta := s.turnActivityFor(sessionID, false)
+func (s *Service) hasBackgroundTask(sessionID, toolCallID string, executionIDs ...string) bool {
+	ta := s.lockTurnActivity(sessionID, false)
 	if ta == nil {
 		return false
 	}
-	ta.mu.Lock()
 	defer ta.mu.Unlock()
-	_, ok := ta.background[toolCallID]
-	return ok
+	work, ok := ta.background[toolCallID]
+	if !ok || len(executionIDs) == 0 || executionIDs[0] == "" {
+		return ok
+	}
+	return work.executionID == executionIDs[0]
 }
 
 // completeBackgroundTaskForExecution clears a previously-registered background
@@ -387,14 +525,13 @@ func (s *Service) completeBackgroundTaskForExecution(sessionID, toolCallID, exec
 	if sessionID == "" || toolCallID == "" {
 		return false
 	}
-	ta := s.turnActivityFor(sessionID, false)
+	ta := s.lockTurnActivity(sessionID, false)
 	if ta == nil {
 		return false
 	}
-	ta.mu.Lock()
+	defer ta.mu.Unlock()
 	work, exists := ta.background[toolCallID]
 	if !exists || (executionID != "" && work.executionID != "" && work.executionID != executionID) {
-		ta.mu.Unlock()
 		return false
 	}
 	delete(ta.background, toolCallID)
@@ -404,7 +541,6 @@ func (s *Service) completeBackgroundTaskForExecution(sessionID, toolCallID, exec
 		ta.yielded = false
 		visibleChanged = true
 	}
-	ta.mu.Unlock()
 	return visibleChanged || work.kind == streams.BackgroundWorkKindSubagent
 }
 
@@ -424,11 +560,10 @@ func (s *Service) completeBackgroundWorkSnapshot(
 	sessionID, executionID, workID string,
 	value interface{},
 ) (activityPublication, bool) {
-	ta := s.turnActivityFor(sessionID, false)
+	ta := s.lockTurnActivity(sessionID, false)
 	if ta == nil {
 		return activityPublication{}, false
 	}
-	ta.mu.Lock()
 	defer ta.mu.Unlock()
 
 	matchedToolCallID := ""
@@ -468,49 +603,172 @@ func (s *Service) completeBackgroundWorkSnapshot(
 	if !visibleChanged && ta.yielded {
 		publicationValue = string(v1.ForegroundActivityBackground)
 	}
-	return activityPublication{activity: ta, revision: ta.revision, value: publicationValue}, true
+	return activityPublication{
+		activity:            ta,
+		revision:            ta.revision,
+		value:               publicationValue,
+		activeSubagentCount: ta.activeSubagentCountLocked(),
+	}, true
 }
 
-// clearExecutionBackgroundWork removes every registration owned by one
-// terminal execution, preserving any successor execution already using the
-// same task session. It returns true whenever registrations were removed so
-// callers publish count-only transitions too.
-func (s *Service) clearExecutionBackgroundWorkSnapshot(
+// retireExecutionActivitySnapshot retires all activity owned by one
+// terminal execution. Record publication, identity validation, and detachment
+// share activityPublicationGuard -> foregroundActivityMu -> turnActivity.mu
+// lock order.
+//
+// The map/record lock coupling is the critical invariant: a successor either
+// locks this mapped record before cleanup can detach it, or observes no record
+// and creates a new one. Cleanup therefore cannot detach a pointer that a
+// successor has loaded but not yet begun mutating. A prompt claim or dispatch
+// token also counts as live use until it is released.
+func (s *Service) retireExecutionActivitySnapshot(
 	sessionID, executionID string,
 ) (activityPublication, bool) {
 	if sessionID == "" || executionID == "" {
 		return activityPublication{}, false
 	}
-	ta := s.turnActivityFor(sessionID, false)
-	if ta == nil {
+	publicationLock, releasePublication := s.acquireActivityPublicationGuard(sessionID)
+	defer releasePublication()
+	publicationLock.Lock()
+	defer publicationLock.Unlock()
+	s.foregroundActivityMu.Lock()
+	ta, ok := s.foregroundActivity[sessionID]
+	if !ok {
+		s.foregroundActivityMu.Unlock()
 		return activityPublication{}, false
 	}
 	ta.mu.Lock()
-	defer ta.mu.Unlock()
-	removed := false
-	removedSubagent := false
+
+	retirement := ta.retireExecutionActivityLocked(executionID)
+	if retirement.retireRecord {
+		delete(s.foregroundActivity, sessionID)
+		publication := activityPublication{
+			activity:            ta,
+			revision:            ta.revision,
+			value:               nil,
+			activeSubagentCount: 0,
+			retired:             true,
+		}
+		ta.mu.Unlock()
+		s.foregroundActivityMu.Unlock()
+		return publication, true
+	}
+
+	if !retirement.removed {
+		ta.mu.Unlock()
+		s.foregroundActivityMu.Unlock()
+		return activityPublication{}, false
+	}
+	if !retirement.finalTransition && !retirement.removedSubagent {
+		ta.mu.Unlock()
+		s.foregroundActivityMu.Unlock()
+		return activityPublication{}, false
+	}
+	publicationValue := interface{}(string(v1.ForegroundActivityGenerating))
+	if ta.yielded {
+		publicationValue = string(v1.ForegroundActivityBackground)
+	} else if retirement.finalTransition {
+		publicationValue = nil
+	}
+	publication := activityPublication{
+		activity:            ta,
+		revision:            ta.revision,
+		value:               publicationValue,
+		activeSubagentCount: ta.activeSubagentCountLocked(),
+	}
+	ta.mu.Unlock()
+	s.foregroundActivityMu.Unlock()
+	return publication, true
+}
+
+func (ta *turnActivity) retireExecutionActivityLocked(
+	executionID string,
+) executionActivityRetirement {
+	result := executionActivityRetirement{}
 	for toolCallID, work := range ta.background {
 		if work.executionID == executionID {
 			delete(ta.background, toolCallID)
-			removed = true
-			removedSubagent = removedSubagent || work.kind == streams.BackgroundWorkKindSubagent
+			result.removed = true
+			result.removedSubagent =
+				result.removedSubagent || work.kind == streams.BackgroundWorkKindSubagent
 		}
 	}
-	if !removed {
-		return activityPublication{}, false
+	for toolCallID, record := range ta.tools {
+		if record.executionID == executionID {
+			delete(ta.tools, toolCallID)
+			result.removed = true
+		}
 	}
-	ta.revision++
-	finalTransition := ta.clearYieldWhenEmptyLocked()
-	if !finalTransition && !removedSubagent {
-		return activityPublication{}, false
+	result.removed = ta.retireExecutionClaimLocked(executionID) || result.removed
+
+	result.finalTransition = ta.clearYieldWhenEmptyLocked()
+	if result.removed || result.finalTransition {
+		ta.revision++
 	}
-	value := interface{}(string(v1.ForegroundActivityGenerating))
-	if ta.yielded {
-		value = string(v1.ForegroundActivityBackground)
-	} else if finalTransition {
-		value = nil
+
+	hasSuccessorUse := ta.hasSuccessorUseLocked()
+	ta.retireWhenUnused = !ta.hasExecutionOwnedActivityLocked() &&
+		(ta.promptInFlight || ta.dispatchInFlightGeneration != 0)
+	if !hasSuccessorUse {
+		// Invalidate snapshots before detaching. The stable publication guard
+		// makes a validated predecessor delivery finish before detachment, while
+		// every later snapshot observes the missing record identity.
+		ta.revision++
+		result.retireRecord = true
 	}
-	return activityPublication{activity: ta, revision: ta.revision, value: value}, true
+	return result
+}
+
+func (ta *turnActivity) hasSuccessorUseLocked() bool {
+	if ta.promptInFlight || ta.dispatchInFlightGeneration != 0 {
+		return true
+	}
+	return ta.hasExecutionOwnedActivityLocked()
+}
+
+func (ta *turnActivity) hasExecutionOwnedActivityLocked() bool {
+	if len(ta.executionClaims) != 0 {
+		return true
+	}
+	for _, work := range ta.background {
+		if work.executionID != "" {
+			return true
+		}
+	}
+	for _, record := range ta.tools {
+		if record.executionID != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *Service) pruneTurnActivityIfUnused(sessionID string, ta *turnActivity) {
+	if sessionID == "" || ta == nil {
+		return
+	}
+	publicationLock, releasePublication := s.acquireActivityPublicationGuard(sessionID)
+	defer releasePublication()
+	publicationLock.Lock()
+	defer publicationLock.Unlock()
+	s.foregroundActivityMu.Lock()
+	current, ok := s.foregroundActivity[sessionID]
+	if !ok || current != ta {
+		s.foregroundActivityMu.Unlock()
+		return
+	}
+	ta.mu.Lock()
+	if ta.retireWhenUnused &&
+		len(ta.executionClaims) == 0 &&
+		!ta.promptInFlight &&
+		ta.dispatchInFlightGeneration == 0 &&
+		len(ta.background) == 0 &&
+		len(ta.tools) == 0 {
+		ta.revision++
+		delete(s.foregroundActivity, sessionID)
+	}
+	ta.mu.Unlock()
+	s.foregroundActivityMu.Unlock()
 }
 
 func (ta *turnActivity) clearYieldWhenEmptyLocked() bool {
@@ -521,11 +779,11 @@ func (ta *turnActivity) clearYieldWhenEmptyLocked() bool {
 	return true
 }
 
-func (s *Service) clearExecutionBackgroundWorkAndPublish(
+func (s *Service) retireExecutionActivityAndPublish(
 	ctx context.Context,
 	taskID, sessionID, executionID string,
 ) {
-	publication, changed := s.clearExecutionBackgroundWorkSnapshot(sessionID, executionID)
+	publication, changed := s.retireExecutionActivitySnapshot(sessionID, executionID)
 	if changed {
 		s.publishForegroundActivitySnapshot(ctx, taskID, sessionID, publication)
 	}
@@ -538,7 +796,18 @@ func (s *Service) clearTurnActivity(sessionID string) {
 	if sessionID == "" {
 		return
 	}
-	s.foregroundActivity.Delete(sessionID)
+	publicationLock, releasePublication := s.acquireActivityPublicationGuard(sessionID)
+	defer releasePublication()
+	publicationLock.Lock()
+	defer publicationLock.Unlock()
+	s.foregroundActivityMu.Lock()
+	if ta, ok := s.foregroundActivity[sessionID]; ok {
+		ta.mu.Lock()
+		ta.revision++
+		delete(s.foregroundActivity, sessionID)
+		ta.mu.Unlock()
+	}
+	s.foregroundActivityMu.Unlock()
 }
 
 // isForegroundTurnGenerating reports whether the session's foreground agent turn
@@ -551,11 +820,10 @@ func (s *Service) clearTurnActivity(sessionID string) {
 // turn on the strength of the answer must use claimForegroundTurn instead, or it
 // races every other prompt reading the same window.
 func (s *Service) isForegroundTurnGenerating(sessionID string) bool {
-	ta := s.turnActivityFor(sessionID, false)
+	ta := s.lockTurnActivity(sessionID, false)
 	if ta == nil {
 		return true
 	}
-	ta.mu.Lock()
 	defer ta.mu.Unlock()
 	return ta.generatingLocked()
 }
@@ -599,11 +867,10 @@ func (s *Service) claimForegroundTurn(sessionID string) *foregroundClaim {
 	if sessionID == "" {
 		return nil
 	}
-	ta := s.turnActivityFor(sessionID, false)
+	ta := s.lockTurnActivity(sessionID, false)
 	if ta == nil {
 		return nil
 	}
-	ta.mu.Lock()
 	defer ta.mu.Unlock()
 	if ta.generatingLocked() {
 		return nil
@@ -613,6 +880,7 @@ func (s *Service) claimForegroundTurn(sessionID string) *foregroundClaim {
 	ta.claimGeneration++
 	ta.revision++
 	return &foregroundClaim{
+		sessionID:       sessionID,
 		activity:        ta,
 		claimGeneration: ta.claimGeneration,
 		foregroundEpoch: ta.foregroundEpoch,
@@ -626,11 +894,10 @@ func (s *Service) isForegroundClaimCurrent(sessionID string, claim *foregroundCl
 	if sessionID == "" || claim == nil || claim.activity == nil {
 		return false
 	}
-	ta := s.turnActivityFor(sessionID, false)
-	if ta == nil || ta != claim.activity {
+	if claim.sessionID != sessionID || !s.lockTurnActivityToken(sessionID, claim.activity) {
 		return false
 	}
-	ta.mu.Lock()
+	ta := claim.activity
 	defer ta.mu.Unlock()
 	return ta.promptInFlight && ta.claimGeneration == claim.claimGeneration
 }
@@ -641,21 +908,29 @@ func (s *Service) isForegroundClaimCurrent(sessionID string, claim *foregroundCl
 // creating a newer null snapshot between "begin" and a later foreground flip.
 // agentctl starts its prompt goroutine before returning the accepted response,
 // so provider frames can also beat onDispatched.
-func (s *Service) beginForegroundDispatch(sessionID string, claim *foregroundClaim) *foregroundDispatch {
+func (s *Service) beginForegroundDispatch(
+	sessionID string,
+	claim *foregroundClaim,
+	executionIDs ...string,
+) *foregroundDispatch {
+	executionID := ""
+	if len(executionIDs) > 0 {
+		executionID = executionIDs[0]
+	}
 	var ta *turnActivity
 	if claim != nil {
 		ta = claim.activity
-		if ta == nil {
+		if ta == nil || claim.sessionID != sessionID ||
+			!s.lockTurnActivityToken(sessionID, ta) {
 			return nil
 		}
 	} else {
 		if sessionID == "" {
 			return nil
 		}
-		ta = s.turnActivityFor(sessionID, true)
+		ta = s.lockTurnActivity(sessionID, true)
 	}
 
-	ta.mu.Lock()
 	defer ta.mu.Unlock()
 	if claim != nil {
 		if !ta.promptInFlight || ta.claimGeneration != claim.claimGeneration {
@@ -676,10 +951,13 @@ func (s *Service) beginForegroundDispatch(sessionID string, claim *foregroundCla
 	yieldedBeforeBegin := ta.yielded
 	ta.yielded = false
 	ta.promptCycleGeneration++
+	ta.claimExecutionLocked(executionID)
+	ta.dispatchInFlightGeneration = ta.promptCycleGeneration
 	// Starting any successor cycle invalidates delayed terminal/background
 	// publications, including claimless prompts admitted from a settled state.
 	ta.revision++
 	return &foregroundDispatch{
+		sessionID:             sessionID,
 		activity:              ta,
 		generation:            ta.promptCycleGeneration,
 		foregroundEpoch:       ta.foregroundEpoch,
@@ -697,8 +975,16 @@ func (s *Service) acceptForegroundDispatch(dispatch *foregroundDispatch) bool {
 		return false
 	}
 	ta := dispatch.activity
-	ta.mu.Lock()
-	defer ta.mu.Unlock()
+	if !s.lockTurnActivityToken(dispatch.sessionID, ta) {
+		return false
+	}
+	defer func() {
+		ta.mu.Unlock()
+		s.pruneTurnActivityIfUnused(dispatch.sessionID, ta)
+	}()
+	if ta.dispatchInFlightGeneration == dispatch.generation {
+		ta.dispatchInFlightGeneration = 0
+	}
 
 	// Release the claimed admission before the cycle-generation check below:
 	// resume can advance durable state to WAITING_FOR_INPUT while this claimed
@@ -737,7 +1023,9 @@ func (s *Service) acceptedForegroundDispatchClaim(dispatch *foregroundDispatch) 
 		return false
 	}
 	ta := dispatch.activity
-	ta.mu.Lock()
+	if !s.lockTurnActivityToken(dispatch.sessionID, ta) {
+		return false
+	}
 	defer ta.mu.Unlock()
 	return dispatch.accepted && dispatch.claimedBackgroundTurn
 }
@@ -752,8 +1040,16 @@ func (s *Service) rollbackForegroundDispatch(dispatch *foregroundDispatch) bool 
 		return false
 	}
 	ta := dispatch.activity
-	ta.mu.Lock()
-	defer ta.mu.Unlock()
+	if !s.lockTurnActivityToken(dispatch.sessionID, ta) {
+		return false
+	}
+	defer func() {
+		ta.mu.Unlock()
+		s.pruneTurnActivityIfUnused(dispatch.sessionID, ta)
+	}()
+	if ta.dispatchInFlightGeneration == dispatch.generation {
+		ta.dispatchInFlightGeneration = 0
+	}
 	// Release the claimed admission unconditionally, before the
 	// dispatchRollbackIsCurrentLocked staleness check: that check gates on
 	// promptCycleGeneration/foregroundEpoch, which a claimless successor
@@ -819,16 +1115,21 @@ func (s *Service) releaseForegroundClaim(claim *foregroundClaim) bool {
 		return false
 	}
 	ta := claim.activity
-	ta.mu.Lock()
-	defer ta.mu.Unlock()
+	if !s.lockTurnActivityToken(claim.sessionID, ta) {
+		return false
+	}
 	if !ta.promptInFlight || ta.claimGeneration != claim.claimGeneration {
+		ta.mu.Unlock()
 		return false
 	}
 	ta.promptInFlight = false
 	if ta.foregroundEpoch != claim.foregroundEpoch || len(ta.background) == 0 {
+		ta.mu.Unlock()
+		s.pruneTurnActivityIfUnused(claim.sessionID, ta)
 		return false
 	}
 	ta.yielded = true
+	ta.mu.Unlock()
 	return true
 }
 
@@ -861,14 +1162,24 @@ func (s *Service) ForegroundActivity(sessionID string) v1.ForegroundActivity {
 // it only when a flip actually happened (the mark/register/complete helpers
 // return that), so it never fires per background frame.
 func (s *Service) publishForegroundActivityChanged(ctx context.Context, taskID, sessionID string) {
-	ta := s.turnActivityFor(sessionID, false)
+	publicationLock, releasePublication := s.acquireActivityPublicationGuard(sessionID)
+	defer releasePublication()
+	publicationLock.Lock()
+	defer publicationLock.Unlock()
+	ta := s.lockTurnActivity(sessionID, false)
 	if ta == nil {
-		s.publishForegroundActivityNow(ctx, taskID, sessionID, string(v1.ForegroundActivityGenerating))
+		s.publishForegroundActivityNow(
+			ctx, taskID, sessionID, string(v1.ForegroundActivityGenerating), 0,
+		)
 		return
 	}
-	ta.publishMu.Lock()
-	defer ta.publishMu.Unlock()
-	s.publishForegroundActivityNow(ctx, taskID, sessionID, string(s.foregroundActivityValue(sessionID)))
+	value := v1.ForegroundActivityGenerating
+	if !ta.generatingLocked() {
+		value = v1.ForegroundActivityBackground
+	}
+	activeSubagentCount := ta.activeSubagentCountLocked()
+	ta.mu.Unlock()
+	s.publishForegroundActivityNow(ctx, taskID, sessionID, string(value), activeSubagentCount)
 }
 
 func (s *Service) publishForegroundActivitySnapshot(
@@ -880,21 +1191,41 @@ func (s *Service) publishForegroundActivitySnapshot(
 	if ta == nil {
 		return
 	}
-	ta.publishMu.Lock()
-	defer ta.publishMu.Unlock()
-	ta.mu.Lock()
-	current := ta.revision == publication.revision
-	ta.mu.Unlock()
+	publicationLock, releasePublication := s.acquireActivityPublicationGuard(sessionID)
+	defer releasePublication()
+	publicationLock.Lock()
+	defer publicationLock.Unlock()
+	current := false
+	if publication.retired {
+		s.foregroundActivityMu.Lock()
+		mapped, ok := s.foregroundActivity[sessionID]
+		if !ok || mapped == ta {
+			ta.mu.Lock()
+			current = !ok && ta.revision == publication.revision
+			ta.mu.Unlock()
+		}
+		s.foregroundActivityMu.Unlock()
+	} else if s.lockTurnActivityToken(sessionID, ta) {
+		current = ta.revision == publication.revision
+		ta.mu.Unlock()
+	}
 	if !current {
 		return
 	}
-	s.publishForegroundActivityNow(ctx, taskID, sessionID, publication.value)
+	s.publishForegroundActivityNow(
+		ctx,
+		taskID,
+		sessionID,
+		publication.value,
+		publication.activeSubagentCount,
+	)
 }
 
 func (s *Service) publishForegroundActivityNow(
 	ctx context.Context,
 	taskID, sessionID string,
 	value interface{},
+	activeSubagentCount int,
 ) {
 	if s.eventBus == nil || taskID == "" || sessionID == "" {
 		return
@@ -903,7 +1234,7 @@ func (s *Service) publishForegroundActivityNow(
 		metaKeyTaskID:           taskID,
 		metaKeySessionID:        sessionID,
 		"foreground_activity":   value,
-		"active_subagent_count": s.ActiveSubagentCount(sessionID),
+		"active_subagent_count": activeSubagentCount,
 	}
 	if err := s.eventBus.Publish(ctx, events.TaskSessionActivityChanged,
 		bus.NewEvent(events.TaskSessionActivityChanged, "task-session", eventData)); err != nil {

--- a/docs/decisions/0049-fine-grained-foreground-idle-busy-signal.md
+++ b/docs/decisions/0049-fine-grained-foreground-idle-busy-signal.md
@@ -1,6 +1,6 @@
 # 0049: Fine-grained foreground-idle busy signal
 
-**Status:** accepted (amended 2026-07-25)
+**Status:** accepted (amended 2026-07-26)
 **Date:** 2026-07-11
 **Area:** backend, frontend, protocol
 **Related:** [Background work liveness spec](../specs/platform/background-work-liveness.md)
@@ -92,13 +92,34 @@ to the foreground only:
 - Tool activity marks the foreground as generating only from positive ownership
   evidence. The initial tool call records whether it is top-level foreground,
   recognized background work, or a child of background work; subsequent
-  updates inherit that ownership. Missing parent metadata and update-only tool
-  frames preserve the current activity rather than promoting unknown work to
-  foreground. This is required for incremental ACP streams such as Claude's,
-  which can temporarily omit `parentToolUseId` while the adapter still carries
-  the child tool's cached normalized payload. A known top-level non-background
-  tool still marks the foreground as generating, just like message and thinking
-  frames.
+  updates inherit that ownership only within the execution that established it.
+  Provider-local tool-call IDs may be reused after execution rotation; a stale
+  predecessor entry is never ownership evidence for the successor. Missing
+  parent metadata and update-only tool frames preserve the current activity
+  rather than promoting unknown work to foreground. This is required for
+  incremental ACP streams such as Claude's, which can temporarily omit
+  `parentToolUseId` while the adapter still carries the child tool's cached
+  normalized payload. A known top-level non-background tool still marks the
+  foreground as generating, just like message and thinking frames.
+- Activity records are execution-lifetime state. Each execution that dispatches
+  a prompt or records tool/background activity claims the mapped session record.
+  Terminal cleanup removes that execution's tool ownership, background work,
+  and record claim. It detaches the whole record only when no other execution
+  claim or in-flight prompt/dispatch token still uses it.
+- Record lookup and retirement use one lock-coupled identity protocol: lookup
+  locks the mapped record before releasing the map guard, while retirement
+  validates and detaches that same identity under the guard. A successor
+  therefore either mutates the retained record or creates a new record after
+  retirement; it cannot mutate a detached predecessor pointer. Delayed
+  publications validate both record identity and revision. Validation and
+  synchronous event delivery are serialized by a stable, reference-counted
+  per-session guard that survives record replacement; a predecessor cannot pass
+  validation and then deliver after its successor. Foreground activity and
+  active-subagent count are captured together under the record lock, so a
+  predecessor value cannot be paired with successor-owned count state. Session
+  deletion first quiesces any live lifecycle execution, marks its exact
+  execution ID terminal, then forcibly detaches the identity and invalidates
+  outstanding tokens.
 - All activity-bearing lifecycle and activity-refresh events use one FIFO per
   task; different tasks may publish concurrently. Same-task reentrant
   publication enqueues and returns. Repository reads and synchronous callbacks
@@ -131,6 +152,9 @@ restart. Connected executions retain background liveness and exact subagent
 registrations across foreground turns, but work that survives a restart cannot
 be reconstructed without an agent-side liveness API. Claude and Codex are the
 initial attested adapters; all others keep the conservative busy behavior.
+Terminal execution teardown releases orphaned tool ownership and background
+registrations, and releases the session activity record once no successor uses
+it, so completed session history does not retain live-memory bookkeeping.
 
 ## Alternatives Considered
 
@@ -153,3 +177,9 @@ initial attested adapters; all others keep the conservative busy behavior.
   it on the initial call. Reclassifying from each update makes missing metadata
   override known ownership and falsely closes the prompt gate. Unknown updates
   therefore preserve activity until positive foreground evidence arrives.
+- **Load, check, and delete the session record without a shared identity
+  protocol.** Rejected: a successor can load the predecessor's pointer before
+  cleanup deletes the map entry, then mutate detached state that serializers no
+  longer observe. Execution claims alone do not close that stale-pointer window;
+  lookup, token use, publication, and retirement must validate the same mapped
+  identity.

--- a/docs/decisions/INDEX.md
+++ b/docs/decisions/INDEX.md
@@ -56,7 +56,7 @@ Read individual ADRs for full context. Create new ones via `/record decision` or
 | 0046 | [Settings route save coordinator](0046-settings-route-save-coordinator.md)                                                          | accepted   | frontend                    | 2026-07-14 |
 | 0047 | [Plugins read conversation content via a capability-gated Host RPC](0047-plugin-host-conversation-reads.md)                          | accepted   | backend, protocol           | 2026-07-21 |
 | 0048 | [Plugins invoke a settings-selectable utility agent](0048-plugin-host-utility-agent-invoke.md)                                       | accepted   | backend, frontend, protocol | 2026-07-21 |
-| 0049 | [Fine-grained foreground-idle busy signal](0049-fine-grained-foreground-idle-busy-signal.md)                                      | accepted (amended 2026-07-25) | backend, frontend, protocol | 2026-07-11 |
+| 0049 | [Fine-grained foreground-idle busy signal](0049-fine-grained-foreground-idle-busy-signal.md)                                      | accepted (amended 2026-07-26) | backend, frontend, protocol | 2026-07-11 |
 | 2026-07-23-opencode-review-evidence-trust | [Trusted OpenCode Review Evidence](2026-07-23-opencode-review-evidence-trust.md) | accepted | workflow, infra | 2026-07-23 |
 | 2026-07-23-planner-direct-small-work | [Planner Direct Small Work](2026-07-23-planner-direct-small-work.md) | accepted | workflow | 2026-07-23 |
 | 2026-07-23-post-commit-hook-aware-verification | [Post-Commit Hook-Aware Verification](2026-07-23-post-commit-hook-aware-verification.md) | accepted | workflow | 2026-07-23 |

--- a/docs/specs/platform/background-work-liveness.md
+++ b/docs/specs/platform/background-work-liveness.md
@@ -111,7 +111,8 @@ execution so each prompt owns its completion wait and response buffers.
   cleanup, and session removal retire all activity owned by that execution.
   Cleanup is idempotent and must preserve activity already claimed by a
   successor on the same session. Session removal quiesces any still-live
-  lifecycle execution and rejects deletion if that stop fails. Per-session
+  lifecycle execution and rejects deletion if that stop fails, except when the
+  runtime reports that the exact execution is already absent. Per-session
   activity validation and delivery remain ordered across record replacement;
   each publication snapshots its activity value and active-subagent count
   together. Per-task publication is FIFO: a newly computed activity value must

--- a/docs/specs/platform/background-work-liveness.md
+++ b/docs/specs/platform/background-work-liveness.md
@@ -1,7 +1,7 @@
 ---
 status: shipped
 created: 2026-07-21
-updated: 2026-07-25
+updated: 2026-07-26
 owner: kandev
 ---
 
@@ -43,6 +43,9 @@ and incorrectly prevents prompt delivery.
 - A terminal asynchronous launch result closes its tool card but does not end
   the launched workload. Work remains live until accountable completion or
   execution teardown.
+- Terminal execution teardown retires every tool-ownership and background-work
+  entry owned by that execution. It releases the whole session activity record
+  when no successor execution or in-flight prompt/dispatch token still owns it.
 - The delete confirmation warns when a task has foreground or recognized
   background work. Archive uses the same warning only when archive confirmation
   is enabled.
@@ -94,19 +97,27 @@ execution so each prompt owns its completion wait and response buffers.
   identity is the correlation key; interrupt, cancellation, failure, shutdown,
   and normal completion are terminal.
 - Tool-call ownership is established by the initial call and retained across
-  incremental updates. An update with unknown ownership preserves the current
-  activity; missing parent metadata is not evidence that background-child work
-  became foreground work.
+  incremental updates from the same execution. Ownership includes the execution
+  identity because provider-local tool-call IDs may be reused after rotation.
+  An update with unknown ownership preserves the current activity; missing
+  parent metadata is not evidence that background-child work became foreground
+  work.
 - A task aggregate that cannot be recomputed preserves its last-known value
   rather than publishing a spurious done reading.
 - When provider completion identifies a workload, only that registration is
   retired; duplicate completion is harmless. An uncorrelated completion retires
   only one outstanding registration and leaves an ambiguous remainder live.
-- Execution stop, failure, cancellation, session removal, and teardown retire
-  all registrations owned by that execution. Per-task publication is FIFO: a
-  newly computed activity value must not be published ahead of an earlier value
-  for the same task, and stale publication work must not overwrite a newer
-  aggregate.
+- Execution completion, stop, failure, cancellation, crash cleanup, forced
+  cleanup, and session removal retire all activity owned by that execution.
+  Cleanup is idempotent and must preserve activity already claimed by a
+  successor on the same session. Session removal quiesces any still-live
+  lifecycle execution and rejects deletion if that stop fails. Per-session
+  activity validation and delivery remain ordered across record replacement;
+  each publication snapshots its activity value and active-subagent count
+  together. Per-task publication is FIFO: a newly computed activity value must
+  not be published ahead of an earlier value for the same task, and a detached
+  predecessor record or stale publication must not overwrite a newer session or
+  task aggregate.
 
 ## Persistence guarantees
 
@@ -114,8 +125,9 @@ Fine-grained activity is in memory and is authoritative only while the owning
 agent execution remains connected. A backend or agent-execution restart does
 not reconstruct detached work or active subagent counts; it must not preserve a
 stale live reading. Counts are derived from the live registration map rather
-than persisted or incremented independently. Durable coarse state continues to
-survive as before.
+than persisted or incremented independently. Execution teardown releases the
+record when it has no successor owner; completed session history does not retain
+an empty activity record. Durable coarse state continues to survive as before.
 
 ## Scenarios
 
@@ -151,6 +163,18 @@ survive as before.
 - **GIVEN** an activity transition for a task, **WHEN** a later transition is
   computed before earlier publication completes, **THEN** observers never see
   the later value followed by the stale earlier value.
+- **GIVEN** an execution terminates with orphaned tool ownership and background
+  work and no successor exists, **WHEN** teardown runs, **THEN** all owned state
+  and the session activity record are released.
+- **GIVEN** execution B has claimed the same session before delayed teardown for
+  execution A, **WHEN** A is retired, **THEN** B's prompt claim, prompt
+  generation, foreground state, tools, and background work remain unchanged.
+- **GIVEN** execution B reuses a tool-call ID left nonterminal by execution A,
+  **WHEN** B emits an ownership-incomplete update, **THEN** A's classification
+  is not observable as ownership evidence for B.
+- **GIVEN** execution A's cleanup publication is delayed until after execution B
+  claims the session, **WHEN** the delayed publication resumes, **THEN** it
+  cannot recreate A's record or overwrite B's activity.
 - **GIVEN** a task with active foreground or recognized background work,
   **WHEN** the operator deletes it, **THEN** the confirmation warns that work is
   still in progress.


### PR DESCRIPTION
Terminal executions retained their session activity record and orphaned tool ownership for the session lifetime, allowing stale predecessor state to collide with a successor. Execution-scoped ownership and synchronized retirement now release terminal state without detaching or overwriting successor activity.

## Important Changes

- Bind tool ownership, background work, and activity-record claims to the lifecycle execution that created them.
- Retire completed, failed, stopped, crashed, forced-cleanup, and deleted-session activity through an idempotent execution boundary.
- Couple record identity, revision, and immutable activity/count publication so predecessor cleanup cannot clobber a successor.
- Amend ADR 0049 and the background-work liveness spec with the execution-teardown invariant.

## Validation

- `go test -count=1 ./internal/orchestrator`
- `go test -race -count=1 ./internal/orchestrator`
- `golangci-lint run ./internal/orchestrator/...`
- Delegated full verification: `make fmt`, `make typecheck`, `make test`, and `make lint`
- Independent concurrency review covering stale pointers, use-after-retire, lock order, double cleanup, and successor clobber

Closes #1947

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1961?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->