### PR TITLE
fix(backend): allowlist GitHub credential broker and app webhook

### DIFF
--- a/apps/backend/cmd/agentctl/github_credential.go
+++ b/apps/backend/cmd/agentctl/github_credential.go
@@ -69,6 +69,34 @@ func newGitHubCredentialBrokerClient(
 	return &githubCredentialBrokerClient{endpoint: endpoint, request: request, http: httpClient}, nil
 }
 
+// maxBrokerErrorBodyBytes caps the broker error body appended to a resolve
+// failure. Broker error bodies are code/message JSON and carry no credential
+// (success bodies, which do carry the token, are never passed through this
+// path), but the cap and control-char stripping stay regardless.
+const maxBrokerErrorBodyBytes = 512
+
+// formatBrokerErrorBody reads a bounded, sanitized broker error body suitable
+// for appending to an error message, e.g. ": {\"error\":\"...\"}" — or "" when
+// the body is empty after sanitizing.
+func formatBrokerErrorBody(body io.Reader) string {
+	raw, _ := io.ReadAll(io.LimitReader(body, 1<<20))
+	if len(raw) > maxBrokerErrorBodyBytes {
+		raw = raw[:maxBrokerErrorBodyBytes]
+	}
+	var sanitized strings.Builder
+	for _, r := range string(raw) {
+		if r < 0x20 {
+			continue
+		}
+		sanitized.WriteRune(r)
+	}
+	trimmed := strings.TrimSpace(sanitized.String())
+	if trimmed == "" {
+		return ""
+	}
+	return ": " + trimmed
+}
+
 func (c *githubCredentialBrokerClient) resolve(ctx context.Context) (*githubBrokerCredential, error) {
 	body, err := json.Marshal(c.request)
 	if err != nil {
@@ -85,8 +113,8 @@ func (c *githubCredentialBrokerClient) resolve(ctx context.Context) (*githubBrok
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
-		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<20))
-		return nil, fmt.Errorf("resolve GitHub credential: broker returned HTTP %d", resp.StatusCode)
+		return nil, fmt.Errorf("resolve GitHub credential: broker returned HTTP %d%s",
+			resp.StatusCode, formatBrokerErrorBody(resp.Body))
 	}
 	var credential githubBrokerCredential
 	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&credential); err != nil {

--- a/apps/backend/cmd/agentctl/github_credential.go
+++ b/apps/backend/cmd/agentctl/github_credential.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/kandev/kandev/internal/githubauth"
 )
