### PR TITLE
fix(web): reset filtered command list scroll

### DIFF
--- a/apps/packages/ui/src/command.tsx
+++ b/apps/packages/ui/src/command.tsx
@@ -8,6 +8,18 @@ import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } f
 import { InputGroup, InputGroupAddon } from "./input-group";
 import { IconSearch, IconCheck } from "@tabler/icons-react";
 
+type CommandListElement = React.ElementRef<typeof CommandPrimitive.List>;
+type CommandListProps = React.ComponentPropsWithoutRef<typeof CommandPrimitive.List>;
+type RefCleanup = void | (() => void);
+
+function applyCommandListRef(
+  ref: React.ForwardedRef<CommandListElement>,
+  node: CommandListElement | null,
+): RefCleanup {
+  if (typeof ref === "function") return ref(node);
+  if (ref) ref.current = node;
+}
+
 function Command({ className, ...props }: React.ComponentProps<typeof CommandPrimitive>) {
   return (
     <CommandPrimitive
@@ -76,21 +88,69 @@ function CommandInput({
   );
 }
 
-const CommandList = React.forwardRef<
-  React.ElementRef<typeof CommandPrimitive.List>,
-  React.ComponentPropsWithoutRef<typeof CommandPrimitive.List>
->(function CommandList({ className, ...props }, ref) {
+const CommandList = React.forwardRef<CommandListElement, CommandListProps>(function CommandList(
+  { className, ...props },
+  ref,
+) {
   const search = useCommandState((state) => state.search);
-  const internalRef = React.useRef<React.ElementRef<typeof CommandPrimitive.List> | null>(null);
+  const internalRef = React.useRef<CommandListElement | null>(null);
+  const latestForwardedRef = React.useRef(ref);
+  const assignedRef = React.useRef<React.ForwardedRef<CommandListElement>>(null);
+  const assignedCleanup = React.useRef<(() => void) | undefined>(undefined);
+
+  latestForwardedRef.current = ref;
+
+  const detachAssignedRef = React.useCallback(() => {
+    const cleanup = assignedCleanup.current;
+    const forwardedRef = assignedRef.current;
+
+    assignedCleanup.current = undefined;
+    assignedRef.current = null;
+
+    if (cleanup) {
+      cleanup();
+      return;
+    }
+
+    if (forwardedRef) applyCommandListRef(forwardedRef, null);
+  }, []);
+
+  const attachAssignedRef = React.useCallback(
+    (node: CommandListElement, forwardedRef: typeof ref) => {
+      assignedRef.current = forwardedRef;
+      const cleanup = applyCommandListRef(forwardedRef, node);
+      assignedCleanup.current = typeof cleanup === "function" ? cleanup : undefined;
+    },
+    [],
+  );
 
   const setRefs = React.useCallback(
-    (node: React.ElementRef<typeof CommandPrimitive.List> | null) => {
+    (node: CommandListElement | null) => {
+      if (internalRef.current === node) return;
+
+      detachAssignedRef();
       internalRef.current = node;
-      if (typeof ref === "function") ref(node);
-      else if (ref) ref.current = node;
+
+      if (!node) return;
+
+      attachAssignedRef(node, latestForwardedRef.current);
+
+      return () => {
+        if (internalRef.current !== node) return;
+        internalRef.current = null;
+        detachAssignedRef();
+      };
     },
-    [ref],
+    [attachAssignedRef, detachAssignedRef],
   );
+
+  React.useLayoutEffect(() => {
+    const node = internalRef.current;
+    if (!node || assignedRef.current === ref) return;
+
+    detachAssignedRef();
+    attachAssignedRef(node, ref);
+  }, [attachAssignedRef, detachAssignedRef, ref]);
 
   React.useLayoutEffect(() => {
     if (internalRef.current) internalRef.current.scrollTop = 0;

--- a/apps/packages/ui/src/command.tsx
+++ b/apps/packages/ui/src/command.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { Command as CommandPrimitive } from "cmdk";
+import { Command as CommandPrimitive, useCommandState } from "cmdk";
 
 import { cn } from "./lib/utils";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "./dialog";
@@ -76,9 +76,29 @@ function CommandInput({
   );
 }
 
-function CommandList({ className, ...props }: React.ComponentProps<typeof CommandPrimitive.List>) {
+const CommandList = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.List>
+>(function CommandList({ className, ...props }, ref) {
+  const search = useCommandState((state) => state.search);
+  const internalRef = React.useRef<React.ElementRef<typeof CommandPrimitive.List> | null>(null);
+
+  const setRefs = React.useCallback(
+    (node: React.ElementRef<typeof CommandPrimitive.List> | null) => {
+      internalRef.current = node;
+      if (typeof ref === "function") ref(node);
+      else if (ref) ref.current = node;
+    },
+    [ref],
+  );
+
+  React.useLayoutEffect(() => {
+    if (internalRef.current) internalRef.current.scrollTop = 0;
+  }, [search]);
+
   return (
     <CommandPrimitive.List
+      ref={setRefs}
       data-slot="command-list"
       className={cn(
         "max-h-72 scroll-py-1 outline-none overflow-x-hidden overflow-y-auto",
@@ -87,7 +107,9 @@ function CommandList({ className, ...props }: React.ComponentProps<typeof Comman
       {...props}
     />
   );
-}
+});
+
+CommandList.displayName = CommandPrimitive.List.displayName;
 
 function CommandEmpty({
   className,

--- a/apps/web/components/command-list-scroll-reset.test.tsx
+++ b/apps/web/components/command-list-scroll-reset.test.tsx
@@ -1,6 +1,6 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { createRef, useState } from "react";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { Command, CommandInput, CommandItem, CommandList } from "@kandev/ui/command";
 
 const LIST_TEST_ID = "command-list";
@@ -97,5 +97,24 @@ describe("CommandList scroll reset", () => {
     );
 
     expect(ref.current).toBe(getList());
+  });
+
+  it("runs cleanup returned by a callback ref on unmount", () => {
+    const refCleanup = vi.fn();
+    const callbackRef = vi.fn(() => refCleanup);
+    const { unmount } = render(
+      <Command>
+        <CommandInput placeholder={SEARCH_PLACEHOLDER} />
+        <CommandList ref={callbackRef} data-testid={LIST_TEST_ID}>
+          {renderItems()}
+        </CommandList>
+      </Command>,
+    );
+
+    expect(callbackRef).toHaveBeenCalledWith(getList());
+
+    unmount();
+
+    expect(refCleanup).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/components/command-list-scroll-reset.test.tsx
+++ b/apps/web/components/command-list-scroll-reset.test.tsx
@@ -1,0 +1,101 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { createRef, useState } from "react";
+import { afterEach, describe, expect, it } from "vitest";
+import { Command, CommandInput, CommandItem, CommandList } from "@kandev/ui/command";
+
+const LIST_TEST_ID = "command-list";
+const SEARCH_PLACEHOLDER = "Search commands";
+
+function getList() {
+  return screen.getByTestId(LIST_TEST_ID) as HTMLDivElement;
+}
+
+function renderItems() {
+  return ["Alpha", "Beta", "Gamma", "Delta", "Epsilon", "Zeta"].map((label) => (
+    <CommandItem key={label} value={label.toLowerCase()}>
+      {label}
+    </CommandItem>
+  ));
+}
+
+function ControlledCommandHarness() {
+  const [search, setSearch] = useState("");
+
+  return (
+    <Command shouldFilter={false}>
+      <CommandInput placeholder={SEARCH_PLACEHOLDER} value={search} onValueChange={setSearch} />
+      <CommandList data-testid={LIST_TEST_ID}>{renderItems()}</CommandList>
+    </Command>
+  );
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("CommandList scroll reset", () => {
+  it("resets scrollTop when the cmdk query changes", () => {
+    render(
+      <Command>
+        <CommandInput placeholder={SEARCH_PLACEHOLDER} />
+        <CommandList data-testid={LIST_TEST_ID}>{renderItems()}</CommandList>
+      </Command>,
+    );
+
+    const list = getList();
+    list.scrollTop = 123;
+
+    fireEvent.change(screen.getByPlaceholderText(SEARCH_PLACEHOLDER), {
+      target: { value: "be" },
+    });
+
+    expect(list.scrollTop).toBe(0);
+  });
+
+  it("resets scrollTop for controlled inputs that disable cmdk filtering", () => {
+    render(<ControlledCommandHarness />);
+
+    const list = getList();
+    list.scrollTop = 123;
+
+    fireEvent.change(screen.getByPlaceholderText(SEARCH_PLACEHOLDER), {
+      target: { value: "ga" },
+    });
+
+    expect(list.scrollTop).toBe(0);
+  });
+
+  it("resets scrollTop when the query is cleared", () => {
+    render(
+      <Command>
+        <CommandInput placeholder={SEARCH_PLACEHOLDER} />
+        <CommandList data-testid={LIST_TEST_ID}>{renderItems()}</CommandList>
+      </Command>,
+    );
+
+    const input = screen.getByPlaceholderText(SEARCH_PLACEHOLDER);
+    fireEvent.change(input, { target: { value: "de" } });
+
+    const list = getList();
+    list.scrollTop = 88;
+
+    fireEvent.change(input, { target: { value: "" } });
+
+    expect(list.scrollTop).toBe(0);
+  });
+
+  it("forwards external refs to the underlying list element", () => {
+    const ref = createRef<HTMLDivElement>();
+
+    render(
+      <Command>
+        <CommandInput placeholder={SEARCH_PLACEHOLDER} />
+        <CommandList ref={ref} data-testid={LIST_TEST_ID}>
+          {renderItems()}
+        </CommandList>
+      </Command>,
+    );
+
+    expect(ref.current).toBe(getList());
+  });
+});

--- a/docs/plans/search-filter-scroll-reset/plan.md
+++ b/docs/plans/search-filter-scroll-reset/plan.md
@@ -1,0 +1,126 @@
+---
+spec: docs/specs/ui/search-filter-scroll-reset.md
+created: 2026-08-06
+status: completed
+---
+
+# Implementation Plan: Search/filter dropdown scroll reset
+
+## Overview
+
+Fix the scroll-position bug centrally in the shared `@kandev/ui/command`
+`CommandList` primitive so the list scrolls back to the top whenever the active
+search query changes. Because the Command Center, model selectors, comboboxes,
+and the sidebar filter multi-select all render their results through this one
+primitive, a single change fixes every affected input with no call-site edits.
+
+---
+
+## Root cause (confirmed)
+
+`CommandList` (`apps/packages/ui/src/command.tsx`, lines 79-90) renders
+`CommandPrimitive.List` from `cmdk` with `overflow-y-auto`. When the query
+changes, `cmdk` re-filters/re-sorts items and re-renders, but it never resets the
+list element's `scrollTop`. There is no `useEffect`/`ref` in `CommandList` (or any
+consumer) that resets scroll on query change, so the previous scroll offset
+persists over the freshly filtered results.
+
+`cmdk@1.1.1` exports `useCommandState` (aliased from `useCmdk`), a selector hook
+against `cmdk`'s internal store `State`, which includes `search`. `CommandList` is
+always rendered inside a `Command` context in every consumer (verified:
+`command-panel-footer.tsx`, `model-config-selector.tsx`,
+`settings/model-combobox.tsx`, `settings/mode-combobox.tsx`, `combobox.tsx`,
+`task/sidebar-filter/filter-multi-select.tsx`), so it can subscribe to
+`state.search`. The Command Center uses `shouldFilter={false}` with a controlled
+`CommandInput value={search}`; `cmdk` still syncs the controlled input value into
+`state.search`, so the subscription reflects query changes there too.
+
+---
+
+## Frontend
+
+### Shared primitive — `apps/packages/ui/src/command.tsx`
+
+Change `CommandList` so it:
+
+- Imports `useCommandState` from `cmdk` alongside the existing `Command as
+  CommandPrimitive` import.
+- Keeps an internal `ref` to the list element and merges it with any `ref` a
+  consumer passes (so external `ref`s keep working). Add `ref` to the component
+  signature via `React.ComponentProps<typeof CommandPrimitive.List>` (which already
+  includes `ref`) and compose with a local ref (small `mergeRefs`-style callback,
+  or assign inside a callback ref).
+- Subscribes to the query with `const search = useCommandState((state) =>
+  state.search)`.
+- In a `useLayoutEffect` keyed on `[search]`, sets the list element's
+  `scrollTop = 0`. `useLayoutEffect` (not `useEffect`) avoids a one-frame flash of
+  the old scroll offset before the reset paints.
+
+Keep all existing classes, `data-slot="command-list"`, and prop spreading intact.
+Do not touch any consumer component.
+
+### State
+
+No store/hook changes. The behavior derives entirely from `cmdk`'s existing
+internal search state.
+
+---
+
+## Tests
+
+The shared `@kandev/ui` package has no test runner; `apps/web` has vitest + jsdom
+and already renders these primitives, so the regression test lives in `apps/web`
+and imports the REAL primitives (it must NOT mock `@kandev/ui/command`).
+
+- **What:** `CommandList` resets `scrollTop` to 0 when the query changes.
+  **File:** `apps/web/components/command-list-scroll-reset.test.tsx` (new).
+  **How:** Render `<Command><CommandInput/><CommandList>…many CommandItems…
+  </CommandList></Command>`. Grab the `[data-slot="command-list"]` element, set
+  its `scrollTop` to a nonzero value, type into the input via
+  `fireEvent.change`, and assert `scrollTop === 0`. (`scrollTop` is a writable
+  property in jsdom.)
+- **What:** query cleared resets scroll to top. **File:** same. **How:** set a
+  query, set `scrollTop` nonzero, clear the input, assert `scrollTop === 0`.
+- **What:** an external `ref` passed to `CommandList` still receives the list
+  element. **File:** same. **How:** pass a `ref`, assert `ref.current` is the
+  `[data-slot="command-list"]` node.
+
+Run: `cd apps && pnpm install --frozen-lockfile` (fresh worktree only), then
+`cd apps/web && pnpm run typecheck` and
+`cd apps && pnpm --filter @kandev/web test -- components/command-list-scroll-reset.test.tsx`.
+
+---
+
+## E2E Tests
+
+No new E2E is required; the behavior is covered by the unit test above and would
+be brittle to assert via pixel scroll offset in Playwright. If desired later, a
+Command Center E2E could type a query and assert the first result is in view, but
+it is out of scope for this fix.
+
+---
+
+## Verification Results
+
+- ✅ `cd apps && pnpm --filter @kandev/web test -- components/command-list-scroll-reset.test.tsx`
+  - `1` test file passed
+  - `4` tests passed
+- ✅ `cd apps/web && pnpm run typecheck`
+  - `tsc --noEmit` passed
+
+---
+
+## Implementation Waves And Parallel Candidates
+
+Single task; no parallelism.
+
+```
+Wave 1:
+- [x] [task-01-command-list-scroll-reset](task-01-command-list-scroll-reset.md)
+```
+
+---
+
+## Open Questions
+
+None.

--- a/docs/plans/search-filter-scroll-reset/plan.md
+++ b/docs/plans/search-filter-scroll-reset/plan.md
@@ -104,7 +104,7 @@ it is out of scope for this fix.
 
 - ✅ `cd apps && pnpm --filter @kandev/web test -- components/command-list-scroll-reset.test.tsx`
   - `1` test file passed
-  - `4` tests passed
+  - `5` tests passed
 - ✅ `cd apps/web && pnpm run typecheck`
   - `tsc --noEmit` passed
 
@@ -114,7 +114,7 @@ it is out of scope for this fix.
 
 Single task; no parallelism.
 
-```
+```text
 Wave 1:
 - [x] [task-01-command-list-scroll-reset](task-01-command-list-scroll-reset.md)
 ```

--- a/docs/plans/search-filter-scroll-reset/task-01-command-list-scroll-reset.md
+++ b/docs/plans/search-filter-scroll-reset/task-01-command-list-scroll-reset.md
@@ -1,0 +1,100 @@
+---
+id: "01-command-list-scroll-reset"
+title: "Reset CommandList scroll on query change"
+status: done
+wave: 1
+depends_on: []
+plan: "plan.md"
+spec: "../../specs/ui/search-filter-scroll-reset.md"
+---
+
+# Task 01: Reset CommandList scroll on query change
+
+## Intent
+
+Make the shared `@kandev/ui/command` `CommandList` scroll back to the top whenever
+the active `cmdk` search query changes, without altering filtering, sorting,
+selection, keyboard navigation, or any consumer component. One central change
+fixes the Command Center, model selectors, comboboxes, and the sidebar filter
+multi-select.
+
+## Root cause
+
+`CommandList` in `apps/packages/ui/src/command.tsx` renders `cmdk`'s
+`CommandPrimitive.List` (overflow-y-auto) but never resets `scrollTop` when the
+query changes, so the prior scroll offset persists over freshly filtered results.
+
+## Acceptance
+
+- Changing the `cmdk` query resets the list element's `scrollTop` to 0 (verified
+  by the regression test), for both the controlled-input Command Center path
+  (`shouldFilter={false}`) and the default `cmdk`-filtered path.
+- Clearing the query resets the list to the top.
+- Moving the highlight with the arrow keys does NOT force the list back to the
+  top; `cmdk`'s keyboard auto-scroll still follows the active item.
+- An external `ref` passed to `CommandList` still receives the underlying list
+  element, and existing `className`/`onWheel`/other props still apply.
+- No consumer component is modified.
+
+## Files likely touched
+
+- `apps/packages/ui/src/command.tsx` (edit `CommandList`)
+- `apps/web/components/command-list-scroll-reset.test.tsx` (new regression test,
+  importing the real `@kandev/ui/command` primitives — must not mock them)
+
+## Dependencies
+
+None.
+
+## Parallelism
+
+Sequential. Single-file behavior change plus its focused test.
+
+## Inputs
+
+- Spec: `docs/specs/ui/search-filter-scroll-reset.md` (`What`, all `Scenarios`,
+  `Failure modes`).
+- Plan: `plan.md` (`Root cause`, `Frontend`, `Tests`).
+- `cmdk@1.1.1` API: `useCommandState((state) => state.search)` (exported alias of
+  `useCmdk`); `CommandPrimitive.List` accepts a forwarded `ref` to the list div.
+- Existing scroll-reset precedent in the repo:
+  `apps/web/components/task/chat/clamped-scroll-restore.ts`.
+
+## Implementation notes
+
+- Add `useCommandState` to the `cmdk` import in `command.tsx`.
+- In `CommandList`, keep a local `React.useRef` to the list node, compose it with
+  any incoming `ref` via a callback ref, subscribe with
+  `const search = useCommandState((s) => s.search)`, and in
+  `React.useLayoutEffect(() => { if (node) node.scrollTop = 0; }, [search])` reset
+  the scroll. Preserve `data-slot`, classes, and `{...props}`.
+
+## Verification
+
+Bootstrap once if this worktree lacks dependencies:
+
+```bash
+cd apps && pnpm install --frozen-lockfile
+```
+
+TDD: write the regression test first and confirm it fails (scrollTop stays
+nonzero) before editing `CommandList`, then confirm it passes after.
+
+```bash
+cd apps && pnpm --filter @kandev/web test -- components/command-list-scroll-reset.test.tsx
+cd apps/web && pnpm run typecheck
+```
+
+Also run lint on the touched files if the pre-commit hook flags them.
+
+## Results
+
+- Added a focused regression test at `apps/web/components/command-list-scroll-reset.test.tsx`
+  covering plain cmdk filtering, controlled `shouldFilter={false}` inputs, query
+  clearing, and forwarded refs.
+- Updated `apps/packages/ui/src/command.tsx` so `CommandList` subscribes to
+  `useCommandState((state) => state.search)`, resets `scrollTop` in a
+  `useLayoutEffect`, and preserves forwarded refs.
+- Verification passed:
+  - `cd apps && pnpm --filter @kandev/web test -- components/command-list-scroll-reset.test.tsx`
+  - `cd apps/web && pnpm run typecheck`

--- a/docs/plans/search-filter-scroll-reset/task-01-command-list-scroll-reset.md
+++ b/docs/plans/search-filter-scroll-reset/task-01-command-list-scroll-reset.md
@@ -91,7 +91,7 @@ Also run lint on the touched files if the pre-commit hook flags them.
 
 - Added a focused regression test at `apps/web/components/command-list-scroll-reset.test.tsx`
   covering plain cmdk filtering, controlled `shouldFilter={false}` inputs, query
-  clearing, and forwarded refs.
+  clearing, forwarded refs, and callback-ref cleanup on unmount.
 - Updated `apps/packages/ui/src/command.tsx` so `CommandList` subscribes to
   `useCommandState((state) => state.search)`, resets `scrollTop` in a
   `useLayoutEffect`, and preserves forwarded refs.

--- a/docs/specs/ui/search-filter-scroll-reset.md
+++ b/docs/specs/ui/search-filter-scroll-reset.md
@@ -1,0 +1,69 @@
+---
+status: building
+created: 2026-08-06
+owner: kandev
+---
+
+# Search/filter dropdown scroll reset
+
+## Why
+
+Every search/filter dropdown in the web UI renders its results inside the shared
+`@kandev/ui/command` list (a `cmdk` list wrapped in a scrollable `div`). When the
+user scrolls that list and then types (or edits) the search query, `cmdk`
+re-filters and re-sorts the items and re-renders, but it never resets the list's
+scroll offset. The viewport stays parked at the previous `scrollTop`, so the
+newly filtered results can render with the top entries scrolled out of view and a
+scrollbar thumb sitting in the middle of a now-short list. This is visible in the
+Command Center (command palette) and the model selector, and affects the shared
+combobox and filter multi-select that build on the same primitive.
+
+## What
+
+- Whenever the active search query of a `@kandev/ui/command` list changes, the
+  list's scroll position resets to the top (`scrollTop = 0`) so the highest-ranked
+  filtered result is visible.
+- This behavior is provided centrally by the shared `CommandList` primitive, so it
+  applies to every consumer without per-call-site changes: the Command Center
+  (`command-panel`), the task model selector (`model-config-selector`), the
+  settings model/mode comboboxes, the generic `combobox`, and the sidebar filter
+  multi-select.
+- The reset fires only when the query text changes. Highlighting a different item
+  with the arrow keys, opening/closing the popover, or selecting an item does not
+  force the list back to the top, so `cmdk`'s existing keyboard auto-scroll to the
+  active item is preserved.
+- Clearing the query (query becomes empty) also resets the list to the top.
+- Existing filtering, sorting, item selection, keyboard navigation, grouping,
+  `forceMount`, and `shouldFilter={false}` behavior are unchanged.
+
+## Scenarios
+
+- **GIVEN** the Command Center is open with more results than fit in the list and
+  the user has scrolled part-way down, **WHEN** the user types another character
+  that changes the filter, **THEN** the results list is scrolled back to the top
+  and the first matching result is visible.
+- **GIVEN** the task model selector dropdown is open and scrolled down a long
+  model list, **WHEN** the user types in the filter box, **THEN** the filtered
+  model list is scrolled to the top.
+- **GIVEN** a filtered list scrolled to the top, **WHEN** the user presses the
+  Down arrow to move the highlight past the visible area, **THEN** the list scrolls
+  to follow the highlighted item and is NOT forced back to the top.
+- **GIVEN** a search query with results scrolled down, **WHEN** the user clears the
+  query, **THEN** the (unfiltered) list is shown scrolled to the top.
+- **GIVEN** a `CommandList` given an external `ref` or scroll props by a consumer,
+  **WHEN** the scroll-reset behavior runs, **THEN** the consumer's `ref` still
+  receives the underlying list element and consumer scroll props still apply.
+
+## Out of scope
+
+- Persisting or restoring scroll position across dropdown open/close cycles.
+- Changing filtering/sorting/scoring, grouping, or selection semantics of any
+  dropdown.
+- Non-`cmdk` scrollable surfaces (chat transcript, file tree, settings pages).
+- Visual restyling of the scrollbar or list.
+
+## Failure modes
+
+- `CommandList` renders inside a `cmdk` `Command` context in every current
+  consumer; the scroll-reset subscription depends on that context. Rendering
+  `CommandList` outside a `Command` is unsupported and out of scope.

--- a/docs/specs/ui/search-filter-scroll-reset.md
+++ b/docs/specs/ui/search-filter-scroll-reset.md
@@ -1,5 +1,5 @@
 ---
-status: building
+status: shipped
 created: 2026-08-06
 owner: kandev
 ---


### PR DESCRIPTION
## Summary
- reset the shared `@kandev/ui` `CommandList` scroll position to the top whenever the active cmdk search query changes
- preserve forwarded refs and existing keyboard-selection behavior so arrow-key navigation still auto-scrolls to the highlighted item
- add a focused regression test covering normal cmdk filtering, controlled `shouldFilter={false}` inputs, query clearing, and ref forwarding
- include the repair spec and completed plan/task artifacts for the bug investigation and fix workflow

## Testing
- cd apps && pnpm --filter @kandev/web test -- components/command-list-scroll-reset.test.tsx
- cd apps/web && pnpm run typecheck

## Notes
- this fixes the repro in the Command Center and model selector, and also covers other search/filter dropdowns that use the shared `CommandList` primitive


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2318?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->