### PR TITLE
chore: remove dead system.error websocket contract

### DIFF
--- a/apps/packages/types/src/backend.ts
+++ b/apps/packages/types/src/backend.ts
@@ -7,7 +7,6 @@ export type BackendMessageType =
   | "agent.updated"
   | "terminal.output"
   | "diff.update"
-  | "system.error"
   | "workspace.created"
   | "workspace.updated"
   | "workspace.deleted"
@@ -75,11 +74,6 @@ export type DiffUpdatePayload = {
   }>;
 };
 
-export type SystemErrorPayload = {
-  message: string;
-  code?: string;
-};
-
 export type TaskSessionNotificationPayload = {
   task_id: string;
   session_id: string;
@@ -133,7 +127,6 @@ export type BackendMessageMap = {
   "agent.updated": BackendMessage<"agent.updated", AgentUpdatePayload>;
   "terminal.output": BackendMessage<"terminal.output", TerminalOutputPayload>;
   "diff.update": BackendMessage<"diff.update", DiffUpdatePayload>;
-  "system.error": BackendMessage<"system.error", SystemErrorPayload>;
   "workspace.created": BackendMessage<"workspace.created", WorkspacePayload>;
   "workspace.updated": BackendMessage<"workspace.updated", WorkspacePayload>;
   "workspace.deleted": BackendMessage<"workspace.deleted", WorkspacePayload>;

--- a/apps/web/lib/types/backend.ts
+++ b/apps/web/lib/types/backend.ts
@@ -172,11 +172,6 @@ export type DiffUpdatePayload = {
   }>;
 };
 
-export type SystemErrorPayload = {
-  message: string;
-  code?: string;
-};
-
 export type UpdateAvailablePayload = {
   version: string;
   url?: string;
@@ -541,7 +536,6 @@ export type BackendMessageMap = OfficeBackendMessageMap &
     "terminal.output": BackendMessage<"terminal.output", TerminalOutputPayload>;
     "diff.update": BackendMessage<"diff.update", DiffUpdatePayload>;
     "session.git.event": BackendMessage<"session.git.event", GitEventPayload>;
-    "system.error": BackendMessage<"system.error", SystemErrorPayload>;
     "system.job.update": BackendMessage<"system.job.update", import("./system").SystemJob>;
     "system.metrics.updated": BackendMessage<"system.metrics.updated", SystemMetricsSnapshot>;
     "system.update_available": BackendMessage<"system.update_available", UpdateAvailablePayload>;

--- a/apps/web/lib/ws/handlers/system-events.ts
+++ b/apps/web/lib/ws/handlers/system-events.ts
@@ -4,9 +4,6 @@ import type { WsHandlers } from "@/lib/ws/handlers/types";
 
 export function registerSystemEventsHandlers(store: StoreApi<AppState>): WsHandlers {
   return {
-    "system.error": () => {
-      // TODO: surface as toast/notification once UI is ready.
-    },
     "system.job.update": (message) => {
       // The WS payload is the full SystemJob row published by the backend
       // jobs tracker (see internal/system/jobs). Upsert by id so the


### PR DESCRIPTION
The `system.error` WebSocket event was typed end-to-end but wired to nothing on either side — the backend has no `ActionSystemError` constant and never emitted it, while the frontend handler body was only a `// TODO: surface as toast/notification once UI is ready.` comment that swallowed the event. Removing the contract makes the codebase honest about a capability that never existed.

## Important Changes

- Dropped the `"system.error"` union member, message-map entry, and now-unused `SystemErrorPayload` type from both `apps/packages/types/src/backend.ts` and `apps/web/lib/types/backend.ts`.
- Removed the dead handler from `apps/web/lib/ws/handlers/system-events.ts`; `system.job.update` and `system.metrics.updated` are untouched.
- Deliberately scoped to deletion. Wiring the channel up — a backend emitter, gateway subscription, store slice, toast bridge, and mobile-parity pass — is a feature and belongs in its own change.

Recorded for whoever picks that follow-up up: the candidate failure paths are the `jobs.Tracker` failed-job transitions (`vacuum`, `optimize`, `factory-reset`, `backup-create`, `restore`, `self-update`, storage `cleanup`), which today surface only while a System page component holds that job ID via `useSystemJob` and are lost on navigation; and the scheduled storage-maintenance run at `internal/system/storage/scheduler.go:110`, whose error is discarded outright (`_, _ = s.runner.Run(...)`) with no job, no log, and no notification. None of that is addressed here.

## Validation

- `grep -rn "SystemErrorPayload|system\.error|ActionSystemError"` across `*.ts`, `*.tsx`, `*.go`, `*.rs`, `*.md`, `*.json`, `*.yaml` — only the 6 declaration sites removed here, no consumers anywhere including e2e specs and the desktop shell. `@kandev/types` is consumed only by `@kandev/web`.
- `cd apps/web && pnpm run typecheck` — clean
- `pnpm --filter @kandev/web lint` — clean at `--max-warnings 0`
- `pnpm vitest run lib/ws/handlers` — 29 files, 253 tests passed

No new tests: this is a pure deletion of an unreferenced type and a no-op handler. No backend changes, so `make -C apps/backend test lint` is not implicated. No UI change, so no `/mobile-parity` pass applies.

## Possible Improvements

Negligible risk — nothing on the wire ever carried this action, so removal is unobservable at runtime; re-adding the type is trivial if an emitter ever lands.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.