### PR TITLE
fix(backend): detect WSAEADDRINUSE so Windows port-bind retries actually fire

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -377,8 +377,14 @@ jobs:
       # in source with a documented reason. The shell-fixture tests now use
       # a self-hosting Go helper (see testmain_test.go) so they run on
       # every platform.
+      # portutil carries the cross-platform "address already in use" check.
+      # It builds and vets clean everywhere, so only a real double-bind on
+      # Windows tells WSAEADDRINUSE apart from syscall.EADDRINUSE — without
+      # this entry the regression is invisible to CI. Its callers
+      # (agentctl/server/instance, gateway/websocket) only delegate to it and
+      # are deliberately left out: they carry unrelated shell-dependent tests.
       - name: Test windows-sensitive packages
-        run: go test -race -v ./internal/agentctl/server/process/... ./internal/agent/runtime/agentctl/launcher/...
+        run: go test -race -v ./internal/agentctl/server/process/... ./internal/agent/runtime/agentctl/launcher/... ./internal/common/portutil/...
 
       # Keep this targeted: the service package has broad subprocess coverage,
       # while this native test is the Windows path-semantics regression.

--- a/apps/backend/internal/agentctl/server/instance/manager.go
+++ b/apps/backend/internal/agentctl/server/instance/manager.go
@@ -10,13 +10,13 @@ import (
 	"os/exec"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/kandev/kandev/internal/agentctl/server/config"
 	"github.com/kandev/kandev/internal/agentctl/server/process"
 	"github.com/kandev/kandev/internal/common/logger"
+	"github.com/kandev/kandev/internal/common/portutil"
 	"github.com/kandev/kandev/pkg/agent"
 	"go.uber.org/zap"
 )
