### PR TITLE
fix(i18n): pass the routine cron example through as a value

### DIFF
--- a/apps/web/app/office/routines/create-routine-dialog.i18n.test.ts
+++ b/apps/web/app/office/routines/create-routine-dialog.i18n.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import { t } from "@/lib/i18n";
+import enOffice from "@/src/locales/en/office.json";
+import pseudoOffice from "@/src/locales/pseudo/office.json";
+
+/**
+ * A cron expression is syntax, not copy. Baked into a catalog message a
+ * translator can reorder its fields, localise `MON`, or insert a space and ship
+ * an example no cron parser accepts — and the pseudo-locale mangles it outright.
+ * Both office cron examples therefore carry the expression as a `values` entry.
+ *
+ * `standardCronExpressionExample` is rendered by the routine trigger fields in
+ * `create-routine-dialog.tsx`; `aCronScheduleExample` by the routine editor.
+ */
+describe("office cron example messages", () => {
+  const CRON_KEYS = ["standardCronExpressionExample", "aCronScheduleExample"] as const;
+
+  /** Five whitespace-separated cron fields — what must never appear in a message. */
+  const CRON_SHAPED = /[\d*/,-]+\s+[\d*/,-]+\s+[\d*/,-]+\s+[\d*/,-]+\s+[\dA-Z*/,-]+/;
+
+  it.each(CRON_KEYS)("keeps the cron expression out of the en message for %s", (key) => {
+    const message: string = enOffice[key];
+    expect(message).toContain("{{cron}}");
+    expect(message).not.toMatch(CRON_SHAPED);
+  });
+
+  it.each(CRON_KEYS)("keeps {{cron}} verbatim in the pseudo message for %s", (key) => {
+    // The placeholder surviving transliteration is the proof the value is
+    // substituted at render rather than living inside the translated text.
+    expect(pseudoOffice[key]).toContain("{{cron}}");
+  });
+
+  it("renders the dialog hint byte-identically to the pre-extraction English", () => {
+    expect(t("office:standardCronExpressionExample", { cron: "0 9 * * MON" })).toBe(
+      "Standard cron expression (e.g. 0 9 * * MON for every Monday at 9am)",
+    );
+  });
+});

