### PR TITLE
fix: reconcile Windows workspace directory links (#2005)

### DIFF
--- a/apps/backend/internal/agent/runtime/lifecycle/workspace_sources_reconcile.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/workspace_sources_reconcile.go
@@ -40,6 +40,10 @@ func reconcileWorkspaceRepositories(root string, repositories []WorkspaceReposit
 	if root == "" {
 		return fmt.Errorf("workspace root is required for durable repositories")
 	}
+	rootInfo, err := os.Stat(root)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("inspect workspace root: %w", err)
+	}
 	for _, repository := range repositories {
 		if repository.RepoName == "" || filepath.Base(repository.RepoName) != repository.RepoName || repository.RepositoryPath == "" {
 			return fmt.Errorf("invalid durable workspace repository")
@@ -47,6 +51,12 @@ func reconcileWorkspaceRepositories(root string, repositories []WorkspaceReposit
 		info, err := os.Stat(repository.RepositoryPath)
 		if err != nil || !info.IsDir() {
 			return fmt.Errorf("workspace repository %q target is missing: %s", repository.RepoName, repository.RepositoryPath)
+		}
+		if rootInfo != nil && os.SameFile(rootInfo, info) {
+			if _, err := worktree.RemoveSelfReferentialDirectoryLink(root, repository.RepoName); err != nil {
+				return fmt.Errorf("remove self-referential workspace repository %q: %w", repository.RepoName, err)
+			}
+			continue
 		}
 		if _, _, err := worktree.EnsureOwnedDirectoryLink(root, repository.RepoName, repository.RepositoryPath); err != nil {
 			return fmt.Errorf("link workspace repository %q: %w", repository.RepoName, err)

--- a/apps/backend/internal/agent/runtime/lifecycle/workspace_sources_reconcile_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/workspace_sources_reconcile_test.go
@@ -19,13 +19,59 @@ func TestReconcileWorkspaceRepositories_RecreatesMissingOwnedLink(t *testing.T) 
 	if err := reconcileWorkspaceRepositories(root, []WorkspaceRepositorySpec{{RepoName: "api", RepositoryPath: source}}); err != nil {
 		t.Fatalf("reconcileWorkspaceRepositories: %v", err)
 	}
-	if got, err := os.Readlink(filepath.Join(root, "api")); err != nil || got != source {
-		t.Fatalf("repository link = %q, %v; want %q", got, err, source)
+	linkInfo, err := os.Stat(filepath.Join(root, "api"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	sourceInfo, err := os.Stat(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !os.SameFile(linkInfo, sourceInfo) {
+		t.Fatal("repository link does not resolve to its source")
 	}
 	if err := os.Remove(filepath.Join(root, "api")); err != nil {
 		t.Fatal(err)
 	}
 	if err := reconcileWorkspaceRepositories(root, []WorkspaceRepositorySpec{{RepoName: "api", RepositoryPath: source}}); err != nil {
 		t.Fatalf("reconcile after reset: %v", err)
+	}
+}
+
+func TestReconcileWorkspaceRepositories_SkipsRepositoryUsedAsWorkspaceRoot(t *testing.T) {
+	root := t.TempDir()
+	link := filepath.Join(root, filepath.Base(root))
+
+	if err := reconcileWorkspaceRepositories(root, []WorkspaceRepositorySpec{{RepoName: filepath.Base(root), RepositoryPath: root}}); err != nil {
+		t.Fatalf("reconcileWorkspaceRepositories: %v", err)
+	}
+	if _, err := os.Lstat(link); !os.IsNotExist(err) {
+		t.Fatalf("self-referential repository link exists after reconcile: %v", err)
+	}
+}
+
+func TestReconcileWorkspaceRepositories_RemovesExistingSelfReferentialLink(t *testing.T) {
+	root := t.TempDir()
+	link := filepath.Join(root, filepath.Base(root))
+	if err := os.Symlink(root, link); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	before, err := os.Stat(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := reconcileWorkspaceRepositories(root, []WorkspaceRepositorySpec{{RepoName: filepath.Base(root), RepositoryPath: root}}); err != nil {
+		t.Fatalf("reconcileWorkspaceRepositories: %v", err)
+	}
+	if _, err := os.Lstat(link); !os.IsNotExist(err) {
+		t.Fatalf("self-referential repository link exists after reconcile: %v", err)
+	}
+	after, err := os.Stat(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !os.SameFile(before, after) {
+		t.Fatal("workspace root changed while removing its self-link")
 	}
 }

--- a/apps/backend/internal/worktree/directory_link.go
+++ b/apps/backend/internal/worktree/directory_link.go
@@ -88,15 +88,15 @@ func EnsureOwnedDirectoryLink(root, name, target string) (string, bool, error) {
 		if !isPlatformDirectoryLink(info, link) {
 			return "", false, fmt.Errorf("owned link entry already exists: %s", name)
 		}
-		actual, err := filepath.EvalSymlinks(link)
+		actual, err := os.Stat(link)
 		if err != nil {
 			return "", false, fmt.Errorf("resolve owned link: %w", err)
 		}
-		expected, err := filepath.EvalSymlinks(target)
+		expected, err := os.Stat(target)
 		if err != nil {
 			return "", false, fmt.Errorf("canonicalize link target: %w", err)
 		}
-		if filepath.Clean(actual) != filepath.Clean(expected) {
+		if !os.SameFile(actual, expected) {
 			return "", false, fmt.Errorf("owned link target mismatch: %s", name)
 		}
 		return link, false, nil
@@ -106,6 +106,43 @@ func EnsureOwnedDirectoryLink(root, name, target string) (string, bool, error) {
 	}
 	created, err := CreateOwnedDirectoryLink(root, name, target)
 	return created, err == nil, err
+}
+
+// RemoveSelfReferentialDirectoryLink removes name only when it is a platform
+// directory link whose target is root. It never recursively removes entries.
+func RemoveSelfReferentialDirectoryLink(root, name string) (bool, error) {
+	if !isOwnedDirectoryLinkPath(root, name) {
+		return false, fmt.Errorf("invalid owned link path")
+	}
+	link, err := ownedDirectoryLinkPath(root, name)
+	if err != nil {
+		return false, err
+	}
+	linkInfo, err := os.Lstat(link)
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("inspect owned link entry: %w", err)
+	}
+	if !isPlatformDirectoryLink(linkInfo, link) {
+		return false, nil
+	}
+	rootInfo, err := os.Stat(root)
+	if err != nil {
+		return false, fmt.Errorf("inspect owned root: %w", err)
+	}
+	targetInfo, err := os.Stat(link)
+	if err != nil {
+		return false, fmt.Errorf("resolve owned link: %w", err)
+	}
+	if !os.SameFile(rootInfo, targetInfo) {
+		return false, nil
+	}
+	if err := os.Remove(link); err != nil {
+		return false, fmt.Errorf("remove self-referential owned link: %w", err)
+	}
+	return true, nil
 }
 
 func mkdirOwned(root string) error {

--- a/apps/backend/internal/worktree/directory_link_linux_test.go
+++ b/apps/backend/internal/worktree/directory_link_linux_test.go
@@ -1,0 +1,38 @@
+//go:build linux
+
+package worktree
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+func TestEnsureOwnedDirectoryLinkAcceptsSameFileTargetAlias(t *testing.T) {
+	source := filepath.Join(t.TempDir(), "source")
+	alias := filepath.Join(t.TempDir(), "alias")
+	if err := os.Mkdir(source, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(alias, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := syscall.Mount(source, alias, "", syscall.MS_BIND, ""); err != nil {
+		t.Skipf("bind mounts unavailable: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := syscall.Unmount(alias, 0); err != nil {
+			t.Errorf("unmount alias: %v", err)
+		}
+	})
+
+	root := filepath.Join(t.TempDir(), "tasks", "task-1")
+	if _, err := CreateOwnedDirectoryLink(root, "source", source); err != nil {
+		t.Fatalf("CreateOwnedDirectoryLink: %v", err)
+	}
+
+	if _, _, err := EnsureOwnedDirectoryLink(root, "source", alias); err != nil {
+		t.Fatalf("EnsureOwnedDirectoryLink rejected the same directory through an alias: %v", err)
+	}
+}

--- a/apps/backend/internal/worktree/directory_link_test.go
+++ b/apps/backend/internal/worktree/directory_link_test.go
@@ -55,3 +55,110 @@ func TestCreateOwnedDirectoryLinkRejectsSymlinkedControlAncestor(t *testing.T) {
 		t.Fatal("CreateOwnedDirectoryLink accepted symlinked control ancestor")
 	}
 }
+
+func TestEnsureOwnedDirectoryLinkReturnsExistingMatchingLink(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "tasks", "task-1")
+	target := t.TempDir()
+	link, err := CreateOwnedDirectoryLink(root, "source", target)
+	if err != nil {
+		t.Fatalf("CreateOwnedDirectoryLink: %v", err)
+	}
+
+	got, created, err := EnsureOwnedDirectoryLink(root, "source", target)
+	if err != nil {
+		t.Fatalf("EnsureOwnedDirectoryLink: %v", err)
+	}
+	if got != link || created {
+		t.Fatalf("EnsureOwnedDirectoryLink = %q, %t; want %q, false", got, created, link)
+	}
+}
+
+func TestEnsureOwnedDirectoryLinkRejectsDifferentTarget(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "tasks", "task-1")
+	originalTarget := t.TempDir()
+	if _, err := CreateOwnedDirectoryLink(root, "source", originalTarget); err != nil {
+		t.Fatalf("CreateOwnedDirectoryLink: %v", err)
+	}
+
+	if _, _, err := EnsureOwnedDirectoryLink(root, "source", t.TempDir()); err == nil {
+		t.Fatal("EnsureOwnedDirectoryLink accepted a different target")
+	}
+	targetInfo, err := os.Stat(filepath.Join(root, "source"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	originalInfo, err := os.Stat(originalTarget)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !os.SameFile(targetInfo, originalInfo) {
+		t.Fatal("EnsureOwnedDirectoryLink replaced the existing link")
+	}
+}
+
+func TestRemoveSelfReferentialDirectoryLinkRemovesOnlyLink(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "keep.txt"), []byte("keep"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := CreateOwnedDirectoryLink(root, "source", root); err != nil {
+		t.Fatalf("CreateOwnedDirectoryLink: %v", err)
+	}
+
+	removed, err := RemoveSelfReferentialDirectoryLink(root, "source")
+	if err != nil {
+		t.Fatalf("RemoveSelfReferentialDirectoryLink: %v", err)
+	}
+	if !removed {
+		t.Fatal("RemoveSelfReferentialDirectoryLink did not remove the self-link")
+	}
+	if _, err := os.Lstat(filepath.Join(root, "source")); !os.IsNotExist(err) {
+		t.Fatalf("self-link still exists: %v", err)
+	}
+	if got, err := os.ReadFile(filepath.Join(root, "keep.txt")); err != nil || string(got) != "keep" {
+		t.Fatalf("root contents changed: %q, %v", got, err)
+	}
+}
+
+func TestRemoveSelfReferentialDirectoryLinkLeavesOtherEntries(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(t *testing.T, root, entry string)
+	}{
+		{
+			name: "link to another directory",
+			setup: func(t *testing.T, root, entry string) {
+				t.Helper()
+				if _, err := CreateOwnedDirectoryLink(root, entry, t.TempDir()); err != nil {
+					t.Fatalf("CreateOwnedDirectoryLink: %v", err)
+				}
+			},
+		},
+		{
+			name: "real directory",
+			setup: func(t *testing.T, root, entry string) {
+				t.Helper()
+				if err := os.Mkdir(filepath.Join(root, entry), 0o755); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			tt.setup(t, root, "source")
+
+			removed, err := RemoveSelfReferentialDirectoryLink(root, "source")
+			if err != nil {
+				t.Fatalf("RemoveSelfReferentialDirectoryLink: %v", err)
+			}
+			if removed {
+				t.Fatal("RemoveSelfReferentialDirectoryLink removed a non-self entry")
+			}
+			if _, err := os.Lstat(filepath.Join(root, "source")); err != nil {
+				t.Fatalf("entry was modified: %v", err)
+			}
+		})
+	}
+}

--- a/docs/plans/windows-owned-directory-links/plan.md
+++ b/docs/plans/windows-owned-directory-links/plan.md
@@ -1,0 +1,83 @@
+---
+spec: docs/specs/tasks/attach-workspace-sources.md
+created: 2026-07-28
+status: done
+issue: https://github.com/kdlbs/kandev/issues/2005
+---
+
+# Implementation Plan: Windows Owned Directory Link Reconciliation
+
+## Overview
+
+Local launch and resume currently reconcile the primary repository beneath a workspace root that
+may be that same repository, creating a self-referential link. Existing Windows junctions are then
+rejected because `filepath.EvalSymlinks` does not follow mount-point reparse points. The fix first
+makes owned-link matching and cleanup use filesystem identity, then makes repository reconciliation
+skip and self-heal only a source that is the workspace root.
+
+## Confirmed root cause
+
+- `launchResolveWorkspacePath` uses the primary repository as the Local workspace when no promoted
+  task root exists.
+- `reconcileWorkspaceRepositories` attempts to materialize every repository spec, including that
+  primary repository, beneath the workspace.
+- `EnsureOwnedDirectoryLink` compares `filepath.EvalSymlinks` strings. On Windows, a directory
+  junction's evaluated path remains the junction path, so an unchanged junction mismatches its
+  target.
+
+## Backend
+
+### Owned directory-link identity
+
+Update `apps/backend/internal/worktree/directory_link.go` so an existing platform directory link is
+matched with `os.Stat` plus `os.SameFile`. Add a narrowly scoped removal helper that validates the
+owned entry, confirms it is a platform directory link whose target is the root by filesystem
+identity, and removes it with `os.Remove` only.
+
+### Local repository reconciliation
+
+Update
+`apps/backend/internal/agent/runtime/lifecycle/workspace_sources_reconcile.go` to compare each valid
+repository target with the workspace root by filesystem identity. When they match, remove an
+existing exact self-reference through the worktree helper and skip materialization. Preserve every
+repository link when the workspace is a distinct Kandev-owned task root.
+
+## Tests
+
+- **What:** matching owned links are idempotent, mismatched links fail closed, and only an exact
+  self-reference is removed.
+  **File:** `apps/backend/internal/worktree/directory_link_test.go`.
+  **How:** filesystem unit tests using real temporary directories and platform directory links.
+- **What:** a repository identical to the workspace root is skipped and a pre-existing self-link is
+  healed, while a distinct primary source remains linked under a promoted task root.
+  **File:**
+  `apps/backend/internal/agent/runtime/lifecycle/workspace_sources_reconcile_test.go`.
+  **How:** lifecycle package tests using real temporary directories.
+
+No Playwright test is planned because this changes backend launch/resume filesystem behavior and
+does not change a browser flow or UI contract.
+
+## Implementation Waves And Parallel Candidates
+
+Sequential execution in the primary conversation:
+
+- [x] [Task 01: filesystem identity and safe self-link removal](task-01-directory-link-identity.md)
+- [x] [Task 02: root-aware repository reconciliation](task-02-root-aware-reconciliation.md)
+
+## Risks and out of scope
+
+- Removal must fail closed for real directories, files, non-directory links, and links to any
+  directory other than the workspace root.
+- Multi-repository Local tasks already promoted to a Kandev-owned task root must retain every
+  source link, including the first repository.
+- The issue's unconfirmed attached-folder root-equality path and unmaterialized multi-repository
+  Local layout are out of scope.
+
+## Verification results
+
+- `make fmt` — passed.
+- `make typecheck` — passed.
+- `make test` — passed, including backend, web, CLI, scripts, and desktop smoke coverage.
+- `make lint` — passed.
+- Windows `amd64` test binaries for `internal/worktree` and
+  `internal/agent/runtime/lifecycle` — cross-compiled successfully.

--- a/docs/plans/windows-owned-directory-links/task-01-directory-link-identity.md
+++ b/docs/plans/windows-owned-directory-links/task-01-directory-link-identity.md
@@ -1,0 +1,57 @@
+---
+id: "01-directory-link-identity"
+title: "Filesystem identity and safe self-link removal"
+status: done
+wave: 1
+depends_on: []
+plan: "plan.md"
+spec: "../../specs/tasks/attach-workspace-sources.md"
+---
+
+# Task 01: Filesystem identity and safe self-link removal
+
+## Acceptance
+
+- Re-ensuring an owned platform directory link succeeds when the link and configured target refer
+  to the same filesystem directory.
+- A mismatched or non-link entry remains untouched and fails closed where applicable.
+- Self-link cleanup removes only a platform directory link whose target is the owned root and uses
+  non-recursive removal.
+
+## Verification
+
+```bash
+cd apps/backend && go test -run 'Test(Ensure|RemoveSelfReferential)' ./internal/worktree
+```
+
+## Files likely touched
+
+- `apps/backend/internal/worktree/directory_link.go`
+- `apps/backend/internal/worktree/directory_link_test.go`
+
+## Dependencies
+
+None.
+
+## Parallelism
+
+Sequential. Task 02 consumes the cleanup helper created here.
+
+## Inputs
+
+- `docs/specs/tasks/attach-workspace-sources.md`
+- Issue #2005's measured Windows junction behavior
+- Existing platform-link detection in `directory_link_unix.go` and `directory_link_windows.go`
+
+## Output contract
+
+Report the failing and passing targeted test commands, changed files, blockers and risks, then mark
+this task done and update `plan.md`.
+
+## Results
+
+- RED: the Linux bind-alias regression failed because the existing link was rejected as a target
+  mismatch.
+- GREEN: all seven `EnsureOwnedDirectoryLink` and `RemoveSelfReferentialDirectoryLink` targeted
+  tests passed.
+- Windows `amd64` package test binary cross-compilation passed.

--- a/docs/plans/windows-owned-directory-links/task-02-root-aware-reconciliation.md
+++ b/docs/plans/windows-owned-directory-links/task-02-root-aware-reconciliation.md
@@ -1,0 +1,58 @@
+---
+id: "02-root-aware-reconciliation"
+title: "Root-aware repository reconciliation"
+status: done
+wave: 2
+depends_on: ["01-directory-link-identity"]
+plan: "plan.md"
+spec: "../../specs/tasks/attach-workspace-sources.md"
+---
+
+# Task 02: Root-aware repository reconciliation
+
+## Acceptance
+
+- A Local task whose workspace root is its primary repository does not create a nested repository
+  link.
+- A pre-existing exact self-referential platform directory link is removed without modifying the
+  repository target.
+- A host-materialized task root still receives links for every distinct repository, including the
+  first repository spec.
+
+## Verification
+
+```bash
+cd apps/backend && go test -run TestReconcileWorkspaceRepositories ./internal/agent/runtime/lifecycle
+```
+
+## Files likely touched
+
+- `apps/backend/internal/agent/runtime/lifecycle/workspace_sources_reconcile.go`
+- `apps/backend/internal/agent/runtime/lifecycle/workspace_sources_reconcile_test.go`
+
+## Dependencies
+
+Task 01.
+
+## Parallelism
+
+Sequential because it consumes the worktree cleanup helper.
+
+## Inputs
+
+- `docs/specs/tasks/attach-workspace-sources.md`
+- `docs/plans/windows-owned-directory-links/plan.md`
+- `buildRemoteWorkspaceRepositories` primary-root skip as a behavioral analogue
+
+## Output contract
+
+Report the failing and passing targeted test commands, changed files, blockers and risks, then mark
+this task and the plan done.
+
+## Results
+
+- RED: the root-equality and existing-self-link regressions both failed because reconciliation
+  left a self-referential entry in place.
+- GREEN: all three targeted repository-reconciliation tests passed.
+- Full affected packages passed with 1,237 tests across `internal/worktree` and
+  `internal/agent/runtime/lifecycle`.

--- a/docs/specs/tasks/attach-workspace-sources.md
+++ b/docs/specs/tasks/attach-workspace-sources.md
@@ -60,6 +60,13 @@ manually moving files into the task workspace.
   reachable so **Open workspace folder** still works. The repository action is disabled and shows
   the reason in touch-visible text rather than relying on a tooltip.
 - Existing conversations, task state, plan, sessions, and repository attachments remain intact.
+- Launching or resuming a Local task whose workspace is its primary repository does not create a
+  repository-named link inside that repository. If an earlier Kandev version created that exact
+  self-referential directory link, the next reconciliation removes only the link and leaves the
+  repository contents unchanged.
+- Reconciliation treats an existing owned directory link as unchanged when it resolves to the same
+  filesystem directory as its configured target, including Windows directory junctions and path
+  aliases.
 - Agents receive a batch `add_workspace_sources_kandev` MCP tool that uses the same validation and
   materialization path.
 - The existing worktree-only `add_branch_to_task_kandev` tool remains a live compatibility path
@@ -178,6 +185,8 @@ persisted in source URLs or copied into agent-visible metadata.
 | An idle agent must restart to adopt the promoted root          | The intentional stop is not shown as a prior agent failure; the replacement agent uses the promoted task root.                                      |
 | A requested file move or rename crosses canonical source roots | The request is rejected before either source is mutated.                                                                                            |
 | A persisted local folder later disappears                      | The current live environment keeps its existing materialization; a new/reset environment surfaces the missing source and does not silently omit it. |
+| A Local task workspace is the primary repository itself        | Reconciliation skips the primary repository entry and removes only an existing self-referential Kandev directory link.                              |
+| An owned directory link already targets the configured source  | Relaunch and resume accept the link by filesystem identity instead of replacing or rejecting it.                                                    |
 | The client disconnects during materialization                  | Rollback runs on a detached bounded context and the eventual task event reflects durable state.                                                     |
 
 ## Persistence guarantees
@@ -220,6 +229,14 @@ must be retried.
 - **GIVEN** a repository-backed local task, **WHEN** the user adds a local Git repository and an
   arbitrary folder in one submission, **THEN** both live sources appear under one task workspace and
   the folder does not appear in Git-only controls.
+- **GIVEN** a single-repository Local task whose workspace path is the repository itself, **WHEN**
+  the task launches or resumes, **THEN** Kandev does not create a repository-named entry inside the
+  repository.
+- **GIVEN** an earlier Kandev version created a directory link inside a Local task repository that
+  points back to that repository, **WHEN** workspace repositories reconcile, **THEN** Kandev
+  removes only that self-referential link and leaves every repository file unchanged.
+- **GIVEN** an owned Windows directory junction already targets the configured workspace source,
+  **WHEN** the task relaunches or resumes, **THEN** reconciliation accepts the unchanged junction.
 - **GIVEN** a Docker, SSH, or Sprites task, **WHEN** the user opens **Add sources**, **THEN** the
   workspace, local-Git, and remote repository choices are available from **Add repository**, and
   the local-folder affordance is not offered.


### PR DESCRIPTION
Local launches can use the primary repository as the workspace root, which planted a recursive repository-named link and caused Windows relaunches to fail. This PR compares links by filesystem identity and removes only exact self-referential links, while preserving distinct source links.

## Important Changes

- Accept unchanged Windows junctions and other filesystem path aliases.
- Skip and self-heal the primary repository when it is already the workspace root.
- Add regression coverage for aliases, self-links, mismatched targets, and fail-closed cleanup.

## Validation

- `make fmt`
- `make typecheck`
- `make test`
- `make lint`
- `go test ./internal/worktree ./internal/agent/runtime/lifecycle` (1,237 tests)
- Windows amd64 cross-compilation of both affected package test binaries

Closes #2005

## Possible Improvements

Low risk; attached-folder root-equality and unmaterialized multi-repository Local layouts remain outside this fix's confirmed scope.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2009?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->