### PR TITLE
fix(worktree): export executor-profile env into repo setup script

### DIFF
--- a/apps/backend/internal/agent/runtime/lifecycle/env_preparer_worktree.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/env_preparer_worktree.go
@@ -285,6 +285,11 @@ func buildWorktreeCreateRequest(req *EnvPrepareRequest) worktree.CreateRequest {
 		RepoName:               req.RepoName,
 		BranchSlug:             req.BranchSlug,
 		BranchIdentitySlug:     req.BranchIdentitySlug,
+		// Export resolved executor-profile env vars into the repository setup
+		// script so tokens (e.g. an npm auth token) are available during
+		// install. Set for both single-repo and multi-repo launches, which both
+		// build their CreateRequest here (multi-repo copies req.Env per spec).
+		ScriptEnv: req.Env,
 	}
 }
 

--- a/apps/backend/internal/agent/runtime/lifecycle/env_preparer_worktree_env_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/env_preparer_worktree_env_test.go
@@ -1,0 +1,25 @@
+package lifecycle
+
+import "testing"
+
+// TestBuildWorktreeCreateRequestForwardsProfileEnv guards that resolved
+// executor-profile env vars (already merged into EnvPrepareRequest.Env) are
+// forwarded to the worktree CreateRequest so the repository setup script can
+// use them (e.g. an npm auth token during install). Both single-repo and
+// multi-repo launches build their CreateRequest here — multi-repo copies
+// req.Env into each per-repo sub-request — so covering the builder covers both.
+func TestBuildWorktreeCreateRequestForwardsProfileEnv(t *testing.T) {
+	req := &EnvPrepareRequest{
+		TaskID:         "task-1",
+		RepositoryPath: "/repo",
+		Env: map[string]string{
+			"FONTAWESOME_NPM_AUTH_TOKEN": "fa-secret-value",
+		},
+	}
+
+	got := buildWorktreeCreateRequest(req)
+
+	if got.ScriptEnv["FONTAWESOME_NPM_AUTH_TOKEN"] != "fa-secret-value" {
+		t.Fatalf("CreateRequest.ScriptEnv = %#v, want profile env forwarded", got.ScriptEnv)
+	}
+}

