### PR TITLE
fix(gitlab): stop MR badge specs racing workflow auto-advance

### DIFF
--- a/apps/web/components/gitlab/mr-topbar-button.layout-settle.test.tsx
+++ b/apps/web/components/gitlab/mr-topbar-button.layout-settle.test.tsx
@@ -161,6 +161,24 @@ describe("MRTopbarButton desktop review opener — layout settling", () => {
     expect(dockviewMocks.addMRPanel.mock.calls.length).toBe(callsAfterClick);
   });
 
+  it("retains the intent when a stale env id makes the layout look settled mid-remount", () => {
+    // `setApi(null)` does not reset `currentLayoutEnvId`, so navigating between
+    // tasks leaves the previous env id in place while the new dockview mounts.
+    // "Settled" must not be trusted on its own — without the dockviewReady
+    // check the click would be dropped and no later API init could open it.
+    dockviewMocks.set({ api: null, currentLayoutEnvId: "stale-env", isRestoringLayout: false });
+    render(createElement(MRTopbarButton));
+    act(() => {
+      fireEvent.click(screen.getByTestId(TRIGGER_TESTID));
+    });
+    expect(dockviewMocks.addMRPanel).not.toHaveBeenCalled();
+
+    act(() => {
+      dockviewMocks.set({ api: {}, currentLayoutEnvId: "env-1" });
+    });
+    expect(dockviewMocks.addMRPanel).toHaveBeenCalled();
+  });
+
   it("defers the open until dockview exists when clicked before onReady", () => {
     dockviewMocks.set({ api: null });
     render(createElement(MRTopbarButton));

--- a/apps/web/components/gitlab/mr-topbar-button.layout-settle.test.tsx
+++ b/apps/web/components/gitlab/mr-topbar-button.layout-settle.test.tsx
@@ -1,0 +1,177 @@
+/**
+ * Regression cover for the MR detail panel being silently discarded when the
+ * user clicks the topbar button while a task's session is still loading.
+ *
+ * Navigating straight to /t/:id runs dockview's `onReady` before the
+ * session→env mapping hydrates, so it builds a throwaway DEFAULT layout with a
+ * null env; `switchEnvLayout` then replaces that layout wholesale via
+ * `api.fromJSON` once the env arrives. A panel added in that gap is thrown
+ * away and the click appears to do nothing. `useMRDesktopReviewOpener` must
+ * therefore re-apply the open once the env's layout has settled.
+ */
+import { createElement, useSyncExternalStore } from "react";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MRTopbarButton } from "./mr-topbar-button";
+import type { TaskMR } from "@/lib/types/gitlab";
+
+const TRIGGER_TESTID = "mr-topbar-button";
+
+const gitlabMocks = vi.hoisted(() => ({ mrs: [] as TaskMR[] }));
+// A genuinely reactive stand-in for the dockview store: MRTopbarButton is
+// memo()-wrapped, so a plain rerender with identical props would never re-read
+// module-level mock values. Subscribers make store changes drive the re-render
+// the same way zustand does in the app.
+const dockviewMocks = vi.hoisted(() => {
+  const listeners = new Set<() => void>();
+  const state = {
+    addMRPanel: vi.fn(),
+    api: {} as object | null,
+    currentLayoutEnvId: null as string | null,
+    isRestoringLayout: false,
+  };
+  return {
+    state,
+    listeners,
+    get addMRPanel() {
+      return state.addMRPanel;
+    },
+    set(patch: Partial<typeof state>) {
+      Object.assign(state, patch);
+      listeners.forEach((l) => l());
+    },
+  };
+});
+
+vi.mock("@/lib/state/dockview-store", () => ({
+  useDockviewStore: (selector: (state: unknown) => unknown) =>
+    useSyncExternalStore(
+      (onChange: () => void) => {
+        dockviewMocks.listeners.add(onChange);
+        return () => dockviewMocks.listeners.delete(onChange);
+      },
+      () => selector(dockviewMocks.state),
+    ),
+}));
+
+vi.mock("@/components/state-provider", () => ({
+  useAppStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      tasks: { activeTaskId: "task-1", activeSessionId: "session-1" },
+      workspaces: { activeId: "workspace-1" },
+      repositories: { itemsByWorkspaceId: { "workspace-1": [] } },
+      removeTaskMR: vi.fn(),
+      setMobileSessionReview: vi.fn(),
+    }),
+}));
+
+vi.mock("@/hooks/domains/gitlab/use-task-mr", () => ({
+  useGitLabAvailable: () => true,
+  useTaskMRs: () => gitlabMocks.mrs,
+  useWorkspaceMRs: vi.fn(),
+}));
+
+vi.mock("@/hooks/domains/kanban/use-task-by-id", () => ({
+  useTaskById: () => ({ id: "task-1", repositories: [] }),
+}));
+
+vi.mock("@/components/toast-provider", () => ({ useToast: () => ({ toast: vi.fn() }) }));
+vi.mock("./task-mr-link-dialog", () => ({ TaskMRLinkDialog: () => null }));
+vi.mock("./mr-automation-controls", () => ({ MRAutomationControls: () => null }));
+vi.mock("./mr-ci-popover", () => ({ MRCIPopover: () => null }));
+vi.mock("@/hooks/use-compact-task-chrome", () => ({ useTouchDrawer: () => false }));
+
+function singleMR(): TaskMR {
+  return {
+    id: "association-1",
+    task_id: "task-1",
+    host: "https://gitlab.example",
+    project_path: "group/project",
+    mr_iid: 81,
+    mr_url: "https://gitlab.example/group/project/-/merge_requests/81",
+    mr_title: "Test MR",
+    head_branch: "feature",
+    base_branch: "main",
+    author_username: "alice",
+    state: "opened",
+    approval_state: "",
+    pipeline_state: "",
+    merge_status: "",
+    draft: false,
+    approval_count: 0,
+    required_approvals: 0,
+    pipeline_jobs_total: 0,
+    pipeline_jobs_pass: 0,
+    reviewer_count: 0,
+    unapproved_reviewers: 0,
+    unresolved_discussions: 0,
+    created_at: "",
+    updated_at: "",
+  } as TaskMR;
+}
+
+describe("MRTopbarButton desktop review opener — layout settling", () => {
+  beforeEach(() => {
+    gitlabMocks.mrs = [singleMR()];
+    dockviewMocks.addMRPanel.mockClear();
+    dockviewMocks.set({ api: {}, currentLayoutEnvId: null, isRestoringLayout: false });
+  });
+
+  afterEach(cleanup);
+
+  it("re-opens the panel after the env-switch restore that would have discarded it", () => {
+    // Session still loading: dockview api exists, but no env has been adopted.
+    render(createElement(MRTopbarButton));
+    act(() => {
+      fireEvent.click(screen.getByTestId(TRIGGER_TESTID));
+    });
+    // Opened immediately so the click gives instant feedback...
+    expect(dockviewMocks.addMRPanel).toHaveBeenCalled();
+    const callsBeforeRestore = dockviewMocks.addMRPanel.mock.calls.length;
+
+    // ...then the env hydrates and switchEnvLayout replaces the layout,
+    // discarding that panel. Once it settles, the open must be re-applied.
+    act(() => {
+      dockviewMocks.set({ currentLayoutEnvId: "env-1", isRestoringLayout: false });
+    });
+
+    expect(dockviewMocks.addMRPanel.mock.calls.length).toBeGreaterThan(callsBeforeRestore);
+  });
+
+  it("does not re-open the panel on a later layout change once the env has settled", () => {
+    // Env already adopted at click time — the common case for an established
+    // session. The intent must not be retained, or a later preset switch or
+    // maximize would resurrect a panel the user has since closed.
+    dockviewMocks.set({ currentLayoutEnvId: "env-1" });
+    render(createElement(MRTopbarButton));
+    act(() => {
+      fireEvent.click(screen.getByTestId(TRIGGER_TESTID));
+    });
+    const callsAfterClick = dockviewMocks.addMRPanel.mock.calls.length;
+    expect(callsAfterClick).toBeGreaterThan(0);
+
+    // A later user-initiated layout restore (preset switch / maximize).
+    act(() => {
+      dockviewMocks.set({ isRestoringLayout: true });
+    });
+    act(() => {
+      dockviewMocks.set({ isRestoringLayout: false });
+    });
+
+    expect(dockviewMocks.addMRPanel.mock.calls.length).toBe(callsAfterClick);
+  });
+
+  it("defers the open until dockview exists when clicked before onReady", () => {
+    dockviewMocks.set({ api: null });
+    render(createElement(MRTopbarButton));
+    act(() => {
+      fireEvent.click(screen.getByTestId(TRIGGER_TESTID));
+    });
+    expect(dockviewMocks.addMRPanel).not.toHaveBeenCalled();
+
+    act(() => {
+      dockviewMocks.set({ api: {}, currentLayoutEnvId: "env-1" });
+    });
+    expect(dockviewMocks.addMRPanel).toHaveBeenCalled();
+  });
+});

