### PR TITLE
fix(web): show dark mode toggle in mobile menu

### DIFF
--- a/apps/web/components/global-commands.tsx
+++ b/apps/web/components/global-commands.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next";
 import type { TFunction } from "i18next";
 import { useRouter } from "@/lib/routing/client-router";
 import { useTheme } from "@/components/theme/app-theme";
+import { getThemeToggleLabelKey, getThemeToggleTarget } from "@/components/theme/theme-toggle";
 import { IconSun, IconMoon, IconMessageCircle, IconSparkles } from "@tabler/icons-react";
 import { useStaticDestinations } from "@/hooks/use-app-destinations";
 import { PALETTE_NAVIGATION_GROUP_KEY } from "@/lib/navigation/surface-policy";
@@ -98,10 +99,11 @@ function buildThemeCommand(
   t: TFunction,
 ): CommandItem {
   const isDark = resolvedTheme === "dark";
-  const destinationTheme = isDark ? "light" : "dark";
+  const currentTheme = isDark ? "dark" : "light";
+  const destinationTheme = getThemeToggleTarget(currentTheme);
   return {
     id: "pref-theme",
-    label: isDark ? t("common:commandSwitchToLightMode") : t("common:commandSwitchToDarkMode"),
+    label: t(getThemeToggleLabelKey(currentTheme)),
     group: t("common:commandGroupPreferences"),
     icon: isDark ? <IconSun className="size-3.5" /> : <IconMoon className="size-3.5" />,
     keywords: searchKeywords(t, "common:commandThemeKeywords"),

--- a/apps/web/components/kanban/mobile-menu-utility-actions.test.tsx
+++ b/apps/web/components/kanban/mobile-menu-utility-actions.test.tsx
@@ -2,13 +2,20 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MobileUtilityActions } from "./mobile-menu-utility-actions";
 
+const THEME_TOGGLE_TEST_ID = "mobile-theme-toggle-button";
+
 const mocks = vi.hoisted(() => ({
   setTheme: vi.fn(),
-  theme: "light" as "light" | "dark",
+  theme: "light" as "light" | "dark" | "system",
+  resolvedTheme: "light" as "light" | "dark",
 }));
 
 vi.mock("@/components/theme/app-theme", () => ({
-  useTheme: () => ({ theme: mocks.theme, setTheme: mocks.setTheme }),
+  useTheme: () => ({
+    theme: mocks.theme,
+    resolvedTheme: mocks.resolvedTheme,
+    setTheme: mocks.setTheme,
+  }),
 }));
 vi.mock("@/hooks/use-app-destinations", () => ({
   useStaticDestinations: () => [],
@@ -30,6 +37,7 @@ describe("MobileUtilityActions", () => {
   beforeEach(() => {
     mocks.setTheme.mockClear();
     mocks.theme = "light";
+    mocks.resolvedTheme = "light";
   });
 
   function renderComponent() {
@@ -45,19 +53,36 @@ describe("MobileUtilityActions", () => {
 
   it("renders a theme toggle button", () => {
     renderComponent();
-    expect(screen.getByTestId("mobile-theme-toggle-button")).toBeTruthy();
+    expect(screen.getByTestId(THEME_TOGGLE_TEST_ID)).toBeTruthy();
   });
 
   it("switches from light to dark on click", () => {
     renderComponent();
-    fireEvent.click(screen.getByTestId("mobile-theme-toggle-button"));
+    fireEvent.click(screen.getByTestId(THEME_TOGGLE_TEST_ID));
     expect(mocks.setTheme).toHaveBeenCalledWith("dark");
   });
 
   it("switches from dark to light on click", () => {
     mocks.theme = "dark";
+    mocks.resolvedTheme = "dark";
     renderComponent();
-    fireEvent.click(screen.getByTestId("mobile-theme-toggle-button"));
+    fireEvent.click(screen.getByTestId(THEME_TOGGLE_TEST_ID));
     expect(mocks.setTheme).toHaveBeenCalledWith("light");
+  });
+
+  it("uses resolvedTheme when theme is 'system' and the OS prefers dark", () => {
+    mocks.theme = "system";
+    mocks.resolvedTheme = "dark";
+    renderComponent();
+    fireEvent.click(screen.getByTestId(THEME_TOGGLE_TEST_ID));
+    expect(mocks.setTheme).toHaveBeenCalledWith("light");
+  });
+
+  it("uses resolvedTheme when theme is 'system' and the OS prefers light", () => {
+    mocks.theme = "system";
+    mocks.resolvedTheme = "light";
+    renderComponent();
+    fireEvent.click(screen.getByTestId(THEME_TOGGLE_TEST_ID));
+    expect(mocks.setTheme).toHaveBeenCalledWith("dark");
   });
 });

--- a/apps/web/components/kanban/mobile-menu-utility-actions.test.tsx
+++ b/apps/web/components/kanban/mobile-menu-utility-actions.test.tsx
@@ -1,0 +1,63 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MobileUtilityActions } from "./mobile-menu-utility-actions";
+
+const mocks = vi.hoisted(() => ({
+  setTheme: vi.fn(),
+  theme: "light" as "light" | "dark",
+}));
+
+vi.mock("@/components/theme/app-theme", () => ({
+  useTheme: () => ({ theme: mocks.theme, setTheme: mocks.setTheme }),
+}));
+vi.mock("@/hooks/use-app-destinations", () => ({
+  useStaticDestinations: () => [],
+}));
+vi.mock("@/components/app-status-bar/app-status-surface-provider", () => ({
+  useAppStatusDrawer: () => ({
+    enabled: false,
+    issueSeverity: "none",
+    openStatusDrawer: vi.fn(),
+  }),
+}));
+vi.mock("@/components/app-status-bar/connection-status-item", () => ({
+  useConnectionIssueCopy: () => null,
+}));
+
+afterEach(cleanup);
+
+describe("MobileUtilityActions", () => {
+  beforeEach(() => {
+    mocks.setTheme.mockClear();
+    mocks.theme = "light";
+  });
+
+  function renderComponent() {
+    return render(
+      <MobileUtilityActions
+        showHealthIndicator={false}
+        onOpenHealthDialog={vi.fn()}
+        onOpenImproveKandev={vi.fn()}
+        onOpenChange={vi.fn()}
+      />,
+    );
+  }
+
+  it("renders a theme toggle button", () => {
+    renderComponent();
+    expect(screen.getByTestId("mobile-theme-toggle-button")).toBeTruthy();
+  });
+
+  it("switches from light to dark on click", () => {
+    renderComponent();
+    fireEvent.click(screen.getByTestId("mobile-theme-toggle-button"));
+    expect(mocks.setTheme).toHaveBeenCalledWith("dark");
+  });
+
+  it("switches from dark to light on click", () => {
+    mocks.theme = "dark";
+    renderComponent();
+    fireEvent.click(screen.getByTestId("mobile-theme-toggle-button"));
+    expect(mocks.setTheme).toHaveBeenCalledWith("light");
+  });
+});

--- a/apps/web/components/kanban/mobile-menu-utility-actions.test.tsx
+++ b/apps/web/components/kanban/mobile-menu-utility-actions.test.tsx
@@ -85,4 +85,22 @@ describe("MobileUtilityActions", () => {
     fireEvent.click(screen.getByTestId(THEME_TOGGLE_TEST_ID));
     expect(mocks.setTheme).toHaveBeenCalledWith("dark");
   });
+
+  it("exposes the target theme and current state to assistive technology", () => {
+    renderComponent();
+
+    const toggle = screen.getByTestId(THEME_TOGGLE_TEST_ID);
+    expect(toggle.getAttribute("aria-label")).toBe("Switch to Dark Mode");
+    expect(toggle.getAttribute("aria-pressed")).toBe("false");
+  });
+
+  it("updates the accessible target and pressed state for a resolved dark theme", () => {
+    mocks.theme = "system";
+    mocks.resolvedTheme = "dark";
+    renderComponent();
+
+    const toggle = screen.getByTestId(THEME_TOGGLE_TEST_ID);
+    expect(toggle.getAttribute("aria-label")).toBe("Switch to Light Mode");
+    expect(toggle.getAttribute("aria-pressed")).toBe("true");
+  });
 });

--- a/apps/web/components/kanban/mobile-menu-utility-actions.tsx
+++ b/apps/web/components/kanban/mobile-menu-utility-actions.tsx
@@ -15,6 +15,7 @@ import { MOBILE_MENU_UTILITY_SECTIONS } from "@/lib/navigation/surface-policy";
 import { useAppStatusDrawer } from "@/components/app-status-bar/app-status-surface-provider";
 import { useConnectionIssueCopy } from "@/components/app-status-bar/connection-status-item";
 import { useTheme } from "@/components/theme/app-theme";
+import { getThemeToggleLabelKey, getThemeToggleTarget } from "@/components/theme/theme-toggle";
 import { cn } from "@/lib/utils";
 import {
   mobileControlClass,
@@ -37,6 +38,7 @@ export function MobileUtilityActions({
   const { enabled: statusDrawerEnabled, issueSeverity, openStatusDrawer } = useAppStatusDrawer();
   const issueDetails = useConnectionIssueCopy(issueSeverity);
   const { resolvedTheme, setTheme } = useTheme();
+  const themeToggleTarget = getThemeToggleTarget(resolvedTheme);
   // Stats, Settings, and anything else added to the manifest's insight/utility
   // sections. Before the manifest, this block hardcoded a Settings link and
   // Stats had no phone entry point at all.
@@ -82,8 +84,10 @@ export function MobileUtilityActions({
         type="button"
         variant="outline"
         className={cn(mobileControlClass, "h-11 cursor-pointer justify-start gap-3")}
-        onClick={() => setTheme(resolvedTheme === "dark" ? "light" : "dark")}
+        onClick={() => setTheme(themeToggleTarget)}
         data-testid="mobile-theme-toggle-button"
+        aria-label={t(getThemeToggleLabelKey(resolvedTheme))}
+        aria-pressed={resolvedTheme === "dark"}
       >
         {resolvedTheme === "dark" ? (
           <IconSun className={mobileControlIconClass} />

--- a/apps/web/components/kanban/mobile-menu-utility-actions.tsx
+++ b/apps/web/components/kanban/mobile-menu-utility-actions.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import { IconActivity, IconAlertTriangle, IconStethoscope } from "@tabler/icons-react";
+import {
+  IconActivity,
+  IconAlertTriangle,
+  IconMoon,
+  IconStethoscope,
+  IconSun,
+} from "@tabler/icons-react";
 import { Button } from "@kandev/ui/button";
 import { useTranslation } from "react-i18next";
 import { DestinationRows } from "@/components/navigation/destination-rows";
@@ -8,6 +14,7 @@ import { useStaticDestinations } from "@/hooks/use-app-destinations";
 import { MOBILE_MENU_UTILITY_SECTIONS } from "@/lib/navigation/surface-policy";
 import { useAppStatusDrawer } from "@/components/app-status-bar/app-status-surface-provider";
 import { useConnectionIssueCopy } from "@/components/app-status-bar/connection-status-item";
+import { useTheme } from "@/components/theme/app-theme";
 import { cn } from "@/lib/utils";
 import {
   mobileControlClass,
@@ -29,6 +36,7 @@ export function MobileUtilityActions({
   const { t } = useTranslation();
   const { enabled: statusDrawerEnabled, issueSeverity, openStatusDrawer } = useAppStatusDrawer();
   const issueDetails = useConnectionIssueCopy(issueSeverity);
+  const { theme, setTheme } = useTheme();
   // Stats, Settings, and anything else added to the manifest's insight/utility
   // sections. Before the manifest, this block hardcoded a Settings link and
   // Stats had no phone entry point at all.
@@ -70,6 +78,20 @@ export function MobileUtilityActions({
           )}
         </Button>
       )}
+      <Button
+        type="button"
+        variant="outline"
+        className={cn(mobileControlClass, "cursor-pointer justify-start gap-3")}
+        onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+        data-testid="mobile-theme-toggle-button"
+      >
+        {theme === "dark" ? (
+          <IconSun className={mobileControlIconClass} />
+        ) : (
+          <IconMoon className={mobileControlIconClass} />
+        )}
+        {t("sidebar:toggleTheme")}
+      </Button>
       <DestinationRows
         destinations={destinations}
         onNavigate={closeSheet}

--- a/apps/web/components/kanban/mobile-menu-utility-actions.tsx
+++ b/apps/web/components/kanban/mobile-menu-utility-actions.tsx
@@ -36,7 +36,7 @@ export function MobileUtilityActions({
   const { t } = useTranslation();
   const { enabled: statusDrawerEnabled, issueSeverity, openStatusDrawer } = useAppStatusDrawer();
   const issueDetails = useConnectionIssueCopy(issueSeverity);
-  const { theme, setTheme } = useTheme();
+  const { resolvedTheme, setTheme } = useTheme();
   // Stats, Settings, and anything else added to the manifest's insight/utility
   // sections. Before the manifest, this block hardcoded a Settings link and
   // Stats had no phone entry point at all.
@@ -81,11 +81,11 @@ export function MobileUtilityActions({
       <Button
         type="button"
         variant="outline"
-        className={cn(mobileControlClass, "cursor-pointer justify-start gap-3")}
-        onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+        className={cn(mobileControlClass, "h-11 cursor-pointer justify-start gap-3")}
+        onClick={() => setTheme(resolvedTheme === "dark" ? "light" : "dark")}
         data-testid="mobile-theme-toggle-button"
       >
-        {theme === "dark" ? (
+        {resolvedTheme === "dark" ? (
           <IconSun className={mobileControlIconClass} />
         ) : (
           <IconMoon className={mobileControlIconClass} />

--- a/apps/web/components/theme-toggle.test.tsx
+++ b/apps/web/components/theme-toggle.test.tsx
@@ -1,0 +1,35 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ThemeToggle } from "./theme-toggle";
+
+const mocks = vi.hoisted(() => ({
+  setTheme: vi.fn(),
+  theme: "system" as "light" | "dark" | "system",
+  resolvedTheme: "dark" as "light" | "dark",
+}));
+
+vi.mock("@/components/theme/app-theme", () => ({
+  useTheme: () => ({
+    theme: mocks.theme,
+    resolvedTheme: mocks.resolvedTheme,
+    setTheme: mocks.setTheme,
+  }),
+}));
+
+afterEach(cleanup);
+
+describe("ThemeToggle", () => {
+  beforeEach(() => {
+    mocks.setTheme.mockClear();
+    mocks.theme = "system";
+    mocks.resolvedTheme = "dark";
+  });
+
+  it("switches from the resolved dark theme to light when the saved theme is system", () => {
+    render(<ThemeToggle />);
+
+    fireEvent.click(screen.getByRole("button"));
+
+    expect(mocks.setTheme).toHaveBeenCalledWith("light");
+  });
+});

--- a/apps/web/components/theme-toggle.tsx
+++ b/apps/web/components/theme-toggle.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useTheme } from "@/components/theme/app-theme";
+import { getThemeToggleLabelKey, getThemeToggleTarget } from "@/components/theme/theme-toggle";
 import { IconMoon, IconSun } from "@tabler/icons-react";
 import { Button } from "@kandev/ui/button";
 import { useSyncExternalStore } from "react";
@@ -8,7 +9,9 @@ import { useTranslation } from "react-i18next";
 
 export function ThemeToggle() {
   const { t } = useTranslation();
-  const { theme, setTheme } = useTheme();
+  const { resolvedTheme, setTheme } = useTheme();
+  const targetTheme = getThemeToggleTarget(resolvedTheme);
+  const labelKey = getThemeToggleLabelKey(resolvedTheme);
   const mounted = useSyncExternalStore(
     () => () => {},
     () => true,
@@ -23,11 +26,16 @@ export function ThemeToggle() {
     <Button
       variant="ghost"
       size="sm"
-      onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+      onClick={() => setTheme(targetTheme)}
       className="h-9 w-9 p-0"
+      aria-label={t(labelKey)}
+      aria-pressed={resolvedTheme === "dark"}
     >
-      {theme === "dark" ? <IconSun className="h-4 w-4" /> : <IconMoon className="h-4 w-4" />}
-      <span className="sr-only">{t("sidebar:toggleTheme")}</span>
+      {resolvedTheme === "dark" ? (
+        <IconSun className="h-4 w-4" />
+      ) : (
+        <IconMoon className="h-4 w-4" />
+      )}
     </Button>
   );
 }

--- a/apps/web/components/theme/app-theme.tsx
+++ b/apps/web/components/theme/app-theme.tsx
@@ -11,7 +11,7 @@ import {
 } from "react";
 
 type Theme = "light" | "dark" | "system";
-type ResolvedTheme = "light" | "dark";
+export type ResolvedTheme = "light" | "dark";
 
 type ThemeContextValue = {
   theme: Theme;

--- a/apps/web/components/theme/theme-toggle.ts
+++ b/apps/web/components/theme/theme-toggle.ts
@@ -1,0 +1,15 @@
+import type { ResolvedTheme } from "./app-theme";
+
+export type ThemeToggleLabelKey =
+  | "common:commandSwitchToDarkMode"
+  | "common:commandSwitchToLightMode";
+
+export function getThemeToggleTarget(resolvedTheme: ResolvedTheme): ResolvedTheme {
+  return resolvedTheme === "dark" ? "light" : "dark";
+}
+
+export function getThemeToggleLabelKey(resolvedTheme: ResolvedTheme): ThemeToggleLabelKey {
+  return resolvedTheme === "dark"
+    ? "common:commandSwitchToLightMode"
+    : "common:commandSwitchToDarkMode";
+}

--- a/apps/web/e2e/tests/kanban/mobile-menu-theme-toggle.spec.ts
+++ b/apps/web/e2e/tests/kanban/mobile-menu-theme-toggle.spec.ts
@@ -1,13 +1,41 @@
+import { devices, type Browser } from "@playwright/test";
 import { test, expect } from "../../fixtures/test-base";
+import type { BackendContext } from "../../fixtures/backend";
 import { MobileKanbanPage } from "../../pages/mobile-kanban-page";
 
 /**
  * Mobile parity for the desktop sidebar footer's theme toggle. The footer is
- * desktop-only (`hidden md:block`), so on a phone viewport dark mode used to
- * be entirely unreachable — the hamburger sheet's Utilities section had no
- * theme control at all. This proves the toggle is reachable there and that a
- * tap actually flips the app's resolved theme (not just that a row renders).
+ * desktop-only (`hidden md:block`), so on a phone viewport there used to be no
+ * *quick* way to flip dark mode — Settings still has the theme select, but
+ * the hamburger sheet's Utilities section had no one-tap control. This proves
+ * the toggle is reachable there and that a tap actually flips the app's
+ * resolved theme (not just that a row renders).
  */
+
+/**
+ * A second mobile client with the OS/browser color scheme forced to dark, so
+ * a fresh session's `theme: "system"` resolves to `resolvedTheme: "dark"`
+ * before any tap. This is the state where a toggle keyed off `theme` instead
+ * of `resolvedTheme` looks correct while actually being a no-op on first tap.
+ */
+async function openDarkModeMobileContext(browser: Browser, backend: BackendContext) {
+  const context = await browser.newContext({
+    ...devices["Pixel 5"],
+    baseURL: backend.frontendUrl,
+    colorScheme: "dark",
+  });
+  const page = await context.newPage();
+  await page.addInitScript(
+    ({ backendPort }: { backendPort: string }) => {
+      localStorage.setItem("kandev.onboarding.completed", "true");
+      window.__KANDEV_API_PORT = backendPort;
+      window.__KANDEV_E2E_EXPOSE_STORE__ = true;
+    },
+    { backendPort: String(backend.port) },
+  );
+  return { page, context };
+}
+
 test.describe("Theme toggle on mobile", () => {
   test("exposes a theme toggle in the hamburger sheet and flips the resolved theme", async ({
     testPage,
@@ -40,5 +68,40 @@ test.describe("Theme toggle on mobile", () => {
     await themeToggle.click();
     await expect(html).toHaveClass(/(^|\s)light(\s|$)/);
     await expect(html).not.toHaveClass(/(^|\s)dark(\s|$)/);
+  });
+
+  test("flips out of dark mode on the first tap when the OS already prefers dark", async ({
+    testPage: _testPage,
+    browser,
+    backend,
+  }) => {
+    // Depend on testPage so its per-test backend and settings reset runs
+    // before this specialized dark-mode context is created.
+    const { page, context } = await openDarkModeMobileContext(browser, backend);
+    try {
+      const kanban = new MobileKanbanPage(page);
+      await kanban.goto();
+
+      // theme is still "system", but resolvedTheme is already "dark" because
+      // the browser's color scheme is forced dark — exactly the state the
+      // buggy `theme === "dark"` comparison could not distinguish from light.
+      const html = page.locator("html");
+      await expect(html).toHaveClass(/(^|\s)dark(\s|$)/);
+
+      await kanban.mobileMenuButton.click();
+      const sheet = page.getByRole("dialog");
+      const themeToggle = sheet.getByTestId("mobile-theme-toggle-button");
+      await expect(themeToggle).toBeVisible({ timeout: 10_000 });
+
+      await themeToggle.click();
+
+      // One tap must be enough to leave dark mode. A toggle keyed off the raw
+      // `theme` value ("system") instead of `resolvedTheme` ("dark") would
+      // call setTheme("dark") here and this assertion would time out.
+      await expect(html).toHaveClass(/(^|\s)light(\s|$)/);
+      await expect(html).not.toHaveClass(/(^|\s)dark(\s|$)/);
+    } finally {
+      await context.close();
+    }
   });
 });

--- a/apps/web/e2e/tests/kanban/mobile-menu-theme-toggle.spec.ts
+++ b/apps/web/e2e/tests/kanban/mobile-menu-theme-toggle.spec.ts
@@ -48,26 +48,32 @@ test.describe("Theme toggle on mobile", () => {
     const html = testPage.locator("html");
     await expect(html).toHaveClass(/(^|\s)light(\s|$)/);
 
-    await kanban.mobileMenuButton.click();
+    await kanban.mobileMenuButton.tap();
 
     const sheet = testPage.getByRole("dialog");
     const themeToggle = sheet.getByTestId("mobile-theme-toggle-button");
     await expect(themeToggle).toBeVisible({ timeout: 10_000 });
+    await expect(themeToggle).toHaveAttribute("aria-label", "Switch to Dark Mode");
+    await expect(themeToggle).toHaveAttribute("aria-pressed", "false");
 
-    await themeToggle.click();
+    await themeToggle.tap();
 
     // The real downstream effect: AppThemeProvider re-applies the resolved
     // theme class on <html>, not just local component state.
     await expect(html).toHaveClass(/(^|\s)dark(\s|$)/);
     await expect(html).not.toHaveClass(/(^|\s)light(\s|$)/);
+    await expect(themeToggle).toHaveAttribute("aria-label", "Switch to Light Mode");
+    await expect(themeToggle).toHaveAttribute("aria-pressed", "true");
 
     // The sheet stays open (unlike the navigation rows above it, this is a
     // persistent toggle, not a navigate-and-close action).
     await expect(sheet).toBeVisible();
 
-    await themeToggle.click();
+    await themeToggle.tap();
     await expect(html).toHaveClass(/(^|\s)light(\s|$)/);
     await expect(html).not.toHaveClass(/(^|\s)dark(\s|$)/);
+    await expect(themeToggle).toHaveAttribute("aria-label", "Switch to Dark Mode");
+    await expect(themeToggle).toHaveAttribute("aria-pressed", "false");
   });
 
   test("flips out of dark mode on the first tap when the OS already prefers dark", async ({
@@ -88,18 +94,22 @@ test.describe("Theme toggle on mobile", () => {
       const html = page.locator("html");
       await expect(html).toHaveClass(/(^|\s)dark(\s|$)/);
 
-      await kanban.mobileMenuButton.click();
+      await kanban.mobileMenuButton.tap();
       const sheet = page.getByRole("dialog");
       const themeToggle = sheet.getByTestId("mobile-theme-toggle-button");
       await expect(themeToggle).toBeVisible({ timeout: 10_000 });
+      await expect(themeToggle).toHaveAttribute("aria-label", "Switch to Light Mode");
+      await expect(themeToggle).toHaveAttribute("aria-pressed", "true");
 
-      await themeToggle.click();
+      await themeToggle.tap();
 
       // One tap must be enough to leave dark mode. A toggle keyed off the raw
       // `theme` value ("system") instead of `resolvedTheme` ("dark") would
       // call setTheme("dark") here and this assertion would time out.
       await expect(html).toHaveClass(/(^|\s)light(\s|$)/);
       await expect(html).not.toHaveClass(/(^|\s)dark(\s|$)/);
+      await expect(themeToggle).toHaveAttribute("aria-label", "Switch to Dark Mode");
+      await expect(themeToggle).toHaveAttribute("aria-pressed", "false");
     } finally {
       await context.close();
     }

--- a/apps/web/e2e/tests/kanban/mobile-menu-theme-toggle.spec.ts
+++ b/apps/web/e2e/tests/kanban/mobile-menu-theme-toggle.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from "../../fixtures/test-base";
+import { MobileKanbanPage } from "../../pages/mobile-kanban-page";
+
+/**
+ * Mobile parity for the desktop sidebar footer's theme toggle. The footer is
+ * desktop-only (`hidden md:block`), so on a phone viewport dark mode used to
+ * be entirely unreachable — the hamburger sheet's Utilities section had no
+ * theme control at all. This proves the toggle is reachable there and that a
+ * tap actually flips the app's resolved theme (not just that a row renders).
+ */
+test.describe("Theme toggle on mobile", () => {
+  test("exposes a theme toggle in the hamburger sheet and flips the resolved theme", async ({
+    testPage,
+  }) => {
+    const kanban = new MobileKanbanPage(testPage);
+    await kanban.goto();
+
+    // Fresh session defaults to the "system" theme, which resolves to light
+    // in a headless Chromium profile with no forced color scheme.
+    const html = testPage.locator("html");
+    await expect(html).toHaveClass(/(^|\s)light(\s|$)/);
+
+    await kanban.mobileMenuButton.click();
+
+    const sheet = testPage.getByRole("dialog");
+    const themeToggle = sheet.getByTestId("mobile-theme-toggle-button");
+    await expect(themeToggle).toBeVisible({ timeout: 10_000 });
+
+    await themeToggle.click();
+
+    // The real downstream effect: AppThemeProvider re-applies the resolved
+    // theme class on <html>, not just local component state.
+    await expect(html).toHaveClass(/(^|\s)dark(\s|$)/);
+    await expect(html).not.toHaveClass(/(^|\s)light(\s|$)/);
+
+    // The sheet stays open (unlike the navigation rows above it, this is a
+    // persistent toggle, not a navigate-and-close action).
+    await expect(sheet).toBeVisible();
+
+    await themeToggle.click();
+    await expect(html).toHaveClass(/(^|\s)light(\s|$)/);
+    await expect(html).not.toHaveClass(/(^|\s)dark(\s|$)/);
+  });
+});


### PR DESCRIPTION
The desktop sidebar footer's dark mode toggle is hidden on mobile (`hidden md:block`), so phone users had no quick way to flip themes — only a full trip through Settings. This adds a "Toggle theme" row to the mobile hamburger menu's Utilities section, keyed off `resolvedTheme` so it works correctly even for the default `system` theme on a device with OS dark mode enabled.

## Important Changes

- The toggle reads `resolvedTheme` (not the raw `theme` state) for both the icon and the click target, matching the existing pattern in `global-commands.tsx` — a `theme`-keyed version looks correct on a light-default device but is a visible no-op on the first tap for anyone whose OS already prefers dark.

## Validation

- `pnpm exec vitest run components/kanban/mobile-menu-utility-actions.test.tsx components/kanban/mobile-menu-sheet.test.tsx` — 10/10 passing, including cases for `theme: "system"` resolving to both light and dark.
- `pnpm e2e:run --host --project mobile-chrome -- tests/kanban/mobile-menu-theme-toggle.spec.ts` — 2/2 passing: a light-start flip and a dark-start flip (`colorScheme: "dark"`) that proves one tap is enough to leave dark mode.
- `make typecheck test lint` and `make lint-format` — all clean. `test-backend`/`test-web`/`test-scripts` have pre-existing failures unrelated to this change (Docker not running locally, macOS temp-dir behavior, a `gh`/`glab` path-resolution test, an unbound-variable script test) — each reproduced identically against the merge-base commit in a scratch worktree before this PR.
- `pnpm run i18n:ratchet` — clean; reuses the existing `sidebar:toggleTheme` key already present in all four locale catalogs, no new strings added.
- Targeted `make test-e2e` run partially (`routing`, `auth`, `chromium` through ~611/1683 tests) before being stopped in favor of CI's sharded/parallel run of the same suite: no failure touched a file this PR changed (kanban/theme/mobile), all 14 failures observed were in unrelated chat/PR/automations specs consistent with local single-worker flakiness (no retries locally vs. CI's 2x retry).
- Manual verification: screenshots of the rendered mobile menu confirmed the row, icon, and row height (44px, matching its siblings) visually.

## Possible Improvements

- Low risk. One residual test-rigor gap: no automated test currently asserts which icon (sun vs. moon) renders for a given `resolvedTheme` — a future regression there would ship green. A follow-up assertion (e.g. a `data-testid` per icon) would close it.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.

## Screenshots

<!-- kandev-screenshots-start -->
![Mobile hamburger menu with the new Toggle theme row under Status](https://raw.githubusercontent.com/nova28/kandev/e897a6490192a573ffbfa3b0e105cfb771765234/mobile-menu-theme-toggle.png)
<!-- kandev-screenshots-end -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2514?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->