### PR TITLE
docs: plan the office/service collapse into office sub-packages

### DIFF
--- a/docs/decisions/2026-08-08-office-domain-ownership-boundary.md
+++ b/docs/decisions/2026-08-08-office-domain-ownership-boundary.md
@@ -1,0 +1,136 @@
+# ADR-2026-08-08-office-domain-ownership-boundary: Office Sub-Packages Own Domain CRUD; `office/service` Owns Run Execution
+
+**Status:** proposed
+**Date:** 2026-08-08
+**Area:** backend
+
+## Context
+
+`internal/office/service` (7,818 LOC across 38 non-test files) carries a verbatim
+copy of logic that also lives in the sub-packages extracted out of it. An
+AST-based scan of `internal/office/**` (committed at
+`docs/plans/office-service-collapse/officedup/`) finds **40 groups of
+byte-identical function bodies** spanning package boundaries and **37 same-name
+near-duplicate pairs** between `office/service` and its sub-packages.
+
+Both copies are compiled into the binary. `internal/backendapp` wires
+`office/service` *and* `office/agents`, `office/config`, `office/projects`,
+`office/routines`, `office/skills`, `office/channels`, `office/scheduler`.
+
+The extraction did complete on the routing side, and this is the fact that
+settles the decision: `internal/office/service` contains **no `gin` import and
+has no HTTP surface**. `office/routes.go` builds every handler from the
+sub-package services, and `office/services.go:26-40` wires
+`Agents`/`Skills`/`Projects`/`Routines`/`Config`/`Channels` to sub-package types.
+Even the `office/runtime` action interfaces — `Projects.CreateProject`,
+`Skills.DeleteSkill`, `AgentModifier.UpdateAgentInstance` — resolve to
+`svcs.Projects` / `svcs.Skills` / `svcs.Agents`, not to the facade.
+
+What the extraction never did was delete the source. The result is not a facade
+delegating to sub-packages; it is an orphaned copy whose duplicated CRUD is
+reachable only from inside `service` itself, from its own test suite, and from
+six `office/scheduler` call sites.
+
+Meanwhile the duplication has started to diverge, in both directions. The facade
+imports a config bundle across *every* workspace and writes rows with an empty
+`WorkspaceID`, where `office/config` scopes correctly; and `office/config` writes
+those rows through the repository directly, skipping the validation and
+defaulting the facade performs. Elsewhere the facade swallows a repository error
+and admits a duplicate agent name, where `office/agents` propagates it. Each
+divergence is a latent bug that exists *because* nobody owns the behavior.
+
+## Decision
+
+**Domain ownership in `internal/office` follows the HTTP boundary that already
+exists.**
+
+1. The feature sub-packages — `agents`, `skills`, `projects`, `routines`,
+   `config`, `channels`, `costs`, `approvals`, `labels`, `dashboard`,
+   `onboarding` — own their domain's CRUD, validation, config import/export, and
+   HTTP routes. They are the single implementation.
+
+2. `internal/office/service` owns **run execution only**: the tick and dispatch
+   loop, prompt and environment construction, executor resolution, wake payloads,
+   failure and retry handling, event subscribers, task-tree controls, and
+   workspace deletion. It has no `gin` import and must not gain one. New office
+   CRUD goes in the sub-package, never in `service`.
+
+3. Where a duplicate exists, the **owner's** copy survives and the other is
+   deleted — not wrapped, not delegated to. Delegation is what produced the
+   current state.
+
+4. The one reversal: `office/scheduler` already imports `office/service`
+   (`scheduler/run.go:154` holds `svc *service.Service`; `run.go:54` and
+   `executor_resolver.go:11` alias `service.LaunchContext` and
+   `service.ExecutorConfig`). Run execution is `office/service`'s domain under
+   rule 2, so for the scheduler fork the **facade is the owner** and
+   `office/scheduler`'s copies collapse onto it. Inverting that edge would create
+   an import cycle.
+
+5. Duplication is measured, not asserted. The AST detector at
+   `docs/plans/office-service-collapse/officedup/` is the check; its group count
+   is the regression signal.
+
+The migration is sequenced in
+[`docs/plans/office-service-collapse/plan.md`](../plans/office-service-collapse/plan.md)
+as ten independently mergeable PRs.
+
+## Consequences
+
+**Positive.** One implementation per behavior, so the six recorded divergences
+resolve by construction rather than by future bug reports. Roughly 2,390 LOC of
+production code and a comparable volume of duplicated tests are removed. The
+boundary is mechanically checkable — a new duplicate raises the detector's group
+count. `office/config` and `office/projects` gain their first test coverage, as
+part of relocating the suites that today only exist on the facade side.
+
+**Negative.** Ten PRs of churn across a load-bearing subsystem. The riskiest
+step is config import/preview, where the correct end state exists on *neither*
+side: it needs `office/config`'s workspace scoping combined with the facade's
+validated create path. Test coverage is unevenly distributed — `office/config`
+and `office/projects` have zero tests while the facade has 720 LOC covering
+those domains, so the relocation is a genuine porting exercise, not a file move.
+Two changes are externally observable and are called out for explicit decision
+rather than assumed: the `events.OfficeCommentCreated` source string
+(`"office-service"` → `"channels-service"`) and the `GetSkillFromConfig` error
+form (plain → `ErrSkillNotFound`-wrapped).
+
+**Neutral.** `office/workspaces` (61 LOC) and `office/tree_controls` are
+unaffected. They are thin gin handlers over `*service.Service` containing no
+duplicated logic; under this ADR they are the definition of the run-engine
+surface the facade retains, not candidates for collapse.
+
+## Alternatives Considered
+
+**Absorb the sub-packages back into `office/service`.** Rejected. It contradicts
+the wiring that already ships — the sub-packages own every office HTTP route —
+so it would mean rewriting `office/routes.go` and `office/services.go` to
+unwind a completed migration. It also recreates a single 15,000-LOC package
+against the `.golangci.yml` complexity limits, and discards the better behavior:
+`office/config`'s workspace scoping and `office/agents`' error propagation both
+live on the sub-package side.
+
+**Keep the facade and make it delegate.** This is the option the original
+extraction implicitly aimed at, and it is the most tempting because it is the
+smallest diff. Rejected because it preserves two public entry points for every
+behavior and therefore preserves the conditions that produced the drift — a
+delegating facade still lets a caller reach CRUD through `office/service`, and
+the next divergence arrives the same way this one did. It also carries a
+permanent indirection cost for a facade that, per the wiring evidence above, has
+no external CRUD caller to serve.
+
+**Leave it alone and document the duplication.** Rejected. The six recorded
+divergences are already live bugs, not hypothetical risk: cross-workspace config
+import, rows created without a `WorkspaceID`, imports bypassing validation, a
+swallowed uniqueness error, and stale runs rescheduled instead of cancelled.
+Documentation does not fix any of them, and the duplication is still growing —
+three of the forty duplicate groups (`office/onboarding`, `office/dashboard`)
+postdate the original extraction.
+
+## References
+
+- Plan: [`docs/plans/office-service-collapse/plan.md`](../plans/office-service-collapse/plan.md)
+- Evidence: [`docs/plans/office-service-collapse/inventory.md`](../plans/office-service-collapse/inventory.md)
+- Detector: `docs/plans/office-service-collapse/officedup/`
+- Constraint: `apps/backend/internal/office/repository/sqlite/base.go:60`
+  (`Repository` embeds `*runssqlite.Repository`; run-write ownership is untouched)

--- a/docs/decisions/INDEX.md
+++ b/docs/decisions/INDEX.md
@@ -130,3 +130,4 @@ Read individual ADRs for full context. Create new ones via `/record decision` or
 | 2026-08-05-homebrew-remote-helper-audit | [Preserve Remote Helpers in Homebrew Installs](2026-08-05-homebrew-remote-helper-audit.md) | accepted | infra, workflow | 2026-08-05 |
 | 2026-08-07-model-aware-provider-capability-resolution | [Model-aware provider capability resolution](2026-08-07-model-aware-provider-capability-resolution.md) | accepted | backend, frontend, protocol | 2026-08-07 |
 | 2026-08-07-claude-allowlist-label-bridge | [Use the Claude Allowlist as a Trusted Preview Gate](2026-08-07-claude-allowlist-label-bridge.md) | accepted | infra, workflow, security | 2026-08-07 |
+| 2026-08-08-office-domain-ownership-boundary | [Office Sub-Packages Own Domain CRUD; `office/service` Owns Run Execution](2026-08-08-office-domain-ownership-boundary.md) | proposed | backend | 2026-08-08 |

