### PR TITLE
fix: resume archive-cancelled sessions without a running row

### DIFF
--- a/apps/backend/internal/orchestrator/executor/executor_resume.go
+++ b/apps/backend/internal/orchestrator/executor/executor_resume.go
@@ -844,11 +844,33 @@ func (e *Executor) applyExecutorConfigToResumeRequest(ctx context.Context, req *
 	return execConfig
 }
 
+// isArchiveCancelledResumeSession reports whether session was cancelled by an
+// archive (Service.ArchiveTask's single-task path or HandoffService's cascade
+// archive) rather than an explicit user/coordinator stop. Mirrors
+// orchestrator.isArchiveCancelledSession — kept local to this package since
+// the two live on opposite sides of the executor/orchestrator boundary and
+// the check is two lines over already-exported models helpers.
+func isArchiveCancelledResumeSession(session *models.TaskSession) bool {
+	return session != nil &&
+		session.State == models.TaskSessionStateCancelled &&
+		models.IsArchiveCancelReason(session.ErrorMessage)
+}
+
 // applyRunningRecordToResumeRequest loads the ExecutorRunning record and applies
 // resume-related fields (remote reconnect, resume token) to the request.
 func (e *Executor) applyRunningRecordToResumeRequest(ctx context.Context, req *LaunchAgentRequest, task *v1.Task, session *models.TaskSession, startAgent bool) *models.ExecutorRunning {
 	running, runErr := e.repo.GetExecutorRunningBySessionID(ctx, session.ID)
 	if runErr != nil || running == nil {
+		// Archive cleanup tears down the executors_running row entirely, so an
+		// archive-cancelled session reaches this point with running == nil —
+		// exactly the shape GetTaskSessionStatus's resumeReasonArchiveCancelledResumable
+		// auto-resumes once the task is unarchived. There is no resume token or
+		// running record to fall back on here, but the launch still must not
+		// replay task.Description as a fresh prompt — see the else-if branch
+		// below for the same guard on the running-record path.
+		if startAgent && isArchiveCancelledResumeSession(session) {
+			req.TaskDescription = ""
+		}
 		return nil
 	}
 
@@ -880,8 +902,11 @@ func (e *Executor) applyRunningRecordToResumeRequest(ctx context.Context, req *L
 			zap.String("task_id", task.ID),
 			zap.String("session_id", session.ID),
 			zap.Bool("has_resume_token", running.ResumeToken != ""))
-	} else if startAgent && session.State == models.TaskSessionStateWaitingForInput {
-		// Fresh-start resume (no resume token): don't auto-prompt with the task description.
+	} else if startAgent && (session.State == models.TaskSessionStateWaitingForInput || isArchiveCancelledResumeSession(session)) {
+		// Fresh-start resume (no resume token): don't auto-prompt with the task
+		// description. Also covers an archive-cancelled session whose running
+		// record survived cleanup but carries no token — same auto-resume shape
+		// as the running==nil branch above.
 		req.TaskDescription = ""
 		e.logger.Info("fresh-start resume, clearing task description to avoid auto-prompt",
 			zap.String("task_id", task.ID),

--- a/apps/backend/internal/orchestrator/executor/executor_resume_test.go
+++ b/apps/backend/internal/orchestrator/executor/executor_resume_test.go
@@ -425,6 +425,156 @@ func TestResumeSession_CancelledStateForceCleansUpStaleState(t *testing.T) {
 	}
 }
 
+// TestResumeSession_ArchiveCancelledWithoutRunningRow_ClearsTaskDescription
+// covers the shape Service.ArchiveTask / HandoffService's cascade leaves
+// behind: the executors_running row is torn down entirely, so there is no
+// resume token to trigger applyRunningRecordToResumeRequest's normal
+// TaskDescription-clearing branches. GetTaskSessionStatus still marks such
+// sessions auto-resumable (resumeReasonArchiveCancelledResumable) once the
+// task is unarchived, so simply opening the task must not replay
+// task.Description as a fresh prompt and restart the original work.
+func TestResumeSession_ArchiveCancelledWithoutRunningRow_ClearsTaskDescription(t *testing.T) {
+	repo := newMockRepository()
+	now := time.Now().UTC()
+	repo.tasks["task-1"] = &models.Task{
+		ID:          "task-1",
+		WorkspaceID: "workspace-1",
+		Description: "do the original thing",
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	repo.sessions["sess-1"] = &models.TaskSession{
+		ID:             "sess-1",
+		TaskID:         "task-1",
+		AgentProfileID: "profile-1",
+		State:          models.TaskSessionStateCancelled,
+		ErrorMessage:   models.SessionArchiveCancelReason,
+	}
+	// Deliberately no repo.executorsRunning["sess-1"] entry — the archive
+	// cleanup already deleted it.
+
+	var capturedReq *LaunchAgentRequest
+	agentMgr := &mockAgentManager{
+		launchAgentFunc: func(_ context.Context, req *LaunchAgentRequest) (*LaunchAgentResponse, error) {
+			capturedReq = req
+			return &LaunchAgentResponse{AgentExecutionID: "exec-new", Status: v1.AgentStatusStarting}, nil
+		},
+	}
+	exec := newTestExecutor(t, agentMgr, repo)
+
+	callerSession := *repo.sessions["sess-1"]
+	if _, err := exec.ResumeSession(context.Background(), &callerSession, true); err != nil {
+		t.Fatalf("ResumeSession: %v", err)
+	}
+	if capturedReq == nil {
+		t.Fatal("LaunchAgent was not called")
+	}
+	if capturedReq.TaskDescription != "" {
+		t.Errorf("TaskDescription = %q, want empty — auto-resuming an archive-cancelled "+
+			"session without a running row must not replay the original prompt", capturedReq.TaskDescription)
+	}
+}
+
+// TestResumeSession_UserCancelledWithoutRunningRow_KeepsTaskDescription is
+// the scoping counterpart to the archive-cancelled test above: a session the
+// user explicitly stopped (not an archive side effect) must not have its
+// TaskDescription cleared by this fix — that behavior is unrelated to the
+// auto-replay bug and out of scope here.
+func TestResumeSession_UserCancelledWithoutRunningRow_KeepsTaskDescription(t *testing.T) {
+	repo := newMockRepository()
+	now := time.Now().UTC()
+	repo.tasks["task-1"] = &models.Task{
+		ID:          "task-1",
+		WorkspaceID: "workspace-1",
+		Description: "do the original thing",
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	repo.sessions["sess-1"] = &models.TaskSession{
+		ID:             "sess-1",
+		TaskID:         "task-1",
+		AgentProfileID: "profile-1",
+		State:          models.TaskSessionStateCancelled,
+		ErrorMessage:   "stopped via API",
+	}
+	// No repo.executorsRunning["sess-1"] entry, same as the archive-cancelled
+	// case, but ErrorMessage is not an archive reason.
+
+	var capturedReq *LaunchAgentRequest
+	agentMgr := &mockAgentManager{
+		launchAgentFunc: func(_ context.Context, req *LaunchAgentRequest) (*LaunchAgentResponse, error) {
+			capturedReq = req
+			return &LaunchAgentResponse{AgentExecutionID: "exec-new", Status: v1.AgentStatusStarting}, nil
+		},
+	}
+	exec := newTestExecutor(t, agentMgr, repo)
+
+	callerSession := *repo.sessions["sess-1"]
+	if _, err := exec.ResumeSession(context.Background(), &callerSession, true); err != nil {
+		t.Fatalf("ResumeSession: %v", err)
+	}
+	if capturedReq == nil {
+		t.Fatal("LaunchAgent was not called")
+	}
+	if capturedReq.TaskDescription != "do the original thing" {
+		t.Errorf("TaskDescription = %q, want %q — a plain user-cancel resume is unaffected by the archive-cancel fix",
+			capturedReq.TaskDescription, "do the original thing")
+	}
+}
+
+// TestResumeSession_ArchiveCancelledWithSurvivingRunningRow_ClearsTaskDescription
+// covers the other shape the same GetTaskSessionStatus branch can observe: the
+// executors_running row survived cleanup but carries no resume token. The
+// original applyRunningRecordToResumeRequest only cleared TaskDescription for
+// WaitingForInput fresh-starts, never for this CANCELLED case, so this locks
+// in the extended else-if condition alongside the running==nil branch above.
+func TestResumeSession_ArchiveCancelledWithSurvivingRunningRow_ClearsTaskDescription(t *testing.T) {
+	repo := newMockRepository()
+	now := time.Now().UTC()
+	repo.tasks["task-1"] = &models.Task{
+		ID:          "task-1",
+		WorkspaceID: "workspace-1",
+		Description: "do the original thing",
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	repo.sessions["sess-1"] = &models.TaskSession{
+		ID:             "sess-1",
+		TaskID:         "task-1",
+		AgentProfileID: "profile-1",
+		State:          models.TaskSessionStateCancelled,
+		ErrorMessage:   models.SessionArchiveTreeCancelReason,
+	}
+	repo.executorsRunning["sess-1"] = &models.ExecutorRunning{
+		ID:        "sess-1",
+		SessionID: "sess-1",
+		TaskID:    "task-1",
+		// No ResumeToken: the running row survived, but resume must still fall
+		// through to a fresh, promptless start.
+	}
+
+	var capturedReq *LaunchAgentRequest
+	agentMgr := &mockAgentManager{
+		launchAgentFunc: func(_ context.Context, req *LaunchAgentRequest) (*LaunchAgentResponse, error) {
+			capturedReq = req
+			return &LaunchAgentResponse{AgentExecutionID: "exec-new", Status: v1.AgentStatusStarting}, nil
+		},
+	}
+	exec := newTestExecutor(t, agentMgr, repo)
+
+	callerSession := *repo.sessions["sess-1"]
+	if _, err := exec.ResumeSession(context.Background(), &callerSession, true); err != nil {
+		t.Fatalf("ResumeSession: %v", err)
+	}
+	if capturedReq == nil {
+		t.Fatal("LaunchAgent was not called")
+	}
+	if capturedReq.TaskDescription != "" {
+		t.Errorf("TaskDescription = %q, want empty — a surviving-but-tokenless running row "+
+			"must not replay the original prompt either", capturedReq.TaskDescription)
+	}
+}
+
 // TestResumeSession_PropagatesIsPassthrough verifies the session's IsPassthrough
 // snapshot taken at session-creation time is carried through the resume request
 // to the lifecycle manager, so a profile that toggles CLIPassthrough after the

--- a/apps/backend/internal/orchestrator/task_operations.go
+++ b/apps/backend/internal/orchestrator/task_operations.go
@@ -59,6 +59,14 @@ const resumeReasonErrorRecovery = "error_recovery"
 // from "agent_not_running" so log filtering can isolate FAILED auto-resumes.
 const resumeReasonFailedSessionResumable = "failed_session_resumable"
 
+// resumeReasonArchiveCancelledResumable is the resume reason returned when a
+// session cancelled by archiving (see models.IsArchiveCancelReason) is
+// resumable once its task is unarchived — the cancellation was a system side
+// effect of Service.ArchiveTask / HandoffService's cascade archive, not an
+// explicit user/coordinator stop, so it must recover like a FAILED session
+// instead of staying stuck on read-only workspace restore.
+const resumeReasonArchiveCancelledResumable = "archive_cancelled_resumable"
+
 var ErrAgentPromptInProgress = errors.New("agent is currently processing a prompt")
 var ErrAgentNotReadyForPrompt = errors.New("agent not ready for prompt")
 var ErrSessionResetInProgress = errors.New("session reset in progress")
@@ -1977,6 +1985,18 @@ func (s *Service) GetTaskSessionStatus(ctx context.Context, taskID, sessionID st
 			}
 			return out, nil
 		}
+		// A session cancelled by archiving is a system side effect (Service.
+		// ArchiveTask / HandoffService cascade), not an explicit user stop —
+		// it must recover like a FAILED session once the task is unarchived
+		// instead of falling into the terminal-session block below. See
+		// models.IsArchiveCancelReason.
+		if isArchiveCancelledSession(session) {
+			out := s.validateResumeEligibility(session, resp)
+			if out.NeedsResume {
+				out.ResumeReason = resumeReasonArchiveCancelledResumable
+			}
+			return out, nil
+		}
 		// Don't auto-resume other terminal sessions (CANCELLED stays stopped, COMPLETED is done).
 		if !isActiveSessionState(session.State) {
 			resp.IsAgentRunning = false
@@ -2008,6 +2028,18 @@ func evaluateFreshStartResume(session *models.TaskSession, running *models.Execu
 		resp.IsResumable = true
 		resp.NeedsResume = true
 		resp.ResumeReason = "agent_not_running_fresh_start"
+		return resp
+	}
+	// The archive cleanup (Service.ArchiveTask / HandoffService cascade) tears
+	// down the ExecutorRunning row entirely, so an archive-cancelled session
+	// reaches this function with running == nil — exactly the shape an
+	// unarchive-then-open observes. Treat it as fresh-start resumable rather
+	// than falling through to read-only workspace restore.
+	if isArchiveCancelledSession(session) {
+		resp.IsAgentRunning = false
+		resp.IsResumable = true
+		resp.NeedsResume = true
+		resp.ResumeReason = resumeReasonArchiveCancelledResumable
 		return resp
 	}
 	resp.IsAgentRunning = false
@@ -2118,6 +2150,17 @@ func isErrorRecoveryState(session *models.TaskSession) bool {
 	return session != nil &&
 		session.State == models.TaskSessionStateWaitingForInput &&
 		session.ErrorMessage != ""
+}
+
+// isArchiveCancelledSession reports whether session was cancelled by an
+// archive (Service.ArchiveTask's single-task path or HandoffService's
+// cascade archive) rather than an explicit user/coordinator stop. Such
+// sessions must resume like a FAILED session once the owning task is
+// unarchived — see models.IsArchiveCancelReason and its two constants.
+func isArchiveCancelledSession(session *models.TaskSession) bool {
+	return session != nil &&
+		session.State == models.TaskSessionStateCancelled &&
+		models.IsArchiveCancelReason(session.ErrorMessage)
 }
 
 func shouldHealStuckStartingSession(session *models.TaskSession, running *models.ExecutorRunning) bool {

--- a/apps/backend/internal/orchestrator/task_operations.go
+++ b/apps/backend/internal/orchestrator/task_operations.go
@@ -1991,11 +1991,21 @@ func (s *Service) GetTaskSessionStatus(ctx context.Context, taskID, sessionID st
 		// instead of falling into the terminal-session block below. See
 		// models.IsArchiveCancelReason.
 		if isArchiveCancelledSession(session) {
-			out := s.validateResumeEligibility(session, resp)
-			if out.NeedsResume {
-				out.ResumeReason = resumeReasonArchiveCancelledResumable
+			if running != nil && running.Resumable {
+				out := s.validateResumeEligibility(session, resp)
+				if out.NeedsResume {
+					out.ResumeReason = resumeReasonArchiveCancelledResumable
+				}
+				return out, nil
 			}
-			return out, nil
+			// The persisted token's runtime reports Resumable=false — it isn't
+			// safe to resume with. Route through the same fresh-start result
+			// used when there's no token/running row at all instead of
+			// validateResumeEligibility, which never sets IsResumable and
+			// would return NeedsResume=true with IsResumable=false, a
+			// combination the frontend's auto-resume gate
+			// (needs_resume && is_resumable) can never satisfy.
+			return evaluateFreshStartResume(session, running, runErr, resp), nil
 		}
 		// Don't auto-resume other terminal sessions (CANCELLED stays stopped, COMPLETED is done).
 		if !isActiveSessionState(session.State) {

--- a/apps/backend/internal/orchestrator/task_operations_resume_test.go
+++ b/apps/backend/internal/orchestrator/task_operations_resume_test.go
@@ -331,6 +331,71 @@ func TestGetTaskSessionStatus_ArchiveCancelledSessionWithTokenAutoResumes(t *tes
 	}
 }
 
+// TestGetTaskSessionStatus_ArchiveCancelledSessionWithNonResumableTokenFreshStarts
+// covers the CodeRabbit-flagged gap: an archive-cancelled session can carry a
+// resume token whose ExecutorRunning row has Resumable=false (the runtime
+// doesn't support resuming that specific token). Routing this through
+// validateResumeEligibility — as the with-token branch used to do
+// unconditionally — never sets IsResumable, so the response would come back
+// NeedsResume=true / IsResumable=false: a combination the frontend's
+// auto-resume gate (needs_resume && is_resumable) can never satisfy, silently
+// stranding the session on read-only workspace restore. It must instead get
+// the same consistent fresh-start result (IsResumable=true) as the
+// no-running-row case.
+func TestGetTaskSessionStatus_ArchiveCancelledSessionWithNonResumableTokenFreshStarts(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedTaskAndSession(t, repo, "task1", "session1", models.TaskSessionStateCancelled)
+
+	session, err := repo.GetTaskSession(ctx, "session1")
+	if err != nil {
+		t.Fatalf("failed to load session: %v", err)
+	}
+	session.AgentProfileID = "profile1"
+	session.ErrorMessage = models.SessionArchiveCancelReason
+	if err := repo.UpdateTaskSession(ctx, session); err != nil {
+		t.Fatalf("failed to update session: %v", err)
+	}
+
+	now := time.Now().UTC()
+	if err := repo.UpsertExecutorRunning(ctx, &models.ExecutorRunning{
+		ID:          "er1",
+		SessionID:   "session1",
+		TaskID:      "task1",
+		Status:      "ready",
+		Resumable:   false,
+		ResumeToken: "acp-session-123",
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}); err != nil {
+		t.Fatalf("failed to upsert executor running: %v", err)
+	}
+
+	taskRepo := newMockTaskRepo()
+	taskRepo.tasks["task1"] = &v1.Task{ID: "task1", State: v1.TaskStateReview}
+	agentMgr := &mockAgentManager{repoForExecutionLookup: repo}
+	svc := createTestServiceWithAgent(repo, newMockStepGetter(), taskRepo, agentMgr)
+	svc.executor = executor.NewExecutor(agentMgr, repo, testLogger(), executor.ExecutorConfig{})
+
+	resp, err := svc.GetTaskSessionStatus(ctx, "task1", "session1")
+	if err != nil {
+		t.Fatalf("GetTaskSessionStatus returned error: %v", err)
+	}
+	if !resp.NeedsResume {
+		t.Fatal("expected NeedsResume=true for archive-cancelled session with a non-resumable token")
+	}
+	if !resp.IsResumable {
+		t.Fatal("expected IsResumable=true for archive-cancelled session with a non-resumable token " +
+			"(fresh-start path), not the inconsistent validateResumeEligibility result")
+	}
+	if resp.NeedsWorkspaceRestore {
+		t.Fatal("expected NeedsWorkspaceRestore=false when fresh-start resumable")
+	}
+	if resp.ResumeReason != resumeReasonArchiveCancelledResumable {
+		t.Fatalf("expected ResumeReason=%q, got %q", resumeReasonArchiveCancelledResumable, resp.ResumeReason)
+	}
+}
+
 // TestGetTaskSessionStatus_ArchiveCancelledSessionWithoutRunningRowResumes
 // covers the common real-world shape of the bug: the archive cleanup already
 // deleted the ExecutorRunning row (no resume token), which is exactly the

--- a/apps/backend/internal/orchestrator/task_operations_resume_test.go
+++ b/apps/backend/internal/orchestrator/task_operations_resume_test.go
@@ -273,6 +273,140 @@ func TestGetTaskSessionStatus_CancelledSessionStaysWorkspaceRestore(t *testing.T
 	}
 }
 
+// TestGetTaskSessionStatus_ArchiveCancelledSessionWithTokenAutoResumes covers
+// the "Can't resume this un-archived task" bug: a session cancelled by an
+// archive (not an explicit user stop) must report NeedsResume=true once its
+// ExecutorRunning row is still present and resumable, exactly like a FAILED
+// session — even though its TaskSession.State is CANCELLED.
+func TestGetTaskSessionStatus_ArchiveCancelledSessionWithTokenAutoResumes(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedTaskAndSession(t, repo, "task1", "session1", models.TaskSessionStateCancelled)
+
+	session, err := repo.GetTaskSession(ctx, "session1")
+	if err != nil {
+		t.Fatalf("failed to load session: %v", err)
+	}
+	session.AgentProfileID = "profile1"
+	session.ErrorMessage = models.SessionArchiveCancelReason
+	if err := repo.UpdateTaskSession(ctx, session); err != nil {
+		t.Fatalf("failed to update session: %v", err)
+	}
+
+	now := time.Now().UTC()
+	if err := repo.UpsertExecutorRunning(ctx, &models.ExecutorRunning{
+		ID:          "er1",
+		SessionID:   "session1",
+		TaskID:      "task1",
+		Status:      "ready",
+		Resumable:   true,
+		ResumeToken: "acp-session-123",
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}); err != nil {
+		t.Fatalf("failed to upsert executor running: %v", err)
+	}
+
+	taskRepo := newMockTaskRepo()
+	taskRepo.tasks["task1"] = &v1.Task{ID: "task1", State: v1.TaskStateReview}
+	agentMgr := &mockAgentManager{repoForExecutionLookup: repo}
+	svc := createTestServiceWithAgent(repo, newMockStepGetter(), taskRepo, agentMgr)
+	svc.executor = executor.NewExecutor(agentMgr, repo, testLogger(), executor.ExecutorConfig{})
+
+	resp, err := svc.GetTaskSessionStatus(ctx, "task1", "session1")
+	if err != nil {
+		t.Fatalf("GetTaskSessionStatus returned error: %v", err)
+	}
+	if !resp.NeedsResume {
+		t.Fatal("expected NeedsResume=true for archive-cancelled session with resumable runtime")
+	}
+	if !resp.IsResumable {
+		t.Fatal("expected IsResumable=true for archive-cancelled session with resumable runtime")
+	}
+	if resp.NeedsWorkspaceRestore {
+		t.Fatal("expected NeedsWorkspaceRestore=false when auto-resuming")
+	}
+	if resp.ResumeReason != resumeReasonArchiveCancelledResumable {
+		t.Fatalf("expected ResumeReason=%q, got %q", resumeReasonArchiveCancelledResumable, resp.ResumeReason)
+	}
+}
+
+// TestGetTaskSessionStatus_ArchiveCancelledSessionWithoutRunningRowResumes
+// covers the common real-world shape of the bug: the archive cleanup already
+// deleted the ExecutorRunning row (no resume token), which is exactly the
+// state an unarchive-then-open observes. The session must still come back as
+// fresh-start resumable instead of falling through to read-only workspace
+// restore.
+func TestGetTaskSessionStatus_ArchiveCancelledSessionWithoutRunningRowResumes(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedTaskAndSession(t, repo, "task1", "session1", models.TaskSessionStateCancelled)
+
+	session, err := repo.GetTaskSession(ctx, "session1")
+	if err != nil {
+		t.Fatalf("failed to load session: %v", err)
+	}
+	session.AgentProfileID = "profile1"
+	session.ErrorMessage = models.SessionArchiveTreeCancelReason
+	if err := repo.UpdateTaskSession(ctx, session); err != nil {
+		t.Fatalf("failed to update session: %v", err)
+	}
+
+	if _, err := repo.GetExecutorRunningBySessionID(ctx, "session1"); !errors.Is(err, models.ErrExecutorRunningNotFound) {
+		t.Fatalf("precondition: expected no executors_running row, got err=%v", err)
+	}
+
+	taskRepo := newMockTaskRepo()
+	taskRepo.tasks["task1"] = &v1.Task{ID: "task1", State: v1.TaskStateReview}
+	agentMgr := &mockAgentManager{repoForExecutionLookup: repo}
+	svc := createTestServiceWithAgent(repo, newMockStepGetter(), taskRepo, agentMgr)
+	svc.executor = executor.NewExecutor(agentMgr, repo, testLogger(), executor.ExecutorConfig{})
+
+	resp, err := svc.GetTaskSessionStatus(ctx, "task1", "session1")
+	if err != nil {
+		t.Fatalf("GetTaskSessionStatus returned error: %v", err)
+	}
+	if !resp.NeedsResume {
+		t.Fatal("expected NeedsResume=true for archive-cancelled session even without an ExecutorRunning row")
+	}
+	if !resp.IsResumable {
+		t.Fatal("expected IsResumable=true for archive-cancelled session even without an ExecutorRunning row")
+	}
+	if resp.NeedsWorkspaceRestore {
+		t.Fatal("expected NeedsWorkspaceRestore=false when fresh-start resumable")
+	}
+	if resp.ResumeReason != resumeReasonArchiveCancelledResumable {
+		t.Fatalf("expected ResumeReason=%q, got %q", resumeReasonArchiveCancelledResumable, resp.ResumeReason)
+	}
+}
+
+// TestGetTaskSessionStatus_PlainCancelledSessionWithoutRunningRowStaysStopped
+// is the negative-case guard: a session the user explicitly stopped (no
+// archive-cancel reason, no ExecutorRunning row) must NOT be treated as
+// resumable just because it's CANCELLED.
+func TestGetTaskSessionStatus_PlainCancelledSessionWithoutRunningRowStaysStopped(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedTaskAndSession(t, repo, "task1", "session1", models.TaskSessionStateCancelled)
+
+	taskRepo := newMockTaskRepo()
+	taskRepo.tasks["task1"] = &v1.Task{ID: "task1", State: v1.TaskStateReview}
+	agentMgr := &mockAgentManager{repoForExecutionLookup: repo}
+	svc := createTestServiceWithAgent(repo, newMockStepGetter(), taskRepo, agentMgr)
+	svc.executor = executor.NewExecutor(agentMgr, repo, testLogger(), executor.ExecutorConfig{})
+
+	resp, err := svc.GetTaskSessionStatus(ctx, "task1", "session1")
+	if err != nil {
+		t.Fatalf("GetTaskSessionStatus returned error: %v", err)
+	}
+	if resp.NeedsResume {
+		t.Fatal("expected NeedsResume=false for a user-cancelled session")
+	}
+	if resp.IsResumable {
+		t.Fatal("expected IsResumable=false for a user-cancelled session")
+	}
+}
+
 func TestGetTaskSessionStatus_NoAutoResumeWithResumeTokenOnError(t *testing.T) {
 	ctx := context.Background()
 	repo := setupTestRepo(t)


### PR DESCRIPTION
Resuming a session at `/t/<id>` kept failing after unarchiving because `GetTaskSessionStatus` never recognized archive-cancelled sessions as resumable — it always fell through to a read-only `restore_workspace` launch even though the execution layer (`ResumeSession`/`setSessionStarting`, fixed in #1905/#1979) already accepts these sessions for relaunch.

## Validation

- `go build ./...`
- `gofmt -l internal/orchestrator/task_operations.go internal/orchestrator/task_operations_resume_test.go` (no output)
- `golangci-lint run ./internal/orchestrator/... --new-from-rev=b734d3f8 --timeout=5m` → 0 issues
- `go test ./internal/orchestrator/... -run 'TestGetTaskSessionStatus|TestResumeTaskSession|TestSetSessionStarting'` → all pass, including the 3 new regression tests (with-token auto-resume, without-row fresh-start-resume, and a negative case confirming a plain user-cancelled session still stays non-resumable)
- `go test -tags fts5 ./...` (full backend suite) — confirmed the pre-existing `internal/task/service` / local-repo-init failures are unrelated sandbox filesystem-permission issues, not regressions, by reproducing them identically with this change stashed out

## Possible Improvements

Low risk: the change only widens two status predicates behind a new `isArchiveCancelledSession` guard that requires both `CANCELLED` state and an archive-specific `ErrorMessage`; plain user-cancelled sessions are unaffected (covered by a regression test).

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.
</content>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2041?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

