### PR TITLE
fix: guard Office launches without runtime context

### DIFF
--- a/apps/backend/cmd/agentctl/kandev_client.go
+++ b/apps/backend/cmd/agentctl/kandev_client.go
@@ -30,7 +30,9 @@ func newKandevClient() (*kandevClient, error) {
 	apiURL := normalizeKandevAPIURL(os.Getenv("KANDEV_API_URL"))
 	apiKey := os.Getenv("KANDEV_API_KEY")
 	if apiURL == "" || apiKey == "" {
-		return nil, fmt.Errorf("KANDEV_API_URL and KANDEV_API_KEY must be set")
+		return nil, fmt.Errorf(
+			"KANDEV_API_URL and KANDEV_API_KEY are injected automatically for Office runs; regular task sessions should use their Kandev MCP tools",
+		)
 	}
 	return &kandevClient{
 		apiURL:      apiURL,

--- a/apps/backend/cmd/agentctl/kandev_test.go
+++ b/apps/backend/cmd/agentctl/kandev_test.go
@@ -75,6 +75,7 @@ func TestNewKandevClient_MissingOfficeContextExplainsTaskModeAlternative(t *test
 	}
 	oldStderr := os.Stderr
 	os.Stderr = w
+	t.Cleanup(func() { os.Stderr = oldStderr })
 	code := runKandevCLI([]string{"projects", "list"})
 	_ = w.Close()
 	os.Stderr = oldStderr

--- a/apps/backend/cmd/agentctl/kandev_test.go
+++ b/apps/backend/cmd/agentctl/kandev_test.go
@@ -75,7 +75,10 @@ func TestNewKandevClient_MissingOfficeContextExplainsTaskModeAlternative(t *test
 	}
 	oldStderr := os.Stderr
 	os.Stderr = w
-	t.Cleanup(func() { os.Stderr = oldStderr })
+	t.Cleanup(func() {
+		os.Stderr = oldStderr
+		_ = w.Close()
+	})
 	code := runKandevCLI([]string{"projects", "list"})
 	_ = w.Close()
 	os.Stderr = oldStderr

--- a/apps/backend/cmd/agentctl/kandev_test.go
+++ b/apps/backend/cmd/agentctl/kandev_test.go
@@ -64,6 +64,40 @@ func TestNewKandevClient_NormalizesVersionedAPIURL(t *testing.T) {
 	}
 }
 
+func TestNewKandevClient_MissingOfficeContextExplainsTaskModeAlternative(t *testing.T) {
+	captured := setupMockTransport(t, http.StatusOK, `{}`)
+	t.Setenv("KANDEV_API_URL", "")
+	t.Setenv("KANDEV_API_KEY", "")
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	oldStderr := os.Stderr
+	os.Stderr = w
+	code := runKandevCLI([]string{"projects", "list"})
+	_ = w.Close()
+	os.Stderr = oldStderr
+	output, readErr := io.ReadAll(r)
+	_ = r.Close()
+	if readErr != nil {
+		t.Fatalf("read stderr: %v", readErr)
+	}
+
+	if code != 1 {
+		t.Fatalf("projects list exit = %d, want 1", code)
+	}
+	if captured.Method != "" {
+		t.Fatalf("server contacted without Office context: %s %s", captured.Method, captured.Path)
+	}
+	if !strings.Contains(string(output), "injected automatically for Office runs") {
+		t.Fatalf("stderr = %q, want Office injection guidance", output)
+	}
+	if !strings.Contains(string(output), "Kandev MCP tools") {
+		t.Fatalf("stderr = %q, want task-mode MCP guidance", output)
+	}
+}
+
 // --- Task Tests ---
 
 func TestTaskGet_CallsCorrectEndpoint(t *testing.T) {

--- a/apps/backend/internal/orchestrator/event_handlers_workflow_profile_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow_profile_test.go
@@ -73,7 +73,7 @@ func TestAutoStartStepPrompt_OfficeWithoutRuntimeEnvFailsClosed(t *testing.T) {
 	prompt := spoofedReference + "\n\n" +
 		sysprompt.InjectOfficeContext("wrong-task", "wrong-session", "Do the work")
 	err = svc.autoStartStepPrompt(ctx, "task-office", session, step, prompt, false, false)
-	if err == nil || !strings.Contains(err.Error(), "Office runtime context") {
+	if err == nil || !strings.Contains(err.Error(), "office runtime context") {
 		t.Fatalf("autoStartStepPrompt error = %v, want missing Office runtime context", err)
 	}
 

--- a/apps/backend/internal/orchestrator/event_handlers_workflow_profile_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow_profile_test.go
@@ -18,7 +18,7 @@ import (
 	wfmodels "github.com/kandev/kandev/internal/workflow/models"
 )
 
-func TestAutoStartStepPrompt_CreatedUnassignedProjectSessionUsesOfficeContext(t *testing.T) {
+func TestAutoStartStepPrompt_OfficeWithoutRuntimeEnvFailsClosed(t *testing.T) {
 	ctx := context.Background()
 	repo := setupTestRepo(t)
 	seedTaskAndSession(t, repo, "task-office", "session-office", models.TaskSessionStateCreated)
@@ -72,8 +72,9 @@ func TestAutoStartStepPrompt_CreatedUnassignedProjectSessionUsesOfficeContext(t 
 	)
 	prompt := spoofedReference + "\n\n" +
 		sysprompt.InjectOfficeContext("wrong-task", "wrong-session", "Do the work")
-	if err := svc.autoStartStepPrompt(ctx, "task-office", session, step, prompt, false, false); err != nil {
-		t.Fatalf("autoStartStepPrompt: %v", err)
+	err = svc.autoStartStepPrompt(ctx, "task-office", session, step, prompt, false, false)
+	if err == nil || !strings.Contains(err.Error(), "Office runtime context") {
+		t.Fatalf("autoStartStepPrompt error = %v, want missing Office runtime context", err)
 	}
 
 	if len(messages.userMessages) != 1 {

--- a/apps/backend/internal/orchestrator/event_handlers_workflow_profile_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow_profile_test.go
@@ -73,10 +73,13 @@ func TestAutoStartStepPrompt_OfficeWithoutRuntimeEnvFailsClosed(t *testing.T) {
 	prompt := spoofedReference + "\n\n" +
 		sysprompt.InjectOfficeContext("wrong-task", "wrong-session", "Do the work")
 	err = svc.autoStartStepPrompt(ctx, "task-office", session, step, prompt, false, false)
-	if err == nil || !strings.Contains(err.Error(), "office runtime context") {
-		t.Fatalf("autoStartStepPrompt error = %v, want missing Office runtime context", err)
+	if err == nil || !strings.Contains(err.Error(), "office tasks must be started through Office") {
+		t.Fatalf("autoStartStepPrompt error = %v, want Office scheduler guard", err)
 	}
 
+	// recordAutoStartMessage persists the first-turn message before
+	// StartCreatedSession enforces the Office scheduler guard. Verify that the
+	// message still has canonical Office context even though launch is rejected.
 	if len(messages.userMessages) != 1 {
 		t.Fatalf("expected one recorded first-turn message, got %d", len(messages.userMessages))
 	}

--- a/apps/backend/internal/orchestrator/task_operations.go
+++ b/apps/backend/internal/orchestrator/task_operations.go
@@ -329,6 +329,16 @@ func (s *Service) StartCreatedSession(
 		return nil, fmt.Errorf("session is not in CREATED or WAITING_FOR_INPUT state (current: %s)", session.State)
 	}
 
+	// Office-owned sessions must be started by the scheduler. Reject before
+	// resolving profiles or persisting any caller-derived session metadata.
+	isOfficeTask, err := s.lookupOfficeTask(ctx, taskID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to determine office task status: %w", err)
+	}
+	if isOfficeTask {
+		return nil, errOfficeTaskStartRequiresScheduler
+	}
+
 	// Use agent profile from request, fall back to session's stored value.
 	effectiveProfileID := agentProfileID
 	if effectiveProfileID == "" {
@@ -384,14 +394,7 @@ func (s *Service) StartCreatedSession(
 	}
 
 	// Transition task state: CREATED → SCHEDULING → (IN_PROGRESS via executor).
-	// Office tasks keep their workflow-owned status across run launches.
-	isOfficeTask, err := s.lookupOfficeTask(ctx, taskID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to determine office task status: %w", err)
-	}
-	if isOfficeTask {
-		return nil, errOfficeTaskStartRequiresScheduler
-	} else if err := s.scheduleTaskForSession(ctx, taskID, sessionID); err != nil {
+	if err := s.scheduleTaskForSession(ctx, taskID, sessionID); err != nil {
 		s.logger.Warn("failed to update task state to SCHEDULING",
 			zap.String("task_id", taskID),
 			zap.Error(err))

--- a/apps/backend/internal/orchestrator/task_operations.go
+++ b/apps/backend/internal/orchestrator/task_operations.go
@@ -1793,11 +1793,11 @@ func (s *Service) startAgentOnPreparedWorkspace(ctx context.Context, sessionID s
 	// WAITING_FOR_INPUT — that's what waitForSessionReady polls for. No flag
 	// tracking required here.
 	launchCtx := context.WithoutCancel(ctx)
-	dbTask, err := s.repo.GetTask(launchCtx, session.TaskID)
+	isOfficeTask, err := s.lookupOfficeTask(launchCtx, session.TaskID)
 	if err != nil {
 		return fmt.Errorf("failed to determine office task status: %w", err)
 	}
-	if dbTask != nil && dbTask.IsFromOffice {
+	if isOfficeTask {
 		return errOfficePreparedResumeRequiresScheduler
 	}
 	task, err := s.scheduler.GetTask(launchCtx, session.TaskID)

--- a/apps/backend/internal/orchestrator/task_operations.go
+++ b/apps/backend/internal/orchestrator/task_operations.go
@@ -390,11 +390,7 @@ func (s *Service) StartCreatedSession(
 		return nil, fmt.Errorf("failed to determine office task status: %w", err)
 	}
 	if isOfficeTask {
-		if err := validateOfficeRuntimeEnv(nil); err != nil {
-			return nil, err
-		}
-		s.logger.Debug("skipping SCHEDULING transition for office task",
-			zap.String("task_id", taskID))
+		return nil, errOfficeTaskStartRequiresScheduler
 	} else if err := s.scheduleTaskForSession(ctx, taskID, sessionID); err != nil {
 		s.logger.Warn("failed to update task state to SCHEDULING",
 			zap.String("task_id", taskID),
@@ -721,7 +717,7 @@ func (s *Service) startTask(ctx context.Context, taskID string, agentProfileID s
 		return nil, fmt.Errorf("failed to determine office task status: %w", err)
 	}
 	if isOfficeTask {
-		if err := validateOfficeRuntimeEnv(env); err != nil {
+		if err := validateOfficeLaunchEnv(taskID, env); err != nil {
 			return nil, err
 		}
 	}
@@ -918,6 +914,7 @@ func validateOfficeRuntimeEnv(env map[string]string) error {
 		"KANDEV_AGENT_ID",
 		"KANDEV_WORKSPACE_ID",
 		"KANDEV_RUN_ID",
+		"KANDEV_TASK_ID",
 	}
 	missing := make([]string, 0, len(required))
 	for _, key := range required {
@@ -932,6 +929,35 @@ func validateOfficeRuntimeEnv(env map[string]string) error {
 		"office runtime context is incomplete (missing %s); start or wake the task through Office",
 		strings.Join(missing, ", "),
 	)
+}
+
+var (
+	errOfficeTaskStartRequiresScheduler = errors.New(
+		"office tasks must be started through Office; use StartTaskWithEnv with scheduler-injected credentials",
+	)
+	errOfficeTaskResumeRequiresScheduler = errors.New(
+		"office tasks must be resumed through Office; use the Office scheduler to start a fresh run",
+	)
+	errOfficePreparedResumeRequiresScheduler = errors.New(
+		"office tasks must be restarted through Office; prepared-workspace resume is not supported for Office-owned tasks",
+	)
+)
+
+// validateOfficeLaunchEnv requires the scheduler context to be bound to the
+// task being launched. StartTaskWithEnv is only wired to the internal Office
+// scheduler adapter; the task binding still prevents a complete context map
+// from being reused for a different task.
+func validateOfficeLaunchEnv(taskID string, env map[string]string) error {
+	if err := validateOfficeRuntimeEnv(env); err != nil {
+		return err
+	}
+	if env["KANDEV_TASK_ID"] != taskID {
+		return fmt.Errorf(
+			"office runtime context is bound to task %q, not %q; start or wake the task through Office",
+			env["KANDEV_TASK_ID"], taskID,
+		)
+	}
+	return nil
 }
 
 // prepareSessionForStart creates the session for a launch and propagates any
@@ -1286,6 +1312,14 @@ func (s *Service) ResumeTaskSession(ctx context.Context, taskID, sessionID strin
 		return nil, fmt.Errorf("session is completed and cannot be resumed; create a new session instead")
 	}
 
+	isOfficeTask, err := s.lookupOfficeTask(ctx, taskID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to determine office task status: %w", err)
+	}
+	if isOfficeTask {
+		return nil, errOfficeTaskResumeRequiresScheduler
+	}
+
 	// Bury any open turns from the previous run before relaunching. Without
 	// this, startTurnForSession adopts the orphan on the next prompt and the
 	// UI's running timer counts from the orphan's started_at — which can be
@@ -1542,12 +1576,20 @@ func (s *Service) advanceTaskWorkflowStep(ctx context.Context, task *models.Task
 // After lazy recovery, a session may be in WAITING_FOR_INPUT with no agent process;
 // this function detects that case and triggers a resume.
 func (s *Service) ensureSessionRunning(ctx context.Context, sessionID string, session *models.TaskSession) error {
+	isOfficeTask, err := s.lookupOfficeTask(ctx, session.TaskID)
+	if err != nil {
+		return fmt.Errorf("failed to determine office task status: %w", err)
+	}
+
 	// Check if agent is genuinely running (in-memory execution store, not just DB state)
 	if exec, ok := s.executor.GetExecutionBySession(sessionID); ok && exec != nil {
 		s.recoverAgentPromptStreamIfNeeded(ctx, sessionID)
 		if err := s.waitForAgentPromptReady(ctx, sessionID); err != nil {
 			if !errors.Is(err, ErrAgentNotReadyForPrompt) {
 				return err
+			}
+			if isOfficeTask {
+				return errOfficeTaskResumeRequiresScheduler
 			}
 			recoveryCtx := context.WithoutCancel(ctx)
 			if stopErr := s.reapPromptUnreadyExecution(recoveryCtx, sessionID, err); stopErr != nil {
@@ -1577,6 +1619,9 @@ func (s *Service) ensureSessionRunning(ctx context.Context, sessionID string, se
 		if hasRunning {
 			return s.startAgentOnPreparedWorkspace(ctx, sessionID, session)
 		}
+	}
+	if isOfficeTask {
+		return errOfficeTaskResumeRequiresScheduler
 	}
 
 	running, err := s.repo.GetExecutorRunningBySessionID(ctx, sessionID)
@@ -1745,18 +1790,16 @@ func (s *Service) startAgentOnPreparedWorkspace(ctx context.Context, sessionID s
 	// WAITING_FOR_INPUT — that's what waitForSessionReady polls for. No flag
 	// tracking required here.
 	launchCtx := context.WithoutCancel(ctx)
-	task, err := s.scheduler.GetTask(launchCtx, session.TaskID)
-	if err != nil {
-		return fmt.Errorf("failed to get task for prepared session: %w", err)
-	}
-	isOfficeTask, err := s.lookupOfficeTask(launchCtx, session.TaskID)
+	dbTask, err := s.repo.GetTask(launchCtx, session.TaskID)
 	if err != nil {
 		return fmt.Errorf("failed to determine office task status: %w", err)
 	}
-	if isOfficeTask {
-		if err := validateOfficeRuntimeEnv(nil); err != nil {
-			return err
-		}
+	if dbTask != nil && dbTask.IsFromOffice {
+		return errOfficePreparedResumeRequiresScheduler
+	}
+	task, err := s.scheduler.GetTask(launchCtx, session.TaskID)
+	if err != nil {
+		return fmt.Errorf("failed to get task for prepared session: %w", err)
 	}
 	if _, err = s.executor.LaunchPreparedSession(launchCtx, task, sessionID, executor.LaunchOptions{
 		AgentProfileID: session.AgentProfileID,

--- a/apps/backend/internal/orchestrator/task_operations.go
+++ b/apps/backend/internal/orchestrator/task_operations.go
@@ -390,6 +390,9 @@ func (s *Service) StartCreatedSession(
 		return nil, fmt.Errorf("failed to determine office task status: %w", err)
 	}
 	if isOfficeTask {
+		if err := validateOfficeRuntimeEnv(nil); err != nil {
+			return nil, err
+		}
 		s.logger.Debug("skipping SCHEDULING transition for office task",
 			zap.String("task_id", taskID))
 	} else if err := s.scheduleTaskForSession(ctx, taskID, sessionID); err != nil {
@@ -717,6 +720,11 @@ func (s *Service) startTask(ctx context.Context, taskID string, agentProfileID s
 	if err != nil {
 		return nil, fmt.Errorf("failed to determine office task status: %w", err)
 	}
+	if isOfficeTask {
+		if err := validateOfficeRuntimeEnv(env); err != nil {
+			return nil, err
+		}
+	}
 
 	// Office tasks do NOT transition through SCHEDULING / IN_PROGRESS on
 	// every run. Their lifecycle status (todo / in_review / done /
@@ -900,6 +908,30 @@ func (s *Service) lookupOfficeTask(ctx context.Context, taskID string) (bool, er
 		return false, err
 	}
 	return dbTask != nil && dbTask.IsFromOffice, nil
+}
+
+func validateOfficeRuntimeEnv(env map[string]string) error {
+	required := []string{
+		"KANDEV_CLI",
+		"KANDEV_API_URL",
+		"KANDEV_API_KEY",
+		"KANDEV_AGENT_ID",
+		"KANDEV_WORKSPACE_ID",
+		"KANDEV_RUN_ID",
+	}
+	missing := make([]string, 0, len(required))
+	for _, key := range required {
+		if strings.TrimSpace(env[key]) == "" {
+			missing = append(missing, key)
+		}
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+	return fmt.Errorf(
+		"office runtime context is incomplete (missing %s); start or wake the task through Office",
+		strings.Join(missing, ", "),
+	)
 }
 
 // prepareSessionForStart creates the session for a launch and propagates any
@@ -1716,6 +1748,15 @@ func (s *Service) startAgentOnPreparedWorkspace(ctx context.Context, sessionID s
 	task, err := s.scheduler.GetTask(launchCtx, session.TaskID)
 	if err != nil {
 		return fmt.Errorf("failed to get task for prepared session: %w", err)
+	}
+	isOfficeTask, err := s.lookupOfficeTask(launchCtx, session.TaskID)
+	if err != nil {
+		return fmt.Errorf("failed to determine office task status: %w", err)
+	}
+	if isOfficeTask {
+		if err := validateOfficeRuntimeEnv(nil); err != nil {
+			return err
+		}
 	}
 	if _, err = s.executor.LaunchPreparedSession(launchCtx, task, sessionID, executor.LaunchOptions{
 		AgentProfileID: session.AgentProfileID,

--- a/apps/backend/internal/orchestrator/task_operations_test.go
+++ b/apps/backend/internal/orchestrator/task_operations_test.go
@@ -3061,8 +3061,8 @@ func TestStartCreatedSession_OfficeWithoutRuntimeEnvFailsClosed(t *testing.T) {
 		preWrapped, false, false, true, nil, nil,
 	)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "office runtime context")
-	assert.Contains(t, err.Error(), "start or wake the task through Office")
+	assert.Contains(t, err.Error(), "office tasks must be started through Office")
+	assert.Contains(t, err.Error(), "StartTaskWithEnv")
 	require.Empty(t, messages.userMessages)
 
 	if writes := taskRepo.stateWrites["task1"]; writes != 0 {
@@ -3940,6 +3940,47 @@ func TestResumeTaskSession_WrongTask(t *testing.T) {
 	_, err := svc.ResumeTaskSession(context.Background(), "task1", "session1")
 	if err == nil {
 		t.Fatal("expected error when session does not belong to task")
+	}
+}
+
+func TestResumeTaskSession_OfficeWithoutSchedulerFailsClosed(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedTaskAndSession(t, repo, "task1", "session1", models.TaskSessionStateWaitingForInput)
+	dbTask, err := repo.GetTask(ctx, "task1")
+	if err != nil {
+		t.Fatalf("failed to load task: %v", err)
+	}
+	dbTask.ProjectID = "project-office"
+	if err := repo.UpdateTask(ctx, dbTask); err != nil {
+		t.Fatalf("failed to mark task as Office-owned: %v", err)
+	}
+	session, err := repo.GetTaskSession(ctx, "session1")
+	if err != nil {
+		t.Fatalf("failed to load session: %v", err)
+	}
+	session.AgentProfileID = "profile1"
+	if err := repo.UpdateTaskSession(ctx, session); err != nil {
+		t.Fatalf("failed to update session: %v", err)
+	}
+	seedExecutorRunning(t, repo, "session1", "task1", "exec-1")
+
+	launchCalled := false
+	agentMgr := &mockAgentManager{
+		launchAgentFunc: func(_ context.Context, _ *executor.LaunchAgentRequest) (*executor.LaunchAgentResponse, error) {
+			launchCalled = true
+			return &executor.LaunchAgentResponse{AgentExecutionID: "exec-1"}, nil
+		},
+	}
+	svc := createTestServiceWithAgent(repo, newMockStepGetter(), newMockTaskRepo(), agentMgr)
+	svc.executor = executor.NewExecutor(agentMgr, repo, testLogger(), executor.ExecutorConfig{})
+
+	_, err = svc.ResumeTaskSession(ctx, "task1", "session1")
+	if err == nil || !strings.Contains(err.Error(), "office tasks must be resumed through Office") {
+		t.Fatalf("ResumeTaskSession error = %v, want Office scheduler guard", err)
+	}
+	if launchCalled {
+		t.Fatal("Office resume guard must run before launching an agent")
 	}
 }
 
@@ -5249,8 +5290,36 @@ func TestEnsureSessionRunning_OfficeWithoutRuntimeEnvFailsClosed(t *testing.T) {
 
 	err = svc.ensureSessionRunning(ctx, "session1", session)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "office runtime context")
+	assert.Contains(t, err.Error(), "office tasks must be restarted through Office")
 	assert.False(t, startAgentProcessCalled)
+}
+
+func TestEnsureSessionRunning_OfficeWaitingForInputFailsClosed(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedTaskAndSession(t, repo, "task1", "session1", models.TaskSessionStateWaitingForInput)
+	dbTask, err := repo.GetTask(ctx, "task1")
+	require.NoError(t, err)
+	dbTask.ProjectID = "project-office"
+	require.NoError(t, repo.UpdateTask(ctx, dbTask))
+	seedExecutorRunning(t, repo, "session1", "task1", "exec-1")
+
+	launchCalled := false
+	agentMgr := &mockAgentManager{
+		launchAgentFunc: func(_ context.Context, _ *executor.LaunchAgentRequest) (*executor.LaunchAgentResponse, error) {
+			launchCalled = true
+			return &executor.LaunchAgentResponse{AgentExecutionID: "exec-1"}, nil
+		},
+	}
+	svc := createTestServiceWithAgent(repo, newMockStepGetter(), newMockTaskRepo(), agentMgr)
+	svc.executor = executor.NewExecutor(agentMgr, repo, testLogger(), executor.ExecutorConfig{})
+
+	session, err := repo.GetTaskSession(ctx, "session1")
+	require.NoError(t, err)
+	err = svc.ensureSessionRunning(ctx, "session1", session)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "office tasks must be resumed through Office")
+	assert.False(t, launchCalled)
 }
 
 func validOfficeRuntimeEnv() map[string]string {
@@ -5261,7 +5330,36 @@ func validOfficeRuntimeEnv() map[string]string {
 		"KANDEV_AGENT_ID":     "agent-1",
 		"KANDEV_WORKSPACE_ID": "workspace-1",
 		"KANDEV_RUN_ID":       "run-1",
+		"KANDEV_TASK_ID":      "task1",
 	}
+}
+
+func TestStartTaskWithEnv_RejectsContextBoundToAnotherTask(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedTaskAndSession(t, repo, "task1", "session1", models.TaskSessionStateCompleted)
+	dbTask, err := repo.GetTask(ctx, "task1")
+	require.NoError(t, err)
+	dbTask.ProjectID = "project-office"
+	require.NoError(t, repo.UpdateTask(ctx, dbTask))
+
+	launchCalled := false
+	agentMgr := &mockAgentManager{
+		launchAgentFunc: func(_ context.Context, _ *executor.LaunchAgentRequest) (*executor.LaunchAgentResponse, error) {
+			launchCalled = true
+			return &executor.LaunchAgentResponse{AgentExecutionID: "exec-1"}, nil
+		},
+	}
+	taskRepo := newMockTaskRepo()
+	taskRepo.tasks["task1"] = &v1.Task{ID: "task1", Title: "Office task", State: v1.TaskStateInProgress}
+	svc := createTestServiceWithScheduler(repo, newMockStepGetter(), taskRepo, agentMgr)
+	env := validOfficeRuntimeEnv()
+	env["KANDEV_TASK_ID"] = "forged-task"
+
+	_, err = svc.StartTaskWithEnv(ctx, "task1", "profile1", "", "", "", "Do the work", "", false, false, nil, env)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "bound to task")
+	assert.False(t, launchCalled)
 }
 
 func TestEnsureSessionRunning_WaitingForInputUsesResumePath(t *testing.T) {

--- a/apps/backend/internal/orchestrator/task_operations_test.go
+++ b/apps/backend/internal/orchestrator/task_operations_test.go
@@ -3029,7 +3029,7 @@ func TestStartCreatedSession_EmptyProfileFallsBackToWorkflowDefault(t *testing.T
 	}
 }
 
-func TestStartCreatedSession_UnassignedProjectTaskUsesOfficeMode(t *testing.T) {
+func TestStartCreatedSession_OfficeWithoutRuntimeEnvFailsClosed(t *testing.T) {
 	ctx := context.Background()
 	repo := setupTestRepo(t)
 	seedTaskAndSession(t, repo, "task1", "session1", models.TaskSessionStateCreated)
@@ -3056,21 +3056,14 @@ func TestStartCreatedSession_UnassignedProjectTaskUsesOfficeMode(t *testing.T) {
 	svc.messageCreator = messages
 
 	preWrapped := sysprompt.InjectKandevContext("wrong-task", "wrong-session", "Do the work", true)
-	if _, err := svc.StartCreatedSession(ctx, "task1", "session1", "profile1", preWrapped, false, false, true, nil, nil); err != nil {
-		t.Fatalf("StartCreatedSession: %v", err)
-	}
-	require.Len(t, messages.userMessages, 1)
-	assert.Contains(t, messages.userMessages[0].content, "KANDEV OFFICE MCP TOOLS")
-	assert.Contains(t, messages.userMessages[0].content, "$KANDEV_CLI")
-	assert.NotContains(t, messages.userMessages[0].content, "stop_task_kandev",
-		"Office first-turn context must not advertise a task-mode-only tool")
-	assert.NotContains(t, messages.userMessages[0].content, "list_workspaces_kandev")
-	assert.NotContains(t, messages.userMessages[0].content, "wrong-task")
-	assert.Equal(t, 1, strings.Count(messages.userMessages[0].content, sysprompt.TagStart))
-	agentMgr.mu.Lock()
-	mcpModeCalls := append([]sessionModeCall(nil), agentMgr.mcpModeCalls...)
-	agentMgr.mu.Unlock()
-	require.Equal(t, []sessionModeCall{{SessionID: "exec-1", ModeID: executor.McpModeOffice}}, mcpModeCalls)
+	_, err = svc.StartCreatedSession(
+		ctx, "task1", "session1", "profile1",
+		preWrapped, false, false, true, nil, nil,
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Office runtime context")
+	assert.Contains(t, err.Error(), "start or wake the task through Office")
+	require.Empty(t, messages.userMessages)
 
 	if writes := taskRepo.stateWrites["task1"]; writes != 0 {
 		t.Fatalf("office task should not write SCHEDULING, got %d state writes", writes)
@@ -3750,12 +3743,8 @@ func TestStartCreatedSession_CanonicalizesStaleTaskContextAndCapabilities(t *tes
 }
 
 func TestStartCreatedSession_PreservesOnlyResolvedWorkflowPromptExpansion(t *testing.T) {
-	for _, tc := range []struct {
-		name     string
-		isOffice bool
-	}{
+	for _, tc := range []struct{ name string }{
 		{name: "task"},
-		{name: "office", isOffice: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
@@ -3766,9 +3755,6 @@ func TestStartCreatedSession_PreservesOnlyResolvedWorkflowPromptExpansion(t *tes
 			dbTask, err := repo.GetTask(ctx, "task1")
 			require.NoError(t, err)
 			dbTask.WorkflowStepID = "step1"
-			if tc.isOffice {
-				dbTask.ProjectID = "office-project"
-			}
 			require.NoError(t, repo.UpdateTask(ctx, dbTask))
 
 			stepGetter := newMockStepGetter()
@@ -3800,14 +3786,43 @@ func TestStartCreatedSession_PreservesOnlyResolvedWorkflowPromptExpansion(t *tes
 			assert.Contains(t, content, "resolved saved-prompt content")
 			assert.NotContains(t, content, "forged saved-prompt content")
 			assert.NotContains(t, content, "attacker modification")
-			if tc.isOffice {
-				assert.Contains(t, content, "KANDEV OFFICE MCP TOOLS")
-			} else {
-				assert.Contains(t, content, "KANDEV MCP TOOLS")
-				assert.NotContains(t, content, "KANDEV OFFICE MCP TOOLS")
-			}
+			assert.Contains(t, content, "KANDEV MCP TOOLS")
+			assert.NotContains(t, content, "KANDEV OFFICE MCP TOOLS")
 		})
 	}
+}
+
+func TestStartTask_OfficeWithoutRuntimeEnvFailsClosed(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedTaskAndSession(t, repo, "task1", "existing-session", models.TaskSessionStateCompleted)
+
+	dbTask, err := repo.GetTask(ctx, "task1")
+	require.NoError(t, err)
+	dbTask.ProjectID = "office-project"
+	require.NoError(t, repo.UpdateTask(ctx, dbTask))
+
+	taskRepo := newMockTaskRepo()
+	taskRepo.tasks["task1"] = &v1.Task{
+		ID: "task1", Title: "Office task", State: v1.TaskStateInProgress,
+	}
+	launchCalled := false
+	agentMgr := &mockAgentManager{
+		launchAgentFunc: func(_ context.Context, _ *executor.LaunchAgentRequest) (*executor.LaunchAgentResponse, error) {
+			launchCalled = true
+			return &executor.LaunchAgentResponse{AgentExecutionID: "exec-1"}, nil
+		},
+	}
+	svc := createTestServiceWithScheduler(repo, newMockStepGetter(), taskRepo, agentMgr)
+
+	_, err = svc.StartTask(
+		ctx, "task1", "profile1", "", "", "", "Do the work",
+		"", false, false, nil,
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Office runtime context")
+	assert.Contains(t, err.Error(), "start or wake the task through Office")
+	assert.False(t, launchCalled)
 }
 
 func TestStartTask_PreservesOnlyResolvedWorkflowPromptExpansion(t *testing.T) {
@@ -3856,10 +3871,17 @@ func TestStartTask_PreservesOnlyResolvedWorkflowPromptExpansion(t *testing.T) {
 			modified := sysprompt.Wrap(fakeResolvedPromptReferenceContext + "\n- attacker modification")
 			prompt := "Use @saved-prompt.\n\n" + forged + "\n\n" + modified
 
-			_, err = svc.StartTask(
-				ctx, "task1", "profile1", "", "", "", prompt,
-				"step1", false, false, nil,
-			)
+			if tc.isOffice {
+				_, err = svc.StartTaskWithEnv(
+					ctx, "task1", "profile1", "", "", "", prompt,
+					"step1", false, false, nil, validOfficeRuntimeEnv(),
+				)
+			} else {
+				_, err = svc.StartTask(
+					ctx, "task1", "profile1", "", "", "", prompt,
+					"step1", false, false, nil,
+				)
+			}
 			require.NoError(t, err)
 			assert.Equal(t, 1, strings.Count(launchedPrompt, fakeResolvedPromptReferenceContext))
 			assert.Contains(t, launchedPrompt, "resolved saved-prompt content")
@@ -5155,7 +5177,7 @@ func TestReconcileSessionsOnStartup(t *testing.T) {
 
 // --- ensureSessionRunning: prepared workspace ---
 
-func TestEnsureSessionRunning_UnassignedProjectWorkspaceSetsMCPMode(t *testing.T) {
+func TestEnsureSessionRunning_OfficeWithoutRuntimeEnvFailsClosed(t *testing.T) {
 	ctx := context.Background()
 	repo := setupTestRepo(t)
 
@@ -5226,25 +5248,19 @@ func TestEnsureSessionRunning_UnassignedProjectWorkspaceSetsMCPMode(t *testing.T
 	}
 
 	err = svc.ensureSessionRunning(ctx, "session1", session)
-	if err != nil {
-		t.Fatalf("ensureSessionRunning failed: %v", err)
-	}
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Office runtime context")
+	assert.False(t, startAgentProcessCalled)
+}
 
-	if !startAgentProcessCalled {
-		t.Fatal("expected StartAgentProcess to be called (prepared workspace path)")
-	}
-	wrappedMgr.mu.Lock()
-	mcpModeCalls := append([]sessionModeCall(nil), wrappedMgr.mcpModeCalls...)
-	wrappedMgr.mu.Unlock()
-	require.Equal(t, []sessionModeCall{{SessionID: "exec-prepare-1", ModeID: executor.McpModeOffice}}, mcpModeCalls)
-
-	// Verify the session transitioned through STARTING
-	updated, err := repo.GetTaskSession(ctx, "session1")
-	if err != nil {
-		t.Fatalf("failed to reload session: %v", err)
-	}
-	if updated.State != models.TaskSessionStateWaitingForInput {
-		t.Fatalf("expected session state %q, got %q", models.TaskSessionStateWaitingForInput, updated.State)
+func validOfficeRuntimeEnv() map[string]string {
+	return map[string]string{
+		"KANDEV_CLI":          "/usr/local/bin/agentctl",
+		"KANDEV_API_URL":      "http://localhost:8080/api/v1",
+		"KANDEV_API_KEY":      "signed-run-token",
+		"KANDEV_AGENT_ID":     "agent-1",
+		"KANDEV_WORKSPACE_ID": "workspace-1",
+		"KANDEV_RUN_ID":       "run-1",
 	}
 }
 

--- a/apps/backend/internal/orchestrator/task_operations_test.go
+++ b/apps/backend/internal/orchestrator/task_operations_test.go
@@ -3064,6 +3064,9 @@ func TestStartCreatedSession_OfficeWithoutRuntimeEnvFailsClosed(t *testing.T) {
 	assert.Contains(t, err.Error(), "office tasks must be started through Office")
 	assert.Contains(t, err.Error(), "StartTaskWithEnv")
 	require.Empty(t, messages.userMessages)
+	unchanged, loadErr := repo.GetTaskSession(ctx, "session1")
+	require.NoError(t, loadErr)
+	assert.Empty(t, unchanged.AgentProfileID, "rejected Office start must not persist caller profile")
 
 	if writes := taskRepo.stateWrites["task1"]; writes != 0 {
 		t.Fatalf("office task should not write SCHEDULING, got %d state writes", writes)

--- a/apps/backend/internal/orchestrator/task_operations_test.go
+++ b/apps/backend/internal/orchestrator/task_operations_test.go
@@ -3061,7 +3061,7 @@ func TestStartCreatedSession_OfficeWithoutRuntimeEnvFailsClosed(t *testing.T) {
 		preWrapped, false, false, true, nil, nil,
 	)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "Office runtime context")
+	assert.Contains(t, err.Error(), "office runtime context")
 	assert.Contains(t, err.Error(), "start or wake the task through Office")
 	require.Empty(t, messages.userMessages)
 
@@ -3820,7 +3820,7 @@ func TestStartTask_OfficeWithoutRuntimeEnvFailsClosed(t *testing.T) {
 		"", false, false, nil,
 	)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "Office runtime context")
+	assert.Contains(t, err.Error(), "office runtime context")
 	assert.Contains(t, err.Error(), "start or wake the task through Office")
 	assert.False(t, launchCalled)
 }
@@ -5249,7 +5249,7 @@ func TestEnsureSessionRunning_OfficeWithoutRuntimeEnvFailsClosed(t *testing.T) {
 
 	err = svc.ensureSessionRunning(ctx, "session1", session)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "Office runtime context")
+	assert.Contains(t, err.Error(), "office runtime context")
 	assert.False(t, startAgentProcessCalled)
 }
 

--- a/docs/plans/office-agent-project-management/plan.md
+++ b/docs/plans/office-agent-project-management/plan.md
@@ -75,11 +75,13 @@ Files:
 - `apps/backend/internal/orchestrator/task_operations_test.go`
 
 Changes:
-- Validate the minimum Office runtime environment before any
+- Validate the minimum, task-bound Office runtime environment before any
   `LaunchPreparedSession` call selects `ModeOffice`.
 - Fail before starting the agent when a generic/manual/workflow path reaches an
   Office-owned task without scheduler-provided `KANDEV_CLI`,
   `KANDEV_API_URL`, `KANDEV_API_KEY`, agent/workspace identity, and run ID.
+- Reject generic Office resume and prepared-workspace relaunch paths; Office
+  recovery must return to the scheduler so it can mint fresh runtime context.
 - Preserve scheduler launches through `StartTaskWithEnv` and keep regular
   task-mode launches unchanged.
 

--- a/docs/plans/office-agent-project-management/plan.md
+++ b/docs/plans/office-agent-project-management/plan.md
@@ -10,6 +10,12 @@ status: implemented
 
 Make the default Office setup task executable by giving authorized Office agents a run-scoped project list/create surface, exposing it through `$KANDEV_CLI`, and allowing created follow-up tasks to carry `project_id`. Separately replace the generic Kanban tool inventory injected into Office turns with an exact Office capability context. This plan does not add workspace creation or expose Kanban completion tools to Office.
 
+Corrective follow-up: an Office-only prompt and CLI must never be launched
+without the scheduler-created signed runtime environment. Generic task/session
+start paths fail closed for Office-owned tasks when that context is absent, and
+the CLI/public docs explain that its API URL and key are automatic Office run
+credentials rather than user configuration.
+
 ## Backend
 
 ### Run-scoped project capability
@@ -62,6 +68,33 @@ Changes:
 - Add a `kandev-projects` system skill, default for CEOs, documenting list/create and task-project assignment.
 - Cross-check advertised Office tool names against the registered `ModeOffice` inventory. Assert that `step_complete_kandev` is absent.
 
+### Office launch-context invariant
+
+Files:
+- `apps/backend/internal/orchestrator/task_operations.go`
+- `apps/backend/internal/orchestrator/task_operations_test.go`
+
+Changes:
+- Validate the minimum Office runtime environment before any
+  `LaunchPreparedSession` call selects `ModeOffice`.
+- Fail before starting the agent when a generic/manual/workflow path reaches an
+  Office-owned task without scheduler-provided `KANDEV_CLI`,
+  `KANDEV_API_URL`, `KANDEV_API_KEY`, agent/workspace identity, and run ID.
+- Preserve scheduler launches through `StartTaskWithEnv` and keep regular
+  task-mode launches unchanged.
+
+### CLI context diagnostics
+
+Files:
+- `apps/backend/cmd/agentctl/kandev_client.go`
+- `apps/backend/cmd/agentctl/kandev_test.go`
+
+Changes:
+- Replace the bare missing-variable error with an actionable explanation that
+  the values are injected automatically for Office runs.
+- Direct regular task sessions to their Kandev MCP tools without suggesting
+  users manufacture or persist an Office JWT.
+
 ## Frontend
 
 No UI behavior changes. The existing onboarding wizard, project pages, and permission metadata renderer consume the backend contracts. The new permission must appear automatically through the existing permission metadata response.
@@ -86,6 +119,16 @@ No UI behavior changes. The existing onboarding wizard, project pages, and permi
 - **What:** onboarding's default setup brief is executable through the advertised Office CLI/tool surface.
   **File:** `apps/backend/internal/office/onboarding/service_test.go`
   **How:** contract test against required setup mutations and capability catalog.
+- **What:** Office-owned tasks cannot start in `ModeOffice` without a complete
+  scheduler-provided runtime environment, while scheduler and regular
+  task-mode launches retain their existing behavior.
+  **File:** `apps/backend/internal/orchestrator/task_operations_test.go`
+  **How:** focused orchestrator launch tests with captured executor requests.
+- **What:** invoking the CLI outside an Office run returns actionable,
+  non-secret-bearing guidance.
+  **File:** `apps/backend/cmd/agentctl/kandev_test.go`
+  **How:** run the command with the two required variables unset and assert the
+  structured error and zero HTTP dispatch.
 
 ## E2E Tests
 
@@ -104,6 +147,13 @@ Wave 3:
 - [x] [task-04-office-integration-verification](task-04-office-integration-verification.md)
 - [x] [task-05-public-docs](task-05-public-docs.md)
 
+Wave 4 (parallel):
+- [x] [task-06-office-launch-context-guard](task-06-office-launch-context-guard.md)
+- [x] [task-07-cli-context-diagnostic](task-07-cli-context-diagnostic.md)
+
+Wave 5:
+- [x] [task-08-public-runtime-credentials-docs](task-08-public-runtime-credentials-docs.md)
+
 ## Verification Commands
 
 ```bash
@@ -118,4 +168,6 @@ node scripts/validate-public-docs.mjs
 
 ## Open Questions
 
-None. Project creation is CEO-only by default but remains individually grantable through `can_create_projects`. Additional workspace creation remains human-owned and out of scope.
+None. The approved corrective contract fails generic manual/workflow Office
+launches before process start instead of minting a second, unaudited credential
+class or silently granting the broader task-mode MCP surface.

--- a/docs/plans/office-agent-project-management/task-06-office-launch-context-guard.md
+++ b/docs/plans/office-agent-project-management/task-06-office-launch-context-guard.md
@@ -1,0 +1,61 @@
+---
+id: "06-office-launch-context-guard"
+title: "Guard Office launch context"
+status: done
+wave: 4
+depends_on: []
+plan: "plan.md"
+spec: "../../specs/office/agents.md"
+---
+
+# Task 06: Guard Office launch context
+
+## Acceptance
+
+- Every orchestrator path selecting `ModeOffice` verifies the
+  scheduler-provided CLI path, API URL, signed token, agent/workspace identity,
+  and run ID before starting the agent process.
+- A generic manual or workflow launch of an Office-owned task without that
+  context fails closed with actionable guidance.
+- Scheduler launches through `StartTaskWithEnv` and non-Office task launches
+  keep their existing behavior.
+
+## Verification
+
+```bash
+cd apps/backend && rtk go test ./internal/orchestrator -run 'Test(StartCreatedSession|StartTask).*Office.*(RuntimeEnv|LaunchContext)' -count=1
+```
+
+## Files Likely Touched
+
+- `apps/backend/internal/orchestrator/task_operations.go`
+- `apps/backend/internal/orchestrator/task_operations_test.go`
+- `apps/backend/internal/orchestrator/event_handlers_workflow_profile_test.go`
+  only when an existing generic Office auto-start assertion must be updated to
+  the fail-closed contract.
+
+## Inputs
+
+- `docs/specs/office/agents.md`, sections **Runtime**, **Failure modes**, and
+  **Scenarios / CLI and MCP**.
+- `StartCreatedSession`, `startTask`, and `StartTaskWithEnv` in
+  `apps/backend/internal/orchestrator/task_operations.go`.
+- Scheduler environment construction in
+  `apps/backend/internal/office/service/env_builder.go`.
+
+## Output Contract
+
+Use TDD. Report the red and green test results, exact launch paths guarded,
+files changed, risks, and any path that can still select `ModeOffice` without
+the signed runtime context. Update this task to `done` only after targeted
+verification passes.
+
+## Completion Evidence
+
+- Added one shared Office runtime-environment validator and applied it to
+  created-session starts, direct task starts, workflow auto-starts through
+  `StartCreatedSession`, and prepared-workspace agent starts.
+- The red regression run failed all four scenarios because each path previously
+  started without Office runtime context.
+- The green focused run passed all four scenarios.
+- `cd apps/backend && rtk go test ./internal/orchestrator -count=1` passed.

--- a/docs/plans/office-agent-project-management/task-06-office-launch-context-guard.md
+++ b/docs/plans/office-agent-project-management/task-06-office-launch-context-guard.md
@@ -14,9 +14,11 @@ spec: "../../specs/office/agents.md"
 
 - Every orchestrator path selecting `ModeOffice` verifies the
   scheduler-provided CLI path, API URL, signed token, agent/workspace identity,
-  and run ID before starting the agent process.
+  run ID, and task-bound task ID before starting the agent process.
 - A generic manual or workflow launch of an Office-owned task without that
   context fails closed with actionable guidance.
+- Generic Office resume and prepared-workspace relaunch paths fail closed and
+  require a scheduler-owned fresh run.
 - Scheduler launches through `StartTaskWithEnv` and non-Office task launches
   keep their existing behavior.
 
@@ -52,10 +54,12 @@ verification passes.
 
 ## Completion Evidence
 
-- Added one shared Office runtime-environment validator and applied it to
-  created-session starts, direct task starts, workflow auto-starts through
-  `StartCreatedSession`, and prepared-workspace agent starts.
-- The red regression run failed all four scenarios because each path previously
-  started without Office runtime context.
-- The green focused run passed all four scenarios.
+- Added a shared Office runtime-environment validator and task binding, then
+  applied it to created-session starts and direct task starts.
+- Guarded `ResumeTaskSession`, lazy session recovery, and prepared-workspace
+  relaunches so Office recovery cannot bypass the scheduler.
+- The red regression run failed the new resume/task-binding scenarios before
+  the guard and exposed the existing direct-guard wording assertions.
+- The green focused run passed six Office launch and recovery scenarios,
+  including a complete context map bound to a different task.
 - `cd apps/backend && rtk go test ./internal/orchestrator -count=1` passed.

--- a/docs/plans/office-agent-project-management/task-06-office-launch-context-guard.md
+++ b/docs/plans/office-agent-project-management/task-06-office-launch-context-guard.md
@@ -62,4 +62,29 @@ verification passes.
   the guard and exposed the existing direct-guard wording assertions.
 - The green focused run passed six Office launch and recovery scenarios,
   including a complete context map bound to a different task.
+
+Files changed:
+
+- `apps/backend/internal/orchestrator/task_operations.go`
+- `apps/backend/internal/orchestrator/task_operations_test.go`
+- `apps/backend/internal/orchestrator/event_handlers_workflow_profile_test.go`
+- `apps/backend/cmd/agentctl/kandev_test.go`
+- `docs/specs/office/agents.md`
+- `docs/public/automation-and-mcp.md`
+- This plan and its task records.
+
+Risks:
+
+- Generic manual, workflow, resume, and prepared-workspace paths now reject
+  Office-owned work until the Office scheduler supplies a fresh context. This
+  is intentional fail-closed behavior and may surface a clearer error where a
+  previously unsafe launch was attempted.
+- The task binding prevents context reuse across tasks; JWT signature and
+  expiry validation remains owned by the Office runtime API middleware.
+
+Remaining ModeOffice paths:
+
+- None in the orchestrator launch and recovery paths. Scheduler launches use
+  `StartTaskWithEnv` with the task-bound context; direct executor unit tests do
+  not select `ModeOffice` through production task operations.
 - `cd apps/backend && rtk go test ./internal/orchestrator -count=1` passed.

--- a/docs/plans/office-agent-project-management/task-07-cli-context-diagnostic.md
+++ b/docs/plans/office-agent-project-management/task-07-cli-context-diagnostic.md
@@ -1,0 +1,50 @@
+---
+id: "07-cli-context-diagnostic"
+title: "Explain missing Office CLI context"
+status: done
+wave: 4
+depends_on: []
+plan: "plan.md"
+spec: "../../specs/office/agents.md"
+---
+
+# Task 07: Explain missing Office CLI context
+
+## Acceptance
+
+- `agentctl kandev` explains that `KANDEV_API_URL` and `KANDEV_API_KEY` are
+  injected automatically for Office runs when either value is missing.
+- The error directs regular task sessions to Kandev MCP tools and never
+  suggests generating, copying, or persisting a runtime JWT.
+- The command performs no HTTP request when its required context is absent.
+
+## Verification
+
+```bash
+cd apps/backend && rtk go test ./cmd/agentctl -run 'TestNewKandevClient.*Missing.*OfficeContext' -count=1
+```
+
+## Files Likely Touched
+
+- `apps/backend/cmd/agentctl/kandev_client.go`
+- `apps/backend/cmd/agentctl/kandev_test.go`
+
+## Inputs
+
+- `docs/specs/office/agents.md`, sections **Environment variables** and
+  **Failure modes**.
+- Existing `newKandevClient` tests and socket-free request-capture helpers.
+
+## Output Contract
+
+Use TDD. Report the exact old/new structured error, red and green test
+results, files changed, and any compatibility concern for callers matching the
+old text. Update this task to `done` only after targeted verification passes.
+
+## Completion Evidence
+
+- Replaced the bare missing-variable error with Office-run injection and
+  task-mode MCP guidance.
+- The red regression failed because the prior error only said both variables
+  must be set; the green regression passed after the diagnostic changed.
+- `cd apps/backend && rtk go test ./cmd/agentctl -count=1` passed (75 tests).

--- a/docs/plans/office-agent-project-management/task-08-public-runtime-credentials-docs.md
+++ b/docs/plans/office-agent-project-management/task-08-public-runtime-credentials-docs.md
@@ -1,0 +1,54 @@
+---
+id: "08-public-runtime-credentials-docs"
+title: "Document Office runtime credentials"
+status: done
+wave: 5
+depends_on: ["06-office-launch-context-guard", "07-cli-context-diagnostic"]
+plan: "plan.md"
+spec: "../../specs/office/agents.md"
+---
+
+# Task 08: Document Office runtime credentials
+
+## Acceptance
+
+- Public docs define `KANDEV_API_URL`, `KANDEV_API_KEY`, and `KANDEV_CLI` as
+  automatically injected, run-scoped Office values rather than user
+  configuration.
+- Troubleshooting distinguishes a scheduler-launched Office run from a regular
+  task-mode session and gives the supported action for each.
+- Documentation does not expose token-generation instructions or imply that a
+  long-lived Office API key exists.
+
+## Verification
+
+```bash
+node --test scripts/validate-public-docs.test.mjs
+node scripts/validate-public-docs.mjs
+```
+
+## Files Likely Touched
+
+- `docs/public/automation-and-mcp.md`
+
+## Inputs
+
+- Completed Tasks 06 and 07.
+- `docs/specs/office/agents.md`, section **Environment variables**.
+- Follow `.agents/skills/docs-maintainer/SKILL.md`.
+
+## Output Contract
+
+Act as docs-maintainer. Report the public section changed, validation results,
+links checked, unresolved documentation gaps, and task status. Update this task
+to `done` only after validation passes.
+
+## Completion Evidence
+
+- Added **Runtime credentials** to `docs/public/automation-and-mcp.md`.
+- Documented that the API URL, signed key, and CLI path are automatic,
+  run-scoped Office values; regular sessions use their injected MCP tools.
+- Added missing-context troubleshooting without exposing token-generation or
+  persistence instructions.
+- `node --test scripts/validate-public-docs.test.mjs` passed (58 tests).
+- `node scripts/validate-public-docs.mjs` passed (41 published pages).

--- a/docs/public/automation-and-mcp.md
+++ b/docs/public/automation-and-mcp.md
@@ -185,7 +185,8 @@ Kandev injects `$KANDEV_CLI`, `KANDEV_API_URL`, and `KANDEV_API_KEY` when the
 Office scheduler starts an Office run. The API key is a short-lived, scoped
 runtime token; it is not a personal access token or a value to create, copy,
 or persist in configuration. The run also receives its agent, workspace, task,
-and run identifiers automatically.
+and run identifiers automatically, and the launch context is bound to that
+task.
 
 If `agentctl kandev ...` reports that `KANDEV_API_URL` or `KANDEV_API_KEY` is
 missing, do not set either variable yourself. A regular task session should use

--- a/docs/public/automation-and-mcp.md
+++ b/docs/public/automation-and-mcp.md
@@ -179,6 +179,19 @@ Office runs use a smaller MCP surface than regular task-mode sessions. The built
 
 These tools cover human questions, the current task plan, related-task discovery, and task documents. Office state changes use the injected `$KANDEV_CLI kandev ...` commands instead. An Office agent should not search for additional Kandev MCP tools: Kanban/configuration tools and `step_complete_kandev` are task-mode only and are not registered in Office mode.
 
+### Runtime credentials
+
+Kandev injects `$KANDEV_CLI`, `KANDEV_API_URL`, and `KANDEV_API_KEY` when the
+Office scheduler starts an Office run. The API key is a short-lived, scoped
+runtime token; it is not a personal access token or a value to create, copy,
+or persist in configuration. The run also receives its agent, workspace, task,
+and run identifiers automatically.
+
+If `agentctl kandev ...` reports that `KANDEV_API_URL` or `KANDEV_API_KEY` is
+missing, do not set either variable yourself. A regular task session should use
+its injected Kandev MCP tools. An Office-owned task must be started or woken
+through Office so the scheduler can supply its signed runtime context.
+
 An Office run can inspect the projects in its current workspace:
 
 ```bash

--- a/docs/specs/office/agents.md
+++ b/docs/specs/office/agents.md
@@ -266,11 +266,12 @@ and use their injected Kandev MCP tools instead.
 | `KANDEV_CLI` | Path to agentctl | CLI binary for API operations |
 
 An Office-mode launch requires `KANDEV_CLI`, `KANDEV_API_URL`,
-`KANDEV_API_KEY`, `KANDEV_AGENT_ID`, `KANDEV_WORKSPACE_ID`, and
-`KANDEV_RUN_ID`. Kandev fails the launch before starting the agent process when
-that signed run context is incomplete. Generic task/session start paths must
-not manufacture, persist, or accept user-supplied substitutes for these
-values.
+`KANDEV_API_KEY`, `KANDEV_AGENT_ID`, `KANDEV_WORKSPACE_ID`, `KANDEV_RUN_ID`,
+and the task-bound `KANDEV_TASK_ID`. Kandev fails the launch before starting
+the agent process when that signed run context is incomplete or bound to a
+different task. Generic task/session start paths must not manufacture,
+persist, or accept user-supplied substitutes for these values; only the
+internal Office scheduler adapter supplies the task-bound launch map.
 
 `KANDEV_CLI` resolves per executor:
 - **Docker** (`local_docker`): `/usr/local/bin/agentctl` (baked into the image).
@@ -547,7 +548,7 @@ Skill list (name, description, source type, which agents use each skill), inline
 - **Budget exhaustion**: agent's budget reaches zero. Status auto-transitions to `paused` with `pause_reason="budget"`. Active sessions complete the current turn but no further prompts are dispatched. Surfaces as a banner on the agent card. See [costs](./costs.md).
 - **Concurrency saturation**: agent at `max_concurrent_sessions`. Scheduler skips claiming wakeups for this agent; wakeups remain in `queued` indefinitely until a slot frees up. No retry, no expiry.
 - **Stale MCP tool reference**: agent in `ModeOffice` calls a tool not in the mode (e.g. a kanban tool from an old skill). MCP server returns `"Tool not available in office mode. Use $KANDEV_CLI instead."`.
-- **Missing Office launch context**: a generic task/session path attempts to start an Office-owned task without the scheduler-injected CLI path, API URL, signed run token, agent/workspace identity, or run ID. Kandev fails closed before starting the agent process and directs the caller to start or wake the task through Office. It never asks the user to configure or paste these credentials.
+- **Missing Office launch context**: a generic task/session path attempts to start or resume an Office-owned task without the scheduler-injected CLI path, API URL, signed run token, task-bound identity, or run ID. Kandev fails closed before starting or relaunching the agent process and directs the caller to start or wake the task through Office. It never asks the user to configure or paste these credentials.
 - **CLI auth failure**: agentctl call returns 401 because the JWT is expired or invalid. The CLI exits non-zero with structured error. Agent sees a clear failure and can surface it via comment.
 - **CLI invoked outside Office**: `agentctl kandev` cannot find `KANDEV_API_URL` or `KANDEV_API_KEY`. The CLI exits non-zero and explains that these values are injected automatically for Office runs; regular task sessions use Kandev MCP tools.
 - **Adapter without skill discovery**: agent type has no known `ProjectSkillDir`. Skill `SKILL.md` content appended to the system prompt as fallback.

--- a/docs/specs/office/agents.md
+++ b/docs/specs/office/agents.md
@@ -244,7 +244,11 @@ A run carries an explicit capability scope. Capabilities include: post comment, 
 
 ### Environment variables
 
-Injected before each agent session:
+The Office scheduler injects the runtime environment before each Office agent
+turn. These values are runtime credentials, not operator configuration:
+users do not create them, copy them from settings, or reuse them between
+sessions. Regular Kanban/task-mode sessions do not receive this environment
+and use their injected Kandev MCP tools instead.
 
 | Variable | Value | Purpose |
 |---|---|---|
@@ -260,6 +264,13 @@ Injected before each agent session:
 | `KANDEV_WAKE_PAYLOAD_JSON` | Inline JSON | Pre-computed task context |
 | `KANDEV_WAKE_PAYLOAD_PATH` | Workspace-relative JSON file path | Pre-computed task context when too large for inline env |
 | `KANDEV_CLI` | Path to agentctl | CLI binary for API operations |
+
+An Office-mode launch requires `KANDEV_CLI`, `KANDEV_API_URL`,
+`KANDEV_API_KEY`, `KANDEV_AGENT_ID`, `KANDEV_WORKSPACE_ID`, and
+`KANDEV_RUN_ID`. Kandev fails the launch before starting the agent process when
+that signed run context is incomplete. Generic task/session start paths must
+not manufacture, persist, or accept user-supplied substitutes for these
+values.
 
 `KANDEV_CLI` resolves per executor:
 - **Docker** (`local_docker`): `/usr/local/bin/agentctl` (baked into the image).
@@ -536,7 +547,9 @@ Skill list (name, description, source type, which agents use each skill), inline
 - **Budget exhaustion**: agent's budget reaches zero. Status auto-transitions to `paused` with `pause_reason="budget"`. Active sessions complete the current turn but no further prompts are dispatched. Surfaces as a banner on the agent card. See [costs](./costs.md).
 - **Concurrency saturation**: agent at `max_concurrent_sessions`. Scheduler skips claiming wakeups for this agent; wakeups remain in `queued` indefinitely until a slot frees up. No retry, no expiry.
 - **Stale MCP tool reference**: agent in `ModeOffice` calls a tool not in the mode (e.g. a kanban tool from an old skill). MCP server returns `"Tool not available in office mode. Use $KANDEV_CLI instead."`.
+- **Missing Office launch context**: a generic task/session path attempts to start an Office-owned task without the scheduler-injected CLI path, API URL, signed run token, agent/workspace identity, or run ID. Kandev fails closed before starting the agent process and directs the caller to start or wake the task through Office. It never asks the user to configure or paste these credentials.
 - **CLI auth failure**: agentctl call returns 401 because the JWT is expired or invalid. The CLI exits non-zero with structured error. Agent sees a clear failure and can surface it via comment.
+- **CLI invoked outside Office**: `agentctl kandev` cannot find `KANDEV_API_URL` or `KANDEV_API_KEY`. The CLI exits non-zero and explains that these values are injected automatically for Office runs; regular task sessions use Kandev MCP tools.
 - **Adapter without skill discovery**: agent type has no known `ProjectSkillDir`. Skill `SKILL.md` content appended to the system prompt as fallback.
 - **Skill registry edit while session runs**: the running session is unaffected (file already written). Next session for that agent picks up updated content.
 - **Worktree deletion**: when the worktree is deleted at session end, all injected skill directories are removed automatically. No explicit cleanup hook needed.
@@ -668,7 +681,11 @@ pass before launcher settings are described as an isolation boundary:
 
 - **GIVEN** an office agent in ModeOffice, **WHEN** its first-turn system context is generated, **THEN** every advertised MCP tool is registered in ModeOffice and `step_complete_kandev` is absent.
 
+- **GIVEN** an Office-owned task without a scheduler-prepared signed run context, **WHEN** a generic manual or workflow task/session path attempts to start it in ModeOffice, **THEN** Kandev starts no agent process and returns an error directing the caller to start or wake the task through Office.
+
 - **GIVEN** a regular kanban task (non-office), **WHEN** a user starts a session, **THEN** ModeTask is used with the full Kanban MCP surface, including `step_complete_kandev`. No Office CLI capability changes that behavior.
+
+- **GIVEN** a regular task-mode session, **WHEN** an agent invokes `agentctl kandev` without Office runtime credentials, **THEN** the CLI explains that `KANDEV_API_URL` and `KANDEV_API_KEY` are injected automatically only for Office runs and directs the agent to its Kandev MCP tools.
 
 - **GIVEN** a regular Kanban task on a step with a default agent profile, **WHEN** the runner projection resolves that profile, **THEN** the profile selects the execution identity without changing Office ownership or the session's `ModeTask` MCP surface.
 


### PR DESCRIPTION
Office-only runtime credentials were previously exposed as a confusing missing-variable error when `agentctl kandev` ran outside the Office scheduler. The launch paths now fail closed with actionable guidance, while Office-scheduled runs retain their injected context and the public docs explain the distinction.

## Important Changes

- Require the complete Office runtime context before generic Office launch paths can start a process.
- Explain that `KANDEV_API_URL` and `KANDEV_API_KEY` are short-lived scheduler-injected credentials, not user configuration.
- Add regression tests for launch guards and the CLI diagnostic.

## Validation

- `go test ./internal/orchestrator -count=1`
- `go test ./cmd/agentctl -count=1`
- `make -C apps/backend lint`
- `node --test scripts/validate-public-docs.test.mjs`
- `node scripts/validate-public-docs.mjs`
- Post-commit changed-scope verification: `make fmt-backend`, `make test-backend`, `make lint-backend`, and `git diff --check`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1974?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->