### PR TITLE
test(i18n): scope the office cron guard to the namespace, not one dialog

### DIFF
--- a/apps/web/app/office/office-cron-i18n.test.ts
+++ b/apps/web/app/office/office-cron-i18n.test.ts
@@ -10,8 +10,10 @@ import pseudoOffice from "@/src/locales/pseudo/office.json";
  * an example no cron parser accepts — and the pseudo-locale mangles it outright.
  * Both office cron examples therefore carry the expression as a `values` entry.
  *
- * `standardCronExpressionExample` is rendered by the routine trigger fields in
- * `create-routine-dialog.tsx`; `aCronScheduleExample` by the routine editor.
+ * The two live in different files — `standardCronExpressionExample` in
+ * `routines/create-routine-dialog.tsx`, `aCronScheduleExample` in
+ * `agents/[id]/layout.tsx` — so the guard sits at the `office` namespace root
+ * rather than beside either call site.
  */
 describe("office cron example messages", () => {
   const CRON_KEYS = ["standardCronExpressionExample", "aCronScheduleExample"] as const;

--- a/apps/web/app/office/routines/create-routine-dialog.tsx
+++ b/apps/web/app/office/routines/create-routine-dialog.tsx
@@ -225,11 +225,9 @@ function TriggerFields({
         <>
           <p className="text-xs text-muted-foreground -mt-2">
             {/*
-              The cron expression is SYNTAX, not copy: it travels as a value so
-              a translator (and the pseudo-locale) leaves it verbatim. Baked into
-              the message, reordering a field or localising `MON` yields an
-              example no cron parser accepts. Same reasoning as
-              `office:aCronScheduleExample` and `settings:externalMcpEndpointsDescription`.
+              The cron expression is SYNTAX, not copy: it travels as a value so a
+              translator cannot reword it into something no parser accepts.
+              Guarded by app/office/office-cron-i18n.test.ts.
             */}
             {t("office:standardCronExpressionExample", { cron: "0 9 * * MON" })}
           </p>


### PR DESCRIPTION
The cron guard added in #2373 covers both office cron keys, but it was named after one of their two call sites and its docstring named the wrong file for the other — so the second key's coverage is invisible to anyone who goes looking for it. Renames the test to match what it actually guards and corrects the pointer.

## Important Changes

`office-cron-i18n.test.ts` asserts the "cron travels as a value" invariant for **both** office cron keys, and they render from different files:

| Key | Rendered by |
| --- | --- |
| `office:standardCronExpressionExample` | `app/office/routines/create-routine-dialog.tsx` |
| `office:aCronScheduleExample` | `app/office/agents/[id]/layout.tsx:183` |

Two problems with the name it shipped under:

- **The docstring was wrong.** It said `aCronScheduleExample` is rendered by "the routine editor". It isn't — it's the agent detail layout. My error in #2373, now corrected.
- **The filename was misleading.** `routines/create-routine-dialog.i18n.test.ts` reads as dialog-scoped coverage. Anyone deleting or moving that dialog would reasonably assume the test goes with it, silently taking `aCronScheduleExample`'s guard along with a file that never rendered it.

```diff
- apps/web/app/office/routines/create-routine-dialog.i18n.test.ts
+ apps/web/app/office/office-cron-i18n.test.ts
```

The guard now sits at the `office` namespace root, matching its scope. The call-site comment in `create-routine-dialog.tsx` drops from six lines to three and points at the test, which carries the full reasoning — the invariant is documented once instead of twice.

No behavior change, no copy change, no catalog change. The `en` and `pseudo` messages are untouched.

## Validation

From `apps/web` on Node 24, rebased onto current `main`:

- `pnpm exec vitest run app/office/office-cron-i18n.test.ts` — 5 passed
- `pnpm run i18n:check` — four ✓ including `pseudo in sync` (`en` ↔ `pseudo` parity)
- `pnpm run i18n:ratchet` — ✓ new-code ratchet clean · ✓ guard allowlist intact (452 entries)
- `pnpm run typecheck` — clean
- `pnpm lint --max-warnings 0` — clean

## Possible Improvements

Negligible risk — a file rename plus a comment trim, with no production code path touched.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2376?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->