### PR TITLE
fix: preserve dockview layout during task switches

### DIFF
--- a/apps/web/components/task/dockview-session-handoff.ts
+++ b/apps/web/components/task/dockview-session-handoff.ts
@@ -1,0 +1,61 @@
+import type { AddPanelOptions, DockviewApi } from "dockview-react";
+
+type StaleSessionPanel = {
+  id: string;
+  group: { id: string; panels: Array<{ id: string }> };
+};
+
+export function ensureSessionPanel(
+  api: DockviewApi,
+  sessionId: string,
+  position: AddPanelOptions["position"],
+  inactive: boolean,
+  createdSet: Set<string>,
+): void {
+  if (api.getPanel(`session:${sessionId}`)) {
+    createdSet.add(sessionId);
+    return;
+  }
+  api.addPanel({
+    id: `session:${sessionId}`,
+    component: "chat",
+    tabComponent: "sessionTab",
+    title: "Agent",
+    params: { sessionId },
+    position,
+    inactive,
+  });
+  createdSet.add(sessionId);
+}
+
+/**
+ * Add the incoming task session before closing its stale predecessor. Dockview
+ * destroys a group when its last panel closes, so the replacement must happen
+ * at the predecessor's live group and tab index.
+ */
+export function anchorIncomingSessionPanel(
+  api: DockviewApi,
+  currentIds: Set<string>,
+  stalePanels: StaleSessionPanel[],
+  keepSessionId: string,
+  createdSet: Set<string>,
+): void {
+  const firstStale = stalePanels[0];
+  if (
+    !currentIds.has(keepSessionId) ||
+    api.getPanel(`session:${keepSessionId}`) ||
+    !firstStale ||
+    !api.groups.some((group) => group.id === firstStale.group.id)
+  ) {
+    return;
+  }
+
+  const index = firstStale.group.panels.findIndex((panel) => panel.id === firstStale.id);
+  ensureSessionPanel(
+    api,
+    keepSessionId,
+    { referenceGroup: firstStale.group.id, ...(index >= 0 ? { index } : {}) },
+    true,
+    createdSet,
+  );
+}

--- a/apps/web/components/task/dockview-session-tabs.test-utils.ts
+++ b/apps/web/components/task/dockview-session-tabs.test-utils.ts
@@ -1,0 +1,87 @@
+import { vi } from "vitest";
+import type { DockviewApi } from "dockview-react";
+import { CENTER_GROUP, RIGHT_TOP_GROUP } from "@/lib/state/layout-manager";
+
+type HandoffPanel = {
+  id: string;
+  group: HandoffGroup;
+  api: {
+    close: ReturnType<typeof vi.fn<() => void>>;
+    component: string;
+  };
+};
+
+type HandoffGroup = {
+  id: string;
+  panels: HandoffPanel[];
+};
+
+type HandoffAddOptions = {
+  id: string;
+  component: string;
+  position?: { referenceGroup?: string; index?: number };
+};
+
+/**
+ * Models the Dockview behavior behind the layout corruption: closing the
+ * final panel synchronously destroys its group. The right-side groups remain
+ * so a later fallback would attach the incoming session in the wrong split.
+ */
+export function makeSharedEnvironmentHandoffApi(): {
+  api: DockviewApi;
+  events: string[];
+  groupIds: () => string[];
+} {
+  const center: HandoffGroup = { id: CENTER_GROUP, panels: [] };
+  const rightTop: HandoffGroup = { id: RIGHT_TOP_GROUP, panels: [] };
+  const rightBottom: HandoffGroup = { id: "group-right-bottom", panels: [] };
+  const groups = [center, rightTop, rightBottom];
+  const panels: HandoffPanel[] = [];
+  const events: string[] = [];
+
+  const removePanel = (panel: HandoffPanel) => {
+    events.push(`close:${panel.id}`);
+    const panelIndex = panels.indexOf(panel);
+    if (panelIndex !== -1) panels.splice(panelIndex, 1);
+    const groupPanelIndex = panel.group.panels.indexOf(panel);
+    if (groupPanelIndex !== -1) panel.group.panels.splice(groupPanelIndex, 1);
+    if (panel.group.panels.length === 0) {
+      const groupIndex = groups.indexOf(panel.group);
+      if (groupIndex !== -1) groups.splice(groupIndex, 1);
+    }
+  };
+
+  const createPanel = (id: string, component: string, group: HandoffGroup, index?: number) => {
+    const panel: HandoffPanel = {
+      id,
+      group,
+      api: {
+        close: vi.fn(() => removePanel(panel)),
+        component,
+      },
+    };
+    panels.push(panel);
+    group.panels.splice(index ?? group.panels.length, 0, panel);
+  };
+
+  createPanel("session:outgoing", "chat", center);
+  createPanel("files", "files", rightTop);
+  createPanel("changes", "changes", rightTop);
+  createPanel("terminal-default", "terminal", rightBottom);
+
+  return {
+    api: {
+      panels,
+      groups,
+      getPanel: (id: string) => panels.find((panel) => panel.id === id) ?? null,
+      addPanel: (options: HandoffAddOptions) => {
+        const group = groups.find((candidate) => candidate.id === options.position?.referenceGroup);
+        if (!group) throw new Error("expected a live reference group");
+        events.push(`add:${options.id}`);
+        createPanel(options.id, options.component, group, options.position?.index);
+      },
+    } as unknown as DockviewApi,
+    events,
+    groupIds: () => groups.map((group) => group.id),
+  };
+}

