### PR TITLE
fix(web): phone navigation for plugin pages

### DIFF
--- a/apps/web/components/kanban/mobile-menu-sheet.tsx
+++ b/apps/web/components/kanban/mobile-menu-sheet.tsx
@@ -19,6 +19,7 @@ import {
 } from "@tabler/icons-react";
 import { AppSidebarWorkspacePicker } from "@/components/app-sidebar/app-sidebar-workspace-picker";
 import { MobileIntegrationsSection } from "@/components/integrations/integrations-menu";
+import { MobilePluginNavSection } from "@/components/plugins/mobile-plugin-nav-section";
 import { TaskSearchInput } from "./task-search-input";
 import {
   MobileTasksListOptions,
@@ -449,6 +450,7 @@ function MobileMenuContent({
         showPipeline={showPipeline}
       />
       <MobileDisplayOptions {...displayOptions} />
+      <MobilePluginNavSection onNavigate={() => onOpenChange(false)} />
       <MobileIntegrationsSection onNavigate={() => onOpenChange(false)} />
       <MobileUtilityActions
         showHealthIndicator={showHealthIndicator}

--- a/apps/web/components/page-topbar.test.tsx
+++ b/apps/web/components/page-topbar.test.tsx
@@ -1,0 +1,42 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { PageTopbar } from "./page-topbar";
+
+vi.mock("@/components/app-status-bar/app-status-surface-provider", () => ({
+  AppStatusDrawerTrigger: () => null,
+}));
+
+const PHONE_HOME = "topbar-phone-home";
+
+describe("PageTopbar phone home crumb", () => {
+  afterEach(cleanup);
+
+  it("renders a phone-only home crumb for a root-level page with no nav of its own", () => {
+    render(<PageTopbar title="Hello E2E" />);
+
+    const home = screen.getByTestId(PHONE_HOME);
+    expect(home).not.toBeNull();
+    // Hidden from md up, where the always-visible AppSidebar owns Home.
+    expect(home.className).toContain("md:hidden");
+    expect(home.querySelector("a")?.getAttribute("href")).toBe("/");
+  });
+
+  it("omits it when the page supplies its own leading nav", () => {
+    render(<PageTopbar title="Plugins" leading={<button type="button">Open menu</button>} />);
+
+    expect(screen.queryByTestId(PHONE_HOME)).toBeNull();
+  });
+
+  it("omits it when the page already shows a real back link", () => {
+    render(<PageTopbar title="Agent" backHref="/settings/agents" backLabel="Agents" />);
+
+    expect(screen.queryByTestId(PHONE_HOME)).toBeNull();
+    expect(screen.getByText("Agents")).not.toBeNull();
+  });
+
+  it("omits it for the root variant, which renders a plain label instead of a breadcrumb", () => {
+    render(<PageTopbar title="Home" variant="root" backLabel="Kandev" />);
+
+    expect(screen.queryByTestId(PHONE_HOME)).toBeNull();
+  });
+});

--- a/apps/web/components/page-topbar.tsx
+++ b/apps/web/components/page-topbar.tsx
@@ -73,6 +73,7 @@ function TopbarBreadcrumb({
   title,
   subtitle,
   icon,
+  showPhoneHome,
 }: {
   backHref: string;
   backLabel: string;
@@ -80,11 +81,16 @@ function TopbarBreadcrumb({
   title: string;
   subtitle?: string;
   icon?: ReactNode;
+  showPhoneHome: boolean;
 }) {
-  // The Home prefix is redundant now that the AppSidebar always shows a Home
-  // nav item. Only render the back link when a page sets a non-root backHref
-  // (e.g. a true ancestor route within a section).
+  // The Home prefix is redundant on desktop, where the AppSidebar always shows
+  // a Home nav item. Only render the back link when a page sets a non-root
+  // backHref (e.g. a true ancestor route within a section).
   const showBackLink = backHref !== "/" && !!backLabel;
+  // Below md the sidebar is hidden, so a root-level page that brings no nav of
+  // its own (a plugin route with default chrome) would otherwise strand phone
+  // users with no way back. Keep the home crumb phone-only.
+  const showHomeCrumb = !showBackLink && showPhoneHome;
   return (
     <Breadcrumb className="relative z-10 min-w-0">
       <BreadcrumbList className="flex-nowrap text-sm">
@@ -96,6 +102,16 @@ function TopbarBreadcrumb({
               </BreadcrumbLink>
             </BreadcrumbItem>
             <BreadcrumbSeparator className="shrink-0" />
+          </>
+        )}
+        {showHomeCrumb && (
+          <>
+            <BreadcrumbItem className="shrink-0 md:hidden" data-testid="topbar-phone-home">
+              <BreadcrumbLink asChild>
+                <BackLink href="/" label="Home" />
+              </BreadcrumbLink>
+            </BreadcrumbItem>
+            <BreadcrumbSeparator className="shrink-0 md:hidden" />
           </>
         )}
         {parents?.flatMap((p) => [
@@ -138,6 +154,7 @@ type TopbarLeadingProps = {
   title: string;
   subtitle?: string;
   icon?: ReactNode;
+  showPhoneHome: boolean;
 };
 
 function TopbarLeading({
@@ -148,6 +165,7 @@ function TopbarLeading({
   title,
   subtitle,
   icon,
+  showPhoneHome,
 }: TopbarLeadingProps) {
   if (variant === "root") {
     if (!backLabel) return null;
@@ -165,6 +183,7 @@ function TopbarLeading({
       title={title}
       subtitle={subtitle}
       icon={icon}
+      showPhoneHome={showPhoneHome}
     />
   );
 }
@@ -206,6 +225,9 @@ export const PageTopbar = forwardRef<HTMLElement, PageTopbarProps>(function Page
         title={title}
         subtitle={subtitle}
         icon={icon}
+        // A page that supplies its own `leading` nav (Settings' menu sheet)
+        // already gets phone users home; don't add a second affordance.
+        showPhoneHome={!leading}
       />
       {leftActions && (
         <div className="relative z-10 flex shrink-0 items-center gap-1 [&:empty]:hidden">

--- a/apps/web/components/plugins/mobile-plugin-nav-section.test.tsx
+++ b/apps/web/components/plugins/mobile-plugin-nav-section.test.tsx
@@ -1,0 +1,100 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { pluginRegistry } from "@/lib/plugins/registry";
+import { MobilePluginNavSection } from "./mobile-plugin-nav-section";
+
+const HELLO_PATH = "/plugins/hello";
+
+vi.mock("@/lib/routing/client-router", () => ({
+  usePathname: () => "/",
+}));
+
+function renderSection(onNavigate = () => {}) {
+  return render(<MobilePluginNavSection onNavigate={onNavigate} />);
+}
+
+describe("MobilePluginNavSection", () => {
+  afterEach(() => {
+    cleanup();
+    ["plugin-a", "plugin-b"].forEach((id) => pluginRegistry.unregisterPlugin(id));
+    window.history.pushState({}, "", "/");
+  });
+
+  it("renders nothing when no plugin has registered a nav item", () => {
+    const { container } = renderSection();
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders main-section nav items so plugin pages are reachable on a phone", () => {
+    pluginRegistry
+      .forPlugin("plugin-a")
+      .registerNavItem({ id: "hello", label: "Hello", path: HELLO_PATH });
+
+    renderSection();
+
+    expect(screen.getByTestId("mobile-plugin-nav-section")).not.toBeNull();
+    expect(screen.getByTestId("mobile-plugin-nav-item-hello")).not.toBeNull();
+    expect(screen.getByText("Hello")).not.toBeNull();
+  });
+
+  it("treats an omitted section as main, matching the desktop sidebar", () => {
+    pluginRegistry
+      .forPlugin("plugin-a")
+      .registerNavItem({ id: "implicit", label: "Implicit", path: "/plugins/implicit" });
+    pluginRegistry.forPlugin("plugin-b").registerNavItem({
+      id: "explicit",
+      label: "Explicit",
+      path: "/plugins/explicit",
+      section: "main",
+    });
+
+    renderSection();
+
+    expect(screen.getByTestId("mobile-plugin-nav-item-implicit")).not.toBeNull();
+    expect(screen.getByTestId("mobile-plugin-nav-item-explicit")).not.toBeNull();
+  });
+
+  it("omits integrations-section items, which MobileIntegrationsSection owns", () => {
+    pluginRegistry.forPlugin("plugin-a").registerNavItem({
+      id: "tracker",
+      label: "Tracker",
+      path: "/plugins/tracker",
+      section: "integrations",
+    });
+
+    const { container } = renderSection();
+
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders the named curated icon, falling back to the puzzle glyph", () => {
+    pluginRegistry
+      .forPlugin("plugin-a")
+      .registerNavItem({ id: "hello", label: "Hello", path: HELLO_PATH, icon: "ticket" });
+    pluginRegistry
+      .forPlugin("plugin-b")
+      .registerNavItem({ id: "other", label: "Other", path: "/plugins/other", icon: "nope" });
+
+    renderSection();
+
+    expect(
+      screen.getByTestId("mobile-plugin-nav-item-hello").querySelector("svg.tabler-icon-ticket"),
+    ).not.toBeNull();
+    expect(
+      screen.getByTestId("mobile-plugin-nav-item-other").querySelector("svg.tabler-icon-puzzle"),
+    ).not.toBeNull();
+  });
+
+  it("navigates to item.path and closes the menu when tapped", () => {
+    const onNavigate = vi.fn();
+    pluginRegistry
+      .forPlugin("plugin-a")
+      .registerNavItem({ id: "hello", label: "Hello", path: HELLO_PATH });
+
+    renderSection(onNavigate);
+    screen.getByTestId("mobile-plugin-nav-item-hello").click();
+
+    expect(window.location.pathname).toBe(HELLO_PATH);
+    expect(onNavigate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/components/plugins/mobile-plugin-nav-section.test.tsx
+++ b/apps/web/components/plugins/mobile-plugin-nav-section.test.tsx
@@ -54,12 +54,18 @@ describe("MobilePluginNavSection", () => {
     expect(screen.getByTestId("mobile-plugin-nav-item-explicit")).not.toBeNull();
   });
 
-  it("omits integrations-section items, which MobileIntegrationsSection owns", () => {
+  it("omits non-main sections: integrations belongs to MobileIntegrationsSection, and settings is rendered nowhere", () => {
     pluginRegistry.forPlugin("plugin-a").registerNavItem({
       id: "tracker",
       label: "Tracker",
       path: "/plugins/tracker",
       section: "integrations",
+    });
+    pluginRegistry.forPlugin("plugin-b").registerNavItem({
+      id: "prefs",
+      label: "Prefs",
+      path: "/settings/plugins/plugin-b",
+      section: "settings",
     });
 
     const { container } = renderSection();

--- a/apps/web/components/plugins/mobile-plugin-nav-section.tsx
+++ b/apps/web/components/plugins/mobile-plugin-nav-section.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { Button } from "@kandev/ui/button";
+import Link from "@/components/routing/app-link";
+import { resolvePluginIcon } from "@/lib/plugins/icons";
+import { usePluginRegistry } from "@/lib/plugins/registry";
+
+type MobilePluginNavSectionProps = {
+  /** Closes the surrounding menu sheet once a plugin page is opened. */
+  onNavigate: () => void;
+};
+
+/**
+ * Mobile counterpart to the desktop sidebar's `<PluginNavItems/>`: the
+ * hamburger-sheet surface for plugin-registered "main"-section nav items
+ * (`registerNavItem({ section: "main" })`, the default). The desktop rail is
+ * `hidden md:block`, so without this section a plugin's own page has no phone
+ * entry point at all. "integrations"-section items keep rendering inside
+ * `MobileIntegrationsSection`.
+ */
+export function MobilePluginNavSection({ onNavigate }: MobilePluginNavSectionProps) {
+  const registry = usePluginRegistry();
+  const items = registry.getNavItems().filter((item) => (item.section ?? "main") === "main");
+
+  if (items.length === 0) return null;
+
+  return (
+    <div className="space-y-3" data-testid="mobile-plugin-nav-section">
+      <div className="text-sm font-medium">Plugins</div>
+      {items.map((item) => {
+        const Icon = resolvePluginIcon(item.icon);
+        return (
+          <Button
+            key={item.id}
+            asChild
+            variant="outline"
+            className="h-11 w-full cursor-pointer justify-start gap-2"
+          >
+            <Link
+              href={item.path}
+              onClick={onNavigate}
+              data-testid={`mobile-plugin-nav-item-${item.id}`}
+            >
+              <Icon className="h-4 w-4 shrink-0" />
+              <span className="flex-1 truncate text-left">{item.label}</span>
+            </Link>
+          </Button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/e2e/tests/plugins/mobile-plugin-nav.spec.ts
+++ b/apps/web/e2e/tests/plugins/mobile-plugin-nav.spec.ts
@@ -91,6 +91,14 @@ test.describe("Mobile plugin navigation", () => {
     // Tapping the item also dismisses the sheet.
     await expect(testPage.getByTestId("mobile-plugin-nav-section")).toBeHidden();
 
+    // A plugin route with default chrome brings no nav of its own, and the
+    // sidebar that normally owns Home is hidden below md — so the topbar must
+    // carry a phone escape route or the user is stranded here.
+    const home = testPage.getByTestId("topbar-phone-home");
+    await expect(home).toBeVisible();
+    await home.click();
+    await expect(testPage).toHaveURL(/\/$/);
+
     // Desktop parity reference: the same item in the always-visible sidebar.
     const desktop = await openDesktopClient(browser, backend.frontendUrl, backend.port);
     await desktop.page.goto("/");

--- a/apps/web/e2e/tests/plugins/mobile-plugin-nav.spec.ts
+++ b/apps/web/e2e/tests/plugins/mobile-plugin-nav.spec.ts
@@ -1,0 +1,107 @@
+/**
+ * E2E: a plugin's own page is reachable from a phone.
+ *
+ * The desktop app sidebar (which renders `<PluginNavItems/>`) is
+ * `hidden md:block`, so before `MobilePluginNavSection` existed a
+ * `registerNavItem({ section: "main" })` entry had no phone entry point at
+ * all — the route worked, but only if you typed the URL. Settings > Plugins
+ * was always reachable through the settings menu sheet; this covers the
+ * plugin's *own* nav item.
+ */
+import path from "node:path";
+import type { Browser, BrowserContext, Page } from "@playwright/test";
+import { expect, test } from "../../fixtures/test-base";
+import { PrAssetCapture } from "../../helpers/pr-asset-capture";
+
+const PLUGIN_ID = "kandev-plugin-e2e";
+const NAV_ITEM_ID = "e2e-hello";
+const DESKTOP_VIEWPORT = { width: 1440, height: 900 };
+const PACKAGE_PATH = path.resolve(
+  __dirname,
+  "../../../../../apps/backend/.build/kandev-plugin-e2e-1.0.0.tar.gz",
+);
+
+/** A desktop-sized client against the same backend, for the parity screenshot. */
+async function openDesktopClient(
+  browser: Browser,
+  frontendUrl: string,
+  backendPort: number,
+): Promise<{ page: Page; context: BrowserContext }> {
+  const context = await browser.newContext({
+    baseURL: frontendUrl,
+    viewport: DESKTOP_VIEWPORT,
+  });
+  const page = await context.newPage();
+  await page.addInitScript(
+    ({ port }: { port: number }) => {
+      localStorage.setItem("kandev.onboarding.completed", "true");
+      window.__KANDEV_API_PORT = String(port);
+    },
+    { port: backendPort },
+  );
+  return { page, context };
+}
+
+test.describe("Mobile plugin navigation", () => {
+  test.afterEach(async ({ apiClient }) => {
+    await apiClient.rawRequest("DELETE", `/api/plugins/${PLUGIN_ID}`).catch(() => undefined);
+  });
+
+  test("opens a plugin page from the phone menu sheet", async ({
+    testPage,
+    backend,
+    browser,
+  }, testInfo) => {
+    test.setTimeout(120_000);
+    const capture = new PrAssetCapture(testPage, testInfo.file);
+
+    // Settings > Plugins is reachable on a phone through the settings menu
+    // sheet — install the fixture through that same real flow.
+    await testPage.goto("/settings/plugins");
+    await testPage.getByTestId("install-plugin-trigger").click();
+    await testPage.getByTestId("install-plugin-tab-upload").click();
+    await testPage.getByTestId("install-plugin-file-input").setInputFiles(PACKAGE_PATH);
+    await testPage.getByTestId("install-plugin-upload-submit").click();
+    await expect(testPage.getByTestId(`plugin-row-${PLUGIN_ID}`)).toBeVisible({ timeout: 30_000 });
+
+    await testPage.goto("/");
+    await testPage.reload();
+
+    // The desktop rail carries the same item but is hidden on a phone.
+    await expect(testPage.getByTestId("app-sidebar")).toBeHidden();
+
+    await testPage.getByRole("button", { name: "Open menu" }).click();
+    const navItem = testPage.getByTestId(`mobile-plugin-nav-item-${NAV_ITEM_ID}`);
+    await expect(navItem).toBeVisible();
+    await expect(navItem).toHaveText(/Hello E2E/);
+    expect((await navItem.boundingBox())?.height).toBeGreaterThanOrEqual(44);
+
+    // The sheet slides up on open and the section sits below the fold, so
+    // settle both before shooting or the asset captures an empty mid-animation
+    // drawer instead of the change under test.
+    await testPage.getByTestId("mobile-plugin-nav-section").scrollIntoViewIfNeeded();
+    await expect(navItem).toBeInViewport();
+    await capture.screenshot("mobile-plugin-nav-section", {
+      caption: "Phone menu sheet: the plugin's page now has an entry point",
+    });
+
+    await navItem.click();
+    await expect(testPage).toHaveURL(/\/plugins\/e2e-hello$/);
+    await expect(testPage.locator("#hello-plugin-page")).toBeVisible();
+    // Tapping the item also dismisses the sheet.
+    await expect(testPage.getByTestId("mobile-plugin-nav-section")).toBeHidden();
+
+    // Desktop parity reference: the same item in the always-visible sidebar.
+    const desktop = await openDesktopClient(browser, backend.frontendUrl, backend.port);
+    await desktop.page.goto("/");
+    await desktop.page.waitForLoadState("networkidle");
+    await expect(desktop.page.getByTestId(`plugin-nav-item-${NAV_ITEM_ID}`)).toBeVisible();
+    await capture.screenshot("desktop-plugin-nav-sidebar", {
+      page: desktop.page,
+      caption: "Desktop, unchanged: the same nav item in the app sidebar",
+    });
+    await desktop.context.close();
+
+    capture.flush();
+  });
+});

--- a/docs/plans/plugins/PLUGIN-API.md
+++ b/docs/plans/plugins/PLUGIN-API.md
@@ -129,7 +129,9 @@ interface PluginRegistry {
   registerRoute(path: string, Component: React.ComponentType, options?: PluginRouteOptions): void;
 
   // Sidebar/main nav entry. Rendered by <PluginNavItems/> in the app sidebar,
-  // with item.icon resolved against the curated icon map (fallback: puzzle).
+  // and by <MobilePluginNavSection/> in the phone menu sheet (the sidebar is
+  // hidden below md), with item.icon resolved against the curated icon map
+  // (fallback: puzzle).
   registerNavItem(item: NavItem): void;
 
   // Route under /settings/plugins/{id}/... rendered inside settings shell.

--- a/docs/public/plugins-authoring.md
+++ b/docs/public/plugins-authoring.md
@@ -337,6 +337,8 @@ interface NavItem {
   icon?: string;
   // "main" (default): top-level sidebar entry. "integrations": renders inside
   // the sidebar's Integrations section alongside first-party integration links.
+  // Both also render in the phone menu sheet, so plugin pages stay reachable
+  // when the desktop sidebar is hidden.
   // "settings" is accepted by the type but not rendered by any sidebar section
   // today — for a settings page use registerSettingsRoute instead.
   section?: "main" | "settings" | "integrations";


### PR DESCRIPTION
Plugin pages registered with `registerNavItem({ section: "main" })` rendered only in the desktop app sidebar, which is `hidden md:block`, so on a phone they had no entry point at all — the route worked, but only by typing the URL. Adds a phone counterpart to `<PluginNavItems/>` so a plugin's own page is reachable from the mobile menu sheet, and gives root-level pages a phone route back out — a plugin route with default chrome had no back, home, or menu affordance at all below `md`.

## Important Changes

- `MobilePluginNavSection` renders `"main"`-section plugin nav items in the phone menu sheet, mirroring how `MobileIntegrationsSection` already surfaces `"integrations"`-section items. Desktop is untouched.
- `PageTopbar` renders a phone-only home crumb for root-level pages that supply no `leading` nav of their own. `TopbarBreadcrumb` skipped the Home prefix because "the AppSidebar always shows a Home nav item" — true on desktop, false below `md` where the rail is `hidden md:block`, so a plugin page stranded phone users with only the browser back button. Reuses the `IconHome` branch `BackLink` already had (unreachable until now). Suppressed where a page brings its own nav, so Settings keeps just its menu sheet.

## Validation

- `pnpm exec vitest run` — 983 files, 7512 passed, 4 skipped. `components/page-topbar.test.tsx` is new (4 cases: renders phone-only + `md:hidden` + href `/`; suppressed with `leading`, with a real back link, and for `variant="root"`).
- `pnpm exec vitest run components/plugins` — 34 tests passed (6 new cases: empty registry, main section, implicit-main default, integrations exclusion, icon fallback, navigate + close-on-tap).
- `pnpm exec playwright test --project=mobile-chrome -g "Mobile plugin navigation"` — passes with the new section, and fails when it is removed, so the spec is not a false green. It installs the real gRPC fixture plugin through the upload UI, opens its page from the sheet, and taps the home crumb back to `/`. The full `--project=mobile-chrome` suite is 222 passed / 1 flaky / 3 failed; the 3 failures (`mobile-passthrough-*`) reproduce with these changes reverted and pass in CI, so they are a local passthrough-terminal environment issue.
- `pnpm run typecheck` — clean.
- `pnpm exec eslint <changed files>` — clean.
- Manually verified on a Pixel 5 viewport that Settings > Plugins was already fine on mobile (nav leaf, list, Browse tab, install dialog, per-plugin config form, floating Save) — that surface needed no change; only the plugin's own nav item was missing.

## Possible Improvements

Low risk: additive, rendered only when a plugin registers a `"main"` nav item, and it reuses the existing registry subscription. `section: "settings"` nav items remain unrendered on every surface, as documented. The topbar change is the broader one: it touches shared chrome, but only adds a crumb that is `md:hidden` and only where a page has neither a back link nor its own `leading` nav.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2093?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- kandev-screenshots-start -->
## Screenshots

**Phone menu sheet: the plugin's page now has an entry point**

![Kandev mobile Menu sheet on a Pixel 5 viewport, showing a new Plugins section with a Hello E2E row between Display Options and Utilities](https://raw.githubusercontent.com/kdlbs/kandev/7864e308e30652a4ab3fe16a436ee619dd84f00f/mobile-plugin-nav-section.png)

**Desktop, unchanged: the same nav item in the app sidebar**

![Kandev desktop at 1440x900, showing the Hello E2E plugin nav item in the app sidebar below Home and New Task](https://raw.githubusercontent.com/kdlbs/kandev/7864e308e30652a4ab3fe16a436ee619dd84f00f/desktop-plugin-nav-sidebar.png)
<!-- kandev-screenshots-end -->
