### PR TITLE
docs: simplify ACP agent launch entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,29 +70,29 @@ Connect Kandev to the tools your team already uses — pull issues into the kanb
 
 ## Supported ACP Agents
 
-| Agent | Launch |
+| Agent | Package / command |
 |:-------:|:----------:|
-| **Claude Code** | `npx --yes --prefer-offline @agentclientprotocol/claude-agent-acp` |
-| **Codex** | `npx --yes --prefer-offline @agentclientprotocol/codex-acp` |
-| **GitHub Copilot** | `npx --yes --prefer-offline @github/copilot --acp` |
-| **Gemini CLI** | `npx --yes --prefer-offline @google/gemini-cli --acp` |
-| **Amp** | `npx -y amp-acp` |
-| **Auggie** | `npx -y @augmentcode/auggie --acp` |
-| **OpenCode** | `npx --yes --prefer-offline opencode-ai acp` |
-| **Cursor** | `cursor-agent acp` *(requires Cursor Pro)* |
-| **Devin** | `devin acp` *(install Devin CLI from Devin Desktop or standalone installer)* |
-| **Qwen** | `npx -y @qwen-code/qwen-code --acp` |
-| **Factory Droid** | `npx -y droid exec --output-format acp` |
-| **iFlow (beta)** | `npx -y @iflow-ai/iflow-cli --experimental-acp` |
-| **Kilocode** | `npx -y @kilocode/cli acp` |
-| **Pi** | `npx -y pi-acp` |
-| **Kimi** | `kimi acp` *(install Kimi CLI from Moonshot AI)* |
-| **Kiro** | `kiro-cli-chat acp` *(install Kiro CLI from AWS)* |
-| **Qoder** | `qodercli --acp` *(install Qoder CLI)* |
-| **Trae** | `traecli acp serve` *(install Trae IDE CLI)* |
-| **Oh My Pi** | `omp acp` *(install `bun install -g @oh-my-pi/pi-coding-agent`)* |
-| **Grok** | `grok --no-auto-update agent stdio` *(install `npm install -g @xai-official/grok`)* |
-| **Hermes** | `hermes acp` *(install with the official Hermes installer)* |
+| **Claude Code** | `@agentclientprotocol/claude-agent-acp` |
+| **Codex** | `@agentclientprotocol/codex-acp` |
+| **GitHub Copilot** | `@github/copilot` |
+| **Gemini CLI** | `@google/gemini-cli` |
+| **Amp** | `amp-acp` |
+| **Auggie** | `@augmentcode/auggie` |
+| **OpenCode** | `opencode-ai` |
+| **Cursor** | `cursor-agent` *(requires Cursor Pro)* |
+| **Devin** | `devin` *(install Devin CLI from Devin Desktop or standalone installer)* |
+| **Qwen** | `@qwen-code/qwen-code` |
+| **Factory Droid** | `droid` |
+| **iFlow (beta)** | `@iflow-ai/iflow-cli` |
+| **Kilocode** | `@kilocode/cli` |
+| **Pi** | `pi-acp` |
+| **Kimi** | `kimi` *(install Kimi CLI from Moonshot AI)* |
+| **Kiro** | `kiro-cli-chat` *(install Kiro CLI from AWS)* |
+| **Qoder** | `qodercli` *(install Qoder CLI)* |
+| **Trae** | `traecli` *(install Trae IDE CLI)* |
+| **Oh My Pi** | `omp` *(install `@oh-my-pi/pi-coding-agent` with Bun)* |
+| **Grok** | `grok` *(install `@xai-official/grok` with npm)* |
+| **Hermes** | `hermes` *(install with the official Hermes installer)* |
 
 > All agents communicate via [ACP](https://agentclientprotocol.com) (Agent Client Protocol). Some agents support ACP natively, while others use ACP adapter packages that bridge their native protocols. **CLI Passthrough mode** is available when an integration provides a passthrough command. If your agent isn't supported yet, open an issue or submit a PR with the integration. See [Adding a New Agent CLI](docs/add-agent-cli.md) for a step-by-step guide.
 


### PR DESCRIPTION
The ACP agent table included npm runner, ACP mode, and install flags that obscured the package or executable used by each integration. The table now presents only the relevant package or command, with concise installation notes where needed.

## Validation

- `node --test scripts/validate-public-docs.test.mjs`
- `node scripts/validate-public-docs.mjs`
- `git diff --check`
- Pre-commit hooks passed; code-specific hooks were skipped for this README-only change.
- No `docs/public/**` files required changes because this PR only simplifies the root README table.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->