### PR TITLE
fix(agentctl): serialize workspace stream websocket writes

### DIFF
--- a/apps/backend/internal/agentctl/server/api/workspace.go
+++ b/apps/backend/internal/agentctl/server/api/workspace.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"sync"
 
 	"github.com/gin-gonic/gin"
 	"github.com/gorilla/websocket"
@@ -13,6 +14,29 @@ import (
 	"github.com/kandev/kandev/internal/agentctl/types/streams"
 	"go.uber.org/zap"
 )
+
+// workspaceStreamConn is the single seam onto the workspace stream socket.
+//
+// A gorilla *websocket.Conn supports exactly one concurrent writer, and this
+// endpoint has two producers: the event-forwarding loop and the input loop
+// that answers client pings. Both write through WriteJSON, so the lock lives
+// in one place and a future write site cannot forget it.
+type workspaceStreamConn struct {
+	conn    *websocket.Conn
+	writeMu sync.Mutex
+}
+
+// WriteJSON sends one message. Safe for concurrent use.
+func (w *workspaceStreamConn) WriteJSON(msg types.WorkspaceStreamMessage) error {
+	w.writeMu.Lock()
+	defer w.writeMu.Unlock()
+	return w.conn.WriteJSON(msg)
+}
+
+// ReadJSON receives one message. Only the input loop reads, so it needs no lock.
+func (w *workspaceStreamConn) ReadJSON(msg *types.WorkspaceStreamMessage) error {
+	return w.conn.ReadJSON(msg)
+}
 
 // handleWorkspaceStreamWS handles the unified workspace stream WebSocket endpoint.
 // It streams git status, file changes, file lists, and shell I/O over a single connection.
@@ -27,6 +51,8 @@ func (s *Server) handleWorkspaceStreamWS(c *gin.Context) {
 			s.logger.Debug("failed to close workspace stream websocket", zap.Error(err))
 		}
 	}()
+
+	stream := &workspaceStreamConn{conn: conn}
 
 	s.logger.Info("Workspace stream WebSocket connected")
 
