### PR TITLE
fix(i18n): restore zh-cn parity for the chat attachment keys

### DIFF
--- a/apps/web/src/locales/zh-cn/chat.json
+++ b/apps/web/src/locales/zh-cn/chat.json
@@ -36,5 +36,18 @@
   "providerQuotaResetUnknown": "请在提供商恢复可用容量后重试。",
   "providerQuotaProviderFallback": "提供商",
   "turnGroupToolCalls_one": "{{count}} 次工具调用",
-  "turnGroupToolCalls_other": "{{count}} 次工具调用"
+  "turnGroupToolCalls_other": "{{count}} 次工具调用",
+  "attachmentUploadPending": "正在上传附件…",
+  "attachmentUploadPendingSubmit": "请等待附件上传完成后再发送。",
+  "attachmentUploadFailed": "附件上传失败",
+  "retryAttachmentUpload": "重试上传附件",
+  "attachmentPreviewAlt": "预览",
+  "attachmentMessageAlt": "附件 {{index}}",
+  "attachmentFallbackName": "附件",
+  "attachmentPreviewFullAlt": "全尺寸预览",
+  "attachmentDeliveryMode": "附件传递方式",
+  "attachmentDeliveryPrompt": "提示词",
+  "attachmentDeliveryFile": "文件",
+  "attachmentDeliveryPromptDescription": "作为提示词上下文发送，供智能体识别图像内容。智能体不会获得文件路径。",
+  "attachmentDeliveryPathDescription": "上传到工作区，使智能体可以读取或编辑该文件。"
 }


### PR DESCRIPTION
## Problem

`pnpm run i18n:check` is failing on `main`. `en/chat.json` carries thirteen
attachment keys that `zh-cn/chat.json` never received, and the parity check
treats a missing real-locale key as an error:

```
✖ 13 real-locale catalog parity issue(s):
  zh-cn / chat: missing key: attachmentUploadPending
  zh-cn / chat: missing key: attachmentUploadPendingSubmit
  zh-cn / chat: missing key: attachmentUploadFailed
  ...
```

This is the "Run i18n checks" step of **Run Frontend Lint, Tests, and Build**,
so it fails on `main` itself ([run 30951568390](https://github.com/kdlbs/kandev/actions/runs/30951568390))
and on every open PR that carries `main`'s catalogs — #2241, #2262, #2267 and
#2268 all fail at the same step for this reason and no other.

## Change

Translate the thirteen keys. Locale data only — no UI source is added or
modified, so the new-code ratchet has nothing to judge.

## Verification

```
✓ i18n keys OK — 2803 key(s) referenced, 3313 en entr(ies), 4 orphan(s), pseudo and zh-cn in sync.
✓ <Trans> indices OK — 53 element(s) checked.
✓ no inline English plurals — count-bearing messages use _one/_other.
✓ no module-scope t() — all copy resolves at render.
✓ i18n new-code ratchet — no UI source added or modified
✓ guard allowlist intact — 248 entr(ies)
```

The four remaining orphan warnings (`turnGroupToolCalls_*`, `activeSubagents_*`)
are pre-existing plural variants the reference scanner does not match; they are
warnings, not failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2271?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

