### PR TITLE
fix: harden remote contribution launch safety

### DIFF
--- a/apps/backend/internal/agent/runtime/lifecycle/branch_injection_poc_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/branch_injection_poc_test.go
@@ -54,7 +54,10 @@ func TestBranchNameCommandInjection_Regression(t *testing.T) {
 			Env: map[string]string{},
 		}
 
-		script := exec.resolvePrepareScript(req)
+		script, err := exec.resolvePrepareScript(req)
+		if err != nil {
+			t.Fatalf("resolvePrepareScript() error = %v", err)
+		}
 
 		// The raw, unquoted `$(...)` must NOT appear naked. It may only appear
 		// inside single quotes, where the shell treats it as a literal.
@@ -89,7 +92,10 @@ func TestBranchNameCommandInjection_Regression(t *testing.T) {
 			Env: map[string]string{},
 		}
 
-		script := exec.resolvePrepareScript(req)
+		script, err := exec.resolvePrepareScript(req)
+		if err != nil {
+			t.Fatalf("resolvePrepareScript() error = %v", err)
+		}
 		assertNoUnquotedPayload(t, script, maliciousBranch)
 
 		cloneLine := extractLine(t, script, "git clone --depth=1 --branch")
@@ -132,7 +138,10 @@ func TestBranchNameCommandInjection_Regression(t *testing.T) {
 			Env: map[string]string{},
 		}
 
-		script := exec.resolvePrepareScript(req)
+		script, err := exec.resolvePrepareScript(req)
+		if err != nil {
+			t.Fatalf("resolvePrepareScript() error = %v", err)
+		}
 		assertNoUnquotedPayload(t, script, "main;touch "+markerClone+";#")
 		assertNoUnquotedPayload(t, script, "$(touch "+markerCheckout+")")
 

