### PR TITLE
fix(task): stop reporting abandoned requests as server errors

### DIFF
--- a/apps/backend/internal/common/httpmw/logging.go
+++ b/apps/backend/internal/common/httpmw/logging.go
@@ -8,6 +8,10 @@ import (
 	"go.uber.org/zap"
 )
 
+// statusClientClosedRequest is nginx's 499, returned by handlers when the
+// caller abandoned the request. Go defines no constant for it.
+const statusClientClosedRequest = 499
+
 // RequestLogger logs HTTP request details after the handler completes.
 func RequestLogger(log *logger.Logger, serverName string) gin.HandlerFunc {
 	return func(c *gin.Context) {
@@ -35,7 +39,9 @@ func RequestLogger(log *logger.Logger, serverName string) gin.HandlerFunc {
 			zap.Int("bytes", size),
 		}
 		switch {
-		case status >= 400 && status != 404:
+		// 404 and 499 are routine: one is a miss, the other is the caller
+		// hanging up mid-request. Neither means something went wrong here.
+		case status >= 400 && status != 404 && status != statusClientClosedRequest:
 			log.Warn("http", fields...)
 		default:
 			log.Debug("http", fields...)

--- a/apps/backend/internal/task/handlers/errors.go
+++ b/apps/backend/internal/task/handlers/errors.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"strings"
@@ -12,7 +13,15 @@ import (
 	"go.uber.org/zap"
 )
 
+// statusClientClosedRequest is nginx's 499. Go defines no constant for it and
+// no standard 4xx says "the client hung up", which is what actually happened.
+const statusClientClosedRequest = 499
+
 func handleNotFound(c *gin.Context, log *logger.Logger, err error, fallback string) {
+	if isClientDisconnect(err) {
+		abortClientDisconnect(c)
+		return
+	}
 	if isNotFound(err) {
 		c.JSON(http.StatusNotFound, gin.H{"error": fallback})
 		return
@@ -31,6 +40,8 @@ func handleNotFound(c *gin.Context, log *logger.Logger, err error, fallback stri
 
 func handleSelectedMoveError(c *gin.Context, log *logger.Logger, err error) {
 	switch {
+	case isClientDisconnect(err):
+		abortClientDisconnect(c)
 	case isNotFound(err):
 		c.JSON(http.StatusNotFound, gin.H{"error": "task or workflow not found"})
 	case isMoveConflict(err):
@@ -41,6 +52,22 @@ func handleSelectedMoveError(c *gin.Context, log *logger.Logger, err error) {
 		log.Error("task move failed", zap.Error(err))
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "task move failed"})
 	}
+}
+
+// isClientDisconnect reports a request the caller abandoned. Handlers derive
+// their context from c.Request.Context(), which the server cancels when the
+// peer goes away, so context.Canceled here means the browser navigated,
+// unmounted a component, or aborted an in-flight fetch. Nothing failed
+// server-side and nobody is left to read a response.
+//
+// DeadlineExceeded is deliberately not included: that is our own timeout
+// firing, and it stays a logged 500.
+func isClientDisconnect(err error) bool {
+	return err != nil && errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded)
+}
+
+func abortClientDisconnect(c *gin.Context) {
+	c.AbortWithStatus(statusClientClosedRequest)
 }
 
 func isNotFound(err error) bool {

--- a/apps/backend/internal/task/handlers/errors_test.go
+++ b/apps/backend/internal/task/handlers/errors_test.go
@@ -47,6 +47,43 @@ func TestErrorsAreClassifiable(t *testing.T) {
 		}
 	})
 
+	// A browser that navigates away or unmounts a component aborts its
+	// in-flight fetches. That reaches handlers as a cancelled request context,
+	// which used to fall through to the 500 branch and log an ERROR with a
+	// full stacktrace for a response nobody was waiting on any more.
+	t.Run("client disconnect is not a server error", func(t *testing.T) {
+		gin.SetMode(gin.TestMode)
+		handlers := map[string]func(*gin.Context, error){
+			"handleNotFound": func(ctx *gin.Context, err error) {
+				handleNotFound(ctx, newTestLogger(t), err, "task sessions not found")
+			},
+			"handleSelectedMoveError": func(ctx *gin.Context, err error) {
+				handleSelectedMoveError(ctx, newTestLogger(t), err)
+			},
+		}
+		for name, handle := range handlers {
+			t.Run(name, func(t *testing.T) {
+				rec := httptest.NewRecorder()
+				ctx, _ := gin.CreateTestContext(rec)
+				handle(ctx, fmt.Errorf("list task sessions: %w", context.Canceled))
+				if rec.Code != statusClientClosedRequest {
+					t.Fatalf("status=%d, want %d", rec.Code, statusClientClosedRequest)
+				}
+			})
+		}
+	})
+
+	// Our own deadline firing is a real failure and must keep its 500.
+	t.Run("server timeout stays a server error", func(t *testing.T) {
+		gin.SetMode(gin.TestMode)
+		rec := httptest.NewRecorder()
+		ctx, _ := gin.CreateTestContext(rec)
+		handleNotFound(ctx, newTestLogger(t), fmt.Errorf("query: %w", context.DeadlineExceeded), "task not found")
+		if rec.Code != http.StatusInternalServerError {
+			t.Fatalf("status=%d, want %d", rec.Code, http.StatusInternalServerError)
+		}
+	})
+
 	t.Run("WIP limit is a conflict for task creation", func(t *testing.T) {
 		gin.SetMode(gin.TestMode)
 		rec := httptest.NewRecorder()


### PR DESCRIPTION
## Problem

A browser that navigates away, unmounts a component, or aborts an in-flight
fetch cancels the request. That reaches the handler as a cancelled request
context — handlers derive theirs from `c.Request.Context()`, which the server
cancels when the peer goes away.

`handleNotFound` did not classify it. `context.Canceled` matches none of
`isNotFound`, the WIP-limit check, or `isValidationError`, so it fell through
to the last branch: an ERROR log with a full stacktrace, and a 500 written for
a client that had already gone.

Observed on a plain page transition:

```
ERROR  request failed  {"component": "task-task-handlers", "error": "context canceled"}
  ...handlers.handleNotFound
      internal/task/handlers/errors.go:28
  ...handlers.(*TaskHandlers).httpListTaskSessions
      internal/task/handlers/task_http_handlers.go:424
  [+20 frames]
WARN   http  {"method": "GET", "path": "/api/v1/tasks/:id/sessions", "status": 500}
```

Nothing failed. The stacktrace points at a healthy code path, and the 500 in
the metrics is not a real one.

## Fix

Classify `context.Canceled` as a client disconnect: answer 499 and skip the
error log. One classifier covers all 59 `handleNotFound` call sites plus
`handleSelectedMoveError`.

`context.DeadlineExceeded` is deliberately excluded — that is our own timeout
firing, a genuine server-side failure, and it keeps its logged 500. There is a
test pinning that distinction so a later "simplification" to
`errors.Is(err, ctx.Err())` cannot quietly swallow real timeouts.

`RequestLogger` also stops warning about 499, alongside the 404 it already
ignores. A caller hanging up is as routine as a miss, and leaving it at WARN
would just move the noise one level down rather than remove it.

## Why 499

Go defines no constant and no standard 4xx means "the client hung up". 499 is
nginx's, widely understood, and does not collide with anything the API
returns. It is declared as a named constant in both packages that need it
rather than as a bare literal.

## Testing

`TestErrorsAreClassifiable` gains two cases: a cancelled context through both
handlers, and a deadline-exceeded that must stay 500. Against the parent
commit the first fails with `status=500, want 499` on both handlers while the
second passes, so the tests pin the behaviour rather than merely describing
it.

`./internal/task/handlers/` and `./internal/common/httpmw/` pass.

## Notes

This is the second half of a report from #2325. That PR fixed the terminal
reconnect loop; this is the misleading 500 that showed up in the same logs
while diagnosing it. They are unrelated code paths, hence the separate PR.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2384?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->