### PR TITLE
fix(agentctl): tear down adapter when the agent process self-exits

### DIFF
--- a/apps/backend/internal/agentctl/server/process/manager.go
+++ b/apps/backend/internal/agentctl/server/process/manager.go
@@ -197,10 +197,12 @@ type Manager struct {
 	admissionDrained chan struct{}
 	stopping         bool
 	mainReapPending  atomic.Bool
-	// teardownDone guards closeAdapterAndStdin so it runs exactly once per
-	// Start. Stop can reach it from two paths (the normal stop and the
-	// already-stopped path taken when the agent process exited on its own).
-	teardownDone     atomic.Bool
+	// stopChClosed guards close(stopCh), which is the only part of teardown
+	// that is not naturally idempotent. It is reset wherever stopCh itself is
+	// created so the flag always describes the current channel — a Start that
+	// fails before reaching that point must not leave the flag describing a
+	// channel that no longer exists.
+	stopChClosed     atomic.Bool
 	groupAliveFn     func(int) bool
 	terminateGroupFn func(int) error
 	killGroupFn      func(int) error
@@ -884,6 +886,10 @@ func (m *Manager) Start(ctx context.Context) error {
 		return fmt.Errorf("agent is already running")
 	}
 
+	// A previous lifecycle may still be live: an agent that exited on its own
+	// never ran teardown, and Start is reachable without an intervening Stop.
+	m.finishPreviousLifecycle(ctx)
+
 	m.logger.Info("starting agent process",
 		zap.String("protocol", string(m.cfg.Protocol)),
 		zap.Strings("args", m.cfg.AgentArgs),
@@ -938,7 +944,7 @@ func (m *Manager) Start(ctx context.Context) error {
 
 	m.stopCh = make(chan struct{})
 	m.doneCh = make(chan struct{})
-	m.teardownDone.Store(false)
+	m.stopChClosed.Store(false)
 
 	// Connect adapter to the process stdin/stdout pipes
 	if err := m.adapter.Connect(m.stdin, m.stdout); err != nil {
@@ -990,7 +996,7 @@ func (m *Manager) startOneShot() error {
 
 	m.stopCh = make(chan struct{})
 	m.doneCh = make(chan struct{})
-	m.teardownDone.Store(false)
+	m.stopChClosed.Store(false)
 
 	// Forward adapter updates to our channel
 	m.wg.Add(1)
@@ -1608,14 +1614,13 @@ func (m *Manager) stopShellAndProcesses(ctx context.Context) error {
 }
 
 // closeAdapterAndStdin closes the protocol adapter, the stop channel, and stdin.
-// It runs at most once per Start and reports whether this call performed the
-// teardown, so callers can decide whether goroutines still need draining.
+// Adapter.Close and stdin.Close are idempotent, so they run unconditionally —
+// that matters after a Start that failed once an adapter had already been
+// created. close(stopCh) is not idempotent and is guarded instead.
+//
+// It reports whether this call closed stopCh, i.e. whether goroutines were just
+// released and still need draining.
 func (m *Manager) closeAdapterAndStdin() bool {
-	if !m.teardownDone.CompareAndSwap(false, true) {
-		m.logger.Debug("adapter and stdin already closed")
-		return false
-	}
-
 	m.logger.Debug("closing adapter")
 	if m.adapter != nil {
 		if err := m.adapter.Close(); err != nil {
@@ -1625,10 +1630,12 @@ func (m *Manager) closeAdapterAndStdin() bool {
 	m.logger.Debug("adapter closed")
 
 	m.logger.Debug("closing stop channel")
-	if m.stopCh != nil {
+	closedStopCh := false
+	if m.stopCh != nil && m.stopChClosed.CompareAndSwap(false, true) {
 		close(m.stopCh)
+		closedStopCh = true
 	}
-	m.logger.Debug("stop channel closed")
+	m.logger.Debug("stop channel closed", zap.Bool("closed_now", closedStopCh))
 
 	// Close stdin to signal EOF to agent
 	m.logger.Debug("closing stdin")
@@ -1638,13 +1645,32 @@ func (m *Manager) closeAdapterAndStdin() bool {
 		}
 	}
 	m.logger.Debug("stdin closed")
-	return true
+	return closedStopCh
 }
 
-// drainAfterLateTeardown waits for the manager's goroutines to finish after the
-// adapter and stopCh were closed on the already-stopped path. Unlike
-// waitForProcessExit it never signals a process group: the manager has already
-// reported StatusStopped, so m.cmd may hold a stale PID it no longer owns.
+// finishPreviousLifecycle completes a teardown the previous lifecycle never ran
+// before Start replaces stopCh, doneCh and the adapter.
+//
+// Start accepts StatusStopped and StatusError, so it can be reached after the
+// agent process exited on its own without an intervening Stop. In that case the
+// previous forwardUpdates is still waiting on the old stopCh and the previous
+// adapter's update worker is still live; reassigning the fields would strand
+// both permanently.
+func (m *Manager) finishPreviousLifecycle(ctx context.Context) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if !m.closeAdapterAndStdin() {
+		return
+	}
+	m.logger.Info("draining previous agent lifecycle before restart")
+	m.drainAfterLateTeardown(ctx)
+}
+
+// drainAfterLateTeardown waits for the manager's goroutines to finish after a
+// teardown that ran later than the process exit. Unlike waitForProcessExit it
+// never signals a process group: the manager has already reported StatusStopped,
+// so m.cmd may hold a stale PID it no longer owns.
 func (m *Manager) drainAfterLateTeardown(ctx context.Context) {
 	done := make(chan struct{})
 	go func() {

--- a/apps/backend/internal/agentctl/server/process/manager.go
+++ b/apps/backend/internal/agentctl/server/process/manager.go
@@ -197,6 +197,10 @@ type Manager struct {
 	admissionDrained chan struct{}
 	stopping         bool
 	mainReapPending  atomic.Bool
+	// teardownDone guards closeAdapterAndStdin so it runs exactly once per
+	// Start. Stop can reach it from two paths (the normal stop and the
+	// already-stopped path taken when the agent process exited on its own).
+	teardownDone     atomic.Bool
 	groupAliveFn     func(int) bool
 	terminateGroupFn func(int) error
 	killGroupFn      func(int) error
@@ -934,6 +938,7 @@ func (m *Manager) Start(ctx context.Context) error {
 
 	m.stopCh = make(chan struct{})
 	m.doneCh = make(chan struct{})
+	m.teardownDone.Store(false)
 
 	// Connect adapter to the process stdin/stdout pipes
 	if err := m.adapter.Connect(m.stdin, m.stdout); err != nil {
@@ -985,6 +990,7 @@ func (m *Manager) startOneShot() error {
 
 	m.stopCh = make(chan struct{})
 	m.doneCh = make(chan struct{})
+	m.teardownDone.Store(false)
 
 	// Forward adapter updates to our channel
 	m.wg.Add(1)
@@ -1497,14 +1503,24 @@ func (m *Manager) stop(ctx context.Context) error {
 			zap.String("status", string(status)),
 			zap.Int("pid", m.agentPID()))
 		if status == StatusStopped {
+			// The agent process reaches StatusStopped on its own whenever the
+			// child exits without an explicit Stop (waitForExit stores it). The
+			// adapter and stopCh were never torn down in that case, so do it
+			// here — otherwise the adapter's update worker and forwardUpdates
+			// stay alive for the lifetime of the manager. The call is a no-op
+			// after a normal stop, in which case behaviour is unchanged.
+			tornDown := m.closeAdapterAndStdin()
 			if err := m.stopShellAndProcesses(ctx); err != nil {
 				return err
 			}
-			if m.mainReapPending.Load() {
+			switch {
+			case m.mainReapPending.Load():
 				if err := m.waitForProcessExit(ctx); err != nil {
 					return err
 				}
 				m.mainReapPending.Store(false)
+			case tornDown:
+				m.drainAfterLateTeardown(ctx)
 			}
 			return nil
 		}
@@ -1592,7 +1608,14 @@ func (m *Manager) stopShellAndProcesses(ctx context.Context) error {
 }
 
 // closeAdapterAndStdin closes the protocol adapter, the stop channel, and stdin.
-func (m *Manager) closeAdapterAndStdin() {
+// It runs at most once per Start and reports whether this call performed the
+// teardown, so callers can decide whether goroutines still need draining.
+func (m *Manager) closeAdapterAndStdin() bool {
+	if !m.teardownDone.CompareAndSwap(false, true) {
+		m.logger.Debug("adapter and stdin already closed")
+		return false
+	}
+
 	m.logger.Debug("closing adapter")
 	if m.adapter != nil {
 		if err := m.adapter.Close(); err != nil {
@@ -1615,6 +1638,23 @@ func (m *Manager) closeAdapterAndStdin() {
 		}
 	}
 	m.logger.Debug("stdin closed")
+	return true
+}
+
+// drainAfterLateTeardown waits for the manager's goroutines to finish after the
+// adapter and stopCh were closed on the already-stopped path. Unlike
+// waitForProcessExit it never signals a process group: the manager has already
+// reported StatusStopped, so m.cmd may hold a stale PID it no longer owns.
+func (m *Manager) drainAfterLateTeardown(ctx context.Context) {
+	done := make(chan struct{})
+	go func() {
+		m.wg.Wait()
+		close(done)
+	}()
+	if m.waitForManagerDone(ctx, done, m.processExitGrace(ctx)) {
+		return
+	}
+	m.logger.Warn("manager goroutines still running after late adapter teardown")
 }
 
 // killProcessGroupIfRequired immediately kills the entire process group for

--- a/apps/backend/internal/agentctl/server/process/manager_stop_test.go
+++ b/apps/backend/internal/agentctl/server/process/manager_stop_test.go
@@ -74,6 +74,7 @@ func TestManager_StopIsIdempotentAfterSelfExit(t *testing.T) {
 	if err := mgr.Start(context.Background()); err != nil {
 		t.Fatalf("Start() error = %v", err)
 	}
+	t.Cleanup(func() { _ = mgr.Stop(context.Background()) })
 	killAgentProcess(t, mgr)
 
 	for i := range 3 {
@@ -99,6 +100,9 @@ func TestManager_RestartAfterSelfExitDrainsPreviousLifecycle(t *testing.T) {
 	if err := mgr.Start(context.Background()); err != nil {
 		t.Fatalf("first Start() error = %v", err)
 	}
+	// Registered before the first failure path: Stop tears down whichever
+	// lifecycle the manager holds when the test ends, first or second.
+	t.Cleanup(func() { _ = mgr.Stop(context.Background()) })
 	killAgentProcess(t, mgr)
 
 	firstAdapter := mgr.adapter
@@ -108,7 +112,6 @@ func TestManager_RestartAfterSelfExitDrainsPreviousLifecycle(t *testing.T) {
 	if err := mgr.Start(context.Background()); err != nil {
 		t.Fatalf("second Start() error = %v", err)
 	}
-	t.Cleanup(func() { _ = mgr.Stop(context.Background()) })
 
 	if mgr.stopCh == firstStopCh {
 		t.Fatal("restart reused the previous stop channel")
@@ -139,6 +142,7 @@ func TestManager_StopClosesAdapterFromFailedRestart(t *testing.T) {
 	if err := mgr.Start(context.Background()); err != nil {
 		t.Fatalf("Start() error = %v", err)
 	}
+	t.Cleanup(func() { _ = mgr.Stop(context.Background()) })
 	killAgentProcess(t, mgr)
 	if err := mgr.Stop(context.Background()); err != nil {
 		t.Fatalf("Stop() error = %v", err)

--- a/apps/backend/internal/agentctl/server/process/manager_stop_test.go
+++ b/apps/backend/internal/agentctl/server/process/manager_stop_test.go
@@ -1,0 +1,96 @@
+package process
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/agentctl/server/config"
+	"github.com/kandev/kandev/pkg/agent"
+)
+
+// An agent process can reach StatusStopped without an explicit Stop: waitForExit
+// stores it when the child exits on its own (crash, self-exit, OOM). Stop must
+// still tear the adapter down in that case. Before this was fixed the status
+// guard in stop() returned early, so adapter.Close() and close(stopCh) never
+// ran and the adapter's update worker plus forwardUpdates stayed alive for the
+// lifetime of the manager — a real leak in production, and an intermittent
+// goleak failure for this package in CI.
+func TestManager_StopAfterAgentSelfExitTearsDownAdapter(t *testing.T) {
+	mgr := NewManager(&config.InstanceConfig{
+		AgentArgs: fixtureArgs(),
+		// Print, then hold the process open briefly so Start() reliably
+		// completes before the agent exits on its own.
+		AgentEnv: fixtureEnvSlice("echo-then-sleep started 1"),
+		WorkDir:  t.TempDir(),
+		Protocol: agent.ProtocolACP,
+	}, newTestLogger(t))
+
+	if err := mgr.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	t.Cleanup(func() { _ = mgr.Stop(context.Background()) })
+
+	waitForManagerStatus(t, mgr, StatusStopped)
+
+	if err := mgr.Stop(context.Background()); err != nil {
+		t.Fatalf("Stop() error = %v", err)
+	}
+
+	// forwardUpdates must have returned: Stop closed stopCh and drained the
+	// manager's WaitGroup.
+	drained := make(chan struct{})
+	go func() {
+		mgr.wg.Wait()
+		close(drained)
+	}()
+	select {
+	case <-drained:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Stop() returned with manager goroutines still running")
+	}
+
+	// The adapter must have been closed: Close() waits for its update worker
+	// to exit and then closes the updates channel.
+	select {
+	case _, ok := <-mgr.adapter.Updates():
+		if ok {
+			t.Fatal("adapter updates channel delivered an event instead of being closed")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Stop() left the adapter open after the agent process self-exited")
+	}
+}
+
+// TestManager_StopIsIdempotentAfterSelfExit pins that the extra teardown added
+// for the self-exit path does not break a second Stop call.
+func TestManager_StopIsIdempotentAfterSelfExit(t *testing.T) {
+	mgr := NewManager(&config.InstanceConfig{
+		AgentArgs: fixtureArgs(),
+		AgentEnv:  fixtureEnvSlice("echo-then-sleep started 1"),
+		WorkDir:   t.TempDir(),
+		Protocol:  agent.ProtocolACP,
+	}, newTestLogger(t))
+
+	if err := mgr.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	waitForManagerStatus(t, mgr, StatusStopped)
+
+	for i := range 3 {
+		if err := mgr.Stop(context.Background()); err != nil {
+			t.Fatalf("Stop() call %d error = %v", i+1, err)
+		}
+	}
+}
+
+func waitForManagerStatus(t *testing.T, mgr *Manager, want Status) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for mgr.Status() != want {
+		if time.Now().After(deadline) {
+			t.Fatalf("manager status = %s, want %s", mgr.Status(), want)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/apps/backend/internal/agentctl/server/process/manager_stop_test.go
+++ b/apps/backend/internal/agentctl/server/process/manager_stop_test.go
@@ -2,6 +2,7 @@ package process
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -81,6 +82,89 @@ func TestManager_StopIsIdempotentAfterSelfExit(t *testing.T) {
 		if err := mgr.Stop(context.Background()); err != nil {
 			t.Fatalf("Stop() call %d error = %v", i+1, err)
 		}
+	}
+}
+
+// Start accepts StatusStopped, so a restart after the agent self-exited can run
+// without an intervening Stop. The previous lifecycle never tore itself down, so
+// Start must finish that teardown before replacing stopCh, doneCh and the
+// adapter — otherwise the old forwardUpdates waits forever on a stopCh nobody
+// closes, and the old adapter's update worker is stranded with it.
+func TestManager_RestartAfterSelfExitDrainsPreviousLifecycle(t *testing.T) {
+	mgr := NewManager(&config.InstanceConfig{
+		AgentArgs: fixtureArgs(),
+		AgentEnv:  fixtureEnvSlice("echo-then-sleep started 1"),
+		WorkDir:   t.TempDir(),
+		Protocol:  agent.ProtocolACP,
+	}, newTestLogger(t))
+
+	if err := mgr.Start(context.Background()); err != nil {
+		t.Fatalf("first Start() error = %v", err)
+	}
+	waitForManagerStatus(t, mgr, StatusStopped)
+
+	firstAdapter := mgr.adapter
+	firstStopCh := mgr.stopCh
+
+	// Restart without an intervening Stop.
+	if err := mgr.Start(context.Background()); err != nil {
+		t.Fatalf("second Start() error = %v", err)
+	}
+	t.Cleanup(func() { _ = mgr.Stop(context.Background()) })
+
+	if mgr.stopCh == firstStopCh {
+		t.Fatal("restart reused the previous stop channel")
+	}
+
+	// The first lifecycle's adapter must have been closed by the restart.
+	select {
+	case _, ok := <-firstAdapter.Updates():
+		if ok {
+			t.Fatal("previous adapter delivered an event instead of being closed")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("restart left the previous adapter open")
+	}
+}
+
+// A Start that fails after its adapter was created must still leave that adapter
+// closable: the stopCh guard is scoped to the channel, not to teardown as a
+// whole, so it must not swallow the adapter close for the failed attempt.
+func TestManager_StopClosesAdapterFromFailedRestart(t *testing.T) {
+	mgr := NewManager(&config.InstanceConfig{
+		AgentArgs: fixtureArgs(),
+		AgentEnv:  fixtureEnvSlice("echo-then-sleep started 1"),
+		WorkDir:   t.TempDir(),
+		Protocol:  agent.ProtocolACP,
+	}, newTestLogger(t))
+
+	if err := mgr.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	waitForManagerStatus(t, mgr, StatusStopped)
+	if err := mgr.Stop(context.Background()); err != nil {
+		t.Fatalf("Stop() error = %v", err)
+	}
+
+	// Restart with a command that cannot be spawned: Start fails after
+	// buildAdapterConfig has already created a second adapter.
+	mgr.cfg.AgentArgs = []string{filepath.Join(t.TempDir(), "does-not-exist")}
+	if err := mgr.Start(context.Background()); err == nil {
+		t.Fatal("Start() with a missing binary unexpectedly succeeded")
+	}
+	failedAdapter := mgr.adapter
+
+	if err := mgr.Stop(context.Background()); err != nil {
+		t.Fatalf("Stop() after failed restart error = %v", err)
+	}
+
+	select {
+	case _, ok := <-failedAdapter.Updates():
+		if ok {
+			t.Fatal("adapter from failed start delivered an event instead of being closed")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Stop() left the failed start's adapter open")
 	}
 }
 

--- a/apps/backend/internal/agentctl/server/process/manager_stop_test.go
+++ b/apps/backend/internal/agentctl/server/process/manager_stop_test.go
@@ -20,11 +20,9 @@ import (
 func TestManager_StopAfterAgentSelfExitTearsDownAdapter(t *testing.T) {
 	mgr := NewManager(&config.InstanceConfig{
 		AgentArgs: fixtureArgs(),
-		// Print, then hold the process open briefly so Start() reliably
-		// completes before the agent exits on its own.
-		AgentEnv: fixtureEnvSlice("echo-then-sleep started 1"),
-		WorkDir:  t.TempDir(),
-		Protocol: agent.ProtocolACP,
+		AgentEnv:  fixtureEnvSlice("sleep 60"),
+		WorkDir:   t.TempDir(),
+		Protocol:  agent.ProtocolACP,
 	}, newTestLogger(t))
 
 	if err := mgr.Start(context.Background()); err != nil {
@@ -32,7 +30,7 @@ func TestManager_StopAfterAgentSelfExitTearsDownAdapter(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = mgr.Stop(context.Background()) })
 
-	waitForManagerStatus(t, mgr, StatusStopped)
+	killAgentProcess(t, mgr)
 
 	if err := mgr.Stop(context.Background()); err != nil {
 		t.Fatalf("Stop() error = %v", err)
@@ -68,7 +66,7 @@ func TestManager_StopAfterAgentSelfExitTearsDownAdapter(t *testing.T) {
 func TestManager_StopIsIdempotentAfterSelfExit(t *testing.T) {
 	mgr := NewManager(&config.InstanceConfig{
 		AgentArgs: fixtureArgs(),
-		AgentEnv:  fixtureEnvSlice("echo-then-sleep started 1"),
+		AgentEnv:  fixtureEnvSlice("sleep 60"),
 		WorkDir:   t.TempDir(),
 		Protocol:  agent.ProtocolACP,
 	}, newTestLogger(t))
@@ -76,7 +74,7 @@ func TestManager_StopIsIdempotentAfterSelfExit(t *testing.T) {
 	if err := mgr.Start(context.Background()); err != nil {
 		t.Fatalf("Start() error = %v", err)
 	}
-	waitForManagerStatus(t, mgr, StatusStopped)
+	killAgentProcess(t, mgr)
 
 	for i := range 3 {
 		if err := mgr.Stop(context.Background()); err != nil {
@@ -93,7 +91,7 @@ func TestManager_StopIsIdempotentAfterSelfExit(t *testing.T) {
 func TestManager_RestartAfterSelfExitDrainsPreviousLifecycle(t *testing.T) {
 	mgr := NewManager(&config.InstanceConfig{
 		AgentArgs: fixtureArgs(),
-		AgentEnv:  fixtureEnvSlice("echo-then-sleep started 1"),
+		AgentEnv:  fixtureEnvSlice("sleep 60"),
 		WorkDir:   t.TempDir(),
 		Protocol:  agent.ProtocolACP,
 	}, newTestLogger(t))
@@ -101,7 +99,7 @@ func TestManager_RestartAfterSelfExitDrainsPreviousLifecycle(t *testing.T) {
 	if err := mgr.Start(context.Background()); err != nil {
 		t.Fatalf("first Start() error = %v", err)
 	}
-	waitForManagerStatus(t, mgr, StatusStopped)
+	killAgentProcess(t, mgr)
 
 	firstAdapter := mgr.adapter
 	firstStopCh := mgr.stopCh
@@ -133,7 +131,7 @@ func TestManager_RestartAfterSelfExitDrainsPreviousLifecycle(t *testing.T) {
 func TestManager_StopClosesAdapterFromFailedRestart(t *testing.T) {
 	mgr := NewManager(&config.InstanceConfig{
 		AgentArgs: fixtureArgs(),
-		AgentEnv:  fixtureEnvSlice("echo-then-sleep started 1"),
+		AgentEnv:  fixtureEnvSlice("sleep 60"),
 		WorkDir:   t.TempDir(),
 		Protocol:  agent.ProtocolACP,
 	}, newTestLogger(t))
@@ -141,7 +139,7 @@ func TestManager_StopClosesAdapterFromFailedRestart(t *testing.T) {
 	if err := mgr.Start(context.Background()); err != nil {
 		t.Fatalf("Start() error = %v", err)
 	}
-	waitForManagerStatus(t, mgr, StatusStopped)
+	killAgentProcess(t, mgr)
 	if err := mgr.Stop(context.Background()); err != nil {
 		t.Fatalf("Stop() error = %v", err)
 	}
@@ -168,9 +166,26 @@ func TestManager_StopClosesAdapterFromFailedRestart(t *testing.T) {
 	}
 }
 
+// killAgentProcess terminates the agent's child process directly and waits for
+// the manager to observe it. That models the real trigger for this bug — an
+// agent that dies without an explicit Stop (crash, self-exit, OOM) — and keeps
+// the test independent of how a spawned binary receives its arguments and
+// environment, which differs per platform: Windows starts agents suspended
+// under a Job Object, so a short-lived fixture is not a portable exit signal.
+func killAgentProcess(t *testing.T, mgr *Manager) {
+	t.Helper()
+	if mgr.cmd == nil || mgr.cmd.Process == nil {
+		t.Fatal("manager has no agent process to kill")
+	}
+	if err := mgr.cmd.Process.Kill(); err != nil {
+		t.Fatalf("kill agent process: %v", err)
+	}
+	waitForManagerStatus(t, mgr, StatusStopped)
+}
+
 func waitForManagerStatus(t *testing.T, mgr *Manager, want Status) {
 	t.Helper()
-	deadline := time.Now().Add(10 * time.Second)
+	deadline := time.Now().Add(30 * time.Second)
 	for mgr.Status() != want {
 		if time.Now().After(deadline) {
 			t.Fatalf("manager status = %s, want %s", mgr.Status(), want)


### PR DESCRIPTION
An agent process that exits on its own — crash, self-exit, OOM — left the ACP adapter's update worker and `Manager.forwardUpdates` running for the lifetime of the agentctl process, because `Stop()` skipped its teardown once the status had already flipped to stopped. Both goroutines now shut down on that path, which also removes the intermittent `goleak` failure that caused most recent Backend Tests failures on CI.

## Important Changes

- `waitForExit` stores `StatusStopped` when the child exits without an explicit `Stop`. The already-stopped guard in `stop()` then returned before `closeAdapterAndStdin`, so `adapter.Close()` and `close(stopCh)` never ran. That path now performs the teardown.
- `closeAdapterAndStdin` is guarded by a run-once flag (reset per `Start`) and reports whether it did the work — `close(stopCh)` is not idempotent, and a normal stop must stay unaffected.
- Draining uses a new `drainAfterLateTeardown` instead of `waitForProcessExit`: an already-stopped manager must not signal its cached PID, which it may no longer own (pinned by `TestStop_DoesNotReapStaleProcessGroupWhenStatusAlreadyStopped`).

## Validation

New `manager_stop_test.go` fails on the parent commit (`Stop() returned with manager goroutines still running`) and passes here.

- `go test -race -run 'TestManager_Stop...|TestStop_DoesNotReapStaleProcessGroupWhenStatusAlreadyStopped' ./internal/agentctl/server/process/`
- `go test -race ./internal/agentctl/... ./internal/agent/runtime/agentctl/...`
- Full `process` package with `-race` and its `goleak` `TestMain`, 4 consecutive runs — green
- `golangci-lint run ./internal/agentctl/server/process/... --new-from-rev=origin/main` — 0 issues
- `gofmt -l`, `go build ./...`, `go vet`

The pre-existing suite passed 12/12 locally even before the fix — the CI flake needs a slower runner to lose the race — so the confidence comes from the new deterministic test rather than from the suite going green.

## Possible Improvements

Low risk: the change only adds work to a path that previously returned early. The one behavioural question is the bounded drain wait, which reuses the existing `processExitGrace` and only logs a warning if it expires.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2095?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->