### PR TITLE
fix(agentctl): abandon instance creation when the caller has gone

### DIFF
--- a/apps/backend/internal/agentctl/server/instance/manager.go
+++ b/apps/backend/internal/agentctl/server/instance/manager.go
@@ -26,6 +26,11 @@ type ServerFactory func(cfg *config.InstanceConfig, procMgr *process.Manager, lo
 
 const instanceHTTPShutdownGrace = 250 * time.Millisecond
 
+// ErrManagerShuttingDown is returned by CreateInstance once Shutdown has begun.
+// Callers get a clear refusal instead of an instance that the shutdown sequence
+// has already walked past and will never stop.
+var ErrManagerShuttingDown = errors.New("instance manager is shutting down")
+
 // Manager manages multiple agent instances.
 // It handles creation, tracking, and removal of agent instances,
 // each with their own HTTP server on a dedicated port.
@@ -50,7 +55,22 @@ type Manager struct {
 	// caller vanishes mid-creation. They run off the creation mutex so a slow
 	// tracker stop cannot block the queue; Shutdown drains them so a process
 	// exit does not leave half-torn-down trackers behind.
-	abandonWG sync.WaitGroup
+	//
+	// shuttingDown, guarded by mu, closes the window where Shutdown could
+	// observe the counter at zero and a CreateInstance already past its own
+	// checks could then Add(1) behind it. Setting the flag under the same mutex
+	// CreateInstance holds means every creation either completes before the
+	// flag is set — so its Add is visible to the Wait below — or sees the flag
+	// and refuses.
+	abandonWG    sync.WaitGroup
+	shuttingDown bool
+
+	// afterTrackerStart runs immediately after StartAllWorkspaceTrackers and is
+	// nil in production. It exists so a test can cancel the caller's context at
+	// exactly that point and assert the abandonment branch ran, rather than
+	// racing cancellation against tracker startup and accepting whichever
+	// outcome it happens to get.
+	afterTrackerStart func()
 }
 
 // NewManager creates a new instance manager.
@@ -87,6 +107,12 @@ func (m *Manager) SetServerFactory(factory ServerFactory) {
 func (m *Manager) CreateInstance(ctx context.Context, req *CreateRequest) (*CreateResponse, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+
+	// Refuse once Shutdown has begun, so no creation can register an
+	// abandonment teardown after Shutdown drained the wait group.
+	if m.shuttingDown {
+		return nil, ErrManagerShuttingDown
+	}
 
 	// The caller may already be gone. Creation is serialised on m.mu, the
 	// control client gives up after 30s, and callers that give up retry — so
@@ -169,6 +195,9 @@ func (m *Manager) CreateInstance(ctx context.Context, req *CreateRequest) (*Crea
 
 	// Start root + per-repo trackers so file-change events fire even in passthrough mode.
 	procMgr.StartAllWorkspaceTrackers(context.Background())
+	if m.afterTrackerStart != nil {
+		m.afterTrackerStart()
+	}
 
 	// Starting the trackers is the slow part of creation, so re-check: a caller
 	// that was still waiting when we took the lock can time out during it.
@@ -238,6 +267,14 @@ func (m *Manager) abandonPartialInstance(id string, port int, listener net.Liste
 	ctx, cancel := context.WithTimeout(context.Background(), abandonPartialInstanceTimeout)
 	defer cancel()
 
+	// Give the port back first. Nothing was ever published on this listener, and
+	// stopping the trackers below can take seconds — holding the port for that
+	// long shrinks the pool exactly when creations are already piling up.
+	if listener != nil {
+		_ = listener.Close()
+	}
+	m.portAlloc.Release(port)
+
 	if procMgr != nil {
 		procMgr.CloseAdmission()
 		if err := procMgr.StopForTeardown(ctx); err != nil {
@@ -246,10 +283,6 @@ func (m *Manager) abandonPartialInstance(id string, port int, listener net.Liste
 				zap.Error(err))
 		}
 	}
-	if listener != nil {
-		_ = listener.Close()
-	}
-	m.portAlloc.Release(port)
 
 	m.logger.Warn("abandoned partially created instance",
 		zap.String("instance_id", id),
@@ -512,6 +545,12 @@ func (m *Manager) Shutdown(ctx context.Context) error {
 	// Stop the idle reaper first so it doesn't fire StopInstance concurrently
 	// with our explicit per-instance shutdown loop.
 	m.stopReaperOnce()
+
+	// Refuse new creations before draining, so nothing can register another
+	// teardown goroutine behind the Wait below.
+	m.mu.Lock()
+	m.shuttingDown = true
+	m.mu.Unlock()
 
 	// Drain any in-flight abandonment teardowns. They own trackers and a port
 	// that are no longer reachable through m.instances, so nothing below would

--- a/apps/backend/internal/agentctl/server/instance/manager.go
+++ b/apps/backend/internal/agentctl/server/instance/manager.go
@@ -81,6 +81,26 @@ func (m *Manager) SetServerFactory(factory ServerFactory) {
 func (m *Manager) CreateInstance(ctx context.Context, req *CreateRequest) (*CreateResponse, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+
+	// The caller may already be gone. Creation is serialised on m.mu, the
+	// control client gives up after 30s, and callers that give up retry — so
+	// under load this lock grows a queue of requests nobody is waiting for any
+	// more. Building an instance for one of those leaks it: no caller holds its
+	// ID, so nothing ever stops it, and it keeps a port, an HTTP server and a
+	// full set of workspace trackers polling git. That extra polling is what
+	// makes the next creation slower, which lengthens the queue, which leaks
+	// more instances.
+	//
+	// Seen in the field as create latency climbing 6ms -> 5.5s -> 34s -> 192s
+	// with 16 live instances and zero deletions, by which point plain
+	// `git ls-files` was hitting its 10s timeout and session resume failed.
+	if err := ctx.Err(); err != nil {
+		m.logger.Warn("create instance abandoned while queued; caller had already given up",
+			zap.String("workspace_path", req.WorkspacePath),
+			zap.Error(err))
+		return nil, fmt.Errorf("create instance abandoned while queued: %w", err)
+	}
+
 	agentEnv, err := config.CollectAgentEnvWithError(req.Env)
 	if err != nil {
 		return nil, fmt.Errorf("prepare agent environment: %w", err)
@@ -144,6 +164,15 @@ func (m *Manager) CreateInstance(ctx context.Context, req *CreateRequest) (*Crea
 	// Start root + per-repo trackers so file-change events fire even in passthrough mode.
 	procMgr.StartAllWorkspaceTrackers(context.Background())
 
+	// Starting the trackers is the slow part of creation, so re-check: a caller
+	// that was still waiting when we took the lock can time out during it.
+	// Everything built so far has to be undone by hand — StopInstance takes the
+	// same mutex we are holding, and the instance is not registered yet anyway.
+	if err := ctx.Err(); err != nil {
+		m.abandonPartialInstance(id, port, listener, procMgr)
+		return nil, fmt.Errorf("create instance abandoned during startup: %w", err)
+	}
+
 	// Create instance up-front so the activity middleware can reference it.
 	inst := &Instance{
 		ID:            id,
@@ -171,6 +200,40 @@ func (m *Manager) CreateInstance(ctx context.Context, req *CreateRequest) (*Crea
 		ID:   id,
 		Port: port,
 	}, nil
+}
+
+// abandonPartialInstanceTimeout bounds the teardown of an instance whose caller
+// vanished mid-creation. It is deliberately short: m.mu is held throughout, so
+// every other creation waits on it, and the queue that produced the abandoned
+// request in the first place is exactly what must not grow further.
+const abandonPartialInstanceTimeout = 5 * time.Second
+
+// abandonPartialInstance unwinds the pieces CreateInstance built before it
+// noticed the caller had gone: the tracker goroutines, the bound listener and
+// the allocated port. It must be called with m.mu held and must not route
+// through StopInstance, which takes that same lock — and the instance was never
+// registered in m.instances, so there is nothing there to remove.
+func (m *Manager) abandonPartialInstance(id string, port int, listener net.Listener, procMgr *process.Manager) {
+	// The request context is already cancelled, so teardown needs its own.
+	ctx, cancel := context.WithTimeout(context.Background(), abandonPartialInstanceTimeout)
+	defer cancel()
+
+	if procMgr != nil {
+		procMgr.CloseAdmission()
+		if err := procMgr.StopForTeardown(ctx); err != nil {
+			m.logger.Warn("error stopping process manager for abandoned instance",
+				zap.String("instance_id", id),
+				zap.Error(err))
+		}
+	}
+	if listener != nil {
+		_ = listener.Close()
+	}
+	m.portAlloc.Release(port)
+
+	m.logger.Warn("abandoned partially created instance",
+		zap.String("instance_id", id),
+		zap.Int("port", port))
 }
 
 // allocatePortAndListener allocates a free port and binds a TCP listener to it.

--- a/apps/backend/internal/agentctl/server/instance/manager.go
+++ b/apps/backend/internal/agentctl/server/instance/manager.go
@@ -45,6 +45,12 @@ type Manager struct {
 	reaperStop     chan struct{}
 	reaperStopOnce sync.Once
 	reaperWG       sync.WaitGroup
+
+	// abandonWG tracks the teardown goroutines CreateInstance spawns when a
+	// caller vanishes mid-creation. They run off the creation mutex so a slow
+	// tracker stop cannot block the queue; Shutdown drains them so a process
+	// exit does not leave half-torn-down trackers behind.
+	abandonWG sync.WaitGroup
 }
 
 // NewManager creates a new instance manager.
@@ -166,10 +172,22 @@ func (m *Manager) CreateInstance(ctx context.Context, req *CreateRequest) (*Crea
 
 	// Starting the trackers is the slow part of creation, so re-check: a caller
 	// that was still waiting when we took the lock can time out during it.
-	// Everything built so far has to be undone by hand — StopInstance takes the
-	// same mutex we are holding, and the instance is not registered yet anyway.
 	if err := ctx.Err(); err != nil {
-		m.abandonPartialInstance(id, port, listener, procMgr)
+		// Teardown runs off this goroutine because it must not happen under
+		// m.mu. stopWorkspaceTrackers stops trackers one at a time, and
+		// WorkspaceTracker.Stop takes no context — it waits on its own
+		// stopTimeout timer — so a workspace with a dozen repositories could
+		// pin the creation mutex for the better part of a minute, lengthening
+		// the very queue this abandonment exists to drain.
+		//
+		// Nothing can observe the instance meanwhile: it was never added to
+		// m.instances, and PortAllocator carries its own mutex. The wait group
+		// lets Shutdown drain these before it returns.
+		m.abandonWG.Add(1)
+		go func() {
+			defer m.abandonWG.Done()
+			m.abandonPartialInstance(id, port, listener, procMgr)
+		}()
 		return nil, fmt.Errorf("create instance abandoned during startup: %w", err)
 	}
 
@@ -202,17 +220,19 @@ func (m *Manager) CreateInstance(ctx context.Context, req *CreateRequest) (*Crea
 	}, nil
 }
 
-// abandonPartialInstanceTimeout bounds the teardown of an instance whose caller
-// vanished mid-creation. It is deliberately short: m.mu is held throughout, so
-// every other creation waits on it, and the queue that produced the abandoned
-// request in the first place is exactly what must not grow further.
+// abandonPartialInstanceTimeout bounds the admission wait inside
+// StopForTeardown for an instance whose caller vanished mid-creation. It does
+// not bound the tracker stops themselves — WorkspaceTracker.Stop honours no
+// context and falls back to its own stopTimeout — which is exactly why this
+// teardown runs off the creation mutex rather than under it.
 const abandonPartialInstanceTimeout = 5 * time.Second
 
 // abandonPartialInstance unwinds the pieces CreateInstance built before it
 // noticed the caller had gone: the tracker goroutines, the bound listener and
-// the allocated port. It must be called with m.mu held and must not route
-// through StopInstance, which takes that same lock — and the instance was never
-// registered in m.instances, so there is nothing there to remove.
+// the allocated port. It must be called WITHOUT m.mu held — the tracker stops
+// are slow and uninterruptible — and it does not route through StopInstance,
+// which would take that lock. The instance was never registered in
+// m.instances, so there is nothing there to remove.
 func (m *Manager) abandonPartialInstance(id string, port int, listener net.Listener, procMgr *process.Manager) {
 	// The request context is already cancelled, so teardown needs its own.
 	ctx, cancel := context.WithTimeout(context.Background(), abandonPartialInstanceTimeout)
@@ -492,6 +512,11 @@ func (m *Manager) Shutdown(ctx context.Context) error {
 	// Stop the idle reaper first so it doesn't fire StopInstance concurrently
 	// with our explicit per-instance shutdown loop.
 	m.stopReaperOnce()
+
+	// Drain any in-flight abandonment teardowns. They own trackers and a port
+	// that are no longer reachable through m.instances, so nothing below would
+	// wait for them otherwise.
+	m.abandonWG.Wait()
 
 	m.mu.Lock()
 	ids := make([]string, 0, len(m.instances))

--- a/apps/backend/internal/agentctl/server/instance/manager_abandon_test.go
+++ b/apps/backend/internal/agentctl/server/instance/manager_abandon_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net"
+	"strings"
 	"testing"
 
 	"github.com/kandev/kandev/internal/agentctl/server/config"
@@ -84,54 +85,82 @@ func TestAbandonPartialInstanceReleasesPort(t *testing.T) {
 	mgr.portAlloc.Release(next)
 }
 
-// TestCreateInstanceAbandonsWhenCallerLeavesMidCreation covers a caller that is
-// still waiting when CreateInstance takes the lock and gives up while it works.
-//
-// It asserts the invariant rather than which of the two context checks caught
-// it: whichever fires, no instance may be registered and no port may be lost.
-// Pinning the branch would mean racing the cancellation against tracker
-// startup, and a test that has to win a race to be meaningful is a test that
-// quietly stops being meaningful.
-func TestCreateInstanceAbandonsWhenCallerLeavesMidCreation(t *testing.T) {
+// TestCreateInstanceAbandonsAfterTrackerStartup drives the second context check
+// deterministically. The caller's context is live when CreateInstance takes the
+// lock and is cancelled exactly once the trackers have started, via the
+// afterTrackerStart seam — so the abandonment branch is guaranteed to run
+// rather than merely likely to.
+func TestCreateInstanceAbandonsAfterTrackerStartup(t *testing.T) {
 	log := newTestLogger(t)
 	mgr := NewManager(&config.Config{
 		Ports:    config.PortConfig{Base: 0, Max: 0},
 		Defaults: config.InstanceDefaults{Protocol: agent.ProtocolACP},
 	}, log)
-	t.Cleanup(func() { _ = mgr.Shutdown(context.Background()) })
 
 	ctx, cancel := context.WithCancel(context.Background())
-	started := make(chan struct{})
-	go func() {
-		<-started
-		cancel()
-	}()
-	close(started)
+	mgr.afterTrackerStart = cancel
 
 	resp, err := mgr.CreateInstance(ctx, &CreateRequest{WorkspacePath: t.TempDir()})
 	if err == nil {
-		// The caller can win the race and get a live instance; that is a valid
-		// outcome, and the instance is owned so it is not a leak.
-		if resp == nil {
-			t.Fatal("nil error and nil response")
-		}
-		return
+		t.Fatalf("expected an error once the caller was cancelled mid-creation, got %+v", resp)
 	}
 	if !errors.Is(err, context.Canceled) {
 		t.Errorf("error = %v, want it to wrap context.Canceled", err)
+	}
+	if !strings.Contains(err.Error(), "during startup") {
+		t.Errorf("error = %v, want the post-startup branch rather than the queued one", err)
 	}
 	if resp != nil {
 		t.Errorf("returned response %+v alongside the error", resp)
 	}
 
-	// Teardown is asynchronous by design — it must not run under the creation
-	// mutex — so wait for it before asserting nothing was left behind.
-	mgr.abandonWG.Wait()
+	mgr.mu.RLock()
+	live := len(mgr.instances)
+	mgr.mu.RUnlock()
+	if live != 0 {
+		t.Errorf("registered %d instances after abandoning creation, want 0", live)
+	}
+
+	// Shutdown must wait for the teardown goroutine rather than racing it.
+	if err := mgr.Shutdown(context.Background()); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+
+	// With teardown drained, the port is back in the pool and bindable.
+	port, listener, err := mgr.allocatePortAndListener("after-abandon")
+	if err != nil {
+		t.Fatalf("port was not released by the abandoned creation: %v", err)
+	}
+	_ = listener.Close()
+	mgr.portAlloc.Release(port)
+}
+
+// TestCreateInstanceRefusedAfterShutdown closes the ordering window Shutdown
+// would otherwise leave: it could observe abandonWG at zero and a creation
+// already past its own checks could register a teardown behind the Wait.
+func TestCreateInstanceRefusedAfterShutdown(t *testing.T) {
+	log := newTestLogger(t)
+	mgr := NewManager(&config.Config{
+		Ports:    config.PortConfig{Base: 0, Max: 0},
+		Defaults: config.InstanceDefaults{Protocol: agent.ProtocolACP},
+	}, log)
+
+	if err := mgr.Shutdown(context.Background()); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+
+	resp, err := mgr.CreateInstance(context.Background(), &CreateRequest{WorkspacePath: t.TempDir()})
+	if !errors.Is(err, ErrManagerShuttingDown) {
+		t.Fatalf("error = %v, want ErrManagerShuttingDown", err)
+	}
+	if resp != nil {
+		t.Errorf("returned response %+v after shutdown", resp)
+	}
 
 	mgr.mu.RLock()
 	live := len(mgr.instances)
 	mgr.mu.RUnlock()
 	if live != 0 {
-		t.Errorf("registered %d instances for a caller that had gone, want 0", live)
+		t.Errorf("registered %d instances after shutdown, want 0", live)
 	}
 }

--- a/apps/backend/internal/agentctl/server/instance/manager_abandon_test.go
+++ b/apps/backend/internal/agentctl/server/instance/manager_abandon_test.go
@@ -83,3 +83,55 @@ func TestAbandonPartialInstanceReleasesPort(t *testing.T) {
 	_ = nextListener.Close()
 	mgr.portAlloc.Release(next)
 }
+
+// TestCreateInstanceAbandonsWhenCallerLeavesMidCreation covers a caller that is
+// still waiting when CreateInstance takes the lock and gives up while it works.
+//
+// It asserts the invariant rather than which of the two context checks caught
+// it: whichever fires, no instance may be registered and no port may be lost.
+// Pinning the branch would mean racing the cancellation against tracker
+// startup, and a test that has to win a race to be meaningful is a test that
+// quietly stops being meaningful.
+func TestCreateInstanceAbandonsWhenCallerLeavesMidCreation(t *testing.T) {
+	log := newTestLogger(t)
+	mgr := NewManager(&config.Config{
+		Ports:    config.PortConfig{Base: 0, Max: 0},
+		Defaults: config.InstanceDefaults{Protocol: agent.ProtocolACP},
+	}, log)
+	t.Cleanup(func() { _ = mgr.Shutdown(context.Background()) })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	started := make(chan struct{})
+	go func() {
+		<-started
+		cancel()
+	}()
+	close(started)
+
+	resp, err := mgr.CreateInstance(ctx, &CreateRequest{WorkspacePath: t.TempDir()})
+	if err == nil {
+		// The caller can win the race and get a live instance; that is a valid
+		// outcome, and the instance is owned so it is not a leak.
+		if resp == nil {
+			t.Fatal("nil error and nil response")
+		}
+		return
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("error = %v, want it to wrap context.Canceled", err)
+	}
+	if resp != nil {
+		t.Errorf("returned response %+v alongside the error", resp)
+	}
+
+	// Teardown is asynchronous by design — it must not run under the creation
+	// mutex — so wait for it before asserting nothing was left behind.
+	mgr.abandonWG.Wait()
+
+	mgr.mu.RLock()
+	live := len(mgr.instances)
+	mgr.mu.RUnlock()
+	if live != 0 {
+		t.Errorf("registered %d instances for a caller that had gone, want 0", live)
+	}
+}

--- a/apps/backend/internal/agentctl/server/instance/manager_abandon_test.go
+++ b/apps/backend/internal/agentctl/server/instance/manager_abandon_test.go
@@ -1,0 +1,85 @@
+package instance
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/kandev/kandev/internal/agentctl/server/config"
+	"github.com/kandev/kandev/pkg/agent"
+)
+
+// TestCreateInstanceAbandonsWhenCallerGaveUp covers the leak that made instance
+// creation collapse under load. Creation is serialised on m.mu and the control
+// client gives up after 30s, so a queue fills with requests nobody awaits; each
+// one used to build a full instance — port, HTTP server, workspace trackers —
+// that no caller could ever stop, and the polling those trackers did made the
+// next creation slower still.
+func TestCreateInstanceAbandonsWhenCallerGaveUp(t *testing.T) {
+	log := newTestLogger(t)
+	mgr := NewManager(&config.Config{
+		Ports:    config.PortConfig{Base: 0, Max: 0},
+		Defaults: config.InstanceDefaults{Protocol: agent.ProtocolACP},
+	}, log)
+	t.Cleanup(func() { _ = mgr.Shutdown(context.Background()) })
+
+	// The caller timed out while this request sat in the queue.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	resp, err := mgr.CreateInstance(ctx, &CreateRequest{WorkspacePath: t.TempDir()})
+	if err == nil {
+		t.Fatalf("expected an error for a caller that had gone, got instance %+v", resp)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("error = %v, want it to wrap context.Canceled", err)
+	}
+	if resp != nil {
+		t.Errorf("returned a response %+v alongside the error; the caller would treat the instance as live", resp)
+	}
+
+	mgr.mu.RLock()
+	live := len(mgr.instances)
+	mgr.mu.RUnlock()
+	if live != 0 {
+		t.Errorf("registered %d instances for a caller that had gone, want 0", live)
+	}
+}
+
+// TestAbandonPartialInstanceReleasesPort pins the unwind path taken when the
+// caller disappears mid-creation: the port must go back to the allocator and
+// the listener must close, or the pool drains one entry per abandoned request.
+func TestAbandonPartialInstanceReleasesPort(t *testing.T) {
+	log := newTestLogger(t)
+	mgr := NewManager(&config.Config{
+		Ports:    config.PortConfig{Base: 0, Max: 0},
+		Defaults: config.InstanceDefaults{Protocol: agent.ProtocolACP},
+	}, log)
+	t.Cleanup(func() { _ = mgr.Shutdown(context.Background()) })
+
+	port, listener, err := mgr.allocatePortAndListener("abandoned")
+	if err != nil {
+		t.Fatalf("allocatePortAndListener: %v", err)
+	}
+	addr := listener.Addr().String()
+
+	// A nil process manager stands in for abandonment before one exists; the
+	// port and the listener still have to be given back.
+	mgr.abandonPartialInstance("abandoned", port, listener, nil)
+
+	// The listener is closed, so the address is bindable again.
+	reopened, err := net.Listen("tcp", addr)
+	if err != nil {
+		t.Fatalf("port %d still bound after abandon: %v", port, err)
+	}
+	_ = reopened.Close()
+
+	// And the allocator handed the port back rather than holding it as in use.
+	next, nextListener, err := mgr.allocatePortAndListener("next")
+	if err != nil {
+		t.Fatalf("allocatePortAndListener after abandon: %v", err)
+	}
+	_ = nextListener.Close()
+	mgr.portAlloc.Release(next)
+}


### PR DESCRIPTION
`CreateInstance` is serialised on a single mutex and the control client gives up after 30s, so under load the lock grows a queue of requests whose callers have already timed out — and each one still built a complete instance that nobody could ever stop, which is what turned a transient slowdown into a permanent collapse.

## Important Changes

- `CreateInstance` now checks the request context twice: on entry, which covers the queued case, and again after `StartAllWorkspaceTrackers`, which is the slow part a caller can time out during.
- `abandonPartialInstance` unwinds what was built when the second check fires — tracker goroutines, bound listener, allocated port. It has to do this by hand: `StopInstance` takes the same mutex still held here, and the instance was never registered in the map to begin with.

The context was already threaded in — `handleCreateInstance` passes `c.Request.Context()`. It was simply never consulted.

## Validation

Measured on a Windows dev machine with one task open, before the fix. `POST /api/v1/instances` latency over a single session:

```
9ms  18ms  7ms  6ms  6ms  →  5541ms  →  34329ms  36215ms  50144ms
                                        64698ms  99775ms  149126ms  192104ms
```

Monotonically increasing, which is the signature of a queue rather than of slow work: the first five completed in single-digit milliseconds. 14 creations, **zero** deletions, 16 instances still listening at the end. By that point plain `git ls-files` was exceeding its 10s timeout, terminals returned 503, and session resume failed outright — each failure prompting a retry that lengthened the queue further.

- `go build ./...` and `go vet ./internal/agentctl/server/instance/` — clean.
- `golangci-lint run ./internal/agentctl/server/instance/` — 0 issues.
- `go test -race ./internal/agentctl/server/instance/` — passes.
- Two new tests: a cancelled caller must produce an error wrapping `context.Canceled` and register no instance; and the unwind path must return the port to the allocator and close the listener. I verified both fail without the fix — with the context checks disabled, the first reports `got instance &{ID:34a23e49-... Port:0}`, which is precisely the orphan.

## Possible Improvements

Low risk in isolation — no exported signature changes, no persisted state, and the new behaviour only triggers on an already-cancelled context, where the previous code produced an instance nobody could reach.

What this deliberately does **not** address, both of which deserve their own change:

- **Why a creation became slow in the first place.** The trigger is contention on the process-wide git throttle (cap 12 in `common/subproc`), which background workspace polling shares with interactive request fan-outs. On a task with many repositories a single fan-out saturates it, and `CreateInstance` starts every repository's trackers while holding the lock. This fix stops a slowdown from compounding; it does not prevent the slowdown.
- **The serialisation itself.** One slow creation still blocks every other. Callers now fail cleanly instead of leaking, which is strictly better, but they still fail.

Related and independent: #2113 demotes unwatched workspace trackers out of fast polling, #2133 collapses the poll tick from four git spawns to one, and #2138 parallelises the multi-repo fan-outs. No file overlap between any of the four.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.
