### PR TITLE
refactor(make): report the real dev ports and document every override

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,11 @@ SERVICE_HOME_DIR_FLAG := $(if $(HOME_DIR),--home-dir "$(HOME_DIR)",)
 SERVICE_NO_BOOT_START_FLAG := $(if $(filter 1 true yes,$(NO_BOOT_START)),--no-boot-start,)
 SERVICE_INSTALL_FLAGS := $(PORT_FLAG) $(SERVICE_HOME_DIR_FLAG) $(SERVICE_NO_BOOT_START_FLAG)
 DEV_WEB_PORT_FLAG := $(if $(WEB_PORT),--web-internal-port $(WEB_PORT),)
-DEV_FLAGS := $(strip $(PORT_FLAG) $(DEV_WEB_PORT_FLAG) $(DEV_ARGS))
+DEV_FLAGS := $(PORT_FLAG) $(DEV_WEB_PORT_FLAG) $(DEV_ARGS)
+# $(if …) does not strip its condition, so an all-whitespace DEV_FLAGS reads as
+# true. Test and print this instead, and forward DEV_FLAGS itself — stripping
+# what reaches the CLI would collapse whitespace inside a quoted DEV_ARGS value.
+DEV_FLAGS_DISPLAY := $(strip $(DEV_FLAGS))
 DESKTOP_BUNDLES ?= dmg
 
 # Phase headers
@@ -191,7 +195,7 @@ ifeq ($(OS),Windows_NT)
 	@echo "Building winjob (Ctrl-C-safe wrapper for Windows)..."
 	@$(MAKE) -C $(BACKEND_DIR) build-winjob
 endif
-	@echo "Launching via CLI$(if $(DEV_FLAGS), ($(DEV_FLAGS)), (auto ports))..."
+	@echo "Launching via CLI$(if $(DEV_FLAGS_DISPLAY), ($(DEV_FLAGS_DISPLAY)), (auto ports))..."
 	@cd $(APPS_DIR) && $(PNPM) -C cli dev -- dev $(DEV_FLAGS)
 
 .PHONY: dev-prod-db

--- a/Makefile
+++ b/Makefile
@@ -53,13 +53,12 @@ SERVICE_BUNDLE_DIR ?= $(CURDIR)/dist/kandev
 SERVICE_LAUNCHER = $(SERVICE_BUNDLE_DIR)/bin/kandev
 SERVICE_VERSION ?= $(RUNTIME_VERSION)
 SERVICE_ENV = KANDEV_BUNDLE_DIR="$(SERVICE_BUNDLE_DIR)" KANDEV_VERSION="$(SERVICE_VERSION)"
-SERVICE_PORT_FLAG := $(if $(PORT),--port $(PORT),)
+PORT_FLAG := $(if $(PORT),--port $(PORT),)
 SERVICE_HOME_DIR_FLAG := $(if $(HOME_DIR),--home-dir "$(HOME_DIR)",)
 SERVICE_NO_BOOT_START_FLAG := $(if $(filter 1 true yes,$(NO_BOOT_START)),--no-boot-start,)
-SERVICE_INSTALL_FLAGS := $(SERVICE_PORT_FLAG) $(SERVICE_HOME_DIR_FLAG) $(SERVICE_NO_BOOT_START_FLAG)
-DEV_PORT_FLAG := $(if $(PORT),--port $(PORT),)
+SERVICE_INSTALL_FLAGS := $(PORT_FLAG) $(SERVICE_HOME_DIR_FLAG) $(SERVICE_NO_BOOT_START_FLAG)
 DEV_WEB_PORT_FLAG := $(if $(WEB_PORT),--web-internal-port $(WEB_PORT),)
-DEV_FLAGS := $(DEV_PORT_FLAG) $(DEV_WEB_PORT_FLAG) $(DEV_ARGS)
+DEV_FLAGS := $(strip $(PORT_FLAG) $(DEV_WEB_PORT_FLAG) $(DEV_ARGS))
 DESKTOP_BUNDLES ?= dmg
 
 # Phase headers
@@ -87,7 +86,8 @@ help:
 	@echo "  bootstrap        Install mise tools, workspace deps, and git hooks"
 	@echo "  bootstrap-e2e    Bootstrap plus Playwright browser/system deps"
 	@echo "  dev              Run backend + web via local CLI (auto ports)"
-	@echo "  dev PORT=38430   Run dev on a fixed backend port (beats KANDEV_BACKEND_PORT)"
+	@echo "  dev PORT=38430 WEB_PORT=37430   Run dev on fixed ports (beat KANDEV_BACKEND_PORT/KANDEV_PORT)"
+	@echo "  dev DEV_ARGS='--verbose'        Pass extra flags through to the dev CLI"
 	@echo "  dev-prod-db      Run dev mode against the production db at ~/.kandev"
 	@echo "  dev-backend      Run backend in development mode (port 38429)"
 	@echo "  dev-web          Run web app in development mode (port 37429)"
@@ -191,7 +191,7 @@ ifeq ($(OS),Windows_NT)
 	@echo "Building winjob (Ctrl-C-safe wrapper for Windows)..."
 	@$(MAKE) -C $(BACKEND_DIR) build-winjob
 endif
-	@echo "Launching via CLI (auto ports)..."
+	@echo "Launching via CLI$(if $(DEV_FLAGS), ($(DEV_FLAGS)), (auto ports))..."
 	@cd $(APPS_DIR) && $(PNPM) -C cli dev -- dev $(DEV_FLAGS)
 
 .PHONY: dev-prod-db


### PR DESCRIPTION
`make dev` announced "auto ports" even when PORT or WEB_PORT pinned them, and `make help` documented only PORT. Both were raised by CodeRabbit on #2368 and went in unaddressed.

## Important Changes

- `DEV_PORT_FLAG` was a byte-for-byte copy of `SERVICE_PORT_FLAG`; both are now `PORT_FLAG`, used by the `dev` and `service-install` targets alike.
- The banner has to test whether any flags were supplied, and `$(if …)` does not strip its condition — an all-whitespace `DEV_FLAGS` reads as true and prints `(  )` instead of `(auto ports)`. Stripping `DEV_FLAGS` itself is not the fix either: that collapses whitespace inside a quoted `DEV_ARGS` before the CLI sees it. So `DEV_FLAGS` is forwarded verbatim and a separate stripped `DEV_FLAGS_DISPLAY` drives both the condition and the banner.

## Validation

Ran for real in both PowerShell and Git Bash, against a checkout with an installed Kandev already serving on 38429 and `KANDEV_BACKEND_PORT=38429` exported:

- `make dev PORT=38430 WEB_PORT=37430` → `Launching via CLI (--port 38430 --web-internal-port 37430)...`, backend ready on 38430, SPA renders with no console errors.
- `make dev PORT=38431 WEB_PORT=37431 DEV_ARGS=--verbose` → all three reported and forwarded, backend ready on 38431, SPA renders.
- `make dev` → `Launching via CLI (auto ports)...`, port selection unchanged.
- `make -n dev DEV_ARGS='--label "alpha  beta"'` → the recipe keeps both spaces; only the banner collapses them.
- `make -n service-install PORT=3000 HOME_DIR=/tmp/x` → `service install --port 3000 --home-dir "/tmp/x"`, unchanged by the `PORT_FLAG` rename; likewise with no variables.
- `make help` lists PORT, WEB_PORT and DEV_ARGS.

The banner is the one line where a dry run is not enough: `$(if …)` expands parentheses into an `@echo`, which cmd.exe could have parsed. It survives both shells.

## Possible Improvements

Low risk: `make help` output and a launch banner. No change to what the dev target actually runs.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.
