### PR TITLE
fix(backend): retry prompt once after agent-not-ready-after-resume timeout

### DIFF
--- a/apps/backend/internal/task/handlers/message_handlers.go
+++ b/apps/backend/internal/task/handlers/message_handlers.go
@@ -775,10 +775,16 @@ func (h *MessageHandlers) handlePromptWithResume(
 			zap.String("task_id", taskID),
 			zap.String("session_id", sessionID),
 			zap.Error(waitErr))
-		return waitErr
+		return origErr
 	}
-	_, err := h.orchestrator.PromptTask(ctx, taskID, sessionID, content, model, planMode, attachments, false)
-	return err
+	if _, err := h.orchestrator.PromptTask(ctx, taskID, sessionID, content, model, planMode, attachments, false); err != nil {
+		h.logger.Warn("retry prompt failed after resume",
+			zap.String("task_id", taskID),
+			zap.String("session_id", sessionID),
+			zap.Error(err))
+		return origErr
+	}
+	return nil
 }
 
 // createPromptErrorMessage creates an agent error message visible to the user when

--- a/apps/backend/internal/task/handlers/message_handlers.go
+++ b/apps/backend/internal/task/handlers/message_handlers.go
@@ -754,6 +754,15 @@ func isTimeoutError(err error) bool {
 // from ensureSessionRunning, before executor.PromptWithDispatchCallback ever
 // runs, so retrying here cannot double-send a prompt the agent already
 // accepted.
+//
+// ResumeTaskSession and waitForSessionReady failures return origErr: neither
+// step ever reaches PromptTask, so the original pre-dispatch error is still
+// the only meaningful signal. Once the retry's own PromptTask call runs,
+// though, that call IS a real dispatch attempt — its error is authoritative
+// and takes over from origErr, so the caller's isAgentReportedError check
+// still fires correctly (e.g. the retry failing with a wrapped
+// lifecycle.ErrAgentReported must suppress createPromptErrorMessage, not get
+// masked by the unrelated original timeout).
 func (h *MessageHandlers) handlePromptWithResume(
 	ctx context.Context,
 	taskID, sessionID, content, model string,
@@ -787,7 +796,7 @@ func (h *MessageHandlers) handlePromptWithResume(
 			zap.String("task_id", taskID),
 			zap.String("session_id", sessionID),
 			zap.Error(err))
-		return origErr
+		return err
 	}
 	return nil
 }

