### PR TITLE
fix(tasks): clear the pending-input icon when a request resolves

### DIFF
--- a/apps/backend/internal/task/statussummary/projector.go
+++ b/apps/backend/internal/task/statussummary/projector.go
@@ -620,7 +620,14 @@ func (p *Projector) applyPendingMessageLocked(state *projectionState, eventType 
 		return false
 	}
 	state.pendingObserved = true
-	if eventType == events.MessageDeleted || (!isPendingMessage && status != "" && status != statusPending) {
+	// A terminal status means the prompt is no longer awaiting the user, whatever
+	// the message type. Resolutions land as a message.updated on the request row
+	// itself (approved/rejected/expired for permissions, answered/rejected/
+	// cancelled/expired for clarifications), so gating the clear on "not a
+	// request message" left the task-list affordance armed after the user had
+	// already answered. Only the empty and "pending" statuses keep it armed —
+	// that covers a detached-but-answerable clarification, which stays pending.
+	if eventType == events.MessageDeleted || (status != "" && status != statusPending) {
 		return p.clearPendingLocked(state, sessionID)
 	}
 	action := pendingPermission

--- a/apps/backend/internal/task/statussummary/projector_test.go
+++ b/apps/backend/internal/task/statussummary/projector_test.go
@@ -505,6 +505,34 @@ func TestProjectorClearsPendingWhenRequestMessageResolves(t *testing.T) {
 			wantArmed: "clarification",
 			status:    "answered",
 		},
+		{
+			name:        "permission rejected",
+			messageType: "permission_request",
+			arm: func(t *testing.T, eventBus *bus.MemoryEventBus, taskID, sessionID string) {
+				publishProjectorEvent(t, eventBus, events.PermissionRequestReceived, events.BuildPermissionRequestSubject(sessionID), map[string]interface{}{
+					"task_id":    taskID,
+					"session_id": sessionID,
+				})
+			},
+			wantArmed: "permission",
+			status:    "rejected",
+		},
+		{
+			name:        "clarification cancelled",
+			messageType: "clarification_request",
+			arm: func(t *testing.T, eventBus *bus.MemoryEventBus, taskID, sessionID string) {
+				publishProjectorEvent(t, eventBus, events.MessageAdded, events.MessageAdded, map[string]interface{}{
+					"task_id":        taskID,
+					"session_id":     sessionID,
+					"author_type":    "user",
+					"type":           "clarification_request",
+					"requests_input": true,
+					"metadata":       map[string]interface{}{"status": "pending", "pending_id": "pending-1"},
+				})
+			},
+			wantArmed: "clarification",
+			status:    "cancelled",
+		},
 	}
 
 	for i, tc := range cases {

--- a/apps/backend/internal/task/statussummary/projector_test.go
+++ b/apps/backend/internal/task/statussummary/projector_test.go
@@ -452,3 +452,125 @@ func TestProjectorRehydratesSiblingGitObservationsAfterRestart(t *testing.T) {
 		t.Fatalf("Git summary after sibling rehydration = %+v, want additions=8 changed_files=3", got.Git)
 	}
 }
