### PR TITLE
fix(i18n): tie the pseudo-coverage oracle to the screen it claims to check

### DIFF
--- a/apps/web/components/settings/secrets-settings.tsx
+++ b/apps/web/components/settings/secrets-settings.tsx
@@ -497,7 +497,10 @@ function SecretsSettingsBody({
   const { isValid, isBusy } = actions;
   return (
     <>
-      <div className="space-y-6">
+      {/* `secrets-settings-body` is the pseudo-coverage oracle's render anchor for
+          this screen (e2e/tests/i18n/pseudo-coverage.spec.ts). Renaming it makes
+          that spec time out rather than silently scan an unrendered route. */}
+      <div className="space-y-6" data-testid="secrets-settings-body">
         <div className="flex items-center justify-between">
           <div className="text-sm font-medium text-foreground">{secretScopeTitle(t)}</div>
           <Button

--- a/apps/web/components/settings/sprites-settings.tsx
+++ b/apps/web/components/settings/sprites-settings.tsx
@@ -54,7 +54,13 @@ export function SpritesConnectionCard({ secretId }: { secretId?: string }) {
   }, [secretId, t]);
 
   return (
-    <SettingsCard discoveryTargetId={GENERAL_SETTINGS_TARGETS.spritesConnection}>
+    // `sprites-connection-card` is the pseudo-coverage oracle's render anchor for
+    // this screen (e2e/tests/i18n/pseudo-coverage.spec.ts). Renaming it makes that
+    // spec time out rather than silently scan an unrendered route.
+    <SettingsCard
+      discoveryTargetId={GENERAL_SETTINGS_TARGETS.spritesConnection}
+      data-testid="sprites-connection-card"
+    >
       <CardHeader>
         <div className="flex items-center justify-between">
           <div>

--- a/apps/web/e2e/tests/i18n/pseudo-coverage.spec.ts
+++ b/apps/web/e2e/tests/i18n/pseudo-coverage.spec.ts
@@ -35,11 +35,12 @@ import { test, expect } from "../../fixtures/test-base";
  * pseudo-locale), or is on an allowlist that says why it must not be translated.
  *
  * That guarantee rests on the scan having run against the screen it names, which
- * for a while it did not. Each `SCREENS` entry carries a required `anchor` — an
- * element that screen alone renders — and `waitForScreen` blocks on it before
- * anything is inspected. Read its comment before touching the readiness logic:
- * the wait it replaced was a one-second settle, and with the lazy settings chunk
- * blocked so that NO screen rendered, all nine screen tests passed.
+ * for a while it did not. Each `SCREENS` entry carries a required `anchor` — a
+ * selector that cannot match until that route rendered — and `waitForScreen`
+ * blocks on it before anything is inspected. Read its comment before touching
+ * the readiness logic: the wait it replaced was a one-second settle, and with
+ * both lazy route chunks blocked so that NO screen rendered, 13-16 of the 21
+ * tests still reported clean.
  *
  * It is a floor, not a proof of total coverage. Two limits are deliberate and
  * both are documented where they are implemented, because relaxing either
@@ -279,12 +280,49 @@ const SCREENS: Screen[] = [
   // settings screens above — their own lazy chunk, loaded by `office-routes`
   // rather than `settings-routes` — so they need their own anchors and were
   // proved separately; see `waitForScreen`.
-  { name: "office — dashboard", url: "/office", anchor: 'main[data-office-route="/office"]' },
-  { name: "office — inbox", url: "/office/inbox", anchor: 'main[data-office-route="/office/inbox"]' },
-  { name: "office — tasks", url: "/office/tasks", anchor: 'main[data-office-route="/office/tasks"]' },
-  { name: "office — agents", url: "/office/agents", anchor: 'main[data-office-route="/office/agents"]' },
-  { name: "office — projects", url: "/office/projects", anchor: 'main[data-office-route="/office/projects"]' },
-  { name: "office — routines", url: "/office/routines", anchor: 'main[data-office-route="/office/routines"]' },
+  // NOT YET: "office — dashboard" (`/office`). The entry existed and passed, and
+  // it was not testing the dashboard.
+  //
+  // `/office` renders the dashboard only for a workspace that has an
+  // `office_workflow_id` (`hasOfficeWorkspace` in src/office-routes.tsx). The
+  // shared e2e fixture never seeds one, so `resolveOfficeHomeSetupRedirect`
+  // sends `/office` to `/office/setup?mode=new` on every run, and the screen the
+  // walk actually scanned was the SETUP WIZARD — "Set up your Office workspace",
+  // a different screen from the one the test named. It reported clean because
+  // the wizard is itself fully migrated, so the pass was real and was about
+  // something else.
+  //
+  // The anchor is what surfaced this: the redirect is invisible to a walk that
+  // only asks "is anything accented". Restoring real dashboard coverage needs an
+  // office workflow seeded in the fixture, which is a change to shared
+  // `test-base` state and belongs with whoever owns that fixture — not an
+  // allowlist entry and not a renamed screen, either of which would keep the
+  // false claim alive in a new form.
+  {
+    name: "office — inbox",
+    url: "/office/inbox",
+    anchor: 'main[data-office-route="/office/inbox"]',
+  },
+  {
+    name: "office — tasks",
+    url: "/office/tasks",
+    anchor: 'main[data-office-route="/office/tasks"]',
+  },
+  {
+    name: "office — agents",
+    url: "/office/agents",
+    anchor: 'main[data-office-route="/office/agents"]',
+  },
+  {
+    name: "office — projects",
+    url: "/office/projects",
+    anchor: 'main[data-office-route="/office/projects"]',
+  },
+  {
+    name: "office — routines",
+    url: "/office/routines",
+    anchor: 'main[data-office-route="/office/routines"]',
+  },
   {
     name: "office — workspace costs",
     url: "/office/workspace/costs",
@@ -454,24 +492,26 @@ async function activatePseudo(page: Page, url: string) {
  * thing in this file worth reading twice: THE SETTLE LET THE ORACLE REPORT A
  * PASS IT HAD NOT EARNED, and it did so in the direction that hurts.
  *
- * `SCREENS` are lazy routes in a 2.8 MB `settings-routes` chunk. Nothing in the
- * old wait was tied to that chunk arriving:
+ * `SCREENS` are lazy routes in two separate chunks — `settings-routes` (2.8 MB)
+ * and `office-routes`. Nothing in the old wait was tied to either arriving:
  *   - `activatePseudo`'s `lang="pseudo"` assertion is written server-side by
  *     shell.go before a single script runs, so it is true immediately;
  *   - the `inspectedAttributes > 0` control below is satisfied by the sidebar,
  *     topbar and status bar, which are accented long before the route renders;
  *   - so the only thing standing between "route rendered" and "scan the DOM"
  *     was one second of wall clock.
- * Measured on this branch: with the chunk blocked outright, so that not one
- * screen rendered at all, ALL NINE screen tests still passed. The failure mode
+ * Measured with BOTH chunks blocked outright, so that not one screen rendered:
+ * 13-16 of the 21 tests reported clean, varying run to run — because whether a
+ * screen "passed" came down to a race the settle could not see. The failure mode
  * is worse than flakiness — under CI load a slow render makes a green result
  * MORE likely, so the gate is at its most permissive exactly when the tree is
- * most likely to be broken.
+ * most likely to be broken. With the anchors below the same probe fails all 21,
+ * every run.
  *
  * The fix has to be per-screen. Any signal generic enough to share is a signal
  * the app shell already satisfies, which is how this happened in the first
- * place. So each screen names an element it owns, and this waits on two facts
- * about it:
+ * place. So each screen names a selector nothing but that route can satisfy, and
+ * this waits on two facts about it:
  *   1. it is VISIBLE — the lazy route mounted and this screen, specifically, is
  *      the one on screen;
  *   2. its text is ACCENTED — the pseudo catalog has actually been applied to

--- a/apps/web/e2e/tests/i18n/pseudo-coverage.spec.ts
+++ b/apps/web/e2e/tests/i18n/pseudo-coverage.spec.ts
@@ -34,6 +34,13 @@ import { test, expect } from "../../fixtures/test-base";
  * either came through `t()` / `<Trans>` (and so renders accented under the
  * pseudo-locale), or is on an allowlist that says why it must not be translated.
  *
+ * That guarantee rests on the scan having run against the screen it names, which
+ * for a while it did not. Each `SCREENS` entry carries a required `anchor` — an
+ * element that screen alone renders — and `waitForScreen` blocks on it before
+ * anything is inspected. Read its comment before touching the readiness logic:
+ * the wait it replaced was a one-second settle, and with the lazy settings chunk
+ * blocked so that NO screen rendered, all nine screen tests passed.
+ *
  * It is a floor, not a proof of total coverage. Two limits are deliberate and
  * both are documented where they are implemented, because relaxing either
  * reddens every screen today:
@@ -90,29 +97,90 @@ import { test, expect } from "../../fixtures/test-base";
  * must NOT translate but cannot avoid rendering — records the backend owns, or a
  * product name — and say where the value comes from, so the exemption stays
  * auditable instead of quietly widening into a place to hide missed strings.
+ *
+ * `anchor` is REQUIRED and is what makes a green result mean anything; see
+ * `waitForScreen` below for why a settle timeout did not.
  */
-const SCREENS: Array<{ name: string; url: string; allow?: string[] }> = [
-  { name: "settings — appearance", url: "/settings/general/appearance" },
+type Screen = {
+  name: string;
+  url: string;
+  /**
+   * A selector that cannot match until the ROUTE UNDER TEST has rendered. The
+   * walk does not start until it matches AND the matched element's text is
+   * accented.
+   *
+   * The test it must pass is not "is it unique" but "could the app shell alone
+   * satisfy it?". `secrets-settings-body` also renders on the workspace-scoped
+   * secrets page, and that is fine — reaching it still proves a secrets screen
+   * mounted. What disqualifies a selector is matching something painted before
+   * the route arrives, which is exactly the bug this field fixes.
+   *
+   * The two route trees answer that differently, and the difference is real
+   * rather than an inconsistency to tidy up:
+   *
+   *   - SETTINGS screens anchor on a `data-testid` the page's own component
+   *     renders. Seven already had one; `secrets-settings-body` and
+   *     `sprites-connection-card` were added alongside this field.
+   *   - OFFICE screens anchor on `main[data-office-route="<path>"]`, the route
+   *     outlet in src/office-routes.tsx stamped with the RESOLVED path. A
+   *     component-level testid was tried and rejected: the SPA route table
+   *     mounts these pages with empty collections (`initialItems={[]}`), so they
+   *     legitimately render empty states in e2e and any anchor inside the
+   *     populated branch would never match. The outlet is present whichever
+   *     branch a page takes, lives inside the office chunk, is absent while
+   *     `OfficeRouteLoading` holds, and — because the selector pins the VALUE —
+   *     cannot be satisfied by a different office route or by the unknown-route
+   *     fallback.
+   *
+   * Note what carries the weight in the Office case: the element is generic, so
+   * the ACCENTED half of `waitForScreen` is what proves a page actually painted
+   * into it. An empty outlet has no accented text and times out.
+   *
+   * An attribute and not a heading name, deliberately, in both trees: the anchor
+   * has to be findable BEFORE the pseudo catalog is known to have applied, and
+   * every accessible name in the app changes under pseudo.
+   */
+  anchor: string;
+  allow?: string[];
+};
+
+const SCREENS: Screen[] = [
+  {
+    name: "settings — appearance",
+    url: "/settings/general/appearance",
+    anchor: "[data-testid=theme-settings-card]",
+  },
   {
     name: "settings — notifications",
     url: "/settings/general/notifications",
+    anchor: "[data-testid=notification-sound-group]",
     // Provider names are rows in the notification_providers table. The backend
     // seeds these two (apps/backend/internal/notifications/service/service.go)
     // and users name their own Apprise ones, so they are data on the same
     // footing as a task title. `Apprise` labels the provider type.
     allow: ["Desktop Notifications", "System Notifications", "Apprise"],
   },
-  { name: "settings — secrets", url: "/settings/general/secrets" },
-  { name: "settings — terminal", url: "/settings/general/terminal" },
+  {
+    name: "settings — secrets",
+    url: "/settings/general/secrets",
+    anchor: "[data-testid=secrets-settings-body]",
+  },
+  {
+    name: "settings — terminal",
+    url: "/settings/general/terminal",
+    anchor: "[data-testid=terminal-font-size-card]",
+  },
   {
     name: "settings — sprites",
     url: "/settings/general/sprites",
+    anchor: "[data-testid=sprites-connection-card]",
     // Product name of the sandbox provider.
     allow: ["Sprites.dev"],
   },
   {
     name: "settings — layouts",
     url: "/settings/general/layouts",
+    anchor: "[data-testid=layout-settings]",
     // NOTE: everything here must be a PERSISTED name. This list is load-bearing
     // in the wrong direction — a broad token also hides genuinely un-migrated
     // copy that happens to match it. "Default" already masked the
@@ -158,6 +226,7 @@ const SCREENS: Array<{ name: string; url: string; allow?: string[] }> = [
   {
     name: "settings — keyboard shortcuts",
     url: "/settings/general/keyboard-shortcuts",
+    anchor: "[data-testid=chat-submit-key-card]",
     // Modifier/key names label a physical key and are out of scope for
     // translation — the same rule the eslint guard's keyboard pattern encodes.
     //
@@ -191,26 +260,60 @@ const SCREENS: Array<{ name: string; url: string; allow?: string[] }> = [
       "Open Task Pull Request",
     ],
   },
-  { name: "settings — task actions", url: "/settings/general/task-actions" },
-  { name: "settings — plugins", url: "/settings/plugins" },
+  {
+    name: "settings — task actions",
+    url: "/settings/general/task-actions",
+    anchor: "[data-testid=archive-confirmation-card]",
+  },
+  {
+    name: "settings — plugins",
+    url: "/settings/plugins",
+    anchor: "[data-testid=plugins-tab-installed]",
+  },
   // Office — the last live directory to migrate (#2357 was the batch before it).
   // All twelve routes were run under the pseudo-locale before being listed here;
   // eleven came back with nothing, and the one `allow` below is the only string
   // any of them renders that must stay ASCII.
-  { name: "office — dashboard", url: "/office" },
-  { name: "office — inbox", url: "/office/inbox" },
-  { name: "office — tasks", url: "/office/tasks" },
-  { name: "office — agents", url: "/office/agents" },
-  { name: "office — projects", url: "/office/projects" },
-  { name: "office — routines", url: "/office/routines" },
-  { name: "office — workspace costs", url: "/office/workspace/costs" },
-  { name: "office — workspace activity", url: "/office/workspace/activity" },
-  { name: "office — workspace routing", url: "/office/workspace/routing" },
-  { name: "office — workspace skills", url: "/office/workspace/skills" },
-  { name: "office — workspace org", url: "/office/workspace/org" },
+  //
+  // These twelve reach the browser through a DIFFERENT route tree than the
+  // settings screens above — their own lazy chunk, loaded by `office-routes`
+  // rather than `settings-routes` — so they need their own anchors and were
+  // proved separately; see `waitForScreen`.
+  { name: "office — dashboard", url: "/office", anchor: 'main[data-office-route="/office"]' },
+  { name: "office — inbox", url: "/office/inbox", anchor: 'main[data-office-route="/office/inbox"]' },
+  { name: "office — tasks", url: "/office/tasks", anchor: 'main[data-office-route="/office/tasks"]' },
+  { name: "office — agents", url: "/office/agents", anchor: 'main[data-office-route="/office/agents"]' },
+  { name: "office — projects", url: "/office/projects", anchor: 'main[data-office-route="/office/projects"]' },
+  { name: "office — routines", url: "/office/routines", anchor: 'main[data-office-route="/office/routines"]' },
+  {
+    name: "office — workspace costs",
+    url: "/office/workspace/costs",
+    anchor: 'main[data-office-route="/office/workspace/costs"]',
+  },
+  {
+    name: "office — workspace activity",
+    url: "/office/workspace/activity",
+    anchor: 'main[data-office-route="/office/workspace/activity"]',
+  },
+  {
+    name: "office — workspace routing",
+    url: "/office/workspace/routing",
+    anchor: 'main[data-office-route="/office/workspace/routing"]',
+  },
+  {
+    name: "office — workspace skills",
+    url: "/office/workspace/skills",
+    anchor: 'main[data-office-route="/office/workspace/skills"]',
+  },
+  {
+    name: "office — workspace org",
+    url: "/office/workspace/org",
+    anchor: 'main[data-office-route="/office/workspace/org"]',
+  },
   {
     name: "office — workspace settings",
     url: "/office/workspace/settings",
+    anchor: 'main[data-office-route="/office/workspace/settings"]',
     // The clone field's placeholder is an example git URL — the SHAPE the user
     // is meant to imitate, on the same footing as the email and CSS-function
     // placeholders the eslint guard already excludes via its `(https?|ssh|git)://`
@@ -329,6 +432,12 @@ const ALLOWED = [
   "QA",
 ];
 
+/**
+ * Any character in the accented range the pseudo-locale transform emits. Shared
+ * with the in-page detector below, which cannot close over it.
+ */
+const ACCENTED = /[À-ɏ]/;
+
 async function activatePseudo(page: Page, url: string) {
   await page.goto(url);
   await page.evaluate(() => {
@@ -336,6 +445,75 @@ async function activatePseudo(page: Page, url: string) {
   });
   await page.reload();
   await expect(page.locator("html")).toHaveAttribute("lang", "pseudo", { timeout: 15_000 });
+}
+
+/**
+ * Block until the SCREEN UNDER TEST has rendered under the pseudo locale.
+ *
+ * This replaces a `waitForTimeout(1_000)` settle, and the reason is the only
+ * thing in this file worth reading twice: THE SETTLE LET THE ORACLE REPORT A
+ * PASS IT HAD NOT EARNED, and it did so in the direction that hurts.
+ *
+ * `SCREENS` are lazy routes in a 2.8 MB `settings-routes` chunk. Nothing in the
+ * old wait was tied to that chunk arriving:
+ *   - `activatePseudo`'s `lang="pseudo"` assertion is written server-side by
+ *     shell.go before a single script runs, so it is true immediately;
+ *   - the `inspectedAttributes > 0` control below is satisfied by the sidebar,
+ *     topbar and status bar, which are accented long before the route renders;
+ *   - so the only thing standing between "route rendered" and "scan the DOM"
+ *     was one second of wall clock.
+ * Measured on this branch: with the chunk blocked outright, so that not one
+ * screen rendered at all, ALL NINE screen tests still passed. The failure mode
+ * is worse than flakiness — under CI load a slow render makes a green result
+ * MORE likely, so the gate is at its most permissive exactly when the tree is
+ * most likely to be broken.
+ *
+ * The fix has to be per-screen. Any signal generic enough to share is a signal
+ * the app shell already satisfies, which is how this happened in the first
+ * place. So each screen names an element it owns, and this waits on two facts
+ * about it:
+ *   1. it is VISIBLE — the lazy route mounted and this screen, specifically, is
+ *      the one on screen;
+ *   2. its text is ACCENTED — the pseudo catalog has actually been applied to
+ *      copy this route owns. Locale catalogs are eagerly bundled today, but a
+ *      catalog that arrives asynchronously would otherwise let the walk run
+ *      against a route rendered in English fallback and report every string on
+ *      it as a miss. Waiting here is robust to that without weakening anything:
+ *      a wait can only delay the scan, never excuse a finding.
+ *
+ * Both are `expect` assertions, not `waitFor`s, so an anchor that never arrives
+ * FAILS this spec instead of quietly scanning whatever the shell had painted.
+ * That is the whole point: the gate has to be capable of going red.
+ *
+ * Do NOT be tempted to swap this for `waitForLoadState("networkidle")`. Kandev
+ * holds a live WebSocket for the session stream, so the network is never idle
+ * and it would hang until timeout — it looks like a stronger wait and is not a
+ * wait at all.
+ */
+async function waitForScreen(page: Page, screen: Screen) {
+  // NOT `.first()`. A selector that matches more than one element is an
+  // ambiguous anchor, and `.first()` would silently pick one and gate on it —
+  // the same shape of mistake as the settle this function replaced. Playwright's
+  // strict mode turns that ambiguity into a failure, which is the direction this
+  // spec wants. All nine anchors resolve to exactly one element today.
+  const anchor = page.locator(screen.anchor);
+
+  await expect(
+    anchor,
+    `The render anchor \`${screen.anchor}\` never appeared on ${screen.name}, so the ` +
+      `route under test did not render. Scanning now would report the app shell as ` +
+      `clean and prove nothing about ${screen.name}. If this element was renamed, ` +
+      `update the \`anchor\` for this screen in SCREENS.`,
+  ).toBeVisible({ timeout: 15_000 });
+
+  await expect(
+    anchor,
+    `The render anchor \`${screen.anchor}\` rendered on ${screen.name} but its copy ` +
+      `never went accented, so the pseudo catalog had not been applied to this ` +
+      `route's copy. Every string on the screen would be reported as a miss. If ` +
+      `this anchor's own copy was just un-externalized, THAT is the finding — fix ` +
+      `it rather than moving the anchor.`,
+  ).toHaveText(ACCENTED, { timeout: 15_000 });
 }
 
 /**
@@ -389,6 +567,8 @@ async function findUnlocalizedCopy(
       // cannot present a label at all are skipped here.
       const attrSkipTags = new Set(["SCRIPT", "STYLE", "NOSCRIPT"]);
       const wordlike = /[A-Za-z]{4,}/;
+      // Same range as `ACCENTED` above, restated because this body is
+      // serialized into the page and cannot close over module scope.
       const accented = /[À-ɏ]/;
 
       // User data is never copy, and a workspace's name is user data on the same
@@ -555,8 +735,7 @@ test.describe("i18n pseudo-locale coverage", () => {
   for (const screen of SCREENS) {
     test(`no un-externalized copy on ${screen.name}`, async ({ testPage }) => {
       await activatePseudo(testPage, screen.url);
-      // Let lazy panels settle before scanning.
-      await testPage.waitForTimeout(1_000);
+      await waitForScreen(testPage, screen);
 
       const { leftovers, localizedAttributes, inspectedAttributes } = await findUnlocalizedCopy(
         testPage,
@@ -567,6 +746,14 @@ test.describe("i18n pseudo-locale coverage", () => {
       // to the leftover check by construction, which means a screen that is
       // clean and a selector that matched NOTHING report identically. Assert the
       // pass actually read attributes before believing what it did not find.
+      //
+      // NOTE what this does and does not establish, because getting that wrong
+      // is what made this spec passable without looking at anything: it proves
+      // the pass READ ATTRIBUTES, not that it read THIS SCREEN'S. The sidebar,
+      // topbar and status bar supply well over a hundred of them on every route,
+      // so this stays green on a page where the route never mounted. `anchor`
+      // above is what ties the scan to the screen under test; this remains
+      // useful only as the narrower check that the selector itself works.
       expect(
         inspectedAttributes,
         `The attribute pass examined no attribute at all on ${screen.name}, so a ` +
@@ -598,8 +785,11 @@ test.describe("i18n pseudo-locale coverage", () => {
    * so it fired on three screens that were fine.
    */
   test("the attribute pass recognizes migrated attribute copy", async ({ testPage }) => {
-    await activatePseudo(testPage, "/settings/general/appearance");
-    await testPage.waitForTimeout(1_000);
+    const appearance = SCREENS.find((screen) => screen.url === "/settings/general/appearance");
+    if (!appearance) throw new Error("the appearance screen is no longer in SCREENS");
+
+    await activatePseudo(testPage, appearance.url);
+    await waitForScreen(testPage, appearance);
 
     const { localizedAttributes } = await findUnlocalizedCopy(testPage, ALLOWED);
 

--- a/apps/web/src/office-routes.tsx
+++ b/apps/web/src/office-routes.tsx
@@ -108,7 +108,23 @@ export function OfficeRoutes({ pathname }: { pathname: string }) {
     <TooltipProvider>
       <div className="flex h-full min-h-0 flex-col">
         <OfficeTopbar />
-        <main className="flex-1 min-h-0 overflow-y-auto">
+        {/* `data-office-route` stamps the RESOLVED route onto the outlet, and is
+            the render anchor the pseudo-coverage oracle waits on for every
+            `office — …` screen (e2e/tests/i18n/pseudo-coverage.spec.ts).
+
+            It is an attribute on the outlet rather than a testid inside each
+            page because these pages are mounted with empty collections
+            (`initialItems={[]}`), so they legitimately render empty states in
+            e2e — an anchor inside the populated branch would never match. This
+            attribute is present whichever branch a page takes, and it is not
+            shell-satisfiable: this element lives in the office chunk, is not
+            rendered while `OfficeRouteLoading` holds, and its VALUE identifies
+            the specific route, so a mis-pointed URL cannot match another
+            screen's anchor. */}
+        <main
+          className="flex-1 min-h-0 overflow-y-auto"
+          data-office-route={normalizedPathname}
+        >
           {renderOfficeRoute(normalizedPathname)}
         </main>
       </div>

--- a/apps/web/src/office-routes.tsx
+++ b/apps/web/src/office-routes.tsx
@@ -121,10 +121,7 @@ export function OfficeRoutes({ pathname }: { pathname: string }) {
             rendered while `OfficeRouteLoading` holds, and its VALUE identifies
             the specific route, so a mis-pointed URL cannot match another
             screen's anchor. */}
-        <main
-          className="flex-1 min-h-0 overflow-y-auto"
-          data-office-route={normalizedPathname}
-        >
+        <main className="flex-1 min-h-0 overflow-y-auto" data-office-route={normalizedPathname}>
           {renderOfficeRoute(normalizedPathname)}
         </main>
       </div>

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -648,19 +648,28 @@ positive control.
 looks.** `inspectedAttributes > 0` proves the pass *inspected something*. It does
 not prove it inspected *the screen under test* — the sidebar, topbar and status
 bar contribute over a hundred attributes on every route, and they are accented
-long before a `SCREENS` route mounts out of the 2.8 MB lazy `settings-routes`
-chunk. For a while the only thing separating "route rendered" from "scan the DOM"
-was a `waitForTimeout(1_000)`, and with that chunk blocked so that *no screen
-rendered at all*, all nine screen tests passed. That is the worst direction for a
+long before a `SCREENS` route mounts out of its lazy chunk (`settings-routes` is
+2.8 MB; Office has its own). For a while the only thing separating "route
+rendered" from "scan the DOM" was a `waitForTimeout(1_000)`, and with both chunks
+blocked so that *no screen rendered at all*, 13-16 of the 21 tests still reported
+clean — varying run to run, because it was a race the settle could not see. That is the worst direction for a
 gate to fail in: under CI load a slower render makes a green result *more* likely,
 so the check is most permissive exactly when the tree is most likely to be broken.
 
-Each `SCREENS` entry now carries a required `anchor` — a `data-testid` that
-screen alone renders — and the walk does not start until it is visible *and*
-accented. **Generalize the lesson rather than the fix: a positive control
-asserting that a check inspected something does not establish that it inspected
-the thing under test.** When you add a control, ask what the *weakest* state of
-the system is that still satisfies it.
+Each `SCREENS` entry now carries a required `anchor` — a selector that cannot
+match until that route has rendered — and the walk does not start until it
+matches *and* the matched element's text is accented. Settings screens anchor on
+a `data-testid` their own component renders; Office screens anchor on
+`main[data-office-route="<path>"]`, the route outlet stamped with the resolved
+path, because the SPA mounts Office pages with empty collections and any anchor
+inside the populated branch would never match. Adding a screen to `SCREENS`
+means adding its anchor, and the anchor is the part to think about.
+
+**Generalize the lesson rather than the fix: a positive control asserting that a
+check inspected something does not establish that it inspected the thing under
+test.** When you add a control, ask what the *weakest* state of the system is
+that still satisfies it — here, "the app shell painted" satisfied it, and that
+state is reached on every route whether or not the route ever arrives.
 
 Four things about that pass are deliberate, and worth knowing before you read its
 output:

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -644,6 +644,24 @@ pins accent detection once against `#language-select`'s known-migrated
 `aria-label`. If you scan by hand, emit a known-migrated attribute as your own
 positive control.
 
+**But note exactly what that control establishes, because it is less than it
+looks.** `inspectedAttributes > 0` proves the pass *inspected something*. It does
+not prove it inspected *the screen under test* — the sidebar, topbar and status
+bar contribute over a hundred attributes on every route, and they are accented
+long before a `SCREENS` route mounts out of the 2.8 MB lazy `settings-routes`
+chunk. For a while the only thing separating "route rendered" from "scan the DOM"
+was a `waitForTimeout(1_000)`, and with that chunk blocked so that *no screen
+rendered at all*, all nine screen tests passed. That is the worst direction for a
+gate to fail in: under CI load a slower render makes a green result *more* likely,
+so the check is most permissive exactly when the tree is most likely to be broken.
+
+Each `SCREENS` entry now carries a required `anchor` — a `data-testid` that
+screen alone renders — and the walk does not start until it is visible *and*
+accented. **Generalize the lesson rather than the fix: a positive control
+asserting that a check inspected something does not establish that it inspected
+the thing under test.** When you add a control, ask what the *weakest* state of
+the system is that still satisfies it.
+
 Four things about that pass are deliberate, and worth knowing before you read its
 output:
 


### PR DESCRIPTION
The pseudo-locale coverage oracle became a binding CI gate in #2360, but it could report a pass without having examined the screen it names. With both lazy route chunks blocked so that *no screen rendered at all*, **13–16 of the 21 tests still reported clean** — varying run to run, because it was a race the one-second settle could not see. Each screen now waits on an anchor that cannot match until its route has rendered, and the same probe now fails all 21, every run.

## Important Changes

- **The general finding, which outlives this spec: a positive control asserting that a check *inspected something* does not establish that it inspected *the thing under test*.** The oracle's control was `inspectedAttributes > 0`, satisfied by the app shell — sidebar, topbar and status bar contribute 100+ attributes on every route, accented long before a lazy route mounts. The control was real; it answered a weaker question than it appeared to. When adding a control, ask what the *weakest* state of the system is that still satisfies it. This project has shipped three checks that returned a pass they had not earned; this is the first caught by someone deliberately trying to make it fail.
- **It failed in the direction that hurts.** `activatePseudo`'s `lang="pseudo"` assertion proves nothing — `shell.go` writes it server-side before any script runs. So the only thing between "route rendered" and "scan the DOM" was wall clock, and under CI load a *slower* render makes a *green* result *more* likely.
- **Each `SCREENS` entry now carries a required `anchor`**, and `waitForScreen` blocks until it matches **and** the matched element's text is accented. Two conditions: matching means the route mounted; accented means the pseudo catalog reached copy that route owns. Both are `expect` assertions, so a missing anchor fails rather than scans. Strict mode is left on, so an ambiguous anchor is a failure rather than a silent pick.
- **The two route trees anchor differently, and the difference is real.** Settings screens anchor on a `data-testid` their own component renders (seven already had one; `secrets-settings-body` and `sprites-connection-card` were added). Office screens anchor on `main[data-office-route="<path>"]`, the route outlet stamped with the resolved path — because the SPA route table mounts Office pages with empty collections (`initialItems={[]}`), so they legitimately render empty states in e2e and any anchor inside the populated branch would never match. The outlet survives every branch, lives in the office chunk, is absent while `OfficeRouteLoading` holds, and pins the route *value* so a mis-pointed URL cannot satisfy another screen's anchor.

### The anchors found a screen that was testing the wrong thing

**`office — dashboard` was asserting nothing about the dashboard, and is dropped.** `/office` renders the dashboard only for a workspace with an `office_workflow_id` (`hasOfficeWorkspace`), which the shared e2e fixture never seeds — so `resolveOfficeHomeSetupRedirect` sends it to `/office/setup?mode=new` on every run and the walk was scanning the **Office setup wizard** under the dashboard's name. It reported clean because the wizard is itself fully migrated: the pass was real and was about a different screen. A redirect is invisible to a walk that only asks "is anything accented".

Restoring real dashboard coverage needs an office workflow seeded in `test-base`, which is a shared-fixture change and deliberately not done here. The full reason is recorded at the removal site so it cannot be quietly re-added. **This is the only entry removed, and it is removed because it was false, not because it was inconvenient** — neither an `allow` entry nor a rename was used, since both would keep the false claim alive in a new form.

**Nothing was weakened.** No `allow:` entries added or removed (#2367's example-clone-URL entry is untouched), the walk is still body-wide, no `networkidle` (Kandev holds a live WebSocket, so it never fires). The unrelated `office:standardCronExpressionExample` issue is deliberately left alone for its own follow-up.

## Validation

**Proof 1 — break the render, both route trees.** `page.route("**/assets/{settings,office}-routes-*.js", abort)`:

```
before (1s settle):   13 passed / 8 failed,  16 passed / 5 failed,  13 passed / 8 failed   ← nondeterministic
after  (anchors):     21 failed,  21 failed                                                 ← deterministic
```

Every pass in the "before" row is a false pass; nothing had rendered. Sample failure after:

```
Error: The render anchor `main[data-office-route="/office/inbox"]` never appeared on
office — inbox, so the route under test did not render. Scanning now would report the
app shell as clean and prove nothing about office — inbox.
```

**Proof 2 — a screen pointed at a route that renders nothing** (`/settings/general/this-route-does-not-exist`) fails the same way.

**Proof 3 — the settle removed nothing.** Comparing the DOM at the anchor against 2s later, all screens are identical in element count, attributes inspected and findings. It was pure latency.

- `pnpm run typecheck` — clean
- `pnpm lint --max-warnings 0` — clean
- `pnpm run i18n:check` / `pnpm run i18n:ratchet` — clean, guard allowlist intact (452 entries)
- `pnpm e2e e2e/tests/i18n/` — **25 passed** (9 settings + 11 Office + control + 3 language-switch + 1 mobile)
- `pnpm test -- --run src/ components/settings` — 664 passed (115 files)

## Possible Improvements

Low risk — the change can only make the gate stricter. Maintenance cost: renaming an anchor breaks this spec, so each is commented at its definition site and the failure is a loud timeout naming the fix. Follow-up worth having: seed an office workflow in `test-base` so `/office` reaches the dashboard and the entry can come back meaning what it says.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.