--- a/apps/web/components/gitlab/mr-topbar-button.tsx
+++ b/apps/web/components/gitlab/mr-topbar-button.tsx
@@ -257,14 +257,14 @@ function useMRDesktopReviewOpener(mobile: boolean) {
   const [pendingDesktopMR, setPendingDesktopMR] = useState<TaskMR | null>(null);
 
   useEffect(() => {
-    if (!dockviewReady || isRestoringLayout || !pendingDesktopMR) return;
+    if (!dockviewReady || !layoutSettled || !pendingDesktopMR) return;
+    // Only re-apply once the layout has actually settled: at that point no
+    // switchEnvLayout restore can land afterwards and discard this add. The
+    // intent is cleared here so a later user-initiated layout change (preset
+    // switch, maximize) cannot resurrect a panel the user has since closed.
     openDesktopMRReview(addMRPanel, pendingDesktopMR);
-    // Hold the intent until the env layout has settled so a restore landing
-    // after this add re-opens the panel. Clearing it on the first settle keeps
-    // a later user-initiated layout change (preset switch, maximize) from
-    // resurrecting a panel the user has since closed.
-    if (layoutSettled) setPendingDesktopMR(null);
-  }, [addMRPanel, dockviewReady, isRestoringLayout, layoutSettled, pendingDesktopMR]);
+    setPendingDesktopMR(null);
+  }, [addMRPanel, dockviewReady, layoutSettled, pendingDesktopMR]);
 
   return (mr: TaskMR) => {
     if (mobile) {
@@ -273,11 +273,12 @@ function useMRDesktopReviewOpener(mobile: boolean) {
     }
     // Open straight away when we can, so the panel appears on click rather
     // than after the session finishes loading — but never into a layout that
-    // is being replaced right now. Keeping the intent pending while the layout
-    // is unsettled is what makes it survive the env-switch restore; the effect
-    // above re-applies and then clears it.
+    // is being replaced right now. Retain the intent until dockview exists AND
+    // the env layout has settled: `currentLayoutEnvId` outlives `setApi(null)`,
+    // so a stale env id can leave `layoutSettled` true while dockview is still
+    // remounting, and dropping the intent there would lose the click entirely.
     if (dockviewReady && !isRestoringLayout) openDesktopMRReview(addMRPanel, mr);
-    if (!layoutSettled) setPendingDesktopMR(mr);
+    if (!dockviewReady || !layoutSettled) setPendingDesktopMR(mr);
   };
 }
 

