### PR TITLE
fix(agentctl): clamp file-search limit to bound result allocation

### DIFF
--- a/apps/backend/internal/agentctl/server/process/workspace_files.go
+++ b/apps/backend/internal/agentctl/server/process/workspace_files.go
@@ -876,6 +876,19 @@ type fileSearchCandidate struct {
 	repositoryName string
 }
 
+const (
+	// fileSearchDefaultLimit applies when the caller passes a non-positive limit.
+	fileSearchDefaultLimit = 20
+	// fileSearchMaxLimit caps the caller-supplied limit before it is used to
+	// pre-allocate the result slice. The limit reaches this code straight from
+	// the `limit` query parameter of GET /api/v1/workspace/search, so without a
+	// ceiling a request like `?limit=2000000000` makes the process reserve
+	// gigabytes for a result set that can never exceed the number of tracked
+	// files. Mirrors the clamp validateContentSearch already applies to
+	// content search.
+	fileSearchMaxLimit = 200
+)
+
 // GetFileContentAtRef returns the content of a file at a specific git ref (branch, commit, HEAD, etc).
 // If the file is not valid UTF-8, it is base64-encoded and isBinary is true.
 func (wt *WorkspaceTracker) GetFileContentAtRef(ctx context.Context, reqPath string, ref string) (string, int64, bool, error) {
@@ -1007,7 +1020,10 @@ func searchFileCandidates(
 		return []types.FileSearchResult{}
 	}
 	if limit <= 0 {
-		limit = 20
+		limit = fileSearchDefaultLimit
+	}
+	if limit > fileSearchMaxLimit {
+		limit = fileSearchMaxLimit
 	}
 
 	query = strings.ToLower(query)

--- a/apps/backend/internal/agentctl/server/process/workspace_files_test.go
+++ b/apps/backend/internal/agentctl/server/process/workspace_files_test.go
@@ -2,6 +2,8 @@ package process
 
 import (
 	"context"
+	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -514,6 +516,44 @@ func TestSearchFileCandidatesBreaksTiesByRepositoryRelativePathLength(t *testing
 
 	if len(results) != 2 || results[0].Path != "long-repository-name/a/query.go" {
 		t.Fatalf("search results = %#v, want shortest repo-relative path first", results)
+	}
+}
+
+// A caller-supplied limit reaches searchFileCandidates straight from the
+// `limit` query parameter, so an absurd value must not drive the result
+// slice's pre-allocation.
+func TestSearchFileCandidatesClampsCallerSuppliedLimit(t *testing.T) {
+	candidates := make([]fileSearchCandidate, 0, fileSearchMaxLimit+50)
+	for i := range fileSearchMaxLimit + 50 {
+		candidates = append(candidates, fileSearchCandidate{
+			path:      fmt.Sprintf("src/query-%d.go", i),
+			matchPath: fmt.Sprintf("src/query-%d.go", i),
+		})
+	}
+
+	results := searchFileCandidates(candidates, "query", math.MaxInt32)
+
+	if len(results) != fileSearchMaxLimit {
+		t.Fatalf("len(results) = %d, want the clamped %d", len(results), fileSearchMaxLimit)
+	}
+	if cap(results) > fileSearchMaxLimit {
+		t.Fatalf("cap(results) = %d, want no more than the clamped %d", cap(results), fileSearchMaxLimit)
+	}
+}
+
+func TestSearchFileCandidatesDefaultsNonPositiveLimit(t *testing.T) {
+	candidates := make([]fileSearchCandidate, 0, fileSearchDefaultLimit+5)
+	for i := range fileSearchDefaultLimit + 5 {
+		candidates = append(candidates, fileSearchCandidate{
+			path:      fmt.Sprintf("src/query-%d.go", i),
+			matchPath: fmt.Sprintf("src/query-%d.go", i),
+		})
+	}
+
+	results := searchFileCandidates(candidates, "query", 0)
+
+	if len(results) != fileSearchDefaultLimit {
+		t.Fatalf("len(results) = %d, want the default %d", len(results), fileSearchDefaultLimit)
 	}
 }
 

--- a/apps/backend/internal/agentctl/server/process/workspace_files_test.go
+++ b/apps/backend/internal/agentctl/server/process/workspace_files_test.go
@@ -550,10 +550,13 @@ func TestSearchFileCandidatesDefaultsNonPositiveLimit(t *testing.T) {
 		})
 	}
 
-	results := searchFileCandidates(candidates, "query", 0)
+	for _, limit := range []int{0, -1} {
+		results := searchFileCandidates(candidates, "query", limit)
 
-	if len(results) != fileSearchDefaultLimit {
-		t.Fatalf("len(results) = %d, want the default %d", len(results), fileSearchDefaultLimit)
+		if len(results) != fileSearchDefaultLimit {
+			t.Fatalf("limit %d: len(results) = %d, want the default %d",
+				limit, len(results), fileSearchDefaultLimit)
+		}
 	}
 }
 


### PR DESCRIPTION
The `limit` query parameter of `GET /api/v1/workspace/search` reached `searchFileCandidates` unbounded and was used directly as the result slice's capacity, so `?limit=2000000000` made agentctl reserve gigabytes for a result set that can never exceed the number of tracked files. It is now clamped the same way `validateContentSearch` already clamps content search, closing CodeQL alert #288 (`go/uncontrolled-allocation-size`).

## Validation

- `go test ./internal/agentctl/server/process/` — pass (includes two new tests covering the clamp and the non-positive-limit default)
- `golangci-lint run ./internal/agentctl/server/process/... --new-from-rev=origin/main` — 0 issues
- `go build ./...` — pass

The other 11 open code-scanning alerts were reviewed and dismissed as false positives; each already passes through a containment sanitizer CodeQL does not recognise (`secureDestination`/`pathInsideRoot` in `copyfiles`, `safeRefPath` in `gitref`, `containedPath` in the session seeder and log service, `cleanArchivePath`/`securejoin` in `pkgtar`). Dismissal comments on each alert record the specific chain.

## Possible Improvements

Low risk. The 200-result ceiling is well above any current caller (both entry points default to 20), but a future consumer that wants more would silently get 200.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2088?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->