### PR TITLE
fix(git): ignore inherited indexed Git config beyond GIT_CONFIG_COUNT

### DIFF
--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -225,10 +225,10 @@ Client (WS) ← Orchestrator ← Lifecycle Manager ←──── stream update
   - **Path/security tests:** Avoid using the real filesystem root as a fixture root. Build fake absolute roots under `t.TempDir()` with `filepath.Join`; this keeps tests portable across Windows, POSIX, and privileged cloud executors.
   - **Filesystem permission tests:** Assert permission-denied behavior only after probing that the current executor enforces the permission bit change. Root-like Sprite executors may bypass `chmod` restrictions.
   - **Filesystem safety checks:** Carry the original `os.Lstat` `FileInfo` (or opened handle) through every decision; do not re-stat a validated path, which reopens a TOCTOU window before side effects. Test mismatches before writes or manager commands.
-  - **Git indexed-environment tests:** When a test supplies `GIT_CONFIG_COUNT`,
-    `GIT_CONFIG_KEY_n`, and `GIT_CONFIG_VALUE_n`, clear every inherited indexed
-    key first and restore it with `t.Cleanup`. Changing only the count can leave
-    higher parent indexes behind and create a malformed Git config block.
+  - **Git indexed-environment tests:** When a test supplies `GIT_CONFIG_COUNT`, `GIT_CONFIG_KEY_n`,
+    and `GIT_CONFIG_VALUE_n`, clear every inherited indexed key first and restore it with
+    `t.Cleanup`. `internal/gitconfigenv` ignores indexes past the count the way Git does, so an
+    uncleared parent silently changes what the block contains instead of failing loudly.
   - **Full test output:** For local full-suite pass/fail validation, prefer plain `go test -race ./...`. `go test -json ./...` can emit very large JSONL streams; if a wrapper or tracing tool truncates the stream mid-record, downstream JSON parsing may fail even when Go tests passed. Use JSON output mainly for CI artifacts or test-report tooling that explicitly requires it.
   - **Private executable helpers:** When library code starts `os.Executable()` in
     a private helper mode, do not rely only on a command package's dispatch or

--- a/apps/backend/internal/agentctl/server/config/config_test.go
+++ b/apps/backend/internal/agentctl/server/config/config_test.go
@@ -282,6 +282,40 @@ func TestCollectAgentEnvPreservesParentIndexedGitConfig(t *testing.T) {
 	}
 }
 
+func TestCollectAgentEnvIgnoresParentIndexedGitConfigBeyondCount(t *testing.T) {
+	// Hosts inherit indexed entries from a parent that later lowered
+	// GIT_CONFIG_COUNT. Git ignores the leftovers, so instance creation must
+	// too instead of failing every task start.
+	clearParentIndexedGitConfig(t)
+	t.Setenv("GIT_CONFIG_COUNT", "1")
+	t.Setenv("GIT_CONFIG_KEY_0", "core.hooksPath")
+	t.Setenv("GIT_CONFIG_VALUE_0", "/opt/locstat/hooks")
+	t.Setenv("GIT_CONFIG_KEY_1", "notes.augment.mergeStrategy")
+	t.Setenv("GIT_CONFIG_VALUE_1", "cat_sort_uniq")
+
+	env, err := CollectAgentEnvWithError(map[string]string{
+		"GIT_CONFIG_COUNT":   "1",
+		"GIT_CONFIG_KEY_0":   "credential.https://github.com.helper",
+		"GIT_CONFIG_VALUE_0": "!agentctl git-credential",
+	})
+	if err != nil {
+		t.Fatalf("CollectAgentEnvWithError() error = %v", err)
+	}
+
+	if got := envSliceValue(env, "GIT_CONFIG_COUNT"); got != "2" {
+		t.Fatalf("GIT_CONFIG_COUNT = %q, want 2", got)
+	}
+	if got := envSliceValue(env, "GIT_CONFIG_KEY_0"); got != "core.hooksPath" {
+		t.Fatalf("GIT_CONFIG_KEY_0 = %q, want core.hooksPath", got)
+	}
+	if got := envSliceValue(env, "GIT_CONFIG_KEY_1"); got != "credential.https://github.com.helper" {
+		t.Fatalf("GIT_CONFIG_KEY_1 = %q, want managed helper", got)
+	}
+	if got := envSliceValue(env, "GIT_CONFIG_KEY_2"); got != "" {
+		t.Fatalf("GIT_CONFIG_KEY_2 = %q, want stray parent entry dropped", got)
+	}
+}
+
 func TestCollectAgentEnvPreservesParentGitConfigHook(t *testing.T) {
 	clearParentIndexedGitConfig(t)
 	repository := t.TempDir()

--- a/apps/backend/internal/gitconfigenv/environment.go
+++ b/apps/backend/internal/gitconfigenv/environment.go
@@ -123,9 +123,9 @@ func entriesFrom(env map[string]string) ([]Entry, error) {
 	}
 	countValue, hasCount := env[countKey]
 	if !hasCount {
-		if hasIndexedEntry(env) {
-			return nil, fmt.Errorf("%s is required when indexed entries are set", countKey)
-		}
+		// Git reads indexed entries only when GIT_CONFIG_COUNT is set, so any
+		// leftover key/value pair configures nothing. Ignore them the way Git
+		// does rather than rejecting an inherited environment we do not own.
 		return nil, nil
 	}
 	count, err := strconv.Atoi(countValue)
@@ -141,40 +141,10 @@ func entriesFrom(env map[string]string) ([]Entry, error) {
 		}
 		entries = append(entries, Entry{Key: key, Value: value})
 	}
