### PR TITLE
test(i18n): make the pseudo-locale oracle read attribute copy

### DIFF
--- a/apps/web/e2e/tests/i18n/pseudo-coverage.spec.ts
+++ b/apps/web/e2e/tests/i18n/pseudo-coverage.spec.ts
@@ -228,8 +228,20 @@ const COPY_ATTRIBUTES = ["aria-label", "aria-description", "title", "placeholder
  * that carries it (`aria-label on button[data-testid=…]: "More information"`),
  * because an attribute string is invisible on screen — a bare value gives you
  * nothing to grep for and nowhere to look.
+ *
+ * Two counters make an empty `leftovers` mean something, because a selector that
+ * matched no elements reports exactly as clean as a clean screen:
+ *   - `inspectedAttributes` — non-empty attribute values examined. Asserted per
+ *     screen; this is the one that catches a selector matching nothing.
+ *   - `localizedAttributes` — those that rendered FULLY accented, i.e. migrated
+ *     attribute copy the pass demonstrably reached. Not asserted per screen: a
+ *     page of plain inputs and text can legitimately have none, and secrets,
+ *     terminal and sprites do. Pinned once instead, in its own test below.
  */
-async function findUnlocalizedCopy(page: Page, allowed: string[]): Promise<string[]> {
+async function findUnlocalizedCopy(
+  page: Page,
+  allowed: string[],
+): Promise<{ leftovers: string[]; localizedAttributes: string[]; inspectedAttributes: number }> {
   return page.evaluate(
     ({ allowedList, copyAttributes }) => {
       const skipTags = new Set(["SCRIPT", "STYLE", "NOSCRIPT", "CODE", "PRE", "SVG"]);
@@ -246,13 +258,16 @@ async function findUnlocalizedCopy(page: Page, allowed: string[]): Promise<strin
       // side" would leave "side by side" behind and report it as a leftover.
       const tokens = [...allowedList].sort((a, b) => b.length - a.length);
 
-      /** Plain-English, and still word-like once allowlisted tokens are removed. */
-      const looksUnlocalized = (text: string) => {
-        if (!text || !wordlike.test(text) || accented.test(text)) return false;
+      /** Still word-like ASCII once allowlisted tokens are removed. */
+      const hasUnmigratedAscii = (text: string) => {
+        if (!text || !wordlike.test(text)) return false;
         let residue = text;
         for (const token of tokens) residue = residue.split(token).join(" ");
         return wordlike.test(residue);
       };
+
+      /** The text pass's rule, unchanged: any accented character clears a node. */
+      const looksUnlocalized = (text: string) => !accented.test(text) && hasUnmigratedAscii(text);
 
       const collectText = () => {
         const found = new Set<string>();
@@ -296,41 +311,78 @@ async function findUnlocalizedCopy(page: Page, allowed: string[]): Promise<strin
         typeof el.checkVisibility !== "function" ||
         el.checkVisibility({ contentVisibilityAuto: true, visibilityProperty: true });
 
+      const seen = new Map<string, { label: string; count: number }>();
+      // The positive control. An attribute that HAS been migrated renders as
+      // `Mōŕē ĩńfōŕmàţĩōń`, which contains no 4-letter ASCII run — so it is
+      // dropped at the `wordlike` gate and never even reaches the `accented`
+      // test. Soundness is unaffected (a real miss is pure ASCII and is still
+      // caught), but it means a working pass and a pass whose selector matched
+      // NOTHING produce identical empty output. Collecting the accented values
+      // proves the pass actually reached migrated attribute copy on this
+      // screen, so the caller can tell those two apart.
+      const localized: string[] = [];
+      let inspected = 0;
+
+      const inspectAttribute = (el: Element, attr: string) => {
+        // An empty value is never a missed string, and `alt=""` is load-bearing:
+        // it marks an image as decorative so screen readers skip it. Reporting
+        // one would push authors into writing alt text for spacers.
+        const value = (el.getAttribute(attr) ?? "").trim();
+        if (!value) return;
+        inspected += 1;
+
+        // NOTE the divergence from the text pass, which clears a node the moment
+        // it contains one accented character. That rule hides a real shape here:
+        // an `aria-label` built as "Collapse ${label}" renders
+        // "Collapse Ĝēńēŕàĺ" — an un-migrated English FRAME around a migrated
+        // value, which accent-clears-all would call done. Allowlist stripping is
+        // what separates it from the legitimate case, where the ASCII fragment is
+        // the allowlisted DATA rather than the frame ("Àćţĩōńś ƒōŕ Agent" on the
+        // layouts screen strips to nothing).
+        if (!hasUnmigratedAscii(value)) {
+          // Fully accented, nothing ASCII left: a migrated attribute, and the
+          // positive control.
+          if (accented.test(value)) {
+            localized.push(`${attr} on ${describe(el)}: "${value.slice(0, 60)}"`);
+          }
+          return;
+        }
+
+        // Keyed by attribute+value, not by element: one un-migrated shared
+        // component renders on twenty rows, and twenty identical findings bury
+        // the other nineteen strings. The first element carrying it is the
+        // sample you go and look at.
+        const key = `${attr} ${value}`;
+        const hit = seen.get(key);
+        if (hit) {
+          hit.count += 1;
+          return;
+        }
+        const label = `${attr} on ${describe(el)}: "${value.slice(0, 120)}"`;
+        seen.set(key, {
+          label: accented.test(value) ? `${label} - English frame, migrated value` : label,
+          count: 1,
+        });
+      };
+
       const collectAttributes = () => {
-        const seen = new Map<string, { label: string; count: number }>();
         const selector = copyAttributes.map((attr) => `[${attr}]`).join(",");
         for (const el of Array.from(document.querySelectorAll(selector))) {
           if (attrSkipTags.has(el.tagName.toUpperCase()) || !isRendered(el)) continue;
-          for (const attr of copyAttributes) {
-            // An empty value is never a missed string, and `alt=""` is load-
-            // bearing: it marks an image as decorative so screen readers skip
-            // it. Reporting one would push authors into writing alt text for
-            // spacers. `looksUnlocalized` rejects "" on the word-like test.
-            const value = (el.getAttribute(attr) ?? "").trim();
-            if (!looksUnlocalized(value)) continue;
-
-            // Keyed by attribute+value, not by element: one un-migrated shared
-            // component renders on twenty rows, and twenty identical findings
-            // bury the other nineteen strings. The first element carrying it is
-            // the sample you go and look at.
-            const key = `${attr} ${value}`;
-            const hit = seen.get(key);
-            if (hit) {
-              hit.count += 1;
-              continue;
-            }
-            seen.set(key, {
-              label: `${attr} on ${describe(el)}: "${value.slice(0, 120)}"`,
-              count: 1,
-            });
-          }
+          for (const attr of copyAttributes) inspectAttribute(el, attr);
         }
-        return [...seen.values()].map(({ label, count }) =>
+        const leftovers = [...seen.values()].map(({ label, count }) =>
           count > 1 ? `${label} (×${count})` : label,
         );
+        return { leftovers, localized, inspected };
       };
 
-      return [...collectText(), ...collectAttributes()];
+      const attributes = collectAttributes();
+      return {
+        leftovers: [...collectText(), ...attributes.leftovers],
+        localizedAttributes: attributes.localized,
+        inspectedAttributes: attributes.inspected,
+      };
     },
     { allowedList: allowed, copyAttributes: COPY_ATTRIBUTES },
   );
@@ -348,11 +400,55 @@ test.describe("i18n pseudo-locale coverage", () => {
       // Let lazy panels settle before scanning.
       await testPage.waitForTimeout(1_000);
 
-      const leftovers = await findUnlocalizedCopy(testPage, [...ALLOWED, ...(screen.allow ?? [])]);
+      const { leftovers, localizedAttributes, inspectedAttributes } = await findUnlocalizedCopy(
+        testPage,
+        [...ALLOWED, ...(screen.allow ?? [])],
+      );
+
+      // Control FIRST. A migrated attribute renders accented and so is invisible
+      // to the leftover check by construction, which means a screen that is
+      // clean and a selector that matched NOTHING report identically. Assert the
+      // pass actually read attributes before believing what it did not find.
+      expect(
+        inspectedAttributes,
+        `The attribute pass examined no attribute at all on ${screen.name}, so a ` +
+          `green leftover check proves nothing about attribute copy here.`,
+      ).toBeGreaterThan(0);
+
       expect(
         leftovers,
-        `Un-externalized strings on ${screen.name}:\n${leftovers.map((s) => `  - ${s}`).join("\n")}`,
+        `Un-externalized strings on ${screen.name}:\n${leftovers.map((s) => `  - ${s}`).join("\n")}` +
+          `\n\nAttribute pass examined ${inspectedAttributes} attribute(s), of which ` +
+          `${localizedAttributes.length} rendered fully accented.`,
       ).toEqual([]);
     });
   }
+
+  /**
+   * The positive control, pinned once rather than per screen.
+   *
+   * `inspectedAttributes` above proves the selector matched; it does not prove
+   * the pass can tell migrated attribute copy apart from a miss. This does, on
+   * the one element we know is migrated: `language-settings.tsx` renders
+   * `aria-label={t("settings:displayLanguage")}` on `#language-select`, so under
+   * pseudo it must come back accented. If this test fails while the screens
+   * above pass, the accent detection is broken and every green screen is
+   * meaningless — which is the failure this whole file exists to not have.
+   *
+   * A per-screen version of this assertion was tried and dropped: secrets,
+   * terminal and sprites legitimately render no fully-accented attribute at all,
+   * so it fired on three screens that were fine.
+   */
+  test("the attribute pass recognizes migrated attribute copy", async ({ testPage }) => {
+    await activatePseudo(testPage, "/settings/general/appearance");
+    await testPage.waitForTimeout(1_000);
+
+    const { localizedAttributes } = await findUnlocalizedCopy(testPage, ALLOWED);
+
+    expect(
+      localizedAttributes.join("\n"),
+      `Expected the migrated aria-label on #language-select to render accented. Got:\n` +
+        localizedAttributes.join("\n"),
+    ).toContain("language-select");
+  });
 });

--- a/apps/web/e2e/tests/i18n/pseudo-coverage.spec.ts
+++ b/apps/web/e2e/tests/i18n/pseudo-coverage.spec.ts
@@ -6,9 +6,15 @@ import { test, expect } from "../../fixtures/test-base";
  * Pseudo-locale coverage oracle.
  *
  * Under the pseudo-locale every EXTRACTED message is accented
- * (`Language` → `Ĺàńĝũàĝē`). So any user-facing text that is still plain ASCII
+ * (`Language` → `Ĺàńĝũàĝē`). So any user-facing copy that is still plain ASCII
  * is, by definition, a string that was never wrapped in a Lingui macro. This
  * spec crawls chrome-heavy screens and reports those leftovers.
+ *
+ * It runs TWO passes, because copy reaches the user by two routes:
+ *   - visible text nodes, and
+ *   - `COPY_ATTRIBUTES` — the copy a screen-reader user receives and a sighted
+ *     one never sees. That pass is why the oracle is no longer blind to an
+ *     `aria-label` that was never externalized; see docs/i18n.md.
  *
  * `SCREENS` mirrors `i18nGuardFiles` in eslint.i18n.options.mjs: a screen belongs
  * here once the components that render it have been migrated. The eslint guard
@@ -196,41 +202,138 @@ async function activatePseudo(page: Page, url: string) {
 }
 
 /**
- * Collect visible text nodes that look like un-externalized English copy.
- * Nodes inside script/style, and nodes that are wholly allowlisted, are ignored.
+ * Attributes that carry display copy rather than a value the app compares.
+ * Kept in sync with `jsx-attributes.include` in apps/web/eslint.i18n.options.mjs,
+ * so the guard and this oracle answer the same question about the same set: on an
+ * allowlisted path lint flags the literal, and here it is checked at render.
+ *
+ * `aria-labelledby` / `aria-describedby` / `aria-controls` are deliberately
+ * absent — they carry element ids, not prose, and are excluded by the guard too.
+ *
+ * `title` is checked on EVERY element, not just interactive ones. A `title` is
+ * exposed as an accessible name or description whatever the element is, and the
+ * browser renders its native tooltip on hover for any of them — so "the app never
+ * shows this one" is not true of a rendered `title`. Restricting it to
+ * interactive elements would need a tag/role/tabindex heuristic, and that
+ * heuristic would immediately become the place attribute copy hides. The guard
+ * checks `title` unconditionally too; the two stay in step.
  */
-async function findUnlocalizedText(page: Page, allowed: string[]): Promise<string[]> {
-  return page.evaluate((allowedList) => {
-    const skipTags = new Set(["SCRIPT", "STYLE", "NOSCRIPT", "CODE", "PRE", "SVG"]);
-    const wordlike = /[A-Za-z]{4,}/;
-    const accented = /[À-ɏ]/;
-    const found = new Set<string>();
+const COPY_ATTRIBUTES = ["aria-label", "aria-description", "title", "placeholder", "alt"];
 
-    const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
-    let node: Node | null;
-    while ((node = walker.nextNode())) {
-      const text = (node.textContent ?? "").trim();
-      if (!text || !wordlike.test(text) || accented.test(text)) continue;
+/**
+ * Collect copy that looks un-externalized: plain-English visible text nodes, and
+ * plain-English values of the five copy-bearing attributes.
+ *
+ * Attribute findings are returned prefixed with the attribute and the element
+ * that carries it (`aria-label on button[data-testid=…]: "More information"`),
+ * because an attribute string is invisible on screen — a bare value gives you
+ * nothing to grep for and nowhere to look.
+ */
+async function findUnlocalizedCopy(page: Page, allowed: string[]): Promise<string[]> {
+  return page.evaluate(
+    ({ allowedList, copyAttributes }) => {
+      const skipTags = new Set(["SCRIPT", "STYLE", "NOSCRIPT", "CODE", "PRE", "SVG"]);
+      // A narrower set for attributes. `skipTags` above encodes "this element's
+      // CONTENT is not prose", which is a different question from whether its
+      // LABEL is: an `aria-label` on an <svg> icon, or a `title` on a <code>
+      // chip, is copy the user receives either way. Only the three tags that
+      // cannot present a label at all are skipped here.
+      const attrSkipTags = new Set(["SCRIPT", "STYLE", "NOSCRIPT"]);
+      const wordlike = /[A-Za-z]{4,}/;
+      const accented = /[À-ɏ]/;
 
-      const el = node.parentElement;
-      if (!el || skipTags.has(el.tagName)) continue;
-      // Ignore hidden nodes — not user-visible copy.
-      const rect = el.getBoundingClientRect();
-      if (rect.width === 0 && rect.height === 0) continue;
-
-      // Strip allowlisted tokens; if nothing word-like remains, it's fine.
       // Longest first: stripping "VS Code" before "Agent and VS Code side by
       // side" would leave "side by side" behind and report it as a leftover.
-      let residue = text;
-      for (const token of [...allowedList].sort((a, b) => b.length - a.length)) {
-        residue = residue.split(token).join(" ");
-      }
-      if (!wordlike.test(residue)) continue;
+      const tokens = [...allowedList].sort((a, b) => b.length - a.length);
 
-      found.add(text.slice(0, 120));
-    }
-    return [...found];
-  }, allowed);
+      /** Plain-English, and still word-like once allowlisted tokens are removed. */
+      const looksUnlocalized = (text: string) => {
+        if (!text || !wordlike.test(text) || accented.test(text)) return false;
+        let residue = text;
+        for (const token of tokens) residue = residue.split(token).join(" ");
+        return wordlike.test(residue);
+      };
+
+      const collectText = () => {
+        const found = new Set<string>();
+        const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
+        let node: Node | null;
+        while ((node = walker.nextNode())) {
+          const text = (node.textContent ?? "").trim();
+          if (!looksUnlocalized(text)) continue;
+
+          const el = node.parentElement;
+          if (!el || skipTags.has(el.tagName)) continue;
+          // Ignore hidden nodes — not user-visible copy.
+          const rect = el.getBoundingClientRect();
+          if (rect.width === 0 && rect.height === 0) continue;
+
+          found.add(text.slice(0, 120));
+        }
+        return [...found];
+      };
+
+      /** Enough to find the element in the DOM and in the source. */
+      const describe = (el: Element) => {
+        const tag = el.tagName.toLowerCase();
+        const testId = el.getAttribute("data-testid");
+        if (testId) return `${tag}[data-testid=${testId}]`;
+        if (el.id) return `${tag}#${el.id}`;
+        const role = el.getAttribute("role");
+        return role ? `${tag}[role=${role}]` : tag;
+      };
+
+      // The text pass drops zero-size nodes because nothing is on screen to read.
+      // That test is WRONG for an attribute: a visually hidden control with an
+      // `aria-label` is precisely the case this pass exists to catch, and every
+      // `sr-only` node measures as good as zero. What actually disqualifies a
+      // label is the element not being rendered at all — `display: none`,
+      // `visibility: hidden`, or a skipped `content-visibility` subtree — because
+      // then no user receives it, sighted or not. `checkVisibility` asks that
+      // directly; deliberately WITHOUT `opacityProperty`, since an opacity-0
+      // element is still in the accessibility tree.
+      const isRendered = (el: Element) =>
+        typeof el.checkVisibility !== "function" ||
+        el.checkVisibility({ contentVisibilityAuto: true, visibilityProperty: true });
+
+      const collectAttributes = () => {
+        const seen = new Map<string, { label: string; count: number }>();
+        const selector = copyAttributes.map((attr) => `[${attr}]`).join(",");
+        for (const el of Array.from(document.querySelectorAll(selector))) {
+          if (attrSkipTags.has(el.tagName.toUpperCase()) || !isRendered(el)) continue;
+          for (const attr of copyAttributes) {
+            // An empty value is never a missed string, and `alt=""` is load-
+            // bearing: it marks an image as decorative so screen readers skip
+            // it. Reporting one would push authors into writing alt text for
+            // spacers. `looksUnlocalized` rejects "" on the word-like test.
+            const value = (el.getAttribute(attr) ?? "").trim();
+            if (!looksUnlocalized(value)) continue;
+
+            // Keyed by attribute+value, not by element: one un-migrated shared
+            // component renders on twenty rows, and twenty identical findings
+            // bury the other nineteen strings. The first element carrying it is
+            // the sample you go and look at.
+            const key = `${attr} ${value}`;
+            const hit = seen.get(key);
+            if (hit) {
+              hit.count += 1;
+              continue;
+            }
+            seen.set(key, {
+              label: `${attr} on ${describe(el)}: "${value.slice(0, 120)}"`,
+              count: 1,
+            });
+          }
+        }
+        return [...seen.values()].map(({ label, count }) =>
+          count > 1 ? `${label} (×${count})` : label,
+        );
+      };
+
+      return [...collectText(), ...collectAttributes()];
+    },
+    { allowedList: allowed, copyAttributes: COPY_ATTRIBUTES },
+  );
 }
 
 test.describe("i18n pseudo-locale coverage", () => {
@@ -245,7 +348,7 @@ test.describe("i18n pseudo-locale coverage", () => {
       // Let lazy panels settle before scanning.
       await testPage.waitForTimeout(1_000);
 
-      const leftovers = await findUnlocalizedText(testPage, [...ALLOWED, ...(screen.allow ?? [])]);
+      const leftovers = await findUnlocalizedCopy(testPage, [...ALLOWED, ...(screen.allow ?? [])]);
       expect(
         leftovers,
         `Un-externalized strings on ${screen.name}:\n${leftovers.map((s) => `  - ${s}`).join("\n")}`,

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -437,7 +437,18 @@ it, since a bare string gives you nowhere to look:
 aria-label on button#language-select: "Display language (pseudo)"
 ```
 
-Three things about that pass are deliberate, and worth knowing before you read its
+**Read the control line before you trust a green screen.** A migrated attribute
+renders as `Mōŕē ĩńfōŕmàţĩōń`, which has no 4-letter ASCII run and so is dropped
+at the `wordlike` gate before the accented test ever sees it. Soundness is fine —
+a real miss is pure ASCII — but it means a working pass and a pass whose selector
+matched *nothing* produce the same empty output. One agent scanning by hand
+concluded their scan was broken on exactly this. The spec therefore asserts
+`inspectedAttributes > 0` per screen, prints how many rendered fully accented, and
+pins accent detection once against `#language-select`'s known-migrated
+`aria-label`. If you scan by hand, emit a known-migrated attribute as your own
+positive control.
+
+Four things about that pass are deliberate, and worth knowing before you read its
 output:
 
 - **It does not reuse the text pass's zero-size-rect check.** A visually hidden
@@ -452,6 +463,13 @@ output:
 - **Findings are keyed by attribute and value, not by element**, with a `(×N)`
   count. One un-migrated shared component rendered on twenty rows would otherwise
   bury every other string on the screen.
+- **One accented character does not clear an attribute**, unlike the text pass.
+  An `aria-label` built as `` `Collapse ${label}` `` renders `Collapse Ĝēńēŕàĺ` —
+  an un-migrated English *frame* around a migrated value, which accent-clears-all
+  would call done. Allowlist stripping is what separates that from the legitimate
+  case, where the ASCII fragment is allowlisted *data* rather than the frame
+  (`Àćţĩōńś ƒōŕ Agent` on the layouts screen strips to nothing). Such findings are
+  tagged `— English frame, migrated value`.
 
 The guard is still the primary defence: those five attributes are in
 `jsx-attributes.include`, so on an allowlisted path the lint rule flags the

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -407,33 +407,58 @@ One thing it shows you is **not** a miss: an interpolated API or network payload
 stays English by design, so it renders unaccented and is still correct. See
 [the interpolated-value limit](#and-it-is-weakest-at-an-interpolated-value).
 
-Three things it cannot show you at all — the second and third are detailed below:
+Two things it cannot show you at all — the second is detailed below:
 
 1. **Module-scope `t()`.** That copy *is* translated, just frozen at the boot
    locale, so it renders accented and looks correct while never responding to a
    switch. `check-module-scope-t.mjs` is what catches it.
-2. **Copy that never becomes a text node** — an attribute string leaves no trace
-   on screen at all.
-3. **An un-migrated value interpolated into a migrated frame** — it renders
+2. **An un-migrated value interpolated into a migrated frame** — it renders
    inside accented copy and reads as done.
 
-### It cannot see copy that is not a text node
+A third used to belong on that list — copy that never becomes a text node — and
+the spec now reads it directly. That pass is described next, because what it does
+*not* check still matters when you migrate.
 
-`findUnlocalizedText` in `e2e/tests/i18n/pseudo-coverage.spec.ts` walks
-`NodeFilter.SHOW_TEXT`, and a human looking at the screen is no different:
-**copy carried in an attribute — `aria-label`, `aria-description`, `title`,
-`placeholder`, `alt` — renders nothing visible and leaves no trace under
-pseudo.** The Settings → System → Storage review demonstrated it by reverting an
-`aria-label` to an English template literal; nothing failed.
+### It reads attribute copy, which nothing on screen shows you
 
-The guard is the primary defence here, not the oracle: those five attributes are
-in `jsx-attributes.include`, so on an allowlisted path the lint rule does flag
-them. The consequence is that for attribute copy there is **no second check** — on
-a path not yet allowlisted, or for a fragment the `words.exclude` patterns skip,
-nothing downstream catches it. The copy only screen-reader users receive is
-therefore the copy with the weakest safety net. Read attribute props by eye when
-you migrate, and prefer a `t()` call over a template literal in them so the value
-stays greppable.
+**Copy carried in an attribute — `aria-label`, `aria-description`, `title`,
+`placeholder`, `alt` — renders nothing visible, so a human eyeballing the
+pseudo-locale can never catch it.** The Settings → System → Storage review
+demonstrated the gap by reverting an `aria-label` to an English template literal:
+nothing failed.
+
+`findUnlocalizedCopy` in `e2e/tests/i18n/pseudo-coverage.spec.ts` therefore runs a
+second pass over `document.querySelectorAll("[aria-label],…")` alongside the
+`NodeFilter.SHOW_TEXT` walk, applying the same accented/word-like tests and the
+same allowlist stripping. Findings name the attribute and the element that carries
+it, since a bare string gives you nowhere to look:
+
+```text
+aria-label on button#language-select: "Display language (pseudo)"
+```
+
+Three things about that pass are deliberate, and worth knowing before you read its
+output:
+
+- **It does not reuse the text pass's zero-size-rect check.** A visually hidden
+  control with an `aria-label` is the exact case the pass exists to catch, and
+  every `sr-only` node measures as good as zero. It uses `checkVisibility()`
+  instead — `display: none`, `visibility: hidden` and skipped `content-visibility`
+  subtrees are dropped, because then nobody receives the label; opacity and
+  off-screen positioning are kept, because the accessibility tree keeps them.
+- **An empty value is never reported.** `alt=""` is load-bearing markup — it marks
+  an image as decorative so screen readers skip it — and flagging it would push
+  authors into writing alt text for spacers.
+- **Findings are keyed by attribute and value, not by element**, with a `(×N)`
+  count. One un-migrated shared component rendered on twenty rows would otherwise
+  bury every other string on the screen.
+
+The guard is still the primary defence: those five attributes are in
+`jsx-attributes.include`, so on an allowlisted path the lint rule flags the
+literal before it ever renders. The oracle is the second check that attribute copy
+previously had none of — on a path not yet allowlisted, or for a fragment the
+`words.exclude` patterns skip. Prefer a `t()` call over a template literal in an
+attribute either way, so the value stays greppable.
 
 ### …and it is weakest at an interpolated value
 


### PR DESCRIPTION
The pseudo-locale oracle walked `NodeFilter.SHOW_TEXT` only, so copy carried in `aria-label` / `aria-description` / `title` / `placeholder` / `alt` was structurally unreachable — it renders nothing visible and left no trace under pseudo, which #2194's review demonstrated by reverting an `aria-label` to an English template literal and watching nothing fail. `findUnlocalizedCopy` now runs a second pass over those five attributes, so the copy only screen-reader users receive finally has the second check every visible string already had.

## Important Changes

- **A second pass over `document.querySelectorAll("[aria-label],…")`**, sharing the word-like test and the longest-first allowlist stripping with the text walk. Both passes live in one `page.evaluate` around one predicate, so the two halves cannot drift.
- **`COPY_ATTRIBUTES` mirrors `jsx-attributes.include`** in `eslint.i18n.options.mjs`. The guard flags the literal at lint time on an allowlisted path; this checks the same five at render on any path. `aria-labelledby` / `aria-describedby` / `aria-controls` stay out of both — element ids, not prose.
- **Findings name the attribute and the element**: `aria-label on button#language-select: "Display language (pseudo)"`. A bare string is not actionable for copy that is invisible on screen.
- **A positive control, because an empty result is ambiguous here.** A migrated attribute renders `Mōŕē ĩńfōŕmàţĩōń`, which has no 4-letter ASCII run and is dropped at the `wordlike` gate before the accented test sees it. Soundness is unaffected — a real miss is pure ASCII — but a working pass and a pass whose selector matched *nothing* produce identical empty output. Each screen asserts `inspectedAttributes > 0` and prints how many rendered fully accented; one dedicated test pins accent detection against `#language-select`'s known-migrated `aria-label`.

### The design decisions, and why

**The zero-size-rect check is not reused.** The text pass drops zero-size nodes because there is nothing on screen to read; that reasoning inverts for an attribute. A visually hidden control with an `aria-label` is precisely what this pass exists to catch, and every `sr-only` node measures as good as zero — reusing the rect check would have made the new pass blind to its own motivating case. It uses `checkVisibility({ contentVisibilityAuto: true, visibilityProperty: true })` instead: `display: none`, `visibility: hidden` and skipped `content-visibility` subtrees are dropped, because then *nobody* receives the label. `opacityProperty` is deliberately omitted — an opacity-0 element is still in the accessibility tree.

**Empty values are skipped, never reported.** `alt=""` is load-bearing markup: it marks an image decorative so screen readers skip it. Flagging one would push authors into writing alt text for spacers, which is worse than the miss.

**`title` is checked on every element, not just interactive ones.** A `title` is exposed as an accessible name or description whatever the element is, and the browser renders its native tooltip on hover for any of them — "the app never shows this one" is not true of a rendered `title`. Restricting it to interactive elements needs a tag/role/tabindex heuristic, and that heuristic becomes the next place attribute copy hides. The guard checks `title` unconditionally too, so the two stay in step.

**Findings are keyed by attribute+value, not by element,** with a `(×N)` count and the first element as the sample. One un-migrated shared component rendered on twenty rows would otherwise bury every other string on the screen.

**One accented character does not clear an attribute** — the pass's one deliberate divergence from the text walk, and the one change here that goes beyond "port the same logic". See below; it was not a design choice up front, it was a bug the positive control found.

**A narrower skip-tag set for attributes** (`SCRIPT` / `STYLE` / `NOSCRIPT`). `skipTags` encodes "this element's *content* is not prose", which is a different question from whether its *label* is — an `aria-label` on an `<svg>` or a `title` on a `<code>` chip is copy either way, and reusing the text set would have excluded exactly where icon labels live.

### The false negative the positive control found

**The accent check answers "is *any* of this translated", never "is *all* of it translated."** That is the finding; everything below is mechanism. It has two directions, and this PR only closes one of them.

`docs/i18n.md` already records the first: an **un-migrated value inside a migrated frame** — `Ữńàƀĺē ţō śţàŕţ ūþďàţē: Agent installation is already in progress.` Accented frame, English payload, reads as done.

This is the mirror image — an **un-migrated frame around a migrated value** — and it is the worse of the two, because accent-clears-all does not merely fail to notice it, it *counts it as evidence of migration*. Building the positive control is what surfaced it, by sampling one as proof:

```text
aria-label on button: "Collapse Ĝēńēŕàĺ"
```

That is `settings-nav-primitives.tsx`'s `` aria-label={`Collapse ${label}`} `` — an un-migrated English **frame** around a migrated value. It was being counted as proof of migration *and* excluded from the leftovers. The text pass has the same blind spot by design, but for attributes there is no other check, which is the whole premise of this PR.

The separator is allowlist stripping, not accenting. Attributes now strip allowlisted tokens and look for a surviving ASCII word run regardless of accented characters:

| value | verdict |
| --- | --- |
| `Collapse Ĝēńēŕàĺ` | reported — `Collapse` survives the strip; English frame |
| `Àćţĩōńś ƒōŕ Agent` | clear — `Agent` is allowlisted layout data, strips to nothing |
| `Àĝēńţ ţũŕń ƒĩńĩśĥēď ƒōŕ Desktop Notifications` | clear — allowlisted provider name |
| `Ĺàŷōũţ ƥŕōƒĩĺēś` | clear — fully migrated; counts as positive control |

Net effect measured across the 8 screens: **+2 real findings, −4 false positives.** Such findings are tagged `— English frame, migrated value`.

**Known remaining gap, deliberately not closed here: the text pass still has the un-migrated-frame hole.** Its rule is unchanged — one accented character still clears a text node — so a visible `Collapse Ĝēńēŕàĺ` would go unreported. That is scope discipline, not a verdict: applying the same generalisation to the text walk changes the finding set on every screen at once and needs its own measurement, which does not belong in a PR about attributes. Read it as deferred, not settled.

### Why the control is split in two

Asserting "at least one fully-accented attribute" *per screen* was tried and dropped: it fired on secrets, terminal and sprites, which legitimately render none — no labelled icon controls, nothing to find. Per-screen fully-accented counts are 0, 0, 0, 2, 8, 12, 30 and one more. So:

- **per screen** — `inspectedAttributes > 0` (19–49 in practice). This is what actually catches a selector matching nothing.
- **once** — a dedicated test asserting `#language-select`'s migrated `aria-label` comes back accented. Standing proof the accent detection works, without the false alarms.

## Validation

Mutation-checked, because an oracle that passes when it should fail is worth nothing. `components/settings/language-settings.tsx` is on the appearance screen, which is in `SCREENS` and on the guard allowlist; its `aria-label={t("settings:displayLanguage")}` was reverted to an English template literal (``aria-label={`Display language (${locale})`}``), `dist` rebuilt, and the appearance test run under both oracles. Comparing finding sets, since the screen is not green to begin with (see below):

| run | oracle | tree | findings |
| --- | --- | --- | --- |
| A | `main` | clean | 12 |
| B | `main` | **mutated** | 12 — **byte-identical to A** |
| C | this PR | clean | 30 |
| D | this PR | **mutated** | 31 |
| E | this PR | restored | 30 — byte-identical to C |

B vs A is the finding: the old oracle does not notice. D vs C is the fix — one new line, and it says where to look:

```text
aria-label on button#language-select: "Display language (pseudo)"
```

The first attempt at D produced no delta at all. The e2e harness serves the prebuilt `apps/web/dist`, so a source mutation is invisible until `make build-web` runs — worth knowing before anyone repeats this and concludes the pass does not work.

```
pnpm run typecheck                  # clean
pnpm lint --max-warnings 0          # clean
pnpm run i18n:check                 # 4/4 gates pass
pnpm run i18n:ratchet               # clean; allowlist 192, unchanged
pnpm test                           # 1073 files, 8129 passed | 4 skipped
KANDEV_I18N_COVERAGE=1 pnpm exec playwright test … pseudo-coverage.spec.ts
```

### What the new pass found, reported and NOT fixed

18 distinct attribute findings, **identical on all 8 screens** — so it is not noisy, it is one fixed set of shared chrome. **Every one belongs to a path that is not in `i18nGuardFiles`; not one comes from a migrated file.** The migrated screens' own attribute copy is clean, which is the reassuring half of the result.

| owner | findings |
| --- | --- |
| `components/app-sidebar/**` | `Kandev home`, `Switch workspace`, `Collapse sidebar`, `Close settings` (×2), `Stats`, `Improve Kandev`, `What's new`, `Office`, `Resize sidebar` |
| `components/app-sidebar/sections/settings/settings-nav-primitives.tsx` | `Expand Workspaces` / `Expand Executors` / `Expand System`, plus `Collapse Ĝēńēŕàĺ` / `Expand Àĝēńţś` — the same `` `Expand ${label}` `` template, reported or not depending only on whether the interpolated group name happens to be migrated |
| `components/app-status-bar/app-status-bar.tsx` | `Application status` |
| `components/global-commands.tsx` | `Configuration Chat` |
| `packages/ui/src/breadcrumb.tsx` | `breadcrumb` — shadcn's hardcoded landmark name |
| `sonner` (third-party) | `Notifications alt+T` — the toast container's default `containerAriaLabel` |

Two of these are cheap wins already located, for whoever flips the gate to hard: sonner's is a `containerAriaLabel` prop on `<Toaster>` in `app/layout.tsx`, and the breadcrumb is ours to localize in `packages/ui/src/breadcrumb.tsx`. Neither needs a vendor change.

**Third-party attribute copy — decision: in scope for reporting, out of scope for fixing here.** Excluding it needs an allowlist entry, and an entry broad enough to match vendor defaults will also hide our own copy — the argument this file already makes about broad tokens. Two of the three are fixable without touching a vendor anyway: sonner takes `containerAriaLabel` on `<Toaster>` in `app/layout.tsx`, and `@kandev/ui` is ours. Whoever flips the gate to hard decides; this PR does not. It is the same shape as the unowned-shared-copy case #2204 just documented.

### Pre-existing, and NOT caused by this PR: the gate is already red

`SCREENS` does not pass on `main` in the Playwright harness — all 8 screens fail on **12 text findings**, before this change and with the old oracle (run A above). Verified by running `git show HEAD:…/pseudo-coverage.spec.ts` unmodified:

```text
E2E Workspace · Settings · Workspaces · Prompts · Voice Mode · Utility Agents
Executors · Secrets · External MCP · Plugins · System · Toggle theme
```

Eleven are the settings nav tree's top-level group labels plus `Toggle theme` — the same list the spec's own "NOT YET" comment says renders plain English from the un-migrated `workspaces-group.tsx` / `settings-tree.tsx`. The comment claims `/settings/general/*` passes because its expanded branch is the migrated `general-group.tsx`, but sibling group *headers* render whether or not they are expanded, so the claim does not hold here. The twelfth, `E2E Workspace`, is the fixture's workspace name — user data, and unallowlisted, so the spec cannot go green under this harness at all. That points at these screens having been verified against a live instance rather than through `pnpm exec playwright`, which is what the file's workflows comment says was done there.

Left entirely alone, per the brief: fixing it means migrating the settings nav, which is a directory that belongs to its own PR.

For routing, the 12 split 11 chrome / 1 fixture data:

| finding | source |
| --- | --- |
| `Prompts`, `Voice Mode`, `Utility Agents`, `Secrets`, `External MCP`, `Plugins` | `components/app-sidebar/sections/settings/settings-tree.tsx` |
| `Workspaces` | `…/sections/settings/workspaces-group.tsx` |
| `Executors` | `…/sections/settings/executors-group.tsx` |
| `System` | `…/sections/settings/system-group.tsx` |
| `Settings` | `components/app-sidebar/app-sidebar-footer.tsx` |
| `Toggle theme` | `components/theme-toggle.tsx` — an `sr-only` span, which has a 1px rect and so survives the zero-size check |
| `E2E Workspace` | not chrome — the fixture's workspace name, i.e. user data that was never eligible |

Also observed while running the file repeatedly: `activatePseudo` intermittently times out with `<html>` never receiving a `lang` attribute. It does not correlate with a screen — it hit appearance and the new control test in one run, notifications in the next. It does correlate with run length: **0 timeouts across four 8-test runs and three single-test runs, then 2 and 1 across the two 9-test runs.** `workers: 1`, so parallelism is not the variable. Small n, not investigated; noting it so the next person does not read it as a real finding.

## Possible Improvements

Low risk — the gate is opt-in (`KANDEV_I18N_COVERAGE=1`), deliberately still not enabled in CI, and the text pass is behaviourally unchanged (its rule is now expressed as `!accented && hasUnmigratedAscii`, which is the same predicate it always applied). The judgement call that could bite is `checkVisibility` over the rect check: a label inside a subtree hidden by a mechanism it does not model would be reported rather than skipped. That fails toward noise, not silence, which is the correct direction for this gate.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have manually tested my changes and they work as expected. — the five-run mutation table above, with `dist` rebuilt between mutation and restore.
- [x] My changes have tests that cover the new functionality and edge cases. — this PR *is* the test; the mutation check and the pinned positive control are its coverage argument.
- [x] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`. — the changed file is the Playwright spec; verified with the targeted `KANDEV_I18N_COVERAGE=1` run rather than the full suite, since the gate is opt-in and excluded from CI.
- [x] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed. — no public-docs impact. `docs/i18n.md` is contributor documentation and is updated here: the section that recorded this as a known gap now describes the pass, its four deliberate choices, the positive-control requirement, and the guard/oracle split that still holds.