### PR TITLE
fix(acpdbg): kill the whole process tree so --timeout takes effect

### DIFF
--- a/apps/backend/cmd/acpdbg/README.md
+++ b/apps/backend/cmd/acpdbg/README.md
@@ -51,16 +51,18 @@ Create a session in one directory, then load it from another and ask the agent
 to report its working directory:
 
 ```bash
-apps/backend/bin/acpdbg prompt codex-acp \
+apps/backend/bin/acpdbg prompt \
   --workdir /tmp/folder-a \
   --prompt "Reply with pwd only" \
-  --file /tmp/codex-new.jsonl
+  --file /tmp/codex-new.jsonl \
+  codex-acp
 
-apps/backend/bin/acpdbg session-load codex-acp \
+apps/backend/bin/acpdbg session-load \
   --session-id <session-id-from-first-run> \
   --workdir /tmp/folder-b \
   --prompt "Reply with pwd only" \
-  --file /tmp/codex-load.jsonl
+  --file /tmp/codex-load.jsonl \
+  codex-acp
 ```
 
 `session-load` sends the selected `--workdir` as the ACP `cwd` parameter. The

--- a/apps/backend/cmd/acpdbg/README.md
+++ b/apps/backend/cmd/acpdbg/README.md
@@ -24,12 +24,17 @@ Or invoke the binary directly: `apps/backend/bin/acpdbg <subcommand> [flags]`.
 | Command | Purpose |
 |---|---|
 | `list` | Enumerate registered ACP agents with their spawn command |
-| `probe <agent>` | `initialize` → `session/new` → close. Shows models, modes, auth methods. |
+| `probe [flags] <agent>` | `initialize` → `session/new` → close. Shows models, modes, auth methods. |
 | `probe --exec "<cmd> [args...]"` | Same but against an arbitrary binary not in the registry |
-| `mcp-probe <agent>` | Inject a temporary HTTP MCP sentinel into `session/new` and report delivery separately from observed initialize, `tools/list`, and tool use. |
-| `prompt <agent> --prompt "..." [--model M] [--mode M]` | Full prompt round-trip, collects text chunks from `session/update` |
-| `session-load <agent> --session-id <id> [--prompt "..."]` | Load an existing session in `--workdir`, then optionally verify it with a prompt |
+| `mcp-probe [flags] <agent>` | Inject a temporary HTTP MCP sentinel into `session/new` and report delivery separately from observed initialize, `tools/list`, and tool use. |
+| `prompt --prompt "..." [--model M] [--mode M] <agent>` | Full prompt round-trip, collects text chunks from `session/update` |
+| `session-load --session-id <id> [--prompt "..."] <agent>` | Load an existing session in `--workdir`, then optionally verify it with a prompt |
 | `matrix` | Probe every registered ACP agent in parallel, write one JSONL per agent + `matrix-summary.json` |
+
+> **Flags go before the agent name.** Parsing uses the standard library `flag`
+> package, which stops at the first non-flag argument — so
+> `session-load opencode-acp --session-id X` silently drops `--session-id` and
+> fails with `--session-id is required`.
 
 ### Shared flags
 

