### PR TITLE
fix(agents): set confirmed SessionDirTemplate for Pi, Qoder, Kiro and Trae

### DIFF
--- a/apps/backend/internal/agent/agents/kiro_acp.go
+++ b/apps/backend/internal/agent/agents/kiro_acp.go
@@ -89,12 +89,14 @@ func (a *KiroACP) Runtime() *RuntimeConfig {
 		Protocol:       agent.ProtocolACP,
 		UserSkillDir:   ".kiro/skills",
 		SessionConfig: SessionConfig{
-			// TODO: set SessionDirTemplate once the Kiro session dir is
-			// confirmed (likely "{home}/.kiro"). Without it, the Docker
-			// runtime skips mounting the session dir, so NativeSessionResume
-			// has no persistence across container restarts. ACP-native
-			// session/load still works in standalone mode where the host
-			// home dir is the working filesystem.
+			// Verified against Kiro CLI 2.15.0 by driving `kiro-cli-chat acp`
+			// through session/new: each ACP session is persisted as
+			// ~/.kiro/sessions/cli/<sessionId>.{json,jsonl}. KIRO_HOME
+			// relocates the directory. Note ~/.kiro carries config + sessions
+			// only — the login token lives in the separate
+			// ~/.local/share/kiro-cli/data.sqlite3 (auth_kv table), so this
+			// mount persists resumable sessions but not authentication.
+			SessionDirTemplate:  "{home}/.kiro",
 			NativeSessionResume: true,
 			CanRecover:          &canRecover,
 		},

--- a/apps/backend/internal/agent/agents/new_acp_agents_test.go
+++ b/apps/backend/internal/agent/agents/new_acp_agents_test.go
@@ -30,6 +30,13 @@ type acpAgentSpec struct {
 	installViaNpm   bool     // InstallScript starts with "npm install -g"
 	installScript   string   // expected InstallScript() value (empty = unchecked)
 	stripEnv        []string // expected Runtime().StripEnv (nil = unchecked)
+	// sessionDirTemplate is the agent's on-disk session root. Pinned per
+	// agent because it is derived from what the CLI actually writes (see the
+	// evidence comment on each Runtime()), not from a naming convention —
+	// Trae and Devin both diverge from the "{home}/.<agent>" shape, and a
+	// wrong value silently bind-mounts the wrong directory into the
+	// container.
+	sessionDirTemplate string
 }
 
 var newACPAgentSpecs = []struct {
@@ -38,38 +45,43 @@ var newACPAgentSpecs = []struct {
 }{
 	{func() Agent { return NewQwenACP() }, acpAgentSpec{
 		id: "qwen-acp", displayName: "Qwen", detectBinaries: []string{"qwen"},
-		expectedArgv:    []string{"npx", "-y", "@qwen-code/qwen-code", "--acp"},
-		inferenceArgv:   []string{"npx", "-y", "@qwen-code/qwen-code", "--acp"},
-		passthroughArgv: []string{"npx", "-y", "@qwen-code/qwen-code"},
-		installViaNpm:   true,
+		expectedArgv:       []string{"npx", "-y", "@qwen-code/qwen-code", "--acp"},
+		inferenceArgv:      []string{"npx", "-y", "@qwen-code/qwen-code", "--acp"},
+		passthroughArgv:    []string{"npx", "-y", "@qwen-code/qwen-code"},
+		installViaNpm:      true,
+		sessionDirTemplate: "{home}/.qwen",
 	}},
 	{func() Agent { return NewIFlowACP() }, acpAgentSpec{
 		id: "iflow-acp", displayName: "iFlow (beta)", detectBinaries: []string{"iflow"},
-		expectedArgv:    []string{"npx", "-y", "@iflow-ai/iflow-cli", "--experimental-acp"},
-		inferenceArgv:   []string{"npx", "-y", "@iflow-ai/iflow-cli", "--experimental-acp"},
-		passthroughArgv: []string{"npx", "-y", "@iflow-ai/iflow-cli"},
-		installViaNpm:   true,
+		expectedArgv:       []string{"npx", "-y", "@iflow-ai/iflow-cli", "--experimental-acp"},
+		inferenceArgv:      []string{"npx", "-y", "@iflow-ai/iflow-cli", "--experimental-acp"},
+		passthroughArgv:    []string{"npx", "-y", "@iflow-ai/iflow-cli"},
+		installViaNpm:      true,
+		sessionDirTemplate: "{home}/.iflow",
 	}},
 	{func() Agent { return NewDroidACP() }, acpAgentSpec{
 		id: "droid-acp", displayName: "Droid", detectBinaries: []string{"droid"},
-		expectedArgv:    []string{"npx", "-y", "droid", "exec", "--output-format", "acp"},
-		inferenceArgv:   []string{"npx", "-y", "droid", "exec", "--output-format", "acp"},
-		passthroughArgv: []string{"npx", "-y", "droid"},
-		installViaNpm:   true,
+		expectedArgv:       []string{"npx", "-y", "droid", "exec", "--output-format", "acp"},
+		inferenceArgv:      []string{"npx", "-y", "droid", "exec", "--output-format", "acp"},
+		passthroughArgv:    []string{"npx", "-y", "droid"},
+		installViaNpm:      true,
+		sessionDirTemplate: "{home}/.factory",
 	}},
 	{func() Agent { return NewKilocodeACP() }, acpAgentSpec{
 		id: "kilocode-acp", displayName: "Kilocode", detectBinaries: []string{"kilo", "kilocode"},
-		expectedArgv:    []string{"npx", "-y", "@kilocode/cli", "acp"},
-		inferenceArgv:   []string{"npx", "-y", "@kilocode/cli", "acp"},
-		passthroughArgv: []string{"npx", "-y", "@kilocode/cli"},
-		installViaNpm:   true,
+		expectedArgv:       []string{"npx", "-y", "@kilocode/cli", "acp"},
+		inferenceArgv:      []string{"npx", "-y", "@kilocode/cli", "acp"},
+		passthroughArgv:    []string{"npx", "-y", "@kilocode/cli"},
+		installViaNpm:      true,
+		sessionDirTemplate: "{home}/.kilocode",
 	}},
 	{func() Agent { return NewPiACP() }, acpAgentSpec{
 		id: "pi-acp", displayName: "Pi", detectBinaries: []string{"pi-acp", "pi"},
-		expectedArgv:    []string{"npx", "-y", "pi-acp"},
-		inferenceArgv:   []string{"npx", "-y", "pi-acp"},
-		passthroughArgv: []string{"npx", "-y", "pi-acp"},
-		installViaNpm:   true,
+		expectedArgv:       []string{"npx", "-y", "pi-acp"},
+		inferenceArgv:      []string{"npx", "-y", "pi-acp"},
+		passthroughArgv:    []string{"npx", "-y", "pi-acp"},
+		installViaNpm:      true,
+		sessionDirTemplate: "{home}/.pi",
 	}},
 	{func() Agent { return NewCursorACP() }, acpAgentSpec{
 		id: "cursor-acp", displayName: "Cursor", detectBinaries: []string{"cursor-agent"},
@@ -87,49 +99,56 @@ bash "$tmp"
 rm -f "$tmp"
 export PATH="$HOME/.local/bin:$PATH"
 grep -qxF 'export PATH="$HOME/.local/bin:$PATH"' "$HOME/.bashrc" 2>/dev/null || echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$HOME/.bashrc"`,
+		sessionDirTemplate: "{home}/.cursor",
 	}},
 	{func() Agent { return NewKimiACP() }, acpAgentSpec{
 		id: "kimi-acp", displayName: "Kimi", detectBinaries: []string{"kimi"},
-		expectedArgv:    []string{"kimi", "acp"},
-		inferenceArgv:   []string{"kimi", "acp"},
-		passthroughArgv: []string{"kimi"},
-		installViaNpm:   false,
+		expectedArgv:       []string{"kimi", "acp"},
+		inferenceArgv:      []string{"kimi", "acp"},
+		passthroughArgv:    []string{"kimi"},
+		installViaNpm:      false,
+		sessionDirTemplate: "{home}/.kimi",
 	}},
 	{func() Agent { return NewKiroACP() }, acpAgentSpec{
 		id: "kiro-acp", displayName: "Kiro", detectBinaries: []string{"kiro-cli-chat"},
-		expectedArgv:    []string{"kiro-cli-chat", "acp"},
-		inferenceArgv:   []string{"kiro-cli-chat", "acp"},
-		passthroughArgv: []string{"kiro-cli-chat"},
-		installViaNpm:   false,
+		expectedArgv:       []string{"kiro-cli-chat", "acp"},
+		inferenceArgv:      []string{"kiro-cli-chat", "acp"},
+		passthroughArgv:    []string{"kiro-cli-chat"},
+		installViaNpm:      false,
+		sessionDirTemplate: "{home}/.kiro",
 	}},
 	{func() Agent { return NewQoderACP() }, acpAgentSpec{
 		id: "qoder-acp", displayName: "Qoder", detectBinaries: []string{"qodercli"},
-		expectedArgv:    []string{"qodercli", "--acp"},
-		inferenceArgv:   []string{"qodercli", "--acp"},
-		passthroughArgv: []string{"qodercli"},
-		installViaNpm:   false,
+		expectedArgv:       []string{"qodercli", "--acp"},
+		inferenceArgv:      []string{"qodercli", "--acp"},
+		passthroughArgv:    []string{"qodercli"},
+		installViaNpm:      false,
+		sessionDirTemplate: "{home}/.qoder",
 	}},
 	{func() Agent { return NewTraeACP() }, acpAgentSpec{
 		id: "trae-acp", displayName: "Trae", detectBinaries: []string{"traecli"},
-		expectedArgv:    []string{"traecli", "acp", "serve"},
-		inferenceArgv:   []string{"traecli", "acp", "serve"},
-		passthroughArgv: []string{"traecli"},
-		installViaNpm:   false,
+		expectedArgv:       []string{"traecli", "acp", "serve"},
+		inferenceArgv:      []string{"traecli", "acp", "serve"},
+		passthroughArgv:    []string{"traecli"},
+		installViaNpm:      false,
+		sessionDirTemplate: "{home}/.cache/trae-cli",
 	}},
 	{func() Agent { return NewOmpACP() }, acpAgentSpec{
 		id: "omp-acp", displayName: "omp", detectBinaries: []string{"omp"},
-		expectedArgv:    []string{"omp", "acp"},
-		inferenceArgv:   []string{"omp", "acp"},
-		passthroughArgv: []string{"omp"},
-		installViaNpm:   false,
+		expectedArgv:       []string{"omp", "acp"},
+		inferenceArgv:      []string{"omp", "acp"},
+		passthroughArgv:    []string{"omp"},
+		installViaNpm:      false,
+		sessionDirTemplate: "{home}/.omp",
 	}},
 	{func() Agent { return NewDevinACP() }, acpAgentSpec{
 		id: "devin-acp", displayName: "Devin", detectBinaries: []string{"devin"},
-		expectedArgv:    []string{"devin", "acp"},
-		inferenceArgv:   []string{"devin", "acp"},
-		passthroughArgv: []string{"devin"},
-		installViaNpm:   false,
-		stripEnv:        []string{"ACP_BACKEND"},
+		expectedArgv:       []string{"devin", "acp"},
+		inferenceArgv:      []string{"devin", "acp"},
+		passthroughArgv:    []string{"devin"},
+		installViaNpm:      false,
+		stripEnv:           []string{"ACP_BACKEND"},
+		sessionDirTemplate: "{home}/.local/share/devin",
 	}},
 }
 
@@ -192,6 +211,30 @@ func TestNewACPAgents_AllCommandSurfaces(t *testing.T) {
 				t.Fatalf("%s does not implement PassthroughAgent", tc.spec.id)
 			}
 			assertArgvEqual(t, "PassthroughCmd", pa.PassthroughConfig().PassthroughCmd.Args(), tc.spec.passthroughArgv)
+		})
+	}
+}
+
+// TestNewACPAgents_SessionDirTemplate pins the session root each agent
+// declares. The lifecycle manager turns SessionDirTemplate into the
+// bind-mount source under <kandev-home>/agent-sessions/<instance>/, so an
+// unset value means an agent's own session state is quietly lost on every
+// container restart, and a wrong value mounts a directory the CLI never
+// reads.
+func TestNewACPAgents_SessionDirTemplate(t *testing.T) {
+	for _, tc := range newACPAgentSpecs {
+		t.Run(tc.spec.id, func(t *testing.T) {
+			rt := tc.new().Runtime()
+			if rt == nil {
+				t.Fatalf("Runtime() returned nil")
+			}
+			if got := rt.SessionConfig.SessionDirTemplate; got != tc.spec.sessionDirTemplate {
+				t.Errorf("SessionDirTemplate = %q, want %q", got, tc.spec.sessionDirTemplate)
+			}
+			if !strings.HasPrefix(tc.spec.sessionDirTemplate, "{home}/") {
+				t.Errorf("SessionDirTemplate %q must be {home}-relative; SessionDirHostPath only trims that prefix",
+					tc.spec.sessionDirTemplate)
+			}
 		})
 	}
 }

