### PR TITLE
fix(backend): bound tool installer downloads with timeouts

### DIFF
--- a/apps/backend/internal/tools/installer/download.go
+++ b/apps/backend/internal/tools/installer/download.go
@@ -1,0 +1,116 @@
+package installer
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"sync/atomic"
+	"time"
+)
+
+// Timeouts bounding a release download. There is deliberately no overall
+// http.Client.Timeout: these are tarballs, and a single deadline for the whole
+// transfer would kill a large-but-healthy download on a slow link. Instead each
+// phase that can stall silently gets its own bound — connect, TLS handshake,
+// response headers — and the body stream is watched for lack of progress by
+// stallGuard. http.DefaultClient has none of these, so a stalled mirror hangs
+// the install forever with no way out.
+const (
+	downloadDialTimeout           = 30 * time.Second
+	downloadTLSHandshakeTimeout   = 30 * time.Second
+	downloadResponseHeaderTimeout = 60 * time.Second
+)
+
+// downloadStallTimeout is the longest gap tolerated between two successful
+// reads from a response body before the download is abandoned. It is a var so
+// tests can shrink it.
+var downloadStallTimeout = 2 * time.Minute
+
+// downloadClient is the shared client for tool downloads. Swapped in tests.
+var downloadClient = newDownloadClient()
+
+func newDownloadClient() *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+			DialContext: (&net.Dialer{
+				Timeout:   downloadDialTimeout,
+				KeepAlive: 30 * time.Second,
+			}).DialContext,
+			ForceAttemptHTTP2:     true,
+			MaxIdleConns:          10,
+			IdleConnTimeout:       90 * time.Second,
+			TLSHandshakeTimeout:   downloadTLSHandshakeTimeout,
+			ExpectContinueTimeout: 1 * time.Second,
+			ResponseHeaderTimeout: downloadResponseHeaderTimeout,
+		},
+	}
+}
+
+// getDownload issues a GET for url and returns a response whose body fails
+// instead of blocking when the transfer stops making progress. The caller owns
+// resp.Body and must close it — closing also releases the stall watchdog and
+// the derived request context.
+func getDownload(ctx context.Context, url string) (*http.Response, error) {
+	ctx, cancel := context.WithCancel(ctx)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := downloadClient.Do(req)
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("download failed: %w", err)
+	}
+
+	resp.Body = newStallGuard(resp.Body, cancel, downloadStallTimeout)
+	return resp, nil
+}
+
+// stallGuard aborts a response body that stops delivering data.
+//
+// ResponseHeaderTimeout only covers the wait for the status line; once headers
+// are in, a mirror that goes quiet mid-body would leave the read blocked
+// indefinitely. The guard arms a timer at construction and rearms it on every
+// read that returns bytes, so a download is only killed for lack of progress —
+// never for taking a long time while still moving.
+type stallGuard struct {
+	body    io.ReadCloser
+	cancel  context.CancelFunc
+	timer   *time.Timer
+	timeout time.Duration
+	stalled atomic.Bool
+}
+
+func newStallGuard(body io.ReadCloser, cancel context.CancelFunc, timeout time.Duration) *stallGuard {
+	g := &stallGuard{body: body, cancel: cancel, timeout: timeout}
+	g.timer = time.AfterFunc(timeout, func() {
+		g.stalled.Store(true)
+		// Cancelling the request context unblocks the in-flight Read.
+		cancel()
+	})
+	return g
+}
+
+func (g *stallGuard) Read(p []byte) (int, error) {
+	n, err := g.body.Read(p)
+	if n > 0 {
+		g.timer.Reset(g.timeout)
+	}
+	if err != nil && g.stalled.Load() {
+		return n, fmt.Errorf("download stalled: no data received for %s: %w", g.timeout, err)
+	}
+	return n, err
+}
+
+func (g *stallGuard) Close() error {
+	g.timer.Stop()
+	err := g.body.Close()
+	g.cancel()
+	return err
+}

--- a/apps/backend/internal/tools/installer/download.go
+++ b/apps/backend/internal/tools/installer/download.go
@@ -23,9 +23,8 @@ const (
 	downloadResponseHeaderTimeout = 60 * time.Second
 )
 
