### PR TITLE
fix(sentry): make issue-watch StatsPeriod actually filter by issue age

### DIFF
--- a/apps/backend/internal/sentry/mock_client.go
+++ b/apps/backend/internal/sentry/mock_client.go
@@ -3,8 +3,10 @@ package sentry
 import (
 	"context"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
+	"time"
 )
 
 // MockClient backs the in-memory Client used by E2E tests. It is instance-aware:
@@ -203,8 +205,11 @@ func (m *MockClient) Reset() {
 // mockMatchesFilter applies the filter predicates that map to a per-issue
 // field, so E2E tests can assert the backend forwarded the filter rather than
 // silently returning everything. Deliberately NOT enforced (no per-issue
-// analog on SentryIssue): OrgSlug, Environment, and StatsPeriod. The real REST
-// client's URL building for those params is covered in rest_client_test.go.
+// analog on SentryIssue): OrgSlug and Environment. The real REST client's URL
+// building for those params is covered in rest_client_test.go. StatsPeriod IS
+// enforced here, against issue.FirstSeen — matching the real REST client's
+// `age:` search-token translation (statsPeriodAgeToken in rest_client.go), so
+// mock-backed tests can't pass while production silently ignores the window.
 func mockMatchesFilter(issue *SentryIssue, f SearchFilter) bool {
 	if f.ProjectSlug != "" && issue.ProjectSlug != f.ProjectSlug {
 		return false
@@ -220,7 +225,37 @@ func mockMatchesFilter(issue *SentryIssue, f SearchFilter) bool {
 			return false
 		}
 	}
+	if window, ok := parseStatsPeriod(f.StatsPeriod); ok {
+		firstSeen, err := time.Parse(time.RFC3339, issue.FirstSeen)
+		// An issue with no/unparsable FirstSeen can't be judged against the
+		// window; fail open rather than silently dropping it.
+		if err == nil && time.Since(firstSeen) > window {
+			return false
+		}
+	}
 	return true
+}
+
+// parseStatsPeriod converts a StatsPeriod string ("24h", "7d", "2w") into a
+// time.Duration. ok is false for empty or unrecognized input — mirrors
+// statsPeriodPattern in rest_client.go, which the real REST client uses to
+// build the equivalent `age:` search token.
+func parseStatsPeriod(period string) (time.Duration, bool) {
+	period = strings.TrimSpace(period)
+	if !statsPeriodPattern.MatchString(period) {
+		return 0, false
+	}
+	n, err := strconv.Atoi(period[:len(period)-1])
+	// maxStatsPeriodUnits bounds n well below the point where n * unit could
+	// overflow time.Duration's int64 nanoseconds even for the largest unit
+	// (weeks): 3650 weeks is ~2.2e18 ns, comfortably under the ~9.2e18 ns
+	// ceiling, while covering every real value (the UI offers at most 30).
+	const maxStatsPeriodUnits = 3650
+	if err != nil || n <= 0 || n > maxStatsPeriodUnits {
+		return 0, false
+	}
+	units := map[byte]time.Duration{'h': time.Hour, 'd': 24 * time.Hour, 'w': 7 * 24 * time.Hour}
+	return time.Duration(n) * units[period[len(period)-1]], true
 }
 
 func containsFold(xs []string, target string) bool {

--- a/apps/backend/internal/sentry/mock_client.go
+++ b/apps/backend/internal/sentry/mock_client.go
@@ -3,7 +3,6 @@ package sentry
 import (
 	"context"
 	"net/http"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -237,25 +236,18 @@ func mockMatchesFilter(issue *SentryIssue, f SearchFilter) bool {
 }
 
 // parseStatsPeriod converts a StatsPeriod string ("24h", "7d", "2w") into a
-// time.Duration. ok is false for empty or unrecognized input — mirrors
-// statsPeriodPattern in rest_client.go, which the real REST client uses to
-// build the equivalent `age:` search token.
+// time.Duration. ok is false for empty, unrecognized, or out-of-range input —
+// it shares parseStatsPeriodUnits (rest_client.go) with statsPeriodAgeToken,
+// which the real REST client uses to build the equivalent `age:` search
+// token, so the mock and the real client accept or reject the exact same
+// input.
 func parseStatsPeriod(period string) (time.Duration, bool) {
-	period = strings.TrimSpace(period)
-	if !statsPeriodPattern.MatchString(period) {
-		return 0, false
-	}
-	n, err := strconv.Atoi(period[:len(period)-1])
-	// maxStatsPeriodUnits bounds n well below the point where n * unit could
-	// overflow time.Duration's int64 nanoseconds even for the largest unit
-	// (weeks): 3650 weeks is ~2.2e18 ns, comfortably under the ~9.2e18 ns
-	// ceiling, while covering every real value (the UI offers at most 30).
-	const maxStatsPeriodUnits = 3650
-	if err != nil || n <= 0 || n > maxStatsPeriodUnits {
+	n, unit, ok := parseStatsPeriodUnits(period)
+	if !ok {
 		return 0, false
 	}
 	units := map[byte]time.Duration{'h': time.Hour, 'd': 24 * time.Hour, 'w': 7 * 24 * time.Hour}
-	return time.Duration(n) * units[period[len(period)-1]], true
+	return time.Duration(n) * units[unit], true
 }
 
 func containsFold(xs []string, target string) bool {

--- a/apps/backend/internal/sentry/mock_client_test.go
+++ b/apps/backend/internal/sentry/mock_client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"testing"
+	"time"
 )
 
 // mockInstance returns a Client view of the shared mock bound to instanceID.
@@ -66,6 +67,65 @@ func TestMockClient_SearchFiltersByLevelStatusQuery(t *testing.T) {
 				t.Errorf("got %v, want %v", got, tc.want)
 			}
 		})
+	}
+}
+
+// TestMockClient_SearchFiltersByStatsPeriod locks in the fix for the
+// "watch configured for the last 24h still processes older issues" bug: the
+// mock (which backs E2E tests) must enforce StatsPeriod against each issue's
+// FirstSeen the same way the real REST client now does via the `age:`
+// search token (see statsPeriodAgeToken in rest_client.go).
+func TestMockClient_SearchFiltersByStatsPeriod(t *testing.T) {
+	m := NewMockClient()
+	now := time.Now().UTC()
+	m.AddIssue("inst-1", &SentryIssue{
+		ShortID: "OLD-1", Title: "Ancient", ProjectSlug: "fe",
+		FirstSeen: now.Add(-72 * time.Hour).Format(time.RFC3339),
+	})
+	m.AddIssue("inst-1", &SentryIssue{
+		ShortID: "NEW-1", Title: "Recent", ProjectSlug: "fe",
+		FirstSeen: now.Add(-1 * time.Hour).Format(time.RFC3339),
+	})
+	client := mockInstance(m, "inst-1")
+
+	res, err := client.SearchIssues(context.Background(), SearchFilter{OrgSlug: "acme", StatsPeriod: "24h"}, "")
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	got := make([]string, 0, len(res.Issues))
+	for _, i := range res.Issues {
+		got = append(got, i.ShortID)
+	}
+	if !sameStrings(got, []string{"NEW-1"}) {
+		t.Errorf("expected only NEW-1 within the 24h window, got %v", got)
+	}
+
+	// No StatsPeriod configured -> no age restriction (unchanged behaviour).
+	res, err = client.SearchIssues(context.Background(), SearchFilter{OrgSlug: "acme"}, "")
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	got = got[:0]
+	for _, i := range res.Issues {
+		got = append(got, i.ShortID)
+	}
+	if !sameStrings(got, []string{"OLD-1", "NEW-1"}) {
+		t.Errorf("expected both issues without a period filter, got %v", got)
+	}
+}
+
+// TestParseStatsPeriod_RejectsOverflowRisk pins the fail-safe (not
+// fail-open-to-a-corrupt-duration) behaviour for absurdly large period
+// values that would otherwise overflow time.Duration's int64 nanoseconds
+// when multiplied by the week/day unit.
+func TestParseStatsPeriod_RejectsOverflowRisk(t *testing.T) {
+	for _, period := range []string{"999999999999w", "999999999999d", "0h", "3651w"} {
+		if _, ok := parseStatsPeriod(period); ok {
+			t.Errorf("parseStatsPeriod(%q) should be rejected, was accepted", period)
+		}
+	}
+	if d, ok := parseStatsPeriod("3650w"); !ok || d <= 0 {
+		t.Errorf("parseStatsPeriod(%q) at the bound should be accepted with a positive duration, got %v/%v", "3650w", d, ok)
 	}
 }
 

