### PR TITLE
docs(i18n): name the oracle's blindness to attribute-borne copy

### DIFF
--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -403,15 +403,34 @@ through `t()` — that is the acceptance check for a migrated screen, and the on
 one that sees the guard's blind spots. Interpolation placeholders and `<n>` tag
 markers are preserved by the generator.
 
-Two qualifications, both below: an **interpolated API or network payload** stays
-English by design, so it is not a miss even though it renders unaccented; and
-plain English is not a *complete* signal, because a payload inside a translated
-frame renders accented and reads as done.
+Three limits, all below: an **interpolated API or network payload** stays English
+by design, so it is not a miss even though it renders unaccented; the oracle
+**cannot see copy that never becomes a text node**, so an attribute string leaves
+no trace at all; and plain English is not a *complete* signal, because a payload
+inside a translated frame renders accented and reads as done.
 
 It has one blind spot of its own: **module-scope `t()`**. That copy *is*
 translated, just frozen at the boot locale, so it renders accented under pseudo
 and looks correct while never responding to a switch. `check-module-scope-t.mjs`
 is what catches it.
+
+### It cannot see copy that is not a text node
+
+`findUnlocalizedText` in `e2e/tests/i18n/pseudo-coverage.spec.ts` walks
+`NodeFilter.SHOW_TEXT`, and a human looking at the screen is no different:
+**copy carried in an attribute — `aria-label`, `aria-description`, `title`,
+`placeholder`, `alt` — renders nothing visible and leaves no trace under
+pseudo.** The Settings → System → Storage review demonstrated it by reverting an
+`aria-label` to an English template literal; nothing failed.
+
+The guard is the primary defence here, not the oracle: those five attributes are
+in `jsx-attributes.include`, so on an allowlisted path the lint rule does flag
+them. The consequence is that for attribute copy there is **no second check** — on
+a path not yet allowlisted, or for a fragment the `words.exclude` patterns skip,
+nothing downstream catches it, and the copy a screen-reader user depends on is
+exactly the copy nobody sees regress. Read attribute props by eye when you
+migrate, and prefer a `t()` call over a template literal in them so the value
+stays greppable.
 
 ### …and it is weakest at an interpolated value
 

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -403,16 +403,19 @@ through `t()` — that is the acceptance check for a migrated screen, and the on
 one that sees the guard's blind spots. Interpolation placeholders and `<n>` tag
 markers are preserved by the generator.
 
-Three limits, all below: an **interpolated API or network payload** stays English
-by design, so it is not a miss even though it renders unaccented; the oracle
-**cannot see copy that never becomes a text node**, so an attribute string leaves
-no trace at all; and plain English is not a *complete* signal, because a payload
-inside a translated frame renders accented and reads as done.
+One thing it shows you is **not** a miss: an interpolated API or network payload
+stays English by design, so it renders unaccented and is still correct. See
+[the interpolated-value limit](#and-it-is-weakest-at-an-interpolated-value).
 
-It has one blind spot of its own: **module-scope `t()`**. That copy *is*
-translated, just frozen at the boot locale, so it renders accented under pseudo
-and looks correct while never responding to a switch. `check-module-scope-t.mjs`
-is what catches it.
+Three things it cannot show you at all — the second and third are detailed below:
+
+1. **Module-scope `t()`.** That copy *is* translated, just frozen at the boot
+   locale, so it renders accented and looks correct while never responding to a
+   switch. `check-module-scope-t.mjs` is what catches it.
+2. **Copy that never becomes a text node** — an attribute string leaves no trace
+   on screen at all.
+3. **An un-migrated value interpolated into a migrated frame** — it renders
+   inside accented copy and reads as done.
 
 ### It cannot see copy that is not a text node
 
@@ -427,9 +430,9 @@ The guard is the primary defence here, not the oracle: those five attributes are
 in `jsx-attributes.include`, so on an allowlisted path the lint rule does flag
 them. The consequence is that for attribute copy there is **no second check** — on
 a path not yet allowlisted, or for a fragment the `words.exclude` patterns skip,
-nothing downstream catches it, and the copy a screen-reader user depends on is
-exactly the copy nobody sees regress. Read attribute props by eye when you
-migrate, and prefer a `t()` call over a template literal in them so the value
+nothing downstream catches it. The copy only screen-reader users receive is
+therefore the copy with the weakest safety net. Read attribute props by eye when
+you migrate, and prefer a `t()` call over a template literal in them so the value
 stays greppable.
 
 ### …and it is weakest at an interpolated value


### PR DESCRIPTION
Third limit for the *Pseudo-locale QA* section, from the Settings → System → Storage review (#2194). Docs-only.

## Important Changes

`findUnlocalizedText` in `e2e/tests/i18n/pseudo-coverage.spec.ts` walks `NodeFilter.SHOW_TEXT`:

```ts
const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
```

So **copy carried in an attribute is structurally unreachable** — `aria-label`, `aria-description`, `title`, `placeholder`, `alt` — and a human eyeballing the pseudo-locale is no different, because an untranslated `aria-label` renders nothing visible. #2194's review demonstrated it by mutation: reverting an `aria-label` to an English template literal failed nothing.

This is the same class as the interpolated-value limit added in #2205 — a hole in the **oracle**, not in the guard — and arguably the worse of the two, since screen-reader-only copy leaves no visible trace whatsoever.

### Which layer actually has the hole

I checked before writing, because the obvious framing would have been wrong. Those five attributes **are** in `jsx-attributes.include`, so on an allowlisted path the lint rule does flag them — the guard is the primary defence here, not the oracle.

The accurate consequence is narrower and worth stating precisely: for attribute copy there is **no second check**. On a path not yet allowlisted, or for a fragment the `words.exclude` patterns skip, nothing downstream catches it. The copy only a screen-reader user ever receives is exactly the copy nobody sees regress.

The section opener now reads "Three limits, all below" and names this one alongside the two from #2205, so a QA pass reading top-down meets all three before the acceptance check.

## Validation

```
pnpm run i18n:check                 # 4/4 gates pass (unchanged — docs-only)
node scripts/check-guard-allowlist.mjs   # 163 entries, intact
```

Fences in the touched section are all tagged (`text`, `bash`, `tsx`) — MD040 clean, matching the fix in #2205. `docs/**` stays outside the prettier hook's `web/cli/packages` scope, so the file is deliberately not reformatted.

## Possible Improvements

The real fix is an oracle that reads the five attributes as well as text nodes — `findUnlocalizedText` would need a second pass over `document.querySelectorAll("[aria-label],[title],[placeholder],[alt],[aria-description]")`. That is a change to a gate that is currently opt-in (`KANDEV_I18N_COVERAGE=1`) and would want its own PR and its own mutation check; this one only records the limit so nobody trusts the oracle for attribute copy in the meantime.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have manually tested my changes and they work as expected. — verified the `SHOW_TEXT` walker and the `jsx-attributes.include` list in the merged tree rather than restating the report.
- [ ] My changes have tests that cover the new functionality and edge cases. — documentation only.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`. — no `apps/web/` change.
- [x] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed. — `docs/i18n.md` is contributor documentation; no public-docs impact.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->