--- a/apps/web/components/task/dockview-session-tabs.test.ts
+++ b/apps/web/components/task/dockview-session-tabs.test.ts
@@ -12,6 +12,7 @@ import {
 } from "./dockview-session-tabs";
 import { CENTER_GROUP, RIGHT_TOP_GROUP } from "@/lib/state/layout-manager";
 import { useDockviewStore } from "@/lib/state/dockview-store";
+import { makeSharedEnvironmentHandoffApi } from "./dockview-session-tabs.test-utils";
 
 type FakePanel = {
   id: string;
@@ -248,6 +249,22 @@ function makeReorderingAutoSessionApi(): {
 }
 
 describe("reconcileRemovedSessionPanels", () => {
+  it("replaces the outgoing session before its final close can destroy the center group", () => {
+    const { api, events, groupIds } = makeSharedEnvironmentHandoffApi();
+
+    reconcileRemovedSessionPanels(api, new Set<string>(), ["incoming"], "incoming");
+
+    expect({
+      events,
+      groupIds: groupIds(),
+      incomingGroup: api.getPanel("session:incoming")?.group.id ?? null,
+    }).toEqual({
+      events: ["add:session:incoming", "close:session:outgoing"],
+      groupIds: [CENTER_GROUP, RIGHT_TOP_GROUP, "group-right-bottom"],
+      incomingGroup: CENTER_GROUP,
+    });
+  });
+
   it("closes a stale tracked panel that's still live in dockview", () => {
     // createdSet has session-A; A's panel is live; A is no longer in the task's
     // session list, so it must be closed.

--- a/apps/web/components/task/dockview-session-tabs.ts
+++ b/apps/web/components/task/dockview-session-tabs.ts
@@ -21,6 +21,7 @@ import {
   shouldActivateSessionPanel,
   shouldPreserveActivePanel,
 } from "./dockview-session-tab-activation";
+import { anchorIncomingSessionPanel, ensureSessionPanel } from "./dockview-session-handoff";
 
 const debug = createDebugLogger("dockview:session-tabs");
 
@@ -391,29 +392,6 @@ export function resolveInitialPosition(api: DockviewApi): AddPanelOptions["posit
   return undefined;
 }
 
-function ensureSessionPanel(
-  api: DockviewApi,
-  sessionId: string,
-  position: AddPanelOptions["position"],
-  inactive: boolean,
-  createdSet: Set<string>,
-): void {
-  if (api.getPanel(`session:${sessionId}`)) {
-    createdSet.add(sessionId);
-    return;
-  }
-  api.addPanel({
-    id: `session:${sessionId}`,
-    component: "chat",
-    tabComponent: "sessionTab",
-    title: "Agent",
-    params: { sessionId },
-    position,
-    inactive,
-  });
-  createdSet.add(sessionId);
-}
-
 /**
  * Close session panels that no longer belong to the active task.
  *
@@ -434,11 +412,18 @@ export function reconcileRemovedSessionPanels(
   // Snapshot before iterating: closing a panel can mutate `api.panels`
   // synchronously, which would skip elements in a `for...of` over the live
   // array. Matches the pattern in `removeEphemeralPanels`.
-  for (const panel of [...api.panels]) {
-    if (!panel.id.startsWith("session:")) continue;
+  const stalePanels = api.panels.filter((panel) => {
+    if (!panel.id.startsWith("session:")) return false;
     const sid = panel.id.slice("session:".length);
-    if (sid === keepSessionId) continue;
-    if (currentIds.has(sid)) continue;
+    return sid !== keepSessionId && !currentIds.has(sid);
+  });
+
+  if (keepSessionId) {
+    anchorIncomingSessionPanel(api, currentIds, stalePanels, keepSessionId, createdSet);
+  }
+
+  for (const panel of stalePanels) {
+    const sid = panel.id.slice("session:".length);
     try {
       panel.api.close();
       removed.push(panel.id);

--- a/apps/web/e2e/helpers/api-client.ts
+++ b/apps/web/e2e/helpers/api-client.ts
@@ -226,6 +226,7 @@ type OptionalAgentTaskOpts = {
   executor_profile_id?: string;
   metadata?: Record<string, unknown>;
   parent_id?: string;
+  workspace_mode?: "inherit_parent" | "new_workspace" | "shared_group";
   attachments?: MessageAttachmentInput[];
 };
 
@@ -248,6 +249,7 @@ function buildOptionalAgentTaskFields(opts?: OptionalAgentTaskOpts): Record<stri
   setIf(fields, "executor_profile_id", opts.executor_profile_id);
   setIf(fields, "metadata", opts.metadata);
   setIf(fields, "parent_id", opts.parent_id);
+  setIf(fields, "workspace_mode", opts.workspace_mode);
   setIf(fields, "attachments", opts.attachments);
   return fields;
 }
@@ -619,6 +621,8 @@ export class ApiClient {
       metadata?: Record<string, unknown>;
       /** Parent task ID for subtasks. */
       parent_id?: string;
+      /** Workspace behavior for a child task. */
+      workspace_mode?: "inherit_parent" | "new_workspace" | "shared_group";
       attachments?: MessageAttachmentInput[];
     },
   ): Promise<CreateTaskResponse> {

--- a/apps/web/e2e/tests/layout/saved-layout-session-isolation.spec.ts
+++ b/apps/web/e2e/tests/layout/saved-layout-session-isolation.spec.ts
@@ -70,7 +70,118 @@ async function dockviewPanelIds(page: Page) {
   });
 }
 
+async function dockviewDefaultTree(page: Page, sessionId: string) {
+  return page.evaluate((currentSessionId) => {
+    type GridNode =
+      | { type: "branch"; data: GridNode[] }
+      | { type: "leaf"; data: { views: string[] } };
+    type Api = {
+      getPanel: (id: string) => { group: { id: string } } | null;
+      toJSON: () => { grid: { orientation: string; root: GridNode } };
+    };
+    const api = (window as unknown as { __dockviewApi__?: Api }).__dockviewApi__;
+    if (!api) throw new Error("dockview api not exposed");
+    const layout = api.toJSON();
+    const root = layout.grid.root;
+    const rootColumns = root.type === "branch" ? root.data : [];
+    const rightColumnPreserved = rootColumns.some(
+      (column) =>
+        column.type === "branch" &&
+        column.data.some(
+          (group) =>
+            group.type === "leaf" &&
+            (group.data.views.includes("files") || group.data.views.includes("changes")),
+        ) &&
+        column.data.some(
+          (group) => group.type === "leaf" && group.data.views.includes("terminal-default"),
+        ),
+    );
+
+    return {
+      orientation: layout.grid.orientation,
+      centerGroupId: api.getPanel(`session:${currentSessionId}`)?.group.id ?? null,
+      rootColumnCount: rootColumns.length,
+      rightColumnPreserved,
+    };
+  }, sessionId);
+}
+
 test.describe("saved Dockview layouts", () => {
+  test("keeps the desktop split tree when switching tasks in one environment", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    const parent = await createFinishedTaskWithSession(
+      apiClient,
+      seedData,
+      "Shared environment layout parent",
+      '/e2e:message("parent session")',
+    );
+    const child = await apiClient.createTaskWithAgent(
+      seedData.workspaceId,
+      "Shared environment layout child",
+      seedData.agentProfileId,
+      {
+        description: '/e2e:message("child session")',
+        workflow_id: seedData.workflowId,
+        workflow_step_id: seedData.startStepId,
+        repository_ids: [seedData.repositoryId],
+        parent_id: parent.task.id,
+        workspace_mode: "inherit_parent",
+      },
+    );
+    if (!child.session_id) throw new Error("child task did not return a session_id");
+
+    await expect
+      .poll(async () => {
+        const [{ sessions: parentSessions }, { sessions: childSessions }] = await Promise.all([
+          apiClient.listTaskSessions(parent.task.id),
+          apiClient.listTaskSessions(child.id),
+        ]);
+        const parentEnvironmentId = parentSessions[0]?.task_environment_id;
+        const childEnvironmentId = childSessions[0]?.task_environment_id;
+        return parentEnvironmentId && childEnvironmentId === parentEnvironmentId;
+      })
+      .toBe(true);
+
+    await testPage.goto(`/t/${parent.task.id}`);
+    await expect(testPage.getByTestId("dockview-task-layout")).toBeVisible({ timeout: 15_000 });
+    await expect(testPage.getByText("parent session")).toBeVisible({ timeout: 30_000 });
+
+    const sidebar = testPage.getByTestId("app-sidebar");
+    await sidebar.getByRole("button", { name: /Shared environment layout child/ }).click();
+    await expect(testPage).toHaveURL(new RegExp(`/t/${child.id}(?:\\?|$)`), { timeout: 10_000 });
+
+    await expect
+      .poll(() => dockviewPanelIds(testPage), {
+        timeout: 10_000,
+        message: "Waiting for the child session panel after the same-environment switch",
+      })
+      .toContain(`session:${child.session_id}`);
+    expect(await dockviewPanelIds(testPage)).not.toContain(`session:${parent.sessionId}`);
+
+    await expect
+      .poll(() => dockviewDefaultTree(testPage, child.session_id!))
+      .toEqual({
+        orientation: "HORIZONTAL",
+        centerGroupId: "group-center",
+        rootColumnCount: 2,
+        rightColumnPreserved: true,
+      });
+
+    await testPage.reload();
+    await expect(testPage.getByTestId("dockview-task-layout")).toBeVisible({ timeout: 15_000 });
+    await expect
+      .poll(() => dockviewDefaultTree(testPage, child.session_id!))
+      .toEqual({
+        orientation: "HORIZONTAL",
+        centerGroupId: "group-center",
+        rootColumnCount: 2,
+        rightColumnPreserved: true,
+      });
+  });
+
   test("saved chat-only layouts keep the current task session", async ({
     testPage,
     apiClient,

--- a/docs/plans/dockview-shared-environment-layout/plan.md
+++ b/docs/plans/dockview-shared-environment-layout/plan.md
@@ -1,0 +1,106 @@
+---
+spec: docs/specs/ui/task-layout-profiles.md
+created: 2026-07-27
+status: implemented
+---
+
+# Implementation Plan: Preserve Dockview Layouts Across Shared-Environment Task Switches
+
+## Overview
+
+Make the desktop session-tab handoff atomic when two tasks share the same environment. Today the environment switch correctly reuses the live Dockview layout, but task reconciliation closes the outgoing task's only session panel before adding the incoming panel. Dockview then destroys the empty center group, and the fallback placement creates a nested horizontal split beside the upper-right group while Terminal remains a full-width bottom row. That malformed tree is subsequently persisted for the shared environment.
+
+The fix will add the incoming session panel at the outgoing session panel's group and tab index before stale session panels close. It will preserve same-environment layout reuse, user-customized groups, tab order, and proportions.
+
+## Frontend
+
+Likely files:
+
+- `apps/web/components/task/dockview-session-tabs.ts`
+- `apps/web/components/task/dockview-session-tabs.test.ts`
+
+Update `reconcileRemovedSessionPanels` to snapshot stale session panels and, when the incoming session belongs to the active task but is not yet mounted, call the existing session-panel creation path at the first stale panel's live group and tab index before closing any stale panels. The incoming panel should be created inactive so the existing activation policy remains authoritative.
+
+Keep the same-environment no-op in `switchEnvLayout`. Rebuilding the environment layout would discard task-specific customizations and extra environment-scoped panels. Keep the later `ensureSessionPanel` call idempotent so the normal activation, placeholder removal, ordering, and sibling-panel behavior still runs.
+
+The handoff should mirror the atomic replacement already used by `replaceStaleSessionPanels` during cross-environment restoration. If a small shared helper improves clarity without introducing a dependency cycle, reuse it; otherwise keep the session-tabs change local and behaviorally equivalent.
+
+## Tests
+
+### Unit RED
+
+Extend the session-tabs fake Dockview model so closing the last panel destroys its group, matching Dockview behavior. Add a regression test with:
+
+- an outgoing session as the only panel in `group-center`;
+- Files or Changes in `group-right-top`;
+- Terminal in `group-right-bottom`;
+- an incoming session that is current for the selected task but not yet mounted.
+
+The test must first fail by observing the center group disappear or by recording `close:outgoing` before `add:incoming`. The passing assertion will require the incoming panel to be added to `group-center` at the outgoing tab index before the stale close and require the group to remain live.
+
+Also retain existing coverage for sessionless tasks, multiple stale sessions, already-mounted incoming sessions, and activation behavior.
+
+## E2E
+
+Likely files:
+
+- `apps/web/e2e/tests/layout/saved-layout-session-isolation.spec.ts`
+- `apps/web/e2e/pages/session-page.ts` only if a reusable geometry assertion is warranted
+
+Create a parent task and a related task whose active sessions resolve to the same environment, then navigate between them through the task UI. Assert after the handoff and after reload that:
+
+- only the selected task's session panel is present;
+- the Dockview root orientation remains horizontal;
+- the right-side Files or Changes group remains above Terminal rather than Terminal becoming a full-width root row;
+- the center session group remains present;
+- the environment-scoped saved layout does not adopt the malformed vertical-root tree.
+
+The test should seed state through API helpers and perform the task switch through visible UI. It should explicitly verify that the two sessions share an environment so a fixture regression cannot turn this into a cross-environment test.
+
+## Mobile and Tablet
+
+No mobile or tablet E2E is required for this repair. `TaskLayout` renders `SessionMobileLayout` on phones and `SessionTabletLayout` on tablets; only the desktop workbench mounts Dockview and executes this session-tab reconciliation path. The existing mobile and tablet behavior remains unchanged, as required by the task-layout-profiles spec.
+
+## Implementation Waves
+
+Wave 1:
+
+- [x] [task-01-atomic-session-handoff](task-01-atomic-session-handoff.md)
+
+## Verification
+
+RED and focused unit verification:
+
+```bash
+cd apps && pnpm --filter @kandev/web test -- components/task/dockview-session-tabs.test.ts
+```
+
+Related Dockview unit verification:
+
+```bash
+cd apps && pnpm --filter @kandev/web test -- components/task/dockview-session-tabs.test.ts lib/state/dockview-env-switch-action.test.ts
+```
+
+TypeScript verification:
+
+```bash
+cd apps/web && pnpm run typecheck
+```
+
+Managed production E2E:
+
+```bash
+cd apps/web && pnpm e2e:run tests/layout/saved-layout-session-isolation.spec.ts
+```
+
+## Risks
+
+- Adding the incoming panel before stale cleanup must happen only when that session belongs to the selected task; otherwise an unhydrated or cross-task panel could be introduced.
+- The incoming panel must inherit the stale panel's exact live group and tab index, including user-created groups, rather than assuming `group-center`.
+- Creating the panel inactive is important because Files or Changes may be the user's active panel during a task switch.
+- Multiple stale session groups are already an ambiguous contaminated state. As in cross-environment restoration, only the first stale group can be re-anchored to one active session; all other stale session panels should still close.
+- Geometry assertions must inspect Dockview's tree semantics, not merely positive width and height values, because a malformed vertical root can still report valid dimensions.
+
+## Documentation Impact
+
+No public documentation changes are required. This repair restores the already-specified desktop layout persistence behavior and does not change a public command, configuration key, API, or user-facing workflow.

--- a/docs/plans/dockview-shared-environment-layout/task-01-atomic-session-handoff.md
+++ b/docs/plans/dockview-shared-environment-layout/task-01-atomic-session-handoff.md
@@ -1,0 +1,62 @@
+---
+id: "01-atomic-session-handoff"
+title: "Make shared-environment session handoff atomic"
+status: done
+wave: 1
+depends_on: []
+plan: "plan.md"
+spec: "../../specs/ui/task-layout-profiles.md"
+---
+
+# Task 01: Make Shared-Environment Session Handoff Atomic
+
+## Acceptance
+
+- Switching between tasks in the same environment adds the incoming task's session panel to the outgoing session panel's group and tab index before closing the outgoing panel.
+- Closing the outgoing task's final session panel cannot destroy the center group or change the Dockview root orientation.
+- The existing active-panel policy is preserved when Files, Changes, or another non-session panel is active.
+- Stale session panels are removed, the incoming session panel is unique, and existing cross-environment restoration behavior remains unchanged.
+- Reloading after the task switch restores the same healthy horizontal-root layout and right-column vertical split.
+
+## TDD Sequence
+
+1. RED: add a session-tabs unit regression whose fake Dockview destroys a group when its final panel closes; prove the current close-before-add ordering loses the group.
+2. RED: add a desktop Playwright regression that switches between two tasks sharing an environment and asserts the live and reloaded Dockview tree semantics.
+3. GREEN: anchor the incoming session panel in the first stale session panel's live group and tab index before stale cleanup.
+4. REFACTOR: remove any duplication that can be shared safely with cross-environment stale-session replacement, while preserving focused tests.
+
+## Verification
+
+```bash
+cd apps && pnpm --filter @kandev/web test -- components/task/dockview-session-tabs.test.ts
+cd apps && pnpm --filter @kandev/web test -- components/task/dockview-session-tabs.test.ts lib/state/dockview-env-switch-action.test.ts
+cd apps/web && pnpm run typecheck
+cd apps/web && pnpm e2e:run tests/layout/saved-layout-session-isolation.spec.ts
+```
+
+## Files likely touched
+
+- `apps/web/components/task/dockview-session-tabs.ts`
+- `apps/web/components/task/dockview-session-tabs.test.ts`
+- `apps/web/e2e/tests/layout/saved-layout-session-isolation.spec.ts`
+- `apps/web/e2e/pages/session-page.ts` if the tree assertion belongs in the shared page object
+
+## Dependencies
+
+None.
+
+## Inputs
+
+- `docs/specs/ui/task-layout-profiles.md`, especially `Persistence guarantees` and the shared-environment task-switch scenario.
+- The atomic stale-session replacement in `apps/web/lib/state/dockview-env-switch.ts`.
+- The existing same-environment early return in `apps/web/lib/state/dockview-store.ts`.
+
+## Output contract
+
+Report the exact failing regression, the panel event order before and after the repair, files changed, unit/typecheck/E2E command results, and any remaining ambiguity for layouts contaminated with stale sessions in multiple groups.
+
+## Result
+
+- RED proved that the prior handoff emitted only `close:session:outgoing`, removed `group-center`, and left no incoming session panel.
+- GREEN emits `add:session:incoming` before the outgoing close, preserves `group-center`, and retains the right-side Files or Changes above Terminal split.
+- Focused unit tests, TypeScript typecheck, and the production-build Chromium regression passed on 2026-07-27.

--- a/docs/specs/ui/task-layout-profiles.md
+++ b/docs/specs/ui/task-layout-profiles.md
@@ -22,6 +22,7 @@ Users can arrange and save the desktop task workbench only while a task is open,
 - Removing Terminal from the effective default prevents the default terminal panel and its backing user shell from being created when a fresh task environment is first opened.
 - Applying a layout preserves every configured reusable panel regardless of whether the task has repositories. Panels without applicable content remain available and show their normal empty state.
 - A changed default applies to task environments that have no saved task-specific layout and to an explicit Reset Layout action. It does not overwrite an existing task-specific layout merely because the setting changed.
+- Switching between tasks whose sessions share one task environment atomically replaces task-owned Agent tabs in their existing group. The handoff preserves the live split tree and proportions instead of briefly emptying the group or rebuilding the environment layout.
 - The existing workbench layout menu continues to apply built-in and custom profiles and save the current workbench as a custom profile. Profile mutations from either surface remain consistent after the user-settings response is received.
 - Layout-profile editing is usable with pointer, keyboard, and touch input. On narrow settings viewports, profile management and all editor commands remain reachable without horizontal page scrolling.
 - Layout profiles configure the desktop Dockview workbench only. Mobile and tablet task-detail layouts retain their existing behavior.
@@ -69,6 +70,7 @@ The frontend treats the returned settings payload as authoritative after each su
 - Custom profiles and the selected custom default survive browser and Kandev restarts through backend user settings and are portable across the user's devices.
 - An unsaved editor draft does not survive navigation or restart.
 - Per-task layout state continues to use its existing environment-scoped persistence and is not made portable by this feature.
+- A task handoff within the same environment does not persist an intermediate panel-removal state or change the root split orientation.
 
 ## Scenarios
 
@@ -80,6 +82,7 @@ The frontend treats the returned settings payload as authoritative after each su
 - **GIVEN** a default profile without Terminal and a task environment with no saved layout, **WHEN** the user first opens that task, **THEN** the workbench has no Terminal tab and no default user shell is created.
 - **GIVEN** an existing task with a task-specific layout, **WHEN** the user changes the default profile and returns to that task, **THEN** the task-specific layout is unchanged.
 - **GIVEN** an existing task with a task-specific layout, **WHEN** the user chooses Reset Layout, **THEN** the latest effective default profile replaces that task's layout.
+- **GIVEN** two tasks whose active sessions share one task environment and a desktop workbench with Agent in the center and Files or Changes above Terminal on the right, **WHEN** the user switches between those tasks, **THEN** the incoming Agent replaces the outgoing Agent in the same group, the right column remains vertically split, the root remains horizontally split, and the same geometry survives reload.
 - **GIVEN** a custom default profile, **WHEN** the user deletes it and confirms, **THEN** the built-in Default becomes effective.
 - **GIVEN** a profile draft with Agent removed, duplicate reusable panels, or an empty group, **WHEN** the user attempts to save, **THEN** saving is blocked and the invalid locations are identified.
 - **GIVEN** a backend save failure, **WHEN** the user saves a profile edit, **THEN** the draft remains available and the previous persisted layout stays selected.


### PR DESCRIPTION
The Dockview task handoff used to close the outgoing session before mounting the incoming one, allowing Dockview to destroy the center group and persist a malformed split tree. The handoff now replaces sessions atomically in the existing group, preserving task layout geometry across same-environment switches.

## Important Changes

- Anchor incoming session panels at the outgoing panel's live group and tab index before stale cleanup.
- Add regression coverage for Dockview group destruction/order and desktop task switching with reload persistence.
- Keep same-environment layout reuse and mobile/tablet compositions unchanged.

## Validation

- `cd apps && pnpm --filter @kandev/web test -- components/task/dockview-session-tabs.test.ts lib/state/dockview-env-switch-action.test.ts` (42 tests passed)
- `cd apps/web && pnpm run typecheck`
- `cd apps/web && pnpm e2e:run tests/layout/saved-layout-session-isolation.spec.ts -- --grep "keeps the desktop split tree"` (1 passed)
- Pre-commit hooks passed: harness lint, Prettier, and web lint; Go hooks skipped because no Go files changed.
- Public docs are unaffected; no `docs/public/**` changes were needed.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.

## Screenshots

![Desktop Dockview layout](https://raw.githubusercontent.com/kdlbs/kandev/3f1a3737c2fac547fc845e685662b89f8592b08d/desktop-dockview.png)

![Mobile task layout](https://raw.githubusercontent.com/kdlbs/kandev/3f1a3737c2fac547fc845e685662b89f8592b08d/mobile-dockview.png)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1989?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->