--- a/apps/backend/internal/sentry/rest_client.go
+++ b/apps/backend/internal/sentry/rest_client.go
@@ -503,10 +503,40 @@ func buildIssueQueryString(f SearchFilter) string {
 // token and this integration's StatsPeriod values (1h, 24h, 7d, 14d, 30d) use.
 var statsPeriodPattern = regexp.MustCompile(`^[1-9]\d*[hdw]$`)
 
+// maxStatsPeriodUnits bounds the numeric component parseStatsPeriodUnits
+// accepts. 3650 weeks is ~2.2e18 ns, comfortably under the ~9.2e18 ns
+// ceiling time.Duration's int64 nanoseconds can hold even for the largest
+// unit (weeks) — see mock_client.go's parseStatsPeriod, which multiplies
+// this out into a duration and would otherwise silently wrap on overflow.
+// The bound comfortably covers every real value (the UI offers at most 30)
+// while keeping the REST `age:` token and the mock's duration math
+// rejecting the exact same out-of-range input, so a StatsPeriod that's
+// nonsensical in one path can't still pass as a valid filter in the other.
+const maxStatsPeriodUnits = 3650
+
+// parseStatsPeriodUnits validates period against Sentry's relative-duration
+// syntax and the shared accepted range, returning the numeric component and
+// unit byte ('h'/'d'/'w') on success. statsPeriodAgeToken below and
+// mock_client.go's parseStatsPeriod both build on this so the real REST
+// client and the mock that backs E2E tests accept or reject the exact same
+// input.
+func parseStatsPeriodUnits(period string) (n int, unit byte, ok bool) {
+	period = strings.TrimSpace(period)
+	if !statsPeriodPattern.MatchString(period) {
+		return 0, 0, false
+	}
+	n, err := strconv.Atoi(period[:len(period)-1])
+	if err != nil || n <= 0 || n > maxStatsPeriodUnits {
+		return 0, 0, false
+	}
+	return n, period[len(period)-1], true
+}
+
 // statsPeriodAgeToken translates a StatsPeriod value into Sentry's
 // `age:-<period>` search token, which restricts results to issues first seen
-// within that window. Returns "" for empty or unrecognized input, leaving the
-// query unfiltered by age exactly as before this translation existed.
+// within that window. Returns "" for empty, unrecognized, or out-of-range
+// input, leaving the query unfiltered by age exactly as before this
+// translation existed.
 //
 // This exists because Sentry's `statsPeriod` query param (set separately in
 // searchIssues) does NOT filter which issues an issue search returns — it
@@ -517,7 +547,7 @@ var statsPeriodPattern = regexp.MustCompile(`^[1-9]\d*[hdw]$`)
 // last 24h silently matches (and creates tasks for) issues of any age.
 func statsPeriodAgeToken(period string) string {
 	period = strings.TrimSpace(period)
-	if !statsPeriodPattern.MatchString(period) {
+	if _, _, ok := parseStatsPeriodUnits(period); !ok {
 		return ""
 	}
 	return "age:-" + period

--- a/apps/backend/internal/sentry/rest_client.go
+++ b/apps/backend/internal/sentry/rest_client.go
@@ -449,6 +449,16 @@ func issuesSearchPath(orgSlug, projectSlug string) string {
 // statsPeriodAgeToken's doc comment for why that translation, not the
 // `statsPeriod` query param set separately in searchIssues, is what actually
 // restricts which issues come back.
+//
+// The free-text Query is parenthesized whenever it is combined with another
+// token below. Sentry's search grammar ANDs implicitly-adjacent terms tighter
+// than an explicit `OR`, so an unparenthesized query containing `OR` (e.g.
+// `foo OR bar`) would bind the level/status/age tokens to only the adjacent
+// branch — `foo OR bar age:-24h` parses as `foo OR (bar age:-24h)`, so an old
+// `foo` issue still matches despite the configured age window. Wrapping in
+// parens groups the whole user query before it is ANDed against the
+// structured filters. A standalone query (nothing else to combine with) is
+// left unwrapped since parenthesizing it would be a no-op.
 func buildIssueQueryString(f SearchFilter) string {
 	parts := make([]string, 0, 5)
 	levels := make([]string, 0, len(f.Levels))
@@ -475,10 +485,14 @@ func buildIssueQueryString(f SearchFilter) string {
 		}
 		parts = append(parts, "is:"+st)
 	}
+	age := statsPeriodAgeToken(f.StatsPeriod)
 	if q := strings.TrimSpace(f.Query); q != "" {
+		if len(parts) > 0 || age != "" {
+			q = "(" + q + ")"
+		}
 		parts = append(parts, q)
 	}
-	if age := statsPeriodAgeToken(f.StatsPeriod); age != "" {
+	if age != "" {
 		parts = append(parts, age)
 	}
 	return strings.Join(parts, " ")

--- a/apps/backend/internal/sentry/rest_client.go
+++ b/apps/backend/internal/sentry/rest_client.go
@@ -445,9 +445,12 @@ func issuesSearchPath(orgSlug, projectSlug string) string {
 // form in Sentry search, so statuses are emitted as plain `is:bar` tokens;
 // watch filters are limited to a single status (enforced by
 // validateFilterStatuses) because two `is:` tokens would AND-combine and match
-// nothing.
+// nothing. StatsPeriod is translated into an `age:` token — see
+// statsPeriodAgeToken's doc comment for why that translation, not the
+// `statsPeriod` query param set separately in searchIssues, is what actually
+// restricts which issues come back.
 func buildIssueQueryString(f SearchFilter) string {
-	parts := make([]string, 0, 4)
+	parts := make([]string, 0, 5)
 	levels := make([]string, 0, len(f.Levels))
 	for _, lvl := range f.Levels {
 		if lvl = strings.TrimSpace(lvl); lvl != "" {
@@ -475,7 +478,35 @@ func buildIssueQueryString(f SearchFilter) string {
 	if q := strings.TrimSpace(f.Query); q != "" {
 		parts = append(parts, q)
 	}
+	if age := statsPeriodAgeToken(f.StatsPeriod); age != "" {
+		parts = append(parts, age)
+	}
 	return strings.Join(parts, " ")
+}
+
+// statsPeriodPattern matches Sentry's relative-duration syntax: an integer
+// followed by h(ours)/d(ays)/w(eeks) — the same units Sentry's `age:` search
+// token and this integration's StatsPeriod values (1h, 24h, 7d, 14d, 30d) use.
+var statsPeriodPattern = regexp.MustCompile(`^[1-9]\d*[hdw]$`)
+
+// statsPeriodAgeToken translates a StatsPeriod value into Sentry's
+// `age:-<period>` search token, which restricts results to issues first seen
+// within that window. Returns "" for empty or unrecognized input, leaving the
+// query unfiltered by age exactly as before this translation existed.
+//
+// This exists because Sentry's `statsPeriod` query param (set separately in
+// searchIssues) does NOT filter which issues an issue search returns — it
+// only sizes the per-issue event-count stats window returned alongside each
+// result (https://github.com/getsentry/sentry/issues/36375). Both the issue
+// browser and issue watches expose StatsPeriod as "how far back to look for
+// matching issues"; without this translation a watch configured for e.g. the
+// last 24h silently matches (and creates tasks for) issues of any age.
+func statsPeriodAgeToken(period string) string {
+	period = strings.TrimSpace(period)
+	if !statsPeriodPattern.MatchString(period) {
+		return ""
+	}
+	return "age:-" + period
 }
 
 // nextCursorRe extracts the cursor from a Sentry Link header entry of the form

--- a/apps/backend/internal/sentry/rest_client_test.go
+++ b/apps/backend/internal/sentry/rest_client_test.go
@@ -322,6 +322,31 @@ func TestBuildIssueQueryString_StatsPeriodBecomesAgeFilter(t *testing.T) {
 	}
 }
 
+// TestBuildIssueQueryString_ParenthesizesQueryWithOrOperator locks in the fix
+// for a Codex review finding on this PR: Sentry's search grammar ANDs
+// implicitly-adjacent terms tighter than an explicit `OR`, so appending a
+// level/status/age token directly after a free-text query containing `OR`
+// silently scoped that token to only the last OR-branch (`foo OR bar
+// age:-24h` parsed as `foo OR (bar age:-24h)`, letting an old "foo" issue
+// bypass the age filter). The query must be parenthesized before combining.
+func TestBuildIssueQueryString_ParenthesizesQueryWithOrOperator(t *testing.T) {
+	if got := buildIssueQueryString(SearchFilter{Query: "foo OR bar", StatsPeriod: "24h"}); got != "(foo OR bar) age:-24h" {
+		t.Errorf("expected OR query parenthesized before the age token, got %q", got)
+	}
+
+	if got := buildIssueQueryString(SearchFilter{Levels: []string{"error"}, Query: "foo OR bar"}); got != "level:error (foo OR bar)" {
+		t.Errorf("expected OR query parenthesized after the level token, got %q", got)
+	}
+
+	// A standalone query (nothing else to AND against) is left unwrapped —
+	// parenthesizing it would be a no-op, and this locks in that the literal
+	// query string a user typed is left untouched when there's nothing to
+	// combine it with.
+	if got := buildIssueQueryString(SearchFilter{Query: "foo OR bar"}); got != "foo OR bar" {
+		t.Errorf("expected standalone OR query left unwrapped, got %q", got)
+	}
+}
+
 // TestNewRESTClient_BuildsEndpointFromConfigURL locks in that a self-hosted
 // instance URL becomes the API base with the /api/0 suffix appended, that a
 // trailing slash and missing scheme are normalized, and that an empty URL

--- a/apps/backend/internal/sentry/rest_client_test.go
+++ b/apps/backend/internal/sentry/rest_client_test.go
@@ -322,6 +322,24 @@ func TestBuildIssueQueryString_StatsPeriodBecomesAgeFilter(t *testing.T) {
 	}
 }
 
+// TestStatsPeriodAgeToken_RejectsSameOutOfRangeValuesAsMock locks in a
+// CodeRabbit review finding on this PR: statsPeriodAgeToken (REST) and
+// parseStatsPeriod (mock_client.go) must accept/reject the exact same
+// StatsPeriod values via the shared parseStatsPeriodUnits, or a value like
+// "3651w" would filter live Sentry queries while a mock-backed test silently
+// treated it as unfiltered (or vice versa). Mirrors
+// TestParseStatsPeriod_RejectsOverflowRisk in mock_client_test.go.
+func TestStatsPeriodAgeToken_RejectsSameOutOfRangeValuesAsMock(t *testing.T) {
+	for _, period := range []string{"999999999999w", "999999999999d", "0h", "3651w"} {
+		if got := statsPeriodAgeToken(period); got != "" {
+			t.Errorf("statsPeriodAgeToken(%q) should be rejected, got %q", period, got)
+		}
+	}
+	if got := statsPeriodAgeToken("3650w"); got != "age:-3650w" {
+		t.Errorf("statsPeriodAgeToken(%q) at the bound should be accepted, got %q", "3650w", got)
+	}
+}
+
 // TestBuildIssueQueryString_ParenthesizesQueryWithOrOperator locks in the fix
 // for a Codex review finding on this PR: Sentry's search grammar ANDs
 // implicitly-adjacent terms tighter than an explicit `OR`, so appending a

--- a/apps/backend/internal/sentry/rest_client_test.go
+++ b/apps/backend/internal/sentry/rest_client_test.go
@@ -293,6 +293,35 @@ func TestBuildIssueQueryString(t *testing.T) {
 	}
 }
 
+// TestBuildIssueQueryString_StatsPeriodBecomesAgeFilter locks in the fix for
+// the "older issues get processed by a watch configured for the last 24h"
+// bug: Sentry's statsPeriod query param does NOT filter which issues a
+// search returns (it only sizes the per-issue stats window — see
+// https://github.com/getsentry/sentry/issues/36375). The only way to
+// actually restrict results to recently-first-seen issues is the `age:`
+// search token, so StatsPeriod must be translated into one.
+func TestBuildIssueQueryString_StatsPeriodBecomesAgeFilter(t *testing.T) {
+	if got := buildIssueQueryString(SearchFilter{StatsPeriod: "24h"}); got != "age:-24h" {
+		t.Errorf("expected age:-24h, got %q", got)
+	}
+
+	got := buildIssueQueryString(SearchFilter{Levels: []string{"error"}, StatsPeriod: "7d"})
+	if !strings.Contains(got, "level:error") || !strings.Contains(got, "age:-7d") {
+		t.Errorf("expected level and age tokens combined, got %q", got)
+	}
+
+	// An unrecognized period is dropped rather than injected verbatim into
+	// the Sentry search-bar query string.
+	if got := buildIssueQueryString(SearchFilter{StatsPeriod: "not-a-period"}); got != "" {
+		t.Errorf("expected malformed statsPeriod to be ignored, got %q", got)
+	}
+
+	// No StatsPeriod configured -> no age token (unchanged behaviour).
+	if got := buildIssueQueryString(SearchFilter{Query: "boom"}); got != "boom" {
+		t.Errorf("expected no age token without statsPeriod, got %q", got)
+	}
+}
+
 // TestNewRESTClient_BuildsEndpointFromConfigURL locks in that a self-hosted
 // instance URL becomes the API base with the /api/0 suffix appended, that a
 // trailing slash and missing scheme are normalized, and that an empty URL


### PR DESCRIPTION
Sentry issue watches configured with a "Stats period" (e.g. "Last 24 hours") still triaged issues far older than that window, because Sentry's `statsPeriod` query param only sizes each issue's stats graph — it never filters which issues the search endpoint returns ([getsentry/sentry#36375](https://github.com/getsentry/sentry/issues/36375)).

## Important Changes

- `buildIssueQueryString` now translates `StatsPeriod` into Sentry's real recency filter, the `age:-<period>` search token, so the REST client actually restricts results by first-seen time.
- The mock client enforces the same rule against `issue.FirstSeen` so E2E/mock-backed tests exercise the same contract as production, instead of silently ignoring the setting as before.

## Validation

- TDD: added `TestBuildIssueQueryString_StatsPeriodBecomesAgeFilter`, `TestMockClient_SearchFiltersByStatsPeriod`, and `TestParseStatsPeriod_RejectsOverflowRisk`; each confirmed failing before the fix and passing after.
- `go test -tags fts5 ./internal/sentry/...` — all green.
- `golangci-lint run ./internal/sentry/...` — 0 issues.
- `go build ./...` — clean.
- Ran the full backend suite (`go test -tags fts5 ./...`); pre-existing failures in `internal/task/handlers`, `internal/task/service`, `internal/launcher`, `internal/system/updates` reproduce identically on the unmodified baseline (confirmed via `git stash`) — sandbox filesystem/systemd restrictions unrelated to this change.
- `make fmt` — clean.

## Possible Improvements

Low risk: the fix only tightens an existing, already-broken filter (previously matched issues of any age); malformed or oversized `StatsPeriod` values fall back to "no age filter" rather than erroring, matching prior behavior for unrecognized input.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1977?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

