### PR TITLE
fix(e2e): gate the reasoning burst on a subscribed observer

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -29,7 +29,13 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Cancel superseded runs on PR branches — a force-push should not leave a
+  # full E2E fan-out burning. Never cancel on main: `github.ref` is identical
+  # for every push there, so each merge would cancel the previous merge's run
+  # and most main commits would never get a verdict. A regression that lands
+  # unseen then reappears on every subsequent PR, where it is indistinguishable
+  # from flake.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -29,13 +29,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  # Cancel superseded runs on PR branches — a force-push should not leave a
-  # full E2E fan-out burning. Never cancel on main: `github.ref` is identical
-  # for every push there, so each merge would cancel the previous merge's run
-  # and most main commits would never get a verdict. A regression that lands
-  # unseen then reappears on every subsequent PR, where it is indistinguishable
-  # from flake.
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/apps/web/e2e/helpers/session-stream-overload.ts
+++ b/apps/web/e2e/helpers/session-stream-overload.ts
@@ -50,6 +50,89 @@ export async function waitForExactReasoningBurst(
   };
 }
 
+/**
+ * Resolve once `capture`'s page is *currently* subscribed to `sessionId`.
+ *
+ * The burst is emitted with no per-chunk delay, and the gateway coalescer
+ * merges the whole run into one or two `session.message.updated` frames inside
+ * a single 100ms window. An observer that is not subscribed at that instant
+ * records nothing at all — the traffic it exists to measure is already gone.
+ * Gate the burst on a live subscription rather than racing a browser page boot
+ * against agent start-up.
+ *
+ * "Currently" matters: a page that briefly subscribes during boot and then
+ * settles on a different session (the mobile layout displays one session at a
+ * time and drops the rest) would satisfy a naive "has ever subscribed" check
+ * while receiving none of the traffic.
+ */
+export async function waitForSessionSubscription(
+  capture: { frames: readonly GatewayTrafficFrame[] },
+  sessionId: string,
+): Promise<void> {
+  await expect
+    .poll(
+      () => {
+        const latest = capture.frames.findLast(
+          (frame) =>
+            frame.direction === "sent" &&
+            frame.sessionId === sessionId &&
+            (frame.action === "session.subscribe" || frame.action === "session.unsubscribe"),
+        );
+        return latest?.action === "session.subscribe";
+      },
+      { timeout: 30_000, message: `observer is not subscribed to session ${sessionId}` },
+    )
+    .toBe(true);
+}
+
+/** Wait until `sessionId` is idle, so a follow-up prompt opens a new turn. */
+export async function waitForSessionAwaitingInput(
+  apiClient: ApiClient,
+  taskId: string,
+  sessionId: string,
+): Promise<void> {
+  await expect
+    .poll(
+      async () => {
+        const { sessions } = await apiClient.listTaskSessions(taskId);
+        return sessions.find((session) => session.id === sessionId)?.state ?? "";
+      },
+      { timeout: 60_000, message: `session ${sessionId} never returned to WAITING_FOR_INPUT` },
+    )
+    .toBe("WAITING_FOR_INPUT");
+}
+
+/**
+ * Start the high-volume reasoning burst on a session that is already being
+ * observed. Always call `waitForSessionSubscription` first — the frames this
+ * produces are unrecoverable once emitted.
+ */
+export async function startReasoningBurst(
+  apiClient: ApiClient,
+  taskId: string,
+  sessionId: string,
+  count = REASONING_BURST_COUNT,
+): Promise<void> {
+  await apiClient.addUserMessage(taskId, sessionId, reasoningBurstPrompt(count));
+}
+
+/**
+ * Frame actions that carry the noisy session's message stream to a client.
+ *
+ * Both actions matter. The stream coalescer folds adjacent append chunks into
+ * one segment, and when the producer outruns the first chunk's persistence the
+ * entire burst can land as a single `session.message.added` with no
+ * `session.message.updated` at all. Counting only updates therefore measures a
+ * scheduling accident rather than delivery, and reads as zero on a run where
+ * the observer saw the whole stream.
+ */
+const NOISY_MESSAGE_ACTIONS = new Set(["session.message.added", "session.message.updated"]);
+
+/**
+ * Frames a client actually received for `sessionId`'s message stream. Used
+ * both to prove an observer saw the stream (and saw far fewer frames than the
+ * burst produced chunks) and to prove an unrelated view received none of it.
+ */
 export function noisyReceivedFrames(
   frames: readonly GatewayTrafficFrame[],
   sessionId: string,
@@ -58,7 +141,7 @@ export function noisyReceivedFrames(
     (frame) =>
       frame.direction === "received" &&
       frame.sessionId === sessionId &&
-      frame.action === "session.message.updated",
+      NOISY_MESSAGE_ACTIONS.has(frame.action ?? ""),
   );
 }
 

