### PR TITLE
fix(web): point popular MCP presets at servers that exist

### DIFF
--- a/apps/web/app/settings/agents/[agentId]/profile-mcp-config-card.tsx
+++ b/apps/web/app/settings/agents/[agentId]/profile-mcp-config-card.tsx
@@ -65,11 +65,10 @@ const POPULAR_SERVERS: Record<string, Record<string, unknown>> = {
     },
   },
   github: {
-    type: "stdio",
-    command: "npx",
-    args: ["-y", "@modelcontextprotocol/server-github"],
-    env: {
-      GITHUB_TOKEN: "your_token_here",
+    type: "http",
+    url: "https://api.githubcopilot.com/mcp/",
+    headers: {
+      Authorization: "Bearer your_token_here",
     },
   },
 };

--- a/apps/web/app/settings/agents/[agentId]/profile-mcp-config-card.tsx
+++ b/apps/web/app/settings/agents/[agentId]/profile-mcp-config-card.tsx
@@ -49,17 +49,17 @@ const POPULAR_SERVERS: Record<string, Record<string, unknown>> = {
   playwright: {
     type: "stdio",
     command: "npx",
-    args: ["-y", "@modelcontextprotocol/server-playwright"],
+    args: ["-y", "@playwright/mcp"],
   },
   "chrome-devtools": {
     type: "stdio",
     command: "npx",
-    args: ["-y", "@modelcontextprotocol/server-chrome-devtools"],
+    args: ["-y", "chrome-devtools-mcp"],
   },
   context7: {
     type: "stdio",
     command: "npx",
-    args: ["-y", "@context7/mcp"],
+    args: ["-y", "@upstash/context7-mcp"],
     env: {
       CONTEXT7_API_KEY: "your_api_key_here",
     },


### PR DESCRIPTION
All four presets in the MCP config card install servers that cannot start, so every server added through those buttons fails and the agent waits on it at each session load. Three are npm packages that are not on the registry and the fourth is one npm marks as unsupported; this points each preset at a server that exists.

```
npm view @modelcontextprotocol/server-playwright        -> E404
npm view @modelcontextprotocol/server-chrome-devtools   -> E404
npm view @context7/mcp                                  -> E404
npm view @modelcontextprotocol/server-github            -> "Package no longer supported"
```

| preset | was | now |
|---|---|---|
| playwright | `@modelcontextprotocol/server-playwright` | `@playwright/mcp` |
| chrome-devtools | `@modelcontextprotocol/server-chrome-devtools` | `chrome-devtools-mcp` |
| context7 | `@context7/mcp` | `@upstash/context7-mcp` |
| github | `@modelcontextprotocol/server-github` (stdio) | `https://api.githubcopilot.com/mcp/` (http) |

## Important Changes

- The first three are name swaps: Playwright and Chrome DevTools are published by their own vendors rather than under the `@modelcontextprotocol` scope, and Context7 lives under `@upstash`. Left unversioned, matching the existing style.
- `github` is a shape change, not a name swap. GitHub publishes no replacement on npm — the current server is a remote endpoint or a container image, neither of which fits a `stdio`+`npx` entry. The credential moves with it, from a `GITHUB_TOKEN` env var to the `Authorization` header the remote server expects.

## Validation

```
npm view @playwright/mcp version         -> 0.0.78
npm view chrome-devtools-mcp version     -> 1.6.0
npm view @upstash/context7-mcp version   -> 3.2.5
```

Each of the three also ran standalone through `npx -y <package> --help` (exit 0). The remote github endpoint is the one documented in `github/github-mcp-server`.

Applied the corrected presets to a real profile on Windows 11 and confirmed the servers start where they previously did not: the agent's registered tool count went from 7 to 33, and the `server unavailable` warnings the old presets produced on every load are gone.

No e2e test added: the change is a constant, and the behaviour it feeds is the JSON the button writes into the editor, which the existing tests already cover in shape. Happy to add one if you would rather have it pinned.

## Possible Improvements

Low risk for the three name swaps. The `github` entry is the one to look at: `toACPMcpServers` maps `http` onto `acp.McpServerHttpInline` with headers, so agents advertising http capability get the server and the rest produce a logged filter decision rather than a server that never starts — but that is a change in which agents see the preset at all. Say the word if you would rather have the Docker `stdio` variant, or no github preset.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2255?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->




