### PR TITLE
fix: reduce workspace switcher height

### DIFF
--- a/apps/web/components/app-sidebar/app-sidebar-workspace-picker.tsx
+++ b/apps/web/components/app-sidebar/app-sidebar-workspace-picker.tsx
@@ -45,7 +45,7 @@ const WorkspaceTrigger = forwardRef<
       data-testid="sidebar-workspace-trigger"
       aria-label="Switch workspace"
       className={cn(
-        "group/ws flex h-8 min-w-0 flex-1 items-center gap-1.5 rounded-md border border-border/70 bg-background px-2.5 text-sm font-medium text-foreground shadow-sm cursor-pointer transition-colors hover:border-border hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
+        "group/ws flex h-7 min-w-0 flex-1 items-center gap-1.5 rounded-md border border-border/70 bg-background px-2.5 text-sm font-medium text-foreground shadow-sm cursor-pointer transition-colors hover:border-border hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
         className,
       )}
       {...props}


### PR DESCRIPTION
The workspace switcher now fits the compact sidebar header more closely, reducing excess vertical chrome while preserving the mobile menu’s larger control sizing.

## Validation

- `pnpm --filter @kandev/web exec vitest run components/app-sidebar/app-sidebar-workspace-picker.test.tsx` (16 passed)
- `pnpm --filter @kandev/web exec eslint components/app-sidebar/app-sidebar-workspace-picker.tsx`
- `git diff --check`
- `CAPTURE_PR_ASSETS=1 pnpm e2e:run --no-build --project mobile-chrome e2e/tests/task/mobile-workspace-switcher-pr-capture.spec.ts` (1 passed)
- Fresh desktop and phone screenshots were captured, visually inspected, and compressed.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2178?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- kandev-screenshots-start -->
## Screenshots

![Desktop workspace switcher](https://raw.githubusercontent.com/kdlbs/kandev/a67adfbfc2594c1ba0a6d7e36a62effbe5fb4f2d/desktop-workspace-switcher.png)

![Mobile workspace switcher](https://raw.githubusercontent.com/kdlbs/kandev/a67adfbfc2594c1ba0a6d7e36a62effbe5fb4f2d/mobile-workspace-switcher.png)
<!-- kandev-screenshots-end -->