### PR TITLE
fix: bound task cleanup retries and ignore missing resources (#2027)

### DIFF
--- a/apps/backend/internal/task/models/resource_cleanup.go
+++ b/apps/backend/internal/task/models/resource_cleanup.go
@@ -22,6 +22,7 @@ const (
 	TaskResourceCleanupStateRunning   TaskResourceCleanupState = "running"
 	TaskResourceCleanupStateRetryWait TaskResourceCleanupState = "retry_wait"
 	TaskResourceCleanupStateSucceeded TaskResourceCleanupState = "succeeded"
+	TaskResourceCleanupStateFailed    TaskResourceCleanupState = "failed"
 	TaskResourceCleanupStateCancelled TaskResourceCleanupState = "cancelled"
 )
 

--- a/apps/backend/internal/task/repository/interface.go
+++ b/apps/backend/internal/task/repository/interface.go
@@ -16,6 +16,7 @@ var ErrWorkspaceNotFound = repoerrors.ErrWorkspaceNotFound
 var ErrTaskNotFound = repoerrors.ErrTaskNotFound
 var ErrTaskPlanNotFound = repoerrors.ErrTaskPlanNotFound
 var ErrRepositoryNotFound = repoerrors.ErrRepositoryNotFound
+var ErrTaskEnvironmentNotFound = repoerrors.ErrTaskEnvironmentNotFound
 var ErrWIPLimitExceeded = wfmodels.ErrWIPLimitExceeded
 
 // WorkspaceRepository handles workspace CRUD.

--- a/apps/backend/internal/task/repository/repoerrors/errors.go
+++ b/apps/backend/internal/task/repository/repoerrors/errors.go
@@ -17,3 +17,6 @@ var ErrTaskPlanNotFound = errors.New("task plan not found")
 
 // ErrRepositoryNotFound reports that no live repository row matched the supplied id.
 var ErrRepositoryNotFound = errors.New("repository not found")
+
+// ErrTaskEnvironmentNotFound reports that no task environment row matched the supplied id.
+var ErrTaskEnvironmentNotFound = errors.New("task environment not found")

--- a/apps/backend/internal/task/repository/sqlite/errors.go
+++ b/apps/backend/internal/task/repository/sqlite/errors.go
@@ -20,6 +20,10 @@ var ErrWorkspaceNotFound = repoerrors.ErrWorkspaceNotFound
 // matches the supplied task id.
 var ErrTaskPlanNotFound = repoerrors.ErrTaskPlanNotFound
 
+// ErrTaskEnvironmentNotFound is returned when no task environment row matches
+// the supplied id. Callers should classify it with errors.Is.
+var ErrTaskEnvironmentNotFound = repoerrors.ErrTaskEnvironmentNotFound
+
 // ErrNoPrimarySession is returned by GetPrimarySessionByTaskID when the task
 // has no primary session row. Callers should use errors.Is to distinguish this
 // "not found" case from genuine backend/DB errors.

--- a/apps/backend/internal/task/repository/sqlite/resource_cleanup.go
+++ b/apps/backend/internal/task/repository/sqlite/resource_cleanup.go
@@ -141,7 +141,9 @@ func (r *Repository) StartPreparedTaskResourceCleanupJob(ctx context.Context, id
 func (r *Repository) CompleteTaskResourceCleanupJob(ctx context.Context, id string, state models.TaskResourceCleanupState, lastError string, nextAttemptAt *time.Time) error {
 	now := time.Now().UTC()
 	var completedAt *time.Time
-	if state == models.TaskResourceCleanupStateSucceeded || state == models.TaskResourceCleanupStateCancelled {
+	if state == models.TaskResourceCleanupStateSucceeded ||
+		state == models.TaskResourceCleanupStateFailed ||
+		state == models.TaskResourceCleanupStateCancelled {
 		completedAt = &now
 	}
 	_, err := r.db.ExecContext(ctx, r.db.Rebind(`
@@ -165,7 +167,9 @@ func (r *Repository) CompleteClaimedTaskResourceCleanupJob(
 ) (bool, error) {
 	now := time.Now().UTC()
 	var completedAt *time.Time
-	if state == models.TaskResourceCleanupStateSucceeded || state == models.TaskResourceCleanupStateCancelled {
+	if state == models.TaskResourceCleanupStateSucceeded ||
+		state == models.TaskResourceCleanupStateFailed ||
+		state == models.TaskResourceCleanupStateCancelled {
 		completedAt = &now
 	}
 	result, err := r.db.ExecContext(ctx, r.db.Rebind(`

--- a/apps/backend/internal/task/repository/sqlite/resource_cleanup_test.go
+++ b/apps/backend/internal/task/repository/sqlite/resource_cleanup_test.go
@@ -137,3 +137,43 @@ func TestTaskResourceCleanupJobStaleClaimCannotOverwriteCancellation(t *testing.
 		t.Fatalf("cancelled job lost historical metadata: %#v", got)
 	}
 }
+
+func TestTaskResourceCleanupFailedJobIsTerminalAndNotDue(t *testing.T) {
+	ctx := context.Background()
+	repo := newRepoForHealTests(t)
+	job := &models.TaskResourceCleanupJob{
+		ID: "job-failed", OperationID: "delete:failed", TaskID: "task-failed",
+		Trigger: models.TaskResourceCleanupTriggerDelete,
+		State:   models.TaskResourceCleanupStatePending, ResourceSnapshot: `{}`,
+	}
+	if err := repo.CreateTaskResourceCleanupJob(ctx, job); err != nil {
+		t.Fatalf("CreateTaskResourceCleanupJob: %v", err)
+	}
+	claimed, err := repo.MarkTaskResourceCleanupJobRunning(ctx, job.ID)
+	if err != nil || !claimed {
+		t.Fatalf("claim = %v, %v; want true", claimed, err)
+	}
+	claimedJob, err := repo.GetTaskResourceCleanupJob(ctx, job.ID)
+	if err != nil {
+		t.Fatalf("GetTaskResourceCleanupJob: %v", err)
+	}
+	if _, err := repo.CompleteClaimedTaskResourceCleanupJob(
+		ctx, job.ID, claimedJob.Attempts, models.TaskResourceCleanupState("failed"), "permanent failure", nil,
+	); err != nil {
+		t.Fatalf("complete failed cleanup: %v", err)
+	}
+	got, err := repo.GetTaskResourceCleanupJob(ctx, job.ID)
+	if err != nil {
+		t.Fatalf("reload failed cleanup: %v", err)
+	}
+	if got.CompletedAt == nil {
+		t.Fatal("failed cleanup has no completion timestamp")
+	}
+	due, err := repo.ListDueTaskResourceCleanupJobs(ctx, time.Now().UTC(), 10)
+	if err != nil {
+		t.Fatalf("ListDueTaskResourceCleanupJobs: %v", err)
+	}
+	if len(due) != 0 {
+		t.Fatalf("failed cleanup is due: %#v", due)
+	}
+}

--- a/apps/backend/internal/task/repository/sqlite/resource_cleanup_test.go
+++ b/apps/backend/internal/task/repository/sqlite/resource_cleanup_test.go
@@ -177,3 +177,28 @@ func TestTaskResourceCleanupFailedJobIsTerminalAndNotDue(t *testing.T) {
 		t.Fatalf("failed cleanup is due: %#v", due)
 	}
 }
+
+func TestTaskResourceCleanupFailedUnclaimedCompletionHasTimestamp(t *testing.T) {
+	ctx := context.Background()
+	repo := newRepoForHealTests(t)
+	job := &models.TaskResourceCleanupJob{
+		ID: "job-failed-unclaimed", OperationID: "delete:failed-unclaimed", TaskID: "task-failed-unclaimed",
+		Trigger: models.TaskResourceCleanupTriggerDelete,
+		State:   models.TaskResourceCleanupStatePending, ResourceSnapshot: `{}`,
+	}
+	if err := repo.CreateTaskResourceCleanupJob(ctx, job); err != nil {
+		t.Fatalf("CreateTaskResourceCleanupJob: %v", err)
+	}
+	if err := repo.CompleteTaskResourceCleanupJob(
+		ctx, job.ID, models.TaskResourceCleanupStateFailed, "permanent failure", nil,
+	); err != nil {
+		t.Fatalf("complete unclaimed failed cleanup: %v", err)
+	}
+	got, err := repo.GetTaskResourceCleanupJob(ctx, job.ID)
+	if err != nil {
+		t.Fatalf("reload failed cleanup: %v", err)
+	}
+	if got.CompletedAt == nil {
+		t.Fatal("unclaimed failed cleanup has no completion timestamp")
+	}
+}

--- a/apps/backend/internal/task/repository/sqlite/task_environment.go
+++ b/apps/backend/internal/task/repository/sqlite/task_environment.go
@@ -82,7 +82,7 @@ func (r *Repository) GetTaskEnvironment(ctx context.Context, id string) (*models
 		&env.CreatedAt, &env.UpdatedAt,
 	)
 	if err == sql.ErrNoRows {
-		return nil, fmt.Errorf("task environment not found: %s", id)
+		return nil, fmt.Errorf("%w: %s", ErrTaskEnvironmentNotFound, id)
 	}
 	if err != nil {
 		return nil, err
@@ -165,7 +165,7 @@ func (r *Repository) UpdateTaskEnvironment(ctx context.Context, env *models.Task
 	}
 	rows, _ := result.RowsAffected()
 	if rows == 0 {
-		return fmt.Errorf("task environment not found: %s", env.ID)
+		return fmt.Errorf("%w: %s", ErrTaskEnvironmentNotFound, env.ID)
 	}
 	return nil
 }
@@ -182,7 +182,7 @@ func (r *Repository) TransferTaskEnvironmentToTask(ctx context.Context, envID, t
 	}
 	rows, _ := result.RowsAffected()
 	if rows == 0 {
-		return fmt.Errorf("task environment not found: %s", envID)
+		return fmt.Errorf("%w: %s", ErrTaskEnvironmentNotFound, envID)
 	}
 	return nil
 }
@@ -198,7 +198,7 @@ func (r *Repository) DeleteTaskEnvironment(ctx context.Context, id string) error
 	}
 	rows, _ := result.RowsAffected()
 	if rows == 0 {
-		return fmt.Errorf("task environment not found: %s", id)
+		return fmt.Errorf("%w: %s", ErrTaskEnvironmentNotFound, id)
 	}
 	return nil
 }

--- a/apps/backend/internal/task/repository/sqlite/task_environment_test.go
+++ b/apps/backend/internal/task/repository/sqlite/task_environment_test.go
@@ -1,0 +1,17 @@
+package sqlite
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestDeleteTaskEnvironmentMissingReturnsSentinel(t *testing.T) {
+	repo := newRepoForHealTests(t)
+
+	err := repo.DeleteTaskEnvironment(context.Background(), "missing-environment")
+
+	if !errors.Is(err, ErrTaskEnvironmentNotFound) {
+		t.Fatalf("DeleteTaskEnvironment error = %v, want ErrTaskEnvironmentNotFound", err)
+	}
+}

--- a/apps/backend/internal/task/repository/sqlite/task_environment_test.go
+++ b/apps/backend/internal/task/repository/sqlite/task_environment_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"testing"
+
+	"github.com/kandev/kandev/internal/task/models"
 )
 
 func TestDeleteTaskEnvironmentMissingReturnsSentinel(t *testing.T) {
@@ -13,5 +15,35 @@ func TestDeleteTaskEnvironmentMissingReturnsSentinel(t *testing.T) {
 
 	if !errors.Is(err, ErrTaskEnvironmentNotFound) {
 		t.Fatalf("DeleteTaskEnvironment error = %v, want ErrTaskEnvironmentNotFound", err)
+	}
+}
+
+func TestGetTaskEnvironmentMissingReturnsSentinel(t *testing.T) {
+	repo := newRepoForHealTests(t)
+
+	_, err := repo.GetTaskEnvironment(context.Background(), "missing-environment")
+
+	if !errors.Is(err, ErrTaskEnvironmentNotFound) {
+		t.Fatalf("GetTaskEnvironment error = %v, want ErrTaskEnvironmentNotFound", err)
+	}
+}
+
+func TestUpdateTaskEnvironmentMissingReturnsSentinel(t *testing.T) {
+	repo := newRepoForHealTests(t)
+
+	err := repo.UpdateTaskEnvironment(context.Background(), &models.TaskEnvironment{ID: "missing-environment"})
+
+	if !errors.Is(err, ErrTaskEnvironmentNotFound) {
+		t.Fatalf("UpdateTaskEnvironment error = %v, want ErrTaskEnvironmentNotFound", err)
+	}
+}
+
+func TestTransferTaskEnvironmentMissingReturnsSentinel(t *testing.T) {
+	repo := newRepoForHealTests(t)
+
+	err := repo.TransferTaskEnvironmentToTask(context.Background(), "missing-environment", "task-1")
+
+	if !errors.Is(err, ErrTaskEnvironmentNotFound) {
+		t.Fatalf("TransferTaskEnvironmentToTask error = %v, want ErrTaskEnvironmentNotFound", err)
 	}
 }

--- a/apps/backend/internal/task/service/resource_cleanup_jobs.go
+++ b/apps/backend/internal/task/service/resource_cleanup_jobs.go
@@ -18,7 +18,18 @@ import (
 const (
 	taskResourceCleanupRetryDelay       = time.Minute
 	preparedCleanupTransitionRetryDelay = 50 * time.Millisecond
+	taskResourceCleanupMaxAttempts      = 8
 )
+
+var taskResourceCleanupRetryDelays = []time.Duration{
+	time.Minute,
+	5 * time.Minute,
+	15 * time.Minute,
+	time.Hour,
+	3 * time.Hour,
+	6 * time.Hour,
+	12 * time.Hour,
+}
 
 type persistedTaskStopTarget struct {
 	SessionID   string `json:"session_id"`
@@ -466,16 +477,33 @@ func (s *Service) cancelTaskResourceCleanupJob(ctx context.Context, job *models.
 }
 
 func (s *Service) retryTaskResourceCleanupJob(ctx context.Context, job *models.TaskResourceCleanupJob, cleanupErr error) error {
-	nextAttempt := time.Now().UTC().Add(taskResourceCleanupRetryDelay)
+	state := models.TaskResourceCleanupStateRetryWait
+	var nextAttempt *time.Time
+	if job.Attempts >= taskResourceCleanupMaxAttempts {
+		state = models.TaskResourceCleanupStateFailed
+	} else {
+		next := time.Now().UTC().Add(taskResourceCleanupRetryDelayForAttempt(job.Attempts))
+		nextAttempt = &next
+	}
 	transitionCtx, cancel := detachedCleanupTransitionContext(ctx)
 	defer cancel()
 	_, err := s.resourceCleanups.CompleteClaimedTaskResourceCleanupJob(
-		transitionCtx, job.ID, job.Attempts, models.TaskResourceCleanupStateRetryWait, cleanupErr.Error(), &nextAttempt,
+		transitionCtx, job.ID, job.Attempts, state, cleanupErr.Error(), nextAttempt,
 	)
 	if err != nil {
 		return errors.Join(cleanupErr, err)
 	}
 	return cleanupErr
+}
+
+func taskResourceCleanupRetryDelayForAttempt(attempt int) time.Duration {
+	if attempt < 1 {
+		attempt = 1
+	}
+	if attempt > len(taskResourceCleanupRetryDelays) {
+		attempt = len(taskResourceCleanupRetryDelays)
+	}
+	return taskResourceCleanupRetryDelays[attempt-1]
 }
 
 func detachedCleanupTransitionContext(ctx context.Context) (context.Context, context.CancelFunc) {

--- a/apps/backend/internal/task/service/resource_cleanup_jobs_test.go
+++ b/apps/backend/internal/task/service/resource_cleanup_jobs_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
@@ -963,7 +964,7 @@ func TestTaskResourceCleanupMissingResourcesSucceed(t *testing.T) {
 		{
 			name:        "worktree",
 			environment: &models.TaskEnvironment{ID: "env-gone-worktree", WorktreeID: "worktree-gone"},
-			destroyer:   &stubDestroyer{worktreeErr: worktree.ErrWorktreeNotFound},
+			destroyer:   &stubDestroyer{worktreeErr: fmt.Errorf("worktree cleanup: %w", worktree.ErrWorktreeNotFound)},
 		},
 		{
 			name:        "task environment row",

--- a/apps/backend/internal/task/service/resource_cleanup_jobs_test.go
+++ b/apps/backend/internal/task/service/resource_cleanup_jobs_test.go
@@ -889,6 +889,129 @@ func TestRetryTaskResourceCleanupJobPersistsAfterRunContextCancellation(t *testi
 	}
 }
 
+func TestRetryTaskResourceCleanupJobUsesBoundedBackoffAndTerminalState(t *testing.T) {
+	tests := []struct {
+		name      string
+		attempts  int
+		wantState models.TaskResourceCleanupState
+		wantDelay time.Duration
+	}{
+		{name: "first failure", attempts: 1, wantState: models.TaskResourceCleanupStateRetryWait, wantDelay: time.Minute},
+		{name: "seventh failure", attempts: 7, wantState: models.TaskResourceCleanupStateRetryWait, wantDelay: 12 * time.Hour},
+		{name: "eighth failure", attempts: 8, wantState: models.TaskResourceCleanupState("failed")},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			taskSvc, repo := setupOfficeTest(t)
+			job := &models.TaskResourceCleanupJob{
+				ID: "retry-bound-" + test.name, OperationID: "delete:retry-bound:" + test.name,
+				TaskID: "task-retry-bound", Trigger: models.TaskResourceCleanupTriggerDelete,
+				State: models.TaskResourceCleanupStatePending, Attempts: test.attempts - 1,
+				ResourceSnapshot: `{}`,
+			}
+			if err := repo.CreateTaskResourceCleanupJob(context.Background(), job); err != nil {
+				t.Fatalf("CreateTaskResourceCleanupJob: %v", err)
+			}
+			claimed, err := repo.MarkTaskResourceCleanupJobRunning(context.Background(), job.ID)
+			if err != nil || !claimed {
+				t.Fatalf("MarkTaskResourceCleanupJobRunning = %v, %v", claimed, err)
+			}
+			job, err = repo.GetTaskResourceCleanupJob(context.Background(), job.ID)
+			if err != nil {
+				t.Fatalf("GetTaskResourceCleanupJob: %v", err)
+			}
+
+			before := time.Now().UTC()
+			cleanupErr := errors.New("persistent cleanup failure")
+			if err := taskSvc.retryTaskResourceCleanupJob(context.Background(), job, cleanupErr); !errors.Is(err, cleanupErr) {
+				t.Fatalf("retryTaskResourceCleanupJob error = %v, want cleanup error", err)
+			}
+			got, err := repo.GetTaskResourceCleanupJob(context.Background(), job.ID)
+			if err != nil {
+				t.Fatalf("reload cleanup job: %v", err)
+			}
+			if got.State != test.wantState {
+				t.Fatalf("cleanup state = %q, want %q", got.State, test.wantState)
+			}
+			if got.LastError != cleanupErr.Error() {
+				t.Fatalf("last error = %q, want %q", got.LastError, cleanupErr.Error())
+			}
+			if test.wantState == models.TaskResourceCleanupState("failed") {
+				if got.NextAttemptAt != nil || got.CompletedAt == nil {
+					t.Fatalf("terminal cleanup metadata = next=%v completed=%v, want nil/non-nil", got.NextAttemptAt, got.CompletedAt)
+				}
+				return
+			}
+			if got.NextAttemptAt == nil {
+				t.Fatal("retry cleanup has no next attempt")
+			}
+			delta := got.NextAttemptAt.Sub(before)
+			if delta < test.wantDelay-time.Second || delta > test.wantDelay+time.Second {
+				t.Fatalf("retry delay = %v, want about %v", delta, test.wantDelay)
+			}
+		})
+	}
+}
+
+func TestTaskResourceCleanupMissingResourcesSucceed(t *testing.T) {
+	tests := []struct {
+		name        string
+		environment *models.TaskEnvironment
+		destroyer   *stubDestroyer
+	}{
+		{
+			name:        "worktree",
+			environment: &models.TaskEnvironment{ID: "env-gone-worktree", WorktreeID: "worktree-gone"},
+			destroyer:   &stubDestroyer{worktreeErr: worktree.ErrWorktreeNotFound},
+		},
+		{
+			name:        "task environment row",
+			environment: &models.TaskEnvironment{ID: "env-gone-row"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			taskSvc, repo := setupOfficeTest(t)
+			taskSvc.StopTaskResourceCleanupWorker()
+			if test.destroyer != nil {
+				taskSvc.SetEnvironmentDestroyer(test.destroyer)
+			}
+
+			snapshot, err := json.Marshal(taskResourceCleanupSnapshot{
+				TaskEnvironment:      test.environment,
+				DeleteEnvironmentRow: true,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			job := &models.TaskResourceCleanupJob{
+				ID:               "issue-2027-" + test.name,
+				OperationID:      "cascade_delete:issue-2027:" + test.name,
+				TaskID:           "deleted-task",
+				Trigger:          models.TaskResourceCleanupTriggerCascadeDelete,
+				State:            models.TaskResourceCleanupStatePending,
+				ResourceSnapshot: string(snapshot),
+			}
+			if err := repo.CreateTaskResourceCleanupJob(context.Background(), job); err != nil {
+				t.Fatalf("CreateTaskResourceCleanupJob: %v", err)
+			}
+
+			if err := taskSvc.processTaskResourceCleanupJob(context.Background(), job.ID); err != nil {
+				t.Fatalf("cleanup of already-absent resource: %v", err)
+			}
+			got, err := repo.GetTaskResourceCleanupJob(context.Background(), job.ID)
+			if err != nil {
+				t.Fatalf("GetTaskResourceCleanupJob: %v", err)
+			}
+			if got.State != models.TaskResourceCleanupStateSucceeded {
+				t.Fatalf("cleanup state = %q, want succeeded", got.State)
+			}
+		})
+	}
+}
+
 func TestCancelWorkspaceDeleteCleanupUsesDetachedContext(t *testing.T) {
 	taskSvc, repo := setupOfficeTest(t)
 	ctx := context.Background()

--- a/apps/backend/internal/task/service/service_task_environments.go
+++ b/apps/backend/internal/task/service/service_task_environments.go
@@ -9,6 +9,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/kandev/kandev/internal/task/models"
+	"github.com/kandev/kandev/internal/worktree"
 )
 
 // EnvironmentDestroyer tears down the runtime resources recorded on a TaskEnvironment.
@@ -329,7 +330,8 @@ func (s *Service) ResetTaskEnvironment(ctx context.Context, taskID string, opts 
 // recorded on a TaskEnvironment. Best-effort per resource: every resource is
 // attempted even when an earlier one fails, and all failures are joined into a
 // single error so a stuck container can't permanently orphan the worktree.
-// On any error, the caller should preserve the row so the user can retry.
+// On any non-idempotent error, the caller should preserve the row so the user
+// can retry.
 func (s *Service) teardownEnvironmentResources(ctx context.Context, env *models.TaskEnvironment) error {
 	if cause := context.Cause(ctx); cause != nil {
 		return cause
@@ -369,7 +371,9 @@ func (s *Service) teardownEnvironmentResources(ctx context.Context, env *models.
 			return err
 		}
 		if err := s.envDestroyer.DestroyWorktree(ctx, env.WorktreeID); err != nil {
-			errs = append(errs, fmt.Errorf("destroy worktree %s: %w", env.WorktreeID, err))
+			if !errors.Is(err, worktree.ErrWorktreeNotFound) {
+				errs = append(errs, fmt.Errorf("destroy worktree %s: %w", env.WorktreeID, err))
+			}
 		}
 	}
 	if err := contextError(); err != nil {

--- a/apps/backend/internal/task/service/service_task_environments_test.go
+++ b/apps/backend/internal/task/service/service_task_environments_test.go
@@ -201,6 +201,20 @@ func TestTeardownEnvironmentResources_CancellationStopsBeforeNextResource(t *tes
 	}
 }
 
+func TestTeardownEnvironmentResources_GenericWorktreeFailureRemainsError(t *testing.T) {
+	worktreeErr := errors.New("worktree backend unavailable")
+	svc := newResetTestService(t, &stubEnvRepo{})
+	svc.SetEnvironmentDestroyer(&stubDestroyer{worktreeErr: worktreeErr})
+
+	err := svc.teardownEnvironmentResources(context.Background(), &models.TaskEnvironment{
+		WorktreeID: "worktree-1",
+	})
+
+	if !errors.Is(err, worktreeErr) {
+		t.Fatalf("teardown error = %v, want %v", err, worktreeErr)
+	}
+}
+
 func TestCleanupTaskEnvironment_CancellationPreservesEnvironmentRow(t *testing.T) {
 	repo := &stubEnvRepo{}
 	svc := newResetTestService(t, repo)

--- a/apps/backend/internal/task/service/service_tasks.go
+++ b/apps/backend/internal/task/service/service_tasks.go
@@ -2479,7 +2479,8 @@ func (s *Service) cleanupTaskEnvironment(
 		if cause := context.Cause(ctx); cause != nil {
 			return []error{cause}
 		}
-		if err := s.taskEnvironments.DeleteTaskEnvironment(ctx, cleanup.env.ID); err != nil {
+		if err := s.taskEnvironments.DeleteTaskEnvironment(ctx, cleanup.env.ID); err != nil &&
+			!errors.Is(err, taskrepo.ErrTaskEnvironmentNotFound) {
 			s.logger.Warn("failed to delete task environment row during task cleanup",
 				zap.String("task_id", taskID),
 				zap.String("env_id", cleanup.env.ID),

--- a/docs/plans/task-cleanup-retry-bounds/plan.md
+++ b/docs/plans/task-cleanup-retry-bounds/plan.md
@@ -1,0 +1,103 @@
+---
+spec: docs/specs/tasks/runtime-cleanup.md
+created: 2026-07-29
+status: implemented
+---
+
+# Implementation Plan: Task Cleanup Idempotency and Retry Bounds
+
+## Overview
+
+GitHub issue #2027 is reproducible through the SQLite-backed cleanup worker:
+missing worktrees and missing task-environment rows are returned as cleanup
+errors, so `cascade_delete` jobs enter `retry_wait` forever. The repair first
+makes those two deletion boundaries explicitly idempotent, then adds a bounded
+backoff state machine so any other permanent error reaches a durable terminal
+state.
+
+## Root Cause
+
+- `teardownEnvironmentResources` appends `worktree.ErrWorktreeNotFound` to its
+  aggregate error instead of recognizing that the desired deletion state is
+  already true.
+- SQLite task-environment deletion returns an unclassifiable formatted error
+  when the row is absent, and `cleanupTaskEnvironment` retries that error.
+- `retryTaskResourceCleanupJob` always writes `retry_wait` with a fixed
+  one-minute deadline. `Attempts` is used as a claim generation but never as a
+  retry limit.
+
+## Backend
+
+### Missing-resource contracts
+
+- Add `ErrTaskEnvironmentNotFound` to
+  `apps/backend/internal/task/repository/repoerrors/errors.go`, re-export it
+  from `repository/interface.go` and `repository/sqlite/errors.go`, and wrap
+  task-environment not-found results in
+  `repository/sqlite/task_environment.go`.
+- Update `teardownEnvironmentResources` in
+  `service/service_task_environments.go` to treat only
+  `worktree.ErrWorktreeNotFound` as a successful worktree teardown.
+- Update `cleanupTaskEnvironment` in `service/service_tasks.go` to treat only
+  `repository.ErrTaskEnvironmentNotFound` from the row deletion as complete.
+  Other joined teardown and persistence errors remain retryable.
+
+### Bounded cleanup retries
+
+- Add terminal `TaskResourceCleanupStateFailed` in
+  `task/models/resource_cleanup.go`.
+- Replace the fixed reschedule in
+  `task/service/resource_cleanup_jobs.go` with the spec's seven-step retry
+  schedule and an eight-attempt ceiling. Attempts 1-7 write `retry_wait`;
+  attempt 8 writes `failed`, preserves the final error, clears
+  `next_attempt_at`, and emits no further automatic work.
+- Update `task/repository/sqlite/resource_cleanup.go` so `failed` completions
+  receive `completed_at`; due-job queries continue selecting only `pending` and
+  `retry_wait`.
+
+## Tests
+
+- **What:** deleting a missing task-environment row returns a classifiable
+  sentinel.
+  **File:** `apps/backend/internal/task/repository/sqlite/task_environment_test.go`
+  **How:** SQLite repository test asserting `errors.Is`.
+- **What:** both missing-resource variants complete a `cascade_delete` cleanup
+  job successfully.
+  **File:** `apps/backend/internal/task/service/resource_cleanup_jobs_test.go`
+  **How:** table-driven SQLite-backed service-worker test using the real job
+  claim/completion path and a worktree destroyer fake only at the external
+  worktree boundary.
+- **What:** non-not-found teardown failures remain retryable.
+  **File:** `apps/backend/internal/task/service/service_task_environments_test.go`
+  **How:** focused service test with a generic worktree error.
+- **What:** retry delays follow the documented schedule and the eighth failure
+  becomes terminal.
+  **File:** `apps/backend/internal/task/service/resource_cleanup_jobs_test.go`
+  **How:** table-driven delay unit test plus SQLite-backed claim-completion tests
+  for attempts 1, 7, and 8.
+- **What:** terminal failed jobs have a completion timestamp and are never due.
+  **File:** `apps/backend/internal/task/repository/sqlite/resource_cleanup_test.go`
+  **How:** SQLite repository test that completes a claimed job as `failed` and
+  queries the due inventory.
+
+## Implementation Waves And Parallel Candidates
+
+Execution is sequential because both tasks touch the cleanup service tests and
+the second task builds on the error classification established by the first.
+
+- [x] [Task 01: Make missing cleanup resources idempotent](task-01-idempotent-missing-resources.md)
+- [x] [Task 02: Bound cleanup retries](task-02-bounded-cleanup-retries.md)
+
+## Documentation Impact
+
+The durable task-runtime and storage-maintenance specs are amended in this
+design package. No public CLI, configuration, API, or UI documentation changes
+are required.
+
+## Risks
+
+- Treating only typed sentinels as success is deliberate: matching error strings
+  could hide unrelated repository or Git failures.
+- Terminal failure stops automatic cleanup, so the final error and completion
+  metadata must remain queryable. A user-facing replay action and failure UI are
+  explicitly out of scope.

--- a/docs/plans/task-cleanup-retry-bounds/task-01-idempotent-missing-resources.md
+++ b/docs/plans/task-cleanup-retry-bounds/task-01-idempotent-missing-resources.md
@@ -1,0 +1,65 @@
+---
+id: "01-idempotent-missing-resources"
+title: "Make missing cleanup resources idempotent"
+status: done
+wave: 1
+depends_on: []
+plan: "plan.md"
+spec: "../../specs/tasks/runtime-cleanup.md"
+---
+
+# Task 01: Make Missing Cleanup Resources Idempotent
+
+## Acceptance
+
+- Missing task-environment rows are classifiable through
+  `ErrTaskEnvironmentNotFound` without relying on error text.
+- A `cascade_delete` job succeeds when its captured worktree or environment row
+  is already absent.
+- Generic worktree and repository failures remain retryable.
+
+## Verification
+
+```bash
+cd apps/backend && go test -tags fts5 -run 'Test(DeleteTaskEnvironmentMissing|TaskResourceCleanupMissingResources|TeardownEnvironmentResources)' ./internal/task/repository/sqlite ./internal/task/service
+```
+
+## Files likely touched
+
+- `apps/backend/internal/task/repository/repoerrors/errors.go`
+- `apps/backend/internal/task/repository/interface.go`
+- `apps/backend/internal/task/repository/sqlite/errors.go`
+- `apps/backend/internal/task/repository/sqlite/task_environment.go`
+- `apps/backend/internal/task/repository/sqlite/task_environment_test.go`
+- `apps/backend/internal/task/service/service_task_environments.go`
+- `apps/backend/internal/task/service/service_task_environments_test.go`
+- `apps/backend/internal/task/service/service_tasks.go`
+- `apps/backend/internal/task/service/resource_cleanup_jobs_test.go`
+
+## Dependencies
+
+None.
+
+## Parallelism
+
+`sequential`; Task 02 shares the cleanup service and its regression test file.
+
+## Inputs
+
+- Runtime cleanup spec: idempotency requirements and missing-resource scenarios.
+- Confirmed issue #2027 reproductions for missing worktree and missing
+  task-environment row.
+- Existing `runtimeStopAlreadyComplete` typed-sentinel pattern in
+  `service_tasks.go`.
+
+## Output contract
+
+Report the RED failures, sentinel and cleanup behavior implemented, files
+changed, exact verification result, residual risks, and update this task plus
+`plan.md` status.
+
+## Result
+
+- RED coverage reproduced both issue paths: missing worktree and missing task-environment row.
+- Added typed `ErrTaskEnvironmentNotFound` classification and made only typed not-found cleanup outcomes idempotent.
+- Verified with `go test -tags fts5 -run 'Test(DeleteTaskEnvironmentMissing|TaskResourceCleanupMissingResources|TeardownEnvironmentResources)' ./internal/task/repository/sqlite ./internal/task/service` (6 tests passed).

--- a/docs/plans/task-cleanup-retry-bounds/task-02-bounded-cleanup-retries.md
+++ b/docs/plans/task-cleanup-retry-bounds/task-02-bounded-cleanup-retries.md
@@ -1,0 +1,62 @@
+---
+id: "02-bounded-cleanup-retries"
+title: "Bound cleanup retries"
+status: done
+wave: 2
+depends_on: ["01-idempotent-missing-resources"]
+plan: "plan.md"
+spec: "../../specs/tasks/runtime-cleanup.md"
+---
+
+# Task 02: Bound Cleanup Retries
+
+## Acceptance
+
+- Failed claims 1-7 enter `retry_wait` with the documented delay for that
+  attempt.
+- A failed eighth claim enters terminal `failed`, retains the final diagnostic,
+  has no next-attempt deadline, and receives a completion timestamp.
+- Terminal failed jobs are excluded from automatic due-job selection across
+  worker ticks and backend restarts.
+
+## Verification
+
+```bash
+cd apps/backend && go test -tags fts5 -run 'Test(TaskResourceCleanupRetryDelay|RetryTaskResourceCleanupJob|TaskResourceCleanupJobFailed)' ./internal/task/repository/sqlite ./internal/task/service
+```
+
+## Files likely touched
+
+- `apps/backend/internal/task/models/resource_cleanup.go`
+- `apps/backend/internal/task/repository/sqlite/resource_cleanup.go`
+- `apps/backend/internal/task/repository/sqlite/resource_cleanup_test.go`
+- `apps/backend/internal/task/service/resource_cleanup_jobs.go`
+- `apps/backend/internal/task/service/resource_cleanup_jobs_test.go`
+
+## Dependencies
+
+Task 01.
+
+## Parallelism
+
+`sequential`; it shares cleanup service behavior and tests with Task 01.
+
+## Inputs
+
+- Runtime cleanup spec: retry schedule, terminal state, and persistence
+  guarantees.
+- Storage-maintenance spec: `task_resource_cleanup_jobs` state machine.
+- Existing optimistic claim-generation behavior in
+  `CompleteClaimedTaskResourceCleanupJob`.
+
+## Output contract
+
+Report the RED failures, retry-state implementation, files changed, exact
+verification result, terminal-state persistence evidence, residual risks, and
+update this task plus `plan.md` status.
+
+## Result
+
+- RED coverage reproduced the fixed one-minute retry and missing terminal completion metadata.
+- Added the seven-step backoff schedule, eight-attempt ceiling, terminal `failed` state, and completion timestamps for failed jobs.
+- Verified the targeted retry tests, full SQLite/service suites, and the same suites under `-race`.

--- a/docs/specs/system-page/storage-maintenance.md
+++ b/docs/specs/system-page/storage-maintenance.md
@@ -242,7 +242,7 @@ operation_id      string     unique idempotency key for one lifecycle mutation
 task_id           string     indexed, no foreign key
 trigger           enum       archive | delete | cascade_archive | cascade_delete |
                              workspace_delete | quick_chat_expire | reconcile
-state             enum       pending | running | retry_wait | succeeded | cancelled
+state             enum       pending | running | retry_wait | succeeded | failed | cancelled
 resource_snapshot json       captured runtime/environment/worktree/path handles
 attempts          int        non-negative
 next_attempt_at   timestamp  nullable
@@ -392,7 +392,9 @@ records each provider result.
 ```text
 pending -> running -> succeeded
                    -> cancelled       archived task became active again
-                   -> retry_wait      bounded attempt failed
+                   -> retry_wait      attempts 1-7 failed; retry uses the
+                                      1m, 5m, 15m, 1h, 3h, 6h, 12h schedule
+                   -> failed          attempt 8 failed; terminal diagnostic
 retry_wait -> running                 next attempt or manual maintenance run
 ```
 

--- a/docs/specs/tasks/runtime-cleanup.md
+++ b/docs/specs/tasks/runtime-cleanup.md
@@ -52,9 +52,16 @@ worktrees, or executor rows behind and the machine slowly runs out of memory.
 - Cleanup is idempotent: repeating archive/delete cleanup, startup reconciliation,
   or explicit session stop does not fail because the process, task, session, or
   worktree was already removed.
+- A cleanup operation treats a classifiable missing owned resource as already
+  complete. This includes a missing worktree and a missing `TaskEnvironment`
+  row captured by the durable cleanup snapshot.
 - Archive, delete, cascade, workspace-delete, and quick-chat expiration persist a
   cleanup intent and resource snapshot before mutating or deleting task state.
   Cleanup is performed by a durable worker rather than a detached goroutine.
+- A durable cleanup job makes at most eight attempts. Failed attempts back off
+  for 1 minute, 5 minutes, 15 minutes, 1 hour, 3 hours, 6 hours, and 12 hours
+  before the next claim. An eighth failed attempt becomes terminal `failed`
+  instead of scheduling another retry.
 - Archive cleanup revalidates that the task remains archived before every
   destructive step. Unarchiving a task cancels its pending archive cleanup so a
   delayed retry cannot remove the newly active task's resources.
@@ -97,7 +104,9 @@ no foreign key to `tasks`, so delete cleanup survives deletion of the owning row
 It stores the trigger, state, retry timing, last error, and a JSON snapshot of the
 runtime, environment, worktree, and path handles captured before task mutation.
 Only one non-terminal row exists for an operation ID; repeated event delivery
-reuses the same cleanup job.
+reuses the same cleanup job. `attempts` counts successful worker claims. A
+terminal `failed` row retains its final error and completion timestamp for
+diagnosis but is not selected by the automatic worker.
 
 ## API Surface
 
@@ -147,7 +156,8 @@ The durable cleanup job wraps that resource lifecycle:
 - `pending` -> `running` when the cleanup worker claims the job.
 - `running` -> `succeeded` when runtime and owned resource cleanup finish.
 - `running` -> `retry_wait` when bounded cleanup fails and the resource snapshot
-  must be retried.
+  must be retried and fewer than eight claims have run.
+- `running` -> `failed` when the eighth claimed attempt fails.
 - `retry_wait` -> `running` on the next scheduled retry or manual storage run.
 - `pending|running|retry_wait` -> `cancelled` when an archive-triggered cleanup
   observes that its task has been unarchived.
@@ -168,6 +178,12 @@ The durable cleanup job wraps that resource lifecycle:
   confirmed, the runtime tracking row can still be removed because it no longer
   identifies a live process. The resource cleanup error is logged and handled by
   the resource-specific retry path.
+- If a worktree or captured task-environment row is already absent, cleanup
+  treats that deletion step as successful and continues. Other teardown errors
+  remain retryable and are not hidden by an accompanying not-found result.
+- If cleanup still fails on its eighth worker claim, the job becomes terminal
+  `failed`, preserves `last_error`, clears `next_attempt_at`, stamps
+  `completed_at`, and is excluded from automatic due-job selection.
 - If cleanup cannot prove that a session worktree belongs to the task being
   cleaned, destructive worktree deletion fails closed and skips that worktree.
 - If an agentctl process exits unexpectedly, its owned agent subprocess group is
@@ -198,6 +214,8 @@ The durable cleanup job wraps that resource lifecycle:
   reattempting cleanup for stale runtime rows.
 - Pending and retryable task cleanup jobs survive restart and resume independently
   of whether optional scheduled storage maintenance is enabled.
+- Terminal failed task cleanup jobs survive restart for diagnosis but do not
+  resume automatically.
 - Cleanup snapshots needed after task deletion survive without foreign-keyed task,
   session, environment, or worktree rows.
 - Historical worktree rows for archived tasks remain available to unarchive branch
@@ -250,6 +268,18 @@ The durable cleanup job wraps that resource lifecycle:
 - **GIVEN** the backend exits after a task is deleted but before its worktree is
   removed, **WHEN** the backend restarts, **THEN** the durable cleanup job retries
   using its captured resource snapshot.
+- **GIVEN** a delete cleanup snapshot references a worktree that is already
+  absent, **WHEN** the cleanup worker runs, **THEN** the worktree step is treated
+  as complete and the job does not retry because of that absence.
+- **GIVEN** a delete cleanup snapshot requests deletion of a task-environment row
+  that is already absent, **WHEN** the cleanup worker runs, **THEN** the row step
+  is treated as complete and the job does not retry because of that absence.
+- **GIVEN** a cleanup job fails for a genuinely retryable reason, **WHEN** fewer
+  than eight attempts have run, **THEN** it enters `retry_wait` using the
+  documented backoff schedule.
+- **GIVEN** a cleanup job fails on its eighth attempt, **WHEN** the worker records
+  the result, **THEN** it enters terminal `failed` with the final diagnostic and
+  is not automatically claimed again.
 - **GIVEN** an archive cleanup job is pending, **WHEN** the task is unarchived,
   **THEN** the job is cancelled and cannot delete resources created after
   unarchive.
@@ -262,6 +292,7 @@ The durable cleanup job wraps that resource lifecycle:
 - A general-purpose OS process sweeper that kills every process named
   `codex-acp`, `claude-acp`, or `opencode`.
 - UI changes for showing runtime cleanup failures.
+- A user-facing action to replay a terminal failed cleanup job.
 - New user-facing archive/delete controls.
 - Changing the task/session state model beyond the cleanup guarantees described
   here.


### PR DESCRIPTION
Cleanup jobs previously retried forever when a worktree or task environment had already been removed, and every other failure retried once per minute indefinitely. This makes missing resources idempotent and bounds genuine failures with typed diagnostics and a terminal state.

## Validation

- `go test -tags fts5 -run 'Test(DeleteTaskEnvironmentMissing|TaskResourceCleanupMissingResources|TeardownEnvironmentResources)' ./internal/task/repository/sqlite ./internal/task/service`
- `go test -tags fts5 -run 'Test(TaskResourceCleanupRetryDelay|RetryTaskResourceCleanupJob|TaskResourceCleanupJobFailed)' ./internal/task/repository/sqlite ./internal/task/service`
- `go test -tags fts5 ./internal/task/repository/sqlite ./internal/task/service -count=1`
- `go test -race -tags fts5 ./internal/task/repository/sqlite ./internal/task/service -count=1`
- `make -C apps/backend lint`
- `git diff --check`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.

Closes #2027


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2046?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->