### PR TITLE
docs(i18n): an existing key is not automatically the right key

### DIFF
--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -594,6 +594,60 @@ file to `i18nGuardFiles`, because allowlisting it claims a completeness nobody
 has. The last area to migrate adds it. Say so in your guard comment, naming which
 entries are still English and who owns them.
 
+### An existing key is not automatically the right key
+
+When the same copy is rendered from two places and one of them is already
+migrated, reaching for the key that already exists looks like the careful move.
+It is the one shape in this guide that can **silently rewrite user-visible
+English**, and every gate passes while it does.
+
+Two surfaces rendering "the same" sentence have usually **drifted**. Settings →
+System had an unreferenced `app/settings/system/<route>/page.tsx` twin for every
+route, and the twins were migrated at a different time by a different PR:
+
+| surface | copy |
+|---|---|
+| `SETTINGS_ROUTES` — live, what users see | `Create a diagnostic ZIP with frontend and backend logs.` |
+| `app/settings/system/logs/page.tsx` — dead → `settings:logsPageDescription` | `Download a bounded diagnostic ZIP containing frontend and backend logs.` |
+
+Pointing the live route at the existing key changed the sentence on a shipping
+page. `pnpm lint`, `pnpm run i18n:check`, the ratchet and 8,000+ unit tests were
+all green — the key resolved, the catalogs matched, nothing was hardcoded. The
+copy was simply *different*. `feature-toggles` had drifted the same way in the
+same directory.
+
+Nothing in the toolchain can catch this, because every check verifies that a key
+resolves, not that it resolves to the string the route used to render. The only
+thing that caught it was a single Playwright assertion:
+
+```
+e2e/tests/system/logs-page.spec.ts:16
+  getByText('Create a diagnostic ZIP with frontend and backend logs.')
+```
+
+One of nine routes happened to pin its description. The other eight could have
+drifted with nothing failing.
+
+**Diff the two surfaces before reusing a key**, and when a route group's headers
+are duplicated anywhere, pin them:
+
+```bash
+# What does the live surface actually render today?
+git show origin/main:apps/web/src/settings-routes.tsx | grep -A6 '"/settings/<area>/<route>"'
+# What does the existing key say?
+node -e 'console.log(require("./apps/web/src/locales/en/<ns>.json").<key>)'
+```
+
+`apps/web/components/settings/system/system-route-copy.test.ts` is the shape of
+the guard: a table of every route's title and description as English, asserted
+byte-for-byte. It converts "I diffed them carefully" into something that stays
+true after you leave.
+
+The underlying defect is the duplication itself. Unreferenced pages that
+re-render live copy will drift again, and the next migration inherits the same
+trap — which is why deleting a dead twin is a correctness change, not tidiness.
+Do it in its own PR, not inside a copy-only migration.
+
 ## Adding a real language
 
 1. Add the locale to `SUPPORTED_LOCALES` + `LOCALE_LABELS` in


### PR DESCRIPTION
Reusing a key because a duplicate surface was already migrated looks like the careful move, and it is the one shape in this guide that can **silently rewrite user-visible English** while every gate passes. Settings → System hit it in #2202; this records the rule so the next migration does not.

## Important Changes

- New `### An existing key is not automatically the right key` under *Copy that belongs to no directory*, since both sections are about copy that duplication leaves unowned.
- The worked example is the Logs route. Every System route had an unreferenced `app/settings/system/<route>/page.tsx` twin, migrated at a different time by a different PR, and two of the twins had **drifted** from the live route table:

  | surface | copy |
  |---|---|
  | `SETTINGS_ROUTES` — live | `Create a diagnostic ZIP with frontend and backend logs.` |
  | dead twin → `settings:logsPageDescription` | `Download a bounded diagnostic ZIP containing frontend and backend logs.` |

- **Why no gate caught it:** every check verifies that a key *resolves*, not that it resolves to what the route used to render. `pnpm lint`, `pnpm run i18n:check`, the ratchet and 8,000+ unit tests were all green. One Playwright assertion, on one of nine routes, was the entire safety net — the other eight had no assertion on their description at all.
- Records `system-route-copy.test.ts` as the shape of the fix: a table of every route's title and description asserted byte-for-byte, which converts "I diffed them carefully" into something that stays true.
- States that deleting a dead twin is a **correctness** change rather than tidiness, and belongs in its own PR — the duplication is the defect that produced the drift.

## Validation

```
node -e '…require("./apps/web/src/locales/en/settings.json").logsPageDescription'
  -> "Create a diagnostic ZIP with frontend and backend logs."     # matches the doc
git show origin/main:apps/web/src/settings-routes.tsx | grep -A6 '"/settings/system/logs"'
  -> renders, as the doc's command claims
ls apps/web/components/settings/system/system-route-copy.test.ts   # the referenced guard exists
```

Both shell snippets in the new section were run as written. Docs-only — no code, no catalog, no `i18nGuardFiles` change, so it cannot conflict with an in-flight migration.

`git log --oneline origin/main -- docs/i18n.md` checked first: #2205, #2208, #2204 and #2211 all landed here today. None covers reusing a key from a duplicate surface — the closest, #2204's *Copy that belongs to no directory*, is about a shared file with no owner, which is the adjacent problem rather than this one.

## Possible Improvements

Negligible risk — documentation only.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have manually tested my changes and they work as expected. — both commands in the new section were run as written.
- [ ] My changes have tests that cover the new functionality and edge cases. — docs-only; the guard the section describes shipped with its tests in #2202.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`. — no UI files touched.
- [x] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed. — `docs/i18n.md` is contributor documentation, not `docs/public/**`; no user-facing docs impact.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->