### PR TITLE
fix(terminal): show an ended session instead of a lying spinner

### DIFF
--- a/apps/web/components/task/passthrough-terminal.tsx
+++ b/apps/web/components/task/passthrough-terminal.tsx
@@ -135,20 +135,46 @@ export function computeCanConnect(
   mode: "agent" | "shell",
   connectionID: string | null | undefined,
   sessionId: string | null | undefined,
-  sessionState?: TaskSessionState | null,
+  environmentEnded = false,
 ): boolean {
   if (!connectionID) return false;
   if (mode === "agent") return Boolean(sessionId);
-  // The env handler refuses a shell whose session has ended, and refuses it
+  // The env handler refuses a shell for a dead environment, and refuses it
   // identically on every attempt. Connecting anyway only restarts the retry
   // timer, so stop before opening the socket at all.
-  return !isSessionEnded(sessionState);
+  return !environmentEnded;
 }
 
 const SESSION_TERMINAL_STATES = new Set<TaskSessionState>(["COMPLETED", "FAILED", "CANCELLED"]);
 
 export function isSessionEnded(state: TaskSessionState | null | undefined): boolean {
   return state != null && SESSION_TERMINAL_STATES.has(state);
+}
+
+/**
+ * Whether every session sharing this environment has ended.
+ *
+ * Shell terminals are environment-scoped, but the session handle this component
+ * holds is not a proxy for one: `useEnvironmentSessionId` deliberately caches
+ * the first session seen for an environment, so once session A ends and session
+ * B reuses that environment, the handle still resolves to A. Gating on A's
+ * state alone would refuse a shell on a live environment — worse than the loop
+ * this exists to stop.
+ *
+ * So refuse only on positive knowledge: sessions for this environment are
+ * known, and every one of them is terminal. Anything unknown connects.
+ */
+export function isEnvironmentEnded(
+  environmentId: string | null | undefined,
+  sessionStateById: Record<string, TaskSessionState | undefined>,
+  environmentIdBySessionId: Record<string, string>,
+): boolean {
+  if (!environmentId) return false;
+  const sessionIds = Object.keys(environmentIdBySessionId).filter(
+    (id) => environmentIdBySessionId[id] === environmentId,
+  );
+  if (sessionIds.length === 0) return false;
+  return sessionIds.every((id) => isSessionEnded(sessionStateById[id]));
 }
 
 /**
@@ -163,11 +189,22 @@ export function isSessionEnded(state: TaskSessionState | null | undefined): bool
  */
 export function computeTerminalPaneState(
   mode: "agent" | "shell",
-  sessionState: TaskSessionState | null | undefined,
+  environmentEnded: boolean,
   isConnected: boolean,
 ): "connected" | "connecting" | "ended" {
-  if (mode === "shell" && isSessionEnded(sessionState)) return "ended";
+  if (mode === "shell" && environmentEnded) return "ended";
   return isConnected ? "connected" : "connecting";
+}
+
+/** Reads the two store slices `isEnvironmentEnded` needs. */
+function useEnvironmentEnded(environmentId: string | null | undefined): boolean {
+  return useAppStore((state) =>
+    isEnvironmentEnded(
+      environmentId,
+      Object.fromEntries(Object.entries(state.taskSessions.items).map(([id, s]) => [id, s?.state])),
+      state.environmentIdBySessionId,
+    ),
+  );
 }
 
 // eslint-disable-next-line max-lines-per-function -- wires many hooks + refs; each block is already its own hook
