### PR TITLE
refactor(task): share task-plan WS error mapping across both surfaces

### DIFF
--- a/apps/backend/internal/mcp/handlers/handlers.go
+++ b/apps/backend/internal/mcp/handlers/handlers.go
@@ -26,6 +26,7 @@ import (
 	"github.com/kandev/kandev/internal/sysprompt"
 	"github.com/kandev/kandev/internal/task/dto"
 	"github.com/kandev/kandev/internal/task/models"
+	"github.com/kandev/kandev/internal/task/planws"
 	taskrepository "github.com/kandev/kandev/internal/task/repository"
 	taskrepo "github.com/kandev/kandev/internal/task/repository/sqlite"
 	"github.com/kandev/kandev/internal/task/service"
@@ -680,7 +681,7 @@ func (h *Handlers) handleCreateTask(ctx context.Context, msg *ws.Message) (*ws.M
 		}
 		return ws.NewError(msg.ID, msg.Action, code, err.Error(), nil)
 	}
-	metadata = mergeMCPMetadata(metadata, workspacePolicy.MetadataBlock())
+	metadata = workspacePolicy.MergeMetadataBlock(metadata)
 	var deferredLaunch map[string]interface{}
 	if startAgent {
 		deferredLaunch = map[string]interface{}{
@@ -933,19 +934,6 @@ func (h *Handlers) resolveMCPWorkspacePolicy(parentID, workspaceMode string) (se
 	}
 
 	return service.WorkspacePolicy{Mode: mode}, nil
-}
-
-func mergeMCPMetadata(base, extra map[string]interface{}) map[string]interface{} {
-	if len(extra) == 0 {
-		return base
-	}
-	if base == nil {
-		base = map[string]interface{}{}
-	}
-	for k, v := range extra {
-		base[k] = v
-	}
-	return base
 }
 
 func applyMCPTaskScopeDefaults(parentID, workspaceID, workflowID, workflowStepID string, explicitWorkspaceID, explicitWorkflowID bool, resolved taskRepoResult) (string, string, string) {
@@ -3471,10 +3459,7 @@ func (h *Handlers) handleCreateTaskPlan(ctx context.Context, msg *ws.Message) (*
 		CreatedBy: createdBy,
 	})
 	if err != nil {
-		if errors.Is(err, service.ErrTaskIDRequired) {
-			return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeValidation, "task_id is required", nil)
-		}
-		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError, "Failed to create task plan: "+err.Error(), nil)
+		return planws.CreateError(msg, err)
 	}
 
 	return ws.NewResponse(msg.ID, msg.Action, dto.TaskPlanFromModel(plan))
@@ -3482,19 +3467,14 @@ func (h *Handlers) handleCreateTaskPlan(ctx context.Context, msg *ws.Message) (*
 
 // handleGetTaskPlan retrieves a task plan.
 func (h *Handlers) handleGetTaskPlan(ctx context.Context, msg *ws.Message) (*ws.Message, error) {
-	var req struct {
-		TaskID string `json:"task_id"`
-	}
+	var req planws.TaskIDRequest
 	if err := json.Unmarshal(msg.Payload, &req); err != nil {
 		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeBadRequest, "Invalid payload: "+err.Error(), nil)
 	}
 
 	plan, err := h.planService.GetPlan(ctx, req.TaskID)
 	if err != nil {
-		if errors.Is(err, service.ErrTaskIDRequired) {
-			return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeValidation, "task_id is required", nil)
-		}
-		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError, "Failed to get task plan", nil)
+		return planws.GetError(msg, err)
 	}
 	if plan == nil {
 		// Return empty object if no plan exists
@@ -3531,13 +3511,7 @@ func (h *Handlers) handleUpdateTaskPlan(ctx context.Context, msg *ws.Message) (*
 		CreatedBy: createdBy,
 	})
 	if err != nil {
-		if errors.Is(err, service.ErrTaskIDRequired) {
-			return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeValidation, "task_id is required", nil)
-		}
-		if errors.Is(err, service.ErrTaskPlanNotFound) {
-			return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeNotFound, "Task plan not found", nil)
-		}
-		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError, "Failed to update task plan: "+err.Error(), nil)
+		return planws.UpdateError(msg, err)
 	}
 
 	return ws.NewResponse(msg.ID, msg.Action, dto.TaskPlanFromModel(plan))
@@ -3545,22 +3519,14 @@ func (h *Handlers) handleUpdateTaskPlan(ctx context.Context, msg *ws.Message) (*
 
 // handleDeleteTaskPlan deletes a task plan.
 func (h *Handlers) handleDeleteTaskPlan(ctx context.Context, msg *ws.Message) (*ws.Message, error) {
-	var req struct {
-		TaskID string `json:"task_id"`
-	}
+	var req planws.TaskIDRequest
 	if err := json.Unmarshal(msg.Payload, &req); err != nil {
 		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeBadRequest, "Invalid payload: "+err.Error(), nil)
 	}
 
 	err := h.planService.DeletePlan(ctx, req.TaskID)
 	if err != nil {
-		if errors.Is(err, service.ErrTaskIDRequired) {
-			return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeValidation, "task_id is required", nil)
-		}
-		if errors.Is(err, service.ErrTaskPlanNotFound) {
-			return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeNotFound, "Task plan not found", nil)
-		}
-		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError, "Failed to delete task plan: "+err.Error(), nil)
+		return planws.DeleteError(msg, err)
 	}
 
 	return ws.NewResponse(msg.ID, msg.Action, map[string]interface{}{"success": true})

--- a/apps/backend/internal/mcp/handlers/task_plan_handlers_test.go
+++ b/apps/backend/internal/mcp/handlers/task_plan_handlers_test.go
@@ -42,6 +42,14 @@ func newMCPPlanTestHandlers(t *testing.T) *Handlers {
 		t.Fatalf("OpenSQLite: %v", err)
 	}
 	sqlxDB := sqlx.NewDb(dbConn, "sqlite3")
