### PR TITLE
test: cover workflow prompt web serialization

### DIFF
--- a/apps/web/app/actions/workspaces.test.ts
+++ b/apps/web/app/actions/workspaces.test.ts
@@ -5,10 +5,12 @@ vi.mock("@/lib/config", () => ({
 }));
 
 import {
+  createWorkflowAction,
   createWorkflowStepAction,
   deleteWorkspaceAction,
   exportAllWorkflowsAction,
   listWorkflowStepsAction,
+  updateWorkflowAction,
   updateWorkflowStepAction,
 } from "./workspaces";
 
@@ -242,5 +244,84 @@ describe("workflow step cancellation fields", () => {
     expect(JSON.parse(init.body as string)).toMatchObject({
       cancel_triggers_turn_complete: false,
     });
+  });
+});
+
+const WORKFLOW_PROMPT = "If the PR is merged or closed, move the Task to Done.";
+
+function mockWorkflowJsonResponse(extra: Record<string, unknown> = {}) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () =>
+      Response.json({
+        id: "wf-1",
+        workspace_id: "ws-1",
+        name: "Feature Dev",
+        created_at: "",
+        updated_at: "",
+        ...extra,
+      }),
+    ),
+  );
+}
+
+describe("workflow prompt fields", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("serializes prompt when creating a workflow", async () => {
+    mockWorkflowJsonResponse({ prompt: WORKFLOW_PROMPT });
+
+    const result = await createWorkflowAction({
+      workspace_id: "ws-1",
+      name: "Feature Dev",
+      prompt: WORKFLOW_PROMPT,
+    });
+
+    const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("http://backend.test/api/v1/workflows");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body as string)).toMatchObject({
+      workspace_id: "ws-1",
+      name: "Feature Dev",
+      prompt: WORKFLOW_PROMPT,
+    });
+    expect(result.prompt).toBe(WORKFLOW_PROMPT);
+  });
+
+  it("serializes prompt when updating a workflow", async () => {
+    mockWorkflowJsonResponse({ prompt: WORKFLOW_PROMPT });
+
+    await updateWorkflowAction("wf-1", { prompt: WORKFLOW_PROMPT });
+
+    const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("http://backend.test/api/v1/workflows/wf-1");
+    expect(init.method).toBe("PATCH");
+    expect(JSON.parse(init.body as string)).toEqual({ prompt: WORKFLOW_PROMPT });
+  });
+
+  it("serializes an empty string when clearing the workflow prompt", async () => {
+    mockWorkflowJsonResponse();
+
+    await updateWorkflowAction("wf-1", { prompt: "" });
+
+    const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
+    const [, init] = fetchMock.mock.calls[0];
+    // omit would leave the stored prompt unchanged; "" is the clear contract.
+    expect(JSON.parse(init.body as string)).toEqual({ prompt: "" });
+  });
+
+  it("omits prompt from the update body when the field is not provided", async () => {
+    mockWorkflowJsonResponse();
+
+    await updateWorkflowAction("wf-1", { name: "Renamed" });
+
+    const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
+    const [, init] = fetchMock.mock.calls[0];
+    expect(JSON.parse(init.body as string)).toEqual({ name: "Renamed" });
   });
 });

--- a/apps/web/components/settings/use-workflow-draft-contributor.test.ts
+++ b/apps/web/components/settings/use-workflow-draft-contributor.test.ts
@@ -166,4 +166,40 @@ describe("useWorkflowDraftContributor", () => {
     expect(view.onDeleteWorkflow).toHaveBeenCalledOnce();
     expect(view.result.current.isRemovingDraft).toBe(false);
   });
+
+  it("includes prompt in the save revision fingerprint", () => {
+    const withoutPrompt = workflow();
+    renderContributor({ draftWorkflow: withoutPrompt });
+    const baseline = contributor().revision;
+
+    renderContributor({
+      draftWorkflow: { ...withoutPrompt, prompt: "Keep multi-PR work in subtasks." },
+    });
+    expect(contributor().revision).not.toBe(baseline);
+  });
+
+  it("changes revision when only the prompt is edited", () => {
+    const base = { ...workflow(), prompt: "old instructions" } as Workflow;
+    renderContributor({ draftWorkflow: base });
+    const before = contributor().revision;
+
+    renderContributor({
+      draftWorkflow: { ...base, prompt: "new instructions" },
+    });
+    expect(contributor().revision).not.toBe(before);
+
+    renderContributor({ draftWorkflow: base });
+    expect(contributor().revision).toBe(before);
+  });
+
+  it("treats clearing the prompt as a distinct revision", () => {
+    const withPrompt = { ...workflow(), prompt: "clear me" } as Workflow;
+    renderContributor({ draftWorkflow: withPrompt });
+    const withPromptRevision = contributor().revision;
+
+    renderContributor({
+      draftWorkflow: { ...withPrompt, prompt: "" },
+    });
+    expect(contributor().revision).not.toBe(withPromptRevision);
+  });
 });

