### PR TITLE
fix: keep file attachments compact beside image previews

### DIFF
--- a/apps/web/components/task/chat/messages/chat-message.tsx
+++ b/apps/web/components/task/chat/messages/chat-message.tsx
@@ -448,7 +448,8 @@ function UserMessageContent({
               {fileAttachments.map((att, index) => (
                 <span
                   key={`file-${index}`}
-                  className="inline-flex items-center gap-1.5 rounded-full bg-muted/40 px-2.5 py-1 text-xs text-muted-foreground"
+                  data-testid="message-file-attachment"
+                  className="inline-flex self-start items-center gap-1.5 rounded-full bg-muted/40 px-2.5 py-1 text-xs text-muted-foreground"
                 >
                   <IconFile size={12} />
                   {att.name || "Attachment"}

--- a/apps/web/e2e/helpers/mixed-attachment-layout.ts
+++ b/apps/web/e2e/helpers/mixed-attachment-layout.ts
@@ -45,7 +45,9 @@ export async function assertMixedAttachmentLayout({
   const fileInput = testPage.locator('input[type="file"]');
   // The chat input appends each change event to React attachment state.
   await fileInput.setInputFiles(imagePath);
-  await expect(testPage.getByText(/Image \(/).first()).toBeVisible({ timeout: 10_000 });
+  const imagePreview = testPage.getByText(/Image \(/);
+  await expect(imagePreview).toHaveCount(1, { timeout: 10_000 });
+  await expect(imagePreview).toBeVisible();
   // This second change event appends the text file, preserving both attachments.
   await fileInput.setInputFiles(textPath);
   await session.sendMessageViaButton("send image and file together");

--- a/apps/web/e2e/helpers/mixed-attachment-layout.ts
+++ b/apps/web/e2e/helpers/mixed-attachment-layout.ts
@@ -1,0 +1,65 @@
+import fs from "node:fs";
+import path from "node:path";
+import { expect, type Page, type TestInfo } from "@playwright/test";
+import type { SeedData } from "../fixtures/test-base";
+import type { ApiClient } from "./api-client";
+import { openTaskSession, waitForLatestSessionDone } from "./session";
+
+type MixedAttachmentLayoutOptions = {
+  testPage: Page;
+  apiClient: ApiClient;
+  seedData: SeedData;
+  testInfo: TestInfo;
+  taskTitle: string;
+};
+
+export async function assertMixedAttachmentLayout({
+  testPage,
+  apiClient,
+  seedData,
+  testInfo,
+  taskTitle,
+}: MixedAttachmentLayoutOptions): Promise<void> {
+  const task = await apiClient.createTaskWithAgent(
+    seedData.workspaceId,
+    taskTitle,
+    seedData.agentProfileId,
+    {
+      description: "/e2e:simple-message",
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+      repository_ids: [seedData.repositoryId],
+    },
+  );
+  if (!task.session_id) throw new Error("createTaskWithAgent did not return a session_id");
+  await waitForLatestSessionDone(apiClient, task.id, 1, "Wait for mixed attachment task");
+  const session = await openTaskSession(testPage, task.id);
+  await session.waitForChatIdle({ timeout: 30_000 });
+  fs.mkdirSync(testInfo.outputDir, { recursive: true });
+
+  const imagePath = path.join(testInfo.outputDir, "mixed-attachment.png");
+  fs.copyFileSync(path.join(process.cwd(), "public/web-app-manifest-192x192.png"), imagePath);
+  const textPath = path.join(testInfo.outputDir, "notes.txt");
+  fs.writeFileSync(textPath, "plain text attachment");
+
+  const fileInput = testPage.locator('input[type="file"]');
+  // The chat input appends each change event to React attachment state.
+  await fileInput.setInputFiles(imagePath);
+  await expect(testPage.getByText(/Image \(/).first()).toBeVisible({ timeout: 10_000 });
+  // This second change event appends the text file, preserving both attachments.
+  await fileInput.setInputFiles(textPath);
+  await session.sendMessageViaButton("send image and file together");
+  await session.waitForChatIdle({ timeout: 30_000 });
+
+  const fileAttachment = testPage.getByTestId("message-file-attachment", { exact: true });
+  const imageAttachment = testPage.getByRole("button", { name: "Open Attachment 1" });
+  await expect(fileAttachment).toHaveText("notes.txt");
+  const [fileBox, imageBox] = await Promise.all([
+    fileAttachment.boundingBox(),
+    imageAttachment.boundingBox(),
+  ]);
+
+  expect(fileBox).not.toBeNull();
+  expect(imageBox).not.toBeNull();
+  expect(fileBox!.height).toBeLessThan(imageBox!.height);
+}

--- a/apps/web/e2e/tests/chat/attachment-delivery-mode.spec.ts
+++ b/apps/web/e2e/tests/chat/attachment-delivery-mode.spec.ts
@@ -38,6 +38,54 @@ async function waitForUserAttachment(
 }
 
 test.describe("chat attachment delivery mode", () => {
+  test("keeps a file attachment compact next to an image preview", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }, testInfo) => {
+    test.setTimeout(90_000);
+    const task = await apiClient.createTaskWithAgent(
+      seedData.workspaceId,
+      "Mixed attachment layout",
+      seedData.agentProfileId,
+      {
+        description: "/e2e:simple-message",
+        workflow_id: seedData.workflowId,
+        workflow_step_id: seedData.startStepId,
+        repository_ids: [seedData.repositoryId],
+      },
+    );
+    if (!task.session_id) throw new Error("createTaskWithAgent did not return a session_id");
+    await waitForLatestSessionDone(apiClient, task.id, 1, "Wait for mixed attachment task");
+    const session = await openTaskSession(testPage, task.id);
+    await session.waitForChatIdle({ timeout: 30_000 });
+    fs.mkdirSync(testInfo.outputDir, { recursive: true });
+
+    const imagePath = path.join(testInfo.outputDir, "tiny.png");
+    fs.copyFileSync(path.join(process.cwd(), "public/web-app-manifest-192x192.png"), imagePath);
+    const textPath = path.join(testInfo.outputDir, "notes.txt");
+    fs.writeFileSync(textPath, "plain text attachment");
+
+    const fileInput = testPage.locator('input[type="file"]');
+    await fileInput.setInputFiles(imagePath);
+    await expect(testPage.getByText(/Image \(/).first()).toBeVisible({ timeout: 10_000 });
+    await fileInput.setInputFiles(textPath);
+    await session.sendMessageViaButton("send image and file together");
+    await session.waitForChatIdle({ timeout: 30_000 });
+
+    const fileAttachment = testPage.getByTestId("message-file-attachment", { exact: true });
+    const imageAttachment = testPage.getByRole("button", { name: "Open Attachment 1" });
+    await expect(fileAttachment).toHaveText("notes.txt");
+    const [fileBox, imageBox] = await Promise.all([
+      fileAttachment.boundingBox(),
+      imageAttachment.boundingBox(),
+    ]);
+
+    expect(fileBox).not.toBeNull();
+    expect(imageBox).not.toBeNull();
+    expect(fileBox!.height).toBeLessThan(imageBox!.height);
+  });
+
   test("shows a Prompt/File selector for supported images and sends unsupported files by path", async ({
     testPage,
     apiClient,

--- a/apps/web/e2e/tests/chat/attachment-delivery-mode.spec.ts
+++ b/apps/web/e2e/tests/chat/attachment-delivery-mode.spec.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { test, expect } from "../../fixtures/test-base";
 import type { ApiClient } from "../../helpers/api-client";
+import { assertMixedAttachmentLayout } from "../../helpers/mixed-attachment-layout";
 import { openTaskSession, waitForLatestSessionDone } from "../../helpers/session";
 
 type PersistedAttachment = {
@@ -44,46 +45,13 @@ test.describe("chat attachment delivery mode", () => {
     seedData,
   }, testInfo) => {
     test.setTimeout(90_000);
-    const task = await apiClient.createTaskWithAgent(
-      seedData.workspaceId,
-      "Mixed attachment layout",
-      seedData.agentProfileId,
-      {
-        description: "/e2e:simple-message",
-        workflow_id: seedData.workflowId,
-        workflow_step_id: seedData.startStepId,
-        repository_ids: [seedData.repositoryId],
-      },
-    );
-    if (!task.session_id) throw new Error("createTaskWithAgent did not return a session_id");
-    await waitForLatestSessionDone(apiClient, task.id, 1, "Wait for mixed attachment task");
-    const session = await openTaskSession(testPage, task.id);
-    await session.waitForChatIdle({ timeout: 30_000 });
-    fs.mkdirSync(testInfo.outputDir, { recursive: true });
-
-    const imagePath = path.join(testInfo.outputDir, "tiny.png");
-    fs.copyFileSync(path.join(process.cwd(), "public/web-app-manifest-192x192.png"), imagePath);
-    const textPath = path.join(testInfo.outputDir, "notes.txt");
-    fs.writeFileSync(textPath, "plain text attachment");
-
-    const fileInput = testPage.locator('input[type="file"]');
-    await fileInput.setInputFiles(imagePath);
-    await expect(testPage.getByText(/Image \(/).first()).toBeVisible({ timeout: 10_000 });
-    await fileInput.setInputFiles(textPath);
-    await session.sendMessageViaButton("send image and file together");
-    await session.waitForChatIdle({ timeout: 30_000 });
-
-    const fileAttachment = testPage.getByTestId("message-file-attachment", { exact: true });
-    const imageAttachment = testPage.getByRole("button", { name: "Open Attachment 1" });
-    await expect(fileAttachment).toHaveText("notes.txt");
-    const [fileBox, imageBox] = await Promise.all([
-      fileAttachment.boundingBox(),
-      imageAttachment.boundingBox(),
-    ]);
-
-    expect(fileBox).not.toBeNull();
-    expect(imageBox).not.toBeNull();
-    expect(fileBox!.height).toBeLessThan(imageBox!.height);
+    await assertMixedAttachmentLayout({
+      testPage,
+      apiClient,
+      seedData,
+      testInfo,
+      taskTitle: "Mixed attachment layout",
+    });
   });
 
   test("shows a Prompt/File selector for supported images and sends unsupported files by path", async ({

--- a/apps/web/e2e/tests/chat/mobile-message-attachment-layout.spec.ts
+++ b/apps/web/e2e/tests/chat/mobile-message-attachment-layout.spec.ts
@@ -1,7 +1,5 @@
-import fs from "node:fs";
-import path from "node:path";
-import { test, expect } from "../../fixtures/test-base";
-import { openTaskSession, waitForLatestSessionDone } from "../../helpers/session";
+import { test } from "../../fixtures/test-base";
+import { assertMixedAttachmentLayout } from "../../helpers/mixed-attachment-layout";
 
 test.describe("mobile message attachment layout", () => {
   test("keeps a file attachment compact next to an image preview", async ({
@@ -10,45 +8,12 @@ test.describe("mobile message attachment layout", () => {
     seedData,
   }, testInfo) => {
     test.setTimeout(90_000);
-    const task = await apiClient.createTaskWithAgent(
-      seedData.workspaceId,
-      "Mobile mixed attachment layout",
-      seedData.agentProfileId,
-      {
-        description: "/e2e:simple-message",
-        workflow_id: seedData.workflowId,
-        workflow_step_id: seedData.startStepId,
-        repository_ids: [seedData.repositoryId],
-      },
-    );
-    if (!task.session_id) throw new Error("createTaskWithAgent did not return a session_id");
-    await waitForLatestSessionDone(apiClient, task.id, 1, "Wait for mixed attachment task");
-    const session = await openTaskSession(testPage, task.id);
-    await session.waitForChatIdle({ timeout: 30_000 });
-    fs.mkdirSync(testInfo.outputDir, { recursive: true });
-
-    const imagePath = path.join(testInfo.outputDir, "tiny.png");
-    fs.copyFileSync(path.join(process.cwd(), "public/web-app-manifest-192x192.png"), imagePath);
-    const textPath = path.join(testInfo.outputDir, "notes.txt");
-    fs.writeFileSync(textPath, "plain text attachment");
-
-    const fileInput = testPage.locator('input[type="file"]');
-    await fileInput.setInputFiles(imagePath);
-    await expect(testPage.getByText(/Image \(/).first()).toBeVisible({ timeout: 10_000 });
-    await fileInput.setInputFiles(textPath);
-    await session.sendMessageViaButton("send image and file together");
-    await session.waitForChatIdle({ timeout: 30_000 });
-
-    const fileAttachment = testPage.getByTestId("message-file-attachment", { exact: true });
-    const imageAttachment = testPage.getByRole("button", { name: "Open Attachment 1" });
-    await expect(fileAttachment).toHaveText("notes.txt");
-    const [fileBox, imageBox] = await Promise.all([
-      fileAttachment.boundingBox(),
-      imageAttachment.boundingBox(),
-    ]);
-
-    expect(fileBox).not.toBeNull();
-    expect(imageBox).not.toBeNull();
-    expect(fileBox!.height).toBeLessThan(imageBox!.height);
+    await assertMixedAttachmentLayout({
+      testPage,
+      apiClient,
+      seedData,
+      testInfo,
+      taskTitle: "Mobile mixed attachment layout",
+    });
   });
 });

--- a/apps/web/e2e/tests/chat/mobile-message-attachment-layout.spec.ts
+++ b/apps/web/e2e/tests/chat/mobile-message-attachment-layout.spec.ts
@@ -1,0 +1,54 @@
+import fs from "node:fs";
+import path from "node:path";
+import { test, expect } from "../../fixtures/test-base";
+import { openTaskSession, waitForLatestSessionDone } from "../../helpers/session";
+
+test.describe("mobile message attachment layout", () => {
+  test("keeps a file attachment compact next to an image preview", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }, testInfo) => {
+    test.setTimeout(90_000);
+    const task = await apiClient.createTaskWithAgent(
+      seedData.workspaceId,
+      "Mobile mixed attachment layout",
+      seedData.agentProfileId,
+      {
+        description: "/e2e:simple-message",
+        workflow_id: seedData.workflowId,
+        workflow_step_id: seedData.startStepId,
+        repository_ids: [seedData.repositoryId],
+      },
+    );
+    if (!task.session_id) throw new Error("createTaskWithAgent did not return a session_id");
+    await waitForLatestSessionDone(apiClient, task.id, 1, "Wait for mixed attachment task");
+    const session = await openTaskSession(testPage, task.id);
+    await session.waitForChatIdle({ timeout: 30_000 });
+    fs.mkdirSync(testInfo.outputDir, { recursive: true });
+
+    const imagePath = path.join(testInfo.outputDir, "tiny.png");
+    fs.copyFileSync(path.join(process.cwd(), "public/web-app-manifest-192x192.png"), imagePath);
+    const textPath = path.join(testInfo.outputDir, "notes.txt");
+    fs.writeFileSync(textPath, "plain text attachment");
+
+    const fileInput = testPage.locator('input[type="file"]');
+    await fileInput.setInputFiles(imagePath);
+    await expect(testPage.getByText(/Image \(/).first()).toBeVisible({ timeout: 10_000 });
+    await fileInput.setInputFiles(textPath);
+    await session.sendMessageViaButton("send image and file together");
+    await session.waitForChatIdle({ timeout: 30_000 });
+
+    const fileAttachment = testPage.getByTestId("message-file-attachment", { exact: true });
+    const imageAttachment = testPage.getByRole("button", { name: "Open Attachment 1" });
+    await expect(fileAttachment).toHaveText("notes.txt");
+    const [fileBox, imageBox] = await Promise.all([
+      fileAttachment.boundingBox(),
+      imageAttachment.boundingBox(),
+    ]);
+
+    expect(fileBox).not.toBeNull();
+    expect(imageBox).not.toBeNull();
+    expect(fileBox!.height).toBeLessThan(imageBox!.height);
+  });
+});


### PR DESCRIPTION
Mixed image and file attachments currently make the file chip stretch to the image
preview height, which creates an awkward oversized file attachment. The file chip now
keeps its intrinsic compact height, with desktop and mobile regression coverage.

## Validation

- `pnpm e2e:run --no-build tests/chat/attachment-delivery-mode.spec.ts` (2 passed)
- `pnpm e2e:run --no-build tests/chat/mobile-message-attachment-layout.spec.ts -- --project=mobile-chrome` (1 passed)
- `pnpm exec prettier --check web/components/task/chat/messages/chat-message.tsx web/e2e/tests/chat/attachment-delivery-mode.spec.ts web/e2e/tests/chat/mobile-message-attachment-layout.spec.ts`
- `git diff --check`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1997?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- kandev-screenshots-start -->
## Screenshots

![Desktop mixed image and file attachment layout](https://raw.githubusercontent.com/kdlbs/kandev/1750c4b76b1749279afc2404f1f10d158bafe9b6/attachment-layout-desktop.png)

![Mobile mixed image and file attachment layout](https://raw.githubusercontent.com/kdlbs/kandev/1750c4b76b1749279afc2404f1f10d158bafe9b6/attachment-layout-mobile.png)
<!-- kandev-screenshots-end -->