### PR TITLE
ci(release): publish a Windows zip alongside the tarball

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -812,13 +812,27 @@ jobs:
           cd dist
           tar -czf "kandev-${{ matrix.platform }}.tar.gz" kandev
           shasum -a 256 "kandev-${{ matrix.platform }}.tar.gz" > "kandev-${{ matrix.platform }}.tar.gz.sha256"
+          # Windows package managers cannot consume the tarball: winget's
+          # InstallerType enum accepts zip as its only archive format, and
+          # Chocolatey's unzip helper needs two 7-Zip passes for a .tar.gz.
+          # The zip is published alongside the tarball, not instead of it —
+          # Homebrew and the npm runtime packages still read the tarball.
+          if [ "${{ matrix.goos }}" = "windows" ]; then
+            zip -qr "kandev-${{ matrix.platform }}.zip" kandev
+            shasum -a 256 "kandev-${{ matrix.platform }}.zip" > "kandev-${{ matrix.platform }}.zip.sha256"
+          fi
 
       - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: bundle-${{ matrix.platform }}
+          # The zip entries match nothing on the four non-Windows platforms.
+          # if-no-files-found is left at its default so a missing tarball is
+          # still an error.
           path: |
             dist/kandev-${{ matrix.platform }}.tar.gz
             dist/kandev-${{ matrix.platform }}.tar.gz.sha256
+            dist/kandev-${{ matrix.platform }}.zip
+            dist/kandev-${{ matrix.platform }}.zip.sha256
 
   build-desktop:
     name: Build desktop app (${{ matrix.platform }})
@@ -1883,6 +1897,17 @@ jobs:
               exit 1
             fi
           done
+          # The Windows zip is the only archive winget and Chocolatey can read.
+          # Losing it would break those channels while every other check here
+          # still passed, so it is verified explicitly.
+          for artifact in \
+            dist/release-assets/kandev-windows-x64.zip \
+            dist/release-assets/kandev-windows-x64.zip.sha256; do
+            if [ ! -f "$artifact" ]; then
+              echo "Missing required Windows artifact: $artifact" >&2
+              exit 1
+            fi
+          done
           bash "$DESKTOP_ASSET_VERIFIER" dist/release-assets
           ls -lh dist/release-assets
 
@@ -1923,6 +1948,8 @@ jobs:
             dist/release-assets/kandev-macos-*.tar.gz.sha256
             dist/release-assets/kandev-windows-*.tar.gz
             dist/release-assets/kandev-windows-*.tar.gz.sha256
+            dist/release-assets/kandev-windows-*.zip
+            dist/release-assets/kandev-windows-*.zip.sha256
             dist/release-assets/kandev-desktop-*
             dist/release-assets/latest.json
           preserve_order: true


### PR DESCRIPTION
Publishes `kandev-windows-x64.zip` alongside the existing tarball. Additive — nothing is replaced or renamed.

## Why

Windows package managers cannot read the tarball. winget's `InstallerType` enum is:

```
msix, msi, appx, exe, zip, inno, nullsoft, wix, burn, pwa, portable, font
```

`zip` is the only archive format in it — no `tar`, `tar.gz` or `7z`. Chocolatey's `Install-ChocolateyZipPackage` can reach a `.tar.gz` only by running 7-Zip twice.

`portable` is not an escape hatch: it is for a single executable, and the bundle is six binaries (`kandev`, `agentctl`, and four remote helpers) that `validateRuntimeBundle` all require.

The tarball stays exactly as it is — Homebrew and the `@kdlbs/runtime-*` npm packages read it.

## What changes

- **Package bundle** — for `goos == windows` only, zip the same `dist/kandev` tree the tarball already comes from, and write the matching `.sha256`
- **Verify release assets** — fail the release if the zip or its checksum is missing. Without this, losing the zip would leave every other check green while the Windows channels quietly broke
- **Publish release** — add `kandev-windows-*.zip` and its checksum to the uploaded files

## Checks done before opening this

- **`zip` is present on the runner.** The `windows-x64` bundle cross-compiles on `ubuntu-latest`, not a Windows runner, so this is a Linux step. The ubuntu-24.04 image ships `zip 3.0-13ubuntu0.2`.
- **Archive layout matches the tarball.** Simulated the packaging step: the zip contains `kandev/bin/kandev.exe` plus the five other binaries, with the `kandev/` root preserved. That is what a winget manifest's `RelativeFilePath` would point at, and it mirrors the tarball's `extract_dir`.
- **No collision with the desktop updater.** `updater-manifest.mjs` selects artifacts by `startsWith("kandev-desktop-<platform>-")` **and** `endsWith(".nsis.zip")`. `kandev-windows-x64.zip` fails both. `verify-desktop-assets.sh` looks for `*.nsis.zip` on Windows and does not match it either. Both conditions were executed rather than read.

What could not be checked from a branch: the job actually running. `release.yml` is `workflow_dispatch` only, so no PR CI exercises it — the first real test is the next release.

## Related

A Windows package manager also needs kdlbs/kandev#2285, which lets the launcher find its bundle without `KANDEV_BUNDLE_DIR`. Neither is sufficient alone: this one gives winget something to download, that one lets the result start. They are independent to review and can merge in either order.



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2286?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->