-	if hasOutOfRangeIndexedEntry(env, count) {
-		return nil, fmt.Errorf("indexed entry exceeds %s", countKey)
-	}
+	// Entries at or past the count are invisible to Git — a parent process that
+	// lowered GIT_CONFIG_COUNT leaves its higher indexes behind — so they are
+	// dropped here instead of failing the whole block.
 	return entries, nil
-}
-
-func hasIndexedEntry(env map[string]string) bool {
-	for key := range env {
-		if strings.HasPrefix(key, keyPrefix) || strings.HasPrefix(key, valuePrefix) {
-			return true
-		}
-	}
-	return false
-}
-
-func hasOutOfRangeIndexedEntry(env map[string]string, count int) bool {
-	for key := range env {
-		index, ok := indexedEntryIndex(key)
-		if ok && index >= count {
-			return true
-		}
-	}
-	return false
-}
-
-func indexedEntryIndex(key string) (int, bool) {
-	prefix := keyPrefix
-	if strings.HasPrefix(key, valuePrefix) {
-		prefix = valuePrefix
-	} else if !strings.HasPrefix(key, keyPrefix) {
-		return 0, false
-	}
-	index, err := strconv.Atoi(strings.TrimPrefix(key, prefix))
-	return index, err == nil && index >= 0
 }
 
 func removeBoundaryOverlap(base, overlay []Entry) []Entry {

--- a/apps/backend/internal/gitconfigenv/environment_test.go
+++ b/apps/backend/internal/gitconfigenv/environment_test.go
@@ -77,6 +77,62 @@ func TestIndexedGitConfigMergeRejectsMalformedBlock(t *testing.T) {
 	}
 }
 
