### PR TITLE
fix(deps): bump dompurify override to 3.4.13 (GHSA-55q2-fjhq-7xh7)

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -39,7 +39,7 @@
       "brace-expansion@1": "^1.1.18",
       "brace-expansion@2": "^2.1.4",
       "brace-expansion@5": "^5.0.9",
-      "dompurify": "^3.4.12",
+      "dompurify": "^3.4.13",
       "fast-uri": "^3.1.5",
       "flatted": "^3.4.2",
       "hono": "^4.12.34",

--- a/apps/pnpm-lock.yaml
+++ b/apps/pnpm-lock.yaml
@@ -17,7 +17,7 @@ overrides:
   brace-expansion@1: ^1.1.18
   brace-expansion@2: ^2.1.4
   brace-expansion@5: ^5.0.9
-  dompurify: ^3.4.12
+  dompurify: ^3.4.13
   fast-uri: ^3.1.5
   flatted: ^3.4.2
   hono: ^4.12.34
@@ -4136,8 +4136,8 @@ packages:
   dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
-  dompurify@3.4.12:
-    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
+  dompurify@3.4.13:
+    resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
 
   dot-prop@5.3.0:
     resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
@@ -10213,7 +10213,7 @@ snapshots:
       '@babel/runtime': 7.29.7
       csstype: 3.2.3
 
-  dompurify@3.4.12:
+  dompurify@3.4.13:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -11424,7 +11424,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.14
       dayjs: 1.11.21
-      dompurify: 3.4.12
+      dompurify: 3.4.13
       es-toolkit: 1.50.0
       katex: 0.16.47
       khroma: 2.1.0
@@ -11669,7 +11669,7 @@ snapshots:
 
   monaco-editor@0.55.1:
     dependencies:
-      dompurify: 3.4.12
+      dompurify: 3.4.13
       marked: 14.0.0
 
   ms@2.1.3: {}


### PR DESCRIPTION
DOMPurify ≤ 3.4.12 leaves a detached subtree executable during `IN_PLACE` sanitization when a hook removes an element, so a descendant can retain an attacker-supplied `onload` and fire after `sanitize()` returns ([GHSA-55q2-fjhq-7xh7](https://github.com/cure53/DOMPurify/security/advisories/GHSA-55q2-fjhq-7xh7), Dependabot alert #237). Bumping the pnpm override to 3.4.13 clears the alert.

## Validation

- `pnpm install` — lockfile regenerated; only `dompurify` changed (3.4.12 → 3.4.13 in the override, the package entry, and the `mermaid` / `monaco-editor` snapshots). Pre-existing tiptap/xterm peer warnings unchanged.
- `pnpm run typecheck` (apps/web) — clean.
- `pnpm --filter @kandev/web build:vite` — succeeded.
- Confirmed the advisory's prescribed fix is present in the installed 3.4.13: `_neutralizeSubtree(currentNode)` now runs before both hook-detachment early returns in `_sanitizeElements()` (`dist/purify.js:1693` and `:1741`).
- Confirmed no source file in this repo references `DOMPurify` directly, and `apps/pnpm-lock.yaml` is the only lockfile carrying the package.

## Possible Improvements

Low risk: `dompurify` is transitive only (`mermaid`, `monaco-editor`) and the bump is a patch release, so the blast radius is limited to Mermaid diagram and Monaco hover/markdown rendering.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2433?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->