### PR TITLE
fix(web): stop long GitLab row titles drawing over the row actions

### DIFF
--- a/apps/web/components/gitlab/my-gitlab/issue-list.tsx
+++ b/apps/web/components/gitlab/my-gitlab/issue-list.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import Link from "@/components/routing/app-link";
-import { IconCircle, IconCircleCheck, IconExternalLink } from "@tabler/icons-react";
+import { IconCircle, IconCircleCheck } from "@tabler/icons-react";
 import { Badge } from "@kandev/ui/badge";
 import { Spinner } from "@kandev/ui/spinner";
 import { cn, formatRelativeTime } from "@/lib/utils";
@@ -9,6 +8,7 @@ import type { Issue } from "@/lib/types/gitlab";
 import type { GitLabLaunchPayload, GitLabTaskPreset } from "./quick-task-launcher";
 import { StartTaskMenu } from "./start-task-menu";
 import { SubscriptionToggle } from "../subscription-toggle";
+import { RowTitleLink } from "./row-title-link";
 
 type IssueListProps = {
   items: Issue[];
@@ -62,15 +62,7 @@ function IssueRow({
     >
       <StateIcon className={cn("h-4 w-4 mt-1 shrink-0", stateClass)} />
       <div className="min-w-0 flex-1">
-        <Link
-          href={issue.web_url}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-sm font-semibold hover:underline inline-flex items-center gap-1.5 truncate cursor-pointer"
-        >
-          <span className="truncate">{issue.title}</span>
-          <IconExternalLink className="h-3 w-3 shrink-0 text-muted-foreground" />
-        </Link>
+        <RowTitleLink href={issue.web_url} title={issue.title} />
         <div className="flex flex-wrap items-center gap-x-2 gap-y-1 mt-0.5 text-xs text-muted-foreground">
           <span className="whitespace-nowrap">
             {issue.project_path}#{issue.iid}

--- a/apps/web/components/gitlab/my-gitlab/mr-list.tsx
+++ b/apps/web/components/gitlab/my-gitlab/mr-list.tsx
@@ -1,10 +1,6 @@
 "use client";
 
-import {
-  IconGitPullRequest,
-  IconGitPullRequestClosed,
-  IconGitMerge,
-} from "@tabler/icons-react";
+import { IconGitPullRequest, IconGitPullRequestClosed, IconGitMerge } from "@tabler/icons-react";
 import type { Icon } from "@tabler/icons-react";
 import { Spinner } from "@kandev/ui/spinner";
 import { cn, formatRelativeTime } from "@/lib/utils";

--- a/apps/web/components/gitlab/my-gitlab/mr-list.tsx
+++ b/apps/web/components/gitlab/my-gitlab/mr-list.tsx
@@ -1,11 +1,9 @@
 "use client";
 
-import Link from "@/components/routing/app-link";
 import {
   IconGitPullRequest,
   IconGitPullRequestClosed,
   IconGitMerge,
-  IconExternalLink,
 } from "@tabler/icons-react";
 import type { Icon } from "@tabler/icons-react";
 import { Spinner } from "@kandev/ui/spinner";
@@ -15,6 +13,7 @@ import type { GitLabLaunchPayload, GitLabTaskPreset } from "./quick-task-launche
 import { gitLabMRKey } from "@/lib/gitlab-identity";
 import { MRRowTaskIndicator } from "./mr-row-task-indicator";
 import { StartTaskMenu } from "./start-task-menu";
+import { RowTitleLink } from "./row-title-link";
 
 type MRListProps = {
   items: MR[];
@@ -55,15 +54,7 @@ function MRRow({
     >
       <StateIcon className={cn("h-4 w-4 mt-1 shrink-0", stateIconClass)} />
       <div className="min-w-0 flex-1">
-        <Link
-          href={mr.web_url}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-sm font-semibold hover:underline inline-flex items-center gap-1.5 truncate cursor-pointer"
-        >
-          <span className="truncate">{mr.title}</span>
-          <IconExternalLink className="h-3 w-3 shrink-0 text-muted-foreground" />
-        </Link>
+        <RowTitleLink href={mr.web_url} title={mr.title} />
         <div className="flex flex-wrap items-center gap-x-2 gap-y-1 mt-0.5 text-xs text-muted-foreground">
           <span className="whitespace-nowrap">
             {mr.project_path}!{mr.iid}

--- a/apps/web/components/gitlab/my-gitlab/row-title-link.test.tsx
+++ b/apps/web/components/gitlab/my-gitlab/row-title-link.test.tsx
@@ -1,0 +1,29 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { RowTitleLink } from "./row-title-link";
+
+const longTitle =
+  "§7 item 4 (km-product#27) — EntityLocker is not the REQ-011 FR-8 answer lock (no change proposed; recording the distinction)";
+
+afterEach(cleanup);
+
+describe("RowTitleLink", () => {
+  it("keeps a long title inside its column instead of overlapping row actions", () => {
+    render(<RowTitleLink href="https://gitlab.example.com/x/-/issues/3" title={longTitle} />);
+
+    const link = screen.getByRole("link");
+    // Block-level flex: an inline-flex link sizes to content and overflows the row.
+    expect(link.className).toContain("flex");
+    expect(link.className).not.toContain("inline-flex");
+    expect(link.className).toContain("min-w-0");
+
+    const text = screen.getByText(longTitle);
+    expect(text.className).toContain("truncate");
+  });
+
+  it("exposes the full title on hover since the text may be clipped", () => {
+    render(<RowTitleLink href="https://gitlab.example.com/x/-/issues/3" title={longTitle} />);
+
+    expect(screen.getByRole("link").getAttribute("title")).toBe(longTitle);
+  });
+});

--- a/apps/web/components/gitlab/my-gitlab/row-title-link.tsx
+++ b/apps/web/components/gitlab/my-gitlab/row-title-link.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import Link from "@/components/routing/app-link";
+import { IconExternalLink } from "@tabler/icons-react";
+
+/**
+ * Title link for GitLab issue/MR rows.
+ *
+ * Must stay block-level (`flex`, not `inline-flex`): an inline-flex link sizes
+ * itself to its content, so a long title escapes the row's `min-w-0 flex-1`
+ * column and draws over the row actions. Truncation belongs on the text span —
+ * `overflow-hidden` zeroes its automatic minimum size so it can shrink.
+ */
+export function RowTitleLink({ href, title }: { href: string; title: string }) {
+  return (
+    <Link
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      title={title}
+      className="flex min-w-0 items-center gap-1.5 text-sm font-semibold hover:underline cursor-pointer"
+    >
+      <span className="truncate">{title}</span>
+      <IconExternalLink className="h-3 w-3 shrink-0 text-muted-foreground" />
+    </Link>
+  );
+}


### PR DESCRIPTION
## Problem

In the My GitLab panel, a long issue or MR title escapes its column and paints across the **Unsubscribe** and **Task** buttons, leaving both visually unreachable.

## Cause

The title link carried `inline-flex` together with `truncate`. An inline-flex box sizes itself to its content, so the link grew past the row's `min-w-0 flex-1` column regardless of `truncate` — `truncate` sets `overflow: hidden` on the element it is applied to, but that element had already been allowed to size beyond its parent. Hidden overflow on a box that is itself too wide clips nothing useful.

## Fix

Make the link block-level (`flex min-w-0`) so it participates in the column's width, and move truncation onto the inner text span, whose `overflow-hidden` zeroes its automatic minimum size so it can actually shrink. The external-link icon keeps `shrink-0` so it is never clipped.

Both lists carried the same markup, so it is extracted into `RowTitleLink` rather than fixed twice. The comment there records why the element must stay `flex` and not revert to `inline-flex`, since that is the part a future edit would plausibly undo.

The full title stays available on hover via the `title` attribute.

## Verification

```
vitest run components/gitlab/my-gitlab/row-title-link.test.tsx
Test Files  1 passed (1)
      Tests  2 passed (2)

tsc --noEmit   (clean)
```


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2057?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

