### PR TITLE
feat(web): add favorite star toggle to chat messages

### DIFF
--- a/apps/web/components/task/chat/messages/agent-message-content.tsx
+++ b/apps/web/components/task/chat/messages/agent-message-content.tsx
@@ -6,6 +6,8 @@ import { RichBlocks } from "@/components/task/chat/messages/rich-blocks";
 import { MessageActions } from "@/components/task/chat/messages/message-actions";
 import { MemoizedMarkdown } from "@/components/shared/memoized-markdown";
 import { MessageCommentSurface } from "./message-comment-surface";
+import { useMessageFavorite } from "@/hooks/domains/session/use-message-favorite";
+import { cn } from "@/lib/utils";
 
 type AgentMessageContentProps = {
   comment: Message;
@@ -28,9 +30,16 @@ export const AgentMessageContent = memo(function AgentMessageContent({
   sessionId,
   isTurnActive,
 }: AgentMessageContentProps) {
+  const { isFavorite, toggleFavorite } = useMessageFavorite(comment.session_id, comment.id);
   return (
     <div className="flex items-start gap-2 sm:gap-3 w-full group">
-      <div className="flex-1 min-w-0">
+      <div
+        data-testid="agent-message-highlight"
+        className={cn(
+          "flex-1 min-w-0 -mx-2 -my-1 rounded-lg px-2 py-1 transition-colors",
+          isFavorite ? "bg-yellow-200/50 dark:bg-yellow-500/10" : "bg-transparent",
+        )}
+      >
         {showRaw ? (
           <pre className="whitespace-pre-wrap font-mono text-xs bg-muted/20 p-3 rounded-md">
             {comment.raw_content || comment.content || "(empty)"}
@@ -60,6 +69,8 @@ export const AgentMessageContent = memo(function AgentMessageContent({
           showNavigation={false}
           isRawView={showRaw}
           onToggleRaw={onToggleRaw}
+          isFavorite={isFavorite}
+          onToggleFavorite={toggleFavorite}
         />
       </div>
     </div>

--- a/apps/web/components/task/chat/messages/chat-message.test.tsx
+++ b/apps/web/components/task/chat/messages/chat-message.test.tsx
@@ -586,3 +586,47 @@ describe("ChatMessage image attachments", () => {
     expect(preview.getAttribute("src")).toBe(`data:image/png;base64,${PNG_BASE64}`);
   });
 });
+
+describe("ChatMessage favorite toggle", () => {
+  it("toggles the star and applies a light-yellow background on the user message bubble", () => {
+    render(
+      <StateProvider>
+        <ChatMessage comment={userMessage({ content: "hello" })} label="Message" className="" />
+      </StateProvider>,
+    );
+
+    const star = screen.getByRole("button", { name: /mark message as favorite/i });
+    const bubble = screen.getByTestId("user-message-bubble");
+    expect(bubble.className).not.toMatch(/yellow/);
+
+    fireEvent.click(star);
+
+    expect(screen.getByRole("button", { name: /remove message from favorites/i })).toBe(star);
+    expect(bubble.className).toMatch(/yellow/);
+
+    fireEvent.click(star);
+
+    expect(screen.getByRole("button", { name: /mark message as favorite/i })).toBe(star);
+    expect(bubble.className).not.toMatch(/yellow/);
+  });
+
+  it("toggles the star and applies a light-yellow background on an agent message", () => {
+    render(
+      <StateProvider>
+        <ChatMessage
+          comment={userMessage({ author_type: "agent", content: "hello from agent" })}
+          label="Message"
+          className=""
+        />
+      </StateProvider>,
+    );
+
+    const star = screen.getByRole("button", { name: /mark message as favorite/i });
+    const highlight = screen.getByTestId("agent-message-highlight");
+    expect(highlight.className).not.toMatch(/yellow/);
+
+    fireEvent.click(star);
+
+    expect(highlight.className).toMatch(/yellow/);
+  });
+});

--- a/apps/web/components/task/chat/messages/chat-message.tsx
+++ b/apps/web/components/task/chat/messages/chat-message.tsx
@@ -14,6 +14,7 @@ import { IconWand, IconMessageDots, IconFile } from "@tabler/icons-react";
 import { cn } from "@/lib/utils";
 import type { Message } from "@/lib/types/http";
 import { MessageActions } from "@/components/task/chat/messages/message-actions";
+import { useMessageFavorite } from "@/hooks/domains/session/use-message-favorite";
 import { useUserMessageNavigation } from "@/hooks/use-message-navigation";
 import { SenderTaskBadge, type SenderTaskInfo } from "./sender-task-badge";
 import { MemoizedMarkdown } from "@/components/shared/memoized-markdown";
@@ -395,6 +396,41 @@ function UserContextBadges({
   );
 }
 
+type UserMessageAttachment = { type: string; data: string; mime_type: string; name?: string };
+
+function UserMessageAttachments({
+  imageAttachments,
+  fileAttachments,
+  hasContent,
+}: {
+  imageAttachments: UserMessageAttachment[];
+  fileAttachments: UserMessageAttachment[];
+  hasContent: boolean;
+}) {
+  return (
+    <div className={cn("flex flex-wrap gap-2", hasContent && "mb-2")}>
+      {imageAttachments.map((att, index) => (
+        <ImagePreviewDialog
+          key={index}
+          src={`data:${att.mime_type};base64,${att.data}`}
+          alt={`Attachment ${index + 1}`}
+          thumbnailClassName="max-h-48 max-w-full rounded-lg object-contain transition-opacity hover:opacity-90"
+        />
+      ))}
+      {fileAttachments.map((att, index) => (
+        <span
+          key={`file-${index}`}
+          data-testid="message-file-attachment"
+          className="inline-flex self-start items-center gap-1.5 rounded-full bg-muted/40 px-2.5 py-1 text-xs text-muted-foreground"
+        >
+          <IconFile size={12} />
+          {att.name || "Attachment"}
+        </span>
+      ))}
+    </div>
+  );
+}
+
 function UserMessageContent({
   comment,
   showRaw,
@@ -406,6 +442,7 @@ function UserMessageContent({
 }: UserMessageProps) {
   const userNavigation = useUserMessageNavigation(sessionId ?? null, comment.id);
   const promptNames = usePromptMentionNames();
+  const { isFavorite, toggleFavorite } = useMessageFavorite(comment.session_id, comment.id);
   const entityReferences = useMemo(
     () => entityReferencesFromMetadata(comment.metadata),
     [comment.metadata],
@@ -434,28 +471,19 @@ function UserMessageContent({
           senderTask={senderTask}
           workflowMessage={workflowMessage}
         />
-        <div className="rounded-2xl bg-primary/30 px-4 py-2.5 overflow-hidden">
+        <div
+          data-testid="user-message-bubble"
+          className={cn(
+            "rounded-2xl px-4 py-2.5 overflow-hidden",
+            isFavorite ? "bg-yellow-200/50 dark:bg-yellow-500/10" : "bg-primary/30",
+          )}
+        >
           {hasAttachments && (
-            <div className={cn("flex flex-wrap gap-2", hasContent && "mb-2")}>
-              {imageAttachments.map((att, index) => (
-                <ImagePreviewDialog
-                  key={index}
-                  src={`data:${att.mime_type};base64,${att.data}`}
-                  alt={`Attachment ${index + 1}`}
-                  thumbnailClassName="max-h-48 max-w-full rounded-lg object-contain transition-opacity hover:opacity-90"
-                />
-              ))}
-              {fileAttachments.map((att, index) => (
-                <span
-                  key={`file-${index}`}
-                  data-testid="message-file-attachment"
-                  className="inline-flex self-start items-center gap-1.5 rounded-full bg-muted/40 px-2.5 py-1 text-xs text-muted-foreground"
-                >
-                  <IconFile size={12} />
-                  {att.name || "Attachment"}
-                </span>
-              ))}
-            </div>
+            <UserMessageAttachments
+              imageAttachments={imageAttachments}
+              fileAttachments={fileAttachments}
+              hasContent={hasContent}
+            />
           )}
           {renderUserMessageBody({
             hasContent,
@@ -477,6 +505,8 @@ function UserMessageContent({
           showNavigation={userNavigation.hasPrevious || userNavigation.hasNext}
           isRawView={showRaw}
           onToggleRaw={onToggleRaw}
+          isFavorite={isFavorite}
+          onToggleFavorite={toggleFavorite}
           onNavigatePrev={() => {
             if (userNavigation.previousId && onScrollToMessage)
               onScrollToMessage(userNavigation.previousId);

--- a/apps/web/components/task/chat/messages/chat-message.tsx
+++ b/apps/web/components/task/chat/messages/chat-message.tsx
@@ -398,6 +398,7 @@ function UserContextBadges({
 
 type UserMessageAttachment = { type: string; data: string; mime_type: string; name?: string };
 
+/** Renders image previews and file chips attached to a user message. */
 function UserMessageAttachments({
   imageAttachments,
   fileAttachments,

--- a/apps/web/components/task/chat/messages/message-actions.test.tsx
+++ b/apps/web/components/task/chat/messages/message-actions.test.tsx
@@ -75,3 +75,50 @@ describe("MessageActions timestamp tooltip on touch devices", () => {
     expect(screen.getByText(expectedAbsoluteTime)).not.toBeNull();
   });
 });
+
+describe("MessageActions favorite toggle", () => {
+  it("renders a star button reflecting isFavorite and calls onToggleFavorite when clicked", () => {
+    const onToggleFavorite = vi.fn();
+    render(
+      <StateProvider>
+        <MessageActions
+          message={assistantMessage()}
+          isFavorite={false}
+          onToggleFavorite={onToggleFavorite}
+        />
+      </StateProvider>,
+    );
+
+    const star = screen.getByRole("button", { name: /mark message as favorite/i });
+    expect(star.getAttribute("aria-pressed")).toBe("false");
+
+    fireEvent.click(star);
+
+    expect(onToggleFavorite).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows a filled star and 'remove from favorites' label when isFavorite is true", () => {
+    render(
+      <StateProvider>
+        <MessageActions
+          message={assistantMessage()}
+          isFavorite={true}
+          onToggleFavorite={() => {}}
+        />
+      </StateProvider>,
+    );
+
+    const star = screen.getByRole("button", { name: /remove message from favorites/i });
+    expect(star.getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("omits the favorite button entirely when onToggleFavorite is not provided", () => {
+    render(
+      <StateProvider>
+        <MessageActions message={assistantMessage()} />
+      </StateProvider>,
+    );
+
+    expect(screen.queryByRole("button", { name: /favorite/i })).toBeNull();
+  });
+});

--- a/apps/web/components/task/chat/messages/message-actions.test.tsx
+++ b/apps/web/components/task/chat/messages/message-actions.test.tsx
@@ -95,6 +95,9 @@ describe("MessageActions favorite toggle", () => {
     fireEvent.click(star);
 
     expect(onToggleFavorite).toHaveBeenCalledTimes(1);
+
+    expect(star.className).toMatch(/\bmin-h-11\b/);
+    expect(star.className).toMatch(/\bmin-w-11\b/);
   });
 
   it("shows a filled star and 'remove from favorites' label when isFavorite is true", () => {

--- a/apps/web/components/task/chat/messages/message-actions.tsx
+++ b/apps/web/components/task/chat/messages/message-actions.tsx
@@ -10,6 +10,7 @@ import {
   IconChevronRight,
   IconEyeCode,
   IconInfoCircle,
+  IconStar,
 } from "@tabler/icons-react";
 import { cn } from "@/lib/utils";
 import { formatRelativeTime } from "@/lib/utils";
@@ -50,7 +51,30 @@ type MessageActionsProps = {
   onNavigateNext?: () => void;
   hasPrev?: boolean;
   hasNext?: boolean;
+  isFavorite?: boolean;
+  onToggleFavorite?: () => void;
 };
+
+function FavoriteButton({ isFavorite, onToggle }: { isFavorite: boolean; onToggle: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      aria-pressed={isFavorite}
+      className={cn(
+        ACTION_BUTTON_SIZE,
+        ACTION_BUTTON_HOVER,
+        ACTION_BUTTON_TRANSITION,
+        "cursor-pointer",
+        isFavorite && "text-yellow-500",
+      )}
+      title={isFavorite ? "Remove from favorites" : "Mark as favorite"}
+      aria-label={isFavorite ? "Remove message from favorites" : "Mark message as favorite"}
+    >
+      <IconStar className={cn("h-full w-full", isFavorite && "fill-yellow-500")} />
+    </button>
+  );
+}
 
 function CopyButton({ copied, onCopy }: { copied: boolean; onCopy: () => void }) {
   return (
@@ -238,6 +262,30 @@ function MessageTimestamp({ createdAt }: { createdAt: string }) {
   );
 }
 
+function useMessageTurnAndUsage(message: Message): {
+  turn: Turn | null;
+  usageMultiplier: string | null;
+} {
+  return useAppStore(
+    useShallow((state) => {
+      const turnId = message.turn_id;
+      const turn =
+        turnId && message.session_id
+          ? (state.turns.bySession[message.session_id]?.find((item) => item.id === turnId) ?? null)
+          : null;
+      if (!message.session_id) return { turn, usageMultiplier: null };
+      const sessionModels = state.sessionModels.bySessionId[message.session_id];
+      const metadataModel = (message.metadata?.model ?? turn?.metadata?.model) as
+        | string
+        | undefined;
+      const modelId = metadataModel ?? sessionModels?.currentModelId;
+      const usageMultiplier =
+        sessionModels?.models.find((model) => model.modelId === modelId)?.usageMultiplier ?? null;
+      return { turn, usageMultiplier };
+    }),
+  );
+}
+
 function MessageMetaInfo({
   showModel,
   sessionConfigText,
@@ -261,40 +309,67 @@ function MessageMetaInfo({
   );
 }
 
-export function MessageActions({
-  message,
-  showCopy = true,
-  showTimestamp = true,
-  showRawToggle = true,
-  hasHiddenPrompts = false,
-  showNavigation = false,
-  showModel = false,
-  isRawView = false,
-  onToggleRaw,
-  onNavigatePrev,
-  onNavigateNext,
-  hasPrev = false,
-  hasNext = false,
-}: MessageActionsProps) {
+type ResolvedMessageActionsProps = {
+  message: Message;
+  showCopy: boolean;
+  showTimestamp: boolean;
+  showRawToggle: boolean;
+  hasHiddenPrompts: boolean;
+  showNavigation: boolean;
+  showModel: boolean;
+  isRawView: boolean;
+  onToggleRaw?: () => void;
+  onNavigatePrev?: () => void;
+  onNavigateNext?: () => void;
+  hasPrev: boolean;
+  hasNext: boolean;
+  isFavorite: boolean;
+  onToggleFavorite?: () => void;
+};
+
+// Resolves optional props to their defaults outside of `MessageActions` itself:
+// each defaulted destructured param is a branch for eslint's `complexity`
+// rule, and this component already has enough real branching in its JSX.
+function resolveMessageActionsProps(props: MessageActionsProps): ResolvedMessageActionsProps {
+  return {
+    message: props.message,
+    showCopy: props.showCopy ?? true,
+    showTimestamp: props.showTimestamp ?? true,
+    showRawToggle: props.showRawToggle ?? true,
+    hasHiddenPrompts: props.hasHiddenPrompts ?? false,
+    showNavigation: props.showNavigation ?? false,
+    showModel: props.showModel ?? false,
+    isRawView: props.isRawView ?? false,
+    onToggleRaw: props.onToggleRaw,
+    onNavigatePrev: props.onNavigatePrev,
+    onNavigateNext: props.onNavigateNext,
+    hasPrev: props.hasPrev ?? false,
+    hasNext: props.hasNext ?? false,
+    isFavorite: props.isFavorite ?? false,
+    onToggleFavorite: props.onToggleFavorite,
+  };
+}
+
+export function MessageActions(props: MessageActionsProps) {
+  const {
+    message,
+    showCopy,
+    showTimestamp,
+    showRawToggle,
+    hasHiddenPrompts,
+    showNavigation,
+    showModel,
+    isRawView,
+    onToggleRaw,
+    onNavigatePrev,
+    onNavigateNext,
+    hasPrev,
+    hasNext,
+    isFavorite,
+    onToggleFavorite,
+  } = resolveMessageActionsProps(props);
   const { copied, copy } = useCopyToClipboard();
-  const { turn, usageMultiplier } = useAppStore(
-    useShallow((state) => {
-      const turnId = message.turn_id;
-      const turn =
-        turnId && message.session_id
-          ? (state.turns.bySession[message.session_id]?.find((item) => item.id === turnId) ?? null)
-          : null;
-      if (!message.session_id) return { turn, usageMultiplier: null };
-      const sessionModels = state.sessionModels.bySessionId[message.session_id];
-      const metadataModel = (message.metadata?.model ?? turn?.metadata?.model) as
-        | string
-        | undefined;
-      const modelId = metadataModel ?? sessionModels?.currentModelId;
-      const usageMultiplier =
-        sessionModels?.models.find((model) => model.modelId === modelId)?.usageMultiplier ?? null;
-      return { turn, usageMultiplier };
-    }),
-  );
+  const { turn, usageMultiplier } = useMessageTurnAndUsage(message);
   const sessionConfigText = formatMessageSessionConfig(message.metadata, turn?.metadata);
   const handleCopy = async () => {
     await copy(message.content);
@@ -319,6 +394,7 @@ export function MessageActions({
         />
       )}
       <MessageDebugDialog message={message} turn={turn} usageMultiplier={usageMultiplier} />
+      {onToggleFavorite && <FavoriteButton isFavorite={isFavorite} onToggle={onToggleFavorite} />}
       <MessageMetaInfo
         showModel={showModel}
         sessionConfigText={sessionConfigText}

--- a/apps/web/components/task/chat/messages/message-actions.tsx
+++ b/apps/web/components/task/chat/messages/message-actions.tsx
@@ -55,6 +55,7 @@ type MessageActionsProps = {
   onToggleFavorite?: () => void;
 };
 
+/** Renders the accessible favorite toggle in a message action row. */
 function FavoriteButton({ isFavorite, onToggle }: { isFavorite: boolean; onToggle: () => void }) {
   return (
     <button
@@ -262,6 +263,7 @@ function MessageTimestamp({ createdAt }: { createdAt: string }) {
   );
 }
 
+/** Selects the message turn and its model-specific usage multiplier. */
 function useMessageTurnAndUsage(message: Message): {
   turn: Turn | null;
   usageMultiplier: string | null;
@@ -327,9 +329,9 @@ type ResolvedMessageActionsProps = {
   onToggleFavorite?: () => void;
 };
 
-// Resolves optional props to their defaults outside of `MessageActions` itself:
-// each defaulted destructured param is a branch for eslint's `complexity`
-// rule, and this component already has enough real branching in its JSX.
+/**
+ * Resolves optional action props before rendering to keep JSX complexity low.
+ */
 function resolveMessageActionsProps(props: MessageActionsProps): ResolvedMessageActionsProps {
   return {
     message: props.message,
@@ -350,6 +352,7 @@ function resolveMessageActionsProps(props: MessageActionsProps): ResolvedMessage
   };
 }
 
+/** Renders available actions and metadata for a chat message. */
 export function MessageActions(props: MessageActionsProps) {
   const {
     message,

--- a/apps/web/components/task/chat/messages/message-actions.tsx
+++ b/apps/web/components/task/chat/messages/message-actions.tsx
@@ -63,7 +63,7 @@ function FavoriteButton({ isFavorite, onToggle }: { isFavorite: boolean; onToggl
       onClick={onToggle}
       aria-pressed={isFavorite}
       className={cn(
-        ACTION_BUTTON_SIZE,
+        "flex min-h-11 min-w-11 items-center justify-center sm:min-h-0 sm:min-w-0 sm:h-5 sm:w-5 sm:p-1",
         ACTION_BUTTON_HOVER,
         ACTION_BUTTON_TRANSITION,
         "cursor-pointer",
@@ -72,7 +72,7 @@ function FavoriteButton({ isFavorite, onToggle }: { isFavorite: boolean; onToggl
       title={isFavorite ? "Remove from favorites" : "Mark as favorite"}
       aria-label={isFavorite ? "Remove message from favorites" : "Mark message as favorite"}
     >
-      <IconStar className={cn("h-full w-full", isFavorite && "fill-yellow-500")} />
+      <IconStar className={cn("h-5 w-5", isFavorite && "fill-yellow-500")} />
     </button>
   );
 }

--- a/apps/web/e2e/tests/chat/message-favorite.spec.ts
+++ b/apps/web/e2e/tests/chat/message-favorite.spec.ts
@@ -1,0 +1,56 @@
+// Regression guard: a session transcript message can be starred as a
+// "favorite" so a user can find it again quickly once the session has moved
+// on. Starring toggles the star icon's pressed state and tints the message
+// background light yellow (see message-actions.tsx / agent-message-content.tsx).
+import { test, expect } from "../../fixtures/test-base";
+import { SessionPage } from "../../pages/session-page";
+
+const SEEDED_MESSAGE = "Favorite toggle regression fixture message";
+
+test.describe("Chat message favorite toggle", () => {
+  test("stars a message, tints its background yellow, and un-stars it back", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    const task = await apiClient.createTask(seedData.workspaceId, "Message Favorite", {
+      description: "seeded message favorite fixture",
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+    });
+    const { session_id: sessionId } = await apiClient.seedTaskSession(task.id, {
+      state: "IDLE",
+    });
+    await apiClient.seedSessionMessage(sessionId, {
+      type: "message",
+      content: SEEDED_MESSAGE,
+    });
+
+    await testPage.goto(`/t/${task.id}`);
+    const session = new SessionPage(testPage);
+    await session.waitForLoad();
+
+    const chat = session.activeChat();
+    await expect(chat.getByText(SEEDED_MESSAGE)).toBeVisible({ timeout: 15_000 });
+
+    // Scope to the seeded message's own row, mirroring the timestamp-tooltip spec.
+    const messageBody = chat
+      .locator("[data-agent-message-body][data-message-id]")
+      .filter({ hasText: SEEDED_MESSAGE });
+    const highlight = messageBody.locator("xpath=..");
+    const star = highlight.getByRole("button", { name: "Mark message as favorite" });
+    await expect(star).toBeVisible();
+    expect(await highlight.getAttribute("class")).not.toMatch(/yellow/);
+
+    await star.click();
+
+    const unstar = highlight.getByRole("button", { name: "Remove message from favorites" });
+    await expect(unstar).toBeVisible();
+    await expect.poll(async () => highlight.getAttribute("class")).toMatch(/yellow/);
+
+    await unstar.click();
+
+    await expect(star).toBeVisible();
+    await expect.poll(async () => highlight.getAttribute("class")).not.toMatch(/yellow/);
+  });
+});

--- a/apps/web/e2e/tests/chat/mobile-message-favorite.spec.ts
+++ b/apps/web/e2e/tests/chat/mobile-message-favorite.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from "../../fixtures/test-base";
+import { SessionPage } from "../../pages/session-page";
+
+const SEEDED_MESSAGE = "Mobile favorite touch target fixture message";
+
+test.describe("Mobile chat message favorite toggle", () => {
+  test("offers a 44px target and toggles a message by touch", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    const task = await apiClient.createTask(seedData.workspaceId, "Mobile Message Favorite", {
+      description: "mobile favorite touch target fixture",
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+    });
+    const { session_id: sessionId } = await apiClient.seedTaskSession(task.id, {
+      state: "IDLE",
+    });
+    await apiClient.seedSessionMessage(sessionId, {
+      type: "message",
+      content: SEEDED_MESSAGE,
+    });
+
+    await testPage.goto(`/t/${task.id}`);
+    const session = new SessionPage(testPage);
+    await session.waitForLoad();
+
+    const chat = session.activeChat();
+    const messageBody = chat
+      .locator("[data-agent-message-body][data-message-id]")
+      .filter({ hasText: SEEDED_MESSAGE });
+    const star = messageBody
+      .locator("xpath=..")
+      .getByRole("button", { name: "Mark message as favorite" });
+    await expect(star).toBeVisible();
+
+    const box = await star.boundingBox();
+    expect(box).not.toBeNull();
+    expect(box!.width).toBeGreaterThanOrEqual(44);
+    expect(box!.height).toBeGreaterThanOrEqual(44);
+
+    await star.tap();
+    await expect(
+      messageBody
+        .locator("xpath=..")
+        .getByRole("button", { name: "Remove message from favorites" }),
+    ).toBeVisible();
+  });
+});

--- a/apps/web/hooks/domains/session/use-message-favorite.test.ts
+++ b/apps/web/hooks/domains/session/use-message-favorite.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useMessageFavorite } from "./use-message-favorite";
+import { useMessageFavoritesStore } from "@/lib/state/slices/message-favorites";
+
+const SESSION_ID = "session-hook-1";
+
+describe("useMessageFavorite", () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+    useMessageFavoritesStore.setState({ bySession: {} });
+  });
+
+  it("starts false and flips to true when toggled, then back to false", () => {
+    const { result } = renderHook(() => useMessageFavorite(SESSION_ID, "msg-1"));
+
+    expect(result.current.isFavorite).toBe(false);
+
+    act(() => result.current.toggleFavorite());
+    expect(result.current.isFavorite).toBe(true);
+
+    act(() => result.current.toggleFavorite());
+    expect(result.current.isFavorite).toBe(false);
+  });
+
+  it("hydrates a previously-favorited message from sessionStorage", () => {
+    useMessageFavoritesStore.getState().toggleFavorite(SESSION_ID, "msg-2");
+
+    const { result } = renderHook(() => useMessageFavorite(SESSION_ID, "msg-2"));
+
+    expect(result.current.isFavorite).toBe(true);
+  });
+
+  it("keeps favorites for different messages independent", () => {
+    const { result: resultA } = renderHook(() => useMessageFavorite(SESSION_ID, "msg-a"));
+    const { result: resultB } = renderHook(() => useMessageFavorite(SESSION_ID, "msg-b"));
+
+    act(() => resultA.current.toggleFavorite());
+
+    expect(resultA.current.isFavorite).toBe(true);
+    expect(resultB.current.isFavorite).toBe(false);
+  });
+});

--- a/apps/web/hooks/domains/session/use-message-favorite.test.ts
+++ b/apps/web/hooks/domains/session/use-message-favorite.test.ts
@@ -1,7 +1,10 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import { useMessageFavorite } from "./use-message-favorite";
-import { useMessageFavoritesStore } from "@/lib/state/slices/message-favorites";
+import {
+  useMessageFavoritesStore,
+  persistSessionFavorites,
+} from "@/lib/state/slices/message-favorites";
 
 const SESSION_ID = "session-hook-1";
 
@@ -24,7 +27,8 @@ describe("useMessageFavorite", () => {
   });
 
   it("hydrates a previously-favorited message from sessionStorage", () => {
-    useMessageFavoritesStore.getState().toggleFavorite(SESSION_ID, "msg-2");
+    persistSessionFavorites(SESSION_ID, ["msg-2"]);
+    useMessageFavoritesStore.setState({ bySession: {} });
 
     const { result } = renderHook(() => useMessageFavorite(SESSION_ID, "msg-2"));
 

--- a/apps/web/hooks/domains/session/use-message-favorite.ts
+++ b/apps/web/hooks/domains/session/use-message-favorite.ts
@@ -1,0 +1,27 @@
+import { useEffect } from "react";
+import { useMessageFavoritesStore } from "@/lib/state/slices/message-favorites";
+
+/**
+ * Client-only "favorite" flag for a chat message, scoped to its session and
+ * backed by sessionStorage (see `lib/state/slices/message-favorites`). Lets a
+ * user star a message in a fast-moving transcript to find it again later.
+ */
+export function useMessageFavorite(
+  sessionId: string,
+  messageId: string,
+): { isFavorite: boolean; toggleFavorite: () => void } {
+  const hydrateSession = useMessageFavoritesStore((state) => state.hydrateSession);
+  useEffect(() => {
+    hydrateSession(sessionId);
+  }, [sessionId, hydrateSession]);
+
+  const isFavorite = useMessageFavoritesStore((state) =>
+    Boolean(state.bySession[sessionId]?.[messageId]),
+  );
+  const toggleFavoriteInStore = useMessageFavoritesStore((state) => state.toggleFavorite);
+
+  return {
+    isFavorite,
+    toggleFavorite: () => toggleFavoriteInStore(sessionId, messageId),
+  };
+}

--- a/apps/web/lib/local-storage.test.ts
+++ b/apps/web/lib/local-storage.test.ts
@@ -12,6 +12,26 @@ import {
   wasPRClosedBannerDismissed,
   wasPRMergedBannerDismissed,
 } from "./local-storage";
+import {
+  loadSessionFavorites,
+  persistSessionFavorites,
+} from "./state/slices/message-favorites/persistence";
+
+describe("message favorites storage", () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+  });
+
+  it("clears a session's favorites via cleanupTaskStorage but leaves other sessions intact", () => {
+    persistSessionFavorites("session-a", ["msg-1"]);
+    persistSessionFavorites("session-b", ["msg-2"]);
+
+    cleanupTaskStorage("task-a", ["session-a"]);
+
+    expect(loadSessionFavorites("session-a")).toEqual([]);
+    expect(loadSessionFavorites("session-b")).toEqual(["msg-2"]);
+  });
+});
 
 describe("PR merged banner dismissal storage", () => {
   beforeEach(() => {

--- a/apps/web/lib/local-storage.ts
+++ b/apps/web/lib/local-storage.ts
@@ -671,6 +671,7 @@ export function cleanupTaskStorage(
     removeSessionStorage(`${ACTIVE_TAB_KEY}.${sessionId}`);
     removeSessionStorage(`kandev.contextFiles.${sessionId}`);
     removeSessionStorage(`kandev.comments.${sessionId}`);
+    removeSessionStorage(`kandev.messageFavorites.${sessionId}`);
   }
 }
 

--- a/apps/web/lib/state/slices/message-favorites/favorites-store.test.ts
+++ b/apps/web/lib/state/slices/message-favorites/favorites-store.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { useMessageFavoritesStore } from "./favorites-store";
+import { MESSAGE_FAVORITES_STORAGE_PREFIX, loadSessionFavorites } from "./persistence";
+
+const SESSION_ID = "session-favorites-1";
+const OTHER_SESSION_ID = "session-favorites-2";
+
+describe("message favorites store", () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+    useMessageFavoritesStore.setState({ bySession: {} });
+  });
+
+  it("starts with no favorites for an unhydrated session", () => {
+    const state = useMessageFavoritesStore.getState();
+    expect(state.bySession[SESSION_ID]).toBeUndefined();
+  });
+
+  it("toggling a message on marks it favorited and persists it to sessionStorage", () => {
+    useMessageFavoritesStore.getState().toggleFavorite(SESSION_ID, "msg-1");
+
+    const state = useMessageFavoritesStore.getState();
+    expect(state.bySession[SESSION_ID]?.["msg-1"]).toBe(true);
+    expect(loadSessionFavorites(SESSION_ID)).toEqual(["msg-1"]);
+    expect(
+      window.sessionStorage.getItem(`${MESSAGE_FAVORITES_STORAGE_PREFIX}${SESSION_ID}`),
+    ).not.toBeNull();
+  });
+
+  it("toggling a favorited message off removes it and clears storage once empty", () => {
+    useMessageFavoritesStore.getState().toggleFavorite(SESSION_ID, "msg-1");
+    useMessageFavoritesStore.getState().toggleFavorite(SESSION_ID, "msg-1");
+
+    const state = useMessageFavoritesStore.getState();
+    expect(state.bySession[SESSION_ID]?.["msg-1"]).toBeUndefined();
+    expect(loadSessionFavorites(SESSION_ID)).toEqual([]);
+    expect(
+      window.sessionStorage.getItem(`${MESSAGE_FAVORITES_STORAGE_PREFIX}${SESSION_ID}`),
+    ).toBeNull();
+  });
+
+  it("scopes favorites per session so unrelated sessions never share a namespace", () => {
+    useMessageFavoritesStore.getState().toggleFavorite(SESSION_ID, "msg-1");
+    useMessageFavoritesStore.getState().toggleFavorite(OTHER_SESSION_ID, "msg-2");
+
+    const state = useMessageFavoritesStore.getState();
+    expect(state.bySession[SESSION_ID]).toEqual({ "msg-1": true });
+    expect(state.bySession[OTHER_SESSION_ID]).toEqual({ "msg-2": true });
+  });
+
+  it("hydrates a session's favorites from sessionStorage after a remount", () => {
+    window.sessionStorage.setItem(
+      `${MESSAGE_FAVORITES_STORAGE_PREFIX}${SESSION_ID}`,
+      JSON.stringify(["msg-1", "msg-2"]),
+    );
+
+    useMessageFavoritesStore.getState().hydrateSession(SESSION_ID);
+
+    const state = useMessageFavoritesStore.getState();
+    expect(state.bySession[SESSION_ID]).toEqual({ "msg-1": true, "msg-2": true });
+  });
+
+  it("hydrating is a no-op once a session already has favorites in state", () => {
+    useMessageFavoritesStore.getState().toggleFavorite(SESSION_ID, "msg-1");
+    window.sessionStorage.setItem(
+      `${MESSAGE_FAVORITES_STORAGE_PREFIX}${SESSION_ID}`,
+      JSON.stringify(["msg-stale"]),
+    );
+
+    useMessageFavoritesStore.getState().hydrateSession(SESSION_ID);
+
+    expect(useMessageFavoritesStore.getState().bySession[SESSION_ID]).toEqual({ "msg-1": true });
+  });
+});

--- a/apps/web/lib/state/slices/message-favorites/favorites-store.test.ts
+++ b/apps/web/lib/state/slices/message-favorites/favorites-store.test.ts
@@ -60,6 +60,15 @@ describe("message favorites store", () => {
     expect(state.bySession[SESSION_ID]).toEqual({ "msg-1": true, "msg-2": true });
   });
 
+  it("ignores malformed persisted favorites", () => {
+    window.sessionStorage.setItem(
+      `${MESSAGE_FAVORITES_STORAGE_PREFIX}${SESSION_ID}`,
+      JSON.stringify("stale"),
+    );
+
+    expect(loadSessionFavorites(SESSION_ID)).toEqual([]);
+  });
+
   it("hydrating is a no-op once a session already has favorites in state", () => {
     useMessageFavoritesStore.getState().toggleFavorite(SESSION_ID, "msg-1");
     window.sessionStorage.setItem(
@@ -70,5 +79,25 @@ describe("message favorites store", () => {
     useMessageFavoritesStore.getState().hydrateSession(SESSION_ID);
 
     expect(useMessageFavoritesStore.getState().bySession[SESSION_ID]).toEqual({ "msg-1": true });
+  });
+
+  it("ignores a malformed persisted value instead of crashing on hydrate", () => {
+    window.sessionStorage.setItem(
+      `${MESSAGE_FAVORITES_STORAGE_PREFIX}${SESSION_ID}`,
+      JSON.stringify("stale"),
+    );
+
+    expect(() => useMessageFavoritesStore.getState().hydrateSession(SESSION_ID)).not.toThrow();
+    expect(useMessageFavoritesStore.getState().bySession[SESSION_ID]).toBeUndefined();
+  });
+
+  it("ignores a persisted array containing non-string entries", () => {
+    window.sessionStorage.setItem(
+      `${MESSAGE_FAVORITES_STORAGE_PREFIX}${SESSION_ID}`,
+      JSON.stringify(["msg-1", 42]),
+    );
+
+    expect(() => useMessageFavoritesStore.getState().hydrateSession(SESSION_ID)).not.toThrow();
+    expect(useMessageFavoritesStore.getState().bySession[SESSION_ID]).toBeUndefined();
   });
 });

--- a/apps/web/lib/state/slices/message-favorites/favorites-store.ts
+++ b/apps/web/lib/state/slices/message-favorites/favorites-store.ts
@@ -13,6 +13,7 @@ function persistSession(state: MessageFavoritesState, sessionId: string): void {
   persistSessionFavorites(sessionId, ids);
 }
 
+/** Session-scoped favorite state with hydration and persistence actions. */
 export const useMessageFavoritesStore = create<MessageFavoritesSlice>()(
   immer<MessageFavoritesSlice>((set) => ({
     ...defaultState,

--- a/apps/web/lib/state/slices/message-favorites/favorites-store.ts
+++ b/apps/web/lib/state/slices/message-favorites/favorites-store.ts
@@ -1,0 +1,41 @@
+import { create } from "zustand";
+import { immer } from "zustand/middleware/immer";
+import type { MessageFavoritesSlice, MessageFavoritesState } from "./types";
+import { persistSessionFavorites, loadSessionFavorites } from "./persistence";
+
+const defaultState: MessageFavoritesState = {
+  bySession: {},
+};
+
+/** Persist the current favorite set for a session to sessionStorage. */
+function persistSession(state: MessageFavoritesState, sessionId: string): void {
+  const ids = Object.keys(state.bySession[sessionId] ?? {});
+  persistSessionFavorites(sessionId, ids);
+}
+
+export const useMessageFavoritesStore = create<MessageFavoritesSlice>()(
+  immer<MessageFavoritesSlice>((set) => ({
+    ...defaultState,
+
+    hydrateSession: (sessionId: string) =>
+      set((state) => {
+        const existing = state.bySession[sessionId];
+        if (existing && Object.keys(existing).length > 0) return;
+        const ids = loadSessionFavorites(sessionId);
+        if (ids.length === 0) return;
+        state.bySession[sessionId] = Object.fromEntries(ids.map((id) => [id, true as const]));
+      }),
+
+    toggleFavorite: (sessionId: string, messageId: string) =>
+      set((state) => {
+        const current = { ...(state.bySession[sessionId] ?? {}) };
+        if (current[messageId]) {
+          delete current[messageId];
+        } else {
+          current[messageId] = true;
+        }
+        state.bySession[sessionId] = current;
+        persistSession(state, sessionId);
+      }),
+  })),
+);

--- a/apps/web/lib/state/slices/message-favorites/index.ts
+++ b/apps/web/lib/state/slices/message-favorites/index.ts
@@ -1,0 +1,12 @@
+export { useMessageFavoritesStore } from "./favorites-store";
+export type {
+  MessageFavoritesState,
+  MessageFavoritesActions,
+  MessageFavoritesSlice,
+} from "./types";
+export {
+  persistSessionFavorites,
+  loadSessionFavorites,
+  clearPersistedSessionFavorites,
+  MESSAGE_FAVORITES_STORAGE_PREFIX,
+} from "./persistence";

--- a/apps/web/lib/state/slices/message-favorites/persistence.ts
+++ b/apps/web/lib/state/slices/message-favorites/persistence.ts
@@ -1,0 +1,21 @@
+import { getSessionStorage, setSessionStorage, removeSessionStorage } from "@/lib/local-storage";
+
+const STORAGE_PREFIX = "kandev.messageFavorites.";
+
+export function persistSessionFavorites(sessionId: string, messageIds: string[]): void {
+  if (messageIds.length === 0) {
+    removeSessionStorage(`${STORAGE_PREFIX}${sessionId}`);
+    return;
+  }
+  setSessionStorage(`${STORAGE_PREFIX}${sessionId}`, messageIds);
+}
+
+export function loadSessionFavorites(sessionId: string): string[] {
+  return getSessionStorage<string[]>(`${STORAGE_PREFIX}${sessionId}`, []);
+}
+
+export function clearPersistedSessionFavorites(sessionId: string): void {
+  removeSessionStorage(`${STORAGE_PREFIX}${sessionId}`);
+}
+
+export const MESSAGE_FAVORITES_STORAGE_PREFIX = STORAGE_PREFIX;

--- a/apps/web/lib/state/slices/message-favorites/persistence.ts
+++ b/apps/web/lib/state/slices/message-favorites/persistence.ts
@@ -13,7 +13,8 @@ export function persistSessionFavorites(sessionId: string, messageIds: string[])
 
 /** Loads the favorite message IDs previously stored for a session. */
 export function loadSessionFavorites(sessionId: string): string[] {
-  return getSessionStorage<string[]>(`${STORAGE_PREFIX}${sessionId}`, []);
+  const value = getSessionStorage<string[]>(`${STORAGE_PREFIX}${sessionId}`, []);
+  return Array.isArray(value) && value.every((id) => typeof id === "string") ? value : [];
 }
 
 /** Removes all persisted favorite message IDs for a session. */

--- a/apps/web/lib/state/slices/message-favorites/persistence.ts
+++ b/apps/web/lib/state/slices/message-favorites/persistence.ts
@@ -2,6 +2,7 @@ import { getSessionStorage, setSessionStorage, removeSessionStorage } from "@/li
 
 const STORAGE_PREFIX = "kandev.messageFavorites.";
 
+/** Stores a session's favorite message IDs, removing empty sets. */
 export function persistSessionFavorites(sessionId: string, messageIds: string[]): void {
   if (messageIds.length === 0) {
     removeSessionStorage(`${STORAGE_PREFIX}${sessionId}`);
@@ -10,12 +11,15 @@ export function persistSessionFavorites(sessionId: string, messageIds: string[])
   setSessionStorage(`${STORAGE_PREFIX}${sessionId}`, messageIds);
 }
 
+/** Loads the favorite message IDs previously stored for a session. */
 export function loadSessionFavorites(sessionId: string): string[] {
   return getSessionStorage<string[]>(`${STORAGE_PREFIX}${sessionId}`, []);
 }
 
+/** Removes all persisted favorite message IDs for a session. */
 export function clearPersistedSessionFavorites(sessionId: string): void {
   removeSessionStorage(`${STORAGE_PREFIX}${sessionId}`);
 }
 
+/** Prefix used for session-scoped favorite message storage keys. */
 export const MESSAGE_FAVORITES_STORAGE_PREFIX = STORAGE_PREFIX;

--- a/apps/web/lib/state/slices/message-favorites/types.ts
+++ b/apps/web/lib/state/slices/message-favorites/types.ts
@@ -1,0 +1,19 @@
+/**
+ * Client-only "favorite" flag for chat messages. Lets a user star a message
+ * in the session transcript to find it again quickly. Not synced to the
+ * backend — persisted per-session in sessionStorage only (see persistence.ts).
+ */
+
+export type MessageFavoritesState = {
+  /** sessionId -> set of favorited message ids (value is always `true`). */
+  bySession: Record<string, Record<string, true>>;
+};
+
+export type MessageFavoritesActions = {
+  /** Load persisted favorites for a session into state (no-op once hydrated). */
+  hydrateSession: (sessionId: string) => void;
+  /** Flip the favorite flag for a message and persist the session's set. */
+  toggleFavorite: (sessionId: string, messageId: string) => void;
+};
+
+export type MessageFavoritesSlice = MessageFavoritesState & MessageFavoritesActions;

--- a/apps/web/lib/state/slices/message-favorites/types.ts
+++ b/apps/web/lib/state/slices/message-favorites/types.ts
@@ -1,14 +1,10 @@
-/**
- * Client-only "favorite" flag for chat messages. Lets a user star a message
- * in the session transcript to find it again quickly. Not synced to the
- * backend — persisted per-session in sessionStorage only (see persistence.ts).
- */
-
+/** Maps each session to its favorited message IDs. */
 export type MessageFavoritesState = {
   /** sessionId -> set of favorited message ids (value is always `true`). */
   bySession: Record<string, Record<string, true>>;
 };
 
+/** Actions for hydrating and toggling session-scoped message favorites. */
 export type MessageFavoritesActions = {
   /** Load persisted favorites for a session into state (no-op once hydrated). */
   hydrateSession: (sessionId: string) => void;
@@ -16,4 +12,5 @@ export type MessageFavoritesActions = {
   toggleFavorite: (sessionId: string, messageId: string) => void;
 };
 
+/** Complete message-favorites store contract. */
 export type MessageFavoritesSlice = MessageFavoritesState & MessageFavoritesActions;


### PR DESCRIPTION
Fast-moving session transcripts make important messages hard to find again. Adds a per-message favorite toggle that highlights starred chat messages and keeps the marker across reloads for the browser session.

## Important Changes

- Added a session-scoped message favorites store backed by `sessionStorage`, cleared with task storage cleanup.
- Added a star action to chat message controls and yellow highlight styling for favorited user and agent messages.
- Added unit, hook, component, and Playwright coverage for the favorite toggle flow.

## Validation

- `make fmt` — attempted first; blocked by missing Go toolchain in this environment (`go: No such file or directory`).
- `make fmt-web` — passed.
- `pnpm exec vitest run components/task/chat/messages/chat-message.test.tsx components/task/chat/messages/message-actions.test.tsx components/task/chat/messages/message-comment-surface.test.tsx lib/state/slices/message-favorites/favorites-store.test.ts hooks/domains/session/use-message-favorite.test.ts lib/local-storage.test.ts` — 6 files, 66 tests passed.
- `make typecheck-web` — passed.
- `make lint-web` — passed.
- `make test-web` — 915/917 files passed; 2 unrelated file-browser specs timed out in `beforeEach` under full-suite parallel load.
- `pnpm exec vitest run components/task/file-browser-apply-changes.test.ts components/task/file-browser-load-children.test.ts` — the 2 timeout specs passed in isolation, 8 tests passed.
- Playwright spec added at `apps/web/e2e/tests/chat/message-favorite.spec.ts`; full E2E execution was blocked because the sandbox has no Go toolchain for the backend E2E fixture build.
- Manual browser demo on mock task verified desktop and mobile render, star toggle, yellow highlight, and reload persistence.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2008?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- kandev-screenshots-start -->
## Screenshots

![Desktop chat message favorite highlight](https://raw.githubusercontent.com/ClemDNL/kandev/77e57aa51efc1693bd6ec897e73009f8507cda7b/message-favorite-desktop.png)

![Mobile chat message favorite highlight](https://raw.githubusercontent.com/ClemDNL/kandev/77e57aa51efc1693bd6ec897e73009f8507cda7b/message-favorite-mobile.png)
<!-- kandev-screenshots-end -->
