### PR TITLE
fix(backend): read Claude credentials from the macOS keychain

### DIFF
--- a/apps/backend/internal/agent/agents/billing.go
+++ b/apps/backend/internal/agent/agents/billing.go
@@ -22,7 +22,10 @@ func claudeBillingType() usage.BillingType {
 	if err != nil {
 		return usage.BillingTypeAPIKey
 	}
-	client := usage.NewClaudeUsageClientWithPath(filepath.Join(home, ".claude", ".credentials.json"))
+	client := usage.NewClaudeUsageClientForProfile(
+		filepath.Join(home, ".claude", ".credentials.json"),
+		usage.ClaudeDefaultKeychainService,
+	)
 	if client.HasSubscriptionCredentials() {
 		return usage.BillingTypeSubscription
 	}

--- a/apps/backend/internal/agent/usage/claude_keychain.go
+++ b/apps/backend/internal/agent/usage/claude_keychain.go
@@ -1,0 +1,44 @@
+package usage
+
+import (
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+// ClaudeDefaultKeychainService is the login-keychain item Claude Code writes
+// for the default profile (CLAUDE_CONFIG_DIR unset, i.e. ~/.claude).
+const ClaudeDefaultKeychainService = "Claude Code-credentials"
+
+// readKeychainCredentials returns the raw credentials JSON that Claude Code
+// stores in the macOS login keychain, or nil when it cannot be read.
+//
+// This exists because on macOS the keychain — not ~/.claude/.credentials.json —
+// holds the live token. Claude Code writes the file once at login and then
+// stops updating it, so a machine whose CLI has been refreshing normally for
+// weeks still has a file carrying a long-expired accessToken AND a refresh
+// token that has since been rotated away. Refreshing from that file fails with
+// `invalid_request_error` and no amount of retrying recovers it; the fix is to
+// read the credential the CLI actually maintains.
+//
+// Returns nil (never an error) on non-darwin platforms, when the item is
+// absent, or when the user denies keychain access — every one of those is a
+// legitimate "fall back to the file" signal rather than a failure to report.
+// Indirected so tests can substitute a fake without shelling out to `security`
+// or depending on the developer's own login keychain.
+var readKeychainCredentials = readKeychainCredentialsFromSecurity
+
+func readKeychainCredentialsFromSecurity(service string) []byte {
+	if runtime.GOOS != "darwin" || service == "" {
+		return nil
+	}
+	out, err := exec.Command("security", "find-generic-password", "-s", service, "-w").Output()
+	if err != nil {
+		return nil
+	}
+	trimmed := strings.TrimSpace(string(out))
+	if trimmed == "" {
+		return nil
+	}
+	return []byte(trimmed)
+}

--- a/apps/backend/internal/agent/usage/claude_keychain.go
+++ b/apps/backend/internal/agent/usage/claude_keychain.go
@@ -1,14 +1,64 @@
 package usage
 
 import (
+	"context"
+	"os"
 	"os/exec"
 	"runtime"
+	"strconv"
 	"strings"
+	"time"
 )
 
 // ClaudeDefaultKeychainService is the login-keychain item Claude Code writes
 // for the default profile (CLAUDE_CONFIG_DIR unset, i.e. ~/.claude).
 const ClaudeDefaultKeychainService = "Claude Code-credentials"
+
+// claudeKeychainLookupTimeout bounds one `security` invocation.
+//
+// Reading an item owned by another application can raise a blocking
+// authorization dialog, and a headless kandev has nobody to answer it. An
+// unbounded lookup wedges the usage poll for as long as the dialog stands, so
+// the lookup fails closed to the credentials file instead. Two seconds is far
+// above a warm keychain read and far below any poll interval.
+const claudeKeychainLookupTimeout = 2 * time.Second
+
+// disableKeychainEnv opts a machine out of keychain reads entirely.
+//
+// Declining the dialog is a per-request answer, not a stored preference: the
+// read falls back to the file, that fetch fails, and the failure cache brings
+// the dialog straight back. Without an opt-out the only durable choice offered
+// to a user who declines is "Always Allow" — the very thing they declined.
+const disableKeychainEnv = "KANDEV_DISABLE_CLAUDE_KEYCHAIN"
+
+// keychainGOOS and keychainCommand are seams so this file's behaviour is
+// testable without shelling out to `security`, and so the non-darwin path can
+// be exercised on the only platform where these tests actually run.
+var (
+	keychainGOOS = runtime.GOOS
+
+	keychainCommand = func(ctx context.Context, service string) ([]byte, error) {
+		// -w prints the secret to stdout; it is captured, never echoed.
+		return exec.CommandContext(ctx, "security", "find-generic-password", "-s", service, "-w").Output()
+	}
+)
+
+// keychainDisabled reports whether the opt-out is set.
+//
+// Unset, empty, and an explicit false keep the keychain on; any other value
+// turns it off. Erring toward "off" for an unparseable value is deliberate —
+// someone who typed `=yes` clearly wants it disabled, and ignoring them would
+// do the exact thing they were trying to prevent.
+func keychainDisabled() bool {
+	raw := os.Getenv(disableKeychainEnv)
+	if raw == "" {
+		return false
+	}
+	if parsed, err := strconv.ParseBool(raw); err == nil {
+		return parsed
+	}
+	return true
+}
 
 // readKeychainCredentials returns the raw credentials JSON that Claude Code
 // stores in the macOS login keychain, or nil when it cannot be read.
@@ -21,18 +71,23 @@ const ClaudeDefaultKeychainService = "Claude Code-credentials"
 // `invalid_request_error` and no amount of retrying recovers it; the fix is to
 // read the credential the CLI actually maintains.
 //
-// Returns nil (never an error) on non-darwin platforms, when the item is
-// absent, or when the user denies keychain access — every one of those is a
-// legitimate "fall back to the file" signal rather than a failure to report.
+// Returns nil (never an error) on non-darwin platforms, when the opt-out is
+// set, when the item is absent, when the lookup exceeds its timeout, or when
+// the user denies keychain access — every one of those is a legitimate "fall
+// back to the file" signal rather than a failure to report.
 // Indirected so tests can substitute a fake without shelling out to `security`
 // or depending on the developer's own login keychain.
 var readKeychainCredentials = readKeychainCredentialsFromSecurity
 
 func readKeychainCredentialsFromSecurity(service string) []byte {
-	if runtime.GOOS != "darwin" || service == "" {
+	if keychainGOOS != "darwin" || service == "" || keychainDisabled() {
 		return nil
 	}
-	out, err := exec.Command("security", "find-generic-password", "-s", service, "-w").Output()
+
+	ctx, cancel := context.WithTimeout(context.Background(), claudeKeychainLookupTimeout)
+	defer cancel()
+
+	out, err := keychainCommand(ctx, service)
 	if err != nil {
 		return nil
 	}

--- a/apps/backend/internal/agent/usage/claude_keychain_internal_test.go
+++ b/apps/backend/internal/agent/usage/claude_keychain_internal_test.go
@@ -129,6 +129,37 @@ func TestNewClaudeUsageClientWithPath_IsFileOnly(t *testing.T) {
 // the CLI rather than surfacing a bare OAuth failure — and must not rewrite the
 // file, which would fabricate a competing source of truth for a token we do not
 // own.
+// The refresh token rotates: the endpoint can return a new one and invalidate
+// the one it was given. The keychain item is written by the Claude CLI and we
+// have no way to store a replacement there, so spending its refresh token would
+// leave the CLI holding a dead credential — the same sticky
+// invalid_request_error this change exists to fix, relocated from the file to
+// the keychain. An expired keychain token is therefore reported, never
+// refreshed, and the endpoint must not be contacted at all.
+func TestClaudeFetchUsage_NeverSpendsTheKeychainRefreshToken(t *testing.T) {
+	path := writeClaudeCreds(t, t.TempDir(), futureExpiryMillis(), nil)
+	stubKeychain(t, keychainBlob(t, "expired", time.Now().Add(-time.Hour).UnixMilli()))
+
+	var refreshCalls int
+	refresh := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		refreshCalls++
+		// A rotating endpoint: succeeding here is what would burn the CLI's token.
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"access_token":"rotated","refresh_token":"rotated-refresh","expires_in":3600}`))
+	}))
+	defer refresh.Close()
+
+	client := NewClaudeUsageClientForProfile(path, ClaudeDefaultKeychainService)
+	client.refreshURL = refresh.URL
+
+	if _, err := client.FetchUsage(context.Background()); err == nil {
+		t.Fatal("expected an expired keychain credential to be reported, not refreshed")
+	}
+	if refreshCalls != 0 {
+		t.Errorf("refresh endpoint called %d time(s); a keychain token must never be spent", refreshCalls)
+	}
+}
+
 func TestClaudeFetchUsage_ExpiredKeychainTokenPointsAtCLI(t *testing.T) {
 	path := writeClaudeCreds(t, t.TempDir(), futureExpiryMillis(), nil)
 	stubKeychain(t, keychainBlob(t, "expired", time.Now().Add(-time.Hour).UnixMilli()))

--- a/apps/backend/internal/agent/usage/claude_keychain_internal_test.go
+++ b/apps/backend/internal/agent/usage/claude_keychain_internal_test.go
@@ -1,0 +1,161 @@
+package usage
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// stubKeychain swaps the keychain reader for the duration of one test. It
+// honours the empty-service contract of the real reader, so a client
+// constructed without a service name still bypasses the keychain entirely.
+func stubKeychain(t *testing.T, blob []byte) {
+	t.Helper()
+	prev := readKeychainCredentials
+	readKeychainCredentials = func(service string) []byte {
+		if service == "" {
+			return nil
+		}
+		return blob
+	}
+	t.Cleanup(func() { readKeychainCredentials = prev })
+}
+
+func keychainBlob(t *testing.T, accessToken string, expiresAt int64) []byte {
+	t.Helper()
+	data, err := json.Marshal(map[string]any{
+		"claudeAiOauth": map[string]any{
+			"accessToken":      accessToken,
+			"refreshToken":     "keychain-refresh",
+			"expiresAt":        expiresAt,
+			"subscriptionType": "max",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}
+
+// The regression this whole file exists for: on macOS the CLI refreshes the
+// token in the keychain and never rewrites ~/.claude/.credentials.json, so a
+// working install accumulates a file whose accessToken expired days ago and
+// whose refreshToken has already been rotated away. Reading the file first
+// makes every usage fetch fail with `invalid_request_error` on a machine that
+// is otherwise perfectly authenticated.
+func TestClaudeFetchUsage_PrefersKeychainOverStaleFile(t *testing.T) {
+	staleExpiry := time.Now().Add(-9 * 24 * time.Hour).UnixMilli()
+	path := writeClaudeCreds(t, t.TempDir(), staleExpiry, map[string]any{
+		"accessToken": "stale-file-token",
+	})
+	stubKeychain(t, keychainBlob(t, "live-keychain-token", futureExpiryMillis()))
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer live-keychain-token" {
+			t.Errorf("Authorization = %q, want the keychain token", got)
+		}
+		_, _ = w.Write([]byte(`{"five_hour": {"utilization": 12.5}}`))
+	}))
+	defer srv.Close()
+
+	client := NewClaudeUsageClientForProfile(path, ClaudeDefaultKeychainService)
+	client.usageURL = srv.URL
+
+	usage, err := client.FetchUsage(context.Background())
+	if err != nil {
+		t.Fatalf("FetchUsage: %v", err)
+	}
+	if len(usage.Windows) != 1 || usage.Windows[0].UtilizationPct != 12.5 {
+		t.Fatalf("windows = %+v", usage.Windows)
+	}
+}
+
+// A keychain item that is absent, unreadable, or malformed must not blind the
+// panel — the file is still a legitimate source (and the only one off darwin).
+func TestClaudeFetchUsage_FallsBackToFileWhenKeychainUnusable(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		blob []byte
+	}{
+		{"absent", nil},
+		{"malformed", []byte("not json")},
+		{"no oauth entry", []byte(`{"somethingElse": {}}`)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := writeClaudeCreds(t, t.TempDir(), futureExpiryMillis(), nil)
+			stubKeychain(t, tc.blob)
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if got := r.Header.Get("Authorization"); got != "Bearer live-token" {
+					t.Errorf("Authorization = %q, want the file token", got)
+				}
+				_, _ = w.Write([]byte(`{"five_hour": {"utilization": 1}}`))
+			}))
+			defer srv.Close()
+
+			client := NewClaudeUsageClientForProfile(path, ClaudeDefaultKeychainService)
+			client.usageURL = srv.URL
+
+			if _, err := client.FetchUsage(context.Background()); err != nil {
+				t.Fatalf("FetchUsage: %v", err)
+			}
+		})
+	}
+}
+
+// A test pointed at a temp file must never read the developer's real keychain.
+func TestNewClaudeUsageClientWithPath_IsFileOnly(t *testing.T) {
+	path := writeClaudeCreds(t, t.TempDir(), futureExpiryMillis(), nil)
+	stubKeychain(t, keychainBlob(t, "should-not-be-used", futureExpiryMillis()))
+
+	client := NewClaudeUsageClientWithPath(path)
+	creds, fromKeychain, err := client.readCredentialsWithSource()
+	if err != nil {
+		t.Fatalf("readCredentialsWithSource: %v", err)
+	}
+	if fromKeychain {
+		t.Error("WithPath consulted the keychain")
+	}
+	if creds.ClaudeAiOauth.AccessToken != "live-token" {
+		t.Errorf("accessToken = %q", creds.ClaudeAiOauth.AccessToken)
+	}
+}
+
+// When the credential the CLI owns is itself expired, the error should point at
+// the CLI rather than surfacing a bare OAuth failure — and must not rewrite the
+// file, which would fabricate a competing source of truth for a token we do not
+// own.
+func TestClaudeFetchUsage_ExpiredKeychainTokenPointsAtCLI(t *testing.T) {
+	path := writeClaudeCreds(t, t.TempDir(), futureExpiryMillis(), nil)
+	stubKeychain(t, keychainBlob(t, "expired", time.Now().Add(-time.Hour).UnixMilli()))
+
+	refresh := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"type":"error","error":{"type":"invalid_request_error"}}`))
+	}))
+	defer refresh.Close()
+
+	client := NewClaudeUsageClientForProfile(path, ClaudeDefaultKeychainService)
+	client.refreshURL = refresh.URL
+
+	_, err := client.FetchUsage(context.Background())
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if !strings.Contains(err.Error(), "claude auth status") {
+		t.Errorf("error should name the CLI remedy, got: %v", err)
+	}
+
+	// The file must be untouched.
+	creds, _, err := NewClaudeUsageClientWithPath(path).readCredentialsWithSource()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if creds.ClaudeAiOauth.AccessToken != "live-token" {
+		t.Errorf("file was rewritten: accessToken = %q", creds.ClaudeAiOauth.AccessToken)
+	}
+}

