### PR TITLE
docs(i18n): record how to trust the removed-literal check

### DIFF
--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -672,6 +672,44 @@ hoisted to a constant, or the real thing. It narrows the diff for a human; it
 does not decide. `--base <ref>` overrides the `origin/main` fork point, and
 `--all` widens past prose to identifier-shaped strings.
 
+Some benign findings recur and are worth recognising rather than investigating:
+an array of fragments collapsed into one comma-separated value is accepted
+because every fragment survives verbatim inside the join — the safe property is
+that the collapse is **concatenative**, not that it is an array, and a collapse
+that also *rewords* is reported, correctly. The shape to be wary of is not
+"array collapsed to string", it is "collapse that also edits".
+
+### Prove it can fail, before you believe it passed
+
+**A pass from this check is worth exactly what its ability to fail is worth.**
+After a clean run, reword one string your diff removed, confirm the check
+reports it, and restore. This is not diligence; it is the only way to tell a
+check that read your diff and found nothing from one that could not have failed.
+Both print the same tick.
+
+That distinction is not hypothetical. Every defect found in this tool during
+review had the same signature — *it returned a pass it had not earned* — and not
+one was visible to its own unit tests, because those assume a well-formed
+catalog and a committed tree. A message that was nothing but a placeholder
+compiled to a match-anything pattern and accepted every string in the
+repository. The "after" side read `HEAD` while the file list came from the
+working tree, so uncommitted edits were invisible and it printed a tick *with
+the correct file count*. Each was found by someone running it for real and
+declining to believe the result.
+
+**The probe must be a rewrite, and it must change the opening words.** Two
+probes proved nothing before this was written down, and neither was the
+author's fault:
+
+- an **append** is absorbed by rule 3 by design (`message.includes(norm)`), so
+  `"Try asking"` → `"Try asking now"` always passes;
+- a rewrite that **keeps the opening words** is absorbed by rule 2, because the
+  literal prefix is what the pattern anchors on — a probe on a
+  `"Delete {{name}}"`-shaped message that still begins `Delete ` tests nothing.
+
+A good probe changes the whole sentence: `"What do you want to change?"` →
+`"What would you like to configure?"` is reported.
+
 **Its coverage is partial, and a clean run is evidence rather than proof.** Rule
 2 is only as tight as the literal text around a message's placeholders, so a
 message with too little of it earns no pattern at all — it needs two words of
@@ -697,6 +735,17 @@ from the message can accept one and reject the other. Both are rejected, so a
 string like `"3 of 9"` is reported and classified by hand — the right direction
 for an advisory check, since a false positive costs someone ten seconds and a
 false negative is the failure the check exists to prevent.
+
+**The general rule is: verify against the authority, not against a copy.** The
+route table is the authority for what renders — a `page.tsx` that renders a
+component is not evidence that page is the live surface, and reading one led to
+a changelog surface being treated as live when `SETTINGS_ROUTES` never mounted
+it. `origin/main` is the authority for what ships — a fetched or pasted copy of
+a script is not the script, and testing one produced a defect report against
+code already fixed on the branch. The subtlest instance was an agent quoting a
+colleague's description of a file while its own measurement of that file sat
+unread in its terminal. All three look like diligence: something was read,
+something was run. None was the thing that decides.
 
 The underlying defect is the duplication itself. Unreferenced pages that
 re-render live copy will drift again, and the next migration inherits the same


### PR DESCRIPTION
`check-removed-literals.mjs` shipped in #2212 and five defects were found in it during that review — all with the same signature, and none visible to its own unit tests. This records the three practices that actually caught them, so the next migration inherits the method rather than rediscovering it.

## Important Changes

- **Verify against the authority, not a copy.** The existing dead-twin guidance frames this as a page/route problem; that is a special case. The route table is the authority for what renders, `origin/main` is the authority for what ships. Three instances in one day: reading a `page.tsx` and treating a dead surface as live; testing a *fetched copy* of a script and filing a defect against code already fixed on the branch; and — the subtlest — quoting a colleague's description of a file while one's own measurement of that file sat unread in the terminal. All three look like diligence.
- **Prove it can fail before believing it passed.** Every defect in that check returned *a pass it had not earned*, and its unit tests could not see any of them because they assume a well-formed catalog and a committed tree. A placeholder-only message compiled to a match-anything pattern and accepted every string in the repository; the "after" side read `HEAD` while the file list came from the working tree, so uncommitted edits were invisible and it printed a tick **with the correct file count**. Each was found by someone running it for real and refusing to believe the result.
- **The probe must be a rewrite, and must change the opening words.** Two probes proved nothing before this was written down, for two different reasons — an append is absorbed by rule 3 by design (`message.includes`), and a rewrite that keeps the prefix is absorbed by rule 2, because the prefix is what the pattern anchors on. Neither was the author's fault; the instruction was too loose.
- Names the **concatenative collapse** as a recurring benign finding (an array of fragments joined into one value), so it is recognised rather than investigated — and states the boundary: a collapse that also *rewords* is reported, correctly.

## Validation

Documentation only — `docs/i18n.md`, +49/−0, no code or behavior change. `pnpm run i18n:check` (4/4), `node scripts/check-guard-allowlist.mjs` (223, intact).

`pnpm run i18n:removed` reports `↷ … nothing to compare`, which is itself one of the #2212 fixes working: a docs-only diff has no `.ts`/`.tsx` to inspect, and the check now says so instead of printing a tick it has not earned.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases. — documentation only; the behaviour described is already pinned by the 30 assertions in `scripts/lib/removed-literals.test.ts` from #2212.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`. — no UI files touched.
- [x] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed. — no public-docs impact; this is contributor guidance in `docs/i18n.md`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- kandev-preview-start -->
### Preview Environment

| | |
|---|---|
| **URL** | https://kandev-pr-2226-bwo7.sprites.app |
| **Commit** | `0223aa3` |
| **Agent** | Mock agent |

> Updates automatically on each push. Destroyed when the PR is closed.
<!-- kandev-preview-end -->