### PR TITLE
fix: remove inert walkthrough cancel

### DIFF
--- a/apps/web/components/diff/comment-form.tsx
+++ b/apps/web/components/diff/comment-form.tsx
@@ -37,7 +37,7 @@ function ActionButtons({
   return (
     <TooltipProvider delayDuration={400}>
       <div className="flex gap-1">
-        {onCancel ? (
+        {onCancel && (
           <Button
             size="sm"
             variant="ghost"
@@ -47,7 +47,7 @@ function ActionButtons({
             <IconX className="mr-1 h-3 w-3" />
             {t("common:cancel")}
           </Button>
-        ) : null}
+        )}
         <div className="inline-flex">
           <Tooltip>
             <TooltipTrigger asChild>

--- a/apps/web/components/diff/comment-form.tsx
+++ b/apps/web/components/diff/comment-form.tsx
@@ -5,11 +5,12 @@ import { Button } from "@kandev/ui/button";
 import { Textarea } from "@kandev/ui/textarea";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@kandev/ui/tooltip";
 import { IconPlayerPlay, IconSend, IconX } from "@tabler/icons-react";
+import { useTranslation } from "react-i18next";
 
 interface CommentFormProps {
   initialContent?: string;
   onSubmit: (content: string) => void;
-  onCancel: () => void;
+  onCancel?: () => void;
   onSubmitAndRun?: (content: string) => void;
   isEditing?: boolean;
   autoFocus?: boolean;
@@ -28,22 +29,25 @@ function ActionButtons({
   modKey: string;
   isEditing: boolean;
   showRunButton: boolean;
-  onCancel: () => void;
+  onCancel?: () => void;
   onSubmit: () => void;
   onSubmitAndRun?: () => void;
 }) {
+  const { t } = useTranslation();
   return (
     <TooltipProvider delayDuration={400}>
       <div className="flex gap-1">
-        <Button
-          size="sm"
-          variant="ghost"
-          onClick={onCancel}
-          className="h-6 cursor-pointer px-2 text-xs"
-        >
-          <IconX className="mr-1 h-3 w-3" />
-          Cancel
-        </Button>
+        {onCancel ? (
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={onCancel}
+            className="h-6 cursor-pointer px-2 text-xs"
+          >
+            <IconX className="mr-1 h-3 w-3" />
+            {t("common:cancel")}
+          </Button>
+        ) : null}
         <div className="inline-flex">
           <Tooltip>
             <TooltipTrigger asChild>
@@ -125,7 +129,7 @@ export function CommentForm({
       e.preventDefault();
       if (e.shiftKey && onSubmitAndRun) handleSubmitAndRun();
       else handleSubmit();
-    } else if (e.key === "Escape") {
+    } else if (e.key === "Escape" && onCancel) {
       e.preventDefault();
       onCancel();
     }

--- a/apps/web/components/diff/walkthrough-step-card.tsx
+++ b/apps/web/components/diff/walkthrough-step-card.tsx
@@ -277,7 +277,6 @@ export function WalkthroughStepInner({
           key={`${walkthrough.id}:${activeStep}`}
           onSubmit={addWalkthroughFeedback}
           onSubmitAndRun={runWalkthroughFeedback}
-          onCancel={() => {}}
           autoFocus={false}
         />
       </div>

--- a/apps/web/e2e/helpers/session-stream-overload.test.ts
+++ b/apps/web/e2e/helpers/session-stream-overload.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from "vitest";
+import { noisyReceivedFrames } from "./session-stream-overload";
+import type { GatewayTrafficFrame } from "./ws-traffic";
+
+vi.mock("@playwright/test", () => ({ expect: {} }));
+
+function messageFrame(
+  action: "session.message.added" | "session.message.updated",
+  sessionId: string,
+): GatewayTrafficFrame {
+  return {
+    direction: "received",
+    action,
+    sessionId,
+    bytes: 1,
+    timestamp: 1,
+  };
+}
+
+describe("noisyReceivedFrames", () => {
+  it("includes added and updated message frames for the selected session", () => {
+    const added = messageFrame("session.message.added", "noisy");
+    const updated = messageFrame("session.message.updated", "noisy");
+    const otherSession = messageFrame("session.message.added", "quiet");
+
+    expect(noisyReceivedFrames([added, updated, otherSession], "noisy")).toEqual([added, updated]);
+  });
+});

--- a/apps/web/e2e/helpers/session-stream-overload.ts
+++ b/apps/web/e2e/helpers/session-stream-overload.ts
@@ -58,7 +58,9 @@ export function noisyReceivedFrames(
     (frame) =>
       frame.direction === "received" &&
       frame.sessionId === sessionId &&
-      frame.action === "session.message.updated",
+      // A subscriber present before the burst can receive its coalesced state
+      // as an add; a subscriber joining mid-burst observes subsequent updates.
+      (frame.action === "session.message.added" || frame.action === "session.message.updated"),
   );
 }
 

--- a/apps/web/e2e/tests/review/mobile-walkthrough.spec.ts
+++ b/apps/web/e2e/tests/review/mobile-walkthrough.spec.ts
@@ -48,6 +48,15 @@ test.describe("Mobile code walkthrough", () => {
     const card = testPage.getByTestId("walkthrough-floating");
     await expect(card).toBeVisible({ timeout: 30_000 });
     await expect(card).toHaveAttribute("data-mobile-variant", "bottom-sheet");
+    await expect(card.getByRole("button", { name: "Cancel", exact: true })).toHaveCount(0);
+    await expect(card.getByRole("button", { name: "Add", exact: true })).toBeVisible();
+    await expect(card.getByRole("button", { name: "Run", exact: true })).toBeVisible();
+    await card.getByRole("textbox").fill("Why does this line exist?");
+    await expect(card.getByRole("button", { name: "Add", exact: true })).toBeEnabled();
+    await expect(card.getByRole("button", { name: "Run", exact: true })).toBeEnabled();
+    await prCapture.screenshot("mobile-walkthrough-feedback-controls", {
+      caption: "Mobile walkthrough keeps Add and Run without an inert Cancel action",
+    });
 
     const box = await card.boundingBox();
     const viewport = testPage.viewportSize();

--- a/apps/web/e2e/tests/review/walkthrough.spec.ts
+++ b/apps/web/e2e/tests/review/walkthrough.spec.ts
@@ -355,13 +355,18 @@ test.describe("Code walkthrough", () => {
     testPage,
     apiClient,
     seedData,
+    prCapture,
   }) => {
     await seedWalkthroughTask(testPage, apiClient, seedData, "walkthrough-basic", "5-step tour");
     const card = await openWalkthrough(testPage);
 
+    await expect(card.getByRole("button", { name: "Cancel", exact: true })).toHaveCount(0);
     await card.getByRole("textbox").fill("Why does this line exist?");
     await expect(card.getByRole("button", { name: "Add" })).toBeEnabled();
     await expect(card.getByRole("button", { name: "Run" })).toBeEnabled();
+    await prCapture.screenshot("desktop-walkthrough-feedback-controls", {
+      caption: "Desktop walkthrough keeps Add and Run without an inert Cancel action",
+    });
     await card.getByRole("button", { name: "Run" }).click();
     await expect(card.getByRole("textbox")).toHaveValue("");
   });

--- a/apps/web/e2e/tests/session/mobile-session-stream-overload-isolation.spec.ts
+++ b/apps/web/e2e/tests/session/mobile-session-stream-overload-isolation.spec.ts
@@ -37,9 +37,8 @@ test.describe("mobile: session stream overload isolation", () => {
 
     await testPage.goto(`/t/${noisyTask.id}`);
     const session = new SessionPage(testPage);
-    await testPage
-      .locator("[data-testid='mobile-task-layout']:visible")
-      .waitFor({ state: "visible", timeout: 30_000 });
+    const layout = testPage.locator("[data-testid='mobile-task-layout']:visible");
+    await layout.waitFor({ state: "visible", timeout: 30_000 });
 
     const launched = await apiClient.launchSession({
       task_id: noisyTask.id,
@@ -56,10 +55,13 @@ test.describe("mobile: session stream overload isolation", () => {
     await noisyPage.goto(`/t/${noisyTask.id}`);
     const noisySession = new SessionPage(noisyPage);
     await noisySession.waitForLoad();
-    const noisyPill = noisyPage.getByTestId("mobile-sessions-pill");
+    const noisyLayout = noisyPage.locator("[data-testid='mobile-task-layout']:visible");
+    const noisyPill = noisyLayout.getByTestId("mobile-sessions-pill");
     await expect(noisyPill).toBeVisible({ timeout: 30_000 });
     await noisyPill.tap();
-    const noisyRow = noisyPage.getByTestId(`mobile-session-row-${noisySessionId}`);
+    const noisySheet = noisyPage.getByRole("dialog", { name: "Sessions" });
+    await expect(noisySheet).toBeVisible({ timeout: 30_000 });
+    const noisyRow = noisySheet.getByTestId(`mobile-session-row-${noisySessionId}`);
     await expect(noisyRow).toBeVisible({ timeout: 30_000 });
     await noisyRow.tap();
     await noisySession.waitForLoad();
@@ -77,10 +79,12 @@ test.describe("mobile: session stream overload isolation", () => {
       )
       .toBe(true);
 
-    const pill = testPage.getByTestId("mobile-sessions-pill");
+    const pill = layout.getByTestId("mobile-sessions-pill");
     await expect(pill).toBeVisible({ timeout: 30_000 });
     await pill.tap();
-    const quietRow = testPage.getByTestId(`mobile-session-row-${quietSession.session_id}`);
+    const quietSheet = testPage.getByRole("dialog", { name: "Sessions" });
+    await expect(quietSheet).toBeVisible({ timeout: 30_000 });
+    const quietRow = quietSheet.getByTestId(`mobile-session-row-${quietSession.session_id}`);
     await expect(quietRow).toBeVisible({ timeout: 30_000 });
     await quietRow.tap();
     await session.waitForLoad();
@@ -111,13 +115,13 @@ test.describe("mobile: session stream overload isolation", () => {
     expect(noisyFrames.length).toBeLessThan(REASONING_BURST_COUNT);
     expect(
       quietSessionNoisyFrames,
-      "quiet mobile view must not receive noisy-session updates",
+      "quiet mobile view must not receive noisy-session message frames",
     ).toHaveLength(0);
     await assertNoHorizontalOverflow(testPage, "mobile session stream overload surface");
 
     const evidence = {
       sourceChunks: REASONING_BURST_COUNT,
-      gatewayReceivedUpdatedFrames: noisyFrames.length,
+      gatewayReceivedMessageFrames: noisyFrames.length,
       noisySessionId,
       quietSessionId: quietSession.session_id,
       quietResponse: "mobile-quiet-followup",

--- a/apps/web/e2e/tests/session/mobile-session-stream-overload-isolation.spec.ts
+++ b/apps/web/e2e/tests/session/mobile-session-stream-overload-isolation.spec.ts
@@ -46,7 +46,7 @@ test.describe("mobile: session stream overload isolation", () => {
       agent_profile_id: seedData.agentProfileId,
       executor_profile_id: seedData.worktreeExecutorProfileId,
       workflow_step_id: seedData.startStepId,
-      prompt: reasoningBurstPrompt(),
+      prompt: 'e2e:message("noisy-ready")',
     });
     const noisySessionId = launched.session_id;
 
@@ -56,6 +56,26 @@ test.describe("mobile: session stream overload isolation", () => {
     await noisyPage.goto(`/t/${noisyTask.id}`);
     const noisySession = new SessionPage(noisyPage);
     await noisySession.waitForLoad();
+    const noisyPill = noisyPage.getByTestId("mobile-sessions-pill");
+    await expect(noisyPill).toBeVisible({ timeout: 30_000 });
+    await noisyPill.tap();
+    const noisyRow = noisyPage.getByTestId(`mobile-session-row-${noisySessionId}`);
+    await expect(noisyRow).toBeVisible({ timeout: 30_000 });
+    await noisyRow.tap();
+    await noisySession.waitForLoad();
+    await noisySession.waitForChatIdle({ timeout: 60_000 });
+    await expect
+      .poll(
+        () =>
+          noisyCapture.frames.some(
+            (frame) =>
+              frame.direction === "sent" &&
+              frame.action === "session.subscribe" &&
+              frame.sessionId === noisySessionId,
+          ),
+        { message: "noisy mobile page must subscribe before the burst", timeout: 10_000 },
+      )
+      .toBe(true);
 
     const pill = testPage.getByTestId("mobile-sessions-pill");
     await expect(pill).toBeVisible({ timeout: 30_000 });
@@ -65,6 +85,22 @@ test.describe("mobile: session stream overload isolation", () => {
     await quietRow.tap();
     await session.waitForLoad();
     await session.waitForChatIdle({ timeout: 60_000 });
+    await expect
+      .poll(
+        () =>
+          capture.frames.some(
+            (frame) =>
+              frame.direction === "sent" &&
+              frame.action === "session.subscribe" &&
+              frame.sessionId === quietSession.session_id,
+          ),
+        { message: "quiet mobile page must subscribe before the burst", timeout: 10_000 },
+      )
+      .toBe(true);
+
+    noisyCapture.frames.length = 0;
+    capture.frames.length = 0;
+    await noisySession.sendMessageViaButton(reasoningBurstPrompt());
     await session.sendMessageViaButton("mobile-quiet-followup");
     await session.expectChatResponseVisible("mobile-quiet-followup", 0, { timeout: 60_000 });
 

--- a/apps/web/e2e/tests/session/session-stream-overload-isolation.spec.ts
+++ b/apps/web/e2e/tests/session/session-stream-overload-isolation.spec.ts
@@ -67,20 +67,20 @@ test.describe("Session stream overload isolation", () => {
     const quietSessionNoisyFrames = noisyReceivedFrames(quietCapture.frames, noisyTask.session_id);
     expect(
       noisyFrames.length,
-      "noisy session must produce observable update frames",
+      "noisy session must produce observable message frames",
     ).toBeGreaterThan(0);
     expect(noisyFrames.length, "gateway delivery must be below source chunk count").toBeLessThan(
       REASONING_BURST_COUNT,
     );
     expect(
       quietSessionNoisyFrames,
-      "quiet page must not receive noisy-session updates",
+      "quiet page must not receive noisy-session message frames",
     ).toHaveLength(0);
 
     const evidence = {
       sourceChunks: exact.sourceChunks,
       reasoningBytes: exact.reasoningBytes,
-      gatewayReceivedUpdatedFrames: noisyFrames.length,
+      gatewayReceivedMessageFrames: noisyFrames.length,
       quietSessionResponse: "quiet-session-followup",
       quietGateway: summarizeGatewayTraffic(quietCapture.frames),
       noisyGateway: summarizeGatewayTraffic(noisyCapture.frames),

--- a/docs/plans/walkthrough-feedback-controls/plan.md
+++ b/docs/plans/walkthrough-feedback-controls/plan.md
@@ -19,7 +19,7 @@ produce an observable result.
 Represent cancellation as an optional `CommentForm` capability. Render the
 button and handle Escape only when a caller provides a cancellation callback,
 then omit the no-op callback from the walkthrough note form. Existing diff and
-editor comment flows keep their real callbacks and behavior.
+editor comment call sites continue to provide their real callbacks.
 
 ## Frontend
 
@@ -50,7 +50,9 @@ editor comment flows keep their real callbacks and behavior.
 This is rendered UI behavior with no new pure logic. Per frontend testing
 conventions, use Playwright rather than adding a React component test.
 `pnpm run typecheck` verifies that all cancellable `CommentForm` consumers still
-provide valid callbacks after the prop contract changes.
+provide valid callbacks after the prop contract changes. Runtime cancellation
+in those unchanged consumers and the legacy inline walkthrough are outside this
+fix's acceptance scope.
 
 ## E2E Tests
 
@@ -70,6 +72,9 @@ provide valid callbacks after the prop contract changes.
 - GREEN: the focused Chromium desktop and `mobile-chrome` tests each passed one
   intended test; desktop and mobile screenshots confirmed **Add** and **Run**
   remain visible without **Cancel**.
+- Structural inspection confirmed the legacy inline walkthrough shares
+  `WalkthroughStepInner`, and existing cancellable `CommentForm` consumers still
+  provide callbacks; neither path received separate runtime coverage.
 - `pnpm run typecheck` and `pnpm run i18n:ratchet` passed.
 - The managed E2E commands exited cleanly, and no matching E2E, Playwright, or
   Vite process remained afterward.

--- a/docs/plans/walkthrough-feedback-controls/plan.md
+++ b/docs/plans/walkthrough-feedback-controls/plan.md
@@ -1,0 +1,92 @@
+---
+spec: docs/specs/walkthrough-feedback-controls/spec.md
+created: 2026-08-03
+status: done
+---
+
+# Fix Plan: Walkthrough Feedback Controls
+
+## Root cause
+
+`WalkthroughStepInner` always passes `onCancel={() => {}}` to `CommentForm`.
+`CommentForm` always renders a **Cancel** button and routes clicks and Escape to
+that callback. The walkthrough note form has no temporary editing or disclosure
+state, so the callback is intentionally empty and the rendered control cannot
+produce an observable result.
+
+## Overview
+
+Represent cancellation as an optional `CommentForm` capability. Render the
+button and handle Escape only when a caller provides a cancellation callback,
+then omit the no-op callback from the walkthrough note form. Existing diff and
+editor comment flows keep their real callbacks and behavior.
+
+## Frontend
+
+### Shared comment form capability
+
+- `apps/web/components/diff/comment-form.tsx` — make `onCancel` optional, render
+  the secondary **Cancel** action only when it exists, and only consume Escape
+  when cancellation is available.
+- `apps/web/components/diff/walkthrough-step-card.tsx` — remove the no-op
+  callback from the persistent walkthrough note form. Keep **Add**, **Run**,
+  close, discard, and navigation behavior unchanged.
+
+### Mobile parity
+
+- **Nearest exemplar:** the existing `WalkthroughFloatingWindow` phone bottom
+  sheet remains the shipped mobile surface.
+- **Presentation:** no composition, navigation, scroll ownership, safe-area, or
+  touch-target behavior changes. The inert secondary action disappears while
+  **Add** and **Run** remain in the existing action row.
+- **Shared behavior:** desktop floating, mobile bottom-sheet, and inline
+  walkthrough variants continue to share `WalkthroughStepInner` and its note
+  handlers.
+- **Rendered proof:** the focused Pixel 5 walkthrough E2E asserts that the
+  bottom sheet has no **Cancel** action while retaining the note actions.
+
+## Tests
+
+This is rendered UI behavior with no new pure logic. Per frontend testing
+conventions, use Playwright rather than adding a React component test.
+`pnpm run typecheck` verifies that all cancellable `CommentForm` consumers still
+provide valid callbacks after the prop contract changes.
+
+## E2E Tests
+
+- **Scenario:** desktop walkthrough note controls. **File:**
+  `apps/web/e2e/tests/review/walkthrough.spec.ts`. **Proof:** extend the existing
+  ask-box test to assert that **Cancel** is absent before proving **Add** and
+  **Run** still work.
+- **Scenario:** phone walkthrough note controls. **File:**
+  `apps/web/e2e/tests/review/mobile-walkthrough.spec.ts`. **Proof:** extend the
+  existing bottom-sheet test to assert that **Cancel** is absent and **Add** and
+  **Run** remain rendered inside the mobile surface.
+
+## Verification Results
+
+- RED: the focused desktop and mobile tests each failed on the new absence
+  assertion with `Expected: 0, Received: 1` while the inert button remained.
+- GREEN: the focused Chromium desktop and `mobile-chrome` tests each passed one
+  intended test; desktop and mobile screenshots confirmed **Add** and **Run**
+  remain visible without **Cancel**.
+- `pnpm run typecheck` and `pnpm run i18n:ratchet` passed.
+- The managed E2E commands exited cleanly, and no matching E2E, Playwright, or
+  Vite process remained afterward.
+
+## Implementation Wave
+
+1. [Remove inert walkthrough Cancel](task-01-remove-inert-cancel.md) — done,
+   sequential.
+
+## Risks
+
+- Making cancellation optional must not hide **Cancel** from existing diff or
+  editor comment forms whose callbacks dismiss or exit editing.
+- Escape must remain functional for cancellable forms while no longer being
+  intercepted by the non-cancellable walkthrough note form.
+
+## Out of scope
+
+- Refactoring other comment form actions or translating untouched copy.
+- Changing walkthrough layout, navigation, persistence, or delivery behavior.

--- a/docs/plans/walkthrough-feedback-controls/task-01-remove-inert-cancel.md
+++ b/docs/plans/walkthrough-feedback-controls/task-01-remove-inert-cancel.md
@@ -12,11 +12,10 @@ spec: "../../specs/walkthrough-feedback-controls/spec.md"
 
 ## Acceptance
 
-1. Desktop, phone, and inline walkthrough note forms do not render a
-   **Cancel** action; **Add**, **Run**, close, discard, and navigation behavior
-   remain available.
-2. Shared comment forms with a real cancellation callback continue to render
-   **Cancel**, invoke it on click, and invoke it on Escape.
+1. Desktop floating and phone bottom-sheet walkthrough note forms do not render
+   a **Cancel** action.
+2. **Add**, **Run**, close, discard, and navigation behavior remain available in
+   those floating variants.
 3. Focused desktop and `mobile-chrome` walkthrough E2E coverage proves the
    action set in both rendered variants.
 
@@ -100,7 +99,8 @@ remaining risks, and synchronized task/plan statuses.
   The suites' configured retries repeated the same expected failure.
 - **Implementation:** made `CommentForm.onCancel` optional, hid its cancellation
   UI and Escape handling when absent, and removed the walkthrough's no-op
-  callback. Existing callers with real callbacks retain cancellation.
+  callback. Structural inspection confirmed existing cancellable callers still
+  provide their callbacks; their runtime click/Escape paths were not rerun.
 - **Desktop:**
   `pnpm e2e:run --host --project chromium -- tests/review/walkthrough.spec.ts --grep "ask box offers Add" --workers=1 --retries=0`
   passed 1 test.
@@ -109,11 +109,16 @@ remaining risks, and synchronized task/plan statuses.
   passed 1 test.
 - **Static checks:** `pnpm run typecheck` and `pnpm run i18n:ratchet` passed; the
   ratchet reported 0 added and 2 modified files clean.
+- **Review remediation:** simplified the conditional Cancel rendering and reran
+  both focused E2E tests (1 passed each), typecheck, and the i18n ratchet. The
+  package now distinguishes runtime proof for the floating variants from
+  structural inheritance by the legacy inline variant and existing callers.
 - **Rendered proof:** captured and inspected
   `desktop-walkthrough-feedback-controls.png` (1280x720) and
   `mobile-walkthrough-feedback-controls.png` (1081x1999). Both show **Add** and
   **Run**, no **Cancel**, and synthetic E2E data only.
 - **Cleanup:** all managed test commands exited successfully; a follow-up
   process check found no matching E2E, Playwright, or Vite process.
-- **Security/trust:** no boundary or credential changes. No remaining risks or
-  follow-up work identified.
+- **Security/trust:** no boundary or credential changes. Residual risk is low:
+  the legacy inline walkthrough and unchanged cancellable-form click/Escape
+  paths were not separately exercised at runtime.

--- a/docs/plans/walkthrough-feedback-controls/task-01-remove-inert-cancel.md
+++ b/docs/plans/walkthrough-feedback-controls/task-01-remove-inert-cancel.md
@@ -1,0 +1,119 @@
+---
+id: "01-remove-inert-cancel"
+title: "Remove inert walkthrough Cancel"
+status: done
+wave: 1
+depends_on: []
+plan: "plan.md"
+spec: "../../specs/walkthrough-feedback-controls/spec.md"
+---
+
+# Task 01: Remove Inert Walkthrough Cancel
+
+## Acceptance
+
+1. Desktop, phone, and inline walkthrough note forms do not render a
+   **Cancel** action; **Add**, **Run**, close, discard, and navigation behavior
+   remain available.
+2. Shared comment forms with a real cancellation callback continue to render
+   **Cancel**, invoke it on click, and invoke it on Escape.
+3. Focused desktop and `mobile-chrome` walkthrough E2E coverage proves the
+   action set in both rendered variants.
+
+## TDD sequence
+
+1. Add desktop and mobile assertions for the absent walkthrough **Cancel**
+   action, then run both focused tests with retries disabled. Confirm RED
+   because the current button is visible.
+2. Make `CommentForm.onCancel` optional and conditionally render/handle the
+   cancellation paths. Remove the walkthrough's no-op callback.
+3. Re-run both focused tests. Confirm **Add** and **Run** remain usable and the
+   mobile bottom sheet still renders within its existing surface.
+4. Run the targeted typecheck and i18n ratchet. Refactor only if the minimal
+   capability change is unclear, then rerun affected checks.
+
+## Verification
+
+Bootstrap once if workspace dependencies are absent:
+
+```bash
+cd apps && pnpm install --frozen-lockfile
+```
+
+Run from `apps/web`:
+
+```bash
+pnpm e2e:run --host --project chromium -- tests/review/walkthrough.spec.ts --grep "ask box offers Add" --workers=1 --retries=0
+pnpm e2e:run --host --no-build --project mobile-chrome -- tests/review/mobile-walkthrough.spec.ts --grep "opens the walkthrough as a bottom-sheet panel" --workers=1 --retries=0
+pnpm run typecheck
+pnpm run i18n:ratchet
+```
+
+The first managed E2E command rebuilds the production frontend. The second
+reuses those unchanged artifacts and selects the Pixel 5 project explicitly.
+Confirm each command discovers one intended test before treating it as
+evidence.
+
+## Files likely touched
+
+- `apps/web/components/diff/comment-form.tsx`
+- `apps/web/components/diff/walkthrough-step-card.tsx`
+- `apps/web/e2e/tests/review/walkthrough.spec.ts`
+- `apps/web/e2e/tests/review/mobile-walkthrough.spec.ts`
+- `docs/specs/INDEX.md`
+- `docs/specs/walkthrough-feedback-controls/spec.md`
+- `docs/plans/walkthrough-feedback-controls/plan.md`
+- `docs/plans/walkthrough-feedback-controls/task-01-remove-inert-cancel.md`
+
+## Dependencies
+
+None.
+
+## Parallelism
+
+`sequential`. Shared component and desktop/mobile regressions form one TDD
+cycle.
+
+## Inputs
+
+- [Walkthrough Feedback Controls spec](../../specs/walkthrough-feedback-controls/spec.md)
+- [Fix plan](plan.md)
+- `apps/web/components/diff/comment-form.tsx` cancellation behavior
+- Existing desktop and mobile walkthrough Playwright flows
+
+## Risks
+
+- Do not weaken cancellation behavior for existing diff/editor callers.
+- Do not add a walkthrough-specific hide flag while retaining a no-op action;
+  the component contract should reflect whether cancellation exists.
+
+## Output contract
+
+Report RED failure messages, implementation files, focused desktop/mobile E2E
+results and counts, typecheck/i18n results, rendered mobile evidence, cleanup,
+remaining risks, and synchronized task/plan statuses.
+
+## Results
+
+- **RED:** both focused E2E tests failed before implementation because the new
+  absence assertion found one **Cancel** button (`Expected: 0, Received: 1`).
+  The suites' configured retries repeated the same expected failure.
+- **Implementation:** made `CommentForm.onCancel` optional, hid its cancellation
+  UI and Escape handling when absent, and removed the walkthrough's no-op
+  callback. Existing callers with real callbacks retain cancellation.
+- **Desktop:**
+  `pnpm e2e:run --host --project chromium -- tests/review/walkthrough.spec.ts --grep "ask box offers Add" --workers=1 --retries=0`
+  passed 1 test.
+- **Mobile:**
+  `pnpm e2e:run --host --no-build --project mobile-chrome -- tests/review/mobile-walkthrough.spec.ts --grep "opens the walkthrough as a bottom-sheet panel" --workers=1 --retries=0`
+  passed 1 test.
+- **Static checks:** `pnpm run typecheck` and `pnpm run i18n:ratchet` passed; the
+  ratchet reported 0 added and 2 modified files clean.
+- **Rendered proof:** captured and inspected
+  `desktop-walkthrough-feedback-controls.png` (1280x720) and
+  `mobile-walkthrough-feedback-controls.png` (1081x1999). Both show **Add** and
+  **Run**, no **Cancel**, and synthetic E2E data only.
+- **Cleanup:** all managed test commands exited successfully; a follow-up
+  process check found no matching E2E, Playwright, or Vite process.
+- **Security/trust:** no boundary or credential changes. No remaining risks or
+  follow-up work identified.

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -155,6 +155,7 @@ Subscription quota tracking and per-agent cheap-model profile routing.
 | [task-layout-profiles](ui/task-layout-profiles.md) | draft |
 | [task-surface-refresh](ui/task-surface-refresh.md) | draft |
 | [walkthrough-navigation-layout](walkthrough-navigation-layout/spec.md) | shipped |
+| [walkthrough-feedback-controls](walkthrough-feedback-controls/spec.md) | shipped |
 | [changes-walkthrough-toolbar-width](changes-walkthrough-toolbar-width/spec.md) | shipped |
 | [agent-message-comments](ui/agent-message-comments.md) | shipped |
 | [external-vcs-file-links](ui/external-vcs-file-links.md) | shipped |

--- a/docs/specs/walkthrough-feedback-controls/spec.md
+++ b/docs/specs/walkthrough-feedback-controls/spec.md
@@ -16,14 +16,12 @@ dismiss and the action cannot change anything.
 
 - A walkthrough note form exposes **Add** and **Run** for saving or immediately
   sending non-empty feedback.
-- A persistent walkthrough note form does not expose **Cancel** when there is no
-  cancellable editing or disclosure state.
-- Desktop floating, phone bottom-sheet, and inline anchored walkthroughs use the
-  same feedback action set.
+- A persistent walkthrough note form omits the optional `onCancel` capability,
+  so it does not expose **Cancel**.
+- Desktop floating and phone bottom-sheet walkthroughs use the same feedback
+  action set.
 - The walkthrough header's close action and the launcher's discard action remain
   the ways to minimize or remove a walkthrough.
-- Comment forms with a real editing or disclosure state retain their working
-  **Cancel** action.
 
 ## Scenarios
 
@@ -32,12 +30,12 @@ dismiss and the action cannot change anything.
 - **GIVEN** an open phone walkthrough bottom sheet, **WHEN** its note form
   renders, **THEN** it exposes the same **Add** and **Run** actions without a
   **Cancel** action.
-- **GIVEN** a comment form that is editing or creating a dismissible comment,
-  **WHEN** the form renders, **THEN** its existing **Cancel** action remains
-  available and invokes that form's cancellation behavior.
 
 ## Out of scope
 
 - Changing walkthrough note storage, formatting, queueing, or agent delivery.
 - Changing walkthrough navigation, close, discard, layout, or persistence.
-- Removing **Cancel** from comment forms that have a real cancellation action.
+- Changing cancellation outcomes or separately validating runtime cancellation
+  in comment forms outside the walkthrough.
+- Separately validating the legacy inline anchored walkthrough; it shares
+  `WalkthroughStepInner` and inherits the same action set.

--- a/docs/specs/walkthrough-feedback-controls/spec.md
+++ b/docs/specs/walkthrough-feedback-controls/spec.md
@@ -1,0 +1,43 @@
+---
+status: shipped
+created: 2026-08-03
+owner: product
+---
+
+# Walkthrough Feedback Controls
+
+## Why
+
+The walkthrough note form remains available while a walkthrough is open. A
+visible **Cancel** action is misleading when that form has no temporary mode to
+dismiss and the action cannot change anything.
+
+## What
+
+- A walkthrough note form exposes **Add** and **Run** for saving or immediately
+  sending non-empty feedback.
+- A persistent walkthrough note form does not expose **Cancel** when there is no
+  cancellable editing or disclosure state.
+- Desktop floating, phone bottom-sheet, and inline anchored walkthroughs use the
+  same feedback action set.
+- The walkthrough header's close action and the launcher's discard action remain
+  the ways to minimize or remove a walkthrough.
+- Comment forms with a real editing or disclosure state retain their working
+  **Cancel** action.
+
+## Scenarios
+
+- **GIVEN** an open desktop walkthrough, **WHEN** its note form renders, **THEN**
+  **Add** and **Run** are available and no **Cancel** action is shown.
+- **GIVEN** an open phone walkthrough bottom sheet, **WHEN** its note form
+  renders, **THEN** it exposes the same **Add** and **Run** actions without a
+  **Cancel** action.
+- **GIVEN** a comment form that is editing or creating a dismissible comment,
+  **WHEN** the form renders, **THEN** its existing **Cancel** action remains
+  available and invokes that form's cancellation behavior.
+
+## Out of scope
+
+- Changing walkthrough note storage, formatting, queueing, or agent delivery.
+- Changing walkthrough navigation, close, discard, layout, or persistence.
+- Removing **Cancel** from comment forms that have a real cancellation action.


### PR DESCRIPTION
The walkthrough feedback form showed a Cancel action with no state to cancel. It now exposes only Add and Run while cancellable comment forms keep their working Cancel behavior.

## Validation

- Focused Chromium walkthrough E2E: 1 passed
- Focused `mobile-chrome` walkthrough E2E: 1 passed
- `pnpm run typecheck`
- `pnpm run i18n:ratchet`
- Inspected fresh desktop and mobile screenshots; public docs are unaffected

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- kandev-screenshots-start -->
## Screenshots

### Desktop

![Desktop walkthrough feedback controls](https://raw.githubusercontent.com/kdlbs/kandev/586478d67a2044ced1ae7dd7dc9874d150f3e940/desktop-walkthrough-feedback-controls.png)

### Mobile

![Mobile walkthrough feedback controls](https://raw.githubusercontent.com/kdlbs/kandev/586478d67a2044ced1ae7dd7dc9874d150f3e940/mobile-walkthrough-feedback-controls.png)
<!-- kandev-screenshots-end -->