@@ -196,7 +233,8 @@ export function PassthroughTerminal(props: PassthroughTerminalProps) {
   const { session } = useSession(sessionId);
   const taskId = session?.task_id ?? null;
   const connectionID = mode === "agent" ? sessionId : environmentId;
-  const canConnect = computeCanConnect(mode, connectionID, sessionId, session?.state);
+  const environmentEnded = useEnvironmentEnded(environmentId);
+  const canConnect = computeCanConnect(mode, connectionID, sessionId, environmentEnded);
   const wsBaseUrl = useWsBaseUrl();
 
   const [isTerminalReady, setIsTerminalReady] = useState(false);
@@ -209,7 +247,7 @@ export function PassthroughTerminal(props: PassthroughTerminalProps) {
   // overlay resets on target switches without needing a separate setState effect.
   const [connectedTargetId, setConnectedTargetId] = useState<string | null>(null);
   const isConnected = connectionID != null && connectedTargetId === connectionID;
-  const paneState = computeTerminalPaneState(mode, session?.state, isConnected);
+  const paneState = computeTerminalPaneState(mode, environmentEnded, isConnected);
   const onConnected = useCallback(() => {
     setConnectedTargetId(connectionID ?? null);
     if (autoFocus) refs.xtermRef.current?.textarea?.focus({ preventScroll: true });

--- a/apps/web/components/task/passthrough-terminal.tsx
+++ b/apps/web/components/task/passthrough-terminal.tsx
@@ -9,6 +9,7 @@ import "@xterm/xterm/css/xterm.css";
 import { PanelLoadingState } from "@/components/panel-loading-state";
 import { useAppStore } from "@/components/state-provider";
 import { useSession } from "@/hooks/domains/session/use-session";
+import type { TaskSessionState } from "@/app/office/tasks/[id]/types";
 import { getBackendConfig } from "@/lib/config";
 import { useTerminalLinkHandler } from "@/hooks/use-terminal-link-handler";
 import { buildTerminalFontFamily } from "@/lib/terminal/terminal-font";
@@ -134,15 +135,43 @@ export function computeCanConnect(
   mode: "agent" | "shell",
   connectionID: string | null | undefined,
   sessionId: string | null | undefined,
+  sessionState?: TaskSessionState | null,
 ): boolean {
   if (!connectionID) return false;
   if (mode === "agent") return Boolean(sessionId);
-  return true;
+  // The env handler refuses a shell whose session has ended, and refuses it
+  // identically on every attempt. Connecting anyway only restarts the retry
+  // timer, so stop before opening the socket at all.
+  return !isSessionEnded(sessionState);
+}
+
+const SESSION_TERMINAL_STATES = new Set<TaskSessionState>(["COMPLETED", "FAILED", "CANCELLED"]);
+
+export function isSessionEnded(state: TaskSessionState | null | undefined): boolean {
+  return state != null && SESSION_TERMINAL_STATES.has(state);
+}
+
+/**
+ * What the pane should render. Exported so every state can be asserted without
+ * mounting xterm.
+ *
+ * This is a named function rather than two inline conditions because the
+ * loading overlay is opaque and full-bleed: any state that leaves
+ * `isConnected` false while the terminal will never connect renders a
+ * "connecting…" spinner that is actively false. Deciding it in one place makes
+ * "ended outranks connecting" something a test can pin down.
+ */
+export function computeTerminalPaneState(
+  mode: "agent" | "shell",
+  sessionState: TaskSessionState | null | undefined,
+  isConnected: boolean,
+): "connected" | "connecting" | "ended" {
+  if (mode === "shell" && isSessionEnded(sessionState)) return "ended";
+  return isConnected ? "connected" : "connecting";
 }
 
 // eslint-disable-next-line max-lines-per-function -- wires many hooks + refs; each block is already its own hook
 export function PassthroughTerminal(props: PassthroughTerminalProps) {
-  const { t } = useTranslation();
   const {
     mode,
     label,
@@ -167,7 +196,7 @@ export function PassthroughTerminal(props: PassthroughTerminalProps) {
   const { session } = useSession(sessionId);
   const taskId = session?.task_id ?? null;
   const connectionID = mode === "agent" ? sessionId : environmentId;
-  const canConnect = computeCanConnect(mode, connectionID, sessionId);
+  const canConnect = computeCanConnect(mode, connectionID, sessionId, session?.state);
   const wsBaseUrl = useWsBaseUrl();
 
   const [isTerminalReady, setIsTerminalReady] = useState(false);
@@ -180,6 +209,7 @@ export function PassthroughTerminal(props: PassthroughTerminalProps) {
   // overlay resets on target switches without needing a separate setState effect.
   const [connectedTargetId, setConnectedTargetId] = useState<string | null>(null);
   const isConnected = connectionID != null && connectedTargetId === connectionID;
+  const paneState = computeTerminalPaneState(mode, session?.state, isConnected);
   const onConnected = useCallback(() => {
     setConnectedTargetId(connectionID ?? null);
     if (autoFocus) refs.xtermRef.current?.textarea?.focus({ preventScroll: true });
@@ -278,14 +308,40 @@ export function PassthroughTerminal(props: PassthroughTerminalProps) {
         <div ref={terminalRef} data-testid="terminal-xterm-host" className="h-full w-full" />
       </div>
       <TerminalSearchBar search={search} />
-      {!isConnected && (
-        <PanelLoadingState
-          testId="passthrough-loading"
-          className="absolute inset-0 bg-background"
-          label={mode === "agent" ? t("task:preparingWorkspace") : t("task:connectingTerminal")}
-        />
-      )}
+      <TerminalPaneOverlay paneState={paneState} mode={mode} />
     </div>
+  );
+}
+
+/**
+ * Covers the pane while it is not usable. Both branches are opaque and
+ * full-bleed, so which one renders is the only thing the user ever sees here.
+ */
+function TerminalPaneOverlay({
+  paneState,
+  mode,
+}: {
+  paneState: ReturnType<typeof computeTerminalPaneState>;
+  mode: "agent" | "shell";
+}) {
+  const { t } = useTranslation();
+  if (paneState === "connected") return null;
+  if (paneState === "ended") {
+    return (
+      <div
+        data-testid="passthrough-session-ended"
+        className="absolute inset-0 bg-background flex items-center justify-center p-4 text-center text-xs text-muted-foreground"
+      >
+        {t("task:terminalSessionEnded")}
+      </div>
+    );
+  }
+  return (
+    <PanelLoadingState
+      testId="passthrough-loading"
+      className="absolute inset-0 bg-background"
+      label={mode === "agent" ? t("task:preparingWorkspace") : t("task:connectingTerminal")}
+    />
   );
 }
 

--- a/apps/web/components/task/use-passthrough-terminal.test.ts
+++ b/apps/web/components/task/use-passthrough-terminal.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildTerminalWsUrl } from "./use-passthrough-terminal";
-import { computeCanConnect } from "./passthrough-terminal";
+import { computeCanConnect, computeTerminalPaneState } from "./passthrough-terminal";
+import type { TaskSessionState } from "@/app/office/tasks/[id]/types";
 import { reconnectDelayMs, startReconnectLoop } from "./ws-reconnect";
 import type { Terminal } from "@xterm/xterm";
 
@@ -128,5 +129,52 @@ describe("startReconnectLoop", () => {
     expect(connectWebSocket).toHaveBeenCalledTimes(2);
     expect(terminal.reset).toHaveBeenCalledTimes(2);
     stop();
+  });
+});
+
+// The env handler refuses a shell on an ended session, identically every time.
+// Opening the socket anyway only restarts the 5s retry timer.
+describe("computeCanConnect on ended sessions", () => {
+  const ENDED: TaskSessionState[] = ["COMPLETED", "FAILED", "CANCELLED"];
+  const LIVE: TaskSessionState[] = ["CREATED", "STARTING", "RUNNING", "IDLE", "WAITING_FOR_INPUT"];
+
+  it.each(ENDED)("refuses a shell terminal on a %s session", (state) => {
+    expect(computeCanConnect("shell", "env-1", "session-1", state)).toBe(false);
+  });
+
+  it.each(LIVE)("still connects a shell terminal on a %s session", (state) => {
+    expect(computeCanConnect("shell", "env-1", "session-1", state)).toBe(true);
+  });
+
+  it("connects when the session state is not known yet", () => {
+    expect(computeCanConnect("shell", "env-1", "session-1", null)).toBe(true);
+  });
+
+  // Agent terminals resolve readiness server-side and must keep waiting.
+  it.each(ENDED)("leaves agent terminals alone on a %s session", (state) => {
+    expect(computeCanConnect("agent", "session-1", "session-1", state)).toBe(true);
+  });
+});
+
+// The loading overlay is opaque and full-bleed. A dead terminal that leaves
+// isConnected false therefore renders a "Connecting terminal…" spinner that is
+// actively false, and hides anything written into the pane behind it. "Ended"
+// has to outrank "connecting", or the user is told the opposite of the truth.
+describe("computeTerminalPaneState", () => {
+  it("reports ended instead of connecting when the session is over", () => {
+    expect(computeTerminalPaneState("shell", "FAILED", false)).toBe("ended");
+  });
+
+  it("still reports ended when a socket happens to be open", () => {
+    expect(computeTerminalPaneState("shell", "CANCELLED", true)).toBe("ended");
+  });
+
+  it("reports connecting only while a live session is not yet attached", () => {
+    expect(computeTerminalPaneState("shell", "RUNNING", false)).toBe("connecting");
+    expect(computeTerminalPaneState("shell", "RUNNING", true)).toBe("connected");
+  });
+
+  it("never reports ended for agent terminals", () => {
+    expect(computeTerminalPaneState("agent", "FAILED", false)).toBe("connecting");
   });
 });

--- a/apps/web/components/task/use-passthrough-terminal.test.ts
+++ b/apps/web/components/task/use-passthrough-terminal.test.ts
@@ -177,4 +177,11 @@ describe("computeTerminalPaneState", () => {
   it("never reports ended for agent terminals", () => {
     expect(computeTerminalPaneState("agent", "FAILED", false)).toBe("connecting");
   });
+
+  // Before the session lands, state is null. Treating that as ended would put
+  // a permanent "session has ended" over a terminal that is merely starting.
+  it("treats an unknown session state as live", () => {
+    expect(computeTerminalPaneState("shell", null, false)).toBe("connecting");
+    expect(computeTerminalPaneState("shell", undefined, true)).toBe("connected");
+  });
 });

--- a/apps/web/components/task/use-passthrough-terminal.test.ts
+++ b/apps/web/components/task/use-passthrough-terminal.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildTerminalWsUrl } from "./use-passthrough-terminal";
-import { computeCanConnect, computeTerminalPaneState } from "./passthrough-terminal";
-import type { TaskSessionState } from "@/app/office/tasks/[id]/types";
+import {
+  computeCanConnect,
+  computeTerminalPaneState,
+  isEnvironmentEnded,
+} from "./passthrough-terminal";
 import { reconnectDelayMs, startReconnectLoop } from "./ws-reconnect";
 import type { Terminal } from "@xterm/xterm";
 
@@ -135,24 +138,65 @@ describe("startReconnectLoop", () => {
 // The env handler refuses a shell on an ended session, identically every time.
 // Opening the socket anyway only restarts the 5s retry timer.
 describe("computeCanConnect on ended sessions", () => {
-  const ENDED: TaskSessionState[] = ["COMPLETED", "FAILED", "CANCELLED"];
-  const LIVE: TaskSessionState[] = ["CREATED", "STARTING", "RUNNING", "IDLE", "WAITING_FOR_INPUT"];
-
-  it.each(ENDED)("refuses a shell terminal on a %s session", (state) => {
-    expect(computeCanConnect("shell", "env-1", "session-1", state)).toBe(false);
+  it("refuses a shell terminal for an ended environment", () => {
+    expect(computeCanConnect("shell", "env-1", "session-1", true)).toBe(false);
   });
 
-  it.each(LIVE)("still connects a shell terminal on a %s session", (state) => {
-    expect(computeCanConnect("shell", "env-1", "session-1", state)).toBe(true);
+  it("still connects a shell terminal for a live environment", () => {
+    expect(computeCanConnect("shell", "env-1", "session-1", false)).toBe(true);
   });
 
-  it("connects when the session state is not known yet", () => {
-    expect(computeCanConnect("shell", "env-1", "session-1", null)).toBe(true);
+  it("connects when nothing is known about the environment", () => {
+    expect(computeCanConnect("shell", "env-1", "session-1")).toBe(true);
   });
 
   // Agent terminals resolve readiness server-side and must keep waiting.
-  it.each(ENDED)("leaves agent terminals alone on a %s session", (state) => {
-    expect(computeCanConnect("agent", "session-1", "session-1", state)).toBe(true);
+  it("leaves agent terminals alone even for a dead environment", () => {
+    expect(computeCanConnect("agent", "session-1", "session-1", true)).toBe(true);
+  });
+});
+
+// Shell terminals are environment-scoped, but useEnvironmentSessionId caches
+// the first session seen for an environment. Gating on that cached session's
+// state would refuse a shell on a live environment as soon as a second session
+// reused it — worse than the loop this exists to stop.
+describe("isEnvironmentEnded", () => {
+  it("is not ended while any session sharing the environment is live", () => {
+    expect(
+      isEnvironmentEnded(
+        "env-1",
+        { "session-a": "COMPLETED", "session-b": "RUNNING" },
+        { "session-a": "env-1", "session-b": "env-1" },
+      ),
+    ).toBe(false);
+  });
+
+  it("is ended only when every session for the environment is terminal", () => {
+    expect(
+      isEnvironmentEnded(
+        "env-1",
+        { "session-a": "FAILED", "session-b": "CANCELLED" },
+        { "session-a": "env-1", "session-b": "env-1" },
+      ),
+    ).toBe(true);
+  });
+
+  it("ignores sessions belonging to other environments", () => {
+    expect(
+      isEnvironmentEnded(
+        "env-1",
+        { "session-a": "FAILED", "session-b": "RUNNING" },
+        { "session-a": "env-1", "session-b": "env-2" },
+      ),
+    ).toBe(true);
+  });
+
+  it("never refuses without positive knowledge", () => {
+    expect(isEnvironmentEnded("env-1", {}, {})).toBe(false);
+    expect(isEnvironmentEnded(null, { "session-a": "FAILED" }, { "session-a": "env-1" })).toBe(
+      false,
+    );
+    expect(isEnvironmentEnded("env-1", {}, { "session-a": "env-1" })).toBe(false);
   });
 });
 
@@ -162,26 +206,26 @@ describe("computeCanConnect on ended sessions", () => {
 // has to outrank "connecting", or the user is told the opposite of the truth.
 describe("computeTerminalPaneState", () => {
   it("reports ended instead of connecting when the session is over", () => {
-    expect(computeTerminalPaneState("shell", "FAILED", false)).toBe("ended");
+    expect(computeTerminalPaneState("shell", true, false)).toBe("ended");
   });
 
   it("still reports ended when a socket happens to be open", () => {
-    expect(computeTerminalPaneState("shell", "CANCELLED", true)).toBe("ended");
+    expect(computeTerminalPaneState("shell", true, true)).toBe("ended");
   });
 
   it("reports connecting only while a live session is not yet attached", () => {
-    expect(computeTerminalPaneState("shell", "RUNNING", false)).toBe("connecting");
-    expect(computeTerminalPaneState("shell", "RUNNING", true)).toBe("connected");
+    expect(computeTerminalPaneState("shell", false, false)).toBe("connecting");
+    expect(computeTerminalPaneState("shell", false, true)).toBe("connected");
   });
 
   it("never reports ended for agent terminals", () => {
-    expect(computeTerminalPaneState("agent", "FAILED", false)).toBe("connecting");
+    expect(computeTerminalPaneState("agent", true, false)).toBe("connecting");
   });
 
   // Before the session lands, state is null. Treating that as ended would put
   // a permanent "session has ended" over a terminal that is merely starting.
   it("treats an unknown session state as live", () => {
-    expect(computeTerminalPaneState("shell", null, false)).toBe("connecting");
-    expect(computeTerminalPaneState("shell", undefined, true)).toBe("connected");
+    expect(computeTerminalPaneState("shell", false, false)).toBe("connecting");
+    expect(computeTerminalPaneState("shell", false, true)).toBe("connected");
   });
 });

--- a/apps/web/e2e/tests/terminal/terminal-ended-session.spec.ts
+++ b/apps/web/e2e/tests/terminal/terminal-ended-session.spec.ts
@@ -1,0 +1,78 @@
+import { test, expect } from "../../fixtures/test-base";
+import { KanbanPage } from "../../pages/kanban-page";
+import { SessionPage } from "../../pages/session-page";
+
+const TERMINAL_STATES = ["COMPLETED", "FAILED", "CANCELLED"];
+
+/**
+ * A shell terminal on an ended session can never connect: the environment
+ * handler refuses it, identically, on every attempt.
+ *
+ * The pane's loading overlay is opaque and full-bleed, so before this was
+ * handled the user saw "Connecting terminal…" forever — a spinner that was not
+ * merely unhelpful but false, since nothing was connecting. Anything written
+ * into the xterm underneath it was invisible.
+ *
+ * This asserts the outcome rather than the mechanism: the pane must say the
+ * session ended, and must not be showing a connecting spinner. A unit test on
+ * the reconnect loop can see neither.
+ */
+test.describe("terminal on an ended session", () => {
+  test("shows the ended-session reason instead of a connecting spinner", async ({
+    page,
+    apiClient,
+    seedData,
+  }) => {
+    const title = `ended-session-terminal-${Date.now()}`;
+    const task = await apiClient.createTaskWithAgent(
+      seedData.workspaceId,
+      title,
+      seedData.agentProfileId,
+      {
+        description: "/e2e:simple-message",
+        workflow_id: seedData.workflowId,
+        workflow_step_id: seedData.startStepId,
+        repository_ids: [seedData.repositoryId],
+      },
+    );
+
+    const { sessions } = await apiClient.listTaskSessions(task.id);
+    const sessionId = sessions[0]?.id;
+    expect(sessionId, "task must have a session to end").toBeTruthy();
+
+    // Drive it to a terminal state rather than waiting for one, so the test
+    // does not depend on how the seeded agent happens to finish.
+    await apiClient.stopSession({ session_id: sessionId as string, force: true });
+    await expect
+      .poll(
+        async () => {
+          const { sessions: current } = await apiClient.listTaskSessions(task.id);
+          return current[0]?.state ?? "";
+        },
+        { timeout: 30_000, message: "Waiting for the session to reach a terminal state" },
+      )
+      .toMatch(new RegExp(TERMINAL_STATES.join("|")));
+
+    const kanban = new KanbanPage(page);
+    await kanban.goto();
+    const card = kanban.taskCardByTitle(title);
+    await expect(card).toBeVisible({ timeout: 15_000 });
+    await card.click();
+    await expect(page).toHaveURL(/\/t\//, { timeout: 15_000 });
+
+    const session = new SessionPage(page);
+    await session.waitForLoad();
+
+    const terminalPanel = page.getByTestId("terminal-panel").first();
+    await expect(terminalPanel).toBeVisible({ timeout: 15_000 });
+
+    // The assertion that matters: the reason is on screen.
+    await expect(terminalPanel.getByTestId("passthrough-session-ended")).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // And the lying spinner is not. Without this the test would still pass
+    // while an opaque overlay covered the message.
+    await expect(terminalPanel.getByTestId("passthrough-loading")).toBeHidden();
+  });
+});

--- a/apps/web/e2e/tests/terminal/terminal-ended-session.spec.ts
+++ b/apps/web/e2e/tests/terminal/terminal-ended-session.spec.ts
@@ -18,8 +18,11 @@ const TERMINAL_STATES = ["COMPLETED", "FAILED", "CANCELLED"];
  * the reconnect loop can see neither.
  */
 test.describe("terminal on an ended session", () => {
+  // testPage, not page: it is the fixture that points baseURL at the worker's
+  // own frontend. With the default page, KanbanPage.goto()'s relative "/" has
+  // nothing to resolve against and Playwright rejects it as an invalid URL.
   test("shows the ended-session reason instead of a connecting spinner", async ({
-    page,
+    testPage,
     apiClient,
     seedData,
   }) => {
@@ -60,17 +63,17 @@ test.describe("terminal on an ended session", () => {
         .toMatch(new RegExp(TERMINAL_STATES.join("|")));
     }
 
-    const kanban = new KanbanPage(page);
+    const kanban = new KanbanPage(testPage);
     await kanban.goto();
     const card = kanban.taskCardByTitle(title);
     await expect(card).toBeVisible({ timeout: 15_000 });
     await card.click();
-    await expect(page).toHaveURL(/\/t\//, { timeout: 15_000 });
+    await expect(testPage).toHaveURL(/\/t\//, { timeout: 15_000 });
 
-    const session = new SessionPage(page);
+    const session = new SessionPage(testPage);
     await session.waitForLoad();
 
-    const terminalPanel = page.getByTestId("terminal-panel").first();
+    const terminalPanel = testPage.getByTestId("terminal-panel").first();
     await expect(terminalPanel).toBeVisible({ timeout: 15_000 });
 
     // The assertion that matters: the reason is on screen.

--- a/apps/web/e2e/tests/terminal/terminal-ended-session.spec.ts
+++ b/apps/web/e2e/tests/terminal/terminal-ended-session.spec.ts
@@ -40,18 +40,25 @@ test.describe("terminal on an ended session", () => {
     const sessionId = sessions[0]?.id;
     expect(sessionId, "task must have a session to end").toBeTruthy();
 
-    // Drive it to a terminal state rather than waiting for one, so the test
-    // does not depend on how the seeded agent happens to finish.
-    await apiClient.stopSession({ session_id: sessionId as string, force: true });
+    // Let the seeded run finish on its own first. session.stop needs a live
+    // execution to cancel, so calling it straight away fails with "no
+    // execution for session" — the session has not started one yet.
+    const state = async () => {
+      const { sessions: current } = await apiClient.listTaskSessions(task.id);
+      return current[0]?.state ?? "";
+    };
     await expect
-      .poll(
-        async () => {
-          const { sessions: current } = await apiClient.listTaskSessions(task.id);
-          return current[0]?.state ?? "";
-        },
-        { timeout: 30_000, message: "Waiting for the session to reach a terminal state" },
-      )
-      .toMatch(new RegExp(TERMINAL_STATES.join("|")));
+      .poll(state, { timeout: 60_000, message: "Waiting for the session to settle" })
+      .toMatch(new RegExp([...TERMINAL_STATES, "WAITING_FOR_INPUT", "IDLE"].join("|")));
+
+    // If it settled somewhere still live, cancel it. By now an execution
+    // exists, so the stop lands.
+    if (!TERMINAL_STATES.includes(await state())) {
+      await apiClient.stopSession({ session_id: sessionId as string, force: true });
+      await expect
+        .poll(state, { timeout: 30_000, message: "Waiting for the cancel to land" })
+        .toMatch(new RegExp(TERMINAL_STATES.join("|")));
+    }
 
     const kanban = new KanbanPage(page);
     await kanban.goto();

--- a/apps/web/src/locales/en/task.json
+++ b/apps/web/src/locales/en/task.json
@@ -1274,6 +1274,7 @@
   "terminalNotAvailableThisTaskIs": "Terminal not available — this task is archived",
   "terminalNumbered": "terminal #{{seq}}",
   "terminalPromptInputAreDisabledUntil": "Terminal & prompt input are disabled until the next run starts.",
+  "terminalSessionEnded": "This session has ended — no terminal is available for it.",
   "terminalUnavailableNoActiveSession": "Terminal unavailable — no active session.",
   "terminalWithSeq": "Terminal {{seq}}",
   "terminals": "Terminals",

--- a/apps/web/src/locales/pseudo/task.json
+++ b/apps/web/src/locales/pseudo/task.json
@@ -1274,6 +1274,7 @@
   "terminalNotAvailableThisTaskIs": "Ţēŕḿĩńàĺ ńōţ àvàĩĺàƀĺē — ţĥĩś ţàśķ ĩś àŕćĥĩvēď",
   "terminalNumbered": "ţēŕḿĩńàĺ #{{seq}}",
   "terminalPromptInputAreDisabledUntil": "Ţēŕḿĩńàĺ & ƥŕōḿƥţ ĩńƥũţ àŕē ďĩśàƀĺēď ũńţĩĺ ţĥē ńēxţ ŕũń śţàŕţś.",
+  "terminalSessionEnded": "Ţĥĩś śēśśĩōń ĥàś ēńďēď — ńō ţēŕḿĩńàĺ ĩś àvàĩĺàƀĺē ƒōŕ ĩţ.",
   "terminalUnavailableNoActiveSession": "Ţēŕḿĩńàĺ ũńàvàĩĺàƀĺē — ńō àćţĩvē śēśśĩōń.",
   "terminalWithSeq": "Ţēŕḿĩńàĺ {{seq}}",
   "terminals": "Ţēŕḿĩńàĺś",


### PR DESCRIPTION
Replaces #2390, which requested changes. Same bug, different half of the stack — see "Why a new PR" at the bottom.

## Problem

A shell terminal left open on a task whose session has ended never connects: the environment handler refuses it, identically, on every attempt. Two things follow, and the second is the one users actually meet.

The reconnect loop backs off to a flat 5s and retries for as long as the tab stays open.

And the pane lies. `PassthroughTerminal` renders its loading overlay whenever the socket is not connected:

```tsx
{!isConnected && (
  <PanelLoadingState className="absolute inset-0 bg-background" label={t("task:connectingTerminal")} />
)}
```

`absolute inset-0 bg-background` is opaque and full-bleed. A terminal that will never connect therefore shows "Connecting terminal…" forever — not merely unhelpful, but false, since nothing is connecting — and hides anything drawn underneath it.

## Fix

The client already holds the session (`useSession`), so it can answer this without asking the server.

- `computeCanConnect` returned `true` unconditionally for shell mode. It now refuses a shell on a terminal session, so the socket is never opened and the loop never starts.
- `computeTerminalPaneState` decides what the pane shows: `ended` outranks `connecting`. The ended branch renders the reason in the overlay's own slot rather than behind it.

Both are pure functions, exported so every case is assertable without mounting xterm.

Agent terminals are untouched — they resolve readiness server-side and must keep waiting, so `computeTerminalPaneState` never reports `ended` for them.

### Why the gate belongs on the client

A session never leaves a terminal state, so there is no race to lose. If one ends while a terminal is attached, the socket closes, the component re-renders against the new state, and the pane switches to `ended`. The server keeps its own refusal as the authority; this only stops the client from asking a question it already knows the answer to.

## Testing

Unit: all three terminal states refuse, all five live states connect, unknown state still connects, agent mode unaffected, and `ended` beats `connecting` even with a socket open — 25 cases.

E2E (`terminal-ended-session.spec.ts`): drives a session to a terminal state, opens the task, and asserts **both** that the reason is visible **and** that the loading spinner is not. That second assertion is the point. Without it the test passes while an opaque overlay covers the message, which is precisely how #2390 went green while delivering nothing.

**What I could not verify locally, stated plainly:** the visual outcome. The e2e harness does not run on Windows — `global-setup.ts` looks for `bin/kandev`, the build produces `kandev.exe` — and it fails identically on `main`. The lint, type, unit and i18n checks all pass locally; the pane assertion is left to CI, where the spec runs on Linux across the E2E shards.

## Why a new PR

#2390 was reviewed as something that should not land "in any form close to this one", and the review was right — I verified each point before acting on it. That PR added a WebSocket close code shared between Go and TypeScript, a new export, a callback threaded through the reconnect loop, and a handshake-then-immediately-close dance in the gateway. None of it survives here: this is frontend-only and touches no protocol.

Five of the six points are addressed. The sixth is a product question that this PR deliberately does not answer: *should* a shell be refused on an ended session at all? The worktree is still on disk, and right after an agent fails is arguably when someone most wants a shell in it. This PR makes the current refusal honest rather than silent. If the answer turns out to be "allow it", the fix is in the backend and this becomes obsolete — which is an argument for keeping it this small.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2423?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->