+	// Registered before the Provide call so the handle still closes if Provide
+	// fails and the Fatalf below fires. Cleanups run LIFO, so this one runs
+	// after the repository cleanup registered underneath it.
+	t.Cleanup(func() {
+		if err := sqlxDB.Close(); err != nil {
+			t.Errorf("close database: %v", err)
+		}
+	})
 	repo, cleanup, err := repository.Provide(sqlxDB, sqlxDB, nil)
 	if err != nil {
 		t.Fatalf("repository.Provide: %v", err)
@@ -49,9 +57,6 @@ func newMCPPlanTestHandlers(t *testing.T) *Handlers {
 	t.Cleanup(func() {
 		if err := cleanup(); err != nil {
 			t.Errorf("cleanup repository: %v", err)
-		}
-		if err := sqlxDB.Close(); err != nil {
-			t.Errorf("close database: %v", err)
 		}
 	})
 

--- a/apps/backend/internal/mcp/handlers/task_plan_handlers_test.go
+++ b/apps/backend/internal/mcp/handlers/task_plan_handlers_test.go
@@ -1,0 +1,284 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/kandev/kandev/internal/common/logger"
+	"github.com/kandev/kandev/internal/db"
+	"github.com/kandev/kandev/internal/events/bus"
+	"github.com/kandev/kandev/internal/task/models"
+	"github.com/kandev/kandev/internal/task/repository"
+	"github.com/kandev/kandev/internal/task/service"
+	v1 "github.com/kandev/kandev/pkg/api/v1"
+	ws "github.com/kandev/kandev/pkg/websocket"
+)
+
+// The MCP plan actions and their browser twins in internal/task/handlers share
+// one error mapper (internal/task/planws). The expectations below are spelled
+// out as literals rather than derived from that mapper on purpose: the twin
+// file internal/task/handlers/task_plan_handlers_test.go carries the same
+// literals, so a change to the shared mapping has to fail on both surfaces
+// before it can land.
+
+const (
+	mcpPlanTaskID  = "task-plan-mcp"
+	mcpPlanlessID  = "task-plan-mcp-empty"
+	mcpPlanWS      = "ws-plan-mcp"
+	mcpPlanWF      = "wf-plan-mcp"
+	mcpInvalidJSON = `{"task_id":`
+)
+
+// newMCPPlanTestHandlers builds Handlers with only the plan service wired —
+// the plan actions touch nothing else.
+func newMCPPlanTestHandlers(t *testing.T) *Handlers {
+	t.Helper()
+	dbConn, err := db.OpenSQLite(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("OpenSQLite: %v", err)
+	}
+	sqlxDB := sqlx.NewDb(dbConn, "sqlite3")
+	repo, cleanup, err := repository.Provide(sqlxDB, sqlxDB, nil)
+	if err != nil {
+		t.Fatalf("repository.Provide: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := cleanup(); err != nil {
+			t.Errorf("cleanup repository: %v", err)
+		}
+		if err := sqlxDB.Close(); err != nil {
+			t.Errorf("close database: %v", err)
+		}
+	})
+
+	log, err := logger.NewLogger(logger.LoggingConfig{Level: "error", Format: "json", OutputPath: "stdout"})
+	if err != nil {
+		t.Fatalf("NewLogger: %v", err)
+	}
+	eventBus := bus.NewMemoryEventBus(log)
+	t.Cleanup(func() { eventBus.Close() })
+
+	ctx := context.Background()
+	if err := repo.CreateWorkspace(ctx, &models.Workspace{ID: mcpPlanWS, Name: "Plan WS"}); err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+	if err := repo.CreateWorkflow(ctx, &models.Workflow{ID: mcpPlanWF, WorkspaceID: mcpPlanWS, Name: "WF"}); err != nil {
+		t.Fatalf("CreateWorkflow: %v", err)
+	}
+	for _, id := range []string{mcpPlanTaskID, mcpPlanlessID} {
+		now := time.Now().UTC()
+		task := &models.Task{
+			ID:          id,
+			WorkspaceID: mcpPlanWS,
+			WorkflowID:  mcpPlanWF,
+			Title:       "Plan target",
+			State:       v1.TaskStateCreated,
+			Priority:    "medium",
+			CreatedAt:   now,
+			UpdatedAt:   now,
+		}
+		if err := repo.CreateTask(ctx, task); err != nil {
+			t.Fatalf("CreateTask(%s): %v", id, err)
+		}
+	}
+
+	return &Handlers{planService: service.NewPlanService(repo, eventBus, log), logger: log}
+}
+
+func mcpPlanMsg(t *testing.T, action string, payload string) *ws.Message {
+	t.Helper()
+	return &ws.Message{ID: "req-1", Action: action, Payload: json.RawMessage(payload)}
+}
+
+func assertMCPPlanError(t *testing.T, out *ws.Message, err error, wantCode, wantMessage string) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	if out.Type != ws.MessageTypeError {
+		t.Fatalf("message type = %q, want %q (payload %s)", out.Type, ws.MessageTypeError, out.Payload)
+	}
+	var payload ws.ErrorPayload
+	if jsonErr := json.Unmarshal(out.Payload, &payload); jsonErr != nil {
+		t.Fatalf("unmarshal error payload: %v", jsonErr)
+	}
+	if payload.Code != wantCode {
+		t.Errorf("code = %q, want %q", payload.Code, wantCode)
+	}
+	if payload.Message != wantMessage {
+		t.Errorf("message = %q, want %q", payload.Message, wantMessage)
+	}
+}
+
+// TestMCPPlanActionsRejectMalformedPayloads pins the decode failure reply.
+func TestMCPPlanActionsRejectMalformedPayloads(t *testing.T) {
+	h := newMCPPlanTestHandlers(t)
+	ctx := context.Background()
+
+	actions := map[string]struct {
+		action string
+		handle func(context.Context, *ws.Message) (*ws.Message, error)
+	}{
+		"create": {ws.ActionMCPCreateTaskPlan, h.handleCreateTaskPlan},
+		"get":    {ws.ActionMCPGetTaskPlan, h.handleGetTaskPlan},
+		"update": {ws.ActionMCPUpdateTaskPlan, h.handleUpdateTaskPlan},
+		"delete": {ws.ActionMCPDeleteTaskPlan, h.handleDeleteTaskPlan},
+	}
+	for name, tc := range actions {
+		t.Run(name, func(t *testing.T) {
+			out, err := tc.handle(ctx, mcpPlanMsg(t, tc.action, mcpInvalidJSON))
+			assertMCPPlanError(t, out, err, ws.ErrorCodeBadRequest,
+				"Invalid payload: unexpected end of JSON input")
+		})
+	}
+}
+
+// TestMCPPlanActionsRejectMissingTaskID pins the validation reply every plan
+// action returns for an absent task_id, matching the browser surface.
+func TestMCPPlanActionsRejectMissingTaskID(t *testing.T) {
+	h := newMCPPlanTestHandlers(t)
+	ctx := context.Background()
+
+	actions := map[string]struct {
+		action  string
+		payload string
+		handle  func(context.Context, *ws.Message) (*ws.Message, error)
+	}{
+		"create": {ws.ActionMCPCreateTaskPlan, `{"content":"body"}`, h.handleCreateTaskPlan},
+		"get":    {ws.ActionMCPGetTaskPlan, `{}`, h.handleGetTaskPlan},
+		"update": {ws.ActionMCPUpdateTaskPlan, `{"content":"body"}`, h.handleUpdateTaskPlan},
+		"delete": {ws.ActionMCPDeleteTaskPlan, `{}`, h.handleDeleteTaskPlan},
+	}
+	for name, tc := range actions {
+		t.Run(name, func(t *testing.T) {
+			out, err := tc.handle(ctx, mcpPlanMsg(t, tc.action, tc.payload))
+			assertMCPPlanError(t, out, err, ws.ErrorCodeValidation, "task_id is required")
+		})
+	}
+}
+
+// TestMCPPlanActionsRequireContent pins the agent-only guard the browser
+// surface does not have: an agent must send plan content.
+func TestMCPPlanActionsRequireContent(t *testing.T) {
+	h := newMCPPlanTestHandlers(t)
+	ctx := context.Background()
+
+	t.Run("create", func(t *testing.T) {
+		out, err := h.handleCreateTaskPlan(ctx, mcpPlanMsg(t, ws.ActionMCPCreateTaskPlan,
+			`{"task_id":"`+mcpPlanTaskID+`"}`))
+		assertMCPPlanError(t, out, err, ws.ErrorCodeValidation, "content is required")
+	})
+	t.Run("update", func(t *testing.T) {
+		out, err := h.handleUpdateTaskPlan(ctx, mcpPlanMsg(t, ws.ActionMCPUpdateTaskPlan,
+			`{"task_id":"`+mcpPlanTaskID+`"}`))
+		assertMCPPlanError(t, out, err, ws.ErrorCodeValidation, "content is required")
+	})
+}
+
+// TestMCPPlanActionsReportMissingPlan pins the 404 reply for the two actions
+// that require an existing plan, matching the browser surface.
+func TestMCPPlanActionsReportMissingPlan(t *testing.T) {
+	h := newMCPPlanTestHandlers(t)
+	ctx := context.Background()
+
+	t.Run("update", func(t *testing.T) {
+		out, err := h.handleUpdateTaskPlan(ctx, mcpPlanMsg(t, ws.ActionMCPUpdateTaskPlan,
+			`{"task_id":"`+mcpPlanlessID+`","content":"body"}`))
+		assertMCPPlanError(t, out, err, ws.ErrorCodeNotFound, "Task plan not found")
+	})
+	t.Run("delete", func(t *testing.T) {
+		out, err := h.handleDeleteTaskPlan(ctx, mcpPlanMsg(t, ws.ActionMCPDeleteTaskPlan,
+			`{"task_id":"`+mcpPlanlessID+`"}`))
+		assertMCPPlanError(t, out, err, ws.ErrorCodeNotFound, "Task plan not found")
+	})
+}
+
+// TestMCPPlanActionsSucceed pins the success payloads across a full CRUD round
+// trip. Two replies deliberately differ from the browser surface and must not
+// be "unified" away: get returns {} rather than null for a task with no plan,
+// and an unattributed write is attributed to the agent, not the user.
+func TestMCPPlanActionsSucceed(t *testing.T) {
+	h := newMCPPlanTestHandlers(t)
+	ctx := context.Background()
+
+	t.Run("get with no plan returns an empty object", func(t *testing.T) {
+		out, err := h.handleGetTaskPlan(ctx, mcpPlanMsg(t, ws.ActionMCPGetTaskPlan,
+			`{"task_id":"`+mcpPlanlessID+`"}`))
+		if err != nil {
+			t.Fatalf("handleGetTaskPlan: %v", err)
+		}
+		if out.Type != ws.MessageTypeResponse {
+			t.Fatalf("type = %q, want %q", out.Type, ws.MessageTypeResponse)
+		}
+		if string(out.Payload) != "{}" {
+			t.Errorf("payload = %s, want {}", out.Payload)
+		}
+	})
+
+	t.Run("create", func(t *testing.T) {
+		out, err := h.handleCreateTaskPlan(ctx, mcpPlanMsg(t, ws.ActionMCPCreateTaskPlan,
+			`{"task_id":"`+mcpPlanTaskID+`","title":"Ship it","content":"step one"}`))
+		if err != nil {
+			t.Fatalf("handleCreateTaskPlan: %v", err)
+		}
+		plan := decodeMCPPlanPayload(t, out)
+		if plan["task_id"] != mcpPlanTaskID || plan["content"] != "step one" {
+			t.Errorf("plan = %v", plan)
+		}
+		if plan["created_by"] != "agent" {
+			t.Errorf("created_by = %v, want agent", plan["created_by"])
+		}
+	})
+
+	t.Run("get", func(t *testing.T) {
+		out, err := h.handleGetTaskPlan(ctx, mcpPlanMsg(t, ws.ActionMCPGetTaskPlan,
+			`{"task_id":"`+mcpPlanTaskID+`"}`))
+		if err != nil {
+			t.Fatalf("handleGetTaskPlan: %v", err)
+		}
+		if plan := decodeMCPPlanPayload(t, out); plan["content"] != "step one" {
+			t.Errorf("content = %v, want step one", plan["content"])
+		}
+	})
+
+	t.Run("update", func(t *testing.T) {
+		out, err := h.handleUpdateTaskPlan(ctx, mcpPlanMsg(t, ws.ActionMCPUpdateTaskPlan,
+			`{"task_id":"`+mcpPlanTaskID+`","content":"step two"}`))
+		if err != nil {
+			t.Fatalf("handleUpdateTaskPlan: %v", err)
+		}
+		if plan := decodeMCPPlanPayload(t, out); plan["content"] != "step two" {
+			t.Errorf("content = %v, want step two", plan["content"])
+		}
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		out, err := h.handleDeleteTaskPlan(ctx, mcpPlanMsg(t, ws.ActionMCPDeleteTaskPlan,
+			`{"task_id":"`+mcpPlanTaskID+`"}`))
+		if err != nil {
+			t.Fatalf("handleDeleteTaskPlan: %v", err)
+		}
+		if out.Type != ws.MessageTypeResponse {
+			t.Fatalf("type = %q, want %q", out.Type, ws.MessageTypeResponse)
+		}
+		if string(out.Payload) != `{"success":true}` {
+			t.Errorf("payload = %s, want {\"success\":true}", out.Payload)
+		}
+	})
+}
+
+func decodeMCPPlanPayload(t *testing.T, out *ws.Message) map[string]any {
+	t.Helper()
+	if out.Type != ws.MessageTypeResponse {
+		t.Fatalf("type = %q, want %q (payload %s)", out.Type, ws.MessageTypeResponse, out.Payload)
+	}
+	var plan map[string]any
+	if err := json.Unmarshal(out.Payload, &plan); err != nil {
+		t.Fatalf("unmarshal plan payload: %v", err)
+	}
+	return plan
+}

