### PR TITLE
fix(backend): guard SSH command output buffers against concurrent access

### DIFF
--- a/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_operations.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_operations.go
@@ -123,7 +123,9 @@ func runSSHCommandStdin(ctx context.Context, client *ssh.Client, cmd string, std
 	}
 	defer func() { _ = session.Close() }()
 
-	var outBuf, errBuf bytes.Buffer
+	// Synchronized because the cancellation path below reads these while
+	// session.Run is still going — see syncBuffer.
+	var outBuf, errBuf syncBuffer
 	session.Stdout = &outBuf
 	session.Stderr = &errBuf
 	if stdin != nil {
@@ -141,6 +143,34 @@ func runSSHCommandStdin(ctx context.Context, client *ssh.Client, cmd string, std
 	case err := <-done:
 		return outBuf.String(), errBuf.String(), err
 	}
+}
+
+// syncBuffer is a bytes.Buffer safe for concurrent use by one writer and one
+// reader. It exists for runSSHCommandStdin's cancellation path: that path
+// returns while session.Run is still executing, so golang.org/x/crypto/ssh's
+// stdout/stderr copier goroutines are still writing into these buffers when we
+// read them — a data race on a plain bytes.Buffer, and one that outlives the
+// call, since the copiers keep writing until the remote command actually ends.
+//
+// Deliberately not an io.ReaderFrom: bytes.Buffer implements ReadFrom, and
+// io.Copy prefers it, which would let the copier reach the underlying buffer
+// without taking the lock. Exposing only Write keeps every mutation guarded.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+// String returns a consistent snapshot of whatever the remote has sent so far.
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
 }
 
 // detectRemoteInfo runs a tiny probe to learn about the host. The support gate

--- a/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_operations_remote_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_operations_remote_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -274,15 +275,78 @@ func TestRunSSHCommandStdinFeedsRemoteStdin(t *testing.T) {
 	}
 }
 