--- a/docs/plans/office-service-collapse/inventory.md
+++ b/docs/plans/office-service-collapse/inventory.md
@@ -1,0 +1,178 @@
+# Duplication Inventory — `internal/office/service` vs office sub-packages
+
+Regenerated 2026-08-08 against `fb1d8fdcd`. This file is the evidence base for
+`plan.md`. Re-run the detector before starting any task and reconcile.
+
+## How this was regenerated
+
+The inventory in the original task description was produced with normalized-body
+text hashing (comments/whitespace stripped, ≥6 lines, ≥120 chars) plus Jaccard
+token similarity. That heuristic is name-keyed and text-based, so it misses
+copies whose receiver identifier differs and copies that were renamed.
+
+This inventory was regenerated with an **AST-based** detector committed beside
+this file at `officedup/`:
+
+```bash
+cd docs/plans/office-service-collapse/officedup
+GOTOOLCHAIN=local go run . ../../../../apps/backend/internal/office
+```
+
+Method, and why each step matters:
+
+1. Parse every non-test `.go` file under `internal/office/**` with `go/parser`
+   in mode `0`, which **drops comments entirely** — so a reworded doc comment
+   cannot register as drift (this is what makes `SetupChannel` read as a copy).
+2. Rewrite every use of the **receiver identifier** to the fixed token `RCV`
+   before printing. This is the step the text heuristic lacks: it makes
+   `func (s *Service)` and `func (ss *SchedulerService)` copies hash identically,
+   and it is what surfaced the 8 extra groups below.
+3. Re-print each body with `go/printer` in `RawFormat` and collapse whitespace.
+   Formatting and line-wrapping differences vanish.
+4. **Section A** = SHA-256 of that normalized body, grouped; report any group
+   spanning more than one package. Same floor as the original heuristic
+   (≥6 lines, ≥120 chars) so the two are comparable.
+5. **Section B** = Jaccard similarity over the `go/scanner` token *multiset*
+   (`sum(min)/sum(max)`) between every `service` function and every
+   non-`service` function, reported at ≥0.60.
+
+Known limits, stated so the next person does not over-trust this file:
+
+- It compares **bodies only**. Two functions with identical bodies but different
+  signatures (parameter order, return types) are reported as identical.
+- Identifier renames *other than the receiver* still count as drift, which is
+  why several cosmetic pairs land at 0.95–0.99 rather than 1.00.
+- Section B is quadratic over ~1,486 functions; it reports 303 pairs at ≥0.60.
+  Only the 37 **same-name** pairs are meaningful; the rest are Go boilerplate
+  collisions (guard clause + repo call + error wrap) and were discarded.
+
+## Reconciliation with the original inventory
+
+All 32 groups from the original list reproduce exactly (33 names, but
+`prepareServiceSkillPackageMetadata` / `prepareSkillPackageMetadata` are one
+renamed pair). The AST detector finds **40** groups — a strict superset. The 8
+additional groups, all missed because the text heuristic keys on name and does
+not normalize the receiver:
+
+| Group | Locations | Why it was missed |
+| --- | --- | --- |
+| `ClaimNextRun` | `scheduler/run_processing.go:15` ↔ `service/scheduler_runs.go:18` | receiver `ss` vs `s` |
+| `CreateRoutine` | `routines/service.go:240` ↔ `service/service.go:687` | receiver `s *RoutineService` vs `s *Service` |
+| `UpdateRoutine` | `routines/service.go:258` ↔ `service/service.go:705` | same |
+| `ListActivityFiltered` | `dashboard/service.go:600` ↔ `service/activity.go:124` | different line spans (6L vs 11L) |
+| `countAgentsByRoleInWorkspace` ↔ `countAgentsByRole` | `agents/service.go:793` ↔ `service/agents.go:266` | **renamed** |
+| `generateSlug` | `onboarding/service.go:506` ↔ `service/service.go:833` | receiver |
+| `writeWorkspaceConfig` | `onboarding/service.go:479` ↔ `service/service.go:848` | receiver |
+| `taskIDFromPayload` ↔ `extractRunTaskID` | `dashboard/run_detail.go:83` ↔ `scheduler/dispatch_routing.go:636` | **renamed**, and involves no `service` copy at all |
+
+Two consequences for the plan: `office/onboarding` and `office/dashboard` are
+also forks of the facade (neither was in the original scope), and `office/scheduler`
+is confirmed as a third fork (see plan §Scheduler).
+
+## Section A — identical bodies, by collapse domain (40 groups)
+
+| Domain | Groups | Names |
+| --- | --- | --- |
+| config | 14 | `ApplyIncoming` `ApplyOutgoing` `ExportBundle` `IncomingDiff` `OutgoingDiff` `PreviewImport` `ScanFilesystem` `bundleToZip` `deleteRowsMissingFromBundle` `diffBundles` `missingNames` `parseErrorsFromLoader` `writeBundleEntities` `writeYAMLFile` |
+| agents | 8 | `CreateDefaultInstructions` `GetAgentFromConfig` `ListAgentInstancesFiltered` `UpdateAgentInstance` `UpdateAgentStatus` `validateReportsTo` `validateStatusTransition` `countAgentsByRole`→`countAgentsByRoleInWorkspace` |
+| projects | 4 | `DeleteProject` `GetProjectFromConfig` `UpdateProject` `validateRepositories` |
+| routines | 4 | `CreateRoutine` `UpdateRoutine` `DeleteRoutine` `GetRoutineFromConfig` |
+| skills | 2 | `DeleteSkill` `prepareServiceSkillPackageMetadata`→`prepareSkillPackageMetadata` |
+| channels | 2 | `CreateComment` `HandleChannelInbound` |
+| scheduler | 2 | `ClaimNextRun` `retryDelayWithJitter` |
+| onboarding | 2 | `generateSlug` `writeWorkspaceConfig` |
+| dashboard | 1 | `ListActivityFiltered` |
+| dashboard ↔ scheduler | 1 | `taskIDFromPayload`→`extractRunTaskID` (no `service` copy; out of scope) |
+
+## Section B — the 37 same-name near-duplicate pairs
+
+The headline result: **31 of the 37 differ only cosmetically.** The original
+description flagged 4 pairs as "already drifted — where the risk is"
+(`ApplyImport` 0.98, `CreateProject` 0.97, `validateProject` 0.97,
+`applyAgents` 0.95). Similarity score does not track behavioral risk here:
+`ApplyImport` at 0.990 is cosmetic, while `validateAgentNameUnique` at 0.845 and
+`scheduleRetry` at 0.745 are the two most consequential differences in the tree.
+
+Cosmetic difference classes, all verified against the source:
+
+1. **Receiver type rename** — `*Service` → `*ConfigService` / `*AgentService` /
+   `*ProjectService` / `*SkillService` / `*ChannelService` / `*SchedulerService`.
+2. **Type alias** — `projects/models.go:7` declares `type Project = models.Project`
+   and `projects/models.go:15-18,28` alias the status constants. So
+   `models.Project` vs `Project` and `models.ValidProjectStatuses` vs
+   `ValidProjectStatuses` are *the same identifiers*. This alone accounts for
+   `CreateProject` (0.985) and `validateProject` (0.974).
+3. **One-line wrapper vs its target** — `service/config_read.go:12,30,53,83`
+   define `ListAgentsFromConfig` / `ListSkillsFromConfig` /
+   `ListProjectsFromConfig` / `ListRoutinesFromConfig` as bare `return
+   s.repo.ListX(ctx, workspaceID)`. Every `export*` diff is this substitution.
+   Likewise `service/channels.go:90` `createChannelTask` is a pass-through to
+   `repo.CreateChannelTask`, and `agents/service.go:207` `GetAgentInstance` is a
+   pass-through to `GetAgentFromConfig`. So `SetupChannel` (0.975) is cosmetic.
+4. **Collaborator indirection** — `s.LogActivity(...)` vs
+   `s.activity.LogActivity(...)`; `s.GetAgentFromConfig` vs
+   `ss.svc.GetAgentFromConfig`. Same target, different hop.
+5. **Parameter rename** — `workspaceID` vs `wsID` (`LogActivityWithRun`, 0.982).
+6. **Doc-comment rewording** — invisible to the AST detector, visible to `diff`.
+
+### The 6 differences that are real
+
+Ordered by consequence, not by similarity score.
+
+| # | Pair | Difference | Which side is correct |
+| --- | --- | --- | --- |
+| D1 | `preview{Agents,Projects,Skills,Routines}`, `apply{Agents,Projects,Skills,Routines}` — `service/config_import.go` ↔ `config/import.go` | The facade declares the workspace parameter as `_ string` and lists with `ListXFromConfig(ctx, "")` — **every workspace**. `config` takes `wsID` and lists `repo.ListX(ctx, wsID)`. On the create branch, `config` sets `WorkspaceID: wsID` on the new row; **the facade sets no `WorkspaceID` at all**. | **`config`.** The facade's version matches bundle entries by name across all workspaces, so importing into workspace B can update a row in workspace A, and rows it creates have an empty `WorkspaceID`. Not defensible as intentional. |
+| D2 | Same 4 `apply*` pairs, create/update branch | Facade calls the validated service methods `CreateProject` / `CreateSkill` / `CreateAgentInstance` / `UpdateProject`…; `config` calls `s.repo.CreateX` **directly**, bypassing them. `service/service.go:520` `CreateProject` validates and defaults `Status`, `Repositories`→`"[]"`, `ExecutorConfig`→`"{}"`; `service/agents.go:103` `CreateAgentInstance` validates and defaults `ID`, `Permissions`, `MaxConcurrentSessions`, `CooldownSec`; `skills.CreateSkill` defaults `SourceType`, `FileInventory` and runs `prepareSkillPackageMetadata`. | **The facade.** `config` silently writes rows that skip validation and defaulting. Note this is the *opposite* direction from D1 — the correct collapse is `config`'s scoping **plus** the facade's validated create path. Neither side is wholly right. |
+| D3 | `validateAgentNameUnique` — `service/agents.go:275` ↔ `agents/service.go:804` (0.845) | On a repository error the facade does `return nil`; `agents` does `return fmt.Errorf("check agent name uniqueness: %w", err)`. | **`agents`.** The facade swallows the error and admits a duplicate agent name whenever the uniqueness query fails. |
+| D4 | `scheduleRetry` — `service/retry.go:46` ↔ `scheduler/retry.go:50` (0.745) | The facade opens with `if stale, reason := isRetryStale(run); stale { return s.cancelRetry(ctx, run, reason) }` and logs `source=backoff`. `scheduler` has neither. | **The facade.** `scheduler` retries runs the facade would cancel as stale. **This pair touches `cancelRetry` — see the `db3adcf4` dependency in `plan.md`; it is deferred to task 10.** |
+| D5 | `GetSkillFromConfig` — `service/config_read.go:35` ↔ `skills/service.go:237` (0.958) | Facade returns `fmt.Errorf("skill not found: %s", …)`; `skills` returns `fmt.Errorf("%w: %s", ErrSkillNotFound, …)`. | **`skills`.** Only its form is matchable with `errors.Is`. `internal/agent/runtime/lifecycle/skill/manifest.go:45` calls this through an interface — confirm its error handling before switching. |
+| D6 | `publishCommentCreated` — `service/comments.go:41` ↔ `channels/comments.go:34` (0.960) | Event source string `"office-service"` vs `"channels-service"`; payload type `CommentPostedData` (exported) vs `commentPostedData` (unexported). | **`channels`**, but the source string is **observable on the event bus**. Flagged for review — see task 07. |
+
+### Flagged for review, not decided here
+
+- **D2 vs D1 interact.** Adopting `config`'s repo-direct writes to get workspace
+  scoping would *also* adopt the validation bypass. Task 03 must take both
+  halves or neither, and it needs new tests, because `office/config` has **zero**
+  test files today.
+- **D6's event source string.** Changing `"office-service"` → `"channels-service"`
+  is a wire-visible change to `events.OfficeCommentCreated`. No in-repo consumer
+  filters on it (verified by grep), but it is the kind of thing a plugin could.
+
+## Live consumers of `*service.Service` (the collapse-direction evidence)
+
+`internal/office/service` contains **no `gin` import** — it has no HTTP surface.
+`office/routes.go` registers handlers built exclusively from the sub-package
+services, and `office/services.go:26-40` wires `Agents`/`Skills`/`Projects`/
+`Routines`/`Config`/`Channels`/`Costs`/`Approvals`/`Labels` to sub-package types.
+The `office/runtime` action interfaces (`Comments`, `Skills`, `Projects`,
+`Agents`, `AgentModifier`) resolve to `svcs.Dashboard` / `svcs.Skills` /
+`svcs.Projects` / `svcs.Agents` — **not** to the facade.
+
+The facade's entire live external method surface is 17 methods:
+
+| Consumer | Methods |
+| --- | --- |
+| `office/tree_controls` | `CancelTaskTree` `PauseTaskTree` `ResumeTaskTree` `RestoreTaskTree` `PreviewTaskTree` `GetSubtreeCostSummary` |
+| `office/workspaces` | `DeleteWorkspace` `GetWorkspaceDeletionSummary` |
+| `office/scheduler` | `BuildWakePayload` `ResolveExecutor` `GetAgentFromConfig` `ListAgentInstances` `ListAgentInstancesFiltered` `LogActivityWithRun` |
+| `internal/backendapp` | `SetWorkflowEngineDispatcher` `ListFailedRunInboxRows` `ListPausedAgentInboxRows` + `Set*`/`Register*` wiring calls |
+
+Every duplicated CRUD/config method in the facade is reachable **only** from
+within `service` itself, from its own tests, or from those 6 scheduler calls.
+
+### A note on static-analysis limits
+
+Neither tool settles this on its own, and they fail in **opposite** directions:
+
+- `deadcode -test ./...` reports only 4 unreachable funcs in `office/service`,
+  and `deadcode ./...` only 19 — because it is RTA-based: once `*service.Service`
+  is converted to any interface, every method whose name matches an
+  interface-method invoked anywhere in the program is marked reachable. It
+  **over**-approximates through interface dispatch.
+- `grep` for `.Method(` **under**-approximates: it cannot see interface dispatch
+  at all.
+
+The reliable determination is the composition root — which concrete value is
+wired into each interface field in `office/services.go` and
+`office/routes.go`. That is the evidence used above, and it is what any
+re-verification should re-check.

--- a/docs/plans/office-service-collapse/officedup/go.mod
+++ b/docs/plans/office-service-collapse/officedup/go.mod
@@ -1,0 +1,3 @@
+module officedup
+
+go 1.22

