### PR TITLE
feat(make): add start-windows-verbose and start-windows-debug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -293,6 +293,16 @@ start-windows:
 	@echo Starting server...
 	@"$(subst /,\,$(BACKEND_DIR)/bin/kandev.exe)" start $(if $(filter 1 true yes,$(VERBOSE)),--verbose,) $(if $(filter 1 true yes,$(DEBUG)),--debug,)
 
+# Windows-native counterparts of start-verbose / start-debug. Same cmd.exe
+# constraints as start-windows.
+.PHONY: start-windows-verbose
+start-windows-verbose:
+	@$(MAKE) start-windows VERBOSE=1
+
+.PHONY: start-windows-debug
+start-windows-debug:
+	@$(MAKE) start-windows DEBUG=1
+
 #
 # Service
 #


### PR DESCRIPTION
`start-windows` already honored `VERBOSE=1` and `DEBUG=1`, but the wrapper targets the Unix path gets (`start-verbose`, `start-debug`) were never added for it, so on Windows the variable had to be passed by hand. Adds `start-windows-verbose` and `start-windows-debug` for parity.

## Validation

- `make -n start-windows-verbose` and `make -n start-windows-debug`, run under both Git Bash and PowerShell — each expands to `"apps\backend\bin\kandev.exe" start --verbose` / `... --debug`.
- `make check-make-shells` — 3 shells x 3 targets plus the static `$(shell ...)` guard, all pass.

## Possible Improvements

Negligible risk: two new `.PHONY` wrappers, no existing target or variable touched. `scripts/check-make-shells` asserts only on `apps/backend/Makefile`, so the root `start-windows*` targets remain covered by `make -n` alone — same as the existing `start-verbose`/`start-debug`.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2090?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

