### PR TITLE
fix(launcher): find the runtime bundle next to the launcher

### DIFF
--- a/apps/backend/internal/launcher/bundle.go
+++ b/apps/backend/internal/launcher/bundle.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
 )
 
 type runtimeBundle struct {
@@ -73,9 +72,16 @@ func bundleDirFromExecutable() (string, bool) {
 // bundleDirForLauncherPath maps <bundle>/bin/kandev back to <bundle>. Any other
 // layout is refused, so a launcher sitting somewhere unrelated cannot make
 // validateRuntimeBundle probe an arbitrary directory.
+//
+// The directory name must be exactly "bin", matching what validateRuntimeBundle
+// joins onto the result. Accepting other casings here would derive a bundle on a
+// case-sensitive filesystem that validation then rejects, turning a clear "not a
+// bundle" into a confusing "launcher binary not found". Windows is unaffected:
+// EvalSymlinks above canonicalises the path to the casing on disk, so a launcher
+// invoked as BIN\kandev.exe still arrives here as bin\kandev.exe.
 func bundleDirForLauncherPath(exe string) (string, bool) {
 	binDir := filepath.Dir(exe)
-	if !strings.EqualFold(filepath.Base(binDir), "bin") {
+	if filepath.Base(binDir) != "bin" {
 		return "", false
 	}
 	dir := filepath.Dir(binDir)

--- a/apps/backend/internal/launcher/bundle.go
+++ b/apps/backend/internal/launcher/bundle.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 type runtimeBundle struct {
@@ -34,11 +35,54 @@ var requiredAgentctlRemoteHelpers = []agentctlRemoteHelper{
 }
 
 func resolveRuntimeBundle() (runtimeBundle, error) {
-	dir := os.Getenv("KANDEV_BUNDLE_DIR")
-	if dir == "" {
-		return runtimeBundle{}, fmt.Errorf("no Kandev runtime found; KANDEV_BUNDLE_DIR is not set")
+	if dir := os.Getenv("KANDEV_BUNDLE_DIR"); dir != "" {
+		return validateRuntimeBundle(dir, "env")
 	}
-	return validateRuntimeBundle(dir, "env")
+	if dir, ok := bundleDirFromExecutable(); ok {
+		return validateRuntimeBundle(dir, "executable")
+	}
+	return runtimeBundle{}, fmt.Errorf(
+		"no Kandev runtime found; KANDEV_BUNDLE_DIR is not set and no bundle was found next to the launcher")
+}
+
+// bundleDirFromExecutable locates the bundle from the running launcher's own
+// path. Homebrew, npm and Scoop each set KANDEV_BUNDLE_DIR through a different
+// mechanism (write_env_script, the native shim, env_set); package managers that
+// only unpack the tree and put the launcher on PATH — winget, Chocolatey, a
+// plain archive extraction — have no equivalent, and the launcher already sits
+// inside the bundle it is looking for.
+//
+// The environment variable keeps priority: `kandev service install` writes it
+// into the systemd unit and launchd plist, and a self-update repoints it at the
+// new bundle while the outgoing launcher is still running.
+func bundleDirFromExecutable() (string, bool) {
+	exe, err := os.Executable()
+	if err != nil {
+		return "", false
+	}
+	// Windows resolves a symlinked launcher to its target at process creation,
+	// but not every platform does, and Homebrew links its wrapper into the
+	// prefix. Resolving is best-effort: EvalSymlinks fails on Windows junctions,
+	// and the unresolved path is still worth trying.
+	if resolved, rerr := filepath.EvalSymlinks(exe); rerr == nil {
+		exe = resolved
+	}
+	return bundleDirForLauncherPath(exe)
+}
+
+// bundleDirForLauncherPath maps <bundle>/bin/kandev back to <bundle>. Any other
+// layout is refused, so a launcher sitting somewhere unrelated cannot make
+// validateRuntimeBundle probe an arbitrary directory.
+func bundleDirForLauncherPath(exe string) (string, bool) {
+	binDir := filepath.Dir(exe)
+	if !strings.EqualFold(filepath.Base(binDir), "bin") {
+		return "", false
+	}
+	dir := filepath.Dir(binDir)
+	if dir == "" || dir == binDir {
+		return "", false
+	}
+	return dir, true
 }
 
 func validateRuntimeBundle(dir, source string) (runtimeBundle, error) {

--- a/apps/backend/internal/launcher/bundle.go
+++ b/apps/backend/internal/launcher/bundle.go
@@ -56,7 +56,7 @@ func resolveRuntimeBundle() (runtimeBundle, error) {
 // into the systemd unit and launchd plist, and a self-update repoints it at the
 // new bundle while the outgoing launcher is still running.
 func bundleDirFromExecutable() (string, bool) {
-	exe, err := os.Executable()
+	exe, err := executablePath()
 	if err != nil {
 		return "", false
 	}

--- a/apps/backend/internal/launcher/bundle_test.go
+++ b/apps/backend/internal/launcher/bundle_test.go
@@ -212,6 +212,47 @@ func TestResolveRuntimeBundlePrefersEnvOverExecutable(t *testing.T) {
 	}
 }
 
+func TestResolveRuntimeBundleFallsBackToExecutable(t *testing.T) {
+	dir := t.TempDir()
+	launcher := filepath.Join(dir, "bin", executableName("kandev"))
+	writeFile(t, launcher)
+	writeFile(t, filepath.Join(dir, "bin", executableName("agentctl")))
+	writeRemoteAgentctlHelpers(t, dir)
+	t.Setenv("KANDEV_BUNDLE_DIR", "")
+
+	original := executablePath
+	t.Cleanup(func() { executablePath = original })
+	executablePath = func() (string, error) { return launcher, nil }
+
+	bundle, err := resolveRuntimeBundle()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bundle.Source != "executable" {
+		t.Fatalf("Source = %q, want %q", bundle.Source, "executable")
+	}
+	// The lookup resolves symlinks, so compare against a resolved path. On
+	// Windows t.TempDir can sit under an 8.3 short name (JOOMAN~1) that
+	// EvalSymlinks expands, and on macOS /var is a symlink to /private/var.
+	wantDir := resolvedPath(t, dir)
+	if bundle.Dir != wantDir {
+		t.Fatalf("Dir = %q, want %q", bundle.Dir, wantDir)
+	}
+	wantLauncher := filepath.Join(wantDir, "bin", executableName("kandev"))
+	if bundle.Launcher != wantLauncher {
+		t.Fatalf("Launcher = %q, want %q", bundle.Launcher, wantLauncher)
+	}
+}
+
+func resolvedPath(t *testing.T, path string) string {
+	t.Helper()
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return path
+	}
+	return resolved
+}
+
 func TestResolveRuntimeBundleReportsBothLookupsInError(t *testing.T) {
 	t.Setenv("KANDEV_BUNDLE_DIR", "")
 

--- a/apps/backend/internal/launcher/bundle_test.go
+++ b/apps/backend/internal/launcher/bundle_test.go
@@ -170,6 +170,66 @@ func TestRequiredAgentctlRemoteHelpers(t *testing.T) {
 	}
 }
 
+func TestBundleDirForLauncherPathAcceptsBinLayout(t *testing.T) {
+	dir := filepath.Join("opt", "kandev")
+	got, ok := bundleDirForLauncherPath(filepath.Join(dir, "bin", executableName("kandev")))
+	if !ok {
+		t.Fatal("expected the <bundle>/bin/kandev layout to be accepted")
+	}
+	if got != dir {
+		t.Fatalf("bundle dir = %q, want %q", got, dir)
+	}
+}
+
+func TestBundleDirForLauncherPathRejectsLauncherOutsideBin(t *testing.T) {
+	for _, exe := range []string{
+		filepath.Join("opt", "kandev", executableName("kandev")),
+		filepath.Join("usr", "local", "sbin", executableName("kandev")),
+		executableName("kandev"),
+	} {
+		if got, ok := bundleDirForLauncherPath(exe); ok {
+			t.Fatalf("exe %q was accepted as bundle %q", exe, got)
+		}
+	}
+}
+
+func TestResolveRuntimeBundlePrefersEnvOverExecutable(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "bin", executableName("kandev")))
+	writeFile(t, filepath.Join(dir, "bin", executableName("agentctl")))
+	writeRemoteAgentctlHelpers(t, dir)
+	t.Setenv("KANDEV_BUNDLE_DIR", dir)
+
+	bundle, err := resolveRuntimeBundle()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bundle.Source != "env" {
+		t.Fatalf("Source = %q, want %q", bundle.Source, "env")
+	}
+	if bundle.Dir != dir {
+		t.Fatalf("Dir = %q, want %q", bundle.Dir, dir)
+	}
+}
+
+func TestResolveRuntimeBundleReportsBothLookupsInError(t *testing.T) {
+	t.Setenv("KANDEV_BUNDLE_DIR", "")
+
+	// The test binary does not live in a <bundle>/bin directory, so the
+	// executable-relative lookup finds nothing and the error must say so rather
+	// than blaming the environment variable alone.
+	_, err := resolveRuntimeBundle()
+	if err == nil {
+		t.Fatal("expected an error when neither lookup resolves")
+	}
+	if !strings.Contains(err.Error(), "KANDEV_BUNDLE_DIR") {
+		t.Fatalf("error does not mention the env var: %v", err)
+	}
+	if !strings.Contains(err.Error(), "next to the launcher") {
+		t.Fatalf("error does not mention the executable-relative lookup: %v", err)
+	}
+}
+
 func writeRemoteAgentctlHelpers(t *testing.T, dir string) {
 	t.Helper()
 	for _, helper := range requiredAgentctlRemoteHelpers {

--- a/apps/backend/internal/launcher/bundle_test.go
+++ b/apps/backend/internal/launcher/bundle_test.go
@@ -186,6 +186,10 @@ func TestBundleDirForLauncherPathRejectsLauncherOutsideBin(t *testing.T) {
 		filepath.Join("opt", "kandev", executableName("kandev")),
 		filepath.Join("usr", "local", "sbin", executableName("kandev")),
 		executableName("kandev"),
+		// validateRuntimeBundle joins a lowercase "bin" onto whatever this
+		// returns, so any other casing must be refused here rather than
+		// derived and rejected later with a misleading error.
+		filepath.Join("opt", "kandev", "BIN", executableName("kandev")),
 	} {
 		if got, ok := bundleDirForLauncherPath(exe); ok {
 			t.Fatalf("exe %q was accepted as bundle %q", exe, got)

--- a/docs/public/cli.md
+++ b/docs/public/cli.md
@@ -54,6 +54,28 @@ npx -y kandev@latest
 
 If an npm policy such as `--omit=optional` prevents optional dependencies from being installed, Kandev cannot find its native runtime.
 
+### Release archive
+
+Every release publishes a runtime archive per platform, named `kandev-<platform>.tar.gz`, where
+`<platform>` is one of `linux-x64`, `linux-arm64`, `macos-x64`, `macos-arm64`, or `windows-x64`.
+Pick the archive matching the machine, verify it against the `.sha256` published beside it, extract
+it, and run the launcher from the extracted tree:
+
+```bash
+curl -fsSLO https://github.com/kdlbs/kandev/releases/latest/download/kandev-linux-x64.tar.gz
+curl -fsSLO https://github.com/kdlbs/kandev/releases/latest/download/kandev-linux-x64.tar.gz.sha256
+shasum -a 256 -c kandev-linux-x64.tar.gz.sha256
+tar -xzf kandev-linux-x64.tar.gz
+./kandev/bin/kandev --version
+```
+
+Verifying the checksum matters more here than with the package managers, which do that themselves.
+
+The archive extracts to a `kandev/` directory containing `bin/`, and the launcher finds the rest of
+the bundle relative to itself. The extracted directory can be moved anywhere; add `kandev/bin` to
+`PATH` for a persistent command. Set `KANDEV_BUNDLE_DIR` only to point the launcher at a bundle it
+is not part of.
+
 ### npm nightly
 
 Stable remains npm's default `latest` tag. To opt into the current prerelease from `main`, install


### PR DESCRIPTION
The launcher refuses to start unless `KANDEV_BUNDLE_DIR` is set, even though it is sitting inside the bundle it is looking for. This adds a fallback that derives the bundle from the launcher's own path.

## Why

Every install channel works around this today, each in a different way:

| Channel | Workaround |
|---|---|
| Homebrew | `write_env_script` wraps the binary to export the variable |
| npm | `bin/native-shim.js` sets it before spawning |
| Scoop | `env_set` in the manifest |
| Manual `tar -xzf` | none — `kandev` exits with `KANDEV_BUNDLE_DIR is not set` |

That last row is a real papercut: download the release tarball, extract it, run `kandev`, and it fails with a message pointing at a variable nobody mentioned.

It also blocks winget and Chocolatey, which unpack an archive and put the binary on PATH with no mechanism for setting environment variables.

## What changes

`resolveRuntimeBundle` now tries two sources instead of one:

1. `KANDEV_BUNDLE_DIR`, exactly as before
2. failing that, `<bundle>/bin/kandev` → `<bundle>`, from `os.Executable()`

The environment variable keeps priority on purpose: `kandev service install` writes it into the systemd unit and launchd plist, and a self-update repoints it at the new bundle while the outgoing launcher is still running. Nothing that works today changes behaviour — the only case that behaves differently is the one that is currently a hard error.

The derived path is not trusted blindly. `bundleDirForLauncherPath` accepts only the `<bundle>/bin/<launcher>` layout, and the result still goes through `validateRuntimeBundle`, which already requires `agentctl` and the four remote helpers to be present. A launcher somewhere unrelated fails exactly as it does now.

## On symlinks

winget installs portable packages by unpacking to `WinGet\Packages\<id>\` and putting a symlink on PATH at `WinGet\Links\<name>.exe`, so it was worth checking whether the launcher would see the link or the target. Measured against a real winget symlink on Windows 11:

```
LINK   : ...\WinGet\Links\kubectl.exe
TARGET : ...\WinGet\Packages\Kubernetes.kubectl_.../kubectl.exe
Win32_Process.ExecutablePath = ...\WinGet\Packages\Kubernetes.kubectl_.../kubectl.exe
```

Windows resolves the link at process creation, and that path comes from the same source `os.Executable()` uses. `EvalSymlinks` is still attempted first for platforms that do not resolve it, and is best-effort — it fails on Windows junctions, and the unresolved path is worth trying anyway.

## Tests

Four new cases in `bundle_test.go`: the accepted layout, three rejected layouts, the environment variable winning over the executable-relative lookup, and the error mentioning both lookups rather than blaming the variable alone.

Note for anyone running the suite on Windows: five pre-existing `TestValidateRuntimeBundle*` cases fail there because they create `bin/kandev` without the `.exe` that `executableName` appends. They fail identically on `main` without this change, and pass in CI on Linux.



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2285?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->