--- a/apps/backend/internal/agent/usage/claude_keychain_internal_test.go
+++ b/apps/backend/internal/agent/usage/claude_keychain_internal_test.go
@@ -3,6 +3,7 @@ package usage
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -188,5 +189,150 @@ func TestClaudeFetchUsage_ExpiredKeychainTokenPointsAtCLI(t *testing.T) {
 	}
 	if creds.ClaudeAiOauth.AccessToken != "live-token" {
 		t.Errorf("file was rewritten: accessToken = %q", creds.ClaudeAiOauth.AccessToken)
+	}
+}
+
+// stubKeychainCommand swaps the exec seam — one level below stubKeychain — so
+// the reader itself can be exercised without invoking `security`.
+func stubKeychainCommand(
+	t *testing.T,
+	fn func(ctx context.Context, service string) ([]byte, error),
+) *int {
+	t.Helper()
+	calls := 0
+	prev := keychainCommand
+	keychainCommand = func(ctx context.Context, service string) ([]byte, error) {
+		calls++
+		return fn(ctx, service)
+	}
+	t.Cleanup(func() { keychainCommand = prev })
+	return &calls
+}
+
+func stubKeychainGOOS(t *testing.T, goos string) {
+	t.Helper()
+	prev := keychainGOOS
+	keychainGOOS = goos
+	t.Cleanup(func() { keychainGOOS = prev })
+}
+
+func TestKeychainLookup_SkipsExecWhenItCannotApply(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		goos    string
+		service string
+	}{
+		{"non-darwin", "linux", ClaudeDefaultKeychainService},
+		{"no service name", "darwin", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stubKeychainGOOS(t, tc.goos)
+			calls := stubKeychainCommand(t, func(context.Context, string) ([]byte, error) {
+				return []byte(`{"claudeAiOauth":{"accessToken":"kc"}}`), nil
+			})
+
+			if got := readKeychainCredentialsFromSecurity(tc.service); got != nil {
+				t.Fatalf("expected nil, got %q", got)
+			}
+			if *calls != 0 {
+				t.Fatalf("expected no exec, got %d call(s)", *calls)
+			}
+		})
+	}
+}
+
+func TestKeychainLookup_FallsBackToNil(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		out  []byte
+		err  error
+	}{
+		// What `security` exits with when the item is absent or access is denied.
+		{"lookup error", nil, errors.New("exit status 44")},
+		{"timeout", nil, context.DeadlineExceeded},
+		{"blank output", []byte("  \n\t "), nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stubKeychainGOOS(t, "darwin")
+			stubKeychainCommand(t, func(context.Context, string) ([]byte, error) {
+				return tc.out, tc.err
+			})
+
+			if got := readKeychainCredentialsFromSecurity(ClaudeDefaultKeychainService); got != nil {
+				t.Fatalf("expected nil, got %q", got)
+			}
+		})
+	}
+}
+
+func TestKeychainLookup_TrimsAndReturnsPayload(t *testing.T) {
+	stubKeychainGOOS(t, "darwin")
+	var sawService string
+	stubKeychainCommand(t, func(_ context.Context, service string) ([]byte, error) {
+		sawService = service
+		return []byte("{\"claudeAiOauth\":{\"accessToken\":\"kc\"}}\n"), nil
+	})
+
+	got := readKeychainCredentialsFromSecurity(ClaudeDefaultKeychainService)
+	if want := `{"claudeAiOauth":{"accessToken":"kc"}}`; string(got) != want {
+		t.Fatalf("payload = %q, want %q", got, want)
+	}
+	if sawService != ClaudeDefaultKeychainService {
+		t.Fatalf("service = %q", sawService)
+	}
+}
+
+// The bound is what keeps a headless host from wedging behind an authorization
+// dialog nobody can answer.
+func TestKeychainLookup_BoundsTheCommand(t *testing.T) {
+	stubKeychainGOOS(t, "darwin")
+	var deadline time.Time
+	var hadDeadline bool
+	stubKeychainCommand(t, func(ctx context.Context, _ string) ([]byte, error) {
+		deadline, hadDeadline = ctx.Deadline()
+		return nil, ctx.Err()
+	})
+
+	readKeychainCredentialsFromSecurity(ClaudeDefaultKeychainService)
+
+	if !hadDeadline {
+		t.Fatal("keychain lookup ran with no deadline")
+	}
+	if remaining := time.Until(deadline); remaining > claudeKeychainLookupTimeout {
+		t.Fatalf("deadline %v exceeds the %v bound", remaining, claudeKeychainLookupTimeout)
+	}
+}
+
+func TestKeychainLookup_OptOut(t *testing.T) {
+	for _, tc := range []struct {
+		value    string
+		wantExec bool
+	}{
+		// Anything but an explicit false disables, including a value that does
+		// not parse: someone who wrote "=yes" means to turn it off, and ignoring
+		// them would do the exact thing they were preventing.
+		{"1", false}, {"true", false}, {"TRUE", false}, {"yes", false}, {"anything", false},
+		// An explicit false must not disable, or setting "=0" to keep the
+		// feature on would silently switch it off.
+		{"", true}, {"0", true}, {"false", true}, {"FALSE", true},
+	} {
+		t.Run("value="+tc.value, func(t *testing.T) {
+			stubKeychainGOOS(t, "darwin")
+			t.Setenv(disableKeychainEnv, tc.value)
+			calls := stubKeychainCommand(t, func(context.Context, string) ([]byte, error) {
+				return []byte(`{"claudeAiOauth":{"accessToken":"kc"}}`), nil
+			})
+
+			got := readKeychainCredentialsFromSecurity(ClaudeDefaultKeychainService)
+			if tc.wantExec && got == nil {
+				t.Fatal("expected the keychain to be consulted")
+			}
+			if !tc.wantExec && got != nil {
+				t.Fatalf("expected nil when opted out, got %q", got)
+			}
+			if want := map[bool]int{true: 1, false: 0}[tc.wantExec]; *calls != want {
+				t.Fatalf("exec calls = %d, want %d", *calls, want)
+			}
+		})
 	}
 }

