### PR TITLE
fix(web): keep comment selection below CI popovers

### DIFF
--- a/apps/web/components/task/chat/messages/message-comment-surface.test.tsx
+++ b/apps/web/components/task/chat/messages/message-comment-surface.test.tsx
@@ -185,6 +185,34 @@ describe("MessageCommentSurface", () => {
   });
 });
 
+describe("MessageCommentSurface layering", () => {
+  it("keeps the selection trigger below overlay popovers", () => {
+    const content = "A selection sits above the chat input.";
+    const selectedText = "selection";
+    render(
+      <MessageCommentSurface message={message(content)} sessionId={SESSION_ID} isTurnActive={false}>
+        <span data-testid={MESSAGE_TEXT_TEST_ID}>{content}</span>
+      </MessageCommentSurface>,
+    );
+
+    const text = screen.getByTestId(MESSAGE_TEXT_TEST_ID).firstChild!;
+    const range = document.createRange();
+    const start = content.indexOf(selectedText);
+    range.setStart(text, start);
+    range.setEnd(text, start + selectedText.length);
+    const selection = window.getSelection()!;
+    selection.removeAllRanges();
+    selection.addRange(range);
+    fireEvent.mouseUp(screen.getByTestId(MESSAGE_TEXT_TEST_ID).parentElement!);
+
+    expect(
+      screen
+        .getByRole("button", { name: "Comment on selection" })
+        .parentElement?.classList.contains("z-40"),
+    ).toBe(true);
+  });
+});
+
 describe("MessageCommentSurface mobile drawer", () => {
   it("keeps mobile feedback open when the selected quote was rewritten", () => {
     TOUCH_DRAWER.enabled = true;

--- a/apps/web/components/task/chat/messages/message-comment-surface.tsx
+++ b/apps/web/components/task/chat/messages/message-comment-surface.tsx
@@ -139,7 +139,7 @@ function SelectionCommentTrigger({
   return createPortal(
     <div
       className={cn(
-        "pointer-events-auto z-[60] rounded-lg border border-border/50 bg-popover p-1 shadow-lg",
+        "pointer-events-auto z-40 rounded-lg border border-border/50 bg-popover p-1 shadow-lg",
         portalContainer ? "absolute" : "fixed",
       )}
       style={{


### PR DESCRIPTION
Fix the chat selection comment trigger’s stacking layer so PR/CI hover popovers remain above it when the pointer moves from selected text toward the chat input. The active comment composer keeps its higher layer for normal interaction.

## Important Changes

- Lowered the inactive selection comment trigger below shared PR/CI popovers.
- Added a regression test covering the trigger’s overlay layer.

## Validation

- `pnpm --filter @kandev/web test -- --run components/task/chat/messages/message-comment-surface.test.tsx`
- `pnpm --filter @kandev/web lint`
- `pnpm --filter @kandev/web typecheck`
- Managed Chromium and mobile-chrome E2E capture flows with synthetic chat/PR data.
- `git diff --check`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- kandev-screenshots-start -->
## Screenshots

![Desktop text-selection comment trigger](https://raw.githubusercontent.com/kdlbs/kandev/2ade6454f0ab0809fcd6af39d0014ba09f0160a7/comment-selection-desktop.png)

![Desktop PR/CI popover layering](https://raw.githubusercontent.com/kdlbs/kandev/2ade6454f0ab0809fcd6af39d0014ba09f0160a7/comment-selection-pr-ci-desktop.png)

![Mobile text-selection comment trigger](https://raw.githubusercontent.com/kdlbs/kandev/2ade6454f0ab0809fcd6af39d0014ba09f0160a7/comment-selection-mobile.png)

![Mobile PR/CI drawer layering](https://raw.githubusercontent.com/kdlbs/kandev/2ade6454f0ab0809fcd6af39d0014ba09f0160a7/comment-selection-pr-ci-mobile.png)
<!-- kandev-screenshots-end -->