### PR TITLE
feat(make): accept port overrides on the dev target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,9 @@ SERVICE_PORT_FLAG := $(if $(PORT),--port $(PORT),)
 SERVICE_HOME_DIR_FLAG := $(if $(HOME_DIR),--home-dir "$(HOME_DIR)",)
 SERVICE_NO_BOOT_START_FLAG := $(if $(filter 1 true yes,$(NO_BOOT_START)),--no-boot-start,)
 SERVICE_INSTALL_FLAGS := $(SERVICE_PORT_FLAG) $(SERVICE_HOME_DIR_FLAG) $(SERVICE_NO_BOOT_START_FLAG)
+DEV_PORT_FLAG := $(if $(PORT),--port $(PORT),)
+DEV_WEB_PORT_FLAG := $(if $(WEB_PORT),--web-internal-port $(WEB_PORT),)
+DEV_FLAGS := $(DEV_PORT_FLAG) $(DEV_WEB_PORT_FLAG) $(DEV_ARGS)
 DESKTOP_BUNDLES ?= dmg
 
 # Phase headers
@@ -81,6 +84,7 @@ help:
 	@echo "  bootstrap        Install mise tools, workspace deps, and git hooks"
 	@echo "  bootstrap-e2e    Bootstrap plus Playwright browser/system deps"
 	@echo "  dev              Run backend + web via local CLI (auto ports)"
+	@echo "  dev PORT=38430   Run dev on a fixed backend port (beats KANDEV_BACKEND_PORT)"
 	@echo "  dev-prod-db      Run dev mode against the production db at ~/.kandev"
 	@echo "  dev-backend      Run backend in development mode (port 38429)"
 	@echo "  dev-web          Run web app in development mode (port 37429)"
@@ -184,7 +188,7 @@ ifeq ($(OS),Windows_NT)
 	@$(MAKE) -C $(BACKEND_DIR) build-winjob
 endif
 	@echo "Launching via CLI (auto ports)..."
-	@cd $(APPS_DIR) && $(PNPM) -C cli dev -- dev
+	@cd $(APPS_DIR) && $(PNPM) -C cli dev -- dev $(DEV_FLAGS)
 
 .PHONY: dev-prod-db
 dev-prod-db: export KANDEV_DATABASE_PATH := $(HOME)/.kandev/data/kandev.db

--- a/docs/public/contributing.md
+++ b/docs/public/contributing.md
@@ -34,6 +34,12 @@ make dev
 
 This is the normal development path. The TypeScript supervisor starts the Go backend and Vite, selects available ports, points Go at Vite, and isolates application state under the checkout's `.kandev-dev/`. Use the printed URLs. Backend logs append to `.kandev-dev/logs/backend-logs.log`; startup prints the resolved path.
 
+Automatic port selection only applies when no port was requested, and `KANDEV_BACKEND_PORT` or `KANDEV_PORT` in the environment counts as a request. An installed Kandev service that exported one therefore pins development mode to the port its own backend already occupies, and the development backend fails to listen. Pass `PORT=` to override both the environment and the automatic choice, `WEB_PORT=` for the internal Vite port, and `DEV_ARGS=` for any other launcher flag.
+
+```bash
+make dev PORT=38430 WEB_PORT=37430
+```
+
 `make dev-web` starts only Vite on its fixed development port; it has no live API by itself. `make dev-backend` starts only the backend with the normal production-profile home unless you override it. For an intentionally isolated backend-only run:
 
 ```bash


### PR DESCRIPTION
## Problem

`make dev` cannot be told which port to use. The CLI accepts `--port` / `--backend-port` / `--web-internal-port` and resolves flags ahead of env vars, but `Makefile` invoked it with a literal `dev` and no arguments.

Automatic port selection only kicks in when no port was requested, and an env var counts as requested. Anyone who ran `kandev service install` has `KANDEV_BACKEND_PORT` exported, so `make dev` targets the port the installed service is already listening on. `make dev --port N` is not a workaround — make consumes `--port` itself.

## Change

`PORT` and `WEB_PORT` are typed and appear in `make help`; `DEV_ARGS` is the escape hatch for `--verbose`, `--debug`, `--headless`, mirroring `ARGS` on the `acpdbg` target. `PORT` is already this file's name for "port to pass to the kandev CLI" (see `service-install PORT=3000`).

```bash
make dev PORT=38430 WEB_PORT=37430
```

With the variables unset `$(if …)` expands to nothing, so behaviour is unchanged by default.

## Testing

With an installed Kandev serving on 38429 and `KANDEV_BACKEND_PORT=38429` in the environment, in both PowerShell and Git Bash:

- `make dev PORT=38430 WEB_PORT=37430` → `backend ready at http://localhost:38430`, the SPA renders with no console errors, `db:` resolves inside `<checkout>/.kandev-dev/`, and the installed service keeps serving on 38429.
- `make dev` with no variables → still selects 38429 from the env var; unchanged.
- `make -n dev` with no variables → identical to before except trailing whitespace.

## Notes

- make imports the environment as variables, so an exported `PORT` now influences `make dev` silently. That is already true of `service-install`, so this is consistency rather than a new hazard.
- Unrelated to this change, but found while testing: with no override the launcher's health check succeeds against the *installed* backend on the same port and prints `backend ready` plus an `open:` URL pointing at it, while the development binary is still building. The failure is silent rather than a bind error.
- Also unrelated: the host-utility port 41001 is fixed, so agent instances still fail to bind when an installed Kandev holds it.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2368?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

