### PR TITLE
ci(release): sign the Windows binaries that ship in the release archive

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -727,12 +727,19 @@ jobs:
             platform: macos-arm64
             goos: darwin
             goarch: arm64
-          - os: ubuntu-latest
+          # Windows builds natively instead of cross-compiling from Linux, so
+          # signtool can sign the binaries in place before they are packaged.
+          # The runner image ships gcc, which CGO still needs for the fts5 tag.
+          - os: windows-latest
             platform: windows-x64
             goos: windows
             goarch: amd64
-            cc: x86_64-w64-mingw32-gcc
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        # These steps are POSIX shell; windows-latest would otherwise run them
+        # under pwsh. Git Bash is on the image and provides tar and shasum.
+        shell: bash
     env:
       CGO_ENABLED: 1
       GOOS: ${{ matrix.goos }}
@@ -751,12 +758,6 @@ jobs:
           name: web-bundle
           path: apps/backend/internal/webapp/embedded/generated
 
-      - name: Install cross-compilation tools
-        if: matrix.cc
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-mingw-w64-x86-64
-
       # The `fts5` build tag is REQUIRED on the kandev binary. The office
       # task search migrations create a `tasks_fts` virtual table using
       # `USING fts5(...)`; without the tag, mattn/go-sqlite3 lacks the
@@ -768,7 +769,6 @@ jobs:
       # reports the released tag instead of the build-time default "dev".
       - name: Build backend binaries
         env:
-          CC: ${{ matrix.cc || '' }}
           KANDEV_VERSION: ${{ needs.nightly-prepare.result == 'success' && needs.nightly-prepare.outputs.tag || needs.prepare.outputs.tag }}
         run: |
           test -f apps/backend/internal/webapp/embedded/generated/index.html
@@ -798,6 +798,44 @@ jobs:
           GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 CC= go build -ldflags "${LDFLAGS}" -o bin/agentctl-darwin-arm64 ./cmd/agentctl
           GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 CC= go build -ldflags "${LDFLAGS}" -o bin/agentctl-darwin-amd64 ./cmd/agentctl
 
+      # Signing happens here, before packaging, so the archive published to the
+      # release carries signed binaries. Previously only build-desktop signed,
+      # and only its own copy under src-tauri/resources — so Scoop, npm and
+      # direct downloads shipped unsigned executables even when a certificate
+      # was configured. Unsigned Go binaries that spawn children and open
+      # sockets are a well-known Defender heuristic target; see #2312.
+      - name: Detect Windows signing inputs
+        if: matrix.goos == 'windows'
+        env:
+          WINDOWS_CERTIFICATE: ${{ secrets.WINDOWS_CERTIFICATE }}
+          WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
+        run: |
+          set -euo pipefail
+          if bash scripts/release/desktop-signing-ready.sh windows >/dev/null 2>&1; then
+            echo "WINDOWS_SIGNING_ENABLED=true" >> "$GITHUB_ENV"
+          else
+            echo "WINDOWS_SIGNING_ENABLED=false" >> "$GITHUB_ENV"
+            echo "::notice::Windows signing inputs are incomplete; publishing an unsigned runtime bundle."
+          fi
+
+      - name: Sign Windows runtime binaries
+        if: matrix.goos == 'windows' && env.WINDOWS_SIGNING_ENABLED == 'true'
+        shell: pwsh
+        env:
+          WINDOWS_CERTIFICATE: ${{ secrets.WINDOWS_CERTIFICATE }}
+          WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
+          WINDOWS_TIMESTAMP_URL: ${{ secrets.WINDOWS_TIMESTAMP_URL }}
+          WINDOWS_SIGNTOOL_PATH: ${{ secrets.WINDOWS_SIGNTOOL_PATH }}
+        run: |
+          foreach ($binary in @("kandev.exe", "agentctl.exe")) {
+            $path = Join-Path $env:GITHUB_WORKSPACE "apps/backend/bin/$binary"
+            if (!(Test-Path -LiteralPath $path)) {
+              Write-Error "Missing Windows runtime binary at $path"
+              exit 1
+            }
+            & "$env:GITHUB_WORKSPACE/apps/desktop/src-tauri/windows-sign.ps1" -Path $path
+          }
+
       - name: Package bundle
         run: |
           rm -rf dist/kandev
@@ -817,8 +855,10 @@ jobs:
           # Chocolatey's unzip helper needs two 7-Zip passes for a .tar.gz.
           # The zip is published alongside the tarball, not instead of it —
           # Homebrew and the npm runtime packages still read the tarball.
+          # 7z rather than zip: the Windows bundle now builds on windows-latest,
+          # and Git Bash there has no zip. 7z is on both runner images.
           if [ "${{ matrix.goos }}" = "windows" ]; then
-            zip -qr "kandev-${{ matrix.platform }}.zip" kandev
+            7z a -tzip -bso0 -bsp0 "kandev-${{ matrix.platform }}.zip" kandev
             shasum -a 256 "kandev-${{ matrix.platform }}.zip" > "kandev-${{ matrix.platform }}.zip.sha256"
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -856,9 +856,16 @@ jobs:
           # The zip is published alongside the tarball, not instead of it —
           # Homebrew and the npm runtime packages still read the tarball.
           # 7z rather than zip: the Windows bundle now builds on windows-latest,
