### PR TITLE
feat(plugin-registry): list kandev-plugin-notes

### DIFF
--- a/plugin-registry/plugins.yaml
+++ b/plugin-registry/plugins.yaml
@@ -35,6 +35,9 @@ plugins:
   - id: kandev-plugin-tags
     repo: yattdev/kandev-plugin-tags
     categories: [tools]
+  - id: kandev-plugin-notes
+    repo: yattdev/kandev-plugin-notes
+    categories: [tools]
 # Example entry (copy, uncomment, and fill in when adding a plugin):
 #
 # plugins:


### PR DESCRIPTION
The Notes plugin (`yattdev/kandev-plugin-notes`) has a published `v0.1.0`
release, so it can now be curated into the official marketplace catalog.

A per-user, private scratchpad note on any task: a dockview/mobile task
panel with rich-text editing, a kanban card "Edit notes" shortcut, and a
card indicator glyph. Built on the `registerTaskPanel` / `host.storage` /
`registerTaskMenuAction` hooks from #2152, inspired by (but not a copy of)
PR #2050's native implementation — see the plugin's README for the
per-user-vs-shared distinction.

## Validation

- `node --test plugin-registry/build-index.test.mjs` -- 8/8 pass
- `node plugin-registry/build-index.mjs` locally -- 5 built, 0 skipped, 5
  listed; confirmed the new entry resolves correctly (release, manifest
  `id`/`name`/`description`/`version`, and `package_url` all read correctly
  from the plugin's `v0.1.0` GitHub release)

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have manually tested my changes and they work as expected.
- [x] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [x] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2352?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

