### PR TITLE
refactor(web): reuse stats-utils formatDuration in stats-sections

### DIFF
--- a/apps/web/app/stats/stats-sections.tsx
+++ b/apps/web/app/stats/stats-sections.tsx
@@ -4,21 +4,7 @@ import { IconGitCommit } from "@tabler/icons-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@kandev/ui/card";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
 import type { StatsResponse, TaskStatsDTO, RepositoryStatsDTO } from "@/lib/types/http";
-
-function formatDuration(ms: number): string {
-  if (ms === 0) return "\u2014";
-  const seconds = Math.floor(ms / 1000);
-  const minutes = Math.floor(seconds / 60);
-  const hours = Math.floor(minutes / 60);
-
-  if (hours > 0) {
-    return `${hours}h ${minutes % 60}m`;
-  }
-  if (minutes > 0) {
-    return `${minutes}m ${seconds % 60}s`;
-  }
-  return `${seconds}s`;
-}
+import { formatDuration } from "./stats-utils";
 
 function formatPercent(value: number): string {
   return `${Math.round(value)}%`;


### PR DESCRIPTION
`stats-sections.tsx` carried a private `formatDuration` that was a byte-for-byte copy of the exported one in its sibling `stats-utils.ts`, so the two stats surfaces could silently drift apart. It now imports the shared helper instead.

## Validation

- `pnpm --filter @kandev/web lint` — clean
- `pnpm run typecheck` (apps/web) — clean
- `pnpm vitest run` (apps/web) — 964 files, 7368 passed / 4 skipped

No new test needed: `stats-utils.test.ts` already covers `formatDuration` across all four buckets (`0` → `—`, seconds, minutes, hours). No UI behaviour changes, so no new Playwright coverage.

## Possible Improvements

Negligible risk — the deleted body and the kept one were character-identical apart from `"—"` vs a literal `—`.

The other ~8 `formatDuration` implementations in `apps/web` were deliberately left alone: they genuinely differ (some render `450ms`, some `1.5s`, some `2m 30s`, and some take `(startedAt, completedAt)` strings rather than a number of ms), so collapsing them would be a real behaviour change across many surfaces. One further genuinely-identical pair is a clean follow-up — `components/task/simple/components/session-timeline-entry.tsx:14` and `components/task/simple/components/agent-turn-panel.tsx:21` are byte-for-byte the same.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.