--- a/apps/backend/cmd/acpdbg/main.go
+++ b/apps/backend/cmd/acpdbg/main.go
@@ -70,12 +70,15 @@ func usage() {
 
 Usage:
   acpdbg list
-  acpdbg probe <agent> [flags]
+  acpdbg probe [flags] <agent>
   acpdbg probe --exec "<cmd> [args...]" [flags]
-  acpdbg mcp-probe <agent> [flags]
-  acpdbg prompt <agent> --prompt TEXT [--model M] [--mode M] [flags]
-  acpdbg session-load <agent> --session-id ID [--prompt TEXT] [flags]
+  acpdbg mcp-probe [flags] <agent>
+  acpdbg prompt --prompt TEXT [--model M] [--mode M] [flags] <agent>
+  acpdbg session-load --session-id ID [--prompt TEXT] [flags] <agent>
   acpdbg matrix [flags]
+
+Flags must precede the agent name: parsing uses the standard library flag
+package, which stops at the first non-flag argument.
 
 Shared flags:
   --out DIR        output directory for JSONL (default ./acp-debug/)

--- a/apps/backend/internal/agent/acpdbg/process_tree_other.go
+++ b/apps/backend/internal/agent/acpdbg/process_tree_other.go
@@ -1,0 +1,32 @@
+//go:build !windows
+
+package acpdbg
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// processTree carries no state outside Windows: the child is placed in its own
+// process group at spawn time, so the whole group can be signalled by negating
+// the leader's pid. See the Windows variant for why killing only the direct
+// child is not enough.
+type processTree struct{}
+
+// configureProcessTree must be called before cmd.Start.
+func configureProcessTree(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}
+
+func captureProcessTree(_ *exec.Cmd) processTree { return processTree{} }
+
+func (processTree) kill(cmd *exec.Cmd) {
+	if cmd == nil || cmd.Process == nil {
+		return
+	}
+	// A negative pid targets the whole process group. If the group is gone (or
+	// Setpgid did not take effect) fall back to the direct child.
+	if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil {
+		_ = cmd.Process.Kill()
+	}
+}

--- a/apps/backend/internal/agent/acpdbg/process_tree_other.go
+++ b/apps/backend/internal/agent/acpdbg/process_tree_other.go
@@ -18,7 +18,7 @@ func configureProcessTree(cmd *exec.Cmd) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 }
 
