### PR TITLE
fix(i18n): localize date-fns distances and drop redundant t() test stubs

### DIFF
--- a/apps/web/app/linear/linear-page-client.tsx
+++ b/apps/web/app/linear/linear-page-client.tsx
@@ -32,6 +32,7 @@ import {
 } from "@/components/linear/use-linear-issue-search";
 import type { LinearIssue, LinearTeam } from "@/lib/types/linear";
 import type { Workflow, WorkflowStep } from "@/lib/types/http";
+import { useDateLocale } from "@/lib/i18n/date-locale";
 import { Trans, useTranslation } from "react-i18next";
 
 type LinearPageClientProps = {
@@ -123,7 +124,7 @@ function IssueRow({
   onStartTask: (i: LinearIssue) => void;
 }) {
   const { t } = useTranslation();
-  const relative = formatRelative(issue.updated);
+  const relative = formatRelative(issue.updated, useDateLocale());
   return (
     <div className="flex items-start gap-3 py-3 border-b last:border-b-0">
       <button

--- a/apps/web/app/tasks/columns.tsx
+++ b/apps/web/app/tasks/columns.tsx
@@ -8,7 +8,7 @@ import { IconTrash, IconLoader, IconArchive } from "@tabler/icons-react";
 import { Button } from "@kandev/ui/button";
 import { Badge } from "@kandev/ui/badge";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
-import { formatTimeDistance } from "@/lib/i18n/date-locale";
+import { formatTimeDistance, useDateLocale } from "@/lib/i18n/date-locale";
 import { TaskDeleteConfirmDialog } from "@/components/task/task-delete-confirm-dialog";
 import { TaskArchiveConfirmDialog } from "@/components/task/task-archive-confirm-dialog";
 import { linkToTask } from "@/lib/links";
@@ -138,6 +138,17 @@ function ActionsCell({ row, ctx }: { row: Row<TaskWithResolution>; ctx: ActionsC
   );
 }
 
+// A component rather than an inline cell expression so it can subscribe to the
+// date locale: `getColumns` is a plain builder and cannot call hooks, so an
+// inline cell would keep the `enUS` fallback until some unrelated render.
+function UpdatedAtCell({ updatedAt }: { updatedAt?: string }) {
+  return (
+    <span className="text-xs text-muted-foreground">
+      {formatTimeDistance(updatedAt, useDateLocale())}
+    </span>
+  );
+}
+
 export function getColumns({
   workflows,
   steps,
@@ -178,13 +189,7 @@ export function getColumns({
     {
       accessorKey: "updated_at",
       header: t("tasks:columnUpdated"),
-      cell: ({ row }) => (
-        <span className="text-xs text-muted-foreground">
-          {/* `getColumns` is a plain builder, not a component, so it resolves
-              the locale from the module rather than through `useDateLocale`. */}
-          {formatTimeDistance(row.original.updated_at)}
-        </span>
-      ),
+      cell: ({ row }) => <UpdatedAtCell updatedAt={row.original.updated_at} />,
     },
     {
       id: "actions",

--- a/apps/web/app/tasks/columns.tsx
+++ b/apps/web/app/tasks/columns.tsx
@@ -8,7 +8,7 @@ import { IconTrash, IconLoader, IconArchive } from "@tabler/icons-react";
 import { Button } from "@kandev/ui/button";
 import { Badge } from "@kandev/ui/badge";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
-import { formatDistanceToNow } from "date-fns";
+import { formatTimeDistance } from "@/lib/i18n/date-locale";
 import { TaskDeleteConfirmDialog } from "@/components/task/task-delete-confirm-dialog";
 import { TaskArchiveConfirmDialog } from "@/components/task/task-archive-confirm-dialog";
 import { linkToTask } from "@/lib/links";
@@ -180,7 +180,9 @@ export function getColumns({
       header: t("tasks:columnUpdated"),
       cell: ({ row }) => (
         <span className="text-xs text-muted-foreground">
-          {formatDistanceToNow(new Date(row.original.updated_at), { addSuffix: true })}
+          {/* `getColumns` is a plain builder, not a component, so it resolves
+              the locale from the module rather than through `useDateLocale`. */}
+          {formatTimeDistance(row.original.updated_at)}
         </span>
       ),
     },

--- a/apps/web/components/command-panel-footer.tsx
+++ b/apps/web/components/command-panel-footer.tsx
@@ -3,7 +3,7 @@
 import { useEffect, type Dispatch, type SetStateAction } from "react";
 import { useTranslation } from "react-i18next";
 import type { TFunction } from "i18next";
-import { formatDistanceToNow } from "date-fns";
+import { formatTimeDistance, useDateLocale } from "@/lib/i18n/date-locale";
 import { IconArchive, IconArrowRight, IconHammer, IconLoader2 } from "@tabler/icons-react";
 import {
   Command,
@@ -117,6 +117,7 @@ type TaskResultItemProps = {
 };
 
 function TaskResultItem({ task, stepMap, repoMap, onSelect }: TaskResultItemProps) {
+  const locale = useDateLocale();
   const isArchived = ARCHIVED_STATES.has(task.state);
   const step = stepMap.get(task.workflow_step_id);
   const stepHex = step ? STEP_COLOR_MAP[step.color] : undefined;
@@ -128,7 +129,7 @@ function TaskResultItem({ task, stepMap, repoMap, onSelect }: TaskResultItemProp
   if (workDir) details.push(workDir);
   if (task.primary_agent_name) details.push(task.primary_agent_name);
   if (task.updated_at) {
-    details.push(formatDistanceToNow(new Date(task.updated_at), { addSuffix: true }));
+    details.push(formatTimeDistance(task.updated_at, locale));
   }
   return (
     <CommandItem

--- a/apps/web/components/github/github-rate-limit.tsx
+++ b/apps/web/components/github/github-rate-limit.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { formatDistanceToNow } from "date-fns";
+import type { Locale } from "date-fns";
 import { IconAlertTriangle } from "@tabler/icons-react";
 import { Alert, AlertDescription } from "@kandev/ui/alert";
 import type { GitHubRateLimitInfo, GitHubRateLimitSnapshot } from "@/lib/types/github";
@@ -9,6 +9,7 @@ import { GitHubAccessHelp } from "./github-access-help";
 import { useTranslation } from "react-i18next";
 // Locale-aware digit grouping; `toLocaleString("en-US")` pinned it to English.
 import { formatNumber } from "@/lib/i18n/formats";
+import { formatTimeDistance, useDateLocale } from "@/lib/i18n/date-locale";
 
 // Keyed by GitHub's rate-limit resource name, which is wire data. Catalog keys
 // rather than `t()` calls, because this is module scope (see docs/i18n.md).
@@ -35,10 +36,8 @@ function isExhausted(snap: GitHubRateLimitSnapshot, now: number): boolean {
   return Number.isFinite(reset) && reset > now;
 }
 
-function formatReset(snap: GitHubRateLimitSnapshot): string {
-  const reset = new Date(snap.reset_at);
-  if (!Number.isFinite(reset.getTime())) return "";
-  return formatDistanceToNow(reset, { addSuffix: true });
+function formatReset(snap: GitHubRateLimitSnapshot, locale: Locale): string {
+  return formatTimeDistance(snap.reset_at, locale);
 }
 
 // latestReset returns the snapshot whose reset_at is furthest in the future.
@@ -85,6 +84,9 @@ function RateLimitDetails({
   exhausted: GitHubRateLimitSnapshot[];
 }) {
   const { t } = useTranslation();
+  // `reset` is interpolated into translated sentences, so it has to speak the
+  // same language as the copy around it.
+  const locale = useDateLocale();
   return (
     <div className="space-y-2" data-testid="github-rate-limit-display">
       {exhausted.length > 0 && (
@@ -99,7 +101,7 @@ function RateLimitDetails({
                     : snapshot.resource,
                 )
                 .join(", "),
-              reset: formatReset(latestReset(exhausted)),
+              reset: formatReset(latestReset(exhausted), locale),
             })}
           </AlertDescription>
         </Alert>
@@ -112,7 +114,7 @@ function RateLimitDetails({
           const unit = t(resource?.unitKey ?? "github:rateLimitUnitRequests");
           const limit =
             snapshot.limit > 0 ? formatNumber(snapshot.limit) : t("github:rateLimitUnknown");
-          const reset = formatReset(snapshot);
+          const reset = formatReset(snapshot, locale);
           return (
             <p key={snapshot.resource} data-testid={`github-rate-limit-${snapshot.resource}`}>
               <span className="font-medium text-foreground">{label}:</span>{" "}

--- a/apps/web/components/global-commands.test.tsx
+++ b/apps/web/components/global-commands.test.tsx
@@ -1,10 +1,10 @@
-import { cleanup, render } from "@testing-library/react";
+import { act, cleanup, render } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { CommandItem } from "@/lib/commands/types";
+import { activateLocale, DEFAULT_LOCALE } from "@/lib/i18n";
 import { GlobalCommands } from "./global-commands";
 
 const mocks = vi.hoisted(() => {
-  const translations: Record<string, string> = {};
   return {
     commands: [] as CommandItem[],
     destinations: [
@@ -24,14 +24,9 @@ const mocks = vi.hoisted(() => {
     push: vi.fn(),
     quickChat: vi.fn(),
     setTheme: vi.fn(),
-    translations,
-    translate: vi.fn((key: string) => translations[key] ?? key),
   };
 });
 
-vi.mock("react-i18next", () => ({
-  useTranslation: () => ({ t: mocks.translate }),
-}));
 vi.mock("@/components/state-provider", () => ({
   useAppStore: (selector: (state: unknown) => unknown) =>
     selector({
@@ -70,14 +65,16 @@ function navigationCommand(): CommandItem {
   return command;
 }
 
-beforeEach(() => {
+beforeEach(async () => {
   mocks.commands = [];
   mocks.push.mockReset();
-  mocks.translations["common:commandGroupNavigation"] = "Navigation";
-  mocks.translations["common:commandGoToStatsKeywords"] = "stats, metrics";
+  await activateLocale(DEFAULT_LOCALE);
 });
 
-afterEach(cleanup);
+afterEach(async () => {
+  cleanup();
+  await activateLocale(DEFAULT_LOCALE);
+});
 
 describe("GlobalCommands navigation commands", () => {
   it("maps destinations to commands and navigation actions", () => {
@@ -88,27 +85,32 @@ describe("GlobalCommands navigation commands", () => {
       id: "nav-stats",
       label: "Stats",
       group: "Navigation",
-      keywords: ["stats", "metrics"],
+      keywords: ["stats", "statistics", "analytics", "metrics"],
     });
 
     command.action?.();
     expect(mocks.push).toHaveBeenCalledWith("/stats");
   });
 
-  it("keeps command identity until a translated command value changes", () => {
+  // Drives a real locale switch rather than a stubbed `t`. The point of the
+  // test is that the memo key tracks translated values, and only the real
+  // catalog can show that end to end — a hand-written translation table proves
+  // the memo reacts to the table, not to a locale change.
+  it("keeps command identity until a translated command value changes", async () => {
     const { rerender } = render(<GlobalCommands />);
     const first = navigationCommand();
 
     rerender(<GlobalCommands />);
     expect(navigationCommand()).toBe(first);
 
-    mocks.translations["common:commandGroupNavigation"] = "Navigation pseudo";
-    mocks.translations["common:commandGoToStatsKeywords"] = "statistiques, mesures";
+    await act(async () => {
+      await activateLocale("pt-pt");
+    });
     rerender(<GlobalCommands />);
 
     const translated = navigationCommand();
     expect(translated).not.toBe(first);
-    expect(translated.group).toBe("Navigation pseudo");
-    expect(translated.keywords).toEqual(["statistiques", "mesures"]);
+    expect(translated.group).toBe("Navegação");
+    expect(translated.keywords).toEqual(["estatísticas", "análises", "métricas"]);
   });
 });

--- a/apps/web/components/jira/jira-ticket-common.tsx
+++ b/apps/web/components/jira/jira-ticket-common.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import { formatDistanceToNow } from "date-fns";
+import type { Locale } from "date-fns";
+import { dateLocale, formatTimeDistance } from "@/lib/i18n/date-locale";
 import { Avatar, AvatarFallback, AvatarImage } from "@kandev/ui/avatar";
 import { getJiraTicket, transitionJiraTicket } from "@/lib/api/domains/jira-api";
 import type { JiraStatusCategory, JiraTicket } from "@/lib/types/jira";
@@ -33,11 +34,12 @@ export function statusBadgeClass(category: JiraStatusCategory | undefined): stri
   }
 }
 
-export function formatRelative(iso: string | undefined): string {
-  if (!iso) return "";
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return "";
-  return formatDistanceToNow(d, { addSuffix: true });
+// Distance phrasing comes from date-fns' locale data, so it needs the active
+// locale handed to it — see `@/lib/i18n/date-locale`. Callers inside React
+// should pass `useDateLocale()` so the value re-renders when a lazily loaded
+// locale lands; the default keeps non-component callers correct.
+export function formatRelative(iso: string | undefined, locale?: Locale): string {
+  return formatTimeDistance(iso, locale ?? dateLocale());
 }
 
 export function PersonCell({ name, avatar }: { name?: string; avatar?: string }) {

--- a/apps/web/components/jira/jira-ticket-common.tsx
+++ b/apps/web/components/jira/jira-ticket-common.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import type { Locale } from "date-fns";
-import { dateLocale, formatTimeDistance } from "@/lib/i18n/date-locale";
+import { formatTimeDistance } from "@/lib/i18n/date-locale";
 import { Avatar, AvatarFallback, AvatarImage } from "@kandev/ui/avatar";
 import { getJiraTicket, transitionJiraTicket } from "@/lib/api/domains/jira-api";
 import type { JiraStatusCategory, JiraTicket } from "@/lib/types/jira";
@@ -34,13 +33,11 @@ export function statusBadgeClass(category: JiraStatusCategory | undefined): stri
   }
 }
 
-// Distance phrasing comes from date-fns' locale data, so it needs the active
-// locale handed to it — see `@/lib/i18n/date-locale`. Callers inside React
-// should pass `useDateLocale()` so the value re-renders when a lazily loaded
-// locale lands; the default keeps non-component callers correct.
-export function formatRelative(iso: string | undefined, locale?: Locale): string {
-  return formatTimeDistance(iso, locale ?? dateLocale());
-}
+// Alias of the one canonical distance formatter, kept under this module's
+// historical name so existing consumers and their imports are unchanged.
+// Callers inside React should pass `useDateLocale()` so the value re-renders
+// when a lazily loaded locale lands; the default keeps other callers correct.
+export const formatRelative = formatTimeDistance;
 
 export function PersonCell({ name, avatar }: { name?: string; avatar?: string }) {
   const { t } = useTranslation();

--- a/apps/web/components/jira/jira-ticket-dialog.tsx
+++ b/apps/web/components/jira/jira-ticket-dialog.tsx
@@ -21,6 +21,7 @@ import {
   type TicketState,
 } from "./jira-ticket-common";
 import type { JiraTaskPreset } from "./my-jira/presets";
+import { useDateLocale } from "@/lib/i18n/date-locale";
 import { useTranslation } from "react-i18next";
 
 type JiraTicketDialogProps = {
@@ -348,7 +349,7 @@ function DetailRow({ label, children }: { label: string; children: React.ReactNo
 
 function MetaFooter({ ticket }: { ticket: JiraTicket }) {
   const { t } = useTranslation();
-  const updated = formatRelative(ticket.updated);
+  const updated = formatRelative(ticket.updated, useDateLocale());
   if (!updated) return null;
   return (
     <div className="text-xs text-muted-foreground px-1" title={ticket.updated}>

--- a/apps/web/components/jira/my-jira/ticket-row.tsx
+++ b/apps/web/components/jira/my-jira/ticket-row.tsx
@@ -13,6 +13,7 @@ import {
 import type { JiraTicket } from "@/lib/types/jira";
 import { formatRelative, statusBadgeClass } from "@/components/jira/jira-ticket-common";
 import type { JiraTaskPreset } from "./presets";
+import { useDateLocale } from "@/lib/i18n/date-locale";
 import { useTranslation } from "react-i18next";
 
 type TicketRowProps = {
@@ -82,7 +83,7 @@ function StartTaskMenu({
 
 export function TicketRow({ ticket, presets, onStartTask, onOpen }: TicketRowProps) {
   const { t } = useTranslation();
-  const relative = formatRelative(ticket.updated);
+  const relative = formatRelative(ticket.updated, useDateLocale());
   return (
     <div className="flex items-start gap-3 py-3 border-b last:border-b-0">
       <button

--- a/apps/web/components/linear/linear-issue-common.tsx
+++ b/apps/web/components/linear/linear-issue-common.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import type { Locale } from "date-fns";
-import { dateLocale, formatTimeDistance } from "@/lib/i18n/date-locale";
+import { formatTimeDistance } from "@/lib/i18n/date-locale";
 import { Avatar, AvatarFallback, AvatarImage } from "@kandev/ui/avatar";
 import { getLinearIssue, setLinearIssueState } from "@/lib/api/domains/linear-api";
 import type { LinearIssue, LinearStateCategory } from "@/lib/types/linear";
@@ -36,13 +35,11 @@ export function stateBadgeClass(category: LinearStateCategory | undefined): stri
   }
 }
 
-// Distance phrasing comes from date-fns' locale data, so it needs the active
-// locale handed to it — see `@/lib/i18n/date-locale`. Callers inside React
-// should pass `useDateLocale()` so the value re-renders when a lazily loaded
-// locale lands; the default keeps non-component callers correct.
-export function formatRelative(iso: string | undefined, locale?: Locale): string {
-  return formatTimeDistance(iso, locale ?? dateLocale());
-}
+// Alias of the one canonical distance formatter, kept under this module's
+// historical name so existing consumers and their imports are unchanged.
+// Callers inside React should pass `useDateLocale()` so the value re-renders
+// when a lazily loaded locale lands; the default keeps other callers correct.
+export const formatRelative = formatTimeDistance;
 
 export function PersonCell({ name, avatar }: { name?: string; avatar?: string }) {
   const { t } = useTranslation();

--- a/apps/web/components/linear/linear-issue-common.tsx
+++ b/apps/web/components/linear/linear-issue-common.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import { formatDistanceToNow } from "date-fns";
+import type { Locale } from "date-fns";
+import { dateLocale, formatTimeDistance } from "@/lib/i18n/date-locale";
 import { Avatar, AvatarFallback, AvatarImage } from "@kandev/ui/avatar";
 import { getLinearIssue, setLinearIssueState } from "@/lib/api/domains/linear-api";
 import type { LinearIssue, LinearStateCategory } from "@/lib/types/linear";
@@ -35,11 +36,12 @@ export function stateBadgeClass(category: LinearStateCategory | undefined): stri
   }
 }
 
-export function formatRelative(iso: string | undefined): string {
-  if (!iso) return "";
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return "";
-  return formatDistanceToNow(d, { addSuffix: true });
+// Distance phrasing comes from date-fns' locale data, so it needs the active
+// locale handed to it — see `@/lib/i18n/date-locale`. Callers inside React
+// should pass `useDateLocale()` so the value re-renders when a lazily loaded
+// locale lands; the default keeps non-component callers correct.
+export function formatRelative(iso: string | undefined, locale?: Locale): string {
+  return formatTimeDistance(iso, locale ?? dateLocale());
 }
 
 export function PersonCell({ name, avatar }: { name?: string; avatar?: string }) {

--- a/apps/web/components/linear/linear-issue-dialog.tsx
+++ b/apps/web/components/linear/linear-issue-dialog.tsx
@@ -14,6 +14,7 @@ import {
   useIssueState,
   type IssueState,
 } from "./linear-issue-common";
+import { useDateLocale } from "@/lib/i18n/date-locale";
 import { useTranslation } from "react-i18next";
 
 type LinearIssueDialogProps = {
@@ -321,7 +322,7 @@ function DetailRow({ label, children }: { label: string; children: React.ReactNo
 
 function MetaFooter({ issue }: { issue: LinearIssue }) {
   const { t } = useTranslation();
-  const updated = formatRelative(issue.updated);
+  const updated = formatRelative(issue.updated, useDateLocale());
   if (!updated) return null;
   return (
     <div className="text-xs text-muted-foreground px-1" title={issue.updated}>

--- a/apps/web/components/quick-chat/quick-chat-modal.test.tsx
+++ b/apps/web/components/quick-chat/quick-chat-modal.test.tsx
@@ -52,20 +52,6 @@ vi.mock("@kandev/ui/dropdown-menu", () => ({
   ),
 }));
 
-vi.mock("react-i18next", () => ({
-  useTranslation: () => ({
-    t: (key: string, values?: { count?: number }) => {
-      if (key === "sidebar:quickChatTerminalTab") return `Terminal ${values?.count}`;
-      if (key === "common:agents") return "Agents";
-      if (key === "sidebar:quickChatTerminals") return "Terminals";
-      if (key === "sidebar:quickChatNewAgent") return "New Agent";
-      if (key === "sidebar:quickChatNewTerminal") return "New Terminal";
-      if (key === "sidebar:quickChatAdd") return "Add or switch tab";
-      return key;
-    },
-  }),
-}));
-
 vi.mock("@/hooks/use-quick-chat-width", () => ({
   useQuickChatWidth: () => ({
     width: 720,

--- a/apps/web/components/quick-chat/quick-chat-tab-item.test.tsx
+++ b/apps/web/components/quick-chat/quick-chat-tab-item.test.tsx
@@ -19,17 +19,6 @@ vi.mock("@kandev/ui/context-menu", () => ({
   ),
 }));
 
-vi.mock("react-i18next", () => ({
-  useTranslation: () => ({
-    t: (key: string) =>
-      ({
-        "common:rename": "Rename",
-        "chat:renameChat": "Rename chat",
-        "chat:configurationChat": "Configuration chat",
-      })[key] ?? key,
-  }),
-}));
-
 afterEach(cleanup);
 
 function makeProps(overrides: Partial<Parameters<typeof QuickChatTabItem>[0]> = {}) {

--- a/apps/web/components/quick-chat/quick-tab-add-menu.test.tsx
+++ b/apps/web/components/quick-chat/quick-tab-add-menu.test.tsx
@@ -27,23 +27,6 @@ vi.mock("@kandev/ui/dropdown-menu", () => ({
   ),
 }));
 
-vi.mock("react-i18next", () => ({
-  useTranslation: () => ({
-    t: (key: string, values?: { count?: number; error?: string }) => {
-      const messages: Record<string, string> = {
-        "sidebar:quickChatAdd": "Add or switch tab",
-        "common:agents": "Agents",
-        "sidebar:quickChatNewAgent": "New Agent",
-        "sidebar:quickChatTerminals": "Terminals",
-        "sidebar:quickChatNewTerminal": "New Terminal",
-        "sidebar:quickChatTerminalTab": `Terminal ${values?.count ?? ""}`,
-        "sidebar:quickChatTerminalError": `Terminal error: ${values?.error ?? ""}`,
-      };
-      return messages[key] ?? key;
-    },
-  }),
-}));
-
 afterEach(() => cleanup());
 
 describe("QuickTabAddMenu", () => {

--- a/apps/web/components/quick-chat/quick-terminal-tab-view.test.tsx
+++ b/apps/web/components/quick-chat/quick-terminal-tab-view.test.tsx
@@ -46,21 +46,6 @@ vi.mock("@/components/settings/pty-terminal-view", () => ({
     </button>
   ),
 }));
-vi.mock("react-i18next", () => ({
-  useTranslation: () => ({
-    t: (key: string, values?: { code?: number; error?: string }) => {
-      if (key === "sidebar:quickChatTerminalConnecting") return "Connecting to terminal…";
-      if (key === "sidebar:quickChatTerminalExited") return "Terminal exited.";
-      if (key === "sidebar:quickChatTerminalExitedWithCode") {
-        return `Terminal exited with code ${values?.code}.`;
-      }
-      if (key === "sidebar:quickChatTerminalError") {
-        return `Terminal error: ${values?.error ?? "The terminal could not be started."}`;
-      }
-      return key;
-    },
-  }),
-}));
 
 import { QuickTerminalTabView } from "./quick-terminal-tab-view";
 

--- a/apps/web/components/sentry/sentry-issue-common.tsx
+++ b/apps/web/components/sentry/sentry-issue-common.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import type { Locale } from "date-fns";
-import { dateLocale, formatTimeDistance, useDateLocale } from "@/lib/i18n/date-locale";
+import { formatTimeDistance, useDateLocale } from "@/lib/i18n/date-locale";
 import { Badge } from "@kandev/ui/badge";
 import type { SentryIssue, SentryLevel, SentryStatus } from "@/lib/types/sentry";
 import { IntegrationAuthErrorMessage } from "@/components/integrations/auth-error-message";
@@ -49,13 +48,11 @@ export function statusBadgeClass(status: SentryStatus | undefined): string {
   }
 }
 
-// Distance phrasing comes from date-fns' locale data, so it needs the active
-// locale handed to it — see `@/lib/i18n/date-locale`. Callers inside React
-// should pass `useDateLocale()` so the value re-renders when a lazily loaded
-// locale lands; the default keeps non-component callers correct.
-export function formatRelative(iso: string | undefined, locale?: Locale): string {
-  return formatTimeDistance(iso, locale ?? dateLocale());
-}
+// Alias of the one canonical distance formatter, kept under this module's
+// historical name so existing consumers and their imports are unchanged.
+// Callers inside React should pass `useDateLocale()` so the value re-renders
+// when a lazily loaded locale lands; the default keeps other callers correct.
+export const formatRelative = formatTimeDistance;
 
 export function SentryIssueRow({ issue }: { issue: SentryIssue }) {
   const lastSeen = formatRelative(issue.lastSeen, useDateLocale());

--- a/apps/web/components/sentry/sentry-issue-common.tsx
+++ b/apps/web/components/sentry/sentry-issue-common.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { formatDistanceToNow } from "date-fns";
+import type { Locale } from "date-fns";
+import { dateLocale, formatTimeDistance, useDateLocale } from "@/lib/i18n/date-locale";
 import { Badge } from "@kandev/ui/badge";
 import type { SentryIssue, SentryLevel, SentryStatus } from "@/lib/types/sentry";
 import { IntegrationAuthErrorMessage } from "@/components/integrations/auth-error-message";
@@ -48,15 +49,16 @@ export function statusBadgeClass(status: SentryStatus | undefined): string {
   }
 }
 
-export function formatRelative(iso: string | undefined): string {
-  if (!iso) return "";
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return "";
-  return formatDistanceToNow(d, { addSuffix: true });
+// Distance phrasing comes from date-fns' locale data, so it needs the active
+// locale handed to it — see `@/lib/i18n/date-locale`. Callers inside React
+// should pass `useDateLocale()` so the value re-renders when a lazily loaded
+// locale lands; the default keeps non-component callers correct.
+export function formatRelative(iso: string | undefined, locale?: Locale): string {
+  return formatTimeDistance(iso, locale ?? dateLocale());
 }
 
 export function SentryIssueRow({ issue }: { issue: SentryIssue }) {
-  const lastSeen = formatRelative(issue.lastSeen);
+  const lastSeen = formatRelative(issue.lastSeen, useDateLocale());
   return (
     <div className="space-y-1.5 rounded-md border bg-background px-3 py-2.5">
       <div className="flex items-center gap-2 flex-wrap">

--- a/apps/web/components/settings/workflow-pipeline-editor-step-actions.test.tsx
+++ b/apps/web/components/settings/workflow-pipeline-editor-step-actions.test.tsx
@@ -4,10 +4,6 @@ import type { WorkflowStep } from "@/lib/types/http";
 import { workflowId as toWorkflowId } from "@/lib/types/ids";
 import { TurnCompleteSelect } from "./workflow-pipeline-editor-step-actions";
 
-vi.mock("react-i18next", () => ({
-  useTranslation: () => ({ t: (key: string) => key }),
-}));
-
 afterEach(cleanup);
 
 function step(overrides: Partial<WorkflowStep> = {}): WorkflowStep {
@@ -47,14 +43,10 @@ describe("TurnCompleteSelect cancel completion policy", () => {
     const checkbox = screen.getByTestId("step-1-cancel-completion-checkbox");
 
     expect(checkbox.getAttribute("aria-checked")).toBe("false");
-    // This file stubs react-i18next with an identity `t`, so keys render as
-    // keys. `HelpTip`'s default aria-label is now a catalog key rather than a
-    // hardcoded string, so the expectation follows the same convention as the
-    // queryByText below.
     expect(screen.getByTestId("step-1-cancel-completion-help").getAttribute("aria-label")).toBe(
-      "workflows:moreInformation",
+      "More information",
     );
-    expect(screen.queryByText("workflows:runCompletionActionsWhenTurnCancelledHelp")).toBeNull();
+    expect(screen.queryByText(/Applies only when a user explicitly cancels a turn\./)).toBeNull();
     fireEvent.click(checkbox);
     expect(onUpdate).toHaveBeenCalledWith({ cancel_triggers_turn_complete: true });
   });

--- a/apps/web/components/system-metrics/status-surface-metrics.tsx
+++ b/apps/web/components/system-metrics/status-surface-metrics.tsx
@@ -10,8 +10,9 @@ import {
   IconServer,
 } from "@tabler/icons-react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
-import { formatDistanceToNow } from "date-fns";
+import type { Locale } from "date-fns";
 import type { TFunction } from "i18next";
+import { formatTimeDistance, useDateLocale } from "@/lib/i18n/date-locale";
 import { useTranslation } from "react-i18next";
 import { useAppStore } from "@/components/state-provider";
 import { useResponsiveBreakpoint } from "@/hooks/use-responsive-breakpoint";
@@ -159,6 +160,7 @@ function SourceBadge({
   showLabel: boolean;
 }) {
   const { t } = useTranslation();
+  const locale = useDateLocale();
   return (
     <Tooltip>
       <TooltipTrigger asChild>
@@ -174,7 +176,9 @@ function SourceBadge({
         <div className="space-y-1">
           <div className="font-medium">{t("system:host")}</div>
           <div className="text-xs text-muted-foreground">{source.label}</div>
-          <div className="text-xs text-muted-foreground">{lastUpdatedText(t, updatedAt)}</div>
+          <div className="text-xs text-muted-foreground">
+            {lastUpdatedText(t, locale, updatedAt)}
+          </div>
         </div>
       </TooltipContent>
     </Tooltip>
@@ -221,6 +225,7 @@ function MetricValue({
   simplified: boolean;
 }) {
   const { t } = useTranslation();
+  const locale = useDateLocale();
   const help = metric.id === "io_load" ? t("system:ioLoadHelp") : null;
   return (
     <Tooltip>
@@ -247,7 +252,9 @@ function MetricValue({
           {metric.error ? (
             <div className="text-xs text-muted-foreground">{metric.error}</div>
           ) : null}
-          <div className="text-xs text-muted-foreground">{lastUpdatedText(t, updatedAt)}</div>
+          <div className="text-xs text-muted-foreground">
+            {lastUpdatedText(t, locale, updatedAt)}
+          </div>
         </div>
       </TooltipContent>
     </Tooltip>
@@ -309,11 +316,12 @@ function metricColor(metric: SystemMetricSample) {
   return "text-current";
 }
 
-function lastUpdatedText(t: TFunction, updatedAt?: string) {
-  if (!updatedAt) return t("system:lastUpdateUnknown");
-  const date = new Date(updatedAt);
-  if (Number.isNaN(date.getTime())) return t("system:lastUpdateUnknown");
-  return t("system:updatedRelative", {
-    relative: formatDistanceToNow(date, { addSuffix: true }),
-  });
+// `relative` is interpolated into a translated sentence, so an unlocalized
+// date-fns distance would leave "about 1 hour ago" sitting inside Portuguese
+// prose. Passing the value through `values` is already the right shape; it just
+// needs the active locale to reach the formatter.
+function lastUpdatedText(t: TFunction, locale: Locale, updatedAt?: string) {
+  const relative = formatTimeDistance(updatedAt, locale);
+  if (!relative) return t("system:lastUpdateUnknown");
+  return t("system:updatedRelative", { relative });
 }

--- a/apps/web/components/task/chat/voice-input-button.tsx
+++ b/apps/web/components/task/chat/voice-input-button.tsx
@@ -203,6 +203,14 @@ function useVoiceShortcut(
 
 // ── Unsupported fallback ────────────────────────────────────────────────
 
+// URL schemes the reader has to reproduce verbatim in the address bar, not copy.
+// Interpolated so the pseudo-locale and translators leave them intact — baked
+// into the message, `https://` pseudolocalizes to `ĥţţƥś://`, a scheme that does
+// not exist. Same reasoning as `settings:voiceUnavailableInsecure`, which
+// already passes its scheme and host as values.
+const VOICE_SECURE_SCHEME_URL = "https://";
+const VOICE_LOCALHOST_URL = "http://localhost";
+
 function buildUnsupportedReasonKey(): string {
   if (typeof window === "undefined") return "task:voiceInputUnavailableHere";
   if (!window.isSecureContext) return "task:voiceInputNeedsHttps";
@@ -215,7 +223,12 @@ function UnsupportedVoiceButton({ disabled }: { disabled?: boolean }) {
   const handleClick = () => {
     toast({
       title: t("task:voiceInputUnavailable"),
-      description: t(buildUnsupportedReasonKey()),
+      // Only `voiceInputNeedsHttps` reads these; i18next ignores values a
+      // message does not reference, so they can be passed unconditionally.
+      description: t(buildUnsupportedReasonKey(), {
+        secureSchemeUrl: VOICE_SECURE_SCHEME_URL,
+        localhostUrl: VOICE_LOCALHOST_URL,
+      }),
       variant: "error",
     });
   };

--- a/apps/web/components/task/commit-detail-panel.test.tsx
+++ b/apps/web/components/task/commit-detail-panel.test.tsx
@@ -33,10 +33,6 @@ vi.mock("@/lib/layout/panel-portal-manager", () => ({
   setPanelTitle: vi.fn(),
 }));
 
-vi.mock("react-i18next", () => ({
-  useTranslation: () => ({ t: (key: string) => key }),
-}));
-
 vi.mock("./panel-primitives", () => ({
   PanelRoot: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   PanelBody: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
@@ -66,7 +62,7 @@ describe("CommitDiffView error state", () => {
     expect(screen.getByRole("alert").textContent).toContain("Commit detail unavailable");
     expect(screen.queryByText("No files in this commit")).toBeNull();
 
-    fireEvent.click(screen.getByRole("button", { name: "system:featureTogglesRetry" }));
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
     expect(mocks.refetch).toHaveBeenCalledOnce();
   });
 });

--- a/apps/web/components/task/session-tab-close-action.test.tsx
+++ b/apps/web/components/task/session-tab-close-action.test.tsx
@@ -2,10 +2,6 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { SessionTabCloseAction } from "./session-tab-close-action";
 
-vi.mock("react-i18next", () => ({
-  useTranslation: () => ({ t: (key: string) => key }),
-}));
-
 afterEach(() => cleanup());
 
 describe("SessionTabCloseAction", () => {
@@ -13,7 +9,7 @@ describe("SessionTabCloseAction", () => {
     const onClose = vi.fn();
     render(<SessionTabCloseAction sessionId="s1" isDeleting={false} onClose={onClose} />);
 
-    const button = screen.getByRole("button", { name: "common:deleteSession" });
+    const button = screen.getByRole("button", { name: "Delete session" });
     expect((button as HTMLButtonElement).disabled).toBe(false);
     expect(button.getAttribute("aria-busy")).toBe("false");
     expect(screen.queryByRole("status")).toBeNull();
@@ -27,7 +23,7 @@ describe("SessionTabCloseAction", () => {
     const onClose = vi.fn();
     render(<SessionTabCloseAction sessionId="s1" isDeleting onClose={onClose} />);
 
-    const button = screen.getByRole("button", { name: "common:deleteSession" });
+    const button = screen.getByRole("button", { name: "Delete session" });
     expect((button as HTMLButtonElement).disabled).toBe(true);
     expect(button.getAttribute("aria-busy")).toBe("true");
     expect(screen.getByRole("status")).toBeTruthy();

--- a/apps/web/eslint.i18n.options.mjs
+++ b/apps/web/eslint.i18n.options.mjs
@@ -154,7 +154,10 @@ export const noLiteralStringOptions = {
       "cmd",
       ".*[Ii]dPrefix$",
       ".*[Ii]dSuffix$",
-      ".*SaveId$",
+      // Matches the bare `saveId` prop as well as composed `fooSaveId` names.
+      // The former `.*SaveId$` required at least one leading character, so it
+      // never matched the prop the codebase actually uses (`saveId`).
+      ".*[Ss]aveId$",
       "aria-labelledby",
       "aria-controls",
       "aria-describedby",

--- a/apps/web/eslint.i18n.options.test.ts
+++ b/apps/web/eslint.i18n.options.test.ts
@@ -173,4 +173,15 @@ describe("jsx-attributes.exclude", () => {
       expect(excludesAttribute(name)).toBe(false);
     },
   );
+
+  // The pattern used to be `.*SaveId$`, which requires at least one character
+  // before `SaveId` and so matched a composed `fooSaveId` but never the bare
+  // `saveId` the codebase actually writes (`prompts-settings.tsx`,
+  // `secrets-settings.tsx`). It was inert: the draft ids it was meant to cover
+  // are hyphenated lowercase slugs that `words.exclude` already skips, so
+  // fixing it changes no finding — it only stops the entry lying about its
+  // coverage, and now holds for a `saveId` value that is not slug-shaped.
+  it.each(["saveId", "draftSaveId"])("excludes the draft-id prop %j", (name) => {
+    expect(excludesAttribute(name)).toBe(true);
+  });
 });

--- a/apps/web/hooks/domains/session/use-commit-detail.test.ts
+++ b/apps/web/hooks/domains/session/use-commit-detail.test.ts
@@ -20,10 +20,6 @@ vi.mock("@/components/toast-provider", () => ({
   useToast: () => ({ toast: mocks.toast }),
 }));
 
-vi.mock("react-i18next", () => ({
-  useTranslation: () => ({ t: (key: string) => key }),
-}));
-
 vi.mock("@/components/task/commit-detail-request", () => ({
   CommitDetailProtocolError: class CommitDetailProtocolError extends Error {},
   requestCommitDetail: mocks.requestCommitDetail,
@@ -129,7 +125,7 @@ describe("useCommitDetail", () => {
     const { result } = renderHook(() => useCommitDetail(remoteTarget));
 
     await waitFor(() => expect(result.current.loading).toBe(false));
-    expect(result.current.error).toBe("unexpectedResponseFromTheServer");
+    expect(result.current.error).toBe("Unexpected response from the server");
     expect(result.current.files).toBeNull();
     expect(mocks.toast).toHaveBeenCalled();
   });

--- a/apps/web/hooks/domains/settings/use-settings-discovery.test.ts
+++ b/apps/web/hooks/domains/settings/use-settings-discovery.test.ts
@@ -24,11 +24,6 @@ const mocks = vi.hoisted(() => ({
       }>,
     },
   },
-  t: vi.fn((key: string) => key),
-}));
-
-vi.mock("react-i18next", () => ({
-  useTranslation: () => ({ t: mocks.t }),
 }));
 
 vi.mock("@/components/state-provider", () => ({

--- a/apps/web/lib/i18n/date-locale.test.ts
+++ b/apps/web/lib/i18n/date-locale.test.ts
@@ -1,6 +1,6 @@
 import { formatDistanceToNow } from "date-fns";
 import { enUS } from "date-fns/locale/en-US";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { dateLocale, formatTimeDistance, primeDateLocale, resolveDateLocale } from "./date-locale";
 import { activateLocale, DEFAULT_LOCALE } from "./index";
@@ -86,6 +86,14 @@ describe("resolveDateLocale", () => {
 });
 
 describe("dateLocale", () => {
+  // Restore in a hook rather than at the end of each test body: a failing
+  // assertion would skip inline cleanup and leak `pt-pt` and fake timers into
+  // whatever runs next.
+  afterEach(async () => {
+    vi.useRealTimers();
+    await activateLocale(DEFAULT_LOCALE);
+  });
+
   it("follows the active i18next language once primed", async () => {
     await activateLocale("pt-pt");
     await primeDateLocale("pt-pt");
@@ -104,8 +112,5 @@ describe("dateLocale", () => {
     // The gap this PR closes: previously "about 1 hour ago" in Portuguese prose.
     expect(formatTimeDistance(ago(HOUR))).toBe("há aproximadamente 1 hora");
     expect(formatTimeDistance(ago(3 * DAY))).toBe("há 3 dias");
-
-    await activateLocale(DEFAULT_LOCALE);
-    vi.useRealTimers();
   });
 });

--- a/apps/web/lib/i18n/date-locale.test.ts
+++ b/apps/web/lib/i18n/date-locale.test.ts
@@ -1,0 +1,111 @@
+import { formatDistanceToNow } from "date-fns";
+import { enUS } from "date-fns/locale/en-US";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { dateLocale, formatTimeDistance, primeDateLocale, resolveDateLocale } from "./date-locale";
+import { activateLocale, DEFAULT_LOCALE } from "./index";
+
+// A fixed instant so the distance buckets are deterministic; `formatTimeDistance`
+// measures against `Date.now()`, so each case offsets from a stubbed now.
+const NOW = new Date("2026-08-07T12:00:00.000Z").getTime();
+
+function ago(ms: number): Date {
+  return new Date(NOW - ms);
+}
+
+const MINUTE = 60_000;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+
+describe("formatTimeDistance", () => {
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    await activateLocale(DEFAULT_LOCALE);
+    return () => {
+      vi.useRealTimers();
+    };
+  });
+
+  // The guard clause the three per-integration helpers used to each own.
+  it.each([undefined, null, "", "not-a-date"])("returns empty string for %j", (value) => {
+    expect(formatTimeDistance(value)).toBe("");
+  });
+
+  it("accepts a Date, an ISO string, and an epoch number alike", () => {
+    const date = ago(2 * HOUR);
+    expect(formatTimeDistance(date)).toBe("about 2 hours ago");
+    expect(formatTimeDistance(date.toISOString())).toBe("about 2 hours ago");
+    expect(formatTimeDistance(date.getTime())).toBe("about 2 hours ago");
+  });
+
+  /**
+   * The English output must not move: e2e specs query these timestamps by
+   * accessible name, and this project has broken specs exactly that way.
+   * Pinning literals rather than comparing against date-fns would pass even if
+   * we accidentally swapped the default locale, so this asserts both — the
+   * exact strings AND equality with an unlocalized call.
+   */
+  it.each([
+    // Under 30s reads as "less than a minute"; 30s already rounds up to one.
+    [10_000, "less than a minute ago"],
+    [30_000, "1 minute ago"],
+    [5 * MINUTE, "5 minutes ago"],
+    [HOUR, "about 1 hour ago"],
+    [3 * DAY, "3 days ago"],
+  ])("renders %j ms ago as %j under en", (offset, expected) => {
+    expect(formatTimeDistance(ago(offset))).toBe(expected);
+  });
+
+  it("is byte-identical to an unlocalized date-fns call under en", () => {
+    for (const offset of [30_000, 5 * MINUTE, HOUR, 3 * DAY, 400 * DAY]) {
+      const date = ago(offset);
+      expect(formatTimeDistance(date)).toBe(formatDistanceToNow(date, { addSuffix: true }));
+    }
+  });
+});
+
+describe("resolveDateLocale", () => {
+  it.each([
+    ["en", "en-US"],
+    ["pt-pt", "pt"],
+    ["zh-cn", "zh-CN"],
+  ])("maps %j to the %j date-fns locale", async (locale, code) => {
+    const resolved = await resolveDateLocale(locale as "en");
+    expect(resolved.code).toBe(code);
+  });
+
+  /**
+   * There is no pseudo date locale. Mapping it to `enUS` is a decision, not a
+   * fallthrough — see the module comment. Asserted so a future "just let it be
+   * undefined" change has to be deliberate.
+   */
+  it("maps pseudo to en-US rather than leaving it undefined", async () => {
+    await expect(resolveDateLocale("pseudo")).resolves.toBe(enUS);
+  });
+});
+
+describe("dateLocale", () => {
+  it("follows the active i18next language once primed", async () => {
+    await activateLocale("pt-pt");
+    await primeDateLocale("pt-pt");
+    expect(dateLocale().code).toBe("pt");
+
+    await activateLocale(DEFAULT_LOCALE);
+    expect(dateLocale().code).toBe("en-US");
+  });
+
+  it("renders Portuguese distances once pt is active", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    await activateLocale("pt-pt");
+    await primeDateLocale("pt-pt");
+
+    // The gap this PR closes: previously "about 1 hour ago" in Portuguese prose.
+    expect(formatTimeDistance(ago(HOUR))).toBe("há aproximadamente 1 hora");
+    expect(formatTimeDistance(ago(3 * DAY))).toBe("há 3 dias");
+
+    await activateLocale(DEFAULT_LOCALE);
+    vi.useRealTimers();
+  });
+});

--- a/apps/web/lib/i18n/date-locale.ts
+++ b/apps/web/lib/i18n/date-locale.ts
@@ -1,0 +1,158 @@
+import { useSyncExternalStore } from "react";
+import { formatDistanceToNow, type Locale } from "date-fns";
+import { enUS } from "date-fns/locale/en-US";
+
+import { DEFAULT_LOCALE, i18n, normalizeLocale, type SupportedLocale } from "./index";
+
+/**
+ * date-fns locale resolution.
+ *
+ * `./formats` already covers everything `Intl` can do — numbers, dates, times,
+ * and the hand-bucketed relative strings that route through the catalog. What
+ * `Intl` does not give us is date-fns' fuzzy distance phrasing ("about 1 hour
+ * ago", "3 days ago"). Those words live in date-fns' own locale objects, so
+ * they translate only if the formatter is handed a `Locale`; with none it
+ * silently resolves `defaultLocale` and renders English — which is how a
+ * pt-PT user ended up reading "about 1 hour ago" inside Portuguese prose.
+ *
+ * Kept out of `./index` on purpose. `./index` is on the critical boot path and
+ * is edited often; this module is imported only by the handful of surfaces
+ * that render a distance, so date-fns' locale chunks stay off that path.
+ */
+
+/**
+ * Our locale ids to date-fns locales.
+ *
+ * `en` and `pseudo` resolve to `enUS` statically, which costs no bundle bytes:
+ * date-fns ships `enUS` as its own `defaultLocale`, so it is already present in
+ * any chunk that calls a formatter. The other two are loaded on demand — they
+ * are not tiny, and eagerly importing them would undo the initial-bundle work
+ * happening in parallel on the catalog loader.
+ *
+ * `pseudo` mapping to `enUS` is a decision, not a fallthrough. There is no
+ * pseudo date locale; leaving it out would land on `enUS` anyway, but via
+ * date-fns' default rather than our intent. It does mean distances are the one
+ * part of the UI the pseudo-locale cannot prove, because date-fns owns those
+ * strings rather than our catalog.
+ */
+const LAZY_LOCALES: Partial<Record<SupportedLocale, () => Promise<Locale>>> = {
+  "pt-pt": () => import("date-fns/locale/pt").then((m) => m.pt),
+  "zh-cn": () => import("date-fns/locale/zh-CN").then((m) => m.zhCN),
+};
+
+const loaded = new Map<SupportedLocale, Locale>([
+  ["en", enUS],
+  ["pseudo", enUS],
+]);
+
+const inFlight = new Map<SupportedLocale, Promise<Locale>>();
+const listeners = new Set<() => void>();
+
+function activeLocale(): SupportedLocale {
+  return normalizeLocale(i18n.language || DEFAULT_LOCALE);
+}
+
+/**
+ * The date-fns locale for `locale`, loading it if needed. Resolves to `enUS`
+ * for any locale with no lazy loader, so a caller never has to special-case
+ * the statically-bundled ones.
+ */
+export function resolveDateLocale(locale: SupportedLocale): Promise<Locale> {
+  const cached = loaded.get(locale);
+  if (cached) return Promise.resolve(cached);
+
+  const pending = inFlight.get(locale);
+  if (pending) return pending;
+
+  const load = LAZY_LOCALES[locale];
+  if (!load) return Promise.resolve(enUS);
+
+  const request = load()
+    .then((resolved) => {
+      loaded.set(locale, resolved);
+      return resolved;
+    })
+    .catch(() => {
+      // A failed chunk fetch (offline, stale deploy) must not break the
+      // surface — cache the English fallback so we stop retrying on every
+      // render and the timestamp still shows, just unlocalized.
+      loaded.set(locale, enUS);
+      return enUS;
+    })
+    .finally(() => {
+      inFlight.delete(locale);
+    });
+
+  inFlight.set(locale, request);
+  return request;
+}
+
+/**
+ * The active date-fns locale, synchronously. Returns `enUS` while a lazily
+ * loaded locale is still in flight — components re-render via `useDateLocale`
+ * once it lands.
+ */
+export function dateLocale(): Locale {
+  return loaded.get(activeLocale()) ?? enUS;
+}
+
+function notify(): void {
+  for (const listener of listeners) listener();
+}
+
+function subscribe(onStoreChange: () => void): () => void {
+  listeners.add(onStoreChange);
+  return () => {
+    listeners.delete(onStoreChange);
+  };
+}
+
+/**
+ * The active date-fns locale, re-rendering the caller when the language
+ * changes or a lazily loaded locale arrives.
+ *
+ * `dateLocale` is a stable snapshot: it hands back the same cached `Locale`
+ * object until one of those two things happens, which is what
+ * `useSyncExternalStore` requires.
+ */
+export function useDateLocale(): Locale {
+  return useSyncExternalStore(subscribe, dateLocale, dateLocale);
+}
+
+/** Load `locale`'s date-fns locale and wake subscribed components. */
+export function primeDateLocale(locale: SupportedLocale): Promise<void> {
+  return resolveDateLocale(locale).then(() => {
+    notify();
+  });
+}
+
+/**
+ * Format `value` as a distance from now ("about 1 hour ago") in the active
+ * locale. Returns "" for missing or unparseable input.
+ *
+ * Under `en` this is byte-identical to a bare `formatDistanceToNow(d, {
+ * addSuffix: true })`: date-fns' `defaultLocale` *is* `enUS`, so naming it
+ * changes nothing. That matters because e2e specs query these timestamps by
+ * accessible name.
+ */
+export function formatTimeDistance(
+  value: string | number | Date | null | undefined,
+  locale: Locale = dateLocale(),
+): string {
+  if (value === null || value === undefined || value === "") return "";
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return "";
+  return formatDistanceToNow(date, { addSuffix: true, locale });
+}
+
+// Track the active language for the whole app lifetime. Registered at import
+// rather than from `activateLocale` so this stays out of `./index`; the load
+// starts at app boot, well before any distance-rendering surface mounts.
+i18n.on("languageChanged", (next: string) => {
+  // Notify unconditionally: switching back to an already-cached locale still
+  // has to re-render, and `primeDateLocale` only fires after an await.
+  notify();
+  void primeDateLocale(normalizeLocale(next));
+});
+
+void primeDateLocale(activeLocale());

--- a/apps/web/src/locales/en/task.json
+++ b/apps/web/src/locales/en/task.json
@@ -1384,7 +1384,7 @@
   "viewName": "View name",
   "viewPlanHistory": "View plan history",
   "voiceInput": "Voice input",
-  "voiceInputNeedsHttps": "Voice input needs HTTPS. Open this site over https:// (or http://localhost) — most mobile browsers block microphone APIs on insecure origins.",
+  "voiceInputNeedsHttps": "Voice input needs HTTPS. Open this site over {{secureSchemeUrl}} (or {{localhostUrl}}) — most mobile browsers block microphone APIs on insecure origins.",
   "voiceInputUnavailable": "Voice input unavailable",
   "voiceInputUnavailableHere": "Voice input is unavailable here.",
   "voiceInputUnavailableTapForDetails": "Voice input unavailable — tap for details",

--- a/apps/web/src/locales/pseudo/task.json
+++ b/apps/web/src/locales/pseudo/task.json
@@ -1384,7 +1384,7 @@
   "viewName": "Vĩēŵ ńàḿē",
   "viewPlanHistory": "Vĩēŵ ƥĺàń ĥĩśţōŕŷ",
   "voiceInput": "Vōĩćē ĩńƥũţ",
-  "voiceInputNeedsHttps": "Vōĩćē ĩńƥũţ ńēēďś ĤŢŢƤŚ. Ōƥēń ţĥĩś śĩţē ōvēŕ ĥţţƥś:// (ōŕ ĥţţƥ://ĺōćàĺĥōśţ) — ḿōśţ ḿōƀĩĺē ƀŕōŵśēŕś ƀĺōćķ ḿĩćŕōƥĥōńē ÀƤĨś ōń ĩńśēćũŕē ōŕĩĝĩńś.",
+  "voiceInputNeedsHttps": "Vōĩćē ĩńƥũţ ńēēďś ĤŢŢƤŚ. Ōƥēń ţĥĩś śĩţē ōvēŕ {{secureSchemeUrl}} (ōŕ {{localhostUrl}}) — ḿōśţ ḿōƀĩĺē ƀŕōŵśēŕś ƀĺōćķ ḿĩćŕōƥĥōńē ÀƤĨś ōń ĩńśēćũŕē ōŕĩĝĩńś.",
   "voiceInputUnavailable": "Vōĩćē ĩńƥũţ ũńàvàĩĺàƀĺē",
   "voiceInputUnavailableHere": "Vōĩćē ĩńƥũţ ĩś ũńàvàĩĺàƀĺē ĥēŕē.",
   "voiceInputUnavailableTapForDetails": "Vōĩćē ĩńƥũţ ũńàvàĩĺàƀĺē — ţàƥ ƒōŕ ďēţàĩĺś",

--- a/apps/web/src/locales/pt-pt/task.json
+++ b/apps/web/src/locales/pt-pt/task.json
@@ -753,7 +753,7 @@
   "viewLimitReached_other": "Pode guardar até {{count}} vistas.",
   "viewName": "Nome da vista",
   "voiceInput": "Entrada de voz",
-  "voiceInputNeedsHttps": "A entrada de voz precisa de HTTPS. Abra este site em https:// (ou http://localhost) — a maioria dos navegadores móveis bloqueia as APIs de microfone em origens inseguras.",
+  "voiceInputNeedsHttps": "A entrada de voz precisa de HTTPS. Abra este site em {{secureSchemeUrl}} (ou {{localhostUrl}}) — a maioria dos navegadores móveis bloqueia as APIs de microfone em origens inseguras.",
   "voiceInputUnavailable": "Entrada de voz indisponível",
   "voiceInputUnavailableHere": "A entrada de voz não está disponível aqui.",
   "voiceInputUnavailableTapForDetails": "Entrada de voz indisponível — toque para ver os detalhes",


### PR DESCRIPTION
Now that pt-PT ships, a Portuguese user reads a fully translated UI with `about 1 hour ago` sitting inside it — date-fns distance phrasing was English in every locale because no call site ever passed a `date-fns/locale`. This localizes all of them and clears three smaller i18n defects found alongside it.

## Important Changes

**1 — date-fns distances were English in every locale.**

The scope is smaller than an earlier estimate suggested. A grep for `date-fns` returns 10 lines, but 3 are comments; the real surface is **7 files with 7 call sites, every one of them `formatDistanceToNow(…, { addSuffix: true })`**. There is no date-fns `format` or `formatRelative` anywhere — `formatRelative` in this repo is the repo's own i18next-bucketed helper in `lib/i18n/formats.ts`, and `formatRelativeTime`/`timeAgo` delegate to it. Those were already localized. A broader regex counts 46 "formatting calls", but that number conflates `Intl…format()` and the repo's own helpers with date-fns; the date-fns-owned count is 7.

New `lib/i18n/date-locale.ts` owns resolution — deliberately its own module, not `lib/i18n/index.ts`, which siblings are editing:

- `en` and `pseudo` → `enUS`, statically imported. That import is free: date-fns ships `enUS` as its own `defaultLocale`, so it is already in any chunk calling a formatter. `pseudo` → `enUS` is a decision, not a fallthrough (there is no pseudo date locale); it is asserted in a test so a future "just leave it undefined" has to be deliberate.
- `pt-pt` → `pt` and `zh-cn` → `zhCN` load lazily via dynamic import, so they stay off the boot path and do not eat the initial-bundle work happening in parallel on the catalog loader. Catalog lazy-loading has not landed yet (`lib/i18n/index.ts` still uses an eager glob), so there was no pattern to match. Verified on a production build: `pt` (5.9 KB) and `zh-CN` (6.2 KB) each split into their own chunk, while `enUS` rides along in date-fns' own `defaultLocale` chunk that `formatDistanceToNow` already pulls in.
- `useDateLocale()` re-renders consumers when the language changes or a lazily loaded locale arrives; a failed chunk fetch caches the English fallback rather than retrying every render.

**What a pt-PT user now sees:** `há aproximadamente 1 hora` and `há 3 dias` instead of `about 1 hour ago` and `3 days ago`. Asserted directly in `date-locale.test.ts`.

English output is unchanged. `formatTimeDistance` under `en` is pinned both to exact literals *and* to equality with a bare unlocalized `formatDistanceToNow` call — pinning only literals would still pass if the default locale were swapped out from under it.

Two call sites were the exact trap of a date-fns value interpolated into translated prose — `system:updatedRelative` and `github:resets`/`githubApiAccessIsExhaustedFor`. Both already passed the value through `values` (the right shape), so the fix was to get the locale to the formatter, not to translate around it.

This also collapses three drifted copies of the same six-line guard helper (`linear-issue-common`, `jira-ticket-common`, `sentry-issue-common`) onto one shared implementation, keeping their exported names so no consumer changed.

Two notes worth flagging, neither acted on here:

- `app/tasks/columns.tsx` has **no importers** — it is dead. I localized it for consistency rather than deleting it, since deletion is out of scope and removing an `app/` file also needs a guard-allowlist edit.
- Distances are the one part of the UI the pseudo-locale cannot prove, because date-fns owns those strings rather than our catalog.

**2 — Ten test files stubbed `react-i18next` with a key-echoing `t`.**

The stub cannot fail before a file is migrated and always fails after, and no gate sees it. All ten are removed; `vitest.setup.ts` already bootstraps real i18next from the shipped catalogs, so the stubs were redundant.

**No removal revealed a genuine failure.** Five assertions broke, and all five were tests asserting on a key name that now resolves to real copy (`common:deleteSession` → `Delete session`, `system:featureTogglesRetry` → `Retry`, `workflows:moreInformation` → `More information`, `github:unexpectedResponseFromTheServer` → `Unexpected response from the server`). No component rendered a raw key.

One file needed more than a deletion. `global-commands.test.tsx`'s mock was not a key-echo stub — it was a controllable translation table driving *"keeps command identity until a translated command value changes"*. A hand-written table only proves the memo reacts to the table, so that test now drives a **real locale switch** (`en` → `pt-pt`) and asserts against the real catalog (`Navegação`, `["estatísticas", "análises", "métricas"]`), which exercises the react-i18next re-render path end to end.

**3 — `voiceInputNeedsHttps` mangled a URL scheme under pseudo.**

`https://` and `http://localhost` were baked into the message, so pseudo rewrote them to `ĥţţƥś://` and `ĥţţƥ://ĺōćàĺĥōśţ` — telling the user to open a scheme that does not exist. Both are now interpolated, following the `settings:voiceUnavailableInsecure` precedent. The consumer is `components/task/chat/voice-input-button.tsx` (not `voice-init-button.tsx`). pt-PT was updated in the same shape so the placeholder-drift check stays quiet.

Pseudo output after regeneration, with values substituted:

```
Vōĩćē ĩńƥũţ ńēēďś ĤŢŢƤŚ. Ōƥēń ţĥĩś śĩţē ōvēŕ https:// (ōŕ http://localhost) — ḿōśţ
ḿōƀĩĺē ƀŕōŵśēŕś ƀĺōćķ ḿĩćŕōƥĥōńē ÀƤĨś ōń ĩńśēćũŕē ōŕĩĝĩńś.
```

Both schemes survive verbatim. The bare prose word "HTTPS" is left translatable on purpose — it is a word in a sentence, not something the reader retypes.

**4 — `.*SaveId$` in the guard config never matched.**

`.*SaveId$` requires at least one character before `SaveId`, so it matched a composed `fooSaveId` but never the bare `saveId` the codebase actually writes. Fixed to `.*[Ss]aveId$` and pinned with a test.

**Finding count: 826 before → 826 after, with a byte-identical finding list.** The entry was dead either way, and it is worth recording *why*: the draft ids it was meant to cover (`prompts-item-draft`, and the `secrets-…-item-draft` template chunks) are hyphenated lowercase slugs that the `words.exclude` separator pattern already skips, so the attribute name is never consulted. The fix stops the entry lying about its coverage and makes it hold for a `saveId` whose value is not slug-shaped. No other exclude patterns were touched.

## Validation

```
pnpm run typecheck                                    ✓
pnpm lint --max-warnings 0                            ✓
pnpm run i18n:check                                   ✓ pseudo in sync
pnpm run i18n:ratchet                                 ✓ 1 added + 12 modified clean
node scripts/check-guard-allowlist.mjs                ✓ 451 entries intact
pnpm test                                             ✓ 1229 files, 9591 passed, 4 skipped, 0 failed
pnpm run lint:i18n | grep -c no-literal-string        826 (baseline 826, list identical)
```

`git diff origin/main -- eslint.i18n.options.mjs` shows only the `SaveId` pattern change — no `i18nGuardFiles` entry added or removed. Verified against `origin/main` directly; `main` has not moved from `f09e93867`, so no rebase was needed.

## Possible Improvements

Low risk. English rendering is unchanged and pinned against an unlocalized call, so e2e accessible-name queries are unaffected. The one behavioral nuance is that a non-English user can see an English distance for the few milliseconds before the lazy locale chunk resolves; the load starts at app boot, well before any of these surfaces mount, and a failed fetch degrades to English rather than breaking the surface.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2363?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->