### PR TITLE
feat(plugin-registry): list kandev-augpool

### DIFF
--- a/plugin-registry/plugins.yaml
+++ b/plugin-registry/plugins.yaml
@@ -29,6 +29,9 @@ plugins:
   - id: kandev-provider-usage
     repo: kdlbs/kandev-plugin-provider-usage
     categories: [analytics]
+  - id: kandev-augpool
+    repo: kdlbs/kandev-plugin-augpool
+    categories: [analytics]
   - id: kandev-plugin-kandy
     repo: kdlbs/kandev-plugin-kandy
     categories: [tools]


### PR DESCRIPTION
## Summary

- add `kandev-augpool` to the official plugin registry
- classify it under analytics
- resolve marketplace metadata from the published `kdlbs/kandev-plugin-augpool` release

## Validation

- `node --test plugin-registry/build-index.test.mjs`
- `node plugin-registry/build-index.mjs` — 8 built, 0 skipped
- confirmed the generated entry resolves v0.1.5 and `kandev-augpool-0.1.5.tar.gz`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2491?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->