### PR TITLE
fix(agents): default custom TUI agents to Ink-safe passthrough stdin

### DIFF
--- a/apps/backend/internal/agent/agents/tui_agent.go
+++ b/apps/backend/internal/agent/agents/tui_agent.go
@@ -75,6 +75,15 @@ func NewTUIAgent(cfg TUIAgentConfig) *TUIAgent {
 				IdleTimeout:     cfg.IdleTimeout,
 				BufferMaxBytes:  cfg.BufferMax,
 				WaitForTerminal: cfg.WaitForTerm,
+				// Ink-based TUIs (Claude Code and similar) coalesce multi-byte
+				// stdin reads into a paste burst, absorbing a trailing "\r" into
+				// the pasted content instead of dispatching Enter, and enable
+				// bracketed-paste mode so ESC[200~…ESC[201~ delimiters break
+				// input. Send prompt bytes verbatim and split the submit byte
+				// into a discrete keystroke so programmatic PTY prompts submit.
+				// Matches the built-in Claude passthrough agent.
+				DisableBracketedPaste: true,
+				SubmitDelay:           150 * time.Millisecond,
 			},
 		},
 		cfg: cfg,

--- a/apps/backend/internal/agent/agents/tui_agent_test.go
+++ b/apps/backend/internal/agent/agents/tui_agent_test.go
@@ -1,0 +1,33 @@
+package agents
+
+import (
+	"testing"
+	"time"
+)
+
+// Custom TUI agents wrap arbitrary CLIs, commonly Ink-based TUIs such as Claude
+// Code. Ink coalesces multi-byte stdin reads into a paste burst and absorbs a
+// trailing "\r" into the pasted content instead of dispatching Enter, and it
+// enables bracketed-paste mode so ESC[200~…ESC[201~ delimiters break input.
+// The built-in Claude passthrough agent works around both; custom TUI agents
+// must inherit the same defaults or programmatic PTY prompts (peer messaging,
+// queued-message drain, workflow auto-start) land in the input box unsubmitted.
+func TestNewTUIAgentDefaultsToInkSafePassthrough(t *testing.T) {
+	a := NewTUIAgent(TUIAgentConfig{
+		AgentID:   "custom-tui",
+		AgentName: "custom-tui",
+		Command:   "claude",
+		Desc:      "custom",
+	})
+
+	pt := a.PassthroughConfig()
+	if !pt.DisableBracketedPaste {
+		t.Error("DisableBracketedPaste = false, want true (send prompt bytes verbatim; Ink breaks on bracketed-paste delimiters)")
+	}
+	if pt.SubmitDelay != 150*time.Millisecond {
+		t.Errorf("SubmitDelay = %v, want 150ms (split submit byte into a discrete keystroke so Ink does not absorb it into a paste burst)", pt.SubmitDelay)
+	}
+	if got := EffectiveSubmitSequence(pt.SubmitSequence); got != "\r" {
+		t.Errorf("effective submit sequence = %q, want %q", got, "\r")
+	}
+}


### PR DESCRIPTION
Custom TUI agents created via the "custom TUI" flow did not inherit the Ink-safe stdin defaults that the built-in Claude passthrough agent sets, so programmatic PTY prompt delivery (peer-agent messaging, queued-message drain, workflow auto-start) against an Ink-based TUI such as Claude Code landed in the input box unsubmitted — the trailing submit byte was absorbed into a paste burst and bracketed-paste delimiters broke input. Custom TUI agents now send prompt bytes verbatim and split the submit byte into a discrete keystroke, matching the built-in Claude passthrough agent.

## Validation

- `go test ./internal/agent/agents/` — new test `TestNewTUIAgentDefaultsToInkSafePassthrough` asserts `DisableBracketedPaste == true`, `SubmitDelay == 150ms`, and effective submit sequence `"\r"`; full `agents` package passes.
- `go test ./internal/agent/runtime/lifecycle/` (passthrough/interaction paths) — passes.
- `go test ./internal/agent/agents/ -run 'Passthrough|Submit|Bracketed'` — passes, including `TestPlanPassthroughStdinChunks_*` (the chunk-plan logic that consumes these config fields).
- `gofmt -l` on the changed files — clean. (Skipped full `make fmt` because it re-formats an unrelated pre-existing struct-field alignment drift in `executor_backend.go` on `main`; that is not touched by this change.)
- `go vet ./internal/agent/agents/` — clean.
- `go build ./internal/agent/agents/ ./internal/agent/registry/` — compiles.

## Possible Improvements

Low risk. A non-Ink custom TUI gains a 150ms submit delay and loses bracketed-paste framing; verbatim bytes are handled by every TUI and the delay only affects programmatic submission latency. If a custom TUI is later found to need bracketed paste, expose `DisableBracketedPaste`/`SubmitDelay` as per-agent config on the custom-TUI create surface.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have manually tested my changes and they work as expected.
- [x] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [x] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.

Closes #2365
