### PR TITLE
feat(settings): show disabled badge for profiles in settings sidebar

### DIFF
--- a/apps/web/components/app-sidebar/sections/settings/agents-group.tsx
+++ b/apps/web/components/app-sidebar/sections/settings/agents-group.tsx
@@ -8,6 +8,17 @@ import { useAvailableAgents } from "@/hooks/domains/settings/use-available-agent
 import { AGENTS_SETTINGS_HREF } from "@/lib/settings-discovery/catalog/agents";
 import { SettingsGroup, SettingsLeaf } from "./settings-nav-primitives";
 
+// Mirrors the integration-list EnabledBadge (workspaces-group.tsx) with an
+// "off" color. Disabled profiles stay visible here so they remain editable.
+function DisabledBadge() {
+  const { t } = useTranslation();
+  return (
+    <span className="shrink-0 rounded border border-amber-500/30 bg-amber-500/10 px-1 py-0.5 text-[9px] font-medium leading-none text-amber-600 dark:text-amber-400">
+      {t("sidebar:disabledBadge")}
+    </span>
+  );
+}
+
 type AgentsGroupProps = {
   pathname: string;
   expanded?: boolean;
@@ -38,6 +49,7 @@ export function AgentsGroup({ pathname, expanded, onToggle }: AgentsGroupProps) 
               key={profile.id}
               href={profilePath}
               label={`${agentLabel} • ${profile.name}`}
+              labelSuffix={profile.enabled === false ? <DisabledBadge /> : undefined}
               leadingIcon={<AgentLogo agentName={agent.name} className="h-3.5 w-3.5 shrink-0" />}
               isActive={pathname === profilePath}
               depth={1}

--- a/apps/web/components/app-sidebar/sections/settings/settings-tree-render.test.tsx
+++ b/apps/web/components/app-sidebar/sections/settings/settings-tree-render.test.tsx
@@ -88,6 +88,7 @@ vi.mock("@kandev/ui/collapsible", async () => {
 });
 
 import { SettingsTree } from "./settings-tree";
+import { AgentsGroup } from "./agents-group";
 import { GeneralGroup } from "./general-group";
 import { SystemGroup } from "./system-group";
 import { WorkspacesGroup } from "./workspaces-group";
@@ -248,6 +249,36 @@ describe("SettingsTree integration status", () => {
     expect(screen.getByRole("link", { name: "Azure DevOps Enabled" })).toBeTruthy();
     expect(screen.getByTestId("azure-devops-icon")).toBeTruthy();
     expect(screen.getByRole("link", { name: "GitHub" })).toBeTruthy();
+  });
+});
+
+describe("SettingsTree agents group", () => {
+  beforeEach(() => {
+    state.settingsAgents.items = [
+      {
+        id: "agent-1",
+        name: "mock-agent",
+        profiles: [
+          { id: "p-on", name: "default", agentDisplayName: "Mock", enabled: true },
+          { id: "p-off", name: "alt", agentDisplayName: "Mock", enabled: false },
+          { id: "p-legacy", name: "legacy", agentDisplayName: "Mock" },
+        ],
+      },
+    ] as unknown as typeof state.settingsAgents.items;
+  });
+
+  afterEach(() => {
+    cleanup();
+    state.settingsAgents.items = [];
+  });
+
+  it("labels disabled profiles with a badge and leaves others unlabeled", () => {
+    render(<AgentsGroup pathname="/settings/agents" expanded />);
+
+    expect(screen.getByRole("link", { name: "Mock • default" })).toBeTruthy();
+    expect(screen.getByRole("link", { name: "Mock • alt Disabled" })).toBeTruthy();
+    // Legacy payloads without the flag are treated as enabled — no badge.
+    expect(screen.getByRole("link", { name: "Mock • legacy" })).toBeTruthy();
   });
 });
 

--- a/apps/web/src/locales/en/sidebar.json
+++ b/apps/web/src/locales/en/sidebar.json
@@ -27,6 +27,7 @@
   "connectionUnstable": "Connection unstable",
   "connectionUnstableDescription": "Connection unstable. Reconnecting to Kandev.",
   "costs": "Costs",
+  "disabledBadge": "Disabled",
   "enabledBadge": "Enabled",
   "expandGroup": "Expand {{label}}",
   "expandSidebar": "Expand sidebar",

--- a/apps/web/src/locales/pseudo/sidebar.json
+++ b/apps/web/src/locales/pseudo/sidebar.json
@@ -27,6 +27,7 @@
   "connectionUnstable": "Ćōńńēćţĩōń ũńśţàƀĺē",
   "connectionUnstableDescription": "Ćōńńēćţĩōń ũńśţàƀĺē. Ŕēćōńńēćţĩńĝ ţō Ķàńďēv.",
   "costs": "Ćōśţś",
+  "disabledBadge": "Ďĩśàƀĺēď",
   "enabledBadge": "Ēńàƀĺēď",
   "expandGroup": "Ēxƥàńď {{label}}",
   "expandSidebar": "Ēxƥàńď śĩďēƀàŕ",


### PR DESCRIPTION
Disabled profiles are invisible in the settings sidebar, so there's no way to tell a profile was taken out of rotation without opening it. Profile nav items under Settings → Agents now render a small amber **Disabled** badge (mirroring the integration list's **Enabled** badge) when the profile is disabled, while the profile stays visible and editable; legacy payloads without the flag get no badge. Part of the "Disable an Agent Profile" task.

## Validation

- `pnpm vitest run components/app-sidebar/sections/settings/settings-tree-render.test.tsx` — 18 pass (new test: enabled/legacy profiles unlabeled, disabled link reads `Mock • alt Disabled`)
- `pnpm run typecheck` and `pnpm lint` (eslint `--max-warnings 0`) — pass
- `pnpm run i18n:ratchet` — pass (new `sidebar:disabledBadge` key added to en + regenerated pseudo)
- Manually verified in the dev instance: disabling a profile shows the badge in the sidebar link; re-enabling removes it

<!-- kandev-screenshots-start -->
## Screenshots

![Settings sidebar with the disabled profile badge](https://raw.githubusercontent.com/Fclem/kandev/b0ed24724a48c7700ff4781b464c82d1d99547db/disabled-badge-sidebar.png)

![Settings page with the disabled profile badge in the left navigation](https://raw.githubusercontent.com/Fclem/kandev/b0ed24724a48c7700ff4781b464c82d1d99547db/disabled-badge-full.png)
<!-- kandev-screenshots-end -->

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.