### PR TITLE
fix(gitlab): parse glab's "Token found:" auth status label

### DIFF
--- a/apps/backend/internal/gitlab/glab_client.go
+++ b/apps/backend/internal/gitlab/glab_client.go
@@ -114,16 +114,28 @@ func glabReadToken(ctx context.Context, hostname string) (string, error) {
 	return parseGlabToken(stdout.String() + "\n" + stderr.String()), nil
 }
 
-// parseGlabToken finds a "Token: <value>" line in the combined output of
+// glabTokenLabels are the label variants `glab auth status -t` has used for
+// the token line. glab >= 1.x prints "Token found:"; older builds printed a
+// bare "Token:". Longest first so "Token found:" is not mis-split by "Token:".
+var glabTokenLabels = []string{"token found:", "token:"}
+
+// parseGlabToken finds the token line in the combined output of
 // `glab auth status -t` and returns the token (or "" if none).
 func parseGlabToken(output string) string {
 	for _, line := range strings.Split(output, "\n") {
 		line = strings.TrimSpace(line)
-		idx := strings.Index(strings.ToLower(line), "token:")
+		lower := strings.ToLower(line)
+		idx, label := -1, ""
+		for _, candidate := range glabTokenLabels {
+			if at := strings.Index(lower, candidate); at >= 0 {
+				idx, label = at, candidate
+				break
+			}
+		}
 		if idx < 0 {
 			continue
 		}
-		token := strings.TrimSpace(line[idx+len("token:"):])
+		token := strings.TrimSpace(line[idx+len(label):])
 		// glab sometimes prefixes lines with ANSI / arrows; strip leading
 		// non-alphanumerics until we hit token characters.
 		token = strings.TrimLeft(token, " \t-→>")

--- a/apps/backend/internal/gitlab/glab_client_test.go
+++ b/apps/backend/internal/gitlab/glab_client_test.go
@@ -23,9 +23,27 @@ func TestParseGlabToken_LowercaseLabel(t *testing.T) {
 	}
 }
 
+// glab >= 1.x prints "Token found:" rather than a bare "Token:" label.
+func TestParseGlabToken_TokenFoundLabel(t *testing.T) {
+	output := `gitlab.example.com
+  ✓ Logged in to gitlab.example.com as example-user (/home/example/.config/glab-cli/config.yml)
+  ✓ REST API Endpoint: https://gitlab.example.com/api/v4/
+  ✓ Token found: glpat-AAAAA-BBBBB`
+	got := parseGlabToken(output)
+	if got != "glpat-AAAAA-BBBBB" {
+		t.Errorf("got %q, want glpat-AAAAA-BBBBB", got)
+	}
+}
+
 func TestParseGlabToken_NoToken(t *testing.T) {
 	got := parseGlabToken("Token: <no token>")
 	if got != "" {
+		t.Errorf("got %q, want empty", got)
+	}
+}
+
+func TestParseGlabToken_NoTokenFound(t *testing.T) {
+	if got := parseGlabToken("✓ Token found: <no token>"); got != "" {
 		t.Errorf("got %q, want empty", got)
 	}
 }


### PR DESCRIPTION
## Problem

Saving a GitLab workspace connection in `glab_cli` mode fails against a self-managed host. The UI shows the catch-all

```
500 GitLab connection operation failed
```

which points at the wrong layer — that string is set when the client cannot be **constructed**, before any network call is made. A genuine auth or network failure takes a different branch and says "authentication failed". So the message reads as an upstream problem when it is local string parsing.

## Cause

`parseGlabToken` scanned `glab auth status -t` output for the substring `"token:"`, but glab >= 1.x prints:

```
  ✓ Token found: glpat-...
```

`"token:"` never matches that line, so the token comes back empty, `NewGLabClient` fails with `glab not authenticated for <host>`, and `SetConfigForWorkspace` aborts before persisting.

## Fix

Match against a longest-first label list — `"token found:"` then `"token:"` — so both the current and the legacy bare-`Token:` formats resolve. Longest-first matters: `"token:"` would otherwise mis-split `"Token found:"`. The `<no token>` guard and the ANSI/arrow prefix stripping are unchanged.

## Why not a tolerant regex

The obvious alternative is something like `(?i)token[^:]*:\s*(\S+)`, on the theory that it survives a future rename. I implemented both and ran them against the cases this package asserts plus plausible future output. The regex is worse:

| input | want | this PR | regex |
|---|---|---|---|
| `Token: <no token>` | `""` | `""` | **`<no`** |
| `✓ Token found: <no token>` | `""` | `""` | **`<no`** |
| `✓ Token expiry date: 2026-01-01` then the real token | token | token | **`2026-01-01`** |
| `✓ API token cache: enabled` then the real token | token | token | **`enabled`** |
| `✓ Token status: glpat-ZZZ` (hypothetical rename) | `glpat-ZZZ` | `""` | `glpat-ZZZ` |

Two structural problems, not pattern-tuning ones: `[^:]*` before the colon matches any token-ish label, so unrelated fields get captured; and matching over the whole blob rather than line by line means the first such line wins. Returning `<no` for the no-token case is the worst of it — a caller gets a plausible-looking token instead of a clean "not authenticated", and `TestParseGlabToken_NoToken` / `TestParseGlabToken_NoTokenFound` both go red.

If glab does rename the label, appending one entry to `glabTokenLabels` is precise and cannot start swallowing other fields.

## Verification

Self-managed GitLab, glab 1.101.0: saving the workspace connection in glab-CLI mode now returns `authenticated=true`.

```
go test ./internal/gitlab/
ok  github.com/kandev/kandev/internal/gitlab
```

Workaround for anyone hitting this before it lands: switch the integration from `glab_cli` to `pat` and paste a personal access token — that path does not go near this parser.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2054?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

