### PR TITLE
fix(web): honor hide-disabled-in-nav in the settings integrations tree

### DIFF
--- a/apps/web/components/app-sidebar/sections/settings/settings-tree-render.test.tsx
+++ b/apps/web/components/app-sidebar/sections/settings/settings-tree-render.test.tsx
@@ -306,7 +306,18 @@ describe("SettingsTree hide disabled integrations", () => {
     hideDisabled.value = false;
   });
 
-  afterEach(() => cleanup());
+  afterEach(() => {
+    cleanup();
+    // Restore the file-scoped mock state so later suites in this file never
+    // inherit the previous test's hideDisabled/enabled flags.
+    hideDisabled.value = false;
+    integrationEnabled["azure-devops"] = true;
+    integrationEnabled.github = true;
+    integrationEnabled.gitlab = true;
+    integrationEnabled.jira = true;
+    integrationEnabled.linear = true;
+    integrationEnabled.sentry = true;
+  });
 
   it("keeps every integration listed when the hide-disabled setting is off (default), even disabled ones", () => {
     integrationEnabled.github = false;
@@ -315,8 +326,9 @@ describe("SettingsTree hide disabled integrations", () => {
       <WorkspacesGroup pathname="/settings/workspace/ws-1/integrations/azure-devops" expanded />,
     );
 
-    expect(screen.getByRole("link", { name: "GitHub" })).toBeTruthy();
-    expect(screen.getByRole("link", { name: /Azure DevOps/ })).toBeTruthy();
+    for (const name of [/(Azure DevOps)/, /GitHub/, /GitLab/, /Jira/, /Linear/, /Sentry/]) {
+      expect(screen.getByRole("link", { name })).toBeTruthy();
+    }
   });
 
   it("hides a disabled integration from the workspace integrations list when the setting is on", () => {
@@ -338,9 +350,9 @@ describe("SettingsTree hide disabled integrations", () => {
       <WorkspacesGroup pathname="/settings/workspace/ws-1/integrations/azure-devops" expanded />,
     );
 
-    expect(screen.getByRole("link", { name: "GitHub" })).toBeTruthy();
-    expect(screen.getByRole("link", { name: "Jira" })).toBeTruthy();
-    expect(screen.getByRole("link", { name: "Linear" })).toBeTruthy();
+    for (const name of [/(Azure DevOps)/, /GitHub/, /GitLab/, /Jira/, /Linear/, /Sentry/]) {
+      expect(screen.getByRole("link", { name })).toBeTruthy();
+    }
   });
 
   it("keeps an enabled-but-unconfigured integration listed when the setting is on", () => {

--- a/apps/web/components/app-sidebar/sections/settings/settings-tree-render.test.tsx
+++ b/apps/web/components/app-sidebar/sections/settings/settings-tree-render.test.tsx
@@ -40,6 +40,20 @@ const integrationAvailability = vi.hoisted(() => ({
   sentry: false,
 }));
 
+// Per-integration enable/disable state plus the "hide disabled integrations
+// from left panel navigation" setting, shared by the mocks below so each test
+// can flip them independently (same shape the settings-tree-render suite uses
+// for `integrationAvailability`).
+const integrationEnabled = vi.hoisted(() => ({
+  "azure-devops": true,
+  github: true,
+  gitlab: true,
+  jira: true,
+  linear: true,
+  sentry: true,
+}));
+const hideDisabled = vi.hoisted(() => ({ value: false }));
+
 vi.mock("@/components/state-provider", () => ({
   useAppStore: (selector: (s: typeof state) => unknown) => selector(state),
 }));
@@ -68,6 +82,33 @@ vi.mock("@/hooks/domains/linear/use-linear-availability", () => ({
 }));
 vi.mock("@/hooks/domains/sentry/use-sentry-availability", () => ({
   useSentryAvailable: () => integrationAvailability.sentry,
+}));
+vi.mock("@/hooks/domains/azure-devops/use-azure-devops-enabled", () => ({
+  useAzureDevOpsEnabled: () => ({
+    enabled: integrationEnabled["azure-devops"],
+    setEnabled: vi.fn(),
+  }),
+}));
+vi.mock("@/hooks/domains/github/use-github-enabled", () => ({
+  useGitHubEnabled: () => ({ enabled: integrationEnabled.github, setEnabled: vi.fn() }),
+}));
+vi.mock("@/hooks/domains/gitlab/use-gitlab-enabled", () => ({
+  useGitLabEnabled: () => ({ enabled: integrationEnabled.gitlab, setEnabled: vi.fn() }),
+}));
+vi.mock("@/hooks/domains/jira/use-jira-enabled", () => ({
+  useJiraEnabled: () => ({ enabled: integrationEnabled.jira, setEnabled: vi.fn() }),
+}));
+vi.mock("@/hooks/domains/linear/use-linear-enabled", () => ({
+  useLinearEnabled: () => ({ enabled: integrationEnabled.linear, setEnabled: vi.fn() }),
+}));
+vi.mock("@/hooks/domains/sentry/use-sentry-enabled", () => ({
+  useSentryEnabled: () => ({ enabled: integrationEnabled.sentry, setEnabled: vi.fn() }),
+}));
+vi.mock("@/hooks/domains/integrations/use-hide-disabled-integrations-in-nav", () => ({
+  useHideDisabledIntegrationsInNav: () => ({
+    hideDisabled: hideDisabled.value,
+    setHideDisabled: vi.fn(),
+  }),
 }));
 vi.mock("@kandev/ui/collapsible", async () => {
   const React = await vi.importActual<typeof import("react")>("react");
@@ -242,6 +283,75 @@ describe("SettingsTree integration status", () => {
 
     expect(screen.getByRole("link", { name: "Azure DevOps Enabled" })).toBeTruthy();
     expect(screen.getByTestId("azure-devops-icon")).toBeTruthy();
+    expect(screen.getByRole("link", { name: "GitHub" })).toBeTruthy();
+  });
+});
+
+describe("SettingsTree hide disabled integrations", () => {
+  beforeEach(() => {
+    state.workspaces.activeId = MAIN_WORKSPACE_ID;
+    state.workspaces.items = [{ id: MAIN_WORKSPACE_ID, name: MAIN_WORKSPACE_NAME }];
+    integrationAvailability.azureDevOps = true;
+    integrationAvailability.github = false;
+    integrationAvailability.gitlab = false;
+    integrationAvailability.jira = false;
+    integrationAvailability.linear = false;
+    integrationAvailability.sentry = false;
+    integrationEnabled["azure-devops"] = true;
+    integrationEnabled.github = true;
+    integrationEnabled.gitlab = true;
+    integrationEnabled.jira = true;
+    integrationEnabled.linear = true;
+    integrationEnabled.sentry = true;
+    hideDisabled.value = false;
+  });
+
+  afterEach(() => cleanup());
+
+  it("keeps every integration listed when the hide-disabled setting is off (default), even disabled ones", () => {
+    integrationEnabled.github = false;
+
+    render(
+      <WorkspacesGroup pathname="/settings/workspace/ws-1/integrations/azure-devops" expanded />,
+    );
+
+    expect(screen.getByRole("link", { name: "GitHub" })).toBeTruthy();
+    expect(screen.getByRole("link", { name: /Azure DevOps/ })).toBeTruthy();
+  });
+
+  it("hides a disabled integration from the workspace integrations list when the setting is on", () => {
+    integrationEnabled.github = false;
+    hideDisabled.value = true;
+
+    render(
+      <WorkspacesGroup pathname="/settings/workspace/ws-1/integrations/azure-devops" expanded />,
+    );
+
+    expect(screen.queryByRole("link", { name: "GitHub" })).toBeNull();
+    expect(screen.getByRole("link", { name: /Azure DevOps/ })).toBeTruthy();
+  });
+
+  it("keeps every integration listed when the setting is on but none are disabled", () => {
+    hideDisabled.value = true;
+
+    render(
+      <WorkspacesGroup pathname="/settings/workspace/ws-1/integrations/azure-devops" expanded />,
+    );
+
+    expect(screen.getByRole("link", { name: "GitHub" })).toBeTruthy();
+    expect(screen.getByRole("link", { name: "Jira" })).toBeTruthy();
+    expect(screen.getByRole("link", { name: "Linear" })).toBeTruthy();
+  });
+
+  it("keeps an enabled-but-unconfigured integration listed when the setting is on", () => {
+    // GitHub is enabled (toggle on) but has no credentials — only *disabled*
+    // integrations are hidden by the setting, so it must stay reachable.
+    hideDisabled.value = true;
+
+    render(
+      <WorkspacesGroup pathname="/settings/workspace/ws-1/integrations/azure-devops" expanded />,
+    );
+
     expect(screen.getByRole("link", { name: "GitHub" })).toBeTruthy();
   });
 });

--- a/apps/web/components/app-sidebar/sections/settings/workspaces-group.tsx
+++ b/apps/web/components/app-sidebar/sections/settings/workspaces-group.tsx
@@ -18,11 +18,18 @@ import {
 import { useAppStore } from "@/components/state-provider";
 import { AzureDevOpsIcon } from "@/components/icons/azure-devops-icon";
 import { useAzureDevOpsAvailable } from "@/hooks/domains/azure-devops/use-azure-devops-availability";
+import { useAzureDevOpsEnabled } from "@/hooks/domains/azure-devops/use-azure-devops-enabled";
 import { useGitHubStatus } from "@/hooks/domains/github/use-github-status";
+import { useGitHubEnabled } from "@/hooks/domains/github/use-github-enabled";
 import { useGitLabAvailable } from "@/hooks/domains/gitlab/use-task-mr";
+import { useGitLabEnabled } from "@/hooks/domains/gitlab/use-gitlab-enabled";
+import { useHideDisabledIntegrationsInNav } from "@/hooks/domains/integrations/use-hide-disabled-integrations-in-nav";
 import { useJiraAuthed } from "@/hooks/domains/jira/use-jira-availability";
+import { useJiraEnabled } from "@/hooks/domains/jira/use-jira-enabled";
 import { useLinearAuthed } from "@/hooks/domains/linear/use-linear-availability";
+import { useLinearEnabled } from "@/hooks/domains/linear/use-linear-enabled";
 import { useSentryAvailable } from "@/hooks/domains/sentry/use-sentry-availability";
+import { useSentryEnabled } from "@/hooks/domains/sentry/use-sentry-enabled";
 import { WORKSPACE_INTEGRATIONS } from "@/lib/settings-discovery/catalog/integrations";
 import { WORKSPACES_SETTINGS_HREF } from "@/lib/settings-discovery/catalog/workspaces";
 import { SettingsGroup, SettingsLeaf } from "./settings-nav-primitives";
@@ -73,7 +80,14 @@ function WorkspaceIntegrationItems({
   const jira = useJiraAuthed(workspaceId);
   const linear = useLinearAuthed(workspaceId);
   const sentry = useSentryAvailable(workspaceId);
-  const enabled = new Set([
+  const { enabled: azureDevOpsEnabled } = useAzureDevOpsEnabled();
+  const { enabled: githubEnabled } = useGitHubEnabled();
+  const { enabled: gitlabEnabled } = useGitLabEnabled();
+  const { enabled: jiraEnabled } = useJiraEnabled();
+  const { enabled: linearEnabled } = useLinearEnabled();
+  const { enabled: sentryEnabled } = useSentryEnabled();
+  const { hideDisabled } = useHideDisabledIntegrationsInNav();
+  const configured = new Set([
     ...(azureDevOps ? ["azure-devops"] : []),
     ...(githubStatus?.authenticated || githubStatus?.token_configured ? ["github"] : []),
     ...(gitlab ? ["gitlab"] : []),
@@ -81,21 +95,31 @@ function WorkspaceIntegrationItems({
     ...(linear ? ["linear"] : []),
     ...(sentry ? ["sentry"] : []),
   ]);
+  const toggleEnabled: Record<(typeof WORKSPACE_INTEGRATIONS)[number][0], boolean> = {
+    "azure-devops": azureDevOpsEnabled,
+    github: githubEnabled,
+    gitlab: gitlabEnabled,
+    jira: jiraEnabled,
+    linear: linearEnabled,
+    sentry: sentryEnabled,
+  };
 
-  return WORKSPACE_INTEGRATIONS.map(([slug, label]) => {
-    const href = `${integrationsPath}/${slug}`;
-    return (
-      <SettingsLeaf
-        key={href}
-        href={href}
-        label={label}
-        labelSuffix={enabled.has(slug) ? <EnabledBadge /> : undefined}
-        icon={INTEGRATION_ICONS[slug]}
-        isActive={pathname === href}
-        depth={3}
-      />
-    );
-  });
+  return WORKSPACE_INTEGRATIONS.filter(([slug]) => !hideDisabled || toggleEnabled[slug]).map(
+    ([slug, label]) => {
+      const href = `${integrationsPath}/${slug}`;
+      return (
+        <SettingsLeaf
+          key={href}
+          href={href}
+          label={label}
+          labelSuffix={configured.has(slug) ? <EnabledBadge /> : undefined}
+          icon={INTEGRATION_ICONS[slug]}
+          isActive={pathname === href}
+          depth={3}
+        />
+      );
+    },
+  );
 }
 
 type WorkspacesGroupProps = {

--- a/apps/web/components/app-sidebar/sections/settings/workspaces-group.tsx
+++ b/apps/web/components/app-sidebar/sections/settings/workspaces-group.tsx
@@ -104,6 +104,10 @@ function WorkspaceIntegrationItems({
     sentry: sentryEnabled,
   };
 
+  // Configured status gates the badge only, never the row itself — the tree
+  // always lists all six integrations regardless of credentials, so the
+  // filter here hides only disabled integrations (intentionally looser than
+  // useNavAvailability's `configured && (!hideDisabled || enabled)`).
   return WORKSPACE_INTEGRATIONS.filter(([slug]) => !hideDisabled || toggleEnabled[slug]).map(
     ([slug, label]) => {
       const href = `${integrationsPath}/${slug}`;

--- a/apps/web/e2e/tests/integrations/hide-disabled-integrations-nav.spec.ts
+++ b/apps/web/e2e/tests/integrations/hide-disabled-integrations-nav.spec.ts
@@ -37,6 +37,17 @@ test.describe("hide disabled integrations from left panel navigation", () => {
     const githubNavLink = testPage.getByRole("link", { name: "GitHub" });
     await expect(githubNavLink).toBeVisible({ timeout: 10_000 });
 
+    // The Settings left panel's per-workspace Integrations tree is also part
+    // of left-panel navigation: with "hide disabled" off (default) the
+    // disabled-but-configured GitHub entry must stay listed there too.
+    const { workspaces } = await apiClient.listWorkspaces();
+    const workspaceId = workspaces[0].id;
+    await testPage.goto(`/settings/workspace/${workspaceId}/integrations`);
+    const settingsTree = testPage.getByTestId("app-sidebar-settings-mode");
+    await expect(settingsTree.getByRole("link", { name: /GitHub/ })).toBeVisible({
+      timeout: 10_000,
+    });
+
     // Turn "hide disabled" on.
     await testPage.goto("/settings/integrations");
     await expect(testPage.locator("#github-enabled")).toHaveAttribute("aria-checked", "false");
@@ -53,6 +64,13 @@ test.describe("hide disabled integrations from left panel navigation", () => {
 
     await testPage.goto("/tasks");
     await expect(testPage.getByRole("link", { name: "GitHub" })).not.toBeVisible();
+
+    // The Settings left-panel Integrations tree hides it as well.
+    await testPage.goto(`/settings/workspace/${workspaceId}/integrations`);
+    await expect(settingsTree.getByRole("link", { name: /GitHub/ })).not.toBeVisible();
+    await expect(settingsTree.getByRole("link", { name: /Azure DevOps/ })).toBeVisible({
+      timeout: 10_000,
+    });
 
     // Re-enabling GitHub reveals it again even with "hide disabled" still on.
     await testPage.goto("/settings/integrations");

--- a/docs/specs/integrations/enable-disable-toggle.md
+++ b/docs/specs/integrations/enable-disable-toggle.md
@@ -148,11 +148,13 @@ toggle).
   false` (its documented default) under the same failure, so a storage
   failure never hides an integration a user can't otherwise see or control.
 - No integration ever hides from a *settings* page based on the new nav
-  setting — `hideDisabled` only ever affects `useNavAvailability`'s output,
-  never a settings route's reachability. A user can always reach a disabled
-  integration's own settings page directly (by URL, from the index page, or
-  from the sidebar's Settings section) and re-enable it even while the
-  left-panel nav entry is hidden.
+  setting — `hideDisabled` affects only left-panel navigation surfaces
+  (`useNavAvailability`'s output for the main sidebar and mobile menu, and
+  `WorkspaceIntegrationItems`' filter for the Settings left panel's
+  per-workspace Integrations tree), never a settings route's reachability.
+  A user can always reach a disabled integration's own settings page
+  directly (by URL, from the index page, or from the sidebar's Settings
+  section) and re-enable it even while the left-panel nav entry is hidden.
 
 ## Persistence guarantees
 
@@ -215,11 +217,15 @@ is not synced across devices/browsers.
   (a disabled integration is hidden from it when the setting is on), since
   users reach it through left-panel navigation; the badge convention itself
   is unchanged.
-- Sentry has no left-panel nav destination today (see
+- Sentry has no main-sidebar nav destination today (see
   `lib/navigation/core-destinations.ts` — only Azure DevOps, GitHub, GitLab,
-  Jira and Linear are nav-gated). The new "hide disabled" setting therefore
-  has no observable effect for Sentry; its existing slider (own page
-  + new index-page row) still works for the enable/disable state itself.
+  Jira and Linear are nav-gated), so the setting has no effect for Sentry in
+  the main sidebar or mobile menu. Sentry DOES appear in the Settings left
+  panel's per-workspace Integrations tree (all six integrations are always
+  listed there), so with the setting on and Sentry's toggle off it is hidden
+  from that tree like any other disabled integration; its existing slider
+  (own page + new index-page row) still works for the enable/disable state
+  itself.
 - No new command-palette entries or keyboard shortcuts for the new toggles.
 
 ## Open questions

--- a/docs/specs/integrations/enable-disable-toggle.md
+++ b/docs/specs/integrations/enable-disable-toggle.md
@@ -43,12 +43,16 @@ this spec was written and is out of scope.)
   integrations from left panel navigation"**, disabled (off) by default.
 - When that setting is **off** (default), a disabled-but-configured
   integration MUST still appear in the left panel navigation (the sidebar's
-  Integrations section and its mobile-menu equivalent) exactly as it does
-  today for an enabled integration — only credential/health status controls
-  nav visibility.
-- When that setting is **on**, a disabled integration MUST be hidden from the
-  left panel navigation regardless of its credential/health status. An
-  enabled, healthy integration is unaffected.
+  Integrations section, its mobile-menu equivalent, and the Settings left
+  panel's per-workspace Integrations list under Settings → Workspaces →
+  <workspace>) exactly as it does today for an enabled integration — only
+  credential/health status controls nav visibility.
+- When that setting is **on**, a disabled integration MUST be hidden from all
+  of those left-panel surfaces regardless of its credential/health status. An
+  enabled, healthy integration is unaffected. Only integrations whose
+  enable/disable toggle is off are hidden — an enabled-but-unconfigured
+  integration stays listed (the Settings tree keeps its own configured-status
+  badge convention).
 - The new setting SHALL NOT change any other behavior gated on an
   integration's existing "available" signal (e.g. Jira/Linear import
   popovers, Kanban external-link buttons, task-top-bar issue buttons) — those
@@ -203,15 +207,14 @@ is not synced across devices/browsers.
   visibility, not functional gating (unlike Jira/Linear/Sentry's
   existing toggle, which already gates other surfaces and is unchanged by
   this feature).
-- No change to the Settings-page navigation tree
-  (`components/app-sidebar/sections/settings/workspaces-group.tsx`) — "left
-  panel navigation" in this spec refers to the main `AppSidebar`'s
-  Integrations section and its mobile-menu equivalent
-  (`components/app-sidebar/sections/integrations-section.tsx`,
-  `components/integrations/integrations-menu.tsx`), not the Settings
-  section's own workspace/integration tree, which has a different,
-  unrelated status-badge convention and is not user-navigable "left panel
-  navigation" in the product sense used by this request.
+- No change to the Settings-page navigation tree's status-badge convention
+  (`components/app-sidebar/sections/settings/workspaces-group.tsx`): its
+  per-workspace Integrations list keeps the configured-status badge
+  ("Enabled" = credentials/health present), which is unrelated to the
+  enable/disable toggle. The "hide disabled" setting DOES filter that list
+  (a disabled integration is hidden from it when the setting is on), since
+  users reach it through left-panel navigation; the badge convention itself
+  is unchanged.
 - Sentry has no left-panel nav destination today (see
   `lib/navigation/core-destinations.ts` — only Azure DevOps, GitHub, GitLab,
   Jira and Linear are nav-gated). The new "hide disabled" setting therefore


### PR DESCRIPTION
The "Hide disabled integrations from left panel navigation" setting only filtered the main sidebar's Integrations section and the mobile menu — the Settings left panel's per-workspace Integrations tree (`workspaces-group.tsx`) kept listing every integration unconditionally, so a disabled-but-configured integration stayed visible (even with an "Enabled" badge) after the setting was turned on. The tree now reads the per-integration enable toggles and the hide-disabled flag, filtering disabled integrations out of the list.

## Validation

- TDD: 4 new unit tests in `settings-tree-render.test.tsx` — disabled integration hidden when the setting is on; all listed when it's off (default); all listed when none are disabled; enabled-but-unconfigured stays listed. Confirmed RED before the fix, GREEN after. All 5 affected suites pass (73 tests: `settings-tree-render`, `integrations-menu`, `use-nav-availability`, `use-hide-disabled-integrations-in-nav`, `app/settings/integrations/page`).
- E2E: `pnpm e2e:raw tests/integrations/hide-disabled-integrations-nav.spec.ts` — extended to assert the Settings-tree list hides/reveals GitHub alongside the main sidebar; passes on a fresh build.
- Full web suite: `pnpm vitest run` — 1278 files / 10141+ tests pass. 3 pre-existing failures in `lib/http-git-server.test.ts` require a Docker bridge gateway (unavailable in this environment) and are unrelated to this change; they fail identically without it.
- `make fmt`; `pnpm run lint`; `pnpm run i18n:ratchet` (0 added, modified file clean); `make lint-backend` (0 issues); recursive `tsc --noEmit` across all 6 workspace packages passes (the root `make typecheck` target OOMs under this sandbox's parallel runner; the same command serialized exits 0).
- Manual: reproduced the bug on the pre-fix build, then verified the fix live on a secondary dev instance (`make dev`, auto ports, accessible at `ubu4.in.fiere.fr`) — screenshots below.

## Possible Improvements

Low risk: the Settings tree keeps its configured-status badge convention (badge = credentials/health present, unrelated to the enable toggle), so with the setting off a disabled-but-configured integration still shows an "Enabled" badge. Re-badging to reflect the actual toggle is a possible follow-up.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2461?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- kandev-screenshots-start -->
## Screenshots

![Settings integrations tree with the setting on: GitHub hidden](https://raw.githubusercontent.com/Fclem/kandev/029f4f11a09b51ccc686bf09b81cc2217b5cd972/hide-disabled-fixed-tree.png)

![Same tree with the setting off: GitHub listed with its configured badge](https://raw.githubusercontent.com/Fclem/kandev/029f4f11a09b51ccc686bf09b81cc2217b5cd972/hide-disabled-off-github-visible.png)

![Settings integrations page: Enable GitHub off + hide-disabled on, saved](https://raw.githubusercontent.com/Fclem/kandev/029f4f11a09b51ccc686bf09b81cc2217b5cd972/hide-disabled-settings-toggle.png)
<!-- kandev-screenshots-end -->