### PR TITLE
ci: stop main's E2E runs cancelling each other

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -29,7 +29,13 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Cancel superseded runs on PR branches — a force-push should not leave a
+  # full E2E fan-out burning. Never cancel on main: `github.ref` is identical
+  # for every push there, so each merge would cancel the previous merge's run
+  # and most main commits would never get a verdict. A regression that lands
+  # unseen then reappears on every subsequent PR, where it is indistinguishable
+  # from flake.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read


### PR DESCRIPTION
Every push to `main` currently cancels the previous push's E2E run, because `github.ref` is identical for all of them — so most `main` commits never get a verdict, and a regression that lands there is invisible until it reappears on unrelated PRs looking like flake. This exempts `main` from self-cancellation while leaving PR branches unchanged.

**This is a CI spend decision, not a bug fix, and it is deliberately separated from the spec fix in #2222 so it can be accepted or rejected on its own.** If you want the shard-13 fix but not this spend, close this PR — you get that outcome by doing nothing.

## The problem

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

On a PR, `github.ref` is per-branch and this is correct and valuable: a force-push should not leave a full E2E fan-out burning. On `main`, `github.ref` is `refs/heads/main` for every push, so each merge cancels the merge before it.

| day | main E2E runs | cancelled | reached a verdict |
| --- | --- | --- | --- |
| Jul 31 | 18 | 13 (72%) | 5 |
| Aug 1 | 21 | 8 (38%) | 13 |
| Aug 2 | 36 | 23 (64%) | 13 |
| Aug 3 (partial) | 25 | 16 (64%) | 8 |

**Of the last 20 `main` runs, 13 were cancelled and exactly one succeeded.**

The consequence is not just missing data. A regression that lands on `main` unseen then appears on every subsequent PR, where it is indistinguishable from flake. That happened today: a genuine shard-13 failure went unattributed for over an hour, and the standing triage advice about it was wrong twice — first "it is deterministic on `main`, ignore it", then a correction. Both were coping strategies for a signal that `main` should have given directly.

## What this costs

Every `main` push then runs a full fan-out: 14 E2E shards + 6 container shards + build + desktop smoke + report. Measured on run `30830348642`: **~144 machine-minutes**. At ~25 pushes/day that is roughly **35 extra machine-hours on a busy day**.

**This repository is public, so standard-runner minutes are not billed.** The real cost is **concurrency contention** — uncancelled `main` runs occupy job slots that PR runs would otherwise get. The price is paid in PR feedback latency, not dollars. That is a genuine cost and the reason this is a decision rather than an obvious fix.

## Known limitation — this does not guarantee a verdict for *every* main commit

Both automated reviewers caught the same real gap, and they are right. GitHub allows **at most one pending run per concurrency group** by default (`queue: single`): "When a new job or workflow run is queued, any existing `pending` job or workflow run in the same group is canceled and replaced."

So when several `main` pushes land while a fan-out is already in flight, the *running* one now survives (which is the fix), but each new push still displaces the previous *pending* one. Intermediate commits in a burst can still go without a verdict.

This change removes the dominant failure mode — 64% of runs killed mid-flight — but "every `main` push gets a verdict" would be overstating it.

**`queue: max` would close the rest of the gap, and I deliberately did not add it.** Two reasons, both your call rather than mine:

- `queue` does **not** accept expressions (unlike `group` and `cancel-in-progress`), so it cannot be scoped to `main`. Setting it applies to PR branches too, where up to 100 pending runs could accumulate instead of being replaced.
- Runs in a group execute one at a time. With every `main` push queued and a fan-out taking ~25 min wall-clock, verdicts would lag hours behind merges on a busy day — trading invisibility for staleness.

Say the word and I will add it; I would rather flag the trade than pick it for you.

## Correction to the cost estimate above

The pending-slot behaviour cuts both ways, and it makes my `~35 extra machine-hours/day` figure an **upper bound rather than an estimate**. It assumed every `main` push runs a full fan-out; in reality bursts still drop intermediate pending runs, so real added spend is lower — and so is the added coverage. Both numbers move together.

## The alternative, costed

A nightly scheduled run on `main` instead: **~2.5 machine-hours/day, about 1/14th the cost.**

It still stops a red `main` going unnoticed indefinitely, but it gives up per-commit attribution — you get a night's worth of merges to bisect instead of a named commit, and a regression can poison every PR for up to a day before the nightly fires. Today's incident is precisely the case a nightly would have caught late and an uncancelled `main` catches immediately.

Pick this one if PR feedback latency matters more than attribution speed. It is a small workflow addition and I am happy to write it instead — say so and I will swap this PR for it.

## Recommendation

Take the ref-aware exemption. The failure mode it removes costs engineering time repeatedly and unpredictably, while the contention cost is steady, visible, and trivially reversible. But it is a judgement about your CI capacity, and I do not have the standing to make it — hence this PR being separate.

## Validation

```
git diff --check                                  # clean
python3 .github/scripts/lint-action-pinning_test.py   # 9 tests, OK
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/e2e-tests.yml'))"
#   concurrency.cancel-in-progress -> "${{ github.ref != 'refs/heads/main' }}"
```

`zizmor` is not installed in this environment, so I did not run it; the change adds no checkout, permission, or trigger surface — it is a single concurrency expression.

The effect is observable on this PR itself: `cancel-in-progress` evaluates `true` here (ref is not `refs/heads/main`), so PR cancellation behaviour is unchanged and demonstrably so.

## Possible Improvements

Low risk, one-line revert (`cancel-in-progress: true`). A merge queue would address the same problem more thoroughly and cost less, by testing merge candidates rather than every landed commit — worth considering separately if `main` throughput keeps rising.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.
