### PR TITLE
refactor(backend): share the native-binary ACP agent scaffold

### DIFF
--- a/apps/backend/internal/agent/agents/cursor_acp.go
+++ b/apps/backend/internal/agent/agents/cursor_acp.go
@@ -1,14 +1,9 @@
-//nolint:dupl // Native-binary ACP agents (Cursor, Kimi, Kiro, Qoder, Trae) follow the same minimal scaffold; differences are the binary name and subcommand.
 package agents
 
 import (
-	"context"
 	_ "embed"
-	"time"
 
 	"github.com/kandev/kandev/internal/agent/mcpconfig"
-	"github.com/kandev/kandev/internal/agent/usage"
-	"github.com/kandev/kandev/pkg/agent"
 )
 
 //go:embed logos/cursor_acp_light.svg
@@ -18,6 +13,18 @@ var cursorACPLogoLight []byte
 var cursorACPLogoDark []byte
 
 const cursorACPBin = "cursor-agent"
+
+// cursorACPInstallScript installs cursor-agent, which isn't on npm. The
+// official installer drops the binary into ~/.local/bin; make sure that dir is
+// on PATH for the rest of the prepare script and for future shells on the
+// sprite.
+const cursorACPInstallScript = `set -e
+tmp="$(mktemp)"
+curl -fsS https://cursor.com/install -o "$tmp"
+bash "$tmp"
+rm -f "$tmp"
+export PATH="$HOME/.local/bin:$PATH"
+grep -qxF 'export PATH="$HOME/.local/bin:$PATH"' "$HOME/.bashrc" 2>/dev/null || echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$HOME/.bashrc"`
 
 // cursorPermSettings maps a curated CLI flag to cursor-agent's --force switch.
 // In ACP mode Cursor emits session/request_permission for commands off its
