### PR TITLE
docs(i18n): mark the directory-by-directory migration complete

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,8 +92,8 @@ This is enforced, not just requested. Two ratchets, both of which only tighten:
 - **Listed paths, whole file** — `i18next/no-literal-string` is a lint error for
   the paths in `i18nGuardFiles` (`apps/web/eslint.i18n.options.mjs`). The
   migration of existing strings is **complete**, and the list covers every area it
-  touched; append a path that renders user-facing copy in the same PR that adds
-  it. Never remove an entry to make a build pass — a check rejects that.
+  touched; append a path in the same PR that adds it or externalizes one still
+  off the list. Never remove an entry to make a build pass — a check rejects that.
 
 Three rules that cause silent, hard-to-find bugs when broken: never translate a
 string compared with `===` (type-to-confirm tokens become impossible to type);

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,11 +89,11 @@ This is enforced, not just requested. Two ratchets, both of which only tighten:
   hardcoded string in a file you added, or on a line you changed, regardless of
   directory. Untouched lines are never judged, so you are never asked to migrate
   code you did not write.
-- **Migrated paths, whole file** — `i18next/no-literal-string` is a lint error for
+- **Listed paths, whole file** — `i18next/no-literal-string` is a lint error for
   the paths in `i18nGuardFiles` (`apps/web/eslint.i18n.options.mjs`). The
-  migration of existing strings proceeds **one directory per PR**: when you
-  migrate one, append it to that list in the same PR. Never remove an entry to
-  make a build pass — a check rejects that.
+  migration of existing strings is **complete**, and the list covers every area it
+  touched; append a path that renders user-facing copy in the same PR that adds
+  it. Never remove an entry to make a build pass — a check rejects that.
 
 Three rules that cause silent, hard-to-find bugs when broken: never translate a
 string compared with `===` (type-to-confirm tokens become impossible to type);

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -224,11 +224,11 @@ at render, or make the value a component. `check-module-scope-t.mjs` enforces it
 **error**), but **only on the `i18nGuardFiles` allowlist** in
 `eslint.i18n.options.mjs`, which covers every area the migration touched. It
 stays an allowlist because a repo-wide error breaks every unrelated PR that adds
-a label — what made the first attempt unmergeable. **When you add a path that
-renders user-facing copy, append it in the same PR.** Never delete an entry to
-make a build pass; `check-guard-allowlist.mjs` rejects that unless the file is
-gone. Use `pnpm run lint:i18n <path>` to preview the guard on a path not yet on
-the list.
+a label — what made the first attempt unmergeable. **Append a path in the same PR
+that adds it or externalizes it** (`lib/sidebar` is one still off the list).
+Never delete an entry to make a build pass; `check-guard-allowlist.mjs` rejects
+that unless the file is gone. Use `pnpm run lint:i18n <path>` to preview the
+guard on a path not yet on the list.
 
 Separately, `pnpm run i18n:ratchet` (pre-commit + CI) guards **new code
 everywhere**, regardless of the allowlist: a file you added must be clean outright,

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -188,10 +188,10 @@ surface.
 
 ## Internationalization (i18n)
 
-**The migration is in progress, one directory per PR.** The runtime, the gates,
-and Settings → General → Appearance are done; most of the app still holds English
-literals. New user-facing copy must go through `t()` / `<Trans>` wherever you
-write it, even in a directory that has not been migrated yet.
+**Externalization is complete.** #2367 localized `app/office`, the last
+un-migrated area. A hardcoded user-facing literal is now a regression, not
+leftover migration work. New copy must go through `t()` / `<Trans>` wherever you
+write it.
 
 User-facing strings are localized with i18next + react-i18next, keyed as
 `namespace:key`. Add the English text to `src/locales/en/<namespace>.json`, then
@@ -222,13 +222,13 @@ at render, or make the value a component. `check-module-scope-t.mjs` enforces it
 
 `pnpm lint` fails on hardcoded UI strings (`i18next/no-literal-string` is an
 **error**), but **only on the `i18nGuardFiles` allowlist** in
