### PR TITLE
test(i18n): make fixture data ineligible and fix a stale allow entry

### DIFF
--- a/apps/web/e2e/tests/i18n/pseudo-coverage.spec.ts
+++ b/apps/web/e2e/tests/i18n/pseudo-coverage.spec.ts
@@ -27,6 +27,24 @@ import { test, expect } from "../../fixtures/test-base";
  * directory lands and the env guard comes off.
  *
  *   KANDEV_I18N_COVERAGE=1 pnpm e2e -- e2e/tests/i18n/pseudo-coverage.spec.ts
+ *
+ * BOTH passes walk `document.body`, deliberately, and NOT the page's `<main>`.
+ * Scoping to the page under test is the obvious reading of what each test claims,
+ * and it was tried and rejected on one fact: `@kandev/ui` builds Dialog,
+ * AlertDialog, DropdownMenu, Tooltip and Select on Radix `Portal`, which mounts
+ * to `document.body`. Every dialog, menu and tooltip in the app therefore renders
+ * OUTSIDE `<main>`, so a scoped walk would stop checking the surfaces densest in
+ * copy — and would do it silently, reporting clean. Trading a visible annoyance
+ * for an invisible blind spot is the wrong direction for an oracle whose whole
+ * purpose is the strings nothing else can see.
+ *
+ * The cost of body-wide is that a screen can fail for chrome it does not own.
+ * That cost is now small — migrating the sidebar, settings nav and status bar
+ * (#2214) took the baseline from 28 findings to 5 — and it buys the one thing
+ * nothing else has: copy that belongs to no directory, like `@kandev/ui`'s
+ * hardcoded breadcrumb landmark and sonner's toast-container label, is visible
+ * only because the walk is body-wide. The fix for chrome noise is migrating
+ * chrome, not narrowing the oracle.
  */
 
 const COVERAGE_ENABLED = process.env.KANDEV_I18N_COVERAGE === "1";
@@ -67,6 +85,13 @@ const SCREENS: Array<{ name: string; url: string; allow?: string[] }> = [
     // default-action button once, which rendered a raw English "Default" until
     // `getDefaultActionState` was fixed to resolve it through the catalog.
     //
+    // It fails in the OTHER direction too, and has: these entries duplicate
+    // strings that live in `lib/layout/layout-profiles.ts`, with nothing keeping
+    // the two in sync. #2198 changed the Default profile's description and this
+    // list kept the old wording, so it manufactured a phantom finding for every
+    // run between `cc6eb4dd5` and this commit. Re-check these against
+    // `BUILT_IN_LAYOUT_PROFILES` whenever a built-in name or description moves.
+    //
     // Both groups are display strings that are also PERSISTED, so translating
     // them in place would write locale-dependent values into a user's saved
     // layouts and leave them there after a locale switch:
@@ -82,7 +107,7 @@ const SCREENS: Array<{ name: string; url: string; allow?: string[] }> = [
       "Plan Mode",
       "Preview Mode",
       "VS Code",
-      "Agent with Files, Changes, PR Details, and Terminal",
+      "Agent with Files, Changes, and Terminal",
       "Agent and Plan side by side",
       "Agent and Browser side by side",
       "Agent and VS Code side by side",
@@ -256,9 +281,27 @@ async function findUnlocalizedCopy(
       const wordlike = /[A-Za-z]{4,}/;
       const accented = /[À-ɏ]/;
 
+      // User data is never copy, and a workspace's name is user data on the same
+      // footing as a task title. Derived from the boot payload rather than
+      // listed, because listing it fixes one instance and leaves every other
+      // one broken: `E2E Workspace` is only the fixture's name, and a developer
+      // running this against their own instance would have hit the identical
+      // false positive under a different string.
+      const workspaceNames = (() => {
+        const payload = (window as unknown as { __KANDEV_BOOT_PAYLOAD__?: unknown })
+          .__KANDEV_BOOT_PAYLOAD__;
+        const state = (payload as { initialState?: { workspaces?: { items?: unknown } } })
+          ?.initialState;
+        const items = state?.workspaces?.items;
+        if (!Array.isArray(items)) return [];
+        return items
+          .map((item) => (item as { name?: unknown })?.name)
+          .filter((name): name is string => typeof name === "string" && name.trim().length > 0);
+      })();
+
       // Longest first: stripping "VS Code" before "Agent and VS Code side by
       // side" would leave "side by side" behind and report it as a leftover.
-      const tokens = [...allowedList].sort((a, b) => b.length - a.length);
+      const tokens = [...allowedList, ...workspaceNames].sort((a, b) => b.length - a.length);
 
       /** Still word-like ASCII once allowlisted tokens are removed. */
       const hasUnmigratedAscii = (text: string) => {
@@ -271,6 +314,19 @@ async function findUnlocalizedCopy(
       /** The text pass's rule, unchanged: any accented character clears a node. */
       const looksUnlocalized = (text: string) => !accented.test(text) && hasUnmigratedAscii(text);
 
+      // The text pass drops zero-size nodes because nothing is on screen to read.
+      // That test is WRONG for an attribute: a visually hidden control with an
+      // `aria-label` is precisely the case this pass exists to catch, and every
+      // `sr-only` node measures as good as zero. What actually disqualifies a
+      // label is the element not being rendered at all — `display: none`,
+      // `visibility: hidden`, or a skipped `content-visibility` subtree — because
+      // then no user receives it, sighted or not. `checkVisibility` asks that
+      // directly; deliberately WITHOUT `opacityProperty`, since an opacity-0
+      // element is still in the accessibility tree.
+      const isRendered = (el: Element) =>
+        typeof el.checkVisibility !== "function" ||
+        el.checkVisibility({ contentVisibilityAuto: true, visibilityProperty: true });
+
       const collectText = () => {
         const found = new Set<string>();
         const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
@@ -281,9 +337,17 @@ async function findUnlocalizedCopy(
 
           const el = node.parentElement;
           if (!el || skipTags.has(el.tagName)) continue;
-          // Ignore hidden nodes — not user-visible copy.
-          const rect = el.getBoundingClientRect();
-          if (rect.width === 0 && rect.height === 0) continue;
+          // Same rendered-or-not test the attribute pass uses, rather than the
+          // zero-size rect this used to apply. The rect check kept `sr-only`
+          // text ONLY because that utility measures 1px rather than 0 — so
+          // whether screen-reader-only copy was checked came down to a CSS
+          // implementation detail, and changing `.sr-only` to `clip` at 0×0
+          // would have silently dropped it. It IS copy, and a deliberately
+          // in-scope kind: `theme-toggle.tsx`'s "Toggle theme" reached a user
+          // only this way. `checkVisibility` keeps it for the right reason —
+          // the element renders and is in the accessibility tree — while
+          // correctly dropping `visibility: hidden`, which the rect check kept.
+          if (!isRendered(el)) continue;
 
           found.add(text.slice(0, 120));
         }
@@ -299,19 +363,6 @@ async function findUnlocalizedCopy(
         const role = el.getAttribute("role");
         return role ? `${tag}[role=${role}]` : tag;
       };
-
-      // The text pass drops zero-size nodes because nothing is on screen to read.
-      // That test is WRONG for an attribute: a visually hidden control with an
-      // `aria-label` is precisely the case this pass exists to catch, and every
-      // `sr-only` node measures as good as zero. What actually disqualifies a
-      // label is the element not being rendered at all — `display: none`,
-      // `visibility: hidden`, or a skipped `content-visibility` subtree — because
-      // then no user receives it, sighted or not. `checkVisibility` asks that
-      // directly; deliberately WITHOUT `opacityProperty`, since an opacity-0
-      // element is still in the accessibility tree.
-      const isRendered = (el: Element) =>
-        typeof el.checkVisibility !== "function" ||
-        el.checkVisibility({ contentVisibilityAuto: true, visibilityProperty: true });
 
       const seen = new Map<string, { label: string; count: number }>();
       // The positive control. An attribute that HAS been migrated renders as


### PR DESCRIPTION
Two of the three findings the pseudo-locale oracle still reported on migrated screens were defects in the oracle rather than in the app: the e2e fixture's own workspace name was being treated as copy, and a stale `allow` entry had been manufacturing a phantom finding since `cc6eb4dd5`. Both are fixed, the text pass's visibility test is now deliberate rather than incidental, and the walk stays body-wide for a reason worth recording.

## Important Changes

- **Workspace names are derived, not allowlisted.** They are user data on the same footing as a task title. The names now come from the boot payload (`initialState.workspaces.items[].name`) and are stripped like any allowlisted token. Listing `"E2E Workspace"` would have fixed this harness and left every developer's own instance reporting the identical false positive under a different string.
- **The stale `allow` entry is corrected.** #2198 changed the Default layout profile's description from `"Agent with Files, Changes, PR Details, and Terminal"` to `"Agent with Files, Changes, and Terminal"`; the mirrored entry kept the old wording, so a correctly-English persisted name reported as un-migrated on every run since.
- **The text pass uses `checkVisibility` instead of a zero-size rect**, the same test the attribute pass has used since #2211.
- **The walk stays on `document.body`** rather than scoping to the page's `<main>`.

### The walk stays body-wide — I changed my mind on evidence

Scoping to the page under test is the obvious reading of what each test claims, and I intended to do it. It is wrong here, for one fact I checked rather than assumed:

`@kandev/ui` builds Dialog, AlertDialog, DropdownMenu, Tooltip and Select on Radix `Portal`, which mounts to `document.body`. **Every dialog, menu, select and tooltip in the app renders outside `<main>`.** A scoped walk would stop checking the surfaces densest in copy, and would do it silently — reporting clean. Closing one blind spot in #2211 while opening a larger one here would be incoherent.

The measured picture also moved the trade. Scoping was motivated by chrome noise, and #2214 largely dissolved it: the baseline went from 28 findings this morning to 5. What body-wide buys in exchange is the only view of **copy that belongs to no directory** — `@kandev/ui`'s hardcoded breadcrumb landmark and sonner's toast-container label are visible *only* because the walk is body-wide, and that is the category #2204 documented as the one every migration skips. The fix for chrome noise is migrating chrome, which is exactly what #2214 did.

Structural confirmation, from a probe against two screens: `<main>` exists, and 18 of 22 attribute-bearing elements on the appearance screen sit outside it — all of it the chrome that #2214 has now migrated.

### `sr-only`: in scope, and now for a reason

`Toggle theme` was being checked only because `.sr-only` measures **1×1** rather than 0×0. That is a CSS implementation detail deciding whether screen-reader-only copy is audited — change the utility to clip at 0×0 and the coverage disappears with nothing failing.

Screen-reader-only text is real user-facing copy, so it should be in scope deliberately. `checkVisibility` keeps it for the right reason — the element renders and sits in the accessibility tree — and fixes a false positive the rect test had:

| element | rect | zero-rect rule | `checkVisibility` |
| --- | --- | --- | --- |
| `.sr-only` (`Toggle theme`) | 1×1 | keep | keep |
| `visibility: hidden` probe | 1280×24 | **keep** | **drop** |

A `visibility: hidden` element is not in the accessibility tree and reaches nobody, but measures full size, so the old rule reported it. Both rows are measured, not reasoned — see Validation.

### `allow` has now failed in both directions

The `settings — layouts` block already warned it was "load-bearing in the wrong direction", recording that a broad `"Default"` token once *hid* a genuinely un-migrated button. This PR fixes the inverse: a narrow entry went stale when the string it mirrors changed elsewhere, and started *inventing* a finding.

So `allow` duplicates strings with nothing keeping the copies in sync, and fails both by hiding and by fabricating. The comment now says so and names `BUILT_IN_LAYOUT_PROFILES` as the thing to re-check.

**The structural fix was considered and rejected as not cheap.** Importing `BUILT_IN_LAYOUT_PROFILES` directly would pull `@/lib/state/layout-manager` (the dockview panel registry and preset machinery) plus `generateUUID` into Playwright's Node context, and **no e2e spec currently does a value import from `@/` at all** — the single `@/` import under `e2e/` is an `import type`, which erases and proves nothing about runtime resolution. Wrong trade for deduplicating sixteen strings. The right fix is a vitest test — vitest already resolves `@/` and executes these modules — asserting every built-in name and description appears in the `allow` list, which needs the data extracted to a plain module. That is a config-drift concern rather than an oracle-scoping one and deserves its own PR.

## Validation

Baseline re-measured against `main` at `2d653c962` first, because `main` moved several times since the 12 → 3 measurement. **It was 5, not 2** — the earlier count was text-only, and three attribute findings survive #2214.

| | before | after |
| --- | --- | --- |
| `E2E Workspace` | reported | **cleared** — derived from boot payload |
| `Agent with Files, Changes, and Terminal` | reported | **cleared** — stale entry corrected |
| `aria-label on button: "Configuration Chat"` | reported | still reported |
| `aria-label on nav: "breadcrumb"` | reported | still reported |
| `aria-label on section: "Notifications alt+T"` | reported | still reported |
| **total distinct** | **5** | **3** |

Text findings are now **zero** on all eight screens. The three that remain are attribute copy, all of it un-migrated, and all in directories this PR does not own — see below.

**The visibility change is measured behaviour-neutral, and I checked rather than assumed.** Reverting only the text pass to the zero-rect rule, with the other two fixes in place, produces a byte-identical finding set. Its effect is latent — real, per the `visibility: hidden` probe above, but not exercised by the current screens.

```
pnpm run typecheck                      # clean
pnpm lint --max-warnings 0              # clean
pnpm run i18n:check                     # 4/4 gates pass
pnpm run i18n:ratchet                   # clean
node scripts/check-guard-allowlist.mjs  # 209 entries, intact
pnpm test                               # 1079 files, 8218 passed | 4 skipped
KANDEV_I18N_COVERAGE=1 pnpm exec playwright test … pseudo-coverage.spec.ts
```

The gate stays opt-in. `KANDEV_I18N_COVERAGE` is **not** enabled in CI here — the migration is still in flight and unmigrated screens are expected to be full of English.

### The three remaining, reported and not fixed

Each is real un-migrated copy in a directory this PR does not own. Folding copy changes into an oracle-tooling PR is the thing this series has consistently declined to do, and the "zero" target was computed from a text-only count that did not include them.

| finding | owner | cost |
| --- | --- | --- |
| `Configuration Chat` | `components/config-chat/config-chat-panel.tsx:150` — not on the allowlist. The file also holds `Open in Quick Chat` and `Close configuration chat`, which do not render on these screens | whole-directory migration |
| `breadcrumb` | `packages/ui/src/breadcrumb.tsx` hardcodes `aria-label="breadcrumb"`. Its `{...props}` spread comes *after* the attribute, so a caller override works — but `components/page-topbar.tsx` is not migrated either | one line + one key, in the PR that migrates `page-topbar` |
| `Notifications alt+T` | sonner's default `containerAriaLabel`, via `<SonnerToaster>` in `app/layout.tsx` | one prop, in whichever PR owns the app shell |

So `SCREENS` reaches zero when `config-chat` migrates and the two unowned-shared-copy items are claimed — the same "last area to migrate takes it" rule #2204 established.

### Known follow-up, deliberately not fixed here: the mixed-content label

`pseudo-coverage.spec.ts:416` tags a mixed-content attribute finding `- English frame, migrated value`. That branch fires whenever a value survives `hasUnmigratedAscii` *and* contains an accented character — which is **two opposite shapes wearing one label**, not an inverted one:

| value | truth | current label |
| --- | --- | --- |
| `Collapse Ĝēńēŕàĺ` | English frame + migrated value | correct |
| `Ēxƥàńď System` | migrated frame + English value | wrong |

Both satisfy the same predicate, so flipping the string would simply move the error onto the case the tag was built for. The fix is to decide by position — the frame is the leading fragment, so leftover ASCII *before* the first accented character means an English frame, and *after* it means an English payload interpolated into a migrated frame.

One implementation detail that makes the difference between that working and being subtly wrong: `hasUnmigratedAscii` strips allowlisted tokens with `split(token).join(" ")`, which replaces an N-character token with a single space and therefore **does not preserve offsets**. A position comparison needs `" ".repeat(token.length)` so the residue stays index-aligned with the original value; otherwise a leading brand noun shifts every subsequent index and the comparison silently decides the wrong way.

Not folded in because it is a label on a finding rather than a change to what is reported, and #2220 had an E2E attempt in flight — restarting ~34 checks for a diagnostic string is the wrong trade. Left to the oracle-to-zero follow-up, which owns the next PR on this file and reads these labels closely.

Credit: found by the sidebar migration while reading `Ēxƥàńď System`, which has since disappeared on its own — #2202's `labelKey` conversion resolved the payload, closing the finding across two PRs with nobody touching it.

### CI note: `E2E Shard 13/14` is pre-existing on `main`

This PR's shard 13 failure is inherited, not caused. The same shard fails on `main` itself, on two different commits, neither of them mine:

| run | branch | commit | failing |
| --- | --- | --- | --- |
| `30830348642` | `main` | `2d653c962` | `E2E Shard 13/14`, `Merge E2E Reports` |
| `30828106697` | `main` | `c95d44193` | `E2E Shard 13/14`, `Merge E2E Reports` |

It is not merely the same shard — it is the **same spec**. `mobile-session-stream-overload-isolation.spec.ts:14:7` ("switches through the native session sheet while a sibling streams") is the single failure in all four occurrences: `main` at `2d653c962`, `main` at `c95d44193`, and both attempts on this PR. Two of those predate this branch. Sharding is deterministic by file, so a same-spec repeat is a real breakage — just not one this PR introduced. Attempt 1 here failed on `mobile-session-stream-overload-isolation.spec.ts:14`, a `summarizeGatewayTraffic` volume assertion, alongside **3 flaky** specs on the same shard — a load signature rather than a code regression.

That this was not already obvious is itself a CI gap worth naming: `e2e-tests.yml` *does* run on `main` (`push: branches: [main]`), but its concurrency group is `${{ github.workflow }}-${{ github.ref }}` with `cancel-in-progress: true`. On `main` the ref is identical for every push, so **each merge cancels the previous `main` E2E run** — five of the last eight were cancelled. Under a fast merge cadence `main` effectively stops reporting, and anything it breaks then resurfaces on every subsequent PR looking exactly like flake. Being tracked separately; deliberately not touched here.

This PR's coupling to that shard is nil, and mechanically so rather than by assertion: the only changed file is `e2e/tests/i18n/pseudo-coverage.spec.ts`, nothing imports it (`grep -rn pseudo-coverage apps/web/e2e` returns only itself), no shared fixture or helper is touched, and the spec is gated on `KANDEV_I18N_COVERAGE=1`, which CI never sets — `test.skip()` fires before any of this code runs, so it does not execute in CI at all.

## Possible Improvements

Low risk. The gate is opt-in and not in CI, the visibility change is measured neutral on the current screens, and the workspace-name derivation degrades to stripping nothing if the boot payload shape ever changes — failing toward noise rather than silence, which is the correct direction here.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have manually tested my changes and they work as expected. — baseline re-measured on `2d653c962`, before/after table above, plus the isolation run showing the visibility change is neutral.
- [x] My changes have tests that cover the new functionality and edge cases. — this PR *is* the test; the before/after and the `sr-only` / `visibility: hidden` probe are its evidence.
- [x] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`. — the changed file is the Playwright spec; verified with the targeted `KANDEV_I18N_COVERAGE=1` run, since the gate is opt-in and excluded from CI.
- [x] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed. — no public-docs impact. `docs/i18n.md` already describes both passes and the `checkVisibility` rule; this PR changes which elements that rule is applied to, not the rule or the guidance.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->