+func TestIndexedGitConfigMergeIgnoresEntriesBeyondCount(t *testing.T) {
+	// Observed on a host whose shell hook re-initialized the block at count 2
+	// without clearing the higher indexes a nested shell had appended. Git
+	// reads only entries 0 and 1, so the leftovers must not fail agent startup.
+	merged, err := Merge(map[string]string{
+		"GIT_CONFIG_COUNT":   "2",
+		"GIT_CONFIG_KEY_0":   "notes.augment.mergeStrategy",
+		"GIT_CONFIG_VALUE_0": "union",
+		"GIT_CONFIG_KEY_1":   "core.hooksPath",
+		"GIT_CONFIG_VALUE_1": "/Users/example/.locstat/git/hooks",
+		"GIT_CONFIG_KEY_2":   "credential.useHttpPath",
+		"GIT_CONFIG_VALUE_2": "true",
+		"GIT_CONFIG_KEY_3":   "notes.augment.mergeStrategy",
+		"GIT_CONFIG_VALUE_3": "union",
+		"GIT_CONFIG_KEY_4":   "core.hooksPath",
+		"GIT_CONFIG_VALUE_4": "/Users/example/.locstat/git/hooks",
+	}, environmentWithEntries(
+		Entry{Key: "credential.https://github.com.helper", Value: "!agentctl git-credential"},
+	))
+	if err != nil {
+		t.Fatalf("Merge() error = %v", err)
+	}
+
+	if got := merged["GIT_CONFIG_COUNT"]; got != "3" {
+		t.Fatalf("GIT_CONFIG_COUNT = %q, want 3", got)
+	}
+	if got := merged["GIT_CONFIG_KEY_1"]; got != "core.hooksPath" {
+		t.Fatalf("GIT_CONFIG_KEY_1 = %q, want core.hooksPath", got)
+	}
+	if got := merged["GIT_CONFIG_KEY_2"]; got != "credential.https://github.com.helper" {
+		t.Fatalf("GIT_CONFIG_KEY_2 = %q, want managed helper", got)
+	}
+	if got, exists := merged["GIT_CONFIG_KEY_3"]; exists {
+		t.Fatalf("GIT_CONFIG_KEY_3 = %q, want stray entry dropped", got)
+	}
+}
+
+func TestIndexedGitConfigMergeIgnoresIndexedEntriesWithoutCount(t *testing.T) {
+	// Git reads indexed entries only when GIT_CONFIG_COUNT is set.
+	merged, err := Merge(map[string]string{
+		"GIT_CONFIG_KEY_0":   "core.hooksPath",
+		"GIT_CONFIG_VALUE_0": "/opt/locstat/hooks",
+		"HOME":               "/home/kandev",
+	}, nil)
+	if err != nil {
+		t.Fatalf("Merge() error = %v", err)
+	}
+
+	if got, exists := merged["GIT_CONFIG_KEY_0"]; exists {
+		t.Fatalf("GIT_CONFIG_KEY_0 = %q, want orphaned entry dropped", got)
+	}
+	if got := merged["HOME"]; got != "/home/kandev" {
+		t.Fatalf("HOME = %q, want ordinary variables preserved", got)
+	}
+}
+
 func TestFilterRemovesOnlyRequestedIndexedEntries(t *testing.T) {
 	env := map[string]string{
 		"GIT_CONFIG_COUNT":   "2",


### PR DESCRIPTION
A host whose environment carries stray `GIT_CONFIG_KEY_n`/`GIT_CONFIG_VALUE_n` variables at indexes past `GIT_CONFIG_COUNT` — exactly what a parent process leaves behind when it lowers the count — could not start any task, failing with `prepare agent environment: compose indexed Git config: base Git config: indexed entry exceeds GIT_CONFIG_COUNT`. Kandev was rejecting an inherited block that Git itself silently ignores, so `internal/gitconfigenv` now matches Git's own semantics and ambient environment noise no longer blocks instance creation.

## Important Changes

- `entriesFrom` drops indexed entries at or past `GIT_CONFIG_COUNT` instead of rejecting the block. Git's `git_config_from_parameters` reads only `0..count-1`, so those entries configure nothing and dropping them cannot change the effective config.
- Indexed entries present with no `GIT_CONFIG_COUNT` at all are ignored for the same reason — Git reads them only when the count is set.
- Blocks Git itself rejects still fail loudly: an unparseable, negative, or oversized count, or a key/value missing *within* range.

Why this mattered in practice: the standalone agentctl process inherits `os.Environ()` from the backend, which inherits the user's shell, and `CollectAgentEnvWithError` validates that as the *base* of the merge. One stray variable outside Kandev's control therefore failed every task start, with no recovery except finding and unsetting it.

## Validation

- `go test ./internal/gitconfigenv/ ./internal/agentctl/server/config/` — new tests reproduce the reported error before the change and pass after.
- Mutation-checked: reinstating the strict rejection fails both new tests, confirming they bind the behavior rather than passing incidentally.
- `go test ./internal/orchestrator/executor/ ./internal/repoclone/ ./internal/agentctl/server/process/ ./internal/agent/runtime/lifecycle/` — all consumers of the merge path pass.
- `go build ./...`, `go vet ./internal/gitconfigenv/ ./internal/agentctl/server/config/`.
- Pre-commit hooks all passed, including `golangci-lint` over the changed Go files.

The `gitconfigenv` regression fixture is the real environment block observed on the affected machine (count 2, indexes 0-4, with a duplicated pair from a shell hook that re-initialized the block without clearing higher indexes).

## Possible Improvements

Low risk: the change only widens what is accepted, and the merge output was already rebuilt as a contiguous block by `writeEntries`. The one behavioral trade-off is that a genuinely stale higher index is now dropped silently rather than surfacing as an error — which is what Git already does with it.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2475?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->