--- a/apps/backend/internal/task/handlers/task_http_handlers.go
+++ b/apps/backend/internal/task/handlers/task_http_handlers.go
@@ -873,7 +873,7 @@ func (h *TaskHandlers) httpCreateTask(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": policyErr.Error()})
 		return
 	}
-	metadata := mergeWorkspaceMetadata(body.Metadata, wsPolicy.MetadataBlock())
+	metadata := wsPolicy.MergeMetadataBlock(body.Metadata)
 	var deferredLaunch map[string]interface{}
 	if body.StartAgent || body.PrepareSession {
 		intent := "prepare"

--- a/apps/backend/internal/task/handlers/task_plan_handlers.go
+++ b/apps/backend/internal/task/handlers/task_plan_handlers.go
@@ -3,9 +3,9 @@ package handlers
 import (
 	"context"
 	"encoding/json"
-	"errors"
 
 	"github.com/kandev/kandev/internal/task/dto"
+	"github.com/kandev/kandev/internal/task/planws"
 	"github.com/kandev/kandev/internal/task/service"
 	ws "github.com/kandev/kandev/pkg/websocket"
 )
@@ -40,10 +40,7 @@ func (h *TaskHandlers) wsCreateTaskPlan(ctx context.Context, msg *ws.Message) (*
 		AuthorName: req.AuthorName,
 	})
 	if err != nil {
-		if errors.Is(err, service.ErrTaskIDRequired) {
-			return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeValidation, "task_id is required", nil)
-		}
-		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError, "Failed to create task plan: "+err.Error(), nil)
+		return planws.CreateError(msg, err)
 	}
 
 	return ws.NewResponse(msg.ID, msg.Action, dto.TaskPlanFromModel(plan))
@@ -51,19 +48,14 @@ func (h *TaskHandlers) wsCreateTaskPlan(ctx context.Context, msg *ws.Message) (*
 
 // wsGetTaskPlan retrieves a task plan
 func (h *TaskHandlers) wsGetTaskPlan(ctx context.Context, msg *ws.Message) (*ws.Message, error) {
-	var req struct {
-		TaskID string `json:"task_id"`
-	}
+	var req planws.TaskIDRequest
 	if err := json.Unmarshal(msg.Payload, &req); err != nil {
 		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeBadRequest, "Invalid payload: "+err.Error(), nil)
 	}
 
 	plan, err := h.planService.GetPlan(ctx, req.TaskID)
 	if err != nil {
-		if errors.Is(err, service.ErrTaskIDRequired) {
-			return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeValidation, "task_id is required", nil)
-		}
-		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError, "Failed to get task plan", nil)
+		return planws.GetError(msg, err)
 	}
 	if plan == nil {
 		return ws.NewResponse(msg.ID, msg.Action, nil)
@@ -100,13 +92,7 @@ func (h *TaskHandlers) wsUpdateTaskPlan(ctx context.Context, msg *ws.Message) (*
 		AuthorName: req.AuthorName,
 	})
 	if err != nil {
-		if errors.Is(err, service.ErrTaskIDRequired) {
-			return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeValidation, "task_id is required", nil)
-		}
-		if errors.Is(err, service.ErrTaskPlanNotFound) {
-			return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeNotFound, "Task plan not found", nil)
-		}
-		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError, "Failed to update task plan: "+err.Error(), nil)
+		return planws.UpdateError(msg, err)
 	}
 
 	return ws.NewResponse(msg.ID, msg.Action, dto.TaskPlanFromModel(plan))
