### PR TITLE
fix(i18n): detect duplicate allowlist entries, correct the collapse advice

### DIFF
--- a/apps/web/eslint.i18n.options.mjs
+++ b/apps/web/eslint.i18n.options.mjs
@@ -161,8 +161,21 @@ export const noLiteralStringOptions = {
  *     and there is no treadmill.
  *
  * Entries may be single files or directory globs — use a file glob while a
- * directory is partially migrated, and collapse to `dir/**` once it is done.
- * The list only shrinks by mistake; adding to it is the whole point.
+ * directory is partially migrated. Once it is done, LEAVE those entries alone:
+ * **adding a path is the only safe edit to this list.**
+ *
+ * Do not collapse several file globs into one `dir/**`. That fails
+ * `check-guard-allowlist.mjs`, which flags every entry that disappears while its
+ * path still exists — globs included, resolved with `fs.globSync`. The check
+ * cannot tell a tidy-up from quietly dropping protection, and refusing to guess
+ * is the whole point of the ratchet: the two edits produce an identical diff to
+ * the array, and only one of them is harmless. A broader glob added *alongside*
+ * the existing entries passes; swapping them for it never does.
+ *
+ * Nor may a path be listed twice. An exact duplicate protects nothing new and
+ * presents an earlier migration's work as yours; the same check rejects it.
+ * (Entries a broader glob already covers are a different thing and are kept on
+ * purpose — see the storage globs below.)
  *
  * A clean lint is NOT proof a path is fully migrated — the rule only sees plain
  * literals in JSX. Template literals, `confirm()`/`alert()` arguments, and copy

--- a/apps/web/scripts/check-guard-allowlist.mjs
+++ b/apps/web/scripts/check-guard-allowlist.mjs
@@ -11,6 +11,11 @@
  * Removing an entry is legitimate exactly once: when a file is deleted or renamed.
  * Both are detectable, so the check only complains when the path still exists.
  *
+ * The list also has to stay honest about what it claims, so a second check
+ * rejects a path listed twice. That costs nothing at runtime and so slips
+ * through every other gate, while quietly presenting an earlier migration's work
+ * as the current PR's.
+ *
  * Usage: node scripts/check-guard-allowlist.mjs [--base <ref-or-sha>]
  */
 import fs from "node:fs";
@@ -18,6 +23,7 @@ import os from "node:os";
 import path from "node:path";
 
 import { git, REPO_ROOT, resolveBase, WEB_DIR } from "./lib/git-base.mjs";
+import { duplicateEntries } from "./lib/guard-allowlist.mjs";
 
 const OPTIONS_PATH = "apps/web/eslint.i18n.options.mjs";
 
@@ -88,6 +94,25 @@ if (removed.length > 0) {
       `\n\n  Those paths are still present, so removing them un-protects copy that` +
       `\n  was already migrated. If a literal there is failing lint, externalize it` +
       `\n  — do not drop the entry. See docs/i18n.md ("The guard is scoped").\n`,
+  );
+  process.exit(1);
+}
+
+/**
+ * Nothing above catches a path listed twice: a removal check only ever looks at
+ * what left. A duplicate changes no behaviour, so it clears every gate in the
+ * repo — which is exactly why it needs its own check. See `duplicateEntries`
+ * for why this is deliberately exact-match and not a subsumption check.
+ */
+const duplicates = duplicateEntries(after);
+
+if (duplicates.length > 0) {
+  console.error(
+    `\n✖ ${duplicates.length} duplicate entr(ies) in i18nGuardFiles:\n\n` +
+      duplicates.map((entry) => `  ${entry}`).join("\n") +
+      `\n\n  Each of those is already listed elsewhere in the array, so the second` +
+      `\n  copy protects nothing new — it only reads as coverage this change added.` +
+      `\n  Delete the copy you just wrote; the existing entry already covers it.\n`,
   );
   process.exit(1);
 }

--- a/apps/web/scripts/check-guard-allowlist.mjs
+++ b/apps/web/scripts/check-guard-allowlist.mjs
@@ -12,9 +12,9 @@
  * Both are detectable, so the check only complains when the path still exists.
  *
  * The list also has to stay honest about what it claims, so a second check
