### PR TITLE
fix(agentctl): demote unwatched workspace trackers to slow polling

### DIFF
--- a/apps/backend/internal/agentctl/server/process/manager.go
+++ b/apps/backend/internal/agentctl/server/process/manager.go
@@ -126,13 +126,14 @@ type Manager struct {
 	// per-field repoTrackersMu still allows concurrent subscribe/unsubscribe
 	// readers while a rescan is in flight.
 	rescanMu sync.Mutex
-	// lastPollMode is the most recent mode the gateway pushed for this
-	// workspace, empty until it pushes at all. Trackers created after that
-	// point — rescan adding a repository to a workspace that is already
-	// focused, or a lazily-created subpath tracker — inherit it, because no
-	// further push arrives unless the session's own mode changes.
-	lastPollMode   PollMode
-	lastPollModeMu sync.RWMutex
+	// workspacePollMode is the most recent mode the gateway pushed for this
+	// workspace. Trackers created after that point — rescan, rebind or
+	// reconcile adding a repository to a workspace that is already focused —
+	// inherit it, because no further push arrives unless the session's own
+	// mode changes.
+	workspacePollMode    PollMode
+	workspacePollModeSet bool
+	workspacePollModeMu  sync.RWMutex
 	// workspaceTrackersBySubpath caches per-subpath trackers for multi-repo
 	// task roots. Key is the cleaned subpath (relative to cfg.WorkDir). The
 	// root tracker lives in workspaceTracker above.
@@ -614,7 +615,6 @@ func (m *Manager) GetWorkspaceTrackerFor(subpath string) (*WorkspaceTracker, err
 		return t, nil
 	}
 	t := NewWorkspaceTracker(full, m.logger)
-	m.inheritPollMode(t)
 	t.SetBaseBranch(lookupBaseBranch(m.getBaseBranches(), cleaned))
 	m.workspaceTrackersBySubpath[cleaned] = t
 	return t, nil
@@ -745,20 +745,20 @@ func (m *Manager) RepoSubpaths() []string {
 // 60s later, while the user is looking at it.
 func (m *Manager) newTrackerForRepo(path, repositoryName string) *WorkspaceTracker {
 	t := NewWorkspaceTrackerForRepo(path, repositoryName, m.logger)
-	m.inheritPollMode(t)
+	m.configurePollMode(t)
 	return t
 }
 
-// inheritPollMode applies the last mode the gateway pushed, if it ever pushed
-// one. SetPollMode also disarms the tracker's grace demotion, which is correct:
-// the gateway has spoken for this workspace, so the fallback must not override
-// it. With no prior push the tracker keeps its own default and the grace timer
-// stays in charge.
-func (m *Manager) inheritPollMode(t *WorkspaceTracker) {
-	m.lastPollModeMu.RLock()
-	mode := m.lastPollMode
-	m.lastPollModeMu.RUnlock()
-	if mode == "" {
+// configurePollMode applies the last mode the gateway pushed, if it ever
+// pushed one. SetPollMode also disarms the tracker”s grace demotion, which is
+// correct: the gateway has spoken for this workspace, so the fallback must not
+// override it. With no prior push the tracker keeps its own default and the
+// grace timer stays in charge.
+func (m *Manager) configurePollMode(t *WorkspaceTracker) {
+	m.workspacePollModeMu.RLock()
+	mode, ok := m.workspacePollMode, m.workspacePollModeSet
+	m.workspacePollModeMu.RUnlock()
+	if !ok {
 		return
 	}
 	t.SetPollMode(mode)
@@ -772,9 +772,10 @@ func (m *Manager) inheritPollMode(t *WorkspaceTracker) {
 // after a focus event, since the agent's initial pushes happen at boot and
 // no replay path exists for clients that subscribe later.
 func (m *Manager) SetWorkspacePollMode(ctx context.Context, mode PollMode) {
-	m.lastPollModeMu.Lock()
-	m.lastPollMode = mode
-	m.lastPollModeMu.Unlock()
+	m.workspacePollModeMu.Lock()
+	m.workspacePollMode = mode
+	m.workspacePollModeSet = true
+	m.workspacePollModeMu.Unlock()
 
 	root, trackers := m.snapshotTrackers()
 	root.SetPollMode(mode)

--- a/apps/backend/internal/agentctl/server/process/manager.go
+++ b/apps/backend/internal/agentctl/server/process/manager.go
@@ -785,6 +785,18 @@ func (m *Manager) applyWorkspacePollModeLocked(trackers ...*WorkspaceTracker) {
 // after a focus event, since the agent's initial pushes happen at boot and
 // no replay path exists for clients that subscribe later.
 func (m *Manager) SetWorkspacePollMode(ctx context.Context, mode PollMode) {
+	// Reject before storing, not just before applying. Every tracker already
+	// ignores an invalid mode, so an invalid push is harmless to the trackers
+	// that exist — but recording it would overwrite the last valid one, and
+	// trackers created afterwards inherit what is stored. A single malformed
+	// push would leave every later tracker on its construction default, and
+	// applyWorkspacePollModeLocked could not tell that apart from a workspace
+	// the gateway has genuinely never spoken for.
+	if !mode.IsValid() {
+		m.logger.Warn("ignoring invalid workspace poll mode", zap.String("mode", string(mode)))
+		return
+	}
+
 	// Storing the mode and fanning it out happen under one write lock, the same
 	// one the rescan paths hold while they publish new trackers. That ordering
 	// is what makes the two safe against each other: a tracker is either already

--- a/apps/backend/internal/agentctl/server/process/manager.go
+++ b/apps/backend/internal/agentctl/server/process/manager.go
@@ -126,6 +126,13 @@ type Manager struct {
 	// per-field repoTrackersMu still allows concurrent subscribe/unsubscribe
 	// readers while a rescan is in flight.
 	rescanMu sync.Mutex
+	// lastPollMode is the most recent mode the gateway pushed for this
+	// workspace, empty until it pushes at all. Trackers created after that
+	// point — rescan adding a repository to a workspace that is already
+	// focused, or a lazily-created subpath tracker — inherit it, because no
+	// further push arrives unless the session's own mode changes.
+	lastPollMode   PollMode
+	lastPollModeMu sync.RWMutex
 	// workspaceTrackersBySubpath caches per-subpath trackers for multi-repo
 	// task roots. Key is the cleaned subpath (relative to cfg.WorkDir). The
 	// root tracker lives in workspaceTracker above.
@@ -607,6 +614,7 @@ func (m *Manager) GetWorkspaceTrackerFor(subpath string) (*WorkspaceTracker, err
 		return t, nil
 	}
 	t := NewWorkspaceTracker(full, m.logger)
+	m.inheritPollMode(t)
 	t.SetBaseBranch(lookupBaseBranch(m.getBaseBranches(), cleaned))
 	m.workspaceTrackersBySubpath[cleaned] = t
 	return t, nil
@@ -729,6 +737,33 @@ func (m *Manager) RepoSubpaths() []string {
 	return out
 }
 
+// newTrackerForRepo builds a per-repo tracker that inherits the workspace's
+// current poll mode. Used for every tracker created after launch — rescan and
+// lazy subpath creation — because the gateway only pushes on a session mode
+// transition: a repository added to a workspace that is already focused would
+// otherwise sit at its construction default and be demoted by the grace timer
+// 60s later, while the user is looking at it.
+func (m *Manager) newTrackerForRepo(path, repositoryName string) *WorkspaceTracker {
+	t := NewWorkspaceTrackerForRepo(path, repositoryName, m.logger)
+	m.inheritPollMode(t)
+	return t
+}
+
+// inheritPollMode applies the last mode the gateway pushed, if it ever pushed
+// one. SetPollMode also disarms the tracker's grace demotion, which is correct:
+// the gateway has spoken for this workspace, so the fallback must not override
+// it. With no prior push the tracker keeps its own default and the grace timer
+// stays in charge.
+func (m *Manager) inheritPollMode(t *WorkspaceTracker) {
+	m.lastPollModeMu.RLock()
+	mode := m.lastPollMode
+	m.lastPollModeMu.RUnlock()
+	if mode == "" {
+		return
+	}
+	t.SetPollMode(mode)
+}
+
 // SetWorkspacePollMode propagates a poll-mode change to the root tracker and
 // every per-repo tracker, then forces a RefreshGitStatus on each non-paused
 // tracker so a fresh snapshot reaches every subscriber. Without the refresh,
@@ -737,6 +772,10 @@ func (m *Manager) RepoSubpaths() []string {
 // after a focus event, since the agent's initial pushes happen at boot and
 // no replay path exists for clients that subscribe later.
 func (m *Manager) SetWorkspacePollMode(ctx context.Context, mode PollMode) {
+	m.lastPollModeMu.Lock()
+	m.lastPollMode = mode
+	m.lastPollModeMu.Unlock()
+
 	root, trackers := m.snapshotTrackers()
 	root.SetPollMode(mode)
 	for _, t := range trackers {

--- a/apps/backend/internal/agentctl/server/process/manager.go
+++ b/apps/backend/internal/agentctl/server/process/manager.go
@@ -131,9 +131,14 @@ type Manager struct {
 	// reconcile adding a repository to a workspace that is already focused —
 	// inherit it, because no further push arrives unless the session's own
 	// mode changes.
+	//
+	// Guarded by repoTrackersMu rather than a mutex of its own: the mode and
+	// the tracker set have to move together. A separate lock let a tracker read
+	// the mode, then get registered after a concurrent push had already
+	// snapshotted the set — adopting a stale mode with its grace timer disarmed,
+	// with nothing left to correct it.
 	workspacePollMode    PollMode
 	workspacePollModeSet bool
-	workspacePollModeMu  sync.RWMutex
 	// workspaceTrackersBySubpath caches per-subpath trackers for multi-repo
 	// task roots. Key is the cleaned subpath (relative to cfg.WorkDir). The
 	// root tracker lives in workspaceTracker above.
@@ -744,24 +749,32 @@ func (m *Manager) RepoSubpaths() []string {
 // otherwise sit at its construction default and be demoted by the grace timer
 // 60s later, while the user is looking at it.
 func (m *Manager) newTrackerForRepo(path, repositoryName string) *WorkspaceTracker {
-	t := NewWorkspaceTrackerForRepo(path, repositoryName, m.logger)
-	m.configurePollMode(t)
-	return t
+	return NewWorkspaceTrackerForRepo(path, repositoryName, m.logger)
 }
 
-// configurePollMode applies the last mode the gateway pushed, if it ever
-// pushed one. SetPollMode also disarms the tracker”s grace demotion, which is
-// correct: the gateway has spoken for this workspace, so the fallback must not
-// override it. With no prior push the tracker keeps its own default and the
-// grace timer stays in charge.
-func (m *Manager) configurePollMode(t *WorkspaceTracker) {
-	m.workspacePollModeMu.RLock()
-	mode, ok := m.workspacePollMode, m.workspacePollModeSet
-	m.workspacePollModeMu.RUnlock()
-	if !ok {
+// applyWorkspacePollModeLocked gives newly built trackers the last mode the
+// gateway pushed, if it ever pushed one. SetPollMode also disarms a tracker's
+// grace demotion, which is correct: the gateway has spoken for this workspace,
+// so the fallback must not override it. With no prior push the trackers keep
+// their construction default and the grace timer stays in charge.
+//
+// Callers must hold repoTrackersMu for writing, and must call this in the same
+// critical section that publishes the trackers. Reading the mode and
+// registering the tracker have to be one step: otherwise a SetWorkspacePollMode
+// running in between stores a new mode and fans it out to a tracker set that
+// does not include this one yet, so the tracker adopts the stale mode — and
+// because SetPollMode marks it as pushed and disarms the grace timer, nothing
+// ever corrects it. It would poll at the wrong cadence for the life of the
+// process, which is the exact failure the grace timer exists to prevent.
+func (m *Manager) applyWorkspacePollModeLocked(trackers ...*WorkspaceTracker) {
+	if !m.workspacePollModeSet {
 		return
 	}
-	t.SetPollMode(mode)
+	for _, t := range trackers {
+		if t != nil {
+			t.SetPollMode(m.workspacePollMode)
+		}
+	}
 }
 
 // SetWorkspacePollMode propagates a poll-mode change to the root tracker and
@@ -772,23 +785,38 @@ func (m *Manager) configurePollMode(t *WorkspaceTracker) {
 // after a focus event, since the agent's initial pushes happen at boot and
 // no replay path exists for clients that subscribe later.
 func (m *Manager) SetWorkspacePollMode(ctx context.Context, mode PollMode) {
-	m.workspacePollModeMu.Lock()
+	// Storing the mode and fanning it out happen under one write lock, the same
+	// one the rescan paths hold while they publish new trackers. That ordering
+	// is what makes the two safe against each other: a tracker is either already
+	// registered and gets this push, or it is registered afterwards and reads
+	// this mode when it does. Anything in between would leave it on a stale mode
+	// with its grace timer disarmed — see applyWorkspacePollModeLocked.
+	//
+	// SetPollMode is a mutex update plus a non-blocking wake-up, so holding the
+	// lock across the fan-out costs nothing. RefreshGitStatus is the slow part
+	// and stays outside, in the goroutine below.
+	m.repoTrackersMu.Lock()
 	m.workspacePollMode = mode
 	m.workspacePollModeSet = true
-	m.workspacePollModeMu.Unlock()
-
-	root, trackers := m.snapshotTrackers()
-	root.SetPollMode(mode)
+	root := m.workspaceTracker
+	trackers := make([]*WorkspaceTracker, len(m.repoTrackers))
+	copy(trackers, m.repoTrackers)
+	if root != nil {
+		root.SetPollMode(mode)
+	}
 	for _, t := range trackers {
 		t.SetPollMode(mode)
 	}
+	m.repoTrackersMu.Unlock()
 	if mode == PollModePaused {
 		return
 	}
 	// Refresh in background — RefreshGitStatus blocks on git commands which
 	// can take seconds on large repos; the HTTP caller shouldn't wait.
 	go func() {
-		root.RefreshGitStatus(ctx)
+		if root != nil {
+			root.RefreshGitStatus(ctx)
+		}
 		for _, t := range trackers {
 			t.RefreshGitStatus(ctx)
 		}

--- a/apps/backend/internal/agentctl/server/process/manager_poll_mode_inherit_test.go
+++ b/apps/backend/internal/agentctl/server/process/manager_poll_mode_inherit_test.go
@@ -118,3 +118,53 @@ func TestManagerRescanKeepsGraceWhenNeverFocused(t *testing.T) {
 	}
 	t.Fatal("rescan did not create a tracker for the new repository")
 }
+
+// TestManagerRescanIgnoresInvalidPollModePush covers the gap between rejecting a
+// mode and recording it. Every tracker already refuses an invalid mode, so a
+// malformed push is harmless to the trackers that exist — but if the Manager
+// stored it anyway, trackers created afterwards would inherit the garbage and
+// sit on their construction default, indistinguishable from a workspace the
+// gateway never spoke for. The last valid push has to survive.
+func TestManagerRescanIgnoresInvalidPollModePush(t *testing.T) {
+	isolateTestGitEnv(t)
+	taskRoot := t.TempDir()
+	placeRepo(t, taskRoot, "frontend")
+
+	mgr := NewManager(&config.InstanceConfig{WorkDir: taskRoot}, newTestLogger(t))
+	stopManagerTrackers(t, mgr)
+
+	// The gateway focuses the workspace, then sends something malformed.
+	mgr.SetWorkspacePollMode(context.Background(), PollModeSlow)
+	mgr.SetWorkspacePollMode(context.Background(), PollMode("turbo"))
+
+	mgr.repoTrackersMu.RLock()
+	stored, ok := mgr.workspacePollMode, mgr.workspacePollModeSet
+	mgr.repoTrackersMu.RUnlock()
+	if !ok {
+		t.Fatal("the invalid push cleared the record of the valid one")
+	}
+	if stored != PollModeSlow {
+		t.Errorf("stored mode = %v, want %v — the invalid push overwrote it", stored, PollModeSlow)
+	}
+
+	// A repository added afterwards must inherit the last valid mode.
+	placeRepo(t, taskRoot, "worker")
+	if err := mgr.RescanRepositories(context.Background(), taskRoot); err != nil {
+		t.Fatalf("RescanRepositories: %v", err)
+	}
+
+	_, trackers := mgr.snapshotTrackers()
+	var worker *WorkspaceTracker
+	for _, tr := range trackers {
+		if tr.RepositoryName() == "worker" {
+			worker = tr
+			break
+		}
+	}
+	if worker == nil {
+		t.Fatalf("rescan did not create a tracker for the new repository; got %d trackers", len(trackers))
+	}
+	if got := worker.GetPollMode(); got != PollModeSlow {
+		t.Errorf("new tracker poll mode = %v, want %v — it did not inherit the last valid push", got, PollModeSlow)
+	}
+}

--- a/apps/backend/internal/agentctl/server/process/manager_poll_mode_inherit_test.go
+++ b/apps/backend/internal/agentctl/server/process/manager_poll_mode_inherit_test.go
@@ -1,0 +1,88 @@
+package process
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/agentctl/server/config"
+)
+
+// TestRescanTrackerInheritsFocusedPollMode covers the regression flagged in
+// review on #2113: a rescan adds a repository to a workspace that is already
+// focused. No session mode transition happens, so the gateway pushes nothing,
+// and without inheritance the new tracker would sit at its construction
+// default and be demoted to slow by the grace timer while the user is
+// actively looking at it.
+func TestRescanTrackerInheritsFocusedPollMode(t *testing.T) {
+	isolateTestGitEnv(t)
+	taskRoot := t.TempDir()
+	for _, name := range []string{"frontend", "backend"} {
+		repoDir, cleanup := setupTestRepo(t)
+		t.Cleanup(cleanup)
+		if err := os.Rename(repoDir, filepath.Join(taskRoot, name)); err != nil {
+			t.Fatalf("place %s: %v", name, err)
+		}
+	}
+
+	mgr := NewManager(&config.InstanceConfig{WorkDir: taskRoot}, newTestLogger(t))
+	t.Cleanup(func() {
+		mgr.workspaceTracker.Stop()
+		for _, tr := range mgr.repoTrackers {
+			tr.Stop()
+		}
+	})
+
+	// The user focuses the task: the gateway pushes fast once.
+	mgr.SetWorkspacePollMode(context.Background(), PollModeFast)
+
+	// A repository appears afterwards. The gateway stays silent because the
+	// session's own mode did not change.
+	newRepo, cleanup := setupTestRepo(t)
+	t.Cleanup(cleanup)
+	if err := os.Rename(newRepo, filepath.Join(taskRoot, "worker")); err != nil {
+		t.Fatalf("place worker: %v", err)
+	}
+	tracker := mgr.newTrackerForRepo(filepath.Join(taskRoot, "worker"), "worker")
+	tracker.pollModeGrace = 50 * time.Millisecond
+	tracker.Start(context.Background())
+	t.Cleanup(tracker.Stop)
+
+	if got := tracker.GetPollMode(); got != PollModeFast {
+		t.Fatalf("tracker created during a focused session = %v, want %v", got, PollModeFast)
+	}
+
+	// Well past the grace deadline it must still be fast — inheriting the push
+	// has to disarm the fallback, not merely set the initial value.
+	time.Sleep(300 * time.Millisecond)
+	if got := tracker.GetPollMode(); got != PollModeFast {
+		t.Errorf("tracker demoted to %v while the workspace is focused, want %v", got, PollModeFast)
+	}
+}
+
+// TestRescanTrackerKeepsGraceWhenGatewayNeverPushed is the other half: with no
+// prior push there is nothing to inherit, so the grace demotion must still own
+// the tracker.
+func TestRescanTrackerKeepsGraceWhenGatewayNeverPushed(t *testing.T) {
+	isolateTestGitEnv(t)
+	taskRoot := t.TempDir()
+	repoDir, cleanup := setupTestRepo(t)
+	t.Cleanup(cleanup)
+	if err := os.Rename(repoDir, filepath.Join(taskRoot, "solo")); err != nil {
+		t.Fatalf("place solo: %v", err)
+	}
+
+	mgr := NewManager(&config.InstanceConfig{WorkDir: taskRoot}, newTestLogger(t))
+	t.Cleanup(func() { mgr.workspaceTracker.Stop() })
+
+	tracker := mgr.newTrackerForRepo(filepath.Join(taskRoot, "solo"), "solo")
+	tracker.filePollInterval = 30 * time.Second
+	tracker.gitPollInterval = 30 * time.Second
+	tracker.pollModeGrace = 50 * time.Millisecond
+	tracker.Start(context.Background())
+	t.Cleanup(tracker.Stop)
+
+	waitForPollMode(t, tracker, PollModeSlow, 10*time.Second)
+}

--- a/apps/backend/internal/agentctl/server/process/manager_poll_mode_inherit_test.go
+++ b/apps/backend/internal/agentctl/server/process/manager_poll_mode_inherit_test.go
@@ -5,84 +5,116 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/kandev/kandev/internal/agentctl/server/config"
 )
 
-// TestRescanTrackerInheritsFocusedPollMode covers the regression flagged in
-// review on #2113: a rescan adds a repository to a workspace that is already
-// focused. No session mode transition happens, so the gateway pushes nothing,
-// and without inheritance the new tracker would sit at its construction
-// default and be demoted to slow by the grace timer while the user is
-// actively looking at it.
-func TestRescanTrackerInheritsFocusedPollMode(t *testing.T) {
-	isolateTestGitEnv(t)
-	taskRoot := t.TempDir()
-	for _, name := range []string{"frontend", "backend"} {
-		repoDir, cleanup := setupTestRepo(t)
-		t.Cleanup(cleanup)
-		if err := os.Rename(repoDir, filepath.Join(taskRoot, name)); err != nil {
-			t.Fatalf("place %s: %v", name, err)
-		}
+// placeRepo materialises a git repo as a child of taskRoot under the given name.
+func placeRepo(t *testing.T, taskRoot, name string) string {
+	t.Helper()
+	repoDir, cleanup := setupTestRepo(t)
+	t.Cleanup(cleanup)
+	dest := filepath.Join(taskRoot, name)
+	if err := os.Rename(repoDir, dest); err != nil {
+		t.Fatalf("place %s: %v", name, err)
 	}
+	return dest
+}
 
-	mgr := NewManager(&config.InstanceConfig{WorkDir: taskRoot}, newTestLogger(t))
+func stopManagerTrackers(t *testing.T, m *Manager) {
+	t.Helper()
 	t.Cleanup(func() {
-		mgr.workspaceTracker.Stop()
-		for _, tr := range mgr.repoTrackers {
+		root, trackers := m.snapshotTrackers()
+		if root != nil {
+			root.Stop()
+		}
+		for _, tr := range trackers {
 			tr.Stop()
 		}
 	})
-
-	// The user focuses the task: the gateway pushes fast once.
-	mgr.SetWorkspacePollMode(context.Background(), PollModeFast)
-
-	// A repository appears afterwards. The gateway stays silent because the
-	// session's own mode did not change.
-	newRepo, cleanup := setupTestRepo(t)
-	t.Cleanup(cleanup)
-	if err := os.Rename(newRepo, filepath.Join(taskRoot, "worker")); err != nil {
-		t.Fatalf("place worker: %v", err)
-	}
-	tracker := mgr.newTrackerForRepo(filepath.Join(taskRoot, "worker"), "worker")
-	tracker.pollModeGrace = 50 * time.Millisecond
-	tracker.Start(context.Background())
-	t.Cleanup(tracker.Stop)
-
-	if got := tracker.GetPollMode(); got != PollModeFast {
-		t.Fatalf("tracker created during a focused session = %v, want %v", got, PollModeFast)
-	}
-
-	// Well past the grace deadline it must still be fast — inheriting the push
-	// has to disarm the fallback, not merely set the initial value.
-	time.Sleep(300 * time.Millisecond)
-	if got := tracker.GetPollMode(); got != PollModeFast {
-		t.Errorf("tracker demoted to %v while the workspace is focused, want %v", got, PollModeFast)
-	}
 }
 
-// TestRescanTrackerKeepsGraceWhenGatewayNeverPushed is the other half: with no
-// prior push there is nothing to inherit, so the grace demotion must still own
-// the tracker.
-func TestRescanTrackerKeepsGraceWhenGatewayNeverPushed(t *testing.T) {
+// TestManagerRescanKeepsFocusedWorkspaceFast is the manager-level regression
+// test for review feedback on #2113: the user focuses a task, a rescan then
+// adds a repository, and no further gateway push follows because the session's
+// own mode never changed. Without inheritance the new tracker would sit at its
+// construction default and be demoted by the grace timer while the workspace
+// is still being viewed.
+func TestManagerRescanKeepsFocusedWorkspaceFast(t *testing.T) {
 	isolateTestGitEnv(t)
 	taskRoot := t.TempDir()
-	repoDir, cleanup := setupTestRepo(t)
-	t.Cleanup(cleanup)
-	if err := os.Rename(repoDir, filepath.Join(taskRoot, "solo")); err != nil {
-		t.Fatalf("place solo: %v", err)
-	}
+	placeRepo(t, taskRoot, "frontend")
+	placeRepo(t, taskRoot, "backend")
 
 	mgr := NewManager(&config.InstanceConfig{WorkDir: taskRoot}, newTestLogger(t))
-	t.Cleanup(func() { mgr.workspaceTracker.Stop() })
+	stopManagerTrackers(t, mgr)
 
-	tracker := mgr.newTrackerForRepo(filepath.Join(taskRoot, "solo"), "solo")
-	tracker.filePollInterval = 30 * time.Second
-	tracker.gitPollInterval = 30 * time.Second
-	tracker.pollModeGrace = 50 * time.Millisecond
-	tracker.Start(context.Background())
-	t.Cleanup(tracker.Stop)
+	// The user focuses the task: the gateway pushes fast, once.
+	mgr.SetWorkspacePollMode(context.Background(), PollModeFast)
 
-	waitForPollMode(t, tracker, PollModeSlow, 10*time.Second)
+	// A repository appears afterwards and a rescan picks it up. The gateway
+	// stays silent — the session's mode did not change.
+	placeRepo(t, taskRoot, "worker")
+	if err := mgr.RescanRepositories(context.Background(), taskRoot); err != nil {
+		t.Fatalf("RescanRepositories: %v", err)
+	}
+
+	_, trackers := mgr.snapshotTrackers()
+	var worker *WorkspaceTracker
+	for _, tr := range trackers {
+		if tr.RepositoryName() == "worker" {
+			worker = tr
+			break
+		}
+	}
+	if worker == nil {
+		t.Fatalf("rescan did not create a tracker for the new repository; got %d trackers", len(trackers))
+	}
+
+	if got := worker.GetPollMode(); got != PollModeFast {
+		t.Errorf("rescan-created tracker = %v, want %v — it did not inherit the focused mode", got, PollModeFast)
+	}
+	// Deterministic: with the push recorded and the timer cleared, no elapsed
+	// time can demote it, so there is nothing to wait for.
+	assertGraceDisarmed(t, worker)
+}
+
+// TestManagerRescanKeepsGraceWhenNeverFocused is the other half: with no prior
+// push there is nothing to inherit, so the grace demotion must still own
+// rescan-created trackers.
+func TestManagerRescanKeepsGraceWhenNeverFocused(t *testing.T) {
+	isolateTestGitEnv(t)
+	taskRoot := t.TempDir()
+	placeRepo(t, taskRoot, "frontend")
+	placeRepo(t, taskRoot, "backend")
+
+	mgr := NewManager(&config.InstanceConfig{WorkDir: taskRoot}, newTestLogger(t))
+	stopManagerTrackers(t, mgr)
+
+	placeRepo(t, taskRoot, "worker")
+	if err := mgr.RescanRepositories(context.Background(), taskRoot); err != nil {
+		t.Fatalf("RescanRepositories: %v", err)
+	}
+
+	_, trackers := mgr.snapshotTrackers()
+	for _, tr := range trackers {
+		if tr.RepositoryName() != "worker" {
+			continue
+		}
+		// Assert the fallback is still in charge rather than waiting out the
+		// production grace period: no push recorded and the timer armed is
+		// exactly the state the demotion fires from. That it does fire is
+		// covered by TestPollModeGrace_DemotesWhenNoPushArrives.
+		tr.pollModeMu.RLock()
+		pushed, timer := tr.pollModePushed, tr.pollModeGraceTimer
+		tr.pollModeMu.RUnlock()
+		if pushed {
+			t.Error("tracker recorded a push although the gateway never pushed for this workspace")
+		}
+		if timer == nil {
+			t.Error("grace timer not armed, so an unwatched rescan tracker would poll fast forever")
+		}
+		return
+	}
+	t.Fatal("rescan did not create a tracker for the new repository")
 }

--- a/apps/backend/internal/agentctl/server/process/manager_rescan.go
+++ b/apps/backend/internal/agentctl/server/process/manager_rescan.go
@@ -222,7 +222,7 @@ func (m *Manager) RebindWorkspaceWithSourceRoots(ctx context.Context, workDir st
 	}
 	subs := m.snapshotSubscribers()
 	children := scanRepositorySubdirs(resolved, roots)
-	bare := NewWorkspaceTrackerForRepo(resolved, "", m.logger)
+	bare := m.newTrackerForRepo(resolved, "")
 	bare.SetBaseBranch(lookupBaseBranch(m.getBaseBranches(), ""))
 	bare.SetAllowedSourceRoots(roots)
 	bare.Start(ctx)
@@ -231,7 +231,7 @@ func (m *Manager) RebindWorkspaceWithSourceRoots(ctx context.Context, workDir st
 	}
 	repos := make([]*WorkspaceTracker, 0, len(children))
 	for _, child := range children {
-		tracker := NewWorkspaceTrackerForRepo(child.path, child.name, m.logger)
+		tracker := m.newTrackerForRepo(child.path, child.name)
 		tracker.SetBaseBranch(lookupBaseBranch(m.getBaseBranches(), child.name))
 		tracker.SetAllowedSourceRoots(roots)
 		tracker.Start(ctx)
@@ -270,7 +270,7 @@ func (m *Manager) transitionToMultiRepoMode(ctx context.Context, workDir string,
 		zap.String("work_dir", workDir),
 		zap.Int("children", len(children)))
 
-	bareRoot := NewWorkspaceTrackerForRepo(workDir, "", m.logger)
+	bareRoot := m.newTrackerForRepo(workDir, "")
 	bareRoot.SetBaseBranch(lookupBaseBranch(m.getBaseBranches(), ""))
 	bareRoot.SetAllowedSourceRoots(roots)
 	bareRoot.Start(ctx)
@@ -280,7 +280,7 @@ func (m *Manager) transitionToMultiRepoMode(ctx context.Context, workDir string,
 
 	newRepoTrackers := make([]*WorkspaceTracker, 0, len(children))
 	for _, child := range children {
-		tracker := NewWorkspaceTrackerForRepo(child.path, child.name, m.logger)
+		tracker := m.newTrackerForRepo(child.path, child.name)
 		tracker.SetBaseBranch(lookupBaseBranch(m.getBaseBranches(), child.name))
 		tracker.SetAllowedSourceRoots(roots)
 		tracker.Start(ctx)
@@ -326,7 +326,7 @@ func (m *Manager) appendNewRepoTrackers(ctx context.Context, workDir string, chi
 		m.logger.Info("adding per-repo tracker after rescan",
 			zap.String("repository_name", child.name),
 			zap.String("path", child.path))
-		tracker := NewWorkspaceTrackerForRepo(child.path, child.name, m.logger)
+		tracker := m.newTrackerForRepo(child.path, child.name)
 		tracker.SetBaseBranch(lookupBaseBranch(m.getBaseBranches(), child.name))
 		tracker.SetAllowedSourceRoots(roots)
 		tracker.Start(ctx)
@@ -390,7 +390,7 @@ func (m *Manager) reconcileRepoTrackers(ctx context.Context, workDir string, chi
 		if _, needed := wanted[repositoryTrackerIdentity(child.name, child.path)]; !needed {
 			continue
 		}
-		tracker := NewWorkspaceTrackerForRepo(child.path, child.name, m.logger)
+		tracker := m.newTrackerForRepo(child.path, child.name)
 		tracker.SetBaseBranch(lookupBaseBranch(m.getBaseBranches(), child.name))
 		tracker.SetAllowedSourceRoots(roots)
 		tracker.Start(ctx)

--- a/apps/backend/internal/agentctl/server/process/manager_rescan.go
+++ b/apps/backend/internal/agentctl/server/process/manager_rescan.go
@@ -244,6 +244,7 @@ func (m *Manager) RebindWorkspaceWithSourceRoots(ctx context.Context, workDir st
 	m.repoTrackersMu.Lock()
 	oldBare, oldRepos := m.workspaceTracker, m.repoTrackers
 	m.cfg.WorkDir, m.workspaceTracker, m.repoTrackers, m.workspaceSourceRoots = resolved, bare, repos, append([]string(nil), roots...)
+	m.applyWorkspacePollModeLocked(append([]*WorkspaceTracker{bare}, repos...)...)
 	m.cfg.WorkspaceSourceRoots = append([]string(nil), roots...)
 	m.repoTrackersMu.Unlock()
 	if oldBare != nil {
@@ -294,6 +295,7 @@ func (m *Manager) transitionToMultiRepoMode(ctx context.Context, workDir string,
 	old := m.workspaceTracker
 	m.workspaceTracker = bareRoot
 	m.repoTrackers = append(m.repoTrackers, newRepoTrackers...)
+	m.applyWorkspacePollModeLocked(append([]*WorkspaceTracker{bareRoot}, newRepoTrackers...)...)
 	m.cfg.WorkDir = workDir
 	m.workspaceSourceRoots = append([]string(nil), roots...)
 	m.cfg.WorkspaceSourceRoots = append([]string(nil), roots...)
@@ -352,6 +354,7 @@ func (m *Manager) appendNewRepoTrackers(ctx context.Context, workDir string, chi
 			continue
 		}
 		m.repoTrackers = append(m.repoTrackers, t)
+		m.applyWorkspacePollModeLocked(t)
 	}
 	m.cfg.WorkDir = workDir
 	m.workspaceSourceRoots = append([]string(nil), roots...)
@@ -402,6 +405,7 @@ func (m *Manager) reconcileRepoTrackers(ctx context.Context, workDir string, chi
 	m.repoTrackersMu.Lock()
 	retained = append(retained, newTrackers...)
 	m.repoTrackers = retained
+	m.applyWorkspacePollModeLocked(newTrackers...)
 	m.cfg.WorkDir = workDir
 	m.workspaceSourceRoots = append([]string(nil), roots...)
 	m.cfg.WorkspaceSourceRoots = append([]string(nil), roots...)

--- a/apps/backend/internal/agentctl/server/process/workspace_poll_mode.go
+++ b/apps/backend/internal/agentctl/server/process/workspace_poll_mode.go
@@ -85,6 +85,12 @@ func (wt *WorkspaceTracker) SetPollMode(mode PollMode) {
 	}
 
 	wt.pollModeMu.Lock()
+	// Record the push and drop the fallback timer before the no-op check: a
+	// push that matches the current mode changes nothing about the cadence but
+	// still proves the gateway is managing this workspace, which is exactly
+	// what the grace demotion exists to detect the absence of.
+	wt.pollModePushed = true
+	wt.disarmPollModeGraceLocked()
 	prev := wt.pollMode
 	if prev == mode {
 		wt.pollModeMu.Unlock()
@@ -93,11 +99,35 @@ func (wt *WorkspaceTracker) SetPollMode(mode PollMode) {
 	wt.pollMode = mode
 	wt.pollModeMu.Unlock()
 
-	// Wake both polling loops. Each has its own buffered(1) channel because
-	// a single shared channel would let whichever loop selects first steal
-	// the signal, leaving the other loop blocked on its old timer interval
-	// (potentially 30s) before noticing the mode change. Sends are non-blocking:
-	// if the buffer is full, a notification is already pending which is fine.
+	wt.wakePollLoops()
+}
+
+// demoteUnpushedPollMode drops the tracker to slow once pollModeGracePeriod
+// elapses with no explicit SetPollMode. Fires at most once — the timer is not
+// rearmed — so a later push always wins.
+func (wt *WorkspaceTracker) demoteUnpushedPollMode() {
+	wt.pollModeMu.Lock()
+	wt.pollModeGraceTimer = nil
+	if wt.pollModePushed || wt.pollMode == PollModeSlow {
+		wt.pollModeMu.Unlock()
+		return
+	}
+	wt.pollMode = PollModeSlow
+	wt.pollModeMu.Unlock()
+
+	wt.logger.Info("no poll mode pushed within grace period, demoting to slow",
+		zap.Duration("grace", wt.pollModeGrace),
+		zap.String("workDir", wt.workDir))
+	wt.wakePollLoops()
+}
+
+// wakePollLoops nudges both polling loops so they re-read the mode and reset
+// their timers immediately. Each has its own buffered(1) channel because a
+// single shared channel would let whichever loop selects first steal the
+// signal, leaving the other blocked on its old timer interval (potentially
+// 30s) before noticing the change. Sends are non-blocking: if the buffer is
+// full, a notification is already pending which is fine.
+func (wt *WorkspaceTracker) wakePollLoops() {
 	for _, ch := range []chan struct{}{wt.monitorModeChanged, wt.gitPollModeChanged} {
 		select {
 		case ch <- struct{}{}:

--- a/apps/backend/internal/agentctl/server/process/workspace_poll_mode_grace_test.go
+++ b/apps/backend/internal/agentctl/server/process/workspace_poll_mode_grace_test.go
@@ -1,0 +1,126 @@
+package process
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// waitForPollMode polls GetPollMode until it matches want or the deadline
+// passes. Used instead of a fixed sleep because the grace demotion fires on a
+// timer goroutine, and CI hosts under load can delay it well past its nominal
+// deadline.
+func waitForPollMode(t *testing.T, wt *WorkspaceTracker, want PollMode, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if got := wt.GetPollMode(); got == want {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("poll mode = %v after %v, want %v", wt.GetPollMode(), timeout, want)
+}
+
+// TestPollModeGrace_DemotesWhenNoPushArrives covers the leak this mechanism
+// exists to close: the gateway only pushes a mode for workspaces a client
+// focuses or subscribes to, and it deliberately skips the paused push for a
+// workspace it has never pushed to. Without the grace demotion such a tracker
+// stays at the fast 2s/3s cadence for the life of the process.
+func TestPollModeGrace_DemotesWhenNoPushArrives(t *testing.T) {
+	isolateTestGitEnv(t)
+	repoDir, cleanup := setupTestRepo(t)
+	defer cleanup()
+
+	wt := NewWorkspaceTracker(repoDir, newTestLogger(t))
+	// Long poll intervals keep the loops from doing real git work during the
+	// test; we are asserting on the mode, not on scan output.
+	wt.filePollInterval = 30 * time.Second
+	wt.gitPollInterval = 30 * time.Second
+	wt.pollModeGrace = 50 * time.Millisecond
+
+	if got := wt.GetPollMode(); got != PollModeFast {
+		t.Fatalf("construction mode = %v, want %v", got, PollModeFast)
+	}
+
+	wt.Start(context.Background())
+	defer wt.Stop()
+
+	waitForPollMode(t, wt, PollModeSlow, 10*time.Second)
+}
+
+// TestPollModeGrace_ExplicitPushDisarmsDemotion verifies the gateway wins: once
+// it has spoken for a workspace, the fallback must never override it.
+func TestPollModeGrace_ExplicitPushDisarmsDemotion(t *testing.T) {
+	isolateTestGitEnv(t)
+	repoDir, cleanup := setupTestRepo(t)
+	defer cleanup()
+
+	wt := NewWorkspaceTracker(repoDir, newTestLogger(t))
+	wt.filePollInterval = 30 * time.Second
+	wt.gitPollInterval = 30 * time.Second
+	wt.pollModeGrace = 50 * time.Millisecond
+
+	wt.Start(context.Background())
+	defer wt.Stop()
+
+	// A focused workspace: the gateway pushes fast right after the instance
+	// comes up. The tracker must still be fast well after the grace deadline.
+	wt.SetPollMode(PollModeFast)
+	time.Sleep(300 * time.Millisecond)
+
+	if got := wt.GetPollMode(); got != PollModeFast {
+		t.Errorf("poll mode = %v after an explicit fast push, want %v", got, PollModeFast)
+	}
+}
+
+// TestPollModeGrace_NoOpPushStillDisarms pins the subtle case: pushing the mode
+// the tracker is already in changes no cadence, but it does prove the gateway
+// is managing this workspace — which is precisely what the grace demotion
+// exists to detect the absence of. Recording the push must therefore happen
+// before SetPollMode's same-mode early return.
+func TestPollModeGrace_NoOpPushStillDisarms(t *testing.T) {
+	isolateTestGitEnv(t)
+	repoDir, cleanup := setupTestRepo(t)
+	defer cleanup()
+
+	wt := NewWorkspaceTracker(repoDir, newTestLogger(t))
+	wt.filePollInterval = 30 * time.Second
+	wt.gitPollInterval = 30 * time.Second
+	wt.pollModeGrace = 50 * time.Millisecond
+
+	wt.Start(context.Background())
+	defer wt.Stop()
+
+	// Same mode the tracker was constructed with — a no-op for the cadence.
+	wt.SetPollMode(PollModeFast)
+	time.Sleep(300 * time.Millisecond)
+
+	if got := wt.GetPollMode(); got != PollModeFast {
+		t.Errorf("poll mode = %v after a same-mode push, want %v — the push was not recorded", got, PollModeFast)
+	}
+}
+
+// TestPollModeGrace_NotArmedWhenNeverStarted guards against a tracker that is
+// constructed but never started leaving a live timer (and therefore a
+// goroutine reference) behind.
+func TestPollModeGrace_NotArmedWhenNeverStarted(t *testing.T) {
+	isolateTestGitEnv(t)
+	repoDir, cleanup := setupTestRepo(t)
+	defer cleanup()
+
+	wt := NewWorkspaceTracker(repoDir, newTestLogger(t))
+	wt.pollModeGrace = 50 * time.Millisecond
+
+	time.Sleep(300 * time.Millisecond)
+
+	wt.pollModeMu.RLock()
+	armed := wt.pollModeGraceTimer != nil
+	wt.pollModeMu.RUnlock()
+	if armed {
+		t.Error("grace timer armed on a tracker that was never started")
+	}
+	if got := wt.GetPollMode(); got != PollModeFast {
+		t.Errorf("poll mode = %v on an unstarted tracker, want %v", got, PollModeFast)
+	}
+}

--- a/apps/backend/internal/agentctl/server/process/workspace_poll_mode_grace_test.go
+++ b/apps/backend/internal/agentctl/server/process/workspace_poll_mode_grace_test.go
@@ -39,7 +39,19 @@ func assertGraceDisarmed(t *testing.T, wt *WorkspaceTracker) {
 	}
 }
 
-func newGraceTestTracker(t *testing.T) *WorkspaceTracker {
+const (
+	// graceNeverFires is long enough that the fallback cannot run mid-test.
+	// Every test asserting that a push disarmed the demotion needs it: with a
+	// short grace the timer can fire between Start and SetPollMode on a loaded
+	// machine, and the test would still pass while exercising a different path
+	// — a slow-to-fast transition instead of the case it claims to cover.
+	graceNeverFires = time.Hour
+
+	// graceFiresQuickly keeps the one test that genuinely waits for a demotion short.
+	graceFiresQuickly = 50 * time.Millisecond
+)
+
+func newGraceTestTracker(t *testing.T, grace time.Duration) *WorkspaceTracker {
 	t.Helper()
 	isolateTestGitEnv(t)
 	repoDir, cleanup := setupTestRepo(t)
@@ -50,7 +62,7 @@ func newGraceTestTracker(t *testing.T) *WorkspaceTracker {
 	// assert on the mode, not on scan output.
 	wt.filePollInterval = 30 * time.Second
 	wt.gitPollInterval = 30 * time.Second
-	wt.pollModeGrace = 50 * time.Millisecond
+	wt.pollModeGrace = grace
 	return wt
 }
 
@@ -60,7 +72,7 @@ func newGraceTestTracker(t *testing.T) *WorkspaceTracker {
 // workspace it has never pushed to. Without the grace demotion such a tracker
 // stays at the fast 2s/3s cadence for the life of the process.
 func TestPollModeGrace_DemotesWhenNoPushArrives(t *testing.T) {
-	wt := newGraceTestTracker(t)
+	wt := newGraceTestTracker(t, graceFiresQuickly)
 
 	if got := wt.GetPollMode(); got != PollModeFast {
 		t.Fatalf("construction mode = %v, want %v", got, PollModeFast)
@@ -73,17 +85,19 @@ func TestPollModeGrace_DemotesWhenNoPushArrives(t *testing.T) {
 }
 
 // TestPollModeGrace_ExplicitPushDisarmsDemotion verifies the gateway wins: once
-// it has spoken for a workspace, the fallback must never override it.
+// it has spoken for a workspace, the fallback must never override it. The push
+// is a mode-changing one, and the grace is long enough that it cannot fire —
+// so the slow mode asserted below can only have come from the push.
 func TestPollModeGrace_ExplicitPushDisarmsDemotion(t *testing.T) {
-	wt := newGraceTestTracker(t)
+	wt := newGraceTestTracker(t, graceNeverFires)
 	wt.Start(context.Background())
 	defer wt.Stop()
 
-	wt.SetPollMode(PollModeFast)
+	wt.SetPollMode(PollModeSlow)
 
 	assertGraceDisarmed(t, wt)
-	if got := wt.GetPollMode(); got != PollModeFast {
-		t.Errorf("poll mode = %v after an explicit fast push, want %v", got, PollModeFast)
+	if got := wt.GetPollMode(); got != PollModeSlow {
+		t.Errorf("poll mode = %v after an explicit slow push, want %v", got, PollModeSlow)
 	}
 }
 
@@ -93,21 +107,27 @@ func TestPollModeGrace_ExplicitPushDisarmsDemotion(t *testing.T) {
 // exists to detect the absence of. Recording the push must therefore happen
 // before SetPollMode's same-mode early return.
 func TestPollModeGrace_NoOpPushStillDisarms(t *testing.T) {
-	wt := newGraceTestTracker(t)
+	wt := newGraceTestTracker(t, graceNeverFires)
 	wt.Start(context.Background())
 	defer wt.Stop()
 
-	// Same mode the tracker was constructed with — a no-op for the cadence.
+	// Same mode the tracker was constructed with — a no-op for the cadence. The
+	// long grace is what makes it one: had the fallback been able to demote
+	// first, this would be a slow-to-fast transition and the test would prove
+	// nothing about the same-mode path.
 	wt.SetPollMode(PollModeFast)
 
 	assertGraceDisarmed(t, wt)
+	if got := wt.GetPollMode(); got != PollModeFast {
+		t.Errorf("poll mode = %v after a no-op push, want it left at %v", got, PollModeFast)
+	}
 }
 
 // TestPollModeGrace_NotArmedWhenNeverStarted guards against a tracker that is
-// constructed but never started leaving a live timer (and therefore a
-// goroutine reference) behind.
+// constructed but never started allocating a fallback timer — one nothing would
+// ever disarm, since only Stop clears it.
 func TestPollModeGrace_NotArmedWhenNeverStarted(t *testing.T) {
-	wt := newGraceTestTracker(t)
+	wt := newGraceTestTracker(t, graceNeverFires)
 
 	wt.pollModeMu.RLock()
 	armed := wt.pollModeGraceTimer != nil
@@ -124,9 +144,9 @@ func TestPollModeGrace_NotArmedWhenNeverStarted(t *testing.T) {
 // Stop must clear the pending timer so it cannot fire against a torn-down
 // tracker and so it holds no reference past the tracker's lifetime.
 func TestPollModeGrace_StopDisarmsTimer(t *testing.T) {
-	wt := newGraceTestTracker(t)
-	// Long enough that the timer is certain to still be pending at Stop.
-	wt.pollModeGrace = time.Hour
+	// The long grace is what makes this test meaningful: the timer is certain to
+	// still be pending when Stop runs.
+	wt := newGraceTestTracker(t, graceNeverFires)
 
 	wt.Start(context.Background())
 

--- a/apps/backend/internal/agentctl/server/process/workspace_poll_mode_grace_test.go
+++ b/apps/backend/internal/agentctl/server/process/workspace_poll_mode_grace_test.go
@@ -7,9 +7,9 @@ import (
 )
 
 // waitForPollMode polls GetPollMode until it matches want or the deadline
-// passes. Used instead of a fixed sleep because the grace demotion fires on a
-// timer goroutine, and CI hosts under load can delay it well past its nominal
-// deadline.
+// passes. Used only for the demotion assertions, where the transition is
+// inherently timer-driven; the "must NOT demote" cases assert on timer state
+// instead so they need no sleeping at all.
 func waitForPollMode(t *testing.T, wt *WorkspaceTracker, want PollMode, timeout time.Duration) {
 	t.Helper()
 	deadline := time.Now().Add(timeout)
@@ -22,22 +22,45 @@ func waitForPollMode(t *testing.T, wt *WorkspaceTracker, want PollMode, timeout 
 	t.Fatalf("poll mode = %v after %v, want %v", wt.GetPollMode(), timeout, want)
 }
 
+// assertGraceDisarmed reports whether the fallback can still fire. Asserting on
+// the timer directly is deterministic: once a push has been recorded and the
+// timer cleared, no amount of elapsed time can demote the tracker, so there is
+// nothing to wait for.
+func assertGraceDisarmed(t *testing.T, wt *WorkspaceTracker) {
+	t.Helper()
+	wt.pollModeMu.RLock()
+	pushed, timer := wt.pollModePushed, wt.pollModeGraceTimer
+	wt.pollModeMu.RUnlock()
+	if !pushed {
+		t.Error("push was not recorded, so the grace demotion can still fire")
+	}
+	if timer != nil {
+		t.Error("grace timer still armed after an explicit push")
+	}
+}
+
+func newGraceTestTracker(t *testing.T) *WorkspaceTracker {
+	t.Helper()
+	isolateTestGitEnv(t)
+	repoDir, cleanup := setupTestRepo(t)
+	t.Cleanup(cleanup)
+
+	wt := NewWorkspaceTracker(repoDir, newTestLogger(t))
+	// Long poll intervals keep the loops from doing real git work; these tests
+	// assert on the mode, not on scan output.
+	wt.filePollInterval = 30 * time.Second
+	wt.gitPollInterval = 30 * time.Second
+	wt.pollModeGrace = 50 * time.Millisecond
+	return wt
+}
+
 // TestPollModeGrace_DemotesWhenNoPushArrives covers the leak this mechanism
 // exists to close: the gateway only pushes a mode for workspaces a client
 // focuses or subscribes to, and it deliberately skips the paused push for a
 // workspace it has never pushed to. Without the grace demotion such a tracker
 // stays at the fast 2s/3s cadence for the life of the process.
 func TestPollModeGrace_DemotesWhenNoPushArrives(t *testing.T) {
-	isolateTestGitEnv(t)
-	repoDir, cleanup := setupTestRepo(t)
-	defer cleanup()
-
-	wt := NewWorkspaceTracker(repoDir, newTestLogger(t))
-	// Long poll intervals keep the loops from doing real git work during the
-	// test; we are asserting on the mode, not on scan output.
-	wt.filePollInterval = 30 * time.Second
-	wt.gitPollInterval = 30 * time.Second
-	wt.pollModeGrace = 50 * time.Millisecond
+	wt := newGraceTestTracker(t)
 
 	if got := wt.GetPollMode(); got != PollModeFast {
 		t.Fatalf("construction mode = %v, want %v", got, PollModeFast)
@@ -52,23 +75,13 @@ func TestPollModeGrace_DemotesWhenNoPushArrives(t *testing.T) {
 // TestPollModeGrace_ExplicitPushDisarmsDemotion verifies the gateway wins: once
 // it has spoken for a workspace, the fallback must never override it.
 func TestPollModeGrace_ExplicitPushDisarmsDemotion(t *testing.T) {
-	isolateTestGitEnv(t)
-	repoDir, cleanup := setupTestRepo(t)
-	defer cleanup()
-
-	wt := NewWorkspaceTracker(repoDir, newTestLogger(t))
-	wt.filePollInterval = 30 * time.Second
-	wt.gitPollInterval = 30 * time.Second
-	wt.pollModeGrace = 50 * time.Millisecond
-
+	wt := newGraceTestTracker(t)
 	wt.Start(context.Background())
 	defer wt.Stop()
 
-	// A focused workspace: the gateway pushes fast right after the instance
-	// comes up. The tracker must still be fast well after the grace deadline.
 	wt.SetPollMode(PollModeFast)
-	time.Sleep(300 * time.Millisecond)
 
+	assertGraceDisarmed(t, wt)
 	if got := wt.GetPollMode(); got != PollModeFast {
 		t.Errorf("poll mode = %v after an explicit fast push, want %v", got, PollModeFast)
 	}
@@ -80,39 +93,21 @@ func TestPollModeGrace_ExplicitPushDisarmsDemotion(t *testing.T) {
 // exists to detect the absence of. Recording the push must therefore happen
 // before SetPollMode's same-mode early return.
 func TestPollModeGrace_NoOpPushStillDisarms(t *testing.T) {
-	isolateTestGitEnv(t)
-	repoDir, cleanup := setupTestRepo(t)
-	defer cleanup()
-
-	wt := NewWorkspaceTracker(repoDir, newTestLogger(t))
-	wt.filePollInterval = 30 * time.Second
-	wt.gitPollInterval = 30 * time.Second
-	wt.pollModeGrace = 50 * time.Millisecond
-
+	wt := newGraceTestTracker(t)
 	wt.Start(context.Background())
 	defer wt.Stop()
 
 	// Same mode the tracker was constructed with — a no-op for the cadence.
 	wt.SetPollMode(PollModeFast)
-	time.Sleep(300 * time.Millisecond)
 
-	if got := wt.GetPollMode(); got != PollModeFast {
-		t.Errorf("poll mode = %v after a same-mode push, want %v — the push was not recorded", got, PollModeFast)
-	}
+	assertGraceDisarmed(t, wt)
 }
 
 // TestPollModeGrace_NotArmedWhenNeverStarted guards against a tracker that is
 // constructed but never started leaving a live timer (and therefore a
 // goroutine reference) behind.
 func TestPollModeGrace_NotArmedWhenNeverStarted(t *testing.T) {
-	isolateTestGitEnv(t)
-	repoDir, cleanup := setupTestRepo(t)
-	defer cleanup()
-
-	wt := NewWorkspaceTracker(repoDir, newTestLogger(t))
-	wt.pollModeGrace = 50 * time.Millisecond
-
-	time.Sleep(300 * time.Millisecond)
+	wt := newGraceTestTracker(t)
 
 	wt.pollModeMu.RLock()
 	armed := wt.pollModeGraceTimer != nil
@@ -122,5 +117,35 @@ func TestPollModeGrace_NotArmedWhenNeverStarted(t *testing.T) {
 	}
 	if got := wt.GetPollMode(); got != PollModeFast {
 		t.Errorf("poll mode = %v on an unstarted tracker, want %v", got, PollModeFast)
+	}
+}
+
+// TestPollModeGrace_StopDisarmsTimer covers teardown inside the grace window:
+// Stop must clear the pending timer so it cannot fire against a torn-down
+// tracker and so it holds no reference past the tracker's lifetime.
+func TestPollModeGrace_StopDisarmsTimer(t *testing.T) {
+	wt := newGraceTestTracker(t)
+	// Long enough that the timer is certain to still be pending at Stop.
+	wt.pollModeGrace = time.Hour
+
+	wt.Start(context.Background())
+
+	wt.pollModeMu.RLock()
+	armed := wt.pollModeGraceTimer != nil
+	wt.pollModeMu.RUnlock()
+	if !armed {
+		t.Fatal("grace timer was not armed by Start")
+	}
+
+	wt.Stop()
+
+	wt.pollModeMu.RLock()
+	timer := wt.pollModeGraceTimer
+	wt.pollModeMu.RUnlock()
+	if timer != nil {
+		t.Error("grace timer still armed after Stop")
+	}
+	if got := wt.GetPollMode(); got != PollModeFast {
+		t.Errorf("Stop changed the poll mode to %v, want it left at %v", got, PollModeFast)
 	}
 }

--- a/apps/backend/internal/agentctl/server/process/workspace_tracker.go
+++ b/apps/backend/internal/agentctl/server/process/workspace_tracker.go
@@ -259,10 +259,10 @@ func newWorkspaceTracker(resolvedWorkDir, repositoryName string, log *logger.Log
 		// Start() then arms pollModeGraceTimer: the gateway only pushes a mode
 		// for workspaces a client focuses or subscribes to, and it deliberately
 		// skips the paused push for a workspace it has never pushed to
-		// (workspacePollAggregator.plan). Without the timer, every tracker the
-		// gateway never speaks about — including all of manager_rescan.go's and
-		// GetWorkspaceTrackerFor's, which are assigned no mode at all — scanned
-		// at 2s/3s for the life of the process.
+		// (workspacePollAggregator.plan). Without the timer, a tracker the
+		// gateway never speaks about scans at 2s/3s for the life of the
+		// process. Trackers created after launch inherit the workspace's
+		// current mode instead — see Manager.configurePollMode.
 		pollMode:                PollModeFast,
 		pollModeGrace:           pollModeGracePeriod,
 		monitorModeChanged:      make(chan struct{}, 1),

--- a/apps/backend/internal/agentctl/server/process/workspace_tracker.go
+++ b/apps/backend/internal/agentctl/server/process/workspace_tracker.go
@@ -24,6 +24,13 @@ const DefaultGitPollInterval = 3 * time.Second
 // a wedged Git process cannot retain the tracker flight indefinitely.
 const workspaceGitStatusObserveTimeout = 60 * time.Second
 
+// pollModeGracePeriod is how long a tracker stays at its fast construction
+// default before demoting itself to slow when no explicit mode ever arrives.
+// Long enough to cover a freshly-spawned instance being opened by the user
+// (the gateway pushes within milliseconds of a focus), short enough that a
+// workspace nobody watches stops scanning almost immediately.
+const pollModeGracePeriod = 60 * time.Second
+
 // fileStatus constants for FileInfo.Status values.
 const (
 	fileStatusDeleted   = "deleted"
@@ -75,11 +82,20 @@ type WorkspaceTracker struct {
 	gitPollInterval  time.Duration
 
 	// pollMode is the current rate at which the polling loops scan git state.
-	// Default at construction is PollModeSlow — safe fallback before the gateway
-	// pushes a focus signal. Mutate via SetPollMode (never directly) so loops
-	// receive the wake-up notification on transitions.
+	// Default at construction is PollModeFast so a freshly-spawned instance has
+	// no blind window, then pollModeGraceTimer demotes it to slow unless the
+	// gateway pushes a mode first. Mutate via SetPollMode (never directly) so
+	// loops receive the wake-up notification on transitions.
 	pollMode   PollMode
 	pollModeMu sync.RWMutex
+	// pollModePushed records that an explicit SetPollMode arrived, which
+	// disarms the grace demotion for good — from then on the gateway owns the
+	// mode. Guarded by pollModeMu.
+	pollModePushed     bool
+	pollModeGraceTimer *time.Timer
+	// pollModeGrace is pollModeGracePeriod in production; tests shorten it the
+	// same way they shorten filePollInterval / gitPollInterval.
+	pollModeGrace time.Duration
 	// One channel per loop because we need both loops to wake up on a mode
 	// change. A single shared channel would let the first reader steal the
 	// signal so only one loop wakes.
@@ -238,15 +254,17 @@ func newWorkspaceTracker(resolvedWorkDir, repositoryName string, log *logger.Log
 		workspaceStreamSubscribers: make(map[types.WorkspaceStreamSubscriber]struct{}),
 		filePollInterval:           DefaultFilePollInterval,
 		gitPollInterval:            DefaultGitPollInterval,
-		// Default to fast polling — matches pre-PR behavior so newly-created
-		// agentctl instances don't have a startup window where changes go
-		// undetected for up to 30s. The gateway pushes slow/paused once it
-		// knows no client is actively watching this workspace; until then,
-		// fast is the safe default (a freshly-spawned instance was always
-		// about to be used by someone, historically). Retained-task CPU
-		// savings still apply because those instances eventually receive a
-		// slow or paused mode push.
+		// Start fast so a freshly-spawned instance — which is usually about to
+		// be opened by someone — has no window where changes go unnoticed.
+		// Start() then arms pollModeGraceTimer: the gateway only pushes a mode
+		// for workspaces a client focuses or subscribes to, and it deliberately
+		// skips the paused push for a workspace it has never pushed to
+		// (workspacePollAggregator.plan). Without the timer, every tracker the
+		// gateway never speaks about — including all of manager_rescan.go's and
+		// GetWorkspaceTrackerFor's, which are assigned no mode at all — scanned
+		// at 2s/3s for the life of the process.
 		pollMode:                PollModeFast,
+		pollModeGrace:           pollModeGracePeriod,
 		monitorModeChanged:      make(chan struct{}, 1),
 		gitPollModeChanged:      make(chan struct{}, 1),
 		stopCh:                  make(chan struct{}),
@@ -390,6 +408,28 @@ func (wt *WorkspaceTracker) Start(_ context.Context) {
 	// Start git polling for detecting manual git operations (commits, resets, etc.)
 	wt.wg.Add(1)
 	go wt.pollGitChanges(wt.cancelCtx)
+
+	wt.armPollModeGrace()
+}
+
+// armPollModeGrace schedules the fallback demotion to slow. Armed here rather
+// than in the constructor so a tracker that is built but never started leaves
+// no timer behind. A SetPollMode that lands first disarms it permanently.
+func (wt *WorkspaceTracker) armPollModeGrace() {
+	wt.pollModeMu.Lock()
+	defer wt.pollModeMu.Unlock()
+	if wt.pollModePushed || wt.pollModeGraceTimer != nil || wt.pollModeGrace <= 0 {
+		return
+	}
+	wt.pollModeGraceTimer = time.AfterFunc(wt.pollModeGrace, wt.demoteUnpushedPollMode)
+}
+
+// disarmPollModeGraceLocked stops the fallback timer. Caller must hold pollModeMu.
+func (wt *WorkspaceTracker) disarmPollModeGraceLocked() {
+	if wt.pollModeGraceTimer != nil {
+		wt.pollModeGraceTimer.Stop()
+		wt.pollModeGraceTimer = nil
+	}
 }
 
 // stopTimeout is the maximum time Stop() will wait for goroutines to exit.
@@ -399,6 +439,10 @@ const stopTimeout = 5 * time.Second
 // up to 5 seconds for goroutines to exit before proceeding.
 func (wt *WorkspaceTracker) Stop() {
 	wt.stopOnce.Do(func() {
+		wt.pollModeMu.Lock()
+		wt.disarmPollModeGraceLocked()
+		wt.pollModeMu.Unlock()
+
 		// Synchronize cancellation with shared-observation admission. Once this
 		// lock is released, no observation can Add to gitStatusObserveWG.
 		wt.gitStatusObserveMu.Lock()


### PR DESCRIPTION
Workspace trackers are constructed in `PollModeFast` on the assumption that the gateway will push a slower mode once it knows whether anyone is watching, but for a workspace nobody focuses or subscribes to that push never arrives — so an unwatched tracker scanned at the 2s/3s cadence for the life of the process, costing ~18.6 `git.exe` spawns/second and ~50% of a core on Windows. A 60s grace timer now demotes any tracker the gateway never speaks about, while trackers created after launch inherit the mode it already pushed.

## Important Changes

- `newWorkspaceTracker` keeps the fast default, and `Start` arms a 60s fallback that demotes to slow when no explicit `SetPollMode` arrives. Fixed at the tracker rather than on the push path because `manager_rescan.go` and `GetWorkspaceTrackerFor` create trackers without assigning any mode, so a push-side fix would miss them.
- Any push disarms the fallback permanently, including a push matching the current mode: it changes no cadence but proves the gateway is managing the workspace, which is what the demotion exists to detect the absence of.
- `Manager` remembers the last pushed mode and applies it to trackers created after launch, so a repository added by rescan to an already-focused workspace is not demoted while the user is looking at it.

## Validation

- `go build ./...`, `go vet ./internal/agentctl/server/process/` — clean.
- `go test ./internal/agentctl/server/process/ -run 'TestPollModeGrace|TestRescanTracker|TestManager_SetWorkspacePollMode' -race` — 7 tests pass, covering demotion, explicit push, no-op push, unstarted tracker, inheritance into a focused workspace, and grace still owning a tracker when the gateway never pushed.
- Verified on a live Windows instance: unwatched workspaces log `no poll mode pushed within grace period, demoting to slow` 60s after startup while focused ones stay fast. With no client attached the backend now goes quiet — 0.1 `git.exe`/s and ~0% agentctl CPU, against 15+/s and ~50% of a core before.

## Possible Improvements

Low risk; the blast radius is the polling cadence of workspaces nobody is watching. Two larger issues found while investigating are not addressed here: agentctl instances are created per execution and never deleted in the standalone path, so trackers accumulate; and a focused task pays the fast cadence once per repository, which on a 12-repo task is 12 trackers at ~2.33 git commands/second each. Process spawn on Windows costs ~134ms against 3-5ms on macOS, so the same cadence is roughly 30x more expensive there.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.
