### PR TITLE
fix(web): stop unrelated task.updated events from un-nesting a subtask

### DIFF
--- a/apps/web/lib/ws/handlers/tasks.test.ts
+++ b/apps/web/lib/ws/handlers/tasks.test.ts
@@ -596,3 +596,93 @@ describe("task.updated executor preservation", () => {
     });
   });
 });
+
+describe("task.updated parent preservation", () => {
+  it("preserves parentTaskId when a partial update omits parent_id", () => {
+    // A task.updated for an unrelated field change (e.g. a title rename) must
+    // not silently un-nest a live child — only an explicit detach (parent_id:
+    // null) should clear the link. See parentIDEventField in service_tasks.go.
+    const existingTask = {
+      id: "t1",
+      workflowStepId: "step1",
+      title: "Old title",
+      position: 0,
+      primarySessionId: "session-1",
+      parentTaskId: "parent-1",
+    };
+    const store = makeStore({
+      kanban: {
+        workflowId: "wf1",
+        steps: [],
+        tasks: [existingTask],
+      } as unknown as AppState["kanban"],
+      kanbanMulti: {
+        isLoading: false,
+        snapshots: {
+          wf1: { workflowId: "wf1", workflowName: "WF1", steps: [], tasks: [existingTask] },
+        },
+      } as unknown as AppState["kanbanMulti"],
+    });
+
+    registerTasksHandlers(store)["task.updated"]!(
+      makeMessage({
+        ...makeTask("t1", "session-1"),
+        title: "Retitled task",
+      }),
+    );
+
+    const state = store.getState();
+    const kanbanTask = state.kanban.tasks.find((task) => task.id === "t1");
+    const snapshotTask = state.kanbanMulti.snapshots.wf1.tasks.find((task) => task.id === "t1");
+    expect(kanbanTask).toMatchObject({ parentTaskId: "parent-1" });
+    expect(snapshotTask).toMatchObject({ parentTaskId: "parent-1" });
+  });
+
+  it("clears parentTaskId when the task is explicitly detached (parent_id: null)", () => {
+    const existingTask = {
+      id: "t1",
+      workflowStepId: "step1",
+      title: "Task",
+      position: 0,
+      primarySessionId: "session-1",
+      parentTaskId: "parent-1",
+    };
+    const store = makeStore({
+      kanban: {
+        workflowId: "wf1",
+        steps: [],
+        tasks: [existingTask],
+      } as unknown as AppState["kanban"],
+    });
+
+    registerTasksHandlers(store)["task.updated"]!(
+      makeMessage({ ...makeTask("t1", "session-1"), parent_id: null }),
+    );
+
+    expect(store.getState().kanban.tasks[0]).toMatchObject({ parentTaskId: undefined });
+  });
+
+  it("adopts an explicit re-parent even while the previous parent is still preserved elsewhere", () => {
+    const existingTask = {
+      id: "t1",
+      workflowStepId: "step1",
+      title: "Task",
+      position: 0,
+      primarySessionId: "session-1",
+      parentTaskId: "parent-old",
+    };
+    const store = makeStore({
+      kanban: {
+        workflowId: "wf1",
+        steps: [],
+        tasks: [existingTask],
+      } as unknown as AppState["kanban"],
+    });
+
+    registerTasksHandlers(store)["task.updated"]!(
+      makeMessage({ ...makeTask("t1", "session-1"), parent_id: "parent-new" }),
+    );
+
+    expect(store.getState().kanban.tasks[0]).toMatchObject({ parentTaskId: "parent-new" });
+  });
+});

--- a/apps/web/lib/ws/handlers/tasks.test.ts
+++ b/apps/web/lib/ws/handlers/tasks.test.ts
@@ -94,6 +94,15 @@ function makeMessage(payload: Record<string, unknown>) {
   } as Parameters<NonNullable<ReturnType<typeof registerTasksHandlers>["task.updated"]>>[0];
 }
 
+function makeStateChangedMessage(payload: Record<string, unknown>) {
+  return {
+    id: "msg-1",
+    type: "notification" as const,
+    action: "task.state_changed" as const,
+    payload,
+  } as Parameters<NonNullable<ReturnType<typeof registerTasksHandlers>["task.state_changed"]>>[0];
+}
+
 // Shared setup for the primary-session focus-follow tests: a single task t1
 // whose kanban primary, plus the active/pinned session ids, are the only knobs
 // that vary between cases.
@@ -597,32 +606,33 @@ describe("task.updated executor preservation", () => {
   });
 });
 