--- a/apps/backend/internal/agent/agents/pi_acp.go
+++ b/apps/backend/internal/agent/agents/pi_acp.go
@@ -96,10 +96,12 @@ func (a *PiACP) Runtime() *RuntimeConfig {
 		UserSkillDir:       ".pi/agent/skills",
 		ProjectMCPStrategy: mcpconfig.PiStrategy{},
 		SessionConfig: SessionConfig{
-			// TODO: set SessionDirTemplate once the Pi session dir is
-			// confirmed. Without it, the Docker runtime skips mounting the
-			// session dir, so NativeSessionResume has no persistence across
-			// container restarts.
+			// Verified against pi-acp@0.0.32: the adapter keeps the ACP↔pi
+			// session map in ~/.pi/pi-acp/session-map.json and reads pi's own
+			// transcripts from ~/.pi/agent/sessions (relocatable via
+			// PI_CODING_AGENT_DIR or a sessionDir in ~/.pi/agent/settings.json).
+			// Both halves of session/load live under ~/.pi.
+			SessionDirTemplate:  "{home}/.pi",
 			NativeSessionResume: true,
 			CanRecover:          &canRecover,
 		},

--- a/apps/backend/internal/agent/agents/qoder_acp.go
+++ b/apps/backend/internal/agent/agents/qoder_acp.go
@@ -87,10 +87,11 @@ func (a *QoderACP) Runtime() *RuntimeConfig {
 		ResourceLimits: ResourceLimits{MemoryMB: 4096, CPUCores: 2.0, Timeout: time.Hour},
 		Protocol:       agent.ProtocolACP,
 		SessionConfig: SessionConfig{
-			// TODO: set SessionDirTemplate once the Qoder session dir is
-			// confirmed. Without it, the Docker runtime skips mounting the
-			// session dir, so NativeSessionResume has no persistence across
-			// container restarts.
+			// Verified against qodercli 1.1.7: every user-level artifact
+			// (settings.json, .auth/, logs/sessions/<project>) is written
+			// under ~/.qoder, and the --config-dir flag relocates that single
+			// root wholesale — running with it leaves nothing else in $HOME.
+			SessionDirTemplate:  "{home}/.qoder",
 			NativeSessionResume: true,
 			CanRecover:          &canRecover,
 		},

--- a/apps/backend/internal/agent/agents/trae_acp.go
+++ b/apps/backend/internal/agent/agents/trae_acp.go
@@ -86,10 +86,16 @@ func (a *TraeACP) Runtime() *RuntimeConfig {
 		ResourceLimits: ResourceLimits{MemoryMB: 4096, CPUCores: 2.0, Timeout: time.Hour},
 		Protocol:       agent.ProtocolACP,
 		SessionConfig: SessionConfig{
-			// TODO: set SessionDirTemplate once the Trae session dir is
-			// confirmed. Without it, the Docker runtime skips mounting the
-			// session dir, so NativeSessionResume has no persistence across
-			// container restarts.
+			// Verified against Trae CLI 0.120.48 by driving `traecli acp
+			// serve` through session/new + session/prompt: the ACP session ID
+			// appears as ~/.cache/trae-cli/sessions/<sessionId>/, which is
+			// where the CLI persists conversation history and metadata.
+			// ~/.trae holds config only (traecli.yaml, skills, agents,
+			// commands) and the login token lives in the OS keyring, not a
+			// file, so neither belongs here. The published manual still
+			// documents the older ~/.cache/coco/ cache root; the shipped
+			// binary uses ~/.cache/trae-cli, so re-check this on upgrades.
+			SessionDirTemplate:  "{home}/.cache/trae-cli",
 			NativeSessionResume: true,
 			CanRecover:          &canRecover,
 		},


### PR DESCRIPTION
## What

Four ACP agent definitions carried an identical unresolved TODO — `// TODO: set SessionDirTemplate once the <agent> session dir is confirmed`. `SessionDirTemplate` is the agent's on-disk session root; the lifecycle manager turns it into the bind-mount source under `<kandev-home>/agent-sessions/<instance>/<dotdir>` (`lifecycle.SessionDirHostPath`), so an unset value means the agent's session state is lost on every container restart.

**All four are resolved with confirmed paths.** None was guessed — each was verified against the shipped CLI, and two of them are *not* `{home}/.<agent>`:

| Agent | `SessionDirTemplate` | Evidence |
| --- | --- | --- |
| `pi-acp` | `{home}/.pi` | Source of `pi-acp@0.0.32` |
| `qoder-acp` | `{home}/.qoder` | Ran `qodercli` 1.1.7 |
| `kiro-acp` | `{home}/.kiro` | Ran `kiro-cli-chat` 2.15.0 over ACP |
| `trae-acp` | `{home}/.cache/trae-cli` | Ran `traecli` 0.120.48 over ACP |

## Evidence

Every probe ran under an isolated `HOME` (`env -i HOME=<tmpdir>`) so the observed writes are unambiguous.

### Pi — `{home}/.pi`

`npm pack pi-acp` (0.0.32), read `dist/index.js`:

- `getPiAcpDir() = join(homedir(), ".pi", "pi-acp")`, holding `session-map.json` — the ACP-session-ID → pi-session-file map that backs `session/load`.
- `getPiAgentDir() = process.env.PI_CODING_AGENT_DIR ?? join(homedir(), ".pi", "agent")`, and `getPiSessionsDir()` defaults to `<agentDir>/sessions` (overridable by `sessionDir` in `~/.pi/agent/settings.json`).

Both halves of resume live under `~/.pi`.

### Qoder — `{home}/.qoder`

Qoder CLI ships on npm as `@qoder-ai/qodercli` (1.1.7). Running it with an isolated `HOME` creates `~/.qoder/` containing `settings.json`, `.auth/`, `installation_id`, and `logs/sessions/<project-slug>/`.

Proof that this is the *whole* user-level root rather than one of several: `--config-dir <alt>` relocates all of it — with that flag set, `settings.json`, `.auth/`, and `logs/sessions/` appear under `<alt>` and **nothing** is written to `$HOME`.

`session/new` over ACP returns `Authentication required`, so the transcript file itself wasn't observed; the `--config-dir` result makes the containing root conclusive regardless.

### Kiro — `{home}/.kiro`

Downloaded `kirocli-x86_64-linux.zip` (Kiro CLI 2.15.0), which contains the exact `kiro-cli-chat` binary this agent launches. Driving `kiro-cli-chat acp` through `initialize` + `session/new` wrote:

```
~/.kiro/sessions/cli/e43ed2c8-6a7b-4b0a-bf65-d1a15f270d3b.json
~/.kiro/sessions/cli/e43ed2c8-6a7b-4b0a-bf65-d1a15f270d3b.jsonl
```

— filenames matching the ACP session ID returned by `session/new`. `KIRO_HOME` relocates the directory ([Kiro docs](https://kiro.dev/docs/cli/chat/configuration/)).

Worth recording, since the old TODO guessed `{home}/.kiro` for the wrong reason: `~/.kiro` is config **and** sessions, but *not* auth. The login token lives in `~/.local/share/kiro-cli/data.sqlite3` (`auth_kv` table, alongside legacy `conversations`/`conversations_v2`, which stayed empty on the ACP path), and that data dir honors `XDG_DATA_HOME`. So this mount persists resumable sessions but not authentication — noted in the code comment.

### Trae — `{home}/.cache/trae-cli`

`traecli` is a symlink to `trae-cli`; installed from the official install script's artifact (0.120.48). Driving `traecli acp serve` through `initialize` + `session/new` + `session/prompt` created:

```
~/.cache/trae-cli/sessions/11d311bb-ae67-4a42-b301-64e5c41a4be9/
```

— again keyed by the ACP session ID. Corroborated twice: `trae-cli --session-id <uuid> -p …` creates the same per-ID directory, and the bundled manual (`traecli doc session-management`) states local session data — conversation history and metadata — is stored in the local cache directory.

Two things deliberately excluded, both recorded in the code comment:

- `~/.trae` is **config only** (`traecli.yaml`, `skills/`, `commands/`, `agents/`) — confirmed by `traecli doctor`, which prints `config: $HOME/.trae`.
- Login uses the **OS keyring**, not a file (`failed to get value from keyring: secret not found in keyring`), so no bind mount can carry Trae auth into a container.

One caveat flagged in the comment: the published manual still documents `~/.cache/coco/` as the cache root (`coco` is the internal project name), while the shipped binary uses `~/.cache/trae-cli/`. The observed behaviour wins here, but it's worth re-checking on upgrades. The full conversation transcript could not be observed directly — this build requires an enterprise SSO login and rejects custom model config — so the assertion rests on the per-session directory being created under the ACP session ID plus the manual's statement about the cache dir.

## Tests

`new_acp_agents_test.go` already drives every one of these agents from a shared spec table, so the template joins it as a pinned field: `acpAgentSpec.sessionDirTemplate` is populated for all 12 agents (including the 8 that already had templates) and `TestNewACPAgents_SessionDirTemplate` asserts the exact value plus the `{home}/`-relative shape that `SessionDirHostPath` requires.

## Follow-up (not in scope here)

`expandMounts` only adds the Docker bind mount when **both** `SessionDirTemplate` and `SessionDirTarget` are set. Only 3 of 20 agents (codex, grok, devin) set `SessionDirTarget`, so for these four — as for claude, gemini, cursor, kimi, and the rest — the template is now correct but no mount is created yet. Wiring targets is a separate, cross-cutting change; flagging it so the half-wired state isn't mistaken for a complete fix.

## Validation

- `make -C apps/backend lint` → 0 issues
- `golangci-lint run ./... --new-from-rev=origin/main` → 0 issues
- `go test ./internal/agent/agents/... ./internal/agent/runtime/lifecycle/...` → pass
- `make -C apps/backend test` → 4 packages fail (`internal/gitlab`, `internal/notifications/service`, `internal/task/handlers`, `internal/task/service`). **Pre-existing**: verified by running the same packages in a separate worktree at clean `HEAD` (`e5237b26c`), where they fail identically. None is touched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2019?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->