### PR TITLE
docs: restore Star History chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,8 +312,8 @@ Built with these excellent open-source projects:
 
 <a href="https://www.star-history.com/?repos=kdlbs%2Fkandev&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=kdlbs/kandev&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=kdlbs/kandev&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=kdlbs/kandev&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=kdlbs/kandev&type=date&theme=dark&legend=top-left&sealed_token=VcdQXTkas2odX-D8DZINZOcBVuA6ZfkugIzgWgnAi0lqW3gwdqlh_Ei77fi2bdXwc3HnCFz3NQAYtRnoKxspsck-pIQxTdEwEIveR27Y3k8cKBWJxYGOCFqYhHiJGcECnrrMU_NhWcWWTWaz0t5cX-3Fm-1BOouTejaUEy9w78CSuoakpeUJby66XlCB" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=kdlbs/kandev&type=date&legend=top-left&sealed_token=VcdQXTkas2odX-D8DZINZOcBVuA6ZfkugIzgWgnAi0lqW3gwdqlh_Ei77fi2bdXwc3HnCFz3NQAYtRnoKxspsck-pIQxTdEwEIveR27Y3k8cKBWJxYGOCFqYhHiJGcECnrrMU_NhWcWWTWaz0t5cX-3Fm-1BOouTejaUEy9w78CSuoakpeUJby66XlCB" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=kdlbs/kandev&type=date&legend=top-left&sealed_token=VcdQXTkas2odX-D8DZINZOcBVuA6ZfkugIzgWgnAi0lqW3gwdqlh_Ei77fi2bdXwc3HnCFz3NQAYtRnoKxspsck-pIQxTdEwEIveR27Y3k8cKBWJxYGOCFqYhHiJGcECnrrMU_NhWcWWTWaz0t5cX-3Fm-1BOouTejaUEy9w78CSuoakpeUJby66XlCB" />
  </picture>
 </a>


### PR DESCRIPTION
Star History's shared-token endpoint stopped rendering after GitHub restricted stargazer access. The official sealed-token embed restores the README chart in light and dark themes.

## Validation

- Confirmed all three embed URLs contain the same sealed token.
- Confirmed light and dark endpoints return HTTP 200, `image/svg+xml`, and valid SVG.
- `git diff --check`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2482?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->