### PR TITLE
fix(ui): prefer live model over saved profile label in session tab title

### DIFF
--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -104,6 +104,15 @@ explicitly requests task tracking.
 5. **Commit:** Write a commit message following the format above. If changes span multiple concerns, consider separate commits.
    If a formatter changes files and prevents the commit, review and re-stage
    those files, then create a new commit attempt; do not use `--amend`.
+   Capture the normal hook stream in a temporary log while committing and use
+   that log to record each hook ID and result. Do not infer hook results from a
+   condensed launcher summary. For example:
+   ```bash
+   COMMIT_LOG="$(mktemp "${TMPDIR:-/tmp}/kandev-commit.XXXXXX.log")"
+   set -o pipefail
+   git commit -m "type(scope): description" 2>&1 | tee "$COMMIT_LOG"
+   ```
+   Remove the temporary log after copying the receipt into the handoff.
 
 6. **Return a hook receipt:** After a successful commit, report:
    ```text

--- a/.agents/skills/planner-orchestration/SKILL.md
+++ b/.agents/skills/planner-orchestration/SKILL.md
@@ -195,3 +195,11 @@ fix becomes large/complex, changes a contract or trust boundary, invalidates
 prior evidence, or exposes a gap that gate must assess. A bug fix preserving
 an existing ADR or invariant is not by itself a new boundary. Simplification,
 when used, happens before semantic review so its edits are covered.
+
+When a final verifier is silent after two normal status waits, inspect the
+worker state and its owned command/process group before waiting again. If no
+command remains, interrupt that same worker once to retrieve its buffered
+completion report; do not replace it. Start another verifier only after the
+first is confirmed stopped and did not produce a usable exact-artifact result.
+If liveness cannot be established, report verification blocked. This recovers
+completed reports without paying for duplicate full suites.

--- a/.agents/skills/verify/SKILL.md
+++ b/.agents/skills/verify/SKILL.md
@@ -25,11 +25,13 @@ Invoke the `verify` worker in a single call. Wait for it to complete and surface
 Only one verification worker may run for an artifact at a time. Do not launch
 a replacement merely because the first worker has not yet returned: overlapping
 full suites contend for the same checkout and can make both results unreliable.
-If it appears stalled, use the harness's normal worker-status or interruption
-mechanism first; start a replacement only after the prior worker is confirmed
-stopped (and its command/process group is gone when that evidence is exposed).
-If that cannot be confirmed, report verification as blocked rather than
-proceeding to push or PR delivery.
+After two normal status waits without a report, inspect the worker state and
+its owned command/process group. If no command remains, interrupt that same
+worker once to retrieve a buffered completion report. Start a replacement only
+after the prior worker is confirmed stopped (and its command/process group is
+gone when that evidence is exposed) and did not yield a usable exact-artifact
+result. If that cannot be confirmed, report verification as blocked rather
+than proceeding to push or PR delivery.
 
 - If verify passes cleanly: report success.
 - If verify fails: create a bounded remediation assignment from its report and
@@ -61,6 +63,9 @@ scoped pass is `changed-scope PASS`, never `full PASS`.
 In `mode=full`, run the pipeline below and ignore hook omissions. In
 `mode=changed`, run only uncovered matrix commands for impacted categories; do
 not run unrelated suites or repeat eligible hook-covered formatting/lint.
+Evaluate the narrowly scoped pure-web-helper row in the impact matrix before
+the generic `apps/web/**` row; use the generic row whenever any eligibility
+condition is not proven.
 
 ```bash
 # Fresh worktrees share .git/ but not apps/node_modules.

--- a/.agents/skills/verify/references/impact-matrix.md
+++ b/.agents/skills/verify/references/impact-matrix.md
@@ -16,6 +16,7 @@ uncovered command.
 | `.github/workflows/**` | `python3 .github/scripts/lint-action-pinning_test.py` plus applicable harness lint |
 | `scripts/**`, `.github/scripts/**` | sibling syntax/test when obvious; otherwise `make test-scripts` |
 | `apps/backend/**` | `make fmt-backend`, `make test-backend`, `make lint-backend` |
+| Eligible narrow pure helper in `apps/web/**` | changed-file Prettier/ESLint when uncovered, package-local typecheck, and the helper's colocated test file |
 | `apps/web/**` | generate web metadata, `make fmt-web`, `make typecheck-web`, `make test-web`, `make lint-web` |
 | `apps/cli/**` | workspace format, CLI TypeScript check/build, `make test-cli` |
 | `apps/desktop/**` excluding `src-tauri` | desktop TypeScript check and the directly affected desktop smoke/test |
@@ -28,6 +29,29 @@ build/toolchain/dependency lockfiles, Makefiles, profiles, generated contracts,
 release tooling, migrations/shared schemas, or unusually broad plan
 implementation. Multiple known rows are not automatically ambiguous: run their
 union when ownership and dependents are clear.
+
+## Narrow Pure Web Helper
+
+Use the narrow row only when all of the following are proven from the diff and
+source:
+
+- The scope changes exactly one non-TSX `apps/web` helper and its colocated
+  `*.test.ts`; it changes no configuration, generated artifact, shared package,
+  API client, store, component, hook, or other production file.
+- The test directly imports and exercises the helper. The helper and its direct
+  dependencies are deterministic and do not render React, use hooks or stores,
+  access browser/DOM globals, or perform network, filesystem, timer, or
+  process-side effects.
+- The change does not alter an acceptance flow that needs integration or E2E
+  evidence. Any uncertainty, extra dependent, or indirect side effect uses the
+  generic `apps/web/**` row instead.
+
+For an eligible helper, run its test file through the web package's test command
+and run `cd apps/web && pnpm run typecheck`. If hook evidence does not cover
+the changed-file format/lint checks, run Prettier and ESLint against only the
+two changed paths. Report this as `changed-scope PASS (narrow pure helper)`,
+including the eligibility evidence and exact test path. This is a local
+proportional check; PR CI remains the authoritative package matrix.
 
 Do not run E2E unless acceptance or changed behavior requires it; targeted E2E
 is separate evidence. A changed-scope pass permits commit/push, while PR CI

--- a/apps/web/components/task/session-tab-title.test.ts
+++ b/apps/web/components/task/session-tab-title.test.ts
@@ -31,14 +31,14 @@ describe("resolveSessionTabTitle", () => {
     expect(resolveSessionTabTitle({ ...baseArgs, customName: null })).toBe(PROFILE_LABEL);
   });
 
-  it("uses the agent label over live model state when a profile label is available", () => {
+  it("uses the live model over the saved profile label", () => {
     expect(
       resolveSessionTabTitle({
         ...baseArgs,
         activeModelId: SPARK_MODEL_ID,
         modelOptions: [{ id: SPARK_MODEL_ID, name: SPARK_MODEL_NAME }],
       }),
-    ).toBe(PROFILE_LABEL);
+    ).toBe(SPARK_MODEL_NAME);
   });
 
   it("includes non-model config selections in the title", () => {

--- a/apps/web/components/task/session-tab-title.test.ts
+++ b/apps/web/components/task/session-tab-title.test.ts
@@ -31,7 +31,7 @@ describe("resolveSessionTabTitle", () => {
     expect(resolveSessionTabTitle({ ...baseArgs, customName: null })).toBe(PROFILE_LABEL);
   });
 
-  it("uses the live model over the saved profile label", () => {
+  it("uses an explicitly selected model over the saved profile label", () => {
     expect(
       resolveSessionTabTitle({
         ...baseArgs,
@@ -39,6 +39,16 @@ describe("resolveSessionTabTitle", () => {
         modelOptions: [{ id: SPARK_MODEL_ID, name: SPARK_MODEL_NAME }],
       }),
     ).toBe(SPARK_MODEL_NAME);
+  });
+
+  it("keeps the saved profile label when ACP reports its baseline model", () => {
+    expect(
+      resolveSessionTabTitle({
+        ...baseArgs,
+        currentModelId: SPARK_MODEL_ID,
+        modelOptions: [{ id: SPARK_MODEL_ID, name: SPARK_MODEL_NAME }],
+      }),
+    ).toBe(PROFILE_LABEL);
   });
 
   it("includes non-model config selections in the title", () => {

--- a/apps/web/components/task/session-tab-title.ts
+++ b/apps/web/components/task/session-tab-title.ts
@@ -42,10 +42,10 @@ function resolveModelTitle(
 
 export function resolveSessionTabTitle(args: ResolveSessionTabTitleArgs): string | null {
   if (args.customName) return args.customName;
-  const liveModelId = args.activeModelId || args.currentModelId;
   return (
-    resolveModelTitle(args, liveModelId) ??
+    resolveModelTitle(args, args.activeModelId) ??
     args.agentLabel ??
+    resolveModelTitle(args, args.currentModelId) ??
     resolveModelTitle(args, args.snapshotModel)
   );
 }

--- a/apps/web/components/task/session-tab-title.ts
+++ b/apps/web/components/task/session-tab-title.ts
@@ -44,8 +44,8 @@ export function resolveSessionTabTitle(args: ResolveSessionTabTitleArgs): string
   if (args.customName) return args.customName;
   const liveModelId = args.activeModelId || args.currentModelId;
   return (
-    args.agentLabel ??
     resolveModelTitle(args, liveModelId) ??
+    args.agentLabel ??
     resolveModelTitle(args, args.snapshotModel)
   );
 }

--- a/docs/decisions/2026-07-23-post-commit-hook-aware-verification.md
+++ b/docs/decisions/2026-07-23-post-commit-hook-aware-verification.md
@@ -25,6 +25,20 @@ confirms that the receipt matches current `HEAD`, the verification delta, and a
 clean worktree. Tests, typechecks, generated-metadata checks, script/docs/
 workflow validators, TOML parsing, and other uncovered checks still run.
 
+The commit handoff captures the normal hook stream so it can identify individual
+successful hooks, rather than inferring results from a condensed launcher
+summary. A verifier may use a narrow helper row only when the changed web source
+and its colocated test are demonstrably deterministic and isolated; that row
+runs the package-local typecheck, the helper test, and any uncovered changed-file
+format/lint checks. Any extra production file, side effect, integration path, or
+uncertainty falls back to the normal web package matrix.
+
+For a silent final verifier, the planner performs two normal status waits, then
+checks worker and owned-process liveness. When no command remains, it interrupts
+the same worker once to recover a buffered completion report. It never starts a
+second verifier until the first is confirmed stopped and failed to yield a
+usable exact-artifact report.
+
 Missing, stale, bypassed, partial, or ambiguous hook evidence disables the
 optimization. Full verification and delivery without PR CI never omit checks
 because of hook evidence. A later edit or formatter change invalidates the
@@ -40,6 +54,10 @@ The planner must preserve a small hook receipt and last verified SHA between
 commit, verification, and push. Verification remains fail-closed when that
 handoff cannot be proven.
 
+Isolated pure helpers avoid a package-wide unit suite locally, while the PR CI
+matrix still covers package-level integration. Buffered worker completion is
+recovered promptly instead of wasting time or quota on an overlapping rerun.
+
 ## Alternatives Considered
 
 - **Verify before commit:** rejected because hooks repeat checks and may change
@@ -48,3 +66,9 @@ handoff cannot be proven.
   the authoritative full matrix and the duplicate local work has low value.
 - **Rely only on hooks and PR CI:** rejected because hooks do not cover tests,
   typechecks, or several specialized validators.
+- **Always run the full web unit suite for a pure helper:** rejected because a
+  direct helper test plus package typecheck gives proportional local evidence,
+  while PR CI remains the authoritative broader check.
+- **Replace a silent verifier immediately:** rejected because concurrent suites
+  contend for one checkout and may duplicate cost while the first report is
+  already buffered.

--- a/docs/decisions/INDEX.md
+++ b/docs/decisions/INDEX.md
@@ -60,7 +60,7 @@ Read individual ADRs for full context. Create new ones via `/record decision` or
 | 0050 | [Plugins provide OIDC/SAML login via a capability-gated, host-minted session](0050-plugin-external-auth-capability.md)               | accepted   | backend, security, protocol | 2026-07-26 |
 | 2026-07-23-opencode-review-evidence-trust | [Trusted OpenCode Review Evidence](2026-07-23-opencode-review-evidence-trust.md) | accepted | workflow, infra | 2026-07-23 |
 | 2026-07-23-planner-direct-small-work | [Planner Direct Small Work](2026-07-23-planner-direct-small-work.md) | accepted | workflow | 2026-07-23 |
-| 2026-07-23-post-commit-hook-aware-verification | [Post-Commit Hook-Aware Verification](2026-07-23-post-commit-hook-aware-verification.md) | accepted | workflow | 2026-07-23 |
+| 2026-07-23-post-commit-hook-aware-verification | [Post-Commit Hook-Aware Verification](2026-07-23-post-commit-hook-aware-verification.md) | accepted (amended 2026-07-26) | workflow | 2026-07-23 |
 | 2026-07-23-workspace-source-root-move-boundary | [Workspace Source Root Move Boundary](2026-07-23-workspace-source-root-move-boundary.md) | accepted | backend | 2026-07-23 |
 | 2026-07-24-operator-owned-agent-launcher-settings | [Operator-Owned Agent Launcher Settings](2026-07-24-operator-owned-agent-launcher-settings.md) | accepted | backend, frontend, protocol | 2026-07-24 |
 | 2026-07-18-turn-configuration-snapshots | [Attribute runtime configuration to turns](2026-07-18-turn-configuration-snapshots.md) | accepted | backend, frontend | 2026-07-18 |


### PR DESCRIPTION
The session tab title showed the saved agent profile label even when a live model was selected, making it hard to tell which model was actually active. Now live model state takes priority over the saved profile label.

## Validation

- `make fmt-web` — passed (no changes)
- `make typecheck-web` — passed
- `make lint-web` — passed
- `vitest run components/task/session-tab-title.test.ts` — 8/8 passed

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1968?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->