### PR TITLE
test(backend): cover the untested sqlite task-repository surfaces

### DIFF
--- a/apps/backend/internal/task/repository/sqlite/document_plan_postgres_test.go
+++ b/apps/backend/internal/task/repository/sqlite/document_plan_postgres_test.go
@@ -1,0 +1,205 @@
+package sqlite
+
+// Postgres parity coverage for the document and plan revision write paths.
+// Both go through `INSERT ... ON CONFLICT (...) DO UPDATE SET ... excluded.*`
+// inside an explicit transaction, and MarkTaskPlanImplementationStarted uses
+// COALESCE plus CASE WHEN over a nullable TIMESTAMP — all dialect-sensitive.
+// Skips unless KANDEV_TEST_POSTGRES_DSN is set; CI runs these in postgres-boot.
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/task/models"
+	"github.com/kandev/kandev/internal/testutil"
+)
+
+// seedPostgresTask inserts a tasks row directly: the FK targets of documents
+// and plans are all this table, and a raw insert keeps the fixture minimal.
+func seedPostgresTask(t *testing.T, repo *Repository, taskID string) {
+	t.Helper()
+	now := time.Now().UTC()
+	if _, err := repo.db.Exec(repo.db.Rebind(`
+		INSERT INTO tasks (id, workspace_id, title, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?)
+	`), taskID, "ws-"+taskID, taskID, now, now); err != nil {
+		t.Fatalf("seed task %s: %v", taskID, err)
+	}
+}
+
+func TestPostgresWriteDocumentRevisionUpsertAndCoalesce(t *testing.T) {
+	db := testutil.OpenIsolatedPostgres(t, testutil.PostgresDSNFromEnv(t))
+	repo, err := NewWithDB(db, db, nil)
+	if err != nil {
+		t.Fatalf("init postgres schema: %v", err)
+	}
+	ctx := context.Background()
+	seedPostgresTask(t, repo, "task-doc-pg")
+
+	head := &models.TaskDocument{
+		ID: "doc-pg", TaskID: "task-doc-pg", Key: "plan", Type: "plan",
+		Title: "v1", Content: "one", AuthorKind: "agent", AuthorName: "claude",
+		Filename: "plan.md", MimeType: "text/markdown", SizeBytes: 3, DiskPath: "/plan.md",
+	}
+	first := &models.TaskDocumentRevision{
+		TaskID: "task-doc-pg", DocumentKey: "plan",
+		Title: "v1", Content: "one", AuthorKind: "agent", AuthorName: "claude",
+	}
+	if err := repo.WriteDocumentRevision(ctx, head, first, nil); err != nil {
+		t.Fatalf("WriteDocumentRevision(first): %v", err)
+	}
+	if first.RevisionNumber != 1 {
+		t.Fatalf("RevisionNumber = %d, want 1", first.RevisionNumber)
+	}
+	createdAt := head.CreatedAt
+
+	// Second write: ON CONFLICT (task_id, key) must update the same HEAD row
+	// and the revision number must advance to 2.
+	head.Title = "v2"
+	head.Content = "two"
+	head.SizeBytes = 3
+	second := &models.TaskDocumentRevision{
+		TaskID: "task-doc-pg", DocumentKey: "plan", Title: "v2", Content: "two", AuthorKind: "user",
+	}
+	if err := repo.WriteDocumentRevision(ctx, head, second, nil); err != nil {
+		t.Fatalf("WriteDocumentRevision(second): %v", err)
+	}
+	if second.RevisionNumber != 2 {
+		t.Errorf("second RevisionNumber = %d, want 2", second.RevisionNumber)
+	}
+	if got := countRows(t, repo, `SELECT COUNT(1) FROM task_documents WHERE task_id = ?`, "task-doc-pg"); got != 1 {
+		t.Errorf("HEAD rows = %d, want 1 (ON CONFLICT must update, not insert)", got)
+	}
+	gotHead, err := repo.GetDocument(ctx, "task-doc-pg", "plan")
+	if err != nil {
+		t.Fatalf("GetDocument: %v", err)
+	}
+	if gotHead.ID != "doc-pg" || gotHead.Title != "v2" || gotHead.Content != "two" {
+		t.Errorf("HEAD = %+v, want doc-pg at v2/two", gotHead)
+	}
+	assertTimeEqual(t, "HEAD CreatedAt", gotHead.CreatedAt, createdAt)
+
+	// Coalesce merge into the newest revision.
+	coalesceID := second.ID
+	merged := &models.TaskDocumentRevision{
+		TaskID: "task-doc-pg", DocumentKey: "plan", Title: "v2 edited", Content: "two edited",
+	}
+	head.Title = "v2 edited"
+	head.Content = "two edited"
+	if err := repo.WriteDocumentRevision(ctx, head, merged, &coalesceID); err != nil {
+		t.Fatalf("WriteDocumentRevision(merge): %v", err)
+	}
+	history, err := repo.ListDocumentRevisions(ctx, "task-doc-pg", "plan", 0)
+	if err != nil {
+		t.Fatalf("ListDocumentRevisions: %v", err)
+	}
+	if len(history) != 2 {
+		t.Fatalf("history has %d revisions, want 2 (coalesce must merge, not append)", len(history))
+	}
+	if history[0].RevisionNumber != 2 || history[0].Content != "two edited" {
+		t.Errorf("newest revision = %+v, want revision 2 with the merged content", history[0])
+	}
+	if history[0].AuthorKind != "user" {
+		t.Errorf("AuthorKind = %q, want the stored user preserved across the merge", history[0].AuthorKind)
+	}
+
+	next, err := repo.NextDocumentRevisionNumber(ctx, "task-doc-pg", "plan")
+	if err != nil {
+		t.Fatalf("NextDocumentRevisionNumber: %v", err)
+	}
+	if next != 3 {
+		t.Errorf("NextDocumentRevisionNumber = %d, want 3 (MAX+1 over the nullable aggregate)", next)
+	}
+
+	// The NULL revert_of_revision_id column must scan back as a nil pointer.
+	if history[0].RevertOfRevisionID != nil {
+		t.Errorf("RevertOfRevisionID = %q, want nil", *history[0].RevertOfRevisionID)
+	}
+}
+
+func TestPostgresWritePlanRevisionUpsertAndImplementationMarker(t *testing.T) {
+	db := testutil.OpenIsolatedPostgres(t, testutil.PostgresDSNFromEnv(t))
+	repo, err := NewWithDB(db, db, nil)
+	if err != nil {
+		t.Fatalf("init postgres schema: %v", err)
+	}
+	ctx := context.Background()
+	seedPostgresTask(t, repo, "task-plan-pg")
+
+	head := &models.TaskPlan{ID: "plan-pg", TaskID: "task-plan-pg", Content: "one"}
+	first := &models.TaskPlanRevision{
+		TaskID: "task-plan-pg", Title: "Plan", Content: "one", AuthorKind: "agent", AuthorName: "claude",
+	}
+	if err := repo.WritePlanRevision(ctx, head, first, nil); err != nil {
+		t.Fatalf("WritePlanRevision(first): %v", err)
+	}
+	if head.Title != "Plan" || head.CreatedBy != authorKindAgent {
+		t.Errorf("head defaults = %q/%q, want Plan/%s", head.Title, head.CreatedBy, authorKindAgent)
+	}
+	if first.RevisionNumber != 1 {
+		t.Fatalf("RevisionNumber = %d, want 1", first.RevisionNumber)
+	}
+
+	// The nullable implementation marker: COALESCE + CASE WHEN over TIMESTAMP.
+	marked, err := repo.MarkTaskPlanImplementationStarted(ctx, "task-plan-pg", "session-pg", "jcfs")
+	if err != nil {
+		t.Fatalf("MarkTaskPlanImplementationStarted: %v", err)
+	}
+	if marked.ImplementationStartedAt == nil {
+		t.Fatal("ImplementationStartedAt = nil, want the marker set")
+	}
+	startedAt := *marked.ImplementationStartedAt
+	if marked.ImplementationStartedSessionID == nil || *marked.ImplementationStartedSessionID != "session-pg" {
+		t.Errorf("ImplementationStartedSessionID = %v, want session-pg", marked.ImplementationStartedSessionID)
+	}
+	again, err := repo.MarkTaskPlanImplementationStarted(ctx, "task-plan-pg", "session-other", "someone")
+	if err != nil {
+		t.Fatalf("second MarkTaskPlanImplementationStarted: %v", err)
+	}
+	if !again.ImplementationStartedAt.Equal(startedAt) {
+		t.Errorf("ImplementationStartedAt = %v, want the first value %v preserved", *again.ImplementationStartedAt, startedAt)
+	}
+	if again.ImplementationStartedBy == nil || *again.ImplementationStartedBy != "jcfs" {
+		t.Errorf("ImplementationStartedBy = %v, want jcfs preserved", again.ImplementationStartedBy)
+	}
+
+	// A second WritePlanRevision must hit ON CONFLICT (task_id) and leave the
+	// marker columns alone (they are not in the DO UPDATE SET list).
+	head.Title = "Plan v2"
+	head.Content = "two"
+	second := &models.TaskPlanRevision{
+		TaskID: "task-plan-pg", Title: "Plan v2", Content: "two", AuthorKind: "user", AuthorName: "jcfs",
+	}
+	if err := repo.WritePlanRevision(ctx, head, second, nil); err != nil {
+		t.Fatalf("WritePlanRevision(second): %v", err)
+	}
+	if second.RevisionNumber != 2 {
+		t.Errorf("second RevisionNumber = %d, want 2", second.RevisionNumber)
+	}
+	if got := countRows(t, repo, `SELECT COUNT(1) FROM task_plans WHERE task_id = ?`, "task-plan-pg"); got != 1 {
+		t.Errorf("HEAD rows = %d, want 1 (ON CONFLICT must update, not insert)", got)
+	}
+	gotHead, err := repo.GetTaskPlan(ctx, "task-plan-pg")
+	if err != nil {
+		t.Fatalf("GetTaskPlan: %v", err)
+	}
+	if gotHead.Title != "Plan v2" || gotHead.Content != "two" {
+		t.Errorf("HEAD = %+v, want Plan v2/two", gotHead)
+	}
+	if gotHead.ImplementationStartedAt == nil || !gotHead.ImplementationStartedAt.Equal(startedAt) {
+		t.Errorf("ImplementationStartedAt = %v, want %v preserved across the upsert",
+			gotHead.ImplementationStartedAt, startedAt)
+	}
+
+	// The sentinel path on a task with no plan row.
+	if _, err := repo.MarkTaskPlanImplementationStarted(ctx, "task-plan-pg-absent", "s", "a"); !errors.Is(err, ErrTaskPlanNotFound) {
+		t.Errorf("error = %v, want ErrTaskPlanNotFound", err)
+	}
+	// And the nil,nil not-found contract on the read path.
+	missing, err := repo.GetTaskPlan(ctx, "task-plan-pg-absent")
+	if err != nil || missing != nil {
+		t.Errorf("GetTaskPlan(missing) = %+v, %v; want nil, nil", missing, err)
+	}
+}

--- a/apps/backend/internal/task/repository/sqlite/document_test.go
+++ b/apps/backend/internal/task/repository/sqlite/document_test.go
@@ -1,0 +1,838 @@
+package sqlite
+
+//revive:disable:file-length-limit // Document HEAD + revision persistence coverage is intentionally scenario-heavy.
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/task/models"
+)
+
+func seedTaskForDocs(t *testing.T, repo *Repository, taskID string) {
+	t.Helper()
+	if err := repo.CreateTask(context.Background(), &models.Task{ID: taskID, Title: taskID}); err != nil {
+		t.Fatalf("CreateTask(%s): %v", taskID, err)
+	}
+}
+
+func fullDocument(taskID string) *models.TaskDocument {
+	return &models.TaskDocument{
+		ID:         "doc-full",
+		TaskID:     taskID,
+		Key:        "spec",
+		Type:       "spec",
+		Title:      "Feature specification",
+		Content:    "# Spec\n\nEverything.",
+		AuthorKind: "user",
+		AuthorName: "jcfs",
+		Filename:   "spec.md",
+		MimeType:   "text/markdown",
+		SizeBytes:  4096,
+		DiskPath:   "/var/kandev/docs/spec.md",
+	}
+}
+
+func assertDocumentEqual(t *testing.T, got, want *models.TaskDocument) {
+	t.Helper()
+	if got == nil {
+		t.Fatal("document is nil")
+	}
+	if got.ID != want.ID {
+		t.Errorf("ID = %q, want %q", got.ID, want.ID)
+	}
+	if got.TaskID != want.TaskID {
+		t.Errorf("TaskID = %q, want %q", got.TaskID, want.TaskID)
+	}
+	if got.Key != want.Key {
+		t.Errorf("Key = %q, want %q", got.Key, want.Key)
+	}
+	if got.Type != want.Type {
+		t.Errorf("Type = %q, want %q", got.Type, want.Type)
+	}
+	if got.Title != want.Title {
+		t.Errorf("Title = %q, want %q", got.Title, want.Title)
+	}
+	if got.Content != want.Content {
+		t.Errorf("Content = %q, want %q", got.Content, want.Content)
+	}
+	if got.AuthorKind != want.AuthorKind {
+		t.Errorf("AuthorKind = %q, want %q", got.AuthorKind, want.AuthorKind)
+	}
+	if got.AuthorName != want.AuthorName {
+		t.Errorf("AuthorName = %q, want %q", got.AuthorName, want.AuthorName)
+	}
+	if got.Filename != want.Filename {
+		t.Errorf("Filename = %q, want %q", got.Filename, want.Filename)
+	}
+	if got.MimeType != want.MimeType {
+		t.Errorf("MimeType = %q, want %q", got.MimeType, want.MimeType)
+	}
+	if got.SizeBytes != want.SizeBytes {
+		t.Errorf("SizeBytes = %d, want %d", got.SizeBytes, want.SizeBytes)
+	}
+	if got.DiskPath != want.DiskPath {
+		t.Errorf("DiskPath = %q, want %q", got.DiskPath, want.DiskPath)
+	}
+	assertTimeEqual(t, "CreatedAt", got.CreatedAt, want.CreatedAt)
+	assertTimeEqual(t, "UpdatedAt", got.UpdatedAt, want.UpdatedAt)
+}
+
+func assertDocRevisionEqual(t *testing.T, got, want *models.TaskDocumentRevision) {
+	t.Helper()
+	if got == nil {
+		t.Fatal("revision is nil")
+	}
+	if got.ID != want.ID {
+		t.Errorf("ID = %q, want %q", got.ID, want.ID)
+	}
+	if got.TaskID != want.TaskID {
+		t.Errorf("TaskID = %q, want %q", got.TaskID, want.TaskID)
+	}
+	if got.DocumentKey != want.DocumentKey {
+		t.Errorf("DocumentKey = %q, want %q", got.DocumentKey, want.DocumentKey)
+	}
+	if got.RevisionNumber != want.RevisionNumber {
+		t.Errorf("RevisionNumber = %d, want %d", got.RevisionNumber, want.RevisionNumber)
+	}
+	if got.Title != want.Title {
+		t.Errorf("Title = %q, want %q", got.Title, want.Title)
+	}
+	if got.Content != want.Content {
+		t.Errorf("Content = %q, want %q", got.Content, want.Content)
+	}
+	if got.AuthorKind != want.AuthorKind {
+		t.Errorf("AuthorKind = %q, want %q", got.AuthorKind, want.AuthorKind)
+	}
+	if got.AuthorName != want.AuthorName {
+		t.Errorf("AuthorName = %q, want %q", got.AuthorName, want.AuthorName)
+	}
+	switch {
+	case want.RevertOfRevisionID == nil && got.RevertOfRevisionID != nil:
+		t.Errorf("RevertOfRevisionID = %q, want nil", *got.RevertOfRevisionID)
+	case want.RevertOfRevisionID != nil && got.RevertOfRevisionID == nil:
+		t.Errorf("RevertOfRevisionID = nil, want %q", *want.RevertOfRevisionID)
+	case want.RevertOfRevisionID != nil && *got.RevertOfRevisionID != *want.RevertOfRevisionID:
+		t.Errorf("RevertOfRevisionID = %q, want %q", *got.RevertOfRevisionID, *want.RevertOfRevisionID)
+	}
+	assertTimeEqual(t, "CreatedAt", got.CreatedAt, want.CreatedAt)
+	assertTimeEqual(t, "UpdatedAt", got.UpdatedAt, want.UpdatedAt)
+}
+
+func TestCreateDocumentRoundTripsEveryField(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+	ctx := context.Background()
+	seedTaskForDocs(t, repo, "task-doc-full")
+
+	want := fullDocument("task-doc-full")
+	before := time.Now().UTC().Add(-time.Second)
+	if err := repo.CreateDocument(ctx, want); err != nil {
+		t.Fatalf("CreateDocument: %v", err)
+	}
+	if want.CreatedAt.Before(before) || !want.CreatedAt.Equal(want.UpdatedAt) {
+		t.Fatalf("CreateDocument stamped CreatedAt=%v UpdatedAt=%v, want equal times after %v",
+			want.CreatedAt, want.UpdatedAt, before)
+	}
+
+	got, err := repo.GetDocument(ctx, "task-doc-full", "spec")
+	if err != nil {
+		t.Fatalf("GetDocument: %v", err)
+	}
+	assertDocumentEqual(t, got, want)
+
+	listed, err := repo.ListDocuments(ctx, "task-doc-full")
+	if err != nil {
+		t.Fatalf("ListDocuments: %v", err)
+	}
+	if len(listed) != 1 {
+		t.Fatalf("ListDocuments returned %d rows, want 1", len(listed))
+	}
+	assertDocumentEqual(t, listed[0], want)
+}
+
+func TestCreateDocumentGeneratesIDWhenEmpty(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+	ctx := context.Background()
+	seedTaskForDocs(t, repo, "task-doc-id")
+
+	doc := &models.TaskDocument{TaskID: "task-doc-id", Key: "plan", Type: "plan", Title: "Plan"}
+	if err := repo.CreateDocument(ctx, doc); err != nil {
+		t.Fatalf("CreateDocument: %v", err)
+	}
+	if doc.ID == "" {
+		t.Fatal("CreateDocument left ID empty; a UUID should have been generated")
+	}
+	got, err := repo.GetDocument(ctx, "task-doc-id", "plan")
+	if err != nil {
+		t.Fatalf("GetDocument: %v", err)
+	}
+	if got.ID != doc.ID {
+		t.Errorf("persisted ID = %q, want the generated %q", got.ID, doc.ID)
+	}
+}
+
+func TestCreateDocumentRejectsDuplicateTaskKey(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+	ctx := context.Background()
+	seedTaskForDocs(t, repo, "task-doc-dupe")
+
+	first := &models.TaskDocument{ID: "doc-dupe-1", TaskID: "task-doc-dupe", Key: "plan", Type: "plan", Title: "One"}
+	if err := repo.CreateDocument(ctx, first); err != nil {
+		t.Fatalf("CreateDocument(first): %v", err)
+	}
+	second := &models.TaskDocument{ID: "doc-dupe-2", TaskID: "task-doc-dupe", Key: "plan", Type: "plan", Title: "Two"}
+	if err := repo.CreateDocument(ctx, second); err == nil {
+		t.Fatal("CreateDocument accepted a duplicate (task_id, key); the UNIQUE constraint should reject it")
+	}
+	got, err := repo.GetDocument(ctx, "task-doc-dupe", "plan")
+	if err != nil {
+		t.Fatalf("GetDocument: %v", err)
+	}
+	if got.Title != "One" {
+		t.Errorf("Title = %q, want the original %q to survive the rejected insert", got.Title, "One")
+	}
+}
+
+func TestGetDocumentReturnsNilNilWhenMissing(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+	ctx := context.Background()
+
+	got, err := repo.GetDocument(ctx, "task-doc-missing", "plan")
+	if err != nil {
+		t.Fatalf("GetDocument returned error %v, want the nil,nil not-found contract", err)
+	}
+	if got != nil {
+		t.Errorf("GetDocument = %+v, want nil", got)
+	}
+}
+
+func TestUpdateDocumentWritesEveryMutableFieldAndReportsMissing(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+	ctx := context.Background()
+	seedTaskForDocs(t, repo, "task-doc-update")
+
+	doc := &models.TaskDocument{
+		ID: "doc-update", TaskID: "task-doc-update", Key: "notes", Type: "notes",
+		Title: "Before", Content: "old", AuthorKind: "agent", AuthorName: "claude",
+		Filename: "old.md", MimeType: "text/plain", SizeBytes: 1, DiskPath: "/old",
+	}
+	if err := repo.CreateDocument(ctx, doc); err != nil {
+		t.Fatalf("CreateDocument: %v", err)
+	}
+	createdAt := doc.CreatedAt
+
+	doc.Type = "spec"
+	doc.Title = "After"
+	doc.Content = "new content"
+	doc.AuthorKind = "user"
+	doc.AuthorName = "jcfs"
+	doc.Filename = "new.md"
+	doc.MimeType = "text/markdown"
+	doc.SizeBytes = 999
+	doc.DiskPath = "/new"
+	if err := repo.UpdateDocument(ctx, doc); err != nil {
+		t.Fatalf("UpdateDocument: %v", err)
+	}
+
+	got, err := repo.GetDocument(ctx, "task-doc-update", "notes")
+	if err != nil {
+		t.Fatalf("GetDocument: %v", err)
+	}
+	assertDocumentEqual(t, got, doc)
+	if !got.CreatedAt.Equal(createdAt) {
+		t.Errorf("CreatedAt = %v, want it preserved at %v across the update", got.CreatedAt, createdAt)
+	}
+	if !got.UpdatedAt.After(createdAt) && !got.UpdatedAt.Equal(doc.UpdatedAt) {
+		t.Errorf("UpdatedAt = %v, want the refreshed %v", got.UpdatedAt, doc.UpdatedAt)
+	}
+
+	missing := &models.TaskDocument{TaskID: "task-doc-update", Key: "nope"}
+	err = repo.UpdateDocument(ctx, missing)
+	if err == nil {
+		t.Fatal("UpdateDocument on a missing row returned nil")
+	}
+	if !strings.Contains(err.Error(), "document not found") {
+		t.Errorf("UpdateDocument error = %q, want a document-not-found message", err)
+	}
+}
+
+func TestDeleteDocumentRemovesHeadAndReportsMissing(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+	ctx := context.Background()
+	seedTaskForDocs(t, repo, "task-doc-delete")
+
+	for _, key := range []string{"plan", "spec"} {
+		if err := repo.CreateDocument(ctx, &models.TaskDocument{
+			ID: "doc-del-" + key, TaskID: "task-doc-delete", Key: key, Type: key, Title: key,
+		}); err != nil {
+			t.Fatalf("CreateDocument(%s): %v", key, err)
+		}
+	}
+
+	if err := repo.DeleteDocument(ctx, "task-doc-delete", "plan"); err != nil {
+		t.Fatalf("DeleteDocument: %v", err)
+	}
+	if got := countRows(t, repo, `SELECT COUNT(1) FROM task_documents WHERE task_id = ?`, "task-doc-delete"); got != 1 {
+		t.Errorf("rows after delete = %d, want 1", got)
+	}
+	gone, err := repo.GetDocument(ctx, "task-doc-delete", "plan")
+	if err != nil {
+		t.Fatalf("GetDocument: %v", err)
+	}
+	if gone != nil {
+		t.Errorf("deleted document still readable: %+v", gone)
+	}
+	survivor, err := repo.GetDocument(ctx, "task-doc-delete", "spec")
+	if err != nil || survivor == nil {
+		t.Fatalf("GetDocument(spec) = %+v, %v; want the sibling key untouched", survivor, err)
+	}
+
+	err = repo.DeleteDocument(ctx, "task-doc-delete", "plan")
+	if err == nil {
+		t.Fatal("second DeleteDocument returned nil; a missing row must be reported")
+	}
+	if !strings.Contains(err.Error(), "document not found") {
+		t.Errorf("DeleteDocument error = %q, want a document-not-found message", err)
+	}
+}
+
+// TestDeleteDocumentLeavesRevisionsBehind pins the current behavior: the
+// revisions table's only foreign key points at tasks(id), not at the document
+// HEAD row, so removing a HEAD does not cascade to its history.
+func TestDeleteDocumentLeavesRevisionsBehind(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+	ctx := context.Background()
+	seedTaskForDocs(t, repo, "task-doc-orphan")
+
+	if err := repo.CreateDocument(ctx, &models.TaskDocument{
+		ID: "doc-orphan", TaskID: "task-doc-orphan", Key: "plan", Type: "plan", Title: "Plan",
+	}); err != nil {
+		t.Fatalf("CreateDocument: %v", err)
+	}
+	if err := repo.InsertDocumentRevision(ctx, &models.TaskDocumentRevision{
+		ID: "rev-orphan", TaskID: "task-doc-orphan", DocumentKey: "plan", RevisionNumber: 1,
+		Title: "Plan", Content: "v1", AuthorKind: "agent",
+	}); err != nil {
+		t.Fatalf("InsertDocumentRevision: %v", err)
+	}
+
+	if err := repo.DeleteDocument(ctx, "task-doc-orphan", "plan"); err != nil {
+		t.Fatalf("DeleteDocument: %v", err)
+	}
+	if got := countRows(t, repo,
+		`SELECT COUNT(1) FROM task_document_revisions WHERE task_id = ?`, "task-doc-orphan"); got != 1 {
+		t.Errorf("revision rows after HEAD delete = %d, want 1 (no cascade from task_documents)", got)
+	}
+}
+
+func TestDocumentsAndRevisionsCascadeOnTaskDelete(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+	ctx := context.Background()
+	seedTaskForDocs(t, repo, "task-doc-cascade")
+
+	if err := repo.CreateDocument(ctx, &models.TaskDocument{
+		ID: "doc-cascade", TaskID: "task-doc-cascade", Key: "plan", Type: "plan", Title: "Plan",
+	}); err != nil {
+		t.Fatalf("CreateDocument: %v", err)
+	}
+	if err := repo.InsertDocumentRevision(ctx, &models.TaskDocumentRevision{
+		ID: "rev-cascade", TaskID: "task-doc-cascade", DocumentKey: "plan", RevisionNumber: 1,
+		Title: "Plan", Content: "v1", AuthorKind: "agent",
+	}); err != nil {
+		t.Fatalf("InsertDocumentRevision: %v", err)
+	}
+
+	if err := repo.DeleteTask(ctx, "task-doc-cascade"); err != nil {
+		t.Fatalf("DeleteTask: %v", err)
+	}
+	if got := countRows(t, repo, `SELECT COUNT(1) FROM task_documents WHERE task_id = ?`, "task-doc-cascade"); got != 0 {
+		t.Errorf("document rows after task delete = %d, want 0 (FK cascade)", got)
+	}
+	if got := countRows(t, repo,
+		`SELECT COUNT(1) FROM task_document_revisions WHERE task_id = ?`, "task-doc-cascade"); got != 0 {
+		t.Errorf("revision rows after task delete = %d, want 0 (FK cascade)", got)
+	}
+}
+
+func TestListDocumentsOrdersByKeyAndScopesToTask(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+	ctx := context.Background()
+	seedTaskForDocs(t, repo, "task-doc-list")
+	seedTaskForDocs(t, repo, "task-doc-list-other")
+
+	for _, key := range []string{"spec", "alpha", "notes"} {
+		if err := repo.CreateDocument(ctx, &models.TaskDocument{
+			ID: "doc-list-" + key, TaskID: "task-doc-list", Key: key, Type: key, Title: key,
+		}); err != nil {
+			t.Fatalf("CreateDocument(%s): %v", key, err)
+		}
+	}
+	if err := repo.CreateDocument(ctx, &models.TaskDocument{
+		ID: "doc-list-foreign", TaskID: "task-doc-list-other", Key: "aaa", Type: "plan", Title: "foreign",
+	}); err != nil {
+		t.Fatalf("CreateDocument(foreign): %v", err)
+	}
+
+	got, err := repo.ListDocuments(ctx, "task-doc-list")
+	if err != nil {
+		t.Fatalf("ListDocuments: %v", err)
+	}
+	want := []string{"alpha", "notes", "spec"}
+	if len(got) != len(want) {
+		t.Fatalf("ListDocuments returned %d rows, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i].Key != want[i] {
+			t.Fatalf("ListDocuments keys = %q at index %d, want %q (ORDER BY key)", got[i].Key, i, want[i])
+		}
+	}
+
+	empty, err := repo.ListDocuments(ctx, "task-doc-list-nothing")
+	if err != nil {
+		t.Fatalf("ListDocuments(unknown task): %v", err)
+	}
+	if len(empty) != 0 {
+		t.Errorf("ListDocuments(unknown task) = %+v, want empty", empty)
+	}
+}
+
+func TestInsertDocumentRevisionRoundTripsEveryField(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+	ctx := context.Background()
+	seedTaskForDocs(t, repo, "task-rev-full")
+
+	revertOf := "rev-previous"
+	want := &models.TaskDocumentRevision{
+		ID: "rev-full", TaskID: "task-rev-full", DocumentKey: "spec", RevisionNumber: 7,
+		Title: "Spec v7", Content: "seven", AuthorKind: "user", AuthorName: "jcfs",
+		RevertOfRevisionID: &revertOf,
+		CreatedAt:          time.Date(2026, 3, 3, 3, 3, 3, 456000000, time.UTC),
+	}
+	if err := repo.InsertDocumentRevision(ctx, want); err != nil {
+		t.Fatalf("InsertDocumentRevision: %v", err)
+	}
+	if want.UpdatedAt.IsZero() {
+		t.Fatal("InsertDocumentRevision left UpdatedAt zero")
+	}
+
+	got, err := repo.GetDocumentRevision(ctx, "rev-full")
+	if err != nil {
+		t.Fatalf("GetDocumentRevision: %v", err)
+	}
+	assertDocRevisionEqual(t, got, want)
+
+	latest, err := repo.GetLatestDocumentRevision(ctx, "task-rev-full", "spec")
+	if err != nil {
+		t.Fatalf("GetLatestDocumentRevision: %v", err)
+	}
+	assertDocRevisionEqual(t, latest, want)
+
+	listed, err := repo.ListDocumentRevisions(ctx, "task-rev-full", "spec", 0)
+	if err != nil {
+		t.Fatalf("ListDocumentRevisions: %v", err)
+	}
+	if len(listed) != 1 {
+		t.Fatalf("ListDocumentRevisions returned %d rows, want 1", len(listed))
+	}
+	assertDocRevisionEqual(t, listed[0], want)
+}
+
+func TestInsertDocumentRevisionPreservesSuppliedCreatedAtAndDefaultsID(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+	ctx := context.Background()
+	seedTaskForDocs(t, repo, "task-rev-defaults")
+
+	rev := &models.TaskDocumentRevision{
+		TaskID: "task-rev-defaults", DocumentKey: "plan", RevisionNumber: 1,
+		Title: "Plan", Content: "v1", AuthorKind: "agent",
+	}
+	before := time.Now().UTC().Add(-time.Second)
+	if err := repo.InsertDocumentRevision(ctx, rev); err != nil {
+		t.Fatalf("InsertDocumentRevision: %v", err)
+	}
+	if rev.ID == "" {
+		t.Fatal("ID left empty; a UUID should have been generated")
+	}
+	if rev.CreatedAt.Before(before) {
+		t.Errorf("CreatedAt = %v, want a freshly stamped time after %v", rev.CreatedAt, before)
+	}
+
+	got, err := repo.GetDocumentRevision(ctx, rev.ID)
+	if err != nil {
+		t.Fatalf("GetDocumentRevision: %v", err)
+	}
+	if got.RevertOfRevisionID != nil {
+		t.Errorf("RevertOfRevisionID = %q, want nil for a NULL column", *got.RevertOfRevisionID)
+	}
+}
+
+func TestGetDocumentRevisionReturnsNilNilWhenMissing(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+	ctx := context.Background()
+
+	got, err := repo.GetDocumentRevision(ctx, "rev-missing")
+	if err != nil {
+		t.Fatalf("GetDocumentRevision returned error %v, want the nil,nil not-found contract", err)
+	}
+	if got != nil {
+		t.Errorf("GetDocumentRevision = %+v, want nil", got)
+	}
+	latest, err := repo.GetLatestDocumentRevision(ctx, "task-missing", "plan")
+	if err != nil {
+		t.Fatalf("GetLatestDocumentRevision returned error %v, want nil,nil", err)
+	}
+	if latest != nil {
+		t.Errorf("GetLatestDocumentRevision = %+v, want nil", latest)
+	}
+}
+
+func TestListDocumentRevisionsOrdersDescendingScopedByKeyAndHonoursLimit(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+	ctx := context.Background()
+	seedTaskForDocs(t, repo, "task-rev-list")
+
+	for _, key := range []string{"plan", "spec"} {
+		for number := 1; number <= 3; number++ {
+			if err := repo.InsertDocumentRevision(ctx, &models.TaskDocumentRevision{
+				ID:     "rev-" + key + "-" + string(rune('0'+number)),
+				TaskID: "task-rev-list", DocumentKey: key, RevisionNumber: number,
+				Title:   key,
+				Content: key, AuthorKind: "agent",
+			}); err != nil {
+				t.Fatalf("InsertDocumentRevision(%s %d): %v", key, number, err)
+			}
+		}
+	}
+
+	all, err := repo.ListDocumentRevisions(ctx, "task-rev-list", "plan", 0)
+	if err != nil {
+		t.Fatalf("ListDocumentRevisions(limit=0): %v", err)
+	}
+	if len(all) != 3 {
+		t.Fatalf("limit=0 returned %d rows, want 3 (only the plan key)", len(all))
+	}
+	for i, wantNumber := range []int{3, 2, 1} {
+		if all[i].RevisionNumber != wantNumber {
+			t.Fatalf("revision numbers = %d at index %d, want %d (newest first)", all[i].RevisionNumber, i, wantNumber)
+		}
+		if all[i].DocumentKey != "plan" {
+			t.Fatalf("document key = %q at index %d, want plan", all[i].DocumentKey, i)
+		}
+	}
+
+	limited, err := repo.ListDocumentRevisions(ctx, "task-rev-list", "plan", 2)
+	if err != nil {
+		t.Fatalf("ListDocumentRevisions(limit=2): %v", err)
+	}
+	if len(limited) != 2 || limited[0].RevisionNumber != 3 || limited[1].RevisionNumber != 2 {
+		t.Errorf("limit=2 returned %+v, want revisions 3 then 2", limited)
+	}
+
+	latest, err := repo.GetLatestDocumentRevision(ctx, "task-rev-list", "spec")
+	if err != nil {
+		t.Fatalf("GetLatestDocumentRevision: %v", err)
+	}
+	if latest.RevisionNumber != 3 || latest.DocumentKey != "spec" {
+		t.Errorf("latest spec revision = %+v, want revision 3 of spec", latest)
+	}
+}
+
+func TestNextDocumentRevisionNumber(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+	ctx := context.Background()
+	seedTaskForDocs(t, repo, "task-rev-next")
+
+	next, err := repo.NextDocumentRevisionNumber(ctx, "task-rev-next", "plan")
+	if err != nil {
+		t.Fatalf("NextDocumentRevisionNumber: %v", err)
+	}
+	if next != 1 {
+		t.Errorf("NextDocumentRevisionNumber with no history = %d, want 1", next)
+	}
+
+	if err := repo.InsertDocumentRevision(ctx, &models.TaskDocumentRevision{
+		ID: "rev-next-5", TaskID: "task-rev-next", DocumentKey: "plan", RevisionNumber: 5,
+		Title: "Plan", Content: "v5", AuthorKind: "agent",
+	}); err != nil {
+		t.Fatalf("InsertDocumentRevision: %v", err)
+	}
+	// A different key must not influence the plan key's numbering.
+	if err := repo.InsertDocumentRevision(ctx, &models.TaskDocumentRevision{
+		ID: "rev-next-spec-9", TaskID: "task-rev-next", DocumentKey: "spec", RevisionNumber: 9,
+		Title: "Spec", Content: "v9", AuthorKind: "agent",
+	}); err != nil {
+		t.Fatalf("InsertDocumentRevision(spec): %v", err)
+	}
+
+	next, err = repo.NextDocumentRevisionNumber(ctx, "task-rev-next", "plan")
+	if err != nil {
+		t.Fatalf("NextDocumentRevisionNumber: %v", err)
+	}
+	if next != 6 {
+		t.Errorf("NextDocumentRevisionNumber = %d, want 6 (MAX(5)+1 for the plan key only)", next)
+	}
+}
+
+func TestWriteDocumentRevisionCreatesHeadAndFirstRevision(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+	ctx := context.Background()
+	seedTaskForDocs(t, repo, "task-write-doc")
+
+	head := &models.TaskDocument{
+		TaskID: "task-write-doc", Key: "plan", Type: "plan", Title: "Plan v1",
+		Content: "first", AuthorKind: "agent", AuthorName: "claude",
+		Filename: "plan.md", MimeType: "text/markdown", SizeBytes: 5, DiskPath: "/plan.md",
+	}
+	rev := &models.TaskDocumentRevision{
+		TaskID: "task-write-doc", DocumentKey: "plan",
+		Title: "Plan v1", Content: "first", AuthorKind: "agent", AuthorName: "claude",
+	}
+	if err := repo.WriteDocumentRevision(ctx, head, rev, nil); err != nil {
+		t.Fatalf("WriteDocumentRevision: %v", err)
+	}
+	if head.ID == "" {
+		t.Fatal("head ID left empty; a UUID should have been generated")
+	}
+	if rev.RevisionNumber != 1 {
+		t.Errorf("RevisionNumber = %d, want 1 for the first revision", rev.RevisionNumber)
+	}
+
+	gotHead, err := repo.GetDocument(ctx, "task-write-doc", "plan")
+	if err != nil {
+		t.Fatalf("GetDocument: %v", err)
+	}
+	assertDocumentEqual(t, gotHead, head)
+
+	gotRev, err := repo.GetLatestDocumentRevision(ctx, "task-write-doc", "plan")
+	if err != nil {
+		t.Fatalf("GetLatestDocumentRevision: %v", err)
+	}
+	assertDocRevisionEqual(t, gotRev, rev)
+}
+
+func TestWriteDocumentRevisionUpdatesHeadInPlaceAndAppendsRevisions(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+	ctx := context.Background()
+	seedTaskForDocs(t, repo, "task-write-doc-append")
+
+	head := &models.TaskDocument{
+		ID: "head-append", TaskID: "task-write-doc-append", Key: "plan", Type: "plan",
+		Title: "v1", Content: "one", AuthorKind: "agent",
+	}
+	if err := repo.WriteDocumentRevision(ctx, head, &models.TaskDocumentRevision{
+		TaskID: "task-write-doc-append", DocumentKey: "plan", Title: "v1", Content: "one", AuthorKind: "agent",
+	}, nil); err != nil {
+		t.Fatalf("WriteDocumentRevision(first): %v", err)
+	}
+	createdAt := head.CreatedAt
+
+	head.Title = "v2"
+	head.Content = "two"
+	head.SizeBytes = 3
+	second := &models.TaskDocumentRevision{
+		TaskID: "task-write-doc-append", DocumentKey: "plan", Title: "v2", Content: "two", AuthorKind: "user",
+	}
+	if err := repo.WriteDocumentRevision(ctx, head, second, nil); err != nil {
+		t.Fatalf("WriteDocumentRevision(second): %v", err)
+	}
+	if second.RevisionNumber != 2 {
+		t.Errorf("second RevisionNumber = %d, want 2", second.RevisionNumber)
+	}
+
+	if got := countRows(t, repo,
+		`SELECT COUNT(1) FROM task_documents WHERE task_id = ?`, "task-write-doc-append"); got != 1 {
+		t.Errorf("HEAD rows = %d, want 1 (the upsert must not insert a second row)", got)
+	}
+	gotHead, err := repo.GetDocument(ctx, "task-write-doc-append", "plan")
+	if err != nil {
+		t.Fatalf("GetDocument: %v", err)
+	}
+	if gotHead.ID != "head-append" {
+		t.Errorf("HEAD id = %q, want the original head-append", gotHead.ID)
+	}
+	if gotHead.Title != "v2" || gotHead.Content != "two" || gotHead.SizeBytes != 3 {
+		t.Errorf("HEAD = %+v, want the v2 values", gotHead)
+	}
+	if !gotHead.CreatedAt.Equal(createdAt) {
+		t.Errorf("HEAD CreatedAt = %v, want it preserved at %v", gotHead.CreatedAt, createdAt)
+	}
+
+	history, err := repo.ListDocumentRevisions(ctx, "task-write-doc-append", "plan", 0)
+	if err != nil {
+		t.Fatalf("ListDocumentRevisions: %v", err)
+	}
+	if len(history) != 2 {
+		t.Fatalf("history has %d revisions, want 2", len(history))
+	}
+	if history[0].RevisionNumber != 2 || history[0].Content != "two" || history[0].AuthorKind != "user" {
+		t.Errorf("newest revision = %+v, want revision 2 authored by user", history[0])
+	}
+	if history[1].RevisionNumber != 1 || history[1].Content != "one" {
+		t.Errorf("oldest revision = %+v, want revision 1 with the original content", history[1])
+	}
+}
+
+func TestWriteDocumentRevisionCoalescesIntoExistingRevision(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+	ctx := context.Background()
+	seedTaskForDocs(t, repo, "task-write-doc-merge")
+
+	head := &models.TaskDocument{
+		ID: "head-merge", TaskID: "task-write-doc-merge", Key: "plan", Type: "plan",
+		Title: "v1", Content: "one", AuthorKind: "agent",
+	}
+	first := &models.TaskDocumentRevision{
+		ID: "rev-merge", TaskID: "task-write-doc-merge", DocumentKey: "plan",
+		Title: "v1", Content: "one", AuthorKind: "agent", AuthorName: "claude",
+		CreatedAt: time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC),
+	}
+	if err := repo.WriteDocumentRevision(ctx, head, first, nil); err != nil {
+		t.Fatalf("WriteDocumentRevision(first): %v", err)
+	}
+
+	head.Title = "v1 edited"
+	head.Content = "one edited"
+	merged := &models.TaskDocumentRevision{
+		TaskID: "task-write-doc-merge", DocumentKey: "plan",
+		Title: "v1 edited", Content: "one edited", AuthorKind: "ignored", AuthorName: "ignored",
+	}
+	coalesceID := "rev-merge"
+	if err := repo.WriteDocumentRevision(ctx, head, merged, &coalesceID); err != nil {
+		t.Fatalf("WriteDocumentRevision(merge): %v", err)
+	}
+	if merged.ID != "rev-merge" {
+		t.Errorf("merged revision ID = %q, want rev-merge", merged.ID)
+	}
+
+	history, err := repo.ListDocumentRevisions(ctx, "task-write-doc-merge", "plan", 0)
+	if err != nil {
+		t.Fatalf("ListDocumentRevisions: %v", err)
+	}
+	if len(history) != 1 {
+		t.Fatalf("history has %d revisions, want 1 (coalesce must merge, not append)", len(history))
+	}
+	got := history[0]
+	if got.Title != "v1 edited" || got.Content != "one edited" {
+		t.Errorf("merged revision = %+v, want the edited title/content", got)
+	}
+	if got.RevisionNumber != 1 {
+		t.Errorf("RevisionNumber = %d, want 1 preserved across the merge", got.RevisionNumber)
+	}
+	if got.AuthorKind != "agent" || got.AuthorName != "claude" {
+		t.Errorf("author = %q/%q, want the original agent/claude preserved", got.AuthorKind, got.AuthorName)
+	}
+	if !got.CreatedAt.Equal(first.CreatedAt) {
+		t.Errorf("CreatedAt = %v, want the original %v preserved", got.CreatedAt, first.CreatedAt)
+	}
+	if !got.UpdatedAt.After(got.CreatedAt) {
+		t.Errorf("UpdatedAt = %v, want it bumped past CreatedAt %v", got.UpdatedAt, got.CreatedAt)
+	}
+}
+
+func TestWriteDocumentRevisionRollsBackWhenCoalesceTargetMissing(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+	ctx := context.Background()
+	seedTaskForDocs(t, repo, "task-write-doc-rollback")
+
+	head := &models.TaskDocument{
+		ID: "head-rollback", TaskID: "task-write-doc-rollback", Key: "plan", Type: "plan",
+		Title: "should not persist", Content: "nope", AuthorKind: "agent",
+	}
+	missingID := "rev-does-not-exist"
+	err := repo.WriteDocumentRevision(ctx, head, &models.TaskDocumentRevision{
+		TaskID: "task-write-doc-rollback", DocumentKey: "plan", Title: "x", Content: "y",
+	}, &missingID)
+	if err == nil {
+		t.Fatal("WriteDocumentRevision with an unknown coalesce id returned nil")
+	}
+	if !strings.Contains(err.Error(), "document revision not found") {
+		t.Errorf("error = %q, want a document-revision-not-found message", err)
+	}
+
+	// The HEAD upsert happened inside the same transaction and must roll back.
+	if got := countRows(t, repo,
+		`SELECT COUNT(1) FROM task_documents WHERE task_id = ?`, "task-write-doc-rollback"); got != 0 {
+		t.Errorf("HEAD rows after a failed merge = %d, want 0 (transaction must roll back)", got)
+	}
+	if got := countRows(t, repo,
+		`SELECT COUNT(1) FROM task_document_revisions WHERE task_id = ?`, "task-write-doc-rollback"); got != 0 {
+		t.Errorf("revision rows after a failed merge = %d, want 0", got)
+	}
+}
+
+func TestWriteDocumentRevisionTreatsEmptyCoalesceIDAsInsert(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+	ctx := context.Background()
+	seedTaskForDocs(t, repo, "task-write-doc-empty")
+
+	head := &models.TaskDocument{
+		ID: "head-empty", TaskID: "task-write-doc-empty", Key: "plan", Type: "plan",
+		Title: "v1", Content: "one", AuthorKind: "agent",
+	}
+	empty := ""
+	rev := &models.TaskDocumentRevision{
+		TaskID: "task-write-doc-empty", DocumentKey: "plan", Title: "v1", Content: "one", AuthorKind: "agent",
+	}
+	if err := repo.WriteDocumentRevision(ctx, head, rev, &empty); err != nil {
+		t.Fatalf("WriteDocumentRevision: %v", err)
+	}
+	if rev.RevisionNumber != 1 {
+		t.Errorf("RevisionNumber = %d, want 1 — an empty coalesce id means append", rev.RevisionNumber)
+	}
+	if got := countRows(t, repo,
+		`SELECT COUNT(1) FROM task_document_revisions WHERE task_id = ?`, "task-write-doc-empty"); got != 1 {
+		t.Errorf("revision rows = %d, want 1", got)
+	}
+}
+
+func TestDocumentMethodsPropagateBackendErrors(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+	ctx := context.Background()
+	seedTaskForDocs(t, repo, "task-doc-broken")
+	if err := repo.CreateDocument(ctx, &models.TaskDocument{
+		ID: "doc-broken", TaskID: "task-doc-broken", Key: "plan", Type: "plan", Title: "Plan",
+	}); err != nil {
+		t.Fatalf("CreateDocument: %v", err)
+	}
+	closeRepoDB(t, repo)
+
+	if err := repo.CreateDocument(ctx, &models.TaskDocument{
+		ID: "doc-after-close", TaskID: "task-doc-broken", Key: "spec",
+	}); err == nil {
+		t.Error("CreateDocument on a closed database returned nil")
+	}
+	if _, err := repo.GetDocument(ctx, "task-doc-broken", "plan"); err == nil {
+		t.Error("GetDocument on a closed database returned nil")
+	}
+	if err := repo.UpdateDocument(ctx, &models.TaskDocument{TaskID: "task-doc-broken", Key: "plan"}); err == nil {
+		t.Error("UpdateDocument on a closed database returned nil")
+	}
+	if err := repo.DeleteDocument(ctx, "task-doc-broken", "plan"); err == nil {
+		t.Error("DeleteDocument on a closed database returned nil")
+	}
+	if _, err := repo.ListDocuments(ctx, "task-doc-broken"); err == nil {
+		t.Error("ListDocuments on a closed database returned nil")
+	}
+	if err := repo.InsertDocumentRevision(ctx, &models.TaskDocumentRevision{
+		TaskID: "task-doc-broken", DocumentKey: "plan", RevisionNumber: 1,
+	}); err == nil {
+		t.Error("InsertDocumentRevision on a closed database returned nil")
+	}
+	if _, err := repo.GetDocumentRevision(ctx, "rev-broken"); err == nil {
+		t.Error("GetDocumentRevision on a closed database returned nil")
+	}
+	if _, err := repo.ListDocumentRevisions(ctx, "task-doc-broken", "plan", 0); err == nil {
+		t.Error("ListDocumentRevisions on a closed database returned nil")
+	}
+	if _, err := repo.NextDocumentRevisionNumber(ctx, "task-doc-broken", "plan"); err == nil {
+		t.Error("NextDocumentRevisionNumber on a closed database returned nil")
+	}
+	if err := repo.WriteDocumentRevision(ctx,
+		&models.TaskDocument{TaskID: "task-doc-broken", Key: "plan"},
+		&models.TaskDocumentRevision{TaskID: "task-doc-broken", DocumentKey: "plan"},
+		nil); err == nil {
+		t.Error("WriteDocumentRevision on a closed database returned nil")
+	}
+}

