### PR TITLE
fix: quiet terminal-session ERROR noise in git and resume paths

### DIFF
--- a/apps/backend/internal/agent/handlers/git_handlers.go
+++ b/apps/backend/internal/agent/handlers/git_handlers.go
@@ -778,9 +778,13 @@ func (h *GitHandlers) wsGitCommits(ctx context.Context, msg *ws.Message) (*ws.Me
 func (h *GitHandlers) computeGitCommits(ctx context.Context, req *GitCommitsRequest) (interface{}, error) {
 	execution, err := h.lifecycleMgr.GetOrEnsureExecution(ctx, req.SessionID)
 	if err != nil {
-		// "Not ready" errors map to ready:false so the client retries; any
-		// other error (DB failure, etc.) propagates as a real error.
-		if errors.Is(err, lifecycle.ErrSessionWorkspaceNotReady) || isSessionNotReadyError(err) {
+		// "Not ready" errors map to ready:false so the client retries; a
+		// terminal session (cancelled/completed/failed) also maps to
+		// ready:false since it will never gain an execution. Any other error
+		// (DB failure, etc.) propagates as a real error.
+		if errors.Is(err, lifecycle.ErrSessionWorkspaceNotReady) ||
+			errors.Is(err, lifecycle.ErrSessionTerminal) ||
+			isSessionNotReadyError(err) {
 			return map[string]any{"commits": []any{}, "ready": false}, nil
 		}
 		return nil, fmt.Errorf("failed to get execution for session %s: %w", req.SessionID, err)
@@ -852,7 +856,9 @@ func (h *GitHandlers) wsCumulativeDiff(ctx context.Context, msg *ws.Message) (*w
 func (h *GitHandlers) computeCumulativeDiff(ctx context.Context, req *CumulativeDiffRequest) (interface{}, error) {
 	execution, err := h.lifecycleMgr.GetOrEnsureExecution(ctx, req.SessionID)
 	if err != nil {
-		if errors.Is(err, lifecycle.ErrSessionWorkspaceNotReady) || isSessionNotReadyError(err) {
+		if errors.Is(err, lifecycle.ErrSessionWorkspaceNotReady) ||
+			errors.Is(err, lifecycle.ErrSessionTerminal) ||
+			isSessionNotReadyError(err) {
 			return map[string]any{"cumulative_diff": nil, "ready": false}, nil
 		}
 		return nil, fmt.Errorf("failed to get execution for session %s: %w", req.SessionID, err)

--- a/apps/backend/internal/agent/handlers/git_handlers.go
+++ b/apps/backend/internal/agent/handlers/git_handlers.go
@@ -771,6 +771,11 @@ func (h *GitHandlers) wsGitCommits(ctx context.Context, msg *ws.Message) (*ws.Me
 	}
 }
 
+// sessionTerminalReason is the ready:false reason clients use to stop
+// retrying. Transient not-ready paths leave reason unset (or use another
+// code); a terminal session will never gain an execution.
+const sessionTerminalReason = "session_terminal"
+
 // computeGitCommits is the singleflight body for wsGitCommits. Returns
 // a JSON-ready payload — the not-ready / agent-client-nil cases return
 // the same `{commits:[], ready:false}` envelope as before, just packaged
@@ -778,13 +783,18 @@ func (h *GitHandlers) wsGitCommits(ctx context.Context, msg *ws.Message) (*ws.Me
 func (h *GitHandlers) computeGitCommits(ctx context.Context, req *GitCommitsRequest) (interface{}, error) {
 	execution, err := h.lifecycleMgr.GetOrEnsureExecution(ctx, req.SessionID)
 	if err != nil {
-		// "Not ready" errors map to ready:false so the client retries; a
-		// terminal session (cancelled/completed/failed) also maps to
-		// ready:false since it will never gain an execution. Any other error
-		// (DB failure, etc.) propagates as a real error.
-		if errors.Is(err, lifecycle.ErrSessionWorkspaceNotReady) ||
-			errors.Is(err, lifecycle.ErrSessionTerminal) ||
-			isSessionNotReadyError(err) {
+		// Terminal sessions will never recover an execution — return a
+		// distinct reason so clients stop retrying instead of polling forever.
+		if errors.Is(err, lifecycle.ErrSessionTerminal) {
+			return map[string]any{
+				"commits": []any{},
+				"ready":   false,
+				"reason":  sessionTerminalReason,
+			}, nil
+		}
+		// "Not ready" errors map to ready:false so the client retries.
+		// Any other error (DB failure, etc.) propagates as a real error.
+		if errors.Is(err, lifecycle.ErrSessionWorkspaceNotReady) || isSessionNotReadyError(err) {
 			return map[string]any{"commits": []any{}, "ready": false}, nil
 		}
 		return nil, fmt.Errorf("failed to get execution for session %s: %w", req.SessionID, err)
@@ -856,9 +866,17 @@ func (h *GitHandlers) wsCumulativeDiff(ctx context.Context, msg *ws.Message) (*w
 func (h *GitHandlers) computeCumulativeDiff(ctx context.Context, req *CumulativeDiffRequest) (interface{}, error) {
 	execution, err := h.lifecycleMgr.GetOrEnsureExecution(ctx, req.SessionID)
 	if err != nil {
-		if errors.Is(err, lifecycle.ErrSessionWorkspaceNotReady) ||
-			errors.Is(err, lifecycle.ErrSessionTerminal) ||
-			isSessionNotReadyError(err) {
+		// Distinct terminal reason: clients must not treat this as an
+		// authoritative empty diff (that would clear a previously cached
+		// snapshot) and should not retry.
+		if errors.Is(err, lifecycle.ErrSessionTerminal) {
+			return map[string]any{
+				"cumulative_diff": nil,
+				"ready":           false,
+				"reason":          sessionTerminalReason,
+			}, nil
+		}
+		if errors.Is(err, lifecycle.ErrSessionWorkspaceNotReady) || isSessionNotReadyError(err) {
 			return map[string]any{"cumulative_diff": nil, "ready": false}, nil
 		}
 		return nil, fmt.Errorf("failed to get execution for session %s: %w", req.SessionID, err)

--- a/apps/backend/internal/agent/handlers/git_handlers_test.go
+++ b/apps/backend/internal/agent/handlers/git_handlers_test.go
@@ -720,6 +720,9 @@ func TestWsGitCommits_TerminalSessionError(t *testing.T) {
 	if ready, ok := payload["ready"].(bool); !ok || ready {
 		t.Errorf("expected ready=false, got %v", payload["ready"])
 	}
+	if got, want := payload["reason"], sessionTerminalReason; got != want {
+		t.Errorf("reason = %v, want %v", got, want)
+	}
 	commits, ok := payload["commits"].([]any)
 	if !ok {
 		t.Fatalf("expected commits array, got %T", payload["commits"])
@@ -755,6 +758,9 @@ func TestWsGitCommits_WrappedTerminalSessionError(t *testing.T) {
 	if ready, ok := payload["ready"].(bool); !ok || ready {
 		t.Errorf("expected ready=false, got %v", payload["ready"])
 	}
+	if got, want := payload["reason"], sessionTerminalReason; got != want {
+		t.Errorf("reason = %v, want %v", got, want)
+	}
 }
 
 func TestWsCumulativeDiff_TerminalSessionError(t *testing.T) {
@@ -780,6 +786,9 @@ func TestWsCumulativeDiff_TerminalSessionError(t *testing.T) {
 	}
 	if ready, ok := payload["ready"].(bool); !ok || ready {
 		t.Errorf("expected ready=false, got %v", payload["ready"])
+	}
+	if got, want := payload["reason"], sessionTerminalReason; got != want {
+		t.Errorf("reason = %v, want %v", got, want)
 	}
 	if payload["cumulative_diff"] != nil {
 		t.Errorf("expected cumulative_diff=nil, got %v", payload["cumulative_diff"])

--- a/apps/backend/internal/agent/handlers/git_handlers_test.go
+++ b/apps/backend/internal/agent/handlers/git_handlers_test.go
@@ -693,6 +693,99 @@ func TestWsGitCommits_WrappedWorkspaceNotReadyError(t *testing.T) {
 	}
 }
 
+func TestWsGitCommits_TerminalSessionError(t *testing.T) {
+	// A terminal session (cancelled/completed/failed) returns ready:false
+	// gracefully instead of propagating an error the WS layer would log at
+	// ERROR with a stacktrace.
+	log := newTestLogger()
+	lookup := &mockExecutionLookup{
+		ensureErr: lifecycle.ErrSessionTerminal,
+	}
+	h := NewGitHandlers(lookup, nil, log)
+
+	msg, _ := ws.NewRequest("test-1", ws.ActionSessionGitCommits, GitCommitsRequest{SessionID: "session-1"})
+
+	resp, err := h.wsGitCommits(context.Background(), msg)
+	if err != nil {
+		t.Fatalf("expected graceful response for terminal session, got error: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("expected non-nil response")
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(resp.Payload, &payload); err != nil {
+		t.Fatalf("failed to parse payload: %v", err)
+	}
+	if ready, ok := payload["ready"].(bool); !ok || ready {
+		t.Errorf("expected ready=false, got %v", payload["ready"])
+	}
+	commits, ok := payload["commits"].([]any)
+	if !ok {
+		t.Fatalf("expected commits array, got %T", payload["commits"])
+	}
+	if len(commits) != 0 {
+		t.Errorf("expected empty commits, got %d", len(commits))
+	}
+}
+
+func TestWsGitCommits_WrappedTerminalSessionError(t *testing.T) {
+	// The terminal-session sentinel is wrapped in a descriptive message by the
+	// lifecycle manager; errors.Is must still detect it.
+	log := newTestLogger()
+	lookup := &mockExecutionLookup{
+		ensureErr: fmt.Errorf("verify session before registering execution: session %q is CANCELLED: %w", "session-1", lifecycle.ErrSessionTerminal),
+	}
+	h := NewGitHandlers(lookup, nil, log)
+
+	msg, _ := ws.NewRequest("test-1", ws.ActionSessionGitCommits, GitCommitsRequest{SessionID: "session-1"})
+
+	resp, err := h.wsGitCommits(context.Background(), msg)
+	if err != nil {
+		t.Fatalf("expected graceful response for wrapped terminal session, got error: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("expected non-nil response")
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(resp.Payload, &payload); err != nil {
+		t.Fatalf("failed to parse payload: %v", err)
+	}
+	if ready, ok := payload["ready"].(bool); !ok || ready {
+		t.Errorf("expected ready=false, got %v", payload["ready"])
+	}
+}
+
+func TestWsCumulativeDiff_TerminalSessionError(t *testing.T) {
+	log := newTestLogger()
+	lookup := &mockExecutionLookup{
+		ensureErr: fmt.Errorf("verify session before registering execution: session %q is FAILED: %w", "session-1", lifecycle.ErrSessionTerminal),
+	}
+	h := NewGitHandlers(lookup, nil, log)
+
+	msg, _ := ws.NewRequest("test-1", ws.ActionSessionCumulativeDiff, CumulativeDiffRequest{SessionID: "session-1"})
+
+	resp, err := h.wsCumulativeDiff(context.Background(), msg)
+	if err != nil {
+		t.Fatalf("expected graceful response for terminal session, got error: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("expected non-nil response")
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(resp.Payload, &payload); err != nil {
+		t.Fatalf("failed to parse payload: %v", err)
+	}
+	if ready, ok := payload["ready"].(bool); !ok || ready {
+		t.Errorf("expected ready=false, got %v", payload["ready"])
+	}
+	if payload["cumulative_diff"] != nil {
+		t.Errorf("expected cumulative_diff=nil, got %v", payload["cumulative_diff"])
+	}
+}
+
 // TestWsGitCommits_SingleflightDedupesConcurrentRequests verifies that N
 // concurrent identical (sessionID, limit) requests collapse onto a single
 // computeGitCommits invocation. Without dedup, a frontend re-render storm

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_execution.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_execution.go
@@ -23,6 +23,13 @@ import (
 // have a resolved workspace path (typically while worktree preparation is in progress).
 var ErrSessionWorkspaceNotReady = errors.New("session workspace not ready")
 
+// ErrSessionTerminal indicates the task session has reached a terminal state
+// (cancelled/completed/failed) and no execution can be created for it. User-facing
+// workspace handlers treat this like ErrSessionWorkspaceNotReady: a graceful
+// not-ready envelope rather than an ERROR-logged failure, since a terminal session
+// will never recover an execution.
+var ErrSessionTerminal = errors.New("session is terminal")
+
 // coalescedExecutionCreationTimeout matches the runtime's 60-second agentctl
 // startup window while preventing blocked instance I/O from owning the shared
 // session slot and its activity lease for the lifetime of the manager.

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_launch.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_launch.go
@@ -1326,7 +1326,7 @@ func (m *Manager) ensureLaunchSessionStillActive(ctx context.Context, sessionID 
 	case models.TaskSessionStateCancelled,
 		models.TaskSessionStateCompleted,
 		models.TaskSessionStateFailed:
-		return fmt.Errorf("verify session before registering execution: session %q is %s", sessionID, session.State)
+		return fmt.Errorf("verify session before registering execution: session %q is %s: %w", sessionID, session.State, ErrSessionTerminal)
 	default:
 		return nil
 	}

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_launch_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_launch_test.go
@@ -1942,6 +1942,9 @@ func TestEnsureLaunchSessionStillActiveRereadsAfterCleanupAdmission(t *testing.T
 	if err == nil || !strings.Contains(err.Error(), "CANCELLED") {
 		t.Fatalf("ensureLaunchSessionStillActive error = %v, want terminal-session validation", err)
 	}
+	if !errors.Is(err, ErrSessionTerminal) {
+		t.Fatalf("ensureLaunchSessionStillActive error = %v, want wrapped ErrSessionTerminal", err)
+	}
 	if got := reader.reads.Load(); got != 2 {
 		t.Fatalf("session reads = %d, want 2", got)
 	}

--- a/apps/backend/internal/agent/runtime/lifecycle/session.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/session.go
@@ -231,11 +231,13 @@ func (sm *SessionManager) loadSession(
 		zap.String("session_id", sessionID))
 
 	if err := client.LoadSession(ctx, sessionID, mcpServers); err != nil {
-		// A cancelled/expired context here is caller teardown (WS disconnect,
-		// session already gone) rather than an agent or transport fault, so it
-		// does not warrant an ERROR + stacktrace. The caller still classifies
-		// it as a transport-dead load and skips the session/new fallback.
-		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		// context.Canceled is caller teardown (WS disconnect, session already
+		// gone) rather than an agent or transport fault, so it does not warrant
+		// an ERROR + stacktrace. DeadlineExceeded is a real startup/handshake
+		// timeout and stays ERROR — matching the executor startup-deadline
+		// classification. The caller still classifies canceled loads as
+		// transport-dead and skips the session/new fallback.
+		if errors.Is(err, context.Canceled) {
 			sm.logger.Warn("ACP session/load aborted by context",
 				zap.String("agent_type", agentConfig.ID()),
 				zap.String("session_id", sessionID),
@@ -403,11 +405,11 @@ func (sm *SessionManager) initializeACPConnection(
 	}
 	result, err := sm.InitializeSession(ctx, execution.agentctl, agentConfig, execution.ACPSessionID, execution.WorkspacePath, mcpServers)
 	if err != nil {
-		// loadSession already logged the root cause. A cancelled/expired
-		// context is caller teardown, so keep this outer boundary at WARN
-		// too — otherwise the intentional load-path downgrade is undone
-		// by a second ERROR stacktrace here.
-		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		// loadSession already logged the root cause. context.Canceled is
+		// caller teardown, so keep this outer boundary at WARN too —
+		// otherwise the intentional load-path downgrade is undone by a
+		// second ERROR stacktrace here. DeadlineExceeded stays ERROR.
+		if errors.Is(err, context.Canceled) {
 			sm.logger.Warn("session initialization aborted by context",
 				zap.String("execution_id", execution.ID), zap.Error(err))
 		} else {

--- a/apps/backend/internal/agent/runtime/lifecycle/session.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/session.go
@@ -231,10 +231,21 @@ func (sm *SessionManager) loadSession(
 		zap.String("session_id", sessionID))
 
 	if err := client.LoadSession(ctx, sessionID, mcpServers); err != nil {
-		sm.logger.Error("ACP session/load failed",
-			zap.String("agent_type", agentConfig.ID()),
-			zap.String("session_id", sessionID),
-			zap.Error(err))
+		// A cancelled/expired context here is caller teardown (WS disconnect,
+		// session already gone) rather than an agent or transport fault, so it
+		// does not warrant an ERROR + stacktrace. The caller still classifies
+		// it as a transport-dead load and skips the session/new fallback.
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			sm.logger.Warn("ACP session/load aborted by context",
+				zap.String("agent_type", agentConfig.ID()),
+				zap.String("session_id", sessionID),
+				zap.Error(err))
+		} else {
+			sm.logger.Error("ACP session/load failed",
+				zap.String("agent_type", agentConfig.ID()),
+				zap.String("session_id", sessionID),
+				zap.Error(err))
+		}
 		return "", fmt.Errorf("session/load failed: %w", err)
 	}
 

--- a/apps/backend/internal/agent/runtime/lifecycle/session.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/session.go
@@ -403,7 +403,17 @@ func (sm *SessionManager) initializeACPConnection(
 	}
 	result, err := sm.InitializeSession(ctx, execution.agentctl, agentConfig, execution.ACPSessionID, execution.WorkspacePath, mcpServers)
 	if err != nil {
-		sm.logger.Error("session initialization failed", zap.String("execution_id", execution.ID), zap.Error(err))
+		// loadSession already logged the root cause. A cancelled/expired
+		// context is caller teardown, so keep this outer boundary at WARN
+		// too — otherwise the intentional load-path downgrade is undone
+		// by a second ERROR stacktrace here.
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			sm.logger.Warn("session initialization aborted by context",
+				zap.String("execution_id", execution.ID), zap.Error(err))
+		} else {
+			sm.logger.Error("session initialization failed",
+				zap.String("execution_id", execution.ID), zap.Error(err))
+		}
 		return ctx, nil, err
 	}
 	sm.logger.Info("ACP session initialized",

--- a/apps/backend/internal/orchestrator/executor/executor_execute.go
+++ b/apps/backend/internal/orchestrator/executor/executor_execute.go
@@ -115,11 +115,25 @@ func (e *Executor) handleAgentProcessStartFailure(
 	startErr error,
 	escalateTaskOnFailure, fromResume bool,
 ) {
-	e.logger.Error("failed to start agent process",
-		zap.String("task_id", taskID),
-		zap.String("session_id", sessionID),
-		zap.String("agent_execution_id", agentExecutionID),
-		zap.Error(startErr))
+	// A context cancellation or a terminal-session error is a benign teardown
+	// race (the session ended while StartAgentProcess was blocked), not a
+	// genuine start fault, so it logs at WARN without a stacktrace. Real start
+	// failures keep ERROR severity. Control flow below is unchanged.
+	if errors.Is(startErr, context.Canceled) ||
+		errors.Is(startErr, context.DeadlineExceeded) ||
+		errors.Is(startErr, lifecycle.ErrSessionTerminal) {
+		e.logger.Warn("agent process start aborted by session teardown",
+			zap.String("task_id", taskID),
+			zap.String("session_id", sessionID),
+			zap.String("agent_execution_id", agentExecutionID),
+			zap.Error(startErr))
+	} else {
+		e.logger.Error("failed to start agent process",
+			zap.String("task_id", taskID),
+			zap.String("session_id", sessionID),
+			zap.String("agent_execution_id", agentExecutionID),
+			zap.Error(startErr))
+	}
 
 	// A terminal transition may have landed while StartAgentProcess was
 	// blocked. Drop all failure/recovery side effects in that case. CANCELLED

--- a/apps/backend/internal/orchestrator/executor/executor_execute.go
+++ b/apps/backend/internal/orchestrator/executor/executor_execute.go
@@ -115,12 +115,13 @@ func (e *Executor) handleAgentProcessStartFailure(
 	startErr error,
 	escalateTaskOnFailure, fromResume bool,
 ) {
-	// A context cancellation or a terminal-session error is a benign teardown
-	// race (the session ended while StartAgentProcess was blocked), not a
-	// genuine start fault, so it logs at WARN without a stacktrace. Real start
-	// failures keep ERROR severity. Control flow below is unchanged.
+	// A cancelled context or a terminal-session error is a benign teardown race
+	// (the session ended while StartAgentProcess was blocked), not a genuine
+	// start fault, so it logs at WARN without a stacktrace. DeadlineExceeded
+	// is NOT treated as teardown: runAgentProcessAsync owns a 5-minute startup
+	// deadline, and a hung agent that hits it on a still-active session is a
+	// real operational failure that must stay at ERROR.
 	if errors.Is(startErr, context.Canceled) ||
-		errors.Is(startErr, context.DeadlineExceeded) ||
 		errors.Is(startErr, lifecycle.ErrSessionTerminal) {
 		e.logger.Warn("agent process start aborted by session teardown",
 			zap.String("task_id", taskID),

--- a/apps/backend/internal/orchestrator/executor/executor_start_failure_log_test.go
+++ b/apps/backend/internal/orchestrator/executor/executor_start_failure_log_test.go
@@ -1,0 +1,86 @@
+package executor
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/kandev/kandev/internal/agent/runtime/lifecycle"
+	"github.com/kandev/kandev/internal/common/logger"
+	"github.com/kandev/kandev/internal/task/models"
+	v1 "github.com/kandev/kandev/pkg/api/v1"
+)
+
+func newObservedExecutor(t *testing.T, level zapcore.Level) (*Executor, *observer.ObservedLogs) {
+	t.Helper()
+	core, logs := observer.New(level)
+	log, err := logger.NewFromZap(zap.New(core))
+	if err != nil {
+		t.Fatalf("NewFromZap: %v", err)
+	}
+	repo := newMockRepository()
+	repo.sessions["session-123"] = &models.TaskSession{
+		ID: "session-123", TaskID: "task-123", State: models.TaskSessionStateStarting,
+	}
+	repo.tasks["task-123"] = &models.Task{ID: "task-123", State: v1.TaskStateTODO}
+	exec := NewExecutor(&mockAgentManager{}, repo, log, ExecutorConfig{
+		ShellPrefs: &mockShellPrefs{},
+	})
+	exec.SetCapabilities(&mockCapabilities{})
+	// Avoid side-effect callbacks changing the state under test.
+	exec.SetOnAgentStartFailed(func(context.Context, string, string, string, error, bool) bool {
+		return true
+	})
+	return exec, logs
+}
+
+func TestHandleAgentProcessStartFailure_LogsWarnForTeardown(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{"context canceled", context.Canceled},
+		{"terminal session", lifecycle.ErrSessionTerminal},
+		{"wrapped terminal", errors.Join(errors.New("start failed"), lifecycle.ErrSessionTerminal)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exec, logs := newObservedExecutor(t, zapcore.WarnLevel)
+			exec.handleAgentProcessStartFailure(
+				context.Background(),
+				"task-123", "session-123", "exec-456",
+				tt.err, true, false,
+			)
+			warns := logs.FilterMessage("agent process start aborted by session teardown").All()
+			if len(warns) != 1 {
+				t.Fatalf("warn entries = %d, want 1; all=%v", len(warns), logs.All())
+			}
+			if errs := logs.FilterLevelExact(zapcore.ErrorLevel).Len(); errs != 0 {
+				t.Fatalf("error entries = %d, want 0", errs)
+			}
+		})
+	}
+}
+
+func TestHandleAgentProcessStartFailure_LogsErrorForStartupDeadline(t *testing.T) {
+	exec, logs := newObservedExecutor(t, zapcore.WarnLevel)
+	exec.handleAgentProcessStartFailure(
+		context.Background(),
+		"task-123", "session-123", "exec-456",
+		context.DeadlineExceeded, true, false,
+	)
+	errs := logs.FilterMessage("failed to start agent process").All()
+	if len(errs) != 1 {
+		t.Fatalf("error entries = %d, want 1; all=%v", len(errs), logs.All())
+	}
+	if got := errs[0].Level; got != zapcore.ErrorLevel {
+		t.Fatalf("level = %v, want error", got)
+	}
+	if warns := logs.FilterMessage("agent process start aborted by session teardown").Len(); warns != 0 {
+		t.Fatalf("warn teardown entries = %d, want 0", warns)
+	}
+}

--- a/apps/web/e2e/pages/session-page.ts
+++ b/apps/web/e2e/pages/session-page.ts
@@ -931,10 +931,22 @@ export class SessionPage {
   async expandChangesSection(testId: string): Promise<void> {
     const toggle = this.changes.getByTestId(`${testId}-collapse-toggle`);
     await expect(toggle).toBeVisible({ timeout: 15_000 });
-    if ((await toggle.getAttribute("aria-expanded")) === "false") {
-      await toggle.click();
-      await expect(toggle).toHaveAttribute("aria-expanded", "true");
-    }
+    // TimelineSection re-syncs collapsed state from defaultCollapsed until the
+    // user has toggled. A late git-data update can therefore re-collapse right
+    // after the first click (and can also remount the section). Retry until the
+    // expanded attribute sticks instead of asserting once.
+    await expect
+      .poll(
+        async () => {
+          if ((await toggle.getAttribute("aria-expanded")) === "true") {
+            return true;
+          }
+          await toggle.click();
+          return (await toggle.getAttribute("aria-expanded")) === "true";
+        },
+        { timeout: 15_000 },
+      )
+      .toBe(true);
   }
 
   /** Expand the commits section (collapsed by default in the changes panel). */

--- a/apps/web/e2e/tests/task/mobile-changes-panel.spec.ts
+++ b/apps/web/e2e/tests/task/mobile-changes-panel.spec.ts
@@ -12,10 +12,20 @@ async function openMobileChangesPanel(testPage: Page) {
 async function expandSection(testPage: Page, sectionTestId: string) {
   const toggle = testPage.getByTestId(`${sectionTestId}-collapse-toggle`);
   await expect(toggle).toBeVisible({ timeout: 10_000 });
-  if ((await toggle.getAttribute("aria-expanded")) === "false") {
-    await toggle.tap();
-    await expect(toggle).toHaveAttribute("aria-expanded", "true");
-  }
+  // Mirror session-page expandChangesSection: late defaultCollapsed resyncs
+  // can re-collapse after the first tap, so retry until expanded sticks.
+  await expect
+    .poll(
+      async () => {
+        if ((await toggle.getAttribute("aria-expanded")) === "true") {
+          return true;
+        }
+        await toggle.tap();
+        return (await toggle.getAttribute("aria-expanded")) === "true";
+      },
+      { timeout: 15_000 },
+    )
+    .toBe(true);
 }
 
 async function expectDiffText(testPage: Page, text: string, timeout = 45_000) {

--- a/apps/web/hooks/domains/session/use-cumulative-diff.test.ts
+++ b/apps/web/hooks/domains/session/use-cumulative-diff.test.ts
@@ -188,5 +188,10 @@ describe("useCumulativeDiff terminal session", () => {
 
     expect(mockRequest).toHaveBeenCalledTimes(2);
     expect(result.current.diff).toEqual(cached);
+
+    // A later subscriber (e.g. another panel mount) must also see the restored
+    // shared cache — not null from the post-invalidation miss.
+    const second = renderHook(() => useCumulativeDiff(sid));
+    expect(second.result.current.diff).toEqual(cached);
   });
 });

--- a/apps/web/hooks/domains/session/use-cumulative-diff.test.ts
+++ b/apps/web/hooks/domains/session/use-cumulative-diff.test.ts
@@ -146,3 +146,47 @@ describe("useCumulativeDiff invalidation coalescing", () => {
     expect(mockRequest).toHaveBeenCalledTimes(2);
   });
 });
+
+describe("useCumulativeDiff terminal session", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    setStore();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it("preserves a cached diff when the backend reports session_terminal", async () => {
+    const sid = "sess-terminal";
+    const cached = {
+      session_id: sid,
+      files: { "a.ts": { status: "modified", additions: 1, deletions: 0 } },
+    };
+    mockRequest.mockResolvedValueOnce({ cumulative_diff: cached }).mockResolvedValueOnce({
+      cumulative_diff: null,
+      ready: false,
+      reason: "session_terminal",
+    });
+
+    const { result } = renderHook(() => useCumulativeDiff(sid));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(result.current.diff).toEqual(cached);
+
+    // Invalidate so the hook refetches; the terminal envelope must not wipe
+    // the previously visible snapshot.
+    act(() => {
+      invalidateCumulativeDiffCache(sid);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(WINDOW);
+    });
+
+    expect(mockRequest).toHaveBeenCalledTimes(2);
+    expect(result.current.diff).toEqual(cached);
+  });
+});

--- a/apps/web/hooks/domains/session/use-cumulative-diff.ts
+++ b/apps/web/hooks/domains/session/use-cumulative-diff.ts
@@ -7,6 +7,9 @@ import type { CumulativeDiff } from "@/lib/state/slices/session-runtime/types";
 const debug = createDebugLogger("review:cumulative");
 
 const cumulativeDiffCache: Record<string, CumulativeDiff | null> = {};
+// Survives invalidateCumulativeDiffCache. Used to restore the shared cache
+// when a terminal-session response means we cannot recompute a fresh diff.
+const lastKnownDiffByEnvKey: Record<string, CumulativeDiff | null> = {};
 const loadingState: Record<string, boolean> = {};
 // Invalidations that arrived while a fetch was in flight. The in-flight
 // request can't be guaranteed to capture the working-tree state it was
@@ -75,6 +78,7 @@ function commitFetchedDiff(
   setDiff: (d: CumulativeDiff | null) => void,
 ) {
   cumulativeDiffCache[envKey] = diff;
+  lastKnownDiffByEnvKey[envKey] = diff;
   setDiff(diff);
   if (isDebug()) {
     debug("fetch.success", {
@@ -97,20 +101,23 @@ type CumulativeDiffResponse = {
 };
 
 // applyCumulativeDiffResponse commits a successful fetch unless the backend
-// reports a permanent terminal-session envelope. Returns true when the
-// response was applied (or intentionally skipped as terminal); false when the
-// caller should treat the response as stale/abandoned.
+// reports a permanent terminal-session envelope. On terminal, restore the
+// last known snapshot into the shared cache so later mounts still see it
+// after invalidateCumulativeDiffCache cleared the live entry.
 function applyCumulativeDiffResponse(
   envKey: string,
   sessionId: string,
   response: CumulativeDiffResponse | null | undefined,
   setDiff: (d: CumulativeDiff | null) => void,
 ): void {
-  // Terminal sessions no longer have an execution. A ready:false envelope
-  // with reason session_terminal is not an authoritative empty diff — keep
-  // any previously cached snapshot instead of clearing the panel.
   if (response?.ready === false && response.reason === "session_terminal") {
-    debug("fetch.terminal", { sessionId, envKey });
+    const known = lastKnownDiffByEnvKey[envKey] ?? null;
+    debug("fetch.terminal", { sessionId, envKey, restored: known != null });
+    // Restore into the live cache + notify subscribers without treating the
+    // terminal envelope as a fresh authoritative empty diff.
+    cumulativeDiffCache[envKey] = known;
+    setDiff(known);
+    listeners.forEach((fn) => fn({ envKey, kind: "populated" }));
     return;
   }
   commitFetchedDiff(envKey, sessionId, response?.cumulative_diff ?? null, setDiff);

--- a/apps/web/hooks/domains/session/use-cumulative-diff.ts
+++ b/apps/web/hooks/domains/session/use-cumulative-diff.ts
@@ -90,6 +90,32 @@ function commitFetchedDiff(
   listeners.forEach((fn) => fn({ envKey, kind: "populated" }));
 }
 
+type CumulativeDiffResponse = {
+  cumulative_diff?: CumulativeDiff | null;
+  ready?: boolean;
+  reason?: string;
+};
+
+// applyCumulativeDiffResponse commits a successful fetch unless the backend
+// reports a permanent terminal-session envelope. Returns true when the
+// response was applied (or intentionally skipped as terminal); false when the
+// caller should treat the response as stale/abandoned.
+function applyCumulativeDiffResponse(
+  envKey: string,
+  sessionId: string,
+  response: CumulativeDiffResponse | null | undefined,
+  setDiff: (d: CumulativeDiff | null) => void,
+): void {
+  // Terminal sessions no longer have an execution. A ready:false envelope
+  // with reason session_terminal is not an authoritative empty diff — keep
+  // any previously cached snapshot instead of clearing the panel.
+  if (response?.ready === false && response.reason === "session_terminal") {
+    debug("fetch.terminal", { sessionId, envKey });
+    return;
+  }
+  commitFetchedDiff(envKey, sessionId, response?.cumulative_diff ?? null, setDiff);
+}
+
 export function useCumulativeDiff(sessionId: string | null) {
   // Resolve to environment key so sessions sharing the same environment share the cache.
   const envKey = useAppStore((state) => {
@@ -131,15 +157,14 @@ export function useCumulativeDiff(sessionId: string | null) {
 
     try {
       // Backend routes by session_id, but we cache by envKey
-      const response = await client.request<{ cumulative_diff?: CumulativeDiff }>(
-        "session.cumulative_diff",
-        { session_id: sessionId },
-      );
+      const response = await client.request<CumulativeDiffResponse>("session.cumulative_diff", {
+        session_id: sessionId,
+      });
 
       // Discard if the environment changed while the request was in flight
       if (version !== requestVersionRef.current) return;
 
-      commitFetchedDiff(envKey, sessionId, response?.cumulative_diff ?? null, setDiff);
+      applyCumulativeDiffResponse(envKey, sessionId, response, setDiff);
     } catch (err) {
       if (version !== requestVersionRef.current) return;
       console.error("Failed to fetch cumulative diff:", err);

--- a/apps/web/hooks/domains/session/use-session-commits.test.ts
+++ b/apps/web/hooks/domains/session/use-session-commits.test.ts
@@ -142,6 +142,34 @@ describe("useSessionCommits", () => {
     expect(mockRequest).toHaveBeenCalledTimes(1);
   });
 
+  it("does not retry or clear commits when the session is terminal", async () => {
+    // A cancelled/completed/failed session returns ready:false with
+    // reason session_terminal forever. Retrying would poll every 2s with
+    // loading stuck true; overwriting with [] would wipe a previously
+    // visible snapshot.
+    storeState.sessionCommits = {
+      byEnvironmentId: {
+        "sess-1": [{ commit_sha: "kept", insertions: 1, deletions: 0 }],
+      },
+      loading: {},
+      refetchTrigger: {},
+    };
+    mockRequest.mockResolvedValue({
+      commits: [],
+      ready: false,
+      reason: "session_terminal",
+    });
+
+    renderHook(() => useSessionCommits("sess-1"));
+
+    await waitFor(() => expect(mockRequest).toHaveBeenCalledTimes(1));
+    expect(mockSetSessionCommits).not.toHaveBeenCalled();
+
+    await new Promise((resolve) => setTimeout(resolve, 2500));
+    expect(mockRequest).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(mockSetSessionCommitsLoading).toHaveBeenCalledWith("sess-1", false));
+  });
+
   it("does not fetch when disconnected", () => {
     setStore("disconnected");
     renderHook(() => useSessionCommits("sess-1"));

--- a/apps/web/hooks/domains/session/use-session-commits.ts
+++ b/apps/web/hooks/domains/session/use-session-commits.ts
@@ -89,10 +89,11 @@ export function useSessionCommits(sessionId: string | null) {
       const version = ++requestVersionRef.current;
       setSessionCommitsLoading(sessionId, true);
       try {
-        const response = await client.request<{ commits?: SessionCommit[]; ready?: boolean }>(
-          "session.git.commits",
-          { session_id: sessionId },
-        );
+        const response = await client.request<{
+          commits?: SessionCommit[];
+          ready?: boolean;
+          reason?: string;
+        }>("session.git.commits", { session_id: sessionId });
 
         // Drop stale callbacks: another fetch (e.g. a later trigger bump)
         // already started, so this response is for an older state and must
@@ -109,7 +110,13 @@ export function useSessionCommits(sessionId: string | null) {
         // Schedule a retry so we eventually pick up the real list. Preserve
         // `opts` across retries so a trigger-bump fetch that gets ready:false
         // still applies its authoritative empty response when it succeeds.
+        //
+        // reason:"session_terminal" is permanent (cancelled/completed/failed):
+        // never retry and keep any previously loaded snapshot.
         if (response?.ready === false) {
+          if (response.reason === "session_terminal") {
+            return;
+          }
           retryTimerRef.current = setTimeout(() => {
             retryTimerRef.current = null;
             fetchCommits(opts);


### PR DESCRIPTION
Polling git commits/diffs on a CANCELLED/COMPLETED/FAILED session was logging
full ERROR stacktraces, and context-canceled session resume paths were
cascading the same noise. Terminal sessions now return a graceful ready:false
envelope, and expected teardown races log at WARN without changing control flow.

## Validation

- `go build ./internal/agent/handlers/... ./internal/agent/runtime/lifecycle/... ./internal/orchestrator/executor/...`
- `go test ./internal/agent/handlers/... -run "GitCommits|CumulativeDiff|TerminalSession" -count=1`
- `go test ./internal/agent/runtime/lifecycle/... -run "EnsureLaunchSessionStillActive" -count=1`
- `go test ./internal/agent/handlers/... ./internal/orchestrator/executor/... -count=1`
- `go test ./internal/agent/runtime/lifecycle/... -count=1`
- `golangci-lint run ./internal/agent/handlers/... ./internal/agent/runtime/lifecycle/... ./internal/orchestrator/executor/... --new-from-rev=<base> --timeout=5m` (0 issues)
- pre-commit hooks on commit (gofmt, Go lint changed code, harness lint)

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2258?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->