### PR TITLE
fix(terminal): tell the client when a terminal will never reconnect

### DIFF
--- a/apps/backend/internal/gateway/websocket/terminal_handler.go
+++ b/apps/backend/internal/gateway/websocket/terminal_handler.go
@@ -50,6 +50,17 @@ var terminalUpgrader = gorillaws.Upgrader{
 	CheckOrigin:     checkWebSocketOrigin,
 }
 
+const (
+	// closeCodeSessionTerminal tells the client this terminal will never come
+	// back, so it must stop reconnecting. 4000-4999 is the range RFC 6455
+	// reserves for application close codes.
+	closeCodeSessionTerminal = 4001
+	// sessionTerminalCloseReason travels in the close frame. Keep it under the
+	// 123-byte control-frame payload limit, or the frame is rejected and the
+	// client sees an anonymous 1006 again.
+	sessionTerminalCloseReason = "session has ended"
+)
+
 type terminalRoute struct {
 	kind string
 	id   string
@@ -138,6 +149,17 @@ func (h *TerminalHandler) handleAgentTerminalRoute(c *gin.Context, sessionID str
 func (h *TerminalHandler) handleEnvironmentUserShellWS(c *gin.Context, environmentID, terminalID string) {
 	execution, err := h.lifecycleMgr.GetOrEnsureExecutionForEnvironment(c.Request.Context(), environmentID)
 	if err != nil {
+		// A terminal session never gains an execution, so retrying cannot help.
+		// Rejecting the upgrade with 503 does not say that: a failed handshake
+		// reaches the browser as a bare 1006 close with no status and no body,
+		// indistinguishable from "agentctl is still booting". The client backs
+		// off to a flat 5s and then retries for as long as the tab stays open.
+		// Complete the handshake instead, and close with a code that carries
+		// the verdict.
+		if errors.Is(err, lifecycle.ErrSessionTerminal) {
+			h.closeTerminalAsPermanent(c, environmentID, terminalID, err)
+			return
+		}
 		h.logger.Warn("environment terminal execution not ready",
 			zap.String("task_environment_id", environmentID),
 			zap.String("terminal_id", terminalID),
@@ -170,6 +192,35 @@ func (h *TerminalHandler) handleEnvironmentUserShellWS(c *gin.Context, environme
 		zap.String("terminal_id", terminalID),
 		zap.String("remote_addr", c.Request.RemoteAddr))
 	h.handleUserShellWS(c, execution, environmentID, terminalID, interactiveRunner)
+}
+
+// closeTerminalAsPermanent completes the WebSocket handshake only to close it
+// with closeCodeSessionTerminal. The handshake is the point: a close code is
+// the only channel a browser gives us for saying *why* a terminal is
+// unavailable, and it is what lets the client tell "never" from "not yet".
+func (h *TerminalHandler) closeTerminalAsPermanent(c *gin.Context, environmentID, terminalID string, cause error) {
+	h.logger.Info("terminal permanently unavailable",
+		zap.String("task_environment_id", environmentID),
+		zap.String("terminal_id", terminalID),
+		zap.String("reason", sessionTerminalCloseReason),
+		zap.Error(cause))
+	conn, err := terminalUpgrader.Upgrade(c.Writer, c.Request, nil)
+	if err != nil {
+		// Upgrade already wrote an HTTP error to the client.
+		h.logger.Warn("upgrade failed while rejecting terminal session",
+			zap.String("task_environment_id", environmentID),
+			zap.Error(err))
+		return
+	}
+	defer func() { _ = conn.Close() }()
+	if err := conn.WriteMessage(
+		gorillaws.CloseMessage,
+		gorillaws.FormatCloseMessage(closeCodeSessionTerminal, sessionTerminalCloseReason),
+	); err != nil {
+		h.logger.Warn("failed to send terminal close frame",
+			zap.String("task_environment_id", environmentID),
+			zap.Error(err))
+	}
 }
 
 func (h *TerminalHandler) handleRemoteUserShellWS(

--- a/apps/backend/internal/gateway/websocket/terminal_handler_test.go
+++ b/apps/backend/internal/gateway/websocket/terminal_handler_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	gorillaws "github.com/gorilla/websocket"
 	agentctlclient "github.com/kandev/kandev/internal/agent/runtime/agentctl"
 	"github.com/kandev/kandev/internal/agent/runtime/lifecycle"
 	"github.com/kandev/kandev/internal/agentctl/server/process"
@@ -393,5 +394,75 @@ func TestStartUserShellProcessExportsEffectiveRuntimeEnv(t *testing.T) {
 		if env[key] != want {
 			t.Fatalf("shell env[%q] = %q, want %q (env=%#v)", key, env[key], want, env)
 		}
+	}
+}
+
+type terminalSessionWorkspaceProvider struct {
+	info *lifecycle.WorkspaceInfo
+}
+
+func (p *terminalSessionWorkspaceProvider) GetWorkspaceInfoForSession(_ context.Context, _, _ string) (*lifecycle.WorkspaceInfo, error) {
+	return p.info, nil
+}
+
+func (p *terminalSessionWorkspaceProvider) GetWorkspaceInfoForEnvironment(_ context.Context, _ string) (*lifecycle.WorkspaceInfo, error) {
+	return p.info, nil
+}
+
+// A shell terminal on an ended session used to be refused with a 503 on the
+// upgrade, which the browser reports as a bare 1006 close - no status, no
+// body, and no way to tell "never" from "not yet". The client retried every
+// 5s for as long as the tab stayed open. The handshake must complete so the
+// close code can carry the verdict.
+func TestEnvironmentTerminalClosesPermanentlyForTerminalSession(t *testing.T) {
+	log := testTerminalLogger(t)
+	manager := lifecycle.NewManager(
+		nil, bus.NewMemoryEventBus(log), nil, nil, nil, nil,
+		lifecycle.ExecutorFallbackDeny, t.TempDir(), log,
+	)
+	manager.SetWorkspaceInfoProvider(&terminalSessionWorkspaceProvider{
+		info: &lifecycle.WorkspaceInfo{
+			TaskID:            "task-terminal",
+			SessionID:         "session-terminal",
+			TaskEnvironmentID: "env-terminal",
+			WorkspacePath:     t.TempDir(),
+			AgentID:           "auggie",
+		},
+	})
+	manager.SetExecutorProfileReader(&stubExecutorProfileReader{
+		session: &taskmodels.TaskSession{
+			ID:    "session-terminal",
+			State: taskmodels.TaskSessionStateFailed,
+		},
+	})
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.GET("/terminal/*target", NewTerminalHandler(manager, nil, nil, log).HandleTerminalWS)
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	wsURL := "ws" + server.URL[len("http"):] + "/terminal/environment/env-terminal?terminalId=term-1"
+	conn, resp, err := gorillaws.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		status := 0
+		if resp != nil {
+			status = resp.StatusCode
+		}
+		t.Fatalf("handshake must succeed so the close code is observable; err=%v status=%d", err, status)
+	}
+	defer func() { _ = conn.Close() }()
+
+	_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	_, _, readErr := conn.ReadMessage()
+	closeErr, ok := readErr.(*gorillaws.CloseError)
+	if !ok {
+		t.Fatalf("ReadMessage() error = %v, want a websocket close error", readErr)
+	}
+	if closeErr.Code != closeCodeSessionTerminal {
+		t.Fatalf("close code = %d, want %d", closeErr.Code, closeCodeSessionTerminal)
+	}
+	if closeErr.Text != sessionTerminalCloseReason {
+		t.Fatalf("close reason = %q, want %q", closeErr.Text, sessionTerminalCloseReason)
 	}
 }

--- a/apps/web/components/task/use-passthrough-terminal.test.ts
+++ b/apps/web/components/task/use-passthrough-terminal.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildTerminalWsUrl } from "./use-passthrough-terminal";
 import { computeCanConnect } from "./passthrough-terminal";
-import { reconnectDelayMs, startReconnectLoop } from "./ws-reconnect";
+import { CLOSE_CODE_SESSION_TERMINAL, reconnectDelayMs, startReconnectLoop } from "./ws-reconnect";
 import type { Terminal } from "@xterm/xterm";
 
 const WS_BASE_URL = "ws://localhost:38429";
@@ -56,6 +56,32 @@ describe("buildTerminalWsUrl", () => {
   });
 });
 