--- a/apps/web/e2e/helpers/session-stream-overload.ts
+++ b/apps/web/e2e/helpers/session-stream-overload.ts
@@ -54,16 +54,23 @@ export async function waitForExactReasoningBurst(
  * Resolve once `capture`'s page is *currently* subscribed to `sessionId`.
  *
  * The burst is emitted with no per-chunk delay, and the gateway coalescer
- * merges the whole run into one or two `session.message.updated` frames inside
- * a single 100ms window. An observer that is not subscribed at that instant
- * records nothing at all — the traffic it exists to measure is already gone.
- * Gate the burst on a live subscription rather than racing a browser page boot
- * against agent start-up.
+ * merges the whole run into one or two frames inside a single 100ms window —
+ * either `session.message.updated`, or a single `session.message.added` when
+ * the producer outruns the first chunk's persistence. An observer that is not
+ * subscribed at that instant records nothing at all: the traffic it exists to
+ * measure is already gone. Gate the burst on a live subscription rather than
+ * racing a browser page boot against agent start-up.
  *
- * "Currently" matters: a page that briefly subscribes during boot and then
- * settles on a different session (the mobile layout displays one session at a
- * time and drops the rest) would satisfy a naive "has ever subscribed" check
- * while receiving none of the traffic.
+ * Two details this deliberately gets right:
+ *
+ * - It matches the server's *received* subscribe/unsubscribe acks, not the
+ *   frames the page sent. The burst is posted by the test's own API client
+ *   over a different connection, so a merely-sent subscribe carries no
+ *   ordering guarantee against it and would leave the original race intact.
+ * - "Currently" matters: a page that briefly subscribes during boot and then
+ *   settles on a different session (the mobile layout displays one session at
+ *   a time and drops the rest) would satisfy a naive "has ever subscribed"
+ *   check while receiving none of the traffic.
  */
 export async function waitForSessionSubscription(
   capture: { frames: readonly GatewayTrafficFrame[] },
@@ -74,7 +81,7 @@ export async function waitForSessionSubscription(
       () => {
         const latest = capture.frames.findLast(
           (frame) =>
-            frame.direction === "sent" &&
+            frame.direction === "received" &&
             frame.sessionId === sessionId &&
             (frame.action === "session.subscribe" || frame.action === "session.unsubscribe"),
         );

--- a/apps/web/e2e/tests/session/mobile-session-stream-overload-isolation.spec.ts
+++ b/apps/web/e2e/tests/session/mobile-session-stream-overload-isolation.spec.ts
@@ -4,9 +4,11 @@ import { SessionPage } from "../../pages/session-page";
 import {
   assertNoHorizontalOverflow,
   noisyReceivedFrames,
-  reasoningBurstPrompt,
   REASONING_BURST_COUNT,
+  startReasoningBurst,
   waitForExactReasoningBurst,
+  waitForSessionAwaitingInput,
+  waitForSessionSubscription,
 } from "../../helpers/session-stream-overload";
 import { attachGatewayTrafficCapture, summarizeGatewayTraffic } from "../../helpers/ws-traffic";
 
@@ -41,12 +43,14 @@ test.describe("mobile: session stream overload isolation", () => {
       .locator("[data-testid='mobile-task-layout']:visible")
       .waitFor({ state: "visible", timeout: 30_000 });
 
+    // Launch the sibling on a short scenario, not the burst: the observing
+    // page below has to be subscribed before any high-volume traffic exists.
     const launched = await apiClient.launchSession({
       task_id: noisyTask.id,
       agent_profile_id: seedData.agentProfileId,
       executor_profile_id: seedData.worktreeExecutorProfileId,
       workflow_step_id: seedData.startStepId,
-      prompt: reasoningBurstPrompt(),
+      prompt: "/e2e:simple-message",
     });
     const noisySessionId = launched.session_id;
 
@@ -56,6 +60,22 @@ test.describe("mobile: session stream overload isolation", () => {
     await noisyPage.goto(`/t/${noisyTask.id}`);
     const noisySession = new SessionPage(noisyPage);
     await noisySession.waitForLoad();
+
+    // The mobile layout keeps only the displayed session subscribed, so the
+    // observer has to be switched onto the noisy session explicitly — landing
+    // on the task is not enough.
+    const noisyPill = noisyPage.getByTestId("mobile-sessions-pill");
+    await expect(noisyPill).toBeVisible({ timeout: 30_000 });
+    await noisyPill.tap();
+    const noisyRow = noisyPage.getByTestId(`mobile-session-row-${noisySessionId}`);
+    await expect(noisyRow).toBeVisible({ timeout: 30_000 });
+    await noisyRow.tap();
+    await noisySession.waitForLoad();
+    await waitForSessionSubscription(noisyCapture, noisySessionId);
+
+    // Only now open the firehose, with a confirmed observer attached.
+    await waitForSessionAwaitingInput(apiClient, noisyTask.id, noisySessionId);
+    await startReasoningBurst(apiClient, noisyTask.id, noisySessionId);
 
     const pill = testPage.getByTestId("mobile-sessions-pill");
     await expect(pill).toBeVisible({ timeout: 30_000 });

--- a/apps/web/e2e/tests/session/session-stream-overload-isolation.spec.ts
+++ b/apps/web/e2e/tests/session/session-stream-overload-isolation.spec.ts
@@ -4,9 +4,11 @@ import { SessionPage } from "../../pages/session-page";
 import {
   assertNoHorizontalOverflow,
   noisyReceivedFrames,
-  reasoningBurstPrompt,
   REASONING_BURST_COUNT,
+  startReasoningBurst,
   waitForExactReasoningBurst,
+  waitForSessionAwaitingInput,
+  waitForSessionSubscription,
 } from "../../helpers/session-stream-overload";
 import { attachGatewayTrafficCapture, summarizeGatewayTraffic } from "../../helpers/ws-traffic";
 
@@ -24,7 +26,9 @@ test.describe("Session stream overload isolation", () => {
       "Noisy reasoning isolation task",
       seedData.agentProfileId,
       {
-        description: reasoningBurstPrompt(),
+        // Short scenario, not the burst: the observing page below has to be
+        // subscribed before any high-volume traffic exists.
+        description: "/e2e:simple-message",
         workflow_id: seedData.workflowId,
         workflow_step_id: seedData.startStepId,
         repository_ids: [seedData.repositoryId],
@@ -40,6 +44,11 @@ test.describe("Session stream overload isolation", () => {
     await noisyPage.goto(`/t/${noisyTask.id}`);
     const noisySession = new SessionPage(noisyPage);
     await noisySession.waitForLoad();
+    await waitForSessionSubscription(noisyCapture, noisyTask.session_id);
+
+    // Only now open the firehose, with a confirmed observer attached.
+    await waitForSessionAwaitingInput(apiClient, noisyTask.id, noisyTask.session_id);
+    await startReasoningBurst(apiClient, noisyTask.id, noisyTask.session_id);
 
     const quietTask = await apiClient.createTaskWithAgent(
       seedData.workspaceId,


### PR DESCRIPTION
`E2E Shard 13/14` has been failing on `main` because the mobile stream-overload isolation spec races the agent's reasoning burst against its own observer's page boot — the observer subscribes after the traffic it measures has already been delivered. This makes the spec deterministic by gating the burst on a confirmed-subscribed observer.

The CI concurrency change that hid this failure is split out into #2227, so this test fix carries no policy decision.

## Important Changes

- **The spec observed a window that had already closed.** `waitForExactReasoningBurst` proves 2000 chunks were produced, but the mock agent emits them with *no per-chunk delay* and the gateway coalescer folds the run into one or two frames inside a single 100ms window. The spec called `launchSession(reasoningBurstPrompt())` and only *then* booted a second browser page to watch — racing agent start-up against an SPA boot for a ~100ms target. It now launches the sibling on a short scenario, waits for a live subscription, and starts the burst only once an observer is confirmed attached.
- **The mobile layout keeps only the *displayed* session subscribed.** Landing the observer on the task subscribes transiently and then unsubscribes (`session.unsubscribe` at ~4.9s), so the observer has to be switched onto the noisy session explicitly. `waitForSessionSubscription` matches the server's *received* subscribe/unsubscribe acks and requires the subscription to be *current*. Both halves matter: the burst is posted by the test's API client over a different connection, so a merely-sent subscribe carries no ordering guarantee against it, and a "has ever subscribed" check passes while receiving nothing.
- **The burst is not guaranteed to emit any `session.message.updated`.** When the producer outruns the first chunk's persistence, the entire run lands as a single `session.message.added`. Counting only updates measured a scheduling accident rather than delivery, and read as zero on runs where the observer saw the whole stream. `noisyReceivedFrames` now counts both message actions, which also strengthens the isolation assertion on the quiet view.

The desktop sibling spec had the same defect and is fixed the same way. It was passing only because its setup gap is shorter.

## Validation

Reproduced, then verified by injecting a delay before the observer page — the knob that isolates the race:

| observer delayed | before | after |
| --- | --- | --- |
| 0 ms | 1 frame (pass, zero margin) | 7 frames (pass) |
| 1500 ms | **0 frames — CI failure reproduced** | — |
| 3000 ms | **0 frames** | 3 frames (pass) |
| 8000 ms | — | 3 frames (pass) |

The desktop spec measured the identical 1-frame margin across three runs before the change.

```
# both specs, both projects — 8/8 before review fixes, 6/6 after
pnpm exec playwright test --config e2e/playwright.config.ts \
  --project=mobile-chrome --project=chromium \
  e2e/tests/session/mobile-session-stream-overload-isolation.spec.ts \
  e2e/tests/session/session-stream-overload-isolation.spec.ts --retries=0 --repeat-each=3

pnpm run typecheck   # clean
pnpm run lint        # clean
```

Evidence the failure is this race and not a traffic regression:

- All 20 other shards passed on the same `main` run, including the shard carrying the desktop sibling's identical `> 0` assertion.
- Shard 13 **passes** on current `main` (`8ae850956`) and failed on `2d653c962` and `c95d44193` — it is flaky, not deterministic, which is exactly what a one-frame margin produces. It tips under shard load and holds in isolation.
- The frames *are* delivered locally whenever the observer is subscribed in time.

Note that Playwright's retries are not independent trials here: all three attempts run under the same shard load, so exhausting them is not evidence of a deterministic fault.

## Why this went unnoticed on `main`

`main`'s E2E runs cancel each other — `github.ref` is identical for every push, so each merge cancels the previous merge's run. 13 of the last 20 `main` runs were cancelled and exactly one succeeded. That is a separate decision with a real CI cost, so it is proposed on its own in **#2227** rather than riding in on this fix's green tick.

## Possible Improvements

Low risk, and test-only — no production code changes. The spec adds two API round-trips (idle poll + follow-up message) and a session switch on the observer page, costing a few seconds per spec.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.