### PR TITLE
fix(lifecycle): reject terminal sessions before creating an execution

### DIFF
--- a/apps/backend/internal/agent/runtime/lifecycle/manager_execution.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_execution.go
@@ -419,6 +419,10 @@ func (m *Manager) resumeExistingExecution(ctx context.Context, sessionID string,
 
 // createExecutionFromSessionInfo creates a new execution for a passthrough session
 // when no execution exists (e.g., backend restarted and execution store was cleared).
+//
+// Terminal sessions are rejected by the guard at the top of createExecution, the
+// same one every other creation path goes through, so this recovery path never
+// spawns a runtime for a session that ended before the restart.
 func (m *Manager) createExecutionFromSessionInfo(ctx context.Context, sessionID string) (*AgentExecution, error) {
 	if m.workspaceInfoProvider == nil {
 		return nil, fmt.Errorf("cannot restore session %s: workspace info provider not configured", sessionID)

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_execution.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_execution.go
@@ -510,6 +510,15 @@ func (m *Manager) createExecution(ctx context.Context, taskID string, info *Work
 	if info == nil {
 		return nil, fmt.Errorf("workspace info is required")
 	}
+	// A terminal session can never gain an execution, so reject it before
+	// reconciling the workspace, taking an activity lease, or creating a
+	// runtime instance. User-facing panels (terminal, git, files) reconnect on
+	// a timer; without this every retry paid for a full instance creation that
+	// the post-creation check below tore straight back down. That check stays —
+	// it guards the session that terminalizes *during* creation.
+	if err := m.ensureLaunchSessionStillActive(ctx, info.SessionID); err != nil {
+		return nil, err
+	}
 	owner := ownedDirectoryLinkOwner(taskID, info.TaskDirName)
 	if err := reconcileWorkspaceSources(ctx, info.WorkspacePath, info.WorkspaceFolders, owner); err != nil {
 		return nil, err

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_execution_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_execution_test.go
@@ -358,48 +358,76 @@ func TestCreateExecutionRollsBackWhenRegistrationCannotPersist(t *testing.T) {
 	}
 }
 
-// A shell terminal left open on a terminal session reconnects on a timer. Each
-// attempt must be rejected from the session state alone: creating the runtime
-// instance first and rolling it back turned an idle panel into a spawn/teardown
-// loop for as long as the tab stayed open.
-func TestGetOrEnsureExecutionForEnvironmentRejectsTerminalSessionWithoutCreatingInstance(t *testing.T) {
-	for _, state := range []models.TaskSessionState{
+const (
+	terminalSessionID     = "session-terminal-shell"
+	terminalEnvironmentID = "env-terminal-shell"
+	terminalTaskID        = "task-terminal-shell"
+)
+
+func newTerminalSessionManager(t *testing.T, state models.TaskSessionState) (*Manager, *createInstanceExecutor) {
+	t.Helper()
+	mgr, backend := newEnvironmentExecutionTestManager(t, &mockWorkspaceInfoProvider{
+		infos: map[string]*WorkspaceInfo{
+			terminalSessionID: {
+				TaskID: terminalTaskID, SessionID: terminalSessionID,
+				TaskEnvironmentID: terminalEnvironmentID, WorkspacePath: "/workspace/task",
+				AgentID: "auggie",
+			},
+		},
+	})
+	mgr.SetExecutorProfileReader(&fakeExecutorProfileReader{session: &models.TaskSession{
+		ID: terminalSessionID, TaskID: terminalTaskID, State: state,
+	}})
+	return mgr, backend
+}
+
+// A shell terminal left open on a terminal session reconnects on a timer, and
+// the file, git, LSP and port panels poll their own session-keyed path. Every
+// entry point must be rejected from the session state alone: creating the
+// runtime instance first and rolling it back turned an idle panel into a
+// spawn/teardown loop for as long as the tab stayed open.
+func TestEnsureExecutionRejectsTerminalSessionWithoutCreatingInstance(t *testing.T) {
+	entryPoints := []struct {
+		name string
+		call func(*Manager) error
+	}{
+		{"GetOrEnsureExecutionForEnvironment", func(m *Manager) error {
+			_, err := m.GetOrEnsureExecutionForEnvironment(context.Background(), terminalEnvironmentID)
+			return err
+		}},
+		{"GetOrEnsureExecution", func(m *Manager) error {
+			_, err := m.GetOrEnsureExecution(context.Background(), terminalSessionID)
+			return err
+		}},
+		{"EnsureWorkspaceExecutionForSession", func(m *Manager) error {
+			_, err := m.EnsureWorkspaceExecutionForSession(context.Background(), terminalTaskID, terminalSessionID)
+			return err
+		}},
+	}
+	states := []models.TaskSessionState{
 		models.TaskSessionStateFailed,
 		models.TaskSessionStateCancelled,
 		models.TaskSessionStateCompleted,
-	} {
-		t.Run(string(state), func(t *testing.T) {
-			const (
-				sessionID     = "session-terminal-shell"
-				environmentID = "env-terminal-shell"
-			)
-			mgr, backend := newEnvironmentExecutionTestManager(t, &mockWorkspaceInfoProvider{
-				infos: map[string]*WorkspaceInfo{
-					sessionID: {
-						TaskID: "task-terminal-shell", SessionID: sessionID,
-						TaskEnvironmentID: environmentID, WorkspacePath: "/workspace/task",
-						AgentID: "auggie",
-					},
-				},
-			})
-			mgr.SetExecutorProfileReader(&fakeExecutorProfileReader{session: &models.TaskSession{
-				ID: sessionID, TaskID: "task-terminal-shell", State: state,
-			}})
+	}
+	for _, entryPoint := range entryPoints {
+		for _, state := range states {
+			t.Run(entryPoint.name+"/"+string(state), func(t *testing.T) {
+				mgr, backend := newTerminalSessionManager(t, state)
 
-			_, err := mgr.GetOrEnsureExecutionForEnvironment(context.Background(), environmentID)
-			if !errors.Is(err, ErrSessionTerminal) {
-				t.Fatalf("GetOrEnsureExecutionForEnvironment error = %v, want ErrSessionTerminal", err)
-			}
-			if got := backend.createCount.Load(); got != 0 {
-				t.Fatalf("CreateInstance calls = %d, want 0", got)
-			}
-			if got := backend.stopCount.Load(); got != 0 {
-				t.Fatalf("StopInstance calls = %d, want 0", got)
-			}
-			if _, exists := mgr.executionStore.GetBySessionID(sessionID); exists {
-				t.Fatal("terminal session must not register an execution")
-			}
-		})
+				if err := entryPoint.call(mgr); !errors.Is(err, ErrSessionTerminal) {
+					t.Fatalf("%s error = %v, want ErrSessionTerminal", entryPoint.name, err)
+				}
+				if got := backend.createCount.Load(); got != 0 {
+					t.Fatalf("CreateInstance calls = %d, want 0", got)
+				}
+				if got := backend.stopCount.Load(); got != 0 {
+					t.Fatalf("StopInstance calls = %d, want 0", got)
+				}
+				if _, exists := mgr.executionStore.GetBySessionID(terminalSessionID); exists {
+					t.Fatal("terminal session must not register an execution")
+				}
+			})
+		}
 	}
 }
 

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_execution_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_execution_test.go
@@ -358,6 +358,51 @@ func TestCreateExecutionRollsBackWhenRegistrationCannotPersist(t *testing.T) {
 	}
 }
 
+// A shell terminal left open on a terminal session reconnects on a timer. Each
+// attempt must be rejected from the session state alone: creating the runtime
+// instance first and rolling it back turned an idle panel into a spawn/teardown
+// loop for as long as the tab stayed open.
+func TestGetOrEnsureExecutionForEnvironmentRejectsTerminalSessionWithoutCreatingInstance(t *testing.T) {
+	for _, state := range []models.TaskSessionState{
+		models.TaskSessionStateFailed,
+		models.TaskSessionStateCancelled,
+		models.TaskSessionStateCompleted,
+	} {
+		t.Run(string(state), func(t *testing.T) {
+			const (
+				sessionID     = "session-terminal-shell"
+				environmentID = "env-terminal-shell"
+			)
+			mgr, backend := newEnvironmentExecutionTestManager(t, &mockWorkspaceInfoProvider{
+				infos: map[string]*WorkspaceInfo{
+					sessionID: {
+						TaskID: "task-terminal-shell", SessionID: sessionID,
+						TaskEnvironmentID: environmentID, WorkspacePath: "/workspace/task",
+						AgentID: "auggie",
+					},
+				},
+			})
+			mgr.SetExecutorProfileReader(&fakeExecutorProfileReader{session: &models.TaskSession{
+				ID: sessionID, TaskID: "task-terminal-shell", State: state,
+			}})
+
+			_, err := mgr.GetOrEnsureExecutionForEnvironment(context.Background(), environmentID)
+			if !errors.Is(err, ErrSessionTerminal) {
+				t.Fatalf("GetOrEnsureExecutionForEnvironment error = %v, want ErrSessionTerminal", err)
+			}
+			if got := backend.createCount.Load(); got != 0 {
+				t.Fatalf("CreateInstance calls = %d, want 0", got)
+			}
+			if got := backend.stopCount.Load(); got != 0 {
+				t.Fatalf("StopInstance calls = %d, want 0", got)
+			}
+			if _, exists := mgr.executionStore.GetBySessionID(sessionID); exists {
+				t.Fatal("terminal session must not register an execution")
+			}
+		})
+	}
+}
+
 func TestResolveTaskEnvironmentID(t *testing.T) {
 	t.Run("returns TaskEnvironmentID when execution carries it", func(t *testing.T) {
 		store := NewExecutionStore()


### PR DESCRIPTION
## Problem

A shell terminal tab left open on a task whose session has reached a terminal
state turns into a runtime spawn/teardown loop that runs for as long as the tab
stays open.

The frontend terminal reconnect loop (`apps/web/components/task/ws-reconnect.ts`)
backs off to a flat 5s and never gives up. Every attempt reaches
`handleEnvironmentUserShellWS` → `GetOrEnsureExecutionForEnvironment` →
`createExecution`, which reconciles the workspace, takes an activity lease, and
creates a full runtime instance — and only *then* calls
`ensureLaunchSessionStillActive`, discovers the session is terminal, and rolls
the instance straight back down.

From a local run, 27 identical cycles in three minutes before the user
relaunched the session:

```
WARN  rolling back launch execution
      {"component": "lifecycle-manager", "reason": "session ended during runtime creation"}
WARN  environment terminal execution not ready
      {"component": "terminal_handler",
       "error": "verify session before registering execution: session \"<id>\" is FAILED"}
WARN  http  {"method": "GET", "path": "/terminal/*target", "status": 503, "duration_ms": 772}
```

Each doomed attempt cost 156–3200 ms. The wasted work is not only the runtime
instance: `createExecution` also runs `reconcileWorkspaceSources`,
`reconcileWorkspaceRepositories` and `reconcileWorkspaceWorktrees` first, and
holds an `activity.KindExecutionStarting` lease for the duration — so a dead
terminal tab repeatedly blocks maintenance from acquiring the activity
coordinator. The cost per cycle is worst where process creation and git
invocations are expensive, but the loop itself is platform-independent.

`ErrSessionTerminal` already documents the intended contract:

> a terminal session will never recover an execution

`computeGitCommits` and `computeCumulativeDiff` honour it by returning a
`session_terminal` reason so clients stop polling. The execution-creation path
knew the same fact but only checked it after paying for the instance.

## Fix

Hoist the existing `ensureLaunchSessionStillActive` check to the top of
`createExecution`, before any workspace reconciliation, activity lease, or
`CreateInstance`. Nine lines, no new error type, no behavioural change for any
caller: a terminal session already failed with `ErrSessionTerminal` — it now
fails with the same sentinel without the wasted work.

The post-creation check is deliberately kept. The two are not redundant: the new
one rejects a session that is *already* terminal, the existing one guards the
session that terminalizes *during* creation, which is the remote-runtime race
its comment describes.

This covers all three entry points that funnel into `createExecution` —
`GetOrEnsureExecution`, `GetOrEnsureExecutionForEnvironment` and
`EnsureWorkspaceExecutionForSession` — so the file, git, LSP, port and VS Code
panels stop paying for it too, not just the terminal.

## Testing

`TestGetOrEnsureExecutionForEnvironmentRejectsTerminalSessionWithoutCreatingInstance`
covers all three terminal states (FAILED, CANCELLED, COMPLETED) and asserts the
sentinel plus `CreateInstance == 0` and `StopInstance == 0`. Without the fix it
fails with `CreateInstance calls = 1, want 0` in each state.

`go test -tags fts5 ./internal/agent/runtime/lifecycle/` was run before and after
the change on the same machine; the set of failures is identical (all
pre-existing Windows-environment failures: symlink privileges, path separators,
`autocrlf` on embedded prompt templates). `./internal/gateway/websocket/` and
`./internal/agent/handlers/` pass clean, and
`golangci-lint run ./... --new-from-rev=<base>` reports 0 issues.

## Not in this PR

The client half of the loop is untouched: `ws-reconnect.ts` retries on any
`onclose` and cannot tell a permanent failure from a transient one, because a
503 on the WebSocket upgrade reaches the browser as a bare 1006 close with no
body. Signalling permanence properly means accepting the upgrade and closing
with a dedicated code, plus deciding what the terminal pane should show — a
separate change, and a UX call I did not want to make unilaterally. Happy to
follow up if you tell me which shape you prefer.

Whether a user shell *should* be refused on a terminal session at all is also
left alone. Opening a shell in the worktree is arguably most useful right after
an agent failed, but that is a product decision, not a bug.

One path worth naming explicitly, since it is easy to miss in the diff:
passthrough recovery (`EnsurePassthroughExecution` → `createExecutionFromSessionInfo`)
reaches `createExecution` too, so it picks up the early rejection as well. The
outcome there is unchanged — the late guard already rejected those sessions and
rolled the instance back — but a backend restart that finds a terminal session
now skips the runtime spawn instead of paying for it. `262afcd22` points at the
shared guard from the recovery function so the next reader does not have to
trace it.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2325?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
