### PR TITLE
test(backend): cover the untested task handler surfaces

### DIFF
--- a/apps/backend/internal/task/handlers/executor_handlers_test.go
+++ b/apps/backend/internal/task/handlers/executor_handlers_test.go
@@ -1,0 +1,579 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kandev/kandev/internal/task/dto"
+	"github.com/kandev/kandev/internal/task/models"
+	"github.com/kandev/kandev/internal/task/service"
+	ws "github.com/kandev/kandev/pkg/websocket"
+)
+
+// executorRepo backs both the executor and executor-profile handler tests.
+type executorRepo struct {
+	mockRepository
+
+	executors []*models.Executor
+	byID      map[string]*models.Executor
+	profiles  []*models.ExecutorProfile
+	// profilesByExecutor answers ListExecutorProfiles(executorID).
+	profilesByExecutor map[string][]*models.ExecutorProfile
+	profileByID        map[string]*models.ExecutorProfile
+
+	listErr           error
+	listProfilesErr   error
+	createErr         error
+	updateErr         error
+	deleteErr         error
+	hasActiveSessions bool
+
+	created        []*models.Executor
+	updated        []*models.Executor
+	deleted        []string
+	createdProfile []*models.ExecutorProfile
+	updatedProfile []*models.ExecutorProfile
+	deletedProfile []string
+}
+
+func (r *executorRepo) ListExecutors(context.Context) ([]*models.Executor, error) {
+	if r.listErr != nil {
+		return nil, r.listErr
+	}
+	return r.executors, nil
+}
+
+func (r *executorRepo) GetExecutor(_ context.Context, id string) (*models.Executor, error) {
+	if executor, ok := r.byID[id]; ok {
+		return executor, nil
+	}
+	return nil, fmt.Errorf("executor not found: %s", id)
+}
+
+func (r *executorRepo) CreateExecutor(_ context.Context, executor *models.Executor) error {
+	if r.createErr != nil {
+		return r.createErr
+	}
+	r.created = append(r.created, executor)
+	return nil
+}
+
+func (r *executorRepo) UpdateExecutor(_ context.Context, executor *models.Executor) error {
+	if r.updateErr != nil {
+		return r.updateErr
+	}
+	r.updated = append(r.updated, executor)
+	return nil
+}
+
+func (r *executorRepo) DeleteExecutor(_ context.Context, id string) error {
+	if r.deleteErr != nil {
+		return r.deleteErr
+	}
+	r.deleted = append(r.deleted, id)
+	return nil
+}
+
+func (r *executorRepo) HasActiveTaskSessionsByExecutor(context.Context, string) (bool, error) {
+	return r.hasActiveSessions, nil
+}
+
+func (r *executorRepo) ListAllExecutorProfiles(context.Context) ([]*models.ExecutorProfile, error) {
+	if r.listProfilesErr != nil {
+		return nil, r.listProfilesErr
+	}
+	return r.profiles, nil
+}
+
+func (r *executorRepo) ListExecutorProfiles(_ context.Context, executorID string) ([]*models.ExecutorProfile, error) {
+	if r.listProfilesErr != nil {
+		return nil, r.listProfilesErr
+	}
+	return r.profilesByExecutor[executorID], nil
+}
+
+func (r *executorRepo) GetExecutorProfile(_ context.Context, id string) (*models.ExecutorProfile, error) {
+	if profile, ok := r.profileByID[id]; ok {
+		return profile, nil
+	}
+	return nil, fmt.Errorf("executor profile not found: %s", id)
+}
+
+func (r *executorRepo) CreateExecutorProfile(_ context.Context, profile *models.ExecutorProfile) error {
+	if r.createErr != nil {
+		return r.createErr
+	}
+	r.createdProfile = append(r.createdProfile, profile)
+	return nil
+}
+
+func (r *executorRepo) UpdateExecutorProfile(_ context.Context, profile *models.ExecutorProfile) error {
+	if r.updateErr != nil {
+		return r.updateErr
+	}
+	r.updatedProfile = append(r.updatedProfile, profile)
+	return nil
+}
+
+func (r *executorRepo) DeleteExecutorProfile(_ context.Context, id string) error {
+	if r.deleteErr != nil {
+		return r.deleteErr
+	}
+	r.deletedProfile = append(r.deletedProfile, id)
+	return nil
+}
+
+func newExecutorService(t *testing.T, repo *executorRepo) *service.Service {
+	t.Helper()
+	log := newTestLogger(t)
+	return service.NewService(service.Repos{
+		Workspaces: repo, Tasks: repo, TaskRepos: repo,
+		Workflows: repo, Messages: repo, Turns: repo,
+		Sessions: repo, GitSnapshots: repo, RepoEntities: repo,
+		Executors: repo, Environments: repo, TaskEnvironments: repo,
+		Reviews: repo,
+	}, nil, log, service.RepositoryDiscoveryConfig{})
+}
+
+func newExecutorHandlers(t *testing.T, repo *executorRepo) *ExecutorHandlers {
+	t.Helper()
+	return NewExecutorHandlers(newExecutorService(t, repo), newTestLogger(t))
+}
+
+// executorFixture holds two executors, one of them carrying a profile, so the
+// list handler's profile-grouping has something to get wrong.
+func executorFixture() *executorRepo {
+	docker := &models.Executor{ID: "ex-docker", Name: "Docker", Type: models.ExecutorTypeLocalDocker, IsSystem: true}
+	local := &models.Executor{ID: "ex-local", Name: "Local", Type: models.ExecutorTypeLocal}
+	profile := &models.ExecutorProfile{ID: "pr-1", ExecutorID: "ex-docker", Name: "Default"}
+	return &executorRepo{
+		executors: []*models.Executor{docker, local},
+		byID:      map[string]*models.Executor{"ex-docker": docker, "ex-local": local},
+		profiles:  []*models.ExecutorProfile{profile},
+		profilesByExecutor: map[string][]*models.ExecutorProfile{
+			"ex-docker": {profile},
+		},
+		profileByID: map[string]*models.ExecutorProfile{"pr-1": profile},
+	}
+}
+
+func decodeExecutorList(t *testing.T, body []byte) dto.ListExecutorsResponse {
+	t.Helper()
+	var resp dto.ListExecutorsResponse
+	require.NoError(t, json.Unmarshal(body, &resp))
+	return resp
+}
+
+func TestHTTPListExecutorsAttachesProfilesToTheirExecutor(t *testing.T) {
+	repo := executorFixture()
+	h := newExecutorHandlers(t, repo)
+	c, rec := newWorkflowRequest(t, http.MethodGet, "/api/v1/executors", "")
+
+	h.httpListExecutors(c)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	resp := decodeExecutorList(t, rec.Body.Bytes())
+	require.Equal(t, 2, resp.Total)
+	require.Len(t, resp.Executors, 2)
+	require.Equal(t, "ex-docker", resp.Executors[0].ID)
+	require.Len(t, resp.Executors[0].Profiles, 1)
+	require.Equal(t, "pr-1", resp.Executors[0].Profiles[0].ID)
+	require.Empty(t, resp.Executors[1].Profiles, "an executor without profiles must not inherit another's")
+}
+
+func TestHTTPListExecutorsReturnsInternalErrorWhenListFails(t *testing.T) {
+	repo := executorFixture()
+	repo.listErr = errors.New("database unavailable")
+	h := newExecutorHandlers(t, repo)
+	c, rec := newWorkflowRequest(t, http.MethodGet, "/api/v1/executors", "")
+
+	h.httpListExecutors(c)
+
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	require.JSONEq(t, `{"error":"Failed to list executors"}`, rec.Body.String())
+}
+
+// TestHTTPListExecutorsToleratesProfileLookupFailure documents that the profile
+// read is best-effort: a failure there must still return the executors rather
+// than blanking the settings page.
+func TestHTTPListExecutorsToleratesProfileLookupFailure(t *testing.T) {
+	repo := executorFixture()
+	repo.listProfilesErr = errors.New("profiles unavailable")
+	h := newExecutorHandlers(t, repo)
+	c, rec := newWorkflowRequest(t, http.MethodGet, "/api/v1/executors", "")
+
+	h.httpListExecutors(c)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	resp := decodeExecutorList(t, rec.Body.Bytes())
+	require.Len(t, resp.Executors, 2)
+	require.Empty(t, resp.Executors[0].Profiles)
+}
+
+func TestHTTPCreateExecutorRejectsInvalidRequests(t *testing.T) {
+	repo := executorFixture()
+	h := newExecutorHandlers(t, repo)
+
+	for name, tc := range map[string]struct {
+		body     string
+		wantBody string
+	}{
+		"malformed json": {body: `{`, wantBody: `{"error":"invalid payload"}`},
+		"missing name":   {body: `{"type":"local"}`, wantBody: `{"error":"name and type are required"}`},
+		"missing type":   {body: `{"name":"Local"}`, wantBody: `{"error":"name and type are required"}`},
+	} {
+		t.Run(name, func(t *testing.T) {
+			c, rec := newWorkflowRequest(t, http.MethodPost, "/api/v1/executors", tc.body)
+			h.httpCreateExecutor(c)
+			require.Equal(t, http.StatusBadRequest, rec.Code)
+			require.JSONEq(t, tc.wantBody, rec.Body.String())
+		})
+	}
+	require.Empty(t, repo.created)
+}
+
+// TestHTTPCreateExecutorDefaultsStatusAndResumable pins the two implicit
+// defaults: an omitted status becomes "active" and an omitted resumable
+// becomes true (not the Go zero value false).
+func TestHTTPCreateExecutorDefaultsStatusAndResumable(t *testing.T) {
+	repo := executorFixture()
+	h := newExecutorHandlers(t, repo)
+	c, rec := newWorkflowRequest(t, http.MethodPost, "/api/v1/executors",
+		`{"name":"New","type":"local"}`)
+
+	h.httpCreateExecutor(c)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Len(t, repo.created, 1)
+	require.Equal(t, models.ExecutorStatusActive, repo.created[0].Status)
+	require.True(t, repo.created[0].Resumable)
+
+	var got dto.ExecutorDTO
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Equal(t, "New", got.Name)
+	require.Equal(t, models.ExecutorTypeLocal, got.Type)
+	require.True(t, got.Resumable)
+}
+
+func TestHTTPCreateExecutorHonorsExplicitResumableFalse(t *testing.T) {
+	repo := executorFixture()
+	h := newExecutorHandlers(t, repo)
+	c, rec := newWorkflowRequest(t, http.MethodPost, "/api/v1/executors",
+		`{"name":"New","type":"local","status":"inactive","resumable":false}`)
+
+	h.httpCreateExecutor(c)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Len(t, repo.created, 1)
+	require.False(t, repo.created[0].Resumable)
+	require.Equal(t, models.ExecutorStatus("inactive"), repo.created[0].Status)
+}
+
+func TestHTTPCreateExecutorRejectsInvalidMCPPolicy(t *testing.T) {
+	repo := executorFixture()
+	h := newExecutorHandlers(t, repo)
+	c, rec := newWorkflowRequest(t, http.MethodPost, "/api/v1/executors",
+		`{"name":"New","type":"local","config":{"mcp_policy":"not-json"}}`)
+
+	h.httpCreateExecutor(c)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Contains(t, rec.Body.String(), service.ErrInvalidExecutorConfig.Error())
+	require.Empty(t, repo.created)
+}
+
+func TestHTTPCreateExecutorSurfacesRepositoryFailure(t *testing.T) {
+	repo := executorFixture()
+	repo.createErr = errors.New("disk full")
+	h := newExecutorHandlers(t, repo)
+	c, rec := newWorkflowRequest(t, http.MethodPost, "/api/v1/executors",
+		`{"name":"New","type":"local"}`)
+
+	h.httpCreateExecutor(c)
+
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	require.JSONEq(t, `{"error":"executor not created"}`, rec.Body.String())
+}
+
+func TestHTTPGetExecutorReturnsExecutorOrNotFound(t *testing.T) {
+	repo := executorFixture()
+	h := newExecutorHandlers(t, repo)
+
+	c, rec := newWorkflowRequest(t, http.MethodGet, "/api/v1/executors/ex-local", "")
+	c.Params = gin.Params{{Key: "id", Value: "ex-local"}}
+	h.httpGetExecutor(c)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got dto.ExecutorDTO
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Equal(t, "ex-local", got.ID)
+	require.Equal(t, "Local", got.Name)
+
+	missingCtx, missingRec := newWorkflowRequest(t, http.MethodGet, "/api/v1/executors/nope", "")
+	missingCtx.Params = gin.Params{{Key: "id", Value: "nope"}}
+	h.httpGetExecutor(missingCtx)
+	require.Equal(t, http.StatusNotFound, missingRec.Code)
+	require.JSONEq(t, `{"error":"executor not found"}`, missingRec.Body.String())
+}
+
+func TestHTTPUpdateExecutorAppliesProvidedFieldsOnly(t *testing.T) {
+	repo := executorFixture()
+	h := newExecutorHandlers(t, repo)
+	c, rec := newWorkflowRequest(t, http.MethodPatch, "/api/v1/executors/ex-local",
+		`{"name":"Renamed","resumable":false}`)
+	c.Params = gin.Params{{Key: "id", Value: "ex-local"}}
+
+	h.httpUpdateExecutor(c)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Len(t, repo.updated, 1)
+	require.Equal(t, "Renamed", repo.updated[0].Name)
+	require.False(t, repo.updated[0].Resumable)
+	require.Equal(t, models.ExecutorTypeLocal, repo.updated[0].Type, "an omitted field must be left alone")
+}
+
+func TestHTTPUpdateExecutorRejectsInvalidPayload(t *testing.T) {
+	repo := executorFixture()
+	h := newExecutorHandlers(t, repo)
+	c, rec := newWorkflowRequest(t, http.MethodPatch, "/api/v1/executors/ex-local", `{`)
+	c.Params = gin.Params{{Key: "id", Value: "ex-local"}}
+
+	h.httpUpdateExecutor(c)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.JSONEq(t, `{"error":"invalid payload"}`, rec.Body.String())
+	require.Empty(t, repo.updated)
+}
+
+func TestHTTPUpdateExecutorRejectsInvalidMCPPolicy(t *testing.T) {
+	repo := executorFixture()
+	h := newExecutorHandlers(t, repo)
+	c, rec := newWorkflowRequest(t, http.MethodPatch, "/api/v1/executors/ex-local",
+		`{"config":{"mcp_policy":"[1,2]"}}`)
+	c.Params = gin.Params{{Key: "id", Value: "ex-local"}}
+
+	h.httpUpdateExecutor(c)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Contains(t, rec.Body.String(), "mcp_policy must be a JSON object")
+	require.Empty(t, repo.updated)
+}
+
+// TestHTTPUpdateExecutorRefusesToRenameSystemExecutor covers the service-side
+// system guard reaching the handler as a plain 500 rather than a 400 — the
+// error is not an ErrInvalidExecutorConfig, so it takes the generic branch.
+func TestHTTPUpdateExecutorRefusesToRenameSystemExecutor(t *testing.T) {
+	repo := executorFixture()
+	h := newExecutorHandlers(t, repo)
+	c, rec := newWorkflowRequest(t, http.MethodPatch, "/api/v1/executors/ex-docker",
+		`{"name":"Renamed"}`)
+	c.Params = gin.Params{{Key: "id", Value: "ex-docker"}}
+
+	h.httpUpdateExecutor(c)
+
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	require.JSONEq(t, `{"error":"executor not updated"}`, rec.Body.String())
+	require.Empty(t, repo.updated, "a system executor must not be modified")
+}
+
+func TestHTTPDeleteExecutorDeletesAndReportsConflicts(t *testing.T) {
+	repo := executorFixture()
+	h := newExecutorHandlers(t, repo)
+	c, rec := newWorkflowRequest(t, http.MethodDelete, "/api/v1/executors/ex-local", "")
+	c.Params = gin.Params{{Key: "id", Value: "ex-local"}}
+
+	h.httpDeleteExecutor(c)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.JSONEq(t, `{"success":true}`, rec.Body.String())
+	require.Equal(t, []string{"ex-local"}, repo.deleted)
+}
+
+func TestHTTPDeleteExecutorReturnsConflictWhenSessionsAreActive(t *testing.T) {
+	repo := executorFixture()
+	repo.hasActiveSessions = true
+	h := newExecutorHandlers(t, repo)
+	c, rec := newWorkflowRequest(t, http.MethodDelete, "/api/v1/executors/ex-local", "")
+	c.Params = gin.Params{{Key: "id", Value: "ex-local"}}
+
+	h.httpDeleteExecutor(c)
+
+	require.Equal(t, http.StatusConflict, rec.Code)
+	require.JSONEq(t, `{"error":"executor is used by an active agent session"}`, rec.Body.String())
+	require.Empty(t, repo.deleted, "an in-use executor must survive the request")
+}
+
+func TestHTTPDeleteExecutorReturnsBadRequestForUnknownExecutor(t *testing.T) {
+	repo := executorFixture()
+	h := newExecutorHandlers(t, repo)
+	c, rec := newWorkflowRequest(t, http.MethodDelete, "/api/v1/executors/nope", "")
+	c.Params = gin.Params{{Key: "id", Value: "nope"}}
+
+	h.httpDeleteExecutor(c)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.JSONEq(t, `{"error":"executor not deleted"}`, rec.Body.String())
+}
+
+func TestWSListExecutorsReturnsExecutorsWithProfiles(t *testing.T) {
+	repo := executorFixture()
+	h := newExecutorHandlers(t, repo)
+
+	resp, err := h.wsListExecutors(context.Background(),
+		wsWorkflowRequest(t, ws.ActionExecutorList, map[string]any{}))
+
+	require.NoError(t, err)
+	var list dto.ListExecutorsResponse
+	wsWorkflowResponse(t, resp, &list)
+	require.Equal(t, 2, list.Total)
+	require.Len(t, list.Executors[0].Profiles, 1)
+}
+
+func TestWSListExecutorsSurfacesRepositoryFailure(t *testing.T) {
+	repo := executorFixture()
+	repo.listErr = errors.New("database unavailable")
+	h := newExecutorHandlers(t, repo)
+
+	resp, err := h.wsListExecutors(context.Background(),
+		wsWorkflowRequest(t, ws.ActionExecutorList, map[string]any{}))
+
+	require.NoError(t, err)
+	payload := wsWorkflowError(t, resp)
+	require.Equal(t, string(ws.ErrorCodeInternalError), payload.Code)
+	require.Equal(t, "Failed to list executors", payload.Message)
+}
+
+func TestWSCreateExecutorValidatesAndCreates(t *testing.T) {
+	repo := executorFixture()
+	h := newExecutorHandlers(t, repo)
+
+	invalid, err := h.wsCreateExecutor(context.Background(),
+		wsWorkflowRequest(t, ws.ActionExecutorCreate, map[string]any{"name": "New"}))
+	require.NoError(t, err)
+	require.Equal(t, "name and type are required", wsWorkflowError(t, invalid).Message)
+
+	malformed, err := h.wsCreateExecutor(context.Background(), wsMalformedRequest(ws.ActionExecutorCreate))
+	require.NoError(t, err)
+	require.Equal(t, string(ws.ErrorCodeBadRequest), wsWorkflowError(t, malformed).Code)
+	require.Empty(t, repo.created)
+
+	resp, err := h.wsCreateExecutor(context.Background(),
+		wsWorkflowRequest(t, ws.ActionExecutorCreate, map[string]any{"name": "New", "type": "local"}))
+	require.NoError(t, err)
+	var created dto.ExecutorDTO
+	wsWorkflowResponse(t, resp, &created)
+	require.Equal(t, "New", created.Name)
+	require.True(t, created.Resumable, "resumable defaults to true over the WS surface too")
+	require.Len(t, repo.created, 1)
+}
+
+func TestWSCreateExecutorRejectsInvalidMCPPolicy(t *testing.T) {
+	repo := executorFixture()
+	h := newExecutorHandlers(t, repo)
+
+	resp, err := h.wsCreateExecutor(context.Background(),
+		wsWorkflowRequest(t, ws.ActionExecutorCreate, map[string]any{
+			"name": "New", "type": "local", "config": map[string]string{"mcp_policy": "nope"},
+		}))
+
+	require.NoError(t, err)
+	payload := wsWorkflowError(t, resp)
+	require.Equal(t, string(ws.ErrorCodeValidation), payload.Code)
+	require.Contains(t, payload.Message, "mcp_policy must be valid JSON")
+	require.Empty(t, repo.created)
+}
+
+func TestWSGetExecutorReturnsExecutorOrErrors(t *testing.T) {
+	repo := executorFixture()
+	h := newExecutorHandlers(t, repo)
+
+	resp, err := h.wsGetExecutor(context.Background(),
+		wsWorkflowRequest(t, ws.ActionExecutorGet, map[string]any{"id": "ex-local"}))
+	require.NoError(t, err)
+	var got dto.ExecutorDTO
+	wsWorkflowResponse(t, resp, &got)
+	require.Equal(t, "ex-local", got.ID)
+
+	missing, err := h.wsGetExecutor(context.Background(),
+		wsWorkflowRequest(t, ws.ActionExecutorGet, map[string]any{"id": "nope"}))
+	require.NoError(t, err)
+	require.Equal(t, string(ws.ErrorCodeNotFound), wsWorkflowError(t, missing).Code)
+
+	empty, err := h.wsGetExecutor(context.Background(),
+		wsWorkflowRequest(t, ws.ActionExecutorGet, map[string]any{}))
+	require.NoError(t, err)
+	require.Equal(t, "id is required", wsWorkflowError(t, empty).Message)
+}
+
+func TestWSUpdateExecutorAppliesFields(t *testing.T) {
+	repo := executorFixture()
+	h := newExecutorHandlers(t, repo)
+
+	resp, err := h.wsUpdateExecutor(context.Background(),
+		wsWorkflowRequest(t, ws.ActionExecutorUpdate, map[string]any{
+			"id": "ex-local", "name": "Renamed", "status": "inactive",
+		}))
+
+	require.NoError(t, err)
+	var updated dto.ExecutorDTO
+	wsWorkflowResponse(t, resp, &updated)
+	require.Equal(t, "Renamed", updated.Name)
+	require.Equal(t, models.ExecutorStatus("inactive"), updated.Status)
+	require.Len(t, repo.updated, 1)
+}
+
+func TestWSUpdateExecutorRequiresID(t *testing.T) {
+	repo := executorFixture()
+	h := newExecutorHandlers(t, repo)
+
+	resp, err := h.wsUpdateExecutor(context.Background(),
+		wsWorkflowRequest(t, ws.ActionExecutorUpdate, map[string]any{"name": "Renamed"}))
+
+	require.NoError(t, err)
+	require.Equal(t, "id is required", wsWorkflowError(t, resp).Message)
+	require.Empty(t, repo.updated)
+}
+
+func TestWSUpdateExecutorSurfacesRepositoryFailure(t *testing.T) {
+	repo := executorFixture()
+	repo.updateErr = errors.New("disk full")
+	h := newExecutorHandlers(t, repo)
+
+	resp, err := h.wsUpdateExecutor(context.Background(),
+		wsWorkflowRequest(t, ws.ActionExecutorUpdate, map[string]any{"id": "ex-local", "name": "Renamed"}))
+
+	require.NoError(t, err)
+	payload := wsWorkflowError(t, resp)
+	require.Equal(t, string(ws.ErrorCodeInternalError), payload.Code)
+	require.Equal(t, "Failed to update executor", payload.Message)
+}
+
+func TestWSDeleteExecutorDeletesAndReportsActiveSessions(t *testing.T) {
+	repo := executorFixture()
+	h := newExecutorHandlers(t, repo)
+
+	resp, err := h.wsDeleteExecutor(context.Background(),
+		wsWorkflowRequest(t, ws.ActionExecutorDelete, map[string]any{"id": "ex-local"}))
+	require.NoError(t, err)
+	var success dto.SuccessResponse
+	wsWorkflowResponse(t, resp, &success)
+	require.True(t, success.Success)
+	require.Equal(t, []string{"ex-local"}, repo.deleted)
+
+	busy := executorFixture()
+	busy.hasActiveSessions = true
+	busyHandlers := newExecutorHandlers(t, busy)
+	blocked, err := busyHandlers.wsDeleteExecutor(context.Background(),
+		wsWorkflowRequest(t, ws.ActionExecutorDelete, map[string]any{"id": "ex-local"}))
+	require.NoError(t, err)
+	payload := wsWorkflowError(t, blocked)
+	require.Equal(t, string(ws.ErrorCodeValidation), payload.Code)
+	require.Equal(t, "executor is used by an active agent session", payload.Message)
+	require.Empty(t, busy.deleted)
+}