--- a/apps/web/app/office/routines/create-routine-dialog.tsx
+++ b/apps/web/app/office/routines/create-routine-dialog.tsx
@@ -224,7 +224,14 @@ function TriggerFields({
       {state.triggerKind === "cron" && (
         <>
           <p className="text-xs text-muted-foreground -mt-2">
-            {t("office:standardCronExpressionExample")}
+            {/*
+              The cron expression is SYNTAX, not copy: it travels as a value so
+              a translator (and the pseudo-locale) leaves it verbatim. Baked into
+              the message, reordering a field or localising `MON` yields an
+              example no cron parser accepts. Same reasoning as
+              `office:aCronScheduleExample` and `settings:externalMcpEndpointsDescription`.
+            */}
+            {t("office:standardCronExpressionExample", { cron: "0 9 * * MON" })}
           </p>
           <div>
             <Label htmlFor="routine-timezone">{t("office:timezone")}</Label>

--- a/apps/web/src/locales/en/office.json
+++ b/apps/web/src/locales/en/office.json
@@ -741,7 +741,7 @@
   "sourceType": "Source Type",
   "spritesRemoteSandbox": "Sprites (remote sandbox)",
   "staleRunCancelled": "stale run cancelled",
-  "standardCronExpressionExample": "Standard cron expression (e.g. 0 9 * * MON for every Monday at 9am)",
+  "standardCronExpressionExample": "Standard cron expression (e.g. {{cron}} for every Monday at 9am)",
   "startASessionOrSendA": "Start a session or send a message to begin.",
   "started": "Started",
   "startFresh": "Start Fresh",

--- a/apps/web/src/locales/pseudo/office.json
+++ b/apps/web/src/locales/pseudo/office.json
@@ -741,7 +741,7 @@
   "sourceType": "Śōũŕćē Ţŷƥē",
   "spritesRemoteSandbox": "Śƥŕĩţēś (ŕēḿōţē śàńďƀōx)",
   "staleRunCancelled": "śţàĺē ŕũń ćàńćēĺĺēď",
-  "standardCronExpressionExample": "Śţàńďàŕď ćŕōń ēxƥŕēśśĩōń (ē.ĝ. 0 9 * * ḾŌŃ ƒōŕ ēvēŕŷ Ḿōńďàŷ àţ 9àḿ)",
+  "standardCronExpressionExample": "Śţàńďàŕď ćŕōń ēxƥŕēśśĩōń (ē.ĝ. {{cron}} ƒōŕ ēvēŕŷ Ḿōńďàŷ àţ 9àḿ)",
   "startASessionOrSendA": "Śţàŕţ à śēśśĩōń ōŕ śēńď à ḿēśśàĝē ţō ƀēĝĩń.",
   "started": "Śţàŕţēď",
   "startFresh": "Śţàŕţ Ƒŕēśĥ",


### PR DESCRIPTION
`office:standardCronExpressionExample` baked a live cron expression into translatable text, so a translator could reorder its fields, localise `MON`, or insert a space and ship an example no cron parser accepts. The expression now travels as an interpolated value, leaving the English rendering byte-identical. Flagged by CodeRabbit on #2367.

## Important Changes

**Before / after**

```diff
- "standardCronExpressionExample": "Standard cron expression (e.g. 0 9 * * MON for every Monday at 9am)"
+ "standardCronExpressionExample": "Standard cron expression (e.g. {{cron}} for every Monday at 9am)"
```

```diff
- {t("office:standardCronExpressionExample")}
+ {t("office:standardCronExpressionExample", { cron: "0 9 * * MON" })}
```

Rendered English is unchanged, byte for byte — asserted in the new test, since E2E queries by accessible name.

This follows the precedent already in the repo: `office:aCronScheduleExample` (the *other* cron in #2367, which handled this class correctly) and `settings:externalMcpEndpointsDescription` / `settings:voiceUnavailableInsecure`, which pass `localhost` and URL schemes as values for the same reason.

**Pseudo output — the token now survives verbatim**

```diff
- "standardCronExpressionExample": "Śţàńďàŕď ćŕōń ēxƥŕēśśĩōń (ē.ĝ. 0 9 * * ḾŌŃ ƒōŕ ēvēŕŷ Ḿōńďàŷ àţ 9àḿ)"
+ "standardCronExpressionExample": "Śţàńďàŕď ćŕōń ēxƥŕēśśĩōń (ē.ĝ. {{cron}} ƒōŕ ēvēŕŷ Ḿōńďàŷ àţ 9àḿ)"
```

`ḾŌŃ` → `{{cron}}`, substituted at render, so the QA locale now shows a cron a reader can actually paste. For comparison, the already-correct sibling: `"À ćŕōń śćĥēďũĺē (ē.ĝ. <1>{{cron}}</1> ƒōŕ ŵēēķďàŷś àţ 9àḿ)"`.

**Sweep for the same shape**

Ran the flagged regex plus a wider one (cron / glob / regex / URL scheme / abs path / shell command / git ref / keyboard chord / env var / config key / filename) over all 30 `src/locales/en/*.json` **and** the four backend catalogs in `apps/backend/internal/i18n/locales/`. Backend: zero hits. Frontend classification:

| Hit | Class | Call |
| --- | --- | --- |
| `office:standardCronExpressionExample` | **Defect.** Only cron-shaped string in any catalog. | **fixed** |
| `executors:localGitIdentityNotDetected` — `user.name/user.email` | git config keys | report |
| `github:enterAPublicHostNotLocalhost` · `executors:rewriteLocalhostForDocker` — `localhost` | same token the repo interpolates elsewhere | report |
| `workspaces:environmentSecretKeyPlaceholder` = `NPM_TOKEN` | message is *only* an identifier | report |
| ~14 chord strings (`editors:boldCmdB`, `settings:pressCmdCtrlEnterToSend`, `workflows:showInCommandPanelHelp` …) | keyboard chords | report |
| `office:skillMdContent` (`SKILL.md`), 4× `skills.sh` | filename / brand domain | report |
| `task:moveHeadToThisCommitKeep` (`HEAD`) | git ref used as prose noun | report |
| `*GitRepository*`, `descriptionWorktree`, `noGitActivityYet`, `setupScriptHelp`, … | prose mentioning a technology | not a defect |
| `settings:externalMcpEndpointsDescription`, `voiceUnavailableInsecure`, `diff:saveAndSendToAgent` | already interpolated | not a defect |

The reported rows are left alone deliberately, and the evidence says that is right: the two real translations both **preserved every one of those tokens verbatim** — pt-pt `'Não foram detetados user.name/user.email do Git locais nesta máquina'`, zh-cn `'按 Cmd/Ctrl+Enter 发送消息。按 Enter 换行。'`, pt-pt `'NPM_TOKEN'`. Each is an **atomic token** a translator treats as a proper noun. A cron expression is the one case with internal *grammar* — field order and whitespace — which is what makes it reword-able into something that looks fine and parses as nothing. Happy to take any of the reported rows in a follow-up.

**Third-party locales:** neither `zh-cn/` nor `pt-pt/` has an `office.json`, so nothing was touched or needs re-translation there. No allowlist entries added, no strings migrated.

## Validation

From `apps/web` on Node 24:

- `pnpm run typecheck` — clean
- `pnpm lint --max-warnings 0` — clean
- `pnpm run i18n:check` — four ✓ including `pseudo in sync` (`en` ↔ `pseudo` parity)
- `pnpm run i18n:ratchet` — `✓ new-code ratchet clean` · `✓ guard allowlist intact — 452 entries`
- `pnpm run i18n:pseudo` — regenerated, diff above
- `pnpm exec vitest run app/office/routines/create-routine-dialog.i18n.test.ts` — 5 passed

New test `create-routine-dialog.i18n.test.ts` locks the invariant for **both** office cron keys: no cron-shaped run in the `en` message, `{{cron}}` intact in `pseudo`, and the dialog hint rendering byte-identically to the pre-extraction English.

## Possible Improvements

Negligible risk — one catalog message and its single call site. The pseudo-coverage oracle is unaffected: the paragraph's text node stays accented (any accent clears a node), and its `hasUnmigratedAscii` heuristic needs a 4-letter ASCII run, which `0 9 * * MON` does not contain — the same reason the existing `0 9 * * MON-FRI` value already passes.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2373?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->