-// downloadStallTimeout is the longest gap tolerated between two successful
-// reads from a response body before the download is abandoned. It is a var so
-// tests can shrink it.
+// downloadStallTimeout is the longest a single read from a response body may
+// block before the download is abandoned. It is a var so tests can shrink it.
 var downloadStallTimeout = 2 * time.Minute
 
 // downloadClient is the shared client for tool downloads. Swapped in tests.
@@ -76,9 +75,15 @@ func getDownload(ctx context.Context, url string) (*http.Response, error) {
 //
 // ResponseHeaderTimeout only covers the wait for the status line; once headers
 // are in, a mirror that goes quiet mid-body would leave the read blocked
-// indefinitely. The guard arms a timer at construction and rearms it on every
-// read that returns bytes, so a download is only killed for lack of progress —
-// never for taking a long time while still moving.
+// indefinitely. The guard bounds how long any single read may block, so a
+// download is killed only for lack of progress — never for taking a long time
+// while still moving.
+//
+// The timer is armed around the blocking read alone and stopped as soon as it
+// returns. Wall-clock time the caller then spends downstream — decompressing,
+// untarring, writing to a slow disk — is not the mirror's fault and must not
+// count against it; a highly compressed archive can easily take longer to
+// expand one read's worth of bytes than to fetch the next.
 type stallGuard struct {
 	body    io.ReadCloser
 	cancel  context.CancelFunc
@@ -94,16 +99,18 @@ func newStallGuard(body io.ReadCloser, cancel context.CancelFunc, timeout time.D
 		// Cancelling the request context unblocks the in-flight Read.
 		cancel()
 	})
+	// Created armed; Read owns arming from here on.
+	g.timer.Stop()
 	return g
 }
 
 func (g *stallGuard) Read(p []byte) (int, error) {
+	g.timer.Reset(g.timeout)
 	n, err := g.body.Read(p)
-	if n > 0 {
-		g.timer.Reset(g.timeout)
-	}
+	g.timer.Stop()
+
 	if err != nil && g.stalled.Load() {
-		return n, fmt.Errorf("download stalled: no data received for %s: %w", g.timeout, err)
+		return n, fmt.Errorf("download stalled: read blocked for %s: %w", g.timeout, err)
 	}
 	return n, err
 }

