### PR TITLE
fix(agentctl): log canceled git status refreshes at debug

### DIFF
--- a/apps/backend/internal/agentctl/server/process/workspace_git_status.go
+++ b/apps/backend/internal/agentctl/server/process/workspace_git_status.go
@@ -2,6 +2,7 @@ package process
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"regexp"
@@ -36,7 +37,16 @@ func (wt *WorkspaceTracker) updateGitStatus(ctx context.Context) bool {
 func (wt *WorkspaceTracker) updateGitStatusClass(ctx context.Context, class subproc.GitWorkClass) bool {
 	status, err := wt.getGitStatusClass(ctx, class)
 	if err != nil {
-		wt.logger.Warn("updateGitStatus: getGitStatus failed", zap.Error(err))
+		// A cancellation is the expected outcome when the tracker is being
+		// torn down (Stop cancels cancelCtx, which kills the in-flight git
+		// command) or when the poll's admission slot is revoked. That is not a
+		// failure worth a warning — it mirrors handleGitPollFailure, which also
+		// downgrades cancellation-class errors to Debug to keep shutdown quiet.
+		if wt.isGitStatusCancellation(err) {
+			wt.logger.Debug("updateGitStatus: getGitStatus canceled", zap.Error(err))
+		} else {
+			wt.logger.Warn("updateGitStatus: getGitStatus failed", zap.Error(err))
+		}
 		return false
 	}
 	if ctx.Err() != nil || wt.cancelCtx.Err() != nil {
@@ -50,6 +60,16 @@ func (wt *WorkspaceTracker) updateGitStatusClass(ctx context.Context, class subp
 	// Notify workspace stream subscribers
 	wt.notifyWorkspaceStreamGitStatus(status)
 	return true
+}
+
+// isGitStatusCancellation reports whether a getGitStatus error is a benign
+// cancellation rather than a real git failure: the passed context or the
+// tracker's own shutdown context was canceled, or the background admission slot
+// was revoked. These are all expected during teardown and don't warrant a warn.
+func (wt *WorkspaceTracker) isGitStatusCancellation(err error) bool {
+	return errors.Is(err, context.Canceled) ||
+		errors.Is(err, subproc.ErrAdmissionCanceled) ||
+		wt.cancelCtx.Err() != nil
 }
 
 // tryUpdateGitStatus attempts a non-blocking git status update. If another

--- a/apps/backend/internal/agentctl/server/process/workspace_git_status.go
+++ b/apps/backend/internal/agentctl/server/process/workspace_git_status.go
@@ -49,7 +49,7 @@ func (wt *WorkspaceTracker) updateGitStatusClass(ctx context.Context, class subp
 		}
 		return false
 	}
-	if ctx.Err() != nil || wt.cancelCtx.Err() != nil {
+	if ctx.Err() != nil || (wt.cancelCtx != nil && wt.cancelCtx.Err() != nil) {
 		return false
 	}
 
@@ -67,9 +67,10 @@ func (wt *WorkspaceTracker) updateGitStatusClass(ctx context.Context, class subp
 // tracker's own shutdown context was canceled, or the background admission slot
 // was revoked. These are all expected during teardown and don't warrant a warn.
 func (wt *WorkspaceTracker) isGitStatusCancellation(err error) bool {
-	return errors.Is(err, context.Canceled) ||
-		errors.Is(err, subproc.ErrAdmissionCanceled) ||
-		wt.cancelCtx.Err() != nil
+	if errors.Is(err, context.Canceled) || errors.Is(err, subproc.ErrAdmissionCanceled) {
+		return true
+	}
+	return wt.cancelCtx != nil && wt.cancelCtx.Err() != nil
 }
 
 // tryUpdateGitStatus attempts a non-blocking git status update. If another

--- a/apps/backend/internal/agentctl/server/process/workspace_git_status_test.go
+++ b/apps/backend/internal/agentctl/server/process/workspace_git_status_test.go
@@ -2,13 +2,66 @@ package process
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/kandev/kandev/internal/agentctl/types"
 	"github.com/kandev/kandev/internal/common/subproc"
+	"go.uber.org/zap/zapcore"
 )
+
+// TestUpdateGitStatus_CancellationLogsDebugNotWarn verifies that a canceled
+// observation (the expected outcome during tracker teardown) is logged at
+// Debug, while a genuine failure still warns. This keeps shutdown from
+// emitting a burst of "getGitStatus failed" warnings for context.Canceled.
+func TestUpdateGitStatus_CancellationLogsDebugNotWarn(t *testing.T) {
+	tests := []struct {
+		name        string
+		observerErr error
+		wantWarn    bool
+	}{
+		{"context canceled", context.Canceled, false},
+		{"admission canceled", subproc.ErrAdmissionCanceled, false},
+		{"real failure", errors.New("git exploded"), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			log, observed := newObservedTestLogger(t)
+			wt := NewWorkspaceTracker(t.TempDir(), log)
+			t.Cleanup(wt.Stop)
+			wt.gitStatusObserver = func(context.Context) (types.GitStatusUpdate, error) {
+				return types.GitStatusUpdate{}, tt.observerErr
+			}
+
+			if wt.updateGitStatus(context.Background()) {
+				t.Fatal("updateGitStatus returned true on error")
+			}
+
+			warns := observed.FilterMessage("updateGitStatus: getGitStatus failed").
+				FilterLevelExact(zapcore.WarnLevel).Len()
+			debugs := observed.FilterMessage("updateGitStatus: getGitStatus canceled").
+				FilterLevelExact(zapcore.DebugLevel).Len()
+
+			if tt.wantWarn {
+				if warns != 1 {
+					t.Fatalf("warn count = %d, want 1", warns)
+				}
+				if debugs != 0 {
+					t.Fatalf("debug count = %d, want 0", debugs)
+				}
+				return
+			}
+			if warns != 0 {
+				t.Fatalf("warn count = %d, want 0 for cancellation", warns)
+			}
+			if debugs != 1 {
+				t.Fatalf("debug count = %d, want 1 for cancellation", debugs)
+			}
+		})
+	}
+}
 
 func TestUnquoteGitPath(t *testing.T) {
 	tests := []struct {

--- a/apps/backend/internal/agentctl/server/process/workspace_git_status_test.go
+++ b/apps/backend/internal/agentctl/server/process/workspace_git_status_test.go
@@ -20,11 +20,13 @@ func TestUpdateGitStatus_CancellationLogsDebugNotWarn(t *testing.T) {
 	tests := []struct {
 		name        string
 		observerErr error
+		cancelWT    bool
 		wantWarn    bool
 	}{
-		{"context canceled", context.Canceled, false},
-		{"admission canceled", subproc.ErrAdmissionCanceled, false},
-		{"real failure", errors.New("git exploded"), true},
+		{"context canceled", context.Canceled, false, false},
+		{"admission canceled", subproc.ErrAdmissionCanceled, false, false},
+		{"tracker context canceled with opaque error", errors.New("exit status 1"), true, false},
+		{"real failure", errors.New("git exploded"), false, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -33,6 +35,9 @@ func TestUpdateGitStatus_CancellationLogsDebugNotWarn(t *testing.T) {
 			t.Cleanup(wt.Stop)
 			wt.gitStatusObserver = func(context.Context) (types.GitStatusUpdate, error) {
 				return types.GitStatusUpdate{}, tt.observerErr
+			}
+			if tt.cancelWT {
+				wt.cancelFunc()
 			}
 
 			if wt.updateGitStatus(context.Background()) {
@@ -60,6 +65,13 @@ func TestUpdateGitStatus_CancellationLogsDebugNotWarn(t *testing.T) {
 				t.Fatalf("debug count = %d, want 1 for cancellation", debugs)
 			}
 		})
+	}
+}
+
+func TestWorkspaceTrackerIsGitStatusCancellation_NilCancelCtx(t *testing.T) {
+	wt := &WorkspaceTracker{}
+	if wt.isGitStatusCancellation(errors.New("git exploded")) {
+		t.Fatal("isGitStatusCancellation returned true with nil cancelCtx")
 	}
 }
 


### PR DESCRIPTION
## Summary
- downgrade canceled workspace git status updates from warn to debug during tracker teardown
- keep genuine git status failures at warn so real problems still surface
- add targeted test coverage for cancellation versus failure logging

## Testing
- cd apps/backend && go test ./internal/agentctl/server/process/ -run "TestUpdateGitStatus_CancellationLogsDebugNotWarn|TestGitOperator_Commit|TestGetGitStatus" -count=1
- cd apps/backend && go vet ./internal/agentctl/server/process/
- cd apps/backend && go test ./internal/agentctl/server/process/ -count=1


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2398?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->