### PR TITLE
fix(agentctl): accept the Windows executable suffix in the ACP probe allow-list

### DIFF
--- a/apps/backend/internal/agentctl/server/utility/acp_executor.go
+++ b/apps/backend/internal/agentctl/server/utility/acp_executor.go
@@ -854,16 +854,23 @@ var allowedProbeCommands = map[string]string{
 //
 // An agent launched from an absolute path arrives here carrying the executable
 // suffix Windows requires — "mock-agent.exe" — which never matches the bare
-// allow-list key, so its probe is refused before it can spawn. The suffix is
-// stripped only on Windows: Unix executables carry no such convention, and
-// trimming an extension there would let "opencode.sh" pass as "opencode".
+// allow-list key, so its probe is refused before it can spawn.
+//
+// Only ".exe" is trimmed, and only on Windows. That is the suffix the Go build
+// emits, so it is the only one an allow-listed binary can arrive with; trimming
+// whatever filepath.Ext returns would instead let "mock-agent.cmd" or
+// "mock-agent.txt" reach an allow-listed entry. Unix executables carry no such
+// convention at all, and trimming there would let "opencode.sh" pass as
+// "opencode".
 func resolveProbeCommand(name string) string {
 	base := filepath.Base(name)
 	if resolved, ok := allowedProbeCommands[base]; ok {
 		return resolved
 	}
 	if runtime.GOOS == "windows" {
-		return allowedProbeCommands[strings.TrimSuffix(base, filepath.Ext(base))]
+		if ext := filepath.Ext(base); strings.EqualFold(ext, ".exe") {
+			return allowedProbeCommands[strings.TrimSuffix(base, ext)]
+		}
 	}
 	return ""
 }

--- a/apps/backend/internal/agentctl/server/utility/acp_executor.go
+++ b/apps/backend/internal/agentctl/server/utility/acp_executor.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -850,8 +851,21 @@ var allowedProbeCommands = map[string]string{
 
 // resolveProbeCommand validates and returns a hard-coded executable name for
 // the given command. Returns the empty string if the command is not allowed.
+//
+// An agent launched from an absolute path arrives here carrying the executable
+// suffix Windows requires — "mock-agent.exe" — which never matches the bare
+// allow-list key, so its probe is refused before it can spawn. The suffix is
+// stripped only on Windows: Unix executables carry no such convention, and
+// trimming an extension there would let "opencode.sh" pass as "opencode".
 func resolveProbeCommand(name string) string {
-	return allowedProbeCommands[filepath.Base(name)]
+	base := filepath.Base(name)
+	if resolved, ok := allowedProbeCommands[base]; ok {
+		return resolved
+	}
+	if runtime.GOOS == "windows" {
+		return allowedProbeCommands[strings.TrimSuffix(base, filepath.Ext(base))]
+	}
+	return ""
 }
 
 // sanitizeEnvForAgent returns a child-process environment with agent-declared

--- a/apps/backend/internal/agentctl/server/utility/acp_executor_test.go
+++ b/apps/backend/internal/agentctl/server/utility/acp_executor_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"maps"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strings"
 	"testing"
@@ -97,6 +98,28 @@ func TestResolveProbeCommand_RejectsUnknown(t *testing.T) {
 	t.Parallel()
 	if got := resolveProbeCommand("claude"); got != "" {
 		t.Fatalf("resolveProbeCommand(claude) = %q, want empty", got)
+	}
+}
+
+// The mock agent is the one allow-listed command launched from an absolute
+// path, so on Windows it reaches this lookup as "mock-agent.exe". The coverage
+// above builds Unix-style paths, whose base name never carries an executable
+// suffix, which is why the gap passed on every runner including Windows.
+func TestResolveProbeCommand_ExecutableSuffix(t *testing.T) {
+	t.Parallel()
+
+	const name = "mock-agent"
+	path := filepath.Join(t.TempDir(), name+".exe")
+
+	got := resolveProbeCommand(path)
+	if runtime.GOOS == "windows" {
+		if got != name {
+			t.Fatalf("resolveProbeCommand(%q) = %q, want %q", path, got, name)
+		}
+		return
+	}
+	if got != "" {
+		t.Fatalf("resolveProbeCommand(%q) = %q, want empty — a Unix name keeps its suffix", path, got)
 	}
 }
 

--- a/apps/backend/internal/agentctl/server/utility/acp_executor_test.go
+++ b/apps/backend/internal/agentctl/server/utility/acp_executor_test.go
@@ -109,17 +109,34 @@ func TestResolveProbeCommand_ExecutableSuffix(t *testing.T) {
 	t.Parallel()
 
 	const name = "mock-agent"
-	path := filepath.Join(t.TempDir(), name+".exe")
+	dir := t.TempDir()
 
-	got := resolveProbeCommand(path)
-	if runtime.GOOS == "windows" {
-		if got != name {
-			t.Fatalf("resolveProbeCommand(%q) = %q, want %q", path, got, name)
-		}
-		return
-	}
-	if got != "" {
-		t.Fatalf("resolveProbeCommand(%q) = %q, want empty — a Unix name keeps its suffix", path, got)
+	for _, tc := range []struct {
+		file        string
+		wantWindows string
+	}{
+		{file: name + ".exe", wantWindows: name},
+		{file: name + ".EXE", wantWindows: name},
+		{file: name + ".cmd", wantWindows: ""},
+		{file: name + ".txt", wantWindows: ""},
+		{file: name + ".exe.txt", wantWindows: ""},
+	} {
+		t.Run(tc.file, func(t *testing.T) {
+			t.Parallel()
+
+			path := filepath.Join(dir, tc.file)
+			got := resolveProbeCommand(path)
+
+			// Only Windows trims, and only ".exe" — any other suffix, and any
+			// suffix at all on Unix, leaves the name unmatched.
+			want := ""
+			if runtime.GOOS == "windows" {
+				want = tc.wantWindows
+			}
+			if got != want {
+				t.Fatalf("resolveProbeCommand(%q) = %q, want %q", path, got, want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Problem

On Windows the mock agent's capability probe is refused before it can spawn:

```
command "…\apps\backend\bin\mock-agent.exe" is not an allowed ACP probe command
```

`resolveProbeCommand` looks the command up as `allowedProbeCommands[filepath.Base(name)]`. The mock agent is the one allow-listed command launched from an absolute path, so on Windows its base name is `mock-agent.exe` while the allow-list key is `mock-agent`. The same gate guards one-shot inference, so both paths are blocked.

## Fix

Strip the executable suffix on Windows only. Unix executables carry no such convention, and trimming an extension there would let `opencode.sh` pass as `opencode`.

Two things deliberately unchanged:

- The lookup still returns the hard-coded literal from the map rather than the caller's path, so the taint-tracking rationale in the surrounding comment still holds.
- A name whose stem is not allow-listed is still refused — `evil.exe` resolves to `evil`, which is not in the map.

Case folding is not applied: kandev builds these paths from the binary name, so an upper-case `MOCK-AGENT.EXE` is not a case I have observed, and guessing at it would widen the match on no evidence.

## Why CI did not catch it

`TestResolveProbeCommand_AllowsEveryListedBinary` builds its paths with `filepath.Join("/usr/local/bin", name)`. On Windows that yields `\usr\local\bin\mock-agent`, whose base name still carries no suffix — so the test passed on Windows runners without ever exercising a name that has one. The new test builds its path with `t.TempDir()` and asserts both platforms: the suffix resolves on Windows, and is still refused on Unix.

## Scope, and what this does not fix

Development and E2E only; no user-facing agent is launched from an absolute path today. It matters because the mock agent is what the E2E suite drives, so its capability surface was untestable on Windows.

This removes the incorrect allow-list refusal. It does not by itself turn the mock agent's probe green in a plain dev run: `exec` still resolves the returned literal through `PATH`, and only the E2E harness prepends `apps/backend/bin` (see the comment in `apps/web/e2e/fixtures/backend.ts`). After this change the dev-run failure becomes a spawn failure rather than a refusal, which is at least the honest one.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2422?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->