### PR TITLE
fix(e2e): give the plan-mode projection assertion the same timeout as its siblings

### DIFF
--- a/apps/web/e2e/tests/workflow/workflow-automation.spec.ts
+++ b/apps/web/e2e/tests/workflow/workflow-automation.spec.ts
@@ -226,8 +226,13 @@ test.describe("Workflow automation", () => {
     await expect(session.planModeInput()).toBeVisible({ timeout: 15_000 });
 
     // The active kanban projection must win over any stale all-workflow
-    // snapshot that was already in flight when the turn completed.
-    await expect(session.taskInSection("Plan Mode Workflow Task", "Turn Finished")).toBeVisible();
+    // snapshot that was already in flight when the turn completed. That
+    // reconciliation is exactly what this waits on, so it needs the same
+    // explicit budget as the assertions above — on the default expect timeout
+    // it loses the race under a loaded 14-shard run while passing locally.
+    await expect(session.taskInSection("Plan Mode Workflow Task", "Turn Finished")).toBeVisible({
+      timeout: 15_000,
+    });
   });
 
   /**


### PR DESCRIPTION
## What

`workflow-automation.spec.ts:230` is the only `toBeVisible()` in that file without an explicit timeout. The other three all carry `{ timeout: 15_000 }`. This gives it the same budget.

## Why

It is the last assertion in `"enable_plan_mode event activates plan mode UI in session"`, and it waits on the kanban projection reconciling against a stale all-workflow snapshot — the race its own comment describes:

```
// The active kanban projection must win over any stale all-workflow
// snapshot that was already in flight when the turn completed.
```

On the default expect timeout that is a zero-margin wait: green locally, lost under a loaded 14-shard run.

**It is failing on `main`, not just on branches.** `E2E Shard 10/14` = `failure` on `c3fd434a2`, with shard 10 clean on the three commits before it. Every PR branched after `c3fd434a2` inherits it.

Worth recording because it is not obvious: `failOnFlakyTests: CI` is set in `e2e/playwright.config.ts` with `retries: 2`, so a test that recovers on retry **still exits 1**. A job reporting `1 flaky · 123 passed` is red, and re-running is otherwise the only remedy.

## The wider pattern this sits in

This assertion is the one clear-cut case, but it is not an isolated flake. Measured across three CI attempts on #2272 — a docs-and-scripts diff with no path into a Playwright run:

| attempt | shard | test | signature | shard duration |
|---|---|---|---|---|
| 1 | 10/14 | `workflow-automation.spec.ts:230` | `element(s) not found` | 5.9m |
| 1 | 5/14 | `newSessionDialog().not.toBeVisible({10s})` :134 | `Received: visible` | 13.2m |
| 2 | 4/14 | `expect.poll(...).toBe(2)` :88 "waiting for second session" | `Expected: 2, Received: 1` | 11.4m |

Three attempts, three **different** shards, three different tests, every one reported `1 flaky` — i.e. passed on retry — and every one green on re-run. A real regression picks the same test; this picks a different one each time.

**The tell is the durations.** 11–13 minutes against 5.9m for a same-sized shard: the slow runs are the ones that flake. That points at contention on the runner rather than at any of the three tests.

**Why it costs more than it looks:** with 14 shards in parallel and `failOnFlakyTests: CI`, a PR needs *all fourteen* to avoid a load flake. At ~5% per shard that is roughly even odds any given PR needs a re-run — a tax on every merge, which matches what we saw all day.

Only shard 10's assertion is fixed here, deliberately. Shard 5's already carries `{ timeout: 10_000 }` and shard 4's already polls with `{ timeout: 60_000 }` — both already have a budget and still lost, so raising either would be guessing at a number without evidence, and a threshold loosened without understanding why is how a real regression gets buried. They are recorded here rather than patched.

## Testing

One-line timeout change to a single E2E assertion. No app code, no test logic, no new assertion — the same expectation, given the same budget its siblings already have.

Verification is the shard itself: shard 10 must go green here and stay green on `main`.

## Checklist

- [x] Change is scoped to the failing assertion
- [x] No app or product code touched
- [x] Reasoning recorded in the code comment, not only in this PR
- [x] Conventional Commit title


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2273?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
