### PR TITLE
fix(hostutility): cap concurrent agent bootstraps so a cold sweep can finish

### DIFF
--- a/apps/backend/internal/agent/hostutility/manager.go
+++ b/apps/backend/internal/agent/hostutility/manager.go
@@ -130,6 +130,7 @@ func (m *Manager) Start(ctx context.Context) error {
 	}
 
 	g, gctx := errgroup.WithContext(startCtx)
+	g.SetLimit(maxConcurrentBootstraps)
 	for _, ag := range targets {
 		ag := ag
 		g.Go(func() error {
@@ -519,6 +520,18 @@ func (m *Manager) dropStaleInstance(ctx context.Context, agentType string, inst 
 // quickly. Without this bound the only ceiling is the 5-minute HTTP client
 // timeout on the agentctl call.
 const probeTimeout = 60 * time.Second
+
+// maxConcurrentBootstraps caps how many agents are warmed and probed at once at
+// boot. Unbounded, every ACP-capable agent starts together, and each spawns its
+// runtime through `npx -y <package>`, which installs the package when missing.
+// On a cold npm cache they starve each other: measured on Windows with five
+// installed agents, every probe hit the 60s probeTimeout and none succeeded,
+// while the same five capped at two produced two usable results.
+//
+// With a warm cache the cap makes no measurable difference, so this is not a
+// speed-up — it stops a cold sweep from failing wholesale and leaving the
+// capability cache empty for every agent.
+const maxConcurrentBootstraps = 2
 
 // probe runs an ACP probe against the given instance and translates the result
 // into an AgentCapabilities record suitable for the cache.

--- a/apps/backend/internal/agent/hostutility/manager_test.go
+++ b/apps/backend/internal/agent/hostutility/manager_test.go
@@ -242,6 +242,111 @@ func TestStopCancelsInFlightBootstrap(t *testing.T) {
 	}
 }
 
+func TestStartLimitsConcurrentBootstraps(t *testing.T) {
+	log := newTestLogger(t)
+	reg := registry.NewRegistry(log)
+	started := make(chan string, 8)
+	release := make(chan struct{})
+	var active atomic.Int32
+	var peak atomic.Int32
+	var attempted atomic.Int32
+
+	for i := 0; i < maxConcurrentBootstraps+2; i++ {
+		ag := &trackingInferenceAgent{
+			installedInferenceAgent: installedInferenceAgent{id: "tracking-acp-" + strconv.Itoa(i)},
+			started:                 started,
+			release:                 release,
+			active:                  &active,
+			peak:                    &peak,
+			attempted:               &attempted,
+		}
+		require.NoError(t, reg.Register(ag))
+	}
+
+	mgr := NewManager(reg, "127.0.0.1", 1, nil, log)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- mgr.Start(ctx) }()
+
+	waitForStartedAgents(t, started, maxConcurrentBootstraps)
+	require.LessOrEqual(t, peak.Load(), int32(maxConcurrentBootstraps))
+	close(release)
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("host utility bootstrap did not finish after releasing agents")
+	}
+	require.Equal(t, int32(maxConcurrentBootstraps+2), attempted.Load())
+	require.LessOrEqual(t, peak.Load(), int32(maxConcurrentBootstraps))
+	mgr.Stop(context.Background())
+}
+
+func TestStopCancelsQueuedBootstrap(t *testing.T) {
+	log := newTestLogger(t)
+	reg := registry.NewRegistry(log)
+	started := make(chan string, 8)
+	canceled := make(chan string, 8)
+	var active atomic.Int32
+	var peak atomic.Int32
+	var attempted atomic.Int32
+
+	for i := 0; i < maxConcurrentBootstraps+2; i++ {
+		ag := &trackingInferenceAgent{
+			installedInferenceAgent: installedInferenceAgent{id: "queued-acp-" + strconv.Itoa(i)},
+			started:                 started,
+			canceled:                canceled,
+			active:                  &active,
+			peak:                    &peak,
+			attempted:               &attempted,
+		}
+		require.NoError(t, reg.Register(ag))
+	}
+
+	mgr := NewManager(reg, "127.0.0.1", 1, nil, log)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- mgr.Start(ctx) }()
+
+	waitForStartedAgents(t, started, maxConcurrentBootstraps)
+	mgr.Stop(context.Background())
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("host utility Start did not return after queued cancellation")
+	}
+	cancel()
+	require.Equal(t, int32(maxConcurrentBootstraps+2), attempted.Load())
+	waitForCanceledAgents(t, canceled, maxConcurrentBootstraps+2)
+	require.LessOrEqual(t, peak.Load(), int32(maxConcurrentBootstraps))
+}
+
+func waitForStartedAgents(t *testing.T, started <-chan string, count int) {
+	t.Helper()
+	for i := 0; i < count; i++ {
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			t.Fatalf("timed out waiting for bootstrap %d/%d to start", i+1, count)
+		}
+	}
+}
+
+func waitForCanceledAgents(t *testing.T, canceled <-chan string, count int) {
+	t.Helper()
+	for i := 0; i < count; i++ {
+		select {
+		case <-canceled:
+		case <-time.After(time.Second):
+			t.Fatalf("timed out waiting for bootstrap %d/%d to observe cancellation", i+1, count)
+		}
+	}
+}
+
 func TestProbePreservesConfigOptionDescriptions(t *testing.T) {
 	log := newTestLogger(t)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -629,6 +734,42 @@ type blockingInferenceAgent struct {
 	once     sync.Once
 	started  chan struct{}
 	canceled chan struct{}
+}
+
+type trackingInferenceAgent struct {
+	installedInferenceAgent
+	started   chan<- string
+	canceled  chan<- string
+	release   <-chan struct{}
+	active    *atomic.Int32
+	peak      *atomic.Int32
+	attempted *atomic.Int32
+}
+
+func (a *trackingInferenceAgent) IsInstalled(ctx context.Context) (*agents.DiscoveryResult, error) {
+	a.attempted.Add(1)
+	current := a.active.Add(1)
+	for {
+		previous := a.peak.Load()
+		if current <= previous || a.peak.CompareAndSwap(previous, current) {
+			break
+		}
+	}
+	a.started <- a.id
+	defer a.active.Add(-1)
+
+	if a.release == nil {
+		<-ctx.Done()
+		a.canceled <- a.id
+		return nil, ctx.Err()
+	}
+	select {
+	case <-a.release:
+		return &agents.DiscoveryResult{Available: false}, nil
+	case <-ctx.Done():
+		a.canceled <- a.id
+		return nil, ctx.Err()
+	}
 }
 
 func (a *blockingInferenceAgent) ID() string          { return "blocking-acp" }


### PR DESCRIPTION
## What

`hostutility.Manager.Start` fans out over every installed ACP agent with no bound. Each
probe spawns the agent's runtime through `npx -y <package>`, which **installs** the
package when it is missing, and each has a 60s `probeTimeout`.

On a cold npm cache the probes starve each other and all of them time out, leaving the
capability cache empty for every agent — no models, no modes.

## Measurement

Five installed agents, probed directly with `acpdbg` (no kandev involved), 60s timeout
each, alternating unbounded vs capped at 2, three rounds:

| round | npm cache | unbounded | capped at 2 |
|---|---|---|---|
| 1 | cold | **0 of 5** | **2 of 5** |
| 2 | warm | 1 of 5 | 1 of 5 |
| 3 | warm | 1 of 5 | 1 of 5 |

In round 1 the unbounded arm had all five probes land within 0.6s of the ceiling
(60.1 / 60.2 / 60.3 / 60.7) — total saturation. The capped arm completed all five
(15.5 / 33.2 / 0.3 / 59.0 / 57.2), two of them successfully.

Only two of the five can succeed at all on this machine; the others fail for their own
reasons (one rejected by the probe allowlist, one exits at ~15s, one fails at ~40s).
Counting only the reachable two: **unbounded 2 of 6, capped 4 of 6**.

## Scope of the claim

This is **not** a speed-up. With a warm cache the two arms are indistinguishable. It
fixes the cold case — first run after install, a fresh machine, CI — where today the
whole sweep fails.

## Trade-off

Capping serialises the sweep, so an agent that would fail instantly can now wait behind
slow ones before being attempted at all.

## Note

`2` is a conservative default, not a tuned value. I have no data for macOS or Linux,
where process spawn is far cheaper. Happy to make it configurable or key it off
`runtime.NumCPU()` if you prefer.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

