### PR TITLE
fix(web): show last-prompt affordances when the prompt is beyond the loaded window

### DIFF
--- a/apps/backend/internal/task/handlers/message_handlers.go
+++ b/apps/backend/internal/task/handlers/message_handlers.go
@@ -125,11 +125,12 @@ func (h *MessageHandlers) registerWS(dispatcher *ws.Dispatcher) {
 }
 
 type listMessagesParams struct {
-	before    string
-	after     string
-	sort      string
-	limit     int
-	paginated bool
+	before     string
+	after      string
+	sort       string
+	limit      int
+	paginated  bool
+	authorType string
 }
 
 func (h *MessageHandlers) parseListMessageParams(c *gin.Context) (listMessagesParams, bool) {
@@ -137,12 +138,17 @@ func (h *MessageHandlers) parseListMessageParams(c *gin.Context) (listMessagesPa
 	after := c.Query("after")
 	sort := strings.ToLower(strings.TrimSpace(c.Query("sort")))
 	limitProvided := strings.TrimSpace(c.Query("limit")) != ""
+	authorType := strings.ToLower(strings.TrimSpace(c.Query("author_type")))
 	if before != "" && after != "" {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "only one of before or after can be set"})
 		return listMessagesParams{}, false
 	}
 	if sort != "" && sort != "asc" && sort != "desc" {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "sort must be asc or desc"})
+		return listMessagesParams{}, false
+	}
+	if authorType != "" && authorType != string(models.MessageAuthorUser) && authorType != string(models.MessageAuthorAgent) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "author_type must be user or agent"})
 		return listMessagesParams{}, false
 	}
 	limit := 0
@@ -152,11 +158,12 @@ func (h *MessageHandlers) parseListMessageParams(c *gin.Context) (listMessagesPa
 		}
 	}
 	return listMessagesParams{
-		before:    before,
-		after:     after,
-		sort:      sort,
-		limit:     limit,
-		paginated: limitProvided || before != "" || after != "" || sort != "",
+		before:     before,
+		after:      after,
+		sort:       sort,
+		limit:      limit,
+		paginated:  limitProvided || before != "" || after != "" || sort != "" || authorType != "",
+		authorType: authorType,
 	}, true
 }
 
@@ -187,6 +194,7 @@ func (h *MessageHandlers) fetchMessagesPaginated(
 		Before:        params.before,
 		After:         params.after,
 		Sort:          params.sort,
+		AuthorType:    params.authorType,
 	})
 	if err != nil {
 		return dto.ListMessagesResponse{}, err

--- a/apps/backend/internal/task/handlers/message_handlers_test.go
+++ b/apps/backend/internal/task/handlers/message_handlers_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/kandev/kandev/internal/common/logger"
 	"github.com/kandev/kandev/internal/task/models"
+	"github.com/kandev/kandev/internal/task/repository"
 	"github.com/kandev/kandev/internal/task/service"
 )
 
@@ -115,7 +116,7 @@ func TestHTTPShellOutputSnapshot(t *testing.T) {
 	}
 }
 