--- a/docs/plans/office-service-collapse/officedup/main.go
+++ b/docs/plans/office-service-collapse/officedup/main.go
@@ -1,0 +1,229 @@
+// Command officedup finds duplicated and drifted function bodies across the
+// apps/backend/internal/office/** package tree.
+//
+// Detection is AST-based, not text-based: each function body is re-printed with
+// go/printer (which drops comments and normalizes all whitespace/formatting),
+// with the receiver identifier rewritten to a fixed token so that `s *Service`
+// and `m *Manager` copies hash identically. Two functions are "identical" when
+// those normalized bodies are byte-equal. Near-duplicates are scored by Jaccard
+// similarity over the go/scanner token multiset of the same normalized body.
+//
+// Usage: go run . <office-dir>
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/printer"
+	"go/scanner"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+type fn struct {
+	Pkg      string // office-relative package dir, e.g. "service" or "agents"
+	File     string
+	Line     int
+	Name     string // Recv.Name for methods, else bare name
+	Recv     string
+	Lines    int
+	Body     string // normalized
+	Hash     string
+	Tokens   map[string]int
+	TokCount int
+}
+
+func (f fn) ID() string { return f.Pkg + "." + f.Name }
+
+func main() {
+	root := os.Args[1]
+	fset := token.NewFileSet()
+	var fns []fn
+
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() || !strings.HasSuffix(path, ".go") {
+			return err
+		}
+		if strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		file, perr := parser.ParseFile(fset, path, nil, 0) // mode 0 => comments dropped
+		if perr != nil {
+			fmt.Fprintln(os.Stderr, "parse:", perr)
+			return nil
+		}
+		rel, _ := filepath.Rel(root, filepath.Dir(path))
+		for _, decl := range file.Decls {
+			fd, ok := decl.(*ast.FuncDecl)
+			if !ok || fd.Body == nil {
+				continue
+			}
+			recv := ""
+			if fd.Recv != nil && len(fd.Recv.List) > 0 && len(fd.Recv.List[0].Names) > 0 {
+				recv = fd.Recv.List[0].Names[0].Name
+			}
+			if recv != "" {
+				normalizeRecv(fd.Body, recv)
+			}
+			var sb strings.Builder
+			if perr := (&printer.Config{Mode: printer.RawFormat}).Fprint(&sb, fset, fd.Body); perr != nil {
+				continue
+			}
+			body := strings.Join(strings.Fields(sb.String()), " ")
+			start := fset.Position(fd.Pos())
+			end := fset.Position(fd.End())
+			nLines := end.Line - start.Line + 1
+			if nLines < 6 || len(body) < 120 {
+				continue // same floor as the original heuristic
+			}
+			sum := sha256.Sum256([]byte(body))
+			toks, n := tokenize(sb.String())
+			fns = append(fns, fn{
+				Pkg: rel, File: path, Line: start.Line, Name: fd.Name.Name, Recv: recv,
+				Lines: nLines, Body: body, Hash: hex.EncodeToString(sum[:8]),
+				Tokens: toks, TokCount: n,
+			})
+		}
+		return nil
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("## parsed %d functions (>=6 lines, >=120 chars normalized)\n\n", len(fns))
+
+	// --- Section A: byte-identical normalized bodies spanning >1 package.
+	byHash := map[string][]fn{}
+	for _, f := range fns {
+		byHash[f.Hash] = append(byHash[f.Hash], f)
+	}
+	type group struct {
+		hash string
+		fs   []fn
+	}
+	var ident []group
+	for h, g := range byHash {
+		pkgs := map[string]bool{}
+		for _, f := range g {
+			pkgs[f.Pkg] = true
+		}
+		if len(pkgs) > 1 {
+			ident = append(ident, group{h, g})
+		}
+	}
+	sort.Slice(ident, func(i, j int) bool { return ident[i].fs[0].Name < ident[j].fs[0].Name })
+	fmt.Printf("## SECTION A — identical normalized bodies across packages (%d groups)\n\n", len(ident))
+	for _, g := range ident {
+		sort.Slice(g.fs, func(i, j int) bool { return g.fs[i].Pkg < g.fs[j].Pkg })
+		names := map[string]bool{}
+		var locs []string
+		for _, f := range g.fs {
+			names[f.Name] = true
+			locs = append(locs, fmt.Sprintf("%s:%d(%s.%s,%dL)", f.File, f.Line, f.Pkg, f.Name, f.Lines))
+		}
+		tag := ""
+		if len(names) > 1 {
+			tag = " [RENAMED]"
+		}
+		fmt.Printf("- %s%s\n    %s\n", g.fs[0].Name, tag, strings.Join(locs, "\n    "))
+	}
+
+	// --- Section B: near-duplicates between office/service and every other package.
+	var svc, other []fn
+	for _, f := range fns {
+		if f.Pkg == "service" {
+			svc = append(svc, f)
+		} else {
+			other = append(other, f)
+		}
+	}
+	type pair struct {
+		a, b fn
+		sim  float64
+	}
+	var near []pair
+	for _, a := range svc {
+		for _, b := range other {
+			if a.Hash == b.Hash {
+				continue // already in Section A
+			}
+			s := jaccard(a.Tokens, b.Tokens)
+			if s < 0.60 {
+				continue
+			}
+			near = append(near, pair{a, b, s})
+		}
+	}
+	sort.Slice(near, func(i, j int) bool { return near[i].sim > near[j].sim })
+	fmt.Printf("\n## SECTION B — near-duplicate service<->subpackage pairs, sim>=0.60 (%d pairs)\n\n", len(near))
+	for _, p := range near {
+		same := ""
+		if p.a.Name == p.b.Name {
+			same = " SAME-NAME"
+		}
+		fmt.Printf("%.3f%s  service.%s (%s:%d,%dL)  <->  %s.%s (%s:%d,%dL)\n",
+			p.sim, same, p.a.Name, p.a.File, p.a.Line, p.a.Lines,
+			p.b.Pkg, p.b.Name, p.b.File, p.b.Line, p.b.Lines)
+	}
+}
+
+// normalizeRecv rewrites every use of the receiver identifier to a fixed token
+// so that copies differing only in receiver name (s/m/svc) hash identically.
+func normalizeRecv(body *ast.BlockStmt, recv string) {
+	ast.Inspect(body, func(n ast.Node) bool {
+		if id, ok := n.(*ast.Ident); ok && id.Name == recv {
+			id.Name = "RCV"
+		}
+		return true
+	})
+}
+
+func tokenize(src string) (map[string]int, int) {
+	var s scanner.Scanner
+	fset := token.NewFileSet()
+	f := fset.AddFile("", fset.Base(), len(src))
+	s.Init(f, []byte(src), nil, 0)
+	out := map[string]int{}
+	n := 0
+	for {
+		_, tok, lit := s.Scan()
+		if tok == token.EOF {
+			break
+		}
+		k := tok.String()
+		if lit != "" {
+			k = lit
+		}
+		out[k]++
+		n++
+	}
+	return out, n
+}
+
+// jaccard over token multisets: sum(min)/sum(max).
+func jaccard(a, b map[string]int) float64 {
+	seen := map[string]bool{}
+	var inter, union int
+	for k, va := range a {
+		seen[k] = true
+		vb := b[k]
+		inter += min(va, vb)
+		union += max(va, vb)
+	}
+	for k, vb := range b {
+		if seen[k] {
+			continue
+		}
+		union += vb
+	}
+	if union == 0 {
+		return 0
+	}
+	return float64(inter) / float64(union)
+}

--- a/docs/plans/office-service-collapse/plan.md
+++ b/docs/plans/office-service-collapse/plan.md
@@ -1,0 +1,330 @@
+---
+spec: none (behavior-preserving refactor — /spec excludes refactors)
+adr: docs/decisions/2026-08-08-office-domain-ownership-boundary.md
+created: 2026-08-08
+status: draft
+---
+
+# Implementation Plan: Collapse `internal/office/service` Into the Office Sub-Packages
+
+## Overview
+
+`internal/office/service` (7,818 LOC, 38 non-test files) carries a verbatim CRUD
+and config mirror of `office/{agents,channels,config,projects,routines,skills}`,
+plus a third fork of `office/scheduler`'s run-claim and retry logic. Both copies
+are live in the binary. This plan removes the mirror in **10 independently
+mergeable PRs**, sequenced identical-bodies-first, and narrows `office/service`
+to what it is actually used for: the run-execution engine behind
+`tree_controls`, `workspaces`, `scheduler`, and `backendapp`.
+
+No behavior changes are intended except the six documented in
+[`inventory.md`](inventory.md) §"The 6 differences that are real", each of which
+picks a side deliberately and lands with a test that pins it.
+
+## Evidence base
+
+[`inventory.md`](inventory.md) — regenerated 2026-08-08 against `fb1d8fdcd` with
+an AST-based detector committed at [`officedup/`](officedup/). **Re-run it before
+starting any task**; every task's acceptance includes a group-count delta.
+
+Headline corrections to the assumptions this plan was commissioned under:
+
+- **40 identical-body groups, not 33 names.** The 8 extra were missed because
+  the text heuristic keys on function name and does not normalize the receiver
+  identifier. Two of them (`generateSlug`, `writeWorkspaceConfig`) put
+  `office/onboarding` in scope, and one (`ListActivityFiltered`) puts
+  `office/dashboard` in scope. Neither was in the original brief.
+- **31 of the 37 drifted pairs are cosmetic, and similarity score does not rank
+  risk.** The four pairs flagged as high-risk (`ApplyImport` 0.990,
+  `CreateProject` 0.985, `validateProject` 0.974, `applyAgents` 0.964) are —
+  except for `applyAgents` — receiver renames over a `type Project =
+  models.Project` alias. The two genuinely dangerous differences score *lowest*:
+  `validateAgentNameUnique` at 0.845 and `scheduleRetry` at 0.745.
+- **The collapse direction is the same for all six domains**, contrary to the
+  survey's expectation. See below.
+
+## Survey results
+
+### 1. Direction of collapse — sub-packages win, uniformly
+
+The deciding evidence is not LOC or importer count, it is the composition root.
+`internal/office/service` has **no `gin` import and no HTTP surface**.
+`office/routes.go` builds every handler from the sub-package services, and
+`office/services.go:26-40` wires `Agents`/`Skills`/`Projects`/`Routines`/
+`Config`/`Channels` to sub-package types. Even the `office/runtime` action
+interfaces (`Projects.CreateProject`, `Skills.DeleteSkill`,
+`AgentModifier.UpdateAgentInstance`) resolve to `svcs.Projects`/`svcs.Skills`/
+`svcs.Agents`, not to the facade.
+
+So for **agents, channels, config, projects, routines, skills** the answer is the
+same: **the sub-package is the owner; the facade's copy is deleted**, not made to
+delegate. The facade's mirror is reachable only from inside `service`, from its
+own tests, and from six `scheduler` calls (task 05 repoints three of them).
+
+This is not the "it will not be the same answer everywhere" the brief expected,
+and the reason is worth stating: the extraction did complete on the *routing*
+side. What it never did was delete the source. The facade is not a facade — it is
+an orphaned copy that only its own test suite still exercises.
+
+The two apparent counter-examples are not counter-examples:
+
+- **`office/workspaces` (61 LOC)** and **`office/tree_controls`** are not forks.
+  They are thin gin handlers *over* `*service.Service`
+  (`workspaces/handler.go:13`, `tree_controls/handler.go:12`). They contain no
+  duplicated logic and define the 8-method run-engine surface the facade keeps.
+- **`office/skills` (2,332 LOC)** is the largest sub-package, but `office/service`
+  **already imports it** (`service/skill_compat.go` re-exports
+  `skills.AgentTypeResolver`, `skills.ParseDesiredSlugs`, and the source-type
+  constants). The dependency edge already points the right way.
+
+### 2. Is `office/scheduler` a third fork? — Yes; scoped in, split across two tasks
+
+Confirmed. `ClaimNextRun` and `retryDelayWithJitter` are byte-identical across
+`service/scheduler_runs.go`/`service/retry.go` and `scheduler/`; `ProcessRunGuard`
+(0.979), `guardAgentStatus` (0.978), `escalateFailure` (0.982),
+`queueCEOAgentError` (0.960) and `scheduleRetry` (0.745) are near-identical.
+
+Direction here is forced and runs opposite to the six CRUD domains:
+`office/scheduler` **imports** `office/service` (`scheduler/run.go:154`
+`svc *service.Service`; `scheduler/retry.go:110` uses `service.AgentListFilter`;
+`scheduler/executor_resolver.go:11` and `scheduler/run.go:54` alias
+`service.ExecutorConfig` and `service.LaunchContext`). Making the facade delegate
+to `scheduler` would invert an existing edge and create a cycle. So here the
+**facade is the owner** and `scheduler`'s copies collapse onto it.
+
+Split across two tasks for a specific reason:
+
+- **Task 09 — run-claim/guard fork.** `ClaimNextRun`, `ProcessRunGuard`,
+  `guardAgentStatus`. Mechanical; no cancel-path involvement.
+- **Task 10 — retry fork. Blocked.** `scheduleRetry`'s real drift (D4) is
+  precisely its `isRetryStale` → `cancelRetry` branch, and `escalateFailure`
+  calls `FailRun`. Sibling task **`db3adcf4` is consolidating the run-cancel
+  writers**. Task 10 must not start until that lands; see Constraints.
+
+### 3. Drifted pairs — recorded in full
+
+All 37 same-name pairs are diffed and classified in
+[`inventory.md`](inventory.md) §"Section B", with the six real differences
+recorded as D1–D6 (both behaviors, which side wins, and why). Two are flagged
+for human review rather than decided: the D1/D2 interaction (task 03) and D6's
+wire-visible event source string (task 07).
+
+### 4. Existing seams — the cheap wins
+
+- `service/skill_compat.go` already re-exports from `skills` — the skills seam
+  exists and is used. Task 06 is small for this reason.
+- `service/config_read.go:12,30,53,83` are bare one-line wrappers over
+  `repo.ListX`. Deleting them is a rename, not a behavior change (task 02).
+- `agents/service.go:207,213` already forward `GetAgentInstance` →
+  `GetAgentFromConfig` and `ListAgentInstances` → `ListAgentsFromConfig`, so the
+  three scheduler call sites in task 05 repoint onto methods that already exist
+  with matching signatures.
+- `shared.ActivityLoggerImpl` already implements the activity-logging interface
+  the facade's `activity.go` re-implements (task 08).
+
+---
+
+## Duplication ledger
+
+Each task's acceptance is a **delta** against its branch point, not an absolute
+count — wave-2 tasks may land in any order. The arithmetic must close:
+
+| Task | Section A groups removed | Section B same-name pairs removed |
+| --- | ---: | ---: |
+| 02 config helpers | 14 | 10 |
+| 03 config import drift | 0 | 8 |
+| 04 projects | 4 | 2 |
+| 05 agents | 7 | 3 |
+| 06 skills + routines | 6 | 3 |
+| 07 channels + comments + instructions | 3 | 2 |
+| 08 activity + onboarding | 3 | 1 |
+| 09 scheduler run-claim | 1 | 2 |
+| 10 scheduler retry (blocked) | 1 | 3 |
+| **Total removed** | **39** | **34** |
+| Baseline (2026-08-08) | 40 | 37 |
+| **Expected residue** | **1** | **3** |
+
+The residue is out of scope by design and is recorded so it is not mistaken for
+incomplete work:
+
+- Section A: `taskIDFromPayload` ↔ `extractRunTaskID`
+  (`dashboard/run_detail.go:83` ↔ `scheduler/dispatch_routing.go:636`) — a real
+  identical pair, but it involves **no `office/service` copy**. Out of this
+  plan's remit; noted for a future task.
+- Section B: `publishCommentCreated` ↔ `dashboard` (0.653), `CreateComment` ↔
+  `dashboard` (0.646), and `service.Start` ↔ `infra.Start` (0.610). The first two
+  are a `dashboard` third copy of the comment path; the third is a coincidental
+  Go-boilerplate collision at the detector's floor.
+
+`CreateDefaultInstructions` is an easy double-count: it is an **agents**-domain
+group that physically lives in `service/instructions.go`, so it is removed by
+task 07, not task 05.
+
+---
+
+## Backend
+
+Frontend section omitted deliberately: this refactor touches no HTTP route, no
+response shape, and no user-visible behavior. `office/routes.go` is unchanged by
+every task except 11.
+
+### Deletion targets in `internal/office/service`
+
+| File | LOC | Task | Fate |
+| --- | --- | --- | --- |
+| `config_export.go` `config_sync.go` `config_sync_helpers.go` `config_sync_util.go` `config_read.go` | 840 | 02 | delete; `office/config` owns |
+| `config_import.go` | 319 | 03 | delete; `office/config` owns, after D1+D2 reconciliation |
+| `service.go` (project CRUD, lines 520-620) | ~100 | 04 | delete; `office/projects` owns |
+| `agents.go` | 313 | 05 | delete; `office/agents` owns |
+| `service.go` (skill + routine CRUD, lines 461-518, 687-730) | ~100 | 06 | delete; `office/skills`, `office/routines` own |
+| `channels.go` `comments.go` `instructions.go` | 247 | 07 | delete; `office/channels`, `office/agents` own |
+| `activity.go` | 146 | 08 | delete; `shared.ActivityLoggerImpl` owns |
+| `service.go` (`generateSlug`, `writeWorkspaceConfig`, lines 833-869) | ~37 | 08 | delete; `office/onboarding` owns |
+| `scheduler_runs.go` | 113 | 09 | delete; `office/scheduler` owns |
+| `retry.go` `retry_cancel.go` | 177+ | 10 | **blocked on `db3adcf4`** |
+
+Approximately 2,390 LOC of production code removed across tasks 02–09, plus the
+corresponding test files relocated or retired.
+
+### What `office/service` keeps
+
+The run-execution engine: `run.go`, `engine_dispatcher.go`, `prompt_builder.go`,
+`env_builder.go`, `wake_payload.go`, `executor_resolver.go`,
+`event_subscribers.go`, `failure.go`, `idle_timeout.go`,
+`continuation_summary.go`, `task_assignee.go`, `channel_relay.go`,
+`skill_manifest.go`, `skill_lookup.go`, `workspace_deletion.go`,
+`tree_controls.go`, `scheduler_integration.go`, `scheduler_recovery.go`,
+`scheduler_staleness.go`, `pricing.go`, `service.go` (constructor + wiring).
+
+Task 11 records that boundary in `apps/backend/AGENTS.md` so the mirror cannot
+grow back.
+
+---
+
+## Tests
+
+The test asymmetry is the single largest risk in this plan and is uneven across
+domains. Coverage counted from the working tree:
+
+| Domain | Facade tests | Sub-package tests | Consequence |
+| --- | --- | --- | --- |
+| config | 4 files, 576 LOC (`config_read_test.go` `config_sync_test.go` `config_test.go` `config_write_test.go`) | **0 files** | Tests **must** move to `office/config` or all config coverage is lost. Tasks 02, 03. |
+| projects | `service_project_test.go`, 144 LOC | **0 files** | Must move. Task 04. |
+| channels | `channels_test.go` 114 LOC, `channel_relay_test.go` | `handler_test.go` only | Service-layer tests must move. Task 07. |
+| agents | `agents_test.go`, 249 LOC | 7 files, 1,240 LOC | Sub-package suite survives; port only uncovered cases. Task 05. |
+| skills | none | 8 files, 2,169 LOC | Sub-package suite survives as-is. Task 06. |
+| routines | none | 2 files, 534 LOC | Sub-package suite survives as-is. Task 06. |
+| scheduler | `retry_test.go` and run tests | 3 files, 848 LOC | Facade is the owner here; scheduler-side tests move *to* the facade. Tasks 09, 10. |
+
+**Rule for every task:** tests move with the code they cover. Where both sides
+cover the same function, the surviving suite is the one on the **owning** side,
+and the task file names any assertion present only in the retired suite and
+ports it. No task may reduce the assertion count for a domain.
+
+Two specific coverage hazards:
+
+1. **Task 03 cannot be a test move.** The facade's config tests encode the
+   *unscoped* behavior (D1). Moving them to `office/config` verbatim would make
+   them fail, and "fixing" them to pass would re-introduce the bug. Task 03
+   writes new workspace-scoping tests first (RED), then reconciles.
+2. **`office/config` and `office/projects` have zero tests today.** Tasks 02, 03
+   and 04 are the only opportunity to land that coverage; each is required to.
+
+---
+
+## Constraints carried into every task
+
+- **`office/repository/sqlite.Repository` embeds `*runssqlite.Repository`**
+  (`office/repository/sqlite/base.go:60`). No task moves ownership of run writes.
+  Tasks 02–08 touch no run-write path at all.
+- **Sibling task `db3adcf4` is consolidating the run-cancel writers.** The cancel
+  path is **left alone**. Task 10 (`retry.go`/`retry_cancel.go`, whose real drift
+  D4 *is* the `cancelRetry` branch) is blocked on `db3adcf4` landing and must
+  rebase onto it. Tasks 01–09 and 11 are independent of it.
+- **Go limits** (`apps/backend/.golangci.yml`): functions ≤80 lines / ≤50
+  statements, cyclomatic ≤15, cognitive ≤30, nesting ≤5. Relevant to task 03,
+  where merging D1's scoping with D2's validated create path grows `apply*`.
+- **No production code change lands without its own green full suite.** Each task
+  is a separately mergeable PR.
+
+### Validation, every task
+
+```bash
+make -C apps/backend test
+make -C apps/backend lint
+cd apps/backend && golangci-lint run ./... --new-from-rev=main --timeout=5m
+```
+
+Plus the task's own targeted `go test` run, and a detector re-run:
+
+```bash
+cd docs/plans/office-service-collapse/officedup && GOTOOLCHAIN=local go run . \
+  ../../../../apps/backend/internal/office | head -3
+```
+
+**Environment note:** the backend full suite fails ~4 packages in a task worktree
+with `parent directory cannot be accessed`. That is the sandbox, not breakage —
+CI passes the same commit. Do not treat it as a blocker or try to fix it.
+
+---
+
+## Architecture decision
+
+**Yes, an ADR is warranted** — drafted at
+[`docs/decisions/2026-08-08-office-domain-ownership-boundary.md`](../../decisions/2026-08-08-office-domain-ownership-boundary.md).
+It meets `/record decision`'s criteria: it establishes a durable ownership
+boundary for the office domain (sub-packages own domain CRUD and HTTP;
+`office/service` owns run execution) and there are two real, rejected
+alternatives — absorb the sub-packages back into the facade, or keep the facade
+and make it delegate.
+
+---
+
+## Verification Results
+
+Pending. On completion, synchronize with each task's `## Results`: exact
+commands, outcomes/counts, the detector's group count before and after, and the
+final `office/service` LOC.
+
+---
+
+## Implementation Waves And Parallel Candidates
+
+Sequenced by risk: tooling first, then identical bodies, then drifted bodies,
+then the scheduler fork. Leaf domains (no facade consumer) precede domains the
+facade's own callers depend on (agents, reached by `scheduler`).
+
+```
+Wave 1 (tooling — no production code):
+- [ ] [task-01-duplication-detector](task-01-duplication-detector.md)
+
+Wave 2 (identical bodies, leaf domains — parallel candidates, disjoint files):
+- [ ] [task-02-config-helpers](task-02-config-helpers.md)
+- [ ] [task-04-projects-domain](task-04-projects-domain.md)
+- [ ] [task-06-skills-routines](task-06-skills-routines.md)
+
+Wave 3 (drifted bodies, and domains with facade consumers):
+- [ ] [task-03-config-import-drift](task-03-config-import-drift.md)   (depends on 02)
+- [ ] [task-05-agents-domain](task-05-agents-domain.md)
+- [ ] [task-07-channels-comments](task-07-channels-comments.md)
+- [ ] [task-08-activity-onboarding](task-08-activity-onboarding.md)
+
+Wave 4 (scheduler fork):
+- [ ] [task-09-scheduler-run-claim](task-09-scheduler-run-claim.md)
+- [ ] [task-10-scheduler-retry](task-10-scheduler-retry.md)   BLOCKED on db3adcf4
+
+Wave 5 (close out):
+- [ ] [task-11-narrow-facade-and-document](task-11-narrow-facade-and-document.md)
+```
+
+Waves 2 and 3 list parallel *candidates* only. Default execution is sequential in
+the primary conversation; waves do not authorize subagents.
+
+## Open Questions
+
+- **D6 (task 07):** changing the `events.OfficeCommentCreated` source string from
+  `"office-service"` to `"channels-service"` is wire-visible. No in-repo consumer
+  filters on it, but a plugin could. Task 07 asks for a decision rather than
+  assuming.
+- **Task 10 rebase surface:** the exact overlap with `db3adcf4` is unknown until
+  that task lands. Task 10's scope is provisional.