@@ -44,116 +51,47 @@ var (
 // CursorACP implements Agent for Cursor's CLI via its native ACP mode.
 // Cursor isn't published to npm — users must install the cursor-agent binary
 // from Cursor (Pro subscription required).
+//
+// --force is applied via profile cli_flags (seeded from cursor_force), not
+// PermissionValues, so auto_approve stays agentctl-only.
 type CursorACP struct {
-	StandardPassthrough
+	nativeACPPassthroughAgent
 }
 
 func NewCursorACP() *CursorACP {
-	return &CursorACP{
-		StandardPassthrough: StandardPassthrough{
-			PermSettings: cursorPermSettings,
-			Cfg: PassthroughConfig{
-				Supported:      true,
-				Label:          "CLI Passthrough",
-				Description:    "Show terminal directly instead of chat interface",
-				PassthroughCmd: NewCommand(cursorACPBin),
-				ModelFlag:      NewParam("--model", "{model}"),
-				IdleTimeout:    3 * time.Second,
-				BufferMaxBytes: DefaultBufferMaxBytes,
+	return &CursorACP{newNativeACPPassthrough(
+		nativeACPSpec{
+			id:            "cursor-acp",
+			name:          "Cursor ACP Agent",
+			displayName:   "Cursor",
+			description:   "Cursor CLI coding agent (cursor-agent) using the ACP protocol. Requires a Cursor Pro subscription.",
+			displayOrder:  13,
+			bin:           cursorACPBin,
+			args:          []string{"acp"},
+			logoLight:     cursorACPLogoLight,
+			logoDark:      cursorACPLogoDark,
+			installScript: cursorACPInstallScript,
+			permSettings:  cursorPermSettings,
+			remoteAuth: &RemoteAuth{
+				Methods: []RemoteAuthMethod{
+					{
+						Type:      "env",
+						EnvVar:    "CURSOR_API_KEY",
+						SetupHint: "Create an API key at https://cursor.com/dashboard/integrations (Cursor Pro).",
+					},
+				},
+			},
+			runtime: nativeACPRuntimeSpec{
+				userSkillDir:       ".cursor/skills",
+				sessionDirTemplate: "{home}/.cursor",
 				// cursor-agent has no MCP flag/env; write or merge a
 				// project-local .cursor/mcp.json into the worktree.
-				MCPStrategy: mcpconfig.CursorStrategy{},
+				projectMCPStrategy: mcpconfig.CursorStrategy{},
 			},
 		},
-	}
-}
-
-func (a *CursorACP) ID() string          { return "cursor-acp" }
-func (a *CursorACP) Name() string        { return "Cursor ACP Agent" }
-func (a *CursorACP) DisplayName() string { return "Cursor" }
-func (a *CursorACP) Description() string {
-	return "Cursor CLI coding agent (cursor-agent) using the ACP protocol. Requires a Cursor Pro subscription."
-}
-func (a *CursorACP) Enabled() bool     { return true }
-func (a *CursorACP) DisplayOrder() int { return 13 }
-
-func (a *CursorACP) Logo(v LogoVariant) []byte {
-	if v == LogoDark {
-		return cursorACPLogoDark
-	}
-	return cursorACPLogoLight
-}
-
-func (a *CursorACP) IsInstalled(ctx context.Context) (*DiscoveryResult, error) {
-	result, err := Detect(ctx, WithCommand(cursorACPBin))
-	if err != nil {
-		return result, err
-	}
-	result.SupportsMCP = true
-	result.Capabilities = DiscoveryCapabilities{
-		SupportsSessionResume: true,
-	}
-	return result, nil
-}
-
-func (a *CursorACP) BuildCommand(opts CommandOptions) Command {
-	// --force is applied via profile cli_flags (seeded from cursor_force), not
-	// PermissionValues, so auto_approve stays agentctl-only.
-	return Cmd(cursorACPBin, "acp").Build()
-}
-
-func (a *CursorACP) Runtime() *RuntimeConfig {
-	canRecover := true
-	return &RuntimeConfig{
-		Cmd:                Cmd(cursorACPBin, "acp").Build(),
-		WorkingDir:         "{workspace}",
-		Env:                map[string]string{},
-		ResourceLimits:     ResourceLimits{MemoryMB: 4096, CPUCores: 2.0, Timeout: time.Hour},
-		Protocol:           agent.ProtocolACP,
-		UserSkillDir:       ".cursor/skills",
-		ProjectMCPStrategy: mcpconfig.CursorStrategy{},
-		SessionConfig: SessionConfig{
-			NativeSessionResume: true,
-			CanRecover:          &canRecover,
-			SessionDirTemplate:  "{home}/.cursor",
+		nativeACPPassthroughSpec{
+			modelFlag:   nativeACPModelFlag(),
+			mcpStrategy: mcpconfig.CursorStrategy{},
 		},
-	}
+	)}
 }
-
-func (a *CursorACP) RemoteAuth() *RemoteAuth {
-	return &RemoteAuth{
-		Methods: []RemoteAuthMethod{
-			{
-				Type:      "env",
-				EnvVar:    "CURSOR_API_KEY",
-				SetupHint: "Create an API key at https://cursor.com/dashboard/integrations (Cursor Pro).",
-			},
-		},
-	}
-}
-
-// cursor-agent isn't on npm. The official installer drops the binary into
-// ~/.local/bin; make sure that dir is on PATH for the rest of the prepare
-// script and for future shells on the sprite.
-func (a *CursorACP) InstallScript() string {
-	return `set -e
-tmp="$(mktemp)"
-curl -fsS https://cursor.com/install -o "$tmp"
-bash "$tmp"
-rm -f "$tmp"
-export PATH="$HOME/.local/bin:$PATH"
-grep -qxF 'export PATH="$HOME/.local/bin:$PATH"' "$HOME/.bashrc" 2>/dev/null || echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$HOME/.bashrc"`
-}
-
-func (a *CursorACP) PermissionSettings() map[string]PermissionSetting {
-	return cursorPermSettings
-}
-
-func (a *CursorACP) InferenceConfig() *InferenceConfig {
-	return &InferenceConfig{
-		Supported: true,
-		Command:   NewCommand(cursorACPBin, "acp"),
-	}
-}
-
-func (a *CursorACP) BillingType() usage.BillingType { return defaultBillingType() }

--- a/apps/backend/internal/agent/agents/devin_acp.go
+++ b/apps/backend/internal/agent/agents/devin_acp.go
@@ -1,13 +1,7 @@
-//nolint:dupl,goconst // Native-binary ACP agents (Cursor, Kimi, Kiro, Qoder, Trae, Omp, Devin) follow the same minimal scaffold; shared literals (CLI Passthrough, etc.) live in every peer file by convention.
 package agents
 
 import (
-	"context"
 	_ "embed"
-	"time"
-
-	"github.com/kandev/kandev/internal/agent/usage"
-	"github.com/kandev/kandev/pkg/agent"
 )
 
 //go:embed logos/devin_acp_light.svg
@@ -23,6 +17,37 @@ const (
 	devinCredentialsRelPath = devinCredentialsDir + "/credentials.toml"
 	devinDefaultAPIServer   = "https://server.self-serve.windsurf.com"
 )
+
+const devinACPInstallScript = `set -e
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+curl -fsSL https://cli.devin.ai/install.sh -o "$tmp"
+if ! bash "$tmp" && [ ! -x "$HOME/.local/bin/devin" ]; then
+  exit 1
+fi
+export PATH="$HOME/.local/bin:$PATH"
+persist_devin_path() {
+  grep -qxF 'export PATH="$HOME/.local/bin:$PATH"' "$1" 2>/dev/null || echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$1"
+}
+persist_devin_path "$HOME/.profile"
+persist_devin_path "$HOME/.bash_profile"
+persist_devin_path "$HOME/.bashrc"
+persist_devin_path "$HOME/.zprofile"
+persist_devin_path "$HOME/.zshrc"
+devin --version >/dev/null`
+
+const devinACPCredentialsSetupScript = `mkdir -p "${HOME}/.local/share/devin"
+escape_toml() {
+  printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
+}
+api_key="$(escape_toml "${WINDSURF_API_KEY}")"
+api_server="$(escape_toml "${WINDSURF_API_SERVER_URL:-` + devinDefaultAPIServer + `}")"
+umask 077
+cat > "${HOME}/.local/share/devin/credentials.toml" <<CREDS
+windsurf_api_key = "${api_key}"
+api_server_url = "${api_server}"
+CREDS
+chmod 600 "${HOME}/.local/share/devin/credentials.toml"`
 
 var (
 	_ Agent            = (*DevinACP)(nil)
@@ -41,145 +66,57 @@ var (
 // strips ACP_BACKEND from the child environment so Devin uses the fall-back
 // path — no protocol-level authenticate needed.
 type DevinACP struct {
-	StandardPassthrough
+	nativeACPPassthroughAgent
 }
 
 func NewDevinACP() *DevinACP {
-	return &DevinACP{
-		StandardPassthrough: StandardPassthrough{
-			PermSettings: emptyPermSettings,
-			Cfg: PassthroughConfig{
-				Supported:      true,
-				Label:          "CLI Passthrough",
-				Description:    "Show terminal directly instead of chat interface",
-				PassthroughCmd: NewCommand(devinACPBin),
-				IdleTimeout:    3 * time.Second,
-				BufferMaxBytes: DefaultBufferMaxBytes,
-			},
-		},
-	}
-}
-
-func (a *DevinACP) ID() string          { return "devin-acp" }
-func (a *DevinACP) Name() string        { return "Devin ACP Agent" }
-func (a *DevinACP) DisplayName() string { return "Devin" }
-func (a *DevinACP) Description() string {
-	return "Cognition Devin coding agent using the ACP protocol via `devin acp`."
-}
-func (a *DevinACP) Enabled() bool     { return true }
-func (a *DevinACP) DisplayOrder() int { return 19 }
-
-func (a *DevinACP) Logo(v LogoVariant) []byte {
-	if v == LogoDark {
-		return devinACPLogoDark
-	}
-	return devinACPLogoLight
-}
-
-func (a *DevinACP) IsInstalled(ctx context.Context) (*DiscoveryResult, error) {
-	result, err := Detect(ctx, WithCommand(devinACPBin))
-	if err != nil {
-		return result, err
-	}
-	result.SupportsMCP = true
-	result.Capabilities = DiscoveryCapabilities{
-		SupportsSessionResume: true,
-	}
-	return result, nil
-}
-
-func (a *DevinACP) BuildCommand(opts CommandOptions) Command {
-	return Cmd(devinACPBin, "acp").Build()
-}
-
-func (a *DevinACP) Runtime() *RuntimeConfig {
-	canRecover := true
-	return &RuntimeConfig{
-		Cmd:            Cmd(devinACPBin, "acp").Build(),
-		WorkingDir:     "{workspace}",
-		Env:            map[string]string{},
-		ResourceLimits: ResourceLimits{MemoryMB: 4096, CPUCores: 2.0, Timeout: time.Hour},
-		Protocol:       agent.ProtocolACP,
-		// Devin advertises mcpCapabilities {http: false, sse: false} but
-		// actually supports streamable HTTP MCP (used by Windsurf Next).
-		// Without these overrides, filterMcpServersByCapabilities drops the
-		// Kandev MCP server (exposed via HTTP /mcp and SSE /sse), and the
-		// agent loses access to task tools (get_task_plan_kandev, etc.).
-		AssumeMcpSse:  true,
-		AssumeMcpHttp: true,
-		// See DevinACP doc comment for the ACP_BACKEND rationale.
-		StripEnv: []string{"ACP_BACKEND"},
-		SessionConfig: SessionConfig{
-			NativeSessionResume: true,
-			CanRecover:          &canRecover,
-			SessionDirTemplate:  "{home}/.local/share/devin",
-			SessionDirTarget:    "/root/.local/share/devin",
-		},
-	}
-}
-
-func (a *DevinACP) RemoteAuth() *RemoteAuth {
-	return &RemoteAuth{
-		Methods: []RemoteAuthMethod{
-			{
-				Type:  "files",
-				Label: "Copy Devin CLI credentials",
-				SourceFiles: map[string][]string{
-					"darwin": {devinCredentialsRelPath},
-					"linux":  {devinCredentialsRelPath},
+	return &DevinACP{newNativeACPPassthrough(
+		nativeACPSpec{
+			id:            "devin-acp",
+			name:          "Devin ACP Agent",
+			displayName:   "Devin",
+			description:   "Cognition Devin coding agent using the ACP protocol via `devin acp`.",
+			displayOrder:  19,
+			bin:           devinACPBin,
+			args:          []string{"acp"},
+			logoLight:     devinACPLogoLight,
+			logoDark:      devinACPLogoDark,
+			installScript: devinACPInstallScript,
+			permSettings:  emptyPermSettings,
+			remoteAuth: &RemoteAuth{
+				Methods: []RemoteAuthMethod{
+					{
+						Type:  "files",
+						Label: "Copy Devin CLI credentials",
+						SourceFiles: map[string][]string{
+							"darwin": {devinCredentialsRelPath},
+							"linux":  {devinCredentialsRelPath},
+						},
+						TargetRelDir: devinCredentialsDir,
+					},
+					{
+						Type:        "env",
+						EnvVar:      "WINDSURF_API_KEY",
+						SetupHint:   "Set WINDSURF_API_KEY to authenticate Devin CLI in remote or headless environments.",
+						SetupScript: devinACPCredentialsSetupScript,
+					},
 				},
-				TargetRelDir: devinCredentialsDir,
 			},
-			{
-				Type:      "env",
-				EnvVar:    "WINDSURF_API_KEY",
-				SetupHint: "Set WINDSURF_API_KEY to authenticate Devin CLI in remote or headless environments.",
-				SetupScript: `mkdir -p "${HOME}/.local/share/devin"
-escape_toml() {
-  printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
-}
-api_key="$(escape_toml "${WINDSURF_API_KEY}")"
-api_server="$(escape_toml "${WINDSURF_API_SERVER_URL:-` + devinDefaultAPIServer + `}")"
-umask 077
-cat > "${HOME}/.local/share/devin/credentials.toml" <<CREDS
-windsurf_api_key = "${api_key}"
-api_server_url = "${api_server}"
-CREDS
-chmod 600 "${HOME}/.local/share/devin/credentials.toml"`,
+			runtime: nativeACPRuntimeSpec{
+				// Devin advertises mcpCapabilities {http: false, sse: false} but
+				// actually supports streamable HTTP MCP (used by Windsurf Next).
+				// Without these overrides, filterMcpServersByCapabilities drops the
+				// Kandev MCP server (exposed via HTTP /mcp and SSE /sse), and the
+				// agent loses access to task tools (get_task_plan_kandev, etc.).
+				assumeMcpSse:  true,
+				assumeMcpHttp: true,
+				// See DevinACP doc comment for the ACP_BACKEND rationale.
+				stripEnv:           []string{"ACP_BACKEND"},
+				sessionDirTemplate: "{home}/.local/share/devin",
+				sessionDirTarget:   "/root/.local/share/devin",
 			},
 		},
-	}
+		// Devin's CLI takes no --model flag in passthrough mode.
+		nativeACPPassthroughSpec{},
+	)}
 }
-
-func (a *DevinACP) InstallScript() string {
-	return `set -e
-tmp="$(mktemp)"
-trap 'rm -f "$tmp"' EXIT
-curl -fsSL https://cli.devin.ai/install.sh -o "$tmp"
-if ! bash "$tmp" && [ ! -x "$HOME/.local/bin/devin" ]; then
-  exit 1
-fi
-export PATH="$HOME/.local/bin:$PATH"
-persist_devin_path() {
-  grep -qxF 'export PATH="$HOME/.local/bin:$PATH"' "$1" 2>/dev/null || echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$1"
-}
-persist_devin_path "$HOME/.profile"
-persist_devin_path "$HOME/.bash_profile"
-persist_devin_path "$HOME/.bashrc"
-persist_devin_path "$HOME/.zprofile"
-persist_devin_path "$HOME/.zshrc"
-devin --version >/dev/null`
-}
-
-func (a *DevinACP) PermissionSettings() map[string]PermissionSetting {
-	return emptyPermSettings
-}
-
-func (a *DevinACP) InferenceConfig() *InferenceConfig {
-	return &InferenceConfig{
-		Supported: true,
-		Command:   NewCommand(devinACPBin, "acp"),
-	}
-}
-
-func (a *DevinACP) BillingType() usage.BillingType { return defaultBillingType() }

--- a/apps/backend/internal/agent/agents/grok_acp.go
+++ b/apps/backend/internal/agent/agents/grok_acp.go
@@ -1,13 +1,7 @@
-//nolint:dupl // Native-binary ACP agents follow the same minimal scaffold; differences are the binary name, argv, and auth surface.
 package agents
 
 import (
-	"context"
 	_ "embed"
-	"time"
-
-	"github.com/kandev/kandev/internal/agent/usage"
-	"github.com/kandev/kandev/pkg/agent"
 )
 
 //go:embed logos/grok_acp_light.svg
@@ -18,10 +12,10 @@ var grokACPLogoDark []byte
 
 const grokACPBin = "grok"
 
-// grokACPArgv is the ACP / inference launch argv. --no-auto-update must
+// grokACPArgs are the ACP / inference launch arguments. --no-auto-update must
 // precede the agent subcommand so background self-update checks do not run
 // for Kandev-managed sessions.
-var grokACPArgv = []string{grokACPBin, "--no-auto-update", "agent", "stdio"}
+var grokACPArgs = []string{"--no-auto-update", "agent", "stdio"}
 
 var (
 	_ Agent          = (*GrokACP)(nil)
@@ -31,85 +25,53 @@ var (
 
 // GrokACP implements Agent for xAI's Grok Build CLI using native ACP over
 // stdin/stdout. Raw TUI passthrough is intentionally deferred (requires a
-// project-scoped PassthroughMCPStrategy — see ADR 0014).
-type GrokACP struct{}
+// project-scoped PassthroughMCPStrategy — see ADR 0014), so this embeds the
+// bare nativeACPAgent rather than the passthrough variant.
+type GrokACP struct {
+	nativeACPAgent
+}
 
 func NewGrokACP() *GrokACP {
-	return &GrokACP{}
-}
-
-func (a *GrokACP) ID() string          { return "grok-acp" }
-func (a *GrokACP) Name() string        { return "Grok ACP Agent" }
-func (a *GrokACP) DisplayName() string { return "Grok" }
-func (a *GrokACP) Description() string {
-	return "xAI Grok coding agent using the ACP protocol over stdin/stdout."
-}
-func (a *GrokACP) Enabled() bool     { return true }
-func (a *GrokACP) DisplayOrder() int { return 20 }
-
-func (a *GrokACP) Logo(v LogoVariant) []byte {
-	if v == LogoDark {
-		return grokACPLogoDark
-	}
-	return grokACPLogoLight
-}
-
-func (a *GrokACP) IsInstalled(ctx context.Context) (*DiscoveryResult, error) {
-	result, err := Detect(ctx, WithCommand(grokACPBin))
-	if err != nil {
-		return result, err
-	}
-	result.SupportsMCP = true
-	result.Capabilities = DiscoveryCapabilities{
-		SupportsSessionResume: true,
-	}
-	return result, nil
-}
-
-func (a *GrokACP) BuildCommand(opts CommandOptions) Command {
-	return Cmd(grokACPArgv...).Build()
-}
-
-func (a *GrokACP) Runtime() *RuntimeConfig {
-	canRecover := true
-	return &RuntimeConfig{
-		Cmd:             Cmd(grokACPArgv...).Build(),
-		WorkingDir:      "{workspace}",
-		RequiredEnv:     []string{}, // Cached OAuth or optional XAI_API_KEY — not a launch prerequisite.
-		Env:             map[string]string{},
-		ResourceLimits:  ResourceLimits{MemoryMB: 4096, CPUCores: 2.0, Timeout: time.Hour},
-		Protocol:        agent.ProtocolACP,
-		ProjectSkillDir: ".grok/skills",
-		UserSkillDir:    ".grok/skills",
-		SessionConfig: SessionConfig{
-			NativeSessionResume:         true,
-			NewSessionOnWorkspaceRebind: true,
-			CanRecover:                  &canRecover,
-			SessionDirTemplate:          "{home}/.grok",
-			SessionDirTarget:            "/root/.grok",
-		},
-	}
-}
-
-func (a *GrokACP) RemoteAuth() *RemoteAuth {
-	return &RemoteAuth{
-		Methods: []RemoteAuthMethod{
-			{
-				Type:  "files",
-				Label: "Copy auth files",
-				SourceFiles: map[string][]string{
-					"darwin": {".grok/auth.json"},
-					"linux":  {".grok/auth.json"},
+	return &GrokACP{nativeACPAgent{spec: nativeACPSpec{
+		id:            "grok-acp",
+		name:          "Grok ACP Agent",
+		displayName:   "Grok",
+		description:   "xAI Grok coding agent using the ACP protocol over stdin/stdout.",
+		displayOrder:  20,
+		bin:           grokACPBin,
+		args:          grokACPArgs,
+		logoLight:     grokACPLogoLight,
+		logoDark:      grokACPLogoDark,
+		installScript: "npm install -g @xai-official/grok",
+		permSettings:  emptyPermSettings,
+		remoteAuth: &RemoteAuth{
+			Methods: []RemoteAuthMethod{
+				{
+					Type:  "files",
+					Label: "Copy auth files",
+					SourceFiles: map[string][]string{
+						"darwin": {".grok/auth.json"},
+						"linux":  {".grok/auth.json"},
+					},
+					// Only auth.json — do not copy config.toml, sessions, logs, or caches.
+					TargetRelDir: ".grok",
 				},
-				// Only auth.json — do not copy config.toml, sessions, logs, or caches.
-				TargetRelDir: ".grok",
-			},
-			{
-				Type:   "env",
-				EnvVar: "XAI_API_KEY",
+				{
+					Type:   "env",
+					EnvVar: "XAI_API_KEY",
+				},
 			},
 		},
-	}
+		runtime: nativeACPRuntimeSpec{
+			// Cached OAuth or optional XAI_API_KEY — not a launch prerequisite.
+			requiredEnv:                 []string{},
+			projectSkillDir:             ".grok/skills",
+			userSkillDir:                ".grok/skills",
+			sessionDirTemplate:          "{home}/.grok",
+			sessionDirTarget:            "/root/.grok",
+			newSessionOnWorkspaceRebind: true,
+		},
+	}}}
 }
 
 // LoginCommand uses device-code auth so headless/container/SSH environments
@@ -120,20 +82,3 @@ func (a *GrokACP) LoginCommand() *LoginCommand {
 		Description: "Sign in with your xAI / Grok account.",
 	}
 }
-
-func (a *GrokACP) InstallScript() string {
-	return "npm install -g @xai-official/grok"
-}
-
-func (a *GrokACP) PermissionSettings() map[string]PermissionSetting {
-	return emptyPermSettings
-}
-
-func (a *GrokACP) InferenceConfig() *InferenceConfig {
-	return &InferenceConfig{
-		Supported: true,
-		Command:   NewCommand(grokACPArgv...),
-	}
-}
-
-func (a *GrokACP) BillingType() usage.BillingType { return defaultBillingType() }

--- a/apps/backend/internal/agent/agents/kimi_acp.go
+++ b/apps/backend/internal/agent/agents/kimi_acp.go
@@ -1,13 +1,7 @@
-//nolint:dupl // Native-binary ACP agents (Cursor, Kimi, Kiro, Qoder, Trae) follow the same minimal scaffold; differences are the binary name and subcommand.
 package agents
 
 import (
-	"context"
 	_ "embed"
-	"time"
-
-	"github.com/kandev/kandev/internal/agent/usage"
-	"github.com/kandev/kandev/pkg/agent"
 )
 
 //go:embed logos/kimi_acp_light.svg
@@ -27,89 +21,27 @@ var (
 // KimiACP implements Agent for Moonshot's Kimi CLI using ACP.
 // Not on npm — users must install the kimi binary from Moonshot AI.
 type KimiACP struct {
-	StandardPassthrough
+	nativeACPPassthroughAgent
 }
 
 func NewKimiACP() *KimiACP {
-	return &KimiACP{
-		StandardPassthrough: StandardPassthrough{
-			PermSettings: emptyPermSettings,
-			Cfg: PassthroughConfig{
-				Supported:      true,
-				Label:          "CLI Passthrough",
-				Description:    "Show terminal directly instead of chat interface",
-				PassthroughCmd: NewCommand(kimiACPBin),
-				ModelFlag:      NewParam("--model", "{model}"),
-				IdleTimeout:    3 * time.Second,
-				BufferMaxBytes: DefaultBufferMaxBytes,
+	return &KimiACP{newNativeACPPassthrough(
+		nativeACPSpec{
+			id:            "kimi-acp",
+			name:          "Kimi ACP Agent",
+			displayName:   "Kimi",
+			description:   "Moonshot AI Kimi coding agent using the ACP protocol over stdin/stdout.",
+			displayOrder:  14,
+			bin:           kimiACPBin,
+			args:          []string{"acp"},
+			logoLight:     kimiACPLogoLight,
+			logoDark:      kimiACPLogoDark,
+			installScript: "Install Kimi CLI from Moonshot AI",
+			permSettings:  emptyPermSettings,
+			runtime: nativeACPRuntimeSpec{
+				sessionDirTemplate: "{home}/.kimi",
 			},
 		},
-	}
+		nativeACPPassthroughSpec{modelFlag: nativeACPModelFlag()},
+	)}
 }
-
-func (a *KimiACP) ID() string          { return "kimi-acp" }
-func (a *KimiACP) Name() string        { return "Kimi ACP Agent" }
-func (a *KimiACP) DisplayName() string { return "Kimi" }
-func (a *KimiACP) Description() string {
-	return "Moonshot AI Kimi coding agent using the ACP protocol over stdin/stdout."
-}
-func (a *KimiACP) Enabled() bool     { return true }
-func (a *KimiACP) DisplayOrder() int { return 14 }
-
-func (a *KimiACP) Logo(v LogoVariant) []byte {
-	if v == LogoDark {
-		return kimiACPLogoDark
-	}
-	return kimiACPLogoLight
-}
-
-func (a *KimiACP) IsInstalled(ctx context.Context) (*DiscoveryResult, error) {
-	result, err := Detect(ctx, WithCommand(kimiACPBin))
-	if err != nil {
-		return result, err
-	}
-	result.SupportsMCP = true
-	result.Capabilities = DiscoveryCapabilities{
-		SupportsSessionResume: true,
-	}
-	return result, nil
-}
-
-func (a *KimiACP) BuildCommand(opts CommandOptions) Command {
-	return Cmd(kimiACPBin, "acp").Build()
-}
-
-func (a *KimiACP) Runtime() *RuntimeConfig {
-	canRecover := true
-	return &RuntimeConfig{
-		Cmd:            Cmd(kimiACPBin, "acp").Build(),
-		WorkingDir:     "{workspace}",
-		Env:            map[string]string{},
-		ResourceLimits: ResourceLimits{MemoryMB: 4096, CPUCores: 2.0, Timeout: time.Hour},
-		Protocol:       agent.ProtocolACP,
-		SessionConfig: SessionConfig{
-			NativeSessionResume: true,
-			CanRecover:          &canRecover,
-			SessionDirTemplate:  "{home}/.kimi",
-		},
-	}
-}
-
-func (a *KimiACP) RemoteAuth() *RemoteAuth { return nil }
-
-func (a *KimiACP) InstallScript() string {
-	return "Install Kimi CLI from Moonshot AI"
-}
-
-func (a *KimiACP) PermissionSettings() map[string]PermissionSetting {
-	return emptyPermSettings
-}
-
-func (a *KimiACP) InferenceConfig() *InferenceConfig {
-	return &InferenceConfig{
-		Supported: true,
-		Command:   NewCommand(kimiACPBin, "acp"),
-	}
-}
-
-func (a *KimiACP) BillingType() usage.BillingType { return defaultBillingType() }

--- a/apps/backend/internal/agent/agents/kiro_acp.go
+++ b/apps/backend/internal/agent/agents/kiro_acp.go
@@ -1,13 +1,7 @@
-//nolint:dupl // Native-binary ACP agents (Cursor, Kimi, Kiro, Qoder, Trae) follow the same minimal scaffold; differences are the binary name and subcommand.
 package agents
 
 import (
-	"context"
 	_ "embed"
-	"time"
-
-	"github.com/kandev/kandev/internal/agent/usage"
-	"github.com/kandev/kandev/pkg/agent"
 )
 
 //go:embed logos/kiro_acp_light.svg
@@ -27,97 +21,35 @@ var (
 // KiroACP implements Agent for AWS Kiro using ACP. The CLI binary
 // (kiro-cli-chat) is installed via AWS-provided tooling.
 type KiroACP struct {
-	StandardPassthrough
+	nativeACPPassthroughAgent
 }
 
 func NewKiroACP() *KiroACP {
-	return &KiroACP{
-		StandardPassthrough: StandardPassthrough{
-			PermSettings: emptyPermSettings,
-			Cfg: PassthroughConfig{
-				Supported:      true,
-				Label:          "CLI Passthrough",
-				Description:    "Show terminal directly instead of chat interface",
-				PassthroughCmd: NewCommand(kiroACPBin),
-				ModelFlag:      NewParam("--model", "{model}"),
-				IdleTimeout:    3 * time.Second,
-				BufferMaxBytes: DefaultBufferMaxBytes,
+	return &KiroACP{newNativeACPPassthrough(
+		nativeACPSpec{
+			id:            "kiro-acp",
+			name:          "Kiro ACP Agent",
+			displayName:   "Kiro",
+			description:   "AWS Kiro coding agent using the ACP protocol via kiro-cli-chat.",
+			displayOrder:  15,
+			bin:           kiroACPBin,
+			args:          []string{"acp"},
+			logoLight:     kiroACPLogoLight,
+			logoDark:      kiroACPLogoDark,
+			installScript: "Install Kiro CLI from AWS",
+			permSettings:  emptyPermSettings,
+			runtime: nativeACPRuntimeSpec{
+				userSkillDir: ".kiro/skills",
+				// Verified against Kiro CLI 2.15.0 by driving `kiro-cli-chat acp`
+				// through session/new: each ACP session is persisted as
+				// ~/.kiro/sessions/cli/<sessionId>.{json,jsonl}. KIRO_HOME
+				// relocates the directory. Note ~/.kiro carries config + sessions
+				// only — the login token lives in the separate
+				// ~/.local/share/kiro-cli/data.sqlite3 (auth_kv table), so this
+				// mount persists resumable sessions but not authentication.
+				sessionDirTemplate: "{home}/.kiro",
 			},
 		},
-	}
+		nativeACPPassthroughSpec{modelFlag: nativeACPModelFlag()},
+	)}
 }
-
-func (a *KiroACP) ID() string          { return "kiro-acp" }
-func (a *KiroACP) Name() string        { return "Kiro ACP Agent" }
-func (a *KiroACP) DisplayName() string { return "Kiro" }
-func (a *KiroACP) Description() string {
-	return "AWS Kiro coding agent using the ACP protocol via kiro-cli-chat."
-}
-func (a *KiroACP) Enabled() bool     { return true }
-func (a *KiroACP) DisplayOrder() int { return 15 }
-
-func (a *KiroACP) Logo(v LogoVariant) []byte {
-	if v == LogoDark {
-		return kiroACPLogoDark
-	}
-	return kiroACPLogoLight
-}
-
-func (a *KiroACP) IsInstalled(ctx context.Context) (*DiscoveryResult, error) {
-	result, err := Detect(ctx, WithCommand(kiroACPBin))
-	if err != nil {
-		return result, err
-	}
-	result.SupportsMCP = true
-	result.Capabilities = DiscoveryCapabilities{
-		SupportsSessionResume: true,
-	}
-	return result, nil
-}
-
-func (a *KiroACP) BuildCommand(opts CommandOptions) Command {
-	return Cmd(kiroACPBin, "acp").Build()
-}
-
-func (a *KiroACP) Runtime() *RuntimeConfig {
-	canRecover := true
-	return &RuntimeConfig{
-		Cmd:            Cmd(kiroACPBin, "acp").Build(),
-		WorkingDir:     "{workspace}",
-		Env:            map[string]string{},
-		ResourceLimits: ResourceLimits{MemoryMB: 4096, CPUCores: 2.0, Timeout: time.Hour},
-		Protocol:       agent.ProtocolACP,
-		UserSkillDir:   ".kiro/skills",
-		SessionConfig: SessionConfig{
-			// Verified against Kiro CLI 2.15.0 by driving `kiro-cli-chat acp`
-			// through session/new: each ACP session is persisted as
-			// ~/.kiro/sessions/cli/<sessionId>.{json,jsonl}. KIRO_HOME
-			// relocates the directory. Note ~/.kiro carries config + sessions
-			// only — the login token lives in the separate
-			// ~/.local/share/kiro-cli/data.sqlite3 (auth_kv table), so this
-			// mount persists resumable sessions but not authentication.
-			SessionDirTemplate:  "{home}/.kiro",
-			NativeSessionResume: true,
-			CanRecover:          &canRecover,
-		},
-	}
-}
-
-func (a *KiroACP) RemoteAuth() *RemoteAuth { return nil }
-
-func (a *KiroACP) InstallScript() string {
-	return "Install Kiro CLI from AWS"
-}
-
-func (a *KiroACP) PermissionSettings() map[string]PermissionSetting {
-	return emptyPermSettings
-}
-
-func (a *KiroACP) InferenceConfig() *InferenceConfig {
-	return &InferenceConfig{
-		Supported: true,
-		Command:   NewCommand(kiroACPBin, "acp"),
-	}
-}
-
-func (a *KiroACP) BillingType() usage.BillingType { return defaultBillingType() }

--- a/apps/backend/internal/agent/agents/native_acp.go
+++ b/apps/backend/internal/agent/agents/native_acp.go
@@ -1,0 +1,215 @@
+package agents
+
+import (
+	"context"
+	"time"
+
+	"github.com/kandev/kandev/internal/agent/mcpconfig"
+	"github.com/kandev/kandev/internal/agent/usage"
+	"github.com/kandev/kandev/pkg/agent"
+)
+
+// Native-binary ACP agents (Cursor, Kimi, Kiro, Qoder, Trae, Omp, Devin,
+// Grok) share one scaffold: a CLI distributed outside npm that speaks ACP
+// over stdin/stdout on a fixed argv, resumes sessions natively, and reports
+// availability by looking for its binary on PATH. nativeACPSpec captures
+// everything that differs between them; nativeACPAgent turns a spec into the
+// Agent implementation, so each agent file is just its own values.
+
+// passthroughLabel and passthroughDescription are the shared UI strings for
+// the raw-terminal affordance every native-binary ACP agent exposes.
+const (
+	passthroughLabel       = "CLI Passthrough"
+	passthroughDescription = "Show terminal directly instead of chat interface"
+)
+
+// workspaceWorkingDir is the RuntimeConfig.WorkingDir placeholder the
+// lifecycle expands to the session's materialized workspace path.
+const workspaceWorkingDir = "{workspace}"
+
+// nativeACPIdleTimeout is the passthrough idle window after which the PTY is
+// considered quiescent.
+const nativeACPIdleTimeout = 3 * time.Second
+
+// nativeACPModelFlag is the `--model <model>` passthrough template shared by
+// the native-binary CLIs. Returned fresh per call so no two agents alias the
+// same backing array.
+func nativeACPModelFlag() Param { return NewParam("--model", "{model}") }
+
+// nativeACPRuntimeSpec holds the RuntimeConfig fields that vary between
+// native-binary ACP agents. Everything omitted here is identical across the
+// cluster and is filled in by nativeACPAgent.Runtime.
+type nativeACPRuntimeSpec struct {
+	// requiredEnv is a launch prerequisite list. An explicitly empty (non-nil)
+	// slice documents "auth is optional", which is distinct from unset.
+	requiredEnv []string
+	// projectSkillDir / userSkillDir are the CWD- and home-relative skill
+	// directories this CLI reads.
+	projectSkillDir string
+	userSkillDir    string
+	// projectMCPStrategy materializes MCP servers into a project-local config
+	// for CLIs whose ACP mode has no MCP flag or env var.
+	projectMCPStrategy mcpconfig.PassthroughMCPStrategy
+	// assumeMcpSse / assumeMcpHttp override an agent's advertised MCP
+	// capabilities when the advertisement understates what it supports.
+	assumeMcpSse  bool
+	assumeMcpHttp bool
+	// stripEnv lists env vars removed from the child process entirely.
+	stripEnv []string
+	// sessionDirTemplate / sessionDirTarget locate the CLI's session state so
+	// the Docker runtime can mount it. An empty template means resume has no
+	// persistence across container restarts.
+	sessionDirTemplate string
+	sessionDirTarget   string
+	// newSessionOnWorkspaceRebind forces session/new when an idle execution's
+	// working directory changes.
+	newSessionOnWorkspaceRebind bool
+}
+
+// nativeACPSpec is the complete per-agent description of a native-binary ACP
+// agent.
+type nativeACPSpec struct {
+	id           string
+	name         string
+	displayName  string
+	description  string
+	displayOrder int
+	// bin is the executable looked up on PATH by IsInstalled, and the command
+	// used for raw passthrough.
+	bin string
+	// args are the arguments appended to bin to launch ACP mode. BuildCommand,
+	// Runtime().Cmd and InferenceConfig().Command all use the same argv.
+	args          []string
+	logoLight     []byte
+	logoDark      []byte
+	installScript string
+	remoteAuth    *RemoteAuth
+	permSettings  map[string]PermissionSetting
+	runtime       nativeACPRuntimeSpec
+}
+
+// launchArgv returns the full ACP launch command line.
+func (s nativeACPSpec) launchArgv() []string {
+	argv := make([]string, 0, len(s.args)+1)
+	argv = append(argv, s.bin)
+	return append(argv, s.args...)
+}
+
+// nativeACPAgent implements Agent and InferenceAgent from a nativeACPSpec.
+// Agents embed it (directly, or via nativeACPPassthroughAgent) and override
+// only the methods their spec cannot express.
+type nativeACPAgent struct {
+	spec nativeACPSpec
+}
+
+func (a *nativeACPAgent) ID() string          { return a.spec.id }
+func (a *nativeACPAgent) Name() string        { return a.spec.name }
+func (a *nativeACPAgent) DisplayName() string { return a.spec.displayName }
+func (a *nativeACPAgent) Description() string { return a.spec.description }
+func (a *nativeACPAgent) Enabled() bool       { return true }
+func (a *nativeACPAgent) DisplayOrder() int   { return a.spec.displayOrder }
+
+func (a *nativeACPAgent) Logo(v LogoVariant) []byte {
+	if v == LogoDark {
+		return a.spec.logoDark
+	}
+	return a.spec.logoLight
+}
+
+func (a *nativeACPAgent) IsInstalled(ctx context.Context) (*DiscoveryResult, error) {
+	result, err := Detect(ctx, WithCommand(a.spec.bin))
+	if err != nil {
+		return result, err
+	}
+	result.SupportsMCP = true
+	result.Capabilities = DiscoveryCapabilities{
+		SupportsSessionResume: true,
+	}
+	return result, nil
+}
+
+func (a *nativeACPAgent) BuildCommand(opts CommandOptions) Command {
+	return Cmd(a.spec.launchArgv()...).Build()
+}
+
+func (a *nativeACPAgent) Runtime() *RuntimeConfig {
+	canRecover := true
+	rt := a.spec.runtime
+	return &RuntimeConfig{
+		Cmd:                Cmd(a.spec.launchArgv()...).Build(),
+		WorkingDir:         workspaceWorkingDir,
+		Env:                map[string]string{},
+		RequiredEnv:        rt.requiredEnv,
+		ResourceLimits:     DefaultResourceLimits,
+		Protocol:           agent.ProtocolACP,
+		ProjectSkillDir:    rt.projectSkillDir,
+		UserSkillDir:       rt.userSkillDir,
+		ProjectMCPStrategy: rt.projectMCPStrategy,
+		AssumeMcpSse:       rt.assumeMcpSse,
+		AssumeMcpHttp:      rt.assumeMcpHttp,
+		StripEnv:           rt.stripEnv,
+		SessionConfig: SessionConfig{
+			NativeSessionResume:         true,
+			NewSessionOnWorkspaceRebind: rt.newSessionOnWorkspaceRebind,
+			CanRecover:                  &canRecover,
+			SessionDirTemplate:          rt.sessionDirTemplate,
+			SessionDirTarget:            rt.sessionDirTarget,
+		},
+	}
+}
+
+func (a *nativeACPAgent) RemoteAuth() *RemoteAuth { return a.spec.remoteAuth }
+
+func (a *nativeACPAgent) InstallScript() string { return a.spec.installScript }
+
+func (a *nativeACPAgent) PermissionSettings() map[string]PermissionSetting {
+	return a.spec.permSettings
+}
+
+func (a *nativeACPAgent) InferenceConfig() *InferenceConfig {
+	return &InferenceConfig{
+		Supported: true,
+		Command:   NewCommand(a.spec.launchArgv()...),
+	}
+}
+
+func (a *nativeACPAgent) BillingType() usage.BillingType { return defaultBillingType() }
+
+// nativeACPPassthroughSpec declares the per-agent parts of the shared
+// terminal-passthrough config. A zero value is valid: it means the CLI takes
+// no model or resume flags in passthrough mode.
+type nativeACPPassthroughSpec struct {
+	modelFlag         Param
+	resumeFlag        Param
+	sessionResumeFlag Param
+	mcpStrategy       mcpconfig.PassthroughMCPStrategy
+}
+
+// nativeACPPassthroughAgent is a nativeACPAgent that also runs its CLI in raw
+// terminal passthrough mode. Grok deliberately stays on the bare
+// nativeACPAgent so it does not satisfy PassthroughAgent (see ADR 0014).
+type nativeACPPassthroughAgent struct {
+	nativeACPAgent
+	StandardPassthrough
+}
+
+func newNativeACPPassthrough(spec nativeACPSpec, pt nativeACPPassthroughSpec) nativeACPPassthroughAgent {
+	return nativeACPPassthroughAgent{
+		nativeACPAgent: nativeACPAgent{spec: spec},
+		StandardPassthrough: StandardPassthrough{
+			PermSettings: spec.permSettings,
+			Cfg: PassthroughConfig{
+				Supported:         true,
+				Label:             passthroughLabel,
+				Description:       passthroughDescription,
+				PassthroughCmd:    NewCommand(spec.bin),
+				ModelFlag:         pt.modelFlag,
+				ResumeFlag:        pt.resumeFlag,
+				SessionResumeFlag: pt.sessionResumeFlag,
+				IdleTimeout:       nativeACPIdleTimeout,
+				BufferMaxBytes:    DefaultBufferMaxBytes,
+				MCPStrategy:       pt.mcpStrategy,
+			},
+		},
+	}
+}

--- a/apps/backend/internal/agent/agents/native_acp_test.go
+++ b/apps/backend/internal/agent/agents/native_acp_test.go
@@ -1,0 +1,406 @@
+package agents
+
+import (
+	"reflect"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/agent/mcpconfig"
+	"github.com/kandev/kandev/pkg/agent"
+)
+
+// nativeACPCase pins the registered definition of one native-binary ACP agent
+// — everything nativeACPSpec feeds into Agent. These agents share a single
+// constructor (newNativeACPPassthrough / nativeACPAgent), so a slip in the
+// shared scaffold would otherwise silently change eight agents at once:
+// a stray shared default, a spec field wired to the wrong RuntimeConfig
+// member, or an aliased argv slice.
+type nativeACPCase struct {
+	name string
+	// newAgent builds the agent under test.
+	newAgent func() Agent
+	// Identity.
+	id           string
+	agentName    string
+	displayName  string
+	description  string
+	displayOrder int
+	// Launch surfaces. argv is asserted on BuildCommand, Runtime().Cmd and
+	// InferenceConfig().Command; passthroughArgv on PassthroughCmd.
+	bin  string
+	argv []string
+	// Passthrough. wantPassthrough=false means the agent must NOT satisfy
+	// PassthroughAgent (Grok).
+	wantPassthrough   bool
+	modelFlag         []string
+	resumeFlag        []string
+	sessionResumeFlag []string
+	mcpStrategy       mcpconfig.PassthroughMCPStrategy
+	// Runtime.
+	requiredEnv                 []string
+	projectSkillDir             string
+	userSkillDir                string
+	projectMCPStrategy          mcpconfig.PassthroughMCPStrategy
+	assumeMcpSse                bool
+	assumeMcpHttp               bool
+	stripEnv                    []string
+	sessionDirTemplate          string
+	sessionDirTarget            string
+	newSessionOnWorkspaceRebind bool
+	// Auth / install.
+	installScript   string
+	wantRemoteAuth  bool
+	remoteAuthTypes []string
+	permSettingKeys []string
+}
+
+var nativeACPCases = []nativeACPCase{
+	{
+		name: "cursor", newAgent: func() Agent { return NewCursorACP() },
+		id: "cursor-acp", agentName: "Cursor ACP Agent", displayName: "Cursor",
+		description:  "Cursor CLI coding agent (cursor-agent) using the ACP protocol. Requires a Cursor Pro subscription.",
+		displayOrder: 13,
+		bin:          "cursor-agent", argv: []string{"cursor-agent", "acp"},
+		wantPassthrough: true, modelFlag: []string{"--model", "{model}"},
+		mcpStrategy:        mcpconfig.CursorStrategy{},
+		userSkillDir:       ".cursor/skills",
+		sessionDirTemplate: "{home}/.cursor",
+		projectMCPStrategy: mcpconfig.CursorStrategy{},
+		installScript:      cursorACPInstallScript,
+		wantRemoteAuth:     true, remoteAuthTypes: []string{"env"},
+		permSettingKeys: []string{PermissionKeyCursorForce},
+	},
+	{
+		name: "kimi", newAgent: func() Agent { return NewKimiACP() },
+		id: "kimi-acp", agentName: "Kimi ACP Agent", displayName: "Kimi",
+		description:  "Moonshot AI Kimi coding agent using the ACP protocol over stdin/stdout.",
+		displayOrder: 14,
+		bin:          "kimi", argv: []string{"kimi", "acp"},
+		wantPassthrough: true, modelFlag: []string{"--model", "{model}"},
+		sessionDirTemplate: "{home}/.kimi",
+		installScript:      "Install Kimi CLI from Moonshot AI",
+	},
+	{
+		name: "kiro", newAgent: func() Agent { return NewKiroACP() },
+		id: "kiro-acp", agentName: "Kiro ACP Agent", displayName: "Kiro",
+		description:  "AWS Kiro coding agent using the ACP protocol via kiro-cli-chat.",
+		displayOrder: 15,
+		bin:          "kiro-cli-chat", argv: []string{"kiro-cli-chat", "acp"},
+		wantPassthrough: true, modelFlag: []string{"--model", "{model}"},
+		userSkillDir:       ".kiro/skills",
+		sessionDirTemplate: "{home}/.kiro",
+		installScript:      "Install Kiro CLI from AWS",
+	},
+	{
+		name: "qoder", newAgent: func() Agent { return NewQoderACP() },
+		id: "qoder-acp", agentName: "Qoder ACP Agent", displayName: "Qoder",
+		description:  "Qoder coding agent using the ACP protocol via qodercli --acp.",
+		displayOrder: 16,
+		bin:          "qodercli", argv: []string{"qodercli", "--acp"},
+		wantPassthrough: true, modelFlag: []string{"--model", "{model}"},
+		sessionDirTemplate: "{home}/.qoder",
+		installScript:      "Install Qoder CLI from https://qoder.com",
+	},
+	{
+		name: "trae", newAgent: func() Agent { return NewTraeACP() },
+		id: "trae-acp", agentName: "Trae ACP Agent", displayName: "Trae",
+		description:  "ByteDance Trae IDE coding agent using the ACP protocol via traecli acp serve.",
+		displayOrder: 17,
+		bin:          "traecli", argv: []string{"traecli", "acp", "serve"},
+		wantPassthrough: true, modelFlag: []string{"--model", "{model}"},
+		sessionDirTemplate: "{home}/.cache/trae-cli",
+		installScript:      "Install Trae IDE CLI from https://trae.ai",
+	},
+	{
+		name: "omp", newAgent: func() Agent { return NewOmpACP() },
+		id: "omp-acp", agentName: "Oh My Pi ACP Agent", displayName: "omp",
+		description:  "Oh My Pi (omp) coding agent using the ACP protocol via the `omp acp` subcommand.",
+		displayOrder: 18,
+		bin:          "omp", argv: []string{"omp", "acp"},
+		wantPassthrough: true, modelFlag: []string{"--model", "{model}"},
+		resumeFlag: []string{"-c"}, sessionResumeFlag: []string{"--resume"},
+		projectSkillDir:    ".omp/skills",
+		userSkillDir:       ".omp/agent/skills",
+		sessionDirTemplate: "{home}/.omp",
+		installScript:      "bun install -g @oh-my-pi/pi-coding-agent",
+	},
+	{
+		name: "devin", newAgent: func() Agent { return NewDevinACP() },
+		id: "devin-acp", agentName: "Devin ACP Agent", displayName: "Devin",
+		description:  "Cognition Devin coding agent using the ACP protocol via `devin acp`.",
+		displayOrder: 19,
+		bin:          "devin", argv: []string{"devin", "acp"},
+		// Devin's CLI takes no --model flag in passthrough mode.
+		wantPassthrough: true,
+		assumeMcpSse:    true, assumeMcpHttp: true,
+		stripEnv:           []string{"ACP_BACKEND"},
+		sessionDirTemplate: "{home}/.local/share/devin",
+		sessionDirTarget:   "/root/.local/share/devin",
+		installScript:      devinACPInstallScript,
+		wantRemoteAuth:     true, remoteAuthTypes: []string{"files", "env"},
+	},
+	{
+		name: "grok", newAgent: func() Agent { return NewGrokACP() },
+		id: "grok-acp", agentName: "Grok ACP Agent", displayName: "Grok",
+		description:  "xAI Grok coding agent using the ACP protocol over stdin/stdout.",
+		displayOrder: 20,
+		bin:          "grok", argv: []string{"grok", "--no-auto-update", "agent", "stdio"},
+		// Raw TUI passthrough is deferred for Grok (ADR 0014).
+		wantPassthrough:             false,
+		requiredEnv:                 []string{},
+		projectSkillDir:             ".grok/skills",
+		userSkillDir:                ".grok/skills",
+		sessionDirTemplate:          "{home}/.grok",
+		sessionDirTarget:            "/root/.grok",
+		newSessionOnWorkspaceRebind: true,
+		installScript:               "npm install -g @xai-official/grok",
+		wantRemoteAuth:              true, remoteAuthTypes: []string{"files", "env"},
+	},
+}
+
+func TestNativeACPAgents_Identity(t *testing.T) {
+	for _, tc := range nativeACPCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ag := tc.newAgent()
+			assertString(t, "ID", ag.ID(), tc.id)
+			assertString(t, "Name", ag.Name(), tc.agentName)
+			assertString(t, "DisplayName", ag.DisplayName(), tc.displayName)
+			assertString(t, "Description", ag.Description(), tc.description)
+			if got := ag.DisplayOrder(); got != tc.displayOrder {
+				t.Errorf("DisplayOrder() = %d, want %d", got, tc.displayOrder)
+			}
+			if !ag.Enabled() {
+				t.Error("Enabled() = false, want true")
+			}
+			if len(ag.Logo(LogoLight)) == 0 || len(ag.Logo(LogoDark)) == 0 {
+				t.Errorf("Logo lengths = (%d, %d), want both non-empty",
+					len(ag.Logo(LogoLight)), len(ag.Logo(LogoDark)))
+			}
+		})
+	}
+}
+
+// TestNativeACPAgents_LaunchArgv pins the three launch surfaces that must
+// agree: BuildCommand, Runtime().Cmd, and InferenceConfig().Command. The
+// shared spec derives all three from one `bin` + `args` pair, so this also
+// catches a spec whose bin and args disagree with its documented CLI.
+func TestNativeACPAgents_LaunchArgv(t *testing.T) {
+	for _, tc := range nativeACPCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ag := tc.newAgent()
+			assertArgv(t, "BuildCommand", ag.BuildCommand(CommandOptions{}).Args(), tc.argv)
+			assertArgv(t, "Runtime.Cmd", ag.Runtime().Cmd.Args(), tc.argv)
+
+			ia, ok := ag.(InferenceAgent)
+			if !ok {
+				t.Fatalf("%s does not implement InferenceAgent", tc.id)
+			}
+			ic := ia.InferenceConfig()
+			if ic == nil || !ic.Supported {
+				t.Fatalf("InferenceConfig() = %+v, want Supported=true", ic)
+			}
+			assertArgv(t, "InferenceConfig.Command", ic.Command.Args(), tc.argv)
+
+			if tc.argv[0] != tc.bin {
+				t.Errorf("argv[0] = %q, want the detection binary %q", tc.argv[0], tc.bin)
+			}
+		})
+	}
+}
+
+// TestNativeACPAgents_LaunchArgvIsNotAliased guards the shared spec against
+// handing every surface the same backing array — appending to one command's
+// argv must not corrupt the next caller's.
+func TestNativeACPAgents_LaunchArgvIsNotAliased(t *testing.T) {
+	for _, tc := range nativeACPCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ag := tc.newAgent()
+			ag.BuildCommand(CommandOptions{}).Args()[0] = "corrupted"
+			assertArgv(t, "BuildCommand after mutation", ag.BuildCommand(CommandOptions{}).Args(), tc.argv)
+			assertArgv(t, "Runtime.Cmd after mutation", ag.Runtime().Cmd.Args(), tc.argv)
+			ia, ok := ag.(InferenceAgent)
+			if !ok {
+				t.Fatalf("%s does not implement InferenceAgent", tc.id)
+			}
+			assertArgv(t, "InferenceConfig.Command after mutation", ia.InferenceConfig().Command.Args(), tc.argv)
+		})
+	}
+}
+
+func TestNativeACPAgents_Runtime(t *testing.T) {
+	for _, tc := range nativeACPCases {
+		t.Run(tc.name, func(t *testing.T) {
+			rt := tc.newAgent().Runtime()
+			if rt == nil {
+				t.Fatal("Runtime() = nil")
+			}
+			if rt.Protocol != agent.ProtocolACP {
+				t.Errorf("Protocol = %q, want %q", rt.Protocol, agent.ProtocolACP)
+			}
+			assertString(t, "WorkingDir", rt.WorkingDir, "{workspace}")
+			if rt.Env == nil || len(rt.Env) != 0 {
+				t.Errorf("Env = %v, want empty non-nil map", rt.Env)
+			}
+			if rt.ResourceLimits != DefaultResourceLimits {
+				t.Errorf("ResourceLimits = %+v, want %+v", rt.ResourceLimits, DefaultResourceLimits)
+			}
+			// nil and empty RequiredEnv are different: an explicitly empty
+			// slice documents "auth is optional, not a launch prerequisite".
+			if !reflect.DeepEqual(rt.RequiredEnv, tc.requiredEnv) {
+				t.Errorf("RequiredEnv = %#v, want %#v", rt.RequiredEnv, tc.requiredEnv)
+			}
+			assertString(t, "ProjectSkillDir", rt.ProjectSkillDir, tc.projectSkillDir)
+			assertString(t, "UserSkillDir", rt.UserSkillDir, tc.userSkillDir)
+			if rt.ProjectMCPStrategy != tc.projectMCPStrategy {
+				t.Errorf("ProjectMCPStrategy = %#v, want %#v", rt.ProjectMCPStrategy, tc.projectMCPStrategy)
+			}
+			if rt.AssumeMcpSse != tc.assumeMcpSse || rt.AssumeMcpHttp != tc.assumeMcpHttp {
+				t.Errorf("AssumeMcp{Sse,Http} = (%v, %v), want (%v, %v)",
+					rt.AssumeMcpSse, rt.AssumeMcpHttp, tc.assumeMcpSse, tc.assumeMcpHttp)
+			}
+			if !slices.Equal(rt.StripEnv, tc.stripEnv) {
+				t.Errorf("StripEnv = %#v, want %#v", rt.StripEnv, tc.stripEnv)
+			}
+		})
+	}
+}
+
+func TestNativeACPAgents_SessionConfig(t *testing.T) {
+	for _, tc := range nativeACPCases {
+		t.Run(tc.name, func(t *testing.T) {
+			sc := tc.newAgent().Runtime().SessionConfig
+			if !sc.NativeSessionResume {
+				t.Error("NativeSessionResume = false, want true")
+			}
+			if !sc.SupportsRecovery() {
+				t.Error("SupportsRecovery() = false, want true")
+			}
+			if sc.CanRecover == nil || !*sc.CanRecover {
+				t.Errorf("CanRecover = %v, want explicit true", sc.CanRecover)
+			}
+			assertString(t, "SessionDirTemplate", sc.SessionDirTemplate, tc.sessionDirTemplate)
+			assertString(t, "SessionDirTarget", sc.SessionDirTarget, tc.sessionDirTarget)
+			if sc.NewSessionOnWorkspaceRebind != tc.newSessionOnWorkspaceRebind {
+				t.Errorf("NewSessionOnWorkspaceRebind = %v, want %v",
+					sc.NewSessionOnWorkspaceRebind, tc.newSessionOnWorkspaceRebind)
+			}
+		})
+	}
+}
+
+func TestNativeACPAgents_Passthrough(t *testing.T) {
+	for _, tc := range nativeACPCases {
+		t.Run(tc.name, func(t *testing.T) {
+			pa, ok := tc.newAgent().(PassthroughAgent)
+			if ok != tc.wantPassthrough {
+				t.Fatalf("implements PassthroughAgent = %v, want %v", ok, tc.wantPassthrough)
+			}
+			if !tc.wantPassthrough {
+				return
+			}
+			cfg := pa.PassthroughConfig()
+			if !cfg.Supported {
+				t.Error("PassthroughConfig.Supported = false, want true")
+			}
+			assertString(t, "Label", cfg.Label, passthroughLabel)
+			assertString(t, "Description", cfg.Description, passthroughDescription)
+			assertArgv(t, "PassthroughCmd", cfg.PassthroughCmd.Args(), []string{tc.bin})
+			assertArgv(t, "ModelFlag", cfg.ModelFlag.Args(), tc.modelFlag)
+			assertArgv(t, "ResumeFlag", cfg.ResumeFlag.Args(), tc.resumeFlag)
+			assertArgv(t, "SessionResumeFlag", cfg.SessionResumeFlag.Args(), tc.sessionResumeFlag)
+			if cfg.MCPStrategy != tc.mcpStrategy {
+				t.Errorf("MCPStrategy = %#v, want %#v", cfg.MCPStrategy, tc.mcpStrategy)
+			}
+			if cfg.IdleTimeout != 3*time.Second {
+				t.Errorf("IdleTimeout = %v, want 3s", cfg.IdleTimeout)
+			}
+			if cfg.BufferMaxBytes != DefaultBufferMaxBytes {
+				t.Errorf("BufferMaxBytes = %d, want %d", cfg.BufferMaxBytes, DefaultBufferMaxBytes)
+			}
+		})
+	}
+}
+
+// TestNativeACPAgents_PassthroughCommandUsesAgentPermSettings pins that the
+// shared constructor wires each agent's own PermissionSettings into
+// StandardPassthrough — Cursor's --force is the only cli_flag in the cluster,
+// so a mis-wired shared default would silently drop or leak it.
+func TestNativeACPAgents_PassthroughCommandUsesAgentPermSettings(t *testing.T) {
+	values := map[string]bool{PermissionKeyCursorForce: true}
+	for _, tc := range nativeACPCases {
+		if !tc.wantPassthrough {
+			continue
+		}
+		t.Run(tc.name, func(t *testing.T) {
+			pa := tc.newAgent().(PassthroughAgent)
+			argv := pa.BuildPassthroughCommand(PassthroughOptions{PermissionValues: values}).Args()
+			wantForce := slices.Contains(tc.permSettingKeys, PermissionKeyCursorForce)
+			if got := slices.Contains(argv, "--force"); got != wantForce {
+				t.Errorf("passthrough argv %#v contains --force = %v, want %v", argv, got, wantForce)
+			}
+		})
+	}
+}
+
+func TestNativeACPAgents_PermissionSettings(t *testing.T) {
+	for _, tc := range nativeACPCases {
+		t.Run(tc.name, func(t *testing.T) {
+			settings := tc.newAgent().PermissionSettings()
+			if len(settings) != len(tc.permSettingKeys) {
+				t.Fatalf("PermissionSettings() has %d entries %v, want %d %v",
+					len(settings), keysOf(settings), len(tc.permSettingKeys), tc.permSettingKeys)
+			}
+			for _, key := range tc.permSettingKeys {
+				if _, ok := settings[key]; !ok {
+					t.Errorf("PermissionSettings() missing %q", key)
+				}
+			}
+		})
+	}
+}
+
+func TestNativeACPAgents_InstallScriptAndRemoteAuth(t *testing.T) {
+	for _, tc := range nativeACPCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ag := tc.newAgent()
+			assertString(t, "InstallScript", ag.InstallScript(), tc.installScript)
+
+			auth := ag.RemoteAuth()
+			if (auth != nil) != tc.wantRemoteAuth {
+				t.Fatalf("RemoteAuth() = %+v, want non-nil=%v", auth, tc.wantRemoteAuth)
+			}
+			if auth == nil {
+				return
+			}
+			gotTypes := make([]string, 0, len(auth.Methods))
+			for _, m := range auth.Methods {
+				gotTypes = append(gotTypes, m.Type)
+			}
+			assertArgv(t, "RemoteAuth method types", gotTypes, tc.remoteAuthTypes)
+		})
+	}
+}
+
+func assertString(t *testing.T, label, got, want string) {
+	t.Helper()
+	if got != want {
+		t.Errorf("%s = %q, want %q", label, got, want)
+	}
+}
+
+func assertArgv(t *testing.T, label string, got, want []string) {
+	t.Helper()
+	if !slices.Equal(got, want) {
+		t.Errorf("%s = %#v, want %#v", label, got, want)
+	}
+}
+
+func keysOf(m map[string]PermissionSetting) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	slices.Sort(keys)
+	return keys
+}

--- a/apps/backend/internal/agent/agents/omp_acp.go
+++ b/apps/backend/internal/agent/agents/omp_acp.go
@@ -1,13 +1,7 @@
-//nolint:dupl,goconst // Native-binary ACP agents (Cursor, Kimi, Kiro, Omp, Qoder, Trae) follow the same minimal scaffold; differences are the binary name and subcommand. Shared literals (`CLI Passthrough`, `Show terminal directly instead of chat interface`, `{workspace}`) live in every peer file by convention.
 package agents
 
 import (
-	"context"
 	_ "embed"
-	"time"
-
-	"github.com/kandev/kandev/internal/agent/usage"
-	"github.com/kandev/kandev/pkg/agent"
 )
 
 //go:embed logos/omp_acp_light.svg
@@ -29,93 +23,33 @@ var (
 // API key — omp reads any of the dozen provider env vars (ANTHROPIC_API_KEY,
 // OPENAI_API_KEY, GEMINI_API_KEY, ...) directly.
 type OmpACP struct {
-	StandardPassthrough
+	nativeACPPassthroughAgent
 }
 
 func NewOmpACP() *OmpACP {
-	return &OmpACP{
-		StandardPassthrough: StandardPassthrough{
-			PermSettings: emptyPermSettings,
-			Cfg: PassthroughConfig{
-				Supported:         true,
-				Label:             "CLI Passthrough",
-				Description:       "Show terminal directly instead of chat interface",
-				PassthroughCmd:    NewCommand(ompACPBin),
-				ModelFlag:         NewParam("--model", "{model}"),
-				ResumeFlag:        NewParam("-c"),
-				SessionResumeFlag: NewParam("--resume"),
-				IdleTimeout:       3 * time.Second,
-				BufferMaxBytes:    DefaultBufferMaxBytes,
+	return &OmpACP{newNativeACPPassthrough(
+		nativeACPSpec{
+			id:            "omp-acp",
+			name:          "Oh My Pi ACP Agent",
+			displayName:   ompACPBin,
+			description:   "Oh My Pi (omp) coding agent using the ACP protocol via the `omp acp` subcommand.",
+			displayOrder:  18,
+			bin:           ompACPBin,
+			args:          []string{"acp"},
+			logoLight:     ompACPLogoLight,
+			logoDark:      ompACPLogoDark,
+			installScript: "bun install -g @oh-my-pi/pi-coding-agent",
+			permSettings:  emptyPermSettings,
+			runtime: nativeACPRuntimeSpec{
+				projectSkillDir:    ".omp/skills",
+				userSkillDir:       ".omp/agent/skills",
+				sessionDirTemplate: "{home}/.omp",
 			},
 		},
-	}
-}
-
-func (a *OmpACP) ID() string          { return "omp-acp" }
-func (a *OmpACP) Name() string        { return "Oh My Pi ACP Agent" }
-func (a *OmpACP) DisplayName() string { return ompACPBin }
-func (a *OmpACP) Description() string {
-	return "Oh My Pi (omp) coding agent using the ACP protocol via the `omp acp` subcommand."
-}
-func (a *OmpACP) Enabled() bool     { return true }
-func (a *OmpACP) DisplayOrder() int { return 18 }
-
-func (a *OmpACP) Logo(v LogoVariant) []byte {
-	if v == LogoDark {
-		return ompACPLogoDark
-	}
-	return ompACPLogoLight
-}
-
-func (a *OmpACP) IsInstalled(ctx context.Context) (*DiscoveryResult, error) {
-	result, err := Detect(ctx, WithCommand(ompACPBin))
-	if err != nil {
-		return result, err
-	}
-	result.SupportsMCP = true
-	result.Capabilities = DiscoveryCapabilities{
-		SupportsSessionResume: true,
-	}
-	return result, nil
-}
-
-func (a *OmpACP) BuildCommand(opts CommandOptions) Command {
-	return Cmd(ompACPBin, "acp").Build()
-}
-
-func (a *OmpACP) Runtime() *RuntimeConfig {
-	canRecover := true
-	return &RuntimeConfig{
-		Cmd:             Cmd(ompACPBin, "acp").Build(),
-		WorkingDir:      "{workspace}",
-		Env:             map[string]string{},
-		ResourceLimits:  ResourceLimits{MemoryMB: 4096, CPUCores: 2.0, Timeout: time.Hour},
-		Protocol:        agent.ProtocolACP,
-		ProjectSkillDir: ".omp/skills",
-		UserSkillDir:    ".omp/agent/skills",
-		SessionConfig: SessionConfig{
-			NativeSessionResume: true,
-			CanRecover:          &canRecover,
-			SessionDirTemplate:  "{home}/.omp",
+		nativeACPPassthroughSpec{
+			modelFlag:         nativeACPModelFlag(),
+			resumeFlag:        NewParam("-c"),
+			sessionResumeFlag: NewParam("--resume"),
 		},
-	}
+	)}
 }
-
-func (a *OmpACP) RemoteAuth() *RemoteAuth { return nil }
-
-func (a *OmpACP) InstallScript() string {
-	return "bun install -g @oh-my-pi/pi-coding-agent"
-}
-
-func (a *OmpACP) PermissionSettings() map[string]PermissionSetting {
-	return emptyPermSettings
-}
-
-func (a *OmpACP) InferenceConfig() *InferenceConfig {
-	return &InferenceConfig{
-		Supported: true,
-		Command:   NewCommand(ompACPBin, "acp"),
-	}
-}
-
-func (a *OmpACP) BillingType() usage.BillingType { return defaultBillingType() }

--- a/apps/backend/internal/agent/agents/qoder_acp.go
+++ b/apps/backend/internal/agent/agents/qoder_acp.go
@@ -1,13 +1,7 @@
-//nolint:dupl // Native-binary ACP agents (Cursor, Kimi, Kiro, Qoder, Trae) follow the same minimal scaffold; differences are the binary name and subcommand.
 package agents
 
 import (
-	"context"
 	_ "embed"
-	"time"
-
-	"github.com/kandev/kandev/internal/agent/usage"
-	"github.com/kandev/kandev/pkg/agent"
 )
 
 //go:embed logos/qoder_acp_light.svg
@@ -26,93 +20,31 @@ var (
 
 // QoderACP implements Agent for the Qoder CLI using ACP.
 type QoderACP struct {
-	StandardPassthrough
+	nativeACPPassthroughAgent
 }
 
 func NewQoderACP() *QoderACP {
-	return &QoderACP{
-		StandardPassthrough: StandardPassthrough{
-			PermSettings: emptyPermSettings,
-			Cfg: PassthroughConfig{
-				Supported:      true,
-				Label:          "CLI Passthrough",
-				Description:    "Show terminal directly instead of chat interface",
-				PassthroughCmd: NewCommand(qoderACPBin),
-				ModelFlag:      NewParam("--model", "{model}"),
-				IdleTimeout:    3 * time.Second,
-				BufferMaxBytes: DefaultBufferMaxBytes,
+	return &QoderACP{newNativeACPPassthrough(
+		nativeACPSpec{
+			id:            "qoder-acp",
+			name:          "Qoder ACP Agent",
+			displayName:   "Qoder",
+			description:   "Qoder coding agent using the ACP protocol via qodercli --acp.",
+			displayOrder:  16,
+			bin:           qoderACPBin,
+			args:          []string{"--acp"},
+			logoLight:     qoderACPLogoLight,
+			logoDark:      qoderACPLogoDark,
+			installScript: "Install Qoder CLI from https://qoder.com",
+			permSettings:  emptyPermSettings,
+			runtime: nativeACPRuntimeSpec{
+				// Verified against qodercli 1.1.7: every user-level artifact
+				// (settings.json, .auth/, logs/sessions/<project>) is written
+				// under ~/.qoder, and the --config-dir flag relocates that single
+				// root wholesale — running with it leaves nothing else in $HOME.
+				sessionDirTemplate: "{home}/.qoder",
 			},
 		},
-	}
+		nativeACPPassthroughSpec{modelFlag: nativeACPModelFlag()},
+	)}
 }
-
-func (a *QoderACP) ID() string          { return "qoder-acp" }
-func (a *QoderACP) Name() string        { return "Qoder ACP Agent" }
-func (a *QoderACP) DisplayName() string { return "Qoder" }
-func (a *QoderACP) Description() string {
-	return "Qoder coding agent using the ACP protocol via qodercli --acp."
-}
-func (a *QoderACP) Enabled() bool     { return true }
-func (a *QoderACP) DisplayOrder() int { return 16 }
-
-func (a *QoderACP) Logo(v LogoVariant) []byte {
-	if v == LogoDark {
-		return qoderACPLogoDark
-	}
-	return qoderACPLogoLight
-}
-
-func (a *QoderACP) IsInstalled(ctx context.Context) (*DiscoveryResult, error) {
-	result, err := Detect(ctx, WithCommand(qoderACPBin))
-	if err != nil {
-		return result, err
-	}
-	result.SupportsMCP = true
-	result.Capabilities = DiscoveryCapabilities{
-		SupportsSessionResume: true,
-	}
-	return result, nil
-}
-
-func (a *QoderACP) BuildCommand(opts CommandOptions) Command {
-	return Cmd(qoderACPBin, "--acp").Build()
-}
-
-func (a *QoderACP) Runtime() *RuntimeConfig {
-	canRecover := true
-	return &RuntimeConfig{
-		Cmd:            Cmd(qoderACPBin, "--acp").Build(),
-		WorkingDir:     "{workspace}",
-		Env:            map[string]string{},
-		ResourceLimits: ResourceLimits{MemoryMB: 4096, CPUCores: 2.0, Timeout: time.Hour},
-		Protocol:       agent.ProtocolACP,
-		SessionConfig: SessionConfig{
-			// Verified against qodercli 1.1.7: every user-level artifact
-			// (settings.json, .auth/, logs/sessions/<project>) is written
-			// under ~/.qoder, and the --config-dir flag relocates that single
-			// root wholesale — running with it leaves nothing else in $HOME.
-			SessionDirTemplate:  "{home}/.qoder",
-			NativeSessionResume: true,
-			CanRecover:          &canRecover,
-		},
-	}
-}
-
-func (a *QoderACP) RemoteAuth() *RemoteAuth { return nil }
-
-func (a *QoderACP) InstallScript() string {
-	return "Install Qoder CLI from https://qoder.com"
-}
-
-func (a *QoderACP) PermissionSettings() map[string]PermissionSetting {
-	return emptyPermSettings
-}
-
-func (a *QoderACP) InferenceConfig() *InferenceConfig {
-	return &InferenceConfig{
-		Supported: true,
-		Command:   NewCommand(qoderACPBin, "--acp"),
-	}
-}
-
-func (a *QoderACP) BillingType() usage.BillingType { return defaultBillingType() }

--- a/apps/backend/internal/agent/agents/trae_acp.go
+++ b/apps/backend/internal/agent/agents/trae_acp.go
@@ -1,12 +1,7 @@
 package agents
 
 import (
-	"context"
 	_ "embed"
-	"time"
-
-	"github.com/kandev/kandev/internal/agent/usage"
-	"github.com/kandev/kandev/pkg/agent"
 )
 
 //go:embed logos/trae_acp_light.svg
@@ -25,98 +20,36 @@ var (
 
 // TraeACP implements Agent for ByteDance's Trae IDE CLI using ACP.
 type TraeACP struct {
-	StandardPassthrough
+	nativeACPPassthroughAgent
 }
 
 func NewTraeACP() *TraeACP {
-	return &TraeACP{
-		StandardPassthrough: StandardPassthrough{
-			PermSettings: emptyPermSettings,
-			Cfg: PassthroughConfig{
-				Supported:      true,
-				Label:          "CLI Passthrough",
-				Description:    "Show terminal directly instead of chat interface",
-				PassthroughCmd: NewCommand(traeACPBin),
-				ModelFlag:      NewParam("--model", "{model}"),
-				IdleTimeout:    3 * time.Second,
-				BufferMaxBytes: DefaultBufferMaxBytes,
+	return &TraeACP{newNativeACPPassthrough(
+		nativeACPSpec{
+			id:            "trae-acp",
+			name:          "Trae ACP Agent",
+			displayName:   "Trae",
+			description:   "ByteDance Trae IDE coding agent using the ACP protocol via traecli acp serve.",
+			displayOrder:  17,
+			bin:           traeACPBin,
+			args:          []string{"acp", "serve"},
+			logoLight:     traeACPLogoLight,
+			logoDark:      traeACPLogoDark,
+			installScript: "Install Trae IDE CLI from https://trae.ai",
+			permSettings:  emptyPermSettings,
+			runtime: nativeACPRuntimeSpec{
+				// Verified against Trae CLI 0.120.48 by driving `traecli acp
+				// serve` through session/new + session/prompt: the ACP session ID
+				// appears as ~/.cache/trae-cli/sessions/<sessionId>/, which is
+				// where the CLI persists conversation history and metadata.
+				// ~/.trae holds config only (traecli.yaml, skills, agents,
+				// commands) and the login token lives in the OS keyring, not a
+				// file, so neither belongs here. The published manual still
+				// documents the older ~/.cache/coco/ cache root; the shipped
+				// binary uses ~/.cache/trae-cli, so re-check this on upgrades.
+				sessionDirTemplate: "{home}/.cache/trae-cli",
 			},
 		},
-	}
+		nativeACPPassthroughSpec{modelFlag: nativeACPModelFlag()},
+	)}
 }
-
-func (a *TraeACP) ID() string          { return "trae-acp" }
-func (a *TraeACP) Name() string        { return "Trae ACP Agent" }
-func (a *TraeACP) DisplayName() string { return "Trae" }
-func (a *TraeACP) Description() string {
-	return "ByteDance Trae IDE coding agent using the ACP protocol via traecli acp serve."
-}
-func (a *TraeACP) Enabled() bool     { return true }
-func (a *TraeACP) DisplayOrder() int { return 17 }
-
-func (a *TraeACP) Logo(v LogoVariant) []byte {
-	if v == LogoDark {
-		return traeACPLogoDark
-	}
-	return traeACPLogoLight
-}
-
-func (a *TraeACP) IsInstalled(ctx context.Context) (*DiscoveryResult, error) {
-	result, err := Detect(ctx, WithCommand(traeACPBin))
-	if err != nil {
-		return result, err
-	}
-	result.SupportsMCP = true
-	result.Capabilities = DiscoveryCapabilities{
-		SupportsSessionResume: true,
-	}
-	return result, nil
-}
-
-func (a *TraeACP) BuildCommand(opts CommandOptions) Command {
-	return Cmd(traeACPBin, "acp", "serve").Build()
-}
-
-func (a *TraeACP) Runtime() *RuntimeConfig {
-	canRecover := true
-	return &RuntimeConfig{
-		Cmd:            Cmd(traeACPBin, "acp", "serve").Build(),
-		WorkingDir:     "{workspace}",
-		Env:            map[string]string{},
-		ResourceLimits: ResourceLimits{MemoryMB: 4096, CPUCores: 2.0, Timeout: time.Hour},
-		Protocol:       agent.ProtocolACP,
-		SessionConfig: SessionConfig{
-			// Verified against Trae CLI 0.120.48 by driving `traecli acp
-			// serve` through session/new + session/prompt: the ACP session ID
-			// appears as ~/.cache/trae-cli/sessions/<sessionId>/, which is
-			// where the CLI persists conversation history and metadata.
-			// ~/.trae holds config only (traecli.yaml, skills, agents,
-			// commands) and the login token lives in the OS keyring, not a
-			// file, so neither belongs here. The published manual still
-			// documents the older ~/.cache/coco/ cache root; the shipped
-			// binary uses ~/.cache/trae-cli, so re-check this on upgrades.
-			SessionDirTemplate:  "{home}/.cache/trae-cli",
-			NativeSessionResume: true,
-			CanRecover:          &canRecover,
-		},
-	}
-}
-
-func (a *TraeACP) RemoteAuth() *RemoteAuth { return nil }
-
-func (a *TraeACP) InstallScript() string {
-	return "Install Trae IDE CLI from https://trae.ai"
-}
-
-func (a *TraeACP) PermissionSettings() map[string]PermissionSetting {
-	return emptyPermSettings
-}
-
-func (a *TraeACP) InferenceConfig() *InferenceConfig {
-	return &InferenceConfig{
-		Supported: true,
-		Command:   NewCommand(traeACPBin, "acp", "serve"),
-	}
-}
-
-func (a *TraeACP) BillingType() usage.BillingType { return defaultBillingType() }

--- a/docs/add-agent-cli.md
+++ b/docs/add-agent-cli.md
@@ -100,6 +100,47 @@ Note: passthrough-only agents provide terminal interaction only. There are no st
 
 ---
 
+## Native-Binary ACP Agent - Recommended for non-npm ACP CLIs
+
+If the agent ships a standalone binary (not npm) that speaks ACP over stdin/stdout on a fixed argv, use the shared scaffold in [`native_acp.go`](../apps/backend/internal/agent/agents/native_acp.go) rather than reimplementing the `Agent` interface. Cursor, Kimi, Kiro, Qoder, Trae, Omp, Devin, and Grok are all defined this way — the whole agent file is its own values:
+
+```go
+type MyAgentACP struct {
+    nativeACPPassthroughAgent
+}
+
+func NewMyAgentACP() *MyAgentACP {
+    return &MyAgentACP{newNativeACPPassthrough(
+        nativeACPSpec{
+            id:            "myagent-acp",
+            name:          "MyAgent ACP Agent",
+            displayName:   "MyAgent",
+            description:   "MyAgent coding agent using the ACP protocol.",
+            displayOrder:  21,
+            bin:           "myagent",
+            args:          []string{"acp"},
+            logoLight:     myagentACPLogoLight,
+            logoDark:      myagentACPLogoDark,
+            installScript: "Install MyAgent CLI from https://myagent.example",
+            permSettings:  emptyPermSettings,
+            runtime: nativeACPRuntimeSpec{
+                userSkillDir:       ".myagent/skills",
+                sessionDirTemplate: "{home}/.myagent",
+            },
+        },
+        nativeACPPassthroughSpec{modelFlag: nativeACPModelFlag()},
+    )}
+}
+```
+
+`nativeACPSpec` covers identity, logos, launch argv, install script, remote auth, and permission settings; `nativeACPRuntimeSpec` covers the `RuntimeConfig` fields that vary (skill dirs, session dir, MCP overrides, `StripEnv`, `RequiredEnv`). Everything else — `WorkingDir`, resource limits, `ProtocolACP`, native session resume, `IsInstalled` via `WithCommand(bin)`, `InferenceConfig`, and billing — is filled in by the scaffold, and `BuildCommand`, `Runtime().Cmd` and `InferenceConfig().Command` all derive from the same `bin` + `args`.
+
+Embed the bare `nativeACPAgent` instead of `nativeACPPassthroughAgent` when the CLI must **not** offer raw terminal passthrough (Grok does this). Add per-agent methods on your own type for anything the spec can't express — Grok's `LoginCommand()` is the example. Register the agent in `LoadDefaults()` as below, and add a case to `nativeACPCases` in [`native_acp_test.go`](../apps/backend/internal/agent/agents/native_acp_test.go) to pin its definition.
+
+Reach for the full manual implementation below only when the agent diverges from this shape (as `claude_acp.go`, `codex_acp.go`, `copilot_acp.go`, and `opencode_acp.go` do).
+
+---
+
 ## Adding a New Agent (Full Integration)
 
 For agents with a structured protocol (JSON-RPC, streaming JSON, etc.), implement the full [`Agent`](../apps/backend/internal/agent/agents/agent.go) interface.
@@ -240,4 +281,6 @@ Start the dev server and verify:
 | `apps/backend/internal/agentctl/server/adapter/factory.go` | Only if adding a new protocol |
 | `apps/backend/internal/agentctl/server/adapter/transport/{proto}/` | Only if adding a new protocol |
 | `apps/backend/internal/agent/agents/passthrough.go` | Never - provides `StandardPassthrough` (read-only reference) |
+| `apps/backend/internal/agent/agents/native_acp.go` | Never - provides the `nativeACPSpec` scaffold for native-binary ACP agents (read-only reference) |
+| `apps/backend/internal/agent/agents/native_acp_test.go` | Always for a native-binary ACP agent - add a `nativeACPCases` entry pinning its definition |
 | `apps/backend/internal/agent/agents/agent.go` | Never - defines the `Agent` interface (read-only reference) |


### PR DESCRIPTION
## What

Eight ACP agent definitions in `apps/backend/internal/agent/agents/` were near-identical ~110-160 line copies of the same `Agent` implementation. Seven opened with a file-level `//nolint:dupl` (two also `goconst`) whose comment said the quiet part out loud:

> Native-binary ACP agents (Cursor, Kimi, Kiro, Qoder, Trae, Omp, Devin) follow the same minimal scaffold; differences are the binary name, argv, and auth surface.

This extracts that scaffold.

- **`native_acp.go`** — `nativeACPSpec` declares everything that varies (identity, `bin` + `args`, logos, install script, remote auth, permission settings, plus a `nativeACPRuntimeSpec` for the `RuntimeConfig` fields that differ: skill dirs, session dir, MCP overrides, `StripEnv`, `RequiredEnv`). `nativeACPAgent` derives the rest — `WorkingDir`, resource limits, `ProtocolACP`, native session resume, `IsInstalled` via `WithCommand(bin)`, `InferenceConfig`, billing — and `BuildCommand`, `Runtime().Cmd` and `InferenceConfig().Command` all come from one argv instead of three hand-kept-in-sync copies.
- **Passthrough** is a separate embed (`nativeACPPassthroughAgent`). Grok stays on the bare `nativeACPAgent` so it still does **not** satisfy `PassthroughAgent` (ADR 0014) — a pre-existing test pins that, and the new table does too.
- **Shared literals** — `"CLI Passthrough"`, `"Show terminal directly instead of chat interface"` and `"{workspace}"` now live in one place, which is what the `goconst` suppressions were complaining about.
- **All `//nolint:dupl` / `//nolint:goconst` directives removed.**

`claude_acp.go`, `codex_acp.go`, `copilot_acp.go` and `opencode_acp.go` are untouched — they're substantially different and not part of the cluster.

Net: **-786 / +310** lines across the eight agent files.

## Proving it's a pure refactor

Before touching anything I dumped the complete registered surface of all eight agents — identity, all three launch argvs, full `RuntimeConfig` (including `RequiredEnv` nil-vs-empty and `ProjectMCPStrategy` concrete type), `SessionConfig`, `PassthroughConfig`, six `BuildPassthroughCommand` option combinations, `RemoteAuth`, install script, `PermissionSettings`, `CatalogPermissionSettings`, `BillingType`, skill dirs, and which optional interfaces each type satisfies. The dump is **byte-identical before and after** (modulo `*bool` addresses).

That scaffolding was temporary. The permanent safety net is **`native_acp_test.go`**, a table-driven pin over all eight agents covering identity, the three launch surfaces, runtime, session config, passthrough config, permission settings, install script and remote auth. Mutation-checked: swapping `projectSkillDir`/`userSkillDir` in the shared `Runtime()` fails it on cursor, kiro and omp.

## Validation

- `make -C apps/backend lint` — 0 issues, with the suppressions gone.
- `make -C apps/backend test` — the agents packages pass. Four unrelated packages fail (`internal/gitlab`, `internal/notifications/service`, `internal/task/handlers`, `internal/task/service` — local-repository-init and notification-occurrence tests). I confirmed the **identical** failure set on a clean `HEAD` worktree, so they're pre-existing/environmental, not from this change.

## Notes for review

**The `//nolint` directives were already stale.** I checked: at `HEAD`, with the directives stripped, `dupl` and `goconst` both report **0 issues** on this package under the repo config. `dupl` at `threshold: 150` only starts flagging these files around threshold 60 — and when it does, it points at `qwen_acp.go` / `kilocode_acp.go`, not the suppressed cluster. So removing them is safe, but the refactor stands on readability rather than on un-suppressing a live warning. (There is still a real `dupl` cluster among the *npm-launched* ACP agents — `qwen`, `iflow`, `droid`, `kilocode`, `pi` — that a follow-up could give the same treatment.)

**Per-agent quirks preserved verbatim, not "fixed"** (flagging rather than changing, per the refactor's scope):
- Kiro, Qoder and Trae have no `SessionDirTemplate`, so `NativeSessionResume` has no persistence across container restarts. Their TODOs moved with them.
- Devin is the only passthrough agent with no `--model` flag.
- Grok sets `RequiredEnv: []string{}` where every peer leaves it nil. The distinction is preserved and asserted (`reflect.DeepEqual`, not `slices.Equal`) since it reads as deliberate documentation of "auth is optional".
- Cursor's `PermissionSettings` are the cluster's only non-empty ones, and the only `cli_flag`.

## Docs

`docs/add-agent-cli.md` gains a "Native-Binary ACP Agent" section — this is now the shortest path for a non-npm ACP CLI, and new agents should add a `nativeACPCases` entry.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2018?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->