+
+// A resolved permission/clarification request must clear the task-list pending
+// affordance. The resolution arrives as a message.updated on the request row
+// itself, so the projector has to read the terminal status off that row instead
+// of treating every request-typed message as evidence of a live prompt.
+func TestProjectorClearsPendingWhenRequestMessageResolves(t *testing.T) {
+	cases := []struct {
+		name        string
+		messageType string
+		arm         func(t *testing.T, eventBus *bus.MemoryEventBus, taskID, sessionID string)
+		wantArmed   string
+		status      string
+	}{
+		{
+			name:        "permission approved",
+			messageType: "permission_request",
+			arm: func(t *testing.T, eventBus *bus.MemoryEventBus, taskID, sessionID string) {
+				publishProjectorEvent(t, eventBus, events.PermissionRequestReceived, events.BuildPermissionRequestSubject(sessionID), map[string]interface{}{
+					"task_id":    taskID,
+					"session_id": sessionID,
+				})
+			},
+			wantArmed: "permission",
+			status:    "approved",
+		},
+		{
+			name:        "permission expired",
+			messageType: "permission_request",
+			arm: func(t *testing.T, eventBus *bus.MemoryEventBus, taskID, sessionID string) {
+				publishProjectorEvent(t, eventBus, events.PermissionRequestReceived, events.BuildPermissionRequestSubject(sessionID), map[string]interface{}{
+					"task_id":    taskID,
+					"session_id": sessionID,
+				})
+			},
+			wantArmed: "permission",
+			status:    "expired",
+		},
+		{
+			name:        "clarification answered",
+			messageType: "clarification_request",
+			arm: func(t *testing.T, eventBus *bus.MemoryEventBus, taskID, sessionID string) {
+				publishProjectorEvent(t, eventBus, events.MessageAdded, events.MessageAdded, map[string]interface{}{
+					"task_id":        taskID,
+					"session_id":     sessionID,
+					"author_type":    "user",
+					"type":           "clarification_request",
+					"requests_input": true,
+					"metadata":       map[string]interface{}{"status": "pending", "pending_id": "pending-1"},
+				})
+			},
+			wantArmed: "clarification",
+			status:    "answered",
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, store, eventBus, _, _ := newProjectorTest(t)
+			taskID := fmt.Sprintf("task-pending-resolve-%d", i)
+			sessionID := fmt.Sprintf("session-pending-resolve-%d", i)
+
+			publishSessionState(t, eventBus, taskID, sessionID, nil)
+			tc.arm(t, eventBus, taskID, sessionID)
+
+			if got := store.summary(taskID); got == nil || got.PendingAction != tc.wantArmed {
+				t.Fatalf("pending action before resolution = %+v, want %q", got, tc.wantArmed)
+			}
+
+			publishProjectorEvent(t, eventBus, events.MessageUpdated, events.MessageUpdated, map[string]interface{}{
+				"task_id":        taskID,
+				"session_id":     sessionID,
+				"author_type":    "user",
+				"type":           tc.messageType,
+				"requests_input": tc.messageType == "clarification_request",
+				"metadata":       map[string]interface{}{"status": tc.status, "pending_id": "pending-1"},
+			})
+
+			got := store.summary(taskID)
+			if got == nil {
+				t.Fatal("missing projected summary")
+			}
+			if got.PendingAction != "" {
+				t.Fatalf("pending action after %q resolution = %q, want empty", tc.status, got.PendingAction)
+			}
+		})
+	}
+}
+
+// A detached-but-still-answerable clarification keeps status=pending, so the
+// task-list affordance must survive that update.
+func TestProjectorKeepsPendingWhenRequestStaysAnswerable(t *testing.T) {
+	_, store, eventBus, _, _ := newProjectorTest(t)
+	const taskID = "task-pending-detached"
+	const sessionID = "session-pending-detached"
+
+	publishSessionState(t, eventBus, taskID, sessionID, nil)
+	publishProjectorEvent(t, eventBus, events.MessageAdded, events.MessageAdded, map[string]interface{}{
+		"task_id":        taskID,
+		"session_id":     sessionID,
+		"author_type":    "user",
+		"type":           "clarification_request",
+		"requests_input": true,
+		"metadata":       map[string]interface{}{"status": "pending", "pending_id": "pending-1"},
+	})
+	publishProjectorEvent(t, eventBus, events.MessageUpdated, events.MessageUpdated, map[string]interface{}{
+		"task_id":        taskID,
+		"session_id":     sessionID,
+		"author_type":    "user",
+		"type":           "clarification_request",
+		"requests_input": true,
+		"metadata": map[string]interface{}{
+			"status":             "pending",
+			"pending_id":         "pending-1",
+			"agent_disconnected": true,
+		},
+	})
+
+	got := store.summary(taskID)
+	if got == nil || got.PendingAction != "clarification" {
+		t.Fatalf("pending action after detach = %+v, want clarification", got)
+	}
+}


### PR DESCRIPTION
The sidebar kept showing the amber "pending permission / question" icon on tasks whose agent was actively running, because the status-summary projector could never clear the flag once a prompt was answered.

## Important Changes

- `applyPendingMessageLocked` gated its clear branch on the message *not* being a `clarification_request` / `permission_request`. But resolutions arrive as a `message.updated` on the request row itself (`approved`/`rejected`/`expired` for permissions, `answered`/`rejected`/`cancelled`/`expired` for clarifications), so an answered prompt fell past the clear and **re-armed** the flag.
- Permissions had no other clear path at all. Clarifications only escaped by luck, via the separate `clarification.answered` event published after the message update.
- The projection then stayed stale until an unrelated message with a terminal status arrived, or the next `task.updated` re-read the (correct) DB-derived value.
- Now any terminal status clears it, whatever the message type. Empty and `"pending"` still keep it armed, preserving the detached-but-answerable clarification that `clarification/canceller.go` deliberately leaves at `status=pending` with `agent_disconnected=true`.

## Validation

- Added `TestProjectorClearsPendingWhenRequestMessageResolves` (permission approved, permission expired, clarification answered) and `TestProjectorKeepsPendingWhenRequestStaysAnswerable`. All three sub-cases fail before the fix with the exact stale value (`"permission"` / `"clarification"`) and pass after.
- `go test ./internal/task/... ./internal/orchestrator/... ./internal/clarification/...` — passes, except `task/handlers` and `task/service`, which fail only on `parent directory cannot be accessed` (the known worktree-sandbox failures, unrelated to this change and green in CI).
- `golangci-lint run ./internal/task/statussummary/... --new-from-rev=<merge-base>` — 0 issues.
- Confirmed against the live DB that no task currently has a persisted `pending_action` and no session has a pending request row in its latest turn, so the icon observed in the UI was stale projection state rather than real data.

## Possible Improvements

Low risk. `state.pending` holds a single action per session, so a session blocked on a clarification *and* a permission at once still tracks only the latest, and resolving one clears both until the next `task.updated` restores the DB-derived value. That coarseness is pre-existing and not addressed here.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2343?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->