-// NOTE: the context-cancellation arm of runSSHCommandStdin's select is
-// deliberately NOT covered here. Reaching it requires the remote command to
-// still be running when the context is cancelled, and on that path the
-// function reads outBuf/errBuf while golang.org/x/crypto/ssh's stdout/stderr
-// copier goroutines are still writing into them — a data race that `go test
-// -race` reports against the production code, not against the test. Covering
-// it would mean shipping a test that fails under -race. See the PR discussion;
-// once the buffers are made race-safe, add a test that holds the remote
-// command open, cancels, and asserts errors.Is(err, context.Canceled).
+func TestRunSSHCommandAbandonsARunningCommandOnCancellation(t *testing.T) {
+	// The remote command is held open across the cancellation for two reasons:
+	// it makes the select land on ctx.Done() deterministically (cancelling up
+	// front leaves both arms ready, and Go picks a ready arm at random), and it
+	// keeps x/crypto/ssh's stdout/stderr copier goroutines writing while the
+	// buffers are read — so under -race this doubles as the regression test for
+	// the syncBuffer guarding those buffers.
+	started := make(chan struct{})
+	release := make(chan struct{})
+	finished := make(chan struct{})
+	var releaseOnce, startOnce sync.Once
+	releaseRemote := func() { releaseOnce.Do(func() { close(release) }) }
+	t.Cleanup(releaseRemote)
+
+	server := newFakeSSHServer(t, func(string, string) sshExecResult {
+		startOnce.Do(func() { close(started) })
+		<-release
+		close(finished)
+		return sshOut("output produced after the caller gave up")
+	})
+	client := server.dial(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		<-started
+		cancel()
+	}()
+
+	_, _, err := runSSHCommand(ctx, client, "sleep 60")
+
+	// Returning while the command is still running is the whole point: the
+	// caller must not be pinned to a remote command that outlives its context.
+	select {
+	case <-finished:
+		t.Fatal("runSSHCommand waited for the remote command instead of abandoning it")
+	default:
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context.Canceled", err)
+	}
+
+	// Let the remote command finish and drain the server handler before the
+	// test returns, so goleak sees no stragglers.
+	releaseRemote()
+	<-finished
+}
+
+func TestSyncBufferSnapshotsConcurrentWrites(t *testing.T) {
+	var buf syncBuffer
+	const writers, perWriter = 8, 50
+
+	var wg sync.WaitGroup
+	wg.Add(writers)
+	for range writers {
+		go func() {
+			defer wg.Done()
+			for range perWriter {
+				_, _ = buf.Write([]byte("x"))
+			}
+		}()
+	}
+	// Read concurrently with the writes; under -race this is the assertion.
+	for range 100 {
+		_ = buf.String()
+	}
+	wg.Wait()
+
+	if got := len(buf.String()); got != writers*perWriter {
+		t.Fatalf("buffered bytes = %d, want %d", got, writers*perWriter)
+	}
+}
 
 func TestRunSSHCommandSurfacesRemoteExitStatus(t *testing.T) {
 	server := newFakeSSHServer(t, func(string, string) sshExecResult {


### PR DESCRIPTION
`runSSHCommandStdin` returns on context cancellation while `session.Run` is still executing, so `x/crypto/ssh`'s stdout/stderr copier goroutines were still writing into `outBuf`/`errBuf` when the function read them — a data race, and one that outlives the call since those copiers keep writing until the remote command actually ends. Found while writing the SSH executor tests in #2493; reported there rather than fixed inline because that PR is scoped test-only.

## Important Changes

- **`syncBuffer` replaces the plain `bytes.Buffer`** in `runSSHCommandStdin`. It deliberately does *not* implement `io.ReaderFrom`: `bytes.Buffer` does, and `io.Copy` prefers that path, which would let the SSH copier reach the underlying buffer without taking the lock. Exposing only `Write` keeps every mutation guarded — that subtlety is why the obvious "embed a Buffer" version would have silently kept the race.

## When this fired

Any cancellation or deadline with a remote command in flight: `sshPrepareTimeout` (10 min) expiring mid-prepare, a cancelled launch, backend shutdown. The visible symptom is a torn read of the diagnostic output we then surface to the user; the deeper one is unsynchronised writes into memory the caller has stopped tracking.

## Validation

- `CGO_ENABLED=1 go test -tags fts5 -race ./internal/agent/runtime/lifecycle/...` — passes, no goroutine leaks.
- `golangci-lint run ./internal/agent/runtime/lifecycle/...` — 0 issues.
- `CGO_ENABLED=1 go build -tags fts5 ./...` — clean.

Verified by mutation: reverting `syncBuffer` back to `bytes.Buffer` makes `TestRunSSHCommandAbandonsARunningCommandOnCancellation` reproduce the original race exactly —

```
WARNING: DATA RACE
  bytes.(*Buffer).String()
  ...lifecycle.runSSHCommandStdin()
  bytes.(*Buffer).grow()
  bytes.(*Buffer).ReadFrom()
  golang.org/x/crypto/ssh.(*Session).stdout.func1()
```

— and restoring it returns to green. Ran `-count=20 -race` on the new tests to confirm the cancellation timing is deterministic rather than lucky.

The regression test holds the remote command open across the cancellation, so it pins two things at once: that the caller is not left waiting on a command that outlived its context, and (under `-race`) that the buffers are safe to read while the copiers run. `TestSyncBufferSnapshotsConcurrentWrites` covers the type directly.

## Possible Improvements

Low risk. `syncBuffer` gives up `bytes.Buffer`'s `ReadFrom` fast path, so `io.Copy` now goes through a 32 KB intermediate buffer — irrelevant for the short command output this function handles (uname, mkdir, sha256, git).

> [!NOTE]
> **Stacked on #2493** (base `feature/cover-ssh-and-sprite-wjt`), because the regression test needs the in-process `newFakeSSHServer` harness that PR introduces. Retarget to `main` once #2493 merges; the diff of this PR alone is the two files shown.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2494?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->