### PR TITLE
feat(web): open the workspace picker with a keyboard shortcut

### DIFF
--- a/apps/web/components/app-sidebar/app-sidebar-header.test.tsx
+++ b/apps/web/components/app-sidebar/app-sidebar-header.test.tsx
@@ -2,6 +2,8 @@ import { cleanup, render, screen } from "@testing-library/react";
 import { TooltipProvider } from "@kandev/ui/tooltip";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+const setWorkspacePickerOpen = vi.fn();
+
 const state = {
   workspaces: {
     activeId: "kanban-1" as string | null,
@@ -10,6 +12,8 @@ const state = {
       { id: "office-1", name: "Office", office_workflow_id: "wf-office" },
     ],
   },
+  appSidebar: { workspacePickerOpen: false },
+  setWorkspacePickerOpen,
 };
 
 vi.mock("@/components/state-provider", () => ({
@@ -17,7 +21,20 @@ vi.mock("@/components/state-provider", () => ({
 }));
 
 vi.mock("./app-sidebar-workspace-picker", () => ({
-  AppSidebarWorkspacePicker: () => <div data-testid="workspace-picker" />,
+  AppSidebarWorkspacePicker: ({
+    open,
+    onOpenChange,
+  }: {
+    open?: boolean;
+    onOpenChange?: (open: boolean) => void;
+  }) => (
+    <button
+      type="button"
+      data-testid="workspace-picker"
+      data-open={String(open)}
+      onClick={() => onOpenChange?.(false)}
+    />
+  ),
 }));
 
 import { AppSidebarHeader } from "./app-sidebar-header";
@@ -33,6 +50,8 @@ function renderHeader(collapsed = false) {
 describe("AppSidebarHeader", () => {
   beforeEach(() => {
     state.workspaces.activeId = "kanban-1";
+    state.appSidebar.workspacePickerOpen = false;
+    setWorkspacePickerOpen.mockClear();
   });
 
   afterEach(() => cleanup());
@@ -53,5 +72,22 @@ describe("AppSidebarHeader", () => {
     expect(screen.getByRole("link", { name: "Kandev home" }).getAttribute("href")).toBe(
       "/office?workspaceId=office-1",
     );
+  });
+
+  it("drives the workspace picker from the store flag", () => {
+    state.appSidebar.workspacePickerOpen = true;
+
+    renderHeader();
+
+    expect(screen.getByTestId("workspace-picker").getAttribute("data-open")).toBe("true");
+  });
+
+  it("writes the picker's dismissal back to the store", () => {
+    state.appSidebar.workspacePickerOpen = true;
+
+    renderHeader();
+    screen.getByTestId("workspace-picker").click();
+
+    expect(setWorkspacePickerOpen).toHaveBeenCalledWith(false);
   });
 });

--- a/apps/web/components/app-sidebar/app-sidebar-header.tsx
+++ b/apps/web/components/app-sidebar/app-sidebar-header.tsx
@@ -20,6 +20,10 @@ const COLLAPSE_BUTTON_CLASS = "h-7 w-7 shrink-0 cursor-pointer";
 export function AppSidebarHeader({ collapsed, onToggleCollapse }: AppSidebarHeaderProps) {
   const { t } = useTranslation();
   const workspaces = useAppStore((s) => s.workspaces);
+  // The global WORKSPACE_PICKER shortcut opens this instance (and only this
+  // one) through the store; the mobile sheet keeps its own local open state.
+  const pickerOpen = useAppStore((s) => s.appSidebar.workspacePickerOpen);
+  const setPickerOpen = useAppStore((s) => s.setWorkspacePickerOpen);
   const activeWorkspace = workspaces.items.find(
     (workspace) => workspace.id === workspaces.activeId,
   );
@@ -82,7 +86,7 @@ export function AppSidebarHeader({ collapsed, onToggleCollapse }: AppSidebarHead
       <span aria-hidden className="shrink-0 select-none text-muted-foreground/30">
         /
       </span>
-      <AppSidebarWorkspacePicker />
+      <AppSidebarWorkspacePicker open={pickerOpen} onOpenChange={setPickerOpen} />
       <Tooltip>
         <TooltipTrigger asChild>
           <Button

--- a/apps/web/components/app-sidebar/app-sidebar-workspace-picker.test.tsx
+++ b/apps/web/components/app-sidebar/app-sidebar-workspace-picker.test.tsx
@@ -11,7 +11,11 @@ vi.mock("@/lib/routing/client-router", () => ({
 // model well. Render them as plain elements so the focus stays on the picker's
 // routing logic: `onSelect` fires on click of the item.
 vi.mock("@kandev/ui/dropdown-menu", () => ({
-  DropdownMenu: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenu: ({ children, open }: { children: React.ReactNode; open?: boolean }) => (
+    <div data-testid="dropdown-root" data-open={String(open)}>
+      {children}
+    </div>
+  ),
   DropdownMenuTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   DropdownMenuContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   DropdownMenuItem: ({
@@ -275,5 +279,56 @@ describe("AppSidebarWorkspacePicker — active workspace display and routing", (
     fireEvent.click(screen.getByTestId(KANBAN_WORKSPACE_ITEM));
 
     expect(onActionComplete).toHaveBeenCalledOnce();
+  });
+});
+
+function menuOpenState(): string | null {
+  return screen.getByTestId("dropdown-root").getAttribute("data-open");
+}
+
+describe("AppSidebarWorkspacePicker — controlled open state", () => {
+  beforeEach(resetWorkspaceSelectTest);
+
+  afterEach(cleanupWorkspaceSelectTest);
+
+  it("stays closed and self-managed when no open prop is passed", () => {
+    render(<AppSidebarWorkspacePicker />);
+
+    expect(menuOpenState()).toBe("false");
+  });
+
+  it("passes a controlled open prop straight through to the menu", () => {
+    render(<AppSidebarWorkspacePicker open onOpenChange={vi.fn()} />);
+
+    expect(menuOpenState()).toBe("true");
+  });
+
+  it("keeps the controlled value when the picker asks to close", () => {
+    // A controlled owner that ignores the request keeps the menu open — proof
+    // the component does not fall back to its internal state.
+    render(<AppSidebarWorkspacePicker open onOpenChange={vi.fn()} />);
+
+    fireEvent.click(screen.getByTestId(ALTERNATE_KANBAN_WORKSPACE_ITEM));
+
+    expect(menuOpenState()).toBe("true");
+  });
+
+  it("reports the close request to the controlled owner on workspace select", () => {
+    const onOpenChange = vi.fn();
+    render(<AppSidebarWorkspacePicker open onOpenChange={onOpenChange} />);
+
+    fireEvent.click(screen.getByTestId(ALTERNATE_KANBAN_WORKSPACE_ITEM));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("reports open changes while still self-managing state", () => {
+    const onOpenChange = vi.fn();
+    render(<AppSidebarWorkspacePicker onOpenChange={onOpenChange} />);
+
+    fireEvent.click(screen.getByTestId(ALTERNATE_KANBAN_WORKSPACE_ITEM));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(menuOpenState()).toBe("false");
   });
 });

--- a/apps/web/components/app-sidebar/app-sidebar-workspace-picker.tsx
+++ b/apps/web/components/app-sidebar/app-sidebar-workspace-picker.tsx
@@ -91,6 +91,12 @@ type WorkspacePickerProps = {
  * Open state that is self-managed by default and controlled when the caller
  * passes `open`. `onOpenChange` fires in both modes, so a controlled owner sees
  * every dismissal (item select, outside click, Escape).
+ *
+ * A caller must pick one mode and keep it for the component's lifetime. Going
+ * from a defined `open` to `undefined` (or back) silently swaps which state
+ * wins and strands the other — the usual React controlled/uncontrolled
+ * anti-pattern. Both current callers are static: the sidebar header always
+ * passes the store flag, the mobile sheet never passes one.
  */
 function useMenuOpenState(controlledOpen?: boolean, onOpenChange?: (open: boolean) => void) {
   const [uncontrolledOpen, setUncontrolledOpen] = useState(false);

--- a/apps/web/components/app-sidebar/app-sidebar-workspace-picker.tsx
+++ b/apps/web/components/app-sidebar/app-sidebar-workspace-picker.tsx
@@ -78,7 +78,32 @@ type WorkspacePickerProps = {
   itemTestIdPrefix?: string;
   modal?: boolean;
   onActionComplete?: () => void;
+  /**
+   * Controlled open state. Omit for the default self-managed menu; the
+   * sidebar-header instance passes the store flag so the global
+   * WORKSPACE_PICKER shortcut can open it.
+   */
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
 };
+
+/**
+ * Open state that is self-managed by default and controlled when the caller
+ * passes `open`. `onOpenChange` fires in both modes, so a controlled owner sees
+ * every dismissal (item select, outside click, Escape).
+ */
+function useMenuOpenState(controlledOpen?: boolean, onOpenChange?: (open: boolean) => void) {
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
+  const isControlled = controlledOpen !== undefined;
+  const setOpen = useCallback(
+    (next: boolean) => {
+      if (!isControlled) setUncontrolledOpen(next);
+      onOpenChange?.(next);
+    },
+    [isControlled, onOpenChange],
+  );
+  return { open: isControlled ? controlledOpen : uncontrolledOpen, setOpen };
+}
 
 function workspaceType(workspace: WorkspaceItem | undefined): WorkspaceType {
   return workspace?.office_workflow_id ? "office" : "kanban";
@@ -215,6 +240,8 @@ export function AppSidebarWorkspacePicker({
   itemTestIdPrefix = "sidebar-workspace-item",
   modal = true,
   onActionComplete,
+  open: controlledOpen,
+  onOpenChange,
 }: WorkspacePickerProps = {}) {
   const { t } = useTranslation();
   const router = useRouter();
@@ -222,7 +249,7 @@ export function AppSidebarWorkspacePicker({
   const workspaces = useAppStore((s) => s.workspaces);
   const setActiveWorkspace = useAppStore((s) => s.setActiveWorkspace);
   const resetKanbanWorkspaceContext = useAppStore((s) => s.resetKanbanWorkspaceContext);
-  const [open, setOpen] = useState(false);
+  const { open, setOpen } = useMenuOpenState(controlledOpen, onOpenChange);
 
   const activeWorkspace = workspaces.items.find((w) => w.id === workspaces.activeId);
   const activeId = activeWorkspace?.id ?? null;
@@ -266,6 +293,7 @@ export function AppSidebarWorkspacePicker({
       resetKanbanWorkspaceContext,
       officeEnabled,
       onActionComplete,
+      setOpen,
     ],
   );
   const handleNavigate = useCallback(

--- a/apps/web/e2e/tests/i18n/pseudo-coverage.spec.ts
+++ b/apps/web/e2e/tests/i18n/pseudo-coverage.spec.ts
@@ -259,6 +259,7 @@ const SCREENS: Screen[] = [
       "Voice Input",
       "Reverse Chat Search",
       "Open Task Pull Request",
+      "Open Workspace Picker",
     ],
   },
   {

--- a/apps/web/e2e/tests/layout/workspace-picker-shortcut.spec.ts
+++ b/apps/web/e2e/tests/layout/workspace-picker-shortcut.spec.ts
@@ -1,0 +1,126 @@
+import { test, expect } from "../../fixtures/test-base";
+import type { Page } from "@playwright/test";
+
+// WORKSPACE_PICKER (Cmd/Ctrl+E by default) opens the sidebar-header
+// workspace switcher with focus already inside the menu, so a workspace can be
+// picked with arrows + Enter alone. The shortcut runs on the global app-root
+// listener (useAppShortcuts) and drives the picker through the store flag, so
+// it also works while the sidebar is collapsed — the rail expands first.
+
+const MODIFIER = process.platform === "darwin" ? "Meta" : "Control";
+const WORKSPACE_ITEM_SELECTOR = '[data-testid^="sidebar-workspace-item-"]';
+
+/** Clear focus so the shortcut isn't suppressed by a page-autofocused input. */
+async function pressWorkspacePickerShortcut(page: Page): Promise<void> {
+  await page.evaluate(() => (document.activeElement as HTMLElement | null)?.blur());
+  await page.keyboard.press(`${MODIFIER}+e`);
+}
+
+/** Workspace ids in the order the open menu lists them. */
+async function listedWorkspaceIds(page: Page): Promise<string[]> {
+  const testIds = await page
+    .locator(WORKSPACE_ITEM_SELECTOR)
+    .evaluateAll((nodes) => nodes.map((node) => node.getAttribute("data-testid") ?? ""));
+  return testIds.map((testId) => testId.replace("sidebar-workspace-item-", ""));
+}
+
+test.describe("Workspace picker shortcut (global)", () => {
+  test("opens the picker and switches workspace with arrows and Enter", async ({
+    testPage,
+    apiClient,
+  }) => {
+    const second = await apiClient.createWorkspace("Picker Shortcut Workspace");
+
+    await testPage.goto("/");
+    await expect(testPage.getByTestId("sidebar-workspace-trigger")).toBeVisible({
+      timeout: 10_000,
+    });
+
+    await pressWorkspacePickerShortcut(testPage);
+
+    await expect(testPage.getByTestId("sidebar-workspace-trigger")).toHaveAttribute(
+      "data-state",
+      "open",
+    );
+    const workspaceIds = await listedWorkspaceIds(testPage);
+    expect(workspaceIds).toContain(second.id);
+    expect(workspaceIds.length).toBeGreaterThanOrEqual(2);
+
+    // Focus lands on the menu itself, so the first ArrowDown moves to item 1
+    // and the second to item 2 — no mouse needed at any point.
+    await testPage.keyboard.press("ArrowDown");
+    await expect(testPage.getByTestId(`sidebar-workspace-item-${workspaceIds[0]}`)).toBeFocused();
+    await testPage.keyboard.press("ArrowDown");
+    await expect(testPage.getByTestId(`sidebar-workspace-item-${workspaceIds[1]}`)).toBeFocused();
+
+    await testPage.keyboard.press("Enter");
+
+    await expect(testPage).toHaveURL(
+      (url) => url.searchParams.get("workspaceId") === workspaceIds[1],
+      { timeout: 10_000 },
+    );
+    await expect(testPage.locator(WORKSPACE_ITEM_SELECTOR).first()).not.toBeVisible();
+  });
+
+  test("expands a collapsed sidebar before opening the picker", async ({ testPage, apiClient }) => {
+    await apiClient.createWorkspace("Collapsed Picker Workspace");
+
+    await testPage.goto("/");
+    const sidebar = testPage.getByTestId("app-sidebar");
+    await expect(sidebar).toBeVisible({ timeout: 10_000 });
+
+    await testPage.getByRole("button", { name: "Collapse sidebar" }).click();
+    await expect(sidebar).toHaveAttribute("data-collapsed", "true");
+
+    await pressWorkspacePickerShortcut(testPage);
+
+    await expect(sidebar).toHaveAttribute("data-collapsed", "false");
+    await expect(testPage.getByTestId("sidebar-workspace-trigger")).toHaveAttribute(
+      "data-state",
+      "open",
+    );
+    await expect(testPage.locator(WORKSPACE_ITEM_SELECTOR).first()).toBeVisible();
+  });
+
+  test("Escape closes the picker and leaves the workspace unchanged", async ({
+    testPage,
+    apiClient,
+  }) => {
+    await apiClient.createWorkspace("Escape Picker Workspace");
+
+    await testPage.goto("/");
+    await expect(testPage.getByTestId("sidebar-workspace-trigger")).toBeVisible({
+      timeout: 10_000,
+    });
+    const urlBefore = testPage.url();
+
+    await pressWorkspacePickerShortcut(testPage);
+    await expect(testPage.locator(WORKSPACE_ITEM_SELECTOR).first()).toBeVisible();
+
+    await testPage.keyboard.press("Escape");
+
+    await expect(testPage.locator(WORKSPACE_ITEM_SELECTOR).first()).not.toBeVisible();
+    expect(testPage.url()).toBe(urlBefore);
+
+    // The store flag must have cleared on dismiss, or a second press would be
+    // a no-op (open -> open).
+    await pressWorkspacePickerShortcut(testPage);
+    await expect(testPage.locator(WORKSPACE_ITEM_SELECTOR).first()).toBeVisible();
+  });
+
+  test("does nothing below the sidebar's md boundary", async ({ testPage, apiClient }) => {
+    await apiClient.createWorkspace("Narrow Viewport Workspace");
+
+    // 700px sits in the 640-767px band: the sidebar (and picker trigger) is
+    // display:none, but the menu portals to document.body — without the
+    // viewport guard it opened detached at the corner with a scroll lock.
+    await testPage.setViewportSize({ width: 700, height: 800 });
+    await testPage.goto("/");
+    await testPage.waitForLoadState("networkidle");
+
+    await pressWorkspacePickerShortcut(testPage);
+
+    await expect(testPage.locator(WORKSPACE_ITEM_SELECTOR).first()).not.toBeVisible();
+    await expect(testPage.locator("body")).not.toHaveAttribute("data-scroll-locked", /.+/);
+  });
+});

--- a/apps/web/e2e/tests/settings/keyboard-shortcuts.spec.ts
+++ b/apps/web/e2e/tests/settings/keyboard-shortcuts.spec.ts
@@ -27,6 +27,8 @@ test.describe("Keyboard Shortcuts Settings", () => {
     await expect(testPage.getByTestId("shortcut-recorder-TASK_SWITCHER")).toBeVisible();
     await expect(testPage.getByTestId("shortcut-recorder-TASK_SWITCHER_REVERSE")).toBeVisible();
     await expect(testPage.getByTestId("shortcut-recorder-REVERSE_SEARCH")).toBeVisible();
+    await expect(testPage.getByTestId("shortcut-recorder-WORKSPACE_PICKER")).toBeVisible();
+    await expect(testPage.getByText("Open Workspace Picker")).toBeVisible();
   });
 
   test("can record a new shortcut and persist it", async ({ testPage, apiClient, seedData }) => {

--- a/apps/web/hooks/use-app-shortcuts.test.ts
+++ b/apps/web/hooks/use-app-shortcuts.test.ts
@@ -3,6 +3,7 @@ import { renderHook, cleanup } from "@testing-library/react";
 import type { StoredShortcutOverrides } from "@/lib/keyboard/shortcut-overrides";
 
 const mockToggleAppSidebar = vi.fn();
+const mockSetWorkspacePickerOpen = vi.fn();
 const mockOpenMode = vi.fn();
 let mockShortcuts: StoredShortcutOverrides = {};
 let mockPathname = "/t/task-1";
@@ -14,6 +15,7 @@ function buildState() {
   return {
     userSettings: { keyboardShortcuts: mockShortcuts },
     toggleAppSidebar: mockToggleAppSidebar,
+    setWorkspacePickerOpen: mockSetWorkspacePickerOpen,
     tasks: {
       activeTaskId: mockActiveTaskId,
       activeSessionId: mockActiveSessionId,
@@ -70,20 +72,50 @@ function pressContentSearch(
   return event;
 }
 
+function pressWorkspacePicker(
+  modifier: "ctrlKey" | "metaKey",
+  target: EventTarget = window,
+): KeyboardEvent {
+  const init: KeyboardEventInit = {
+    key: "e",
+    bubbles: true,
+    cancelable: true,
+  };
+  init[modifier] = true;
+  const event = new KeyboardEvent("keydown", init);
+  target.dispatchEvent(event);
+  return event;
+}
+
+/**
+ * jsdom has no `window.matchMedia`; the WORKSPACE_PICKER branch queries it to
+ * suppress the shortcut where the sidebar is display:none (below md/768px).
+ * Default every test to a desktop-sized answer.
+ */
+function stubMatchMedia(matches: boolean) {
+  window.matchMedia = vi.fn(
+    (query: string) => ({ media: query, matches }) as unknown as MediaQueryList,
+  );
+}
+
 // Cover both `ctrlOrCmd` branches: Ctrl on Windows/Linux, Cmd (metaKey) on macOS.
 const pressCtrlB = (target?: EventTarget) => pressB("ctrlKey", target);
 const pressMetaB = (target?: EventTarget) => pressB("metaKey", target);
 
+function resetShortcutMocks() {
+  mockToggleAppSidebar.mockClear();
+  mockSetWorkspacePickerOpen.mockClear();
+  mockOpenMode.mockClear();
+  mockShortcuts = {};
+  mockPathname = "/t/task-1";
+  mockActiveTaskId = "task-1";
+  mockActiveSessionId = "session-1";
+  mockSessionTaskId = "task-1";
+  stubMatchMedia(true);
+}
+
 describe("useAppShortcuts", () => {
-  beforeEach(() => {
-    mockToggleAppSidebar.mockClear();
-    mockOpenMode.mockClear();
-    mockShortcuts = {};
-    mockPathname = "/t/task-1";
-    mockActiveTaskId = "task-1";
-    mockActiveSessionId = "session-1";
-    mockSessionTaskId = "task-1";
-  });
+  beforeEach(resetShortcutMocks);
 
   // renderHook attaches a window listener; unmount it between tests so stale
   // listeners from earlier tests don't fire on later dispatches.
@@ -199,5 +231,84 @@ describe("useAppShortcuts", () => {
 
     expect(mockOpenMode).not.toHaveBeenCalled();
     expect(event.defaultPrevented).toBe(false);
+  });
+});
+
+describe("useAppShortcuts — workspace picker", () => {
+  beforeEach(resetShortcutMocks);
+
+  afterEach(() => cleanup());
+
+  it("opens the workspace picker on Cmd/Ctrl+E", () => {
+    renderHook(() => useAppShortcuts());
+
+    const event = pressWorkspacePicker("ctrlKey");
+
+    expect(mockSetWorkspacePickerOpen).toHaveBeenCalledWith(true);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("opens the workspace picker with Cmd on macOS", () => {
+    renderHook(() => useAppShortcuts());
+
+    const event = pressWorkspacePicker("metaKey");
+
+    expect(mockSetWorkspacePickerOpen).toHaveBeenCalledWith(true);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("ignores the workspace picker shortcut while typing in an editable element", () => {
+    renderHook(() => useAppShortcuts());
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+
+    pressWorkspacePicker("ctrlKey", input);
+
+    expect(mockSetWorkspacePickerOpen).not.toHaveBeenCalled();
+    input.remove();
+  });
+
+  it("uses a stored workspace-picker override instead of its default", () => {
+    mockShortcuts = {
+      WORKSPACE_PICKER: { key: "w", modifiers: { ctrlOrCmd: true, alt: true } },
+    };
+    renderHook(() => useAppShortcuts());
+
+    pressWorkspacePicker("ctrlKey");
+    expect(mockSetWorkspacePickerOpen).not.toHaveBeenCalled();
+
+    const event = new KeyboardEvent("keydown", {
+      key: "w",
+      ctrlKey: true,
+      altKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    window.dispatchEvent(event);
+
+    expect(mockSetWorkspacePickerOpen).toHaveBeenCalledWith(true);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("does not toggle the sidebar when the picker shortcut fires", () => {
+    mockShortcuts = CTRL_B_OVERRIDE;
+    renderHook(() => useAppShortcuts());
+
+    pressWorkspacePicker("ctrlKey");
+
+    expect(mockToggleAppSidebar).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op below the sidebar's md boundary and leaves the event alone", () => {
+    // Below 768px the sidebar is display:none; opening the portaled menu there
+    // would float it detached over the mobile nav.
+    stubMatchMedia(false);
+    renderHook(() => useAppShortcuts());
+
+    const event = pressWorkspacePicker("ctrlKey");
+
+    expect(mockSetWorkspacePickerOpen).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
+    expect(window.matchMedia).toHaveBeenCalledWith("(min-width: 768px)");
   });
 });

--- a/apps/web/hooks/use-app-shortcuts.test.ts
+++ b/apps/web/hooks/use-app-shortcuts.test.ts
@@ -305,10 +305,23 @@ describe("useAppShortcuts — workspace picker", () => {
     stubMatchMedia(false);
     renderHook(() => useAppShortcuts());
 
-    const event = pressWorkspacePicker("ctrlKey");
+    // Built inline rather than via pressWorkspacePicker so the spy is attached
+    // before dispatch: the contract is that the event is left entirely alone,
+    // so neither half of the handled-event pair may fire. Asserting only
+    // `defaultPrevented` would miss a stopPropagation moved above the guard,
+    // which would silently starve every other listener on the combo.
+    const event = new KeyboardEvent("keydown", {
+      key: "e",
+      ctrlKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    const stopPropagation = vi.spyOn(event, "stopPropagation");
+    window.dispatchEvent(event);
 
     expect(mockSetWorkspacePickerOpen).not.toHaveBeenCalled();
     expect(event.defaultPrevented).toBe(false);
+    expect(stopPropagation).not.toHaveBeenCalled();
     expect(window.matchMedia).toHaveBeenCalledWith("(min-width: 768px)");
   });
 });

--- a/apps/web/hooks/use-app-shortcuts.ts
+++ b/apps/web/hooks/use-app-shortcuts.ts
@@ -7,12 +7,15 @@ import { getShortcut } from "@/lib/keyboard/shortcut-overrides";
 import { useCommandPanelOpen } from "@/lib/commands/command-registry";
 import { isTaskWorkspaceSearchAvailable } from "@/lib/commands/task-workspace-search";
 import { usePathname } from "@/lib/routing/client-router";
+import { isAppSidebarViewport } from "@/hooks/use-responsive-breakpoint";
 
 /**
  * App-root keyboard shortcuts that must fire on every route — not just inside
  * the dockview session editor.
  *
- * Currently handles `TOGGLE_SIDEBAR` (collapse/expand the global AppSidebar).
+ * Currently handles `CONTENT_SEARCH`, `TOGGLE_SIDEBAR` (collapse/expand the
+ * global AppSidebar), and `WORKSPACE_PICKER` (open the sidebar-header workspace
+ * switcher with focus inside the menu).
  * Previously this lived in {@link useEditorKeybinds}, which is mounted only by
  * the dockview desktop layout, so the shortcut was dead on the Kanban board,
  * task list, Office, Settings, etc. Mount this once near the app root (it has
@@ -57,6 +60,20 @@ export function useAppShortcuts() {
         e.preventDefault();
         e.stopPropagation();
         appStore.getState().toggleAppSidebar();
+        return;
+      }
+
+      if (matchesShortcut(e, getShortcut("WORKSPACE_PICKER", overrides))) {
+        // The sidebar is display:none below md (`hidden md:block`), but the
+        // menu portals to document.body — opening it there would float a
+        // detached, focus-trapped menu over the mobile nav. Match the
+        // sidebar's own boundary and let the event through untouched.
+        if (!isAppSidebarViewport()) return;
+        e.preventDefault();
+        e.stopPropagation();
+        // The action expands a collapsed sidebar itself — the picker trigger
+        // renders only in the expanded header.
+        appStore.getState().setWorkspacePickerOpen(true);
       }
     };
 

--- a/apps/web/hooks/use-responsive-breakpoint.ts
+++ b/apps/web/hooks/use-responsive-breakpoint.ts
@@ -108,3 +108,19 @@ function subscribeBreakpoint(callback: () => void): () => void {
 export function useResponsiveBreakpoint(): ResponsiveBreakpoint {
   return React.useSyncExternalStore(subscribeBreakpoint, getClientSnapshot, () => SERVER_SNAPSHOT);
 }
+
+/**
+ * One-shot check for code that cannot subscribe to the hook — a global keydown
+ * dispatcher reads it inside the event handler rather than at render.
+ *
+ * Answers "is the AppSidebar rendered?": it uses the same `md`/768px boundary
+ * as `isMobile` and as the sidebar's own `hidden md:block`, so a shortcut that
+ * targets a sidebar-only surface can bail where that surface is `display:none`.
+ * Defaults to true without `matchMedia`, matching the desktop server snapshot.
+ */
+export function isAppSidebarViewport(): boolean {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+    return true;
+  }
+  return window.matchMedia(`(min-width: ${MOBILE_BREAKPOINT}px)`).matches;
+}

--- a/apps/web/lib/keyboard/constants.test.ts
+++ b/apps/web/lib/keyboard/constants.test.ts
@@ -105,6 +105,15 @@ describe("SHORTCUTS", () => {
     });
   });
 
+  describe("WORKSPACE_PICKER", () => {
+    it("uses E with the ctrlOrCmd modifier and no shift", () => {
+      const shortcut = SHORTCUTS.WORKSPACE_PICKER as KeyboardShortcut;
+      expect(shortcut.key).toBe("e");
+      expect(shortcut.modifiers?.ctrlOrCmd).toBe(true);
+      expect(shortcut.modifiers?.shift).toBeUndefined();
+    });
+  });
+
   it("has correct type", () => {
     // TypeScript ensures these are readonly at compile time
     const shortcuts: typeof SHORTCUTS = SHORTCUTS;

--- a/apps/web/lib/keyboard/constants.ts
+++ b/apps/web/lib/keyboard/constants.ts
@@ -186,4 +186,13 @@ export const SHORTCUTS = {
     key: KEYS.G,
     modifiers: { ctrlOrCmd: true, shift: true },
   },
+  // Cmd+E opens the sidebar-header workspace picker with focus inside the
+  // menu, so a workspace can be switched with arrows + Enter alone. Cmd+Shift+
+  // Space (the natural pairing with TASK_SWITCHER) is taken by
+  // TASK_SWITCHER_REVERSE; the browser defaults on Cmd/Ctrl+E (omnibox search,
+  // macOS find-selection) all yield to preventDefault.
+  WORKSPACE_PICKER: {
+    key: KEYS.E,
+    modifiers: { ctrlOrCmd: true },
+  },
 } as const;

--- a/apps/web/lib/keyboard/shortcut-overrides.test.ts
+++ b/apps/web/lib/keyboard/shortcut-overrides.test.ts
@@ -28,7 +28,8 @@ describe("CONFIGURABLE_SHORTCUTS", () => {
     expect(ids).toContain("VOICE_INPUT_TOGGLE");
     expect(ids).toContain("REVERSE_SEARCH");
     expect(ids).toContain("OPEN_TASK_PR");
-    expect(ids).toHaveLength(16);
+    expect(ids).toContain("WORKSPACE_PICKER");
+    expect(ids).toHaveLength(17);
   });
 
   it("each entry has a label and default matching SHORTCUTS", () => {
@@ -72,6 +73,9 @@ describe("CONFIGURABLE_SHORTCUTS", () => {
 
     expect(CONFIGURABLE_SHORTCUTS.OPEN_TASK_PR.label).toBe("Open Task Pull Request");
     expect(CONFIGURABLE_SHORTCUTS.OPEN_TASK_PR.default).toBe(SHORTCUTS.OPEN_TASK_PR);
+
+    expect(CONFIGURABLE_SHORTCUTS.WORKSPACE_PICKER.label).toBe("Open Workspace Picker");
+    expect(CONFIGURABLE_SHORTCUTS.WORKSPACE_PICKER.default).toBe(SHORTCUTS.WORKSPACE_PICKER);
   });
 });
 

--- a/apps/web/lib/keyboard/shortcut-overrides.ts
+++ b/apps/web/lib/keyboard/shortcut-overrides.ts
@@ -16,7 +16,8 @@ export type ConfigurableShortcutId =
   | "TASK_SWITCHER_REVERSE"
   | "VOICE_INPUT_TOGGLE"
   | "REVERSE_SEARCH"
-  | "OPEN_TASK_PR";
+  | "OPEN_TASK_PR"
+  | "WORKSPACE_PICKER";
 
 export type StoredShortcutOverrides = Record<
   string,
@@ -60,6 +61,7 @@ export const CONFIGURABLE_SHORTCUTS: Record<
   VOICE_INPUT_TOGGLE: { label: "Voice Input", default: SHORTCUTS.VOICE_INPUT_TOGGLE },
   REVERSE_SEARCH: { label: "Reverse Chat Search", default: SHORTCUTS.REVERSE_SEARCH },
   OPEN_TASK_PR: { label: "Open Task Pull Request", default: SHORTCUTS.OPEN_TASK_PR },
+  WORKSPACE_PICKER: { label: "Open Workspace Picker", default: SHORTCUTS.WORKSPACE_PICKER },
 };
 
 export function getShortcut(

--- a/apps/web/lib/state/slices/ui/app-sidebar-actions.test.ts
+++ b/apps/web/lib/state/slices/ui/app-sidebar-actions.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { create } from "zustand";
+import { immer } from "zustand/middleware/immer";
+import { createUISlice } from "./ui-slice";
+import type { UISlice } from "./types";
+
+vi.mock("@/lib/api/domains/settings-api", () => ({
+  updateUserSettings: vi.fn(() => Promise.resolve({ settings: {} })),
+}));
+
+function makeStore() {
+  return create<UISlice>()(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    immer((...a) => ({ ...(createUISlice as any)(...a) })),
+  );
+}
+
+const COLLAPSED_KEY = "kandev.appSidebar.collapsed";
+const PICKER_KEY = "kandev.appSidebar.workspacePickerOpen";
+
+describe("appSidebar workspace picker flag", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("defaults closed and is never read from storage", () => {
+    window.localStorage.setItem(PICKER_KEY, JSON.stringify(true));
+    const store = makeStore();
+    expect(store.getState().appSidebar.workspacePickerOpen).toBe(false);
+  });
+
+  it("setWorkspacePickerOpen opens and closes the picker without persisting it", () => {
+    const store = makeStore();
+
+    store.getState().setWorkspacePickerOpen(true);
+    expect(store.getState().appSidebar.workspacePickerOpen).toBe(true);
+    expect(window.localStorage.getItem(PICKER_KEY)).toBeNull();
+
+    store.getState().setWorkspacePickerOpen(false);
+    expect(store.getState().appSidebar.workspacePickerOpen).toBe(false);
+  });
+
+  it("opening the picker while collapsed force-expands the rail", () => {
+    window.localStorage.setItem(COLLAPSED_KEY, JSON.stringify(true));
+    const store = makeStore();
+    expect(store.getState().appSidebar.collapsed).toBe(true);
+
+    store.getState().setWorkspacePickerOpen(true);
+
+    expect(store.getState().appSidebar.workspacePickerOpen).toBe(true);
+    expect(store.getState().appSidebar.collapsed).toBe(false);
+    expect(JSON.parse(window.localStorage.getItem(COLLAPSED_KEY) ?? "null")).toBe(false);
+  });
+
+  it("closing the picker leaves the collapsed flag untouched", () => {
+    window.localStorage.setItem(COLLAPSED_KEY, JSON.stringify(true));
+    const store = makeStore();
+
+    store.getState().setWorkspacePickerOpen(false);
+
+    expect(store.getState().appSidebar.collapsed).toBe(true);
+  });
+});

--- a/apps/web/lib/state/slices/ui/app-sidebar-actions.ts
+++ b/apps/web/lib/state/slices/ui/app-sidebar-actions.ts
@@ -30,10 +30,21 @@ export function loadAppSidebarState(): AppSidebarState {
     // Transient — always starts off, never read from / written to storage.
     settingsMode: false,
     improveDialogOpen: false,
+    workspacePickerOpen: false,
   };
 }
 
 type ImmerSet = Parameters<StateCreator<UISlice, [["zustand/immer", never]], [], UISlice>>[0];
+
+/**
+ * Force-expand the rail and persist it — surfaces that render only in the
+ * expanded header (settings tree, workspace picker) need this before opening.
+ */
+function expandAppSidebar(draft: { appSidebar: AppSidebarState }) {
+  if (!draft.appSidebar.collapsed) return;
+  draft.appSidebar.collapsed = false;
+  setStoredAppSidebarCollapsed(false);
+}
 
 export function buildAppSidebarActions(set: ImmerSet) {
   return {
@@ -64,14 +75,18 @@ export function buildAppSidebarActions(set: ImmerSet) {
     setAppSidebarSettingsMode: (settingsMode: boolean) =>
       set((draft) => {
         draft.appSidebar.settingsMode = settingsMode;
-        if (settingsMode && draft.appSidebar.collapsed) {
-          draft.appSidebar.collapsed = false;
-          setStoredAppSidebarCollapsed(false);
-        }
+        if (settingsMode) expandAppSidebar(draft);
       }),
     setImproveDialogOpen: (open: boolean) =>
       set((draft) => {
         draft.appSidebar.improveDialogOpen = open;
+      }),
+    setWorkspacePickerOpen: (open: boolean) =>
+      set((draft) => {
+        draft.appSidebar.workspacePickerOpen = open;
+        // The picker trigger renders only in the expanded header, so a
+        // collapsed rail has nothing to anchor the menu to — expand first.
+        if (open) expandAppSidebar(draft);
       }),
     toggleAppSidebarSettingsMode: () =>
       set((draft) => {
@@ -79,10 +94,7 @@ export function buildAppSidebarActions(set: ImmerSet) {
         draft.appSidebar.settingsMode = next;
         // Entering settings mode while collapsed would render an empty rail —
         // the tree needs the expanded width — so force-expand on the way in.
-        if (next && draft.appSidebar.collapsed) {
-          draft.appSidebar.collapsed = false;
-          setStoredAppSidebarCollapsed(false);
-        }
+        if (next) expandAppSidebar(draft);
       }),
   };
 }

--- a/apps/web/lib/state/slices/ui/types.ts
+++ b/apps/web/lib/state/slices/ui/types.ts
@@ -200,6 +200,13 @@ export type AppSidebarState = {
    * the same dialog instance. Transient, never persisted.
    */
   improveDialogOpen: boolean;
+  /**
+   * Open state of the workspace picker in the expanded sidebar header. Owned by
+   * the store so the global WORKSPACE_PICKER shortcut can open the menu without
+   * reaching into the DOM. Transient, never persisted. Only the sidebar-header
+   * picker instance binds to it — the mobile sheet keeps its own local state.
+   */
+  workspacePickerOpen: boolean;
 };
 
 export type UISliceState = {
@@ -348,6 +355,11 @@ export type UISliceActions = {
   toggleAppSidebarSettingsMode: () => void;
   /** Open/close the shared Improve Kandev dialog (footer + New Task routing). */
   setImproveDialogOpen: (open: boolean) => void;
+  /**
+   * Open/close the sidebar-header workspace picker. Opening force-expands the
+   * sidebar, since the trigger renders only in the expanded header.
+   */
+  setWorkspacePickerOpen: (open: boolean) => void;
   /** Record multiple sidebar badge acknowledgements with one localStorage merge. */
   acknowledgeAgentErrors: (stamps: Record<string, string>) => void;
   /** Record that `stamp` has been dismissed for `sessionId`. */

--- a/apps/web/lib/state/slices/ui/ui-slice.ts
+++ b/apps/web/lib/state/slices/ui/ui-slice.ts
@@ -136,6 +136,7 @@ export const defaultUIState: UISliceState = {
     width: APP_SIDEBAR_EXPANDED_WIDTH,
     settingsMode: false,
     improveDialogOpen: false,
+    workspacePickerOpen: false,
   },
   acknowledgedAgentErrors: {},
   dismissedAgentErrors: {},

--- a/apps/web/lib/state/store.ts
+++ b/apps/web/lib/state/store.ts
@@ -524,6 +524,7 @@ export type AppState = KanbanSlice & {
   setAppSidebarSettingsMode: UIA["setAppSidebarSettingsMode"];
   toggleAppSidebarSettingsMode: UIA["toggleAppSidebarSettingsMode"];
   setImproveDialogOpen: UIA["setImproveDialogOpen"];
+  setWorkspacePickerOpen: UIA["setWorkspacePickerOpen"];
   acknowledgeAgentErrors: UIA["acknowledgeAgentErrors"];
   dismissAgentError: UIA["dismissAgentError"];
 } & GitHubSliceActions &

--- a/docs/public/use-kandev.md
+++ b/docs/public/use-kandev.md
@@ -105,6 +105,20 @@ settings appear only after typing, while **Go to Settings** remains in the comma
 Discovery searches setting names and curated aliases, never saved values, secrets, paths, or other
 configuration content.
 
+## Switch workspace
+
+The workspace picker sits in the sidebar header, next to the Kandev brand. It lists every
+workspace with a **Kanban** or **Office** badge and ends with the workspace-creation actions.
+
+From anywhere, press `Cmd/Ctrl+E` to open it with the keyboard: focus lands inside the menu,
+so arrow keys move between workspaces and **Enter** switches to the highlighted one. If the sidebar
+is collapsed, the shortcut expands it first. Rebind it under
+**Settings > General > Keyboard Shortcuts** (**Open Workspace Picker**) if it clashes with a
+browser or window-manager binding.
+
+The shortcut does nothing on narrow windows and phones, where the sidebar is hidden. Switch
+workspace there from the menu sheet instead.
+
 ## Add a local repository
 
 1. Open **Settings > Workspaces > Default Workspace > Repositories**. If you created or renamed the workspace, choose that workspace instead.


### PR DESCRIPTION
Switching workspace meant reaching for the mouse — the picker lives in the sidebar header with no keyboard path to it. `Cmd/Ctrl+E` now opens it with focus already inside the menu, so arrows and Enter switch workspace, and the binding is configurable under **Settings → General → Keyboard Shortcuts**.

## Important Changes

- The shortcut drives the picker through a transient `appSidebar.workspacePickerOpen` store flag instead of reaching into the DOM, matching how other global surfaces are opened. Opening force-expands a collapsed rail, since the trigger only renders in the expanded header.
- `AppSidebarWorkspacePicker` gained optional controlled `open`/`onOpenChange`. Only the sidebar-header instance binds the flag, so the mobile menu sheet keeps its own local state and the shortcut can't pop both.
- Below the sidebar's `md`/768px boundary the handler returns before `preventDefault`: the sidebar is `display:none` there and the menu portals to `document.body`, so opening it floated a detached, focus-trapped menu and its scroll lock over the mobile nav. The boundary is read via a new `isAppSidebarViewport()` built from `MOBILE_BREAKPOINT`, so it cannot drift from the sidebar's own `hidden md:block`.

## Validation

- `cd apps/web && pnpm exec vitest run` — 10304 passed, 4 skipped. The 3 failures in `lib/http-git-server.test.ts` are pre-existing and need a Docker daemon, which this environment has none of.
- `cd apps/web && pnpm e2e:run --host tests/layout/workspace-picker-shortcut.spec.ts tests/settings/keyboard-shortcuts.spec.ts` — 9 Playwright tests passed.
- `cd apps/web && pnpm e2e:run --host tests/office/workspace-picker.spec.ts tests/layout/toggle-sidebar-shortcut.spec.ts` — 5 Playwright tests passed.
- `cd apps/web && pnpm e2e:run --host --grep "settings — keyboard shortcuts" tests/i18n/pseudo-coverage.spec.ts` — 1 passed.
- `cd apps/web && pnpm e2e:run --host --project=mobile-chrome tests/task/mobile-workspace-switch-sidebar-isolation.spec.ts` — 1 passed.
- `cd apps/web && pnpm run typecheck` and `cd apps && pnpm --filter @kandev/web lint` — clean, 0 warnings.
- `cd apps/web && pnpm run i18n:ratchet` and `pnpm run i18n:check` — clean.
- Manually exercised in a preview instance: open, arrow to a workspace and Enter, the same press with the sidebar collapsed, and a sub-768px window where the shortcut correctly does nothing.

## Possible Improvements

Low risk — behavior is additive; the main exposure is `Cmd/Ctrl+E` colliding with a browser or window-manager binding, which is recoverable by rebinding without a code change.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have manually tested my changes and they work as expected.
- [x] My changes have tests that cover the new functionality and edge cases.
- [x] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [x] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2478?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->