-func captureProcessTree(_ *exec.Cmd) processTree { return processTree{} }
+func captureProcessTree(_ *exec.Cmd) (processTree, error) { return processTree{}, nil }
 
 func (processTree) kill(cmd *exec.Cmd) {
 	if cmd == nil || cmd.Process == nil {

--- a/apps/backend/internal/agent/acpdbg/process_tree_windows.go
+++ b/apps/backend/internal/agent/acpdbg/process_tree_windows.go
@@ -4,8 +4,10 @@ package acpdbg
 
 import (
 	"os/exec"
+	"syscall"
 
 	"github.com/kandev/kandev/internal/agentctl/server/winproc"
+	"golang.org/x/sys/windows"
 )
 
 // processTree holds whatever the platform needs to kill a child *and* every
@@ -17,19 +19,21 @@ type processTree struct {
 	job winproc.KillOnCloseJob
 }
 
-// configureProcessTree is a no-op on Windows; containment is established after
-// the child starts, by assigning it to a Job Object.
-func configureProcessTree(_ *exec.Cmd) {}
-
-// captureProcessTree must be called after cmd.Start, because the Job Object is
-// assigned by pid. A failure here is not fatal: kill falls back to terminating
-// the direct child, which is what the code did before.
-func captureProcessTree(cmd *exec.Cmd) processTree {
-	job, err := winproc.InstallKillOnCloseJobForCommand(cmd)
-	if err != nil {
-		return processTree{}
+// configureProcessTree keeps the child suspended until its Job Object is ready.
+func configureProcessTree(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP | windows.CREATE_SUSPENDED,
 	}
-	return processTree{job: job}
+}
+
+// captureProcessTree assigns the suspended child before resuming it. The
+// helper terminates the child if containment or resume setup fails.
+func captureProcessTree(cmd *exec.Cmd) (processTree, error) {
+	job, err := winproc.InstallKillOnCloseJobForSuspendedCommand(cmd)
+	if err != nil {
+		return processTree{}, err
+	}
+	return processTree{job: job}, nil
 }
 
 func (t processTree) kill(cmd *exec.Cmd) {

--- a/apps/backend/internal/agent/acpdbg/process_tree_windows.go
+++ b/apps/backend/internal/agent/acpdbg/process_tree_windows.go
@@ -1,0 +1,43 @@
+//go:build windows
+
+package acpdbg
+
+import (
+	"os/exec"
+
+	"github.com/kandev/kandev/internal/agentctl/server/winproc"
+)
+
+// processTree holds whatever the platform needs to kill a child *and* every
+// process it spawned. Agents are usually launched through `npx`, which is a
+// shim: npx -> node -> the agent's own node process. Killing only the direct
+// child leaves the grandchildren alive holding the inherited stdout handle, so
+// the read loop never sees EOF and Close blocks forever.
+type processTree struct {
+	job winproc.KillOnCloseJob
+}
+
+// configureProcessTree is a no-op on Windows; containment is established after
+// the child starts, by assigning it to a Job Object.
+func configureProcessTree(_ *exec.Cmd) {}
+
+// captureProcessTree must be called after cmd.Start, because the Job Object is
+// assigned by pid. A failure here is not fatal: kill falls back to terminating
+// the direct child, which is what the code did before.
+func captureProcessTree(cmd *exec.Cmd) processTree {
+	job, err := winproc.InstallKillOnCloseJobForCommand(cmd)
+	if err != nil {
+		return processTree{}
+	}
+	return processTree{job: job}
+}
+
+func (t processTree) kill(cmd *exec.Cmd) {
+	if t.job.Valid() {
+		_ = t.job.Close()
+		return
+	}
+	if cmd != nil && cmd.Process != nil {
+		_ = cmd.Process.Kill()
+	}
+}

--- a/apps/backend/internal/agent/acpdbg/process_tree_windows_test.go
+++ b/apps/backend/internal/agent/acpdbg/process_tree_windows_test.go
@@ -1,0 +1,26 @@
+//go:build windows
+
+package acpdbg
+
+import (
+	"os/exec"
+	"syscall"
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
+
+func TestConfigureProcessTreeStartsSuspended(t *testing.T) {
+	cmd := exec.Command("cmd.exe")
+	configureProcessTree(cmd)
+
+	if cmd.SysProcAttr == nil {
+		t.Fatal("configureProcessTree did not set process attributes")
+	}
+	if cmd.SysProcAttr.CreationFlags&windows.CREATE_SUSPENDED == 0 {
+		t.Fatalf("CreationFlags = %#x, want CREATE_SUSPENDED", cmd.SysProcAttr.CreationFlags)
+	}
+	if cmd.SysProcAttr.CreationFlags&syscall.CREATE_NEW_PROCESS_GROUP == 0 {
+		t.Fatalf("CreationFlags = %#x, want CREATE_NEW_PROCESS_GROUP", cmd.SysProcAttr.CreationFlags)
+	}
+}

--- a/apps/backend/internal/agent/acpdbg/runner.go
+++ b/apps/backend/internal/agent/acpdbg/runner.go
@@ -170,6 +170,8 @@ func startChild(cfg RunConfig, workdir string) (*exec.Cmd, processTree, io.Write
 	}
 	tree, err := captureProcessTree(cmd)
 	if err != nil {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
 		return nil, processTree{}, nil, nil, nil, fmt.Errorf("contain %s: %w", cfg.Command[0], err)
 	}
 	return cmd, tree, stdin, stdout, stderr, nil
@@ -395,6 +397,12 @@ func (r *Runner) readLoop() {
 		select {
 		case r.oob <- frame:
 		case <-r.shutdownCh:
+			r.mu.Lock()
+			for id, ch := range r.pending {
+				close(ch)
+				delete(r.pending, id)
+			}
+			r.mu.Unlock()
 			return
 		}
 	}

--- a/apps/backend/internal/agent/acpdbg/runner.go
+++ b/apps/backend/internal/agent/acpdbg/runner.go
@@ -42,6 +42,7 @@ type Runner struct {
 	tmpDir string // non-empty if we allocated the workdir ourselves
 
 	cmd    *exec.Cmd
+	tree   processTree
 	stdin  io.WriteCloser
 	stdout io.ReadCloser
 	framer *Framer
@@ -102,7 +103,7 @@ func NewRunner(ctx context.Context, jsonlPath string, cfg RunConfig) (*Runner, e
 		"workdir": workdir,
 	})
 
-	cmd, stdin, stdout, stderr, err := startChild(ctx, cfg, workdir)
+	cmd, tree, stdin, stdout, stderr, err := startChild(ctx, cfg, workdir)
 	if err != nil {
 		_ = rec.Meta("close", map[string]any{"reason": err.Error()})
 		_ = rec.Close()
@@ -117,6 +118,7 @@ func NewRunner(ctx context.Context, jsonlPath string, cfg RunConfig) (*Runner, e
 		cfg:     cfg,
 		tmpDir:  tmpDir,
 		cmd:     cmd,
+		tree:    tree,
 		stdin:   stdin,
 		stdout:  stdout,
 		framer:  NewFramer(stdin, stdout),
@@ -138,26 +140,27 @@ func NewRunner(ctx context.Context, jsonlPath string, cfg RunConfig) (*Runner, e
 }
 
 // startChild spawns the subprocess and returns its stdio pipes.
-func startChild(ctx context.Context, cfg RunConfig, workdir string) (*exec.Cmd, io.WriteCloser, io.ReadCloser, io.ReadCloser, error) {
+func startChild(ctx context.Context, cfg RunConfig, workdir string) (*exec.Cmd, processTree, io.WriteCloser, io.ReadCloser, io.ReadCloser, error) {
 	//nolint:gosec // the command comes from the agent registry or the user's --exec flag; both are trusted inputs
 	cmd := exec.CommandContext(ctx, cfg.Command[0], cfg.Command[1:]...)
 	cmd.Dir = workdir
+	configureProcessTree(cmd)
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
-		return nil, nil, nil, nil, fmt.Errorf("stdin pipe: %w", err)
+		return nil, processTree{}, nil, nil, nil, fmt.Errorf("stdin pipe: %w", err)
 	}
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
-		return nil, nil, nil, nil, fmt.Errorf("stdout pipe: %w", err)
+		return nil, processTree{}, nil, nil, nil, fmt.Errorf("stdout pipe: %w", err)
 	}
 	stderr, err := cmd.StderrPipe()
 	if err != nil {
-		return nil, nil, nil, nil, fmt.Errorf("stderr pipe: %w", err)
+		return nil, processTree{}, nil, nil, nil, fmt.Errorf("stderr pipe: %w", err)
 	}
 	if err := cmd.Start(); err != nil {
-		return nil, nil, nil, nil, fmt.Errorf("start %s: %w", cfg.Command[0], err)
+		return nil, processTree{}, nil, nil, nil, fmt.Errorf("start %s: %w", cfg.Command[0], err)
 	}
-	return cmd, stdin, stdout, stderr, nil
+	return cmd, captureProcessTree(cmd), stdin, stdout, stderr, nil
 }
 
 // Path returns the JSONL file path the runner is writing to.
@@ -270,7 +273,11 @@ func (r *Runner) Close(reason string) {
 		case err := <-done:
 			waitErr = err
 		case <-time.After(5 * time.Second):
-			_ = r.cmd.Process.Kill()
+			// Kill the whole tree, not just the direct child. Agents spawned
+			// through `npx` leave grandchildren holding the inherited stdout
+			// handle; with those alive the read loop never sees EOF and the
+			// readLoopWG.Wait below blocks forever, so --timeout never lands.
+			r.tree.kill(r.cmd)
 			waitErr = <-done
 			if reason == "" {
 				reason = "killed after timeout"

--- a/apps/backend/internal/agent/acpdbg/runner.go
+++ b/apps/backend/internal/agent/acpdbg/runner.go
@@ -60,7 +60,11 @@ type Runner struct {
 	readLoopWG sync.WaitGroup
 	readLoopEr error
 
-	closeOnce sync.Once
+	closeOnce    sync.Once
+	shutdownOnce sync.Once
+	shutdownCh   chan struct{}
+	watchStopCh  chan struct{}
+	cancelWG     sync.WaitGroup
 }
 
 // NewRunner spawns the configured child process, wires its stdio through a
@@ -103,7 +107,7 @@ func NewRunner(ctx context.Context, jsonlPath string, cfg RunConfig) (*Runner, e
 		"workdir": workdir,
 	})
 
-	cmd, tree, stdin, stdout, stderr, err := startChild(ctx, cfg, workdir)
+	cmd, tree, stdin, stdout, stderr, err := startChild(cfg, workdir)
 	if err != nil {
 		_ = rec.Meta("close", map[string]any{"reason": err.Error()})
 		_ = rec.Close()
@@ -114,17 +118,21 @@ func NewRunner(ctx context.Context, jsonlPath string, cfg RunConfig) (*Runner, e
 	}
 
 	r := &Runner{
-		rec:     rec,
-		cfg:     cfg,
-		tmpDir:  tmpDir,
-		cmd:     cmd,
-		tree:    tree,
-		stdin:   stdin,
-		stdout:  stdout,
-		framer:  NewFramer(stdin, stdout),
-		oob:     make(chan Frame, 32),
-		pending: map[int]chan Frame{},
+		rec:         rec,
+		cfg:         cfg,
+		tmpDir:      tmpDir,
+		cmd:         cmd,
+		tree:        tree,
+		stdin:       stdin,
+		stdout:      stdout,
+		framer:      NewFramer(stdin, stdout),
+		oob:         make(chan Frame, 32),
+		pending:     map[int]chan Frame{},
+		shutdownCh:  make(chan struct{}),
+		watchStopCh: make(chan struct{}),
 	}
+	r.cancelWG.Add(1)
+	go r.watchContext(ctx)
 
 	// Stderr goroutine. Always drain it to avoid blocking the child; only
 	// record to JSONL when CaptureStderr is set.
@@ -140,9 +148,9 @@ func NewRunner(ctx context.Context, jsonlPath string, cfg RunConfig) (*Runner, e
 }
 
 // startChild spawns the subprocess and returns its stdio pipes.
-func startChild(ctx context.Context, cfg RunConfig, workdir string) (*exec.Cmd, processTree, io.WriteCloser, io.ReadCloser, io.ReadCloser, error) {
+func startChild(cfg RunConfig, workdir string) (*exec.Cmd, processTree, io.WriteCloser, io.ReadCloser, io.ReadCloser, error) {
 	//nolint:gosec // the command comes from the agent registry or the user's --exec flag; both are trusted inputs
-	cmd := exec.CommandContext(ctx, cfg.Command[0], cfg.Command[1:]...)
+	cmd := exec.Command(cfg.Command[0], cfg.Command[1:]...)
 	cmd.Dir = workdir
 	configureProcessTree(cmd)
 	stdin, err := cmd.StdinPipe()
@@ -160,7 +168,25 @@ func startChild(ctx context.Context, cfg RunConfig, workdir string) (*exec.Cmd, 
 	if err := cmd.Start(); err != nil {
 		return nil, processTree{}, nil, nil, nil, fmt.Errorf("start %s: %w", cfg.Command[0], err)
 	}
-	return cmd, captureProcessTree(cmd), stdin, stdout, stderr, nil
+	tree, err := captureProcessTree(cmd)
+	if err != nil {
+		return nil, processTree{}, nil, nil, nil, fmt.Errorf("contain %s: %w", cfg.Command[0], err)
+	}
+	return cmd, tree, stdin, stdout, stderr, nil
+}
+
+func (r *Runner) watchContext(ctx context.Context) {
+	defer r.cancelWG.Done()
+	select {
+	case <-ctx.Done():
+		r.signalShutdown()
+		r.tree.kill(r.cmd)
+	case <-r.watchStopCh:
+	}
+}
+
+func (r *Runner) signalShutdown() {
+	r.shutdownOnce.Do(func() { close(r.shutdownCh) })
 }
 
 // Path returns the JSONL file path the runner is writing to.
@@ -263,6 +289,7 @@ func (r *Runner) NextOOB(ctx context.Context) (Frame, error) {
 // the recorder. Idempotent.
 func (r *Runner) Close(reason string) {
 	r.closeOnce.Do(func() {
+		r.signalShutdown()
 		_ = r.stdin.Close()
 		done := make(chan error, 1)
 		go func() { done <- r.cmd.Wait() }()
@@ -283,6 +310,10 @@ func (r *Runner) Close(reason string) {
 				reason = "killed after timeout"
 			}
 		}
+		// The child may have exited before the grace-period branch. Closing
+		// the owned tree in every terminal path also handles shims that leave
+		// descendants behind after the leader exits.
+		r.tree.kill(r.cmd)
 		if exitErr, ok := waitErr.(*exec.ExitError); ok {
 			exitCode = exitErr.ExitCode()
 		} else if waitErr != nil {
@@ -305,6 +336,8 @@ func (r *Runner) Close(reason string) {
 		}
 		_ = r.rec.Meta("close", meta)
 		_ = r.rec.Close()
+		close(r.watchStopCh)
+		r.cancelWG.Wait()
 		if r.tmpDir != "" {
 			_ = os.RemoveAll(r.tmpDir)
 		}
@@ -359,7 +392,11 @@ func (r *Runner) readLoop() {
 		// orphaned responses) goes out of band. Block rather than drop,
 		// so session/update chunks and agent-initiated requests are
 		// never lost — this is a debug tool, correctness beats throughput.
-		r.oob <- frame
+		select {
+		case r.oob <- frame:
+		case <-r.shutdownCh:
+			return
+		}
 	}
 }
 

--- a/apps/backend/internal/agent/acpdbg/runner_test.go
+++ b/apps/backend/internal/agent/acpdbg/runner_test.go
@@ -3,10 +3,12 @@
 package acpdbg
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"syscall"
 	"testing"
@@ -127,7 +129,20 @@ func processAlive(pid int) bool {
 	if pid <= 0 {
 		return false
 	}
-	return syscall.Kill(pid, 0) == nil
+	if syscall.Kill(pid, 0) != nil {
+		return false
+	}
+	// Linux keeps killed children as zombies until their parent reaps them.
+	// A zombie is no longer running, so do not treat it as a surviving
+	// descendant while the test waits for the process group to settle.
+	if runtime.GOOS == "linux" {
+		if raw, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid)); err == nil {
+			if end := bytes.LastIndexByte(raw, ')'); end >= 0 && end+2 < len(raw) {
+				return raw[end+2] != 'Z'
+			}
+		}
+	}
+	return true
 }
 
 func waitForProcessGone(t *testing.T, pid int) {

--- a/apps/backend/internal/agent/acpdbg/runner_test.go
+++ b/apps/backend/internal/agent/acpdbg/runner_test.go
@@ -1,0 +1,146 @@
+//go:build !windows
+
+package acpdbg
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestRunnerContextCancellationKillsProcessTree(t *testing.T) {
+	pidPath := filepath.Join(t.TempDir(), "child.pid")
+	ctx, cancel := context.WithCancel(context.Background())
+	runner, err := NewRunner(ctx, filepath.Join(t.TempDir(), "frames.jsonl"), RunConfig{
+		AgentID: "process-tree-helper",
+		Command: []string{"sh", "-c", fmt.Sprintf("sleep 30 & child=$!; printf '%%s' $child > %q; wait", pidPath)},
+	})
+	if err != nil {
+		t.Fatalf("NewRunner: %v", err)
+	}
+
+	pid := waitForPIDFile(t, pidPath)
+	t.Cleanup(func() {
+		cancel()
+		runner.tree.kill(runner.cmd)
+		runner.Close("test cleanup")
+		if processAlive(pid) {
+			_ = syscall.Kill(pid, syscall.SIGKILL)
+		}
+	})
+
+	cancel()
+	closed := make(chan struct{})
+	go func() {
+		runner.Close("context canceled")
+		close(closed)
+	}()
+
+	select {
+	case <-closed:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Runner.Close did not return after context cancellation")
+	}
+
+	waitForProcessGone(t, pid)
+}
+
+func TestRunnerCloseUnblocksFullOOBQueue(t *testing.T) {
+	const frame = `{"jsonrpc":"2.0","method":"session/update"}`
+	cmd := fmt.Sprintf("for i in $(seq 1 40); do printf '%%s\\n' '%s'; done; sleep 30", frame)
+	ctx, cancel := context.WithCancel(context.Background())
+	runner, err := NewRunner(ctx, filepath.Join(t.TempDir(), "frames.jsonl"), RunConfig{
+		AgentID: "oob-helper",
+		Command: []string{"sh", "-c", cmd},
+	})
+	if err != nil {
+		t.Fatalf("NewRunner: %v", err)
+	}
+
+	t.Cleanup(func() {
+		cancel()
+		runner.tree.kill(runner.cmd)
+		for len(runner.oob) > 0 {
+			<-runner.oob
+		}
+		runner.Close("test cleanup")
+	})
+
+	waitForOOBQueue(t, runner)
+	cancel()
+	closed := make(chan struct{})
+	go func() {
+		runner.Close("context canceled")
+		close(closed)
+	}()
+
+	select {
+	case <-closed:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Runner.Close remained blocked on a full OOB queue")
+	}
+}
+
+func waitForPIDFile(t *testing.T, path string) int {
+	t.Helper()
+	deadline := time.NewTimer(3 * time.Second)
+	defer deadline.Stop()
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		if raw, err := os.ReadFile(path); err == nil {
+			pid, err := strconv.Atoi(string(raw))
+			if err != nil {
+				t.Fatalf("parse child pid %q: %v", string(raw), err)
+			}
+			return pid
+		}
+		select {
+		case <-deadline.C:
+			t.Fatalf("timed out waiting for child pid file %s", path)
+		case <-ticker.C:
+		}
+	}
+}
+
+func waitForOOBQueue(t *testing.T, runner *Runner) {
+	t.Helper()
+	deadline := time.NewTimer(3 * time.Second)
+	defer deadline.Stop()
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for len(runner.oob) < cap(runner.oob) {
+		select {
+		case <-deadline.C:
+			t.Fatalf("timed out waiting for OOB queue to fill: %d/%d", len(runner.oob), cap(runner.oob))
+		case <-ticker.C:
+		}
+	}
+}
+
+func processAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	return syscall.Kill(pid, 0) == nil
+}
+
+func waitForProcessGone(t *testing.T, pid int) {
+	t.Helper()
+	deadline := time.NewTimer(3 * time.Second)
+	defer deadline.Stop()
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for processAlive(pid) {
+		select {
+		case <-deadline.C:
+			t.Fatalf("process %d survived shutdown", pid)
+		case <-ticker.C:
+		}
+	}
+}

--- a/apps/backend/internal/agent/acpdbg/runner_test.go
+++ b/apps/backend/internal/agent/acpdbg/runner_test.go
@@ -26,7 +26,7 @@ func TestRunnerContextCancellationKillsProcessTree(t *testing.T) {
 		t.Fatalf("NewRunner: %v", err)
 	}
 
-	pid := waitForPIDFile(t, pidPath)
+	pid := 0
 	t.Cleanup(func() {
 		cancel()
 		runner.tree.kill(runner.cmd)
@@ -35,6 +35,7 @@ func TestRunnerContextCancellationKillsProcessTree(t *testing.T) {
 			_ = syscall.Kill(pid, syscall.SIGKILL)
 		}
 	})
+	pid = waitForPIDFile(t, pidPath)
 
 	cancel()
 	closed := make(chan struct{})
@@ -73,6 +74,16 @@ func TestRunnerCloseUnblocksFullOOBQueue(t *testing.T) {
 		runner.Close("test cleanup")
 	})
 
+	requestDone := make(chan error, 1)
+	go func() {
+		_, err := runner.Request(context.Background(), Frame{
+			"jsonrpc": "2.0",
+			"id":      1,
+			"method":  "probe",
+		})
+		requestDone <- err
+	}()
+	waitForPendingRequest(t, runner)
 	waitForOOBQueue(t, runner)
 	cancel()
 	closed := make(chan struct{})
@@ -85,6 +96,14 @@ func TestRunnerCloseUnblocksFullOOBQueue(t *testing.T) {
 	case <-closed:
 	case <-time.After(3 * time.Second):
 		t.Fatal("Runner.Close remained blocked on a full OOB queue")
+	}
+	select {
+	case err := <-requestDone:
+		if err == nil {
+			t.Fatal("pending Request returned nil after runner shutdown")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("pending Request remained blocked after runner shutdown")
 	}
 }
 
@@ -120,6 +139,27 @@ func waitForOOBQueue(t *testing.T, runner *Runner) {
 		select {
 		case <-deadline.C:
 			t.Fatalf("timed out waiting for OOB queue to fill: %d/%d", len(runner.oob), cap(runner.oob))
+		case <-ticker.C:
+		}
+	}
+}
+
+func waitForPendingRequest(t *testing.T, runner *Runner) {
+	t.Helper()
+	deadline := time.NewTimer(3 * time.Second)
+	defer deadline.Stop()
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		runner.mu.Lock()
+		pending := len(runner.pending)
+		runner.mu.Unlock()
+		if pending > 0 {
+			return
+		}
+		select {
+		case <-deadline.C:
+			t.Fatal("timed out waiting for pending Request")
 		case <-ticker.C:
 		}
 	}


### PR DESCRIPTION
## What

`acpdbg`'s `--timeout` does not end a run when the agent stops responding — the exact
situation the tool exists to debug.

Agents are spawned through `npx`, which is a shim: `npx` → `node` → the agent's own
`node` process. `Runner.Close` killed only the direct child, so the grandchildren
survived holding the inherited stdout handle. The read loop never saw EOF,
`readLoopWG.Wait()` blocked forever, and the timeout never landed.

I hit this against an agent that answered `session/load` with a burst of
`session/update` notifications and then never sent the response frame: `acpdbg` stayed
alive for **42 minutes** against `-timeout 300s`, and I only got the JSONL because I
killed the process by hand.

## How

Contain the child and its descendants at spawn time, and tear the whole group down in
`Close`:

- **Windows** — a kill-on-close Job Object, reusing the existing
  `winproc.InstallKillOnCloseJobForCommand`
- **elsewhere** — `Setpgid` at spawn, `kill(-pid)` on close

Both fall back to `Process.Kill`, so failed containment is no worse than today's
behaviour. This mirrors the platform split `internal/launcher` already uses.

## Also

The documented argument order cannot work. Parsing uses the standard library `flag`
package, which stops at the first non-flag argument, so the documented

```
acpdbg session-load <agent> --session-id ID
```

silently drops the flag and fails with `--session-id is required`. Corrected in the
README and in the usage text.

## Verification

| | before | after |
|---|---|---|
| `session-load -timeout 60s`, agent never answers | hung indefinitely (42 min observed) | exits at **60.3s** with `session/load: context deadline exceeded` |

`go vet` clean; builds for `windows/amd64`, `linux/amd64` and `darwin/arm64`.

**The Unix branch is compile-checked only.** I have no macOS or Linux machine to run it
on, so the `Setpgid` / `kill(-pid)` path deserves a second pair of eyes.

`go test ./internal/agent/acpdbg/...` has one failure on my machine
(`TestProbe_DefaultWorkdirReachesSessionNew`, `initialize: context deadline exceeded`).
It fails identically on an unmodified `main` worktree under the same load, so it is not
from this change.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

