### PR TITLE
fix(tasks): keep workflow step and state consistent when messaging review

### DIFF
--- a/apps/backend/internal/mcp/handlers/handlers.go
+++ b/apps/backend/internal/mcp/handlers/handlers.go
@@ -2392,7 +2392,7 @@ func (h *Handlers) dispatchTaskMessage(ctx context.Context, taskID string, sessi
 		return h.queueTaskMessage(ctx, taskID, session, prompt, metadata)
 
 	default:
-		reviewRollback, err := h.ensureTaskInProgressForTaskMessage(ctx, taskID)
+		reviewRollback, err := h.snapshotTaskForTaskMessage(ctx, taskID)
 		if err != nil {
 			return taskMessageDispatchResult{}, err
 		}
@@ -2413,8 +2413,10 @@ func (h *Handlers) dispatchTaskMessage(ctx context.Context, taskID string, sessi
 		result, err := h.dispatchPreparedTaskMessage(ctx, taskID, session, prompt, metadata)
 		if err != nil {
 			h.restoreTaskReviewForTaskMessage(ctx, taskID, reviewRollback)
+			return result, err
 		}
-		return result, err
+		h.reactivateTaskAfterTaskMessageTurnStart(ctx, taskID, reviewRollback)
+		return result, nil
 	}
 }
 
@@ -2585,7 +2587,11 @@ func (h *Handlers) prepareSessionForTaskMessage(ctx context.Context, taskID stri
 	return resolved, nil
 }
 