-          # and Git Bash there has no zip. 7z is on both runner images.
+          # and Git Bash there has no zip. 7-Zip is on the image but the runner
+          # docs do not promise it on PATH, so fall back to its install path
+          # rather than failing the release on a lookup.
           if [ "${{ matrix.goos }}" = "windows" ]; then
-            7z a -tzip -bso0 -bsp0 "kandev-${{ matrix.platform }}.zip" kandev
+            sevenzip=7z
+            if ! command -v "$sevenzip" >/dev/null 2>&1; then
+              sevenzip="/c/Program Files/7-Zip/7z.exe"
+              test -x "$sevenzip" || { echo "7-Zip not found on PATH or at $sevenzip" >&2; exit 1; }
+            fi
+            "$sevenzip" a -tzip -bso0 -bsp0 "kandev-${{ matrix.platform }}.zip" kandev
             shasum -a 256 "kandev-${{ matrix.platform }}.zip" > "kandev-${{ matrix.platform }}.zip.sha256"
           fi
 


### PR DESCRIPTION
Signs the Windows runtime binaries that ship in the release archive. Closes the gap described in #2312.

## The gap

`kandev.exe` and `agentctl.exe` already go through `signtool` — but only in `build-desktop`, and only on the copy under `apps/desktop/src-tauri/resources/kandev/bin`. Every signing step in the workflow sits inside that job (lines 1010–1077 and 1286–1322); `build-bundles` has none, and neither does `publish-release`.

So the desktop installer and the CLI archive carry byte-identical binaries — `build-desktop` downloads the very artifact `build-bundles` produced — and only one copy is signed. Scoop, npm and direct downloads get unsigned executables today, and would keep getting them even after a certificate is configured.

That is what #2312 ran into: Defender quarantined the unsigned `agentctl.exe` as `Trojan:Win32/Wacatac.B!ml` while it was running.

## The change

The Windows bundle now builds on `windows-latest` instead of cross-compiling from Linux, so `signtool` can sign the binaries in place, before `tar`/`zip`. No repackaging, no checksums to regenerate, and the archive that reaches users is the one that was signed.

It reuses the existing `desktop-signing-ready.sh` guard, so with no certificate configured it builds unsigned and logs a notice, exactly as `build-desktop` does today. Nothing changes until the secrets exist; then both paths sign without further work.

Knock-on changes, all consequences of the runner move:

- **`defaults: run: shell: bash`** on the job. The steps are POSIX shell and `windows-latest` would otherwise run them under pwsh. Git Bash is on the image and supplies `tar` and `shasum`.
- **`zip` → `7z a -tzip`.** Git Bash has no `zip`, so the Windows zip step added in #2286 would break. 7z is on both runner images, so this also removes a Linux-only assumption.
- **Cross-compilation removed.** Windows was the only entry with `cc`, so the mingw install step and the `CC:` passthrough are now dead and are dropped.

## Checked

- **The runner can still build it.** `windows-latest` ships gcc 14.2.0, so CGO with the required `fts5` tag compiles natively. Git Bash is present at `C:\Program Files\Git\bin\bash.exe`.
- **7z produces the same archive.** Verified the layout is unchanged — `kandev/`, `kandev/bin/…` — which is what Scoop's `extract_dir` and a winget `RelativeFilePath` both depend on. Integrity check and checksum verify.
- **`windows-sign.ps1` is reusable outside the desktop job.** It takes a path parameter, reads the certificate from the environment, materialises the `.pfx` under `RUNNER_TEMP` and resolves `signtool` itself. Nothing in it depends on Tauri or on `build-desktop` having run.
- **7-Zip on PATH is not guaranteed.** The runner image lists 7-Zip 26.02 but the documentation does not promise a `7z` on PATH, so the step resolves the command and falls back to the install path rather than failing a release on a lookup. This one is defended against rather than verified — I cannot check a runner's PATH from a branch.
- **No cross-compilation residue.** The only remaining `CC=` occurrences are the deliberate `CGO_ENABLED=0 CC=` on the four remote agentctl helpers, which are unrelated.

What cannot be checked from a branch: the job actually running. `release.yml` is `workflow_dispatch` only, so no PR CI exercises it. The first real test is the next release, and the risk is concentrated in the native Windows build rather than in the signing, which is inert without secrets.

## Timing, if a release is cut soon

Worth deciding deliberately rather than by accident:

- **Release before this merges** — publishes as today: unsigned, but carrying the `.zip` from #2286 and the launcher fallback from #2285, which is what a winget submission needs.
- **Release after this merges** — that release is the first to exercise the native Windows build. The signing itself stays inert without secrets, so the new risk is the compiler change, not the signature.

## Not in scope

The certificate itself. That is a purchase and an org decision; this only ensures a certificate would reach the archive users actually install. Also worth knowing: since March 2024 an EV certificate no longer clears SmartScreen immediately — EV and OV build reputation the same way — so signing improves the odds rather than switching the detection off.
