### PR TITLE
fix: restore executor settings card spacing

### DIFF
--- a/apps/web/app/settings/executors/[profileId]/page.tsx
+++ b/apps/web/app/settings/executors/[profileId]/page.tsx
@@ -591,7 +591,7 @@ function ProfileEditForm({ executor, profile }: { executor: Executor; profile: E
       />
       <fieldset
         disabled={!baselineReady || persistence.saveStatus === "loading"}
-        className="contents"
+        className="space-y-8"
       >
         <ProfileEditSections executor={executor} profile={profile} form={form} secrets={secrets} />
       </fieldset>

--- a/apps/web/app/settings/executors/new/[type]/page.tsx
+++ b/apps/web/app/settings/executors/new/[type]/page.tsx
@@ -574,7 +574,7 @@ function CreateProfileForm({
         label={typeInfo.label}
         description={typeInfo.description}
       />
-      <fieldset disabled={saving} className="contents">
+      <fieldset disabled={saving} className="space-y-8">
         <CreateProfileSections executorType={executorType} form={form} secrets={secrets} />
       </fieldset>
       {spritesTokenMissing && (

--- a/apps/web/e2e/tests/settings/executor-profile-spacing-helpers.ts
+++ b/apps/web/e2e/tests/settings/executor-profile-spacing-helpers.ts
@@ -3,11 +3,13 @@ import { expect, type Page } from "@playwright/test";
 const PROFILE_CARD_TITLES = ["Profile Details", "Environment Variables", "Prepare Script"] as const;
 
 export async function expectExecutorProfileCardsSeparated(page: Page) {
+  const profileFieldset = page.locator("fieldset").filter({ hasText: "Profile Details" });
+
   for (const title of PROFILE_CARD_TITLES) {
-    await expect(page.getByText(title, { exact: true })).toBeVisible();
+    await expect(profileFieldset.getByText(title, { exact: true })).toBeVisible();
   }
 
-  const cards = page.locator('[data-slot="card"]:visible');
+  const cards = profileFieldset.locator(':scope > [data-slot="card"]:visible');
   const cardBoxes = await cards.evaluateAll((elements) =>
     elements.map((element) => {
       const box = element.getBoundingClientRect();

--- a/apps/web/e2e/tests/settings/executor-profile-spacing-helpers.ts
+++ b/apps/web/e2e/tests/settings/executor-profile-spacing-helpers.ts
@@ -1,0 +1,35 @@
+import { expect, type Page } from "@playwright/test";
+
+const PROFILE_CARD_TITLES = ["Profile Details", "Environment Variables", "Prepare Script"] as const;
+
+export async function expectExecutorProfileCardsSeparated(page: Page) {
+  for (const title of PROFILE_CARD_TITLES) {
+    await expect(page.getByText(title, { exact: true })).toBeVisible();
+  }
+
+  const cards = page.locator('[data-slot="card"]:visible');
+  const cardBoxes = await cards.evaluateAll((elements) =>
+    elements.map((element) => {
+      const box = element.getBoundingClientRect();
+      return { top: box.top, bottom: box.bottom };
+    }),
+  );
+
+  expect(cardBoxes.length).toBeGreaterThanOrEqual(PROFILE_CARD_TITLES.length);
+
+  for (let index = 1; index < cardBoxes.length; index += 1) {
+    const gap = cardBoxes[index].top - cardBoxes[index - 1].bottom;
+    expect(gap, `card ${index} should be separated from the previous card`).toBeGreaterThanOrEqual(
+      31,
+    );
+  }
+}
+
+export async function expectNoHorizontalOverflow(page: Page) {
+  const documentWidth = await page.evaluate(() => ({
+    clientWidth: document.documentElement.clientWidth,
+    scrollWidth: document.documentElement.scrollWidth,
+  }));
+
+  expect(documentWidth.scrollWidth).toBeLessThanOrEqual(documentWidth.clientWidth + 1);
+}

--- a/apps/web/e2e/tests/settings/executor-profile-spacing.spec.ts
+++ b/apps/web/e2e/tests/settings/executor-profile-spacing.spec.ts
@@ -1,0 +1,12 @@
+import { test } from "../../fixtures/test-base";
+import { expectExecutorProfileCardsSeparated } from "./executor-profile-spacing-helpers";
+
+test.describe("executor profile card spacing", () => {
+  test("separates cards on edit and create pages", async ({ seedData, testPage }) => {
+    await testPage.goto(`/settings/executors/${seedData.worktreeExecutorProfileId}`);
+    await expectExecutorProfileCardsSeparated(testPage);
+
+    await testPage.goto("/settings/executors/new/worktree");
+    await expectExecutorProfileCardsSeparated(testPage);
+  });
+});

--- a/apps/web/e2e/tests/settings/mobile-executor-profile-spacing.spec.ts
+++ b/apps/web/e2e/tests/settings/mobile-executor-profile-spacing.spec.ts
@@ -1,0 +1,20 @@
+import { test } from "../../fixtures/test-base";
+import {
+  expectExecutorProfileCardsSeparated,
+  expectNoHorizontalOverflow,
+} from "./executor-profile-spacing-helpers";
+
+test.describe("executor profile card spacing on mobile", () => {
+  test("keeps edit and create cards separated without horizontal overflow", async ({
+    seedData,
+    testPage,
+  }) => {
+    await testPage.goto(`/settings/executors/${seedData.worktreeExecutorProfileId}`);
+    await expectExecutorProfileCardsSeparated(testPage);
+    await expectNoHorizontalOverflow(testPage);
+
+    await testPage.goto("/settings/executors/new/worktree");
+    await expectExecutorProfileCardsSeparated(testPage);
+    await expectNoHorizontalOverflow(testPage);
+  });
+});

--- a/docs/plans/executor-settings-card-spacing/plan.md
+++ b/docs/plans/executor-settings-card-spacing/plan.md
@@ -1,0 +1,70 @@
+---
+spec: docs/specs/ui/executor-settings-card-spacing.md
+created: 2026-08-03
+status: complete
+---
+
+# Implementation Plan: Executor settings card spacing
+
+## Overview
+
+The regression is limited to the two modern executor profile forms. Manual-save fieldsets use `display: contents`, which removes the layout box needed for the parent `space-y-8` utility to separate the section-card siblings. Restore a vertical spacing container on both fieldsets, then prove the shared edit and create surfaces with desktop and mobile bounding-box checks.
+
+Confirmed root cause: `apps/web/app/settings/executors/[profileId]/page.tsx` and `apps/web/app/settings/executors/new/[type]/page.tsx` both render their card fragments inside `className="contents"` fieldsets introduced with manual-save coordination. The older executor routes keep spacing because their cards remain direct children of a normal `space-y-8` wrapper.
+
+---
+
+## Frontend
+
+### Modern executor profile edit
+
+- `apps/web/app/settings/executors/[profileId]/page.tsx`: keep the existing disabled fieldset and replace its layout-only `contents` class with a vertical `space-y-8` container so all conditionally rendered cards receive the shared settings rhythm.
+
+### Modern executor profile create
+
+- `apps/web/app/settings/executors/new/[type]/page.tsx`: apply the same fieldset layout treatment to the shared create form, covering local, worktree, Docker, Sprites, and any other supported non-SSH type routed through `CreateProfileSections`.
+
+No API, store, state, copy, card primitive, or mobile navigation changes are required.
+
+## Tests
+
+- **What:** adjacent cards on a modern edit form have the intended separation and remain horizontally contained.
+  **File:** `apps/web/e2e/tests/settings/executor-profile-spacing.spec.ts`
+  **How:** seed data through the existing worker fixture, open the seeded worktree profile and a new worktree profile form, locate the visible card sections by their headings, and assert each adjacent bounding-box gap is at least the intended `2rem` rhythm.
+- **What:** the same edit and create card spacing contract holds on a phone viewport.
+  **File:** `apps/web/e2e/tests/settings/mobile-executor-profile-spacing.spec.ts`
+  **How:** use the `mobile-chrome` Pixel 5 project, repeat the shared geometry assertion, and assert `document.documentElement.scrollWidth <= document.documentElement.clientWidth`.
+
+The shared geometry and overflow assertions live in `apps/web/e2e/tests/settings/executor-profile-spacing-helpers.ts`.
+
+The regression tests must be written and run red before the class change, then rerun green after the fix. No backend or unit test is needed because the defect is a rendered layout relationship with no non-trivial domain logic.
+
+## E2E Tests
+
+- **Scenario:** GIVEN a saved worktree executor profile, WHEN the modern profile editor is opened, THEN the visible settings cards have a consistent vertical gap.
+  **File:** `apps/web/e2e/tests/settings/executor-profile-spacing.spec.ts`
+  **What to verify:** the Profile Details, Environment Variables, Prepare Script, and subsequent visible card bounding boxes are separated.
+- **Scenario:** GIVEN a new worktree executor profile form on desktop or phone, WHEN the form is opened, THEN its visible cards use the same gap and fit the viewport.
+  **File:** `apps/web/e2e/tests/settings/executor-profile-spacing.spec.ts` and `apps/web/e2e/tests/settings/mobile-executor-profile-spacing.spec.ts`
+  **What to verify:** card geometry and, on mobile, absence of document-level horizontal overflow.
+
+## Verification Results
+
+- RED: `cd apps/web && pnpm e2e:run --project chromium tests/settings/executor-profile-spacing.spec.ts` — failed as expected with a `0px` first card gap.
+- RED: `cd apps/web && pnpm e2e:run --project mobile-chrome tests/settings/mobile-executor-profile-spacing.spec.ts` — failed as expected with a `0px` first card gap.
+- GREEN: `cd apps/web && pnpm e2e:run --project chromium tests/settings/executor-profile-spacing.spec.ts` — 1 passed.
+- GREEN: `cd apps/web && pnpm e2e:run --project mobile-chrome tests/settings/mobile-executor-profile-spacing.spec.ts` — 1 passed.
+- `cd apps/web && pnpm run typecheck` — passed.
+- `git diff --check` — passed.
+
+## Implementation Waves And Parallel Candidates
+
+Wave 1 — sequential:
+
+- [x] [task-01-restore-card-spacing](task-01-restore-card-spacing.md)
+
+The production class changes and their regression tests are intentionally one sequential task because the test must establish the failing geometry before the fix is applied.
+
+## Open Questions
+
+None.

--- a/docs/plans/executor-settings-card-spacing/task-01-restore-card-spacing.md
+++ b/docs/plans/executor-settings-card-spacing/task-01-restore-card-spacing.md
@@ -1,0 +1,82 @@
+---
+id: "01-restore-card-spacing"
+title: "Restore executor card spacing"
+status: done
+wave: 1
+depends_on: []
+plan: "plan.md"
+spec: "../../specs/ui/executor-settings-card-spacing.md"
+---
+
+# Task 01: Restore executor card spacing
+
+Restore the layout box around the modern executor profile card fragments and add rendered regression coverage for edit and create forms on desktop and mobile.
+
+## Acceptance
+
+- Modern executor profile edit and create pages render at least the existing `space-y-8` rhythm between every adjacent visible settings card for all shared executor profile sections.
+- Existing fieldset disabled state, manual-save behavior, card content, and route behavior remain unchanged.
+- Desktop and mobile geometry checks pass, and the mobile profile form has no document-level horizontal overflow.
+
+## Verification
+
+Bootstrap a fresh worktree once if dependencies are absent:
+
+```bash
+cd apps && pnpm install --frozen-lockfile
+```
+
+Write and run the regression specs before the production class change (RED):
+
+```bash
+cd apps/web && pnpm e2e:run --project chromium tests/settings/executor-profile-spacing.spec.ts
+cd apps/web && pnpm e2e:run --project mobile-chrome tests/settings/mobile-executor-profile-spacing.spec.ts
+```
+
+Apply the minimal fieldset layout fix, then run the same commands (GREEN), followed by:
+
+```bash
+cd apps/web && pnpm run typecheck
+git diff --check
+```
+
+The managed E2E runner rebuilds the production web assets before each change-aware run.
+
+## Files likely touched
+
+- `apps/web/app/settings/executors/[profileId]/page.tsx`
+- `apps/web/app/settings/executors/new/[type]/page.tsx`
+- `apps/web/e2e/tests/settings/executor-profile-spacing.spec.ts`
+- `apps/web/e2e/tests/settings/executor-profile-spacing-helpers.ts`
+- `apps/web/e2e/tests/settings/mobile-executor-profile-spacing.spec.ts`
+- `docs/specs/ui/executor-settings-card-spacing.md`
+- `docs/specs/INDEX.md`
+- `docs/plans/executor-settings-card-spacing/plan.md`
+- `docs/plans/executor-settings-card-spacing/task-01-restore-card-spacing.md`
+
+## Dependencies
+
+None.
+
+## Parallelism
+
+Sequential. The regression specs and the two production class changes share the same rendered surface and must be validated as one red-green pass.
+
+## Inputs
+
+- Repair contract and scenarios in `docs/specs/ui/executor-settings-card-spacing.md`.
+- Root cause and file-level approach in `docs/plans/executor-settings-card-spacing/plan.md`.
+- Existing settings mobile shell in `apps/web/components/settings/settings-layout-client.tsx` and mobile settings E2E conventions in `apps/web/e2e/tests/settings/mobile-settings-sidebar.spec.ts`.
+- Existing worker fixture field `seedData.worktreeExecutorProfileId` and `ApiClient.createExecutorProfile` for the create-form setup.
+
+## Output contract
+
+Report the root cause confirmation, files changed, exact red and green commands with outcomes, typecheck and diff-check results, any blockers or risks, and synchronized task/plan status in the same conversation.
+
+## Results
+
+- Confirmed the `contents` fieldset class removed the layout box needed for the parent card stack spacing, producing `0px` gaps between adjacent cards.
+- Replaced `contents` with `space-y-8` on both modern executor profile edit and create fieldsets. Disabled-state and manual-save behavior remain on the same fieldsets.
+- RED desktop and mobile E2E runs both failed on the expected `0px` card gap.
+- GREEN desktop and mobile E2E runs both passed (`1 passed` each).
+- `pnpm run typecheck` and `git diff --check` passed.

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -148,6 +148,7 @@ Subscription quota tracking and per-agent cheap-model profile routing.
 | [mermaid-rendering](ui/mermaid-rendering.md) | shipped |
 | [message-queue-merge](ui/message-queue-merge.md) | shipped |
 | [settings-manual-save](ui/settings-manual-save.md) | shipped |
+| [executor-settings-card-spacing](ui/executor-settings-card-spacing.md) | shipped |
 | [transcript-navigation-settings](ui/transcript-navigation-settings.md) | shipped |
 | [app-status-bar](ui/app-status-bar.md) | shipped |
 | [mobile-task-navigation](ui/mobile-task-navigation.md) | shipped |

--- a/docs/specs/ui/executor-settings-card-spacing.md
+++ b/docs/specs/ui/executor-settings-card-spacing.md
@@ -1,0 +1,32 @@
+---
+status: shipped
+created: 2026-08-03
+owner: kandev
+---
+
+# Executor settings card spacing
+
+## Why
+
+Executor profile pages show several independently editable settings cards in one long form. On the modern profile edit and create routes, those cards touch edge-to-edge, which makes the form read as one dense surface and makes section boundaries harder to scan on desktop and phone screens.
+
+## What
+
+- Modern executor profile edit pages at `/settings/executors/:profileId` keep a consistent vertical gap between every visible settings card, including cards that appear only for a particular executor type.
+- Modern executor profile create pages at `/settings/executors/new/:type` use the same vertical card spacing for every supported executor type.
+- The spacing is the existing settings rhythm of `2rem` between adjacent cards and remains present at the configured phone viewport as well as desktop widths.
+- Card-internal padding, form fields, manual-save behavior, disabled-fieldset behavior, routing, and executor-specific content remain unchanged.
+- The profile form remains a single vertically scrolling surface and does not introduce document-level horizontal overflow on a phone viewport.
+
+## Scenarios
+
+- **GIVEN** a saved worktree executor profile, **WHEN** the user opens its modern profile editor, **THEN** the Profile Details, Environment Variables, Prepare Script, and any subsequent cards have a visible `2rem` vertical separation from the preceding card.
+- **GIVEN** a new profile form for a supported executor type, **WHEN** the user opens the form, **THEN** every visible settings card is separated by the same vertical rhythm.
+- **GIVEN** a modern executor profile editor or create form on a phone-sized viewport, **WHEN** the user scrolls through the form, **THEN** adjacent cards retain the separation, remain within the viewport, and the document has no horizontal overflow.
+- **GIVEN** an executor profile form is disabled while it is loading or saving, **WHEN** the spacing layout is rendered, **THEN** the fieldset remains disabled without changing the card spacing or form state.
+
+## Out of scope
+
+- Changing the shared card primitive's internal padding or spacing for unrelated settings pages.
+- Redesigning executor settings navigation, card content, form controls, save coordination, or executor-specific behavior.
+- Adding a new mobile navigation surface or changing desktop preferences on phone viewports.


### PR DESCRIPTION
Executor profile settings became difficult to scan because fragment-rendered cards lost the layout box that applies the shared vertical rhythm. Restoring the spacing container separates every visible executor card on desktop and mobile while preserving form state and behavior.

## Validation

- `cd apps/web && pnpm e2e:run --project chromium tests/settings/executor-profile-spacing.spec.ts` — passed
- `cd apps/web && pnpm e2e:run --project mobile-chrome tests/settings/mobile-executor-profile-spacing.spec.ts` — passed
- `cd apps/web && pnpm run typecheck` — passed
- Prettier check — passed
- `git diff --check` — passed

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- kandev-screenshots-start -->
## Screenshots

![Executor settings card spacing on desktop](https://raw.githubusercontent.com/kdlbs/kandev/53c19b26341b3fb2673188f90c11bbef3bdc308d/executor-settings-desktop.png)

![Executor settings card spacing on mobile](https://raw.githubusercontent.com/kdlbs/kandev/53c19b26341b3fb2673188f90c11bbef3bdc308d/executor-settings-mobile.png)
<!-- kandev-screenshots-end -->