### PR TITLE
docs(i18n): record the two blind spots the Agents and Storage migrations hit

### DIFF
--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -403,6 +403,11 @@ through `t()` — that is the acceptance check for a migrated screen, and the on
 one that sees the guard's blind spots. Interpolation placeholders and `<n>` tag
 markers are preserved by the generator.
 
+Two qualifications, both below: an **interpolated API or network payload** stays
+English by design, so it is not a miss even though it renders unaccented; and
+plain English is not a *complete* signal, because a payload inside a translated
+frame renders accented and reads as done.
+
 It has one blind spot of its own: **module-scope `t()`**. That copy *is*
 translated, just frozen at the boot locale, so it renders accented under pseudo
 and looks correct while never responding to a switch. `check-module-scope-t.mjs`
@@ -414,7 +419,7 @@ Plain-English-on-screen is not a complete signal. When an un-migrated value is
 interpolated into a **migrated** frame, the frame renders accented and the
 payload reads as part of the sentence:
 
-```
+```text
 agents:unableToStartUpdate = "Unable to start update: {{error}}"
 →  Ữńàƀĺē ţō śţàŕţ ūþďàţē: Agent installation is already in progress.
 ```

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -282,7 +282,19 @@ That is why module-scope config objects survived the sweep, and why the
 new-code ratchet inherits the same hole. `check-module-scope-t.mjs` catches the
 adjacent case (a module-scope `t()` call, frozen at the boot locale) but not
 module-scope literal copy. Reviewing a new `const TABLE = [...]` of labels by eye
-is still required.
+is still required — and note the shape one step out from a config table is just
+as invisible: **a plain function returning object literals**, e.g. a
+`buildRows()` that returns `[{ label: "Disk usage" }]`, is never inspected either.
+
+**Walk the hooks your routes call, not just the components.** A closure derived
+from component imports misses them, and they hold no JSX so the string count
+reports them as zero. Settings → Agents shipped that way and needed a follow-up
+for a thrown `Error` and a `setError` fallback in two `hooks/domains/settings/`
+modules; Settings → System → Storage caught ten toast titles in
+`use-storage-maintenance.ts` only because it re-derived its closure instead of
+trusting the count. Install/update flows and any maintenance action are the
+toast-heavy cases. A count from `pnpm run lint:i18n` is a floor on the visible
+half, never a work-list.
 
 `externalize-strings.mjs`
 covers those shapes — it walks `.ts` as well as `.tsx` and handles template
@@ -395,6 +407,52 @@ It has one blind spot of its own: **module-scope `t()`**. That copy *is*
 translated, just frozen at the boot locale, so it renders accented under pseudo
 and looks correct while never responding to a switch. `check-module-scope-t.mjs`
 is what catches it.
+
+### …and it is weakest at an interpolated value
+
+Plain-English-on-screen is not a complete signal. When an un-migrated value is
+interpolated into a **migrated** frame, the frame renders accented and the
+payload reads as part of the sentence:
+
+```
+agents:unableToStartUpdate = "Unable to start update: {{error}}"
+→  Ữńàƀĺē ţō śţàŕţ ūþďàţē: Agent installation is already in progress.
+```
+
+That scans as done. Both instances found this way survived a twelve-screen pseudo
+walk of the migrated surface before anyone noticed them.
+
+So when a message interpolates a value, ask **where the value originates** —
+that distinction is the whole check, and it is a two-minute grep for
+`t("…", { error` over the paths you migrated:
+
+- **An API or network error payload stays English by design.** `String(err)` from
+  a failed request, or a `result.error` the backend returned, is a diagnostic —
+  see [Backend](#what-the-backend-deliberately-does-not-translate) for why the
+  ~1,100 server error strings are out of scope. Around 37 catalog keys already
+  interpolate one; none of them is a miss. Where such a call needs a fallback for
+  a missing payload, the *fallback* is copy and is translated
+  (`t("linear:testFailed", { error: result.error || t("linear:unknownError") })`)
+  while the payload itself is not.
+- **A client-side literal reaching a translated frame is a miss.** A string
+  thrown, `setError`'d, or assigned in one of your own hooks or helpers is copy
+  you wrote, and neither the lint rule nor the pseudo-locale can see it.
+
+**A translated toast followed by an English `throw` is correct, not a miss.**
+This shape recurs across the migrated GitHub and Jira settings and should not be
+churned:
+
+```tsx
+} catch {
+  toast({ description: t("github:failedToSaveQuickActions"), variant: "error" });
+  // Signals failure to the settings save coordinator, which only records the
+  // contributor id — this message never reaches a user, so it is not copy.
+  throw new Error("Failed to save quick actions");
+}
+```
+
+The user already saw translated copy; the throw is control flow for
+`useSettingsSaveContributor`. Translating it would change nothing on screen.
 
 While the migration is in flight, an unmigrated screen is expected to be full of
 plain English — pseudo only proves anything about screens whose components are on

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -422,9 +422,14 @@ agents:unableToStartUpdate = "Unable to start update: {{error}}"
 That scans as done. Both instances found this way survived a twelve-screen pseudo
 walk of the migrated surface before anyone noticed them.
 
-So when a message interpolates a value, ask **where the value originates** —
-that distinction is the whole check, and it is a two-minute grep for
-`t("…", { error` over the paths you migrated:
+So when a message interpolates a value, ask **where the value originates**. That
+distinction is the whole check, and it is a two-minute grep over the paths you
+migrated:
+
+```bash
+cd apps/web
+grep -rnE 't\("[^"]+", \{ (error|message)' components app hooks | grep -v '\.test\.'
+```
 
 - **An API or network error payload stays English by design.** `String(err)` from
   a failed request, or a `result.error` the backend returned, is a diagnostic —


### PR DESCRIPTION
Two blind spots that the Settings → Agents (#2193 / #2197) and Settings → System → Storage (#2194) migrations both hit independently. Docs-only — no code, no catalog change.

## Important Changes

**1. Walk the hooks, not just the components** — added to *The guard has blind spots*.

Both migrations derived their closure from component imports, and both missed copy that lives in hooks. Those files hold no JSX, so `mode: "jsx-only"` never inspects them and the string count reports them as zero. Agents shipped that way and needed a follow-up; Storage caught ten toast titles in `use-storage-maintenance.ts` only because it re-derived its closure instead of trusting the count.

The same paragraph also now names the shape one step out from a SCREAMING_CASE config table — **a plain function returning object literals** — which is equally invisible and is what hid `installButtonContent()`'s four button labels.

**2. The pseudo-locale is weakest at an interpolated value** — a new subsection under *Pseudo-locale QA*.

That section currently implies plain-English-on-screen is a complete signal. It is not. When an un-migrated value is interpolated into a **migrated** frame, the frame renders accented and the payload reads as part of the sentence:

```
agents:unableToStartUpdate = "Unable to start update: {{error}}"
→  Ữńàƀĺē ţō śţàŕţ ūþďàţē: Agent installation is already in progress.
```

That scans as done. Both instances found this way survived a twelve-screen pseudo walk of the migrated surface before anyone noticed them.

### Why the origin distinction is the whole finding

"Check interpolated values" on its own is unactionable and actively harmful — it would send the next agent at 37 keys that are correct by design. So the note asks **where the value originates**, which makes it a two-minute grep for `t("…", { error`:

- **An API or network payload stays English by design.** `String(err)` from a failed request, or a `result.error` the backend returned, is a diagnostic; `docs/specs/platform/i18n.md` already puts the ~1,100 server error strings out of scope. I verified the claim rather than taking it on trust: **38 catalog keys across the merged namespaces interpolate an error payload, and none is a miss.** `linear:testFailed` is the instructive one — it translates its *fallback* (`t("linear:unknownError")`) while leaving the payload English, which is the distinction already working correctly in shipped code.
- **A client-side literal reaching a translated frame is a miss.** Thrown, `setError`'d, or assigned in your own hook — copy you wrote, invisible to both the lint rule and the pseudo-locale.

### The pattern that is correct and must not be churned

A naive sweep would translate these five and gain nothing, so the note names the shape explicitly:

```tsx
} catch {
  toast({ description: t("github:failedToSaveQuickActions"), variant: "error" });
  throw new Error("Failed to save quick actions");
}
```

The user already saw translated copy; the `throw` is control flow for `useSettingsSaveContributor`, which only records the contributor id. I checked all five instances in the allowlisted GitHub and Jira files — every one fires after a translated toast. `components/jira/task-presets-section.tsx` already carries a comment saying so; this promotes that one-file note to the shared doc.

## Validation

```
pnpm run i18n:check                 # 4/4 gates pass (unchanged — docs-only)
```

`docs/**` is outside the prettier pre-commit hook's scope (`web/cli/packages`), and `docs/i18n.md` is already unformatted on `main`, so it is deliberately **not** reformatted here — doing so would bury 59 lines of content in a whole-file rewrite.

The one cross-reference added, `#what-the-backend-deliberately-does-not-translate`, resolves to the existing heading in the same file.

## Possible Improvements

Docs-only, so the risk is guidance being wrong rather than code breaking. The narrowing came from the sibling Storage migration, which went looking for a third instance of the interpolation shape across every merged namespace and could not evidence one — that negative result is what turned a vague warning into a bounded check, and it is why this PR adds no code sweep.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have manually tested my changes and they work as expected. — verified both claims against the merged tree (38 interpolating keys, 5 throw-after-toast sites) rather than restating them.
- [ ] My changes have tests that cover the new functionality and edge cases. — documentation only.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`. — no `apps/web/` change.
- [x] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed. — `docs/i18n.md` is contributor documentation, not `docs/public/**`; no public-docs impact.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->