--- a/apps/backend/internal/task/handlers/executor_profile_handlers_test.go
+++ b/apps/backend/internal/task/handlers/executor_profile_handlers_test.go
@@ -1,0 +1,558 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kandev/kandev/internal/agent/agents"
+	"github.com/kandev/kandev/internal/agent/runtime/lifecycle"
+	"github.com/kandev/kandev/internal/task/dto"
+	"github.com/kandev/kandev/internal/task/models"
+	ws "github.com/kandev/kandev/pkg/websocket"
+)
+
+// recordingAgentLister proves buildRemoteAuthSpecs consults the wired lister
+// instead of silently falling back to the agentless catalog.
+type recordingAgentLister struct {
+	calls int
+}
+
+func (l *recordingAgentLister) ListEnabled() []agents.Agent {
+	l.calls++
+	return nil
+}
+
+func newProfileHandlers(t *testing.T, repo *executorRepo, lister AgentLister) *ExecutorProfileHandlers {
+	t.Helper()
+	return NewExecutorProfileHandlers(newExecutorService(t, repo), lister, newTestLogger(t))
+}
+
+func decodeProfileList(t *testing.T, body []byte) dto.ListExecutorProfilesResponse {
+	t.Helper()
+	var resp dto.ListExecutorProfilesResponse
+	require.NoError(t, json.Unmarshal(body, &resp))
+	return resp
+}
+
+// TestHTTPListAllProfilesEnrichesWithExecutorIdentity pins the join: each
+// profile must carry the name and type of *its own* executor.
+func TestHTTPListAllProfilesEnrichesWithExecutorIdentity(t *testing.T) {
+	repo := executorFixture()
+	repo.profiles = append(repo.profiles,
+		&models.ExecutorProfile{ID: "pr-2", ExecutorID: "ex-local", Name: "Local Default"})
+	h := newProfileHandlers(t, repo, nil)
+	c, rec := newWorkflowRequest(t, http.MethodGet, "/api/v1/executor-profiles", "")
+
+	h.httpListAllProfiles(c)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	resp := decodeProfileList(t, rec.Body.Bytes())
+	require.Equal(t, 2, resp.Total)
+	require.Equal(t, "Docker", resp.Profiles[0].ExecutorName)
+	require.Equal(t, string(models.ExecutorTypeLocalDocker), resp.Profiles[0].ExecutorType)
+	require.Equal(t, "Local", resp.Profiles[1].ExecutorName)
+	require.Equal(t, string(models.ExecutorTypeLocal), resp.Profiles[1].ExecutorType)
+}
+
+func TestHTTPListAllProfilesReturnsInternalErrorWhenProfilesFail(t *testing.T) {
+	repo := executorFixture()
+	repo.listProfilesErr = errors.New("database unavailable")
+	h := newProfileHandlers(t, repo, nil)
+	c, rec := newWorkflowRequest(t, http.MethodGet, "/api/v1/executor-profiles", "")
+
+	h.httpListAllProfiles(c)
+
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	require.JSONEq(t, `{"error":"Failed to list profiles"}`, rec.Body.String())
+}
+
+func TestHTTPListAllProfilesReturnsInternalErrorWhenExecutorsFail(t *testing.T) {
+	repo := executorFixture()
+	repo.listErr = errors.New("database unavailable")
+	h := newProfileHandlers(t, repo, nil)
+	c, rec := newWorkflowRequest(t, http.MethodGet, "/api/v1/executor-profiles", "")
+
+	h.httpListAllProfiles(c)
+
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	require.JSONEq(t, `{"error":"Failed to list executors"}`, rec.Body.String())
+}
+
+func TestHTTPListScriptPlaceholdersReturnsTheRegistry(t *testing.T) {
+	h := newProfileHandlers(t, executorFixture(), nil)
+	c, rec := newWorkflowRequest(t, http.MethodGet, "/api/v1/script-placeholders", "")
+
+	h.httpListScriptPlaceholders(c)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var body struct {
+		Placeholders []struct {
+			Name string `json:"name"`
+		} `json:"placeholders"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Len(t, body.Placeholders, len(scriptPlaceholders))
+	require.NotEmpty(t, body.Placeholders, "the placeholder registry must not serialize as empty")
+}
+
+func TestHTTPGetDefaultScriptRequiresTypeAndReturnsTheScript(t *testing.T) {
+	h := newProfileHandlers(t, executorFixture(), nil)
+
+	missingCtx, missingRec := newWorkflowRequest(t, http.MethodGet,
+		"/api/v1/executor-profiles/default-script", "")
+	h.httpGetDefaultScript(missingCtx)
+	require.Equal(t, http.StatusBadRequest, missingRec.Code)
+	require.JSONEq(t, `{"error":"type query parameter is required"}`, missingRec.Body.String())
+
+	c, rec := newWorkflowRequest(t, http.MethodGet,
+		"/api/v1/executor-profiles/default-script?type=worktree", "")
+	h.httpGetDefaultScript(c)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var body struct {
+		PrepareScript string `json:"prepare_script"`
+		CleanupScript string `json:"cleanup_script"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Equal(t, lifecycle.DefaultPrepareScript("worktree"), body.PrepareScript)
+	require.NotEmpty(t, body.PrepareScript, "worktree has a default prepare script")
+	require.Empty(t, body.CleanupScript)
+}
+
+func TestHTTPListRemoteCredentialsUsesTheWiredAgentLister(t *testing.T) {
+	lister := &recordingAgentLister{}
+	h := newProfileHandlers(t, executorFixture(), lister)
+	c, rec := newWorkflowRequest(t, http.MethodGet, "/api/v1/remote-credentials", "")
+
+	h.httpListRemoteCredentials(c)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, 1, lister.calls, "the handler must ask the lister which agents are enabled")
+	var body struct {
+		AuthSpecs []struct {
+			ID      string `json:"id"`
+			Methods []struct {
+				MethodID string `json:"method_id"`
+			} `json:"methods"`
+		} `json:"auth_specs"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.NotEmpty(t, body.AuthSpecs, "the GitHub CLI spec is always present")
+	require.NotEmpty(t, body.AuthSpecs[0].Methods)
+}
+
+func TestHTTPListRemoteCredentialsFallsBackWithoutAnAgentLister(t *testing.T) {
+	h := newProfileHandlers(t, executorFixture(), nil)
+	c, rec := newWorkflowRequest(t, http.MethodGet, "/api/v1/remote-credentials", "")
+
+	h.httpListRemoteCredentials(c)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), `"auth_specs"`)
+}
+
+// TestHTTPGetGitIdentityReportsDetectionConsistently shells out to the real
+// git, so the values depend on the host. The invariant that must hold either
+// way is that "detected" agrees with the two fields it summarizes.
+func TestHTTPGetGitIdentityReportsDetectionConsistently(t *testing.T) {
+	h := newProfileHandlers(t, executorFixture(), nil)
+	c, rec := newWorkflowRequest(t, http.MethodGet, "/api/v1/git/identity", "")
+
+	h.httpGetGitIdentity(c)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var body struct {
+		UserName  string `json:"user_name"`
+		UserEmail string `json:"user_email"`
+		Detected  bool   `json:"detected"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Equal(t, body.UserName != "" && body.UserEmail != "", body.Detected)
+}
+
+func TestHTTPListProfilesReturnsOnlyTheExecutorsProfiles(t *testing.T) {
+	repo := executorFixture()
+	h := newProfileHandlers(t, repo, nil)
+
+	c, rec := newWorkflowRequest(t, http.MethodGet, "/api/v1/executors/ex-docker/profiles", "")
+	c.Params = gin.Params{{Key: "id", Value: "ex-docker"}}
+	h.httpListProfiles(c)
+	require.Equal(t, http.StatusOK, rec.Code)
+	resp := decodeProfileList(t, rec.Body.Bytes())
+	require.Equal(t, 1, resp.Total)
+	require.Equal(t, "pr-1", resp.Profiles[0].ID)
+
+	otherCtx, otherRec := newWorkflowRequest(t, http.MethodGet, "/api/v1/executors/ex-local/profiles", "")
+	otherCtx.Params = gin.Params{{Key: "id", Value: "ex-local"}}
+	h.httpListProfiles(otherCtx)
+	require.Equal(t, http.StatusOK, otherRec.Code)
+	other := decodeProfileList(t, otherRec.Body.Bytes())
+	require.Equal(t, 0, other.Total)
+	require.NotNil(t, other.Profiles, "an empty list must serialize as [] rather than null")
+}
+
+func TestHTTPListProfilesSurfacesRepositoryFailure(t *testing.T) {
+	repo := executorFixture()
+	repo.listProfilesErr = errors.New("database unavailable")
+	h := newProfileHandlers(t, repo, nil)
+	c, rec := newWorkflowRequest(t, http.MethodGet, "/api/v1/executors/ex-docker/profiles", "")
+	c.Params = gin.Params{{Key: "id", Value: "ex-docker"}}
+
+	h.httpListProfiles(c)
+
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	require.JSONEq(t, `{"error":"Failed to list profiles"}`, rec.Body.String())
+}
+
+func TestHTTPCreateProfileRejectsInvalidRequests(t *testing.T) {
+	repo := executorFixture()
+	h := newProfileHandlers(t, repo, nil)
+
+	for name, tc := range map[string]struct {
+		body     string
+		wantBody string
+	}{
+		"malformed json": {body: `{`, wantBody: `{"error":"invalid payload"}`},
+		"missing name":   {body: `{"mcp_policy":"{}"}`, wantBody: `{"error":"name is required"}`},
+	} {
+		t.Run(name, func(t *testing.T) {
+			c, rec := newWorkflowRequest(t, http.MethodPost, "/api/v1/executors/ex-docker/profiles", tc.body)
+			c.Params = gin.Params{{Key: "id", Value: "ex-docker"}}
+			h.httpCreateProfile(c)
+			require.Equal(t, http.StatusBadRequest, rec.Code)
+			require.JSONEq(t, tc.wantBody, rec.Body.String())
+		})
+	}
+	require.Empty(t, repo.createdProfile)
+}
+
+func TestHTTPCreateProfileTakesExecutorIDFromThePath(t *testing.T) {
+	repo := executorFixture()
+	h := newProfileHandlers(t, repo, nil)
+	c, rec := newWorkflowRequest(t, http.MethodPost, "/api/v1/executors/ex-local/profiles",
+		`{"name":"Fresh","mcp_policy":"{}","prepare_script":"echo hi"}`)
+	c.Params = gin.Params{{Key: "id", Value: "ex-local"}}
+
+	h.httpCreateProfile(c)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Len(t, repo.createdProfile, 1)
+	require.Equal(t, "ex-local", repo.createdProfile[0].ExecutorID)
+	require.Equal(t, "Fresh", repo.createdProfile[0].Name)
+	require.Equal(t, "echo hi", repo.createdProfile[0].PrepareScript)
+
+	var got dto.ExecutorProfileDTO
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Equal(t, "Fresh", got.Name)
+	require.Equal(t, "ex-local", got.ExecutorID)
+}
+
+// TestHTTPCreateProfileFailsForUnknownExecutor covers the service-side
+// existence check surfacing through the handler's generic 500.
+func TestHTTPCreateProfileFailsForUnknownExecutor(t *testing.T) {
+	repo := executorFixture()
+	h := newProfileHandlers(t, repo, nil)
+	c, rec := newWorkflowRequest(t, http.MethodPost, "/api/v1/executors/nope/profiles", `{"name":"Fresh"}`)
+	c.Params = gin.Params{{Key: "id", Value: "nope"}}
+
+	h.httpCreateProfile(c)
+
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	require.JSONEq(t, `{"error":"profile not created"}`, rec.Body.String())
+	require.Empty(t, repo.createdProfile)
+}
+
+func TestHTTPGetProfileReturnsProfileOrNotFound(t *testing.T) {
+	repo := executorFixture()
+	h := newProfileHandlers(t, repo, nil)
+
+	c, rec := newWorkflowRequest(t, http.MethodGet, "/api/v1/executors/ex-docker/profiles/pr-1", "")
+	c.Params = gin.Params{{Key: "id", Value: "ex-docker"}, {Key: "profileId", Value: "pr-1"}}
+	h.httpGetProfile(c)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got dto.ExecutorProfileDTO
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Equal(t, "pr-1", got.ID)
+
+	missingCtx, missingRec := newWorkflowRequest(t, http.MethodGet,
+		"/api/v1/executors/ex-docker/profiles/nope", "")
+	missingCtx.Params = gin.Params{{Key: "id", Value: "ex-docker"}, {Key: "profileId", Value: "nope"}}
+	h.httpGetProfile(missingCtx)
+	require.Equal(t, http.StatusNotFound, missingRec.Code)
+	require.JSONEq(t, `{"error":"profile not found"}`, missingRec.Body.String())
+}
+
+func TestHTTPUpdateProfileAppliesProvidedFieldsOnly(t *testing.T) {
+	repo := executorFixture()
+	repo.profileByID["pr-1"].PrepareScript = "original"
+	h := newProfileHandlers(t, repo, nil)
+	c, rec := newWorkflowRequest(t, http.MethodPatch, "/api/v1/executors/ex-docker/profiles/pr-1",
+		`{"name":"Renamed"}`)
+	c.Params = gin.Params{{Key: "id", Value: "ex-docker"}, {Key: "profileId", Value: "pr-1"}}
+
+	h.httpUpdateProfile(c)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Len(t, repo.updatedProfile, 1)
+	require.Equal(t, "Renamed", repo.updatedProfile[0].Name)
+	require.Equal(t, "original", repo.updatedProfile[0].PrepareScript, "an omitted script must be preserved")
+}
+
+func TestHTTPUpdateProfileRejectsInvalidPayload(t *testing.T) {
+	repo := executorFixture()
+	h := newProfileHandlers(t, repo, nil)
+	c, rec := newWorkflowRequest(t, http.MethodPatch, "/api/v1/executors/ex-docker/profiles/pr-1", `{`)
+	c.Params = gin.Params{{Key: "id", Value: "ex-docker"}, {Key: "profileId", Value: "pr-1"}}
+
+	h.httpUpdateProfile(c)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.JSONEq(t, `{"error":"invalid payload"}`, rec.Body.String())
+	require.Empty(t, repo.updatedProfile)
+}
+
+func TestHTTPUpdateProfileSurfacesRepositoryFailure(t *testing.T) {
+	repo := executorFixture()
+	repo.updateErr = errors.New("disk full")
+	h := newProfileHandlers(t, repo, nil)
+	c, rec := newWorkflowRequest(t, http.MethodPatch, "/api/v1/executors/ex-docker/profiles/pr-1",
+		`{"name":"Renamed"}`)
+	c.Params = gin.Params{{Key: "id", Value: "ex-docker"}, {Key: "profileId", Value: "pr-1"}}
+
+	h.httpUpdateProfile(c)
+
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	require.JSONEq(t, `{"error":"profile not updated"}`, rec.Body.String())
+}
+
+// TestHTTPDeleteProfileWorksFromEitherRoute covers both registrations: the
+// nested one under an executor and the top-level profile-only one. Both read
+// the same :profileId param, so both must delete the same row.
+func TestHTTPDeleteProfileWorksFromEitherRoute(t *testing.T) {
+	for name, params := range map[string]gin.Params{
+		"nested":    {{Key: "id", Value: "ex-docker"}, {Key: "profileId", Value: "pr-1"}},
+		"top level": {{Key: "profileId", Value: "pr-1"}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			repo := executorFixture()
+			h := newProfileHandlers(t, repo, nil)
+			c, rec := newWorkflowRequest(t, http.MethodDelete, "/api/v1/executor-profiles/pr-1", "")
+			c.Params = params
+
+			h.httpDeleteProfile(c)
+
+			require.Equal(t, http.StatusOK, rec.Code)
+			require.JSONEq(t, `{"success":true}`, rec.Body.String())
+			require.Equal(t, []string{"pr-1"}, repo.deletedProfile)
+		})
+	}
+}
+
+func TestHTTPDeleteProfileReturnsBadRequestForUnknownProfile(t *testing.T) {
+	repo := executorFixture()
+	h := newProfileHandlers(t, repo, nil)
+	c, rec := newWorkflowRequest(t, http.MethodDelete, "/api/v1/executor-profiles/nope", "")
+	c.Params = gin.Params{{Key: "profileId", Value: "nope"}}
+
+	h.httpDeleteProfile(c)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.JSONEq(t, `{"error":"profile not deleted"}`, rec.Body.String())
+	require.Empty(t, repo.deletedProfile)
+}
+
+func TestWSListProfilesRequiresExecutorID(t *testing.T) {
+	h := newProfileHandlers(t, executorFixture(), nil)
+
+	resp, err := h.wsListProfiles(context.Background(),
+		wsWorkflowRequest(t, ws.ActionExecutorProfileList, map[string]any{}))
+	require.NoError(t, err)
+	payload := wsWorkflowError(t, resp)
+	require.Equal(t, string(ws.ErrorCodeValidation), payload.Code)
+	require.Equal(t, "executor_id is required", payload.Message)
+
+	malformed, err := h.wsListProfiles(context.Background(), wsMalformedRequest(ws.ActionExecutorProfileList))
+	require.NoError(t, err)
+	require.Equal(t, string(ws.ErrorCodeBadRequest), wsWorkflowError(t, malformed).Code)
+}
+
+func TestWSListProfilesReturnsTheExecutorsProfiles(t *testing.T) {
+	h := newProfileHandlers(t, executorFixture(), nil)
+
+	resp, err := h.wsListProfiles(context.Background(),
+		wsWorkflowRequest(t, ws.ActionExecutorProfileList, map[string]any{"executor_id": "ex-docker"}))
+
+	require.NoError(t, err)
+	var list dto.ListExecutorProfilesResponse
+	wsWorkflowResponse(t, resp, &list)
+	require.Equal(t, 1, list.Total)
+	require.Equal(t, "pr-1", list.Profiles[0].ID)
+}
+
+func TestWSListProfilesSurfacesRepositoryFailure(t *testing.T) {
+	repo := executorFixture()
+	repo.listProfilesErr = errors.New("database unavailable")
+	h := newProfileHandlers(t, repo, nil)
+
+	resp, err := h.wsListProfiles(context.Background(),
+		wsWorkflowRequest(t, ws.ActionExecutorProfileList, map[string]any{"executor_id": "ex-docker"}))
+
+	require.NoError(t, err)
+	require.Equal(t, "Failed to list profiles", wsWorkflowError(t, resp).Message)
+}
+
+func TestWSListAllProfilesEnrichesWithExecutorIdentity(t *testing.T) {
+	h := newProfileHandlers(t, executorFixture(), nil)
+
+	resp, err := h.wsListAllProfiles(context.Background(),
+		wsWorkflowRequest(t, ws.ActionExecutorProfileListAll, map[string]any{}))
+
+	require.NoError(t, err)
+	var list dto.ListExecutorProfilesResponse
+	wsWorkflowResponse(t, resp, &list)
+	require.Equal(t, 1, list.Total)
+	require.Equal(t, "Docker", list.Profiles[0].ExecutorName)
+}
+
+func TestWSListAllProfilesSurfacesFailures(t *testing.T) {
+	profilesFail := executorFixture()
+	profilesFail.listProfilesErr = errors.New("database unavailable")
+	resp, err := newProfileHandlers(t, profilesFail, nil).wsListAllProfiles(context.Background(),
+		wsWorkflowRequest(t, ws.ActionExecutorProfileListAll, map[string]any{}))
+	require.NoError(t, err)
+	require.Equal(t, "Failed to list profiles", wsWorkflowError(t, resp).Message)
+
+	executorsFail := executorFixture()
+	executorsFail.listErr = errors.New("database unavailable")
+	resp, err = newProfileHandlers(t, executorsFail, nil).wsListAllProfiles(context.Background(),
+		wsWorkflowRequest(t, ws.ActionExecutorProfileListAll, map[string]any{}))
+	require.NoError(t, err)
+	require.Equal(t, "Failed to list executors", wsWorkflowError(t, resp).Message)
+}
+
+func TestWSCreateProfileValidatesAndCreates(t *testing.T) {
+	repo := executorFixture()
+	h := newProfileHandlers(t, repo, nil)
+
+	invalid, err := h.wsCreateProfile(context.Background(),
+		wsWorkflowRequest(t, ws.ActionExecutorProfileCreate, map[string]any{"name": "Fresh"}))
+	require.NoError(t, err)
+	require.Equal(t, "executor_id and name are required", wsWorkflowError(t, invalid).Message)
+	require.Empty(t, repo.createdProfile)
+
+	resp, err := h.wsCreateProfile(context.Background(),
+		wsWorkflowRequest(t, ws.ActionExecutorProfileCreate, map[string]any{
+			"executor_id": "ex-local", "name": "Fresh", "cleanup_script": "echo bye",
+		}))
+	require.NoError(t, err)
+	var created dto.ExecutorProfileDTO
+	wsWorkflowResponse(t, resp, &created)
+	require.Equal(t, "Fresh", created.Name)
+	require.Equal(t, "ex-local", created.ExecutorID)
+	require.Len(t, repo.createdProfile, 1)
+	require.Equal(t, "echo bye", repo.createdProfile[0].CleanupScript)
+}
+
+func TestWSCreateProfileSurfacesUnknownExecutor(t *testing.T) {
+	repo := executorFixture()
+	h := newProfileHandlers(t, repo, nil)
+
+	resp, err := h.wsCreateProfile(context.Background(),
+		wsWorkflowRequest(t, ws.ActionExecutorProfileCreate, map[string]any{
+			"executor_id": "nope", "name": "Fresh",
+		}))
+
+	require.NoError(t, err)
+	payload := wsWorkflowError(t, resp)
+	require.Equal(t, string(ws.ErrorCodeInternalError), payload.Code)
+	require.Equal(t, "Failed to create profile", payload.Message)
+	require.Empty(t, repo.createdProfile)
+}
+
+func TestWSGetProfileReturnsProfileOrErrors(t *testing.T) {
+	h := newProfileHandlers(t, executorFixture(), nil)
+
+	resp, err := h.wsGetProfile(context.Background(),
+		wsWorkflowRequest(t, ws.ActionExecutorProfileGet, map[string]any{"id": "pr-1"}))
+	require.NoError(t, err)
+	var got dto.ExecutorProfileDTO
+	wsWorkflowResponse(t, resp, &got)
+	require.Equal(t, "pr-1", got.ID)
+
+	missing, err := h.wsGetProfile(context.Background(),
+		wsWorkflowRequest(t, ws.ActionExecutorProfileGet, map[string]any{"id": "nope"}))
+	require.NoError(t, err)
+	require.Equal(t, string(ws.ErrorCodeNotFound), wsWorkflowError(t, missing).Code)
+
+	empty, err := h.wsGetProfile(context.Background(),
+		wsWorkflowRequest(t, ws.ActionExecutorProfileGet, map[string]any{}))
+	require.NoError(t, err)
+	require.Equal(t, "id is required", wsWorkflowError(t, empty).Message)
+}
+
+func TestWSUpdateProfileAppliesFields(t *testing.T) {
+	repo := executorFixture()
+	h := newProfileHandlers(t, repo, nil)
+
+	resp, err := h.wsUpdateProfile(context.Background(),
+		wsWorkflowRequest(t, ws.ActionExecutorProfileUpdate, map[string]any{
+			"id": "pr-1", "name": "Renamed", "prepare_script": "echo hi",
+		}))
+
+	require.NoError(t, err)
+	var updated dto.ExecutorProfileDTO
+	wsWorkflowResponse(t, resp, &updated)
+	require.Equal(t, "Renamed", updated.Name)
+	require.Equal(t, "echo hi", updated.PrepareScript)
+	require.Len(t, repo.updatedProfile, 1)
+}
+
+func TestWSUpdateProfileRequiresID(t *testing.T) {
+	repo := executorFixture()
+	h := newProfileHandlers(t, repo, nil)
+
+	resp, err := h.wsUpdateProfile(context.Background(),
+		wsWorkflowRequest(t, ws.ActionExecutorProfileUpdate, map[string]any{"name": "Renamed"}))
+
+	require.NoError(t, err)
+	require.Equal(t, "id is required", wsWorkflowError(t, resp).Message)
+	require.Empty(t, repo.updatedProfile)
+}
+
+func TestWSDeleteProfileDeletesAndValidates(t *testing.T) {
+	repo := executorFixture()
+	h := newProfileHandlers(t, repo, nil)
+
+	empty, err := h.wsDeleteProfile(context.Background(),
+		wsWorkflowRequest(t, ws.ActionExecutorProfileDelete, map[string]any{}))
+	require.NoError(t, err)
+	require.Equal(t, "id is required", wsWorkflowError(t, empty).Message)
+	require.Empty(t, repo.deletedProfile)
+
+	resp, err := h.wsDeleteProfile(context.Background(),
+		wsWorkflowRequest(t, ws.ActionExecutorProfileDelete, map[string]any{"id": "pr-1"}))
+	require.NoError(t, err)
+	var success dto.SuccessResponse
+	wsWorkflowResponse(t, resp, &success)
+	require.True(t, success.Success)
+	require.Equal(t, []string{"pr-1"}, repo.deletedProfile)
+}
+
+func TestWSDeleteProfileSurfacesRepositoryFailure(t *testing.T) {
+	repo := executorFixture()
+	h := newProfileHandlers(t, repo, nil)
+
+	resp, err := h.wsDeleteProfile(context.Background(),
+		wsWorkflowRequest(t, ws.ActionExecutorProfileDelete, map[string]any{"id": "nope"}))
+
+	require.NoError(t, err)
+	payload := wsWorkflowError(t, resp)
+	require.Equal(t, string(ws.ErrorCodeInternalError), payload.Code)
+	require.Equal(t, "Failed to delete profile", payload.Message)
+	require.Empty(t, repo.deletedProfile)
+}