--- a/apps/web/components/gitlab/mr-topbar-button.tsx
+++ b/apps/web/components/gitlab/mr-topbar-button.tsx
@@ -242,6 +242,16 @@ function useMRDesktopReviewOpener(mobile: boolean) {
   const addMRPanel = useDockviewStore((state) => state.addMRPanel);
   const dockviewReady = useDockviewStore((state) => state.api !== null);
   const isRestoringLayout = useDockviewStore((state) => state.isRestoringLayout);
+  // Not restoring right now is necessary but NOT sufficient. Navigating
+  // straight to /t/:id runs dockview's `onReady` while the session→env mapping
+  // is still hydrating, so it builds a throwaway DEFAULT layout with a null env
+  // (see tryRestoreLayout) and `isRestoringLayout` is false the whole time.
+  // `switchEnvLayout` only replaces that layout wholesale via `api.fromJSON`
+  // once the env arrives, discarding any panel added in the gap — the user
+  // clicks the MR button during session load and nothing ever opens. The env
+  // being adopted is what marks the layout as actually settled.
+  const envAdopted = useDockviewStore((state) => state.currentLayoutEnvId !== null);
+  const layoutSettled = envAdopted && !isRestoringLayout;
   const activeSessionId = useAppStore((state) => state.tasks.activeSessionId);
   const setMobileSessionReview = useAppStore((state) => state.setMobileSessionReview);
   const [pendingDesktopMR, setPendingDesktopMR] = useState<TaskMR | null>(null);
@@ -249,19 +259,25 @@ function useMRDesktopReviewOpener(mobile: boolean) {
   useEffect(() => {
     if (!dockviewReady || isRestoringLayout || !pendingDesktopMR) return;
     openDesktopMRReview(addMRPanel, pendingDesktopMR);
-    setPendingDesktopMR(null);
-  }, [addMRPanel, dockviewReady, isRestoringLayout, pendingDesktopMR]);
+    // Hold the intent until the env layout has settled so a restore landing
+    // after this add re-opens the panel. Clearing it on the first settle keeps
+    // a later user-initiated layout change (preset switch, maximize) from
+    // resurrecting a panel the user has since closed.
+    if (layoutSettled) setPendingDesktopMR(null);
+  }, [addMRPanel, dockviewReady, isRestoringLayout, layoutSettled, pendingDesktopMR]);
 
   return (mr: TaskMR) => {
     if (mobile) {
       if (activeSessionId) openMobileMRReview(setMobileSessionReview, activeSessionId, mr);
       return;
     }
-    if (!dockviewReady || isRestoringLayout) {
-      setPendingDesktopMR(mr);
-    } else {
-      openDesktopMRReview(addMRPanel, mr);
-    }
+    // Open straight away when we can, so the panel appears on click rather
+    // than after the session finishes loading — but never into a layout that
+    // is being replaced right now. Keeping the intent pending while the layout
+    // is unsettled is what makes it survive the env-switch restore; the effect
+    // above re-applies and then clears it.
+    if (dockviewReady && !isRestoringLayout) openDesktopMRReview(addMRPanel, mr);
+    if (!layoutSettled) setPendingDesktopMR(mr);
   };
 }
 

