### PR TITLE
fix(backend): cover the whole launch chain in waitForSessionReady

### DIFF
--- a/apps/backend/internal/orchestrator/task_operations.go
+++ b/apps/backend/internal/orchestrator/task_operations.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kandev/kandev/internal/agent/runtime/agentctl"
 	"github.com/kandev/kandev/internal/agent/runtime/lifecycle"
 	"github.com/kandev/kandev/internal/agent/runtime/routingerr"
+	"github.com/kandev/kandev/internal/common/constants"
 	"github.com/kandev/kandev/internal/orchestrator/dto"
 	"github.com/kandev/kandev/internal/orchestrator/executor"
 	"github.com/kandev/kandev/internal/orchestrator/messagequeue"
@@ -1844,7 +1845,7 @@ func (s *Service) startAgentOnPreparedWorkspace(ctx context.Context, sessionID s
 func (s *Service) waitForSessionReady(ctx context.Context, sessionID string) error {
 	const (
 		pollInterval = 500 * time.Millisecond
-		maxWait      = 90 * time.Second
+		maxWait      = constants.AgentLaunchTimeout
 	)
 	// Derive a bounded context so the overall wait AND each GetTaskSession query
 	// inside the loop honor maxWait. Callers pass context.WithoutCancel(ctx) so

--- a/apps/backend/internal/orchestrator/task_operations_wait_test.go
+++ b/apps/backend/internal/orchestrator/task_operations_wait_test.go
@@ -28,7 +28,7 @@ func (r *deadlineRecordingRepo) GetTaskSession(ctx context.Context, id string) (
 // for cubic's P2: resume/launch pass context.WithoutCancel(ctx) (no deadline) so
 // the wait survives the caller's request timeout, but the GetTaskSession queries
 // inside the poll loop must still be bounded by waitForSessionReady's own
-// deadline — otherwise a single blocking query could hang past the 90s budget,
+// deadline — otherwise a single blocking query could hang past that budget,
 // which is only checked between iterations.
 func TestWaitForSessionReady_BoundsQueriesWithNonCancellableContext(t *testing.T) {
 	repo := setupTestRepo(t)


### PR DESCRIPTION
A launch that takes longer than 90s is reported to the user as failed while the session goes on to initialize and become ready seconds later, because `waitForSessionReady` gives up well before the agentctl calls it is waiting on can. Deriving its budget from `constants.AgentLaunchTimeout` makes the wait cover the work it is actually waiting for, so slow launches stop surfacing as false failures.

## Important Changes

- `waitForSessionReady` uses `constants.AgentLaunchTimeout` (6m) instead of a hardcoded 90s.

The orchestrator waits 90s + 30s (`waitForAgentPromptReady`) = 120s, while agentctl allows 180s for `initialize` (`agentctl/server/api/agent.go:288`) plus 120s for `session/new` or `session/load` (`SessionNewTimeout` / `SessionLoadTimeout`) — up to 300s. Raising the value to 180s would only close half the gap; `AgentLaunchTimeout` already documents itself as the budget for agent launch and covers the chain.

This was consistent once: `maxWait = 90s` landed in #269 (2026-02-23) when the initialize ceiling was 60s. #352 (2026-03-02) raised that ceiling to 180s as a side effect of unrelated work on remote executors, and #1949 widened the gap further. The change restores the relationship rather than picking a new number.

Raising the ceiling does not delay reporting of real failures: the poll loop returns as soon as the session reaches `FAILED`, so only genuine silence uses the longer budget — which is exactly the case that currently produces a false failure.

## Validation

- `go build ./internal/orchestrator/...` and `go vet ./internal/orchestrator/` pass.
- `gofmt`, Go lint, and commit-message hooks pass.
- Reproduced the failure before the change on native Windows: `initializing ACP session` at 21:44:56.269, `failed to launch session: timeout waiting for agent to become ready: context deadline exceeded` at 21:46:23.139 (86.7s), then `session initialized` and `ready` for the same execution at 21:47:06 — 43s after the user was told it had failed. After the change, launching several tasks concurrently no longer produces the false failure.
- I could not run `go test ./internal/orchestrator/` locally: those tests need cgo for `go-sqlite3`, and cgo fails to link on this machine for an unrelated pre-existing reason (a non-ASCII character in the user profile path breaks `ld`). CI coverage would be welcome here.

`TestWaitForSessionReady_BoundsQueriesWithNonCancellableContext` still exercises this function and is unaffected — it forces a terminal session state on the first poll, so it never runs the budget. Its comment referenced the old 90s value and is updated.

## Possible Improvements

Low risk. The visible cost is that a launch which hangs with no state change now takes up to 6 minutes to report instead of 90 seconds; failures that set `FAILED` are unaffected. If a tighter ceiling is preferred, the alternative is to lower the agentctl-side timeouts instead and cancel the in-flight `initialize` when the launch gives up, which it currently does not do — that would be a larger change. `waitForAgentPromptReady` keeps its own 30s and is untouched.

## Related Issues

Refs #2028

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2032?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