--- a/apps/backend/internal/task/handlers/message_list_handlers_test.go
+++ b/apps/backend/internal/task/handlers/message_list_handlers_test.go
@@ -211,6 +211,14 @@ func TestHTTPListMessagesSurfacesRepositoryFailure(t *testing.T) {
 
 // TestHTTPListMessagesDeniesForeignSession covers the transcript read, which
 // carries the full agent conversation.
+//
+// The denial itself is sound — AuthorizeSessionAccess refuses before any
+// repository call — but it surfaces as 500 rather than the 404 every other
+// session route answers, because httpListMessages funnels every fetchMessages
+// error into one generic branch without separating the authorization sentinel
+// from a storage failure. The status is asserted as-is so the behavior is
+// pinned; the inconsistency is reported separately rather than treated here as
+// if it were intended.
 func TestHTTPListMessagesDeniesForeignSession(t *testing.T) {
 	repo := &messageListRepo{}
 	h := newMessageListHandlers(t, repo)

--- a/apps/backend/internal/task/handlers/message_list_handlers_test.go
+++ b/apps/backend/internal/task/handlers/message_list_handlers_test.go
@@ -1,0 +1,361 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kandev/kandev/internal/auth/authn"
+	"github.com/kandev/kandev/internal/task/dto"
+	"github.com/kandev/kandev/internal/task/models"
+	"github.com/kandev/kandev/internal/task/service"
+	ws "github.com/kandev/kandev/pkg/websocket"
+)
+
+// messageListRepo owns session "sess-b" as "user-b" and records the options
+// each list/search request reaches the repository with.
+type messageListRepo struct {
+	foreignSessionRepo
+
+	listErr      error
+	paginatedErr error
+	searchErr    error
+
+	listCalls        int
+	paginatedOptions []models.ListMessagesOptions
+	searchOptions    []models.SearchMessagesOptions
+	hasMore          bool
+}
+
+func (r *messageListRepo) ListMessages(context.Context, string) ([]*models.Message, error) {
+	r.listCalls++
+	if r.listErr != nil {
+		return nil, r.listErr
+	}
+	return []*models.Message{
+		{ID: "msg-1", TaskSessionID: "sess-b", Content: "hello world"},
+		{ID: "msg-2", TaskSessionID: "sess-b", Content: "goodbye"},
+	}, nil
+}
+
+func (r *messageListRepo) ListMessagesPaginated(
+	_ context.Context, _ string, opts models.ListMessagesOptions,
+) ([]*models.Message, bool, error) {
+	r.paginatedOptions = append(r.paginatedOptions, opts)
+	if r.paginatedErr != nil {
+		return nil, false, r.paginatedErr
+	}
+	return []*models.Message{
+		{ID: "msg-1", TaskSessionID: "sess-b", Content: "hello world"},
+	}, r.hasMore, nil
+}
+
+func (r *messageListRepo) SearchMessages(
+	_ context.Context, _ string, opts models.SearchMessagesOptions,
+) ([]*models.Message, error) {
+	r.searchOptions = append(r.searchOptions, opts)
+	if r.searchErr != nil {
+		return nil, r.searchErr
+	}
+	return []*models.Message{
+		{ID: "msg-1", TaskSessionID: "sess-b", Content: "hello world", TurnID: "turn-1"},
+	}, nil
+}
+
+func newMessageListHandlers(t *testing.T, repo *messageListRepo) *MessageHandlers {
+	t.Helper()
+	log := newTestLogger(t)
+	svc := service.NewService(service.Repos{
+		Workspaces: repo, Tasks: repo, TaskRepos: repo,
+		Workflows: repo, Messages: repo, Turns: repo,
+		Sessions: repo, GitSnapshots: repo, RepoEntities: repo,
+		Executors: repo, Environments: repo, TaskEnvironments: repo,
+		Reviews: repo,
+	}, nil, log, service.RepositoryDiscoveryConfig{})
+	return &MessageHandlers{service: svc, logger: log}
+}
+
+func messageRequestAs(t *testing.T, userID, target, sessionID string) (*gin.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	c, rec := newWorkflowRequest(t, http.MethodGet, target, "")
+	if userID != "" {
+		c.Request = c.Request.WithContext(authn.WithIdentity(
+			c.Request.Context(), authn.Identity{UserID: userID, Role: authn.RoleMember}))
+	}
+	c.Params = gin.Params{{Key: "id", Value: sessionID}}
+	return c, rec
+}
+
+func TestHTTPListMessagesRequiresSessionID(t *testing.T) {
+	repo := &messageListRepo{}
+	h := newMessageListHandlers(t, repo)
+	c, rec := messageRequestAs(t, "", "/api/v1/task-sessions//messages", "")
+
+	h.httpListMessages(c)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.JSONEq(t, `{"error":"task session id is required"}`, rec.Body.String())
+	require.Zero(t, repo.listCalls)
+}
+
+// TestHTTPListMessagesUsesTheUnpaginatedPathByDefault pins the mode switch:
+// with no cursor, sort or limit the handler must take the plain list, whose
+// response carries no cursor.
+func TestHTTPListMessagesUsesTheUnpaginatedPathByDefault(t *testing.T) {
+	repo := &messageListRepo{}
+	h := newMessageListHandlers(t, repo)
+	c, rec := messageRequestAs(t, "", "/api/v1/task-sessions/sess-b/messages", "sess-b")
+
+	h.httpListMessages(c)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp dto.ListMessagesResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Equal(t, 2, resp.Total)
+	require.Equal(t, 1, repo.listCalls)
+	require.Empty(t, repo.paginatedOptions, "the paginated query must not run")
+	require.Empty(t, resp.Cursor)
+	require.False(t, resp.HasMore)
+}
+
+// TestHTTPListMessagesSwitchesToPaginationOnAnyCursorParam covers each param
+// that flips the mode independently — a regression that only checked `limit`
+// would silently ignore before/after/sort.
+func TestHTTPListMessagesSwitchesToPaginationOnAnyCursorParam(t *testing.T) {
+	for name, query := range map[string]string{
+		"limit":  "?limit=25",
+		"before": "?before=msg-9",
+		"after":  "?after=msg-1",
+		"sort":   "?sort=asc",
+	} {
+		t.Run(name, func(t *testing.T) {
+			repo := &messageListRepo{hasMore: true}
+			h := newMessageListHandlers(t, repo)
+			c, rec := messageRequestAs(t, "", "/api/v1/task-sessions/sess-b/messages"+query, "sess-b")
+
+			h.httpListMessages(c)
+
+			require.Equal(t, http.StatusOK, rec.Code)
+			require.Zero(t, repo.listCalls, "the unpaginated query must not run")
+			require.Len(t, repo.paginatedOptions, 1)
+
+			var resp dto.ListMessagesResponse
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+			require.True(t, resp.HasMore)
+			require.Equal(t, "msg-1", resp.Cursor, "the cursor is the last returned message")
+		})
+	}
+}
+
+func TestHTTPListMessagesRejectsConflictingAndInvalidParams(t *testing.T) {
+	repo := &messageListRepo{}
+	h := newMessageListHandlers(t, repo)
+
+	for name, tc := range map[string]struct {
+		query    string
+		wantBody string
+	}{
+		"before and after together": {
+			query:    "?before=msg-9&after=msg-1",
+			wantBody: `{"error":"only one of before or after can be set"}`,
+		},
+		"unknown sort": {
+			query:    "?sort=sideways",
+			wantBody: `{"error":"sort must be asc or desc"}`,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			c, rec := messageRequestAs(t, "", "/api/v1/task-sessions/sess-b/messages"+tc.query, "sess-b")
+
+			h.httpListMessages(c)
+
+			require.Equal(t, http.StatusBadRequest, rec.Code)
+			require.JSONEq(t, tc.wantBody, rec.Body.String())
+		})
+	}
+	require.Empty(t, repo.paginatedOptions, "a rejected request must not query messages")
+	require.Zero(t, repo.listCalls)
+}
+
+// TestHTTPListMessagesIgnoresAnUnparseableLimit documents the lenient parse:
+// a garbage limit leaves limit at 0 but still selects the paginated path,
+// because the parameter was present.
+func TestHTTPListMessagesIgnoresAnUnparseableLimit(t *testing.T) {
+	repo := &messageListRepo{}
+	h := newMessageListHandlers(t, repo)
+	c, rec := messageRequestAs(t, "", "/api/v1/task-sessions/sess-b/messages?limit=many", "sess-b")
+
+	h.httpListMessages(c)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Len(t, repo.paginatedOptions, 1)
+	require.Zero(t, repo.listCalls)
+}
+
+func TestHTTPListMessagesSurfacesRepositoryFailure(t *testing.T) {
+	repo := &messageListRepo{listErr: errors.New("database unavailable")}
+	h := newMessageListHandlers(t, repo)
+	c, rec := messageRequestAs(t, "", "/api/v1/task-sessions/sess-b/messages", "sess-b")
+
+	h.httpListMessages(c)
+
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	require.JSONEq(t, `{"error":"failed to list messages"}`, rec.Body.String())
+}
+
+// TestHTTPListMessagesDeniesForeignSession covers the transcript read, which
+// carries the full agent conversation.
+func TestHTTPListMessagesDeniesForeignSession(t *testing.T) {
+	repo := &messageListRepo{}
+	h := newMessageListHandlers(t, repo)
+
+	c, rec := messageRequestAs(t, "user-a", "/api/v1/task-sessions/sess-b/messages", "sess-b")
+	h.httpListMessages(c)
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	require.NotContains(t, rec.Body.String(), "hello world", "the transcript must not leak")
+	require.Zero(t, repo.listCalls, "a denied read must not reach the repository")
+
+	ownerCtx, ownerRec := messageRequestAs(t, "user-b", "/api/v1/task-sessions/sess-b/messages", "sess-b")
+	h.httpListMessages(ownerCtx)
+	require.Equal(t, http.StatusOK, ownerRec.Code)
+	require.Contains(t, ownerRec.Body.String(), "hello world")
+}
+
+func TestWSListMessagesValidatesRequest(t *testing.T) {
+	repo := &messageListRepo{}
+	h := newMessageListHandlers(t, repo)
+
+	for name, tc := range map[string]struct {
+		payload any
+		wantMsg string
+	}{
+		"missing session": {
+			payload: map[string]any{},
+			wantMsg: "session_id is required",
+		},
+		"before and after": {
+			payload: map[string]any{"session_id": "sess-b", "before": "m1", "after": "m2"},
+			wantMsg: "only one of before or after can be set",
+		},
+		"unknown sort": {
+			payload: map[string]any{"session_id": "sess-b", "sort": "sideways"},
+			wantMsg: "sort must be asc or desc",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			resp, err := h.wsListMessages(context.Background(),
+				wsWorkflowRequest(t, ws.ActionMessageList, tc.payload))
+
+			require.NoError(t, err)
+			payload := wsWorkflowError(t, resp)
+			require.Equal(t, string(ws.ErrorCodeValidation), payload.Code)
+			require.Equal(t, tc.wantMsg, payload.Message)
+		})
+	}
+	require.Empty(t, repo.paginatedOptions)
+
+	malformed, err := h.wsListMessages(context.Background(), wsMalformedRequest(ws.ActionMessageList))
+	require.NoError(t, err)
+	require.Equal(t, string(ws.ErrorCodeBadRequest), wsWorkflowError(t, malformed).Code)
+}
+
+func TestWSListMessagesReturnsPageAndCursor(t *testing.T) {
+	repo := &messageListRepo{hasMore: true}
+	h := newMessageListHandlers(t, repo)
+
+	resp, err := h.wsListMessages(context.Background(),
+		wsWorkflowRequest(t, ws.ActionMessageList, map[string]any{
+			"session_id": "sess-b", "limit": 10, "sort": "asc",
+		}))
+
+	require.NoError(t, err)
+	var page dto.ListMessagesResponse
+	wsWorkflowResponse(t, resp, &page)
+	require.Equal(t, 1, page.Total)
+	require.True(t, page.HasMore)
+	require.Equal(t, "msg-1", page.Cursor)
+	require.Len(t, repo.paginatedOptions, 1)
+	require.Equal(t, 10, repo.paginatedOptions[0].Limit)
+	require.Equal(t, "asc", repo.paginatedOptions[0].Sort)
+}
+
+func TestWSListMessagesSurfacesRepositoryFailure(t *testing.T) {
+	repo := &messageListRepo{paginatedErr: errors.New("database unavailable")}
+	h := newMessageListHandlers(t, repo)
+
+	resp, err := h.wsListMessages(context.Background(),
+		wsWorkflowRequest(t, ws.ActionMessageList, map[string]any{"session_id": "sess-b"}))
+
+	require.NoError(t, err)
+	payload := wsWorkflowError(t, resp)
+	require.Equal(t, string(ws.ErrorCodeInternalError), payload.Code)
+	require.Equal(t, "Failed to list messages", payload.Message)
+}
+
+// TestWSSearchMessagesShortCircuitsOnBlankQuery pins the empty-result contract:
+// a whitespace-only query must not reach the repository, and must serialize as
+// an empty array rather than null.
+func TestWSSearchMessagesShortCircuitsOnBlankQuery(t *testing.T) {
+	repo := &messageListRepo{}
+	h := newMessageListHandlers(t, repo)
+
+	resp, err := h.wsSearchMessages(context.Background(),
+		wsWorkflowRequest(t, ws.ActionMessageSearch, map[string]any{
+			"session_id": "sess-b", "query": "   ",
+		}))
+
+	require.NoError(t, err)
+	var search dto.SearchMessagesResponse
+	wsWorkflowResponse(t, resp, &search)
+	require.Equal(t, 0, search.Total)
+	require.NotNil(t, search.Hits)
+	require.Empty(t, repo.searchOptions, "a blank query must not hit the index")
+}
+
+func TestWSSearchMessagesReturnsHitsWithSnippets(t *testing.T) {
+	repo := &messageListRepo{}
+	h := newMessageListHandlers(t, repo)
+
+	resp, err := h.wsSearchMessages(context.Background(),
+		wsWorkflowRequest(t, ws.ActionMessageSearch, map[string]any{
+			"session_id": "sess-b", "query": "world", "limit": 5,
+		}))
+
+	require.NoError(t, err)
+	var search dto.SearchMessagesResponse
+	wsWorkflowResponse(t, resp, &search)
+	require.Equal(t, 1, search.Total)
+	require.Equal(t, "msg-1", search.Hits[0].ID)
+	require.Equal(t, "turn-1", search.Hits[0].TurnID)
+	require.Contains(t, search.Hits[0].Snippet, "world")
+	require.Len(t, repo.searchOptions, 1)
+	require.Equal(t, "world", repo.searchOptions[0].Query)
+	require.Equal(t, 5, repo.searchOptions[0].Limit)
+}
+
+func TestWSSearchMessagesValidatesAndSurfacesFailures(t *testing.T) {
+	repo := &messageListRepo{}
+	h := newMessageListHandlers(t, repo)
+
+	empty, err := h.wsSearchMessages(context.Background(),
+		wsWorkflowRequest(t, ws.ActionMessageSearch, map[string]any{"query": "x"}))
+	require.NoError(t, err)
+	require.Equal(t, "session_id is required", wsWorkflowError(t, empty).Message)
+
+	malformed, err := h.wsSearchMessages(context.Background(), wsMalformedRequest(ws.ActionMessageSearch))
+	require.NoError(t, err)
+	require.Equal(t, string(ws.ErrorCodeBadRequest), wsWorkflowError(t, malformed).Code)
+
+	failing := newMessageListHandlers(t, &messageListRepo{searchErr: errors.New("index unavailable")})
+	resp, err := failing.wsSearchMessages(context.Background(),
+		wsWorkflowRequest(t, ws.ActionMessageSearch, map[string]any{"session_id": "sess-b", "query": "x"}))
+	require.NoError(t, err)
+	require.Equal(t, "Failed to search messages", wsWorkflowError(t, resp).Message)
+	require.Empty(t, repo.searchOptions)
+}

