### PR TITLE
fix(mcp): report the agent profile that will actually launch

### DIFF
--- a/apps/backend/internal/mcp/handlers/config_workflow_handlers_test.go
+++ b/apps/backend/internal/mcp/handlers/config_workflow_handlers_test.go
@@ -531,3 +531,28 @@ func TestHandleImportWorkflow_ValidationError(t *testing.T) {
 	require.NoError(t, err)
 	assertWSError(t, resp, ws.ErrorCodeValidation)
 }
+
+// A step's pinned agent profile outranks an explicit agent_profile_id, matching
+// what the orchestrator launches. Reporting the caller's profile back would
+// confirm an agent that never runs.
+func TestResolveMCPAutoStartConfig_StepPinnedProfileOutranksExplicit(t *testing.T) {
+	h, _, repo := setupImportHandlers(t)
+	ctx := context.Background()
+	h.workflowCtrl = workflowctrl.NewController(h.workflowSvc)
+
+	require.NoError(t, repo.CreateStep(ctx, &wfmodels.WorkflowStep{
+		ID:             "step-pinned",
+		WorkflowID:     "wf-test",
+		Name:           "In Progress",
+		Position:       0,
+		IsStartStep:    true,
+		AgentProfileID: "step-pinned-profile",
+	}))
+
+	config, err := h.resolveMCPAutoStartConfigWithError(ctx, &taskmodels.Task{
+		WorkflowID:     "wf-test",
+		WorkflowStepID: "step-pinned",
+	}, "explicit-profile", "", "")
+	require.NoError(t, err)
+	assert.Equal(t, "step-pinned-profile", config.AgentProfileID)
+}

--- a/apps/backend/internal/mcp/handlers/handlers.go
+++ b/apps/backend/internal/mcp/handlers/handlers.go
@@ -1129,6 +1129,14 @@ func (h *Handlers) resolveMCPAutoStartConfigWithError(ctx context.Context, task 
 		}
 	}
 
