### PR TITLE
fix: persist default sidebar view

### DIFF
--- a/apps/backend/internal/user/handlers/handlers_test.go
+++ b/apps/backend/internal/user/handlers/handlers_test.go
@@ -42,6 +42,33 @@ func TestHTTPUpdateSidebarDraftFromCleanSettings(t *testing.T) {
 	router := gin.New()
 	NewHandlers(controller.NewController(service.NewService(repo, nil, log)), log).registerHTTP(router)
 
+	resetRequest := httptest.NewRequest(
+		http.MethodPatch,
+		"/api/v1/user/settings",
+		bytes.NewReader([]byte(`{"sidebar_views":[]}`)),
+	)
+	resetRequest.Header.Set("Content-Type", "application/json")
+	resetResponse := httptest.NewRecorder()
+	router.ServeHTTP(resetResponse, resetRequest)
+	if resetResponse.Code != http.StatusOK {
+		t.Fatalf("PATCH empty sidebar views status = %d, want %d: %s", resetResponse.Code, http.StatusOK, resetResponse.Body.String())
+	}
+	resetGetResponse := httptest.NewRecorder()
+	router.ServeHTTP(resetGetResponse, httptest.NewRequest(http.MethodGet, "/api/v1/user/settings", nil))
+	if resetGetResponse.Code != http.StatusOK {
+		t.Fatalf("GET reset user settings status = %d, want %d: %s", resetGetResponse.Code, http.StatusOK, resetGetResponse.Body.String())
+	}
+	var resetPayload dto.UserSettingsResponse
+	if err := json.NewDecoder(resetGetResponse.Body).Decode(&resetPayload); err != nil {
+		t.Fatalf("decode reset user settings: %v", err)
+	}
+	if len(resetPayload.Settings.SidebarViews) != 1 || resetPayload.Settings.SidebarViews[0].ID != "view-all-tasks" {
+		t.Fatalf("reset sidebar views = %+v, want canonical All tasks view", resetPayload.Settings.SidebarViews)
+	}
+	if resetPayload.Settings.SidebarActiveViewID != "view-all-tasks" {
+		t.Fatalf("reset active sidebar view = %q, want %q", resetPayload.Settings.SidebarActiveViewID, "view-all-tasks")
+	}
+
 	patch := []byte(`{
 		"sidebar_active_view_id":"view-all-tasks",
 		"sidebar_draft":{

--- a/apps/backend/internal/user/handlers/handlers_test.go
+++ b/apps/backend/internal/user/handlers/handlers_test.go
@@ -1,0 +1,80 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/jmoiron/sqlx"
+	_ "github.com/mattn/go-sqlite3"
+
+	"github.com/kandev/kandev/internal/common/logger"
+	"github.com/kandev/kandev/internal/user/controller"
+	"github.com/kandev/kandev/internal/user/dto"
+	"github.com/kandev/kandev/internal/user/service"
+	userstore "github.com/kandev/kandev/internal/user/store"
+	"go.uber.org/zap"
+)
+
+func TestHTTPUpdateSidebarDraftFromCleanSettings(t *testing.T) {
+	conn, err := sqlx.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	conn.SetMaxOpenConns(1)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	repo, cleanup, err := userstore.Provide(conn, conn)
+	if err != nil {
+		t.Fatalf("create user repository: %v", err)
+	}
+	t.Cleanup(func() { _ = cleanup() })
+
+	log, err := logger.NewFromZap(zap.NewNop())
+	if err != nil {
+		t.Fatalf("create logger: %v", err)
+	}
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	NewHandlers(controller.NewController(service.NewService(repo, nil, log)), log).registerHTTP(router)
+
+	patch := []byte(`{
+		"sidebar_active_view_id":"view-all-tasks",
+		"sidebar_draft":{
+			"base_view_id":"view-all-tasks",
+			"filters":[],
+			"sort":{"key":"updatedAt","direction":"desc"},
+			"group":"workflow"
+		}
+	}`)
+	request := httptest.NewRequest(http.MethodPatch, "/api/v1/user/settings", bytes.NewReader(patch))
+	request.Header.Set("Content-Type", "application/json")
+	response := httptest.NewRecorder()
+	router.ServeHTTP(response, request)
+	if response.Code != http.StatusOK {
+		t.Fatalf("PATCH clean sidebar settings status = %d, want %d: %s", response.Code, http.StatusOK, response.Body.String())
+	}
+
+	getResponse := httptest.NewRecorder()
+	router.ServeHTTP(getResponse, httptest.NewRequest(http.MethodGet, "/api/v1/user/settings", nil))
+	if getResponse.Code != http.StatusOK {
+		t.Fatalf("GET user settings status = %d, want %d: %s", getResponse.Code, http.StatusOK, getResponse.Body.String())
+	}
+	var payload dto.UserSettingsResponse
+	if err := json.NewDecoder(getResponse.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode user settings: %v", err)
+	}
+	if len(payload.Settings.SidebarViews) != 1 || payload.Settings.SidebarViews[0].ID != "view-all-tasks" {
+		t.Fatalf("sidebar views = %+v, want canonical All tasks view", payload.Settings.SidebarViews)
+	}
+	if payload.Settings.SidebarActiveViewID != "view-all-tasks" {
+		t.Fatalf("active sidebar view = %q, want %q", payload.Settings.SidebarActiveViewID, "view-all-tasks")
+	}
+	if payload.Settings.SidebarDraft == nil || payload.Settings.SidebarDraft.Group != "workflow" {
+		t.Fatalf("sidebar draft = %+v, want workflow draft", payload.Settings.SidebarDraft)
+	}
+}

--- a/apps/backend/internal/user/service/service.go
+++ b/apps/backend/internal/user/service/service.go
@@ -591,6 +591,10 @@ func applySidebarViews(settings *models.UserSettings, req *UpdateUserSettingsReq
 		}
 		seen[views[i].ID] = struct{}{}
 	}
+	if len(views) == 0 && req.SidebarActiveViewID == nil {
+		views = store.DefaultSidebarViews()
+		settings.SidebarActiveViewID = store.DefaultSidebarViewID
+	}
 	settings.SidebarViews = views
 	return nil
 }

--- a/apps/backend/internal/user/service/service_test.go
+++ b/apps/backend/internal/user/service/service_test.go
@@ -835,9 +835,9 @@ func TestApplySidebarViews(t *testing.T) {
 			wantApplied: false,
 		},
 		{
-			name:        "empty slice is accepted",
+			name:        "empty slice restores the canonical default",
 			req:         &UpdateUserSettingsRequest{SidebarViews: ptr([]models.SidebarView{})},
-			wantCount:   0,
+			wantCount:   1,
 			wantApplied: true,
 		},
 		{

--- a/apps/backend/internal/user/store/sqlite.go
+++ b/apps/backend/internal/user/store/sqlite.go
@@ -15,11 +15,11 @@ import (
 )
 
 const (
-	DefaultUserID    = "default-user"
-	DefaultUserEmail = "default@kandev.local"
+	DefaultUserID        = "default-user"
+	DefaultUserEmail     = "default@kandev.local"
+	DefaultSidebarViewID = "view-all-tasks"
 
 	defaultChangesPanelLayout = "tree"
-	defaultSidebarViewID      = "view-all-tasks"
 )
 
 type sqliteRepository struct {
@@ -599,17 +599,17 @@ func defaultUserSettings(userID string) *models.UserSettings {
 		KeyboardShortcuts:               map[string]interface{}{},
 		TerminalLinkBehavior:            "new_tab",
 		ChangesPanelLayout:              defaultChangesPanelLayout,
-		SidebarViews:                    defaultSidebarViews(),
-		SidebarActiveViewID:             defaultSidebarViewID,
+		SidebarViews:                    DefaultSidebarViews(),
+		SidebarActiveViewID:             DefaultSidebarViewID,
 		SidebarTaskPrefs:                normalizeSidebarTaskPrefs(models.SidebarTaskPrefs{}),
 		AppStatusBarOrder:               normalizeAppStatusBarOrder(models.AppStatusBarOrder{}),
 		VoiceMode:                       defaultVoiceModeSettings(),
 	}
 }
 
-func defaultSidebarViews() []models.SidebarView {
+func DefaultSidebarViews() []models.SidebarView {
 	return []models.SidebarView{{
-		ID:              defaultSidebarViewID,
+		ID:              DefaultSidebarViewID,
 		Name:            "All tasks",
 		Filters:         []models.SidebarViewClause{},
 		Sort:            models.SidebarViewSort{Key: "state", Direction: "asc"},

--- a/apps/backend/internal/user/store/sqlite.go
+++ b/apps/backend/internal/user/store/sqlite.go
@@ -19,6 +19,7 @@ const (
 	DefaultUserEmail = "default@kandev.local"
 
 	defaultChangesPanelLayout = "tree"
+	defaultSidebarViewID      = "view-all-tasks"
 )
 
 type sqliteRepository struct {
@@ -598,11 +599,23 @@ func defaultUserSettings(userID string) *models.UserSettings {
 		KeyboardShortcuts:               map[string]interface{}{},
 		TerminalLinkBehavior:            "new_tab",
 		ChangesPanelLayout:              defaultChangesPanelLayout,
-		SidebarViews:                    []models.SidebarView{},
+		SidebarViews:                    defaultSidebarViews(),
+		SidebarActiveViewID:             defaultSidebarViewID,
 		SidebarTaskPrefs:                normalizeSidebarTaskPrefs(models.SidebarTaskPrefs{}),
 		AppStatusBarOrder:               normalizeAppStatusBarOrder(models.AppStatusBarOrder{}),
 		VoiceMode:                       defaultVoiceModeSettings(),
 	}
+}
+
+func defaultSidebarViews() []models.SidebarView {
+	return []models.SidebarView{{
+		ID:              defaultSidebarViewID,
+		Name:            "All tasks",
+		Filters:         []models.SidebarViewClause{},
+		Sort:            models.SidebarViewSort{Key: "state", Direction: "asc"},
+		Group:           "repository",
+		CollapsedGroups: []string{},
+	}}
 }
 
 func scanUserSettings(scanner interface{ Scan(dest ...any) error }, userID string) (*models.UserSettings, error) {
@@ -644,8 +657,8 @@ func scanUserSettings(scanner interface{ Scan(dest ...any) error }, userID strin
 		LspServerConfigs                map[string]map[string]interface{}   `json:"lsp_server_configs"`
 		LspStatusLocation               string                              `json:"lsp_status_location"`
 		SavedLayouts                    []models.SavedLayout                `json:"saved_layouts"`
-		SidebarViews                    []models.SidebarView                `json:"sidebar_views"`
-		SidebarActiveViewID             string                              `json:"sidebar_active_view_id"`
+		SidebarViews                    json.RawMessage                     `json:"sidebar_views"`
+		SidebarActiveViewID             json.RawMessage                     `json:"sidebar_active_view_id"`
 		SidebarDraft                    *models.SidebarViewDraft            `json:"sidebar_draft"`
 		SidebarTaskPrefs                models.SidebarTaskPrefs             `json:"sidebar_task_prefs"`
 		TaskCreateLastUsed              models.TaskCreateLastUsed           `json:"task_create_last_used"`
@@ -733,11 +746,25 @@ func scanUserSettings(scanner interface{ Scan(dest ...any) error }, userID strin
 	if settings.SavedLayouts == nil {
 		settings.SavedLayouts = []models.SavedLayout{}
 	}
-	settings.SidebarViews = payload.SidebarViews
-	if settings.SidebarViews == nil {
-		settings.SidebarViews = []models.SidebarView{}
+	if len(payload.SidebarViews) > 0 {
+		if err := json.Unmarshal(payload.SidebarViews, &settings.SidebarViews); err != nil {
+			return nil, err
+		}
+		if settings.SidebarViews == nil {
+			settings.SidebarViews = []models.SidebarView{}
+		}
 	}
-	settings.SidebarActiveViewID = payload.SidebarActiveViewID
+	if len(payload.SidebarActiveViewID) > 0 {
+		var activeViewID *string
+		if err := json.Unmarshal(payload.SidebarActiveViewID, &activeViewID); err != nil {
+			return nil, err
+		}
+		if activeViewID == nil {
+			settings.SidebarActiveViewID = ""
+		} else {
+			settings.SidebarActiveViewID = *activeViewID
+		}
+	}
 	settings.SidebarDraft = payload.SidebarDraft
 	settings.SidebarTaskPrefs = normalizeSidebarTaskPrefs(payload.SidebarTaskPrefs)
 	settings.TaskCreateLastUsed = payload.TaskCreateLastUsed

--- a/apps/backend/internal/user/store/sqlite_test.go
+++ b/apps/backend/internal/user/store/sqlite_test.go
@@ -69,6 +69,72 @@ func TestScanUserSettingsStartupPage(t *testing.T) {
 	}
 }
 
+func TestScanUserSettingsSidebarDefaults(t *testing.T) {
+	defaultView := models.SidebarView{
+		ID:              "view-all-tasks",
+		Name:            "All tasks",
+		Filters:         []models.SidebarViewClause{},
+		Sort:            models.SidebarViewSort{Key: "state", Direction: "asc"},
+		Group:           "repository",
+		CollapsedGroups: []string{},
+	}
+
+	tests := []struct {
+		name          string
+		raw           string
+		wantDefaults  bool
+		wantViewCount int
+	}{
+		{name: "empty settings use canonical sidebar default", raw: "{}", wantDefaults: true, wantViewCount: 1},
+		{name: "unrelated settings retain canonical sidebar default", raw: `{"workspace_id":"workspace-1"}`, wantDefaults: true, wantViewCount: 1},
+		{name: "explicit sidebar settings are preserved", raw: `{"sidebar_views":[{"id":"custom","name":"Custom"}],"sidebar_active_view_id":"custom"}`, wantDefaults: false, wantViewCount: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			settings, err := scanUserSettings(settingsScanner{raw: tt.raw}, DefaultUserID)
+			if err != nil {
+				t.Fatalf("scan settings: %v", err)
+			}
+			if len(settings.SidebarViews) != tt.wantViewCount {
+				t.Fatalf("sidebar view count = %d, want %d", len(settings.SidebarViews), tt.wantViewCount)
+			}
+			if tt.wantDefaults {
+				if !reflect.DeepEqual(settings.SidebarViews[0], defaultView) {
+					t.Fatalf("sidebar default = %+v, want %+v", settings.SidebarViews[0], defaultView)
+				}
+				if settings.SidebarActiveViewID != defaultView.ID {
+					t.Fatalf("active sidebar view = %q, want %q", settings.SidebarActiveViewID, defaultView.ID)
+				}
+				return
+			}
+			if settings.SidebarViews[0].ID != "custom" || settings.SidebarActiveViewID != "custom" {
+				t.Fatalf("explicit sidebar settings were not preserved: views=%+v active=%q", settings.SidebarViews, settings.SidebarActiveViewID)
+			}
+		})
+	}
+}
+
+func TestScanUserSettingsPreservesExplicitEmptySidebarSettings(t *testing.T) {
+	for _, raw := range []string{
+		`{"sidebar_views":[],"sidebar_active_view_id":""}`,
+		`{"sidebar_views":null,"sidebar_active_view_id":null}`,
+	} {
+		t.Run(raw, func(t *testing.T) {
+			settings, err := scanUserSettings(settingsScanner{raw: raw}, DefaultUserID)
+			if err != nil {
+				t.Fatalf("scan settings: %v", err)
+			}
+			if len(settings.SidebarViews) != 0 {
+				t.Fatalf("sidebar views = %+v, want an explicit empty list", settings.SidebarViews)
+			}
+			if settings.SidebarActiveViewID != "" {
+				t.Fatalf("active sidebar view = %q, want an explicit empty ID", settings.SidebarActiveViewID)
+			}
+		})
+	}
+}
+
 func TestScanUserSettingsChangesPanelLayoutDefault(t *testing.T) {
 	t.Run("empty settings default to tree", func(t *testing.T) {
 		settings, err := scanUserSettings(settingsScanner{raw: "{}"}, DefaultUserID)

--- a/apps/web/e2e/fixtures/test-base.ts
+++ b/apps/web/e2e/fixtures/test-base.ts
@@ -8,6 +8,15 @@ import { PrAssetCapture } from "../helpers/pr-asset-capture";
 import { makeGitEnv } from "../helpers/git-helper";
 import type { WorkflowStep } from "../../lib/types/http";
 
+const DEFAULT_SIDEBAR_VIEW = {
+  id: "view-all-tasks",
+  name: "All tasks",
+  filters: [],
+  sort: { key: "state", direction: "asc" },
+  group: "repository",
+  collapsed_groups: [],
+};
+
 export type SeedData = {
   workspaceId: string;
   workflowId: string;
@@ -185,7 +194,8 @@ export const test = backendFixture.extend<
       confirm_task_archive: true,
       agent_generated_task_titles: false,
       mcp_task_agent_profile_default: "current_task",
-      sidebar_views: [],
+      sidebar_views: [DEFAULT_SIDEBAR_VIEW],
+      sidebar_active_view_id: DEFAULT_SIDEBAR_VIEW.id,
       saved_layouts: [],
       lsp_auto_start_languages: [],
       lsp_auto_install_languages: [],
@@ -320,7 +330,8 @@ test.beforeEach(async ({ apiClient, seedData }) => {
     confirm_task_archive: true,
     agent_generated_task_titles: false,
     mcp_task_agent_profile_default: "current_task",
-    sidebar_views: [],
+    sidebar_views: [DEFAULT_SIDEBAR_VIEW],
+    sidebar_active_view_id: DEFAULT_SIDEBAR_VIEW.id,
     saved_layouts: [],
     lsp_auto_start_languages: [],
     lsp_auto_install_languages: [],

--- a/apps/web/e2e/helpers/api-client.ts
+++ b/apps/web/e2e/helpers/api-client.ts
@@ -851,6 +851,7 @@ export class ApiClient {
     unread_divider?: boolean;
     agent_generated_task_titles?: boolean;
     mcp_task_agent_profile_default?: MCPTaskAgentProfileDefault;
+    sidebar_active_view_id?: string;
     show_anchored_prompt_bar?: boolean;
     show_scroll_to_last_prompt?: boolean;
     show_scroll_to_start?: boolean;

--- a/apps/web/e2e/tests/task/sidebar-filter.spec.ts
+++ b/apps/web/e2e/tests/task/sidebar-filter.spec.ts
@@ -94,6 +94,22 @@ test.describe("Sidebar filter bar — popover basics", () => {
     const chips = filters.chipMenu.getByTestId("sidebar-view-chip");
     await expect(chips).toHaveCount(1);
     await expect(chips.filter({ hasText: "All tasks" })).toBeVisible();
+    await filters.closeViewPicker();
+
+    await filters.addFilterRow();
+    await filters.setClauseDimension(0, "Archived");
+    await expect
+      .poll(async () => {
+        const { settings } = await apiClient.getUserSettings();
+        const draft = settings.sidebar_draft as { base_view_id?: string } | null | undefined;
+        return draft?.base_view_id ?? null;
+      })
+      .toBe("view-all-tasks");
+    await expect(testPage.getByText("Sidebar views", { exact: true })).toHaveCount(0);
+
+    await testPage.reload();
+    await new SessionPage(testPage).waitForLoad();
+    await new SidebarFilterPopoverPage(testPage).expectActiveViewChip("All tasks");
   });
 
   test("switching chips updates active state and persists across reload", async ({

--- a/docs/plans/sidebar-default-view-persistence/plan.md
+++ b/docs/plans/sidebar-default-view-persistence/plan.md
@@ -1,0 +1,148 @@
+---
+spec: docs/specs/ui/sidebar-view-creation.md
+created: 2026-08-05
+status: complete
+---
+
+# Implementation Plan: Persist the Default Sidebar View
+
+## Overview
+
+Repair the clean-settings contract at its backend source of truth. The backend
+will provide the canonical `All tasks` view and matching active ID whenever
+stored user settings omit sidebar-view fields, while preserving explicit stored
+values and the existing active-view validation. A focused HTTP integration test
+and the existing sidebar browser suite will prove that the first filter edit no
+longer returns HTTP 400.
+
+## Confirmed root cause
+
+`internal/user/store.defaultUserSettings` currently supplies an empty
+`SidebarViews` slice and no active ID, while the frontend independently starts
+with `view-all-tasks`. The first draft-only PATCH sends
+`sidebar_active_view_id="view-all-tasks"` without `sidebar_views`, so
+`applySidebarViewState` validates the ID against the backend's empty list and
+rejects the request. Commit `b9eb6ae05` removed the legacy client migration
+that previously populated the backend, exposing this mismatch on clean data.
+
+This repair follows
+[ADR 0041](../../decisions/0041-backend-owned-portable-user-settings.md): the
+backend owns the effective value of omitted portable settings. It does not
+reintroduce browser migration or relax referential validation.
+
+---
+
+## Backend
+
+### Canonical sidebar defaults
+
+- In `apps/backend/internal/user/store/sqlite.go`, add a fresh-value helper for
+  the canonical sidebar view: ID `view-all-tasks`, name `All tasks`, empty
+  filters, `state`/`asc` sort, `repository` grouping, and empty collapsed
+  groups.
+- Use fresh slices on each call so one request cannot mutate another user's
+  defaults through shared backing arrays.
+- Set both `SidebarViews` and `SidebarActiveViewID` in
+  `defaultUserSettings`.
+- Change the temporary JSON scan fields for `sidebar_views` and
+  `sidebar_active_view_id` to preserve field presence. Overlay them only when
+  they are present, so settings JSON such as `{}` or
+  `{"workspace_id":"..."}` retains the backend default while explicit stored
+  values remain authoritative.
+- Keep `applySidebarViewState` unchanged: non-default or stale active IDs must
+  still be rejected unless they exist in the effective saved-view list.
+
+### HTTP integration path
+
+- Add `apps/backend/internal/user/handlers/handlers_test.go` using an in-memory
+  SQLite repository, the real service/controller, and a Gin test router.
+- Start from the repository-created default user whose settings JSON is `{}`.
+- Assert `GET /api/v1/user/settings` returns the canonical view and matching
+  active ID.
+- PATCH only `sidebar_active_view_id` plus `sidebar_draft`, matching the current
+  frontend edit request, and assert HTTP 200 plus durable read-back. This test
+  must return HTTP 400 before the production change for the diagnosed reason.
+
+---
+
+## Frontend
+
+No production frontend change is planned. The existing client PATCH shape and
+optimistic behavior remain the consumer contract being verified.
+
+### E2E fixture and scenario
+
+- In `apps/web/e2e/fixtures/test-base.ts`, reset sidebar settings to the same
+  canonical view and active ID rather than an impossible empty-view UI state.
+  Reuse one fixture constant for both reset paths.
+- In `apps/web/e2e/tests/task/sidebar-filter.spec.ts`, extend the new-user
+  default-view scenario to edit the canonical view before any create/save-as
+  action. Assert the draft reaches user settings, no `Sidebar views` error toast
+  appears, and the view remains active after reload.
+- Desktop and mobile use the same store action and backend route; this repair
+  changes no layout, interaction target, or responsive composition. Existing
+  mobile sidebar-view coverage remains applicable.
+
+---
+
+## Tests
+
+- **What:** omitted sidebar fields resolve to a fresh canonical view and
+  matching active ID, including when unrelated settings are present.
+  **File:** `apps/backend/internal/user/store/sqlite_test.go`.
+  **How:** table-driven `scanUserSettings` unit test covering `{}` and an
+  unrelated-field JSON object, plus an explicit stored-view preservation case.
+- **What:** the first draft PATCH succeeds through the real HTTP → controller →
+  service → SQLite path without sending `sidebar_views`.
+  **File:** `apps/backend/internal/user/handlers/handlers_test.go`.
+  **How:** Gin/`httptest` integration test with the repository-created clean
+  user; assert GET defaults, PATCH 200, and GET read-back.
+- **What:** unmatched active IDs remain rejected.
+  **File:** `apps/backend/internal/user/service/service_test.go`.
+  **How:** retain and run the existing `TestApplySidebarViewState` regression
+  coverage; no validation weakening is expected.
+
+## E2E Tests
+
+- **Scenario:** **GIVEN** a new user's canonical `All tasks` view, **WHEN** the
+  first filter is edited, **THEN** the draft persists without a settings error
+  and survives reload.
+  **File:** `apps/web/e2e/tests/task/sidebar-filter.spec.ts`.
+  **What to verify:** canonical view selection, persisted
+  `sidebar_active_view_id`/`sidebar_draft`, absence of the error toast, and
+  active-view continuity after reload.
+
+---
+
+## Verification Results
+
+- `cd apps/backend && go test -tags fts5 -run 'TestScanUserSettingsSidebarDefaults|TestScanUserSettingsPreservesExplicitEmptySidebarSettings|TestHTTPUpdateSidebarDraftFromCleanSettings|TestApplySidebarViewState' ./internal/user/store ./internal/user/handlers ./internal/user/service -v` — 14 tests passed across 3 packages.
+- `cd apps/backend && go test -tags fts5 ./internal/user/...` — 227 tests passed across 6 packages.
+- `cd apps && pnpm --filter @kandev/web run typecheck` — passed with no TypeScript errors.
+- `cd apps && pnpm --filter @kandev/web test -- lib/state/slices/ui/ui-slice.test.ts -t "syncs filter sort and group drafts"` — 1 passed, 41 skipped.
+- `cd apps && pnpm --filter @kandev/web lint -- e2e/fixtures/test-base.ts e2e/helpers/api-client.ts e2e/tests/task/sidebar-filter.spec.ts` — passed.
+- `cd apps/web && pnpm e2e:run --host --no-build --project chromium tests/task/sidebar-filter.spec.ts -- --grep "default 'All tasks' view"` — 1 Playwright test passed in 5.7s; the managed runner exited cleanly and left no E2E backend/browser processes.
+- `git diff --check` — passed.
+
+---
+
+## Implementation Waves And Parallel Candidates
+
+Sequential execution in the primary conversation:
+
+- [x] [Task 01: Persist the canonical sidebar default](task-01-persist-canonical-sidebar-default.md) — done
+
+This is one vertical fix spanning a shared persistence contract and its browser
+regression. It is not parallel-safe and does not authorize subagents.
+
+## Risks and boundaries
+
+- The backend and frontend currently duplicate the canonical view identity and
+  shape. The tests pin their agreement; introducing a generated/shared contract
+  is out of scope for this repair.
+- `All tasks` is existing persisted domain copy. This fix does not change
+  localization behavior or rename existing views.
+- Explicitly stored sidebar arrays remain explicit values under ADR 0041; this
+  plan only repairs omitted-value defaults.
+- No schema migration, endpoint shape change, feature flag, or settings-data
+  rewrite is required.

--- a/docs/plans/sidebar-default-view-persistence/plan.md
+++ b/docs/plans/sidebar-default-view-persistence/plan.md
@@ -133,7 +133,7 @@ optimistic behavior remain the consumer contract being verified.
 - `cd apps/web && pnpm e2e:run --host --project chromium tests/task/sidebar-filter.spec.ts -- --grep "default 'All tasks' view"` — 1 Playwright test passed in 5.3s against the rebuilt backend; the managed runner exited cleanly and left no E2E backend/browser processes.
 - `git diff --check` — passed.
 
-- PR #2293 ([implementation head `cdc4f3737408d0aeb9c24b7076d98db2b21342b3`](https://github.com/kdlbs/kandev/pull/2293)) — all 40 reported checks passed after the review fixup; the final documentation-only head `63a97ce189007388c072cf3bed83f871fc39d30e` is pushed with no failures or unresolved review threads while its fresh checks run.
+- PR #2293 ([implementation head `cdc4f3737408d0aeb9c24b7076d98db2b21342b3`](https://github.com/kdlbs/kandev/pull/2293)) — all 40 reported checks passed after the review fixup; subsequent documentation-only commits are pushed with no failures or unresolved review threads observed while their fresh checks run.
 
 ---
 

--- a/docs/plans/sidebar-default-view-persistence/plan.md
+++ b/docs/plans/sidebar-default-view-persistence/plan.md
@@ -1,7 +1,7 @@
 ---
 spec: docs/specs/ui/sidebar-view-creation.md
 created: 2026-08-05
-status: complete
+status: building
 ---
 
 # Implementation Plan: Persist the Default Sidebar View
@@ -49,6 +49,9 @@ reintroduce browser migration or relax referential validation.
   they are present, so settings JSON such as `{}` or
   `{"workspace_id":"..."}` retains the backend default while explicit stored
   values remain authoritative.
+- When a write explicitly replaces `sidebar_views` without an active-view
+  field, preserve the referential invariant: an empty replacement resolves to
+  the canonical default instead of persisting an active ID that has no view.
 - Keep `applySidebarViewState` unchanged: non-default or stale active IDs must
   still be rejected unless they exist in the effective saved-view list.
 
@@ -101,6 +104,12 @@ optimistic behavior remain the consumer contract being verified.
   **File:** `apps/backend/internal/user/service/service_test.go`.
   **How:** retain and run the existing `TestApplySidebarViewState` regression
   coverage; no validation weakening is expected.
+- **What:** an explicit empty `sidebar_views` replacement without an active ID
+  retains a coherent canonical view.
+  **File:** `apps/backend/internal/user/service/service_test.go` and
+  `apps/backend/internal/user/handlers/handlers_test.go`.
+  **How:** assert service normalization and real HTTP read-back before the
+  first draft-only edit.
 
 ## E2E Tests
 
@@ -116,12 +125,12 @@ optimistic behavior remain the consumer contract being verified.
 
 ## Verification Results
 
-- `cd apps/backend && go test -tags fts5 -run 'TestScanUserSettingsSidebarDefaults|TestScanUserSettingsPreservesExplicitEmptySidebarSettings|TestHTTPUpdateSidebarDraftFromCleanSettings|TestApplySidebarViewState' ./internal/user/store ./internal/user/handlers ./internal/user/service -v` — 14 tests passed across 3 packages.
+- `cd apps/backend && go test -tags fts5 -run 'TestScanUserSettingsSidebarDefaults|TestScanUserSettingsPreservesExplicitEmptySidebarSettings|TestHTTPUpdateSidebarDraftFromCleanSettings|TestApplySidebarViews|TestApplySidebarViewState' ./internal/user/store ./internal/user/handlers ./internal/user/service -v` — 23 tests passed across 3 packages.
 - `cd apps/backend && go test -tags fts5 ./internal/user/...` — 227 tests passed across 6 packages.
 - `cd apps && pnpm --filter @kandev/web run typecheck` — passed with no TypeScript errors.
 - `cd apps && pnpm --filter @kandev/web test -- lib/state/slices/ui/ui-slice.test.ts -t "syncs filter sort and group drafts"` — 1 passed, 41 skipped.
 - `cd apps && pnpm --filter @kandev/web lint -- e2e/fixtures/test-base.ts e2e/helpers/api-client.ts e2e/tests/task/sidebar-filter.spec.ts` — passed.
-- `cd apps/web && pnpm e2e:run --host --no-build --project chromium tests/task/sidebar-filter.spec.ts -- --grep "default 'All tasks' view"` — 1 Playwright test passed in 5.7s; the managed runner exited cleanly and left no E2E backend/browser processes.
+- `cd apps/web && pnpm e2e:run --host --project chromium tests/task/sidebar-filter.spec.ts -- --grep "default 'All tasks' view"` — 1 Playwright test passed in 5.3s against the rebuilt backend; the managed runner exited cleanly and left no E2E backend/browser processes.
 - `git diff --check` — passed.
 
 ---
@@ -130,7 +139,7 @@ optimistic behavior remain the consumer contract being verified.
 
 Sequential execution in the primary conversation:
 
-- [x] [Task 01: Persist the canonical sidebar default](task-01-persist-canonical-sidebar-default.md) — done
+- [ ] [Task 01: Persist the canonical sidebar default](task-01-persist-canonical-sidebar-default.md) — in_progress (PR fixup)
 
 This is one vertical fix spanning a shared persistence contract and its browser
 regression. It is not parallel-safe and does not authorize subagents.
@@ -142,7 +151,8 @@ regression. It is not parallel-safe and does not authorize subagents.
   is out of scope for this repair.
 - `All tasks` is existing persisted domain copy. This fix does not change
   localization behavior or rename existing views.
-- Explicitly stored sidebar arrays remain explicit values under ADR 0041; this
-  plan only repairs omitted-value defaults.
+- Explicit non-empty sidebar arrays remain explicit values under ADR 0041;
+  empty replacements without an active ID normalize to the canonical view so
+  the backend cannot persist an invalid active/view pair.
 - No schema migration, endpoint shape change, feature flag, or settings-data
   rewrite is required.

--- a/docs/plans/sidebar-default-view-persistence/plan.md
+++ b/docs/plans/sidebar-default-view-persistence/plan.md
@@ -1,7 +1,7 @@
 ---
 spec: docs/specs/ui/sidebar-view-creation.md
 created: 2026-08-05
-status: building
+status: complete
 ---
 
 # Implementation Plan: Persist the Default Sidebar View
@@ -133,13 +133,15 @@ optimistic behavior remain the consumer contract being verified.
 - `cd apps/web && pnpm e2e:run --host --project chromium tests/task/sidebar-filter.spec.ts -- --grep "default 'All tasks' view"` — 1 Playwright test passed in 5.3s against the rebuilt backend; the managed runner exited cleanly and left no E2E backend/browser processes.
 - `git diff --check` — passed.
 
+- PR #2293 ([current head `cdc4f3737408d0aeb9c24b7076d98db2b21342b3`](https://github.com/kdlbs/kandev/pull/2293)) — all 40 reported checks passed after the review fixup; no failed checks or unresolved review threads remain.
+
 ---
 
 ## Implementation Waves And Parallel Candidates
 
 Sequential execution in the primary conversation:
 
-- [ ] [Task 01: Persist the canonical sidebar default](task-01-persist-canonical-sidebar-default.md) — in_progress (PR fixup)
+- [x] [Task 01: Persist the canonical sidebar default](task-01-persist-canonical-sidebar-default.md) — done
 
 This is one vertical fix spanning a shared persistence contract and its browser
 regression. It is not parallel-safe and does not authorize subagents.

--- a/docs/plans/sidebar-default-view-persistence/plan.md
+++ b/docs/plans/sidebar-default-view-persistence/plan.md
@@ -133,7 +133,7 @@ optimistic behavior remain the consumer contract being verified.
 - `cd apps/web && pnpm e2e:run --host --project chromium tests/task/sidebar-filter.spec.ts -- --grep "default 'All tasks' view"` — 1 Playwright test passed in 5.3s against the rebuilt backend; the managed runner exited cleanly and left no E2E backend/browser processes.
 - `git diff --check` — passed.
 
-- PR #2293 ([current head `cdc4f3737408d0aeb9c24b7076d98db2b21342b3`](https://github.com/kdlbs/kandev/pull/2293)) — all 40 reported checks passed after the review fixup; no failed checks or unresolved review threads remain.
+- PR #2293 ([implementation head `cdc4f3737408d0aeb9c24b7076d98db2b21342b3`](https://github.com/kdlbs/kandev/pull/2293)) — all 40 reported checks passed after the review fixup; the final documentation-only head `63a97ce189007388c072cf3bed83f871fc39d30e` is pushed with no failures or unresolved review threads while its fresh checks run.
 
 ---
 

--- a/docs/plans/sidebar-default-view-persistence/task-01-persist-canonical-sidebar-default.md
+++ b/docs/plans/sidebar-default-view-persistence/task-01-persist-canonical-sidebar-default.md
@@ -1,7 +1,7 @@
 ---
 id: "01-persist-canonical-sidebar-default"
 title: "Persist the canonical sidebar default"
-status: done
+status: in_progress
 wave: 1
 depends_on: []
 plan: "plan.md"
@@ -18,6 +18,8 @@ filter edit through unit, HTTP integration, and browser coverage.
 - Effective settings whose stored JSON omits sidebar-view fields contain one
   canonical `All tasks` view with ID `view-all-tasks` and the same active ID;
   unrelated stored fields and explicit sidebar values are preserved.
+- A `sidebar_views: []` write that omits the active ID normalizes back to the
+  canonical view instead of persisting an invalid active/view pair.
 - A PATCH containing only `sidebar_active_view_id="view-all-tasks"` and a
   sidebar draft succeeds from a clean user and persists the draft.
 - Editing the first default view in the browser produces no sidebar settings
@@ -27,9 +29,10 @@ filter edit through unit, HTTP integration, and browser coverage.
 
 1. Add the clean-user HTTP regression test and run it before production edits;
    record the expected HTTP 400 caused by the missing saved view.
-2. Add the store default/overlay unit cases and implement the minimal fresh
-   canonical default plus presence-aware scan overlay.
-3. Rerun the targeted Go tests until the HTTP regression returns 200 and the
+2. Add the store default/overlay and empty-replacement service/HTTP cases, then
+   implement the minimal fresh canonical default plus presence-aware scan
+   overlay and write normalization.
+3. Rerun the targeted Go tests until both HTTP regressions return 200 and the
    existing stale-ID validation test remains green.
 4. Align the E2E reset fixture with the canonical backend state, extend the
    first-edit browser scenario, and run only that scenario.
@@ -69,10 +72,10 @@ regression describe one cross-layer contract and should be landed together.
 From the repository root:
 
 ```bash
-cd apps/backend && go test -tags fts5 -run 'TestScanUserSettingsSidebarDefaults|TestScanUserSettingsPreservesExplicitEmptySidebarSettings|TestHTTPUpdateSidebarDraftFromCleanSettings|TestApplySidebarViewState' ./internal/user/store ./internal/user/handlers ./internal/user/service -v
+cd apps/backend && go test -tags fts5 -run 'TestScanUserSettingsSidebarDefaults|TestScanUserSettingsPreservesExplicitEmptySidebarSettings|TestHTTPUpdateSidebarDraftFromCleanSettings|TestApplySidebarViews|TestApplySidebarViewState' ./internal/user/store ./internal/user/handlers ./internal/user/service -v
 ```
 
-Result: 14 tests passed across 3 packages.
+Result: 23 tests passed across 3 packages.
 
 The worktree was missing the Playwright/Vitest links, so dependencies were
 bootstrapped once:
@@ -102,13 +105,13 @@ The focused browser test was run through the managed runner, which builds and
 tears down the real backend/browser fixture:
 
 ```bash
-cd apps/web && pnpm e2e:run --host --no-build --project chromium tests/task/sidebar-filter.spec.ts -- --grep "default 'All tasks' view"
+cd apps/web && pnpm e2e:run --host --project chromium tests/task/sidebar-filter.spec.ts -- --grep "default 'All tasks' view"
 ```
 
-Result: 1 Playwright test passed in 5.7s. The first run exposed a test-overlay
-timing defect after leaving the view picker open; the test now closes the
-picker before editing and the rerun passes. The runner exited cleanly with no
-leftover E2E backend/browser processes.
+Result: 1 Playwright test passed in 5.3s against the rebuilt backend. The first
+run exposed a test-overlay timing defect after leaving the view picker open;
+the test now closes the picker before editing and the rerun passes. The runner
+exited cleanly with no leftover E2E backend/browser processes.
 
 ```bash
 git diff --check
@@ -126,7 +129,9 @@ and synchronize `plan.md` only after all acceptance criteria pass.
 ## Results
 
 - RED store regression before the production change: `rtk go test -tags fts5 -run TestScanUserSettingsSidebarDefaults ./internal/user/store -v` failed because `{}` and unrelated settings returned zero sidebar views instead of one canonical view.
-- RED HTTP regression before the production change: `rtk go test -tags fts5 -run TestHTTPUpdateSidebarDraftFromCleanSettings ./internal/user/handlers -v` returned HTTP 400 with the diagnosed missing-saved-view validation error.
+- RED HTTP regressions before the production change: the clean draft request returned HTTP 400 with the diagnosed missing-saved-view validation error, and the empty-view reset read back zero views instead of the canonical default.
 - Implemented fresh backend `All tasks` defaults and presence-aware JSON overlay; explicit empty/null values remain explicit.
+- Normalized explicit empty sidebar-view writes without an active field back to the canonical default, preserving the active/view referential invariant.
+- The review regression was reproduced in `TestApplySidebarViews` and the HTTP reset path before normalization; both now pass.
 - Added the real HTTP persistence regression, store coverage, canonical E2E reset state, and first-filter-edit browser scenario.
 - All verification commands above pass; no blockers remain.

--- a/docs/plans/sidebar-default-view-persistence/task-01-persist-canonical-sidebar-default.md
+++ b/docs/plans/sidebar-default-view-persistence/task-01-persist-canonical-sidebar-default.md
@@ -1,7 +1,7 @@
 ---
 id: "01-persist-canonical-sidebar-default"
 title: "Persist the canonical sidebar default"
-status: in_progress
+status: done
 wave: 1
 depends_on: []
 plan: "plan.md"
@@ -135,3 +135,4 @@ and synchronize `plan.md` only after all acceptance criteria pass.
 - The review regression was reproduced in `TestApplySidebarViews` and the HTTP reset path before normalization; both now pass.
 - Added the real HTTP persistence regression, store coverage, canonical E2E reset state, and first-filter-edit browser scenario.
 - All verification commands above pass; no blockers remain.
+- PR #2293 was pushed as `b6ea4b50b` plus review-fix commit `cdc4f3737`. After the 15-minute fixup monitor, the current head reported 40 successful checks, zero failures, and zero unresolved review threads.

--- a/docs/plans/sidebar-default-view-persistence/task-01-persist-canonical-sidebar-default.md
+++ b/docs/plans/sidebar-default-view-persistence/task-01-persist-canonical-sidebar-default.md
@@ -1,0 +1,132 @@
+---
+id: "01-persist-canonical-sidebar-default"
+title: "Persist the canonical sidebar default"
+status: done
+wave: 1
+depends_on: []
+plan: "plan.md"
+spec: "../../specs/ui/sidebar-view-creation.md"
+---
+
+# Task 01: Persist the canonical sidebar default
+
+Implement the backend-owned omitted-value default and prove the first sidebar
+filter edit through unit, HTTP integration, and browser coverage.
+
+## Acceptance
+
+- Effective settings whose stored JSON omits sidebar-view fields contain one
+  canonical `All tasks` view with ID `view-all-tasks` and the same active ID;
+  unrelated stored fields and explicit sidebar values are preserved.
+- A PATCH containing only `sidebar_active_view_id="view-all-tasks"` and a
+  sidebar draft succeeds from a clean user and persists the draft.
+- Editing the first default view in the browser produces no sidebar settings
+  toast and survives reload; stale active IDs remain rejected.
+
+## TDD sequence
+
+1. Add the clean-user HTTP regression test and run it before production edits;
+   record the expected HTTP 400 caused by the missing saved view.
+2. Add the store default/overlay unit cases and implement the minimal fresh
+   canonical default plus presence-aware scan overlay.
+3. Rerun the targeted Go tests until the HTTP regression returns 200 and the
+   existing stale-ID validation test remains green.
+4. Align the E2E reset fixture with the canonical backend state, extend the
+   first-edit browser scenario, and run only that scenario.
+
+## Files likely touched
+
+- `docs/specs/ui/sidebar-view-creation.md`
+- `apps/backend/internal/user/store/sqlite.go`
+- `apps/backend/internal/user/store/sqlite_test.go`
+- `apps/backend/internal/user/handlers/handlers_test.go`
+- `apps/web/e2e/fixtures/test-base.ts`
+- `apps/web/e2e/tests/task/sidebar-filter.spec.ts`
+- `docs/plans/sidebar-default-view-persistence/plan.md`
+- `docs/plans/sidebar-default-view-persistence/task-01-persist-canonical-sidebar-default.md`
+
+## Dependencies
+
+None.
+
+## Parallelism
+
+`sequential`. Backend defaults, the shared E2E fixture, and the browser
+regression describe one cross-layer contract and should be landed together.
+
+## Inputs
+
+- Spec: `docs/specs/ui/sidebar-view-creation.md`, especially **Persistence and
+  failure behavior** and the clean-user scenarios.
+- Decision: `docs/decisions/0041-backend-owned-portable-user-settings.md`.
+- Backend paths: `defaultUserSettings`, `scanUserSettings`,
+  `applySidebarViewState`, and `Handlers.httpUpdateUserSettings`.
+- Frontend consumer: `updateSidebarDraft` in
+  `apps/web/lib/state/slices/ui/sidebar-view-actions.ts`.
+
+## Verification
+
+From the repository root:
+
+```bash
+cd apps/backend && go test -tags fts5 -run 'TestScanUserSettingsSidebarDefaults|TestScanUserSettingsPreservesExplicitEmptySidebarSettings|TestHTTPUpdateSidebarDraftFromCleanSettings|TestApplySidebarViewState' ./internal/user/store ./internal/user/handlers ./internal/user/service -v
+```
+
+Result: 14 tests passed across 3 packages.
+
+The worktree was missing the Playwright/Vitest links, so dependencies were
+bootstrapped once:
+
+```bash
+cd apps && pnpm install --frozen-lockfile
+```
+
+Additional scoped checks:
+
+```bash
+cd apps/backend && go test -tags fts5 ./internal/user/...
+```
+
+Result: 227 tests passed across 6 packages.
+
+```bash
+cd apps && pnpm --filter @kandev/web run typecheck
+cd apps && pnpm --filter @kandev/web test -- lib/state/slices/ui/ui-slice.test.ts -t "syncs filter sort and group drafts"
+cd apps && pnpm --filter @kandev/web lint -- e2e/fixtures/test-base.ts e2e/helpers/api-client.ts e2e/tests/task/sidebar-filter.spec.ts
+```
+
+Results: typecheck and lint passed; the focused unit test passed (1 passed, 41
+skipped).
+
+The focused browser test was run through the managed runner, which builds and
+tears down the real backend/browser fixture:
+
+```bash
+cd apps/web && pnpm e2e:run --host --no-build --project chromium tests/task/sidebar-filter.spec.ts -- --grep "default 'All tasks' view"
+```
+
+Result: 1 Playwright test passed in 5.7s. The first run exposed a test-overlay
+timing defect after leaving the view picker open; the test now closes the
+picker before editing and the rerun passes. The runner exited cleanly with no
+leftover E2E backend/browser processes.
+
+```bash
+git diff --check
+```
+
+Result: passed.
+
+## Output contract
+
+Report the root-cause regression test's red result, the files changed, every
+exact verification command and outcome/count, any generated artifacts or E2E
+teardown evidence, remaining risks, and blockers. Update this task to `done`
+and synchronize `plan.md` only after all acceptance criteria pass.
+
+## Results
+
+- RED store regression before the production change: `rtk go test -tags fts5 -run TestScanUserSettingsSidebarDefaults ./internal/user/store -v` failed because `{}` and unrelated settings returned zero sidebar views instead of one canonical view.
+- RED HTTP regression before the production change: `rtk go test -tags fts5 -run TestHTTPUpdateSidebarDraftFromCleanSettings ./internal/user/handlers -v` returned HTTP 400 with the diagnosed missing-saved-view validation error.
+- Implemented fresh backend `All tasks` defaults and presence-aware JSON overlay; explicit empty/null values remain explicit.
+- Added the real HTTP persistence regression, store coverage, canonical E2E reset state, and first-filter-edit browser scenario.
+- All verification commands above pass; no blockers remain.

--- a/docs/specs/ui/sidebar-view-creation.md
+++ b/docs/specs/ui/sidebar-view-creation.md
@@ -26,6 +26,13 @@ Creating a sidebar view currently requires changing an existing view before `Sav
 
 ## Persistence and failure behavior
 
+- A user settings record that omits sidebar-view fields resolves to one canonical
+  `All tasks` view and a matching active-view ID in every complete backend
+  settings payload. The canonical view uses no filters, `state` ascending sort,
+  `repository` grouping, and no collapsed groups.
+- The first edit to that canonical view persists its draft without requiring a
+  prior create, rename, or save-as action and without surfacing a sidebar-view
+  settings error.
 - Creation persists the new view and active-view selection immediately through existing backend-owned user settings. A successful create survives reload and is available on the user's other clients.
 - A failed create restores the previous saved views, active view, and draft, then surfaces the existing sidebar-view sync error. It never leaves a selected view that is absent from persisted settings.
 - Each new view owns independent filter, sort, and collapsed-group data; later changes to it cannot mutate the canonical default or another view by shared reference.
@@ -34,6 +41,12 @@ See [ADR 0041](../../decisions/0041-backend-owned-portable-user-settings.md) for
 
 ## Scenarios
 
+- **GIVEN** a new user whose stored settings omit sidebar-view fields, **WHEN**
+  Kandev returns the user's effective settings, **THEN** the response contains
+  exactly one canonical `All tasks` view and its ID is the active-view ID.
+- **GIVEN** that new user's canonical `All tasks` view, **WHEN** the user changes
+  a filter, sort, or group before creating any other view, **THEN** the draft
+  persists successfully and no sidebar-view error is shown.
 - **GIVEN** fewer than 50 saved views and no unsaved draft, **WHEN** the user selects `New view`, **THEN** a canonical default view is appended, activated immediately, and offered for focused rename.
 - **GIVEN** the active saved view has custom filters, sort, grouping, or collapsed groups, **WHEN** the user creates a new view, **THEN** the new view still uses the canonical defaults rather than cloning the active state.
 - **GIVEN** saved views named `New view` and `New view 3`, **WHEN** the user creates a new view, **THEN** its automatic name is `New view 2`.
@@ -46,6 +59,9 @@ See [ADR 0041](../../decisions/0041-backend-owned-portable-user-settings.md) for
 
 ## Out of scope
 
+- Changing the semantics of an explicitly stored `sidebar_views` array,
+  migrating existing custom views, or weakening active-view referential
+  validation.
 - Changing `Save as…`, duplicate-view, rename, delete, or saved-view ordering semantics.
 - A pre-creation naming dialog, cancel-to-delete behavior, or delayed persistence until rename.
 - Cloning the active view from the direct-create action.

--- a/docs/specs/ui/sidebar-view-creation.md
+++ b/docs/specs/ui/sidebar-view-creation.md
@@ -33,6 +33,9 @@ Creating a sidebar view currently requires changing an existing view before `Sav
 - The first edit to that canonical view persists its draft without requiring a
   prior create, rename, or save-as action and without surfacing a sidebar-view
   settings error.
+- Replacing `sidebar_views` without an active-view field keeps the persisted
+  active ID referentially valid; an empty replacement resolves to the same
+  canonical `All tasks` view.
 - Creation persists the new view and active-view selection immediately through existing backend-owned user settings. A successful create survives reload and is available on the user's other clients.
 - A failed create restores the previous saved views, active view, and draft, then surfaces the existing sidebar-view sync error. It never leaves a selected view that is absent from persisted settings.
 - Each new view owns independent filter, sort, and collapsed-group data; later changes to it cannot mutate the canonical default or another view by shared reference.
@@ -47,6 +50,9 @@ See [ADR 0041](../../decisions/0041-backend-owned-portable-user-settings.md) for
 - **GIVEN** that new user's canonical `All tasks` view, **WHEN** the user changes
   a filter, sort, or group before creating any other view, **THEN** the draft
   persists successfully and no sidebar-view error is shown.
+- **GIVEN** a settings update replaces `sidebar_views` with an empty array and
+  omits `sidebar_active_view_id`, **THEN** the effective settings retain the
+  canonical `All tasks` view and matching active ID.
 - **GIVEN** fewer than 50 saved views and no unsaved draft, **WHEN** the user selects `New view`, **THEN** a canonical default view is appended, activated immediately, and offered for focused rename.
 - **GIVEN** the active saved view has custom filters, sort, grouping, or collapsed groups, **WHEN** the user creates a new view, **THEN** the new view still uses the canonical defaults rather than cloning the active state.
 - **GIVEN** saved views named `New view` and `New view 3`, **WHEN** the user creates a new view, **THEN** its automatic name is `New view 2`.
@@ -59,9 +65,8 @@ See [ADR 0041](../../decisions/0041-backend-owned-portable-user-settings.md) for
 
 ## Out of scope
 
-- Changing the semantics of an explicitly stored `sidebar_views` array,
-  migrating existing custom views, or weakening active-view referential
-  validation.
+- Migrating existing non-empty custom views or weakening active-view
+  referential validation.
 - Changing `Save as…`, duplicate-view, rename, delete, or saved-view ordering semantics.
 - A pre-creation naming dialog, cancel-to-delete behavior, or delayed persistence until rename.
 - Cloning the active view from the direct-create action.


### PR DESCRIPTION
Fresh users could render the frontend's `view-all-tasks` view while the backend still had no saved views, so the first filter edit was rejected as an invalid active-view ID. The backend now supplies and preserves the canonical default, with HTTP, store, and Playwright coverage for the first edit and reload path.

## Validation

- `cd apps/backend && go test -tags fts5 ./internal/user/...` — 227 passed across 6 packages.
- `cd apps && pnpm --filter @kandev/web run typecheck` — passed.
- `cd apps && pnpm --filter @kandev/web test -- lib/state/slices/ui/ui-slice.test.ts -t "syncs filter sort and group drafts"` — 1 passed, 41 skipped.
- `cd apps && pnpm --filter @kandev/web lint -- e2e/fixtures/test-base.ts e2e/helpers/api-client.ts e2e/tests/task/sidebar-filter.spec.ts` — passed.
- `cd apps/web && pnpm e2e:run --host --no-build --project chromium tests/task/sidebar-filter.spec.ts -- --grep "default 'All tasks' view"` — 1 passed.
- `git diff --check` — passed.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2293?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->