### PR TITLE
fix(github): stop SELECT * scans from breaking on TaskPR schema drift

### DIFF
--- a/apps/backend/internal/github/store.go
+++ b/apps/backend/internal/github/store.go
@@ -1395,11 +1395,35 @@ func (s *Store) CreateTaskPR(ctx context.Context, tp *TaskPR) error {
 	return err
 }
 
+// taskPRColumns is the explicit column list for every github_task_prs read.
+// Using `SELECT *` here is unsafe: sqlx's StructScan errors out
+// ("missing destination name X in *github.TaskPR") the moment the table has
+// a column the current TaskPR struct doesn't declare a field for. That drift
+// is not hypothetical — a self-update that applies a newer release's
+// migration (adding a column) followed by a rollback to an older binary
+// leaves exactly this mismatch permanently on disk, since SQLite migrations
+// are additive and never reverted. Projecting the known columns keeps every
+// read working regardless of what the table has picked up beyond them.
+const taskPRColumns = `id, workspace_id, task_id, repository_id, owner, repo, pr_number, pr_url,
+	pr_title, head_branch, base_branch, author_login, state, review_state, checks_state,
+	mergeable_state, review_count, pending_review_count, required_reviews, comment_count,
+	unresolved_review_threads, checks_total, checks_passing, additions, deletions,
+	created_at, merged_at, closed_at, last_synced_at, updated_at`
+
+// taskPRColumnsQualified is taskPRColumns with each column qualified by the
+// `gtp` alias, for queries that join github_task_prs against another table.
+const taskPRColumnsQualified = `gtp.id, gtp.workspace_id, gtp.task_id, gtp.repository_id, gtp.owner, gtp.repo,
+	gtp.pr_number, gtp.pr_url, gtp.pr_title, gtp.head_branch, gtp.base_branch, gtp.author_login,
+	gtp.state, gtp.review_state, gtp.checks_state, gtp.mergeable_state, gtp.review_count,
+	gtp.pending_review_count, gtp.required_reviews, gtp.comment_count, gtp.unresolved_review_threads,
+	gtp.checks_total, gtp.checks_passing, gtp.additions, gtp.deletions,
+	gtp.created_at, gtp.merged_at, gtp.closed_at, gtp.last_synced_at, gtp.updated_at`
+
 // GetTaskPR returns the first PR association for a task. For multi-repo tasks
 // the result is non-deterministic across repos — use ListTaskPRsByTask instead.
 func (s *Store) GetTaskPR(ctx context.Context, taskID string) (*TaskPR, error) {
 	var tp TaskPR
-	err := s.ro.GetContext(ctx, &tp, `SELECT * FROM github_task_prs WHERE task_id = ? LIMIT 1`, taskID)
+	err := s.ro.GetContext(ctx, &tp, `SELECT `+taskPRColumns+` FROM github_task_prs WHERE task_id = ? LIMIT 1`, taskID)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
@@ -1416,7 +1440,7 @@ func (s *Store) GetTaskPR(ctx context.Context, taskID string) (*TaskPR, error) {
 func (s *Store) GetTaskPRByRepository(ctx context.Context, taskID, repositoryID string) (*TaskPR, error) {
 	var tp TaskPR
 	err := s.ro.GetContext(ctx, &tp,
-		`SELECT * FROM github_task_prs WHERE task_id = ? AND repository_id = ?
+		`SELECT `+taskPRColumns+` FROM github_task_prs WHERE task_id = ? AND repository_id = ?
 		 ORDER BY updated_at DESC LIMIT 1`,
 		taskID, repositoryID)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -1433,7 +1457,7 @@ func (s *Store) GetTaskPRByRepository(ctx context.Context, taskID, repositoryID 
 func (s *Store) GetTaskPRByRepoAndNumber(ctx context.Context, taskID, repositoryID string, prNumber int) (*TaskPR, error) {
 	var tp TaskPR
 	err := s.ro.GetContext(ctx, &tp,
-		`SELECT * FROM github_task_prs
+		`SELECT `+taskPRColumns+` FROM github_task_prs
 		 WHERE task_id = ? AND repository_id = ? AND pr_number = ? LIMIT 1`,
 		taskID, repositoryID, prNumber)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -1447,7 +1471,7 @@ func (s *Store) GetTaskPRByRepoAndNumber(ctx context.Context, taskID, repository
 func (s *Store) ListTaskPRsByTask(ctx context.Context, taskID string) ([]*TaskPR, error) {
 	var prs []TaskPR
 	if err := s.ro.SelectContext(ctx, &prs,
-		`SELECT * FROM github_task_prs WHERE task_id = ? ORDER BY created_at ASC`, taskID); err != nil {
+		`SELECT `+taskPRColumns+` FROM github_task_prs WHERE task_id = ? ORDER BY created_at ASC`, taskID); err != nil {
 		return nil, err
 	}
 	out := make([]*TaskPR, 0, len(prs))
@@ -1465,7 +1489,7 @@ func (s *Store) ListTaskPRsByTaskIDs(ctx context.Context, taskIDs []string) (map
 		return make(map[string][]*TaskPR), nil
 	}
 	query, args, err := sqlx.In(
-		`SELECT * FROM github_task_prs WHERE task_id IN (?) ORDER BY created_at ASC`,
+		`SELECT `+taskPRColumns+` FROM github_task_prs WHERE task_id IN (?) ORDER BY created_at ASC`,
 		taskIDs,
 	)
 	if err != nil {
@@ -1485,7 +1509,7 @@ func (s *Store) ListTaskPRsByTaskIDs(ctx context.Context, taskIDs []string) (map
 func (s *Store) ListTaskPRsByWorkspaceID(ctx context.Context, workspaceID string) (map[string][]*TaskPR, error) {
 	var prs []TaskPR
 	if err := s.ro.SelectContext(ctx, &prs,
-		`SELECT gtp.* FROM github_task_prs gtp
+		`SELECT `+taskPRColumnsQualified+` FROM github_task_prs gtp
 		 INNER JOIN tasks t ON gtp.task_id = t.id
 		 WHERE t.workspace_id = ?
 		 ORDER BY gtp.created_at ASC`, workspaceID); err != nil {

--- a/apps/backend/internal/github/store_taskpr_schema_drift_test.go
+++ b/apps/backend/internal/github/store_taskpr_schema_drift_test.go
@@ -1,0 +1,96 @@
+package github
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestTaskPRReads_ToleratesExtraColumn locks in resilience against a
+// specific production incident: the "Link GitHub pull request" dialog
+// failed with "associate PR with task: missing destination name workspace_id
+// in *github.TaskPR" for a task in a workspace whose github_task_prs table
+// had picked up a column (via a schema migration from a newer release, e.g.
+// a self-update that was later rolled back) that the running binary's
+// TaskPR struct doesn't declare. sqlx's StructScan errors out on any SELECT
+// * column with no matching destination field, so every TaskPR read query
+// must project an explicit column list rather than `SELECT *` /
+// `SELECT gtp.*` — otherwise ANY future schema drift ahead of the binary
+// breaks every read path, not just the one column that happened to trigger
+// the original report.
+func TestTaskPRReads_ToleratesExtraColumn(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	// Simulate schema drift: a column present in the table that the
+	// current TaskPR struct has no field for.
+	if _, err := store.db.Exec(
+		`ALTER TABLE github_task_prs ADD COLUMN future_only_column TEXT NOT NULL DEFAULT ''`,
+	); err != nil {
+		t.Fatalf("simulate schema drift: %v", err)
+	}
+	if _, err := store.db.Exec(
+		`INSERT INTO tasks (id, workspace_id) VALUES ('task-drift', 'ws-drift')`,
+	); err != nil {
+		t.Fatalf("seed task: %v", err)
+	}
+
+	tp := &TaskPR{
+		WorkspaceID: "ws-drift",
+		TaskID:      "task-drift",
+		Owner:       "kdlbs",
+		Repo:        "kandev",
+		PRNumber:    1978,
+		PRURL:       "https://github.com/kdlbs/kandev/pull/1978",
+		PRTitle:     "drifted schema",
+		State:       "open",
+		CreatedAt:   time.Now().UTC(),
+	}
+	if err := store.ReplaceTaskPR(ctx, tp); err != nil {
+		t.Fatalf("ReplaceTaskPR: %v", err)
+	}
+
+	fatalOnScanError := func(name string, err error) {
+		t.Helper()
+		if err == nil {
+			return
+		}
+		t.Fatalf("%s: SELECT scan broke on schema drift: %v", name, err)
+	}
+
+	got, err := store.GetTaskPR(ctx, "task-drift")
+	fatalOnScanError("GetTaskPR", err)
+	if got == nil || got.PRNumber != 1978 || got.WorkspaceID != "ws-drift" {
+		t.Fatalf("GetTaskPR: expected PR #1978 in ws-drift, got %+v", got)
+	}
+
+	gotByRepo, err := store.GetTaskPRByRepository(ctx, "task-drift", "")
+	fatalOnScanError("GetTaskPRByRepository", err)
+	if gotByRepo == nil || gotByRepo.PRNumber != 1978 {
+		t.Fatalf("GetTaskPRByRepository: expected PR #1978, got %+v", gotByRepo)
+	}
+
+	gotByNumber, err := store.GetTaskPRByRepoAndNumber(ctx, "task-drift", "", 1978)
+	fatalOnScanError("GetTaskPRByRepoAndNumber", err)
+	if gotByNumber == nil || gotByNumber.PRTitle != "drifted schema" {
+		t.Fatalf("GetTaskPRByRepoAndNumber: expected the drifted-schema PR, got %+v", gotByNumber)
+	}
+
+	list, err := store.ListTaskPRsByTask(ctx, "task-drift")
+	fatalOnScanError("ListTaskPRsByTask", err)
+	if len(list) != 1 || list[0].PRNumber != 1978 {
+		t.Fatalf("ListTaskPRsByTask: expected 1 PR (#1978), got %+v", list)
+	}
+
+	byIDs, err := store.ListTaskPRsByTaskIDs(ctx, []string{"task-drift"})
+	fatalOnScanError("ListTaskPRsByTaskIDs", err)
+	if len(byIDs["task-drift"]) != 1 || byIDs["task-drift"][0].PRNumber != 1978 {
+		t.Fatalf("ListTaskPRsByTaskIDs: expected 1 PR (#1978) for task-drift, got %+v", byIDs)
+	}
+
+	byWorkspace, err := store.ListTaskPRsByWorkspaceID(ctx, "ws-drift")
+	fatalOnScanError("ListTaskPRsByWorkspaceID", err)
+	if len(byWorkspace["task-drift"]) != 1 || byWorkspace["task-drift"][0].PRNumber != 1978 {
+		t.Fatalf("ListTaskPRsByWorkspaceID: expected 1 PR (#1978) for task-drift, got %+v", byWorkspace)
+	}
+}


### PR DESCRIPTION
## Problem

Linking a GitHub PR to a task (`Link GitHub pull request` dialog) failed with:

```
associate PR with task: missing destination name workspace_id in *github.TaskPR
```

That's a Go/sqlx error, not a data problem — it means the `github_task_prs` table
had a column the running binary's `TaskPR` struct had no field for. sqlx's
`StructScan` rejects any `SELECT *` result column with no matching destination
field.

That mismatch is not hypothetical: `github_task_prs.workspace_id` and
`TaskPR.WorkspaceID` were added together, but a self-update that applies a
newer release's migration (adding a column) followed by a rollback to an
older binary leaves the column permanently in place — SQLite migrations are
additive and never revert. Any future column addition reproduces this same
failure class, not just `workspace_id`.

Confirmed the affected task's `workspace_id` itself was valid and pointed at
a real, non-archived workspace — the error text just uses "missing
destination name" to mean "no matching Go struct field", which reads as
"something is missing" but isn't a data-integrity issue at all.

## Fix

`internal/github/store.go`: replaced every `SELECT * FROM github_task_prs` /
`SELECT gtp.*` TaskPR read with an explicit column projection
(`taskPRColumns` / `taskPRColumnsQualified`), so an unexpected extra column
no longer breaks:

- `GetTaskPR`
- `GetTaskPRByRepository`
- `GetTaskPRByRepoAndNumber`
- `ListTaskPRsByTask`
- `ListTaskPRsByTaskIDs`
- `ListTaskPRsByWorkspaceID`

Writes (`ReplaceTaskPR`, `CreateTaskPR`, `UpdateTaskPR`) already used
explicit columns and needed no change.

## Testing

Added `TestTaskPRReads_ToleratesExtraColumn`
(`store_taskpr_schema_drift_test.go`), which:

1. Simulates schema drift via `ALTER TABLE github_task_prs ADD COLUMN
   future_only_column ...`.
2. RED: before the fix, `GetTaskPR` failed with `missing destination name
   future_only_column in *github.TaskPR` — the exact reported error class.
3. GREEN: after the fix, all six read paths succeed and return the correct
   PR data despite the extra column.

- `make fmt` — clean
- `make build` — clean
- `make test` — `internal/github` package passes; the only backend-wide
  failures are pre-existing `internal/task/service` sandbox
  filesystem-permission failures (`parent directory cannot be accessed`),
  confirmed unrelated by reproducing them against the unmodified base
  commit.
- `make lint` (golangci-lint) — 0 issues


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1988?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



## Demo evidence (browser-driven, real UI)

Reproduced the reported condition end-to-end against a running instance: built this branch,
started the backend fresh, stopped it, ran `ALTER TABLE github_task_prs ADD COLUMN
future_only_column ...` directly on the SQLite file to simulate the schema-drift condition,
restarted, then drove the actual "Link GitHub pull request" dialog through a real browser.

1. Dialog opened from the task card's Link → GitHub Pull Request menu:

   ![Dialog open](https://raw.githubusercontent.com/ClemDNL/kandev/085e4a77f90f49f2fc71ba641546e4c5e67c03e3/01-dialog-open.webp)

2. PR URL entered:

   ![PR URL entered](https://raw.githubusercontent.com/ClemDNL/kandev/085e4a77f90f49f2fc71ba641546e4c5e67c03e3/02-pr-url-entered.webp)

3. Saved successfully — no sqlx error, despite the extra `future_only_column` still present
   in `github_task_prs`:

   ![Linked successfully](https://raw.githubusercontent.com/ClemDNL/kandev/085e4a77f90f49f2fc71ba641546e4c5e67c03e3/03-linked-success.webp)

Verified server-side too: the `github_task_prs` row persisted with correct
`task_id`/`workspace_id`/`owner`/`repo`/`pr_number`/`pr_title`, with
`future_only_column` still sitting there unused.

(Screenshots hosted on a separate `screenshots/pr-1988` branch on the fork — not part of
this PR's diff.)