-describe("task.updated parent preservation", () => {
+function makeParentTaskStore(parentTaskId: string) {
+  const existingTask = {
+    id: "t1",
+    workflowStepId: "step1",
+    title: "Old title",
+    position: 0,
+    primarySessionId: "session-1",
+    parentTaskId,
+  };
+  return makeStore({
+    kanban: {
+      workflowId: "wf1",
+      steps: [],
+      tasks: [existingTask],
+    } as unknown as AppState["kanban"],
+    kanbanMulti: {
+      isLoading: false,
+      snapshots: {
+        wf1: { workflowId: "wf1", workflowName: "WF1", steps: [], tasks: [existingTask] },
+      },
+    } as unknown as AppState["kanbanMulti"],
+  });
+}
+
+describe("task parent preservation", () => {
   it("preserves parentTaskId when a partial update omits parent_id", () => {
-    // A task.updated for an unrelated field change (e.g. a title rename) must
-    // not silently un-nest a live child — only an explicit detach (parent_id:
-    // null) should clear the link. See parentIDEventField in service_tasks.go.
-    const existingTask = {
-      id: "t1",
-      workflowStepId: "step1",
-      title: "Old title",
-      position: 0,
-      primarySessionId: "session-1",
-      parentTaskId: "parent-1",
-    };
-    const store = makeStore({
-      kanban: {
-        workflowId: "wf1",
-        steps: [],
-        tasks: [existingTask],
-      } as unknown as AppState["kanban"],
-      kanbanMulti: {
-        isLoading: false,
-        snapshots: {
-          wf1: { workflowId: "wf1", workflowName: "WF1", steps: [], tasks: [existingTask] },
-        },
-      } as unknown as AppState["kanbanMulti"],
-    });
+    const store = makeParentTaskStore("parent-1");
 
     registerTasksHandlers(store)["task.updated"]!(
       makeMessage({
@@ -630,59 +640,36 @@ describe("task.updated parent preservation", () => {
         title: "Retitled task",
       }),
     );
+    registerTasksHandlers(store)["task.state_changed"]!(
+      makeStateChangedMessage({ ...makeTask("t1", "session-1"), title: "Retitled again" }),
+    );
 
     const state = store.getState();
-    const kanbanTask = state.kanban.tasks.find((task) => task.id === "t1");
-    const snapshotTask = state.kanbanMulti.snapshots.wf1.tasks.find((task) => task.id === "t1");
-    expect(kanbanTask).toMatchObject({ parentTaskId: "parent-1" });
-    expect(snapshotTask).toMatchObject({ parentTaskId: "parent-1" });
+    expect(state.kanban.tasks[0]).toMatchObject({ parentTaskId: "parent-1" });
+    expect(state.kanbanMulti.snapshots.wf1.tasks[0]).toMatchObject({ parentTaskId: "parent-1" });
   });
 
   it("clears parentTaskId when the task is explicitly detached (parent_id: null)", () => {
-    const existingTask = {
-      id: "t1",
-      workflowStepId: "step1",
-      title: "Task",
-      position: 0,
-      primarySessionId: "session-1",
-      parentTaskId: "parent-1",
-    };
-    const store = makeStore({
-      kanban: {
-        workflowId: "wf1",
-        steps: [],
-        tasks: [existingTask],
-      } as unknown as AppState["kanban"],
-    });
+    const store = makeParentTaskStore("parent-1");
 
     registerTasksHandlers(store)["task.updated"]!(
       makeMessage({ ...makeTask("t1", "session-1"), parent_id: null }),
     );
 
-    expect(store.getState().kanban.tasks[0]).toMatchObject({ parentTaskId: undefined });
+    const state = store.getState();
+    expect(state.kanban.tasks[0]).toMatchObject({ parentTaskId: undefined });
+    expect(state.kanbanMulti.snapshots.wf1.tasks[0]).toMatchObject({ parentTaskId: undefined });
   });
 
   it("adopts an explicit re-parent even while the previous parent is still preserved elsewhere", () => {
-    const existingTask = {
-      id: "t1",
-      workflowStepId: "step1",
-      title: "Task",
-      position: 0,
-      primarySessionId: "session-1",
-      parentTaskId: "parent-old",
-    };
-    const store = makeStore({
-      kanban: {
-        workflowId: "wf1",
-        steps: [],
-        tasks: [existingTask],
-      } as unknown as AppState["kanban"],
-    });
+    const store = makeParentTaskStore("parent-old");
 
     registerTasksHandlers(store)["task.updated"]!(
       makeMessage({ ...makeTask("t1", "session-1"), parent_id: "parent-new" }),
     );
 
-    expect(store.getState().kanban.tasks[0]).toMatchObject({ parentTaskId: "parent-new" });
+    const state = store.getState();
+    expect(state.kanban.tasks[0]).toMatchObject({ parentTaskId: "parent-new" });
+    expect(state.kanbanMulti.snapshots.wf1.tasks[0]).toMatchObject({ parentTaskId: "parent-new" });
   });
 });

--- a/apps/web/lib/ws/handlers/tasks.ts
+++ b/apps/web/lib/ws/handlers/tasks.ts
@@ -57,18 +57,15 @@ function preserveOmittedStatusSummary(
   }
 }
 
-// A task.updated for an unrelated field change omits parent_id entirely when
-// the task's parent is unchanged from the last event that reported it — the
-// backend only sends an explicit `parent_id: null` on a real detach (see
-// parentIDEventField in service_tasks.go). Without this guard, any such
-// partial update silently un-nests an already-nested child.
+// Task lifecycle events may omit parent_id when the parent is unchanged. Only
+// an explicit `parent_id: null` means detach (see parentIDEventField in
+// service_tasks.go), so an omitted link must not un-nest a cached child.
 function preserveOmittedParent(
   existing: KanbanTask,
   merged: KanbanTask,
-  nextTask: KanbanTask,
   payload: TaskEventPayload,
 ): void {
-  if (!hasPayloadField(payload, "parent_id") && nextTask.parentTaskId === undefined) {
+  if (!hasPayloadField(payload, "parent_id")) {
     merged.parentTaskId = existing.parentTaskId;
   }
 }
@@ -83,7 +80,7 @@ function mergeTaskUpdate(
     ...nextTask,
     ...mergeTaskRepositoryFields(existing, nextTask),
   };
-  preserveOmittedParent(existing, merged, nextTask, payload);
+  preserveOmittedParent(existing, merged, payload);
   if (!hasPayloadField(payload, "primary_session_id") && nextTask.primarySessionId === undefined) {
     merged.primarySessionId = existing.primarySessionId;
   }

--- a/apps/web/lib/ws/handlers/tasks.ts
+++ b/apps/web/lib/ws/handlers/tasks.ts
@@ -57,6 +57,22 @@ function preserveOmittedStatusSummary(
   }
 }
 
+// A task.updated for an unrelated field change omits parent_id entirely when
+// the task's parent is unchanged from the last event that reported it — the
+// backend only sends an explicit `parent_id: null` on a real detach (see
+// parentIDEventField in service_tasks.go). Without this guard, any such
+// partial update silently un-nests an already-nested child.
+function preserveOmittedParent(
+  existing: KanbanTask,
+  merged: KanbanTask,
+  nextTask: KanbanTask,
+  payload: TaskEventPayload,
+): void {
+  if (!hasPayloadField(payload, "parent_id") && nextTask.parentTaskId === undefined) {
+    merged.parentTaskId = existing.parentTaskId;
+  }
+}
+
 function mergeTaskUpdate(
   existing: KanbanTask | undefined,
   nextTask: KanbanTask,
@@ -67,6 +83,7 @@ function mergeTaskUpdate(
     ...nextTask,
     ...mergeTaskRepositoryFields(existing, nextTask),
   };
+  preserveOmittedParent(existing, merged, nextTask, payload);
   if (!hasPayloadField(payload, "primary_session_id") && nextTask.primarySessionId === undefined) {
     merged.primarySessionId = existing.primarySessionId;
   }


### PR DESCRIPTION
## Problem

A subtask created by an agent via `create_task_kandev({parent_id: "self", ...})`
would nest correctly under its parent at first, then silently un-nest and
float to the sidebar root later — even though the parent was never archived,
detached, or deleted, and the backend's `parent_id` was untouched.

## Root cause

`mergeTaskUpdate` (`apps/web/lib/ws/handlers/tasks.ts`) already has an
established pattern for ~8 other fields the backend sends with
`omitempty` (`primarySessionId`, `primaryExecutor*`, `taskPendingAction`,
`foregroundActivity`, `activeSubagentCount`, `statusSummary`, ...): when a
`task.updated`/`task.state_changed` WS payload omits one of these keys, fall
back to the value already in the store instead of clearing it.

`parent_id` had no such guard. The backend correctly omits `parent_id`
whenever an update doesn't touch a task's parent (and sends an explicit
`parent_id: null` only on a real detach — see `parentIDEventField` in
`service_tasks.go`), but the frontend merge unconditionally took
`nextTask.parentTaskId` (`undefined` whenever the key is absent) — so **any**
unrelated `task.updated` for an already-nested child (a title rename, a
repository change, a session-state flip, ...) silently cleared its
`parentTaskId` in the kanban store, un-nesting it in the sidebar.

## Fix

Add `preserveOmittedParent`, mirroring the existing
`preserveOmittedStatusSummary`/`preservePrimaryExecutorFields` helpers: fall
back to the existing `parentTaskId` only when the payload's `parent_id` key
is entirely absent. An explicit `parent_id: null` (detach) and an explicit
new `parent_id` (re-parent) both still win unconditionally.

No backend changes — the backend's event contract was already correct; this
closes a gap in the frontend's own defensive-merge convention.

## Testing

Added `describe("task.updated parent preservation", ...)` to
`apps/web/lib/ws/handlers/tasks.test.ts`:
- reproduces the bug: an unrelated partial update (`title` rename only) was
  clearing `parentTaskId` — now preserved.
- explicit detach (`parent_id: null`) still clears it.
- explicit re-parent (`parent_id: "parent-new"`) still adopts it.

`pnpm run typecheck`, `make lint-web`, and the full `lib/ws/handlers/`,
`lib/kanban/`, `lib/sidebar/`, `components/task/`,
`hooks/domains/kanban/` suites (2172 tests) are green.

Backend `fmt`/`test`/`lint` not run — no Go toolchain in the environment this
PR was authored in, and no backend files are touched by this change.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

