### PR TITLE
fix: backfill remote_url from local checkout for legacy GitLab repos

### DIFF
--- a/apps/backend/internal/gitlab/service_task_mr_link_test.go
+++ b/apps/backend/internal/gitlab/service_task_mr_link_test.go
@@ -104,6 +104,38 @@ func seedLocalGitCheckout(t *testing.T, dir, remoteURL string) {
 	}
 }
 
+// seedLocalGitWorktreeCheckout creates a linked worktree checkout at
+// worktreeDir: a ".git" *file* (not directory) containing a "gitdir:"
+// pointer into mainGitDir/worktrees/<name>, whose own "commondir" file
+// points back at mainGitDir where the origin remote is actually configured
+// (mirroring what `git worktree add` produces on disk).
+func seedLocalGitWorktreeCheckout(t *testing.T, worktreeDir, mainGitDir, remoteURL string) {
+	t.Helper()
+	if err := os.MkdirAll(mainGitDir, 0o755); err != nil {
+		t.Fatalf("mkdir main git dir: %v", err)
+	}
+	config := "[core]\n\trepositoryformatversion = 0\n[remote \"origin\"]\n\turl = " + remoteURL + "\n\tfetch = +refs/heads/*:refs/remotes/origin/*\n"
+	if err := os.WriteFile(filepath.Join(mainGitDir, "config"), []byte(config), 0o644); err != nil {
+		t.Fatalf("write main git config: %v", err)
+	}
+
+	worktreeGitDir := filepath.Join(mainGitDir, "worktrees", "wt")
+	if err := os.MkdirAll(worktreeGitDir, 0o755); err != nil {
+		t.Fatalf("mkdir worktree git dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(worktreeGitDir, "commondir"), []byte("../..\n"), 0o644); err != nil {
+		t.Fatalf("write commondir: %v", err)
+	}
+
+	if err := os.MkdirAll(worktreeDir, 0o755); err != nil {
+		t.Fatalf("mkdir worktree dir: %v", err)
+	}
+	gitFile := "gitdir: " + worktreeGitDir + "\n"
+	if err := os.WriteFile(filepath.Join(worktreeDir, ".git"), []byte(gitFile), 0o644); err != nil {
+		t.Fatalf("write .git pointer file: %v", err)
+	}
+}
+
 // setTaskMRRepositoryIdentityColumnsNull sets every provider identity column
 // (provider, provider_host, provider_owner, provider_name, remote_url) to
 // SQL NULL, mirroring rows persisted before those columns existed or by code
@@ -432,6 +464,43 @@ func TestAssociateExistingMRByURLBackfillsRemoteURLFromLocalCheckoutWhenLegacyRo
 
 	// Backfilled as a credential-free canonical "host/project" form, not the
 	// raw local remote (which may embed ssh/scp syntax or credentials).
+	got := getTaskMRRepositoryRemoteURL(t, store, "repo-1")
+	if got != host+"/clients/socodevi/laravel/co-up" {
+		t.Fatalf("remote_url not backfilled, got %q", got)
+	}
+}
+
+func TestAssociateExistingMRByURLBackfillsRemoteURLFromLocalWorktreeCheckoutWhenLegacyRowIsBlank(t *testing.T) {
+	// Covers the `git worktree add` on-disk shape: local_path/.git is a
+	// *file* containing a "gitdir:" pointer into the main checkout's
+	// "worktrees/<name>" directory, which in turn has a "commondir" file
+	// pointing back at the main checkout where the origin remote actually
+	// lives. resolveLocalGitDir/resolveLocalCommonGitDir must follow both
+	// indirections for the legacy-row fallback to work for worktree
+	// checkouts, not just plain clones.
+	const host = "https://gitlab.savoirfairelinux.com"
+	svc, store, client := newTaskMRLinkService(t, host)
+	seedTaskMRLinkFixture(t, store, "ws-1", "task-1", "repo-1")
+	root := t.TempDir()
+	mainGitDir := filepath.Join(root, "main", ".git")
+	worktreeDir := filepath.Join(root, "worktree")
+	seedLocalGitWorktreeCheckout(
+		t, worktreeDir, mainGitDir,
+		"git@gitlab.savoirfairelinux.com:clients/socodevi/laravel/co-up.git",
+	)
+	setTaskMRRepositoryLocalPath(t, store, "repo-1", worktreeDir)
+	client.SeedMR("clients/socodevi/laravel/co-up", &MR{
+		IID: 92, Title: "MR", WebURL: host + "/clients/socodevi/laravel/co-up/-/merge_requests/92",
+		State: "opened", CreatedAt: time.Now().UTC(),
+	})
+
+	if _, err := svc.AssociateExistingMRByURL(
+		context.Background(), "ws-1", "task-1", "repo-1",
+		host+"/clients/socodevi/laravel/co-up/-/merge_requests/92",
+	); err != nil {
+		t.Fatalf("AssociateExistingMRByURL: %v", err)
+	}
+
 	got := getTaskMRRepositoryRemoteURL(t, store, "repo-1")
 	if got != host+"/clients/socodevi/laravel/co-up" {
 		t.Fatalf("remote_url not backfilled, got %q", got)

--- a/apps/backend/internal/gitlab/service_task_mr_link_test.go
+++ b/apps/backend/internal/gitlab/service_task_mr_link_test.go
@@ -23,7 +23,8 @@ func seedTaskMRLinkFixture(t *testing.T, store *Store, workspaceID, taskID, repo
 		provider_owner TEXT DEFAULT '',
 		provider_name TEXT DEFAULT '',
 		remote_url TEXT DEFAULT '',
-		local_path TEXT DEFAULT ''
+		local_path TEXT DEFAULT '',
+		updated_at TIMESTAMP
 	); CREATE TABLE IF NOT EXISTS task_repositories (
 		id TEXT PRIMARY KEY,
 		task_id TEXT NOT NULL,
@@ -618,7 +619,10 @@ func TestAssociateExistingMRByURLBackfillsCredentialFreeRemoteURLWhenLocalOrigin
 	svc, store, client := newTaskMRLinkService(t, host)
 	seedTaskMRLinkFixture(t, store, "ws-1", "task-1", "repo-1")
 	localPath := t.TempDir()
-	seedLocalGitCheckout(t, localPath, "https://oauth2:glpat-secrettoken@gitlab.savoirfairelinux.com/clients/socodevi/laravel/co-up.git")
+	seedLocalGitCheckout(
+		t, localPath,
+		"https://alice:apikey123@gitlab.savoirfairelinux.com/clients/socodevi/laravel/co-up.git",
+	)
 	setTaskMRRepositoryLocalPath(t, store, "repo-1", localPath)
 	client.SeedMR("clients/socodevi/laravel/co-up", &MR{
 		IID: 92, Title: "MR", WebURL: host + "/clients/socodevi/laravel/co-up/-/merge_requests/92",
@@ -633,8 +637,11 @@ func TestAssociateExistingMRByURLBackfillsCredentialFreeRemoteURLWhenLocalOrigin
 	}
 
 	got := getTaskMRRepositoryRemoteURL(t, store, "repo-1")
-	if strings.Contains(got, "secrettoken") || strings.Contains(got, "oauth2") {
-		t.Fatalf("backfilled remote_url leaked credentials: %q", got)
+	// Assert on the userinfo separator itself, not specific token/password
+	// substrings, so this stays correct regardless of the fake credential
+	// used above.
+	if strings.Contains(got, "@") {
+		t.Fatalf("backfilled remote_url leaked userinfo credentials: %q", got)
 	}
 	if got != host+"/clients/socodevi/laravel/co-up" {
 		t.Fatalf("backfilled remote_url = %q, want credential-free canonical form", got)

--- a/apps/backend/internal/gitlab/service_task_mr_link_test.go
+++ b/apps/backend/internal/gitlab/service_task_mr_link_test.go
@@ -3,6 +3,7 @@ package gitlab
 import (
 	"context"
 	"errors"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -19,7 +20,8 @@ func seedTaskMRLinkFixture(t *testing.T, store *Store, workspaceID, taskID, repo
 		provider_host TEXT DEFAULT '',
 		provider_owner TEXT DEFAULT '',
 		provider_name TEXT DEFAULT '',
-		remote_url TEXT DEFAULT ''
+		remote_url TEXT DEFAULT '',
+		local_path TEXT DEFAULT ''
 	); CREATE TABLE IF NOT EXISTS task_repositories (
 		id TEXT PRIMARY KEY,
 		task_id TEXT NOT NULL,
@@ -64,6 +66,40 @@ func setTaskMRRepositoryRemoteURL(t *testing.T, store *Store, repositoryID, remo
 		`UPDATE repositories SET remote_url = ? WHERE id = ?`, remoteURL, repositoryID,
 	); err != nil {
 		t.Fatalf("set repository remote_url: %v", err)
+	}
+}
+
+func setTaskMRRepositoryLocalPath(t *testing.T, store *Store, repositoryID, localPath string) {
+	t.Helper()
+	if _, err := store.db.Exec(
+		`UPDATE repositories SET local_path = ? WHERE id = ?`, localPath, repositoryID,
+	); err != nil {
+		t.Fatalf("set repository local_path: %v", err)
+	}
+}
+
+func getTaskMRRepositoryRemoteURL(t *testing.T, store *Store, repositoryID string) string {
+	t.Helper()
+	var remoteURL string
+	if err := store.db.Get(&remoteURL, `SELECT COALESCE(remote_url, '') FROM repositories WHERE id = ?`, repositoryID); err != nil {
+		t.Fatalf("get repository remote_url: %v", err)
+	}
+	return remoteURL
+}
+
+// seedLocalGitCheckout creates a minimal local git checkout at dir whose
+// origin remote is remoteURL, mirroring the on-disk shape
+// resolveLocalGitOriginURL reads (a ".git" directory containing a "config"
+// file with a "[remote \"origin\"]" section).
+func seedLocalGitCheckout(t *testing.T, dir, remoteURL string) {
+	t.Helper()
+	gitDir := dir + "/.git"
+	if err := os.MkdirAll(gitDir, 0o755); err != nil {
+		t.Fatalf("mkdir git dir: %v", err)
+	}
+	config := "[core]\n\trepositoryformatversion = 0\n[remote \"origin\"]\n\turl = " + remoteURL + "\n\tfetch = +refs/heads/*:refs/remotes/origin/*\n"
+	if err := os.WriteFile(gitDir+"/config", []byte(config), 0o644); err != nil {
+		t.Fatalf("write git config: %v", err)
 	}
 }
 
@@ -365,6 +401,63 @@ func TestAssociateExistingMRByURLAcceptsRemoteURLWhenDurableIdentityEmpty(t *tes
 				t.Fatalf("AssociateExistingMRByURL: %v", err)
 			}
 		})
+	}
+}
+
+func TestAssociateExistingMRByURLBackfillsRemoteURLFromLocalCheckoutWhenLegacyRowIsBlank(t *testing.T) {
+	// Reproduces the persisted-bug shape found on a live instance: a
+	// repository row created before remote_url resolution existed has BOTH
+	// the durable provider identity AND remote_url blank, even though its
+	// local_path checkout still has a valid origin remote. This must
+	// succeed by falling back to the local git config, and must backfill
+	// remote_url so subsequent calls don't need the filesystem read.
+	const host = "https://gitlab.savoirfairelinux.com"
+	svc, store, client := newTaskMRLinkService(t, host)
+	seedTaskMRLinkFixture(t, store, "ws-1", "task-1", "repo-1")
+	localPath := t.TempDir()
+	seedLocalGitCheckout(t, localPath, "git@gitlab.savoirfairelinux.com:clients/socodevi/laravel/co-up.git")
+	setTaskMRRepositoryLocalPath(t, store, "repo-1", localPath)
+	client.SeedMR("clients/socodevi/laravel/co-up", &MR{
+		IID: 92, Title: "MR", WebURL: host + "/clients/socodevi/laravel/co-up/-/merge_requests/92",
+		State: "opened", CreatedAt: time.Now().UTC(),
+	})
+
+	if _, err := svc.AssociateExistingMRByURL(
+		context.Background(), "ws-1", "task-1", "repo-1",
+		host+"/clients/socodevi/laravel/co-up/-/merge_requests/92",
+	); err != nil {
+		t.Fatalf("AssociateExistingMRByURL: %v", err)
+	}
+
+	got := getTaskMRRepositoryRemoteURL(t, store, "repo-1")
+	if got != "git@gitlab.savoirfairelinux.com:clients/socodevi/laravel/co-up.git" {
+		t.Fatalf("remote_url not backfilled, got %q", got)
+	}
+}
+
+func TestAssociateExistingMRByURLRejectsLocalCheckoutPointingElsewhere(t *testing.T) {
+	// A legacy blank row whose local checkout's origin points to a different
+	// project must still fail closed, and must not backfill the wrong URL.
+	const host = "https://gitlab.savoirfairelinux.com"
+	svc, store, client := newTaskMRLinkService(t, host)
+	seedTaskMRLinkFixture(t, store, "ws-1", "task-1", "repo-1")
+	localPath := t.TempDir()
+	seedLocalGitCheckout(t, localPath, "git@gitlab.savoirfairelinux.com:clients/socodevi/laravel/other-project.git")
+	setTaskMRRepositoryLocalPath(t, store, "repo-1", localPath)
+	client.SeedMR("clients/socodevi/laravel/co-up", &MR{
+		IID: 92, Title: "MR", WebURL: host + "/clients/socodevi/laravel/co-up/-/merge_requests/92",
+		State: "opened", CreatedAt: time.Now().UTC(),
+	})
+
+	_, err := svc.AssociateExistingMRByURL(
+		context.Background(), "ws-1", "task-1", "repo-1",
+		host+"/clients/socodevi/laravel/co-up/-/merge_requests/92",
+	)
+	if !errors.Is(err, ErrTaskMRRepositoryMismatch) {
+		t.Fatalf("error = %v, want ErrTaskMRRepositoryMismatch", err)
+	}
+	if got := getTaskMRRepositoryRemoteURL(t, store, "repo-1"); got != "" {
+		t.Fatalf("remote_url should stay blank on mismatch, got %q", got)
 	}
 }
 

--- a/apps/backend/internal/gitlab/service_task_mr_link_test.go
+++ b/apps/backend/internal/gitlab/service_task_mr_link_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -93,12 +94,12 @@ func getTaskMRRepositoryRemoteURL(t *testing.T, store *Store, repositoryID strin
 // file with a "[remote \"origin\"]" section).
 func seedLocalGitCheckout(t *testing.T, dir, remoteURL string) {
 	t.Helper()
-	gitDir := dir + "/.git"
+	gitDir := filepath.Join(dir, ".git")
 	if err := os.MkdirAll(gitDir, 0o755); err != nil {
 		t.Fatalf("mkdir git dir: %v", err)
 	}
 	config := "[core]\n\trepositoryformatversion = 0\n[remote \"origin\"]\n\turl = " + remoteURL + "\n\tfetch = +refs/heads/*:refs/remotes/origin/*\n"
-	if err := os.WriteFile(gitDir+"/config", []byte(config), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(gitDir, "config"), []byte(config), 0o644); err != nil {
 		t.Fatalf("write git config: %v", err)
 	}
 }

--- a/apps/backend/internal/gitlab/service_task_mr_link_test.go
+++ b/apps/backend/internal/gitlab/service_task_mr_link_test.go
@@ -429,8 +429,10 @@ func TestAssociateExistingMRByURLBackfillsRemoteURLFromLocalCheckoutWhenLegacyRo
 		t.Fatalf("AssociateExistingMRByURL: %v", err)
 	}
 
+	// Backfilled as a credential-free canonical "host/project" form, not the
+	// raw local remote (which may embed ssh/scp syntax or credentials).
 	got := getTaskMRRepositoryRemoteURL(t, store, "repo-1")
-	if got != "git@gitlab.savoirfairelinux.com:clients/socodevi/laravel/co-up.git" {
+	if got != host+"/clients/socodevi/laravel/co-up" {
 		t.Fatalf("remote_url not backfilled, got %q", got)
 	}
 }
@@ -458,6 +460,102 @@ func TestAssociateExistingMRByURLRejectsLocalCheckoutPointingElsewhere(t *testin
 	}
 	if got := getTaskMRRepositoryRemoteURL(t, store, "repo-1"); got != "" {
 		t.Fatalf("remote_url should stay blank on mismatch, got %q", got)
+	}
+}
+
+func TestAssociateExistingMRByURLIgnoresLocalCheckoutWhenDurableIdentityAlreadyPointsElsewhere(t *testing.T) {
+	// A repository row that already has a durable provider identity for a
+	// DIFFERENT project (remote_url blank, e.g. it predates remote_url
+	// resolution) must not be overridden by a coincidentally-matching local
+	// checkout: the durable identity is authoritative once it exists at all.
+	const host = "https://gitlab.savoirfairelinux.com"
+	svc, store, client := newTaskMRLinkService(t, host)
+	seedTaskMRLinkFixture(t, store, "ws-1", "task-1", "repo-1")
+	setTaskMRRepositoryIdentity(t, store, "repo-1", host, "clients/socodevi/laravel/other-project")
+	localPath := t.TempDir()
+	seedLocalGitCheckout(t, localPath, "git@gitlab.savoirfairelinux.com:clients/socodevi/laravel/co-up.git")
+	setTaskMRRepositoryLocalPath(t, store, "repo-1", localPath)
+	client.SeedMR("clients/socodevi/laravel/co-up", &MR{
+		IID: 92, Title: "MR", WebURL: host + "/clients/socodevi/laravel/co-up/-/merge_requests/92",
+		State: "opened", CreatedAt: time.Now().UTC(),
+	})
+
+	_, err := svc.AssociateExistingMRByURL(
+		context.Background(), "ws-1", "task-1", "repo-1",
+		host+"/clients/socodevi/laravel/co-up/-/merge_requests/92",
+	)
+	if !errors.Is(err, ErrTaskMRRepositoryMismatch) {
+		t.Fatalf("error = %v, want ErrTaskMRRepositoryMismatch", err)
+	}
+	if got := getTaskMRRepositoryRemoteURL(t, store, "repo-1"); got != "" {
+		t.Fatalf("remote_url should stay blank, got %q", got)
+	}
+}
+
+func TestAssociateExistingMRByURLBackfillsCredentialFreeRemoteURLWhenLocalOriginEmbedsCredentials(t *testing.T) {
+	// A local checkout's origin can legitimately embed userinfo credentials
+	// (e.g. an HTTPS remote with an inline PAT). Those must never be
+	// persisted to remote_url, which is returned in repository API payloads.
+	const host = "https://gitlab.savoirfairelinux.com"
+	svc, store, client := newTaskMRLinkService(t, host)
+	seedTaskMRLinkFixture(t, store, "ws-1", "task-1", "repo-1")
+	localPath := t.TempDir()
+	seedLocalGitCheckout(t, localPath, "https://oauth2:glpat-secrettoken@gitlab.savoirfairelinux.com/clients/socodevi/laravel/co-up.git")
+	setTaskMRRepositoryLocalPath(t, store, "repo-1", localPath)
+	client.SeedMR("clients/socodevi/laravel/co-up", &MR{
+		IID: 92, Title: "MR", WebURL: host + "/clients/socodevi/laravel/co-up/-/merge_requests/92",
+		State: "opened", CreatedAt: time.Now().UTC(),
+	})
+
+	if _, err := svc.AssociateExistingMRByURL(
+		context.Background(), "ws-1", "task-1", "repo-1",
+		host+"/clients/socodevi/laravel/co-up/-/merge_requests/92",
+	); err != nil {
+		t.Fatalf("AssociateExistingMRByURL: %v", err)
+	}
+
+	got := getTaskMRRepositoryRemoteURL(t, store, "repo-1")
+	if strings.Contains(got, "secrettoken") || strings.Contains(got, "oauth2") {
+		t.Fatalf("backfilled remote_url leaked credentials: %q", got)
+	}
+	if got != host+"/clients/socodevi/laravel/co-up" {
+		t.Fatalf("backfilled remote_url = %q, want credential-free canonical form", got)
+	}
+}
+
+func TestParseLocalGitConfigOriginURLToleratesWhitespaceAndCaseVariants(t *testing.T) {
+	tests := []struct {
+		name   string
+		config string
+		want   string
+	}{
+		{
+			name:   "canonical spacing",
+			config: "[remote \"origin\"]\n\turl = https://gitlab.example.com/g/p.git\n",
+			want:   "https://gitlab.example.com/g/p.git",
+		},
+		{
+			name:   "no spaces around equals",
+			config: "[remote \"origin\"]\n\turl=https://gitlab.example.com/g/p.git\n",
+			want:   "https://gitlab.example.com/g/p.git",
+		},
+		{
+			name:   "extra whitespace around equals",
+			config: "[remote \"origin\"]\n\turl    =    https://gitlab.example.com/g/p.git\n",
+			want:   "https://gitlab.example.com/g/p.git",
+		},
+		{
+			name:   "uppercase key",
+			config: "[remote \"origin\"]\n\tURL = https://gitlab.example.com/g/p.git\n",
+			want:   "https://gitlab.example.com/g/p.git",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parseLocalGitConfigOriginURL(tt.config); got != tt.want {
+				t.Fatalf("parseLocalGitConfigOriginURL() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/apps/backend/internal/gitlab/service_task_mr_link_test.go
+++ b/apps/backend/internal/gitlab/service_task_mr_link_test.go
@@ -18,6 +18,7 @@ func seedTaskMRLinkFixture(t *testing.T, store *Store, workspaceID, taskID, repo
 		id TEXT PRIMARY KEY,
 		workspace_id TEXT NOT NULL,
 		provider TEXT DEFAULT '',
+		provider_repo_id TEXT DEFAULT '',
 		provider_host TEXT DEFAULT '',
 		provider_owner TEXT DEFAULT '',
 		provider_name TEXT DEFAULT '',
@@ -79,6 +80,20 @@ func setTaskMRRepositoryLocalPath(t *testing.T, store *Store, repositoryID, loca
 	}
 }
 
+// setTaskMRRepositoryProviderRepoID sets only provider_repo_id, leaving every
+// other identity column (provider/host/owner/name/remote_url) blank. Used to
+// verify hasNoDurableIdentitySignal treats provider_repo_id as a durable
+// identity signal on its own, since service-layer backfills can populate it
+// independently of the other provider_* columns.
+func setTaskMRRepositoryProviderRepoID(t *testing.T, store *Store, repositoryID, providerRepoID string) {
+	t.Helper()
+	if _, err := store.db.Exec(
+		`UPDATE repositories SET provider_repo_id = ? WHERE id = ?`, providerRepoID, repositoryID,
+	); err != nil {
+		t.Fatalf("set repository provider_repo_id: %v", err)
+	}
+}
+
 func getTaskMRRepositoryRemoteURL(t *testing.T, store *Store, repositoryID string) string {
 	t.Helper()
 	var remoteURL string
@@ -137,14 +152,15 @@ func seedLocalGitWorktreeCheckout(t *testing.T, worktreeDir, mainGitDir, remoteU
 }
 
 // setTaskMRRepositoryIdentityColumnsNull sets every provider identity column
-// (provider, provider_host, provider_owner, provider_name, remote_url) to
-// SQL NULL, mirroring rows persisted before those columns existed or by code
-// paths that never populated them. The production schema declares them
-// nullable, so ValidateTaskMRRepositoryIdentity must tolerate NULL scans.
+// (provider, provider_repo_id, provider_host, provider_owner, provider_name,
+// remote_url) to SQL NULL, mirroring rows persisted before those columns
+// existed or by code paths that never populated them. The production schema
+// declares them nullable, so ValidateTaskMRRepositoryIdentity must tolerate
+// NULL scans.
 func setTaskMRRepositoryIdentityColumnsNull(t *testing.T, store *Store, repositoryID string) {
 	t.Helper()
 	if _, err := store.db.Exec(`UPDATE repositories
-		SET provider = NULL, provider_host = NULL, provider_owner = NULL,
+		SET provider = NULL, provider_repo_id = NULL, provider_host = NULL, provider_owner = NULL,
 			provider_name = NULL, remote_url = NULL
 		WHERE id = ?`, repositoryID); err != nil {
 		t.Fatalf("null repository identity columns: %v", err)
@@ -542,6 +558,38 @@ func TestAssociateExistingMRByURLIgnoresLocalCheckoutWhenDurableIdentityAlreadyP
 	svc, store, client := newTaskMRLinkService(t, host)
 	seedTaskMRLinkFixture(t, store, "ws-1", "task-1", "repo-1")
 	setTaskMRRepositoryIdentity(t, store, "repo-1", host, "clients/socodevi/laravel/other-project")
+	localPath := t.TempDir()
+	seedLocalGitCheckout(t, localPath, "git@gitlab.savoirfairelinux.com:clients/socodevi/laravel/co-up.git")
+	setTaskMRRepositoryLocalPath(t, store, "repo-1", localPath)
+	client.SeedMR("clients/socodevi/laravel/co-up", &MR{
+		IID: 92, Title: "MR", WebURL: host + "/clients/socodevi/laravel/co-up/-/merge_requests/92",
+		State: "opened", CreatedAt: time.Now().UTC(),
+	})
+
+	_, err := svc.AssociateExistingMRByURL(
+		context.Background(), "ws-1", "task-1", "repo-1",
+		host+"/clients/socodevi/laravel/co-up/-/merge_requests/92",
+	)
+	if !errors.Is(err, ErrTaskMRRepositoryMismatch) {
+		t.Fatalf("error = %v, want ErrTaskMRRepositoryMismatch", err)
+	}
+	if got := getTaskMRRepositoryRemoteURL(t, store, "repo-1"); got != "" {
+		t.Fatalf("remote_url should stay blank, got %q", got)
+	}
+}
+
+func TestAssociateExistingMRByURLIgnoresLocalCheckoutWhenOnlyProviderRepoIDIsSet(t *testing.T) {
+	// provider_repo_id is part of the durable provider identity and can be
+	// populated by service-layer backfills independently of the other
+	// provider_* columns and remote_url. A row carrying only
+	// provider_repo_id (every other identity column blank) already has an
+	// established identity and must not fall back to the local checkout,
+	// even though a naive "all other columns blank" check would treat it as
+	// a fully legacy row.
+	const host = "https://gitlab.savoirfairelinux.com"
+	svc, store, client := newTaskMRLinkService(t, host)
+	seedTaskMRLinkFixture(t, store, "ws-1", "task-1", "repo-1")
+	setTaskMRRepositoryProviderRepoID(t, store, "repo-1", "12345")
 	localPath := t.TempDir()
 	seedLocalGitCheckout(t, localPath, "git@gitlab.savoirfairelinux.com:clients/socodevi/laravel/co-up.git")
 	setTaskMRRepositoryLocalPath(t, store, "repo-1", localPath)

--- a/apps/backend/internal/gitlab/store_task_mr_link.go
+++ b/apps/backend/internal/gitlab/store_task_mr_link.go
@@ -51,11 +51,16 @@ func (s *Store) ValidateTaskMRScope(ctx context.Context, workspaceID, taskID, re
 // tagged at discovery time) yet still carry a resolvable remote_url.
 //
 // Rows created before remote_url resolution existed (or where it otherwise
-// failed to populate) have neither signal. For those, as a last resort, this
-// re-derives the origin directly from the repository's local git checkout
-// (local_path) and, if it matches the MR, opportunistically backfills
-// remote_url so the local filesystem read isn't needed on subsequent calls.
-// Rows with no signal resolving to a GitLab identity fail closed.
+// failed to populate) have no signal at all: provider/provider_host/
+// provider_owner/provider_name AND remote_url are all blank. Only for those
+// rows, as a last resort, this re-derives the origin directly from the
+// repository's local git checkout (local_path) and, if it matches the MR,
+// opportunistically backfills remote_url so the local filesystem read isn't
+// needed on subsequent calls. The local-checkout fallback deliberately never
+// runs when the row already carries ANY durable identity signal (even one
+// that doesn't match the MR), so it can never override an already-known
+// repository's identity with an unrelated local checkout. Rows with no
+// signal resolving to a GitLab identity fail closed.
 func (s *Store) ValidateTaskMRRepositoryIdentity(
 	ctx context.Context,
 	workspaceID, taskID, repositoryID, configuredHost, projectPath string,
@@ -63,14 +68,7 @@ func (s *Store) ValidateTaskMRRepositoryIdentity(
 	if repositoryID == "" {
 		return ErrTaskMRRepositoryMismatch
 	}
-	var identity struct {
-		Provider  string `db:"provider"`
-		Host      string `db:"provider_host"`
-		Owner     string `db:"provider_owner"`
-		Name      string `db:"provider_name"`
-		RemoteURL string `db:"remote_url"`
-		LocalPath string `db:"local_path"`
-	}
+	var identity taskMRRepositoryIdentityRow
 	err := s.ro.GetContext(ctx, &identity, `
 		SELECT COALESCE(r.provider, '') AS provider,
 			COALESCE(r.provider_host, '') AS provider_host,
@@ -108,17 +106,19 @@ func (s *Store) ValidateTaskMRRepositoryIdentity(
 			candidates = append(candidates, taskMRIdentityCandidate{host: gotHost, project: remoteProject})
 		}
 	}
-	// Legacy rows: neither the durable identity nor remote_url resolved to
-	// anything. Fall back to reading the local checkout's origin directly,
-	// since local_path is the one signal every locally-cloned repository
-	// carries regardless of when it was added.
-	if localCandidate, ok := localCheckoutIdentityCandidate(identity.RemoteURL, identity.LocalPath); ok {
-		candidates = append(candidates, localCandidate)
+	// Legacy rows only: no durable identity signal at all. A row that
+	// already carries any provider/host/owner/name/remote_url value has an
+	// established identity, even if it doesn't match this MR, and must not
+	// be overridden by a coincidentally-matching local checkout.
+	if identity.hasNoDurableIdentitySignal() {
+		if localCandidate, ok := localCheckoutIdentityCandidate(identity.LocalPath); ok {
+			candidates = append(candidates, localCandidate)
+		}
 	}
 	for _, c := range candidates {
 		if sameGitLabHost(c.host, wantHost) && strings.EqualFold(c.project, wantProject) {
-			if c.remoteURL != "" {
-				s.backfillRepositoryRemoteURL(ctx, repositoryID, c.remoteURL)
+			if c.backfillRemoteURL != "" {
+				s.backfillRepositoryRemoteURL(ctx, repositoryID, c.backfillRemoteURL)
 			}
 			return nil
 		}
@@ -126,19 +126,43 @@ func (s *Store) ValidateTaskMRRepositoryIdentity(
 	return ErrTaskMRRepositoryMismatch
 }
 
+// taskMRRepositoryIdentityRow is the repository identity data loaded for one
+// task-repository pair.
+type taskMRRepositoryIdentityRow struct {
+	Provider  string `db:"provider"`
+	Host      string `db:"provider_host"`
+	Owner     string `db:"provider_owner"`
+	Name      string `db:"provider_name"`
+	RemoteURL string `db:"remote_url"`
+	LocalPath string `db:"local_path"`
+}
+
+// hasNoDurableIdentitySignal reports whether the row carries absolutely no
+// identity signal: no durable provider/host/owner/name AND no remote_url.
+// Only such rows are eligible for the local-checkout fallback, so a row that
+// already identifies a (possibly different) repository can never be
+// overridden by a coincidentally-matching local checkout.
+func (r taskMRRepositoryIdentityRow) hasNoDurableIdentitySignal() bool {
+	return r.Provider == "" && r.Host == "" && r.Owner == "" && r.Name == "" && r.RemoteURL == ""
+}
+
 // taskMRIdentityCandidate is one (host, project) identity derived from a
 // repository row that an incoming MR's host/project can be checked against.
-// remoteURL is set only for candidates re-derived from a local checkout, so
-// the caller knows to backfill the repository row's remote_url on a match.
-type taskMRIdentityCandidate struct{ host, project, remoteURL string }
+// backfillRemoteURL is set only for candidates re-derived from a local
+// checkout, so the caller knows to persist it onto the repository row on a
+// match. It deliberately holds a credential-free canonical "host/project"
+// value rather than the raw local remote URL, since the raw value may embed
+// userinfo credentials (e.g. "https://user:token@host/...") that must never
+// be persisted into a column returned by repository API payloads.
+type taskMRIdentityCandidate struct{ host, project, backfillRemoteURL string }
 
 // localCheckoutIdentityCandidate re-derives a GitLab (host, project) identity
-// from a repository's local git checkout, for legacy rows where both the
-// durable provider identity and remote_url are blank. ok is false when there
-// is nothing to fall back to (no local_path, or remote_url already set) or
-// the checkout's origin can't be parsed as a GitLab remote.
-func localCheckoutIdentityCandidate(remoteURL, localPath string) (candidate taskMRIdentityCandidate, ok bool) {
-	if remoteURL != "" || localPath == "" {
+// from a repository's local git checkout, for legacy rows where neither the
+// durable provider identity nor remote_url carries any signal. ok is false
+// when there is nothing to fall back to (no local_path) or the checkout's
+// origin can't be parsed as a GitLab remote.
+func localCheckoutIdentityCandidate(localPath string) (candidate taskMRIdentityCandidate, ok bool) {
+	if localPath == "" {
 		return taskMRIdentityCandidate{}, false
 	}
 	localRemoteURL := resolveLocalGitOriginURL(localPath)
@@ -150,7 +174,8 @@ func localCheckoutIdentityCandidate(remoteURL, localPath string) (candidate task
 	if err != nil {
 		return taskMRIdentityCandidate{}, false
 	}
-	return taskMRIdentityCandidate{host: gotHost, project: remoteProject, remoteURL: localRemoteURL}, true
+	backfillRemoteURL := strings.TrimRight(gotHost, "/") + "/" + strings.Trim(remoteProject, "/")
+	return taskMRIdentityCandidate{host: gotHost, project: remoteProject, backfillRemoteURL: backfillRemoteURL}, true
 }
 
 // backfillRepositoryRemoteURL persists a remote_url re-derived from a local
@@ -231,6 +256,11 @@ func resolveLocalCommonGitDir(gitDir string) string {
 
 // parseLocalGitConfigOriginURL extracts the "origin" remote's url from raw
 // git config file content.
+// parseLocalGitConfigOriginURL extracts the "origin" remote's url from raw
+// git config file content. Tolerant of the whitespace-around-"=" and
+// key-casing variations git itself accepts ("url = x", "url=x", "URL\t=\tx"),
+// since hand-edited or tool-written configs don't always match the exact
+// "url = " spacing git-init produces.
 func parseLocalGitConfigOriginURL(config string) string {
 	inOrigin := false
 	for _, line := range strings.Split(config, "\n") {
@@ -243,10 +273,15 @@ func parseLocalGitConfigOriginURL(config string) string {
 			inOrigin = false
 			continue
 		}
-		if inOrigin {
-			if url, ok := strings.CutPrefix(line, "url = "); ok {
-				return url
-			}
+		if !inOrigin {
+			continue
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(key), "url") {
+			return strings.TrimSpace(value)
 		}
 	}
 	return ""

--- a/apps/backend/internal/gitlab/store_task_mr_link.go
+++ b/apps/backend/internal/gitlab/store_task_mr_link.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 // ValidateTaskMRScope verifies that the task and optional repository belong to
@@ -190,9 +191,9 @@ func localCheckoutIdentityCandidate(localPath string) (candidate taskMRIdentityC
 func (s *Store) backfillRepositoryRemoteURL(ctx context.Context, repositoryID, remoteURL string) {
 	_, _ = s.db.ExecContext(ctx, `
 		UPDATE repositories
-		SET remote_url = ?
+		SET remote_url = ?, updated_at = ?
 		WHERE id = ? AND (remote_url IS NULL OR remote_url = '')`,
-		remoteURL, repositoryID)
+		remoteURL, time.Now().UTC(), repositoryID)
 }
 
 // resolveLocalGitOriginURL reads the "origin" remote URL directly from a

--- a/apps/backend/internal/gitlab/store_task_mr_link.go
+++ b/apps/backend/internal/gitlab/store_task_mr_link.go
@@ -71,6 +71,7 @@ func (s *Store) ValidateTaskMRRepositoryIdentity(
 	var identity taskMRRepositoryIdentityRow
 	err := s.ro.GetContext(ctx, &identity, `
 		SELECT COALESCE(r.provider, '') AS provider,
+			COALESCE(r.provider_repo_id, '') AS provider_repo_id,
 			COALESCE(r.provider_host, '') AS provider_host,
 			COALESCE(r.provider_owner, '') AS provider_owner,
 			COALESCE(r.provider_name, '') AS provider_name,
@@ -129,21 +130,24 @@ func (s *Store) ValidateTaskMRRepositoryIdentity(
 // taskMRRepositoryIdentityRow is the repository identity data loaded for one
 // task-repository pair.
 type taskMRRepositoryIdentityRow struct {
-	Provider  string `db:"provider"`
-	Host      string `db:"provider_host"`
-	Owner     string `db:"provider_owner"`
-	Name      string `db:"provider_name"`
-	RemoteURL string `db:"remote_url"`
-	LocalPath string `db:"local_path"`
+	Provider       string `db:"provider"`
+	ProviderRepoID string `db:"provider_repo_id"`
+	Host           string `db:"provider_host"`
+	Owner          string `db:"provider_owner"`
+	Name           string `db:"provider_name"`
+	RemoteURL      string `db:"remote_url"`
+	LocalPath      string `db:"local_path"`
 }
 
 // hasNoDurableIdentitySignal reports whether the row carries absolutely no
-// identity signal: no durable provider/host/owner/name AND no remote_url.
-// Only such rows are eligible for the local-checkout fallback, so a row that
-// already identifies a (possibly different) repository can never be
-// overridden by a coincidentally-matching local checkout.
+// identity signal: no durable provider/provider_repo_id/host/owner/name AND
+// no remote_url. Only such rows are eligible for the local-checkout
+// fallback, so a row that already identifies a (possibly different)
+// repository can never be overridden by a coincidentally-matching local
+// checkout.
 func (r taskMRRepositoryIdentityRow) hasNoDurableIdentitySignal() bool {
-	return r.Provider == "" && r.Host == "" && r.Owner == "" && r.Name == "" && r.RemoteURL == ""
+	return r.Provider == "" && r.ProviderRepoID == "" && r.Host == "" && r.Owner == "" &&
+		r.Name == "" && r.RemoteURL == ""
 }
 
 // taskMRIdentityCandidate is one (host, project) identity derived from a

--- a/apps/backend/internal/gitlab/store_task_mr_link.go
+++ b/apps/backend/internal/gitlab/store_task_mr_link.go
@@ -255,8 +255,6 @@ func resolveLocalCommonGitDir(gitDir string) string {
 }
 
 // parseLocalGitConfigOriginURL extracts the "origin" remote's url from raw
-// git config file content.
-// parseLocalGitConfigOriginURL extracts the "origin" remote's url from raw
 // git config file content. Tolerant of the whitespace-around-"=" and
 // key-casing variations git itself accepts ("url = x", "url=x", "URL\t=\tx"),
 // since hand-edited or tool-written configs don't always match the exact

--- a/apps/backend/internal/gitlab/store_task_mr_link.go
+++ b/apps/backend/internal/gitlab/store_task_mr_link.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 )
 
@@ -46,8 +48,14 @@ func (s *Store) ValidateTaskMRScope(ctx context.Context, workspaceID, taskID, re
 // match against either the repository's durable provider identity or its
 // remote_url, since self-hosted GitLab repositories added as local clones
 // never get a durable provider identity (only github.com/gitlab.com are
-// tagged at discovery time) yet still carry a resolvable remote_url. Rows
-// with neither signal resolving to a GitLab identity fail closed.
+// tagged at discovery time) yet still carry a resolvable remote_url.
+//
+// Rows created before remote_url resolution existed (or where it otherwise
+// failed to populate) have neither signal. For those, as a last resort, this
+// re-derives the origin directly from the repository's local git checkout
+// (local_path) and, if it matches the MR, opportunistically backfills
+// remote_url so the local filesystem read isn't needed on subsequent calls.
+// Rows with no signal resolving to a GitLab identity fail closed.
 func (s *Store) ValidateTaskMRRepositoryIdentity(
 	ctx context.Context,
 	workspaceID, taskID, repositoryID, configuredHost, projectPath string,
@@ -61,13 +69,15 @@ func (s *Store) ValidateTaskMRRepositoryIdentity(
 		Owner     string `db:"provider_owner"`
 		Name      string `db:"provider_name"`
 		RemoteURL string `db:"remote_url"`
+		LocalPath string `db:"local_path"`
 	}
 	err := s.ro.GetContext(ctx, &identity, `
 		SELECT COALESCE(r.provider, '') AS provider,
 			COALESCE(r.provider_host, '') AS provider_host,
 			COALESCE(r.provider_owner, '') AS provider_owner,
 			COALESCE(r.provider_name, '') AS provider_name,
-			COALESCE(r.remote_url, '') AS remote_url
+			COALESCE(r.remote_url, '') AS remote_url,
+			COALESCE(r.local_path, '') AS local_path
 		FROM task_repositories tr
 		JOIN repositories r ON r.id = tr.repository_id
 		JOIN tasks t ON t.id = tr.task_id
@@ -86,25 +96,160 @@ func (s *Store) ValidateTaskMRRepositoryIdentity(
 	}
 	wantProject := strings.Trim(strings.TrimSpace(projectPath), "/")
 
-	type candidate struct{ host, project string }
-	var candidates []candidate
+	var candidates []taskMRIdentityCandidate
 	if strings.EqualFold(identity.Provider, "gitlab") {
 		if gotHost, err := normalizeHostOrigin(identity.Host); err == nil {
 			gotProject := strings.Trim(strings.TrimSpace(identity.Owner+"/"+identity.Name), "/")
-			candidates = append(candidates, candidate{host: gotHost, project: gotProject})
+			candidates = append(candidates, taskMRIdentityCandidate{host: gotHost, project: gotProject})
 		}
 	}
 	if remoteURLHost, remoteProject := parseGitLabRemoteURLIdentity(identity.RemoteURL); remoteURLHost != "" {
 		if gotHost, err := normalizeHostOrigin(remoteURLHost); err == nil {
-			candidates = append(candidates, candidate{host: gotHost, project: remoteProject})
+			candidates = append(candidates, taskMRIdentityCandidate{host: gotHost, project: remoteProject})
 		}
+	}
+	// Legacy rows: neither the durable identity nor remote_url resolved to
+	// anything. Fall back to reading the local checkout's origin directly,
+	// since local_path is the one signal every locally-cloned repository
+	// carries regardless of when it was added.
+	if localCandidate, ok := localCheckoutIdentityCandidate(identity.RemoteURL, identity.LocalPath); ok {
+		candidates = append(candidates, localCandidate)
 	}
 	for _, c := range candidates {
 		if sameGitLabHost(c.host, wantHost) && strings.EqualFold(c.project, wantProject) {
+			if c.remoteURL != "" {
+				s.backfillRepositoryRemoteURL(ctx, repositoryID, c.remoteURL)
+			}
 			return nil
 		}
 	}
 	return ErrTaskMRRepositoryMismatch
+}
+
+// taskMRIdentityCandidate is one (host, project) identity derived from a
+// repository row that an incoming MR's host/project can be checked against.
+// remoteURL is set only for candidates re-derived from a local checkout, so
+// the caller knows to backfill the repository row's remote_url on a match.
+type taskMRIdentityCandidate struct{ host, project, remoteURL string }
+
+// localCheckoutIdentityCandidate re-derives a GitLab (host, project) identity
+// from a repository's local git checkout, for legacy rows where both the
+// durable provider identity and remote_url are blank. ok is false when there
+// is nothing to fall back to (no local_path, or remote_url already set) or
+// the checkout's origin can't be parsed as a GitLab remote.
+func localCheckoutIdentityCandidate(remoteURL, localPath string) (candidate taskMRIdentityCandidate, ok bool) {
+	if remoteURL != "" || localPath == "" {
+		return taskMRIdentityCandidate{}, false
+	}
+	localRemoteURL := resolveLocalGitOriginURL(localPath)
+	remoteURLHost, remoteProject := parseGitLabRemoteURLIdentity(localRemoteURL)
+	if remoteURLHost == "" {
+		return taskMRIdentityCandidate{}, false
+	}
+	gotHost, err := normalizeHostOrigin(remoteURLHost)
+	if err != nil {
+		return taskMRIdentityCandidate{}, false
+	}
+	return taskMRIdentityCandidate{host: gotHost, project: remoteProject, remoteURL: localRemoteURL}, true
+}
+
+// backfillRepositoryRemoteURL persists a remote_url re-derived from a local
+// git checkout onto a legacy repository row so future MR-link checks (and
+// any other remote_url consumer) no longer need a filesystem read. Best
+// effort: failures are swallowed since the caller already has what it needs
+// to proceed with the current request.
+func (s *Store) backfillRepositoryRemoteURL(ctx context.Context, repositoryID, remoteURL string) {
+	_, _ = s.db.ExecContext(ctx, `
+		UPDATE repositories
+		SET remote_url = ?
+		WHERE id = ? AND (remote_url IS NULL OR remote_url = '')`,
+		remoteURL, repositoryID)
+}
+
+// resolveLocalGitOriginURL reads the "origin" remote URL directly from a
+// local git checkout's config, without depending on the task/service
+// package (see parseGitLabRemoteURLIdentity for the rationale: this package
+// stays self-contained to avoid a gitlab -> task/service import cycle).
+// Returns "" on any error, including non-existent paths and checkouts with
+// no origin remote.
+func resolveLocalGitOriginURL(repoPath string) string {
+	gitDir, err := resolveLocalGitDir(repoPath)
+	if err != nil {
+		return ""
+	}
+	commonDir := resolveLocalCommonGitDir(gitDir)
+	content, err := os.ReadFile(filepath.Join(commonDir, "config"))
+	if err != nil {
+		return ""
+	}
+	return parseLocalGitConfigOriginURL(string(content))
+}
+
+// resolveLocalGitDir resolves repoPath/.git to an absolute git directory,
+// following the "gitdir: <path>" pointer file used by worktree checkouts.
+func resolveLocalGitDir(repoPath string) (string, error) {
+	gitPath := filepath.Join(repoPath, ".git")
+	info, err := os.Stat(gitPath)
+	if err != nil {
+		return "", err
+	}
+	if info.IsDir() {
+		return gitPath, nil
+	}
+	content, err := os.ReadFile(gitPath)
+	if err != nil {
+		return "", err
+	}
+	line := strings.TrimSpace(string(content))
+	gitDir, ok := strings.CutPrefix(line, "gitdir:")
+	if !ok {
+		return "", fmt.Errorf("invalid gitdir reference")
+	}
+	gitDir = strings.TrimSpace(gitDir)
+	if filepath.IsAbs(gitDir) {
+		return gitDir, nil
+	}
+	return filepath.Clean(filepath.Join(repoPath, gitDir)), nil
+}
+
+// resolveLocalCommonGitDir follows a worktree's "commondir" file back to the
+// main checkout's git directory, where its remotes are actually configured.
+func resolveLocalCommonGitDir(gitDir string) string {
+	content, err := os.ReadFile(filepath.Join(gitDir, "commondir"))
+	if err != nil {
+		return gitDir
+	}
+	commonDir := strings.TrimSpace(string(content))
+	if commonDir == "" {
+		return gitDir
+	}
+	if filepath.IsAbs(commonDir) {
+		return filepath.Clean(commonDir)
+	}
+	return filepath.Clean(filepath.Join(gitDir, commonDir))
+}
+
+// parseLocalGitConfigOriginURL extracts the "origin" remote's url from raw
+// git config file content.
+func parseLocalGitConfigOriginURL(config string) string {
+	inOrigin := false
+	for _, line := range strings.Split(config, "\n") {
+		line = strings.TrimSpace(line)
+		if line == `[remote "origin"]` {
+			inOrigin = true
+			continue
+		}
+		if strings.HasPrefix(line, "[") {
+			inOrigin = false
+			continue
+		}
+		if inOrigin {
+			if url, ok := strings.CutPrefix(line, "url = "); ok {
+				return url
+			}
+		}
+	}
+	return ""
 }
 
 func sameGitLabHost(left, right string) bool {


### PR DESCRIPTION
## Summary

Follow-up to #1996. Linking a GitLab merge request to a task could still fail
with "repository does not match GitLab merge request" for repositories that
were added **before** #1996 landed, even on hosts/instances where the original
fix already applies.

## Root cause

`resolveRepositoryProviderIdentity` (which populates a repository's durable
`provider_*` columns and `remote_url`) only runs once, at repository
**creation** time. Repository rows created before #1996 shipped have both the
durable provider identity **and** `remote_url` blank — `ValidateTaskMR
RepositoryIdentity` therefore has no signal to match the incoming MR against
and fails closed, even though the repository's local checkout still has a
perfectly valid `origin` remote.

This was confirmed live: on the reporter's own instance, the "co-up"
repository rows in the database had `provider`, `provider_host`,
`provider_owner`, `provider_name`, and `remote_url` all empty — only
`local_path` was populated.

## Fix

`ValidateTaskMRRepositoryIdentity` (`apps/backend/internal/gitlab/
store_task_mr_link.go`) now adds a third fallback candidate when both the
durable identity and `remote_url` are blank: it reads the `origin` remote
directly from the repository's local git checkout (`local_path`), self-
contained within the `gitlab` package to avoid a `gitlab -> task/service`
import cycle. On a match, it opportunistically backfills `remote_url` in the
database so subsequent lookups no longer need the filesystem read.

Requirements covered:
- Existing repositories (created pre-#1996) with blank `provider_*` and
  `remote_url` link successfully when their local checkout's origin matches
  the MR's host + project path.
- A match backfills `remote_url` so future MR links for that repository are
  fast-pathed without touching the filesystem.
- Repositories whose local checkout origin points to a *different* GitLab
  host or project still fail closed with `ErrTaskMRRepositoryMismatch`, and
  `remote_url` is left untouched on a mismatch.
- All existing durable-identity and remote_url-based matching behavior from
  #1996 is preserved unchanged.

## Validation

- `go test ./internal/gitlab/...` — new backfill/mismatch tests pass; only 3
  pre-existing, unrelated GitLab-connection-poller tests fail (network-
  dependent tests that fail identically on unmodified `main`).
- `make -C apps/backend lint` — 0 issues.
- Live end-to-end repro against a real self-hosted GitLab instance and a real
  MR: a repository row shaped exactly like the reporter's live database rows
  (blank `remote_url`/`provider_*`, only `local_path` set) linked successfully
  and backfilled `remote_url`.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have manually tested my changes and they work as expected.
- [x] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated
      Playwright e2e tests in `apps/web/e2e/` and verified them with
      `make test-e2e`.
- [x] I checked whether this affects public docs in `docs/public/**` and
      updated them or noted why no docs change is needed (backend-only bug
      fix, no public API/config/doc surface changed).
