### PR TITLE
fix(github): stop the PR panel from showing the previous task's stale feedback

### DIFF
--- a/apps/web/components/github/pr-detail-panel.test.tsx
+++ b/apps/web/components/github/pr-detail-panel.test.tsx
@@ -1,0 +1,184 @@
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { StoreApi } from "zustand";
+import { StateProvider, useAppStoreApi } from "@/components/state-provider";
+import { ToastProvider } from "@/components/toast-provider";
+import { TooltipProvider } from "@kandev/ui/tooltip";
+import type { AppState } from "@/lib/state/store";
+import type { PRFeedback, TaskPR } from "@/lib/types/github";
+import { getPRFeedback } from "@/lib/api/domains/github-api";
+import { PRDetailPanelComponent } from "./pr-detail-panel";
+
+vi.mock("@/lib/api/domains/github-api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api/domains/github-api")>();
+  return {
+    ...actual,
+    getPRFeedback: vi.fn(),
+  };
+});
+
+vi.mock("@/lib/ws/connection", () => ({
+  getWebSocketClient: () => null,
+}));
+
+vi.mock("@/lib/layout/panel-portal-manager", () => ({
+  setPanelTitle: vi.fn(),
+}));
+
+function makePR(overrides: Partial<TaskPR> = {}): TaskPR {
+  return {
+    id: overrides.id ?? "pr-id",
+    task_id: "task-1",
+    owner: "acme",
+    repo: "demo",
+    pr_number: 1,
+    pr_url: "https://github.com/acme/demo/pull/1",
+    pr_title: "Test PR",
+    head_branch: "feat",
+    base_branch: "main",
+    author_login: "alice",
+    state: "open",
+    review_state: "",
+    checks_state: "success",
+    mergeable_state: "clean",
+    review_count: 0,
+    pending_review_count: 0,
+    comment_count: 1,
+    unresolved_review_threads: 0,
+    checks_total: 0,
+    checks_passing: 0,
+    additions: 0,
+    deletions: 0,
+    created_at: "",
+    merged_at: null,
+    closed_at: null,
+    last_synced_at: null,
+    updated_at: "",
+    ...overrides,
+  };
+}
+
+function makeFeedback(pr: TaskPR, botCommentBody: string): PRFeedback {
+  return {
+    pr: {
+      number: pr.pr_number,
+      title: pr.pr_title,
+      url: pr.pr_url,
+      html_url: pr.pr_url,
+      state: "open",
+      head_branch: pr.head_branch,
+      base_branch: pr.base_branch,
+      author_login: pr.author_login,
+      repo_owner: pr.owner,
+      repo_name: pr.repo,
+      draft: false,
+      mergeable: true,
+      additions: 0,
+      deletions: 0,
+      requested_reviewers: [],
+      created_at: "",
+      updated_at: "",
+      merged_at: null,
+      closed_at: null,
+    },
+    reviews: [],
+    comments: [
+      {
+        id: pr.pr_number,
+        author: "codex-bot",
+        author_avatar: "",
+        author_is_bot: true,
+        body: botCommentBody,
+        path: "",
+        line: 0,
+        side: "",
+        comment_type: "issue",
+        created_at: "",
+        updated_at: "",
+        in_reply_to: null,
+      },
+    ],
+    checks: [],
+    has_issues: false,
+  };
+}
+
+function StoreCapture({ onReady }: { onReady: (api: StoreApi<AppState>) => void }) {
+  const api = useAppStoreApi();
+  onReady(api);
+  return null;
+}
+
+function renderPanel(initialState: Partial<AppState>) {
+  let storeApi!: StoreApi<AppState>;
+  render(
+    <StateProvider initialState={initialState}>
+      <ToastProvider>
+        <TooltipProvider>
+          <StoreCapture onReady={(api) => (storeApi = api)} />
+          <PRDetailPanelComponent panelId="pr-detail" />
+        </TooltipProvider>
+      </ToastProvider>
+    </StateProvider>,
+  );
+  return { getStoreApi: () => storeApi };
+}
+
+function taskState(taskId: string, sessionId: string, prs: TaskPR[]): Partial<AppState> {
+  return {
+    workspaces: { items: [], activeId: "ws-1" },
+    taskPRs: { byTaskId: { [taskId]: prs } },
+    tasks: {
+      activeTaskId: taskId,
+      activeSessionId: sessionId,
+      pinnedSessionId: null,
+      lastSessionByTaskId: {},
+    },
+  } as unknown as Partial<AppState>;
+}
+
+beforeEach(() => {
+  vi.mocked(getPRFeedback).mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("PRDetailPanelComponent — task switch on the singleton legacy panel", () => {
+  it("resets the bot-comments toggle instead of leaking it across a task switch", async () => {
+    const pr1 = makePR({ id: "pr-1", task_id: "task-1", pr_number: 1 });
+    const pr2 = makePR({ id: "pr-2", task_id: "task-2", pr_number: 2 });
+
+    vi.mocked(getPRFeedback).mockImplementation((_ws, _owner, _repo, prNumber) =>
+      Promise.resolve(
+        prNumber === 1
+          ? makeFeedback(pr1, "PR 1 bot comment")
+          : makeFeedback(pr2, "PR 2 bot comment"),
+      ),
+    );
+
+    const { getStoreApi } = renderPanel(taskState("task-1", "session-1", [pr1]));
+
+    // Task 1: expand the bot-comments disclosure.
+    await waitFor(() => expect(screen.getByText("Bot comments (1)")).toBeTruthy());
+    fireEvent.click(screen.getByText("Bot comments (1)"));
+    await waitFor(() => expect(screen.getByText("PR 1 bot comment")).toBeTruthy());
+
+    // Switch to a different task whose PR also has exactly one bot comment —
+    // the singleton "pr-detail" panel is reused, not remounted by dockview.
+    await act(async () => {
+      getStoreApi().setState((prev) => ({
+        ...prev,
+        taskPRs: { byTaskId: { ...prev.taskPRs.byTaskId, "task-2": [pr2] } },
+        tasks: { ...prev.tasks, activeTaskId: "task-2", activeSessionId: "session-2" },
+      }));
+    });
+
+    await waitFor(() => expect(screen.getByText("Bot comments (1)")).toBeTruthy());
+    // Task 2's bot comment must stay collapsed by default, not inherit task 1's
+    // expanded disclosure state.
+    expect(screen.queryByText("PR 2 bot comment")).toBeNull();
+    expect(screen.queryByText("PR 1 bot comment")).toBeNull();
+  });
+});

--- a/apps/web/e2e/helpers/api-client.ts
+++ b/apps/web/e2e/helpers/api-client.ts
@@ -1436,6 +1436,7 @@ export class ApiClient {
       id: number;
       author: string;
       author_avatar?: string;
+      author_is_bot?: boolean;
       body: string;
       path?: string;
       line?: number;

--- a/apps/web/e2e/tests/pr/pr-detail-auto-show.spec.ts
+++ b/apps/web/e2e/tests/pr/pr-detail-auto-show.spec.ts
@@ -630,4 +630,229 @@ test.describe("PR detail panel", () => {
     await session.waitForChatIdle({ timeout: 30_000 });
     await expect(session.prDetailTab()).toHaveText("PR #401", { timeout: 15_000 });
   });
+
+  /**
+   * Contract coverage for switching to a different task's PR while its
+   * feedback (reviews/comments/checks) is still in flight: the tab/header
+   * must reflect the new task's PR immediately, and once the held fetch
+   * resolves, its "Bot comments" disclosure must render collapsed (not
+   * inheriting whatever the previous PR's disclosure was left in).
+   *
+   * This harness gives each task its own isolated worktree/env, so the
+   * auto-shown "pr-detail" panel is freshly mounted per task here and this
+   * does not reproduce the exact same-React-instance staleness window
+   * reported in production (reused instance carrying over `usePRFeedback`
+   * state and `CommentsSection`'s bot-comments toggle across tasks sharing
+   * one env — same category of limitation already called out on the
+   * "switching between two PR-linked tasks" test above). That reused-instance
+   * regression is covered deterministically by
+   * `hooks/domains/github/use-pr-feedback.test.ts` (masks stale feedback by
+   * PR identity) and `components/github/pr-detail-panel.test.tsx` (proves the
+   * bot-comments toggle doesn't leak across a switch on one panel instance).
+   * This spec still guards the real browser flow end-to-end.
+   *
+   * Setup:
+   *   Inbox → Working (auto_start, on_turn_complete → Done) → Done
+   *   Task A (PR #601, one bot comment), Task B (PR #602, one bot comment,
+   *   feedback fetch held back until explicitly released)
+   */
+  test("shows the new task's PR immediately and renders its bot-comments disclosure collapsed while switching with feedback in flight", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    test.setTimeout(120_000);
+
+    const workflow = await apiClient.createWorkflow(seedData.workspaceId, "PR Leak Workflow");
+
+    const inboxStep = await apiClient.createWorkflowStep(workflow.id, "Inbox", 0);
+    const workingStep = await apiClient.createWorkflowStep(workflow.id, "Working", 1);
+    const doneStep = await apiClient.createWorkflowStep(workflow.id, "Done", 2);
+
+    await apiClient.updateWorkflowStep(workingStep.id, {
+      prompt: 'e2e:message("done")\n{{task_prompt}}',
+      events: {
+        on_enter: [{ type: "auto_start_agent" }],
+        on_turn_complete: [{ type: "move_to_step", config: { step_id: doneStep.id } }],
+      },
+    });
+
+    await apiClient.saveUserSettings({
+      workspace_id: seedData.workspaceId,
+      workflow_filter_id: workflow.id,
+      enable_preview_on_click: false,
+    });
+
+    const OWNER = "testorg";
+    const REPO = "testrepo";
+    const PR_A = 601;
+    const PR_B = 602;
+
+    await apiClient.mockGitHubReset();
+    await apiClient.mockGitHubSetUser("test-user");
+    await apiClient.mockGitHubAddPRs([
+      {
+        number: PR_A,
+        title: "Leak Task A PR",
+        state: "open",
+        head_branch: "feat/leak-a",
+        base_branch: "main",
+        author_login: "test-user",
+        repo_owner: OWNER,
+        repo_name: REPO,
+        additions: 3,
+        deletions: 1,
+      },
+      {
+        number: PR_B,
+        title: "Leak Task B PR",
+        state: "open",
+        head_branch: "feat/leak-b",
+        base_branch: "main",
+        author_login: "test-user",
+        repo_owner: OWNER,
+        repo_name: REPO,
+        additions: 4,
+        deletions: 2,
+      },
+    ]);
+
+    const taskA = await apiClient.createTask(seedData.workspaceId, "Leak Task A", {
+      workflow_id: workflow.id,
+      workflow_step_id: inboxStep.id,
+      agent_profile_id: seedData.agentProfileId,
+      repository_ids: [seedData.repositoryId],
+    });
+    const taskB = await apiClient.createTask(seedData.workspaceId, "Leak Task B", {
+      workflow_id: workflow.id,
+      workflow_step_id: inboxStep.id,
+      agent_profile_id: seedData.agentProfileId,
+      repository_ids: [seedData.repositoryId],
+    });
+
+    const kanban = new KanbanPage(testPage);
+    await kanban.goto();
+
+    await apiClient.moveTask(taskA.id, workflow.id, workingStep.id);
+    await apiClient.moveTask(taskB.id, workflow.id, workingStep.id);
+    await apiClient.mockGitHubAssociateTaskPR({
+      task_id: taskA.id,
+      owner: OWNER,
+      repo: REPO,
+      pr_number: PR_A,
+      pr_url: `https://github.com/${OWNER}/${REPO}/pull/${PR_A}`,
+      pr_title: "Leak Task A PR",
+      head_branch: "feat/leak-a",
+      base_branch: "main",
+      author_login: "test-user",
+      additions: 3,
+      deletions: 1,
+    });
+    await apiClient.mockGitHubAssociateTaskPR({
+      task_id: taskB.id,
+      owner: OWNER,
+      repo: REPO,
+      pr_number: PR_B,
+      pr_url: `https://github.com/${OWNER}/${REPO}/pull/${PR_B}`,
+      pr_title: "Leak Task B PR",
+      head_branch: "feat/leak-b",
+      base_branch: "main",
+      author_login: "test-user",
+      additions: 4,
+      deletions: 2,
+    });
+
+    await apiClient.mockGitHubSeedPRFeedback({
+      owner: OWNER,
+      repo: REPO,
+      pr_number: PR_A,
+      comments: [
+        {
+          id: 1,
+          author: "review-bot",
+          author_is_bot: true,
+          body: "PR A bot comment",
+        },
+      ],
+    });
+    await apiClient.mockGitHubSeedPRFeedback({
+      owner: OWNER,
+      repo: REPO,
+      pr_number: PR_B,
+      comments: [
+        {
+          id: 2,
+          author: "review-bot",
+          author_is_bot: true,
+          body: "PR B bot comment",
+        },
+      ],
+    });
+
+    await expect(kanban.taskCardInColumn("Leak Task A", doneStep.id)).toBeVisible({
+      timeout: 45_000,
+    });
+    await expect(kanban.taskCardInColumn("Leak Task B", doneStep.id)).toBeVisible({
+      timeout: 45_000,
+    });
+
+    // Hold PR B's feedback fetch until explicitly released, so the switch
+    // below lands while its comments are still loading.
+    let releasePRBFeedback!: () => void;
+    const prBFeedbackHeld = new Promise<void>((resolve) => {
+      releasePRBFeedback = resolve;
+    });
+    let observePRBFeedbackRequested!: () => void;
+    const prBFeedbackRequested = new Promise<void>((resolve) => {
+      observePRBFeedbackRequested = resolve;
+    });
+    await testPage.route(
+      (url) => url.pathname === `/api/v1/github/prs/${OWNER}/${REPO}/${PR_B}`,
+      async (route) => {
+        const response = await route.fetch();
+        observePRBFeedbackRequested();
+        await prBFeedbackHeld;
+        await route.fulfill({ response });
+      },
+    );
+
+    await kanban.taskCardInColumn("Leak Task A", doneStep.id).click();
+    await expect(testPage).toHaveURL(/\/t\//, { timeout: 15_000 });
+
+    const session = new SessionPage(testPage);
+    await session.waitForLoad();
+    await session.waitForChatIdle({ timeout: 30_000 });
+    await expect(session.prDetailTab()).toHaveText(`PR #${PR_A}`, { timeout: 15_000 });
+    await session.prDetailTab().click();
+
+    const panel = session.prDetailPanel();
+    await expect(panel).toBeVisible({ timeout: 10_000 });
+    await expect(panel.getByText("Bot comments (1)")).toBeVisible({ timeout: 15_000 });
+    await panel.getByText("Bot comments (1)").click();
+    await expect(panel.getByText("PR A bot comment")).toBeVisible();
+
+    // Switch to Task B — its feedback request is held back by the route above.
+    await session.clickTaskInSidebar("Leak Task B");
+    await prBFeedbackRequested;
+
+    // The header/tab already reflects Task B's PR (comes from the task-PR
+    // association, not the held feedback fetch) …
+    await expect(session.prDetailTab()).toHaveText(`PR #${PR_B}`, { timeout: 15_000 });
+    await session.prDetailTab().click();
+    await expect(panel).toBeVisible({ timeout: 10_000 });
+    // … but PR A's comment, and its expanded bot-comments disclosure, must
+    // be gone immediately — not left on screen for the several seconds the
+    // feedback fetch is still in flight.
+    await expect(panel.getByText("PR A bot comment")).toHaveCount(0);
+
+    releasePRBFeedback();
+
+    // PR B's bot comment must stay collapsed by default — the disclosure
+    // must not inherit Task A's expanded state — and must never be PR A's.
+    await expect(panel.getByText("Bot comments (1)")).toBeVisible({ timeout: 15_000 });
+    await expect(panel.getByText("PR B bot comment")).toHaveCount(0);
+    await panel.getByText("Bot comments (1)").click();
+    await expect(panel.getByText("PR B bot comment")).toBeVisible();
+    await expect(panel.getByText("PR A bot comment")).toHaveCount(0);
+  });
 });

--- a/apps/web/hooks/domains/github/use-pr-feedback.test.ts
+++ b/apps/web/hooks/domains/github/use-pr-feedback.test.ts
@@ -1,0 +1,167 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { StateProvider } from "@/components/state-provider";
+import type { AppState } from "@/lib/state/store";
+import type { PRFeedback } from "@/lib/types/github";
+import { resolvePRFeedbackView, usePRFeedback, type PRFeedbackState } from "./use-pr-feedback";
+
+const getPRFeedbackMock = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/api/domains/github-api", () => ({
+  getPRFeedback: getPRFeedbackMock,
+}));
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+function makeFeedback(commentBody: string): PRFeedback {
+  return {
+    pr: {
+      number: 1,
+      title: "Test PR",
+      url: "https://github.com/acme/app/pull/1",
+      html_url: "https://github.com/acme/app/pull/1",
+      state: "open",
+      head_branch: "feat",
+      base_branch: "main",
+      author_login: "alice",
+      repo_owner: "acme",
+      repo_name: "app",
+      draft: false,
+      mergeable: true,
+      additions: 1,
+      deletions: 0,
+      requested_reviewers: [],
+      created_at: "",
+      updated_at: "",
+      merged_at: null,
+      closed_at: null,
+    },
+    reviews: [],
+    comments: [
+      {
+        id: 1,
+        author: "bot",
+        author_avatar: "",
+        author_is_bot: true,
+        body: commentBody,
+        path: "",
+        line: 0,
+        side: "",
+        comment_type: "issue",
+        created_at: "",
+        updated_at: "",
+        in_reply_to: null,
+      },
+    ],
+    checks: [],
+    has_issues: false,
+  };
+}
+
+beforeEach(() => {
+  getPRFeedbackMock.mockReset();
+});
+
+function wrapper({ children }: { children: ReactNode }) {
+  const initialState = {
+    workspaces: { activeId: "ws-1" },
+  } as unknown as Partial<AppState>;
+  return createElement(StateProvider, { initialState, children });
+}
+
+const staleState: PRFeedbackState = {
+  key: "ws-1/acme/app/1",
+  feedback: makeFeedback("stale comment from PR 1"),
+  loading: false,
+  error: null,
+};
+
+describe("resolvePRFeedbackView", () => {
+  it("masks the previous PR's feedback while a newly requested PR starts loading", () => {
+    expect(resolvePRFeedbackView(staleState, "ws-1/acme/app/2")).toEqual({
+      feedback: null,
+      loading: true,
+      error: null,
+    });
+  });
+
+  it("clears stale feedback without loading when no PR is requested", () => {
+    expect(resolvePRFeedbackView(staleState, "")).toEqual({
+      feedback: null,
+      loading: false,
+      error: null,
+    });
+  });
+
+  it("passes through cached feedback when the requested key matches (e.g. manual refresh)", () => {
+    expect(resolvePRFeedbackView(staleState, "ws-1/acme/app/1")).toEqual({
+      feedback: staleState.feedback,
+      loading: false,
+      error: null,
+    });
+  });
+});
+
+describe("usePRFeedback request ownership", () => {
+  it("masks PR 1's feedback immediately on switching to PR 2, and ignores PR 1 when it resolves late", async () => {
+    const first = deferred<PRFeedback>();
+    const second = deferred<PRFeedback>();
+    getPRFeedbackMock.mockImplementation(
+      (_ws: string, _owner: string, _repo: string, prNumber: number) =>
+        prNumber === 1 ? first.promise : second.promise,
+    );
+
+    const { result, rerender } = renderHook(
+      ({ prNumber }) => usePRFeedback("ws-1", "acme", "app", prNumber),
+      { initialProps: { prNumber: 1 }, wrapper },
+    );
+
+    await act(async () => {
+      first.resolve(makeFeedback("PR 1 comment"));
+      await first.promise;
+    });
+    await waitFor(() => expect(result.current.feedback?.comments[0]?.body).toBe("PR 1 comment"));
+
+    // Switch to a different PR (simulating switching tasks) before the new
+    // fetch resolves — the panel must not keep showing PR 1's stale content.
+    rerender({ prNumber: 2 });
+    expect(result.current.feedback).toBeNull();
+    expect(result.current.loading).toBe(true);
+
+    await act(async () => {
+      second.resolve(makeFeedback("PR 2 comment"));
+      await second.promise;
+    });
+    await waitFor(() => expect(result.current.feedback?.comments[0]?.body).toBe("PR 2 comment"));
+
+    // PR 1's request resolving late must not resurrect its stale data.
+    expect(result.current.feedback?.comments[0]?.body).toBe("PR 2 comment");
+  });
+
+  it("keeps showing cached feedback while a manual refresh of the same PR is in flight", async () => {
+    const first = deferred<PRFeedback>();
+    getPRFeedbackMock.mockReturnValueOnce(first.promise);
+
+    const { result } = renderHook(() => usePRFeedback("ws-1", "acme", "app", 1), { wrapper });
+
+    await act(async () => {
+      first.resolve(makeFeedback("initial comment"));
+      await first.promise;
+    });
+    await waitFor(() => expect(result.current.feedback?.comments[0]?.body).toBe("initial comment"));
+
+    const second = deferred<PRFeedback>();
+    getPRFeedbackMock.mockReturnValueOnce(second.promise);
+    act(() => result.current.refresh());
+
+    // Same identity refresh: old feedback stays visible while reloading.
+    expect(result.current.feedback?.comments[0]?.body).toBe("initial comment");
+    expect(result.current.loading).toBe(true);
+  });
+});