--- a/apps/web/components/settings/workflow-card-actions.test.ts
+++ b/apps/web/components/settings/workflow-card-actions.test.ts
@@ -415,6 +415,104 @@ describe("persistWorkflowDraft cancellation policy", () => {
   });
 });
 
+const WORKFLOW_PROMPT = "If the PR is merged or closed, move the Task to Done.";
+
+describe("persistWorkflowDraft workflow prompt", () => {
+  beforeEach(() => {
+    vi.mocked(reorderWorkflowStepsAction).mockResolvedValue({ steps: [], total: 0 });
+  });
+
+  it("includes prompt when creating a temporary workflow", async () => {
+    const draftWorkflow = {
+      ...workflow,
+      id: CLIENT_WORKFLOW_ID,
+      prompt: WORKFLOW_PROMPT,
+      description: "Shared instructions",
+    } as Workflow;
+    const created = { ...workflow, id: "wf-created", prompt: WORKFLOW_PROMPT } as Workflow;
+    vi.mocked(createWorkflowAction).mockResolvedValue(created);
+    vi.mocked(updateWorkflowAction).mockResolvedValue(created);
+
+    await persistWorkflowDraft({
+      workflow: draftWorkflow,
+      draftSteps: [],
+      savedSteps: [],
+      progress: createWorkflowDraftSaveProgress(),
+    });
+
+    expect(createWorkflowAction).toHaveBeenCalledWith({
+      workspace_id: "ws-1",
+      name: "Workflow",
+      description: "Shared instructions",
+      prompt: WORKFLOW_PROMPT,
+      workflow_template_id: undefined,
+    });
+  });
+
+  it("sends prompt on every metadata update for an existing workflow", async () => {
+    const draftWorkflow = {
+      ...workflow,
+      prompt: WORKFLOW_PROMPT,
+      description: "desc",
+    } as Workflow;
+    vi.mocked(updateWorkflowAction).mockResolvedValue(draftWorkflow);
+
+    await persistWorkflowDraft({
+      workflow: draftWorkflow,
+      draftSteps: [],
+      savedSteps: [],
+      progress: createWorkflowDraftSaveProgress(),
+    });
+
+    expect(createWorkflowAction).not.toHaveBeenCalled();
+    expect(updateWorkflowAction).toHaveBeenCalledWith("wf-1", {
+      name: "Workflow",
+      description: "desc",
+      prompt: WORKFLOW_PROMPT,
+      agent_profile_id: "",
+    });
+  });
+
+  it("clears the workflow prompt with an empty string", async () => {
+    const draftWorkflow = {
+      ...workflow,
+      prompt: "",
+      agent_profile_id: "profile-1",
+    } as Workflow;
+    vi.mocked(updateWorkflowAction).mockResolvedValue(draftWorkflow);
+
+    await persistWorkflowDraft({
+      workflow: draftWorkflow,
+      draftSteps: [],
+      savedSteps: [],
+      progress: createWorkflowDraftSaveProgress(),
+    });
+
+    expect(updateWorkflowAction).toHaveBeenCalledWith(
+      "wf-1",
+      expect.objectContaining({ prompt: "" }),
+    );
+  });
+
+  it("normalizes a missing prompt to empty string on update", async () => {
+    // create uses `?? undefined` (omit when unset); update always sends "" so
+    // omit-vs-clear remains an intentional wire contract difference.
+    vi.mocked(updateWorkflowAction).mockResolvedValue(workflow);
+
+    await persistWorkflowDraft({
+      workflow,
+      draftSteps: [],
+      savedSteps: [],
+      progress: createWorkflowDraftSaveProgress(),
+    });
+
+    expect(updateWorkflowAction).toHaveBeenCalledWith(
+      "wf-1",
+      expect.objectContaining({ prompt: "" }),
+    );
+  });
+});
+
 describe("useWorkflowDeleteHandlers", () => {
   it("refuses to open the delete-workflow dialog when readOnly", async () => {
     const wfDel = {


### PR DESCRIPTION
Fill the gap CodeRabbit flagged outside the #2338 diff: unit tests that the web layer serializes optional workflow-level prompt on create/update (including clear via empty string) and that draft-save revision fingerprints include prompt-only edits.

## Validation

- From apps/web: pnpm exec vitest run app/actions/workspaces.test.ts components/settings/workflow-card-actions.test.ts components/settings/use-workflow-draft-contributor.test.ts — 40 passed

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2375?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->