@@ -114,22 +100,14 @@ func (h *TaskHandlers) wsUpdateTaskPlan(ctx context.Context, msg *ws.Message) (*
 
 // wsDeleteTaskPlan deletes a task plan
 func (h *TaskHandlers) wsDeleteTaskPlan(ctx context.Context, msg *ws.Message) (*ws.Message, error) {
-	var req struct {
-		TaskID string `json:"task_id"`
-	}
+	var req planws.TaskIDRequest
 	if err := json.Unmarshal(msg.Payload, &req); err != nil {
 		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeBadRequest, "Invalid payload: "+err.Error(), nil)
 	}
 
 	err := h.planService.DeletePlan(ctx, req.TaskID)
 	if err != nil {
-		if errors.Is(err, service.ErrTaskIDRequired) {
-			return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeValidation, "task_id is required", nil)
-		}
-		if errors.Is(err, service.ErrTaskPlanNotFound) {
-			return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeNotFound, "Task plan not found", nil)
-		}
-		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError, "Failed to delete task plan: "+err.Error(), nil)
+		return planws.DeleteError(msg, err)
 	}
 
 	return ws.NewResponse(msg.ID, msg.Action, map[string]interface{}{responseKeySuccess: true})
@@ -151,7 +129,7 @@ func (h *TaskHandlers) wsMarkTaskPlanImplementationStarted(ctx context.Context, 
 		Actor:     req.Actor,
 	})
 	if err != nil {
-		return taskPlanServiceError(msg, err, "Failed to mark task plan implementation started")
+		return planws.Error(msg, err, "Failed to mark task plan implementation started")
 	}
 
 	return ws.NewResponse(msg.ID, msg.Action, dto.TaskPlanFromModel(plan))
@@ -159,19 +137,14 @@ func (h *TaskHandlers) wsMarkTaskPlanImplementationStarted(ctx context.Context, 
 
 // wsListTaskPlanRevisions returns revision metadata newest-first (no content).
 func (h *TaskHandlers) wsListTaskPlanRevisions(ctx context.Context, msg *ws.Message) (*ws.Message, error) {
-	var req struct {
-		TaskID string `json:"task_id"`
-	}
+	var req planws.TaskIDRequest
 	if err := json.Unmarshal(msg.Payload, &req); err != nil {
 		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeBadRequest, "Invalid payload: "+err.Error(), nil)
 	}
 
 	revs, err := h.planService.ListRevisions(ctx, req.TaskID)
 	if err != nil {
-		if errors.Is(err, service.ErrTaskIDRequired) {
-			return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeValidation, "task_id is required", nil)
-		}
-		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError, "Failed to list revisions: "+err.Error(), nil)
+		return planws.Error(msg, err, "Failed to list revisions")
 	}
 
 	out := make([]*dto.TaskPlanRevisionDTO, 0, len(revs))
@@ -200,10 +173,7 @@ func (h *TaskHandlers) wsGetTaskPlanRevision(ctx context.Context, msg *ws.Messag
 
 	rev, err := h.planService.GetRevision(ctx, req.RevisionID)
 	if err != nil {
-		if errors.Is(err, service.ErrRevisionNotFound) {
-			return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeNotFound, "Revision not found", nil)
-		}
-		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError, "Failed to get revision: "+err.Error(), nil)
+		return planws.Error(msg, err, "Failed to get revision")
 	}
 	// Match wsRevertTaskPlan's ownership check so a caller can only read
 	// content for revisions belonging to the task they hold a reference to.
@@ -232,27 +202,7 @@ func (h *TaskHandlers) wsRevertTaskPlan(ctx context.Context, msg *ws.Message) (*
 		AuthorName:       req.AuthorName,
 	})
 	if err != nil {
-		return taskPlanServiceError(msg, err, "Failed to revert plan")
+		return planws.Error(msg, err, "Failed to revert plan")
 	}
 	return ws.NewResponse(msg.ID, msg.Action, dto.TaskPlanRevisionFromModel(rev))
-}
-
-func taskPlanServiceError(msg *ws.Message, err error, fallback string) (*ws.Message, error) {
-	switch {
-	case errors.Is(err, service.ErrTaskIDRequired):
-		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeValidation, "task_id is required", nil)
-	case errors.Is(err, service.ErrSessionIDRequired):
-		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeValidation, "session_id is required", nil)
-	case errors.Is(err, service.ErrSessionTaskMismatch):
-		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeValidation, "Session does not belong to task", nil)
-	case errors.Is(err, service.ErrTaskPlanNotFound):
-		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeNotFound, "Task plan not found", nil)
-	case errors.Is(err, service.ErrRevisionIDRequired):
-		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeValidation, "revision_id is required", nil)
-	case errors.Is(err, service.ErrRevisionNotFound):
-		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeNotFound, "Revision not found", nil)
-	case errors.Is(err, service.ErrRevisionTaskMismatch):
-		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeValidation, "Revision does not belong to task", nil)
-	}
-	return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError, fallback+": "+err.Error(), nil)
 }

