### PR TITLE
test(acpdbg): resolve the helper process by absolute path

### DIFF
--- a/apps/backend/internal/agent/acpdbg/ops_test.go
+++ b/apps/backend/internal/agent/acpdbg/ops_test.go
@@ -33,9 +33,16 @@ func TestProbe_DefaultWorkdirReachesSessionNew(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
+	// os.Executable rather than os.Args[0]: the runner gives the child its own
+	// working directory, so a relative argv[0] — what you get running the binary
+	// as ./pkg.test after `go test -c` — would not resolve there.
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatalf("locate test binary: %v", err)
+	}
 	runner, err := NewRunner(ctx, filepath.Join(t.TempDir(), "frames.jsonl"), RunConfig{
 		AgentID: "helper",
-		Command: []string{os.Args[0], "-test.run=^TestACPDBGHelperProcess$"},
+		Command: []string{self, "-test.run=^TestACPDBGHelperProcess$"},
 	})
 	if err != nil {
 		t.Fatalf("NewRunner() error = %v", err)


### PR DESCRIPTION
## What

`TestProbe_DefaultWorkdirReachesSessionNew` re-executes the test binary as a scripted
agent using `os.Args[0]`. `NewRunner` gives the child its own working directory, so a
relative argv[0] does not resolve from there:

```
NewRunner() error = start ./pkg.test: fork/exec ./pkg.test: no such file or directory
```

## When it matters

Never under plain `go test` — that passes an absolute path, which is why CI is green.

It fires when the binary is built with `go test -c` and run from elsewhere. That is how
someone on Windows can exercise this package's unix-tagged tests: cross-compile for
linux/amd64, then run the binary under WSL. Without this, the run reports a failure that
has nothing to do with the code under test.

## Verification

Cross-compiled for linux/amd64 and executed from `/tmp`, where it previously failed:
the test now passes. Also green under plain `go test` on Windows.

One line plus a comment; happy to drop it if you would rather not carry the extra call.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