--- a/apps/backend/internal/agent/usage/client_claude.go
+++ b/apps/backend/internal/agent/usage/client_claude.go
@@ -23,15 +23,33 @@ const (
 // ClaudeUsageClient fetches utilization from the Anthropic OAuth usage API.
 type ClaudeUsageClient struct {
 	credentialsPath string
+	keychainService string
 	usageURL        string
 	refreshURL      string
 	httpClient      *http.Client
 }
 
-// NewClaudeUsageClientWithPath creates a client with an explicit credentials path (for tests).
+// NewClaudeUsageClientWithPath creates a file-only client with an explicit
+// credentials path (for tests). It deliberately does NOT consult the keychain,
+// so a test pointed at a temp file cannot silently read the developer's real
+// credential instead. Production callers want NewClaudeUsageClientForProfile.
 func NewClaudeUsageClientWithPath(credentialsPath string) *ClaudeUsageClient {
+	return NewClaudeUsageClientForProfile(credentialsPath, "")
+}
+
+// NewClaudeUsageClientForProfile creates a client for one Claude login.
+//
+// A second account is a second CLAUDE_CONFIG_DIR: `claude auth login` under a
+// custom config dir stores its token in a hash-suffixed keychain item
+// ("Claude Code-credentials-<8 hex>") so it never collides with the default
+// profile's. Pass that service name to poll the non-default account.
+//
+// keychainService may be empty to force the file path (used by tests, and the
+// only sane behaviour on non-darwin hosts).
+func NewClaudeUsageClientForProfile(credentialsPath, keychainService string) *ClaudeUsageClient {
 	return &ClaudeUsageClient{
 		credentialsPath: credentialsPath,
+		keychainService: keychainService,
 		usageURL:        claudeUsageURL,
 		refreshURL:      claudeRefreshURL,
 		httpClient:      &http.Client{Timeout: 10 * time.Second},
@@ -87,14 +105,14 @@ type claudeUsageResponse struct {
 
 // FetchUsage implements ProviderUsageClient.
 func (c *ClaudeUsageClient) FetchUsage(ctx context.Context) (*ProviderUsage, error) {
-	creds, err := c.readCredentials()
+	creds, fromKeychain, err := c.readCredentialsWithSource()
 	if err != nil {
 		return nil, fmt.Errorf("claude usage: read credentials: %w", err)
 	}
 	if creds.ClaudeAiOauth == nil {
 		return nil, fmt.Errorf("claude usage: no claudeAiOauth entry in %s", c.credentialsPath)
 	}
-	token, err := c.freshAccessToken(ctx, creds.ClaudeAiOauth)
+	token, err := c.freshAccessToken(ctx, creds.ClaudeAiOauth, fromKeychain)
 	if err != nil {
 		return nil, fmt.Errorf("claude usage: %w", err)
 	}
@@ -205,7 +223,15 @@ func claudeLimitLabel(l claudeLimit) string {
 }
 
 // freshAccessToken returns a valid access token, refreshing if expired.
-func (c *ClaudeUsageClient) freshAccessToken(ctx context.Context, tok *claudeOAuthToken) (string, error) {
+//
+// fromKeychain reports whether the credential came from the keychain, which the
+// Claude CLI owns and keeps refreshed. In that case we never write a refreshed
+// token back to ~/.claude/.credentials.json: that file is already stale by
+// design, and overwriting it would fabricate a second, competing source of
+// truth for a token we do not own.
+func (c *ClaudeUsageClient) freshAccessToken(
+	ctx context.Context, tok *claudeOAuthToken, fromKeychain bool,
+) (string, error) {
 	// ExpiresAt is in milliseconds; treat as expired if within 60 s of now.
 	expiresAt := time.UnixMilli(tok.ExpiresAt)
 	if time.Until(expiresAt) > 60*time.Second {
@@ -216,26 +242,52 @@ func (c *ClaudeUsageClient) freshAccessToken(ctx context.Context, tok *claudeOAu
 	}
 	newTok, err := c.refreshToken(ctx, tok.RefreshToken)
 	if err != nil {
+		if fromKeychain {
+			// The CLI is the only writer of this credential. A failure here
+			// means it has not run recently enough, not that we should retry
+			// harder — say so instead of surfacing a bare OAuth error.
+			return "", fmt.Errorf("refresh token: %w (run `claude auth status` to refresh)", err)
+		}
 		return "", fmt.Errorf("refresh token: %w", err)
 	}
-	// Write new token back. Non-fatal — we have the new token in memory even if
-	// persistence fails, but log the error so it doesn't go unnoticed.
-	if writeErr := c.persistRefreshedToken(newTok); writeErr != nil {
-		fmt.Fprintf(os.Stderr, "claude usage: persist refreshed token: %v\n", writeErr)
+	if !fromKeychain {
+		// Write new token back. Non-fatal — we have the new token in memory even if
+		// persistence fails, but log the error so it doesn't go unnoticed.
+		if writeErr := c.persistRefreshedToken(newTok); writeErr != nil {
+			fmt.Fprintf(os.Stderr, "claude usage: persist refreshed token: %v\n", writeErr)
+		}
 	}
 	return newTok.AccessToken, nil
 }
 
+// readCredentials returns the live credential and whether it came from the
+// keychain. The keychain is authoritative on macOS: Claude Code refreshes the
+// token there and leaves the file frozen at first-login state, so preferring
+// the file yields a token that expired days or weeks ago.
 func (c *ClaudeUsageClient) readCredentials() (*claudeCredentials, error) {
+	creds, _, err := c.readCredentialsWithSource()
+	return creds, err
+}
+
+func (c *ClaudeUsageClient) readCredentialsWithSource() (*claudeCredentials, bool, error) {
+	if blob := readKeychainCredentials(c.keychainService); blob != nil {
+		var creds claudeCredentials
+		// A malformed keychain item is not fatal — fall through to the file
+		// rather than blinding the panel on a shape change we did not expect.
+		if err := json.Unmarshal(blob, &creds); err == nil && creds.ClaudeAiOauth != nil {
+			return &creds, true, nil
+		}
+	}
+
 	data, err := os.ReadFile(c.credentialsPath)
 	if err != nil {
-		return nil, fmt.Errorf("read %s: %w", c.credentialsPath, err)
+		return nil, false, fmt.Errorf("read %s: %w", c.credentialsPath, err)
 	}
 	var creds claudeCredentials
 	if err := json.Unmarshal(data, &creds); err != nil {
-		return nil, fmt.Errorf("parse %s: %w", c.credentialsPath, err)
+		return nil, false, fmt.Errorf("parse %s: %w", c.credentialsPath, err)
 	}
-	return &creds, nil
+	return &creds, false, nil
 }
 
 // persistRefreshedToken updates only the token fields inside claudeAiOauth,

--- a/apps/backend/internal/agent/usage/client_claude.go
+++ b/apps/backend/internal/agent/usage/client_claude.go
@@ -225,10 +225,17 @@ func claudeLimitLabel(l claudeLimit) string {
 // freshAccessToken returns a valid access token, refreshing if expired.
 //
 // fromKeychain reports whether the credential came from the keychain, which the
-// Claude CLI owns and keeps refreshed. In that case we never write a refreshed
-// token back to ~/.claude/.credentials.json: that file is already stale by
-// design, and overwriting it would fabricate a second, competing source of
-// truth for a token we do not own.
+// Claude CLI owns and keeps refreshed. A keychain-sourced token is never
+// refreshed here, because the refresh token rotates: the endpoint may hand back
+// a new one and invalidate the one it was given. We cannot write the
+// replacement back to the keychain — the CLI holds the write side of that item
+// — so refreshing would spend the CLI's credential and leave it holding a dead
+// one. That is precisely the sticky invalid_request_error this whole change
+// exists to fix, just moved from the file to the keychain, where it would be
+// worse: the file can be repaired by re-login, the CLI's own session cannot.
+//
+// So an expired keychain credential is reported, not repaired. The CLI refreshes
+// it on its next run, which is a thing the user can do in one command.
 func (c *ClaudeUsageClient) freshAccessToken(
 	ctx context.Context, tok *claudeOAuthToken, fromKeychain bool,
 ) (string, error) {
@@ -237,25 +244,21 @@ func (c *ClaudeUsageClient) freshAccessToken(
 	if time.Until(expiresAt) > 60*time.Second {
 		return tok.AccessToken, nil
 	}
+	if fromKeychain {
+		return "", fmt.Errorf(
+			"claude keychain token expired; run `claude auth status` to refresh it")
+	}
 	if tok.RefreshToken == "" {
 		return "", fmt.Errorf("claude token expired and no refresh token available")
 	}
 	newTok, err := c.refreshToken(ctx, tok.RefreshToken)
 	if err != nil {
-		if fromKeychain {
-			// The CLI is the only writer of this credential. A failure here
-			// means it has not run recently enough, not that we should retry
-			// harder — say so instead of surfacing a bare OAuth error.
-			return "", fmt.Errorf("refresh token: %w (run `claude auth status` to refresh)", err)
-		}
 		return "", fmt.Errorf("refresh token: %w", err)
 	}
-	if !fromKeychain {
-		// Write new token back. Non-fatal — we have the new token in memory even if
-		// persistence fails, but log the error so it doesn't go unnoticed.
-		if writeErr := c.persistRefreshedToken(newTok); writeErr != nil {
-			fmt.Fprintf(os.Stderr, "claude usage: persist refreshed token: %v\n", writeErr)
-		}
+	// Write new token back. Non-fatal — we have the new token in memory even if
+	// persistence fails, but log the error so it doesn't go unnoticed.
+	if writeErr := c.persistRefreshedToken(newTok); writeErr != nil {
+		fmt.Fprintf(os.Stderr, "claude usage: persist refreshed token: %v\n", writeErr)
 	}
 	return newTok.AccessToken, nil
 }

--- a/apps/backend/internal/backendapp/usage_adapter.go
+++ b/apps/backend/internal/backendapp/usage_adapter.go
@@ -56,7 +56,9 @@ func (a *usageProviderAdapter) ensureRegistered(profileID, agentName string) {
 	switch agentName {
 	case "claude-acp":
 		credPath := filepath.Join(home, ".claude", ".credentials.json")
-		client := agentusage.NewClaudeUsageClientWithPath(credPath)
+		client := agentusage.NewClaudeUsageClientForProfile(
+			credPath, agentusage.ClaudeDefaultKeychainService,
+		)
 		key := agentusage.CacheKey("anthropic", credPath)
 		a.svc.Register(profileID, client, key)
 	case "codex-acp":


### PR DESCRIPTION
## Problem

Claude subscription usage never populates on macOS. The card either stays empty or the request fails permanently with `invalid_request_error`, and once it does it never recovers.

## Cause

Two independent bugs, both in the read path.

**1. The credentials file is stale by design on macOS.** The Claude CLI keeps the live OAuth token in the **login keychain**; `~/.claude/.credentials.json` is written once at login and then abandoned. On this machine the file was 9 days old while the keychain token was current. Kandev read only the file, so it refreshed an already-rotated token and got `invalid_request_error` — and because the refresh result was written back to the file, the failure was sticky.

This is not the Cloudflare/WAF issue people usually reach for. The request never got far enough for that to matter.

**2. Idle rate-limit windows were dropped entirely.** Anthropic reports an untouched window as:

```json
{"kind": "session", "percent": 0, "resets_at": null}
```

`resets_at: null` failed to parse, and the whole window was discarded rather than the reset time alone. "Used none of it" therefore rendered identically to "no data" — two windows vanished across two accounts.

## Fix

Read the keychain first and fall back to the file, via a small indirection (`readKeychainCredentials`) so the lookup is testable without touching the real keychain.

Two properties worth calling out:

- **A keychain-sourced token is never written back to the file.** Persisting it would recreate the same staleness the file already suffers from, one layer down.
- **Idle windows are kept with a nil reset time** rather than dropped, so `percent: 0` reaches the UI as real data. Rendering an absent reset time is the caller's job — a zero timestamp would otherwise display as an imminent reset that is not happening.

`NewClaudeUsageClientForProfile` takes the keychain service name alongside the credentials path so a profile can point at a specific account.

## Verification

```
go test ./internal/agent/usage/
ok  github.com/kandev/kandev/internal/agent/usage
```

`claude_keychain_internal_test.go` covers the keychain-first order, the file fallback, the no-write-back property, and the `resets_at: null` case. The keychain reader is stubbed, so the suite needs no keychain access and stays hermetic on Linux and CI.

Confirmed live on macOS 15: all windows populate, including the idle ones, and the plan tier renders.

## Note on reachability

The usage surface this feeds is not reachable on `main` today. It is still worth fixing here rather than only on a release branch — the code path is live, so the bug would surface silently the moment that surface ships.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2055?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