--- a/apps/backend/internal/task/handlers/process_handlers_routes_test.go
+++ b/apps/backend/internal/task/handlers/process_handlers_routes_test.go
@@ -1,0 +1,374 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	agentctlclient "github.com/kandev/kandev/internal/agent/runtime/agentctl"
+	"github.com/kandev/kandev/internal/agent/runtime/lifecycle"
+	"github.com/kandev/kandev/internal/auth/authn"
+	"github.com/kandev/kandev/internal/task/models"
+	"github.com/kandev/kandev/internal/task/service"
+)
+
+// newForeignProcessHandlers wires ProcessHandlers over the shared
+// foreign-session fixture, whose sole session "sess-b" belongs to "user-b".
+func newForeignProcessHandlers(t *testing.T, mgr *lifecycle.Manager) *ProcessHandlers {
+	t.Helper()
+	log := newTestLogger(t)
+	repo := &foreignSessionRepo{}
+	svc := service.NewService(service.Repos{
+		Workspaces: repo, Tasks: repo, TaskRepos: repo,
+		Workflows: repo, Messages: repo, Turns: repo,
+		Sessions: repo, GitSnapshots: repo, RepoEntities: repo,
+		Executors: repo, Environments: repo, TaskEnvironments: repo,
+		Reviews: repo,
+	}, nil, log, service.RepositoryDiscoveryConfig{})
+	return &ProcessHandlers{service: svc, lifecycleMgr: mgr, logger: log}
+}
+
+// processRequestAs builds a request for sess-b carrying userID's identity.
+func processRequestAs(t *testing.T, userID, method, target, body string) (*gin.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(method, target, strings.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Request = c.Request.WithContext(authn.WithIdentity(
+		c.Request.Context(), authn.Identity{UserID: userID, Role: authn.RoleMember}))
+	c.Params = gin.Params{{Key: "id", Value: "sess-b"}, {Key: "processId", Value: "proc-1"}}
+	return c, rec
+}
+
+// agentctlProcessServer serves a single process owned by procSessionID and
+// reports whether the list endpoint was reached.
+func agentctlProcessServer(t *testing.T, procSessionID string) (*httptest.Server, *atomic.Bool) {
+	t.Helper()
+	listed := &atomic.Bool{}
+	proc := agentctlclient.ProcessInfo{
+		ID:        "proc-1",
+		SessionID: procSessionID,
+		Kind:      agentctlclient.ProcessKind("dev"),
+		Status:    agentctlclient.ProcessStatus("running"),
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/v1/processes":
+			listed.Store(true)
+			data, _ := json.Marshal([]agentctlclient.ProcessInfo{proc})
+			_, _ = w.Write(data)
+		case strings.HasPrefix(r.URL.Path, "/api/v1/processes/"):
+			data, _ := json.Marshal(proc)
+			_, _ = w.Write(data)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server, listed
+}
+
+// managerWithSessionExecution registers a running execution for sessionID that
+// talks to the given agentctl server.
+func managerWithSessionExecution(t *testing.T, serverURL, sessionID string) *lifecycle.Manager {
+	t.Helper()
+	log := newTestLogger(t)
+	mgr := newLifecycleManager(t, log)
+	exec := (&lifecycle.ExecutorInstance{
+		InstanceID: "exec-1",
+		TaskID:     "task-b",
+		SessionID:  sessionID,
+		Client:     newAgentctlClient(t, serverURL, log),
+	}).ToAgentExecution(&lifecycle.ExecutorCreateRequest{
+		InstanceID:     "exec-1",
+		TaskID:         "task-b",
+		SessionID:      sessionID,
+		AgentProfileID: "profile-1",
+		WorkspacePath:  "/tmp/workspace",
+	})
+	addExecution(t, mgr, exec)
+	return mgr
+}
+
+// TestHTTPListProcessesDeniesForeignSession closes the read half of the
+// session-keyed process routes. The owner request is the witness: it reaches
+// agentctl and returns the process, so the 404 above is the scoping denial and
+// not some unrelated failure.
+func TestHTTPListProcessesDeniesForeignSession(t *testing.T) {
+	server, listed := agentctlProcessServer(t, "sess-b")
+	h := newForeignProcessHandlers(t, managerWithSessionExecution(t, server.URL, "sess-b"))
+
+	c, rec := processRequestAs(t, "user-a", http.MethodGet, "/api/v1/task-sessions/sess-b/processes", "")
+	h.httpListProcesses(c)
+	require.Equal(t, http.StatusNotFound, rec.Code, "body: %s", rec.Body.String())
+	require.NotContains(t, rec.Body.String(), "proc-1", "a foreign session's processes must not leak")
+	require.False(t, listed.Load(), "the denial must land before agentctl is contacted")
+
+	ownerCtx, ownerRec := processRequestAs(t, "user-b", http.MethodGet, "/api/v1/task-sessions/sess-b/processes", "")
+	h.httpListProcesses(ownerCtx)
+	require.Equal(t, http.StatusOK, ownerRec.Code)
+	require.Contains(t, ownerRec.Body.String(), "proc-1")
+	require.True(t, listed.Load())
+}
+
+// TestHTTPGetProcessDeniesForeignSession is the same shape for the single-process
+// read, whose payload can carry captured process output.
+func TestHTTPGetProcessDeniesForeignSession(t *testing.T) {
+	server, _ := agentctlProcessServer(t, "sess-b")
+	h := newForeignProcessHandlers(t, managerWithSessionExecution(t, server.URL, "sess-b"))
+
+	c, rec := processRequestAs(t, "user-a", http.MethodGet,
+		"/api/v1/task-sessions/sess-b/processes/proc-1", "")
+	h.httpGetProcess(c)
+	require.Equal(t, http.StatusNotFound, rec.Code)
+	require.NotContains(t, rec.Body.String(), "running", "the foreign process must not be serialized")
+
+	ownerCtx, ownerRec := processRequestAs(t, "user-b", http.MethodGet,
+		"/api/v1/task-sessions/sess-b/processes/proc-1", "")
+	h.httpGetProcess(ownerCtx)
+	require.Equal(t, http.StatusOK, ownerRec.Code)
+	require.Contains(t, ownerRec.Body.String(), "proc-1")
+}
+
+// TestHTTPGetProcessRejectsProcessFromAnotherSession covers the ownership
+// re-check after the lookup: agentctl is asked by process ID alone, so the
+// handler must compare the returned SessionID against the route's.
+func TestHTTPGetProcessRejectsProcessFromAnotherSession(t *testing.T) {
+	server, _ := agentctlProcessServer(t, "sess-elsewhere")
+	h := newForeignProcessHandlers(t, managerWithSessionExecution(t, server.URL, "sess-b"))
+
+	c, rec := processRequestAs(t, "user-b", http.MethodGet,
+		"/api/v1/task-sessions/sess-b/processes/proc-1", "")
+	h.httpGetProcess(c)
+
+	require.Equal(t, http.StatusNotFound, rec.Code)
+	require.JSONEq(t, `{"error":"process not found"}`, rec.Body.String())
+}
+
+// TestHTTPStartProcessDeniesForeignSession covers the write half. Starting a
+// process runs a shell command inside the session's workspace, so this is the
+// highest-value denial in the file. The owner witness fails later, on the
+// repository the fixture deliberately does not provide.
+func TestHTTPStartProcessDeniesForeignSession(t *testing.T) {
+	h := newForeignProcessHandlers(t, newLifecycleManager(t, newTestLogger(t)))
+
+	c, rec := processRequestAs(t, "user-a", http.MethodPost,
+		"/api/v1/task-sessions/sess-b/processes/start", `{"kind":"dev"}`)
+	h.httpStartProcess(c)
+	require.Equal(t, http.StatusNotFound, rec.Code)
+	require.JSONEq(t, `{"error":"task session not found"}`, rec.Body.String())
+
+	ownerCtx, ownerRec := processRequestAs(t, "user-b", http.MethodPost,
+		"/api/v1/task-sessions/sess-b/processes/start", `{"kind":"dev"}`)
+	h.httpStartProcess(ownerCtx)
+	require.NotEqual(t, http.StatusNotFound, ownerRec.Code,
+		"the owner must get past the session check — otherwise the 404 above proves nothing")
+	require.Equal(t, http.StatusBadRequest, ownerRec.Code)
+	require.JSONEq(t, `{"error":"session has no repository"}`, ownerRec.Body.String())
+}
+
+// TestProcessRoutesRejectMissingIdentifiers covers the cheap argument checks
+// that run before any lookup.
+func TestProcessRoutesRejectMissingIdentifiers(t *testing.T) {
+	h := newForeignProcessHandlers(t, nil)
+
+	for name, tc := range map[string]struct {
+		handler  func(*gin.Context)
+		params   gin.Params
+		wantBody string
+	}{
+		"start without session": {
+			handler:  h.httpStartProcess,
+			wantBody: `{"error":"session_id is required"}`,
+		},
+		"list without session": {
+			handler:  h.httpListProcesses,
+			wantBody: `{"error":"session_id is required"}`,
+		},
+		"get without session": {
+			handler:  h.httpGetProcess,
+			params:   gin.Params{{Key: "processId", Value: "proc-1"}},
+			wantBody: `{"error":"session_id and process_id are required"}`,
+		},
+		"get without process": {
+			handler:  h.httpGetProcess,
+			params:   gin.Params{{Key: "id", Value: "sess-b"}},
+			wantBody: `{"error":"session_id and process_id are required"}`,
+		},
+		"stop without process": {
+			handler:  h.httpStopProcessByID,
+			params:   gin.Params{{Key: "id", Value: "sess-b"}},
+			wantBody: `{"error":"session_id and process_id are required"}`,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			gin.SetMode(gin.TestMode)
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+			c.Request = httptest.NewRequest(http.MethodPost, "/x", strings.NewReader(`{}`))
+			c.Request.Header.Set("Content-Type", "application/json")
+			c.Params = tc.params
+
+			tc.handler(c)
+
+			require.Equal(t, http.StatusBadRequest, rec.Code)
+			require.JSONEq(t, tc.wantBody, rec.Body.String())
+		})
+	}
+}
+
+func TestHTTPStartProcessRejectsInvalidBody(t *testing.T) {
+	h := newForeignProcessHandlers(t, nil)
+	c, rec := processRequestAs(t, "user-b", http.MethodPost,
+		"/api/v1/task-sessions/sess-b/processes/start", `{`)
+
+	h.httpStartProcess(c)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.JSONEq(t, `{"error":"invalid request body"}`, rec.Body.String())
+}
+
+// TestHTTPListProcessesReportsEmptyWhenAgentNotStarted pins the graceful
+// degradation: an absent execution is "no processes yet", not a 500, because
+// the UI polls this endpoint while the agent is still launching.
+func TestHTTPListProcessesReportsEmptyWhenAgentNotStarted(t *testing.T) {
+	h := newForeignProcessHandlers(t, newLifecycleManager(t, newTestLogger(t)))
+	c, rec := processRequestAs(t, "user-b", http.MethodGet, "/api/v1/task-sessions/sess-b/processes", "")
+
+	h.httpListProcesses(c)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.JSONEq(t, `[]`, rec.Body.String())
+}
+
+// TestHTTPStopProcessIsIdempotentWithoutAnExecution documents the 204 fast
+// path: nothing is running, so there is nothing to stop and no error to report.
+// Driven through the real router because a 204 is only flushed to the recorder
+// once gin finishes the request.
+func TestHTTPStopProcessIsIdempotentWithoutAnExecution(t *testing.T) {
+	log := newTestLogger(t)
+	repo := &foreignSessionRepo{}
+	svc := service.NewService(service.Repos{
+		Workspaces: repo, Tasks: repo, TaskRepos: repo,
+		Workflows: repo, Messages: repo, Turns: repo,
+		Sessions: repo, GitSnapshots: repo, RepoEntities: repo,
+		Executors: repo, Environments: repo, TaskEnvironments: repo,
+		Reviews: repo,
+	}, nil, log, service.RepositoryDiscoveryConfig{})
+	router := newProcessStopRouter(t, svc, newLifecycleManager(t, log), log)
+
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/v1/task-sessions/sess-b/processes/proc-1/stop", nil)
+	req = req.WithContext(authn.WithIdentity(req.Context(),
+		authn.Identity{UserID: "user-b", Role: authn.RoleMember}))
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	require.Empty(t, rec.Body.String())
+}
+
+func TestResolveWorkingDirForStartPrefersTheExecutionWorkspace(t *testing.T) {
+	server, _ := agentctlProcessServer(t, "sess-b")
+	h := newForeignProcessHandlers(t, managerWithSessionExecution(t, server.URL, "sess-b"))
+	c, rec := processRequestAs(t, "user-b", http.MethodPost, "/x", "")
+
+	dir, ok := h.resolveWorkingDirForStart(c, "sess-b", "/fallback")
+
+	require.True(t, ok)
+	require.Equal(t, "/tmp/workspace", dir, "a live execution's workspace wins over the legacy fallback")
+	require.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestResolveWorkingDirForStartFallsBackAndThenFails(t *testing.T) {
+	h := newForeignProcessHandlers(t, newLifecycleManager(t, newTestLogger(t)))
+
+	c, _ := processRequestAs(t, "user-b", http.MethodPost, "/x", "")
+	dir, ok := h.resolveWorkingDirForStart(c, "sess-none", "  /repo/path  ")
+	require.True(t, ok)
+	require.Equal(t, "/repo/path", dir, "the fallback is trimmed")
+
+	emptyCtx, emptyRec := processRequestAs(t, "user-b", http.MethodPost, "/x", "")
+	_, ok = h.resolveWorkingDirForStart(emptyCtx, "sess-none", "   ")
+	require.False(t, ok)
+	require.Equal(t, http.StatusServiceUnavailable, emptyRec.Code)
+	require.JSONEq(t, `{"error":"workspace path unavailable for session"}`, emptyRec.Body.String())
+}
+
+func TestPrepareCommandWithPortsLeavesPlainCommandsAlone(t *testing.T) {
+	h := newForeignProcessHandlers(t, nil)
+	c, rec := processRequestAs(t, "user-b", http.MethodPost, "/x", "")
+
+	command, portEnv, ok := h.prepareCommandWithPorts(c, "sess-b", "pnpm dev")
+
+	require.True(t, ok)
+	require.Equal(t, "pnpm dev", command)
+	require.Empty(t, portEnv)
+	require.Equal(t, http.StatusOK, rec.Code, "no response is written on the success path")
+}
+
+func TestResolveScriptCommandRejectsUnconfiguredAndUnknownKinds(t *testing.T) {
+	svc := newTestService(t, nil)
+	empty := &models.Repository{ID: "repo-1"}
+
+	for name, tc := range map[string]struct {
+		kind       string
+		scriptName string
+		wantErr    string
+	}{
+		"setup not configured":   {kind: "setup", wantErr: "setup script not configured"},
+		"cleanup not configured": {kind: "cleanup", wantErr: "cleanup script not configured"},
+		"dev not configured":     {kind: "dev", wantErr: "dev script not configured"},
+		"custom without name":    {kind: "custom", wantErr: "script_name is required for custom scripts"},
+		"unknown kind":           {kind: "deploy", wantErr: "invalid script kind"},
+		"empty kind":             {kind: "", wantErr: "invalid script kind"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			command, kind, scriptName, err := resolveScriptCommand(
+				context.Background(), svc, empty, tc.kind, tc.scriptName)
+
+			require.EqualError(t, err, tc.wantErr)
+			require.Empty(t, command)
+			require.Empty(t, kind)
+			require.Empty(t, scriptName)
+		})
+	}
+}
+
+// TestResolveScriptCommandIsCaseInsensitiveOnKind pins the strings.ToLower on
+// the kind: the UI has sent "Dev" before.
+func TestResolveScriptCommandIsCaseInsensitiveOnKind(t *testing.T) {
+	svc := newTestService(t, nil)
+	repo := &models.Repository{ID: "repo-1", DevScript: "pnpm dev"}
+
+	command, kind, _, err := resolveScriptCommand(context.Background(), svc, repo, "DEV", "")
+
+	require.NoError(t, err)
+	require.Equal(t, "pnpm dev", command)
+	require.Equal(t, "dev", kind, "the normalized kind is reported back, not the caller's casing")
+}
+
+func TestResolveScriptCommandRejectsMissingAndEmptyCustomScripts(t *testing.T) {
+	svc := newTestService(t, map[string][]*models.RepositoryScript{
+		"repo-1": {
+			{ID: "s1", RepositoryID: "repo-1", Name: "build", Command: "make build"},
+			{ID: "s2", RepositoryID: "repo-1", Name: "blank", Command: "   "},
+		},
+	})
+	repo := &models.Repository{ID: "repo-1"}
+
+	_, _, _, err := resolveScriptCommand(context.Background(), svc, repo, "custom", "missing")
+	require.EqualError(t, err, "custom script not found")
+
+	_, _, _, err = resolveScriptCommand(context.Background(), svc, repo, "custom", "blank")
+	require.EqualError(t, err, "script command is empty")
+}

--- a/apps/backend/internal/task/handlers/repository_script_handlers_test.go
+++ b/apps/backend/internal/task/handlers/repository_script_handlers_test.go
@@ -1,0 +1,488 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kandev/kandev/internal/auth/authn"
+	"github.com/kandev/kandev/internal/task/dto"
+	"github.com/kandev/kandev/internal/task/models"
+	"github.com/kandev/kandev/internal/task/service"
+	ws "github.com/kandev/kandev/pkg/websocket"
+)
+
+// scriptRepo holds one editable repository owned by "user-b" and one living in
+// the read-only Improve Kandev workspace.
+type scriptRepo struct {
+	mockRepository
+
+	listErr   error
+	createErr error
+	updateErr error
+	deleteErr error
+
+	created []*models.RepositoryScript
+	updated []*models.RepositoryScript
+	deleted []string
+}
+
+func (r *scriptRepo) GetWorkspace(_ context.Context, id string) (*models.Workspace, error) {
+	switch id {
+	case "ws-1":
+		return &models.Workspace{ID: "ws-1", Name: "Team", OwnerID: "user-b"}, nil
+	case "ws-improve":
+		return &models.Workspace{ID: "ws-improve", Name: models.WorkspaceNameImproveKandev}, nil
+	default:
+		return nil, fmt.Errorf("workspace not found: %s", id)
+	}
+}
+
+func (r *scriptRepo) GetRepository(_ context.Context, id string) (*models.Repository, error) {
+	switch id {
+	case "repo-1":
+		return &models.Repository{ID: "repo-1", WorkspaceID: "ws-1", Name: "kandev"}, nil
+	case "repo-improve":
+		return &models.Repository{ID: "repo-improve", WorkspaceID: "ws-improve", Name: "kandev"}, nil
+	default:
+		return nil, fmt.Errorf("repository not found: %s", id)
+	}
+}
+
+func (r *scriptRepo) GetRepositoryScript(_ context.Context, id string) (*models.RepositoryScript, error) {
+	switch id {
+	case "s-1":
+		return &models.RepositoryScript{ID: "s-1", RepositoryID: "repo-1", Name: "build", Command: "make", Position: 1}, nil
+	case "s-improve":
+		return &models.RepositoryScript{ID: "s-improve", RepositoryID: "repo-improve", Name: "build", Command: "make"}, nil
+	default:
+		return nil, fmt.Errorf("repository script not found: %s", id)
+	}
+}
+
+func (r *scriptRepo) ListRepositoryScripts(_ context.Context, repositoryID string) ([]*models.RepositoryScript, error) {
+	if r.listErr != nil {
+		return nil, r.listErr
+	}
+	if repositoryID != "repo-1" {
+		return nil, nil
+	}
+	return []*models.RepositoryScript{
+		{ID: "s-1", RepositoryID: "repo-1", Name: "build", Command: "make", Position: 1},
+	}, nil
+}
+
+func (r *scriptRepo) CreateRepositoryScript(_ context.Context, script *models.RepositoryScript) error {
+	if r.createErr != nil {
+		return r.createErr
+	}
+	r.created = append(r.created, script)
+	return nil
+}
+
+func (r *scriptRepo) UpdateRepositoryScript(_ context.Context, script *models.RepositoryScript) error {
+	if r.updateErr != nil {
+		return r.updateErr
+	}
+	r.updated = append(r.updated, script)
+	return nil
+}
+
+func (r *scriptRepo) DeleteRepositoryScript(_ context.Context, id string) error {
+	if r.deleteErr != nil {
+		return r.deleteErr
+	}
+	r.deleted = append(r.deleted, id)
+	return nil
+}
+
+func newScriptHandlers(t *testing.T, repo *scriptRepo) *RepositoryHandlers {
+	t.Helper()
+	log := newTestLogger(t)
+	svc := service.NewService(service.Repos{
+		Workspaces: repo, Tasks: repo, TaskRepos: repo,
+		Workflows: repo, Messages: repo, Turns: repo,
+		Sessions: repo, GitSnapshots: repo, RepoEntities: repo,
+		Executors: repo, Environments: repo, TaskEnvironments: repo,
+		Reviews: repo,
+	}, nil, log, service.RepositoryDiscoveryConfig{})
+	return NewRepositoryHandlers(svc, log)
+}
+
+// newScriptRouter drives the script routes through the real router so status
+// codes written with c.Status (the 204 on delete) are actually flushed.
+func newScriptRouter(t *testing.T, repo *scriptRepo) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	newScriptHandlers(t, repo).registerHTTP(router)
+	return router
+}
+
+func scriptRequest(t *testing.T, router *gin.Engine, method, target, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(method, target, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestHTTPListRepositoryScriptsReturnsScripts(t *testing.T) {
+	repo := &scriptRepo{}
+	router := newScriptRouter(t, repo)
+
+	rec := scriptRequest(t, router, http.MethodGet, "/api/v1/repositories/repo-1/scripts", "")
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp dto.ListRepositoryScriptsResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Equal(t, 1, resp.Total)
+	require.Equal(t, "s-1", resp.Scripts[0].ID)
+	require.Equal(t, "make", resp.Scripts[0].Command)
+}
+
+func TestHTTPListRepositoryScriptsSurfacesRepositoryFailure(t *testing.T) {
+	repo := &scriptRepo{listErr: errors.New("database unavailable")}
+	router := newScriptRouter(t, repo)
+
+	rec := scriptRequest(t, router, http.MethodGet, "/api/v1/repositories/repo-1/scripts", "")
+
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	require.JSONEq(t, `{"error":"failed to list repository scripts"}`, rec.Body.String())
+}
+
+func TestHTTPCreateRepositoryScriptRejectsInvalidRequests(t *testing.T) {
+	repo := &scriptRepo{}
+	router := newScriptRouter(t, repo)
+
+	for name, tc := range map[string]struct {
+		body     string
+		wantBody string
+	}{
+		"malformed json":  {body: `{`, wantBody: `{"error":"invalid request body"}`},
+		"missing name":    {body: `{"command":"make"}`, wantBody: `{"error":"name and command are required"}`},
+		"missing command": {body: `{"name":"build"}`, wantBody: `{"error":"name and command are required"}`},
+	} {
+		t.Run(name, func(t *testing.T) {
+			rec := scriptRequest(t, router, http.MethodPost, "/api/v1/repositories/repo-1/scripts", tc.body)
+			require.Equal(t, http.StatusBadRequest, rec.Code)
+			require.JSONEq(t, tc.wantBody, rec.Body.String())
+		})
+	}
+	require.Empty(t, repo.created)
+}
+
+func TestHTTPCreateRepositoryScriptTakesRepositoryIDFromThePath(t *testing.T) {
+	repo := &scriptRepo{}
+	router := newScriptRouter(t, repo)
+
+	rec := scriptRequest(t, router, http.MethodPost, "/api/v1/repositories/repo-1/scripts",
+		`{"name":"test","command":"go test ./...","position":3}`)
+
+	require.Equal(t, http.StatusCreated, rec.Code)
+	require.Len(t, repo.created, 1)
+	require.Equal(t, "repo-1", repo.created[0].RepositoryID)
+	require.Equal(t, "test", repo.created[0].Name)
+	require.Equal(t, "go test ./...", repo.created[0].Command)
+	require.Equal(t, 3, repo.created[0].Position)
+
+	var created dto.RepositoryScriptDTO
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &created))
+	require.Equal(t, repo.created[0].ID, created.ID)
+}
+
+func TestHTTPCreateRepositoryScriptSurfacesRepositoryFailure(t *testing.T) {
+	repo := &scriptRepo{createErr: errors.New("disk full")}
+	router := newScriptRouter(t, repo)
+
+	rec := scriptRequest(t, router, http.MethodPost, "/api/v1/repositories/repo-1/scripts",
+		`{"name":"test","command":"go test"}`)
+
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	require.JSONEq(t, `{"error":"failed to create repository script"}`, rec.Body.String())
+}
+
+func TestHTTPGetRepositoryScriptReturnsScriptOrNotFound(t *testing.T) {
+	router := newScriptRouter(t, &scriptRepo{})
+
+	rec := scriptRequest(t, router, http.MethodGet, "/api/v1/scripts/s-1", "")
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got dto.RepositoryScriptDTO
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Equal(t, "s-1", got.ID)
+	require.Equal(t, "build", got.Name)
+
+	missing := scriptRequest(t, router, http.MethodGet, "/api/v1/scripts/nope", "")
+	require.Equal(t, http.StatusNotFound, missing.Code)
+	require.JSONEq(t, `{"error":"repository script not found"}`, missing.Body.String())
+}
+
+func TestHTTPUpdateRepositoryScriptAppliesProvidedFieldsOnly(t *testing.T) {
+	repo := &scriptRepo{}
+	router := newScriptRouter(t, repo)
+
+	rec := scriptRequest(t, router, http.MethodPut, "/api/v1/scripts/s-1", `{"command":"make all"}`)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Len(t, repo.updated, 1)
+	require.Equal(t, "make all", repo.updated[0].Command)
+	require.Equal(t, "build", repo.updated[0].Name, "an omitted name must be preserved")
+	require.Equal(t, 1, repo.updated[0].Position)
+}
+
+func TestHTTPUpdateRepositoryScriptRejectsInvalidBody(t *testing.T) {
+	repo := &scriptRepo{}
+	router := newScriptRouter(t, repo)
+
+	rec := scriptRequest(t, router, http.MethodPut, "/api/v1/scripts/s-1", `{`)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.JSONEq(t, `{"error":"invalid request body"}`, rec.Body.String())
+	require.Empty(t, repo.updated)
+}
+
+func TestHTTPDeleteRepositoryScriptReturnsNoContent(t *testing.T) {
+	repo := &scriptRepo{}
+	router := newScriptRouter(t, repo)
+
+	rec := scriptRequest(t, router, http.MethodDelete, "/api/v1/scripts/s-1", "")
+
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	require.Empty(t, rec.Body.String())
+	require.Equal(t, []string{"s-1"}, repo.deleted)
+}
+
+func TestHTTPDeleteRepositoryScriptReturnsNotFoundForUnknownScript(t *testing.T) {
+	repo := &scriptRepo{}
+	router := newScriptRouter(t, repo)
+
+	rec := scriptRequest(t, router, http.MethodDelete, "/api/v1/scripts/nope", "")
+
+	require.Equal(t, http.StatusNotFound, rec.Code)
+	require.JSONEq(t, `{"error":"repository script not found"}`, rec.Body.String())
+	require.Empty(t, repo.deleted)
+}
+
+// TestRepositoryScriptRoutesDenyForeignWorkspace covers per-user scoping on the
+// script surface: scripts hold shell commands and are executed inside the
+// session workspace, so reading or editing another user's is a real breach.
+// Each case runs as the owner too, so the denial is proven to come from
+// scoping rather than a broken fixture.
+func TestRepositoryScriptRoutesDenyForeignWorkspace(t *testing.T) {
+	repo := &scriptRepo{}
+	router := newScriptRouter(t, repo)
+
+	for name, tc := range map[string]struct {
+		method    string
+		target    string
+		body      string
+		ownerCode int
+	}{
+		"list":   {method: http.MethodGet, target: "/api/v1/repositories/repo-1/scripts", ownerCode: http.StatusOK},
+		"get":    {method: http.MethodGet, target: "/api/v1/scripts/s-1", ownerCode: http.StatusOK},
+		"update": {method: http.MethodPut, target: "/api/v1/scripts/s-1", body: `{"command":"rm -rf /"}`, ownerCode: http.StatusOK},
+		"delete": {method: http.MethodDelete, target: "/api/v1/scripts/s-1", ownerCode: http.StatusNoContent},
+	} {
+		t.Run(name, func(t *testing.T) {
+			foreign := scriptRequestAs(t, router, "user-a", tc.method, tc.target, tc.body)
+			require.NotEqual(t, tc.ownerCode, foreign.Code,
+				"a foreign caller must not get the owner's outcome (body: %s)", foreign.Body.String())
+			require.NotContains(t, foreign.Body.String(), "make", "the script command must not leak")
+
+			owner := scriptRequestAs(t, router, "user-b", tc.method, tc.target, tc.body)
+			require.Equal(t, tc.ownerCode, owner.Code,
+				"the owner must succeed — otherwise the check above proves nothing (body: %s)", owner.Body.String())
+		})
+	}
+}
+
+func scriptRequestAs(t *testing.T, router *gin.Engine, userID, method, target, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(method, target, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(authn.WithIdentity(req.Context(),
+		authn.Identity{UserID: userID, Role: authn.RoleMember}))
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestWSListRepositoryScriptsReturnsScripts(t *testing.T) {
+	h := newScriptHandlers(t, &scriptRepo{})
+
+	resp, err := h.wsListRepositoryScripts(context.Background(),
+		wsWorkflowRequest(t, ws.ActionRepositoryScriptList, map[string]any{"repository_id": "repo-1"}))
+
+	require.NoError(t, err)
+	var list dto.ListRepositoryScriptsResponse
+	wsWorkflowResponse(t, resp, &list)
+	require.Equal(t, 1, list.Total)
+	require.Equal(t, "s-1", list.Scripts[0].ID)
+}
+
+func TestWSListRepositoryScriptsRejectsMalformedPayload(t *testing.T) {
+	h := newScriptHandlers(t, &scriptRepo{})
+
+	resp, err := h.wsListRepositoryScripts(context.Background(),
+		wsMalformedRequest(ws.ActionRepositoryScriptList))
+
+	require.NoError(t, err)
+	require.Equal(t, string(ws.ErrorCodeBadRequest), wsWorkflowError(t, resp).Code)
+}
+
+func TestWSListRepositoryScriptsSurfacesRepositoryFailure(t *testing.T) {
+	h := newScriptHandlers(t, &scriptRepo{listErr: errors.New("database unavailable")})
+
+	resp, err := h.wsListRepositoryScripts(context.Background(),
+		wsWorkflowRequest(t, ws.ActionRepositoryScriptList, map[string]any{"repository_id": "repo-1"}))
+
+	require.NoError(t, err)
+	require.Equal(t, "Failed to list repository scripts", wsWorkflowError(t, resp).Message)
+}
+
+func TestWSCreateRepositoryScriptValidatesAndCreates(t *testing.T) {
+	repo := &scriptRepo{}
+	h := newScriptHandlers(t, repo)
+
+	invalid, err := h.wsCreateRepositoryScript(context.Background(),
+		wsWorkflowRequest(t, ws.ActionRepositoryScriptCreate, map[string]any{"repository_id": "repo-1"}))
+	require.NoError(t, err)
+	require.Equal(t, "repository_id, name, and command are required", wsWorkflowError(t, invalid).Message)
+	require.Empty(t, repo.created)
+
+	resp, err := h.wsCreateRepositoryScript(context.Background(),
+		wsWorkflowRequest(t, ws.ActionRepositoryScriptCreate, map[string]any{
+			"repository_id": "repo-1", "name": "lint", "command": "make lint", "position": 2,
+		}))
+	require.NoError(t, err)
+	var created dto.RepositoryScriptDTO
+	wsWorkflowResponse(t, resp, &created)
+	require.Equal(t, "lint", created.Name)
+	require.Len(t, repo.created, 1)
+	require.Equal(t, 2, repo.created[0].Position)
+}
+
+func TestWSCreateRepositoryScriptReturnsNotFoundForUnknownRepository(t *testing.T) {
+	repo := &scriptRepo{}
+	h := newScriptHandlers(t, repo)
+
+	resp, err := h.wsCreateRepositoryScript(context.Background(),
+		wsWorkflowRequest(t, ws.ActionRepositoryScriptCreate, map[string]any{
+			"repository_id": "nope", "name": "lint", "command": "make lint",
+		}))
+
+	require.NoError(t, err)
+	payload := wsWorkflowError(t, resp)
+	require.Equal(t, string(ws.ErrorCodeNotFound), payload.Code)
+	require.Equal(t, "Repository not found", payload.Message)
+	require.Empty(t, repo.created)
+}
+
+// TestWSRepositoryScriptMutationsRejectImproveKandevWorkspace pins the
+// read-only guard across create, update and delete, with the no-write
+// assertion that makes each one meaningful.
+func TestWSRepositoryScriptMutationsRejectImproveKandevWorkspace(t *testing.T) {
+	repo := &scriptRepo{}
+	h := newScriptHandlers(t, repo)
+
+	create, err := h.wsCreateRepositoryScript(context.Background(),
+		wsWorkflowRequest(t, ws.ActionRepositoryScriptCreate, map[string]any{
+			"repository_id": "repo-improve", "name": "lint", "command": "make lint",
+		}))
+	require.NoError(t, err)
+	require.Equal(t, string(ws.ErrorCodeConflict), wsWorkflowError(t, create).Code)
+	require.Equal(t, workspaceReadOnlyMsg, wsWorkflowError(t, create).Message)
+	require.Empty(t, repo.created)
+
+	update, err := h.wsUpdateRepositoryScript(context.Background(),
+		wsWorkflowRequest(t, ws.ActionRepositoryScriptUpdate, map[string]any{
+			"id": "s-improve", "command": "make other",
+		}))
+	require.NoError(t, err)
+	require.Equal(t, string(ws.ErrorCodeConflict), wsWorkflowError(t, update).Code)
+	require.Empty(t, repo.updated)
+
+	del, err := h.wsDeleteRepositoryScript(context.Background(),
+		wsWorkflowRequest(t, ws.ActionRepositoryScriptDelete, map[string]any{"id": "s-improve"}))
+	require.NoError(t, err)
+	require.Equal(t, string(ws.ErrorCodeConflict), wsWorkflowError(t, del).Code)
+	require.Empty(t, repo.deleted)
+}
+
+func TestWSGetRepositoryScriptReturnsScriptOrErrors(t *testing.T) {
+	h := newScriptHandlers(t, &scriptRepo{})
+
+	resp, err := h.wsGetRepositoryScript(context.Background(),
+		wsWorkflowRequest(t, ws.ActionRepositoryScriptGet, map[string]any{"id": "s-1"}))
+	require.NoError(t, err)
+	var got dto.RepositoryScriptDTO
+	wsWorkflowResponse(t, resp, &got)
+	require.Equal(t, "s-1", got.ID)
+
+	missing, err := h.wsGetRepositoryScript(context.Background(),
+		wsWorkflowRequest(t, ws.ActionRepositoryScriptGet, map[string]any{"id": "nope"}))
+	require.NoError(t, err)
+	require.Equal(t, string(ws.ErrorCodeNotFound), wsWorkflowError(t, missing).Code)
+
+	empty, err := h.wsGetRepositoryScript(context.Background(),
+		wsWorkflowRequest(t, ws.ActionRepositoryScriptGet, map[string]any{}))
+	require.NoError(t, err)
+	require.Equal(t, "id is required", wsWorkflowError(t, empty).Message)
+}
+
+func TestWSUpdateRepositoryScriptAppliesFields(t *testing.T) {
+	repo := &scriptRepo{}
+	h := newScriptHandlers(t, repo)
+
+	resp, err := h.wsUpdateRepositoryScript(context.Background(),
+		wsWorkflowRequest(t, ws.ActionRepositoryScriptUpdate, map[string]any{
+			"id": "s-1", "name": "build-all",
+		}))
+
+	require.NoError(t, err)
+	var updated dto.RepositoryScriptDTO
+	wsWorkflowResponse(t, resp, &updated)
+	require.Equal(t, "build-all", updated.Name)
+	require.Len(t, repo.updated, 1)
+	require.Equal(t, "make", repo.updated[0].Command, "an omitted command must be preserved")
+}
+
+func TestWSUpdateRepositoryScriptRequiresID(t *testing.T) {
+	repo := &scriptRepo{}
+	h := newScriptHandlers(t, repo)
+
+	resp, err := h.wsUpdateRepositoryScript(context.Background(),
+		wsWorkflowRequest(t, ws.ActionRepositoryScriptUpdate, map[string]any{"name": "x"}))
+
+	require.NoError(t, err)
+	require.Equal(t, "id is required", wsWorkflowError(t, resp).Message)
+	require.Empty(t, repo.updated)
+}
+
+func TestWSDeleteRepositoryScriptDeletesAndValidates(t *testing.T) {
+	repo := &scriptRepo{}
+	h := newScriptHandlers(t, repo)
+
+	empty, err := h.wsDeleteRepositoryScript(context.Background(),
+		wsWorkflowRequest(t, ws.ActionRepositoryScriptDelete, map[string]any{}))
+	require.NoError(t, err)
+	require.Equal(t, "id is required", wsWorkflowError(t, empty).Message)
+	require.Empty(t, repo.deleted)
+
+	resp, err := h.wsDeleteRepositoryScript(context.Background(),
+		wsWorkflowRequest(t, ws.ActionRepositoryScriptDelete, map[string]any{"id": "s-1"}))
+	require.NoError(t, err)
+	var body map[string]any
+	wsWorkflowResponse(t, resp, &body)
+	require.Equal(t, true, body["deleted"])
+	require.Equal(t, []string{"s-1"}, repo.deleted)
+}

--- a/apps/backend/internal/task/handlers/route_registration_test.go
+++ b/apps/backend/internal/task/handlers/route_registration_test.go
@@ -1,0 +1,222 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	ws "github.com/kandev/kandev/pkg/websocket"
+)
+
+// registeredRoutes returns the router's method+path set.
+func registeredRoutes(router *gin.Engine) map[string]bool {
+	routes := make(map[string]bool)
+	for _, route := range router.Routes() {
+		routes[route.Method+" "+route.Path] = true
+	}
+	return routes
+}
+
+func requireRoutes(t *testing.T, router *gin.Engine, want ...string) {
+	t.Helper()
+	routes := registeredRoutes(router)
+	for _, route := range want {
+		require.Truef(t, routes[route], "route %q is not registered", route)
+	}
+}
+
+func requireActions(t *testing.T, dispatcher *ws.Dispatcher, want ...string) {
+	t.Helper()
+	for _, action := range want {
+		require.Truef(t, dispatcher.HasHandler(action), "WS action %q has no handler", action)
+	}
+}
+
+// TestRegisterWorkflowRoutesWiresHTTPAndWS pins the full public surface of the
+// workflow handlers. A route silently dropped during a refactor is invisible to
+// every other test in this file, which calls the methods directly.
+func TestRegisterWorkflowRoutesWiresHTTPAndWS(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	dispatcher := ws.NewDispatcher()
+	repo := workflowFixture()
+	svc, log := newWorkflowService(t, repo)
+
+	handlers := RegisterWorkflowRoutes(router, dispatcher, svc, &stubStepLister{}, log)
+
+	require.NotNil(t, handlers)
+	requireRoutes(t, router,
+		"GET /api/v1/workflows",
+		"GET /api/v1/workspaces/:id/workflows",
+		"GET /api/v1/workspaces/:id/snapshot",
+		"GET /api/v1/workflows/:id",
+		"GET /api/v1/workflows/:id/snapshot",
+		"POST /api/v1/workflows",
+		"PATCH /api/v1/workflows/:id",
+		"DELETE /api/v1/workflows/:id",
+		"PUT /api/v1/workspaces/:id/workflows/reorder",
+	)
+	requireActions(t, dispatcher,
+		ws.ActionWorkflowList, ws.ActionWorkflowCreate, ws.ActionWorkflowGet,
+		ws.ActionWorkflowUpdate, ws.ActionWorkflowDelete, ws.ActionWorkflowReorder,
+	)
+}
+
+func TestRegisterExecutorRoutesWiresHTTPAndWS(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	dispatcher := ws.NewDispatcher()
+	repo := executorFixture()
+
+	RegisterExecutorRoutes(router, dispatcher, newExecutorService(t, repo), newTestLogger(t))
+
+	requireRoutes(t, router,
+		"GET /api/v1/executors",
+		"POST /api/v1/executors",
+		"GET /api/v1/executors/:id",
+		"PATCH /api/v1/executors/:id",
+		"DELETE /api/v1/executors/:id",
+	)
+	requireActions(t, dispatcher,
+		ws.ActionExecutorList, ws.ActionExecutorCreate, ws.ActionExecutorGet,
+		ws.ActionExecutorUpdate, ws.ActionExecutorDelete,
+	)
+}
+
+// TestRegisterExecutorProfileRoutesWiresBothDeleteRoutes covers the two DELETE
+// registrations in particular: profile IDs are globally unique, so callers
+// holding only the profile ID use the top-level route.
+func TestRegisterExecutorProfileRoutesWiresBothDeleteRoutes(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	dispatcher := ws.NewDispatcher()
+	repo := executorFixture()
+
+	RegisterExecutorProfileRoutes(router, dispatcher, newExecutorService(t, repo), nil, newTestLogger(t))
+
+	requireRoutes(t, router,
+		"GET /api/v1/executor-profiles",
+		"GET /api/v1/executor-profiles/default-script",
+		"GET /api/v1/remote-credentials",
+		"GET /api/v1/git/identity",
+		"GET /api/v1/script-placeholders",
+		"GET /api/v1/executors/:id/profiles",
+		"POST /api/v1/executors/:id/profiles",
+		"GET /api/v1/executors/:id/profiles/:profileId",
+		"PATCH /api/v1/executors/:id/profiles/:profileId",
+		"DELETE /api/v1/executors/:id/profiles/:profileId",
+		"DELETE /api/v1/executor-profiles/:profileId",
+	)
+	requireActions(t, dispatcher,
+		ws.ActionExecutorProfileList, ws.ActionExecutorProfileListAll,
+		ws.ActionExecutorProfileCreate, ws.ActionExecutorProfileGet,
+		ws.ActionExecutorProfileUpdate, ws.ActionExecutorProfileDelete,
+	)
+}
+
+func TestRegisterWorkspaceRoutesWiresHTTPAndWS(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	dispatcher := ws.NewDispatcher()
+	repo := workflowFixture()
+	svc, log := newWorkflowService(t, repo)
+
+	RegisterWorkspaceRoutes(router, dispatcher, svc, log)
+
+	requireRoutes(t, router,
+		"GET /api/v1/workspaces",
+		"POST /api/v1/workspaces",
+		"GET /api/v1/workspaces/:id",
+		"PATCH /api/v1/workspaces/:id",
+		"DELETE /api/v1/workspaces/:id",
+	)
+	requireActions(t, dispatcher,
+		ws.ActionWorkspaceList, ws.ActionWorkspaceCreate, ws.ActionWorkspaceGet,
+		ws.ActionWorkspaceUpdate, ws.ActionWorkspaceDelete,
+	)
+}
+
+func TestRegisterEnvironmentRoutesWiresHTTPAndWS(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	dispatcher := ws.NewDispatcher()
+	repo := workflowFixture()
+	svc, log := newWorkflowService(t, repo)
+
+	RegisterEnvironmentRoutes(router, dispatcher, svc, log)
+
+	requireRoutes(t, router,
+		"GET /api/v1/environments",
+		"POST /api/v1/environments",
+		"GET /api/v1/environments/:id",
+		"PATCH /api/v1/environments/:id",
+		"DELETE /api/v1/environments/:id",
+	)
+	requireActions(t, dispatcher,
+		ws.ActionEnvironmentList, ws.ActionEnvironmentCreate, ws.ActionEnvironmentGet,
+		ws.ActionEnvironmentUpdate, ws.ActionEnvironmentDelete,
+	)
+}
+
+func TestRegisterRepositoryRoutesWiresHTTPAndWS(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	dispatcher := ws.NewDispatcher()
+	repo := workflowFixture()
+	svc, log := newWorkflowService(t, repo)
+
+	RegisterRepositoryRoutes(router, dispatcher, svc, log)
+
+	requireRoutes(t, router,
+		"GET /api/v1/workspaces/:id/repositories",
+		"POST /api/v1/workspaces/:id/repositories",
+		"POST /api/v1/workspaces/:id/repositories/initialize-local",
+		"GET /api/v1/workspaces/:id/repositories/discover",
+		"GET /api/v1/workspaces/:id/branches",
+		"GET /api/v1/workspaces/:id/repositories/local-status",
+		"GET /api/v1/workspaces/:id/repositories/validate",
+		"GET /api/v1/fs/list-dir",
+		"POST /api/v1/fs/create-dir",
+		"GET /api/v1/repositories/:id",
+		"GET /api/v1/repositories/:id/branches",
+		"GET /api/v1/repositories/:id/active-session-count",
+		"PATCH /api/v1/repositories/:id",
+		"DELETE /api/v1/repositories/:id",
+		"GET /api/v1/repositories/:id/scripts",
+		"POST /api/v1/repositories/:id/scripts",
+		"GET /api/v1/scripts/:id",
+		"PUT /api/v1/scripts/:id",
+		"DELETE /api/v1/scripts/:id",
+	)
+	requireActions(t, dispatcher,
+		ws.ActionRepositoryList, ws.ActionRepositoryCreate, ws.ActionRepositoryGet,
+		ws.ActionRepositoryUpdate, ws.ActionRepositoryDelete,
+		ws.ActionRepositoryScriptList, ws.ActionRepositoryScriptCreate,
+		ws.ActionRepositoryScriptGet, ws.ActionRepositoryScriptUpdate,
+		ws.ActionRepositoryScriptDelete,
+	)
+}
+
+// TestRegisterProcessRoutesWiresSessionScopedRoutes pins the process group,
+// including the session-level ACP actions that share the :id parameter.
+func TestRegisterProcessRoutesWiresSessionScopedRoutes(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	log := newTestLogger(t)
+	repo := workflowFixture()
+	svc, _ := newWorkflowService(t, repo)
+
+	RegisterProcessRoutes(router, svc, newLifecycleManager(t, log), log)
+
+	requireRoutes(t, router,
+		"POST /api/v1/task-sessions/:id/processes/start",
+		"POST /api/v1/task-sessions/:id/processes/:processId/stop",
+		"GET /api/v1/task-sessions/:id/processes",
+		"GET /api/v1/task-sessions/:id/processes/:processId",
+		"POST /api/v1/task-sessions/:id/set-mode",
+		"POST /api/v1/task-sessions/:id/set-model",
+		"POST /api/v1/task-sessions/:id/set-config-option",
+		"POST /api/v1/task-sessions/:id/authenticate",
+	)
+}

--- a/apps/backend/internal/task/handlers/task_http_lifecycle_test.go
+++ b/apps/backend/internal/task/handlers/task_http_lifecycle_test.go
@@ -1,0 +1,356 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kandev/kandev/internal/auth/authn"
+	"github.com/kandev/kandev/internal/task/dto"
+	"github.com/kandev/kandev/internal/task/models"
+	"github.com/kandev/kandev/internal/task/service"
+)
+
+// httpTaskRepo extends the WS fixture with the paging and counting surfaces
+// the HTTP list/count routes need, recording the arguments they receive.
+type httpTaskRepo struct {
+	wsTaskRepo
+
+	listedWorkspaceID string
+	listedPage        int
+	listedPageSize    int
+	listedSort        string
+	listedArchived    bool
+	listTotal         int
+
+	workflowCount     int
+	workflowCountErr  error
+	stepCount         int
+	stepCountErr      error
+	countedWorkflowID string
+	countedStepID     string
+}
+
+func (r *httpTaskRepo) ListTasksByWorkspace(
+	_ context.Context,
+	workspaceID, _, _, _ string,
+	page, pageSize int,
+	sort string,
+	includeArchived, _, _, _ bool,
+) ([]*models.Task, int, error) {
+	r.listedWorkspaceID = workspaceID
+	r.listedPage = page
+	r.listedPageSize = pageSize
+	r.listedSort = sort
+	r.listedArchived = includeArchived
+	return []*models.Task{{ID: "task-b", WorkspaceID: "ws-b", Title: "Mine"}}, r.listTotal, nil
+}
+
+func (r *httpTaskRepo) CountTasksByWorkflow(_ context.Context, workflowID string) (int, error) {
+	r.countedWorkflowID = workflowID
+	return r.workflowCount, r.workflowCountErr
+}
+
+func (r *httpTaskRepo) CountTasksByWorkflowStep(_ context.Context, stepID string) (int, error) {
+	r.countedStepID = stepID
+	return r.stepCount, r.stepCountErr
+}
+
+func newHTTPTaskHandlers(t *testing.T, repo *httpTaskRepo) *TaskHandlers {
+	t.Helper()
+	log := newTestLogger(t)
+	svc := service.NewService(service.Repos{
+		Workspaces: repo, Tasks: repo, TaskRepos: repo,
+		Workflows: repo, Messages: repo, Turns: repo,
+		Sessions: repo, GitSnapshots: repo, RepoEntities: repo,
+		Executors: repo, Environments: repo, TaskEnvironments: repo,
+		Reviews: repo,
+	}, nil, log, service.RepositoryDiscoveryConfig{})
+	return &TaskHandlers{service: svc, logger: log}
+}
+
+// taskRequestAs builds a request for a task route carrying userID's identity.
+// An empty userID leaves the context identity-free (an internal caller).
+func taskRequestAs(t *testing.T, userID, method, target, id string) (*gin.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	c, rec := newWorkflowRequest(t, method, target, "")
+	if userID != "" {
+		c.Request = c.Request.WithContext(authn.WithIdentity(
+			c.Request.Context(), authn.Identity{UserID: userID, Role: authn.RoleMember}))
+	}
+	c.Params = gin.Params{{Key: "id", Value: id}}
+	return c, rec
+}
+
+func TestHTTPGetTaskDeniesForeignTask(t *testing.T) {
+	h := newHTTPTaskHandlers(t, &httpTaskRepo{})
+
+	c, rec := taskRequestAs(t, "user-a", http.MethodGet, "/api/v1/tasks/task-b", "task-b")
+	h.httpGetTask(c)
+	require.Equal(t, http.StatusNotFound, rec.Code)
+	require.JSONEq(t, `{"error":"task not found"}`, rec.Body.String())
+	require.NotContains(t, rec.Body.String(), "Victim")
+
+	ownerCtx, ownerRec := taskRequestAs(t, "user-b", http.MethodGet, "/api/v1/tasks/task-b", "task-b")
+	h.httpGetTask(ownerCtx)
+	require.Equal(t, http.StatusOK, ownerRec.Code)
+	require.Contains(t, ownerRec.Body.String(), "Victim", "the owner must still get their task")
+}
+
+func TestHTTPGetTaskReturnsNotFoundForUnknownTask(t *testing.T) {
+	h := newHTTPTaskHandlers(t, &httpTaskRepo{})
+	c, rec := taskRequestAs(t, "", http.MethodGet, "/api/v1/tasks/nope", "nope")
+
+	h.httpGetTask(c)
+
+	require.Equal(t, http.StatusNotFound, rec.Code)
+	require.JSONEq(t, `{"error":"task not found"}`, rec.Body.String())
+}
+
+func TestHTTPListTasksFiltersForeignWorkspaceRows(t *testing.T) {
+	h := newHTTPTaskHandlers(t, &httpTaskRepo{})
+	c, rec := taskRequestAs(t, "", http.MethodGet, "/api/v1/workflows/wf-b/tasks", "wf-b")
+
+	h.httpListTasks(c)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp dto.ListTasksResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Equal(t, 1, resp.Total, "the row from another workspace must be dropped")
+	require.Equal(t, "task-b", resp.Tasks[0].ID)
+}
+
+func TestHTTPListTasksReturnsNotFoundForUnknownWorkflow(t *testing.T) {
+	h := newHTTPTaskHandlers(t, &httpTaskRepo{})
+	c, rec := taskRequestAs(t, "", http.MethodGet, "/api/v1/workflows/nope/tasks", "nope")
+
+	h.httpListTasks(c)
+
+	require.Equal(t, http.StatusNotFound, rec.Code)
+	require.JSONEq(t, `{"error":"tasks not found"}`, rec.Body.String())
+}
+
+// TestHTTPListTasksByWorkspaceClampsPaging pins the query-parameter parsing:
+// page and page_size fall back to their defaults for anything non-positive,
+// out of range, or unparseable, and page_size is capped at 100.
+func TestHTTPListTasksByWorkspaceClampsPaging(t *testing.T) {
+	for name, tc := range map[string]struct {
+		query        string
+		wantPage     int
+		wantPageSize int
+	}{
+		"defaults":           {query: "", wantPage: 1, wantPageSize: 50},
+		"explicit":           {query: "?page=3&page_size=25", wantPage: 3, wantPageSize: 25},
+		"page zero":          {query: "?page=0", wantPage: 1, wantPageSize: 50},
+		"page negative":      {query: "?page=-2", wantPage: 1, wantPageSize: 50},
+		"page garbage":       {query: "?page=abc", wantPage: 1, wantPageSize: 50},
+		"page size over cap": {query: "?page_size=500", wantPage: 1, wantPageSize: 50},
+		"page size at cap":   {query: "?page_size=100", wantPage: 1, wantPageSize: 100},
+		"page size non int":  {query: "?page_size=many", wantPage: 1, wantPageSize: 50},
+		"page size negative": {query: "?page_size=-1", wantPage: 1, wantPageSize: 50},
+	} {
+		t.Run(name, func(t *testing.T) {
+			repo := &httpTaskRepo{listTotal: 7}
+			h := newHTTPTaskHandlers(t, repo)
+			c, rec := taskRequestAs(t, "", http.MethodGet,
+				"/api/v1/workspaces/ws-b/tasks"+tc.query, "ws-b")
+
+			h.httpListTasksByWorkspace(c)
+
+			require.Equal(t, http.StatusOK, rec.Code)
+			require.Equal(t, "ws-b", repo.listedWorkspaceID)
+			require.Equal(t, tc.wantPage, repo.listedPage)
+			require.Equal(t, tc.wantPageSize, repo.listedPageSize)
+
+			var resp dto.ListTasksResponse
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+			require.Equal(t, 7, resp.Total, "Total is the repository's grand total, not the page length")
+			require.Len(t, resp.Tasks, 1)
+		})
+	}
+}
+
+func TestHTTPListTasksByWorkspacePassesThroughFilters(t *testing.T) {
+	repo := &httpTaskRepo{}
+	h := newHTTPTaskHandlers(t, repo)
+	c, rec := taskRequestAs(t, "", http.MethodGet,
+		"/api/v1/workspaces/ws-b/tasks?include_archived=true&sort=created_at", "ws-b")
+
+	h.httpListTasksByWorkspace(c)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.True(t, repo.listedArchived)
+	require.NotEmpty(t, repo.listedSort, "sort is normalized rather than dropped")
+}
+
+func TestHTTPListTasksByWorkspaceDeniesForeignWorkspace(t *testing.T) {
+	repo := &httpTaskRepo{}
+	h := newHTTPTaskHandlers(t, repo)
+	c, rec := taskRequestAs(t, "user-a", http.MethodGet, "/api/v1/workspaces/ws-b/tasks", "ws-b")
+
+	h.httpListTasksByWorkspace(c)
+
+	require.Equal(t, http.StatusNotFound, rec.Code)
+	require.Empty(t, repo.listedWorkspaceID, "a denied list must not reach the repository")
+}
+
+func TestHTTPGetWorkflowTaskCount(t *testing.T) {
+	repo := &httpTaskRepo{workflowCount: 4}
+	h := newHTTPTaskHandlers(t, repo)
+	c, rec := taskRequestAs(t, "", http.MethodGet, "/api/v1/workflows/wf-b/task-count", "wf-b")
+
+	h.httpGetWorkflowTaskCount(c)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.JSONEq(t, `{"task_count":4}`, rec.Body.String())
+	require.Equal(t, "wf-b", repo.countedWorkflowID)
+}
+
+func TestHTTPGetWorkflowTaskCountSurfacesFailure(t *testing.T) {
+	h := newHTTPTaskHandlers(t, &httpTaskRepo{workflowCountErr: errors.New("database unavailable")})
+	c, rec := taskRequestAs(t, "", http.MethodGet, "/api/v1/workflows/wf-b/task-count", "wf-b")
+
+	h.httpGetWorkflowTaskCount(c)
+
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	require.JSONEq(t, `{"error":"failed to count tasks"}`, rec.Body.String())
+}
+
+func TestHTTPGetStepTaskCount(t *testing.T) {
+	repo := &httpTaskRepo{stepCount: 2}
+	h := newHTTPTaskHandlers(t, repo)
+	c, rec := taskRequestAs(t, "", http.MethodGet, "/api/v1/workflow-steps/step-1/task-count", "step-1")
+
+	h.httpGetStepTaskCount(c)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.JSONEq(t, `{"task_count":2}`, rec.Body.String())
+	require.Equal(t, "step-1", repo.countedStepID)
+}
+
+func TestHTTPGetStepTaskCountSurfacesFailure(t *testing.T) {
+	h := newHTTPTaskHandlers(t, &httpTaskRepo{stepCountErr: errors.New("database unavailable")})
+	c, rec := taskRequestAs(t, "", http.MethodGet, "/api/v1/workflow-steps/step-1/task-count", "step-1")
+
+	h.httpGetStepTaskCount(c)
+
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	require.JSONEq(t, `{"error":"failed to count tasks"}`, rec.Body.String())
+}
+
+// TestHTTPArchiveTaskDeniesForeignTask is the highest-value denial on this
+// surface: archiving takes work away. The owner witness proves the 404 comes
+// from scoping, and the write counter proves nothing was archived on the way
+// out.
+//
+// The sibling delete route is deliberately not covered here: it derives its
+// context from context.Background() rather than the request, which drops the
+// caller identity before the service's check runs. That is reported separately
+// rather than pinned here as if it were intended.
+func TestHTTPArchiveTaskDeniesForeignTask(t *testing.T) {
+	repo := &httpTaskRepo{}
+	h := newHTTPTaskHandlers(t, repo)
+
+	c, rec := taskRequestAs(t, "user-a", http.MethodDelete, "/api/v1/tasks/task-b", "task-b")
+	h.httpArchiveTask(c)
+	require.Equal(t, http.StatusNotFound, rec.Code)
+	require.JSONEq(t, `{"error":"task not archived"}`, rec.Body.String())
+	require.Empty(t, repo.archived, "a denied request must not archive the task")
+
+	ownerCtx, ownerRec := taskRequestAs(t, "user-b", http.MethodDelete, "/api/v1/tasks/task-b", "task-b")
+	h.httpArchiveTask(ownerCtx)
+	require.Equal(t, http.StatusOK, ownerRec.Code,
+		"the owner must succeed — otherwise the 404 above proves nothing (body: %s)", ownerRec.Body.String())
+	require.Equal(t, []string{"task-b"}, repo.archived)
+}
+
+func TestHTTPDeleteTaskDeletesAndReportsMissingTasks(t *testing.T) {
+	repo := &httpTaskRepo{}
+	h := newHTTPTaskHandlers(t, repo)
+
+	c, rec := taskRequestAs(t, "", http.MethodDelete, "/api/v1/tasks/task-b", "task-b")
+	h.httpDeleteTask(c)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.JSONEq(t, `{"success":true}`, rec.Body.String())
+	require.Equal(t, []string{"task-b"}, repo.deleted)
+
+	missingCtx, missingRec := taskRequestAs(t, "", http.MethodDelete, "/api/v1/tasks/nope", "nope")
+	h.httpDeleteTask(missingCtx)
+	require.Equal(t, http.StatusNotFound, missingRec.Code)
+	require.JSONEq(t, `{"error":"task not deleted"}`, missingRec.Body.String())
+	require.Len(t, repo.deleted, 1, "a missing task must not add a delete")
+}
+
+func TestCascadeQueryParam(t *testing.T) {
+	for query, want := range map[string]bool{
+		"":               false,
+		"?cascade=true":  true,
+		"?cascade=TRUE":  true,
+		"?cascade=True":  true,
+		"?cascade=false": false,
+		"?cascade=1":     false,
+		"?cascade=yes":   false,
+		"?cascade":       false,
+	} {
+		c, _ := newWorkflowRequest(t, http.MethodDelete, "/api/v1/tasks/task-b"+query, "")
+		require.Equalf(t, want, cascadeQueryParam(c), "cascade query %q", query)
+	}
+}
+
+func TestHTTPBulkMoveTasksRejectsInvalidRequests(t *testing.T) {
+	h := newHTTPTaskHandlers(t, &httpTaskRepo{})
+
+	for name, tc := range map[string]struct {
+		body     string
+		wantBody string
+	}{
+		"malformed json": {
+			body:     `{`,
+			wantBody: `{"error":"invalid payload"}`,
+		},
+		"missing target workflow": {
+			body:     `{"source_workflow_id":"wf-b","target_step_id":"step-1"}`,
+			wantBody: `{"error":"target_workflow_id and target_step_id are required"}`,
+		},
+		"missing target step": {
+			body:     `{"source_workflow_id":"wf-b","target_workflow_id":"wf-b"}`,
+			wantBody: `{"error":"target_workflow_id and target_step_id are required"}`,
+		},
+		"missing source without explicit ids": {
+			body:     `{"target_workflow_id":"wf-b","target_step_id":"step-1"}`,
+			wantBody: `{"error":"source_workflow_id, target_workflow_id, and target_step_id are required"}`,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			c, rec := newWorkflowRequest(t, http.MethodPost, "/api/v1/tasks/bulk-move", tc.body)
+
+			h.httpBulkMoveTasks(c)
+
+			require.Equal(t, http.StatusBadRequest, rec.Code)
+			require.JSONEq(t, tc.wantBody, rec.Body.String())
+		})
+	}
+}
+
+// TestHTTPBulkMoveSelectedTasksWithEmptySelectionIsANoOp documents that an
+// explicit but empty task list short-circuits instead of falling through to
+// the whole-column move, which would move tasks nobody selected.
+func TestHTTPBulkMoveSelectedTasksWithEmptySelectionIsANoOp(t *testing.T) {
+	h := newHTTPTaskHandlers(t, &httpTaskRepo{})
+	c, rec := newWorkflowRequest(t, http.MethodPost, "/api/v1/tasks/bulk-move", "")
+
+	h.httpBulkMoveSelectedTasks(c, httpBulkMoveTasksRequest{
+		TaskIDs:          nil,
+		TargetWorkflowID: "wf-b",
+		TargetStepID:     "step-1",
+	})
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.JSONEq(t, `{"moved_count":0}`, rec.Body.String())
+}

