### PR TITLE
fix(task): home borrowed environments in the worktree cutover

### DIFF
--- a/apps/backend/internal/task/repository/sqlite/worktree_ownership_migration_test.go
+++ b/apps/backend/internal/task/repository/sqlite/worktree_ownership_migration_test.go
@@ -712,6 +712,146 @@ func TestCutover_PreservesCreatedSessionWorktreeWithoutCanonicalOwner(t *testing
 	}
 }
 
+// TestCutover_SharedEnvironmentAcrossTasks proves that a session bound to
+// another task's environment (workspace-group sharing / subtask inheritance)
+// normalizes onto the owning task's environment instead of failing the
+// cutover or fabricating a duplicate worktree owner.
+func TestCutover_SharedEnvironmentAcrossTasks(t *testing.T) {
+	db := openLegacyDB(t)
+	now := time.Now().UTC().Truncate(time.Second)
+	owner := legacySeed{envID: "env-shared", taskID: "task-owner", repoID: "repo-shared", sessionID: "sess-owner"}
+	seedLegacyTask(t, db, owner, now)
+	seedSharedMemberTask(t, db, "task-member", "sess-member", "env-shared", now)
+	linkSessionEnvironment(t, db, "sess-owner", "env-shared")
+
+	seedLegacyFlatEnv(t, db, owner, "wt-shared", "/tasks/shared/kandev", "feature/shared", now)
+	seedLegacyEnvRepo(t, db, "env-repo-shared", "env-shared", "repo-shared", "wt-shared", "/tasks/shared/kandev", "feature/shared", now)
+	seedLegacySessionWorktree(t, db, "sess-owner", "wt-shared", "repo-shared", "", "/tasks/shared/kandev", "feature/shared", "active", now)
+	seedLegacySessionWorktree(t, db, "sess-member", "wt-shared", "repo-shared", "", "/tasks/shared/kandev", "feature/shared", "active", now)
+
+	repo, err := NewWithDB(db, db, nil)
+	if err != nil {
+		t.Fatalf("cutover: %v", err)
+	}
+	ctx := context.Background()
+
+	env, err := repo.GetTaskEnvironment(ctx, "env-shared")
+	if err != nil {
+		t.Fatalf("GetTaskEnvironment: %v", err)
+	}
+	if len(env.Repos) != 1 || env.Repos[0].WorktreeID != "wt-shared" {
+		t.Fatalf("shared environment repos = %+v, want one wt-shared row", env.Repos)
+	}
+	for _, sessionID := range []string{"sess-owner", "sess-member"} {
+		session, err := repo.GetTaskSession(ctx, sessionID)
+		if err != nil {
+			t.Fatalf("GetTaskSession(%s): %v", sessionID, err)
+		}
+		if session.TaskEnvironmentID != "env-shared" {
+			t.Fatalf("session %s env = %q, want env-shared", sessionID, session.TaskEnvironmentID)
+		}
+	}
+	// The borrowing task must not gain an environment of its own: the
+	// physical worktree has exactly one owner.
+	memberEnv, err := repo.GetTaskEnvironmentByTaskID(ctx, "task-member")
+	if err != nil {
+		t.Fatalf("GetTaskEnvironmentByTaskID(task-member): %v", err)
+	}
+	if memberEnv != nil {
+		t.Fatalf("borrowing task gained environment %s with repos %+v", memberEnv.ID, memberEnv.Repos)
+	}
+	var owners int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM task_environment_repos WHERE worktree_id = 'wt-shared'`).Scan(&owners); err != nil {
+		t.Fatalf("count worktree owners: %v", err)
+	}
+	if owners != 1 {
+		t.Fatalf("worktree owner rows = %d, want 1", owners)
+	}
+}
+
+// TestCutover_SharedEnvironmentWithoutCanonicalRepoRow covers the same
+// borrowed-environment shape when only the member session carries the
+// worktree metadata: it must land on the environment's owning task.
+func TestCutover_SharedEnvironmentWithoutCanonicalRepoRow(t *testing.T) {
+	db := openLegacyDB(t)
+	now := time.Now().UTC().Truncate(time.Second)
+	owner := legacySeed{envID: "env-borrow", taskID: "task-lender", repoID: "", sessionID: "sess-lender"}
+	seedLegacyTask(t, db, owner, now)
+	seedSharedMemberTask(t, db, "task-borrower", "sess-borrower", "env-borrow", now)
+	linkSessionEnvironment(t, db, "sess-lender", "env-borrow")
+	seedLegacyFlatEnv(t, db, owner, "", "", "", now)
+	seedLegacySessionWorktree(t, db, "sess-borrower", "wt-borrow", "repo-borrow", "", "/tasks/borrow/kandev", "feature/borrow", "active", now)
+
+	repo, err := NewWithDB(db, db, nil)
+	if err != nil {
+		t.Fatalf("cutover: %v", err)
+	}
+	env, err := repo.GetTaskEnvironment(context.Background(), "env-borrow")
+	if err != nil {
+		t.Fatalf("GetTaskEnvironment: %v", err)
+	}
+	if len(env.Repos) != 1 || env.Repos[0].WorktreeID != "wt-borrow" ||
+		env.Repos[0].WorktreePath != "/tasks/borrow/kandev" {
+		t.Fatalf("borrowed worktree row = %+v, want wt-borrow on the lending environment", env.Repos)
+	}
+}
+
+// TestCutover_SharedEnvironmentIgnoresStaleMemberMetadata proves that stale
+// worktree metadata on a borrowing session cannot conflict with the canonical
+// row owned by the lending task's environment.
+func TestCutover_SharedEnvironmentIgnoresStaleMemberMetadata(t *testing.T) {
+	db := openLegacyDB(t)
+	now := time.Now().UTC().Truncate(time.Second)
+	owner := legacySeed{envID: "env-stale", taskID: "task-stale-owner", repoID: "repo-stale", sessionID: "sess-stale-owner"}
+	seedLegacyTask(t, db, owner, now)
+	seedSharedMemberTask(t, db, "task-stale-member", "sess-stale-member", "env-stale", now)
+	linkSessionEnvironment(t, db, "sess-stale-owner", "env-stale")
+	if _, err := db.Exec(db.Rebind(
+		`UPDATE task_sessions SET state = 'WAITING_FOR_INPUT' WHERE id = ?`), "sess-stale-member"); err != nil {
+		t.Fatalf("set member session state: %v", err)
+	}
+	seedLegacyFlatEnv(t, db, owner, "wt-stale", "/tasks/stale/kandev", "feature/current", now)
+	seedLegacyEnvRepo(t, db, "env-repo-stale", "env-stale", "repo-stale", "wt-stale", "/tasks/stale/kandev", "feature/current", now)
+	seedLegacySessionWorktree(t, db, "sess-stale-member", "wt-stale", "repo-stale", "", "/tasks/stale/kandev", "feature/stale", "active", now)
+
+	repo, err := NewWithDB(db, db, nil)
+	if err != nil {
+		t.Fatalf("cutover: %v", err)
+	}
+	env, err := repo.GetTaskEnvironment(context.Background(), "env-stale")
+	if err != nil {
+		t.Fatalf("GetTaskEnvironment: %v", err)
+	}
+	if len(env.Repos) != 1 || env.Repos[0].WorktreeBranch != "feature/current" {
+		t.Fatalf("shared environment repos = %+v, want the canonical feature/current row", env.Repos)
+	}
+}
+
+// seedSharedMemberTask seeds a task whose only session borrows another
+// task's environment.
+func seedSharedMemberTask(t *testing.T, db *sqlx.DB, taskID, sessionID, envID string, startedAt time.Time) {
+	t.Helper()
+	if _, err := db.Exec(db.Rebind(`
+		INSERT INTO tasks (id, workspace_id, title, created_at, updated_at)
+		VALUES (?, 'ws-1', 'shared member', ?, ?)`), taskID, startedAt, startedAt); err != nil {
+		t.Fatalf("seed member task: %v", err)
+	}
+	if _, err := db.Exec(db.Rebind(`
+		INSERT INTO task_sessions (id, task_id, state, task_environment_id, started_at, updated_at)
+		VALUES (?, ?, 'COMPLETED', ?, ?, ?)`), sessionID, taskID, envID, startedAt, startedAt); err != nil {
+		t.Fatalf("seed member session: %v", err)
+	}
+}
+
+func linkSessionEnvironment(t *testing.T, db *sqlx.DB, sessionID, envID string) {
+	t.Helper()
+	if _, err := db.Exec(db.Rebind(
+		`UPDATE task_sessions SET task_environment_id = ? WHERE id = ?`), envID, sessionID); err != nil {
+		t.Fatalf("link session environment: %v", err)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // PostgreSQL coverage
 // ---------------------------------------------------------------------------

--- a/apps/backend/internal/task/repository/sqlite/worktree_ownership_normalize.go
+++ b/apps/backend/internal/task/repository/sqlite/worktree_ownership_normalize.go
@@ -248,10 +248,13 @@ func (c *worktreeCutover) normalize(tx *sqlx.Tx) error {
 	if err := c.backfillMissingEnvironments(tx); err != nil {
 		return err
 	}
+	// Sessions are linked before session worktrees are merged: a session's
+	// worktree belongs to the environment the session resolves to, which is
+	// not always an environment owned by the session's own task.
+	c.linkSessions()
 	c.mergeSessionWorktrees()
 	c.registerWorktreeIdentities()
 	c.bindTargetsToEnvironments()
-	c.linkSessions()
 
 	if len(c.conflicts) > 0 {
 		return fmt.Errorf("cutover: %d conflicting legacy ownership row(s):\n- %s",
@@ -324,14 +327,13 @@ func (c *worktreeCutover) mergeFlatEnvironmentFields() {
 }
 
 // mergeSessionWorktrees folds every legacy session-worktree row into the
-// session's task targets.
+// targets of the task that owns the session's environment.
 func (c *worktreeCutover) mergeSessionWorktrees() {
 	for _, wt := range c.sessionWts {
-		session, ok := c.sessions[wt.sessionID]
-		if !ok {
+		if _, ok := c.sessions[wt.sessionID]; !ok {
 			continue // already reported in load
 		}
-		targets := c.targetsForTask(session.taskID)
+		targets := c.targetsForTask(c.sessionOwnerTaskID(wt.sessionID))
 		if err := targets.mergeSessionWorktree(wt, c.isSupersededSessionWorktree(wt)); err != nil {
 			c.conflicts = append(c.conflicts, fmt.Sprintf(
 				"session %s worktree %s: %v", wt.sessionID, wt.worktreeID, err))
@@ -358,6 +360,9 @@ func isLegacyHistoricalSession(state string) bool {
 // environment.
 func (c *worktreeCutover) bindTargetsToEnvironments() {
 	for taskID, targets := range c.tasks {
+		if len(targets.ordering) == 0 {
+			continue // nothing to home
+		}
 		envID := c.taskEnvIDs[taskID]
 		if envID == "" {
 			c.conflicts = append(c.conflicts, fmt.Sprintf(
@@ -382,14 +387,20 @@ func (c *worktreeCutover) targetsForTask(taskID string) *taskWorktreeTargets {
 
 // backfillMissingEnvironments creates a normalized environment for every task
 // that has sessions but no environment, mirroring the legacy startup backfill
-// (now folded into this one-time cutover).
+// (now folded into this one-time cutover). Sessions that borrow a surviving
+// environment from another task are skipped: fabricating an environment for
+// the borrowing task would duplicate the shared workspace.
 func (c *worktreeCutover) backfillMissingEnvironments(tx *sqlx.Tx) error {
 	tasksWithSessions := make(map[string]*legacySession)
 	for _, s := range c.sessions {
-		if _, ok := c.taskEnvIDs[s.taskID]; !ok {
-			if _, seen := tasksWithSessions[s.taskID]; !seen {
-				tasksWithSessions[s.taskID] = s
-			}
+		if _, ok := c.taskEnvIDs[s.taskID]; ok {
+			continue
+		}
+		if c.hasSurvivingEnvironmentRef(s.id) {
+			continue
+		}
+		if _, seen := tasksWithSessions[s.taskID]; !seen {
+			tasksWithSessions[s.taskID] = s
 		}
 	}
 	for taskID, sample := range tasksWithSessions {
@@ -472,16 +483,17 @@ func (c *worktreeCutover) isSupersededSessionWorktree(wt legacySessionWorktree) 
 	}
 
 	session, hasSession := c.sessions[wt.sessionID]
+	ownerTaskID := c.sessionOwnerTaskID(wt.sessionID)
 	superseded := false
 	switch {
 	case isLegacyDeletedWorktree(wt):
 		superseded = true
-	case hasSession && c.authoritativeWorktreeIDs[authoritativeWorktreeKey(session.taskID, wt.worktreeID)]:
+	case hasSession && c.authoritativeWorktreeIDs[authoritativeWorktreeKey(ownerTaskID, wt.worktreeID)]:
 		superseded = true
 	case hasSession && isLegacyHistoricalSession(session.state):
 		for _, row := range c.envRepos {
 			env, ok := c.envs[row.envID]
-			if !ok || env.taskID != session.taskID || row.worktreeID == "" {
+			if !ok || env.taskID != ownerTaskID || row.worktreeID == "" {
 				continue
 			}
 			if row.repositoryID == wt.repositoryID && row.branchSlug == wt.branchSlug {
@@ -492,6 +504,34 @@ func (c *worktreeCutover) isSupersededSessionWorktree(wt legacySessionWorktree) 
 	}
 	c.sessionWorktreeSuperseded[cacheKey] = superseded
 	return superseded
+}
+
+// sessionOwnerTaskID returns the task that owns the environment a session
+// resolves to. A session does not always run in an environment owned by its
+// own task: workspace-group members, subtasks inheriting their parent's
+// workspace, and tasks that received a shared environment through ownership
+// handoff all borrow another task's environment. The physical worktree such a
+// session used belongs to that environment, so its normalized repository row
+// must be homed on the owning task — homing it on the borrowing task would
+// give one worktree two owners.
+//
+// Only valid after linkSessions has settled every session's environment.
+func (c *worktreeCutover) sessionOwnerTaskID(sessionID string) string {
+	if env, ok := c.envs[c.sessionEnvIDs[sessionID]]; ok && env.taskID != "" {
+		return env.taskID
+	}
+	return c.sessionTasks[sessionID]
+}
+
+// hasSurvivingEnvironmentRef reports whether a session already points at an
+// environment that survives the cutover (its own task's or a borrowed one).
+func (c *worktreeCutover) hasSurvivingEnvironmentRef(sessionID string) bool {
+	envID := c.sessionEnvIDs[sessionID]
+	if envID == "" || c.loserEnvIDs[envID] {
+		return false
+	}
+	_, ok := c.envs[envID]
+	return ok
 }
 
 func (c *worktreeCutover) recordAuthoritativeWorktree(taskID, worktreeID string) {

--- a/apps/backend/internal/task/repository/sqlite/worktree_ownership_targets.go
+++ b/apps/backend/internal/task/repository/sqlite/worktree_ownership_targets.go
@@ -266,7 +266,8 @@ func (r *Repository) validateCutover(c *worktreeCutover, tx *sqlx.Tx) error {
 	}
 
 	// Every session that referenced a worktree must resolve to an
-	// environment that owns that worktree.
+	// environment that owns that worktree. The owning environment can belong
+	// to another task when the session borrows a shared workspace.
 	for _, wt := range c.sessionWts {
 		if c.isSupersededSessionWorktree(wt) {
 			continue
@@ -275,10 +276,13 @@ func (r *Repository) validateCutover(c *worktreeCutover, tx *sqlx.Tx) error {
 		if envID == "" {
 			return fmt.Errorf("cutover: session %s lost its environment", wt.sessionID)
 		}
-		targets, ok := c.tasks[c.sessionTasks[wt.sessionID]]
+		ownerTaskID := c.sessionOwnerTaskID(wt.sessionID)
+		targets, ok := c.tasks[ownerTaskID]
 		if !ok || targets.envID != envID || !targets.ownsWorktree(wt.worktreeID) {
-			return fmt.Errorf("cutover: session %s worktree %s has no environment-repository owner",
-				wt.sessionID, wt.worktreeID)
+			return fmt.Errorf(
+				"cutover: session %s worktree %s has no environment-repository owner "+
+					"(session task %s, environment %s owned by task %s)",
+				wt.sessionID, wt.worktreeID, c.sessionTasks[wt.sessionID], envID, ownerTaskID)
 		}
 	}
 

--- a/docs/specs/session-delete-resource-cleanup/spec.md
+++ b/docs/specs/session-delete-resource-cleanup/spec.md
@@ -112,6 +112,12 @@ worktree fields take precedence over a legacy session reference to the same
 physical `worktree_id`. This source precedence applies regardless of session
 lifecycle state: path or branch drift on a lower-precedence row does not create
 a second owner when the physical identity is unchanged.
+A legacy session's worktree is normalized onto the environment the session
+resolves to, which is not always an environment owned by the session's own
+task: workspace-group members, subtasks inheriting a parent workspace, and
+tasks that received an environment through ownership handoff share one
+environment across tasks. Such a borrowing task gains no environment of its
+own, and the shared physical worktree keeps exactly one owner.
 Legacy session rows marked `deleted` (or carrying `deleted_at`) and stale
 references from terminal sessions are historical evidence, not additional
 owners, and bypass validation only when a canonical repository owner exists.
@@ -220,6 +226,8 @@ remain the authorization boundary for physical cleanup.
   cannot block migration solely because its path or branch metadata is stale,
   including when the session is resumable. The higher-precedence repository or
   flat environment metadata remains authoritative.
+- A session bound to another task's environment does not block migration and
+  does not create a second owner for the shared worktree.
 - If migration fails after shadow tables are populated or after legacy DDL has
   begun, the database transaction restores the complete legacy schema and data.
 - If SQLite cannot create its pre-upgrade snapshot, startup stops before the
@@ -289,6 +297,11 @@ remain the authorization boundary for physical cleanup.
   repeats the surviving task environment's `worktree_id` with stale path or
   branch metadata, **WHEN** the new binary starts, **THEN** the flat environment
   metadata is retained and the cutover completes.
+- **GIVEN** a legacy session of one task is bound to another task's environment
+  and carries a session-worktree row for that shared workspace, **WHEN** the new
+  binary starts, **THEN** the worktree is normalized onto the owning task's
+  environment, both sessions keep that environment, the borrowing task gains no
+  environment of its own, and the cutover completes.
 - **GIVEN** a non-terminal session references a worktree that conflicts with
   the canonical owner and cannot be reconciled, **WHEN** the new binary starts,
   **THEN** startup fails closed, the transaction rolls back, and the verified


### PR DESCRIPTION
The task-worktree ownership cutover assumed every session runs in an environment owned by its own task, so any database where a session borrows another task's environment — workspace-group members, subtasks inheriting a parent workspace, tasks that received an environment through ownership handoff — failed the migration and the backend refused to boot with `cutover: session <id> worktree <id> has no environment-repository owner`.

## Important Changes

- Session worktrees are homed on the task that owns the environment the session resolves to, not on the session's own task, so a shared worktree keeps exactly one owner instead of gaining a second under a fabricated environment.
- `linkSessions` now runs before session worktrees are merged, so ownership attribution and cutover validation can no longer disagree.
- A task whose sessions all borrow a surviving environment no longer gets an empty environment backfilled for it.
- The validation failure now names the session's task, the resolved environment, and its owning task.

## Validation

- `go test ./internal/task/repository/sqlite/ -race -count=1` (includes three new cutover cases: shared environment with and without a canonical repository row, and stale metadata on a borrowing session)
- Each new test was mutation-checked: reverting the attribution fix, the backfill skip, or the owner-scoped supersession rule individually makes the corresponding test fail.
- `golangci-lint run ./internal/task/repository/sqlite/... --new-from-rev=<base>` — 0 issues
- `go build ./...`

## Possible Improvements

Low risk, migration-only: the cutover stays fail-closed, so genuinely ambiguous legacy data still aborts startup and rolls back rather than guessing an owner.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2473?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->