@@ -79,9 +80,9 @@ const maxBrokerErrorBodyBytes = 512
 // for appending to an error message, e.g. ": {\"error\":\"...\"}" — or "" when
 // the body is empty after sanitizing.
 func formatBrokerErrorBody(body io.Reader) string {
-	raw, _ := io.ReadAll(io.LimitReader(body, 1<<20))
-	if len(raw) > maxBrokerErrorBodyBytes {
-		raw = raw[:maxBrokerErrorBodyBytes]
+	raw, _ := io.ReadAll(io.LimitReader(body, maxBrokerErrorBodyBytes))
+	for !utf8.Valid(raw) && len(raw) > 0 {
+		raw = raw[:len(raw)-1]
 	}
 	var sanitized strings.Builder
 	for _, r := range string(raw) {

--- a/apps/backend/cmd/agentctl/github_credential_test.go
+++ b/apps/backend/cmd/agentctl/github_credential_test.go
@@ -148,6 +148,77 @@ func TestGitHubCredentialHelperIgnoresStoreAndErase(t *testing.T) {
 	}
 }
 
+func TestGitHubCredentialHelperSurfacesBrokerErrorBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = io.WriteString(w, `{"error":"authentication required"}`)
+	}))
+	t.Cleanup(server.Close)
+	env := githubCredentialTestEnv(server.URL)
+
+	err := runGitHubCredentialHelper(
+		context.Background(), []string{"get"},
+		strings.NewReader("protocol=https\nhost=github.com\npath=acme/widgets.git\n\n"),
+		io.Discard, lookupEnv(env), server.Client(),
+	)
+	if err == nil {
+		t.Fatal("runGitHubCredentialHelper() error = nil, want broker denial")
+	}
+	want := `resolve GitHub credential: broker returned HTTP 401: {"error":"authentication required"}`
+	if err.Error() != want {
+		t.Fatalf("error = %q, want %q", err.Error(), want)
+	}
+}
+
+func TestGitHubCredentialHelperTruncatesAndSanitizesBrokerErrorBody(t *testing.T) {
+	rawBody := strings.Repeat("x", 600) + "\x00\x01\x1f control chars"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = io.WriteString(w, rawBody)
+	}))
+	t.Cleanup(server.Close)
+	env := githubCredentialTestEnv(server.URL)
+
+	err := runGitHubCredentialHelper(
+		context.Background(), []string{"get"},
+		strings.NewReader("protocol=https\nhost=github.com\npath=acme/widgets.git\n\n"),
+		io.Discard, lookupEnv(env), server.Client(),
+	)
+	if err == nil {
+		t.Fatal("runGitHubCredentialHelper() error = nil, want broker denial")
+	}
+	if !strings.HasPrefix(err.Error(), "resolve GitHub credential: broker returned HTTP 500: ") {
+		t.Fatalf("error = %q, want HTTP 500 prefix", err.Error())
+	}
+	appended := strings.TrimPrefix(err.Error(), "resolve GitHub credential: broker returned HTTP 500: ")
+	if len(appended) > 512 {
+		t.Fatalf("appended body length = %d, want <= 512", len(appended))
+	}
+	for _, r := range appended {
+		if r < 0x20 {
+			t.Fatalf("appended body contains control char %q: %q", r, appended)
+		}
+	}
+}
+
+func TestGitHubCredentialHelperOmitsAppendedBodyWhenEmpty(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	t.Cleanup(server.Close)
+	env := githubCredentialTestEnv(server.URL)
+
+	err := runGitHubCredentialHelper(
+		context.Background(), []string{"get"},
+		strings.NewReader("protocol=https\nhost=github.com\npath=acme/widgets.git\n\n"),
+		io.Discard, lookupEnv(env), server.Client(),
+	)
+	want := "resolve GitHub credential: broker returned HTTP 502"
+	if err == nil || err.Error() != want {
+		t.Fatalf("error = %v, want %q", err, want)
+	}
+}
+
 func githubCredentialTestEnv(url string) map[string]string {
 	return map[string]string{
 		envGitHubCredentialBrokerURL:  url,

--- a/apps/backend/cmd/agentctl/github_credential_test.go
+++ b/apps/backend/cmd/agentctl/github_credential_test.go
@@ -171,7 +171,7 @@ func TestGitHubCredentialHelperSurfacesBrokerErrorBody(t *testing.T) {
 }
 
 func TestGitHubCredentialHelperTruncatesAndSanitizesBrokerErrorBody(t *testing.T) {
-	rawBody := strings.Repeat("x", 600) + "\x00\x01\x1f control chars"
+	rawBody := "prefix\x00\x01\x1f control chars" + strings.Repeat("x", 600)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 		_, _ = io.WriteString(w, rawBody)

--- a/apps/backend/cmd/agentctl/github_credential_utf8_test.go
+++ b/apps/backend/cmd/agentctl/github_credential_utf8_test.go
@@ -13,8 +13,8 @@ import (
 // TestGitHubCredentialHelperHandlesMultibyteTruncationBoundary guards against
 // a byte-boundary truncation splitting a multi-byte UTF-8 rune in the broker
 // error body. formatBrokerErrorBody truncates by raw bytes before rune
-// iteration, so a cut mid-rune must not panic or produce invalid UTF-8 in the
-// surfaced error message.
+// iteration, so a cut mid-rune must not expand the bounded body or produce
+// replacement runes in the surfaced error message.
 func TestGitHubCredentialHelperHandlesMultibyteTruncationBoundary(t *testing.T) {
 	// Build a body whose byte 512 boundary lands mid-rune: pad with ASCII to
 	// 510 bytes, then place a 3-byte rune (e.g. '中') straddling the cut.
@@ -38,5 +38,19 @@ func TestGitHubCredentialHelperHandlesMultibyteTruncationBoundary(t *testing.T) 
 	if !utf8.ValidString(err.Error()) {
 		t.Fatalf("error message is not valid UTF-8: %q", err.Error())
 	}
-	t.Logf("error = %q (len=%d)", err.Error(), len(err.Error()))
+	const errorPrefix = "resolve GitHub credential: broker returned HTTP 401"
+	appended := strings.TrimPrefix(err.Error(), errorPrefix)
+	if !strings.HasPrefix(appended, ": ") {
+		t.Fatalf("error = %q, want appended broker body", err.Error())
+	}
+	appended = strings.TrimPrefix(appended, ": ")
+	if len(appended) > maxBrokerErrorBodyBytes {
+		t.Fatalf("appended body length = %d, want <= %d", len(appended), maxBrokerErrorBodyBytes)
+	}
+	if strings.ContainsRune(appended, utf8.RuneError) {
+		t.Fatalf("appended body contains replacement rune: %q", appended)
+	}
+	if strings.Contains(appended, "中") {
+		t.Fatalf("appended body contains the split rune: %q", appended)
+	}
 }

--- a/apps/backend/cmd/agentctl/github_credential_utf8_test.go
+++ b/apps/backend/cmd/agentctl/github_credential_utf8_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+// TestGitHubCredentialHelperHandlesMultibyteTruncationBoundary guards against
+// a byte-boundary truncation splitting a multi-byte UTF-8 rune in the broker
+// error body. formatBrokerErrorBody truncates by raw bytes before rune
+// iteration, so a cut mid-rune must not panic or produce invalid UTF-8 in the
+// surfaced error message.
+func TestGitHubCredentialHelperHandlesMultibyteTruncationBoundary(t *testing.T) {
+	// Build a body whose byte 512 boundary lands mid-rune: pad with ASCII to
+	// 510 bytes, then place a 3-byte rune (e.g. '中') straddling the cut.
+	prefix := strings.Repeat("a", 510)
+	rawBody := prefix + "中文emoji😀tail"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = io.WriteString(w, rawBody)
+	}))
+	t.Cleanup(server.Close)
+	env := githubCredentialTestEnv(server.URL)
+
+	err := runGitHubCredentialHelper(
+		context.Background(), []string{"get"},
+		strings.NewReader("protocol=https\nhost=github.com\npath=acme/widgets.git\n\n"),
+		io.Discard, lookupEnv(env), server.Client(),
+	)
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if !utf8.ValidString(err.Error()) {
+		t.Fatalf("error message is not valid UTF-8: %q", err.Error())
+	}
+	t.Logf("error = %q (len=%d)", err.Error(), len(err.Error()))
+}

--- a/apps/backend/internal/auth/httpmw/middleware.go
+++ b/apps/backend/internal/auth/httpmw/middleware.go
@@ -98,6 +98,13 @@ func isPublicPath(method, path string) bool {
 	case "/api/v1/auth/me":
 		// Returns {authenticated:false, mode} for anonymous visitors.
 		return method == http.MethodGet
+	case "/api/v1/github/credentials/resolve":
+		// Opaque, task-scoped broker lease (SHA-256-hashed at rest, TTL'd,
+		// scope-matched on redeem) is the credential — containers and remote
+		// executors hold no session cookie or PAT by design. GET is the
+		// readiness probe, POST redeems the lease; both self-authenticate
+		// inside the handler, never off request identity.
+		return method == http.MethodGet || method == http.MethodPost
 	}
 	switch {
 	case strings.HasPrefix(path, "/api/v1/automations/webhook/"):
@@ -105,6 +112,10 @@ func isPublicPath(method, path string) bool {
 		return true
 	case strings.HasPrefix(path, "/api/v1/office/channels/") && strings.HasSuffix(path, "/inbound"):
 		// HMAC-SHA256 / provider token verified by the channel handler.
+		return true
+	case strings.HasPrefix(path, "/api/v1/github/app/registrations/") && strings.HasSuffix(path, "/webhook"):
+		// GitHub App webhook delivery; HMAC (X-Hub-Signature-256) verified by
+		// the handler, not request identity.
 		return true
 	case strings.HasPrefix(path, "/api/plugins/") && strings.Contains(path, "/webhooks/"):
 		// Relayed to the plugin subprocess, which owns signature validation.

--- a/apps/backend/internal/auth/httpmw/middleware_test.go
+++ b/apps/backend/internal/auth/httpmw/middleware_test.go
@@ -181,6 +181,13 @@ func TestEnabledModeAllowlistMatrix(t *testing.T) {
 			mutate: []func(*http.Request){func(r *http.Request) { r.Header.Set("Authorization", "Bearer agent.jwt.here") }},
 		},
 
+		{name: "github credential broker readiness", method: http.MethodGet, path: "/api/v1/github/credentials/resolve"},
+		{name: "github credential broker resolve", method: http.MethodPost, path: "/api/v1/github/credentials/resolve"},
+		{
+			name: "github app webhook", method: http.MethodPost,
+			path: "/api/v1/github/app/registrations/reg1/webhook",
+		},
+
 		{name: "office without bearer", method: http.MethodGet, path: "/api/v1/office/tasks/t1", blocked: true},
 		{name: "tasks api", method: http.MethodGet, path: "/api/v1/tasks", blocked: true},
 		{name: "workspaces api", method: http.MethodGet, path: "/api/v1/workspaces", blocked: true},
@@ -191,6 +198,10 @@ func TestEnabledModeAllowlistMatrix(t *testing.T) {
 			path: "/api/plugins/p1/user-state/task/task1/note", blocked: true,
 		},
 		{name: "debug", method: http.MethodGet, path: "/debug/vars", blocked: true},
+		{
+			name: "github connections requires auth", method: http.MethodGet,
+			path: "/api/v1/github/connections", blocked: true,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/apps/backend/internal/github/credential_broker_http_test.go
+++ b/apps/backend/internal/github/credential_broker_http_test.go
@@ -1,0 +1,153 @@
+package github
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/jmoiron/sqlx"
+	_ "github.com/mattn/go-sqlite3"
+
+	"github.com/kandev/kandev/internal/auth"
+	"github.com/kandev/kandev/internal/auth/httpmw"
+	authstore "github.com/kandev/kandev/internal/auth/store"
+	"github.com/kandev/kandev/internal/common/config"
+	userstore "github.com/kandev/kandev/internal/user/store"
+)
+
+// resolveCredentialLeaseBody mirrors the JSON shape httpResolveCredentialLease
+// binds against (controller_auth.go); BrokerCredentialRequest itself carries
+// no json tags, so it cannot be marshaled directly for this HTTP-level test.
+type resolveCredentialLeaseBody struct {
+	Lease        string `json:"lease"`
+	TaskID       string `json:"task_id"`
+	SessionID    string `json:"session_id"`
+	RepositoryID string `json:"repository_id"`
+	Owner        string `json:"owner"`
+	Repo         string `json:"repo"`
+	Host         string `json:"host"`
+}
+
+// newEnabledAuthService builds a real auth.Service in enabled mode (flag on,
+// admin provisioned) so the broker HTTP test below exercises the production
+// httpmw.Middleware, not a stub — this is what pins that the middleware, not
+// just the handler, lets these routes through.
+func newEnabledAuthService(t *testing.T) *auth.Service {
+	t.Helper()
+	conn, err := sqlx.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	users, cleanup, err := userstore.Provide(conn, conn)
+	if err != nil {
+		t.Fatalf("user store: %v", err)
+	}
+	t.Cleanup(func() { _ = cleanup() })
+	store, err := authstore.New(conn, conn)
+	if err != nil {
+		t.Fatalf("auth store: %v", err)
+	}
+	cfg := &config.Config{}
+	cfg.Features.Auth = true
+	cfg.Auth.SessionTTLHours = 720
+	svc, err := auth.NewService(context.Background(), auth.Deps{Cfg: cfg, Store: store, Users: users})
+	if err != nil {
+		t.Fatalf("auth service: %v", err)
+	}
+	if _, _, err := svc.Setup(context.Background(), "admin@x.dev", "adminpass123", "Admin", "", ""); err != nil {
+		t.Fatalf("setup admin: %v", err)
+	}
+	return svc
+}
+
+func newBrokerHTTPTestRouter(t *testing.T, broker *CredentialBroker) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	log := newControllerTestLogger()
+	svc := NewService(&stubClient{}, "pat", nil, nil, nil, log)
+	svc.SetCredentialBroker(broker)
+	ctrl := NewController(svc, log)
+
+	router := gin.New()
+	router.Use(httpmw.Middleware(newEnabledAuthService(t)))
+	useControllerTestWorkspace(router)
+	ctrl.RegisterHTTPRoutes(router)
+	return router
+}
+
+// TestCredentialBrokerRoutesPassRealAuthMiddleware pins that the credential
+// broker's readiness and resolve routes reach the broker (and its own
+// scope/lease checks) instead of being rejected by httpmw.Middleware in
+// enabled mode. This is the regression guard for the missing-allowlist bug:
+// without the isPublicPath entries, every assertion below fails with a
+// generic 401 "authentication required" instead of the broker's own status
+// and error code.
+func TestCredentialBrokerRoutesPassRealAuthMiddleware(t *testing.T) {
+	broker, _, _ := newPATCredentialBroker(t)
+	lease, err := broker.Issue(context.Background(), brokerLeaseRequest())
+	if err != nil {
+		t.Fatalf("issue lease: %v", err)
+	}
+	router := newBrokerHTTPTestRouter(t, broker)
+
+	t.Run("GET readiness reaches the broker unauthenticated", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/github/credentials/resolve", nil)
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+		if rec.Code != http.StatusNoContent {
+			t.Fatalf("status = %d body=%s, want %d", rec.Code, rec.Body.String(), http.StatusNoContent)
+		}
+	})
+
+	t.Run("POST with a valid lease redeems a credential", func(t *testing.T) {
+		body, err := json.Marshal(resolveCredentialLeaseBody{
+			Lease: lease.Token, TaskID: "task-1", SessionID: "session-1",
+			RepositoryID: "repository-1", Owner: "kdlbs", Repo: "kandev", Host: "github.com",
+		})
+		if err != nil {
+			t.Fatalf("marshal body: %v", err)
+		}
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/github/credentials/resolve", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d body=%s, want %d", rec.Code, rec.Body.String(), http.StatusOK)
+		}
+		var credential struct {
+			Username string `json:"username"`
+			Password string `json:"password"`
+		}
+		if err := json.Unmarshal(rec.Body.Bytes(), &credential); err != nil {
+			t.Fatalf("decode credential: %v", err)
+		}
+		if credential.Username == "" || credential.Password == "" {
+			t.Fatalf("expected populated credential, got %+v", credential)
+		}
+	})
+
+	t.Run("POST with an invalid lease is denied by the broker, not the middleware", func(t *testing.T) {
+		body, err := json.Marshal(resolveCredentialLeaseBody{
+			Lease: "not-a-real-lease", TaskID: "task-1", SessionID: "session-1",
+			RepositoryID: "repository-1", Owner: "kdlbs", Repo: "kandev", Host: "github.com",
+		})
+		if err != nil {
+			t.Fatalf("marshal body: %v", err)
+		}
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/github/credentials/resolve", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+		if rec.Code != http.StatusUnauthorized {
+			t.Fatalf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+		}
+		if !bytes.Contains(rec.Body.Bytes(), []byte("github_credential_denied")) {
+			t.Fatalf("body = %s, want broker code github_credential_denied", rec.Body.String())
+		}
+	})
+}