--- a/apps/backend/internal/task/handlers/message_handlers.go
+++ b/apps/backend/internal/task/handlers/message_handlers.go
@@ -52,6 +52,10 @@ type MessageHandlers struct {
 	referenceValidator  entityrefs.SubmissionValidator
 	messageIDMu         sync.Mutex
 	messageIDGates      map[string]*messageIDGate
+	// waitForSessionReadyFn backs waitForSessionReady; defaults to
+	// service.WaitForSessionReady but is overridable in tests to avoid its
+	// real polling delay.
+	waitForSessionReadyFn func(ctx context.Context, sessionID string) error
 }
 
 type messageIDGate struct {
@@ -67,9 +71,10 @@ func NewMessageHandlers(
 	validators ...entityrefs.SubmissionValidator,
 ) *MessageHandlers {
 	handlers := &MessageHandlers{
-		service:      svc,
-		orchestrator: orchestrator,
-		logger:       log.WithFields(zap.String("component", "task-message-handlers")),
+		service:               svc,
+		orchestrator:          orchestrator,
+		logger:                log.WithFields(zap.String("component", "task-message-handlers")),
+		waitForSessionReadyFn: svc.WaitForSessionReady,
 	}
 	if len(validators) > 0 {
 		handlers.referenceValidator = validators[0]
@@ -821,10 +826,12 @@ func (h *MessageHandlers) createPromptErrorMessage(ctx context.Context, taskID, 
 	}
 }
 
-// waitForSessionReady delegates to the shared service.WaitForSessionReady helper.
-// Kept as a thin wrapper so existing tests on this method continue to pass.
+// waitForSessionReady delegates to waitForSessionReadyFn (by default
+// service.WaitForSessionReady). Kept as a thin wrapper so existing tests on
+// this method continue to pass; the indirection lets tests stub out the
+// real polling delay via waitForSessionReadyFn.
 func (h *MessageHandlers) waitForSessionReady(ctx context.Context, sessionID string) error {
-	return h.service.WaitForSessionReady(ctx, sessionID)
+	return h.waitForSessionReadyFn(ctx, sessionID)
 }
 
 type wsListMessagesRequest struct {

--- a/apps/backend/internal/task/handlers/message_handlers.go
+++ b/apps/backend/internal/task/handlers/message_handlers.go
@@ -728,8 +728,27 @@ func isTimeoutError(err error) bool {
 	return strings.Contains(strings.ToLower(err.Error()), "timeout")
 }
 
-// handlePromptWithResume attempts to resume a session and retry a prompt when the
-// initial prompt fails with ErrExecutionNotFound.
+// handlePromptWithResume attempts to resume a session and retry a prompt once
+// when the initial prompt fails with a recoverable, pre-dispatch error:
+//
+//   - executor.ErrExecutionNotFound: no live execution is tracked for the
+//     session (e.g. after a lazy backend restart).
+//   - orchestrator.ErrAgentNotReadyForPrompt: ensureSessionRunning's post-resume
+//     readiness wait (agentPromptReadyTimeout, 30s) expired — the exact error
+//     class behind "agent not ready after resume: ... context deadline
+//     exceeded". ensureSessionRunning already reaps a stuck execution on this
+//     error internally, and a fresh resume typically completes in a few
+//     seconds (ACP re-initialize + session/load), well inside a second
+//     attempt's own budget. Without this retry, a merely-slow-to-recover
+//     resume surfaced "Request timed out. The agent may be processing a
+//     complex task. Please try again." to the user on the very first hiccup,
+//     even though the backend's own self-healing would have succeeded
+//     silently one attempt later.
+//
+// Both error classes are guaranteed pre-dispatch: promptTask returns them
+// from ensureSessionRunning, before executor.PromptWithDispatchCallback ever
+// runs, so retrying here cannot double-send a prompt the agent already
+// accepted.
 func (h *MessageHandlers) handlePromptWithResume(
 	ctx context.Context,
 	taskID, sessionID, content, model string,
@@ -737,7 +756,8 @@ func (h *MessageHandlers) handlePromptWithResume(
 	attachments []v1.MessageAttachment,
 	origErr error,
 ) error {
-	if !errors.Is(origErr, executor.ErrExecutionNotFound) {
+	if !errors.Is(origErr, executor.ErrExecutionNotFound) &&
+		!errors.Is(origErr, orchestrator.ErrAgentNotReadyForPrompt) {
 		return origErr
 	}
 	if resumeErr := h.orchestrator.ResumeTaskSession(ctx, taskID, sessionID); resumeErr != nil {

--- a/apps/backend/internal/task/handlers/message_handlers_resume_readiness_test.go
+++ b/apps/backend/internal/task/handlers/message_handlers_resume_readiness_test.go
@@ -130,6 +130,7 @@ func TestForwardMessageAsPrompt_RetriesOnceWhenAgentNotReadyAfterResume(t *testi
 	}
 	orch := &resumeRetryOrchestrator{promptErr: promptErr}
 	h := newTestMessageHandlersWithOrchestrator(t, repo, orch)
+	h.waitForSessionReadyFn = func(context.Context, string) error { return nil }
 
 	h.forwardMessageAsPrompt(
 		context.Background(), "task-1", "session-1", "profile-1", "continue",
@@ -190,6 +191,7 @@ func TestForwardMessageAsPrompt_RetryGoesThroughResumeBeforeReprompting(t *testi
 	}
 	orch := &resumeRetryOrchestrator{promptErr: promptErr}
 	h := newTestMessageHandlersWithOrchestrator(t, repo, orch)
+	h.waitForSessionReadyFn = func(context.Context, string) error { return nil }
 
 	h.forwardMessageAsPrompt(
 		context.Background(), "task-1", "session-1", "profile-1", "continue",
@@ -245,11 +247,14 @@ func TestForwardMessageAsPrompt_SurfacesOrigErrorWhenReadinessWaitFails(t *testi
 
 	repo := &resumeRetryRepo{
 		sessionStateSequencer: sessionStateSequencer{
-			states: []models.TaskSessionState{models.TaskSessionStateFailed},
+			states: []models.TaskSessionState{models.TaskSessionStateWaitingForInput},
 		},
 	}
 	orch := &resumeRetryOrchestrator{promptErr: promptErr}
 	h := newTestMessageHandlersWithOrchestrator(t, repo, orch)
+	h.waitForSessionReadyFn = func(context.Context, string) error {
+		return errors.New("session failed after resume: session failed during resume")
+	}
 
 	h.forwardMessageAsPrompt(
 		context.Background(), "task-1", "session-1", "profile-1", "continue",
@@ -283,6 +288,7 @@ func TestForwardMessageAsPrompt_SurfacesOrigErrorWhenRetryPromptFails(t *testing
 		retryPromptErr: errors.New("dispatch: connection refused"),
 	}
 	h := newTestMessageHandlersWithOrchestrator(t, repo, orch)
+	h.waitForSessionReadyFn = func(context.Context, string) error { return nil }
 
 	h.forwardMessageAsPrompt(
 		context.Background(), "task-1", "session-1", "profile-1", "continue",

--- a/apps/backend/internal/task/handlers/message_handlers_resume_readiness_test.go
+++ b/apps/backend/internal/task/handlers/message_handlers_resume_readiness_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/kandev/kandev/internal/agent/runtime/lifecycle"
 	"github.com/kandev/kandev/internal/common/logger"
 	"github.com/kandev/kandev/internal/orchestrator"
 	"github.com/kandev/kandev/internal/task/models"
@@ -268,12 +269,15 @@ func TestForwardMessageAsPrompt_SurfacesOrigErrorWhenReadinessWaitFails(t *testi
 		"the surfaced error must be the original readiness timeout, not the internal 'session failed after resume' wait error")
 }
 
-// TestForwardMessageAsPrompt_SurfacesOrigErrorWhenRetryPromptFails ensures
-// that when the retry's second PromptTask call fails with its own,
-// differently-classified error (e.g. a dispatch/transport failure), the
-// original pre-dispatch error is still what reaches createPromptErrorMessage,
-// preserving the "failed recovery surfaces the original error" contract.
-func TestForwardMessageAsPrompt_SurfacesOrigErrorWhenRetryPromptFails(t *testing.T) {
+// TestForwardMessageAsPrompt_SurfacesRetryErrorWhenRetryPromptFails ensures
+// that once the retry's second PromptTask call actually runs, its error is
+// authoritative and reaches createPromptErrorMessage — not the original
+// pre-dispatch timeout. The retry is a real dispatch attempt, so its error
+// may be post-dispatch (e.g. wrap lifecycle.ErrAgentReported, see the next
+// test) and must flow through the same isAgentReportedError classification
+// as any other prompt failure; silently substituting origErr would mask
+// that classification and risk a misleading duplicate message.
+func TestForwardMessageAsPrompt_SurfacesRetryErrorWhenRetryPromptFails(t *testing.T) {
 	readinessErr := fmt.Errorf("%w: %w", orchestrator.ErrAgentNotReadyForPrompt, context.DeadlineExceeded)
 	resumeErr := fmt.Errorf("agent not ready after resume: %w", readinessErr)
 	promptErr := fmt.Errorf("failed to ensure session is running: %w", resumeErr)
@@ -298,6 +302,42 @@ func TestForwardMessageAsPrompt_SurfacesOrigErrorWhenRetryPromptFails(t *testing
 	assert.Equal(t, 2, orch.promptCalls, "the retry must still be attempted even though it goes on to fail")
 	assert.Equal(t, 1, orch.resumeCalls)
 	require.Len(t, repo.createdMessages, 1, "a failed retry must still surface an error message")
-	assert.Contains(t, repo.createdMessages[0].Content, "Request timed out",
-		"the surfaced error must be the original readiness timeout, not the retry's own dispatch error")
+	assert.Contains(t, repo.createdMessages[0].Content, "Failed to send message to agent",
+		"a generic retry-dispatch failure must surface its own error, not the unrelated original readiness timeout")
+}
+
+// TestForwardMessageAsPrompt_SuppressesMessageWhenRetryIsAgentReported covers
+// carlosflorencio's review comment on PR #2250: when the retry's PromptTask
+// call fails with an error wrapping lifecycle.ErrAgentReported, the agent's
+// own failure path (handleAgentFailed) has already surfaced the error to the
+// user via agent-status. forwardMessageAsPrompt's isAgentReportedError check
+// must see that sentinel and skip createPromptErrorMessage — which only
+// works if handlePromptWithResume returns the retry's real error instead of
+// substituting the original (non-agent-reported) readiness timeout.
+func TestForwardMessageAsPrompt_SuppressesMessageWhenRetryIsAgentReported(t *testing.T) {
+	readinessErr := fmt.Errorf("%w: %w", orchestrator.ErrAgentNotReadyForPrompt, context.DeadlineExceeded)
+	resumeErr := fmt.Errorf("agent not ready after resume: %w", readinessErr)
+	promptErr := fmt.Errorf("failed to ensure session is running: %w", resumeErr)
+
+	repo := &resumeRetryRepo{
+		sessionStateSequencer: sessionStateSequencer{
+			states: []models.TaskSessionState{models.TaskSessionStateWaitingForInput},
+		},
+	}
+	orch := &resumeRetryOrchestrator{
+		promptErr:      promptErr,
+		retryPromptErr: fmt.Errorf("retry failed: %w", lifecycle.ErrAgentReported),
+	}
+	h := newTestMessageHandlersWithOrchestrator(t, repo, orch)
+	h.waitForSessionReadyFn = func(context.Context, string) error { return nil }
+
+	h.forwardMessageAsPrompt(
+		context.Background(), "task-1", "session-1", "profile-1", "continue",
+		"", false, nil, nil, false,
+	)
+
+	assert.Equal(t, 2, orch.promptCalls)
+	assert.Equal(t, 1, orch.resumeCalls)
+	assert.Empty(t, repo.createdMessages,
+		"the retry's agent-reported error must be recognized and suppressed, not masked into a duplicate 'Request timed out' message")
 }

--- a/apps/backend/internal/task/handlers/message_handlers_resume_readiness_test.go
+++ b/apps/backend/internal/task/handlers/message_handlers_resume_readiness_test.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -31,13 +32,16 @@ func (r *resumeRetryRepo) CreateMessage(_ context.Context, message *models.Messa
 // resumeRetryOrchestrator is a minimal OrchestratorService fake that fails
 // PromptTask's first call with a caller-supplied error and succeeds on every
 // subsequent call, so tests can observe whether forwardMessageAsPrompt
-// retries automatically after a recoverable failure.
+// retries automatically after a recoverable failure. Setting retryPromptErr
+// additionally fails the second (retry) call, so tests can assert that a
+// failed retry still surfaces the original error rather than the retry's own.
 type resumeRetryOrchestrator struct {
-	promptErr   error
-	promptCalls int
-	resumeCalls int
-	resumeErr   error
-	callOrder   []string
+	promptErr      error
+	retryPromptErr error
+	promptCalls    int
+	resumeCalls    int
+	resumeErr      error
+	callOrder      []string
 }
 
 func (o *resumeRetryOrchestrator) PromptTask(
@@ -47,6 +51,9 @@ func (o *resumeRetryOrchestrator) PromptTask(
 	o.callOrder = append(o.callOrder, fmt.Sprintf("prompt:%d", o.promptCalls))
 	if o.promptCalls == 1 && o.promptErr != nil {
 		return nil, o.promptErr
+	}
+	if o.promptCalls == 2 && o.retryPromptErr != nil {
+		return nil, o.retryPromptErr
 	}
 	return &orchestrator.PromptResult{}, nil
 }
@@ -221,4 +228,70 @@ func TestForwardMessageAsPrompt_DoesNotRetryGenericTimeout(t *testing.T) {
 	assert.Equal(t, 0, orch.resumeCalls)
 	require.Len(t, repo.createdMessages, 1)
 	assert.Contains(t, repo.createdMessages[0].Content, "Request timed out")
+}
+
+// TestForwardMessageAsPrompt_SurfacesOrigErrorWhenReadinessWaitFails ensures
+// that when the post-resume readiness wait itself fails (e.g. the session
+// transitions to FAILED while waiting), handlePromptWithResume surfaces the
+// original pre-dispatch error rather than the internal readiness-wait error.
+// The two errors classify differently for the user-facing message
+// (createPromptErrorMessage), so returning the wrong one would silently
+// downgrade the readiness timeout's "Request timed out..." UX to the
+// generic "Failed to send message to agent".
+func TestForwardMessageAsPrompt_SurfacesOrigErrorWhenReadinessWaitFails(t *testing.T) {
+	readinessErr := fmt.Errorf("%w: %w", orchestrator.ErrAgentNotReadyForPrompt, context.DeadlineExceeded)
+	resumeErr := fmt.Errorf("agent not ready after resume: %w", readinessErr)
+	promptErr := fmt.Errorf("failed to ensure session is running: %w", resumeErr)
+
+	repo := &resumeRetryRepo{
+		sessionStateSequencer: sessionStateSequencer{
+			states: []models.TaskSessionState{models.TaskSessionStateFailed},
+		},
+	}
+	orch := &resumeRetryOrchestrator{promptErr: promptErr}
+	h := newTestMessageHandlersWithOrchestrator(t, repo, orch)
+
+	h.forwardMessageAsPrompt(
+		context.Background(), "task-1", "session-1", "profile-1", "continue",
+		"", false, nil, nil, false,
+	)
+
+	assert.Equal(t, 1, orch.promptCalls, "PromptTask must not be retried when the post-resume readiness wait itself fails")
+	assert.Equal(t, 1, orch.resumeCalls)
+	require.Len(t, repo.createdMessages, 1, "a failed readiness wait must still surface an error message")
+	assert.Contains(t, repo.createdMessages[0].Content, "Request timed out",
+		"the surfaced error must be the original readiness timeout, not the internal 'session failed after resume' wait error")
+}
+
+// TestForwardMessageAsPrompt_SurfacesOrigErrorWhenRetryPromptFails ensures
+// that when the retry's second PromptTask call fails with its own,
+// differently-classified error (e.g. a dispatch/transport failure), the
+// original pre-dispatch error is still what reaches createPromptErrorMessage,
+// preserving the "failed recovery surfaces the original error" contract.
+func TestForwardMessageAsPrompt_SurfacesOrigErrorWhenRetryPromptFails(t *testing.T) {
+	readinessErr := fmt.Errorf("%w: %w", orchestrator.ErrAgentNotReadyForPrompt, context.DeadlineExceeded)
+	resumeErr := fmt.Errorf("agent not ready after resume: %w", readinessErr)
+	promptErr := fmt.Errorf("failed to ensure session is running: %w", resumeErr)
+
+	repo := &resumeRetryRepo{
+		sessionStateSequencer: sessionStateSequencer{
+			states: []models.TaskSessionState{models.TaskSessionStateWaitingForInput},
+		},
+	}
+	orch := &resumeRetryOrchestrator{
+		promptErr:      promptErr,
+		retryPromptErr: errors.New("dispatch: connection refused"),
+	}
+	h := newTestMessageHandlersWithOrchestrator(t, repo, orch)
+
+	h.forwardMessageAsPrompt(
+		context.Background(), "task-1", "session-1", "profile-1", "continue",
+		"", false, nil, nil, false,
+	)
+
+	assert.Equal(t, 2, orch.promptCalls, "the retry must still be attempted even though it goes on to fail")
+	assert.Equal(t, 1, orch.resumeCalls)
+	require.Len(t, repo.createdMessages, 1, "a failed retry must still surface an error message")
+	assert.Contains(t, repo.createdMessages[0].Content, "Request timed out",
+		"the surfaced error must be the original readiness timeout, not the retry's own dispatch error")
 }

--- a/apps/backend/internal/task/handlers/message_handlers_resume_readiness_test.go
+++ b/apps/backend/internal/task/handlers/message_handlers_resume_readiness_test.go
@@ -1,0 +1,224 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kandev/kandev/internal/common/logger"
+	"github.com/kandev/kandev/internal/orchestrator"
+	"github.com/kandev/kandev/internal/task/models"
+	"github.com/kandev/kandev/internal/task/service"
+	v1 "github.com/kandev/kandev/pkg/api/v1"
+)
+
+// resumeRetryRepo extends sessionStateSequencer to also record every message
+// the handler persists, so tests can assert whether a user-visible error
+// message ("Request timed out...") was created.
+type resumeRetryRepo struct {
+	sessionStateSequencer
+	createdMessages []*models.Message
+}
+
+func (r *resumeRetryRepo) CreateMessage(_ context.Context, message *models.Message) error {
+	r.createdMessages = append(r.createdMessages, message)
+	return nil
+}
+
+// resumeRetryOrchestrator is a minimal OrchestratorService fake that fails
+// PromptTask's first call with a caller-supplied error and succeeds on every
+// subsequent call, so tests can observe whether forwardMessageAsPrompt
+// retries automatically after a recoverable failure.
+type resumeRetryOrchestrator struct {
+	promptErr   error
+	promptCalls int
+	resumeCalls int
+	resumeErr   error
+	callOrder   []string
+}
+
+func (o *resumeRetryOrchestrator) PromptTask(
+	context.Context, string, string, string, string, bool, []v1.MessageAttachment, bool,
+) (*orchestrator.PromptResult, error) {
+	o.promptCalls++
+	o.callOrder = append(o.callOrder, fmt.Sprintf("prompt:%d", o.promptCalls))
+	if o.promptCalls == 1 && o.promptErr != nil {
+		return nil, o.promptErr
+	}
+	return &orchestrator.PromptResult{}, nil
+}
+
+func (o *resumeRetryOrchestrator) ResumeTaskSession(context.Context, string, string) error {
+	o.resumeCalls++
+	o.callOrder = append(o.callOrder, "resume")
+	return o.resumeErr
+}
+
+func (o *resumeRetryOrchestrator) StartCreatedSession(
+	context.Context, string, string, string, string, bool, bool, bool, []v1.MessageAttachment, []v1.EntityReference,
+) error {
+	return nil
+}
+
+func (o *resumeRetryOrchestrator) ProcessOnTurnStart(context.Context, string, string) error {
+	return nil
+}
+
+func (o *resumeRetryOrchestrator) StepRequiresCompletionSignal(context.Context, string) bool {
+	return false
+}
+
+func (o *resumeRetryOrchestrator) ForegroundActivity(string) v1.ForegroundActivity {
+	return ""
+}
+
+// newTestMessageHandlersWithOrchestrator mirrors newTestMessageHandlers but
+// wires a real OrchestratorService fake, which forwardMessageAsPrompt/
+// handlePromptWithResume require (they early-return when h.orchestrator is
+// nil, which is how the shared helper is normally used).
+func newTestMessageHandlersWithOrchestrator(t *testing.T, repo *resumeRetryRepo, orch OrchestratorService) *MessageHandlers {
+	t.Helper()
+	log, err := logger.NewLogger(logger.LoggingConfig{
+		Level:  "error",
+		Format: "json",
+	})
+	require.NoError(t, err)
+	svc := service.NewService(service.Repos{
+		Workspaces: repo, Tasks: repo, TaskRepos: repo,
+		Workflows: repo, Messages: repo, Turns: repo,
+		Sessions: repo, GitSnapshots: repo, RepoEntities: repo,
+		Executors: repo, Environments: repo, TaskEnvironments: repo,
+		Reviews: repo,
+	}, nil, log, service.RepositoryDiscoveryConfig{})
+	return NewMessageHandlers(svc, orch, log)
+}
+
+// TestForwardMessageAsPrompt_RetriesOnceWhenAgentNotReadyAfterResume covers
+// the case where ensureSessionRunning's post-resume readiness wait times out
+// (orchestrator.ErrAgentNotReadyForPrompt, the exact error class behind the
+// "agent not ready after resume: ... context deadline exceeded" log line).
+// That failure is pre-dispatch: promptTask returns it before ever calling
+// executor.PromptWithDispatchCallback, so no prompt has reached the agent
+// yet and a retry cannot double-send.
+//
+// The backend already self-heals this condition (ensureSessionRunning reaps
+// the stuck execution and a fresh resume typically succeeds in a few
+// seconds), but forwardMessageAsPrompt only retried automatically for
+// executor.ErrExecutionNotFound — this timeout class fell straight through
+// to createPromptErrorMessage, surfacing "Request timed out. The agent may
+// be processing a complex task. Please try again." to the user even though
+// one more attempt would have silently succeeded.
+func TestForwardMessageAsPrompt_RetriesOnceWhenAgentNotReadyAfterResume(t *testing.T) {
+	readinessErr := fmt.Errorf("%w: %w", orchestrator.ErrAgentNotReadyForPrompt, context.DeadlineExceeded)
+	resumeErr := fmt.Errorf("agent not ready after resume: %w", readinessErr)
+	promptErr := fmt.Errorf("failed to ensure session is running: %w", resumeErr)
+
+	repo := &resumeRetryRepo{
+		sessionStateSequencer: sessionStateSequencer{
+			states: []models.TaskSessionState{models.TaskSessionStateWaitingForInput},
+		},
+	}
+	orch := &resumeRetryOrchestrator{promptErr: promptErr}
+	h := newTestMessageHandlersWithOrchestrator(t, repo, orch)
+
+	h.forwardMessageAsPrompt(
+		context.Background(), "task-1", "session-1", "profile-1", "continue",
+		"", false, nil, nil, false,
+	)
+
+	assert.Equal(t, 2, orch.promptCalls, "PromptTask must be retried once after the readiness timeout")
+	assert.Equal(t, 1, orch.resumeCalls, "the retry must go through ResumeTaskSession, reusing the existing reap/relaunch recovery")
+	assert.Empty(t, repo.createdMessages, "a successful automatic retry must not surface a 'Request timed out' error message to the user")
+}
+
+// TestForwardMessageAsPrompt_SurfacesErrorWhenResumeRetryAlsoFails ensures
+// the automatic retry does not swallow a genuine, non-recoverable failure:
+// if ResumeTaskSession itself fails, the original readiness error must still
+// reach the user via createPromptErrorMessage.
+func TestForwardMessageAsPrompt_SurfacesErrorWhenResumeRetryAlsoFails(t *testing.T) {
+	readinessErr := fmt.Errorf("%w: %w", orchestrator.ErrAgentNotReadyForPrompt, context.DeadlineExceeded)
+	resumeErr := fmt.Errorf("agent not ready after resume: %w", readinessErr)
+	promptErr := fmt.Errorf("failed to ensure session is running: %w", resumeErr)
+
+	repo := &resumeRetryRepo{
+		sessionStateSequencer: sessionStateSequencer{
+			states: []models.TaskSessionState{models.TaskSessionStateWaitingForInput},
+		},
+	}
+	orch := &resumeRetryOrchestrator{
+		promptErr: promptErr,
+		resumeErr: fmt.Errorf("resume: no executor record"),
+	}
+	h := newTestMessageHandlersWithOrchestrator(t, repo, orch)
+
+	h.forwardMessageAsPrompt(
+		context.Background(), "task-1", "session-1", "profile-1", "continue",
+		"", false, nil, nil, false,
+	)
+
+	assert.Equal(t, 1, orch.promptCalls, "PromptTask must not be retried when the resume itself fails")
+	assert.Equal(t, 1, orch.resumeCalls)
+	require.Len(t, repo.createdMessages, 1, "a genuinely unrecoverable failure must still surface an error message")
+	assert.Contains(t, repo.createdMessages[0].Content, "Request timed out")
+}
+
+// TestForwardMessageAsPrompt_RetryGoesThroughResumeBeforeReprompting locks
+// down call order: the retry must resume the session (reusing the existing
+// reap/relaunch recovery in ResumeTaskSession) strictly between the failing
+// first PromptTask call and the successful second one. Retrying PromptTask
+// directly, without going through ResumeTaskSession first, would just
+// reproduce the same "not ready" failure.
+func TestForwardMessageAsPrompt_RetryGoesThroughResumeBeforeReprompting(t *testing.T) {
+	readinessErr := fmt.Errorf("%w: %w", orchestrator.ErrAgentNotReadyForPrompt, context.DeadlineExceeded)
+	resumeErr := fmt.Errorf("agent not ready after resume: %w", readinessErr)
+	promptErr := fmt.Errorf("failed to ensure session is running: %w", resumeErr)
+
+	repo := &resumeRetryRepo{
+		sessionStateSequencer: sessionStateSequencer{
+			states: []models.TaskSessionState{models.TaskSessionStateWaitingForInput},
+		},
+	}
+	orch := &resumeRetryOrchestrator{promptErr: promptErr}
+	h := newTestMessageHandlersWithOrchestrator(t, repo, orch)
+
+	h.forwardMessageAsPrompt(
+		context.Background(), "task-1", "session-1", "profile-1", "continue",
+		"", false, nil, nil, false,
+	)
+
+	assert.Equal(t, []string{"prompt:1", "resume", "prompt:2"}, orch.callOrder)
+}
+
+// TestForwardMessageAsPrompt_DoesNotRetryGenericTimeout is the negative
+// counterpart: a plain timeout error that does NOT wrap
+// orchestrator.ErrAgentNotReadyForPrompt or executor.ErrExecutionNotFound
+// (e.g. a provider/transport timeout that struck after the prompt may
+// already have reached the agent) must not trigger the automatic retry.
+// The fix is intentionally scoped to the two typed, provably pre-dispatch
+// sentinels handlePromptWithResume already checks — broadening it to
+// isTimeoutError's substring-based check would risk double-sending a
+// prompt the agent already accepted.
+func TestForwardMessageAsPrompt_DoesNotRetryGenericTimeout(t *testing.T) {
+	promptErr := fmt.Errorf("prompt dispatch: %w", context.DeadlineExceeded)
+
+	repo := &resumeRetryRepo{
+		sessionStateSequencer: sessionStateSequencer{
+			states: []models.TaskSessionState{models.TaskSessionStateWaitingForInput},
+		},
+	}
+	orch := &resumeRetryOrchestrator{promptErr: promptErr}
+	h := newTestMessageHandlersWithOrchestrator(t, repo, orch)
+
+	h.forwardMessageAsPrompt(
+		context.Background(), "task-1", "session-1", "profile-1", "continue",
+		"", false, nil, nil, false,
+	)
+
+	assert.Equal(t, 1, orch.promptCalls, "a generic timeout unrelated to the typed sentinels must not be retried")
+	assert.Equal(t, 0, orch.resumeCalls)
+	require.Len(t, repo.createdMessages, 1)
+	assert.Contains(t, repo.createdMessages[0].Content, "Request timed out")
+}


### PR DESCRIPTION
Users on long-running sessions were seeing "Request timed out. The agent may be processing a complex task. Please try again." on the very first hiccup after a resume, even though the backend's own reap-and-relaunch recovery would have silently succeeded one attempt later — this teaches `handlePromptWithResume` to retry that specific, provably pre-dispatch failure automatically instead of surfacing it to the user.

## Validation

- Root-caused against a live production log: task `77a8b7a5` hit `agent not ready after resume: ... context deadline exceeded` (the `agentPromptReadyTimeout` 30s post-resume readiness wait), while the backend's own internal reap + fresh resume completed in under 5 seconds moments later.
- New TDD tests in `message_handlers_resume_readiness_test.go` (red before the fix, green after):
  - retries once and suppresses the error message on a successful retry
  - still surfaces the error when the retry's `ResumeTaskSession` also fails
  - locks call order to `prompt → resume → prompt` (never a bare re-prompt)
  - negative case: a generic timeout error that does **not** wrap either typed sentinel is *not* retried, proving the fix stays scoped to provably pre-dispatch failures
- `go vet ./internal/task/handlers/... ./internal/orchestrator/...` — clean
- `go test ./internal/task/handlers/...` and `go test ./internal/orchestrator/...` (full suite, including every `Resume*`/`Reap*`/`PromptReady*` test) — all pass, zero regressions
- Full `apps/backend` suite run; remaining failures (git/gpg signing, filesystem sandbox) reproduce identically on unmodified `HEAD` via `git stash` comparison — confirmed pre-existing/environmental, unrelated to this change

## Possible Improvements

Low risk: the retry only fires for `orchestrator.ErrAgentNotReadyForPrompt`, a sentinel `ensureSessionRunning` returns before any prompt reaches the agent, so it cannot double-send; a genuinely unrecoverable resume still surfaces the original error to the user.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2250?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