-func shellOutputTestRouter(t *testing.T, repo *shellOutputMessageRepo) *gin.Engine {
+func shellOutputTestRouter(t *testing.T, repo repository.MessageRepository) *gin.Engine {
 	t.Helper()
 	log, err := logger.NewLogger(logger.LoggingConfig{Level: "error", Format: "json"})
 	require.NoError(t, err)
@@ -267,4 +268,70 @@ func TestWaitForSessionReady_ContextCancelled(t *testing.T) {
 	err := h.waitForSessionReady(ctx, "session-1")
 	require.Error(t, err)
 	assert.ErrorIs(t, err, context.Canceled)
+}
+
+// authorTypeCapturingRepo records the ListMessagesOptions the service passes
+// to the repository so the handler test can assert the author_type query param
+// reaches the pagination layer.
+type authorTypeCapturingRepo struct {
+	mockRepository
+	mu       sync.Mutex
+	captured []models.ListMessagesOptions
+}
+
+func (r *authorTypeCapturingRepo) GetTaskSession(ctx context.Context, id string) (*models.TaskSession, error) {
+	return &models.TaskSession{ID: id, TaskID: "task-1"}, nil
+}
+
+func (r *authorTypeCapturingRepo) ListMessagesPaginated(ctx context.Context, sessionID string, opts models.ListMessagesOptions) ([]*models.Message, bool, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.captured = append(r.captured, opts)
+	return nil, false, nil
+}
+
+func TestHTTPListMessagesAuthorTypeParam(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	repo := &authorTypeCapturingRepo{}
+	router := shellOutputTestRouter(t, repo)
+
+	t.Run("author_type=user passes through", func(t *testing.T) {
+		response := httptest.NewRecorder()
+		router.ServeHTTP(
+			response,
+			httptest.NewRequest(http.MethodGet, "/api/v1/task-sessions/session-1/messages?limit=1&sort=desc&author_type=user", nil),
+		)
+		require.Equal(t, http.StatusOK, response.Code)
+		repo.mu.Lock()
+		require.Len(t, repo.captured, 1)
+		require.Equal(t, "user", repo.captured[0].AuthorType)
+		repo.captured = nil
+		repo.mu.Unlock()
+	})
+
+	t.Run("author_type=agent passes through", func(t *testing.T) {
+		response := httptest.NewRecorder()
+		router.ServeHTTP(
+			response,
+			httptest.NewRequest(http.MethodGet, "/api/v1/task-sessions/session-1/messages?limit=1&author_type=agent", nil),
+		)
+		require.Equal(t, http.StatusOK, response.Code)
+		repo.mu.Lock()
+		require.Len(t, repo.captured, 1)
+		require.Equal(t, "agent", repo.captured[0].AuthorType)
+		repo.captured = nil
+		repo.mu.Unlock()
+	})
+
+	t.Run("invalid author_type rejected", func(t *testing.T) {
+		response := httptest.NewRecorder()
+		router.ServeHTTP(
+			response,
+			httptest.NewRequest(http.MethodGet, "/api/v1/task-sessions/session-1/messages?author_type=banana", nil),
+		)
+		require.Equal(t, http.StatusBadRequest, response.Code)
+		repo.mu.Lock()
+		require.Len(t, repo.captured, 0)
+		repo.mu.Unlock()
+	})
 }

--- a/apps/backend/internal/task/models/models.go
+++ b/apps/backend/internal/task/models/models.go
@@ -62,6 +62,9 @@ type ListMessagesOptions struct {
 	Before string
 	After  string
 	Sort   string
+	// AuthorType narrows the result to messages with exactly this author
+	// type ("user" or "agent"). Empty means unfiltered.
+	AuthorType string
 }
 
 // SearchMessagesOptions defines options for searching a session's messages.

--- a/apps/backend/internal/task/repository/message_repository_test.go
+++ b/apps/backend/internal/task/repository/message_repository_test.go
@@ -201,6 +201,68 @@ func TestSQLiteRepository_ListMessagesPagination(t *testing.T) {
 	}
 }
 
+func TestSQLiteRepository_ListMessagesPaginatedAuthorTypeFilter(t *testing.T) {
+	repo, cleanup := createTestSQLiteRepo(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	workflow := &models.Workflow{ID: "wf-auth", Name: "Test Workflow"}
+	_ = repo.CreateWorkflow(ctx, workflow)
+	task := &models.Task{ID: "task-auth", WorkflowID: "wf-auth", WorkflowStepID: "step-auth", Title: "Test Task"}
+	_ = repo.CreateTask(ctx, task)
+	sessionID := setupSQLiteTestSession(ctx, repo, task.ID, "session-auth")
+	turnID := setupSQLiteTestTurn(ctx, repo, sessionID, task.ID, "turn-auth")
+
+	baseTime := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	_ = repo.CreateMessage(ctx, &models.Message{
+		ID: "user-1", TaskSessionID: sessionID, TaskID: task.ID, TurnID: turnID,
+		AuthorType: models.MessageAuthorUser, Content: "User 1", CreatedAt: baseTime.Add(-3 * time.Minute),
+	})
+	_ = repo.CreateMessage(ctx, &models.Message{
+		ID: "agent-1", TaskSessionID: sessionID, TaskID: task.ID, TurnID: turnID,
+		AuthorType: models.MessageAuthorAgent, Content: "Agent 1", CreatedAt: baseTime.Add(-2 * time.Minute),
+	})
+	_ = repo.CreateMessage(ctx, &models.Message{
+		ID: "user-2", TaskSessionID: sessionID, TaskID: task.ID, TurnID: turnID,
+		AuthorType: models.MessageAuthorUser, Content: "User 2", CreatedAt: baseTime.Add(-1 * time.Minute),
+	})
+
+	userOnly, _, err := repo.ListMessagesPaginated(ctx, sessionID, models.ListMessagesOptions{
+		Limit:      10,
+		Sort:       "desc",
+		AuthorType: string(models.MessageAuthorUser),
+	})
+	if err != nil {
+		t.Fatalf("filter user: %v", err)
+	}
+	if len(userOnly) != 2 {
+		t.Fatalf("expected 2 user messages, got %d", len(userOnly))
+	}
+	if userOnly[0].ID != "user-2" || userOnly[1].ID != "user-1" {
+		t.Errorf("expected newest-first user messages, got [%s, %s]", userOnly[0].ID, userOnly[1].ID)
+	}
+
+	agentOnly, _, err := repo.ListMessagesPaginated(ctx, sessionID, models.ListMessagesOptions{
+		Limit:      10,
+		Sort:       "desc",
+		AuthorType: string(models.MessageAuthorAgent),
+	})
+	if err != nil {
+		t.Fatalf("filter agent: %v", err)
+	}
+	if len(agentOnly) != 1 || agentOnly[0].ID != "agent-1" {
+		t.Errorf("expected only agent-1, got %d messages", len(agentOnly))
+	}
+
+	unfiltered, _, err := repo.ListMessagesPaginated(ctx, sessionID, models.ListMessagesOptions{Limit: 10, Sort: "desc"})
+	if err != nil {
+		t.Fatalf("unfiltered: %v", err)
+	}
+	if len(unfiltered) != 3 {
+		t.Errorf("expected all 3 messages unfiltered, got %d", len(unfiltered))
+	}
+}
+
 func TestSQLiteRepository_MessageWithRequestsInput(t *testing.T) {
 	repo, cleanup := createTestSQLiteRepo(t)
 	defer cleanup()

--- a/apps/backend/internal/task/repository/sqlite/message.go
+++ b/apps/backend/internal/task/repository/sqlite/message.go
@@ -237,6 +237,10 @@ func buildListMessagesQuery(sessionID string, opts models.ListMessagesOptions, c
 		SELECT id, task_session_id, task_id, turn_id, author_type, author_id, content, requests_input, type, metadata, created_at, updated_at
 		FROM task_session_messages WHERE task_session_id = ?`
 	args := []interface{}{sessionID}
+	if opts.AuthorType != "" {
+		query += " AND author_type = ?"
+		args = append(args, opts.AuthorType)
+	}
 	if cursor != nil {
 		if opts.Before != "" {
 			query += " AND (created_at < ? OR (created_at = ? AND id < ?))"

--- a/apps/backend/internal/task/service/service_messages.go
+++ b/apps/backend/internal/task/service/service_messages.go
@@ -301,10 +301,11 @@ func (s *Service) ListMessagesPaginated(ctx context.Context, req ListMessagesReq
 		limit = MaxMessagesPageSize
 	}
 	return s.messages.ListMessagesPaginated(ctx, req.TaskSessionID, models.ListMessagesOptions{
-		Limit:  limit,
-		Before: req.Before,
-		After:  req.After,
-		Sort:   req.Sort,
+		Limit:      limit,
+		Before:     req.Before,
+		After:      req.After,
+		Sort:       req.Sort,
+		AuthorType: req.AuthorType,
 	})
 }
 

--- a/apps/backend/internal/task/service/service_requests.go
+++ b/apps/backend/internal/task/service/service_requests.go
@@ -244,6 +244,9 @@ type ListMessagesRequest struct {
 	Before        string
 	After         string
 	Sort          string
+	// AuthorType narrows the result to messages with exactly this author
+	// type ("user" or "agent"). Empty means unfiltered.
+	AuthorType string
 }
 
 // CreateRepositoryScriptRequest contains the data for creating a repository script

--- a/apps/web/components/task/chat/message-list-shared.test.tsx
+++ b/apps/web/components/task/chat/message-list-shared.test.tsx
@@ -85,8 +85,8 @@ import {
   isElementFullyVisible,
   resolveLastPromptControls,
   resolveLastPromptEdge,
+  resolveEffectiveLastPromptEdge,
   shouldAutoScrollToBottom,
-  shouldLoadMoreForTranscriptTarget,
 } from "./message-list-shared";
 
 const item: RenderItem = { type: "message", message: { id: "m1" } as Message };
@@ -437,19 +437,44 @@ describe("getFirstUserMessageId", () => {
   });
 });
 
-describe("shouldLoadMoreForTranscriptTarget", () => {
-  const message = (id: string, author_type: "user" | "agent") => ({ id, author_type }) as Message;
+describe("resolveEffectiveLastPromptEdge", () => {
+  const base = {
+    trackedEdge: "visible" as const,
+    lastPromptMessageId: "prompt-1",
+    lastPromptRendered: true,
+    hasMore: false,
+  };
 
-  it("keeps loading older pages when the latest loaded page has no user prompt", () => {
-    expect(
-      shouldLoadMoreForTranscriptTarget("last_prompt", [message("reply", "agent")], true),
-    ).toBe(true);
+  it("uses the tracked edge once the prompt is mounted", () => {
+    expect(resolveEffectiveLastPromptEdge({ ...base, trackedEdge: "above" })).toBe("above");
+    expect(resolveEffectiveLastPromptEdge({ ...base, trackedEdge: "below" })).toBe("below");
+    expect(resolveEffectiveLastPromptEdge(base)).toBe("visible");
   });
 
-  it("keeps loading for scroll-to-start until pagination reaches the real first prompt", () => {
+  it("reports above for a resolved-but-unmounted prompt while older pages remain", () => {
+    // Regression: the loaded window holds the newest messages, so a resolved
+    // last prompt that is not mounted is deterministically above the viewport.
+    // The renderer would report "visible" (no target row) and wrongly suppress
+    // both affordances.
     expect(
-      shouldLoadMoreForTranscriptTarget("start", [message("loaded-prompt", "user")], true),
-    ).toBe(true);
+      resolveEffectiveLastPromptEdge({ ...base, lastPromptRendered: false, hasMore: true }),
+    ).toBe("above");
+  });
+
+  it("falls back to the tracked edge when no older pages remain", () => {
+    expect(
+      resolveEffectiveLastPromptEdge({ ...base, lastPromptRendered: false, hasMore: false }),
+    ).toBe("visible");
+  });
+
+  it("uses the tracked edge when no last prompt is resolved", () => {
+    expect(
+      resolveEffectiveLastPromptEdge({
+        ...base,
+        lastPromptMessageId: null,
+        trackedEdge: "visible",
+      }),
+    ).toBe("visible");
   });
 });
 

--- a/apps/web/components/task/chat/message-list-shared.tsx
+++ b/apps/web/components/task/chat/message-list-shared.tsx
@@ -102,22 +102,6 @@ export function getFirstUserMessageId(messages: Message[]): string | null {
   return first ? first.id : null;
 }
 
-export type TranscriptNavigationTarget = "last_prompt" | "start";
-
-/**
- * Whether resolving a transcript-navigation target needs another older page.
- * The latest prompt may sit before a long agent response; the true start can
- * only be known after the pagination cursor is exhausted.
- */
-export function shouldLoadMoreForTranscriptTarget(
-  target: TranscriptNavigationTarget,
-  messages: Message[],
-  hasMore: boolean,
-): boolean {
-  if (!hasMore) return false;
-  return target === "start" || getLastUserMessageId(messages) === null;
-}
-
 /**
  * Whether the transcript's auto-follow-bottom behavior should force a scroll
  * to the bottom right now. `false` whenever a user-initiated programmatic
@@ -169,6 +153,25 @@ export function resolveLastPromptControls(edge: LastPromptEdge): {
     scrollButtonEligible: edge !== "visible",
     scrollDirection: edge === "below" ? "down" : "up",
   };
+}
+
+/**
+ * Effective last-prompt edge when the prompt's DOM row may not be mounted.
+ * The renderer reports `"visible"` whenever the target row is absent, which
+ * would wrongly suppress both affordances for a session whose last prompt is
+ * older than the loaded window. When the prompt is resolved but not mounted
+ * and older messages remain (`hasMore`), the loaded window is the newest
+ * content, so the prompt deterministically sits above the viewport — report
+ * `"above"` until the row mounts and the renderer's tracked edge takes over.
+ */
+export function resolveEffectiveLastPromptEdge(params: {
+  trackedEdge: LastPromptEdge;
+  lastPromptMessageId: string | null;
+  lastPromptRendered: boolean;
+  hasMore: boolean;
+}): LastPromptEdge {
+  if (params.lastPromptMessageId && !params.lastPromptRendered && params.hasMore) return "above";
+  return params.trackedEdge;
 }
 
 /** True when `target` sits entirely within `container`'s visible viewport —

--- a/apps/web/components/task/chat/use-drain-older-messages.ts
+++ b/apps/web/components/task/chat/use-drain-older-messages.ts
@@ -16,11 +16,10 @@ const MAX_DRAIN_BATCHES = 50;
  *
  * Step-driven, not an imperative loop: each batch only fires once `isLoading`
  * (from `useLazyLoadMessages`, reactive) is confirmed false, so this never
- * races a concurrent caller sharing the same session (e.g. the transcript's
- * own last-prompt preload effect) — it waits for that fetch to actually
- * finish and re-reads the resulting `hasMore` instead of guessing from an
- * ambiguous "0 fetched" return that could mean either genuine exhaustion or
- * a no-op against someone else's in-flight request.
+ * races a concurrent caller sharing the same session — it waits for that
+ * fetch to actually finish and re-reads the resulting `hasMore` instead of
+ * guessing from an ambiguous "0 fetched" return that could mean either
+ * genuine exhaustion or a no-op against someone else's in-flight request.
  */
 export function useDrainOlderMessages(sessionId: string | null, active: boolean) {
   const { loadMore, hasMore, isLoading } = useLazyLoadMessages(sessionId);

--- a/apps/web/components/task/task-chat-panel.tsx
+++ b/apps/web/components/task/task-chat-panel.tsx
@@ -12,12 +12,12 @@ import { MessageList } from "@/components/task/chat/message-list";
 import {
   type MessageListHandle,
   type LastPromptEdge,
-  getLastUserMessageId,
   getFirstUserMessageId,
   resolveLastPromptControls,
-  shouldLoadMoreForTranscriptTarget,
+  resolveEffectiveLastPromptEdge,
 } from "@/components/task/chat/message-list-shared";
 import { AnchoredLastPromptBar } from "@/components/task/chat/anchored-last-prompt-bar";
+import { useLastUserMessage } from "@/hooks/domains/session/use-last-user-message";
 import { useResponsiveBreakpoint } from "@/hooks/use-responsive-breakpoint";
 import { useIsTaskArchived } from "./task-archived-context";
 import { useChatPanelState } from "./chat/use-chat-panel-state";
@@ -36,16 +36,6 @@ import { useDrainOlderMessages } from "@/components/task/chat/use-drain-older-me
 import { useAppStore } from "@/components/state-provider";
 import type { Message } from "@/lib/types/http";
 import { routePanelMouseDown } from "./chat/route-panel-mouse-down";
-
-/**
- * Cap on how many extra pages the last-prompt background lookup will fetch
- * (see the `lastPromptLookupPagesRef` effect below) before giving up and
- * falling back to the transcript's manual "Load older messages" pagination.
- * 3 pages of 20 covers a long single agent turn without silently draining
- * an entire long-lived conversation that happens to have no recent user
- * message at all.
- */
-const MAX_LAST_PROMPT_LOOKUP_PAGES = 3;
 
 function useClarificationKey(agentMessageCount: number) {
   const lastCountRef = useRef(agentMessageCount);
@@ -248,14 +238,12 @@ export const TaskChatPanel = memo(function TaskChatPanel({
 
   const panelRef = useRef<HTMLDivElement>(null);
   const messageListRef = useRef<MessageListHandle>(null);
-  const lastPromptMessageId = useMemo(() => getLastUserMessageId(allMessages), [allMessages]);
-  const lastPromptMessage = useMemo(
-    () =>
-      lastPromptMessageId
-        ? (allMessages.find((message) => message.id === lastPromptMessageId) ?? null)
-        : null,
-    [allMessages, lastPromptMessageId],
-  );
+  // The last prompt may sit far above the initially loaded window (autonomous
+  // session whose only user prompt is its task description). Resolve it with a
+  // targeted fetch when the loaded window has no user message, rather than
+  // paginating the whole transcript in the background.
+  const { lastPromptMessage } = useLastUserMessage(resolvedSessionId, allMessages);
+  const lastPromptMessageId = lastPromptMessage?.id ?? null;
   const [lastPromptEdge, setLastPromptEdge] = useState<LastPromptEdge>("visible");
   const showAnchoredPromptBar = useAppStore((state) => state.userSettings.showAnchoredPromptBar);
   const showScrollToLastPrompt = useAppStore((state) => state.userSettings.showScrollToLastPrompt);
@@ -264,28 +252,69 @@ export const TaskChatPanel = memo(function TaskChatPanel({
   // The anchored bar is a desktop-only, opt-in affordance; mobile always
   // falls back to the scroll button.
   const showAnchoredBar = !isMobile && showAnchoredPromptBar;
-  const { anchoredBarVisible, scrollButtonEligible, scrollDirection } =
-    resolveLastPromptControls(lastPromptEdge);
-  const showScrollButton =
-    showScrollToLastPrompt && Boolean(lastPromptMessageId) && scrollButtonEligible;
-  const scrollToLastPrompt = useCallback(() => {
-    if (lastPromptMessageId) {
-      messageListRef.current?.scrollToMessage(lastPromptMessageId, { align: "start" });
-    }
-  }, [lastPromptMessageId]);
   const firstMessageId = useMemo(() => getFirstUserMessageId(allMessages), [allMessages]);
   const [isFirstMessageHidden, setIsFirstMessageHidden] = useState(false);
   const showScrollToStartButton =
     showScrollToStart && Boolean(firstMessageId) && isFirstMessageHidden;
-  const { loadMore, hasMore, isLoading: isLoadingMore } = useLazyLoadMessages(resolvedSessionId);
+  const { loadMore, hasMore } = useLazyLoadMessages(resolvedSessionId);
+  const lastPromptRendered = useMemo(
+    () =>
+      lastPromptMessageId
+        ? allMessages.some((message) => message.id === lastPromptMessageId)
+        : false,
+    [allMessages, lastPromptMessageId],
+  );
+  // While the last prompt is resolved but not mounted and older pages remain,
+  // it deterministically sits above the viewport (the loaded window is the
+  // newest content), so report "above" instead of the renderer's "visible"
+  // default. Once the prompt row mounts, the tracked edge takes over.
+  const effectiveLastPromptEdge = resolveEffectiveLastPromptEdge({
+    trackedEdge: lastPromptEdge,
+    lastPromptMessageId,
+    lastPromptRendered,
+    hasMore,
+  });
+  const { anchoredBarVisible, scrollButtonEligible, scrollDirection } =
+    resolveLastPromptControls(effectiveLastPromptEdge);
+  const showScrollButton =
+    showScrollToLastPrompt && Boolean(lastPromptMessageId) && scrollButtonEligible;
+  // Scroll-to-last-prompt: a resolved prompt that is not mounted needs older
+  // pages drained before the row exists to scroll to — the same drain-then-
+  // scroll pattern scroll-to-start uses below.
+  const [pendingScrollToLastPrompt, setPendingScrollToLastPrompt] = useState(false);
+  const [pendingScrollToStart, setPendingScrollToStart] = useState(false);
+  // Reset both pending navigations when the session changes so a drain started
+  // on a previous tab can't keep paginating the new session.
+  useEffect(() => {
+    setPendingScrollToLastPrompt(false);
+    setPendingScrollToStart(false);
+  }, [resolvedSessionId]);
+  useDrainOlderMessages(
+    resolvedSessionId,
+    (pendingScrollToLastPrompt || pendingScrollToStart) && hasMore,
+  );
+  useEffect(() => {
+    if (!pendingScrollToLastPrompt) return;
+    if (!lastPromptRendered && hasMore) return;
+    setPendingScrollToLastPrompt(false);
+    if (lastPromptMessageId) {
+      messageListRef.current?.scrollToMessage(lastPromptMessageId, { align: "start" });
+    }
+  }, [pendingScrollToLastPrompt, lastPromptRendered, hasMore, lastPromptMessageId]);
+  const scrollToLastPrompt = useCallback(() => {
+    if (!lastPromptMessageId) return;
+    if (hasMore && !lastPromptRendered) {
+      setPendingScrollToLastPrompt(true);
+      return;
+    }
+    messageListRef.current?.scrollToMessage(lastPromptMessageId, { align: "start" });
+  }, [hasMore, lastPromptRendered, lastPromptMessageId]);
   // A paginated session's `firstMessageId` only reflects the oldest message in
   // the currently loaded page while `hasMore` is true — jumping there directly
   // lands on a partial-page boundary, not the transcript's real start. Drain
   // older pages first so `firstMessageId` (derived from `allMessages` above,
   // which grows as pages prepend) has settled on the true first prompt by the
   // time the scroll fires.
-  const [pendingScrollToStart, setPendingScrollToStart] = useState(false);
-  useDrainOlderMessages(resolvedSessionId, pendingScrollToStart && hasMore);
   useEffect(() => {
     if (!pendingScrollToStart || hasMore) return;
     setPendingScrollToStart(false);
@@ -302,26 +331,6 @@ export const TaskChatPanel = memo(function TaskChatPanel({
       messageListRef.current?.scrollToMessage(firstMessageId, { align: "start" });
     }
   }, [hasMore, firstMessageId]);
-  // Bounded background lookup: the last prompt is usually within a page or
-  // two of a long single agent turn, but a session with no recent user
-  // message at all (e.g. hours of tool-only activity) would otherwise drain
-  // its *entire* history just to power this convenience affordance. Stop
-  // after a handful of pages and fall back to the manual "Load older
-  // messages" pagination the transcript already offers.
-  const lastPromptLookupPagesRef = useRef(0);
-  useEffect(() => {
-    lastPromptLookupPagesRef.current = 0;
-  }, [resolvedSessionId]);
-  useEffect(() => {
-    if (lastPromptMessageId !== null) {
-      lastPromptLookupPagesRef.current = 0;
-      return;
-    }
-    if (isLoadingMore || lastPromptLookupPagesRef.current >= MAX_LAST_PROMPT_LOOKUP_PAGES) return;
-    if (!shouldLoadMoreForTranscriptTarget("last_prompt", allMessages, hasMore)) return;
-    lastPromptLookupPagesRef.current += 1;
-    void loadMore();
-  }, [allMessages, hasMore, isLoadingMore, loadMore, lastPromptMessageId, resolvedSessionId]);
   const search = useSessionSearch(resolvedSessionId, loadMore);
   const { label: agentLabel, name: agentName } = useSessionAgentIdentity(resolvedSessionId);
   usePanelSearch({

--- a/apps/web/e2e/tests/chat/last-prompt-multi-tab.spec.ts
+++ b/apps/web/e2e/tests/chat/last-prompt-multi-tab.spec.ts
@@ -1,0 +1,440 @@
+// Regression: with multiple agent tabs on a task, some tabs do not display /
+// use the last-prompt navigation affordances (the scroll-to-last-prompt button
+// and the anchored prompt bar). Sessions whose panels are created while another
+// tab is active mount hidden (dockview toggles the inactive overlay to
+// `display:none`), which can leave their transcript edge state out of sync when
+// the tab is activated.
+import { test, expect } from "../../fixtures/test-base";
+import { SessionPage } from "../../pages/session-page";
+import { FIRST_PROMPT_MARKER, LAST_PROMPT_MARKER } from "./last-prompt-scroll-helpers";
+
+const DONE_STATES = ["COMPLETED", "WAITING_FOR_INPUT"];
+
+// The dockview session tabs keep every session's chat mounted (hidden), so
+// SessionPage.waitForChatIdle's global idle-input locator resolves to multiple
+// elements here. Wait for the active panel's own idle input instead.
+async function waitForActiveChatIdle(session: SessionPage, timeout = 30_000): Promise<void> {
+  const idle = session.activeChat().locator('[data-placeholder^="Continue working"]');
+  await expect(idle).toBeVisible({ timeout });
+}
+
+async function seedSessionScrolledPastLastPrompt(
+  session: SessionPage,
+  apiClient: import("../../helpers/api-client").ApiClient,
+  sessionId: string,
+): Promise<void> {
+  const send = async (text: string) => {
+    await session.sendMessage(text);
+    await waitForActiveChatIdle(session);
+  };
+  await send(FIRST_PROMPT_MARKER);
+  await apiClient.seedAgentMessages(sessionId, 30, "middle filler message");
+  await send(LAST_PROMPT_MARKER);
+  await apiClient.seedAgentMessages(sessionId, 50);
+  await expect(session.activeChat().getByText("filler message 50", { exact: false })).toBeVisible({
+    timeout: 15_000,
+  });
+}
+
+/** Read the active transcript's scroll position. */
+async function activeScrollTop(chat: ReturnType<SessionPage["activeChat"]>): Promise<number> {
+  return chat.evaluate((root) => {
+    const el = root.querySelector<HTMLElement>(".chat-message-list");
+    return el ? el.scrollTop : -1;
+  });
+}
+
+/** Manually scroll the active transcript so a given trailing filler row is in
+ * view — the last prompt then sits above the viewport, with content still
+ * below (a mid-transcript position, not the bottom). */
+async function scrollToFiller(
+  chat: ReturnType<SessionPage["activeChat"]>,
+  n: number,
+): Promise<void> {
+  await chat.getByText(`filler message ${n}`, { exact: false }).scrollIntoViewIfNeeded();
+  await expect(chat.getByTestId("anchored-last-prompt-bar")).toHaveAttribute("data-state", "open", {
+    timeout: 10_000,
+  });
+}
+
+test.describe("@chat last prompt affordances with multiple agent tabs", () => {
+  test.afterEach(async ({ apiClient }) => {
+    await apiClient.saveUserSettings({
+      show_anchored_prompt_bar: false,
+      show_scroll_to_last_prompt: true,
+      show_scroll_to_start: false,
+      show_transcript_auto_scroll_control: true,
+    });
+  });
+
+  test("second agent tab keeps the pinned bar and scroll button across tab switches", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    test.setTimeout(180_000);
+    await apiClient.saveUserSettings({
+      show_anchored_prompt_bar: true,
+      show_scroll_to_last_prompt: true,
+      show_scroll_to_start: true,
+    });
+
+    // 1. Create the task and wait for the first agent session to finish.
+    const task = await apiClient.createTaskWithAgent(
+      seedData.workspaceId,
+      "Multi-Agent Last Prompt",
+      seedData.agentProfileId,
+      {
+        description: "/e2e:simple-message",
+        workflow_id: seedData.workflowId,
+        workflow_step_id: seedData.startStepId,
+        repository_ids: [seedData.repositoryId],
+      },
+    );
+    await expect
+      .poll(
+        async () => {
+          const { sessions } = await apiClient.listTaskSessions(task.id);
+          return DONE_STATES.includes(sessions[0]?.state ?? "");
+        },
+        { timeout: 45_000, message: "Waiting for first session to finish" },
+      )
+      .toBe(true);
+
+    // 2. Open the task in the UI and seed the first tab past its last prompt.
+    await testPage.goto(`/t/${task.id}`);
+    const session = new SessionPage(testPage);
+    await session.waitForLoad();
+    const { sessions: firstSessions } = await apiClient.listTaskSessions(task.id);
+    const session1Id = firstSessions[0].id;
+    await seedSessionScrolledPastLastPrompt(session, apiClient, session1Id);
+    const chat1 = session.activeChat();
+    await expect(chat1.getByTestId("anchored-last-prompt-bar")).toHaveAttribute(
+      "data-state",
+      "open",
+      { timeout: 15_000 },
+    );
+    await expect(
+      chat1.getByTestId("chat-status-bar").getByTestId("scroll-to-last-prompt-button"),
+    ).toBeVisible();
+
+    // 3. Launch a second agent session on the same task.
+    const launched = await apiClient.launchSession(
+      {
+        task_id: task.id,
+        agent_profile_id: seedData.agentProfileId,
+        executor_profile_id: seedData.worktreeExecutorProfileId,
+        workflow_step_id: seedData.startStepId,
+        prompt: "/e2e:simple-message",
+      },
+      60_000,
+    );
+    await expect(session.sessionTabBySessionId(launched.session_id)).toBeVisible({
+      timeout: 20_000,
+    });
+
+    // 4. Switch to the second tab and seed it past its last prompt too.
+    await session.sessionTabBySessionId(launched.session_id).click();
+    await waitForActiveChatIdle(session);
+    await seedSessionScrolledPastLastPrompt(session, apiClient, launched.session_id);
+    const chat2 = session.activeChat();
+    await expect(chat2.getByTestId("anchored-last-prompt-bar")).toHaveAttribute(
+      "data-state",
+      "open",
+      { timeout: 15_000 },
+    );
+    await expect(
+      chat2.getByTestId("chat-status-bar").getByTestId("scroll-to-last-prompt-button"),
+    ).toBeVisible();
+
+    // 5. Switch back to the first tab — its controls must survive.
+    await session.sessionTabBySessionId(session1Id).click();
+    await waitForActiveChatIdle(session);
+    await expect(chat1.getByTestId("anchored-last-prompt-bar")).toHaveAttribute(
+      "data-state",
+      "open",
+      { timeout: 15_000 },
+    );
+    await expect(
+      chat1.getByTestId("chat-status-bar").getByTestId("scroll-to-last-prompt-button"),
+    ).toBeVisible();
+
+    // 6. Switch back to the second tab — its controls must survive as well.
+    await session.sessionTabBySessionId(launched.session_id).click();
+    await waitForActiveChatIdle(session);
+    await expect(chat2.getByTestId("anchored-last-prompt-bar")).toHaveAttribute(
+      "data-state",
+      "open",
+      { timeout: 15_000 },
+    );
+    await expect(
+      chat2.getByTestId("chat-status-bar").getByTestId("scroll-to-last-prompt-button"),
+    ).toBeVisible();
+    // Scope to the transcript row itself: the anchored bar renders a
+    // shortened copy of the last prompt text and sits in the viewport by
+    // design, so a loose text match could resolve to that copy instead.
+    const lastPromptRow = chat2
+      .locator("[id^='msg-']")
+      .filter({ has: testPage.getByText(LAST_PROMPT_MARKER, { exact: true }) });
+    await expect(lastPromptRow).not.toBeInViewport();
+  });
+
+  test("an agent tab created while inactive lands on the latest transcript when first activated", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    test.setTimeout(180_000);
+    await apiClient.saveUserSettings({
+      show_anchored_prompt_bar: true,
+      show_scroll_to_last_prompt: true,
+      show_scroll_to_start: true,
+    });
+
+    // 1. Create the task and open it — the first session's tab is active.
+    const task = await apiClient.createTaskWithAgent(
+      seedData.workspaceId,
+      "Multi-Agent Inactive Tab",
+      seedData.agentProfileId,
+      {
+        description: "/e2e:simple-message",
+        workflow_id: seedData.workflowId,
+        workflow_step_id: seedData.startStepId,
+        repository_ids: [seedData.repositoryId],
+      },
+    );
+    await testPage.goto(`/t/${task.id}`);
+    const session = new SessionPage(testPage);
+    await session.waitForLoad();
+    await waitForActiveChatIdle(session);
+
+    // 2. Launch a second agent session while the first tab stays active. Its
+    //    dockview panel is created inactive (hidden), and its transcript is
+    //    seeded entirely while the panel stays hidden.
+    const launched = await apiClient.launchSession(
+      {
+        task_id: task.id,
+        agent_profile_id: seedData.agentProfileId,
+        executor_profile_id: seedData.worktreeExecutorProfileId,
+        workflow_step_id: seedData.startStepId,
+        prompt: `/e2e:simple-message ${FIRST_PROMPT_MARKER}`,
+      },
+      60_000,
+    );
+    await expect(session.sessionTabBySessionId(launched.session_id)).toBeVisible({
+      timeout: 20_000,
+    });
+    await expect
+      .poll(
+        async () => {
+          const { sessions } = await apiClient.listTaskSessions(task.id);
+          const target = sessions.find((s) => s.id === launched.session_id);
+          return target ? DONE_STATES.includes(target.state) : false;
+        },
+        { timeout: 60_000, message: "Waiting for second session to finish" },
+      )
+      .toBe(true);
+    await apiClient.seedAgentMessages(launched.session_id, 50);
+
+    // 3. First activation: the transcript must land at the bottom (latest
+    //    messages), like any chat tab — not stuck at the top where the whole
+    //    transcript appears empty of activity.
+    await session.sessionTabBySessionId(launched.session_id).click();
+    await waitForActiveChatIdle(session);
+    const chat2 = session.activeChat();
+    await expect(chat2.getByText("filler message 50", { exact: false })).toBeVisible({
+      timeout: 15_000,
+    });
+    const isAtBottom = await chat2.evaluate((root) => {
+      const el = root.querySelector<HTMLElement>(".chat-message-list");
+      if (!el) return false;
+      return el.scrollHeight - el.scrollTop - el.clientHeight < 5;
+    });
+    expect(isAtBottom, "first activation should scroll the transcript to the bottom").toBe(true);
+  });
+
+  test("manually scrolled transcript keeps its last-prompt bar and scroll position across repeated tab switches", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    test.setTimeout(180_000);
+    await apiClient.saveUserSettings({
+      show_anchored_prompt_bar: true,
+      show_scroll_to_last_prompt: true,
+      show_scroll_to_start: true,
+    });
+
+    // 1. First session: seed past its last prompt, then manually scroll to a
+    //    mid-transcript position (last prompt above the viewport, content
+    //    still below) and record that position.
+    const task = await apiClient.createTaskWithAgent(
+      seedData.workspaceId,
+      "Multi-Agent Manual Scroll",
+      seedData.agentProfileId,
+      {
+        description: "/e2e:simple-message",
+        workflow_id: seedData.workflowId,
+        workflow_step_id: seedData.startStepId,
+        repository_ids: [seedData.repositoryId],
+      },
+    );
+    await expect
+      .poll(
+        async () => {
+          const { sessions } = await apiClient.listTaskSessions(task.id);
+          return DONE_STATES.includes(sessions[0]?.state ?? "");
+        },
+        { timeout: 45_000, message: "Waiting for first session to finish" },
+      )
+      .toBe(true);
+    await testPage.goto(`/t/${task.id}`);
+    const session = new SessionPage(testPage);
+    await session.waitForLoad();
+    const { sessions: firstSessions } = await apiClient.listTaskSessions(task.id);
+    const session1Id = firstSessions[0].id;
+    await seedSessionScrolledPastLastPrompt(session, apiClient, session1Id);
+    const chat1 = session.activeChat();
+    await scrollToFiller(chat1, 35);
+    const savedScrollTop1 = await activeScrollTop(chat1);
+    await expect(
+      chat1.getByTestId("chat-status-bar").getByTestId("scroll-to-last-prompt-button"),
+    ).toBeVisible();
+
+    // 2. Launch a second agent session and seed it the same way.
+    const launched = await apiClient.launchSession(
+      {
+        task_id: task.id,
+        agent_profile_id: seedData.agentProfileId,
+        executor_profile_id: seedData.worktreeExecutorProfileId,
+        workflow_step_id: seedData.startStepId,
+        prompt: "/e2e:simple-message",
+      },
+      60_000,
+    );
+    await expect(session.sessionTabBySessionId(launched.session_id)).toBeVisible({
+      timeout: 20_000,
+    });
+    await session.sessionTabBySessionId(launched.session_id).click();
+    await waitForActiveChatIdle(session);
+    await seedSessionScrolledPastLastPrompt(session, apiClient, launched.session_id);
+    const chat2 = session.activeChat();
+    await scrollToFiller(chat2, 35);
+    const savedScrollTop2 = await activeScrollTop(chat2);
+    await expect(
+      chat2.getByTestId("chat-status-bar").getByTestId("scroll-to-last-prompt-button"),
+    ).toBeVisible();
+
+    // 3. Repeated round-trips: every return must keep the last prompt above
+    //    the viewport (bar open + scroll button visible) AND preserve the
+    //    exact manual scroll position.
+    for (let i = 0; i < 4; i++) {
+      await session.sessionTabBySessionId(session1Id).click();
+      await waitForActiveChatIdle(session);
+      await expect(chat1.getByTestId("anchored-last-prompt-bar")).toHaveAttribute(
+        "data-state",
+        "open",
+        { timeout: 10_000 },
+      );
+      await expect(
+        chat1.getByTestId("chat-status-bar").getByTestId("scroll-to-last-prompt-button"),
+      ).toBeVisible();
+      expect(Math.abs((await activeScrollTop(chat1)) - savedScrollTop1)).toBeLessThan(10);
+
+      await session.sessionTabBySessionId(launched.session_id).click();
+      await waitForActiveChatIdle(session);
+      await expect(chat2.getByTestId("anchored-last-prompt-bar")).toHaveAttribute(
+        "data-state",
+        "open",
+        { timeout: 10_000 },
+      );
+      await expect(
+        chat2.getByTestId("chat-status-bar").getByTestId("scroll-to-last-prompt-button"),
+      ).toBeVisible();
+      expect(Math.abs((await activeScrollTop(chat2)) - savedScrollTop2)).toBeLessThan(10);
+    }
+  });
+
+  test("autonomous session with only its task description as a prompt still gets the last-prompt affordances", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    test.setTimeout(180_000);
+    await apiClient.saveUserSettings({
+      show_anchored_prompt_bar: true,
+      show_scroll_to_last_prompt: true,
+      show_scroll_to_start: true,
+    });
+
+    // 1. An agent that ran entirely on its own: the task description is the
+    //    session's only user message. Bury it under so much autonomous agent
+    //    output that the initial fetch window alone can never reach it.
+    const task = await apiClient.createTaskWithAgent(
+      seedData.workspaceId,
+      "Multi-Agent Autonomous Session",
+      seedData.agentProfileId,
+      {
+        description: "/e2e:simple-message",
+        workflow_id: seedData.workflowId,
+        workflow_step_id: seedData.startStepId,
+        repository_ids: [seedData.repositoryId],
+      },
+    );
+    await expect
+      .poll(
+        async () => {
+          const { sessions } = await apiClient.listTaskSessions(task.id);
+          return DONE_STATES.includes(sessions[0]?.state ?? "");
+        },
+        { timeout: 45_000, message: "Waiting for session to finish" },
+      )
+      .toBe(true);
+    await testPage.goto(`/t/${task.id}`);
+    const session = new SessionPage(testPage);
+    await session.waitForLoad();
+    const { sessions: firstSessions } = await apiClient.listTaskSessions(task.id);
+    await waitForActiveChatIdle(session);
+    const chat = session.activeChat();
+    await apiClient.seedAgentMessages(firstSessions[0].id, 200);
+    await expect(chat.getByText("filler message 200", { exact: false })).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // 2. Reload so the store re-fetches only the newest window: a task
+    //    description that is the session's only user message sits 200 agent
+    //    messages behind it, beyond the initial fetch.
+    await testPage.reload();
+    await session.waitForLoad();
+    await waitForActiveChatIdle(session);
+    const reloadedChat = session.activeChat();
+    await expect(reloadedChat.getByText("filler message 200", { exact: false })).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // 3. The last prompt (the task description) exists in the transcript and
+    //    sits above the viewport, so the affordances must be available even
+    //    though it is not part of the initially loaded window.
+    await expect(
+      reloadedChat.getByTestId("chat-status-bar").getByTestId("scroll-to-last-prompt-button"),
+    ).toBeVisible({ timeout: 15_000 });
+    await expect(reloadedChat.getByTestId("anchored-last-prompt-bar")).toHaveAttribute(
+      "data-state",
+      "open",
+      { timeout: 15_000 },
+    );
+
+    // 4. Clicking jumps to the prompt, draining older pages on demand: the
+    //    transcript lands near the top, on the task-description message.
+    await reloadedChat
+      .getByTestId("chat-status-bar")
+      .getByTestId("scroll-to-last-prompt-button")
+      .click();
+    await expect
+      .poll(async () => activeScrollTop(reloadedChat), {
+        timeout: 30_000,
+        message: "Waiting for scroll-to-last-prompt to land near the top",
+      })
+      .toBeLessThan(100);
+  });
+});

--- a/apps/web/hooks/domains/session/use-last-user-message.test.ts
+++ b/apps/web/hooks/domains/session/use-last-user-message.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { Message } from "@/lib/types/http";
+
+const mockListTaskSessionMessages = vi.fn();
+
+vi.mock("@/lib/api/domains/session-api", () => ({
+  listTaskSessionMessages: (...args: unknown[]) => mockListTaskSessionMessages(...args),
+}));
+
+vi.mock("@/components/task/chat/message-list-shared", () => ({
+  getLastUserMessageId: (messages: Message[]) => {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i].author_type === "user") return messages[i].id;
+    }
+    return null;
+  },
+}));
+
+import { useLastUserMessage } from "./use-last-user-message";
+
+function message(id: string, authorType: Message["author_type"]): Message {
+  return { id, author_type: authorType, content: id, created_at: "", type: "message" } as Message;
+}
+
+const userPrompt = message("user-1", "user");
+const agentReply = message("agent-1", "agent");
+
+describe("useLastUserMessage", () => {
+  beforeEach(() => {
+    mockListTaskSessionMessages.mockReset();
+  });
+
+  it("returns the window-derived last user message without fetching", () => {
+    const messages = [userPrompt, agentReply, message("agent-2", "agent")];
+    const { result } = renderHook(() => useLastUserMessage("session-1", messages));
+
+    expect(result.current.lastPromptMessage).toEqual(userPrompt);
+    expect(mockListTaskSessionMessages).not.toHaveBeenCalled();
+  });
+
+  it("fetches the last user message when the window has none", async () => {
+    mockListTaskSessionMessages.mockResolvedValue({ messages: [userPrompt], has_more: false });
+    const messages = [agentReply, message("agent-2", "agent")];
+
+    const { result } = renderHook(() => useLastUserMessage("session-1", messages));
+
+    await waitFor(() => expect(result.current.lastPromptMessage).toEqual(userPrompt));
+    expect(mockListTaskSessionMessages).toHaveBeenCalledWith("session-1", {
+      limit: 1,
+      author_type: "user",
+      sort: "desc",
+    });
+  });
+
+  it("returns null when the fetch finds no user message", async () => {
+    mockListTaskSessionMessages.mockResolvedValue({ messages: [], has_more: false });
+    const messages = [agentReply];
+
+    const { result } = renderHook(() => useLastUserMessage("session-1", messages));
+
+    await waitFor(() => expect(result.current.lastPromptMessage).toBeNull());
+  });
+
+  it("prefers a newly-loaded window message over the fetched fallback", async () => {
+    mockListTaskSessionMessages.mockResolvedValue({ messages: [userPrompt], has_more: false });
+    const windowOnly = [agentReply];
+
+    const { result, rerender } = renderHook(
+      ({ sessionId, messages }) => useLastUserMessage(sessionId, messages),
+      {
+        initialProps: { sessionId: "session-1", messages: windowOnly },
+      },
+    );
+    await waitFor(() => expect(result.current.lastPromptMessage).toEqual(userPrompt));
+
+    // A user message now arrives in the window (e.g. the user sends a new prompt).
+    rerender({ sessionId: "session-1", messages: [userPrompt, agentReply] });
+    expect(result.current.lastPromptMessage).toEqual(userPrompt);
+    // The fetched fallback no longer drives the result; window message wins.
+    mockListTaskSessionMessages.mockResolvedValue({ messages: [userPrompt], has_more: false });
+    await waitFor(() => expect(result.current.lastPromptMessage).toEqual(userPrompt));
+  });
+
+  it("does not refetch while the session is unchanged", async () => {
+    mockListTaskSessionMessages.mockResolvedValue({ messages: [userPrompt], has_more: false });
+    const messages = [agentReply];
+
+    const { rerender } = renderHook(() => useLastUserMessage("session-1", messages));
+    await waitFor(() => expect(mockListTaskSessionMessages).toHaveBeenCalledTimes(1));
+
+    rerender();
+    await waitFor(() => expect(mockListTaskSessionMessages).toHaveBeenCalledTimes(1));
+  });
+});

--- a/apps/web/hooks/domains/session/use-last-user-message.test.tsx
+++ b/apps/web/hooks/domains/session/use-last-user-message.test.tsx
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { StrictMode } from "react";
 import { renderHook, waitFor } from "@testing-library/react";
 import type { Message } from "@/lib/types/http";
 
@@ -91,5 +92,20 @@ describe("useLastUserMessage", () => {
 
     rerender();
     await waitFor(() => expect(mockListTaskSessionMessages).toHaveBeenCalledTimes(1));
+  });
+
+  it("resolves under React StrictMode's double-invoked effects", async () => {
+    // Regression: the app runs under <StrictMode> in dev, which mounts,
+    // cleans up, and re-mounts the effect. The first mount's cleanup must not
+    // cancel the in-flight request in a way that starves the fetched result.
+    mockListTaskSessionMessages.mockResolvedValue({ messages: [userPrompt], has_more: false });
+    const messages = [agentReply];
+
+    const { result } = renderHook(() => useLastUserMessage("session-1", messages), {
+      wrapper: ({ children }) => <StrictMode>{children}</StrictMode>,
+    });
+
+    await waitFor(() => expect(result.current.lastPromptMessage).toEqual(userPrompt));
+    expect(mockListTaskSessionMessages).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/hooks/domains/session/use-last-user-message.ts
+++ b/apps/web/hooks/domains/session/use-last-user-message.ts
@@ -1,0 +1,61 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { listTaskSessionMessages } from "@/lib/api/domains/session-api";
+import { getLastUserMessageId } from "@/components/task/chat/message-list-shared";
+import type { Message } from "@/lib/types/http";
+
+/**
+ * Resolves the session's last user-authored message ("last prompt") even when
+ * it is older than the loaded message window (e.g. an autonomous session whose
+ * only user prompt is its task description, buried under hundreds of agent
+ * messages).
+ *
+ * Prefers the window-derived message — always freshest, because a new user
+ * message arrives via the store and is immediately present in `allMessages`.
+ * Only when the window contains no user message at all does it issue a single
+ * targeted fetch (`author_type=user`, newest first) instead of paginating
+ * through the whole transcript. Returns the fetched message as a fallback so
+ * the scroll-to-last-prompt affordances can render before the prompt row is
+ * ever mounted.
+ */
+export function useLastUserMessage(
+  sessionId: string | null,
+  allMessages: Message[],
+): { lastPromptMessage: Message | null } {
+  const windowMessage = useMemo(() => {
+    const id = getLastUserMessageId(allMessages);
+    if (!id) return null;
+    return allMessages.find((message) => message.id === id) ?? null;
+  }, [allMessages]);
+
+  const [fetchedMessage, setFetchedMessage] = useState<Message | null>(null);
+  const fetchedSessionRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    // A user message in the window is the authoritative answer and wins over
+    // any earlier targeted fetch (it may be a brand-new prompt).
+    if (windowMessage) {
+      setFetchedMessage(null);
+      fetchedSessionRef.current = null;
+      return;
+    }
+    if (!sessionId || fetchedSessionRef.current === sessionId) return;
+    fetchedSessionRef.current = sessionId;
+    let cancelled = false;
+    void listTaskSessionMessages(sessionId, {
+      limit: 1,
+      author_type: "user",
+      sort: "desc",
+    })
+      .then((response) => {
+        if (!cancelled) setFetchedMessage(response.messages[0] ?? null);
+      })
+      .catch(() => {
+        if (!cancelled) setFetchedMessage(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionId, windowMessage]);
+
+  return { lastPromptMessage: windowMessage ?? fetchedMessage };
+}

--- a/apps/web/hooks/domains/session/use-last-user-message.ts
+++ b/apps/web/hooks/domains/session/use-last-user-message.ts
@@ -39,22 +39,27 @@ export function useLastUserMessage(
       return;
     }
     if (!sessionId || fetchedSessionRef.current === sessionId) return;
-    fetchedSessionRef.current = sessionId;
-    let cancelled = false;
-    void listTaskSessionMessages(sessionId, {
+    const session = sessionId;
+    fetchedSessionRef.current = session;
+    // Do NOT cancel this request in the effect cleanup: React StrictMode
+    // double-invokes effects in dev, so the first mount's cleanup would mark
+    // the in-flight request cancelled and the one-shot guard would skip the
+    // retry — the fetched message would never land. Instead guard the commit
+    // on the session still being the one we fetched for, which is safe under
+    // both a StrictMode remount and a real navigation.
+    void listTaskSessionMessages(session, {
       limit: 1,
       author_type: "user",
       sort: "desc",
     })
       .then((response) => {
-        if (!cancelled) setFetchedMessage(response.messages[0] ?? null);
+        if (fetchedSessionRef.current !== session) return;
+        setFetchedMessage(response.messages[0] ?? null);
       })
       .catch(() => {
-        if (!cancelled) setFetchedMessage(null);
+        if (fetchedSessionRef.current !== session) return;
+        setFetchedMessage(null);
       });
-    return () => {
-      cancelled = true;
-    };
   }, [sessionId, windowMessage]);
 
   return { lastPromptMessage: windowMessage ?? fetchedMessage };

--- a/apps/web/lib/api/domains/session-api.ts
+++ b/apps/web/lib/api/domains/session-api.ts
@@ -111,7 +111,13 @@ export async function markSessionRead(
 
 export async function listTaskSessionMessages(
   taskSessionId: string,
-  params?: { limit?: number; before?: string; after?: string; sort?: "asc" | "desc" },
+  params?: {
+    limit?: number;
+    before?: string;
+    after?: string;
+    sort?: "asc" | "desc";
+    author_type?: "user" | "agent";
+  },
   options?: ApiRequestOptions,
 ) {
   const query = new URLSearchParams();
@@ -119,6 +125,7 @@ export async function listTaskSessionMessages(
   if (params?.before) query.set("before", params.before);
   if (params?.after) query.set("after", params.after);
   if (params?.sort) query.set("sort", params.sort);
+  if (params?.author_type) query.set("author_type", params.author_type);
   const suffix = query.toString();
   const url = `/api/v1/task-sessions/${taskSessionId}/messages${suffix ? `?${suffix}` : ""}`;
   return fetchJson<ListMessagesResponse>(url, options);

--- a/docs/plans/last-prompt-lookup-beyond-window/plan.md
+++ b/docs/plans/last-prompt-lookup-beyond-window/plan.md
@@ -1,0 +1,68 @@
+---
+spec: docs/specs/last-prompt-pinning-regressions/spec.md
+created: 2026-07-31
+status: completed
+---
+
+# Implementation Plan: Last-prompt affordances when the prompt is beyond the loaded window
+
+## Overview
+
+Sessions whose last user prompt is older than the initially loaded transcript window never show the scroll-to-last-prompt control or the anchored last-prompt bar, even though the prompt is in the transcript above the loaded window. Replace the bounded background lookup with a single targeted query for the session's last user message, resolve the affordances from it, and drain older pages on demand when the user clicks.
+
+## Root cause
+
+`apps/web/components/task/task-chat-panel.tsx` derives `lastPromptMessageId` only from the loaded message window (`getLastUserMessageId(allMessages)`). When the newest ~100 messages contain no user message, a background lookup paginates older pages but caps at `MAX_LAST_PROMPT_LOOKUP_PAGES = 3` (3 × 20 = 60 messages past the initial fetch). A session whose last user prompt is older than ~160 messages — e.g. an autonomous session whose only user prompt is its task description — never resolves it, so `showScrollButton` is `false` and the anchored bar never renders. `useTranscriptEdgeTracking` reports `"visible"` when the target row is not mounted, keeping the controls suppressed.
+
+Smallest reliable reproduction: seed an autonomous session with 200 agent messages after its task-description user message, reload the task page, and assert the scroll-to-last-prompt button / anchored bar appear. Fails today (`apps/web/e2e/tests/chat/last-prompt-multi-tab.spec.ts`, "autonomous session …" test).
+
+## Approach
+
+Add an `author_type` filter to the existing paginated messages endpoint, fetch the last user message directly (one request) instead of draining pages, and treat a resolved-but-not-rendered last prompt as edge `"above"` so the affordances render immediately. Clicking jumps by draining older pages until the prompt is mounted, then scrolling — the same pattern scroll-to-start already uses.
+
+- Backend: `author_type` query filter on `GET /api/v1/task-sessions/:id/messages` (also the WS list path via the shared `service.ListMessagesPaginated`), threaded through `models.ListMessagesOptions`, `service.ListMessagesRequest`, and `buildListMessagesQuery`.
+- Frontend: `useLastUserMessage` hook that prefers the window-derived last user message (always freshest) and otherwise issues one filtered fetch `{ limit: 1, author_type: "user", sort: "desc" }`.
+- Edge resolution: while the last prompt is resolved but not mounted in the loaded window and `hasMore` is true, its position is deterministically above the viewport → effective edge `"above"`. Once mounted, the renderer's tracked edge takes over.
+- Click behavior: if the prompt is not mounted, set a pending state that drains older pages (`useDrainOlderMessages`) and scrolls once loaded; if mounted, scroll immediately.
+
+## Files
+
+### Backend (`apps/backend`)
+
+- `internal/task/models/models.go` — add `AuthorType string` to `ListMessagesOptions`.
+- `internal/task/repository/sqlite/message.go` — add `AND author_type = ?` to `buildListMessagesQuery` when set.
+- `internal/task/repository/interface.go` — unchanged (method signature stable).
+- `internal/task/service/service_requests.go` — add `AuthorType string` to `ListMessagesRequest`.
+- `internal/task/service/service_messages.go` — pass `AuthorType` through to `ListMessagesOptions`.
+- `internal/task/handlers/message_handlers.go` — parse and validate `author_type` (`user`/`agent`) in `listMessagesParams`, pass through.
+
+### Frontend (`apps/web`)
+
+- `lib/api/domains/session-api.ts` — add `author_type?: string` to `listTaskSessionMessages` params.
+- `hooks/domains/session/use-last-user-message.ts` (new) — window-derived first, else one filtered fetch; refetch per session; prefer window-derived once present. Unit test alongside.
+- `components/task/task-chat-panel.tsx` — replace `lastPromptMessageId`/`lastPromptMessage` memos and the bounded lookup effect with the hook; compute effective edge (`"above"` when resolved-but-not-mounted with `hasMore`); add pending-scroll drain for scroll-to-last-prompt.
+- `components/task/chat/message-list-shared.tsx` — add `resolveEffectiveLastPromptEdge` helper (pure); remove the now-dead `shouldLoadMoreForTranscriptTarget`.
+- `components/task/chat/message-list-shared.test.tsx` — cover `resolveEffectiveLastPromptEdge`; drop `shouldLoadMoreForTranscriptTarget` cases.
+- `components/task/chat/use-drain-older-messages.ts` — update the stale comment reference to the removed last-prompt preload effect.
+
+## Tests
+
+- **Backend filter:** repository test asserting `author_type=user` returns only user messages (newest-first), `author_type=agent` the reverse, empty = unfiltered; handler test asserting invalid `author_type` → 400 and valid pass-through. Files: `internal/task/repository/message_repository_test.go`, `internal/task/handlers/message_handlers_test.go` (or existing test files for these packages).
+- **Hook:** `apps/web/hooks/domains/session/use-last-user-message.test.ts` — window-derived wins when a user message is loaded; filtered fetch fires when none is; fetch result used as fallback; switching sessions refetches.
+- **Edge helper:** `apps/web/components/task/chat/message-list-shared.test.tsx` — `resolveEffectiveLastPromptEdge` truth table (mounted / not-mounted × hasMore).
+- **E2E (red before, green after):** `apps/web/e2e/tests/chat/last-prompt-multi-tab.spec.ts` "autonomous session …" test asserts the button + open anchored bar after reload of a session with 200 seeded agent messages; extend it to click the scroll button and assert the transcript lands at the task-description prompt.
+
+## Verification commands
+
+- `cd apps/backend && PATH=/tmp/go/bin:$PATH make test`
+- `cd apps/backend && PATH=/tmp/go/bin:$PATH make lint`
+- `cd apps/web && pnpm exec vitest run components/task/chat/message-list-shared.test.tsx hooks/domains/session/use-last-user-message.test.ts`
+- `cd apps/web && pnpm run typecheck`
+- `cd apps/web && pnpm run lint`
+- `cd apps/web && KANDEV_SERVER_HOST= pnpm e2e --project=chromium tests/chat/last-prompt-multi-tab.spec.ts`
+
+## Implementation waves
+
+1. [task-01-backend-author-type-filter](task-01-backend-author-type-filter.md) — sequential. Backend query filter + tests.
+2. [task-02-frontend-targeted-lookup](task-02-frontend-targeted-lookup.md) — sequential; depends on task 01 (needs the filter). Hook + edge helper + panel wiring + unit tests.
+3. [task-03-e2e-verification](task-03-e2e-verification.md) — sequential; depends on tasks 01–02. E2E red→green + full verification.

--- a/docs/plans/last-prompt-lookup-beyond-window/task-01-backend-author-type-filter.md
+++ b/docs/plans/last-prompt-lookup-beyond-window/task-01-backend-author-type-filter.md
@@ -1,0 +1,18 @@
+---
+id: "01-backend-author-type-filter"
+title: "Add author_type filter to the paginated messages query"
+status: done
+wave: 1
+depends_on: []
+plan: "plan.md"
+spec: "../../specs/last-prompt-pinning-regressions/spec.md"
+---
+
+# Task 01: Add `author_type` filter to the paginated messages query
+
+- **Acceptance:** `GET /api/v1/task-sessions/:id/messages?author_type=user` returns only user-authored messages (newest-first with `sort=desc`, still cursor-paginated); `author_type=agent` returns only agent-authored ones; omitting the param leaves current behavior unchanged. Invalid values are rejected with 400. The WS list path is unaffected (it never sets the filter).
+- **Verification:** First write the repository + handler tests and confirm the filter case fails (no filtering yet), then implement and re-run: `cd apps/backend && PATH=/tmp/go/bin:$PATH go test ./internal/task/repository/... ./internal/task/handlers/...` and the lint gate `PATH=/tmp/go/bin:$PATH make lint`.
+- **Files likely touched:** `apps/backend/internal/task/models/models.go`, `internal/task/repository/sqlite/message.go`, `internal/task/repository/message_repository_test.go`, `internal/task/service/service_requests.go`, `internal/task/service/service_messages.go`, `internal/task/handlers/message_handlers.go`, existing handler/repository test files.
+- **Dependencies:** None.
+- **Parallelism:** sequential — shared query contract with the frontend.
+- **Output contract:** Summary, exact files changed, targeted test result, remaining risks, and plan/task status update.

--- a/docs/plans/last-prompt-lookup-beyond-window/task-02-frontend-targeted-lookup.md
+++ b/docs/plans/last-prompt-lookup-beyond-window/task-02-frontend-targeted-lookup.md
@@ -1,0 +1,18 @@
+---
+id: "02-frontend-targeted-lookup"
+title: "Resolve the last prompt with a targeted fetch and wire the affordances"
+status: done
+wave: 2
+depends_on: ["01-backend-author-type-filter"]
+plan: "plan.md"
+spec: "../../specs/last-prompt-pinning-regressions/spec.md"
+---
+
+# Task 02: Resolve the last prompt with a targeted fetch and wire the affordances
+
+- **Acceptance:** The scroll-to-last-prompt control and anchored bar appear for a session whose last user prompt is older than the initially loaded window (task description only, 200 seeded agent messages), with no multi-page background drain. While the prompt is resolved but not mounted and `hasMore` is true, the effective edge is `"above"` (button points up, bar open); once the prompt is mounted, the renderer's tracked edge drives the controls. Clicking an unmounted prompt drains older pages then scrolls to it; clicking a mounted one scrolls immediately. The bounded `MAX_LAST_PROMPT_LOOKUP_PAGES` preload effect and the now-dead `shouldLoadMoreForTranscriptTarget` are removed.
+- **Verification:** Unit tests first (hook, edge helper), then wiring; run `cd apps/web && pnpm exec vitest run components/task/chat/message-list-shared.test.tsx hooks/domains/session/use-last-user-message.test.ts`, then `cd apps/web && pnpm run typecheck && pnpm run lint`.
+- **Files likely touched:** `apps/web/lib/api/domains/session-api.ts`, `hooks/domains/session/use-last-user-message.ts` (new) + test, `components/task/task-chat-panel.tsx`, `components/task/chat/message-list-shared.tsx` + test, `components/task/chat/use-drain-older-messages.ts` (comment).
+- **Dependencies:** Task 01 (backend filter must exist for the targeted fetch to work).
+- **Parallelism:** sequential — frontend consumes the new backend filter.
+- **Output contract:** Summary, exact files changed, targeted test result, remaining risks, and plan/task status update.

--- a/docs/plans/last-prompt-lookup-beyond-window/task-03-e2e-verification.md
+++ b/docs/plans/last-prompt-lookup-beyond-window/task-03-e2e-verification.md
@@ -1,0 +1,18 @@
+---
+id: "03-e2e-verification"
+title: "E2E red-to-green for the autonomous-session last-prompt affordances"
+status: done
+wave: 3
+depends_on: ["02-frontend-targeted-lookup"]
+plan: "plan.md"
+spec: "../../specs/last-prompt-pinning-regressions/spec.md"
+---
+
+# Task 03: E2E red-to-green for the autonomous-session last-prompt affordances
+
+- **Acceptance:** The `apps/web/e2e/tests/chat/last-prompt-multi-tab.spec.ts` "autonomous session with only its task description as a prompt still gets the last-prompt affordances" test (already failing on current code — this is the regression test) passes after tasks 01–02. It asserts, after reloading a task page for a session seeded with 200 agent messages after its task-description user message: the status-bar scroll-to-last-prompt button is visible and the anchored bar is open; clicking the button lands the transcript on the task-description prompt (older pages drained on demand). The full spec file still passes (multi-tab switching, hidden-created tab, manual-scroll preservation).
+- **Verification:** `cd apps/web && KANDEV_SERVER_HOST= pnpm e2e --project=chromium tests/chat/last-prompt-multi-tab.spec.ts` (green), then full validation `cd apps/backend && PATH=/tmp/go/bin:$PATH make test lint`, `cd apps/web && pnpm exec vitest run components/task/chat/message-list-shared.test.tsx hooks/domains/session/use-last-user-message.test.ts`, `cd apps/web && pnpm run typecheck && pnpm run lint`.
+- **Files likely touched:** `apps/web/e2e/tests/chat/last-prompt-multi-tab.spec.ts` (extend the autonomous test with a click-and-lands assertion).
+- **Dependencies:** Tasks 01–02.
+- **Parallelism:** sequential — end-to-end verification of the whole fix.
+- **Output contract:** Summary, exact files changed, targeted test result, remaining risks, and plan/task status update.

--- a/docs/specs/last-prompt-pinning-regressions/spec.md
+++ b/docs/specs/last-prompt-pinning-regressions/spec.md
@@ -19,6 +19,7 @@ The desktop anchored last-prompt bar currently appears once the prompt's top cro
 - The pinned prompt preserves the user message's Markdown formatting, including inline code, block code, lists, headings, and tables. Its compact and expanded layouts may constrain height, but do not render Markdown source as plain text.
 - On mobile, the pinned bar remains absent and the existing scroll-to-last-prompt action remains the discoverable, touch-accessible fallback.
 - **Scroll to last prompt** and **Scroll to start of transcript** reliably land on their target even if the agent streams new content into the transcript while the scroll animation is still in progress; a streamed message never silently snaps the transcript back to the bottom mid-scroll.
+- The **Scroll to last prompt** and anchored-bar affordances are available whenever the session has a last prompt *anywhere* in its transcript, including when that prompt is older than the initially loaded transcript window (e.g. an autonomous session whose only user prompt is its task description, with hundreds of agent/tool messages after it). Opening the transcript for such a session must show the scroll-to-last-prompt control (pointing up) and, since the viewport sits below the last prompt, the open anchored bar. Clicking either jumps to the prompt, paginating the transcript as needed.
 
 ## Regression scenarios
 
@@ -60,6 +61,13 @@ The desktop anchored last-prompt bar currently appears once the prompt's top cro
 **GIVEN** a user clicks **Scroll to start of transcript** or **Scroll to last prompt**
 **WHEN** the agent streams a new message into the transcript before the scroll animation settles
 **THEN** the transcript still lands at the requested target instead of being snapped back to the bottom.
+
+### Last prompt beyond the loaded window
+
+**GIVEN** a session whose last user prompt is older than the initially loaded transcript window (its newest messages are all agent/tool output)
+**WHEN** the transcript is opened
+**THEN** the scroll-to-last-prompt control is available (pointing up), the anchored bar is open (the viewport sits below the last prompt), and clicking either scrolls the transcript up to the prompt, loading older pages as needed.
+
 
 ## Constraints
 


### PR DESCRIPTION
Multi-agent sessions whose last user prompt sits older than the initially loaded transcript window (e.g. an autonomous agent that ran with only its task description as the prompt) never showed the scroll-to-last-prompt control or the anchored last-prompt bar, even though the prompt was in the transcript above the loaded window. The last prompt is now resolved with a single targeted query and the affordances render immediately, with click-to-jump paginating older messages on demand.

## Important Changes

- Backend: added an `author_type` query filter to the paginated messages endpoint (one WHERE clause; backward compatible, WS list path unaffected) so the last user message can be fetched directly instead of draining pages.
- Frontend: new `useLastUserMessage` hook prefers the window-derived last prompt and otherwise issues one filtered fetch `{limit:1, author_type:user, sort:desc}`; StrictMode-safe under the dev double-effect.
- Edge resolution: a resolved-but-unmounted prompt with older pages remaining is deterministically above the viewport, so the controls render (`"above"`) until the row mounts and the renderer's tracked edge takes over.
- Click behavior: an unmounted prompt drains older pages via the existing `useDrainOlderMessages` then scrolls — the same pattern scroll-to-start already uses; mounted prompts scroll immediately.
- Removed the bounded background preload (`MAX_LAST_PROMPT_LOOKUP_PAGES`) and the now-dead `shouldLoadMoreForTranscriptTarget`.

## Validation

- E2E regression (`apps/web/e2e/tests/chat/last-prompt-multi-tab.spec.ts`, 4 tests, chromium): multi-tab switching, hidden-created tab, manual-scroll preservation across switches, and the autonomous-session case (200 seeded agent messages, reload) asserting the button, open anchored bar, and click-lands-near-top — all pass.
- `cd apps/backend && PATH=/tmp/go/bin:$PATH make test` and `make lint` (0 issues); the only failures are pre-existing git/filesystem environment tests confirmed on the base branch.
- `cd apps/web && pnpm run typecheck` and `pnpm run lint` (clean).
- `pnpm exec vitest run components/task/chat/message-list-shared.test.tsx hooks/domains/session/use-last-user-message.test.tsx` — 55 tests pass, including new `resolveEffectiveLastPromptEdge` and StrictMode hook coverage.
- Manual verification in a side-by-side dev instance: opened a task whose autonomous session (~500 messages) has only `/bulk:250` as its user prompt; the anchored bar pins the prompt, the scroll button appears, and clicking lands on the prompt.

## Possible Improvements

- Low risk: the targeted lookup is one-shot per session; if the fetch fails the affordances stay hidden (manual "Load older messages" pagination still works). Clicking an unmounted prompt drains to the session start, bounded at the existing 50-batch cap.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.

---

Original task: "Multiple agent tabs: some tabs do not show/use the last-prompt scroll icon and the anchored last-prompt bar (pinning)."


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- kandev-screenshots-start -->
## Screenshots

Autonomous session whose only user prompt (the task description `/bulk:250`) sits hundreds of messages above the viewport. The fix resolves the far-away prompt, so the scroll-to-last-prompt button and the open anchored bar appear, and clicking jumps to it.

![Desktop: open anchored last-prompt bar pinning the task description](https://raw.githubusercontent.com/ClemDNL/kandev/01bd29e22c227bfd49d8d376c30038b433db6105/last-prompt-anchored-bar-desktop.png)

![Mobile: scroll-to-last-prompt button in the chat status bar](https://raw.githubusercontent.com/ClemDNL/kandev/01bd29e22c227bfd49d8d376c30038b433db6105/last-prompt-scroll-button-mobile.png)
<!-- kandev-screenshots-end -->
