### PR TITLE
fix(i18n): externalize blocker-cycle toast and cover task-pane helpers

### DIFF
--- a/apps/web/components/task/add-workspace-sources/add-workspace-sources-availability.ts
+++ b/apps/web/components/task/add-workspace-sources/add-workspace-sources-availability.ts
@@ -1,3 +1,5 @@
+import { t } from "@/lib/i18n";
+
 type AvailabilityInput = {
   isLoading?: boolean;
   hasActiveTurn?: boolean;
@@ -10,7 +12,6 @@ export function hasActiveTaskSourceWork(
 ): boolean {
   return taskSessionIds.some((sessionId) => Boolean(activeTurnBySession[sessionId]));
 }
-import { t } from "@/lib/i18n";
 
 export function getAddSourcesDisabledReason({
   isLoading,

--- a/apps/web/components/task/simple/components/blockers-picker.tsx
+++ b/apps/web/components/task/simple/components/blockers-picker.tsx
@@ -14,13 +14,16 @@ import type { OfficeTask } from "@/lib/state/slices/office/types";
 import type { Task } from "@/app/office/tasks/[id]/types";
 import { MultiSelectPopover, type MultiSelectItem } from "./multi-select-popover";
 import { useTranslation } from "react-i18next";
+import { t } from "@/lib/i18n";
 
 // formatBlockerCycleMessage renders the toast text for a 400 response
 // whose body carries a `cycle` array. The backend already substitutes
 // identifiers when available; we just join with the arrow separator and
 // prepend a human label.
+// Module-level `t` rather than a hook: this runs when the API rejects the edit,
+// not at import. The task identifiers in `cycle` are data and stay verbatim.
 export function formatBlockerCycleMessage(cycle: string[]): string {
-  return `Would create a blocker cycle: ${cycle.join(" → ")}`;
+  return t("task:wouldCreateABlockerCycle", { cycle: cycle.join(" → ") });
 }
 
 // extractCycle reads the `cycle` field from a structured ApiError body.

--- a/apps/web/src/locales/en/task.json
+++ b/apps/web/src/locales/en/task.json
@@ -777,6 +777,7 @@
   "workspaceCount_one": "{{count}} workspace",
   "workspaceCount_other": "{{count}} workspaces",
   "workspaceRepository": "Workspace repository",
+  "wouldCreateABlockerCycle": "Would create a blocker cycle: {{cycle}}",
   "writeYourChangesHere": "Write your changes here",
   "you": "You",
   "youCanAttachUpToFiles": "You can attach up to {{maxFiles}} files.",

--- a/apps/web/src/locales/pseudo/task.json
+++ b/apps/web/src/locales/pseudo/task.json
@@ -777,6 +777,7 @@
   "workspaceCount_one": "{{count}} ŵōŕķśƥàćē",
   "workspaceCount_other": "{{count}} ŵōŕķśƥàćēś",
   "workspaceRepository": "Ŵōŕķśƥàćē ŕēƥōśĩţōŕŷ",
+  "wouldCreateABlockerCycle": "Ŵōũĺď ćŕēàţē à ƀĺōćķēŕ ćŷćĺē: {{cycle}}",
   "writeYourChangesHere": "Ŵŕĩţē ŷōũŕ ćĥàńĝēś ĥēŕē",
   "you": "Ŷōũ",
   "youCanAttachUpToFiles": "Ŷōũ ćàń àţţàćĥ ũƥ ţō {{maxFiles}} ƒĩĺēś.",

--- a/apps/web/src/locales/pseudo/workspaces.json
+++ b/apps/web/src/locales/pseudo/workspaces.json
@@ -56,7 +56,7 @@
   "selectEnvironmentSecret": "Śēĺēćţ à śēćŕēţ",
   "missingSecretReference": "Ḿĩśśĩńĝ śēćŕēţ ŕēƒēŕēńćē",
   "noEnvironmentSecrets": "Ńō ēńvĩŕōńḿēńţ śēćŕēţś ćōńƒĩĝũŕēď.",
-  "noAvailableEnvironmentSecrets": "Ńō Ĝĺōƀàĺ ōŕ ŵōŕķśƥàćē śēćŕēţś àŕē àvàĩĺàƀĺē.",
+  "noAvailableEnvironmentSecrets": "Ńō Ĝĺōƀàĺ ōŕ Ŵōŕķśƥàćē śēćŕēţś àŕē àvàĩĺàƀĺē.",
   "addEnvironmentSecret": "Àďď ēńvĩŕōńḿēńţ śēćŕēţ",
   "removeEnvironmentSecret": "Ŕēḿōvē ēńvĩŕōńḿēńţ śēćŕēţ {{key}}",
   "environmentSecretKeyInvalid": "Ũśē à vàĺĩď ƤŌŚĨX ēńvĩŕōńḿēńţ ķēŷ.",


### PR DESCRIPTION
#2316 merged while three review fixes were still in flight, so `components/task/simple` is on the `i18nGuardFiles` allowlist while one user-facing toast in it is still hardcoded English — the guard runs in JSX-only mode and cannot see it, so nothing would catch the gap.

## Important Changes

- **`formatBlockerCycleMessage` now goes through `t()`.** It builds the "Would create a blocker cycle: …" toast from a plain TS helper, which `mode: "jsx-only"` never inspects. The task identifiers in `cycle` stay verbatim as data. My own non-JSX sweep for #2316 only scanned double-quoted literals and missed this template literal.
- **Tests for the two helpers whose contract changed in #2316.** `groupSessionsForTimeline`'s `roleChip` and the sidebar-filter registry's `getDimensionEnumOptions` / `getOpLabel` now return catalog keys rather than resolved copy; these pin that, including a locale switch asserting filter option *values* stay English while labels move.
- **Import placement** in `add-workspace-sources-availability.ts` — the `t` import sat below a function definition.

Deliberately left English: `Unknown filter dimension: ${dim}` in `filter-dimension-registry.ts` is a developer invariant thrown on an unreachable branch, not user-facing copy.

## Validation

From `apps/web` on Node 24, against current `main`:

- `pnpm run typecheck` — clean
- `pnpm lint --max-warnings 0` — clean
- `pnpm run i18n:check` — all four gates pass
- `node scripts/check-guard-allowlist.mjs` — 410 entries intact
- `pnpm run i18n:sweep <the seven task subdirectories>` — 0 plural concatenations, 0 literals to review
- `pnpm exec vitest run` on the three affected test files — 12 passing

## Possible Improvements

Low risk — the rendered English is byte-identical to the literal it replaced, so accessible-name queries are unaffected.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2321?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->