### PR TITLE
fix: preserve prompts across usage-limit recovery

### DIFF
--- a/apps/backend/internal/agent/runtime/routingerr/classify_test.go
+++ b/apps/backend/internal/agent/runtime/routingerr/classify_test.go
@@ -59,6 +59,7 @@ func TestClassify_ProviderRules(t *testing.T) {
 		{"claude auth", "claude-acp", "you are not authenticated", CodeAuthRequired},
 		{"claude model", "claude-acp", "model claude-foo not found here", CodeModelUnavailable},
 		{"codex quota", "codex-acp", "insufficient_quota for project", CodeQuotaLimited},
+		{"codex usage limit", "codex-acp", `{"codexErrorInfo":"usageLimitExceeded"}`, CodeQuotaLimited},
 		{"codex rate", "codex-acp", "rate_limit_exceeded", CodeRateLimited},
 		{"codex apikey", "codex-acp", "invalid api key provided", CodeMissingCredentials},
 		{"opencode auth", "opencode-acp", "Unauthorized request", CodeAuthRequired},

--- a/apps/backend/internal/agent/runtime/routingerr/rules.go
+++ b/apps/backend/internal/agent/runtime/routingerr/rules.go
@@ -19,7 +19,7 @@ var providerRules = map[string][]rule{
 		mustRule("claude.stderr.notinstalled.v1", `(?i)command not found|no such file`, CodeProviderNotConfigured, ConfMedium),
 	},
 	"codex-acp": {
-		mustRule("codex.stderr.quota.v1", `(?i)insufficient_quota|quota_exceeded`, CodeQuotaLimited, ConfHigh),
+		mustRule("codex.stderr.quota.v1", `(?i)insufficient_quota|quota_exceeded|usagelimitexceeded`, CodeQuotaLimited, ConfHigh),
 		mustRule("codex.stderr.rate.v1", `(?i)rate_limit_exceeded|too many requests`, CodeRateLimited, ConfHigh),
 		mustRule("codex.stderr.auth.v1", `(?i)invalid api key|incorrect api key|missing api key`, CodeMissingCredentials, ConfHigh),
 		mustRule("codex.stderr.model.v1", `(?i)model_not_found`, CodeModelUnavailable, ConfHigh),

--- a/apps/backend/internal/orchestrator/event_handlers_agent.go
+++ b/apps/backend/internal/orchestrator/event_handlers_agent.go
@@ -584,16 +584,16 @@ func (s *Service) executeQueuedMessage(callerSessionID string, queuedMsg *messag
 			if userMessageRecorded {
 				markQueuedUserMessageRecorded(queuedMsg)
 			}
-			queuedBy := "workflow-auto-start-retry"
-			if manualRecovery {
-				queuedBy = "manual-recovery-retry"
-			}
 			s.logger.Warn("queued message execution failed; requeueing",
 				zap.String("session_id", callerSessionID),
 				zap.String("task_id", queuedMsg.TaskID),
 				zap.String("queue_id", queuedMsg.ID),
 				zap.Bool("manual_recovery", manualRecovery))
-			s.requeueMessage(promptCtx, queuedMsg, queuedBy)
+			if manualRecovery {
+				s.restoreQueuedMessage(promptCtx, queuedMsg)
+			} else {
+				s.requeueMessage(promptCtx, queuedMsg, "workflow-auto-start-retry")
+			}
 			return
 		}
 
@@ -607,6 +607,24 @@ func (s *Service) executeQueuedMessage(callerSessionID string, queuedMsg *messag
 			zap.String("queue_id", queuedMsg.ID),
 			zap.String("content_preview", queuedMsg.Content[:min(50, len(queuedMsg.Content))]))
 	}
+}
+
+func (s *Service) restoreQueuedMessage(ctx context.Context, queuedMsg *messagequeue.QueuedMessage) {
+	restored, err := s.messageQueue.RestoreMessage(ctx, queuedMsg)
+	if err != nil {
+		s.logger.Error("failed to restore queued message",
+			zap.String("session_id", queuedMsg.SessionID),
+			zap.String("task_id", queuedMsg.TaskID),
+			zap.String("queue_id", queuedMsg.ID),
+			zap.Error(err))
+		return
+	}
+	s.logger.Info("message restored for manual recovery",
+		zap.String("session_id", restored.SessionID),
+		zap.String("task_id", restored.TaskID),
+		zap.String("queue_id", restored.ID),
+		zap.Int64("position", restored.Position))
+	s.publishQueueStatusEvent(ctx, queuedMsg.SessionID)
 }
 
 func markQueuedUserMessageRecorded(queuedMsg *messagequeue.QueuedMessage) {

--- a/apps/backend/internal/orchestrator/event_handlers_agent.go
+++ b/apps/backend/internal/orchestrator/event_handlers_agent.go
@@ -510,6 +510,7 @@ func (s *Service) executeQueuedMessage(callerSessionID string, queuedMsg *messag
 	// here would produce the duplicate user message observed when a workflow
 	// auto-start failed transiently and the queue drained on boot_ready.
 	alreadyRecorded, _ := queuedMsg.Metadata[metaKeyUserMessageRecorded].(bool)
+	userMessageRecorded := alreadyRecorded
 	if s.messageCreator != nil && !alreadyRecorded {
 		turnID := s.getActiveTurnID(queuedMsg.SessionID)
 		if turnID == "" {
@@ -532,6 +533,8 @@ func (s *Service) executeQueuedMessage(callerSessionID string, queuedMsg *messag
 				zap.String("session_id", queuedMsg.SessionID),
 				zap.Error(err))
 			// Continue anyway - the prompt should still be sent
+		} else {
+			userMessageRecorded = true
 		}
 	} else if s.messageCreator != nil && alreadyRecorded {
 		s.logger.Debug("skipping CreateUserMessage for queued workflow auto-start; already recorded before queueing",
@@ -575,13 +578,22 @@ func (s *Service) executeQueuedMessage(callerSessionID string, queuedMsg *messag
 			zap.String("queue_id", queuedMsg.ID),
 			zap.Error(err))
 
-		if isSessionBusyError(err) || isTransientPromptError(err) ||
+		manualRecovery := isManualRecoveryPromptError(err)
+		if isSessionBusyError(err) || isTransientPromptError(err) || manualRecovery ||
 			errors.Is(err, lifecycle.ErrCancelEscalated) || isSessionResetInProgressError(err) {
-			s.logger.Warn("queued message execution failed transiently; requeueing",
+			if userMessageRecorded {
+				markQueuedUserMessageRecorded(queuedMsg)
+			}
+			queuedBy := "workflow-auto-start-retry"
+			if manualRecovery {
+				queuedBy = "manual-recovery-retry"
+			}
+			s.logger.Warn("queued message execution failed; requeueing",
 				zap.String("session_id", callerSessionID),
 				zap.String("task_id", queuedMsg.TaskID),
-				zap.String("queue_id", queuedMsg.ID))
-			s.requeueMessage(promptCtx, queuedMsg, "workflow-auto-start-retry")
+				zap.String("queue_id", queuedMsg.ID),
+				zap.Bool("manual_recovery", manualRecovery))
+			s.requeueMessage(promptCtx, queuedMsg, queuedBy)
 			return
 		}
 
@@ -595,6 +607,13 @@ func (s *Service) executeQueuedMessage(callerSessionID string, queuedMsg *messag
 			zap.String("queue_id", queuedMsg.ID),
 			zap.String("content_preview", queuedMsg.Content[:min(50, len(queuedMsg.Content))]))
 	}
+}
+
+func markQueuedUserMessageRecorded(queuedMsg *messagequeue.QueuedMessage) {
+	if queuedMsg.Metadata == nil {
+		queuedMsg.Metadata = make(map[string]interface{})
+	}
+	queuedMsg.Metadata[metaKeyUserMessageRecorded] = true
 }
 
 func metadataWithoutEntityReferences(metadata map[string]interface{}) map[string]interface{} {

--- a/apps/backend/internal/orchestrator/event_handlers_queue_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_queue_test.go
@@ -159,19 +159,28 @@ func TestExecuteQueuedMessage_RequeuesUsageLimitForManualResume(t *testing.T) {
 		Content:   "continue the interrupted task",
 		QueuedBy:  messagequeue.QueuedByUser,
 	}
+	if _, err := svc.messageQueue.QueueMessage(ctx, "s1", "t1", "later prompt", "", messagequeue.QueuedByUser, false, nil); err != nil {
+		t.Fatalf("queue later prompt: %v", err)
+	}
 
 	svc.markQueuedDispatchInFlight("s1", queuedMsg.ID)
 	svc.executeQueuedMessage("s1", queuedMsg)
 
 	select {
 	case <-firstPromptDone:
-	case <-time.After(3 * time.Second):
-		t.Fatal("first prompt did not reach the agent")
+	default:
+		t.Fatal("first prompt did not reach the agent synchronously")
 	}
 
 	queued := svc.messageQueue.GetStatus(ctx, "s1")
-	if queued.Count != 1 {
-		t.Fatalf("expected the usage-limited prompt to wait for manual resume, got %d queued messages", queued.Count)
+	if queued.Count != 2 {
+		t.Fatalf("expected the usage-limited prompt and later prompt to remain queued, got %d messages", queued.Count)
+	}
+	if queued.Entries[0].Content != queuedMsg.Content {
+		t.Fatalf("expected the usage-limited prompt to retain FIFO priority, got %+v", queued.Entries)
+	}
+	if queued.Entries[0].QueuedBy != messagequeue.QueuedByUser {
+		t.Fatalf("expected the usage-limited prompt to retain its queued_by identity, got %q", queued.Entries[0].QueuedBy)
 	}
 	if queued.Entries[0].Metadata[metaKeyUserMessageRecorded] != true {
 		t.Fatalf("expected retried prompt to skip creating a duplicate user message, metadata=%+v", queued.Entries[0].Metadata)
@@ -195,8 +204,9 @@ func TestExecuteQueuedMessage_RequeuesUsageLimitForManualResume(t *testing.T) {
 	case <-time.After(3 * time.Second):
 		t.Fatal("manual resume did not dispatch the preserved prompt")
 	}
-	if got := svc.messageQueue.GetStatus(ctx, "s1").Count; got != 0 {
-		t.Fatalf("expected preserved prompt to drain after manual resume, got %d queued messages", got)
+	queued = svc.messageQueue.GetStatus(ctx, "s1")
+	if queued.Count != 1 || queued.Entries[0].Content != "later prompt" {
+		t.Fatalf("expected only the later prompt to remain after manual resume, got %+v", queued.Entries)
 	}
 	if len(messages.userMessages) != 1 {
 		t.Fatalf("expected manual resume to reuse the existing user message, got %d", len(messages.userMessages))

--- a/apps/backend/internal/orchestrator/event_handlers_queue_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_queue_test.go
@@ -3,15 +3,18 @@ package orchestrator
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/kandev/kandev/internal/agent/runtime/lifecycle"
 	"github.com/kandev/kandev/internal/github"
 	"github.com/kandev/kandev/internal/orchestrator/executor"
 	"github.com/kandev/kandev/internal/orchestrator/messagequeue"
+	"github.com/kandev/kandev/internal/orchestrator/watcher"
 	"github.com/kandev/kandev/internal/sysprompt"
 	"github.com/kandev/kandev/internal/task/models"
 	wfmodels "github.com/kandev/kandev/internal/workflow/models"
@@ -118,6 +121,85 @@ func TestExecuteQueuedMessage_RequeuesCancelReleaseFailure(t *testing.T) {
 	}
 	if !reflect.DeepEqual(status.Entries[0].Metadata, queuedMsg.Metadata) {
 		t.Fatalf("expected queued metadata to be preserved, got %#v", status.Entries[0].Metadata)
+	}
+}
+
+func TestExecuteQueuedMessage_RequeuesUsageLimitForManualResume(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "t1", "s1", "step1")
+
+	session, err := repo.GetTaskSession(ctx, "s1")
+	if err != nil {
+		t.Fatalf("failed to get session: %v", err)
+	}
+	session.State = models.TaskSessionStateWaitingForInput
+	session.AgentExecutionID = "exec-1"
+	seedExecutorRunning(t, repo, session.ID, session.TaskID, "exec-1")
+	if err := repo.UpdateTaskSession(ctx, session); err != nil {
+		t.Fatalf("failed to update session: %v", err)
+	}
+
+	firstPromptDone := make(chan struct{})
+	agentMgr := &mockAgentManager{
+		isAgentRunning:         true,
+		repoForExecutionLookup: repo,
+		promptDone:             firstPromptDone,
+		promptErr:              errors.New(`agent error: {"data":{"codexErrorInfo":"usageLimitExceeded"}}`),
+	}
+	svc := createTestServiceWithAgent(repo, newMockStepGetter(), newMockTaskRepo(), agentMgr)
+	svc.executor = executor.NewExecutor(agentMgr, repo, testLogger(), executor.ExecutorConfig{})
+	messages := &mockMessageCreator{}
+	svc.messageCreator = messages
+
+	queuedMsg := &messagequeue.QueuedMessage{
+		ID:        "q-usage-limit",
+		SessionID: "s1",
+		TaskID:    "t1",
+		Content:   "continue the interrupted task",
+		QueuedBy:  messagequeue.QueuedByUser,
+	}
+
+	svc.markQueuedDispatchInFlight("s1", queuedMsg.ID)
+	svc.executeQueuedMessage("s1", queuedMsg)
+
+	select {
+	case <-firstPromptDone:
+	case <-time.After(3 * time.Second):
+		t.Fatal("first prompt did not reach the agent")
+	}
+
+	queued := svc.messageQueue.GetStatus(ctx, "s1")
+	if queued.Count != 1 {
+		t.Fatalf("expected the usage-limited prompt to wait for manual resume, got %d queued messages", queued.Count)
+	}
+	if queued.Entries[0].Metadata[metaKeyUserMessageRecorded] != true {
+		t.Fatalf("expected retried prompt to skip creating a duplicate user message, metadata=%+v", queued.Entries[0].Metadata)
+	}
+	if len(messages.userMessages) != 1 {
+		t.Fatalf("expected one persisted user message before recovery, got %d", len(messages.userMessages))
+	}
+
+	secondPromptDone := make(chan struct{})
+	agentMgr.mu.Lock()
+	agentMgr.promptErr = nil
+	agentMgr.promptDone = secondPromptDone
+	agentMgr.capturedPrompts = agentMgr.capturedPrompts[:0]
+	agentMgr.capturedPromptCalls = agentMgr.capturedPromptCalls[:0]
+	agentMgr.mu.Unlock()
+
+	svc.handleAgentBootReady(ctx, watcher.AgentEventData{TaskID: "t1", SessionID: "s1"})
+
+	select {
+	case <-secondPromptDone:
+	case <-time.After(3 * time.Second):
+		t.Fatal("manual resume did not dispatch the preserved prompt")
+	}
+	if got := svc.messageQueue.GetStatus(ctx, "s1").Count; got != 0 {
+		t.Fatalf("expected preserved prompt to drain after manual resume, got %d queued messages", got)
+	}
+	if len(messages.userMessages) != 1 {
+		t.Fatalf("expected manual resume to reuse the existing user message, got %d", len(messages.userMessages))
 	}
 }
 

--- a/apps/backend/internal/orchestrator/event_handlers_queue_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_queue_test.go
@@ -97,6 +97,8 @@ func TestExecuteQueuedMessage_RequeuesCancelReleaseFailure(t *testing.T) {
 	}
 	svc := createTestServiceWithAgent(repo, newMockStepGetter(), taskRepo, agentMgr)
 	svc.executor = executor.NewExecutor(agentMgr, repo, testLogger(), executor.ExecutorConfig{})
+	messages := &mockMessageCreator{}
+	svc.messageCreator = messages
 
 	queuedMsg := &messagequeue.QueuedMessage{
 		ID:        "q-cancel",
@@ -121,6 +123,27 @@ func TestExecuteQueuedMessage_RequeuesCancelReleaseFailure(t *testing.T) {
 	}
 	if !reflect.DeepEqual(status.Entries[0].Metadata, queuedMsg.Metadata) {
 		t.Fatalf("expected queued metadata to be preserved, got %#v", status.Entries[0].Metadata)
+	}
+	if status.Entries[0].Metadata[metaKeyUserMessageRecorded] != true {
+		t.Fatalf("expected requeued cancel-release prompt to retain recorded-user-message metadata, got %#v", status.Entries[0].Metadata)
+	}
+
+	secondPromptDone := make(chan struct{})
+	agentMgr.mu.Lock()
+	agentMgr.promptErr = nil
+	agentMgr.promptDone = secondPromptDone
+	agentMgr.capturedPrompts = agentMgr.capturedPrompts[:0]
+	agentMgr.capturedPromptCalls = agentMgr.capturedPromptCalls[:0]
+	agentMgr.mu.Unlock()
+
+	svc.handleAgentBootReady(ctx, watcher.AgentEventData{TaskID: "t1", SessionID: "s1"})
+	select {
+	case <-secondPromptDone:
+	case <-time.After(3 * time.Second):
+		t.Fatal("boot-ready drain did not dispatch the cancel-release requeued prompt")
+	}
+	if len(messages.userMessages) != 1 {
+		t.Fatalf("expected boot-ready drain to reuse the existing user message, got %d", len(messages.userMessages))
 	}
 }
 

--- a/apps/backend/internal/orchestrator/event_handlers_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_test.go
@@ -1267,6 +1267,8 @@ func TestExecuteQueuedMessage_RequeuesTransientPromptFailure(t *testing.T) {
 	}
 	svc := createTestServiceWithAgent(repo, newMockStepGetter(), taskRepo, agentMgr)
 	svc.executor = executor.NewExecutor(agentMgr, repo, testLogger(), executor.ExecutorConfig{})
+	messages := &mockMessageCreator{}
+	svc.messageCreator = messages
 
 	queuedMsg := &messagequeue.QueuedMessage{
 		ID:        "q1",
@@ -1285,6 +1287,27 @@ func TestExecuteQueuedMessage_RequeuesTransientPromptFailure(t *testing.T) {
 	}
 	if status.Entries[0].Content != "hello" {
 		t.Fatalf("expected queued content to be preserved, got %q", status.Entries[0].Content)
+	}
+	if status.Entries[0].Metadata[metaKeyUserMessageRecorded] != true {
+		t.Fatalf("expected requeued transient prompt to retain recorded-user-message metadata, got %#v", status.Entries[0].Metadata)
+	}
+
+	secondPromptDone := make(chan struct{})
+	agentMgr.mu.Lock()
+	agentMgr.promptErr = nil
+	agentMgr.promptDone = secondPromptDone
+	agentMgr.capturedPrompts = agentMgr.capturedPrompts[:0]
+	agentMgr.capturedPromptCalls = agentMgr.capturedPromptCalls[:0]
+	agentMgr.mu.Unlock()
+
+	svc.handleAgentBootReady(ctx, watcher.AgentEventData{TaskID: "t1", SessionID: "s1"})
+	select {
+	case <-secondPromptDone:
+	case <-time.After(3 * time.Second):
+		t.Fatal("boot-ready drain did not dispatch the transiently requeued prompt")
+	}
+	if len(messages.userMessages) != 1 {
+		t.Fatalf("expected boot-ready drain to reuse the existing user message, got %d", len(messages.userMessages))
 	}
 }
 

--- a/apps/backend/internal/orchestrator/messagequeue/repository.go
+++ b/apps/backend/internal/orchestrator/messagequeue/repository.go
@@ -9,6 +9,11 @@ type Repository interface {
 	// Returns ErrQueueFull if maxPerSession > 0 and the count would exceed it.
 	Insert(ctx context.Context, msg *QueuedMessage, maxPerSession int) error
 
+	// Restore reinserts a previously dequeued entry at its original FIFO
+	// position. It is used when a delivery fails after TakeHead so later
+	// messages cannot overtake the failed one.
+	Restore(ctx context.Context, msg *QueuedMessage, maxPerSession int) error
+
 	// AppendOrInsertTail concatenates content onto the tail entry when the tail
 	// exists AND its QueuedBy matches the supplied queuedBy. Otherwise inserts a
 	// new entry. Returns the resulting entry and whether the call appended (true)

--- a/apps/backend/internal/orchestrator/messagequeue/repository_memory.go
+++ b/apps/backend/internal/orchestrator/messagequeue/repository_memory.go
@@ -33,6 +33,31 @@ func (r *memoryRepository) Insert(_ context.Context, msg *QueuedMessage, maxPerS
 	return r.insertLocked(msg, maxPerSession)
 }
 
+func (r *memoryRepository) Restore(_ context.Context, msg *QueuedMessage, maxPerSession int) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	list := r.entries[msg.SessionID]
+	if maxPerSession > 0 && len(list) >= maxPerSession {
+		return ErrQueueFull
+	}
+	if msg.ID == "" {
+		msg.ID = uuid.New().String()
+	}
+	if msg.QueuedAt.IsZero() {
+		msg.QueuedAt = time.Now().UTC()
+	}
+	clone := *msg
+	index := sort.Search(len(list), func(i int) bool { return list[i].Position > clone.Position })
+	list = append(list, nil)
+	copy(list[index+1:], list[index:])
+	list[index] = &clone
+	r.entries[msg.SessionID] = list
+	if clone.Position > r.nextPosition[msg.SessionID] {
+		r.nextPosition[msg.SessionID] = clone.Position
+	}
+	return nil
+}
+
 // insertLocked performs the actual insert. Caller must already hold r.mu.
 func (r *memoryRepository) insertLocked(msg *QueuedMessage, maxPerSession int) error {
 	list := r.entries[msg.SessionID]

--- a/apps/backend/internal/orchestrator/messagequeue/repository_sqlite.go
+++ b/apps/backend/internal/orchestrator/messagequeue/repository_sqlite.go
@@ -109,6 +109,49 @@ func (r *sqliteRepository) Insert(ctx context.Context, msg *QueuedMessage, maxPe
 	return tx.Commit()
 }
 
+func (r *sqliteRepository) Restore(ctx context.Context, msg *QueuedMessage, maxPerSession int) error {
+	tx, err := r.db.BeginTxx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin restore tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if maxPerSession > 0 {
+		var count int
+		if err := tx.GetContext(ctx, &count, r.db.Rebind(`SELECT COUNT(*) FROM queued_messages WHERE session_id = ?`), msg.SessionID); err != nil {
+			return fmt.Errorf("count: %w", err)
+		}
+		if count >= maxPerSession {
+			return ErrQueueFull
+		}
+	}
+	if msg.ID == "" {
+		msg.ID = uuid.New().String()
+	}
+	if msg.QueuedAt.IsZero() {
+		msg.QueuedAt = time.Now().UTC()
+	}
+	attachmentsJSON, err := marshalAttachments(msg.Attachments)
+	if err != nil {
+		return err
+	}
+	metadataJSON, err := marshalMetadata(msg.Metadata)
+	if err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, r.db.Rebind(`
+		INSERT INTO queued_messages
+			(id, session_id, task_id, position, content, model, plan_mode, attachments_json, metadata_json, queued_at, queued_by)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`),
+		msg.ID, msg.SessionID, msg.TaskID, msg.Position, msg.Content, msg.Model,
+		boolToInt(msg.PlanMode), attachmentsJSON, metadataJSON, msg.QueuedAt, msg.QueuedBy,
+	); err != nil {
+		return fmt.Errorf("restore queued_messages: %w", err)
+	}
+	return tx.Commit()
+}
+
 func (r *sqliteRepository) AppendOrInsertTail(ctx context.Context, sessionID, taskID, content, model, queuedBy string, planMode bool, attachments []MessageAttachment, metadata map[string]interface{}, maxPerSession int) (*QueuedMessage, bool, error) {
 	tx, err := r.db.BeginTxx(ctx, nil)
 	if err != nil {

--- a/apps/backend/internal/orchestrator/messagequeue/service.go
+++ b/apps/backend/internal/orchestrator/messagequeue/service.go
@@ -82,6 +82,26 @@ func (s *Service) QueueMessageWithMetadata(ctx context.Context, sessionID, taskI
 	return msg, nil
 }
 
+// RestoreMessage restores a dequeued message at its original FIFO position
+// after a delivery failure. Unlike QueueMessageWithMetadata, it preserves the
+// entry's identity, position, queued_at time, and queued_by ownership.
+func (s *Service) RestoreMessage(ctx context.Context, msg *QueuedMessage) (*QueuedMessage, error) {
+	if msg == nil {
+		return nil, errors.New("queued message is nil")
+	}
+	restored := *msg
+	restored.Metadata = copyMessageMetadata(msg.Metadata, false)
+	if err := s.repo.Restore(ctx, &restored, s.maxPerSession); err != nil {
+		return nil, err
+	}
+	s.logger.Info("message restored at original queue position",
+		zap.String("session_id", restored.SessionID),
+		zap.String("task_id", restored.TaskID),
+		zap.String("entry_id", restored.ID),
+		zap.Int64("position", restored.Position))
+	return &restored, nil
+}
+
 // QueueMessageWithCoalesceKey replaces an existing pending entry with the same
 // coalesce key, session, and queued_by value. When no matching entry exists it
 // inserts a new tail entry if allowInsert is true; otherwise ErrEntryNotFound is

--- a/apps/backend/internal/orchestrator/task_operations.go
+++ b/apps/backend/internal/orchestrator/task_operations.go
@@ -141,6 +141,20 @@ func isTransientPromptError(err error) bool {
 		strings.Contains(msg, "use of closed network connection")
 }
 
+// isManualRecoveryPromptError identifies a provider error that should retain
+// the queued prompt until the user explicitly resumes the session. It is
+// intentionally separate from isTransientPromptError: exhausted usage does
+// not become available on a short automatic retry, and repeatedly attempting
+// it would consume the queue's retry budget without making progress.
+func isManualRecoveryPromptError(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "usagelimitexceeded") ||
+		strings.Contains(message, "you've hit your usage limit")
+}
+
 func isAgentAlreadyRunningError(err error) bool {
 	return err != nil && errors.Is(err, lifecycle.ErrAgentAlreadyRunning)
 }

--- a/apps/web/components/task/chat/messages/action-message.test.tsx
+++ b/apps/web/components/task/chat/messages/action-message.test.tsx
@@ -12,14 +12,18 @@ import {
 import type { AppState } from "@/lib/state/store";
 
 const requestMock = vi.fn().mockResolvedValue({});
+const getWebSocketClientMock = vi.fn<() => { request: typeof requestMock } | null>(() => ({
+  request: requestMock,
+}));
 
 vi.mock("@/lib/ws/connection", () => ({
-  getWebSocketClient: () => ({ request: requestMock }),
+  getWebSocketClient: () => getWebSocketClientMock(),
 }));
 
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
+  getWebSocketClientMock.mockReturnValue({ request: requestMock });
 });
 
 const CANCEL_TEST_ID = "recovery-cancel-retry-button";
@@ -155,6 +159,16 @@ describe("ActionMessage — transient retry (warning variant)", () => {
     renderAction(errorMsg, "WAITING_FOR_INPUT", "");
     fireEvent.click(screen.getByTestId(RESUME_TEST_ID));
     await waitFor(() => expect(screen.queryByText(RECOVERY_MESSAGE)).toBeNull());
+  });
+
+  it("keeps a recovery card visible when the WebSocket client is unavailable", () => {
+    getWebSocketClientMock.mockReturnValue(null);
+    renderAction(recoveryMessage(true), "WAITING_FOR_INPUT", "");
+
+    fireEvent.click(screen.getByTestId(RESUME_TEST_ID));
+
+    expect(screen.getByTestId(RESUME_TEST_ID)).toBeTruthy();
+    expect(screen.getByText(RECOVERY_MESSAGE)).toBeTruthy();
   });
 });
 

--- a/apps/web/components/task/chat/messages/action-message.test.tsx
+++ b/apps/web/components/task/chat/messages/action-message.test.tsx
@@ -24,6 +24,8 @@ afterEach(() => {
 
 const CANCEL_TEST_ID = "recovery-cancel-retry-button";
 const TECHNICAL_DETAILS = "Technical details";
+const RECOVERY_MESSAGE = "Agent encountered an error";
+const RESUME_TEST_ID = "recovery-resume-button";
 
 function retryMessage(overrides: Partial<Message> = {}): Message {
   return {
@@ -57,6 +59,31 @@ function retryMessage(overrides: Partial<Message> = {}): Message {
     },
     ...overrides,
   } as Message;
+}
+
+function recoveryMessage(withParams = false): Message {
+  return retryMessage({
+    content: RECOVERY_MESSAGE,
+    metadata: {
+      variant: "error",
+      recovery_actions: true,
+      actions: [
+        {
+          type: "ws_request",
+          label: "Resume session",
+          test_id: RESUME_TEST_ID,
+          ...(withParams
+            ? {
+                params: {
+                  method: "session.recover",
+                  payload: { task_id: "task-1", session_id: "sess-1" },
+                },
+              }
+            : {}),
+        },
+      ],
+    },
+  } as Partial<Message>);
 }
 
 /** ActionMessage reads session state from the store (keyed by comment.session_id),
@@ -108,36 +135,26 @@ describe("ActionMessage — transient retry (warning variant)", () => {
   });
 
   it("renders the red variant for a non-warning recovery banner", () => {
-    const errorMsg = retryMessage({
-      content: "Agent encountered an error",
-      metadata: {
-        variant: "error",
-        recovery_actions: true,
-        actions: [
-          { type: "ws_request", label: "Resume session", test_id: "recovery-resume-button" },
-        ],
-      },
-    } as Partial<Message>);
+    const errorMsg = recoveryMessage();
     renderAction(errorMsg, "WAITING_FOR_INPUT", "agent process exited unexpectedly");
     const text = screen.getByText(/Agent encountered an error/i);
     expect(text.className).toContain("text-red-600");
     expect(text.className).not.toContain("text-amber-600");
   });
 
-  it("hides a completed recovery card after resume clears the session error", () => {
-    const errorMsg = retryMessage({
-      content: "Agent encountered an error",
-      metadata: {
-        variant: "error",
-        recovery_actions: true,
-        actions: [
-          { type: "ws_request", label: "Resume session", test_id: "recovery-resume-button" },
-        ],
-      },
-    } as Partial<Message>);
+  it("keeps a recovery card visible while the session is waiting, even without an error_message", () => {
+    const errorMsg = recoveryMessage();
 
-    const { container } = renderAction(errorMsg, "WAITING_FOR_INPUT", "");
-    expect(container.firstChild).toBeNull();
+    renderAction(errorMsg, "WAITING_FOR_INPUT", "");
+    expect(screen.getByTestId(RESUME_TEST_ID)).toBeTruthy();
+  });
+
+  it("hides a recovery card after its Resume request succeeds", async () => {
+    const errorMsg = recoveryMessage(true);
+
+    renderAction(errorMsg, "WAITING_FOR_INPUT", "");
+    fireEvent.click(screen.getByTestId(RESUME_TEST_ID));
+    await waitFor(() => expect(screen.queryByText(RECOVERY_MESSAGE)).toBeNull());
   });
 });
 

--- a/apps/web/components/task/chat/messages/action-message.test.tsx
+++ b/apps/web/components/task/chat/messages/action-message.test.tsx
@@ -118,10 +118,26 @@ describe("ActionMessage — transient retry (warning variant)", () => {
         ],
       },
     } as Partial<Message>);
-    renderAction(errorMsg, "WAITING_FOR_INPUT");
+    renderAction(errorMsg, "WAITING_FOR_INPUT", "agent process exited unexpectedly");
     const text = screen.getByText(/Agent encountered an error/i);
     expect(text.className).toContain("text-red-600");
     expect(text.className).not.toContain("text-amber-600");
+  });
+
+  it("hides a completed recovery card after resume clears the session error", () => {
+    const errorMsg = retryMessage({
+      content: "Agent encountered an error",
+      metadata: {
+        variant: "error",
+        recovery_actions: true,
+        actions: [
+          { type: "ws_request", label: "Resume session", test_id: "recovery-resume-button" },
+        ],
+      },
+    } as Partial<Message>);
+
+    const { container } = renderAction(errorMsg, "WAITING_FOR_INPUT", "");
+    expect(container.firstChild).toBeNull();
   });
 });
 

--- a/apps/web/components/task/chat/messages/action-message.tsx
+++ b/apps/web/components/task/chat/messages/action-message.tsx
@@ -47,17 +47,8 @@ type ActionMeta = {
   missing_branch?: string;
 };
 
-function isRecoveryResolved(
-  state: TaskSessionState | undefined,
-  sessionError: string | undefined,
-  hasRecoveryActions: boolean,
-) {
-  return (
-    state === "RUNNING" ||
-    state === "STARTING" ||
-    state === "COMPLETED" ||
-    (hasRecoveryActions && state === "WAITING_FOR_INPUT" && !sessionError)
-  );
+function isSessionActive(state?: TaskSessionState) {
+  return state === "RUNNING" || state === "STARTING" || state === "COMPLETED";
 }
 
 export const ActionMessage = memo(function ActionMessage({ comment }: { comment: Message }) {
@@ -74,14 +65,14 @@ export const ActionMessage = memo(function ActionMessage({ comment }: { comment:
       ? (state.taskSessions.items[comment.session_id]?.error_message as string | undefined)
       : undefined,
   );
+  const [recoveryRequested, setRecoveryRequested] = useState(false);
   const metadata = comment.metadata as ActionMeta | undefined;
   const isWarning = metadata?.variant === "warning";
   const message = comment.content || "An error occurred";
 
-  // Hide once recovery has succeeded. A resumed session settles in
-  // WAITING_FOR_INPUT, so use its cleared error_message as the completion
-  // signal instead of leaving the persisted recovery card on screen.
-  if (isRecoveryResolved(sessionState, sessionError, metadata?.recovery_actions === true))
+  // A waiting session can still need recovery, so only hide this persisted
+  // card after its own Resume request is acknowledged (or the session starts).
+  if (isSessionActive(sessionState) || (metadata?.recovery_actions && recoveryRequested))
     return null;
 
   if (metadata?.failure_kind === "missing_pr_branch") {
@@ -110,7 +101,13 @@ export const ActionMessage = memo(function ActionMessage({ comment }: { comment:
           <div className={cn("text-xs break-words", textClass)}>{message}</div>
           <ActionMessageDetails metadata={metadata} />
           {metadata?.actions && metadata.actions.length > 0 && (
-            <ActionButtons actions={metadata.actions} taskId={comment.task_id} />
+            <ActionButtons
+              actions={metadata.actions}
+              taskId={comment.task_id}
+              onRecoveryRequested={
+                metadata.recovery_actions ? () => setRecoveryRequested(true) : undefined
+              }
+            />
           )}
         </div>
       </div>
@@ -226,11 +223,24 @@ function ActionMessageDetails({
   );
 }
 
-function ActionButtons({ actions, taskId }: { actions: MessageAction[]; taskId?: string }) {
+function ActionButtons({
+  actions,
+  taskId,
+  onRecoveryRequested,
+}: {
+  actions: MessageAction[];
+  taskId?: string;
+  onRecoveryRequested?: () => void;
+}) {
   return (
     <div className="mt-2 flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center">
       {actions.map((action, i) => (
-        <ActionButton key={action.test_id ?? i} action={action} messageTaskId={taskId} />
+        <ActionButton
+          key={action.test_id ?? i}
+          action={action}
+          messageTaskId={taskId}
+          onCompleted={onRecoveryRequested}
+        />
       ))}
     </div>
   );
@@ -239,9 +249,11 @@ function ActionButtons({ actions, taskId }: { actions: MessageAction[]; taskId?:
 function ActionButton({
   action,
   messageTaskId,
+  onCompleted,
 }: {
   action: MessageAction;
   messageTaskId?: string;
+  onCompleted?: () => void;
 }): ReactElement | null {
   const [state, setState] = useState<"idle" | "busy" | "done" | "error">("idle");
   const activeTaskId = useAppStore((s) => s.tasks.activeTaskId);
@@ -280,6 +292,7 @@ function ActionButton({
         }
       }
       setState("done");
+      if (action.type === "ws_request") onCompleted?.();
     } catch {
       setState("error");
       setTimeout(() => setState("idle"), 3000);

--- a/apps/web/components/task/chat/messages/action-message.tsx
+++ b/apps/web/components/task/chat/messages/action-message.tsx
@@ -287,7 +287,8 @@ function ActionButton({
           const params = action.params as
             | { method: string; payload: Record<string, unknown> }
             | undefined;
-          if (client && params) await client.request(params.method, params.payload);
+          if (!client || !params) throw new Error("WebSocket recovery request is unavailable");
+          await client.request(params.method, params.payload);
           break;
         }
       }

--- a/apps/web/components/task/chat/messages/action-message.tsx
+++ b/apps/web/components/task/chat/messages/action-message.tsx
@@ -39,6 +39,7 @@ const ICON_MAP: Record<string, React.ElementType> = {
 type ActionMeta = {
   actions?: MessageAction[];
   variant?: string;
+  recovery_actions?: boolean;
   is_auth_error?: boolean;
   auth_methods?: RecoveryAuthMethod[];
   error_output?: string;
@@ -46,8 +47,17 @@ type ActionMeta = {
   missing_branch?: string;
 };
 
-function isSessionActive(state?: TaskSessionState) {
-  return state === "RUNNING" || state === "STARTING" || state === "COMPLETED";
+function isRecoveryResolved(
+  state: TaskSessionState | undefined,
+  sessionError: string | undefined,
+  hasRecoveryActions: boolean,
+) {
+  return (
+    state === "RUNNING" ||
+    state === "STARTING" ||
+    state === "COMPLETED" ||
+    (hasRecoveryActions && state === "WAITING_FOR_INPUT" && !sessionError)
+  );
 }
 
 export const ActionMessage = memo(function ActionMessage({ comment }: { comment: Message }) {
@@ -68,8 +78,11 @@ export const ActionMessage = memo(function ActionMessage({ comment }: { comment:
   const isWarning = metadata?.variant === "warning";
   const message = comment.content || "An error occurred";
 
-  // Hide once session is active again (recovery succeeded)
-  if (isSessionActive(sessionState)) return null;
+  // Hide once recovery has succeeded. A resumed session settles in
+  // WAITING_FOR_INPUT, so use its cleared error_message as the completion
+  // signal instead of leaving the persisted recovery card on screen.
+  if (isRecoveryResolved(sessionState, sessionError, metadata?.recovery_actions === true))
+    return null;
 
   if (metadata?.failure_kind === "missing_pr_branch") {
     return (


### PR DESCRIPTION
The Codex usage-limit failure left the original prompt dropped while the session appeared resumable, and the persisted recovery card remained after a successful Resume. Recovery now preserves the prompt for explicit retry, avoids duplicate user messages, classifies the provider error correctly, and clears the stale card when the resumed session is ready.

## Validation

- `go test ./internal/orchestrator ./internal/agent/runtime/routingerr`
- `pnpm --filter @kandev/web exec vitest run components/task/chat/messages/action-message.test.tsx`
- `pnpm --filter @kandev/web lint components/task/chat/messages/action-message.tsx components/task/chat/messages/action-message.test.tsx`
- `pnpm run typecheck` (from `apps/web`)
- `git diff --check`
- Pre-commit hooks: harness lint, gofmt, changed-file Go lint, Prettier, changed-file web lint, commit message validation

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [x] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1976?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->