### PR TITLE
ci: mirror postgres service image in ghcr

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -176,7 +176,14 @@ jobs:
     container: ghcr.io/kdlbs/kandev-ci:build-latest
     services:
       postgres:
-        image: postgres:16@sha256:fe03a7605299a34ddf5e4f285dff78c3d7190a576b3c6b46f2fcff69f4bffd54
+        # Mirrored from the digest-pinned Docker Hub image by
+        # ci-base-image.yml. Service images are pulled before steps begin, so
+        # moving this pull to GHCR removes an otherwise unwrappable Docker Hub
+        # timeout from job startup.
+        image: ghcr.io/kdlbs/kandev-ci:postgres-16@sha256:fe03a7605299a34ddf5e4f285dff78c3d7190a576b3c6b46f2fcff69f4bffd54
+        credentials:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
         env:
           POSTGRES_USER: kandev
           POSTGRES_PASSWORD: kandev

--- a/.github/workflows/ci-base-image.yml
+++ b/.github/workflows/ci-base-image.yml
@@ -25,6 +25,9 @@ permissions:
 
 env:
   IMAGE_NAME: ghcr.io/kdlbs/kandev-ci
+  POSTGRES_DIGEST: sha256:fe03a7605299a34ddf5e4f285dff78c3d7190a576b3c6b46f2fcff69f4bffd54
+  POSTGRES_SOURCE: docker.io/library/postgres:16@sha256:fe03a7605299a34ddf5e4f285dff78c3d7190a576b3c6b46f2fcff69f4bffd54
+  POSTGRES_TARGET: ghcr.io/kdlbs/kandev-ci:postgres-16
 
 jobs:
   build-and-push:
@@ -50,6 +53,31 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Service containers are pulled before any job step can add retries. Keep
+      # the Postgres image beside the job image in GHCR so backend CI has one
+      # registry dependency. A single image-index source is copied byte-for-byte,
+      # so the upstream digest remains valid at the mirrored location.
+      - name: Mirror Postgres to GHCR
+        if: |
+          github.event_name == 'workflow_dispatch'
+          || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+        run: |
+          set -euo pipefail
+
+          docker buildx imagetools create \
+            --tag "${POSTGRES_TARGET}" \
+            "${POSTGRES_SOURCE}"
+
+          mirrored_digest="sha256:$(
+            docker buildx imagetools inspect --raw "${POSTGRES_TARGET}" \
+              | sha256sum \
+              | cut -d ' ' -f 1
+          )"
+          if [[ "${mirrored_digest}" != "${POSTGRES_DIGEST}" ]]; then
+            echo "::error::Postgres mirror digest ${mirrored_digest} does not match ${POSTGRES_DIGEST}"
+            exit 1
+          fi
 
       - name: Compute image tag
         id: tag
@@ -111,6 +139,7 @@ jobs:
             echo ""
             echo "- runtime: \`${IMAGE_NAME}:runtime-sha-${IMAGE_TAG}\` / \`runtime-latest\`"
             echo "- build:   \`${IMAGE_NAME}:build-sha-${IMAGE_TAG}\` / \`build-latest\`"
+            echo "- postgres: \`${POSTGRES_TARGET}@${POSTGRES_DIGEST}\`"
             echo "- pushed:  \`${PUSHED}\`"
           } >> "$GITHUB_STEP_SUMMARY"
         env:


### PR DESCRIPTION
The Backend Postgres job can fail before tests start when Docker Hub times out during service-container startup. This mirrors the pinned PostgreSQL image into GHCR and points the service at that authenticated copy, removing the transient Docker Hub dependency.

## Important Changes

- Add a digest-preserving PostgreSQL mirror step to the CI base-image workflow.
- Use the digest-pinned GHCR mirror for the backend PostgreSQL service.

## Validation

- Workflow YAML parsed successfully.
- `.github/scripts/lint-action-pinning_test.py` passed.
- `.github/scripts/lint-action-pinning.py` passed.
- Source manifest digest verified with Docker Buildx.
- Retried GitHub Actions run [30652842737](https://github.com/kdlbs/kandev/actions/runs/30652842737); all jobs passed, including Backend Postgres.

## Possible Improvements

Low risk: when the PostgreSQL digest changes, update the mirror and consumer references together; the mirror workflow verifies this at publish time.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->