### PR TITLE
feat(plugins): add primary task-menu group and registerTaskFilter hook

### DIFF
--- a/apps/web/components/kanban-board.tsx
+++ b/apps/web/components/kanban-board.tsx
@@ -25,6 +25,7 @@ import { useWorkspacePRs } from "@/hooks/domains/github/use-task-pr";
 import { useWorkspaceMRs } from "@/hooks/domains/gitlab/use-task-mr";
 import { useResponsiveBreakpoint } from "@/hooks/use-responsive-breakpoint";
 import { useTaskMultiSelect } from "@/hooks/use-task-multi-select";
+import { usePluginTaskFilters } from "@/hooks/use-plugin-task-filters";
 import { HomepageCommands } from "./homepage-commands";
 import { linkToTask } from "@/lib/links";
 import {
@@ -392,6 +393,11 @@ export function KanbanBoard({ onPreviewTask, onOpenTask, onBeforeEdit }: KanbanB
   const s = useKanbanBoardSetup(onPreviewTask, onOpenTask, onBeforeEdit);
   const isMobileSearchOpen = useAppStore((state) => state.mobileKanban.isSearchOpen);
   const setMobileSearchOpen = useAppStore((state) => state.setMobileKanbanSearchOpen);
+  const { taskMatchesPluginFilters } = usePluginTaskFilters();
+  const matchesPluginTaskFilters = useCallback(
+    (taskId: string) => taskMatchesPluginFilters({ taskId }),
+    [taskMatchesPluginFilters],
+  );
 
   // Collapse search on unmount so the global flag doesn't auto-open (and focus)
   // the search bar after navigating to another route.
@@ -452,6 +458,7 @@ export function KanbanBoard({ onPreviewTask, onOpenTask, onBeforeEdit }: KanbanB
         showMaximizeButton={s.enablePreviewOnClick}
         searchQuery={s.searchQuery}
         selectedRepositoryIds={s.userSettings.repositoryIds}
+        matchesPluginTaskFilters={matchesPluginTaskFilters}
         selectedIds={s.multiSelect.selectedIds}
         onToggleSelect={s.multiSelect.toggleSelect}
         onSelectRange={s.multiSelect.selectRange}

--- a/apps/web/components/kanban-card-edit-submenu.tsx
+++ b/apps/web/components/kanban-card-edit-submenu.tsx
@@ -2,8 +2,11 @@
 
 import { IconPencil } from "@tabler/icons-react";
 import { t } from "@/lib/i18n";
-import { pluginRegistry } from "@/lib/plugins/registry";
 import type { PluginTaskMenuContext } from "@/lib/plugins/types";
+import {
+  runnablePluginMenuEntry,
+  visiblePluginMenuActions,
+} from "./kanban-card-plugin-menu-actions";
 import type { KanbanCardMenuEntry } from "./kanban-card-menu-items";
 
 /**
@@ -25,18 +28,7 @@ export function buildEditMenuEntry({
   disabled?: boolean;
   context: PluginTaskMenuContext;
 }): KanbanCardMenuEntry {
-  const pluginActions = pluginRegistry.getTaskMenuActions("edit").filter((action) => {
-    if (!action.visible) return true;
-    try {
-      return action.visible(context);
-    } catch (error: unknown) {
-      console.error(
-        `[plugins] task menu action "${action.pluginId}:${action.id}" visible() threw`,
-        error,
-      );
-      return false;
-    }
-  });
+  const pluginActions = visiblePluginMenuActions("edit", context);
 
   const icon = <IconPencil className="mr-2 h-4 w-4" />;
 
@@ -69,35 +61,5 @@ export function buildEditMenuEntry({
       },
       ...pluginActions.map((action) => runnablePluginMenuEntry(action, context, disabled)),
     ],
-  };
-}
-
-function runnablePluginMenuEntry(
-  action: ReturnType<typeof pluginRegistry.getTaskMenuActions>[number],
-  context: PluginTaskMenuContext,
-  disabled?: boolean,
-): KanbanCardMenuEntry {
-  return {
-    kind: "item",
-    key: `plugin-edit-${action.pluginId}-${action.id}`,
-    icon: action.icon,
-    label: action.label,
-    disabled,
-    onSelect: () => {
-      // Promise.resolve().then(() => action.run(context)) — not
-      // Promise.resolve(action.run(context)) — so a *synchronous* throw
-      // inside run() also lands in the .catch() below. Calling action.run
-      // directly as the Promise.resolve() argument still throws before that
-      // expression finishes evaluating, escaping past .catch() entirely and
-      // straight out of this onSelect handler.
-      Promise.resolve()
-        .then(() => action.run(context))
-        .catch((error: unknown) => {
-          console.error(
-            `[plugins] task menu action "${action.pluginId}:${action.id}" failed`,
-            error,
-          );
-        });
-    },
   };
 }

--- a/apps/web/components/kanban-card-link-submenu.tsx
+++ b/apps/web/components/kanban-card-link-submenu.tsx
@@ -1,0 +1,126 @@
+import {
+  IconBrandGitlab,
+  IconBrandSentry,
+  IconCircleDot,
+  IconGitPullRequest,
+  IconLink,
+  IconTicket,
+} from "@tabler/icons-react";
+import { t } from "@/lib/i18n";
+import type { KanbanCardMenuEntry } from "./kanban-card-menu-items";
+
+function buildGitLabMergeRequestLinkEntry({
+  disabled,
+  onLinkMergeRequest,
+}: {
+  disabled?: boolean;
+  onLinkMergeRequest?: () => void;
+}): KanbanCardMenuEntry | null {
+  if (!onLinkMergeRequest) return null;
+  return {
+    kind: "item",
+    key: "link-gitlab-merge-request",
+    testId: "task-context-link-gitlab-merge-request",
+    icon: <IconBrandGitlab className="mr-2 h-4 w-4" />,
+    label: t("kanban:gitlabMergeRequest"),
+    disabled,
+    onSelect: onLinkMergeRequest,
+  };
+}
+
+export function buildLinkSubmenu({
+  disabled,
+  onLinkPullRequest,
+  onLinkIssue,
+  onLinkMergeRequest,
+  onLinkJiraTicket,
+  onLinkLinearIssue,
+  onLinkSentryIssue,
+}: {
+  disabled?: boolean;
+  onLinkPullRequest?: () => void;
+  onLinkIssue?: () => void;
+  onLinkMergeRequest?: () => void;
+  onLinkJiraTicket?: () => void;
+  onLinkLinearIssue?: () => void;
+  onLinkSentryIssue?: () => void;
+}): KanbanCardMenuEntry | null {
+  if (
+    !onLinkPullRequest &&
+    !onLinkIssue &&
+    !onLinkMergeRequest &&
+    !onLinkJiraTicket &&
+    !onLinkLinearIssue &&
+    !onLinkSentryIssue
+  ) {
+    return null;
+  }
+  const children: KanbanCardMenuEntry[] = [];
+  if (onLinkPullRequest) {
+    children.push({
+      kind: "item",
+      key: "link-github-pull-request",
+      testId: "task-context-link-github-pull-request",
+      icon: <IconGitPullRequest className="mr-2 h-4 w-4" />,
+      label: t("kanban:githubPullRequest"),
+      disabled,
+      onSelect: onLinkPullRequest,
+    });
+  }
+  if (onLinkIssue) {
+    children.push({
+      kind: "item",
+      key: "link-github-issue",
+      testId: "task-context-link-github-issue",
+      icon: <IconCircleDot className="mr-2 h-4 w-4" />,
+      label: t("kanban:githubIssue"),
+      disabled,
+      onSelect: onLinkIssue,
+    });
+  }
+  const gitLabEntry = buildGitLabMergeRequestLinkEntry({ disabled, onLinkMergeRequest });
+  if (gitLabEntry) children.push(gitLabEntry);
+  if (onLinkJiraTicket) {
+    children.push({
+      kind: "item",
+      key: "link-jira-ticket",
+      testId: "task-context-link-jira-ticket",
+      icon: <IconTicket className="mr-2 h-4 w-4" />,
+      label: t("kanban:jiraTicket"),
+      disabled,
+      onSelect: onLinkJiraTicket,
+    });
+  }
+  if (onLinkLinearIssue) {
+    children.push({
+      kind: "item",
+      key: "link-linear-issue",
+      testId: "task-context-link-linear-issue",
+      icon: <IconCircleDot className="mr-2 h-4 w-4" />,
+      label: t("kanban:linearIssue"),
+      disabled,
+      onSelect: onLinkLinearIssue,
+    });
+  }
+  if (onLinkSentryIssue) {
+    children.push({
+      kind: "item",
+      key: "link-sentry-issue",
+      testId: "task-context-link-sentry-issue",
+      icon: <IconBrandSentry className="mr-2 h-4 w-4" />,
+      label: t("kanban:sentryIssue"),
+      disabled,
+      onSelect: onLinkSentryIssue,
+    });
+  }
+  return {
+    kind: "submenu",
+    key: "link",
+    testId: "task-context-link",
+    icon: <IconLink className="mr-2 h-4 w-4" />,
+    label: t("kanban:link"),
+    disabled,
+    className: "w-56",
+    children,
+  };
+}

--- a/apps/web/components/kanban-card-menu-items.test.tsx
+++ b/apps/web/components/kanban-card-menu-items.test.tsx
@@ -171,6 +171,87 @@ describe("buildKanbanCardMenuEntries — !onEdit does not disable plugin edit ac
   });
 });
 
+describe("buildKanbanCardMenuEntries — 'primary' group plugin actions", () => {
+  const PLUGIN_ID = "kandev-plugin-tags";
+
+  afterEach(() => {
+    pluginRegistry.unregisterPlugin(PLUGIN_ID);
+  });
+
+  function entryKeys(entries: KanbanCardMenuEntry[]) {
+    return entries.map((entry) => entry.key);
+  }
+
+  it("renders a 'primary' group action as a flat item between Send to workflow and Link", () => {
+    pluginRegistry.forPlugin(PLUGIN_ID).registerTaskMenuAction({
+      id: "quick-tag",
+      label: "Quick tag",
+      group: "primary",
+      run: vi.fn(),
+    });
+
+    const entries = buildKanbanCardMenuEntries({
+      currentWorkflowId: "wf-1",
+      workflows: [
+        { id: "wf-1", name: "Workflow 1" },
+        { id: "wf-2", name: "Workflow 2" },
+      ],
+      stepsByWorkflowId: {
+        "wf-1": [
+          { id: "s1", title: "Step 1" },
+          { id: "s2", title: "Step 2" },
+        ],
+        "wf-2": [{ id: "s3", title: "Step 3" }],
+      },
+      onSendToWorkflow: vi.fn(),
+      onLinkPullRequest: vi.fn(),
+    });
+
+    const keys = entryKeys(entries);
+    const sendToIndex = keys.indexOf("send-to-workflow");
+    const primaryIndex = keys.indexOf(`plugin-primary-${PLUGIN_ID}-quick-tag`);
+    const linkIndex = keys.indexOf("link");
+
+    expect(sendToIndex).toBeGreaterThanOrEqual(0);
+    expect(primaryIndex).toBeGreaterThanOrEqual(0);
+    expect(linkIndex).toBeGreaterThanOrEqual(0);
+    expect(sendToIndex).toBeLessThan(primaryIndex);
+    expect(primaryIndex).toBeLessThan(linkIndex);
+
+    const primaryEntry = entries[primaryIndex];
+    expect(primaryEntry.kind).toBe("item");
+    if (primaryEntry.kind === "item") expect(primaryEntry.label).toBe("Quick tag");
+  });
+
+  it("does not add a 'primary' entry when visible(context) returns false", () => {
+    pluginRegistry.forPlugin(PLUGIN_ID).registerTaskMenuAction({
+      id: "quick-tag",
+      label: "Quick tag",
+      group: "primary",
+      visible: () => false,
+      run: vi.fn(),
+    });
+
+    const entries = buildKanbanCardMenuEntries({ workflows: [], stepsByWorkflowId: {} });
+
+    expect(entryKeys(entries)).not.toContain(`plugin-primary-${PLUGIN_ID}-quick-tag`);
+  });
+
+  it("leaves the 'edit' group submenu unaffected by 'primary' group registrations", () => {
+    pluginRegistry.forPlugin(PLUGIN_ID).registerTaskMenuAction({
+      id: "quick-tag",
+      label: "Quick tag",
+      group: "primary",
+      run: vi.fn(),
+    });
+
+    const entries = buildKanbanCardMenuEntries({ workflows: [], stepsByWorkflowId: {} });
+    const editMenu = entries.find((entry) => entry.key === "edit");
+
+    expect(editMenu?.kind).toBe("item");
+  });
+});
+
 describe("buildKanbanCardMenuEntries — detach", () => {
   const baseArgs = {
     workflows: [],

--- a/apps/web/components/kanban-card-menu-items.tsx
+++ b/apps/web/components/kanban-card-menu-items.tsx
@@ -4,14 +4,8 @@ import { useMemo, type ReactNode } from "react";
 import {
   IconArchive,
   IconArrowRight,
-  IconBrandGitlab,
-  IconBrandSentry,
-  IconCircleDot,
-  IconGitPullRequest,
-  IconLink,
   IconLoader,
   IconLogicBuffer,
-  IconTicket,
   IconTrash,
   IconUnlink,
 } from "@tabler/icons-react";
@@ -40,6 +34,8 @@ import {
 import { cn } from "@/lib/utils";
 import type { PluginTaskMenuContext } from "@/lib/plugins/types";
 import { buildEditMenuEntry } from "./kanban-card-edit-submenu";
+import { buildLinkSubmenu } from "./kanban-card-link-submenu";
+import { buildPrimaryPluginEntries } from "./kanban-card-plugin-menu-actions";
 import { useTranslation } from "react-i18next";
 import { t } from "@/lib/i18n";
 
@@ -249,122 +245,6 @@ function buildSendToWorkflowSubmenu({
   };
 }
 
-function buildGitLabMergeRequestLinkEntry({
-  disabled,
-  onLinkMergeRequest,
-}: {
-  disabled?: boolean;
-  onLinkMergeRequest?: () => void;
-}): KanbanCardMenuEntry | null {
-  if (!onLinkMergeRequest) return null;
-  return {
-    kind: "item",
-    key: "link-gitlab-merge-request",
-    testId: "task-context-link-gitlab-merge-request",
-    icon: <IconBrandGitlab className="mr-2 h-4 w-4" />,
-    label: t("kanban:gitlabMergeRequest"),
-    disabled,
-    onSelect: onLinkMergeRequest,
-  };
-}
-
-function buildLinkSubmenu({
-  disabled,
-  onLinkPullRequest,
-  onLinkIssue,
-  onLinkMergeRequest,
-  onLinkJiraTicket,
-  onLinkLinearIssue,
-  onLinkSentryIssue,
-}: {
-  disabled?: boolean;
-  onLinkPullRequest?: () => void;
-  onLinkIssue?: () => void;
-  onLinkMergeRequest?: () => void;
-  onLinkJiraTicket?: () => void;
-  onLinkLinearIssue?: () => void;
-  onLinkSentryIssue?: () => void;
-}): KanbanCardMenuEntry | null {
-  if (
-    !onLinkPullRequest &&
-    !onLinkIssue &&
-    !onLinkMergeRequest &&
-    !onLinkJiraTicket &&
-    !onLinkLinearIssue &&
-    !onLinkSentryIssue
-  ) {
-    return null;
-  }
-  const children: KanbanCardMenuEntry[] = [];
-  if (onLinkPullRequest) {
-    children.push({
-      kind: "item",
-      key: "link-github-pull-request",
-      testId: "task-context-link-github-pull-request",
-      icon: <IconGitPullRequest className="mr-2 h-4 w-4" />,
-      label: t("kanban:githubPullRequest"),
-      disabled,
-      onSelect: onLinkPullRequest,
-    });
-  }
-  if (onLinkIssue) {
-    children.push({
-      kind: "item",
-      key: "link-github-issue",
-      testId: "task-context-link-github-issue",
-      icon: <IconCircleDot className="mr-2 h-4 w-4" />,
-      label: t("kanban:githubIssue"),
-      disabled,
-      onSelect: onLinkIssue,
-    });
-  }
-  const gitLabEntry = buildGitLabMergeRequestLinkEntry({ disabled, onLinkMergeRequest });
-  if (gitLabEntry) children.push(gitLabEntry);
-  if (onLinkJiraTicket) {
-    children.push({
-      kind: "item",
-      key: "link-jira-ticket",
-      testId: "task-context-link-jira-ticket",
-      icon: <IconTicket className="mr-2 h-4 w-4" />,
-      label: t("kanban:jiraTicket"),
-      disabled,
-      onSelect: onLinkJiraTicket,
-    });
-  }
-  if (onLinkLinearIssue) {
-    children.push({
-      kind: "item",
-      key: "link-linear-issue",
-      testId: "task-context-link-linear-issue",
-      icon: <IconCircleDot className="mr-2 h-4 w-4" />,
-      label: t("kanban:linearIssue"),
-      disabled,
-      onSelect: onLinkLinearIssue,
-    });
-  }
-  if (onLinkSentryIssue) {
-    children.push({
-      kind: "item",
-      key: "link-sentry-issue",
-      testId: "task-context-link-sentry-issue",
-      icon: <IconBrandSentry className="mr-2 h-4 w-4" />,
-      label: t("kanban:sentryIssue"),
-      disabled,
-      onSelect: onLinkSentryIssue,
-    });
-  }
-  return {
-    kind: "submenu",
-    key: "link",
-    testId: "task-context-link",
-    icon: <IconLink className="mr-2 h-4 w-4" />,
-    label: t("kanban:link"),
-    disabled,
-    className: "w-56",
-    children,
-  };
-}
-
 export function buildKanbanCardMenuEntries({
   currentWorkflowId,
   currentStepId,
@@ -416,6 +296,13 @@ export function buildKanbanCardMenuEntries({
     onSendToWorkflow,
   });
   if (sendToEntry) entries.push(sendToEntry);
+
+  entries.push(
+    ...buildPrimaryPluginEntries({
+      disabled: isProcessing,
+      context: resolvePluginMenuContext(pluginMenuContext),
+    }),
+  );
 
   const linkEntry = buildLinkSubmenu({
     disabled: isProcessing,

--- a/apps/web/components/kanban-card-plugin-menu-actions.ts
+++ b/apps/web/components/kanban-card-plugin-menu-actions.ts
@@ -1,0 +1,82 @@
+import { pluginRegistry } from "@/lib/plugins/registry";
+import type { PluginTaskMenuContext } from "@/lib/plugins/types";
+import type { KanbanCardMenuEntry } from "./kanban-card-menu-items";
+type PluginTaskMenuAction = ReturnType<typeof pluginRegistry.getTaskMenuActions>[number];
+
+/**
+ * Registered actions for `group`, filtered by `visible(context)` (default
+ * visible when omitted). A `visible` that throws is caught, logged, and
+ * treated as hidden — the same defensive handling as `run`'s rejection.
+ */
+export function visiblePluginMenuActions(
+  group: PluginTaskMenuAction["group"],
+  context: PluginTaskMenuContext,
+): PluginTaskMenuAction[] {
+  return pluginRegistry.getTaskMenuActions(group).filter((action) => {
+    if (!action.visible) return true;
+    try {
+      return action.visible(context);
+    } catch (error: unknown) {
+      console.error(
+        `[plugins] task menu action "${action.pluginId}:${action.id}" visible() threw`,
+        error,
+      );
+      return false;
+    }
+  });
+}
+
+/**
+ * Builds a runnable menu entry for a plugin task menu action. A `run` that
+ * throws or rejects is caught and logged; the menu still closes because
+ * `DropdownMenuItem`/`ContextMenuItem` already close on select regardless
+ * of the async result.
+ */
+export function runnablePluginMenuEntry(
+  action: PluginTaskMenuAction,
+  context: PluginTaskMenuContext,
+  disabled?: boolean,
+  keyPrefix = "plugin-edit",
+): KanbanCardMenuEntry {
+  return {
+    kind: "item",
+    key: `${keyPrefix}-${action.pluginId}-${action.id}`,
+    icon: action.icon,
+    label: action.label,
+    disabled,
+    onSelect: () => {
+      // Promise.resolve().then(() => action.run(context)) — not
+      // Promise.resolve(action.run(context)) — so a *synchronous* throw
+      // inside run() also lands in the .catch() below. Calling action.run
+      // directly as the Promise.resolve() argument still throws before that
+      // expression finishes evaluating, escaping past .catch() entirely and
+      // straight out of this onSelect handler.
+      Promise.resolve()
+        .then(() => action.run(context))
+        .catch((error: unknown) => {
+          console.error(
+            `[plugins] task menu action "${action.pluginId}:${action.id}" failed`,
+            error,
+          );
+        });
+    },
+  };
+}
+
+/**
+ * Builds flat, top-level menu entries for group "primary" task menu
+ * actions, in registration order. Unlike group "edit" (nested in the Edit
+ * submenu), these render directly in the card menu — positioned between
+ * "Move to"/"Send to workflow" and "Link".
+ */
+export function buildPrimaryPluginEntries({
+  disabled,
+  context,
+}: {
+  disabled?: boolean;
+  context: PluginTaskMenuContext;
+}): KanbanCardMenuEntry[] {
+  return visiblePluginMenuActions("primary", context).map((action) =>
+    runnablePluginMenuEntry(action, context, disabled, "plugin-primary"),
+  );
+}

--- a/apps/web/components/kanban-display-dropdown.test.tsx
+++ b/apps/web/components/kanban-display-dropdown.test.tsx
@@ -21,14 +21,33 @@ vi.mock("@/hooks/use-kanban-display-settings", () => ({
 
 afterEach(cleanup);
 
-describe("KanbanDisplayDropdown — plugin task filters", () => {
-  function openDropdown() {
-    const trigger = screen.getByTestId("display-button");
-    fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false, pointerType: "mouse" });
-    fireEvent.pointerUp(trigger, { button: 0, ctrlKey: false, pointerType: "mouse" });
-    fireEvent.click(trigger);
-  }
+const TAGS_PLUGIN_ID = "kandev-plugin-tags";
+const TAGS_FILTER_ID = "tags";
+const TAGS_FILTER_KEY = `${TAGS_PLUGIN_ID}:${TAGS_FILTER_ID}`;
+const TAGS_FILTER_TEST_ID = `display-plugin-filter-${TAGS_FILTER_KEY}`;
+const PRIORITY_PLUGIN_ID = "kandev-plugin-priority";
+const PRIORITY_FILTER_KEY = `${PRIORITY_PLUGIN_ID}:${TAGS_FILTER_ID}`;
+const DATA_STATE_ATTRIBUTE = "data-state";
 
+const TAGS_FILTER = {
+  pluginId: TAGS_PLUGIN_ID,
+  id: TAGS_FILTER_ID,
+  label: "Tags",
+  getOptions: () => [
+    { value: "bug", label: "Bug" },
+    { value: "feature", label: "Feature" },
+  ],
+  matches: () => true,
+};
+
+function openDropdown() {
+  const trigger = screen.getByTestId("display-button");
+  fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false, pointerType: "mouse" });
+  fireEvent.pointerUp(trigger, { button: 0, ctrlKey: false, pointerType: "mouse" });
+  fireEvent.click(trigger);
+}
+
+describe("KanbanDisplayDropdown — plugin task filters", () => {
   it("renders no plugin filter section when none are registered", () => {
     render(<KanbanDisplayDropdown pluginFilters={[]} />);
     openDropdown();
@@ -39,30 +58,21 @@ describe("KanbanDisplayDropdown — plugin task filters", () => {
   it("renders a filter section with its options and current selection", () => {
     render(
       <KanbanDisplayDropdown
-        pluginFilters={[
-          {
-            pluginId: "kandev-plugin-tags",
-            id: "tags",
-            label: "Tags",
-            getOptions: () => [
-              { value: "bug", label: "Bug" },
-              { value: "feature", label: "Feature" },
-            ],
-            matches: () => true,
-          },
-        ]}
-        pluginFilterSelections={{ "kandev-plugin-tags:tags": ["bug"] }}
+        pluginFilters={[TAGS_FILTER]}
+        pluginFilterSelections={{ [TAGS_FILTER_KEY]: ["bug"] }}
       />,
     );
     openDropdown();
 
-    expect(screen.getByTestId("display-plugin-filter-tags")).not.toBeNull();
+    expect(screen.getByTestId(TAGS_FILTER_TEST_ID)).not.toBeNull();
     expect(screen.getByText("Tags")).not.toBeNull();
     expect(
-      screen.getByTestId("display-plugin-filter-tags-option-bug").getAttribute("data-state"),
+      screen.getByTestId(`${TAGS_FILTER_TEST_ID}-option-bug`).getAttribute(DATA_STATE_ATTRIBUTE),
     ).toBe("checked");
     expect(
-      screen.getByTestId("display-plugin-filter-tags-option-feature").getAttribute("data-state"),
+      screen
+        .getByTestId(`${TAGS_FILTER_TEST_ID}-option-feature`)
+        .getAttribute(DATA_STATE_ATTRIBUTE),
     ).toBe("unchecked");
   });
 
@@ -70,23 +80,74 @@ describe("KanbanDisplayDropdown — plugin task filters", () => {
     const onPluginFilterChange = vi.fn();
     render(
       <KanbanDisplayDropdown
-        pluginFilters={[
-          {
-            pluginId: "kandev-plugin-tags",
-            id: "tags",
-            label: "Tags",
-            getOptions: () => [{ value: "bug", label: "Bug" }],
-            matches: () => true,
-          },
-        ]}
+        pluginFilters={[TAGS_FILTER]}
         pluginFilterSelections={{}}
         onPluginFilterChange={onPluginFilterChange}
       />,
     );
     openDropdown();
 
-    fireEvent.click(screen.getByTestId("display-plugin-filter-tags-option-bug"));
+    fireEvent.click(screen.getByTestId(`${TAGS_FILTER_TEST_ID}-option-bug`));
 
-    expect(onPluginFilterChange).toHaveBeenCalledWith("kandev-plugin-tags:tags", ["bug"]);
+    expect(onPluginFilterChange).toHaveBeenCalledWith(TAGS_FILTER_KEY, ["bug"]);
+  });
+});
+
+describe("KanbanDisplayDropdown — plugin task filter identities", () => {
+  it("keeps same-id filters from different plugins independent", () => {
+    const onPluginFilterChange = vi.fn();
+    const firstFilterKey = TAGS_FILTER_KEY;
+    const secondFilterKey = PRIORITY_FILTER_KEY;
+    const secondFilter = {
+      pluginId: PRIORITY_PLUGIN_ID,
+      id: TAGS_FILTER_ID,
+      label: "Priority",
+      getOptions: () => [{ value: "high", label: "High" }],
+      matches: () => true,
+    };
+
+    render(
+      <KanbanDisplayDropdown
+        pluginFilters={[TAGS_FILTER, secondFilter]}
+        pluginFilterSelections={{ [firstFilterKey]: ["bug"] }}
+        onPluginFilterChange={onPluginFilterChange}
+      />,
+    );
+    openDropdown();
+
+    expect(
+      screen
+        .getByTestId(`display-plugin-filter-${firstFilterKey}-option-bug`)
+        .getAttribute(DATA_STATE_ATTRIBUTE),
+    ).toBe("checked");
+    expect(
+      screen
+        .getByTestId(`display-plugin-filter-${secondFilterKey}-option-high`)
+        .getAttribute(DATA_STATE_ATTRIBUTE),
+    ).toBe("unchecked");
+
+    fireEvent.click(screen.getByTestId(`display-plugin-filter-${secondFilterKey}-option-high`));
+
+    expect(onPluginFilterChange).toHaveBeenCalledWith(secondFilterKey, ["high"]);
+  });
+
+  it("memoizes options while a filter registration remains stable", () => {
+    const getOptions = vi.fn(() => [{ value: "bug", label: "Bug" }]);
+    const filter = {
+      pluginId: TAGS_PLUGIN_ID,
+      id: TAGS_FILTER_ID,
+      label: TAGS_FILTER.label,
+      getOptions,
+      matches: () => true,
+    };
+    const props = { pluginFilters: [filter] };
+    const { rerender } = render(<KanbanDisplayDropdown {...props} />);
+    openDropdown();
+
+    expect(getOptions).toHaveBeenCalledTimes(1);
+
+    rerender(<KanbanDisplayDropdown {...props} />);
+
+    expect(getOptions).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/components/kanban-display-dropdown.test.tsx
+++ b/apps/web/components/kanban-display-dropdown.test.tsx
@@ -51,7 +51,7 @@ describe("KanbanDisplayDropdown — plugin task filters", () => {
             matches: () => true,
           },
         ]}
-        pluginFilterSelections={{ tags: ["bug"] }}
+        pluginFilterSelections={{ "kandev-plugin-tags:tags": ["bug"] }}
       />,
     );
     openDropdown();
@@ -87,6 +87,6 @@ describe("KanbanDisplayDropdown — plugin task filters", () => {
 
     fireEvent.click(screen.getByTestId("display-plugin-filter-tags-option-bug"));
 
-    expect(onPluginFilterChange).toHaveBeenCalledWith("tags", ["bug"]);
+    expect(onPluginFilterChange).toHaveBeenCalledWith("kandev-plugin-tags:tags", ["bug"]);
   });
 });

--- a/apps/web/components/kanban-display-dropdown.test.tsx
+++ b/apps/web/components/kanban-display-dropdown.test.tsx
@@ -1,0 +1,92 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { KanbanDisplayDropdown } from "./kanban-display-dropdown";
+
+vi.mock("@/hooks/use-kanban-display-settings", () => ({
+  useKanbanDisplaySettings: () => ({
+    workflows: [],
+    activeWorkflowId: null,
+    repositories: [],
+    repositoriesLoading: false,
+    allRepositoriesSelected: true,
+    selectedRepositoryId: null,
+    enablePreviewOnClick: false,
+    tasksListShowDetails: false,
+    onWorkflowChange: vi.fn(),
+    onRepositoryChange: vi.fn(),
+    onTogglePreviewOnClick: vi.fn(),
+    onToggleTasksListShowDetails: vi.fn(),
+  }),
+}));
+
+afterEach(cleanup);
+
+describe("KanbanDisplayDropdown — plugin task filters", () => {
+  function openDropdown() {
+    const trigger = screen.getByTestId("display-button");
+    fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false, pointerType: "mouse" });
+    fireEvent.pointerUp(trigger, { button: 0, ctrlKey: false, pointerType: "mouse" });
+    fireEvent.click(trigger);
+  }
+
+  it("renders no plugin filter section when none are registered", () => {
+    render(<KanbanDisplayDropdown pluginFilters={[]} />);
+    openDropdown();
+
+    expect(screen.queryByTestId(/display-plugin-filter-/)).toBeNull();
+  });
+
+  it("renders a filter section with its options and current selection", () => {
+    render(
+      <KanbanDisplayDropdown
+        pluginFilters={[
+          {
+            pluginId: "kandev-plugin-tags",
+            id: "tags",
+            label: "Tags",
+            getOptions: () => [
+              { value: "bug", label: "Bug" },
+              { value: "feature", label: "Feature" },
+            ],
+            matches: () => true,
+          },
+        ]}
+        pluginFilterSelections={{ tags: ["bug"] }}
+      />,
+    );
+    openDropdown();
+
+    expect(screen.getByTestId("display-plugin-filter-tags")).not.toBeNull();
+    expect(screen.getByText("Tags")).not.toBeNull();
+    expect(
+      screen.getByTestId("display-plugin-filter-tags-option-bug").getAttribute("data-state"),
+    ).toBe("checked");
+    expect(
+      screen.getByTestId("display-plugin-filter-tags-option-feature").getAttribute("data-state"),
+    ).toBe("unchecked");
+  });
+
+  it("invokes onPluginFilterChange with the updated selection when toggling an option", () => {
+    const onPluginFilterChange = vi.fn();
+    render(
+      <KanbanDisplayDropdown
+        pluginFilters={[
+          {
+            pluginId: "kandev-plugin-tags",
+            id: "tags",
+            label: "Tags",
+            getOptions: () => [{ value: "bug", label: "Bug" }],
+            matches: () => true,
+          },
+        ]}
+        pluginFilterSelections={{}}
+        onPluginFilterChange={onPluginFilterChange}
+      />,
+    );
+    openDropdown();
+
+    fireEvent.click(screen.getByTestId("display-plugin-filter-tags-option-bug"));
+
+    expect(onPluginFilterChange).toHaveBeenCalledWith("tags", ["bug"]);
+  });
+});

--- a/apps/web/components/kanban-display-dropdown.tsx
+++ b/apps/web/components/kanban-display-dropdown.tsx
@@ -12,6 +12,7 @@ import {
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@kandev/ui/select";
 import { IconAdjustmentsHorizontal } from "@tabler/icons-react";
 import { useKanbanDisplaySettings } from "@/hooks/use-kanban-display-settings";
+import type { PluginTaskFilterRegistration } from "@/lib/plugins/registry";
 import type { Repository } from "@/lib/types/http";
 import type { WorkflowsState } from "@/lib/state/slices";
 import type { ComponentProps } from "react";
@@ -21,6 +22,10 @@ import { getRepositoryPlaceholderKey } from "@/lib/kanban/repository-placeholder
 type KanbanDisplayDropdownProps = {
   triggerSize?: ComponentProps<typeof Button>["size"];
   currentPage?: "kanban" | "tasks";
+  /** Plugin-registered task filters (`registerTaskFilter`) rendered as extra sections. */
+  pluginFilters?: PluginTaskFilterRegistration[];
+  pluginFilterSelections?: Record<string, string[]>;
+  onPluginFilterChange?: (filterId: string, values: string[]) => void;
 };
 
 function WorkflowSection({
@@ -98,11 +103,111 @@ function RepositorySection({
   );
 }
 
+function PluginFilterSection({
+  filter,
+  selected,
+  onChange,
+}: {
+  filter: PluginTaskFilterRegistration;
+  selected: string[];
+  onChange: (values: string[]) => void;
+}) {
+  const options = filter.getOptions();
+  const toggleOption = (value: string, checked: boolean) => {
+    onChange(checked ? [...selected, value] : selected.filter((v) => v !== value));
+  };
+
+  return (
+    <div className="space-y-1.5" data-testid={`display-plugin-filter-${filter.id}`}>
+      <DropdownMenuLabel className="px-0 text-foreground">{filter.label}</DropdownMenuLabel>
+      <div className="space-y-1">
+        {options.map((option) => (
+          <label key={option.value} className="flex items-center gap-2 cursor-pointer">
+            <Checkbox
+              data-testid={`display-plugin-filter-${filter.id}-option-${option.value}`}
+              checked={selected.includes(option.value)}
+              onCheckedChange={(checked) => toggleOption(option.value, checked === true)}
+            />
+            {option.color && (
+              <span
+                className="h-2 w-2 rounded-full shrink-0"
+                style={{ backgroundColor: option.color }}
+              />
+            )}
+            <span className="text-sm text-foreground">{option.label}</span>
+          </label>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function PreviewPanelSection({
+  enablePreviewOnClick,
+  onTogglePreviewOnClick,
+}: {
+  enablePreviewOnClick: boolean | undefined;
+  onTogglePreviewOnClick: ((value: boolean) => void) | undefined;
+}) {
+  const { t } = useTranslation();
+  return (
+    <div className="space-y-1.5">
+      <DropdownMenuLabel className="px-0 text-foreground">
+        {t("kanban:previewPanel")}
+      </DropdownMenuLabel>
+      <label className="flex items-center gap-2 cursor-pointer">
+        <Checkbox
+          checked={enablePreviewOnClick ?? false}
+          onCheckedChange={(checked) => {
+            onTogglePreviewOnClick?.(!!checked);
+          }}
+        />
+        <span className="text-sm text-foreground">{t("kanban:openPreviewOnClick")}</span>
+      </label>
+      <p className="text-xs text-muted-foreground pl-6">
+        {t("kanban:whenEnabledClickingATaskOpens")}
+      </p>
+    </div>
+  );
+}
+
+function TasksListSection({
+  tasksListShowDetails,
+  onToggleTasksListShowDetails,
+}: {
+  tasksListShowDetails: boolean;
+  onToggleTasksListShowDetails: (value: boolean) => void;
+}) {
+  const { t } = useTranslation();
+  return (
+    <>
+      <DropdownMenuSeparator />
+      <div className="space-y-1.5">
+        <DropdownMenuLabel className="px-0 text-foreground">
+          {t("kanban:listRows")}
+        </DropdownMenuLabel>
+        <label className="flex items-center gap-2 cursor-pointer">
+          <Checkbox
+            checked={tasksListShowDetails}
+            onCheckedChange={(checked) => onToggleTasksListShowDetails(checked === true)}
+          />
+          <span className="text-sm text-foreground">{t("kanban:showTaskDetails")}</span>
+        </label>
+        <p className="pl-6 text-xs text-muted-foreground">
+          {t("kanban:addRepositoryPullRequestSessionParent")}
+        </p>
+      </div>
+    </>
+  );
+}
+
 export function KanbanDisplayDropdown({
   triggerSize = "icon",
   currentPage = "kanban",
+  pluginFilters,
+  pluginFilterSelections,
+  onPluginFilterChange,
 }: KanbanDisplayDropdownProps) {
-  const { t } = useTranslation();
   const {
     workflows,
     activeWorkflowId,
@@ -146,43 +251,26 @@ export function KanbanDisplayDropdown({
             repositoriesLoading={repositoriesLoading}
             onRepositoryChange={onRepositoryChange}
           />
-          <DropdownMenuSeparator />
-          <div className="space-y-1.5">
-            <DropdownMenuLabel className="px-0 text-foreground">
-              {t("kanban:previewPanel")}
-            </DropdownMenuLabel>
-            <label className="flex items-center gap-2 cursor-pointer">
-              <Checkbox
-                checked={enablePreviewOnClick ?? false}
-                onCheckedChange={(checked) => {
-                  onTogglePreviewOnClick?.(!!checked);
-                }}
-              />
-              <span className="text-sm text-foreground">{t("kanban:openPreviewOnClick")}</span>
-            </label>
-            <p className="text-xs text-muted-foreground pl-6">
-              {t("kanban:whenEnabledClickingATaskOpens")}
-            </p>
-          </div>
-          {currentPage === "tasks" && (
-            <>
+          {pluginFilters?.map((filter) => (
+            <div key={filter.id} className="contents">
               <DropdownMenuSeparator />
-              <div className="space-y-1.5">
-                <DropdownMenuLabel className="px-0 text-foreground">
-                  {t("kanban:listRows")}
-                </DropdownMenuLabel>
-                <label className="flex items-center gap-2 cursor-pointer">
-                  <Checkbox
-                    checked={tasksListShowDetails}
-                    onCheckedChange={(checked) => onToggleTasksListShowDetails(checked === true)}
-                  />
-                  <span className="text-sm text-foreground">{t("kanban:showTaskDetails")}</span>
-                </label>
-                <p className="pl-6 text-xs text-muted-foreground">
-                  {t("kanban:addRepositoryPullRequestSessionParent")}
-                </p>
-              </div>
-            </>
+              <PluginFilterSection
+                filter={filter}
+                selected={pluginFilterSelections?.[filter.id] ?? []}
+                onChange={(values) => onPluginFilterChange?.(filter.id, values)}
+              />
+            </div>
+          ))}
+          <DropdownMenuSeparator />
+          <PreviewPanelSection
+            enablePreviewOnClick={enablePreviewOnClick}
+            onTogglePreviewOnClick={onTogglePreviewOnClick}
+          />
+          {currentPage === "tasks" && (
+            <TasksListSection
+              tasksListShowDetails={tasksListShowDetails}
+              onToggleTasksListShowDetails={onToggleTasksListShowDetails}
+            />
           )}
         </div>
       </DropdownMenuContent>

--- a/apps/web/components/kanban-display-dropdown.tsx
+++ b/apps/web/components/kanban-display-dropdown.tsx
@@ -12,7 +12,10 @@ import {
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@kandev/ui/select";
 import { IconAdjustmentsHorizontal } from "@tabler/icons-react";
 import { useKanbanDisplaySettings } from "@/hooks/use-kanban-display-settings";
-import type { PluginTaskFilterRegistration } from "@/lib/plugins/registry";
+import {
+  pluginTaskFilterRegistrationKey,
+  type PluginTaskFilterRegistration,
+} from "@/lib/plugins/registry";
 import type { Repository } from "@/lib/types/http";
 import type { WorkflowsState } from "@/lib/state/slices";
 import type { ComponentProps } from "react";
@@ -252,12 +255,14 @@ export function KanbanDisplayDropdown({
             onRepositoryChange={onRepositoryChange}
           />
           {pluginFilters?.map((filter) => (
-            <div key={filter.id} className="contents">
+            <div key={pluginTaskFilterRegistrationKey(filter)} className="contents">
               <DropdownMenuSeparator />
               <PluginFilterSection
                 filter={filter}
-                selected={pluginFilterSelections?.[filter.id] ?? []}
-                onChange={(values) => onPluginFilterChange?.(filter.id, values)}
+                selected={pluginFilterSelections?.[pluginTaskFilterRegistrationKey(filter)] ?? []}
+                onChange={(values) =>
+                  onPluginFilterChange?.(pluginTaskFilterRegistrationKey(filter), values)
+                }
               />
             </div>
           ))}

--- a/apps/web/components/kanban-display-dropdown.tsx
+++ b/apps/web/components/kanban-display-dropdown.tsx
@@ -18,7 +18,7 @@ import {
 } from "@/lib/plugins/registry";
 import type { Repository } from "@/lib/types/http";
 import type { WorkflowsState } from "@/lib/state/slices";
-import type { ComponentProps } from "react";
+import { useMemo, type ComponentProps } from "react";
 import { useTranslation } from "react-i18next";
 import { getRepositoryPlaceholderKey } from "@/lib/kanban/repository-placeholder";
 
@@ -108,26 +108,28 @@ function RepositorySection({
 
 function PluginFilterSection({
   filter,
+  filterKey,
   selected,
   onChange,
 }: {
   filter: PluginTaskFilterRegistration;
+  filterKey: string;
   selected: string[];
   onChange: (values: string[]) => void;
 }) {
-  const options = filter.getOptions();
+  const options = useMemo(() => filter.getOptions(), [filter]);
   const toggleOption = (value: string, checked: boolean) => {
     onChange(checked ? [...selected, value] : selected.filter((v) => v !== value));
   };
 
   return (
-    <div className="space-y-1.5" data-testid={`display-plugin-filter-${filter.id}`}>
+    <div className="space-y-1.5" data-testid={`display-plugin-filter-${filterKey}`}>
       <DropdownMenuLabel className="px-0 text-foreground">{filter.label}</DropdownMenuLabel>
       <div className="space-y-1">
         {options.map((option) => (
           <label key={option.value} className="flex items-center gap-2 cursor-pointer">
             <Checkbox
-              data-testid={`display-plugin-filter-${filter.id}-option-${option.value}`}
+              data-testid={`display-plugin-filter-${filterKey}-option-${option.value}`}
               checked={selected.includes(option.value)}
               onCheckedChange={(checked) => toggleOption(option.value, checked === true)}
             />
@@ -254,18 +256,20 @@ export function KanbanDisplayDropdown({
             repositoriesLoading={repositoriesLoading}
             onRepositoryChange={onRepositoryChange}
           />
-          {pluginFilters?.map((filter) => (
-            <div key={pluginTaskFilterRegistrationKey(filter)} className="contents">
-              <DropdownMenuSeparator />
-              <PluginFilterSection
-                filter={filter}
-                selected={pluginFilterSelections?.[pluginTaskFilterRegistrationKey(filter)] ?? []}
-                onChange={(values) =>
-                  onPluginFilterChange?.(pluginTaskFilterRegistrationKey(filter), values)
-                }
-              />
-            </div>
-          ))}
+          {pluginFilters?.map((filter) => {
+            const filterKey = pluginTaskFilterRegistrationKey(filter);
+            return (
+              <div key={filterKey} className="contents">
+                <DropdownMenuSeparator />
+                <PluginFilterSection
+                  filter={filter}
+                  filterKey={filterKey}
+                  selected={pluginFilterSelections?.[filterKey] ?? []}
+                  onChange={(values) => onPluginFilterChange?.(filterKey, values)}
+                />
+              </div>
+            );
+          })}
           <DropdownMenuSeparator />
           <PreviewPanelSection
             enablePreviewOnClick={enablePreviewOnClick}

--- a/apps/web/components/kanban/kanban-header.tsx
+++ b/apps/web/components/kanban/kanban-header.tsx
@@ -16,6 +16,7 @@ import {
 import { useTranslation } from "react-i18next";
 import { PageTopbar } from "@/components/page-topbar";
 import { KanbanDisplayDropdown } from "../kanban-display-dropdown";
+import { usePluginTaskFilters } from "@/hooks/use-plugin-task-filters";
 import { ReleaseNotesDialog } from "../release-notes/release-notes-dialog";
 import { HealthIndicatorButton, HealthIssuesDialog } from "../system-health/health-indicator";
 import { TaskSearchInput } from "./task-search-input";
@@ -206,6 +207,7 @@ function TabletHeader({
 }) {
   const { t } = useTranslation();
   const isHome = title === "Home";
+  const pluginTaskFilters = usePluginTaskFilters();
 
   return (
     <PageTopbar
@@ -236,7 +238,13 @@ function TabletHeader({
           <TooltipProvider>
             <ViewToggleGroup toggleValue={toggleValue} onValueChange={handleViewChange} size="lg" />
           </TooltipProvider>
-          <KanbanDisplayDropdown triggerSize="icon-lg" currentPage={currentPage} />
+          <KanbanDisplayDropdown
+            triggerSize="icon-lg"
+            currentPage={currentPage}
+            pluginFilters={pluginTaskFilters.filters}
+            pluginFilterSelections={pluginTaskFilters.selections}
+            onPluginFilterChange={pluginTaskFilters.setFilterSelection}
+          />
           <HealthIndicatorButton
             hasIssues={showHealthIndicator}
             onClick={onOpenHealthDialog}
@@ -287,6 +295,7 @@ function DesktopHeader({
   const { t } = useTranslation();
   const headerRef = useRef<HTMLElement>(null);
   const isNarrow = useIsHeaderNarrow(headerRef);
+  const pluginTaskFilters = usePluginTaskFilters();
   const searchInput = onSearchChange ? (
     <TaskSearchInput
       value={searchQuery}
@@ -322,7 +331,13 @@ function DesktopHeader({
           <TooltipProvider>
             <ViewToggleGroup toggleValue={toggleValue} onValueChange={handleViewChange} size="lg" />
           </TooltipProvider>
-          <KanbanDisplayDropdown triggerSize="icon-lg" currentPage={currentPage} />
+          <KanbanDisplayDropdown
+            triggerSize="icon-lg"
+            currentPage={currentPage}
+            pluginFilters={pluginTaskFilters.filters}
+            pluginFilterSelections={pluginTaskFilters.selections}
+            onPluginFilterChange={pluginTaskFilters.setFilterSelection}
+          />
           <HealthIndicatorButton
             hasIssues={showHealthIndicator}
             onClick={onOpenHealthDialog}

--- a/apps/web/components/kanban/swimlane-container.test.ts
+++ b/apps/web/components/kanban/swimlane-container.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Task } from "@/components/kanban-card";
+import { filterTasks } from "./swimlane-container";
+import { mapSelectedRepositoryIds } from "@/lib/kanban/filters";
+
+function makeTask(overrides: Partial<Task> & { id: string }): Task {
+  return {
+    title: "Task",
+    description: "",
+    repositoryId: undefined,
+    ...overrides,
+  } as Task;
+}
+
+describe("filterTasks — plugin task filter predicate", () => {
+  const NO_REPO_FILTER = mapSelectedRepositoryIds([], []);
+
+  it("keeps every task when no predicate is supplied", () => {
+    const snapshots = {
+      wf: { tasks: [makeTask({ id: "1" }), makeTask({ id: "2" })] },
+    };
+
+    const result = filterTasks(snapshots, "wf", NO_REPO_FILTER);
+
+    expect(result.map((t) => t.id)).toEqual(["1", "2"]);
+  });
+
+  it("excludes tasks the predicate rejects", () => {
+    const snapshots = {
+      wf: { tasks: [makeTask({ id: "1" }), makeTask({ id: "2" })] },
+    };
+    const matches = vi.fn((taskId: string) => taskId === "1");
+
+    const result = filterTasks(snapshots, "wf", NO_REPO_FILTER, undefined, matches);
+
+    expect(result.map((t) => t.id)).toEqual(["1"]);
+    expect(matches).toHaveBeenCalledWith("1");
+    expect(matches).toHaveBeenCalledWith("2");
+  });
+
+  it("composes with search and repository filtering (all must pass)", () => {
+    const snapshots = {
+      wf: {
+        tasks: [
+          makeTask({ id: "1", title: "Fix bug", repositoryId: "repo-a" }),
+          makeTask({ id: "2", title: "Fix bug", repositoryId: "repo-b" }),
+        ],
+      },
+    };
+    const repoFilter = mapSelectedRepositoryIds(
+      [{ id: "repo-a", name: "A" } as never, { id: "repo-b", name: "B" } as never],
+      ["repo-a", "repo-b"],
+    );
+    const matches = (taskId: string) => taskId === "1";
+
+    const result = filterTasks(snapshots, "wf", repoFilter, "fix", matches);
+
+    expect(result.map((t) => t.id)).toEqual(["1"]);
+  });
+});

--- a/apps/web/components/kanban/swimlane-container.tsx
+++ b/apps/web/components/kanban/swimlane-container.tsx
@@ -46,6 +46,8 @@ export type SwimlaneContainerProps = {
   showMaximizeButton?: boolean;
   searchQuery?: string;
   selectedRepositoryIds?: string[];
+  /** Predicate combining every active plugin `registerTaskFilter` selection (AND semantics). */
+  matchesPluginTaskFilters?: (taskId: string) => boolean;
   selectedIds?: Set<string>;
   onToggleSelect?: (taskId: string) => void;
   onSelectRange?: (taskId: string, orderedIds: string[]) => void;
@@ -91,11 +93,13 @@ function renderEmptyState(emptyMessage: string) {
   );
 }
 
-function filterTasks(
+/** Exported for unit testing; not part of the module's public component API. */
+export function filterTasks(
   snapshots: Record<string, { tasks: Task[] }>,
   workflowId: string,
   repoFilter: ReturnType<typeof mapSelectedRepositoryIds>,
   searchQuery?: string,
+  matchesPluginTaskFilters?: (taskId: string) => boolean,
 ): Task[] {
   const snapshot = snapshots[workflowId];
   if (!snapshot) return [];
@@ -108,6 +112,9 @@ function filterTasks(
         t.title.toLowerCase().includes(q) ||
         (t.description && t.description.toLowerCase().includes(q)),
     );
+  }
+  if (matchesPluginTaskFilters) {
+    tasks = tasks.filter((t) => matchesPluginTaskFilters(t.id));
   }
   return tasks;
 }
@@ -241,6 +248,7 @@ function useSwimlaneData(
   workflowFilter: string | null | undefined,
   selectedRepositoryIds: string[],
   searchQuery: string,
+  matchesPluginTaskFilters?: (taskId: string) => boolean,
 ) {
   const snapshots = useAppStore((state) => state.kanbanMulti.snapshots);
   const isLoading = useAppStore((state) => state.kanbanMulti.isLoading);
@@ -268,8 +276,9 @@ function useSwimlaneData(
   }, [workflowFilter, allOrderedWorkflows]);
 
   const getFilteredTasks = useCallback(
-    (wfId: string) => filterTasks(snapshots, wfId, repoFilter, searchQuery),
-    [snapshots, repoFilter, searchQuery],
+    (wfId: string) =>
+      filterTasks(snapshots, wfId, repoFilter, searchQuery, matchesPluginTaskFilters),
+    [snapshots, repoFilter, searchQuery, matchesPluginTaskFilters],
   );
 
   return { snapshots, isLoading, orderedWorkflows, allOrderedWorkflows, getFilteredTasks };
@@ -378,7 +387,12 @@ export function SwimlaneContainer(containerProps: SwimlaneContainerProps) {
   const { isMobile } = useResponsiveBreakpoint();
   const { isCollapsed, toggleCollapse } = useSwimlaneCollapse();
   const { snapshots, isLoading, orderedWorkflows, allOrderedWorkflows, getFilteredTasks } =
-    useSwimlaneData(workflowFilter, selectedRepositoryIds, searchQuery ?? "");
+    useSwimlaneData(
+      workflowFilter,
+      selectedRepositoryIds,
+      searchQuery ?? "",
+      containerProps.matchesPluginTaskFilters,
+    );
   const {
     sensors: workflowSensors,
     canSort: canSortWorkflows,

--- a/apps/web/hooks/use-plugin-task-filters.test.ts
+++ b/apps/web/hooks/use-plugin-task-filters.test.ts
@@ -1,0 +1,125 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { pluginRegistry } from "@/lib/plugins/registry";
+import {
+  resetPluginTaskFilterSelectionsForTests,
+  usePluginTaskFilters,
+} from "./use-plugin-task-filters";
+
+const PLUGIN_ID = "kandev-plugin-tags";
+
+describe("usePluginTaskFilters", () => {
+  afterEach(() => {
+    pluginRegistry.unregisterPlugin(PLUGIN_ID);
+    resetPluginTaskFilterSelectionsForTests();
+  });
+
+  it("returns registered task filters", () => {
+    pluginRegistry.forPlugin(PLUGIN_ID).registerTaskFilter({
+      id: "tags",
+      label: "Tags",
+      getOptions: () => [{ value: "bug", label: "Bug" }],
+      matches: () => true,
+    });
+
+    const { result } = renderHook(() => usePluginTaskFilters());
+
+    expect(result.current.filters).toHaveLength(1);
+    expect(result.current.filters[0]).toMatchObject({ id: "tags", pluginId: PLUGIN_ID });
+  });
+
+  it("matches every task when no selection is set (implicit All)", () => {
+    const matches = vi.fn().mockReturnValue(false);
+    pluginRegistry.forPlugin(PLUGIN_ID).registerTaskFilter({
+      id: "tags",
+      label: "Tags",
+      getOptions: () => [],
+      matches,
+    });
+
+    const { result } = renderHook(() => usePluginTaskFilters());
+
+    expect(result.current.taskMatchesPluginFilters({ taskId: "task-1" })).toBe(true);
+    expect(matches).not.toHaveBeenCalled();
+  });
+
+  it("delegates to matches() once a selection is set, and clearing restores All", () => {
+    const matches = vi.fn((_context: { taskId: string }, selected: string[]) =>
+      selected.includes("bug"),
+    );
+    pluginRegistry.forPlugin(PLUGIN_ID).registerTaskFilter({
+      id: "tags",
+      label: "Tags",
+      getOptions: () => [
+        { value: "bug", label: "Bug" },
+        { value: "feature", label: "Feature" },
+      ],
+      matches,
+    });
+
+    const { result } = renderHook(() => usePluginTaskFilters());
+
+    act(() => result.current.setFilterSelection("tags", ["feature"]));
+    expect(result.current.taskMatchesPluginFilters({ taskId: "task-1" })).toBe(false);
+    expect(matches).toHaveBeenCalledWith({ taskId: "task-1" }, ["feature"]);
+
+    act(() => result.current.setFilterSelection("tags", []));
+    expect(result.current.taskMatchesPluginFilters({ taskId: "task-1" })).toBe(true);
+  });
+
+  it("catches a throwing matches() and treats it as non-matching", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    pluginRegistry.forPlugin(PLUGIN_ID).registerTaskFilter({
+      id: "tags",
+      label: "Tags",
+      getOptions: () => [{ value: "bug", label: "Bug" }],
+      matches: () => {
+        throw new Error("boom");
+      },
+    });
+
+    const { result } = renderHook(() => usePluginTaskFilters());
+    act(() => result.current.setFilterSelection("tags", ["bug"]));
+
+    expect(result.current.taskMatchesPluginFilters({ taskId: "task-1" })).toBe(false);
+    errorSpy.mockRestore();
+  });
+
+  it("requires every registered filter to match (AND semantics across filters)", () => {
+    pluginRegistry.forPlugin(PLUGIN_ID).registerTaskFilter({
+      id: "tags",
+      label: "Tags",
+      getOptions: () => [{ value: "bug", label: "Bug" }],
+      matches: () => true,
+    });
+    pluginRegistry.forPlugin(PLUGIN_ID).registerTaskFilter({
+      id: "priority",
+      label: "Priority",
+      getOptions: () => [{ value: "high", label: "High" }],
+      matches: () => false,
+    });
+
+    const { result } = renderHook(() => usePluginTaskFilters());
+    act(() => result.current.setFilterSelection("tags", ["bug"]));
+    act(() => result.current.setFilterSelection("priority", ["high"]));
+
+    expect(result.current.taskMatchesPluginFilters({ taskId: "task-1" })).toBe(false);
+  });
+
+  it("shares selection state across independent hook instances (singleton store)", () => {
+    pluginRegistry.forPlugin(PLUGIN_ID).registerTaskFilter({
+      id: "tags",
+      label: "Tags",
+      getOptions: () => [{ value: "bug", label: "Bug" }],
+      matches: (_context, selected) => selected.includes("bug"),
+    });
+
+    const dropdown = renderHook(() => usePluginTaskFilters());
+    const board = renderHook(() => usePluginTaskFilters());
+
+    act(() => dropdown.result.current.setFilterSelection("tags", ["bug"]));
+
+    expect(board.result.current.selections).toEqual({ tags: ["bug"] });
+    expect(board.result.current.taskMatchesPluginFilters({ taskId: "task-1" })).toBe(true);
+  });
+});

--- a/apps/web/hooks/use-plugin-task-filters.test.ts
+++ b/apps/web/hooks/use-plugin-task-filters.test.ts
@@ -7,6 +7,7 @@ import {
 } from "./use-plugin-task-filters";
 
 const PLUGIN_ID = "kandev-plugin-tags";
+const FILTER_KEY = `${PLUGIN_ID}:tags`;
 
 describe("usePluginTaskFilters", () => {
   afterEach(() => {
@@ -26,6 +27,37 @@ describe("usePluginTaskFilters", () => {
 
     expect(result.current.filters).toHaveLength(1);
     expect(result.current.filters[0]).toMatchObject({ id: "tags", pluginId: PLUGIN_ID });
+  });
+
+  it("reacts when plugins register and unregister task filters after mount", () => {
+    const { result } = renderHook(() => usePluginTaskFilters());
+
+    expect(result.current.filters).toEqual([]);
+
+    act(() => {
+      pluginRegistry.forPlugin(PLUGIN_ID).registerTaskFilter({
+        id: "tags",
+        label: "Tags",
+        getOptions: () => [{ value: "bug", label: "Bug" }],
+        matches: () => true,
+      });
+    });
+
+    expect(result.current.filters).toHaveLength(1);
+    expect(result.current.filters[0]).toMatchObject({ id: "tags", pluginId: PLUGIN_ID });
+
+    act(() => {
+      pluginRegistry.unregisterPlugin(PLUGIN_ID);
+    });
+
+    expect(result.current.filters).toEqual([]);
+  });
+});
+
+describe("usePluginTaskFilters matching", () => {
+  afterEach(() => {
+    pluginRegistry.unregisterPlugin(PLUGIN_ID);
+    resetPluginTaskFilterSelectionsForTests();
   });
 
   it("matches every task when no selection is set (implicit All)", () => {
@@ -59,11 +91,11 @@ describe("usePluginTaskFilters", () => {
 
     const { result } = renderHook(() => usePluginTaskFilters());
 
-    act(() => result.current.setFilterSelection("tags", ["feature"]));
+    act(() => result.current.setFilterSelection(FILTER_KEY, ["feature"]));
     expect(result.current.taskMatchesPluginFilters({ taskId: "task-1" })).toBe(false);
     expect(matches).toHaveBeenCalledWith({ taskId: "task-1" }, ["feature"]);
 
-    act(() => result.current.setFilterSelection("tags", []));
+    act(() => result.current.setFilterSelection(FILTER_KEY, []));
     expect(result.current.taskMatchesPluginFilters({ taskId: "task-1" })).toBe(true);
   });
 
@@ -79,7 +111,7 @@ describe("usePluginTaskFilters", () => {
     });
 
     const { result } = renderHook(() => usePluginTaskFilters());
-    act(() => result.current.setFilterSelection("tags", ["bug"]));
+    act(() => result.current.setFilterSelection(FILTER_KEY, ["bug"]));
 
     expect(result.current.taskMatchesPluginFilters({ taskId: "task-1" })).toBe(false);
     errorSpy.mockRestore();
@@ -100,8 +132,41 @@ describe("usePluginTaskFilters", () => {
     });
 
     const { result } = renderHook(() => usePluginTaskFilters());
-    act(() => result.current.setFilterSelection("tags", ["bug"]));
-    act(() => result.current.setFilterSelection("priority", ["high"]));
+    act(() => result.current.setFilterSelection(FILTER_KEY, ["bug"]));
+    act(() => result.current.setFilterSelection(`${PLUGIN_ID}:priority`, ["high"]));
+
+    expect(result.current.taskMatchesPluginFilters({ taskId: "task-1" })).toBe(false);
+  });
+});
+
+describe("usePluginTaskFilters (cross-plugin & shared-store behavior)", () => {
+  afterEach(() => {
+    pluginRegistry.unregisterPlugin(PLUGIN_ID);
+    pluginRegistry.unregisterPlugin("kandev-plugin-priority");
+    resetPluginTaskFilterSelectionsForTests();
+  });
+
+  it("keeps same-id filters from different plugins independent", () => {
+    pluginRegistry.forPlugin(PLUGIN_ID).registerTaskFilter({
+      id: "tags",
+      label: "Tags",
+      getOptions: () => [{ value: "bug", label: "Bug" }],
+      matches: (_context, selected) => selected.includes("bug"),
+    });
+    pluginRegistry.forPlugin("kandev-plugin-priority").registerTaskFilter({
+      id: "tags",
+      label: "Priority",
+      getOptions: () => [{ value: "high", label: "High" }],
+      matches: (_context, selected) => selected.includes("high"),
+    });
+
+    const { result } = renderHook(() => usePluginTaskFilters());
+
+    act(() => result.current.setFilterSelection(FILTER_KEY, ["bug"]));
+
+    expect(result.current.taskMatchesPluginFilters({ taskId: "task-1" })).toBe(true);
+
+    act(() => result.current.setFilterSelection("kandev-plugin-priority:tags", ["not-high"]));
 
     expect(result.current.taskMatchesPluginFilters({ taskId: "task-1" })).toBe(false);
   });
@@ -117,9 +182,9 @@ describe("usePluginTaskFilters", () => {
     const dropdown = renderHook(() => usePluginTaskFilters());
     const board = renderHook(() => usePluginTaskFilters());
 
-    act(() => dropdown.result.current.setFilterSelection("tags", ["bug"]));
+    act(() => dropdown.result.current.setFilterSelection(FILTER_KEY, ["bug"]));
 
-    expect(board.result.current.selections).toEqual({ tags: ["bug"] });
+    expect(board.result.current.selections).toEqual({ [FILTER_KEY]: ["bug"] });
     expect(board.result.current.taskMatchesPluginFilters({ taskId: "task-1" })).toBe(true);
   });
 });

--- a/apps/web/hooks/use-plugin-task-filters.test.ts
+++ b/apps/web/hooks/use-plugin-task-filters.test.ts
@@ -52,6 +52,22 @@ describe("usePluginTaskFilters", () => {
 
     expect(result.current.filters).toEqual([]);
   });
+
+  it("keeps the matching callback stable when the registry is unchanged", () => {
+    pluginRegistry.forPlugin(PLUGIN_ID).registerTaskFilter({
+      id: "tags",
+      label: "Tags",
+      getOptions: () => [],
+      matches: () => true,
+    });
+
+    const { result, rerender } = renderHook(() => usePluginTaskFilters());
+    const initialMatcher = result.current.taskMatchesPluginFilters;
+
+    rerender();
+
+    expect(result.current.taskMatchesPluginFilters).toBe(initialMatcher);
+  });
 });
 
 describe("usePluginTaskFilters matching", () => {

--- a/apps/web/hooks/use-plugin-task-filters.ts
+++ b/apps/web/hooks/use-plugin-task-filters.ts
@@ -1,0 +1,100 @@
+import { useCallback, useMemo, useSyncExternalStore } from "react";
+import { usePluginRegistry } from "@/lib/plugins/registry";
+import type { PluginTaskFilterContext } from "@/lib/plugins/types";
+
+/** Per-filter-id selected option values, keyed by `TaskFilterRegistration.id`. */
+export type PluginTaskFilterSelections = Record<string, string[]>;
+
+/**
+ * Singleton, in-memory selection store for plugin-registered task filters
+ * (`registerTaskFilter`) — shared across every `usePluginTaskFilters()` call
+ * site in the app (the kanban display dropdown and the board's filtering
+ * pipeline are separate components, so a plain `useState` local to one of
+ * them would not be visible to the other). Never persisted to backend user
+ * settings, unlike the Workflow/Repository filters.
+ */
+class PluginTaskFilterStore {
+  private selections: PluginTaskFilterSelections = {};
+  private listeners = new Set<() => void>();
+
+  subscribe = (listener: () => void): (() => void) => {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  };
+
+  getSelections = (): PluginTaskFilterSelections => this.selections;
+
+  setFilterSelection(filterId: string, values: string[]): void {
+    if (values.length === 0) {
+      if (!(filterId in this.selections)) return;
+      const next = { ...this.selections };
+      delete next[filterId];
+      this.selections = next;
+    } else {
+      this.selections = { ...this.selections, [filterId]: values };
+    }
+    this.notify();
+  }
+
+  private notify(): void {
+    this.listeners.forEach((listener) => listener());
+  }
+}
+
+const pluginTaskFilterStore = new PluginTaskFilterStore();
+
+/** Test-only: clears all selection state so specs don't leak into each other. */
+export function resetPluginTaskFilterSelectionsForTests(): void {
+  for (const filterId of Object.keys(pluginTaskFilterStore.getSelections())) {
+    pluginTaskFilterStore.setFilterSelection(filterId, []);
+  }
+}
+
+/**
+ * Reactive hook over the shared `pluginTaskFilterStore` plus the currently
+ * registered `registerTaskFilter` filters. Re-renders whenever a plugin
+ * registers/unregisters a filter (enable/disable/uninstall), or when any
+ * component updates a selection via `setFilterSelection`.
+ */
+export function usePluginTaskFilters() {
+  const registry = usePluginRegistry();
+  const selections = useSyncExternalStore(
+    pluginTaskFilterStore.subscribe,
+    pluginTaskFilterStore.getSelections,
+    pluginTaskFilterStore.getSelections,
+  );
+
+  const filters = useMemo(() => registry.getTaskFilters(), [registry]);
+
+  const setFilterSelection = useCallback((filterId: string, values: string[]) => {
+    pluginTaskFilterStore.setFilterSelection(filterId, values);
+  }, []);
+
+  /**
+   * A task matches when every active plugin filter's `matches` returns true.
+   * A filter with no selection (empty/absent array) is "All" — it does not
+   * gate the task and its `matches` is not even called.
+   */
+  const taskMatchesPluginFilters = useCallback(
+    (context: PluginTaskFilterContext): boolean => {
+      return filters.every((filter) => {
+        const selected = selections[filter.id] ?? [];
+        if (selected.length === 0) return true;
+        try {
+          return filter.matches(context, selected);
+        } catch (error: unknown) {
+          console.error(
+            `[plugins] task filter "${filter.pluginId}:${filter.id}" matches() threw`,
+            error,
+          );
+          return false;
+        }
+      });
+    },
+    [filters, selections],
+  );
+
+  return { filters, selections, setFilterSelection, taskMatchesPluginFilters };
+}

--- a/apps/web/hooks/use-plugin-task-filters.ts
+++ b/apps/web/hooks/use-plugin-task-filters.ts
@@ -1,8 +1,8 @@
-import { useCallback, useMemo, useSyncExternalStore } from "react";
-import { usePluginRegistry } from "@/lib/plugins/registry";
+import { useCallback, useSyncExternalStore } from "react";
+import { pluginTaskFilterRegistrationKey, usePluginRegistry } from "@/lib/plugins/registry";
 import type { PluginTaskFilterContext } from "@/lib/plugins/types";
 
-/** Per-filter-id selected option values, keyed by `TaskFilterRegistration.id`. */
+/** Selected option values, keyed by owning plugin plus `TaskFilterRegistration.id`. */
 export type PluginTaskFilterSelections = Record<string, string[]>;
 
 /**
@@ -26,14 +26,14 @@ class PluginTaskFilterStore {
 
   getSelections = (): PluginTaskFilterSelections => this.selections;
 
-  setFilterSelection(filterId: string, values: string[]): void {
+  setFilterSelection(filterKey: string, values: string[]): void {
     if (values.length === 0) {
-      if (!(filterId in this.selections)) return;
+      if (!(filterKey in this.selections)) return;
       const next = { ...this.selections };
-      delete next[filterId];
+      delete next[filterKey];
       this.selections = next;
     } else {
-      this.selections = { ...this.selections, [filterId]: values };
+      this.selections = { ...this.selections, [filterKey]: values };
     }
     this.notify();
   }
@@ -66,10 +66,10 @@ export function usePluginTaskFilters() {
     pluginTaskFilterStore.getSelections,
   );
 
-  const filters = useMemo(() => registry.getTaskFilters(), [registry]);
+  const filters = registry.getTaskFilters();
 
-  const setFilterSelection = useCallback((filterId: string, values: string[]) => {
-    pluginTaskFilterStore.setFilterSelection(filterId, values);
+  const setFilterSelection = useCallback((filterKey: string, values: string[]) => {
+    pluginTaskFilterStore.setFilterSelection(filterKey, values);
   }, []);
 
   /**
@@ -80,7 +80,7 @@ export function usePluginTaskFilters() {
   const taskMatchesPluginFilters = useCallback(
     (context: PluginTaskFilterContext): boolean => {
       return filters.every((filter) => {
-        const selected = selections[filter.id] ?? [];
+        const selected = selections[pluginTaskFilterRegistrationKey(filter)] ?? [];
         if (selected.length === 0) return true;
         try {
           return filter.matches(context, selected);

--- a/apps/web/hooks/use-plugin-task-filters.ts
+++ b/apps/web/hooks/use-plugin-task-filters.ts
@@ -1,5 +1,5 @@
-import { useCallback, useSyncExternalStore } from "react";
-import { pluginTaskFilterRegistrationKey, usePluginRegistry } from "@/lib/plugins/registry";
+import { useCallback, useMemo, useSyncExternalStore } from "react";
+import { pluginRegistry, pluginTaskFilterRegistrationKey } from "@/lib/plugins/registry";
 import type { PluginTaskFilterContext } from "@/lib/plugins/types";
 
 /** Selected option values, keyed by owning plugin plus `TaskFilterRegistration.id`. */
@@ -59,14 +59,18 @@ export function resetPluginTaskFilterSelectionsForTests(): void {
  * component updates a selection via `setFilterSelection`.
  */
 export function usePluginTaskFilters() {
-  const registry = usePluginRegistry();
+  const registryVersion = useSyncExternalStore(
+    pluginRegistry.subscribe,
+    pluginRegistry.getVersion,
+    pluginRegistry.getVersion,
+  );
   const selections = useSyncExternalStore(
     pluginTaskFilterStore.subscribe,
     pluginTaskFilterStore.getSelections,
     pluginTaskFilterStore.getSelections,
   );
 
-  const filters = registry.getTaskFilters();
+  const filters = useMemo(() => pluginRegistry.getTaskFilters(), [registryVersion]);
 
   const setFilterSelection = useCallback((filterKey: string, values: string[]) => {
     pluginTaskFilterStore.setFilterSelection(filterKey, values);

--- a/apps/web/lib/plugins/registry.test.ts
+++ b/apps/web/lib/plugins/registry.test.ts
@@ -262,6 +262,28 @@ describe("pluginRegistry — task panels and task menu actions", () => {
     expect(pluginRegistry.getTaskMenuActions()).toHaveLength(1);
   });
 
+  it("registers a 'primary' group task menu action separately from 'edit'", () => {
+    const scoped = pluginRegistry.forPlugin("plugin-a");
+    const editRun = vi.fn();
+    const primaryRun = vi.fn();
+
+    scoped.registerTaskMenuAction({ id: "enhance", label: "Enhance", group: "edit", run: editRun });
+    scoped.registerTaskMenuAction({
+      id: "quick-tag",
+      label: "Tag",
+      group: "primary",
+      run: primaryRun,
+    });
+
+    expect(pluginRegistry.getTaskMenuActions("edit")).toEqual([
+      { pluginId: "plugin-a", id: "enhance", label: "Enhance", group: "edit", run: editRun },
+    ]);
+    expect(pluginRegistry.getTaskMenuActions("primary")).toEqual([
+      { pluginId: "plugin-a", id: "quick-tag", label: "Tag", group: "primary", run: primaryRun },
+    ]);
+    expect(pluginRegistry.getTaskMenuActions()).toHaveLength(2);
+  });
+
   it("bulk-revokes task panels and task menu actions on unregisterPlugin", () => {
     const scopedA = pluginRegistry.forPlugin("plugin-a");
     const scopedB = pluginRegistry.forPlugin("plugin-b");
@@ -284,6 +306,69 @@ describe("pluginRegistry — task panels and task menu actions", () => {
       { pluginId: "plugin-b", id: "notes", title: "Notes", icon: undefined, Component: Notes },
     ]);
     expect(pluginRegistry.getTaskMenuActions()).toEqual([]);
+  });
+});
+
+describe("pluginRegistry — task filters", () => {
+  afterEach(() => {
+    cleanup("plugin-a", "plugin-b");
+  });
+
+  it("registers a task filter and returns it with its owning pluginId", () => {
+    const scoped = pluginRegistry.forPlugin("plugin-a");
+    const getOptions = () => [{ value: "bug", label: "Bug" }];
+    const matches = () => true;
+
+    scoped.registerTaskFilter({ id: "tags", label: "Tags", getOptions, matches });
+
+    expect(pluginRegistry.getTaskFilters()).toEqual([
+      { pluginId: "plugin-a", id: "tags", label: "Tags", getOptions, matches },
+    ]);
+  });
+
+  it("returns task filters from multiple plugins in registration order", () => {
+    const scopedA = pluginRegistry.forPlugin("plugin-a");
+    const scopedB = pluginRegistry.forPlugin("plugin-b");
+
+    scopedA.registerTaskFilter({
+      id: "tags",
+      label: "Tags",
+      getOptions: () => [],
+      matches: () => true,
+    });
+    scopedB.registerTaskFilter({
+      id: "priority",
+      label: "Priority",
+      getOptions: () => [],
+      matches: () => true,
+    });
+
+    expect(pluginRegistry.getTaskFilters().map((filter) => filter.id)).toEqual([
+      "tags",
+      "priority",
+    ]);
+  });
+
+  it("bulk-revokes task filters on unregisterPlugin", () => {
+    const scopedA = pluginRegistry.forPlugin("plugin-a");
+    const scopedB = pluginRegistry.forPlugin("plugin-b");
+
+    scopedA.registerTaskFilter({
+      id: "tags",
+      label: "Tags",
+      getOptions: () => [],
+      matches: () => true,
+    });
+    scopedB.registerTaskFilter({
+      id: "priority",
+      label: "Priority",
+      getOptions: () => [],
+      matches: () => true,
+    });
+
+    pluginRegistry.unregisterPlugin("plugin-a");
+
+    expect(pluginRegistry.getTaskFilters().map((filter) => filter.id)).toEqual(["priority"]);
   });
 });
 

--- a/apps/web/lib/plugins/registry.ts
+++ b/apps/web/lib/plugins/registry.ts
@@ -91,6 +91,13 @@ export interface PluginTaskFilterRegistration extends TaskFilterRegistration {
   pluginId: string;
 }
 
+/** Stable UI/state identity for plugin-local task filter ids. */
+export function pluginTaskFilterRegistrationKey(
+  registration: Pick<PluginTaskFilterRegistration, "pluginId" | "id">,
+): string {
+  return `${registration.pluginId}:${registration.id}`;
+}
+
 /** Host-owned lifecycle states used to reconcile registrations with UI state. */
 export type PluginLifecycleStatus = "loading" | "ready" | "failed" | "removed";
 

--- a/apps/web/lib/plugins/registry.ts
+++ b/apps/web/lib/plugins/registry.ts
@@ -16,6 +16,7 @@ import type {
   PluginRegistry,
   PluginRouteOptions,
   SlotComponent,
+  TaskFilterRegistration,
   TaskMenuActionRegistration,
   TaskPanelRegistration,
   WsHandler,
@@ -85,6 +86,11 @@ export interface PluginTaskMenuActionRegistration extends TaskMenuActionRegistra
   pluginId: string;
 }
 
+/** Task filter registration plus the owning pluginId. */
+export interface PluginTaskFilterRegistration extends TaskFilterRegistration {
+  pluginId: string;
+}
+
 /** Host-owned lifecycle states used to reconcile registrations with UI state. */
 export type PluginLifecycleStatus = "loading" | "ready" | "failed" | "removed";
 
@@ -107,6 +113,7 @@ class PluginRegistryStore {
   private keybindingHandlers: Owned<PluginKeybindingHandler>[] = [];
   private taskPanels: Owned<TaskPanelRegistration>[] = [];
   private taskMenuActions: Owned<TaskMenuActionRegistration>[] = [];
+  private taskFilters: Owned<TaskFilterRegistration>[] = [];
   private nextSlotRegistrationId = 0;
   /** Display names from the boot payload, used for derived page-chrome titles. */
   private pluginNames = new Map<string, string>();
@@ -236,6 +243,11 @@ class PluginRegistryStore {
     this.notify();
   }
 
+  registerTaskFilter(pluginId: string, registration: TaskFilterRegistration): void {
+    this.taskFilters.push({ pluginId, value: registration });
+    this.notify();
+  }
+
   /**
    * Records the keybinding ids declared in `pluginId`'s `ui.keybindings`
    * manifest, so `registerKeybinding` can warn on an undeclared id. Safe to
@@ -256,6 +268,7 @@ class PluginRegistryStore {
     this.keybindingHandlers = removeByPlugin(this.keybindingHandlers, pluginId);
     this.taskPanels = removeByPlugin(this.taskPanels, pluginId);
     this.taskMenuActions = removeByPlugin(this.taskMenuActions, pluginId);
+    this.taskFilters = removeByPlugin(this.taskFilters, pluginId);
     this.pluginNames.delete(pluginId);
     this.declaredKeybindingIds.delete(pluginId);
     if (this.totalCount() !== before) this.notify();
@@ -361,6 +374,11 @@ class PluginRegistryStore {
       .map((entry) => ({ ...entry.value, pluginId: entry.pluginId }));
   }
 
+  /** Every registered task filter, in registration order. */
+  getTaskFilters(): PluginTaskFilterRegistration[] {
+    return this.taskFilters.map((entry) => ({ ...entry.value, pluginId: entry.pluginId }));
+  }
+
   /** Registry view scoped to one plugin — matches the frozen `PluginRegistry` contract. */
   forPlugin(pluginId: string, pluginName?: string): PluginRegistry {
     if (pluginName) this.pluginNames.set(pluginId, pluginName);
@@ -375,6 +393,7 @@ class PluginRegistryStore {
       registerKeybinding: (id, handler) => this.registerKeybinding(pluginId, id, handler),
       registerTaskPanel: (registration) => this.registerTaskPanel(pluginId, registration),
       registerTaskMenuAction: (registration) => this.registerTaskMenuAction(pluginId, registration),
+      registerTaskFilter: (registration) => this.registerTaskFilter(pluginId, registration),
     };
   }
 
@@ -387,7 +406,8 @@ class PluginRegistryStore {
       this.wsHandlers.length +
       this.keybindingHandlers.length +
       this.taskPanels.length +
-      this.taskMenuActions.length
+      this.taskMenuActions.length +
+      this.taskFilters.length
     );
   }
 

--- a/apps/web/lib/plugins/registry.ts
+++ b/apps/web/lib/plugins/registry.ts
@@ -14,6 +14,7 @@ import { useSyncExternalStore } from "react";
 import type {
   NavItem,
   PluginRegistry,
+  PluginTaskFilterRegistrationKey,
   PluginRouteOptions,
   SlotComponent,
   TaskFilterRegistration,
@@ -94,7 +95,7 @@ export interface PluginTaskFilterRegistration extends TaskFilterRegistration {
 /** Stable UI/state identity for plugin-local task filter ids. */
 export function pluginTaskFilterRegistrationKey(
   registration: Pick<PluginTaskFilterRegistration, "pluginId" | "id">,
-): string {
+): PluginTaskFilterRegistrationKey {
   return `${registration.pluginId}:${registration.id}`;
 }
 

--- a/apps/web/lib/plugins/types.ts
+++ b/apps/web/lib/plugins/types.ts
@@ -184,6 +184,9 @@ export interface PluginTaskFilterOption {
   color?: string;
 }
 
+/** Stable host identity for a plugin task filter (`pluginId:id`). */
+export type PluginTaskFilterRegistrationKey = `${string}:${string}`;
+
 /**
  * Registration accepted by `PluginRegistry.registerTaskFilter`: contributes
  * a filter section to the kanban board's Workflow/Repository filter
@@ -192,7 +195,7 @@ export interface PluginTaskFilterOption {
  * backend query for this filter.
  */
 export interface TaskFilterRegistration {
-  /** Plugin-local filter id (unique within the plugin, not globally). */
+  /** Plugin-local filter id; the host namespaces it as `pluginId:id`. */
   id: string;
   /** Filter section label shown in the dropdown. */
   label: string;

--- a/apps/web/lib/plugins/types.ts
+++ b/apps/web/lib/plugins/types.ts
@@ -155,18 +155,60 @@ export interface PluginTaskMenuContext {
 
 /**
  * Registration accepted by `PluginRegistry.registerTaskMenuAction`:
- * contributes an item to the kanban card context/dropdown menu's `Edit`
- * submenu (group "edit" is the only group today).
+ * contributes an item to the kanban card context/dropdown menu. Group
+ * "edit" nests the item inside the card's `Edit` submenu; group "primary"
+ * renders it as a flat, top-level menu item, positioned between the "Move
+ * to"/"Send to workflow" submenus and the "Link" submenu.
  */
 export interface TaskMenuActionRegistration {
   id: string;
   label: string;
   icon?: ReactType.ReactNode;
-  group: "edit";
+  group: "edit" | "primary";
   /** Hide this item for a given card/context. Default: always visible. */
   visible?(context: PluginTaskMenuContext): boolean;
   /** A rejected promise is caught and logged; the menu still closes. */
   run(context: PluginTaskMenuContext): void | Promise<void>;
+}
+
+/** Read-only context passed to `TaskFilterRegistration.matches`. */
+export interface PluginTaskFilterContext {
+  taskId: string;
+}
+
+/** One selectable option returned by `TaskFilterRegistration.getOptions`. */
+export interface PluginTaskFilterOption {
+  value: string;
+  label: string;
+  /** Optional swatch color rendered beside the option label. */
+  color?: string;
+}
+
+/**
+ * Registration accepted by `PluginRegistry.registerTaskFilter`: contributes
+ * a filter section to the kanban board's Workflow/Repository filter
+ * dropdown. Filtering is evaluated client-side against tasks already loaded
+ * in the board's in-memory state — there is no host-side pagination or
+ * backend query for this filter.
+ */
+export interface TaskFilterRegistration {
+  /** Plugin-local filter id (unique within the plugin, not globally). */
+  id: string;
+  /** Filter section label shown in the dropdown. */
+  label: string;
+  /**
+   * Options offered by this filter's multi-select, e.g. tag values. An
+   * empty selection means "All" (no filtering applied) — the plugin decides
+   * how to represent a sentinel like "untagged" as a normal option value; the
+   * host does not special-case any option value.
+   */
+  getOptions(): PluginTaskFilterOption[];
+  /**
+   * Whether `context.taskId` should remain visible given the current
+   * `selected` option values. Called only when `selected` is non-empty (an
+   * empty selection always matches, without invoking this method).
+   */
+  matches(context: PluginTaskFilterContext, selected: string[]): boolean;
 }
 
 /** One entry returned by `host.storage.list`. */
@@ -379,10 +421,16 @@ export interface PluginRegistry {
    */
   registerTaskPanel(registration: TaskPanelRegistration): void;
   /**
-   * Contributes an item to the kanban card `Edit` submenu. See
-   * `TaskMenuActionRegistration`.
+   * Contributes an item to the kanban card menu — nested in the `Edit`
+   * submenu (group "edit") or as a flat top-level item (group "primary").
+   * See `TaskMenuActionRegistration`.
    */
   registerTaskMenuAction(registration: TaskMenuActionRegistration): void;
+  /**
+   * Contributes a filter section to the kanban board's Workflow/Repository
+   * filter dropdown. See `TaskFilterRegistration`.
+   */
+  registerTaskFilter(registration: TaskFilterRegistration): void;
 }
 
 /** Shape every plugin bundle registers via `window.registerKandevPlugin(id, plugin)`. */

--- a/docs/plans/plugins/PLUGIN-API.md
+++ b/docs/plans/plugins/PLUGIN-API.md
@@ -347,9 +347,15 @@ interface PluginRegistry {
   // `plugin:{pluginId}:{panelKey}`. See "Task panels" below.
   registerTaskPanel(registration: TaskPanelRegistration): void;
 
-  // Contributes an item to the kanban card's Edit submenu. See
-  // "Kanban card contributions" below.
+  // Contributes an item to the kanban card's Edit submenu (group "edit") or
+  // a flat, top-level card menu item between "Move to"/"Send to workflow"
+  // and "Link" (group "primary"). See "Kanban card contributions" below.
   registerTaskMenuAction(registration: TaskMenuActionRegistration): void;
+
+  // Contributes a client-side filter section to the kanban board's display
+  // dropdown, alongside the built-in Workflow/Repository sections. See
+  // "Task filters" below.
+  registerTaskFilter(registration: TaskFilterRegistration): void;
 }
 
 type PluginPresentation = "desktop" | "mobile";
@@ -381,9 +387,31 @@ interface TaskMenuActionRegistration {
   id: string;
   label: string;
   icon?: React.ReactNode;
-  group: "edit"; // only group today — the card's Edit submenu
+  // "edit" nests the item in the card's Edit submenu; "primary" renders it
+  // as a flat, top-level item between the "Move to"/"Send to workflow"
+  // submenus and the "Link" submenu.
+  group: "edit" | "primary";
   visible?(context: PluginTaskMenuContext): boolean; // default: always visible
   run(context: PluginTaskMenuContext): void | Promise<void>; // a rejection is caught and logged
+}
+
+interface PluginTaskFilterContext {
+  taskId: string;
+}
+
+interface PluginTaskFilterOption {
+  value: string;
+  label: string;
+  color?: string; // optional swatch color rendered beside the option label
+}
+
+interface TaskFilterRegistration {
+  id: string;   // plugin-local filter id (unique within the plugin, not globally)
+  label: string; // filter section label shown in the dropdown
+  getOptions(): PluginTaskFilterOption[];
+  // Called only when `selected` is non-empty — an empty selection is
+  // implicit "All" and always matches without invoking this method.
+  matches(context: PluginTaskFilterContext, selected: string[]): boolean;
 }
 ```
 
@@ -469,9 +497,37 @@ action calls `run(context)`; a rejected promise is caught and logged to the
 console, and the menu still closes either way (Radix's own close-on-select,
 independent of the async result).
 
+Group `"primary"` renders each visible action as its own flat, top-level menu
+item instead of nesting it under `Edit` — positioned between the "Move
+to"/"Send to workflow" submenus and the "Link" submenu. Visibility filtering,
+registration order, and `run()`/error handling are identical to the `"edit"`
+group; the two groups are independent lists (an action only ever belongs to
+one).
+
 `"task-card-indicators"` (documented above with the other slots) is the
 matching read-only surface: a small icon/badge rendered beside the PR status
 icon on every card, receiving `{ taskId, workspaceId, workflowStepId }`.
+
+### Task filters
+
+`registerTaskFilter` adds one section to the kanban board's display dropdown
+(the same menu that holds the built-in Workflow and Repository filters),
+rendered below Repository and above the Preview Panel section. Each
+registration's `getOptions()` supplies the section's checkbox list; the
+plugin owns option identity, ordering, and labels — including any
+"untagged"-style sentinel, which is just a normal option value the host does
+not special-case.
+
+Selections are multi-select and purely client-side against tasks already
+loaded in the board's in-memory state: there is no backend query, pagination,
+or persistence for this filter, and selections reset on reload (unlike
+Workflow/Repository, which persist to backend user settings). An empty
+selection is implicit "All" for that section — `matches()` is only invoked
+once at least one option is selected, and multiple plugin filter sections
+combine with AND (a task must match every section with an active selection),
+mirroring how Workflow/Repository combine with the search query today. If
+`matches()` throws, the task is treated as non-matching and the error is
+logged (mirroring `TaskMenuActionRegistration.visible`'s error handling).
 
 ## Registry internals (host side)
 

--- a/docs/public/plugins-authoring.md
+++ b/docs/public/plugins-authoring.md
@@ -187,7 +187,8 @@ bookkeeping is host-internal; plugins do not call lifecycle methods.
 | registerWsHandler | registerWsHandler(action, handler(payload)); receives actions bridged from lib/ws | Active ui.bundle | Handler is removed on disable/uninstall; tolerate duplicate/replayed actions | registry.registerWsHandler("acme.updated", renderUpdate) |
 | registerKeybinding | registerKeybinding(id, handler(event)); id must be declared in ui.keybindings; users can override the effective combo | ui.bundle and ui.keybindings[] | Handler is removed on disable/uninstall; editable targets/core shortcuts win | registry.registerKeybinding("open-panel", () => host.openModal(...)) |
 | registerTaskPanel | { id, title, icon?, Component, mobileEnabled? }; adds a row to the task workspace's "+" (add panel) menu; Component receives { panelId, taskId, sessionId, presentation } | Active ui.bundle | Panel renders behind its own error boundary; slow/failed reloads preserve it, a ready generation missing it closes it, and disable/uninstall closes every owned instance | registry.registerTaskPanel({ id: "notes", title: "Notes", Component: NotesPanel }) |
-| registerTaskMenuAction | { id, label, icon?, group: "edit", visible?(context), run(context) }; adds an item to the kanban card's Edit submenu | Active ui.bundle | Action is revoked on disable/uninstall; a throwing/rejecting run is caught and logged | registry.registerTaskMenuAction({ id: "enhance", label: "Enhance", group: "edit", run: doEnhance }) |
+| registerTaskMenuAction | { id, label, icon?, group: "edit" \| "primary", visible?(context), run(context) }; "edit" nests inside the card's Edit submenu, "primary" renders as a flat top-level item between "Move to"/"Send to workflow" and "Link" | Active ui.bundle | Action is revoked on disable/uninstall; a throwing/rejecting run is caught and logged | registry.registerTaskMenuAction({ id: "enhance", label: "Enhance", group: "edit", run: doEnhance }) |
+| registerTaskFilter | { id, label, getOptions(), matches(context, selected) }; adds a client-side, multi-select filter section to the kanban board's display dropdown, alongside Workflow/Repository | Active ui.bundle | Filter is revoked on disable/uninstall; selections are ephemeral (not persisted); matches is only called for a non-empty selection, and a throw is caught, logged, and treated as non-matching | registry.registerTaskFilter({ id: "tags", label: "Tags", getOptions: listTagOptions, matches: taskHasSelectedTag }) |
 | host.React / host.jsx | Shared React instance and React.createElement alias | Active ui.bundle | No cleanup; never bundle a second React/Radix runtime | const h = host.jsx |
 | host.store | Curated Zustand { getState, setState, subscribe } for the live app store | Active ui.bundle | Unsubscribe in destroy; setState mutates the whole SPA and is not a plugin database | const stop = host.store.subscribe(render) |
 | host.api.fetch / baseUrl | fetch(path, init?) is scoped to /api/plugins/<id>/...; baseUrl is the backend origin for split-origin deployments | Active ui.bundle; backend path must be a declared webhook when relayed | Abort/ignore requests after destroy; do not assume a webhook authenticates callers | host.api.fetch("webhooks/inbound", { method: "POST" }) |
@@ -657,7 +658,10 @@ Host reader because event queues are bounded and delivery is best-effort.
 
 ### 6. Kanban-aware contribution
 
-`registerTaskMenuAction` adds an item to the kanban card's `Edit` submenu;
+`registerTaskMenuAction` adds an item to the kanban card's context/dropdown
+menu — group `"edit"` nests it inside the `Edit` submenu, group `"primary"`
+renders it as a flat, top-level item positioned between the "Move
+to"/"Send to workflow" submenus and the "Link" submenu.
 `task-card-indicators` (see the named slots table) is the matching read-only
 surface, rendered beside the PR status icon on every card. Both `visible(context)`
 and `run(context)` receive the card's actual `presentation`: `"desktop"` on the
@@ -677,10 +681,37 @@ registry.registerTaskMenuAction({
 ```
 
 With no plugin action registered, the card's `Edit` item stays flat; once any
-plugin registers one, it becomes `Edit > Edit task` followed by each visible
-action. A `run` that throws or rejects is caught and logged, not left to crash
-the card; the menu closes either way. Do not patch first-party Kanban
-components directly.
+plugin registers one for group `"edit"`, it becomes `Edit > Edit task`
+followed by each visible action. A `run` that throws or rejects is caught and
+logged, not left to crash the card; the menu closes either way. Group
+`"primary"` actions render and behave the same way, just as their own
+top-level menu row instead of nested under `Edit`. Do not patch first-party
+Kanban components directly.
+
+`registerTaskFilter` adds a client-side, multi-select filter section to the
+kanban board's display dropdown, next to the built-in Workflow and Repository
+sections. The plugin supplies its own options (including any "untagged"-style
+sentinel — the host does not special-case option values) and a `matches`
+predicate; filtering runs entirely against tasks already loaded in the
+board's in-memory state, with no backend query or persistence — selections
+reset on reload.
+
+```js
+registry.registerTaskFilter({
+  id: "tags",
+  label: "Tags",
+  getOptions: () => [
+    { value: "bug", label: "Bug", color: "#ef4444" },
+    { value: "untagged", label: "Untagged" },
+  ],
+  matches: (context, selected) => taskHasAnyTag(context.taskId, selected),
+});
+```
+
+An empty selection is implicit "All" for that section — `matches` is only
+called once at least one option is selected, and a `matches` that throws is
+caught, logged, and treated as non-matching for that task.
+
 
 ## Build, package, install, and test
 


### PR DESCRIPTION
Adds two host extension points the Tags plugin (`yattdev/kandev-plugin-tags`) needs — a flat top-level kanban card menu group and a client-side task filter hook — following the conventions established by PR #2152 and PR #2332, as a standalone follow-up separate from that PR.

## Important Changes

- `TaskMenuActionRegistration.group` extended from `"edit"` to `"edit" | "primary"`. Group `"primary"` renders each visible action as a flat, top-level card menu item positioned between "Move to"/"Send to workflow" and "Link", while the existing `"edit"` group (nested `Edit` submenu) is completely unchanged.
- New `registerTaskFilter` registry method contributes a client-side, multi-select filter section to the kanban board's display dropdown, alongside the built-in Workflow/Repository sections. Selections are ephemeral (not persisted), an empty selection is implicit "All", and multiple plugin filter sections combine with AND against tasks already loaded in the board's in-memory state.
- Extracted shared `visible()`/`run()` helpers into `kanban-card-plugin-menu-actions.ts` for reuse across the `"edit"` and `"primary"` groups, and the pre-existing Link submenu builder into `kanban-card-link-submenu.tsx` to keep `kanban-card-menu-items.tsx` under the file-length lint limit.
- Added a `usePluginTaskFilters()` singleton-store hook so the display dropdown (`kanban-header.tsx`) and the board's filtering pipeline (`kanban-board.tsx` / `swimlane-container.tsx`) share selection state across separate component subtrees.
- Documented both extension points in `docs/plans/plugins/PLUGIN-API.md` and `docs/public/plugins-authoring.md`.

## Validation

- `pnpm --filter @kandev/web exec vitest run` — full web test suite, 1226 files / 9552 tests passed.
- `pnpm --filter @kandev/web run typecheck` — clean.
- `npx eslint` on all changed/new files — no warnings.
- `pnpm run i18n:ratchet` and `pnpm run i18n:check` — clean (no new hardcoded user-facing strings; new UI renders plugin-supplied labels directly).

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2351?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->