+	// A workflow step's pinned profile outranks the caller's, because that is
+	// what the orchestrator launches (resolveEffectiveAgentProfile). Resolving
+	// it here too keeps the profile reported back to the caller equal to the
+	// one that will actually run.
+	if stepProfileID, _ := h.resolveWorkflowControllerAgentProfile(ctx, task.WorkflowStepID, task.WorkflowID); stepProfileID != "" {
+		agentProfileID = stepProfileID
+	}
+
 	if agentProfileID == "" {
 		var err error
 		agentProfileID, err = h.resolveWorkflowAgentProfileWithError(ctx, task.WorkflowStepID, task.WorkflowID)

--- a/apps/backend/internal/mcp/server/handlers_test.go
+++ b/apps/backend/internal/mcp/server/handlers_test.go
@@ -62,7 +62,7 @@ func TestCreateTask_ToolSchema_HasParentID(t *testing.T) {
 	require.True(t, ok, "prompt should have a description")
 	assert.Contains(t, promptDesc, "For auto-started subtasks")
 	assert.NotContains(t, promptDesc, "REQUIRED")
-	assert.Contains(t, tool.Tool.Description, "explicit agent_profile_id always wins")
+	assert.Contains(t, tool.Tool.Description, "outranks an explicit agent_profile_id")
 	assert.Contains(t, tool.Tool.Description, "current_task")
 	assert.Contains(t, tool.Tool.Description, "workspace_default")
 	assert.Contains(t, tool.Tool.Description, "workflow")
@@ -73,7 +73,7 @@ func TestCreateTask_ToolSchema_HasParentID(t *testing.T) {
 	require.True(t, ok, "agent_profile_id schema should be an object")
 	agentProfileDesc, ok := agentProfileProp["description"].(string)
 	require.True(t, ok, "agent_profile_id should have a description")
-	assert.Contains(t, agentProfileDesc, "Explicit agent_profile_id always wins")
+	assert.Contains(t, agentProfileDesc, "outranks it")
 	assert.Contains(t, agentProfileDesc, "current_task")
 	assert.Contains(t, agentProfileDesc, "workspace_default")
 

--- a/apps/backend/internal/mcp/server/server.go
+++ b/apps/backend/internal/mcp/server/server.go
@@ -818,7 +818,7 @@ WHEN TO OMIT parent_id (top-level task):
 
 IMPORTANT:
 - Subtasks inherit task workspace, workflow, agent profile, executor, and materialized workspace from the parent by default. Pass workspace_id/workflow_id only when deliberately targeting a different task workspace/workflow; any supplied workflow_id must belong to the effective workspace_id. Pass workspace_mode='new_workspace' when the subtask needs its own materialized workspace/worktree.
-- A workflow step's pinned agent profile (or the workflow default behind it) outranks an explicit agent_profile_id — that profile is what launches, and it is the one reported back in the created task's metadata. Otherwise an explicit agent_profile_id wins. When both are absent, the saved user policy applies: current_task inherits from the current/source task or parent before workflow and target-workspace defaults; workspace_default skips current/source and parent profiles, honors workflow profiles first, then uses the target workspace default.
+- A workflow step's pinned agent profile outranks an explicit agent_profile_id — that profile is what launches, and it is the one reported back in the created task's metadata. Otherwise an explicit agent_profile_id wins. When both are absent, the saved user policy applies: current_task inherits from the current/source task or parent before workflow and target-workspace defaults; workspace_default skips current/source and parent profiles, honors workflow profiles first, then uses the target workspace default.
 - Executor and executor-profile inheritance from the current/source task or parent is unchanged by either saved agent-profile policy.
 - Every created task must have a resolvable agent profile. start_agent=false still records the profile for a later manual start.
 - Subtasks inherit the parent's repository unless you supply repository_url, repository_id, or local_path — in which case the subtask targets that repo instead
@@ -831,7 +831,7 @@ IMPORTANT:
 - start_agent defaults to true and is what you want in nearly every case — the new task auto-launches an agent that immediately works on the prompt. Pass start_agent=false ONLY for an explicit placeholder (e.g. queuing work the user will start later, or creating a tracking task with no immediate work), and still pass agent_profile_id unless it can be inherited. When in doubt, leave it true.
 - Kanban subtasks cannot have their own subtasks (max nesting depth is 1). To break work down further, create a sibling under the same parent. (Office task trees are exempt.)`
 	parentDesc := "Parent task ID for subtasks. Use 'self' to create a subtask of your current task (RECOMMENDED for plan phases, delegated work). Omit only for unrelated top-level tasks."
-	agentProfileDesc := "Agent profile ID to use. A workflow step's pinned profile (or the workflow default behind it) outranks it; otherwise an explicit agent_profile_id wins. When both are absent, current_task inherits the current/source or parent profile before workflow/workspace defaults; workspace_default skips those task profiles, then uses workflow profiles before the target workspace default. start_agent=false still needs a resolvable profile for later manual start."
+	agentProfileDesc := "Agent profile ID to use. A workflow step's pinned profile outranks it; otherwise an explicit agent_profile_id wins. When both are absent, current_task inherits the current/source or parent profile before workflow/workspace defaults; workspace_default skips those task profiles, then uses workflow profiles before the target workspace default. start_agent=false still needs a resolvable profile for later manual start."
 
 	if s.mode == ModeExternal {
 		toolDesc = `Create a new top-level task and auto-start an agent on it.
@@ -839,14 +839,14 @@ IMPORTANT:
 IMPORTANT:
 - Provide a repository via repository_url, repository_id, or local_path
 - workspace_id and workflow_id are auto-resolved if only one exists; provide explicitly if ambiguous
-- A workflow step's pinned agent profile (or the workflow default behind it) outranks an explicit agent_profile_id — that profile is what launches, and it is the one reported back in the created task's metadata. Otherwise an explicit agent_profile_id wins. When both are absent, the saved user policy applies: current_task inherits a parent profile before workflow and target-workspace defaults; workspace_default skips the parent profile, honors workflow profiles first, then uses the target workspace default. External mode has no current/source task.
+- A workflow step's pinned agent profile outranks an explicit agent_profile_id — that profile is what launches, and it is the one reported back in the created task's metadata. Otherwise an explicit agent_profile_id wins. When both are absent, the saved user policy applies: current_task inherits a parent profile before workflow and target-workspace defaults; workspace_default skips the parent profile, honors workflow profiles first, then uses the target workspace default. External mode has no current/source task.
 - Executor and executor-profile inheritance from a parent is unchanged by either saved agent-profile policy.
 - Every created task must have a resolvable agent profile. start_agent=false still records the profile for a later manual start.
 - 'prompt' is the agent's initial prompt — be specific and detailed
 - start_agent defaults to true and is what you want in nearly every case — the new task auto-launches an agent that immediately works on the prompt. Pass start_agent=false ONLY for an explicit placeholder (e.g. queuing work the user will start later), and still pass agent_profile_id unless a default exists. When in doubt, leave it true.
 - Use parent_id only when delegating to a known existing task by its ID`
 		parentDesc = "Optional parent task ID. Omit for top-level tasks; provide an existing task ID only to create a subtask of that task."
-		agentProfileDesc = "Agent profile ID to use. A workflow step's pinned profile (or the workflow default behind it) outranks it; otherwise an explicit agent_profile_id wins. When both are absent, current_task inherits a parent profile before workflow/workspace defaults; workspace_default skips the parent profile, then uses workflow profiles before the target workspace default. External mode has no current/source task. start_agent=false still needs a resolvable profile for later manual start."
+		agentProfileDesc = "Agent profile ID to use. A workflow step's pinned profile outranks it; otherwise an explicit agent_profile_id wins. When both are absent, current_task inherits a parent profile before workflow/workspace defaults; workspace_default skips the parent profile, then uses workflow profiles before the target workspace default. External mode has no current/source task. start_agent=false still needs a resolvable profile for later manual start."
 	}
 
 	s.mcpServer.AddTool(

--- a/apps/backend/internal/mcp/server/server.go
+++ b/apps/backend/internal/mcp/server/server.go
@@ -818,7 +818,7 @@ WHEN TO OMIT parent_id (top-level task):
 
 IMPORTANT:
 - Subtasks inherit task workspace, workflow, agent profile, executor, and materialized workspace from the parent by default. Pass workspace_id/workflow_id only when deliberately targeting a different task workspace/workflow; any supplied workflow_id must belong to the effective workspace_id. Pass workspace_mode='new_workspace' when the subtask needs its own materialized workspace/worktree.
-- An explicit agent_profile_id always wins. When omitted, the saved user policy applies: current_task inherits from the current/source task or parent before workflow and target-workspace defaults; workspace_default skips current/source and parent profiles, honors workflow profiles first, then uses the target workspace default.
+- A workflow step's pinned agent profile (or the workflow default behind it) outranks an explicit agent_profile_id — that profile is what launches, and it is the one reported back in the created task's metadata. Otherwise an explicit agent_profile_id wins. When both are absent, the saved user policy applies: current_task inherits from the current/source task or parent before workflow and target-workspace defaults; workspace_default skips current/source and parent profiles, honors workflow profiles first, then uses the target workspace default.
 - Executor and executor-profile inheritance from the current/source task or parent is unchanged by either saved agent-profile policy.
 - Every created task must have a resolvable agent profile. start_agent=false still records the profile for a later manual start.
 - Subtasks inherit the parent's repository unless you supply repository_url, repository_id, or local_path — in which case the subtask targets that repo instead
@@ -831,7 +831,7 @@ IMPORTANT:
 - start_agent defaults to true and is what you want in nearly every case — the new task auto-launches an agent that immediately works on the prompt. Pass start_agent=false ONLY for an explicit placeholder (e.g. queuing work the user will start later, or creating a tracking task with no immediate work), and still pass agent_profile_id unless it can be inherited. When in doubt, leave it true.
 - Kanban subtasks cannot have their own subtasks (max nesting depth is 1). To break work down further, create a sibling under the same parent. (Office task trees are exempt.)`
 	parentDesc := "Parent task ID for subtasks. Use 'self' to create a subtask of your current task (RECOMMENDED for plan phases, delegated work). Omit only for unrelated top-level tasks."
-	agentProfileDesc := "Agent profile ID to use. Explicit agent_profile_id always wins. When omitted, current_task inherits the current/source or parent profile before workflow/workspace defaults; workspace_default skips those task profiles, then uses workflow profiles before the target workspace default. start_agent=false still needs a resolvable profile for later manual start."
+	agentProfileDesc := "Agent profile ID to use. A workflow step's pinned profile (or the workflow default behind it) outranks it; otherwise an explicit agent_profile_id wins. When both are absent, current_task inherits the current/source or parent profile before workflow/workspace defaults; workspace_default skips those task profiles, then uses workflow profiles before the target workspace default. start_agent=false still needs a resolvable profile for later manual start."
 
 	if s.mode == ModeExternal {
 		toolDesc = `Create a new top-level task and auto-start an agent on it.
@@ -839,14 +839,14 @@ IMPORTANT:
 IMPORTANT:
 - Provide a repository via repository_url, repository_id, or local_path
 - workspace_id and workflow_id are auto-resolved if only one exists; provide explicitly if ambiguous
-- An explicit agent_profile_id always wins. When omitted, the saved user policy applies: current_task inherits a parent profile before workflow and target-workspace defaults; workspace_default skips the parent profile, honors workflow profiles first, then uses the target workspace default. External mode has no current/source task.
+- A workflow step's pinned agent profile (or the workflow default behind it) outranks an explicit agent_profile_id — that profile is what launches, and it is the one reported back in the created task's metadata. Otherwise an explicit agent_profile_id wins. When both are absent, the saved user policy applies: current_task inherits a parent profile before workflow and target-workspace defaults; workspace_default skips the parent profile, honors workflow profiles first, then uses the target workspace default. External mode has no current/source task.
 - Executor and executor-profile inheritance from a parent is unchanged by either saved agent-profile policy.
 - Every created task must have a resolvable agent profile. start_agent=false still records the profile for a later manual start.
 - 'prompt' is the agent's initial prompt — be specific and detailed
 - start_agent defaults to true and is what you want in nearly every case — the new task auto-launches an agent that immediately works on the prompt. Pass start_agent=false ONLY for an explicit placeholder (e.g. queuing work the user will start later), and still pass agent_profile_id unless a default exists. When in doubt, leave it true.
 - Use parent_id only when delegating to a known existing task by its ID`
 		parentDesc = "Optional parent task ID. Omit for top-level tasks; provide an existing task ID only to create a subtask of that task."
-		agentProfileDesc = "Agent profile ID to use. Explicit agent_profile_id always wins. When omitted, current_task inherits a parent profile before workflow/workspace defaults; workspace_default skips the parent profile, then uses workflow profiles before the target workspace default. External mode has no current/source task. start_agent=false still needs a resolvable profile for later manual start."
+		agentProfileDesc = "Agent profile ID to use. A workflow step's pinned profile (or the workflow default behind it) outranks it; otherwise an explicit agent_profile_id wins. When both are absent, current_task inherits a parent profile before workflow/workspace defaults; workspace_default skips the parent profile, then uses workflow profiles before the target workspace default. External mode has no current/source task. start_agent=false still needs a resolvable profile for later manual start."
 	}
 
 	s.mcpServer.AddTool(

--- a/apps/backend/internal/mcp/server/server_test.go
+++ b/apps/backend/internal/mcp/server/server_test.go
@@ -646,7 +646,7 @@ func TestServerModeExternal_RegistersCorrectTools(t *testing.T) {
 	// External mode includes create_task_kandev so external agents can spawn tasks
 	assert.Contains(t, tools, "create_task_kandev")
 	createTask := s.mcpServer.ListTools()["create_task_kandev"]
-	assert.Contains(t, createTask.Tool.Description, "explicit agent_profile_id always wins")
+	assert.Contains(t, createTask.Tool.Description, "outranks an explicit agent_profile_id")
 	assert.Contains(t, createTask.Tool.Description, "current_task")
 	assert.Contains(t, createTask.Tool.Description, "workspace_default")
 	assert.Contains(t, createTask.Tool.Description, "workflow profiles first")


### PR DESCRIPTION
Fixes #2328.

Per @carlosflorencio's call on the issue — the step's pinned profile winning is correct, the problem is that nothing says so.

## What was wrong

Two layers disagreed on precedence:

- **MCP** (`resolveMCPAutoStartConfigWithError`) consulted the workflow profile only when the caller passed none — caller wins.
- **Orchestrator** (`resolveEffectiveAgentProfile`) applies the step's pinned profile at launch regardless — step wins.

The MCP layer writes the created task's `agent_profile_id` metadata, so `create_task_kandev` returned the *requested* profile while a different one launched. The only trace was a backend log line, which is what made this hard to diagnose from the API.

The tool description compounded it by promising "an explicit agent_profile_id always wins", and three tests pinned that string — so the suite was holding the inaccurate side in place.

## Change

- `handlers.go`: apply the step-pinned profile in the MCP resolution path, so the reported profile equals the launched one.
- `server.go`: state the real precedence in both the tool description and the `agent_profile_id` field description (in-session and external mode).
- Tests: update the three assertions pinning the old wording; add a regression test that a step-pinned profile outranks an explicit `agent_profile_id`.

## Scope deliberately kept narrow

Only the **step-pinned** profile is made authoritative here. The workflow-level *default* keeps its current precedence, because `TestHandleCreateTask_SourceTaskMetadataWinsOverSessionAndDefaults` encodes that an inherited source-task profile beats a workflow default, and I did not want to silently change that.

Worth flagging though: the orchestrator's `resolveStepAgentProfile` falls back to the workflow default and then overrides the caller with it, so a workflow default still outranks an explicit profile at launch while losing to source-task inheritance in the MCP layer. That asymmetry survives this PR. Happy to follow up if you want it aligned — I just didn't want to guess which direction.

## Verification

`go build ./...` clean; `go test ./internal/mcp/... ./internal/orchestrator/...` all packages pass.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2329?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->