### PR TITLE
fix: hide false session question indicator

### DIFF
--- a/apps/backend/internal/backendapp/boot_state.go
+++ b/apps/backend/internal/backendapp/boot_state.go
@@ -930,6 +930,14 @@ func (b bootStateBuilder) addTaskDetailSessionsState(
 	worktreesBySession := make(map[string]any)
 	sessionModelsByID := make(map[string]any)
 	sessionMCPStatusByID := make(map[string]any)
+	pendingActionsBySession, err := b.bootPendingActionsForInputCapableSessions(
+		ctx,
+		map[string][]*taskmodels.TaskSession{taskID: sessions},
+	)
+	if err != nil {
+		b.logBootError("get task detail session pending actions", err)
+		pendingActionsBySession = map[string]taskmodels.TaskPendingAction{}
+	}
 	for _, session := range sessions {
 		if session == nil {
 			continue
@@ -942,6 +950,7 @@ func (b bootStateBuilder) addTaskDetailSessionsState(
 		if b.p.orchestratorSvc != nil {
 			taskdto.EnrichForegroundActivity(&dto, b.p.orchestratorSvc)
 		}
+		dto.PendingAction = bootPendingActionPtr(&session.ID, pendingActionsBySession)
 		sessionItems[session.ID] = dto
 		sessionList = append(sessionList, dto)
 		if session.TaskEnvironmentID != "" {

--- a/apps/backend/internal/task/dto/dto.go
+++ b/apps/backend/internal/task/dto/dto.go
@@ -265,8 +265,11 @@ type TaskSessionDTO struct {
 	// background may remain present after the foreground turn settles.
 	// Not persisted — populated at the serialization boundary by
 	// EnrichForegroundActivity, never by FromTaskSession.
-	ForegroundActivity  v1.ForegroundActivity `json:"foreground_activity,omitempty"`
-	ActiveSubagentCount int                   `json:"active_subagent_count"`
+	ForegroundActivity v1.ForegroundActivity `json:"foreground_activity,omitempty"`
+	// PendingAction is the compact per-session projection used when the
+	// session transcript is not loaded in the client.
+	PendingAction       *string `json:"pending_action,omitempty"`
+	ActiveSubagentCount int     `json:"active_subagent_count"`
 	// LastReadMessageID is the session's Slack-style read cursor — the id of
 	// the newest message the frontend has marked as read. Used by the
 	// transcript to position the unread ("New") divider.
@@ -312,9 +315,12 @@ type TaskSessionSummaryDTO struct {
 	TaskEnvironmentID string                        `json:"task_environment_id,omitempty"`
 	// ForegroundActivity mirrors the in-memory fine-grained busy substate
 	// (ADR-0049); see TaskSessionDTO.
-	ForegroundActivity  v1.ForegroundActivity `json:"foreground_activity,omitempty"`
-	ActiveSubagentCount int                   `json:"active_subagent_count"`
-	LastReadMessageID   string                `json:"last_read_message_id,omitempty"`
+	ForegroundActivity v1.ForegroundActivity `json:"foreground_activity,omitempty"`
+	// PendingAction is the compact per-session projection used when the
+	// session transcript is not loaded in the client.
+	PendingAction       *string `json:"pending_action"`
+	ActiveSubagentCount int     `json:"active_subagent_count"`
+	LastReadMessageID   string  `json:"last_read_message_id,omitempty"`
 	// CommandCount is the number of tool_call messages on this session,
 	// surfaced inline in the timeline entry header ("ran N commands").
 	// Populated by ListTaskSessions; defaults to 0 for callers that don't

--- a/apps/backend/internal/task/handlers/task_http_handlers.go
+++ b/apps/backend/internal/task/handlers/task_http_handlers.go
@@ -369,6 +369,21 @@ func pendingActionPtr(
 	return &value
 }
 
+func (h *TaskHandlers) taskSessionDTO(ctx context.Context, session *models.TaskSession) dto.TaskSessionDTO {
+	result := dto.FromTaskSession(session)
+	if !isInputCapableSession(session) {
+		return result
+	}
+	actions, err := h.service.GetPendingActionsForSessions(ctx, []string{session.ID})
+	if err != nil {
+		h.logger.Warn("get task session pending action failed",
+			zap.String("session_id", session.ID), zap.Error(err))
+		return result
+	}
+	result.PendingAction = pendingActionPtr(&session.ID, actions)
+	return result
+}
+
 func (h *TaskHandlers) toTaskDTOsWithSessionInfo(ctx context.Context, tasks []*models.Task) ([]dto.TaskDTO, error) {
 	return buildTaskDTOsWithSessionInfo(ctx, h.service, h.logger, h.foregroundActivity, tasks)
 }
@@ -395,11 +410,21 @@ func (h *TaskHandlers) httpListTaskSessions(c *gin.Context) {
 		handleNotFound(c, h.logger, err, "task sessions not found")
 		return
 	}
+	pendingActionsBySession, pendingErr := pendingActionsForInputCapableSessions(
+		ctx,
+		h.service,
+		map[string][]*models.TaskSession{c.Param("id"): sessions},
+	)
+	if pendingErr != nil {
+		h.logger.Warn("get task session pending actions failed", zap.Error(pendingErr))
+		pendingActionsBySession = map[string]models.TaskPendingAction{}
+	}
 	sessionDTOs := make([]dto.TaskSessionSummaryDTO, 0, len(sessions))
 	ids := make([]string, 0, len(sessions))
 	for _, session := range sessions {
 		summary := dto.FromTaskSessionSummary(session)
 		dto.EnrichForegroundActivitySummary(&summary, h.foregroundActivity)
+		summary.PendingAction = pendingActionPtr(&session.ID, pendingActionsBySession)
 		sessionDTOs = append(sessionDTOs, summary)
 		ids = append(ids, session.ID)
 	}
@@ -442,7 +467,7 @@ func (h *TaskHandlers) httpGetTaskSession(c *gin.Context) {
 		handleNotFound(c, h.logger, err, "task session not found")
 		return
 	}
-	sessionDTO := dto.FromTaskSession(session)
+	sessionDTO := h.taskSessionDTO(c.Request.Context(), session)
 	dto.EnrichForegroundActivity(&sessionDTO, h.foregroundActivity)
 	c.JSON(http.StatusOK, dto.GetTaskSessionResponse{
 		Session: sessionDTO,
@@ -464,7 +489,7 @@ func (h *TaskHandlers) httpDismissLastAgentError(c *gin.Context) {
 		handleNotFound(c, h.logger, err, "task session not found")
 		return
 	}
-	sessionDTO := dto.FromTaskSession(session)
+	sessionDTO := h.taskSessionDTO(c.Request.Context(), session)
 	dto.EnrichForegroundActivity(&sessionDTO, h.foregroundActivity)
 	c.JSON(http.StatusOK, dto.GetTaskSessionResponse{
 		Session: sessionDTO,
@@ -550,7 +575,7 @@ func (h *TaskHandlers) httpApproveSession(c *gin.Context) {
 
 	resp := dto.ApproveSessionResponse{
 		Success: true,
-		Session: dto.FromTaskSession(result.Session),
+		Session: h.taskSessionDTO(c.Request.Context(), result.Session),
 	}
 	if result.WorkflowStep != nil {
 		resp.WorkflowStep = dto.FromWorkflowStep(result.WorkflowStep)

--- a/apps/backend/internal/task/handlers/task_ws_handlers.go
+++ b/apps/backend/internal/task/handlers/task_ws_handlers.go
@@ -35,10 +35,20 @@ func (h *TaskHandlers) doListTaskSessions(ctx context.Context, msg *ws.Message, 
 		h.logger.Error("failed to list task sessions", zap.Error(err))
 		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError, "Failed to list task sessions", nil)
 	}
+	pendingActionsBySession, pendingErr := pendingActionsForInputCapableSessions(
+		ctx,
+		h.service,
+		map[string][]*models.TaskSession{taskID: sessions},
+	)
+	if pendingErr != nil {
+		h.logger.Warn("get task session pending actions failed", zap.Error(pendingErr))
+		pendingActionsBySession = map[string]models.TaskPendingAction{}
+	}
 	sessionDTOs := make([]dto.TaskSessionSummaryDTO, 0, len(sessions))
 	for _, session := range sessions {
 		summary := dto.FromTaskSessionSummary(session)
 		dto.EnrichForegroundActivitySummary(&summary, h.foregroundActivity)
+		summary.PendingAction = pendingActionPtr(&session.ID, pendingActionsBySession)
 		sessionDTOs = append(sessionDTOs, summary)
 	}
 	resp := dto.ListTaskSessionSummariesResponse{

--- a/apps/web/components/task/session-reopen-menu.test.tsx
+++ b/apps/web/components/task/session-reopen-menu.test.tsx
@@ -38,6 +38,7 @@ describe("shouldShowReopenStateIcon", () => {
   it("surfaces explicit pending input while waiting", () => {
     expect(shouldShowReopenStateIcon("WAITING_FOR_INPUT", null, true, false)).toBe(true);
     expect(shouldShowReopenStateIcon("WAITING_FOR_INPUT", null, false, true)).toBe(true);
+    expect(shouldShowReopenStateIcon("WAITING_FOR_INPUT", "background")).toBe(true);
   });
 
   it("surfaces the icon for a pending prompt even mid-turn (still coarsely RUNNING)", () => {

--- a/apps/web/components/task/session-reopen-menu.test.tsx
+++ b/apps/web/components/task/session-reopen-menu.test.tsx
@@ -29,10 +29,15 @@ describe("shouldShowReopenStateIcon", () => {
     expect(shouldShowReopenStateIcon("STARTING", null, false, true)).toBe(false);
   });
 
-  it("now surfaces the waiting-for-input affordance", () => {
-    // Previously WAITING_FOR_INPUT was silent; it now shows the "needs me" icon
-    // so the reopen menu distinguishes waiting from done and running.
-    expect(shouldShowReopenStateIcon("WAITING_FOR_INPUT", null)).toBe(true);
+  it("keeps a plain waiting session icon-less when no input is pending", () => {
+    // WAITING_FOR_INPUT also means an ordinary turn finished and the session is
+    // ready for another prompt; it is not proof that the agent asked a question.
+    expect(shouldShowReopenStateIcon("WAITING_FOR_INPUT", null)).toBe(false);
+  });
+
+  it("surfaces explicit pending input while waiting", () => {
+    expect(shouldShowReopenStateIcon("WAITING_FOR_INPUT", null, true, false)).toBe(true);
+    expect(shouldShowReopenStateIcon("WAITING_FOR_INPUT", null, false, true)).toBe(true);
   });
 
   it("surfaces the icon for a pending prompt even mid-turn (still coarsely RUNNING)", () => {

--- a/apps/web/components/task/session-reopen-menu.tsx
+++ b/apps/web/components/task/session-reopen-menu.tsx
@@ -145,7 +145,7 @@ export function SessionReopenMenuItems({
 }
 
 // One reopen-menu row. Split into its own component so each row can read its
-// session's message-derived "needs me" flags
+// session's loaded-or-projected "needs me" flags
 // via the useSessionPendingInput hook without violating the rules of hooks
 // inside the sessions map.
 function SessionReopenMenuItem({

--- a/apps/web/components/task/session-reopen-menu.tsx
+++ b/apps/web/components/task/session-reopen-menu.tsx
@@ -26,8 +26,8 @@ type AgentInfo = { label: string; agentName: string };
  * An actionable pending prompt surfaces for RUNNING and WAITING_FOR_INPUT
  * sessions. Background-running also reads distinctly (the shared background
  * spinner), never as done. STARTING stays icon-less, and stale pending data
- * cannot override terminal lifecycle icons. A generating RUNNING session with
- * no pending prompt also stays silent.
+ * cannot override terminal lifecycle icons. A generating RUNNING session or a
+ * plain WAITING_FOR_INPUT session with no pending prompt stays silent.
  */
 export function shouldShowReopenStateIcon(
   state: TaskSessionState,
@@ -39,7 +39,7 @@ export function shouldShowReopenStateIcon(
   const canRequestInput = state === "RUNNING" || state === "WAITING_FOR_INPUT";
   if (canRequestInput && (hasPendingClarification || hasPendingPermission)) return true;
   if (canRequestInput && foregroundActivity === "background") return true;
-  if (state === "RUNNING") return false;
+  if (canRequestInput) return false;
   return true;
 }
 

--- a/apps/web/e2e/tests/session/multi-session-ux.spec.ts
+++ b/apps/web/e2e/tests/session/multi-session-ux.spec.ts
@@ -173,6 +173,61 @@ test.describe("Multi-session UX", () => {
     await expect(row.locator(".tabler-icon-shield-question")).toHaveCount(0);
   });
 
+  test("reload keeps a secondary pending prompt visible in the reopen menu", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    test.setTimeout(90_000);
+
+    const { task, session } = await createTaskAndNavigate(
+      testPage,
+      apiClient,
+      seedData,
+      "Secondary Pending Prompt Task",
+    );
+    const secondary = await apiClient.seedTaskSession(task.id, {
+      state: "WAITING_FOR_INPUT",
+      sessionId: `secondary-pending-${task.id}`,
+      startedAt: "2020-01-01T00:00:00Z",
+    });
+    await apiClient.seedSessionMessage(secondary.session_id, {
+      type: "clarification_request",
+      content: "Which database should the task use?",
+      metadata: { status: "pending" },
+    });
+
+    // The boot payload loads messages only for the active primary session. The
+    // secondary row must use its compact pending-action projection instead.
+    await testPage.reload();
+    await session.waitForLoad();
+    // The desktop layout eagerly hydrates opened panels; evict this secondary
+    // transcript to model the closed row that prompted the reload regression.
+    await testPage.evaluate((sessionId) => {
+      const store = (
+        window as Window & {
+          __KANDEV_E2E_STORE__?: {
+            getState: () => {
+              messages: { bySession: Record<string, unknown> };
+            };
+            setState: (next: unknown) => void;
+          };
+        }
+      ).__KANDEV_E2E_STORE__;
+      if (!store) return;
+      const state = store.getState();
+      const bySession = { ...state.messages.bySession };
+      delete bySession[sessionId];
+      store.setState({ messages: { ...state.messages, bySession } });
+    }, secondary.session_id);
+    await session.addPanelButton().click();
+
+    const row = session.sessionReopenItem(secondary.session_id);
+    await expect(row).toBeVisible({ timeout: 5_000 });
+    await expect(row.locator(".tabler-icon-message-question")).toHaveCount(1);
+    await expect(row.locator(".tabler-icon-shield-question")).toHaveCount(0);
+  });
+
   test("delete session via context menu shows confirmation", async ({
     testPage,
     apiClient,

--- a/apps/web/e2e/tests/session/multi-session-ux.spec.ts
+++ b/apps/web/e2e/tests/session/multi-session-ux.spec.ts
@@ -151,6 +151,28 @@ test.describe("Multi-session UX", () => {
     await expect(stateIcon).toBeVisible();
   });
 
+  test("idle waiting session has no question icon", async ({ testPage, apiClient, seedData }) => {
+    test.setTimeout(90_000);
+
+    const { task, session } = await createTaskAndNavigate(
+      testPage,
+      apiClient,
+      seedData,
+      "Idle Waiting Indicator Task",
+    );
+
+    const { sessions } = await apiClient.listTaskSessions(task.id);
+    expect(sessions).toHaveLength(1);
+    const idleSession = sessions[0];
+    expect(idleSession.state).toBe("WAITING_FOR_INPUT");
+
+    await session.addPanelButton().click();
+    const row = session.sessionReopenItem(idleSession.id);
+    await expect(row).toBeVisible({ timeout: 5_000 });
+    await expect(row.locator(".tabler-icon-message-question")).toHaveCount(0);
+    await expect(row.locator(".tabler-icon-shield-question")).toHaveCount(0);
+  });
+
   test("delete session via context menu shows confirmation", async ({
     testPage,
     apiClient,

--- a/apps/web/hooks/use-task-pending-input.test.tsx
+++ b/apps/web/hooks/use-task-pending-input.test.tsx
@@ -11,6 +11,7 @@ import {
 import { useSessionPendingInput, useTaskPendingInput } from "./use-task-pending-input";
 
 const PRIMARY_SESSION_ID = "session-primary";
+const SECONDARY_SESSION_ID = "session-secondary";
 
 function message(overrides: Partial<Message>): Message {
   return {
@@ -35,12 +36,19 @@ function session(id: string, state: TaskSession["state"]): TaskSession {
   };
 }
 
+function sessionWithPendingAction(id: string, action: "clarification" | "permission"): TaskSession {
+  return Object.assign(session(id, "WAITING_FOR_INPUT"), { pending_action: action });
+}
+
 function wrapper(messagesBySession: Record<string, Message[]> = {}, sessions: TaskSession[] = []) {
   return function Wrapper({ children }: { children: ReactNode }) {
     return (
       <StateProvider
         initialState={{
           messages: { bySession: messagesBySession, metaBySession: {} },
+          taskSessions: {
+            items: Object.fromEntries(sessions.map((item) => [item.id, item])),
+          },
           taskSessionsByTask: {
             itemsByTaskId: { "task-1": sessions },
             loadingByTaskId: {},
@@ -118,10 +126,10 @@ describe("useTaskPendingInput", () => {
         wrapper: wrapper(
           {
             [PRIMARY_SESSION_ID]: [],
-            "session-secondary": [
+            [SECONDARY_SESSION_ID]: [
               message({
                 id: "secondary-permission",
-                session_id: toSessionId("session-secondary"),
+                session_id: toSessionId(SECONDARY_SESSION_ID),
                 type: "permission_request",
                 metadata: { status: "pending" },
               }),
@@ -129,7 +137,7 @@ describe("useTaskPendingInput", () => {
           },
           [
             session(PRIMARY_SESSION_ID, "RUNNING"),
-            session("session-secondary", "WAITING_FOR_INPUT"),
+            session(SECONDARY_SESSION_ID, "WAITING_FOR_INPUT"),
           ],
         ),
       },
@@ -174,5 +182,21 @@ describe("useSessionPendingInput", () => {
       }),
     });
     expect(result.current).toEqual({ clarification: true, permission: false });
+  });
+
+  it("uses a per-session pending-action snapshot when messages are unloaded", () => {
+    const { result } = renderHook(() => useSessionPendingInput(SECONDARY_SESSION_ID), {
+      wrapper: wrapper({}, [sessionWithPendingAction(SECONDARY_SESSION_ID, "clarification")]),
+    });
+    expect(result.current).toEqual({ clarification: true, permission: false });
+  });
+
+  it("prefers loaded messages over a stale per-session pending-action snapshot", () => {
+    const { result } = renderHook(() => useSessionPendingInput(SECONDARY_SESSION_ID), {
+      wrapper: wrapper({ [SECONDARY_SESSION_ID]: [] }, [
+        sessionWithPendingAction(SECONDARY_SESSION_ID, "permission"),
+      ]),
+    });
+    expect(result.current).toEqual({ clarification: false, permission: false });
   });
 });

--- a/apps/web/hooks/use-task-pending-input.ts
+++ b/apps/web/hooks/use-task-pending-input.ts
@@ -123,14 +123,18 @@ function selectTaskPendingFlags(
   return selectFlagsFromPrimarySession(messagesBySession, primarySessionId, fallback);
 }
 
-/** Per-session pending-input flags; session menus already operate on loaded sessions. */
+/**
+ * Per-session pending-input flags. Loaded messages are authoritative; when a
+ * transcript is not hydrated, use the compact session projection from boot or
+ * the session list instead.
+ */
 export function useSessionPendingInput(sessionId: string | null | undefined): PendingInput {
-  const clarification = useAppStore((state) =>
-    hasPendingClarificationForSession(state.messages.bySession, sessionId),
-  );
-  const permission = useAppStore((state) =>
-    hasPendingPermissionForSession(state.messages.bySession, sessionId),
-  );
-  if (!sessionId) return NONE;
-  return { clarification, permission };
+  const flags = useAppStore((state) => {
+    if (!sessionId) return 0;
+    if (state.messages.bySession[sessionId] !== undefined) {
+      return toBitmask(loadedSessionFlags(state.messages.bySession, sessionId));
+    }
+    return toBitmask(actionFlags(state.taskSessions.items[sessionId]?.pending_action));
+  });
+  return { clarification: (flags & 1) !== 0, permission: (flags & 2) !== 0 };
 }

--- a/apps/web/hooks/use-task-pending-input.ts
+++ b/apps/web/hooks/use-task-pending-input.ts
@@ -134,7 +134,7 @@ export function useSessionPendingInput(sessionId: string | null | undefined): Pe
     if (state.messages.bySession[sessionId] !== undefined) {
       return toBitmask(loadedSessionFlags(state.messages.bySession, sessionId));
     }
-    return toBitmask(actionFlags(state.taskSessions.items[sessionId]?.pending_action));
+    return toBitmask(actionFlags(state.taskSessions?.items?.[sessionId]?.pending_action));
   });
   return { clarification: (flags & 1) !== 0, permission: (flags & 2) !== 0 };
 }

--- a/apps/web/lib/types/http.ts
+++ b/apps/web/lib/types/http.ts
@@ -424,6 +424,8 @@ export type TaskSession = ActiveSubagentCountFields & {
   state: TaskSessionState;
   /** Fine-grained busy substate; background may outlive the foreground turn (ADR-0049). */
   foreground_activity?: ForegroundActivity | null;
+  /** Compact pending-input projection used when this session's messages are unloaded. */
+  pending_action?: TaskPendingAction | null;
   error_message?: string;
   metadata?: Record<string, unknown> | null;
   agent_profile_snapshot?: Record<string, unknown> | null;

--- a/docs/plans/session-reopen-status-icon/plan.md
+++ b/docs/plans/session-reopen-status-icon/plan.md
@@ -1,0 +1,104 @@
+---
+spec: docs/specs/platform/background-work-liveness.md
+created: 2026-08-01
+status: draft
+---
+
+# Fix Plan: Session Reopen Status Icon
+
+## Overview
+
+The task add-panel menu currently treats every `WAITING_FOR_INPUT` session as
+an active clarification, even though that lifecycle state also means an
+ordinary turn has finished and the session is ready for another prompt. The fix
+will make the reopen-menu indicator depend on the existing message-derived
+pending-input flags while preserving background-running and terminal lifecycle
+icons. Production and permanent test changes wait for user approval.
+
+## Confirmed Root Cause
+
+`shouldShowReopenStateIcon` returns `true` for an input-capable
+`WAITING_FOR_INPUT` session after both pending-input checks are false. The row
+then calls `getSessionStateIcon`, whose lifecycle fallback maps
+`WAITING_FOR_INPUT` to `IconMessageQuestion`. The Dockview tab bar does not use
+that fallback and instead shows the agent logo when the session is not active,
+which creates the visible mismatch.
+
+The smallest reliable reproduction is a normal mock-agent turn that settles to
+`WAITING_FOR_INPUT` without a pending clarification or permission: opening the
+Dockview `+` menu shows a question icon on that session row.
+
+## Frontend
+
+### Reopen-menu status derivation
+
+- Update `apps/web/components/task/session-reopen-menu.tsx` so
+  `shouldShowReopenStateIcon` returns `false` for a plain
+  `WAITING_FOR_INPUT` session.
+- Continue returning `true` when an input-capable session has an explicit
+  pending clarification or permission, or when it carries background activity.
+- Preserve the current behavior for `STARTING`, generating `RUNNING`, and
+  terminal/created lifecycle states.
+- Do not change the shared `getSessionStateIcon` mapping; other status surfaces
+  and their labels are outside this repair.
+
+### Responsive and mobile contract
+
+This is a content/state-normalization change inside the existing Radix menu;
+it does not alter composition, navigation, scrolling, safe-area handling, or
+touch targets. The Dockview add-panel control is not part of the dedicated
+phone task layout. The nearest mobile semantic exemplar is
+`apps/web/components/task/mobile/mobile-sessions-section.tsx`, which already
+uses explicit pending-input flags to distinguish real clarification and
+permission variants. No mobile-specific presentation change is planned; the
+pure helper regression matrix is viewport-independent.
+
+## Tests
+
+- **What:** a plain `WAITING_FOR_INPUT` session does not request a reopen-menu
+  state icon, while explicit clarification/permission and background activity
+  still do.
+- **File:** `apps/web/components/task/session-reopen-menu.test.tsx`.
+- **How:** update the existing Vitest helper matrix. First change the plain
+  waiting assertion to the desired `false` result and run it against current
+  production code to prove RED; then implement the minimal helper change and
+  rerun for GREEN.
+
+## E2E Tests
+
+- **Scenario:** **GIVEN** a mock-agent session has completed an ordinary turn
+  and the backend reports `WAITING_FOR_INPUT` with no pending clarification or
+  permission, **WHEN** the user opens the Dockview add-panel menu, **THEN** its
+  row contains neither a message-question icon nor a shield-question icon.
+- **File:** `apps/web/e2e/tests/session/multi-session-ux.spec.ts`.
+- **What to verify:** poll the backend precondition to exactly
+  `WAITING_FOR_INPUT`, open the existing `dockview-add-panel-btn`, scope the
+  assertion to `reopen-session-<session-id>`, and assert the two misleading
+  glyphs are absent. Run this E2E before the production edit to confirm RED and
+  after the edit to confirm GREEN.
+- **Mobile coverage:** no separate mobile Playwright scenario is added because
+  the Dockview add-panel menu is absent from the phone composition and this
+  repair changes only viewport-independent state normalization. Existing
+  mobile session-picker tests continue proving that actual pending
+  clarifications and permissions retain their distinct icons.
+
+## Implementation Task
+
+- [ ] [Task 01: Correct the reopen-menu input indicator](task-01-correct-reopen-input-indicator.md)
+
+Execution is sequential in the primary conversation. This single task is not a
+parallel candidate and does not authorize subagent use.
+
+## Environment Prerequisite
+
+This worktree currently lacks `apps/node_modules`. Before the RED run, execute
+`pnpm install --frozen-lockfile` from `apps/`; the lockfile must remain
+unchanged.
+
+## Risks and Boundaries
+
+- The helper must not suppress background-running or terminal-state icons.
+- The E2E must prove the exact backend state so a terminal `COMPLETED` session
+  cannot make the regression assertion pass accidentally.
+- Shared lifecycle icon mappings, session labels, tab-bar presentation, and
+  mobile session-picker presentation remain out of scope.

--- a/docs/plans/session-reopen-status-icon/plan.md
+++ b/docs/plans/session-reopen-status-icon/plan.md
@@ -1,7 +1,7 @@
 ---
 spec: docs/specs/platform/background-work-liveness.md
 created: 2026-08-01
-status: draft
+status: completed
 ---
 
 # Fix Plan: Session Reopen Status Icon
@@ -84,7 +84,7 @@ pure helper regression matrix is viewport-independent.
 
 ## Implementation Task
 
-- [ ] [Task 01: Correct the reopen-menu input indicator](task-01-correct-reopen-input-indicator.md)
+- [x] [Task 01: Correct the reopen-menu input indicator](task-01-correct-reopen-input-indicator.md)
 
 Execution is sequential in the primary conversation. This single task is not a
 parallel candidate and does not authorize subagent use.

--- a/docs/plans/session-reopen-status-icon/plan.md
+++ b/docs/plans/session-reopen-status-icon/plan.md
@@ -11,9 +11,8 @@ status: completed
 The task add-panel menu currently treats every `WAITING_FOR_INPUT` session as
 an active clarification, even though that lifecycle state also means an
 ordinary turn has finished and the session is ready for another prompt. The fix
-will make the reopen-menu indicator depend on the existing message-derived
-pending-input flags while preserving background-running and terminal lifecycle
-icons. Production and permanent test changes wait for user approval.
+makes the reopen-menu indicator depend on explicit per-session pending-input
+projections while preserving background-running and terminal lifecycle icons.
 
 ## Confirmed Root Cause
 
@@ -37,6 +36,9 @@ Dockview `+` menu shows a question icon on that session row.
   `WAITING_FOR_INPUT` session.
 - Continue returning `true` when an input-capable session has an explicit
   pending clarification or permission, or when it carries background activity.
+- Carry the pending action as a per-session boot/list projection so a closed
+  session row can retain the actionable icon even when its transcript is not
+  hydrated; loaded messages remain authoritative when available.
 - Preserve the current behavior for `STARTING`, generating `RUNNING`, and
   terminal/created lifecycle states.
 - Do not change the shared `getSessionStateIcon` mapping; other status surfaces
@@ -66,16 +68,17 @@ pure helper regression matrix is viewport-independent.
 
 ## E2E Tests
 
-- **Scenario:** **GIVEN** a mock-agent session has completed an ordinary turn
-  and the backend reports `WAITING_FOR_INPUT` with no pending clarification or
-  permission, **WHEN** the user opens the Dockview add-panel menu, **THEN** its
-  row contains neither a message-question icon nor a shield-question icon.
+- **Scenario:** **GIVEN** a task has a secondary `WAITING_FOR_INPUT` session
+  with a pending clarification, **WHEN** the user reloads the task and the
+  secondary transcript is not loaded before opening the Dockview add-panel
+  menu, **THEN** its row still contains the message-question icon (and not the
+  shield-question icon); the ordinary idle-session scenario remains icon-free.
 - **File:** `apps/web/e2e/tests/session/multi-session-ux.spec.ts`.
-- **What to verify:** poll the backend precondition to exactly
-  `WAITING_FOR_INPUT`, open the existing `dockview-add-panel-btn`, scope the
-  assertion to `reopen-session-<session-id>`, and assert the two misleading
-  glyphs are absent. Run this E2E before the production edit to confirm RED and
-  after the edit to confirm GREEN.
+- **What to verify:** seed the secondary pending message, reload the task,
+  evict that session's transcript to model an unloaded row, open the existing
+  `dockview-add-panel-btn`, scope the assertion to
+  `reopen-session-<session-id>`, and assert the projected icon variant. Keep
+  the existing idle-waiting check for the absence of both misleading glyphs.
 - **Mobile coverage:** no separate mobile Playwright scenario is added because
   the Dockview add-panel menu is absent from the phone composition and this
   repair changes only viewport-independent state normalization. Existing

--- a/docs/plans/session-reopen-status-icon/task-01-correct-reopen-input-indicator.md
+++ b/docs/plans/session-reopen-status-icon/task-01-correct-reopen-input-indicator.md
@@ -1,0 +1,75 @@
+---
+id: "01-correct-reopen-input-indicator"
+title: "Correct the reopen-menu input indicator"
+status: pending
+wave: 1
+depends_on: []
+plan: "plan.md"
+spec: "../../specs/platform/background-work-liveness.md"
+---
+
+# Task 01: Correct the Reopen-Menu Input Indicator
+
+## Acceptance
+
+- A `WAITING_FOR_INPUT` session with no pending clarification, permission, or
+  background activity renders no state icon in the task add-panel menu.
+- An input-capable session with a pending clarification or permission still
+  renders the corresponding question or shield-question icon, and background
+  plus terminal lifecycle icons remain unchanged.
+- A focused browser regression proves the exact idle-waiting backend
+  precondition and the absence of both misleading question glyphs in the
+  session row.
+
+## TDD Sequence
+
+1. Update the pure-helper assertion and add the focused Playwright regression.
+2. Run both focused checks against unchanged production code and record the
+   expected failures.
+3. Make the minimal `shouldShowReopenStateIcon` change.
+4. Rerun both focused checks and record the passing results.
+
+## Verification
+
+From a worktree with dependencies installed:
+
+```bash
+cd apps && pnpm --filter @kandev/web exec vitest run components/task/session-reopen-menu.test.tsx
+cd apps/web && pnpm e2e:run tests/session/multi-session-ux.spec.ts -- --grep "idle waiting session has no question icon"
+```
+
+## Files Likely Touched
+
+- `apps/web/components/task/session-reopen-menu.tsx`
+- `apps/web/components/task/session-reopen-menu.test.tsx`
+- `apps/web/e2e/tests/session/multi-session-ux.spec.ts`
+
+## Dependencies
+
+None.
+
+## Parallelism
+
+`sequential`. The unit regression, browser regression, and production helper
+must share one RED-GREEN cycle.
+
+## Inputs
+
+- `docs/specs/platform/background-work-liveness.md`, especially the status
+  semantics and new add-panel scenarios.
+- `docs/specs/platform/notifications.md`, which establishes that generic
+  `WAITING_FOR_INPUT` is not an explicit request for an answer.
+- `apps/web/hooks/use-task-pending-input.ts` for the authoritative
+  message-derived pending clarification and permission flags.
+- `apps/web/components/task/session-reopen-menu.tsx` and its existing helper
+  tests as the implementation pattern.
+- `apps/web/e2e/pages/session-page.ts` and
+  `apps/web/e2e/tests/session/multi-session-ux.spec.ts` for existing add-panel
+  locators and mock-agent setup.
+
+## Output Contract
+
+Report the RED and GREEN results, files changed, any blocker or residual risk,
+and update this task to `done` plus the matching checkbox and plan status in
+`plan.md`. Do not modify shared session icon mappings or adjacent status
+surfaces.

--- a/docs/plans/session-reopen-status-icon/task-01-correct-reopen-input-indicator.md
+++ b/docs/plans/session-reopen-status-icon/task-01-correct-reopen-input-indicator.md
@@ -20,6 +20,8 @@ spec: "../../specs/platform/background-work-liveness.md"
 - A focused browser regression proves the exact idle-waiting backend
   precondition and the absence of both misleading question glyphs in the
   session row.
+- A reload regression preserves a real pending clarification on a secondary
+  session row when that session's messages are not loaded.
 
 ## TDD Sequence
 
@@ -27,7 +29,9 @@ spec: "../../specs/platform/background-work-liveness.md"
 2. Run both focused checks against unchanged production code and record the
    expected failures.
 3. Make the minimal `shouldShowReopenStateIcon` change.
-4. Rerun both focused checks and record the passing results.
+4. Add the per-session pending-action projection and message-aware fallback.
+5. Rerun the focused checks and the reload regression and record the passing
+   results.
 
 ## Verification
 
@@ -42,7 +46,13 @@ cd apps/web && pnpm e2e:run tests/session/multi-session-ux.spec.ts -- --grep "id
 
 - `apps/web/components/task/session-reopen-menu.tsx`
 - `apps/web/components/task/session-reopen-menu.test.tsx`
+- `apps/web/hooks/use-task-pending-input.ts`
+- `apps/web/hooks/use-task-pending-input.test.tsx`
 - `apps/web/e2e/tests/session/multi-session-ux.spec.ts`
+- `apps/backend/internal/backendapp/boot_state.go`
+- `apps/backend/internal/task/dto/dto.go`
+- `apps/backend/internal/task/handlers/task_http_handlers.go`
+- `apps/backend/internal/task/handlers/task_ws_handlers.go`
 
 ## Dependencies
 
@@ -83,11 +93,27 @@ GREEN results:
   session has no question icon"` — 1 Chromium test passed against the managed
   production build.
 
+Remediation results:
+
+- Frontend unit tests: 20 tests passed across the pending-input hook and
+  reopen-menu helper suites.
+- Backend package tests: `go test ./internal/backendapp ./internal/task/dto
+  ./internal/task/handlers` passed.
+- Reload E2E: the secondary pending clarification row retained the projected
+  message-question icon after its transcript was evicted; the idle waiting
+  regression remained icon-free.
+
 Files changed:
 
 - `apps/web/components/task/session-reopen-menu.tsx`
 - `apps/web/components/task/session-reopen-menu.test.tsx`
 - `apps/web/e2e/tests/session/multi-session-ux.spec.ts`
+- `apps/web/hooks/use-task-pending-input.ts`
+- `apps/web/hooks/use-task-pending-input.test.tsx`
+- `apps/backend/internal/backendapp/boot_state.go`
+- `apps/backend/internal/task/dto/dto.go`
+- `apps/backend/internal/task/handlers/task_http_handlers.go`
+- `apps/backend/internal/task/handlers/task_ws_handlers.go`
 - This task and its plan status.
 
 No blockers or residual risks remain within scope. Shared session icon mappings

--- a/docs/plans/session-reopen-status-icon/task-01-correct-reopen-input-indicator.md
+++ b/docs/plans/session-reopen-status-icon/task-01-correct-reopen-input-indicator.md
@@ -1,7 +1,7 @@
 ---
 id: "01-correct-reopen-input-indicator"
 title: "Correct the reopen-menu input indicator"
-status: pending
+status: done
 wave: 1
 depends_on: []
 plan: "plan.md"
@@ -69,7 +69,26 @@ must share one RED-GREEN cycle.
 
 ## Output Contract
 
-Report the RED and GREEN results, files changed, any blocker or residual risk,
-and update this task to `done` plus the matching checkbox and plan status in
-`plan.md`. Do not modify shared session icon mappings or adjacent status
-surfaces.
+RED results:
+
+- Unit: failed as expected because plain `WAITING_FOR_INPUT` returned `true`.
+- E2E: failed as expected because the reopen row contained one
+  `tabler-icon-message-question` glyph.
+
+GREEN results:
+
+- `pnpm --filter @kandev/web exec vitest run
+  components/task/session-reopen-menu.test.tsx` — 9 tests passed.
+- `pnpm e2e:run tests/session/multi-session-ux.spec.ts -- --grep "idle waiting
+  session has no question icon"` — 1 Chromium test passed against the managed
+  production build.
+
+Files changed:
+
+- `apps/web/components/task/session-reopen-menu.tsx`
+- `apps/web/components/task/session-reopen-menu.test.tsx`
+- `apps/web/e2e/tests/session/multi-session-ux.spec.ts`
+- This task and its plan status.
+
+No blockers or residual risks remain within scope. Shared session icon mappings
+and adjacent status surfaces were not modified.

--- a/docs/specs/platform/background-work-liveness.md
+++ b/docs/specs/platform/background-work-liveness.md
@@ -1,7 +1,7 @@
 ---
 status: shipped
 created: 2026-07-21
-updated: 2026-07-28
+updated: 2026-08-01
 owner: kandev
 ---
 
@@ -24,6 +24,10 @@ lifecycle unless a deployment deliberately enables the Claude-only experiment.
   does not select a separate operator-visible activity tier by default.
 - A settled session follows its coarse state and does not remain visually busy
   solely because detached work is still registered.
+- Session status surfaces do not infer that an agent needs an answer from the
+  coarse `WAITING_FOR_INPUT` state alone. A clarification question or permission
+  indicator requires the corresponding pending input record; an idle session
+  that is merely ready for another prompt does not show either indicator.
 - The runtime retains one registration per recognized live subagent and derives
   `active_subagent_count` from those registrations. Background shells and
   Monitor watches may remain internally tracked but do not contribute to the
@@ -113,6 +117,13 @@ truth for prompt admission and operator-visible activity.
 - **GIVEN** the session leaves `RUNNING`, **WHEN** its DTO or task aggregate is
   serialized, **THEN** foreground activity is omitted even if detached work
   remains registered.
+- **GIVEN** a session is `WAITING_FOR_INPUT` with no pending clarification or
+  permission, **WHEN** the user opens the task add-panel menu, **THEN** the
+  session row shows neither the clarification-question icon nor the
+  permission-question icon.
+- **GIVEN** an input-capable session has a pending clarification or permission,
+  **WHEN** the user opens the task add-panel menu, **THEN** its session row shows
+  the corresponding question or shield-question indicator.
 - **GIVEN** an execution terminates with orphaned tool ownership and background
   work, **WHEN** teardown runs, **THEN** its owned accounting state is released.
 
@@ -121,6 +132,8 @@ truth for prompt admission and operator-visible activity.
 - Mid-turn steering for agents without concurrent-prompt capability.
 - Reconstructing detached-work liveness after restart.
 - Rendering active subagent counts or individual subagent details in the UI.
+- Renaming the generic `WAITING_FOR_INPUT` lifecycle state or redesigning status
+  labels and icons outside the task add-panel menu.
 
 ## Decision record
 


### PR DESCRIPTION
Idle sessions that have reached `WAITING_FOR_INPUT` without a pending clarification or permission were incorrectly shown with a question icon in the desktop add-panel menu. The reopen-menu predicate now requires explicit pending input or background activity, while preserving genuine prompts and other session-state indicators.

## Validation

- `pnpm --filter @kandev/web exec vitest run components/task/session-reopen-menu.test.tsx` — 9 passed.
- `pnpm e2e:run tests/session/multi-session-ux.spec.ts -- --grep "idle waiting session has no question icon"` — 1 Chromium test passed against the managed production build.
- Fresh desktop and mobile Playwright captures passed with synthetic tasks; PNG assets were compressed and validated through `apps/web/.pr-assets/manifest.json`.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2132?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- kandev-screenshots-start -->
## Screenshots

![Desktop add-panel menu without a false question icon](https://raw.githubusercontent.com/kdlbs/kandev/0c5303cede6e5e96f8dc55cae74092cd1f097e8f/pr-session-reopen-screenshot--desktop-idle-session-menu.png)

![Mobile task composition](https://raw.githubusercontent.com/kdlbs/kandev/0c5303cede6e5e96f8dc55cae74092cd1f097e8f/mobile-pr-session-reopen-screenshot--mobile-session-composition.png)
<!-- kandev-screenshots-end -->