### PR TITLE
docs: correct ADR 0013 heading number and broken spec link

### DIFF
--- a/docs/decisions/0013-multi-branch-tasks.md
+++ b/docs/decisions/0013-multi-branch-tasks.md
@@ -1,4 +1,4 @@
-# 0012: Multi-branch task support — extend multi-repo to allow N branches per repo
+# 0013: Multi-branch task support — extend multi-repo to allow N branches per repo
 
 **Status:** accepted
 **Date:** 2026-06-01

--- a/docs/specs/tasks/multi-branch/spec.md
+++ b/docs/specs/tasks/multi-branch/spec.md
@@ -3,7 +3,7 @@
 **Status:** shipped
 **Owner:** Kandev backend
 **Date:** 2026-06-01
-**Related:** [ADR 0013](../../decisions/0013-multi-branch-tasks.md)
+**Related:** [ADR 0013](../../../decisions/0013-multi-branch-tasks.md)
 
 ## What
 


### PR DESCRIPTION
The multi-branch ADR is numbered 0013 everywhere it is referenced (the filename, the decisions index, and the spec cross-reference all use 0013), but the document heading still read 0012 and the spec linked to it one directory level too shallow, so that link did not resolve. This aligns both references with the actual ADR number and path.

## Validation

- `docs/decisions/INDEX.md` lists this ADR as `0013` (Multi-branch task support) and assigns `0012` to a separate document, `0012-service-only-self-update.md`, so the heading should read `0013`.
- From `docs/specs/tasks/multi-branch/`, the old link `../../decisions/0013-multi-branch-tasks.md` resolves to `docs/specs/decisions/...`, which does not exist. The corrected `../../../decisions/0013-multi-branch-tasks.md` resolves to the real file at `docs/decisions/0013-multi-branch-tasks.md`.
- Documentation-only change; no code paths or tests are affected.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2163?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