--- a/apps/backend/internal/task/handlers/task_http_lifecycle_test.go
+++ b/apps/backend/internal/task/handlers/task_http_lifecycle_test.go
@@ -136,9 +136,11 @@ func TestHTTPListTasksReturnsNotFoundForUnknownWorkflow(t *testing.T) {
 	require.JSONEq(t, `{"error":"tasks not found"}`, rec.Body.String())
 }
 
-// TestHTTPListTasksByWorkspaceClampsPaging pins the query-parameter parsing:
-// page and page_size fall back to their defaults for anything non-positive,
-// out of range, or unparseable, and page_size is capped at 100.
+// TestHTTPListTasksByWorkspaceClampsPaging pins the query-parameter parsing.
+// page must be a positive integer and page_size must land in [1, 100];
+// anything else — non-positive, out of range, or unparseable — falls back to
+// the default rather than to the nearest bound, so page_size=500 yields 50,
+// not 100.
 func TestHTTPListTasksByWorkspaceClampsPaging(t *testing.T) {
 	for name, tc := range map[string]struct {
 		query        string

--- a/apps/backend/internal/task/handlers/task_ws_handlers_test.go
+++ b/apps/backend/internal/task/handlers/task_ws_handlers_test.go
@@ -151,6 +151,12 @@ func TestWSTaskReadsDenyForeignTask(t *testing.T) {
 // task.state and task.move are deliberately absent — their service methods
 // take no authorization step at all, and the two are reported separately
 // rather than pinned here as if the current behavior were intended.
+//
+// Note the error code: these mutations answer InternalError where the read
+// surface above answers NotFound for the very same denial, so a client cannot
+// tell "refused" from "server broke". The refusal is what matters and is what
+// this test guards; the code mismatch is asserted as-is and reported
+// separately rather than endorsed here.
 func TestWSTaskMutationsDenyForeignTask(t *testing.T) {
 	for name, tc := range map[string]struct {
 		call    func(*TaskHandlers, context.Context) (*ws.Message, error)

--- a/apps/backend/internal/task/handlers/task_ws_handlers_test.go
+++ b/apps/backend/internal/task/handlers/task_ws_handlers_test.go
@@ -1,0 +1,419 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kandev/kandev/internal/auth/authn"
+	"github.com/kandev/kandev/internal/task/dto"
+	"github.com/kandev/kandev/internal/task/models"
+	"github.com/kandev/kandev/internal/task/service"
+	v1 "github.com/kandev/kandev/pkg/api/v1"
+	ws "github.com/kandev/kandev/pkg/websocket"
+)
+
+// wsTaskRepo owns everything as "user-b" and records every write, so a request
+// made as "user-a" both fails and leaves no trace.
+type wsTaskRepo struct {
+	mockRepository
+
+	updated       []*models.Task
+	deleted       []string
+	archived      []string
+	stateUpdates  []string
+	sessionsCalls []string
+	created       []*models.Task
+}
+
+func (r *wsTaskRepo) GetTask(_ context.Context, id string) (*models.Task, error) {
+	if id != "task-b" {
+		return nil, fmt.Errorf("task not found: %s", id)
+	}
+	return &models.Task{ID: "task-b", WorkspaceID: "ws-b", Title: "Victim", State: v1.TaskStateTODO}, nil
+}
+
+func (r *wsTaskRepo) GetWorkspace(_ context.Context, id string) (*models.Workspace, error) {
+	if id != "ws-b" {
+		return nil, fmt.Errorf("workspace not found: %s", id)
+	}
+	return &models.Workspace{ID: "ws-b", Name: "Theirs", OwnerID: "user-b"}, nil
+}
+
+func (r *wsTaskRepo) UpdateTask(_ context.Context, task *models.Task) error {
+	r.updated = append(r.updated, task)
+	return nil
+}
+
+func (r *wsTaskRepo) DeleteTask(_ context.Context, id string) error {
+	r.deleted = append(r.deleted, id)
+	return nil
+}
+
+func (r *wsTaskRepo) ArchiveTask(_ context.Context, id string) error {
+	r.archived = append(r.archived, id)
+	return nil
+}
+
+func (r *wsTaskRepo) UpdateTaskState(_ context.Context, id string, _ v1.TaskState) error {
+	r.stateUpdates = append(r.stateUpdates, id)
+	return nil
+}
+
+func (r *wsTaskRepo) CreateTask(_ context.Context, task *models.Task) error {
+	r.created = append(r.created, task)
+	return nil
+}
+
+func (r *wsTaskRepo) ListTaskSessions(_ context.Context, taskID string) ([]*models.TaskSession, error) {
+	r.sessionsCalls = append(r.sessionsCalls, taskID)
+	return []*models.TaskSession{{ID: "sess-b", TaskID: taskID}}, nil
+}
+
+func (r *wsTaskRepo) GetWorkflow(_ context.Context, id string) (*models.Workflow, error) {
+	if id != "wf-b" {
+		return nil, fmt.Errorf("workflow not found: %s", id)
+	}
+	return &models.Workflow{ID: "wf-b", WorkspaceID: "ws-b", Name: "Board"}, nil
+}
+
+func (r *wsTaskRepo) ListTasks(_ context.Context, workflowID string) ([]*models.Task, error) {
+	if workflowID != "wf-b" {
+		return nil, nil
+	}
+	return []*models.Task{
+		{ID: "task-b", WorkspaceID: "ws-b", Title: "Mine"},
+		// A row that leaked in from another workspace: ListTasks filters it out.
+		{ID: "task-other", WorkspaceID: "ws-other", Title: "Theirs"},
+	}, nil
+}
+
+func newWSTaskHandlers(t *testing.T, repo *wsTaskRepo) *TaskHandlers {
+	t.Helper()
+	log := newTestLogger(t)
+	svc := service.NewService(service.Repos{
+		Workspaces: repo, Tasks: repo, TaskRepos: repo,
+		Workflows: repo, Messages: repo, Turns: repo,
+		Sessions: repo, GitSnapshots: repo, RepoEntities: repo,
+		Executors: repo, Environments: repo, TaskEnvironments: repo,
+		Reviews: repo,
+	}, nil, log, service.RepositoryDiscoveryConfig{})
+	return &TaskHandlers{service: svc, logger: log}
+}
+
+// asUser returns a context carrying a scoped identity. An identity-free
+// context is treated as an internal caller and skips scoping entirely, so
+// every authorization test must supply one.
+func asUser(userID string) context.Context {
+	return authn.WithIdentity(context.Background(), authn.Identity{UserID: userID, Role: authn.RoleMember})
+}
+
+// TestWSTaskReadsDenyForeignTask covers the read side: neither the task itself
+// nor its session list may be served to a user who does not own the workspace.
+// Each case also runs as the owner, so a denial that came from a broken
+// fixture rather than from scoping fails here instead of passing silently.
+func TestWSTaskReadsDenyForeignTask(t *testing.T) {
+	repo := &wsTaskRepo{}
+	h := newWSTaskHandlers(t, repo)
+
+	foreign, err := h.wsGetTask(asUser("user-a"),
+		wsWorkflowRequest(t, ws.ActionTaskGet, map[string]any{"id": "task-b"}))
+	require.NoError(t, err)
+	require.Equal(t, string(ws.ErrorCodeNotFound), wsWorkflowError(t, foreign).Code)
+	require.NotContains(t, string(foreign.Payload), "Victim", "the foreign task must not be serialized")
+
+	owner, err := h.wsGetTask(asUser("user-b"),
+		wsWorkflowRequest(t, ws.ActionTaskGet, map[string]any{"id": "task-b"}))
+	require.NoError(t, err)
+	require.Equal(t, ws.MessageTypeResponse, owner.Type, "the owner must get past the check")
+
+	foreignSessions, err := h.wsListTaskSessions(asUser("user-a"),
+		wsWorkflowRequest(t, ws.ActionTaskSessionList, map[string]any{"task_id": "task-b"}))
+	require.NoError(t, err)
+	require.Equal(t, ws.MessageTypeError, foreignSessions.Type)
+	require.NotContains(t, string(foreignSessions.Payload), "sess-b", "session IDs must not leak")
+
+	ownerSessions, err := h.wsListTaskSessions(asUser("user-b"),
+		wsWorkflowRequest(t, ws.ActionTaskSessionList, map[string]any{"task_id": "task-b"}))
+	require.NoError(t, err)
+	var list dto.ListTaskSessionSummariesResponse
+	wsWorkflowResponse(t, ownerSessions, &list)
+	require.Equal(t, 1, list.Total)
+	require.Equal(t, "sess-b", list.Sessions[0].ID)
+}
+
+// TestWSTaskMutationsDenyForeignTask is the mutation half. The recorded-write
+// assertions matter more than the error codes: a guard that refused the
+// response after committing the write would still be a data-loss bug.
+//
+// task.state and task.move are deliberately absent — their service methods
+// take no authorization step at all, and the two are reported separately
+// rather than pinned here as if the current behavior were intended.
+func TestWSTaskMutationsDenyForeignTask(t *testing.T) {
+	for name, tc := range map[string]struct {
+		call    func(*TaskHandlers, context.Context) (*ws.Message, error)
+		writes  func(*wsTaskRepo) int
+		wantMsg string
+	}{
+		"update": {
+			call: func(h *TaskHandlers, ctx context.Context) (*ws.Message, error) {
+				return h.wsUpdateTask(ctx, wsWorkflowRequest(t, ws.ActionTaskUpdate,
+					map[string]any{"id": "task-b", "title": "Hijacked"}))
+			},
+			writes:  func(r *wsTaskRepo) int { return len(r.updated) },
+			wantMsg: "Failed to update task",
+		},
+		"delete": {
+			call: func(h *TaskHandlers, ctx context.Context) (*ws.Message, error) {
+				return h.wsDeleteTask(ctx, wsWorkflowRequest(t, ws.ActionTaskDelete,
+					map[string]any{"id": "task-b"}))
+			},
+			writes:  func(r *wsTaskRepo) int { return len(r.deleted) },
+			wantMsg: "failed to delete task",
+		},
+		"archive": {
+			call: func(h *TaskHandlers, ctx context.Context) (*ws.Message, error) {
+				return h.wsArchiveTask(ctx, wsWorkflowRequest(t, ws.ActionTaskArchive,
+					map[string]any{"id": "task-b"}))
+			},
+			writes:  func(r *wsTaskRepo) int { return len(r.archived) },
+			wantMsg: "failed to archive task",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			repo := &wsTaskRepo{}
+			h := newWSTaskHandlers(t, repo)
+
+			resp, err := tc.call(h, asUser("user-a"))
+
+			require.NoError(t, err)
+			payload := wsWorkflowError(t, resp)
+			require.Equal(t, string(ws.ErrorCodeInternalError), payload.Code)
+			require.Equal(t, tc.wantMsg, payload.Message)
+			require.Zero(t, tc.writes(repo), "a denied mutation must not reach the repository")
+		})
+	}
+}
+
+// TestWSCreateTaskDeniesForeignWorkspace stops a caller from planting a task in
+// somebody else's workspace.
+func TestWSCreateTaskDeniesForeignWorkspace(t *testing.T) {
+	repo := &wsTaskRepo{}
+	h := newWSTaskHandlers(t, repo)
+
+	resp, err := h.wsCreateTask(asUser("user-a"), wsWorkflowRequest(t, ws.ActionTaskCreate, map[string]any{
+		"workspace_id": "ws-b", "workflow_id": "wf-b", "title": "Planted",
+	}))
+
+	require.NoError(t, err)
+	require.Equal(t, ws.MessageTypeError, resp.Type)
+	require.Empty(t, repo.created, "a denied create must not insert a task")
+}
+
+func TestWSCreateTaskValidatesRequiredFields(t *testing.T) {
+	repo := &wsTaskRepo{}
+	h := newWSTaskHandlers(t, repo)
+
+	for name, tc := range map[string]struct {
+		payload map[string]any
+		wantMsg string
+	}{
+		"missing workspace": {
+			payload: map[string]any{"workflow_id": "wf-1", "title": "T"},
+			wantMsg: "workspace_id is required",
+		},
+		"missing workflow": {
+			payload: map[string]any{"workspace_id": "ws-b", "title": "T"},
+			wantMsg: "workflow_id is required",
+		},
+		"missing title": {
+			payload: map[string]any{"workspace_id": "ws-b", "workflow_id": "wf-1"},
+			wantMsg: "title is required",
+		},
+		"start agent without profile": {
+			payload: map[string]any{
+				"workspace_id": "ws-b", "workflow_id": "wf-1", "title": "T", "start_agent": true,
+			},
+			wantMsg: "agent_profile_id is required to start agent",
+		},
+		"repository without any identifier": {
+			payload: map[string]any{
+				"workspace_id": "ws-b", "workflow_id": "wf-1", "title": "T",
+				"repositories": []map[string]any{{"base_branch": "main"}},
+			},
+			wantMsg: "repository_id, local_path, or remote_url is required",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			resp, err := h.wsCreateTask(context.Background(),
+				wsWorkflowRequest(t, ws.ActionTaskCreate, tc.payload))
+
+			require.NoError(t, err)
+			payload := wsWorkflowError(t, resp)
+			require.Equal(t, string(ws.ErrorCodeValidation), payload.Code)
+			require.Equal(t, tc.wantMsg, payload.Message)
+		})
+	}
+	require.Empty(t, repo.created, "no validation failure may create a task")
+}
+
+func TestWSTaskHandlersRejectMalformedPayloads(t *testing.T) {
+	repo := &wsTaskRepo{}
+	h := newWSTaskHandlers(t, repo)
+
+	for name, call := range map[string]func(context.Context, *ws.Message) (*ws.Message, error){
+		"task.list":           h.wsListTasks,
+		"task.create":         h.wsCreateTask,
+		"task.get":            h.wsGetTask,
+		"task.update":         h.wsUpdateTask,
+		"task.delete":         h.wsDeleteTask,
+		"task.archive":        h.wsArchiveTask,
+		"task.move":           h.wsMoveTask,
+		"task.state":          h.wsUpdateTaskState,
+		"task.session.list":   h.wsListTaskSessions,
+		"task.repository.upd": h.wsUpdateTaskRepository,
+	} {
+		t.Run(name, func(t *testing.T) {
+			resp, err := call(context.Background(), wsMalformedRequest(name))
+
+			require.NoError(t, err)
+			payload := wsWorkflowError(t, resp)
+			require.Equal(t, string(ws.ErrorCodeBadRequest), payload.Code)
+			require.Contains(t, payload.Message, "Invalid payload")
+		})
+	}
+}
+
+func TestWSTaskHandlersValidateRequiredIdentifiers(t *testing.T) {
+	repo := &wsTaskRepo{}
+	h := newWSTaskHandlers(t, repo)
+
+	for name, tc := range map[string]struct {
+		call    func(context.Context, *ws.Message) (*ws.Message, error)
+		action  string
+		payload map[string]any
+		wantMsg string
+	}{
+		"list tasks needs workflow": {
+			call: h.wsListTasks, action: ws.ActionTaskList,
+			payload: map[string]any{}, wantMsg: "workflow_id is required",
+		},
+		"list sessions needs task": {
+			call: h.wsListTaskSessions, action: ws.ActionTaskSessionList,
+			payload: map[string]any{}, wantMsg: "task_id is required",
+		},
+		"get needs id": {
+			call: h.wsGetTask, action: ws.ActionTaskGet,
+			payload: map[string]any{}, wantMsg: "id is required",
+		},
+		"update needs id": {
+			call: h.wsUpdateTask, action: ws.ActionTaskUpdate,
+			payload: map[string]any{"title": "T"}, wantMsg: "id is required",
+		},
+		"delete needs id": {
+			call: h.wsDeleteTask, action: ws.ActionTaskDelete,
+			payload: map[string]any{}, wantMsg: "id is required",
+		},
+		"archive needs id": {
+			call: h.wsArchiveTask, action: ws.ActionTaskArchive,
+			payload: map[string]any{}, wantMsg: "id is required",
+		},
+		"move needs id": {
+			call: h.wsMoveTask, action: ws.ActionTaskMove,
+			payload: map[string]any{"workflow_id": "wf-1", "workflow_step_id": "st-1"},
+			wantMsg: "id is required",
+		},
+		"move needs workflow": {
+			call: h.wsMoveTask, action: ws.ActionTaskMove,
+			payload: map[string]any{"id": "task-b", "workflow_step_id": "st-1"},
+			wantMsg: "workflow_id is required",
+		},
+		"move needs step": {
+			call: h.wsMoveTask, action: ws.ActionTaskMove,
+			payload: map[string]any{"id": "task-b", "workflow_id": "wf-1"},
+			wantMsg: "workflow_step_id is required",
+		},
+		"state needs id": {
+			call: h.wsUpdateTaskState, action: ws.ActionTaskState,
+			payload: map[string]any{"state": "TODO"}, wantMsg: "id is required",
+		},
+		"state needs state": {
+			call: h.wsUpdateTaskState, action: ws.ActionTaskState,
+			payload: map[string]any{"id": "task-b"}, wantMsg: "state is required",
+		},
+		"repository update needs task": {
+			call: h.wsUpdateTaskRepository, action: ws.ActionTaskRepoUpdate,
+			payload: map[string]any{"task_repository_id": "tr-1"}, wantMsg: "task_id is required",
+		},
+		"repository update needs row": {
+			call: h.wsUpdateTaskRepository, action: ws.ActionTaskRepoUpdate,
+			payload: map[string]any{"task_id": "task-b"}, wantMsg: "task_repository_id is required",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			resp, err := tc.call(context.Background(), wsWorkflowRequest(t, tc.action, tc.payload))
+
+			require.NoError(t, err)
+			payload := wsWorkflowError(t, resp)
+			require.Equal(t, string(ws.ErrorCodeValidation), payload.Code)
+			require.Equal(t, tc.wantMsg, payload.Message)
+		})
+	}
+
+	require.Empty(t, repo.updated)
+	require.Empty(t, repo.deleted)
+	require.Empty(t, repo.archived)
+	require.Empty(t, repo.stateUpdates)
+	require.Empty(t, repo.sessionsCalls, "a request rejected on validation must not query sessions")
+}
+
+// TestWSUpdateTaskReportsValidationErrorsVerbatim proves the two-way split in
+// wsUpdateTask's error mapping: a validation failure keeps its message so the
+// UI can show it, while anything else is flattened to a generic message.
+func TestWSUpdateTaskReportsValidationErrorsVerbatim(t *testing.T) {
+	repo := &wsTaskRepo{}
+	h := newWSTaskHandlers(t, repo)
+	overlong := ""
+	for range 80 {
+		overlong += "x"
+	}
+
+	resp, err := h.wsUpdateTask(context.Background(),
+		wsWorkflowRequest(t, ws.ActionTaskUpdate, map[string]any{"id": "task-b", "title": overlong}))
+
+	require.NoError(t, err)
+	payload := wsWorkflowError(t, resp)
+	require.Equal(t, string(ws.ErrorCodeValidation), payload.Code)
+	require.Contains(t, payload.Message, "too long")
+	require.Empty(t, repo.updated)
+}
+
+func TestWSListTasksReturnsOnlyTheWorkflowsWorkspaceTasks(t *testing.T) {
+	repo := &wsTaskRepo{}
+	h := newWSTaskHandlers(t, repo)
+
+	resp, err := h.wsListTasks(context.Background(),
+		wsWorkflowRequest(t, ws.ActionTaskList, map[string]any{"workflow_id": "wf-b"}))
+
+	require.NoError(t, err)
+	var list dto.ListTasksResponse
+	wsWorkflowResponse(t, resp, &list)
+	require.Equal(t, 1, list.Total, "a task from another workspace must be filtered out")
+	require.Len(t, list.Tasks, 1)
+	require.Equal(t, "task-b", list.Tasks[0].ID)
+}
+
+func TestWSListTasksSurfacesUnknownWorkflow(t *testing.T) {
+	repo := &wsTaskRepo{}
+	h := newWSTaskHandlers(t, repo)
+
+	resp, err := h.wsListTasks(context.Background(),
+		wsWorkflowRequest(t, ws.ActionTaskList, map[string]any{"workflow_id": "wf-missing"}))
+
+	require.NoError(t, err)
+	payload := wsWorkflowError(t, resp)
+	require.Equal(t, string(ws.ErrorCodeInternalError), payload.Code)
+	require.Equal(t, "Failed to list tasks", payload.Message)
+}

--- a/apps/backend/internal/task/handlers/workflow_handlers_test.go
+++ b/apps/backend/internal/task/handlers/workflow_handlers_test.go
@@ -1,0 +1,710 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kandev/kandev/internal/common/logger"
+	"github.com/kandev/kandev/internal/task/dto"
+	"github.com/kandev/kandev/internal/task/models"
+	"github.com/kandev/kandev/internal/task/service"
+	workflowmodels "github.com/kandev/kandev/internal/workflow/models"
+	ws "github.com/kandev/kandev/pkg/websocket"
+)
+
+// workflowRepo is the shared fixture for the workflow handler tests. It records
+// every mutation the handlers make so a test can assert that a rejected request
+// wrote nothing, which is the whole point of the read-only guards.
+type workflowRepo struct {
+	mockRepository
+
+	workspaces  map[string]*models.Workspace
+	workflows   map[string]*models.Workflow
+	byWorkspace map[string][]*models.Workflow
+
+	listErr    error
+	createErr  error
+	updateErr  error
+	deleteErr  error
+	reorderErr error
+
+	created            []*models.Workflow
+	updated            []*models.Workflow
+	deleted            []string
+	reordered          []string
+	reorderedWorkspace string
+
+	listedWorkspaceID string
+	listedHidden      bool
+}
+
+func (r *workflowRepo) GetWorkspace(_ context.Context, id string) (*models.Workspace, error) {
+	if workspace, ok := r.workspaces[id]; ok {
+		return workspace, nil
+	}
+	return nil, fmt.Errorf("workspace not found: %s", id)
+}
+
+func (r *workflowRepo) ListWorkspaces(context.Context) ([]*models.Workspace, error) {
+	all := make([]*models.Workspace, 0, len(r.workspaces))
+	for _, workspace := range r.workspaces {
+		all = append(all, workspace)
+	}
+	return all, nil
+}
+
+func (r *workflowRepo) GetWorkflow(_ context.Context, id string) (*models.Workflow, error) {
+	if workflow, ok := r.workflows[id]; ok {
+		return workflow, nil
+	}
+	return nil, fmt.Errorf("workflow not found: %s", id)
+}
+
+func (r *workflowRepo) ListWorkflows(_ context.Context, workspaceID string, includeHidden bool) ([]*models.Workflow, error) {
+	r.listedWorkspaceID = workspaceID
+	r.listedHidden = includeHidden
+	if r.listErr != nil {
+		return nil, r.listErr
+	}
+	return r.byWorkspace[workspaceID], nil
+}
+
+func (r *workflowRepo) CreateWorkflow(_ context.Context, workflow *models.Workflow) error {
+	if r.createErr != nil {
+		return r.createErr
+	}
+	r.created = append(r.created, workflow)
+	return nil
+}
+
+func (r *workflowRepo) UpdateWorkflow(_ context.Context, workflow *models.Workflow) error {
+	if r.updateErr != nil {
+		return r.updateErr
+	}
+	r.updated = append(r.updated, workflow)
+	return nil
+}
+
+func (r *workflowRepo) DeleteWorkflow(_ context.Context, id string) error {
+	if r.deleteErr != nil {
+		return r.deleteErr
+	}
+	r.deleted = append(r.deleted, id)
+	return nil
+}
+
+func (r *workflowRepo) ReorderWorkflows(_ context.Context, workspaceID string, ids []string) error {
+	if r.reorderErr != nil {
+		return r.reorderErr
+	}
+	r.reorderedWorkspace = workspaceID
+	r.reordered = ids
+	return nil
+}
+
+func (r *workflowRepo) ListTasks(context.Context, string) ([]*models.Task, error) {
+	return nil, nil
+}
+
+// stubStepLister satisfies WorkflowStepLister without a workflow repository.
+type stubStepLister struct {
+	steps []*workflowmodels.WorkflowStep
+	err   error
+	calls []string
+}
+
+func (s *stubStepLister) ListStepsByWorkflow(_ context.Context, workflowID string) ([]*workflowmodels.WorkflowStep, error) {
+	s.calls = append(s.calls, workflowID)
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.steps, nil
+}
+
+func newWorkflowService(t *testing.T, repo *workflowRepo) (*service.Service, *logger.Logger) {
+	t.Helper()
+	log := newTestLogger(t)
+	svc := service.NewService(service.Repos{
+		Workspaces: repo, Tasks: repo, TaskRepos: repo,
+		Workflows: repo, Messages: repo, Turns: repo,
+		Sessions: repo, GitSnapshots: repo, RepoEntities: repo,
+		Executors: repo, Environments: repo, TaskEnvironments: repo,
+		Reviews: repo,
+	}, nil, log, service.RepositoryDiscoveryConfig{})
+	return svc, log
+}
+
+func newWorkflowHandlers(t *testing.T, repo *workflowRepo, steps WorkflowStepLister) *WorkflowHandlers {
+	t.Helper()
+	svc, log := newWorkflowService(t, repo)
+	return NewWorkflowHandlers(svc, steps, log)
+}
+
+// workflowFixture builds a repo with one ordinary workspace holding two
+// workflows: a normal one and the workspace's office workflow.
+func workflowFixture() *workflowRepo {
+	normal := &models.Workflow{ID: "wf-1", WorkspaceID: "ws-1", Name: "Kanban"}
+	office := &models.Workflow{ID: "wf-office", WorkspaceID: "ws-1", Name: "Office"}
+	return &workflowRepo{
+		workspaces: map[string]*models.Workspace{
+			"ws-1":       {ID: "ws-1", Name: "Team", OfficeWorkflowID: "wf-office"},
+			"ws-improve": {ID: "ws-improve", Name: models.WorkspaceNameImproveKandev},
+		},
+		workflows: map[string]*models.Workflow{
+			"wf-1":       normal,
+			"wf-office":  office,
+			"wf-synced":  {ID: "wf-synced", WorkspaceID: "ws-1", Name: "Synced", Source: models.WorkflowSourceGitHub},
+			"wf-improve": {ID: "wf-improve", WorkspaceID: "ws-improve", Name: "Improve"},
+		},
+		byWorkspace: map[string][]*models.Workflow{
+			"ws-1": {normal, office},
+		},
+	}
+}
+
+func newWorkflowRequest(t *testing.T, method, target, body string) (*gin.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	var reader *strings.Reader
+	if body != "" {
+		reader = strings.NewReader(body)
+	} else {
+		reader = strings.NewReader("")
+	}
+	c.Request = httptest.NewRequest(method, target, reader)
+	c.Request.Header.Set("Content-Type", "application/json")
+	return c, rec
+}
+
+func decodeWorkflowList(t *testing.T, body []byte) dto.ListWorkflowsResponse {
+	t.Helper()
+	var resp dto.ListWorkflowsResponse
+	require.NoError(t, json.Unmarshal(body, &resp))
+	return resp
+}
+
+func workflowIDsOf(workflows []dto.WorkflowDTO) []string {
+	ids := make([]string, 0, len(workflows))
+	for _, w := range workflows {
+		ids = append(ids, w.ID)
+	}
+	return ids
+}
+
+func TestHTTPListWorkflowsExcludesOfficeWorkflowByDefault(t *testing.T) {
+	repo := workflowFixture()
+	h := newWorkflowHandlers(t, repo, &stubStepLister{})
+	c, rec := newWorkflowRequest(t, http.MethodGet, "/api/v1/workflows?workspace_id=ws-1", "")
+
+	h.httpListWorkflows(c)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	resp := decodeWorkflowList(t, rec.Body.Bytes())
+	require.Equal(t, []string{"wf-1"}, workflowIDsOf(resp.Workflows))
+	require.Equal(t, 1, resp.Total, "Total must count the filtered list, not the raw one")
+	require.Equal(t, "ws-1", repo.listedWorkspaceID)
+	require.False(t, repo.listedHidden, "include_hidden defaults to false")
+}
+
+func TestHTTPListWorkflowsIncludesOfficeWhenExplicitlyRequested(t *testing.T) {
+	repo := workflowFixture()
+	h := newWorkflowHandlers(t, repo, &stubStepLister{})
+	c, rec := newWorkflowRequest(t, http.MethodGet,
+		"/api/v1/workflows?workspace_id=ws-1&exclude_office=false&include_hidden=true", "")
+
+	h.httpListWorkflows(c)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	resp := decodeWorkflowList(t, rec.Body.Bytes())
+	require.Equal(t, []string{"wf-1", "wf-office"}, workflowIDsOf(resp.Workflows))
+	require.Equal(t, 2, resp.Total)
+	require.True(t, repo.listedHidden, "include_hidden=true must reach the repository")
+}
+
+func TestHTTPListWorkflowsReturnsInternalErrorWhenListFails(t *testing.T) {
+	repo := workflowFixture()
+	repo.listErr = errors.New("database unavailable")
+	h := newWorkflowHandlers(t, repo, &stubStepLister{})
+	c, rec := newWorkflowRequest(t, http.MethodGet, "/api/v1/workflows?workspace_id=ws-1", "")
+
+	h.httpListWorkflows(c)
+
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	require.JSONEq(t, `{"error":"failed to list workflows"}`, rec.Body.String())
+}
+
+func TestHTTPListWorkflowsByWorkspaceReadsThePathParam(t *testing.T) {
+	repo := workflowFixture()
+	h := newWorkflowHandlers(t, repo, &stubStepLister{})
+	c, rec := newWorkflowRequest(t, http.MethodGet, "/api/v1/workspaces/ws-1/workflows", "")
+	c.Params = gin.Params{{Key: "id", Value: "ws-1"}}
+
+	h.httpListWorkflowsByWorkspace(c)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "ws-1", repo.listedWorkspaceID)
+	require.Equal(t, []string{"wf-1"}, workflowIDsOf(decodeWorkflowList(t, rec.Body.Bytes()).Workflows))
+}
+
+func TestParseIncludeHidden(t *testing.T) {
+	for _, tc := range []struct {
+		in   string
+		want bool
+	}{
+		{"", false},
+		{"true", true},
+		{"1", true},
+		{"false", false},
+		{"yes", false},
+	} {
+		require.Equalf(t, tc.want, parseIncludeHidden(tc.in), "parseIncludeHidden(%q)", tc.in)
+	}
+}
+
+func TestHTTPGetWorkflowReturnsWorkflowOrNotFound(t *testing.T) {
+	repo := workflowFixture()
+	h := newWorkflowHandlers(t, repo, &stubStepLister{})
+
+	c, rec := newWorkflowRequest(t, http.MethodGet, "/api/v1/workflows/wf-1", "")
+	c.Params = gin.Params{{Key: "id", Value: "wf-1"}}
+	h.httpGetWorkflow(c)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got dto.WorkflowDTO
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Equal(t, "wf-1", got.ID)
+	require.Equal(t, "Kanban", got.Name)
+
+	missingCtx, missingRec := newWorkflowRequest(t, http.MethodGet, "/api/v1/workflows/nope", "")
+	missingCtx.Params = gin.Params{{Key: "id", Value: "nope"}}
+	h.httpGetWorkflow(missingCtx)
+	require.Equal(t, http.StatusNotFound, missingRec.Code)
+	require.JSONEq(t, `{"error":"workflow not found"}`, missingRec.Body.String())
+}
+
+func TestHTTPCreateWorkflowRejectsInvalidRequests(t *testing.T) {
+	repo := workflowFixture()
+	h := newWorkflowHandlers(t, repo, &stubStepLister{})
+
+	for name, tc := range map[string]struct {
+		body     string
+		wantBody string
+	}{
+		"malformed json": {body: `{`, wantBody: `{"error":"invalid request body"}`},
+		"missing name": {
+			body:     `{"workspace_id":"ws-1"}`,
+			wantBody: `{"error":"workspace_id and name are required"}`,
+		},
+		"missing workspace": {
+			body:     `{"name":"Flow"}`,
+			wantBody: `{"error":"workspace_id and name are required"}`,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			c, rec := newWorkflowRequest(t, http.MethodPost, "/api/v1/workflows", tc.body)
+			h.httpCreateWorkflow(c)
+			require.Equal(t, http.StatusBadRequest, rec.Code)
+			require.JSONEq(t, tc.wantBody, rec.Body.String())
+		})
+	}
+	require.Empty(t, repo.created, "rejected requests must not create a workflow")
+}
+
+func TestHTTPCreateWorkflowCreatesWorkflow(t *testing.T) {
+	repo := workflowFixture()
+	h := newWorkflowHandlers(t, repo, &stubStepLister{})
+	c, rec := newWorkflowRequest(t, http.MethodPost, "/api/v1/workflows",
+		`{"workspace_id":"ws-1","name":"Flow","description":"d","prompt":"p"}`)
+
+	h.httpCreateWorkflow(c)
+
+	require.Equal(t, http.StatusCreated, rec.Code)
+	require.Len(t, repo.created, 1)
+	require.Equal(t, "Flow", repo.created[0].Name)
+	require.Equal(t, "ws-1", repo.created[0].WorkspaceID)
+	require.Equal(t, "d", repo.created[0].Description)
+	require.Equal(t, "p", repo.created[0].Prompt)
+
+	var got dto.WorkflowDTO
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Equal(t, repo.created[0].ID, got.ID)
+	require.Equal(t, "Flow", got.Name)
+}
+
+func TestHTTPCreateWorkflowRejectsImproveKandevWorkspace(t *testing.T) {
+	repo := workflowFixture()
+	h := newWorkflowHandlers(t, repo, &stubStepLister{})
+	c, rec := newWorkflowRequest(t, http.MethodPost, "/api/v1/workflows",
+		`{"workspace_id":"ws-improve","name":"Flow"}`)
+
+	h.httpCreateWorkflow(c)
+
+	require.Equal(t, http.StatusConflict, rec.Code)
+	require.JSONEq(t, `{"error":"`+workspaceReadOnlyMsg+`"}`, rec.Body.String())
+	require.Empty(t, repo.created, "the read-only workspace must not gain a workflow")
+}
+
+func TestHTTPCreateWorkflowReturnsNotFoundForUnknownWorkspace(t *testing.T) {
+	repo := workflowFixture()
+	h := newWorkflowHandlers(t, repo, &stubStepLister{})
+	c, rec := newWorkflowRequest(t, http.MethodPost, "/api/v1/workflows",
+		`{"workspace_id":"ws-missing","name":"Flow"}`)
+
+	h.httpCreateWorkflow(c)
+
+	require.Equal(t, http.StatusNotFound, rec.Code)
+	require.JSONEq(t, `{"error":"workspace not found"}`, rec.Body.String())
+	require.Empty(t, repo.created)
+}
+
+func TestHTTPCreateWorkflowSurfacesRepositoryFailure(t *testing.T) {
+	repo := workflowFixture()
+	repo.createErr = errors.New("disk full")
+	h := newWorkflowHandlers(t, repo, &stubStepLister{})
+	c, rec := newWorkflowRequest(t, http.MethodPost, "/api/v1/workflows",
+		`{"workspace_id":"ws-1","name":"Flow"}`)
+
+	h.httpCreateWorkflow(c)
+
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	require.JSONEq(t, `{"error":"failed to create workflow"}`, rec.Body.String())
+}
+
+func TestHTTPUpdateWorkflowUpdatesFields(t *testing.T) {
+	repo := workflowFixture()
+	h := newWorkflowHandlers(t, repo, &stubStepLister{})
+	c, rec := newWorkflowRequest(t, http.MethodPatch, "/api/v1/workflows/wf-1",
+		`{"name":"Renamed","agent_profile_id":"  ap-1  "}`)
+	c.Params = gin.Params{{Key: "id", Value: "wf-1"}}
+
+	h.httpUpdateWorkflow(c)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Len(t, repo.updated, 1)
+	require.Equal(t, "Renamed", repo.updated[0].Name)
+	require.Equal(t, "ap-1", repo.updated[0].AgentProfileID, "agent_profile_id is trimmed")
+
+	var got dto.WorkflowDTO
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Equal(t, "Renamed", got.Name)
+}
+
+func TestHTTPUpdateWorkflowRejectsInvalidBody(t *testing.T) {
+	repo := workflowFixture()
+	h := newWorkflowHandlers(t, repo, &stubStepLister{})
+	c, rec := newWorkflowRequest(t, http.MethodPatch, "/api/v1/workflows/wf-1", `{`)
+	c.Params = gin.Params{{Key: "id", Value: "wf-1"}}
+
+	h.httpUpdateWorkflow(c)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.JSONEq(t, `{"error":"invalid request body"}`, rec.Body.String())
+	require.Empty(t, repo.updated)
+}
+
+// TestHTTPWorkflowMutationsRejectReadOnlyWorkflows covers both read-only
+// reasons on both mutating routes: a GitHub-synced workflow and any workflow
+// living in the Improve Kandev workspace. The recorded-mutation assertions are
+// the point — a guard that answered 409 after writing would still be a bug.
+func TestHTTPWorkflowMutationsRejectReadOnlyWorkflows(t *testing.T) {
+	for name, tc := range map[string]struct {
+		workflowID string
+		wantMsg    string
+	}{
+		"github synced":     {workflowID: "wf-synced", wantMsg: workflowReadOnlyMsg},
+		"improve workspace": {workflowID: "wf-improve", wantMsg: workspaceReadOnlyMsg},
+	} {
+		t.Run(name, func(t *testing.T) {
+			repo := workflowFixture()
+			h := newWorkflowHandlers(t, repo, &stubStepLister{})
+
+			updateCtx, updateRec := newWorkflowRequest(t, http.MethodPatch,
+				"/api/v1/workflows/"+tc.workflowID, `{"name":"Renamed"}`)
+			updateCtx.Params = gin.Params{{Key: "id", Value: tc.workflowID}}
+			h.httpUpdateWorkflow(updateCtx)
+			require.Equal(t, http.StatusConflict, updateRec.Code)
+			require.JSONEq(t, `{"error":"`+tc.wantMsg+`"}`, updateRec.Body.String())
+			require.Empty(t, repo.updated, "read-only workflow must not be updated")
+
+			deleteCtx, deleteRec := newWorkflowRequest(t, http.MethodDelete,
+				"/api/v1/workflows/"+tc.workflowID, "")
+			deleteCtx.Params = gin.Params{{Key: "id", Value: tc.workflowID}}
+			h.httpDeleteWorkflow(deleteCtx)
+			require.Equal(t, http.StatusConflict, deleteRec.Code)
+			require.JSONEq(t, `{"error":"`+tc.wantMsg+`"}`, deleteRec.Body.String())
+			require.Empty(t, repo.deleted, "read-only workflow must not be deleted")
+		})
+	}
+}
+
+func TestHTTPDeleteWorkflowDeletesEditableWorkflow(t *testing.T) {
+	repo := workflowFixture()
+	h := newWorkflowHandlers(t, repo, &stubStepLister{})
+	c, rec := newWorkflowRequest(t, http.MethodDelete, "/api/v1/workflows/wf-1", "")
+	c.Params = gin.Params{{Key: "id", Value: "wf-1"}}
+
+	h.httpDeleteWorkflow(c)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.JSONEq(t, `{"success":true}`, rec.Body.String())
+	require.Equal(t, []string{"wf-1"}, repo.deleted)
+}
+
+func TestHTTPDeleteWorkflowReturnsNotFoundForUnknownWorkflow(t *testing.T) {
+	repo := workflowFixture()
+	h := newWorkflowHandlers(t, repo, &stubStepLister{})
+	c, rec := newWorkflowRequest(t, http.MethodDelete, "/api/v1/workflows/nope", "")
+	c.Params = gin.Params{{Key: "id", Value: "nope"}}
+
+	h.httpDeleteWorkflow(c)
+
+	require.Equal(t, http.StatusNotFound, rec.Code)
+	require.JSONEq(t, `{"error":"workflow not found"}`, rec.Body.String())
+	require.Empty(t, repo.deleted)
+}
+
+func TestHTTPReorderWorkflowsRejectsInvalidRequests(t *testing.T) {
+	repo := workflowFixture()
+	h := newWorkflowHandlers(t, repo, &stubStepLister{})
+
+	badCtx, badRec := newWorkflowRequest(t, http.MethodPut,
+		"/api/v1/workspaces/ws-1/workflows/reorder", `{`)
+	badCtx.Params = gin.Params{{Key: "id", Value: "ws-1"}}
+	h.httpReorderWorkflows(badCtx)
+	require.Equal(t, http.StatusBadRequest, badRec.Code)
+	require.Contains(t, badRec.Body.String(), "Invalid request:")
+
+	emptyCtx, emptyRec := newWorkflowRequest(t, http.MethodPut,
+		"/api/v1/workspaces/ws-1/workflows/reorder", `{"workflow_ids":[]}`)
+	emptyCtx.Params = gin.Params{{Key: "id", Value: "ws-1"}}
+	h.httpReorderWorkflows(emptyCtx)
+	require.Equal(t, http.StatusBadRequest, emptyRec.Code)
+	require.JSONEq(t, `{"error":"workflow_ids is required"}`, emptyRec.Body.String())
+
+	require.Nil(t, repo.reordered, "rejected requests must not reorder")
+}
+
+func TestHTTPReorderWorkflowsRejectsImproveKandevWorkspace(t *testing.T) {
+	repo := workflowFixture()
+	h := newWorkflowHandlers(t, repo, &stubStepLister{})
+	c, rec := newWorkflowRequest(t, http.MethodPut,
+		"/api/v1/workspaces/ws-improve/workflows/reorder", `{"workflow_ids":["wf-improve"]}`)
+	c.Params = gin.Params{{Key: "id", Value: "ws-improve"}}
+
+	h.httpReorderWorkflows(c)
+
+	require.Equal(t, http.StatusConflict, rec.Code)
+	require.JSONEq(t, `{"error":"`+workspaceReadOnlyMsg+`"}`, rec.Body.String())
+	require.Nil(t, repo.reordered)
+}
+
+func TestHTTPReorderWorkflowsPersistsOrder(t *testing.T) {
+	repo := workflowFixture()
+	h := newWorkflowHandlers(t, repo, &stubStepLister{})
+	c, rec := newWorkflowRequest(t, http.MethodPut,
+		"/api/v1/workspaces/ws-1/workflows/reorder", `{"workflow_ids":["wf-office","wf-1"]}`)
+	c.Params = gin.Params{{Key: "id", Value: "ws-1"}}
+
+	h.httpReorderWorkflows(c)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.JSONEq(t, `{"success":true}`, rec.Body.String())
+	require.Equal(t, "ws-1", repo.reorderedWorkspace)
+	require.Equal(t, []string{"wf-office", "wf-1"}, repo.reordered)
+}
+
+func TestHTTPReorderWorkflowsSurfacesRepositoryFailure(t *testing.T) {
+	repo := workflowFixture()
+	repo.reorderErr = errors.New("constraint violation")
+	h := newWorkflowHandlers(t, repo, &stubStepLister{})
+	c, rec := newWorkflowRequest(t, http.MethodPut,
+		"/api/v1/workspaces/ws-1/workflows/reorder", `{"workflow_ids":["wf-1"]}`)
+	c.Params = gin.Params{{Key: "id", Value: "ws-1"}}
+
+	h.httpReorderWorkflows(c)
+
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	require.JSONEq(t, `{"error":"Failed to reorder workflows"}`, rec.Body.String())
+}
+
+func decodeWorkflowSnapshot(t *testing.T, body []byte) dto.WorkflowSnapshotDTO {
+	t.Helper()
+	var snapshot dto.WorkflowSnapshotDTO
+	require.NoError(t, json.Unmarshal(body, &snapshot))
+	return snapshot
+}
+
+func TestHTTPGetWorkflowSnapshotReturnsWorkflowStepsAndTasks(t *testing.T) {
+	repo := workflowFixture()
+	steps := &stubStepLister{steps: []*workflowmodels.WorkflowStep{
+		{ID: "step-1", WorkflowID: "wf-1", Name: "Todo"},
+		{ID: "step-2", WorkflowID: "wf-1", Name: "Done"},
+	}}
+	h := newWorkflowHandlers(t, repo, steps)
+	c, rec := newWorkflowRequest(t, http.MethodGet, "/api/v1/workflows/wf-1/snapshot", "")
+	c.Params = gin.Params{{Key: "id", Value: "wf-1"}}
+
+	h.httpGetWorkflowSnapshot(c)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	snapshot := decodeWorkflowSnapshot(t, rec.Body.Bytes())
+	require.Equal(t, "wf-1", snapshot.Workflow.ID)
+	require.Len(t, snapshot.Steps, 2)
+	require.Equal(t, "step-1", snapshot.Steps[0].ID)
+	require.Equal(t, []string{"wf-1"}, steps.calls)
+	require.Empty(t, snapshot.Tasks)
+}
+
+func TestHTTPGetWorkflowSnapshotReturnsNotFoundForUnknownWorkflow(t *testing.T) {
+	repo := workflowFixture()
+	h := newWorkflowHandlers(t, repo, &stubStepLister{})
+	c, rec := newWorkflowRequest(t, http.MethodGet, "/api/v1/workflows/nope/snapshot", "")
+	c.Params = gin.Params{{Key: "id", Value: "nope"}}
+
+	h.httpGetWorkflowSnapshot(c)
+
+	require.Equal(t, http.StatusNotFound, rec.Code)
+	require.JSONEq(t, `{"error":"workflow not found"}`, rec.Body.String())
+}
+
+func TestHTTPGetWorkflowSnapshotFailsWithoutAStepLister(t *testing.T) {
+	repo := workflowFixture()
+	h := newWorkflowHandlers(t, repo, nil)
+	c, rec := newWorkflowRequest(t, http.MethodGet, "/api/v1/workflows/wf-1/snapshot", "")
+	c.Params = gin.Params{{Key: "id", Value: "wf-1"}}
+
+	h.httpGetWorkflowSnapshot(c)
+
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	require.JSONEq(t, `{"error":"request failed"}`, rec.Body.String())
+}
+
+func TestHTTPGetWorkspaceSnapshotFallsBackToFirstWorkflow(t *testing.T) {
+	repo := workflowFixture()
+	steps := &stubStepLister{steps: []*workflowmodels.WorkflowStep{{ID: "step-1", WorkflowID: "wf-1"}}}
+	h := newWorkflowHandlers(t, repo, steps)
+	c, rec := newWorkflowRequest(t, http.MethodGet, "/api/v1/workspaces/ws-1/snapshot", "")
+	c.Params = gin.Params{{Key: "id", Value: "ws-1"}}
+
+	h.httpGetWorkspaceSnapshot(c)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	snapshot := decodeWorkflowSnapshot(t, rec.Body.Bytes())
+	require.Equal(t, "wf-1", snapshot.Workflow.ID, "no workflow_id means the workspace's first workflow")
+	require.Equal(t, []string{"wf-1"}, steps.calls)
+}
+
+func TestHTTPGetWorkspaceSnapshotUsesExplicitWorkflowID(t *testing.T) {
+	repo := workflowFixture()
+	steps := &stubStepLister{}
+	h := newWorkflowHandlers(t, repo, steps)
+	c, rec := newWorkflowRequest(t, http.MethodGet,
+		"/api/v1/workspaces/ws-1/snapshot?workflow_id=wf-office", "")
+	c.Params = gin.Params{{Key: "id", Value: "ws-1"}}
+
+	h.httpGetWorkspaceSnapshot(c)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "wf-office", decodeWorkflowSnapshot(t, rec.Body.Bytes()).Workflow.ID)
+	require.Equal(t, []string{"wf-office"}, steps.calls)
+}
+
+func TestHTTPGetWorkspaceSnapshotRejectsMissingWorkspaceID(t *testing.T) {
+	repo := workflowFixture()
+	h := newWorkflowHandlers(t, repo, &stubStepLister{})
+	c, rec := newWorkflowRequest(t, http.MethodGet, "/api/v1/workspaces//snapshot", "")
+
+	h.httpGetWorkspaceSnapshot(c)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.JSONEq(t, `{"error":"workspace id is required"}`, rec.Body.String())
+}
+
+// TestHTTPGetWorkspaceSnapshotWhenWorkspaceHasNoWorkflows pins the status this
+// path actually returns. The handler builds its own error and passes the
+// "workflow not found" fallback to handleNotFound, clearly intending a 404 —
+// but handleNotFound classifies by message, and "no workflows found for
+// workspace: X" contains neither "not found" nor a validation keyword, so the
+// request lands on the generic 500. Asserted as-is: this is existing behavior,
+// and pinning it means a future fix has to come with a deliberate test change.
+func TestHTTPGetWorkspaceSnapshotWhenWorkspaceHasNoWorkflows(t *testing.T) {
+	repo := workflowFixture()
+	repo.workspaces["ws-empty"] = &models.Workspace{ID: "ws-empty", Name: "Empty"}
+	h := newWorkflowHandlers(t, repo, &stubStepLister{})
+	c, rec := newWorkflowRequest(t, http.MethodGet, "/api/v1/workspaces/ws-empty/snapshot", "")
+	c.Params = gin.Params{{Key: "id", Value: "ws-empty"}}
+
+	h.httpGetWorkspaceSnapshot(c)
+
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	require.JSONEq(t, `{"error":"request failed"}`, rec.Body.String())
+}
+
+// TestHTTPGetWorkspaceSnapshotRejectsWorkflowFromAnotherWorkspace pins the
+// cross-workspace check: asking workspace A for workspace B's workflow must not
+// serve B's board. The refusal currently arrives as a 500 for the same
+// message-classification reason as the test above; what matters for safety is
+// that no foreign data is returned and B's steps are never read.
+func TestHTTPGetWorkspaceSnapshotRejectsWorkflowFromAnotherWorkspace(t *testing.T) {
+	repo := workflowFixture()
+	steps := &stubStepLister{}
+	h := newWorkflowHandlers(t, repo, steps)
+	c, rec := newWorkflowRequest(t, http.MethodGet,
+		"/api/v1/workspaces/ws-1/snapshot?workflow_id=wf-improve", "")
+	c.Params = gin.Params{{Key: "id", Value: "ws-1"}}
+
+	h.httpGetWorkspaceSnapshot(c)
+
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	require.NotContains(t, rec.Body.String(), "wf-improve", "the foreign workflow must not be serialized")
+	require.Empty(t, steps.calls, "the foreign workflow's steps must never be read")
+}
+
+func TestApplyTaskLimitTruncatesOnlyForPositiveSmallerLimits(t *testing.T) {
+	tasks := []*models.Task{{ID: "t1"}, {ID: "t2"}, {ID: "t3"}}
+	for name, tc := range map[string]struct {
+		query string
+		want  int
+	}{
+		"no limit":       {query: "", want: 3},
+		"limit two":      {query: "?task_limit=2", want: 2},
+		"limit exceeds":  {query: "?task_limit=99", want: 3},
+		"limit zero":     {query: "?task_limit=0", want: 3},
+		"limit negative": {query: "?task_limit=-1", want: 3},
+		"limit garbage":  {query: "?task_limit=abc", want: 3},
+	} {
+		t.Run(name, func(t *testing.T) {
+			c, _ := newWorkflowRequest(t, http.MethodGet, "/api/v1/workflows/wf-1/snapshot"+tc.query, "")
+			require.Len(t, applyTaskLimit(c, tasks), tc.want)
+		})
+	}
+}
+
+func TestNewWorkflowHandlersStoresForegroundActivityProvider(t *testing.T) {
+	repo := workflowFixture()
+	h := newWorkflowHandlers(t, repo, &stubStepLister{})
+	require.Nil(t, h.foregroundActivity)
+
+	h.SetForegroundActivityProvider(fakeForegroundActivityProvider{})
+	require.NotNil(t, h.foregroundActivity)
+}
+
+// wsWorkflowError decodes an error frame so tests can assert on the code and
+// message separately instead of substring-matching the whole payload.
+func wsWorkflowError(t *testing.T, msg *ws.Message) ws.ErrorPayload {
+	t.Helper()
+	require.Equal(t, ws.MessageTypeError, msg.Type, "expected an error frame, got %s", msg.Payload)
+	var payload ws.ErrorPayload
+	require.NoError(t, json.Unmarshal(msg.Payload, &payload))
+	return payload
+}