+/** A connect that immediately reports the given close, to drive the loop. */
+function closesWith(code: number, reason: string) {
+  return vi.fn(({ onSocketClose }: { onSocketClose: (e: CloseEvent) => void }) => {
+    onSocketClose({ code, reason } as CloseEvent);
+  });
+}
+
+function startTestLoop(
+  overrides: Partial<Parameters<typeof startReconnectLoop>[0]> &
+    Pick<Parameters<typeof startReconnectLoop>[0], "connectWebSocket">,
+) {
+  return startReconnectLoop({
+    environmentId: "env-1",
+    wsBaseUrl: WS_BASE_URL,
+    mode: "shell",
+    terminalId: "shell-1",
+    label: undefined,
+    terminal: { reset: vi.fn() } as unknown as Terminal,
+    fitAndResize: vi.fn(),
+    wsRef: { current: null },
+    attachAddonRef: { current: null },
+    onConnected: vi.fn(),
+    ...overrides,
+  });
+}
+
 describe("startReconnectLoop", () => {
   afterEach(() => {
     vi.useRealTimers();
@@ -88,6 +114,42 @@ describe("startReconnectLoop", () => {
 
     expect(connectWebSocket).toHaveBeenCalledTimes(1);
     expect(onDisconnected).toHaveBeenCalledTimes(1);
+    stop();
+  });
+
+  // A terminal on an ended session used to reconnect every 5s for as long as
+  // the tab stayed open, because a rejected upgrade is indistinguishable from
+  // a transient one. The server now closes with a dedicated code instead.
+  it("stops reconnecting when the server says the session has ended", () => {
+    vi.useFakeTimers();
+    const onPermanentClose = vi.fn();
+    const connectWebSocket = closesWith(CLOSE_CODE_SESSION_TERMINAL, "session has ended");
+
+    const stop = startTestLoop({ connectWebSocket, onPermanentClose });
+
+    vi.advanceTimersByTime(150);
+    expect(connectWebSocket).toHaveBeenCalledTimes(1);
+
+    // Well past the 5s the backoff saturates at, and several times over.
+    vi.advanceTimersByTime(60_000);
+    expect(connectWebSocket).toHaveBeenCalledTimes(1);
+    expect(onPermanentClose).toHaveBeenCalledWith("session has ended");
+    stop();
+  });
+
+  it("still retries transient closes so a booting agentctl is not given up on", () => {
+    vi.useFakeTimers();
+    const onPermanentClose = vi.fn();
+    const connectWebSocket = closesWith(1006, "");
+
+    const stop = startTestLoop({ connectWebSocket, onPermanentClose });
+
+    vi.advanceTimersByTime(150);
+    expect(connectWebSocket).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(300);
+    expect(connectWebSocket).toHaveBeenCalledTimes(2);
+    expect(onPermanentClose).not.toHaveBeenCalled();
     stop();
   });
 

--- a/apps/web/components/task/use-passthrough-terminal.ts
+++ b/apps/web/components/task/use-passthrough-terminal.ts
@@ -11,6 +11,7 @@ import { matchesShortcut } from "@/lib/keyboard/utils";
 import { SHORTCUTS } from "@/lib/keyboard/constants";
 import { getShortcut, type StoredShortcutOverrides } from "@/lib/keyboard/shortcut-overrides";
 import { exposeBufferReader, clearBufferReader } from "./terminal-buffer-reader";
+import { t } from "@/lib/i18n";
 
 // Debug flag - set to true to see detailed logs
 const DEBUG = false;
@@ -551,6 +552,13 @@ export function useWebSocketConnection({
       attachAddonRef,
       onConnected,
       onDisconnected,
+      onPermanentClose: (reason) => {
+        // The socket is gone for good, so nothing else will ever draw here.
+        // Write the verdict into the pane rather than leaving the user with a
+        // terminal that silently stopped responding.
+        terminal.write(`\r\n\x1b[33m${t("task:terminalSessionEnded")}\x1b[0m\r\n`);
+        log("Terminal closed permanently", { reason });
+      },
       connectWebSocket,
       manualInputRouting,
       onWsReady,

--- a/apps/web/components/task/ws-reconnect.ts
+++ b/apps/web/components/task/ws-reconnect.ts
@@ -25,6 +25,20 @@ export function teardownWebSocket(
 
 const STABLE_CONNECTION_MS = 500;
 
+/**
+ * Sent by the server when the session behind a terminal has ended. Nothing
+ * about that recovers, so the loop must stop rather than back off. Kept in
+ * sync with `closeCodeSessionTerminal` in the gateway's terminal_handler.go.
+ */
+export const CLOSE_CODE_SESSION_TERMINAL = 4001;
+
+/** Close codes that mean "do not reconnect", as opposed to "not yet". */
+const PERMANENT_CLOSE_CODES = new Set<number>([CLOSE_CODE_SESSION_TERMINAL]);
+
+export function isPermanentCloseCode(code: number): boolean {
+  return PERMANENT_CLOSE_CODES.has(code);
+}
+
 export function reconnectDelayMs(attempt: number): number {
   const cappedAttempt = Math.min(attempt, 5);
   return Math.min(5000, 300 * 2 ** cappedAttempt);
@@ -62,6 +76,10 @@ export type ReconnectLoopOptions = {
   attachAddonRef: React.MutableRefObject<AttachAddon | null>;
   onConnected: () => void;
   onDisconnected?: () => void;
+  /** Called instead of scheduling a retry when the server says the terminal
+   * will never be available again. Receives the close reason so the caller can
+   * tell the user why the terminal stopped, rather than leaving it blank. */
+  onPermanentClose?: (reason: string) => void;
   connectWebSocket: ConnectWebSocketFn;
   manualInputRouting?: boolean;
   onWsReady?: (ws: WebSocket) => void;
@@ -80,6 +98,7 @@ export function startReconnectLoop({
   attachAddonRef,
   onConnected,
   onDisconnected,
+  onPermanentClose,
   connectWebSocket,
   manualInputRouting,
   onWsReady,
@@ -130,6 +149,18 @@ export function startReconnectLoop({
           if (stableOpenTimeout) {
             clearTimeout(stableOpenTimeout);
             stableOpenTimeout = null;
+          }
+          // Retrying a permanent failure is what turned a dead terminal tab
+          // into an endless reconnect loop. Stop, and hand the reason up so
+          // the pane can say something instead of sitting blank.
+          if (isPermanentCloseCode(event.code)) {
+            log("Permanent close, not reconnecting", {
+              code: event.code,
+              reason: event.reason,
+            });
+            isMounted = false;
+            onPermanentClose?.(event.reason);
+            return;
           }
           const nextDelay = reconnectDelayMs(retryAttempt);
           retryAttempt += 1;

--- a/apps/web/src/locales/en/task.json
+++ b/apps/web/src/locales/en/task.json
@@ -1258,6 +1258,7 @@
   "terminalNotAvailableThisTaskIs": "Terminal not available — this task is archived",
   "terminalNumbered": "terminal #{{seq}}",
   "terminalPromptInputAreDisabledUntil": "Terminal & prompt input are disabled until the next run starts.",
+  "terminalSessionEnded": "This session has ended — the terminal will not reconnect.",
   "terminalUnavailableNoActiveSession": "Terminal unavailable — no active session.",
   "terminalWithSeq": "Terminal {{seq}}",
   "terminals": "Terminals",

--- a/apps/web/src/locales/pseudo/task.json
+++ b/apps/web/src/locales/pseudo/task.json
@@ -1258,6 +1258,7 @@
   "terminalNotAvailableThisTaskIs": "Ţēŕḿĩńàĺ ńōţ àvàĩĺàƀĺē — ţĥĩś ţàśķ ĩś àŕćĥĩvēď",
   "terminalNumbered": "ţēŕḿĩńàĺ #{{seq}}",
   "terminalPromptInputAreDisabledUntil": "Ţēŕḿĩńàĺ & ƥŕōḿƥţ ĩńƥũţ àŕē ďĩśàƀĺēď ũńţĩĺ ţĥē ńēxţ ŕũń śţàŕţś.",
+  "terminalSessionEnded": "Ţĥĩś śēśśĩōń ĥàś ēńďēď — ţĥē ţēŕḿĩńàĺ ŵĩĺĺ ńōţ ŕēćōńńēćţ.",
   "terminalUnavailableNoActiveSession": "Ţēŕḿĩńàĺ ũńàvàĩĺàƀĺē — ńō àćţĩvē śēśśĩōń.",
   "terminalWithSeq": "Ţēŕḿĩńàĺ {{seq}}",
   "terminals": "Ţēŕḿĩńàĺś",


### PR DESCRIPTION
## Problem

#2325 fixed the server side of a reconnect loop: a shell terminal left open on
a session that had ended made the backend build and tear down a runtime every
five seconds. The client half was left alone, and it is the half users see.

A terminal on an ended session is refused with `503` on the WebSocket upgrade.
A failed handshake reaches the browser as a bare `1006` close — no status
code, no body, no reason. That is exactly what a transient failure looks like
too, so `ws-reconnect.ts` cannot tell "this will never work" from "agentctl is
still booting". It backs off to a flat 5s and retries for as long as the tab
stays open, and the pane shows nothing at all: no error, no explanation, just a
terminal that stopped responding.

## Fix

**Server** — when `GetOrEnsureExecutionForEnvironment` returns
`ErrSessionTerminal`, complete the handshake and then close with `4001`
(`closeCodeSessionTerminal`) and a short reason, instead of rejecting the
upgrade. Completing the handshake is the point: a close code is the only
channel the browser gives us for saying *why*.

Other failures keep their `503`. They are transient by nature, and the client
should keep retrying them.

**Client** — `ws-reconnect.ts` stops the loop on a permanent close code rather
than scheduling the next attempt, and hands the reason to a new optional
`onPermanentClose`. `use-passthrough-terminal.ts` writes it into the xterm
pane, so the terminal says what happened instead of going quiet.

The close code is a small shared contract between the two sides, so both
constants carry a comment pointing at the other.

## Testing

**Backend** — `TestEnvironmentTerminalClosesPermanentlyForTerminalSession`
dials the real handler over `httptest`, asserts the handshake *succeeds*
(regressing to a 503 fails the test on the dial), and that the close frame
carries `4001` with the expected reason.

**Client** — two cases, and the second is the control for the first:

- a `4001` close stops the loop: one connect attempt, still one after 60s of
  simulated time, and `onPermanentClose` receives the reason
- a `1006` close still retries: a second connect after the 300ms backoff, and
  `onPermanentClose` untouched

Without the pairing, the first test would also pass if the loop were broken
outright.

`./internal/gateway/websocket/` passes, the web suite passes, and eslint,
`tsc --noEmit` and `pnpm i18n:check` are clean.

## Notes

The user-facing string goes through `t()` with a new `task:terminalSessionEnded`
key; `pt-pt` and `zh-cn` fall back to `en` as they do for the other ~650 keys
they do not carry yet.

Scoped to the environment shell route, which is where the reported loop was.
The agent passthrough route has its own readiness path and is left alone.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2390?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

