### PR TITLE
feat: refresh task surfaces on foreground and pull

### DIFF
--- a/apps/web/app/tasks/tasks-list-view.tsx
+++ b/apps/web/app/tasks/tasks-list-view.tsx
@@ -16,6 +16,7 @@ import { isTaskInFlight } from "@/lib/ui/state-icons";
 import { formatRelativeTime } from "@/lib/utils";
 import { TasksPagination } from "./tasks-pagination";
 import { TaskListRowPrimaryContent } from "./rich-task-list-row";
+import { PullToRefresh } from "@/components/mobile/pull-to-refresh";
 import {
   TASKS_LIST_GROUP_OPTIONS,
   TASKS_LIST_SORT_OPTIONS,
@@ -45,6 +46,7 @@ export type TasksListViewProps = {
   handleArchive: (taskId: string, opts?: { cascade?: boolean }) => Promise<void>;
   handleUnarchive: (taskId: string) => Promise<void>;
   handleDelete: (taskId: string, opts?: { cascade?: boolean }) => Promise<void>;
+  onRefresh?: () => void | Promise<void>;
 };
 
 export function TasksListView({
@@ -68,8 +70,9 @@ export function TasksListView({
   handleArchive,
   handleUnarchive,
   handleDelete,
+  onRefresh,
 }: TasksListViewProps) {
-  return (
+  const content = (
     <main className="flex-1 overflow-auto px-4 py-4 sm:px-6 sm:py-6">
       <div className="space-y-4">
         <TasksListControls
@@ -102,6 +105,7 @@ export function TasksListView({
       </div>
     </main>
   );
+  return onRefresh ? <PullToRefresh onRefresh={onRefresh}>{content}</PullToRefresh> : content;
 }
 
 function TasksListControls({

--- a/apps/web/app/tasks/tasks-page-client.tsx
+++ b/apps/web/app/tasks/tasks-page-client.tsx
@@ -60,6 +60,17 @@ type UseTaskOperationsParams = {
   setTotal: (total: number) => void;
 };
 
+const EMPTY_WORKFLOW_STEPS: KanbanStep[] = [];
+
+type KanbanStep = {
+  id: string;
+  title: string;
+  events?: {
+    on_enter?: Array<{ type: string; config?: Record<string, unknown> }>;
+    on_turn_complete?: Array<{ type: string; config?: Record<string, unknown> }>;
+  };
+};
+
 function useLatestWorkspaceRequest(activeWorkspaceId: string | null) {
   const latestFetchRef = useRef({ seq: 0, workspaceId: activeWorkspaceId });
 
@@ -505,7 +516,7 @@ export function TasksPageClient(props: TasksPageClientProps) {
   const { isMobile } = useResponsiveBreakpoint();
   const showTaskDetails = useAppStore((state) => state.userSettings.tasksListShowDetails ?? false);
   const activeSteps = useAppStore((state) =>
-    state.kanban.workflowId === s.activeWorkflowId ? state.kanban.steps : [],
+    state.kanban.workflowId === s.activeWorkflowId ? state.kanban.steps : EMPTY_WORKFLOW_STEPS,
   );
   useWorkflowSnapshot(s.activeWorkflowId);
   useWorkspacePRs(showTaskDetails ? s.activeWorkspaceId : null);
@@ -594,14 +605,7 @@ type MobileTasksCreateDialogProps = {
   onOpenChange: (open: boolean) => void;
   workspaceId: string;
   workflowId: string | null;
-  steps: Array<{
-    id: string;
-    title: string;
-    events?: {
-      on_enter?: Array<{ type: string; config?: Record<string, unknown> }>;
-      on_turn_complete?: Array<{ type: string; config?: Record<string, unknown> }>;
-    };
-  }>;
+  steps: KanbanStep[];
   onCreated: () => Promise<void>;
 };
 

--- a/apps/web/app/tasks/tasks-page-client.tsx
+++ b/apps/web/app/tasks/tasks-page-client.tsx
@@ -124,6 +124,8 @@ function useTaskOperations({
             description: errorDescription(err),
             variant: "error",
           });
+        } else {
+          console.error("[TasksPage] Silent foreground refresh failed:", err);
         }
       } finally {
         if (shouldCommit()) setIsLoading(false);
@@ -568,7 +570,7 @@ export function TasksPageClient(props: TasksPageClientProps) {
         handleArchive={s.handleArchive}
         handleUnarchive={s.handleUnarchive}
         handleDelete={s.handleDelete}
-        onRefresh={isMobile ? () => s.fetchTasks(true) : undefined}
+        onRefresh={isMobile ? () => s.fetchTasks() : undefined}
       />
       {isMobile && s.activeWorkspaceId && (
         <>

--- a/apps/web/app/tasks/tasks-page-client.tsx
+++ b/apps/web/app/tasks/tasks-page-client.tsx
@@ -11,7 +11,9 @@ import {
   updateUserSettings,
 } from "@/lib/api";
 import { KanbanHeader } from "@/components/kanban/kanban-header";
+import { MobileFab } from "@/components/kanban/mobile-fab";
 import { MobileSearchBar } from "@/components/kanban/mobile-search-bar";
+import { TaskCreateDialog } from "@/components/task-create-dialog";
 import type { Task, Workspace, Workflow, Repository } from "@/lib/types/http";
 import { useToast } from "@/components/toast-provider";
 import { useAppStore, useAppStoreApi } from "@/components/state-provider";
@@ -19,6 +21,8 @@ import { useKanbanDisplaySettings } from "@/hooks/use-kanban-display-settings";
 import { useDebounce } from "@/hooks/use-debounce";
 import { useResponsiveBreakpoint } from "@/hooks/use-responsive-breakpoint";
 import { useTaskListingView } from "@/hooks/use-task-listing-view";
+import { useForegroundRefresh } from "@/hooks/use-foreground-refresh";
+import { useWorkflowSnapshot } from "@/hooks/use-workflow-snapshot";
 import { useWorkspacePRs } from "@/hooks/domains/github/use-task-pr";
 import { linkToTask } from "@/lib/links";
 import { unarchiveToastPayload } from "@/lib/tasks/unarchive-feedback";
@@ -93,49 +97,54 @@ function useTaskOperations({
   const [isLoading, setIsLoading] = useState(false);
   const { beginRequest, isCurrentRequest } = useLatestWorkspaceRequest(activeWorkspaceId);
 
-  const fetchTasks = useCallback(async () => {
-    if (!activeWorkspaceId) return;
-    const requestSeq = beginRequest(activeWorkspaceId);
-    const shouldCommit = () => isCurrentRequest(requestSeq, activeWorkspaceId);
-    setIsLoading(true);
-    try {
-      const result = await listTasksByWorkspace(activeWorkspaceId, {
-        page: pagination.pageIndex + 1,
-        pageSize: pagination.pageSize,
-        query: debouncedQuery,
-        includeArchived: showArchived,
-        workflowId: activeWorkflowId,
-        repositoryId: selectedRepositoryId,
-        sort: tasksListSort,
-      });
-      if (!shouldCommit()) return;
-      setTasks(result.tasks);
-      setTotal(result.total);
-    } catch (err) {
-      if (!shouldCommit()) return;
-      toast({
-        title: "Failed to load tasks",
-        description: errorDescription(err),
-        variant: "error",
-      });
-    } finally {
-      if (shouldCommit()) setIsLoading(false);
-    }
-  }, [
-    activeWorkspaceId,
-    activeWorkflowId,
-    selectedRepositoryId,
-    pagination.pageIndex,
-    pagination.pageSize,
-    debouncedQuery,
-    showArchived,
-    tasksListSort,
-    beginRequest,
-    isCurrentRequest,
-    toast,
-    setTasks,
-    setTotal,
-  ]);
+  const fetchTasks = useCallback(
+    async (silent = false) => {
+      if (!activeWorkspaceId) return;
+      const requestSeq = beginRequest(activeWorkspaceId);
+      const shouldCommit = () => isCurrentRequest(requestSeq, activeWorkspaceId);
+      setIsLoading(true);
+      try {
+        const result = await listTasksByWorkspace(activeWorkspaceId, {
+          page: pagination.pageIndex + 1,
+          pageSize: pagination.pageSize,
+          query: debouncedQuery,
+          includeArchived: showArchived,
+          workflowId: activeWorkflowId,
+          repositoryId: selectedRepositoryId,
+          sort: tasksListSort,
+        });
+        if (!shouldCommit()) return;
+        setTasks(result.tasks);
+        setTotal(result.total);
+      } catch (err) {
+        if (!shouldCommit()) return;
+        if (!silent) {
+          toast({
+            title: "Failed to load tasks",
+            description: errorDescription(err),
+            variant: "error",
+          });
+        }
+      } finally {
+        if (shouldCommit()) setIsLoading(false);
+      }
+    },
+    [
+      activeWorkspaceId,
+      activeWorkflowId,
+      selectedRepositoryId,
+      pagination.pageIndex,
+      pagination.pageSize,
+      debouncedQuery,
+      showArchived,
+      tasksListSort,
+      beginRequest,
+      isCurrentRequest,
+      toast,
+      setTasks,
+      setTotal,
+    ],
+  );
 
   const mutations = useTaskMutations(fetchTasks);
   return { isLoading, fetchTasks, ...mutations };
@@ -376,7 +385,7 @@ function useTasksPageSetup(props: TasksPageClientProps) {
     pagination: viewState.pagination,
     router,
   });
-  return { ...viewState, ...ops, ...computed, activeWorkspaceId, debouncedQuery };
+  return { ...viewState, ...ops, ...computed, activeWorkspaceId, activeWorkflowId, debouncedQuery };
 }
 
 function useTasksListPreferenceSync({
@@ -487,12 +496,18 @@ function useTasksListPreferenceSync({
 
 export function TasksPageClient(props: TasksPageClientProps) {
   const s = useTasksPageSetup(props);
+  const [isCreateOpen, setIsCreateOpen] = useState(false);
   const { setView } = useTaskListingView();
   const setMobileSearchOpen = useAppStore((state) => state.setMobileKanbanSearchOpen);
   const isMobileSearchOpen = useAppStore((state) => state.mobileKanban.isSearchOpen);
   const { isMobile } = useResponsiveBreakpoint();
   const showTaskDetails = useAppStore((state) => state.userSettings.tasksListShowDetails ?? false);
+  const activeSteps = useAppStore((state) =>
+    state.kanban.workflowId === s.activeWorkflowId ? state.kanban.steps : [],
+  );
+  useWorkflowSnapshot(s.activeWorkflowId);
   useWorkspacePRs(showTaskDetails ? s.activeWorkspaceId : null);
+  useForegroundRefresh(() => s.fetchTasks(true), Boolean(s.activeWorkspaceId), s.activeWorkspaceId);
   const { handleSortChange, handleGroupChange } = useTasksListPreferenceSync({
     tasksListSort: s.tasksListSort,
     setTasksListSort: s.setTasksListSort,
@@ -553,7 +568,62 @@ export function TasksPageClient(props: TasksPageClientProps) {
         handleArchive={s.handleArchive}
         handleUnarchive={s.handleUnarchive}
         handleDelete={s.handleDelete}
+        onRefresh={isMobile ? () => s.fetchTasks(true) : undefined}
       />
+      {isMobile && s.activeWorkspaceId && (
+        <>
+          <MobileFab onClick={() => setIsCreateOpen(true)} />
+          <MobileTasksCreateDialog
+            open={isCreateOpen}
+            onOpenChange={setIsCreateOpen}
+            workspaceId={s.activeWorkspaceId}
+            workflowId={s.activeWorkflowId}
+            steps={activeSteps}
+            onCreated={() => s.fetchTasks(true)}
+          />
+        </>
+      )}
     </div>
+  );
+}
+
+type MobileTasksCreateDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  workspaceId: string;
+  workflowId: string | null;
+  steps: Array<{
+    id: string;
+    title: string;
+    events?: {
+      on_enter?: Array<{ type: string; config?: Record<string, unknown> }>;
+      on_turn_complete?: Array<{ type: string; config?: Record<string, unknown> }>;
+    };
+  }>;
+  onCreated: () => Promise<void>;
+};
+
+function MobileTasksCreateDialog({
+  open,
+  onOpenChange,
+  workspaceId,
+  workflowId,
+  steps,
+  onCreated,
+}: MobileTasksCreateDialogProps) {
+  return (
+    <TaskCreateDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      mode="create"
+      workspaceId={workspaceId}
+      workflowId={workflowId}
+      defaultStepId={steps[0]?.id ?? null}
+      steps={steps}
+      onSuccess={() => {
+        onOpenChange(false);
+        void onCreated();
+      }}
+    />
   );
 }

--- a/apps/web/components/kanban-board.tsx
+++ b/apps/web/components/kanban-board.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type ComponentProps } from "react";
 import { useRouter, useSearchParams } from "@/lib/routing/client-router";
 import { Task } from "./kanban-card";
 import { TaskCreateDialog } from "./task-create-dialog";
@@ -11,6 +11,7 @@ import { type MoveTaskError } from "@/hooks/use-drag-and-drop";
 import { SwimlaneContainer } from "./kanban/swimlane-container";
 import { KanbanHeader } from "./kanban/kanban-header";
 import { MobileFab } from "./kanban/mobile-fab";
+import { PullToRefresh } from "./mobile/pull-to-refresh";
 import { MobileSearchBar } from "./kanban/mobile-search-bar";
 import { TaskMultiSelectToolbar } from "./kanban/task-multi-select-toolbar";
 import { useKanbanData, useKanbanActions, useKanbanNavigation } from "@/hooks/domains/kanban";
@@ -304,7 +305,7 @@ function useKanbanBoardSetup(
     setWorkflows,
   } = useKanbanBoardStore();
 
-  useAllWorkflowSnapshots(workspaceState.activeId);
+  const { refresh } = useAllWorkflowSnapshots(workspaceState.activeId);
   useWorkspacePRs(workspaceState.activeId);
   useWorkspaceMRs(workspaceState.activeId);
 
@@ -382,6 +383,7 @@ function useKanbanBoardSetup(
     effectiveWorkflowId,
     effectiveSteps,
     setMobileWorkflowFocusId,
+    refresh,
   };
 }
 
@@ -435,7 +437,7 @@ export function KanbanBoard({ onPreviewTask, onOpenTask, onBeforeEdit }: KanbanB
         setMoveError={s.setMoveError}
         handleGoToTask={s.handleGoToTask}
       />
-      <SwimlaneContainer
+      <KanbanSwimlanes
         viewMode={s.kanbanViewMode || ""}
         workflowFilter={s.workflowsState.activeId}
         onPreviewTask={s.handleCardClick}
@@ -456,6 +458,8 @@ export function KanbanBoard({ onPreviewTask, onOpenTask, onBeforeEdit }: KanbanB
         onToggleMultiSelect={s.multiSelect.toggleMultiSelect}
         onWorkflowChange={s.handleWorkflowChange}
         onMobileWorkflowFocusChange={s.setMobileWorkflowFocusId}
+        isMobile={s.isMobile}
+        onRefresh={s.refresh}
       />
       <TaskMultiSelectToolbar
         selectedIds={s.multiSelect.selectedIds}
@@ -470,6 +474,16 @@ export function KanbanBoard({ onPreviewTask, onOpenTask, onBeforeEdit }: KanbanB
       {s.isMobile && <MobileFab onClick={s.handleCreate} />}
     </div>
   );
+}
+
+type KanbanSwimlanesProps = ComponentProps<typeof SwimlaneContainer> & {
+  isMobile: boolean;
+  onRefresh: () => Promise<void>;
+};
+
+function KanbanSwimlanes({ isMobile, onRefresh, ...props }: KanbanSwimlanesProps) {
+  const swimlanes = <SwimlaneContainer {...props} />;
+  return isMobile ? <PullToRefresh onRefresh={onRefresh}>{swimlanes}</PullToRefresh> : swimlanes;
 }
 
 type KanbanBoardDialogsProps = {

--- a/apps/web/components/mobile/pull-to-refresh.test.tsx
+++ b/apps/web/components/mobile/pull-to-refresh.test.tsx
@@ -1,0 +1,59 @@
+import { act, cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { PullToRefresh } from "./pull-to-refresh";
+
+function touch(clientX: number, clientY: number) {
+  return [{ clientX, clientY }];
+}
+
+describe("PullToRefresh", () => {
+  afterEach(cleanup);
+
+  it("refreshes after an eligible downward pull", async () => {
+    const onRefresh = vi.fn().mockResolvedValue(undefined);
+    const { getByTestId } = render(<PullToRefresh onRefresh={onRefresh}>Tasks</PullToRefresh>);
+    const root = getByTestId("pull-to-refresh");
+
+    fireEvent.touchStart(root, { touches: touch(20, 0) });
+    fireEvent.touchMove(root, { touches: touch(20, 140) });
+    expect(getByTestId("pull-to-refresh-indicator")).toBeTruthy();
+    fireEvent.touchEnd(root);
+
+    await waitFor(() => expect(onRefresh).toHaveBeenCalledTimes(1));
+  });
+
+  it("does not refresh cancelled, horizontal, or below-threshold gestures", () => {
+    const onRefresh = vi.fn();
+    const { getByTestId } = render(<PullToRefresh onRefresh={onRefresh}>Tasks</PullToRefresh>);
+    const root = getByTestId("pull-to-refresh");
+
+    fireEvent.touchStart(root, { touches: touch(20, 0) });
+    fireEvent.touchMove(root, { touches: touch(20, 40) });
+    fireEvent.touchEnd(root);
+    fireEvent.touchStart(root, { touches: touch(20, 0) });
+    fireEvent.touchMove(root, { touches: touch(140, 20) });
+    fireEvent.touchEnd(root);
+    fireEvent.touchStart(root, { touches: touch(20, 0) });
+    fireEvent.touchMove(root, { touches: touch(20, 140) });
+    fireEvent.touchCancel(root);
+
+    expect(onRefresh).not.toHaveBeenCalled();
+  });
+
+  it("ignores a second gesture while refreshing", async () => {
+    let resolveRefresh!: () => void;
+    const onRefresh = vi.fn(() => new Promise<void>((resolve) => (resolveRefresh = resolve)));
+    const { getByTestId } = render(<PullToRefresh onRefresh={onRefresh}>Tasks</PullToRefresh>);
+    const root = getByTestId("pull-to-refresh");
+    const pull = () => {
+      fireEvent.touchStart(root, { touches: touch(20, 0) });
+      fireEvent.touchMove(root, { touches: touch(20, 140) });
+      fireEvent.touchEnd(root);
+    };
+
+    pull();
+    pull();
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+    await act(async () => resolveRefresh());
+  });
+});

--- a/apps/web/components/mobile/pull-to-refresh.tsx
+++ b/apps/web/components/mobile/pull-to-refresh.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { useRef, useState, type ReactNode, type TouchEvent } from "react";
+import { IconRefresh } from "@tabler/icons-react";
+import {
+  PULL_TO_REFRESH_THRESHOLD,
+  pullDistance,
+  shouldRefreshAfterPull,
+} from "@/lib/mobile/pull-to-refresh";
+
+type PullState = { x: number; y: number; eligible: boolean } | null;
+
+function refreshLabel(refreshing: boolean, distance: number): string {
+  if (refreshing) return "Refreshing tasks";
+  if (distance >= PULL_TO_REFRESH_THRESHOLD) return "Release to refresh";
+  return "Pull to refresh";
+}
+
+function isAtVerticalScrollTop(target: EventTarget | null, root: HTMLDivElement | null): boolean {
+  let current = target instanceof HTMLElement ? target : null;
+  while (current) {
+    if (current.scrollHeight > current.clientHeight && current.scrollTop > 0) return false;
+    if (current === root) break;
+    current = current.parentElement;
+  }
+  return true;
+}
+
+export function PullToRefresh({
+  children,
+  onRefresh,
+}: {
+  children: ReactNode;
+  onRefresh: () => void | Promise<void>;
+}) {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const pullRef = useRef<PullState>(null);
+  const distanceRef = useRef(0);
+  const [distance, setDistance] = useState(0);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const onTouchStart = (event: TouchEvent<HTMLDivElement>) => {
+    if (refreshing || event.touches.length !== 1) return;
+    const touch = event.touches[0];
+    pullRef.current = {
+      x: touch.clientX,
+      y: touch.clientY,
+      eligible: isAtVerticalScrollTop(event.target, rootRef.current),
+    };
+  };
+
+  const onTouchMove = (event: TouchEvent<HTMLDivElement>) => {
+    const pull = pullRef.current;
+    if (!pull || !pull.eligible) return;
+    if (event.touches.length !== 1) {
+      pullRef.current = null;
+      distanceRef.current = 0;
+      setDistance(0);
+      return;
+    }
+    const touch = event.touches[0];
+    const dx = touch.clientX - pull.x;
+    const dy = touch.clientY - pull.y;
+    if (Math.abs(dx) > Math.abs(dy) || dy <= 0) {
+      pullRef.current = null;
+      distanceRef.current = 0;
+      setDistance(0);
+      return;
+    }
+    event.preventDefault();
+    const nextDistance = pullDistance(dy);
+    distanceRef.current = nextDistance;
+    setDistance(nextDistance);
+  };
+
+  const onTouchEnd = () => {
+    const shouldRefresh = shouldRefreshAfterPull(distanceRef.current);
+    pullRef.current = null;
+    distanceRef.current = 0;
+    setDistance(0);
+    if (!shouldRefresh || refreshing) return;
+    setRefreshing(true);
+    Promise.resolve(onRefresh()).finally(() => setRefreshing(false));
+  };
+
+  const visible = refreshing || distance > 0;
+  return (
+    <div
+      ref={rootRef}
+      className="relative flex min-h-0 flex-1 flex-col"
+      onTouchStartCapture={onTouchStart}
+      onTouchMoveCapture={onTouchMove}
+      onTouchEndCapture={onTouchEnd}
+      onTouchCancelCapture={onTouchEnd}
+      data-testid="pull-to-refresh"
+    >
+      {visible && (
+        <div
+          className="pointer-events-none absolute inset-x-0 top-1 z-20 flex justify-center text-muted-foreground"
+          data-testid="pull-to-refresh-indicator"
+          aria-live="polite"
+        >
+          <IconRefresh className={refreshing ? "size-5 animate-spin" : "size-5"} />
+          <span className="sr-only">{refreshLabel(refreshing, distance)}</span>
+        </div>
+      )}
+      {children}
+    </div>
+  );
+}

--- a/apps/web/components/mobile/pull-to-refresh.tsx
+++ b/apps/web/components/mobile/pull-to-refresh.tsx
@@ -4,6 +4,7 @@ import { useRef, useState, type ReactNode, type TouchEvent } from "react";
 import { IconRefresh } from "@tabler/icons-react";
 import {
   PULL_TO_REFRESH_THRESHOLD,
+  isAtVerticalScrollTop,
   pullDistance,
   shouldRefreshAfterPull,
 } from "@/lib/mobile/pull-to-refresh";
@@ -14,16 +15,6 @@ function refreshLabel(refreshing: boolean, distance: number): string {
   if (refreshing) return "Refreshing tasks";
   if (distance >= PULL_TO_REFRESH_THRESHOLD) return "Release to refresh";
   return "Pull to refresh";
-}
-
-function isAtVerticalScrollTop(target: EventTarget | null, root: HTMLDivElement | null): boolean {
-  let current = target instanceof HTMLElement ? target : null;
-  while (current) {
-    if (current.scrollHeight > current.clientHeight && current.scrollTop > 0) return false;
-    if (current === root) break;
-    current = current.parentElement;
-  }
-  return true;
 }
 
 export function PullToRefresh({
@@ -91,7 +82,11 @@ export function PullToRefresh({
       onTouchStartCapture={onTouchStart}
       onTouchMoveCapture={onTouchMove}
       onTouchEndCapture={onTouchEnd}
-      onTouchCancelCapture={onTouchEnd}
+      onTouchCancelCapture={() => {
+        pullRef.current = null;
+        distanceRef.current = 0;
+        setDistance(0);
+      }}
       data-testid="pull-to-refresh"
     >
       {visible && (

--- a/apps/web/components/task/task-page-content.tsx
+++ b/apps/web/components/task/task-page-content.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { IconAlertTriangle } from "@tabler/icons-react";
 import type { Repository, RepositoryScript, Task } from "@/lib/types/http";
 import type { Terminal } from "@/hooks/domains/session/use-terminals";
@@ -16,6 +16,7 @@ import { useExternalVcsFileLinkHydration } from "@/hooks/domains/workspace/use-e
 import { fetchTask } from "@/lib/api";
 import { useTasks } from "@/hooks/use-tasks";
 import { useResponsiveBreakpoint } from "@/hooks/use-responsive-breakpoint";
+import { useForegroundRefresh } from "@/hooks/use-foreground-refresh";
 import type { Layout } from "react-resizable-panels";
 import {
   deriveIsAgentWorking,
@@ -169,6 +170,7 @@ function TaskLoadErrorState() {
 function useTaskDetails(activeTaskId: string | null, initialTask: Task | null) {
   const [taskDetails, setTaskDetails] = useState<Task | null>(initialTask);
   const [taskLoadError, setTaskLoadError] = useState<unknown | null>(null);
+  const activeTaskIdRef = useRef(activeTaskId);
   const kanbanTask = useAppStore((state) =>
     activeTaskId
       ? (state.kanban.tasks.find(
@@ -189,34 +191,34 @@ function useTaskDetails(activeTaskId: string | null, initialTask: Task | null) {
   useTasks(task?.workflow_id ?? null);
 
   useEffect(() => {
+    activeTaskIdRef.current = activeTaskId;
+  }, [activeTaskId]);
+
+  const loadTaskDetails = useCallback(async () => {
+    if (!activeTaskId) return;
+    const requestedTaskId = activeTaskId;
+    try {
+      const response = await fetchTask(requestedTaskId, { cache: "no-store" });
+      if (activeTaskIdRef.current !== requestedTaskId) return;
+      setTaskDetails(response);
+      setTaskLoadError(null);
+    } catch (error) {
+      if (activeTaskIdRef.current !== requestedTaskId) return;
+      console.error("[TaskPageContent] Failed to load task details:", error);
+      setTaskLoadError(error);
+    }
+  }, [activeTaskId]);
+
+  useEffect(() => {
     if (!activeTaskId || taskDetails?.id === activeTaskId) {
       setTaskLoadError(null);
       return;
     }
-    let cancelled = false;
     setTaskLoadError(null);
-    fetchTask(activeTaskId, { cache: "no-store" })
-      .then((response) => {
-        if (cancelled) return;
-        setTaskDetails(response);
-        setTaskLoadError(null);
-      })
-      .catch((error) => {
-        if (cancelled) return;
-        console.error("[TaskPageContent] Failed to load task details:", error);
-        setTaskLoadError(error);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [
-    activeTaskId,
-    taskDetails?.id,
-    taskDetails?.workspace_id,
-    taskDetails?.workflow_id,
-    kanbanTask,
-    setTaskDetails,
-  ]);
+    void loadTaskDetails();
+  }, [activeTaskId, taskDetails?.id, loadTaskDetails]);
+
+  useForegroundRefresh(loadTaskDetails, Boolean(activeTaskId), activeTaskId);
 
   const onTaskUnarchived = useCallback((taskId: string) => {
     setTaskDetails((current) =>

--- a/apps/web/hooks/domains/kanban/use-all-workflow-snapshots.test.ts
+++ b/apps/web/hooks/domains/kanban/use-all-workflow-snapshots.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 
 const mockClearKanbanMulti = vi.fn();
 const mockSetKanbanMultiLoading = vi.fn();
@@ -88,6 +88,23 @@ describe("useAllWorkflowSnapshots — workspace scoping", () => {
     expect(mockFetchWorkflowSnapshot).not.toHaveBeenCalled();
     expect(mockSetKanbanMultiLoading).not.toHaveBeenCalledWith(true);
     expect(mockClearKanbanMulti).not.toHaveBeenCalled();
+  });
+
+  it("refetches boot-hydrated snapshots when the Kandev window regains focus", async () => {
+    mockState.kanbanMulti.snapshots = {
+      "wf-A": { workflowId: "wf-A", workflowName: "A", steps: [], tasks: [] },
+    };
+
+    renderHook(() => useAllWorkflowSnapshots("ws-A"));
+    expect(mockFetchWorkflowSnapshot).not.toHaveBeenCalled();
+
+    act(() => window.dispatchEvent(new Event("focus")));
+
+    await waitFor(() =>
+      expect(mockFetchWorkflowSnapshot).toHaveBeenCalledWith("wf-A", {
+        cache: "no-store",
+      }),
+    );
   });
 
   it("clears snapshots when workspaceId changes", async () => {

--- a/apps/web/hooks/domains/kanban/use-all-workflow-snapshots.ts
+++ b/apps/web/hooks/domains/kanban/use-all-workflow-snapshots.ts
@@ -79,12 +79,24 @@ async function fetchAndWriteSnapshot(
         stepIds.has(task.workflowStepId),
     );
 
-    store.getState().setWorkflowSnapshot(wf.id, {
+    const workflowSnapshot = {
       workflowId: wf.id,
       workflowName: wf.name,
       steps,
       tasks: [...tasks, ...inFlightCreatedTasks],
-    });
+    };
+    store.getState().setWorkflowSnapshot(wf.id, workflowSnapshot);
+    const activeKanban = store.getState().kanban;
+    if (activeKanban?.workflowId === wf.id) {
+      store.getState().hydrate({
+        kanban: {
+          ...activeKanban,
+          isLoading: false,
+          steps,
+          tasks: workflowSnapshot.tasks,
+        },
+      });
+    }
   } catch (err) {
     console.error(
       `[useAllWorkflowSnapshots] Failed to fetch snapshot for workflow "${wf.name}" (${wf.id}):`,
@@ -105,16 +117,19 @@ export function useAllWorkflowSnapshots(workspaceId: string | null) {
   const lastFetchedRef = useRef<string>("");
   const lastWorkspaceIdRef = useRef<string | null>(null);
   const fetchGenRef = useRef(0);
-  const refreshResolversRef = useRef<Array<() => void>>([]);
+  const refreshResolversRef = useRef<Array<{ generation: number; resolve: () => void }>>([]);
   const [refreshNonce, setRefreshNonce] = useState(0);
-  const resolveRefreshes = useCallback(() => {
-    const resolvers = refreshResolversRef.current.splice(0);
-    resolvers.forEach((resolve) => resolve());
+  const resolveRefreshes = useCallback((generation: number) => {
+    const ready = refreshResolversRef.current.filter((entry) => entry.generation === generation);
+    refreshResolversRef.current = refreshResolversRef.current.filter(
+      (entry) => entry.generation !== generation,
+    );
+    ready.forEach(({ resolve }) => resolve());
   }, []);
   const refresh = useCallback(
     () =>
       new Promise<void>((resolve) => {
-        refreshResolversRef.current.push(resolve);
+        refreshResolversRef.current.push({ generation: fetchGenRef.current, resolve });
         setRefreshNonce((current) => current + 1);
       }),
     [],
@@ -126,6 +141,7 @@ export function useAllWorkflowSnapshots(workspaceId: string | null) {
     // Skip clear on initial mount to preserve SSR-hydrated snapshots.
     if (lastWorkspaceIdRef.current !== workspaceId) {
       if (lastWorkspaceIdRef.current !== null) {
+        resolveRefreshes(fetchGenRef.current);
         store.getState().clearKanbanMulti();
         lastFetchedRef.current = "";
         fetchGenRef.current += 1;
@@ -134,13 +150,13 @@ export function useAllWorkflowSnapshots(workspaceId: string | null) {
     }
 
     if (!workspaceId) {
-      resolveRefreshes();
+      resolveRefreshes(fetchGenRef.current);
       return;
     }
 
     const workspaceWorkflows = workflows.filter((w) => w.workspaceId === workspaceId);
     if (workspaceWorkflows.length === 0) {
-      resolveRefreshes();
+      resolveRefreshes(fetchGenRef.current);
       return;
     }
 
@@ -155,7 +171,7 @@ export function useAllWorkflowSnapshots(workspaceId: string | null) {
       ":" +
       refreshNonce;
     if (lastFetchedRef.current === key) {
-      resolveRefreshes();
+      resolveRefreshes(fetchGenRef.current);
       return;
     }
     if (
@@ -165,7 +181,7 @@ export function useAllWorkflowSnapshots(workspaceId: string | null) {
       )
     ) {
       lastFetchedRef.current = key;
-      resolveRefreshes();
+      resolveRefreshes(fetchGenRef.current);
       return;
     }
     lastFetchedRef.current = key;
@@ -187,7 +203,7 @@ export function useAllWorkflowSnapshots(workspaceId: string | null) {
         return;
       }
       store.getState().setKanbanMultiLoading(false);
-      resolveRefreshes();
+      resolveRefreshes(myGen);
     });
   }, [workspaceId, workflows, connectionStatus, refreshNonce, resolveRefreshes, store]);
 

--- a/apps/web/hooks/domains/kanban/use-all-workflow-snapshots.ts
+++ b/apps/web/hooks/domains/kanban/use-all-workflow-snapshots.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, type MutableRefObject } from "react";
+import { useCallback, useEffect, useRef, useState, type MutableRefObject } from "react";
 import { fetchWorkflowSnapshot } from "@/lib/api";
 import { useAppStore, useAppStoreApi } from "@/components/state-provider";
 import { toKanbanTask } from "@/lib/kanban/map-task";
@@ -7,6 +7,7 @@ import type { Task } from "@/lib/types/http";
 import type { StoreApi } from "zustand";
 import type { AppState } from "@/lib/state/store";
 import { isCurrentWorkspaceContext } from "@/lib/state/workspace-context";
+import { useForegroundRefresh } from "@/hooks/use-foreground-refresh";
 
 type KanbanTask = KanbanState["tasks"][number];
 type Workflow = { id: string; name: string };
@@ -104,6 +105,22 @@ export function useAllWorkflowSnapshots(workspaceId: string | null) {
   const lastFetchedRef = useRef<string>("");
   const lastWorkspaceIdRef = useRef<string | null>(null);
   const fetchGenRef = useRef(0);
+  const refreshResolversRef = useRef<Array<() => void>>([]);
+  const [refreshNonce, setRefreshNonce] = useState(0);
+  const resolveRefreshes = useCallback(() => {
+    const resolvers = refreshResolversRef.current.splice(0);
+    resolvers.forEach((resolve) => resolve());
+  }, []);
+  const refresh = useCallback(
+    () =>
+      new Promise<void>((resolve) => {
+        refreshResolversRef.current.push(resolve);
+        setRefreshNonce((current) => current + 1);
+      }),
+    [],
+  );
+
+  useForegroundRefresh(refresh, Boolean(workspaceId), workspaceId);
 
   useEffect(() => {
     // Skip clear on initial mount to preserve SSR-hydrated snapshots.
@@ -117,11 +134,13 @@ export function useAllWorkflowSnapshots(workspaceId: string | null) {
     }
 
     if (!workspaceId) {
+      resolveRefreshes();
       return;
     }
 
     const workspaceWorkflows = workflows.filter((w) => w.workspaceId === workspaceId);
     if (workspaceWorkflows.length === 0) {
+      resolveRefreshes();
       return;
     }
 
@@ -132,8 +151,11 @@ export function useAllWorkflowSnapshots(workspaceId: string | null) {
         .sort()
         .join(",") +
       ":" +
-      connectionStatus;
+      connectionStatus +
+      ":" +
+      refreshNonce;
     if (lastFetchedRef.current === key) {
+      resolveRefreshes();
       return;
     }
     if (
@@ -143,6 +165,7 @@ export function useAllWorkflowSnapshots(workspaceId: string | null) {
       )
     ) {
       lastFetchedRef.current = key;
+      resolveRefreshes();
       return;
     }
     lastFetchedRef.current = key;
@@ -164,6 +187,9 @@ export function useAllWorkflowSnapshots(workspaceId: string | null) {
         return;
       }
       store.getState().setKanbanMultiLoading(false);
+      resolveRefreshes();
     });
-  }, [workspaceId, workflows, connectionStatus, store]);
+  }, [workspaceId, workflows, connectionStatus, refreshNonce, resolveRefreshes, store]);
+
+  return { refresh };
 }

--- a/apps/web/hooks/domains/session/use-queue.test.ts
+++ b/apps/web/hooks/domains/session/use-queue.test.ts
@@ -140,6 +140,16 @@ describe("useQueue", () => {
     });
   });
 
+  it("refetches a stale queue snapshot when the Kandev window regains focus", async () => {
+    renderHook(() => useQueue(SESSION_ID));
+    await waitFor(() => expect(queueApiMock.getQueueStatus).toHaveBeenCalledTimes(1));
+    queueApiMock.getQueueStatus.mockClear();
+
+    window.dispatchEvent(new Event("focus"));
+
+    await waitFor(() => expect(queueApiMock.getQueueStatus).toHaveBeenCalledWith(SESSION_ID));
+  });
+
   it("does not refetch on foreground visibility while disconnected", async () => {
     mockState.connection.status = "disconnected";
     renderHook(() => useQueue(SESSION_ID));

--- a/apps/web/hooks/domains/session/use-queue.ts
+++ b/apps/web/hooks/domains/session/use-queue.ts
@@ -218,7 +218,7 @@ export function useQueue(sessionId: string | null) {
     () => {
       if (!sessionId) return;
       if (connectionStatus !== "connected") return;
-      void refetch(sessionId).catch((err) => {
+      return refetch(sessionId).catch((err) => {
         console.error("Failed to fetch queue status after foreground refresh:", err);
       });
     },

--- a/apps/web/hooks/domains/session/use-queue.ts
+++ b/apps/web/hooks/domains/session/use-queue.ts
@@ -1,5 +1,6 @@
 import { useEffect, useCallback } from "react";
 import { useAppStore } from "@/components/state-provider";
+import { useForegroundRefresh } from "@/hooks/use-foreground-refresh";
 import {
   queueMessage,
   clearQueue,
@@ -213,18 +214,17 @@ export function useQueue(sessionId: string | null) {
     });
   }, [sessionId, connectionStatus, refetch]);
 
-  useEffect(() => {
-    if (!sessionId) return;
-    const refetchOnVisible = () => {
-      if (document.visibilityState !== "visible") return;
+  useForegroundRefresh(
+    () => {
+      if (!sessionId) return;
       if (connectionStatus !== "connected") return;
       void refetch(sessionId).catch((err) => {
-        console.error("Failed to fetch queue status after visibility change:", err);
+        console.error("Failed to fetch queue status after foreground refresh:", err);
       });
-    };
-    document.addEventListener("visibilitychange", refetchOnVisible);
-    return () => document.removeEventListener("visibilitychange", refetchOnVisible);
-  }, [sessionId, connectionStatus, refetch]);
+    },
+    Boolean(sessionId),
+    sessionId,
+  );
 
   const refetchBound = useCallback(
     () => (sessionId ? refetch(sessionId) : Promise.resolve()),

--- a/apps/web/hooks/domains/session/use-session-messages.ts
+++ b/apps/web/hooks/domains/session/use-session-messages.ts
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState, type MutableRefObject } from "react";
 import { getWebSocketClient } from "@/lib/ws/connection";
+import { useForegroundRefresh } from "@/hooks/use-foreground-refresh";
 import { useAppStore, useAppStoreApi } from "@/components/state-provider";
 import type { TaskSessionState, Message } from "@/lib/types/http";
 import { listTaskSessionMessages } from "@/lib/api";
@@ -382,13 +383,9 @@ export function useVisibilityBackfill(
   taskSessionId: string | null,
   store: ReturnType<typeof useAppStoreApi>,
 ) {
-  useEffect(() => {
-    if (!taskSessionId) {
-      debug("visibilityBackfill: skipped attaching (no sessionId)");
-      return;
-    }
-    debug("visibilityBackfill: attached", { sessionId: taskSessionId });
-    const onVisible = () => {
+  useForegroundRefresh(
+    () => {
+      if (!taskSessionId) return;
       const visibilityState = document.visibilityState;
       const state = store.getState();
       const existingCount = state.messages.bySession[taskSessionId]?.length ?? 0;
@@ -401,7 +398,6 @@ export function useVisibilityBackfill(
         existingCount,
         newestBefore,
       });
-      if (visibilityState !== "visible") return;
       fetchAndStoreMessages(taskSessionId, store)
         .then(() => {
           const afterCount = store.getState().messages.bySession[taskSessionId]?.length ?? 0;
@@ -417,13 +413,10 @@ export function useVisibilityBackfill(
         .catch((err) => {
           debug("visibilityBackfill: refetch failed", { sessionId: taskSessionId, err });
         });
-    };
-    document.addEventListener("visibilitychange", onVisible);
-    return () => {
-      document.removeEventListener("visibilitychange", onVisible);
-      debug("visibilityBackfill: detached", { sessionId: taskSessionId });
-    };
-  }, [taskSessionId, store]);
+    },
+    Boolean(taskSessionId),
+    taskSessionId,
+  );
 }
 
 function useSessionSubscription(

--- a/apps/web/hooks/domains/session/use-visibility-backfill.test.ts
+++ b/apps/web/hooks/domains/session/use-visibility-backfill.test.ts
@@ -3,6 +3,8 @@ import { cleanup, renderHook } from "@testing-library/react";
 
 const mockRequest = vi.fn();
 const mockSetMessages = vi.fn();
+const SESSION_ID = "sess-1";
+const MESSAGE_LIST = "message.list";
 
 vi.mock("@/lib/ws/connection", () => ({
   getWebSocketClient: () => ({ request: mockRequest }),
@@ -41,18 +43,30 @@ describe("useVisibilityBackfill", () => {
   });
 
   it("fetches when the tab becomes visible", () => {
-    renderHook(() => useVisibilityBackfill("sess-1", store as never));
+    renderHook(() => useVisibilityBackfill(SESSION_ID, store as never));
     setVisibility("visible");
     expect(mockRequest).toHaveBeenCalledTimes(1);
     expect(mockRequest).toHaveBeenCalledWith(
-      "message.list",
-      expect.objectContaining({ session_id: "sess-1" }),
+      MESSAGE_LIST,
+      expect.objectContaining({ session_id: SESSION_ID }),
+      expect.any(Number),
+    );
+  });
+
+  it("fetches when the Kandev window regains focus", () => {
+    renderHook(() => useVisibilityBackfill(SESSION_ID, store as never));
+
+    window.dispatchEvent(new Event("focus"));
+
+    expect(mockRequest).toHaveBeenCalledWith(
+      MESSAGE_LIST,
+      expect.objectContaining({ session_id: SESSION_ID }),
       expect.any(Number),
     );
   });
 
   it("does not fetch when the tab becomes hidden", () => {
-    renderHook(() => useVisibilityBackfill("sess-1", store as never));
+    renderHook(() => useVisibilityBackfill(SESSION_ID, store as never));
     setVisibility("hidden");
     expect(mockRequest).not.toHaveBeenCalled();
   });
@@ -64,7 +78,7 @@ describe("useVisibilityBackfill", () => {
   });
 
   it("removes the listener on unmount", () => {
-    const { unmount } = renderHook(() => useVisibilityBackfill("sess-1", store as never));
+    const { unmount } = renderHook(() => useVisibilityBackfill(SESSION_ID, store as never));
     unmount();
     setVisibility("visible");
     expect(mockRequest).not.toHaveBeenCalled();
@@ -73,19 +87,19 @@ describe("useVisibilityBackfill", () => {
   it("re-registers when sessionId changes", () => {
     const { rerender } = renderHook(
       ({ id }: { id: string | null }) => useVisibilityBackfill(id, store as never),
-      { initialProps: { id: "sess-1" } },
+      { initialProps: { id: SESSION_ID } },
     );
     setVisibility("visible");
     expect(mockRequest).toHaveBeenLastCalledWith(
-      "message.list",
-      expect.objectContaining({ session_id: "sess-1" }),
+      MESSAGE_LIST,
+      expect.objectContaining({ session_id: SESSION_ID }),
       expect.any(Number),
     );
 
     rerender({ id: "sess-2" });
     setVisibility("visible");
     expect(mockRequest).toHaveBeenLastCalledWith(
-      "message.list",
+      MESSAGE_LIST,
       expect.objectContaining({ session_id: "sess-2" }),
       expect.any(Number),
     );

--- a/apps/web/hooks/use-foreground-refresh.test.ts
+++ b/apps/web/hooks/use-foreground-refresh.test.ts
@@ -1,0 +1,61 @@
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useForegroundRefresh } from "./use-foreground-refresh";
+
+function setVisibility(value: DocumentVisibilityState) {
+  Object.defineProperty(document, "visibilityState", { configurable: true, value });
+}
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((innerResolve) => {
+    resolve = innerResolve;
+  });
+  return { promise, resolve };
+}
+
+describe("useForegroundRefresh", () => {
+  beforeEach(() => {
+    setVisibility("visible");
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("refreshes when the Kandev window regains focus", () => {
+    const refresh = vi.fn();
+    renderHook(() => useForegroundRefresh(refresh));
+
+    act(() => window.dispatchEvent(new Event("focus")));
+
+    expect(refresh).toHaveBeenCalledOnce();
+  });
+
+  it("does not refresh while the document is hidden", () => {
+    const refresh = vi.fn();
+    renderHook(() => useForegroundRefresh(refresh));
+    setVisibility("hidden");
+
+    act(() => window.dispatchEvent(new Event("focus")));
+
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it("coalesces a foreground event burst while the first request is in flight", () => {
+    const request = deferred();
+    const refresh = vi.fn(() => request.promise);
+    renderHook(() => useForegroundRefresh(refresh));
+
+    act(() => {
+      window.dispatchEvent(new Event("focus"));
+      document.dispatchEvent(new Event("visibilitychange"));
+      window.dispatchEvent(new Event("pageshow"));
+      window.dispatchEvent(new Event("online"));
+    });
+
+    expect(refresh).toHaveBeenCalledOnce();
+    act(() => request.resolve());
+  });
+});

--- a/apps/web/hooks/use-foreground-refresh.ts
+++ b/apps/web/hooks/use-foreground-refresh.ts
@@ -1,0 +1,67 @@
+import { useCallback, useEffect, useRef } from "react";
+
+const FOREGROUND_EVENT_COALESCE_MS = 250;
+
+type Refresh = () => void | Promise<void>;
+
+/**
+ * Runs an authoritative refresh when a browser surface returns to the
+ * foreground. Browsers commonly emit focus, visibilitychange, pageshow, and
+ * online together; one return should cause at most one request per consumer.
+ */
+export function useForegroundRefresh(refresh: Refresh, enabled = true, scopeKey?: unknown) {
+  const refreshRef = useRef(refresh);
+  const inFlightRef = useRef<Promise<void> | null>(null);
+  const lastRunAtRef = useRef(-Infinity);
+
+  useEffect(() => {
+    refreshRef.current = refresh;
+  }, [refresh]);
+
+  useEffect(() => {
+    lastRunAtRef.current = -Infinity;
+    inFlightRef.current = null;
+  }, [scopeKey]);
+
+  const run = useCallback(() => {
+    if (!enabled || document.visibilityState !== "visible") return;
+    if (inFlightRef.current) return;
+
+    const now = Date.now();
+    if (now - lastRunAtRef.current < FOREGROUND_EVENT_COALESCE_MS) return;
+    lastRunAtRef.current = now;
+
+    let request: Promise<void>;
+    try {
+      request = Promise.resolve(refreshRef.current());
+    } catch {
+      request = Promise.resolve();
+    }
+    const pending = request
+      .catch(() => undefined)
+      .finally(() => {
+        if (inFlightRef.current === pending) inFlightRef.current = null;
+      });
+    inFlightRef.current = pending;
+  }, [enabled]);
+
+  useEffect(() => {
+    if (!enabled) return;
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "visible") run();
+    };
+
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    window.addEventListener("focus", run);
+    window.addEventListener("pageshow", run);
+    window.addEventListener("online", run);
+    return () => {
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+      window.removeEventListener("focus", run);
+      window.removeEventListener("pageshow", run);
+      window.removeEventListener("online", run);
+    };
+  }, [enabled, run]);
+
+  return run;
+}

--- a/apps/web/hooks/use-task-sessions.test.ts
+++ b/apps/web/hooks/use-task-sessions.test.ts
@@ -220,6 +220,40 @@ describe("useTaskSessions refreshes", () => {
   });
 });
 
+describe("useTaskSessions foreground refresh", () => {
+  beforeEach(() => {
+    resetMockState();
+    setDocumentVisibility("visible");
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  it("refetches a loaded session list when the Kandev window regains focus", async () => {
+    mockState.taskSessionsByTask.itemsByTaskId[TASK_ID] = [session("old", "RUNNING")];
+    mockState.taskSessionsByTask.loadedByTaskId[TASK_ID] = true;
+    apiMock.listTaskSessions.mockResolvedValueOnce({ sessions: [session("old", "COMPLETED")] });
+
+    renderHook(() => useTaskSessions(TASK_ID));
+    await act(async () => {});
+    apiMock.listTaskSessions.mockClear();
+
+    window.dispatchEvent(new Event("focus"));
+
+    await waitFor(() =>
+      expect(apiMock.listTaskSessions).toHaveBeenCalledWith(TASK_ID, {
+        cache: "no-store",
+      }),
+    );
+    expect(mockState.setTaskSessionsForTask).toHaveBeenCalledWith(TASK_ID, [
+      session("old", "COMPLETED"),
+    ]);
+  });
+});
+
 describe("useTaskSessions queued refreshes", () => {
   beforeEach(() => {
     resetMockState();

--- a/apps/web/hooks/use-task-sessions.ts
+++ b/apps/web/hooks/use-task-sessions.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef } from "react";
 import { useAppStore } from "@/components/state-provider";
 import { listTaskSessions } from "@/lib/api";
 import type { TaskSession } from "@/lib/types/http";
+import { useForegroundRefresh } from "@/hooks/use-foreground-refresh";
 
 const EMPTY_SESSIONS: TaskSession[] = [];
 
@@ -85,19 +86,18 @@ export function useTaskSessions(taskId: string | null) {
     void loadSessions(true);
   }, [connectionStatus, isLoaded, isLoading, loadSessions, taskId]);
 
-  useEffect(() => {
-    if (!taskId) return;
-    const refetchOnVisible = () => {
-      if (document.visibilityState !== "visible") return;
+  useForegroundRefresh(
+    () => {
+      if (!taskId) return;
       if (!isLoaded) {
         if (isLoading) void loadSessions(true);
         return;
       }
       void loadSessions(true);
-    };
-    document.addEventListener("visibilitychange", refetchOnVisible);
-    return () => document.removeEventListener("visibilitychange", refetchOnVisible);
-  }, [isLoaded, isLoading, loadSessions, taskId]);
+    },
+    Boolean(taskId),
+    taskId,
+  );
 
   return { sessions, isLoading, isLoaded, loadSessions };
 }

--- a/apps/web/lib/mobile/pull-to-refresh.test.ts
+++ b/apps/web/lib/mobile/pull-to-refresh.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { PULL_TO_REFRESH_THRESHOLD, pullDistance, shouldRefreshAfterPull } from "./pull-to-refresh";
+import {
+  isAtVerticalScrollTop,
+  PULL_TO_REFRESH_THRESHOLD,
+  pullDistance,
+  shouldRefreshAfterPull,
+} from "./pull-to-refresh";
 
 describe("pull-to-refresh gesture", () => {
   it("dampens pull distance and caps it at the refresh threshold", () => {
@@ -11,5 +16,21 @@ describe("pull-to-refresh gesture", () => {
   it("refreshes only after the threshold is reached", () => {
     expect(shouldRefreshAfterPull(PULL_TO_REFRESH_THRESHOLD - 1)).toBe(false);
     expect(shouldRefreshAfterPull(PULL_TO_REFRESH_THRESHOLD)).toBe(true);
+  });
+
+  it("recognizes the touched scroll owner and nested ancestors", () => {
+    const root = document.createElement("div");
+    const scrollOwner = document.createElement("div");
+    const target = document.createElement("button");
+    root.append(scrollOwner);
+    scrollOwner.append(target);
+    Object.defineProperties(scrollOwner, {
+      clientHeight: { configurable: true, value: 100 },
+      scrollHeight: { configurable: true, value: 200 },
+      scrollTop: { configurable: true, value: 0 },
+    });
+    expect(isAtVerticalScrollTop(target, root)).toBe(true);
+    Object.defineProperty(scrollOwner, "scrollTop", { configurable: true, value: 10 });
+    expect(isAtVerticalScrollTop(target, root)).toBe(false);
   });
 });

--- a/apps/web/lib/mobile/pull-to-refresh.test.ts
+++ b/apps/web/lib/mobile/pull-to-refresh.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { PULL_TO_REFRESH_THRESHOLD, pullDistance, shouldRefreshAfterPull } from "./pull-to-refresh";
+
+describe("pull-to-refresh gesture", () => {
+  it("dampens pull distance and caps it at the refresh threshold", () => {
+    expect(pullDistance(-20)).toBe(0);
+    expect(pullDistance(80)).toBe(44);
+    expect(pullDistance(500)).toBe(PULL_TO_REFRESH_THRESHOLD);
+  });
+
+  it("refreshes only after the threshold is reached", () => {
+    expect(shouldRefreshAfterPull(PULL_TO_REFRESH_THRESHOLD - 1)).toBe(false);
+    expect(shouldRefreshAfterPull(PULL_TO_REFRESH_THRESHOLD)).toBe(true);
+  });
+});

--- a/apps/web/lib/mobile/pull-to-refresh.ts
+++ b/apps/web/lib/mobile/pull-to-refresh.ts
@@ -1,5 +1,18 @@
 export const PULL_TO_REFRESH_THRESHOLD = 72;
 
+export function isAtVerticalScrollTop(
+  target: EventTarget | null,
+  root: HTMLElement | null,
+): boolean {
+  let current = target instanceof HTMLElement ? target : null;
+  while (current) {
+    if (current.scrollHeight > current.clientHeight && current.scrollTop > 0) return false;
+    if (current === root) break;
+    current = current.parentElement;
+  }
+  return true;
+}
+
 export function pullDistance(verticalDistance: number): number {
   return Math.min(Math.max(verticalDistance, 0) * 0.55, PULL_TO_REFRESH_THRESHOLD);
 }

--- a/apps/web/lib/mobile/pull-to-refresh.ts
+++ b/apps/web/lib/mobile/pull-to-refresh.ts
@@ -1,0 +1,9 @@
+export const PULL_TO_REFRESH_THRESHOLD = 72;
+
+export function pullDistance(verticalDistance: number): number {
+  return Math.min(Math.max(verticalDistance, 0) * 0.55, PULL_TO_REFRESH_THRESHOLD);
+}
+
+export function shouldRefreshAfterPull(distance: number): boolean {
+  return distance >= PULL_TO_REFRESH_THRESHOLD;
+}

--- a/docs/plans/task-surface-refresh/plan.md
+++ b/docs/plans/task-surface-refresh/plan.md
@@ -1,0 +1,186 @@
+---
+spec: docs/specs/ui/task-surface-refresh.md
+created: 2026-07-27
+status: building
+---
+
+# Implementation Plan: Task Surface Foreground Refresh and Mobile Create Action
+
+## Overview
+
+Introduce one frontend foreground lifecycle primitive, migrate task-detail
+backfills to it, and make Kanban and List expose authoritative refresh
+callbacks. Add a phone-native pull surface around the existing List and Kanban
+scroll compositions, then reuse the shipped Kanban FAB geometry for task
+creation from List. No backend route, WebSocket event, persistence, or public
+API changes are required.
+
+## Frontend
+
+### Foreground lifecycle and request coalescing
+
+- Add `apps/web/hooks/use-foreground-refresh.ts` to listen for visible
+  `visibilitychange`, `window.focus`, `pageshow`, and `online`.
+- Keep the latest callback in a ref, suppress overlapping calls, and deduplicate
+  the burst of browser events emitted by one foreground transition. The hook
+  must not depend on `connection.status`, because a suspended socket can still
+  appear connected.
+- Replace the visibility-only listeners in
+  `apps/web/hooks/use-task-sessions.ts`,
+  `apps/web/hooks/domains/session/use-session-messages.ts`, and
+  `apps/web/hooks/domains/session/use-queue.ts` with the shared lifecycle hook.
+  Preserve each hook's current forced-reload and error behavior.
+- Refactor the task loader in
+  `apps/web/components/task/task-page-content.tsx` into a stable forced-refresh
+  callback. Foreground recovery reloads the active task without changing the
+  selected task/session and discards a response if navigation changed its task
+  identity before completion.
+
+### Kanban and List authoritative refresh
+
+- Refactor
+  `apps/web/hooks/domains/kanban/use-all-workflow-snapshots.ts` to expose a
+  promise-returning forced refresh for the current workspace. Keep its existing
+  workspace-generation guard and in-flight task preservation.
+- When refreshing the workflow selected as the active Kanban workflow, update
+  both `kanbanMulti.snapshots[workflowId]` and the active `kanban` snapshot from
+  the same guarded response. This keeps preview/create consumers consistent
+  with the rendered board.
+- Use the shared foreground hook from the Kanban data owner so Home refreshes
+  whether or not WebSocket status changes. A partial or failed refresh retains
+  prior snapshots and allows retry.
+- Extend the List page's existing `fetchTasks` callback in
+  `apps/web/app/tasks/tasks-page-client.tsx` with silent foreground failure
+  handling while retaining toast feedback for explicit/manual loads. Reuse its
+  request sequence and workspace guard so stale requests cannot commit.
+- Invoke the same List callback after a successful List task creation so the
+  new row appears only when it matches the current filters and page.
+
+### Mobile pull surface
+
+- Add a small pure gesture-state helper under
+  `apps/web/lib/mobile/pull-to-refresh.ts` and a responsive component under
+  `apps/web/components/mobile/pull-to-refresh.tsx`.
+- The component activates only for one-touch, primarily vertical downward
+  movement beginning with the active vertical scroll owner at `scrollTop ===
+  0`. It cancels for horizontal movement, multi-touch, task drag interactions,
+  and movement below the threshold.
+- Keep rendered content mounted during refresh. Show an accessible top
+  indicator for pull progress, release readiness, and refreshing; settle it
+  after success or failure.
+- Wrap the List scroll surface and the mobile Kanban content without adding a
+  second vertical scroll owner. The current List `main` and current Kanban
+  column remain authoritative scroll containers.
+
+### Mobile List create action
+
+- Reuse `apps/web/components/kanban/mobile-fab.tsx` from
+  `apps/web/app/tasks/tasks-page-client.tsx`; do not introduce a second FAB
+  style.
+- Mount the existing `TaskCreateDialog` for List with the active workspace and
+  workflow context. When no workflow filter is selected, preserve the existing
+  dialog workflow-resolution behavior rather than persisting a new filter.
+- Keep the control phone-only, fixed above the bottom safe area, at a 56px
+  touch target, with the existing **Add task** accessible name.
+
+## Mobile design contract
+
+- **Desktop outcome / mobile entry:** foreground focus refresh works on all
+  viewports. Phone users additionally pull the current task surface or tap the
+  bottom-right **Add task** FAB in List.
+- **Nearest exemplar:** `apps/web/components/kanban/mobile-fab.tsx` supplies FAB
+  geometry and safe-area behavior; the current mobile Kanban column and mobile
+  List `main` supply scroll ownership.
+- **Hierarchy / primary action:** tasks remain the focal content. Create is the
+  persistent thumb-reachable primary action; refresh is a top-edge recovery
+  gesture with visible progress.
+- **Presentation:** inline pull indicator plus the existing fixed FAB. A drawer
+  or full-height surface would add unnecessary navigation for these frequent,
+  shallow actions.
+- **Scroll and viewport:** no new document scroll or nested vertical scroller.
+  The gesture interrogates the touched view's existing vertical scroll owner,
+  uses overscroll containment, and leaves the FAB clear of
+  `env(safe-area-inset-bottom)`.
+- **Shared state:** data loaders, filters, workspace/workflow selection, and
+  create behavior remain shared. Only the pull gesture and FAB presentation
+  are phone-specific.
+- **Mobile proof:** Playwright creates a task through List's FAB, pulls List and
+  Kanban to recover dropped updates, checks a mid-scroll/horizontal gesture
+  does not refresh, and asserts no horizontal document overflow.
+
+## Tests
+
+- **What:** foreground events invoke one refresh independent of WebSocket
+  status; burst events and in-flight requests coalesce; hidden visibility
+  events do nothing.
+  **File:** `apps/web/hooks/use-foreground-refresh.test.ts`.
+  **How:** Vitest hook tests with controlled promises and synthetic browser
+  lifecycle events.
+- **What:** sessions, chat messages, and queued messages backfill on window
+  focus as well as visibility without duplicate concurrent requests.
+  **Files:** `apps/web/hooks/use-task-sessions.test.ts`,
+  `apps/web/hooks/domains/session/use-visibility-backfill.test.ts`,
+  `apps/web/hooks/domains/session/use-queue.test.ts`.
+  **How:** existing hook fakes extended with focus/burst cases.
+- **What:** forced Kanban refresh updates current workflow snapshots, preserves
+  mutations arriving during an in-flight request, and rejects stale workspace
+  results.
+  **Files:**
+  `apps/web/hooks/domains/kanban/use-all-workflow-snapshots.test.ts`,
+  `apps/web/hooks/domains/kanban/use-all-workflow-snapshots-inflight.test.ts`.
+  **How:** controlled API promises against the existing store harness.
+- **What:** pull state crosses the threshold only for eligible vertical
+  gestures and resets on cancellation, horizontal movement, multi-touch, and
+  request settlement.
+  **File:** `apps/web/lib/mobile/pull-to-refresh.test.ts`.
+  **How:** table-driven Vitest tests of the pure gesture state transitions.
+
+## E2E Tests
+
+- **Scenario:** mobile List FAB opens the real create flow and a matching task
+  appears in the current List after creation.
+  **File:** `apps/web/e2e/tests/task/mobile-task-surface-refresh.spec.ts`.
+  **What to verify:** 56px FAB, safe viewport containment, dialog context,
+  created row, and no horizontal document overflow.
+- **Scenario:** a dropped task update is recovered by pulling mobile List and
+  mobile Kanban from scroll-top; mid-scroll and primarily horizontal gestures
+  do not start a refresh.
+  **File:** `apps/web/e2e/tests/task/mobile-task-surface-refresh.spec.ts`.
+  **What to verify:** indicator state and authoritative task content after the
+  pull while the current view/workflow/column remains selected.
+- **Scenario:** Kanban/Home and List recover a deliberately dropped task event
+  when the desktop page receives a foreground signal while its WebSocket still
+  exists.
+  **File:** `apps/web/e2e/tests/task/task-surface-foreground-refresh.spec.ts`.
+  **What to verify:** stale row/card becomes current without `page.reload()`.
+- **Scenario:** task-detail chat recovers a deliberately dropped persisted
+  message on desktop focus.
+  **File:** `apps/web/e2e/tests/task/task-surface-foreground-refresh.spec.ts`.
+  **What to verify:** the message appears without navigation/reload and the
+  selected task/session does not change.
+- Extend `apps/web/e2e/helpers/ws-drop.ts` only as needed to drop named task or
+  message notifications deterministically; the test must assert that the
+  intended frame was actually dropped.
+
+## Implementation Waves And Parallel Candidates
+
+The tasks are sequential because Task 02 consumes the foreground primitive from
+Task 01, and E2E in Task 03 covers both.
+
+- [x] [task-01-foreground-recovery](task-01-foreground-recovery.md)
+- [x] [task-02-listing-pull-and-create](task-02-listing-pull-and-create.md)
+- [ ] [task-03-task-surface-e2e](task-03-task-surface-e2e.md)
+
+## Risks
+
+- Browser focus, visibility, page-cache, and online events commonly arrive in
+  a burst; insufficient deduplication would multiply expensive snapshot and
+  message requests.
+- Kanban's horizontal Embla gesture and task drag-and-drop share the same touch
+  surface as pull-to-refresh. Direction locking and scroll-top detection must
+  happen before preventing default browser behavior.
+- A snapshot refresh can race task creation, task WS updates, or workspace
+  navigation. Existing generation and in-flight mutation guards must remain
+  intact for both the multi-workflow and active snapshots.
+- E2E must prove notifications were dropped; otherwise live WebSocket delivery
+  could make foreground recovery tests pass without exercising the new path.

--- a/docs/plans/task-surface-refresh/task-01-foreground-recovery.md
+++ b/docs/plans/task-surface-refresh/task-01-foreground-recovery.md
@@ -1,0 +1,75 @@
+---
+id: "01-foreground-recovery"
+title: "Foreground recovery"
+status: done
+wave: 1
+depends_on: []
+plan: "plan.md"
+spec: "../../specs/ui/task-surface-refresh.md"
+---
+
+# Task 01: Foreground recovery
+
+## Acceptance
+
+- One shared hook emits refresh on visible `visibilitychange`, `focus`,
+  `pageshow`, and `online` independent of WebSocket status, while coalescing
+  burst and in-flight calls.
+- Open task details, session lists, active chat messages, and queued messages
+  reload from their existing authoritative endpoints without changing task or
+  session selection.
+- Hidden events, stale task responses, and failed foreground requests retain
+  the last usable UI and remain retryable.
+
+## Verification
+
+```bash
+cd apps && pnpm --filter @kandev/web test -- --run hooks/use-foreground-refresh.test.ts hooks/use-task-sessions.test.ts hooks/domains/session/use-visibility-backfill.test.ts hooks/domains/session/use-queue.test.ts
+```
+
+## Files likely touched
+
+- `apps/web/hooks/use-foreground-refresh.ts`
+- `apps/web/hooks/use-foreground-refresh.test.ts`
+- `apps/web/hooks/use-task-sessions.ts`
+- `apps/web/hooks/use-task-sessions.test.ts`
+- `apps/web/hooks/domains/session/use-session-messages.ts`
+- `apps/web/hooks/domains/session/use-visibility-backfill.test.ts`
+- `apps/web/hooks/domains/session/use-queue.ts`
+- `apps/web/hooks/domains/session/use-queue.test.ts`
+- `apps/web/components/task/task-page-content.tsx`
+
+## Dependencies
+
+None.
+
+## Parallelism
+
+Sequential. Task 02 consumes this task's lifecycle hook.
+
+## Inputs
+
+- Spec: `What` foreground and task-detail bullets; task-detail and event-burst
+  scenarios; failure modes.
+- Existing forced reload behavior in `useTaskSessions`.
+- Existing visibility-only message and queue backfills.
+- Existing task identity/request guard in `TaskPageContent`.
+
+## Risks
+
+- React callback identity churn must not re-register global listeners or bypass
+  coalescing.
+- Task navigation during an in-flight foreground request must not commit the
+  old task.
+
+## Output contract
+
+Completed 2026-07-27.
+
+Verification passed:
+
+```bash
+cd apps && pnpm --filter @kandev/web test -- --run hooks/use-foreground-refresh.test.ts hooks/use-task-sessions.test.ts hooks/domains/session/use-visibility-backfill.test.ts hooks/domains/session/use-queue.test.ts
+```
+
+Result: 4 files, 27 tests passed.

--- a/docs/plans/task-surface-refresh/task-02-listing-pull-and-create.md
+++ b/docs/plans/task-surface-refresh/task-02-listing-pull-and-create.md
@@ -1,0 +1,71 @@
+---
+id: "02-listing-pull-and-create"
+title: "Listing pull refresh and mobile create"
+status: done
+wave: 2
+depends_on: ["01-foreground-recovery"]
+plan: "plan.md"
+spec: "../../specs/ui/task-surface-refresh.md"
+---
+
+# Task 02: Listing pull refresh and mobile create
+
+## Acceptance
+
+- Kanban/Home and List use authoritative guarded callbacks for foreground and
+  manual refresh while retaining rendered data on failure.
+- Mobile List and Kanban refresh only after an eligible downward pull from the
+  active vertical scroll owner's top; horizontal, multi-touch, mid-scroll, and
+  below-threshold gestures do not refresh.
+- Mobile List renders the shipped safe-area-aware FAB, opens the existing
+  create dialog in current context, and refreshes the current List after a
+  matching task is created.
+
+## Verification
+
+```bash
+cd apps && pnpm --filter @kandev/web test -- --run hooks/domains/kanban/use-all-workflow-snapshots.test.ts hooks/domains/kanban/use-all-workflow-snapshots-inflight.test.ts lib/mobile/pull-to-refresh.test.ts
+```
+
+## Files likely touched
+
+- `apps/web/hooks/domains/kanban/use-all-workflow-snapshots.ts`
+- `apps/web/hooks/domains/kanban/use-all-workflow-snapshots.test.ts`
+- `apps/web/hooks/domains/kanban/use-all-workflow-snapshots-inflight.test.ts`
+- `apps/web/lib/mobile/pull-to-refresh.ts`
+- `apps/web/lib/mobile/pull-to-refresh.test.ts`
+- `apps/web/components/mobile/pull-to-refresh.tsx`
+- `apps/web/components/kanban-board.tsx`
+- `apps/web/components/kanban/mobile-fab.tsx`
+- `apps/web/app/tasks/tasks-page-client.tsx`
+- `apps/web/app/tasks/tasks-list-view.tsx`
+
+## Dependencies
+
+Task 01.
+
+## Parallelism
+
+Sequential. Kanban and List share the new refresh and pull contracts.
+
+## Inputs
+
+- Spec: mobile create, pull, Kanban/List foreground behavior, race/failure
+  requirements.
+- Mobile design contract in `plan.md`.
+- Existing request-generation guards in List and multi-workflow snapshot
+  fetches.
+- Existing Kanban FAB and `TaskCreateDialog`.
+
+## Risks
+
+- Gesture arbitration with Embla and task DnD.
+- Active `kanban` and `kanbanMulti` state diverging after a forced refresh.
+- Explicit/manual error feedback accidentally appearing for silent foreground
+  refresh.
+
+## Output contract
+
+Report RED failures, changed files, exact verification result, rendered mobile
+check status, residual risks, and update this task plus `plan.md` status in the
+primary conversation.

--- a/docs/plans/task-surface-refresh/task-03-task-surface-e2e.md
+++ b/docs/plans/task-surface-refresh/task-03-task-surface-e2e.md
@@ -1,0 +1,62 @@
+---
+id: "03-task-surface-e2e"
+title: "Task surface browser coverage"
+status: pending
+wave: 3
+depends_on: ["01-foreground-recovery", "02-listing-pull-and-create"]
+plan: "plan.md"
+spec: "../../specs/ui/task-surface-refresh.md"
+---
+
+# Task 03: Task surface browser coverage
+
+## Acceptance
+
+- Mobile Playwright proves List creation, List/Kanban pull recovery, gesture
+  rejection, safe-area containment, and no horizontal document overflow.
+- Desktop Playwright proves Kanban/Home, List, and task-detail chat recover
+  deliberately dropped live updates on a foreground event without reload or
+  selection changes.
+- Every dropped-frame test asserts the intended WebSocket notification was
+  actually suppressed before asserting recovery.
+
+## Verification
+
+```bash
+cd apps/web && pnpm e2e:run tests/task/mobile-task-surface-refresh.spec.ts tests/task/task-surface-foreground-refresh.spec.ts
+```
+
+## Files likely touched
+
+- `apps/web/e2e/helpers/ws-drop.ts`
+- `apps/web/e2e/pages/mobile-kanban-page.ts`
+- `apps/web/e2e/tests/task/mobile-task-surface-refresh.spec.ts`
+- `apps/web/e2e/tests/task/task-surface-foreground-refresh.spec.ts`
+
+## Dependencies
+
+Tasks 01 and 02.
+
+## Parallelism
+
+Sequential. These scenarios validate the integrated result.
+
+## Inputs
+
+- Spec scenarios.
+- E2E section and mobile design contract in `plan.md`.
+- Existing `routeMainWebSocketWithPromptDrop`, task List fixtures, and
+  `MobileKanbanPage`.
+
+## Risks
+
+- A live event that was not actually dropped can create a false-positive
+  recovery test.
+- Production E2E builds are required after frontend changes; do not use stale
+  assets.
+
+## Output contract
+
+Report RED failures, production-build E2E result, screenshots or failure
+artifacts inspected, residual risks, and update this task plus `plan.md` status
+in the primary conversation.

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -130,6 +130,7 @@ Subscription quota tracking and per-agent cheap-model profile routing.
 | [app-status-bar](ui/app-status-bar.md) | draft |
 | [mobile-task-navigation](ui/mobile-task-navigation.md) | shipped |
 | [task-layout-profiles](ui/task-layout-profiles.md) | draft |
+| [task-surface-refresh](ui/task-surface-refresh.md) | draft |
 | [agent-message-comments](ui/agent-message-comments.md) | shipped |
 | [external-vcs-file-links](ui/external-vcs-file-links.md) | shipped |
 | [task-listing-display-preferences](ui/task-listing-display-preferences.md) | shipped |

--- a/docs/specs/ui/task-surface-refresh.md
+++ b/docs/specs/ui/task-surface-refresh.md
@@ -1,0 +1,119 @@
+---
+status: approved
+created: 2026-07-27
+owner: Kandev
+---
+
+# Task Surface Foreground Refresh and Mobile Create Action
+
+## Why
+
+People returning to Kandev after the browser, window, or device has been idle
+can see a task List, Kanban board, or task-detail chat that no longer matches
+backend state. This affects desktop window switching as well as suspended
+mobile browsers. Phone users also need a familiar recovery gesture and the same
+thumb-reachable create action in List that Kanban already provides.
+
+## What
+
+- Mobile List shows the same safe-area-aware floating **Add task** button as
+  mobile Kanban.
+- The List floating action opens the existing task-create flow in the active
+  workspace and workflow; a successful creation becomes visible under the
+  current List filters and pagination rules.
+- Mobile List and mobile Kanban support pull-to-refresh from the top of their
+  current vertical scroll surface.
+- The pull gesture activates only for a primarily downward single-touch drag
+  that starts while the active vertical scroll owner is at its top. Horizontal
+  Kanban navigation, task drag-and-drop, and ordinary scrolling do not trigger
+  refresh.
+- The UI shows pull progress, a release threshold, and an in-progress state
+  without replacing already-rendered tasks with an empty or loading screen.
+- Releasing beyond the threshold performs one refresh at a time. Releasing
+  before the threshold restores the surface without fetching.
+- A List refresh reloads the current page using the current workspace,
+  workflow, repository, query, archive, sort, and pagination settings.
+- A Kanban refresh reloads the current workspace's visible workflow snapshots,
+  including the active workflow state used by task preview and creation.
+- When Kandev becomes the focused window, becomes visible after being hidden,
+  resumes from the browser page cache, or returns online, the active task
+  surface performs an authoritative foreground refresh even when the WebSocket
+  connection still reports `connected`.
+- Foreground events emitted together for one return to Kandev are coalesced so
+  each active data source refreshes once rather than once per browser event.
+- Kanban/Home foreground refresh reloads the current workspace's workflow
+  snapshots.
+- List foreground refresh reloads the current filtered and paginated List
+  request.
+- Task-detail foreground refresh reloads the open task, its session list, the
+  active session's chat messages, and its queued-message state. Existing
+  subscription and focus state remains attached to the same task and session.
+- Automatic foreground refresh applies on desktop and mobile. Pull-to-refresh
+  and the List floating create action are phone-only.
+- Refreshed responses must not overwrite a newer workspace selection or a task
+  mutation that lands while a refresh is in flight.
+
+## Failure modes
+
+- A failed manual refresh keeps the last rendered tasks and presents the
+  existing user-facing error feedback pattern; the pull indicator settles back
+  to idle so the user can retry.
+- A failed automatic foreground refresh keeps the last rendered tasks and does
+  not interrupt the user with a modal.
+- A refresh requested while another refresh for the same data source is in
+  flight is coalesced rather than issuing overlapping requests.
+- If the active workspace or workflow changes during a refresh, the stale
+  response is discarded.
+
+## Scenarios
+
+- **GIVEN** List is open on a phone, **WHEN** the user taps the floating **Add
+  task** button and completes task creation, **THEN** the existing create flow
+  uses the active workspace and workflow and the new task appears when it
+  matches the current List query.
+- **GIVEN** mobile List is scrolled to the top, **WHEN** the user pulls downward
+  beyond the release threshold, **THEN** the current filtered page is reloaded
+  and a refresh indicator remains visible until the request settles.
+- **GIVEN** mobile Kanban's current column is scrolled to the top, **WHEN** the
+  user pulls downward beyond the release threshold, **THEN** current workflow
+  snapshots are reloaded without changing the focused workflow or column.
+- **GIVEN** either task listing is not at its vertical scroll top, **WHEN** the
+  user drags downward, **THEN** the surface scrolls normally and no refresh is
+  started.
+- **GIVEN** mobile Kanban, **WHEN** the user swipes primarily horizontally
+  between columns, **THEN** pull-to-refresh does not activate.
+- **GIVEN** a task changes while Kandev is hidden or suspended, **WHEN** the
+  user returns to List, **THEN** the changed task is reflected without a full
+  browser reload.
+- **GIVEN** a task changes while Kandev is hidden or suspended, **WHEN** the
+  user returns to Kanban, **THEN** the changed task is reflected without a full
+  browser reload even if connection status never left `connected`.
+- **GIVEN** Kanban/Home remains visible in an unfocused desktop browser window
+  while tasks change, **WHEN** the user focuses Kandev again, **THEN** the board
+  reflects those changes without a full browser reload.
+- **GIVEN** an open task receives messages or session-state changes while the
+  Kandev window is unfocused, hidden, suspended, or offline, **WHEN** the user
+  returns to Kandev, **THEN** the task details, session list, active chat
+  messages, and queued-message state converge to their authoritative backend
+  values without changing the selected task or session.
+- **GIVEN** one return to Kandev emits `focus`, `visibilitychange`, `pageshow`,
+  and/or `online` close together, **WHEN** foreground recovery runs, **THEN**
+  each active data source issues at most one concurrent refresh.
+- **GIVEN** a manual or automatic refresh fails, **WHEN** the request settles,
+  **THEN** previously rendered tasks remain usable and a later pull or
+  foreground event can retry.
+
+## Out of scope
+
+- Adding pull-to-refresh to task detail, Office, settings, or other Kandev
+  pages.
+- Changing the existing WebSocket event schema or backend task APIs.
+- Periodically polling all Kandev data while the app remains continuously
+  focused.
+- Adding a floating create action on desktop List.
+- Persisting pull distance, refresh timestamps, or refresh state.
+- Changing List filters, sorting, grouping, pagination, or Kanban navigation.
+
+## Implementation plan
+
+- [Task surface refresh implementation plan](../../plans/task-surface-refresh/plan.md)


### PR DESCRIPTION
Task surfaces could remain stale after the browser or desktop app regained focus, and mobile List lacked the Kanban create affordance. This adds coalesced foreground recovery across task surfaces plus mobile pull-to-refresh and task creation controls.

## Important Changes

- Added shared foreground lifecycle refresh handling for List, Kanban/Home, task details, chat, sessions, and queues.
- Added mobile pull-to-refresh wrappers for List and Kanban while preserving existing scroll owners.
- Reused the Kanban mobile FAB and create dialog for mobile List.

## Validation

- `cd apps/web && pnpm lint`
- `cd apps/web && pnpm typecheck`
- Focused Vitest suite: 7 files, 40 tests passed
- Production Vite build passed
- Existing mobile Kanban Playwright smoke test passed
- Desktop and mobile PR screenshots captured and inspected

## Possible Improvements

Low risk: add dedicated Playwright coverage for the new List FAB and pull gestures once the local mobile List runner consistently loads the route; its current run rendered a blank page before existing List assertions.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1986?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- kandev-screenshots-start -->
## Screenshots

![Desktop Kanban with foreground refresh support](https://raw.githubusercontent.com/kdlbs/kandev/dd6b0f243e2a0ce3d22b6847819ca7b7083dc15d/kanban-desktop.png)

![Mobile Kanban with refresh and create controls](https://raw.githubusercontent.com/kdlbs/kandev/dd6b0f243e2a0ce3d22b6847819ca7b7083dc15d/kanban-mobile.png)
<!-- kandev-screenshots-end -->