--- a/apps/backend/internal/worktree/manager_cleanup.go
+++ b/apps/backend/internal/worktree/manager_cleanup.go
@@ -369,7 +369,7 @@ func mergeScriptEnv(profileEnv, managed map[string]string) map[string]string {
 	if len(profileEnv) == 0 && len(managed) == 0 {
 		return nil
 	}
-	merged := make(map[string]string, len(profileEnv)+len(managed))
+	merged := make(map[string]string, len(profileEnv))
 	for k, v := range profileEnv {
 		merged[k] = v
 	}

--- a/apps/backend/internal/worktree/manager_cleanup.go
+++ b/apps/backend/internal/worktree/manager_cleanup.go
@@ -278,7 +278,7 @@ func (m *Manager) ReleaseWorktreeReference(ctx context.Context, wt *Worktree) er
 // and the failure is recorded on wt as a warning (surfaced by the env preparer)
 // so the agent can still launch. This mirrors the task-level setup script
 // behavior in runSetupScriptStep — a broken setup script must not block the task.
-func (m *Manager) runWorktreeSetupScript(ctx context.Context, wt *Worktree) {
+func (m *Manager) runWorktreeSetupScript(ctx context.Context, wt *Worktree, profileEnv map[string]string) {
 	if m.scriptMsgHandler == nil || m.repoProvider == nil {
 		return
 	}
@@ -307,7 +307,7 @@ func (m *Manager) runWorktreeSetupScript(ctx context.Context, wt *Worktree) {
 		Script:       repo.SetupScript,
 		WorkingDir:   wt.Path,
 		ScriptType:   "setup",
-		Env:          m.managedScriptEnvironment(ctx),
+		Env:          mergeScriptEnv(profileEnv, m.managedScriptEnvironment(ctx)),
 	}
 	if err := m.scriptMsgHandler.ExecuteSetupScript(ctx, scriptReq); err != nil {
 		// Non-fatal: keep the worktree and surface a warning. The detailed
@@ -358,6 +358,25 @@ func (m *Manager) runWorktreeCleanupScript(ctx context.Context, wt *Worktree) {
 		m.logger.Info("cleanup script completed successfully",
 			zap.String("worktree_id", wt.ID))
 	}
+}
+
+// mergeScriptEnv combines resolved executor-profile env vars with the
+// install-managed script environment. Managed values (e.g. GOCACHE) take
+// precedence so the managed build cache is never clobbered by a profile entry.
+// Returns nil when both inputs are empty so callers preserve the "inherit the
+// full process environment" behavior of scriptProcessEnvironment(nil).
+func mergeScriptEnv(profileEnv, managed map[string]string) map[string]string {
+	if len(profileEnv) == 0 && len(managed) == 0 {
+		return nil
+	}
+	merged := make(map[string]string, len(profileEnv)+len(managed))
+	for k, v := range profileEnv {
+		merged[k] = v
+	}
+	for k, v := range managed {
+		merged[k] = v
+	}
+	return merged
 }
 
 func (m *Manager) managedScriptEnvironment(ctx context.Context) map[string]string {

--- a/apps/backend/internal/worktree/manager_lifecycle.go
+++ b/apps/backend/internal/worktree/manager_lifecycle.go
@@ -287,7 +287,7 @@ func (m *Manager) createInTaskDir(ctx context.Context, req CreateRequest, baseRe
 
 	// Setup script failures are non-fatal — runWorktreeSetupScript records a
 	// warning on wt and keeps the worktree so the agent can still launch.
-	m.runWorktreeSetupScript(ctx, wt)
+	m.runWorktreeSetupScript(ctx, wt, req.ScriptEnv)
 
 	m.logger.Info("created worktree in task directory",
 		zap.String("session_id", req.SessionID),

--- a/apps/backend/internal/worktree/manager_script_environment_test.go
+++ b/apps/backend/internal/worktree/manager_script_environment_test.go
@@ -48,7 +48,7 @@ func TestRunWorktreeCleanupScriptInjectsManagedGoCacheOnly(t *testing.T) {
 		RepositoryID: "repo-1",
 		Path:         t.TempDir(),
 	}
-	mgr.runWorktreeSetupScript(context.Background(), worktree)
+	mgr.runWorktreeSetupScript(context.Background(), worktree, nil)
 	mgr.runWorktreeCleanupScript(context.Background(), worktree)
 
 	if got := recorder.setupReq.Env["GOCACHE"]; got != "/opt/kandev/cache/go-build" {
@@ -59,5 +59,65 @@ func TestRunWorktreeCleanupScriptInjectsManagedGoCacheOnly(t *testing.T) {
 	}
 	if _, exists := recorder.cleanupReq.Env["TOKEN"]; exists {
 		t.Fatalf("cleanup script received unrelated provider environment: %#v", recorder.cleanupReq.Env)
+	}
+}
+
+// TestManagerCreate_SetupScriptReceivesProfileEnv covers the fix for the
+// executor-profile env var (e.g. an npm auth token) not reaching the repository
+// setup script. Create() runs the per-repo setup script, and CreateRequest.ScriptEnv
+// (resolved executor-profile env) must be exported into that script's process
+// environment while the managed GOCACHE is preserved. Exercises the single-repo
+// path; the multi-repo path builds the same CreateRequest via
+// buildWorktreeCreateRequest, so this also guards it (see the lifecycle test).
+func TestManagerCreate_SetupScriptReceivesProfileEnv(t *testing.T) {
+	repoPath := initGitRepoForWorktreeTest(t)
+	provider := &fakeRepoProvider{repo: &Repository{ID: "repo-env", SetupScript: "npm install"}}
+	recorder := &cleanupEnvironmentRecorder{}
+	mgr := newManagerForSetupTest(t, provider, recorder)
+	mgr.SetScriptEnvironmentProvider(staticScriptEnvironment{env: map[string]string{
+		"GOCACHE": "/opt/kandev/cache/go-build",
+	}})
+
+	_, err := mgr.Create(context.Background(), CreateRequest{
+		TaskID:         "task-env",
+		SessionID:      "session-env",
+		TaskTitle:      "Setup script needs token",
+		RepositoryID:   "repo-env",
+		RepositoryPath: repoPath,
+		BaseBranch:     "main",
+		TaskDirName:    "task-env",
+		RepoName:       "repo-env",
+		ScriptEnv: map[string]string{
+			"FONTAWESOME_NPM_AUTH_TOKEN": "fa-secret-value",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create() unexpected error: %v", err)
+	}
+	if got := recorder.setupReq.Env["FONTAWESOME_NPM_AUTH_TOKEN"]; got != "fa-secret-value" {
+		t.Fatalf("setup script FONTAWESOME_NPM_AUTH_TOKEN = %q, want profile secret; env=%#v",
+			got, recorder.setupReq.Env)
+	}
+	if got := recorder.setupReq.Env["GOCACHE"]; got != "/opt/kandev/cache/go-build" {
+		t.Fatalf("setup script GOCACHE = %q, want managed path preserved", got)
+	}
+}
+
+func TestMergeScriptEnv(t *testing.T) {
+	if got := mergeScriptEnv(nil, nil); got != nil {
+		t.Fatalf("mergeScriptEnv(nil, nil) = %#v, want nil (inherit full process env)", got)
+	}
+
+	// Managed values win over profile entries so the build cache is never
+	// clobbered by a user-supplied variable of the same name.
+	merged := mergeScriptEnv(
+		map[string]string{"TOKEN": "secret", "GOCACHE": "/profile/override"},
+		map[string]string{"GOCACHE": "/managed/cache"},
+	)
+	if merged["TOKEN"] != "secret" {
+		t.Fatalf("merged TOKEN = %q, want profile value", merged["TOKEN"])
+	}
+	if merged["GOCACHE"] != "/managed/cache" {
+		t.Fatalf("merged GOCACHE = %q, want managed value to win", merged["GOCACHE"])
 	}
 }

--- a/apps/backend/internal/worktree/manager_script_environment_test.go
+++ b/apps/backend/internal/worktree/manager_script_environment_test.go
@@ -120,4 +120,14 @@ func TestMergeScriptEnv(t *testing.T) {
 	if merged["GOCACHE"] != "/managed/cache" {
 		t.Fatalf("merged GOCACHE = %q, want managed value to win", merged["GOCACHE"])
 	}
+
+	// Profile-only: managed nil, profile entries survive.
+	if got := mergeScriptEnv(map[string]string{"TOKEN": "secret"}, nil); got["TOKEN"] != "secret" {
+		t.Fatalf("mergeScriptEnv(profile, nil)[TOKEN] = %q, want profile value", got["TOKEN"])
+	}
+
+	// Managed-only: profile nil, managed entries survive.
+	if got := mergeScriptEnv(nil, map[string]string{"GOCACHE": "/managed/cache"}); got["GOCACHE"] != "/managed/cache" {
+		t.Fatalf("mergeScriptEnv(nil, managed)[GOCACHE] = %q, want managed value", got["GOCACHE"])
+	}
 }

--- a/apps/backend/internal/worktree/worktree.go
+++ b/apps/backend/internal/worktree/worktree.go
@@ -201,6 +201,14 @@ type CreateRequest struct {
 	// may differ from BranchSlug when the primary branch keeps the flat path.
 	BranchIdentitySlug string
 
+	// ScriptEnv carries resolved executor-profile environment variables
+	// (secrets already revealed) that must be exported into the repository
+	// setup script's process environment — e.g. an npm auth token needed by
+	// `npm install`. Merged over the install-managed script environment
+	// (GOCACHE) when the per-repo setup script runs. Transient per Create;
+	// never persisted on the Worktree record, so secrets stay out of the DB.
+	ScriptEnv map[string]string
+
 	// OnSyncProgress receives progress updates for pre-worktree branch sync.
 	OnSyncProgress SyncProgressCallback
 

--- a/apps/backend/internal/worktree/worktree.go
+++ b/apps/backend/internal/worktree/worktree.go
@@ -204,9 +204,10 @@ type CreateRequest struct {
 	// ScriptEnv carries resolved executor-profile environment variables
 	// (secrets already revealed) that must be exported into the repository
 	// setup script's process environment — e.g. an npm auth token needed by
-	// `npm install`. Merged over the install-managed script environment
-	// (GOCACHE) when the per-repo setup script runs. Transient per Create;
-	// never persisted on the Worktree record, so secrets stay out of the DB.
+	// `npm install`. Merged with the install-managed script environment;
+	// managed values such as GOCACHE take precedence on key collisions.
+	// Transient per Create; never persisted on the Worktree record, so
+	// secrets stay out of the DB.
 	ScriptEnv map[string]string
 
 	// OnSyncProgress receives progress updates for pre-worktree branch sync.


### PR DESCRIPTION
## Problem

The Worktree executor's profile **Environment Variables** (including secret-backed ones like a FontAwesome npm token) were resolved and reached the agent subprocess, but were **never exported into the repository setup script's environment**.

The repository setup script runs inside `worktree.Manager.Create` — which is exactly where `npm install` typically runs — and it was built with only the install-managed env (`GOCACHE`). So a `.npmrc` referencing `${FONTAWESOME_NPM_AUTH_TOKEN}` failed at install time. This affected **both single-repo and multi-repo** tasks, since both run their setup script through `Create`.

## Fix

Thread the resolved profile env into the setup script at the one point both paths converge:

- New transient `worktree.CreateRequest.ScriptEnv` field (secrets already revealed; **never persisted** to the `Worktree` record, so secrets stay out of the DB).
- `buildWorktreeCreateRequest` sets `ScriptEnv: req.Env` — used by the single-repo path and per-repo in multi-repo (which copies `req.Env` into each sub-request), so one change covers both.
- `runWorktreeSetupScript` merges it over the managed env via a new `mergeScriptEnv` helper. Managed `GOCACHE` keeps precedence so the build cache is never clobbered; returns `nil` when empty to preserve the "inherit full process env" behavior.

## Tests

- `TestManagerCreate_SetupScriptReceivesProfileEnv` — end-to-end through `Create`; confirmed red without the fix.
- `TestMergeScriptEnv` — merge precedence + nil semantics.
- `TestBuildWorktreeCreateRequestForwardsProfileEnv` — builder forwards `Env → ScriptEnv` (guards single + multi-repo).
- Existing `TestRunWorktreeCleanupScriptInjectsManagedGoCacheOnly` updated for the new signature; still green.

Changed-scope `verify` (full mode): `make fmt/build/lint` clean; changed-package tests green. (Six unrelated tests in `gitlab`/`notifications`/`task/handlers` fail identically at the merge-base commit — pre-existing, not caused by this change.)

## Known separate limitation (not addressed here)

For **multi-repo** tasks, the executor-profile **Prepare Script** (`req.SetupScript`, distinct from the per-repository setup script) is still intentionally not run at all (`env_preparer_worktree.go` — "handled by the caller in a future phase"). This PR fixes env export wherever setup scripts run; the multi-repo Prepare-Script-not-run gap is a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1971?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->