--- a/apps/backend/internal/task/handlers/workflow_ws_handlers_test.go
+++ b/apps/backend/internal/task/handlers/workflow_ws_handlers_test.go
@@ -1,0 +1,377 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kandev/kandev/internal/task/dto"
+	ws "github.com/kandev/kandev/pkg/websocket"
+)
+
+// wsWorkflowRequest builds a request frame with an arbitrary payload.
+func wsWorkflowRequest(t *testing.T, action string, payload any) *ws.Message {
+	t.Helper()
+	msg, err := ws.NewRequest("req-1", action, payload)
+	require.NoError(t, err)
+	return msg
+}
+
+// wsMalformedRequest builds a frame whose payload is not valid JSON, which is
+// the only way to reach the ParsePayload error branches.
+func wsMalformedRequest(action string) *ws.Message {
+	return &ws.Message{ID: "req-1", Type: ws.MessageTypeRequest, Action: action, Payload: json.RawMessage(`{`)}
+}
+
+func wsWorkflowResponse(t *testing.T, msg *ws.Message, out any) {
+	t.Helper()
+	require.Equal(t, ws.MessageTypeResponse, msg.Type, "expected a response frame, got %s", msg.Payload)
+	require.NoError(t, json.Unmarshal(msg.Payload, out))
+}
+
+func TestWSListWorkflowsExcludesOfficeByDefault(t *testing.T) {
+	repo := workflowFixture()
+	h := newWorkflowHandlers(t, repo, &stubStepLister{})
+	msg := wsWorkflowRequest(t, ws.ActionWorkflowList, map[string]any{"workspace_id": "ws-1"})
+
+	resp, err := h.wsListWorkflows(context.Background(), msg)
+
+	require.NoError(t, err)
+	var list dto.ListWorkflowsResponse
+	wsWorkflowResponse(t, resp, &list)
+	require.Equal(t, []string{"wf-1"}, workflowIDsOf(list.Workflows))
+	require.Equal(t, 1, list.Total)
+}
+
+func TestWSListWorkflowsIncludesOfficeWhenExcludeOfficeIsFalse(t *testing.T) {
+	repo := workflowFixture()
+	h := newWorkflowHandlers(t, repo, &stubStepLister{})
+	msg := wsWorkflowRequest(t, ws.ActionWorkflowList, map[string]any{
+		"workspace_id":   "ws-1",
+		"exclude_office": false,
+		"include_hidden": true,
+	})
+
+	resp, err := h.wsListWorkflows(context.Background(), msg)
+
+	require.NoError(t, err)
+	var list dto.ListWorkflowsResponse
+	wsWorkflowResponse(t, resp, &list)
+	require.Equal(t, []string{"wf-1", "wf-office"}, workflowIDsOf(list.Workflows))
+	require.True(t, repo.listedHidden)
+}
+
+func TestWSListWorkflowsRejectsMalformedPayload(t *testing.T) {
+	repo := workflowFixture()
+	h := newWorkflowHandlers(t, repo, &stubStepLister{})
+
+	resp, err := h.wsListWorkflows(context.Background(), wsMalformedRequest(ws.ActionWorkflowList))
+
+	require.NoError(t, err)
+	payload := wsWorkflowError(t, resp)
+	require.Equal(t, string(ws.ErrorCodeBadRequest), payload.Code)
+	require.Contains(t, payload.Message, "Invalid payload")
+}
+
+func TestWSListWorkflowsSurfacesRepositoryFailure(t *testing.T) {
+	repo := workflowFixture()
+	repo.listErr = errors.New("database unavailable")
+	h := newWorkflowHandlers(t, repo, &stubStepLister{})
+	msg := wsWorkflowRequest(t, ws.ActionWorkflowList, map[string]any{"workspace_id": "ws-1"})
+
+	resp, err := h.wsListWorkflows(context.Background(), msg)
+
+	require.NoError(t, err)
+	payload := wsWorkflowError(t, resp)
+	require.Equal(t, string(ws.ErrorCodeInternalError), payload.Code)
+	require.Equal(t, "Failed to list workflows", payload.Message)
+}
+
+func TestWSCreateWorkflowValidatesRequiredFields(t *testing.T) {
+	repo := workflowFixture()
+	h := newWorkflowHandlers(t, repo, &stubStepLister{})
+
+	for name, tc := range map[string]struct {
+		payload any
+		wantMsg string
+	}{
+		"missing name":      {payload: map[string]any{"workspace_id": "ws-1"}, wantMsg: "name is required"},
+		"missing workspace": {payload: map[string]any{"name": "Flow"}, wantMsg: "workspace_id is required"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			msg := wsWorkflowRequest(t, ws.ActionWorkflowCreate, tc.payload)
+
+			resp, err := h.wsCreateWorkflow(context.Background(), msg)
+
+			require.NoError(t, err)
+			payload := wsWorkflowError(t, resp)
+			require.Equal(t, string(ws.ErrorCodeValidation), payload.Code)
+			require.Equal(t, tc.wantMsg, payload.Message)
+		})
+	}
+	require.Empty(t, repo.created)
+}
+
+func TestWSCreateWorkflowCreatesWorkflow(t *testing.T) {
+	repo := workflowFixture()
+	h := newWorkflowHandlers(t, repo, &stubStepLister{})
+	msg := wsWorkflowRequest(t, ws.ActionWorkflowCreate, map[string]any{
+		"workspace_id": "ws-1", "name": "Flow", "prompt": "p",
+	})
+
+	resp, err := h.wsCreateWorkflow(context.Background(), msg)
+
+	require.NoError(t, err)
+	var created dto.WorkflowDTO
+	wsWorkflowResponse(t, resp, &created)
+	require.Len(t, repo.created, 1)
+	require.Equal(t, repo.created[0].ID, created.ID)
+	require.Equal(t, "Flow", created.Name)
+	require.Equal(t, "ws-1", created.WorkspaceID)
+	require.NotNil(t, created.Prompt)
+	require.Equal(t, "p", *created.Prompt)
+}
+
+func TestWSCreateWorkflowRejectsImproveKandevWorkspace(t *testing.T) {
+	repo := workflowFixture()
+	h := newWorkflowHandlers(t, repo, &stubStepLister{})
+	msg := wsWorkflowRequest(t, ws.ActionWorkflowCreate, map[string]any{
+		"workspace_id": "ws-improve", "name": "Flow",
+	})
+
+	resp, err := h.wsCreateWorkflow(context.Background(), msg)
+
+	require.NoError(t, err)
+	payload := wsWorkflowError(t, resp)
+	require.Equal(t, string(ws.ErrorCodeConflict), payload.Code)
+	require.Equal(t, workspaceReadOnlyMsg, payload.Message)
+	require.Empty(t, repo.created, "the read-only workspace must not gain a workflow")
+}
+
+func TestWSCreateWorkflowReturnsNotFoundForUnknownWorkspace(t *testing.T) {
+	repo := workflowFixture()
+	h := newWorkflowHandlers(t, repo, &stubStepLister{})
+	msg := wsWorkflowRequest(t, ws.ActionWorkflowCreate, map[string]any{
+		"workspace_id": "ws-missing", "name": "Flow",
+	})
+
+	resp, err := h.wsCreateWorkflow(context.Background(), msg)
+
+	require.NoError(t, err)
+	payload := wsWorkflowError(t, resp)
+	require.Equal(t, string(ws.ErrorCodeNotFound), payload.Code)
+	require.Equal(t, "Workspace not found", payload.Message)
+	require.Empty(t, repo.created)
+}
+
+func TestWSGetWorkflowReturnsWorkflowOrErrors(t *testing.T) {
+	repo := workflowFixture()
+	h := newWorkflowHandlers(t, repo, &stubStepLister{})
+
+	resp, err := h.wsGetWorkflow(context.Background(),
+		wsWorkflowRequest(t, ws.ActionWorkflowGet, map[string]any{"id": "wf-1"}))
+	require.NoError(t, err)
+	var got dto.WorkflowDTO
+	wsWorkflowResponse(t, resp, &got)
+	require.Equal(t, "wf-1", got.ID)
+
+	missing, err := h.wsGetWorkflow(context.Background(),
+		wsWorkflowRequest(t, ws.ActionWorkflowGet, map[string]any{"id": "nope"}))
+	require.NoError(t, err)
+	require.Equal(t, string(ws.ErrorCodeNotFound), wsWorkflowError(t, missing).Code)
+
+	empty, err := h.wsGetWorkflow(context.Background(),
+		wsWorkflowRequest(t, ws.ActionWorkflowGet, map[string]any{}))
+	require.NoError(t, err)
+	require.Equal(t, "id is required", wsWorkflowError(t, empty).Message)
+
+	malformed, err := h.wsGetWorkflow(context.Background(), wsMalformedRequest(ws.ActionWorkflowGet))
+	require.NoError(t, err)
+	require.Equal(t, string(ws.ErrorCodeBadRequest), wsWorkflowError(t, malformed).Code)
+}
+
+func TestWSUpdateWorkflowUpdatesFields(t *testing.T) {
+	repo := workflowFixture()
+	h := newWorkflowHandlers(t, repo, &stubStepLister{})
+	msg := wsWorkflowRequest(t, ws.ActionWorkflowUpdate, map[string]any{
+		"id": "wf-1", "name": "Renamed", "description": "next",
+	})
+
+	resp, err := h.wsUpdateWorkflow(context.Background(), msg)
+
+	require.NoError(t, err)
+	var updated dto.WorkflowDTO
+	wsWorkflowResponse(t, resp, &updated)
+	require.Equal(t, "Renamed", updated.Name)
+	require.Len(t, repo.updated, 1)
+	require.Equal(t, "next", repo.updated[0].Description)
+}
+
+func TestWSUpdateWorkflowRequiresID(t *testing.T) {
+	repo := workflowFixture()
+	h := newWorkflowHandlers(t, repo, &stubStepLister{})
+
+	resp, err := h.wsUpdateWorkflow(context.Background(),
+		wsWorkflowRequest(t, ws.ActionWorkflowUpdate, map[string]any{"name": "Renamed"}))
+
+	require.NoError(t, err)
+	payload := wsWorkflowError(t, resp)
+	require.Equal(t, string(ws.ErrorCodeValidation), payload.Code)
+	require.Equal(t, "id is required", payload.Message)
+	require.Empty(t, repo.updated)
+}
+
+func TestWSUpdateWorkflowSurfacesRepositoryFailure(t *testing.T) {
+	repo := workflowFixture()
+	repo.updateErr = errors.New("disk full")
+	h := newWorkflowHandlers(t, repo, &stubStepLister{})
+
+	resp, err := h.wsUpdateWorkflow(context.Background(),
+		wsWorkflowRequest(t, ws.ActionWorkflowUpdate, map[string]any{"id": "wf-1", "name": "Renamed"}))
+
+	require.NoError(t, err)
+	payload := wsWorkflowError(t, resp)
+	require.Equal(t, string(ws.ErrorCodeInternalError), payload.Code)
+	require.Equal(t, "Failed to update workflow", payload.Message)
+}
+
+// TestWSWorkflowMutationsRejectReadOnlyWorkflows is the WS twin of the HTTP
+// read-only test: both reasons, both mutating actions, and no write recorded.
+func TestWSWorkflowMutationsRejectReadOnlyWorkflows(t *testing.T) {
+	for name, tc := range map[string]struct {
+		workflowID string
+		wantMsg    string
+	}{
+		"github synced":     {workflowID: "wf-synced", wantMsg: workflowReadOnlyMsg},
+		"improve workspace": {workflowID: "wf-improve", wantMsg: workspaceReadOnlyMsg},
+	} {
+		t.Run(name, func(t *testing.T) {
+			repo := workflowFixture()
+			h := newWorkflowHandlers(t, repo, &stubStepLister{})
+
+			update, err := h.wsUpdateWorkflow(context.Background(),
+				wsWorkflowRequest(t, ws.ActionWorkflowUpdate, map[string]any{"id": tc.workflowID, "name": "x"}))
+			require.NoError(t, err)
+			updatePayload := wsWorkflowError(t, update)
+			require.Equal(t, string(ws.ErrorCodeConflict), updatePayload.Code)
+			require.Equal(t, tc.wantMsg, updatePayload.Message)
+			require.Empty(t, repo.updated)
+
+			del, err := h.wsDeleteWorkflow(context.Background(),
+				wsWorkflowRequest(t, ws.ActionWorkflowDelete, map[string]any{"id": tc.workflowID}))
+			require.NoError(t, err)
+			deletePayload := wsWorkflowError(t, del)
+			require.Equal(t, string(ws.ErrorCodeConflict), deletePayload.Code)
+			require.Equal(t, tc.wantMsg, deletePayload.Message)
+			require.Empty(t, repo.deleted)
+		})
+	}
+}
+
+func TestWSDeleteWorkflowDeletesEditableWorkflow(t *testing.T) {
+	repo := workflowFixture()
+	h := newWorkflowHandlers(t, repo, &stubStepLister{})
+
+	resp, err := h.wsDeleteWorkflow(context.Background(),
+		wsWorkflowRequest(t, ws.ActionWorkflowDelete, map[string]any{"id": "wf-1"}))
+
+	require.NoError(t, err)
+	var success dto.SuccessResponse
+	wsWorkflowResponse(t, resp, &success)
+	require.True(t, success.Success)
+	require.Equal(t, []string{"wf-1"}, repo.deleted)
+}
+
+func TestWSDeleteWorkflowRequiresID(t *testing.T) {
+	repo := workflowFixture()
+	h := newWorkflowHandlers(t, repo, &stubStepLister{})
+
+	resp, err := h.wsDeleteWorkflow(context.Background(),
+		wsWorkflowRequest(t, ws.ActionWorkflowDelete, map[string]any{}))
+
+	require.NoError(t, err)
+	require.Equal(t, "id is required", wsWorkflowError(t, resp).Message)
+	require.Empty(t, repo.deleted)
+}
+
+func TestWSReorderWorkflowsValidatesRequest(t *testing.T) {
+	repo := workflowFixture()
+	h := newWorkflowHandlers(t, repo, &stubStepLister{})
+
+	for name, tc := range map[string]struct {
+		payload any
+		wantMsg string
+	}{
+		"missing workspace": {
+			payload: map[string]any{"workflow_ids": []string{"wf-1"}},
+			wantMsg: "workspace_id is required",
+		},
+		"missing ids": {
+			payload: map[string]any{"workspace_id": "ws-1"},
+			wantMsg: "workflow_ids is required",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			resp, err := h.wsReorderWorkflows(context.Background(),
+				wsWorkflowRequest(t, ws.ActionWorkflowReorder, tc.payload))
+
+			require.NoError(t, err)
+			payload := wsWorkflowError(t, resp)
+			require.Equal(t, string(ws.ErrorCodeValidation), payload.Code)
+			require.Equal(t, tc.wantMsg, payload.Message)
+		})
+	}
+	require.Nil(t, repo.reordered)
+}
+
+func TestWSReorderWorkflowsRejectsImproveKandevWorkspace(t *testing.T) {
+	repo := workflowFixture()
+	h := newWorkflowHandlers(t, repo, &stubStepLister{})
+
+	resp, err := h.wsReorderWorkflows(context.Background(),
+		wsWorkflowRequest(t, ws.ActionWorkflowReorder, map[string]any{
+			"workspace_id": "ws-improve", "workflow_ids": []string{"wf-improve"},
+		}))
+
+	require.NoError(t, err)
+	payload := wsWorkflowError(t, resp)
+	require.Equal(t, string(ws.ErrorCodeConflict), payload.Code)
+	require.Equal(t, workspaceReadOnlyMsg, payload.Message)
+	require.Nil(t, repo.reordered)
+}
+
+func TestWSReorderWorkflowsPersistsOrder(t *testing.T) {
+	repo := workflowFixture()
+	h := newWorkflowHandlers(t, repo, &stubStepLister{})
+
+	resp, err := h.wsReorderWorkflows(context.Background(),
+		wsWorkflowRequest(t, ws.ActionWorkflowReorder, map[string]any{
+			"workspace_id": "ws-1", "workflow_ids": []string{"wf-office", "wf-1"},
+		}))
+
+	require.NoError(t, err)
+	var success dto.SuccessResponse
+	wsWorkflowResponse(t, resp, &success)
+	require.True(t, success.Success)
+	require.Equal(t, "ws-1", repo.reorderedWorkspace)
+	require.Equal(t, []string{"wf-office", "wf-1"}, repo.reordered)
+}
+
+func TestWSReorderWorkflowsSurfacesRepositoryFailure(t *testing.T) {
+	repo := workflowFixture()
+	repo.reorderErr = errors.New("constraint violation")
+	h := newWorkflowHandlers(t, repo, &stubStepLister{})
+
+	resp, err := h.wsReorderWorkflows(context.Background(),
+		wsWorkflowRequest(t, ws.ActionWorkflowReorder, map[string]any{
+			"workspace_id": "ws-1", "workflow_ids": []string{"wf-1"},
+		}))
+
+	require.NoError(t, err)
+	payload := wsWorkflowError(t, resp)
+	require.Equal(t, string(ws.ErrorCodeInternalError), payload.Code)
+	require.Equal(t, "Failed to reorder workflows", payload.Message)
+}


