### PR TITLE
fix(backend): return bad request on malformed sprites WS payloads

### DIFF
--- a/apps/backend/internal/sprites/handlers.go
+++ b/apps/backend/internal/sprites/handlers.go
@@ -184,7 +184,9 @@ func (h *Handler) wsStatus(ctx context.Context, msg *ws.Message) (*ws.Message, e
 	var payload struct {
 		SecretID string `json:"secret_id"`
 	}
-	_ = msg.ParsePayload(&payload)
+	if err := msg.ParsePayload(&payload); err != nil {
+		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeBadRequest, "invalid payload", nil)
+	}
 	return ws.NewResponse(msg.ID, msg.Action, h.getStatus(ctx, payload.SecretID))
 }
 
@@ -192,7 +194,9 @@ func (h *Handler) wsListInstances(ctx context.Context, msg *ws.Message) (*ws.Mes
 	var payload struct {
 		SecretID string `json:"secret_id"`
 	}
-	_ = msg.ParsePayload(&payload)
+	if err := msg.ParsePayload(&payload); err != nil {
+		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeBadRequest, "invalid payload", nil)
+	}
 	instances, err := h.listInstances(ctx, payload.SecretID)
 	if err != nil {
 		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError, err.Error(), nil)
@@ -218,7 +222,9 @@ func (h *Handler) wsTest(ctx context.Context, msg *ws.Message) (*ws.Message, err
 	var payload struct {
 		SecretID string `json:"secret_id"`
 	}
-	_ = msg.ParsePayload(&payload)
+	if err := msg.ParsePayload(&payload); err != nil {
+		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeBadRequest, "invalid payload", nil)
+	}
 	return ws.NewResponse(msg.ID, msg.Action, h.testConnection(ctx, payload.SecretID))
 }
 

--- a/apps/backend/internal/sprites/handlers_test.go
+++ b/apps/backend/internal/sprites/handlers_test.go
@@ -1,9 +1,15 @@
 package sprites
 
 import (
+	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/kandev/kandev/internal/common/logger"
+	ws "github.com/kandev/kandev/pkg/websocket"
 )
 
 func TestNormalizeSpriteStatus(t *testing.T) {
@@ -26,5 +32,124 @@ func TestNormalizeSpriteStatus(t *testing.T) {
 			got := NormalizeSpriteStatus(tt.input)
 			require.Equal(t, tt.want, got)
 		})
+	}
+}
+
+// wsHandler is the signature shared by every sprites WS handler.
+type wsHandler func(context.Context, *ws.Message) (*ws.Message, error)
+
+// newTestHandler builds a Handler with no secret store, so every code path
+// short-circuits on "API token not configured" before touching the network.
+func newTestHandler(t *testing.T) *Handler {
+	t.Helper()
+	log, err := logger.NewFromZap(zap.NewNop())
+	require.NoError(t, err)
+	return NewHandler(nil, log)
+}
+
+func newTestMessage(action string, payload string) *ws.Message {
+	msg := &ws.Message{ID: "req-1", Type: ws.MessageTypeRequest, Action: action}
+	if payload != "" {
+		msg.Payload = json.RawMessage(payload)
+	}
+	return msg
+}
+
+func requireErrorPayload(t *testing.T, resp *ws.Message, action, code string) ws.ErrorPayload {
+	t.Helper()
+	require.Equal(t, ws.MessageTypeError, resp.Type)
+	require.Equal(t, "req-1", resp.ID)
+	require.Equal(t, action, resp.Action)
+
+	var payload ws.ErrorPayload
+	require.NoError(t, json.Unmarshal(resp.Payload, &payload))
+	require.Equal(t, code, payload.Code)
+	return payload
+}
+
+func TestWSHandlersRejectMalformedPayload(t *testing.T) {
+	h := newTestHandler(t)
+
+	handlers := []struct {
+		name   string
+		action string
+		fn     wsHandler
+	}{
+		{name: "status", action: ws.ActionSpritesStatus, fn: h.wsStatus},
+		{name: "instances list", action: ws.ActionSpritesInstancesList, fn: h.wsListInstances},
+		{name: "instances destroy", action: ws.ActionSpritesInstancesDestroy, fn: h.wsDestroyInstance},
+		{name: "test", action: ws.ActionSpritesTest, fn: h.wsTest},
+		{name: "network policy get", action: ws.ActionSpritesNetworkPolicyGet, fn: h.wsGetNetworkPolicy},
+		{name: "network policy update", action: ws.ActionSpritesNetworkPolicyUpdate, fn: h.wsUpdateNetworkPolicy},
+	}
+	payloads := []struct {
+		name string
+		body string
+	}{
+		{name: "truncated json", body: `{"secret_id":`},
+		{name: "wrong field type", body: `{"secret_id": 42}`},
+		{name: "not an object", body: `["secret-1"]`},
+	}
+
+	for _, handler := range handlers {
+		for _, payload := range payloads {
+			t.Run(handler.name+"/"+payload.name, func(t *testing.T) {
+				resp, err := handler.fn(context.Background(), newTestMessage(handler.action, payload.body))
+				require.NoError(t, err)
+
+				errPayload := requireErrorPayload(t, resp, handler.action, ws.ErrorCodeBadRequest)
+				require.Equal(t, "invalid payload", errPayload.Message)
+			})
+		}
+	}
+}
+
+func TestWSStatusAcceptsValidPayload(t *testing.T) {
+	h := newTestHandler(t)
+
+	// An absent payload is legal: ParsePayload treats a nil payload as a no-op,
+	// so the handler answers for the zero-valued secret ID instead of erroring.
+	for _, body := range []string{"", `{"secret_id":"sec-1"}`} {
+		resp, err := h.wsStatus(context.Background(), newTestMessage(ws.ActionSpritesStatus, body))
+		require.NoError(t, err)
+		require.Equal(t, ws.MessageTypeResponse, resp.Type)
+		require.Equal(t, ws.ActionSpritesStatus, resp.Action)
+
+		var status SpritesStatus
+		require.NoError(t, json.Unmarshal(resp.Payload, &status))
+		require.False(t, status.TokenConfigured)
+		require.False(t, status.Connected)
+	}
+}
+
+func TestWSListInstancesAcceptsValidPayload(t *testing.T) {
+	h := newTestHandler(t)
+
+	for _, body := range []string{"", `{"secret_id":"sec-1"}`} {
+		resp, err := h.wsListInstances(context.Background(), newTestMessage(ws.ActionSpritesInstancesList, body))
+		require.NoError(t, err)
+
+		// No secret store is wired, so the request gets past payload parsing and
+		// fails downstream — an internal error, never a bad request.
+		errPayload := requireErrorPayload(t, resp, ws.ActionSpritesInstancesList, ws.ErrorCodeInternalError)
+		require.Contains(t, errPayload.Message, "API token not configured")
+	}
+}
+
+func TestWSTestAcceptsValidPayload(t *testing.T) {
+	h := newTestHandler(t)
+
+	for _, body := range []string{"", `{"secret_id":"sec-1"}`} {
+		resp, err := h.wsTest(context.Background(), newTestMessage(ws.ActionSpritesTest, body))
+		require.NoError(t, err)
+		require.Equal(t, ws.MessageTypeResponse, resp.Type)
+		require.Equal(t, ws.ActionSpritesTest, resp.Action)
+
+		var result SpritesTestResult
+		require.NoError(t, json.Unmarshal(resp.Payload, &result))
+		require.False(t, result.Success)
+		require.Len(t, result.Steps, 1)
+		require.Equal(t, "Get API token", result.Steps[0].Name)
+		require.False(t, result.Steps[0].Success)
 	}
 }


