### PR TITLE
refactor(backend): drop dead req param from resolveGHToken

### DIFF
--- a/apps/backend/internal/agent/runtime/lifecycle/executor_sprites_credentials.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/executor_sprites_credentials.go
@@ -42,7 +42,7 @@ func (r *SpritesExecutor) uploadCredentials(
 
 	// Ignore the retired host-global gh token method in stale profiles. GitHub
 	// automation credentials are supplied by the workspace credential broker.
-	selectedMethodIDs = r.resolveGHToken(selectedMethodIDs, req)
+	selectedMethodIDs = r.resolveGHToken(selectedMethodIDs)
 
 	if len(selectedMethodIDs) == 0 {
 		return nil
@@ -122,8 +122,7 @@ func (r *SpritesExecutor) runAuthSetupScripts(
 
 // resolveGHToken filters the retired host-global gh token method from stale
 // profiles. Explicit secret-backed GITHUB_TOKEN values are resolved separately.
-func (r *SpritesExecutor) resolveGHToken(credentialIDs []string, req *ExecutorCreateRequest) []string {
-	_ = req
+func (r *SpritesExecutor) resolveGHToken(credentialIDs []string) []string {
 	return removeID(credentialIDs, "gh_cli_token")
 }
 

--- a/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_credentials.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_credentials.go
@@ -46,7 +46,7 @@ func (r *SSHExecutor) uploadCredentials(
 		return fmt.Errorf("failed to parse remote_credentials: %w", err)
 	}
 
-	selectedMethodIDs = r.resolveGHToken(selectedMethodIDs, req)
+	selectedMethodIDs = r.resolveGHToken(selectedMethodIDs)
 
 	fileMethods := selectFileMethods(catalog, selectedMethodIDs, r.logger)
 	if len(fileMethods) == 0 {
@@ -133,8 +133,7 @@ func (r *SSHExecutor) runOneAuthSetupScript(
 
 // resolveGHToken filters the retired host-global gh token method from stale
 // profiles. Explicit secret-backed GITHUB_TOKEN values are resolved separately.
-func (r *SSHExecutor) resolveGHToken(ids []string, req *ExecutorCreateRequest) []string {
-	_ = req
+func (r *SSHExecutor) resolveGHToken(ids []string) []string {
 	return removeID(ids, "gh_cli_token")
 }
 

--- a/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_credentials_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_credentials_test.go
@@ -2,8 +2,6 @@ package lifecycle
 
 import (
 	"context"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -11,29 +9,24 @@ import (
 )
 
 func TestRemoteExecutorsIgnoreLegacyHostGHTokenSelection(t *testing.T) {
-	binDir := t.TempDir()
-	ghPath := filepath.Join(binDir, "gh")
-	if err := os.WriteFile(ghPath, []byte("#!/bin/sh\nprintf host-global-token\n"), 0o755); err != nil {
-		t.Fatalf("write fake gh: %v", err)
-	}
-	t.Setenv("PATH", binDir)
-
+	// resolveGHToken is a pure filter: it can no longer reach the request, so
+	// a stale gh_cli_token selection is dropped rather than turned into a
+	// host-global GITHUB_TOKEN injection.
 	tests := []struct {
 		name    string
-		resolve func([]string, *ExecutorCreateRequest) []string
+		resolve func([]string) []string
 	}{
 		{name: "ssh", resolve: (&SSHExecutor{logger: newTestLogger()}).resolveGHToken},
 		{name: "sprites", resolve: (&SpritesExecutor{logger: newTestLogger()}).resolveGHToken},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := &ExecutorCreateRequest{Env: map[string]string{}}
-			remaining := tt.resolve([]string{"gh_cli_token", "agent:codex:files:0"}, req)
-			if got := req.Env["GITHUB_TOKEN"]; got != "" {
-				t.Fatalf("GITHUB_TOKEN = %q, want no host-global token injection", got)
-			}
+			remaining := tt.resolve([]string{"gh_cli_token", "agent:codex:files:0"})
 			if len(remaining) != 1 || remaining[0] != "agent:codex:files:0" {
 				t.Fatalf("remaining methods = %v, want stale gh_cli_token filtered", remaining)
+			}
+			if got := tt.resolve([]string{"agent:codex:files:0"}); len(got) != 1 {
+				t.Fatalf("resolve without gh_cli_token = %v, want untouched selection", got)
 			}
 		})
 	}

--- a/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_credentials_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_credentials_test.go
@@ -25,7 +25,7 @@ func TestRemoteExecutorsIgnoreLegacyHostGHTokenSelection(t *testing.T) {
 			if len(remaining) != 1 || remaining[0] != "agent:codex:files:0" {
 				t.Fatalf("remaining methods = %v, want stale gh_cli_token filtered", remaining)
 			}
-			if got := tt.resolve([]string{"agent:codex:files:0"}); len(got) != 1 {
+			if got := tt.resolve([]string{"agent:codex:files:0"}); len(got) != 1 || got[0] != "agent:codex:files:0" {
 				t.Fatalf("resolve without gh_cli_token = %v, want untouched selection", got)
 			}
 		})


### PR DESCRIPTION
## What

`resolveGHToken` on both remote executors (`SpritesExecutor`, `SSHExecutor`) carried a `req *ExecutorCreateRequest` parameter that was only kept alive by a `_ = req` line. Both are now pure filters over the selected credential IDs, so the parameter is gone.

## Why

Not a deliberate hook for upcoming work — it's residue. `git log -S'_ = req'` points at #1810 (per-workspace GitHub App registrations), which deleted the host-global `gh` token detection that used to write `req.Env["GITHUB_TOKEN"]`. `DetectGHToken` and `containsID` went with it; only the parameter and its silencer survived. GitHub automation credentials now come from the workspace credential broker, and explicit secret-backed `GITHUB_TOKEN` values are resolved by `resolveAuthSecrets`, which still takes the request.

## Changes

- `executor_sprites_credentials.go` — drop `req` from `resolveGHToken` + call site
- `executor_ssh_credentials.go` — same (identical placeholder in the SSH flavor)
- `executor_ssh_credentials_test.go` — adapt `TestRemoteExecutorsIgnoreLegacyHostGHTokenSelection` to the new signature

The test previously put a fake `gh` on `PATH` and asserted `req.Env["GITHUB_TOKEN"]` stayed empty. With no request in scope that injection is impossible by construction, so those two props are dropped in favour of the filtering assertions (stale `gh_cli_token` removed; a selection without it passes through untouched). Both executors are still exercised through the same table.

No other `_ = <param>` placeholders exist in either file — the remaining `_ =` uses are deliberate `Close()` error discards.

## Validation

- `make -C apps/backend test` — the lifecycle package passes. Unrelated pre-existing failures in `internal/gitlab`, `internal/notifications/service`, `internal/task/handlers`, and `internal/task/service` reproduce identically on a pristine `HEAD` checkout of this branch's base, with and without sandboxing (e.g. `parent directory cannot be accessed` in the local-repository-initialization tests). Untouched by this diff.
- `make -C apps/backend lint` — 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2013?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->