### PR DESCRIPTION
`internal/task/handlers` was the lowest-covered large package in the backend at 36.4%, with three files (`workflow_handlers.go`, `executor_handlers.go`, `executor_profile_handlers.go`) never executed by a test at all — so per-user scoping and the read-only-workspace guards on those routes were entirely unverified. Coverage is now 65.4% (+990 statements), with the authorization paths covered first.

## Important Changes

- Tests only; no production code was touched.
- Authorization is covered as behavior, not incidentally: every denial test also issues the same request as the resource owner, so a 404 produced by a broken fixture instead of the scoping check fails loudly rather than passing as a false positive.
- Denied mutations assert the repository recorded **no** write, so a guard that refuses the response after committing would still fail.

## Validation

- `cd apps/backend && CGO_ENABLED=1 go test -tags fts5 -race -count=1 -cover ./internal/task/handlers/...` — 36.4% → 65.4%. The four pre-existing `parent directory cannot be accessed` failures (`TestHTTPInitializeLocalRepositoryCreatesRepository`, `TestHTTPInitializeLocalRepositoryMapsClientErrors`, `TestHTTPCreateDirectoryCreatesFolder`, `TestRepositoryMutationsRejectedInImproveKandevWorkspace`) are a task-worktree sandbox artifact, fail identically on a clean checkout, and are unrelated to this change.
- `golangci-lint run ./internal/task/handlers/...` and `golangci-lint run ./... --new-from-rev=origin/main` — 0 issues.
- Verified by mutation — six production changes, each reverted after confirming the expected test failed and named itself:
  1. `httpCreateWorkflow` 201 → 200 — `TestHTTPCreateWorkflowCreatesWorkflow` failed (`expected: 201, actual: 200`).
  2. `httpCreateExecutor` `resumable` default true → false — `TestHTTPCreateExecutorDefaultsStatusAndResumable` failed (`Should be true`).
  3. `httpGetProcess` — dropped the `proc.SessionID != sessionID` re-check — `TestHTTPGetProcessRejectsProcessFromAnotherSession` failed (`expected: 404, actual: 200`).
  4. `Service.authorizeTaskID` — made it always allow — `TestHTTPArchiveTaskDeniesForeignTask` (404 → 200) and all four `TestWSTaskReadsDenyForeignTask` / `TestWSTaskMutationsDenyForeignTask` subtests (`error` → `response`) failed.
  5. `wsDeleteRepositoryScript` — dropped the read-only guard — `TestWSRepositoryScriptMutationsRejectImproveKandevWorkspace` failed (`error` → `response`).
  6. `parseListMessageParams` — dropped `sort` from the pagination switch — `TestHTTPListMessagesSwitchesToPaginationOnAnyCursorParam/sort` failed.

Per-file mean function coverage after: workflow 93.5%, executor 95.5%, executor-profile 95.1%, repository-script 90.1%, message 85.9%, task-http 70.9%, task-ws 70.8%, process 54.7%.

## Possible Improvements

Low risk — test-only. Three pre-existing authorization gaps were found while writing these tests and are reported separately rather than fixed here (the task was scoped to tests): `task.state` and `task.move` reach unauthorized service methods over WS, and `httpDeleteTask` drops the caller identity by building its context from `context.Background()`. Those three entry points are deliberately left uncovered, with comments in the tests explaining why, so nothing here pins the current behavior as intended.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2500?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->