### PR TITLE
ci(web): gate frontend CI on typecheck

### DIFF
--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -154,6 +154,12 @@ jobs:
       - name: Run lint
         run: pnpm --filter @kandev/web lint
 
+      # `build` below is Vite, which strips types with esbuild and never checks
+      # them, so nothing in this job used to fail on a type error. Runs before
+      # the tests to fail fast on the cheaper check.
+      - name: Run typecheck
+        run: pnpm --filter @kandev/web typecheck
+
       # Unlike the eslint literal-string guard (scoped to already-migrated paths
       # via i18nGuardFiles), these four checks scan components/app/hooks/lib
       # repo-wide. Each one pins a class of i18n bug that fails silently at

--- a/apps/web/components/app-sidebar/sections/settings/settings-tree-render.test.tsx
+++ b/apps/web/components/app-sidebar/sections/settings/settings-tree-render.test.tsx
@@ -225,8 +225,11 @@ describe("Workspace settings order", () => {
 
     expect(automationsIndex).toBeGreaterThanOrEqual(0);
     expect(secretsIndex).toBeGreaterThan(automationsIndex);
-    expect(screen.getByRole("link", { name: "Secrets", exact: true })).toBeTruthy();
-    expect(screen.queryByRole("link", { name: "Workspace Secrets", exact: true })).toBeNull();
+    // Anchored so the leaf must be labelled exactly "Secrets" — a rename to
+    // "Workspace Secrets" has to fail here. `ByRoleOptions` has no `exact`
+    // flag; a RegExp is how ByRole expresses a strict accessible-name match.
+    expect(screen.getByRole("link", { name: /^Secrets$/ })).toBeTruthy();
+    expect(screen.queryByRole("link", { name: /^Workspace Secrets$/ })).toBeNull();
   });
 });
 

--- a/apps/web/components/vcs/vcs-dialogs.tsx
+++ b/apps/web/components/vcs/vcs-dialogs.tsx
@@ -369,7 +369,10 @@ export function pickRepoLabel(
   scopedRepo: string,
   isMultiRepo: boolean,
   resolveDisplayName: (name: string) => string | undefined,
-  t: ReturnType<typeof useTranslation>["t"],
+  // Structural, matching the other translate-taking helpers in the app: this
+  // only ever looks a key up, so both the hook's `t` and the module-level one
+  // from `@/lib/i18n` qualify. The branded `TFunction` excluded the latter.
+  t: (key: string) => string,
 ): string {
   if (scopedRepo) return resolveDisplayName(scopedRepo) || scopedRepo;
   if (isMultiRepo) return t("integrations:allRepos");


### PR DESCRIPTION
Type errors have never been able to fail this repo's CI: `frontend-tests.yml` ends in `vite build`, and Vite strips types with esbuild without checking them, so `tsc` has never run in the pipeline. Two real type errors had already landed on `main` unnoticed as a result — this fixes them and adds `typecheck` as a gating step so the next one cannot.

## Important Changes

- **`Run typecheck` step** in `frontend-tests.yml`, after lint and before the i18n checks and tests, so the cheap check fails first. Nothing scoped types out — `apps/web/tsconfig.json` already includes all `.ts`/`.tsx`/`.mts` and excludes only `node_modules` and `e2e`; the job simply never invoked `tsc`.
- **Two pre-existing errors fixed** in `settings-tree-render.test.tsx`. Both passed `exact: true` inside `ByRoleOptions`, which `@testing-library/dom` v10 does not have (`TS2769`). The flag was also a **runtime no-op**: `queryAllByRole` filters accessible names through the exact `matches` helper and never threads an `exact` option, so the strictness the flag asked for was already the default. Replaced with anchored regexes — `{ name: /^Secrets$/ }` and `{ name: /^Workspace Secrets$/ }` — which is how `ByRole` expresses a strict accessible-name match, keeping the intent visible in the code rather than deleting it.
- **Seven more errors, caught by the gate itself.** Those two were the whole backlog at this branch's fork point. #2302 then merged to `main` mid-review and added `components/vcs/vcs-dialogs.test.ts`, which fails to compile — it went green precisely because typecheck was not yet gating. `pickRepoLabel` typed its `t` parameter as the branded `ReturnType<typeof useTranslation>["t"]`, so the module-level plain `t` from `@/lib/i18n` that the test passes is not assignable (`$TFunctionBrand` missing, `TS2345` ×7). That was the **only** branded translate parameter in the repo; 14+ other translate-taking helpers already use structural `t: (key: string) => string`, which is all `pickRepoLabel` ever needs. Widened to match the convention, with the test left untouched.

No `@ts-expect-error`, no `any`, no casts, no `tsconfig.json` change, and no new scripts — `apps/web` already had a correct `typecheck` script (`tsc --noEmit`).

## Validation

The assertion still has teeth, verified by mutation rather than assumption: temporarily relabelling the sidebar leaf to `Workspace ${t("settings:secrets")}` fails the test with `Unable to find an accessible element with the role "link" and name /^Secrets$/`, then passes again on revert.

The gate has now also been proven in CI rather than only locally: the first push of this branch went **red on its own new step**, catching the `vcs-dialogs.test.ts` regression that had just landed on `main`. It worked within an hour of existing, on someone else's change.

The gate was additionally verified to fail on demand, not just to exist. With a deliberate type error added (`export const deliberatelyBroken: number = "not a number";`), the exact CI command exits non-zero:

```
$ pnpm --filter @kandev/web typecheck
lib/__typecheck_gate_probe.ts(1,14): error TS2322: Type 'string' is not assignable to type 'number'.
→ exit 2
```

and returns to exit 0 once the probe file is removed.

Commands run locally on Node 24:

- `pnpm --filter @kandev/web typecheck` — exit 0, no errors anywhere in the tree, rebased on current `main`
- `pnpm lint --max-warnings 0` — clean
- `pnpm test` — full web suite, 9090 passed. Four unrelated files timed out on a memory-starved local box and pass in isolation (`workflow-card-dialogs`, `git-base`, `codemirror-code-editor.cursor`, `storage-confirmation-dialogs`); CI is the authority on those.
- `pnpm test components/vcs/ …/settings-tree-render.test.tsx` — 30 passed, covering both fixes
- `git diff --check` and `python3 .github/scripts/lint-action-pinning_test.py` — clean (9 tests OK)

## Possible Improvements

Low risk — the step is additive and the tree is clean as of this rebase. Two things worth knowing: it covers only `apps/web`, leaving `apps/cli` and `apps/packages` unchecked by this job; and since `main` is currently taking a stream of large i18n PRs, expect this gate to start failing in-flight branches that were written while nothing checked their types. That is the gate working, not the gate being wrong.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.