--- a/apps/backend/internal/tools/installer/download_test.go
+++ b/apps/backend/internal/tools/installer/download_test.go
@@ -1,0 +1,269 @@
+package installer
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// swapDownloadClient installs c as the package download client for the test.
+func swapDownloadClient(t *testing.T, c *http.Client) {
+	t.Helper()
+	original := downloadClient
+	downloadClient = c
+	t.Cleanup(func() { downloadClient = original })
+}
+
+// swapStallTimeout shrinks the body stall window for the test.
+func swapStallTimeout(t *testing.T, d time.Duration) {
+	t.Helper()
+	original := downloadStallTimeout
+	downloadStallTimeout = d
+	t.Cleanup(func() { downloadStallTimeout = original })
+}
+
+// testDownloadClient builds the real download client with a shortened response
+// header timeout, so tests exercise the production transport configuration.
+func testDownloadClient(responseHeaderTimeout time.Duration) *http.Client {
+	c := newDownloadClient()
+	c.Transport.(*http.Transport).ResponseHeaderTimeout = responseHeaderTimeout
+	return c
+}
+
+// serverTransport routes every request to srv regardless of the URL under test,
+// letting strategy-level tests exercise real network behavior against a server
+// that misbehaves on purpose.
+type serverTransport struct {
+	base http.RoundTripper
+	addr *url.URL
+}
+
+func (t serverTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	clone := req.Clone(req.Context())
+	clone.URL.Scheme = t.addr.Scheme
+	clone.URL.Host = t.addr.Host
+	clone.Host = ""
+	return t.base.RoundTrip(clone)
+}
+
+func redirectToServer(t *testing.T, c *http.Client, srv *httptest.Server) *http.Client {
+	t.Helper()
+	addr, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("parse server URL: %v", err)
+	}
+	return &http.Client{Transport: serverTransport{base: c.Transport, addr: addr}}
+}
+
+// stallingServer serves a handler that writes prelude (if any), flushes, and
+// then goes silent for the rest of the test — the stalled-mirror case.
+func stallingServer(t *testing.T, prelude []byte) *httptest.Server {
+	t.Helper()
+
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if len(prelude) > 0 {
+			w.Header().Set("Content-Length", "1048576")
+			_, _ = w.Write(prelude)
+			w.(http.Flusher).Flush()
+		}
+		select {
+		case <-release:
+		case <-r.Context().Done():
+		}
+	}))
+	// Cleanups run LIFO: unblock the handler before the server waits on it.
+	t.Cleanup(srv.Close)
+	t.Cleanup(func() { close(release) })
+	return srv
+}
+
+func TestGetDownloadFailsWhenResponseHeadersStall(t *testing.T) {
+	srv := stallingServer(t, nil)
+	swapDownloadClient(t, testDownloadClient(150*time.Millisecond))
+
+	start := time.Now()
+	resp, err := getDownload(t.Context(), srv.URL)
+	if err == nil {
+		_ = resp.Body.Close()
+		t.Fatal("getDownload() error = nil, want response header timeout")
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("getDownload() blocked for %s, want prompt failure", elapsed)
+	}
+	if !strings.Contains(err.Error(), "download failed") {
+		t.Fatalf("getDownload() error = %v, want download failure", err)
+	}
+}
+
+func TestGetDownloadFailsWhenBodyStalls(t *testing.T) {
+	srv := stallingServer(t, []byte("partial payload"))
+	swapDownloadClient(t, testDownloadClient(5*time.Second))
+	swapStallTimeout(t, 150*time.Millisecond)
+
+	resp, err := getDownload(t.Context(), srv.URL)
+	if err != nil {
+		t.Fatalf("getDownload() error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	start := time.Now()
+	_, err = io.ReadAll(resp.Body)
+	if err == nil {
+		t.Fatal("body read error = nil, want stall error")
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("body read blocked for %s, want prompt failure", elapsed)
+	}
+	if !strings.Contains(err.Error(), "download stalled") {
+		t.Fatalf("body read error = %v, want stall error", err)
+	}
+}
+
+func TestGetDownloadAllowsSlowButProgressingBody(t *testing.T) {
+	const chunks = 6
+	payload := strings.Repeat("x", 64)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		for range chunks {
+			_, _ = io.WriteString(w, payload)
+			w.(http.Flusher).Flush()
+			select {
+			case <-time.After(40 * time.Millisecond):
+			case <-r.Context().Done():
+				return
+			}
+		}
+	}))
+	defer srv.Close()
+
+	swapDownloadClient(t, testDownloadClient(5*time.Second))
+	// Total transfer time far exceeds the stall window; each gap stays under it.
+	swapStallTimeout(t, 120*time.Millisecond)
+
+	resp, err := getDownload(t.Context(), srv.URL)
+	if err != nil {
+		t.Fatalf("getDownload() error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("slow but progressing download failed: %v", err)
+	}
+	if want := chunks * len(payload); len(body) != want {
+		t.Fatalf("body length = %d, want %d", len(body), want)
+	}
+}
+
+func TestGetDownloadCancelsWithParentContext(t *testing.T) {
+	srv := stallingServer(t, []byte("partial payload"))
+	swapDownloadClient(t, testDownloadClient(5*time.Second))
+	swapStallTimeout(t, time.Minute)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	resp, err := getDownload(ctx, srv.URL)
+	if err != nil {
+		t.Fatalf("getDownload() error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	time.AfterFunc(50*time.Millisecond, cancel)
+	if _, err := io.ReadAll(resp.Body); err == nil {
+		t.Fatal("body read error = nil, want context cancellation")
+	}
+}
+
+func TestGithubTarballStrategyInstallFailsOnStalledServer(t *testing.T) {
+	target := runtime.GOOS + "-" + runtime.GOARCH
+	archive := tarGzWithFiles(t, map[string]string{
+		"tool-1.0.0-" + target + "/bin/tool": "complete",
+	})
+
+	// Enough bytes for the gzip header to parse, then silence mid-stream.
+	srv := stallingServer(t, archive[:16])
+	swapDownloadClient(t, redirectToServer(t, testDownloadClient(5*time.Second), srv))
+	swapStallTimeout(t, 150*time.Millisecond)
+
+	strategy := NewGithubTarballStrategy(t.TempDir(), "tool", GithubTarballConfig{
+		Owner:        "owner",
+		Repo:         "repo",
+		Version:      "1.0.0",
+		AssetPattern: "tool-{version}-{os}-{arch}.tar.gz",
+		BinaryPath:   "tool-{version}-{os}-{arch}/bin/tool",
+		Targets: map[string]string{
+			runtime.GOOS + "/" + runtime.GOARCH: target,
+		},
+	}, testLogger())
+
+	err := installWithinDeadline(t, strategy)
+	if err == nil || !strings.Contains(err.Error(), "download stalled") {
+		t.Fatalf("Install() error = %v, want stall error", err)
+	}
+}
+
+func TestGithubReleaseStrategyInstallFailsOnStalledServer(t *testing.T) {
+	srv := stallingServer(t, []byte("partial binary"))
+	swapDownloadClient(t, redirectToServer(t, testDownloadClient(5*time.Second), srv))
+	swapStallTimeout(t, 150*time.Millisecond)
+
+	strategy := NewGithubReleaseStrategy(t.TempDir(), "tool", GithubReleaseConfig{
+		Owner:        "owner",
+		Repo:         "repo",
+		AssetPattern: "tool-{target}",
+		Targets: map[string]string{
+			runtime.GOOS + "/" + runtime.GOARCH: "target",
+		},
+	}, testLogger())
+
+	err := installWithinDeadline(t, strategy)
+	if err == nil || !strings.Contains(err.Error(), "download stalled") {
+		t.Fatalf("Install() error = %v, want stall error", err)
+	}
+}
+
+func TestGithubReleaseStrategyInstallFailsOnStalledHeaders(t *testing.T) {
+	srv := stallingServer(t, nil)
+	swapDownloadClient(t, redirectToServer(t, testDownloadClient(150*time.Millisecond), srv))
+
+	strategy := NewGithubReleaseStrategy(t.TempDir(), "tool", GithubReleaseConfig{
+		Owner:        "owner",
+		Repo:         "repo",
+		AssetPattern: "tool-{target}",
+		Targets: map[string]string{
+			runtime.GOOS + "/" + runtime.GOARCH: "target",
+		},
+	}, testLogger())
+
+	err := installWithinDeadline(t, strategy)
+	if err == nil || !strings.Contains(err.Error(), "download failed") {
+		t.Fatalf("Install() error = %v, want download failure", err)
+	}
+}
+
+// installWithinDeadline fails the test if Install blocks instead of erroring
+// out, which is the regression these tests guard against.
+func installWithinDeadline(t *testing.T, strategy Strategy) error {
+	t.Helper()
+
+	type result struct{ err error }
+	done := make(chan result, 1)
+	go func() {
+		_, err := strategy.Install(t.Context())
+		done <- result{err: err}
+	}()
+
+	select {
+	case r := <-done:
+		return r.err
+	case <-time.After(30 * time.Second):
+		t.Fatal("Install() blocked on a stalled server instead of failing")
+		return nil
+	}
+}

--- a/apps/backend/internal/tools/installer/download_test.go
+++ b/apps/backend/internal/tools/installer/download_test.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"testing/synctest"
 	"time"
 )
 
@@ -160,6 +161,37 @@ func TestGetDownloadAllowsSlowButProgressingBody(t *testing.T) {
 	if want := chunks * len(payload); len(body) != want {
 		t.Fatalf("body length = %d, want %d", len(body), want)
 	}
+}
+
+// TestStallGuardIgnoresTimeSpentDownstream pins the distinction the guard
+// exists to make: it must bound how long a read blocks, not how long the caller
+// takes to digest what the read returned. Expanding one read's worth of a
+// highly compressed archive onto a slow disk can outlast the stall window
+// without the mirror having gone quiet at all.
+func TestStallGuardIgnoresTimeSpentDownstream(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		const timeout = 50 * time.Millisecond
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		guard := newStallGuard(io.NopCloser(strings.NewReader("abcdefghij")), cancel, timeout)
+		buf := make([]byte, 5)
+
+		if _, err := guard.Read(buf); err != nil {
+			t.Fatalf("first read error = %v", err)
+		}
+
+		// The caller is busy downstream, far longer than the stall window.
+		time.Sleep(10 * timeout)
+
+		if _, err := guard.Read(buf); err != nil {
+			t.Fatalf("read after slow downstream processing error = %v, want success", err)
+		}
+		if ctx.Err() != nil {
+			t.Fatalf("guard cancelled a progressing download: %v", ctx.Err())
+		}
+	})
 }
 
 func TestGetDownloadCancelsWithParentContext(t *testing.T) {

--- a/apps/backend/internal/tools/installer/github_release_strategy.go
+++ b/apps/backend/internal/tools/installer/github_release_strategy.go
@@ -63,14 +63,9 @@ func (s *GithubReleaseStrategy) Install(ctx context.Context) (*InstallResult, er
 		zap.String("target", target))
 
 	// Download
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	resp, err := getDownload(ctx, url)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("download failed: %w", err)
+		return nil, err
 	}
 	defer func() { _ = resp.Body.Close() }()
 

