### PR TITLE
refactor(runs): funnel run cancellation through one guarded writer

### DIFF
--- a/apps/backend/internal/office/repository/sqlite/runs_cancel_test.go
+++ b/apps/backend/internal/office/repository/sqlite/runs_cancel_test.go
@@ -1,0 +1,266 @@
+package sqlite_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/office/models"
+	"github.com/kandev/kandev/internal/office/repository/sqlite"
+)
+
+// The three cancel entry points (CancelRun, BulkCancelRuns,
+// CancelRunsForTasks) are thin selectors over one guarded writer, so these
+// tests assert the shared guard through each of them: a run may only move to
+// cancelled from queued or claimed, and a run that already reached a terminal
+// state keeps its status, cancel_reason and finished_at.
+
+// seedCancelRun inserts a run for taskID in the given status. When finishedAt is
+// non-nil it is stamped onto the row, so terminal fixtures carry the
+// finished_at a cancel must not overwrite.
+func seedCancelRun(
+	t *testing.T,
+	repo *sqlite.Repository,
+	taskID, status string,
+	cancelReason *string,
+	finishedAt *time.Time,
+) string {
+	t.Helper()
+	ctx := context.Background()
+	run := &models.Run{
+		AgentProfileID: "a1",
+		Reason:         "task_assigned",
+		Payload:        `{"task_id":"` + taskID + `"}`,
+		Status:         models.RunStatus(status),
+		CoalescedCount: 1,
+		CancelReason:   cancelReason,
+	}
+	if err := repo.CreateRun(ctx, run); err != nil {
+		t.Fatalf("create run (%s): %v", status, err)
+	}
+	if finishedAt != nil {
+		if err := repo.SetRunStatusForTest(ctx, run.ID, status, nil, finishedAt); err != nil {
+			t.Fatalf("stamp finished_at: %v", err)
+		}
+	}
+	return run.ID
+}
+
+func fetchRun(t *testing.T, repo *sqlite.Repository, id string) *models.Run {
+	t.Helper()
+	run, err := repo.GetRunByID(context.Background(), id)
+	if err != nil {
+		t.Fatalf("get run %s: %v", id, err)
+	}
+	return run
+}
+
+func TestCancelRun_QueuedRunIsCancelled(t *testing.T) {
+	repo := newTestRepo(t)
+	id := seedCancelRun(t, repo, "t1", "queued", nil, nil)
+
+	if err := repo.CancelRun(context.Background(), id, "run_too_old"); err != nil {
+		t.Fatalf("cancel: %v", err)
+	}
+
+	run := fetchRun(t, repo, id)
+	if run.Status != "cancelled" {
+		t.Errorf("status = %q, want cancelled", run.Status)
+	}
+	if run.CancelReason == nil || *run.CancelReason != "run_too_old" {
+		t.Errorf("cancel_reason = %v, want run_too_old", run.CancelReason)
+	}
+	if run.FinishedAt == nil {
+		t.Error("finished_at = nil, want a timestamp")
+	}
+}
+
+func TestCancelRun_ClaimedRunIsCancelled(t *testing.T) {
+	repo := newTestRepo(t)
+	id := seedCancelRun(t, repo, "t1", "claimed", nil, nil)
+
+	if err := repo.CancelRun(context.Background(), id, "execution_too_old"); err != nil {
+		t.Fatalf("cancel: %v", err)
+	}
+
+	run := fetchRun(t, repo, id)
+	if run.Status != "cancelled" {
+		t.Errorf("status = %q, want cancelled", run.Status)
+	}
+	if run.CancelReason == nil || *run.CancelReason != "execution_too_old" {
+		t.Errorf("cancel_reason = %v, want execution_too_old", run.CancelReason)
+	}
+}
+
+// A run that reached a terminal state between the caller's SELECT and this
+// UPDATE must keep its own outcome — this is the race the guard closes.
+func TestCancelRun_TerminalRunIsUntouched(t *testing.T) {
+	finished := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+
+	tests := []struct {
+		name         string
+		status       string
+		cancelReason *string
+	}{
+		{name: "finished", status: "finished"},
+		{name: "failed", status: "failed"},
+		{name: "already cancelled", status: "cancelled", cancelReason: strPtr("tree_cancelled")},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := newTestRepo(t)
+			id := seedCancelRun(t, repo, "t1", tc.status, tc.cancelReason, &finished)
+
+			if err := repo.CancelRun(context.Background(), id, "task_reassigned"); err != nil {
+				t.Fatalf("cancel: %v", err)
+			}
+
+			run := fetchRun(t, repo, id)
+			if string(run.Status) != tc.status {
+				t.Errorf("status = %q, want %q", run.Status, tc.status)
+			}
+			if run.FinishedAt == nil {
+				t.Fatal("finished_at = nil, want the original timestamp preserved")
+			}
+			if !run.FinishedAt.UTC().Equal(finished) {
+				t.Errorf("finished_at = %v, want the original %v", run.FinishedAt.UTC(), finished)
+			}
+			switch {
+			case tc.cancelReason == nil && run.CancelReason != nil:
+				t.Errorf("cancel_reason = %q, want unset", *run.CancelReason)
+			case tc.cancelReason != nil && run.CancelReason == nil:
+				t.Errorf("cancel_reason = nil, want the original %q", *tc.cancelReason)
+			case tc.cancelReason != nil && *run.CancelReason != *tc.cancelReason:
+				t.Errorf("cancel_reason = %q, want the original %q", *run.CancelReason, *tc.cancelReason)
+			}
+		})
+	}
+}
+
+// CancelRunsWhere is the writer the three entry points share; assert the
+// rows-affected contract directly on it.
+func TestCancelRunsWhere_RowsAffected(t *testing.T) {
+	repo := newTestRepo(t)
+	ctx := context.Background()
+	finished := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+
+	queued := seedCancelRun(t, repo, "t1", "queued", nil, nil)
+	terminal := seedCancelRun(t, repo, "t1", "finished", nil, &finished)
+
+	rows, err := repo.CancelRunsWhere(ctx, "tree_cancelled", `id = ?`, terminal)
+	if err != nil {
+		t.Fatalf("cancel terminal: %v", err)
+	}
+	if rows != 0 {
+		t.Errorf("rows affected = %d, want 0 for an already-terminal run", rows)
+	}
+
+	rows, err = repo.CancelRunsWhere(ctx, "tree_cancelled", `id = ?`, queued)
+	if err != nil {
+		t.Fatalf("cancel queued: %v", err)
+	}
+	if rows != 1 {
+		t.Errorf("rows affected = %d, want 1", rows)
+	}
+}
+
+func TestBulkCancelRuns_OnlyCancelsEligibleRuns(t *testing.T) {
+	repo := newTestRepo(t)
+	ctx := context.Background()
+	finished := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+
+	queued := seedCancelRun(t, repo, "t1", "queued", nil, nil)
+	claimed := seedCancelRun(t, repo, "t1", "claimed", nil, nil)
+	done := seedCancelRun(t, repo, "t1", "finished", nil, &finished)
+
+	if err := repo.BulkCancelRuns(ctx, []string{queued, claimed, done}, "task_reassigned"); err != nil {
+		t.Fatalf("bulk cancel: %v", err)
+	}
+
+	for _, id := range []string{queued, claimed} {
+		if run := fetchRun(t, repo, id); run.Status != "cancelled" {
+			t.Errorf("run %s status = %q, want cancelled", id, run.Status)
+		}
+	}
+	run := fetchRun(t, repo, done)
+	if run.Status != "finished" {
+		t.Errorf("finished run status = %q, want finished", run.Status)
+	}
+	if run.FinishedAt == nil || !run.FinishedAt.UTC().Equal(finished) {
+		t.Errorf("finished run finished_at = %v, want the original %v", run.FinishedAt, finished)
+	}
+}
+
+func TestCancelRunsForTasks_MixedSetCountMatches(t *testing.T) {
+	repo := newTestRepo(t)
+	ctx := context.Background()
+	finished := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+
+	queued := seedCancelRun(t, repo, "t1", "queued", nil, nil)
+	claimed := seedCancelRun(t, repo, "t1", "claimed", nil, nil)
+	done := seedCancelRun(t, repo, "t1", "finished", nil, &finished)
+
+	count, err := repo.CancelRunsForTasks(ctx, []string{"t1"}, "tree_paused")
+	if err != nil {
+		t.Fatalf("cancel for tasks: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("count = %d, want 2 (queued + claimed, not the finished run)", count)
+	}
+	for _, id := range []string{queued, claimed} {
+		if run := fetchRun(t, repo, id); run.Status != "cancelled" {
+			t.Errorf("run %s status = %q, want cancelled", id, run.Status)
+		}
+	}
+	if run := fetchRun(t, repo, done); run.Status != "finished" {
+		t.Errorf("finished run status = %q, want finished", run.Status)
+	}
+}
+
+// The by-task-id selector matches on the payload's task_id, not the run ID.
+func TestCancelRunsForTasks_MatchesPayloadTaskID(t *testing.T) {
+	repo := newTestRepo(t)
+	ctx := context.Background()
+
+	mine := seedCancelRun(t, repo, "t1", "queued", nil, nil)
+	other := seedCancelRun(t, repo, "t2", "queued", nil, nil)
+
+	count, err := repo.CancelRunsForTasks(ctx, []string{"t1"}, "tree_cancelled")
+	if err != nil {
+		t.Fatalf("cancel for tasks: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("count = %d, want 1", count)
+	}
+	if run := fetchRun(t, repo, mine); run.Status != "cancelled" {
+		t.Errorf("t1 run status = %q, want cancelled", run.Status)
+	}
+	if run := fetchRun(t, repo, other); run.Status != "queued" {
+		t.Errorf("t2 run status = %q, want queued", run.Status)
+	}
+}
+
+// An empty slice is a no-op: no error, nothing cancelled. This pins the
+// observable contract, not the short-circuit itself — SQLite accepts an empty
+// "id IN ()" list, so removing the early return still passes here. The early
+// return still matters: that same list is a syntax error on Postgres.
+func TestCancelPaths_EmptySliceIsANoOp(t *testing.T) {
+	repo := newTestRepo(t)
+	ctx := context.Background()
+	id := seedCancelRun(t, repo, "t1", "queued", nil, nil)
+
+	if err := repo.BulkCancelRuns(ctx, nil, "task_reassigned"); err != nil {
+		t.Errorf("bulk cancel with no ids: %v", err)
+	}
+	count, err := repo.CancelRunsForTasks(ctx, nil, "tree_cancelled")
+	if err != nil {
+		t.Errorf("cancel for tasks with no task ids: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("count = %d, want 0", count)
+	}
+	if run := fetchRun(t, repo, id); run.Status != "queued" {
+		t.Errorf("unrelated run status = %q, want queued", run.Status)
+	}
+}

--- a/apps/backend/internal/office/repository/sqlite/runs_cancel_test.go
+++ b/apps/backend/internal/office/repository/sqlite/runs_cancel_test.go
@@ -90,6 +90,9 @@ func TestCancelRun_ClaimedRunIsCancelled(t *testing.T) {
 	if run.CancelReason == nil || *run.CancelReason != "execution_too_old" {
 		t.Errorf("cancel_reason = %v, want execution_too_old", run.CancelReason)
 	}
+	if run.FinishedAt == nil {
+		t.Error("finished_at = nil, want a timestamp")
+	}
 }
 
 // A run that reached a terminal state between the caller's SELECT and this

--- a/apps/backend/internal/office/repository/sqlite/tree_holds.go
+++ b/apps/backend/internal/office/repository/sqlite/tree_holds.go
@@ -207,22 +207,23 @@ func (r *Repository) CountActiveRunsForTasks(ctx context.Context, taskIDs []stri
 	return count, err
 }
 
+// CancelRunsForTasks cancels the queued or claimed runs belonging to the
+// given tasks and returns how many rows were actually cancelled.
+//
+// The terminal write itself lives in the runs repository's CancelRunsWhere,
+// which applies the queued/claimed guard; only the by-task-id selector stays
+// here. json_extract is SQLite-flavoured — Postgres is a supported driver
+// (internal/persistence/provider.go) and would need dialect.JSONExtract — so
+// keeping it local avoids baking dialect-specific SQL into the shared writer.
 func (r *Repository) CancelRunsForTasks(ctx context.Context, taskIDs []string, reason string) (int, error) {
 	if len(taskIDs) == 0 {
 		return 0, nil
 	}
-	query, args := taskIDInQuery(`
-		UPDATE runs
-		SET status = 'cancelled', cancel_reason = ?, finished_at = ?
-		WHERE status IN ('queued', 'claimed')
-		  AND json_extract(payload, '$.task_id') IN (%s)
-	`, taskIDs)
-	args = append([]interface{}{reason, time.Now().UTC()}, args...)
-	res, err := r.db.ExecContext(ctx, r.db.Rebind(query), args...)
+	selector, args := taskIDInQuery(`json_extract(payload, '$.task_id') IN (%s)`, taskIDs)
+	rows, err := r.CancelRunsWhere(ctx, reason, selector, args...)
 	if err != nil {
 		return 0, err
 	}
-	rows, _ := res.RowsAffected()
 	return int(rows), nil
 }
 

--- a/apps/backend/internal/runs/repository/sqlite/cancel.go
+++ b/apps/backend/internal/runs/repository/sqlite/cancel.go
@@ -1,0 +1,77 @@
+package sqlite
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// cancellableRunStatuses is the guard on every terminal-cancel write: a run
+// may only be moved to cancelled while it is still queued or claimed.
+//
+// Callers reach the cancel path by reading a run (or a set of run IDs) and
+// then writing, so without the guard a run that the scheduler claimed and
+// completed between that SELECT and this UPDATE would be stamped cancelled
+// and have its real finished_at overwritten.
+const cancellableRunStatuses = `status IN ('queued', 'claimed')`
+
+// CancelRunsWhere is the single writer of the terminal cancel state on the
+// runs table. CancelRun, BulkCancelRuns and the office repository's
+// CancelRunsForTasks are all thin selectors over it, so the guard above
+// cannot be bypassed by picking a different entry point.
+//
+// selector is an extra WHERE fragment ANDed onto the guard; it must be a
+// SQL literal owned by the calling repository method, using ? placeholders
+// (rebound here) for every value. Never interpolate caller-supplied data
+// into it. selectorArgs bind those placeholders, in order.
+//
+// Returns the number of rows actually cancelled: 0 means every run the
+// selector matched had already reached a terminal state.
+func (r *Repository) CancelRunsWhere(
+	ctx context.Context,
+	cancelReason string,
+	selector string,
+	selectorArgs ...interface{},
+) (int64, error) {
+	args := make([]interface{}, 0, len(selectorArgs)+2)
+	args = append(args, cancelReason, time.Now().UTC())
+	args = append(args, selectorArgs...)
+
+	query := fmt.Sprintf(`
+		UPDATE runs
+		SET status = 'cancelled', cancel_reason = ?, finished_at = ?
+		WHERE %s
+		  AND (%s)
+	`, cancellableRunStatuses, selector)
+
+	res, err := r.db.ExecContext(ctx, r.db.Rebind(query), args...)
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}
+
+// CancelRun marks a run as cancelled with an optional cancel reason.
+// A run that already reached a terminal state is left untouched.
+func (r *Repository) CancelRun(ctx context.Context, id, cancelReason string) error {
+	_, err := r.CancelRunsWhere(ctx, cancelReason, `id = ?`, id)
+	return err
+}
+
+// BulkCancelRuns cancels multiple runs by ID with the given reason.
+// Runs in the set that already reached a terminal state are left untouched.
+func (r *Repository) BulkCancelRuns(ctx context.Context, ids []string, cancelReason string) error {
+	if len(ids) == 0 {
+		return nil
+	}
+	placeholders := make([]string, len(ids))
+	args := make([]interface{}, len(ids))
+	for i, id := range ids {
+		placeholders[i] = "?"
+		args[i] = id
+	}
+	selector := fmt.Sprintf(`id IN (%s)`, strings.Join(placeholders, ","))
+	_, err := r.CancelRunsWhere(ctx, cancelReason, selector, args...)
+	return err
+}

--- a/apps/backend/internal/runs/repository/sqlite/runs.go
+++ b/apps/backend/internal/runs/repository/sqlite/runs.go
@@ -450,17 +450,6 @@ func (r *Repository) RecoverStale(ctx context.Context, claimedOlderThan time.Tim
 	return res.RowsAffected()
 }
 
-// CancelRun marks a run as cancelled with an optional cancel reason.
-func (r *Repository) CancelRun(ctx context.Context, id, cancelReason string) error {
-	now := time.Now().UTC()
-	_, err := r.db.ExecContext(ctx, r.db.Rebind(`
-		UPDATE runs
-		SET status = 'cancelled', cancel_reason = ?, finished_at = ?
-		WHERE id = ?
-	`), cancelReason, now, id)
-	return err
-}
-
 // ListPendingRunsForTask returns queued runs in retry state for the given task.
 func (r *Repository) ListPendingRunsForTask(ctx context.Context, taskID string) ([]*models.Run, error) {
 	var reqs []*models.Run
@@ -629,26 +618,5 @@ func (r *Repository) SetRunErrorMessageForTest(
 	_, err := r.db.ExecContext(ctx, r.db.Rebind(`
 		UPDATE runs SET error_message = ? WHERE id = ?
 	`), errMsg, runID)
-	return err
-}
-
-// BulkCancelRuns cancels multiple runs by ID with the given reason.
-func (r *Repository) BulkCancelRuns(ctx context.Context, ids []string, cancelReason string) error {
-	if len(ids) == 0 {
-		return nil
-	}
-	now := time.Now().UTC()
-	placeholders := make([]string, len(ids))
-	args := make([]interface{}, 0, len(ids)+2)
-	args = append(args, cancelReason, now)
-	for i, id := range ids {
-		placeholders[i] = "?"
-		args = append(args, id)
-	}
-	query := fmt.Sprintf(
-		`UPDATE runs SET status = 'cancelled', cancel_reason = ?, finished_at = ? WHERE id IN (%s)`,
-		strings.Join(placeholders, ","),
-	)
-	_, err := r.db.ExecContext(ctx, r.db.Rebind(query), args...)
 	return err
 }


### PR DESCRIPTION
Three functions emitted the identical run-cancellation terminal write and only one of them guarded on status, so a caller picked between them with no signal about which guard applied. Consolidating them onto a single writer also closes the read-then-write window that let a run claimed between a caller's `SELECT` and the `UPDATE` be stamped cancelled over its real outcome.

This is a consolidation, not a fix for a reported defect — no current caller is known to hit the inconsistency.

## Important Changes

- `CancelRunsWhere` (`internal/runs/repository/sqlite/cancel.go`) is now the only place that writes `status = 'cancelled', cancel_reason, finished_at`. It applies `status IN ('queued','claimed')` unconditionally and returns rows affected.
- `CancelRun`, `BulkCancelRuns` and `CancelRunsForTasks` are thin selectors over it (by id / by id set / by task id). Since `office/repository/sqlite.Repository` embeds `*runssqlite.Repository`, all three were already methods on one receiver; now they also share one guard.
- **Behavior change:** the two previously unguarded paths no longer re-stamp a run that already reached `finished`, `failed` or `cancelled`. Verified no caller depends on the unconditional write — both `CancelRunsForTasks` call sites (`tree_controls.go:58,102`) discard the count, and no caller treats zero rows affected as an error or re-cancels a terminal run expecting a fresh `finished_at`.
- **Return types unchanged** for `CancelRun` and `BulkCancelRuns`. No caller consumes a count, so widening two signatures would mean touching call sites and tests for an unused value; the shared writer already returns rows affected, so surfacing it later is a one-line change.
- **The by-task-id selector stays in the office package.** `json_extract(payload, '$.task_id')` is SQLite-flavoured and Postgres is a supported driver (`internal/persistence/provider.go`), so lifting it verbatim would bake dialect-specific SQL into shared code. Only the portable guard and `SET` clause moved. (The raw `json_extract` in these two packages is a pre-existing portability gap in ~4 other spots; not touched here.)

`internal/review/runner.go:279` calls a different `store.CancelRun` — `ReviewService.CancelRun` over `task_review_runs`, a separate interface and table. Out of scope, unchanged.

## Validation

New repository tests in `internal/office/repository/sqlite/runs_cancel_test.go` (the runs table's schema is owned by the office repo's `initSchema`, so runs-repo tests run through that harness): queued and claimed runs cancel; `finished`/`failed`/already-`cancelled` rows keep status, `cancel_reason` and original `finished_at`; rows-affected is 0 for a terminal run and 1 for an eligible one; bulk and by-task paths over a mixed set change only eligible rows with a matching count; the by-task path matches on the payload task id; empty slices are a no-op.

Mutation-tested rather than trusting a green run — the existing suite passed against the three-writer shape, so passing proves nothing on its own:

| Mutation | Result |
| --- | --- |
| Guard dropped (`1 = 1`) | 4 test functions fail, across all three entry points and the shared writer |
| Guard narrowed (`claimed` removed) | 3 fail |
| By-task selector → `id IN (...)` | 2 fail |
| Empty-slice short-circuit removed | **Survives** — SQLite accepts an empty `IN ()` list, so this is unobservable here. Documented in the test; the short-circuit still matters because that list is a syntax error on Postgres. |

Commands run from `apps/backend`:

- `make -C apps/backend test` — passes except `internal/gitlab`, `internal/task/handlers`, `internal/task/service`. All three are pre-existing worktree-sandbox failures (`parent directory cannot be accessed`), and `internal/gitlab`'s `TestEnvironmentTokenAllowsImmutableStartupHost` fails identically on a clean tree at the base commit. None of the three depends on either changed package (verified with `go list -deps`).
- `make -C apps/backend lint` — `0 issues.`
- `golangci-lint run ./... --new-from-rev=fb1d8fdcd7ab244fb204ac05d47387996371be80 --timeout=5m` — `0 issues.`

## Possible Improvements

Low risk. The one thing to watch: `CancelRunsWhere` takes a SQL fragment, which is safe only because every caller passes a compile-time literal with `?` placeholders — documented on the method, but it is a shape that would become unsafe if someone interpolated a value into a selector. The two `CancelRun` call sites also still publish a `run_processed / cancelled` event unconditionally; the guard protects the row, not the event, so a lost race now leaves the row correct but the event still fires. Worth revisiting if the event turns out to matter.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2435?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->