### PR TITLE
docs: clarify subscription usage surfaces

### DIFF
--- a/docs/public/agents-and-profiles.md
+++ b/docs/public/agents-and-profiles.md
@@ -87,12 +87,20 @@ Model, mode, command, and configuration choices are probed from the locally inst
 
 Use the profile refresh control after installing, authenticating, or upgrading an agent. A manual refresh updates both the advertised models, modes, and commands and the visible capability status, so an old failure banner does not remain authoritative after the local CLI recovers.
 
-Subscription usage is not shown on **Settings > Agents**, which is the page for
-installing host CLIs and configuring their profiles. When [Office mode](feature-status.md)
-is enabled, open **Office > Agents** and select an Office agent to see its
-**Subscription Quota** on the overview; the Office dashboard also summarizes
-the highest utilization across subscription agents. These cards appear only
-for supported subscription agents with provider credentials.
+### Monitor Office agent quota
+
+> [!EXPERIMENTAL]
+> Office mode is feature-flagged and disabled in the production profile by
+> default. Enable **Office mode** under **Settings > System > Feature Toggles**
+> and restart Kandev to try it; its routes and agent surfaces are still in
+> progress. For stable host-CLI installation and profile configuration, use
+> **Settings > Agents**.
+
+When [Office mode](feature-status.md) is enabled, open **Office > Agents** and
+select an Office agent to see its **Subscription Quota** on the overview; the
+Office dashboard also summarizes the highest utilization across subscription
+agents. These cards appear only for supported subscription agents with provider
+credentials.
 
 For account-wide provider usage across supported providers, install the
 [Provider Usage plugin](https://github.com/kdlbs/kandev-plugin-provider-usage).

--- a/docs/public/agents-and-profiles.md
+++ b/docs/public/agents-and-profiles.md
@@ -87,7 +87,20 @@ Model, mode, command, and configuration choices are probed from the locally inst
 
 Use the profile refresh control after installing, authenticating, or upgrading an agent. A manual refresh updates both the advertised models, modes, and commands and the visible capability status, so an old failure banner does not remain authoritative after the local CLI recovers.
 
-**Settings > Agents** shows **Subscription Usage** only when a supported host agent is signed in through a subscription plan. The current section covers Codex and Claude Code, reports the provider's plan and rate-limit windows, and can be refreshed on demand. It is an operational signal from the installed CLI, not a billing ledger or a guarantee that the next request will be accepted; provider availability, account policy, and concurrent usage still apply.
+Subscription usage is not shown on **Settings > Agents**, which is the page for
+installing host CLIs and configuring their profiles. When [Office mode](feature-status.md)
+is enabled, open **Office > Agents** and select an Office agent to see its
+**Subscription Quota** on the overview; the Office dashboard also summarizes
+the highest utilization across subscription agents. These cards appear only
+for supported subscription agents with provider credentials.
+
+For account-wide provider usage across supported providers, install the
+[Provider Usage plugin](https://github.com/kdlbs/kandev-plugin-provider-usage).
+It adds a provider pill to the session top bar and can add a compact display to
+the global status bar. Configure it under **Settings > Plugins > Provider
+Usage**. These usage surfaces are operational signals, not a billing ledger or
+a guarantee that the next request will be accepted; provider availability,
+account policy, and concurrent usage still apply.
 
 ### CLI flags
 

--- a/docs/public/agents-and-profiles.md
+++ b/docs/public/agents-and-profiles.md
@@ -97,10 +97,14 @@ for supported subscription agents with provider credentials.
 For account-wide provider usage across supported providers, install the
 [Provider Usage plugin](https://github.com/kdlbs/kandev-plugin-provider-usage).
 It adds a provider pill to the session top bar and can add a compact display to
-the global status bar. Configure it under **Settings > Plugins > Provider
-Usage**. These usage surfaces are operational signals, not a billing ledger or
-a guarantee that the next request will be accepted; provider availability,
-account policy, and concurrent usage still apply.
+the global status bar. The optional status-bar display requires **App status
+bar** to be enabled under **Settings > System > Feature Toggles**; enable it
+and restart Kandev for the change to take effect. If it remains disabled, the
+session top-bar pill still works, but the global status-bar and phone Status
+drawer display do not appear. Configure the plugin under **Settings > Plugins
+> Provider Usage**. These usage surfaces are operational signals, not a billing
+ledger or a guarantee that the next request will be accepted; provider
+availability, account policy, and concurrent usage still apply.
 
 ### CLI flags
 

--- a/docs/public/agents-and-profiles.md
+++ b/docs/public/agents-and-profiles.md
@@ -108,11 +108,12 @@ It adds a provider pill to the session top bar and can add a compact display to
 the global status bar. The optional status-bar display requires **App status
 bar** to be enabled under **Settings > System > Feature Toggles**; enable it
 and restart Kandev for the change to take effect. If it remains disabled, the
-session top-bar pill still works, but the global status-bar and phone Status
-drawer display do not appear. Configure the plugin under **Settings > Plugins
-> Provider Usage**. These usage surfaces are operational signals, not a billing
-ledger or a guarantee that the next request will be accepted; provider
-availability, account policy, and concurrent usage still apply.
+session top-bar pill remains available; enabling it also adds the global
+status-bar and phone Status drawer display. Configure the plugin under
+**Settings > Plugins > Provider Usage**. These usage surfaces are operational
+signals, not a billing ledger or a guarantee that the next request will be
+accepted; provider availability, account policy, and concurrent usage still
+apply.
 
 ### CLI flags
 

--- a/docs/public/sessions-and-review.md
+++ b/docs/public/sessions-and-review.md
@@ -108,7 +108,15 @@ All panels for a task point at the same task environment. In a multi-repository 
 
 Structured shell-command activity keeps the command, working directory, status, and output size in the chat row. Expand **Output** to fetch the transcript; Kandev continues refreshing an open, running command and stops when it reaches a terminal state. The disclosure separates standard output and errors, reports truncation and the exit code when known, and offers **Retry** when the transcript request fails. Historical command transcripts are loaded only when opened, which keeps long conversations responsive without discarding the stored output.
 
-The ring in the chat-input toolbar shows the active session's context-window use when the agent reports a trustworthy window size. Open it to see used and total tokens. For a supported Codex or Claude Code subscription session, the same popover also fetches the account plan and rate-limit windows; opening it again requests fresh provider data, subject to a short server-side refresh clamp. Kandev hides the ring instead of presenting impossible data when reported use exceeds the reported window, and agents without usage support show no subscription rows.
+The ring in the chat-input toolbar shows the active session's context-window use
+when the agent reports a trustworthy window size. Open it to see used and total
+tokens. This popover does not show provider subscription plans or rate-limit
+windows. For account-wide provider usage, install the [Provider Usage
+plugin](https://github.com/kdlbs/kandev-plugin-provider-usage), which adds a
+provider pill to the session top bar and can add a compact display to the global
+status bar; configure it under **Settings > Plugins > Provider Usage**. Kandev
+hides the context ring instead of presenting impossible data when reported use
+exceeds the reported window.
 
 ## Inspect changes
 

--- a/docs/public/sessions-and-review.md
+++ b/docs/public/sessions-and-review.md
@@ -114,9 +114,13 @@ tokens. This popover does not show provider subscription plans or rate-limit
 windows. For account-wide provider usage, install the [Provider Usage
 plugin](https://github.com/kdlbs/kandev-plugin-provider-usage), which adds a
 provider pill to the session top bar and can add a compact display to the global
-status bar; configure it under **Settings > Plugins > Provider Usage**. Kandev
-hides the context ring instead of presenting impossible data when reported use
-exceeds the reported window.
+status bar. The optional status-bar display requires **App status bar** to be
+enabled under **Settings > System > Feature Toggles**; enable it and restart
+Kandev for the change to take effect. If it remains disabled, the session
+top-bar pill still works, but the global status-bar and phone Status drawer
+display do not appear. Configure the plugin under **Settings > Plugins >
+Provider Usage**. Kandev hides the context ring instead of presenting
+impossible data when reported use exceeds the reported window.
 
 ## Inspect changes
 

--- a/docs/public/sessions-and-review.md
+++ b/docs/public/sessions-and-review.md
@@ -110,16 +110,16 @@ Structured shell-command activity keeps the command, working directory, status, 
 
 The ring in the chat-input toolbar shows the active session's context-window use
 when the agent reports a trustworthy window size. Open it to see used and total
-tokens. This popover does not show provider subscription plans or rate-limit
-windows. For account-wide provider usage, install the [Provider Usage
+tokens; it focuses on the active session's context window. For account-wide
+provider usage, install the [Provider Usage
 plugin](https://github.com/kdlbs/kandev-plugin-provider-usage), which adds a
 provider pill to the session top bar and can add a compact display to the global
 status bar. The optional status-bar display requires **App status bar** to be
 enabled under **Settings > System > Feature Toggles**; enable it and restart
-Kandev for the change to take effect. If it remains disabled, the session
-top-bar pill still works, but the global status-bar and phone Status drawer
-display do not appear. Configure the plugin under **Settings > Plugins >
-Provider Usage**. Kandev hides the context ring instead of presenting
+Kandev for the change to take effect. The session top-bar pill remains available
+on its own, while enabling App status bar also adds the global status-bar and
+phone Status drawer display. Configure the plugin under **Settings > Plugins >
+Provider Usage**. Kandev hides the context ring rather than presenting
 impossible data when reported use exceeds the reported window.
 
 ## Inspect changes


### PR DESCRIPTION
The public guides still described subscription usage surfaces removed from Settings > Agents and the chat context tooltip, sending users to controls that no longer exist. The documentation now distinguishes Office subscription quota from the Provider Usage plugin's account-wide displays and accurately describes the context ring.

## Validation

- `node --test scripts/validate-public-docs.test.mjs`
- `node scripts/validate-public-docs.mjs`
- `git diff --check`
- Commit hooks: harness lint and commitlint passed.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->