### PR TITLE
feat(plugins): add GitHub Status to the marketplace registry

### DIFF
--- a/plugin-registry/plugins.yaml
+++ b/plugin-registry/plugins.yaml
@@ -35,6 +35,9 @@ plugins:
   - id: kandev-plugin-slack
     repo: kdlbs/kandev-plugin-slack
     categories: [integrations, automation]
+  - id: kandev-plugin-github-status
+    repo: kdlbs/kandev-plugin-github-status
+    categories: [tools]
   - id: kandev-plugin-tags
     repo: yattdev/kandev-plugin-tags
     categories: [tools]


### PR DESCRIPTION
Answering "is it me or is it GitHub?" currently means leaving Kandev for githubstatus.com, so this adds the GitHub Status plugin to the official catalog: a status-bar chip that stays recessed while GitHub is healthy and turns loud when Git Operations, Actions, or the API degrade.

The plugin lives in [kdlbs/kandev-plugin-github-status](https://github.com/kdlbs/kandev-plugin-github-status) and has published [v0.1.0](https://github.com/kdlbs/kandev-plugin-github-status/releases/tag/v0.1.0). This PR is the one-line pointer entry only — all catalog metadata is read from that release at index-build time.

It is deliberately adjacent to CI Monitor rather than overlapping it: CI Monitor answers "did *my* PR's checks pass", this answers "is the provider up".

## Validation

Ran the exact steps the `plugin-registry-index` workflow runs on this PR:

- `node --test plugin-registry/build-index.test.mjs` — 8/8 pass.
- `node plugin-registry/build-index.mjs` — `7 built, 0 skipped, 7 listed`.

The new entry resolves against the live GitHub API to:

```json
{
  "id": "kandev-plugin-github-status",
  "name": "GitHub Status",
  "version": "0.1.0",
  "categories": ["tools"],
  "repo_url": "https://github.com/kdlbs/kandev-plugin-github-status",
  "package_url": "https://github.com/kdlbs/kandev-plugin-github-status/releases/download/v0.1.0/kandev-plugin-github-status-0.1.0.tar.gz"
}
```

Also confirmed against the submission requirements in `plugin-registry/README.md`:

- The release publishes `kandev-plugin-github-status-0.1.0.tar.gz` (plus an optional `checksums.txt`), matching the required `<id>-<version>.tar.gz` name.
- Downloaded that published asset and read its `manifest.yaml`: `id: "kandev-plugin-github-status"`, equal to the `id` in this entry and unique in the file.
- Entry shape matches `schema.json` (`id`, `repo`, `categories`; no maintainer-only `featured`).

On the plugin side, before release: `go test ./server/...` (59 test functions, 79 runs), `go vet`, `gofmt -l .` clean, and `make package` building all five declared platforms. It was installed into a disposable Kandev instance via `POST /api/plugins/install`, reaching `active`, with every declared webhook exercised, Host state verified in `plugin_state`, and state confirmed preserved across a version upgrade.

## Possible Improvements

Low risk — a pointer-list addition with no Kandev code change; the worst case is a skipped catalog entry if the release were unresolvable, which the local index build rules out. Note `package_sha256` resolves to `null`: the catalog does not populate release-level digests today, so integrity still rests on the package's internal generated `checksums.txt`, which the install pipeline verifies.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2452?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->