--- a/docs/plans/office-service-collapse/task-01-duplication-detector.md
+++ b/docs/plans/office-service-collapse/task-01-duplication-detector.md
@@ -1,0 +1,72 @@
+---
+id: "01-duplication-detector"
+title: "Land the duplication detector and golden inventory"
+status: pending
+wave: 1
+depends_on: []
+plan: "plan.md"
+spec: none
+parallel-safe: true
+---
+
+# Task 01: Duplication Detector and Golden Inventory
+
+Every later task's acceptance is "the detector's group count dropped by N".
+That check only exists if the detector is in the repo first. This task lands no
+production code, so it is risk-free and can merge immediately.
+
+## Inputs
+
+- [`officedup/main.go`](officedup/main.go) — the AST-based detector, already
+  written and committed with this plan.
+- [`inventory.md`](inventory.md) — the 2026-08-08 baseline it produced.
+
+## Acceptance
+
+- `docs/plans/office-service-collapse/officedup` runs clean from a fresh
+  checkout and reproduces **40 Section A groups** and **37 same-name Section B
+  pairs** against `fb1d8fdcd`.
+- `inventory.md` records the method well enough for someone who has never seen
+  it to re-run and reconcile — specifically the receiver-normalization step,
+  which is what the original text heuristic lacked.
+- The detector lives outside the `apps/backend` Go module (own `go.mod`), so
+  `make -C apps/backend test|lint` and `go vet ./...` never see it.
+
+## Verification
+
+```bash
+cd docs/plans/office-service-collapse/officedup
+GOTOOLCHAIN=local go run . ../../../../apps/backend/internal/office > /tmp/officedup-baseline.txt
+grep -c '^- ' /tmp/officedup-baseline.txt          # expect 40 Section A groups
+grep -c 'SAME-NAME' /tmp/officedup-baseline.txt    # expect 37
+
+# Confirm it is invisible to the backend module:
+make -C apps/backend lint
+```
+
+## Files likely touched
+
+- `docs/plans/office-service-collapse/officedup/main.go` (new)
+- `docs/plans/office-service-collapse/officedup/go.mod` (new)
+- `docs/plans/office-service-collapse/inventory.md` (new)
+
+## Dependencies
+
+None.
+
+## Parallelism
+
+`parallel-safe` — docs-only, disjoint from every other task.
+
+## Rollback position
+
+Revert the commit. Nothing in `apps/backend` depends on these files.
+
+## Output contract
+
+Summary, files changed, the baseline counts, and confirmation that the detector
+is outside the backend module.
+
+## Results
+
+Pending.

--- a/docs/plans/office-service-collapse/task-02-config-helpers.md
+++ b/docs/plans/office-service-collapse/task-02-config-helpers.md
@@ -1,0 +1,111 @@
+---
+id: "02-config-helpers"
+title: "Delete the facade's config sync/export/read mirror"
+status: pending
+wave: 2
+depends_on: ["01-duplication-detector"]
+plan: "plan.md"
+spec: none
+parallel-safe: true
+---
+
+# Task 02: Config Sync / Export / Read Mirror
+
+The largest single win and the lowest behavioral risk: 14 of the 40 identical
+groups are here, and every one is byte-identical after receiver normalization.
+`config_import.go` is deliberately **excluded** — its `apply*`/`preview*`
+functions carry the D1/D2 drift and are task 03.
+
+## Scope
+
+Delete from `internal/office/service`:
+
+- `config_sync.go` (134) — `ScanFilesystem` `parseErrorsFromLoader`
+  `IncomingDiff` `OutgoingDiff` `ApplyIncoming` `ApplyOutgoing`
+- `config_sync_helpers.go` (184) — `deleteRowsMissingFromBundle` `diffBundles`
+  and the `deleteMissing*` / `appendDeletions` family
+- `config_sync_util.go` (160) — `missingNames` `writeBundleEntities`
+- `config_export.go` (244) — `ExportBundle` `bundleToZip` `writeYAMLFile`
+  `export{Agents,Skills,Routines,Projects}`
+- `config_read.go` (118) — `List{Agents,Skills,Projects,Routines}FromConfig`,
+  `Get{Agent,Project,Routine}FromConfig`. **Keep `GetAgentFromConfig` for now** —
+  `scheduler` calls it at three sites; task 05 repoints them. Leave it in a
+  trimmed `config_read.go` and note the TODO pointing at task 05.
+
+`office/config` and `office/agents` already own equivalents. The `export*` and
+`deleteMissing*`/`appendDeletions` pairs read as drifted at 0.918–0.975 but are
+cosmetic — the facade calls its own one-line wrapper `ListXFromConfig`, `config`
+calls `repo.ListX` directly, and `service/config_read.go:12,30,53,83` show those
+are the same call (see [`inventory.md`](inventory.md) §Section B class 3).
+Verify that equivalence holds at implementation time before deleting.
+
+## Test migration
+
+`office/config` has **zero test files**. All four facade config test files must
+move, minus the import/preview cases that belong to task 03:
+
+| From | To | Note |
+| --- | --- | --- |
+| `service/config_read_test.go` (76) | `config/read_test.go` | direct move |
+| `service/config_sync_test.go` (122) | `config/sync_test.go` | direct move |
+| `service/config_write_test.go` (226) | `config/write_test.go` | direct move |
+| `service/config_test.go` (152) | `config/service_test.go` | **split** — import/preview cases stay in `service/` for task 03 to migrate |
+
+Adapt receivers (`*Service` → `*ConfigService`) and constructor calls. **No
+assertion may be dropped.** If a moved test exercises a facade method that has no
+`config` equivalent, that is a finding — stop and report it rather than deleting
+the test.
+
+## Acceptance
+
+1. Detector Section A drops by **14** groups; Section B same-name pairs drop by
+   **10** (`ApplyImport`, `export{Agents,Skills,Projects,Routines}`,
+   `deleteMissing{Agents,Projects,Routines,Skills}`, `appendDeletions`).
+   Measure as a delta against the branch point, not an absolute — wave-2 tasks
+   may land in any order. See the ledger in [`plan.md`](plan.md).
+2. `office/config` has non-zero test coverage for sync, export, and read.
+3. `make -C apps/backend test` green; no change to any HTTP route or response.
+
+## Verification
+
+```bash
+cd apps/backend && go test ./internal/office/config/... ./internal/office/service/... -count=1
+make -C apps/backend test
+make -C apps/backend lint
+cd apps/backend && golangci-lint run ./... --new-from-rev=main --timeout=5m
+
+cd docs/plans/office-service-collapse/officedup && GOTOOLCHAIN=local go run . \
+  ../../../../apps/backend/internal/office | head -3   # expect 14 fewer groups
+```
+
+## Files likely touched
+
+- deleted: `internal/office/service/config_sync.go`, `config_sync_helpers.go`,
+  `config_sync_util.go`, `config_export.go`
+- trimmed: `internal/office/service/config_read.go`
+- moved: the four `service/config*_test.go` files → `internal/office/config/`
+- possibly: `internal/office/service/service.go` (constructor field cleanup)
+
+## Dependencies
+
+Task 01 (for the group-count check).
+
+## Parallelism
+
+`parallel-safe` with tasks 04 and 06 — disjoint files, no shared schema,
+migration, or generated contract.
+
+## Rollback position
+
+Single revert. `office/config` was already the wired owner
+(`office/routes.go:60-61`), so reverting restores dead code, not behavior.
+
+## Output contract
+
+Summary, files changed, detector delta 40→26, the test-move table with final
+assertion counts per file, and any facade method found to have no `config`
+equivalent.
+
+## Results
+
+Pending.

