### PR TITLE
fix(plugins): match per-session-suffixed event subjects in plugin delivery

### DIFF
--- a/apps/backend/internal/events/bus/bus.go
+++ b/apps/backend/internal/events/bus/bus.go
@@ -10,11 +10,36 @@ import (
 
 // Event represents a message on the event bus
 type Event struct {
-	ID        string      `json:"id"`
-	Type      string      `json:"type"`
+	ID   string `json:"id"`
+	Type string `json:"type"`
+	// Subject is the concrete subject this event was published on, stamped
+	// by EventBus.Publish. It is NOT always equal to Type: many per-session
+	// (and per-run) events are published on a suffixed subject while Type
+	// stays the bare event constant — e.g. Type "shell.output" published on
+	// subject "shell.output.<sessionId>". Subscribers that need to know
+	// which concrete subject matched (the plugin deliverer, which re-checks
+	// the subscriber's manifest pattern) must read Subject, not Type. Use
+	// EffectiveSubject to read it with a Type fallback for events that
+	// predate the stamping (or were constructed by hand in a test).
+	Subject   string      `json:"subject,omitempty"`
 	Source    string      `json:"source"` // Service that produced the event
 	Timestamp time.Time   `json:"timestamp"`
 	Data      interface{} `json:"data"`
+}
+
+// EffectiveSubject returns the concrete subject e was published on, falling
+// back to e.Type when no subject was stamped (an Event handed straight to a
+// handler without going through Publish). For every subject that is
+// published unsuffixed the two are identical, so the fallback is exact
+// there; only per-session/per-run suffixed subjects depend on Subject.
+func (e *Event) EffectiveSubject() string {
+	if e == nil {
+		return ""
+	}
+	if e.Subject != "" {
+		return e.Subject
+	}
+	return e.Type
 }
 
 // NewEvent creates a new event with a UUID and current timestamp.

--- a/apps/backend/internal/events/bus/bus.go
+++ b/apps/backend/internal/events/bus/bus.go
@@ -16,11 +16,16 @@ type Event struct {
 	// by EventBus.Publish. It is NOT always equal to Type: many per-session
 	// (and per-run) events are published on a suffixed subject while Type
 	// stays the bare event constant — e.g. Type "shell.output" published on
-	// subject "shell.output.<sessionId>". Subscribers that need to know
-	// which concrete subject matched (the plugin deliverer, which re-checks
-	// the subscriber's manifest pattern) must read Subject, not Type. Use
-	// EffectiveSubject to read it with a Type fallback for events that
-	// predate the stamping (or were constructed by hand in a test).
+	// subject "shell.output.<sessionId>". A few carry an unrelated type
+	// entirely (three git.ws publish sites in the orchestrator stamp
+	// "git.event"). Subscribers that need to know which concrete subject
+	// matched (the plugin deliverer, which re-checks the subscriber's
+	// manifest pattern) must read Subject, not Type. Use EffectiveSubject to
+	// read it with a Type fallback for events that predate the stamping (or
+	// were constructed by hand in a test).
+	//
+	// Because Publish stamps this in place, a single *Event must not be
+	// published to more than one subject concurrently — see EventBus.Publish.
 	Subject   string      `json:"subject,omitempty"`
 	Source    string      `json:"source"` // Service that produced the event
 	Timestamp time.Time   `json:"timestamp"`
@@ -65,7 +70,15 @@ type Subscription interface {
 
 // EventBus interface for event bus operations
 type EventBus interface {
-	// Publish sends an event to a subject
+	// Publish sends an event to a subject.
+	//
+	// Implementations stamp subject onto event.Subject in place before
+	// dispatching, so callers must not share one *Event across concurrent
+	// Publish calls on different subjects — build a fresh Event per publish
+	// (which every call site does today). Publishing the same pointer to
+	// several subjects sequentially is fine: the memory bus dispatches its
+	// handlers synchronously inside Publish, so each handler observes the
+	// subject it was published on.
 	Publish(ctx context.Context, subject string, event *Event) error
 
 	// Subscribe creates a subscription to a subject pattern

--- a/apps/backend/internal/events/bus/memory.go
+++ b/apps/backend/internal/events/bus/memory.go
@@ -93,13 +93,21 @@ func NewMemoryEventBus(log *logger.Logger) *MemoryEventBus {
 	}
 }
 
-// Publish sends an event to all matching subscribers
+// Publish sends an event to all matching subscribers.
+//
+// The concrete subject is stamped onto event.Subject before dispatch so
+// handlers can tell which subject actually matched — event.Type alone is
+// not enough for the per-session/per-run suffixed subjects (see Event.Subject).
 func (b *MemoryEventBus) Publish(ctx context.Context, subject string, event *Event) error {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
 
 	if b.closed {
 		return fmt.Errorf("event bus is closed")
+	}
+
+	if event != nil {
+		event.Subject = subject
 	}
 
 	// Track which queue groups we've already delivered to

--- a/apps/backend/internal/events/bus/memory_test.go
+++ b/apps/backend/internal/events/bus/memory_test.go
@@ -702,3 +702,66 @@ func TestMemoryEventBus_QueueMessageOrdering(t *testing.T) {
 		}
 	}
 }
+
+// TestMemoryEventBus_PublishStampsSubject pins the contract the plugin
+// deliverer depends on: the concrete subject an event was published on is
+// stamped onto the event, even when it differs from event.Type (which is
+// exactly the per-session case, e.g. type "shell.output" on subject
+// "shell.output.<sessionId>").
+func TestMemoryEventBus_PublishStampsSubject(t *testing.T) {
+	eventBus := NewMemoryEventBus(newTestLogger(t))
+	defer eventBus.Close()
+
+	receivedCh := make(chan *Event, 1)
+	sub, err := eventBus.Subscribe("shell.output.*", func(_ context.Context, e *Event) error {
+		receivedCh <- e
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	defer func() { _ = sub.Unsubscribe() }()
+
+	ev := NewEvent("shell.output", "test", map[string]interface{}{})
+	if ev.Subject != "" {
+		t.Errorf("NewEvent should not set Subject, got %q", ev.Subject)
+	}
+	if err := eventBus.Publish(context.Background(), "shell.output.sess-1", ev); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+
+	select {
+	case got := <-receivedCh:
+		if got.Subject != "shell.output.sess-1" {
+			t.Errorf("Subject = %q, want shell.output.sess-1", got.Subject)
+		}
+		if got.Type != "shell.output" {
+			t.Errorf("Type = %q, want the unchanged bare type shell.output", got.Type)
+		}
+		if got.EffectiveSubject() != "shell.output.sess-1" {
+			t.Errorf("EffectiveSubject() = %q, want shell.output.sess-1", got.EffectiveSubject())
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for the event")
+	}
+}
+
+func TestEvent_EffectiveSubject(t *testing.T) {
+	cases := []struct {
+		name  string
+		event *Event
+		want  string
+	}{
+		{"nil event", nil, ""},
+		{"stamped subject wins", &Event{Type: "shell.output", Subject: "shell.output.sess-1"}, "shell.output.sess-1"},
+		{"falls back to type", &Event{Type: "task.created"}, "task.created"},
+		{"empty both", &Event{}, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.event.EffectiveSubject(); got != tc.want {
+				t.Errorf("EffectiveSubject() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/apps/backend/internal/events/bus/nats.go
+++ b/apps/backend/internal/events/bus/nats.go
@@ -70,8 +70,15 @@ func NewNATSEventBus(cfg config.NATSConfig, log *logger.Logger) (*NATSEventBus, 
 	return bus, nil
 }
 
-// Publish sends an event to a subject
+// Publish sends an event to a subject.
+//
+// The concrete subject is stamped onto event.Subject before marshaling so it
+// survives the wire hop — see Event.Subject.
 func (b *NATSEventBus) Publish(ctx context.Context, subject string, event *Event) error {
+	if event != nil {
+		event.Subject = subject
+	}
+
 	data, err := json.Marshal(event)
 	if err != nil {
 		return fmt.Errorf("failed to marshal event: %w", err)
@@ -131,6 +138,11 @@ func (b *NATSEventBus) createMsgHandler(handler EventHandler) nats.MsgHandler {
 			)
 			return
 		}
+
+		// The delivering subject is authoritative on the receive side (a
+		// wildcard subscription resolves to the concrete subject here), so
+		// prefer it over whatever the publisher marshaled.
+		event.Subject = msg.Subject
 
 		ctx := context.Background()
 		if err := handler(ctx, &event); err != nil {

--- a/apps/backend/internal/events/bus/nats_test.go
+++ b/apps/backend/internal/events/bus/nats_test.go
@@ -98,11 +98,14 @@ func TestNATSPublish_StampsSubject(t *testing.T) {
 	ev := NewEvent("shell.output", "test", map[string]interface{}{})
 
 	b := &NATSEventBus{logger: newTestLogger(t)}
-	// conn is nil, so Publish fails at the connection hop — the stamping
-	// happens before that and is what this test asserts.
-	_ = func() (err error) {
+	// No server here, so conn is nil and the send hop (b.conn.Publish) panics
+	// on the nil dereference. The recover is deliberate: stamping happens
+	// before the marshal/send, so the assertion below still holds, and if the
+	// implementation were ever rearranged to stamp after sending, this test
+	// would fail rather than silently pass.
+	func() {
 		defer func() { _ = recover() }()
-		return b.Publish(context.Background(), "shell.output.sess-1", ev)
+		_ = b.Publish(context.Background(), "shell.output.sess-1", ev)
 	}()
 
 	if ev.Subject != "shell.output.sess-1" {

--- a/apps/backend/internal/events/bus/nats_test.go
+++ b/apps/backend/internal/events/bus/nats_test.go
@@ -1,0 +1,114 @@
+package bus
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go"
+)
+
+// TestNATSCreateMsgHandler_MessageSubjectIsAuthoritative pins the receive-side
+// half of the Subject contract: a wildcard NATS subscription resolves to the
+// concrete subject only in msg.Subject, so the handler must overwrite whatever
+// Subject the publisher marshaled (stale, forged, or absent) with it, while
+// leaving the rest of the event as published.
+//
+// createMsgHandler is exercised directly — it never touches the connection, so
+// this needs no NATS server.
+func TestNATSCreateMsgHandler_MessageSubjectIsAuthoritative(t *testing.T) {
+	published := &Event{
+		ID:        "evt-1",
+		Type:      "shell.output",
+		Subject:   "shell.output.forged-session",
+		Source:    "test",
+		Timestamp: time.Unix(1700000000, 0).UTC(),
+		Data:      map[string]interface{}{"chunk": "hello"},
+	}
+	data, err := json.Marshal(published)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	receivedCh := make(chan *Event, 1)
+	b := &NATSEventBus{logger: newTestLogger(t)}
+	handler := b.createMsgHandler(func(_ context.Context, e *Event) error {
+		receivedCh <- e
+		return nil
+	})
+
+	handler(&nats.Msg{Subject: "shell.output.sess-1", Data: data})
+
+	select {
+	case got := <-receivedCh:
+		if got.Subject != "shell.output.sess-1" {
+			t.Errorf("Subject = %q, want the delivering msg.Subject shell.output.sess-1", got.Subject)
+		}
+		if got.EffectiveSubject() != "shell.output.sess-1" {
+			t.Errorf("EffectiveSubject() = %q, want shell.output.sess-1", got.EffectiveSubject())
+		}
+		if got.Type != "shell.output" {
+			t.Errorf("Type = %q, want the unchanged published type shell.output", got.Type)
+		}
+		if got.ID != "evt-1" || got.Source != "test" {
+			t.Errorf("ID/Source = %q/%q, want evt-1/test", got.ID, got.Source)
+		}
+		payload, ok := got.Data.(map[string]interface{})
+		if !ok || payload["chunk"] != "hello" {
+			t.Errorf("Data = %#v, want the published payload", got.Data)
+		}
+	default:
+		t.Fatal("handler did not invoke the EventHandler")
+	}
+}
+
+// TestNATSCreateMsgHandler_StampsSubjectOnUnstampedEvent covers an event
+// marshaled by a publisher that predates Subject stamping: the concrete
+// message subject is still applied on arrival.
+func TestNATSCreateMsgHandler_StampsSubjectOnUnstampedEvent(t *testing.T) {
+	data, err := json.Marshal(&Event{ID: "evt-2", Type: "task.created", Source: "test"})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	receivedCh := make(chan *Event, 1)
+	b := &NATSEventBus{logger: newTestLogger(t)}
+	handler := b.createMsgHandler(func(_ context.Context, e *Event) error {
+		receivedCh <- e
+		return nil
+	})
+
+	handler(&nats.Msg{Subject: "task.created", Data: data})
+
+	select {
+	case got := <-receivedCh:
+		if got.Subject != "task.created" {
+			t.Errorf("Subject = %q, want task.created", got.Subject)
+		}
+	default:
+		t.Fatal("handler did not invoke the EventHandler")
+	}
+}
+
+// TestNATSPublish_StampsSubject pins the send side: Publish stamps the concrete
+// subject onto the event so it survives the marshal/wire hop (the receive side
+// then re-applies the delivering subject on top).
+func TestNATSPublish_StampsSubject(t *testing.T) {
+	ev := NewEvent("shell.output", "test", map[string]interface{}{})
+
+	b := &NATSEventBus{logger: newTestLogger(t)}
+	// conn is nil, so Publish fails at the connection hop — the stamping
+	// happens before that and is what this test asserts.
+	_ = func() (err error) {
+		defer func() { _ = recover() }()
+		return b.Publish(context.Background(), "shell.output.sess-1", ev)
+	}()
+
+	if ev.Subject != "shell.output.sess-1" {
+		t.Errorf("Subject = %q, want shell.output.sess-1", ev.Subject)
+	}
+	if ev.Type != "shell.output" {
+		t.Errorf("Type = %q, want the unchanged bare type shell.output", ev.Type)
+	}
+}

--- a/apps/backend/internal/plugins/delivery/deliverer.go
+++ b/apps/backend/internal/plugins/delivery/deliverer.go
@@ -306,20 +306,36 @@ func (d *Deliverer) resubscribe(w *pluginWorker, rec PluginRecord) {
 
 // makeHandler builds the bus.EventHandler that turns a matching event into
 // a Delivery and enqueues it on w. pattern is re-checked against the
-// concrete event type via manifest.MatchSubject — the same matcher plugin
-// capabilities use elsewhere — so delivery is governed by one wildcard
-// semantics regardless of the underlying EventBus's own subscription
-// matching behavior.
+// concrete subject the event was published on via manifest.MatchSubject —
+// the same matcher plugin capabilities use elsewhere — so delivery is
+// governed by one wildcard semantics regardless of the underlying
+// EventBus's own subscription matching behavior (the memory/NATS buses also
+// honor NATS' multi-segment ">" wildcard, which manifest patterns do not).
+//
+// The re-check reads bus.Event.EffectiveSubject(), NOT event.Type: per-session
+// and per-run events are published on a suffixed subject
+// ("shell.output.<sessionId>") while event.Type stays the bare constant
+// ("shell.output"). Matching the pattern against Type made every such
+// subject undeliverable — a 3-segment pattern subscribed successfully but
+// then failed the re-check on segment count, and a 2-segment pattern passed
+// the re-check but never subscribed to the 3-segment subject.
+//
+// The concrete subject is also what the plugin receives as
+// pluginsdk.Event.EventType (documented in the proto as "bus subject"), so a
+// plugin subscribed to "shell.output.*" can read the session id off it. For
+// every unsuffixed subject the subject and the type are identical, so
+// existing 2-segment subscriptions see exactly what they saw before.
 func (d *Deliverer) makeHandler(w *pluginWorker, pattern string) bus.EventHandler {
 	return func(_ context.Context, event *bus.Event) error {
-		if !manifest.MatchSubject(pattern, event.Type) {
+		subject := event.EffectiveSubject()
+		if !manifest.MatchSubject(pattern, subject) {
 			return nil
 		}
 
 		payload, err := dataToMap(event.Data)
 		if err != nil {
 			d.log.Error("plugin delivery: failed to convert event payload",
-				zap.String("plugin_id", w.id), zap.String("event_type", event.Type), zap.Error(err))
+				zap.String("plugin_id", w.id), zap.String("event_type", subject), zap.Error(err))
 			return nil
 		}
 
@@ -327,7 +343,7 @@ func (d *Deliverer) makeHandler(w *pluginWorker, pattern string) bus.EventHandle
 			PluginID: w.id,
 			Event: &pluginsdk.Event{
 				EventID:     uuid.New().String(),
-				EventType:   event.Type,
+				EventType:   subject,
 				OccurredAt:  d.nowFn().UTC().Format(time.RFC3339),
 				WorkspaceID: workspaceIDFromData(event.Data),
 				Payload:     payload,

--- a/apps/backend/internal/plugins/delivery/deliverer_test.go
+++ b/apps/backend/internal/plugins/delivery/deliverer_test.go
@@ -442,15 +442,17 @@ func TestDeliverer_RefreshReturnsPromptlyDuringInFlightDelivery(t *testing.T) {
 	close(released)
 }
 
-// publishForPattern subscribes a single plugin with pattern, publishes one
-// event on subject stamped with eventType (mirroring how kandev publishes
-// per-session events: a suffixed subject carrying the bare type constant),
-// and returns the delivered pluginsdk.Event or nil if nothing was delivered
-// within window.
-func publishForPattern(t *testing.T, pattern, subject, eventType string, window time.Duration) *pluginsdk.Event {
+// barrierSubject is the control subject the negative-delivery assertions
+// publish on after the event under test — see assertNotDelivered.
+const barrierSubject = "delivery_test.barrier"
+
+// newSubjectFixture wires a Deliverer with a single plugin subscribed to
+// pattern (plus the barrier subject used by assertNotDelivered) and returns
+// the bus plus the channel every delivered event lands on.
+func newSubjectFixture(t *testing.T, pattern string) (bus.EventBus, <-chan *pluginsdk.Event) {
 	t.Helper()
 
-	receivedCh := make(chan *pluginsdk.Event, 1)
+	receivedCh := make(chan *pluginsdk.Event, 4)
 	transport := &fakeTransport{}
 	transport.setHandler(func(_ string, e *pluginsdk.Event) error {
 		receivedCh <- e
@@ -459,21 +461,59 @@ func publishForPattern(t *testing.T, pattern, subject, eventType string, window 
 
 	eventBus := bus.NewMemoryEventBus(logger.Default())
 	lister := &fakeLister{}
-	lister.set(PluginRecord{ID: "plug1", EventSubjects: []string{pattern}, Status: store.StatusActive})
+	lister.set(PluginRecord{
+		ID:            "plug1",
+		EventSubjects: []string{pattern, barrierSubject},
+		Status:        store.StatusActive,
+	})
 
 	d := newTestDeliverer(t, eventBus, transport, lister)
 	d.Refresh()
 
+	return eventBus, receivedCh
+}
+
+// publishSubject publishes one event on subject stamped with eventType,
+// mirroring how kandev publishes per-session events: a suffixed subject
+// carrying the bare type constant.
+func publishSubject(t *testing.T, eventBus bus.EventBus, subject, eventType string) {
+	t.Helper()
 	ev := bus.NewEvent(eventType, "test", map[string]interface{}{"session_id": "sess-1"})
 	if err := eventBus.Publish(context.Background(), subject, ev); err != nil {
-		t.Fatalf("Publish: %v", err)
+		t.Fatalf("Publish(%s): %v", subject, err)
 	}
+}
 
-	select {
-	case got := <-receivedCh:
-		return got
-	case <-time.After(window):
-		return nil
+// publishForPattern subscribes a single plugin with pattern, publishes one
+// event on subject, and returns the delivered pluginsdk.Event (failing the
+// test if nothing arrives). Only used for the positive cases, so it never
+// waits out its timeout on a passing run.
+func publishForPattern(t *testing.T, pattern, subject, eventType string) *pluginsdk.Event {
+	t.Helper()
+
+	eventBus, receivedCh := newSubjectFixture(t, pattern)
+	publishSubject(t, eventBus, subject, eventType)
+
+	return requireNoTimeout(t, receivedCh, 2*time.Second,
+		fmt.Sprintf("delivery of %s to pattern %s", subject, pattern))
+}
+
+// assertNotDelivered asserts pattern does not receive an event published on
+// subject, without waiting out a wall clock window: after the event under
+// test it publishes a control event on barrierSubject, which the same plugin
+// also subscribes to. The memory bus enqueues synchronously inside Publish
+// and the worker drains its single queue in FIFO order, so the barrier
+// arriving first is proof the event under test was never enqueued.
+func assertNotDelivered(t *testing.T, pattern, subject, eventType string) {
+	t.Helper()
+
+	eventBus, receivedCh := newSubjectFixture(t, pattern)
+	publishSubject(t, eventBus, subject, eventType)
+	publishSubject(t, eventBus, barrierSubject, barrierSubject)
+
+	got := requireNoTimeout(t, receivedCh, 2*time.Second, "barrier delivery")
+	if got.EventType != barrierSubject {
+		t.Fatalf("pattern %q must not receive subject %q, got EventType %q", pattern, subject, got.EventType)
 	}
 }
 
@@ -486,11 +526,7 @@ func TestDeliverer_DeliversPerSessionSuffixedSubject(t *testing.T) {
 	got := publishForPattern(t,
 		"session_prompt_usage.updated.*",
 		"session_prompt_usage.updated.sess-1",
-		"session_prompt_usage.updated",
-		2*time.Second)
-	if got == nil {
-		t.Fatal("no delivery for a 3-segment wildcard subscription to a per-session subject")
-	}
+		"session_prompt_usage.updated")
 	if got.EventType != "session_prompt_usage.updated.sess-1" {
 		t.Errorf("EventType = %q, want the concrete published subject session_prompt_usage.updated.sess-1", got.EventType)
 	}
@@ -532,10 +568,7 @@ func TestDeliverer_PerSessionSubjectFamilies(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.pattern, func(t *testing.T) {
-			got := publishForPattern(t, tc.pattern, tc.subject, tc.eventType, 2*time.Second)
-			if got == nil {
-				t.Fatalf("no delivery for pattern %q on subject %q", tc.pattern, tc.subject)
-			}
+			got := publishForPattern(t, tc.pattern, tc.subject, tc.eventType)
 			if got.EventType != tc.subject {
 				t.Errorf("EventType = %q, want %q", got.EventType, tc.subject)
 			}
@@ -562,10 +595,7 @@ func TestDeliverer_UnsuffixedSubscriptionsUnchanged(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := publishForPattern(t, tc.pattern, tc.subject, tc.subject, 2*time.Second)
-			if got == nil {
-				t.Fatalf("no delivery for pattern %q on subject %q", tc.pattern, tc.subject)
-			}
+			got := publishForPattern(t, tc.pattern, tc.subject, tc.subject)
 			if got.EventType != tc.subject {
 				t.Errorf("EventType = %q, want %q", got.EventType, tc.subject)
 			}
@@ -595,9 +625,7 @@ func TestDeliverer_SegmentCountStrictnessPreserved(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := publishForPattern(t, tc.pattern, tc.subject, tc.subject, 150*time.Millisecond); got != nil {
-				t.Fatalf("pattern %q must not receive subject %q, got EventType %q", tc.pattern, tc.subject, got.EventType)
-			}
+			assertNotDelivered(t, tc.pattern, tc.subject, tc.subject)
 		})
 	}
 }
@@ -605,13 +633,7 @@ func TestDeliverer_SegmentCountStrictnessPreserved(t *testing.T) {
 // TestDeliverer_WrongSessionSuffixNotDelivered checks a literal session id in
 // the pattern only receives that session's events.
 func TestDeliverer_WrongSessionSuffixNotDelivered(t *testing.T) {
-	if got := publishForPattern(t,
-		"shell.output.sess-other",
-		"shell.output.sess-1",
-		"shell.output",
-		150*time.Millisecond); got != nil {
-		t.Fatalf("delivered another session's event: %q", got.EventType)
-	}
+	assertNotDelivered(t, "shell.output.sess-other", "shell.output.sess-1", "shell.output")
 }
 
 // TestDeliverer_UnstampedEventFallsBackToType covers an Event handed to the

--- a/apps/backend/internal/plugins/delivery/deliverer_test.go
+++ b/apps/backend/internal/plugins/delivery/deliverer_test.go
@@ -576,6 +576,22 @@ func TestDeliverer_PerSessionSubjectFamilies(t *testing.T) {
 	}
 }
 
+// TestDeliverer_SubjectUnrelatedToTypeIsDelivered covers the one shape where
+// the published subject is not even a suffixed form of the event's own type:
+// handleGitCommitCreated / handleGitCommitsReset / handleBranchSwitched in the
+// orchestrator publish on git.ws.<sessionId> while stamping events.GitEvent
+// ("git.event"). Matching on the subject makes these deliverable under
+// "git.ws.*"; matching on the type could never have delivered them at all.
+func TestDeliverer_SubjectUnrelatedToTypeIsDelivered(t *testing.T) {
+	got := publishForPattern(t, "git.ws.*", "git.ws.sess-1", "git.event")
+	if got.EventType != "git.ws.sess-1" {
+		t.Errorf("EventType = %q, want the concrete published subject git.ws.sess-1", got.EventType)
+	}
+
+	// ...and the type it carries must not make it match that type's pattern.
+	assertNotDelivered(t, "git.event.*", "git.ws.sess-1", "git.event")
+}
+
 // TestDeliverer_UnsuffixedSubscriptionsUnchanged pins the backward-compatible
 // half: subjects published unsuffixed have subject == type, so both exact
 // and wildcard 2-segment subscriptions still match and still see the same

--- a/apps/backend/internal/plugins/delivery/deliverer_test.go
+++ b/apps/backend/internal/plugins/delivery/deliverer_test.go
@@ -441,3 +441,234 @@ func TestDeliverer_RefreshReturnsPromptlyDuringInFlightDelivery(t *testing.T) {
 	}
 	close(released)
 }
+
+// publishForPattern subscribes a single plugin with pattern, publishes one
+// event on subject stamped with eventType (mirroring how kandev publishes
+// per-session events: a suffixed subject carrying the bare type constant),
+// and returns the delivered pluginsdk.Event or nil if nothing was delivered
+// within window.
+func publishForPattern(t *testing.T, pattern, subject, eventType string, window time.Duration) *pluginsdk.Event {
+	t.Helper()
+
+	receivedCh := make(chan *pluginsdk.Event, 1)
+	transport := &fakeTransport{}
+	transport.setHandler(func(_ string, e *pluginsdk.Event) error {
+		receivedCh <- e
+		return nil
+	})
+
+	eventBus := bus.NewMemoryEventBus(logger.Default())
+	lister := &fakeLister{}
+	lister.set(PluginRecord{ID: "plug1", EventSubjects: []string{pattern}, Status: store.StatusActive})
+
+	d := newTestDeliverer(t, eventBus, transport, lister)
+	d.Refresh()
+
+	ev := bus.NewEvent(eventType, "test", map[string]interface{}{"session_id": "sess-1"})
+	if err := eventBus.Publish(context.Background(), subject, ev); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+
+	select {
+	case got := <-receivedCh:
+		return got
+	case <-time.After(window):
+		return nil
+	}
+}
+
+// TestDeliverer_DeliversPerSessionSuffixedSubject is the regression test for
+// the catch-22 that made every per-session-suffixed subject undeliverable:
+// the event is published on a 3-segment subject but stamped with the bare
+// 2-segment type constant, so re-checking the manifest pattern against
+// event.Type dropped it after the bus subscription had already matched.
+func TestDeliverer_DeliversPerSessionSuffixedSubject(t *testing.T) {
+	got := publishForPattern(t,
+		"session_prompt_usage.updated.*",
+		"session_prompt_usage.updated.sess-1",
+		"session_prompt_usage.updated",
+		2*time.Second)
+	if got == nil {
+		t.Fatal("no delivery for a 3-segment wildcard subscription to a per-session subject")
+	}
+	if got.EventType != "session_prompt_usage.updated.sess-1" {
+		t.Errorf("EventType = %q, want the concrete published subject session_prompt_usage.updated.sess-1", got.EventType)
+	}
+	if got.Payload["session_id"] != "sess-1" {
+		t.Errorf("Payload[session_id] = %v, want sess-1", got.Payload["session_id"])
+	}
+}
+
+// TestDeliverer_PerSessionSubjectFamilies covers the rest of the suffixed
+// subject families the docs advertise as subscribable, including the
+// 3-segment base type file.change.notified (whose per-session subject has
+// four segments) and the per-run office subject.
+func TestDeliverer_PerSessionSubjectFamilies(t *testing.T) {
+	cases := []struct {
+		pattern   string
+		subject   string
+		eventType string
+	}{
+		{"shell.output.*", "shell.output.sess-1", "shell.output"},
+		{"shell.exit.*", "shell.exit.sess-1", "shell.exit"},
+		{"process.output.*", "process.output.sess-1", "process.output"},
+		{"process.status.*", "process.status.sess-1", "process.status"},
+		{"agent.stream.*", "agent.stream.sess-1", "agent.stream"},
+		{"git.event.*", "git.event.sess-1", "git.event"},
+		{"git.ws.*", "git.ws.sess-1", "git.ws"},
+		{"file.change.notified.*", "file.change.notified.sess-1", "file.change.notified"},
+		{"permission_request.received.*", "permission_request.received.sess-1", "permission_request.received"},
+		{"context_window.updated.*", "context_window.updated.sess-1", "context_window.updated"},
+		{"available_commands.updated.*", "available_commands.updated.sess-1", "available_commands.updated"},
+		{"session_mode.changed.*", "session_mode.changed.sess-1", "session_mode.changed"},
+		{"agent_capabilities.updated.*", "agent_capabilities.updated.sess-1", "agent_capabilities.updated"},
+		{"session_models.updated.*", "session_models.updated.sess-1", "session_models.updated"},
+		{"session_info.updated.*", "session_info.updated.sess-1", "session_info.updated"},
+		{"session_todos.updated.*", "session_todos.updated.sess-1", "session_todos.updated"},
+		// office.run.event_appended already publishes with Type == subject;
+		// it must keep working now that the subject is what gets matched.
+		{"office.run.event_appended.*", "office.run.event_appended.run-1", "office.run.event_appended.run-1"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.pattern, func(t *testing.T) {
+			got := publishForPattern(t, tc.pattern, tc.subject, tc.eventType, 2*time.Second)
+			if got == nil {
+				t.Fatalf("no delivery for pattern %q on subject %q", tc.pattern, tc.subject)
+			}
+			if got.EventType != tc.subject {
+				t.Errorf("EventType = %q, want %q", got.EventType, tc.subject)
+			}
+		})
+	}
+}
+
+// TestDeliverer_UnsuffixedSubscriptionsUnchanged pins the backward-compatible
+// half: subjects published unsuffixed have subject == type, so both exact
+// and wildcard 2-segment subscriptions still match and still see the same
+// EventType they saw before.
+func TestDeliverer_UnsuffixedSubscriptionsUnchanged(t *testing.T) {
+	cases := []struct {
+		name    string
+		pattern string
+		subject string
+	}{
+		{"exact", "task.created", "task.created"},
+		{"wildcard", "task.*", "task.created"},
+		{"three segment exact", "message.queue.status_changed", "message.queue.status_changed"},
+		{"three segment wildcard", "message.queue.*", "message.queue.status_changed"},
+		{"cross plugin wildcard", "plugin.other-plugin.*", "plugin.other-plugin.ping"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := publishForPattern(t, tc.pattern, tc.subject, tc.subject, 2*time.Second)
+			if got == nil {
+				t.Fatalf("no delivery for pattern %q on subject %q", tc.pattern, tc.subject)
+			}
+			if got.EventType != tc.subject {
+				t.Errorf("EventType = %q, want %q", got.EventType, tc.subject)
+			}
+		})
+	}
+}
+
+// TestDeliverer_SegmentCountStrictnessPreserved proves the manifest re-check
+// still governs delivery after switching it to the concrete subject: NATS'
+// multi-segment ">" wildcard (which the underlying bus honors, and which
+// manifest.MatchSubject deliberately does not) must not deliver, and neither
+// must a pattern whose segment count differs from the subject's.
+func TestDeliverer_SegmentCountStrictnessPreserved(t *testing.T) {
+	cases := []struct {
+		name    string
+		pattern string
+		subject string
+	}{
+		// The bus subscription matches ">" but manifest.MatchSubject does not.
+		{"multi segment nats wildcard", "shell.>", "shell.output.sess-1"},
+		{"multi segment nats wildcard on unsuffixed", "task.>", "task.created"},
+		// Too few pattern segments for the subject.
+		{"two segment pattern vs three segment subject", "shell.*", "shell.output.sess-1"},
+		// Too many pattern segments for the subject.
+		{"three segment pattern vs two segment subject", "task.created.*", "task.created"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := publishForPattern(t, tc.pattern, tc.subject, tc.subject, 150*time.Millisecond); got != nil {
+				t.Fatalf("pattern %q must not receive subject %q, got EventType %q", tc.pattern, tc.subject, got.EventType)
+			}
+		})
+	}
+}
+
+// TestDeliverer_WrongSessionSuffixNotDelivered checks a literal session id in
+// the pattern only receives that session's events.
+func TestDeliverer_WrongSessionSuffixNotDelivered(t *testing.T) {
+	if got := publishForPattern(t,
+		"shell.output.sess-other",
+		"shell.output.sess-1",
+		"shell.output",
+		150*time.Millisecond); got != nil {
+		t.Fatalf("delivered another session's event: %q", got.EventType)
+	}
+}
+
+// TestDeliverer_UnstampedEventFallsBackToType covers an Event handed to the
+// handler without going through Publish (no Subject stamped): matching falls
+// back to event.Type so nothing regresses for a bus implementation or test
+// that constructs deliveries by hand.
+func TestDeliverer_UnstampedEventFallsBackToType(t *testing.T) {
+	receivedCh := make(chan *pluginsdk.Event, 1)
+	transport := &fakeTransport{}
+	transport.setHandler(func(_ string, e *pluginsdk.Event) error {
+		receivedCh <- e
+		return nil
+	})
+
+	lister := &fakeLister{}
+	lister.set(PluginRecord{ID: "plug1", EventSubjects: []string{"task.*"}, Status: store.StatusActive})
+
+	captureBus := &handlerCapturingBus{MemoryEventBus: bus.NewMemoryEventBus(logger.Default())}
+	d := newTestDeliverer(t, captureBus, transport, lister)
+	d.Refresh()
+
+	handler := captureBus.handlerFor("task.*")
+	if handler == nil {
+		t.Fatal("deliverer did not subscribe to task.*")
+	}
+	// No Subject field: straight to the handler, as an unstamped event.
+	if err := handler(context.Background(), &bus.Event{ID: "e1", Type: "task.created"}); err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+
+	got := requireNoTimeout(t, receivedCh, 2*time.Second, "event delivery")
+	if got.EventType != "task.created" {
+		t.Errorf("EventType = %q, want task.created", got.EventType)
+	}
+}
+
+// handlerCapturingBus records the handler registered for each subscription
+// pattern so a test can invoke it directly with a hand-built Event.
+type handlerCapturingBus struct {
+	*bus.MemoryEventBus
+
+	mu       sync.Mutex
+	handlers map[string]bus.EventHandler
+}
+
+func (b *handlerCapturingBus) Subscribe(subject string, handler bus.EventHandler) (bus.Subscription, error) {
+	b.mu.Lock()
+	if b.handlers == nil {
+		b.handlers = make(map[string]bus.EventHandler)
+	}
+	b.handlers[subject] = handler
+	b.mu.Unlock()
+	return b.MemoryEventBus.Subscribe(subject, handler)
+}
+
+func (b *handlerCapturingBus) handlerFor(subject string) bus.EventHandler {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.handlers[subject]
+}

--- a/docs/public/plugins-manifest.md
+++ b/docs/public/plugins-manifest.md
@@ -205,6 +205,12 @@ area. The table below groups every subject defined in
 e.g. `shell.output.<sessionId>`, `git.event.<sessionId>` — subscribe to the
 literal wildcard segment count that matches, e.g. `shell.output.*`).
 
+A delivered event's `event_type` (`pluginsdk.Event.EventType`) is the
+**concrete subject it was published on**, i.e. the same string your pattern
+matched — so a plugin subscribed to `shell.output.*` reads the session id off
+`event_type` as its last segment. For an unsuffixed subject that string is
+just the subject itself (`task.created`).
+
 | Domain | Events |
 |---|---|
 | Tasks | `task.created`, `task.updated`, `task.state_changed`, `task.deleted`, `task.moved`, `task.tree_hold_created`, `task.tree_hold_released` |


### PR DESCRIPTION
## The bug

Per-session events are published on a **suffixed** bus subject but stamped with the **bare** event-type constant. For example `apps/backend/internal/orchestrator/event_handlers_streaming.go`:

```go
subject := events.BuildSessionPromptUsageSubject(sessionID) // "session_prompt_usage.updated.<sessionId>"
_ = s.eventBus.Publish(ctx, subject, bus.NewEvent(events.SessionPromptUsageUpdated /* "session_prompt_usage.updated" */, "orchestrator", eventPayload))
```

The plugin deliverer subscribes to the bus with the plugin's manifest pattern and then **re-checks that pattern against `event.Type`** (`internal/plugins/delivery/deliverer.go`, `makeHandler`). Since `manifest.MatchSubject` requires pattern and subject to have the same segment count, this was a catch-22 — no manifest pattern could ever receive one of these events:

| Manifest pattern | Bus subscription fires? | Passes `MatchSubject(pattern, event.Type)`? | Delivered? |
|---|---|---|---|
| `session_prompt_usage.updated.*` | ✅ (3 vs 3 segments) | ❌ (3 vs 2 segments) | **no** |
| `session_prompt_usage.updated` | ❌ (2 vs 3 segments) | ✅ | **no** |

`docs/public/plugins-manifest.md` has advertised these as subscribable (`shell.output.*`, etc.) the whole time, so the docs described the intended behavior and the code never implemented it.

## Audit — every subject published with a suffixed subject

Checked all 109 `EventBus.Publish` call sites. Only these publish on a subject that is not the event's own `Type`. All but three are a per-session or per-run suffix of that type; the three exceptions are called out in the `git.ws` row (thanks @claude for catching that my first version of this table got them wrong).

| Subject family | Published on | `event.Type` | Affected | Publish site |
|---|---|---|---|---|
| `shell.output` | `shell.output.<sessionId>` | `shell.output` | ✅ fixed | `runtime/lifecycle/events.go:427` |
| `shell.exit` | `shell.exit.<sessionId>` | `shell.exit` | ✅ fixed | `runtime/lifecycle/events.go:456` |
| `process.output` | `process.output.<sessionId>` | `process.output` | ✅ fixed | `runtime/lifecycle/events.go:484` |
| `process.status` | `process.status.<sessionId>` | `process.status` | ✅ fixed | `runtime/lifecycle/events.go:514` |
| `agent.stream` | `agent.stream.<sessionId>` | `agent.stream` | ✅ fixed | `runtime/lifecycle/events.go:196`, `:215` |
| `git.event` | `git.event.<sessionId>` | `git.event` | ✅ fixed | `runtime/lifecycle/events.go:236` |
| `git.ws` | `git.ws.<sessionId>` | `git.ws` at `:151`; **`git.event`** at `:557`, `:589`, `:658` | ✅ fixed | `orchestrator/event_handlers_git.go:151`, `:557`, `:589`, `:658` |
| `file.change.notified` | `file.change.notified.<sessionId>` (4 segments) | `file.change.notified` | ✅ fixed | `runtime/lifecycle/events.go:350` |
| `permission_request.received` | `permission_request.received.<sessionId>` | `permission_request.received` | ✅ fixed | `runtime/lifecycle/events.go:392` |
| `context_window.updated` | `context_window.updated.<sessionId>` | `context_window.updated` | ✅ fixed | `runtime/lifecycle/events.go:543` |
| `available_commands.updated` | `available_commands.updated.<sessionId>` | `available_commands.updated` | ✅ fixed | `runtime/lifecycle/events.go:571`, `orchestrator/event_handlers_streaming.go:2284` |
| `session_mode.changed` | `session_mode.changed.<sessionId>` | `session_mode.changed` | ✅ fixed | `orchestrator/event_handlers_streaming.go:2311` |
| `agent_capabilities.updated` | `agent_capabilities.updated.<sessionId>` | `agent_capabilities.updated` | ✅ fixed | `orchestrator/event_handlers_streaming.go:2347` |
| `session_models.updated` | `session_models.updated.<sessionId>` | `session_models.updated` | ✅ fixed | `orchestrator/event_handlers_streaming.go:2389` |
| `session_info.updated` | `session_info.updated.<sessionId>` | `session_info.updated` | ✅ fixed | `orchestrator/event_handlers_streaming.go:2216` |
| `session_todos.updated` | `session_todos.updated.<sessionId>` | `session_todos.updated` | ✅ fixed | `orchestrator/event_handlers_streaming.go:2636` |
| `session_prompt_usage.updated` | `session_prompt_usage.updated.<sessionId>` | `session_prompt_usage.updated` | ✅ fixed | `orchestrator/event_handlers_streaming.go:2068` |

Suffixed subjects that were **already correct** (they stamp `Type` with the full subject, so they were deliverable before this PR and still are):

| Subject | Why it was fine | Publish site |
|---|---|---|
| `office.run.event_appended.<runId>` | `bus.NewEvent(subject, …)` | `office/service/activity.go:116`, `office/testharness/routes_office.go:563` |
| `task.tree_hold_created` / `task.tree_hold_released` | `bus.NewEvent(subject, …)` | `office/service/tree_controls.go:219` |
| `plugin.<pluginId>.<name>` (cross-plugin) | `bus.NewEvent(subject, …)` | `plugins/host.go:300` |

Every other publish site passes the same string as both subject and type, so `subject == Type` and nothing changes for them.

### The three `git.ws` outliers

`handleGitCommitCreated`, `handleGitCommitsReset` and `handleBranchSwitched` build their event with `bus.NewEvent(events.GitEvent, …)` (`"git.event"`) but publish it on `events.BuildGitWSEventSubject(sessionID)` (`"git.ws.<sessionId>"`), so the subject is not a suffixed form of the event's own type at all. This is pre-existing and left alone — `event.Type` there is only read by structured logging, and the WS gateway routes off the subject.

It does mean matching on `event.Type` could never have delivered these under any pattern, and matching on the subject makes them behave like the rest. `TestDeliverer_SubjectUnrelatedToTypeIsDelivered` pins both halves: deliverable under `git.ws.*`, still not deliverable under `git.event.*`.

## The fix

Approach 1 from the two candidates, i.e. carry the real subject rather than restamping `event.Type` at ~17 publish sites:

- **`bus.Event` gains a `Subject` field**, stamped in place by `Publish` in both `MemoryEventBus` and `NATSEventBus` (documented on the `EventBus.Publish` contract: callers must not share one `*Event` across concurrent publishes to different subjects — every call site builds a fresh event today) — so all 109 publish sites get it for free with no call-site churn, and no other consumer of `event.Type` (gateway routing, logs) is disturbed. On the NATS receive side the delivering `msg.Subject` is authoritative and overwrites whatever was marshaled, since that is where a wildcard subscription resolves to a concrete subject.
- **`Event.EffectiveSubject()`** returns `Subject` with a fallback to `Type`, so an `Event` handed to a handler without going through `Publish` still behaves exactly as before.
- **`deliverer.makeHandler` matches the manifest pattern against `EffectiveSubject()`** instead of `Type`.

Why approach 2 (stamping `Type` with the suffixed subject at each publish site) was rejected: ~17 call sites to change, and `event.Type` is read by other subscribers and by structured logging as the bare constant — restamping it would leak a session id into every one of those.

**Why the re-check exists at all** (checked before changing it): the memory and NATS buses honor NATS' multi-segment `>` wildcard, which `manifest.MatchSubject` deliberately does not, and the buses do not enforce manifest segment-count strictness the same way. The re-check makes one wildcard semantics authoritative for plugin delivery regardless of the bus implementation. That property is preserved — only the string it matches against changed.

### `pluginsdk.Event.EventType`

Plugins now receive the **concrete subject** as `EventType`, so a plugin subscribed to `shell.output.*` reads the session id off its last segment. This matches what the proto already documented (`string event_type = 2; // bus subject, e.g. "task.created"`), so no proto or SDK-surface change was needed.

Backward compatibility: for every unsuffixed subject `subject == Type`, so existing 2-segment subscriptions (`task.created`, `task.*`, …) see byte-identical `EventType` to before. For the suffixed subjects nothing was ever delivered, so there is no prior behavior to preserve.

## Tests

`internal/plugins/delivery`:
- `TestDeliverer_DeliversPerSessionSuffixedSubject` — end-to-end: a 3-segment wildcard subscription receives a per-session event published with a bare 2-segment type, and `EventType` carries the full subject.
- `TestDeliverer_PerSessionSubjectFamilies` — all 16 affected families plus the per-run office subject.
- `TestDeliverer_UnsuffixedSubscriptionsUnchanged` — 2-segment exact and wildcard, 3-segment exact and wildcard, and cross-plugin `plugin.<id>.*` still deliver with unchanged `EventType`.
- `TestDeliverer_SegmentCountStrictnessPreserved` — NATS `>` patterns (which the bus subscription *does* match) are still filtered out, and mismatched segment counts in both directions still do not deliver.
- `TestDeliverer_SubjectUnrelatedToTypeIsDelivered` — the three `git.ws`/`git.event` outliers above.
- `TestDeliverer_WrongSessionSuffixNotDelivered`, `TestDeliverer_UnstampedEventFallsBackToType`.

The negative assertions do not use wall-clock timeouts: `assertNotDelivered` publishes a control event on a second subscribed subject after the event under test, and the memory bus enqueues synchronously inside `Publish` while the worker drains one FIFO queue, so the control arriving first proves the event under test was never enqueued. Verified the barrier still fails when a genuinely matching case is fed to it.

`internal/events/bus`:
- `TestMemoryEventBus_PublishStampsSubject` — `Publish` stamps the concrete subject and leaves `Type` alone.
- `TestEvent_EffectiveSubject` — table test incl. nil receiver and the `Type` fallback.
- `TestNATSCreateMsgHandler_MessageSubjectIsAuthoritative` / `…_StampsSubjectOnUnstampedEvent` / `TestNATSPublish_StampsSubject` — the receive side prefers the delivering `msg.Subject` over a stale or forged marshaled one, stamps an unstamped event, and leaves `Type`/`ID`/`Source`/payload as published. Driven directly against `createMsgHandler`, so no NATS server is needed.

Verified red-before-green: with the deliverer reverted to `event.Type`, all 17 per-session cases fail and every backward-compat/strictness case still passes.

## Docs

`docs/public/plugins-manifest.md` already described the intended subscription contract (`shell.output.*` etc.), so the contract text is unchanged. Added one short paragraph to "Event subscription vocabulary" documenting that a delivered event's `event_type` is the concrete subject that matched — newly observable behavior for suffixed subjects.

## Verification

- `make -C apps/backend fmt` clean. (`make fmt`'s web half needs `apps/node_modules`; no web files are touched by this PR.)
- `make -C apps/backend lint` → 0 issues; `golangci-lint run ./... --new-from-rev=origin/main` → 0 issues.
- `go test ./...` — 4 packages fail (`internal/gitlab`, `internal/notifications/service`, `internal/task/handlers`, `internal/task/service`). Confirmed pre-existing: the identical failure set reproduces on a pristine `git archive HEAD` checkout of the base commit, and is the known task-worktree sandbox artifact (`parent directory cannot be accessed`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)