### PR TITLE
fix(acp): strip multi-line command echoes in workDir-resolved output

### DIFF
--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/shell_output.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/shell_output.go
@@ -85,24 +85,28 @@ func stripCommandEcho(command, workDir, stdout string, commitExactMatch bool) st
 // that resolve a relative file-path argument in the command to an absolute
 // (workDir-joined) one before actually invoking the real terminal, while the
 // tool call's reported "command" field - the same text the chat header
-// renders - keeps the original relative form. The captured echo line then no
-// longer matches literally. Retry against just the first echoed line with
-// the workDir prefix collapsed back out, so real output later in stdout
-// (which may legitimately contain workDir-prefixed paths of its own) is
-// never touched.
+// renders - keeps the original relative form. The captured echo then no
+// longer matches literally. Retry against exactly as many leading echoed
+// lines as the command itself spans - a command can carry an embedded
+// newline (e.g. a multi-line script or commit message passed as a single
+// tool-call argument), and a real terminal echoes that verbatim across
+// multiple lines, not just the first - with the workDir prefix collapsed
+// back out, so real output later in stdout (which may legitimately contain
+// workDir-prefixed paths of its own) is never touched.
 func stripCommandEchoWithWorkDir(command, workDir, stdout string, commitExactMatch bool) string {
 	if workDir == "" {
 		return stdout
 	}
+	echoLines := strings.Count(command, "\n") + 1
+	chunk, remainder, hasMore := cutLines(stdout, echoLines)
 	// workDir's trailing slashes are collapsed to exactly one first: a
 	// provider can report cwd already "/"-terminated (e.g. "/repo/"), and
 	// the root directory "/" is inherently "/"-terminated. Appending "/"
 	// unconditionally would search for a doubled separator ("/repo//" or
 	// "//") that the actually-joined path never contains, silently
 	// declining to strip a real echo.
-	firstLine, remainder, hasMore := cutFirstLine(stdout)
 	workDirPrefix := strings.TrimRight(workDir, "/") + "/"
-	if strings.ReplaceAll(firstLine, workDirPrefix, "") != "$ "+command {
+	if strings.ReplaceAll(chunk, workDirPrefix, "") != "$ "+command {
 		return stdout
 	}
 	if !hasMore {
@@ -124,14 +128,24 @@ func finishCommandEchoStrip(rest, stdout string, commitExactMatch bool) string {
 	return strings.TrimPrefix(rest, "\n")
 }
 
-// cutFirstLine splits s at its first newline, reporting whether one was
-// found. The returned line excludes both the newline and any preceding "\r".
-func cutFirstLine(s string) (line, remainder string, hasMore bool) {
-	idx := strings.IndexByte(s, '\n')
-	if idx < 0 {
-		return s, "", false
+// cutLines splits s at its Nth newline (n >= 1), reporting whether that many
+// newlines were found. The returned chunk joins the first n lines with "\n"
+// (matching how a multi-line command's literal newlines read back once
+// echoed), stripping any "\r" that precedes each newline within it. When s
+// contains fewer than n newlines, chunk is the whole of s and hasMore is
+// false - the echo (or its trailing lines) may still be in flight.
+func cutLines(s string, n int) (chunk, remainder string, hasMore bool) {
+	rest := s
+	for i := 0; i < n; i++ {
+		idx := strings.IndexByte(rest, '\n')
+		if idx < 0 {
+			return s, "", false
+		}
+		rest = rest[idx+1:]
 	}
-	return strings.TrimSuffix(s[:idx], "\r"), s[idx+1:], true
+	chunk = strings.TrimSuffix(s[:len(s)-len(rest)-1], "\r")
+	chunk = strings.ReplaceAll(chunk, "\r\n", "\n")
+	return chunk, rest, true
 }
 
 // NormalizeShellToolUpdate merges live and final ACP shell result fields into

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/shell_output_test.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/shell_output_test.go
@@ -551,6 +551,33 @@ func TestNormalizeShellToolResultStripsLeadingCommandEchoWithRootWorkDir(t *test
 	require.Equal(t, "hello\n", payload.ShellExec().Output.Stdout)
 }
 
+// TestNormalizeShellToolResultStripsLeadingCommandEchoWithWorkDirResolvedPathMultilineCommand
+// is a regression for a report that PR #1975's workDir fallback still
+// leaves the echo in the output: the fallback only ever compared stdout's
+// FIRST line against "$ "+command (see cutLines). A command that itself
+// contains an embedded newline (e.g. a multi-line script or commit message
+// passed as a single tool-call argument) is echoed across as many lines as
+// it spans, not just one, so a single-line comparison can never match and
+// the entire multi-line echo (with the resolved absolute path) leaks into
+// the persisted Output.
+func TestNormalizeShellToolResultStripsLeadingCommandEchoWithWorkDirResolvedPathMultilineCommand(t *testing.T) {
+	t.Parallel()
+
+	command := "echo start\ncat notes.txt"
+	workDir := "/repo"
+	resolvedCommand := "echo start\ncat /repo/notes.txt"
+
+	normalizer := NewNormalizer("")
+	payload := normalizer.NormalizeToolCall("execute", map[string]any{
+		"kind":      "execute",
+		"raw_input": map[string]any{"command": command, "cwd": workDir},
+	})
+
+	normalizer.NormalizeToolResult(payload, "$ "+resolvedCommand+"\nstart\nhello\n")
+
+	require.Equal(t, "start\nhello\n", payload.ShellExec().Output.Stdout)
+}
+
 func TestNormalizeShellToolUpdateStripsLeadingCommandEchoFromLiveOutput(t *testing.T) {
 	t.Parallel()
 

--- a/apps/web/e2e/tests/chat/shell-output-echo.spec.ts
+++ b/apps/web/e2e/tests/chat/shell-output-echo.spec.ts
@@ -117,4 +117,68 @@ test.describe("shell command output echo stripping", () => {
     await expect(outputRegion).not.toContainText(cwd);
     await expect(outputRegion).not.toContainText(resolvedCommand);
   });
+
+  test("does not repeat a multi-line workDir-resolved echo inside the expanded Output disclosure", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    // Regression for a report that the workDir-resolved-path fix above
+    // still leaked the echo: a command that itself carries an embedded
+    // newline (a multi-line script or commit message passed as a single
+    // tool-call argument) is echoed by the real terminal across as many
+    // lines as it spans, not just the first.
+    const command = "echo start\ncat notes.txt";
+    const cwd = "/workspace/example-repo";
+    const resolvedCommand = `echo start\ncat ${cwd}/notes.txt`;
+    const echoedOutput = `$ ${resolvedCommand}\nstart\nhello\n`;
+
+    const script = [
+      `e2e:shell_result("${command.replace(/\n/g, "\\n")}", "${echoedOutput.replace(/\n/g, "\\n")}", "${cwd}")`,
+      'e2e:message("done")',
+    ].join("\n");
+
+    const task = await apiClient.createTaskWithAgent(
+      seedData.workspaceId,
+      "Shell echo multiline workDir regression",
+      seedData.agentProfileId,
+      {
+        description: script,
+        workflow_id: seedData.workflowId,
+        workflow_step_id: seedData.startStepId,
+        repository_ids: [seedData.repositoryId],
+      },
+    );
+
+    await testPage.goto(`/t/${task.id}`);
+    const session = new SessionPage(testPage);
+    await session.waitForLoad();
+    await session.waitForChatIdle({ timeout: 30_000 });
+
+    const chat = session.activeChat();
+    const commandRow = chat.getByTestId("tool-execute-command").filter({ hasText: "echo start" });
+    await expect(commandRow).toBeVisible();
+    await expect(commandRow).toHaveText(command);
+
+    const disclosure = chat.getByRole("button", { name: "Show command output" });
+    const responsePromise = testPage.waitForResponse(
+      (response) => response.url().endsWith("/shell-output") && response.status() === 200,
+    );
+    await disclosure.click();
+    await responsePromise;
+
+    const outputRegion = chat.getByTestId("tool-execute-output");
+    await expect(outputRegion).toContainText("hello");
+    // Critical: neither the workDir-prefixed absolute path nor a repeat of
+    // the resolved multi-line command may leak into the Output disclosure.
+    await expect(outputRegion).not.toContainText(cwd);
+    await expect(outputRegion).not.toContainText("cat /workspace");
+
+    // Visual evidence: the Output disclosure shows only "start\nhello",
+    // never the "$ echo start" / "cat /workspace/..." echo lines.
+    await testPage.screenshot({
+      path: "test-results/screenshots/shell-output-multiline-workdir-echo-fixed.png",
+      fullPage: true,
+    });
+  });
 });

--- a/apps/web/e2e/tests/chat/shell-output-echo.spec.ts
+++ b/apps/web/e2e/tests/chat/shell-output-echo.spec.ts
@@ -122,7 +122,7 @@ test.describe("shell command output echo stripping", () => {
     testPage,
     apiClient,
     seedData,
-  }) => {
+  }, testInfo) => {
     // Regression for a report that the workDir-resolved-path fix above
     // still leaked the echo: a command that itself carries an embedded
     // newline (a multi-line script or commit message passed as a single
@@ -177,7 +177,7 @@ test.describe("shell command output echo stripping", () => {
     // Visual evidence: the Output disclosure shows only "start\nhello",
     // never the "$ echo start" / "cat /workspace/..." echo lines.
     await testPage.screenshot({
-      path: "test-results/screenshots/shell-output-multiline-workdir-echo-fixed.png",
+      path: testInfo.outputPath("shell-output-multiline-workdir-echo-fixed.png"),
       fullPage: true,
     });
   });

--- a/apps/web/e2e/tests/chat/shell-output-echo.spec.ts
+++ b/apps/web/e2e/tests/chat/shell-output-echo.spec.ts
@@ -168,6 +168,7 @@ test.describe("shell command output echo stripping", () => {
     await responsePromise;
 
     const outputRegion = chat.getByTestId("tool-execute-output");
+    await expect(outputRegion).toContainText("start");
     await expect(outputRegion).toContainText("hello");
     // Critical: neither the workDir-prefixed absolute path nor a repeat of
     // the resolved multi-line command may leak into the Output disclosure.


### PR DESCRIPTION
PR #1975's workDir-resolved-path echo fix only ever compared the first line of captured shell output against the tool call's command, so any command carrying an embedded newline (a multi-line script or commit message passed as a single tool-call argument) still leaked its terminal echo into the chat's Output disclosure exactly like the original report.

## Validation

- `go test ./internal/agentctl/server/adapter/transport/acp/...` — new regression (`TestNormalizeShellToolResultStripsLeadingCommandEchoWithWorkDirResolvedPathMultilineCommand`) fails before the fix (leaks `$ echo start\ncat /repo/notes.txt\n...`) and passes after; full existing suite (pending/commit variants, trailing-slash/root workDir, near-miss corruption guard) stays green.
- `go build ./...`, `gofmt`, `go vet ./internal/agentctl/server/adapter/transport/acp/...` — clean.
- `golangci-lint run ./internal/agentctl/server/adapter/transport/acp/...` — 0 issues.
- Added `apps/web/e2e/tests/chat/shell-output-echo.spec.ts` coverage that drives the mock-agent through the real ACP pipeline (backend + frontend + WS + `/shell-output` API) with a multi-line, workDir-resolved command, expands "Show command output" in the browser, and asserts the echo is absent. Ran via `pnpm e2e:run --no-build -- tests/chat/shell-output-echo.spec.ts` against a production build (`make build-backend build-web`) — 3/3 pass (one unrelated pre-existing test flaked once under worker contention and passed on retry).
- `make -C apps/backend test` (full suite) — pre-existing, unrelated failures in `internal/task/service`/`internal/task/repository` (`t.TempDir()`-based fixtures reporting "parent directory cannot be accessed" in this sandbox); confirmed unrelated by inspecting the failing tests, which have no dependency on the ACP shell normalizer.

## Possible Improvements

Low risk: the fix only widens how many leading lines the workDir fallback compares (`cutLines`, replacing the old always-one-line `cutFirstLine`); single-line commands are unaffected and every existing echo-stripping regression still passes.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- kandev-screenshots-start -->
## Screenshots

![Command header keeps the multi-line relative command; expanded Output disclosure shows only "start\nhello", no echo](https://raw.githubusercontent.com/ClemDNL/kandev/ea71049c3bec091450a1091885f2a459d7230275/shell-output-multiline-echo-fixed.png)
<!-- kandev-screenshots-end -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2072?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