--- a/docs/plans/office-service-collapse/task-03-config-import-drift.md
+++ b/docs/plans/office-service-collapse/task-03-config-import-drift.md
@@ -1,0 +1,149 @@
+---
+id: "03-config-import-drift"
+title: "Reconcile the config import/preview drift (D1 + D2)"
+status: pending
+wave: 3
+depends_on: ["02-config-helpers"]
+plan: "plan.md"
+spec: none
+parallel-safe: false
+---
+
+# Task 03: Config Import / Preview Drift
+
+**This is the highest-risk task in the plan.** It is the one place where a
+mechanical "delete one copy" would silently pick a behavior, and where *neither*
+copy is correct on its own.
+
+## The drift
+
+Eight pairs: `preview{Agents,Projects,Skills,Routines}` and
+`apply{Agents,Projects,Skills,Routines}`, between
+`service/config_import.go` and `config/import.go`.
+
+**D1 — workspace scoping. `office/config` is correct.**
+
+The facade declares the workspace parameter as `_ string` and lists with
+`ListXFromConfig(ctx, "")` — *every workspace*. `office/config` takes `wsID` and
+lists `repo.ListX(ctx, wsID)`. On the create branch `office/config` sets
+`WorkspaceID: wsID` on the new row; **the facade sets no `WorkspaceID` at all**.
+
+Consequences of the facade's version: importing a bundle into workspace B can
+match an entry by name against a row in workspace A and update it; and rows it
+creates have an empty `WorkspaceID`. This is not defensible as intentional.
+
+**D2 — validated create path. The facade is correct.**
+
+The facade calls `s.CreateProject` / `s.CreateSkill` / `s.CreateAgentInstance` /
+`s.UpdateProject`. `office/config` calls `s.repo.CreateX` **directly**, bypassing:
+
+- `service/service.go:520` `CreateProject` — `validateProject`, then defaults
+  `Status`→`ProjectStatusActive`, `Repositories`→`"[]"`, `ExecutorConfig`→`"{}"`
+- `service/agents.go:103` `CreateAgentInstance` — `validateAgentCreate`, then
+  defaults `ID` (uuid), `Permissions`→`DefaultPermissions(role)`,
+  `MaxConcurrentSessions`→1, `CooldownSec`→10
+- `skills.CreateSkill` — defaults `SourceType`→inline, `FileInventory`→`"[]"`,
+  runs `prepareSkillPackageMetadata`
+
+So `office/config` currently writes rows that skip validation and defaulting.
+
+**These two point in opposite directions and must be taken together.** The
+correct end state is `office/config`'s workspace scoping **plus** the validated
+create path, which today exists on neither side.
+
+## Approach (TDD — RED first)
+
+`office/config` has zero tests, so there is nothing to protect the reconciliation.
+Write the tests before touching the code.
+
+1. **RED — workspace scoping.** In `config/import_test.go`: two workspaces each
+   holding a same-named agent/project/skill/routine; import a bundle into
+   workspace B; assert workspace A's row is untouched and the created/updated row
+   carries `WorkspaceID == B`. This passes on `office/config` today and fails on
+   the facade — it pins D1.
+2. **RED — validation and defaulting.** Import a bundle whose entries omit
+   `Status` / `Repositories` / `Permissions` / `SourceType`; assert the persisted
+   rows carry the documented defaults, and that an entry violating
+   `validateProject` / `validateAgentCreate` is rejected. **This fails on
+   `office/config` today** — it is the regression D2 describes.
+3. **GREEN.** In `office/config`, replace the direct `repo.CreateX`/`UpdateX`
+   calls with the owning sub-package's validated methods
+   (`projects.ProjectService.CreateProject`, `agents.AgentService.CreateAgentInstance`,
+   `skills.SkillService.CreateSkill`, `routines.RoutineService.CreateRoutine`),
+   injected as narrow interfaces on `ConfigService`. Keep the `wsID` scoping.
+4. Delete `service/config_import.go` and migrate the import/preview cases held
+   back from `service/config_test.go` by task 02.
+
+> `routines.CreateRoutine` is a bare repo call plus an error wrap
+> (`service/service.go:687`), so for routines steps 3's change is a no-op beyond
+> setting `WorkspaceID`. Do not invent validation that does not exist.
+
+## Watch the Go limits
+
+Merging scoping with the validated create path grows the `apply*` functions,
+which are already 36–43 lines. `.golangci.yml` caps functions at 80 lines / 50
+statements, cyclomatic 15, cognitive 30, nesting 5. Extract a per-entity
+`upsertEntry` helper rather than growing the four `apply*` bodies in parallel.
+
+## Acceptance
+
+1. Detector Section A is **unchanged** (these eight are Section B pairs, not
+   Section A); Section B same-name pairs drop by **8**
+   (`preview{Agents,Projects,Skills,Routines}`,
+   `apply{Agents,Projects,Skills,Routines}`). Measure as a delta against the
+   branch point; see the ledger in [`plan.md`](plan.md).
+2. Importing into workspace B never reads or writes a row in workspace A.
+3. Imported rows carry `WorkspaceID` and the documented defaults; invalid
+   entries are rejected.
+4. `internal/office/service/config_import.go` no longer exists.
+
+## Verification
+
+```bash
+cd apps/backend && go test ./internal/office/config/... -run 'TestImport|TestPreview|TestApply' -count=1 -v
+cd apps/backend && go test ./internal/office/... -count=1
+make -C apps/backend test
+make -C apps/backend lint
+cd apps/backend && golangci-lint run ./... --new-from-rev=main --timeout=5m
+```
+
+## Files likely touched
+
+- `internal/office/config/import.go`, `internal/office/config/service.go`
+  (new narrow interface fields)
+- `internal/office/config/import_test.go` (new)
+- deleted: `internal/office/service/config_import.go`
+- `internal/office/services.go` and/or `internal/backendapp/main.go` — wiring the
+  validated collaborators into `config.ConfigService`
+- migrated import/preview cases from `internal/office/service/config_test.go`
+
+## Dependencies
+
+Task 02 (owns the rest of the config surface and the test relocation).
+
+## Parallelism
+
+`sequential`. Touches `office/services.go` wiring, which several other tasks read.
+
+## Rollback position
+
+Revert to task 02's state: `office/config` keeps the unvalidated-but-scoped
+behavior it has today, and the facade's `config_import.go` is already gone. **The
+scoping fix (D1) and the validation fix (D2) must land in the same commit** —
+splitting them leaves a window where imports are both unscoped and unvalidated.
+
+## Escalation
+
+If step 3 cannot inject the validated methods without an import cycle
+(`config` → `projects`/`agents`/`skills` while any of those imports `config`),
+**stop and report** rather than reaching for a repo-direct shortcut. That
+cycle would be a genuine finding about the boundary this plan's ADR establishes.
+
+## Output contract
+
+Summary, files changed, both RED tests quoted with their pre-fix failure output,
+Section B pair delta 37→29, and confirmation that D1 and D2 landed together.
+
+## Results
+
+Pending.

--- a/docs/plans/office-service-collapse/task-04-projects-domain.md
+++ b/docs/plans/office-service-collapse/task-04-projects-domain.md
@@ -1,0 +1,90 @@
+---
+id: "04-projects-domain"
+title: "Delete the facade's projects mirror"
+status: pending
+wave: 2
+depends_on: ["01-duplication-detector"]
+plan: "plan.md"
+spec: none
+parallel-safe: true
+---
+
+# Task 04: Projects Domain
+
+A leaf domain: `office/projects` (367 LOC) owns the routes
+(`office/routes.go:45-46`) and the `office/runtime` `Projects` action interface
+resolves to `svcs.Projects` (`office/routes.go:32`). Nothing calls the facade's
+project methods.
+
+## Scope
+
+Delete from `internal/office/service/service.go` (roughly lines 520–620):
+`CreateProject` `UpdateProject` `DeleteProject` `validateProject`
+`validateRepositories`, and `GetProjectFromConfig` /
+`ListProjectsFromConfig` / `ListProjectsWithCountsFromConfig` from
+`config_read.go` if task 02 left them.
+
+Four are byte-identical (`DeleteProject` `UpdateProject` `GetProjectFromConfig`
+`validateRepositories`). The two that read as drifted are **not**:
+
+- `CreateProject` (0.985) and `validateProject` (0.974) differ only because
+  `projects/models.go:7` declares `type Project = models.Project` and
+  `projects/models.go:15-18,28` alias the status constants. `models.Project` and
+  `Project` are the *same type*; `models.ValidProjectStatuses` and
+  `ValidProjectStatuses` are the *same variable*. Confirm those alias
+  declarations still exist before relying on this.
+
+## Test migration
+
+`office/projects` has **zero test files**. `service/service_project_test.go`
+(144 LOC) must move to `projects/service_test.go`, adapting the receiver to
+`*ProjectService`. Because of the type aliases, the assertions themselves should
+need no change — if one does, that is a real difference the inventory missed and
+should be reported.
+
+## Acceptance
+
+1. Detector Section A drops by **4** groups; Section B same-name pairs drop by 2.
+2. `office/projects` has non-zero test coverage.
+3. No change to `/api/.../projects` request or response shapes.
+
+## Verification
+
+```bash
+cd apps/backend && go test ./internal/office/projects/... -count=1 -v
+cd apps/backend && go test ./internal/office/... -count=1
+make -C apps/backend test
+make -C apps/backend lint
+cd apps/backend && golangci-lint run ./... --new-from-rev=main --timeout=5m
+```
+
+## Files likely touched
+
+- `internal/office/service/service.go` (delete the project block)
+- `internal/office/service/config_read.go` (project readers, if still present)
+- deleted: `internal/office/service/service_project_test.go`
+- new: `internal/office/projects/service_test.go`
+
+## Dependencies
+
+Task 01.
+
+## Parallelism
+
+`parallel-safe` with tasks 02 and 06. All three touch
+`internal/office/service/service.go`, so if run concurrently they **will**
+conflict there — run them sequentially or accept a trivial rebase. Files are
+otherwise disjoint.
+
+## Rollback position
+
+Single revert; restores dead code only.
+
+## Output contract
+
+Summary, files changed, detector delta, and confirmation that the type aliases in
+`projects/models.go` still hold (or the list of assertions that had to change).
+
+## Results
+
+Pending.