--- a/apps/backend/internal/task/repository/sqlite/document_test.go
+++ b/apps/backend/internal/task/repository/sqlite/document_test.go
@@ -244,8 +244,8 @@ func TestUpdateDocumentWritesEveryMutableFieldAndReportsMissing(t *testing.T) {
 	if !got.CreatedAt.Equal(createdAt) {
 		t.Errorf("CreatedAt = %v, want it preserved at %v across the update", got.CreatedAt, createdAt)
 	}
-	if !got.UpdatedAt.After(createdAt) && !got.UpdatedAt.Equal(doc.UpdatedAt) {
-		t.Errorf("UpdatedAt = %v, want the refreshed %v", got.UpdatedAt, doc.UpdatedAt)
+	if !got.UpdatedAt.After(createdAt) {
+		t.Errorf("UpdatedAt = %v, want it bumped past CreatedAt %v", got.UpdatedAt, createdAt)
 	}
 
 	missing := &models.TaskDocument{TaskID: "task-doc-update", Key: "nope"}

--- a/apps/backend/internal/task/repository/sqlite/environment_test.go
+++ b/apps/backend/internal/task/repository/sqlite/environment_test.go
@@ -1,0 +1,389 @@
+package sqlite
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/task/models"
+)
+
+func assertEnvironmentEqual(t *testing.T, got, want *models.Environment) {
+	t.Helper()
+	if got == nil {
+		t.Fatal("environment is nil")
+	}
+	if got.ID != want.ID {
+		t.Errorf("ID = %q, want %q", got.ID, want.ID)
+	}
+	if got.Name != want.Name {
+		t.Errorf("Name = %q, want %q", got.Name, want.Name)
+	}
+	if got.Kind != want.Kind {
+		t.Errorf("Kind = %q, want %q", got.Kind, want.Kind)
+	}
+	if got.IsSystem != want.IsSystem {
+		t.Errorf("IsSystem = %v, want %v", got.IsSystem, want.IsSystem)
+	}
+	if got.WorktreeRoot != want.WorktreeRoot {
+		t.Errorf("WorktreeRoot = %q, want %q", got.WorktreeRoot, want.WorktreeRoot)
+	}
+	if got.ImageTag != want.ImageTag {
+		t.Errorf("ImageTag = %q, want %q", got.ImageTag, want.ImageTag)
+	}
+	if got.Dockerfile != want.Dockerfile {
+		t.Errorf("Dockerfile = %q, want %q", got.Dockerfile, want.Dockerfile)
+	}
+	if len(got.BuildConfig) != len(want.BuildConfig) {
+		t.Errorf("BuildConfig = %v, want %v", got.BuildConfig, want.BuildConfig)
+	}
+	for key, value := range want.BuildConfig {
+		if got.BuildConfig[key] != value {
+			t.Errorf("BuildConfig[%q] = %q, want %q", key, got.BuildConfig[key], value)
+		}
+	}
+	assertTimeEqual(t, "CreatedAt", got.CreatedAt, want.CreatedAt)
+	assertTimeEqual(t, "UpdatedAt", got.UpdatedAt, want.UpdatedAt)
+	if (got.DeletedAt == nil) != (want.DeletedAt == nil) {
+		t.Errorf("DeletedAt = %v, want %v", got.DeletedAt, want.DeletedAt)
+	}
+}
+
+func TestCreateEnvironmentRoundTripsEveryField(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+	ctx := context.Background()
+
+	before := time.Now().UTC().Add(-time.Second)
+	want := &models.Environment{
+		ID:           "env-full",
+		Name:         "Docker build env",
+		Kind:         models.EnvironmentKindDockerImage,
+		IsSystem:     true,
+		WorktreeRoot: "~/kandev/worktrees",
+		ImageTag:     "ghcr.io/kdlbs/kandev:latest",
+		Dockerfile:   "FROM golang:1.26\nRUN echo hi\n",
+		BuildConfig:  map[string]string{"context": ".", "target": "runtime"},
+	}
+	if err := repo.CreateEnvironment(ctx, want); err != nil {
+		t.Fatalf("CreateEnvironment: %v", err)
+	}
+	if want.CreatedAt.Before(before) || !want.CreatedAt.Equal(want.UpdatedAt) {
+		t.Fatalf("CreateEnvironment stamped CreatedAt=%v UpdatedAt=%v, want equal times after %v",
+			want.CreatedAt, want.UpdatedAt, before)
+	}
+
+	got, err := repo.GetEnvironment(ctx, "env-full")
+	if err != nil {
+		t.Fatalf("GetEnvironment: %v", err)
+	}
+	assertEnvironmentEqual(t, got, want)
+
+	listed, err := repo.ListEnvironments(ctx)
+	if err != nil {
+		t.Fatalf("ListEnvironments: %v", err)
+	}
+	var found *models.Environment
+	for _, environment := range listed {
+		if environment.ID == "env-full" {
+			found = environment
+		}
+	}
+	if found == nil {
+		t.Fatalf("ListEnvironments did not return env-full (got %d rows)", len(listed))
+	}
+	assertEnvironmentEqual(t, found, want)
+}
+
+func TestCreateEnvironmentGeneratesIDAndNormalizesEmptyBuildConfig(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+	ctx := context.Background()
+
+	environment := &models.Environment{Name: "Plain", Kind: models.EnvironmentKindLocalPC}
+	if err := repo.CreateEnvironment(ctx, environment); err != nil {
+		t.Fatalf("CreateEnvironment: %v", err)
+	}
+	if environment.ID == "" {
+		t.Fatal("ID left empty; a UUID should have been generated")
+	}
+	got, err := repo.GetEnvironment(ctx, environment.ID)
+	if err != nil {
+		t.Fatalf("GetEnvironment: %v", err)
+	}
+	if got.IsSystem {
+		t.Error("IsSystem = true, want false for an environment created without the flag")
+	}
+	if got.BuildConfig != nil {
+		t.Errorf("BuildConfig = %v, want nil for an environment created without one", got.BuildConfig)
+	}
+
+	empty := &models.Environment{ID: "env-empty-config", Name: "Empty", Kind: models.EnvironmentKindLocalPC,
+		BuildConfig: map[string]string{}}
+	if err := repo.CreateEnvironment(ctx, empty); err != nil {
+		t.Fatalf("CreateEnvironment(empty config): %v", err)
+	}
+	gotEmpty, err := repo.GetEnvironment(ctx, "env-empty-config")
+	if err != nil {
+		t.Fatalf("GetEnvironment: %v", err)
+	}
+	if gotEmpty.BuildConfig != nil {
+		t.Errorf("BuildConfig = %v, want nil (an empty map serializes to the {} sentinel)", gotEmpty.BuildConfig)
+	}
+}
+
+func TestGetEnvironmentReportsMissingID(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+
+	got, err := repo.GetEnvironment(context.Background(), "env-nope")
+	if got != nil {
+		t.Errorf("environment = %+v, want nil", got)
+	}
+	if err == nil {
+		t.Fatal("GetEnvironment on a missing id returned nil error")
+	}
+	if !strings.Contains(err.Error(), "environment not found: env-nope") {
+		t.Errorf("error = %q, want an environment-not-found message naming the id", err)
+	}
+}
+
+func TestUpdateEnvironmentWritesMutableFieldsAndReportsMissing(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+	ctx := context.Background()
+
+	environment := &models.Environment{
+		ID: "env-update", Name: "Before", Kind: models.EnvironmentKindLocalPC,
+		WorktreeRoot: "/old", ImageTag: "old:tag", Dockerfile: "FROM old",
+		BuildConfig: map[string]string{"a": "1"},
+	}
+	if err := repo.CreateEnvironment(ctx, environment); err != nil {
+		t.Fatalf("CreateEnvironment: %v", err)
+	}
+	createdAt := environment.CreatedAt
+
+	environment.Name = "After"
+	environment.Kind = models.EnvironmentKindDockerImage
+	environment.IsSystem = true
+	environment.WorktreeRoot = "/new"
+	environment.ImageTag = "new:tag"
+	environment.Dockerfile = "FROM new"
+	environment.BuildConfig = map[string]string{"b": "2", "c": "3"}
+	if err := repo.UpdateEnvironment(ctx, environment); err != nil {
+		t.Fatalf("UpdateEnvironment: %v", err)
+	}
+
+	got, err := repo.GetEnvironment(ctx, "env-update")
+	if err != nil {
+		t.Fatalf("GetEnvironment: %v", err)
+	}
+	assertEnvironmentEqual(t, got, environment)
+	if !got.CreatedAt.Equal(createdAt) {
+		t.Errorf("CreatedAt = %v, want it preserved at %v", got.CreatedAt, createdAt)
+	}
+	if !got.UpdatedAt.After(createdAt) {
+		t.Errorf("UpdatedAt = %v, want it bumped past CreatedAt %v", got.UpdatedAt, createdAt)
+	}
+
+	err = repo.UpdateEnvironment(ctx, &models.Environment{ID: "env-nowhere", Name: "x", Kind: models.EnvironmentKindLocalPC})
+	if err == nil {
+		t.Fatal("UpdateEnvironment on a missing row returned nil")
+	}
+	if !strings.Contains(err.Error(), "environment not found: env-nowhere") {
+		t.Errorf("error = %q, want an environment-not-found message", err)
+	}
+}
+
+func TestDeleteEnvironmentSoftDeletesAndHidesFromReads(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+	ctx := context.Background()
+
+	if err := repo.CreateEnvironment(ctx, &models.Environment{
+		ID: "env-soft-delete", Name: "Doomed", Kind: models.EnvironmentKindDockerImage,
+	}); err != nil {
+		t.Fatalf("CreateEnvironment: %v", err)
+	}
+	if err := repo.CreateEnvironment(ctx, &models.Environment{
+		ID: "env-survivor", Name: "Survivor", Kind: models.EnvironmentKindDockerImage,
+	}); err != nil {
+		t.Fatalf("CreateEnvironment(survivor): %v", err)
+	}
+
+	if err := repo.DeleteEnvironment(ctx, "env-soft-delete"); err != nil {
+		t.Fatalf("DeleteEnvironment: %v", err)
+	}
+
+	// Soft delete: the row survives with deleted_at set.
+	if got := countRows(t, repo, `SELECT COUNT(1) FROM environments WHERE id = ?`, "env-soft-delete"); got != 1 {
+		t.Errorf("rows for the deleted environment = %d, want 1 (soft delete keeps the row)", got)
+	}
+	if got := countRows(t, repo,
+		`SELECT COUNT(1) FROM environments WHERE id = ? AND deleted_at IS NOT NULL`, "env-soft-delete"); got != 1 {
+		t.Errorf("deleted_at-set rows = %d, want 1", got)
+	}
+
+	if _, err := repo.GetEnvironment(ctx, "env-soft-delete"); err == nil {
+		t.Error("GetEnvironment returned a soft-deleted environment")
+	}
+	listed, err := repo.ListEnvironments(ctx)
+	if err != nil {
+		t.Fatalf("ListEnvironments: %v", err)
+	}
+	for _, environment := range listed {
+		if environment.ID == "env-soft-delete" {
+			t.Fatalf("ListEnvironments returned the soft-deleted row: %+v", environment)
+		}
+	}
+	if _, err := repo.GetEnvironment(ctx, "env-survivor"); err != nil {
+		t.Errorf("GetEnvironment(env-survivor): %v", err)
+	}
+
+	// A soft-deleted row can neither be updated nor deleted again.
+	err = repo.UpdateEnvironment(ctx, &models.Environment{
+		ID: "env-soft-delete", Name: "Resurrect", Kind: models.EnvironmentKindLocalPC,
+	})
+	if err == nil || !strings.Contains(err.Error(), "environment not found") {
+		t.Errorf("UpdateEnvironment on a soft-deleted row = %v, want an environment-not-found error", err)
+	}
+	err = repo.DeleteEnvironment(ctx, "env-soft-delete")
+	if err == nil || !strings.Contains(err.Error(), "environment not found") {
+		t.Errorf("second DeleteEnvironment = %v, want an environment-not-found error", err)
+	}
+	err = repo.DeleteEnvironment(ctx, "env-never-existed")
+	if err == nil || !strings.Contains(err.Error(), "environment not found") {
+		t.Errorf("DeleteEnvironment(unknown) = %v, want an environment-not-found error", err)
+	}
+}
+
+func TestListEnvironmentsOrdersByCreatedAtAscending(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+	ctx := context.Background()
+
+	// CreateEnvironment stamps created_at itself, so pin explicit values
+	// afterwards to make the ORDER BY assertion deterministic.
+	base := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	stamps := map[string]time.Time{
+		"env-order-c": base.Add(3 * time.Hour),
+		"env-order-a": base.Add(1 * time.Hour),
+		"env-order-b": base.Add(2 * time.Hour),
+	}
+	for id, stamp := range stamps {
+		if err := repo.CreateEnvironment(ctx, &models.Environment{
+			ID: id, Name: id, Kind: models.EnvironmentKindDockerImage,
+		}); err != nil {
+			t.Fatalf("CreateEnvironment(%s): %v", id, err)
+		}
+		if _, err := repo.db.ExecContext(ctx, repo.db.Rebind(
+			`UPDATE environments SET created_at = ? WHERE id = ?`), stamp, id); err != nil {
+			t.Fatalf("pin created_at for %s: %v", id, err)
+		}
+	}
+	// Push the seeded default environment before all three.
+	if _, err := repo.db.ExecContext(ctx, repo.db.Rebind(
+		`UPDATE environments SET created_at = ? WHERE id = ?`), base, models.EnvironmentIDLocal); err != nil {
+		t.Fatalf("pin created_at for the default environment: %v", err)
+	}
+
+	listed, err := repo.ListEnvironments(ctx)
+	if err != nil {
+		t.Fatalf("ListEnvironments: %v", err)
+	}
+	gotIDs := make([]string, 0, len(listed))
+	for _, environment := range listed {
+		gotIDs = append(gotIDs, environment.ID)
+	}
+	want := []string{models.EnvironmentIDLocal, "env-order-a", "env-order-b", "env-order-c"}
+	if len(gotIDs) != len(want) {
+		t.Fatalf("ListEnvironments = %v, want %v", gotIDs, want)
+	}
+	for i := range want {
+		if gotIDs[i] != want[i] {
+			t.Fatalf("ListEnvironments = %v, want %v (ORDER BY created_at ASC)", gotIDs, want)
+		}
+	}
+}
+
+func TestListEnvironmentsDecodesBuildConfigPerRow(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+	ctx := context.Background()
+
+	if err := repo.CreateEnvironment(ctx, &models.Environment{
+		ID: "env-decode-1", Name: "One", Kind: models.EnvironmentKindDockerImage, IsSystem: true,
+		BuildConfig: map[string]string{"one": "1"},
+	}); err != nil {
+		t.Fatalf("CreateEnvironment(one): %v", err)
+	}
+	if err := repo.CreateEnvironment(ctx, &models.Environment{
+		ID: "env-decode-2", Name: "Two", Kind: models.EnvironmentKindDockerImage,
+		BuildConfig: map[string]string{"two": "2", "three": "3"},
+	}); err != nil {
+		t.Fatalf("CreateEnvironment(two): %v", err)
+	}
+
+	listed, err := repo.ListEnvironments(ctx)
+	if err != nil {
+		t.Fatalf("ListEnvironments: %v", err)
+	}
+	byID := make(map[string]*models.Environment, len(listed))
+	for _, environment := range listed {
+		byID[environment.ID] = environment
+	}
+	one, ok := byID["env-decode-1"]
+	if !ok {
+		t.Fatal("env-decode-1 missing from ListEnvironments")
+	}
+	if !one.IsSystem {
+		t.Error("env-decode-1 IsSystem = false, want true")
+	}
+	if len(one.BuildConfig) != 1 || one.BuildConfig["one"] != "1" {
+		t.Errorf("env-decode-1 BuildConfig = %v, want {one:1}", one.BuildConfig)
+	}
+	two, ok := byID["env-decode-2"]
+	if !ok {
+		t.Fatal("env-decode-2 missing from ListEnvironments")
+	}
+	if two.IsSystem {
+		t.Error("env-decode-2 IsSystem = true, want false")
+	}
+	if len(two.BuildConfig) != 2 || two.BuildConfig["two"] != "2" || two.BuildConfig["three"] != "3" {
+		t.Errorf("env-decode-2 BuildConfig = %v, want {two:2, three:3}", two.BuildConfig)
+	}
+}
+
+// closeRepoDB closes the repository's shared connection so the next call must
+// surface a backend error instead of silently returning a zero value.
+func closeRepoDB(t *testing.T, repo *Repository) {
+	t.Helper()
+	if err := repo.db.Close(); err != nil {
+		t.Fatalf("close repo db: %v", err)
+	}
+}
+
+func TestEnvironmentMethodsPropagateBackendErrors(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+	ctx := context.Background()
+	if err := repo.CreateEnvironment(ctx, &models.Environment{
+		ID: "env-broken", Name: "Broken", Kind: models.EnvironmentKindLocalPC,
+	}); err != nil {
+		t.Fatalf("CreateEnvironment: %v", err)
+	}
+	closeRepoDB(t, repo)
+
+	if err := repo.CreateEnvironment(ctx, &models.Environment{
+		ID: "env-after-close", Name: "x", Kind: models.EnvironmentKindLocalPC,
+	}); err == nil {
+		t.Error("CreateEnvironment on a closed database returned nil")
+	}
+	if _, err := repo.GetEnvironment(ctx, "env-broken"); err == nil {
+		t.Error("GetEnvironment on a closed database returned nil")
+	}
+	if err := repo.UpdateEnvironment(ctx, &models.Environment{
+		ID: "env-broken", Name: "x", Kind: models.EnvironmentKindLocalPC,
+	}); err == nil {
+		t.Error("UpdateEnvironment on a closed database returned nil")
+	}
+	if err := repo.DeleteEnvironment(ctx, "env-broken"); err == nil {
+		t.Error("DeleteEnvironment on a closed database returned nil")
+	}
+	if _, err := repo.ListEnvironments(ctx); err == nil {
+		t.Error("ListEnvironments on a closed database returned nil")
+	}
+}

--- a/apps/backend/internal/task/repository/sqlite/executor_profile_test.go
+++ b/apps/backend/internal/task/repository/sqlite/executor_profile_test.go
@@ -1,0 +1,460 @@
+package sqlite
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/task/models"
+)
+
+// seedExecutorForProfiles creates the executors row that executor_profiles
+// references through its foreign key.
+func seedExecutorForProfiles(t *testing.T, repo *Repository, id string) {
+	t.Helper()
+	if err := repo.CreateExecutor(context.Background(), &models.Executor{
+		ID: id, Name: id, Type: models.ExecutorTypeLocal, Status: models.ExecutorStatusActive,
+	}); err != nil {
+		t.Fatalf("CreateExecutor(%s): %v", id, err)
+	}
+}
+
+func assertExecutorProfileEqual(t *testing.T, got, want *models.ExecutorProfile) {
+	t.Helper()
+	if got == nil {
+		t.Fatal("profile is nil")
+	}
+	if got.ID != want.ID {
+		t.Errorf("ID = %q, want %q", got.ID, want.ID)
+	}
+	if got.ExecutorID != want.ExecutorID {
+		t.Errorf("ExecutorID = %q, want %q", got.ExecutorID, want.ExecutorID)
+	}
+	if got.Name != want.Name {
+		t.Errorf("Name = %q, want %q", got.Name, want.Name)
+	}
+	if got.McpPolicy != want.McpPolicy {
+		t.Errorf("McpPolicy = %q, want %q", got.McpPolicy, want.McpPolicy)
+	}
+	if got.PrepareScript != want.PrepareScript {
+		t.Errorf("PrepareScript = %q, want %q", got.PrepareScript, want.PrepareScript)
+	}
+	if got.CleanupScript != want.CleanupScript {
+		t.Errorf("CleanupScript = %q, want %q", got.CleanupScript, want.CleanupScript)
+	}
+	if len(got.Config) != len(want.Config) {
+		t.Errorf("Config = %v, want %v", got.Config, want.Config)
+	}
+	for key, value := range want.Config {
+		if got.Config[key] != value {
+			t.Errorf("Config[%q] = %q, want %q", key, got.Config[key], value)
+		}
+	}
+	if len(got.EnvVars) != len(want.EnvVars) {
+		t.Errorf("EnvVars = %+v, want %+v", got.EnvVars, want.EnvVars)
+	} else {
+		for i := range want.EnvVars {
+			if got.EnvVars[i] != want.EnvVars[i] {
+				t.Errorf("EnvVars[%d] = %+v, want %+v", i, got.EnvVars[i], want.EnvVars[i])
+			}
+		}
+	}
+	assertTimeEqual(t, "CreatedAt", got.CreatedAt, want.CreatedAt)
+	assertTimeEqual(t, "UpdatedAt", got.UpdatedAt, want.UpdatedAt)
+}
+
+func TestCreateExecutorProfileRoundTripsEveryField(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+	ctx := context.Background()
+	seedExecutorForProfiles(t, repo, "executor-profile-full")
+
+	before := time.Now().UTC().Add(-time.Second)
+	want := &models.ExecutorProfile{
+		ID:            "profile-full",
+		ExecutorID:    "executor-profile-full",
+		Name:          "Full profile",
+		McpPolicy:     "allow_all",
+		Config:        map[string]string{"docker_host": "unix:///var/run/docker.sock", "cpus": "4"},
+		PrepareScript: "pnpm install --frozen-lockfile",
+		CleanupScript: "rm -rf node_modules",
+		EnvVars: []models.ProfileEnvVar{
+			{Key: "NODE_ENV", Value: "test"},
+			{Key: "API_TOKEN", SecretID: "secret-123"},
+		},
+	}
+	if err := repo.CreateExecutorProfile(ctx, want); err != nil {
+		t.Fatalf("CreateExecutorProfile: %v", err)
+	}
+	if want.CreatedAt.Before(before) || !want.CreatedAt.Equal(want.UpdatedAt) {
+		t.Fatalf("CreateExecutorProfile stamped CreatedAt=%v UpdatedAt=%v, want equal times after %v",
+			want.CreatedAt, want.UpdatedAt, before)
+	}
+
+	got, err := repo.GetExecutorProfile(ctx, "profile-full")
+	if err != nil {
+		t.Fatalf("GetExecutorProfile: %v", err)
+	}
+	assertExecutorProfileEqual(t, got, want)
+
+	listed, err := repo.ListExecutorProfiles(ctx, "executor-profile-full")
+	if err != nil {
+		t.Fatalf("ListExecutorProfiles: %v", err)
+	}
+	if len(listed) != 1 {
+		t.Fatalf("ListExecutorProfiles returned %d rows, want 1", len(listed))
+	}
+	assertExecutorProfileEqual(t, listed[0], want)
+}
+
+func TestCreateExecutorProfileGeneratesIDAndNormalizesEmptyCollections(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+	ctx := context.Background()
+	seedExecutorForProfiles(t, repo, "executor-profile-defaults")
+
+	profile := &models.ExecutorProfile{ExecutorID: "executor-profile-defaults", Name: "Bare"}
+	if err := repo.CreateExecutorProfile(ctx, profile); err != nil {
+		t.Fatalf("CreateExecutorProfile: %v", err)
+	}
+	if profile.ID == "" {
+		t.Fatal("ID left empty; a UUID should have been generated")
+	}
+	got, err := repo.GetExecutorProfile(ctx, profile.ID)
+	if err != nil {
+		t.Fatalf("GetExecutorProfile: %v", err)
+	}
+	if got.Config != nil {
+		t.Errorf("Config = %v, want nil for a profile written without one", got.Config)
+	}
+	if got.EnvVars != nil {
+		t.Errorf("EnvVars = %+v, want nil for a profile written without any", got.EnvVars)
+	}
+	if got.McpPolicy != "" || got.PrepareScript != "" || got.CleanupScript != "" {
+		t.Errorf("empty string columns = %q/%q/%q, want all empty",
+			got.McpPolicy, got.PrepareScript, got.CleanupScript)
+	}
+
+	// An explicitly empty map serializes to the "{}" sentinel and is skipped
+	// on read; an explicitly empty slice serializes to "[]" and decodes back
+	// as an empty (non-nil) slice.
+	empty := &models.ExecutorProfile{
+		ID: "profile-empty", ExecutorID: "executor-profile-defaults", Name: "Empty",
+		Config: map[string]string{}, EnvVars: []models.ProfileEnvVar{},
+	}
+	if err := repo.CreateExecutorProfile(ctx, empty); err != nil {
+		t.Fatalf("CreateExecutorProfile(empty): %v", err)
+	}
+	gotEmpty, err := repo.GetExecutorProfile(ctx, "profile-empty")
+	if err != nil {
+		t.Fatalf("GetExecutorProfile(empty): %v", err)
+	}
+	if gotEmpty.Config != nil {
+		t.Errorf("Config = %v, want nil (an empty map serializes to the {} sentinel)", gotEmpty.Config)
+	}
+	if gotEmpty.EnvVars == nil || len(gotEmpty.EnvVars) != 0 {
+		t.Errorf("EnvVars = %+v, want an empty non-nil slice", gotEmpty.EnvVars)
+	}
+}
+
+func TestCreateExecutorProfileRejectsUnknownExecutor(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+
+	err := repo.CreateExecutorProfile(context.Background(), &models.ExecutorProfile{
+		ID: "profile-orphan", ExecutorID: "executor-does-not-exist", Name: "Orphan",
+	})
+	if err == nil {
+		t.Fatal("CreateExecutorProfile accepted a profile for a non-existent executor")
+	}
+	if got := countRows(t, repo,
+		`SELECT COUNT(1) FROM executor_profiles WHERE id = ?`, "profile-orphan"); got != 0 {
+		t.Errorf("rows = %d, want 0", got)
+	}
+}
+
+func TestGetExecutorProfileReportsMissingID(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+
+	got, err := repo.GetExecutorProfile(context.Background(), "profile-nope")
+	if got != nil {
+		t.Errorf("profile = %+v, want nil", got)
+	}
+	if err == nil {
+		t.Fatal("GetExecutorProfile on a missing id returned nil error")
+	}
+	if !strings.Contains(err.Error(), "executor profile not found: profile-nope") {
+		t.Errorf("error = %q, want an executor-profile-not-found message naming the id", err)
+	}
+}
+
+func TestUpdateExecutorProfileWritesMutableFieldsAndReportsMissing(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+	ctx := context.Background()
+	seedExecutorForProfiles(t, repo, "executor-profile-update")
+
+	profile := &models.ExecutorProfile{
+		ID: "profile-update", ExecutorID: "executor-profile-update", Name: "Before",
+		McpPolicy: "deny", Config: map[string]string{"old": "value"},
+		PrepareScript: "old prepare", CleanupScript: "old cleanup",
+		EnvVars: []models.ProfileEnvVar{{Key: "OLD", Value: "1"}},
+	}
+	if err := repo.CreateExecutorProfile(ctx, profile); err != nil {
+		t.Fatalf("CreateExecutorProfile: %v", err)
+	}
+	createdAt := profile.CreatedAt
+
+	profile.Name = "After"
+	profile.McpPolicy = "allow"
+	profile.Config = map[string]string{"new": "value", "extra": "x"}
+	profile.PrepareScript = "new prepare"
+	profile.CleanupScript = "new cleanup"
+	profile.EnvVars = []models.ProfileEnvVar{{Key: "NEW", SecretID: "secret-9"}}
+	if err := repo.UpdateExecutorProfile(ctx, profile); err != nil {
+		t.Fatalf("UpdateExecutorProfile: %v", err)
+	}
+
+	got, err := repo.GetExecutorProfile(ctx, "profile-update")
+	if err != nil {
+		t.Fatalf("GetExecutorProfile: %v", err)
+	}
+	assertExecutorProfileEqual(t, got, profile)
+	if !got.CreatedAt.Equal(createdAt) {
+		t.Errorf("CreatedAt = %v, want it preserved at %v", got.CreatedAt, createdAt)
+	}
+	if !got.UpdatedAt.After(createdAt) {
+		t.Errorf("UpdatedAt = %v, want it bumped past CreatedAt %v", got.UpdatedAt, createdAt)
+	}
+	if got.ExecutorID != "executor-profile-update" {
+		t.Errorf("ExecutorID = %q, want it untouched by the update", got.ExecutorID)
+	}
+
+	err = repo.UpdateExecutorProfile(ctx, &models.ExecutorProfile{ID: "profile-nowhere", Name: "x"})
+	if err == nil {
+		t.Fatal("UpdateExecutorProfile on a missing row returned nil")
+	}
+	if !strings.Contains(err.Error(), "executor profile not found: profile-nowhere") {
+		t.Errorf("error = %q, want an executor-profile-not-found message", err)
+	}
+}
+
+func TestDeleteExecutorProfileRemovesRowAndReportsMissing(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+	ctx := context.Background()
+	seedExecutorForProfiles(t, repo, "executor-profile-delete")
+
+	for _, id := range []string{"profile-del", "profile-keep"} {
+		if err := repo.CreateExecutorProfile(ctx, &models.ExecutorProfile{
+			ID: id, ExecutorID: "executor-profile-delete", Name: id,
+		}); err != nil {
+			t.Fatalf("CreateExecutorProfile(%s): %v", id, err)
+		}
+	}
+
+	if err := repo.DeleteExecutorProfile(ctx, "profile-del"); err != nil {
+		t.Fatalf("DeleteExecutorProfile: %v", err)
+	}
+	if got := countRows(t, repo,
+		`SELECT COUNT(1) FROM executor_profiles WHERE executor_id = ?`, "executor-profile-delete"); got != 1 {
+		t.Errorf("rows after delete = %d, want 1", got)
+	}
+	if _, err := repo.GetExecutorProfile(ctx, "profile-del"); err == nil {
+		t.Error("GetExecutorProfile returned a deleted profile")
+	}
+	if _, err := repo.GetExecutorProfile(ctx, "profile-keep"); err != nil {
+		t.Errorf("GetExecutorProfile(profile-keep): %v", err)
+	}
+
+	err := repo.DeleteExecutorProfile(ctx, "profile-del")
+	if err == nil {
+		t.Fatal("second DeleteExecutorProfile returned nil; a missing row must be reported")
+	}
+	if !strings.Contains(err.Error(), "executor profile not found: profile-del") {
+		t.Errorf("error = %q, want an executor-profile-not-found message", err)
+	}
+}
+
+func TestListExecutorProfilesOrdersByNameAndScopesToExecutor(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+	ctx := context.Background()
+	seedExecutorForProfiles(t, repo, "executor-list-a")
+	seedExecutorForProfiles(t, repo, "executor-list-b")
+
+	for _, name := range []string{"zulu", "alpha", "mike"} {
+		if err := repo.CreateExecutorProfile(ctx, &models.ExecutorProfile{
+			ID: "profile-a-" + name, ExecutorID: "executor-list-a", Name: name,
+		}); err != nil {
+			t.Fatalf("CreateExecutorProfile(%s): %v", name, err)
+		}
+	}
+	if err := repo.CreateExecutorProfile(ctx, &models.ExecutorProfile{
+		ID: "profile-b-aaa", ExecutorID: "executor-list-b", Name: "aaa",
+	}); err != nil {
+		t.Fatalf("CreateExecutorProfile(b): %v", err)
+	}
+
+	got, err := repo.ListExecutorProfiles(ctx, "executor-list-a")
+	if err != nil {
+		t.Fatalf("ListExecutorProfiles: %v", err)
+	}
+	want := []string{"alpha", "mike", "zulu"}
+	if len(got) != len(want) {
+		t.Fatalf("ListExecutorProfiles returned %d rows, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i].Name != want[i] {
+			t.Fatalf("names = %q at index %d, want %q (ORDER BY name ASC)", got[i].Name, i, want[i])
+		}
+		if got[i].ExecutorID != "executor-list-a" {
+			t.Fatalf("ExecutorID = %q at index %d, want executor-list-a", got[i].ExecutorID, i)
+		}
+	}
+
+	empty, err := repo.ListExecutorProfiles(ctx, "executor-list-nothing")
+	if err != nil {
+		t.Fatalf("ListExecutorProfiles(unknown executor): %v", err)
+	}
+	if len(empty) != 0 {
+		t.Errorf("unknown executor returned %+v, want empty", empty)
+	}
+}
+
+func TestListAllExecutorProfilesOrdersByExecutorThenName(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+	ctx := context.Background()
+	seedExecutorForProfiles(t, repo, "executor-all-2")
+	seedExecutorForProfiles(t, repo, "executor-all-1")
+
+	rows := []struct {
+		id, executorID, name string
+	}{
+		{"profile-all-2b", "executor-all-2", "beta"},
+		{"profile-all-1b", "executor-all-1", "beta"},
+		{"profile-all-2a", "executor-all-2", "alpha"},
+		{"profile-all-1a", "executor-all-1", "alpha"},
+	}
+	for _, row := range rows {
+		if err := repo.CreateExecutorProfile(ctx, &models.ExecutorProfile{
+			ID: row.id, ExecutorID: row.executorID, Name: row.name,
+			Config: map[string]string{"row": row.id},
+		}); err != nil {
+			t.Fatalf("CreateExecutorProfile(%s): %v", row.id, err)
+		}
+	}
+
+	listed, err := repo.ListAllExecutorProfiles(ctx)
+	if err != nil {
+		t.Fatalf("ListAllExecutorProfiles: %v", err)
+	}
+
+	// The repository seeds two default profiles at init; assert on the
+	// relative order of the four rows this test owns.
+	ordered := make([]string, 0, len(rows))
+	for _, profile := range listed {
+		if strings.HasPrefix(profile.ID, "profile-all-") {
+			ordered = append(ordered, profile.ID)
+			if profile.Config["row"] != profile.ID {
+				t.Errorf("Config for %s = %v, want per-row decoding", profile.ID, profile.Config)
+			}
+		}
+	}
+	want := []string{"profile-all-1a", "profile-all-1b", "profile-all-2a", "profile-all-2b"}
+	if len(ordered) != len(want) {
+		t.Fatalf("ListAllExecutorProfiles owned rows = %v, want %v", ordered, want)
+	}
+	for i := range want {
+		if ordered[i] != want[i] {
+			t.Fatalf("ListAllExecutorProfiles = %v, want %v (ORDER BY executor_id, name)", ordered, want)
+		}
+	}
+
+	// The two seeded defaults are still there — ListAll must not filter.
+	if len(listed) != len(rows)+2 {
+		t.Errorf("ListAllExecutorProfiles returned %d rows, want %d (4 owned + 2 seeded defaults)",
+			len(listed), len(rows)+2)
+	}
+}
+
+func TestExecutorProfileEnvVarsSurviveListPaths(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+	ctx := context.Background()
+	seedExecutorForProfiles(t, repo, "executor-envvars")
+
+	want := []models.ProfileEnvVar{
+		{Key: "PLAIN", Value: "visible"},
+		{Key: "SECRET", SecretID: "secret-ref"},
+		{Key: "EMPTY"},
+	}
+	if err := repo.CreateExecutorProfile(ctx, &models.ExecutorProfile{
+		ID: "profile-envvars", ExecutorID: "executor-envvars", Name: "Env vars", EnvVars: want,
+	}); err != nil {
+		t.Fatalf("CreateExecutorProfile: %v", err)
+	}
+
+	scoped, err := repo.ListExecutorProfiles(ctx, "executor-envvars")
+	if err != nil {
+		t.Fatalf("ListExecutorProfiles: %v", err)
+	}
+	if len(scoped) != 1 {
+		t.Fatalf("ListExecutorProfiles returned %d rows, want 1", len(scoped))
+	}
+	assertProfileEnvVars(t, "ListExecutorProfiles", scoped[0].EnvVars, want)
+
+	all, err := repo.ListAllExecutorProfiles(ctx)
+	if err != nil {
+		t.Fatalf("ListAllExecutorProfiles: %v", err)
+	}
+	var found *models.ExecutorProfile
+	for _, profile := range all {
+		if profile.ID == "profile-envvars" {
+			found = profile
+		}
+	}
+	if found == nil {
+		t.Fatal("profile-envvars missing from ListAllExecutorProfiles")
+	}
+	assertProfileEnvVars(t, "ListAllExecutorProfiles", found.EnvVars, want)
+}
+
+func assertProfileEnvVars(t *testing.T, label string, got, want []models.ProfileEnvVar) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("%s EnvVars = %+v, want %+v", label, got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("%s EnvVars[%d] = %+v, want %+v", label, i, got[i], want[i])
+		}
+	}
+}
+
+func TestExecutorProfileMethodsPropagateBackendErrors(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+	ctx := context.Background()
+	seedExecutorForProfiles(t, repo, "executor-broken")
+	if err := repo.CreateExecutorProfile(ctx, &models.ExecutorProfile{
+		ID: "profile-broken", ExecutorID: "executor-broken", Name: "Broken",
+	}); err != nil {
+		t.Fatalf("CreateExecutorProfile: %v", err)
+	}
+	closeRepoDB(t, repo)
+
+	if err := repo.CreateExecutorProfile(ctx, &models.ExecutorProfile{
+		ID: "profile-after-close", ExecutorID: "executor-broken", Name: "x",
+	}); err == nil {
+		t.Error("CreateExecutorProfile on a closed database returned nil")
+	}
+	if _, err := repo.GetExecutorProfile(ctx, "profile-broken"); err == nil {
+		t.Error("GetExecutorProfile on a closed database returned nil")
+	}
+	if err := repo.UpdateExecutorProfile(ctx, &models.ExecutorProfile{ID: "profile-broken", Name: "x"}); err == nil {
+		t.Error("UpdateExecutorProfile on a closed database returned nil")
+	}
+	if err := repo.DeleteExecutorProfile(ctx, "profile-broken"); err == nil {
+		t.Error("DeleteExecutorProfile on a closed database returned nil")
+	}
+	if _, err := repo.ListExecutorProfiles(ctx, "executor-broken"); err == nil {
+		t.Error("ListExecutorProfiles on a closed database returned nil")
+	}
+	if _, err := repo.ListAllExecutorProfiles(ctx); err == nil {
+		t.Error("ListAllExecutorProfiles on a closed database returned nil")
+	}
+}