--- a/apps/backend/internal/task/handlers/task_plan_handlers_test.go
+++ b/apps/backend/internal/task/handlers/task_plan_handlers_test.go
@@ -1,0 +1,265 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/kandev/kandev/internal/common/logger"
+	"github.com/kandev/kandev/internal/db"
+	"github.com/kandev/kandev/internal/events/bus"
+	"github.com/kandev/kandev/internal/task/models"
+	"github.com/kandev/kandev/internal/task/repository"
+	"github.com/kandev/kandev/internal/task/service"
+	v1 "github.com/kandev/kandev/pkg/api/v1"
+	ws "github.com/kandev/kandev/pkg/websocket"
+)
+
+// The task-plan WS actions and their MCP twins in internal/mcp/handlers share
+// one error mapper (internal/task/planws). The expectations below are spelled
+// out as literals rather than derived from that mapper on purpose: the twin
+// file internal/mcp/handlers/task_plan_handlers_test.go carries the same
+// literals, so a change to the shared mapping has to fail on both surfaces
+// before it can land.
+
+const (
+	planTaskID  = "task-plan-ws"
+	planlessID  = "task-plan-ws-empty"
+	planTestWS  = "ws-plan-ws"
+	planTestWF  = "wf-plan-ws"
+	invalidJSON = `{"task_id":`
+)
+
+// newPlanTestHandlers builds TaskHandlers with only the plan service wired —
+// the plan actions touch nothing else.
+func newPlanTestHandlers(t *testing.T) *TaskHandlers {
+	t.Helper()
+	dbConn, err := db.OpenSQLite(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("OpenSQLite: %v", err)
+	}
+	sqlxDB := sqlx.NewDb(dbConn, "sqlite3")
+	repo, cleanup, err := repository.Provide(sqlxDB, sqlxDB, nil)
+	if err != nil {
+		t.Fatalf("repository.Provide: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := cleanup(); err != nil {
+			t.Errorf("cleanup repository: %v", err)
+		}
+		if err := sqlxDB.Close(); err != nil {
+			t.Errorf("close database: %v", err)
+		}
+	})
+
+	log, err := logger.NewLogger(logger.LoggingConfig{Level: "error", Format: "json", OutputPath: "stdout"})
+	if err != nil {
+		t.Fatalf("NewLogger: %v", err)
+	}
+	eventBus := bus.NewMemoryEventBus(log)
+	t.Cleanup(func() { eventBus.Close() })
+
+	ctx := context.Background()
+	if err := repo.CreateWorkspace(ctx, &models.Workspace{ID: planTestWS, Name: "Plan WS"}); err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+	if err := repo.CreateWorkflow(ctx, &models.Workflow{ID: planTestWF, WorkspaceID: planTestWS, Name: "WF"}); err != nil {
+		t.Fatalf("CreateWorkflow: %v", err)
+	}
+	for _, id := range []string{planTaskID, planlessID} {
+		now := time.Now().UTC()
+		task := &models.Task{
+			ID:          id,
+			WorkspaceID: planTestWS,
+			WorkflowID:  planTestWF,
+			Title:       "Plan target",
+			State:       v1.TaskStateCreated,
+			Priority:    "medium",
+			CreatedAt:   now,
+			UpdatedAt:   now,
+		}
+		if err := repo.CreateTask(ctx, task); err != nil {
+			t.Fatalf("CreateTask(%s): %v", id, err)
+		}
+	}
+
+	return &TaskHandlers{planService: service.NewPlanService(repo, eventBus, log), logger: log}
+}
+
+func planMsg(t *testing.T, action string, payload string) *ws.Message {
+	t.Helper()
+	return &ws.Message{ID: "req-1", Action: action, Payload: json.RawMessage(payload)}
+}
+
+// assertPlanError decodes a handler reply and checks the error code and message
+// a client would see.
+func assertPlanError(t *testing.T, out *ws.Message, err error, wantCode, wantMessage string) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	if out.Type != ws.MessageTypeError {
+		t.Fatalf("message type = %q, want %q (payload %s)", out.Type, ws.MessageTypeError, out.Payload)
+	}
+	var payload ws.ErrorPayload
+	if jsonErr := json.Unmarshal(out.Payload, &payload); jsonErr != nil {
+		t.Fatalf("unmarshal error payload: %v", jsonErr)
+	}
+	if payload.Code != wantCode {
+		t.Errorf("code = %q, want %q", payload.Code, wantCode)
+	}
+	if payload.Message != wantMessage {
+		t.Errorf("message = %q, want %q", payload.Message, wantMessage)
+	}
+}
+
+// TestPlanWSActionsRejectMalformedPayloads pins the decode failure reply.
+func TestPlanWSActionsRejectMalformedPayloads(t *testing.T) {
+	h := newPlanTestHandlers(t)
+	ctx := context.Background()
+
+	actions := map[string]struct {
+		action string
+		handle func(context.Context, *ws.Message) (*ws.Message, error)
+	}{
+		"create": {ws.ActionTaskPlanCreate, h.wsCreateTaskPlan},
+		"get":    {ws.ActionTaskPlanGet, h.wsGetTaskPlan},
+		"update": {ws.ActionTaskPlanUpdate, h.wsUpdateTaskPlan},
+		"delete": {ws.ActionTaskPlanDelete, h.wsDeleteTaskPlan},
+	}
+	for name, tc := range actions {
+		t.Run(name, func(t *testing.T) {
+			out, err := tc.handle(ctx, planMsg(t, tc.action, invalidJSON))
+			assertPlanError(t, out, err, ws.ErrorCodeBadRequest,
+				"Invalid payload: unexpected end of JSON input")
+		})
+	}
+}
+
+// TestPlanWSActionsRejectMissingTaskID pins the validation reply every plan
+// action returns for an absent task_id.
+func TestPlanWSActionsRejectMissingTaskID(t *testing.T) {
+	h := newPlanTestHandlers(t)
+	ctx := context.Background()
+
+	actions := map[string]struct {
+		action  string
+		payload string
+		handle  func(context.Context, *ws.Message) (*ws.Message, error)
+	}{
+		"create": {ws.ActionTaskPlanCreate, `{"content":"body"}`, h.wsCreateTaskPlan},
+		"get":    {ws.ActionTaskPlanGet, `{}`, h.wsGetTaskPlan},
+		"update": {ws.ActionTaskPlanUpdate, `{"content":"body"}`, h.wsUpdateTaskPlan},
+		"delete": {ws.ActionTaskPlanDelete, `{}`, h.wsDeleteTaskPlan},
+	}
+	for name, tc := range actions {
+		t.Run(name, func(t *testing.T) {
+			out, err := tc.handle(ctx, planMsg(t, tc.action, tc.payload))
+			assertPlanError(t, out, err, ws.ErrorCodeValidation, "task_id is required")
+		})
+	}
+}
+
+// TestPlanWSActionsReportMissingPlan pins the 404 reply for the two actions
+// that require an existing plan.
+func TestPlanWSActionsReportMissingPlan(t *testing.T) {
+	h := newPlanTestHandlers(t)
+	ctx := context.Background()
+
+	t.Run("update", func(t *testing.T) {
+		out, err := h.wsUpdateTaskPlan(ctx, planMsg(t, ws.ActionTaskPlanUpdate,
+			`{"task_id":"`+planlessID+`","content":"body"}`))
+		assertPlanError(t, out, err, ws.ErrorCodeNotFound, "Task plan not found")
+	})
+	t.Run("delete", func(t *testing.T) {
+		out, err := h.wsDeleteTaskPlan(ctx, planMsg(t, ws.ActionTaskPlanDelete,
+			`{"task_id":"`+planlessID+`"}`))
+		assertPlanError(t, out, err, ws.ErrorCodeNotFound, "Task plan not found")
+	})
+}
+
+// TestPlanWSActionsSucceed pins the success payloads across a full CRUD round
+// trip, including the browser surface's null reply for a task with no plan and
+// its {"success":true} delete reply.
+func TestPlanWSActionsSucceed(t *testing.T) {
+	h := newPlanTestHandlers(t)
+	ctx := context.Background()
+
+	t.Run("get with no plan returns null", func(t *testing.T) {
+		out, err := h.wsGetTaskPlan(ctx, planMsg(t, ws.ActionTaskPlanGet, `{"task_id":"`+planlessID+`"}`))
+		if err != nil {
+			t.Fatalf("wsGetTaskPlan: %v", err)
+		}
+		if out.Type != ws.MessageTypeResponse {
+			t.Fatalf("type = %q, want %q", out.Type, ws.MessageTypeResponse)
+		}
+		if string(out.Payload) != "null" {
+			t.Errorf("payload = %s, want null", out.Payload)
+		}
+	})
+
+	t.Run("create", func(t *testing.T) {
+		out, err := h.wsCreateTaskPlan(ctx, planMsg(t, ws.ActionTaskPlanCreate,
+			`{"task_id":"`+planTaskID+`","title":"Ship it","content":"step one"}`))
+		if err != nil {
+			t.Fatalf("wsCreateTaskPlan: %v", err)
+		}
+		plan := decodePlanPayload(t, out)
+		if plan["task_id"] != planTaskID || plan["content"] != "step one" {
+			t.Errorf("plan = %v", plan)
+		}
+		// The browser surface defaults an unattributed write to the user.
+		if plan["created_by"] != "user" {
+			t.Errorf("created_by = %v, want user", plan["created_by"])
+		}
+	})
+
+	t.Run("get", func(t *testing.T) {
+		out, err := h.wsGetTaskPlan(ctx, planMsg(t, ws.ActionTaskPlanGet, `{"task_id":"`+planTaskID+`"}`))
+		if err != nil {
+			t.Fatalf("wsGetTaskPlan: %v", err)
+		}
+		if plan := decodePlanPayload(t, out); plan["content"] != "step one" {
+			t.Errorf("content = %v, want step one", plan["content"])
+		}
+	})
+
+	t.Run("update", func(t *testing.T) {
+		out, err := h.wsUpdateTaskPlan(ctx, planMsg(t, ws.ActionTaskPlanUpdate,
+			`{"task_id":"`+planTaskID+`","content":"step two"}`))
+		if err != nil {
+			t.Fatalf("wsUpdateTaskPlan: %v", err)
+		}
+		if plan := decodePlanPayload(t, out); plan["content"] != "step two" {
+			t.Errorf("content = %v, want step two", plan["content"])
+		}
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		out, err := h.wsDeleteTaskPlan(ctx, planMsg(t, ws.ActionTaskPlanDelete, `{"task_id":"`+planTaskID+`"}`))
+		if err != nil {
+			t.Fatalf("wsDeleteTaskPlan: %v", err)
+		}
+		if out.Type != ws.MessageTypeResponse {
+			t.Fatalf("type = %q, want %q", out.Type, ws.MessageTypeResponse)
+		}
+		if string(out.Payload) != `{"success":true}` {
+			t.Errorf("payload = %s, want {\"success\":true}", out.Payload)
+		}
+	})
+}
+
+func decodePlanPayload(t *testing.T, out *ws.Message) map[string]any {
+	t.Helper()
+	if out.Type != ws.MessageTypeResponse {
+		t.Fatalf("type = %q, want %q (payload %s)", out.Type, ws.MessageTypeResponse, out.Payload)
+	}
+	var plan map[string]any
+	if err := json.Unmarshal(out.Payload, &plan); err != nil {
+		t.Fatalf("unmarshal plan payload: %v", err)
+	}
+	return plan
+}