--- a/apps/backend/internal/agent/runtime/lifecycle/executor_docker.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/executor_docker.go
@@ -180,7 +180,10 @@ func (r *DockerExecutor) CreateInstance(ctx context.Context, req *ExecutorCreate
 
 	r.seedSessionDir(ctx, req)
 
-	containerCfg := r.buildContainerLaunchConfig(req)
+	containerCfg, err := r.buildContainerLaunchConfig(req)
+	if err != nil {
+		return nil, fmt.Errorf("build container launch config: %w", err)
+	}
 	result, err := containerMgr.LaunchContainer(ctx, containerCfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to launch container: %w", err)
@@ -245,7 +248,11 @@ func (r *DockerExecutor) seedSessionDir(ctx context.Context, req *ExecutorCreate
 	}
 }
 
-func (r *DockerExecutor) buildContainerLaunchConfig(req *ExecutorCreateRequest) ContainerConfig {
+func (r *DockerExecutor) buildContainerLaunchConfig(req *ExecutorCreateRequest) (ContainerConfig, error) {
+	prepareScript, err := r.resolvePrepareScript(req)
+	if err != nil {
+		return ContainerConfig{}, err
+	}
 	return ContainerConfig{
 		AgentConfig:                    req.AgentConfig,
 		WorkspacePath:                  "", // Empty = no workspace mount; we clone inside container.
@@ -260,12 +267,12 @@ func (r *DockerExecutor) buildContainerLaunchConfig(req *ExecutorCreateRequest) 
 		AutoApprovePermissionsOverride: req.AutoApprovePermissionsOverride,
 		McpServers:                     req.McpServers,
 		McpProviders:                   req.McpProviders,
-		PrepareScript:                  r.resolvePrepareScript(req),
+		PrepareScript:                  prepareScript,
 		ImageTagOverride:               getMetadataString(req.Metadata, MetadataKeyImageTagOverride),
 		LocalClonePath:                 localCloneMountPath(req.Metadata),
 		BaseBranches:                   getMetadataStringMap(req.Metadata, MetadataKeyBaseBranches),
 		RemoteContributions:            req.RemoteContributions,
-	}
+	}, nil
 }
 
 func (r *DockerExecutor) buildCreatedInstance(req *ExecutorCreateRequest, result *LaunchResult, containerIP string) *ExecutorInstance {
@@ -770,17 +777,21 @@ func (r *DockerExecutor) IsAlwaysResumable() bool         { return true }
 // postlude — older profiles that snapshot a then-current default lacked it,
 // so simply updating DefaultPrepareScript wouldn't reach those users. The
 // postlude runs after the user's prepare script and is idempotent.
-func (r *DockerExecutor) resolvePrepareScript(req *ExecutorCreateRequest) string {
+func (r *DockerExecutor) resolvePrepareScript(req *ExecutorCreateRequest) (string, error) {
 	script := getMetadataString(req.Metadata, MetadataKeySetupScript)
 	if script == "" {
 		script = DefaultPrepareScript("local_docker")
 	}
 	if script == "" {
-		return ""
+		return "", nil
 	}
 	script += KandevBranchCheckoutPostlude()
 	if binding, ok := req.RemoteContributions[""]; ok {
-		script += scriptengine.RemoteContributionSetupScript(&binding)
+		contributionScript, err := scriptengine.RemoteContributionSetupScript(&binding)
+		if err != nil {
+			return "", err
+		}
+		script += contributionScript
 	}
 
 	resolver := scriptengine.NewResolver().
@@ -810,7 +821,7 @@ func (r *DockerExecutor) resolvePrepareScript(req *ExecutorCreateRequest) string
 			"kandev.agentctl.start":   "",
 		})
 
-	return resolver.Resolve(script)
+	return resolver.Resolve(script), nil
 }
 
 func localCloneMountPath(metadata map[string]interface{}) string {

--- a/apps/backend/internal/agent/runtime/lifecycle/executor_docker_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/executor_docker_test.go
@@ -898,7 +898,10 @@ func TestResolvePrepareScript(t *testing.T) {
 			},
 			Env: map[string]string{"GH_TOKEN": "ghp_test"},
 		}
-		script := exec.resolvePrepareScript(req)
+		script, err := exec.resolvePrepareScript(req)
+		if err != nil {
+			t.Fatalf("resolvePrepareScript() error = %v", err)
+		}
 		if script == "" {
 			t.Fatal("expected non-empty script")
 		}
@@ -923,7 +926,10 @@ func TestResolvePrepareScript(t *testing.T) {
 			Metadata: map[string]interface{}{},
 			Env:      map[string]string{},
 		}
-		script := exec.resolvePrepareScript(req)
+		script, err := exec.resolvePrepareScript(req)
+		if err != nil {
+			t.Fatalf("resolvePrepareScript() error = %v", err)
+		}
 		// Should still produce a script (default docker script)
 		if script == "" {
 			t.Fatal("expected non-empty default script")
@@ -942,7 +948,10 @@ func TestResolvePrepareScript(t *testing.T) {
 				"KANDEV_GITLAB_HOST": "http://gitlab.internal:8080",
 			},
 		}
-		script := exec.resolvePrepareScript(req)
+		script, err := exec.resolvePrepareScript(req)
+		if err != nil {
+			t.Fatalf("resolvePrepareScript() error = %v", err)
+		}
 		if !strings.Contains(script, "'http://gitlab.internal:8080/group/repo.git'") {
 			t.Fatalf("resolved script does not retain raw clone URL:\n%s", script)
 		}

--- a/apps/backend/internal/agent/runtime/lifecycle/executor_sprites_operations.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/executor_sprites_operations.go
@@ -219,7 +219,10 @@ func (r *SpritesExecutor) runPrepareScript(
 	req *ExecutorCreateRequest,
 	onOutput func(string),
 ) error {
-	script := r.resolvePrepareScript(req)
+	script, err := r.resolvePrepareScript(req)
+	if err != nil {
+		return err
+	}
 	if script == "" {
 		r.logger.Debug("no prepare script configured, skipping")
 		return nil
@@ -292,17 +295,21 @@ func (r *SpritesExecutor) runPrepareScript(
 // pattern. Profiles created in the UI snapshot the default at create time,
 // so without an unconditional postlude older Sprites profiles would still
 // commit straight onto main.
-func (r *SpritesExecutor) resolvePrepareScript(req *ExecutorCreateRequest) string {
+func (r *SpritesExecutor) resolvePrepareScript(req *ExecutorCreateRequest) (string, error) {
 	script := getMetadataString(req.Metadata, MetadataKeySetupScript)
 	if script == "" {
 		script = DefaultPrepareScript("sprites")
 	}
 	if script == "" {
-		return ""
+		return "", nil
 	}
 	script += KandevBranchCheckoutPostlude()
 	if binding, ok := req.RemoteContributions[""]; ok {
-		script += scriptengine.RemoteContributionSetupScript(&binding)
+		contributionScript, err := scriptengine.RemoteContributionSetupScript(&binding)
+		if err != nil {
+			return "", err
+		}
+		script += contributionScript
 	}
 
 	installScripts := r.collectAgentInstallScripts(req)
@@ -327,7 +334,7 @@ func (r *SpritesExecutor) resolvePrepareScript(req *ExecutorCreateRequest) strin
 			injectGitHubTokenIntoCloneURL,
 		))
 
-	return resolver.Resolve(script)
+	return resolver.Resolve(script), nil
 }
 
 // collectAgentInstallScripts extracts agent IDs from the executor profile metadata

--- a/apps/backend/internal/agent/runtime/lifecycle/manager.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager.go
@@ -97,9 +97,12 @@ type Manager struct {
 	remoteStatusPollInterval time.Duration
 	remoteStatusMu           sync.RWMutex
 	remoteStatusBySession    map[string]*RemoteStatus
-	stopCh                   chan struct{}
-	stopOnce                 sync.Once
-	wg                       sync.WaitGroup
+	// Bounds the non-mutating contribution push check before agent launch.
+	// A zero value uses the production default and keeps test Manager literals safe.
+	remoteContributionPreflightTimeout time.Duration
+	stopCh                             chan struct{}
+	stopOnce                           sync.Once
+	wg                                 sync.WaitGroup
 	// shuttingDown is flipped true when graceful shutdown begins (see
 	// StopAllAgents) so handlers running in detached goroutines can
 	// short-circuit work that would otherwise race the teardown and log

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_startup.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_startup.go
@@ -18,6 +18,15 @@ import (
 	"github.com/kandev/kandev/internal/task/models"
 )
 
+const defaultRemoteContributionPreflightTimeout = 30 * time.Second
+
+func (m *Manager) contributionPreflightTimeout() time.Duration {
+	if m.remoteContributionPreflightTimeout > 0 {
+		return m.remoteContributionPreflightTimeout
+	}
+	return defaultRemoteContributionPreflightTimeout
+}
+
 // startPassthroughExecution dispatches a passthrough-routed execution to the
 // resume or fresh launch path. profileInfo may be nil — see routePassthrough's
 // contract.
@@ -133,7 +142,10 @@ func (m *Manager) StartAgentProcess(ctx context.Context, executionID string) (re
 		m.updateExecutionError(executionID, "agentctl not ready: "+err.Error())
 		return fmt.Errorf("agentctl not ready: %w", err)
 	}
-	if err := m.preflightRemoteContributionPushes(operationCtx, execution); err != nil {
+	preflightCtx, cancelPreflight := context.WithTimeout(operationCtx, m.contributionPreflightTimeout())
+	err = m.preflightRemoteContributionPushes(preflightCtx, execution)
+	cancelPreflight()
+	if err != nil {
 		m.updateExecutionError(executionID, "contribution push preflight failed: "+err.Error())
 		return err
 	}

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_startup_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_startup_test.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/kandev/kandev/internal/agent/runtime/activity"
 	agentctl "github.com/kandev/kandev/internal/agent/runtime/agentctl"
@@ -173,6 +174,79 @@ func TestStartAgentProcess_RunsContributionPreflightBeforeAgentStart(t *testing.
 	}
 	if len(paths) != 2 || paths[0] != "/health" || paths[1] != "/api/v1/git/push-preflight" {
 		t.Fatalf("agentctl request order = %v, want health then push-preflight only", paths)
+	}
+}
+
+func TestStartAgentProcessBoundsContributionPreflight(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/health":
+			w.WriteHeader(http.StatusOK)
+		case "/api/v1/git/push-preflight":
+			close(started)
+			<-release
+			_ = json.NewEncoder(w).Encode(map[string]any{"success": true})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+	host, portText, err := net.SplitHostPort(strings.TrimPrefix(server.URL, "http://"))
+	if err != nil {
+		t.Fatalf("parse agentctl test URL: %v", err)
+	}
+	port, err := strconv.Atoi(portText)
+	if err != nil {
+		t.Fatalf("parse agentctl test port: %v", err)
+	}
+
+	mgr := newTestManager(t)
+	mgr.remoteContributionPreflightTimeout = 10 * time.Millisecond
+	binding := models.RemoteContribution{
+		Version:      models.RemoteContributionVersion,
+		Provider:     models.RemoteContributionProviderGitHub,
+		Kind:         models.RemoteContributionKindPullRequest,
+		CanonicalURL: "https://github.com/acme/widget/pull/7",
+		Number:       7,
+		State:        models.RemoteContributionStateOpen,
+		BaseBranch:   "main",
+		HeadBranch:   "feature/remote",
+		HeadSHA:      strings.Repeat("a", 40),
+		SourceRepository: models.RemoteContributionRepository{
+			Host: "github.com", Path: "contributor/widget", RemoteURL: "https://github.com/contributor/widget.git",
+		},
+		CollaborationAllowed: true,
+	}
+	execution := &AgentExecution{
+		ID: "exec-preflight-timeout", SessionID: "session-preflight-timeout",
+		AgentCommand: "agent", AgentProfileID: "profile-preflight-timeout",
+		Metadata: map[string]interface{}{
+			MetadataKeyRemoteContributions: map[string]models.RemoteContribution{"": binding},
+		},
+		agentctl: agentctl.NewClient(host, port, newTestLogger()),
+	}
+	if err := mgr.executionStore.Add(execution); err != nil {
+		t.Fatalf("seed execution: %v", err)
+	}
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- mgr.StartAgentProcess(context.Background(), execution.ID) }()
+	<-started
+	startedAt := time.Now()
+	select {
+	case err := <-errCh:
+		close(release)
+		if err == nil {
+			t.Fatal("StartAgentProcess() succeeded after preflight timeout")
+		}
+		if elapsed := time.Since(startedAt); elapsed > 500*time.Millisecond {
+			t.Fatalf("StartAgentProcess() returned after %s; want bounded preflight", elapsed)
+		}
+	case <-time.After(time.Second):
+		close(release)
+		t.Fatal("StartAgentProcess() did not return after preflight timeout")
 	}
 }
 

--- a/apps/backend/internal/agent/runtime/lifecycle/types.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/types.go
@@ -735,6 +735,7 @@ func (r *LaunchRequest) RepoSpecs() []RepoLaunchSpec {
 		DefaultBranch:          r.DefaultBranch,
 		CheckoutBranch:         r.CheckoutBranch,
 		PRNumber:               r.PRNumber,
+		RemoteContribution:     r.RemoteContribution,
 		WorktreeID:             r.WorktreeID,
 		WorktreeBranchPrefix:   r.WorktreeBranchPrefix,
 		WorktreeBranchTemplate: r.WorktreeBranchTemplate,

--- a/apps/backend/internal/agent/runtime/lifecycle/types_repospecs_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/types_repospecs_test.go
@@ -1,6 +1,10 @@
 package lifecycle
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/kandev/kandev/internal/task/models"
+)
 
 func TestLaunchRequest_RepoSpecs_ReturnsExplicitListWhenSet(t *testing.T) {
 	req := &LaunchRequest{
@@ -24,6 +28,7 @@ func TestLaunchRequest_RepoSpecs_ReturnsExplicitListWhenSet(t *testing.T) {
 }
 
 func TestLaunchRequest_RepoSpecs_SynthesizesFromLegacyFields(t *testing.T) {
+	binding := models.RemoteContribution{CanonicalURL: "https://github.com/acme/widget/pull/7"}
 	req := &LaunchRequest{
 		RepositoryID:         "repo-x",
 		RepositoryPath:       "/x",
@@ -35,6 +40,7 @@ func TestLaunchRequest_RepoSpecs_SynthesizesFromLegacyFields(t *testing.T) {
 		RepoName:             "x",
 		BranchSlug:           "feature-y",
 		BranchIdentitySlug:   "feature-y",
+		RemoteContribution:   &binding,
 	}
 	specs := req.RepoSpecs()
 	if len(specs) != 1 {
@@ -47,6 +53,9 @@ func TestLaunchRequest_RepoSpecs_SynthesizesFromLegacyFields(t *testing.T) {
 		!got.PullBeforeWorktree || got.RepoName != "x" ||
 		got.BranchSlug != "feature-y" || got.BranchIdentitySlug != "feature-y" {
 		t.Errorf("synthesized spec mismatch: %+v", got)
+	}
+	if got.RemoteContribution != &binding {
+		t.Errorf("remote contribution = %#v, want %#v", got.RemoteContribution, &binding)
 	}
 }
 

--- a/apps/backend/internal/common/securityutil/git.go
+++ b/apps/backend/internal/common/securityutil/git.go
@@ -61,12 +61,12 @@ func IsKnownSafeGitFlag(arg string) bool {
 		"--abbrev-ref", "--symbolic-full-name", "--verify", "--no-patch",
 		"--format", "--format=", "--stat", "--shortstat", "--numstat", "-p", "-A",
 		"--amend", "--allow-empty", "--soft", "--mixed", "--hard",
-		"--cached", "--force", "--source=HEAD", "--staged", "--worktree", "--push",
-		"--dry-run", "--get-all",
+		"--cached", "--force", "--source=HEAD", "--staged", "--worktree",
+		"--dry-run", "--get-all", "--first-parent", "--is-ancestor",
 		"--", // Path separator - everything after this is treated as paths, not flags
 	}
 	for _, safe := range safeFlags {
-		if arg == safe || strings.HasPrefix(arg, safe) {
+		if arg == safe || (safe != "--" && strings.HasPrefix(arg, safe)) {
 			return true
 		}
 	}

--- a/apps/backend/internal/common/securityutil/git_test.go
+++ b/apps/backend/internal/common/securityutil/git_test.go
@@ -27,8 +27,18 @@ func TestIsValidBaseBranchRef(t *testing.T) {
 	}
 }
 
-func TestIsKnownSafeGitFlagAllowsPushDryRun(t *testing.T) {
-	if !IsKnownSafeGitFlag("--dry-run") {
-		t.Fatal("--dry-run must be allowed for non-mutating push preflight")
+func TestIsKnownSafeGitFlagAllowsRequiredGitOperationFlags(t *testing.T) {
+	for _, flag := range []string{"--dry-run", "--first-parent", "--is-ancestor"} {
+		if !IsKnownSafeGitFlag(flag) {
+			t.Fatalf("%s must be allowed for the git operations that use it", flag)
+		}
+	}
+}
+
+func TestIsKnownSafeGitFlagRejectsPushOptionPrefixes(t *testing.T) {
+	for _, flag := range []string{"--push", "--push-option=notify"} {
+		if IsKnownSafeGitFlag(flag) {
+			t.Fatalf("IsKnownSafeGitFlag(%q) = true, want false", flag)
+		}
 	}
 }

--- a/apps/backend/internal/github/gh_client.go
+++ b/apps/backend/internal/github/gh_client.go
@@ -1250,11 +1250,10 @@ func convertGHPR(raw *ghPR, owner, repo string) *PR {
 		pr.HeadRepoCloneURL = raw.HeadRepository.HTTPSURL
 	}
 	// gh pr view does not expose baseRepository. The --repo arguments are the
-	// trusted target identity, while the PR response supplies the immutable
-	// base ref. Keep these separate from the source repository identity above.
+	// trusted target identity. Do not treat the PR base ref as the repository's
+	// default branch; they can differ for a PR that targets a release branch.
 	pr.BaseRepoOwner = owner
 	pr.BaseRepoName = repo
-	pr.BaseDefaultBranch = raw.BaseRefName
 	return pr
 }
 

--- a/apps/backend/internal/github/gh_client_test.go
+++ b/apps/backend/internal/github/gh_client_test.go
@@ -166,8 +166,8 @@ printf '%s\n' '{"number":7,"title":"Remote contribution","url":"https://github.c
 	if pr.HeadRepoNodeID != "R_kgDOFork123" || pr.HeadRepoOwner != "contributor" || pr.HeadRepoName != "widget-fork" {
 		t.Fatalf("source repository = (%q, %q, %q), want CLI node ID and owner shape", pr.HeadRepoNodeID, pr.HeadRepoOwner, pr.HeadRepoName)
 	}
-	if pr.BaseRepoOwner != "acme" || pr.BaseRepoName != "widget" || pr.BaseDefaultBranch != "main" {
-		t.Fatalf("target repository = (%q, %q, %q), want acme/widget/main", pr.BaseRepoOwner, pr.BaseRepoName, pr.BaseDefaultBranch)
+	if pr.BaseRepoOwner != "acme" || pr.BaseRepoName != "widget" || pr.BaseDefaultBranch != "" {
+		t.Fatalf("target repository = (%q, %q, %q), want acme/widget with no guessed default branch", pr.BaseRepoOwner, pr.BaseRepoName, pr.BaseDefaultBranch)
 	}
 	args, err := os.ReadFile(logPath)
 	if err != nil {

--- a/apps/backend/internal/github/service_remote_contribution.go
+++ b/apps/backend/internal/github/service_remote_contribution.go
@@ -96,10 +96,6 @@ func buildGitHubRemoteContribution(rawURL, owner, repo string, number int, pr *P
 	if err := binding.Validate(); err != nil {
 		return nil, err
 	}
-	targetDefault := pr.BaseDefaultBranch
-	if targetDefault == "" {
-		targetDefault = pr.BaseBranch
-	}
 	return &taskmodels.RemoteContributionResolution{
 		Binding:             binding,
 		TargetProvider:      taskmodels.RemoteContributionProviderGitHub,
@@ -107,7 +103,7 @@ func buildGitHubRemoteContribution(rawURL, owner, repo string, number int, pr *P
 		TargetPath:          owner + "/" + repo,
 		TargetProviderID:    positiveID(pr.BaseRepoID),
 		TargetRemoteURL:     fmt.Sprintf("https://github.com/%s/%s.git", owner, repo),
-		TargetDefaultBranch: targetDefault,
+		TargetDefaultBranch: pr.BaseDefaultBranch,
 	}, nil
 }
 

--- a/apps/backend/internal/gitlab/service_remote_contribution.go
+++ b/apps/backend/internal/gitlab/service_remote_contribution.go
@@ -85,10 +85,6 @@ func buildGitLabRemoteContribution(rawURL, configuredHost, projectPath string, i
 	if err := binding.Validate(); err != nil {
 		return nil, err
 	}
-	targetDefault := mr.TargetDefaultBranch
-	if targetDefault == "" {
-		targetDefault = mr.BaseBranch
-	}
 	return &taskmodels.RemoteContributionResolution{
 		Binding:             binding,
 		TargetProvider:      taskmodels.RemoteContributionProviderGitLab,
@@ -96,7 +92,7 @@ func buildGitLabRemoteContribution(rawURL, configuredHost, projectPath string, i
 		TargetPath:          projectPath,
 		TargetProviderID:    positiveGitLabID(firstGitLabID(mr.TargetProjectID, mr.ProjectID)),
 		TargetRemoteURL:     fmt.Sprintf("%s/%s.git", strings.TrimRight(hostOrigin, "/"), projectPath),
-		TargetDefaultBranch: targetDefault,
+		TargetDefaultBranch: mr.TargetDefaultBranch,
 	}, nil
 }
 

--- a/apps/backend/internal/mcp/handlers/handlers.go
+++ b/apps/backend/internal/mcp/handlers/handlers.go
@@ -240,7 +240,7 @@ type Handlers struct {
 	diagnosticBundles      DiagnosticBundleProvider
 	diagnosticMaterializer DiagnosticBundleMaterializer
 	// Optional task-bound GitLab MR automation controls.
-	taskMRAutomation       TaskMRAutomationService
+	taskMRAutomation TaskMRAutomationService
 }
 
 // NewHandlers creates new MCP handlers.
@@ -815,7 +815,9 @@ func (h *Handlers) resolveMCPRemoteContributions(
 		repo.ProviderRepoID = resolution.TargetProviderID
 		repo.ProviderOwner = owner
 		repo.ProviderName = name
-		repo.DefaultBranch = resolution.TargetDefaultBranch
+		if resolution.TargetDefaultBranch != "" {
+			repo.DefaultBranch = resolution.TargetDefaultBranch
+		}
 		repo.BaseBranch = resolution.Binding.BaseBranch
 		repo.CheckoutBranch = resolution.Binding.HeadBranch
 		repo.RemoteContribution = &resolution.Binding

--- a/apps/backend/internal/mcp/handlers/handlers_test.go
+++ b/apps/backend/internal/mcp/handlers/handlers_test.go
@@ -275,6 +275,27 @@ func TestHandleCreateTask_AssociatesExistingRemoteContribution(t *testing.T) {
 	}
 }
 
+func TestResolveMCPRemoteContributionsPreservesExistingDefaultBranch(t *testing.T) {
+	resolution := testRemoteContributionResolution()
+	resolution.TargetDefaultBranch = ""
+	remote := &recordingRemoteContributionService{resolution: resolution}
+	h := &Handlers{remoteContributionSvc: remote, logger: testLogger(t)}
+	repos := []service.TaskRepositoryInput{{
+		RemoteURL:     "https://github.com/acme/widget/pull/7",
+		DefaultBranch: "trunk",
+	}}
+	resolutions, err := h.resolveMCPRemoteContributions(context.Background(), "workspace-1", "user-1", repos)
+	if err != nil {
+		t.Fatalf("resolveMCPRemoteContributions() error = %v", err)
+	}
+	if len(resolutions) != 1 || resolutions[0] == nil {
+		t.Fatalf("resolutions = %#v, want one resolution", resolutions)
+	}
+	if repos[0].DefaultBranch != "trunk" {
+		t.Fatalf("default branch = %q, want existing branch trunk", repos[0].DefaultBranch)
+	}
+}
+
 func TestHandleCreateTask_RollsBackWhenRemoteContributionAssociationFails(t *testing.T) {
 	svc, repo := newTestTaskService(t)
 	ctx := context.Background()

--- a/apps/backend/internal/orchestrator/executor/executor_credentials.go
+++ b/apps/backend/internal/orchestrator/executor/executor_credentials.go
@@ -312,7 +312,10 @@ func (e *Executor) issueGitHubContributionCredentialScope(
 	if err := binding.Validate(); err != nil {
 		return nil, fmt.Errorf("validate remote contribution credential scope: %w", err)
 	}
-	if binding.Provider != models.RemoteContributionProviderGitHub || !strings.EqualFold(binding.SourceRepository.Host, defaultGitHubHost) {
+	if binding.Provider != models.RemoteContributionProviderGitHub {
+		return nil, nil
+	}
+	if !strings.EqualFold(binding.SourceRepository.Host, defaultGitHubHost) {
 		return nil, fmt.Errorf("remote contribution source is not a GitHub repository")
 	}
 	parts := strings.Split(binding.SourceRepository.Path, "/")

--- a/apps/backend/internal/orchestrator/executor/executor_credentials_test.go
+++ b/apps/backend/internal/orchestrator/executor/executor_credentials_test.go
@@ -322,6 +322,43 @@ func TestConfigureGitHubCredentialBrokerIssuesOneLeasePerRepository(t *testing.T
 	}
 }
 
+func TestIssueGitHubContributionCredentialScopeIgnoresGitLabBinding(t *testing.T) {
+	exec := newTestExecutor(t, &mockAgentManager{}, newMockRepository())
+	info := &repoInfo{
+		RepositoryID: "repo-1",
+		Repository: &models.Repository{
+			Provider:      "gitlab",
+			ProviderOwner: "acme",
+			ProviderName:  "widget",
+		},
+		RemoteContribution: &models.RemoteContribution{
+			Version:      models.RemoteContributionVersion,
+			Provider:     models.RemoteContributionProviderGitLab,
+			Kind:         models.RemoteContributionKindMergeRequest,
+			CanonicalURL: "https://gitlab.com/acme/widget/-/merge_requests/7",
+			Number:       7,
+			State:        models.RemoteContributionStateOpen,
+			BaseBranch:   "main",
+			HeadBranch:   "feature/remote",
+			HeadSHA:      strings.Repeat("a", 40),
+			SourceRepository: models.RemoteContributionRepository{
+				Host:      "gitlab.com",
+				Path:      "contributor/widget",
+				RemoteURL: "https://gitlab.com/contributor/widget.git",
+			},
+			CollaborationAllowed: true,
+		},
+	}
+
+	scope, err := exec.issueGitHubContributionCredentialScope(context.Background(), &LaunchAgentRequest{}, info)
+	if err != nil {
+		t.Fatalf("issueGitHubContributionCredentialScope() error = %v", err)
+	}
+	if scope != nil {
+		t.Fatalf("scope = %#v, want nil for GitLab binding", scope)
+	}
+}
+
 func TestConfigureGitHubCredentialBrokerPreservesExplicitProfileToken(t *testing.T) {
 	issuer := &fakeGitHubCredentialLeaseIssuer{lease: GitHubCredentialLease{Token: "opaque-lease"}}
 	exec := newTestExecutor(t, &mockAgentManager{}, newMockRepository())

--- a/apps/backend/internal/scriptengine/providers.go
+++ b/apps/backend/internal/scriptengine/providers.go
@@ -15,12 +15,12 @@ import (
 // All binding values have already passed the credential-free domain validator,
 // but they are still shell-quoted here because branch names are provider data.
 // The fragment intentionally does not print the remote URL or provider text.
-func RemoteContributionSetupScript(binding *models.RemoteContribution) string {
+func RemoteContributionSetupScript(binding *models.RemoteContribution) (string, error) {
 	if binding == nil {
-		return ""
+		return "", nil
 	}
 	if err := binding.Validate(); err != nil {
-		return ""
+		return "", fmt.Errorf("validate remote contribution: %w", err)
 	}
 	remoteName := binding.ContributionRemoteName()
 	remoteBranch := binding.HeadBranch
@@ -75,7 +75,7 @@ func RemoteContributionSetupScript(binding *models.RemoteContribution) string {
 )
 `, shellQuote("/workspace"), shellQuote(remoteName), shellQuote(binding.SourceRepository.RemoteURL),
 		shellQuote(remoteBranch), shellQuote(remoteRef), shellQuote(refspec), shellQuote(binding.HeadSHA),
-		branchSuffix, branchSuffix)
+		branchSuffix, branchSuffix), nil
 }
 
 // RepositoryProvider returns git-related placeholders from metadata and environment.

--- a/apps/backend/internal/scriptengine/providers_test.go
+++ b/apps/backend/internal/scriptengine/providers_test.go
@@ -4,6 +4,8 @@ import (
 	"os/exec"
 	"strings"
 	"testing"
+
+	"github.com/kandev/kandev/internal/task/models"
 )
 
 // shellUnquote runs `printf %s <arg>` through /bin/sh so the test can prove that
@@ -66,6 +68,16 @@ func TestRepositoryProvider_UsesRepositorySetupScriptKey(t *testing.T) {
 	vars := provider()
 	if got := vars["repository.setup_script"]; got != "npm ci" {
 		t.Fatalf("repository.setup_script = %q, want %q", got, "npm ci")
+	}
+}
+
+func TestRemoteContributionSetupScriptRejectsInvalidBinding(t *testing.T) {
+	script, err := RemoteContributionSetupScript(&models.RemoteContribution{})
+	if err == nil {
+		t.Fatal("RemoteContributionSetupScript() accepted an invalid binding")
+	}
+	if script != "" {
+		t.Fatalf("script = %q, want empty script on validation error", script)
 	}
 }
 

--- a/apps/backend/internal/worktree/manager_contribution.go
+++ b/apps/backend/internal/worktree/manager_contribution.go
@@ -17,6 +17,38 @@ func contributionRemoteName(binding *models.RemoteContribution) string {
 	return binding.ContributionRemoteName()
 }
 
+func (m *Manager) ensureContributionRemote(
+	ctx context.Context, repoPath, remoteName, remoteURL string,
+) error {
+	getURL := m.newNonInteractiveGitCmd(ctx, repoPath, "config", "--get", "remote."+remoteName+".url")
+	configuredURL, getErr := runGitCmdOutput(ctx, getURL)
+	if getErr == nil {
+		if strings.TrimSpace(string(configuredURL)) != remoteURL {
+			return fmt.Errorf("contribution remote %q is already configured for another URL", remoteName)
+		}
+		return nil
+	}
+
+	add := m.newNonInteractiveGitCmd(ctx, repoPath, "remote", "add", remoteName, remoteURL)
+	output, addErr := runGitCmdCombinedOutput(ctx, add)
+	if addErr == nil {
+		return nil
+	}
+
+	// Another materialization can add the same remote between the config read
+	// and this command. Re-read after a failed add and accept the result only
+	// when it has the exact binding URL.
+	readAfterAdd := m.newNonInteractiveGitCmd(ctx, repoPath, "config", "--get", "remote."+remoteName+".url")
+	configuredAfterAdd, readErr := runGitCmdOutput(ctx, readAfterAdd)
+	if readErr == nil && strings.TrimSpace(string(configuredAfterAdd)) == remoteURL {
+		return nil
+	}
+	if readErr == nil {
+		return fmt.Errorf("contribution remote %q is already configured for another URL", remoteName)
+	}
+	return fmt.Errorf("add contribution remote: %s: %w", strings.TrimSpace(string(output)), addErr)
+}
+
 func (m *Manager) materializeRemoteContribution(ctx context.Context, repoPath string, binding *models.RemoteContribution) (string, string, error) {
 	if binding == nil {
 		return "", "", errors.New("remote contribution binding is required")
@@ -25,17 +57,8 @@ func (m *Manager) materializeRemoteContribution(ctx context.Context, repoPath st
 		return "", "", fmt.Errorf("validate remote contribution: %w", err)
 	}
 	remoteName := contributionRemoteName(binding)
-	getURL := m.newNonInteractiveGitCmd(ctx, repoPath, "config", "--get", "remote."+remoteName+".url")
-	configuredURL, getErr := runGitCmdOutput(ctx, getURL)
-	if getErr == nil {
-		if strings.TrimSpace(string(configuredURL)) != binding.SourceRepository.RemoteURL {
-			return "", "", fmt.Errorf("contribution remote %q is already configured for another URL", remoteName)
-		}
-	} else {
-		add := m.newNonInteractiveGitCmd(ctx, repoPath, "remote", "add", remoteName, binding.SourceRepository.RemoteURL)
-		if output, err := runGitCmdCombinedOutput(ctx, add); err != nil {
-			return "", "", fmt.Errorf("add contribution remote: %s: %w", strings.TrimSpace(string(output)), err)
-		}
+	if err := m.ensureContributionRemote(ctx, repoPath, remoteName, binding.SourceRepository.RemoteURL); err != nil {
+		return "", "", err
 	}
 	remoteRef := "refs/remotes/" + remoteName + "/" + binding.HeadBranch
 	refspec := "+refs/heads/" + binding.HeadBranch + ":" + remoteRef


### PR DESCRIPTION
Harden the remote contribution task implementation after PR #2265.

- Preserve remote contribution bindings through legacy launch repo specs.
- Bound push preflight before agent launch and fail closed on invalid setup bindings.
- Keep GitHub credentials scoped to GitHub sources, preserve existing default branches, and reject unsafe Git flag prefixes.
- Make contribution remote setup race-safe and retain exact provider-head validation for resume.
- Add regression coverage for launch ordering, credential routing, GitHub CLI shape, default branches, safe flags, and setup validation.

Verification:
- `make -C apps/backend test`
- `make -C apps/backend lint`
- `node --test scripts/validate-public-docs.test.mjs`
- `node scripts/validate-public-docs.mjs`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2294?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->