### PR DESCRIPTION
## Problem

Three sprites WebSocket handlers discarded the `ParsePayload` error:

- `wsStatus`
- `wsListInstances`
- `wsTest`

Their siblings in the same file (`wsDestroyInstance`, `wsGetNetworkPolicy`, `wsUpdateNetworkPolicy`) return a bad-request response instead. The three outliers carried on with a zero-valued `SecretID`, so a client sending a malformed frame got a confusing downstream failure (or a lookup against an empty secret ID) rather than a clear `BAD_REQUEST`.

## Change

All three now match the sibling shape:

```go
if err := msg.ParsePayload(&payload); err != nil {
    return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeBadRequest, "invalid payload", nil)
}
```

These were the only `_ = msg.ParsePayload(...)` occurrences in `internal/sprites` — none remain in the package.

## Empty/absent payloads are preserved

`Message.ParsePayload` short-circuits on a nil payload:

```go
func (m *Message) ParsePayload(v interface{}) error {
    if m.Payload == nil {
        return nil
    }
    return json.Unmarshal(m.Payload, v)
}
```

So a frame with no payload still succeeds and the handler answers for the zero-valued secret ID exactly as before — only genuinely malformed JSON now errors. **No handler was deliberately left as-is.**

Frontend impact is nil: `grep -rn "sprites\." apps/web/lib/ws` finds nothing, and a repo-wide search for the `sprites.status` / `sprites.instances.*` / `sprites.test` / `sprites.network_policy.*` action strings shows the only references are the backend `RegisterFunc` calls. The web app talks to sprites over HTTP (`apps/web/lib/api/domains/sprites-api.ts` → `/api/v1/sprites/*`), which has its own separate handlers that are unchanged.

## Tests

`internal/sprites/handlers_test.go`:

- `TestWSHandlersRejectMalformedPayload` — all **six** WS handlers × three malformed payload shapes (truncated JSON, wrong field type, non-object) assert `MessageTypeError` + `BAD_REQUEST` + `"invalid payload"`, and that the request ID/action are echoed back. The three siblings are included as a pin so the shape can't drift apart again.
- `TestWSStatusAcceptsValidPayload` / `TestWSListInstancesAcceptsValidPayload` / `TestWSTestAcceptsValidPayload` — happy path for each changed handler, run with both a valid payload and an absent payload. `wsListInstances` asserts the failure it does surface is `INTERNAL_ERROR` ("API token not configured"), i.e. it got past parsing.

The handler under test is built with a nil secret store, so every path short-circuits before any network call.

Verified red before the fix: reverting `handlers.go` fails exactly the 9 `status` / `instances_list` / `test` subtests while the three sibling handlers stay green.

## Validation

- `make -C apps/backend lint` → **0 issues**
- `go test ./internal/sprites/...` → **ok**
- `make -C apps/backend test` → the sprites package passes. Four unrelated packages fail in this sandbox (`internal/gitlab`, `internal/notifications/service`, `internal/task/handlers`, `internal/task/service`) with errors like `invalid directory creation: parent directory cannot be accessed`. This diff touches only `internal/sprites`, so those files are byte-identical to `main` — pre-existing/environmental, not caused by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2014?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->