### PR TITLE
fix(backend): cover agent launch readiness timeout

### DIFF
--- a/apps/backend/internal/orchestrator/task_operations.go
+++ b/apps/backend/internal/orchestrator/task_operations.go
@@ -1682,8 +1682,8 @@ func (s *Service) ensureSessionRunning(ctx context.Context, sessionID string, se
 	// MCP tool-call timeout, etc.) would otherwise still abort these polling
 	// waits early with a misleading "context deadline exceeded" even though the
 	// resume is progressing fine in the background and would succeed within its
-	// own bounded timeouts (waitForSessionReady's 90s, waitForAgentPromptReady's
-	// 30s below).
+	// own bounded timeouts (waitForSessionReady's AgentLaunchTimeout launch
+	// budget, and waitForAgentPromptReady's 30s below).
 	if err := s.waitForSessionReady(resumeCtx, sessionID); err != nil {
 		return fmt.Errorf("session not ready after resume: %w", err)
 	}

--- a/apps/backend/internal/orchestrator/task_operations_wait_test.go
+++ b/apps/backend/internal/orchestrator/task_operations_wait_test.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"testing/synctest"
+	"time"
 
+	"github.com/kandev/kandev/internal/common/constants"
 	"github.com/kandev/kandev/internal/task/models"
 )
 
@@ -16,11 +19,12 @@ type deadlineRecordingRepo struct {
 	sessionExecutorStore
 	sawCall     bool
 	hadDeadline bool
+	deadline    time.Time
 }
 
 func (r *deadlineRecordingRepo) GetTaskSession(ctx context.Context, id string) (*models.TaskSession, error) {
 	r.sawCall = true
-	_, r.hadDeadline = ctx.Deadline()
+	r.deadline, r.hadDeadline = ctx.Deadline()
 	return &models.TaskSession{ID: id, State: models.TaskSessionStateFailed, ErrorMessage: "forced-by-test"}, nil
 }
 
@@ -51,4 +55,27 @@ func TestWaitForSessionReady_BoundsQueriesWithNonCancellableContext(t *testing.T
 	if !rec.hadDeadline {
 		t.Error("GetTaskSession received a context WITHOUT a deadline — queries are unbounded (regression of cubic P2 fix)")
 	}
+}
+
+func TestWaitForSessionReady_UsesAgentLaunchTimeout(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		repo := setupTestRepo(t)
+		svc := createTestService(repo, newMockStepGetter(), newMockTaskRepo())
+		seedTaskAndSession(t, repo, "task1", "session1", models.TaskSessionStateRunning)
+
+		rec := &deadlineRecordingRepo{sessionExecutorStore: svc.repo}
+		svc.repo = rec
+		startedAt := time.Now()
+
+		if err := svc.waitForSessionReady(context.WithoutCancel(context.Background()), "session1"); err == nil {
+			t.Fatal("expected error from the forced-failed session")
+		}
+
+		if !rec.hadDeadline {
+			t.Fatal("GetTaskSession received a context WITHOUT a deadline")
+		}
+		if got := rec.deadline.Sub(startedAt); got != constants.AgentLaunchTimeout {
+			t.Fatalf("waitForSessionReady deadline = %s, want %s", got, constants.AgentLaunchTimeout)
+		}
+	})
 }


### PR DESCRIPTION
A readiness wait could regress to 90 seconds without the existing tests detecting it, causing slow agent launches to fail prematurely. This adds deterministic coverage for the shared six-minute launch budget and updates the resume-path comment to name that budget.

## Validation

- `go test -run 'TestWaitForSessionReady_(BoundsQueriesWithNonCancellableContext|UsesAgentLaunchTimeout)$' ./internal/orchestrator -count=1`
- `go test ./internal/orchestrator -count=1` (1,268 tests passed)
- Pre-commit hooks: harness lint, gofmt, Go lint, and commitlint passed; web hooks skipped because no web files changed.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2040?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->