### PR TITLE
fix: keep sidebar diff stats visible

### DIFF
--- a/apps/web/components/task/task-item.test.tsx
+++ b/apps/web/components/task/task-item.test.tsx
@@ -20,6 +20,7 @@ const VIOLET_SPINNER_CLASS = "text-violet-500";
 const PREPARING_SPINNER_CLASS = "text-muted-foreground/40";
 const SPIN_CLASS = "animate-spin";
 const SLOW_SPIN_CLASS = "[animation-duration:2s]";
+const TASK_ACTIONS_LABEL = "Task actions";
 
 afterEach(() => cleanup());
 
@@ -166,6 +167,16 @@ describe("TaskItem status icon", () => {
 });
 
 describe("TaskItem actions", () => {
+  it("keeps row-focus actions visible when no diff stats are available", () => {
+    renderTaskItem({ isSelected: true });
+
+    const actionButton = screen.getByRole("button", { name: TASK_ACTIONS_LABEL });
+    const actionContainer = actionButton.parentElement;
+
+    expect(actionContainer?.className).toContain("group-focus-within:opacity-100");
+    expect(actionContainer?.className.split(/\s+/)).not.toContain("focus-within:opacity-100");
+  });
+
   it("keeps diff stats as the idle affordance when the selected row owns focus", () => {
     renderTaskItem({
       isSelected: true,
@@ -173,7 +184,7 @@ describe("TaskItem actions", () => {
     });
 
     const diffStats = screen.getByTestId("sidebar-task-diff-stats");
-    const actionButton = screen.getByRole("button", { name: "Task actions" });
+    const actionButton = screen.getByRole("button", { name: TASK_ACTIONS_LABEL });
     const actionContainer = actionButton.parentElement;
 
     expect(diffStats.className).not.toContain("group-focus-within:opacity-0");
@@ -181,10 +192,24 @@ describe("TaskItem actions", () => {
     expect(actionContainer?.className).toContain("focus-within:opacity-100");
   });
 
+  it("hides diff stats and keeps the action trigger visible when the context menu is open", () => {
+    renderTaskItem({
+      menuOpen: true,
+      diffStats: { additions: 42, deletions: 7 },
+    });
+
+    const diffStats = screen.getByTestId("sidebar-task-diff-stats");
+    const actionButton = screen.getByRole("button", { name: TASK_ACTIONS_LABEL });
+    const actionContainer = actionButton.parentElement;
+
+    expect(diffStats.className).toContain("opacity-0");
+    expect(actionContainer?.className).toContain("opacity-100");
+  });
+
   it("announces the task menu state", () => {
     renderTaskItem({ menuOpen: true });
 
-    const actions = screen.getByRole("button", { name: "Task actions" });
+    const actions = screen.getByRole("button", { name: TASK_ACTIONS_LABEL });
     expect(actions.getAttribute("aria-haspopup")).toBe("menu");
     expect(actions.getAttribute("aria-expanded")).toBe("true");
   });
@@ -192,9 +217,9 @@ describe("TaskItem actions", () => {
   it("does not announce a closed menu as expanded while deleting", () => {
     renderTaskItem({ isDeleting: true });
 
-    expect(screen.getByRole("button", { name: "Task actions" }).getAttribute("aria-expanded")).toBe(
-      "false",
-    );
+    expect(
+      screen.getByRole("button", { name: TASK_ACTIONS_LABEL }).getAttribute("aria-expanded"),
+    ).toBe("false");
   });
 });
 

--- a/apps/web/components/task/task-item.test.tsx
+++ b/apps/web/components/task/task-item.test.tsx
@@ -166,6 +166,21 @@ describe("TaskItem status icon", () => {
 });
 
 describe("TaskItem actions", () => {
+  it("keeps diff stats as the idle affordance when the selected row owns focus", () => {
+    renderTaskItem({
+      isSelected: true,
+      diffStats: { additions: 3488, deletions: 199 },
+    });
+
+    const diffStats = screen.getByTestId("sidebar-task-diff-stats");
+    const actionButton = screen.getByRole("button", { name: "Task actions" });
+    const actionContainer = actionButton.parentElement;
+
+    expect(diffStats.className).not.toContain("group-focus-within:opacity-0");
+    expect(actionContainer?.className).not.toContain("group-focus-within:opacity-100");
+    expect(actionContainer?.className).toContain("focus-within:opacity-100");
+  });
+
   it("announces the task menu state", () => {
     renderTaskItem({ menuOpen: true });
 

--- a/apps/web/components/task/task-item.tsx
+++ b/apps/web/components/task/task-item.tsx
@@ -325,9 +325,7 @@ function DiffStatsRight({ diffStats, menuOpen }: { diffStats: DiffStats; menuOpe
       data-testid="sidebar-task-diff-stats"
       className={cn(
         "mobile-task-diff-stats shrink-0 self-center font-mono text-[11px] transition-opacity duration-100",
-        menuOpen
-          ? "opacity-0"
-          : "[@media(hover:hover)]:group-hover:opacity-0 group-focus-within:opacity-0",
+        menuOpen ? "opacity-0" : "[@media(hover:hover)]:group-hover:opacity-0",
       )}
     >
       <span className="text-emerald-500">+{diffStats.additions}</span>{" "}
@@ -618,7 +616,7 @@ function TaskMenuButton({ visible, expanded }: { visible: boolean; expanded: boo
         !visible && "[@media(hover:none)]:hidden",
         visible
           ? "opacity-100"
-          : "opacity-0 pointer-events-none [@media(hover:hover)]:group-hover:opacity-100 [@media(hover:hover)]:group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto",
+          : "opacity-0 pointer-events-none [@media(hover:hover)]:group-hover:opacity-100 [@media(hover:hover)]:group-hover:pointer-events-auto focus-within:opacity-100 focus-within:pointer-events-auto",
       )}
     >
       <button

--- a/apps/web/components/task/task-item.tsx
+++ b/apps/web/components/task/task-item.tsx
@@ -325,7 +325,9 @@ function DiffStatsRight({ diffStats, menuOpen }: { diffStats: DiffStats; menuOpe
       data-testid="sidebar-task-diff-stats"
       className={cn(
         "mobile-task-diff-stats shrink-0 self-center font-mono text-[11px] transition-opacity duration-100",
-        menuOpen ? "opacity-0" : "[@media(hover:hover)]:group-hover:opacity-0",
+        menuOpen
+          ? "opacity-0"
+          : "[@media(hover:hover)]:group-hover:opacity-0 group-focus-within/actions:opacity-0",
       )}
     >
       <span className="text-emerald-500">+{diffStats.additions}</span>{" "}
@@ -521,14 +523,14 @@ export const TaskItem = memo(function TaskItem({
         agentErrorMessage={agentErrorMessage}
       />
       {hasDiffStats ? (
-        <div className="mobile-task-actions-with-stats relative shrink-0 self-center flex items-center">
+        <div className="mobile-task-actions-with-stats group/actions relative shrink-0 self-center flex items-center">
           <DiffStatsRight diffStats={diffStats!} menuOpen={effectiveMenuOpen} />
           <div className="mobile-task-actions-slot absolute inset-0 flex items-center justify-end">
             <TaskMenuButton visible={effectiveMenuOpen} expanded={menuOpen} />
           </div>
         </div>
       ) : (
-        <TaskMenuButton visible={effectiveMenuOpen} expanded={menuOpen} />
+        <TaskMenuButton visible={effectiveMenuOpen} expanded={menuOpen} rowFocus />
       )}
       {showSubtaskToggle && (
         <SubtaskToggle
@@ -608,7 +610,15 @@ function SubtaskToggle({
   );
 }
 
-function TaskMenuButton({ visible, expanded }: { visible: boolean; expanded: boolean }) {
+function TaskMenuButton({
+  visible,
+  expanded,
+  rowFocus = false,
+}: {
+  visible: boolean;
+  expanded: boolean;
+  rowFocus?: boolean;
+}) {
   return (
     <div
       className={cn(
@@ -616,7 +626,12 @@ function TaskMenuButton({ visible, expanded }: { visible: boolean; expanded: boo
         !visible && "[@media(hover:none)]:hidden",
         visible
           ? "opacity-100"
-          : "opacity-0 pointer-events-none [@media(hover:hover)]:group-hover:opacity-100 [@media(hover:hover)]:group-hover:pointer-events-auto focus-within:opacity-100 focus-within:pointer-events-auto",
+          : cn(
+              "opacity-0 pointer-events-none [@media(hover:hover)]:group-hover:opacity-100 [@media(hover:hover)]:group-hover:pointer-events-auto",
+              rowFocus
+                ? "group-focus-within:opacity-100 group-focus-within:pointer-events-auto"
+                : "focus-within:opacity-100 focus-within:pointer-events-auto",
+            ),
       )}
     >
       <button

--- a/apps/web/e2e/tests/task/sidebar-diff-stats.spec.ts
+++ b/apps/web/e2e/tests/task/sidebar-diff-stats.spec.ts
@@ -103,5 +103,32 @@ test.describe("Task sidebar diff stats", () => {
 
     // Diff badge is rendered as "+N -N" inside a font-mono span.
     await expect(alphaRow.getByText(/\+\d+\s+-\d+/)).toBeVisible({ timeout: 30_000 });
+
+    // The active row keeps its diff totals visible after the row receives focus.
+    // Only fine-pointer hover should swap them for the actions trigger.
+    await alphaRow.click();
+    await expect.poll(() => testPage.url(), { timeout: 10_000 }).toContain(taskAlpha.id);
+
+    const activeAlphaRow = betaSession.sidebar
+      .getByTestId("sidebar-task-item")
+      .filter({ hasText: "Diff Alpha" });
+    const activeDiffStats = activeAlphaRow.getByTestId("sidebar-task-diff-stats");
+    const activeActions = activeAlphaRow.getByRole("button", { name: "Task actions" });
+    const activeActionContainer = activeActions.locator("..");
+
+    await testPage.mouse.move(0, 0);
+    await expect
+      .poll(() => activeDiffStats.evaluate((element) => getComputedStyle(element).opacity))
+      .toBe("1");
+    await expect
+      .poll(() => activeActionContainer.evaluate((element) => getComputedStyle(element).opacity))
+      .toBe("0");
+
+    await activeAlphaRow.hover();
+    await expect(activeActionContainer).toHaveCSS("opacity", "1");
+    await expect(activeDiffStats).toHaveCSS("opacity", "0");
+
+    await activeActions.click();
+    await expect(testPage.getByRole("menuitem", { name: "Archive", exact: true })).toBeVisible();
   });
 });

--- a/docs/plans/sidebar-diff-stat-priority/plan.md
+++ b/docs/plans/sidebar-diff-stat-priority/plan.md
@@ -1,0 +1,99 @@
+---
+spec: docs/specs/ui/sidebar-diff-stat-priority.md
+created: 2026-08-02
+status: completed
+---
+
+# Implementation Plan: Sidebar Diff Stat Priority
+
+## Overview
+
+Refine the shared task-row visibility rules so a desktop row's diff totals remain the idle
+affordance even after task selection leaves focus on the row. Keep the existing hover replacement
+for the ellipsis, retain a focus-visible keyboard path on the action control itself, and leave the
+mobile drawer's side-by-side controls unchanged.
+
+## Frontend
+
+### Shared sidebar task row
+
+- Update `apps/web/components/task/task-item.tsx` so `DiffStatsRight` no longer hides totals for
+  row-level `group-focus-within`; it should hide only for an open menu and fine-pointer hover.
+- Update `TaskMenuButton` so row-level focus does not make the ellipsis visible. Preserve a
+  keyboard-focus selector on the button/control so Tab users can reveal and use the trigger.
+- Keep the existing context-menu `menuOpen` and deletion behavior intact: an open menu remains
+  associated with a visible trigger, while the normal idle state restores the totals.
+- Do not alter the mobile classes or `apps/web/app/globals.css` overrides that intentionally show
+  both controls and preserve the 44px action hit target below 640px.
+
+## Tests
+
+- **What:** an active/focused desktop row with diff stats keeps the totals in its idle visibility
+  state; row focus is not included in either swapped-visibility class.
+  **File:** `apps/web/components/task/task-item.test.tsx`.
+  **How:** render a selected `TaskItem` with non-zero stats and assert its semantic elements and
+  visibility-class contract.
+- **What:** the context-menu-open state retains the existing visible action trigger and hides the
+  underlying totals.
+  **File:** `apps/web/components/task/task-item.test.tsx`.
+  **How:** extend the action-state component coverage with non-zero diff stats.
+
+## E2E Tests
+
+- **Scenario:** an active desktop sidebar task preserves diff totals until hover, then reveals the
+  action ellipsis and opens its context menu.
+  **File:** `apps/web/e2e/tests/task/sidebar-diff-stats.spec.ts`.
+  **What to verify:** after selecting a task with real non-zero status-summary stats, assert the
+  idle action trigger is hidden, the diff badge is visible, and hover swaps the two before opening
+  a menu item.
+- **Scenario:** the phone task-switcher keeps diff totals and a non-overlapping touch-sized action
+  control visible together.
+  **File:** `apps/web/e2e/tests/task/mobile-sidebar-task-actions.spec.ts` (existing coverage).
+  **What to verify:** retain the existing `mobile-chrome` geometry assertion; no mobile markup or
+  interaction changes are planned.
+
+## Mobile Parity
+
+The nearest shipped mobile exemplar is
+`apps/web/components/task/mobile/session-task-switcher-sheet.tsx`, which renders the shared
+`TaskSwitcher` inside the phone task drawer. Desktop's hover replacement is not a valid touch
+interaction, so the existing mobile hierarchy keeps both the diff badge and explicit overflow
+button visible. The drawer remains the sole scroll owner; no composition, safe-area, or navigation
+change is needed. Existing mobile E2E coverage proves the same task-action capability with a 44px
+control and no overlap.
+
+## Verification Results
+
+- `rtk pnpm --filter @kandev/web test -- components/task/task-item.test.tsx` — final run passed,
+  1 file / 28 tests. The initial RED run passed 27 tests and failed the new visibility assertion
+  against the old `group-focus-within` classes.
+- `rtk pnpm e2e:run tests/task/sidebar-diff-stats.spec.ts` — the first production-build run
+  reached the new active-row assertion but failed because the test pointer was still hovering the
+  clicked row. After moving the pointer away, the change-aware rerun
+  `rtk pnpm e2e:run --no-build tests/task/sidebar-diff-stats.spec.ts` passed, 1 test; the final
+  rerun also passed after asserting that the hovered trigger opens the existing context menu.
+- `rtk pnpm e2e:run --no-build --project mobile-chrome tests/task/mobile-sidebar-task-actions.spec.ts`
+  — passed, 8 tests; the existing mobile diff/action geometry remains green.
+- `rtk pnpm run typecheck` — passed with `tsc --noEmit` and no diagnostics.
+- `rtk git diff --check` — passed.
+- `rtk pnpm e2e:run --no-build tests/task/sidebar-diff-stats-capture.spec.ts` — passed, 1
+  desktop capture test; produced fresh idle and hover PNGs.
+- `rtk pnpm e2e:run --no-build --project mobile-chrome
+  tests/task/mobile-sidebar-diff-stats-capture.spec.ts` — final capture run passed, 1 test; the
+  mobile screenshot was scrolled to show the task row's stats and action button together.
+- The temporary capture specs were removed after capture. `apps/web/.pr-assets/manifest.json` is
+  non-empty, PNGs were visually inspected, and the `pngquant-bin` fallback compressed them.
+
+The fresh-worktree dependency bootstrap was not needed because `apps/node_modules` was already
+present. E2E production assets were rebuilt by the first managed run; the later `--no-build` runs
+used those fresh artifacts.
+
+## Implementation Waves And Parallel Candidates
+
+Wave 1 (sequential):
+
+- [x] [Task 01: Preserve sidebar diff stats](task-01-preserve-sidebar-diff-stats.md) — done
+
+## Open Questions
+
+None.

--- a/docs/plans/sidebar-diff-stat-priority/plan.md
+++ b/docs/plans/sidebar-diff-stat-priority/plan.md
@@ -18,9 +18,11 @@ mobile drawer's side-by-side controls unchanged.
 ### Shared sidebar task row
 
 - Update `apps/web/components/task/task-item.tsx` so `DiffStatsRight` no longer hides totals for
-  row-level `group-focus-within`; it should hide only for an open menu and fine-pointer hover.
-- Update `TaskMenuButton` so row-level focus does not make the ellipsis visible. Preserve a
-  keyboard-focus selector on the button/control so Tab users can reveal and use the trigger.
+  row-level `group-focus-within`; it should hide for an open menu, fine-pointer hover, or the
+  named `group-focus-within/actions` state while the action trigger itself owns focus.
+- Update `TaskMenuButton` so row-level focus does not make the ellipsis visible on rows with diff
+  stats. Preserve a keyboard-focus selector on the button/control so Tab users can reveal and use
+  the trigger, while rows without diff stats retain their existing row-focus disclosure.
 - Keep the existing context-menu `menuOpen` and deletion behavior intact: an open menu remains
   associated with a visible trigger, while the normal idle state restores the totals.
 - Do not alter the mobile classes or `apps/web/app/globals.css` overrides that intentionally show
@@ -65,7 +67,7 @@ control and no overlap.
 ## Verification Results
 
 - `rtk pnpm --filter @kandev/web test -- components/task/task-item.test.tsx` — final run passed,
-  1 file / 28 tests. The initial RED run passed 27 tests and failed the new visibility assertion
+  1 file / 30 tests. The initial RED run passed 27 tests and failed the new visibility assertion
   against the old `group-focus-within` classes.
 - `rtk pnpm e2e:run tests/task/sidebar-diff-stats.spec.ts` — the first production-build run
   reached the new active-row assertion but failed because the test pointer was still hovering the
@@ -76,6 +78,10 @@ control and no overlap.
   — passed, 8 tests; the existing mobile diff/action geometry remains green.
 - `rtk pnpm run typecheck` — passed with `tsc --noEmit` and no diagnostics.
 - `rtk git diff --check` — passed.
+- Fixup commit `8c0f56c0b` added scoped action-focus behavior, restored no-stats row-focus
+  disclosure, and added the context-menu-open unit assertion; the targeted unit suite passed
+  30/30, desktop E2E passed 1/1 after a production rebuild, mobile E2E passed 8/8, and web
+  typecheck passed.
 - `rtk pnpm e2e:run --no-build tests/task/sidebar-diff-stats-capture.spec.ts` — passed, 1
   desktop capture test; produced fresh idle and hover PNGs.
 - `rtk pnpm e2e:run --no-build --project mobile-chrome

--- a/docs/plans/sidebar-diff-stat-priority/task-01-preserve-sidebar-diff-stats.md
+++ b/docs/plans/sidebar-diff-stat-priority/task-01-preserve-sidebar-diff-stats.md
@@ -28,10 +28,10 @@ spec: "../../specs/ui/sidebar-diff-stat-priority.md"
 - **Verification:**
   ```bash
   cd apps && pnpm install --frozen-lockfile
-  cd apps && pnpm --filter @kandev/web test -- components/task/task-item.test.tsx
-  cd apps/web && pnpm e2e:run tests/task/sidebar-diff-stats.spec.ts
-  cd apps/web && pnpm e2e:run --project mobile-chrome tests/task/mobile-sidebar-task-actions.spec.ts
-  cd apps/web && pnpm run typecheck
+  pnpm --filter @kandev/web test -- components/task/task-item.test.tsx
+  pnpm --filter @kandev/web e2e:run -- tests/task/sidebar-diff-stats.spec.ts
+  pnpm --filter @kandev/web e2e:run -- --project mobile-chrome tests/task/mobile-sidebar-task-actions.spec.ts
+  pnpm --filter @kandev/web run typecheck
   ```
 - **Output contract:** Report the changed files, exact tests and results, blockers and risks, then
   update this task and `plan.md` status in the same conversation.
@@ -49,6 +49,10 @@ spec: "../../specs/ui/sidebar-diff-stat-priority.md"
   — passed, 8/8 tests, including the diff/action non-overlap check.
 - `rtk pnpm run typecheck` — passed.
 - `rtk git diff --check` — passed.
+- Fixup commit `8c0f56c0b` added the named action-focus scope, restored no-stats row-focus
+  disclosure, and added the context-menu-open unit assertion; the targeted unit suite passed
+  30/30, desktop E2E passed 1/1 after a production rebuild, mobile E2E passed 8/8, and web
+  typecheck passed.
 - `rtk pnpm e2e:run --no-build tests/task/sidebar-diff-stats-capture.spec.ts` — passed, 1 desktop
   screenshot capture test.
 - `rtk pnpm e2e:run --no-build --project mobile-chrome

--- a/docs/plans/sidebar-diff-stat-priority/task-01-preserve-sidebar-diff-stats.md
+++ b/docs/plans/sidebar-diff-stat-priority/task-01-preserve-sidebar-diff-stats.md
@@ -1,0 +1,60 @@
+---
+id: "01-preserve-sidebar-diff-stats"
+title: "Preserve sidebar diff stats"
+status: done
+wave: 1
+depends_on: []
+plan: "plan.md"
+spec: "../../specs/ui/sidebar-diff-stat-priority.md"
+---
+
+# Task 01: Preserve sidebar diff stats
+
+- **Acceptance:** A selected desktop task row with non-zero diff stats displays its totals while
+  idle, even if the row owns focus after selection.
+- **Acceptance:** Fine-pointer hover swaps the totals for the existing Task actions trigger;
+  opening the context menu retains the visible trigger, and keyboard focus on that trigger remains
+  discoverable.
+- **Acceptance:** The existing mobile task-switcher continues to show both the totals and a
+  non-overlapping, 44px Task actions target.
+- **Files likely touched:** `apps/web/components/task/task-item.tsx`,
+  `apps/web/components/task/task-item.test.tsx`,
+  `apps/web/e2e/tests/task/sidebar-diff-stats.spec.ts`.
+- **Dependencies:** None.
+- **Parallelism:** Sequential; the shared row and its desktop E2E coverage are coupled.
+- **Inputs:** `docs/specs/ui/sidebar-diff-stat-priority.md`, `plan.md`,
+  `apps/web/components/task/task-switcher-context-menu.tsx`, and the existing mobile assertion in
+  `apps/web/e2e/tests/task/mobile-sidebar-task-actions.spec.ts`.
+- **Verification:**
+  ```bash
+  cd apps && pnpm install --frozen-lockfile
+  cd apps && pnpm --filter @kandev/web test -- components/task/task-item.test.tsx
+  cd apps/web && pnpm e2e:run tests/task/sidebar-diff-stats.spec.ts
+  cd apps/web && pnpm e2e:run --project mobile-chrome tests/task/mobile-sidebar-task-actions.spec.ts
+  cd apps/web && pnpm run typecheck
+  ```
+- **Output contract:** Report the changed files, exact tests and results, blockers and risks, then
+  update this task and `plan.md` status in the same conversation.
+
+## Results
+
+- `rtk pnpm --filter @kandev/web test -- components/task/task-item.test.tsx` — final run passed,
+  28/28 tests. The preceding RED run failed only the new selected-row visibility assertion
+  (27/28 passing), proving the old focus rule was exercised.
+- `rtk pnpm e2e:run tests/task/sidebar-diff-stats.spec.ts` — initial run reached the new assertion
+  but failed because the pointer remained over the clicked row; the corrected
+  `rtk pnpm e2e:run --no-build tests/task/sidebar-diff-stats.spec.ts` passed, 1/1 test, including
+  the final context-menu-open assertion.
+- `rtk pnpm e2e:run --no-build --project mobile-chrome tests/task/mobile-sidebar-task-actions.spec.ts`
+  — passed, 8/8 tests, including the diff/action non-overlap check.
+- `rtk pnpm run typecheck` — passed.
+- `rtk git diff --check` — passed.
+- `rtk pnpm e2e:run --no-build tests/task/sidebar-diff-stats-capture.spec.ts` — passed, 1 desktop
+  screenshot capture test.
+- `rtk pnpm e2e:run --no-build --project mobile-chrome
+  tests/task/mobile-sidebar-diff-stats-capture.spec.ts` — final capture run passed, 1 mobile
+  screenshot capture test.
+
+Fresh-worktree installation was skipped because `apps/node_modules` was already present. No
+temporary capture specs remain; ignored PR assets were inspected, compressed, and recorded in the
+non-empty `apps/web/.pr-assets/manifest.json`.

--- a/docs/specs/ui/sidebar-diff-stat-priority.md
+++ b/docs/specs/ui/sidebar-diff-stat-priority.md
@@ -1,0 +1,49 @@
+---
+status: shipped
+created: 2026-08-02
+owner: kandev
+---
+
+# Sidebar Diff Stat Priority
+
+## Why
+
+An active task in the desktop sidebar currently retains row focus after it is selected. That
+focus exposes the overflow control and obscures its addition/deletion totals, making the most
+useful progress signal disappear exactly when the task is active.
+
+## What
+
+- A desktop/fine-pointer sidebar task row with non-zero diff stats shows its `+additions` and
+  `-deletions` totals while idle, including when the row is the active task or has row focus.
+- Hovering that row temporarily replaces the diff totals with the Task actions ellipsis control.
+- Opening the task context menu keeps its trigger visible while the menu is open; closing the
+  menu restores the idle diff totals unless the pointer remains over the row.
+- Keyboard users can still discover and operate the Task actions control when the control itself
+  receives keyboard focus. Row focus alone does not replace the diff totals.
+- Rows without diff stats retain their existing action-control behavior.
+- The phone task-switcher drawer retains its existing explicit controls: non-zero diff totals and
+  the 44px Task actions button remain visible together, with no hover-only requirement.
+
+## Scenarios
+
+- **GIVEN** an active desktop sidebar task with non-zero additions or deletions, **WHEN** the
+  pointer is not over its row, **THEN** the row displays its diff totals and does not display the
+  Task actions ellipsis.
+- **GIVEN** a desktop sidebar task with non-zero diff totals, **WHEN** the user hovers the row,
+  **THEN** the Task actions ellipsis replaces the totals and can open the existing context menu.
+- **GIVEN** a desktop sidebar task with non-zero diff totals and a closed context menu,
+  **WHEN** keyboard focus reaches the Task actions button, **THEN** the button becomes visible and
+  usable without treating focus on the row itself as hover.
+- **GIVEN** a phone task-switcher row with non-zero diff totals, **WHEN** the task switcher opens,
+  **THEN** the totals and the touch-sized Task actions button remain visible without overlap.
+
+## Out of scope
+
+- Changing task diff calculation, task-status summary delivery, or the displayed numbers.
+- Changing context-menu actions, task selection, focus ownership, or sidebar navigation.
+- Redesigning the mobile task-switcher drawer, its action sheet, or its touch-target sizing.
+
+## Implementation plan
+
+- [Sidebar diff stat priority plan](../../plans/sidebar-diff-stat-priority/plan.md)


### PR DESCRIPTION
Active task rows were hiding their diff totals after selection because row focus triggered the
overflow state. This keeps the `+/-` counts visible until fine-pointer hover, while preserving
keyboard access, the existing context menu, and the mobile side-by-side controls.

## Validation

- `pnpm --filter @kandev/web test -- components/task/task-item.test.tsx` — 28 tests passed.
- `pnpm e2e:run --no-build tests/task/sidebar-diff-stats.spec.ts` — passed.
- `pnpm e2e:run --no-build --project mobile-chrome tests/task/mobile-sidebar-task-actions.spec.ts` — 8 tests passed.
- `pnpm run typecheck` — passed.
- Fresh desktop and mobile screenshots captured, inspected, and compressed for this PR.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2183?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- kandev-screenshots-start -->
## Screenshots

![Desktop idle diff stats](https://raw.githubusercontent.com/kdlbs/kandev/25e6fe174ed58ab7d752abe87ff031e13d05d9ef/sidebar-diff-stats-idle.png)

![Desktop hover task actions](https://raw.githubusercontent.com/kdlbs/kandev/25e6fe174ed58ab7d752abe87ff031e13d05d9ef/sidebar-diff-stats-hover.png)

![Mobile diff stats and actions](https://raw.githubusercontent.com/kdlbs/kandev/25e6fe174ed58ab7d752abe87ff031e13d05d9ef/mobile-sidebar-diff-stats.png)
<!-- kandev-screenshots-end -->