### PR TITLE
fix(agentctl): size file-search results from trusted bounds

### DIFF
--- a/apps/backend/internal/agentctl/server/process/workspace_files.go
+++ b/apps/backend/internal/agentctl/server/process/workspace_files.go
@@ -893,13 +893,13 @@ type fileSearchCandidate struct {
 const (
 	// fileSearchDefaultLimit applies when the caller passes a non-positive limit.
 	fileSearchDefaultLimit = 20
-	// fileSearchMaxLimit caps the caller-supplied limit before it is used to
-	// pre-allocate the result slice. The limit reaches this code straight from
-	// the `limit` query parameter of GET /api/v1/workspace/search, so without a
-	// ceiling a request like `?limit=2000000000` makes the process reserve
-	// gigabytes for a result set that can never exceed the number of tracked
-	// files. Mirrors the clamp validateContentSearch already applies to
-	// content search.
+	// fileSearchMaxLimit caps how many results one search may return. The limit
+	// reaches this code straight from the `limit` query parameter of
+	// GET /api/v1/workspace/search, so without a ceiling a request like
+	// `?limit=2000000000` would ask for a result set that can never exceed the
+	// number of tracked files. It also bounds the result slice's capacity,
+	// which is sized from this cap rather than from the request. Mirrors the
+	// clamp validateContentSearch already applies to content search.
 	fileSearchMaxLimit = 200
 )
 
@@ -1100,8 +1100,11 @@ func searchFileCandidates(
 		return len(matches[i].matchPath) < len(matches[j].matchPath)
 	})
 
-	// Return top limit results
-	result := make([]types.FileSearchResult, 0, limit)
+	// Return top limit results. The capacity is derived from values we own —
+	// the matches we actually collected and the hard cap — instead of the
+	// caller-supplied limit, so the allocation size never depends on request
+	// input even indirectly.
+	result := make([]types.FileSearchResult, 0, min(len(matches), fileSearchMaxLimit))
 	for i := 0; i < len(matches) && i < limit; i++ {
 		result = append(result, types.FileSearchResult{
 			RepositoryName: matches[i].repositoryName,

--- a/apps/backend/internal/agentctl/server/process/workspace_files_test.go
+++ b/apps/backend/internal/agentctl/server/process/workspace_files_test.go
@@ -541,6 +541,27 @@ func TestSearchFileCandidatesClampsCallerSuppliedLimit(t *testing.T) {
 	}
 }
 
+// The result slice must be sized from the matches we collected, never from the
+// caller-supplied limit, so a workspace with a handful of files cannot be made
+// to reserve a large slice by a single request.
+func TestSearchFileCandidatesSizesResultFromMatchCount(t *testing.T) {
+	candidates := []fileSearchCandidate{
+		{path: "src/query-a.go", matchPath: "src/query-a.go"},
+		{path: "src/query-b.go", matchPath: "src/query-b.go"},
+		{path: "src/unrelated.go", matchPath: "src/unrelated.go"},
+	}
+
+	results := searchFileCandidates(candidates, "query", math.MaxInt32)
+
+	if len(results) != 2 {
+		t.Fatalf("len(results) = %d, want the 2 matching candidates", len(results))
+	}
+	if cap(results) > len(candidates) {
+		t.Fatalf("cap(results) = %d, want no more than the %d candidates searched",
+			cap(results), len(candidates))
+	}
+}
+
 func TestSearchFileCandidatesDefaultsNonPositiveLimit(t *testing.T) {
 	candidates := make([]fileSearchCandidate, 0, fileSearchDefaultLimit+5)
 	for i := range fileSearchDefaultLimit + 5 {


### PR DESCRIPTION
CodeQL alert [#288](https://github.com/kdlbs/kandev/security/code-scanning/288) (`go/uncontrolled-allocation-size`) still reports the workspace file-search allocation on `main` even after #2088 clamped the caller-supplied limit, because a clamp written as reassignment is not modelled as a barrier — the result slice now takes its capacity from values we own, so no request-derived value reaches `make` at all.

## Validation

- `go test ./internal/agentctl/server/process/` — pass
- Mutated the fix back to `make(..., 0, limit)` to confirm the new test fails without it: `cap(results) = 200, want no more than the 3 candidates searched`
- `golangci-lint run ./internal/agentctl/server/process/... --new-from-rev=main` — 0 issues
- `go build ./...` — pass

## Possible Improvements

Low risk — behaviour is unchanged; the clamp still bounds the returned result count, and only the slice's pre-allocation moved off the request-derived value.

## Verification that the alert clears

This PR's `Analyze (go)` CodeQL run recorded **no** alert-288 instance for `refs/pull/2434/head`. PRs #2117 and #2051 never touched `workspace_files.go` and still got an instance recorded for their refs, so the PR scan records the instance regardless of the diff — its absence here is the fix taking effect, not the file simply being untouched. The `refs/heads/main` instance stays open until `main` is re-scanned after merge.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2434?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