- * rejects a path listed twice. That costs nothing at runtime and so slips
- * through every other gate, while quietly presenting an earlier migration's work
- * as the current PR's.
+ * rejects a path listed twice. A duplicate costs nothing at runtime, so before
+ * this check existed it slipped through every gate the repo had while quietly
+ * presenting an earlier migration's work as the current PR's.
  *
  * Usage: node scripts/check-guard-allowlist.mjs [--base <ref-or-sha>]
  */
@@ -100,9 +100,10 @@ if (removed.length > 0) {
 
 /**
  * Nothing above catches a path listed twice: a removal check only ever looks at
- * what left. A duplicate changes no behaviour, so it clears every gate in the
- * repo — which is exactly why it needs its own check. See `duplicateEntries`
- * for why this is deliberately exact-match and not a subsumption check.
+ * what left. A duplicate changes no behaviour either, so `i18next/no-literal-string`,
+ * `i18n:check` and the new-code half of the ratchet are all indifferent to one —
+ * which is exactly why it needs its own check here. See `duplicateEntries` for
+ * why this is deliberately exact-match and not a subsumption check.
  */
 const duplicates = duplicateEntries(after);
 

--- a/apps/web/scripts/lib/guard-allowlist.mjs
+++ b/apps/web/scripts/lib/guard-allowlist.mjs
@@ -1,0 +1,29 @@
+/**
+ * Shape checks on the i18n guard allowlist itself.
+ *
+ * Split out of `check-guard-allowlist.mjs` so they can be tested directly: that
+ * script resolves this repository's own git history and options module from
+ * fixed paths, so it cannot be pointed at a fixture.
+ */
+
+/**
+ * Entries listed more than once, each named once however often it repeats.
+ *
+ * A duplicate is invisible to every other gate — ESLint does not care that a
+ * pattern appears twice, so lint, `i18n:check`, the ratchet and the unit suite
+ * all pass. What it damages is the record: a second copy of a path an earlier
+ * migration already listed reads as the new PR's own coverage, which is the
+ * misinformation the comments around the list exist to prevent. #2214 added two
+ * and nothing objected.
+ *
+ * EXACT duplicates only, deliberately. The list also carries entries a broader
+ * glob already covers — `app/settings/system/storage/**` sits inside
+ * `app/settings/system/**`, `system-page-shell.tsx` inside
+ * `components/settings/system/*` — and #2202 kept those on purpose, as the
+ * record of which PR migrated which half of a group. That redundancy is
+ * intentional and must keep passing. Do not turn this into a subsumption check;
+ * it would fight a decision the list makes knowingly.
+ */
+export function duplicateEntries(entries) {
+  return [...new Set(entries.filter((entry, index) => entries.indexOf(entry) !== index))];
+}

--- a/apps/web/scripts/lib/guard-allowlist.mjs
+++ b/apps/web/scripts/lib/guard-allowlist.mjs
@@ -9,12 +9,14 @@
 /**
  * Entries listed more than once, each named once however often it repeats.
  *
- * A duplicate is invisible to every other gate — ESLint does not care that a
- * pattern appears twice, so lint, `i18n:check`, the ratchet and the unit suite
- * all pass. What it damages is the record: a second copy of a path an earlier
- * migration already listed reads as the new PR's own coverage, which is the
- * misinformation the comments around the list exist to prevent. #2214 added two
- * and nothing objected.
+ * Nothing else looks for one, because a duplicate changes no behaviour: ESLint is
+ * indifferent to a repeated pattern, and the removal check in
+ * `check-guard-allowlist.mjs` only ever inspects entries that LEFT the array. So
+ * when #2214 added two, lint, `i18n:check`, the ratchet and the unit suite all
+ * passed and it was caught by eye. What a duplicate damages is the record: a
+ * second copy of a path an earlier migration already listed reads as the new
+ * PR's own coverage, which is the misinformation the comments around the list
+ * exist to prevent.
  *
  * EXACT duplicates only, deliberately. The list also carries entries a broader
  * glob already covers — `app/settings/system/storage/**` sits inside

--- a/apps/web/scripts/lib/guard-allowlist.test.ts
+++ b/apps/web/scripts/lib/guard-allowlist.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Duplicate detection for `i18nGuardFiles`, and the invariant it protects.
+ *
+ * The bug this pins down (#2214): the sidebar migration appended two paths that
+ * earlier migrations had already listed. A duplicate changes no behaviour — the
+ * ESLint config just passes the same pattern twice — so it cleared `pnpm lint`,
+ * `i18n:check`, the ratchet, `check-guard-allowlist.mjs` itself and 8,218 unit
+ * tests. It was caught by eye. What it costs is the record: the array is read as
+ * "which PR migrated what", and a second copy silently books someone else's work
+ * as the new PR's coverage.
+ *
+ * Following the pattern in `git-base.test.ts`, the "fixed" assertions are paired
+ * with one showing the pre-existing removal check still cannot see a duplicate —
+ * a test that only exercised the new helper would not explain why it has to be a
+ * separate check.
+ */
+import { describe, expect, it } from "vitest";
+
+import { i18nGuardFiles } from "../../eslint.i18n.options.mjs";
+import { duplicateEntries } from "./guard-allowlist.mjs";
+
+/** What `check-guard-allowlist.mjs` did before this helper existed. */
+function removedEntries(before: string[], after: string[]) {
+  const afterSet = new Set(after);
+  return before.filter((entry) => !afterSet.has(entry));
+}
+
+describe("duplicateEntries", () => {
+  it("reports nothing for a list with no repeats", () => {
+    expect(duplicateEntries(["a.tsx", "b.tsx", "components/c/**"])).toEqual([]);
+  });
+
+  it("names an entry listed twice", () => {
+    const entries = ["a.tsx", "b.tsx", "a.tsx"];
+
+    expect(duplicateEntries(entries)).toEqual(["a.tsx"]);
+  });
+
+  it("names an entry once however often it repeats", () => {
+    expect(duplicateEntries(["a.tsx", "a.tsx", "a.tsx", "a.tsx"])).toEqual(["a.tsx"]);
+  });
+
+  it("names every distinct repeat — #2214 added two, not one", () => {
+    const entries = [
+      "components/app-sidebar/sections/settings/general-group.tsx",
+      "components/app-sidebar/sections/settings/agents-group.tsx",
+      "components/app-status-bar/**/*.{ts,tsx}",
+      "components/app-sidebar/sections/settings/general-group.tsx",
+      "components/app-sidebar/sections/settings/agents-group.tsx",
+    ];
+
+    expect(duplicateEntries(entries)).toEqual([
+      "components/app-sidebar/sections/settings/general-group.tsx",
+      "components/app-sidebar/sections/settings/agents-group.tsx",
+    ]);
+  });
+
+  /**
+   * The check is exact-match ON PURPOSE. `main` carries entries that a broader
+   * glob already covers, and #2202's comment keeps them deliberately: they are
+   * the historical record of which PR migrated which half of the System group.
+   * Widening this into a subsumption check would fail the list as it stands.
+   */
+  it("does not flag an entry a broader glob already covers", () => {
+    const entries = [
+      "app/settings/system/**/*.{ts,tsx}",
+      "app/settings/system/storage/**/*.{ts,tsx}",
+      "components/settings/system/*.{ts,tsx}",
+      "components/settings/system/system-page-shell.tsx",
+    ];
+
+    expect(duplicateEntries(entries)).toEqual([]);
+  });
+});
+
+describe("the removal check cannot stand in for it", () => {
+  it("reproduces the gap: adding a duplicate removes nothing", () => {
+    const before = ["a.tsx", "b.tsx"];
+    const after = ["a.tsx", "b.tsx", "a.tsx"];
+
+    expect(removedEntries(before, after)).toEqual([]);
+    expect(duplicateEntries(after)).toEqual(["a.tsx"]);
+  });
+});
+
+describe("the live allowlist", () => {
+  it("lists no path twice", () => {
+    expect(duplicateEntries(i18nGuardFiles)).toEqual([]);
+  });
+
+  /**
+   * Guards the scenario above against drift: if these two ever stop coexisting,
+   * the "exact duplicates only" test is no longer pinning a real decision.
+   */
+  it("still carries the deliberate storage redundancy the check must tolerate", () => {
+    expect(i18nGuardFiles).toContain("app/settings/system/**/*.{ts,tsx}");
+    expect(i18nGuardFiles).toContain("app/settings/system/storage/**/*.{ts,tsx}");
+  });
+});

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -214,10 +214,23 @@ Scoping inverts it. The guard can only ever tighten:
   is no treadmill.
 - Every migration PR moves one path from the second group to the first.
 
-Entries are globs, so use a file glob while a directory is partly migrated and
-collapse to `dir/**` once it is done. **Never remove an entry** to make a build
-pass — that silently un-protects migrated copy. `check-guard-allowlist.mjs`
-enforces this: it fails if an entry disappears while its path still exists.
+Entries are globs, so use a file glob while a directory is partly migrated. When
+it is done, leave those entries where they are: **adding a path is the only safe
+edit to this list.**
+
+`check-guard-allowlist.mjs` fails if an entry disappears while its path still
+exists — globs included, resolved with `fs.globSync`. So **never remove an entry**
+to make a build pass, and equally, never tidy several file globs into one
+`dir/**`. Both produce the same diff to the array, the check cannot tell them
+apart, and refusing to guess is the point: one of them silently un-protects
+migrated copy. A broader glob added *alongside* the existing entries passes;
+swapping them for it does not.
+
+The same check rejects a path listed **twice**. An exact duplicate changes no
+behaviour, so lint, `i18n:check` and the unit suite all pass it, but it claims an
+earlier migration's coverage as the new PR's. Entries that a broader glob already
+covers are deliberate and stay — they record which PR migrated which half of a
+group — so this is an exact-match check, not a redundancy check.
 
 ### …but new code is guarded everywhere
 

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -227,10 +227,13 @@ migrated copy. A broader glob added *alongside* the existing entries passes;
 swapping them for it does not.
 
 The same check rejects a path listed **twice**. An exact duplicate changes no
-behaviour, so lint, `i18n:check` and the unit suite all pass it, but it claims an
-earlier migration's coverage as the new PR's. Entries that a broader glob already
-covers are deliberate and stay — they record which PR migrated which half of a
-group — so this is an exact-match check, not a redundancy check.
+behaviour, so nothing else looks for one — the eslint rule is indifferent to a
+repeated pattern, and the removal check above only inspects entries that *left*
+the array. That is how #2214 landed two past every gate the repo then had. What a
+duplicate costs is the record: it claims an earlier migration's coverage as the
+new PR's. Entries that a broader glob already covers are deliberate and stay —
+they record which PR migrated which half of a group — so this is an exact-match
+check, not a redundancy check.
 
 ### …but new code is guarded everywhere
 


### PR DESCRIPTION
The i18n guard allowlist only ever checked what *left* the array, so a path listed twice was invisible to every gate in the repo, and the array's own header comment told you to do something that fails the build. Both were found by #2214 after it hit them.

## Important Changes

- **`check-guard-allowlist.mjs` now rejects an exact duplicate.** The removal check only looks at entries that disappeared, so a second copy of an already-listed path passed everything. It changes no behaviour — which is why nothing objected — but it books an earlier migration's work as the new PR's coverage, the misinformation the comments around the list exist to prevent.
- **Exact matches only, deliberately.** `main` carries entries a broader glob already covers (`app/settings/system/storage/**` inside `app/settings/system/**`, `system-page-shell.tsx` inside `components/settings/system/*`). #2202 kept those on purpose as the record of which PR migrated which half of the group, so a subsumption check would fail the list as it stands. A test pins that.
- **`duplicateEntries` lives in `scripts/lib/`** because `check-guard-allowlist.mjs` resolves this repo's git history and options module from fixed paths and cannot be pointed at a fixture — the same reason `changed-files.mjs` was split out of `check-new-code-i18n.mjs`.
- **The "collapse to `dir/**`" advice is corrected** in both places that carried it. Adding a path is the only safe edit; broaden-and-remove always fails.

No allowlist entry was added or removed — still **209**. No strings migrated, no catalog touched.

### The two "collapse later" instances found

Grepped `eslint.i18n.options.mjs`, `docs/i18n.md`, and then the whole repo for `collapse` / `dir/**` / `once it is done` / `broader glob` / `tidy`, plus every file mentioning `i18nGuardFiles`. Exactly two carried the failing advice:

| File | Was |
|---|---|
| `apps/web/eslint.i18n.options.mjs:164` | "use a file glob while a directory is partially migrated, and collapse to `dir/**` once it is done" |
| `docs/i18n.md:217` | "use a file glob while a directory is partly migrated and collapse to `dir/**` once it is done" |

Three near-misses are already correct and were left alone: `eslint.i18n.options.mjs:826` (#2214's "Do NOT tidy that into `components/app-sidebar/**`" note, which is the counter-advice), `eslint.i18n.config.mjs:22` and `docs/i18n.md:255`, which both say *add*.

## Validation

Both defects were reproduced before being fixed.

**Mutation 1 — duplicate entry.** Re-added #2214's two real duplicates (`general-group.tsx`, `agents-group.tsx`) to the sidebar block:

*Before the fix — every gate passes:*

```
node scripts/check-guard-allowlist.mjs  → ✓ guard allowlist intact — 210 entr(ies)   exit 0
pnpm run i18n:check                     → all four checks ✓                          exit 0
pnpm run i18n:ratchet                   → ✓ guard allowlist intact — 210 entr(ies)   exit 0
pnpm lint --max-warnings 0              → clean                                      exit 0
pnpm test                               → 8218 passed | 4 skipped                    exit 0
```

*After the fix — caught:*

```
✖ 2 duplicate entr(ies) in i18nGuardFiles:

  components/app-sidebar/sections/settings/general-group.tsx
  components/app-sidebar/sections/settings/agents-group.tsx
                                                                exit 1
```

The ratchet fails with it, and `scripts/lib/guard-allowlist.test.ts` → `the live allowlist › lists no path twice` fails (`expected [ …(2) ] to deeply equal []`). Mutation reverted.

**Mutation 2 — the collapse the header recommends.** Replaced the seven `components/app-sidebar/*` entries with one `components/app-sidebar/**/*.{ts,tsx}`, simulated against a base that contains them (`origin/main` @ `2d653c962`):

```
✖ 7 entr(ies) removed from i18nGuardFiles:

  components/app-sidebar/*.{ts,tsx}
  components/app-sidebar/sections/*.tsx
  components/app-sidebar/sections/settings/account-group.tsx
  components/app-sidebar/sections/settings/executors-group.tsx
  components/app-sidebar/sections/settings/settings-nav-primitives.tsx
  components/app-sidebar/sections/settings/settings-tree.tsx
  components/app-sidebar/sections/settings/workspaces-group.tsx
                                                                exit 1
```

Also verified the other half of the claim the new wording makes — the same broader glob added *alongside* the seven entries passes: `✓ guard allowlist intact — 210 entr(ies), 1 added`, exit 0. Mutation reverted.

Both mutations were run at the 209-entry state this branch forked from. Rebased since onto #2212 (`957cbb910`), where the allowlist is **223** — re-checked for duplicates before trusting the green, since #2220 also edited this array; `main` is 223 unique, so nothing pre-existing trips the new check.

**Full suite on the rebased tree:**

```
pnpm run typecheck          exit 0
pnpm lint --max-warnings 0  exit 0
pnpm run i18n:check         exit 0  (2517 keys, 0 orphans, pseudo in sync)
pnpm run i18n:ratchet       exit 0  (✓ guard allowlist intact — 223 entr(ies))
pnpm test                   exit 0  (1085 files, 8280 passed | 4 skipped)
```

8 new tests. CI was fully green on the pre-rebase head (33 pass / 12 skipping, all 14 E2E shards and all 6 container shards).

CodeRabbit caught a real inaccuracy, fixed in `ed7c59bc`: the three comments explaining why duplicates need their own check asserted in the present tense that a duplicate clears the ratchet and the unit suite — which *this PR* made false, since the ratchet runs this checker and the new test fails on one. They now attribute that to #2214 and name the checks genuinely indifferent to a repeated pattern.

## Possible Improvements

Low risk — one new check on a list that is edited a few times a week, plus comment text. The check is exact-match by design and will not notice a *near*-duplicate (a path relisted with a different glob spelling). Widening it to subsumption is a separate proposal and would need to reckon with the storage globs `main` keeps on purpose.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.