--- a/docs/plans/office-service-collapse/task-05-agents-domain.md
+++ b/docs/plans/office-service-collapse/task-05-agents-domain.md
@@ -1,0 +1,140 @@
+---
+id: "05-agents-domain"
+title: "Delete the facade's agents mirror and repoint scheduler"
+status: pending
+wave: 3
+depends_on: ["01-duplication-detector"]
+plan: "plan.md"
+spec: none
+parallel-safe: false
+---
+
+# Task 05: Agents Domain and the Scheduler Repoint
+
+The only CRUD domain with a live facade consumer. `office/scheduler` reaches
+three of these methods through its `svc *service.Service` field
+(`scheduler/run.go:154`), so this task is a repoint, not just a deletion — which
+is why it sits in wave 3 while the other leaf domains sit in wave 2.
+
+## Scope
+
+Delete `internal/office/service/agents.go` (313 LOC) and the agent readers in
+`config_read.go`. **Seven** identical groups are removed here:
+`GetAgentFromConfig` `ListAgentInstancesFiltered` `UpdateAgentInstance`
+`UpdateAgentStatus` `validateReportsTo` `validateStatusTransition`, and
+`countAgentsByRole` → `countAgentsByRoleInWorkspace` (**renamed**; the text
+heuristic missed this one).
+
+The eighth agents-domain group, `CreateDefaultInstructions`, is owned by
+`office/agents` but lives in `internal/office/service/instructions.go` — it is
+deleted by **task 07**, not here. Do not double-count it.
+
+### D3 — a real fix comes with the deletion
+
+`service/agents.go:275` `validateAgentNameUnique` swallows the repository error:
+
+```go
+exists, err := s.repo.AgentInstanceExistsByName(ctx, workspaceID, name, excludeID)
+if err != nil {
+    return nil          // ← facade: admits a duplicate name on any query failure
+}
+```
+
+`agents/service.go:804` returns `fmt.Errorf("check agent name uniqueness: %w", err)`.
+**`office/agents` is correct.** Deleting the facade copy fixes this by
+construction; add a test in `agents/service_test.go` that injects a failing
+repository and asserts the error propagates, so the fix is pinned rather than
+incidental.
+
+## The scheduler repoint
+
+Three call sites hold `*service.Service` and must move to `*agents.AgentService`:
+
+| Site | Call | Target |
+| --- | --- | --- |
+| `scheduler/run_processing.go:43` | `ss.svc.GetAgentFromConfig` | `agents.AgentService.GetAgentFromConfig` |
+| `scheduler/run.go:316` | `ss.svc.GetAgentFromConfig` | same |
+| `scheduler/retry.go:73` | `ss.svc.GetAgentFromConfig` | same |
+| `scheduler/retry.go:109` | `ss.svc.ListAgentInstancesFiltered` | `agents.AgentService.ListAgentInstancesFiltered` |
+| (also) | `ss.svc.ListAgentInstances` | `agents/service.go:213`, already forwards |
+
+`agents/service.go:207,213` already forward `GetAgentInstance` →
+`GetAgentFromConfig` and `ListAgentInstances` → `ListAgentsFromConfig` with
+matching signatures, so the seam exists. Add a narrow interface on
+`SchedulerService` (e.g. `agentReader`) rather than a concrete
+`*agents.AgentService` field, to keep `scheduler` testable and avoid widening the
+`scheduler → agents` edge.
+
+`scheduler/retry.go:110` also references `service.AgentListFilter`. Check whether
+`agents` exports an equivalent; if not, alias it in `agents` rather than keeping
+the `scheduler → service` import alive purely for a type name.
+
+`ss.svc.LogActivityWithRun` (`scheduler/retry.go:85`) is **task 08**, not this
+one. Leave it.
+
+## Test migration
+
+`office/agents` has 7 test files / 1,240 LOC; the facade has `agents_test.go`
+(249 LOC). The **`office/agents` suite survives**. Before deleting
+`service/agents_test.go`, diff its assertions against `agents/service_test.go`
+and port anything not already covered — in particular any `validateReportsTo` /
+`validateStatusTransition` / `UpdateAgentStatus` transition cases. Record in
+`## Results` which assertions were ported and which were already duplicated.
+
+## Acceptance
+
+1. Detector Section A drops by **7** groups; Section B same-name pairs drop by **3**
+   (`validateAgentCreate` 0.983, `validateAgentUpdate` 0.979,
+   `validateAgentNameUnique` 0.845).
+2. `internal/office/scheduler` no longer calls `svc.GetAgentFromConfig`,
+   `svc.ListAgentInstances`, or `svc.ListAgentInstancesFiltered`.
+3. A new test pins D3: a failing `AgentInstanceExistsByName` produces an error,
+   not a silent pass.
+4. No assertion lost from `service/agents_test.go`.
+
+## Verification
+
+```bash
+cd apps/backend && go test ./internal/office/agents/... ./internal/office/scheduler/... -count=1 -v
+cd apps/backend && go test ./internal/office/... -count=1
+make -C apps/backend test
+make -C apps/backend lint
+cd apps/backend && golangci-lint run ./... --new-from-rev=main --timeout=5m
+
+# confirm the repoint actually happened:
+grep -rn 'svc\.GetAgentFromConfig\|svc\.ListAgentInstances' apps/backend/internal/office/scheduler/   # expect no hits
+```
+
+## Files likely touched
+
+- deleted: `internal/office/service/agents.go`, `internal/office/service/agents_test.go`
+- `internal/office/service/config_read.go` (agent readers)
+- `internal/office/scheduler/run.go`, `run_processing.go`, `retry.go`
+- `internal/office/agents/service.go` (possible `AgentListFilter` alias)
+- `internal/office/agents/service_test.go` (D3 test + ported assertions)
+- `internal/office/services.go`, `internal/backendapp/main.go` (scheduler wiring)
+
+## Dependencies
+
+Task 01. Independent of tasks 02–04, but shares `office/services.go` wiring with
+task 03 — sequence after it if both are in flight.
+
+## Parallelism
+
+`sequential`.
+
+## Rollback position
+
+Single revert. The scheduler repoint and the `agents.go` deletion **must be one
+commit** — reverting only the deletion would leave `scheduler` pointing at
+methods that still exist but are no longer the ones under test.
+
+## Output contract
+
+Summary, files changed, detector delta, the ported-assertion list, D3's new test
+with its pre-fix failure output, and the grep showing zero remaining scheduler
+calls into the facade's agent methods.
+
+## Results
+
+Pending.

--- a/docs/plans/office-service-collapse/task-06-skills-routines.md
+++ b/docs/plans/office-service-collapse/task-06-skills-routines.md
@@ -1,0 +1,106 @@
+---
+id: "06-skills-routines"
+title: "Delete the facade's skills and routines mirrors"
+status: pending
+wave: 2
+depends_on: ["01-duplication-detector"]
+plan: "plan.md"
+spec: none
+parallel-safe: true
+---
+
+# Task 06: Skills and Routines Domains
+
+The cheapest task in the plan: both sub-packages are well tested, both own their
+routes, and the skills seam **already exists** — `service/skill_compat.go`
+re-exports `skills.AgentTypeResolver`, `skills.ProjectSkillDirResolver`,
+`skills.ParseDesiredSlugs`, `SkillSourceTypeInline` and `DefaultProjectSkillDir`.
+The facade already depends on `office/skills`; it just never deleted its own copy
+of the CRUD.
+
+## Scope
+
+Delete from `internal/office/service/service.go`:
+
+- skills (lines ~461–518): `CreateSkill` `UpdateSkill` `DeleteSkill`
+  `prepareServiceSkillPackageMetadata`
+- routines (lines ~687–730): `CreateRoutine` `UpdateRoutine` `DeleteRoutine`
+  `GetRoutine` `ListRoutines`
+
+and `GetSkillFromConfig` / `ListSkillsFromConfig` / `GetRoutineFromConfig` /
+`ListRoutinesFromConfig` from `config_read.go` if task 02 left them.
+
+Identical groups: `DeleteSkill`, `prepareServiceSkillPackageMetadata` →
+`prepareSkillPackageMetadata` (**renamed**), `CreateRoutine`, `UpdateRoutine`,
+`DeleteRoutine`, `GetRoutineFromConfig`.
+
+`CreateSkill` (0.972) and `UpdateSkill` (0.952) differ only by that helper
+rename. `applyRoutines`' use of `CreateRoutine` is a bare repo call plus an error
+wrap — there is no validation to preserve on the routines side.
+
+### D5 — sentinel error, decided
+
+`GetSkillFromConfig`: the facade returns `fmt.Errorf("skill not found: %s", …)`;
+`skills/service.go:237` returns `fmt.Errorf("%w: %s", ErrSkillNotFound, …)`.
+**`office/skills` wins** — only its form is matchable with `errors.Is`.
+
+One caller reaches this through an interface:
+`internal/agent/runtime/lifecycle/skill/manifest.go:45`
+(`d.skillReader.GetSkillFromConfig`). Confirm that call site's error handling
+before switching — if it string-matches `"skill not found"`, update it to
+`errors.Is(err, skills.ErrSkillNotFound)` in the same commit.
+`skills/errors_test.go` already exists; extend it rather than adding a new file.
+
+## Test migration
+
+None required. `office/skills` has 8 test files / 2,169 LOC and
+`office/routines` 2 files / 534 LOC; the facade has **no** skill or routine test
+files. Nothing is lost. Add only the D5 caller test described above.
+
+## Acceptance
+
+1. Detector Section A drops by **6** groups; Section B same-name pairs drop by 3.
+2. `errors.Is(err, skills.ErrSkillNotFound)` holds at the
+   `lifecycle/skill/manifest.go` call site.
+3. `make -C apps/backend test` green.
+
+## Verification
+
+```bash
+cd apps/backend && go test ./internal/office/skills/... ./internal/office/routines/... -count=1
+cd apps/backend && go test ./internal/agent/runtime/lifecycle/skill/... -count=1 -v
+make -C apps/backend test
+make -C apps/backend lint
+cd apps/backend && golangci-lint run ./... --new-from-rev=main --timeout=5m
+```
+
+## Files likely touched
+
+- `internal/office/service/service.go` (delete the skill and routine blocks)
+- `internal/office/service/config_read.go`
+- possibly `internal/office/service/skill_compat.go` (drop now-unused re-exports)
+- `internal/agent/runtime/lifecycle/skill/manifest.go` (D5 error handling)
+- `internal/office/skills/errors_test.go`
+
+## Dependencies
+
+Task 01.
+
+## Parallelism
+
+`parallel-safe` with tasks 02 and 04 in principle, but all three edit
+`internal/office/service/service.go` — expect a rebase if run concurrently.
+
+## Rollback position
+
+Single revert. If only the D5 half needs backing out, the sentinel-error change
+at the `manifest.go` call site is independently revertible from the deletions.
+
+## Output contract
+
+Summary, files changed, detector delta, and the `manifest.go` error-handling
+decision with evidence of how that call site previously matched the error.
+
+## Results
+
+Pending.

--- a/docs/plans/office-service-collapse/task-07-channels-comments.md
+++ b/docs/plans/office-service-collapse/task-07-channels-comments.md
@@ -1,0 +1,130 @@
+---
+id: "07-channels-comments"
+title: "Delete the facade's channels, comments and instructions mirrors"
+status: pending
+wave: 3
+depends_on: ["01-duplication-detector"]
+plan: "plan.md"
+spec: none
+parallel-safe: false
+---
+
+# Task 07: Channels, Comments, Instructions
+
+Carries the one **open question** in the plan (D6), which is why it is not in
+wave 2 despite being a leaf domain.
+
+## Scope
+
+Delete from `internal/office/service`:
+
+- `channels.go` (145) — `SetupChannel` `HandleChannelInbound` `createChannelTask`
+  `GetChannelByID`
+- `comments.go` (55) — `CreateComment` `publishCommentCreated`
+- `instructions.go` (47) — `CreateDefaultInstructions`
+
+**Keep `channel_relay.go`** — it is run-engine code, not a channels mirror, and
+stays in `office/service` (see plan §"What `office/service` keeps").
+`NewChannelRelayWithClient` currently shows as unreachable in
+`deadcode ./...`; that is a separate question, not this task's.
+
+Identical groups: `HandleChannelInbound`, `CreateComment`,
+`CreateDefaultInstructions` (this last one pairs with **`office/agents`**, not
+`office/channels`).
+
+`SetupChannel` reads as drifted at 0.975 but is **cosmetic** — verified:
+
+- `s.GetAgentFromConfig` vs `s.agents.GetAgentInstance`: `agents/service.go:207`
+  is `return s.GetAgentFromConfig(ctx, idOrName)`, identical including the
+  by-name fallback through `GetAgentInstanceByNameAny`.
+- `s.createChannelTask` vs `s.repo.CreateChannelTask`:
+  `service/channels.go:90` is a pass-through.
+- the remaining diff is a reworded ADR-0005 doc comment.
+
+Re-verify both pass-throughs at implementation time before relying on this.
+
+## D6 — OPEN QUESTION, do not decide silently
+
+`publishCommentCreated` differs in two ways:
+
+| | facade (`service/comments.go:41`) | `channels/comments.go:34` |
+| --- | --- | --- |
+| event source | `"office-service"` | `"channels-service"` |
+| payload type | `CommentPostedData` (exported) | `commentPostedData` (unexported) |
+
+The payload type difference is internal and harmless — the wire shape is
+identical. **The source string is wire-visible on `events.OfficeCommentCreated`.**
+No in-repo consumer filters on it (verified by grep across `internal/` and
+`apps/web/`), but a Kandev plugin subscribing to the office event stream could.
+
+Since `office/channels` is the wired owner (`office/routes.go:57-58`), deleting
+the facade copy changes the emitted source from `"office-service"` to
+`"channels-service"` **whether or not that is intended**. Options:
+
+1. Accept the change (it reflects reality after this refactor).
+2. Set `channels`' source back to `"office-service"` to preserve the wire value.
+
+**Ask before implementing.** Do not let a deletion make this choice implicitly.
+
+## Test migration
+
+`office/channels` has only `handler_test.go` (31 LOC). The facade's
+`channels_test.go` (114) and `instructions_test.go` (143) cover service-layer
+behavior with no sub-package equivalent.
+
+| From | To | Note |
+| --- | --- | --- |
+| `service/channels_test.go` | `channels/service_test.go` | direct move, receiver → `*ChannelService` |
+| `service/instructions_test.go` | `agents/instructions_test.go` | `CreateDefaultInstructions` lives in `office/agents` |
+| `service/channel_relay_test.go` | — | **stays**; `channel_relay.go` stays |
+
+If D6 option 1 is chosen, the moved channel tests must assert the new source
+string explicitly so the change is pinned rather than incidental.
+
+## Acceptance
+
+1. Detector Section A drops by **3** groups; Section B same-name pairs drop by 2.
+2. `office/channels` has service-layer test coverage where it had none.
+3. D6 is decided explicitly and the chosen source string is asserted in a test.
+4. `channel_relay.go` and its test are untouched.
+
+## Verification
+
+```bash
+cd apps/backend && go test ./internal/office/channels/... ./internal/office/agents/... -count=1 -v
+cd apps/backend && go test ./internal/office/service/... -run ChannelRelay -count=1
+cd apps/backend && go test ./internal/office/... -count=1
+make -C apps/backend test
+make -C apps/backend lint
+cd apps/backend && golangci-lint run ./... --new-from-rev=main --timeout=5m
+```
+
+## Files likely touched
+
+- deleted: `internal/office/service/channels.go`, `comments.go`, `instructions.go`
+- moved: `service/channels_test.go` → `channels/service_test.go`;
+  `service/instructions_test.go` → `agents/instructions_test.go`
+- possibly `internal/office/channels/comments.go` (D6 source string)
+
+## Dependencies
+
+Task 01.
+
+## Parallelism
+
+`sequential` — blocked on the D6 answer.
+
+## Rollback position
+
+Single revert. If D6 option 1 turns out to break a plugin, the source string is a
+one-line follow-up revert independent of the deletions.
+
+## Output contract
+
+Summary, files changed, detector delta, **the D6 decision and who made it**, the
+test-move table, and re-verification that both `SetupChannel` pass-throughs still
+hold.
+
+## Results
+
+Pending.

