### PR TITLE
feat(web): streamline mobile review file headers

### DIFF
--- a/apps/web/components/editors/external-vcs-file-link.tsx
+++ b/apps/web/components/editors/external-vcs-file-link.tsx
@@ -2,6 +2,7 @@
 
 import { IconBrandGithub, IconBrandGitlab } from "@tabler/icons-react";
 import { Button } from "@kandev/ui/button";
+import { DropdownMenuItem } from "@kandev/ui/dropdown-menu";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
 import { AzureDevOpsIcon } from "@/components/icons/azure-devops-icon";
 import { useExternalVcsFileLink } from "@/hooks/domains/workspace/use-external-vcs-file-link";
@@ -15,6 +16,8 @@ import type { ExternalVcsProvider } from "@/lib/utils/external-vcs-file-url";
 export type ExternalVcsFileLinkProps = UseExternalVcsFileLinkInput & {
   size?: "xs" | "sm" | "touch";
 };
+
+export type ExternalVcsFileMenuItemProps = UseExternalVcsFileLinkInput;
 
 const providerNames: Record<ExternalVcsProvider, string> = {
   github: "GitHub",
@@ -62,11 +65,15 @@ export function useExternalVcsFileStatus(
   return status?.files?.[filePath];
 }
 
+function externalLinkLabel(provider: ExternalVcsProvider): string {
+  return `Open file in ${providerNames[provider]}`;
+}
+
 export function ExternalVcsFileLink({ size = "xs", ...input }: ExternalVcsFileLinkProps) {
   const link = useExternalVcsFileLink(input);
   if (!link) return null;
 
-  const label = `Open file in ${providerNames[link.provider]}`;
+  const label = externalLinkLabel(link.provider);
   return (
     <Tooltip>
       <TooltipTrigger asChild>
@@ -84,5 +91,20 @@ export function ExternalVcsFileLink({ size = "xs", ...input }: ExternalVcsFileLi
       </TooltipTrigger>
       <TooltipContent>{label}</TooltipContent>
     </Tooltip>
+  );
+}
+
+export function ExternalVcsFileMenuItem(input: ExternalVcsFileMenuItemProps) {
+  const link = useExternalVcsFileLink(input);
+  if (!link) return null;
+
+  const label = externalLinkLabel(link.provider);
+  return (
+    <DropdownMenuItem asChild className="cursor-pointer">
+      <a href={link.url} target="_blank" rel="noopener noreferrer" aria-label={label} title={label}>
+        <ProviderIcon provider={link.provider} />
+        <span>{label}</span>
+      </a>
+    </DropdownMenuItem>
   );
 }

--- a/apps/web/components/editors/file-actions-dropdown.tsx
+++ b/apps/web/components/editors/file-actions-dropdown.tsx
@@ -23,17 +23,29 @@ type FileActionsDropdownProps = {
   /** Session ID override — defaults to activeSessionId from store */
   sessionId?: string;
   /** Button size variant */
-  size?: "sm" | "xs";
+  size?: "sm" | "xs" | "touch";
   /** Optional toast callback after copy */
   onCopied?: () => void;
 };
 
-export function FileActionsDropdown({
+type FileActionsMenuItemsProps = Pick<
+  FileActionsDropdownProps,
+  "filePath" | "sessionId" | "onCopied"
+>;
+
+function fileActionsButtonClass(size: NonNullable<FileActionsDropdownProps["size"]>): string {
+  if (size === "xs") return "h-6 w-6 p-0 cursor-pointer opacity-60 hover:opacity-100";
+  if (size === "touch") {
+    return "size-11 p-0 cursor-pointer text-muted-foreground hover:text-foreground transition-[scale,color,background-color] active:scale-[0.96]";
+  }
+  return "h-8 w-8 p-0 cursor-pointer text-muted-foreground hover:text-foreground";
+}
+
+function useFileActions({
   filePath,
   sessionId: sessionIdProp,
-  size = "xs",
   onCopied,
-}: FileActionsDropdownProps) {
+}: FileActionsMenuItemsProps) {
   const storeSessionId = useAppStore((state) => state.tasks.activeSessionId);
   const sessionId = sessionIdProp ?? storeSessionId ?? null;
   const worktreePath = useAppStore((state) => {
@@ -80,11 +92,59 @@ export function FileActionsDropdown({
     void openFolder.open();
   }, [openFolder]);
 
-  const btnClass =
-    size === "xs"
-      ? "h-6 w-6 p-0 cursor-pointer opacity-60 hover:opacity-100"
-      : "h-8 w-8 p-0 cursor-pointer";
+  return {
+    defaultEditorId,
+    enabledEditors,
+    handleCopyPath,
+    handleOpenFolder,
+    handleOpenInEditor,
+  };
+}
 
+export function FileActionsMenuItems(props: FileActionsMenuItemsProps) {
+  const { defaultEditorId, enabledEditors, handleCopyPath, handleOpenFolder, handleOpenInEditor } =
+    useFileActions(props);
+
+  return (
+    <>
+      {enabledEditors.map((editor: EditorOption) => (
+        <DropdownMenuItem
+          key={editor.id}
+          className="cursor-pointer text-xs"
+          onSelect={() => handleOpenInEditor(editor.id)}
+        >
+          <IconExternalLink className="h-3.5 w-3.5" />
+          {editor.name}
+          {editor.id === defaultEditorId && (
+            <span className="ml-auto text-[10px] text-muted-foreground">default</span>
+          )}
+        </DropdownMenuItem>
+      ))}
+      {enabledEditors.length === 0 && (
+        <DropdownMenuItem disabled className="text-xs">
+          No editors configured
+        </DropdownMenuItem>
+      )}
+      <DropdownMenuSeparator />
+      <DropdownMenuItem className="cursor-pointer text-xs" onSelect={handleCopyPath}>
+        <IconCopy className="h-3.5 w-3.5" />
+        Copy path
+      </DropdownMenuItem>
+      <DropdownMenuItem className="cursor-pointer text-xs" onSelect={handleOpenFolder}>
+        <IconFolderShare className="h-3.5 w-3.5" />
+        Open folder
+      </DropdownMenuItem>
+    </>
+  );
+}
+
+export function FileActionsDropdown({
+  filePath,
+  sessionId,
+  size = "xs",
+  onCopied,
+}: FileActionsDropdownProps) {
+  const btnClass = fileActionsButtonClass(size);
   const iconClass = size === "xs" ? "h-3.5 w-3.5" : "h-4 w-4";
 
   return (
@@ -100,32 +160,7 @@ export function FileActionsDropdown({
         <TooltipContent>Open with...</TooltipContent>
       </Tooltip>
       <DropdownMenuContent align="end" className="w-44">
-        {enabledEditors.map((editor: EditorOption) => (
-          <DropdownMenuItem
-            key={editor.id}
-            className="cursor-pointer text-xs"
-            onClick={() => handleOpenInEditor(editor.id)}
-          >
-            {editor.name}
-            {editor.id === defaultEditorId && (
-              <span className="ml-auto text-[10px] text-muted-foreground">default</span>
-            )}
-          </DropdownMenuItem>
-        ))}
-        {enabledEditors.length === 0 && (
-          <DropdownMenuItem disabled className="text-xs">
-            No editors configured
-          </DropdownMenuItem>
-        )}
-        <DropdownMenuSeparator />
-        <DropdownMenuItem className="cursor-pointer text-xs" onClick={handleCopyPath}>
-          <IconCopy className="h-3.5 w-3.5 mr-1.5" />
-          Copy path
-        </DropdownMenuItem>
-        <DropdownMenuItem className="cursor-pointer text-xs" onClick={handleOpenFolder}>
-          <IconFolderShare className="h-3.5 w-3.5 mr-1.5" />
-          Open folder
-        </DropdownMenuItem>
+        <FileActionsMenuItems filePath={filePath} sessionId={sessionId} onCopied={onCopied} />
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/apps/web/components/review/review-diff-header.test.tsx
+++ b/apps/web/components/review/review-diff-header.test.tsx
@@ -2,15 +2,27 @@ import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ReviewFile } from "./types";
 
+const mocks = vi.hoisted(() => ({ isMobile: false }));
+
 vi.mock("./review-diff-toolbar", () => ({
   FileDiffToolbar: (props: Record<string, unknown>) => (
     <span data-testid="review-toolbar-props" data-props={JSON.stringify(props)} />
   ),
 }));
 
+vi.mock("@/hooks/use-responsive-breakpoint", () => ({
+  useResponsiveBreakpoint: () => ({ isMobile: mocks.isMobile }),
+}));
+
 import { ReviewDiffHeader } from "./review-diff-header";
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  mocks.isMobile = false;
+});
+
+const SESSION_ID = "session-1";
+const TOOLBAR_PROPS_TEST_ID = "review-toolbar-props";
 
 const file: ReviewFile = {
   path: "src/app.ts",
@@ -31,7 +43,7 @@ describe("ReviewDiffHeader external context", () => {
         file={file}
         isReviewed={false}
         isStale={false}
-        sessionId="session-1"
+        sessionId={SESSION_ID}
         collapsed={false}
         wordWrap={false}
         expandUnchanged={false}
@@ -47,7 +59,7 @@ describe("ReviewDiffHeader external context", () => {
       />,
     );
 
-    const props = JSON.parse(screen.getByTestId("review-toolbar-props").dataset.props ?? "{}");
+    const props = JSON.parse(screen.getByTestId(TOOLBAR_PROPS_TEST_ID).dataset.props ?? "{}");
     expect(props).toMatchObject({
       filePath: "src/app.ts",
       repositoryId: "repo-2",
@@ -64,7 +76,7 @@ describe("ReviewDiffHeader external context", () => {
         file={file}
         isReviewed={false}
         isStale={false}
-        sessionId="session-1"
+        sessionId={SESSION_ID}
         collapsed={false}
         wordWrap={false}
         expandUnchanged={false}
@@ -79,7 +91,7 @@ describe("ReviewDiffHeader external context", () => {
       />,
     );
 
-    const props = JSON.parse(screen.getByTestId("review-toolbar-props").dataset.props ?? "{}");
+    const props = JSON.parse(screen.getByTestId(TOOLBAR_PROPS_TEST_ID).dataset.props ?? "{}");
     expect(props).not.toHaveProperty("publishedBranch");
     expect(props).not.toHaveProperty("publishedPullRequestNumber");
   });
@@ -90,7 +102,7 @@ describe("ReviewDiffHeader external context", () => {
         file={{ ...file, repository_id: "repo-1" }}
         isReviewed={false}
         isStale={false}
-        sessionId="session-1"
+        sessionId={SESSION_ID}
         collapsed={false}
         wordWrap={false}
         expandUnchanged={false}
@@ -106,10 +118,68 @@ describe("ReviewDiffHeader external context", () => {
       />,
     );
 
-    const props = JSON.parse(screen.getByTestId("review-toolbar-props").dataset.props ?? "{}");
+    const props = JSON.parse(screen.getByTestId(TOOLBAR_PROPS_TEST_ID).dataset.props ?? "{}");
     expect(props).toMatchObject({
       publishedBranch: "contributor:feature/share",
     });
     expect(props).not.toHaveProperty("publishedPullRequestNumber");
+  });
+});
+
+describe("ReviewDiffHeader responsive composition", () => {
+  it("uses one compact mobile header with the toolbar embedded as the overflow trigger", () => {
+    mocks.isMobile = true;
+    render(
+      <ReviewDiffHeader
+        file={{
+          ...file,
+          path: "packages/frontend/review/deeply/nested/mobile-file-bar.tsx",
+        }}
+        isReviewed={false}
+        isStale={false}
+        sessionId={SESSION_ID}
+        collapsed={false}
+        wordWrap={false}
+        expandUnchanged={false}
+        baseBranchByRepo={{ frontend: "main" }}
+        onCheckboxChange={vi.fn()}
+        onDiscard={vi.fn()}
+        onToggleCollapse={vi.fn()}
+        onToggleExpandUnchanged={vi.fn()}
+        onToggleWordWrap={vi.fn()}
+      />,
+    );
+
+    const identity = screen.getByTestId("review-file-identity");
+    const toolbar = screen.getByTestId(TOOLBAR_PROPS_TEST_ID);
+    expect(identity.contains(toolbar)).toBe(true);
+    expect(screen.queryByTestId("review-file-actions")).toBeNull();
+    expect(screen.getByText("mobile-file-bar.tsx")).toBeTruthy();
+    expect(document.querySelector("[data-review-file-directory]")?.textContent).toBe(
+      "packages/frontend/review/deeply/nested",
+    );
+  });
+
+  it("keeps the desktop toolbar in its existing inline actions slot", () => {
+    render(
+      <ReviewDiffHeader
+        file={file}
+        isReviewed={false}
+        isStale={false}
+        sessionId={SESSION_ID}
+        collapsed={false}
+        wordWrap={false}
+        expandUnchanged={false}
+        baseBranchByRepo={{ frontend: "main" }}
+        onCheckboxChange={vi.fn()}
+        onDiscard={vi.fn()}
+        onToggleCollapse={vi.fn()}
+        onToggleExpandUnchanged={vi.fn()}
+        onToggleWordWrap={vi.fn()}
+      />,
+    );
+
+    const actions = screen.getByTestId("review-file-actions");
+    expect(actions.contains(screen.getByTestId(TOOLBAR_PROPS_TEST_ID))).toBe(true);
   });
 });

--- a/apps/web/components/review/review-diff-header.tsx
+++ b/apps/web/components/review/review-diff-header.tsx
@@ -1,8 +1,11 @@
 "use client";
 
+import type { ReactNode } from "react";
 import { IconAlertTriangle, IconChevronDown, IconChevronRight } from "@tabler/icons-react";
 import { Checkbox } from "@kandev/ui/checkbox";
 import { FileStatusIcon } from "@/components/shared/file-status-icon";
+import { useResponsiveBreakpoint } from "@/hooks/use-responsive-breakpoint";
+import { cn } from "@/lib/utils";
 import type { ReviewFile } from "./types";
 import { FileDiffToolbar } from "./review-diff-toolbar";
 
@@ -31,6 +34,203 @@ type ReviewDiffHeaderProps = ReviewExternalLinkContext & {
   onToggleWordWrap: () => void;
 };
 
+function splitFilePath(filePath: string): { directory: string; name: string } {
+  const lastSlash = filePath.lastIndexOf("/");
+  if (lastSlash === -1) return { directory: "", name: filePath };
+  return {
+    directory: filePath.slice(0, lastSlash),
+    name: filePath.slice(lastSlash + 1),
+  };
+}
+
+function ReviewDiffStats({ file, compact = false }: { file: ReviewFile; compact?: boolean }) {
+  return (
+    <span
+      className={cn(
+        "shrink-0 whitespace-nowrap tabular-nums text-muted-foreground",
+        compact ? "text-[11px]" : "text-xs",
+      )}
+    >
+      {file.additions > 0 && <span className="text-emerald-500">+{file.additions}</span>}
+      {file.additions > 0 && file.deletions > 0 && " / "}
+      {file.deletions > 0 && <span className="text-rose-500">-{file.deletions}</span>}
+    </span>
+  );
+}
+
+function StaleIndicator({ compact = false }: { compact?: boolean }) {
+  return (
+    <span
+      className={cn(
+        "flex shrink-0 items-center gap-1 text-yellow-500",
+        compact ? "text-[11px]" : "text-xs",
+      )}
+    >
+      <IconAlertTriangle className="size-3.5" />
+      changed
+    </span>
+  );
+}
+
+function DesktopReviewFilePath({ path }: { path: string }) {
+  const { directory, name } = splitFilePath(path);
+  return (
+    <span
+      className="flex min-w-0 flex-1 items-baseline overflow-hidden text-[13px] font-medium"
+      title={path}
+    >
+      {directory && (
+        <>
+          <span
+            aria-hidden="true"
+            className="min-w-0 truncate text-muted-foreground [direction:rtl] [unicode-bidi:isolate]"
+          >
+            {directory}
+          </span>
+          <span aria-hidden="true" className="shrink-0 text-muted-foreground">
+            /
+          </span>
+        </>
+      )}
+      <span data-review-file-name className="max-w-full shrink-0 truncate">
+        {name}
+      </span>
+    </span>
+  );
+}
+
+function MobileReviewFileDetails({ file, isStale }: { file: ReviewFile; isStale: boolean }) {
+  const { directory, name } = splitFilePath(file.path);
+  return (
+    <span
+      className="flex min-w-0 flex-1 flex-col justify-center overflow-hidden text-left leading-none"
+      title={file.path}
+    >
+      <span data-review-file-name className="truncate text-[13px] font-medium leading-4">
+        {name}
+      </span>
+      <span className="flex min-w-0 items-center gap-1 leading-4">
+        {directory && (
+          <span
+            aria-hidden="true"
+            data-review-file-directory
+            className="min-w-0 flex-1 truncate text-[11px] text-muted-foreground [direction:rtl] [unicode-bidi:isolate]"
+          >
+            {directory}
+          </span>
+        )}
+        <FileStatusIcon
+          status={file.status}
+          oldPath={file.old_path}
+          className="size-3.5 shrink-0"
+        />
+        {isStale && <StaleIndicator compact />}
+        <ReviewDiffStats file={file} compact />
+      </span>
+    </span>
+  );
+}
+
+function MobileReviewCheckbox({
+  checked,
+  onCheckedChange,
+}: {
+  checked: boolean;
+  onCheckedChange: ReviewDiffHeaderProps["onCheckboxChange"];
+}) {
+  return (
+    <span className="flex size-10 shrink-0 items-center justify-center">
+      <Checkbox
+        checked={checked}
+        onCheckedChange={onCheckedChange}
+        className="relative size-4 cursor-pointer after:absolute after:left-1/2 after:top-1/2 after:size-10 after:-translate-x-1/2 after:-translate-y-1/2 after:content-['']"
+      />
+    </span>
+  );
+}
+
+type ResponsiveHeaderIdentityProps = Pick<
+  ReviewDiffHeaderProps,
+  "file" | "isReviewed" | "isStale" | "collapsed" | "onCheckboxChange" | "onToggleCollapse"
+> & {
+  toolbar: ReactNode;
+};
+
+function MobileHeaderIdentity({
+  file,
+  isReviewed,
+  isStale,
+  collapsed,
+  onCheckboxChange,
+  onToggleCollapse,
+  toolbar,
+}: ResponsiveHeaderIdentityProps) {
+  return (
+    <div
+      data-testid="review-file-identity"
+      className="flex min-h-14 w-full min-w-0 items-center gap-1 px-2"
+    >
+      <MobileReviewCheckbox checked={isReviewed} onCheckedChange={onCheckboxChange} />
+      <button
+        type="button"
+        aria-expanded={!collapsed}
+        aria-label={`${collapsed ? "Expand" : "Collapse"} ${file.path}`}
+        onClick={onToggleCollapse}
+        className="flex min-h-11 min-w-0 flex-1 cursor-pointer items-center gap-1.5 text-left transition-colors duration-150 ease-out hover:text-foreground"
+      >
+        {collapsed ? (
+          <IconChevronRight className="size-3.5 shrink-0 text-muted-foreground" />
+        ) : (
+          <IconChevronDown className="size-3.5 shrink-0 text-muted-foreground" />
+        )}
+        <MobileReviewFileDetails file={file} isStale={isStale} />
+      </button>
+      {toolbar}
+    </div>
+  );
+}
+
+function DesktopHeaderIdentity({
+  file,
+  isReviewed,
+  isStale,
+  collapsed,
+  onCheckboxChange,
+  onToggleCollapse,
+  toolbar,
+}: ResponsiveHeaderIdentityProps) {
+  return (
+    <>
+      <div data-testid="review-file-identity" className="flex min-w-0 flex-1 items-center gap-2">
+        <Checkbox
+          checked={isReviewed}
+          onCheckedChange={onCheckboxChange}
+          className="size-4 cursor-pointer"
+        />
+        <button
+          type="button"
+          aria-expanded={!collapsed}
+          aria-label={`${collapsed ? "Expand" : "Collapse"} ${file.path}`}
+          onClick={onToggleCollapse}
+          className="flex min-w-0 flex-1 cursor-pointer items-center gap-1.5 text-left hover:text-foreground"
+        >
+          {collapsed ? (
+            <IconChevronRight className="size-3.5 shrink-0 text-muted-foreground" />
+          ) : (
+            <IconChevronDown className="size-3.5 shrink-0 text-muted-foreground" />
+          )}
+          <DesktopReviewFilePath path={file.path} />
+        </button>
+        {isStale && <StaleIndicator />}
+        <ReviewDiffStats file={file} />
+      </div>
+      <div data-testid="review-file-actions" className="flex items-center">
+        {toolbar}
+      </div>
+    </>
+  );
+}
+
 export function ReviewDiffHeader({
   file,
   isReviewed,
@@ -52,67 +252,66 @@ export function ReviewDiffHeader({
   publishedPRBranch,
   publishedPRRepositoryId,
 }: ReviewDiffHeaderProps) {
+  const { isMobile } = useResponsiveBreakpoint();
   const hasPublishedPR =
     file.source === "pr" && (!file.repository_id || file.repository_id === publishedPRRepositoryId);
   const publishedBranch = hasPublishedPR ? publishedPRBranch : undefined;
   const baseBranch =
     baseBranchByRepo[file.repository_name ?? ""] ??
     (file.repository_name ? undefined : fallbackBaseBranch);
+  const toolbar = (
+    <FileDiffToolbar
+      diff={file.diff}
+      filePath={file.path}
+      sessionId={sessionId}
+      source={file.source}
+      previousPath={file.old_path}
+      status={file.status}
+      taskId={taskId}
+      repositoryId={file.repository_id}
+      publishedBranch={publishedBranch}
+      baseBranch={baseBranch}
+      wordWrap={wordWrap}
+      expandUnchanged={expandUnchanged}
+      onDiscard={onDiscard}
+      onOpenFile={onOpenFile}
+      onPreviewMarkdown={onPreviewMarkdown}
+      onToggleExpandUnchanged={onToggleExpandUnchanged}
+      onToggleWordWrap={onToggleWordWrap}
+      repo={file.repository_name}
+    />
+  );
 
   return (
     <div
       data-testid="review-file-header"
       data-file-path={file.path}
-      className="sticky top-0 z-10 flex items-center gap-2 px-4 py-2 bg-card/95 backdrop-blur-sm border-b border-border/50"
-    >
-      <Checkbox
-        checked={isReviewed}
-        onCheckedChange={onCheckboxChange}
-        className="h-4 w-4 cursor-pointer"
-      />
-      <button
-        onClick={onToggleCollapse}
-        className="flex items-center gap-1.5 flex-1 min-w-0 cursor-pointer text-left hover:text-foreground"
-      >
-        {collapsed ? (
-          <IconChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-        ) : (
-          <IconChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-        )}
-        <span className="text-[13px] font-medium truncate">{file.path}</span>
-      </button>
-      <FileStatusIcon status={file.status} oldPath={file.old_path} className="sm:hidden" />
-      {isStale && (
-        <span className="flex items-center gap-1 text-xs text-yellow-500">
-          <IconAlertTriangle className="h-3.5 w-3.5" />
-          changed
-        </span>
+      className={cn(
+        "sticky top-0 z-10 border-b border-border/50 bg-card/95 backdrop-blur-sm",
+        !isMobile && "flex items-center gap-2 px-4 py-2",
       )}
-      <span className="text-xs text-muted-foreground">
-        {file.additions > 0 && <span className="text-emerald-500">+{file.additions}</span>}
-        {file.additions > 0 && file.deletions > 0 && " / "}
-        {file.deletions > 0 && <span className="text-rose-500">-{file.deletions}</span>}
-      </span>
-      <FileDiffToolbar
-        diff={file.diff}
-        filePath={file.path}
-        sessionId={sessionId}
-        source={file.source}
-        previousPath={file.old_path}
-        status={file.status}
-        taskId={taskId}
-        repositoryId={file.repository_id}
-        publishedBranch={publishedBranch}
-        baseBranch={baseBranch}
-        wordWrap={wordWrap}
-        expandUnchanged={expandUnchanged}
-        onDiscard={onDiscard}
-        onOpenFile={onOpenFile}
-        onPreviewMarkdown={onPreviewMarkdown}
-        onToggleExpandUnchanged={onToggleExpandUnchanged}
-        onToggleWordWrap={onToggleWordWrap}
-        repo={file.repository_name}
-      />
+    >
+      {isMobile ? (
+        <MobileHeaderIdentity
+          file={file}
+          isReviewed={isReviewed}
+          isStale={isStale}
+          collapsed={collapsed}
+          onCheckboxChange={onCheckboxChange}
+          onToggleCollapse={onToggleCollapse}
+          toolbar={toolbar}
+        />
+      ) : (
+        <DesktopHeaderIdentity
+          file={file}
+          isReviewed={isReviewed}
+          isStale={isStale}
+          collapsed={collapsed}
+          onCheckboxChange={onCheckboxChange}
+          onToggleCollapse={onToggleCollapse}
+          toolbar={toolbar}
+        />
+      )}
     </div>
   );
 }

--- a/apps/web/components/review/review-diff-list-grouping.test.tsx
+++ b/apps/web/components/review/review-diff-list-grouping.test.tsx
@@ -4,6 +4,8 @@ import { createRef, type ReactNode } from "react";
 import { TooltipProvider } from "@kandev/ui/tooltip";
 import type { ReviewFile } from "./types";
 
+const mocks = vi.hoisted(() => ({ isMobile: false }));
+
 // FileDiffViewer is heavy and irrelevant to the grouping test — stub it.
 vi.mock("@/components/diff", () => ({
   FileDiffViewer: ({ filePath }: { filePath: string }) => (
@@ -14,12 +16,18 @@ vi.mock("@/components/diff", () => ({
 
 vi.mock("@/components/editors/file-actions-dropdown", () => ({
   FileActionsDropdown: () => null,
+  FileActionsMenuItems: () => null,
 }));
 
 // External link resolution is unrelated to grouping and requires a fully
 // hydrated repository store, which this focused test intentionally omits.
 vi.mock("@/components/editors/external-vcs-file-link", () => ({
   ExternalVcsFileLink: () => null,
+  ExternalVcsFileMenuItem: () => null,
+}));
+
+vi.mock("@/hooks/use-responsive-breakpoint", () => ({
+  useResponsiveBreakpoint: () => ({ isMobile: mocks.isMobile }),
 }));
 
 vi.mock("@/lib/ws/connection", () => ({ getWebSocketClient: () => null }));
@@ -42,7 +50,10 @@ vi.mock("@/components/toast-provider", () => ({
 
 import { ReviewDiffList } from "./review-diff-list";
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  mocks.isMobile = false;
+});
 
 function file(path: string, repo?: string): ReviewFile {
   return {
@@ -144,6 +155,7 @@ describe("ReviewDiffList — multi-repo grouping", () => {
 
 describe("ReviewDiffList — file status rendering", () => {
   it("shows moved status in the mobile header and honest copy for a patchless rename", () => {
+    mocks.isMobile = true;
     const movedFile = {
       ...file("new-name.ts"),
       diff: "",
@@ -153,7 +165,7 @@ describe("ReviewDiffList — file status rendering", () => {
     renderSingleFile(movedFile);
 
     const marker = screen.getByRole("img", { name: "Moved from old-name.ts" });
-    expect(marker.className).toContain("sm:hidden");
+    expect(marker.className).toContain("size-3.5");
     expect(screen.getByText("Moved from old-name.ts; no textual changes")).toBeTruthy();
   });
 

--- a/apps/web/components/review/review-diff-toolbar.test.tsx
+++ b/apps/web/components/review/review-diff-toolbar.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { TooltipProvider } from "@kandev/ui/tooltip";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -8,10 +8,14 @@ vi.mock("@/components/editors/external-vcs-file-link", () => ({
   ExternalVcsFileLink: (props: Record<string, unknown>) => (
     <span data-testid="external-vcs-file-link-props" data-props={JSON.stringify(props)} />
   ),
+  ExternalVcsFileMenuItem: (props: Record<string, unknown>) => (
+    <span data-testid="external-vcs-file-menu-item-props" data-props={JSON.stringify(props)} />
+  ),
 }));
 
 vi.mock("@/components/editors/file-actions-dropdown", () => ({
   FileActionsDropdown: () => <span data-testid="file-actions-dropdown" />,
+  FileActionsMenuItems: () => <span data-testid="file-actions-menu-items" />,
 }));
 
 vi.mock("@/hooks/use-global-view-mode", () => ({
@@ -71,10 +75,14 @@ describe("FileDiffToolbar", () => {
       size: "xs",
     });
     expect(screen.getByTestId("file-actions-dropdown")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Copy diff" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /More actions for/ })).toBeNull();
   });
 
-  it("uses the 44px touch action in the mobile diff drawer", () => {
+  it("replaces the mobile icon strip with one labelled actions menu", () => {
     mocks.isMobile = true;
+    const onToggleExpandUnchanged = vi.fn();
+    const onToggleWordWrap = vi.fn();
     render(
       <TooltipProvider>
         <FileDiffToolbar
@@ -85,12 +93,32 @@ describe("FileDiffToolbar", () => {
           wordWrap={false}
           expandUnchanged={false}
           onDiscard={vi.fn()}
-          onToggleExpandUnchanged={vi.fn()}
-          onToggleWordWrap={vi.fn()}
+          onToggleExpandUnchanged={onToggleExpandUnchanged}
+          onToggleWordWrap={onToggleWordWrap}
         />
       </TooltipProvider>,
     );
 
-    expect(externalLinkProps().size).toBe("touch");
+    expect(screen.queryByRole("button", { name: "Copy diff" })).toBeNull();
+    expect(screen.queryByTestId("file-actions-dropdown")).toBeNull();
+
+    const trigger = screen.getByRole("button", { name: "More actions for src/app.ts" });
+    expect(trigger.className).toContain("size-11");
+    fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false });
+    fireEvent.click(trigger);
+
+    const menu = screen.getByTestId("review-file-actions-menu");
+    expect(menu).toBeTruthy();
+    expect(screen.getByRole("menuitem", { name: "Copy diff" })).toBeTruthy();
+    const expand = screen.getByRole("menuitemcheckbox", { name: "Expand unchanged lines" });
+    const wrap = screen.getByRole("menuitemcheckbox", { name: "Wrap long lines" });
+    expect(expand.getAttribute("aria-checked")).toBe("false");
+    expect(wrap.getAttribute("aria-checked")).toBe("false");
+    expect(screen.queryByRole("menuitem", { name: /Switch to unified view/ })).toBeNull();
+    expect(screen.getByTestId("external-vcs-file-menu-item-props")).toBeTruthy();
+    expect(screen.getByTestId("file-actions-menu-items")).toBeTruthy();
+
+    fireEvent.click(expand);
+    expect(onToggleExpandUnchanged).toHaveBeenCalledOnce();
   });
 });

--- a/apps/web/components/review/review-diff-toolbar.test.tsx
+++ b/apps/web/components/review/review-diff-toolbar.test.tsx
@@ -118,7 +118,13 @@ describe("FileDiffToolbar", () => {
     expect(screen.getByTestId("external-vcs-file-menu-item-props")).toBeTruthy();
     expect(screen.getByTestId("file-actions-menu-items")).toBeTruthy();
 
-    fireEvent.click(expand);
+    fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false });
+    fireEvent.click(trigger);
+    expect(screen.queryByTestId("review-file-actions-menu")).toBeNull();
+
+    fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false });
+    fireEvent.click(trigger);
+    fireEvent.click(screen.getByRole("menuitemcheckbox", { name: "Expand unchanged lines" }));
     expect(onToggleExpandUnchanged).toHaveBeenCalledOnce();
   });
 });

--- a/apps/web/components/review/review-diff-toolbar.tsx
+++ b/apps/web/components/review/review-diff-toolbar.tsx
@@ -221,7 +221,7 @@ function MobileFileActionsMenu(props: FileDiffToolbarProps) {
           title={`More actions for ${filePath}`}
           className="size-11 shrink-0 cursor-pointer text-muted-foreground transition-[scale,color,background-color] duration-150 ease-out active:scale-[0.96]"
           onPointerDown={(event) => event.preventDefault()}
-          onClick={() => setOpen(true)}
+          onClick={() => setOpen((previous) => !previous)}
         >
           <IconDots className="size-4" />
         </Button>

--- a/apps/web/components/review/review-diff-toolbar.tsx
+++ b/apps/web/components/review/review-diff-toolbar.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 import {
   IconArrowBackUp,
   IconCopy,
+  IconDots,
   IconEye,
   IconFold,
   IconFoldDown,
@@ -13,14 +14,33 @@ import {
   IconTextWrap,
 } from "@tabler/icons-react";
 import { Button } from "@kandev/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@kandev/ui/dropdown-menu";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
-import { FileActionsDropdown } from "@/components/editors/file-actions-dropdown";
-import { ExternalVcsFileLink } from "@/components/editors/external-vcs-file-link";
+import {
+  FileActionsDropdown,
+  FileActionsMenuItems,
+} from "@/components/editors/file-actions-dropdown";
+import {
+  ExternalVcsFileLink,
+  ExternalVcsFileMenuItem,
+} from "@/components/editors/external-vcs-file-link";
 import { useGlobalViewMode } from "@/hooks/use-global-view-mode";
 import { useResponsiveBreakpoint } from "@/hooks/use-responsive-breakpoint";
 
 const iconBtn = "h-6 w-6 p-0 cursor-pointer opacity-60 hover:opacity-100";
-const iconBtnActive = "h-6 w-6 p-0 cursor-pointer opacity-100 bg-muted";
+const iconBtnActive = "h-6 w-6 p-0 cursor-pointer bg-muted opacity-100";
+const iconBtnDestructive =
+  "h-6 w-6 p-0 cursor-pointer opacity-60 hover:text-destructive hover:opacity-100";
+const mobileMenuItem = "cursor-pointer gap-3 text-sm";
+const mobileMenuIcon = "size-4 text-muted-foreground";
 
 function isMarkdownPath(filePath: string): boolean {
   const ext = filePath.split(".").pop()?.toLowerCase();
@@ -83,7 +103,87 @@ function ToolbarIconBtn({
   );
 }
 
-export function FileDiffToolbar(props: FileDiffToolbarProps) {
+type DiffDisplayControlsProps = {
+  expandUnchanged: boolean;
+  globalViewMode: "split" | "unified";
+  wordWrap: boolean;
+  onToggleExpandUnchanged: () => void;
+  onToggleViewMode: () => void;
+  onToggleWordWrap: () => void;
+};
+
+function DiffDisplayControls({
+  expandUnchanged,
+  globalViewMode,
+  wordWrap,
+  onToggleExpandUnchanged,
+  onToggleViewMode,
+  onToggleWordWrap,
+}: DiffDisplayControlsProps) {
+  return (
+    <>
+      <ToolbarIconBtn
+        onClick={onToggleExpandUnchanged}
+        tooltip={expandUnchanged ? "Collapse unchanged" : "Expand all"}
+        active={expandUnchanged}
+      >
+        {expandUnchanged ? (
+          <IconFold className="h-3.5 w-3.5" />
+        ) : (
+          <IconFoldDown className="h-3.5 w-3.5" />
+        )}
+      </ToolbarIconBtn>
+      <ToolbarIconBtn onClick={onToggleWordWrap} tooltip="Toggle word wrap" active={wordWrap}>
+        <IconTextWrap className="h-3.5 w-3.5" />
+      </ToolbarIconBtn>
+      <ToolbarIconBtn
+        onClick={onToggleViewMode}
+        tooltip={globalViewMode === "split" ? "Switch to unified view" : "Switch to split view"}
+      >
+        {globalViewMode === "split" ? (
+          <IconLayoutRows className="h-3.5 w-3.5" />
+        ) : (
+          <IconLayoutColumns className="h-3.5 w-3.5" />
+        )}
+      </ToolbarIconBtn>
+    </>
+  );
+}
+
+function MobileDiffViewMenuItems({
+  expandUnchanged,
+  wordWrap,
+  onToggleExpandUnchanged,
+  onToggleWordWrap,
+}: Pick<
+  FileDiffToolbarProps,
+  "expandUnchanged" | "wordWrap" | "onToggleExpandUnchanged" | "onToggleWordWrap"
+>) {
+  return (
+    <>
+      <DropdownMenuSeparator />
+      <DropdownMenuLabel>View</DropdownMenuLabel>
+      <DropdownMenuCheckboxItem
+        checked={expandUnchanged}
+        className={mobileMenuItem}
+        onCheckedChange={onToggleExpandUnchanged}
+      >
+        <IconFoldDown className={mobileMenuIcon} />
+        Expand unchanged lines
+      </DropdownMenuCheckboxItem>
+      <DropdownMenuCheckboxItem
+        checked={wordWrap}
+        className={mobileMenuItem}
+        onCheckedChange={onToggleWordWrap}
+      >
+        <IconTextWrap className={mobileMenuIcon} />
+        Wrap long lines
+      </DropdownMenuCheckboxItem>
+    </>
+  );
+}
+
+function MobileFileActionsMenu(props: FileDiffToolbarProps) {
   const {
     diff,
     filePath,
@@ -104,15 +204,115 @@ export function FileDiffToolbar(props: FileDiffToolbarProps) {
     onToggleWordWrap,
     repo,
   } = props;
-  const { isMobile } = useResponsiveBreakpoint();
+  const handleCopyDiff = useCallback(() => {
+    void navigator.clipboard.writeText(diff || "");
+  }, [diff]);
+  const [open, setOpen] = useState(false);
+  const fileName = filePath.split("/").pop() || filePath;
+
+  return (
+    <DropdownMenu open={open} onOpenChange={setOpen}>
+      <DropdownMenuTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          aria-label={`More actions for ${filePath}`}
+          title={`More actions for ${filePath}`}
+          className="size-11 shrink-0 cursor-pointer text-muted-foreground transition-[scale,color,background-color] duration-150 ease-out active:scale-[0.96]"
+          onPointerDown={(event) => event.preventDefault()}
+          onClick={() => setOpen(true)}
+        >
+          <IconDots className="size-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        data-testid="review-file-actions-menu"
+        aria-label={`Actions for ${filePath}`}
+        align="end"
+        className="w-64"
+      >
+        <DropdownMenuLabel className="truncate font-medium text-foreground" title={filePath}>
+          {fileName}
+        </DropdownMenuLabel>
+        <DropdownMenuItem className={mobileMenuItem} onSelect={handleCopyDiff}>
+          <IconCopy className={mobileMenuIcon} />
+          Copy diff
+        </DropdownMenuItem>
+        {onOpenFile && (
+          <DropdownMenuItem className={mobileMenuItem} onSelect={() => onOpenFile(filePath, repo)}>
+            <IconPencil className={mobileMenuIcon} />
+            Edit file
+          </DropdownMenuItem>
+        )}
+        {onPreviewMarkdown && isMarkdownPath(filePath) && (
+          <DropdownMenuItem className={mobileMenuItem} onSelect={() => onPreviewMarkdown(filePath)}>
+            <IconEye className={mobileMenuIcon} />
+            Preview markdown
+          </DropdownMenuItem>
+        )}
+        <ExternalVcsFileMenuItem
+          filePath={filePath}
+          previousPath={previousPath}
+          status={status}
+          taskId={taskId}
+          sessionId={sessionId}
+          repositoryId={repositoryId}
+          repositoryName={repo}
+          publishedBranch={publishedBranch}
+          baseBranch={baseBranch}
+        />
+        <FileActionsMenuItems filePath={filePath} sessionId={sessionId} />
+        <MobileDiffViewMenuItems
+          expandUnchanged={expandUnchanged}
+          wordWrap={wordWrap}
+          onToggleExpandUnchanged={onToggleExpandUnchanged}
+          onToggleWordWrap={onToggleWordWrap}
+        />
+        {source === "uncommitted" && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem variant="destructive" className={mobileMenuItem} onSelect={onDiscard}>
+              <IconArrowBackUp className="size-4" />
+              Revert changes
+            </DropdownMenuItem>
+          </>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+function DesktopFileDiffToolbar(props: FileDiffToolbarProps) {
+  const {
+    diff,
+    filePath,
+    previousPath,
+    status,
+    taskId,
+    sessionId,
+    repositoryId,
+    source,
+    publishedBranch,
+    baseBranch,
+    wordWrap,
+    expandUnchanged,
+    onDiscard,
+    onOpenFile,
+    onPreviewMarkdown,
+    onToggleExpandUnchanged,
+    onToggleWordWrap,
+    repo,
+  } = props;
   const [globalViewMode, setGlobalViewMode] = useGlobalViewMode();
   const handleCopyDiff = useCallback(() => {
-    navigator.clipboard.writeText(diff || "");
+    void navigator.clipboard.writeText(diff || "");
   }, [diff]);
   const handleToggleViewMode = useCallback(
     () => setGlobalViewMode(globalViewMode === "split" ? "unified" : "split"),
     [globalViewMode, setGlobalViewMode],
   );
+
   return (
     <div className="flex items-center gap-0.5">
       <ToolbarIconBtn onClick={handleCopyDiff} tooltip="Copy diff">
@@ -128,32 +328,16 @@ export function FileDiffToolbar(props: FileDiffToolbarProps) {
         repositoryName={repo}
         publishedBranch={publishedBranch}
         baseBranch={baseBranch}
-        size={isMobile ? "touch" : "xs"}
+        size="xs"
       />
-      <ToolbarIconBtn
-        onClick={onToggleExpandUnchanged}
-        tooltip={expandUnchanged ? "Collapse unchanged" : "Expand all"}
-        active={expandUnchanged}
-      >
-        {expandUnchanged ? (
-          <IconFold className="h-3.5 w-3.5" />
-        ) : (
-          <IconFoldDown className="h-3.5 w-3.5" />
-        )}
-      </ToolbarIconBtn>
-      <ToolbarIconBtn onClick={onToggleWordWrap} tooltip="Toggle word wrap" active={wordWrap}>
-        <IconTextWrap className="h-3.5 w-3.5" />
-      </ToolbarIconBtn>
-      <ToolbarIconBtn
-        onClick={handleToggleViewMode}
-        tooltip={globalViewMode === "split" ? "Switch to unified view" : "Switch to split view"}
-      >
-        {globalViewMode === "split" ? (
-          <IconLayoutRows className="h-3.5 w-3.5" />
-        ) : (
-          <IconLayoutColumns className="h-3.5 w-3.5" />
-        )}
-      </ToolbarIconBtn>
+      <DiffDisplayControls
+        expandUnchanged={expandUnchanged}
+        globalViewMode={globalViewMode}
+        wordWrap={wordWrap}
+        onToggleExpandUnchanged={onToggleExpandUnchanged}
+        onToggleViewMode={handleToggleViewMode}
+        onToggleWordWrap={onToggleWordWrap}
+      />
       {onPreviewMarkdown && isMarkdownPath(filePath) && (
         <ToolbarIconBtn onClick={() => onPreviewMarkdown(filePath)} tooltip="Preview markdown">
           <IconEye className="h-3.5 w-3.5" />
@@ -166,14 +350,15 @@ export function FileDiffToolbar(props: FileDiffToolbarProps) {
       )}
       <FileActionsDropdown filePath={filePath} sessionId={sessionId} size="xs" />
       {source === "uncommitted" && (
-        <ToolbarIconBtn
-          onClick={onDiscard}
-          tooltip="Revert changes"
-          className="h-6 w-6 p-0 cursor-pointer opacity-60 hover:opacity-100 hover:text-destructive"
-        >
+        <ToolbarIconBtn onClick={onDiscard} tooltip="Revert changes" className={iconBtnDestructive}>
           <IconArrowBackUp className="h-3.5 w-3.5" />
         </ToolbarIconBtn>
       )}
     </div>
   );
+}
+
+export function FileDiffToolbar(props: FileDiffToolbarProps) {
+  const { isMobile } = useResponsiveBreakpoint();
+  return isMobile ? <MobileFileActionsMenu {...props} /> : <DesktopFileDiffToolbar {...props} />;
 }

--- a/apps/web/e2e/tests/review/mobile-review-file-status.spec.ts
+++ b/apps/web/e2e/tests/review/mobile-review-file-status.spec.ts
@@ -3,14 +3,14 @@ import { GitHelper, makeGitEnv } from "../../helpers/git-helper";
 import { SessionPage } from "../../pages/session-page";
 import path from "node:path";
 
-const MOBILE_FILE = "mobile-review-status-added.ts";
+const MOBILE_FILE = "packages/mobile/review/surfaces/deeply/nested/mobile-review-status-added.ts";
 const MOBILE_MOVED_FROM_FILE = "mobile-review-status-old-name.ts";
 const MOBILE_MOVED_FILE = "mobile-review-status-new-name.ts";
 
 test.describe("Review file status on mobile", () => {
   test.describe.configure({ timeout: 120_000 });
 
-  test("shows status in the sticky header without horizontal overflow", async ({
+  test("uses a compact file header with a labelled mobile actions menu", async ({
     testPage,
     apiClient,
     seedData,
@@ -82,19 +82,33 @@ test.describe("Review file status on mobile", () => {
     await testPage.getByRole("button", { name: "Changes" }).tap();
     const changesPanel = testPage.getByTestId("mobile-changes-panel");
     await expect(changesPanel).toBeVisible();
-    await expect(testPage.getByTestId(`file-row-${MOBILE_FILE}`)).toBeVisible({ timeout: 20_000 });
+    await expect(
+      testPage.getByTestId(`file-row-${MOBILE_FILE.replace(/[/\\]/g, "-")}`),
+    ).toBeVisible({ timeout: 20_000 });
     await changesPanel.getByRole("button", { name: "Review", exact: true }).tap();
 
     const dialog = testPage.getByRole("dialog", { name: "Review Changes" });
     await expect(dialog).toBeVisible();
-    const header = dialog.getByTestId("review-file-header").filter({ hasText: MOBILE_FILE });
+    const header = dialog.locator(
+      `[data-testid="review-file-header"][data-file-path="${MOBILE_FILE}"]`,
+    );
     await expect(header).toBeVisible();
     const marker = header.getByRole("img", { name: "Added" });
     await expect(marker).toBeVisible();
+    await expect(header.getByText("+1", { exact: true })).toBeVisible();
 
-    const movedHeader = dialog
-      .getByTestId("review-file-header")
-      .filter({ hasText: MOBILE_MOVED_FILE });
+    const identityRow = header.getByTestId("review-file-identity");
+    const fileName = identityRow.locator("[data-review-file-name]");
+    await expect(fileName).toHaveText(path.basename(MOBILE_FILE));
+    await expect(header.getByTestId("review-file-actions")).toHaveCount(0);
+    const moreActions = header.getByRole("button", {
+      name: `More actions for ${MOBILE_FILE}`,
+    });
+    await expect(moreActions).toBeVisible();
+
+    const movedHeader = dialog.locator(
+      `[data-testid="review-file-header"][data-file-path="${MOBILE_MOVED_FILE}"]`,
+    );
     await expect(movedHeader).toBeVisible();
     await expect(
       movedHeader.getByRole("img", { name: `Moved from ${MOBILE_MOVED_FROM_FILE}` }),
@@ -103,24 +117,103 @@ test.describe("Review file status on mobile", () => {
       dialog.getByText(`Moved from ${MOBILE_MOVED_FROM_FILE}; no textual changes`),
     ).toBeVisible();
 
-    const headerGeometry = await header.evaluate((element) => {
+    const headerGeometry = await header.evaluate((element, filePath) => {
       const markerElement = element.querySelector<HTMLElement>('[data-file-status="added"]');
-      if (!markerElement) return null;
+      const identityElement = element.querySelector<HTMLElement>(
+        '[data-testid="review-file-identity"]',
+      );
+      const fileNameElement = element.querySelector<HTMLElement>("[data-review-file-name]");
+      const moreActionsElement = element.querySelector<HTMLElement>(
+        `[aria-label="More actions for ${filePath}"]`,
+      );
+      if (!markerElement || !identityElement || !fileNameElement || !moreActionsElement) {
+        return null;
+      }
       const headerBounds = element.getBoundingClientRect();
       const markerBounds = markerElement.getBoundingClientRect();
+      const fileNameBounds = fileNameElement.getBoundingClientRect();
+      const moreActionsBounds = moreActionsElement.getBoundingClientRect();
       return {
         scrollWidth: element.scrollWidth,
         clientWidth: element.clientWidth,
+        height: headerBounds.height,
         headerLeft: headerBounds.left,
         headerRight: headerBounds.right,
         markerLeft: markerBounds.left,
         markerRight: markerBounds.right,
+        fileNameLeft: fileNameBounds.left,
+        fileNameRight: fileNameBounds.right,
+        moreActionsLeft: moreActionsBounds.left,
+        moreActionsRight: moreActionsBounds.right,
+        moreActionsWidth: moreActionsBounds.width,
+        moreActionsHeight: moreActionsBounds.height,
       };
-    });
+    }, MOBILE_FILE);
     if (!headerGeometry) throw new Error("Mobile Review header geometry is unavailable");
     expect(headerGeometry.scrollWidth).toBeLessThanOrEqual(headerGeometry.clientWidth);
+    expect(headerGeometry.height).toBeLessThanOrEqual(64);
     expect(headerGeometry.markerLeft).toBeGreaterThanOrEqual(headerGeometry.headerLeft);
     expect(headerGeometry.markerRight).toBeLessThanOrEqual(headerGeometry.headerRight);
+    expect(headerGeometry.fileNameLeft).toBeGreaterThanOrEqual(headerGeometry.headerLeft);
+    expect(headerGeometry.fileNameRight).toBeLessThanOrEqual(headerGeometry.headerRight);
+    expect(headerGeometry.moreActionsLeft).toBeGreaterThanOrEqual(headerGeometry.headerLeft);
+    expect(headerGeometry.moreActionsRight).toBeLessThanOrEqual(headerGeometry.headerRight);
+    expect(headerGeometry.moreActionsWidth).toBeGreaterThanOrEqual(44);
+    expect(headerGeometry.moreActionsHeight).toBeGreaterThanOrEqual(44);
+
+    await moreActions.click();
+    const actionsMenu = testPage.getByTestId("review-file-actions-menu");
+    await expect(actionsMenu).toBeVisible();
+    await actionsMenu.evaluate((element) =>
+      Promise.all(
+        element
+          .getAnimations({ subtree: true })
+          .map((animation) => animation.finished.catch(() => undefined)),
+      ),
+    );
+    const menuGeometry = await actionsMenu.evaluate((element) => {
+      const bounds = element.getBoundingClientRect();
+      const items = Array.from(
+        element.querySelectorAll<HTMLElement>('[role^="menuitem"]'),
+        (item) => item.getBoundingClientRect(),
+      );
+      return {
+        left: bounds.left,
+        right: bounds.right,
+        top: bounds.top,
+        bottom: bounds.bottom,
+        viewportWidth: window.innerWidth,
+        viewportHeight: window.innerHeight,
+        minItemHeight: Math.min(...items.map((item) => item.height)),
+      };
+    });
+    expect(menuGeometry.left).toBeGreaterThanOrEqual(0);
+    expect(menuGeometry.right).toBeLessThanOrEqual(menuGeometry.viewportWidth);
+    expect(menuGeometry.top).toBeGreaterThanOrEqual(0);
+    expect(menuGeometry.bottom).toBeLessThanOrEqual(menuGeometry.viewportHeight);
+    expect(menuGeometry.minItemHeight).toBeGreaterThanOrEqual(44);
+
+    await expect(actionsMenu.getByRole("menuitem", { name: "Copy diff" })).toBeVisible();
+    await expect(actionsMenu.getByRole("menuitem", { name: "Edit file" })).toBeVisible();
+    await expect(actionsMenu.getByRole("menuitem", { name: "Copy path" })).toBeVisible();
+    await expect(actionsMenu.getByRole("menuitem", { name: "Open folder" })).toBeVisible();
+    await expect(actionsMenu.getByRole("menuitem", { name: "Revert changes" })).toBeVisible();
+    await expect(
+      actionsMenu.getByRole("menuitemcheckbox", { name: "Expand unchanged lines" }),
+    ).toBeVisible();
+    const wrapLines = actionsMenu.getByRole("menuitemcheckbox", { name: "Wrap long lines" });
+    const initialWrapState = await wrapLines.getAttribute("aria-checked");
+    expect(["true", "false"]).toContain(initialWrapState);
+
+    await wrapLines.click();
+    await expect(actionsMenu).not.toBeVisible();
+    await moreActions.click();
+    await expect(
+      testPage
+        .getByTestId("review-file-actions-menu")
+        .getByRole("menuitemcheckbox", { name: "Wrap long lines" }),
+    ).toHaveAttribute("aria-checked", initialWrapState === "true" ? "false" : "true");
+    await testPage.keyboard.press("Escape");
 
     const checkbox = header.getByRole("checkbox");
     await checkbox.tap();


### PR DESCRIPTION
Dense per-file controls made mobile reviews difficult to scan and obscured long filenames. Mobile reviews now keep the basename and diff stats visible in a compact header while moving file-specific actions into a labelled, touch-friendly menu; desktop remains unchanged.

## Validation

- `pnpm exec vitest run components/editors/external-vcs-file-link.test.tsx components/review/review-diff-header.test.tsx components/review/review-diff-toolbar.test.tsx` (18 tests)
- `pnpm run typecheck`
- Changed-file ESLint and Prettier checks
- Pixel 5 `mobile-review-file-status.spec.ts` and desktop review smoke
- Production Vite build and approved manual Pixel 5 review with a long-path `+35/-11` fixture
- Public docs unchanged: this only adjusts responsive review presentation

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.