--- a/apps/backend/internal/task/repository/sqlite/executor_profile_test.go
+++ b/apps/backend/internal/task/repository/sqlite/executor_profile_test.go
@@ -323,6 +323,14 @@ func TestListAllExecutorProfilesOrdersByExecutorThenName(t *testing.T) {
 	seedExecutorForProfiles(t, repo, "executor-all-2")
 	seedExecutorForProfiles(t, repo, "executor-all-1")
 
+	// The repository seeds default profiles at init; measure that baseline
+	// rather than hardcoding today's count.
+	baseline, err := repo.ListAllExecutorProfiles(ctx)
+	if err != nil {
+		t.Fatalf("ListAllExecutorProfiles(baseline): %v", err)
+	}
+	seeded := len(baseline)
+
 	rows := []struct {
 		id, executorID, name string
 	}{
@@ -344,9 +352,13 @@ func TestListAllExecutorProfilesOrdersByExecutorThenName(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListAllExecutorProfiles: %v", err)
 	}
+	if len(listed) != seeded+len(rows) {
+		t.Errorf("ListAllExecutorProfiles returned %d rows, want %d seeded + %d owned — ListAll must not filter",
+			len(listed), seeded, len(rows))
+	}
 
-	// The repository seeds two default profiles at init; assert on the
-	// relative order of the four rows this test owns.
+	// Assert on the relative order of the rows this test owns; the seeded
+	// defaults are interleaved by executor id.
 	ordered := make([]string, 0, len(rows))
 	for _, profile := range listed {
 		if strings.HasPrefix(profile.ID, "profile-all-") {
@@ -366,11 +378,6 @@ func TestListAllExecutorProfilesOrdersByExecutorThenName(t *testing.T) {
 		}
 	}
 
-	// The two seeded defaults are still there — ListAll must not filter.
-	if len(listed) != len(rows)+2 {
-		t.Errorf("ListAllExecutorProfiles returned %d rows, want %d (4 owned + 2 seeded defaults)",
-			len(listed), len(rows)+2)
-	}
 }
 
 func TestExecutorProfileEnvVarsSurviveListPaths(t *testing.T) {

--- a/apps/backend/internal/task/repository/sqlite/git_snapshots_postgres_test.go
+++ b/apps/backend/internal/task/repository/sqlite/git_snapshots_postgres_test.go
@@ -1,0 +1,279 @@
+package sqlite
+
+// Postgres parity coverage for the git snapshot read/write paths.
+// GetLatestGitSnapshotsBySessionIDs uses a ROW_NUMBER() window function with a
+// CASE-ordered partition and a rebound IN list; UpsertLatestLiveGitSnapshot
+// runs DELETE + INSERT in one transaction; and the files/metadata columns are
+// JSON text with an "{}"-sentinel contract. All dialect-sensitive.
+// Skips unless KANDEV_TEST_POSTGRES_DSN is set; CI runs these in postgres-boot.
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/task/models"
+	"github.com/kandev/kandev/internal/testutil"
+)
+
+func TestPostgresGitSnapshotLifecycle(t *testing.T) {
+	db := testutil.OpenIsolatedPostgres(t, testutil.PostgresDSNFromEnv(t))
+	repo, err := NewWithDB(db, db, nil)
+	if err != nil {
+		t.Fatalf("init postgres schema: %v", err)
+	}
+	ctx := context.Background()
+	seedPostgresTask(t, repo, "task-git-pg")
+	for _, sessionID := range []string{"session-git-pg-a", "session-git-pg-b"} {
+		if err := repo.CreateTaskSession(ctx, &models.TaskSession{
+			ID: sessionID, TaskID: "task-git-pg", State: models.TaskSessionStateWaitingForInput,
+		}); err != nil {
+			t.Fatalf("CreateTaskSession(%s): %v", sessionID, err)
+		}
+	}
+
+	base := time.Date(2026, 3, 4, 5, 6, 7, 123456000, time.UTC)
+	want := fullGitSnapshot("session-git-pg-a", base)
+	if err := repo.CreateGitSnapshot(ctx, want); err != nil {
+		t.Fatalf("CreateGitSnapshot: %v", err)
+	}
+	got, err := repo.GetLatestGitSnapshot(ctx, "session-git-pg-a")
+	if err != nil {
+		t.Fatalf("GetLatestGitSnapshot: %v", err)
+	}
+	assertGitSnapshotEqual(t, got, want)
+
+	// A newer live_monitor row must lose to the older agent_completed row in
+	// both the single-row read and the window-function batch read.
+	if err := repo.CreateGitSnapshot(ctx, &models.GitSnapshot{
+		ID: "snap-pg-live", SessionID: "session-git-pg-a",
+		SnapshotType: models.SnapshotTypeStatusUpdate, Branch: "main",
+		TriggeredBy: TriggeredByLiveMonitor, HeadCommit: "stale", CreatedAt: base.Add(time.Hour),
+	}); err != nil {
+		t.Fatalf("CreateGitSnapshot(live): %v", err)
+	}
+	if err := repo.CreateGitSnapshot(ctx, &models.GitSnapshot{
+		ID: "snap-pg-b", SessionID: "session-git-pg-b",
+		SnapshotType: models.SnapshotTypeStatusUpdate, Branch: "main",
+		TriggeredBy: TriggeredByLiveMonitor, HeadCommit: "b-head", CreatedAt: base,
+	}); err != nil {
+		t.Fatalf("CreateGitSnapshot(b): %v", err)
+	}
+
+	latest, err := repo.GetLatestGitSnapshot(ctx, "session-git-pg-a")
+	if err != nil {
+		t.Fatalf("GetLatestGitSnapshot: %v", err)
+	}
+	if latest.ID != "snapshot-full" {
+		t.Errorf("GetLatestGitSnapshot = %q, want the agent_completed snapshot-full", latest.ID)
+	}
+	batch, err := repo.GetLatestGitSnapshotsBySessionIDs(ctx,
+		[]string{"session-git-pg-a", "session-git-pg-b", "session-git-pg-missing"})
+	if err != nil {
+		t.Fatalf("GetLatestGitSnapshotsBySessionIDs: %v", err)
+	}
+	if len(batch) != 2 {
+		t.Fatalf("batch has %d entries (%v), want 2", len(batch), batch)
+	}
+	if batch["session-git-pg-a"].ID != "snapshot-full" {
+		t.Errorf("batch[a] = %q, want snapshot-full (ROW_NUMBER must mirror the single-row read)",
+			batch["session-git-pg-a"].ID)
+	}
+	if batch["session-git-pg-b"].HeadCommit != "b-head" {
+		t.Errorf("batch[b] head = %q, want b-head", batch["session-git-pg-b"].HeadCommit)
+	}
+	assertJSONMapEqual(t, "batch[a].Files", batch["session-git-pg-a"].Files, want.Files)
+
+	// The single-live-row upsert transaction.
+	if err := repo.UpsertLatestLiveGitSnapshot(ctx, &models.GitSnapshot{
+		ID: "snap-pg-live-2", SessionID: "session-git-pg-a", Branch: "main",
+		HeadCommit: "fresh", CreatedAt: base.Add(2 * time.Hour),
+	}); err != nil {
+		t.Fatalf("UpsertLatestLiveGitSnapshot: %v", err)
+	}
+	liveRows := countRows(t, repo,
+		`SELECT COUNT(1) FROM task_session_git_snapshots WHERE session_id = ? AND triggered_by = ?`,
+		"session-git-pg-a", TriggeredByLiveMonitor)
+	if liveRows != 1 {
+		t.Errorf("live_monitor rows = %d, want exactly 1", liveRows)
+	}
+	if got := countRows(t, repo,
+		`SELECT COUNT(1) FROM task_session_git_snapshots WHERE session_id = ?`, "session-git-pg-a"); got != 2 {
+		t.Errorf("total rows = %d, want 2 (archive snapshot + one live row)", got)
+	}
+
+	if err := repo.DeleteLiveMonitorSnapshots(ctx, "session-git-pg-a"); err != nil {
+		t.Fatalf("DeleteLiveMonitorSnapshots: %v", err)
+	}
+	if got := countRows(t, repo,
+		`SELECT COUNT(1) FROM task_session_git_snapshots WHERE session_id = ?`, "session-git-pg-a"); got != 1 {
+		t.Errorf("rows after live delete = %d, want 1", got)
+	}
+
+	if _, err := repo.GetLatestGitSnapshot(ctx, "session-git-pg-missing"); !errors.Is(err, sql.ErrNoRows) {
+		t.Errorf("GetLatestGitSnapshot(missing) = %v, want sql.ErrNoRows", err)
+	}
+}
+
+func TestPostgresSessionCommitLifecycle(t *testing.T) {
+	db := testutil.OpenIsolatedPostgres(t, testutil.PostgresDSNFromEnv(t))
+	repo, err := NewWithDB(db, db, nil)
+	if err != nil {
+		t.Fatalf("init postgres schema: %v", err)
+	}
+	ctx := context.Background()
+	seedPostgresTask(t, repo, "task-commit-pg")
+	if err := repo.CreateTaskSession(ctx, &models.TaskSession{
+		ID: "session-commit-pg", TaskID: "task-commit-pg", State: models.TaskSessionStateWaitingForInput,
+	}); err != nil {
+		t.Fatalf("CreateTaskSession: %v", err)
+	}
+
+	want := &models.SessionCommit{
+		ID: "commit-pg", SessionID: "session-commit-pg",
+		CommitSHA: "0123456789abcdef", ParentSHA: "fedcba9876543210",
+		AuthorName: "Kandev Agent", AuthorEmail: "agent@kandev.local",
+		CommitMessage:       "feat: postgres parity",
+		CommittedAt:         time.Date(2026, 4, 2, 3, 4, 5, 678000000, time.UTC),
+		PreCommitSnapshotID: "pre", PostCommitSnapshotID: "post",
+		FilesChanged: 9, Insertions: 123, Deletions: 45,
+		CreatedAt: time.Date(2026, 4, 2, 3, 4, 6, 0, time.UTC),
+	}
+	if err := repo.CreateSessionCommit(ctx, want); err != nil {
+		t.Fatalf("CreateSessionCommit: %v", err)
+	}
+	got, err := repo.GetLatestSessionCommit(ctx, "session-commit-pg")
+	if err != nil {
+		t.Fatalf("GetLatestSessionCommit: %v", err)
+	}
+	assertSessionCommitEqual(t, got, want)
+
+	if err := repo.CreateSessionCommit(ctx, &models.SessionCommit{
+		ID: "commit-pg-older", SessionID: "session-commit-pg", CommitSHA: "older",
+		CommittedAt: want.CommittedAt.Add(-time.Hour),
+	}); err != nil {
+		t.Fatalf("CreateSessionCommit(older): %v", err)
+	}
+	listed, err := repo.GetSessionCommits(ctx, "session-commit-pg")
+	if err != nil {
+		t.Fatalf("GetSessionCommits: %v", err)
+	}
+	if len(listed) != 2 || listed[0].ID != "commit-pg" || listed[1].ID != "commit-pg-older" {
+		t.Fatalf("GetSessionCommits = %+v, want commit-pg then commit-pg-older", listed)
+	}
+
+	if err := repo.DeleteSessionCommit(ctx, "commit-pg-older"); err != nil {
+		t.Fatalf("DeleteSessionCommit: %v", err)
+	}
+	if got := countRows(t, repo,
+		`SELECT COUNT(1) FROM task_session_commits WHERE session_id = ?`, "session-commit-pg"); got != 1 {
+		t.Errorf("rows after delete = %d, want 1", got)
+	}
+	if _, err := repo.GetLatestSessionCommit(ctx, "session-commit-pg-missing"); !errors.Is(err, sql.ErrNoRows) {
+		t.Errorf("GetLatestSessionCommit(missing) = %v, want sql.ErrNoRows", err)
+	}
+}
+
+func TestPostgresEnvironmentAndExecutorProfileLifecycle(t *testing.T) {
+	db := testutil.OpenIsolatedPostgres(t, testutil.PostgresDSNFromEnv(t))
+	repo, err := NewWithDB(db, db, nil)
+	if err != nil {
+		t.Fatalf("init postgres schema: %v", err)
+	}
+	ctx := context.Background()
+
+	// environments.is_system is an INTEGER column written through
+	// dialect.BoolToInt and scanned back as an int — worth pinning on Postgres.
+	environment := &models.Environment{
+		ID: "env-pg", Name: "PG env", Kind: models.EnvironmentKindDockerImage, IsSystem: true,
+		WorktreeRoot: "~/kandev", ImageTag: "img:tag", Dockerfile: "FROM scratch",
+		BuildConfig: map[string]string{"context": ".", "target": "runtime"},
+	}
+	if err := repo.CreateEnvironment(ctx, environment); err != nil {
+		t.Fatalf("CreateEnvironment: %v", err)
+	}
+	gotEnv, err := repo.GetEnvironment(ctx, "env-pg")
+	if err != nil {
+		t.Fatalf("GetEnvironment: %v", err)
+	}
+	assertEnvironmentEqual(t, gotEnv, environment)
+
+	environment.IsSystem = false
+	environment.BuildConfig = map[string]string{"context": "sub"}
+	if err := repo.UpdateEnvironment(ctx, environment); err != nil {
+		t.Fatalf("UpdateEnvironment: %v", err)
+	}
+	gotEnv, err = repo.GetEnvironment(ctx, "env-pg")
+	if err != nil {
+		t.Fatalf("GetEnvironment after update: %v", err)
+	}
+	if gotEnv.IsSystem {
+		t.Error("IsSystem = true, want false after the update")
+	}
+	if len(gotEnv.BuildConfig) != 1 || gotEnv.BuildConfig["context"] != "sub" {
+		t.Errorf("BuildConfig = %v, want {context: sub}", gotEnv.BuildConfig)
+	}
+
+	// Soft delete hides the row from both reads but keeps it on disk.
+	if err := repo.DeleteEnvironment(ctx, "env-pg"); err != nil {
+		t.Fatalf("DeleteEnvironment: %v", err)
+	}
+	if _, err := repo.GetEnvironment(ctx, "env-pg"); err == nil {
+		t.Error("GetEnvironment returned a soft-deleted environment")
+	}
+	listedEnvs, err := repo.ListEnvironments(ctx)
+	if err != nil {
+		t.Fatalf("ListEnvironments: %v", err)
+	}
+	for _, candidate := range listedEnvs {
+		if candidate.ID == "env-pg" {
+			t.Fatalf("ListEnvironments returned the soft-deleted row: %+v", candidate)
+		}
+	}
+	if got := countRows(t, repo, `SELECT COUNT(1) FROM environments WHERE id = ?`, "env-pg"); got != 1 {
+		t.Errorf("rows for the soft-deleted environment = %d, want 1", got)
+	}
+
+	// executor_profiles.env_vars is a nullable JSON text column read through
+	// sql.NullString with a "null" sentinel check.
+	if err := repo.CreateExecutor(ctx, &models.Executor{
+		ID: "executor-pg", Name: "PG executor",
+		Type: models.ExecutorTypeLocal, Status: models.ExecutorStatusActive,
+	}); err != nil {
+		t.Fatalf("CreateExecutor: %v", err)
+	}
+	profile := &models.ExecutorProfile{
+		ID: "profile-pg", ExecutorID: "executor-pg", Name: "PG profile", McpPolicy: "allow",
+		Config: map[string]string{"cpus": "4"}, PrepareScript: "prepare", CleanupScript: "cleanup",
+		EnvVars: []models.ProfileEnvVar{{Key: "PLAIN", Value: "v"}, {Key: "SECRET", SecretID: "s-1"}},
+	}
+	if err := repo.CreateExecutorProfile(ctx, profile); err != nil {
+		t.Fatalf("CreateExecutorProfile: %v", err)
+	}
+	gotProfile, err := repo.GetExecutorProfile(ctx, "profile-pg")
+	if err != nil {
+		t.Fatalf("GetExecutorProfile: %v", err)
+	}
+	assertExecutorProfileEqual(t, gotProfile, profile)
+
+	scoped, err := repo.ListExecutorProfiles(ctx, "executor-pg")
+	if err != nil {
+		t.Fatalf("ListExecutorProfiles: %v", err)
+	}
+	if len(scoped) != 1 {
+		t.Fatalf("ListExecutorProfiles returned %d rows, want 1", len(scoped))
+	}
+	assertProfileEnvVars(t, "ListExecutorProfiles", scoped[0].EnvVars, profile.EnvVars)
+
+	if err := repo.DeleteExecutorProfile(ctx, "profile-pg"); err != nil {
+		t.Fatalf("DeleteExecutorProfile: %v", err)
+	}
+	if got := countRows(t, repo, `SELECT COUNT(1) FROM executor_profiles WHERE id = ?`, "profile-pg"); got != 0 {
+		t.Errorf("rows after delete = %d, want 0", got)
+	}
+	if err := repo.DeleteExecutorProfile(ctx, "profile-pg"); err == nil {
+		t.Error("second DeleteExecutorProfile returned nil; a missing row must be reported")
+	}
+}

--- a/apps/backend/internal/task/repository/sqlite/git_snapshots_test.go
+++ b/apps/backend/internal/task/repository/sqlite/git_snapshots_test.go
@@ -1,0 +1,934 @@
+package sqlite
+
+//revive:disable:file-length-limit // Git snapshot/commit persistence coverage is intentionally scenario-heavy.
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/task/models"
+)
+
+// seedSessionForGit creates the task + session rows that the git snapshot and
+// commit tables reference via ON DELETE CASCADE foreign keys.
+func seedSessionForGit(t *testing.T, repo *Repository, taskID, sessionID string) {
+	t.Helper()
+	ctx := context.Background()
+	if err := repo.CreateTask(ctx, &models.Task{ID: taskID, Title: taskID}); err != nil {
+		t.Fatalf("CreateTask(%s): %v", taskID, err)
+	}
+	if err := repo.CreateTaskSession(ctx, &models.TaskSession{ID: sessionID, TaskID: taskID}); err != nil {
+		t.Fatalf("CreateTaskSession(%s): %v", sessionID, err)
+	}
+}
+
+// countRows is a raw row counter used to assert deletes actually removed rows
+// rather than trusting the repository read path to agree with itself.
+func countRows(t *testing.T, repo *Repository, query string, args ...interface{}) int {
+	t.Helper()
+	var n int
+	if err := repo.db.QueryRowContext(context.Background(), repo.db.Rebind(query), args...).Scan(&n); err != nil {
+		t.Fatalf("count rows: %v", err)
+	}
+	return n
+}
+
+// assertTimeEqual compares two timestamps at microsecond resolution. SQLite
+// round-trips full nanoseconds but Postgres TIMESTAMP tops out at microseconds,
+// so the shared assertion helpers — which both dialects' tests call — must
+// compare at the coarser of the two. A dropped or zeroed column still fails.
+func assertTimeEqual(t *testing.T, label string, got, want time.Time) {
+	t.Helper()
+	if !got.Truncate(time.Microsecond).Equal(want.Truncate(time.Microsecond)) {
+		t.Errorf("%s = %v, want %v", label, got, want)
+	}
+}
+
+func fullGitSnapshot(sessionID string, createdAt time.Time) *models.GitSnapshot {
+	return &models.GitSnapshot{
+		ID:           "snapshot-full",
+		SessionID:    sessionID,
+		SnapshotType: models.SnapshotTypeArchive,
+		Branch:       "feature/full",
+		RemoteBranch: "origin/feature/full",
+		HeadCommit:   "head-sha-1234",
+		BaseCommit:   "base-sha-9876",
+		Ahead:        3,
+		Behind:       7,
+		Files: map[string]interface{}{
+			"apps/backend/main.go": map[string]interface{}{
+				"status":    "modified",
+				"additions": float64(12),
+			},
+		},
+		TriggeredBy: "agent_completed",
+		Metadata: map[string]interface{}{
+			"reason":  "task archived",
+			"attempt": float64(2),
+		},
+		CreatedAt: createdAt,
+	}
+}
+
+func assertGitSnapshotEqual(t *testing.T, got, want *models.GitSnapshot) {
+	t.Helper()
+	if got.ID != want.ID {
+		t.Errorf("ID = %q, want %q", got.ID, want.ID)
+	}
+	if got.SessionID != want.SessionID {
+		t.Errorf("SessionID = %q, want %q", got.SessionID, want.SessionID)
+	}
+	if got.SnapshotType != want.SnapshotType {
+		t.Errorf("SnapshotType = %q, want %q", got.SnapshotType, want.SnapshotType)
+	}
+	if got.Branch != want.Branch {
+		t.Errorf("Branch = %q, want %q", got.Branch, want.Branch)
+	}
+	if got.RemoteBranch != want.RemoteBranch {
+		t.Errorf("RemoteBranch = %q, want %q", got.RemoteBranch, want.RemoteBranch)
+	}
+	if got.HeadCommit != want.HeadCommit {
+		t.Errorf("HeadCommit = %q, want %q", got.HeadCommit, want.HeadCommit)
+	}
+	if got.BaseCommit != want.BaseCommit {
+		t.Errorf("BaseCommit = %q, want %q", got.BaseCommit, want.BaseCommit)
+	}
+	if got.Ahead != want.Ahead {
+		t.Errorf("Ahead = %d, want %d", got.Ahead, want.Ahead)
+	}
+	if got.Behind != want.Behind {
+		t.Errorf("Behind = %d, want %d", got.Behind, want.Behind)
+	}
+	if got.TriggeredBy != want.TriggeredBy {
+		t.Errorf("TriggeredBy = %q, want %q", got.TriggeredBy, want.TriggeredBy)
+	}
+	assertTimeEqual(t, "CreatedAt", got.CreatedAt, want.CreatedAt)
+	assertJSONMapEqual(t, "Files", got.Files, want.Files)
+	assertJSONMapEqual(t, "Metadata", got.Metadata, want.Metadata)
+}
+
+// assertJSONMapEqual compares two JSON-decoded maps structurally. It is written
+// by hand (instead of reflect.DeepEqual on the whole snapshot) so a dropped
+// nested key names the field it came from.
+func assertJSONMapEqual(t *testing.T, label string, got, want map[string]interface{}) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Errorf("%s has %d keys (%v), want %d (%v)", label, len(got), got, len(want), want)
+		return
+	}
+	for key, wantValue := range want {
+		gotValue, ok := got[key]
+		if !ok {
+			t.Errorf("%s missing key %q", label, key)
+			continue
+		}
+		wantNested, wantIsMap := wantValue.(map[string]interface{})
+		gotNested, gotIsMap := gotValue.(map[string]interface{})
+		if wantIsMap != gotIsMap {
+			t.Errorf("%s[%q] = %#v, want %#v", label, key, gotValue, wantValue)
+			continue
+		}
+		if wantIsMap {
+			assertJSONMapEqual(t, label+"["+key+"]", gotNested, wantNested)
+			continue
+		}
+		if gotValue != wantValue {
+			t.Errorf("%s[%q] = %#v, want %#v", label, key, gotValue, wantValue)
+		}
+	}
+}
+
+func TestCreateGitSnapshotRoundTripsEveryField(t *testing.T) {
+	repo := newRepoForSessionTests(t)
+	ctx := context.Background()
+	seedSessionForGit(t, repo, "task-snap-full", "session-snap-full")
+
+	createdAt := time.Date(2026, 3, 4, 5, 6, 7, 123456000, time.UTC)
+	want := fullGitSnapshot("session-snap-full", createdAt)
+	if err := repo.CreateGitSnapshot(ctx, want); err != nil {
+		t.Fatalf("CreateGitSnapshot: %v", err)
+	}
+
+	got, err := repo.GetLatestGitSnapshot(ctx, "session-snap-full")
+	if err != nil {
+		t.Fatalf("GetLatestGitSnapshot: %v", err)
+	}
+	assertGitSnapshotEqual(t, got, want)
+
+	// The same row must survive the other three read paths identically.
+	first, err := repo.GetFirstGitSnapshot(ctx, "session-snap-full")
+	if err != nil {
+		t.Fatalf("GetFirstGitSnapshot: %v", err)
+	}
+	assertGitSnapshotEqual(t, first, want)
+
+	listed, err := repo.GetGitSnapshotsBySession(ctx, "session-snap-full", 0)
+	if err != nil {
+		t.Fatalf("GetGitSnapshotsBySession: %v", err)
+	}
+	if len(listed) != 1 {
+		t.Fatalf("GetGitSnapshotsBySession returned %d rows, want 1", len(listed))
+	}
+	assertGitSnapshotEqual(t, listed[0], want)
+
+	batch, err := repo.GetLatestGitSnapshotsBySessionIDs(ctx, []string{"session-snap-full"})
+	if err != nil {
+		t.Fatalf("GetLatestGitSnapshotsBySessionIDs: %v", err)
+	}
+	if len(batch) != 1 {
+		t.Fatalf("batch returned %d entries, want 1", len(batch))
+	}
+	assertGitSnapshotEqual(t, batch["session-snap-full"], want)
+}
+
+func TestCreateGitSnapshotDefaultsIDAndCreatedAt(t *testing.T) {
+	repo := newRepoForSessionTests(t)
+	ctx := context.Background()
+	seedSessionForGit(t, repo, "task-snap-defaults", "session-snap-defaults")
+
+	before := time.Now().UTC().Add(-time.Second)
+	snapshot := &models.GitSnapshot{
+		SessionID:    "session-snap-defaults",
+		SnapshotType: models.SnapshotTypeStatusUpdate,
+		Branch:       "main",
+	}
+	if err := repo.CreateGitSnapshot(ctx, snapshot); err != nil {
+		t.Fatalf("CreateGitSnapshot: %v", err)
+	}
+	if snapshot.ID == "" {
+		t.Fatal("CreateGitSnapshot left ID empty; a UUID should have been generated")
+	}
+	if snapshot.CreatedAt.Before(before) {
+		t.Fatalf("CreatedAt = %v, want a freshly stamped time after %v", snapshot.CreatedAt, before)
+	}
+
+	got, err := repo.GetLatestGitSnapshot(ctx, "session-snap-defaults")
+	if err != nil {
+		t.Fatalf("GetLatestGitSnapshot: %v", err)
+	}
+	if got.ID != snapshot.ID {
+		t.Errorf("persisted ID = %q, want the generated %q", got.ID, snapshot.ID)
+	}
+	// Files/Metadata were nil on the way in; they serialize to "{}" and must
+	// come back nil rather than as an empty-but-non-nil map.
+	if got.Files != nil {
+		t.Errorf("Files = %#v, want nil for a snapshot written without files", got.Files)
+	}
+	if got.Metadata != nil {
+		t.Errorf("Metadata = %#v, want nil for a snapshot written without metadata", got.Metadata)
+	}
+}
+
+func TestCreateGitSnapshotEmptyMapsReadBackAsNil(t *testing.T) {
+	repo := newRepoForSessionTests(t)
+	ctx := context.Background()
+	seedSessionForGit(t, repo, "task-snap-empty", "session-snap-empty")
+
+	if err := repo.CreateGitSnapshot(ctx, &models.GitSnapshot{
+		ID: "snapshot-empty", SessionID: "session-snap-empty",
+		SnapshotType: models.SnapshotTypeStatusUpdate, Branch: "main",
+		Files:    map[string]interface{}{},
+		Metadata: map[string]interface{}{},
+	}); err != nil {
+		t.Fatalf("CreateGitSnapshot: %v", err)
+	}
+
+	got, err := repo.GetLatestGitSnapshot(ctx, "session-snap-empty")
+	if err != nil {
+		t.Fatalf("GetLatestGitSnapshot: %v", err)
+	}
+	if got.Files != nil {
+		t.Errorf("Files = %#v, want nil (an empty map serializes to the {} sentinel)", got.Files)
+	}
+	if got.Metadata != nil {
+		t.Errorf("Metadata = %#v, want nil (an empty map serializes to the {} sentinel)", got.Metadata)
+	}
+}
+
+func TestCreateGitSnapshotRejectsUnserializableFiles(t *testing.T) {
+	repo := newRepoForSessionTests(t)
+	ctx := context.Background()
+	seedSessionForGit(t, repo, "task-snap-bad", "session-snap-bad")
+
+	err := repo.CreateGitSnapshot(ctx, &models.GitSnapshot{
+		ID: "snapshot-bad", SessionID: "session-snap-bad",
+		SnapshotType: models.SnapshotTypeStatusUpdate, Branch: "main",
+		Files: map[string]interface{}{"chan": make(chan int)},
+	})
+	if err == nil {
+		t.Fatal("CreateGitSnapshot accepted an unserializable Files map")
+	}
+	if got := countRows(t, repo, `SELECT COUNT(1) FROM task_session_git_snapshots WHERE session_id = ?`, "session-snap-bad"); got != 0 {
+		t.Errorf("rows after a failed serialize = %d, want 0", got)
+	}
+}
+
+func TestGetLatestGitSnapshotPrefersAgentCompletedOverNewerLiveMonitor(t *testing.T) {
+	repo := newRepoForSessionTests(t)
+	ctx := context.Background()
+	seedSessionForGit(t, repo, "task-snap-prefer", "session-snap-prefer")
+
+	base := time.Date(2026, 2, 1, 12, 0, 0, 0, time.UTC)
+	if err := repo.CreateGitSnapshot(ctx, &models.GitSnapshot{
+		ID: "snap-completed", SessionID: "session-snap-prefer",
+		SnapshotType: models.SnapshotTypeStatusUpdate, Branch: "main",
+		TriggeredBy: "agent_completed", HeadCommit: "authoritative", CreatedAt: base,
+	}); err != nil {
+		t.Fatalf("CreateGitSnapshot(agent_completed): %v", err)
+	}
+	if err := repo.CreateGitSnapshot(ctx, &models.GitSnapshot{
+		ID: "snap-live", SessionID: "session-snap-prefer",
+		SnapshotType: models.SnapshotTypeStatusUpdate, Branch: "main",
+		TriggeredBy: TriggeredByLiveMonitor, HeadCommit: "stale-poll", CreatedAt: base.Add(time.Hour),
+	}); err != nil {
+		t.Fatalf("CreateGitSnapshot(live_monitor): %v", err)
+	}
+
+	got, err := repo.GetLatestGitSnapshot(ctx, "session-snap-prefer")
+	if err != nil {
+		t.Fatalf("GetLatestGitSnapshot: %v", err)
+	}
+	if got.ID != "snap-completed" {
+		t.Errorf("GetLatestGitSnapshot returned %q (head %q), want the agent_completed row", got.ID, got.HeadCommit)
+	}
+
+	batch, err := repo.GetLatestGitSnapshotsBySessionIDs(ctx, []string{"session-snap-prefer"})
+	if err != nil {
+		t.Fatalf("GetLatestGitSnapshotsBySessionIDs: %v", err)
+	}
+	if batch["session-snap-prefer"].ID != "snap-completed" {
+		t.Errorf("batch returned %q, want the agent_completed row (must mirror GetLatestGitSnapshot)", batch["session-snap-prefer"].ID)
+	}
+}
+
+func TestGetLatestGitSnapshotFallsBackToNewestWithoutAgentCompleted(t *testing.T) {
+	repo := newRepoForSessionTests(t)
+	ctx := context.Background()
+	seedSessionForGit(t, repo, "task-snap-newest", "session-snap-newest")
+
+	base := time.Date(2026, 2, 1, 12, 0, 0, 0, time.UTC)
+	for i, id := range []string{"snap-old", "snap-mid", "snap-new"} {
+		if err := repo.CreateGitSnapshot(ctx, &models.GitSnapshot{
+			ID: id, SessionID: "session-snap-newest",
+			SnapshotType: models.SnapshotTypeStatusUpdate, Branch: "main",
+			TriggeredBy: TriggeredByLiveMonitor, CreatedAt: base.Add(time.Duration(i) * time.Hour),
+		}); err != nil {
+			t.Fatalf("CreateGitSnapshot(%s): %v", id, err)
+		}
+	}
+
+	got, err := repo.GetLatestGitSnapshot(ctx, "session-snap-newest")
+	if err != nil {
+		t.Fatalf("GetLatestGitSnapshot: %v", err)
+	}
+	if got.ID != "snap-new" {
+		t.Errorf("GetLatestGitSnapshot = %q, want snap-new (most recent by created_at)", got.ID)
+	}
+
+	first, err := repo.GetFirstGitSnapshot(ctx, "session-snap-newest")
+	if err != nil {
+		t.Fatalf("GetFirstGitSnapshot: %v", err)
+	}
+	if first.ID != "snap-old" {
+		t.Errorf("GetFirstGitSnapshot = %q, want snap-old (oldest by created_at)", first.ID)
+	}
+}
+
+func TestGitSnapshotReadsReturnErrNoRowsForUnknownSession(t *testing.T) {
+	repo := newRepoForSessionTests(t)
+	ctx := context.Background()
+
+	if _, err := repo.GetLatestGitSnapshot(ctx, "session-missing"); !errors.Is(err, sql.ErrNoRows) {
+		t.Errorf("GetLatestGitSnapshot error = %v, want sql.ErrNoRows", err)
+	}
+	if _, err := repo.GetFirstGitSnapshot(ctx, "session-missing"); !errors.Is(err, sql.ErrNoRows) {
+		t.Errorf("GetFirstGitSnapshot error = %v, want sql.ErrNoRows", err)
+	}
+	if _, err := repo.GetLatestSessionCommit(ctx, "session-missing"); !errors.Is(err, sql.ErrNoRows) {
+		t.Errorf("GetLatestSessionCommit error = %v, want sql.ErrNoRows", err)
+	}
+
+	snapshots, err := repo.GetGitSnapshotsBySession(ctx, "session-missing", 0)
+	if err != nil {
+		t.Fatalf("GetGitSnapshotsBySession: %v", err)
+	}
+	if len(snapshots) != 0 {
+		t.Errorf("GetGitSnapshotsBySession = %v, want empty", snapshots)
+	}
+	commits, err := repo.GetSessionCommits(ctx, "session-missing")
+	if err != nil {
+		t.Fatalf("GetSessionCommits: %v", err)
+	}
+	if len(commits) != 0 {
+		t.Errorf("GetSessionCommits = %v, want empty", commits)
+	}
+}
+
+func TestGetGitSnapshotsBySessionOrdersDescendingAndHonoursLimit(t *testing.T) {
+	repo := newRepoForSessionTests(t)
+	ctx := context.Background()
+	seedSessionForGit(t, repo, "task-snap-list", "session-snap-list")
+	seedSessionForGit(t, repo, "task-snap-other", "session-snap-other")
+
+	base := time.Date(2026, 5, 5, 8, 0, 0, 0, time.UTC)
+	for i, id := range []string{"list-1", "list-2", "list-3"} {
+		if err := repo.CreateGitSnapshot(ctx, &models.GitSnapshot{
+			ID: id, SessionID: "session-snap-list",
+			SnapshotType: models.SnapshotTypeStatusUpdate, Branch: "main",
+			CreatedAt: base.Add(time.Duration(i) * time.Minute),
+		}); err != nil {
+			t.Fatalf("CreateGitSnapshot(%s): %v", id, err)
+		}
+	}
+	// A snapshot on a different session must never leak into the results.
+	if err := repo.CreateGitSnapshot(ctx, &models.GitSnapshot{
+		ID: "other-1", SessionID: "session-snap-other",
+		SnapshotType: models.SnapshotTypeStatusUpdate, Branch: "main", CreatedAt: base.Add(time.Hour),
+	}); err != nil {
+		t.Fatalf("CreateGitSnapshot(other): %v", err)
+	}
+
+	all, err := repo.GetGitSnapshotsBySession(ctx, "session-snap-list", 0)
+	if err != nil {
+		t.Fatalf("GetGitSnapshotsBySession(limit=0): %v", err)
+	}
+	gotIDs := make([]string, 0, len(all))
+	for _, snapshot := range all {
+		gotIDs = append(gotIDs, snapshot.ID)
+	}
+	wantIDs := []string{"list-3", "list-2", "list-1"}
+	if len(gotIDs) != len(wantIDs) {
+		t.Fatalf("limit=0 returned %v, want %v", gotIDs, wantIDs)
+	}
+	for i := range wantIDs {
+		if gotIDs[i] != wantIDs[i] {
+			t.Fatalf("limit=0 returned %v, want %v (newest first)", gotIDs, wantIDs)
+		}
+	}
+
+	limited, err := repo.GetGitSnapshotsBySession(ctx, "session-snap-list", 2)
+	if err != nil {
+		t.Fatalf("GetGitSnapshotsBySession(limit=2): %v", err)
+	}
+	if len(limited) != 2 {
+		t.Fatalf("limit=2 returned %d rows, want 2", len(limited))
+	}
+	if limited[0].ID != "list-3" || limited[1].ID != "list-2" {
+		t.Errorf("limit=2 returned %q,%q, want list-3,list-2", limited[0].ID, limited[1].ID)
+	}
+
+	negative, err := repo.GetGitSnapshotsBySession(ctx, "session-snap-list", -1)
+	if err != nil {
+		t.Fatalf("GetGitSnapshotsBySession(limit=-1): %v", err)
+	}
+	if len(negative) != 3 {
+		t.Errorf("limit=-1 returned %d rows, want all 3", len(negative))
+	}
+}
+
+func TestUpsertLatestLiveGitSnapshotKeepsOneLiveRowPerSession(t *testing.T) {
+	repo := newRepoForSessionTests(t)
+	ctx := context.Background()
+	seedSessionForGit(t, repo, "task-snap-upsert", "session-snap-upsert")
+
+	base := time.Date(2026, 6, 1, 9, 0, 0, 0, time.UTC)
+	// An archive snapshot that the live upsert must not disturb.
+	if err := repo.CreateGitSnapshot(ctx, &models.GitSnapshot{
+		ID: "archive-row", SessionID: "session-snap-upsert",
+		SnapshotType: models.SnapshotTypeArchive, Branch: "main",
+		TriggeredBy: "task_archived", CreatedAt: base,
+	}); err != nil {
+		t.Fatalf("CreateGitSnapshot(archive): %v", err)
+	}
+
+	first := &models.GitSnapshot{
+		ID: "live-1", SessionID: "session-snap-upsert", Branch: "main",
+		HeadCommit: "first-head", CreatedAt: base.Add(time.Minute),
+		// Deliberately wrong: the method must force these two fields.
+		SnapshotType: models.SnapshotTypeArchive, TriggeredBy: "someone-else",
+	}
+	if err := repo.UpsertLatestLiveGitSnapshot(ctx, first); err != nil {
+		t.Fatalf("UpsertLatestLiveGitSnapshot(first): %v", err)
+	}
+	if first.SnapshotType != models.SnapshotTypeStatusUpdate {
+		t.Errorf("SnapshotType = %q, want it forced to %q", first.SnapshotType, models.SnapshotTypeStatusUpdate)
+	}
+	if first.TriggeredBy != TriggeredByLiveMonitor {
+		t.Errorf("TriggeredBy = %q, want it forced to %q", first.TriggeredBy, TriggeredByLiveMonitor)
+	}
+
+	second := &models.GitSnapshot{
+		ID: "live-2", SessionID: "session-snap-upsert", Branch: "main",
+		HeadCommit: "second-head", Ahead: 4, CreatedAt: base.Add(2 * time.Minute),
+		Files: map[string]interface{}{"a.go": "modified"},
+	}
+	if err := repo.UpsertLatestLiveGitSnapshot(ctx, second); err != nil {
+		t.Fatalf("UpsertLatestLiveGitSnapshot(second): %v", err)
+	}
+
+	liveRows := countRows(t, repo,
+		`SELECT COUNT(1) FROM task_session_git_snapshots WHERE session_id = ? AND triggered_by = ?`,
+		"session-snap-upsert", TriggeredByLiveMonitor)
+	if liveRows != 1 {
+		t.Errorf("live_monitor rows = %d, want exactly 1 after two upserts", liveRows)
+	}
+	archiveRows := countRows(t, repo,
+		`SELECT COUNT(1) FROM task_session_git_snapshots WHERE session_id = ? AND snapshot_type = ?`,
+		"session-snap-upsert", string(models.SnapshotTypeArchive))
+	if archiveRows != 1 {
+		t.Errorf("archive rows = %d, want the pre-existing archive snapshot untouched", archiveRows)
+	}
+
+	all, err := repo.GetGitSnapshotsBySession(ctx, "session-snap-upsert", 0)
+	if err != nil {
+		t.Fatalf("GetGitSnapshotsBySession: %v", err)
+	}
+	if len(all) != 2 {
+		t.Fatalf("session has %d snapshots, want 2 (archive + one live)", len(all))
+	}
+	if all[0].ID != "live-2" || all[0].HeadCommit != "second-head" || all[0].Ahead != 4 {
+		t.Errorf("newest snapshot = %+v, want the second live upsert", all[0])
+	}
+	assertJSONMapEqual(t, "Files", all[0].Files, map[string]interface{}{"a.go": "modified"})
+}
+
+func TestUpsertLatestLiveGitSnapshotGeneratesIDAndRejectsNil(t *testing.T) {
+	repo := newRepoForSessionTests(t)
+	ctx := context.Background()
+	seedSessionForGit(t, repo, "task-snap-nil", "session-snap-nil")
+
+	if err := repo.UpsertLatestLiveGitSnapshot(ctx, nil); err == nil {
+		t.Fatal("UpsertLatestLiveGitSnapshot(nil) returned nil error")
+	}
+
+	snapshot := &models.GitSnapshot{SessionID: "session-snap-nil", Branch: "main"}
+	before := time.Now().UTC().Add(-time.Second)
+	if err := repo.UpsertLatestLiveGitSnapshot(ctx, snapshot); err != nil {
+		t.Fatalf("UpsertLatestLiveGitSnapshot: %v", err)
+	}
+	if snapshot.ID == "" {
+		t.Error("ID was left empty; a UUID should have been generated")
+	}
+	if snapshot.CreatedAt.Before(before) {
+		t.Errorf("CreatedAt = %v, want a freshly stamped time after %v", snapshot.CreatedAt, before)
+	}
+	got, err := repo.GetLatestGitSnapshot(ctx, "session-snap-nil")
+	if err != nil {
+		t.Fatalf("GetLatestGitSnapshot: %v", err)
+	}
+	if got.ID != snapshot.ID {
+		t.Errorf("persisted ID = %q, want %q", got.ID, snapshot.ID)
+	}
+}
+
+func TestDeleteLiveMonitorSnapshotsRemovesOnlyLiveRows(t *testing.T) {
+	repo := newRepoForSessionTests(t)
+	ctx := context.Background()
+	seedSessionForGit(t, repo, "task-snap-del", "session-snap-del")
+	seedSessionForGit(t, repo, "task-snap-keep", "session-snap-keep")
+
+	base := time.Date(2026, 7, 1, 10, 0, 0, 0, time.UTC)
+	rows := []*models.GitSnapshot{
+		{ID: "del-live", SessionID: "session-snap-del", SnapshotType: models.SnapshotTypeStatusUpdate,
+			Branch: "main", TriggeredBy: TriggeredByLiveMonitor, CreatedAt: base},
+		{ID: "del-completed", SessionID: "session-snap-del", SnapshotType: models.SnapshotTypeStatusUpdate,
+			Branch: "main", TriggeredBy: "agent_completed", CreatedAt: base.Add(time.Minute)},
+		{ID: "keep-live", SessionID: "session-snap-keep", SnapshotType: models.SnapshotTypeStatusUpdate,
+			Branch: "main", TriggeredBy: TriggeredByLiveMonitor, CreatedAt: base},
+	}
+	for _, row := range rows {
+		if err := repo.CreateGitSnapshot(ctx, row); err != nil {
+			t.Fatalf("CreateGitSnapshot(%s): %v", row.ID, err)
+		}
+	}
+
+	if err := repo.DeleteLiveMonitorSnapshots(ctx, "session-snap-del"); err != nil {
+		t.Fatalf("DeleteLiveMonitorSnapshots: %v", err)
+	}
+
+	remaining, err := repo.GetGitSnapshotsBySession(ctx, "session-snap-del", 0)
+	if err != nil {
+		t.Fatalf("GetGitSnapshotsBySession: %v", err)
+	}
+	if len(remaining) != 1 || remaining[0].ID != "del-completed" {
+		t.Errorf("remaining snapshots = %+v, want only del-completed", remaining)
+	}
+	if got := countRows(t, repo,
+		`SELECT COUNT(1) FROM task_session_git_snapshots WHERE session_id = ?`, "session-snap-keep"); got != 1 {
+		t.Errorf("other session rows = %d, want 1 (delete must be session-scoped)", got)
+	}
+
+	// Deleting again is a no-op, not an error.
+	if err := repo.DeleteLiveMonitorSnapshots(ctx, "session-snap-del"); err != nil {
+		t.Errorf("second DeleteLiveMonitorSnapshots: %v", err)
+	}
+}
+
+func TestGetLatestGitSnapshotsBySessionIDsBatchesAndSkipsUnknown(t *testing.T) {
+	repo := newRepoForSessionTests(t)
+	ctx := context.Background()
+	base := time.Date(2026, 8, 1, 11, 0, 0, 0, time.UTC)
+	for i, suffix := range []string{"a", "b"} {
+		seedSessionForGit(t, repo, "task-batch-"+suffix, "session-batch-"+suffix)
+		if err := repo.CreateGitSnapshot(ctx, &models.GitSnapshot{
+			ID: "batch-old-" + suffix, SessionID: "session-batch-" + suffix,
+			SnapshotType: models.SnapshotTypeStatusUpdate, Branch: "main",
+			TriggeredBy: TriggeredByLiveMonitor, CreatedAt: base.Add(time.Duration(i) * time.Minute),
+		}); err != nil {
+			t.Fatalf("CreateGitSnapshot(old %s): %v", suffix, err)
+		}
+		if err := repo.CreateGitSnapshot(ctx, &models.GitSnapshot{
+			ID: "batch-new-" + suffix, SessionID: "session-batch-" + suffix,
+			SnapshotType: models.SnapshotTypeStatusUpdate, Branch: "main",
+			TriggeredBy: TriggeredByLiveMonitor, HeadCommit: "newest-" + suffix,
+			CreatedAt: base.Add(time.Hour + time.Duration(i)*time.Minute),
+		}); err != nil {
+			t.Fatalf("CreateGitSnapshot(new %s): %v", suffix, err)
+		}
+	}
+
+	got, err := repo.GetLatestGitSnapshotsBySessionIDs(ctx,
+		[]string{"session-batch-a", "session-batch-b", "session-batch-missing"})
+	if err != nil {
+		t.Fatalf("GetLatestGitSnapshotsBySessionIDs: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("map has %d entries (%v), want 2 — unknown sessions must be absent", len(got), got)
+	}
+	for _, suffix := range []string{"a", "b"} {
+		entry, ok := got["session-batch-"+suffix]
+		if !ok {
+			t.Fatalf("missing entry for session-batch-%s", suffix)
+		}
+		if entry.ID != "batch-new-"+suffix {
+			t.Errorf("session-batch-%s = %q, want batch-new-%s (one row per session, newest)", suffix, entry.ID, suffix)
+		}
+		if entry.HeadCommit != "newest-"+suffix {
+			t.Errorf("session-batch-%s head = %q, want newest-%s", suffix, entry.HeadCommit, suffix)
+		}
+	}
+
+	empty, err := repo.GetLatestGitSnapshotsBySessionIDs(ctx, nil)
+	if err != nil {
+		t.Fatalf("GetLatestGitSnapshotsBySessionIDs(nil): %v", err)
+	}
+	if len(empty) != 0 {
+		t.Errorf("nil input returned %v, want an empty map", empty)
+	}
+}
+
+func TestGetLatestGitSnapshotsBySessionIDsChunksBeyondHostParamLimit(t *testing.T) {
+	repo := newRepoForSessionTests(t)
+	ctx := context.Background()
+
+	// Two sessions carry snapshots; the ID list is padded past
+	// sqliteMaxHostParams so the chunking loop runs more than once.
+	seedSessionForGit(t, repo, "task-chunk-real", "session-chunk-real")
+	if err := repo.CreateGitSnapshot(ctx, &models.GitSnapshot{
+		ID: "chunk-real", SessionID: "session-chunk-real",
+		SnapshotType: models.SnapshotTypeStatusUpdate, Branch: "main",
+		CreatedAt: time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC),
+	}); err != nil {
+		t.Fatalf("CreateGitSnapshot: %v", err)
+	}
+
+	ids := make([]string, 0, sqliteMaxHostParams+2)
+	for i := 0; i < sqliteMaxHostParams+1; i++ {
+		ids = append(ids, "session-chunk-pad-"+time.Duration(i).String())
+	}
+	ids = append(ids, "session-chunk-real")
+
+	got, err := repo.GetLatestGitSnapshotsBySessionIDs(ctx, ids)
+	if err != nil {
+		t.Fatalf("GetLatestGitSnapshotsBySessionIDs: %v", err)
+	}
+	if len(got) != 1 || got["session-chunk-real"] == nil {
+		t.Fatalf("map = %v, want exactly the one real session", got)
+	}
+	if got["session-chunk-real"].ID != "chunk-real" {
+		t.Errorf("entry = %q, want chunk-real", got["session-chunk-real"].ID)
+	}
+}
+
+func TestGitSnapshotsAndCommitsCascadeOnSessionDelete(t *testing.T) {
+	repo := newRepoForSessionTests(t)
+	ctx := context.Background()
+	seedSessionForGit(t, repo, "task-cascade", "session-cascade")
+
+	if err := repo.CreateGitSnapshot(ctx, &models.GitSnapshot{
+		ID: "cascade-snap", SessionID: "session-cascade",
+		SnapshotType: models.SnapshotTypeStatusUpdate, Branch: "main",
+		CreatedAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	}); err != nil {
+		t.Fatalf("CreateGitSnapshot: %v", err)
+	}
+	if err := repo.CreateSessionCommit(ctx, &models.SessionCommit{
+		ID: "cascade-commit", SessionID: "session-cascade", CommitSHA: "abc123",
+		CommittedAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	}); err != nil {
+		t.Fatalf("CreateSessionCommit: %v", err)
+	}
+
+	if err := repo.DeleteTaskSession(ctx, "session-cascade"); err != nil {
+		t.Fatalf("DeleteTaskSession: %v", err)
+	}
+
+	if got := countRows(t, repo,
+		`SELECT COUNT(1) FROM task_session_git_snapshots WHERE session_id = ?`, "session-cascade"); got != 0 {
+		t.Errorf("git snapshot rows after session delete = %d, want 0 (FK cascade)", got)
+	}
+	if got := countRows(t, repo,
+		`SELECT COUNT(1) FROM task_session_commits WHERE session_id = ?`, "session-cascade"); got != 0 {
+		t.Errorf("commit rows after session delete = %d, want 0 (FK cascade)", got)
+	}
+}
+
+func TestCreateSessionCommitRoundTripsEveryField(t *testing.T) {
+	repo := newRepoForSessionTests(t)
+	ctx := context.Background()
+	seedSessionForGit(t, repo, "task-commit-full", "session-commit-full")
+
+	want := &models.SessionCommit{
+		ID:                   "commit-full",
+		SessionID:            "session-commit-full",
+		CommitSHA:            "0123456789abcdef",
+		ParentSHA:            "fedcba9876543210",
+		AuthorName:           "Kandev Agent",
+		AuthorEmail:          "agent@kandev.local",
+		CommitMessage:        "feat: round-trip every column",
+		CommittedAt:          time.Date(2026, 4, 2, 3, 4, 5, 678000000, time.UTC),
+		PreCommitSnapshotID:  "pre-snap",
+		PostCommitSnapshotID: "post-snap",
+		FilesChanged:         9,
+		Insertions:           123,
+		Deletions:            45,
+		CreatedAt:            time.Date(2026, 4, 2, 3, 4, 6, 0, time.UTC),
+	}
+	if err := repo.CreateSessionCommit(ctx, want); err != nil {
+		t.Fatalf("CreateSessionCommit: %v", err)
+	}
+
+	got, err := repo.GetLatestSessionCommit(ctx, "session-commit-full")
+	if err != nil {
+		t.Fatalf("GetLatestSessionCommit: %v", err)
+	}
+	assertSessionCommitEqual(t, got, want)
+
+	listed, err := repo.GetSessionCommits(ctx, "session-commit-full")
+	if err != nil {
+		t.Fatalf("GetSessionCommits: %v", err)
+	}
+	if len(listed) != 1 {
+		t.Fatalf("GetSessionCommits returned %d rows, want 1", len(listed))
+	}
+	assertSessionCommitEqual(t, listed[0], want)
+}
+
+func assertSessionCommitEqual(t *testing.T, got, want *models.SessionCommit) {
+	t.Helper()
+	if got.ID != want.ID {
+		t.Errorf("ID = %q, want %q", got.ID, want.ID)
+	}
+	if got.SessionID != want.SessionID {
+		t.Errorf("SessionID = %q, want %q", got.SessionID, want.SessionID)
+	}
+	if got.CommitSHA != want.CommitSHA {
+		t.Errorf("CommitSHA = %q, want %q", got.CommitSHA, want.CommitSHA)
+	}
+	if got.ParentSHA != want.ParentSHA {
+		t.Errorf("ParentSHA = %q, want %q", got.ParentSHA, want.ParentSHA)
+	}
+	if got.AuthorName != want.AuthorName {
+		t.Errorf("AuthorName = %q, want %q", got.AuthorName, want.AuthorName)
+	}
+	if got.AuthorEmail != want.AuthorEmail {
+		t.Errorf("AuthorEmail = %q, want %q", got.AuthorEmail, want.AuthorEmail)
+	}
+	if got.CommitMessage != want.CommitMessage {
+		t.Errorf("CommitMessage = %q, want %q", got.CommitMessage, want.CommitMessage)
+	}
+	assertTimeEqual(t, "CommittedAt", got.CommittedAt, want.CommittedAt)
+	if got.PreCommitSnapshotID != want.PreCommitSnapshotID {
+		t.Errorf("PreCommitSnapshotID = %q, want %q", got.PreCommitSnapshotID, want.PreCommitSnapshotID)
+	}
+	if got.PostCommitSnapshotID != want.PostCommitSnapshotID {
+		t.Errorf("PostCommitSnapshotID = %q, want %q", got.PostCommitSnapshotID, want.PostCommitSnapshotID)
+	}
+	if got.FilesChanged != want.FilesChanged {
+		t.Errorf("FilesChanged = %d, want %d", got.FilesChanged, want.FilesChanged)
+	}
+	if got.Insertions != want.Insertions {
+		t.Errorf("Insertions = %d, want %d", got.Insertions, want.Insertions)
+	}
+	if got.Deletions != want.Deletions {
+		t.Errorf("Deletions = %d, want %d", got.Deletions, want.Deletions)
+	}
+	assertTimeEqual(t, "CreatedAt", got.CreatedAt, want.CreatedAt)
+}
+
+func TestCreateSessionCommitDefaultsIDAndCreatedAt(t *testing.T) {
+	repo := newRepoForSessionTests(t)
+	ctx := context.Background()
+	seedSessionForGit(t, repo, "task-commit-defaults", "session-commit-defaults")
+
+	before := time.Now().UTC().Add(-time.Second)
+	commit := &models.SessionCommit{
+		SessionID: "session-commit-defaults", CommitSHA: "deadbeef",
+		CommittedAt: time.Date(2026, 4, 2, 3, 4, 5, 0, time.UTC),
+	}
+	if err := repo.CreateSessionCommit(ctx, commit); err != nil {
+		t.Fatalf("CreateSessionCommit: %v", err)
+	}
+	if commit.ID == "" {
+		t.Fatal("ID was left empty; a UUID should have been generated")
+	}
+	if commit.CreatedAt.Before(before) {
+		t.Errorf("CreatedAt = %v, want a freshly stamped time after %v", commit.CreatedAt, before)
+	}
+	got, err := repo.GetLatestSessionCommit(ctx, "session-commit-defaults")
+	if err != nil {
+		t.Fatalf("GetLatestSessionCommit: %v", err)
+	}
+	if got.ID != commit.ID {
+		t.Errorf("persisted ID = %q, want %q", got.ID, commit.ID)
+	}
+}
+
+func TestGetSessionCommitsOrdersByCommittedAtDescending(t *testing.T) {
+	repo := newRepoForSessionTests(t)
+	ctx := context.Background()
+	seedSessionForGit(t, repo, "task-commit-order", "session-commit-order")
+	seedSessionForGit(t, repo, "task-commit-noise", "session-commit-noise")
+
+	base := time.Date(2026, 4, 10, 0, 0, 0, 0, time.UTC)
+	for i, id := range []string{"c1", "c2", "c3"} {
+		if err := repo.CreateSessionCommit(ctx, &models.SessionCommit{
+			ID: id, SessionID: "session-commit-order", CommitSHA: id,
+			CommittedAt: base.Add(time.Duration(i) * time.Hour),
+		}); err != nil {
+			t.Fatalf("CreateSessionCommit(%s): %v", id, err)
+		}
+	}
+	if err := repo.CreateSessionCommit(ctx, &models.SessionCommit{
+		ID: "noise", SessionID: "session-commit-noise", CommitSHA: "noise",
+		CommittedAt: base.Add(10 * time.Hour),
+	}); err != nil {
+		t.Fatalf("CreateSessionCommit(noise): %v", err)
+	}
+
+	got, err := repo.GetSessionCommits(ctx, "session-commit-order")
+	if err != nil {
+		t.Fatalf("GetSessionCommits: %v", err)
+	}
+	want := []string{"c3", "c2", "c1"}
+	if len(got) != len(want) {
+		t.Fatalf("GetSessionCommits returned %d rows, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i].ID != want[i] {
+			t.Fatalf("GetSessionCommits order = %q at index %d, want %q", got[i].ID, i, want[i])
+		}
+	}
+
+	latest, err := repo.GetLatestSessionCommit(ctx, "session-commit-order")
+	if err != nil {
+		t.Fatalf("GetLatestSessionCommit: %v", err)
+	}
+	if latest.ID != "c3" {
+		t.Errorf("GetLatestSessionCommit = %q, want c3", latest.ID)
+	}
+}
+
+func TestDeleteSessionCommitRemovesOnlyTheTargetRow(t *testing.T) {
+	repo := newRepoForSessionTests(t)
+	ctx := context.Background()
+	seedSessionForGit(t, repo, "task-commit-del", "session-commit-del")
+
+	base := time.Date(2026, 4, 20, 0, 0, 0, 0, time.UTC)
+	for i, id := range []string{"keep-1", "drop-me", "keep-2"} {
+		if err := repo.CreateSessionCommit(ctx, &models.SessionCommit{
+			ID: id, SessionID: "session-commit-del", CommitSHA: id,
+			CommittedAt: base.Add(time.Duration(i) * time.Hour),
+		}); err != nil {
+			t.Fatalf("CreateSessionCommit(%s): %v", id, err)
+		}
+	}
+
+	if err := repo.DeleteSessionCommit(ctx, "drop-me"); err != nil {
+		t.Fatalf("DeleteSessionCommit: %v", err)
+	}
+	if got := countRows(t, repo,
+		`SELECT COUNT(1) FROM task_session_commits WHERE session_id = ?`, "session-commit-del"); got != 2 {
+		t.Errorf("rows after delete = %d, want 2", got)
+	}
+	remaining, err := repo.GetSessionCommits(ctx, "session-commit-del")
+	if err != nil {
+		t.Fatalf("GetSessionCommits: %v", err)
+	}
+	for _, commit := range remaining {
+		if commit.ID == "drop-me" {
+			t.Fatalf("deleted commit still present: %+v", commit)
+		}
+	}
+
+	// Deleting an unknown id is a tolerated no-op (no sentinel).
+	if err := repo.DeleteSessionCommit(ctx, "never-existed"); err != nil {
+		t.Errorf("DeleteSessionCommit(unknown): %v", err)
+	}
+	if got := countRows(t, repo,
+		`SELECT COUNT(1) FROM task_session_commits WHERE session_id = ?`, "session-commit-del"); got != 2 {
+		t.Errorf("rows after no-op delete = %d, want 2", got)
+	}
+}
+
+func TestGitSnapshotMethodsPropagateBackendErrors(t *testing.T) {
+	repo := newRepoForSessionTests(t)
+	ctx := context.Background()
+	seedSessionForGit(t, repo, "task-git-broken", "session-git-broken")
+	closeRepoDB(t, repo)
+
+	snapshot := &models.GitSnapshot{
+		ID: "snap-broken", SessionID: "session-git-broken",
+		SnapshotType: models.SnapshotTypeStatusUpdate, Branch: "main",
+		CreatedAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+	if err := repo.CreateGitSnapshot(ctx, snapshot); err == nil {
+		t.Error("CreateGitSnapshot on a closed database returned nil")
+	}
+	if err := repo.UpsertLatestLiveGitSnapshot(ctx, snapshot); err == nil {
+		t.Error("UpsertLatestLiveGitSnapshot on a closed database returned nil")
+	}
+	if err := repo.DeleteLiveMonitorSnapshots(ctx, "session-git-broken"); err == nil {
+		t.Error("DeleteLiveMonitorSnapshots on a closed database returned nil")
+	}
+	if _, err := repo.GetLatestGitSnapshot(ctx, "session-git-broken"); err == nil {
+		t.Error("GetLatestGitSnapshot on a closed database returned nil")
+	}
+	if _, err := repo.GetFirstGitSnapshot(ctx, "session-git-broken"); err == nil {
+		t.Error("GetFirstGitSnapshot on a closed database returned nil")
+	}
+	if _, err := repo.GetGitSnapshotsBySession(ctx, "session-git-broken", 0); err == nil {
+		t.Error("GetGitSnapshotsBySession on a closed database returned nil")
+	}
+	if _, err := repo.GetLatestGitSnapshotsBySessionIDs(ctx, []string{"session-git-broken"}); err == nil {
+		t.Error("GetLatestGitSnapshotsBySessionIDs on a closed database returned nil")
+	}
+	if err := repo.CreateSessionCommit(ctx, &models.SessionCommit{
+		ID: "commit-broken", SessionID: "session-git-broken", CommitSHA: "x",
+		CommittedAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	}); err == nil {
+		t.Error("CreateSessionCommit on a closed database returned nil")
+	}
+	if _, err := repo.GetSessionCommits(ctx, "session-git-broken"); err == nil {
+		t.Error("GetSessionCommits on a closed database returned nil")
+	}
+	if _, err := repo.GetLatestSessionCommit(ctx, "session-git-broken"); err == nil {
+		t.Error("GetLatestSessionCommit on a closed database returned nil")
+	}
+	if err := repo.DeleteSessionCommit(ctx, "commit-broken"); err == nil {
+		t.Error("DeleteSessionCommit on a closed database returned nil")
+	}
+}

--- a/apps/backend/internal/task/repository/sqlite/plan_test.go
+++ b/apps/backend/internal/task/repository/sqlite/plan_test.go
@@ -1,0 +1,833 @@
+package sqlite
+
+//revive:disable:file-length-limit // Task plan HEAD + revision persistence coverage is intentionally scenario-heavy.
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/task/models"
+)
+
+func assertTaskPlanEqual(t *testing.T, got, want *models.TaskPlan) {
+	t.Helper()
+	if got == nil {
+		t.Fatal("plan is nil")
+	}
+	if got.ID != want.ID {
+		t.Errorf("ID = %q, want %q", got.ID, want.ID)
+	}
+	if got.TaskID != want.TaskID {
+		t.Errorf("TaskID = %q, want %q", got.TaskID, want.TaskID)
+	}
+	if got.Title != want.Title {
+		t.Errorf("Title = %q, want %q", got.Title, want.Title)
+	}
+	if got.Content != want.Content {
+		t.Errorf("Content = %q, want %q", got.Content, want.Content)
+	}
+	if got.CreatedBy != want.CreatedBy {
+		t.Errorf("CreatedBy = %q, want %q", got.CreatedBy, want.CreatedBy)
+	}
+	assertTimeEqual(t, "CreatedAt", got.CreatedAt, want.CreatedAt)
+	assertTimeEqual(t, "UpdatedAt", got.UpdatedAt, want.UpdatedAt)
+	assertOptionalString(t, "ImplementationStartedSessionID", got.ImplementationStartedSessionID, want.ImplementationStartedSessionID)
+	assertOptionalString(t, "ImplementationStartedBy", got.ImplementationStartedBy, want.ImplementationStartedBy)
+	switch {
+	case want.ImplementationStartedAt == nil && got.ImplementationStartedAt != nil:
+		t.Errorf("ImplementationStartedAt = %v, want nil", *got.ImplementationStartedAt)
+	case want.ImplementationStartedAt != nil && got.ImplementationStartedAt == nil:
+		t.Errorf("ImplementationStartedAt = nil, want %v", *want.ImplementationStartedAt)
+	case want.ImplementationStartedAt != nil && !got.ImplementationStartedAt.Truncate(time.Microsecond).Equal(want.ImplementationStartedAt.Truncate(time.Microsecond)):
+		t.Errorf("ImplementationStartedAt = %v, want %v", *got.ImplementationStartedAt, *want.ImplementationStartedAt)
+	}
+}
+
+func assertOptionalString(t *testing.T, label string, got, want *string) {
+	t.Helper()
+	switch {
+	case want == nil && got != nil:
+		t.Errorf("%s = %q, want nil", label, *got)
+	case want != nil && got == nil:
+		t.Errorf("%s = nil, want %q", label, *want)
+	case want != nil && *got != *want:
+		t.Errorf("%s = %q, want %q", label, *got, *want)
+	}
+}
+
+func assertPlanRevisionEqual(t *testing.T, got, want *models.TaskPlanRevision) {
+	t.Helper()
+	if got == nil {
+		t.Fatal("revision is nil")
+	}
+	if got.ID != want.ID {
+		t.Errorf("ID = %q, want %q", got.ID, want.ID)
+	}
+	if got.TaskID != want.TaskID {
+		t.Errorf("TaskID = %q, want %q", got.TaskID, want.TaskID)
+	}
+	if got.RevisionNumber != want.RevisionNumber {
+		t.Errorf("RevisionNumber = %d, want %d", got.RevisionNumber, want.RevisionNumber)
+	}
+	if got.Title != want.Title {
+		t.Errorf("Title = %q, want %q", got.Title, want.Title)
+	}
+	if got.Content != want.Content {
+		t.Errorf("Content = %q, want %q", got.Content, want.Content)
+	}
+	if got.AuthorKind != want.AuthorKind {
+		t.Errorf("AuthorKind = %q, want %q", got.AuthorKind, want.AuthorKind)
+	}
+	if got.AuthorName != want.AuthorName {
+		t.Errorf("AuthorName = %q, want %q", got.AuthorName, want.AuthorName)
+	}
+	assertOptionalString(t, "RevertOfRevisionID", got.RevertOfRevisionID, want.RevertOfRevisionID)
+	assertTimeEqual(t, "CreatedAt", got.CreatedAt, want.CreatedAt)
+	assertTimeEqual(t, "UpdatedAt", got.UpdatedAt, want.UpdatedAt)
+}
+
+func TestCreateTaskPlanRoundTripsEveryField(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+	ctx := context.Background()
+	seedTaskForDocs(t, repo, "task-plan-full")
+
+	before := time.Now().UTC().Add(-time.Second)
+	want := &models.TaskPlan{
+		ID: "plan-full", TaskID: "task-plan-full",
+		Title: "Implementation plan", Content: "## Steps\n1. do it", CreatedBy: "user",
+	}
+	if err := repo.CreateTaskPlan(ctx, want); err != nil {
+		t.Fatalf("CreateTaskPlan: %v", err)
+	}
+	if want.CreatedAt.Before(before) || !want.CreatedAt.Equal(want.UpdatedAt) {
+		t.Fatalf("CreateTaskPlan stamped CreatedAt=%v UpdatedAt=%v, want equal times after %v",
+			want.CreatedAt, want.UpdatedAt, before)
+	}
+
+	got, err := repo.GetTaskPlan(ctx, "task-plan-full")
+	if err != nil {
+		t.Fatalf("GetTaskPlan: %v", err)
+	}
+	assertTaskPlanEqual(t, got, want)
+}
+
+func TestCreateTaskPlanAppliesDefaultsForEmptyFields(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+	ctx := context.Background()
+	seedTaskForDocs(t, repo, "task-plan-defaults")
+
+	plan := &models.TaskPlan{TaskID: "task-plan-defaults", Content: "body"}
+	if err := repo.CreateTaskPlan(ctx, plan); err != nil {
+		t.Fatalf("CreateTaskPlan: %v", err)
+	}
+	if plan.ID == "" {
+		t.Fatal("ID left empty; a UUID should have been generated")
+	}
+	if plan.Title != "Plan" {
+		t.Errorf("Title = %q, want the %q default", plan.Title, "Plan")
+	}
+	if plan.CreatedBy != authorKindAgent {
+		t.Errorf("CreatedBy = %q, want the %q default", plan.CreatedBy, authorKindAgent)
+	}
+
+	got, err := repo.GetTaskPlan(ctx, "task-plan-defaults")
+	if err != nil {
+		t.Fatalf("GetTaskPlan: %v", err)
+	}
+	if got.Title != "Plan" || got.CreatedBy != authorKindAgent {
+		t.Errorf("persisted defaults = %q/%q, want Plan/%s", got.Title, got.CreatedBy, authorKindAgent)
+	}
+	if got.ImplementationStartedAt != nil || got.ImplementationStartedSessionID != nil || got.ImplementationStartedBy != nil {
+		t.Errorf("implementation markers = %+v, want all nil on a fresh plan", got)
+	}
+}
+
+func TestCreateTaskPlanRejectsSecondPlanForSameTask(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+	ctx := context.Background()
+	seedTaskForDocs(t, repo, "task-plan-unique")
+
+	if err := repo.CreateTaskPlan(ctx, &models.TaskPlan{
+		ID: "plan-unique-1", TaskID: "task-plan-unique", Title: "One", Content: "one",
+	}); err != nil {
+		t.Fatalf("CreateTaskPlan(first): %v", err)
+	}
+	if err := repo.CreateTaskPlan(ctx, &models.TaskPlan{
+		ID: "plan-unique-2", TaskID: "task-plan-unique", Title: "Two", Content: "two",
+	}); err == nil {
+		t.Fatal("CreateTaskPlan accepted a second plan for the same task; task_id is UNIQUE")
+	}
+	got, err := repo.GetTaskPlan(ctx, "task-plan-unique")
+	if err != nil {
+		t.Fatalf("GetTaskPlan: %v", err)
+	}
+	if got.Title != "One" {
+		t.Errorf("Title = %q, want the original %q", got.Title, "One")
+	}
+}
+
+func TestGetTaskPlanReturnsNilNilWhenMissing(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+
+	got, err := repo.GetTaskPlan(context.Background(), "task-plan-missing")
+	if err != nil {
+		t.Fatalf("GetTaskPlan returned error %v, want the nil,nil not-found contract", err)
+	}
+	if got != nil {
+		t.Errorf("GetTaskPlan = %+v, want nil", got)
+	}
+}
+
+func TestUpdateTaskPlanWritesMutableFieldsAndReportsMissing(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+	ctx := context.Background()
+	seedTaskForDocs(t, repo, "task-plan-update")
+
+	plan := &models.TaskPlan{
+		ID: "plan-update", TaskID: "task-plan-update", Title: "Before", Content: "old", CreatedBy: "agent",
+	}
+	if err := repo.CreateTaskPlan(ctx, plan); err != nil {
+		t.Fatalf("CreateTaskPlan: %v", err)
+	}
+	createdAt := plan.CreatedAt
+
+	plan.Title = "After"
+	plan.Content = "new"
+	plan.CreatedBy = "user"
+	if err := repo.UpdateTaskPlan(ctx, plan); err != nil {
+		t.Fatalf("UpdateTaskPlan: %v", err)
+	}
+
+	got, err := repo.GetTaskPlan(ctx, "task-plan-update")
+	if err != nil {
+		t.Fatalf("GetTaskPlan: %v", err)
+	}
+	assertTaskPlanEqual(t, got, plan)
+	if !got.CreatedAt.Equal(createdAt) {
+		t.Errorf("CreatedAt = %v, want it preserved at %v", got.CreatedAt, createdAt)
+	}
+
+	err = repo.UpdateTaskPlan(ctx, &models.TaskPlan{TaskID: "task-plan-nowhere", Title: "x"})
+	if err == nil {
+		t.Fatal("UpdateTaskPlan on a missing row returned nil")
+	}
+	if !strings.Contains(err.Error(), "task plan not found") {
+		t.Errorf("UpdateTaskPlan error = %q, want a task-plan-not-found message", err)
+	}
+}
+
+func TestDeleteTaskPlanRemovesRowAndReportsMissing(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+	ctx := context.Background()
+	seedTaskForDocs(t, repo, "task-plan-delete")
+	seedTaskForDocs(t, repo, "task-plan-keep")
+
+	for _, taskID := range []string{"task-plan-delete", "task-plan-keep"} {
+		if err := repo.CreateTaskPlan(ctx, &models.TaskPlan{
+			ID: "plan-" + taskID, TaskID: taskID, Title: "Plan", Content: taskID,
+		}); err != nil {
+			t.Fatalf("CreateTaskPlan(%s): %v", taskID, err)
+		}
+	}
+
+	if err := repo.DeleteTaskPlan(ctx, "task-plan-delete"); err != nil {
+		t.Fatalf("DeleteTaskPlan: %v", err)
+	}
+	if got := countRows(t, repo, `SELECT COUNT(1) FROM task_plans WHERE task_id = ?`, "task-plan-delete"); got != 0 {
+		t.Errorf("rows after delete = %d, want 0", got)
+	}
+	if got := countRows(t, repo, `SELECT COUNT(1) FROM task_plans WHERE task_id = ?`, "task-plan-keep"); got != 1 {
+		t.Errorf("other task's plan rows = %d, want 1 (delete must be task-scoped)", got)
+	}
+
+	err := repo.DeleteTaskPlan(ctx, "task-plan-delete")
+	if err == nil {
+		t.Fatal("second DeleteTaskPlan returned nil; a missing row must be reported")
+	}
+	if !strings.Contains(err.Error(), "task plan not found") {
+		t.Errorf("DeleteTaskPlan error = %q, want a task-plan-not-found message", err)
+	}
+}
+
+func TestMarkTaskPlanImplementationStartedIsIdempotent(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+	ctx := context.Background()
+	seedTaskForDocs(t, repo, "task-plan-mark")
+
+	plan := &models.TaskPlan{ID: "plan-mark", TaskID: "task-plan-mark", Title: "Plan", Content: "body"}
+	if err := repo.CreateTaskPlan(ctx, plan); err != nil {
+		t.Fatalf("CreateTaskPlan: %v", err)
+	}
+	createdUpdatedAt := plan.UpdatedAt
+
+	marked, err := repo.MarkTaskPlanImplementationStarted(ctx, "task-plan-mark", "session-first", "jcfs")
+	if err != nil {
+		t.Fatalf("MarkTaskPlanImplementationStarted: %v", err)
+	}
+	if marked.ImplementationStartedAt == nil {
+		t.Fatal("ImplementationStartedAt = nil, want the first-start marker set")
+	}
+	assertOptionalString(t, "ImplementationStartedSessionID", marked.ImplementationStartedSessionID, strptr("session-first"))
+	assertOptionalString(t, "ImplementationStartedBy", marked.ImplementationStartedBy, strptr("jcfs"))
+	if !marked.UpdatedAt.After(createdUpdatedAt) {
+		t.Errorf("UpdatedAt = %v, want it bumped past %v on the first mark", marked.UpdatedAt, createdUpdatedAt)
+	}
+	firstStartedAt := *marked.ImplementationStartedAt
+	firstUpdatedAt := marked.UpdatedAt
+
+	second, err := repo.MarkTaskPlanImplementationStarted(ctx, "task-plan-mark", "session-second", "someone-else")
+	if err != nil {
+		t.Fatalf("second MarkTaskPlanImplementationStarted: %v", err)
+	}
+	if !second.ImplementationStartedAt.Equal(firstStartedAt) {
+		t.Errorf("ImplementationStartedAt = %v, want the first value %v preserved", *second.ImplementationStartedAt, firstStartedAt)
+	}
+	assertOptionalString(t, "ImplementationStartedSessionID", second.ImplementationStartedSessionID, strptr("session-first"))
+	assertOptionalString(t, "ImplementationStartedBy", second.ImplementationStartedBy, strptr("jcfs"))
+	if !second.UpdatedAt.Equal(firstUpdatedAt) {
+		t.Errorf("UpdatedAt = %v, want it unchanged at %v on a repeat mark", second.UpdatedAt, firstUpdatedAt)
+	}
+}
+
+func TestMarkTaskPlanImplementationStartedReturnsSentinelWhenPlanMissing(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+
+	got, err := repo.MarkTaskPlanImplementationStarted(context.Background(), "task-plan-absent", "session", "actor")
+	if got != nil {
+		t.Errorf("plan = %+v, want nil", got)
+	}
+	if !errors.Is(err, ErrTaskPlanNotFound) {
+		t.Fatalf("error = %v, want ErrTaskPlanNotFound", err)
+	}
+	if !strings.Contains(err.Error(), "task-plan-absent") {
+		t.Errorf("error = %q, want the task id included for diagnostics", err)
+	}
+}
+
+func TestInsertTaskPlanRevisionRoundTripsEveryField(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+	ctx := context.Background()
+	seedTaskForDocs(t, repo, "task-planrev-full")
+
+	revertOf := "rev-earlier"
+	want := &models.TaskPlanRevision{
+		ID: "planrev-full", TaskID: "task-planrev-full", RevisionNumber: 4,
+		Title: "Plan v4", Content: "four", AuthorKind: "user", AuthorName: "jcfs",
+		RevertOfRevisionID: &revertOf,
+		CreatedAt:          time.Date(2026, 6, 6, 6, 6, 6, 789000000, time.UTC),
+	}
+	if err := repo.InsertTaskPlanRevision(ctx, want); err != nil {
+		t.Fatalf("InsertTaskPlanRevision: %v", err)
+	}
+
+	got, err := repo.GetTaskPlanRevision(ctx, "planrev-full")
+	if err != nil {
+		t.Fatalf("GetTaskPlanRevision: %v", err)
+	}
+	assertPlanRevisionEqual(t, got, want)
+
+	latest, err := repo.GetLatestTaskPlanRevision(ctx, "task-planrev-full")
+	if err != nil {
+		t.Fatalf("GetLatestTaskPlanRevision: %v", err)
+	}
+	assertPlanRevisionEqual(t, latest, want)
+
+	listed, err := repo.ListTaskPlanRevisions(ctx, "task-planrev-full", 0)
+	if err != nil {
+		t.Fatalf("ListTaskPlanRevisions: %v", err)
+	}
+	if len(listed) != 1 {
+		t.Fatalf("ListTaskPlanRevisions returned %d rows, want 1", len(listed))
+	}
+	assertPlanRevisionEqual(t, listed[0], want)
+}
+
+func TestInsertTaskPlanRevisionDefaultsIDAndCreatedAt(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+	ctx := context.Background()
+	seedTaskForDocs(t, repo, "task-planrev-defaults")
+
+	before := time.Now().UTC().Add(-time.Second)
+	rev := &models.TaskPlanRevision{
+		TaskID: "task-planrev-defaults", RevisionNumber: 1, Title: "Plan", Content: "v1", AuthorKind: "agent",
+	}
+	if err := repo.InsertTaskPlanRevision(ctx, rev); err != nil {
+		t.Fatalf("InsertTaskPlanRevision: %v", err)
+	}
+	if rev.ID == "" {
+		t.Fatal("ID left empty; a UUID should have been generated")
+	}
+	if rev.CreatedAt.Before(before) {
+		t.Errorf("CreatedAt = %v, want a freshly stamped time after %v", rev.CreatedAt, before)
+	}
+	got, err := repo.GetTaskPlanRevision(ctx, rev.ID)
+	if err != nil {
+		t.Fatalf("GetTaskPlanRevision: %v", err)
+	}
+	if got.RevertOfRevisionID != nil {
+		t.Errorf("RevertOfRevisionID = %q, want nil for a NULL column", *got.RevertOfRevisionID)
+	}
+}
+
+func TestInsertTaskPlanRevisionRejectsDuplicateRevisionNumber(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+	ctx := context.Background()
+	seedTaskForDocs(t, repo, "task-planrev-dupe")
+
+	if err := repo.InsertTaskPlanRevision(ctx, &models.TaskPlanRevision{
+		ID: "planrev-dupe-1", TaskID: "task-planrev-dupe", RevisionNumber: 1,
+		Title: "Plan", Content: "one", AuthorKind: "agent",
+	}); err != nil {
+		t.Fatalf("InsertTaskPlanRevision(first): %v", err)
+	}
+	err := repo.InsertTaskPlanRevision(ctx, &models.TaskPlanRevision{
+		ID: "planrev-dupe-2", TaskID: "task-planrev-dupe", RevisionNumber: 1,
+		Title: "Plan", Content: "two", AuthorKind: "agent",
+	})
+	if err == nil {
+		t.Fatal("InsertTaskPlanRevision accepted a duplicate (task_id, revision_number)")
+	}
+	if got := countRows(t, repo,
+		`SELECT COUNT(1) FROM task_plan_revisions WHERE task_id = ?`, "task-planrev-dupe"); got != 1 {
+		t.Errorf("rows = %d, want 1 (the duplicate must not land)", got)
+	}
+}
+
+func TestUpdateTaskPlanRevisionMergesTitleAndContentOnly(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+	ctx := context.Background()
+	seedTaskForDocs(t, repo, "task-planrev-update")
+
+	rev := &models.TaskPlanRevision{
+		ID: "planrev-update", TaskID: "task-planrev-update", RevisionNumber: 2,
+		Title: "Before", Content: "old", AuthorKind: "agent", AuthorName: "claude",
+		CreatedAt: time.Date(2026, 1, 1, 1, 1, 1, 0, time.UTC),
+	}
+	if err := repo.InsertTaskPlanRevision(ctx, rev); err != nil {
+		t.Fatalf("InsertTaskPlanRevision: %v", err)
+	}
+
+	rev.Title = "After"
+	rev.Content = "new"
+	rev.AuthorKind = "user"
+	rev.AuthorName = "ignored"
+	if err := repo.UpdateTaskPlanRevision(ctx, rev); err != nil {
+		t.Fatalf("UpdateTaskPlanRevision: %v", err)
+	}
+
+	got, err := repo.GetTaskPlanRevision(ctx, "planrev-update")
+	if err != nil {
+		t.Fatalf("GetTaskPlanRevision: %v", err)
+	}
+	if got.Title != "After" || got.Content != "new" {
+		t.Errorf("merged revision = %q/%q, want After/new", got.Title, got.Content)
+	}
+	if got.AuthorKind != "agent" || got.AuthorName != "claude" {
+		t.Errorf("author = %q/%q, want the stored agent/claude — the UPDATE must not touch author columns",
+			got.AuthorKind, got.AuthorName)
+	}
+	if got.RevisionNumber != 2 {
+		t.Errorf("RevisionNumber = %d, want 2 preserved", got.RevisionNumber)
+	}
+	if !got.CreatedAt.Equal(time.Date(2026, 1, 1, 1, 1, 1, 0, time.UTC)) {
+		t.Errorf("CreatedAt = %v, want it preserved", got.CreatedAt)
+	}
+	if !got.UpdatedAt.Equal(rev.UpdatedAt) {
+		t.Errorf("UpdatedAt = %v, want the refreshed %v", got.UpdatedAt, rev.UpdatedAt)
+	}
+
+	err = repo.UpdateTaskPlanRevision(ctx, &models.TaskPlanRevision{ID: "planrev-nowhere", Title: "x"})
+	if err == nil {
+		t.Fatal("UpdateTaskPlanRevision on a missing row returned nil")
+	}
+	if !strings.Contains(err.Error(), "task plan revision not found") {
+		t.Errorf("error = %q, want a task-plan-revision-not-found message", err)
+	}
+}
+
+func TestGetTaskPlanRevisionReturnsNilNilWhenMissing(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+	ctx := context.Background()
+
+	got, err := repo.GetTaskPlanRevision(ctx, "planrev-missing")
+	if err != nil {
+		t.Fatalf("GetTaskPlanRevision returned error %v, want nil,nil", err)
+	}
+	if got != nil {
+		t.Errorf("GetTaskPlanRevision = %+v, want nil", got)
+	}
+	latest, err := repo.GetLatestTaskPlanRevision(ctx, "task-planrev-missing")
+	if err != nil {
+		t.Fatalf("GetLatestTaskPlanRevision returned error %v, want nil,nil", err)
+	}
+	if latest != nil {
+		t.Errorf("GetLatestTaskPlanRevision = %+v, want nil", latest)
+	}
+}
+
+func TestListTaskPlanRevisionsOrdersDescendingAndHonoursLimit(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+	ctx := context.Background()
+	seedTaskForDocs(t, repo, "task-planrev-list")
+	seedTaskForDocs(t, repo, "task-planrev-noise")
+
+	for number := 1; number <= 3; number++ {
+		if err := repo.InsertTaskPlanRevision(ctx, &models.TaskPlanRevision{
+			ID: "planrev-list-" + string(rune('0'+number)), TaskID: "task-planrev-list",
+			RevisionNumber: number, Title: "Plan", Content: "v", AuthorKind: "agent",
+		}); err != nil {
+			t.Fatalf("InsertTaskPlanRevision(%d): %v", number, err)
+		}
+	}
+	if err := repo.InsertTaskPlanRevision(ctx, &models.TaskPlanRevision{
+		ID: "planrev-noise", TaskID: "task-planrev-noise", RevisionNumber: 99,
+		Title: "Plan", Content: "noise", AuthorKind: "agent",
+	}); err != nil {
+		t.Fatalf("InsertTaskPlanRevision(noise): %v", err)
+	}
+
+	all, err := repo.ListTaskPlanRevisions(ctx, "task-planrev-list", 0)
+	if err != nil {
+		t.Fatalf("ListTaskPlanRevisions(limit=0): %v", err)
+	}
+	if len(all) != 3 {
+		t.Fatalf("limit=0 returned %d rows, want 3", len(all))
+	}
+	for i, wantNumber := range []int{3, 2, 1} {
+		if all[i].RevisionNumber != wantNumber {
+			t.Fatalf("revision numbers = %d at index %d, want %d (newest first)", all[i].RevisionNumber, i, wantNumber)
+		}
+	}
+
+	limited, err := repo.ListTaskPlanRevisions(ctx, "task-planrev-list", 1)
+	if err != nil {
+		t.Fatalf("ListTaskPlanRevisions(limit=1): %v", err)
+	}
+	if len(limited) != 1 || limited[0].RevisionNumber != 3 {
+		t.Errorf("limit=1 returned %+v, want only revision 3", limited)
+	}
+
+	empty, err := repo.ListTaskPlanRevisions(ctx, "task-planrev-nothing", 0)
+	if err != nil {
+		t.Fatalf("ListTaskPlanRevisions(unknown task): %v", err)
+	}
+	if len(empty) != 0 {
+		t.Errorf("unknown task returned %+v, want empty", empty)
+	}
+}
+
+func TestNextTaskPlanRevisionNumber(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+	ctx := context.Background()
+	seedTaskForDocs(t, repo, "task-planrev-next")
+
+	next, err := repo.NextTaskPlanRevisionNumber(ctx, "task-planrev-next")
+	if err != nil {
+		t.Fatalf("NextTaskPlanRevisionNumber: %v", err)
+	}
+	if next != 1 {
+		t.Errorf("NextTaskPlanRevisionNumber with no history = %d, want 1", next)
+	}
+
+	if err := repo.InsertTaskPlanRevision(ctx, &models.TaskPlanRevision{
+		ID: "planrev-next-7", TaskID: "task-planrev-next", RevisionNumber: 7,
+		Title: "Plan", Content: "v7", AuthorKind: "agent",
+	}); err != nil {
+		t.Fatalf("InsertTaskPlanRevision: %v", err)
+	}
+	next, err = repo.NextTaskPlanRevisionNumber(ctx, "task-planrev-next")
+	if err != nil {
+		t.Fatalf("NextTaskPlanRevisionNumber: %v", err)
+	}
+	if next != 8 {
+		t.Errorf("NextTaskPlanRevisionNumber = %d, want 8 (MAX(7)+1)", next)
+	}
+}
+
+func TestWritePlanRevisionCreatesHeadAndFirstRevision(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+	ctx := context.Background()
+	seedTaskForDocs(t, repo, "task-writeplan")
+
+	head := &models.TaskPlan{TaskID: "task-writeplan", Content: "first"}
+	rev := &models.TaskPlanRevision{
+		TaskID: "task-writeplan", Title: "Plan", Content: "first", AuthorKind: "agent", AuthorName: "claude",
+	}
+	if err := repo.WritePlanRevision(ctx, head, rev, nil); err != nil {
+		t.Fatalf("WritePlanRevision: %v", err)
+	}
+	if head.ID == "" {
+		t.Fatal("head ID left empty; a UUID should have been generated")
+	}
+	if head.Title != "Plan" || head.CreatedBy != authorKindAgent {
+		t.Errorf("head defaults = %q/%q, want Plan/%s", head.Title, head.CreatedBy, authorKindAgent)
+	}
+	if rev.RevisionNumber != 1 {
+		t.Errorf("RevisionNumber = %d, want 1", rev.RevisionNumber)
+	}
+
+	gotHead, err := repo.GetTaskPlan(ctx, "task-writeplan")
+	if err != nil {
+		t.Fatalf("GetTaskPlan: %v", err)
+	}
+	assertTaskPlanEqual(t, gotHead, head)
+
+	gotRev, err := repo.GetLatestTaskPlanRevision(ctx, "task-writeplan")
+	if err != nil {
+		t.Fatalf("GetLatestTaskPlanRevision: %v", err)
+	}
+	assertPlanRevisionEqual(t, gotRev, rev)
+}
+
+func TestWritePlanRevisionUpsertsHeadAndAppendsRevisions(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+	ctx := context.Background()
+	seedTaskForDocs(t, repo, "task-writeplan-append")
+
+	head := &models.TaskPlan{
+		ID: "plan-append", TaskID: "task-writeplan-append", Title: "v1", Content: "one", CreatedBy: "agent",
+	}
+	if err := repo.WritePlanRevision(ctx, head, &models.TaskPlanRevision{
+		TaskID: "task-writeplan-append", Title: "v1", Content: "one", AuthorKind: "agent",
+	}, nil); err != nil {
+		t.Fatalf("WritePlanRevision(first): %v", err)
+	}
+	createdAt := head.CreatedAt
+
+	head.Title = "v2"
+	head.Content = "two"
+	head.CreatedBy = "user"
+	second := &models.TaskPlanRevision{
+		TaskID: "task-writeplan-append", Title: "v2", Content: "two", AuthorKind: "user", AuthorName: "jcfs",
+	}
+	if err := repo.WritePlanRevision(ctx, head, second, nil); err != nil {
+		t.Fatalf("WritePlanRevision(second): %v", err)
+	}
+	if second.RevisionNumber != 2 {
+		t.Errorf("second RevisionNumber = %d, want 2", second.RevisionNumber)
+	}
+
+	if got := countRows(t, repo,
+		`SELECT COUNT(1) FROM task_plans WHERE task_id = ?`, "task-writeplan-append"); got != 1 {
+		t.Errorf("HEAD rows = %d, want 1 (the upsert must not insert a second row)", got)
+	}
+	gotHead, err := repo.GetTaskPlan(ctx, "task-writeplan-append")
+	if err != nil {
+		t.Fatalf("GetTaskPlan: %v", err)
+	}
+	if gotHead.ID != "plan-append" {
+		t.Errorf("HEAD id = %q, want plan-append", gotHead.ID)
+	}
+	if gotHead.Title != "v2" || gotHead.Content != "two" || gotHead.CreatedBy != "user" {
+		t.Errorf("HEAD = %+v, want the v2 values", gotHead)
+	}
+	if !gotHead.CreatedAt.Equal(createdAt) {
+		t.Errorf("HEAD CreatedAt = %v, want it preserved at %v", gotHead.CreatedAt, createdAt)
+	}
+
+	history, err := repo.ListTaskPlanRevisions(ctx, "task-writeplan-append", 0)
+	if err != nil {
+		t.Fatalf("ListTaskPlanRevisions: %v", err)
+	}
+	if len(history) != 2 {
+		t.Fatalf("history has %d revisions, want 2", len(history))
+	}
+	if history[0].RevisionNumber != 2 || history[0].Content != "two" || history[0].AuthorName != "jcfs" {
+		t.Errorf("newest revision = %+v, want revision 2 by jcfs", history[0])
+	}
+	if history[1].RevisionNumber != 1 || history[1].Content != "one" {
+		t.Errorf("oldest revision = %+v, want revision 1 with the original content", history[1])
+	}
+}
+
+func TestWritePlanRevisionPreservesImplementationMarkerAcrossUpsert(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+	ctx := context.Background()
+	seedTaskForDocs(t, repo, "task-writeplan-marker")
+
+	head := &models.TaskPlan{ID: "plan-marker", TaskID: "task-writeplan-marker", Title: "v1", Content: "one"}
+	if err := repo.WritePlanRevision(ctx, head, &models.TaskPlanRevision{
+		TaskID: "task-writeplan-marker", Title: "v1", Content: "one", AuthorKind: "agent",
+	}, nil); err != nil {
+		t.Fatalf("WritePlanRevision(first): %v", err)
+	}
+	if _, err := repo.MarkTaskPlanImplementationStarted(ctx, "task-writeplan-marker", "session-x", "jcfs"); err != nil {
+		t.Fatalf("MarkTaskPlanImplementationStarted: %v", err)
+	}
+
+	head.Title = "v2"
+	head.Content = "two"
+	if err := repo.WritePlanRevision(ctx, head, &models.TaskPlanRevision{
+		TaskID: "task-writeplan-marker", Title: "v2", Content: "two", AuthorKind: "agent",
+	}, nil); err != nil {
+		t.Fatalf("WritePlanRevision(second): %v", err)
+	}
+
+	got, err := repo.GetTaskPlan(ctx, "task-writeplan-marker")
+	if err != nil {
+		t.Fatalf("GetTaskPlan: %v", err)
+	}
+	if got.ImplementationStartedAt == nil {
+		t.Fatal("ImplementationStartedAt = nil; the ON CONFLICT clause must not clear the marker")
+	}
+	assertOptionalString(t, "ImplementationStartedSessionID", got.ImplementationStartedSessionID, strptr("session-x"))
+	assertOptionalString(t, "ImplementationStartedBy", got.ImplementationStartedBy, strptr("jcfs"))
+}
+
+func TestWritePlanRevisionCoalescesIntoExistingRevision(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+	ctx := context.Background()
+	seedTaskForDocs(t, repo, "task-writeplan-merge")
+
+	head := &models.TaskPlan{ID: "plan-merge", TaskID: "task-writeplan-merge", Title: "v1", Content: "one"}
+	first := &models.TaskPlanRevision{
+		ID: "planrev-merge", TaskID: "task-writeplan-merge", Title: "v1", Content: "one",
+		AuthorKind: "agent", AuthorName: "claude",
+		CreatedAt: time.Date(2026, 2, 2, 2, 2, 2, 0, time.UTC),
+	}
+	if err := repo.WritePlanRevision(ctx, head, first, nil); err != nil {
+		t.Fatalf("WritePlanRevision(first): %v", err)
+	}
+
+	head.Title = "v1 edited"
+	head.Content = "one edited"
+	merged := &models.TaskPlanRevision{
+		TaskID: "task-writeplan-merge", Title: "v1 edited", Content: "one edited",
+		AuthorKind: "ignored", AuthorName: "ignored",
+	}
+	coalesceID := "planrev-merge"
+	if err := repo.WritePlanRevision(ctx, head, merged, &coalesceID); err != nil {
+		t.Fatalf("WritePlanRevision(merge): %v", err)
+	}
+	if merged.ID != "planrev-merge" {
+		t.Errorf("merged ID = %q, want planrev-merge", merged.ID)
+	}
+
+	history, err := repo.ListTaskPlanRevisions(ctx, "task-writeplan-merge", 0)
+	if err != nil {
+		t.Fatalf("ListTaskPlanRevisions: %v", err)
+	}
+	if len(history) != 1 {
+		t.Fatalf("history has %d revisions, want 1 (coalesce must merge, not append)", len(history))
+	}
+	got := history[0]
+	if got.Title != "v1 edited" || got.Content != "one edited" {
+		t.Errorf("merged revision = %+v, want the edited title/content", got)
+	}
+	if got.RevisionNumber != 1 {
+		t.Errorf("RevisionNumber = %d, want 1 preserved", got.RevisionNumber)
+	}
+	if got.AuthorKind != "agent" || got.AuthorName != "claude" {
+		t.Errorf("author = %q/%q, want the original agent/claude preserved", got.AuthorKind, got.AuthorName)
+	}
+	if !got.CreatedAt.Equal(first.CreatedAt) {
+		t.Errorf("CreatedAt = %v, want %v preserved", got.CreatedAt, first.CreatedAt)
+	}
+	if !got.UpdatedAt.After(got.CreatedAt) {
+		t.Errorf("UpdatedAt = %v, want it bumped past CreatedAt %v", got.UpdatedAt, got.CreatedAt)
+	}
+}
+
+func TestWritePlanRevisionRollsBackWhenCoalesceTargetMissing(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+	ctx := context.Background()
+	seedTaskForDocs(t, repo, "task-writeplan-rollback")
+
+	missingID := "planrev-does-not-exist"
+	err := repo.WritePlanRevision(ctx,
+		&models.TaskPlan{ID: "plan-rollback", TaskID: "task-writeplan-rollback", Title: "nope", Content: "nope"},
+		&models.TaskPlanRevision{TaskID: "task-writeplan-rollback", Title: "x", Content: "y"},
+		&missingID)
+	if err == nil {
+		t.Fatal("WritePlanRevision with an unknown coalesce id returned nil")
+	}
+	if !strings.Contains(err.Error(), "task plan revision not found") {
+		t.Errorf("error = %q, want a task-plan-revision-not-found message", err)
+	}
+	if got := countRows(t, repo,
+		`SELECT COUNT(1) FROM task_plans WHERE task_id = ?`, "task-writeplan-rollback"); got != 0 {
+		t.Errorf("HEAD rows after a failed merge = %d, want 0 (transaction must roll back)", got)
+	}
+	if got := countRows(t, repo,
+		`SELECT COUNT(1) FROM task_plan_revisions WHERE task_id = ?`, "task-writeplan-rollback"); got != 0 {
+		t.Errorf("revision rows after a failed merge = %d, want 0", got)
+	}
+}
+
+func TestTaskPlanAndRevisionsCascadeOnTaskDelete(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+	ctx := context.Background()
+	seedTaskForDocs(t, repo, "task-plan-cascade")
+
+	if err := repo.WritePlanRevision(ctx,
+		&models.TaskPlan{ID: "plan-cascade", TaskID: "task-plan-cascade", Title: "Plan", Content: "body"},
+		&models.TaskPlanRevision{TaskID: "task-plan-cascade", Title: "Plan", Content: "body", AuthorKind: "agent"},
+		nil); err != nil {
+		t.Fatalf("WritePlanRevision: %v", err)
+	}
+
+	if err := repo.DeleteTask(ctx, "task-plan-cascade"); err != nil {
+		t.Fatalf("DeleteTask: %v", err)
+	}
+	if got := countRows(t, repo, `SELECT COUNT(1) FROM task_plans WHERE task_id = ?`, "task-plan-cascade"); got != 0 {
+		t.Errorf("plan rows after task delete = %d, want 0 (FK cascade)", got)
+	}
+	if got := countRows(t, repo,
+		`SELECT COUNT(1) FROM task_plan_revisions WHERE task_id = ?`, "task-plan-cascade"); got != 0 {
+		t.Errorf("plan revision rows after task delete = %d, want 0 (FK cascade)", got)
+	}
+}
+
+func TestTaskPlanMethodsPropagateBackendErrors(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+	ctx := context.Background()
+	seedTaskForDocs(t, repo, "task-plan-broken")
+	if err := repo.CreateTaskPlan(ctx, &models.TaskPlan{
+		ID: "plan-broken", TaskID: "task-plan-broken", Title: "Plan", Content: "body",
+	}); err != nil {
+		t.Fatalf("CreateTaskPlan: %v", err)
+	}
+	closeRepoDB(t, repo)
+
+	if err := repo.CreateTaskPlan(ctx, &models.TaskPlan{ID: "plan-after-close", TaskID: "task-plan-broken"}); err == nil {
+		t.Error("CreateTaskPlan on a closed database returned nil")
+	}
+	if _, err := repo.GetTaskPlan(ctx, "task-plan-broken"); err == nil {
+		t.Error("GetTaskPlan on a closed database returned nil")
+	}
+	if err := repo.UpdateTaskPlan(ctx, &models.TaskPlan{TaskID: "task-plan-broken"}); err == nil {
+		t.Error("UpdateTaskPlan on a closed database returned nil")
+	}
+	if _, err := repo.MarkTaskPlanImplementationStarted(ctx, "task-plan-broken", "s", "a"); err == nil {
+		t.Error("MarkTaskPlanImplementationStarted on a closed database returned nil")
+	}
+	if err := repo.DeleteTaskPlan(ctx, "task-plan-broken"); err == nil {
+		t.Error("DeleteTaskPlan on a closed database returned nil")
+	}
+	if err := repo.InsertTaskPlanRevision(ctx, &models.TaskPlanRevision{
+		TaskID: "task-plan-broken", RevisionNumber: 1,
+	}); err == nil {
+		t.Error("InsertTaskPlanRevision on a closed database returned nil")
+	}
+	if err := repo.UpdateTaskPlanRevision(ctx, &models.TaskPlanRevision{ID: "planrev-broken"}); err == nil {
+		t.Error("UpdateTaskPlanRevision on a closed database returned nil")
+	}
+	if _, err := repo.GetTaskPlanRevision(ctx, "planrev-broken"); err == nil {
+		t.Error("GetTaskPlanRevision on a closed database returned nil")
+	}
+	if _, err := repo.ListTaskPlanRevisions(ctx, "task-plan-broken", 0); err == nil {
+		t.Error("ListTaskPlanRevisions on a closed database returned nil")
+	}
+	if _, err := repo.NextTaskPlanRevisionNumber(ctx, "task-plan-broken"); err == nil {
+		t.Error("NextTaskPlanRevisionNumber on a closed database returned nil")
+	}
+	if err := repo.WritePlanRevision(ctx,
+		&models.TaskPlan{TaskID: "task-plan-broken"},
+		&models.TaskPlanRevision{TaskID: "task-plan-broken"},
+		nil); err == nil {
+		t.Error("WritePlanRevision on a closed database returned nil")
+	}
+}