--- a/docs/plans/office-service-collapse/task-08-activity-onboarding.md
+++ b/docs/plans/office-service-collapse/task-08-activity-onboarding.md
@@ -1,0 +1,118 @@
+---
+id: "08-activity-onboarding"
+title: "Collapse activity logging onto shared, and the onboarding strays"
+status: pending
+wave: 3
+depends_on: ["01-duplication-detector"]
+plan: "plan.md"
+spec: none
+parallel-safe: false
+---
+
+# Task 08: Activity Logging, Onboarding and Dashboard Strays
+
+Cleans up the three duplicate groups that were **not in the original brief** —
+they surfaced only once the detector normalized receiver identifiers.
+
+## Scope
+
+### Activity → `office/shared`
+
+`service/activity.go` (146 LOC) duplicates `shared/activity.go`:
+
+- `LogActivityWithRun` — 0.982, differs only by receiver
+  (`*Service` vs `*ActivityLoggerImpl`) and one parameter rename
+  (`workspaceID` → `wsID`). Cosmetic.
+- `ListActivityFiltered` — byte-identical to **`dashboard/service.go:600`**
+  (a third copy).
+
+`office/shared` has 31 non-test importers and already provides the activity
+interface most of the tree consumes. Delete `service/activity.go` and have the
+facade hold a `shared.ActivityLogger`.
+
+**This has one live consumer:** `scheduler/retry.go:85` calls
+`ss.svc.LogActivityWithRun`. Repoint it at `shared` the same way task 05
+repointed the agent readers — a narrow interface field on `SchedulerService`, not
+a concrete type.
+
+`ListActivityFiltered`'s dashboard copy stays; `office/dashboard` owns the
+activity read routes.
+
+### Onboarding strays
+
+`service/service.go:833` `generateSlug` and `service/service.go:848`
+`writeWorkspaceConfig` are byte-identical to `onboarding/service.go:506` and
+`onboarding/service.go:479`. `office/onboarding` owns onboarding
+(`office/routes.go:70`). Delete the facade copies.
+
+`service/test_helpers.go:99` `GenerateSlugForTest` exists only to expose
+`generateSlug` to tests and shows as unreachable in `deadcode ./...` — delete it
+with the function it wraps.
+
+### Explicitly out of scope
+
+`dashboard/run_detail.go:83` `taskIDFromPayload` ↔
+`scheduler/dispatch_routing.go:636` `extractRunTaskID` is a genuine identical
+pair, but it involves **no `office/service` copy** — it is a dashboard↔scheduler
+duplication outside this plan's remit. Recorded in
+[`inventory.md`](inventory.md) for a future task; do not fix it here.
+
+## Test migration
+
+`service/activity_test.go` (72 LOC) moves to `shared/activity_test.go`, adapting
+the receiver to `*ActivityLoggerImpl`. Check whether `office/shared` already has
+activity tests and merge rather than overwrite.
+
+## Acceptance
+
+1. Detector Section A drops by **3** groups (`ListActivityFiltered`,
+   `generateSlug`, `writeWorkspaceConfig`); Section B same-name pairs drop by 1
+   (`LogActivityWithRun`).
+2. `internal/office/scheduler` no longer calls `svc.LogActivityWithRun`.
+3. `GenerateSlugForTest` is gone from `service/test_helpers.go`.
+4. Activity rows written by the scheduler retry path are unchanged — same
+   `action`, `actor_type`, `actor_id`, `run_id`.
+
+## Verification
+
+```bash
+cd apps/backend && go test ./internal/office/shared/... ./internal/office/scheduler/... -count=1 -v
+cd apps/backend && go test ./internal/office/... -count=1
+make -C apps/backend test
+make -C apps/backend lint
+cd apps/backend && golangci-lint run ./... --new-from-rev=main --timeout=5m
+
+grep -rn 'svc\.LogActivityWithRun' apps/backend/internal/office/scheduler/   # expect no hits
+```
+
+## Files likely touched
+
+- deleted: `internal/office/service/activity.go`, `service/activity_test.go`
+- `internal/office/service/service.go` (drop `generateSlug`,
+  `writeWorkspaceConfig`; add a `shared.ActivityLogger` field)
+- `internal/office/service/test_helpers.go` (drop `GenerateSlugForTest`)
+- `internal/office/scheduler/retry.go` (activity repoint)
+- `internal/office/shared/activity_test.go`
+- `internal/office/services.go`, `internal/backendapp/main.go` (wiring)
+
+## Dependencies
+
+Task 01. Overlaps `scheduler/retry.go` with tasks 05 and 10 — sequence after 05.
+
+## Parallelism
+
+`sequential`.
+
+## Rollback position
+
+Single revert. The activity repoint and the `activity.go` deletion must be one
+commit; the onboarding-stray deletions are independently revertible.
+
+## Output contract
+
+Summary, files changed, detector delta, the scheduler repoint grep, and evidence
+that activity rows from the retry path are byte-identical before and after.
+
+## Results
+
+Pending.

--- a/docs/plans/office-service-collapse/task-09-scheduler-run-claim.md
+++ b/docs/plans/office-service-collapse/task-09-scheduler-run-claim.md
@@ -1,0 +1,117 @@
+---
+id: "09-scheduler-run-claim"
+title: "Collapse the scheduler run-claim and guard fork"
+status: pending
+wave: 4
+depends_on: ["05-agents-domain"]
+plan: "plan.md"
+spec: none
+parallel-safe: false
+---
+
+# Task 09: Scheduler Run-Claim / Guard Fork
+
+The direction reverses here. For the six CRUD domains the sub-package is the
+owner; for the scheduler **the facade is the owner**, because
+`office/scheduler` already imports `office/service`:
+
+- `scheduler/run.go:154` — `svc *service.Service`
+- `scheduler/run.go:54` — `type LaunchContext = service.LaunchContext`
+- `scheduler/executor_resolver.go:11` — `type ExecutorConfig = service.ExecutorConfig`
+- `scheduler/retry.go:110` — `service.AgentListFilter`
+
+Making the facade delegate to `scheduler` would invert an existing edge and
+create an import cycle. So `scheduler`'s copies collapse **onto** the facade's.
+
+## Scope
+
+Delete the duplicated run-claim and guard logic from `office/scheduler`, leaving
+`office/service` as the single implementation:
+
+| Pair | Similarity | Facade home | Scheduler copy |
+| --- | --- | --- | --- |
+| `ClaimNextRun` | **identical** | `service/scheduler_runs.go:18` | `scheduler/run_processing.go:15` |
+| `ProcessRunGuard` | 0.979 | `service/scheduler_runs.go:100` | `scheduler/run_processing.go:42` |
+| `guardAgentStatus` | 0.978 | `service/run.go:170` | `scheduler/run.go:315` |
+
+All three differ only by receiver (`s` vs `ss`) and one hop of collaborator
+indirection (`s.GetAgentFromConfig` vs `ss.svc.GetAgentFromConfig`) — no
+behavioral drift. Re-confirm with the detector before deleting.
+
+**Note the interaction with task 05:** that task repoints
+`ss.svc.GetAgentFromConfig` onto `agents.AgentService`. Whichever lands second
+must reconcile — if 05 has landed, the scheduler copies already call `agents`,
+and collapsing them onto the facade's copies means the facade's `ProcessRunGuard`
+/ `guardAgentStatus` should also take an agent reader rather than calling its own
+`GetAgentFromConfig` (which task 05 deleted). Sequence 05 first, as declared.
+
+## Explicitly out of scope
+
+`retryDelayWithJitter` (identical), `escalateFailure` (0.982),
+`queueCEOAgentError` (0.960) and `scheduleRetry` (0.745) are **task 10** and are
+blocked on `db3adcf4`. Do not touch `service/retry.go`,
+`service/retry_cancel.go`, or `scheduler/retry.go`'s retry logic here.
+
+## Test migration
+
+`office/scheduler` has 3 test files / 848 LOC; the facade has run and scheduler
+tests. Since the facade is the owner here, **scheduler-side tests for these three
+functions move to `office/service`**, not the other way round. Diff first: any
+`ClaimNextRun` / `ProcessRunGuard` / `guardAgentStatus` case present only in
+`scheduler`'s suite must be ported into the facade's, and the task records which.
+
+Leave every scheduler test covering tick-loop, dispatch, and routing where it is
+— those are `office/scheduler`'s own behavior, not fork.
+
+## Acceptance
+
+1. Detector Section A drops by **1** group (`ClaimNextRun`); Section B same-name
+   pairs drop by 2.
+2. `office/scheduler` has one implementation of run claiming and agent-status
+   guarding, delegating to `office/service`.
+3. Run claiming is unchanged under concurrency — the existing claim/lease tests
+   pass unmodified.
+4. No change to `office/repository/sqlite` or any run-write path.
+
+## Verification
+
+```bash
+cd apps/backend && go test ./internal/office/scheduler/... ./internal/office/service/... -count=1 -v
+cd apps/backend && go test ./internal/office/scheduler/... -run 'Claim|Guard' -count=20   # concurrency shake-out
+cd apps/backend && go test ./internal/office/... -count=1
+make -C apps/backend test
+make -C apps/backend lint
+cd apps/backend && golangci-lint run ./... --new-from-rev=main --timeout=5m
+```
+
+## Files likely touched
+
+- `internal/office/scheduler/run_processing.go` (delete `ClaimNextRun`,
+  `ProcessRunGuard`; delegate)
+- `internal/office/scheduler/run.go` (delete `guardAgentStatus`; delegate)
+- `internal/office/service/scheduler_runs.go`, `internal/office/service/run.go`
+  (accept an agent reader if task 05 has landed)
+- scheduler test files for the three functions
+
+## Dependencies
+
+Task 05 (the agent-reader repoint). Task 01 for the count check.
+
+## Parallelism
+
+`sequential`.
+
+## Rollback position
+
+Single revert. This task deliberately does not touch the cancel path, so it is
+independent of `db3adcf4` and can be reverted without coordinating with it.
+
+## Output contract
+
+Summary, files changed, detector delta, the ported-test list, the `-count=20`
+concurrency result, and confirmation that `service/retry*.go` and
+`scheduler/retry.go` were not modified.
+
+## Results
+
+Pending.

