### PR TITLE
ci(i18n): make the pseudo-locale coverage oracle a hard CI gate

### DIFF
--- a/apps/web/e2e/tests/i18n/pseudo-coverage.spec.ts
+++ b/apps/web/e2e/tests/i18n/pseudo-coverage.spec.ts
@@ -30,9 +30,23 @@ import { test, expect } from "../../fixtures/test-base";
  *   pnpm e2e -- e2e/tests/i18n/pseudo-coverage.spec.ts
  *
  * WHAT IT GUARANTEES: on each screen in `SCREENS`, every rendered text node and
- * every value of a `COPY_ATTRIBUTES` attribute either came through `t()` /
- * `<Trans>` (and so renders accented under the pseudo-locale), or is on an
- * allowlist that says why it must not be translated.
+ * every value of a `COPY_ATTRIBUTES` attribute that the detector below can see
+ * either came through `t()` / `<Trans>` (and so renders accented under the
+ * pseudo-locale), or is on an allowlist that says why it must not be translated.
+ *
+ * It is a floor, not a proof of total coverage. Two limits are deliberate and
+ * both are documented where they are implemented, because relaxing either
+ * reddens every screen today:
+ *   - `wordlike` requires a 4-letter ASCII run, so a hardcoded string shorter
+ *     than that ("Add", "of") is not reported. Lowering it to 2 was measured:
+ *     9 of the 10 tests here go red, on real but out-of-scope copy owned by
+ *     `@kandev/ui` and sonner (e.g. the `alt+T` in sonner's toast-region label).
+ *   - the text pass clears a node on ANY accented character, so an un-migrated
+ *     word sharing one text node with migrated copy is missed. The attribute
+ *     pass does NOT have this limit — it strips allowlisted tokens first and
+ *     reports the remainder as `English frame, migrated value`. docs/i18n.md
+ *     covers the text-node case under "…and it is weakest at an interpolated
+ *     value"; it is why the by-hand pseudo walk is still step 9 of a migration.
  *
  * IF YOUR PR JUST WENT RED HERE, the failure names the exact strings and the
  * screen. Read them: each one is copy your change put on screen without routing

--- a/apps/web/e2e/tests/i18n/pseudo-coverage.spec.ts
+++ b/apps/web/e2e/tests/i18n/pseudo-coverage.spec.ts
@@ -21,12 +21,34 @@ import { test, expect } from "../../fixtures/test-base";
  * only sees plain literals in JSX, so it and this spec cover different halves of
  * the same question — add to both in the PR that migrates a directory.
  *
- * Gated on `KANDEV_I18N_COVERAGE=1` rather than run in CI: with the migration
- * proceeding one directory at a time, a screen's own copy can be clean while
- * shared chrome it renders is not yet. It becomes a hard gate when the last
- * directory lands and the env guard comes off.
+ * THIS IS A HARD CI GATE. It ran behind `KANDEV_I18N_COVERAGE=1` only while the
+ * migration was mid-flight, because a screen's own copy could be clean while
+ * shared chrome it renders was not yet. The last live directory has landed and
+ * the env guard is gone: it now runs unconditionally in the `chromium` project
+ * alongside every other spec.
  *
- *   KANDEV_I18N_COVERAGE=1 pnpm e2e -- e2e/tests/i18n/pseudo-coverage.spec.ts
+ *   pnpm e2e -- e2e/tests/i18n/pseudo-coverage.spec.ts
+ *
+ * WHAT IT GUARANTEES: on each screen in `SCREENS`, every rendered text node and
+ * every value of a `COPY_ATTRIBUTES` attribute either came through `t()` /
+ * `<Trans>` (and so renders accented under the pseudo-locale), or is on an
+ * allowlist that says why it must not be translated.
+ *
+ * IF YOUR PR JUST WENT RED HERE, the failure names the exact strings and the
+ * screen. Read them: each one is copy your change put on screen without routing
+ * it through `t()`. This spec is the ONLY gate that can see most of them —
+ * `i18next/no-literal-string` inspects literals in JSX and nothing else, so copy
+ * in a variable, a default parameter, a `.ts` helper or a SCREAMING_CASE config
+ * table is invisible to lint and visible only here. Repeated by-hand sweeps
+ * found 15-60 such strings that every other gate passed.
+ *
+ * The fix is to externalize the string: add it to `src/locales/en/<ns>.json` and
+ * call `t("<ns>:<key>")`. See docs/i18n.md. Adding an `allow:` entry is NOT the
+ * fix and is the one failure mode this file has actually shipped twice — an
+ * entry asserting a path was migrated while it still rendered English. `allow`
+ * is for text the frontend must not translate but cannot avoid rendering (a
+ * backend-owned record, a product name), and it must say where the value comes
+ * from.
  *
  * BOTH passes walk `document.body`, deliberately, and NOT the page's `<main>`.
  * Scoping to the page under test is the obvious reading of what each test claims,
@@ -46,8 +68,6 @@ import { test, expect } from "../../fixtures/test-base";
  * only because the walk is body-wide. The fix for chrome noise is migrating
  * chrome, not narrowing the oracle.
  */
-
-const COVERAGE_ENABLED = process.env.KANDEV_I18N_COVERAGE === "1";
 
 /**
  * Migrated screens whose visible text is overwhelmingly UI chrome, not user data.
@@ -494,11 +514,6 @@ async function findUnlocalizedCopy(
 }
 
 test.describe("i18n pseudo-locale coverage", () => {
-  test.skip(
-    !COVERAGE_ENABLED,
-    "Set KANDEV_I18N_COVERAGE=1 to run the string-externalization oracle (hard gate at task-40).",
-  );
-
   for (const screen of SCREENS) {
     test(`no un-externalized copy on ${screen.name}`, async ({ testPage }) => {
       await activatePseudo(testPage, screen.url);

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -318,7 +318,10 @@ pnpm run lint:i18n components/<area>              # 5. clean?
 7. If the area has a screen worth crawling, add it to `SCREENS` in
    `e2e/tests/i18n/pseudo-coverage.spec.ts`. That spec is a **hard CI gate** —
    it runs unconditionally in the E2E `chromium` project — so adding a screen
-   commits the whole surface that screen renders, not just your directory.
+   commits the whole DOM that screen renders, not just your directory. It is a
+   regression floor rather than a completeness proof: it still cannot see a
+   hardcoded string under four letters, or one sharing a text node with migrated
+   copy, which is why step 9 below is still worth doing by hand.
 8. `pnpm run i18n:check && pnpm lint --max-warnings 0 && pnpm exec vitest run`.
 9. Switch to **Pseudo (QA)** in Settings → General → Appearance and look at the
    screen. Anything still in plain English was missed — see below for why lint
@@ -540,10 +543,16 @@ one that sees the guard's blind spots. Interpolation placeholders and `<n>` tag
 markers are preserved by the generator.
 
 The by-hand walk is for a screen you are migrating. For the screens already
-migrated, `e2e/tests/i18n/pseudo-coverage.spec.ts` automates exactly this check
+migrated, `e2e/tests/i18n/pseudo-coverage.spec.ts` automates most of this check
 and **runs as a hard gate in CI** — it is no longer behind an env var. A red run
 there names the strings and the screen; externalize them rather than allowlisting
 them.
+
+It does not replace the walk. The spec reports a plain-ASCII run of four letters
+or more in a text node with no accented character in it — so a hardcoded string
+shorter than that, or one sitting in the same text node as migrated copy, still
+reaches you only by eye. Both limits are load-bearing rather than oversights;
+the spec's header records what happens when you relax them.
 
 One thing it shows you is **not** a miss: an interpolated API or network payload
 stays English by design, so it renders unaccented and is still correct. See

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -316,7 +316,9 @@ pnpm run lint:i18n components/<area>              # 5. clean?
    step that makes the work stick** — without it the directory drifts straight
    back.
 7. If the area has a screen worth crawling, add it to `SCREENS` in
-   `e2e/tests/i18n/pseudo-coverage.spec.ts`.
+   `e2e/tests/i18n/pseudo-coverage.spec.ts`. That spec is a **hard CI gate** —
+   it runs unconditionally in the E2E `chromium` project — so adding a screen
+   commits the whole surface that screen renders, not just your directory.
 8. `pnpm run i18n:check && pnpm lint --max-warnings 0 && pnpm exec vitest run`.
 9. Switch to **Pseudo (QA)** in Settings → General → Appearance and look at the
    screen. Anything still in plain English was missed — see below for why lint
@@ -536,6 +538,12 @@ remaining **plain-English** text on screen is a string that was never routed
 through `t()` — that is the acceptance check for a migrated screen, and the only
 one that sees the guard's blind spots. Interpolation placeholders and `<n>` tag
 markers are preserved by the generator.
+
+The by-hand walk is for a screen you are migrating. For the screens already
+migrated, `e2e/tests/i18n/pseudo-coverage.spec.ts` automates exactly this check
+and **runs as a hard gate in CI** — it is no longer behind an env var. A red run
+there names the strings and the screen; externalize them rather than allowlisting
+them.
 
 One thing it shows you is **not** a miss: an interpolated API or network payload
 stays English by design, so it renders unaccented and is still correct. See

--- a/docs/specs/platform/i18n.md
+++ b/docs/specs/platform/i18n.md
@@ -82,11 +82,14 @@ merge. Sequence:
 3. **Per-directory migrations**: each PR externalizes one directory, appends it
    to `i18nGuardFiles`, and adds its screen to the pseudo-coverage spec.
 4. **Close-out**: the env guard on the pseudo-coverage e2e spec is **removed** —
-   it runs unconditionally in the E2E `chromium` project, so the screens in its
-   `SCREENS` list can no longer regress. Still outstanding: `@kandev/ui`
-   primitives (a separate workspace package, deliberately deferred; its
-   hardcoded strings are not reached by any screen currently in `SCREENS`) and
-   the shared-task artifacts.
+   it runs unconditionally in the E2E `chromium` project, so a regression on the
+   screens in its `SCREENS` list fails CI wherever the detector can see it (a
+   plain-ASCII run of four letters or more, in a text node or a copy-bearing
+   attribute). It is a regression floor, not a proof of total coverage; the
+   spec's header records the two detection limits and what relaxing them costs.
+   Still outstanding: `@kandev/ui` primitives (a separate workspace package,
+   deliberately deferred; its hardcoded strings are not reached by any screen
+   currently in `SCREENS`) and the shared-task artifacts.
 
 ## Data model
 i18n adds no server-side persistent entities. It introduces:

--- a/docs/specs/platform/i18n.md
+++ b/docs/specs/platform/i18n.md
@@ -81,8 +81,12 @@ merge. Sequence:
    parity reporting for every committed real locale.
 3. **Per-directory migrations**: each PR externalizes one directory, appends it
    to `i18nGuardFiles`, and adds its screen to the pseudo-coverage spec.
-4. **Close-out**: `@kandev/ui` primitives, the shared-task artifacts, and
-   removing the env guard on the pseudo-coverage e2e spec once coverage is total.
+4. **Close-out**: the env guard on the pseudo-coverage e2e spec is **removed** —
+   it runs unconditionally in the E2E `chromium` project, so the screens in its
+   `SCREENS` list can no longer regress. Still outstanding: `@kandev/ui`
+   primitives (a separate workspace package, deliberately deferred; its
+   hardcoded strings are not reached by any screen currently in `SCREENS`) and
+   the shared-task artifacts.
 
 ## Data model
 i18n adds no server-side persistent entities. It introduces:


### PR DESCRIPTION
The pseudo-locale coverage oracle is the only gate that can see un-externalized
copy outside JSX — copy in a variable, a default parameter, a `.ts` helper or a
SCREAMING_CASE config table is structurally invisible to
`i18next/no-literal-string` — but it sat behind `KANDEV_I18N_COVERAGE=1` and so
never ran in CI. The last live directory has landed, so the guard comes off and
the nine covered settings screens can no longer regress.

## Important Changes

- Dropped `COVERAGE_ENABLED` / `process.env.KANDEV_I18N_COVERAGE` and the
  `test.skip` from `pseudo-coverage.spec.ts`; the spec now always runs. No
  workflow change was needed — see the collection proof below.
- Rewrote the file header, which explained why the spec was *disabled*, to state
  what it now guarantees, what a failure means, and that the fix for a red run is
  to externalize the string rather than add an `allow:` entry.
- **No string migration and no new `allow:` entries.** The baseline was measured
  green before touching anything.

## Validation

`pnpm run typecheck` · `pnpm lint --max-warnings 0` · `pnpm run i18n:check` ·
`pnpm run i18n:ratchet` — all clean.

### Before: baseline on `main`, with the env guard still in place

Measured rather than assumed — the last recorded baseline was days stale.

```
$ KANDEV_I18N_COVERAGE=1 npx playwright test --config e2e/playwright.config.ts \
    --project=chromium e2e/tests/i18n/pseudo-coverage.spec.ts

  ✓ no un-externalized copy on settings — appearance (2.3s)
  ✓ no un-externalized copy on settings — notifications (2.1s)
  ✓ no un-externalized copy on settings — secrets (2.0s)
  ✓ no un-externalized copy on settings — terminal (2.4s)
  ✓ no un-externalized copy on settings — sprites (2.1s)
  ✓ no un-externalized copy on settings — layouts (2.1s)
  ✓ no un-externalized copy on settings — keyboard shortcuts (2.5s)
  ✓ no un-externalized copy on settings — task actions (2.1s)
  ✓ no un-externalized copy on settings — plugins (2.0s)
  ✓ the attribute pass recognizes migrated attribute copy (2.0s)

  10 passed (23.3s)
```

### After: same run with the guard removed and **no env var set**

```
$ npx playwright test --config e2e/playwright.config.ts \
    --project=chromium e2e/tests/i18n/pseudo-coverage.spec.ts

  ✓ no un-externalized copy on settings — appearance (2.2s)
  ✓ no un-externalized copy on settings — notifications (2.1s)
  ✓ no un-externalized copy on settings — secrets (2.1s)
  ✓ no un-externalized copy on settings — terminal (2.0s)
  ✓ no un-externalized copy on settings — sprites (2.1s)
  ✓ no un-externalized copy on settings — layouts (2.2s)
  ✓ no un-externalized copy on settings — keyboard shortcuts (2.1s)
  ✓ no un-externalized copy on settings — task actions (2.2s)
  ✓ no un-externalized copy on settings — plugins (2.3s)
  ✓ the attribute pass recognizes migrated attribute copy (2.2s)

  10 passed (23.2s)
```

### Deliberate-failure proof — the gate can actually fail

A detector only ever observed staying quiet is indistinguishable from a broken
one. Temporarily added one hardcoded line to `AppearanceSettings`
(`components/settings/general-settings.tsx`), exercising **both** passes at once:

```tsx
<p aria-label="Deliberate attribute miss">Deliberate hardcoded string</p>
```

The oracle failed and named both strings, plus the screen and the element
carrying the attribute:

```
  ✘ no un-externalized copy on settings — appearance (2.2s)
  9 passed

  1) … › no un-externalized copy on settings — appearance

    Error: Un-externalized strings on settings — appearance:
      - Deliberate hardcoded string
      - aria-label on p: "Deliberate attribute miss"

    Attribute pass examined 24 attribute(s), of which 23 rendered fully accented.
```

Note the positive control held while the leftover check fired: 23 of 24
attributes still rendered accented, so the failure is a real finding rather than
a broken pass. Reverted; the "After" run above is the post-revert state.

### The spec is collected by the E2E job

Verified against the exact command `e2e-tests.yml` runs, not assumed. Iterating
every shard, all 10 tests land in shard 3:

```
$ for s in $(seq 1 14); do
    CI=1 npx playwright test --config e2e/playwright.config.ts \
      --project=chromium --project=mobile-chrome --shard=$s/14 --list \
      | grep -c pseudo-coverage.spec.ts
  done

  shard 3/14: 10 pseudo-coverage tests
```

The `chromium` project's `testIgnore` list (`mobile-*`, `docker/`, `ssh/`,
`office-routing-*`, `auth/`) does not match `i18n/pseudo-coverage.spec.ts`, so
`.github/workflows/` is untouched.

## Possible Improvements

Low risk, and the risk is one-directional: this can only make CI red on
genuinely un-externalized copy on nine screens that are green today. The live
exposure is that the walk is body-wide (deliberately — Radix portals mount
outside `<main>`), so a future PR adding un-migrated shared chrome fails here
even though it did not touch these screens. That is the intended trade and the
fix is migrating the chrome, not narrowing the oracle.

`@kandev/ui`'s ~15 hardcoded strings remain unmigrated and deliberately deferred;
none is reached by a screen currently in `SCREENS`, so nothing here depends on
that. `docs/specs/platform/i18n.md` now records it as the remaining close-out
item instead of listing the env guard.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2360?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->