--- a/docs/specs/auth/spec.md
+++ b/docs/specs/auth/spec.md
@@ -61,7 +61,15 @@ the local single-user install with a login screen it never asked for.
   payload (`/api/v1/app-state` — returns only `{features, auth}` for
   anonymous visitors), `/api/v1/features`, credential endpoints
   (login/setup/invite-accept), and self-authenticating webhooks (automation
-  `X-Webhook-Secret`, office channel HMAC, plugin webhooks).
+  `X-Webhook-Secret`, office channel HMAC, plugin webhooks). The GitHub
+  credential broker (`/api/v1/github/credentials/resolve`, GET readiness +
+  POST resolve) is likewise public: containers and remote executors hold no
+  session cookie or PAT by design, and the opaque, task-scoped lease in the
+  request body — hashed at rest, TTL'd, scope-matched on redeem — is the
+  self-authenticating credential. The GitHub App webhook
+  (`/api/v1/github/app/registrations/{id}/webhook`) is public for the same
+  reason as the other webhooks: its own HMAC (`X-Hub-Signature-256`) is
+  verified by the handler.
 - **Session challenges are distinct from provider authentication failures.**
   The browser clears its Kandev identity and opens `/login` only when a 401 is
   a Kandev session challenge. A third-party integration may also return 401


