### PR TITLE
fix(web): remember mobile kanban column when returning from a task

### DIFF
--- a/apps/web/components/kanban/swimlane-kanban-content.tsx
+++ b/apps/web/components/kanban/swimlane-kanban-content.tsx
@@ -25,6 +25,7 @@ import { MobileDropTargets } from "./mobile-drop-targets";
 import { AdaptiveDesktopKanban } from "./adaptive-desktop-kanban";
 import type { KanbanState } from "@/lib/state/slices/kanban/types";
 import type { MobileWorkflowNavigation } from "@/lib/kanban/view-registry";
+import { resolveMobileColumnIndex } from "@/lib/kanban/mobile-column-index";
 import { compareTasksByCreatedDesc } from "@/lib/kanban/task-order";
 import { countAdmittedTasks } from "@/lib/kanban/wip-limit";
 import {
@@ -171,29 +172,24 @@ function useSwimlaneKanbanDnd({ tasks, workflowId, onMoveError }: SwimlaneKanban
   };
 }
 
-function getInitialColumnIndex(steps: WorkflowStep[], tasks: Task[]): number {
-  if (steps.length === 0) return 0;
-  const idx = steps.findIndex((step) => tasks.some((t) => t.workflowStepId === step.id));
-  return idx !== -1 ? idx : 0;
-}
-
 function useMobileColumnIndex(workflowId: string, steps: WorkflowStep[], tasks: Task[]) {
-  const [selection, setSelection] = useState(() => ({
-    workflowId,
-    index: getInitialColumnIndex(steps, tasks),
-  }));
+  const storedStepId = useAppStore(
+    (state) => state.mobileKanban.activeStepIdByWorkflowId[workflowId],
+  );
+  const setMobileKanbanActiveStep = useAppStore((state) => state.setMobileKanbanActiveStep);
 
-  // Derive clamped index — avoids calling setState in an effect
-  const activeIndex = useMemo(() => {
-    if (steps.length === 0) return 0;
-    if (selection.workflowId !== workflowId || selection.index >= steps.length) {
-      return getInitialColumnIndex(steps, tasks);
-    }
-    return selection.index;
-  }, [steps, tasks, selection, workflowId]);
+  const activeIndex = useMemo(
+    () => resolveMobileColumnIndex(steps, tasks, storedStepId),
+    [steps, tasks, storedStepId],
+  );
+
   const setActiveIndex = useCallback(
-    (index: number) => setSelection({ workflowId, index }),
-    [workflowId],
+    (index: number) => {
+      const stepId = steps[index]?.id;
+      if (!stepId) return;
+      setMobileKanbanActiveStep(workflowId, stepId);
+    },
+    [steps, workflowId, setMobileKanbanActiveStep],
   );
 
   return { activeIndex, setActiveIndex };

--- a/apps/web/components/kanban/swimlane-kanban-content.tsx
+++ b/apps/web/components/kanban/swimlane-kanban-content.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   DndContext,
   DragEndEvent,
@@ -182,6 +182,12 @@ function useMobileColumnIndex(workflowId: string, steps: WorkflowStep[], tasks: 
     () => resolveMobileColumnIndex(steps, tasks, storedStepId),
     [steps, tasks, storedStepId],
   );
+  const activeStepId = steps[activeIndex]?.id;
+
+  useEffect(() => {
+    if (!activeStepId || activeStepId === storedStepId) return;
+    setMobileKanbanActiveStep(workflowId, activeStepId);
+  }, [activeStepId, storedStepId, workflowId, setMobileKanbanActiveStep]);
 
   const setActiveIndex = useCallback(
     (index: number) => {

--- a/apps/web/e2e/tests/kanban/mobile-kanban.spec.ts
+++ b/apps/web/e2e/tests/kanban/mobile-kanban.spec.ts
@@ -507,6 +507,58 @@ test.describe("Mobile kanban view", () => {
     await expect(dialog.getByRole("button", { name: "View system status" })).toBeVisible();
   });
 
+  test("restores the selected workflow step after opening a task", async ({
+    testPage,
+    apiClient,
+    seedData,
+    prCapture,
+  }) => {
+    const workflow = await apiClient.createWorkflow(
+      seedData.workspaceId,
+      "Mobile Restore Column Workflow",
+    );
+    const todoStep = await apiClient.createWorkflowStep(workflow.id, "Todo", 0, {
+      is_start_step: true,
+    });
+    const planStep = await apiClient.createWorkflowStep(workflow.id, "Plan", 1);
+    await apiClient.createTask(seedData.workspaceId, "Restore Column Todo Task", {
+      workflow_id: workflow.id,
+      workflow_step_id: todoStep.id,
+    });
+    const planTask = await apiClient.createTask(seedData.workspaceId, "Restore Column Plan Task", {
+      workflow_id: workflow.id,
+      workflow_step_id: planStep.id,
+    });
+    await apiClient.saveUserSettings({
+      workspace_id: seedData.workspaceId,
+      workflow_filter_id: workflow.id,
+    });
+
+    const mobile = new MobileKanbanPage(testPage);
+    await mobile.goto();
+
+    await expect(mobile.boardNavigator).toContainText("Mobile Restore Column Workflow");
+    await prCapture.startRecording("mobile-kanban-column-restore-after");
+    await mobile.boardNavigator.click();
+    await expect(testPage.getByTestId("mobile-board-navigator-drawer")).toBeVisible();
+    await testPage.getByTestId("column-tab-1").click();
+    await expect(testPage.getByTestId("mobile-board-navigator-drawer")).not.toBeVisible();
+    await expect(mobile.boardNavigator).toContainText("Plan");
+    await expect(mobile.taskCardByTitle("Restore Column Plan Task")).toBeInViewport();
+
+    await mobile.taskCard(planTask.id).click();
+    await expect(testPage).toHaveURL(new RegExp(`/t/${planTask.id}`));
+
+    await testPage.getByRole("link", { name: "Task overview" }).click();
+    await expect(mobile.mobileKanbanLayout()).toBeVisible();
+    await expect(mobile.boardNavigator).toContainText("Plan");
+    await expect(mobile.taskCardByTitle("Restore Column Plan Task")).toBeInViewport();
+    await expect(mobile.taskCardByTitle("Restore Column Todo Task")).not.toBeInViewport();
+    await prCapture.stopRecording({
+      caption: "After: returning from a task keeps the Plan column selected",
+    });
+  });
+
   test("step drawer allows switching between workflow steps", async ({
     testPage,
     apiClient,

--- a/apps/web/e2e/tests/kanban/mobile-kanban.spec.ts
+++ b/apps/web/e2e/tests/kanban/mobile-kanban.spec.ts
@@ -559,6 +559,45 @@ test.describe("Mobile kanban view", () => {
     });
   });
 
+  test("keeps the initial fallback step stable after a live task update", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    const workflow = await apiClient.createWorkflow(
+      seedData.workspaceId,
+      "Mobile Stable Fallback Workflow",
+    );
+    const todoStep = await apiClient.createWorkflowStep(workflow.id, "Todo", 0, {
+      is_start_step: true,
+    });
+    const planStep = await apiClient.createWorkflowStep(workflow.id, "Plan", 1);
+    await apiClient.createTask(seedData.workspaceId, "Stable Fallback Plan Task", {
+      workflow_id: workflow.id,
+      workflow_step_id: planStep.id,
+    });
+    await apiClient.saveUserSettings({
+      workspace_id: seedData.workspaceId,
+      workflow_filter_id: workflow.id,
+    });
+
+    const mobile = new MobileKanbanPage(testPage);
+    await mobile.goto();
+
+    await expect(mobile.boardNavigator).toContainText("Plan");
+    await expect(mobile.taskCardByTitle("Stable Fallback Plan Task")).toBeInViewport();
+
+    await apiClient.createTask(seedData.workspaceId, "Live Todo Task", {
+      workflow_id: workflow.id,
+      workflow_step_id: todoStep.id,
+    });
+
+    await expect(mobile.taskCardByTitle("Live Todo Task")).toBeAttached();
+    await expect(mobile.boardNavigator).toContainText("Plan");
+    await expect(mobile.taskCardByTitle("Stable Fallback Plan Task")).toBeInViewport();
+    await expect(mobile.taskCardByTitle("Live Todo Task")).not.toBeInViewport();
+  });
+
   test("step drawer allows switching between workflow steps", async ({
     testPage,
     apiClient,

--- a/apps/web/lib/kanban/mobile-column-index.test.ts
+++ b/apps/web/lib/kanban/mobile-column-index.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { getInitialColumnIndex, resolveMobileColumnIndex } from "./mobile-column-index";
+
+const steps = [{ id: "todo" }, { id: "plan" }, { id: "done" }];
+
+describe("getInitialColumnIndex", () => {
+  it("returns 0 when there are no steps", () => {
+    expect(getInitialColumnIndex([], [{ workflowStepId: "plan" }])).toBe(0);
+  });
+
+  it("returns the first step that has tasks", () => {
+    expect(
+      getInitialColumnIndex(steps, [{ workflowStepId: "plan" }, { workflowStepId: "done" }]),
+    ).toBe(1);
+  });
+
+  it("returns 0 when no step has tasks", () => {
+    expect(getInitialColumnIndex(steps, [])).toBe(0);
+  });
+});
+
+describe("resolveMobileColumnIndex", () => {
+  it("restores the stored step when it is still present", () => {
+    expect(resolveMobileColumnIndex(steps, [{ workflowStepId: "todo" }], "plan")).toBe(1);
+  });
+
+  it("falls back when the stored step id is missing", () => {
+    expect(resolveMobileColumnIndex(steps, [{ workflowStepId: "done" }], undefined)).toBe(2);
+  });
+
+  it("falls back when the stored step id is no longer in the board", () => {
+    expect(resolveMobileColumnIndex(steps, [{ workflowStepId: "todo" }], "deleted")).toBe(0);
+  });
+
+  it("returns 0 for an empty step list", () => {
+    expect(resolveMobileColumnIndex([], [{ workflowStepId: "plan" }], "plan")).toBe(0);
+  });
+});

--- a/apps/web/lib/kanban/mobile-column-index.ts
+++ b/apps/web/lib/kanban/mobile-column-index.ts
@@ -1,0 +1,26 @@
+type StepLike = { id: string };
+type TaskLike = { workflowStepId?: string };
+
+/** First step that currently has tasks, or 0 when the board is empty. */
+export function getInitialColumnIndex(steps: StepLike[], tasks: TaskLike[]): number {
+  if (steps.length === 0) return 0;
+  const idx = steps.findIndex((step) => tasks.some((t) => t.workflowStepId === step.id));
+  return idx !== -1 ? idx : 0;
+}
+
+/**
+ * Resolve the mobile column index from a stored workflow-step id.
+ * Falls back to the first occupied step when the id is missing or stale.
+ */
+export function resolveMobileColumnIndex(
+  steps: StepLike[],
+  tasks: TaskLike[],
+  storedStepId: string | undefined,
+): number {
+  if (steps.length === 0) return 0;
+  if (storedStepId) {
+    const storedIndex = steps.findIndex((step) => step.id === storedStepId);
+    if (storedIndex !== -1) return storedIndex;
+  }
+  return getInitialColumnIndex(steps, tasks);
+}

--- a/apps/web/lib/state/slices/ui/types.ts
+++ b/apps/web/lib/state/slices/ui/types.ts
@@ -38,7 +38,8 @@ export type ConnectionState = {
 };
 
 export type MobileKanbanState = {
-  activeColumnIndex: number;
+  /** Last selected workflow step id, keyed by workflow id (phone board). */
+  activeStepIdByWorkflowId: Record<string, string>;
   isMenuOpen: boolean;
   isSearchOpen: boolean;
 };
@@ -215,7 +216,7 @@ export type UISliceActions = {
   setRightPanelActiveTab: (sessionId: string, tab: string) => void;
   setConnectionStatus: (status: ConnectionState["status"], error?: string | null) => void;
   setConnectionIssueSeverity: (severity: ConnectionIssueSeverity) => void;
-  setMobileKanbanColumnIndex: (index: number) => void;
+  setMobileKanbanActiveStep: (workflowId: string, stepId: string) => void;
   setMobileKanbanMenuOpen: (open: boolean) => void;
   setMobileKanbanSearchOpen: (open: boolean) => void;
   setMobileSessionPanel: (sessionId: string, panel: MobileSessionPanel) => void;

--- a/apps/web/lib/state/slices/ui/ui-slice.test.ts
+++ b/apps/web/lib/state/slices/ui/ui-slice.test.ts
@@ -71,6 +71,20 @@ describe("mobile merge request review selection", () => {
   });
 });
 
+describe("mobile kanban active step", () => {
+  it("stores the selected step id per workflow without clobbering others", () => {
+    const store = makeStore();
+    store.getState().setMobileKanbanActiveStep("wf-a", "plan");
+    store.getState().setMobileKanbanActiveStep("wf-b", "review");
+    store.getState().setMobileKanbanActiveStep("wf-a", "done");
+
+    expect(store.getState().mobileKanban.activeStepIdByWorkflowId).toEqual({
+      "wf-a": "done",
+      "wf-b": "review",
+    });
+  });
+});
+
 describe("toggleSubtaskCollapsed", () => {
   beforeEach(() => {
     window.sessionStorage.clear();

--- a/apps/web/lib/state/slices/ui/ui-slice.ts
+++ b/apps/web/lib/state/slices/ui/ui-slice.ts
@@ -81,7 +81,7 @@ export const defaultUIState: UISliceState = {
   rightPanel: { activeTabBySessionId: {} },
   diffs: { files: [] },
   connection: { status: "disconnected", error: null, issueSeverity: "none" },
-  mobileKanban: { activeColumnIndex: 0, isMenuOpen: false, isSearchOpen: false },
+  mobileKanban: { activeStepIdByWorkflowId: {}, isMenuOpen: false, isSearchOpen: false },
   mobileSession: {
     activePanelBySessionId: {},
     reviewMRKeyBySessionId: {},
@@ -168,9 +168,9 @@ function buildPreviewActions(set: ImmerSet) {
 /** Builds the mobile Kanban view's column-index, menu, and search-open actions. */
 function buildMobileActions(set: ImmerSet) {
   return {
-    setMobileKanbanColumnIndex: (index: number) =>
+    setMobileKanbanActiveStep: (workflowId: string, stepId: string) =>
       set((draft) => {
-        draft.mobileKanban.activeColumnIndex = index;
+        draft.mobileKanban.activeStepIdByWorkflowId[workflowId] = stepId;
       }),
     setMobileKanbanMenuOpen: (open: boolean) =>
       set((draft) => {

--- a/apps/web/lib/state/store.ts
+++ b/apps/web/lib/state/store.ts
@@ -321,7 +321,7 @@ export type AppState = KanbanSlice & {
   setConnectionIssueSeverity: (
     severity: import("@/lib/types/connection").ConnectionIssueSeverity,
   ) => void;
-  setMobileKanbanColumnIndex: (index: number) => void;
+  setMobileKanbanActiveStep: (workflowId: string, stepId: string) => void;
   setMobileKanbanMenuOpen: (open: boolean) => void;
   setMobileKanbanSearchOpen: (open: boolean) => void;
   setMobileSessionPanel: (sessionId: string, panel: UISliceTypes.MobileSessionPanel) => void;


### PR DESCRIPTION
Mobile kanban kept the active workflow step in component-local state, so leaving a task and returning always re-initialized to the first step that had cards. Persist the selected step id per workflow in the UI store so Back restores the same board position.

## Validation

- `cd apps/web && pnpm exec vitest run lib/kanban/mobile-column-index.test.ts lib/state/slices/ui/ui-slice.test.ts`
- `cd apps && pnpm --filter @kandev/web exec eslint` on touched files
- `pnpm e2e:run --project mobile-chrome tests/kanban/mobile-kanban.spec.ts -- --grep "restores the selected workflow step"`
- Manual phone-width check on isolated `make dev` (`.kandev-dev`): Plan → open task → Back → still Plan

## Demo (before / after)

### Before — returning from a task resets to Todo


https://github.com/user-attachments/assets/d32c42cc-8a25-4511-b581-366b33eb8d8c


### After — returning from a task stays on Plan


https://github.com/user-attachments/assets/ac214d78-358b-4d81-9838-92d776f900de


## Possible Improvements

Low risk: in-memory only (lost on full reload). Acceptable for this bug; preference persistence can wait.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have manually tested my changes and they work as expected.
- [x] My changes have tests that cover the new functionality and edge cases.
- [x] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [x] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.

No public docs change — phone board column restore is client UI state only.

Closes #2188


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2189?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