--- a/apps/backend/internal/tools/installer/github_tarball_strategy.go
+++ b/apps/backend/internal/tools/installer/github_tarball_strategy.go
@@ -140,14 +140,9 @@ func (s *GithubTarballStrategy) expandTemplate(tmpl, target string) string {
 }
 
 func (s *GithubTarballStrategy) download(ctx context.Context, url string) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	resp, err := getDownload(ctx, url)
 	if err != nil {
-		return fmt.Errorf("failed to create request: %w", err)
-	}
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("download failed: %w", err)
+		return err
 	}
 	defer func() { _ = resp.Body.Close() }()
 

--- a/apps/backend/internal/tools/installer/github_tarball_strategy_test.go
+++ b/apps/backend/internal/tools/installer/github_tarball_strategy_test.go
@@ -24,16 +24,14 @@ func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 func stubGithubTarballDownload(t *testing.T, archive []byte) func() int {
 	t.Helper()
 	requestCount := 0
-	originalClient := http.DefaultClient
-	http.DefaultClient = &http.Client{Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+	swapDownloadClient(t, &http.Client{Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
 		requestCount++
 		return &http.Response{
 			StatusCode: http.StatusOK,
 			Body:       io.NopCloser(bytes.NewReader(archive)),
 			Header:     make(http.Header),
 		}, nil
-	})}
-	t.Cleanup(func() { http.DefaultClient = originalClient })
+	})})
 	return func() int { return requestCount }
 }
 


