### PR TITLE
chore(plugin-registry): add kandev-plugin-kandy

### DIFF
--- a/plugin-registry/plugins.yaml
+++ b/plugin-registry/plugins.yaml
@@ -29,6 +29,9 @@ plugins:
   - id: kandev-provider-usage
     repo: kdlbs/kandev-plugin-provider-usage
     categories: [analytics]
+  - id: kandev-plugin-kandy
+    repo: kdlbs/kandev-plugin-kandy
+    categories: [tools]
 # Example entry (copy, uncomment, and fill in when adding a plugin):
 #
 # plugins:


### PR DESCRIPTION
Adds **Kandy** to the official plugin catalog.

- Repo: https://github.com/kdlbs/kandev-plugin-kandy
- Release: [v0.1.0](https://github.com/kdlbs/kandev-plugin-kandy/releases/tag/v0.1.0) with the 5-platform tarball attached; manifest `id: kandev-plugin-kandy` matches this entry.
- Category: `tools`.

Kandy is a tamagotchi that lives in the session top bar and grows when work ships: it feeds on archived/completed tasks, agent runs, turns, and messages (hidden server-side XP recipe), evolves through a 100-level procedural arc (per-install DNA: species/palette/biome), reacts live over WS, has moods with a hearts meter, and can be petted (comfort only — only shipped work feeds it). Mobile-supported (tap-to-open card dialog).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2042?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->