@@ -50,7 +76,7 @@ func (s *Server) handleWorkspaceStreamWS(c *gin.Context) {
 
 	// Send connected message
 	connectedMsg := types.NewWorkspaceConnected()
-	if err := conn.WriteJSON(connectedMsg); err != nil {
+	if err := stream.WriteJSON(connectedMsg); err != nil {
 		s.logger.Debug("failed to send connected message", zap.Error(err))
 		return
 	}
@@ -64,9 +90,19 @@ func (s *Server) handleWorkspaceStreamWS(c *gin.Context) {
 	if shell != nil {
 		shellWriter = shell
 	}
-	go s.handleWorkspaceStreamInput(conn, shellWriter, done)
+	go s.handleWorkspaceStreamInput(stream, shellWriter, done)
 
-	// Forward all workspace events to WebSocket
+	s.forwardWorkspaceStream(stream, sub, shellOutputCh, done)
+}
+
+// forwardWorkspaceStream forwards workspace events and shell output to the
+// WebSocket until the client goes away or the handler shuts down.
+func (s *Server) forwardWorkspaceStream(
+	stream *workspaceStreamConn,
+	sub types.WorkspaceStreamSubscriber,
+	shellOutputCh chan []byte,
+	done <-chan struct{},
+) {
 	for {
 		select {
 		case <-done:
@@ -75,7 +111,7 @@ func (s *Server) handleWorkspaceStreamWS(c *gin.Context) {
 			if !ok {
 				return
 			}
-			if err := conn.WriteJSON(msg); err != nil {
+			if err := stream.WriteJSON(msg); err != nil {
 				s.logger.Debug("workspace stream write error", zap.Error(err))
 				return
 			}
@@ -87,7 +123,7 @@ func (s *Server) handleWorkspaceStreamWS(c *gin.Context) {
 			}
 			// Forward shell output as workspace stream message
 			shellMsg := types.NewWorkspaceShellOutput(string(data))
-			if err := conn.WriteJSON(shellMsg); err != nil {
+			if err := stream.WriteJSON(shellMsg); err != nil {
 				s.logger.Debug("workspace stream shell output write error", zap.Error(err))
 				return
 			}
@@ -390,14 +426,14 @@ func (s *Server) handleFileRename(c *gin.Context) {
 	})
 }
 
-func (s *Server) handleWorkspaceStreamInput(conn *websocket.Conn, shell io.Writer, done <-chan struct{}) {
+func (s *Server) handleWorkspaceStreamInput(stream *workspaceStreamConn, shell io.Writer, done <-chan struct{}) {
 	for {
 		select {
 		case <-done:
 			return
 		default:
 			var msg types.WorkspaceStreamMessage
-			if err := conn.ReadJSON(&msg); err != nil {
+			if err := stream.ReadJSON(&msg); err != nil {
 				s.logger.Debug("workspace stream WebSocket read error", zap.Error(err))
 				return
 			}
@@ -412,7 +448,7 @@ func (s *Server) handleWorkspaceStreamInput(conn *websocket.Conn, shell io.Write
 				s.logger.Debug("shell resize requested", zap.Int("cols", msg.Cols), zap.Int("rows", msg.Rows))
 			case types.WorkspaceMessageTypePing:
 				pongMsg := types.NewWorkspacePong()
-				if err := conn.WriteJSON(pongMsg); err != nil {
+				if err := stream.WriteJSON(pongMsg); err != nil {
 					s.logger.Debug("workspace stream pong write error", zap.Error(err))
 					return
 				}

--- a/apps/backend/internal/agentctl/server/api/workspace_stream_concurrency_test.go
+++ b/apps/backend/internal/agentctl/server/api/workspace_stream_concurrency_test.go
@@ -22,8 +22,11 @@ func TestHandleWorkspaceStreamWS_ConcurrentEventsAndPings(t *testing.T) {
 	srv := newTestServer(t)
 	ts, handlerDone := newWorkspaceStreamTestServer(t, srv)
 	conn := dialWorkspaceStream(t, ts)
+	// One deadline for every read in the test, so an unexpected message type
+	// cannot extend the run by a fresh per-message timeout.
+	deadline := workspaceStreamDeadline(t)
 
-	if msg := readWorkspaceStreamMessage(t, conn); msg.Type != types.WorkspaceMessageTypeConnected {
+	if msg := readWorkspaceStreamMessage(t, conn, deadline); msg.Type != types.WorkspaceMessageTypeConnected {
 		t.Fatalf("first message type = %q, want %q", msg.Type, types.WorkspaceMessageTypeConnected)
 	}
 
@@ -60,7 +63,7 @@ func TestHandleWorkspaceStreamWS_ConcurrentEventsAndPings(t *testing.T) {
 		types.WorkspaceMessageTypeGitCommit: false,
 	}
 	for !want[types.WorkspaceMessageTypePong] || !want[types.WorkspaceMessageTypeGitCommit] {
-		msg := readWorkspaceStreamMessage(t, conn)
+		msg := readWorkspaceStreamMessage(t, conn, deadline)
 		if _, tracked := want[msg.Type]; tracked {
 			want[msg.Type] = true
 		}
@@ -98,9 +101,21 @@ func dialWorkspaceStream(t *testing.T, ts *httptest.Server) *websocket.Conn {
 	return conn
 }
 
-func readWorkspaceStreamMessage(t *testing.T, conn *websocket.Conn) types.WorkspaceStreamMessage {
+// workspaceStreamDeadline bounds a whole test's reads. It never outruns the
+// budget `go test -timeout` already enforces, so a stuck server surfaces as a
+// test failure rather than a runner-level panic.
+func workspaceStreamDeadline(t *testing.T) time.Time {
 	t.Helper()
-	if err := conn.SetReadDeadline(time.Now().Add(10 * time.Second)); err != nil {
+	deadline := time.Now().Add(30 * time.Second)
+	if runnerDeadline, ok := t.Deadline(); ok && runnerDeadline.Before(deadline) {
+		return runnerDeadline
+	}
+	return deadline
+}
+
+func readWorkspaceStreamMessage(t *testing.T, conn *websocket.Conn, deadline time.Time) types.WorkspaceStreamMessage {
+	t.Helper()
+	if err := conn.SetReadDeadline(deadline); err != nil {
 		t.Fatalf("SetReadDeadline: %v", err)
 	}
 	var msg types.WorkspaceStreamMessage
@@ -123,20 +138,21 @@ func closeWorkspaceStream(t *testing.T, conn *websocket.Conn) {
 // tracker is nudged until the write fails and the handler unwinds.
 func joinWorkspaceStreamHandler(t *testing.T, srv *Server, done <-chan struct{}) {
 	t.Helper()
-	deadline := time.Now().Add(15 * time.Second)
+	nudge := time.NewTicker(5 * time.Millisecond)
+	defer nudge.Stop()
+	timeout := time.NewTimer(15 * time.Second)
+	defer timeout.Stop()
 	for {
 		select {
 		case <-done:
 			return
-		default:
-		}
-		if time.Now().After(deadline) {
+		case <-timeout.C:
 			t.Fatal("workspace stream handler did not return after client disconnect")
+		case <-nudge.C:
+			srv.procMgr.GetWorkspaceTracker().NotifyGitCommit(&types.GitCommitNotification{
+				Timestamp: time.Now(),
+				CommitSHA: "shutdown-nudge",
+			})
 		}
-		srv.procMgr.GetWorkspaceTracker().NotifyGitCommit(&types.GitCommitNotification{
-			Timestamp: time.Now(),
-			CommitSHA: "shutdown-nudge",
-		})
-		time.Sleep(5 * time.Millisecond)
 	}
 }

--- a/apps/backend/internal/agentctl/server/api/workspace_stream_concurrency_test.go
+++ b/apps/backend/internal/agentctl/server/api/workspace_stream_concurrency_test.go
@@ -1,0 +1,142 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/kandev/kandev/internal/agentctl/types"
+)
+
+// TestHandleWorkspaceStreamWS_ConcurrentEventsAndPings pins the single-writer
+// invariant of the workspace stream: the forwarding loop and the input loop
+// share one *websocket.Conn, and gorilla supports exactly one concurrent
+// writer. Before the write funnel existed, a tracker event racing a client
+// ping tripped the race detector inside Conn.beginMessage.
+func TestHandleWorkspaceStreamWS_ConcurrentEventsAndPings(t *testing.T) {
+	srv := newTestServer(t)
+	ts, handlerDone := newWorkspaceStreamTestServer(t, srv)
+	conn := dialWorkspaceStream(t, ts)
+
+	if msg := readWorkspaceStreamMessage(t, conn); msg.Type != types.WorkspaceMessageTypeConnected {
+		t.Fatalf("first message type = %q, want %q", msg.Type, types.WorkspaceMessageTypeConnected)
+	}
+
+	// Drive both writers at once: the client pings (answered by the input
+	// goroutine) while the tracker broadcasts commits (written by the
+	// forwarding loop).
+	const rounds = 25
+	var writers sync.WaitGroup
+	writers.Add(2)
+	go func() {
+		defer writers.Done()
+		for i := 0; i < rounds; i++ {
+			if err := conn.WriteJSON(types.NewWorkspacePing()); err != nil {
+				return
+			}
+		}
+	}()
+	go func() {
+		defer writers.Done()
+		tracker := srv.procMgr.GetWorkspaceTracker()
+		for i := 0; i < rounds; i++ {
+			tracker.NotifyGitCommit(&types.GitCommitNotification{
+				Timestamp: time.Now(),
+				CommitSHA: fmt.Sprintf("sha-%02d", i),
+			})
+		}
+	}()
+	writers.Wait()
+
+	// Both writers must have reached the wire intact — a corrupted frame
+	// stream shows up here as a decode failure rather than a missing message.
+	want := map[types.WorkspaceMessageType]bool{
+		types.WorkspaceMessageTypePong:      false,
+		types.WorkspaceMessageTypeGitCommit: false,
+	}
+	for !want[types.WorkspaceMessageTypePong] || !want[types.WorkspaceMessageTypeGitCommit] {
+		msg := readWorkspaceStreamMessage(t, conn)
+		if _, tracked := want[msg.Type]; tracked {
+			want[msg.Type] = true
+		}
+	}
+
+	closeWorkspaceStream(t, conn)
+	joinWorkspaceStreamHandler(t, srv, handlerDone)
+	ts.Close()
+}
+
+// newWorkspaceStreamTestServer serves the API router over a real listener and
+// reports when the single expected handler invocation has returned, so
+// goleak-checked tests can join the handler's goroutines.
+func newWorkspaceStreamTestServer(t *testing.T, srv *Server) (*httptest.Server, <-chan struct{}) {
+	t.Helper()
+	done := make(chan struct{})
+	var once sync.Once
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer once.Do(func() { close(done) })
+		srv.router.ServeHTTP(w, r)
+	}))
+	return ts, done
+}
+
+func dialWorkspaceStream(t *testing.T, ts *httptest.Server) *websocket.Conn {
+	t.Helper()
+	url := "ws" + strings.TrimPrefix(ts.URL, "http") + "/api/v1/workspace/stream"
+	conn, resp, err := websocket.DefaultDialer.Dial(url, nil)
+	if err != nil {
+		t.Fatalf("dial %s: %v", url, err)
+	}
+	if resp != nil && resp.Body != nil {
+		_ = resp.Body.Close()
+	}
+	return conn
+}
+
+func readWorkspaceStreamMessage(t *testing.T, conn *websocket.Conn) types.WorkspaceStreamMessage {
+	t.Helper()
+	if err := conn.SetReadDeadline(time.Now().Add(10 * time.Second)); err != nil {
+		t.Fatalf("SetReadDeadline: %v", err)
+	}
+	var msg types.WorkspaceStreamMessage
+	if err := conn.ReadJSON(&msg); err != nil {
+		t.Fatalf("ReadJSON: %v", err)
+	}
+	return msg
+}
+
+func closeWorkspaceStream(t *testing.T, conn *websocket.Conn) {
+	t.Helper()
+	_ = conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
+	if err := conn.Close(); err != nil {
+		t.Fatalf("close client conn: %v", err)
+	}
+}
+
+// joinWorkspaceStreamHandler waits for handleWorkspaceStreamWS to return. The
+// forwarding loop only notices a departed client on its next write, so the
+// tracker is nudged until the write fails and the handler unwinds.
+func joinWorkspaceStreamHandler(t *testing.T, srv *Server, done <-chan struct{}) {
+	t.Helper()
+	deadline := time.Now().Add(15 * time.Second)
+	for {
+		select {
+		case <-done:
+			return
+		default:
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("workspace stream handler did not return after client disconnect")
+		}
+		srv.procMgr.GetWorkspaceTracker().NotifyGitCommit(&types.GitCommitNotification{
+			Timestamp: time.Now(),
+			CommitSHA: "shutdown-nudge",
+		})
+		time.Sleep(5 * time.Millisecond)
+	}
+}

--- a/apps/backend/internal/agentctl/server/api/workspace_stream_concurrency_test.go
+++ b/apps/backend/internal/agentctl/server/api/workspace_stream_concurrency_test.go
@@ -2,14 +2,10 @@ package api
 
 import (
 	"fmt"
-	"net/http"
-	"net/http/httptest"
-	"strings"
 	"sync"
 	"testing"
 	"time"
 
-	"github.com/gorilla/websocket"
 	"github.com/kandev/kandev/internal/agentctl/types"
 )
 
@@ -19,24 +15,10 @@ import (
 // writer. Before the write funnel existed, a tracker event racing a client
 // ping tripped the race detector inside Conn.beginMessage.
 func TestHandleWorkspaceStreamWS_ConcurrentEventsAndPings(t *testing.T) {
-	srv := newTestServer(t)
-	ts, handlerDone := newWorkspaceStreamTestServer(t, srv)
-	conn := dialWorkspaceStream(t, ts)
-	// Registered here rather than at the end of the test: every read below can
-	// t.Fatal, which skips end-of-test statements and would strand the client
-	// conn, the listener, and the handler's goroutines — the forwarding loop
-	// parks in its select — for the rest of the package run. Cleanups are LIFO,
-	// so this joins the handler before the server's own cleanup closes down.
-	t.Cleanup(func() {
-		closeWorkspaceStream(t, conn)
-		joinWorkspaceStreamHandler(t, srv, handlerDone)
-	})
-	// One deadline for every read in the test, so an unexpected message type
-	// cannot extend the run by a fresh per-message timeout.
-	deadline := workspaceStreamDeadline(t)
+	srv, conn := dialWorkspaceStreamEndpoint(t)
 
-	if msg := readWorkspaceStreamMessage(t, conn, deadline); msg.Type != types.WorkspaceMessageTypeConnected {
-		t.Fatalf("first message type = %q, want %q", msg.Type, types.WorkspaceMessageTypeConnected)
+	if got := readWorkspaceMessage(t, conn); got.Type != types.WorkspaceMessageTypeConnected {
+		t.Fatalf("first frame type = %q, want %q", got.Type, types.WorkspaceMessageTypeConnected)
 	}
 
 	// Drive both writers at once: the client pings (answered by the input
@@ -67,101 +49,21 @@ func TestHandleWorkspaceStreamWS_ConcurrentEventsAndPings(t *testing.T) {
 
 	// Both writers must have reached the wire intact — a corrupted frame
 	// stream shows up here as a decode failure rather than a missing message.
+	// The elapsed-time guard bounds the whole drain: readWorkspaceMessage
+	// takes a fresh deadline per call, so an unexpected message type would
+	// otherwise extend the loop one full timeout at a time.
 	want := map[types.WorkspaceMessageType]bool{
 		types.WorkspaceMessageTypePong:      false,
 		types.WorkspaceMessageTypeGitCommit: false,
 	}
+	deadline := time.Now().Add(wsTestTimeout)
 	for !want[types.WorkspaceMessageTypePong] || !want[types.WorkspaceMessageTypeGitCommit] {
-		msg := readWorkspaceStreamMessage(t, conn, deadline)
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out draining the stream; seen = %v", want)
+		}
+		msg := readWorkspaceMessage(t, conn)
 		if _, tracked := want[msg.Type]; tracked {
 			want[msg.Type] = true
-		}
-	}
-}
-
-// newWorkspaceStreamTestServer serves the API router over a real listener and
-// reports when the single expected handler invocation has returned, so
-// goleak-checked tests can join the handler's goroutines.
-func newWorkspaceStreamTestServer(t *testing.T, srv *Server) (*httptest.Server, <-chan struct{}) {
-	t.Helper()
-	done := make(chan struct{})
-	var once sync.Once
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		defer once.Do(func() { close(done) })
-		srv.router.ServeHTTP(w, r)
-	}))
-	t.Cleanup(ts.Close)
-	return ts, done
-}
-
-func dialWorkspaceStream(t *testing.T, ts *httptest.Server) *websocket.Conn {
-	t.Helper()
-	url := "ws" + strings.TrimPrefix(ts.URL, "http") + "/api/v1/workspace/stream"
-	conn, resp, err := websocket.DefaultDialer.Dial(url, nil)
-	if err != nil {
-		t.Fatalf("dial %s: %v", url, err)
-	}
-	if resp != nil && resp.Body != nil {
-		_ = resp.Body.Close()
-	}
-	return conn
-}
-
-// workspaceStreamDeadline bounds a whole test's reads. It never outruns the
-// budget `go test -timeout` already enforces, so a stuck server surfaces as a
-// test failure rather than a runner-level panic.
-func workspaceStreamDeadline(t *testing.T) time.Time {
-	t.Helper()
-	deadline := time.Now().Add(30 * time.Second)
-	if runnerDeadline, ok := t.Deadline(); ok && runnerDeadline.Before(deadline) {
-		return runnerDeadline
-	}
-	return deadline
-}
-
-func readWorkspaceStreamMessage(t *testing.T, conn *websocket.Conn, deadline time.Time) types.WorkspaceStreamMessage {
-	t.Helper()
-	if err := conn.SetReadDeadline(deadline); err != nil {
-		t.Fatalf("SetReadDeadline: %v", err)
-	}
-	var msg types.WorkspaceStreamMessage
-	if err := conn.ReadJSON(&msg); err != nil {
-		t.Fatalf("ReadJSON: %v", err)
-	}
-	return msg
-}
-
-// closeWorkspaceStream reports a close failure with Errorf rather than Fatalf:
-// it runs from a cleanup, and a Fatal there would skip the remaining cleanups
-// that join the handler and shut the listener down.
-func closeWorkspaceStream(t *testing.T, conn *websocket.Conn) {
-	t.Helper()
-	_ = conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
-	if err := conn.Close(); err != nil {
-		t.Errorf("close client conn: %v", err)
-	}
-}
-
-// joinWorkspaceStreamHandler waits for handleWorkspaceStreamWS to return. The
-// forwarding loop only notices a departed client on its next write, so the
-// tracker is nudged until the write fails and the handler unwinds.
-func joinWorkspaceStreamHandler(t *testing.T, srv *Server, done <-chan struct{}) {
-	t.Helper()
-	nudge := time.NewTicker(5 * time.Millisecond)
-	defer nudge.Stop()
-	timeout := time.NewTimer(15 * time.Second)
-	defer timeout.Stop()
-	for {
-		select {
-		case <-done:
-			return
-		case <-timeout.C:
-			t.Fatal("workspace stream handler did not return after client disconnect")
-		case <-nudge.C:
-			srv.procMgr.GetWorkspaceTracker().NotifyGitCommit(&types.GitCommitNotification{
-				Timestamp: time.Now(),
-				CommitSHA: "shutdown-nudge",
-			})
 		}
 	}
 }

--- a/apps/backend/internal/agentctl/server/api/workspace_stream_concurrency_test.go
+++ b/apps/backend/internal/agentctl/server/api/workspace_stream_concurrency_test.go
@@ -22,6 +22,15 @@ func TestHandleWorkspaceStreamWS_ConcurrentEventsAndPings(t *testing.T) {
 	srv := newTestServer(t)
 	ts, handlerDone := newWorkspaceStreamTestServer(t, srv)
 	conn := dialWorkspaceStream(t, ts)
+	// Registered here rather than at the end of the test: every read below can
+	// t.Fatal, which skips end-of-test statements and would strand the client
+	// conn, the listener, and the handler's goroutines — the forwarding loop
+	// parks in its select — for the rest of the package run. Cleanups are LIFO,
+	// so this joins the handler before the server's own cleanup closes down.
+	t.Cleanup(func() {
+		closeWorkspaceStream(t, conn)
+		joinWorkspaceStreamHandler(t, srv, handlerDone)
+	})
 	// One deadline for every read in the test, so an unexpected message type
 	// cannot extend the run by a fresh per-message timeout.
 	deadline := workspaceStreamDeadline(t)
@@ -68,10 +77,6 @@ func TestHandleWorkspaceStreamWS_ConcurrentEventsAndPings(t *testing.T) {
 			want[msg.Type] = true
 		}
 	}
-
-	closeWorkspaceStream(t, conn)
-	joinWorkspaceStreamHandler(t, srv, handlerDone)
-	ts.Close()
 }
 
 // newWorkspaceStreamTestServer serves the API router over a real listener and
@@ -85,6 +90,7 @@ func newWorkspaceStreamTestServer(t *testing.T, srv *Server) (*httptest.Server, 
 		defer once.Do(func() { close(done) })
 		srv.router.ServeHTTP(w, r)
 	}))
+	t.Cleanup(ts.Close)
 	return ts, done
 }
 
@@ -125,11 +131,14 @@ func readWorkspaceStreamMessage(t *testing.T, conn *websocket.Conn, deadline tim
 	return msg
 }
 
+// closeWorkspaceStream reports a close failure with Errorf rather than Fatalf:
+// it runs from a cleanup, and a Fatal there would skip the remaining cleanups
+// that join the handler and shut the listener down.
 func closeWorkspaceStream(t *testing.T, conn *websocket.Conn) {
 	t.Helper()
 	_ = conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
 	if err := conn.Close(); err != nil {
-		t.Fatalf("close client conn: %v", err)
+		t.Errorf("close client conn: %v", err)
 	}
 }
 

--- a/apps/backend/internal/agentctl/server/api/workspace_stream_ws_test.go
+++ b/apps/backend/internal/agentctl/server/api/workspace_stream_ws_test.go
@@ -69,7 +69,7 @@ func dialWorkspaceInputLoop(t *testing.T, shell io.Writer) *websocket.Conn {
 			return
 		}
 		defer func() { _ = conn.Close() }()
-		srv.handleWorkspaceStreamInput(conn, shell, done)
+		srv.handleWorkspaceStreamInput(&workspaceStreamConn{conn: conn}, shell, done)
 		close(loopReturned)
 	}))
 
@@ -89,6 +89,40 @@ func dialWorkspaceInputLoop(t *testing.T, shell io.Writer) *websocket.Conn {
 		httpServer.Close()
 	})
 	return conn
+}
+
+// dialWorkspaceStreamEndpoint drives the whole /workspace/stream endpoint over
+// a real listener and registers the teardown every stream test needs.
+//
+// Cleanups run last-registered-first, so the shutdown loop releases the handler
+// before httpServer.Close, which waits on it. Registering both here, where the
+// resources are created, keeps an early t.Fatal in the caller from stranding
+// the client, the listener, and the handler's goroutines — the forwarding loop
+// parks in its select — for the rest of the package run.
+func dialWorkspaceStreamEndpoint(t *testing.T) (*Server, *websocket.Conn) {
+	t.Helper()
+	srv := newTestServer(t)
+	handlerReturned := make(chan struct{})
+	// sync.Once: a second request to this server — a retry, or a future edit
+	// that dials twice — would otherwise close an already-closed channel and
+	// panic on a server goroutine, taking down the whole test binary.
+	var returnedOnce sync.Once
+	httpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer returnedOnce.Do(func() { close(handlerReturned) })
+		srv.Router().ServeHTTP(w, r)
+	}))
+	t.Cleanup(httpServer.Close)
+
+	conn, _, err := websocket.DefaultDialer.Dial(
+		"ws"+strings.TrimPrefix(httpServer.URL, "http")+"/api/v1/workspace/stream", nil)
+	if err != nil {
+		t.Fatalf("dial workspace stream: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = conn.Close()
+		waitForWorkspaceStreamShutdown(t, srv.procMgr.GetWorkspaceTracker().NotifyGitCommit, handlerReturned)
+	})
+	return srv, conn
 }
 
 func readWorkspaceMessage(t *testing.T, conn *websocket.Conn) types.WorkspaceStreamMessage {
@@ -179,31 +213,7 @@ func TestHandleWorkspaceStreamInput_IgnoresNonInputMessages(t *testing.T) {
 // keeps publishing until the handler returns; the channel, not a fixed sleep,
 // is what the test waits on.
 func TestHandleWorkspaceStreamWS_ForwardsTrackerEvents(t *testing.T) {
-	srv := newTestServer(t)
-	handlerReturned := make(chan struct{})
-	// sync.Once: a second request to this server — a retry, or a future edit
-	// that dials twice — would otherwise close an already-closed channel and
-	// panic on a server goroutine, taking down the whole test binary.
-	var returnedOnce sync.Once
-	httpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		defer returnedOnce.Do(func() { close(handlerReturned) })
-		srv.Router().ServeHTTP(w, r)
-	}))
-
-	conn, _, err := websocket.DefaultDialer.Dial(
-		"ws"+strings.TrimPrefix(httpServer.URL, "http")+"/api/v1/workspace/stream", nil)
-	if err != nil {
-		httpServer.Close()
-		t.Fatalf("dial workspace stream: %v", err)
-	}
-	// Registered before any assertion below can t.Fatal. httpServer.Close waits
-	// for the handler, so it must run after the shutdown loop has released it —
-	// cleanups run last-registered-first, hence this ordering.
-	t.Cleanup(httpServer.Close)
-	t.Cleanup(func() {
-		_ = conn.Close()
-		waitForWorkspaceStreamShutdown(t, srv.procMgr.GetWorkspaceTracker().NotifyGitCommit, handlerReturned)
-	})
+	srv, conn := dialWorkspaceStreamEndpoint(t)
 
 	if got := readWorkspaceMessage(t, conn); got.Type != types.WorkspaceMessageTypeConnected {
 		t.Fatalf("first frame type = %q, want %q", got.Type, types.WorkspaceMessageTypeConnected)
@@ -230,11 +240,13 @@ func TestHandleWorkspaceStreamWS_ForwardsTrackerEvents(t *testing.T) {
 		t.Errorf("message = %q, want %q", event.GitCommit.Message, "streamed commit")
 	}
 
-	// Deliberately no ping here: the input goroutine answers a ping by writing
-	// the pong onto this same connection, while the forwarding loop above is
-	// also writing to it, and a gorilla *Conn permits only one concurrent
-	// writer. Ping/pong is covered against the input loop in isolation by
-	// TestHandleWorkspaceStreamInput_AnswersPing.
+	// The input goroutine answers a ping by writing the pong onto this same
+	// connection while the forwarding loop above also writes to it. Both go
+	// through workspaceStreamConn, so the two writers no longer collide.
+	writeWorkspaceMessage(t, conn, types.NewWorkspacePing())
+	if got := readWorkspaceMessage(t, conn); got.Type != types.WorkspaceMessageTypePong {
+		t.Errorf("reply type = %q, want %q", got.Type, types.WorkspaceMessageTypePong)
+	}
 }
 
 // waitForWorkspaceStreamShutdown republishes until the handler's forwarding


### PR DESCRIPTION
`GET /api/v1/workspace/stream` had two goroutines writing to the same gorilla `*websocket.Conn` — the event-forwarding loop and the input loop that answers client `ping` — which corrupts the frame stream, since a gorilla `*Conn` supports exactly one concurrent writer. Every write now goes through a single mutex-guarded helper, so the connection is single-writer for its whole life.

## Important Changes

- `workspaceStreamConn` wraps the socket: `WriteJSON` takes a mutex, `ReadJSON` does not (only the input loop reads). Every write site — `connected`, workspace events, shell output, `pong` — goes through it, so there is one place that owns the lock and a future write site cannot forget it. This matches `handleAgentStreamWS`, which already guards its shared conn with a `writeMessage` closure; the alternative (routing pongs through the forwarding loop over a channel) would need a buffered or non-blocking send and would silently drop keepalive pongs when a peer stalls.
- The forwarding loop moved into `forwardWorkspaceStream` so `handleWorkspaceStreamWS` stays readable.

Audited the sibling stream handlers; all three are already single-writer, no change needed:

| Handler | Finding |
| --- | --- |
| `handleShellTerminalStreamWS` / `shellTerminalReadLoop` (`shell_terminal.go`) | Clean. The buffer replay writes before the output goroutine is spawned, and the read loop only writes to the PTY (`session`), never to the conn. |
| `runAgentStreamReader` / `runAgentStreamWriter` (`agent.go`) | Already fixed. Both goroutines — plus the per-request goroutine the reader spawns for `ws.MessageTypeRequest` — share one `writeMessage` closure guarded by `writeMu`. |
| `handleLSPStreamWS` (`lsp.go`) | Clean. Every pre-bridge write (`installing`/`installed`/`ready`, close frames) happens on the handler goroutine before `runLSPBridge` starts the forwarder; the concurrent `readFirstLSPClientMessage` goroutine only reads. Inside `runLSPBridge` the forwarder is the sole writer and the main loop only reads and writes to the server's stdin. |

**Merge note:** #2499 merged while this was open, so this branch now carries its `workspace_stream_ws_test.go`. That file called `handleWorkspaceStreamInput` with a bare `*websocket.Conn` and stopped compiling against the wrapper, which is what broke vet, lint, and both backend shards. Reconciled in `0867345`: the call site passes the wrapper, the listener/dial/teardown scaffolding is shared through one `dialWorkspaceStreamEndpoint` helper, the duplicate read/join helpers in my file are gone in favor of #2499's, and `TestHandleWorkspaceStreamWS_ForwardsTrackerEvents` now sends the ping it previously had to omit — with the comment explaining the race deleted, since the race is what this PR fixes.

## Validation

- New regression test `TestHandleWorkspaceStreamWS_ConcurrentEventsAndPings` connects to the stream, then concurrently drives both writers (25 client pings against 25 `NotifyGitCommit` broadcasts) and asserts a `pong` and a `git_commit` both arrive decodable.
- Verified by mutation — on the parent commit, with the identical test file, `-race` reports the race and names the test:
  ```
  WARNING: DATA RACE
  Read at 0x00c00062a1d8 by goroutine 32:
    github.com/gorilla/websocket.(*Conn).beginMessage()
    ...api.(*Server).handleWorkspaceStreamInput()  workspace.go:415
  Previous write at 0x00c00062a1d8 by goroutine 30:
    ...api.(*Server).handleWorkspaceStreamWS()     workspace.go:78
  --- FAIL: TestHandleWorkspaceStreamWS_ConcurrentEventsAndPings (0.01s)
      workspace_stream_concurrency_test.go:63: ReadJSON: unexpected EOF
      testing.go:1712: race detected during execution of test
  ```
  With the fix: `ok github.com/kandev/kandev/internal/agentctl/server/api 20.842s`.
- `cd apps/backend && CGO_ENABLED=1 go test -tags fts5 -race -count=3 ./internal/agentctl/server/api/...` — pass (whole package, `goleak` active).
- `golangci-lint run ./... --new-from-rev=main --timeout=10m` — 0 issues.

## Possible Improvements

Low risk — the change is a lock around writes that were already serialized in the common case.

Out of scope, noticed while in here and worth a follow-up: the forwarding loop only discovers a departed client on its **next write**, so after the peer disconnects the handler sits blocked in `select` until an event happens. The subscription and shell-output subscription stay attached for that whole window. Both regression tests have to work around it — `waitForWorkspaceStreamShutdown` nudges the tracker until the write fails and the handler unwinds. A read-loop-owned cancellation (the input loop closing `done` when `ReadJSON` fails) would fix it, but that is a behavioral change to shutdown, not a race fix.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2502?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
