### PR TITLE
fix(acp): keep todo indicator alive across session resume

### DIFF
--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_session.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_session.go
@@ -506,21 +506,7 @@ func (a *Adapter) LoadSession(ctx context.Context, sessionID string, mcpServers 
 	// the frontend doesn't render a stuck "watching" card.
 	a.sweepMonitorsOnReplayEnd(sessionID)
 
-	if replayPlan != nil {
-		entries := make([]PlanEntry, len(replayPlan.Entries))
-		for i, e := range replayPlan.Entries {
-			entries[i] = PlanEntry{
-				Description: e.Content,
-				Status:      string(e.Status),
-				Priority:    string(e.Priority),
-			}
-		}
-		a.sendUpdate(AgentEvent{
-			Type:        streams.EventTypePlan,
-			SessionID:   sessionID,
-			PlanEntries: entries,
-		})
-	}
+	a.emitReplayPlan(sessionID, replayPlan)
 
 	// Emit session status event to normalize with other adapters.
 	// This eliminates the need for ReportsStatusViaStream flag.
@@ -542,6 +528,31 @@ func (a *Adapter) LoadSession(ctx context.Context, sessionID string, mcpServers 
 // than a full process restart since the ACP protocol supports multiple sessions per connection.
 func (a *Adapter) ResetSession(ctx context.Context, mcpServers []types.McpServer) (string, error) {
 	return a.NewSession(ctx, mcpServers)
+}
+
+// emitReplayPlan re-emits the plan captured during session/load replay so the todo
+// indicator survives a resume. An empty plan is dropped: on the ACP ingest path an
+// empty entry list carries no information (same reasoning as extractTodoItems), and
+// re-emitting it would both wipe the live indicator and persist an empty todo snapshot
+// that shadows the last real one in the chat timeline. A genuine "agent cleared the
+// todos" still arrives as a live plan update and keeps its persisted empty snapshot.
+func (a *Adapter) emitReplayPlan(sessionID string, replayPlan *acp.SessionUpdatePlan) {
+	if replayPlan == nil || len(replayPlan.Entries) == 0 {
+		return
+	}
+	entries := make([]PlanEntry, len(replayPlan.Entries))
+	for i, e := range replayPlan.Entries {
+		entries[i] = PlanEntry{
+			Description: e.Content,
+			Status:      string(e.Status),
+			Priority:    string(e.Priority),
+		}
+	}
+	a.sendUpdate(AgentEvent{
+		Type:        streams.EventTypePlan,
+		SessionID:   sessionID,
+		PlanEntries: entries,
+	})
 }
 
 // emitInitialModeState emits a session_mode event from the session response's Modes field.

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/load_suppression_test.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/load_suppression_test.go
@@ -212,21 +212,7 @@ func TestLoadSuppression_PlanReemittedAfterLoad(t *testing.T) {
 	a.isLoadingSession = false
 	a.mu.Unlock()
 
-	if replayPlan != nil {
-		entries := make([]PlanEntry, len(replayPlan.Entries))
-		for i, e := range replayPlan.Entries {
-			entries[i] = PlanEntry{
-				Description: e.Content,
-				Status:      string(e.Status),
-				Priority:    string(e.Priority),
-			}
-		}
-		a.sendUpdate(AgentEvent{
-			Type:        streams.EventTypePlan,
-			SessionID:   "s1",
-			PlanEntries: entries,
-		})
-	}
+	a.emitReplayPlan("s1", replayPlan)
 
 	// Now we should see the re-emitted plan.
 	events = drainEvents(a)
@@ -252,6 +238,19 @@ func TestLoadSuppression_PlanReemittedAfterLoad(t *testing.T) {
 		t.Error("loadReplayPlan should be nil after re-emit")
 	}
 	a.mu.RUnlock()
+}
+
+func TestLoadSuppression_EmptyReplayPlanNotReemitted(t *testing.T) {
+	a := newTestAdapter()
+
+	// A replay that ends with an empty plan must not re-emit it: the event would
+	// clear the live todo indicator and persist an empty todo snapshot that hides
+	// the last real one.
+	a.emitReplayPlan("s1", &acp.SessionUpdatePlan{Entries: []acp.PlanEntry{}})
+
+	if events := drainEvents(a); len(events) != 0 {
+		t.Fatalf("expected no event for an empty replay plan, got %d: %+v", len(events), events)
+	}
 }
 
 func TestLoadSuppression_PostReplayEventsPassThrough(t *testing.T) {


### PR DESCRIPTION
The todo indicator vanished from the chat on every backend restart: the plan captured during ACP `session/load` replay was re-emitted unconditionally, so a replay ending in an empty plan both cleared `sessionTodos` and persisted an empty todo snapshot that then shadowed the last real one for the message-based fallback. Empty replay plans are now dropped, so a resumed session keeps the todo list it had.

## Validation

- `go test ./internal/agentctl/server/adapter/transport/acp/ -run TestLoadSuppression -count=1` — 8/8 pass, including the new `TestLoadSuppression_EmptyReplayPlanNotReemitted`.
- Negative control: with the emptiness guard removed, that new test fails on the exact wiping event (`Type:plan`, `PlanEntries:[]`), so it does cover the regression.
- `go build ./internal/agentctl/...` and `go vet ./internal/agentctl/server/adapter/transport/acp/` — clean.
- The full-package run also reports two failures unrelated to this change (`TestBuildPromptContentBlocks_PathModeAttachmentSavesWritableFile`, `TestBuildPromptContentBlocks_UnsupportedEmbeddedResourceSavesReadOnlyFile`); both fail identically on the untouched base commit — Windows file-mode assertions.
- Diagnosed from a live session: on resume the backend persisted a `{"todos": []}` snapshot 1.6 ms before the `Session resumed` status message, matching the emit order in `LoadSession`.

## Possible Improvements

Low risk — the filter sits on the replay path only. A live "agent cleared the todos" plan update still empties the list as before, and a session whose todos were genuinely cleared before a restart now relies on its persisted empty snapshot for that state.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2315?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->