### PR TITLE
docs: clarify power-user positioning and roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Manage and run tasks in parallel. Orchestrate agents. Review changes. Ship value
 ## What
 
 
+Kandev is a powerful tool for power users who want deeper control over how AI agents work: customize workflows, agent profiles, runtimes, prompts, and review gates to match your process.
+
 Organize work across kanban and pipeline views with opinionated workflows and execute multiple tasks in parallel. Assign agents from any provider, and review their output in an integrated workspace - file editor, file tree, terminal, browser preview, and git changes in one place. Terminal agent TUIs are great for running agents, but reviewing and iterating on changes there doesn't scale.
 
 Run it locally or self-host it on your own infrastructure and access it from anywhere via [Tailscale](https://tailscale.com/) or any VPN.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -6,6 +6,9 @@ High-level direction for the project. This is not a commitment - priorities shif
 
 - Stability and bug fixes across all agent integrations - current primary focus
 - Improved mobile UI - polish the existing mobile view for orchestrating and reviewing from your phone
+- Plugin system - installable extensions and plugin APIs, with initial plugins for [Kandy](https://github.com/kdlbs/kandev-plugin-kandy), [provider usage](https://github.com/kdlbs/kandev-plugin-provider-usage), and [session cost](https://github.com/kdlbs/kandev-plugin-session-cost)
+- Authentication - secure access controls for Kandev deployments
+- Internationalization (i18n) - localized Kandev UI and user experience
 - Office mode - new scheduler, routines, agents with skills, cost tracking
 - Remote SSH runtime - run agents on remote servers over SSH
 - GitLab integration - import issues, manage repos, trigger pipelines


### PR DESCRIPTION
Power users need a clear signal that Kandev is built for deep customization, while the roadmap should make upcoming investment visible. This updates the README positioning and records the plugin system (with links to active plugins), authentication, internationalization, and Office mode as current work.

## Validation

- `git diff --check`
- Commit hooks passed, including harness lint and commit message validation
- Verified active plugin repositories with `gh repo list kdlbs`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2044?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->