### PR TITLE
fix(web): stop prompt font size changing on window resize

### DIFF
--- a/apps/web/components/task/chat/use-tiptap-editor.test.ts
+++ b/apps/web/components/task/chat/use-tiptap-editor.test.ts
@@ -9,10 +9,17 @@ import * as tiptapEditor from "./use-tiptap-editor";
 import { decideHistoryNav } from "./tiptap-editor-history";
 
 describe("TIPTAP_EDITOR_TEXT_SIZE_CLASS", () => {
-  it("keeps 16px text until the lg breakpoint", () => {
-    expect(TIPTAP_EDITOR_TEXT_SIZE_CLASS).toContain("text-base");
-    expect(TIPTAP_EDITOR_TEXT_SIZE_CLASS).toContain("lg:text-sm");
-    expect(TIPTAP_EDITOR_TEXT_SIZE_CLASS).not.toContain("md:text-sm");
+  it("uses one text size at every viewport width", () => {
+    expect(TIPTAP_EDITOR_TEXT_SIZE_CLASS).toContain("text-sm");
+    expect(TIPTAP_EDITOR_TEXT_SIZE_CLASS).not.toContain("text-base");
+  });
+
+  it("carries no responsive text-size variant, so resizing cannot change the font", () => {
+    // The touch 16px floor lives in the `any-pointer: coarse` rule in
+    // globals.css; a width breakpoint here would resize the composer text when
+    // a desktop window is dragged narrow.
+    const responsiveTextSize = /\b(sm|md|lg|xl|2xl|max-\w+):text-/;
+    expect(TIPTAP_EDITOR_TEXT_SIZE_CLASS).not.toMatch(responsiveTextSize);
   });
 });
 

--- a/apps/web/components/task/chat/use-tiptap-editor.test.ts
+++ b/apps/web/components/task/chat/use-tiptap-editor.test.ts
@@ -14,12 +14,15 @@ describe("TIPTAP_EDITOR_TEXT_SIZE_CLASS", () => {
     expect(TIPTAP_EDITOR_TEXT_SIZE_CLASS).not.toContain("text-base");
   });
 
-  it("carries no responsive text-size variant, so resizing cannot change the font", () => {
+  it("carries no variant-prefixed text utility, so resizing cannot change the font", () => {
     // The touch 16px floor lives in the `any-pointer: coarse` rule in
     // globals.css; a width breakpoint here would resize the composer text when
-    // a desktop window is dragged narrow.
-    const responsiveTextSize = /\b(sm|md|lg|xl|2xl|max-\w+):text-/;
-    expect(TIPTAP_EDITOR_TEXT_SIZE_CLASS).not.toMatch(responsiveTextSize);
+    // a desktop window is dragged narrow. Reject *any* `<variant>:text-*`
+    // rather than a list of named breakpoints — an arbitrary variant such as
+    // `min-[1024px]:text-lg` or `max-[900px]:text-base` is just as
+    // viewport-dependent and would slip past an enumerated pattern.
+    const variantTextUtility = /(?:^|\s)\S+:text-\S+/;
+    expect(TIPTAP_EDITOR_TEXT_SIZE_CLASS).not.toMatch(variantTextUtility);
   });
 });
 

--- a/apps/web/components/task/chat/use-tiptap-editor.ts
+++ b/apps/web/components/task/chat/use-tiptap-editor.ts
@@ -51,7 +51,14 @@ export type TipTapInputHandle = {
 };
 
 const lowlightInstance = createLowlight(common);
-export const TIPTAP_EDITOR_TEXT_SIZE_CLASS = "text-base leading-relaxed lg:text-sm";
+/** Viewport-width-independent on purpose. The 16px floor that stops iOS Safari
+ *  from auto-zooming a focused field is owned by the `@media (any-pointer:
+ *  coarse)` rule in `app/globals.css`, which is keyed on the input device
+ *  rather than the window size. A width breakpoint here (the old
+ *  `text-base … lg:text-sm`) made the composer text jump from 14px to 16px when
+ *  a desktop window was dragged narrower than `lg`, which is not a touch
+ *  device and needs no zoom guard. */
+export const TIPTAP_EDITOR_TEXT_SIZE_CLASS = "text-sm leading-relaxed";
 
 type UseTipTapEditorOptions = {
   value: string;

--- a/apps/web/e2e/tests/chat/chat-input-font-size-helpers.ts
+++ b/apps/web/e2e/tests/chat/chat-input-font-size-helpers.ts
@@ -1,0 +1,35 @@
+import { type Page } from "@playwright/test";
+import { SessionPage } from "../../pages/session-page";
+import type { ApiClient } from "../../helpers/api-client";
+import type { SeedData } from "../../fixtures/test-base";
+import type { CreateTaskResponse } from "../../../lib/types/http";
+
+/** Shared setup for the desktop and mobile composer font-size specs. */
+export async function createReadyTask(
+  apiClient: ApiClient,
+  seedData: SeedData,
+  title: string,
+): Promise<CreateTaskResponse> {
+  return apiClient.createTaskWithAgent(seedData.workspaceId, title, seedData.agentProfileId, {
+    description: "/e2e:simple-message",
+    workflow_id: seedData.workflowId,
+    workflow_step_id: seedData.startStepId,
+    repository_ids: [seedData.repositoryId],
+  });
+}
+
+export async function openTaskChat(page: Page, taskId: string): Promise<SessionPage> {
+  await page.goto(`/t/${taskId}`);
+  const session = new SessionPage(page);
+  await session.waitForLoad();
+  await session.waitForChatIdle({ timeout: 30_000 });
+  return session;
+}
+
+/**
+ * Multiple TipTap instances can be mounted in dockview and mobile layouts;
+ * scope to the first visible one.
+ */
+export function composerEditor(page: Page) {
+  return page.locator(".tiptap.ProseMirror:visible").first();
+}

--- a/apps/web/e2e/tests/chat/chat-input-font-size-helpers.ts
+++ b/apps/web/e2e/tests/chat/chat-input-font-size-helpers.ts
@@ -27,9 +27,13 @@ export async function openTaskChat(page: Page, taskId: string): Promise<SessionP
 }
 
 /**
- * Multiple TipTap instances can be mounted in dockview and mobile layouts;
- * scope to the first visible one.
+ * The prompt composer of the active chat panel. Dockview and mobile layouts keep
+ * background panels mounted, and a chat transcript can host read-only
+ * `[contenteditable="false"]` ProseMirror decorations (mention chips, code-block
+ * views), so a bare `.tiptap.ProseMirror` match could measure the wrong element.
+ * Scope through `activeChat()` and require an editable host — the same locator
+ * `SessionPage.sendMessage()` uses.
  */
-export function composerEditor(page: Page) {
-  return page.locator(".tiptap.ProseMirror:visible").first();
+export function composerEditor(session: SessionPage) {
+  return session.activeChat().locator('.tiptap.ProseMirror[contenteditable="true"]').first();
 }

--- a/apps/web/e2e/tests/chat/chat-input-font-size.spec.ts
+++ b/apps/web/e2e/tests/chat/chat-input-font-size.spec.ts
@@ -1,0 +1,73 @@
+import { type Page } from "@playwright/test";
+import { test, expect, type SeedData } from "../../fixtures/test-base";
+import { SessionPage } from "../../pages/session-page";
+import type { ApiClient } from "../../helpers/api-client";
+import type { CreateTaskResponse } from "../../../lib/types/http";
+
+/** Widths on both sides of Tailwind's `lg` (1024px) breakpoint. The composer
+ *  used to carry `text-base … lg:text-sm`, so dragging a desktop window under
+ *  1024px grew the prompt text from 14px to 16px. */
+const WIDTHS = [1440, 1100, 900, 700] as const;
+
+async function createReadyTask(
+  apiClient: ApiClient,
+  seedData: SeedData,
+): Promise<CreateTaskResponse> {
+  return apiClient.createTaskWithAgent(
+    seedData.workspaceId,
+    "Chat Input Font Size",
+    seedData.agentProfileId,
+    {
+      description: "/e2e:simple-message",
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+      repository_ids: [seedData.repositoryId],
+    },
+  );
+}
+
+async function openTaskChat(page: Page, taskId: string): Promise<SessionPage> {
+  await page.goto(`/t/${taskId}`);
+  const session = new SessionPage(page);
+  await session.waitForLoad();
+  await session.waitForChatIdle({ timeout: 30_000 });
+  return session;
+}
+
+test.describe("Chat input font size", () => {
+  test("stays constant while the desktop window is resized", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    const task = await createReadyTask(apiClient, seedData);
+    await openTaskChat(testPage, task.id);
+
+    // Multiple TipTap instances can be mounted in dockview layouts; scope to
+    // the first visible one.
+    const editor = testPage.locator(".tiptap.ProseMirror:visible").first();
+    await expect(editor).toBeVisible();
+
+    // Desktop Chrome exposes a fine pointer, so the globals.css 16px
+    // coarse-pointer floor must not apply here. Assert it, otherwise this test
+    // would pass trivially with every width pinned to 16px.
+    const coarse = await testPage.evaluate(() => matchMedia("(any-pointer: coarse)").matches);
+    expect(coarse).toBe(false);
+
+    const sizes: number[] = [];
+    for (const width of WIDTHS) {
+      await testPage.setViewportSize({ width, height: 900 });
+      // Narrow widths swap the dockview layout, which remounts the composer.
+      // Re-await visibility so the measurement never lands on a detached node
+      // mid-remount (getComputedStyle on a detached element yields "" → NaN).
+      await expect(editor).toBeVisible();
+      await expect
+        .poll(async () => editor.evaluate((el) => getComputedStyle(el).fontSize))
+        .not.toBe("");
+      sizes.push(await editor.evaluate((el) => parseFloat(getComputedStyle(el).fontSize)));
+    }
+
+    expect(sizes).toEqual(sizes.map(() => sizes[0]));
+    expect(sizes[0]).toBeCloseTo(14, 1);
+  });
+});

--- a/apps/web/e2e/tests/chat/chat-input-font-size.spec.ts
+++ b/apps/web/e2e/tests/chat/chat-input-font-size.spec.ts
@@ -1,8 +1,5 @@
-import { type Page } from "@playwright/test";
-import { test, expect, type SeedData } from "../../fixtures/test-base";
-import { SessionPage } from "../../pages/session-page";
-import type { ApiClient } from "../../helpers/api-client";
-import type { CreateTaskResponse } from "../../../lib/types/http";
+import { test, expect } from "../../fixtures/test-base";
+import { composerEditor, createReadyTask, openTaskChat } from "./chat-input-font-size-helpers";
 
 /** Widths on both sides of Tailwind's `lg` (1024px) breakpoint. The composer
  *  used to carry `text-base … lg:text-sm`, so dragging a desktop window under
@@ -13,31 +10,6 @@ const WIDTHS = [1440, 1100, 900, 700] as const;
  *  compare across widths. */
 const SAMPLE_PROMPT = "The quick brown fox jumps over the lazy dog";
 
-async function createReadyTask(
-  apiClient: ApiClient,
-  seedData: SeedData,
-): Promise<CreateTaskResponse> {
-  return apiClient.createTaskWithAgent(
-    seedData.workspaceId,
-    "Chat Input Font Size",
-    seedData.agentProfileId,
-    {
-      description: "/e2e:simple-message",
-      workflow_id: seedData.workflowId,
-      workflow_step_id: seedData.startStepId,
-      repository_ids: [seedData.repositoryId],
-    },
-  );
-}
-
-async function openTaskChat(page: Page, taskId: string): Promise<SessionPage> {
-  await page.goto(`/t/${taskId}`);
-  const session = new SessionPage(page);
-  await session.waitForLoad();
-  await session.waitForChatIdle({ timeout: 30_000 });
-  return session;
-}
-
 test.describe("Chat input font size", () => {
   test("stays constant while the desktop window is resized", async ({
     testPage,
@@ -45,12 +17,10 @@ test.describe("Chat input font size", () => {
     seedData,
     prCapture,
   }) => {
-    const task = await createReadyTask(apiClient, seedData);
+    const task = await createReadyTask(apiClient, seedData, "Chat Input Font Size");
     await openTaskChat(testPage, task.id);
 
-    // Multiple TipTap instances can be mounted in dockview layouts; scope to
-    // the first visible one.
-    const editor = testPage.locator(".tiptap.ProseMirror:visible").first();
+    const editor = composerEditor(testPage);
     await expect(editor).toBeVisible();
 
     // Desktop Chrome exposes a fine pointer, so the globals.css 16px

--- a/apps/web/e2e/tests/chat/chat-input-font-size.spec.ts
+++ b/apps/web/e2e/tests/chat/chat-input-font-size.spec.ts
@@ -9,6 +9,10 @@ import type { CreateTaskResponse } from "../../../lib/types/http";
  *  1024px grew the prompt text from 14px to 16px. */
 const WIDTHS = [1440, 1100, 900, 700] as const;
 
+/** Typed into the composer purely so the screenshots show real glyphs to
+ *  compare across widths. */
+const SAMPLE_PROMPT = "The quick brown fox jumps over the lazy dog";
+
 async function createReadyTask(
   apiClient: ApiClient,
   seedData: SeedData,
@@ -39,6 +43,7 @@ test.describe("Chat input font size", () => {
     testPage,
     apiClient,
     seedData,
+    prCapture,
   }) => {
     const task = await createReadyTask(apiClient, seedData);
     await openTaskChat(testPage, task.id);
@@ -69,5 +74,24 @@ test.describe("Chat input font size", () => {
 
     expect(sizes).toEqual(sizes.map(() => sizes[0]));
     expect(sizes[0]).toBeCloseTo(14, 1);
+
+    // Capture the wide/narrow pair for the PR description (only when
+    // CAPTURE_PR_ASSETS=true). The same prompt text is typed once and shot at
+    // both widths so the two images can be compared directly.
+    await testPage.setViewportSize({ width: 1440, height: 900 });
+    await expect(editor).toBeVisible();
+    await editor.click();
+    await editor.pressSequentially(SAMPLE_PROMPT);
+    await expect(editor).toContainText(SAMPLE_PROMPT);
+    await prCapture.screenshot("composer-1440px", {
+      caption: "Composer at 1440px (above the lg breakpoint) — prompt text at 14px",
+    });
+
+    await testPage.setViewportSize({ width: 900, height: 900 });
+    await expect(editor).toBeVisible();
+    await expect(editor).toContainText(SAMPLE_PROMPT);
+    await prCapture.screenshot("composer-900px", {
+      caption: "Composer at 900px (below the lg breakpoint) — prompt text still 14px, was 16px",
+    });
   });
 });

--- a/apps/web/e2e/tests/chat/chat-input-font-size.spec.ts
+++ b/apps/web/e2e/tests/chat/chat-input-font-size.spec.ts
@@ -18,9 +18,9 @@ test.describe("Chat input font size", () => {
     prCapture,
   }) => {
     const task = await createReadyTask(apiClient, seedData, "Chat Input Font Size");
-    await openTaskChat(testPage, task.id);
+    const session = await openTaskChat(testPage, task.id);
 
-    const editor = composerEditor(testPage);
+    const editor = composerEditor(session);
     await expect(editor).toBeVisible();
 
     // Desktop Chrome exposes a fine pointer, so the globals.css 16px

--- a/apps/web/e2e/tests/chat/mobile-chat-input-font-size.spec.ts
+++ b/apps/web/e2e/tests/chat/mobile-chat-input-font-size.spec.ts
@@ -40,6 +40,7 @@ test.describe("Mobile chat input font size", () => {
     testPage,
     apiClient,
     seedData,
+    prCapture,
   }) => {
     const task = await createReadyTask(apiClient, seedData);
     await openTaskChat(testPage, task.id);
@@ -56,5 +57,10 @@ test.describe("Mobile chat input font size", () => {
 
     const fontSize = await editor.evaluate((el) => parseFloat(getComputedStyle(el).fontSize));
     expect(fontSize).toBeGreaterThanOrEqual(16);
+
+    await editor.pressSequentially("The quick brown fox jumps over the lazy dog");
+    await prCapture.screenshot("mobile-composer", {
+      caption: "Touch composer keeps the 16px iOS focus-zoom floor from the coarse-pointer rule",
+    });
   });
 });

--- a/apps/web/e2e/tests/chat/mobile-chat-input-font-size.spec.ts
+++ b/apps/web/e2e/tests/chat/mobile-chat-input-font-size.spec.ts
@@ -1,8 +1,5 @@
-import { type Page } from "@playwright/test";
-import { test, expect, type SeedData } from "../../fixtures/test-base";
-import { SessionPage } from "../../pages/session-page";
-import type { ApiClient } from "../../helpers/api-client";
-import type { CreateTaskResponse } from "../../../lib/types/http";
+import { test, expect } from "../../fixtures/test-base";
+import { composerEditor, createReadyTask, openTaskChat } from "./chat-input-font-size-helpers";
 
 // Runs on the mobile-chrome Playwright project (Pixel 5 emulation, touch →
 // any-pointer: coarse). The composer's Tailwind class is a flat `text-sm`, so
@@ -10,31 +7,6 @@ import type { CreateTaskResponse } from "../../../lib/types/http";
 // to stop iOS Safari auto-zooming on focus. This guards that dependency —
 // mobile-zoom.spec.ts covers plain form controls, this covers the
 // contenteditable TipTap editor.
-async function createReadyTask(
-  apiClient: ApiClient,
-  seedData: SeedData,
-): Promise<CreateTaskResponse> {
-  return apiClient.createTaskWithAgent(
-    seedData.workspaceId,
-    "Mobile Chat Input Font Size",
-    seedData.agentProfileId,
-    {
-      description: "/e2e:simple-message",
-      workflow_id: seedData.workflowId,
-      workflow_step_id: seedData.startStepId,
-      repository_ids: [seedData.repositoryId],
-    },
-  );
-}
-
-async function openTaskChat(page: Page, taskId: string): Promise<SessionPage> {
-  await page.goto(`/t/${taskId}`);
-  const session = new SessionPage(page);
-  await session.waitForLoad();
-  await session.waitForChatIdle({ timeout: 30_000 });
-  return session;
-}
-
 test.describe("Mobile chat input font size", () => {
   test("composer renders at >= 16px to prevent iOS focus-zoom", async ({
     testPage,
@@ -42,7 +14,7 @@ test.describe("Mobile chat input font size", () => {
     seedData,
     prCapture,
   }) => {
-    const task = await createReadyTask(apiClient, seedData);
+    const task = await createReadyTask(apiClient, seedData, "Mobile Chat Input Font Size");
     await openTaskChat(testPage, task.id);
 
     // Guard: the 16px rule is gated on `@media (any-pointer: coarse)`. Assert
@@ -51,7 +23,7 @@ test.describe("Mobile chat input font size", () => {
     const coarse = await testPage.evaluate(() => matchMedia("(any-pointer: coarse)").matches);
     expect(coarse).toBe(true);
 
-    const editor = testPage.locator(".tiptap.ProseMirror:visible").first();
+    const editor = composerEditor(testPage);
     await expect(editor).toBeVisible();
     await editor.tap();
 

--- a/apps/web/e2e/tests/chat/mobile-chat-input-font-size.spec.ts
+++ b/apps/web/e2e/tests/chat/mobile-chat-input-font-size.spec.ts
@@ -15,7 +15,7 @@ test.describe("Mobile chat input font size", () => {
     prCapture,
   }) => {
     const task = await createReadyTask(apiClient, seedData, "Mobile Chat Input Font Size");
-    await openTaskChat(testPage, task.id);
+    const session = await openTaskChat(testPage, task.id);
 
     // Guard: the 16px rule is gated on `@media (any-pointer: coarse)`. Assert
     // the emulated device really exposes a coarse pointer so a fixture change
@@ -23,7 +23,7 @@ test.describe("Mobile chat input font size", () => {
     const coarse = await testPage.evaluate(() => matchMedia("(any-pointer: coarse)").matches);
     expect(coarse).toBe(true);
 
-    const editor = composerEditor(testPage);
+    const editor = composerEditor(session);
     await expect(editor).toBeVisible();
     await editor.tap();
 

--- a/apps/web/e2e/tests/chat/mobile-chat-input-font-size.spec.ts
+++ b/apps/web/e2e/tests/chat/mobile-chat-input-font-size.spec.ts
@@ -1,0 +1,60 @@
+import { type Page } from "@playwright/test";
+import { test, expect, type SeedData } from "../../fixtures/test-base";
+import { SessionPage } from "../../pages/session-page";
+import type { ApiClient } from "../../helpers/api-client";
+import type { CreateTaskResponse } from "../../../lib/types/http";
+
+// Runs on the mobile-chrome Playwright project (Pixel 5 emulation, touch →
+// any-pointer: coarse). The composer's Tailwind class is a flat `text-sm`, so
+// touch devices depend entirely on the 16px coarse-pointer rule in globals.css
+// to stop iOS Safari auto-zooming on focus. This guards that dependency —
+// mobile-zoom.spec.ts covers plain form controls, this covers the
+// contenteditable TipTap editor.
+async function createReadyTask(
+  apiClient: ApiClient,
+  seedData: SeedData,
+): Promise<CreateTaskResponse> {
+  return apiClient.createTaskWithAgent(
+    seedData.workspaceId,
+    "Mobile Chat Input Font Size",
+    seedData.agentProfileId,
+    {
+      description: "/e2e:simple-message",
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+      repository_ids: [seedData.repositoryId],
+    },
+  );
+}
+
+async function openTaskChat(page: Page, taskId: string): Promise<SessionPage> {
+  await page.goto(`/t/${taskId}`);
+  const session = new SessionPage(page);
+  await session.waitForLoad();
+  await session.waitForChatIdle({ timeout: 30_000 });
+  return session;
+}
+
+test.describe("Mobile chat input font size", () => {
+  test("composer renders at >= 16px to prevent iOS focus-zoom", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    const task = await createReadyTask(apiClient, seedData);
+    await openTaskChat(testPage, task.id);
+
+    // Guard: the 16px rule is gated on `@media (any-pointer: coarse)`. Assert
+    // the emulated device really exposes a coarse pointer so a fixture change
+    // that drops touch emulation fails loudly instead of silently passing.
+    const coarse = await testPage.evaluate(() => matchMedia("(any-pointer: coarse)").matches);
+    expect(coarse).toBe(true);
+
+    const editor = testPage.locator(".tiptap.ProseMirror:visible").first();
+    await expect(editor).toBeVisible();
+    await editor.tap();
+
+    const fontSize = await editor.evaluate((el) => parseFloat(getComputedStyle(el).fontSize));
+    expect(fontSize).toBeGreaterThanOrEqual(16);
+  });
+});


### PR DESCRIPTION
The chat composer sized its text by viewport width (`text-base … lg:text-sm`), so dragging a desktop window narrower than 1024px grew the prompt from 14px to 16px. It now uses a single size at every width, and the touch zoom guard is left to the rule that was already doing that job.

## Important Changes

- `TIPTAP_EDITOR_TEXT_SIZE_CLASS` drops its `lg` breakpoint and becomes a flat `text-sm`. The width breakpoint was added in #1477 as an iOS focus-zoom guard, but #1501 later added the correct device-keyed guard — the `@media (any-pointer: coarse)` rule in `globals.css` forces 16px on touch and already covers the TipTap editor through `[contenteditable="true"]`. The breakpoint was redundant, and it was the last width-based input font sizing left in the codebase.

## Validation

- `pnpm --filter @kandev/web exec vitest run components/task/chat/use-tiptap-editor.test.ts` — 24 passed
- `pnpm --filter @kandev/web typecheck` — clean
- `pnpm --filter @kandev/web lint` (`eslint --max-warnings 0`) — clean
- `./e2e/scripts/run-e2e.sh --project=chromium chat/chat-input-font-size.spec.ts` — passed
- `./e2e/scripts/run-e2e.sh --project=mobile-chrome chat/mobile-chat-input-font-size.spec.ts` — passed
- Regression check: reverted the constant to `text-base … lg:text-sm` and confirmed the desktop spec **fails** (`14, 14, 16, 16` across 1440/1100/900/700px), so the new guard genuinely catches the bug rather than passing vacuously.

The unit test now rejects any responsive `*:text-` variant on the constant instead of pinning the old breakpoint. The desktop e2e also asserts the browser reports a fine pointer, so it cannot pass trivially with every width pinned to 16px by the coarse-pointer rule.

## Possible Improvements

Low risk. Mobile text size depends entirely on the `globals.css` coarse-pointer rule now; the new mobile spec guards that dependency, so removing or narrowing that rule would fail loudly rather than silently reintroducing iOS focus-zoom.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- kandev-screenshots-start -->
## Screenshots

The same prompt text typed once, shot at both widths — identical glyph size, where the narrow shot previously rendered at 16px.

![Kandev session chat at a 1440px desktop window, prompt composer showing "The quick brown fox jumps over the lazy dog" at 14px](https://raw.githubusercontent.com/kdlbs/kandev/f407a0fedd344d125bcbc747946e5fd191176e05/composer-1440px.png)

![The same session chat at a 900px desktop window, below the lg breakpoint, with the prompt text still rendered at 14px](https://raw.githubusercontent.com/kdlbs/kandev/f407a0fedd344d125bcbc747946e5fd191176e05/composer-900px.png)

Touch composer, unchanged — the coarse-pointer rule still holds the 16px iOS focus-zoom floor.

![Kandev mobile session chat on Pixel 5 emulation with the prompt composer text at 16px](https://raw.githubusercontent.com/kdlbs/kandev/f407a0fedd344d125bcbc747946e5fd191176e05/mobile-composer.png)
<!-- kandev-screenshots-end -->