@@ -303,7 +303,7 @@ func (m *Manager) allocatePortAndListener(id string) (int, net.Listener, error) 
 		// all interfaces so Docker/remote executors can reach the instance.
 		ln, err := net.Listen("tcp", fmt.Sprintf("%s:%d", m.config.ListenHost(), allocated))
 		if err != nil {
-			if errors.Is(err, syscall.EADDRINUSE) || strings.Contains(err.Error(), "address already in use") {
+			if portutil.IsAddrInUse(err) {
 				m.portAlloc.MarkUnavailable(allocated)
 				m.logger.Warn("port already in use; retrying",
 					zap.String("instance_id", id),

--- a/apps/backend/internal/common/portutil/addrinuse.go
+++ b/apps/backend/internal/common/portutil/addrinuse.go
@@ -1,0 +1,30 @@
+package portutil
+
+import (
+	"errors"
+	"syscall"
+)
+
+// IsAddrInUse reports whether err is the operating system's "address already
+// in use" bind failure, on every platform kandev builds for.
+//
+// Testing errors.Is(err, syscall.EADDRINUSE) alone is not enough. On Windows
+// the runtime returns the winsock code WSAEADDRINUSE (10048), while
+// syscall.EADDRINUSE in the Windows syscall package is a distinct synthetic
+// value (536870914) that no bind ever produces. The comparison is therefore
+// always false there, and callers silently lose the retry path they wrote —
+// see isPlatformAddrInUse in addrinuse_windows.go.
+//
+// Matching on the error text is not a workaround either: Windows words the
+// failure as "Only one usage of each socket address ... is normally
+// permitted", which shares no substring with the Unix "address already in
+// use", and both strings are localized by the OS.
+func IsAddrInUse(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, syscall.EADDRINUSE) {
+		return true
+	}
+	return isPlatformAddrInUse(err)
+}

--- a/apps/backend/internal/common/portutil/addrinuse_other.go
+++ b/apps/backend/internal/common/portutil/addrinuse_other.go
@@ -1,0 +1,7 @@
+//go:build !windows
+
+package portutil
+
+// isPlatformAddrInUse has nothing to add outside Windows: syscall.EADDRINUSE
+// is the code the kernel actually reports, and IsAddrInUse already matched it.
+func isPlatformAddrInUse(error) bool { return false }

--- a/apps/backend/internal/common/portutil/addrinuse_test.go
+++ b/apps/backend/internal/common/portutil/addrinuse_test.go
@@ -1,0 +1,63 @@
+package portutil
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"syscall"
+	"testing"
+)
+
+// TestIsAddrInUseRealBind is the regression that matters: it binds a real
+// socket twice and asserts the helper recognizes the failure. It runs on every
+// platform, which is the point — the bug this replaces was a comparison that
+// only ever failed on Windows, so no amount of synthetic error fixtures on a
+// Linux runner would have caught it.
+func TestIsAddrInUseRealBind(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("net.Listen() failed: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	second, err := net.Listen("tcp", ln.Addr().String())
+	if err == nil {
+		_ = second.Close()
+		t.Fatalf("second net.Listen(%q) unexpectedly succeeded", ln.Addr())
+	}
+
+	if !IsAddrInUse(err) {
+		t.Fatalf("IsAddrInUse(%v) = false, want true (errno chain: %s)", err, describeErrno(err))
+	}
+}
+
+func TestIsAddrInUseRejectsUnrelated(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{"nil", nil},
+		{"plain", errors.New("boom")},
+		{"other syscall error", &net.OpError{
+			Op:  "listen",
+			Net: "tcp",
+			Err: &os.SyscallError{Syscall: "bind", Err: syscall.EACCES},
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if IsAddrInUse(tc.err) {
+				t.Fatalf("IsAddrInUse(%v) = true, want false", tc.err)
+			}
+		})
+	}
+}
+
+func describeErrno(err error) string {
+	var errno syscall.Errno
+	if errors.As(err, &errno) {
+		return fmt.Sprintf("syscall.Errno(%d)", uintptr(errno))
+	}
+	return "no syscall.Errno in chain"
+}

--- a/apps/backend/internal/common/portutil/addrinuse_windows.go
+++ b/apps/backend/internal/common/portutil/addrinuse_windows.go
@@ -1,0 +1,16 @@
+//go:build windows
+
+package portutil
+
+import (
+	"errors"
+
+	"golang.org/x/sys/windows"
+)
+
+// isPlatformAddrInUse covers the winsock code a real bind failure carries.
+// net.Listen wraps it as *net.OpError -> *os.SyscallError -> syscall.Errno,
+// and errors.Is unwraps the chain for us.
+func isPlatformAddrInUse(err error) bool {
+	return errors.Is(err, windows.WSAEADDRINUSE)
+}

--- a/apps/backend/internal/gateway/websocket/port_tunnel.go
+++ b/apps/backend/internal/gateway/websocket/port_tunnel.go
@@ -2,22 +2,20 @@ package websocket
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
-	"os"
 	"strconv"
 	"strings"
 	"sync"
-	"syscall"
 
 	"go.uber.org/zap"
 
 	"github.com/kandev/kandev/internal/agent/runtime/lifecycle"
 	"github.com/kandev/kandev/internal/common/logger"
+	"github.com/kandev/kandev/internal/common/portutil"
 )
 
 // TunnelInfo describes an active tunnel binding.
@@ -139,7 +137,7 @@ func (m *TunnelManager) resolveAndBind(cacheKey, sessionID string, tunnelPort in
 	ln, err := net.Listen("tcp", fmt.Sprintf(":%d", tunnelPort))
 	if err != nil {
 		cleanup()
-		if isAddrInUse(err) {
+		if portutil.IsAddrInUse(err) {
 			return nil, "", nil, fmt.Errorf("port %d is already in use, choose a different port", tunnelPort)
 		}
 		return nil, "", nil, fmt.Errorf("failed to bind tunnel port %d: %w", tunnelPort, err)
@@ -253,17 +251,6 @@ func (m *TunnelManager) Shutdown() {
 	if len(entries) > 0 {
 		m.logger.Info("shutdown all tunnels", zap.Int("count", len(entries)))
 	}
-}
-
-func isAddrInUse(err error) bool {
-	var opErr *net.OpError
-	if errors.As(err, &opErr) {
-		var sysErr *os.SyscallError
-		if errors.As(opErr.Err, &sysErr) {
-			return errors.Is(sysErr.Err, syscall.EADDRINUSE)
-		}
-	}
-	return false
 }
 
 func (m *TunnelManager) removeTunnel(cacheKey string) {


### PR DESCRIPTION
On Windows the "address already in use" guards in `allocatePortAndListener` and the websocket port tunnel never match, so the first occupied port in the 41001–41100 range is a hard failure instead of a retry and every agent instance fails to start while anything else holds 41001. Both call sites now go through a shared `portutil.IsAddrInUse` that also recognizes the winsock code.

## Important Changes

- `portutil.IsAddrInUse` centralizes the check; the `//go:build windows` variant tests `windows.WSAEADDRINUSE` (10048), which is what a real bind failure carries — `syscall.EADDRINUSE` there is a synthetic 536870914 that no bind ever produces.
- The `strings.Contains(err, "address already in use")` fallback is gone: the Windows wording shares no substring with the Unix one, and both are localized by the OS.
- `./internal/common/portutil/...` joins the `Backend (windows)` job's test scope. `go build` and `go vet` already run there and pass on every platform — neither notices an `errors.Is` that silently returns `false`, which is why this survived.

## Validation

Measured on Windows 11 (amd64) with two `net.Listen` calls on the same address, before the change:

```
err.Error() = "listen tcp 127.0.0.1:58538: bind: Only one usage of each socket
               address (protocol/network address/port) is normally permitted."

errors.Is(err, syscall.EADDRINUSE)              = false
strings.Contains(err, "address already in use") = false
syscall.Errno actually returned                 = 10048
syscall.EADDRINUSE on windows/amd64             = 536870914
```

- `go build -tags fts5 ./...` — pass
- `go vet -tags fts5` on the three touched packages — pass
- `go test -tags fts5 -race ./internal/common/portutil/...` — pass, including the new real-double-bind regression
- `gofmt -d` on every touched file — clean

The two `mcp_validation_test.go` failures visible locally in `internal/agentctl/server/instance` are pre-existing and environmental (`exec: "sh": executable file not found`), unrelated to this change.

## Possible Improvements

Low risk: the helper only widens what counts as "in use", so a missed match degrades to today's behaviour rather than introducing a new failure. `internal/agentctl/server/instance` and `internal/gateway/websocket` were deliberately left out of the Windows CI job — they carry unrelated shell-dependent tests that would redden it.

Closes #2371

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2407?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->