### PR DESCRIPTION
## Problem

The tool installer downloaded release archives with `http.DefaultClient`, which has **no timeout**:

- `github_tarball_strategy.go` — `download()`
- `github_release_strategy.go` — `Install()`

A slow or stalled mirror left an install hanging indefinitely with no way out. `internal/system/updates/service.go` already carries a comment explaining exactly this ("http.DefaultClient has no timeout, so handing it the poller would let a stalled socket hang a goroutine for hours"), so this brings the installer in line with the established preference.

## Approach — and why

The task offered two options: a single package-level `Timeout`, or a plain `Timeout` for metadata calls plus a transport-level `ResponseHeaderTimeout` for body streams. **I went with the second shape, minus the metadata half, plus a stall guard**, for these reasons:

1. **No overall `http.Client.Timeout`.** These are tarballs (code-server is ~100 MB). A single deadline for the whole transfer is a bet on the user's bandwidth: whatever value is generous enough for a slow link is uselessly long as a hang detector, and whatever value is short enough to detect a hang will kill a large-but-perfectly-healthy download mid-flight. Bounding *phases* instead of the *total* separates "stuck" from "slow", which is the actual distinction we care about.

2. **There are no metadata calls in this package.** Both strategies build the download URL directly from config (`https://github.com/{owner}/{repo}/releases/...`) — there is no GitHub API call to give a plain `Timeout` to. So the "metadata vs. body" split collapses to one client, configured for body streams.

