### PR TITLE
fix: restore stable release publication

### DIFF
--- a/.github/scripts/release-workflow-contract_test.py
+++ b/.github/scripts/release-workflow-contract_test.py
@@ -158,6 +158,41 @@ class ReleaseWorkflowContractTest(unittest.TestCase):
             self.assertIn("inputs.channel == 'stable'", block)
             self.assertNotIn("github.event_name == 'schedule'", block)
 
+    def test_stable_jobs_continue_past_skipped_nightly_branch_only_after_successful_needs(
+        self,
+    ) -> None:
+        direct_dependencies = {
+            "build-desktop": ("prepare", "build-bundles"),
+            "docker-amd64": ("prepare", "build-bundles"),
+            "docker-arm64": ("prepare", "build-bundles"),
+            "docker-manifest": ("prepare", "docker-amd64", "docker-arm64"),
+            "docker-universal-amd64": ("prepare", "docker-manifest"),
+            "docker-universal-arm64": ("prepare", "docker-manifest"),
+            "docker-universal-manifest": (
+                "prepare",
+                "docker-universal-amd64",
+                "docker-universal-arm64",
+            ),
+            "publish-release": (
+                "prepare",
+                "build-bundles",
+                "build-desktop",
+                "docker-universal-manifest",
+            ),
+            "publish-npm": ("prepare", "publish-release"),
+            "update-homebrew-tap": ("prepare", "publish-release"),
+        }
+
+        for name, dependencies in direct_dependencies.items():
+            with self.subTest(job=name):
+                condition = job_condition(name)
+                self.assertIn("!cancelled()", condition)
+                for dependency in dependencies:
+                    self.assertIn(
+                        f"needs.{dependency}.result == 'success'",
+                        condition,
+                    )
+
     def test_nightly_publish_uses_exact_sha_local_assets_and_release_serialization(self) -> None:
         stable = job_block("publish-npm")
         nightly = job_block("publish-npm-nightly")

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -823,7 +823,14 @@ jobs:
   build-desktop:
     name: Build desktop app (${{ matrix.platform }})
     needs: [prepare, build-bundles]
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.channel == 'stable' && !inputs.dry_run }}
+    if: >-
+      ${{ !cancelled() &&
+        github.event_name == 'workflow_dispatch' &&
+        inputs.channel == 'stable' &&
+        !inputs.dry_run &&
+        needs.prepare.result == 'success' &&
+        needs.build-bundles.result == 'success'
+      }}
     strategy:
       matrix:
         include:
@@ -1369,7 +1376,15 @@ jobs:
   docker-amd64:
     name: Build & push container image (amd64)
     needs: [prepare, build-bundles]
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.channel == 'stable' && !inputs.dry_run && !inputs.desktop_validation_only }}
+    if: >-
+      ${{ !cancelled() &&
+        github.event_name == 'workflow_dispatch' &&
+        inputs.channel == 'stable' &&
+        !inputs.dry_run &&
+        !inputs.desktop_validation_only &&
+        needs.prepare.result == 'success' &&
+        needs.build-bundles.result == 'success'
+      }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1440,7 +1455,15 @@ jobs:
   docker-arm64:
     name: Build & push container image (arm64)
     needs: [prepare, build-bundles]
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.channel == 'stable' && !inputs.dry_run && !inputs.desktop_validation_only }}
+    if: >-
+      ${{ !cancelled() &&
+        github.event_name == 'workflow_dispatch' &&
+        inputs.channel == 'stable' &&
+        !inputs.dry_run &&
+        !inputs.desktop_validation_only &&
+        needs.prepare.result == 'success' &&
+        needs.build-bundles.result == 'success'
+      }}
     runs-on: ubuntu-24.04-arm
     permissions:
       contents: read
