### PR TITLE
ci: fix OpenCode fork label cleanup permission

### DIFF
--- a/.github/workflows/opencode-code-review.yml
+++ b/.github/workflows/opencode-code-review.yml
@@ -248,7 +248,7 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'safe-to-review')
     runs-on: ubuntu-latest
     permissions:
-      issues: write
+      pull-requests: write
     steps:
       - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:


### PR DESCRIPTION
## Summary

- Restore `pull-requests: write` for the OpenCode fork label cleanup job.
- Prevent `strip-safe-to-review` from failing with HTTP 403 on fork PR synchronizations.

## Root cause

The cleanup job calls the PR label API through `github.rest.issues.removeLabel`, but its job permission was `issues: write`. The analogous preview cleanup job uses `pull-requests: write` and succeeds. The linked failure occurred in this cleanup job before either OpenCode review job ran.

## Validation

- `git diff --check`
- `python3 .github/scripts/lint-action-pinning.py`
- `python3 .github/scripts/lint-action-pinning_test.py`
- Pre-commit hooks and Conventional Commit validation passed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->