### PR TITLE
docs: add Scoop as a Windows install channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,16 @@ brew install kdlbs/kandev/kandev
 kandev
 ```
 
+### Scoop (Windows)
+
+```bash
+scoop bucket add kandev https://github.com/kdlbs/scoop-kandev
+scoop install kandev
+kandev
+```
+
+Installs the native bundle — no Node.js required.
+
 ### NPX
 
 ```bash
@@ -145,6 +155,7 @@ kandev
 ### Updates
 
 - `brew upgrade kandev`
+- `scoop update kandev`
 - `npx kandev@latest` (always uses the latest published version)
 - `npm install -g kandev@latest`
 
@@ -160,8 +171,8 @@ npm install -g kandev@nightly
 installed Kandev until you reinstall `kandev@latest`.
 
 Nightlies are best-effort builds scheduled for 12:00 UTC when `main` has changed since the latest
-stable release. They do not move `latest`, and no Homebrew or Desktop nightly channel is published.
-A verified Kandev-managed npm/npx user service can switch between Stable and Nightly in
+stable release. They do not move `latest`, and no Homebrew, Scoop, or Desktop nightly channel is
+published. A verified Kandev-managed npm/npx user service can switch between Stable and Nightly in
 **Settings > System > Updates**. Other install types expose only Stable in that page; npm/npx users
 can still invoke `@nightly` directly with the commands above.
 

--- a/docs/public/cli.md
+++ b/docs/public/cli.md
@@ -20,7 +20,7 @@ The `kandev` command starts a local Kandev backend, which serves the web UI, HTT
 |---|---|---|
 | macOS | Apple silicon (`arm64`), Intel (`x64`) | Homebrew, npm/npx |
 | Linux | `arm64`, `x64` | Homebrew, npm/npx |
-| Windows | `x64` | npm/npx |
+| Windows | `x64` | Scoop, npm/npx |
 
 The npm package is a small Node.js shim. It selects an exact, same-version native runtime package for `process.platform` and `process.arch`, then starts its `kandev` binary. npm 7 or later is required because the native packages are platform-specific optional dependencies. There is no native Windows ARM64 npm package; running the x64 package under Windows emulation is OS-dependent and is not a tested release target.
 
@@ -36,6 +36,20 @@ Homebrew is available on macOS and Linux:
 brew install kdlbs/kandev/kandev
 kandev --version
 ```
+
+### Scoop
+
+Scoop is available on Windows:
+
+```bash
+scoop bucket add kandev https://github.com/kdlbs/scoop-kandev
+scoop install kandev
+kandev --version
+```
+
+The bucket installs the native runtime bundle, so Node.js is not required to
+install or start Kandev. Node.js is still needed for the agent CLIs Kandev
+installs through its own interface.
 
 ### npm or npx
 
@@ -231,6 +245,7 @@ The installer owns CLI updates. Update persistent Stable installs with:
 
 ```bash
 brew upgrade kandev
+scoop update kandev
 npm install -g kandev@latest
 ```
 

--- a/docs/public/operations.md
+++ b/docs/public/operations.md
@@ -341,7 +341,7 @@ Before any update, finish or stop active sessions, create and export a database 
   `brew upgrade kandev`, reinstall the service with the same flags, and restart.
 - System service: Stable only. Upgrade with the required privileges, reinstall with the same
   service flags, and restart; the UI never applies it.
-- Unmanaged CLI: run `brew upgrade kandev` or `npm install -g kandev@latest`, then restart the process.
+- Unmanaged CLI: run `brew upgrade kandev`, `scoop update kandev`, or `npm install -g kandev@latest`, then restart the process.
 - Transient npx: start the desired release with `npx -y kandev@latest`; this does not update a persistent package.
 - Docker/Kubernetes: replace the image and recreate the workload. Do not treat an in-container package install as a durable update.
 

--- a/docs/public/operations.md
+++ b/docs/public/operations.md
@@ -320,7 +320,7 @@ rate-limited, or registry-failing installations continue to show that channel's 
 
 Nightlies are best-effort daily snapshots. A new version appears only when `main` contains commits
 after the latest Stable release and that exact commit has not already been published. Nightlies do
-not move npm `latest` and do not create Homebrew, Desktop, GHCR, Git tag, or GitHub Release
+not move npm `latest` and do not create Homebrew, Scoop, Desktop, GHCR, Git tag, or GitHub Release
 artifacts.
 
 Configure update alerts in **Settings > General > Notifications > Notification Events**. Select **Kandev update available** for each notification provider that should receive it: Local delivers the in-app update indication and can use an already-granted browser or native desktop notification; System and Apprise use their configured provider transports. Notification routing is independent of the Stable/Nightly release selector. New Local and System providers include this event by default; existing Local and System providers receive it once on upgrade, while existing Apprise providers remain unchanged. Disabling the event for a provider stops that provider's delivery without disabling release checks. Each provider receives a release version at most once; a later version is a new occurrence. Returning from Nightly to a Stable version is an explicit action and does not produce a normal upgrade notification.

--- a/docs/public/use-kandev.md
+++ b/docs/public/use-kandev.md
@@ -67,8 +67,8 @@ The global command replaces the installed `kandev` channel. Return to Stable wit
 `npm install -g kandev@latest`.
 
 Nightly builds may be unstable. They are best-effort daily snapshots, and a new version appears
-only when `main` has commits after the latest Stable release. Homebrew, Desktop, and container
-installs have no Nightly channel.
+only when `main` has commits after the latest Stable release. Homebrew, Scoop, Desktop, and
+container installs have no Nightly channel.
 
 The launcher selects the platform runtime, starts the Go backend and agent runtime, serves the web app, and opens its local URL. The preferred backend port is `38429`; if it is unavailable, the launcher chooses another free port and prints the actual URL. Use `kandev --headless` (or `KANDEV_NO_BROWSER=1`) when a browser must not open.
 

--- a/docs/public/use-kandev.md
+++ b/docs/public/use-kandev.md
@@ -45,6 +45,9 @@ npm install -g kandev@latest
 kandev
 ```
 
+Scoop installs the native runtime bundle, so Node.js is not required to install or start Kandev. It
+is still needed for the agent CLIs Kandev installs through its own interface.
+
 Stable is the default and is selected by npm's `latest` tag. To test the current prerelease from
 `main` without changing a global installation, launch the package once from the npm-only `nightly`
 tag:

--- a/docs/public/use-kandev.md
+++ b/docs/public/use-kandev.md
@@ -32,6 +32,11 @@ Choose one release channel:
 brew install kdlbs/kandev/kandev
 kandev
 
+# Scoop on Windows
+scoop bucket add kandev https://github.com/kdlbs/scoop-kandev
+scoop install kandev
+kandev
+
 # One-off npm launch
 npx kandev@latest
 


### PR DESCRIPTION
Adds Scoop to the install channels now that the bucket is published at [kdlbs/scoop-kandev](https://github.com/kdlbs/scoop-kandev) (kdlbs/scoop-kandev#1, merged).

```
scoop bucket add kandev https://github.com/kdlbs/scoop-kandev
scoop install kandev
```

Scoop installs the native bundle straight from the release asset, so unlike the npm channel it needs no Node.js to install or launch. Node is still required for the agent CLIs that kandev installs through its own UI.

## Changes

- `README.md` — new **Scoop (Windows)** section under Quick Start, `scoop update kandev` in the Updates list, and Scoop added to the list of channels with no nightly
- `docs/public/use-kandev.md` — Scoop added to the release-channel block

Docs only. `scripts/validate-public-docs.mjs` passes.

Relates to #2252.



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->