### PR DESCRIPTION
Inside a Kandev session the shimmed `gh` (and `agentctl git-credential`) failed every call with `broker returned HTTP 401`, while `/usr/bin/gh` worked — because the credential broker's own routes were never added to the global auth middleware's unauthenticated allowlist, so `features.auth` rejected them before the broker's lease check ever ran.

## Important Changes

- Added `GET`/`POST /api/v1/github/credentials/resolve` and `POST /api/v1/github/app/registrations/:registrationId/webhook` to the `isPublicPath` allowlist in `httpmw/middleware.go` — these routes authenticate themselves (opaque lease / HMAC signature) rather than via session cookie or PAT, so the global auth gate must not intercept them.
- Fixed `agentctl/github_credential.go` to surface (bounded, sanitized) the broker's actual error body instead of discarding it, so future failures show actionable codes (`github_reconnect_required`, etc.) instead of an opaque HTTP status.

## Validation

- `go test ./internal/auth/httpmw/... ./internal/github/... ./cmd/agentctl/...` — all pass, including new middleware matrix rows, a real-router broker integration test, and error-body surfacing/truncation/UTF-8-boundary tests.
- Full backend suite `go test ./...` — no regressions (env-clean of ambient shim vars).
- Manually verified against an isolated instance with `features.auth` enabled: broker readiness `GET` → `204`, unrelated routes still `401` unauthenticated, webhook route reaches its handler pre-signature-check, `gh auth status` (broker-shimmed) now succeeds.

## Possible Improvements

Low risk: the change only widens the allowlist to the exact broker/webhook paths (both self-authenticating), verified negative pins on unrelated routes remain `401`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2310?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->