-func (h *Handlers) ensureTaskInProgressForTaskMessage(ctx context.Context, taskID string) (taskMessageReviewRollback, error) {
+// snapshotTaskForTaskMessage captures the task's state and workflow step before
+// on_turn_start runs, so a dispatch failure can restore both and so
+// reactivateTaskAfterTaskMessageTurnStart can tell whether the workflow
+// released the task from the step it was parked on.
+func (h *Handlers) snapshotTaskForTaskMessage(ctx context.Context, taskID string) (taskMessageReviewRollback, error) {
 	if h.taskSvc == nil {
 		return taskMessageReviewRollback{}, errors.New("task service not available")
 	}
@@ -2593,24 +2599,62 @@ func (h *Handlers) ensureTaskInProgressForTaskMessage(ctx context.Context, taskI
 	if err != nil {
 		return taskMessageReviewRollback{}, err
 	}
-	rollback := taskMessageReviewRollback{
+	return taskMessageReviewRollback{
 		changed:        true,
 		restoreTask:    true,
 		taskState:      task.State,
 		workflowStepID: task.WorkflowStepID,
+	}, nil
+}
+
+// reactivateTaskAfterTaskMessageTurnStart transitions a task parked in REVIEW to
+// IN_PROGRESS, but only once on_turn_start released it from the step it was
+// parked on. The workflow step owns the Kanban column and the stepper, so
+// writing IN_PROGRESS while the task still sits on that step splits the two
+// apart with nothing to reconcile them (issue #2063). A step that keeps the
+// task (no on_turn_start transition, or a transition rejected by WIP capacity)
+// keeps REVIEW; the runtime reconciles the state to IN_PROGRESS if and when the
+// agent actually starts working.
+//
+// It runs after a successful dispatch — the prompt is already with the agent,
+// so a failed state write is logged rather than rolled back — and is therefore
+// also skipped whenever dispatch failed or a coordinator stop took the task
+// over mid-flight.
+func (h *Handlers) reactivateTaskAfterTaskMessageTurnStart(
+	ctx context.Context,
+	taskID string,
+	snapshot taskMessageReviewRollback,
+) {
+	if snapshot.taskState != v1.TaskStateReview {
+		return
 	}
-	if task.State != v1.TaskStateReview {
-		return rollback, nil
+	task, err := h.taskSvc.GetTask(ctx, taskID)
+	if err != nil {
+		h.logger.Warn("failed to reload task for REVIEW reactivation",
+			zap.String("task_id", taskID),
+			zap.Error(err))
+		return
 	}
-	if task.IsFromOffice {
-		return rollback, nil
+	if task.State != v1.TaskStateReview || task.IsFromOffice {
+		return
+	}
+	// An empty parked step means the task has no board position at all
+	// (quick chat / ephemeral), so there is nothing to contradict.
+	if snapshot.workflowStepID != "" && task.WorkflowStepID == snapshot.workflowStepID {
+		h.logger.Debug("leaving task in REVIEW: still parked on its workflow step",
+			zap.String("task_id", taskID),
+			zap.String("workflow_step_id", snapshot.workflowStepID))
+		return
 	}
 	if _, err := h.taskSvc.UpdateTaskState(ctx, taskID, v1.TaskStateInProgress); err != nil {
-		return taskMessageReviewRollback{}, fmt.Errorf("failed to transition task from REVIEW to IN_PROGRESS for task message: %w", err)
+		h.logger.Error("failed to transition task from REVIEW to IN_PROGRESS for task message",
+			zap.String("task_id", taskID),
+			zap.Error(err))
+		return
 	}
 	h.logger.Info("task transitioned from REVIEW to IN_PROGRESS for task message",
-		zap.String("task_id", taskID))
-	return rollback, nil
+		zap.String("task_id", taskID),
+		zap.String("workflow_step_id", task.WorkflowStepID))
 }
 
 func (h *Handlers) restoreTaskReviewForTaskMessage(ctx context.Context, taskID string, rollback taskMessageReviewRollback) {

--- a/apps/backend/internal/mcp/handlers/message_task_review_step_test.go
+++ b/apps/backend/internal/mcp/handlers/message_task_review_step_test.go
@@ -1,0 +1,136 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kandev/kandev/internal/events/bus"
+	"github.com/kandev/kandev/internal/task/models"
+	v1 "github.com/kandev/kandev/pkg/api/v1"
+	ws "github.com/kandev/kandev/pkg/websocket"
+)
+
+// assertNoTaskStateChangedEvent fails when any task.state_changed event was
+// published for taskID.
+func assertNoTaskStateChangedEvent(t *testing.T, ch <-chan *bus.Event, taskID string) {
+	t.Helper()
+	for len(ch) > 0 {
+		event := <-ch
+		data, ok := event.Data.(map[string]interface{})
+		require.True(t, ok)
+		if data["task_id"] == taskID {
+			t.Fatalf("unexpected task.state_changed event for task %s: %v", taskID, data["state"])
+		}
+	}
+}
+
+// Regression coverage for issue #2063: messaging a task parked on a review step
+// must not report IN_PROGRESS while the board still shows the task on that
+// step. The workflow step is authoritative for the column, so the REVIEW →
+// IN_PROGRESS reactivation only applies once on_turn_start has actually moved
+// the task off the step it was parked on.
+
+// TestHandleMessageTask_ParkedReviewStepWithoutMoveKeepsReviewState covers a
+// workflow whose review step declares no on_turn_start transition (the built-in
+// PR Review workflow is shaped this way). The task stays on the step, so the
+// state must stay REVIEW instead of drifting to IN_PROGRESS.
+func TestHandleMessageTask_ParkedReviewStepWithoutMoveKeepsReviewState(t *testing.T) {
+	ctx := context.Background()
+	svc, repo := newTestTaskService(t)
+	sender, target, sess := seedTaskWithSession(t, svc, repo, models.TaskSessionStateWaitingForInput)
+
+	task, err := svc.GetTask(ctx, target.ID)
+	require.NoError(t, err)
+	task.State = v1.TaskStateReview
+	task.WorkflowStepID = "step-review"
+	require.NoError(t, repo.UpdateTask(ctx, task))
+
+	h, orch := newMessageTaskHandler(t, svc)
+	// No on_turn_start transition configured: the step never moves.
+	orch.onTurnStart = func(context.Context, string, string) error { return nil }
+
+	msg := makeWSMessage(t, ws.ActionMCPMessageTask, senderPayload(target.ID, "review follow-up", sender.ID))
+	resp, err := h.handleMessageTask(ctx, msg)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, ws.MessageTypeResponse, resp.Type)
+
+	require.Len(t, orch.turnStartCalls, 1)
+	require.Len(t, orch.promptCalls, 1)
+	assert.Equal(t, sess.ID, orch.promptCalls[0].sessionID)
+
+	updatedTask, err := svc.GetTask(ctx, target.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "step-review", updatedTask.WorkflowStepID)
+	assert.Equal(t, v1.TaskStateReview, updatedTask.State,
+		"state must not drift to IN_PROGRESS while the task stays parked on the review step")
+}
+
+// TestHandleMessageTask_ParkedReviewStepMoveReactivatesTask covers the built-in
+// Kanban/Architecture shape, where the review step declares
+// `on_turn_start: move_to_previous`. The task leaves the review step, so the
+// reactivation to IN_PROGRESS is consistent with the board.
+func TestHandleMessageTask_ParkedReviewStepMoveReactivatesTask(t *testing.T) {
+	ctx := context.Background()
+	svc, repo := newTestTaskService(t)
+	sender, target, sess := seedTaskWithSession(t, svc, repo, models.TaskSessionStateWaitingForInput)
+
+	task, err := svc.GetTask(ctx, target.ID)
+	require.NoError(t, err)
+	task.State = v1.TaskStateReview
+	task.WorkflowStepID = "step-review"
+	require.NoError(t, repo.UpdateTask(ctx, task))
+
+	h, orch := newMessageTaskHandler(t, svc)
+	orch.onTurnStart = func(ctx context.Context, taskID, _ string) error {
+		movedTask, err := svc.GetTask(ctx, taskID)
+		require.NoError(t, err)
+		movedTask.WorkflowStepID = "step-in-progress"
+		return repo.UpdateTask(ctx, movedTask)
+	}
+
+	msg := makeWSMessage(t, ws.ActionMCPMessageTask, senderPayload(target.ID, "back to work", sender.ID))
+	resp, err := h.handleMessageTask(ctx, msg)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, ws.MessageTypeResponse, resp.Type)
+
+	require.Len(t, orch.promptCalls, 1)
+	assert.Equal(t, sess.ID, orch.promptCalls[0].sessionID)
+
+	updatedTask, err := svc.GetTask(ctx, target.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "step-in-progress", updatedTask.WorkflowStepID)
+	assert.Equal(t, v1.TaskStateInProgress, updatedTask.State)
+}
+
+// TestHandleMessageTask_ParkedReviewTaskWithoutWorkflowStepReactivates keeps
+// quick-chat/ephemeral tasks (no workflow step, so no board to contradict)
+// on the immediate reactivation they had before.
+func TestHandleMessageTask_ParkedReviewTaskWithoutWorkflowStepReactivates(t *testing.T) {
+	ctx := context.Background()
+	svc, repo := newTestTaskService(t)
+	sender, target, _ := seedTaskWithSession(t, svc, repo, models.TaskSessionStateWaitingForInput)
+
+	task, err := svc.GetTask(ctx, target.ID)
+	require.NoError(t, err)
+	task.State = v1.TaskStateReview
+	task.WorkflowStepID = ""
+	require.NoError(t, repo.UpdateTask(ctx, task))
+
+	h, orch := newMessageTaskHandler(t, svc)
+	orch.onTurnStart = func(context.Context, string, string) error { return nil }
+
+	msg := makeWSMessage(t, ws.ActionMCPMessageTask, senderPayload(target.ID, "keep going", sender.ID))
+	resp, err := h.handleMessageTask(ctx, msg)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, ws.MessageTypeResponse, resp.Type)
+
+	updatedTask, err := svc.GetTask(ctx, target.ID)
+	require.NoError(t, err)
+	assert.Equal(t, v1.TaskStateInProgress, updatedTask.State)
+}

--- a/apps/backend/internal/mcp/handlers/message_task_test.go
+++ b/apps/backend/internal/mcp/handlers/message_task_test.go
@@ -954,7 +954,9 @@ func TestHandleMessageTask_WaitingForInput_FiresTurnStart(t *testing.T) {
 		assert.Equal(t, sess.ID, sessionID)
 		updatedTask, err := svc.GetTask(ctx, taskID)
 		require.NoError(t, err)
-		assert.Equal(t, v1.TaskStateInProgress, updatedTask.State)
+		// The reactivation follows the step move, so the task is still
+		// parked in REVIEW while on_turn_start decides where it goes.
+		assert.Equal(t, v1.TaskStateReview, updatedTask.State)
 		updatedTask.WorkflowStepID = "step-in-progress"
 		return repo.UpdateTask(ctx, updatedTask)
 	}
@@ -991,13 +993,15 @@ func TestHandleMessageTask_KanbanRunnerTransitionsReviewToInProgress(t *testing.
 	require.NoError(t, repo.UpdateTask(ctx, task))
 
 	h, orch := newMessageTaskHandler(t, svc)
+	// The built-in Kanban review step declares `on_turn_start: move_to_previous`,
+	// so the task leaves the review step and the reactivation applies.
 	orch.onTurnStart = func(ctx context.Context, taskID, sessionID string) error {
 		assert.Equal(t, target.ID, taskID)
 		assert.Equal(t, sess.ID, sessionID)
 		updatedTask, err := svc.GetTask(ctx, taskID)
 		require.NoError(t, err)
-		assert.Equal(t, v1.TaskStateInProgress, updatedTask.State)
-		return nil
+		updatedTask.WorkflowStepID = "step-in-progress"
+		return repo.UpdateTask(ctx, updatedTask)
 	}
 
 	msg := makeWSMessage(t, ws.ActionMCPMessageTask, senderPayload(target.ID, "review follow-up", sender.ID))
@@ -1009,7 +1013,7 @@ func TestHandleMessageTask_KanbanRunnerTransitionsReviewToInProgress(t *testing.
 	updatedTask, err := svc.GetTask(ctx, target.ID)
 	require.NoError(t, err)
 	assert.Equal(t, v1.TaskStateInProgress, updatedTask.State)
-	assert.Equal(t, "step-review", updatedTask.WorkflowStepID)
+	assert.Equal(t, "step-in-progress", updatedTask.WorkflowStepID)
 }
 
 func TestHandleMessageTask_WaitingForInput_UsesSessionSelectedByTurnStart(t *testing.T) {
@@ -1292,7 +1296,9 @@ func TestHandleMessageTask_TurnStartErrorRejectsAndRestoresReview(t *testing.T) 
 	require.NoError(t, err)
 	assert.Equal(t, v1.TaskStateReview, updatedTask.State)
 	assert.Equal(t, "step-review", updatedTask.WorkflowStepID)
-	assertTaskStateChangedEvent(t, stateEvents, target.ID, v1.TaskStateReview, "step-review")
+	// The step move is rolled back and the state never left REVIEW, so no
+	// state_changed event is published in either direction.
+	assertNoTaskStateChangedEvent(t, stateEvents, target.ID)
 	assert.Empty(t, orch.promptCalls)
 	messages, err := svc.ListMessages(ctx, sess.ID)
 	require.NoError(t, err)
@@ -1496,7 +1502,9 @@ func TestHandleMessageTask_DispatchErrorAfterSessionSwitchRestoresReviewSession(
 	require.NoError(t, err)
 	assert.Equal(t, v1.TaskStateReview, updatedTask.State)
 	assert.Equal(t, "step-review", updatedTask.WorkflowStepID)
-	assertTaskStateChangedEvent(t, stateEvents, target.ID, v1.TaskStateReview, "step-review")
+	// The step move is rolled back and the state never left REVIEW, so no
+	// state_changed event is published in either direction.
+	assertNoTaskStateChangedEvent(t, stateEvents, target.ID)
 
 	primary, err := svc.GetPrimarySession(ctx, target.ID)
 	require.NoError(t, err)

--- a/apps/backend/internal/task/handlers/message_handlers.go
+++ b/apps/backend/internal/task/handlers/message_handlers.go
@@ -528,7 +528,10 @@ func (h *MessageHandlers) reactivateTaskAfterTurnStart(ctx context.Context, task
 			zap.Error(err))
 		return
 	}
-	if task.State != v1.TaskStateReview {
+	// Office tasks are never marked IN_PROGRESS by anyone but the office
+	// runtime — reconcileTaskStateForRuntimeLocked refuses that write too, and
+	// the MCP message_task path carries the same guard.
+	if task.State != v1.TaskStateReview || task.IsFromOffice {
 		return
 	}
 	// An empty parked step means the task has no board position at all

--- a/apps/backend/internal/task/handlers/message_handlers.go
+++ b/apps/backend/internal/task/handlers/message_handlers.go
@@ -278,8 +278,10 @@ func (h *MessageHandlers) wsAddMessage(ctx context.Context, msg *ws.Message) (*w
 		req.EntityReferences = references
 	}
 
-	// Transition task from REVIEW → IN_PROGRESS if needed
-	if err := h.ensureTaskInProgress(ctx, req.TaskID); err != nil {
+	// Snapshot the REVIEW parking before on_turn_start so the reactivation
+	// below can follow the workflow step instead of drifting from it.
+	parking, err := h.reviewParkingBeforeTurnStart(ctx, req.TaskID)
+	if err != nil {
 		h.logger.Error("failed to get task", zap.String("task_id", req.TaskID), zap.Error(err))
 		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError, "Failed to get task", nil)
 	}
@@ -298,7 +300,6 @@ func (h *MessageHandlers) wsAddMessage(ctx context.Context, msg *ws.Message) (*w
 				zap.String("session_id", req.TaskSessionID),
 				zap.Error(err))
 		}
-		var err error
 		sessionResp, err = h.resolveSessionAfterTurnStart(ctx, req.TaskID, req.TaskSessionID, sessionResp)
 		if err != nil {
 			h.logger.Warn("failed to resolve prompt session after on_turn_start",
@@ -312,6 +313,10 @@ func (h *MessageHandlers) wsAddMessage(ctx context.Context, msg *ws.Message) (*w
 	if wsErr := h.errorForBlockedMessageSession(msg, sessionResp.Session.ID, sessionResp.Session.State); wsErr != nil {
 		return wsErr, nil
 	}
+	// on_turn_start has settled the workflow step and the session survived the
+	// blocked-state gate, so the REVIEW reactivation can now follow the board
+	// instead of contradicting it.
+	h.reactivateTaskAfterTurnStart(ctx, req.TaskID, parking)
 	isCreatedSession := sessionResp.Session.State == models.TaskSessionStateCreated
 
 	// Build metadata with attachments, plan mode, review comments, and context files
@@ -483,15 +488,56 @@ func (h *MessageHandlers) logBlockedRunningSession(sessionID string, state model
 		zap.String("session_state", string(state)))
 }
 
-// ensureTaskInProgress fetches the task and transitions it from REVIEW → IN_PROGRESS if needed.
-// Returns an error only when the task cannot be fetched.
-func (h *MessageHandlers) ensureTaskInProgress(ctx context.Context, taskID string) error {
+// reviewParking records that a task was parked in REVIEW, and on which
+// workflow step, before on_turn_start ran.
+type reviewParking struct {
+	parked bool
+	stepID string
+}
+
+// reviewParkingBeforeTurnStart snapshots the task's review parking so the
+// reactivation below can follow the workflow step. Returns an error only when
+// the task cannot be fetched.
+func (h *MessageHandlers) reviewParkingBeforeTurnStart(ctx context.Context, taskID string) (reviewParking, error) {
 	task, err := h.service.GetTask(ctx, taskID)
 	if err != nil {
-		return err
+		return reviewParking{}, err
 	}
 	if task.State != v1.TaskStateReview {
-		return nil
+		return reviewParking{}, nil
+	}
+	return reviewParking{parked: true, stepID: task.WorkflowStepID}, nil
+}
+
+// reactivateTaskAfterTurnStart transitions a task parked in REVIEW to
+// IN_PROGRESS, but only once the workflow released it from the step it was
+// parked on. The workflow step owns the Kanban column and the stepper, so
+// writing IN_PROGRESS while the task still sits on the step it was parked on
+// splits the two apart with nothing to reconcile them (issue #2063). A step
+// that keeps the task (no on_turn_start transition, or a transition rejected
+// by WIP capacity) keeps REVIEW; the runtime reconciles the state to
+// IN_PROGRESS if and when the agent actually starts working.
+func (h *MessageHandlers) reactivateTaskAfterTurnStart(ctx context.Context, taskID string, parking reviewParking) {
+	if !parking.parked {
+		return
+	}
+	task, err := h.service.GetTask(ctx, taskID)
+	if err != nil {
+		h.logger.Warn("failed to reload task for REVIEW reactivation",
+			zap.String("task_id", taskID),
+			zap.Error(err))
+		return
+	}
+	if task.State != v1.TaskStateReview {
+		return
+	}
+	// An empty parked step means the task has no board position at all
+	// (quick chat / ephemeral), so there is nothing to contradict.
+	if parking.stepID != "" && task.WorkflowStepID == parking.stepID {
+		h.logger.Debug("leaving task in REVIEW: still parked on its workflow step",
+			zap.String("task_id", taskID),
+			zap.String("workflow_step_id", parking.stepID))
+		return
 	}
 	if _, err := h.service.UpdateTaskState(ctx, taskID, v1.TaskStateInProgress); err != nil {
 		h.logger.Error("failed to transition task from REVIEW to IN_PROGRESS",
@@ -499,9 +545,9 @@ func (h *MessageHandlers) ensureTaskInProgress(ctx context.Context, taskID strin
 			zap.Error(err))
 	} else {
 		h.logger.Info("task transitioned from REVIEW to IN_PROGRESS",
-			zap.String("task_id", taskID))
+			zap.String("task_id", taskID),
+			zap.String("workflow_step_id", task.WorkflowStepID))
 	}
-	return nil
 }
 
 // dispatchPromptAsync forwards the message to the agent as a prompt in a

--- a/apps/backend/internal/task/handlers/message_handlers_review_step_test.go
+++ b/apps/backend/internal/task/handlers/message_handlers_review_step_test.go
@@ -1,0 +1,139 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kandev/kandev/internal/common/logger"
+	"github.com/kandev/kandev/internal/orchestrator"
+	"github.com/kandev/kandev/internal/task/models"
+	"github.com/kandev/kandev/internal/task/service"
+	v1 "github.com/kandev/kandev/pkg/api/v1"
+	ws "github.com/kandev/kandev/pkg/websocket"
+)
+
+// Regression coverage for issue #2063 on the WS chat path: a task parked on a
+// review step must not be reported IN_PROGRESS while the board still shows it
+// on that step. The workflow step owns the column, so the REVIEW → IN_PROGRESS
+// reactivation only applies once on_turn_start moved the task off the step.
+
+// reviewStepRepo persists task-state writes so the handler's reactivation is
+// observable; messageAddSwitchRepo's embedded mock swallows them.
+type reviewStepRepo struct {
+	messageAddSwitchRepo
+}
+
+func (r *reviewStepRepo) UpdateTaskState(_ context.Context, id string, state v1.TaskState) error {
+	if task, ok := r.tasks[id]; ok {
+		task.State = state
+	}
+	return nil
+}
+
+// reviewStepOrchestrator models a workflow step's on_turn_start behaviour:
+// moveToStepID is empty when the step declares no transition.
+type reviewStepOrchestrator struct {
+	repo         *reviewStepRepo
+	moveToStepID string
+	prompted     chan struct{}
+}
+
+func (o *reviewStepOrchestrator) PromptTask(
+	context.Context, string, string, string, string, bool, []v1.MessageAttachment, bool,
+) (*orchestrator.PromptResult, error) {
+	close(o.prompted)
+	return &orchestrator.PromptResult{}, nil
+}
+
+func (o *reviewStepOrchestrator) ResumeTaskSession(context.Context, string, string) error {
+	return nil
+}
+
+func (o *reviewStepOrchestrator) StartCreatedSession(
+	context.Context, string, string, string, string, bool, bool, bool,
+	[]v1.MessageAttachment, []v1.EntityReference,
+) error {
+	return nil
+}
+
+func (o *reviewStepOrchestrator) ProcessOnTurnStart(_ context.Context, taskID, _ string) error {
+	if o.moveToStepID == "" {
+		return nil
+	}
+	if task, ok := o.repo.tasks[taskID]; ok {
+		task.WorkflowStepID = o.moveToStepID
+	}
+	return nil
+}
+
+func (o *reviewStepOrchestrator) StepRequiresCompletionSignal(context.Context, string) bool {
+	return false
+}
+
+func (*reviewStepOrchestrator) ForegroundActivity(string) v1.ForegroundActivity {
+	return ""
+}
+
+// runParkedReviewMessage sends one chat message to a task parked in REVIEW on
+// stepID and returns the task as it stands once the prompt was dispatched.
+func runParkedReviewMessage(t *testing.T, stepID, moveToStepID string) *models.Task {
+	t.Helper()
+	now := time.Now().UTC()
+	repo := &reviewStepRepo{messageAddSwitchRepo: messageAddSwitchRepo{
+		tasks: map[string]*models.Task{"t1": {
+			ID: "t1", WorkspaceID: "ws1", State: v1.TaskStateReview,
+			WorkflowStepID: stepID, UpdatedAt: now,
+		}},
+		sessions: map[string]*models.TaskSession{
+			"s1": {
+				ID: "s1", TaskID: "t1", State: models.TaskSessionStateWaitingForInput,
+				AgentProfileID: "profile-1", UpdatedAt: now,
+			},
+		},
+		primaryID: "s1",
+	}}
+	log, err := logger.NewLogger(logger.LoggingConfig{Level: "error", Format: "json"})
+	require.NoError(t, err)
+	svc := service.NewService(service.Repos{
+		Tasks: repo, TaskRepos: repo, Messages: repo, Turns: repo, Sessions: repo,
+	}, nil, log, service.RepositoryDiscoveryConfig{})
+	orch := &reviewStepOrchestrator{repo: repo, moveToStepID: moveToStepID, prompted: make(chan struct{})}
+	h := NewMessageHandlers(svc, orch, log)
+
+	req, err := ws.NewRequest("req-review", ws.ActionMessageAdd, map[string]any{
+		"task_id": "t1", "session_id": "s1", "content": "another round please",
+	})
+	require.NoError(t, err)
+	resp, err := h.wsAddMessage(context.Background(), req)
+	require.NoError(t, err)
+	require.Equal(t, ws.MessageTypeResponse, resp.Type)
+
+	select {
+	case <-orch.prompted:
+	case <-time.After(time.Second):
+		t.Fatal("message was not dispatched to the agent")
+	}
+	return repo.tasks["t1"]
+}
+
+func TestWSAddMessage_ParkedReviewStepWithoutMoveKeepsReviewState(t *testing.T) {
+	task := runParkedReviewMessage(t, "step-review", "")
+	assert.Equal(t, "step-review", task.WorkflowStepID)
+	assert.Equal(t, v1.TaskStateReview, task.State,
+		"state must not drift to IN_PROGRESS while the task stays parked on the review step")
+}
+
+func TestWSAddMessage_ParkedReviewStepMoveReactivatesTask(t *testing.T) {
+	task := runParkedReviewMessage(t, "step-review", "step-in-progress")
+	assert.Equal(t, "step-in-progress", task.WorkflowStepID)
+	assert.Equal(t, v1.TaskStateInProgress, task.State)
+}
+
+func TestWSAddMessage_ParkedReviewTaskWithoutWorkflowStepReactivates(t *testing.T) {
+	task := runParkedReviewMessage(t, "", "")
+	assert.Equal(t, v1.TaskStateInProgress, task.State)
+}

--- a/apps/backend/internal/task/handlers/message_handlers_review_step_test.go
+++ b/apps/backend/internal/task/handlers/message_handlers_review_step_test.go
@@ -82,11 +82,16 @@ func (*reviewStepOrchestrator) ForegroundActivity(string) v1.ForegroundActivity 
 // stepID and returns the task as it stands once the prompt was dispatched.
 func runParkedReviewMessage(t *testing.T, stepID, moveToStepID string) *models.Task {
 	t.Helper()
+	return runParkedReviewMessageForTask(t, stepID, moveToStepID, false)
+}
+
+func runParkedReviewMessageForTask(t *testing.T, stepID, moveToStepID string, isFromOffice bool) *models.Task {
+	t.Helper()
 	now := time.Now().UTC()
 	repo := &reviewStepRepo{messageAddSwitchRepo: messageAddSwitchRepo{
 		tasks: map[string]*models.Task{"t1": {
 			ID: "t1", WorkspaceID: "ws1", State: v1.TaskStateReview,
-			WorkflowStepID: stepID, UpdatedAt: now,
+			WorkflowStepID: stepID, IsFromOffice: isFromOffice, UpdatedAt: now,
 		}},
 		sessions: map[string]*models.TaskSession{
 			"s1": {
@@ -136,4 +141,13 @@ func TestWSAddMessage_ParkedReviewStepMoveReactivatesTask(t *testing.T) {
 func TestWSAddMessage_ParkedReviewTaskWithoutWorkflowStepReactivates(t *testing.T) {
 	task := runParkedReviewMessage(t, "", "")
 	assert.Equal(t, v1.TaskStateInProgress, task.State)
+}
+
+// Office task state belongs to the office runtime, which never writes
+// IN_PROGRESS (reconcileTaskStateForRuntimeLocked skips it), and the MCP
+// message_task path already refuses the same transition.
+func TestWSAddMessage_ParkedReviewOfficeTaskIsNotReactivated(t *testing.T) {
+	task := runParkedReviewMessageForTask(t, "step-review", "step-in-progress", true)
+	assert.Equal(t, "step-in-progress", task.WorkflowStepID)
+	assert.Equal(t, v1.TaskStateReview, task.State)
 }

--- a/apps/backend/internal/task/service/service_workflow.go
+++ b/apps/backend/internal/task/service/service_workflow.go
@@ -162,10 +162,11 @@ func (s *Service) resolveApprovalNextStep(ctx context.Context, step *wfmodels.Wo
 // task.state_changed event.
 //
 // It does NOT move the task on the board: `workflow_step_id` owns the Kanban
-// column and the workflow stepper, and only MoveTask (or a workflow step
-// transition) changes it. Callers that reactivate a task parked on a step must
-// reconcile the step themselves rather than assume a state write follows the
-// board — see issue #2063.
+// column and the workflow stepper, and this method never writes it. The board
+// changes through MoveTask, a workflow step transition, or UpdateTask when the
+// request carries a WorkflowStepID. Callers that reactivate a task parked on a
+// step must reconcile the step themselves rather than assume a state write
+// follows the board — see issue #2063.
 func (s *Service) UpdateTaskState(ctx context.Context, id string, state v1.TaskState) (*models.Task, error) {
 	task, err := s.tasks.GetTask(ctx, id)
 	if err != nil {

--- a/apps/backend/internal/task/service/service_workflow.go
+++ b/apps/backend/internal/task/service/service_workflow.go
@@ -158,8 +158,14 @@ func (s *Service) resolveApprovalNextStep(ctx context.Context, step *wfmodels.Wo
 	return newStepID
 }
 
-// UpdateTaskState updates the state of a task, moves it to the matching column,
-// and publishes a task.state_changed event
+// UpdateTaskState updates the state of a task and publishes a
+// task.state_changed event.
+//
+// It does NOT move the task on the board: `workflow_step_id` owns the Kanban
+// column and the workflow stepper, and only MoveTask (or a workflow step
+// transition) changes it. Callers that reactivate a task parked on a step must
+// reconcile the step themselves rather than assume a state write follows the
+// board — see issue #2063.
 func (s *Service) UpdateTaskState(ctx context.Context, id string, state v1.TaskState) (*models.Task, error) {
 	task, err := s.tasks.GetTask(ctx, id)
 	if err != nil {

--- a/docs/public/workflow-tips.md
+++ b/docs/public/workflow-tips.md
@@ -124,7 +124,7 @@ The portable format also recognizes `set_session_mode`, `clear_decisions`, `queu
 
 Keep one transition action per event. A “next” action on the last step or “previous” on the first has nowhere to go and leaves the task in place. WIP rejection, a missing target step, a failed agent launch, or missing credentials can also prevent the intended progression; inspect the task/session error and backend logs before changing the workflow.
 
-Messaging a task that is waiting in review only sends it back to work when the step it sits on says so. Give a review step an `on_turn_start` “move previous” (or “move to step”) action if you want a new message to return the task to the working step — that is what the built-in Kanban and Architecture workflows do. Without such an action the task stays in its column and keeps its Review status until the agent actually starts the turn, so the board and the task status never disagree.
+Messaging a task that is waiting in review only sends it back to work when the step it sits on says so. Give a review step an `on_turn_start` “move previous” (or “move to step”) action if you want a new message to return the task to the working step — that is what the built-in Kanban and Architecture workflows do. Without such an action, delivering the message leaves the task in its column and in Review; the status changes only once its agent actually starts the turn. Either way Kandev never marks a task In Progress just because a message arrived, so the column and the status cannot drift apart while the task sits idle.
 
 ## Safe authoring pattern
 

--- a/docs/public/workflow-tips.md
+++ b/docs/public/workflow-tips.md
@@ -124,6 +124,8 @@ The portable format also recognizes `set_session_mode`, `clear_decisions`, `queu
 
 Keep one transition action per event. A “next” action on the last step or “previous” on the first has nowhere to go and leaves the task in place. WIP rejection, a missing target step, a failed agent launch, or missing credentials can also prevent the intended progression; inspect the task/session error and backend logs before changing the workflow.
 
+Messaging a task that is waiting in review only sends it back to work when the step it sits on says so. Give a review step an `on_turn_start` “move previous” (or “move to step”) action if you want a new message to return the task to the working step — that is what the built-in Kanban and Architecture workflows do. Without such an action the task stays in its column and keeps its Review status until the agent actually starts the turn, so the board and the task status never disagree.
+
 ## Safe authoring pattern
 
 1. Start with manual transitions and verify prompts in a disposable task.


### PR DESCRIPTION
Fixes #2063

## Problem

A task parked on a **Review** step got `task.state` flipped `REVIEW → IN_PROGRESS` when a message arrived (task chat or MCP `message_task`), while `task.workflow_step_id` stayed on the Review step. Nothing reconciled the two, so the Kanban column and workflow stepper kept showing **Review** while the task chip and MCP `list_tasks` / `list_related_tasks` reported `IN_PROGRESS` — permanently.

## Which field is authoritative

The issue asked for a maintainer decision. Evidence from the code says **the workflow step owns the board**:

- Kanban columns filter strictly on `workflowStepId` (`apps/web/components/kanban/*`), as does the stepper.
- `syncTaskStateForWorkflowMove` derives *state from step moves*; there is no step-from-state derivation anywhere.
- `on_turn_start` transitions are the declared mechanism for "a new message reactivates this task". The built-in **Kanban** and **Architecture** review steps use `on_turn_start: move_to_previous` for exactly this.
- A review step is also allowed to *keep* the task and run an agent on it — the built-in **PR Review** workflow's Review step has `on_enter: auto_start_agent` and no `on_turn_start`. So unconditionally moving tasks off review steps would break that workflow, and unconditionally flipping state contradicts the board in the others.

## Fix

Both message paths snapshot the review parking (state + step) before `on_turn_start` and only transition `REVIEW → IN_PROGRESS` once the workflow actually released the task from the step it was parked on:

- `internal/task/handlers/message_handlers.go` — `ensureTaskInProgress` → `reviewParkingBeforeTurnStart` + `reactivateTaskAfterTurnStart`, run after `ProcessOnTurnStart` and after the blocked-session gate.
- `internal/mcp/handlers/handlers.go` — `ensureTaskInProgressForTaskMessage` → `snapshotTaskForTaskMessage` (snapshot only) + `reactivateTaskAfterTaskMessageTurnStart`, run after a **successful** dispatch. A failed dispatch or a coordinator stop mid-flight therefore no longer leaves an unearned `IN_PROGRESS` behind. The office-task guard is preserved.

A step that keeps the task keeps `REVIEW`; the runtime's own reconciler sets `IN_PROGRESS` if and when the agent actually starts working. Tasks with no workflow step (quick chat / ephemeral) keep the immediate reactivation — there is no board to contradict.

Also corrects the `UpdateTaskState` doc comment, which claimed it "moves it to the matching column"; it never has.

## Tests

New regression coverage for both entry points (each fails on `main` with `IN_PROGRESS` where `REVIEW` is expected):

- `internal/mcp/handlers/message_task_review_step_test.go`
- `internal/task/handlers/message_handlers_review_step_test.go`

Each covers three shapes: review step with no `on_turn_start` move (stays `REVIEW`), review step that moves (reactivates to `IN_PROGRESS` on the new step), and no workflow step (reactivates).

Three existing tests encoded the old drift and were updated: `WaitingForInput_FiresTurnStart`, `KanbanRunnerTransitionsReviewToInProgress` (now moves the step like a real Kanban review step), and the two rollback tests that asserted a `task.state_changed` restore event — with no flip there is no state change to restore, and the step revert still publishes `task.updated`.

## Verification

- `make -C apps/backend lint` — 0 issues; `golangci-lint run ./... --new-from-rev=<base>` — 0 issues.
- `make -C apps/backend test` — `internal/mcp/handlers` and the message-handler tests pass. Pre-existing worktree-sandbox failures remain in `internal/task/{handlers,service}` (local-repository / directory creation), `agentctl/server/process`, `gitlab`, `notifications/service` — all unrelated to this change.
- Public docs: added a note to `docs/public/workflow-tips.md` explaining that a review step needs an `on_turn_start` move to send a messaged task back to work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2070?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->