### PR TITLE
fix(backend): return real results from Service.GetBlocking

### DIFF
--- a/apps/backend/internal/office/repository/sqlite/blockers.go
+++ b/apps/backend/internal/office/repository/sqlite/blockers.go
@@ -40,12 +40,18 @@ func (r *Repository) DeleteTaskBlocker(ctx context.Context, taskID, blockerTaskI
 }
 
 // ListTasksBlockedBy returns task IDs that are blocked by the given task.
+// This is the reverse direction of ListTaskBlockers; results are ordered by
+// insertion time so callers see a stable list.
 func (r *Repository) ListTasksBlockedBy(ctx context.Context, blockerTaskID string) ([]string, error) {
 	var ids []string
 	err := r.ro.SelectContext(ctx, &ids, r.ro.Rebind(
-		`SELECT task_id FROM task_blockers WHERE blocker_task_id = ?`), blockerTaskID)
+		`SELECT task_id FROM task_blockers WHERE blocker_task_id = ? ORDER BY created_at, task_id`),
+		blockerTaskID)
 	if err != nil {
 		return nil, err
+	}
+	if ids == nil {
+		ids = []string{}
 	}
 	return ids, nil
 }

--- a/apps/backend/internal/office/repository/sqlite/blockers_test.go
+++ b/apps/backend/internal/office/repository/sqlite/blockers_test.go
@@ -2,6 +2,7 @@ package sqlite_test
 
 import (
 	"context"
+	"slices"
 	"testing"
 
 	"github.com/kandev/kandev/internal/office/models"
@@ -36,6 +37,70 @@ func TestTaskBlocker_CRUD(t *testing.T) {
 	blockers, _ = repo.ListTaskBlockers(ctx, "task-1")
 	if len(blockers) != 0 {
 		t.Errorf("count after delete = %d, want 0", len(blockers))
+	}
+}
+
+func TestListTasksBlockedBy(t *testing.T) {
+	repo := newTestRepo(t)
+	ctx := context.Background()
+
+	// No edges yet: empty, non-nil result.
+	ids, err := repo.ListTasksBlockedBy(ctx, "task-3")
+	if err != nil {
+		t.Fatalf("ListTasksBlockedBy: %v", err)
+	}
+	if ids == nil {
+		t.Error("expected non-nil empty slice, got nil")
+	}
+	if len(ids) != 0 {
+		t.Errorf("expected no blocked tasks, got %v", ids)
+	}
+
+	// task-1 and task-2 are blocked by task-3; task-2 is also blocked by task-4.
+	for _, b := range []*models.TaskBlocker{
+		{TaskID: "task-1", BlockerTaskID: "task-3"},
+		{TaskID: "task-2", BlockerTaskID: "task-3"},
+		{TaskID: "task-2", BlockerTaskID: "task-4"},
+	} {
+		if err := repo.CreateTaskBlocker(ctx, b); err != nil {
+			t.Fatalf("create blocker: %v", err)
+		}
+	}
+
+	// One blocked task.
+	ids, err = repo.ListTasksBlockedBy(ctx, "task-4")
+	if err != nil {
+		t.Fatalf("ListTasksBlockedBy: %v", err)
+	}
+	if !slices.Equal(ids, []string{"task-2"}) {
+		t.Errorf("blocked by task-4 = %v, want [task-2]", ids)
+	}
+
+	// Several blocked tasks, ordered by insertion time.
+	ids, err = repo.ListTasksBlockedBy(ctx, "task-3")
+	if err != nil {
+		t.Fatalf("ListTasksBlockedBy: %v", err)
+	}
+	if !slices.Equal(ids, []string{"task-1", "task-2"}) {
+		t.Errorf("blocked by task-3 = %v, want [task-1 task-2]", ids)
+	}
+
+	// A task that only appears on the blocked side blocks nothing.
+	ids, err = repo.ListTasksBlockedBy(ctx, "task-1")
+	if err != nil {
+		t.Fatalf("ListTasksBlockedBy: %v", err)
+	}
+	if len(ids) != 0 {
+		t.Errorf("blocked by task-1 = %v, want none", ids)
+	}
+
+	// Deleting an edge removes it from the reverse lookup.
+	if err := repo.DeleteTaskBlocker(ctx, "task-1", "task-3"); err != nil {
+		t.Fatalf("DeleteTaskBlocker: %v", err)
+	}
+	ids, _ = repo.ListTasksBlockedBy(ctx, "task-3")
+	if !slices.Equal(ids, []string{"task-2"}) {
+		t.Errorf("blocked by task-3 after delete = %v, want [task-2]", ids)
 	}
 }
 

--- a/apps/backend/internal/task/service/service_office.go
+++ b/apps/backend/internal/task/service/service_office.go
@@ -147,15 +147,20 @@ func (s *Service) GetBlockers(ctx context.Context, taskID string) ([]string, err
 
 // GetBlocking returns all task IDs that the given task is blocking.
 // This is the reverse lookup: find all tasks where blockerTaskID = taskID.
+// Like GetBlockers, it returns the raw blocker edges: archived tasks are not
+// filtered out, so callers that only want active tasks must filter themselves.
 func (s *Service) GetBlocking(ctx context.Context, taskID string) ([]string, error) {
 	if s.blockers == nil {
 		return nil, fmt.Errorf("blocker repository not configured")
 	}
-	// We need to search across all tasks. For now, we use a pragmatic approach:
-	// query all tasks and check. This will be optimized with a dedicated query later.
-	// For the initial implementation, we return an empty list.
-	// TODO: Add a GetBlockingTasks query to the blocker repository
-	return []string{}, nil
+	ids, err := s.blockers.ListTasksBlockedBy(ctx, taskID)
+	if err != nil {
+		return nil, err
+	}
+	if ids == nil {
+		return []string{}, nil
+	}
+	return ids, nil
 }
 
 // checkCircularBlocker checks if adding blockerTaskID as a blocker to taskID

--- a/apps/backend/internal/task/service/service_office_test.go
+++ b/apps/backend/internal/task/service/service_office_test.go
@@ -3,6 +3,8 @@ package service
 import (
 	"context"
 	"database/sql"
+	"slices"
+	"sort"
 	"strings"
 	"testing"
 
@@ -369,6 +371,122 @@ func TestBlocker_CRUD(t *testing.T) {
 	ids, _ = svc.GetBlockers(ctx, "task-1")
 	if len(ids) != 0 {
 		t.Errorf("expected empty, got %v", ids)
+	}
+}
+
+func TestGetBlocking_ReverseLookup(t *testing.T) {
+	svc, _, _ := createTestService(t)
+	svc.SetBlockerRepository(&mockBlockerRepo{})
+	ctx := context.Background()
+
+	// No blocker edges at all.
+	ids, err := svc.GetBlocking(ctx, "task-1")
+	if err != nil {
+		t.Fatalf("GetBlocking: %v", err)
+	}
+	if ids == nil {
+		t.Error("expected non-nil empty slice, got nil")
+	}
+	if len(ids) != 0 {
+		t.Errorf("expected no blocked tasks, got %v", ids)
+	}
+
+	// One blocked task: task-2 is blocked by task-1.
+	if err := svc.AddBlocker(ctx, "task-2", "task-1"); err != nil {
+		t.Fatalf("AddBlocker: %v", err)
+	}
+	ids, err = svc.GetBlocking(ctx, "task-1")
+	if err != nil {
+		t.Fatalf("GetBlocking: %v", err)
+	}
+	if len(ids) != 1 || ids[0] != "task-2" {
+		t.Errorf("expected [task-2], got %v", ids)
+	}
+
+	// The reverse direction must not be confused with the forward one:
+	// task-2 blocks nothing, and task-1 is the blocker of task-2.
+	if ids, err = svc.GetBlocking(ctx, "task-2"); err != nil || len(ids) != 0 {
+		t.Errorf("GetBlocking(task-2) = %v, %v; want empty", ids, err)
+	}
+	if ids, err = svc.GetBlockers(ctx, "task-2"); err != nil || len(ids) != 1 || ids[0] != "task-1" {
+		t.Errorf("GetBlockers(task-2) = %v, %v; want [task-1]", ids, err)
+	}
+
+	// Several blocked tasks.
+	for _, blocked := range []string{"task-3", "task-4"} {
+		if err := svc.AddBlocker(ctx, blocked, "task-1"); err != nil {
+			t.Fatalf("AddBlocker(%s): %v", blocked, err)
+		}
+	}
+	ids, err = svc.GetBlocking(ctx, "task-1")
+	if err != nil {
+		t.Fatalf("GetBlocking: %v", err)
+	}
+	sort.Strings(ids)
+	want := []string{"task-2", "task-3", "task-4"}
+	if !slices.Equal(ids, want) {
+		t.Errorf("expected %v, got %v", want, ids)
+	}
+
+	// Removing an edge removes it from the reverse lookup too.
+	if err := svc.RemoveBlocker(ctx, "task-3", "task-1"); err != nil {
+		t.Fatalf("RemoveBlocker: %v", err)
+	}
+	ids, _ = svc.GetBlocking(ctx, "task-1")
+	sort.Strings(ids)
+	if !slices.Equal(ids, []string{"task-2", "task-4"}) {
+		t.Errorf("expected [task-2 task-4] after removal, got %v", ids)
+	}
+}
+
+func TestGetBlocking_NoRepositoryConfigured(t *testing.T) {
+	svc, _, _ := createTestService(t)
+	ctx := context.Background()
+
+	if _, err := svc.GetBlocking(ctx, "task-1"); err == nil {
+		t.Fatal("expected error when blocker repository is not configured")
+	}
+}
+
+// Archiving a task does not drop it from the reverse lookup: GetBlocking
+// mirrors GetBlockers and reports the raw blocker edges. Callers that only
+// want active tasks filter themselves.
+func TestGetBlocking_IncludesArchivedTasks(t *testing.T) {
+	svc, repo := setupOfficeTest(t)
+	svc.SetBlockerRepository(&mockBlockerRepo{})
+	ctx := context.Background()
+
+	blocker, err := svc.CreateTask(ctx, &CreateTaskRequest{
+		WorkspaceID: "ws-1", Title: "Blocker", ProjectID: "proj-1",
+	})
+	if err != nil {
+		t.Fatalf("create blocker: %v", err)
+	}
+	blocked, err := svc.CreateTask(ctx, &CreateTaskRequest{
+		WorkspaceID: "ws-1", Title: "Blocked", ProjectID: "proj-1",
+		BlockedBy: []string{blocker.ID},
+	})
+	if err != nil {
+		t.Fatalf("create blocked task: %v", err)
+	}
+
+	ids, err := svc.GetBlocking(ctx, blocker.ID)
+	if err != nil {
+		t.Fatalf("GetBlocking: %v", err)
+	}
+	if len(ids) != 1 || ids[0] != blocked.ID {
+		t.Fatalf("expected [%s], got %v", blocked.ID, ids)
+	}
+
+	if err := repo.ArchiveTask(ctx, blocked.ID); err != nil {
+		t.Fatalf("ArchiveTask: %v", err)
+	}
+	ids, err = svc.GetBlocking(ctx, blocker.ID)
+	if err != nil {
+		t.Fatalf("GetBlocking after archive: %v", err)
+	}
+	if len(ids) != 1 || ids[0] != blocked.ID {
+		t.Errorf("expected archived task %s to still be reported, got %v", blocked.ID, ids)
 	}
 }
 


### PR DESCRIPTION
`Service.GetBlocking` returned a hardcoded empty slice behind a TODO, so every caller asking "which tasks does this task block?" silently got a wrong answer; it now delegates to the reverse-lookup query that already existed on the blocker repository.

## Important Changes

- The TODO asked for a query that was already implemented: `ListTasksBlockedBy` on the office SQLite repository, already declared on the `BlockerRepository` interface in the same file as `GetBlocking`, and already used in production by the office scheduler (`cascadeBlockersResolved`), the office event subscribers (`queueBlockersResolvedRuns`), and `HandoffService`'s related-tasks builder. No new repository method, interface change, or test-double update was needed — `GetBlocking` just never called it.
- `ListTasksBlockedBy` now orders by `created_at, task_id` (mirroring `ListTaskBlockers`) and returns an empty non-nil slice rather than `nil`.
- Archived tasks are deliberately **not** filtered out. `GetBlockers` — the symmetric forward lookup directly above it — returns raw edges, and no existing `ListTasksBlockedBy` consumer filters on `archived_at`; filtering only the reverse direction would make the two asymmetric. Documented on the method and pinned by `TestGetBlocking_IncludesArchivedTasks`.
- `GetBlocking` has no call sites outside tests (verified repo-wide across Go, TS/TSX and docs), so the change from "always empty" to real data cannot break a consumer. The `BlockedBy` data the UI does render already went through `ListTasksBlockedBy` directly and is unchanged.

## Validation

- `make -C apps/backend test lint` — lint reports `0 issues`.
- New service coverage in `service_office_test.go`: `TestGetBlocking_ReverseLookup` (none / one / several blocked tasks, edge removal, and that the forward and reverse directions aren't confused), `TestGetBlocking_NoRepositoryConfigured`, `TestGetBlocking_IncludesArchivedTasks`.
- New repository coverage in `blockers_test.go`: `TestListTasksBlockedBy` (empty non-nil result, one, several with deterministic ordering, a task that only appears on the blocked side, and delete removing the edge).
- Three local test failures — `internal/gitlab` `TestEnvironmentTokenAllowsImmutableStartupHost` and two `internal/notifications/service` delivery-occurrence tests — reproduce identically on a clean `HEAD` worktree and pass in CI, so they are environment-specific and unrelated to this change.

## Possible Improvements

Low risk. Worth noting separately: `task_blockers` has no foreign key to `tasks` and nothing removes its rows on task deletion, so dangling edges are possible in both lookup directions — pre-existing behaviour, not addressed here.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.