--- a/apps/web/hooks/domains/github/use-pr-feedback.ts
+++ b/apps/web/hooks/domains/github/use-pr-feedback.ts
@@ -4,26 +4,57 @@ import { useState, useEffect, useCallback, useReducer } from "react";
 import { getPRFeedback } from "@/lib/api/domains/github-api";
 import type { PRFeedback } from "@/lib/types/github";
 
-type State = {
+export type PRFeedbackState = {
+  /** `<workspaceId>/<owner>/<repo>/<prNumber>` of the request `feedback` belongs to. */
+  key: string;
+  feedback: PRFeedback | null;
+  loading: boolean;
+  error: string | null;
+};
+
+type PRFeedbackView = {
   feedback: PRFeedback | null;
   loading: boolean;
   error: string | null;
 };
 
 type Action =
-  | { type: "fetch" }
-  | { type: "success"; feedback: PRFeedback }
-  | { type: "error"; message: string };
+  | { type: "fetch"; key: string }
+  | { type: "success"; key: string; feedback: PRFeedback }
+  | { type: "error"; key: string; message: string };
 
-function reducer(state: State, action: Action): State {
+const INITIAL_STATE: PRFeedbackState = { key: "", feedback: null, loading: false, error: null };
+
+function reducer(state: PRFeedbackState, action: Action): PRFeedbackState {
+  // Same-PR refresh keeps the cached feedback visible while it reloads;
+  // a different PR (e.g. a task switch reusing this hook instance) never
+  // inherits another PR's feedback.
+  const carried = state.key === action.key ? state.feedback : null;
   switch (action.type) {
     case "fetch":
-      return { ...state, loading: true, error: null };
+      return { key: action.key, feedback: carried, loading: true, error: null };
     case "success":
-      return { feedback: action.feedback, loading: false, error: null };
+      return { key: action.key, feedback: action.feedback, loading: false, error: null };
     case "error":
-      return { ...state, loading: false, error: action.message };
+      return { key: action.key, feedback: carried, loading: false, error: action.message };
   }
+}
+
+/**
+ * Derives the feedback actually safe to render for `requestedKey`. Masks out
+ * `state.feedback` whenever it belongs to a different PR than the one
+ * currently requested — this runs on every render (not just after the fetch
+ * effect dispatches), so a PR/task switch stops showing the previous PR's
+ * reviews/comments immediately, before the new fetch even resolves.
+ */
+export function resolvePRFeedbackView(
+  state: PRFeedbackState,
+  requestedKey: string,
+): PRFeedbackView {
+  if (state.key === requestedKey) {
+    return { feedback: state.feedback, loading: state.loading, error: state.error };
+  }
+  return { feedback: null, loading: requestedKey !== "", error: null };
 }
 
 /**
@@ -37,32 +68,35 @@ export function usePRFeedback(
   repo: string | null,
   prNumber: number | null,
 ) {
-  const [state, dispatch] = useReducer(reducer, { feedback: null, loading: false, error: null });
+  const [state, dispatch] = useReducer(reducer, INITIAL_STATE);
   const [fetchCount, setFetchCount] = useState(0);
+  const key =
+    workspaceId && owner && repo && prNumber ? `${workspaceId}/${owner}/${repo}/${prNumber}` : "";
 
   const refresh = useCallback(() => {
     setFetchCount((c) => c + 1);
   }, []);
 
   useEffect(() => {
-    if (!workspaceId || !owner || !repo || !prNumber) return;
+    if (!workspaceId || !owner || !repo || !prNumber || !key) return;
     let cancelled = false;
-    dispatch({ type: "fetch" });
+    dispatch({ type: "fetch", key });
     getPRFeedback(workspaceId, owner, repo, prNumber, { cache: "no-store" })
       .then((response) => {
-        if (!cancelled) dispatch({ type: "success", feedback: response });
+        if (!cancelled) dispatch({ type: "success", key, feedback: response });
       })
       .catch((err) => {
         if (!cancelled)
           dispatch({
             type: "error",
+            key,
             message: err instanceof Error ? err.message : "Failed to fetch PR feedback",
           });
       });
     return () => {
       cancelled = true;
     };
-  }, [workspaceId, owner, repo, prNumber, fetchCount]);
+  }, [workspaceId, owner, repo, prNumber, key, fetchCount]);
 
-  return { feedback: state.feedback, loading: state.loading, error: state.error, refresh };
+  return { ...resolvePRFeedbackView(state, key), refresh };
 }


### PR DESCRIPTION
Switching from one task's PR tab to another task's PR tab could briefly show the previous task's stale reviews/comments/checks — including whatever "Bot comments" disclosure was left expanded — because `usePRFeedback` kept the old PR's feedback in state while the new PR's fetch was still in flight.

## Important Changes

- `usePRFeedback` now keys its cached feedback by `<workspaceId>/<owner>/<repo>/<prNumber>` and masks it via `resolvePRFeedbackView` whenever the requested key changes (mirrors the existing `resolvePRDiffView` masking pattern used for the diff viewer), while still preserving cached feedback during a same-PR manual refresh so that flow doesn't flicker.
- The `{feedback && (...)}` gate in `PRDetailContent` then naturally unmounts/remounts the reviews/comments/checks subtree on a real identity change, resetting any stale local disclosure state (e.g. the bot-comments toggle) along with the data.

## Validation

- `hooks/domains/github/use-pr-feedback.test.ts` (new): unit tests for `resolvePRFeedbackView`, plus a hook test proving PR 1's feedback is masked immediately on switching to PR 2 and a late PR 1 response can't resurrect stale data. Confirmed failing before the fix, passing after.
- `components/github/pr-detail-panel.test.tsx` (new): renders `PRDetailPanelComponent`, expands "Bot comments" on task 1's PR, switches the store to task 2 while reusing the same panel instance, and asserts task 2 renders with the toggle collapsed and no leaked text. Confirmed failing before the fix, passing after.
- Added a Playwright case to `e2e/tests/pr/pr-detail-auto-show.spec.ts` and ran it against a real Chromium + real Go backend — it passes with the fix. That harness gives each task its own isolated env, so it doesn't reproduce the exact reused-panel-instance race (documented in the test's own comment, matching a precedent already in that file for a sibling bug); the two tests above are the discriminating regression coverage.
- `make fmt-web` (clean), `make typecheck` (pass), `make lint-web` (pass, 0 warnings), `make test-web` (7237/7242 pass; the 1 failure, `storage-maintenance-settings.test.tsx`, is an unrelated pre-existing timeout confirmed passing in isolation).
- No screenshots: this is a data-timing fix, not a visual/layout change — every screen it touches renders identically once the (now-correct) data has loaded.

## Possible Improvements

Low risk: behavior change is scoped to one hook's internal state machine and the render gate that already existed; no API or type surface changed for the hook's callers.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2048?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