--- a/apps/backend/internal/task/handlers/task_plan_handlers_test.go
+++ b/apps/backend/internal/task/handlers/task_plan_handlers_test.go
@@ -42,6 +42,14 @@ func newPlanTestHandlers(t *testing.T) *TaskHandlers {
 		t.Fatalf("OpenSQLite: %v", err)
 	}
 	sqlxDB := sqlx.NewDb(dbConn, "sqlite3")
+	// Registered before the Provide call so the handle still closes if Provide
+	// fails and the Fatalf below fires. Cleanups run LIFO, so this one runs
+	// after the repository cleanup registered underneath it.
+	t.Cleanup(func() {
+		if err := sqlxDB.Close(); err != nil {
+			t.Errorf("close database: %v", err)
+		}
+	})
 	repo, cleanup, err := repository.Provide(sqlxDB, sqlxDB, nil)
 	if err != nil {
 		t.Fatalf("repository.Provide: %v", err)
@@ -49,9 +57,6 @@ func newPlanTestHandlers(t *testing.T) *TaskHandlers {
 	t.Cleanup(func() {
 		if err := cleanup(); err != nil {
 			t.Errorf("cleanup repository: %v", err)
-		}
-		if err := sqlxDB.Close(); err != nil {
-			t.Errorf("close database: %v", err)
 		}
 	})
 

--- a/apps/backend/internal/task/handlers/workspace_policy.go
+++ b/apps/backend/internal/task/handlers/workspace_policy.go
@@ -84,20 +84,3 @@ func validatePolicy(pol *service.WorkspacePolicy) error {
 	}
 	return nil
 }
-
-// mergeWorkspaceMetadata merges the workspace-policy metadata block into
-// the user-supplied metadata. The workspace block always wins for the
-// "workspace" key so callers can't inject conflicting policy via raw
-// metadata.
-func mergeWorkspaceMetadata(base map[string]interface{}, ws map[string]interface{}) map[string]interface{} {
-	if len(ws) == 0 {
-		return base
-	}
-	if base == nil {
-		base = map[string]interface{}{}
-	}
-	for k, v := range ws {
-		base[k] = v
-	}
-	return base
-}

--- a/apps/backend/internal/task/planws/errors.go
+++ b/apps/backend/internal/task/planws/errors.go
@@ -1,0 +1,103 @@
+// Package planws holds the WebSocket contract shared by Kandev's two
+// task-plan surfaces: the browser-facing handlers in internal/task/handlers
+// and the agent-facing MCP handlers in internal/mcp/handlers.
+//
+// Both surfaces drive the same *service.PlanService and are expected to report
+// the same failure the same way, but neither package imports the other, so
+// until now each carried its own copy of the sentinel mapping. Defining it once
+// here is what keeps the two from drifting; the surfaces themselves stay
+// separate on purpose, because their request shapes and success payloads
+// legitimately differ.
+package planws
+
+import (
+	"errors"
+
+	"github.com/kandev/kandev/internal/task/service"
+	ws "github.com/kandev/kandev/pkg/websocket"
+)
+
+// TaskIDRequest is the payload for the plan actions keyed only by task, so the
+// wire shape is declared once rather than re-spelled per surface.
+type TaskIDRequest struct {
+	TaskID string `json:"task_id"`
+}
+
+// mapping pairs a PlanService sentinel with the WebSocket code and message
+// reported for it.
+type mapping struct {
+	sentinel error
+	code     string
+	message  string
+}
+
+// The task-plan error vocabulary. Messages are the ones the frontend and the
+// MCP tools already receive, so editing one now moves both surfaces together.
+var (
+	taskIDRequired       = mapping{service.ErrTaskIDRequired, ws.ErrorCodeValidation, "task_id is required"}
+	sessionIDRequired    = mapping{service.ErrSessionIDRequired, ws.ErrorCodeValidation, "session_id is required"}
+	sessionTaskMismatch  = mapping{service.ErrSessionTaskMismatch, ws.ErrorCodeValidation, "Session does not belong to task"}
+	planNotFound         = mapping{service.ErrTaskPlanNotFound, ws.ErrorCodeNotFound, "Task plan not found"}
+	revisionIDRequired   = mapping{service.ErrRevisionIDRequired, ws.ErrorCodeValidation, "revision_id is required"}
+	revisionNotFound     = mapping{service.ErrRevisionNotFound, ws.ErrorCodeNotFound, "Revision not found"}
+	revisionTaskMismatch = mapping{service.ErrRevisionTaskMismatch, ws.ErrorCodeValidation, "Revision does not belong to task"}
+
+	// allMappings is the vocabulary reachable by an action that can surface any
+	// plan or revision failure.
+	allMappings = []mapping{
+		taskIDRequired,
+		sessionIDRequired,
+		sessionTaskMismatch,
+		planNotFound,
+		revisionIDRequired,
+		revisionNotFound,
+		revisionTaskMismatch,
+	}
+)
+
+// errorResponse returns the shared response when err matches one of recognized,
+// and otherwise an internal error carrying fallback verbatim. Each action
+// passes only the sentinels its PlanService method can actually return, so a
+// sentinel that would mean something different for that action does not get
+// silently reclassified.
+func errorResponse(msg *ws.Message, err error, fallback string, recognized []mapping) (*ws.Message, error) {
+	for _, m := range recognized {
+		if errors.Is(err, m.sentinel) {
+			return ws.NewError(msg.ID, msg.Action, m.code, m.message, nil)
+		}
+	}
+	return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError, fallback, nil)
+}
+
+// CreateError maps a PlanService.CreatePlan failure.
+//
+// ErrTaskPlanNotFound is deliberately absent: CreatePlan only returns it when
+// the plan vanishes between the write and the read-back, which is a server-side
+// inconsistency rather than the caller naming a plan that does not exist.
+func CreateError(msg *ws.Message, err error) (*ws.Message, error) {
+	return errorResponse(msg, err, "Failed to create task plan: "+err.Error(), []mapping{taskIDRequired})
+}
+
+// GetError maps a PlanService.GetPlan failure. The fallback omits err.Error()
+// because a read that fails below the sentinels is a storage fault with nothing
+// actionable for the caller.
+func GetError(msg *ws.Message, err error) (*ws.Message, error) {
+	return errorResponse(msg, err, "Failed to get task plan", []mapping{taskIDRequired})
+}
+
+// UpdateError maps a PlanService.UpdatePlan failure.
+func UpdateError(msg *ws.Message, err error) (*ws.Message, error) {
+	return errorResponse(msg, err, "Failed to update task plan: "+err.Error(), []mapping{taskIDRequired, planNotFound})
+}
+
+// DeleteError maps a PlanService.DeletePlan failure.
+func DeleteError(msg *ws.Message, err error) (*ws.Message, error) {
+	return errorResponse(msg, err, "Failed to delete task plan: "+err.Error(), []mapping{taskIDRequired, planNotFound})
+}
+
+// Error maps a failure from a plan action that can reach the whole sentinel
+// vocabulary — implementation-started, revert, and the revision reads. fallback
+// is the action's own summary; err.Error() is appended to it.
+func Error(msg *ws.Message, err error, fallback string) (*ws.Message, error) {
+	return errorResponse(msg, err, fallback+": "+err.Error(), allMappings)
+}