@@ -1499,7 +1522,16 @@ jobs:
   docker-manifest:
     name: Assemble multi-arch base manifest
     needs: [prepare, docker-amd64, docker-arm64]
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.channel == 'stable' && !inputs.dry_run && !inputs.desktop_validation_only }}
+    if: >-
+      ${{ !cancelled() &&
+        github.event_name == 'workflow_dispatch' &&
+        inputs.channel == 'stable' &&
+        !inputs.dry_run &&
+        !inputs.desktop_validation_only &&
+        needs.prepare.result == 'success' &&
+        needs.docker-amd64.result == 'success' &&
+        needs.docker-arm64.result == 'success'
+      }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1553,7 +1585,15 @@ jobs:
   docker-universal-amd64:
     name: Build & push universal image (amd64)
     needs: [prepare, docker-manifest]
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.channel == 'stable' && !inputs.dry_run && !inputs.desktop_validation_only }}
+    if: >-
+      ${{ !cancelled() &&
+        github.event_name == 'workflow_dispatch' &&
+        inputs.channel == 'stable' &&
+        !inputs.dry_run &&
+        !inputs.desktop_validation_only &&
+        needs.prepare.result == 'success' &&
+        needs.docker-manifest.result == 'success'
+      }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1605,7 +1645,15 @@ jobs:
   docker-universal-arm64:
     name: Build & push universal image (arm64)
     needs: [prepare, docker-manifest]
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.channel == 'stable' && !inputs.dry_run && !inputs.desktop_validation_only }}
+    if: >-
+      ${{ !cancelled() &&
+        github.event_name == 'workflow_dispatch' &&
+        inputs.channel == 'stable' &&
+        !inputs.dry_run &&
+        !inputs.desktop_validation_only &&
+        needs.prepare.result == 'success' &&
+        needs.docker-manifest.result == 'success'
+      }}
     runs-on: ubuntu-24.04-arm
     permissions:
       contents: read
@@ -1656,7 +1704,16 @@ jobs:
     # docker-universal-manifest is included in publish-release's `needs` so
     # its size gate (and any per-arch build failure) blocks the release.
     needs: [prepare, docker-universal-amd64, docker-universal-arm64]
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.channel == 'stable' && !inputs.dry_run && !inputs.desktop_validation_only }}
+    if: >-
+      ${{ !cancelled() &&
+        github.event_name == 'workflow_dispatch' &&
+        inputs.channel == 'stable' &&
+        !inputs.dry_run &&
+        !inputs.desktop_validation_only &&
+        needs.prepare.result == 'success' &&
+        needs.docker-universal-amd64.result == 'success' &&
+        needs.docker-universal-arm64.result == 'success'
+      }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1713,7 +1770,17 @@ jobs:
   publish-release:
     name: Publish GitHub release
     needs: [prepare, build-bundles, build-desktop, docker-universal-manifest]
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.channel == 'stable' && !inputs.dry_run && !inputs.desktop_validation_only }}
+    if: >-
+      ${{ !cancelled() &&
+        github.event_name == 'workflow_dispatch' &&
+        inputs.channel == 'stable' &&
+        !inputs.dry_run &&
+        !inputs.desktop_validation_only &&
+        needs.prepare.result == 'success' &&
+        needs.build-bundles.result == 'success' &&
+        needs.build-desktop.result == 'success' &&
+        needs.docker-universal-manifest.result == 'success'
+      }}
     runs-on: ubuntu-latest
     permissions:
       contents: write    # softprops/action-gh-release creates the release
@@ -1863,7 +1930,15 @@ jobs:
   publish-npm:
     name: Publish npm packages
     needs: [prepare, publish-release]
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.channel == 'stable' && !inputs.dry_run && !inputs.desktop_validation_only }}
+    if: >-
+      ${{ !cancelled() &&
+        github.event_name == 'workflow_dispatch' &&
+        inputs.channel == 'stable' &&
+        !inputs.dry_run &&
+        !inputs.desktop_validation_only &&
+        needs.prepare.result == 'success' &&
+        needs.publish-release.result == 'success'
+      }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write    # Required for OIDC trusted publishing
@@ -1953,7 +2028,15 @@ jobs:
   update-homebrew-tap:
     name: Update Homebrew tap
     needs: [prepare, publish-release]
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.channel == 'stable' && !inputs.dry_run && !inputs.desktop_validation_only }}
+    if: >-
+      ${{ !cancelled() &&
+        github.event_name == 'workflow_dispatch' &&
+        inputs.channel == 'stable' &&
+        !inputs.dry_run &&
+        !inputs.desktop_validation_only &&
+        needs.prepare.result == 'success' &&
+        needs.publish-release.result == 'success'
+      }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6


### PR DESCRIPTION
Stable releases were terminating after runtime bundle builds because the intentionally skipped Nightly preparation propagated through downstream jobs. The workflow now allows the stable publication chain to continue while requiring every direct prerequisite to succeed, and adds a regression contract test.

## Validation

- `python3 .github/scripts/release-workflow-contract_test.py` (23 passed)
- `node --test scripts/release/nightly-version.test.mjs scripts/release/nightly-release.test.mjs` (21 passed)
- `bash -n scripts/release/nightly-release.sh scripts/release/publish-npm.sh`
- `git diff --check`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2260?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- kandev-preview-start -->
### Preview Environment

| | |
|---|---|
| **URL** | https://kandev-pr-2260-bwo7.sprites.app |
| **Commit** | `06b35cd` |
| **Agent** | Mock agent |

> Updates automatically on each push. Destroyed when the PR is closed.
<!-- kandev-preview-end -->