### PR TITLE
fix(web): stabilize task dialog rendering in WebKit

### DIFF
--- a/apps/packages/ui/src/alert-dialog.tsx
+++ b/apps/packages/ui/src/alert-dialog.tsx
@@ -52,12 +52,14 @@ function AlertDialogContent({
   className,
   size = "default",
   enterConfirms = true,
+  overlayClassName,
   onKeyDown,
   ...props
 }: React.ComponentProps<typeof AlertDialogPrimitive.Content> & {
   size?: "default" | "sm";
   /** Pressing Enter activates the semantic action button. Default: true. */
   enterConfirms?: boolean;
+  overlayClassName?: string;
 }) {
   const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
     onKeyDown?.(event);
@@ -65,7 +67,7 @@ function AlertDialogContent({
   };
   return (
     <AlertDialogPortal>
-      <AlertDialogOverlay />
+      <AlertDialogOverlay className={overlayClassName} />
       <AlertDialogPrimitive.Content
         data-slot="alert-dialog-content"
         data-size={size}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -264,8 +264,13 @@ html[data-rendering-engine="webkit"] .create-task-dialog-overlay {
   z-index: 49;
 }
 
+html[data-rendering-engine="webkit"] .discard-confirmation-overlay {
+  z-index: 52;
+}
+
 html[data-rendering-engine="webkit"] [data-webkit-modal-layer="discard-confirmation"] {
   z-index: 53;
+  height: fit-content;
 }
 
 html[data-rendering-engine="webkit"] [data-webkit-safe-motion="true"][data-state="open"] {

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -238,7 +238,9 @@
 /* WebKit can leave a fixed dialog's transform animation on a separate layer,
    which makes the Create Task surface look soft or briefly sit below its
    overlay. Keep the workaround scoped to the dialog opt-in and the engine
-   marker so Chromium keeps the existing motion and geometry. */
+   marker so Chromium keeps the existing motion and geometry. The task's own
+   overlay is one level lower so a nested confirmation can reuse the shared
+   modal level and still paint above the task form. */
 @keyframes kandev-dialog-webkit-enter {
   from {
     opacity: 0;
@@ -255,7 +257,15 @@ html[data-rendering-engine="webkit"] [data-webkit-safe-motion="true"] {
   inset: 0;
   margin: auto;
   translate: 0 0;
-  z-index: 51;
+  z-index: 50;
+}
+
+html[data-rendering-engine="webkit"] .create-task-dialog-overlay {
+  z-index: 49;
+}
+
+html[data-rendering-engine="webkit"] [data-webkit-modal-layer="discard-confirmation"] {
+  z-index: 53;
 }
 
 html[data-rendering-engine="webkit"] [data-webkit-safe-motion="true"][data-state="open"] {

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -235,6 +235,43 @@
   }
 }
 
+/* WebKit can leave a fixed dialog's transform animation on a separate layer,
+   which makes the Create Task surface look soft or briefly sit below its
+   overlay. Keep the workaround scoped to the dialog opt-in and the engine
+   marker so Chromium keeps the existing motion and geometry. */
+@keyframes kandev-dialog-webkit-enter {
+  from {
+    opacity: 0;
+  }
+}
+
+@keyframes kandev-dialog-webkit-exit {
+  to {
+    opacity: 0;
+  }
+}
+
+html[data-rendering-engine="webkit"] [data-webkit-safe-motion="true"] {
+  inset: 0;
+  margin: auto;
+  translate: 0 0;
+  z-index: 51;
+}
+
+html[data-rendering-engine="webkit"] [data-webkit-safe-motion="true"][data-state="open"] {
+  animation-name: kandev-dialog-webkit-enter;
+}
+
+html[data-rendering-engine="webkit"] [data-webkit-safe-motion="true"][data-state="closed"] {
+  animation-name: kandev-dialog-webkit-exit;
+}
+
+@media (min-width: 640px) {
+  html[data-rendering-engine="webkit"] [data-webkit-safe-motion="true"] {
+    height: fit-content;
+  }
+}
+
 /* iOS Safari auto-zooms a focused form control whose computed font-size is
    < 16px (native <select> included). Force 16px on coarse-pointer (touch)
    devices to stop focus-zoom. !important because some controls are styled by

--- a/apps/web/components/discard-local-changes-dialog.tsx
+++ b/apps/web/components/discard-local-changes-dialog.tsx
@@ -38,6 +38,7 @@ export function DiscardLocalChangesDialog({
     <AlertDialog open={open} onOpenChange={onOpenChange}>
       <AlertDialogContent
         data-testid="discard-local-changes-dialog"
+        data-webkit-safe-motion="true"
         data-webkit-modal-layer="discard-confirmation"
         onClick={(e) => e.stopPropagation()}
       >

--- a/apps/web/components/discard-local-changes-dialog.tsx
+++ b/apps/web/components/discard-local-changes-dialog.tsx
@@ -40,6 +40,7 @@ export function DiscardLocalChangesDialog({
         data-testid="discard-local-changes-dialog"
         data-webkit-safe-motion="true"
         data-webkit-modal-layer="discard-confirmation"
+        overlayClassName="discard-confirmation-overlay"
         onClick={(e) => e.stopPropagation()}
       >
         <AlertDialogHeader>

--- a/apps/web/components/discard-local-changes-dialog.tsx
+++ b/apps/web/components/discard-local-changes-dialog.tsx
@@ -38,6 +38,7 @@ export function DiscardLocalChangesDialog({
     <AlertDialog open={open} onOpenChange={onOpenChange}>
       <AlertDialogContent
         data-testid="discard-local-changes-dialog"
+        data-webkit-modal-layer="discard-confirmation"
         onClick={(e) => e.stopPropagation()}
       >
         <AlertDialogHeader>

--- a/apps/web/components/task-create-dialog.tsx
+++ b/apps/web/components/task-create-dialog.tsx
@@ -598,6 +598,7 @@ export function TaskCreateDialog(props: TaskCreateDialogProps) {
       <DialogContent
         ref={setPopoverContainer}
         data-testid="create-task-dialog"
+        data-webkit-safe-motion="true"
         className="w-full h-full min-w-0 max-w-full max-h-full overflow-visible rounded-none sm:w-[900px] sm:h-auto sm:max-w-none sm:max-h-[85vh] sm:rounded-lg flex flex-col"
       >
         <TaskCreateDialogPopoverContainerProvider container={popoverContainer}>

--- a/apps/web/components/task-create-dialog.tsx
+++ b/apps/web/components/task-create-dialog.tsx
@@ -601,7 +601,7 @@ export function TaskCreateDialog(props: TaskCreateDialogProps) {
         data-webkit-safe-motion="true"
         showCloseButton={false}
         overlayClassName="create-task-dialog-overlay"
-        className="w-full h-full min-w-0 max-w-full max-h-full overflow-visible rounded-none sm:w-[900px] sm:h-auto sm:max-w-none sm:max-h-[85vh] sm:rounded-lg flex flex-col"
+        className="w-full h-full min-w-0 max-w-full max-h-full overflow-visible rounded-none pt-0 sm:w-[900px] sm:h-auto sm:max-w-none sm:max-h-[85vh] sm:rounded-lg flex flex-col"
       >
         <TaskCreateDialogPopoverContainerProvider container={popoverContainer}>
           <DialogHeader>

--- a/apps/web/components/task-create-dialog.tsx
+++ b/apps/web/components/task-create-dialog.tsx
@@ -599,6 +599,7 @@ export function TaskCreateDialog(props: TaskCreateDialogProps) {
         ref={setPopoverContainer}
         data-testid="create-task-dialog"
         data-webkit-safe-motion="true"
+        showCloseButton={false}
         overlayClassName="create-task-dialog-overlay"
         className="w-full h-full min-w-0 max-w-full max-h-full overflow-visible rounded-none sm:w-[900px] sm:h-auto sm:max-w-none sm:max-h-[85vh] sm:rounded-lg flex flex-col"
       >

--- a/apps/web/components/task-create-dialog.tsx
+++ b/apps/web/components/task-create-dialog.tsx
@@ -599,6 +599,7 @@ export function TaskCreateDialog(props: TaskCreateDialogProps) {
         ref={setPopoverContainer}
         data-testid="create-task-dialog"
         data-webkit-safe-motion="true"
+        overlayClassName="create-task-dialog-overlay"
         className="w-full h-full min-w-0 max-w-full max-h-full overflow-visible rounded-none sm:w-[900px] sm:h-auto sm:max-w-none sm:max-h-[85vh] sm:rounded-lg flex flex-col"
       >
         <TaskCreateDialogPopoverContainerProvider container={popoverContainer}>

--- a/apps/web/e2e/helpers/dialog-webkit-metrics.ts
+++ b/apps/web/e2e/helpers/dialog-webkit-metrics.ts
@@ -26,7 +26,12 @@ export async function readDialogRenderingMetrics(
   }: DialogRenderingMetricsOptions = {},
 ): Promise<DialogRenderingMetrics> {
   await dialog.evaluate(async (element) => {
-    await Promise.all(element.getAnimations().map((animation) => animation.finished));
+    const animations = element.getAnimations().filter((animation) => {
+      if (animation.playState !== "running") return false;
+      const iterations = animation.effect?.getComputedTiming().iterations;
+      return typeof iterations === "number" && Number.isFinite(iterations);
+    });
+    await Promise.all(animations.map((animation) => animation.finished.catch(() => undefined)));
   });
 
   return dialog.evaluate(

--- a/apps/web/e2e/helpers/dialog-webkit-metrics.ts
+++ b/apps/web/e2e/helpers/dialog-webkit-metrics.ts
@@ -1,0 +1,71 @@
+import { expect, type Locator } from "@playwright/test";
+
+export type DialogRenderingMetrics = {
+  animationName: string;
+  transform: string;
+  translate: string;
+  zIndex: string;
+  overlayZIndex: string;
+  centerX: number;
+  centerY: number;
+  width: number;
+  height: number;
+  contentOverOverlay: boolean;
+};
+
+type DialogRenderingMetricsOptions = {
+  overlaySelector?: string;
+  contentSelector?: string;
+};
+
+export async function readDialogRenderingMetrics(
+  dialog: Locator,
+  {
+    overlaySelector = '[data-slot="dialog-overlay"]',
+    contentSelector,
+  }: DialogRenderingMetricsOptions = {},
+): Promise<DialogRenderingMetrics> {
+  await dialog.evaluate(async (element) => {
+    await Promise.all(element.getAnimations().map((animation) => animation.finished));
+  });
+
+  return dialog.evaluate(
+    (element: HTMLElement, selectors: DialogRenderingMetricsOptions) => {
+      const style = getComputedStyle(element);
+      const box = element.getBoundingClientRect();
+      const center = document.elementFromPoint(box.left + box.width / 2, box.top + box.height / 2);
+      const overlay = document.querySelector<HTMLElement>(selectors.overlaySelector!);
+      return {
+        animationName: style.animationName,
+        transform: style.transform,
+        translate: style.translate,
+        zIndex: style.zIndex,
+        overlayZIndex: overlay ? getComputedStyle(overlay).zIndex : "",
+        centerX: box.left + box.width / 2,
+        centerY: box.top + box.height / 2,
+        width: box.width,
+        height: box.height,
+        contentOverOverlay: selectors.contentSelector
+          ? center?.closest(selectors.contentSelector) === element
+          : false,
+      };
+    },
+    { overlaySelector, contentSelector },
+  );
+}
+
+export async function expectWebkitDialogMotion(
+  dialog: Locator,
+  options: DialogRenderingMetricsOptions & {
+    contentZIndex: string;
+    overlayZIndex: string;
+  },
+): Promise<DialogRenderingMetrics> {
+  const metrics = await readDialogRenderingMetrics(dialog, options);
+  expect(metrics.animationName).toBe("kandev-dialog-webkit-enter");
+  expect(["none", "matrix(1, 0, 0, 1, 0, 0)"]).toContain(metrics.transform);
+  expect(["none", "0px", "0px 0px"]).toContain(metrics.translate);
+  expect(metrics.zIndex).toBe(options.contentZIndex);
+  expect(metrics.overlayZIndex).toBe(options.overlayZIndex);
+  return metrics;
+}

--- a/apps/web/e2e/tests/task/create-task-branch-selector.spec.ts
+++ b/apps/web/e2e/tests/task/create-task-branch-selector.spec.ts
@@ -331,6 +331,9 @@ test.describe("Fresh-branch flow", () => {
       fs.writeFileSync(path.join(setup.repoDir, "WIP.txt"), "draft");
 
       await openDialogWithLocalProfile(testPage, setup.profileName, setup.repoName);
+      await testPage.locator("html").evaluate((root) => {
+        root.setAttribute("data-rendering-engine", "webkit");
+      });
       await testPage.getByTestId("fresh-branch-toggle").click();
       // Submit triggers the dirty preflight; the modal lists WIP.txt.
       await testPage.getByTestId("submit-start-agent").click();
@@ -338,6 +341,22 @@ test.describe("Fresh-branch flow", () => {
       const modal = testPage.getByTestId("discard-local-changes-dialog");
       await expect(modal).toBeVisible({ timeout: 5_000 });
       await expect(testPage.getByTestId("discard-local-changes-files")).toContainText("WIP.txt");
+      const modalRendering = await modal.evaluate((element) => {
+        const style = getComputedStyle(element);
+        const overlay = document.querySelector<HTMLElement>('[data-slot="alert-dialog-overlay"]');
+        return {
+          animationName: style.animationName,
+          transform: style.transform,
+          translate: style.translate,
+          zIndex: style.zIndex,
+          overlayZIndex: overlay ? getComputedStyle(overlay).zIndex : "",
+        };
+      });
+      expect(modalRendering.animationName).toBe("kandev-dialog-webkit-enter");
+      expect(["none", "matrix(1, 0, 0, 1, 0, 0)"]).toContain(modalRendering.transform);
+      expect(["none", "0px", "0px 0px"]).toContain(modalRendering.translate);
+      expect(modalRendering.zIndex).toBe("53");
+      expect(modalRendering.overlayZIndex).toBe("50");
 
       // Cancel returns to the form with the toggle still on.
       await testPage.getByTestId("discard-local-changes-cancel").click();

--- a/apps/web/e2e/tests/task/create-task-branch-selector.spec.ts
+++ b/apps/web/e2e/tests/task/create-task-branch-selector.spec.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import fs from "node:fs";
 import { execSync } from "node:child_process";
 import { test, expect } from "../../fixtures/test-base";
+import { expectWebkitDialogMotion } from "../../helpers/dialog-webkit-metrics";
 import { useRegularMode } from "../../helpers/regular-mode";
 import { KanbanPage } from "../../pages/kanban-page";
 import { makeGitEnv } from "../../helpers/git-helper";
@@ -341,22 +342,11 @@ test.describe("Fresh-branch flow", () => {
       const modal = testPage.getByTestId("discard-local-changes-dialog");
       await expect(modal).toBeVisible({ timeout: 5_000 });
       await expect(testPage.getByTestId("discard-local-changes-files")).toContainText("WIP.txt");
-      const modalRendering = await modal.evaluate((element) => {
-        const style = getComputedStyle(element);
-        const overlay = document.querySelector<HTMLElement>('[data-slot="alert-dialog-overlay"]');
-        return {
-          animationName: style.animationName,
-          transform: style.transform,
-          translate: style.translate,
-          zIndex: style.zIndex,
-          overlayZIndex: overlay ? getComputedStyle(overlay).zIndex : "",
-        };
+      await expectWebkitDialogMotion(modal, {
+        overlaySelector: '[data-slot="alert-dialog-overlay"]',
+        contentZIndex: "53",
+        overlayZIndex: "52",
       });
-      expect(modalRendering.animationName).toBe("kandev-dialog-webkit-enter");
-      expect(["none", "matrix(1, 0, 0, 1, 0, 0)"]).toContain(modalRendering.transform);
-      expect(["none", "0px", "0px 0px"]).toContain(modalRendering.translate);
-      expect(modalRendering.zIndex).toBe("53");
-      expect(modalRendering.overlayZIndex).toBe("52");
 
       // Cancel returns to the form with the toggle still on.
       await testPage.getByTestId("discard-local-changes-cancel").click();

--- a/apps/web/e2e/tests/task/create-task-branch-selector.spec.ts
+++ b/apps/web/e2e/tests/task/create-task-branch-selector.spec.ts
@@ -356,7 +356,7 @@ test.describe("Fresh-branch flow", () => {
       expect(["none", "matrix(1, 0, 0, 1, 0, 0)"]).toContain(modalRendering.transform);
       expect(["none", "0px", "0px 0px"]).toContain(modalRendering.translate);
       expect(modalRendering.zIndex).toBe("53");
-      expect(modalRendering.overlayZIndex).toBe("50");
+      expect(modalRendering.overlayZIndex).toBe("52");
 
       // Cancel returns to the form with the toggle still on.
       await testPage.getByTestId("discard-local-changes-cancel").click();

--- a/apps/web/e2e/tests/task/create-task-webkit-rendering.spec.ts
+++ b/apps/web/e2e/tests/task/create-task-webkit-rendering.spec.ts
@@ -1,26 +1,21 @@
 import { expect, type Locator, type Page } from "@playwright/test";
 import { test } from "../../fixtures/test-base";
+import {
+  readDialogRenderingMetrics,
+  expectWebkitDialogMotion,
+} from "../../helpers/dialog-webkit-metrics";
 import { useRegularMode } from "../../helpers/regular-mode";
 import { KanbanPage } from "../../pages/kanban-page";
 
 useRegularMode();
 
-type DialogRenderingMetrics = {
-  animationName: string;
-  transform: string;
-  translate: string;
-  zIndex: string;
-  overlayZIndex: string;
-  centerX: number;
-  centerY: number;
-  width: number;
-  height: number;
-  contentOverOverlay: boolean;
-};
-
-async function openCreateTaskDialog(testPage: Page): Promise<Locator> {
+async function openCreateTaskDialog(
+  testPage: Page,
+  beforeOpen?: () => Promise<void>,
+): Promise<Locator> {
   const kanban = new KanbanPage(testPage);
   await kanban.goto();
+  await beforeOpen?.();
   await kanban.createTaskButton.first().click();
   const dialog = testPage.getByTestId("create-task-dialog");
   await expect(dialog).toBeVisible();
@@ -30,37 +25,14 @@ async function openCreateTaskDialog(testPage: Page): Promise<Locator> {
   return dialog;
 }
 
-async function readDialogRenderingMetrics(dialog: Locator): Promise<DialogRenderingMetrics> {
-  await dialog.evaluate(async (element) => {
-    await Promise.all(element.getAnimations().map((animation) => animation.finished));
-  });
-
-  return dialog.evaluate((element: HTMLElement) => {
-    const style = getComputedStyle(element);
-    const box = element.getBoundingClientRect();
-    const center = document.elementFromPoint(box.left + box.width / 2, box.top + box.height / 2);
-    const overlay = document.querySelector<HTMLElement>('[data-slot="dialog-overlay"]');
-    return {
-      animationName: style.animationName,
-      transform: style.transform,
-      translate: style.translate,
-      zIndex: style.zIndex,
-      overlayZIndex: overlay ? getComputedStyle(overlay).zIndex : "",
-      centerX: box.left + box.width / 2,
-      centerY: box.top + box.height / 2,
-      width: box.width,
-      height: box.height,
-      contentOverOverlay: center?.closest('[data-testid="create-task-dialog"]') === element,
-    };
-  });
-}
-
 test.describe("Create Task WebKit rendering", () => {
   test("keeps the existing Chromium motion and geometry", async ({ testPage, prCapture }) => {
     const dialog = await openCreateTaskDialog(testPage);
     await expect(testPage.locator("html")).toHaveAttribute("data-rendering-engine", "other");
 
-    const metrics = await readDialogRenderingMetrics(dialog);
+    const metrics = await readDialogRenderingMetrics(dialog, {
+      contentSelector: '[data-testid="create-task-dialog"]',
+    });
     const viewport = testPage.viewportSize();
     expect(viewport).not.toBeNull();
     expect(metrics.animationName).toBe("enter");
@@ -77,27 +49,18 @@ test.describe("Create Task WebKit rendering", () => {
   });
 
   test("uses transform-free motion and centering for WebKit", async ({ testPage, prCapture }) => {
-    await testPage.goto("/");
-    await testPage.locator("html").evaluate((root) => {
-      root.setAttribute("data-rendering-engine", "webkit");
+    const dialog = await openCreateTaskDialog(testPage, async () => {
+      await testPage.locator("html").evaluate((root) => {
+        root.setAttribute("data-rendering-engine", "webkit");
+      });
     });
-
-    const kanban = new KanbanPage(testPage);
-    await kanban.createTaskButton.first().click();
-    const dialog = testPage.getByTestId("create-task-dialog");
-    await expect(dialog).toBeVisible();
-    await expect(dialog.getByRole("button", { name: "Close", exact: true })).toHaveCount(0);
-    await expect(dialog.getByRole("button", { name: "Cancel", exact: true })).toBeVisible();
-    await expect(dialog).toHaveCSS("padding-top", "0px");
-
-    const metrics = await readDialogRenderingMetrics(dialog);
+    const metrics = await expectWebkitDialogMotion(dialog, {
+      contentSelector: '[data-testid="create-task-dialog"]',
+      contentZIndex: "50",
+      overlayZIndex: "49",
+    });
     const viewport = testPage.viewportSize();
     expect(viewport).not.toBeNull();
-    expect(metrics.animationName).toBe("kandev-dialog-webkit-enter");
-    expect(["none", "matrix(1, 0, 0, 1, 0, 0)"]).toContain(metrics.transform);
-    expect(["none", "0px", "0px 0px"]).toContain(metrics.translate);
-    expect(metrics.zIndex).toBe("50");
-    expect(metrics.overlayZIndex).toBe("49");
     expect(metrics.width).toBe(900);
     expect(metrics.centerX).toBeCloseTo(viewport!.width / 2, 0);
     expect(metrics.centerY).toBeCloseTo(viewport!.height / 2, 0);

--- a/apps/web/e2e/tests/task/create-task-webkit-rendering.spec.ts
+++ b/apps/web/e2e/tests/task/create-task-webkit-rendering.spec.ts
@@ -24,6 +24,8 @@ async function openCreateTaskDialog(testPage: Page): Promise<Locator> {
   await kanban.createTaskButton.first().click();
   const dialog = testPage.getByTestId("create-task-dialog");
   await expect(dialog).toBeVisible();
+  await expect(dialog.getByRole("button", { name: "Close", exact: true })).toHaveCount(0);
+  await expect(dialog.getByRole("button", { name: "Cancel", exact: true })).toBeVisible();
   return dialog;
 }
 
@@ -83,6 +85,8 @@ test.describe("Create Task WebKit rendering", () => {
     await kanban.createTaskButton.first().click();
     const dialog = testPage.getByTestId("create-task-dialog");
     await expect(dialog).toBeVisible();
+    await expect(dialog.getByRole("button", { name: "Close", exact: true })).toHaveCount(0);
+    await expect(dialog.getByRole("button", { name: "Cancel", exact: true })).toBeVisible();
 
     const metrics = await readDialogRenderingMetrics(dialog);
     const viewport = testPage.viewportSize();

--- a/apps/web/e2e/tests/task/create-task-webkit-rendering.spec.ts
+++ b/apps/web/e2e/tests/task/create-task-webkit-rendering.spec.ts
@@ -1,0 +1,98 @@
+import { expect, type Locator, type Page } from "@playwright/test";
+import { test } from "../../fixtures/test-base";
+import { useRegularMode } from "../../helpers/regular-mode";
+import { KanbanPage } from "../../pages/kanban-page";
+
+useRegularMode();
+
+type DialogRenderingMetrics = {
+  animationName: string;
+  transform: string;
+  translate: string;
+  zIndex: string;
+  centerX: number;
+  centerY: number;
+  width: number;
+  height: number;
+  contentOverOverlay: boolean;
+};
+
+async function openCreateTaskDialog(testPage: Page): Promise<Locator> {
+  const kanban = new KanbanPage(testPage);
+  await kanban.goto();
+  await kanban.createTaskButton.first().click();
+  const dialog = testPage.getByTestId("create-task-dialog");
+  await expect(dialog).toBeVisible();
+  return dialog;
+}
+
+async function readDialogRenderingMetrics(dialog: Locator): Promise<DialogRenderingMetrics> {
+  await dialog.evaluate(async (element) => {
+    await Promise.all(element.getAnimations().map((animation) => animation.finished));
+  });
+
+  return dialog.evaluate((element: HTMLElement) => {
+    const style = getComputedStyle(element);
+    const box = element.getBoundingClientRect();
+    const center = document.elementFromPoint(box.left + box.width / 2, box.top + box.height / 2);
+    return {
+      animationName: style.animationName,
+      transform: style.transform,
+      translate: style.translate,
+      zIndex: style.zIndex,
+      centerX: box.left + box.width / 2,
+      centerY: box.top + box.height / 2,
+      width: box.width,
+      height: box.height,
+      contentOverOverlay: center?.closest('[data-testid="create-task-dialog"]') === element,
+    };
+  });
+}
+
+test.describe("Create Task WebKit rendering", () => {
+  test("keeps the existing Chromium motion and geometry", async ({ testPage, prCapture }) => {
+    const dialog = await openCreateTaskDialog(testPage);
+    await expect(testPage.locator("html")).toHaveAttribute("data-rendering-engine", "other");
+
+    const metrics = await readDialogRenderingMetrics(dialog);
+    const viewport = testPage.viewportSize();
+    expect(viewport).not.toBeNull();
+    expect(metrics.animationName).toBe("enter");
+    expect(metrics.translate).toContain("-50%");
+    expect(metrics.zIndex).toBe("50");
+    expect(metrics.width).toBe(900);
+    expect(metrics.centerX).toBeCloseTo(viewport!.width / 2, 0);
+    expect(metrics.centerY).toBeCloseTo(viewport!.height / 2, 0);
+    expect(metrics.contentOverOverlay).toBe(true);
+    await prCapture.screenshot("chromium-create-task-dialog", {
+      caption: "Chromium keeps the existing Create Task dialog motion and geometry.",
+    });
+  });
+
+  test("uses transform-free motion and centering for WebKit", async ({ testPage, prCapture }) => {
+    await testPage.goto("/");
+    await testPage.locator("html").evaluate((root) => {
+      root.setAttribute("data-rendering-engine", "webkit");
+    });
+
+    const kanban = new KanbanPage(testPage);
+    await kanban.createTaskButton.first().click();
+    const dialog = testPage.getByTestId("create-task-dialog");
+    await expect(dialog).toBeVisible();
+
+    const metrics = await readDialogRenderingMetrics(dialog);
+    const viewport = testPage.viewportSize();
+    expect(viewport).not.toBeNull();
+    expect(metrics.animationName).toBe("kandev-dialog-webkit-enter");
+    expect(["none", "matrix(1, 0, 0, 1, 0, 0)"]).toContain(metrics.transform);
+    expect(["none", "0px", "0px 0px"]).toContain(metrics.translate);
+    expect(metrics.zIndex).toBe("51");
+    expect(metrics.width).toBe(900);
+    expect(metrics.centerX).toBeCloseTo(viewport!.width / 2, 0);
+    expect(metrics.centerY).toBeCloseTo(viewport!.height / 2, 0);
+    expect(metrics.contentOverOverlay).toBe(true);
+    await prCapture.screenshot("webkit-create-task-dialog", {
+      caption: "The WebKit-safe Create Task dialog is centered without transformed text.",
+    });
+  });
+});

--- a/apps/web/e2e/tests/task/create-task-webkit-rendering.spec.ts
+++ b/apps/web/e2e/tests/task/create-task-webkit-rendering.spec.ts
@@ -10,6 +10,7 @@ type DialogRenderingMetrics = {
   transform: string;
   translate: string;
   zIndex: string;
+  overlayZIndex: string;
   centerX: number;
   centerY: number;
   width: number;
@@ -35,11 +36,13 @@ async function readDialogRenderingMetrics(dialog: Locator): Promise<DialogRender
     const style = getComputedStyle(element);
     const box = element.getBoundingClientRect();
     const center = document.elementFromPoint(box.left + box.width / 2, box.top + box.height / 2);
+    const overlay = document.querySelector<HTMLElement>('[data-slot="dialog-overlay"]');
     return {
       animationName: style.animationName,
       transform: style.transform,
       translate: style.translate,
       zIndex: style.zIndex,
+      overlayZIndex: overlay ? getComputedStyle(overlay).zIndex : "",
       centerX: box.left + box.width / 2,
       centerY: box.top + box.height / 2,
       width: box.width,
@@ -60,6 +63,7 @@ test.describe("Create Task WebKit rendering", () => {
     expect(metrics.animationName).toBe("enter");
     expect(metrics.translate).toContain("-50%");
     expect(metrics.zIndex).toBe("50");
+    expect(metrics.overlayZIndex).toBe("50");
     expect(metrics.width).toBe(900);
     expect(metrics.centerX).toBeCloseTo(viewport!.width / 2, 0);
     expect(metrics.centerY).toBeCloseTo(viewport!.height / 2, 0);
@@ -86,7 +90,8 @@ test.describe("Create Task WebKit rendering", () => {
     expect(metrics.animationName).toBe("kandev-dialog-webkit-enter");
     expect(["none", "matrix(1, 0, 0, 1, 0, 0)"]).toContain(metrics.transform);
     expect(["none", "0px", "0px 0px"]).toContain(metrics.translate);
-    expect(metrics.zIndex).toBe("51");
+    expect(metrics.zIndex).toBe("50");
+    expect(metrics.overlayZIndex).toBe("49");
     expect(metrics.width).toBe(900);
     expect(metrics.centerX).toBeCloseTo(viewport!.width / 2, 0);
     expect(metrics.centerY).toBeCloseTo(viewport!.height / 2, 0);

--- a/apps/web/e2e/tests/task/create-task-webkit-rendering.spec.ts
+++ b/apps/web/e2e/tests/task/create-task-webkit-rendering.spec.ts
@@ -26,6 +26,7 @@ async function openCreateTaskDialog(testPage: Page): Promise<Locator> {
   await expect(dialog).toBeVisible();
   await expect(dialog.getByRole("button", { name: "Close", exact: true })).toHaveCount(0);
   await expect(dialog.getByRole("button", { name: "Cancel", exact: true })).toBeVisible();
+  await expect(dialog).toHaveCSS("padding-top", "0px");
   return dialog;
 }
 
@@ -87,6 +88,7 @@ test.describe("Create Task WebKit rendering", () => {
     await expect(dialog).toBeVisible();
     await expect(dialog.getByRole("button", { name: "Close", exact: true })).toHaveCount(0);
     await expect(dialog.getByRole("button", { name: "Cancel", exact: true })).toBeVisible();
+    await expect(dialog).toHaveCSS("padding-top", "0px");
 
     const metrics = await readDialogRenderingMetrics(dialog);
     const viewport = testPage.viewportSize();

--- a/apps/web/e2e/tests/task/dialog-body-lock-helpers.ts
+++ b/apps/web/e2e/tests/task/dialog-body-lock-helpers.ts
@@ -42,9 +42,11 @@ export async function verifyStalledDialogCloseRecovery(page: Page, touch: boolea
       scrollLocked: true,
     });
 
-  const close = dialog.getByRole("button", { name: "Close" });
-  if (touch) await close.tap();
-  else await close.click();
+  // Create Task intentionally omits the generic top-right Close control; the
+  // footer Cancel action is the shared dismissal path for both viewports.
+  const cancel = dialog.getByRole("button", { name: "Cancel", exact: true });
+  if (touch) await cancel.tap();
+  else await cancel.click();
 
   await expect(dialog).not.toBeAttached();
   await expect(page.locator('[data-slot="dialog-overlay"]')).not.toBeAttached();

--- a/apps/web/e2e/tests/task/mobile-create-task-webkit-rendering.spec.ts
+++ b/apps/web/e2e/tests/task/mobile-create-task-webkit-rendering.spec.ts
@@ -20,6 +20,7 @@ test("keeps the WebKit Create Task dialog full-height and contained on mobile", 
   await expect(dialog).toBeVisible();
   await expect(dialog.getByRole("button", { name: "Close", exact: true })).toHaveCount(0);
   await expect(dialog.getByRole("button", { name: "Cancel", exact: true })).toBeVisible();
+  await expect(dialog).toHaveCSS("padding-top", "0px");
   await expect(dialog.getByTestId("task-title-input")).toBeVisible();
   await expect(dialog.getByTestId("task-description-input")).toBeVisible();
 

--- a/apps/web/e2e/tests/task/mobile-create-task-webkit-rendering.spec.ts
+++ b/apps/web/e2e/tests/task/mobile-create-task-webkit-rendering.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "../../fixtures/test-base";
+import { expectWebkitDialogMotion } from "../../helpers/dialog-webkit-metrics";
 import { assertNoDocumentHorizontalOverflow } from "../../helpers/layout-assertions";
 import { useRegularMode } from "../../helpers/regular-mode";
 import { MobileKanbanPage } from "../../pages/mobile-kanban-page";
@@ -21,8 +22,9 @@ test("keeps the WebKit Create Task dialog full-height and contained on mobile", 
   await expect(dialog.getByRole("button", { name: "Close", exact: true })).toHaveCount(0);
   await expect(dialog.getByRole("button", { name: "Cancel", exact: true })).toBeVisible();
   await expect(dialog).toHaveCSS("padding-top", "0px");
-  await dialog.evaluate(async (element) => {
-    await Promise.all(element.getAnimations().map((animation) => animation.finished));
+  await expectWebkitDialogMotion(dialog, {
+    contentZIndex: "50",
+    overlayZIndex: "49",
   });
   await expect(dialog.getByTestId("task-title-input")).toBeVisible();
   await expect(dialog.getByTestId("task-description-input")).toBeVisible();
@@ -36,17 +38,6 @@ test("keeps the WebKit Create Task dialog full-height and contained on mobile", 
   expect(box!.width).toBeCloseTo(viewport!.width, 0);
   expect(box!.height).toBeCloseTo(viewport!.height, 0);
 
-  const motion = await dialog.evaluate((element) => {
-    const style = getComputedStyle(element);
-    return {
-      animationName: style.animationName,
-      transform: style.transform,
-      translate: style.translate,
-    };
-  });
-  expect(motion.animationName).toBe("kandev-dialog-webkit-enter");
-  expect(["none", "matrix(1, 0, 0, 1, 0, 0)"]).toContain(motion.transform);
-  expect(["none", "0px", "0px 0px"]).toContain(motion.translate);
   await assertNoDocumentHorizontalOverflow(testPage, "WebKit Create Task dialog");
   await prCapture.screenshot("webkit-create-task-dialog-mobile", {
     caption: "The WebKit Create Task dialog remains full-height and contained on mobile.",

--- a/apps/web/e2e/tests/task/mobile-create-task-webkit-rendering.spec.ts
+++ b/apps/web/e2e/tests/task/mobile-create-task-webkit-rendering.spec.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "../../fixtures/test-base";
+import { assertNoDocumentHorizontalOverflow } from "../../helpers/layout-assertions";
+import { useRegularMode } from "../../helpers/regular-mode";
+import { MobileKanbanPage } from "../../pages/mobile-kanban-page";
+
+useRegularMode();
+
+test("keeps the WebKit Create Task dialog full-height and contained on mobile", async ({
+  testPage,
+  prCapture,
+}) => {
+  const mobile = new MobileKanbanPage(testPage);
+  await mobile.goto();
+  await testPage.locator("html").evaluate((root) => {
+    root.setAttribute("data-rendering-engine", "webkit");
+  });
+  await mobile.mobileFab.tap();
+
+  const dialog = testPage.getByTestId("create-task-dialog");
+  await expect(dialog).toBeVisible();
+  await expect(dialog.getByTestId("task-title-input")).toBeVisible();
+  await expect(dialog.getByTestId("task-description-input")).toBeVisible();
+
+  const viewport = testPage.viewportSize();
+  const box = await dialog.boundingBox();
+  expect(viewport).not.toBeNull();
+  expect(box).not.toBeNull();
+  expect(box!.x).toBeCloseTo(0, 0);
+  expect(box!.y).toBeCloseTo(0, 0);
+  expect(box!.width).toBeCloseTo(viewport!.width, 0);
+  expect(box!.height).toBeCloseTo(viewport!.height, 0);
+
+  const motion = await dialog.evaluate((element) => {
+    const style = getComputedStyle(element);
+    return {
+      animationName: style.animationName,
+      transform: style.transform,
+      translate: style.translate,
+    };
+  });
+  expect(motion.animationName).toBe("kandev-dialog-webkit-enter");
+  expect(["none", "matrix(1, 0, 0, 1, 0, 0)"]).toContain(motion.transform);
+  expect(["none", "0px", "0px 0px"]).toContain(motion.translate);
+  await assertNoDocumentHorizontalOverflow(testPage, "WebKit Create Task dialog");
+  await prCapture.screenshot("webkit-create-task-dialog-mobile", {
+    caption: "The WebKit Create Task dialog remains full-height and contained on mobile.",
+  });
+});

--- a/apps/web/e2e/tests/task/mobile-create-task-webkit-rendering.spec.ts
+++ b/apps/web/e2e/tests/task/mobile-create-task-webkit-rendering.spec.ts
@@ -18,6 +18,8 @@ test("keeps the WebKit Create Task dialog full-height and contained on mobile", 
 
   const dialog = testPage.getByTestId("create-task-dialog");
   await expect(dialog).toBeVisible();
+  await expect(dialog.getByRole("button", { name: "Close", exact: true })).toHaveCount(0);
+  await expect(dialog.getByRole("button", { name: "Cancel", exact: true })).toBeVisible();
   await expect(dialog.getByTestId("task-title-input")).toBeVisible();
   await expect(dialog.getByTestId("task-description-input")).toBeVisible();
 

--- a/apps/web/e2e/tests/task/mobile-create-task-webkit-rendering.spec.ts
+++ b/apps/web/e2e/tests/task/mobile-create-task-webkit-rendering.spec.ts
@@ -21,6 +21,9 @@ test("keeps the WebKit Create Task dialog full-height and contained on mobile", 
   await expect(dialog.getByRole("button", { name: "Close", exact: true })).toHaveCount(0);
   await expect(dialog.getByRole("button", { name: "Cancel", exact: true })).toBeVisible();
   await expect(dialog).toHaveCSS("padding-top", "0px");
+  await dialog.evaluate(async (element) => {
+    await Promise.all(element.getAnimations().map((animation) => animation.finished));
+  });
   await expect(dialog.getByTestId("task-title-input")).toBeVisible();
   await expect(dialog.getByTestId("task-description-input")).toBeVisible();
 

--- a/apps/web/lib/browser/rendering-engine.test.ts
+++ b/apps/web/lib/browser/rendering-engine.test.ts
@@ -82,6 +82,17 @@ describe("detectRenderingEngine", () => {
   ] satisfies Array<[string, string]>)("%s is not WebKit", (_name, userAgent) => {
     expect(detectRenderingEngine({ userAgent, platform: "unknown" })).toBe("other");
   });
+
+  it("keeps touch-capable desktop Mac Chrome on the non-WebKit path", () => {
+    expect(
+      detectRenderingEngine({
+        userAgent:
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36",
+        platform: "MacIntel",
+        maxTouchPoints: 5,
+      }),
+    ).toBe("other");
+  });
 });
 
 describe("markRenderingEngine", () => {

--- a/apps/web/lib/browser/rendering-engine.test.ts
+++ b/apps/web/lib/browser/rendering-engine.test.ts
@@ -3,14 +3,11 @@ import { detectRenderingEngine, markRenderingEngine } from "./rendering-engine";
 
 type NavigatorFixture = {
   userAgent: string;
-  platform?: string;
-  maxTouchPoints?: number;
 };
 
 const safariMac: NavigatorFixture = {
   userAgent:
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_5) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Safari/605.1.15",
-  platform: "MacIntel",
 };
 
 describe("detectRenderingEngine", () => {
@@ -21,7 +18,6 @@ describe("detectRenderingEngine", () => {
       {
         userAgent:
           "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_5) AppleWebKit/605.1.15 (KHTML, like Gecko)",
-        platform: "MacIntel",
       },
     ],
     [
@@ -29,7 +25,6 @@ describe("detectRenderingEngine", () => {
       {
         userAgent:
           "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/617.1 (KHTML, like Gecko) Version/18.0 Safari/617.1",
-        platform: "Linux x86_64",
       },
     ],
     [
@@ -37,7 +32,6 @@ describe("detectRenderingEngine", () => {
       {
         userAgent:
           "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/125.0.6422.99 Mobile/15E148 Safari/604.1",
-        platform: "iPhone",
       },
     ],
     [
@@ -45,7 +39,6 @@ describe("detectRenderingEngine", () => {
       {
         userAgent:
           "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) EdgiOS/125.0.2535.85 Mobile/15E148 Safari/604.1",
-        platform: "iPhone",
       },
     ],
     [
@@ -53,8 +46,6 @@ describe("detectRenderingEngine", () => {
       {
         userAgent:
           "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1",
-        platform: "MacIntel",
-        maxTouchPoints: 5,
       },
     ],
   ] satisfies Array<[string, NavigatorFixture]>)("%s is WebKit", (_name, navigatorLike) => {
@@ -80,16 +71,14 @@ describe("detectRenderingEngine", () => {
     ],
     ["unknown", "TestBrowser/1.0"],
   ] satisfies Array<[string, string]>)("%s is not WebKit", (_name, userAgent) => {
-    expect(detectRenderingEngine({ userAgent, platform: "unknown" })).toBe("other");
+    expect(detectRenderingEngine({ userAgent })).toBe("other");
   });
 
-  it("keeps touch-capable desktop Mac Chrome on the non-WebKit path", () => {
+  it("keeps desktop Mac Chrome on the non-WebKit path", () => {
     expect(
       detectRenderingEngine({
         userAgent:
           "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36",
-        platform: "MacIntel",
-        maxTouchPoints: 5,
       }),
     ).toBe("other");
   });

--- a/apps/web/lib/browser/rendering-engine.test.ts
+++ b/apps/web/lib/browser/rendering-engine.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import { detectRenderingEngine, markRenderingEngine } from "./rendering-engine";
+
+type NavigatorFixture = {
+  userAgent: string;
+  platform?: string;
+  maxTouchPoints?: number;
+};
+
+const safariMac: NavigatorFixture = {
+  userAgent:
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_5) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Safari/605.1.15",
+  platform: "MacIntel",
+};
+
+describe("detectRenderingEngine", () => {
+  it.each([
+    ["macOS Safari", safariMac],
+    [
+      "macOS WKWebView",
+      {
+        userAgent:
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_5) AppleWebKit/605.1.15 (KHTML, like Gecko)",
+        platform: "MacIntel",
+      },
+    ],
+    [
+      "WebKitGTK",
+      {
+        userAgent:
+          "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/617.1 (KHTML, like Gecko) Version/18.0 Safari/617.1",
+        platform: "Linux x86_64",
+      },
+    ],
+    [
+      "iOS Chrome",
+      {
+        userAgent:
+          "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/125.0.6422.99 Mobile/15E148 Safari/604.1",
+        platform: "iPhone",
+      },
+    ],
+    [
+      "iOS Edge",
+      {
+        userAgent:
+          "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) EdgiOS/125.0.2535.85 Mobile/15E148 Safari/604.1",
+        platform: "iPhone",
+      },
+    ],
+    [
+      "iPadOS desktop mode",
+      {
+        userAgent:
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1",
+        platform: "MacIntel",
+        maxTouchPoints: 5,
+      },
+    ],
+  ] satisfies Array<[string, NavigatorFixture]>)("%s is WebKit", (_name, navigatorLike) => {
+    expect(detectRenderingEngine(navigatorLike)).toBe("webkit");
+  });
+
+  it.each([
+    [
+      "desktop Chrome",
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36",
+    ],
+    [
+      "Edge WebView2",
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36 Edg/126.0.0.0",
+    ],
+    [
+      "Android Chrome",
+      "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Mobile Safari/537.36",
+    ],
+    [
+      "Firefox",
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 14.5; rv:127.0) Gecko/20100101 Firefox/127.0",
+    ],
+    ["unknown", "TestBrowser/1.0"],
+  ] satisfies Array<[string, string]>)("%s is not WebKit", (_name, userAgent) => {
+    expect(detectRenderingEngine({ userAgent, platform: "unknown" })).toBe("other");
+  });
+});
+
+describe("markRenderingEngine", () => {
+  it("writes a transient WebKit marker to the supplied root", () => {
+    const root = document.createElement("html");
+
+    expect(markRenderingEngine(root, safariMac)).toBe("webkit");
+    expect(root.dataset.renderingEngine).toBe("webkit");
+  });
+
+  it("fails safe to the default marker for missing navigator data", () => {
+    const root = document.createElement("html");
+
+    expect(markRenderingEngine(root, null)).toBe("other");
+    expect(root.dataset.renderingEngine).toBe("other");
+  });
+});

--- a/apps/web/lib/browser/rendering-engine.ts
+++ b/apps/web/lib/browser/rendering-engine.ts
@@ -34,8 +34,8 @@ export function detectRenderingEngine(
 
   const userAgent = navigatorLike.userAgent ?? "";
   if (!/AppleWebKit\//i.test(userAgent)) return "other";
-  if (isIOSLike(navigatorLike, userAgent)) return "webkit";
   if (BLINK_USER_AGENT_TOKENS.test(userAgent)) return "other";
+  if (isIOSLike(navigatorLike, userAgent)) return "webkit";
 
   return "webkit";
 }

--- a/apps/web/lib/browser/rendering-engine.ts
+++ b/apps/web/lib/browser/rendering-engine.ts
@@ -1,0 +1,51 @@
+export type RenderingEngine = "webkit" | "other";
+
+export type RenderingNavigator = {
+  userAgent?: string;
+  platform?: string;
+  maxTouchPoints?: number;
+};
+
+const BLINK_USER_AGENT_TOKENS = /(?:Chrome|Chromium|HeadlessChrome|Edg|OPR|SamsungBrowser)\//i;
+const IOS_USER_AGENT_TOKENS = /\b(?:iPad|iPhone|iPod)\b/i;
+
+function browserNavigator(): RenderingNavigator | undefined {
+  if (typeof navigator === "undefined") return undefined;
+  return navigator;
+}
+
+function isIOSLike(navigatorLike: RenderingNavigator, userAgent: string): boolean {
+  if (IOS_USER_AGENT_TOKENS.test(userAgent)) return true;
+
+  return (
+    navigatorLike.platform?.toLowerCase() === "macintel" && (navigatorLike.maxTouchPoints ?? 0) > 1
+  );
+}
+
+/**
+ * Identify WebKit without mistaking desktop Chromium's AppleWebKit token for
+ * the rendering engine. iOS browser brands remain WebKit because iOS routes
+ * all browser engines through the system WebKit runtime.
+ */
+export function detectRenderingEngine(
+  navigatorLike: RenderingNavigator | null | undefined = browserNavigator(),
+): RenderingEngine {
+  if (!navigatorLike) return "other";
+
+  const userAgent = navigatorLike.userAgent ?? "";
+  if (!/AppleWebKit\//i.test(userAgent)) return "other";
+  if (isIOSLike(navigatorLike, userAgent)) return "webkit";
+  if (BLINK_USER_AGENT_TOKENS.test(userAgent)) return "other";
+
+  return "webkit";
+}
+
+/** Apply the transient engine marker used by scoped rendering workarounds. */
+export function markRenderingEngine(
+  root: HTMLElement,
+  navigatorLike: RenderingNavigator | null | undefined = browserNavigator(),
+): RenderingEngine {
+  const engine = detectRenderingEngine(navigatorLike);
+  root.dataset.renderingEngine = engine;
+  return engine;
+}

--- a/apps/web/lib/browser/rendering-engine.ts
+++ b/apps/web/lib/browser/rendering-engine.ts
@@ -2,24 +2,13 @@ export type RenderingEngine = "webkit" | "other";
 
 export type RenderingNavigator = {
   userAgent?: string;
-  platform?: string;
-  maxTouchPoints?: number;
 };
 
 const BLINK_USER_AGENT_TOKENS = /(?:Chrome|Chromium|HeadlessChrome|Edg|OPR|SamsungBrowser)\//i;
-const IOS_USER_AGENT_TOKENS = /\b(?:iPad|iPhone|iPod)\b/i;
 
 function browserNavigator(): RenderingNavigator | undefined {
   if (typeof navigator === "undefined") return undefined;
   return navigator;
-}
-
-function isIOSLike(navigatorLike: RenderingNavigator, userAgent: string): boolean {
-  if (IOS_USER_AGENT_TOKENS.test(userAgent)) return true;
-
-  return (
-    navigatorLike.platform?.toLowerCase() === "macintel" && (navigatorLike.maxTouchPoints ?? 0) > 1
-  );
 }
 
 /**
@@ -35,7 +24,6 @@ export function detectRenderingEngine(
   const userAgent = navigatorLike.userAgent ?? "";
   if (!/AppleWebKit\//i.test(userAgent)) return "other";
   if (BLINK_USER_AGENT_TOKENS.test(userAgent)) return "other";
-  if (isIOSLike(navigatorLike, userAgent)) return "webkit";
 
   return "webkit";
 }

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -12,8 +12,10 @@ import type { BootPayload } from "./boot-payload";
 import { RootErrorBoundary, RouteErrorBoundary } from "./app-error-boundary";
 import { SpaRoutes } from "./spa-routes";
 import { installVitePreloadRecovery } from "./vite-preload-recovery";
+import { markRenderingEngine } from "@/lib/browser/rendering-engine";
 
 installVitePreloadRecovery();
+markRenderingEngine(document.documentElement);
 
 const AUTH_ROUTE_PATHS = new Set(["/login", "/setup", "/invite"]);
 

--- a/docs/plans/webkit-task-dialog-rendering/plan.md
+++ b/docs/plans/webkit-task-dialog-rendering/plan.md
@@ -130,6 +130,13 @@ lib/browser/rendering-engine.test.ts lib/browser/rendering-engine.ts
 tests/task/create-task-webkit-rendering.spec.ts --workers=1` — 2 passed.
 - `pnpm --filter @kandev/web e2e:run --no-build --host --project mobile-chrome --
 tests/task/mobile-create-task-webkit-rendering.spec.ts --workers=1` — 1 passed.
+- `pnpm --filter @kandev/web e2e:run --no-build --host --project chromium --
+tests/task/create-task-branch-selector.spec.ts --grep "confirm modal lists files" --workers=1` — 1
+  passed, confirming the nested WebKit discard confirmation's motion and stacking.
+- `pnpm --filter @kandev/web e2e:run --no-build --host --project chromium --
+tests/task/dialog-body-lock.spec.ts --workers=1` — 1 passed.
+- `pnpm --filter @kandev/web e2e:run --no-build --host --project mobile-chrome --
+tests/task/mobile-dialog-body-lock.spec.ts --workers=1` — 1 passed.
 - Native macOS Safari/Tauri visual comparison — not run; this Linux worktree cannot launch those
   engines. PR screenshots document the desktop and mobile states for native review.
 

--- a/docs/plans/webkit-task-dialog-rendering/plan.md
+++ b/docs/plans/webkit-task-dialog-rendering/plan.md
@@ -50,6 +50,8 @@ does not configure vibrancy or transparency.
   content at the shared `z-50` modal level; and elevate the nested discard confirmation to `z-53`.
 - Preserve the current mobile `width: 100%` and `height: 100%`, desktop 900px width, 85vh maximum
   height, form overflow ownership, rounded corners, focus, and dismissal behavior.
+- Pass `showCloseButton={false}` only to the Create Task dialog so the generic top-right close
+  control is absent in every browser while the footer Cancel action remains available.
 - Leave the existing scale-and-fade utility classes active for non-WebKit engines.
 
 ### Mobile design contract

--- a/docs/plans/webkit-task-dialog-rendering/plan.md
+++ b/docs/plans/webkit-task-dialog-rendering/plan.md
@@ -108,6 +108,28 @@ does not configure vibrancy or transparency.
 Execution is sequential in the primary conversation. No subagent delegation is planned or
 authorized.
 
+## Validation
+
+Run from `apps` unless noted otherwise:
+
+- `pnpm --filter @kandev/web test -- --run lib/browser/rendering-engine.test.ts` — 14 passed,
+  including the touch-capable desktop Mac Chrome regression.
+- `pnpm run typecheck` from `apps/web` — no errors.
+- `pnpm --filter @kandev/web lint` — passed.
+- `pnpm exec prettier --check app/globals.css components/discard-local-changes-dialog.tsx
+components/task-create-dialog.tsx e2e/tests/task/create-task-webkit-rendering.spec.ts
+lib/browser/rendering-engine.test.ts lib/browser/rendering-engine.ts
+../../docs/plans/webkit-task-dialog-rendering/plan.md
+../../docs/plans/webkit-task-dialog-rendering/task-02-webkit-dialog-rendering.md` from `apps/web`
+  — passed.
+- `pnpm --filter @kandev/web build` — passed.
+- `pnpm --filter @kandev/web e2e:run --no-build --host --project chromium --
+tests/task/create-task-webkit-rendering.spec.ts --workers=1` — 2 passed.
+- `pnpm --filter @kandev/web e2e:run --no-build --host --project mobile-chrome --
+tests/task/mobile-create-task-webkit-rendering.spec.ts --workers=1` — 1 passed.
+- Native macOS Safari/Tauri visual comparison — not run; this Linux worktree cannot launch those
+  engines. PR screenshots document the desktop and mobile states for native review.
+
 ## Risks
 
 - Browsers do not expose a standardized rendering-engine API. The classifier therefore needs

--- a/docs/plans/webkit-task-dialog-rendering/plan.md
+++ b/docs/plans/webkit-task-dialog-rendering/plan.md
@@ -1,7 +1,7 @@
 ---
 spec: docs/specs/ui/webkit-task-dialog-rendering.md
 created: 2026-08-01
-status: draft
+status: complete
 ---
 
 # Implementation Plan: WebKit Task Dialog Rendering
@@ -99,8 +99,8 @@ does not configure vibrancy or transparency.
 
 ## Implementation Tasks
 
-- [ ] [Task 01: Classify the rendering engine](task-01-rendering-engine-marker.md)
-- [ ] [Task 02: Apply WebKit-safe task dialog rendering](task-02-webkit-dialog-rendering.md)
+- [x] [Task 01: Classify the rendering engine](task-01-rendering-engine-marker.md)
+- [x] [Task 02: Apply WebKit-safe task dialog rendering](task-02-webkit-dialog-rendering.md)
 
 Execution is sequential in the primary conversation. No subagent delegation is planned or
 authorized.

--- a/docs/plans/webkit-task-dialog-rendering/plan.md
+++ b/docs/plans/webkit-task-dialog-rendering/plan.md
@@ -43,12 +43,15 @@ does not configure vibrancy or transparency.
 - Add a semantic nested-confirmation marker to
   `apps/web/components/discard-local-changes-dialog.tsx` so the WebKit stack can elevate that
   confirmation without styling by test IDs.
+- Allow the shared `AlertDialogContent` primitive to pass a scoped overlay class to its portaled
+  overlay, keeping the nested stack rule local to the discard confirmation.
 - Add scoped WebKit selectors and opacity-only keyframes in `apps/web/app/globals.css`.
 - Under `html[data-rendering-engine="webkit"]`, override the opted-in Create Task and nested
   confirmation surfaces' animation names so their keyframes never write `transform`; replace
   translated centering with `inset: 0`, automatic margins, and desktop `height: fit-content`; lower
   only the task dialog's own overlay to `z-49` while keeping content at the shared `z-50` modal
-  level; and elevate the nested discard confirmation to `z-53`.
+  level; and elevate the nested discard confirmation to an explicit `z-52` overlay and `z-53`
+  content layer with `height: fit-content` at every viewport width.
 - Preserve the current mobile `width: 100%` and `height: 100%`, desktop 900px width, 85vh maximum
   height, form overflow ownership, rounded corners, focus, and dismissal behavior.
 - Pass `showCloseButton={false}` only to the Create Task dialog so the generic top-right close
@@ -104,6 +107,11 @@ does not configure vibrancy or transparency.
   - **What to verify:** force the WebKit marker, open from `MobileKanbanPage.mobileFab`, assert
     viewport containment, task-name and prompt reachability, internal scrolling when required, and
     no document horizontal overflow.
+- **Scenario:** a nested dirty-tree confirmation remains compact and above the task form.
+  - **File:** `apps/web/e2e/tests/task/create-task-branch-selector.spec.ts`
+  - **What to verify:** force the WebKit marker, trigger the discard confirmation, and assert
+    opacity-only motion, transform-free centering, the explicit `z-52` overlay / `z-53` content
+    stack, and preserved form state after Cancel.
 
 ## Implementation Tasks
 
@@ -134,7 +142,8 @@ tests/task/create-task-webkit-rendering.spec.ts --workers=1` — 2 passed.
 tests/task/mobile-create-task-webkit-rendering.spec.ts --workers=1` — 1 passed.
 - `pnpm --filter @kandev/web e2e:run --no-build --host --project chromium --
 tests/task/create-task-branch-selector.spec.ts --grep "confirm modal lists files" --workers=1` — 1
-  passed, confirming the nested WebKit discard confirmation's motion and stacking.
+  passed, confirming the nested WebKit discard confirmation's motion and explicit z-52/z-53
+  stacking.
 - `pnpm --filter @kandev/web e2e:run --no-build --host --project chromium --
 tests/task/dialog-body-lock.spec.ts --workers=1` — 1 passed.
 - `pnpm --filter @kandev/web e2e:run --no-build --host --project mobile-chrome --

--- a/docs/plans/webkit-task-dialog-rendering/plan.md
+++ b/docs/plans/webkit-task-dialog-rendering/plan.md
@@ -28,8 +28,9 @@ does not configure vibrancy or transparency.
 - Add `apps/web/lib/browser/rendering-engine.ts` with a pure classifier and a small document-marker
   helper.
 - Classify a user agent as WebKit when it contains `AppleWebKit` and is not a desktop Blink runtime.
-  Keep iPhone, iPad, iPod, and touch-capable iPadOS desktop-mode user agents on the WebKit path even
-  when their browser brand is Chrome, Edge, or Firefox.
+  iPhone, iPad, and iPod UAs without Blink compatibility tokens remain on the WebKit path. Branded
+  iPadOS desktop-mode Chrome/Edge UAs that carry `Chrome/` or `Edg/` are intentionally treated as
+  `other`; this token-based classifier does not infer touch capability from a desktop UA.
 - Treat desktop `Chrome`, `Chromium`, `HeadlessChrome`, `Edg`, `OPR`, and `SamsungBrowser` tokens as
   Blink/non-WebKit compatibility UAs. Firefox and unknown engines fall back to `other`.
 - In `apps/web/src/main.tsx`, apply `data-rendering-engine="webkit|other"` to the document root

--- a/docs/plans/webkit-task-dialog-rendering/plan.md
+++ b/docs/plans/webkit-task-dialog-rendering/plan.md
@@ -40,11 +40,14 @@ does not configure vibrancy or transparency.
 - Add a semantic opt-in data attribute to the Create Task `DialogContent` in
   `apps/web/components/task-create-dialog.tsx`; do not modify the shared default motion in
   `apps/packages/ui/src/dialog.tsx`.
+- Add a semantic nested-confirmation marker to
+  `apps/web/components/discard-local-changes-dialog.tsx` so the WebKit stack can elevate that
+  confirmation without styling by test IDs.
 - Add scoped WebKit selectors and opacity-only keyframes in `apps/web/app/globals.css`.
 - Under `html[data-rendering-engine="webkit"]`, override only the opted-in dialog's animation name
   so its keyframes never write `transform`; replace translated centering with `inset: 0`, automatic
-  margins, and desktop `height: fit-content`; and place content one stacking level above the
-  `z-50` overlay.
+  margins, and desktop `height: fit-content`; lower only its own overlay to `z-49` while keeping
+  content at the shared `z-50` modal level; and elevate the nested discard confirmation to `z-53`.
 - Preserve the current mobile `width: 100%` and `height: 100%`, desktop 900px width, 85vh maximum
   height, form overflow ownership, rounded corners, focus, and dismissal behavior.
 - Leave the existing scale-and-fade utility classes active for non-WebKit engines.
@@ -89,8 +92,8 @@ does not configure vibrancy or transparency.
 - **Scenario:** the WebKit override removes transforms while preserving centered desktop geometry.
   - **File:** `apps/web/e2e/tests/task/create-task-webkit-rendering.spec.ts`
   - **What to verify:** force the root marker to `webkit` before opening the dialog; assert the
-    opacity-only animation name, `transform`/`translate` absence, explicit stacking level, 900px
-    capped width, viewport-centered bounds, and focused task-name input.
+    opacity-only animation name, identity `transform`/zero `translate`, explicit overlay/content
+    stacking levels, 900px capped width, viewport-centered bounds, and focused task-name input.
 - **Scenario:** a narrow WebKit Create Task dialog keeps its full-height usable composition.
   - **File:** `apps/web/e2e/tests/task/mobile-create-task-webkit-rendering.spec.ts`
   - **What to verify:** force the WebKit marker, open from `MobileKanbanPage.mobileFab`, assert

--- a/docs/plans/webkit-task-dialog-rendering/plan.md
+++ b/docs/plans/webkit-task-dialog-rendering/plan.md
@@ -116,7 +116,7 @@ authorized.
 Run from `apps` unless noted otherwise:
 
 - `pnpm --filter @kandev/web test -- --run lib/browser/rendering-engine.test.ts` — 14 passed,
-  including the touch-capable desktop Mac Chrome regression.
+  including the desktop Mac Chrome Blink-token regression.
 - `pnpm run typecheck` from `apps/web` — no errors.
 - `pnpm --filter @kandev/web lint` — passed.
 - `pnpm exec prettier --check app/globals.css components/discard-local-changes-dialog.tsx

--- a/docs/plans/webkit-task-dialog-rendering/plan.md
+++ b/docs/plans/webkit-task-dialog-rendering/plan.md
@@ -44,10 +44,11 @@ does not configure vibrancy or transparency.
   `apps/web/components/discard-local-changes-dialog.tsx` so the WebKit stack can elevate that
   confirmation without styling by test IDs.
 - Add scoped WebKit selectors and opacity-only keyframes in `apps/web/app/globals.css`.
-- Under `html[data-rendering-engine="webkit"]`, override only the opted-in dialog's animation name
-  so its keyframes never write `transform`; replace translated centering with `inset: 0`, automatic
-  margins, and desktop `height: fit-content`; lower only its own overlay to `z-49` while keeping
-  content at the shared `z-50` modal level; and elevate the nested discard confirmation to `z-53`.
+- Under `html[data-rendering-engine="webkit"]`, override the opted-in Create Task and nested
+  confirmation surfaces' animation names so their keyframes never write `transform`; replace
+  translated centering with `inset: 0`, automatic margins, and desktop `height: fit-content`; lower
+  only the task dialog's own overlay to `z-49` while keeping content at the shared `z-50` modal
+  level; and elevate the nested discard confirmation to `z-53`.
 - Preserve the current mobile `width: 100%` and `height: 100%`, desktop 900px width, 85vh maximum
   height, form overflow ownership, rounded corners, focus, and dismissal behavior.
 - Pass `showCloseButton={false}` only to the Create Task dialog so the generic top-right close

--- a/docs/plans/webkit-task-dialog-rendering/plan.md
+++ b/docs/plans/webkit-task-dialog-rendering/plan.md
@@ -1,0 +1,119 @@
+---
+spec: docs/specs/ui/webkit-task-dialog-rendering.md
+created: 2026-08-01
+status: draft
+---
+
+# Implementation Plan: WebKit Task Dialog Rendering
+
+## Overview
+
+Classify the active rendering engine before React mounts, then opt only the Create Task dialog into
+a WebKit-safe CSS path. Prove engine classification with unit tests and prove both the unchanged
+Chromium path and the WebKit desktop/mobile geometry through focused browser tests.
+
+## Confirmed root cause
+
+`DialogContent` combines fixed centering with translated positioning and a `scale(0.95)` enter/exit
+animation on the same element that contains the form text. WebKit rasterizes transformed,
+composited text-bearing layers differently from Blink, producing the reported soft dialog while
+the same Go-served SPA and fonts remain sharp in Chrome. The overlay and content also share
+`z-50`, leaving their relative composited-layer ordering implicit. The Tauri window is opaque and
+does not configure vibrancy or transparency.
+
+## Frontend
+
+### Rendering-engine marker
+
+- Add `apps/web/lib/browser/rendering-engine.ts` with a pure classifier and a small document-marker
+  helper.
+- Classify a user agent as WebKit when it contains `AppleWebKit` and is not a desktop Blink runtime.
+  Keep iPhone, iPad, iPod, and touch-capable iPadOS desktop-mode user agents on the WebKit path even
+  when their browser brand is Chrome, Edge, or Firefox.
+- Treat desktop `Chrome`, `Chromium`, `HeadlessChrome`, `Edg`, `OPR`, and `SamsungBrowser` tokens as
+  Blink/non-WebKit compatibility UAs. Firefox and unknown engines fall back to `other`.
+- In `apps/web/src/main.tsx`, apply `data-rendering-engine="webkit|other"` to the document root
+  before boot-payload loading and React rendering. Do not persist the value.
+
+### Create Task dialog rendering
+
+- Add a semantic opt-in data attribute to the Create Task `DialogContent` in
+  `apps/web/components/task-create-dialog.tsx`; do not modify the shared default motion in
+  `apps/packages/ui/src/dialog.tsx`.
+- Add scoped WebKit selectors and opacity-only keyframes in `apps/web/app/globals.css`.
+- Under `html[data-rendering-engine="webkit"]`, override only the opted-in dialog's animation name
+  so its keyframes never write `transform`; replace translated centering with `inset: 0`, automatic
+  margins, and desktop `height: fit-content`; and place content one stacking level above the
+  `z-50` overlay.
+- Preserve the current mobile `width: 100%` and `height: 100%`, desktop 900px width, 85vh maximum
+  height, form overflow ownership, rounded corners, focus, and dismissal behavior.
+- Leave the existing scale-and-fade utility classes active for non-WebKit engines.
+
+### Mobile design contract
+
+- **Desktop outcome:** Safari and WebKit-backed Tauri show the existing centered 900px Create Task
+  form without transformed text; Chromium retains its current motion.
+- **Mobile entry point:** the existing Kanban floating New Task action opens the same full-height
+  dialog.
+- **Nearest shipped exemplar:** the existing mobile Create Task surface and
+  `MobileKanbanPage.mobileFab` remain the composition and entry-point baseline.
+- **Hierarchy and primary action:** task name, prompt, repositories, agent profile, and submit
+  controls remain in their existing order; task creation remains the primary action.
+- **Presentation rationale:** this is a rendering workaround, so preserving the existing
+  full-height mobile dialog is less disruptive than introducing a new drawer or route.
+- **Geometry:** the dialog remains the single viewport-bound surface, keeps its existing internal
+  form scroll owner and safe-area behavior, and introduces no document horizontal overflow.
+- **Shared logic:** all task state, validation, selectors, and submit handlers remain unchanged;
+  only engine classification and presentation CSS differ.
+- **Mobile proof:** Pixel 5 E2E forces the WebKit marker and verifies full-viewport containment,
+  accessible inputs, internal usability, and zero document horizontal overflow.
+
+## Tests
+
+- **What:** Safari/WKWebView/WebKitGTK, desktop Blink, Firefox, iOS branded browsers, iPadOS
+  desktop mode, and unknown-UA classification.
+  - **File:** `apps/web/lib/browser/rendering-engine.test.ts`
+  - **How:** table-driven Vitest cases against the pure classifier plus marker-helper assertions.
+- **What:** the marker is applied before React boot without persistence.
+  - **File:** `apps/web/lib/browser/rendering-engine.test.ts`
+  - **How:** pass a detached document root and navigator-like input to the marker helper and assert
+    the exact `data-rendering-engine` value.
+
+## E2E Tests
+
+- **Scenario:** Chromium retains its existing Create Task scale motion and positioning when the
+  runtime marker is `other`.
+  - **File:** `apps/web/e2e/tests/task/create-task-webkit-rendering.spec.ts`
+  - **What to verify:** the early marker is `other`, the dialog keeps the existing animation name,
+    translated centering, dimensions, and content-over-overlay hit testing.
+- **Scenario:** the WebKit override removes transforms while preserving centered desktop geometry.
+  - **File:** `apps/web/e2e/tests/task/create-task-webkit-rendering.spec.ts`
+  - **What to verify:** force the root marker to `webkit` before opening the dialog; assert the
+    opacity-only animation name, `transform`/`translate` absence, explicit stacking level, 900px
+    capped width, viewport-centered bounds, and focused task-name input.
+- **Scenario:** a narrow WebKit Create Task dialog keeps its full-height usable composition.
+  - **File:** `apps/web/e2e/tests/task/mobile-create-task-webkit-rendering.spec.ts`
+  - **What to verify:** force the WebKit marker, open from `MobileKanbanPage.mobileFab`, assert
+    viewport containment, task-name and prompt reachability, internal scrolling when required, and
+    no document horizontal overflow.
+
+## Implementation Tasks
+
+- [ ] [Task 01: Classify the rendering engine](task-01-rendering-engine-marker.md)
+- [ ] [Task 02: Apply WebKit-safe task dialog rendering](task-02-webkit-dialog-rendering.md)
+
+Execution is sequential in the primary conversation. No subagent delegation is planned or
+authorized.
+
+## Risks
+
+- Browsers do not expose a standardized rendering-engine API. The classifier therefore needs
+  explicit compatibility-UA tests and must fail safe to the existing rendering path.
+- Chromium E2E can prove selector behavior and geometry after forcing the root marker, but it
+  cannot reproduce WKWebView rasterization. Final acceptance requires a macOS Tauri/Safari visual
+  comparison at actual-size zoom (`Cmd+0`) after the automated checks pass.
+- Transform-free absolute centering can accidentally stretch an auto-height desktop dialog. The
+  WebKit desktop selector must set `height: fit-content`, while the narrow layout retains the
+  existing full-height rule.
+- The opt-in attribute deliberately limits blast radius. Other dialogs remain out of scope until
+  they show the same reproduced WebKit defect.

--- a/docs/plans/webkit-task-dialog-rendering/plan.md
+++ b/docs/plans/webkit-task-dialog-rendering/plan.md
@@ -53,6 +53,8 @@ does not configure vibrancy or transparency.
   height, form overflow ownership, rounded corners, focus, and dismissal behavior.
 - Pass `showCloseButton={false}` only to the Create Task dialog so the generic top-right close
   control is absent in every browser while the footer Cancel action remains available.
+- Add `pt-0` to the Create Task surface so it no longer reserves top padding for the removed
+  control while preserving horizontal and bottom padding.
 - Leave the existing scale-and-fade utility classes active for non-WebKit engines.
 
 ### Mobile design contract

--- a/docs/plans/webkit-task-dialog-rendering/task-01-rendering-engine-marker.md
+++ b/docs/plans/webkit-task-dialog-rendering/task-01-rendering-engine-marker.md
@@ -12,9 +12,9 @@ spec: "../../specs/ui/webkit-task-dialog-rendering.md"
 
 ## Acceptance
 
-- Safari, WKWebView/WebKitGTK-shaped user agents, iOS branded browsers, and iPadOS desktop mode
-  classify as `webkit`, while Blink, WebView2, Firefox, and unknown user agents classify as
-  `other`.
+- Safari, WKWebView/WebKitGTK-shaped user agents, iOS branded browsers, and iPadOS desktop-mode
+  Safari UAs classify as `webkit`, while Blink, WebView2, Firefox, unknown user agents, and
+  iPadOS desktop-mode Chrome/Edge UAs carrying Blink tokens classify as `other`.
 - The document root receives `data-rendering-engine="webkit|other"` before boot-payload loading and
   React rendering, without persistence or a user-visible setting.
 - Classification failure falls back to `other` and does not block application startup.

--- a/docs/plans/webkit-task-dialog-rendering/task-01-rendering-engine-marker.md
+++ b/docs/plans/webkit-task-dialog-rendering/task-01-rendering-engine-marker.md
@@ -1,7 +1,7 @@
 ---
 id: "01-rendering-engine-marker"
 title: "Classify the rendering engine"
-status: pending
+status: done
 wave: 1
 depends_on: []
 plan: "plan.md"

--- a/docs/plans/webkit-task-dialog-rendering/task-01-rendering-engine-marker.md
+++ b/docs/plans/webkit-task-dialog-rendering/task-01-rendering-engine-marker.md
@@ -1,0 +1,71 @@
+---
+id: "01-rendering-engine-marker"
+title: "Classify the rendering engine"
+status: pending
+wave: 1
+depends_on: []
+plan: "plan.md"
+spec: "../../specs/ui/webkit-task-dialog-rendering.md"
+---
+
+# Task 01: Classify the Rendering Engine
+
+## Acceptance
+
+- Safari, WKWebView/WebKitGTK-shaped user agents, iOS branded browsers, and iPadOS desktop mode
+  classify as `webkit`, while Blink, WebView2, Firefox, and unknown user agents classify as
+  `other`.
+- The document root receives `data-rendering-engine="webkit|other"` before boot-payload loading and
+  React rendering, without persistence or a user-visible setting.
+- Classification failure falls back to `other` and does not block application startup.
+
+## TDD sequence
+
+1. Add table-driven classifier and marker-helper tests, then run the focused Vitest command and
+   confirm RED because the helper does not exist.
+2. Implement the smallest pure classifier and marker helper that satisfies the cases.
+3. Call the marker helper from `src/main.tsx` before `loadBootPayload()`.
+4. Rerun the focused test and refactor only if naming or compatibility-token handling is unclear.
+
+## Files likely touched
+
+- `apps/web/lib/browser/rendering-engine.ts`
+- `apps/web/lib/browser/rendering-engine.test.ts`
+- `apps/web/src/main.tsx`
+- `docs/plans/webkit-task-dialog-rendering/plan.md`
+- `docs/plans/webkit-task-dialog-rendering/task-01-rendering-engine-marker.md`
+
+## Verification
+
+Run from `apps/web`:
+
+```bash
+pnpm test -- lib/browser/rendering-engine.test.ts
+```
+
+## Dependencies
+
+None.
+
+## Parallelism
+
+`sequential`. Task 02 consumes the exact root marker contract established here.
+
+## Inputs
+
+- Classification and failure-mode requirements in
+  `docs/specs/ui/webkit-task-dialog-rendering.md`.
+- Existing early application bootstrap in `apps/web/src/main.tsx`.
+- Existing navigator-mocking pattern in `apps/web/lib/keyboard/utils.test.ts`.
+- Tauri's current macOS/Linux system-WebView boundary and Chromium/WebView2 exclusion requirement.
+
+## Risks
+
+- Desktop Chromium includes the `AppleWebKit` compatibility token; never use that token alone.
+- iOS Chrome/Edge/Firefox brand tokens do not imply Blink/Gecko on iOS and must remain WebKit.
+- Keep the helper DOM-injectable so unit tests do not need module-level global mutation.
+
+## Output contract
+
+Report the observed RED failure, classifier cases added, files changed, final focused test result,
+remaining UA-classification risks, and updated task/plan statuses in this conversation.

--- a/docs/plans/webkit-task-dialog-rendering/task-02-webkit-dialog-rendering.md
+++ b/docs/plans/webkit-task-dialog-rendering/task-02-webkit-dialog-rendering.md
@@ -1,7 +1,7 @@
 ---
 id: "02-webkit-dialog-rendering"
 title: "Apply WebKit-safe task dialog rendering"
-status: pending
+status: done
 wave: 2
 depends_on: ["01-rendering-engine-marker"]
 plan: "plan.md"
@@ -85,3 +85,14 @@ Red-Green-Refactor cycle.
 Report the observed desktop/mobile RED failures, selectors and geometry applied, files changed,
 both final focused command results, the macOS native visual-check status, remaining risks, and
 updated task/plan statuses in this conversation.
+
+## Results
+
+- RED: the Chromium harness observed the shared `enter` animation and transform-based centering
+  under the forced WebKit marker; the mobile path likewise had the shared motion before the
+  opt-in CSS existed.
+- GREEN: the desktop Chromium/WebKit-branch spec passes 2 tests and the mobile WebKit-branch spec
+  passes 1 test after the opt-in CSS was added.
+- Native visual check: not available in this Linux worktree; the selector behavior and geometry
+  are covered by the focused Chromium and mobile viewport checks, with a macOS Safari/Tauri check
+  remaining for the PR reviewer.

--- a/docs/plans/webkit-task-dialog-rendering/task-02-webkit-dialog-rendering.md
+++ b/docs/plans/webkit-task-dialog-rendering/task-02-webkit-dialog-rendering.md
@@ -14,7 +14,9 @@ spec: "../../specs/ui/webkit-task-dialog-rendering.md"
 
 - The WebKit Create Task dialog and nested discard confirmation use opacity-only motion, have no
   non-identity transform on their text-bearing surfaces, are centered without stretching, and are
-  explicitly stacked above their overlays with the nested confirmation above the task form.
+  explicitly stacked above their overlays with the nested confirmation above the task form. The
+  nested confirmation uses an explicit `z-52` overlay, `z-53` content layer, and fit-content height
+  on narrow WebKit viewports.
 - Desktop Chromium keeps the existing scale-and-fade motion, translated centering, dimensions,
   focus behavior, and task-creation controls.
 - All engines omit the generic top-right close control while retaining the footer Cancel action.

--- a/docs/plans/webkit-task-dialog-rendering/task-02-webkit-dialog-rendering.md
+++ b/docs/plans/webkit-task-dialog-rendering/task-02-webkit-dialog-rendering.md
@@ -17,6 +17,7 @@ spec: "../../specs/ui/webkit-task-dialog-rendering.md"
   overlay while nested discard confirmations remain above it.
 - Desktop Chromium keeps the existing scale-and-fade motion, translated centering, dimensions,
   focus behavior, and task-creation controls.
+- All engines omit the generic top-right close control while retaining the footer Cancel action.
 - The narrow WebKit path remains full-height, viewport-contained, internally usable, and free of
   document horizontal overflow.
 

--- a/docs/plans/webkit-task-dialog-rendering/task-02-webkit-dialog-rendering.md
+++ b/docs/plans/webkit-task-dialog-rendering/task-02-webkit-dialog-rendering.md
@@ -12,8 +12,9 @@ spec: "../../specs/ui/webkit-task-dialog-rendering.md"
 
 ## Acceptance
 
-- The WebKit Create Task dialog uses opacity-only motion, has no transform on its text-bearing
-  surface, is centered without stretching, and is explicitly stacked above the overlay.
+- The WebKit Create Task dialog uses opacity-only motion, has no non-identity transform on its
+  text-bearing surface, is centered without stretching, and is explicitly stacked above its own
+  overlay while nested discard confirmations remain above it.
 - Desktop Chromium keeps the existing scale-and-fade motion, translated centering, dimensions,
   focus behavior, and task-creation controls.
 - The narrow WebKit path remains full-height, viewport-contained, internally usable, and free of
@@ -33,6 +34,7 @@ spec: "../../specs/ui/webkit-task-dialog-rendering.md"
 ## Files likely touched
 
 - `apps/web/components/task-create-dialog.tsx`
+- `apps/web/components/discard-local-changes-dialog.tsx`
 - `apps/web/app/globals.css`
 - `apps/web/e2e/tests/task/create-task-webkit-rendering.spec.ts`
 - `apps/web/e2e/tests/task/mobile-create-task-webkit-rendering.spec.ts`

--- a/docs/plans/webkit-task-dialog-rendering/task-02-webkit-dialog-rendering.md
+++ b/docs/plans/webkit-task-dialog-rendering/task-02-webkit-dialog-rendering.md
@@ -12,9 +12,9 @@ spec: "../../specs/ui/webkit-task-dialog-rendering.md"
 
 ## Acceptance
 
-- The WebKit Create Task dialog uses opacity-only motion, has no non-identity transform on its
-  text-bearing surface, is centered without stretching, and is explicitly stacked above its own
-  overlay while nested discard confirmations remain above it.
+- The WebKit Create Task dialog and nested discard confirmation use opacity-only motion, have no
+  non-identity transform on their text-bearing surfaces, are centered without stretching, and are
+  explicitly stacked above their overlays with the nested confirmation above the task form.
 - Desktop Chromium keeps the existing scale-and-fade motion, translated centering, dimensions,
   focus behavior, and task-creation controls.
 - All engines omit the generic top-right close control while retaining the footer Cancel action.

--- a/docs/plans/webkit-task-dialog-rendering/task-02-webkit-dialog-rendering.md
+++ b/docs/plans/webkit-task-dialog-rendering/task-02-webkit-dialog-rendering.md
@@ -18,6 +18,7 @@ spec: "../../specs/ui/webkit-task-dialog-rendering.md"
 - Desktop Chromium keeps the existing scale-and-fade motion, translated centering, dimensions,
   focus behavior, and task-creation controls.
 - All engines omit the generic top-right close control while retaining the footer Cancel action.
+- The dialog surface has zero top padding while retaining its side and bottom spacing.
 - The narrow WebKit path remains full-height, viewport-contained, internally usable, and free of
   document horizontal overflow.
 

--- a/docs/plans/webkit-task-dialog-rendering/task-02-webkit-dialog-rendering.md
+++ b/docs/plans/webkit-task-dialog-rendering/task-02-webkit-dialog-rendering.md
@@ -1,0 +1,87 @@
+---
+id: "02-webkit-dialog-rendering"
+title: "Apply WebKit-safe task dialog rendering"
+status: pending
+wave: 2
+depends_on: ["01-rendering-engine-marker"]
+plan: "plan.md"
+spec: "../../specs/ui/webkit-task-dialog-rendering.md"
+---
+
+# Task 02: Apply WebKit-Safe Task Dialog Rendering
+
+## Acceptance
+
+- The WebKit Create Task dialog uses opacity-only motion, has no transform on its text-bearing
+  surface, is centered without stretching, and is explicitly stacked above the overlay.
+- Desktop Chromium keeps the existing scale-and-fade motion, translated centering, dimensions,
+  focus behavior, and task-creation controls.
+- The narrow WebKit path remains full-height, viewport-contained, internally usable, and free of
+  document horizontal overflow.
+
+## TDD sequence
+
+1. Add the desktop and mobile E2E regressions, force the document marker to `webkit`, and run the
+   focused commands to confirm RED because the dialog still uses the shared transform animation
+   and centering.
+2. Add the Create Task opt-in attribute and scoped opacity-only WebKit CSS, transform-free
+   centering, and explicit stacking.
+3. Run the desktop Chromium/WebKit-branch E2E, then the mobile WebKit-branch E2E.
+4. Refactor only if the selectors or geometry rules can be made clearer without widening the
+   workaround to other dialogs; rerun both focused commands after refactoring.
+
+## Files likely touched
+
+- `apps/web/components/task-create-dialog.tsx`
+- `apps/web/app/globals.css`
+- `apps/web/e2e/tests/task/create-task-webkit-rendering.spec.ts`
+- `apps/web/e2e/tests/task/mobile-create-task-webkit-rendering.spec.ts`
+- `docs/plans/webkit-task-dialog-rendering/plan.md`
+- `docs/plans/webkit-task-dialog-rendering/task-02-webkit-dialog-rendering.md`
+
+## Verification
+
+Run from `apps/web`:
+
+```bash
+pnpm e2e:run --host --project chromium -- tests/task/create-task-webkit-rendering.spec.ts --workers=1
+pnpm e2e:run --host --no-build --project mobile-chrome -- tests/task/mobile-create-task-webkit-rendering.spec.ts --workers=1
+```
+
+The first managed-runner command rebuilds the production Vite assets. The mobile command reuses
+that build so both checks exercise the same output.
+
+## Dependencies
+
+Task 01 must establish and test the `data-rendering-engine` root contract.
+
+## Parallelism
+
+`sequential`. The CSS, opt-in attribute, and desktop/mobile geometry tests form one coupled
+Red-Green-Refactor cycle.
+
+## Inputs
+
+- Rendering and responsive scenarios in
+  `docs/specs/ui/webkit-task-dialog-rendering.md`.
+- Root marker contract from Task 01.
+- Shared dialog classes in `apps/packages/ui/src/dialog.tsx`.
+- Create Task sizing in `apps/web/components/task-create-dialog.tsx`.
+- Existing entry points in `KanbanPage` and `MobileKanbanPage`.
+- Existing horizontal-overflow assertion in `apps/web/e2e/helpers/layout-assertions.ts`.
+
+## Risks
+
+- Override the animation name with custom keyframes that contain only opacity; setting the
+  animation scale variable to `1` is insufficient because the shared keyframe still writes a
+  transform and creates a composited layer.
+- Preserve mobile `height: 100%`; use desktop `height: fit-content` only at the existing 640px
+  breakpoint so fixed inset centering does not stretch the desktop dialog.
+- Do not add `translateZ(0)`, `will-change: transform`, or font-smoothing overrides; those can force
+  the WebKit compositing behavior this fix avoids.
+
+## Output contract
+
+Report the observed desktop/mobile RED failures, selectors and geometry applied, files changed,
+both final focused command results, the macOS native visual-check status, remaining risks, and
+updated task/plan statuses in this conversation.

--- a/docs/specs/ui/webkit-task-dialog-rendering.md
+++ b/docs/specs/ui/webkit-task-dialog-rendering.md
@@ -27,6 +27,8 @@ renders correctly.
 - The WebKit rendering path preserves the existing task-creation form, focus behavior, dismissal,
   keyboard behavior, dimensions, internal scrolling, responsive full-height phone presentation,
   and safe-area behavior.
+- The Create Task dialog omits the generic top-right close control in every browser; the footer
+  Cancel action remains available for dismissal.
 - Rendering-engine classification is runtime-only and does not add a user setting or persisted
   preference.
 

--- a/docs/specs/ui/webkit-task-dialog-rendering.md
+++ b/docs/specs/ui/webkit-task-dialog-rendering.md
@@ -1,5 +1,5 @@
 ---
-status: complete
+status: shipped
 created: 2026-08-01
 owner: product
 ---

--- a/docs/specs/ui/webkit-task-dialog-rendering.md
+++ b/docs/specs/ui/webkit-task-dialog-rendering.md
@@ -29,6 +29,8 @@ renders correctly.
   and safe-area behavior.
 - The Create Task dialog omits the generic top-right close control in every browser; the footer
   Cancel action remains available for dismissal.
+- The dialog does not reserve top padding for the removed control while retaining its side and
+  bottom spacing.
 - Rendering-engine classification is runtime-only and does not add a user setting or persisted
   preference.
 

--- a/docs/specs/ui/webkit-task-dialog-rendering.md
+++ b/docs/specs/ui/webkit-task-dialog-rendering.md
@@ -1,5 +1,5 @@
 ---
-status: draft
+status: complete
 created: 2026-08-01
 owner: product
 ---

--- a/docs/specs/ui/webkit-task-dialog-rendering.md
+++ b/docs/specs/ui/webkit-task-dialog-rendering.md
@@ -1,0 +1,59 @@
+---
+status: draft
+created: 2026-08-01
+owner: product
+---
+
+# WebKit Task Dialog Rendering
+
+## Why
+
+People opening the Create Task dialog in Safari or a WebKit-backed Tauri app see softer,
+lower-clarity text and controls than people opening the same Kandev surface in Chromium. The
+dialog must remain visually sharp without removing the existing Chromium motion that already
+renders correctly.
+
+## What
+
+- Kandev identifies actual WebKit runtimes before the application renders and exposes that result
+  as a non-persistent document rendering-engine marker.
+- The Create Task dialog uses opacity-only open and close motion in WebKit; the animation does not
+  apply a transform to the text-bearing dialog surface.
+- The Create Task dialog is centered without a transform in WebKit and remains above its overlay.
+- Safari, macOS WKWebView, WebKitGTK, and browsers constrained to WebKit on iOS receive the WebKit
+  rendering path.
+- Desktop Chromium, Android Chromium, Edge/WebView2, Firefox, and other non-WebKit engines retain
+  the existing Create Task dialog animation and positioning.
+- The WebKit rendering path preserves the existing task-creation form, focus behavior, dismissal,
+  keyboard behavior, dimensions, internal scrolling, responsive full-height phone presentation,
+  and safe-area behavior.
+- Rendering-engine classification is runtime-only and does not add a user setting or persisted
+  preference.
+
+## Failure modes
+
+- If the runtime cannot be classified as WebKit, Kandev uses the existing default dialog rendering
+  rather than applying the workaround broadly.
+- User-agent compatibility tokens such as desktop Chromium's `AppleWebKit` token must not classify
+  Blink as WebKit. iOS browser brands remain classified as WebKit because their underlying engine
+  is WebKit.
+
+## Scenarios
+
+- **GIVEN** Kandev is running in Safari, WKWebView, or WebKitGTK, **WHEN** the user opens Create
+  Task, **THEN** the dialog enters with opacity-only motion, has no transform on its text-bearing
+  surface, remains centered, and renders above the overlay.
+- **GIVEN** Kandev is running in desktop Chrome or Edge/WebView2, **WHEN** the user opens Create
+  Task, **THEN** the existing scale-and-fade motion and centered geometry remain unchanged.
+- **GIVEN** Kandev is running in an iOS browser, **WHEN** the user opens Create Task, **THEN** the
+  WebKit rendering path is selected even when the browser has a non-Safari brand.
+- **GIVEN** Create Task is open in a narrow WebKit viewport, **WHEN** the user edits or scrolls the
+  form, **THEN** the dialog remains full-height, contained within the viewport, free of document
+  horizontal overflow, and exposes the same task-creation controls.
+
+## Out of scope
+
+- Changing dialog motion in Chromium or Firefox.
+- Applying the workaround to dialogs other than Create Task without a separate reproduced need.
+- Replacing Tauri's system WebView, changing desktop zoom behavior, or modifying bundled fonts.
+- Adding browser-specific font-smoothing, forced GPU compositing, or `will-change` workarounds.


### PR DESCRIPTION
The Create Task dialog can look soft in Safari and Tauri’s WKWebView because its fixed centering
and scale animation put text on a transformed WebKit layer. This keeps the WebKit path sharp and
stacked above its overlay while preserving Chromium’s existing motion and positioning behavior
apart from these requested shared spacing/control changes.
Per the product request, the generic top-right Close control and its unused top padding are removed
in every browser; the footer Cancel action remains available for dismissal.

## Validation

- `pnpm --filter @kandev/web test -- --run lib/browser/rendering-engine.test.ts` (14 passed)
- `pnpm run typecheck` from `apps/web` (no errors)
- `pnpm --filter @kandev/web lint` (passed)
- Desktop managed E2E: 2 passed (Chromium baseline + forced WebKit marker; shared motion/geometry
  preserved, Close absent, Cancel visible, zero top padding)
- Mobile managed E2E: 1 passed (forced WebKit marker; Close absent, Cancel visible, zero top padding,
  awaited enter animation before geometry and screenshot)
- Nested discard WebKit E2E: 1 passed (transform-free motion, explicit z-52 overlay / z-53 content,
  fit-content alert height, and preserved form state)
- Shared WebKit dialog metrics/motion helper is used by desktop, mobile, and nested E2E specs
- Body-lock recovery E2E: 1 desktop + 1 mobile passed using Cancel dismissal
- Vite production build and Prettier checks (passed)
- Fresh synthetic desktop/mobile screenshots captured and compressed for this PR

## Possible Improvements

Low risk: a native macOS Safari/Tauri visual check is still recommended because this Linux worktree
cannot reproduce WKWebView rasterization directly.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


<!-- kandev-screenshots-start -->
## Screenshots

![WebKit-safe desktop Create Task dialog](https://raw.githubusercontent.com/kdlbs/kandev/7257e1b44d5c06f76f067f182802c642aa0e3df5/desktop-create-task-dialog.png)

![WebKit-safe mobile Create Task dialog](https://raw.githubusercontent.com/kdlbs/kandev/7257e1b44d5c06f76f067f182802c642aa0e3df5/mobile-create-task-dialog.png)
<!-- kandev-screenshots-end -->