### PR TITLE
fix(web): stop unrelated task.updated events from un-nesting a subtask

### DIFF
--- a/apps/web/lib/ws/handlers/tasks.test.ts
+++ b/apps/web/lib/ws/handlers/tasks.test.ts
@@ -596,3 +596,93 @@ describe("task.updated executor preservation", () => {
     });
   });
 });
+
+describe("task.updated parent preservation", () => {
+  it("preserves parentTaskId when a partial update omits parent_id", () => {
+    // A task.updated for an unrelated field change (e.g. a title rename) must
+    // not silently un-nest a live child — only an explicit detach (parent_id:
+    // null) should clear the link. See parentIDEventField in service_tasks.go.
+    const existingTask = {
+      id: "t1",
+      workflowStepId: "step1",
+      title: "Old title",
+      position: 0,
+      primarySessionId: "session-1",
+      parentTaskId: "parent-1",
+    };
+    const store = makeStore({
+      kanban: {
+        workflowId: "wf1",
+        steps: [],
+        tasks: [existingTask],
+      } as unknown as AppState["kanban"],
+      kanbanMulti: {
+        isLoading: false,
+        snapshots: {
+          wf1: { workflowId: "wf1", workflowName: "WF1", steps: [], tasks: [existingTask] },
+        },
+      } as unknown as AppState["kanbanMulti"],
+    });
+
+    registerTasksHandlers(store)["task.updated"]!(
+      makeMessage({
+        ...makeTask("t1", "session-1"),
+        title: "Retitled task",
+      }),
+    );
+
+    const state = store.getState();
+    const kanbanTask = state.kanban.tasks.find((task) => task.id === "t1");
+    const snapshotTask = state.kanbanMulti.snapshots.wf1.tasks.find((task) => task.id === "t1");
+    expect(kanbanTask).toMatchObject({ parentTaskId: "parent-1" });
+    expect(snapshotTask).toMatchObject({ parentTaskId: "parent-1" });
+  });
+
+  it("clears parentTaskId when the task is explicitly detached (parent_id: null)", () => {
+    const existingTask = {
+      id: "t1",
+      workflowStepId: "step1",
+      title: "Task",
+      position: 0,
+      primarySessionId: "session-1",
+      parentTaskId: "parent-1",
+    };
+    const store = makeStore({
+      kanban: {
+        workflowId: "wf1",
+        steps: [],
+        tasks: [existingTask],
+      } as unknown as AppState["kanban"],
+    });
+
+    registerTasksHandlers(store)["task.updated"]!(
+      makeMessage({ ...makeTask("t1", "session-1"), parent_id: null }),
+    );
+
+    expect(store.getState().kanban.tasks[0]).toMatchObject({ parentTaskId: undefined });
+  });
+
+  it("adopts an explicit re-parent even while the previous parent is still preserved elsewhere", () => {
+    const existingTask = {
+      id: "t1",
+      workflowStepId: "step1",
+      title: "Task",
+      position: 0,
+      primarySessionId: "session-1",
+      parentTaskId: "parent-old",
+    };
+    const store = makeStore({
+      kanban: {
+        workflowId: "wf1",
+        steps: [],
+        tasks: [existingTask],
+      } as unknown as AppState["kanban"],
+    });
+
+    registerTasksHandlers(store)["task.updated"]!(
+      makeMessage({ ...makeTask("t1", "session-1"), parent_id: "parent-new" }),
+    );
+
+    expect(store.getState().kanban.tasks[0]).toMatchObject({ parentTaskId: "parent-new" });
+  });
+});

--- a/apps/web/lib/ws/handlers/tasks.ts
+++ b/apps/web/lib/ws/handlers/tasks.ts
@@ -57,6 +57,22 @@ function preserveOmittedStatusSummary(
   }
 }
 
+// A task.updated for an unrelated field change omits parent_id entirely when
+// the task's parent is unchanged from the last event that reported it — the
+// backend only sends an explicit `parent_id: null` on a real detach (see
+// parentIDEventField in service_tasks.go). Without this guard, any such
+// partial update silently un-nests an already-nested child.
+function preserveOmittedParent(
+  existing: KanbanTask,
+  merged: KanbanTask,
+  nextTask: KanbanTask,
+  payload: TaskEventPayload,
+): void {
+  if (!hasPayloadField(payload, "parent_id") && nextTask.parentTaskId === undefined) {
+    merged.parentTaskId = existing.parentTaskId;
+  }
+}
+
 function mergeTaskUpdate(
   existing: KanbanTask | undefined,
   nextTask: KanbanTask,
@@ -67,6 +83,7 @@ function mergeTaskUpdate(
     ...nextTask,
     ...mergeTaskRepositoryFields(existing, nextTask),
   };
+  preserveOmittedParent(existing, merged, nextTask, payload);
   if (!hasPayloadField(payload, "primary_session_id") && nextTask.primarySessionId === undefined) {
     merged.primarySessionId = existing.primarySessionId;
   }


### PR DESCRIPTION
When both the unread-divider and anchored last-prompt bar settings are enabled, opening a task can scroll the transcript so the last prompt is already scrolled past at the same moment the New divider is placed, opening the pinned bar directly on top of it — reserving scroll room for the bar's real height fixes the overlap.

## Important Changes

- `AnchoredLastPromptBar` now measures its pinned content's real height (a normal-flow descendant of the CSS-grid-collapsed row, so the measurement stays stable regardless of open/closed state) and reports it up through `TaskChatPanel`.
- Native renderer: the height feeds a `--anchored-bar-h` CSS var consumed via `scroll-margin-top`; `useScrollToDividerOrBottom` re-asserts the divider's scroll position once the async-measured height arrives, reusing the existing settling-window/no-user-scroll gate.
- Virtuoso renderer: the height feeds a negative `scrollToIndex` offset (Virtuoso's documented sticky-header pattern); `useScrollToDividerOnceResolved` gained the same reassertion gate (previously a strict one-shot).

## Validation

- Unit tests (TDD): `message-list-shared.test.tsx` (`anchoredBarScrollOffsetPx`), `anchored-last-prompt-bar.test.tsx` (height reporting + unmount reset), `message-list-native.test.tsx` and `message-list-virtuoso.test.tsx` (hook-boundary tests mocking `scrollIntoView`/`scrollToIndex`, covering offset reassertion, no-divider-target, settling-window expiry, and a live-update-with-unchanged-offset case).
- `pnpm --filter @kandev/web test` — full suite: 1058+ files passed (one pre-existing, unrelated flaky timeout in `storage-maintenance-settings.test.tsx`, reproduced on the pre-change tree too).
- `pnpm --filter @kandev/web lint` (`eslint --max-warnings 0`) — clean.
- `tsc -p tsconfig.json --noEmit` — clean.
- Added `apps/web/e2e/tests/chat/unread-divider.spec.ts` case asserting the divider's bounding box never overlaps the anchored bar's rendered content.
- Manually verified against a real backend + built frontend on both sides of the fix (see screenshots): seeded a task where the divider lands right after the last prompt, confirmed the bar covers the divider before the fix and clears it after.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.
