### PR TITLE
fix(web): add accessible names to icon-only buttons

### DIFF
--- a/apps/web/app/office/agents/[id]/components/agent-channels-tab.tsx
+++ b/apps/web/app/office/agents/[id]/components/agent-channels-tab.tsx
@@ -140,6 +140,7 @@ function ChannelRow({ channel, onDelete }: { channel: Channel; onDelete: () => v
       <Tooltip>
         <TooltipTrigger asChild>
           <Button
+            aria-label="Delete channel"
             variant="ghost"
             size="icon"
             className="h-7 w-7 shrink-0 cursor-pointer"

--- a/apps/web/app/office/agents/[id]/components/agent-memory-tab.tsx
+++ b/apps/web/app/office/agents/[id]/components/agent-memory-tab.tsx
@@ -321,6 +321,7 @@ function MemoryEntryRow({
         <Tooltip>
           <TooltipTrigger asChild>
             <Button
+              aria-label="Delete entry"
               variant="ghost"
               size="icon"
               className="h-6 w-6 shrink-0 cursor-pointer"

--- a/apps/web/app/office/agents/[id]/components/instruction-file-list.tsx
+++ b/apps/web/app/office/agents/[id]/components/instruction-file-list.tsx
@@ -46,6 +46,7 @@ export function InstructionFileList({
           Files
         </span>
         <Button
+          aria-label="Add instruction file"
           variant="ghost"
           size="icon"
           className="h-6 w-6 cursor-pointer"

--- a/apps/web/app/office/components/new-task-bottom-bar.tsx
+++ b/apps/web/app/office/components/new-task-bottom-bar.tsx
@@ -138,11 +138,16 @@ export function NewTaskBottomBar({ draft, onUpdate }: Props) {
       </Button>
       <Tooltip>
         <TooltipTrigger asChild>
-          <Button variant="ghost" size="icon" className="h-7 w-7 cursor-pointer">
+          <Button
+            aria-label="More task options"
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7 cursor-pointer"
+          >
             <IconDotsVertical className="h-4 w-4" />
           </Button>
         </TooltipTrigger>
-        <TooltipContent>More options</TooltipContent>
+        <TooltipContent>More task options</TooltipContent>
       </Tooltip>
     </div>
   );

--- a/apps/web/app/office/components/new-task-participant-row.tsx
+++ b/apps/web/app/office/components/new-task-participant-row.tsx
@@ -54,7 +54,13 @@ export function ParticipantRow({
       </Popover>
       <Tooltip>
         <TooltipTrigger asChild>
-          <Button variant="ghost" size="icon" className="h-6 w-6 cursor-pointer" onClick={onHide}>
+          <Button
+            aria-label={`Remove ${label.toLowerCase()}`}
+            variant="ghost"
+            size="icon"
+            className="h-6 w-6 cursor-pointer"
+            onClick={onHide}
+          >
             <IconX className="h-3 w-3" />
           </Button>
         </TooltipTrigger>

--- a/apps/web/app/office/components/new-task-selector-row.tsx
+++ b/apps/web/app/office/components/new-task-selector-row.tsx
@@ -129,12 +129,17 @@ export function NewTaskSelectorRow({ draft, onUpdate }: Props) {
           <Tooltip>
             <TooltipTrigger asChild>
               <DropdownMenuTrigger asChild>
-                <Button variant="ghost" size="icon" className="h-7 w-7 cursor-pointer">
+                <Button
+                  aria-label="More participant options"
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7 cursor-pointer"
+                >
                   <IconDotsVertical className="h-4 w-4" />
                 </Button>
               </DropdownMenuTrigger>
             </TooltipTrigger>
-            <TooltipContent>More options</TooltipContent>
+            <TooltipContent>More participant options</TooltipContent>
           </Tooltip>
           <DropdownMenuContent align="start">
             <DropdownMenuItem

--- a/apps/web/app/office/components/routing/route-panel.tsx
+++ b/apps/web/app/office/components/routing/route-panel.tsx
@@ -75,7 +75,12 @@ function RouteAttemptRow({ attempt }: { attempt: RouteAttempt }) {
           {durationLabel(attempt.started_at, attempt.finished_at)}
         </span>
         <CollapsibleTrigger asChild>
-          <Button variant="ghost" size="icon" className="h-6 w-6 cursor-pointer">
+          <Button
+            aria-label={open ? "Hide attempt details" : "Show attempt details"}
+            variant="ghost"
+            size="icon"
+            className="h-6 w-6 cursor-pointer"
+          >
             {open ? (
               <IconChevronDown className="h-3.5 w-3.5" />
             ) : (

--- a/apps/web/app/office/routines/routine-row.tsx
+++ b/apps/web/app/office/routines/routine-row.tsx
@@ -119,7 +119,7 @@ export function RoutineRow({
               className="h-8 w-8 cursor-pointer"
               onClick={(e) => e.stopPropagation()}
             >
-              <Link href={`/office/routines/${routine.id}`}>
+              <Link href={`/office/routines/${routine.id}`} aria-label="Edit routine">
                 <IconPencil className="h-4 w-4" />
               </Link>
             </Button>
@@ -145,6 +145,7 @@ function RoutineActions({ onRunNow, onDelete }: { onRunNow: () => void; onDelete
         <TooltipTrigger asChild>
           <DropdownMenuTrigger asChild>
             <Button
+              aria-label="Routine actions"
               variant="ghost"
               size="icon"
               className="h-8 w-8 cursor-pointer"

--- a/apps/web/app/office/tasks/[id]/advanced-panels/chat-panel.tsx
+++ b/apps/web/app/office/tasks/[id]/advanced-panels/chat-panel.tsx
@@ -261,6 +261,7 @@ function ChatInput({
         <Tooltip>
           <TooltipTrigger asChild>
             <Button
+              aria-label="Send message"
               size="icon"
               className="h-9 w-9 cursor-pointer shrink-0"
               disabled={disabled || !message.trim()}

--- a/apps/web/app/office/tasks/task-group.tsx
+++ b/apps/web/app/office/tasks/task-group.tsx
@@ -28,6 +28,7 @@ export function TaskGroup({ groupBy, onGroupByChange }: IssueGroupProps) {
         <TooltipTrigger asChild>
           <PopoverTrigger asChild>
             <Button
+              aria-label="Group by"
               variant={groupBy !== "none" ? "secondary" : "ghost"}
               size="icon-sm"
               className="cursor-pointer"

--- a/apps/web/app/office/tasks/task-sort.tsx
+++ b/apps/web/app/office/tasks/task-sort.tsx
@@ -28,7 +28,7 @@ export function TaskSort({ field, dir, onFieldChange, onDirChange }: IssueSortPr
       <Tooltip>
         <TooltipTrigger asChild>
           <PopoverTrigger asChild>
-            <Button variant="ghost" size="icon-sm" className="cursor-pointer">
+            <Button aria-label="Sort" variant="ghost" size="icon-sm" className="cursor-pointer">
               <IconArrowsSort className="h-4 w-4" />
             </Button>
           </PopoverTrigger>

--- a/apps/web/app/office/tasks/tasks-toolbar.tsx
+++ b/apps/web/app/office/tasks/tasks-toolbar.tsx
@@ -54,6 +54,7 @@ function ViewModeToggles({
       <Tooltip>
         <TooltipTrigger asChild>
           <Button
+            aria-label="List view"
             variant={viewMode === "list" ? "secondary" : "ghost"}
             size="icon-sm"
             className="cursor-pointer"
@@ -67,6 +68,7 @@ function ViewModeToggles({
       <Tooltip>
         <TooltipTrigger asChild>
           <Button
+            aria-label="Board view"
             variant={viewMode === "board" ? "secondary" : "ghost"}
             size="icon-sm"
             className="cursor-pointer"
@@ -82,6 +84,7 @@ function ViewModeToggles({
         <Tooltip>
           <TooltipTrigger asChild>
             <Button
+              aria-label="Toggle nesting"
               variant={nestingEnabled ? "secondary" : "ghost"}
               size="icon-sm"
               className="cursor-pointer"

--- a/apps/web/app/office/tasks/tasks-toolbar.tsx
+++ b/apps/web/app/office/tasks/tasks-toolbar.tsx
@@ -55,6 +55,7 @@ function ViewModeToggles({
         <TooltipTrigger asChild>
           <Button
             aria-label="List view"
+            aria-pressed={viewMode === "list"}
             variant={viewMode === "list" ? "secondary" : "ghost"}
             size="icon-sm"
             className="cursor-pointer"
@@ -69,6 +70,7 @@ function ViewModeToggles({
         <TooltipTrigger asChild>
           <Button
             aria-label="Board view"
+            aria-pressed={viewMode === "board"}
             variant={viewMode === "board" ? "secondary" : "ghost"}
             size="icon-sm"
             className="cursor-pointer"
@@ -85,6 +87,7 @@ function ViewModeToggles({
           <TooltipTrigger asChild>
             <Button
               aria-label="Toggle nesting"
+              aria-pressed={nestingEnabled}
               variant={nestingEnabled ? "secondary" : "ghost"}
               size="icon-sm"
               className="cursor-pointer"

--- a/apps/web/app/office/workspace/costs/budget-policy-card.tsx
+++ b/apps/web/app/office/workspace/costs/budget-policy-card.tsx
@@ -61,6 +61,7 @@ export function BudgetPolicyCard({ policy, spentSubcents = 0, onDelete }: Props)
           <Tooltip>
             <TooltipTrigger asChild>
               <Button
+                aria-label="Delete policy"
                 variant="ghost"
                 size="icon-sm"
                 className="cursor-pointer"

--- a/apps/web/app/office/workspace/org/org-zoom-controls.tsx
+++ b/apps/web/app/office/workspace/org/org-zoom-controls.tsx
@@ -17,6 +17,7 @@ export function OrgZoomControls({ onZoomIn, onZoomOut, onFit, onExport }: OrgZoo
       <Tooltip>
         <TooltipTrigger asChild>
           <Button
+            aria-label="Zoom in"
             variant="outline"
             size="icon"
             className="h-8 w-8 cursor-pointer"
@@ -30,6 +31,7 @@ export function OrgZoomControls({ onZoomIn, onZoomOut, onFit, onExport }: OrgZoo
       <Tooltip>
         <TooltipTrigger asChild>
           <Button
+            aria-label="Zoom out"
             variant="outline"
             size="icon"
             className="h-8 w-8 cursor-pointer"
@@ -42,7 +44,13 @@ export function OrgZoomControls({ onZoomIn, onZoomOut, onFit, onExport }: OrgZoo
       </Tooltip>
       <Tooltip>
         <TooltipTrigger asChild>
-          <Button variant="outline" size="icon" className="h-8 w-8 cursor-pointer" onClick={onFit}>
+          <Button
+            aria-label="Fit to screen"
+            variant="outline"
+            size="icon"
+            className="h-8 w-8 cursor-pointer"
+            onClick={onFit}
+          >
             <IconArrowsMaximize className="h-4 w-4" />
           </Button>
         </TooltipTrigger>
@@ -52,6 +60,7 @@ export function OrgZoomControls({ onZoomIn, onZoomOut, onFit, onExport }: OrgZoo
         <Tooltip>
           <TooltipTrigger asChild>
             <Button
+              aria-label="Export SVG"
               variant="outline"
               size="icon"
               className="h-8 w-8 cursor-pointer"

--- a/apps/web/app/settings/executor/[id]/profile/[profileId]/page.tsx
+++ b/apps/web/app/settings/executor/[id]/profile/[profileId]/page.tsx
@@ -197,7 +197,7 @@ function EnvVarRow({
         </Select>
       )}
       <Button
-        aria-label="Remove secret"
+        aria-label="Remove environment variable"
         type="button"
         variant="ghost"
         size="icon"

--- a/apps/web/app/settings/executor/[id]/profile/[profileId]/page.tsx
+++ b/apps/web/app/settings/executor/[id]/profile/[profileId]/page.tsx
@@ -197,6 +197,7 @@ function EnvVarRow({
         </Select>
       )}
       <Button
+        aria-label="Remove secret"
         type="button"
         variant="ghost"
         size="icon"

--- a/apps/web/app/settings/executors/page.tsx
+++ b/apps/web/app/settings/executors/page.tsx
@@ -95,6 +95,7 @@ function ProfileCard({
           {getExecutorLabel(profile.executor_type)}
         </Badge>
         <Button
+          aria-label="Delete executor profile"
           variant="ghost"
           size="icon"
           className="h-8 w-8 shrink-0 cursor-pointer opacity-0 group-hover:opacity-100"

--- a/apps/web/components/automations/automations-table.tsx
+++ b/apps/web/components/automations/automations-table.tsx
@@ -65,6 +65,7 @@ function RowActions({
       <Tooltip>
         <TooltipTrigger asChild>
           <Button
+            aria-label="Trigger manually"
             variant="ghost"
             size="icon-sm"
             className="cursor-pointer"
@@ -78,6 +79,7 @@ function RowActions({
       <Tooltip>
         <TooltipTrigger asChild>
           <Button
+            aria-label="Delete automation"
             variant="ghost"
             size="icon-sm"
             className="cursor-pointer"

--- a/apps/web/components/automations/trigger-card.tsx
+++ b/apps/web/components/automations/trigger-card.tsx
@@ -123,6 +123,7 @@ export function TriggerCard({
           <TooltipContent>{TRIGGER_INFO[trigger.type]}</TooltipContent>
         </Tooltip>
         <Button
+          aria-label={expanded ? "Collapse trigger" : "Expand trigger"}
           variant="ghost"
           size="icon-sm"
           className="cursor-pointer"
@@ -141,7 +142,13 @@ export function TriggerCard({
           onCheckedChange={onToggleEnabled}
           className="cursor-pointer"
         />
-        <Button variant="ghost" size="icon-sm" className="cursor-pointer" onClick={onDelete}>
+        <Button
+          aria-label="Delete trigger"
+          variant="ghost"
+          size="icon-sm"
+          className="cursor-pointer"
+          onClick={onDelete}
+        >
           <IconTrash className="h-3.5 w-3.5 text-destructive" />
         </Button>
       </div>

--- a/apps/web/components/quick-chat/quick-chat-dialog.tsx
+++ b/apps/web/components/quick-chat/quick-chat-dialog.tsx
@@ -142,6 +142,7 @@ export const QuickChatPickerDialog = memo(function QuickChatPickerDialog({
         <div className="flex items-center justify-between px-4 py-3 border-b">
           <h2 className="text-lg font-semibold">New Quick Chat</h2>
           <Button
+            aria-label="Close quick chat"
             variant="ghost"
             size="icon"
             onClick={() => onOpenChange(false)}

--- a/apps/web/components/settings/account/api-tokens.tsx
+++ b/apps/web/components/settings/account/api-tokens.tsx
@@ -68,6 +68,7 @@ function MintTokenResult({
           data-testid="api-tokens-raw-value"
         />
         <Button
+          aria-label="Copy token"
           size="icon"
           variant="outline"
           className="cursor-pointer"

--- a/apps/web/components/settings/key-value-input.tsx
+++ b/apps/web/components/settings/key-value-input.tsx
@@ -52,7 +52,12 @@ export function KeyValueInput({
             onChange={(e) => handleChange(item.id, "value", e.target.value)}
             className="flex-1"
           />
-          <Button variant="ghost" size="icon" onClick={() => handleRemove(item.id)}>
+          <Button
+            aria-label="Remove entry"
+            variant="ghost"
+            size="icon"
+            onClick={() => handleRemove(item.id)}
+          >
             <IconX className="h-4 w-4" />
           </Button>
         </div>

--- a/apps/web/components/settings/profile-edit/sprites-sections.tsx
+++ b/apps/web/components/settings/profile-edit/sprites-sections.tsx
@@ -69,6 +69,7 @@ function PolicyRuleRow({
       </TableCell>
       <TableCell>
         <Button
+          aria-label="Remove rule"
           variant="ghost"
           size="icon"
           onClick={() => onRemove(index)}

--- a/apps/web/components/settings/profile-form-fields.tsx
+++ b/apps/web/components/settings/profile-form-fields.tsx
@@ -288,6 +288,7 @@ function RefreshCapabilitiesButton({
       <Tooltip>
         <TooltipTrigger asChild>
           <Button
+            aria-label="Refresh agent capabilities"
             variant="outline"
             size="icon"
             onClick={onRefresh}

--- a/apps/web/components/settings/prompts-settings.tsx
+++ b/apps/web/components/settings/prompts-settings.tsx
@@ -141,6 +141,7 @@ function PromptListItem({
         </div>
         <div className="flex items-center gap-2">
           <Button
+            aria-label="Edit prompt"
             variant="ghost"
             size="icon"
             onClick={() => onStartEditing(prompt)}
@@ -151,6 +152,7 @@ function PromptListItem({
             <IconEdit className="h-4 w-4" />
           </Button>
           <Button
+            aria-label="Delete prompt"
             variant="ghost"
             size="icon"
             onClick={() => onOpenDelete(prompt)}

--- a/apps/web/components/settings/repository-custom-scripts.tsx
+++ b/apps/web/components/settings/repository-custom-scripts.tsx
@@ -86,6 +86,7 @@ function RepositoryCustomScript({
           data-settings-dirty={nameIsDirty}
         />
         <Button
+          aria-label="Remove script"
           type="button"
           variant="ghost"
           size="icon"

--- a/apps/web/components/settings/secrets-settings.tsx
+++ b/apps/web/components/settings/secrets-settings.tsx
@@ -156,6 +156,7 @@ function SecretListItemRow({
         </div>
         <div className="flex items-center gap-1 shrink-0">
           <Button
+            aria-label={revealed ? "Hide secret value" : "Reveal secret value"}
             variant="ghost"
             size="icon"
             onClick={handleReveal}
@@ -165,6 +166,7 @@ function SecretListItemRow({
             {revealed ? <IconEyeOff className="h-4 w-4" /> : <IconEye className="h-4 w-4" />}
           </Button>
           <Button
+            aria-label="Edit secret"
             variant="ghost"
             size="icon"
             onClick={() => onEdit(secret)}
@@ -174,6 +176,7 @@ function SecretListItemRow({
             <IconEdit className="h-4 w-4" />
           </Button>
           <Button
+            aria-label="Delete secret"
             variant="ghost"
             size="icon"
             onClick={() => onDelete(secret)}

--- a/apps/web/components/settings/sprites-settings.tsx
+++ b/apps/web/components/settings/sprites-settings.tsx
@@ -270,6 +270,7 @@ function InstancesContent({
             </TableCell>
             <TableCell>
               <Button
+                aria-label="Destroy instance"
                 variant="ghost"
                 size="icon"
                 onClick={() => onDestroy(inst.name)}

--- a/apps/web/components/settings/system/invite-dialog.tsx
+++ b/apps/web/components/settings/system/invite-dialog.tsx
@@ -117,6 +117,7 @@ function InviteLinkResult({ url, onDone }: { url: string; onDone: () => void }) 
       <div className="flex items-center gap-2">
         <Input readOnly value={url} data-testid="invite-dialog-url" className="font-mono text-xs" />
         <Button
+          aria-label="Copy invite link"
           size="icon"
           variant="outline"
           className="cursor-pointer"

--- a/apps/web/components/task/bottom-terminal-panel.tsx
+++ b/apps/web/components/task/bottom-terminal-panel.tsx
@@ -88,7 +88,13 @@ export function BottomTerminalPanel() {
       {/* Header */}
       <div className="flex items-center justify-between px-3 py-1 border-b border-border bg-muted/30 shrink-0">
         <span className="text-xs font-medium text-muted-foreground">Terminal</span>
-        <Button variant="ghost" size="icon" className="h-5 w-5 cursor-pointer" onClick={toggle}>
+        <Button
+          aria-label="Hide terminal"
+          variant="ghost"
+          size="icon"
+          className="h-5 w-5 cursor-pointer"
+          onClick={toggle}
+        >
           <IconMinus className="h-3 w-3" />
         </Button>
       </div>

--- a/apps/web/components/task/chat/chat-input-toolbar-primitives.tsx
+++ b/apps/web/components/task/chat/chat-input-toolbar-primitives.tsx
@@ -71,10 +71,8 @@ function SendSubmitButton({
         aria-label={isDisabled ? (tooltipDescription ?? "Submit unavailable") : undefined}
       >
         <Button
-          // The tooltip already describes the current action ("Queue message"
-          // while busy, "Request plan changes" in plan mode, or the disabled
-          // reason); keep the accessible name in step with it rather than
-          // always announcing "Send message".
+          // Must track the mode-specific tooltip so screen readers announce the
+          // current action rather than the default send action.
           aria-label={tooltipDescription ?? "Send message"}
           type="button"
           variant="default"

--- a/apps/web/components/task/chat/chat-input-toolbar-primitives.tsx
+++ b/apps/web/components/task/chat/chat-input-toolbar-primitives.tsx
@@ -71,6 +71,7 @@ function SendSubmitButton({
         aria-label={isDisabled ? (tooltipDescription ?? "Submit unavailable") : undefined}
       >
         <Button
+          aria-label="Send message"
           type="button"
           variant="default"
           size="icon"
@@ -131,6 +132,7 @@ export function SubmitButton({
         <Tooltip>
           <TooltipTrigger asChild>
             <Button
+              aria-label="Cancel agent"
               type="button"
               variant="secondary"
               size="icon"

--- a/apps/web/components/task/chat/chat-input-toolbar-primitives.tsx
+++ b/apps/web/components/task/chat/chat-input-toolbar-primitives.tsx
@@ -71,7 +71,11 @@ function SendSubmitButton({
         aria-label={isDisabled ? (tooltipDescription ?? "Submit unavailable") : undefined}
       >
         <Button
-          aria-label="Send message"
+          // The tooltip already describes the current action ("Queue message"
+          // while busy, "Request plan changes" in plan mode, or the disabled
+          // reason); keep the accessible name in step with it rather than
+          // always announcing "Send message".
+          aria-label={tooltipDescription ?? "Send message"}
           type="button"
           variant="default"
           size="icon"

--- a/apps/web/components/task/chat/reset-context-button.tsx
+++ b/apps/web/components/task/chat/reset-context-button.tsx
@@ -40,6 +40,7 @@ export function ResetContextButton({ sessionId }: { sessionId: string }) {
       <Tooltip>
         <TooltipTrigger asChild>
           <Button
+            aria-label="Reset agent context"
             type="button"
             variant="ghost"
             size="icon"

--- a/apps/web/components/task/document/document-controls.tsx
+++ b/apps/web/components/task/document/document-controls.tsx
@@ -34,6 +34,7 @@ export function DocumentControls({ activeSessionId }: DocumentControlsProps) {
         <Tooltip>
           <TooltipTrigger asChild>
             <Button
+              aria-label="Show sidebar"
               size="icon-sm"
               variant="ghost"
               className="cursor-pointer rounded-none border-r border-border/70"
@@ -48,6 +49,7 @@ export function DocumentControls({ activeSessionId }: DocumentControlsProps) {
         <Tooltip>
           <TooltipTrigger asChild>
             <Button
+              aria-label="Hide sidebar"
               size="icon-sm"
               variant="ghost"
               className="cursor-pointer rounded-none border-r border-border/70"
@@ -63,6 +65,7 @@ export function DocumentControls({ activeSessionId }: DocumentControlsProps) {
         <Tooltip>
           <TooltipTrigger asChild>
             <Button
+              aria-label="Show right panel"
               size="icon-sm"
               variant="ghost"
               className="cursor-pointer rounded-none"
@@ -77,6 +80,7 @@ export function DocumentControls({ activeSessionId }: DocumentControlsProps) {
         <Tooltip>
           <TooltipTrigger asChild>
             <Button
+              aria-label="Hide right panel"
               size="icon-sm"
               variant="ghost"
               className="cursor-pointer rounded-none"

--- a/apps/web/components/task/mobile/session-mobile-top-bar.tsx
+++ b/apps/web/components/task/mobile/session-mobile-top-bar.tsx
@@ -321,7 +321,7 @@ export const SessionMobileTopBar = memo(function SessionMobileTopBar(
     <header className="flex items-center justify-between px-2 py-2 bg-background">
       <div className="flex items-center gap-2 min-w-0 flex-1">
         <Button variant="ghost" size="icon-sm" asChild>
-          <Link href="/">
+          <Link href="/" aria-label="Back to home">
             <IconArrowLeft className="h-4 w-4" />
           </Link>
         </Button>

--- a/apps/web/components/task/simple/OfficeSimplePane.tsx
+++ b/apps/web/components/task/simple/OfficeSimplePane.tsx
@@ -136,6 +136,7 @@ function TaskHeaderRow({ task, activeHold }: { task: Task; activeHold: TreeHold 
         <Tooltip>
           <TooltipTrigger asChild>
             <Button
+              aria-label="Copy identifier"
               variant="ghost"
               size="icon"
               className="h-8 w-8 cursor-pointer"

--- a/apps/web/components/task/simple/components/send-comment-button.tsx
+++ b/apps/web/components/task/simple/components/send-comment-button.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { IconSend } from "@tabler/icons-react";
+import { Button } from "@kandev/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
+
+type SendCommentButtonProps = {
+  disabled: boolean;
+  onSubmit: () => Promise<void> | void;
+};
+
+export function SendCommentButton({ disabled, onSubmit }: SendCommentButtonProps) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        {/* While disabled the button leaves the tab order and this span takes
+            focus, so the span has to carry the name in that state. */}
+        <span
+          tabIndex={disabled ? 0 : -1}
+          aria-label={disabled ? "Send comment unavailable" : undefined}
+          className="inline-flex"
+        >
+          <Button
+            aria-label="Send comment"
+            type="button"
+            size="icon"
+            className="h-7 w-7 cursor-pointer"
+            disabled={disabled}
+            onClick={() => void onSubmit()}
+          >
+            <IconSend className="h-3.5 w-3.5" />
+          </Button>
+        </span>
+      </TooltipTrigger>
+      <TooltipContent>Send comment</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/apps/web/components/task/simple/task-chat.tsx
+++ b/apps/web/components/task/simple/task-chat.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState, useCallback } from "react";
 import { toast } from "sonner";
-import { IconCode, IconChevronDown, IconSend, IconPaperclip, IconUser } from "@tabler/icons-react";
+import { IconCode, IconChevronDown, IconPaperclip, IconUser } from "@tabler/icons-react";
 import { AgentAvatar } from "@/app/office/components/agent-avatar";
 import { Button } from "@kandev/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
@@ -10,6 +10,7 @@ import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@kandev/ui/
 import { EnhancePromptButton } from "@/components/enhance-prompt-button";
 import { useIsUtilityConfigured } from "@/hooks/use-is-utility-configured";
 import { PromptResultRecovery } from "@/components/prompt-result-recovery";
+import { SendCommentButton } from "./components/send-comment-button";
 import { usePromptResultDelivery } from "@/hooks/use-prompt-result-delivery";
 import { useUtilityAgentGenerator } from "@/hooks/use-utility-agent-generator";
 import { useAppStore } from "@/components/state-provider";
@@ -342,23 +343,7 @@ function CommentComposerFooter({
           isConfigured={isUtilityConfigured}
         />
         <span className="flex-1" />
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <span tabIndex={isSendDisabled ? 0 : -1} className="inline-flex">
-              <Button
-                aria-label="Send comment"
-                type="button"
-                size="icon"
-                className="h-7 w-7 cursor-pointer"
-                disabled={isSendDisabled}
-                onClick={() => void handleSubmit()}
-              >
-                <IconSend className="h-3.5 w-3.5" />
-              </Button>
-            </span>
-          </TooltipTrigger>
-          <TooltipContent>Send comment</TooltipContent>
-        </Tooltip>
+        <SendCommentButton disabled={isSendDisabled} onSubmit={handleSubmit} />
       </div>
       <div className="px-2 pb-2">
         <PromptResultRecovery

--- a/apps/web/components/task/simple/task-chat.tsx
+++ b/apps/web/components/task/simple/task-chat.tsx
@@ -324,6 +324,7 @@ function CommentComposerFooter({
         <Tooltip>
           <TooltipTrigger asChild>
             <Button
+              aria-label="Attach files"
               type="button"
               size="icon"
               variant="ghost"
@@ -345,6 +346,7 @@ function CommentComposerFooter({
           <TooltipTrigger asChild>
             <span tabIndex={isSendDisabled ? 0 : -1} className="inline-flex">
               <Button
+                aria-label="Send comment"
                 type="button"
                 size="icon"
                 className="h-7 w-7 cursor-pointer"

--- a/apps/web/components/task/simple/task-documents.tsx
+++ b/apps/web/components/task/simple/task-documents.tsx
@@ -172,7 +172,12 @@ function AttachmentBody({ doc }: { doc: TaskDocument }) {
         download={doc.filename ?? doc.key}
         className="cursor-pointer"
       >
-        <Button variant="ghost" size="icon" className="h-7 w-7 cursor-pointer">
+        <Button
+          aria-label="Download attachment"
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7 cursor-pointer"
+        >
           <IconDownload className="h-3.5 w-3.5" />
         </Button>
       </a>

--- a/apps/web/components/task/simple/task-documents.tsx
+++ b/apps/web/components/task/simple/task-documents.tsx
@@ -167,20 +167,20 @@ function AttachmentBody({ doc }: { doc: TaskDocument }) {
         {doc.filename ?? doc.key}
         {doc.size !== undefined && <span className="ml-1">({Math.round(doc.size / 1024)} KB)</span>}
       </span>
-      <a
-        href={`/api/v1/office/tasks/${doc.taskId}/documents/${encodeURIComponent(doc.key)}/download`}
-        download={doc.filename ?? doc.key}
-        className="cursor-pointer"
+      <Button
+        asChild
+        aria-label="Download attachment"
+        variant="ghost"
+        size="icon"
+        className="h-7 w-7 cursor-pointer"
       >
-        <Button
-          aria-label="Download attachment"
-          variant="ghost"
-          size="icon"
-          className="h-7 w-7 cursor-pointer"
+        <a
+          href={`/api/v1/office/tasks/${doc.taskId}/documents/${encodeURIComponent(doc.key)}/download`}
+          download={doc.filename ?? doc.key}
         >
           <IconDownload className="h-3.5 w-3.5" />
-        </Button>
-      </a>
+        </a>
+      </Button>
     </div>
   );
 }

--- a/apps/web/scripts/scan-icon-button-names.mjs
+++ b/apps/web/scripts/scan-icon-button-names.mjs
@@ -50,8 +50,10 @@ function findTagEnd(src, start) {
 // Find the end of the element body for a non-self-closing tag, tracking
 // nesting of same-named elements.
 function findElementEnd(src, tagName, bodyStart) {
-  const open = new RegExp(`<${tagName}[\\s/>]`, "g");
-  const close = new RegExp(`</${tagName}\\s*>`, "g");
+  // Dotted components (<Menu.Trigger>) would otherwise turn `.` into a wildcard.
+  const tag = tagName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const open = new RegExp(`<${tag}[\\s/>]`, "g");
+  const close = new RegExp(`</${tag}\\s*>`, "g");
   let depth = 1;
   let i = bodyStart;
   while (i < src.length) {

--- a/apps/web/scripts/scan-icon-button-names.mjs
+++ b/apps/web/scripts/scan-icon-button-names.mjs
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+// Heuristic scan for icon-only buttons that have no accessible name.
+//
+// Finds JSX elements using the `icon*` Button size variants and reports the
+// ones with no `aria-label` / `aria-labelledby` / `title` attribute and no
+// textual (or `sr-only`) child. Output is a starting point for review, not a
+// verdict: `asChild` wrappers and custom components can supply a name
+// indirectly, so every hit still needs eyeballing.
+//
+// Usage: node scripts/scan-icon-button-names.mjs [--json]
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+
+const ROOTS = ["app", "components", "hooks", "lib"];
+const CWD = process.cwd();
+
+function walk(dir, out = []) {
+  for (const entry of readdirSync(dir)) {
+    if (entry === "node_modules" || entry === "generated") continue;
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) walk(full, out);
+    else if (full.endsWith(".tsx")) out.push(full);
+  }
+  return out;
+}
+
+// Walk forward from the `<` of an opening tag to its closing `>`, skipping
+// over strings, template literals, and balanced braces (JSX expressions).
+function findTagEnd(src, start) {
+  let i = start;
+  let depth = 0;
+  while (i < src.length) {
+    const ch = src[i];
+    if (ch === '"' || ch === "'" || ch === "`") {
+      const quote = ch;
+      i += 1;
+      while (i < src.length && src[i] !== quote) {
+        if (src[i] === "\\") i += 1;
+        i += 1;
+      }
+    } else if (ch === "{") depth += 1;
+    else if (ch === "}") depth -= 1;
+    else if (ch === ">" && depth === 0) return i;
+    i += 1;
+  }
+  return -1;
+}
+
+// Find the end of the element body for a non-self-closing tag, tracking
+// nesting of same-named elements.
+function findElementEnd(src, tagName, bodyStart) {
+  const open = new RegExp(`<${tagName}[\\s/>]`, "g");
+  const close = new RegExp(`</${tagName}\\s*>`, "g");
+  let depth = 1;
+  let i = bodyStart;
+  while (i < src.length) {
+    open.lastIndex = i;
+    close.lastIndex = i;
+    const o = open.exec(src);
+    const c = close.exec(src);
+    if (!c) return src.length;
+    if (o && o.index < c.index) {
+      depth += 1;
+      i = o.index + 1;
+      continue;
+    }
+    depth -= 1;
+    if (depth === 0) return c.index;
+    i = c.index + 1;
+  }
+  return src.length;
+}
+
+const NAME_ATTRS = /\b(aria-label|aria-labelledby|title)\s*=/;
+const SPREAD = /\{\.\.\./;
+
+// Children that count as an accessible name: literal text, or an `sr-only`
+// span. Icon components (<Trash2 />) and bare expressions do not.
+function hasTextualChild(body) {
+  if (/\bsr-only\b/.test(body)) return true;
+  const stripped = body
+    .replace(/<[^>]*>/g, " ") // elements
+    .replace(/\{[^{}]*\}/g, " ") // simple expressions
+    .replace(/\{\{[\s\S]*?\}\}/g, " ");
+  return /[A-Za-z0-9]/.test(stripped.replace(/ /g, ""));
+}
+
+const findings = [];
+
+for (const root of ROOTS) {
+  for (const file of walk(join(CWD, root))) {
+    const src = readFileSync(file, "utf8");
+    const sizeRe = /size="icon(?:-xs|-sm|-lg)?"/g;
+    let m;
+    while ((m = sizeRe.exec(src)) !== null) {
+      // Scan back to the `<` that opens this element.
+      const tagStart = src.lastIndexOf("<", m.index);
+      if (tagStart === -1) continue;
+      const tagName = /^<([A-Za-z][\w.]*)/.exec(src.slice(tagStart))?.[1];
+      if (!tagName) continue;
+      const tagEnd = findTagEnd(src, tagStart);
+      if (tagEnd === -1) continue;
+      const openTag = src.slice(tagStart, tagEnd + 1);
+      const selfClosing = openTag.trimEnd().endsWith("/>");
+
+      const body = selfClosing
+        ? ""
+        : src.slice(tagEnd + 1, findElementEnd(src, tagName, tagEnd + 1));
+
+      const named = NAME_ATTRS.test(openTag);
+      const spread = SPREAD.test(openTag);
+      const asChild = /\basChild\b/.test(openTag);
+      const textChild = !selfClosing && hasTextualChild(body);
+
+      if (named || textChild) continue;
+
+      findings.push({
+        file: relative(CWD, file),
+        line: src.slice(0, tagStart).split("\n").length,
+        tag: tagName,
+        size: m[0],
+        asChild,
+        spread,
+        snippet: openTag.replace(/\s+/g, " ").slice(0, 120),
+      });
+    }
+  }
+}
+
+if (process.argv.includes("--json")) {
+  console.log(JSON.stringify(findings, null, 2));
+} else {
+  for (const f of findings) {
+    const flags = [f.asChild && "asChild", f.spread && "spread"].filter(Boolean).join(",");
+    console.log(`${f.file}:${f.line}\t<${f.tag}> ${f.size}${flags ? ` [${flags}]` : ""}`);
+  }
+  console.log(`\n${findings.length} icon button(s) with no obvious accessible name`);
+}

--- a/apps/web/scripts/scan-icon-button-names.mjs
+++ b/apps/web/scripts/scan-icon-button-names.mjs
@@ -11,6 +11,7 @@
 
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
 
 const ROOTS = ["app", "components", "hooks", "lib"];
 const CWD = process.cwd();
@@ -27,7 +28,7 @@ function walk(dir, out = []) {
 
 // Walk forward from the `<` of an opening tag to its closing `>`, skipping
 // over strings, template literals, and balanced braces (JSX expressions).
-function findTagEnd(src, start) {
+export function findTagEnd(src, start) {
   let i = start;
   let depth = 0;
   while (i < src.length) {
@@ -49,7 +50,7 @@ function findTagEnd(src, start) {
 
 // Find the end of the element body for a non-self-closing tag, tracking
 // nesting of same-named elements.
-function findElementEnd(src, tagName, bodyStart) {
+export function findElementEnd(src, tagName, bodyStart) {
   // Dotted components (<Menu.Trigger>) would otherwise turn `.` into a wildcard.
   const tag = tagName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const open = new RegExp(`<${tag}[\\s/>]`, "g");
@@ -63,8 +64,19 @@ function findElementEnd(src, tagName, bodyStart) {
     const c = close.exec(src);
     if (!c) return src.length;
     if (o && o.index < c.index) {
-      depth += 1;
-      i = o.index + 1;
+      // A self-closing `<Button />` has no matching `</Button>`, so counting it
+      // as a nested open would leave depth permanently short and run the body
+      // to end-of-file — which reads as "has text" and hides a nameless button.
+      const openEnd = findTagEnd(src, o.index);
+      if (openEnd === -1) return src.length;
+      if (
+        !src
+          .slice(o.index, openEnd + 1)
+          .trimEnd()
+          .endsWith("/>")
+      )
+        depth += 1;
+      i = openEnd + 1;
       continue;
     }
     depth -= 1;
@@ -79,7 +91,7 @@ const SPREAD = /\{\.\.\./;
 
 // Children that count as an accessible name: literal text, or an `sr-only`
 // span. Icon components (<Trash2 />) and bare expressions do not.
-function hasTextualChild(body) {
+export function hasTextualChild(body) {
   if (/\bsr-only\b/.test(body)) return true;
   const stripped = body
     .replace(/<[^>]*>/g, " ") // elements
@@ -88,54 +100,67 @@ function hasTextualChild(body) {
   return /[A-Za-z0-9]/.test(stripped.replace(/ /g, ""));
 }
 
-const findings = [];
+// Report every icon-sized element in one file's source that has no obvious
+// accessible name. `file` is only used to label the findings.
+export function scanSource(src, file = "<source>") {
+  const findings = [];
+  const sizeRe = /size="icon(?:-xs|-sm|-lg)?"/g;
+  let m;
+  while ((m = sizeRe.exec(src)) !== null) {
+    // Scan back to the `<` that opens this element.
+    const tagStart = src.lastIndexOf("<", m.index);
+    if (tagStart === -1) continue;
+    const tagName = /^<([A-Za-z][\w.]*)/.exec(src.slice(tagStart))?.[1];
+    if (!tagName) continue;
+    const tagEnd = findTagEnd(src, tagStart);
+    if (tagEnd === -1) continue;
+    const openTag = src.slice(tagStart, tagEnd + 1);
+    const selfClosing = openTag.trimEnd().endsWith("/>");
 
-for (const root of ROOTS) {
-  for (const file of walk(join(CWD, root))) {
-    const src = readFileSync(file, "utf8");
-    const sizeRe = /size="icon(?:-xs|-sm|-lg)?"/g;
-    let m;
-    while ((m = sizeRe.exec(src)) !== null) {
-      // Scan back to the `<` that opens this element.
-      const tagStart = src.lastIndexOf("<", m.index);
-      if (tagStart === -1) continue;
-      const tagName = /^<([A-Za-z][\w.]*)/.exec(src.slice(tagStart))?.[1];
-      if (!tagName) continue;
-      const tagEnd = findTagEnd(src, tagStart);
-      if (tagEnd === -1) continue;
-      const openTag = src.slice(tagStart, tagEnd + 1);
-      const selfClosing = openTag.trimEnd().endsWith("/>");
+    const body = selfClosing ? "" : src.slice(tagEnd + 1, findElementEnd(src, tagName, tagEnd + 1));
 
-      const body = selfClosing
-        ? ""
-        : src.slice(tagEnd + 1, findElementEnd(src, tagName, tagEnd + 1));
+    const named = NAME_ATTRS.test(openTag);
+    const spread = SPREAD.test(openTag);
+    const asChild = /\basChild\b/.test(openTag);
+    const textChild = !selfClosing && hasTextualChild(body);
 
-      const named = NAME_ATTRS.test(openTag);
-      const spread = SPREAD.test(openTag);
-      const asChild = /\basChild\b/.test(openTag);
-      const textChild = !selfClosing && hasTextualChild(body);
+    if (named || textChild) continue;
 
-      if (named || textChild) continue;
-
-      findings.push({
-        file: relative(CWD, file),
-        line: src.slice(0, tagStart).split("\n").length,
-        tag: tagName,
-        size: m[0],
-        asChild,
-        spread,
-        snippet: openTag.replace(/\s+/g, " ").slice(0, 120),
-      });
-    }
+    findings.push({
+      file,
+      line: src.slice(0, tagStart).split("\n").length,
+      tag: tagName,
+      size: m[0],
+      asChild,
+      spread,
+      snippet: openTag.replace(/\s+/g, " ").slice(0, 120),
+    });
   }
+  return findings;
 }
 
-if (process.argv.includes("--json")) {
-  console.log(JSON.stringify(findings, null, 2));
-} else {
+export function scanRepo(roots = ROOTS, cwd = CWD) {
+  const findings = [];
+  for (const root of roots) {
+    for (const file of walk(join(cwd, root))) {
+      findings.push(...scanSource(readFileSync(file, "utf8"), relative(cwd, file)));
+    }
+  }
+  return findings;
+}
+
+function main() {
+  const findings = scanRepo();
+  if (process.argv.includes("--json")) {
+    console.log(JSON.stringify(findings, null, 2));
+    return;
+  }
   for (const f of findings) {
     const flags = [f.asChild && "asChild", f.spread && "spread"].filter(Boolean).join(",");
     console.log(`${f.file}:${f.line}\t<${f.tag}> ${f.size}${flags ? ` [${flags}]` : ""}`);
   }
   console.log(`\n${findings.length} icon button(s) with no obvious accessible name`);
 }
+
+// Only run the scan when invoked as a script, so tests can import the helpers.
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) main();

--- a/apps/web/scripts/scan-icon-button-names.test.mjs
+++ b/apps/web/scripts/scan-icon-button-names.test.mjs
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  findElementEnd,
+  findTagEnd,
+  hasTextualChild,
+  scanSource,
+} from "./scan-icon-button-names.mjs";
+
+const names = (src) => scanSource(src).map((f) => `${f.tag}:${f.line}`);
+
+describe("findTagEnd", () => {
+  it("stops at the closing angle bracket of the opening tag", () => {
+    const src = `<Button size="icon">x</Button>`;
+    expect(findTagEnd(src, 0)).toBe(src.indexOf(">"));
+  });
+
+  it("ignores angle brackets inside strings and expressions", () => {
+    const src = `<Button className={cn("a>b")} onClick={() => go()} size="icon">x</Button>`;
+    // The first unnested `>` is the one closing the tag, after `size="icon"`.
+    expect(src[findTagEnd(src, 0)]).toBe(">");
+    expect(src.slice(0, findTagEnd(src, 0))).toContain('size="icon"');
+  });
+
+  it("returns -1 when the tag never closes", () => {
+    expect(findTagEnd(`<Button size="icon"`, 0)).toBe(-1);
+  });
+});
+
+describe("findElementEnd", () => {
+  it("skips past a nested element of the same name", () => {
+    const src = `<Button><Button /></Button>`;
+    const bodyStart = src.indexOf(">") + 1;
+    expect(findElementEnd(src, "Button", bodyStart)).toBe(src.lastIndexOf("</Button>"));
+  });
+
+  it("treats a dotted component name literally rather than as a regex", () => {
+    // `.` must not act as a wildcard, which would match `<MenuXTrigger>`.
+    const src = `<Menu.Trigger>a</Menu.Trigger>`;
+    const bodyStart = src.indexOf(">") + 1;
+    expect(findElementEnd(src, "Menu.Trigger", bodyStart)).toBe(src.indexOf("</Menu.Trigger>"));
+  });
+});
+
+describe("hasTextualChild", () => {
+  it("counts literal text", () => {
+    expect(hasTextualChild(`Delete`)).toBe(true);
+  });
+
+  it("counts an sr-only span", () => {
+    expect(hasTextualChild(`<IconX /><span className="sr-only">Close</span>`)).toBe(true);
+  });
+
+  it("does not count icon elements alone", () => {
+    expect(hasTextualChild(`<IconTrash className="h-4 w-4" />`)).toBe(false);
+  });
+});
+
+describe("scanSource", () => {
+  it("reports a self-closing icon button with no name", () => {
+    expect(names(`<IconButton size="icon" />`)).toEqual(["IconButton:1"]);
+  });
+
+  it("reports an icon button whose only child is an icon", () => {
+    expect(names(`<Button size="icon"><IconTrash /></Button>`)).toEqual(["Button:1"]);
+  });
+
+  it("does not report a button carrying aria-label, title, or sr-only text", () => {
+    expect(scanSource(`<Button size="icon" aria-label="Delete"><IconX /></Button>`)).toEqual([]);
+    expect(scanSource(`<Button size="icon" title="Delete"><IconX /></Button>`)).toEqual([]);
+    expect(
+      scanSource(`<Button size="icon"><IconX /><span className="sr-only">Delete</span></Button>`),
+    ).toEqual([]);
+  });
+
+  it("still reports a button whose child is a bare expression", () => {
+    // Known false positive: `{page}` renders a page number, but the scanner
+    // cannot evaluate expressions. Documented in the PR; callers must eyeball.
+    expect(names(`<Button size="icon">{page}</Button>`)).toEqual(["Button:1"]);
+  });
+
+  it("reports an asChild button and flags it, since the name may sit on the child", () => {
+    const [finding] = scanSource(`<Button asChild size="icon"><Link href="/" /></Button>`);
+    expect(finding.asChild).toBe(true);
+  });
+
+  it("covers the icon-xs, icon-sm, and icon-lg variants", () => {
+    const src = [
+      `<Button size="icon-xs"><IconX /></Button>`,
+      `<Button size="icon-sm"><IconX /></Button>`,
+      `<Button size="icon-lg"><IconX /></Button>`,
+    ].join("\n");
+    expect(names(src)).toEqual(["Button:1", "Button:2", "Button:3"]);
+  });
+
+  it("reports only the inner button when the same tag is nested", () => {
+    const src = `<Button>\n  <Button size="icon"><IconX /></Button>\n</Button>`;
+    expect(names(src)).toEqual(["Button:2"]);
+  });
+
+  it("reports the correct 1-based line for a button further down the file", () => {
+    const src = `const a = 1;\n\n<Button size="icon"><IconX /></Button>`;
+    expect(scanSource(src)[0].line).toBe(3);
+  });
+});


### PR DESCRIPTION
## Problem

Icon-only buttons in `apps/web` — the `size="icon"` / `icon-sm` / `icon-lg` Button variants — frequently had no accessible name: no `aria-label`, no `title`, no `sr-only` text. Screen readers announce these as a bare "button", and they are invisible to `getByRole("button", { name })` in Playwright, which pushes E2E specs toward more brittle selectors than necessary.

A Radix `Tooltip` does **not** fix this: `TooltipContent` wires up `aria-describedby` on the trigger, which is a description, not a name. So a tooltipped icon button is still nameless.

## Scan

Rather than trust a grep, this adds `apps/web/scripts/scan-icon-button-names.mjs`, which parses each JSX opening tag (handling nested braces, strings, and template literals), then checks for `aria-label` / `aria-labelledby` / `title` on the tag and for a textual or `sr-only` child.

Initial run: **61 hits** across all three icon size variants. **52** were genuinely nameless and are fixed here.

```
$ node scripts/scan-icon-button-names.mjs
...
11 icon button(s) with no obvious accessible name
```

The scan still reports 11 hits, none of which need a change. Two of them are buttons this PR *did* fix — the `asChild` cases where the label went on the `<Link>` child, which the scan cannot see because it only inspects the opening tag. The other nine were already named:

| Site | Why it's fine |
|---|---|
| `linear-page-client.tsx:150`, `jira/my-jira/ticket-row.tsx:109` | `asChild` → the `<a>` child has `title` |
| `azure-devops-results.tsx:50,137`, `integrations-menu.tsx:211` | `asChild` → the `<a>`/`<Link>` child already had `aria-label` |
| `routine-row.tsx:115`, `session-mobile-top-bar.tsx:323` | **fixed by this PR** — `aria-label` added to the `<Link>` child |
| `kanban-header.tsx:207,292` | `<HealthIndicatorButton>` is a custom component with its own `sr-only` text |
| `tasks-pagination.tsx:155`, `data-table-pagination.tsx:58` | child is `{page}`, a rendered page number |

## Changes

Added a concise, action-describing `aria-label` to **52** buttons across Office, settings, task, and automations surfaces.

- **`aria-label` over `sr-only`** — matches what the codebase already does most often (~390 `aria-label` vs ~35 `sr-only` spans).
- **Labels match existing tooltips.** Where a `TooltipContent` already supplied visible wording, the label reuses it verbatim (`Delete channel`, `Zoom in`, `Fit to screen`, `Show right panel`, …) rather than inventing a second phrasing. Where the tooltip was a bare verb, the label adds the noun (`Delete` → `Delete automation`); Playwright's default substring matching means a `name: "Delete"` selector still matches.
- **State-dependent labels** where the button toggles: `revealed ? "Hide secret value" : "Reveal secret value"`, `expanded ? "Collapse trigger" : "Expand trigger"`, `open ? "Hide attempt details" : "Show attempt details"`.
- **For `asChild` buttons**, the label goes on the rendered child (`<Link aria-label="Edit routine">`), following the existing `integrations-menu.tsx` pattern.

### One collision fixed

`NewTaskSelectorRow` and `NewTaskBottomBar` both render inside `new-task-dialog.tsx`, and both had a `More options` tooltip — two identically-named buttons on one surface. Both the labels **and** the visible tooltips are now distinct: **More participant options** / **More task options**.

## Lint enforcement — follow-up, not in this PR

Tried `eslint-plugin-jsx-a11y`'s `control-has-associated-label` (the only rule that covers this) with `{ controlComponents: ["Button"], depth: 3 }`. It does **not** land clean: **27 warnings** remain under `--max-warnings 0`, and none of them are icon buttons. They're all unlabelled form controls — `<input>`, `<select>`, `<textarea>` in `rich-text-input.tsx`, `task-documents.tsx`, `base-branch-picker.tsx`, and others — plus hidden file inputs that are arguably false positives, plus several `*.test.tsx` files. The rule also can't be scoped to only `controlComponents`; built-in controls are always included.

That's a real but separate accessibility gap. Enabling the rule needs its own pass over form-control labelling first, so it's left out here rather than blocking this change. The plugin and config trial were reverted; the lockfile is untouched.

## Tests

No unit tests added — component markup is an explicit testing exception in `CLAUDE.md`, and these are attribute-only additions.

No E2E specs needed tightening. Checked every introduced name against `e2e/`: the only overlaps are `getByRole("button", { name: "More options" })` in `mobile-kanban.spec.ts` (scoped to `mobile.taskCard()`, a different component on a different page) and `"Reset agent context"` in `workflow-agent-switch.spec.ts` (a `checkbox` role, not `button`). Neither collides.

## Validation

```
cd apps/web && pnpm run typecheck && pnpm lint && pnpm test
```

- `typecheck` — clean
- `lint` — clean at `--max-warnings 0`
- `test` — **922 files, 7050 passed**, 4 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)