### PR TITLE
perf(web): hydrate empty message favorites once

### DIFF
--- a/apps/web/e2e/tests/chat/message-favorite.spec.ts
+++ b/apps/web/e2e/tests/chat/message-favorite.spec.ts
@@ -8,7 +8,7 @@ import { SessionPage } from "../../pages/session-page";
 const SEEDED_MESSAGE = "Favorite toggle regression fixture message";
 
 test.describe("Chat message favorite toggle", () => {
-  test("stars a message, tints its background yellow, and un-stars it back", async ({
+  test("keeps a starred message highlighted after reload and un-stars it", async ({
     testPage,
     apiClient,
     seedData,
@@ -45,6 +45,13 @@ test.describe("Chat message favorite toggle", () => {
     await star.click();
 
     const unstar = highlight.getByRole("button", { name: "Remove message from favorites" });
+    await expect(unstar).toBeVisible();
+    await expect.poll(async () => highlight.getAttribute("class")).toMatch(/yellow/);
+
+    await testPage.reload();
+    await session.waitForLoad();
+
+    await expect(chat.getByText(SEEDED_MESSAGE)).toBeVisible();
     await expect(unstar).toBeVisible();
     await expect.poll(async () => highlight.getAttribute("class")).toMatch(/yellow/);
 

--- a/apps/web/lib/state/slices/message-favorites/favorites-store.test.ts
+++ b/apps/web/lib/state/slices/message-favorites/favorites-store.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useMessageFavoritesStore } from "./favorites-store";
 import { MESSAGE_FAVORITES_STORAGE_PREFIX, loadSessionFavorites } from "./persistence";
 
@@ -9,6 +9,10 @@ describe("message favorites store", () => {
   beforeEach(() => {
     window.sessionStorage.clear();
     useMessageFavoritesStore.setState({ bySession: {} });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it("starts with no favorites for an unhydrated session", () => {
@@ -60,6 +64,15 @@ describe("message favorites store", () => {
     expect(state.bySession[SESSION_ID]).toEqual({ "msg-1": true, "msg-2": true });
   });
 
+  it("hydrates an empty session from storage only once", () => {
+    const getItem = vi.spyOn(window.sessionStorage, "getItem");
+
+    useMessageFavoritesStore.getState().hydrateSession(SESSION_ID);
+    useMessageFavoritesStore.getState().hydrateSession(SESSION_ID);
+
+    expect(getItem).toHaveBeenCalledTimes(1);
+  });
+
   it("ignores malformed persisted favorites", () => {
     window.sessionStorage.setItem(
       `${MESSAGE_FAVORITES_STORAGE_PREFIX}${SESSION_ID}`,
@@ -88,7 +101,7 @@ describe("message favorites store", () => {
     );
 
     expect(() => useMessageFavoritesStore.getState().hydrateSession(SESSION_ID)).not.toThrow();
-    expect(useMessageFavoritesStore.getState().bySession[SESSION_ID]).toBeUndefined();
+    expect(useMessageFavoritesStore.getState().bySession[SESSION_ID]).toEqual({});
   });
 
   it("ignores a persisted array containing non-string entries", () => {
@@ -98,6 +111,6 @@ describe("message favorites store", () => {
     );
 
     expect(() => useMessageFavoritesStore.getState().hydrateSession(SESSION_ID)).not.toThrow();
-    expect(useMessageFavoritesStore.getState().bySession[SESSION_ID]).toBeUndefined();
+    expect(useMessageFavoritesStore.getState().bySession[SESSION_ID]).toEqual({});
   });
 });

--- a/apps/web/lib/state/slices/message-favorites/favorites-store.ts
+++ b/apps/web/lib/state/slices/message-favorites/favorites-store.ts
@@ -21,9 +21,8 @@ export const useMessageFavoritesStore = create<MessageFavoritesSlice>()(
     hydrateSession: (sessionId: string) =>
       set((state) => {
         const existing = state.bySession[sessionId];
-        if (existing && Object.keys(existing).length > 0) return;
+        if (existing) return;
         const ids = loadSessionFavorites(sessionId);
-        if (ids.length === 0) return;
         state.bySession[sessionId] = Object.fromEntries(ids.map((id) => [id, true as const]));
       }),
 


### PR DESCRIPTION
Empty transcripts caused every message to repeat the same session-storage hydration, adding
avoidable work on long chats. Empty sessions now get an in-memory hydration sentinel, and the
favorite flow verifies persistence through a browser reload.

## Validation

- `pnpm exec vitest run lib/state/slices/message-favorites/favorites-store.test.ts hooks/domains/session/use-message-favorite.test.ts` — 13 tests passed.
- `pnpm run typecheck` — passed.
- `pnpm exec eslint lib/state/slices/message-favorites/favorites-store.ts lib/state/slices/message-favorites/favorites-store.test.ts e2e/tests/chat/message-favorite.spec.ts` — passed.
- `pnpm exec prettier --check lib/state/slices/message-favorites/favorites-store.ts lib/state/slices/message-favorites/favorites-store.test.ts e2e/tests/chat/message-favorite.spec.ts` — passed.
- `pnpm e2e:run tests/chat/message-favorite.spec.ts` — Chromium reload-persistence flow passed.
- `pnpm e2e:run --no-build tests/chat/mobile-message-favorite.spec.ts -- --project=mobile-chrome` — Pixel 5 favorite flow passed.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2025?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->