--- a/apps/backend/internal/task/repository/sqlite/session_test.go
+++ b/apps/backend/internal/task/repository/sqlite/session_test.go
@@ -1742,3 +1742,568 @@ func sameStringSet(got, want []string) bool {
 	}
 	return true
 }
+
+// --- Turn lifecycle -------------------------------------------------------
+//
+// task_session_turns is the analytics/duration record behind the UI's
+// last-turn readout. AbandonTurn's zero-duration close is the subtle part:
+// it must collapse an orphaned turn to started_at rather than to now.
+
+func seedSessionForTurns(t *testing.T, repo *Repository, taskID, sessionID string) {
+	t.Helper()
+	ctx := context.Background()
+	if err := repo.CreateTask(ctx, &models.Task{ID: taskID, Title: taskID}); err != nil {
+		t.Fatalf("CreateTask(%s): %v", taskID, err)
+	}
+	if err := repo.CreateTaskSession(ctx, &models.TaskSession{
+		ID: sessionID, TaskID: taskID, State: models.TaskSessionStateRunning,
+	}); err != nil {
+		t.Fatalf("CreateTaskSession(%s): %v", sessionID, err)
+	}
+}
+
+func TestCreateTurnRoundTripsEveryFieldAndDefaultsTimestamps(t *testing.T) {
+	repo := newRepoForSessionTests(t)
+	ctx := context.Background()
+	seedSessionForTurns(t, repo, "task-turn-full", "session-turn-full")
+
+	completedAt := time.Date(2026, 5, 5, 10, 30, 0, 0, time.UTC)
+	want := &models.Turn{
+		ID:            "turn-full",
+		TaskSessionID: "session-turn-full",
+		TaskID:        "task-turn-full",
+		StartedAt:     time.Date(2026, 5, 5, 10, 0, 0, 0, time.UTC),
+		CompletedAt:   &completedAt,
+		Metadata:      map[string]interface{}{"tokens": float64(1234), "model": "opus"},
+		CreatedAt:     time.Date(2026, 5, 5, 9, 59, 0, 0, time.UTC),
+	}
+	if err := repo.CreateTurn(ctx, want); err != nil {
+		t.Fatalf("CreateTurn: %v", err)
+	}
+
+	got, err := repo.GetTurn(ctx, "turn-full")
+	if err != nil {
+		t.Fatalf("GetTurn: %v", err)
+	}
+	if got.ID != want.ID || got.TaskSessionID != want.TaskSessionID || got.TaskID != want.TaskID {
+		t.Errorf("identity = %q/%q/%q, want %q/%q/%q",
+			got.ID, got.TaskSessionID, got.TaskID, want.ID, want.TaskSessionID, want.TaskID)
+	}
+	assertTimeEqual(t, "StartedAt", got.StartedAt, want.StartedAt)
+	assertTimeEqual(t, "CreatedAt", got.CreatedAt, want.CreatedAt)
+	assertTimeEqual(t, "UpdatedAt", got.UpdatedAt, want.UpdatedAt)
+	if got.CompletedAt == nil {
+		t.Fatal("CompletedAt = nil, want the supplied value")
+	}
+	assertTimeEqual(t, "CompletedAt", *got.CompletedAt, completedAt)
+	assertJSONMapEqual(t, "Metadata", got.Metadata, want.Metadata)
+
+	// An id-less, timestamp-less turn gets both stamped.
+	before := time.Now().UTC().Add(-time.Second)
+	bare := &models.Turn{TaskSessionID: "session-turn-full", TaskID: "task-turn-full"}
+	if err := repo.CreateTurn(ctx, bare); err != nil {
+		t.Fatalf("CreateTurn(bare): %v", err)
+	}
+	if bare.ID == "" {
+		t.Error("ID left empty; a UUID should have been generated")
+	}
+	if bare.StartedAt.Before(before) || bare.CreatedAt.Before(before) {
+		t.Errorf("StartedAt=%v CreatedAt=%v, want fresh stamps after %v", bare.StartedAt, bare.CreatedAt, before)
+	}
+	gotBare, err := repo.GetTurn(ctx, bare.ID)
+	if err != nil {
+		t.Fatalf("GetTurn(bare): %v", err)
+	}
+	if gotBare.CompletedAt != nil {
+		t.Errorf("CompletedAt = %v, want nil for an open turn", *gotBare.CompletedAt)
+	}
+	if gotBare.Metadata != nil {
+		t.Errorf("Metadata = %#v, want nil (the {} sentinel decodes to nil)", gotBare.Metadata)
+	}
+}
+
+func TestGetTurnAndActiveTurnReturnErrNoRowsWhenAbsent(t *testing.T) {
+	repo := newRepoForSessionTests(t)
+	ctx := context.Background()
+	seedSessionForTurns(t, repo, "task-turn-none", "session-turn-none")
+
+	if _, err := repo.GetTurn(ctx, "turn-missing"); !errors.Is(err, sql.ErrNoRows) {
+		t.Errorf("GetTurn error = %v, want sql.ErrNoRows", err)
+	}
+	if _, err := repo.GetActiveTurnBySessionID(ctx, "session-turn-none"); !errors.Is(err, sql.ErrNoRows) {
+		t.Errorf("GetActiveTurnBySessionID error = %v, want sql.ErrNoRows", err)
+	}
+	turns, err := repo.ListTurnsBySession(ctx, "session-turn-none")
+	if err != nil {
+		t.Fatalf("ListTurnsBySession: %v", err)
+	}
+	if len(turns) != 0 {
+		t.Errorf("ListTurnsBySession = %+v, want empty", turns)
+	}
+}
+
+func TestGetActiveTurnBySessionIDPicksNewestOpenTurn(t *testing.T) {
+	repo := newRepoForSessionTests(t)
+	ctx := context.Background()
+	seedSessionForTurns(t, repo, "task-turn-active", "session-turn-active")
+	seedSessionForTurns(t, repo, "task-turn-other", "session-turn-other")
+
+	base := time.Date(2026, 6, 1, 8, 0, 0, 0, time.UTC)
+	closedAt := base.Add(30 * time.Minute)
+	turns := []*models.Turn{
+		{ID: "turn-closed", TaskSessionID: "session-turn-active", TaskID: "task-turn-active",
+			StartedAt: base, CompletedAt: &closedAt},
+		{ID: "turn-open-old", TaskSessionID: "session-turn-active", TaskID: "task-turn-active",
+			StartedAt: base.Add(time.Hour)},
+		{ID: "turn-open-new", TaskSessionID: "session-turn-active", TaskID: "task-turn-active",
+			StartedAt: base.Add(2 * time.Hour)},
+		{ID: "turn-foreign", TaskSessionID: "session-turn-other", TaskID: "task-turn-other",
+			StartedAt: base.Add(3 * time.Hour)},
+	}
+	for _, turn := range turns {
+		if err := repo.CreateTurn(ctx, turn); err != nil {
+			t.Fatalf("CreateTurn(%s): %v", turn.ID, err)
+		}
+	}
+
+	active, err := repo.GetActiveTurnBySessionID(ctx, "session-turn-active")
+	if err != nil {
+		t.Fatalf("GetActiveTurnBySessionID: %v", err)
+	}
+	if active.ID != "turn-open-new" {
+		t.Errorf("GetActiveTurnBySessionID = %q, want turn-open-new (newest open turn)", active.ID)
+	}
+
+	listed, err := repo.ListTurnsBySession(ctx, "session-turn-active")
+	if err != nil {
+		t.Fatalf("ListTurnsBySession: %v", err)
+	}
+	wantOrder := []string{"turn-closed", "turn-open-old", "turn-open-new"}
+	if len(listed) != len(wantOrder) {
+		t.Fatalf("ListTurnsBySession returned %d turns, want %d (session-scoped)", len(listed), len(wantOrder))
+	}
+	for i := range wantOrder {
+		if listed[i].ID != wantOrder[i] {
+			t.Fatalf("ListTurnsBySession order = %q at index %d, want %q (started_at ASC)", listed[i].ID, i, wantOrder[i])
+		}
+	}
+	if listed[0].CompletedAt == nil {
+		t.Error("turn-closed CompletedAt = nil, want it populated in the list read")
+	}
+	if listed[1].CompletedAt != nil {
+		t.Errorf("turn-open-old CompletedAt = %v, want nil", *listed[1].CompletedAt)
+	}
+}
+
+func TestUpdateTurnWritesCompletionAndMetadata(t *testing.T) {
+	repo := newRepoForSessionTests(t)
+	ctx := context.Background()
+	seedSessionForTurns(t, repo, "task-turn-update", "session-turn-update")
+
+	turn := &models.Turn{
+		ID: "turn-update", TaskSessionID: "session-turn-update", TaskID: "task-turn-update",
+		StartedAt: time.Date(2026, 6, 2, 8, 0, 0, 0, time.UTC),
+		Metadata:  map[string]interface{}{"stage": "start"},
+	}
+	if err := repo.CreateTurn(ctx, turn); err != nil {
+		t.Fatalf("CreateTurn: %v", err)
+	}
+
+	completedAt := time.Date(2026, 6, 2, 8, 45, 0, 0, time.UTC)
+	turn.CompletedAt = &completedAt
+	turn.Metadata = map[string]interface{}{"stage": "done", "tokens": float64(42)}
+	if err := repo.UpdateTurn(ctx, turn); err != nil {
+		t.Fatalf("UpdateTurn: %v", err)
+	}
+
+	got, err := repo.GetTurn(ctx, "turn-update")
+	if err != nil {
+		t.Fatalf("GetTurn: %v", err)
+	}
+	if got.CompletedAt == nil {
+		t.Fatal("CompletedAt = nil after UpdateTurn")
+	}
+	assertTimeEqual(t, "CompletedAt", *got.CompletedAt, completedAt)
+	assertJSONMapEqual(t, "Metadata", got.Metadata, turn.Metadata)
+	assertTimeEqual(t, "StartedAt", got.StartedAt, turn.StartedAt)
+	if !got.UpdatedAt.After(got.StartedAt) {
+		t.Errorf("UpdatedAt = %v, want it bumped past StartedAt %v", got.UpdatedAt, got.StartedAt)
+	}
+
+	// Clearing Metadata writes the {} sentinel back, which reads as nil.
+	turn.Metadata = nil
+	if err := repo.UpdateTurn(ctx, turn); err != nil {
+		t.Fatalf("UpdateTurn(clear metadata): %v", err)
+	}
+	got, err = repo.GetTurn(ctx, "turn-update")
+	if err != nil {
+		t.Fatalf("GetTurn: %v", err)
+	}
+	if got.Metadata != nil {
+		t.Errorf("Metadata = %#v, want nil after being cleared", got.Metadata)
+	}
+}
+
+func TestCompleteTurnStampsNowAndAbandonTurnCollapsesToStartedAt(t *testing.T) {
+	repo := newRepoForSessionTests(t)
+	ctx := context.Background()
+	seedSessionForTurns(t, repo, "task-turn-close", "session-turn-close")
+
+	startedAt := time.Date(2026, 6, 3, 8, 0, 0, 0, time.UTC)
+	for _, id := range []string{"turn-complete", "turn-abandon", "turn-already-closed"} {
+		if err := repo.CreateTurn(ctx, &models.Turn{
+			ID: id, TaskSessionID: "session-turn-close", TaskID: "task-turn-close", StartedAt: startedAt,
+		}); err != nil {
+			t.Fatalf("CreateTurn(%s): %v", id, err)
+		}
+	}
+
+	if err := repo.CompleteTurn(ctx, "turn-complete"); err != nil {
+		t.Fatalf("CompleteTurn: %v", err)
+	}
+	completed, err := repo.GetTurn(ctx, "turn-complete")
+	if err != nil {
+		t.Fatalf("GetTurn: %v", err)
+	}
+	if completed.CompletedAt == nil {
+		t.Fatal("CompletedAt = nil after CompleteTurn")
+	}
+	if !completed.CompletedAt.After(startedAt) {
+		t.Errorf("CompletedAt = %v, want a wall-clock stamp after StartedAt %v", *completed.CompletedAt, startedAt)
+	}
+
+	// AbandonTurn gives the orphaned turn zero duration rather than hours of
+	// dead time.
+	if err := repo.AbandonTurn(ctx, "turn-abandon"); err != nil {
+		t.Fatalf("AbandonTurn: %v", err)
+	}
+	abandoned, err := repo.GetTurn(ctx, "turn-abandon")
+	if err != nil {
+		t.Fatalf("GetTurn: %v", err)
+	}
+	if abandoned.CompletedAt == nil {
+		t.Fatal("CompletedAt = nil after AbandonTurn")
+	}
+	assertTimeEqual(t, "abandoned CompletedAt", *abandoned.CompletedAt, startedAt)
+
+	// AbandonTurn must not rewrite a turn that is already closed.
+	closedAt := startedAt.Add(90 * time.Minute)
+	if err := repo.UpdateTurn(ctx, &models.Turn{ID: "turn-already-closed", CompletedAt: &closedAt}); err != nil {
+		t.Fatalf("UpdateTurn: %v", err)
+	}
+	if err := repo.AbandonTurn(ctx, "turn-already-closed"); err != nil {
+		t.Fatalf("AbandonTurn(already closed): %v", err)
+	}
+	stillClosed, err := repo.GetTurn(ctx, "turn-already-closed")
+	if err != nil {
+		t.Fatalf("GetTurn: %v", err)
+	}
+	assertTimeEqual(t, "already-closed CompletedAt", *stillClosed.CompletedAt, closedAt)
+}
+
+// --- Batch and active-session reads --------------------------------------
+//
+// These feed the kanban card summaries and the environment-sharing guards.
+// They share one fixture: three tasks with a mix of primary/secondary and
+// active/terminal sessions on two task environments.
+
+type sessionBatchFixture struct {
+	repo *Repository
+}
+
+func seedSessionBatchFixture(t *testing.T) *sessionBatchFixture {
+	t.Helper()
+	repo := newRepoForSessionTests(t)
+	ctx := context.Background()
+
+	for _, taskID := range []string{"task-batch-1", "task-batch-2", "task-batch-3"} {
+		if err := repo.CreateTask(ctx, &models.Task{ID: taskID, Title: taskID}); err != nil {
+			t.Fatalf("CreateTask(%s): %v", taskID, err)
+		}
+	}
+	// One environment per task (task_environments.task_id is UNIQUE); the
+	// "shared" one is owned by task-batch-1 and borrowed by task-batch-2.
+	for envID, ownerTaskID := range map[string]string{
+		"env-batch-shared": "task-batch-1",
+		"env-batch-solo":   "task-batch-3",
+	} {
+		if err := repo.CreateTaskEnvironment(ctx, &models.TaskEnvironment{
+			ID: envID, TaskID: ownerTaskID, ExecutorType: string(models.ExecutorTypeLocal),
+			Status: models.TaskEnvironmentStatusReady,
+		}); err != nil {
+			t.Fatalf("CreateTaskEnvironment(%s): %v", envID, err)
+		}
+	}
+
+	sessions := []*models.TaskSession{
+		{ID: "session-b1-primary", TaskID: "task-batch-1", IsPrimary: true,
+			State: models.TaskSessionStateRunning, TaskEnvironmentID: "env-batch-shared",
+			EnvironmentID: "env-batch-shared", ReviewStatus: models.ReviewStatusPending},
+		{ID: "session-b1-secondary", TaskID: "task-batch-1",
+			State: models.TaskSessionStateCompleted, TaskEnvironmentID: "env-batch-shared"},
+		{ID: "session-b2-primary", TaskID: "task-batch-2", IsPrimary: true,
+			State: models.TaskSessionStateWaitingForInput, TaskEnvironmentID: "env-batch-shared"},
+		// task-batch-3 has only a non-primary, terminal session.
+		{ID: "session-b3-secondary", TaskID: "task-batch-3",
+			State: models.TaskSessionStateCompleted, TaskEnvironmentID: "env-batch-solo"},
+	}
+	for _, session := range sessions {
+		if err := repo.CreateTaskSession(ctx, session); err != nil {
+			t.Fatalf("CreateTaskSession(%s): %v", session.ID, err)
+		}
+	}
+	return &sessionBatchFixture{repo: repo}
+}
+
+func TestGetPrimarySessionIDsByTaskIDsOmitsTasksWithoutAPrimary(t *testing.T) {
+	fixture := seedSessionBatchFixture(t)
+	ctx := context.Background()
+
+	got, err := fixture.repo.GetPrimarySessionIDsByTaskIDs(ctx,
+		[]string{"task-batch-1", "task-batch-2", "task-batch-3", "task-batch-missing"})
+	if err != nil {
+		t.Fatalf("GetPrimarySessionIDsByTaskIDs: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("map = %v, want exactly the two tasks with a primary session", got)
+	}
+	if got["task-batch-1"] != "session-b1-primary" {
+		t.Errorf("task-batch-1 = %q, want session-b1-primary", got["task-batch-1"])
+	}
+	if got["task-batch-2"] != "session-b2-primary" {
+		t.Errorf("task-batch-2 = %q, want session-b2-primary", got["task-batch-2"])
+	}
+
+	empty, err := fixture.repo.GetPrimarySessionIDsByTaskIDs(ctx, nil)
+	if err != nil {
+		t.Fatalf("GetPrimarySessionIDsByTaskIDs(nil): %v", err)
+	}
+	if empty == nil || len(empty) != 0 {
+		t.Errorf("nil input = %v, want a non-nil empty map", empty)
+	}
+}
+
+func TestGetSessionCountsByTaskIDsCountsEverySessionState(t *testing.T) {
+	fixture := seedSessionBatchFixture(t)
+	ctx := context.Background()
+
+	got, err := fixture.repo.GetSessionCountsByTaskIDs(ctx,
+		[]string{"task-batch-1", "task-batch-2", "task-batch-3", "task-batch-missing"})
+	if err != nil {
+		t.Fatalf("GetSessionCountsByTaskIDs: %v", err)
+	}
+	want := map[string]int{"task-batch-1": 2, "task-batch-2": 1, "task-batch-3": 1}
+	if len(got) != len(want) {
+		t.Fatalf("map = %v, want %v (tasks with no sessions are omitted)", got, want)
+	}
+	for taskID, count := range want {
+		if got[taskID] != count {
+			t.Errorf("count[%s] = %d, want %d", taskID, got[taskID], count)
+		}
+	}
+
+	empty, err := fixture.repo.GetSessionCountsByTaskIDs(ctx, nil)
+	if err != nil {
+		t.Fatalf("GetSessionCountsByTaskIDs(nil): %v", err)
+	}
+	if empty == nil || len(empty) != 0 {
+		t.Errorf("nil input = %v, want a non-nil empty map", empty)
+	}
+}
+
+func TestGetPrimarySessionInfoByTaskIDsProjectsStateAndExecutor(t *testing.T) {
+	fixture := seedSessionBatchFixture(t)
+	ctx := context.Background()
+
+	got, err := fixture.repo.GetPrimarySessionInfoByTaskIDs(ctx,
+		[]string{"task-batch-1", "task-batch-2", "task-batch-3"})
+	if err != nil {
+		t.Fatalf("GetPrimarySessionInfoByTaskIDs: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("map has %d entries (%v), want 2 — task-batch-3 has no primary", len(got), got)
+	}
+	first := got["task-batch-1"]
+	if first == nil {
+		t.Fatal("task-batch-1 missing from the result")
+	}
+	if first.ID != "session-b1-primary" || first.TaskID != "task-batch-1" {
+		t.Errorf("identity = %q/%q, want session-b1-primary/task-batch-1", first.ID, first.TaskID)
+	}
+	if first.State != models.TaskSessionStateRunning {
+		t.Errorf("State = %q, want RUNNING", first.State)
+	}
+	if first.ReviewStatus != models.ReviewStatusPending {
+		t.Errorf("ReviewStatus = %q, want %q", first.ReviewStatus, models.ReviewStatusPending)
+	}
+	second := got["task-batch-2"]
+	if second == nil || second.State != models.TaskSessionStateWaitingForInput {
+		t.Errorf("task-batch-2 = %+v, want a WAITING_FOR_INPUT primary session", second)
+	}
+
+	empty, err := fixture.repo.GetPrimarySessionInfoByTaskIDs(ctx, nil)
+	if err != nil {
+		t.Fatalf("GetPrimarySessionInfoByTaskIDs(nil): %v", err)
+	}
+	if empty == nil || len(empty) != 0 {
+		t.Errorf("nil input = %v, want a non-nil empty map", empty)
+	}
+}
+
+func TestListActiveTaskSessionsFiltersTerminalStates(t *testing.T) {
+	fixture := seedSessionBatchFixture(t)
+	ctx := context.Background()
+
+	all, err := fixture.repo.ListActiveTaskSessions(ctx)
+	if err != nil {
+		t.Fatalf("ListActiveTaskSessions: %v", err)
+	}
+	activeIDs := make(map[string]bool, len(all))
+	for _, session := range all {
+		activeIDs[session.ID] = true
+	}
+	if len(all) != 2 {
+		t.Fatalf("ListActiveTaskSessions returned %d sessions (%v), want 2", len(all), activeIDs)
+	}
+	if !activeIDs["session-b1-primary"] || !activeIDs["session-b2-primary"] {
+		t.Errorf("active sessions = %v, want the RUNNING and WAITING_FOR_INPUT rows", activeIDs)
+	}
+	if activeIDs["session-b1-secondary"] || activeIDs["session-b3-secondary"] {
+		t.Errorf("active sessions = %v, must exclude COMPLETED rows", activeIDs)
+	}
+
+	scoped, err := fixture.repo.ListActiveTaskSessionsByTaskID(ctx, "task-batch-1")
+	if err != nil {
+		t.Fatalf("ListActiveTaskSessionsByTaskID: %v", err)
+	}
+	if len(scoped) != 1 || scoped[0].ID != "session-b1-primary" {
+		t.Errorf("task-scoped active sessions = %+v, want only session-b1-primary", scoped)
+	}
+	none, err := fixture.repo.ListActiveTaskSessionsByTaskID(ctx, "task-batch-3")
+	if err != nil {
+		t.Fatalf("ListActiveTaskSessionsByTaskID(terminal-only): %v", err)
+	}
+	if len(none) != 0 {
+		t.Errorf("terminal-only task returned %+v, want empty", none)
+	}
+}
+
+func TestTaskEnvironmentSharingGuardsSeeOnlyActiveForeignSessions(t *testing.T) {
+	fixture := seedSessionBatchFixture(t)
+	ctx := context.Background()
+	repo := fixture.repo
+
+	hasActive, err := repo.HasActiveTaskSessionsByEnvironment(ctx, "env-batch-shared")
+	if err != nil {
+		t.Fatalf("HasActiveTaskSessionsByEnvironment: %v", err)
+	}
+	if !hasActive {
+		t.Error("HasActiveTaskSessionsByEnvironment = false, want true for the RUNNING session")
+	}
+	hasActive, err = repo.HasActiveTaskSessionsByEnvironment(ctx, "env-batch-solo")
+	if err != nil {
+		t.Fatalf("HasActiveTaskSessionsByEnvironment(solo): %v", err)
+	}
+	if hasActive {
+		t.Error("HasActiveTaskSessionsByEnvironment(solo) = true, want false — its only session is COMPLETED")
+	}
+
+	// task-batch-2's active session borrows env-batch-shared, so the guard
+	// fires for task-batch-1 but not for task-batch-2 itself.
+	borrowed, err := repo.HasActiveTaskSessionsByTaskEnvironmentExcludingTask(ctx, "env-batch-shared", "task-batch-1")
+	if err != nil {
+		t.Fatalf("HasActiveTaskSessionsByTaskEnvironmentExcludingTask: %v", err)
+	}
+	if !borrowed {
+		t.Error("guard = false, want true — task-batch-2 holds an active session on the shared environment")
+	}
+	borrowerID, err := repo.FindActiveTaskSessionTaskIDByTaskEnvironmentExcludingTask(ctx, "env-batch-shared", "task-batch-1")
+	if err != nil {
+		t.Fatalf("FindActiveTaskSessionTaskIDByTaskEnvironmentExcludingTask: %v", err)
+	}
+	if borrowerID != "task-batch-2" {
+		t.Errorf("borrower = %q, want task-batch-2", borrowerID)
+	}
+
+	borrowed, err = repo.HasActiveTaskSessionsByTaskEnvironmentExcludingTask(ctx, "env-batch-shared", "task-batch-2")
+	if err != nil {
+		t.Fatalf("guard excluding task-batch-2: %v", err)
+	}
+	if !borrowed {
+		t.Error("guard = false, want true — task-batch-1 also holds an active session there")
+	}
+
+	// No active foreign session at all: both guards report the empty answer
+	// rather than an error.
+	borrowed, err = repo.HasActiveTaskSessionsByTaskEnvironmentExcludingTask(ctx, "env-batch-solo", "task-batch-3")
+	if err != nil {
+		t.Fatalf("guard on the solo environment: %v", err)
+	}
+	if borrowed {
+		t.Error("guard = true on the solo environment, want false")
+	}
+	borrowerID, err = repo.FindActiveTaskSessionTaskIDByTaskEnvironmentExcludingTask(ctx, "env-batch-solo", "task-batch-3")
+	if err != nil {
+		t.Fatalf("borrower lookup on the solo environment: %v", err)
+	}
+	if borrowerID != "" {
+		t.Errorf("borrower = %q, want an empty string when nothing matches", borrowerID)
+	}
+}
+
+func TestGetTaskSessionByTaskIDReturnsNewestWhileActiveVariantFiltersState(t *testing.T) {
+	fixture := seedSessionBatchFixture(t)
+	ctx := context.Background()
+	repo := fixture.repo
+
+	// GetTaskSessionByTaskID is newest-by-started_at, not primary-first, so
+	// pin the two task-batch-1 sessions with the terminal one newest.
+	stamps := map[string]time.Time{
+		"session-b1-primary":   time.Date(2026, 7, 1, 8, 0, 0, 0, time.UTC),
+		"session-b1-secondary": time.Date(2026, 7, 1, 9, 0, 0, 0, time.UTC),
+	}
+	for sessionID, startedAt := range stamps {
+		if _, err := repo.db.ExecContext(ctx, repo.db.Rebind(
+			`UPDATE task_sessions SET started_at = ? WHERE id = ?`), startedAt, sessionID); err != nil {
+			t.Fatalf("pin started_at for %s: %v", sessionID, err)
+		}
+	}
+
+	got, err := repo.GetTaskSessionByTaskID(ctx, "task-batch-1")
+	if err != nil {
+		t.Fatalf("GetTaskSessionByTaskID: %v", err)
+	}
+	if got.ID != "session-b1-secondary" {
+		t.Errorf("GetTaskSessionByTaskID = %q, want session-b1-secondary (newest by started_at)", got.ID)
+	}
+
+	// The active-only variant skips the newer COMPLETED row.
+	active, err := repo.GetActiveTaskSessionByTaskID(ctx, "task-batch-1")
+	if err != nil {
+		t.Fatalf("GetActiveTaskSessionByTaskID: %v", err)
+	}
+	if active.ID != "session-b1-primary" {
+		t.Errorf("GetActiveTaskSessionByTaskID = %q, want session-b1-primary (the only active row)", active.ID)
+	}
+	if active.State != models.TaskSessionStateRunning {
+		t.Errorf("State = %q, want RUNNING", active.State)
+	}
+
+	// task-batch-3's only session is COMPLETED: found by the plain read,
+	// reported as not-found by the active-only read.
+	got, err = repo.GetTaskSessionByTaskID(ctx, "task-batch-3")
+	if err != nil {
+		t.Fatalf("GetTaskSessionByTaskID(task-batch-3): %v", err)
+	}
+	if got.ID != "session-b3-secondary" {
+		t.Errorf("GetTaskSessionByTaskID = %q, want session-b3-secondary", got.ID)
+	}
+	_, err = repo.GetActiveTaskSessionByTaskID(ctx, "task-batch-3")
+	if !errors.Is(err, models.ErrTaskSessionNotFound) {
+		t.Errorf("GetActiveTaskSessionByTaskID(terminal-only) error = %v, want ErrTaskSessionNotFound", err)
+	}
+	_, err = repo.GetTaskSessionByTaskID(ctx, "task-batch-missing")
+	if !errors.Is(err, models.ErrTaskSessionNotFound) {
+		t.Errorf("GetTaskSessionByTaskID(missing) error = %v, want ErrTaskSessionNotFound", err)
+	}
+}

--- a/apps/backend/internal/task/repository/sqlite/session_test.go
+++ b/apps/backend/internal/task/repository/sqlite/session_test.go
@@ -1988,7 +1988,12 @@ func TestCompleteTurnStampsNowAndAbandonTurnCollapsesToStartedAt(t *testing.T) {
 
 	// AbandonTurn must not rewrite a turn that is already closed.
 	closedAt := startedAt.Add(90 * time.Minute)
-	if err := repo.UpdateTurn(ctx, &models.Turn{ID: "turn-already-closed", CompletedAt: &closedAt}); err != nil {
+	alreadyClosed, err := repo.GetTurn(ctx, "turn-already-closed")
+	if err != nil {
+		t.Fatalf("GetTurn(turn-already-closed): %v", err)
+	}
+	alreadyClosed.CompletedAt = &closedAt
+	if err := repo.UpdateTurn(ctx, alreadyClosed); err != nil {
 		t.Fatalf("UpdateTurn: %v", err)
 	}
 	if err := repo.AbandonTurn(ctx, "turn-already-closed"); err != nil {
@@ -2305,5 +2310,65 @@ func TestGetTaskSessionByTaskIDReturnsNewestWhileActiveVariantFiltersState(t *te
 	_, err = repo.GetTaskSessionByTaskID(ctx, "task-batch-missing")
 	if !errors.Is(err, models.ErrTaskSessionNotFound) {
 		t.Errorf("GetTaskSessionByTaskID(missing) error = %v, want ErrTaskSessionNotFound", err)
+	}
+}
+
+// TestHasActiveTaskSessionsByEnvironmentKeysOffEnvironmentIDNotTaskEnvironmentID
+// discriminates the two columns. The shared batch fixture sets environment_id
+// and task_environment_id to the same value, so on its own it cannot tell
+// which column the guard reads — swapping them there would go unnoticed.
+func TestHasActiveTaskSessionsByEnvironmentKeysOffEnvironmentIDNotTaskEnvironmentID(t *testing.T) {
+	repo := newRepoForSessionTests(t)
+	ctx := context.Background()
+
+	if err := repo.CreateTask(ctx, &models.Task{ID: "task-envcol", Title: "env column"}); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	if err := repo.CreateTaskEnvironment(ctx, &models.TaskEnvironment{
+		ID: "env-col-taskenv", TaskID: "task-envcol",
+		ExecutorType: string(models.ExecutorTypeLocal), Status: models.TaskEnvironmentStatusReady,
+	}); err != nil {
+		t.Fatalf("CreateTaskEnvironment: %v", err)
+	}
+	// Active, but only task_environment_id points at env-col-taskenv;
+	// environment_id is left empty.
+	if err := repo.CreateTaskSession(ctx, &models.TaskSession{
+		ID: "session-envcol-taskenv-only", TaskID: "task-envcol",
+		State: models.TaskSessionStateRunning, TaskEnvironmentID: "env-col-taskenv",
+	}); err != nil {
+		t.Fatalf("CreateTaskSession(task-env only): %v", err)
+	}
+
+	hasActive, err := repo.HasActiveTaskSessionsByEnvironment(ctx, "env-col-taskenv")
+	if err != nil {
+		t.Fatalf("HasActiveTaskSessionsByEnvironment: %v", err)
+	}
+	if hasActive {
+		t.Error("HasActiveTaskSessionsByEnvironment = true for a value only present in task_environment_id; " +
+			"the guard must key off environment_id")
+	}
+	// The task-environment guard does see the same row, which is what makes
+	// the negative above meaningful rather than an empty-table artifact.
+	borrowed, err := repo.HasActiveTaskSessionsByTaskEnvironmentExcludingTask(ctx, "env-col-taskenv", "task-other")
+	if err != nil {
+		t.Fatalf("HasActiveTaskSessionsByTaskEnvironmentExcludingTask: %v", err)
+	}
+	if !borrowed {
+		t.Fatal("task-environment guard = false; the fixture row is not visible, so the negative above proves nothing")
+	}
+
+	// Now a session whose environment_id carries the value: the guard fires.
+	if err := repo.CreateTaskSession(ctx, &models.TaskSession{
+		ID: "session-envcol-envid", TaskID: "task-envcol",
+		State: models.TaskSessionStateRunning, EnvironmentID: "env-col-envid",
+	}); err != nil {
+		t.Fatalf("CreateTaskSession(environment_id): %v", err)
+	}
+	hasActive, err = repo.HasActiveTaskSessionsByEnvironment(ctx, "env-col-envid")
+	if err != nil {
+		t.Fatalf("HasActiveTaskSessionsByEnvironment(environment_id): %v", err)
+	}
+	if !hasActive {
+		t.Error("HasActiveTaskSessionsByEnvironment = false for a value present in environment_id, want true")
 	}
 }

--- a/apps/backend/internal/task/repository/sqlite/task_archive_test.go
+++ b/apps/backend/internal/task/repository/sqlite/task_archive_test.go
@@ -1,0 +1,374 @@
+package sqlite
+
+// Coverage for the archive/unarchive CAS surface of task.go. The cascade
+// stamp is the interesting part: ArchiveTaskIfActive only fires on an active
+// row, UnarchiveTaskByCascade only restores rows its own cascade archived,
+// and UnarchiveTask only restores rows no cascade owns.
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/task/models"
+	wfmodels "github.com/kandev/kandev/internal/workflow/models"
+)
+
+const archiveWorkspaceID = "ws-archive"
+
+func newRepoForArchiveTests(t *testing.T, taskIDList ...string) *Repository {
+	t.Helper()
+	repo := newRepoForEntityTests(t)
+	ctx := context.Background()
+	seedWorkspace(t, repo, archiveWorkspaceID)
+	for _, id := range taskIDList {
+		if err := repo.CreateTask(ctx, &models.Task{
+			ID: id, WorkspaceID: archiveWorkspaceID, Title: id,
+		}); err != nil {
+			t.Fatalf("CreateTask(%s): %v", id, err)
+		}
+	}
+	return repo
+}
+
+// archivedCascadeID reads the raw stamp column so the assertions do not
+// depend on whichever SELECT projection happens to include it.
+func archivedCascadeID(t *testing.T, repo *Repository, taskID string) string {
+	t.Helper()
+	var cascade string
+	if err := repo.db.QueryRowContext(context.Background(), repo.db.Rebind(
+		`SELECT COALESCE(archived_by_cascade_id, '') FROM tasks WHERE id = ?`), taskID).Scan(&cascade); err != nil {
+		t.Fatalf("read archived_by_cascade_id for %s: %v", taskID, err)
+	}
+	return cascade
+}
+
+func TestArchiveTaskIfActiveOnlyFiresOnActiveRows(t *testing.T) {
+	repo := newRepoForArchiveTests(t, "task-arch-cas")
+	ctx := context.Background()
+
+	changed, err := repo.ArchiveTaskIfActive(ctx, "task-arch-cas", "cascade-1")
+	if err != nil {
+		t.Fatalf("ArchiveTaskIfActive: %v", err)
+	}
+	if !changed {
+		t.Fatal("ArchiveTaskIfActive = false on an active row, want true")
+	}
+	got, err := repo.GetTask(ctx, "task-arch-cas")
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if got.ArchivedAt == nil {
+		t.Fatal("ArchivedAt = nil after archiving")
+	}
+	firstArchivedAt := *got.ArchivedAt
+	if cascade := archivedCascadeID(t, repo, "task-arch-cas"); cascade != "cascade-1" {
+		t.Errorf("archived_by_cascade_id = %q, want cascade-1", cascade)
+	}
+
+	// A second cascade must not re-stamp an already-archived row.
+	changed, err = repo.ArchiveTaskIfActive(ctx, "task-arch-cas", "cascade-2")
+	if err != nil {
+		t.Fatalf("second ArchiveTaskIfActive: %v", err)
+	}
+	if changed {
+		t.Error("ArchiveTaskIfActive = true on an already-archived row, want false")
+	}
+	if cascade := archivedCascadeID(t, repo, "task-arch-cas"); cascade != "cascade-1" {
+		t.Errorf("archived_by_cascade_id = %q, want cascade-1 preserved", cascade)
+	}
+	got, err = repo.GetTask(ctx, "task-arch-cas")
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if !got.ArchivedAt.Equal(firstArchivedAt) {
+		t.Errorf("ArchivedAt = %v, want the first value %v preserved", *got.ArchivedAt, firstArchivedAt)
+	}
+
+	// An unknown id is reported as "not changed", not as an error.
+	changed, err = repo.ArchiveTaskIfActive(ctx, "task-arch-nowhere", "cascade-3")
+	if err != nil {
+		t.Fatalf("ArchiveTaskIfActive(unknown): %v", err)
+	}
+	if changed {
+		t.Error("ArchiveTaskIfActive(unknown) = true, want false")
+	}
+}
+
+func TestArchiveTaskIfActiveWithoutCascadeIDLeavesStampEmpty(t *testing.T) {
+	repo := newRepoForArchiveTests(t, "task-arch-nocascade")
+	ctx := context.Background()
+
+	changed, err := repo.ArchiveTaskIfActive(ctx, "task-arch-nocascade", "")
+	if err != nil {
+		t.Fatalf("ArchiveTaskIfActive: %v", err)
+	}
+	if !changed {
+		t.Fatal("ArchiveTaskIfActive = false, want true")
+	}
+	if cascade := archivedCascadeID(t, repo, "task-arch-nocascade"); cascade != "" {
+		t.Errorf("archived_by_cascade_id = %q, want empty for a manual archive", cascade)
+	}
+}
+
+func TestUnarchiveTaskByCascadeRestoresOnlyItsOwnRows(t *testing.T) {
+	repo := newRepoForArchiveTests(t, "task-owned", "task-other-cascade", "task-manual")
+	ctx := context.Background()
+
+	for id, cascade := range map[string]string{
+		"task-owned":         "cascade-a",
+		"task-other-cascade": "cascade-b",
+		"task-manual":        "",
+	} {
+		if _, err := repo.ArchiveTaskIfActive(ctx, id, cascade); err != nil {
+			t.Fatalf("ArchiveTaskIfActive(%s): %v", id, err)
+		}
+	}
+
+	restored, err := repo.UnarchiveTaskByCascade(ctx, "task-owned", "cascade-a")
+	if err != nil {
+		t.Fatalf("UnarchiveTaskByCascade: %v", err)
+	}
+	if !restored {
+		t.Fatal("UnarchiveTaskByCascade = false on its own row, want true")
+	}
+	owned, err := repo.GetTask(ctx, "task-owned")
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if owned.ArchivedAt != nil {
+		t.Errorf("ArchivedAt = %v, want nil after restoration", *owned.ArchivedAt)
+	}
+	if cascade := archivedCascadeID(t, repo, "task-owned"); cascade != "" {
+		t.Errorf("archived_by_cascade_id = %q, want it cleared", cascade)
+	}
+
+	// A row another cascade owns, and a manually archived row, both survive.
+	for _, id := range []string{"task-other-cascade", "task-manual"} {
+		restored, err = repo.UnarchiveTaskByCascade(ctx, id, "cascade-a")
+		if err != nil {
+			t.Fatalf("UnarchiveTaskByCascade(%s): %v", id, err)
+		}
+		if restored {
+			t.Errorf("UnarchiveTaskByCascade(%s) = true, want false — cascade-a does not own it", id)
+		}
+		still, err := repo.GetTask(ctx, id)
+		if err != nil {
+			t.Fatalf("GetTask(%s): %v", id, err)
+		}
+		if still.ArchivedAt == nil {
+			t.Errorf("%s ArchivedAt = nil, want it still archived", id)
+		}
+	}
+
+	if _, err := repo.UnarchiveTaskByCascade(ctx, "task-owned", ""); err == nil {
+		t.Error("UnarchiveTaskByCascade with an empty cascade id returned nil error")
+	}
+}
+
+func TestUnarchiveTaskRestoresOnlyUnstampedArchivedRows(t *testing.T) {
+	repo := newRepoForArchiveTests(t, "task-manual-arch", "task-cascade-arch", "task-active")
+	ctx := context.Background()
+
+	if _, err := repo.ArchiveTaskIfActive(ctx, "task-manual-arch", ""); err != nil {
+		t.Fatalf("ArchiveTaskIfActive(manual): %v", err)
+	}
+	if _, err := repo.ArchiveTaskIfActive(ctx, "task-cascade-arch", "cascade-x"); err != nil {
+		t.Fatalf("ArchiveTaskIfActive(cascade): %v", err)
+	}
+
+	restored, err := repo.UnarchiveTask(ctx, "task-manual-arch")
+	if err != nil {
+		t.Fatalf("UnarchiveTask: %v", err)
+	}
+	if !restored {
+		t.Fatal("UnarchiveTask = false on a manually archived row, want true")
+	}
+	manual, err := repo.GetTask(ctx, "task-manual-arch")
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if manual.ArchivedAt != nil {
+		t.Errorf("ArchivedAt = %v, want nil", *manual.ArchivedAt)
+	}
+
+	// A cascade-stamped row is off limits to the manual path.
+	restored, err = repo.UnarchiveTask(ctx, "task-cascade-arch")
+	if err != nil {
+		t.Fatalf("UnarchiveTask(cascade-stamped): %v", err)
+	}
+	if restored {
+		t.Error("UnarchiveTask = true on a cascade-stamped row, want false")
+	}
+	stamped, err := repo.GetTask(ctx, "task-cascade-arch")
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if stamped.ArchivedAt == nil {
+		t.Error("cascade-stamped ArchivedAt = nil, want it still archived")
+	}
+
+	// An already-active row reports no change.
+	restored, err = repo.UnarchiveTask(ctx, "task-active")
+	if err != nil {
+		t.Fatalf("UnarchiveTask(active): %v", err)
+	}
+	if restored {
+		t.Error("UnarchiveTask = true on an already-active row, want false")
+	}
+}
+
+func TestArchiveTaskReportsMissingRowWithSentinel(t *testing.T) {
+	repo := newRepoForArchiveTests(t)
+
+	err := repo.ArchiveTask(context.Background(), "task-arch-absent")
+	if !errors.Is(err, ErrTaskNotFound) {
+		t.Fatalf("ArchiveTask(missing) error = %v, want ErrTaskNotFound", err)
+	}
+}
+
+func TestListTasksForAutoArchivePicksOnlyStaleActiveTasksOnEligibleSteps(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+	ctx := context.Background()
+	seedWorkspace(t, repo, archiveWorkspaceID)
+	workflows := newAutoOriginWorkflowStore(t, repo)
+	if err := repo.CreateWorkflow(ctx, &models.Workflow{
+		ID: "wf-auto-archive", WorkspaceID: archiveWorkspaceID, Name: "Auto archive",
+	}); err != nil {
+		t.Fatalf("CreateWorkflow: %v", err)
+	}
+	if err := workflows.CreateStep(ctx, &wfmodels.WorkflowStep{
+		ID: "step-auto-archive", WorkflowID: "wf-auto-archive", Name: "Done",
+		Position: 0, AutoArchiveAfterHours: 1,
+	}); err != nil {
+		t.Fatalf("CreateStep(eligible): %v", err)
+	}
+	if err := workflows.CreateStep(ctx, &wfmodels.WorkflowStep{
+		ID: "step-no-auto-archive", WorkflowID: "wf-auto-archive", Name: "Work",
+		Position: 1, AutoArchiveAfterHours: 0,
+	}); err != nil {
+		t.Fatalf("CreateStep(ineligible): %v", err)
+	}
+
+	rows := []struct {
+		id      string
+		stepID  string
+		updated time.Time
+	}{
+		{"task-stale-eligible", "step-auto-archive", time.Now().UTC().Add(-48 * time.Hour)},
+		{"task-fresh-eligible", "step-auto-archive", time.Now().UTC()},
+		{"task-stale-ineligible", "step-no-auto-archive", time.Now().UTC().Add(-48 * time.Hour)},
+		{"task-stale-archived", "step-auto-archive", time.Now().UTC().Add(-48 * time.Hour)},
+	}
+	for _, row := range rows {
+		if err := repo.CreateTask(ctx, &models.Task{
+			ID: row.id, WorkspaceID: archiveWorkspaceID, WorkflowID: "wf-auto-archive",
+			WorkflowStepID: row.stepID, Title: row.id,
+		}); err != nil {
+			t.Fatalf("CreateTask(%s): %v", row.id, err)
+		}
+	}
+	if err := repo.ArchiveTask(ctx, "task-stale-archived"); err != nil {
+		t.Fatalf("ArchiveTask: %v", err)
+	}
+	// Pin updated_at last: ArchiveTask bumps it.
+	for _, row := range rows {
+		if _, err := repo.db.ExecContext(ctx, repo.db.Rebind(
+			`UPDATE tasks SET updated_at = ? WHERE id = ?`), row.updated, row.id); err != nil {
+			t.Fatalf("pin updated_at for %s: %v", row.id, err)
+		}
+	}
+
+	got, err := repo.ListTasksForAutoArchive(ctx)
+	if err != nil {
+		t.Fatalf("ListTasksForAutoArchive: %v", err)
+	}
+	assertIDsEqual(t, "ListTasksForAutoArchive", taskIDs(got), []string{"task-stale-eligible"})
+}
+
+func TestListArchivedTasksWithActiveSessionsReturnsOnlyStuckTasks(t *testing.T) {
+	repo := newRepoForArchiveTests(t, "task-arch-running", "task-arch-done", "task-active-running")
+	ctx := context.Background()
+
+	sessions := []struct {
+		id     string
+		taskID string
+		state  models.TaskSessionState
+	}{
+		{"session-arch-running", "task-arch-running", models.TaskSessionStateRunning},
+		{"session-arch-done", "task-arch-done", models.TaskSessionStateCompleted},
+		{"session-active-running", "task-active-running", models.TaskSessionStateRunning},
+	}
+	for _, session := range sessions {
+		if err := repo.CreateTaskSession(ctx, &models.TaskSession{
+			ID: session.id, TaskID: session.taskID, State: session.state,
+		}); err != nil {
+			t.Fatalf("CreateTaskSession(%s): %v", session.id, err)
+		}
+	}
+	for _, id := range []string{"task-arch-running", "task-arch-done"} {
+		if err := repo.ArchiveTask(ctx, id); err != nil {
+			t.Fatalf("ArchiveTask(%s): %v", id, err)
+		}
+	}
+
+	got, err := repo.ListArchivedTasksWithActiveSessions(ctx)
+	if err != nil {
+		t.Fatalf("ListArchivedTasksWithActiveSessions: %v", err)
+	}
+	assertIDsEqual(t, "ListArchivedTasksWithActiveSessions", got, []string{"task-arch-running"})
+}
+
+func TestIncrementTaskSequenceAndWorkspaceTaskPrefix(t *testing.T) {
+	repo := newRepoForEntityTests(t)
+	ctx := context.Background()
+	seedWorkspace(t, repo, archiveWorkspaceID)
+
+	first, err := repo.IncrementTaskSequence(ctx, archiveWorkspaceID)
+	if err != nil {
+		t.Fatalf("IncrementTaskSequence: %v", err)
+	}
+	second, err := repo.IncrementTaskSequence(ctx, archiveWorkspaceID)
+	if err != nil {
+		t.Fatalf("second IncrementTaskSequence: %v", err)
+	}
+	if second != first+1 {
+		t.Errorf("sequence went %d -> %d, want a strict +1 increment", first, second)
+	}
+
+	// A second workspace keeps its own counter.
+	seedWorkspace(t, repo, "ws-archive-other")
+	other, err := repo.IncrementTaskSequence(ctx, "ws-archive-other")
+	if err != nil {
+		t.Fatalf("IncrementTaskSequence(other workspace): %v", err)
+	}
+	if other != first {
+		t.Errorf("other workspace sequence = %d, want it to start at %d independently", other, first)
+	}
+
+	// A seeded workspace has no office workflow and falls back to the KAN
+	// prefix default baked into the COALESCE.
+	prefix, officeWorkflowID, err := repo.GetWorkspaceTaskPrefix(ctx, archiveWorkspaceID)
+	if err != nil {
+		t.Fatalf("GetWorkspaceTaskPrefix: %v", err)
+	}
+	if prefix != "KAN" {
+		t.Errorf("prefix = %q, want the KAN default", prefix)
+	}
+	if officeWorkflowID != "" {
+		t.Errorf("officeWorkflowID = %q, want empty for a workspace with no office workflow", officeWorkflowID)
+	}
+
+	officeID, err := repo.EnsureOfficeWorkflow(ctx, archiveWorkspaceID)
+	if err != nil {
+		t.Fatalf("EnsureOfficeWorkflow: %v", err)
+	}
+	_, officeWorkflowID, err = repo.GetWorkspaceTaskPrefix(ctx, archiveWorkspaceID)
+	if err != nil {
+		t.Fatalf("GetWorkspaceTaskPrefix after office workflow: %v", err)
+	}
+	if officeWorkflowID != officeID {
+		t.Errorf("officeWorkflowID = %q, want the stamped %q", officeWorkflowID, officeID)
+	}
+}

--- a/apps/backend/internal/task/repository/sqlite/task_hierarchy_test.go
+++ b/apps/backend/internal/task/repository/sqlite/task_hierarchy_test.go
@@ -1,0 +1,309 @@
+package sqlite
+
+// Coverage for the parent/child/sibling read surface of task.go plus the
+// batch GetTasksByIDs fetch. These share one fixture shape: a parent with
+// active, archived, ephemeral and automation-origin children, so every
+// method's filter clause is exercised against rows that must be excluded.
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/task/models"
+)
+
+const (
+	hierarchyWorkspaceID = "ws-hierarchy"
+	hierarchyParentID    = "task-hierarchy-parent"
+)
+
+// seedHierarchy builds a parent with four children: two ordinary active
+// children, one archived, one ephemeral, plus one automation-origin child.
+// Ordering is pinned by explicit created_at values so the ASC assertions
+// cannot pass by accident.
+func seedHierarchy(t *testing.T) *Repository {
+	t.Helper()
+	repo := newRepoForEntityTests(t)
+	ctx := context.Background()
+	seedWorkspace(t, repo, hierarchyWorkspaceID)
+
+	rows := []struct {
+		id      string
+		created time.Time
+		mutate  func(*models.Task)
+	}{
+		{id: hierarchyParentID, created: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)},
+		{id: "task-child-b", created: time.Date(2026, 1, 3, 0, 0, 0, 0, time.UTC),
+			mutate: func(task *models.Task) { task.ParentID = hierarchyParentID }},
+		{id: "task-child-a", created: time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC),
+			mutate: func(task *models.Task) { task.ParentID = hierarchyParentID }},
+		{id: "task-child-archived", created: time.Date(2026, 1, 4, 0, 0, 0, 0, time.UTC),
+			mutate: func(task *models.Task) { task.ParentID = hierarchyParentID }},
+		{id: "task-child-ephemeral", created: time.Date(2026, 1, 5, 0, 0, 0, 0, time.UTC),
+			mutate: func(task *models.Task) { task.ParentID = hierarchyParentID; task.IsEphemeral = true }},
+		{id: "task-child-automation", created: time.Date(2026, 1, 6, 0, 0, 0, 0, time.UTC),
+			mutate: func(task *models.Task) {
+				task.ParentID = hierarchyParentID
+				task.Origin = models.TaskOriginAutomationRun
+			}},
+		{id: "task-unrelated-root", created: time.Date(2026, 1, 7, 0, 0, 0, 0, time.UTC)},
+	}
+	for _, row := range rows {
+		task := &models.Task{ID: row.id, WorkspaceID: hierarchyWorkspaceID, Title: row.id}
+		if row.mutate != nil {
+			row.mutate(task)
+		}
+		if err := repo.CreateTask(ctx, task); err != nil {
+			t.Fatalf("CreateTask(%s): %v", row.id, err)
+		}
+		if _, err := repo.db.ExecContext(ctx, repo.db.Rebind(
+			`UPDATE tasks SET created_at = ? WHERE id = ?`), row.created, row.id); err != nil {
+			t.Fatalf("pin created_at for %s: %v", row.id, err)
+		}
+	}
+	if err := repo.ArchiveTask(ctx, "task-child-archived"); err != nil {
+		t.Fatalf("ArchiveTask: %v", err)
+	}
+	return repo
+}
+
+func assertIDsEqual(t *testing.T, label string, got, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("%s = %v, want %v", label, got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("%s = %v, want %v", label, got, want)
+		}
+	}
+}
+
+func TestListChildrenExcludesArchivedEphemeralAndAutomationRows(t *testing.T) {
+	repo := seedHierarchy(t)
+	ctx := context.Background()
+
+	got, err := repo.ListChildren(ctx, hierarchyParentID)
+	if err != nil {
+		t.Fatalf("ListChildren: %v", err)
+	}
+	assertIDsEqual(t, "ListChildren", taskIDs(got), []string{"task-child-a", "task-child-b"})
+	for _, child := range got {
+		if child.ParentID != hierarchyParentID {
+			t.Errorf("child %s ParentID = %q, want %q", child.ID, child.ParentID, hierarchyParentID)
+		}
+		if child.Title != child.ID {
+			t.Errorf("child %s Title = %q, want the row's own title", child.ID, child.Title)
+		}
+	}
+
+	empty, err := repo.ListChildren(ctx, "")
+	if err != nil {
+		t.Fatalf("ListChildren(\"\"): %v", err)
+	}
+	if empty == nil || len(empty) != 0 {
+		t.Errorf("ListChildren(\"\") = %v, want a non-nil empty slice", empty)
+	}
+	none, err := repo.ListChildren(ctx, "task-unrelated-root")
+	if err != nil {
+		t.Fatalf("ListChildren(childless): %v", err)
+	}
+	if len(none) != 0 {
+		t.Errorf("ListChildren(childless) = %v, want empty", taskIDs(none))
+	}
+}
+
+func TestListChildrenIncludingArchivedKeepsArchivedButStillDropsEphemeral(t *testing.T) {
+	repo := seedHierarchy(t)
+	ctx := context.Background()
+
+	got, err := repo.ListChildrenIncludingArchived(ctx, hierarchyParentID)
+	if err != nil {
+		t.Fatalf("ListChildrenIncludingArchived: %v", err)
+	}
+	assertIDsEqual(t, "ListChildrenIncludingArchived", taskIDs(got),
+		[]string{"task-child-a", "task-child-b", "task-child-archived"})
+
+	var archived *models.Task
+	for _, child := range got {
+		if child.ID == "task-child-archived" {
+			archived = child
+		}
+	}
+	if archived == nil || archived.ArchivedAt == nil {
+		t.Fatalf("archived child = %+v, want ArchivedAt set", archived)
+	}
+
+	empty, err := repo.ListChildrenIncludingArchived(ctx, "")
+	if err != nil {
+		t.Fatalf("ListChildrenIncludingArchived(\"\"): %v", err)
+	}
+	if empty == nil || len(empty) != 0 {
+		t.Errorf("ListChildrenIncludingArchived(\"\") = %v, want a non-nil empty slice", empty)
+	}
+}
+
+func TestListChildCompletionRowsReturnsCompactActiveChildren(t *testing.T) {
+	repo := seedHierarchy(t)
+	ctx := context.Background()
+
+	if err := repo.UpdateTaskState(ctx, "task-child-a", "DONE"); err != nil {
+		t.Fatalf("UpdateTaskState: %v", err)
+	}
+
+	got, err := repo.ListChildCompletionRows(ctx, hierarchyParentID)
+	if err != nil {
+		t.Fatalf("ListChildCompletionRows: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("ListChildCompletionRows returned %d rows (%+v), want 2", len(got), got)
+	}
+	if got[0].ID != "task-child-a" || got[1].ID != "task-child-b" {
+		t.Fatalf("row order = %q,%q, want task-child-a,task-child-b", got[0].ID, got[1].ID)
+	}
+	if string(got[0].State) != "DONE" {
+		t.Errorf("task-child-a State = %q, want DONE", got[0].State)
+	}
+	if got[0].Title != "task-child-a" {
+		t.Errorf("task-child-a Title = %q, want the row's own title", got[0].Title)
+	}
+	if got[0].UpdatedAt.IsZero() {
+		t.Error("task-child-a UpdatedAt is zero; the column must be projected")
+	}
+
+	empty, err := repo.ListChildCompletionRows(ctx, "")
+	if err != nil {
+		t.Fatalf("ListChildCompletionRows(\"\"): %v", err)
+	}
+	if empty == nil || len(empty) != 0 {
+		t.Errorf("ListChildCompletionRows(\"\") = %v, want a non-nil empty slice", empty)
+	}
+}
+
+func TestListSiblingsExcludesSelfRootsAndOtherWorkspaces(t *testing.T) {
+	repo := seedHierarchy(t)
+	ctx := context.Background()
+
+	got, err := repo.ListSiblings(ctx, "task-child-a")
+	if err != nil {
+		t.Fatalf("ListSiblings: %v", err)
+	}
+	assertIDsEqual(t, "ListSiblings", taskIDs(got), []string{"task-child-b"})
+
+	// A root task has no parent, so it deliberately reports no siblings even
+	// though other roots exist in the same workspace.
+	roots, err := repo.ListSiblings(ctx, hierarchyParentID)
+	if err != nil {
+		t.Fatalf("ListSiblings(root): %v", err)
+	}
+	if roots == nil || len(roots) != 0 {
+		t.Errorf("ListSiblings(root) = %v, want a non-nil empty slice", taskIDs(roots))
+	}
+
+	// A child of the same parent living in a different workspace is not a
+	// sibling: the query pins workspace_id as well as parent_id.
+	seedWorkspace(t, repo, "ws-hierarchy-other")
+	if err := repo.CreateTask(ctx, &models.Task{
+		ID: "task-child-foreign", WorkspaceID: "ws-hierarchy-other",
+		ParentID: hierarchyParentID, Title: "foreign",
+	}); err != nil {
+		t.Fatalf("CreateTask(foreign): %v", err)
+	}
+	got, err = repo.ListSiblings(ctx, "task-child-a")
+	if err != nil {
+		t.Fatalf("ListSiblings after foreign child: %v", err)
+	}
+	assertIDsEqual(t, "ListSiblings (cross-workspace)", taskIDs(got), []string{"task-child-b"})
+
+	// ListSiblings resolves the task first, so an unknown id surfaces
+	// GetTask's sentinel rather than an empty list.
+	missing, err := repo.ListSiblings(ctx, "task-does-not-exist")
+	if !errors.Is(err, ErrTaskNotFound) {
+		t.Fatalf("ListSiblings(missing) error = %v, want ErrTaskNotFound", err)
+	}
+	if missing != nil {
+		t.Errorf("ListSiblings(missing) = %v, want nil alongside the error", taskIDs(missing))
+	}
+}
+
+func TestReparentDirectChildrenMovesEveryChildIncludingArchived(t *testing.T) {
+	repo := seedHierarchy(t)
+	ctx := context.Background()
+	if err := repo.CreateTask(ctx, &models.Task{
+		ID: "task-hierarchy-new-parent", WorkspaceID: hierarchyWorkspaceID, Title: "new parent",
+	}); err != nil {
+		t.Fatalf("CreateTask(new parent): %v", err)
+	}
+
+	before := countRows(t, repo, `SELECT COUNT(1) FROM tasks WHERE parent_id = ?`, hierarchyParentID)
+	if before != 5 {
+		t.Fatalf("children before reparent = %d, want 5", before)
+	}
+
+	if err := repo.ReparentDirectChildren(ctx, hierarchyParentID, "task-hierarchy-new-parent"); err != nil {
+		t.Fatalf("ReparentDirectChildren: %v", err)
+	}
+	if got := countRows(t, repo, `SELECT COUNT(1) FROM tasks WHERE parent_id = ?`, hierarchyParentID); got != 0 {
+		t.Errorf("children left on the old parent = %d, want 0", got)
+	}
+	if got := countRows(t, repo,
+		`SELECT COUNT(1) FROM tasks WHERE parent_id = ?`, "task-hierarchy-new-parent"); got != 5 {
+		t.Errorf("children on the new parent = %d, want all 5 (archived and ephemeral included)", got)
+	}
+
+	// Reparenting to the empty id turns the children into roots.
+	if err := repo.ReparentDirectChildren(ctx, "task-hierarchy-new-parent", ""); err != nil {
+		t.Fatalf("ReparentDirectChildren(to root): %v", err)
+	}
+	if got := countRows(t, repo,
+		`SELECT COUNT(1) FROM tasks WHERE parent_id = ?`, "task-hierarchy-new-parent"); got != 0 {
+		t.Errorf("children after rooting = %d, want 0", got)
+	}
+
+	// An empty old parent is a no-op guard, not a mass update of every root.
+	rootsBefore := countRows(t, repo, `SELECT COUNT(1) FROM tasks WHERE parent_id = ''`)
+	if err := repo.ReparentDirectChildren(ctx, "", "task-hierarchy-new-parent"); err != nil {
+		t.Fatalf("ReparentDirectChildren(\"\"): %v", err)
+	}
+	if got := countRows(t, repo, `SELECT COUNT(1) FROM tasks WHERE parent_id = ''`); got != rootsBefore {
+		t.Errorf("root rows = %d, want %d unchanged — an empty oldParentID must be a no-op", got, rootsBefore)
+	}
+}
+
+func TestGetTasksByIDsFetchesRequestedRowsAndSkipsUnknown(t *testing.T) {
+	repo := seedHierarchy(t)
+	ctx := context.Background()
+
+	got, err := repo.GetTasksByIDs(ctx, []string{"task-child-a", "task-child-archived", "task-nope"})
+	if err != nil {
+		t.Fatalf("GetTasksByIDs: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("GetTasksByIDs returned %d rows (%v), want 2", len(got), taskIDs(got))
+	}
+	byID := make(map[string]*models.Task, len(got))
+	for _, task := range got {
+		byID[task.ID] = task
+	}
+	if byID["task-child-a"] == nil || byID["task-child-archived"] == nil {
+		t.Fatalf("GetTasksByIDs = %v, want both requested rows", taskIDs(got))
+	}
+	// Unlike the list reads, this one is deliberately filter-free: the
+	// archived row must come back.
+	if byID["task-child-archived"].ArchivedAt == nil {
+		t.Error("archived task ArchivedAt = nil, want it populated")
+	}
+	if byID["task-child-a"].WorkspaceID != hierarchyWorkspaceID {
+		t.Errorf("WorkspaceID = %q, want %q", byID["task-child-a"].WorkspaceID, hierarchyWorkspaceID)
+	}
+
+	empty, err := repo.GetTasksByIDs(ctx, nil)
+	if err != nil {
+		t.Fatalf("GetTasksByIDs(nil): %v", err)
+	}
+	if len(empty) != 0 {
+		t.Errorf("GetTasksByIDs(nil) = %v, want empty", taskIDs(empty))
+	}
+}


### PR DESCRIPTION
`internal/task/repository/sqlite` sat at 51.2% statement coverage with five complete persistence surfaces — git snapshots, documents, executor profiles, environments and plans — carrying no tests at all, which is expensive in the task data layer because a dropped column or an inverted condition fails silently. This is test-only work: no production file changed.

## Important Changes

- **Five untested files covered end to end** — `git_snapshots.go` (0% → 88.4%), `document.go` (0% → 93.4%), `executor_profile.go` (0% → 88.2%), `environment.go` (0% → 91.7%), `plan.go` (10% → 95.1%). Create/read/update/delete round trips, list ordering and filters, NULL-vs-empty JSON handling, FK cascades, transaction rollback on a failed coalesce, and the not-found value each method actually returns.
- **Postgres parity** for every dialect-sensitive method touched: `ON CONFLICT ... DO UPDATE` upserts, the `ROW_NUMBER()` batch snapshot read, `COALESCE` + `CASE WHEN` over a nullable `TIMESTAMP`, `is_system` integer booleans and the nullable `env_vars` JSON column. Gated on `KANDEV_TEST_POSTGRES_DSN`, run by `postgres-boot`.
- **Stretch coverage** on the two large files: the hierarchy (`ListChildren`, `ListChildrenIncludingArchived`, `ListChildCompletionRows`, `ListSiblings`, `ReparentDirectChildren`, `GetTasksByIDs`) and archive-cascade CAS methods in `task.go`, and the turn lifecycle plus batch/active-session reads in `session.go` (appended to `session_test.go`).

Every test asserts a real outcome — full-field round trips, error sentinels via `errors.Is`, and raw row counts read straight from the table after deletes — rather than merely executing the code path.

## Validation

- `CGO_ENABLED=1 go test -tags fts5 -race -cover ./internal/task/repository/sqlite/...` — pass. Package statement coverage **51.3% → 65.5%** (67.1% with the Postgres tests enabled).
- Postgres tests run against a real Postgres 16 with `KANDEV_TEST_POSTGRES_DSN` set — all 28 `TestPostgres*` in the package pass. Doing this caught a genuine defect in the new assertions: Postgres `TIMESTAMP` truncates to microseconds, so the shared timestamp assertions now compare at microsecond resolution.
- `golangci-lint run ./internal/task/repository/sqlite/... --new-from-rev=main` — 0 issues.
- **Mutation-verified.** Seven production edits were made one at a time, each confirmed to fail a named new test, then reverted and confirmed green:

  | Mutation | Failing test |
  |---|---|
  | `git_snapshots.go`: invert the `agent_completed` ordering preference | `TestGetLatestGitSnapshotPrefersAgentCompletedOverNewerLiveMonitor` |
  | `document.go`: drop `content` from the `DO UPDATE SET` list | `TestWriteDocumentRevisionUpdatesHeadInPlaceAndAppendsRevisions` |
  | `executor_profile.go`: return `nil` instead of the not-found error | `TestDeleteExecutorProfileRemovesRowAndReportsMissing` |
  | `environment.go`: invert the `is_system` decode | `TestCreateEnvironmentRoundTripsEveryField` (+3 others) |
  | `plan.go`: drop the `COALESCE` that makes the marker idempotent | `TestMarkTaskPlanImplementationStartedIsIdempotent` |
  | `task.go`: drop the `archived_at IS NULL` CAS guard | `TestArchiveTaskIfActiveOnlyFiresOnActiveRows` |
  | `session.go`: `AbandonTurn` stamps `now` instead of `started_at` | `TestCompleteTurnStampsNowAndAbandonTurnCollapsesToStartedAt` |

## Possible Improvements

Low risk — no production code changed. Two documentation-level inaccuracies were found and pinned as tests rather than "fixed": `DeleteDocument`'s comment claims revisions cascade, but the revisions FK targets `tasks(id)`, so a deleted HEAD leaves its history behind (`TestDeleteDocumentLeavesRevisionsBehind`); and `ListSiblings`' `self == nil` branch is unreachable because `GetTask` returns `ErrTaskNotFound` rather than `nil, nil`.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2490?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->