### PR TITLE
fix(tasks): stop tool calls from driving the pending-input icon

### DIFF
--- a/apps/backend/internal/task/statussummary/constants.go
+++ b/apps/backend/internal/task/statussummary/constants.go
@@ -6,6 +6,9 @@ const (
 	pendingPermission    = "permission"
 	pendingClarification = "clarification"
 
+	messageTypeClarificationRequest = "clarification_request"
+	messageTypePermissionRequest    = "permission_request"
+
 	activityBackground = "background"
 	activityGenerating = "generating"
 

--- a/apps/backend/internal/task/statussummary/projector.go
+++ b/apps/backend/internal/task/statussummary/projector.go
@@ -734,12 +734,15 @@ func (p *Projector) applyPendingMessageLocked(state *projectionState, eventType 
 // whenever a turn ended before its last tool_update landed), while their
 // terminal updates tore down a genuinely pending prompt — a background tool
 // completing would clear the icon while the foreground turn was still blocked.
+// The exact request types are matched before the generic requests_input flag, so
+// a permission row that ever starts carrying the flag stays a permission rather
+// than silently degrading to a clarification.
 func pendingActionForMessage(messageType string, requestsInput bool) string {
-	if messageType == messageTypeClarificationRequest || requestsInput {
-		return pendingClarification
-	}
 	if messageType == messageTypePermissionRequest {
 		return pendingPermission
+	}
+	if messageType == messageTypeClarificationRequest || requestsInput {
+		return pendingClarification
 	}
 	return ""
 }

--- a/apps/backend/internal/task/statussummary/projector.go
+++ b/apps/backend/internal/task/statussummary/projector.go
@@ -699,32 +699,49 @@ func (p *Projector) applyPendingMessageLocked(state *projectionState, eventType 
 	messageType := strings.ToLower(stringField(data, "type"))
 	metadata, _ := data["metadata"].(map[string]interface{})
 	status := strings.ToLower(stringField(metadata, "status"))
-	isPendingMessage := boolValue(data["requests_input"]) ||
-		messageType == "clarification_request" || messageType == "permission_request"
-	isTrackedMessage := isPendingMessage || stringField(metadata, "pending_id") != "" || status != ""
-	if !isTrackedMessage {
+	action := pendingActionForMessage(messageType, boolValue(data["requests_input"]))
+	if action == "" {
 		return false
 	}
 	state.pendingObserved = true
-	// A terminal status means the prompt is no longer awaiting the user, whatever
-	// the message type. Resolutions land as a message.updated on the request row
-	// itself (approved/rejected/expired for permissions, answered/rejected/
-	// cancelled/expired for clarifications), so gating the clear on "not a
-	// request message" left the task-list affordance armed after the user had
-	// already answered. Only the empty and "pending" statuses keep it armed —
-	// that covers a detached-but-answerable clarification, which stays pending.
+	// A terminal status on the request row means the prompt is no longer awaiting
+	// the user. Resolutions land as a message.updated on that row (approved/
+	// rejected/expired for permissions, answered/rejected/cancelled/expired for
+	// clarifications), so gating the clear on "not a request message" left the
+	// task-list affordance armed after the user had already answered. Only the
+	// empty and "pending" statuses keep it armed — that covers a
+	// detached-but-answerable clarification, which stays pending.
 	if eventType == events.MessageDeleted || (status != "" && status != statusPending) {
 		return p.clearPendingLocked(state, sessionID)
-	}
-	action := pendingPermission
-	if messageType == "clarification_request" || boolValue(data["requests_input"]) {
-		action = pendingClarification
 	}
 	if state.pending[sessionID] == action {
 		return false
 	}
 	state.pending[sessionID] = action
 	return true
+}
+
+// pendingActionForMessage maps a message to the task-row affordance it drives,
+// or "" when the message asks the user for nothing. A message that asks for
+// nothing is not evidence about the pending state in either direction, so the
+// caller ignores it rather than letting it arm or clear the affordance.
+//
+// The distinction matters because a status of "pending" is not exclusive to
+// prompts: every announced tool call is persisted with the raw ACP tool status,
+// which starts at "pending" and only becomes in_progress/complete on the first
+// tool_update. Treating those rows as prompts made the amber "waiting on you"
+// icon flash onto the task row for every tool call the agent made (and stick
+// whenever a turn ended before its last tool_update landed), while their
+// terminal updates tore down a genuinely pending prompt — a background tool
+// completing would clear the icon while the foreground turn was still blocked.
+func pendingActionForMessage(messageType string, requestsInput bool) string {
+	if messageType == messageTypeClarificationRequest || requestsInput {
+		return pendingClarification
+	}
+	if messageType == messageTypePermissionRequest {
+		return pendingPermission
+	}
+	return ""
 }
 
 func (p *Projector) applyGitEventLocked(state *projectionState, data map[string]interface{}) bool {

--- a/apps/backend/internal/task/statussummary/projector_test.go
+++ b/apps/backend/internal/task/statussummary/projector_test.go
@@ -863,3 +863,29 @@ func TestProjectorKeepsPendingAcrossUnrelatedToolTraffic(t *testing.T) {
 		}
 	}
 }
+
+// The exact request type wins over the generic requests_input flag, so a
+// permission row is never classified as a clarification.
+func TestPendingActionForMessagePrefersExactRequestType(t *testing.T) {
+	cases := []struct {
+		messageType   string
+		requestsInput bool
+		want          string
+	}{
+		{messageTypePermissionRequest, false, pendingPermission},
+		{messageTypePermissionRequest, true, pendingPermission},
+		{messageTypeClarificationRequest, false, pendingClarification},
+		{messageTypeClarificationRequest, true, pendingClarification},
+		{"message", true, pendingClarification},
+		{"tool_execute", false, ""},
+		{"tool_execute", true, pendingClarification},
+		{"", false, ""},
+	}
+	for _, tc := range cases {
+		got := pendingActionForMessage(tc.messageType, tc.requestsInput)
+		if got != tc.want {
+			t.Errorf("pendingActionForMessage(%q, %t) = %q, want %q",
+				tc.messageType, tc.requestsInput, got, tc.want)
+		}
+	}
+}

--- a/apps/backend/internal/task/statussummary/projector_test.go
+++ b/apps/backend/internal/task/statussummary/projector_test.go
@@ -770,3 +770,96 @@ func TestProjectorKeepsPendingWhenRequestStaysAnswerable(t *testing.T) {
 		t.Fatalf("pending action after detach = %+v, want clarification", got)
 	}
 }
+
+// Every announced tool call is persisted with metadata.status="pending" (the raw
+// ACP tool status) before its first tool_update arrives. That is ordinary agent
+// work, not a prompt waiting on the user, so it must never arm the amber
+// permission affordance on the task row.
+func TestProjectorIgnoresPendingToolCallMessages(t *testing.T) {
+	for _, messageType := range []string{"tool_call", "tool_execute", "tool_read", "tool_edit", "tool_search"} {
+		t.Run(messageType, func(t *testing.T) {
+			_, store, eventBus, _, _ := newProjectorTest(t)
+			taskID := "task-pending-tool-" + messageType
+			sessionID := "session-pending-tool-" + messageType
+
+			publishSessionState(t, eventBus, taskID, sessionID, nil)
+			publishProjectorEvent(t, eventBus, events.MessageAdded, events.MessageAdded, map[string]interface{}{
+				"task_id":     taskID,
+				"session_id":  sessionID,
+				"author_type": "agent",
+				"type":        messageType,
+				"metadata": map[string]interface{}{
+					"status":       statusPending,
+					"tool_call_id": "tool-1",
+					"title":        "Terminal",
+				},
+			})
+
+			got := store.summary(taskID)
+			if got == nil {
+				t.Fatal("missing projected summary")
+			}
+			if got.PendingAction != "" {
+				t.Fatalf("pending action for a pending %s = %q, want empty", messageType, got.PendingAction)
+			}
+		})
+	}
+}
+
+// A message that merely carries a pending_id must not default to the permission
+// affordance either: only a real permission_request does.
+func TestProjectorDoesNotDefaultUnknownPendingMessagesToPermission(t *testing.T) {
+	_, store, eventBus, _, _ := newProjectorTest(t)
+	const taskID = "task-pending-unknown"
+	const sessionID = "session-pending-unknown"
+
+	publishSessionState(t, eventBus, taskID, sessionID, nil)
+	publishProjectorEvent(t, eventBus, events.MessageAdded, events.MessageAdded, map[string]interface{}{
+		"task_id":     taskID,
+		"session_id":  sessionID,
+		"author_type": "agent",
+		"type":        "status",
+		"metadata":    map[string]interface{}{"status": statusPending, "pending_id": "pending-1"},
+	})
+
+	got := store.summary(taskID)
+	if got == nil {
+		t.Fatal("missing projected summary")
+	}
+	if got.PendingAction != "" {
+		t.Fatalf("pending action for an untyped pending message = %q, want empty", got.PendingAction)
+	}
+}
+
+// A genuinely pending permission must survive unrelated agent traffic in the
+// same session — a background tool call completing while the foreground turn is
+// blocked on the prompt must not tear down the affordance the user still has to
+// act on.
+func TestProjectorKeepsPendingAcrossUnrelatedToolTraffic(t *testing.T) {
+	_, store, eventBus, _, _ := newProjectorTest(t)
+	const taskID = "task-pending-unrelated-tools"
+	const sessionID = "session-pending-unrelated-tools"
+
+	publishSessionState(t, eventBus, taskID, sessionID, nil)
+	publishProjectorEvent(t, eventBus, events.PermissionRequestReceived, events.BuildPermissionRequestSubject(sessionID), map[string]interface{}{
+		"task_id":    taskID,
+		"session_id": sessionID,
+	})
+	if got := store.summary(taskID); got == nil || got.PendingAction != pendingPermission {
+		t.Fatalf("pending action before tool traffic = %+v, want permission", got)
+	}
+
+	for _, status := range []string{"complete", "error", "cancelled"} {
+		publishProjectorEvent(t, eventBus, events.MessageUpdated, events.MessageUpdated, map[string]interface{}{
+			"task_id":     taskID,
+			"session_id":  sessionID,
+			"author_type": "agent",
+			"type":        "tool_execute",
+			"metadata":    map[string]interface{}{"status": status, "tool_call_id": "background-1"},
+		})
+		got := store.summary(taskID)
+		if got == nil || got.PendingAction != pendingPermission {
+			t.Fatalf("pending action after a %q tool update = %+v, want permission", status, got)
+		}
+	}
+}


### PR DESCRIPTION
The amber "waiting on you" icon appeared on task rows that had asked for nothing, because the pending-input projection read any message carrying a metadata status as a prompt — and tool calls are persisted with the raw ACP tool status, which starts at `pending`. Pending state is now projected only from messages that actually ask the user something, so the icon appears exactly when a prompt is outstanding.

## Important Changes

- `applyPendingMessageLocked` no longer defaults non-clarification messages to `permission`. Every announced tool call armed the icon, and it stuck whenever a turn ended before the last `tool_update` landed.
- The clear path is now symmetric. Previously a terminal status on *any* message tore the affordance down, so a background tool completing cleared the icon while the foreground turn was still blocked on a real permission prompt. Non-request messages are ignored in both directions rather than tracked.

Resolutions still clear the icon: `handlePermissionCancelledEvent` and `task_operations.go` write the terminal status back onto the request row itself, so the `message.updated` that #2343 fixed is unaffected.

## Validation

- `go test -race ./internal/task/statussummary/` — new coverage for pending `tool_call` / `tool_execute` / `tool_read` / `tool_edit` / `tool_search` rows, an untyped row carrying only a `pending_id`, and a genuine permission surviving unrelated tool traffic.
- Each new test mutation-checked against the defect it guards: restoring the `permission` default fails the tool-type cases, restoring the broad tracking fails the over-clear case, and breaking the clear still fails all five `TestProjectorClearsPendingWhenRequestMessageResolves` subtests (#2343 stays guarded).
- `go build ./...`, `go test ./internal/orchestrator/... ./internal/task/repository/...` — pass.
- `golangci-lint run ./internal/task/statussummary/... --new-from-rev=origin/main` — 0 issues.
- Backend-only change, no `apps/web/` files touched, so no screenshots apply.

## Possible Improvements

Low risk. The projection is now stricter about what counts as evidence, so a prompt resolved without writing a terminal status back to its request row would stay armed longer than before; no such path exists today, and the incidental clear it replaces was the cause of the over-clear bug.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2406?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->