### PR TITLE
docs(make): name the env var WEB_PORT actually overrides

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ help:
 	@echo "  bootstrap        Install mise tools, workspace deps, and git hooks"
 	@echo "  bootstrap-e2e    Bootstrap plus Playwright browser/system deps"
 	@echo "  dev              Run backend + web via local CLI (auto ports)"
-	@echo "  dev PORT=38430 WEB_PORT=37430   Run dev on fixed ports (beat KANDEV_BACKEND_PORT/KANDEV_PORT)"
+	@echo "  dev PORT=38430 WEB_PORT=37430   PORT beats KANDEV_BACKEND_PORT/KANDEV_PORT, WEB_PORT beats KANDEV_WEB_PORT"
 	@echo "  dev DEV_ARGS='--verbose'        Pass extra flags through to the dev CLI"
 	@echo "  dev-prod-db      Run dev mode against the production db at ~/.kandev"
 	@echo "  dev-backend      Run backend in development mode (port 38429)"


### PR DESCRIPTION
The `make help` line added in #2389 credited both `PORT` and `WEB_PORT` with beating `KANDEV_BACKEND_PORT`/`KANDEV_PORT`. Only `PORT` does: `WEB_PORT` maps to `--web-internal-port`, which resolves against `KANDEV_WEB_PORT` (`apps/cli/src/args.ts:126`). Someone keeping `KANDEV_WEB_PORT` set in their shell, wondering why `make dev` ignores it, had nowhere to look.

Raised by the review bot on #2389 as a non-blocking suggestion, after that PR had already been approved.

## Validation

- `make help` in both PowerShell and Git Bash prints the corrected line.
- `make -n dev` is unchanged — this touches an `@echo` in the `help` target only.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2458?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->