### PR TITLE
fix(agentctl): extend the inherited PATH key when prepending the GitHub CLI shim

### DIFF
--- a/apps/backend/internal/agentctl/server/config/config.go
+++ b/apps/backend/internal/agentctl/server/config/config.go
@@ -663,8 +663,9 @@ func prependPathEntry(env map[string]string, entry string) {
 	if entry == "" {
 		return
 	}
+	key := searchPathKey(env, runtime.GOOS == "windows")
 	cleanEntry := filepath.Clean(entry)
-	parts := filepath.SplitList(env["PATH"])
+	parts := filepath.SplitList(env[key])
 	filtered := make([]string, 0, len(parts)+1)
 	filtered = append(filtered, entry)
 	for _, part := range parts {
@@ -672,7 +673,35 @@ func prependPathEntry(env map[string]string, entry string) {
 			filtered = append(filtered, part)
 		}
 	}
-	env["PATH"] = strings.Join(filtered, string(os.PathListSeparator))
+	env[key] = strings.Join(filtered, string(os.PathListSeparator))
+}
+
+// searchPathKey returns the key env already carries the executable search path
+// under. Windows inherits it as "Path" and matches variable names
+// case-insensitively, so writing "PATH" leaves the inherited entry in place and
+// adds a second variable holding only the shim directory. The agent is launched
+// through `cmd /c`, which then resolves against that variable alone and dies
+// with "'npx' is not recognized" — the shim dir is all it can see.
+//
+// Unix variable names are case-sensitive, so a "Path" there is a genuinely
+// different variable and must not be mistaken for the search path; the fold is
+// gated on caseInsensitive, matching how environmentValue in
+// internal/tools/installer scopes the same lookup to Windows. The flag is a
+// parameter rather than a runtime.GOOS read inside so the Windows branch stays
+// testable on every runner. An exact "PATH" always wins, so a caller-supplied
+// key still takes precedence over an inherited case variant.
+func searchPathKey(env map[string]string, caseInsensitive bool) string {
+	if _, ok := env["PATH"]; ok {
+		return "PATH"
+	}
+	if caseInsensitive {
+		for key := range env {
+			if strings.EqualFold(key, "PATH") {
+				return key
+			}
+		}
+	}
+	return "PATH"
 }
 
 func envBool(env []string, key string) bool {

--- a/apps/backend/internal/agentctl/server/config/config.go
+++ b/apps/backend/internal/agentctl/server/config/config.go
@@ -570,7 +570,7 @@ func CollectAgentEnvWithError(additional map[string]string) ([]string, error) {
 		return nil, fmt.Errorf("compose indexed Git config: %w", err)
 	}
 	if envMap[githubauth.CredentialBrokerURLEnv] != "" {
-		prependPathEntry(envMap, envMap[githubauth.CredentialCLIShimDirEnv])
+		prependPathEntry(envMap, envMap[githubauth.CredentialCLIShimDirEnv], runtime.GOOS == "windows")
 		configureGitHubCLIStartupEnv(envMap)
 	}
 
@@ -659,11 +659,11 @@ func isBashEnvNameByte(value byte, first bool) bool {
 	return letter || value == '_' || !first && value >= '0' && value <= '9'
 }
 
-func prependPathEntry(env map[string]string, entry string) {
+func prependPathEntry(env map[string]string, entry string, caseInsensitive bool) {
 	if entry == "" {
 		return
 	}
-	key := searchPathKey(env, runtime.GOOS == "windows")
+	key := searchPathKey(env, caseInsensitive)
 	cleanEntry := filepath.Clean(entry)
 	parts := filepath.SplitList(env[key])
 	filtered := make([]string, 0, len(parts)+1)

--- a/apps/backend/internal/agentctl/server/config/config_test.go
+++ b/apps/backend/internal/agentctl/server/config/config_test.go
@@ -24,10 +24,50 @@ func TestNewInstanceConfigNormalizesMcpProviders(t *testing.T) {
 func TestCollectAgentEnvKeepsGitHubCLIShimAheadOfProfilePath(t *testing.T) {
 	t.Setenv("KANDEV_GITHUB_CREDENTIAL_BROKER_URL", "https://kandev.example/api/github/credentials/resolve")
 	t.Setenv("KANDEV_GITHUB_CLI_SHIM_DIR", "/kandev/shims")
-	env := CollectAgentEnv(map[string]string{"PATH": "/profile/bin:/usr/bin"})
+	// The profile path is joined with the platform separator rather than a
+	// literal ":" so SplitList sees two entries on Windows too — hardcoding the
+	// Unix separator made this fail there with the shim ahead of one unsplit entry.
+	profilePath := strings.Join([]string{"/profile/bin", "/usr/bin"}, string(os.PathListSeparator))
+	env := CollectAgentEnv(map[string]string{"PATH": profilePath})
 	want := strings.Join([]string{"/kandev/shims", "/profile/bin", "/usr/bin"}, string(os.PathListSeparator))
 	if got := envSliceValue(env, "PATH"); got != want {
 		t.Fatalf("PATH = %q, want %q", got, want)
+	}
+}
+
+// Windows hands the search path down as "Path". Writing "PATH" used to leave
+// that untouched and add a second variable holding only the shim directory, so
+// `cmd /c npx …` resolved against the shim dir alone and the agent died with
+// "'npx' is not recognized". Both branches are exercised through the parameter
+// rather than runtime.GOOS so the regression is caught on every runner.
+func TestSearchPathKey(t *testing.T) {
+	inherited := map[string]string{"Path": "/node/bin"}
+	if got := searchPathKey(inherited, true); got != "Path" {
+		t.Fatalf("searchPathKey(case-insensitive) = %q, want the inherited %q", got, "Path")
+	}
+	if got := searchPathKey(inherited, false); got != "PATH" {
+		t.Fatalf("searchPathKey(case-sensitive) = %q, want %q — a Unix \"Path\" is a different variable", got, "PATH")
+	}
+
+	both := map[string]string{"PATH": "/exact", "Path": "/variant"}
+	if got := searchPathKey(both, true); got != "PATH" {
+		t.Fatalf("searchPathKey with both keys = %q, want the exact match to win", got)
+	}
+}
+
+func TestPrependPathEntryExtendsTheKeyItFound(t *testing.T) {
+	env := map[string]string{
+		"PATH": strings.Join([]string{"/node/bin", "/usr/bin"}, string(os.PathListSeparator)),
+	}
+
+	prependPathEntry(env, "/kandev/shims")
+
+	want := strings.Join([]string{"/kandev/shims", "/node/bin", "/usr/bin"}, string(os.PathListSeparator))
+	if env["PATH"] != want {
+		t.Fatalf("PATH = %q, want %q", env["PATH"], want)
+	}
+	if len(env) != 1 {
+		t.Fatalf("prependPathEntry left %d variables, want the one it extended: %v", len(env), env)
 	}
 }
 

--- a/apps/backend/internal/agentctl/server/config/config_test.go
+++ b/apps/backend/internal/agentctl/server/config/config_test.go
@@ -60,7 +60,7 @@ func TestPrependPathEntryExtendsTheKeyItFound(t *testing.T) {
 		"PATH": strings.Join([]string{"/node/bin", "/usr/bin"}, string(os.PathListSeparator)),
 	}
 
-	prependPathEntry(env, "/kandev/shims")
+	prependPathEntry(env, "/kandev/shims", false)
 
 	want := strings.Join([]string{"/kandev/shims", "/node/bin", "/usr/bin"}, string(os.PathListSeparator))
 	if env["PATH"] != want {
@@ -68,6 +68,25 @@ func TestPrependPathEntryExtendsTheKeyItFound(t *testing.T) {
 	}
 	if len(env) != 1 {
 		t.Fatalf("prependPathEntry left %d variables, want the one it extended: %v", len(env), env)
+	}
+}
+
+// The regression itself: an environment carrying only the Windows-style "Path"
+// must have that entry extended, not shadowed by a freshly created "PATH"
+// holding the shim directory alone.
+func TestPrependPathEntryExtendsInheritedWindowsPathKey(t *testing.T) {
+	env := map[string]string{
+		"Path": strings.Join([]string{"/node/bin", "/usr/bin"}, string(os.PathListSeparator)),
+	}
+
+	prependPathEntry(env, "/kandev/shims", true)
+
+	if _, duplicated := env["PATH"]; duplicated {
+		t.Fatalf("prependPathEntry added a second search-path variable: %v", env)
+	}
+	want := strings.Join([]string{"/kandev/shims", "/node/bin", "/usr/bin"}, string(os.PathListSeparator))
+	if env["Path"] != want {
+		t.Fatalf("Path = %q, want %q", env["Path"], want)
 	}
 }
 


### PR DESCRIPTION
## Problem

On Windows, every agent session on a GitHub-backed repository failed immediately:

```
Agent process exited with code 1: 'npx' is not recognized as an internal or external command
```

The failure event carried an empty `acp_session_id` — the agent process never started.

## Cause

`prependPathEntry` puts the GitHub CLI shim directory at the front of PATH when the credential broker is active, reading and writing the map key `"PATH"`.

Windows inherits the search path as `Path` and matches variable names case-insensitively, so the function read an empty value and then wrote a *second* variable containing only the shim directory. The child environment ends up carrying both `Path=<real>` and `PATH=<shim only>`; agents are launched through `cmd /c`, which resolves `npx` against that and finds nothing.

Two things kept this hidden:

- Unix uses the same key name, so the overlay works there, and `sh -lc` additionally re-prepends the shim through `managedGitHubPathRestore`. The Windows branch is a plain `cmd /c` with no equivalent repair.
- The shim is only injected when `KANDEV_GITHUB_CREDENTIAL_BROKER_URL` is set, so only GitHub-backed repositories were affected.

The ACP capability probe was unaffected: it does not go through this composition, and Go resolves the executable from the parent process's PATH rather than from `cmd.Env`.

## Fix

Resolve the key the environment already carries before extending it. The fold is gated on Windows, matching how `environmentValue` in `internal/tools/installer` scopes the same lookup — Unix variable names are case-sensitive, so a `Path` there is a genuinely different variable. An exact `PATH` still wins, so a caller-supplied key keeps precedence.

## Tests

- `TestSearchPathKey` covers the inherited Windows variant, the case-sensitive Unix behaviour, and both keys present. The platform bit is a parameter rather than a `runtime.GOOS` read, so the Windows branch is exercised on every runner.
- `TestPrependPathEntryExtendsTheKeyItFound` asserts no second variable is created.
- `TestCollectAgentEnvKeepsGitHubCLIShimAheadOfProfilePath` hardcoded the Unix `:` separator and failed on Windows; it now builds its input with `os.PathListSeparator`.

## Verified on Windows 11

Before, the failure event carried `recent_stderr: ["'npx' is not recognized …"]` and an empty `acp_session_id`. After, the same `agent_command` reaches a live ACP session with a populated session id and no stderr.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2415?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->