### PR TITLE
fix(acp): let Cursor sessions leave fast mode (parameterizedModelPicker)

### DIFF
--- a/apps/backend/internal/agent/runtime/lifecycle/profile_resolver.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/profile_resolver.go
@@ -7,7 +7,9 @@ import (
 	"fmt"
 
 	"github.com/kandev/kandev/internal/agent/registry"
+	"github.com/kandev/kandev/internal/agent/settings/models"
 	"github.com/kandev/kandev/internal/agent/settings/store"
+	"github.com/kandev/kandev/internal/agentctl/acpcompat"
 )
 
 // DeletedProfileError carries the soft-deleted profile's ID and name so the
@@ -60,6 +62,9 @@ func (r *StoreProfileResolver) ResolveProfile(ctx context.Context, profileID str
 	if err != nil {
 		return nil, fmt.Errorf("agent not found for profile: %w", err)
 	}
+	if err := r.migrateCursorProfile(ctx, profile, agent); err != nil {
+		return nil, err
+	}
 
 	// Resolve agent capabilities from the registry.
 	model, nativeSessionResume := r.resolveAgentCapabilities(agent.Name, profile.Model)
@@ -82,6 +87,30 @@ func (r *StoreProfileResolver) ResolveProfile(ctx context.Context, profileID str
 		NativeSessionResume:        nativeSessionResume,
 		SupportsMCP:                agent.SupportsMCP,
 	}, nil
+}
+
+func (r *StoreProfileResolver) migrateCursorProfile(
+	ctx context.Context,
+	profile *models.AgentProfile,
+	agent *models.Agent,
+) error {
+	if profile == nil || agent == nil {
+		return nil
+	}
+	agentID := agent.Name
+	if agentID == "" {
+		agentID = agent.ID
+	}
+	model, options, changed := acpcompat.MigrateCursorModel(agentID, profile.Model, profile.ConfigOptions)
+	if !changed {
+		return nil
+	}
+	profile.Model = model
+	profile.ConfigOptions = options
+	if err := r.store.UpdateAgentProfile(ctx, profile); err != nil {
+		return fmt.Errorf("migrate Cursor profile %q: %w", profile.ID, err)
+	}
+	return nil
 }
 
 // checkSoftDeleted returns a *DeletedProfileError when the missing-row error

--- a/apps/backend/internal/agent/runtime/lifecycle/profile_resolver_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/profile_resolver_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kandev/kandev/internal/agent/registry"
 	"github.com/kandev/kandev/internal/agent/settings/models"
 	"github.com/kandev/kandev/internal/agent/settings/store"
+	"github.com/kandev/kandev/internal/agentctl/acpcompat"
 	"github.com/kandev/kandev/internal/common/logger"
 )
 
@@ -24,6 +25,7 @@ type MockRepository struct {
 	ListAgentsFn                      func(ctx context.Context) ([]*models.Agent, error)
 	ListAgentProfilesFn               func(ctx context.Context, agentID string) ([]*models.AgentProfile, error)
 	HasDeletedAgentProfilesFn         func(ctx context.Context, agentID string) (bool, error)
+	updateAgentProfileFn              func(ctx context.Context, profile *models.AgentProfile) error
 }
 
 var _ store.Repository = (*MockRepository)(nil)
@@ -74,6 +76,9 @@ func (m *MockRepository) CreateAgentProfile(ctx context.Context, profile *models
 }
 
 func (m *MockRepository) UpdateAgentProfile(ctx context.Context, profile *models.AgentProfile) error {
+	if m.updateAgentProfileFn != nil {
+		return m.updateAgentProfileFn(ctx, profile)
+	}
 	return nil
 }
 
@@ -185,6 +190,53 @@ func TestStoreProfileResolver_ResolveProfile_Success(t *testing.T) {
 	}
 	if info.DangerouslySkipPermissions != false {
 		t.Error("expected DangerouslySkipPermissions to be false")
+	}
+}
+
+func TestStoreProfileResolver_MigratesCursorVariantModel(t *testing.T) {
+	profile := &models.AgentProfile{
+		ID:      "profile-cursor",
+		AgentID: "agent-cursor",
+		Model:   "grok-4.5[effort=high,fast=true]",
+		ConfigOptions: map[string]string{
+			"effort": "low",
+		},
+	}
+	var updated *models.AgentProfile
+	mockRepo := &MockRepository{
+		GetAgentProfileFn: func(context.Context, string) (*models.AgentProfile, error) {
+			return profile, nil
+		},
+		GetAgentFn: func(context.Context, string) (*models.Agent, error) {
+			return &models.Agent{ID: "agent-cursor", Name: acpcompat.CursorAgentID}, nil
+		},
+	}
+	// Capture the write without changing the profile returned by the fake read.
+	mockRepo.updateAgentProfileFn = func(_ context.Context, got *models.AgentProfile) error {
+		updated = got
+		return nil
+	}
+
+	resolver := NewStoreProfileResolver(mockRepo, nil)
+	info, err := resolver.ResolveProfile(context.Background(), profile.ID)
+	if err != nil {
+		t.Fatalf("ResolveProfile: %v", err)
+	}
+
+	if info.Model != "grok-4.5" {
+		t.Fatalf("resolved model = %q, want bare Cursor model", info.Model)
+	}
+	if got := info.ConfigOptions["effort"]; got != "low" {
+		t.Errorf("resolved effort = %q, want existing profile value low", got)
+	}
+	if got := info.ConfigOptions["fast"]; got != "true" {
+		t.Errorf("resolved fast = %q, want migrated value true", got)
+	}
+	if updated == nil {
+		t.Fatal("expected migrated profile to be persisted")
+	}
+	if updated.Model != "grok-4.5" || updated.ConfigOptions["fast"] != "true" {
+		t.Fatalf("persisted profile = %+v, want bare model and fast option", updated)
 	}
 }
 

--- a/apps/backend/internal/agent/settings/controller/reconciler.go
+++ b/apps/backend/internal/agent/settings/controller/reconciler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kandev/kandev/internal/agent/registry"
 	"github.com/kandev/kandev/internal/agent/settings/models"
 	"github.com/kandev/kandev/internal/agent/settings/store"
+	"github.com/kandev/kandev/internal/agentctl/acpcompat"
 	"github.com/kandev/kandev/internal/common/logger"
 )
 
@@ -306,7 +307,7 @@ func (r *ProfileReconciler) reconcileAgent(ctx context.Context, ag agents.Agent)
 	}
 
 	for _, p := range profiles {
-		r.healProfile(ctx, p, caps)
+		r.healProfile(ctx, p, caps, ag.ID())
 	}
 }
 
