### PR TITLE
fix: prevent duplicate review-watcher agents and resync task PRs on reconnect

### DIFF
--- a/apps/backend/internal/orchestrator/event_handlers_github.go
+++ b/apps/backend/internal/orchestrator/event_handlers_github.go
@@ -457,6 +457,16 @@ func buildReviewTaskRequest(evt *github.NewReviewPREvent, repositories []ReviewT
 			"pr_branch":           pr.HeadBranch,
 			"agent_profile_id":    evt.AgentProfileID,
 			"executor_profile_id": evt.ExecutorProfileID,
+			// Permanent guard: signals that the auto-start idempotency protocol
+			// is active for this task. Both Path A (promotion, async) and Path B
+			// (watcher, sync) check this marker and then compete for the one-shot
+			// MetaKeyAutoStartClaimed token before calling StartTask.
+			models.MetaKeyAutoStartGuard: true,
+			// One-shot token: both paths atomically remove this key; only the
+			// first removal wins and proceeds to StartTask. Prevents the
+			// duplicate-agent bug when CreateTask synchronously promotes the task
+			// from its feeder into an auto-start destination.
+			models.MetaKeyAutoStartClaimed: true,
 		},
 	}
 }
@@ -479,6 +489,17 @@ func (s *Service) shouldAutoStartStep(ctx context.Context, stepID string) bool {
 func (s *Service) autoStartReviewTask(
 	ctx context.Context, evt *github.NewReviewPREvent, task *models.Task,
 ) {
+	// Compete for the one-shot auto-start token set at task creation.
+	// The promotion that ran inside CreateTask may have already triggered
+	// autoStartTaskForStep (Path A) asynchronously; only the first claimer
+	// launches so exactly one session is created for the task.
+	if !s.claimAutoStart(ctx, task.ID, "review.auto_start") {
+		s.logger.Debug("review auto-start claim lost; promotion path will launch",
+			zap.String("task_id", task.ID),
+			zap.Int("pr_number", evt.PR.Number))
+		return
+	}
+
 	_, err := s.StartTask(
 		ctx,
 		task.ID,
@@ -496,6 +517,7 @@ func (s *Service) autoStartReviewTask(
 		s.logger.Error("failed to auto-start review task",
 			zap.String("task_id", task.ID),
 			zap.Error(err))
+		s.restoreAutoStartClaim(ctx, task.ID, "review.auto_start")
 		return
 	}
 	s.logger.Info("auto-started review task",

--- a/apps/backend/internal/orchestrator/event_handlers_github_review_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_github_review_test.go
@@ -331,6 +331,44 @@ func TestAutoStart_ClaimIsAtomic(t *testing.T) {
 	}
 }
 
+// TestAutoStart_ClaimIsRaceSafe drives the two production auto-start paths'
+// claim through a barrier so both goroutines contend for the single token at
+// once, then joins both results and asserts exactly one winner. The sequential
+// TestAutoStart_ClaimIsAtomic only proves the token disappears after the first
+// call; it would still pass under a non-atomic read-then-delete that lets two
+// concurrent callers both win. This exercises the real read-modify-write under
+// contention against the SQLite repo's conditional UPDATE.
+func TestAutoStart_ClaimIsRaceSafe(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	const taskID = "task-claim-race"
+	seedReviewTask(t, repo, taskID, "step1")
+
+	svc := createTestService(repo, newMockStepGetter(), newMockTaskRepo())
+
+	// Release both claimers at the same instant so their RemoveTaskMetadataKey
+	// calls overlap. Results are joined through a buffered channel.
+	start := make(chan struct{})
+	results := make(chan bool, 2)
+	for range 2 {
+		go func() {
+			<-start
+			results <- svc.claimAutoStart(ctx, taskID, "test")
+		}()
+	}
+	close(start)
+
+	winners := 0
+	for range 2 {
+		if <-results {
+			winners++
+		}
+	}
+	if winners != 1 {
+		t.Fatalf("expected exactly one concurrent claim winner, got %d", winners)
+	}
+}
+
 // TestAutoStart_FailedLaunchRestoresClaim verifies that when an auto-start
 // launch fails, restoreAutoStartClaim puts the token back so a later trigger
 // can retry.

--- a/apps/backend/internal/orchestrator/event_handlers_github_review_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_github_review_test.go
@@ -2,23 +2,28 @@ package orchestrator
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/kandev/kandev/internal/github"
+	"github.com/kandev/kandev/internal/orchestrator/executor"
 	"github.com/kandev/kandev/internal/orchestrator/watcher"
-	"github.com/kandev/kandev/internal/task/models"
+	taskmodels "github.com/kandev/kandev/internal/task/models"
 	wfmodels "github.com/kandev/kandev/internal/workflow/models"
+	v1 "github.com/kandev/kandev/pkg/api/v1"
 )
 
 // countingReviewTaskCreator records how many times CreateReviewTask was called.
 type countingReviewTaskCreator struct {
-	calls  int
-	err    error
-	errs   []error
-	taskID string
+	calls    int
+	err      error
+	errs     []error
+	taskID   string
+	metadata map[string]interface{} // extra metadata added to returned task
 }
 
-func (c *countingReviewTaskCreator) CreateReviewTask(_ context.Context, _ *ReviewTaskRequest) (*models.Task, error) {
+func (c *countingReviewTaskCreator) CreateReviewTask(_ context.Context, _ *ReviewTaskRequest) (*taskmodels.Task, error) {
 	c.calls++
 	if len(c.errs) > 0 {
 		err := c.errs[0]
@@ -32,7 +37,7 @@ func (c *countingReviewTaskCreator) CreateReviewTask(_ context.Context, _ *Revie
 	if id == "" {
 		id = "task-created"
 	}
-	return &models.Task{ID: id}, nil
+	return &taskmodels.Task{ID: id, Metadata: c.metadata}, nil
 }
 
 // newReviewEvent builds a NewReviewPREvent for createReviewTask tests.
@@ -42,6 +47,7 @@ func newReviewEvent() *github.NewReviewPREvent {
 		WorkspaceID:    "ws1",
 		WorkflowID:     "wf1",
 		WorkflowStepID: "step1",
+		AgentProfileID: testAgentProfileID,
 		PR: &github.PR{
 			Number: 42, Title: "Some PR", HTMLURL: "https://gh/acme/widget/pull/42",
 			RepoOwner: "acme", RepoName: "widget",
@@ -176,6 +182,239 @@ func TestCreateReviewTask_WIPRejectionIsRetriedOnLaterPoll(t *testing.T) {
 	}
 }
 
+// --- Auto-start idempotency regression tests ---
+
+// seedReviewTask inserts a workspace, workflow, and task row into the real SQLite
+// repo so that StartTask (which reads the task) can proceed. The task carries
+// MetaKeyAutoStartClaimed so both auto-start paths compete for the same token.
+// testAgentProfileID is a stable profile ID used in auto-start regression tests.
+// It must be non-empty so executor.PrepareSession doesn't return ErrNoAgentProfileID.
+const testAgentProfileID = "test-profile-1"
+
+func seedReviewTask(t *testing.T, repo interface {
+	CreateWorkspace(context.Context, *taskmodels.Workspace) error
+	CreateWorkflow(context.Context, *taskmodels.Workflow) error
+	CreateTask(context.Context, *taskmodels.Task) error
+}, taskID, stepID string) {
+	t.Helper()
+	ctx := context.Background()
+	now := time.Now().UTC()
+	_ = repo.CreateWorkspace(ctx, &taskmodels.Workspace{ID: "ws1", Name: "Test", CreatedAt: now, UpdatedAt: now})
+	_ = repo.CreateWorkflow(ctx, &taskmodels.Workflow{ID: "wf1", WorkspaceID: "ws1", Name: "WF", CreatedAt: now, UpdatedAt: now})
+	task := &taskmodels.Task{
+		ID:             taskID,
+		WorkspaceID:    "ws1",
+		WorkflowID:     "wf1",
+		WorkflowStepID: stepID,
+		Title:          "Review PR #42",
+		Description:    "Review this PR",
+		State:          v1.TaskStateInProgress,
+		Metadata: map[string]interface{}{
+			taskmodels.MetaKeyAutoStartGuard:   true,
+			taskmodels.MetaKeyAutoStartClaimed: true,
+			taskmodels.MetaKeyAgentProfileID:   testAgentProfileID,
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	if err := repo.CreateTask(ctx, task); err != nil {
+		t.Fatalf("seedReviewTask: %v", err)
+	}
+}
+
+// TestAutoStart_BothPathsFireExactlyOnce is the regression test for the
+// duplicate-agent bug: a review task placed into a feeder and immediately
+// promoted (so both the watcher's synchronous Path B and the promotion's
+// event-driven Path A see an admitted, auto-start-eligible task) must launch
+// exactly one agent session.
+func TestAutoStart_BothPathsFireExactlyOnce(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	const taskID = "task-review-42"
+	const stepID = "step-review"
+
+	sg := newMockStepGetter()
+	sg.steps[stepID] = &wfmodels.WorkflowStep{
+		ID: stepID, WorkflowID: "wf1", Name: "Review", Position: 0,
+		Events: wfmodels.StepEvents{
+			OnEnter: []wfmodels.OnEnterAction{{Type: wfmodels.OnEnterAutoStartAgent}},
+		},
+	}
+
+	seedReviewTask(t, repo, taskID, stepID)
+
+	// mockTaskRepo must also contain the task so startTask's s.scheduler.GetTask lookup succeeds.
+	// Include agent_profile_id so executor.PrepareSession doesn't return ErrNoAgentProfileID.
+	// Include auto_start_guard so autoStartTaskForStep knows to compete for the claim token.
+	taskRepo := newMockTaskRepo()
+	taskRepo.tasks[taskID] = &v1.Task{
+		ID:    taskID,
+		State: v1.TaskStateInProgress,
+		Metadata: map[string]interface{}{
+			taskmodels.MetaKeyAutoStartGuard:   true,
+			taskmodels.MetaKeyAutoStartClaimed: true,
+			taskmodels.MetaKeyAgentProfileID:   testAgentProfileID,
+		},
+	}
+
+	var launchCount atomic.Int32
+	launched := make(chan struct{}, 2) // buffered so neither sender blocks
+	agentMgr := &mockAgentManager{
+		repoForExecutionLookup: repo,
+		launchAgentFunc: func(_ context.Context, _ *executor.LaunchAgentRequest) (*executor.LaunchAgentResponse, error) {
+			launchCount.Add(1)
+			launched <- struct{}{}
+			return &executor.LaunchAgentResponse{}, nil
+		},
+	}
+
+	svc := createTestServiceWithScheduler(repo, sg, taskRepo, agentMgr)
+
+	// Load the DB task (which has the MetaKeyAutoStartClaimed token in metadata).
+	dbTask, err := repo.GetTask(ctx, taskID)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+
+	// Path B: watcher's synchronous auto-start on an admitted task with the token.
+	svc.autoStartReviewTask(ctx, newReviewEvent(), dbTask)
+
+	// Path A: promotion event-driven auto-start on the same task.
+	// autoStartTaskForStep spawns a goroutine — we synchronise via the launched channel.
+	svc.autoStartTaskForStep(ctx, taskID, stepID, "task.queue_promoted")
+
+	// Wait for exactly one launch. Allow 2 seconds for the async goroutine.
+	deadline := time.After(2 * time.Second)
+	select {
+	case <-launched:
+	case <-deadline:
+		t.Fatal("timed out waiting for at least one launch")
+	}
+
+	// Give any erroneous second launch a short window to arrive.
+	select {
+	case <-launched:
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	if got := launchCount.Load(); got != 1 {
+		t.Errorf("expected exactly 1 LaunchAgent call, got %d", got)
+	}
+
+	sessions, err := repo.ListTaskSessions(ctx, taskID)
+	if err != nil {
+		t.Fatalf("ListTaskSessions: %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Errorf("expected exactly 1 session in DB, got %d", len(sessions))
+	}
+}
+
+// TestAutoStart_ClaimIsAtomic verifies that two competing calls to claimAutoStart
+// for the same task produce exactly one winner.
+func TestAutoStart_ClaimIsAtomic(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	const taskID = "task-claim-atomic"
+	seedReviewTask(t, repo, taskID, "step1")
+
+	svc := createTestService(repo, newMockStepGetter(), newMockTaskRepo())
+
+	first := svc.claimAutoStart(ctx, taskID, "test")
+	second := svc.claimAutoStart(ctx, taskID, "test")
+
+	if !first {
+		t.Error("first claimAutoStart should have succeeded")
+	}
+	if second {
+		t.Error("second claimAutoStart should have failed (token already removed)")
+	}
+}
+
+// TestAutoStart_FailedLaunchRestoresClaim verifies that when an auto-start
+// launch fails, restoreAutoStartClaim puts the token back so a later trigger
+// can retry.
+func TestAutoStart_FailedLaunchRestoresClaim(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	const taskID = "task-restore-claim"
+	seedReviewTask(t, repo, taskID, "step1")
+
+	svc := createTestService(repo, newMockStepGetter(), newMockTaskRepo())
+
+	// Claim succeeds — simulate a failed launch.
+	if !svc.claimAutoStart(ctx, taskID, "test") {
+		t.Fatal("initial claim should succeed")
+	}
+
+	// Restore the claim.
+	svc.restoreAutoStartClaim(ctx, taskID, "test")
+
+	// A subsequent claim should succeed again.
+	if !svc.claimAutoStart(ctx, taskID, "test") {
+		t.Error("claim after restore should succeed")
+	}
+}
+
+// TestAutoStart_NoTokenDoesNotBlock verifies that autoStartTaskForStep still
+// launches a task that has no MetaKeyAutoStartClaimed token (ordinary auto-start
+// tasks unrelated to the review watcher).
+func TestAutoStart_NoTokenDoesNotBlock(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	const taskID = "task-no-token"
+	const stepID = "step-review"
+
+	sg := newMockStepGetter()
+	sg.steps[stepID] = &wfmodels.WorkflowStep{
+		ID: stepID, WorkflowID: "wf1", Name: "Review", Position: 0,
+		Events: wfmodels.StepEvents{
+			OnEnter: []wfmodels.OnEnterAction{{Type: wfmodels.OnEnterAutoStartAgent}},
+		},
+	}
+
+	// Seed a task WITHOUT the auto-start-claimed token.
+	now := time.Now().UTC()
+	ctx2 := context.Background()
+	_ = repo.CreateWorkspace(ctx2, &taskmodels.Workspace{ID: "ws1", Name: "Test", CreatedAt: now, UpdatedAt: now})
+	_ = repo.CreateWorkflow(ctx2, &taskmodels.Workflow{ID: "wf1", WorkspaceID: "ws1", Name: "WF", CreatedAt: now, UpdatedAt: now})
+	_ = repo.CreateTask(ctx2, &taskmodels.Task{
+		ID: taskID, WorkspaceID: "ws1", WorkflowID: "wf1", WorkflowStepID: stepID,
+		Title: "T", Description: "D", State: v1.TaskStateInProgress,
+		Metadata:  map[string]interface{}{taskmodels.MetaKeyAgentProfileID: testAgentProfileID},
+		CreatedAt: now, UpdatedAt: now,
+	})
+
+	// Also seed the task in mockTaskRepo so startTask's scheduler.GetTask lookup succeeds.
+	// Include agent_profile_id so executor.PrepareSession doesn't return ErrNoAgentProfileID.
+	taskRepo := newMockTaskRepo()
+	taskRepo.tasks[taskID] = &v1.Task{
+		ID:    taskID,
+		State: v1.TaskStateInProgress,
+		Metadata: map[string]interface{}{
+			taskmodels.MetaKeyAgentProfileID: testAgentProfileID,
+		},
+	}
+
+	launched := make(chan struct{}, 1)
+	agentMgr := &mockAgentManager{
+		repoForExecutionLookup: repo,
+		launchAgentFunc: func(_ context.Context, _ *executor.LaunchAgentRequest) (*executor.LaunchAgentResponse, error) {
+			launched <- struct{}{}
+			return &executor.LaunchAgentResponse{}, nil
+		},
+	}
+	svc := createTestServiceWithScheduler(repo, sg, taskRepo, agentMgr)
+
+	svc.autoStartTaskForStep(ctx, taskID, stepID, "task.moved")
+
+	select {
+	case <-launched:
+	case <-time.After(2 * time.Second):
+		t.Fatal("autoStartTaskForStep should launch a task with no token")
+	}
+}
+
 func TestReviewWatchLifecycle_BootReadyStaysOnReviewUntilTurnComplete(t *testing.T) {
 	ctx := context.Background()
 	repo := setupTestRepo(t)
@@ -205,7 +444,7 @@ func TestReviewWatchLifecycle_BootReadyStaysOnReviewUntilTurnComplete(t *testing
 		t.Fatalf("boot-ready must not advance review task, got step %q", bootTask.WorkflowStepID)
 	}
 
-	if err := repo.UpdateTaskSessionState(ctx, "review-session", models.TaskSessionStateRunning, ""); err != nil {
+	if err := repo.UpdateTaskSessionState(ctx, "review-session", taskmodels.TaskSessionStateRunning, ""); err != nil {
 		t.Fatalf("mark review turn running: %v", err)
 	}
 	task, err := repo.GetTask(ctx, "review-task")

--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -453,6 +453,20 @@ func (s *Service) autoStartTaskForStep(ctx context.Context, taskID, stepID, even
 	// Async: event bus delivers synchronously; blocking here → HTTP timeout (see handleTaskMovedWithSession doc).
 	go func() {
 		asyncCtx := context.WithoutCancel(ctx)
+
+		// When the task has the permanent auto-start guard marker, it means
+		// both this promotion path and the watcher's synchronous path (autoStartReviewTask)
+		// can fire. Only the first atomic claim of MetaKeyAutoStartClaimed wins;
+		// the loser skips launch because the winner will handle it.
+		// Absent guard = ordinary (non-watcher) auto-start; proceed as before.
+		if _, hasGuard := task.Metadata[models.MetaKeyAutoStartGuard]; hasGuard {
+			if !s.claimAutoStart(asyncCtx, task.ID, eventName) {
+				s.logger.Debug(eventName+": auto-start claim lost; watcher path will launch",
+					zap.String("task_id", taskID))
+				return
+			}
+		}
+
 		startAgentProfileID := agentProfileID
 		if workflowAgentProfileID != "" {
 			startAgentProfileID = ""
@@ -462,6 +476,7 @@ func (s *Service) autoStartTaskForStep(ctx context.Context, taskID, stepID, even
 			s.logger.Error(eventName+": failed to auto-start task",
 				zap.String("task_id", taskID),
 				zap.Error(err))
+			s.restoreAutoStartClaim(asyncCtx, task.ID, eventName)
 		}
 	}()
 }
@@ -555,6 +570,43 @@ func (s *Service) restoreDeferredLaunch(ctx context.Context, taskID string, raw 
 	}
 	if err := setter.SetTaskMetadataKey(ctx, taskID, models.MetaKeyDeferredLaunch, raw); err != nil {
 		s.logger.Warn(eventName+": failed to restore deferred launch intent", zap.String("task_id", taskID), zap.Error(err))
+	}
+}
+
+// claimAutoStart atomically removes the MetaKeyAutoStartClaimed token from a
+// task. It returns true only for the first caller that removes the key.
+// Both Path A (event-driven autoStartTaskForStep) and Path B (watcher's
+// synchronous autoStartReviewTask) must call this when the token is present;
+// only the winner proceeds to StartTask. When the token is absent (ordinary
+// non-watcher auto-start), the caller skips the claim and launches as before.
+func (s *Service) claimAutoStart(ctx context.Context, taskID, eventName string) bool {
+	remover, ok := s.repo.(interface {
+		RemoveTaskMetadataKey(context.Context, string, string) (bool, error)
+	})
+	if !ok {
+		return true // repo doesn't support atomic removal; allow launch
+	}
+	claimed, err := remover.RemoveTaskMetadataKey(ctx, taskID, models.MetaKeyAutoStartClaimed)
+	if err != nil {
+		s.logger.Warn(eventName+": failed to claim auto-start token",
+			zap.String("task_id", taskID), zap.Error(err))
+		return false
+	}
+	return claimed
+}
+
+// restoreAutoStartClaim puts the MetaKeyAutoStartClaimed token back when a
+// launch fails so a later event trigger can retry. Mirrors restoreDeferredLaunch.
+func (s *Service) restoreAutoStartClaim(ctx context.Context, taskID, eventName string) {
+	setter, ok := s.repo.(interface {
+		SetTaskMetadataKey(context.Context, string, string, interface{}) error
+	})
+	if !ok {
+		return
+	}
+	if err := setter.SetTaskMetadataKey(ctx, taskID, models.MetaKeyAutoStartClaimed, true); err != nil {
+		s.logger.Warn(eventName+": failed to restore auto-start claim",
+			zap.String("task_id", taskID), zap.Error(err))
 	}
 }
 

--- a/apps/backend/internal/task/models/models.go
+++ b/apps/backend/internal/task/models/models.go
@@ -98,6 +98,18 @@ const (
 	// (set by CreateTask, read by the orchestrator when building a session).
 	// Centralised here so the set/read sites can't drift apart.
 	MetaKeyWorkspacePath = "workspace_path"
+	// MetaKeyAutoStartGuard is a permanent marker set at create time on tasks
+	// where both the watcher's synchronous Path B (autoStartReviewTask) and the
+	// promotion's event-driven Path A (autoStartTaskForStep) could both try to
+	// launch an agent. Its presence signals that the one-shot MetaKeyAutoStartClaimed
+	// token governs who may launch. Never removed after task creation.
+	MetaKeyAutoStartGuard = "auto_start_guard"
+	// MetaKeyAutoStartClaimed is a one-shot token set alongside MetaKeyAutoStartGuard.
+	// Both auto-start paths atomically remove this key; only the first removal
+	// succeeds and that path proceeds to StartTask. The other path skips launch
+	// because the winner will (or already did) handle it.
+	// Absent on ordinary (non-watcher) auto-start tasks, which launch normally.
+	MetaKeyAutoStartClaimed = "auto_start_claimed"
 )
 
 // TaskSession.Metadata key that records how the session came into existence.

--- a/apps/web/hooks/domains/github/use-task-pr.test.tsx
+++ b/apps/web/hooks/domains/github/use-task-pr.test.tsx
@@ -120,6 +120,43 @@ describe("useTaskPR — reconnect resync", () => {
     expect(requestMock.mock.calls.length).toBeGreaterThan(callsAfterExhaustion);
   });
 
+  // Resetting the retry refs on reconnect is not enough on its own: once the
+  // retry budget is exhausted the 5s interval clears itself, and simply zeroing
+  // retryRef doesn't recreate it. If the single reconnect sync returns empty,
+  // the store stays empty and the tab never appears. The polling interval must
+  // restart on reconnect so a fresh 30s window of 5s retries runs.
+  it("restarts the 5s retry polling after reconnect when the resync returns empty", async () => {
+    requestMock.mockResolvedValue({ prs: [] });
+
+    const { result } = renderHook(() => useTaskPRWithStore("task-1"), { wrapper });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    // Advance past the clearing tick (7 * 5s = 35s): the 6 retries fire and the
+    // 7th tick hits the budget guard and clears the interval, so no interval is
+    // live when the socket reconnects.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000 * 7);
+    });
+    const callsAfterExhaustion = requestMock.mock.calls.length;
+
+    // Reconnect: the resync fires once immediately (still empty).
+    await act(async () => {
+      result.current.store.getState().setConnectionStatus("connected", null);
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    const callsAfterReconnect = requestMock.mock.calls.length;
+    expect(callsAfterReconnect).toBeGreaterThan(callsAfterExhaustion);
+
+    // A fresh polling window must now run: advancing another 5s tick fires
+    // another retry. Without restarting the interval this stays flat.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000);
+    });
+    expect(requestMock.mock.calls.length).toBeGreaterThan(callsAfterReconnect);
+  });
+
   // A no-op status write (already-connected re-render) must not refire, or
   // every unrelated store update would spam the backend sync.
   it("does not refire while the status stays connected", async () => {

--- a/apps/web/hooks/domains/github/use-task-pr.test.tsx
+++ b/apps/web/hooks/domains/github/use-task-pr.test.tsx
@@ -16,9 +16,18 @@ vi.mock("@/lib/api/domains/github-api", () => ({
 }));
 
 import { useTaskPR } from "./use-task-pr";
+import { useAppStoreApi } from "@/components/state-provider";
 
 function wrapper({ children }: { children: ReactNode }) {
   return createElement(StateProvider, null, children);
+}
+
+// Renders the hook alongside the store api so a test can drive
+// `connection.status` transitions the way `useWebSocket` does in prod.
+function useTaskPRWithStore(taskId: string | null) {
+  const result = useTaskPR(taskId);
+  const store = useAppStoreApi();
+  return { result, store };
 }
 
 beforeEach(() => {
@@ -78,5 +87,58 @@ describe("useTaskPR — permanent flag", () => {
       await vi.advanceTimersByTimeAsync(5_000);
     });
     expect(requestMock).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe("useTaskPR — reconnect resync", () => {
+  // Reproduces the missing "Pull Request" tab: the task is opened while the
+  // WS is down, all 6 retry attempts elapse without a response, and the store
+  // never learns about the PR. When the socket later reconnects, the hook must
+  // reset the exhausted retry window and refire the sync so the tab appears.
+  it("resyncs when the connection transitions to connected after retries are exhausted", async () => {
+    // No PR ever comes back while "disconnected", so the retry loop runs to
+    // exhaustion (initial call + 6 retries).
+    requestMock.mockResolvedValue({ prs: [] });
+
+    const { result } = renderHook(() => useTaskPRWithStore("task-1"), { wrapper });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    // Burn through the full retry budget (6 * 5s).
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000 * 6);
+    });
+    const callsAfterExhaustion = requestMock.mock.calls.length;
+
+    // The socket comes up; useWebSocket flips the store to "connected".
+    await act(async () => {
+      result.current.store.getState().setConnectionStatus("connected", null);
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(requestMock.mock.calls.length).toBeGreaterThan(callsAfterExhaustion);
+  });
+
+  // A no-op status write (already-connected re-render) must not refire, or
+  // every unrelated store update would spam the backend sync.
+  it("does not refire while the status stays connected", async () => {
+    requestMock.mockResolvedValue({ prs: [] });
+
+    const { result } = renderHook(() => useTaskPRWithStore("task-1"), { wrapper });
+
+    await act(async () => {
+      result.current.store.getState().setConnectionStatus("connected", null);
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    const callsAfterConnect = requestMock.mock.calls.length;
+
+    // Re-assert the same status: no transition edge, so no new sync.
+    await act(async () => {
+      result.current.store.getState().setConnectionStatus("connected", null);
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(requestMock.mock.calls.length).toBe(callsAfterConnect);
   });
 });

--- a/apps/web/hooks/domains/github/use-task-pr.ts
+++ b/apps/web/hooks/domains/github/use-task-pr.ts
@@ -76,8 +76,13 @@ export function useTaskPR(taskId: string | null) {
   const prs = useAppStore((state) => (taskId ? (state.taskPRs.byTaskId[taskId] ?? null) : null));
   const pr = getPrimaryTaskPR(prs ?? undefined);
   const setTaskPR = useAppStore((state) => state.setTaskPR);
+  const connectionStatus = useAppStore((state) => state.connection.status);
   const retryRef = useRef(0);
   const permanentRef = useRef(false);
+  // Tracks the previous connection status so the resync effect below only
+  // fires on the transition edge into `connected`, not on every re-render
+  // while already connected.
+  const prevConnectionStatusRef = useRef(connectionStatus);
   // Monotonic counter incremented before each WS request, snapshotted in
   // the .then() closure. Mirrors useWorkspacePRs above. Without this, a
   // stale response from a previous taskId can land after the user
@@ -161,6 +166,23 @@ export function useTaskPR(taskId: string | null) {
 
     return () => clearInterval(interval);
   }, [taskId, pr, refresh]);
+
+  // Reconnect-driven resync. A task can be opened while the WS is down (e.g. a
+  // transient dev HMR disconnect, or a task auto-created by the PR-review
+  // watcher that the user navigates to directly). In that window the freshness
+  // sync and every 5s retry queue/time out with nothing, so the store never
+  // learns about the PR and the auto "Pull Request" tab is never offered. When
+  // the socket comes back up, clear the exhausted retry/permanent state and
+  // refire the sync so a fresh 30s retry window starts. Guarded on the
+  // transition edge into `connected` so unrelated store updates don't refire.
+  useEffect(() => {
+    const prev = prevConnectionStatusRef.current;
+    prevConnectionStatusRef.current = connectionStatus;
+    if (!taskId || connectionStatus !== "connected" || prev === "connected") return;
+    retryRef.current = 0;
+    permanentRef.current = false;
+    refresh();
+  }, [taskId, connectionStatus, refresh]);
 
   return { pr, prs: prs ?? [], refresh } as {
     pr: TaskPR | null;

--- a/apps/web/hooks/domains/github/use-task-pr.ts
+++ b/apps/web/hooks/domains/github/use-task-pr.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useCallback, useRef } from "react";
+import { useEffect, useCallback, useRef, useState } from "react";
 import { listWorkspaceTaskPRs } from "@/lib/api/domains/github-api";
 import { getWebSocketClient } from "@/lib/ws/connection";
 import { useAppStore } from "@/components/state-provider";
@@ -83,6 +83,9 @@ export function useTaskPR(taskId: string | null) {
   // fires on the transition edge into `connected`, not on every re-render
   // while already connected.
   const prevConnectionStatusRef = useRef(connectionStatus);
+  // Bumped on each reconnect transition so the retry-polling effect below
+  // tears down and recreates its interval (see that effect's dependency list).
+  const [reconnectGeneration, setReconnectGeneration] = useState(0);
   // Monotonic counter incremented before each WS request, snapshotted in
   // the .then() closure. Mirrors useWorkspacePRs above. Without this, a
   // stale response from a previous taskId can land after the user
@@ -152,6 +155,14 @@ export function useTaskPR(taskId: string | null) {
   // Retry polling when no PR is in the store yet. permanentRef short-circuits
   // the interval entirely so a task whose repos are all dead doesn't tie up
   // the backend's gh throttle on every 5s tick.
+  //
+  // Depends on `reconnectGeneration` so a reconnect (see the effect below,
+  // which zeroes retryRef/permanentRef and bumps the generation on the
+  // transition edge) tears down and recreates the interval, starting a fresh
+  // 30s retry window. Without that dep, once the budget is exhausted the
+  // interval clears itself and merely resetting the refs never recreates it —
+  // a single empty resync would then leave the store empty and the
+  // "Pull Request" tab missing.
   useEffect(() => {
     if (!taskId || pr || permanentRef.current) return;
 
@@ -165,16 +176,18 @@ export function useTaskPR(taskId: string | null) {
     }, SYNC_RETRY_DELAY);
 
     return () => clearInterval(interval);
-  }, [taskId, pr, refresh]);
+  }, [taskId, pr, refresh, reconnectGeneration]);
 
   // Reconnect-driven resync. A task can be opened while the WS is down (e.g. a
   // transient dev HMR disconnect, or a task auto-created by the PR-review
   // watcher that the user navigates to directly). In that window the freshness
   // sync and every 5s retry queue/time out with nothing, so the store never
   // learns about the PR and the auto "Pull Request" tab is never offered. When
-  // the socket comes back up, clear the exhausted retry/permanent state and
-  // refire the sync so a fresh 30s retry window starts. Guarded on the
-  // transition edge into `connected` so unrelated store updates don't refire.
+  // the socket comes back up, clear the exhausted retry/permanent state, refire
+  // the sync, and bump reconnectGeneration so the polling effect above restarts
+  // its (possibly already self-cleared) interval and runs a fresh 30s retry
+  // window. Guarded on the transition edge into `connected` so unrelated store
+  // updates don't refire.
   useEffect(() => {
     const prev = prevConnectionStatusRef.current;
     prevConnectionStatusRef.current = connectionStatus;
@@ -182,6 +195,7 @@ export function useTaskPR(taskId: string | null) {
     retryRef.current = 0;
     permanentRef.current = false;
     refresh();
+    setReconnectGeneration((g) => g + 1);
   }, [taskId, connectionStatus, refresh]);
 
   return { pr, prs: prs ?? [], refresh } as {

--- a/docs/plans/review-watcher-double-autostart/plan.md
+++ b/docs/plans/review-watcher-double-autostart/plan.md
@@ -1,0 +1,140 @@
+---
+spec: docs/specs/tasks/wip-limit-pull-system.md
+created: 2026-07-29
+status: draft
+---
+
+# Implementation Plan: Single Auto-Start Per Review Task
+
+## Overview
+
+Fix a duplicate-agent bug: a GitHub review-watch task created for an auto-start
+`Review` step that has a WIP limit plus a `pull_from_step_id` feeder can launch
+two agent sessions. The fix adds one race-safe, per-task auto-start claim shared
+by the two auto-start paths so exactly one launches. No schema, API, or UI
+changes are required.
+
+---
+
+## Confirmed root cause
+
+`task/service.Service.CreateTask` places the review task in the feeder, then
+**synchronously** promotes it into `Review` inside the same call
+(`pullTasksFromNewFeederWork` -> `promoteFeederQueuedTask`), re-reads the task,
+and returns the promoted task (`queued_for_step_id` cleared). Two paths then
+each call `StartTask` for that admitted task with no shared guard:
+
+- **Path A (event-driven):** the promotion publishes `task.moved` /
+  `task.queue_promoted`; the orchestrator handler
+  `autoStartTaskForStep` (`event_handlers_workflow.go:406`) passes its
+  `QueuedForStepID != ""` guard (already cleared) and spawns
+  `go StartTask(...)`.
+- **Path B (synchronous):** `createReviewTask`
+  (`event_handlers_github.go:363-366`) sees the returned task with
+  `QueuedForStepID == ""`, so it calls `autoStartReviewTask` ->
+  `StartTask(...)`.
+
+For Kanban (non-Office) tasks `StartTask` always mints a fresh session, so both
+paths create a session. Only the deferred-launch path
+(`claimDeferredLaunch` + `RemoveTaskMetadataKey`) has an atomic claim today; the
+review-watcher/on-enter auto-start paths have none.
+
+---
+
+## Backend design
+
+### Shared auto-start claim helper
+
+Add a single race-safe claim, reusing the existing atomic metadata-claim
+mechanism class (`RemoveTaskMetadataKey`, already used by
+`claimDeferredLaunch`). Introduce a new metadata key
+`MetaKeyAutoStartClaimed` in
+`apps/backend/internal/task/models/models.go` (alongside
+`MetaKeyDeferredLaunch`).
+
+- Creation adapters that produce an auto-start-eligible task set
+  `MetaKeyAutoStartClaimed` in the task metadata at create time (atomic with the
+  task row, same commit as other create metadata). This is the token both paths
+  compete to consume.
+- New helper in `event_handlers_workflow.go`, e.g.
+  `claimAutoStart(ctx, taskID, eventName) bool`, that calls
+  `RemoveTaskMetadataKey(ctx, taskID, MetaKeyAutoStartClaimed)` and returns
+  `true` only for the caller that removed the key. Mirrors
+  `claimDeferredLaunch`'s atomic semantics.
+- On launch failure the claim is restored (`SetTaskMetadataKey`) so the task can
+  be retried, mirroring `restoreDeferredLaunch`.
+
+### Wire both paths through the claim
+
+- **Path A** — `autoStartTaskForStep` (`event_handlers_workflow.go:406`): after
+  the existing `launchDeferredTask` short-circuit and after confirming the step
+  has `OnEnterAutoStartAgent`, call `claimAutoStart`. If it returns `false`,
+  return without launching. Only claim when the token is present so ordinary
+  (non-watcher) auto-start tasks that never set the token keep launching exactly
+  once via this single path (see "Token scope" below).
+- **Path B** — `autoStartReviewTask` (`event_handlers_github.go`): call
+  `claimAutoStart` before `StartTask`; skip when it returns `false`.
+
+### Token scope (avoid regressing normal auto-start)
+
+Only tasks that can be reached by BOTH paths need the token. That is the
+watcher-created task whose destination is a WIP+feeder auto-start step. To keep
+the change minimal and not regress the many tasks that legitimately auto-start
+through Path A alone:
+
+- The claim is a no-op skip when the key is absent AND the caller is Path A
+  (event-driven): absence means "no competing synchronous path exists", so Path
+  A launches as before.
+- Path B always requires a successful claim: it only runs for watcher-created
+  tasks, which set the token at create time.
+
+This makes the guard active precisely for the double-start window (token
+present) and transparent everywhere else. Decision recorded in the task file;
+if review prefers an unconditional claim for every auto-start, that is the
+alternative called out in Open Questions.
+
+---
+
+## Tests
+
+- **What:** A single review task reachable by both auto-start paths launches
+  exactly one session. **File:**
+  `apps/backend/internal/orchestrator/event_handlers_github_review_test.go`.
+  **How:** seed an `OnEnterAutoStartAgent` step; create a task carrying
+  `MetaKeyAutoStartClaimed`; invoke Path A (`autoStartTaskForStep` /
+  `handleTaskQueuePromoted`) and Path B (`autoStartReviewTask`) against the same
+  task; assert exactly one launch. Count launches via `mockAgentManager`'s
+  `launchAgentFunc` and/or `repo.ListTaskSessions(taskID)` == 1. Join the async
+  `go StartTask` goroutines via the launch counter side effect (per backend
+  AGENTS.md goroutine-join guidance), not `time.Sleep`.
+- **What:** `claimAutoStart` is atomic — two concurrent claimers, one winner.
+  **File:** same test file. **How:** call the claim helper twice for one task;
+  assert first returns `true`, second `false`.
+- **What:** failed launch restores the claim so a later trigger can retry.
+  **File:** same test file. **How:** force the launch path to error, assert the
+  key is present again and a subsequent claim succeeds.
+- **What:** an ordinary auto-start task with NO token still launches once via
+  Path A. **File:** same test file (or `event_handlers_workflow_moved_test.go`).
+  **How:** existing `handleTaskMoved` auto-start test remains green.
+
+Run: `cd apps/backend && go test -race -run 'AutoStart|ReviewTask' ./internal/orchestrator/...`
+
+---
+
+## Implementation Waves And Parallel Candidates
+
+Small fix — sequential, single task.
+
+```
+Wave 1:
+- [ ] [task-01-shared-autostart-claim](task-01-shared-autostart-claim.md)
+```
+
+---
+
+## Open Questions
+
+- Should the claim be unconditional for every auto-start path (simpler, but
+  touches all Path A creation sites to set the token) rather than
+  token-present-only? Current plan uses token-present-only to keep the blast
+  radius to watcher-created tasks. Confirm during review.

--- a/docs/plans/review-watcher-double-autostart/plan.md
+++ b/docs/plans/review-watcher-double-autostart/plan.md
@@ -1,7 +1,7 @@
 ---
 spec: docs/specs/tasks/wip-limit-pull-system.md
 created: 2026-07-29
-status: draft
+status: complete
 ---
 
 # Implementation Plan: Single Auto-Start Per Review Task
@@ -127,8 +127,30 @@ Small fix — sequential, single task.
 
 ```
 Wave 1:
-- [ ] [task-01-shared-autostart-claim](task-01-shared-autostart-claim.md)
+- [x] [task-01-shared-autostart-claim](task-01-shared-autostart-claim.md)
 ```
+
+## Verification
+
+Implemented on branch `feature/fix-double-agents`. The shared race-safe claim
+(`MetaKeyAutoStartClaimed`) is set at review-task creation
+(`buildReviewTaskRequest`) alongside the `MetaKeyAutoStartGuard` marker; both
+`autoStartTaskForStep` (Path A) and `autoStartReviewTask` (Path B) compete for
+it via `claimAutoStart`, and a failed launch restores the token via
+`restoreAutoStartClaim`.
+
+Command:
+`cd apps/backend && go test -race -run 'AutoStart|ReviewTask' ./internal/orchestrator/...`
+— pass. Coverage includes both-paths-fire-once, sequential claim atomicity, a
+concurrent barrier claim (exactly one winner under contention), failed-launch
+restore, and no-token-does-not-block.
+
+Known limitation (tracked for follow-up): the guard is not cleared after the
+one-shot token is consumed, so a review task whose completed session is deleted
+and is then moved back into an auto-start step would find the guard present and
+the token gone, and Path A would skip that re-entry launch. Clearing the guard
+on success reopens the creation-time double-launch window, so a correct fix
+needs a launch-generation marker rather than a simple guard clear.
 
 ---
 

--- a/docs/plans/review-watcher-double-autostart/task-01-shared-autostart-claim.md
+++ b/docs/plans/review-watcher-double-autostart/task-01-shared-autostart-claim.md
@@ -1,0 +1,114 @@
+---
+id: "01-shared-autostart-claim"
+title: "Shared race-safe auto-start claim for review tasks"
+status: pending
+wave: 1
+depends_on: []
+plan: "plan.md"
+spec: "../../specs/tasks/wip-limit-pull-system.md"
+---
+
+# Task 01: Shared race-safe auto-start claim
+
+Ensure a single accepted review-watch create auto-starts at most one agent
+session, even when the task is placed in a feeder and immediately promoted into
+an auto-start `Review` step during the same `CreateTask` call.
+
+## Root cause (for the implementer)
+
+Both auto-start paths call `StartTask` for the same admitted task with no shared
+guard:
+
+- Path A: `autoStartTaskForStep` (`internal/orchestrator/event_handlers_workflow.go:406`)
+  triggered by the promotion's `task.moved` / `task.queue_promoted` event; its
+  `task.QueuedForStepID != ""` guard (line 413) is already cleared after
+  promotion, so it spawns `go StartTask(...)`.
+- Path B: `autoStartReviewTask` (`internal/orchestrator/event_handlers_github.go`)
+  called synchronously from `createReviewTask` (lines 363-366) because the
+  returned task has `QueuedForStepID == ""`.
+
+Only `claimDeferredLaunch` (`event_handlers_workflow.go:529`, backed by
+`RemoveTaskMetadataKey` in `internal/task/repository/sqlite/task.go:474`) has an
+atomic claim today. Reuse that mechanism class.
+
+## TDD sequence (Red -> Green)
+
+1. Add a failing test in
+   `internal/orchestrator/event_handlers_github_review_test.go` that seeds an
+   `OnEnterAutoStartAgent` step, creates a task carrying the new
+   `MetaKeyAutoStartClaimed` token, drives BOTH Path A and Path B against that
+   task, and asserts exactly one launch (count via `mockAgentManager.launchAgentFunc`
+   and/or `repo.ListTaskSessions(taskID)` length == 1). Join async `go StartTask`
+   goroutines via the launch counter (channel/side-effect), not `time.Sleep`.
+2. Add a failing unit test that `claimAutoStart` returns `true` then `false` for
+   two claims on the same task.
+3. Add a failing test that a launch failure restores the token (subsequent claim
+   succeeds).
+4. Implement (below) until green.
+5. Keep the existing `handleTaskMoved` auto-start test green (no-token task still
+   launches once via Path A).
+
+## Implementation
+
+- Add constant `MetaKeyAutoStartClaimed = "auto_start_claimed"` in
+  `internal/task/models/models.go` (in the metadata-keys const block near
+  `MetaKeyDeferredLaunch`, line ~96).
+- Set the token at review-task creation so the two paths compete for it. Set it
+  on the create request metadata that `buildReviewTaskRequest`
+  (`event_handlers_github.go`) produces (or in the `CreateReviewTask` adapter in
+  `internal/backendapp/orchestrator.go`), so it commits atomically with the task
+  row. Do NOT set it via a follow-up `UpdateTask`.
+- Add `claimAutoStart(ctx, taskID, eventName string) bool` in
+  `event_handlers_workflow.go`, mirroring `claimDeferredLaunch`: type-assert the
+  repo to the `RemoveTaskMetadataKey(context.Context, string, string) (bool, error)`
+  interface and remove `MetaKeyAutoStartClaimed`. Return `true` only when the key
+  was present and removed.
+- Add `restoreAutoStartClaim(ctx, taskID, eventName string)` mirroring
+  `restoreDeferredLaunch`, using `SetTaskMetadataKey` to re-add the token on
+  launch failure.
+- Path A (`autoStartTaskForStep`): after the `launchDeferredTask` short-circuit
+  and after confirming `step.HasOnEnterAction(OnEnterAutoStartAgent)`, if the
+  task metadata contains `MetaKeyAutoStartClaimed`, call `claimAutoStart`; when
+  it returns `false`, return without launching. When the token is absent, launch
+  as today (no regression for ordinary auto-start tasks). On `StartTask` error
+  inside the goroutine, call `restoreAutoStartClaim`.
+- Path B (`autoStartReviewTask`): call `claimAutoStart` before `StartTask`; when
+  it returns `false`, log and return. On `StartTask` error, call
+  `restoreAutoStartClaim`.
+
+## Acceptance
+
+- A review task reachable by both auto-start paths produces exactly one session
+  / one `LaunchAgent` call.
+- `claimAutoStart` is atomic: two claims for one task yield one `true`, one
+  `false`.
+- A failed launch restores the token so a later trigger retries.
+- An ordinary auto-start task with no token still launches exactly once via
+  Path A (existing tests remain green).
+- No schema, DTO, API, or UI changes.
+
+## Verification
+
+```bash
+cd apps/backend
+go test -race -run 'AutoStart|ReviewTask|TaskMoved' ./internal/orchestrator/... -count=1
+golangci-lint run ./internal/orchestrator/... ./internal/task/models/... --timeout=5m
+```
+
+## Files likely touched
+
+- `apps/backend/internal/task/models/models.go`
+- `apps/backend/internal/orchestrator/event_handlers_workflow.go`
+- `apps/backend/internal/orchestrator/event_handlers_github.go`
+- `apps/backend/internal/backendapp/orchestrator.go` (or `buildReviewTaskRequest`)
+- `apps/backend/internal/orchestrator/event_handlers_github_review_test.go`
+
+## Parallelism
+
+sequential
+
+## Output contract
+
+On completion: summarize the change, list files touched, paste the `go test`
+result, note any blockers/risks, set this file's `status: done`, and tick the
+Wave 1 checkbox in `plan.md`.

--- a/docs/plans/review-watcher-double-autostart/task-01-shared-autostart-claim.md
+++ b/docs/plans/review-watcher-double-autostart/task-01-shared-autostart-claim.md
@@ -1,7 +1,7 @@
 ---
 id: "01-shared-autostart-claim"
 title: "Shared race-safe auto-start claim for review tasks"
-status: pending
+status: done
 wave: 1
 depends_on: []
 plan: "plan.md"
@@ -112,3 +112,38 @@ sequential
 On completion: summarize the change, list files touched, paste the `go test`
 result, note any blockers/risks, set this file's `status: done`, and tick the
 Wave 1 checkbox in `plan.md`.
+
+## Completion record
+
+Summary: added the one-shot `MetaKeyAutoStartClaimed` token (set at review-task
+creation in `buildReviewTaskRequest` alongside `MetaKeyAutoStartGuard`) and the
+`claimAutoStart` / `restoreAutoStartClaim` helpers. Path A
+(`autoStartTaskForStep`) and Path B (`autoStartReviewTask`) both compete for the
+token when the guard is present; only the winner launches, and a failed launch
+restores the token for retry. Ordinary (guardless) auto-start tasks are
+unaffected.
+
+Files touched:
+
+- `apps/backend/internal/task/models/models.go`
+- `apps/backend/internal/orchestrator/event_handlers_workflow.go`
+- `apps/backend/internal/orchestrator/event_handlers_github.go`
+- `apps/backend/internal/orchestrator/event_handlers_github_review_test.go`
+
+Test result:
+
+```
+cd apps/backend && go test -race -run 'AutoStart|ReviewTask|ReviewWatch' ./internal/orchestrator/
+ok  	github.com/kandev/kandev/internal/orchestrator
+```
+
+Covered: both-paths-fire-once, sequential claim atomicity, concurrent barrier
+claim (exactly one winner under contention), failed-launch restore, and
+no-token-does-not-block.
+
+Blockers/risks: the guard is intentionally left permanent. A review task whose
+completed session is deleted and is then moved back into an auto-start step
+would find the guard present and the token consumed, so Path A skips that
+re-entry launch. Clearing the guard on success reopens the creation-time
+double-launch race, so a proper fix needs a launch-generation marker; tracked
+as follow-up in `plan.md` rather than fixed here.

--- a/docs/specs/tasks/wip-limit-pull-system.md
+++ b/docs/specs/tasks/wip-limit-pull-system.md
@@ -1,7 +1,7 @@
 ---
 status: accepted
 created: 2026-07-27
-updated: 2026-07-28
+updated: 2026-07-29
 owner: kandev
 ---
 
@@ -47,6 +47,12 @@ GitHub-specific retry logic.
 - A promoted task follows the destination step's normal `on_enter` behavior.
   If the original create request explicitly requested an agent start, that
   deferred launch intent also becomes eligible when the task is promoted.
+- A single accepted create must auto-start at most one agent session, even when
+  creation synchronously promotes the task into an auto-start destination. A
+  watcher's synchronous auto-start and the promotion's event-driven auto-start
+  must not both launch. This applies whether the destination has capacity at
+  creation (direct admission) or opens capacity during the same create call
+  (feeder placement immediately promoted). See "Auto-start idempotency" below.
 - The Kanban board shows queued state on each affected task and continues to
   show WIP consumption as `admitted/limit`. The total number of cards may be
   larger than the admitted count.
@@ -65,6 +71,36 @@ Kandev attempts that feeder only. If the feeder is itself WIP-full, creation
 returns the existing capacity conflict and creates nothing; Kandev does not
 walk a chain of feeders. This remains an explicit assumption because the user
 did not choose a recursive policy.
+
+### Auto-start idempotency
+
+When a task is created for an auto-start destination step, two independent code
+paths can each try to launch the agent:
+
+- the integration watcher (e.g. GitHub PR review) calls the start path
+  synchronously after `CreateTask` returns, because the returned task reflects
+  its post-promotion placement (`queued_for_step_id` cleared, resident in the
+  auto-start destination);
+- the promotion that ran inside that same `CreateTask` publishes the normal
+  `task.moved` / `task.queue_promoted` event, whose handler independently
+  auto-starts a task that is admitted in an auto-start step.
+
+Both paths resolve to the same task in the same admitted state, so without a
+shared guard each mints its own session. This produces two agents for one
+review task, which the "start exactly once" contract forbids.
+
+- The two auto-start paths must share one race-safe, per-task claim. Whichever
+  path claims first launches; the other observes the claim and does nothing.
+- The claim is atomic against concurrent claimers (same mechanism class as the
+  existing deferred-launch metadata claim) so the two paths cannot both succeed
+  even when they run within milliseconds of each other.
+- A user-initiated start after the task has genuinely finished its automated run
+  is not blocked by this claim: the guard scopes to the automated
+  create-and-promote launch, not to every future launch of the task.
+- If the claiming path's launch fails, the claim is released so the task can be
+  retried instead of being left permanently unstarted.
+- The guard is independent of whether the task was directly admitted or promoted
+  from a feeder; both admission routes are covered.
 
 ## Data model
 
@@ -237,6 +273,12 @@ destination.
 - **GIVEN** a full destination and a configured feeder that is also WIP-full,
   **WHEN** a new task targets the destination, **THEN** creation returns a
   conflict and no task is persisted; a second feeder is not traversed.
+- **GIVEN** an auto-start `Review` step with a WIP limit and a `pull_from_step_id`
+  feeder that has capacity, **WHEN** a GitHub review watch creates a task that is
+  placed in the feeder and immediately promoted into `Review` during the same
+  create call, **THEN** exactly one agent session is auto-started for that task,
+  even though both the watcher's synchronous start and the promotion's
+  event-driven start attempt to launch it.
 - **GIVEN** a same-step queued task with an explicit `start_agent` request,
   **WHEN** the backend restarts before capacity opens, **THEN** the task remains
   queued with no runtime resources and starts exactly once after promotion.
@@ -271,3 +313,6 @@ See
 
 See
 [`../../plans/wip-overflow-queues/plan.md`](../../plans/wip-overflow-queues/plan.md).
+
+Auto-start idempotency repair (single agent per review task):
+[`../../plans/review-watcher-double-autostart/plan.md`](../../plans/review-watcher-double-autostart/plan.md).


### PR DESCRIPTION
Tasks auto-created by the PR-review watcher could open with no "Pull Request" tab, and the same watcher path could spawn duplicate agents; this restores a single agent per promotion and reliably surfaces the PR tab once the socket recovers.

## Important Changes

- Orchestrator: prevent the review watcher's pull+wip promotion from launching a duplicate agent.
- Web: `useTaskPR` now watches `connection.status` and, on the transition edge into `connected`, resets the exhausted retry/permanent state and refires `github.task_pr.sync`, so a task opened while the websocket is down still hydrates its PR into the store and offers the auto PR tab.

## Validation

- `pnpm exec vitest run hooks/domains/github/use-task-pr.test.tsx` (4 passed, incl. new reconnect-resync and no-refire-while-connected cases)
- `pnpm run typecheck` (apps/web) — clean
- `pnpm --filter @kandev/web lint` (`--max-warnings 0`) — clean

## Possible Improvements

Low risk. This covers transient disconnects; a websocket that never reconnects (bad Origin, blocked port) would still leave the task-detail route without PR data. An HTTP fallback on `/t/:id` would close that gap and could follow separately.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2034?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->