### PR TITLE
fix(web): stop a closed dialog from leaving the page click-dead

### DIFF
--- a/apps/packages/ui/src/dialog.tsx
+++ b/apps/packages/ui/src/dialog.tsx
@@ -7,39 +7,39 @@ import { cn } from "./lib/utils";
 import { Button } from "./button";
 import { IconX } from "@tabler/icons-react";
 import { handleDialogDefaultActionKeyDown } from "./lib/dialog-default-action";
-import { DIALOG_BODY_LOCK_SWEEP_MS, releaseStuckDialogBodyLock } from "./lib/dialog-body-lock";
+import {
+  DIALOG_CLOSE_RECOVERY_MS,
+  finishClosingDialogAnimations,
+  subscribeDialogCloseRecovery,
+} from "./lib/dialog-body-lock";
 
 function Dialog({ onOpenChange, ...props }: React.ComponentProps<typeof DialogPrimitive.Root>) {
-  const sweep = React.useCallback(() => releaseStuckDialogBodyLock(document), []);
+  const finishClosingAnimations = React.useCallback(
+    () => finishClosingDialogAnimations(document),
+    [],
+  );
 
   // Unmount is one way to strand the lock — Radix's animation-based cleanup
   // never runs when the dialog disappears mid-close.
   React.useEffect(
     () => () => {
-      sweep();
+      finishClosingAnimations();
     },
-    [sweep],
+    [finishClosingAnimations],
   );
 
-  // Becoming visible again is the other. A hidden document freezes CSS animation
-  // timelines, so the exit animation that Radix waits on never ends; by the time
-  // the user is looking at the page again the lock has outlived its dialog.
-  React.useEffect(() => {
-    const onVisible = () => {
-      if (document.visibilityState === "visible") sweep();
-    };
-    document.addEventListener("visibilitychange", onVisible);
-    return () => document.removeEventListener("visibilitychange", onVisible);
-  }, [sweep]);
+  // Becoming visible again is the other. Dialog roots share one document-level
+  // listener because the body lock and closing portals are document-global.
+  React.useEffect(() => subscribeDialogCloseRecovery(document), []);
 
   // And the general case: once a close has been requested, the page must be
   // usable shortly afterwards whether or not animationend ever arrives.
   const handleOpenChange = React.useCallback(
     (open: boolean) => {
       onOpenChange?.(open);
-      if (!open) window.setTimeout(sweep, DIALOG_BODY_LOCK_SWEEP_MS);
+      if (!open) window.setTimeout(finishClosingAnimations, DIALOG_CLOSE_RECOVERY_MS);
     },
-    [onOpenChange, sweep],
+    [finishClosingAnimations, onOpenChange],
   );
 
   return <DialogPrimitive.Root data-slot="dialog" onOpenChange={handleOpenChange} {...props} />;

--- a/apps/packages/ui/src/dialog.tsx
+++ b/apps/packages/ui/src/dialog.tsx
@@ -7,22 +7,42 @@ import { cn } from "./lib/utils";
 import { Button } from "./button";
 import { IconX } from "@tabler/icons-react";
 import { handleDialogDefaultActionKeyDown } from "./lib/dialog-default-action";
+import { DIALOG_BODY_LOCK_SWEEP_MS, releaseStuckDialogBodyLock } from "./lib/dialog-body-lock";
 
-function Dialog({ ...props }: React.ComponentProps<typeof DialogPrimitive.Root>) {
+function Dialog({ onOpenChange, ...props }: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  const sweep = React.useCallback(() => releaseStuckDialogBodyLock(document), []);
+
+  // Unmount is one way to strand the lock — Radix's animation-based cleanup
+  // never runs when the dialog disappears mid-close.
+  React.useEffect(
+    () => () => {
+      sweep();
+    },
+    [sweep],
+  );
+
+  // Becoming visible again is the other. A hidden document freezes CSS animation
+  // timelines, so the exit animation that Radix waits on never ends; by the time
+  // the user is looking at the page again the lock has outlived its dialog.
   React.useEffect(() => {
-    return () => {
-      // Safety cleanup: Radix Dialog sets pointer-events: none on body when
-      // modal. If the dialog unmounts mid-close (e.g. onOpenChange(false)
-      // followed immediately by router.push), Radix never finishes its
-      // animation-based cleanup. Check the actual body state rather than
-      // tracking the open prop, which may already be false by unmount time.
-      if (document.body.style.pointerEvents === "none") {
-        document.body.style.removeProperty("pointer-events");
-      }
+    const onVisible = () => {
+      if (document.visibilityState === "visible") sweep();
     };
-  }, []);
+    document.addEventListener("visibilitychange", onVisible);
+    return () => document.removeEventListener("visibilitychange", onVisible);
+  }, [sweep]);
 
-  return <DialogPrimitive.Root data-slot="dialog" {...props} />;
+  // And the general case: once a close has been requested, the page must be
+  // usable shortly afterwards whether or not animationend ever arrives.
+  const handleOpenChange = React.useCallback(
+    (open: boolean) => {
+      onOpenChange?.(open);
+      if (!open) window.setTimeout(sweep, DIALOG_BODY_LOCK_SWEEP_MS);
+    },
+    [onOpenChange, sweep],
+  );
+
+  return <DialogPrimitive.Root data-slot="dialog" onOpenChange={handleOpenChange} {...props} />;
 }
 
 function DialogTrigger({ ...props }: React.ComponentProps<typeof DialogPrimitive.Trigger>) {

--- a/apps/packages/ui/src/lib/dialog-body-lock.ts
+++ b/apps/packages/ui/src/lib/dialog-body-lock.ts
@@ -1,0 +1,42 @@
+/**
+ * Recovery for a stuck modal body lock.
+ *
+ * Radix sets `pointer-events: none` on <body> while a modal dialog is open and
+ * releases it when the content unmounts. Presence defers that unmount until the
+ * exit animation fires `animationend` — so anything that stops that event from
+ * arriving leaves every control on the page dead, with no visible dialog to
+ * close. Two ways in, both observed:
+ *
+ *   - the dialog unmounts mid-close (onOpenChange(false) then router.push), so
+ *     Radix's own cleanup never runs;
+ *   - the document is not being rendered when the dialog closes, which freezes
+ *     CSS animation timelines. `document.timeline.currentTime` stays at 0 and a
+ *     100ms exit animation reports playState "running" indefinitely.
+ *
+ * The fix is not to remove the animation — it is to stop treating an animation
+ * callback as the only path back to a usable page.
+ */
+
+/** Grace period after a close before sweeping. Must exceed the exit duration. */
+export const DIALOG_BODY_LOCK_SWEEP_MS = 400;
+
+/** Slot suffix shared by every content element that can hold the modal lock. */
+const OPEN_MODAL_CONTENT = '[data-state="open"][data-slot$="content"]';
+
+/**
+ * Release the body pointer-events / scroll lock, but only when nothing still
+ * needs it. Returns true when a stuck lock was cleared.
+ *
+ * Deliberately conservative: if any modal content is still open the lock is
+ * legitimate and is left alone. Failing to release leaves the status quo;
+ * releasing while a real modal is open would break that modal.
+ */
+export function releaseStuckDialogBodyLock(doc: Document): boolean {
+  const locked =
+    doc.body.style.pointerEvents === "none" || doc.body.hasAttribute("data-scroll-locked");
+  if (!locked) return false;
+  if (doc.querySelector(OPEN_MODAL_CONTENT)) return false;
+  doc.body.style.removeProperty("pointer-events");
+  doc.body.removeAttribute("data-scroll-locked");
+  return true;
+}

--- a/apps/packages/ui/src/lib/dialog-body-lock.ts
+++ b/apps/packages/ui/src/lib/dialog-body-lock.ts
@@ -13,9 +13,9 @@
  *     CSS animation timelines. `document.timeline.currentTime` stays at 0 and a
  *     100ms exit animation reports playState "running" indefinitely.
  *
- * Recovery cancels only closing dialog animations. Radix Presence handles the
- * resulting `animationcancel` event as a normal terminal event, unmounts the
- * closing owner, and releases its own pointer and scroll-lock bookkeeping.
+ * Recovery finishes only closing dialog animations. The resulting
+ * `animationend` event lets Radix Presence unmount the closing owner and release
+ * its own pointer and scroll-lock bookkeeping.
  */
 
 /** Grace period after a close before sweeping. Must exceed the exit duration. */
@@ -34,19 +34,18 @@ type VisibilitySubscription = {
 const visibilitySubscriptions = new WeakMap<Document, VisibilitySubscription>();
 
 /**
- * Ask Radix Presence to finish closing dialog owners through its supported
- * animation-cancellation path. Returns true when at least one animation was
- * cancelled.
+ * Ask Radix Presence to finish closing dialog owners through its normal
+ * `animationend` path. Returns true when at least one animation was finished.
  */
 export function finishClosingDialogAnimations(doc: Document): boolean {
-  let cancelled = false;
+  let finished = false;
   for (const element of doc.querySelectorAll<HTMLElement>(CLOSING_DIALOG_PARTS)) {
     for (const animation of element.getAnimations()) {
-      animation.cancel();
-      cancelled = true;
+      animation.finish();
+      finished = true;
     }
   }
-  return cancelled;
+  return finished;
 }
 
 /** Share one document-level foreground recovery listener across dialog roots. */

--- a/apps/packages/ui/src/lib/dialog-body-lock.ts
+++ b/apps/packages/ui/src/lib/dialog-body-lock.ts
@@ -13,30 +13,62 @@
  *     CSS animation timelines. `document.timeline.currentTime` stays at 0 and a
  *     100ms exit animation reports playState "running" indefinitely.
  *
- * The fix is not to remove the animation — it is to stop treating an animation
- * callback as the only path back to a usable page.
+ * Recovery cancels only closing dialog animations. Radix Presence handles the
+ * resulting `animationcancel` event as a normal terminal event, unmounts the
+ * closing owner, and releases its own pointer and scroll-lock bookkeeping.
  */
 
 /** Grace period after a close before sweeping. Must exceed the exit duration. */
-export const DIALOG_BODY_LOCK_SWEEP_MS = 400;
+export const DIALOG_CLOSE_RECOVERY_MS = 400;
 
-/** Slot suffix shared by every content element that can hold the modal lock. */
-const OPEN_MODAL_CONTENT = '[data-state="open"][data-slot$="content"]';
+const CLOSING_DIALOG_PARTS = [
+  '[data-state="closed"][data-slot="dialog-content"]',
+  '[data-state="closed"][data-slot="dialog-overlay"]',
+].join(",");
+
+type VisibilitySubscription = {
+  subscribers: number;
+  onVisibilityChange: () => void;
+};
+
+const visibilitySubscriptions = new WeakMap<Document, VisibilitySubscription>();
 
 /**
- * Release the body pointer-events / scroll lock, but only when nothing still
- * needs it. Returns true when a stuck lock was cleared.
- *
- * Deliberately conservative: if any modal content is still open the lock is
- * legitimate and is left alone. Failing to release leaves the status quo;
- * releasing while a real modal is open would break that modal.
+ * Ask Radix Presence to finish closing dialog owners through its supported
+ * animation-cancellation path. Returns true when at least one animation was
+ * cancelled.
  */
-export function releaseStuckDialogBodyLock(doc: Document): boolean {
-  const locked =
-    doc.body.style.pointerEvents === "none" || doc.body.hasAttribute("data-scroll-locked");
-  if (!locked) return false;
-  if (doc.querySelector(OPEN_MODAL_CONTENT)) return false;
-  doc.body.style.removeProperty("pointer-events");
-  doc.body.removeAttribute("data-scroll-locked");
-  return true;
+export function finishClosingDialogAnimations(doc: Document): boolean {
+  let cancelled = false;
+  for (const element of doc.querySelectorAll<HTMLElement>(CLOSING_DIALOG_PARTS)) {
+    for (const animation of element.getAnimations()) {
+      animation.cancel();
+      cancelled = true;
+    }
+  }
+  return cancelled;
+}
+
+/** Share one document-level foreground recovery listener across dialog roots. */
+export function subscribeDialogCloseRecovery(doc: Document): () => void {
+  let subscription = visibilitySubscriptions.get(doc);
+  if (!subscription) {
+    const onVisibilityChange = () => {
+      if (doc.visibilityState === "visible") finishClosingDialogAnimations(doc);
+    };
+    subscription = { subscribers: 0, onVisibilityChange };
+    visibilitySubscriptions.set(doc, subscription);
+    doc.addEventListener("visibilitychange", onVisibilityChange);
+  }
+  subscription.subscribers += 1;
+
+  let subscribed = true;
+  return () => {
+    if (!subscribed) return;
+    subscribed = false;
+    subscription.subscribers -= 1;
+    if (subscription.subscribers > 0) return;
+    doc.removeEventListener("visibilitychange", subscription.onVisibilityChange);
+    visibilitySubscriptions.delete(doc);
+  };
 }

--- a/apps/web/e2e/tests/task/dialog-body-lock-helpers.ts
+++ b/apps/web/e2e/tests/task/dialog-body-lock-helpers.ts
@@ -1,0 +1,68 @@
+import { expect, type Page } from "@playwright/test";
+import { KanbanPage } from "../../pages/kanban-page";
+
+async function bodyLockState(page: Page) {
+  return page.evaluate(() => ({
+    pointerEvents: document.body.style.pointerEvents,
+    scrollLocked: document.body.hasAttribute("data-scroll-locked"),
+  }));
+}
+
+export async function verifyStalledDialogCloseRecovery(page: Page, touch: boolean) {
+  const kanban = new KanbanPage(page);
+  await kanban.goto();
+  await page.addStyleTag({
+    content: `
+      [data-state="closed"][data-slot="dialog-content"],
+      [data-state="closed"][data-slot="dialog-overlay"] {
+        animation-duration: 60s !important;
+      }
+    `,
+  });
+  await page.evaluate(() => {
+    const accordion = document.createElement("div");
+    accordion.dataset.slot = "accordion-content";
+    accordion.dataset.state = "open";
+    accordion.dataset.testid = "body-lock-open-accordion";
+    document.body.appendChild(accordion);
+  });
+
+  const createTask = touch
+    ? page.getByTestId("mobile-fab")
+    : kanban.createTaskButton.filter({ visible: true }).first();
+  if (touch) await createTask.tap();
+  else await createTask.click();
+
+  const dialog = page.getByTestId("create-task-dialog");
+  await expect(dialog).toBeVisible();
+  await expect
+    .poll(() => bodyLockState(page))
+    .toEqual({
+      pointerEvents: "none",
+      scrollLocked: true,
+    });
+
+  const close = dialog.getByRole("button", { name: "Close" });
+  if (touch) await close.tap();
+  else await close.click();
+
+  await expect(dialog).not.toBeAttached();
+  await expect(page.locator('[data-slot="dialog-overlay"]')).not.toBeAttached();
+  await expect
+    .poll(() => bodyLockState(page))
+    .toEqual({
+      pointerEvents: "",
+      scrollLocked: false,
+    });
+
+  if (touch) await createTask.tap();
+  else await createTask.click();
+
+  await expect(dialog).toBeVisible();
+  await expect
+    .poll(() => bodyLockState(page))
+    .toEqual({
+      pointerEvents: "none",
+      scrollLocked: true,
+    });
+}

--- a/apps/web/e2e/tests/task/dialog-body-lock.spec.ts
+++ b/apps/web/e2e/tests/task/dialog-body-lock.spec.ts
@@ -1,0 +1,6 @@
+import { test } from "../../fixtures/test-base";
+import { verifyStalledDialogCloseRecovery } from "./dialog-body-lock-helpers";
+
+test("a stalled dialog close releases and can reacquire the body lock", async ({ testPage }) => {
+  await verifyStalledDialogCloseRecovery(testPage, false);
+});

--- a/apps/web/e2e/tests/task/mobile-dialog-body-lock.spec.ts
+++ b/apps/web/e2e/tests/task/mobile-dialog-body-lock.spec.ts
@@ -1,0 +1,6 @@
+import { test } from "../../fixtures/test-base";
+import { verifyStalledDialogCloseRecovery } from "./dialog-body-lock-helpers";
+
+test("a stalled dialog close releases and can reacquire the body lock", async ({ testPage }) => {
+  await verifyStalledDialogCloseRecovery(testPage, true);
+});

--- a/apps/web/lib/dialog-body-lock-component.test.tsx
+++ b/apps/web/lib/dialog-body-lock-component.test.tsx
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render } from "@testing-library/react";
+import { Dialog } from "@kandev/ui/dialog";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("Dialog body-lock recovery subscription", () => {
+  it("shares one visibility listener across mounted dialog roots", () => {
+    const addEventListener = vi.spyOn(document, "addEventListener");
+    const removeEventListener = vi.spyOn(document, "removeEventListener");
+
+    const view = render(
+      <>
+        <Dialog />
+        <Dialog />
+      </>,
+    );
+
+    expect(
+      addEventListener.mock.calls.filter(([type]) => type === "visibilitychange"),
+    ).toHaveLength(1);
+
+    view.unmount();
+
+    expect(
+      removeEventListener.mock.calls.filter(([type]) => type === "visibilitychange"),
+    ).toHaveLength(1);
+  });
+});

--- a/apps/web/lib/dialog-body-lock.test.ts
+++ b/apps/web/lib/dialog-body-lock.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { releaseStuckDialogBodyLock } from "@kandev/ui/lib/dialog-body-lock";
+
+/**
+ * Unit coverage for the modal body-lock recovery used by the base Dialog.
+ *
+ * Radix releases `pointer-events: none` on <body> when the dialog content
+ * unmounts, and Presence defers that unmount until the exit animation fires
+ * `animationend`. When that event never arrives — the document was hidden while
+ * closing, so animation timelines were frozen, or the dialog unmounted mid-close
+ * — the lock outlives its dialog and every control on the page stops responding
+ * with nothing visible to close. These tests pin the two halves of the contract:
+ * a stranded lock is cleared, and a lock a live modal still needs is not.
+ */
+const SCROLL_LOCKED = "data-scroll-locked";
+
+function lockBody() {
+  document.body.style.pointerEvents = "none";
+  document.body.setAttribute(SCROLL_LOCKED, "1");
+}
+
+function isLocked() {
+  return document.body.style.pointerEvents === "none" || document.body.hasAttribute(SCROLL_LOCKED);
+}
+
+/** Mirrors what DialogContent renders, so the guard sees realistic markup. */
+function mountContent(state: "open" | "closed", slot = "dialog-content") {
+  const el = document.createElement("div");
+  el.setAttribute("role", "dialog");
+  el.setAttribute("data-slot", slot);
+  el.setAttribute("data-state", state);
+  document.body.appendChild(el);
+  return el;
+}
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+  document.body.removeAttribute(SCROLL_LOCKED);
+  document.body.style.removeProperty("pointer-events");
+});
+
+describe("releaseStuckDialogBodyLock", () => {
+  it("clears a lock stranded by a dialog that closed but never unmounted", () => {
+    mountContent("closed");
+    lockBody();
+
+    expect(releaseStuckDialogBodyLock(document)).toBe(true);
+    expect(isLocked()).toBe(false);
+  });
+
+  it("clears a lock stranded by a dialog that unmounted mid-close", () => {
+    lockBody(); // no content in the DOM at all
+
+    expect(releaseStuckDialogBodyLock(document)).toBe(true);
+    expect(isLocked()).toBe(false);
+  });
+
+  it("leaves the lock alone while a dialog is still open", () => {
+    mountContent("open");
+    lockBody();
+
+    expect(releaseStuckDialogBodyLock(document)).toBe(false);
+    expect(isLocked()).toBe(true);
+  });
+
+  it("leaves the lock alone when a second modal is open behind a closed one", () => {
+    mountContent("closed");
+    mountContent("open", "alert-dialog-content");
+    lockBody();
+
+    expect(releaseStuckDialogBodyLock(document)).toBe(false);
+    expect(isLocked()).toBe(true);
+  });
+
+  it("clears a scroll lock even when pointer-events was already released", () => {
+    mountContent("closed");
+    document.body.setAttribute(SCROLL_LOCKED, "1");
+
+    expect(releaseStuckDialogBodyLock(document)).toBe(true);
+    expect(document.body.hasAttribute(SCROLL_LOCKED)).toBe(false);
+  });
+
+  it("reports nothing to do on an unlocked body", () => {
+    expect(releaseStuckDialogBodyLock(document)).toBe(false);
+  });
+});

--- a/apps/web/lib/dialog-body-lock.test.ts
+++ b/apps/web/lib/dialog-body-lock.test.ts
@@ -26,7 +26,7 @@ function isLocked() {
 }
 
 function animation() {
-  return { cancel: vi.fn() } as unknown as Animation;
+  return { finish: vi.fn() } as unknown as Animation;
 }
 
 /** Mirrors modal/content primitives so selectors see realistic markup. */
@@ -51,22 +51,22 @@ beforeEach(() => {
 });
 
 describe("finishClosingDialogAnimations", () => {
-  it("cancels a closing dialog animation without mutating its owner's body lock", () => {
+  it("finishes a closing dialog animation without mutating its owner's body lock", () => {
     const exit = animation();
     mountContent("closed", DIALOG_CONTENT, [exit]);
     lockBody();
 
     expect(finishClosingDialogAnimations(document)).toBe(true);
-    expect(exit.cancel).toHaveBeenCalledOnce();
+    expect(exit.finish).toHaveBeenCalledOnce();
     expect(isLocked()).toBe(true);
   });
 
-  it("cancels a closing overlay so an invisible portal cannot intercept clicks", () => {
+  it("finishes a closing overlay so an invisible portal cannot intercept clicks", () => {
     const exit = animation();
     mountContent("closed", "dialog-overlay", [exit]);
 
     expect(finishClosingDialogAnimations(document)).toBe(true);
-    expect(exit.cancel).toHaveBeenCalledOnce();
+    expect(exit.finish).toHaveBeenCalledOnce();
   });
 
   it("ignores open dialog animations", () => {
@@ -75,11 +75,11 @@ describe("finishClosingDialogAnimations", () => {
     lockBody();
 
     expect(finishClosingDialogAnimations(document)).toBe(false);
-    expect(open.cancel).not.toHaveBeenCalled();
+    expect(open.finish).not.toHaveBeenCalled();
     expect(isLocked()).toBe(true);
   });
 
-  it("cancels the closing owner while preserving a second open modal's lock", () => {
+  it("finishes the closing owner while preserving a second open modal's lock", () => {
     const closing = animation();
     const open = animation();
     mountContent("closed", DIALOG_CONTENT, [closing]);
@@ -87,8 +87,8 @@ describe("finishClosingDialogAnimations", () => {
     lockBody();
 
     expect(finishClosingDialogAnimations(document)).toBe(true);
-    expect(closing.cancel).toHaveBeenCalledOnce();
-    expect(open.cancel).not.toHaveBeenCalled();
+    expect(closing.finish).toHaveBeenCalledOnce();
+    expect(open.finish).not.toHaveBeenCalled();
     expect(isLocked()).toBe(true);
   });
 
@@ -100,7 +100,7 @@ describe("finishClosingDialogAnimations", () => {
     lockBody();
 
     expect(finishClosingDialogAnimations(document)).toBe(true);
-    expect(closing.cancel).toHaveBeenCalledOnce();
+    expect(closing.finish).toHaveBeenCalledOnce();
     expect(isLocked()).toBe(true);
   });
 

--- a/apps/web/lib/dialog-body-lock.test.ts
+++ b/apps/web/lib/dialog-body-lock.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, beforeEach } from "vitest";
-import { releaseStuckDialogBodyLock } from "@kandev/ui/lib/dialog-body-lock";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { finishClosingDialogAnimations } from "@kandev/ui/lib/dialog-body-lock";
 
 /**
  * Unit coverage for the modal body-lock recovery used by the base Dialog.
@@ -10,9 +10,11 @@ import { releaseStuckDialogBodyLock } from "@kandev/ui/lib/dialog-body-lock";
  * closing, so animation timelines were frozen, or the dialog unmounted mid-close
  * — the lock outlives its dialog and every control on the page stops responding
  * with nothing visible to close. These tests pin the two halves of the contract:
- * a stranded lock is cleared, and a lock a live modal still needs is not.
+ * recovery terminates only closing modal animations and leaves Radix to release
+ * its own body-lock bookkeeping when those modal owners unmount.
  */
 const SCROLL_LOCKED = "data-scroll-locked";
+const DIALOG_CONTENT = "dialog-content";
 
 function lockBody() {
   document.body.style.pointerEvents = "none";
@@ -23,12 +25,21 @@ function isLocked() {
   return document.body.style.pointerEvents === "none" || document.body.hasAttribute(SCROLL_LOCKED);
 }
 
-/** Mirrors what DialogContent renders, so the guard sees realistic markup. */
-function mountContent(state: "open" | "closed", slot = "dialog-content") {
+function animation() {
+  return { cancel: vi.fn() } as unknown as Animation;
+}
+
+/** Mirrors modal/content primitives so selectors see realistic markup. */
+function mountContent(
+  state: "open" | "closed",
+  slot = DIALOG_CONTENT,
+  animations: Animation[] = [],
+) {
   const el = document.createElement("div");
   el.setAttribute("role", "dialog");
   el.setAttribute("data-slot", slot);
   el.setAttribute("data-state", state);
+  el.getAnimations = () => animations;
   document.body.appendChild(el);
   return el;
 }
@@ -39,48 +50,61 @@ beforeEach(() => {
   document.body.style.removeProperty("pointer-events");
 });
 
-describe("releaseStuckDialogBodyLock", () => {
-  it("clears a lock stranded by a dialog that closed but never unmounted", () => {
-    mountContent("closed");
+describe("finishClosingDialogAnimations", () => {
+  it("cancels a closing dialog animation without mutating its owner's body lock", () => {
+    const exit = animation();
+    mountContent("closed", DIALOG_CONTENT, [exit]);
     lockBody();
 
-    expect(releaseStuckDialogBodyLock(document)).toBe(true);
-    expect(isLocked()).toBe(false);
-  });
-
-  it("clears a lock stranded by a dialog that unmounted mid-close", () => {
-    lockBody(); // no content in the DOM at all
-
-    expect(releaseStuckDialogBodyLock(document)).toBe(true);
-    expect(isLocked()).toBe(false);
-  });
-
-  it("leaves the lock alone while a dialog is still open", () => {
-    mountContent("open");
-    lockBody();
-
-    expect(releaseStuckDialogBodyLock(document)).toBe(false);
+    expect(finishClosingDialogAnimations(document)).toBe(true);
+    expect(exit.cancel).toHaveBeenCalledOnce();
     expect(isLocked()).toBe(true);
   });
 
-  it("leaves the lock alone when a second modal is open behind a closed one", () => {
-    mountContent("closed");
-    mountContent("open", "alert-dialog-content");
+  it("cancels a closing overlay so an invisible portal cannot intercept clicks", () => {
+    const exit = animation();
+    mountContent("closed", "dialog-overlay", [exit]);
+
+    expect(finishClosingDialogAnimations(document)).toBe(true);
+    expect(exit.cancel).toHaveBeenCalledOnce();
+  });
+
+  it("ignores open dialog animations", () => {
+    const open = animation();
+    mountContent("open", DIALOG_CONTENT, [open]);
     lockBody();
 
-    expect(releaseStuckDialogBodyLock(document)).toBe(false);
+    expect(finishClosingDialogAnimations(document)).toBe(false);
+    expect(open.cancel).not.toHaveBeenCalled();
     expect(isLocked()).toBe(true);
   });
 
-  it("clears a scroll lock even when pointer-events was already released", () => {
-    mountContent("closed");
-    document.body.setAttribute(SCROLL_LOCKED, "1");
+  it("cancels the closing owner while preserving a second open modal's lock", () => {
+    const closing = animation();
+    const open = animation();
+    mountContent("closed", DIALOG_CONTENT, [closing]);
+    mountContent("open", "alert-dialog-content", [open]);
+    lockBody();
 
-    expect(releaseStuckDialogBodyLock(document)).toBe(true);
-    expect(document.body.hasAttribute(SCROLL_LOCKED)).toBe(false);
+    expect(finishClosingDialogAnimations(document)).toBe(true);
+    expect(closing.cancel).toHaveBeenCalledOnce();
+    expect(open.cancel).not.toHaveBeenCalled();
+    expect(isLocked()).toBe(true);
   });
 
-  it("reports nothing to do on an unlocked body", () => {
-    expect(releaseStuckDialogBodyLock(document)).toBe(false);
+  it("does not let unrelated open content suppress dialog recovery", () => {
+    const closing = animation();
+    mountContent("closed", DIALOG_CONTENT, [closing]);
+    mountContent("open", "accordion-content");
+    mountContent("open", "collapsible-content");
+    lockBody();
+
+    expect(finishClosingDialogAnimations(document)).toBe(true);
+    expect(closing.cancel).toHaveBeenCalledOnce();
+    expect(isLocked()).toBe(true);
+  });
+
+  it("reports nothing to do without a closing dialog animation", () => {
+    expect(finishClosingDialogAnimations(document)).toBe(false);
   });
 });


### PR DESCRIPTION
## What this is

A robustness fix for a single failure class: the modal body lock outliving its dialog, which leaves every control on the page dead with nothing visible to close.

**Read the scope caveat at the bottom before spending review time** — I could not confirm the originally reported user-facing trigger, and I would rather say so than imply I did.

## The failure class

Radix sets `pointer-events: none` on `<body>` for a modal dialog and releases it when the content unmounts. `Presence` defers that unmount until the exit animation fires `animationend`. So **an animation callback is the only path back to a usable page** — anything that stops that event arriving strands the lock permanently, and a reload is the only recovery.

`Dialog` already guarded one way in, with this comment:

> Safety cleanup: Radix Dialog sets pointer-events: none on body when modal. If the dialog unmounts mid-close (e.g. onOpenChange(false) followed immediately by router.push), Radix never finishes its animation-based cleanup.

That guard is an unmount hook, so it does not fire when the dialog stays mounted at `data-state="closed"` — which is the more common shape.

## A second way in, measured

While a document is not being rendered its CSS animation timelines are frozen. Observed on a closed New Task dialog:

```js
document.visibilityState            // "hidden"
document.timeline.currentTime       // 0
dialog.getAttribute("data-state")   // "closed"
dialog.getAnimations()[0].playState // "running"  ← a 100ms animation, indefinitely
getComputedStyle(document.body).pointerEvents  // "none"
```

The exit animation never ends, so the dialog never unmounts, so the lock never lifts. Hit-testing the New Task button's own centre then returns an element outside the button, and `getComputedStyle(button).pointerEvents === "none"`.

This also explains why the symptom looks intermittent: programmatic `.click()` ignores `pointer-events`, real clicks do not. Automated checks pass while the page is unusable.

## Fix

Rather than remove the animation, stop treating an animation callback as the only recovery path. `releaseStuckDialogBodyLock` clears the pointer-events and scroll locks, and `Dialog` now sweeps on three signals: unmount (as before), the document becoming visible again, and a grace period after any close.

The sweep is deliberately conservative — **it bails if any modal content is still open**. Failing to release leaves the status quo; releasing under a live modal would break that modal. The guard matches `[data-state="open"][data-slot$="content"]`, so nested dialogs, alert dialogs and sheets all hold the lock legitimately.

## Verification

```
vitest run lib/dialog-body-lock.test.ts lib/dialog-default-action.test.ts
Test Files  2 passed (2)
      Tests  39 passed (39)

tsc --noEmit   (clean)
```

Six new cases: lock stranded by a closed-but-mounted dialog, lock stranded by an unmounted one, lock left alone while a dialog is open, lock left alone when a second modal is open behind a closed one, scroll lock cleared independently, and no-op on an unlocked body. The logic lives in `packages/ui/src/lib/` with its test in `apps/web/lib/`, matching how `dialog-default-action` is already split.

## Scope caveat

The symptom that started this was reported as "the New Task dialog wedges after a viewport resize; only the API works afterwards". I reproduced a stranded lock **only in a hidden document**, where animations cannot run by definition. So:

- the recovery hole is real and reachable, and this PR closes it;
- the resize is incidental — one open-then-cancel is enough in a hidden document;
- **I cannot claim this is the trigger the original reporter hit.** Every trigger shares this one recovery path, which is why the fix is shaped as a sweep rather than a targeted patch, but that is an argument for the shape, not proof of the cause.

If you would rather not carry a defensive sweep without a confirmed user-facing repro, that is a reasonable call and I will not argue it. The `visibilitychange` half is the piece I would keep regardless — a backgrounded tab freezing animation timelines is ordinary browser behaviour, not an exotic state.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2056?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

