### PR TITLE
feat(plugin-registry): list kandev-plugin-tags

### DIFF
--- a/plugin-registry/plugins.yaml
+++ b/plugin-registry/plugins.yaml
@@ -32,6 +32,9 @@ plugins:
   - id: kandev-plugin-kandy
     repo: kdlbs/kandev-plugin-kandy
     categories: [tools]
+  - id: kandev-plugin-tags
+    repo: yattdev/kandev-plugin-tags
+    categories: [tools]
 # Example entry (copy, uncomment, and fill in when adding a plugin):
 #
 # plugins:


### PR DESCRIPTION
The Tags plugin (`yattdev/kandev-plugin-tags`) has a published `v0.1.1` release, so it can now be curated into the official marketplace catalog.

## Validation

- `node --test plugin-registry/build-index.test.mjs` -- 8/8 pass
- `node plugin-registry/build-index.mjs` locally -- 4 built, 0 skipped, 4 listed; confirmed the new entry resolves (release, manifest `id`/`name`/`description`/`version`, and `package_url` all read correctly from the plugin's `v0.1.1` GitHub release)

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have manually tested my changes and they work as expected.
- [x] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [x] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2333?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