--- a/docs/plans/office-service-collapse/task-10-scheduler-retry.md
+++ b/docs/plans/office-service-collapse/task-10-scheduler-retry.md
@@ -1,0 +1,127 @@
+---
+id: "10-scheduler-retry"
+title: "Collapse the scheduler retry fork (blocked on db3adcf4)"
+status: blocked
+wave: 4
+depends_on: ["09-scheduler-run-claim"]
+blocked_on: "sibling task db3adcf4 (run-cancel writer consolidation)"
+plan: "plan.md"
+spec: none
+parallel-safe: false
+---
+
+# Task 10: Scheduler Retry Fork
+
+> **BLOCKED.** Do not start until sibling task `db3adcf4` — consolidating the
+> run-cancel writers — has landed on `main`. This task's central drift (D4) is
+> exactly the `cancelRetry` branch that `db3adcf4` is rewriting. Starting early
+> guarantees a conflict in the one part of the tree the plan was told to leave
+> alone.
+
+## Scope
+
+Four pairs between `service/retry.go` and `scheduler/retry.go`:
+
+| Pair | Similarity | Nature |
+| --- | --- | --- |
+| `retryDelayWithJitter` | **identical** | pure function, no drift |
+| `escalateFailure` | 0.982 | cosmetic — receiver + `ss.svc.` indirection |
+| `queueCEOAgentError` | 0.960 | cosmetic — plus `service.AgentListFilter` qualification |
+| `scheduleRetry` | 0.745 | **real drift (D4)** |
+
+As in task 09, the facade is the owner: `office/scheduler` imports
+`office/service`, not the reverse.
+
+## D4 — the real drift
+
+`service/retry.go:46` opens with a staleness guard that `scheduler/retry.go:50`
+does not have at all:
+
+```go
+if stale, reason := isRetryStale(run); stale {
+    return s.cancelRetry(ctx, run, reason)
+}
+```
+
+and logs `zap.String("source", "backoff")`, which `scheduler` also omits.
+
+**The facade is correct.** `office/scheduler` currently reschedules runs that the
+facade would cancel as stale. Collapsing onto the facade's copy fixes this — but
+that fix routes through `cancelRetry`, which is why the task is blocked.
+
+## Required first step, after `db3adcf4` lands
+
+1. Re-run the detector and re-diff all four pairs against the **post-`db3adcf4`**
+   tree. `scheduleRetry`'s similarity and `cancelRetry`'s shape will both have
+   moved; the D4 description above is written against `fb1d8fdcd` and must be
+   re-verified, not assumed.
+2. Establish where `db3adcf4` left ownership of the cancel write. If it
+   centralized cancellation somewhere new, `cancelRetry` should call that rather
+   than this task re-establishing a second writer.
+3. Only then collapse. **Scope is provisional until step 1 is done.**
+
+## Constraint
+
+`office/repository/sqlite.Repository` embeds `*runssqlite.Repository`
+(`office/repository/sqlite/base.go:60`). This task is the only one in the plan
+that goes near run writes. It must not move ownership of them — the retry
+scheduling write (`repo.ScheduleRetry`) and the cancel write stay exactly where
+`db3adcf4` leaves them.
+
+## Test migration
+
+Facade `retry_test.go` cases are the surviving suite. Port any scheduler-side
+retry case not already covered. Add a test pinning D4: a stale run reaching
+`scheduleRetry` is cancelled with its reason, not rescheduled — asserted through
+`office/scheduler`'s entry point, so it proves the fork is actually gone.
+
+## Acceptance
+
+1. Detector Section A drops by **1** group (`retryDelayWithJitter`); Section B
+   same-name pairs drop by 3.
+2. A stale run routed through `office/scheduler` is cancelled, not rescheduled.
+3. `zap` field `source=backoff` is emitted on the scheduler retry path.
+4. `git diff` shows no change to run-write ownership or to
+   `office/repository/sqlite/base.go`.
+
+## Verification
+
+```bash
+cd apps/backend && go test ./internal/office/scheduler/... ./internal/office/service/... -run 'Retry|Escalat|Cancel' -count=1 -v
+cd apps/backend && go test ./internal/office/... ./internal/runs/... -count=1
+make -C apps/backend test
+make -C apps/backend lint
+cd apps/backend && golangci-lint run ./... --new-from-rev=main --timeout=5m
+
+git diff --stat main -- apps/backend/internal/office/repository/   # expect empty
+```
+
+## Files likely touched
+
+- `internal/office/scheduler/retry.go` (delete the fork; delegate)
+- `internal/office/service/retry.go`, `internal/office/service/retry_cancel.go`
+- retry test files on both sides
+
+## Dependencies
+
+Task 09, and **`db3adcf4` merged to `main`**.
+
+## Parallelism
+
+`sequential`.
+
+## Rollback position
+
+Single revert to task 09's state, which leaves the retry fork intact but the
+run-claim fork collapsed. Because this task rebases onto `db3adcf4`, record the
+`db3adcf4` merge SHA in `## Results` so a later revert knows its base.
+
+## Output contract
+
+Summary, files changed, detector delta, the **re-verified** D4 diff against the
+post-`db3adcf4` tree, the `db3adcf4` merge SHA, the D4 regression test with its
+pre-fix failure output, and the empty repository-diff check.
+
+## Results
+
+Pending.

--- a/docs/plans/office-service-collapse/task-11-narrow-facade-and-document.md
+++ b/docs/plans/office-service-collapse/task-11-narrow-facade-and-document.md
@@ -1,0 +1,122 @@
+---
+id: "11-narrow-facade-and-document"
+title: "Narrow the facade's exported surface and document the boundary"
+status: pending
+wave: 5
+depends_on: ["02-config-helpers", "03-config-import-drift", "04-projects-domain", "05-agents-domain", "06-skills-routines", "07-channels-comments", "08-activity-onboarding", "09-scheduler-run-claim"]
+plan: "plan.md"
+spec: none
+parallel-safe: false
+---
+
+# Task 11: Narrow the Facade and Record the Boundary
+
+Closes the plan. Without this task the mirror grows back — nothing in the repo
+would state that `office/service` is not where office CRUD goes.
+
+Deliberately does **not** depend on task 10: the retry fork can land later
+without holding up the boundary documentation.
+
+## Scope
+
+### 1. Narrow the exported surface
+
+After tasks 02–09, `*service.Service`'s live external surface should be exactly
+the 17 methods enumerated in [`inventory.md`](inventory.md) §"Live consumers":
+
+- `tree_controls` — `CancelTaskTree` `PauseTaskTree` `ResumeTaskTree`
+  `RestoreTaskTree` `PreviewTaskTree` `GetSubtreeCostSummary`
+- `workspaces` — `DeleteWorkspace` `GetWorkspaceDeletionSummary`
+- `scheduler` — `BuildWakePayload` `ResolveExecutor` (the other four are
+  repointed by tasks 05 and 08)
+- `backendapp` — `SetWorkflowEngineDispatcher` `ListFailedRunInboxRows`
+  `ListPausedAgentInboxRows` plus the `Set*` / `Register*` wiring calls
+
+Unexport anything left over that no longer has an external caller. Re-run
+`deadcode ./...` and clear what it reports in `office/service` — the pre-existing
+`IdleTimeoutManager` cluster (`idle_timeout.go:38-161`, 8 unreachable funcs) and
+`TickIntervalFromEnv` are **out of scope**; report them as a follow-up finding
+rather than deleting them here, since they are unrelated to the collapse.
+
+### 2. Record the boundary
+
+Update `apps/backend/AGENTS.md`, in the `internal/office/` section:
+
+> `internal/office/service` owns **run execution only** — the tick/dispatch
+> loop, prompt and env construction, executor resolution, wake payloads, failure
+> and retry handling, task-tree controls, and workspace deletion. Domain CRUD,
+> config import/export, and every HTTP route belong to the feature sub-packages
+> (`agents`, `skills`, `projects`, `routines`, `config`, `channels`, `costs`,
+> `approvals`, `labels`, `dashboard`, `onboarding`). `office/service` has no
+> `gin` import and must not gain one. New office CRUD goes in the sub-package,
+> never in `service`.
+
+Then land the ADR at
+`docs/decisions/2026-08-08-office-domain-ownership-boundary.md` (drafted with
+this plan) and add its row to `docs/decisions/INDEX.md`.
+
+### 3. Close the loop on the detector
+
+Record the final Section A and Section B counts in
+[`inventory.md`](inventory.md) as an "after" column beside the 2026-08-08
+baseline, so the next person can tell what this plan removed from what it left.
+
+Expected end state: Section A **40 → 2** (the out-of-scope
+`taskIDFromPayload`↔`extractRunTaskID` dashboard↔scheduler pair, plus
+`retryDelayWithJitter` if task 10 has not landed). Section B same-name pairs
+**37 → 3** or fewer.
+
+## Acceptance
+
+1. `apps/backend/AGENTS.md` states the ownership boundary.
+2. The ADR is committed and indexed in `docs/decisions/INDEX.md`.
+3. `inventory.md` carries before/after counts.
+4. `grep -rn 'gin\.' apps/backend/internal/office/service/` returns nothing.
+5. Every remaining exported method on `*service.Service` has a named external
+   caller, or is documented as intentionally exported for test support.
+
+## Verification
+
+```bash
+grep -rn 'gin\.' apps/backend/internal/office/service/    # expect no hits
+cd apps/backend && ~/go/bin/deadcode ./... | grep 'office/service'
+cd apps/backend && wc -l $(find internal/office/service -name '*.go' -not -name '*_test.go') | tail -1
+
+make -C apps/backend test
+make -C apps/backend lint
+cd apps/backend && golangci-lint run ./... --new-from-rev=main --timeout=5m
+
+cd docs/plans/office-service-collapse/officedup && GOTOOLCHAIN=local go run . \
+  ../../../../apps/backend/internal/office | head -3
+```
+
+## Files likely touched
+
+- `apps/backend/AGENTS.md`
+- `docs/decisions/2026-08-08-office-domain-ownership-boundary.md`
+- `docs/decisions/INDEX.md`
+- `docs/plans/office-service-collapse/inventory.md`, `plan.md`
+- `internal/office/service/*.go` (unexporting leftovers)
+
+## Dependencies
+
+Tasks 02–09. Explicitly **not** task 10.
+
+## Parallelism
+
+`sequential`.
+
+## Rollback position
+
+Docs-only except the unexporting. If an unexport breaks an unforeseen caller,
+revert that symbol alone — the AGENTS.md and ADR changes stand independently.
+
+## Output contract
+
+Summary, files changed, final `office/service` LOC against the 7,818 baseline,
+before/after detector counts, the `deadcode` residue reported as follow-up, and
+the ADR link.
+
+## Results
+
+Pending.


### PR DESCRIPTION
`internal/office/service` (7,818 LOC) carries a live, verbatim copy of the CRUD and config logic that also lives in the office sub-packages it was partly extracted into — the extraction moved the routes but never deleted the source, and the two copies have since begun to diverge into real bugs. This commits an implementation plan that removes the mirror across eleven independently mergeable PRs, plus a draft ADR recording the ownership boundary that results.

Plan only — no production code changes.

## Important Changes

- **The inventory was regenerated, not trusted.** The prior list came from normalized-body text hashing. This uses `go/parser` + `go/printer` and rewrites the receiver identifier to a fixed token before hashing, so `func (s *Service)` and `func (ss *SchedulerService)` copies collide. Result: **40** identical-body groups — a strict superset of the 32 previously known. The extra 8 were invisible to a name-keyed heuristic, and two of them put `office/onboarding` and `office/dashboard` in scope for the first time. The detector is committed at `docs/plans/office-service-collapse/officedup/` so the count is a re-runnable regression signal, not a one-off.
- **Similarity score does not rank risk.** Of 37 same-name near-duplicate pairs, **31 are cosmetic** — receiver renames, a `type Project = models.Project` alias, and one-line `repo.ListX` wrappers. Three of the four pairs previously flagged as high-risk are in that cosmetic set; the two genuinely dangerous differences score *lowest* (0.845 and 0.745).
- **Six differences are real**, each recorded in `inventory.md` with both behaviors and a decision. Config import runs unscoped across every workspace and creates rows with no `WorkspaceID`; the sub-package scopes correctly but bypasses validation and defaulting — so the correct end state exists on **neither** side. Also: a swallowed agent-name uniqueness error, and stale runs rescheduled instead of cancelled.
- **Collapse direction is uniform, and the evidence is the composition root.** `office/service` has no `gin` import and no HTTP surface; `office/routes.go` builds every handler from the sub-packages. So sub-packages own domain CRUD and the facade's copy is deleted rather than made to delegate. The scheduler is the one reversal — it already imports `office/service`, so inverting that edge would create a cycle.
- **The retry/cancel work is left blocked.** Its central drift *is* the `cancelRetry` branch that sibling task `db3adcf4` is rewriting, so task 10 is marked blocked with a required re-verification step rather than scoped against a tree that is about to change.

## Validation

No production code changed, so the backend suites are unaffected. Verified:

- `git commit` — all pre-commit hooks pass (harness lint, architecture lint, commitlint).
- Detector reproduces from its committed location: `cd docs/plans/office-service-collapse/officedup && GOTOOLCHAIN=local go run . ../../../../apps/backend/internal/office` → **40** Section A groups, **37** same-name Section B pairs against `fb1d8fdcd`.
- All 32 previously-known duplicate groups confirmed present in the regenerated output.
- Detector lives outside the `apps/backend` Go module (own `go.mod`), so `make -C apps/backend lint` never sees it — confirmed passing.
- Every drift claim was verified against source rather than inferred from similarity: `ListXFromConfig` confirmed as one-line `repo.ListX` wrappers, `projects.Project` confirmed as a type alias, and both `SetupChannel` collaborator swaps confirmed as pass-throughs.
- Each task file's duplicate-count delta is reconciled in a ledger in `plan.md`; the arithmetic closes to a documented residue of 1 Section A group and 3 Section B pairs, all out of scope by design.

## Possible Improvements

Low risk — docs only. The main uncertainty is downstream: task 03 (config import) is the one place where neither existing copy is correct, and it needs new tests in a package that has none today. Task 07 carries an open question on a wire-visible event source string that is deliberately left for a human rather than decided by a deletion.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2436?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- kandev-preview-start -->
### Preview Environment

| | |
|---|---|
| **URL** | https://kandev-pr-2436-bwo7.sprites.app |
| **Commit** | `9215089` |
| **Agent** | Mock agent |

> Updates automatically on each push. Destroyed when the PR is closed.
<!-- kandev-preview-end -->