@@ -374,8 +375,18 @@ func (r *ProfileReconciler) healProfile(
 	ctx context.Context,
 	p *models.AgentProfile,
 	caps hostutility.AgentCapabilities,
+	agentID string,
 ) {
 	changed := healProfileName(p, caps)
+	if model, options, migrated := acpcompat.MigrateCursorModel(agentID, p.Model, p.ConfigOptions); migrated {
+		r.log.Info("migrating Cursor variant profile model",
+			zap.String("profile_id", p.ID),
+			zap.String("old_model", p.Model),
+			zap.String("new_model", model))
+		p.Model = model
+		p.ConfigOptions = options
+		changed = true
+	}
 
 	if p.Model != "" && !modelExists(p.Model, caps.Models) {
 		r.log.Info("profile model no longer available, auto-healing",

--- a/apps/backend/internal/agent/settings/controller/reconciler_test.go
+++ b/apps/backend/internal/agent/settings/controller/reconciler_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kandev/kandev/internal/agent/registry"
 	"github.com/kandev/kandev/internal/agent/settings/models"
 	"github.com/kandev/kandev/internal/agent/usage"
+	"github.com/kandev/kandev/internal/agentctl/acpcompat"
 	"github.com/kandev/kandev/internal/common/logger"
 )
 
@@ -729,5 +730,52 @@ func TestSyncAgentFromDiscovery_SeedsFreshAgent(t *testing.T) {
 	}
 	if len(st.created) != 1 {
 		t.Fatalf("expected fresh agent to be seeded, got %d created", len(st.created))
+	}
+}
+
+func TestProfileReconciler_MigratesCursorVariantModel(t *testing.T) {
+	st := newFakeStore()
+	ag := &mockInferenceAgent{id: acpcompat.CursorAgentID, displayName: "Cursor", enabled: true}
+	dbAgent := &models.Agent{Name: acpcompat.CursorAgentID}
+	if err := st.CreateAgent(context.Background(), dbAgent); err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+	profile := &models.AgentProfile{
+		AgentID: dbAgent.ID,
+		Name:    "Grok",
+		Model:   "grok-4.5[effort=high,fast=true]",
+		ConfigOptions: map[string]string{
+			"effort": "low",
+		},
+	}
+	if err := st.CreateAgentProfile(context.Background(), profile); err != nil {
+		t.Fatalf("create profile: %v", err)
+	}
+	st.updated = nil
+
+	caps := &fakeCapReader{caps: map[string]hostutility.AgentCapabilities{
+		acpcompat.CursorAgentID: {
+			AgentType:      acpcompat.CursorAgentID,
+			Status:         hostutility.StatusOK,
+			Models:         []hostutility.Model{{ID: "grok-4.5"}},
+			CurrentModelID: "grok-4.5",
+		},
+	}}
+	r := newReconciler(t, st, caps, ag)
+	if err := r.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if profile.Model != "grok-4.5" {
+		t.Fatalf("profile model = %q, want bare Cursor model", profile.Model)
+	}
+	if got := profile.ConfigOptions["effort"]; got != "low" {
+		t.Errorf("profile effort = %q, want existing profile value low", got)
+	}
+	if got := profile.ConfigOptions["fast"]; got != "true" {
+		t.Errorf("profile fast = %q, want migrated value true", got)
+	}
+	if len(st.updated) == 0 {
+		t.Fatal("expected migrated profile to be persisted")
 	}
 }

--- a/apps/backend/internal/agentctl/acpcompat/cursor.go
+++ b/apps/backend/internal/agentctl/acpcompat/cursor.go
@@ -1,0 +1,53 @@
+package acpcompat
+
+const (
+	CursorAgentID = "cursor-acp"
+
+	// ParameterizedModelPickerMetaKey opts the client into cursor-agent's
+	// "parameterized" model picker. cursor-agent decides its picker mode once,
+	// from the initialize handshake, and the choice is not renegotiable later:
+	//
+	//	absent  -> "variants" mode. Models are advertised as exploded strings
+	//	           ("grok-4.5[effort=high,fast=true]") and the per-model
+	//	           parameters are baked in. Cursor pins grok-4.5 and
+	//	           composer-2.5 to fast=true there and offers no other row, so
+	//	           those two models can only be run at the fast tier —
+	//	           session/set_model rejects any value that is not on the
+	//	           advertised list.
+	//	present -> "parameterized" mode. Models are advertised as bare ids
+	//	           ("grok-4.5") and their parameters become ordinary session
+	//	           config options ("effort", "fast"), settable through
+	//	           session/set_config_option like any other agent's knobs.
+	//
+	// Advertising this is what makes a regular-tier Cursor session expressible.
+	// Zed carries the same opt-in for the same reason (zed-industries/zed#59694).
+	//
+	// The two modes advertise disjoint model ids, which makes the pin the
+	// backstop: a profile pinned to bare "grok-4.5" cannot match anything in
+	// variants mode, so if this opt-in ever stops taking effect the fail-closed
+	// SetModel in the lifecycle session manager refuses to start the session
+	// instead of quietly running it at the fast tier.
+	ParameterizedModelPickerMetaKey = "parameterizedModelPicker"
+)
+
+// ClientCapabilityMeta builds the ACP `_meta` map a Kandev client advertises to
+// one agent.
+//
+// This lives here, rather than next to either caller, because the picker mode
+// must be identical on BOTH ACP entry points: the live session adapter and the
+// host-utility capability probe. They are separate handshakes, and when only
+// one of them opted in, the agent-models surface advertised the exploded
+// fast=true rows while sessions ran on the bare ids — a model id the UI could
+// not offer and the probe could not validate.
+//
+// base is copied, never mutated, so callers can pass a shared literal.
+func ClientCapabilityMeta(agentID string, base map[string]any) map[string]any {
+	meta := make(map[string]any, len(base)+1)
+	for k, v := range base {
+		meta[k] = v
+	}
+	if agentID == CursorAgentID {
+		meta[ParameterizedModelPickerMetaKey] = true
+	}
+	return meta
+}

--- a/apps/backend/internal/agentctl/acpcompat/cursor.go
+++ b/apps/backend/internal/agentctl/acpcompat/cursor.go
@@ -1,5 +1,7 @@
 package acpcompat
 
+import "strings"
+
 const (
 	CursorAgentID = "cursor-acp"
 
@@ -22,11 +24,11 @@ const (
 	// Advertising this is what makes a regular-tier Cursor session expressible.
 	// Zed carries the same opt-in for the same reason (zed-industries/zed#59694).
 	//
-	// The two modes advertise disjoint model ids, which makes the pin the
-	// backstop: a profile pinned to bare "grok-4.5" cannot match anything in
-	// variants mode, so if this opt-in ever stops taking effect the fail-closed
-	// SetModel in the lifecycle session manager refuses to start the session
-	// instead of quietly running it at the fast tier.
+	// The two modes advertise disjoint model ids. Existing variant IDs are
+	// migrated to the bare model plus config options before the opt-in is used,
+	// while the fail-closed SetModel in the lifecycle session manager prevents a
+	// bare profile from silently running at the fast tier if the opt-in stops
+	// taking effect.
 	ParameterizedModelPickerMetaKey = "parameterizedModelPicker"
 )
 
@@ -34,11 +36,11 @@ const (
 // one agent.
 //
 // This lives here, rather than next to either caller, because the picker mode
-// must be identical on BOTH ACP entry points: the live session adapter and the
-// host-utility capability probe. They are separate handshakes, and when only
-// one of them opted in, the agent-models surface advertised the exploded
-// fast=true rows while sessions ran on the bare ids — a model id the UI could
-// not offer and the probe could not validate.
+// must be identical across all three ACP handshake consumers: the live session
+// adapter, the host-utility capability probe, and one-shot inference. They are
+// separate handshakes, and when only one of them opted in, the agent-models
+// surface advertised the exploded fast=true rows while sessions ran on the
+// bare ids — a model id the UI could not offer and the probe could not validate.
 //
 // base is copied, never mutated, so callers can pass a shared literal.
 func ClientCapabilityMeta(agentID string, base map[string]any) map[string]any {
@@ -50,4 +52,67 @@ func ClientCapabilityMeta(agentID string, base map[string]any) map[string]any {
 		meta[ParameterizedModelPickerMetaKey] = true
 	}
 	return meta
+}
+
+// ParseVariantModelID splits a legacy Cursor model ID into its bare model ID
+// and encoded session config options. Cursor's variants picker used IDs such
+// as "grok-4.5[effort=high,fast=true]"; parameterized picker mode advertises
+// "grok-4.5" and exposes those values as separate config options.
+//
+// Invalid or ambiguous IDs are returned unchanged so callers fail closed
+// rather than guessing at a model or option value.
+func ParseVariantModelID(modelID string) (string, map[string]string, bool) {
+	open := strings.LastIndexByte(modelID, '[')
+	if open <= 0 || !strings.HasSuffix(modelID, "]") {
+		return modelID, nil, false
+	}
+	encoded := strings.TrimSpace(modelID[open+1 : len(modelID)-1])
+	if encoded == "" {
+		return modelID, nil, false
+	}
+
+	options := make(map[string]string)
+	for _, part := range strings.Split(encoded, ",") {
+		key, value, ok := strings.Cut(part, "=")
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if !ok || key == "" || value == "" {
+			return modelID, nil, false
+		}
+		if _, exists := options[key]; exists {
+			return modelID, nil, false
+		}
+		options[key] = value
+	}
+
+	return modelID[:open], options, true
+}
+
+// MigrateCursorModel converts a legacy Cursor variant ID to the parameterized
+// picker representation. Existing config options win over values encoded in
+// the old ID so a later explicit profile edit is not overwritten. The input
+// map is never mutated.
+func MigrateCursorModel(
+	agentID string,
+	modelID string,
+	configOptions map[string]string,
+) (string, map[string]string, bool) {
+	if agentID != CursorAgentID {
+		return modelID, configOptions, false
+	}
+	bareModelID, variantOptions, ok := ParseVariantModelID(modelID)
+	if !ok {
+		return modelID, configOptions, false
+	}
+
+	merged := make(map[string]string, len(configOptions)+len(variantOptions))
+	for key, value := range configOptions {
+		merged[key] = value
+	}
+	for key, value := range variantOptions {
+		if _, exists := merged[key]; !exists {
+			merged[key] = value
+		}
+	}
+	return bareModelID, merged, true
 }

--- a/apps/backend/internal/agentctl/acpcompat/cursor_test.go
+++ b/apps/backend/internal/agentctl/acpcompat/cursor_test.go
@@ -1,6 +1,9 @@
 package acpcompat
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func TestClientCapabilityMeta_CursorGetsParameterizedPicker(t *testing.T) {
 	meta := ClientCapabilityMeta(CursorAgentID, map[string]any{"terminal_output": true})
@@ -52,5 +55,55 @@ func TestClientCapabilityMeta_DoesNotMutateBase(t *testing.T) {
 	}
 	if len(base) != 1 {
 		t.Errorf("base map grew: %v", base)
+	}
+}
+
+func TestParseVariantModelID(t *testing.T) {
+	model, options, ok := ParseVariantModelID("grok-4.5[effort=high,fast=true]")
+	if !ok {
+		t.Fatal("ParseVariantModelID returned ok=false")
+	}
+	if model != "grok-4.5" {
+		t.Errorf("model = %q, want grok-4.5", model)
+	}
+	want := map[string]string{"effort": "high", "fast": "true"}
+	if !reflect.DeepEqual(options, want) {
+		t.Errorf("options = %#v, want %#v", options, want)
+	}
+}
+
+func TestParseVariantModelID_RejectsMalformedIDs(t *testing.T) {
+	for _, model := range []string{
+		"grok-4.5",
+		"grok-4.5[]",
+		"grok-4.5[fast]",
+		"grok-4.5[fast=true,fast=false]",
+		"[fast=true]",
+	} {
+		t.Run(model, func(t *testing.T) {
+			gotModel, gotOptions, ok := ParseVariantModelID(model)
+			if ok || gotModel != model || gotOptions != nil {
+				t.Fatalf("ParseVariantModelID(%q) = (%q, %#v, %v), want unchanged and false",
+					model, gotModel, gotOptions, ok)
+			}
+		})
+	}
+}
+
+func TestMigrateCursorModel_PreservesExplicitOptions(t *testing.T) {
+	existing := map[string]string{"effort": "low"}
+	model, options, changed := MigrateCursorModel(
+		CursorAgentID,
+		"grok-4.5[effort=high,fast=true]",
+		existing,
+	)
+	if !changed || model != "grok-4.5" {
+		t.Fatalf("MigrateCursorModel() = (%q, %#v, %v), want migrated model", model, options, changed)
+	}
+	if options["effort"] != "low" || options["fast"] != "true" {
+		t.Errorf("options = %#v, want explicit effort and migrated fast", options)
+	}
+	if _, ok := existing["fast"]; ok {
+		t.Error("MigrateCursorModel mutated the input options")
 	}
 }

--- a/apps/backend/internal/agentctl/acpcompat/cursor_test.go
+++ b/apps/backend/internal/agentctl/acpcompat/cursor_test.go
@@ -1,0 +1,56 @@
+package acpcompat
+
+import "testing"
+
+func TestClientCapabilityMeta_CursorGetsParameterizedPicker(t *testing.T) {
+	meta := ClientCapabilityMeta(CursorAgentID, map[string]any{"terminal_output": true})
+
+	if meta[ParameterizedModelPickerMetaKey] != true {
+		t.Errorf("meta[%q] = %v, want true (meta: %v)",
+			ParameterizedModelPickerMetaKey, meta[ParameterizedModelPickerMetaKey], meta)
+	}
+	if meta["terminal_output"] != true {
+		t.Errorf("base entries dropped: meta = %v", meta)
+	}
+}
+
+func TestClientCapabilityMeta_OtherAgentsUnchanged(t *testing.T) {
+	for _, agentID := range []string{"claude-acp", "codex-acp", GrokAgentID, "opencode-acp", ""} {
+		meta := ClientCapabilityMeta(agentID, map[string]any{"terminal_output": true})
+		if _, ok := meta[ParameterizedModelPickerMetaKey]; ok {
+			t.Errorf("%q carries %q; it is Cursor-only (meta: %v)",
+				agentID, ParameterizedModelPickerMetaKey, meta)
+		}
+		if meta["terminal_output"] != true {
+			t.Errorf("%q: base entries dropped: meta = %v", agentID, meta)
+		}
+	}
+}
+
+// The probe passes nil, so a nil base must still produce a usable map rather
+// than panicking or returning a nil the caller writes into.
+func TestClientCapabilityMeta_NilBase(t *testing.T) {
+	meta := ClientCapabilityMeta(CursorAgentID, nil)
+	if meta[ParameterizedModelPickerMetaKey] != true {
+		t.Errorf("nil base lost the picker opt-in: %v", meta)
+	}
+
+	if got := ClientCapabilityMeta("claude-acp", nil); len(got) != 0 {
+		t.Errorf("non-cursor with nil base = %v, want empty", got)
+	}
+}
+
+// Callers pass shared literals; mutating one agent's meta must not leak into
+// the next agent's handshake.
+func TestClientCapabilityMeta_DoesNotMutateBase(t *testing.T) {
+	base := map[string]any{"terminal_output": true}
+
+	ClientCapabilityMeta(CursorAgentID, base)
+
+	if _, ok := base[ParameterizedModelPickerMetaKey]; ok {
+		t.Errorf("base map was mutated: %v", base)
+	}
+	if len(base) != 1 {
+		t.Errorf("base map grew: %v", base)
+	}
+}

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/coder/acp-go-sdk"
+	"github.com/kandev/kandev/internal/agentctl/acpcompat"
 	acpclient "github.com/kandev/kandev/internal/agentctl/server/acp"
 	"github.com/kandev/kandev/internal/agentctl/server/adapter/transport/shared"
 	"github.com/kandev/kandev/internal/agentctl/types"
@@ -44,6 +45,21 @@ const (
 	// by ACP agents to surface the active model as a selectable option.
 	configOptionIDModel = "model"
 )
+
+const (
+	cursorAgentID                   = acpcompat.CursorAgentID
+	parameterizedModelPickerMetaKey = acpcompat.ParameterizedModelPickerMetaKey
+)
+
+// clientCapabilitiesForAgent builds the ACP client capabilities for one agent.
+// The meta map is agent-scoped because cursor-agent reads it to choose a model
+// picker mode (see acpcompat.ClientCapabilityMeta); every other agent sees the
+// capabilities kandev has always sent.
+func clientCapabilitiesForAgent(agentID string) acp.ClientCapabilities {
+	return acp.ClientCapabilities{
+		Meta: acpcompat.ClientCapabilityMeta(agentID, map[string]any{"terminal_output": true}),
+	}
+}
 
 // wakeupPromptTimeout bounds how long a synthetic wakeup prompt can run.
 // Wakeup turns can perform real work (the model often runs a few tool calls
@@ -413,9 +429,7 @@ func (a *Adapter) Initialize(ctx context.Context) error {
 
 	resp, err := a.acpConn.Initialize(ctx, acp.InitializeRequest{
 		ProtocolVersion: acp.ProtocolVersionNumber,
-		ClientCapabilities: acp.ClientCapabilities{
-			Meta: map[string]any{"terminal_output": true},
-		},
+		ClientCapabilities: clientCapabilitiesForAgent(a.agentID),
 		ClientInfo: &acp.Implementation{
 			Name:    "kandev-agentctl",
 			Version: "1.0.0",

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/coder/acp-go-sdk"
-	"github.com/kandev/kandev/internal/agentctl/acpcompat"
 	acpclient "github.com/kandev/kandev/internal/agentctl/server/acp"
 	"github.com/kandev/kandev/internal/agentctl/server/adapter/transport/shared"
 	"github.com/kandev/kandev/internal/agentctl/types"
@@ -45,21 +44,6 @@ const (
 	// by ACP agents to surface the active model as a selectable option.
 	configOptionIDModel = "model"
 )
-
-const (
-	cursorAgentID                   = acpcompat.CursorAgentID
-	parameterizedModelPickerMetaKey = acpcompat.ParameterizedModelPickerMetaKey
-)
-
-// clientCapabilitiesForAgent builds the ACP client capabilities for one agent.
-// The meta map is agent-scoped because cursor-agent reads it to choose a model
-// picker mode (see acpcompat.ClientCapabilityMeta); every other agent sees the
-// capabilities kandev has always sent.
-func clientCapabilitiesForAgent(agentID string) acp.ClientCapabilities {
-	return acp.ClientCapabilities{
-		Meta: acpcompat.ClientCapabilityMeta(agentID, map[string]any{"terminal_output": true}),
-	}
-}
 
 // wakeupPromptTimeout bounds how long a synthetic wakeup prompt can run.
 // Wakeup turns can perform real work (the model often runs a few tool calls
@@ -428,7 +412,7 @@ func (a *Adapter) Initialize(ctx context.Context) error {
 	defer span.End()
 
 	resp, err := a.acpConn.Initialize(ctx, acp.InitializeRequest{
-		ProtocolVersion: acp.ProtocolVersionNumber,
+		ProtocolVersion:    acp.ProtocolVersionNumber,
 		ClientCapabilities: clientCapabilitiesForAgent(a.agentID),
 		ClientInfo: &acp.Implementation{
 			Name:    "kandev-agentctl",

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_client_capabilities_test.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_client_capabilities_test.go
@@ -1,0 +1,126 @@
+package acp
+
+import (
+	"context"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/coder/acp-go-sdk"
+	"github.com/kandev/kandev/internal/agentctl/server/adapter/transport/shared"
+	"github.com/kandev/kandev/internal/common/logger"
+)
+
+// initCaptureAgent records the InitializeRequest it was handed so a test can
+// assert on what actually crossed the wire, not just on what a helper returned.
+type initCaptureAgent struct {
+	burstAgent
+	mu  sync.Mutex
+	req acp.InitializeRequest
+}
+
+func (a *initCaptureAgent) Initialize(_ context.Context, req acp.InitializeRequest) (acp.InitializeResponse, error) {
+	a.mu.Lock()
+	a.req = req
+	a.mu.Unlock()
+	return acp.InitializeResponse{ProtocolVersion: req.ProtocolVersion}, nil
+}
+
+func (a *initCaptureAgent) captured() acp.InitializeRequest {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.req
+}
+
+func newTestAdapterForAgent(agentID string) *Adapter {
+	log, _ := logger.NewLogger(logger.LoggingConfig{
+		Level:      "error",
+		Format:     "json",
+		OutputPath: "stderr",
+	})
+	return NewAdapter(&shared.Config{AgentID: agentID, WorkDir: "/tmp/test"}, log)
+}
+
+// handshakeMeta runs a real Initialize against a fake agent over pipes and
+// returns the client capability meta the agent received.
+func handshakeMeta(t *testing.T, agentID string) map[string]any {
+	t.Helper()
+
+	a := newTestAdapterForAgent(agentID)
+	c2aR, c2aW := io.Pipe()
+	a2cR, a2cW := io.Pipe()
+	t.Cleanup(func() {
+		_ = a.Close()
+		_ = c2aR.Close()
+		_ = c2aW.Close()
+		_ = a2cR.Close()
+		_ = a2cW.Close()
+	})
+	if err := a.Connect(c2aW, a2cR); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	fake := &initCaptureAgent{}
+	acp.NewAgentSideConnection(fake, a2cW, c2aR)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := a.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	drainEvents(a)
+
+	return fake.captured().ClientCapabilities.Meta
+}
+
+// Cursor decides its model picker mode from this one key, and it decides once
+// per session. Without it a Cursor session is locked to the exploded
+// fast=true model rows and cannot run at the regular tier.
+func TestInitialize_AdvertisesParameterizedModelPickerToCursor(t *testing.T) {
+	meta := handshakeMeta(t, cursorAgentID)
+
+	if got := meta[parameterizedModelPickerMetaKey]; got != true {
+		t.Fatalf("cursor handshake meta[%q] = %v, want true (meta: %v)",
+			parameterizedModelPickerMetaKey, got, meta)
+	}
+	if got := meta["terminal_output"]; got != true {
+		t.Errorf("cursor handshake dropped terminal_output: meta = %v", meta)
+	}
+}
+
+// The opt-in is Cursor-specific: no other agent's handshake may change shape,
+// since an unrecognized meta key is at best ignored and at worst a behavior
+// change we did not ask for.
+func TestInitialize_LeavesOtherAgentsHandshakeUnchanged(t *testing.T) {
+	for _, agentID := range []string{"claude-acp", codexAgentID, grokAgentID, "opencode-acp"} {
+		t.Run(agentID, func(t *testing.T) {
+			meta := handshakeMeta(t, agentID)
+
+			if _, ok := meta[parameterizedModelPickerMetaKey]; ok {
+				t.Errorf("%s handshake carries %q; it is Cursor-only (meta: %v)",
+					agentID, parameterizedModelPickerMetaKey, meta)
+			}
+			if got := meta["terminal_output"]; got != true {
+				t.Errorf("%s handshake meta = %v, want terminal_output true", agentID, meta)
+			}
+		})
+	}
+}
+
+func TestClientCapabilitiesForAgent(t *testing.T) {
+	cursor := clientCapabilitiesForAgent(cursorAgentID)
+	if cursor.Meta[parameterizedModelPickerMetaKey] != true {
+		t.Errorf("cursor meta = %v, want %q true", cursor.Meta, parameterizedModelPickerMetaKey)
+	}
+
+	other := clientCapabilitiesForAgent("claude-acp")
+	if _, ok := other.Meta[parameterizedModelPickerMetaKey]; ok {
+		t.Errorf("non-cursor meta = %v, want no %q", other.Meta, parameterizedModelPickerMetaKey)
+	}
+
+	// Distinct maps per call: a shared map would let one agent's session leak
+	// the key into another's handshake.
+	if &cursor.Meta == &other.Meta {
+		t.Error("clientCapabilitiesForAgent returned a shared meta map")
+	}
+}

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_client_capabilities_test.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_client_capabilities_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/coder/acp-go-sdk"
+	"github.com/kandev/kandev/internal/agentctl/acpcompat"
 	"github.com/kandev/kandev/internal/agentctl/server/adapter/transport/shared"
 	"github.com/kandev/kandev/internal/common/logger"
 )
@@ -77,11 +78,11 @@ func handshakeMeta(t *testing.T, agentID string) map[string]any {
 // per session. Without it a Cursor session is locked to the exploded
 // fast=true model rows and cannot run at the regular tier.
 func TestInitialize_AdvertisesParameterizedModelPickerToCursor(t *testing.T) {
-	meta := handshakeMeta(t, cursorAgentID)
+	meta := handshakeMeta(t, acpcompat.CursorAgentID)
 
-	if got := meta[parameterizedModelPickerMetaKey]; got != true {
+	if got := meta[acpcompat.ParameterizedModelPickerMetaKey]; got != true {
 		t.Fatalf("cursor handshake meta[%q] = %v, want true (meta: %v)",
-			parameterizedModelPickerMetaKey, got, meta)
+			acpcompat.ParameterizedModelPickerMetaKey, got, meta)
 	}
 	if got := meta["terminal_output"]; got != true {
 		t.Errorf("cursor handshake dropped terminal_output: meta = %v", meta)
@@ -96,9 +97,9 @@ func TestInitialize_LeavesOtherAgentsHandshakeUnchanged(t *testing.T) {
 		t.Run(agentID, func(t *testing.T) {
 			meta := handshakeMeta(t, agentID)
 
-			if _, ok := meta[parameterizedModelPickerMetaKey]; ok {
+			if _, ok := meta[acpcompat.ParameterizedModelPickerMetaKey]; ok {
 				t.Errorf("%s handshake carries %q; it is Cursor-only (meta: %v)",
-					agentID, parameterizedModelPickerMetaKey, meta)
+					agentID, acpcompat.ParameterizedModelPickerMetaKey, meta)
 			}
 			if got := meta["terminal_output"]; got != true {
 				t.Errorf("%s handshake meta = %v, want terminal_output true", agentID, meta)
@@ -108,19 +109,20 @@ func TestInitialize_LeavesOtherAgentsHandshakeUnchanged(t *testing.T) {
 }
 
 func TestClientCapabilitiesForAgent(t *testing.T) {
-	cursor := clientCapabilitiesForAgent(cursorAgentID)
-	if cursor.Meta[parameterizedModelPickerMetaKey] != true {
-		t.Errorf("cursor meta = %v, want %q true", cursor.Meta, parameterizedModelPickerMetaKey)
+	cursor := clientCapabilitiesForAgent(acpcompat.CursorAgentID)
+	if cursor.Meta[acpcompat.ParameterizedModelPickerMetaKey] != true {
+		t.Errorf("cursor meta = %v, want %q true", cursor.Meta, acpcompat.ParameterizedModelPickerMetaKey)
 	}
 
 	other := clientCapabilitiesForAgent("claude-acp")
-	if _, ok := other.Meta[parameterizedModelPickerMetaKey]; ok {
-		t.Errorf("non-cursor meta = %v, want no %q", other.Meta, parameterizedModelPickerMetaKey)
+	if _, ok := other.Meta[acpcompat.ParameterizedModelPickerMetaKey]; ok {
+		t.Errorf("non-cursor meta = %v, want no %q", other.Meta, acpcompat.ParameterizedModelPickerMetaKey)
 	}
 
 	// Distinct maps per call: a shared map would let one agent's session leak
 	// the key into another's handshake.
-	if &cursor.Meta == &other.Meta {
+	cursor.Meta["test_isolation"] = true
+	if _, ok := other.Meta["test_isolation"]; ok {
 		t.Error("clientCapabilitiesForAgent returned a shared meta map")
 	}
 }

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_helpers.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_helpers.go
@@ -5,8 +5,19 @@ import (
 	"strings"
 
 	"github.com/coder/acp-go-sdk"
+	"github.com/kandev/kandev/internal/agentctl/acpcompat"
 	v1 "github.com/kandev/kandev/pkg/api/v1"
 )
+
+// clientCapabilitiesForAgent builds the ACP client capabilities for one agent.
+// The meta map is agent-scoped because cursor-agent reads it to choose a model
+// picker mode (see acpcompat.ClientCapabilityMeta); every other agent sees the
+// capabilities kandev has always sent.
+func clientCapabilitiesForAgent(agentID string) acp.ClientCapabilities {
+	return acp.ClientCapabilities{
+		Meta: acpcompat.ClientCapabilityMeta(agentID, map[string]any{"terminal_output": true}),
+	}
+}
 
 // derefStr safely dereferences a pointer to a string or named string type,
 // returning empty string if nil.

--- a/apps/backend/internal/agentctl/server/utility/acp_executor.go
+++ b/apps/backend/internal/agentctl/server/utility/acp_executor.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -58,6 +59,7 @@ func (e *ACPInferenceExecutor) Execute(ctx context.Context, req *PromptRequest) 
 	if workDir == "" {
 		return &PromptResponse{Success: false, Error: "work_dir is required for ACP inference"}, nil
 	}
+	model, modelConfigOptions, _ := acpcompat.MigrateCursorModel(req.AgentID, req.Model, nil)
 	resolvedCmd := resolveProbeCommand(cfg.Command[0])
 	if resolvedCmd == "" {
 		return &PromptResponse{Success: false, Error: fmt.Sprintf("command %q is not an allowed ACP command", cfg.Command[0])}, nil
@@ -66,11 +68,11 @@ func (e *ACPInferenceExecutor) Execute(ctx context.Context, req *PromptRequest) 
 	startTime := time.Now()
 
 	// Build command with model flag
-	args := buildACPCommand(cfg, req.Model)
+	args := buildACPCommand(cfg, model)
 
 	e.logger.Info("starting ACP inference",
 		zap.String("agent_id", req.AgentID),
-		zap.String("model", req.Model),
+		zap.String("model", model),
 		zap.Strings("command", args))
 
 	// Use the hard-coded resolvedCmd (not args[0]) so CodeQL can see that
@@ -108,7 +110,7 @@ func (e *ACPInferenceExecutor) Execute(ctx context.Context, req *PromptRequest) 
 		e.logger.Warn("ACP inference: dropping unsupported MCP server transport",
 			zap.String("name", name))
 	}
-	response, err := e.executeACPSession(ctx, stdin, stdout, workDir, req.AgentID, req.Prompt, req.Model, req.Mode, mcpServers)
+	response, err := e.executeACPSession(ctx, stdin, stdout, workDir, req.AgentID, req.Prompt, model, modelConfigOptions, req.Mode, mcpServers)
 	if err != nil {
 		return &PromptResponse{
 			Success:    false,
@@ -120,7 +122,7 @@ func (e *ACPInferenceExecutor) Execute(ctx context.Context, req *PromptRequest) 
 	return &PromptResponse{
 		Success:    true,
 		Response:   response,
-		Model:      req.Model,
+		Model:      model,
 		DurationMs: int(time.Since(startTime).Milliseconds()),
 	}, nil
 }
@@ -138,6 +140,7 @@ func (e *ACPInferenceExecutor) executeACPSession(
 	agentID string,
 	prompt string,
 	model string,
+	modelConfigOptions map[string]string,
 	mode string,
 	mcpServers []acp.McpServer,
 ) (string, error) {
@@ -212,6 +215,9 @@ func (e *ACPInferenceExecutor) executeACPSession(
 			return "", fmt.Errorf("ACP model selection failed: %w", err)
 		}
 	}
+	if err := applySessionConfigOptions(ctx, conn, string(sessionID), modelConfigOptions); err != nil {
+		return "", fmt.Errorf("ACP model config selection failed: %w", err)
+	}
 
 	// Optionally set the session mode before prompting.
 	if mode != "" {
@@ -247,6 +253,29 @@ func applySessionModel(
 	configOptions []acp.SessionConfigOption,
 ) (sessionmodel.Method, error) {
 	return sessionmodel.ApplySDKFromACP(ctx, conn, string(sessionID), model, configOptions)
+}
+
+func applySessionConfigOptions(
+	ctx context.Context,
+	conn sessionmodel.SDKConn,
+	sessionID string,
+	options map[string]string,
+) error {
+	if len(options) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(options))
+	for key := range options {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	applier := sessionmodel.SDKApplier{Conn: conn}
+	for _, key := range keys {
+		if err := applier.SetConfigOption(ctx, sessionID, key, options[key]); err != nil {
+			return fmt.Errorf("set %q: %w", key, err)
+		}
+	}
+	return nil
 }
 
 // toACPMcpServers converts the cross-process DTO list into the ACP SDK shape.
@@ -521,11 +550,12 @@ func (e *ACPInferenceExecutor) probeACPSession(
 	conn := acp.NewClientSideConnection(client, stdin, stdout)
 	conn.SetLogger(slog.Default().With("component", "acp-probe"))
 
-	// Same client capabilities the live session adapter sends. cursor-agent
-	// picks its model picker mode from this handshake, so a probe that opts
-	// out reports the exploded fast=true model rows while sessions run on the
-	// bare ids — the agent-models surface would then offer a model list no
-	// session uses, and a model id the UI cannot select.
+	// Advertise the same model-picker capability the live session adapter sends.
+	// cursor-agent picks its model picker mode from this handshake, so a probe
+	// that opts out reports the exploded fast=true model rows while sessions run
+	// on the bare ids — the agent-models surface would then offer a model list no
+	// session uses, and a model id the UI cannot select. The probe intentionally
+	// omits the live adapter's terminal_output base capability.
 	initResp, err := conn.Initialize(ctx, acp.InitializeRequest{
 		ProtocolVersion: acp.ProtocolVersionNumber,
 		ClientCapabilities: acp.ClientCapabilities{

--- a/apps/backend/internal/agentctl/server/utility/acp_executor.go
+++ b/apps/backend/internal/agentctl/server/utility/acp_executor.go
@@ -108,7 +108,7 @@ func (e *ACPInferenceExecutor) Execute(ctx context.Context, req *PromptRequest) 
 		e.logger.Warn("ACP inference: dropping unsupported MCP server transport",
 			zap.String("name", name))
 	}
-	response, err := e.executeACPSession(ctx, stdin, stdout, workDir, req.Prompt, req.Model, req.Mode, mcpServers)
+	response, err := e.executeACPSession(ctx, stdin, stdout, workDir, req.AgentID, req.Prompt, req.Model, req.Mode, mcpServers)
 	if err != nil {
 		return &PromptResponse{
 			Success:    false,
@@ -135,6 +135,7 @@ func (e *ACPInferenceExecutor) executeACPSession(
 	stdin io.Writer,
 	stdout io.Reader,
 	workDir string,
+	agentID string,
 	prompt string,
 	model string,
 	mode string,
@@ -168,8 +169,16 @@ func (e *ACPInferenceExecutor) executeACPSession(
 	conn.SetLogger(slog.Default().With("component", "acp-inference"))
 
 	// Initialize ACP handshake
+	// Same client capabilities the session adapter and the probe send. This
+	// path applies a caller-supplied model below, and an agent that picks its
+	// model-picker mode from the handshake advertises a different id set per
+	// mode — so opting out here would reject the very model ids the rest of
+	// the product hands out.
 	_, err := conn.Initialize(ctx, acp.InitializeRequest{
 		ProtocolVersion: acp.ProtocolVersionNumber,
+		ClientCapabilities: acp.ClientCapabilities{
+			Meta: acpcompat.ClientCapabilityMeta(agentID, nil),
+		},
 		ClientInfo: &acp.Implementation{
 			Name:    "kandev-inference",
 			Version: "1.0.0",
@@ -512,8 +521,16 @@ func (e *ACPInferenceExecutor) probeACPSession(
 	conn := acp.NewClientSideConnection(client, stdin, stdout)
 	conn.SetLogger(slog.Default().With("component", "acp-probe"))
 
+	// Same client capabilities the live session adapter sends. cursor-agent
+	// picks its model picker mode from this handshake, so a probe that opts
+	// out reports the exploded fast=true model rows while sessions run on the
+	// bare ids — the agent-models surface would then offer a model list no
+	// session uses, and a model id the UI cannot select.
 	initResp, err := conn.Initialize(ctx, acp.InitializeRequest{
 		ProtocolVersion: acp.ProtocolVersionNumber,
+		ClientCapabilities: acp.ClientCapabilities{
+			Meta: acpcompat.ClientCapabilityMeta(agentID, nil),
+		},
 		ClientInfo: &acp.Implementation{
 			Name:    "kandev-probe",
 			Version: "1.0.0",

--- a/apps/backend/internal/agentctl/server/utility/acp_probe_capabilities_test.go
+++ b/apps/backend/internal/agentctl/server/utility/acp_probe_capabilities_test.go
@@ -125,7 +125,7 @@ func TestExecuteACPSession_AdvertisesParameterizedModelPickerToCursor(t *testing
 	defer cancel()
 
 	if _, err := e.executeACPSession(ctx, c2aW, a2cR, t.TempDir(),
-		acpcompat.CursorAgentID, "hello", "", "", nil); err != nil {
+		acpcompat.CursorAgentID, "hello", "", nil, "", nil); err != nil {
 		t.Fatalf("executeACPSession: %v", err)
 	}
 

--- a/apps/backend/internal/agentctl/server/utility/acp_probe_capabilities_test.go
+++ b/apps/backend/internal/agentctl/server/utility/acp_probe_capabilities_test.go
@@ -1,0 +1,150 @@
+package utility
+
+import (
+	"context"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	acp "github.com/coder/acp-go-sdk"
+	"github.com/kandev/kandev/internal/agentctl/acpcompat"
+	"go.uber.org/zap"
+)
+
+// probeCaptureAgent is the agent side of the probe handshake. It records the
+// InitializeRequest and then answers session/new with an empty session so the
+// probe can finish.
+type probeCaptureAgent struct {
+	mu  sync.Mutex
+	req acp.InitializeRequest
+}
+
+func (a *probeCaptureAgent) Initialize(_ context.Context, req acp.InitializeRequest) (acp.InitializeResponse, error) {
+	a.mu.Lock()
+	a.req = req
+	a.mu.Unlock()
+	return acp.InitializeResponse{ProtocolVersion: req.ProtocolVersion}, nil
+}
+
+func (a *probeCaptureAgent) captured() acp.InitializeRequest {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.req
+}
+
+func (*probeCaptureAgent) Authenticate(context.Context, acp.AuthenticateRequest) (acp.AuthenticateResponse, error) {
+	return acp.AuthenticateResponse{}, nil
+}
+func (*probeCaptureAgent) Cancel(context.Context, acp.CancelNotification) error { return nil }
+func (*probeCaptureAgent) CloseSession(context.Context, acp.CloseSessionRequest) (acp.CloseSessionResponse, error) {
+	return acp.CloseSessionResponse{}, nil
+}
+func (*probeCaptureAgent) DeleteSession(context.Context, acp.DeleteSessionRequest) (acp.DeleteSessionResponse, error) {
+	return acp.DeleteSessionResponse{}, acp.NewMethodNotFound(acp.AgentMethodSessionDelete)
+}
+func (*probeCaptureAgent) ListSessions(context.Context, acp.ListSessionsRequest) (acp.ListSessionsResponse, error) {
+	return acp.ListSessionsResponse{}, nil
+}
+func (*probeCaptureAgent) Logout(context.Context, acp.LogoutRequest) (acp.LogoutResponse, error) {
+	return acp.LogoutResponse{}, nil
+}
+func (*probeCaptureAgent) NewSession(context.Context, acp.NewSessionRequest) (acp.NewSessionResponse, error) {
+	return acp.NewSessionResponse{SessionId: acp.SessionId("probe-session")}, nil
+}
+func (*probeCaptureAgent) Prompt(context.Context, acp.PromptRequest) (acp.PromptResponse, error) {
+	return acp.PromptResponse{}, nil
+}
+func (*probeCaptureAgent) ResumeSession(context.Context, acp.ResumeSessionRequest) (acp.ResumeSessionResponse, error) {
+	return acp.ResumeSessionResponse{}, nil
+}
+func (*probeCaptureAgent) SetSessionConfigOption(context.Context, acp.SetSessionConfigOptionRequest) (acp.SetSessionConfigOptionResponse, error) {
+	return acp.SetSessionConfigOptionResponse{}, nil
+}
+func (*probeCaptureAgent) SetSessionMode(context.Context, acp.SetSessionModeRequest) (acp.SetSessionModeResponse, error) {
+	return acp.SetSessionModeResponse{}, nil
+}
+
+func probeHandshakeMeta(t *testing.T, agentID string) map[string]any {
+	t.Helper()
+
+	c2aR, c2aW := io.Pipe()
+	a2cR, a2cW := io.Pipe()
+	t.Cleanup(func() {
+		_ = c2aR.Close()
+		_ = c2aW.Close()
+		_ = a2cR.Close()
+		_ = a2cW.Close()
+	})
+
+	fake := &probeCaptureAgent{}
+	acp.NewAgentSideConnection(fake, a2cW, c2aR)
+
+	e := NewACPInferenceExecutor(zap.NewNop())
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if _, err := e.probeACPSession(ctx, c2aW, a2cR, t.TempDir(), agentID); err != nil {
+		t.Fatalf("probeACPSession(%q): %v", agentID, err)
+	}
+	return fake.captured().ClientCapabilities.Meta
+}
+
+// The probe and the live session adapter are SEPARATE handshakes. When only the
+// adapter opted in, the agent-models surface advertised the exploded fast=true
+// rows while sessions ran on the bare ids — so the UI offered a model list no
+// session used, and could not select the id a stored profile referenced.
+func TestProbeACPSession_AdvertisesParameterizedModelPickerToCursor(t *testing.T) {
+	meta := probeHandshakeMeta(t, acpcompat.CursorAgentID)
+
+	if meta[acpcompat.ParameterizedModelPickerMetaKey] != true {
+		t.Fatalf("probe meta[%q] = %v, want true (meta: %v)",
+			acpcompat.ParameterizedModelPickerMetaKey,
+			meta[acpcompat.ParameterizedModelPickerMetaKey], meta)
+	}
+}
+
+// The one-shot inference path is the THIRD handshake, and it applies a
+// caller-supplied model — so opting out of the picker here would reject the
+// very model ids the session path and the probe hand out.
+func TestExecuteACPSession_AdvertisesParameterizedModelPickerToCursor(t *testing.T) {
+	c2aR, c2aW := io.Pipe()
+	a2cR, a2cW := io.Pipe()
+	t.Cleanup(func() {
+		_ = c2aR.Close()
+		_ = c2aW.Close()
+		_ = a2cR.Close()
+		_ = a2cW.Close()
+	})
+
+	fake := &probeCaptureAgent{}
+	acp.NewAgentSideConnection(fake, a2cW, c2aR)
+
+	e := NewACPInferenceExecutor(zap.NewNop())
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if _, err := e.executeACPSession(ctx, c2aW, a2cR, t.TempDir(),
+		acpcompat.CursorAgentID, "hello", "", "", nil); err != nil {
+		t.Fatalf("executeACPSession: %v", err)
+	}
+
+	meta := fake.captured().ClientCapabilities.Meta
+	if meta[acpcompat.ParameterizedModelPickerMetaKey] != true {
+		t.Fatalf("inference meta[%q] = %v, want true (meta: %v)",
+			acpcompat.ParameterizedModelPickerMetaKey,
+			meta[acpcompat.ParameterizedModelPickerMetaKey], meta)
+	}
+}
+
+func TestProbeACPSession_LeavesOtherAgentsHandshakeUnchanged(t *testing.T) {
+	for _, agentID := range []string{"claude-acp", "codex-acp", "opencode-acp"} {
+		t.Run(agentID, func(t *testing.T) {
+			meta := probeHandshakeMeta(t, agentID)
+			if _, ok := meta[acpcompat.ParameterizedModelPickerMetaKey]; ok {
+				t.Errorf("%s probe carries %q; it is Cursor-only (meta: %v)",
+					agentID, acpcompat.ParameterizedModelPickerMetaKey, meta)
+			}
+		})
+	}
+}

--- a/apps/backend/internal/agentctl/server/utility/model_apply_test.go
+++ b/apps/backend/internal/agentctl/server/utility/model_apply_test.go
@@ -47,6 +47,26 @@ func TestApplySessionModel_UsesConfigOptionWhenSessionAdvertisesModelOption(t *t
 	}
 }
 
+func TestApplySessionConfigOptions_SortsAndAppliesValues(t *testing.T) {
+	t.Parallel()
+
+	conn := &fakeModelConn{}
+	err := applySessionConfigOptions(context.Background(), conn, "sess-1", map[string]string{
+		"fast":   "true",
+		"effort": "high",
+	})
+	if err != nil {
+		t.Fatalf("applySessionConfigOptions() error = %v", err)
+	}
+	wantCalls := []string{
+		"config:effort:high",
+		"config:fast:true",
+	}
+	if !reflect.DeepEqual(conn.calls, wantCalls) {
+		t.Fatalf("calls = %#v, want %#v", conn.calls, wantCalls)
+	}
+}
+
 // TestApplySessionModel_FallsBackToLegacySetModel pins that when the session
 // advertises no model-shaped config option, the dispatcher falls through to
 // the pre-v0.13.5 session/set_model RPC restored by the kdlbs acp-go-sdk


### PR DESCRIPTION
Fixes #2306.

`cursor-agent` decides its model-picker mode **once**, from the ACP `initialize` handshake, and never renegotiates. Kandev never advertises `_meta.parameterizedModelPicker`, so it always lands in **variants** mode — where Cursor offers `grok-4.5` and `composer-2.5` only as `fast=true` rows, and `session/set_model` rejects anything off that list. Those two models therefore cannot be run at the regular tier from Kandev at all.

Verified against `cursor-agent 2026.07.23` — same binary, same account, only the handshake differing:

| | without the key | with it |
|---|---|---|
| model ids | `grok-4.5[effort=high,fast=true]` | `grok-4.5` |
| display names | `grok-4.5` | `Cursor Grok 4.5` |
| config options | `mode`, `model` | `mode`, `model`, `effort`, **`fast`** |
| regular tier | unreachable | `fast` is a select with `false → Off` |

`session/set_config_option {configId: "fast", value: "false"}` then succeeds, and the resulting turn is served by the regular-tier model rather than the fast variant. Zed carries the same opt-in for the same reason (zed-industries/zed#59694).

### Three handshakes, not one

Kandev performs three separate ACP `initialize` calls, and they must agree — each mode advertises a **disjoint** set of model ids, so a mixed state means one surface hands out ids another rejects:

| path | why it needs the opt-in |
|---|---|
| `transport/acp/adapter.go` | the live session |
| `utility/acp_executor.go` → `probeACPSession` | feeds the agent-models surface / UI model list |
| `utility/acp_executor.go` → `executeACPSession` | applies a caller-supplied model, so it validates against the advertised set |

Worth flagging for review: **`grep ClientCapabilities` finds only the first.** The other two *omit* the field rather than set it differently, so they don't appear in that search — enumerating `conn.Initialize(` call sites is what actually finds all three. I fixed the session path first and it looked complete; the probe was only caught by asking a running instance what it advertised afterwards.

### Shape

Shared meta lives in `acpcompat`, per the agentctl guidance that capability normalization shared between live sessions and utility probes belongs there. It is agent-scoped — every non-Cursor handshake is byte-identical to before.

`executeACPSession` gained an `agentID` parameter; the value was already on `PromptRequest` and simply wasn't threaded down.

### Tests

Wire-level tests on all three paths — a fake agent over pipes captures the real `InitializeRequest`, asserting the key is present for `cursor-acp` and absent for every other agent. Plus `acpcompat` unit tests including the nil-base case the probe/inference paths use, and one pinning that the caller's base map isn't mutated (callers pass shared literals). Green under `-race`; `golangci-lint --new-from-rev` clean.

### Migration note

The two picker modes advertise disjoint model ids, so a stored agent profile pinned to an exploded id (`grok-4.5[effort=high,fast=true]`) stops matching once the client opts in, and must be re-pinned to the bare id with `effort`/`fast` as config options. Depending on how you'd like that handled, it could warrant a release note or a migration — happy to add either.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2307?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->