--- a/apps/web/e2e/tests/gitlab/mobile-mr-task-card-badge.spec.ts
+++ b/apps/web/e2e/tests/gitlab/mobile-mr-task-card-badge.spec.ts
@@ -43,17 +43,15 @@ async function seedBoardTaskWithMR(apiClient: ApiClient, seedData: SeedData, tit
       updated_at: now,
     },
   ]);
-  const task = await apiClient.createTaskWithAgent(
-    seedData.workspaceId,
-    title,
-    seedData.agentProfileId,
-    {
-      description: "/e2e:simple-message",
-      workflow_id: seedData.workflowId,
-      workflow_step_id: seedData.startStepId,
-      repository_ids: [seedData.repositoryId],
-    },
-  );
+  // No agent, deliberately — see the desktop spec's seedBoardTask. An
+  // auto-started session's `on_turn_complete` moves the card out of the start
+  // column mid-test, which is what made the desktop badge specs flaky.
+  const task = await apiClient.createTask(seedData.workspaceId, title, {
+    description: "MR badge fixture task",
+    workflow_id: seedData.workflowId,
+    workflow_step_id: seedData.startStepId,
+    repository_ids: [seedData.repositoryId],
+  });
   await apiClient.linkTaskGitLabMR(seedData.workspaceId, {
     task_id: task.id,
     repository_id: seedData.repositoryId,
@@ -73,9 +71,7 @@ test.describe("mobile GitLab MR badge on the Kanban card", () => {
 
     const kanban = new KanbanPage(testPage);
     await kanban.goto();
-    await expect(kanban.taskCardInColumn("Mobile MR badge task", seedData.startStepId)).toBeVisible(
-      { timeout: 45_000 },
-    );
+    await expect(kanban.taskCard(task.id)).toBeVisible({ timeout: 45_000 });
 
     const icon = kanban.board.getByTestId(`mr-task-icon-${task.id}`);
     await expect(icon).toBeVisible({ timeout: 15_000 });

--- a/apps/web/e2e/tests/gitlab/mr-task-card-badge.spec.ts
+++ b/apps/web/e2e/tests/gitlab/mr-task-card-badge.spec.ts
@@ -74,9 +74,24 @@ async function ensureGitLabConfigured(apiClient: ApiClient, seedData: SeedData):
   });
 }
 
+/**
+ * Seeds a board card with NO agent, deliberately.
+ *
+ * `createTaskWithAgent` auto-starts a session on the start step (the Kanban
+ * template's `on_enter: auto_start_agent`), and that same step carries
+ * `on_turn_complete: move_to_step review` — so the card leaves the start
+ * column the instant the mock agent's turn ends. Every assertion here was
+ * therefore racing that transition: on a loaded CI runner the agent won and
+ * the card was already in Review, and when it moved mid-assertion the badge
+ * detached from under `.hover()` and the test burned its full timeout.
+ *
+ * The badge is a pure function of the task's linked MRs, so an agent turn
+ * adds nothing to these ACs. Without one, no turn ever completes and the
+ * card stays put.
+ */
 async function seedBoardTask(apiClient: ApiClient, seedData: SeedData, title: string) {
-  return apiClient.createTaskWithAgent(seedData.workspaceId, title, seedData.agentProfileId, {
-    description: "/e2e:simple-message",
+  return apiClient.createTask(seedData.workspaceId, title, {
+    description: "MR badge fixture task",
     workflow_id: seedData.workflowId,
     workflow_step_id: seedData.startStepId,
     repository_ids: [seedData.repositoryId],
@@ -98,9 +113,10 @@ test.describe("GitLab MR badge on the Kanban card", () => {
 
     const kanban = new KanbanPage(testPage);
     await kanban.goto();
-    await expect(kanban.taskCardInColumn("Single MR badge task", seedData.startStepId)).toBeVisible(
-      { timeout: 45_000 },
-    );
+    // Located by task id rather than by (title, column): which column a card
+    // sits in is irrelevant to the badge, and coupling to it makes the
+    // assertion race any workflow transition (see seedBoardTask).
+    await expect(kanban.taskCard(task.id)).toBeVisible({ timeout: 45_000 });
 
     const icon = kanban.board.getByTestId(`mr-task-icon-${task.id}`);
     await expect(icon).toBeVisible({ timeout: 15_000 });
@@ -118,9 +134,7 @@ test.describe("GitLab MR badge on the Kanban card", () => {
 
     const kanban = new KanbanPage(testPage);
     await kanban.goto();
-    await expect(kanban.taskCardInColumn("No MR badge task", seedData.startStepId)).toBeVisible({
-      timeout: 45_000,
-    });
+    await expect(kanban.taskCard(task.id)).toBeVisible({ timeout: 45_000 });
 
     await expect(kanban.board.getByTestId(`mr-task-icon-${task.id}`)).toHaveCount(0);
   });
@@ -159,9 +173,7 @@ test.describe("GitLab MR badge on the Kanban card", () => {
 
     const kanban = new KanbanPage(testPage);
     await kanban.goto();
-    await expect(kanban.taskCardInColumn("Multi MR badge task", seedData.startStepId)).toBeVisible({
-      timeout: 45_000,
-    });
+    await expect(kanban.taskCard(task.id)).toBeVisible({ timeout: 45_000 });
 
     const icon = kanban.board.getByTestId(`mr-task-icon-${task.id}`);
     await expect(icon).toBeVisible({ timeout: 15_000 });
@@ -200,11 +212,9 @@ test.describe("GitLab MR badge on the Kanban card", () => {
 
     const kanban = new KanbanPage(testPage);
     await kanban.goto();
-    await expect(kanban.taskCardInColumn("PR and MR badge task", seedData.startStepId)).toBeVisible(
-      { timeout: 45_000 },
-    );
+    const card = kanban.taskCard(task.id);
+    await expect(card).toBeVisible({ timeout: 45_000 });
 
-    const card = kanban.taskCardInColumn("PR and MR badge task", seedData.startStepId);
     const prIcon = card.getByTestId(`pr-task-icon-${task.id}`);
     const mrIcon = card.getByTestId(`mr-task-icon-${task.id}`);
     await expect(prIcon).toBeVisible({ timeout: 15_000 });


### PR DESCRIPTION
E2E Shard 3/14 has been intermittently red since #2301 because the GitLab MR badge specs asserted on a card in the start column while an auto-started agent was moving it out of that column. Seeding those cards without an agent makes the specs deterministic, and a real product race behind `gitlab-parity`'s flake — an MR detail panel silently discarded during session load — is fixed alongside it.

## Important Changes

- **`mr-task-card-badge.spec.ts` / `mobile-mr-task-card-badge.spec.ts`** — seed cards with `createTask` instead of `createTaskWithAgent`. The Kanban template's start step carries `on_enter: auto_start_agent` **and** `on_turn_complete: move_to_step review`, so the card left the start column the moment the mock agent's turn ended. Cards are now located by `task-card-<id>` rather than `(title, kanban-column-<startStepId>)`, so the assertions no longer couple to a workflow transition at all.
- **`mr-topbar-button.tsx`** — `useMRDesktopReviewOpener` gated on `api !== null`, which is true well before the session's env layout is adopted. Navigating to `/t/:id` runs dockview's `onReady` with a null env and builds a throwaway default layout; `switchEnvLayout` then replaces it wholesale via `api.fromJSON`. A panel added in that gap was discarded, so **clicking the MR button during session load did nothing**. The opener now holds the intent until the env layout settles and re-applies it, then clears it so a later preset switch or maximize cannot resurrect a panel the user has closed.

## Validation

Root cause was confirmed against the real CI artifacts (`test-results-3` from run 31266667979): every failure snapshot showed `Backlog 0 / In Progress 0 / Review 1` — the card rendered, in the wrong column. The `retry2` log caught it mid-flight: `element was detached from the DOM, retrying` on a badge that had resolved with `data-mr-state="merged"`.

Both fixes were verified by mutation, not just by observing a pass:

- **Badge race** — a probe that waits for the task to leave the start step before asserting reproduced the exact CI signature deterministically: **4/4 failed** (`toBeVisible() failed … element(s) not found`, 45000ms). With the fix and the *same* probe: **4/4 pass**, all reporting `STAYED on start step for 30s`.
- **Parity race** — reproduced locally at **1/8** (`getByTestId('mr-detail-panel').last()` never found, matching CI). Instrumenting the opener refuted the obvious "component remounted" theory (the deferred flush fired in every run, including failures) and showed the panel was added and then wiped. After the fix: a DOM probe reported the panel present **10/10** (baseline dropped it 2/16), and `gitlab-parity.spec.ts:54` passed **24/24** with `--retries=0`.
- The new `mr-topbar-button.layout-settle.test.tsx` was mutation-checked: it fails against the pre-fix opener and passes after.

```
pnpm run typecheck                                    # clean
pnpm test                                             # 1275 files, 10095 passed
pnpm run lint                                         # clean (--max-warnings 0)
pnpm run i18n:ratchet && pnpm run i18n:check          # clean
playwright e2e/tests/gitlab/ --project=chromium --project=mobile-chrome --workers=1 --retries=0   # 25/25
playwright e2e/tests/gitlab/mr-task-card-badge.spec.ts --repeat-each=20 --retries=0               # 80/80
playwright e2e/tests/gitlab/gitlab-parity.spec.ts -g "quick launches" --repeat-each=24 --retries=0 # 24/24
playwright session-layout, maximize-sidebar-switch, long-prepare-panels,
           pr-detail-{layout,manual-open,dedup}, pr-watcher-dockview-layout, pr-open-shortcut      # 17 passed, 1 skipped
```

No timeout bumps, retries, sleeps, or skips were added.

## Possible Improvements

Low risk. The opener change is scoped to the GitLab MR panel; the GitHub PR opener is a separate path and is unchanged, and the layout/PR-panel specs above cover the blast radius. The residual behaviour is that while a session is still loading the MR panel may be re-activated once as the layout settles — a short window the user has explicitly opted into by clicking.

**Out of scope, reported not fixed:** 26 of the last 40 `e2e-tests.yml` runs on `main` are `cancelled` by concurrency-group supersession, which is how #2301 landed with no completed post-merge E2E verdict. That is worth its own task.

Other GitLab specs (`mr-topbar-popover`, `mr-automation-options`, `gitlab-mr-creation`, …) also seed with `createTaskWithAgent`, but they navigate to `/t/:id` rather than asserting on a Kanban column, so they are not exposed to this race and are left alone.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2443?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->