--- a/apps/backend/internal/task/planws/errors_test.go
+++ b/apps/backend/internal/task/planws/errors_test.go
@@ -1,0 +1,163 @@
+package planws
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/kandev/kandev/internal/task/service"
+	ws "github.com/kandev/kandev/pkg/websocket"
+)
+
+// decode reads back the ErrorPayload a mapper produced, so assertions are made
+// against the bytes a client actually receives rather than the Go values.
+func decode(t *testing.T, msg *ws.Message, err error) ws.ErrorPayload {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("mapper returned error: %v", err)
+	}
+	if msg == nil {
+		t.Fatal("mapper returned a nil message")
+	}
+	if msg.Type != ws.MessageTypeError {
+		t.Fatalf("message type = %q, want %q", msg.Type, ws.MessageTypeError)
+	}
+	var payload ws.ErrorPayload
+	if jsonErr := json.Unmarshal(msg.Payload, &payload); jsonErr != nil {
+		t.Fatalf("unmarshal error payload: %v", jsonErr)
+	}
+	return payload
+}
+
+// Expectations repeated across the tables below, named so the package's
+// occurrence count stays under goconst's threshold. They are declared here
+// rather than imported from errors.go on purpose: the test must fail when the
+// production message changes, which it cannot do if both read the same symbol.
+const (
+	wantTaskIDRequired   = "task_id is required"
+	wantTaskPlanNotFound = "Task plan not found"
+)
+
+func request() *ws.Message {
+	return &ws.Message{ID: "req-1", Action: "task.plan.delete"}
+}
+
+// TestMappersCoverEverySentinel pins the code and message for each sentinel an
+// action recognizes, plus the unrecognized-error fallback. The mappers are the
+// single definition both plan surfaces use, so this table is the contract.
+func TestMappersCoverEverySentinel(t *testing.T) {
+	boom := errors.New("disk on fire")
+
+	cases := []struct {
+		name    string
+		mapper  func(*ws.Message, error) (*ws.Message, error)
+		err     error
+		code    string
+		message string
+	}{
+		{"create/task_id", CreateError, service.ErrTaskIDRequired, ws.ErrorCodeValidation, wantTaskIDRequired},
+		{"create/fallback", CreateError, boom, ws.ErrorCodeInternalError, "Failed to create task plan: disk on fire"},
+		// CreatePlan's ErrTaskPlanNotFound means the read-back after a
+		// successful write found nothing — a server fault, not a missing plan.
+		{"create/plan_not_found_is_internal", CreateError, service.ErrTaskPlanNotFound, ws.ErrorCodeInternalError, "Failed to create task plan: task plan not found"},
+
+		{"get/task_id", GetError, service.ErrTaskIDRequired, ws.ErrorCodeValidation, wantTaskIDRequired},
+		// The get fallback carries no err.Error() detail.
+		{"get/fallback", GetError, boom, ws.ErrorCodeInternalError, "Failed to get task plan"},
+
+		{"update/task_id", UpdateError, service.ErrTaskIDRequired, ws.ErrorCodeValidation, wantTaskIDRequired},
+		{"update/plan_not_found", UpdateError, service.ErrTaskPlanNotFound, ws.ErrorCodeNotFound, wantTaskPlanNotFound},
+		{"update/fallback", UpdateError, boom, ws.ErrorCodeInternalError, "Failed to update task plan: disk on fire"},
+
+		{"delete/task_id", DeleteError, service.ErrTaskIDRequired, ws.ErrorCodeValidation, wantTaskIDRequired},
+		{"delete/plan_not_found", DeleteError, service.ErrTaskPlanNotFound, ws.ErrorCodeNotFound, wantTaskPlanNotFound},
+		{"delete/fallback", DeleteError, boom, ws.ErrorCodeInternalError, "Failed to delete task plan: disk on fire"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			msg := request()
+			out, mapErr := tc.mapper(msg, tc.err)
+			payload := decode(t, out, mapErr)
+			if payload.Code != tc.code {
+				t.Errorf("code = %q, want %q", payload.Code, tc.code)
+			}
+			if payload.Message != tc.message {
+				t.Errorf("message = %q, want %q", payload.Message, tc.message)
+			}
+		})
+	}
+}
+
+// TestErrorCoversFullVocabulary pins the mapper used by the actions that can
+// surface any plan or revision failure.
+func TestErrorCoversFullVocabulary(t *testing.T) {
+	cases := []struct {
+		err     error
+		code    string
+		message string
+	}{
+		{service.ErrTaskIDRequired, ws.ErrorCodeValidation, wantTaskIDRequired},
+		{service.ErrSessionIDRequired, ws.ErrorCodeValidation, "session_id is required"},
+		{service.ErrSessionTaskMismatch, ws.ErrorCodeValidation, "Session does not belong to task"},
+		{service.ErrTaskPlanNotFound, ws.ErrorCodeNotFound, wantTaskPlanNotFound},
+		{service.ErrRevisionIDRequired, ws.ErrorCodeValidation, "revision_id is required"},
+		{service.ErrRevisionNotFound, ws.ErrorCodeNotFound, "Revision not found"},
+		{service.ErrRevisionTaskMismatch, ws.ErrorCodeValidation, "Revision does not belong to task"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.err.Error(), func(t *testing.T) {
+			out, mapErr := Error(request(), tc.err, "Failed to revert plan")
+			payload := decode(t, out, mapErr)
+			if payload.Code != tc.code {
+				t.Errorf("code = %q, want %q", payload.Code, tc.code)
+			}
+			if payload.Message != tc.message {
+				t.Errorf("message = %q, want %q", payload.Message, tc.message)
+			}
+		})
+	}
+
+	t.Run("fallback appends the cause", func(t *testing.T) {
+		out, mapErr := Error(request(), errors.New("boom"), "Failed to revert plan")
+		payload := decode(t, out, mapErr)
+		if payload.Code != ws.ErrorCodeInternalError {
+			t.Errorf("code = %q, want %q", payload.Code, ws.ErrorCodeInternalError)
+		}
+		if payload.Message != "Failed to revert plan: boom" {
+			t.Errorf("message = %q", payload.Message)
+		}
+	})
+}
+
+// TestSentinelsMatchThroughWrapping guards the mappers against a service that
+// starts annotating its errors: errors.Is, not equality, decides the code.
+func TestSentinelsMatchThroughWrapping(t *testing.T) {
+	wrapped := fmt.Errorf("delete plan: %w", service.ErrTaskPlanNotFound)
+	out, mapErr := DeleteError(request(), wrapped)
+	payload := decode(t, out, mapErr)
+	if payload.Code != ws.ErrorCodeNotFound {
+		t.Errorf("code = %q, want %q", payload.Code, ws.ErrorCodeNotFound)
+	}
+	if payload.Message != wantTaskPlanNotFound {
+		t.Errorf("message = %q, want %q", payload.Message, wantTaskPlanNotFound)
+	}
+}
+
+// TestErrorResponsePreservesEnvelope checks the mappers copy the request's ID
+// and action onto the reply, which is how the caller correlates it.
+func TestErrorResponsePreservesEnvelope(t *testing.T) {
+	msg := &ws.Message{ID: "req-42", Action: ws.ActionMCPDeleteTaskPlan}
+	out, err := DeleteError(msg, service.ErrTaskIDRequired)
+	if err != nil {
+		t.Fatalf("DeleteError: %v", err)
+	}
+	if out.ID != "req-42" {
+		t.Errorf("ID = %q, want %q", out.ID, "req-42")
+	}
+	if out.Action != ws.ActionMCPDeleteTaskPlan {
+		t.Errorf("Action = %q, want %q", out.Action, ws.ActionMCPDeleteTaskPlan)
+	}
+}

--- a/apps/backend/internal/task/service/handoff_service.go
+++ b/apps/backend/internal/task/service/handoff_service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"sync"
 	"time"
 
@@ -121,6 +122,23 @@ func (p WorkspacePolicy) MetadataBlock() map[string]interface{} {
 		return nil
 	}
 	return map[string]interface{}{"workspace": ws}