-`eslint.i18n.options.mjs` — paths already migrated. That scoping is deliberate:
-a repo-wide error breaks every unrelated PR that adds a label, which is what made
-the first attempt at this migration unmergeable. **When you migrate a directory,
-append it to `i18nGuardFiles` in the same PR** — that is the step that stops it
-drifting back. Never delete an entry to make a build pass. Use
-`pnpm run lint:i18n <path>` to preview the guard on a path that is not on the
-list yet.
+`eslint.i18n.options.mjs`, which covers every area the migration touched. It
+stays an allowlist because a repo-wide error breaks every unrelated PR that adds
+a label — what made the first attempt unmergeable. **When you add a path that
+renders user-facing copy, append it in the same PR.** Never delete an entry to
+make a build pass; `check-guard-allowlist.mjs` rejects that unless the file is
+gone. Use `pnpm run lint:i18n <path>` to preview the guard on a path not yet on
+the list.
 
 Separately, `pnpm run i18n:ratchet` (pre-commit + CI) guards **new code
 everywhere**, regardless of the allowlist: a file you added must be clean outright,

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -52,10 +52,11 @@ const eslintConfig = defineConfig([
     },
   },
   // Hardcoded user-facing strings. An ERROR, but only on the allowlist in
-  // eslint.i18n.options.mjs — paths already migrated, which is where a
-  // regression is real. A repo-wide error would break every unrelated PR that
-  // lands a literal; a warning would let migrated paths drift back. Each
-  // migration PR externalizes one path and appends it to `i18nGuardFiles`.
+  // eslint.i18n.options.mjs — the paths that render user-facing copy, which is
+  // where a regression is real. A repo-wide error would break every unrelated PR
+  // that lands a literal; a warning would let listed paths drift back. The
+  // migration is done, so a PR appends to `i18nGuardFiles` when it adds such a
+  // path, not as it externalizes an old one.
   {
     files: i18nGuardFiles,
     // Test files build fixtures out of literal strings on purpose; guarding them

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -54,9 +54,9 @@ const eslintConfig = defineConfig([
   // Hardcoded user-facing strings. An ERROR, but only on the allowlist in
   // eslint.i18n.options.mjs — the paths that render user-facing copy, which is
   // where a regression is real. A repo-wide error would break every unrelated PR
-  // that lands a literal; a warning would let listed paths drift back. The
-  // migration is done, so a PR appends to `i18nGuardFiles` when it adds such a
-  // path, not as it externalizes an old one.
+  // that lands a literal; a warning would let listed paths drift back. A PR
+  // appends to `i18nGuardFiles` when it adds such a path or externalizes one
+  // still off the list — `lib/sidebar` is one the screen sweep did not cover.
   {
     files: i18nGuardFiles,
     // Test files build fixtures out of literal strings on purpose; guarding them

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -358,10 +358,11 @@ So there are two independent ratchets, and both only tighten:
 
 ## Externalizing a path
 
-The directory-by-directory sweep is **finished** — #2367 localized `app/office`,
-the last un-migrated area. This loop is what you still run for a path you are
-adding, or to remediate a blind-spot find like the SCREAMING_CASE tables in
-#2409:
+The directory-by-directory sweep of the screens is **finished** — #2367 localized
+`app/office`, the last un-migrated area. This loop is what you still run for a
+path you are adding, for a helper directory the sweep did not cover (`lib/sidebar`
+is one), or to remediate a blind-spot find like the SCREAMING_CASE tables in PR
+`#2409`:
 
 ```bash
 cd apps/web

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -17,11 +17,11 @@ Two enforcement layers, and it matters which is which:
 - **New code is guarded everywhere.** Copy you add — in a new file, or on a line
   you changed — must go through `t()` / `<Trans>` whatever directory it is in.
   See [the new-code ratchet](#but-new-code-is-guarded-everywhere).
-- **Whole files are guarded only once migrated.** The eslint literal rule errors
+- **Whole files are guarded only once listed.** The eslint literal rule errors
   across an entire file only for the paths in `i18nGuardFiles`, so you are never
   asked to migrate lines you did not touch. See
   [The guard is scoped](#the-guard-is-scoped-on-purpose) and
-  [Migrating a directory](#migrating-a-directory).
+  [Externalizing a path](#externalizing-a-path).
 
 ## TL;DR for adding a string
 
@@ -336,8 +336,8 @@ all three.
 
 ### …but new code is guarded everywhere
 
-Scoping the whole-file guard leaves a hole: a brand-new component under an
-un-migrated directory would be unchecked. `check-new-code-i18n.mjs` closes it by
+Scoping the whole-file guard leaves a hole: a brand-new component under a path
+that is not on the list would be unchecked. `check-new-code-i18n.mjs` closes it by
 judging the **change** rather than the file:
 
 |                                | Judged on                                  |
@@ -352,12 +352,16 @@ this can be repo-wide without recreating the treadmill. It is the same contract
 
 So there are two independent ratchets, and both only tighten:
 
-- **`i18nGuardFiles`** — whole files, migrated paths. Grows one directory per PR.
+- **`i18nGuardFiles`** — whole files, listed paths. Grew one directory per PR
+  through the migration; now grows when a PR adds a path that renders copy.
 - **the new-code ratchet** — new lines, everywhere. Always on.
 
-## Migrating a directory
+## Externalizing a path
 
-One directory per PR. The whole loop:
+The directory-by-directory sweep is **finished** — #2367 localized `app/office`,
+the last un-migrated area. This loop is what you still run for a path you are
+adding, or to remediate a blind-spot find like the SCREAMING_CASE tables in
+#2409:
 
 ```bash
 cd apps/web


### PR DESCRIPTION
Four places still told agents the web i18n migration was in progress and to externalize "one directory per PR", but that sweep finished at #2367 (`app/office`, the last un-migrated area) — so every agent reading `AGENTS.md` was being told to work through a backlog that no longer exists, while `docs/public/web-development.md` already documented externalization as complete.

## Important Changes

- `apps/web/AGENTS.md` and `AGENTS.md` — the migration is complete; a hardcoded literal is a regression, not leftover work.
- `docs/i18n.md` — "Migrating a directory" is now "Externalizing a path", rescoped to paths you add and to blind-spot remediation (the loop itself is still correct and is kept).
- `apps/web/eslint.config.mjs` — the guard's rationale comment said each migration PR appends one path.

`i18nGuardFiles` keeps its role: the allowlist may only grow and `check-guard-allowlist.mjs` still enforces that. What changes is *when* you append — on a PR that adds a path rendering user-facing copy, rather than as you work through a backlog.

## Validation

The claim was measured, not assumed. Of the `.tsx` files under `app/` and `components/` **not** on `i18nGuardFiles`, only 2 still hold hardcoded UI copy, and both are under `app/demo/` (internal styling pages, not shipped UI).

- `pre-commit` full hook run: harness lint, architecture lint, prettier, commitlint — all pass. The first attempt failed `agent-line-limit` (`apps/web/AGENTS.md` at 302/300); the new prose was tightened to 300 rather than cutting existing content.
- `pnpm exec eslint lib/i18n/index.ts` — exit 0, confirming `eslint.config.mjs` still loads after the comment edit.
- All 34 internal anchors in `docs/i18n.md` resolve (the renamed heading had one inbound link, in the TL;DR, updated with it).

No tests: documentation and one code comment, no logic changed.

## Possible Improvements

Negligible risk — no runtime or lint behavior changes. `docs/specs/platform/i18n.md` is deliberately untouched: its "SHALL be delivered incrementally, one directory per PR" is a delivery requirement that was met, not stale guidance.

Separately noted while verifying, not fixed here: `docs/public/feature-status.md` says Simplified Chinese lags "most visibly in the task workbench", but the current zh-CN gap is 39 `gitlab` / 25 `common` / 13 `task` / 3 `sidebar` — the most visible gap is now GitLab merge-request surfaces.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2453?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->