3. **`ResponseHeaderTimeout` alone is not enough**, which is the part worth flagging. It only bounds the wait for the status line. Once headers are in, a mirror that goes quiet mid-body leaves the read blocked forever — the exact failure being fixed, just moved a few hundred milliseconds later. So response bodies are wrapped in a `stallGuard`, which bounds how long any single read may block: it arms a timer immediately before the blocking `body.Read` and stops it as soon as the read returns, cancelling the request if the read stays blocked past `downloadStallTimeout` (2 min). A download is killed only for *lack of progress*, never for taking a long time while still moving.

The timer deliberately covers the blocking read **only**. Wall-clock time the caller then spends downstream — decompressing, untarring, writing to a slow disk — is not the mirror's fault, and a highly compressed archive can take longer to expand one read's worth of bytes than to fetch the next. Counting that against the mirror would surface a false `download stalled` error on a perfectly healthy install. ([Codex review](https://github.com/kdlbs/kandev/pull/2016#discussion_r3667780407) caught the first version doing exactly that; fixed in b031d3440.)

Resulting bounds: dial 30s, TLS handshake 30s, response headers 60s, body idle 2min, total unbounded.

## Changes

- **New `download.go`** — package-level `downloadClient` (`newDownloadClient()`), the `getDownload(ctx, url)` helper, and `stallGuard`.
- Both strategies call `getDownload`; the derived context is cancelled by `resp.Body.Close()`, which callers already `defer`.
- Requests still go through `http.NewRequestWithContext` (they already did), and the guard's context is derived from the caller's, so **cancelling the install context still cancels the download** — verified by a test.
- **Whole-package sweep**: `internal/tools/installer` had exactly these two `http.DefaultClient` uses; `npm_strategy.go`, `go_install_strategy.go`, `resolve.go`, and `strategy.go` make no HTTP calls. `internal/gitlab/connectivity.go` and `internal/webapp/dev_handler.go` were left alone per the task scope.

## Tests

New `download_test.go`, all `httptest`-based:

| Test | Asserts |
|---|---|
| `TestGetDownloadFailsWhenResponseHeadersStall` | server never writes headers → error, not a block |
| `TestGetDownloadFailsWhenBodyStalls` | server writes a prefix then goes silent → `download stalled` error |
| `TestGetDownloadAllowsSlowButProgressingBody` | total transfer time **exceeds** the stall window while each gap stays under it → succeeds (this is the regression guard for point 1 above) |
| `TestStallGuardIgnoresTimeSpentDownstream` | a caller that sleeps 10x the stall window between reads is not cancelled — guards the downstream-processing fix; confirmed failing against the pre-fix implementation |
| `TestGetDownloadCancelsWithParentContext` | cancelling the caller's context aborts an in-flight read |
| `TestGithubTarballStrategyInstallFailsOnStalledServer` | stall mid-archive → `Install()` errors |
| `TestGithubReleaseStrategyInstallFailsOnStalledServer` | stall mid-binary → `Install()` errors |
| `TestGithubReleaseStrategyInstallFailsOnStalledHeaders` | stall before headers → `Install()` errors |

Strategy-level tests route the hardcoded `github.com` URL to the test server through a rewriting `RoundTripper` layered over the **real** production transport, so the timeout configuration itself is under test rather than mocked away. They run `Install()` against a deadline and fail explicitly if it blocks rather than errors. The pre-existing `stubGithubTarballDownload` helper was updated to swap `downloadClient` instead of mutating the global `http.DefaultClient`.

## Validation

- `go test -race ./internal/tools/installer/` — pass
- `golangci-lint run ./...` (full backend) — **0 issues**
- `make -C apps/backend test` — the installer package and everything it touches pass. Four unrelated packages fail (`internal/gitlab`, `internal/notifications/service`, `internal/task/handlers`, `internal/task/service`); I confirmed these fail **identically on a clean `HEAD` worktree**, so they are pre-existing and environmental (GitLab startup-host trust, local-repo-init folder validation), not caused by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)