### PR TITLE
fix(web): hide transient metrics unavailable state

### DIFF
--- a/apps/web/components/system-metrics/status-surface-metrics.test.tsx
+++ b/apps/web/components/system-metrics/status-surface-metrics.test.tsx
@@ -9,6 +9,7 @@ import { StatusSurfaceMetrics } from "./status-surface-metrics";
 
 const responsiveState = vi.hoisted(() => ({ isMobile: false }));
 const subscribeMock = vi.hoisted(() => vi.fn());
+const metricsTestId = "app-status-metrics";
 
 vi.mock("@/hooks/use-responsive-breakpoint", () => ({
   useResponsiveBreakpoint: () => ({
@@ -27,7 +28,7 @@ vi.mock("@/hooks/use-system-metrics-subscription", () => ({
   useSystemMetricsSubscription: subscribeMock,
 }));
 
-function renderMetrics(drawerOpen = false, simplified = false) {
+function renderMetrics(drawerOpen = false, simplified = false, loading = false) {
   return render(
     <StateProvider
       initialState={
@@ -39,56 +40,58 @@ function renderMetrics(drawerOpen = false, simplified = false) {
           },
           system: {
             ...defaultSystemState.system,
-            metrics: {
-              timestamp: "2026-06-23T10:00:00Z",
-              interval_seconds: 5,
-              sources: [
-                {
-                  id: "backend",
-                  label: "Host",
-                  kind: "backend",
-                  metrics: [
+            metrics: loading
+              ? null
+              : {
+                  timestamp: "2026-06-23T10:00:00Z",
+                  interval_seconds: 5,
+                  sources: [
                     {
-                      id: "cpu_percent",
-                      label: "CPU",
-                      unit: "%",
-                      value: 42,
-                      available: true,
+                      id: "backend",
+                      label: "Host",
+                      kind: "backend",
+                      metrics: [
+                        {
+                          id: "cpu_percent",
+                          label: "CPU",
+                          unit: "%",
+                          value: 42,
+                          available: true,
+                        },
+                        {
+                          id: "memory_percent",
+                          label: "Memory",
+                          unit: "%",
+                          value: 51,
+                          available: true,
+                        },
+                        {
+                          id: "disk_percent",
+                          label: "Disk",
+                          unit: "%",
+                          value: 63,
+                          available: true,
+                        },
+                        { id: "io_load", label: "Load average", value: 2.5, available: true },
+                      ],
                     },
                     {
-                      id: "memory_percent",
-                      label: "Memory",
-                      unit: "%",
-                      value: 51,
-                      available: true,
+                      id: "executor-session-1",
+                      label: "Demo executor",
+                      kind: "execution",
+                      session_id: "session-1",
+                      metrics: [
+                        {
+                          id: "memory_percent",
+                          label: "Memory",
+                          unit: "%",
+                          value: 99,
+                          available: true,
+                        },
+                      ],
                     },
-                    {
-                      id: "disk_percent",
-                      label: "Disk",
-                      unit: "%",
-                      value: 63,
-                      available: true,
-                    },
-                    { id: "io_load", label: "Load average", value: 2.5, available: true },
                   ],
                 },
-                {
-                  id: "executor-session-1",
-                  label: "Demo executor",
-                  kind: "execution",
-                  session_id: "session-1",
-                  metrics: [
-                    {
-                      id: "memory_percent",
-                      label: "Memory",
-                      unit: "%",
-                      value: 99,
-                      available: true,
-                    },
-                  ],
-                },
-              ],
-            },
           },
         } satisfies Partial<AppState>
       }
@@ -116,7 +119,7 @@ describe("StatusSurfaceMetrics", () => {
     renderMetrics();
 
     expect(subscribeMock).toHaveBeenCalledWith(true);
-    expect(screen.getByTestId("app-status-metrics")).toBeTruthy();
+    expect(screen.getByTestId(metricsTestId)).toBeTruthy();
     expect(screen.getByLabelText("CPU 42%")).toBeTruthy();
     expect(screen.getByLabelText("Memory 51%")).toBeTruthy();
     expect(screen.getByLabelText("Disk 63%")).toBeTruthy();
@@ -133,12 +136,20 @@ describe("StatusSurfaceMetrics", () => {
     expect(screen.queryByLabelText("Memory 99%")).toBeNull();
   });
 
+  it("keeps the desktop metrics item hidden while the first snapshot is loading", () => {
+    renderMetrics(false, false, true);
+
+    expect(subscribeMock).toHaveBeenCalledWith(true);
+    expect(screen.queryByTestId(metricsTestId)).toBeNull();
+    expect(screen.queryByText("Metrics unavailable")).toBeNull();
+  });
+
   it("does not subscribe or render while the phone Status drawer is closed", () => {
     responsiveState.isMobile = true;
     renderMetrics(false);
 
     expect(subscribeMock).toHaveBeenCalledWith(false);
-    expect(screen.queryByTestId("app-status-metrics")).toBeNull();
+    expect(screen.queryByTestId(metricsTestId)).toBeNull();
   });
 
   it("subscribes and renders rows when the phone Status drawer opens", () => {
@@ -150,6 +161,15 @@ describe("StatusSurfaceMetrics", () => {
     expect(metricsRow?.className).toContain("min-h-11");
     expect(metricsRow?.className).toContain("w-full");
     expect(metricsRow?.className).toContain("min-w-0");
+  });
+
+  it("keeps the phone metrics row hidden while the first snapshot is loading", () => {
+    responsiveState.isMobile = true;
+    renderMetrics(true, false, true);
+
+    expect(subscribeMock).toHaveBeenCalledWith(true);
+    expect(screen.queryByTestId(metricsTestId)).toBeNull();
+    expect(screen.queryByText("Metrics unavailable")).toBeNull();
   });
 
   it("omits the host marker and meters in simplified desktop mode", () => {

--- a/apps/web/components/system-metrics/status-surface-metrics.tsx
+++ b/apps/web/components/system-metrics/status-surface-metrics.tsx
@@ -36,8 +36,9 @@ export function StatusSurfaceMetrics({
   useSystemMetricsSubscription(shouldSubscribe);
 
   if (!enabled || (isMobile && !drawerOpen)) return null;
+  if (!snapshot) return null;
 
-  const host = snapshot?.sources.find((source) => source.kind === "backend");
+  const host = snapshot.sources.find((source) => source.kind === "backend");
   if (presentation === "mobile-drawer") {
     return (
       <section

--- a/apps/web/e2e/tests/settings/metrics-loading-observer.ts
+++ b/apps/web/e2e/tests/settings/metrics-loading-observer.ts
@@ -1,0 +1,26 @@
+import type { Page } from "@playwright/test";
+
+type MetricsObserverWindow = Window & { __metricsUnavailableSeen?: boolean };
+
+export async function observeMetricsUnavailable(page: Page) {
+  await page.addInitScript(() => {
+    const observedWindow = window as MetricsObserverWindow;
+    observedWindow.__metricsUnavailableSeen = false;
+    const observer = new MutationObserver((mutations) => {
+      if (
+        mutations.some((mutation) =>
+          Array.from(mutation.addedNodes).some((node) =>
+            node.textContent?.includes("Metrics unavailable"),
+          ),
+        )
+      ) {
+        observedWindow.__metricsUnavailableSeen = true;
+      }
+    });
+    observer.observe(document, { childList: true, subtree: true });
+  });
+}
+
+export async function metricsUnavailableWasRendered(page: Page) {
+  return page.evaluate(() => (window as MetricsObserverWindow).__metricsUnavailableSeen ?? false);
+}

--- a/apps/web/e2e/tests/settings/mobile-resource-metrics-display.spec.ts
+++ b/apps/web/e2e/tests/settings/mobile-resource-metrics-display.spec.ts
@@ -1,4 +1,8 @@
 import { expect, test } from "../../fixtures/test-base";
+import {
+  metricsUnavailableWasRendered,
+  observeMetricsUnavailable,
+} from "./metrics-loading-observer";
 
 type SystemMetricsDisplay = {
   show_in_topbar: boolean;
@@ -39,6 +43,7 @@ test.describe("Mobile resource metrics display", () => {
     await testPage.reload();
     await expect(simplified).toHaveAttribute("aria-checked", "true");
 
+    await observeMetricsUnavailable(testPage);
     await testPage.goto("/");
     await testPage.getByRole("button", { name: "Open menu" }).click();
     await testPage.getByTestId("mobile-home-status-button").click();
@@ -46,6 +51,7 @@ test.describe("Mobile resource metrics display", () => {
     const drawer = testPage.getByTestId("app-status-drawer");
     const metrics = drawer.getByTestId("app-status-metrics");
     await expect(metrics.getByLabel(/^CPU /)).toBeVisible();
+    expect(await metricsUnavailableWasRendered(testPage)).toBe(false);
     await expect(metrics.getByLabel("Host metrics")).toHaveCount(0);
     await expect(metrics.getByTestId("system-metric-meter")).toHaveCount(0);
 

--- a/apps/web/e2e/tests/settings/resource-metrics-display.spec.ts
+++ b/apps/web/e2e/tests/settings/resource-metrics-display.spec.ts
@@ -1,4 +1,8 @@
 import { expect, test } from "../../fixtures/test-base";
+import {
+  metricsUnavailableWasRendered,
+  observeMetricsUnavailable,
+} from "./metrics-loading-observer";
 
 type SystemMetricsDisplay = {
   show_in_topbar: boolean;
@@ -30,8 +34,11 @@ test.describe("Resource metrics display", () => {
     const floatingSave = testPage.getByTestId("settings-floating-save");
     await floatingSave.getByRole("button", { name: "Save changes" }).click();
     await expect(floatingSave).not.toBeVisible();
+    await observeMetricsUnavailable(testPage);
     await testPage.reload();
     await expect(simplified).toHaveAttribute("aria-checked", "true");
+    await expect(testPage.getByTestId("app-status-metrics").getByLabel(/^CPU /)).toBeVisible();
+    expect(await metricsUnavailableWasRendered(testPage)).toBe(false);
 
     await testPage.goto("/");
 

--- a/docs/plans/metrics-loading-state/plan.md
+++ b/docs/plans/metrics-loading-state/plan.md
@@ -1,0 +1,66 @@
+---
+spec: docs/specs/ui/app-status-bar.md
+created: 2026-07-30
+status: complete
+---
+
+# Implementation Plan: Metrics Loading State
+
+## Overview
+
+Separate the initial WebSocket loading state from a received snapshot that lacks the Kandev host source. The status surface will stay subscribed but render no metrics item until the first snapshot arrives, then preserve the existing desktop, tablet, and phone presentations and genuine unavailable-sample behavior.
+
+## Confirmed root cause
+
+`defaultSystemState.system.metrics` starts as `null`. `StatusSurfaceMetrics` mounts, starts `useSystemMetricsSubscription`, and immediately maps the missing host source from that null snapshot to `EmptyMetrics`, so every reload briefly claims that metrics are unavailable before `system.metrics.updated` stores the first real snapshot. The backend already publishes the first snapshot through the normal subscription path, and real collection failures arrive as metric samples with `available: false`; no backend, WebSocket, or store contract change is needed.
+
+## Frontend
+
+### Status surface loading gate
+
+- In `apps/web/components/system-metrics/status-surface-metrics.tsx`, keep the subscription hook ahead of all render exits.
+- Return no metrics content when `snapshot` is `null`, allowing the existing `empty:hidden` status-item wrappers to collapse during initial loading.
+- Continue to use `EmptyMetrics` only when a non-null snapshot lacks a backend host source. Preserve all received metric formatting, degraded samples, tooltips, source filtering, and responsive behavior.
+
+### Mobile design contract
+
+- Affected surfaces are the tablet/desktop app status bar and the phone Status drawer's initial metrics state.
+- The nearest shipped phone exemplar remains `AppStatusDrawer` with its existing inset drawer, single internal scroll owner, safe-area handling, and 44 px rows.
+- This repair adds no navigation, action, overlay, scroll, or touch change. On first open, the metrics row is absent until data arrives; the existing row appears in its saved order once ready.
+- Desktop and mobile share the same snapshot state, subscription hook, source selection, and loading gate. Presentation-specific markup remains unchanged.
+
+## Tests
+
+- **What:** A null initial snapshot subscribes normally but renders neither the metrics surface nor “Metrics unavailable” on desktop and phone; a received host snapshot still renders values.
+- **File:** `apps/web/components/system-metrics/status-surface-metrics.test.tsx`
+- **How:** Extend the existing component harness to render `system.metrics: null`, assert the subscription gate remains enabled, and cover both bar and open-drawer presentations before retaining the current ready-state assertions.
+
+## E2E Tests
+
+- **Scenario:** GIVEN metrics are enabled, WHEN a desktop page reloads before its first metrics snapshot, THEN no transient unavailable copy is ever inserted and host values eventually appear.
+- **File:** `apps/web/e2e/tests/settings/resource-metrics-display.spec.ts`
+- **What to verify:** Install a pre-navigation mutation observer, reload the production SPA, wait for CPU metrics, and assert the observer never saw “Metrics unavailable.”
+- **Scenario:** GIVEN metrics are enabled and the phone Status drawer has not subscribed yet, WHEN the user opens Status, THEN no transient unavailable copy is inserted and host values eventually appear in the existing touch-sized row.
+- **File:** `apps/web/e2e/tests/settings/mobile-resource-metrics-display.spec.ts`
+- **What to verify:** Observe the drawer's first-subscription render, wait for CPU metrics, assert no unavailable copy was seen, and retain existing containment, scrolling, and row-height checks.
+
+## Implementation Waves And Parallel Candidates
+
+Wave 1:
+
+- [x] [Task 01: Hide initial metrics loading state](task-01-hide-initial-metrics-loading-state.md) — complete
+
+No task is marked parallel-safe because the production change and both regression levels exercise one shared loading-state behavior.
+
+## Risks and out of scope
+
+- The loading gate must not run before `useSystemMetricsSubscription`, or the missing snapshot would prevent the request that resolves it.
+- A non-null snapshot without a backend host source and per-metric collection errors remain distinguishable genuine unavailable states.
+- No sampler timing, WebSocket protocol, Zustand shape, fallback request, skeleton, reserved-width placeholder, or status-item ordering change is included.
+- Public operations documentation remains accurate because its unavailable guidance describes received platform/sample failures, not the initial client loading state.
+
+## Verification results
+
+- `cd apps && pnpm --filter @kandev/web test -- components/system-metrics/status-surface-metrics.test.tsx` — passed (7 tests).
+- `cd apps/web && pnpm e2e:run tests/settings/resource-metrics-display.spec.ts` — passed in Chromium against a fresh production build.
+- `cd apps/web && pnpm e2e:run --no-build tests/settings/mobile-resource-metrics-display.spec.ts -- --project=mobile-chrome` — passed in the Pixel 5 mobile project against that build.

--- a/docs/plans/metrics-loading-state/task-01-hide-initial-metrics-loading-state.md
+++ b/docs/plans/metrics-loading-state/task-01-hide-initial-metrics-loading-state.md
@@ -1,0 +1,59 @@
+---
+id: "01-hide-initial-metrics-loading-state"
+title: "Hide initial metrics loading state"
+status: done
+wave: 1
+depends_on: []
+plan: "plan.md"
+spec: "../../specs/ui/app-status-bar.md"
+---
+
+# Task 01: Hide initial metrics loading state
+
+## Inputs
+
+- [App status bar failure modes](../../specs/ui/app-status-bar.md#failure-modes)
+- [App status bar scenarios](../../specs/ui/app-status-bar.md#scenarios)
+- [Metrics loading-state plan](plan.md)
+- Existing subscription and responsive rendering in `apps/web/components/system-metrics/status-surface-metrics.tsx`
+
+## Acceptance
+
+1. With metrics display enabled and `system.metrics === null`, desktop/tablet and an open phone Status drawer keep the normal WebSocket subscription active but render no metrics item or unavailable copy.
+2. After a non-null host snapshot arrives, the existing bar/drawer values, detailed or simplified presentation, and mobile row geometry remain unchanged.
+3. A non-null snapshot without a backend host source and received unavailable metric samples retain their genuine degraded presentation.
+
+## TDD sequence
+
+1. RED: extend `status-surface-metrics.test.tsx` with null-snapshot desktop and open-phone cases; confirm they fail because “Metrics unavailable” is rendered.
+2. RED: instrument the existing desktop and mobile resource-metrics E2E flows before reload/first drawer open; confirm the observer records the transient unavailable copy.
+3. GREEN: add the minimal post-subscription null-snapshot render gate in `StatusSurfaceMetrics`.
+4. REFACTOR: remove no-longer-needed loading-only markup only if it is unreachable for every received-snapshot failure case; otherwise keep `EmptyMetrics` for genuine missing-host snapshots.
+
+## Files likely touched
+
+- `apps/web/components/system-metrics/status-surface-metrics.tsx`
+- `apps/web/components/system-metrics/status-surface-metrics.test.tsx`
+- `apps/web/e2e/tests/settings/resource-metrics-display.spec.ts`
+- `apps/web/e2e/tests/settings/mobile-resource-metrics-display.spec.ts`
+
+## Dependencies
+
+None.
+
+## Parallelism
+
+`sequential`. The unit/component and E2E regressions share the same production loading gate and must prove one Red-Green sequence.
+
+## Verification
+
+```sh
+cd apps && pnpm --filter @kandev/web test -- components/system-metrics/status-surface-metrics.test.tsx
+cd apps/web && pnpm e2e:run tests/settings/resource-metrics-display.spec.ts tests/settings/mobile-resource-metrics-display.spec.ts
+```
+
+The managed E2E runner rebuilds the production Vite assets before exercising both desktop and `mobile-chrome` coverage.
+
+## Output contract
+
+Completed with the expected RED failures for null-snapshot desktop and phone rendering plus browser-observed transient unavailable copy. The final targeted component, Chromium, and mobile-chrome checks pass; no blockers remain.

--- a/docs/specs/ui/app-status-bar.md
+++ b/docs/specs/ui/app-status-bar.md
@@ -82,7 +82,8 @@ The only public API addition is `registerComponent("app-status-bar-left" | "app-
 
 ## Failure modes
 
-- Missing metrics snapshot renders a recognizable unavailable/loading state; it does not create a fallback fetch or provider.
+- Before the first metrics snapshot arrives, the metrics item remains hidden while its normal WebSocket subscription stays active; loading is not presented as an availability failure and does not create a fallback fetch or provider.
+- A received snapshot without the Kandev host source renders the recognizable unavailable state. Unavailable metric samples keep their existing per-metric degraded presentation and inspectable error detail.
 - Connection errors remain inspectable through accessible detail; reconnecting is not misrepresented as connected.
 - A failed plugin contribution is contained by its own boundary; remaining contributions and first-party state remain usable.
 - If Status drawer closes during a metrics update or breakpoint changes, the inactive presentation unmounts and releases only its own ref-counted subscription.
@@ -105,6 +106,7 @@ Visual interaction is a clean Kandev adaptation of Orca's public status-bar idea
 
 - **GIVEN** the feature is enabled on a desktop or tablet route, **WHEN** it opens, **THEN** one 24 px app status bar remains at its bottom and route/sidebar content use the remaining height without a new page scrollbar.
 - **GIVEN** metrics preference enabled, **WHEN** a desktop/tablet status bar mounts, **THEN** existing Kandev-host metrics appear there, task/session/executor metrics do not, and no route header still renders metrics.
+- **GIVEN** metrics preference enabled and no metrics snapshot has arrived yet, **WHEN** a desktop/tablet status bar mounts or a phone user opens Status, **THEN** the metrics item remains hidden without showing an unavailable message until the first snapshot arrives, while the normal metrics subscription remains active.
 - **GIVEN** the detailed metrics style or no stored style preference, **WHEN** host metrics render in a status surface, **THEN** the host marker and percentage meter bars remain visible.
 - **GIVEN** the user selects **Simplified metrics** and saves Appearance settings, **WHEN** host metrics render in the desktop/tablet status bar or pre-status-bar topbar fallback, **THEN** each enabled metric shows its icon and formatted value without a host marker or percentage meter bar, and the choice survives reload.
 - **GIVEN** the simplified metrics preference, **WHEN** a phone user opens Status, **THEN** the metrics row shows the same icon-and-value presentation without a host marker or percentage meter bar.


### PR DESCRIPTION
Refreshes briefly showed “Metrics unavailable” because the status surface rendered before its first metrics snapshot arrived. The initial loading state now stays quiet across desktop, tablet, and phone while received unavailable states remain visible, with regression coverage for each presentation.

## Validation

- `cd apps && pnpm --filter @kandev/web test -- components/system-metrics/status-surface-metrics.test.tsx` — passed (7 tests).
- `cd apps/web && pnpm e2e:run tests/settings/resource-metrics-display.spec.ts` — passed in Chromium after a fresh production build.
- `cd apps/web && pnpm e2e:run --no-build tests/settings/mobile-resource-metrics-display.spec.ts -- --project=mobile-chrome` — passed in the Pixel 5 mobile project.
- `git diff --check` — passed.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2081?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- kandev-screenshots-start -->
## Screenshots

![Desktop status bar with host metrics](https://raw.githubusercontent.com/kdlbs/kandev/4ce9de07b188a3997d5fe17befeecbe3757c4241/metrics-status-desktop.png)

![Mobile Status drawer with host metrics](https://raw.githubusercontent.com/kdlbs/kandev/4ce9de07b188a3997d5fe17befeecbe3757c4241/metrics-status-mobile.png)
<!-- kandev-screenshots-end -->