### PR TITLE
fix(mcp): honor explicit task_id in plan/walkthrough/review tools

### DIFF
--- a/apps/backend/internal/backendapp/review_wiring.go
+++ b/apps/backend/internal/backendapp/review_wiring.go
@@ -35,6 +35,11 @@ type reviewComponents struct {
 // "no capable reviewer" (a clear, actionable failure) instead of panicking.
 func buildReviewComponents(p routeParams) reviewComponents {
 	service := taskservice.NewReviewService(p.taskRepo, p.eventBus, p.log)
+	// Gate cross-task finding writes by workspace ownership, matching the plan
+	// and walkthrough services. Under enforced auth an agent may only publish
+	// to a task within its reach; unscoped callers (the built-in review runner,
+	// auth disabled) are unaffected.
+	service.SetTaskAuthorizer(p.taskSvc.AuthorizeTaskAccess)
 
 	resolver := review.NewResolver(
 		reviewProfileLookup{profiles: p.agentSettingsRepo},

--- a/apps/backend/internal/mcp/server/handlers.go
+++ b/apps/backend/internal/mcp/server/handlers.go
@@ -672,13 +672,36 @@ func (s *Server) notifyClarificationTimeout() {
 	}
 }
 
-// resolveTaskID returns the server-injected taskID if available, otherwise falls back
-// to the agent-provided value. This prevents LLM hallucination of task IDs.
+// resolveTaskID resolves the task a plan/walkthrough/review tool call targets.
+//
+// An explicitly provided task_id argument wins; the session-bound task is only a
+// fallback for when the argument is absent (or the server is not session-bound,
+// e.g. external mode). The tool schemas advertise task_id as a first-class
+// parameter, so a caller that names another task — a parent reading its child's
+// plan, say — must reach that task, exactly like message_task_kandev /
+// stop_task_kandev already address tasks other than the caller's own.
+//
+// Honoring the explicit value is safe because cross-task access is authorized on
+// the backend against the *stream owner's* identity: internal/mcp/scope attaches
+// that identity from the agent's own execution (task → workspace → owner), never
+// from the request payload, and the plan/walkthrough/review services then gate
+// the target task_id through the same workspace-ownership check every other
+// cross-task surface uses. A task outside the caller's reach is rejected there,
+// not served.
+//
+// This replaces the earlier behavior, which silently discarded the argument and
+// always used the bound task — turning a cross-task read into a wrong-task read
+// (and a cross-task write into a wrong-task write) with no error. The pin was a
+// blunt guard against LLM-hallucinated task IDs; the backend authorization above
+// is the precise one, so the silent misdirection is no longer worth its cost.
 func (s *Server) resolveTaskID(req mcp.CallToolRequest) (string, error) {
+	if explicit := req.GetString(mcpKeyTaskID, ""); explicit != "" {
+		return explicit, nil
+	}
 	if s.taskID != "" {
 		return s.taskID, nil
 	}
-	return req.RequireString("task_id")
+	return "", fmt.Errorf("task_id is required")
 }
 
 func (s *Server) createTaskPlanHandler() server.ToolHandlerFunc {

--- a/apps/backend/internal/mcp/server/handlers_test.go
+++ b/apps/backend/internal/mcp/server/handlers_test.go
@@ -815,9 +815,11 @@ func TestGetTaskPlan_FallsBackToBoundTask(t *testing.T) {
 }
 
 // TestPlanTools_DescriptionsDocumentCrossTaskBehavior keeps the advertised
-// behavior in the tool schemas honest — the descriptions must state that
-// task_id can name another task and is rejected (not redirected) when out of
-// reach, so callers aren't surprised by the resolution precedence.
+// behavior in the tool schemas honest — the top-level description of every
+// session-defaulting tool must state that task_id can name another task and is
+// rejected (not redirected) when out of reach. LLMs read the tool description
+// first to decide whether cross-task addressing is possible, so this coverage
+// spans plan, walkthrough, and review tools uniformly (not just plan).
 func TestPlanTools_DescriptionsDocumentCrossTaskBehavior(t *testing.T) {
 	s := newTaskModeServer(t, &testBackend{}, "task-A")
 	tools := s.mcpServer.ListTools()
@@ -827,6 +829,10 @@ func TestPlanTools_DescriptionsDocumentCrossTaskBehavior(t *testing.T) {
 		"get_task_plan_kandev",
 		"update_task_plan_kandev",
 		"delete_task_plan_kandev",
+		"show_walkthrough_kandev",
+		"get_walkthrough_kandev",
+		"delete_walkthrough_kandev",
+		"publish_review_findings_kandev",
 	} {
 		tool, ok := tools[name]
 		require.True(t, ok, "tool %q must be registered", name)

--- a/apps/backend/internal/mcp/server/handlers_test.go
+++ b/apps/backend/internal/mcp/server/handlers_test.go
@@ -719,3 +719,118 @@ func TestGetTaskConversation_MissingTaskID_ReturnsError(t *testing.T) {
 
 	assert.True(t, result.IsError)
 }
+
+// --- resolveTaskID precedence (fix for silent cross-task misdirection) ---
+
+// makeTaskIDReq builds a CallToolRequest carrying the given arguments, for
+// exercising resolveTaskID directly.
+func makeTaskIDReq(args map[string]interface{}) mcp.CallToolRequest {
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = args
+	return req
+}
+
+// TestResolveTaskID_ExplicitWinsOverBound is the core regression: a session
+// bound to task A that is handed an explicit task_id B must resolve to B, not
+// silently substitute its own A. This is the misdirection the fix removes.
+func TestResolveTaskID_ExplicitWinsOverBound(t *testing.T) {
+	s := newTaskModeServer(t, &testBackend{}, "task-A")
+
+	got, err := s.resolveTaskID(makeTaskIDReq(map[string]interface{}{"task_id": "task-B"}))
+	require.NoError(t, err)
+	assert.Equal(t, "task-B", got, "explicit task_id must win over the session-bound task")
+}
+
+// TestResolveTaskID_FallsBackToBoundWhenAbsent confirms the ergonomic fallback:
+// with no task_id argument, the session-bound task is used.
+func TestResolveTaskID_FallsBackToBoundWhenAbsent(t *testing.T) {
+	s := newTaskModeServer(t, &testBackend{}, "task-A")
+
+	got, err := s.resolveTaskID(makeTaskIDReq(map[string]interface{}{}))
+	require.NoError(t, err)
+	assert.Equal(t, "task-A", got, "absent task_id must fall back to the session-bound task")
+}
+
+// TestResolveTaskID_ErrorsWhenNeither covers the unbound server (e.g. external
+// mode) with no task_id argument: there is nothing to resolve, so it errors
+// rather than returning an empty task ID.
+func TestResolveTaskID_ErrorsWhenNeither(t *testing.T) {
+	s := newTaskModeServer(t, &testBackend{}, "")
+
+	got, err := s.resolveTaskID(makeTaskIDReq(map[string]interface{}{}))
+	require.Error(t, err)
+	assert.Empty(t, got)
+}
+
+// TestGetTaskPlan_ExplicitTaskIDForwardedNotBound is the handler-level
+// regression for the reported bug: a session bound to task A reading task B's
+// plan must forward task B to the backend, not A.
+func TestGetTaskPlan_ExplicitTaskIDForwardedNotBound(t *testing.T) {
+	backend := &testBackend{response: map[string]interface{}{"content": "B's plan"}}
+	s := newTaskModeServer(t, backend, "task-A")
+
+	result := callTool(t, s, "get_task_plan_kandev", map[string]interface{}{
+		"task_id": "task-B",
+	})
+
+	assert.False(t, result.IsError)
+	assert.Equal(t, ws.ActionMCPGetTaskPlan, backend.lastAction)
+	payload, ok := backend.lastPayload.(map[string]string)
+	require.True(t, ok)
+	assert.Equal(t, "task-B", payload["task_id"], "explicit task_id must reach the backend, not the bound task")
+}
+
+// TestCreateTaskPlan_ExplicitTaskIDForwardedNotBound guards the more dangerous
+// write case: a cross-task create must target the named task, never the
+// caller's own (which the old code did silently).
+func TestCreateTaskPlan_ExplicitTaskIDForwardedNotBound(t *testing.T) {
+	backend := &testBackend{response: map[string]interface{}{"id": "plan-1"}}
+	s := newTaskModeServer(t, backend, "task-A")
+
+	result := callTool(t, s, "create_task_plan_kandev", map[string]interface{}{
+		"task_id": "task-B",
+		"content": "the plan",
+	})
+
+	assert.False(t, result.IsError)
+	assert.Equal(t, ws.ActionMCPCreateTaskPlan, backend.lastAction)
+	payload, ok := backend.lastPayload.(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "task-B", payload["task_id"], "cross-task create must write to the named task, not the caller's own")
+	assert.Equal(t, "the plan", payload["content"])
+}
+
+// TestGetTaskPlan_FallsBackToBoundTask confirms the common case still works:
+// omitting task_id targets the caller's own task.
+func TestGetTaskPlan_FallsBackToBoundTask(t *testing.T) {
+	backend := &testBackend{response: map[string]interface{}{"content": "A's plan"}}
+	s := newTaskModeServer(t, backend, "task-A")
+
+	result := callTool(t, s, "get_task_plan_kandev", map[string]interface{}{})
+
+	assert.False(t, result.IsError)
+	payload, ok := backend.lastPayload.(map[string]string)
+	require.True(t, ok)
+	assert.Equal(t, "task-A", payload["task_id"])
+}
+
+// TestPlanTools_DescriptionsDocumentCrossTaskBehavior keeps the advertised
+// behavior in the tool schemas honest — the descriptions must state that
+// task_id can name another task and is rejected (not redirected) when out of
+// reach, so callers aren't surprised by the resolution precedence.
+func TestPlanTools_DescriptionsDocumentCrossTaskBehavior(t *testing.T) {
+	s := newTaskModeServer(t, &testBackend{}, "task-A")
+	tools := s.mcpServer.ListTools()
+
+	for _, name := range []string{
+		"create_task_plan_kandev",
+		"get_task_plan_kandev",
+		"update_task_plan_kandev",
+		"delete_task_plan_kandev",
+	} {
+		tool, ok := tools[name]
+		require.True(t, ok, "tool %q must be registered", name)
+		assert.Contains(t, tool.Tool.Description, "within your reach",
+			"%q description must document cross-task reach limits", name)
+	}
+}

--- a/apps/backend/internal/mcp/server/handlers_test.go
+++ b/apps/backend/internal/mcp/server/handlers_test.go
@@ -834,3 +834,41 @@ func TestPlanTools_DescriptionsDocumentCrossTaskBehavior(t *testing.T) {
 			"%q description must document cross-task reach limits", name)
 	}
 }
+
+// TestTaskScopedTools_TaskIDIsOptional locks in that task_id is advertised as
+// optional (not required) on every tool whose handler falls back to the
+// session-bound task when task_id is omitted. Marking it required would
+// contradict the documented "defaults to your current task" behavior — the
+// schema/behavior mismatch flagged in review.
+func TestTaskScopedTools_TaskIDIsOptional(t *testing.T) {
+	s := newTaskModeServer(t, &testBackend{}, "task-A")
+	tools := s.mcpServer.ListTools()
+
+	for _, name := range []string{
+		"create_task_plan_kandev",
+		"get_task_plan_kandev",
+		"update_task_plan_kandev",
+		"delete_task_plan_kandev",
+		"show_walkthrough_kandev",
+		"get_walkthrough_kandev",
+		"delete_walkthrough_kandev",
+		"publish_review_findings_kandev",
+	} {
+		tool, ok := tools[name]
+		require.True(t, ok, "tool %q must be registered", name)
+
+		schema, err := json.Marshal(tool.Tool.InputSchema)
+		require.NoError(t, err)
+		var parsed map[string]interface{}
+		require.NoError(t, json.Unmarshal(schema, &parsed))
+
+		props, _ := parsed["properties"].(map[string]interface{})
+		assert.Contains(t, props, "task_id", "%q must still expose task_id", name)
+
+		required, _ := parsed["required"].([]interface{})
+		for _, r := range required {
+			assert.NotEqual(t, "task_id", r,
+				"%q must not mark task_id required — it defaults to the session task when omitted", name)
+		}
+	}
+}

--- a/apps/backend/internal/mcp/server/server.go
+++ b/apps/backend/internal/mcp/server/server.go
@@ -944,8 +944,8 @@ Example rejection:
 func (s *Server) registerPlanTools() {
 	s.mcpServer.AddTool(
 		mcp.NewTool("create_task_plan_kandev",
-			mcp.WithDescription("Create or save a task plan. Use this to save your implementation plan for the current task."),
-			mcp.WithString("task_id", mcp.Required(), mcp.Description("The task ID to create a plan for")),
+			mcp.WithDescription("Create or save a task plan. task_id addresses the plan's task: pass your own task ID for your current task, or another task's ID to write that task's plan (allowed only within your reach — same workspace / task tree; a task outside it is rejected, never silently redirected to your own)."),
+			mcp.WithString("task_id", mcp.Required(), mcp.Description("The task ID to create a plan for. Defaults to your current task when omitted; pass another task's ID to target it directly.")),
 			mcp.WithString("content", mcp.Required(), mcp.Description("The plan content in markdown format")),
 			mcp.WithString("title", mcp.Description("Optional title for the plan (default: 'Plan')")),
 		),
@@ -953,15 +953,15 @@ func (s *Server) registerPlanTools() {
 	)
 	s.mcpServer.AddTool(
 		mcp.NewTool("get_task_plan_kandev",
-			mcp.WithDescription("Get the current plan for a task. Use this to retrieve an existing plan, including any user edits."),
-			mcp.WithString("task_id", mcp.Required(), mcp.Description("The task ID to get the plan for")),
+			mcp.WithDescription("Get the current plan for a task, including any user edits. task_id selects the task: pass your own task ID for your current task, or another task's ID to read that task's plan (allowed only within your reach — same workspace / task tree; a task outside it is rejected, never silently redirected to your own)."),
+			mcp.WithString("task_id", mcp.Required(), mcp.Description("The task ID to get the plan for. Defaults to your current task when omitted; pass another task's ID to read it directly.")),
 		),
 		s.wrapHandler("get_task_plan_kandev", s.getTaskPlanHandler()),
 	)
 	s.mcpServer.AddTool(
 		mcp.NewTool("update_task_plan_kandev",
-			mcp.WithDescription("Update an existing task plan. Use this to modify the plan during implementation."),
-			mcp.WithString("task_id", mcp.Required(), mcp.Description("The task ID to update the plan for")),
+			mcp.WithDescription("Update an existing task plan. task_id selects the task whose plan to modify: your own task by default, or another task's ID to update that task's plan (allowed only within your reach — same workspace / task tree; a task outside it is rejected, never silently redirected to your own)."),
+			mcp.WithString("task_id", mcp.Required(), mcp.Description("The task ID to update the plan for. Defaults to your current task when omitted; pass another task's ID to target it directly.")),
 			mcp.WithString("content", mcp.Required(), mcp.Description("The updated plan content in markdown format")),
 			mcp.WithString("title", mcp.Description("Optional new title for the plan")),
 		),
@@ -969,8 +969,8 @@ func (s *Server) registerPlanTools() {
 	)
 	s.mcpServer.AddTool(
 		mcp.NewTool("delete_task_plan_kandev",
-			mcp.WithDescription("Delete a task plan."),
-			mcp.WithString("task_id", mcp.Required(), mcp.Description("The task ID to delete the plan for")),
+			mcp.WithDescription("Delete a task plan. task_id selects the task whose plan to delete: your own task by default, or another task's ID to delete that task's plan (allowed only within your reach — same workspace / task tree; a task outside it is rejected, never silently redirected to your own)."),
+			mcp.WithString("task_id", mcp.Required(), mcp.Description("The task ID to delete the plan for. Defaults to your current task when omitted; pass another task's ID to target it directly.")),
 		),
 		s.wrapHandler("delete_task_plan_kandev", s.deleteTaskPlanHandler()),
 	)
@@ -995,7 +995,7 @@ func (s *Server) registerWalkthroughTools() {
 					"or to explain how a part of the codebase works. Order steps to follow the reader's "+
 					"natural path through the code (entry point first, then the call chain). Keep text "+
 					"concise and do not add a 'Justification:' preamble."),
-			mcp.WithString("task_id", mcp.Required(), mcp.Description("The task ID to attach the walkthrough to")),
+			mcp.WithString("task_id", mcp.Required(), mcp.Description("The task ID to attach the walkthrough to. Defaults to your current task when omitted; pass another task's ID (within your reach — same workspace / task tree) to target it directly.")),
 			mcp.WithString("title", mcp.Description("Optional title for the walkthrough (default: 'Walkthrough')")),
 			mcp.WithArray("steps", mcp.Required(),
 				mcp.Description("Ordered list of walkthrough steps, each anchored to a file line or range."),
@@ -1007,14 +1007,14 @@ func (s *Server) registerWalkthroughTools() {
 	s.mcpServer.AddTool(
 		mcp.NewTool("get_walkthrough_kandev",
 			mcp.WithDescription("Get the current code walkthrough for a task, including any steps."),
-			mcp.WithString("task_id", mcp.Required(), mcp.Description("The task ID to get the walkthrough for")),
+			mcp.WithString("task_id", mcp.Required(), mcp.Description("The task ID to get the walkthrough for. Defaults to your current task when omitted; pass another task's ID (within your reach — same workspace / task tree) to read it directly.")),
 		),
 		s.wrapHandler("get_walkthrough_kandev", s.getWalkthroughHandler()),
 	)
 	s.mcpServer.AddTool(
 		mcp.NewTool("delete_walkthrough_kandev",
 			mcp.WithDescription("Delete the code walkthrough for a task."),
-			mcp.WithString("task_id", mcp.Required(), mcp.Description("The task ID to delete the walkthrough for")),
+			mcp.WithString("task_id", mcp.Required(), mcp.Description("The task ID to delete the walkthrough for. Defaults to your current task when omitted; pass another task's ID (within your reach — same workspace / task tree) to target it directly.")),
 		),
 		s.wrapHandler("delete_walkthrough_kandev", s.deleteWalkthroughHandler()),
 	)
@@ -1038,7 +1038,7 @@ func (s *Server) registerReviewTools() {
 					"Be honest with severity; marking everything a blocker makes the review useless. "+
 					"Publishing adds to the task's findings; it does not replace earlier ones, except "+
 					"that an unresolved finding with the same file, line range, and title is refreshed."),
-			mcp.WithString("task_id", mcp.Required(), mcp.Description("The task ID to attach the findings to")),
+			mcp.WithString("task_id", mcp.Required(), mcp.Description("The task ID to attach the findings to. Defaults to your current task when omitted; pass another task's ID (within your reach — same workspace / task tree) to target it directly.")),
 			mcp.WithString("summary", mcp.Description("Optional one-paragraph summary of the review")),
 			mcp.WithArray("findings", mcp.Required(),
 				mcp.Description("Findings to publish, each anchored to a file and line range."),

--- a/apps/backend/internal/mcp/server/server.go
+++ b/apps/backend/internal/mcp/server/server.go
@@ -994,7 +994,9 @@ func (s *Server) registerWalkthroughTools() {
 					"Use this after producing a change to narrate the diff (what each hunk does and why), "+
 					"or to explain how a part of the codebase works. Order steps to follow the reader's "+
 					"natural path through the code (entry point first, then the call chain). Keep text "+
-					"concise and do not add a 'Justification:' preamble."),
+					"concise and do not add a 'Justification:' preamble. task_id defaults to your current "+
+					"task; pass another task's ID to target it directly, allowed only within your reach "+
+					"(same workspace / task tree)."),
 			mcp.WithString("task_id", mcp.Description("The task ID to attach the walkthrough to. Defaults to your current task when omitted; pass another task's ID (within your reach — same workspace / task tree) to target it directly.")),
 			mcp.WithString("title", mcp.Description("Optional title for the walkthrough (default: 'Walkthrough')")),
 			mcp.WithArray("steps", mcp.Required(),
@@ -1006,14 +1008,14 @@ func (s *Server) registerWalkthroughTools() {
 	)
 	s.mcpServer.AddTool(
 		mcp.NewTool("get_walkthrough_kandev",
-			mcp.WithDescription("Get the current code walkthrough for a task, including any steps."),
+			mcp.WithDescription("Get the current code walkthrough for a task, including any steps. task_id defaults to your current task; pass another task's ID (within your reach — same workspace / task tree) to read it directly."),
 			mcp.WithString("task_id", mcp.Description("The task ID to get the walkthrough for. Defaults to your current task when omitted; pass another task's ID (within your reach — same workspace / task tree) to read it directly.")),
 		),
 		s.wrapHandler("get_walkthrough_kandev", s.getWalkthroughHandler()),
 	)
 	s.mcpServer.AddTool(
 		mcp.NewTool("delete_walkthrough_kandev",
-			mcp.WithDescription("Delete the code walkthrough for a task."),
+			mcp.WithDescription("Delete the code walkthrough for a task. task_id defaults to your current task; pass another task's ID (within your reach — same workspace / task tree) to target it directly."),
 			mcp.WithString("task_id", mcp.Description("The task ID to delete the walkthrough for. Defaults to your current task when omitted; pass another task's ID (within your reach — same workspace / task tree) to target it directly.")),
 		),
 		s.wrapHandler("delete_walkthrough_kandev", s.deleteWalkthroughHandler()),
@@ -1037,7 +1039,9 @@ func (s *Server) registerReviewTools() {
 					"leaks, contract breaks, missing tests — not style or formatting a linter owns. "+
 					"Be honest with severity; marking everything a blocker makes the review useless. "+
 					"Publishing adds to the task's findings; it does not replace earlier ones, except "+
-					"that an unresolved finding with the same file, line range, and title is refreshed."),
+					"that an unresolved finding with the same file, line range, and title is refreshed. "+
+					"task_id defaults to your current task; pass another task's ID to target it directly, "+
+					"allowed only within your reach (same workspace / task tree)."),
 			mcp.WithString("task_id", mcp.Description("The task ID to attach the findings to. Defaults to your current task when omitted; pass another task's ID (within your reach — same workspace / task tree) to target it directly.")),
 			mcp.WithString("summary", mcp.Description("Optional one-paragraph summary of the review")),
 			mcp.WithArray("findings", mcp.Required(),

--- a/apps/backend/internal/mcp/server/server.go
+++ b/apps/backend/internal/mcp/server/server.go
@@ -945,7 +945,7 @@ func (s *Server) registerPlanTools() {
 	s.mcpServer.AddTool(
 		mcp.NewTool("create_task_plan_kandev",
 			mcp.WithDescription("Create or save a task plan. task_id addresses the plan's task: pass your own task ID for your current task, or another task's ID to write that task's plan (allowed only within your reach — same workspace / task tree; a task outside it is rejected, never silently redirected to your own)."),
-			mcp.WithString("task_id", mcp.Required(), mcp.Description("The task ID to create a plan for. Defaults to your current task when omitted; pass another task's ID to target it directly.")),
+			mcp.WithString("task_id", mcp.Description("The task ID to create a plan for. Defaults to your current task when omitted; pass another task's ID to target it directly.")),
 			mcp.WithString("content", mcp.Required(), mcp.Description("The plan content in markdown format")),
 			mcp.WithString("title", mcp.Description("Optional title for the plan (default: 'Plan')")),
 		),
@@ -954,14 +954,14 @@ func (s *Server) registerPlanTools() {
 	s.mcpServer.AddTool(
 		mcp.NewTool("get_task_plan_kandev",
 			mcp.WithDescription("Get the current plan for a task, including any user edits. task_id selects the task: pass your own task ID for your current task, or another task's ID to read that task's plan (allowed only within your reach — same workspace / task tree; a task outside it is rejected, never silently redirected to your own)."),
-			mcp.WithString("task_id", mcp.Required(), mcp.Description("The task ID to get the plan for. Defaults to your current task when omitted; pass another task's ID to read it directly.")),
+			mcp.WithString("task_id", mcp.Description("The task ID to get the plan for. Defaults to your current task when omitted; pass another task's ID to read it directly.")),
 		),
 		s.wrapHandler("get_task_plan_kandev", s.getTaskPlanHandler()),
 	)
 	s.mcpServer.AddTool(
 		mcp.NewTool("update_task_plan_kandev",
 			mcp.WithDescription("Update an existing task plan. task_id selects the task whose plan to modify: your own task by default, or another task's ID to update that task's plan (allowed only within your reach — same workspace / task tree; a task outside it is rejected, never silently redirected to your own)."),
-			mcp.WithString("task_id", mcp.Required(), mcp.Description("The task ID to update the plan for. Defaults to your current task when omitted; pass another task's ID to target it directly.")),
+			mcp.WithString("task_id", mcp.Description("The task ID to update the plan for. Defaults to your current task when omitted; pass another task's ID to target it directly.")),
 			mcp.WithString("content", mcp.Required(), mcp.Description("The updated plan content in markdown format")),
 			mcp.WithString("title", mcp.Description("Optional new title for the plan")),
 		),
@@ -970,7 +970,7 @@ func (s *Server) registerPlanTools() {
 	s.mcpServer.AddTool(
 		mcp.NewTool("delete_task_plan_kandev",
 			mcp.WithDescription("Delete a task plan. task_id selects the task whose plan to delete: your own task by default, or another task's ID to delete that task's plan (allowed only within your reach — same workspace / task tree; a task outside it is rejected, never silently redirected to your own)."),
-			mcp.WithString("task_id", mcp.Required(), mcp.Description("The task ID to delete the plan for. Defaults to your current task when omitted; pass another task's ID to target it directly.")),
+			mcp.WithString("task_id", mcp.Description("The task ID to delete the plan for. Defaults to your current task when omitted; pass another task's ID to target it directly.")),
 		),
 		s.wrapHandler("delete_task_plan_kandev", s.deleteTaskPlanHandler()),
 	)
@@ -995,7 +995,7 @@ func (s *Server) registerWalkthroughTools() {
 					"or to explain how a part of the codebase works. Order steps to follow the reader's "+
 					"natural path through the code (entry point first, then the call chain). Keep text "+
 					"concise and do not add a 'Justification:' preamble."),
-			mcp.WithString("task_id", mcp.Required(), mcp.Description("The task ID to attach the walkthrough to. Defaults to your current task when omitted; pass another task's ID (within your reach — same workspace / task tree) to target it directly.")),
+			mcp.WithString("task_id", mcp.Description("The task ID to attach the walkthrough to. Defaults to your current task when omitted; pass another task's ID (within your reach — same workspace / task tree) to target it directly.")),
 			mcp.WithString("title", mcp.Description("Optional title for the walkthrough (default: 'Walkthrough')")),
 			mcp.WithArray("steps", mcp.Required(),
 				mcp.Description("Ordered list of walkthrough steps, each anchored to a file line or range."),
@@ -1007,14 +1007,14 @@ func (s *Server) registerWalkthroughTools() {
 	s.mcpServer.AddTool(
 		mcp.NewTool("get_walkthrough_kandev",
 			mcp.WithDescription("Get the current code walkthrough for a task, including any steps."),
-			mcp.WithString("task_id", mcp.Required(), mcp.Description("The task ID to get the walkthrough for. Defaults to your current task when omitted; pass another task's ID (within your reach — same workspace / task tree) to read it directly.")),
+			mcp.WithString("task_id", mcp.Description("The task ID to get the walkthrough for. Defaults to your current task when omitted; pass another task's ID (within your reach — same workspace / task tree) to read it directly.")),
 		),
 		s.wrapHandler("get_walkthrough_kandev", s.getWalkthroughHandler()),
 	)
 	s.mcpServer.AddTool(
 		mcp.NewTool("delete_walkthrough_kandev",
 			mcp.WithDescription("Delete the code walkthrough for a task."),
-			mcp.WithString("task_id", mcp.Required(), mcp.Description("The task ID to delete the walkthrough for. Defaults to your current task when omitted; pass another task's ID (within your reach — same workspace / task tree) to target it directly.")),
+			mcp.WithString("task_id", mcp.Description("The task ID to delete the walkthrough for. Defaults to your current task when omitted; pass another task's ID (within your reach — same workspace / task tree) to target it directly.")),
 		),
 		s.wrapHandler("delete_walkthrough_kandev", s.deleteWalkthroughHandler()),
 	)
@@ -1038,7 +1038,7 @@ func (s *Server) registerReviewTools() {
 					"Be honest with severity; marking everything a blocker makes the review useless. "+
 					"Publishing adds to the task's findings; it does not replace earlier ones, except "+
 					"that an unresolved finding with the same file, line range, and title is refreshed."),
-			mcp.WithString("task_id", mcp.Required(), mcp.Description("The task ID to attach the findings to. Defaults to your current task when omitted; pass another task's ID (within your reach — same workspace / task tree) to target it directly.")),
+			mcp.WithString("task_id", mcp.Description("The task ID to attach the findings to. Defaults to your current task when omitted; pass another task's ID (within your reach — same workspace / task tree) to target it directly.")),
 			mcp.WithString("summary", mcp.Description("Optional one-paragraph summary of the review")),
 			mcp.WithArray("findings", mcp.Required(),
 				mcp.Description("Findings to publish, each anchored to a file and line range."),

--- a/apps/backend/internal/task/service/review_service.go
+++ b/apps/backend/internal/task/service/review_service.go
@@ -61,6 +61,11 @@ type ReviewService struct {
 	repo     reviewRepo
 	eventBus bus.EventBus
 	logger   *logger.Logger
+	// authorizeTask gates cross-task finding writes by the task's workspace
+	// ownership (opt-in auth). Nil = unscoped (internal callers such as the
+	// built-in review runner / auth disabled). Mirrors PlanService and
+	// WalkthroughService.
+	authorizeTask func(ctx context.Context, taskID string) error
 }
 
 // NewReviewService creates a new code-review service.
@@ -70,6 +75,21 @@ func NewReviewService(repo reviewRepo, eventBus bus.EventBus, log *logger.Logger
 		eventBus: eventBus,
 		logger:   log.WithFields(zap.String("component", "review-service")),
 	}
+}
+
+// SetTaskAuthorizer wires the per-user task-access check (opt-in auth). The
+// authorizer must return nil for contexts without a request identity. Mirrors
+// PlanService / WalkthroughService so publish_review_findings_kandev honors an
+// explicit cross-task task_id only within the caller's reach.
+func (s *ReviewService) SetTaskAuthorizer(fn func(ctx context.Context, taskID string) error) {
+	s.authorizeTask = fn
+}
+
+func (s *ReviewService) authorize(ctx context.Context, taskID string) error {
+	if s.authorizeTask == nil {
+		return nil
+	}
+	return s.authorizeTask(ctx, taskID)
 }
 
 // CreateRunRequest describes a new review pass.
@@ -279,6 +299,9 @@ type ReviewFindingInput struct {
 func (s *ReviewService) PublishFindings(ctx context.Context, req PublishFindingsRequest) (*models.TaskReviewRun, []*models.TaskReviewFinding, error) {
 	if req.TaskID == "" {
 		return nil, nil, ErrTaskIDRequired
+	}
+	if err := s.authorize(ctx, req.TaskID); err != nil {
+		return nil, nil, err
 	}
 	if len(req.Findings) == 0 {
 		return nil, nil, fmt.Errorf("%w: at least one finding is required", ErrInvalidReviewFinding)

--- a/apps/backend/internal/task/service/review_service_test.go
+++ b/apps/backend/internal/task/service/review_service_test.go
@@ -215,6 +215,60 @@ func TestReviewService_PublishFindingsWithExistingRun(t *testing.T) {
 	}
 }
 
+func TestReviewService_PublishFindingsDeniedByTaskAuthorizer(t *testing.T) {
+	svc, eventBus, repo := createTestReviewService(t)
+	ctx := context.Background()
+	seedTask(t, ctx, repo, "task-foreign")
+
+	denied := errors.New("task not found")
+	var authorized string
+	svc.SetTaskAuthorizer(func(_ context.Context, taskID string) error {
+		authorized = taskID
+		return denied
+	})
+
+	_, _, err := svc.PublishFindings(ctx, PublishFindingsRequest{
+		TaskID:   "task-foreign",
+		Findings: []ReviewFindingInput{validFindingInput()},
+	})
+	if !errors.Is(err, denied) {
+		t.Fatalf("expected the authorizer's error, got %v", err)
+	}
+	if authorized != "task-foreign" {
+		t.Fatalf("authorizer must be called with the target task_id, got %q", authorized)
+	}
+	// A denied publish must not store findings or emit any event.
+	if len(eventBus.GetPublishedEvents()) != 0 {
+		t.Fatalf("denied publish must not emit events, got %v", eventTypes(eventBus.GetPublishedEvents()))
+	}
+}
+
+func TestReviewService_PublishFindingsAllowedWhenAuthorizerPermits(t *testing.T) {
+	svc, _, repo := createTestReviewService(t)
+	ctx := context.Background()
+	seedTask(t, ctx, repo, "task-reachable")
+
+	var authorized string
+	svc.SetTaskAuthorizer(func(_ context.Context, taskID string) error {
+		authorized = taskID
+		return nil
+	})
+
+	_, findings, err := svc.PublishFindings(ctx, PublishFindingsRequest{
+		TaskID:   "task-reachable",
+		Findings: []ReviewFindingInput{validFindingInput()},
+	})
+	if err != nil {
+		t.Fatalf("PublishFindings: %v", err)
+	}
+	if authorized != "task-reachable" {
+		t.Fatalf("authorizer must be called with the target task_id, got %q", authorized)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected the findings stored, got %d", len(findings))
+	}
+}
+
 func TestReviewService_PublishFindingsCreatesAgentRunWhenRunIDEmpty(t *testing.T) {
 	svc, _, repo := createTestReviewService(t)
 	ctx := context.Background()

--- a/apps/backend/internal/task/service/service_access_test.go
+++ b/apps/backend/internal/task/service/service_access_test.go
@@ -259,14 +259,22 @@ func TestPlanAndWalkthroughScoping(t *testing.T) {
 	}); !errors.Is(err, repoerrors.ErrTaskNotFound) {
 		t.Fatalf("foreign review publish: %v", err)
 	}
-	// Owner passes the gate and the findings are actually stored.
+	// Owner passes the gate and the finding is actually persisted.
 	if _, findings, err := review.PublishFindings(ctxAs("user-b"), PublishFindingsRequest{
 		TaskID:   "task-b",
 		Findings: []ReviewFindingInput{validFindingInput()},
 	}); err != nil {
 		t.Fatalf("owner review publish must pass the auth gate: %v", err)
 	} else if len(findings) != 1 {
-		t.Fatalf("owner review publish should store the finding, got %d", len(findings))
+		t.Fatalf("owner review publish should return the stored finding, got %d", len(findings))
+	}
+	// Confirm the write landed in the repository, not just the returned slice.
+	persisted, err := repo.ListTaskReviewFindings(context.Background(), "task-b")
+	if err != nil {
+		t.Fatalf("list persisted review findings: %v", err)
+	}
+	if len(persisted) != 1 {
+		t.Fatalf("owner review publish should persist exactly one finding, got %d", len(persisted))
 	}
 }
 

--- a/apps/backend/internal/task/service/service_access_test.go
+++ b/apps/backend/internal/task/service/service_access_test.go
@@ -218,8 +218,11 @@ func TestMessageScopingBlocksForeignSession(t *testing.T) {
 	}
 }
 
-// TestPlanAndWalkthroughScoping covers the plan/walkthrough services, which
-// carry their own task authorizer seam (wired to the task service).
+// TestPlanAndWalkthroughScoping covers the plan/walkthrough/review services,
+// which each carry their own task authorizer seam (wired to the task service).
+// Exercises the assembled path AuthorizeTaskAccess → SetTaskAuthorizer →
+// service, so all three stay uniformly covered: a foreign owner is denied with
+// ErrTaskNotFound and the real owner passes the gate.
 func TestPlanAndWalkthroughScoping(t *testing.T) {
 	svc, _, repo := createTestService(t)
 	seedScopedWorkspaces(t, repo)
@@ -246,6 +249,24 @@ func TestPlanAndWalkthroughScoping(t *testing.T) {
 	}
 	if err := wt.DeleteWalkthrough(ctxAs("user-a"), "task-b"); !errors.Is(err, repoerrors.ErrTaskNotFound) {
 		t.Fatalf("foreign walkthrough delete: %v", err)
+	}
+
+	review := NewReviewService(repo, nil, log)
+	review.SetTaskAuthorizer(svc.AuthorizeTaskAccess)
+	if _, _, err := review.PublishFindings(ctxAs("user-a"), PublishFindingsRequest{
+		TaskID:   "task-b",
+		Findings: []ReviewFindingInput{validFindingInput()},
+	}); !errors.Is(err, repoerrors.ErrTaskNotFound) {
+		t.Fatalf("foreign review publish: %v", err)
+	}
+	// Owner passes the gate and the findings are actually stored.
+	if _, findings, err := review.PublishFindings(ctxAs("user-b"), PublishFindingsRequest{
+		TaskID:   "task-b",
+		Findings: []ReviewFindingInput{validFindingInput()},
+	}); err != nil {
+		t.Fatalf("owner review publish must pass the auth gate: %v", err)
+	} else if len(findings) != 1 {
+		t.Fatalf("owner review publish should store the finding, got %d", len(findings))
 	}
 }
 


### PR DESCRIPTION
## The bug

`resolveTaskID` (`apps/backend/internal/mcp/server/handlers.go`) silently discarded the caller-supplied `task_id` whenever the MCP server was session-bound — which is **every agent session** — and substituted the caller's own task:

```go
func (s *Server) resolveTaskID(req mcp.CallToolRequest) (string, error) {
	if s.taskID != "" {
		return s.taskID, nil   // <- caller's task_id ignored
	}
	return req.RequireString("task_id")
}
```

**Real repro (2026-07-27):** a parent agent called `get_task_plan_kandev` with its child's task_id and got back "No plan exists for this task yet" — it was actually served the parent's own empty plan. A cross-task `create_task_plan_kandev` would have silently written to the caller's own task. The tool schemas advertise `task_id` as a usable parameter, so callers reasonably believe cross-task addressing works. It silently didn't.

## The fix

Honor an explicitly provided `task_id`; fall back to the session-bound task only when the argument is absent. This matches how `message_task_kandev` / `stop_task_kandev` already address other tasks.

Cross-task access stays safe without inventing any authz: `internal/mcp/scope` attaches the **stream owner's** identity (from the agent's own execution — task → workspace → owner, never the payload), and the plan/walkthrough/review services gate the target `task_id` through the same workspace-ownership check every other cross-task surface uses. An out-of-reach task is **rejected, not served**. The review service gains the `SetTaskAuthorizer` wiring the plan and walkthrough services already had, closing what would otherwise be a cross-task write hole under enforced auth.

## Scope

- Fixes all 8 `resolveTaskID` call sites uniformly: plan create/get/update/delete, walkthrough show/get/delete, publish_review_findings.
- Tool descriptions now document the default-to-current / cross-task-within-reach behavior.
- No change needed to `sysprompt_sync_test.go` (it validates sysprompt tool-name references, not tool descriptions).

## Tests

- Resolution precedence unit tests: explicit wins / fallback to bound / neither → error.
- Handler-level regression: a session bound to task A reads and creates a plan for task B, and B (not A) is forwarded to the backend.
- Review authorizer allow/deny paths.

`make -C apps/backend lint` clean; all changed-relevant packages pass. The only failing backend tests are the pre-existing `TestServiceInitializeLocalRepository*` sandbox failures (fail on the base commit too; unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1984?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->