+}
+
+// MergeMetadataBlock folds MetadataBlock into caller-supplied task metadata,
+// allocating base only when there is something to write. The policy block wins
+// for the keys it owns, so a caller cannot inject conflicting policy through
+// raw metadata. Both task-create surfaces (HTTP and MCP) go through here, which
+// is what keeps their metadata precedence identical.
+func (p WorkspacePolicy) MergeMetadataBlock(base map[string]interface{}) map[string]interface{} {
+	block := p.MetadataBlock()
+	if len(block) == 0 {
+		return base
+	}
+	if base == nil {
+		base = map[string]interface{}{}
+	}
+	maps.Copy(base, block)
+	return base
 }
 
 // NeedsAttachment returns true when AttachWorkspacePolicy has work to do

--- a/apps/backend/internal/task/service/handoff_workspace_test.go
+++ b/apps/backend/internal/task/service/handoff_workspace_test.go
@@ -503,6 +503,48 @@ func TestWorkspacePolicy_MetadataBlock(t *testing.T) {
 	}
 }
 
+// TestWorkspacePolicy_MergeMetadataBlock pins the merge both task-create
+// surfaces (HTTP in internal/task/handlers, MCP in internal/mcp/handlers) now
+// share, so their metadata precedence cannot diverge again.
+func TestWorkspacePolicy_MergeMetadataBlock(t *testing.T) {
+	pol := WorkspacePolicy{Mode: "new_workspace"}
+
+	t.Run("policy wins over caller metadata", func(t *testing.T) {
+		got := pol.MergeMetadataBlock(map[string]interface{}{
+			"workspace": map[string]interface{}{"mode": "smuggled"},
+			"other":     "kept",
+		})
+		wsBlock, ok := got["workspace"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("workspace map missing: %#v", got)
+		}
+		if wsBlock["mode"] != "new_workspace" {
+			t.Errorf("mode = %v, want new_workspace", wsBlock["mode"])
+		}
+		if got["other"] != "kept" {
+			t.Errorf("unrelated key dropped: %#v", got)
+		}
+	})
+
+	t.Run("nil metadata is allocated", func(t *testing.T) {
+		got := pol.MergeMetadataBlock(nil)
+		if _, ok := got["workspace"]; !ok {
+			t.Fatalf("workspace block missing: %#v", got)
+		}
+	})
+
+	t.Run("empty policy leaves metadata untouched", func(t *testing.T) {
+		if got := (WorkspacePolicy{}).MergeMetadataBlock(nil); got != nil {
+			t.Errorf("got %#v, want nil", got)
+		}
+		base := map[string]interface{}{"other": "kept"}
+		got := (WorkspacePolicy{}).MergeMetadataBlock(base)
+		if len(got) != 1 || got["other"] != "kept" {
+			t.Errorf("got %#v, want the caller's map unchanged", got)
+		}
+	})
+}
+
 func TestWorkspacePolicy_NeedsAttachment(t *testing.T) {
 	cases := []struct {
 		name string


### PR DESCRIPTION
The task-plan CRUD handlers on Kandev's two plan surfaces — agent-facing (`internal/mcp/handlers`) and browser-facing (`internal/task/handlers`) — each carried a private copy of the service-sentinel → `ws.ErrorCode` mapping, so the same `PlanService` failure could be reported differently on each without anything catching it. The mapping now lives in one place and is pinned from both sides.

## Important Changes

- **New neutral package `internal/task/planws`** holds the sentinel → code/message table plus one exported mapper per action (`CreateError`, `GetError`, `UpdateError`, `DeleteError`, and `Error` for the actions that reach the full vocabulary). Placement: neither handler package imports the other today, so exporting the existing `taskPlanServiceError` from `internal/task/handlers` would have created a new dependency from the agent surface onto the browser surface. A neutral package both already-existing dependents can import avoids inventing that edge.
- **Each mapper names only the sentinels its `PlanService` method can return.** `CreateError` deliberately does *not* map `ErrTaskPlanNotFound` to 404 — `CreatePlan` returns it only when the plan vanishes between the write and the read-back, which is a server fault, not a missing plan. That distinction was implicit in the duplicated code and is now documented and tested.
- **`taskPlanServiceError` is gone**; `wsMarkTaskPlanImplementationStarted`, `wsRevertTaskPlan`, `wsListTaskPlanRevisions`, and `wsGetTaskPlanRevision` all use the shared mapper. The last two previously inlined the mapping despite the local helper existing; their reachable sentinel sets are unchanged.
- **Both surfaces keep their own request shapes and success payloads on purpose.** MCP requires non-empty content, defaults an unattributed write to `agent` (browser: `user`), and returns `{}` rather than `null` for a task with no plan. These differences are now pinned by tests so they are not "unified" away by accident. The `"success"` literal and `responseKeySuccess` constant were confirmed to serialize identically (`{"success":true}`) before the delete replies were left as-is.
- **Folded in one verified duplicate outside the plan family:** `mergeMCPMetadata` and `mergeWorkspaceMetadata` were byte-for-byte the same shallow merge, each with a single call site that merged `WorkspacePolicy.MetadataBlock()`. Both are replaced by `WorkspacePolicy.MergeMetadataBlock`, which lives next to the block it merges and uses stdlib `maps.Copy`.

### Candidates checked and rejected

- `classifyMoveTaskError` ↔ `isMoveConflict` — not the same logic. One is a bool predicate feeding an HTTP 409, the other a three-way WebSocket code classifier. The only genuinely shared part is a five-element substring heuristic over untyped error text; extracting it would entrench the heuristic, when the real fix is typed sentinels on the move path.
- `handleCreateWorkflow` ↔ `wsCreateWorkflow` — the same generic shape (decode, validate two fields, call service, 500, respond), not the same logic. Different request fields (`prompt` / `workflow_template_id`), a read-only-workspace guard on only one, and different response types (raw model vs. `dto.FromWorkflow`).
- The similarity-detector noise called out as out of scope (`handleListAgents` vs. the `wsList*` family, `parseTaskIDPayload` vs. `wsGetTaskPlanRevision`, `handleCancelTaskReview` vs. `wsGetTaskPlanRevision`) was left alone.

## Validation

This is a behavior-preserving refactor, so the strongest evidence is a before/after pin: with the two handler files reverted to `HEAD` and the new tests left in place, **both new handler suites pass against the pre-refactor code** as well as against the refactored code.

Mutation-tested the shared mapper twice — `ErrTaskPlanNotFound` → `INTERNAL_ERROR`, and `ErrTaskIDRequired` → `BAD_REQUEST`. Each mutation failed the `planws` table test **and** the pin tests on **both** surfaces, so neither surface is silently untested.

```
go test ./internal/task/planws/ ./internal/mcp/handlers/    # ok
go test ./internal/task/handlers/ -run TestPlanWS           # ok
go test ./internal/task/service/ -run TestWorkspacePolicy   # ok
make -C apps/backend test
make -C apps/backend lint                                   # 0 issues
golangci-lint run ./... --new-from-rev=d38d9a0b8 --timeout=5m  # 0 issues
```

The full suite fails 13 tests across `internal/gitlab`, `internal/task/handlers`, and `internal/task/service`. All are pre-existing and unrelated: the 12 in `task/handlers` + `task/service` are the local-repository/directory-init sandbox failures, verified to fail identically with this branch's changes reverted to `HEAD`; the one in `internal/gitlab` is driven by inherited `GITLAB_HOST` / `KANDEV_GITLAB_HOST` env vars and passes with them scrubbed.

## Possible Improvements

Low risk — no production logic changed, and the error contract is now covered from both surfaces. The residual risk is scope: the decode boilerplate was intentionally *not* wrapped in a helper, because Go's `(*ws.Message, error)` return convention makes every wrapper signature longer at the call site than the three lines it replaces. Only the shared `TaskIDRequest` payload shape was extracted.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2465?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->