### PR TITLE
fix(backend): auto-link gitlab mrs for self-managed hosts

### DIFF
--- a/apps/backend/internal/orchestrator/event_handlers_git.go
+++ b/apps/backend/internal/orchestrator/event_handlers_git.go
@@ -337,7 +337,11 @@ func (s *Service) resolvePushRepositoryProvider(ctx context.Context, sessionID, 
 	// repositories, not just a narrow backfill race. remote_url is their only
 	// durable identity signal (still populated by the same production
 	// backfill), so compare it against the workspace's own configured GitLab
-	// connection instead of a hostname allowlist.
+	// connection instead of a hostname allowlist. This gap is scoped to the
+	// Provider tag only: the project path (owner/name) these repositories
+	// need for MR auto-linking has its own remote_url/local-checkout fallback
+	// in resolveGitLabPushProject (event_handlers_gitlab_mr.go), so a missing
+	// tag here does not by itself block auto-link.
 	if s.gitlabMRLinkService != nil && repoObj.RemoteURL != "" {
 		if workspaceID := s.taskWorkspaceID(ctx, taskID); workspaceID != "" &&
 			s.gitlabMRLinkService.IsConfiguredGitLabHost(ctx, workspaceID, repoObj.RemoteURL) {

--- a/apps/backend/internal/orchestrator/event_handlers_git.go
+++ b/apps/backend/internal/orchestrator/event_handlers_git.go
@@ -284,15 +284,113 @@ func (s *Service) trackPushAndAssociatePR(ctx context.Context, data watcher.GitE
 // provider's association logic, so the two providers' code paths issue zero
 // calls into each other's client. GitHub's proven detectPushAndAssociatePR is
 // called verbatim for every non-GitLab (including unknown/legacy-empty
-// provider) repository — this wraps it, it does not replace it. Extracted
-// from trackPushAndAssociatePR to keep that function inside the statement
-// budget.
+// provider) repository — this passes the shared repository identity into the
+// existing provider-specific path. Extracted from trackPushAndAssociatePR to
+// keep that function inside the statement budget.
 func (s *Service) dispatchPushDetection(ctx context.Context, sessionID, taskID, repositoryName, branch string) {
-	if s.resolvePushRepositoryProvider(ctx, sessionID, taskID, repositoryName) == gitlabProviderName {
-		s.detectPushAndAssociateMR(ctx, sessionID, taskID, repositoryName, branch)
+	identity := s.resolvePushRepositoryIdentity(ctx, sessionID, taskID, repositoryName)
+	if identity.provider == gitlabProviderName {
+		s.detectPushAndAssociateMRWithIdentity(ctx, sessionID, taskID, repositoryName, branch, identity)
 		return
 	}
-	s.detectPushAndAssociatePR(ctx, sessionID, taskID, repositoryName, branch)
+	if s.githubService == nil {
+		return
+	}
+	s.detectPushAndAssociatePRWithIdentity(ctx, sessionID, taskID, repositoryName, branch, identity)
+}
+
+type pushRepositoryIdentity struct {
+	owner        string
+	name         string
+	repositoryID string
+	provider     string
+	projectPath  string
+}
+
+// resolvePushRepositoryIdentity resolves the repository, provider, and full
+// project path from one repository snapshot. Local checkout fallbacks are
+// shared by routing and association so a legacy row cannot be routed from one
+// identity while its provider-specific lookup uses another.
+func (s *Service) resolvePushRepositoryIdentity(
+	ctx context.Context, sessionID, taskID, repositoryName string,
+) pushRepositoryIdentity {
+	owner, name, repositoryID := s.resolvePushRepo(ctx, sessionID, taskID, repositoryName)
+	identity := pushRepositoryIdentity{
+		owner:        owner,
+		name:         name,
+		repositoryID: repositoryID,
+	}
+	if owner != "" && name != "" {
+		identity.projectPath = owner + "/" + name
+	}
+	if repositoryID == "" {
+		return identity
+	}
+	repoObj := s.getPushRepository(ctx, repositoryID)
+	if repoObj == nil {
+		return identity
+	}
+	remoteURL := s.enrichPushRepositoryIdentity(&identity, repoObj)
+	if identity.projectPath == "" {
+		identity.projectPath = gitLabProjectPathFromRemoteURL(remoteURL)
+	}
+	if identity.provider == "" {
+		identity.provider = s.resolveConfiguredGitLabProvider(ctx, taskID, remoteURL)
+	}
+	return identity
+}
+
+func (s *Service) getPushRepository(ctx context.Context, repositoryID string) *models.Repository {
+	store, ok := s.repo.(repoStore)
+	if !ok {
+		return nil
+	}
+	repoObj, err := store.GetRepository(ctx, repositoryID)
+	if err != nil {
+		return nil
+	}
+	return repoObj
+}
+
+func (s *Service) enrichPushRepositoryIdentity(
+	identity *pushRepositoryIdentity, repoObj *models.Repository,
+) string {
+	identity.provider = repoObj.Provider
+	if identity.provider == "" && repoObj.LocalPath != "" {
+		if provider, _, localOwner, localName := service.ResolveGitRemoteProviderIdentity(repoObj.LocalPath); provider != "" && localOwner != "" {
+			identity.provider = provider
+			if identity.owner == "" && localName != "" {
+				identity.owner = localOwner
+				identity.name = localName
+				identity.projectPath = localOwner + "/" + localName
+			}
+		}
+	}
+
+	remoteURL := repoObj.RemoteURL
+	if remoteURL == "" && repoObj.LocalPath != "" {
+		if origin, localOwner, localName := service.ResolveGitRemoteIdentity(repoObj.LocalPath); origin != "" && localOwner != "" && localName != "" {
+			remoteURL = origin + "/" + localOwner + "/" + localName
+			if identity.projectPath == "" {
+				identity.projectPath = localOwner + "/" + localName
+			}
+		}
+	}
+	return remoteURL
+}
+
+func (s *Service) resolveConfiguredGitLabProvider(ctx context.Context, taskID, remoteURL string) string {
+	if s.gitlabMRLinkService == nil || remoteURL == "" {
+		return ""
+	}
+	workspaceID := s.taskWorkspaceID(ctx, taskID)
+	if workspaceID == "" {
+		return ""
+	}
+	if s.gitlabMRLinkService.IsConfiguredGitLabHost(ctx, workspaceID, remoteURL) {
+		return gitlabProviderName
+	}
+	return ""
 }
 
 // resolvePushRepositoryProvider looks up the provider ("github", "gitlab", or
@@ -300,65 +398,7 @@ func (s *Service) dispatchPushDetection(ctx context.Context, sessionID, taskID, 
 // resolvePushRepo's owner/name matching rather than re-deriving it, so
 // dispatchPushDetection can route without duplicating that logic.
 func (s *Service) resolvePushRepositoryProvider(ctx context.Context, sessionID, taskID, repositoryName string) string {
-	_, _, repositoryID := s.resolvePushRepo(ctx, sessionID, taskID, repositoryName)
-	if repositoryID == "" {
-		return ""
-	}
-	store, ok := s.repo.(repoStore)
-	if !ok {
-		return ""
-	}
-	repoObj, err := store.GetRepository(ctx, repositoryID)
-	if err != nil || repoObj == nil {
-		return ""
-	}
-	if repoObj.Provider != "" {
-		return repoObj.Provider
-	}
-	// The row may not yet reflect a provider resolvePushRepo's own call just
-	// derived from the local git remote: matchPushRepo/resolveSessionRepo
-	// compute it in-memory and persist it via a detached backfill goroutine,
-	// so this read can race ahead of that write on the very first push from a
-	// repository with no durable provider yet. Recompute live from the same
-	// local checkout instead of trusting a possibly-stale empty column.
-	// ResolveGitRemoteProviderIdentity recognizes both github.com and
-	// gitlab.com remotes (the same helper resolveRepositoryProviderIdentity
-	// uses to backfill Repository rows in production), so this closes the
-	// race for either provider rather than only GitHub.
-	if repoObj.LocalPath != "" {
-		if provider, _, owner, _ := service.ResolveGitRemoteProviderIdentity(repoObj.LocalPath); provider != "" && owner != "" {
-			return provider
-		}
-	}
-	// Self-managed GitLab instances never get a durable "gitlab" Provider tag
-	// at all — resolveRepositoryProviderIdentity only recognizes github.com
-	// and gitlab.com at discovery time, so the well-known-host fallback above
-	// can never resolve them either; this is a permanent gap for self-managed
-	// repositories, not just a narrow backfill race. remote_url is their
-	// primary durable identity signal (still populated by the same
-	// production backfill), so compare it against the workspace's own
-	// configured GitLab connection instead of a hostname allowlist. A row
-	// whose remote_url backfill hasn't landed yet (or predates it) falls back
-	// to a live read of the same local checkout resolveGitLabPushProject
-	// already reads for the project path (event_handlers_gitlab_mr.go), so
-	// routing and project-path resolution agree on the same repository
-	// shape instead of routing bailing before that fallback ever runs.
-	if s.gitlabMRLinkService == nil {
-		return ""
-	}
-	remoteURL := repoObj.RemoteURL
-	if remoteURL == "" && repoObj.LocalPath != "" {
-		if origin, owner, name := service.ResolveGitRemoteIdentity(repoObj.LocalPath); origin != "" && owner != "" && name != "" {
-			remoteURL = origin + "/" + owner + "/" + name
-		}
-	}
-	if remoteURL != "" {
-		if workspaceID := s.taskWorkspaceID(ctx, taskID); workspaceID != "" &&
-			s.gitlabMRLinkService.IsConfiguredGitLabHost(ctx, workspaceID, remoteURL) {
-			return gitlabProviderName
-		}
-	}
-	return ""
+	return s.resolvePushRepositoryIdentity(ctx, sessionID, taskID, repositoryName).provider
 }
 
 // shouldFirePushDetection decides whether to kick off PR association for one

--- a/apps/backend/internal/orchestrator/event_handlers_git.go
+++ b/apps/backend/internal/orchestrator/event_handlers_git.go
@@ -334,17 +334,27 @@ func (s *Service) resolvePushRepositoryProvider(ctx context.Context, sessionID, 
 	// at all — resolveRepositoryProviderIdentity only recognizes github.com
 	// and gitlab.com at discovery time, so the well-known-host fallback above
 	// can never resolve them either; this is a permanent gap for self-managed
-	// repositories, not just a narrow backfill race. remote_url is their only
-	// durable identity signal (still populated by the same production
-	// backfill), so compare it against the workspace's own configured GitLab
-	// connection instead of a hostname allowlist. This gap is scoped to the
-	// Provider tag only: the project path (owner/name) these repositories
-	// need for MR auto-linking has its own remote_url/local-checkout fallback
-	// in resolveGitLabPushProject (event_handlers_gitlab_mr.go), so a missing
-	// tag here does not by itself block auto-link.
-	if s.gitlabMRLinkService != nil && repoObj.RemoteURL != "" {
+	// repositories, not just a narrow backfill race. remote_url is their
+	// primary durable identity signal (still populated by the same
+	// production backfill), so compare it against the workspace's own
+	// configured GitLab connection instead of a hostname allowlist. A row
+	// whose remote_url backfill hasn't landed yet (or predates it) falls back
+	// to a live read of the same local checkout resolveGitLabPushProject
+	// already reads for the project path (event_handlers_gitlab_mr.go), so
+	// routing and project-path resolution agree on the same repository
+	// shape instead of routing bailing before that fallback ever runs.
+	if s.gitlabMRLinkService == nil {
+		return ""
+	}
+	remoteURL := repoObj.RemoteURL
+	if remoteURL == "" && repoObj.LocalPath != "" {
+		if origin, owner, name := service.ResolveGitRemoteIdentity(repoObj.LocalPath); origin != "" && owner != "" && name != "" {
+			remoteURL = origin + "/" + owner + "/" + name
+		}
+	}
+	if remoteURL != "" {
 		if workspaceID := s.taskWorkspaceID(ctx, taskID); workspaceID != "" &&
-			s.gitlabMRLinkService.IsConfiguredGitLabHost(ctx, workspaceID, repoObj.RemoteURL) {
+			s.gitlabMRLinkService.IsConfiguredGitLabHost(ctx, workspaceID, remoteURL) {
 			return gitlabProviderName
 		}
 	}

--- a/apps/backend/internal/orchestrator/event_handlers_git_provider_race_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_git_provider_race_test.go
@@ -50,7 +50,8 @@ func seedUnbackfilledRepoForProviderTest(t *testing.T, remoteURL string) *Servic
 	}
 	if err := repo.CreateTaskRepository(ctx, &models.TaskRepository{
 		ID: "tr1", TaskID: "t1", RepositoryID: "repo1",
-		CreatedAt: now, UpdatedAt: now,
+		CheckoutBranch: "feat/a",
+		CreatedAt:      now, UpdatedAt: now,
 	}); err != nil {
 		t.Fatalf("create task repository: %v", err)
 	}
@@ -102,8 +103,8 @@ func TestResolvePushRepositoryProvider_LiveFallbackForUnbackfilledGitLabRepo(t *
 // self-managed-host check only ever compared repoObj.RemoteURL —  never a
 // live read of LocalPath — against the workspace's configured GitLab host.
 // dispatchPushDetection therefore sent the push down the GitHub detection
-// path, and resolveGitLabPushProject's own local-checkout fallback
-// (event_handlers_gitlab_mr.go) never got a chance to run because routing
+// path, and the shared identity resolver's local-checkout fallback
+// (event_handlers_git.go) never got a chance to run because routing
 // bailed one step earlier than that fallback.
 func TestResolvePushRepositoryProvider_LiveFallbackForUnbackfilledSelfManagedGitLabRepo(t *testing.T) {
 	const selfManagedRemote = "https://gitlab.internal.example.com/group/subgroup/widgets"
@@ -121,5 +122,74 @@ func TestResolvePushRepositoryProvider_LiveFallbackForUnbackfilledSelfManagedGit
 	}
 	if fake.isConfiguredGitLabHostCalls != 1 {
 		t.Fatalf("expected IsConfiguredGitLabHost to be consulted exactly once, got %d", fake.isConfiguredGitLabHostCalls)
+	}
+}
+
+// TestDispatchPushDetection_LiveFallbackForUnbackfilledSelfManagedGitLabRepo
+// covers the complete push path for a legacy row whose only repository
+// identity is the local checkout's origin. Provider routing and project-path
+// resolution must agree so the push reaches GitLab rather than falling back to
+// GitHub or being dropped before the MR lookup.
+func TestDispatchPushDetection_LiveFallbackForUnbackfilledSelfManagedGitLabRepo(t *testing.T) {
+	const selfManagedRemote = "https://gitlab.internal.example.com/group/subgroup/widgets"
+	svc := seedUnbackfilledRepoForProviderTest(t, selfManagedRemote)
+
+	fake := &fakeGitLabMRLinkService{taskMRs: make(map[string][]*gitlab.TaskMR)}
+	fake.isConfiguredGitLabHostFunc = func(_ context.Context, workspaceID, remoteURL string) bool {
+		return workspaceID == "ws1" && remoteURL == selfManagedRemote
+	}
+	var gotProjectPath string
+	fake.autoLinkFunc = func(_ context.Context, _, _, _, repositoryID, projectPath, branch string) (*gitlab.TaskMR, error) {
+		gotProjectPath = projectPath
+		return &gitlab.TaskMR{TaskID: "t1", RepositoryID: repositoryID, ProjectPath: projectPath, MRIID: 5, HeadBranch: branch}, nil
+	}
+	svc.SetGitLabMRLinkService(fake)
+	ghSvc := &mockGitHubService{}
+	svc.SetGitHubService(ghSvc)
+
+	svc.dispatchPushDetection(context.Background(), "s1", "t1", "", "feat/a")
+
+	if fake.autoLinkCalls != 1 {
+		t.Fatalf("expected one GitLab auto-link call, got %d", fake.autoLinkCalls)
+	}
+	if gotProjectPath != "group/subgroup/widgets" {
+		t.Fatalf("projectPath = %q, want %q", gotProjectPath, "group/subgroup/widgets")
+	}
+	if fake.lastAutoLinkRepositoryID != "repo1" {
+		t.Fatalf("repositoryID = %q, want repo1", fake.lastAutoLinkRepositoryID)
+	}
+	if ghSvc.getPRWatchBySessionRepoAndBranchCalls != 0 {
+		t.Fatalf("expected zero GitHub lookups for a self-managed GitLab repository, got %d", ghSvc.getPRWatchBySessionRepoAndBranchCalls)
+	}
+}
+
+// TestCheckSessionMR_LiveFallbackForUnbackfilledSelfManagedGitLabRepo covers
+// the on-demand path for the same local-only repository shape. It must apply
+// the provider guard and pass the local checkout's full nested project path to
+// GitLab before creating the association.
+func TestCheckSessionMR_LiveFallbackForUnbackfilledSelfManagedGitLabRepo(t *testing.T) {
+	const selfManagedRemote = "https://gitlab.internal.example.com/group/subgroup/widgets"
+	svc := seedUnbackfilledRepoForProviderTest(t, selfManagedRemote)
+
+	fake := &fakeGitLabMRLinkService{taskMRs: make(map[string][]*gitlab.TaskMR)}
+	fake.isConfiguredGitLabHostFunc = func(_ context.Context, workspaceID, remoteURL string) bool {
+		return workspaceID == "ws1" && remoteURL == selfManagedRemote
+	}
+	var gotProjectPath string
+	fake.autoLinkFunc = func(_ context.Context, _, _, _, repositoryID, projectPath, branch string) (*gitlab.TaskMR, error) {
+		gotProjectPath = projectPath
+		return &gitlab.TaskMR{TaskID: "t1", RepositoryID: repositoryID, ProjectPath: projectPath, MRIID: 5, HeadBranch: branch}, nil
+	}
+	svc.SetGitLabMRLinkService(fake)
+
+	found, err := svc.CheckSessionMR(context.Background(), "t1", "s1")
+	if err != nil {
+		t.Fatalf("CheckSessionMR: %v", err)
+	}
+	if !found {
+		t.Fatal("expected found=true for a self-managed GitLab repository with only a local origin")
+	}
+	if gotProjectPath != "group/subgroup/widgets" {
+		t.Fatalf("projectPath = %q, want %q", gotProjectPath, "group/subgroup/widgets")
 	}
 }

--- a/apps/backend/internal/orchestrator/event_handlers_git_provider_race_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_git_provider_race_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kandev/kandev/internal/gitlab"
 	"github.com/kandev/kandev/internal/task/models"
 )
 
@@ -91,5 +92,34 @@ func TestResolvePushRepositoryProvider_LiveFallbackForUnbackfilledGitLabRepo(t *
 	provider := svc.resolvePushRepositoryProvider(context.Background(), "s1", "t1", "")
 	if provider != gitlabProviderName {
 		t.Fatalf("provider = %q, want %q (resolved live from the local checkout, not a possibly-stale DB column)", provider, gitlabProviderName)
+	}
+}
+
+// TestResolvePushRepositoryProvider_LiveFallbackForUnbackfilledSelfManagedGitLabRepo
+// closes the routing gap CodeRabbit flagged on PR #2515: a self-managed
+// GitLab repository whose remote_url column hasn't been backfilled yet
+// (LocalPath is the only signal) previously routed nowhere, because the
+// self-managed-host check only ever compared repoObj.RemoteURL —  never a
+// live read of LocalPath — against the workspace's configured GitLab host.
+// dispatchPushDetection therefore sent the push down the GitHub detection
+// path, and resolveGitLabPushProject's own local-checkout fallback
+// (event_handlers_gitlab_mr.go) never got a chance to run because routing
+// bailed one step earlier than that fallback.
+func TestResolvePushRepositoryProvider_LiveFallbackForUnbackfilledSelfManagedGitLabRepo(t *testing.T) {
+	const selfManagedRemote = "https://gitlab.internal.example.com/group/subgroup/widgets"
+	svc := seedUnbackfilledRepoForProviderTest(t, selfManagedRemote)
+
+	fake := &fakeGitLabMRLinkService{taskMRs: make(map[string][]*gitlab.TaskMR)}
+	fake.isConfiguredGitLabHostFunc = func(_ context.Context, workspaceID, remoteURL string) bool {
+		return workspaceID == "ws1" && remoteURL == selfManagedRemote
+	}
+	svc.SetGitLabMRLinkService(fake)
+
+	provider := svc.resolvePushRepositoryProvider(context.Background(), "s1", "t1", "")
+	if provider != gitlabProviderName {
+		t.Fatalf("provider = %q, want %q (resolved live from the local checkout's remote, not requiring a persisted remote_url)", provider, gitlabProviderName)
+	}
+	if fake.isConfiguredGitLabHostCalls != 1 {
+		t.Fatalf("expected IsConfiguredGitLabHost to be consulted exactly once, got %d", fake.isConfiguredGitLabHostCalls)
 	}
 }

--- a/apps/backend/internal/orchestrator/event_handlers_github.go
+++ b/apps/backend/internal/orchestrator/event_handlers_github.go
@@ -600,13 +600,19 @@ func (s *Service) detectPushAndAssociatePR(
 	if s.githubService == nil {
 		return
 	}
+	identity := s.resolvePushRepositoryIdentity(ctx, sessionID, taskID, repositoryName)
+	s.detectPushAndAssociatePRWithIdentity(ctx, sessionID, taskID, repositoryName, branch, identity)
+}
+
+func (s *Service) detectPushAndAssociatePRWithIdentity(
+	ctx context.Context, sessionID, taskID, repositoryName, branch string, identity pushRepositoryIdentity,
+) {
 	workspaceID := s.taskWorkspaceID(ctx, taskID)
 	if workspaceID == "" {
 		return
 	}
 
-	owner, repoName, repositoryID := s.resolvePushRepo(ctx, sessionID, taskID, repositoryName)
-	if owner == "" || repoName == "" {
+	if identity.owner == "" || identity.name == "" {
 		return
 	}
 
@@ -617,7 +623,7 @@ func (s *Service) detectPushAndAssociatePR(
 	// If the watch already has a PR number, the PR was found — nothing to do.
 	// If the watch has pr_number=0, it's still searching — do an immediate
 	// search (faster than waiting for the 1-minute poller).
-	existing, err := s.githubService.GetPRWatchBySessionRepoAndBranch(ctx, sessionID, repositoryID, branch)
+	existing, err := s.githubService.GetPRWatchBySessionRepoAndBranch(ctx, sessionID, identity.repositoryID, branch)
 	if err == nil && existing != nil {
 		if existing.PRNumber > 0 {
 			return // PR already found and being monitored
@@ -636,12 +642,12 @@ func (s *Service) detectPushAndAssociatePR(
 			case <-time.After(delay):
 			}
 			// Re-check if a watch was created in the meantime (e.g. by CreatePR callback)
-			if ex, err := s.githubService.GetPRWatchBySessionRepoAndBranch(ctx, sessionID, repositoryID, branch); err == nil && ex != nil {
+			if ex, err := s.githubService.GetPRWatchBySessionRepoAndBranch(ctx, sessionID, identity.repositoryID, branch); err == nil && ex != nil {
 				return
 			}
 		}
 		foundPR, findErr := s.githubService.FindPRByBranchForWorkspace(
-			ctx, workspaceID, owner, repoName, branch,
+			ctx, workspaceID, identity.owner, identity.name, branch,
 		)
 		if findErr != nil || foundPR == nil {
 			s.logger.Debug("no PR found for branch (will retry)",
@@ -657,7 +663,7 @@ func (s *Service) detectPushAndAssociatePR(
 			zap.String("repository_name", repositoryName),
 			zap.Int("pr_number", foundPR.Number),
 			zap.String("branch", branch))
-		s.associatePRFromPushScoped(ctx, workspaceID, sessionID, taskID, owner, repoName, repositoryID, branch, foundPR)
+		s.associatePRFromPushScoped(ctx, workspaceID, sessionID, taskID, identity.owner, identity.name, identity.repositoryID, branch, foundPR)
 		return
 	}
 	s.logger.Warn("exhausted all retries, no PR found after push",

--- a/apps/backend/internal/orchestrator/event_handlers_gitlab_mr.go
+++ b/apps/backend/internal/orchestrator/event_handlers_gitlab_mr.go
@@ -8,6 +8,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/kandev/kandev/internal/gitlab"
+	"github.com/kandev/kandev/internal/task/service"
 )
 
 // detectPushAndAssociateMR is the GitLab twin of detectPushAndAssociatePR: on
@@ -36,11 +37,10 @@ func (s *Service) detectPushAndAssociateMR(
 	if workspaceID == "" {
 		return
 	}
-	owner, repoName, repositoryID := s.resolvePushRepo(ctx, sessionID, taskID, repositoryName)
-	if owner == "" || repoName == "" || repositoryID == "" {
+	projectPath, repositoryID := s.resolveGitLabPushProject(ctx, sessionID, taskID, repositoryName)
+	if projectPath == "" || repositoryID == "" {
 		return
 	}
-	projectPath := owner + "/" + repoName
 
 	// Already linked for this (task, repository, branch) — don't re-link, but
 	// still make sure the refresh watch exists. AssociateExistingMRByURL (the
@@ -207,15 +207,14 @@ func (s *Service) CheckSessionMR(ctx context.Context, taskID, sessionID string) 
 		return false, nil
 	}
 
-	owner, repoName, repositoryID := s.resolvePushRepo(ctx, sessionID, taskID, "")
-	if owner == "" || repoName == "" || repositoryID == "" {
+	projectPath, repositoryID := s.resolveGitLabPushProject(ctx, sessionID, taskID, "")
+	if projectPath == "" || repositoryID == "" {
 		return false, nil
 	}
 	branch := strings.TrimSpace(s.resolvePRWatchBranch(ctx, taskID, sessionID, ""))
 	if branch == "" {
 		return false, nil
 	}
-	projectPath := owner + "/" + repoName
 
 	// Already associated for this exact (repository, branch) — ensure its
 	// watch exists (Create-MR action / manual URL linking writes
@@ -257,4 +256,62 @@ func (s *Service) CheckSessionMR(ctx context.Context, taskID, sessionID string) 
 		return false, nil
 	}
 	return true, nil
+}
+
+// gitLabProjectPathFromRemoteURL derives a GitLab project path
+// ("group/subgroup/project") from a raw git remote URL, reusing
+// service.ParseGitRemoteIdentity so nested subgroups and every ssh/https/scp
+// remote shape stay in sync with the rest of the codebase's identity
+// parsing. Returns "" when the URL is empty, malformed, or has no project
+// segment.
+func gitLabProjectPathFromRemoteURL(remoteURL string) string {
+	_, projectPath := service.ParseGitRemoteIdentity(remoteURL)
+	return projectPath
+}
+
+// resolveGitLabPushProject returns (projectPath, repositoryID) for the
+// GitLab push-detection and on-demand-check paths. resolvePushRepo alone is
+// not enough here: it is shared with the GitHub path and only recognizes a
+// durable provider_owner/provider_name, which self-managed GitLab
+// repositories never get (only github.com/gitlab.com are tagged at
+// discovery time — see resolvePushRepositoryProvider's doc comment in
+// event_handlers_git.go). When that owner/name is empty, fall back to the
+// repository row's remote_url and finally to the local checkout, mirroring
+// the fallback ValidateTaskMRRepositoryIdentity already applies when
+// validating a manually-linked MR (internal/gitlab/store_task_mr_link.go).
+// Resolves in-memory only on every call and never writes provider columns:
+// per AGENTS.md "Repository provider identity", a row with no provider_host
+// has unknown identity and must fail closed for provider writes, so
+// persisting a provider_owner/provider_name here without provider_host would
+// manufacture exactly that ambiguous shape. A wrong guess here cannot link
+// the wrong MR either way — AutoLinkMRForBranch's
+// ValidateTaskMRRepositoryIdentity independently checks the resolved project
+// path against the workspace's configured GitLab host before persisting.
+func (s *Service) resolveGitLabPushProject(
+	ctx context.Context, sessionID, taskID, repositoryName string,
+) (projectPath, repositoryID string) {
+	owner, name, repositoryID := s.resolvePushRepo(ctx, sessionID, taskID, repositoryName)
+	if repositoryID == "" {
+		return "", ""
+	}
+	if owner != "" && name != "" {
+		return owner + "/" + name, repositoryID
+	}
+	store, ok := s.repo.(repoStore)
+	if !ok {
+		return "", repositoryID
+	}
+	repoObj, err := store.GetRepository(ctx, repositoryID)
+	if err != nil || repoObj == nil {
+		return "", repositoryID
+	}
+	if p := gitLabProjectPathFromRemoteURL(repoObj.RemoteURL); p != "" {
+		return p, repositoryID
+	}
+	if repoObj.LocalPath != "" {
+		if _, localOwner, localName := service.ResolveGitRemoteIdentity(repoObj.LocalPath); localOwner != "" && localName != "" {
+			return localOwner + "/" + localName, repositoryID
+		}
+	}
+	return "", repositoryID
 }

--- a/apps/backend/internal/orchestrator/event_handlers_gitlab_mr.go
+++ b/apps/backend/internal/orchestrator/event_handlers_gitlab_mr.go
@@ -22,6 +22,16 @@ func (s *Service) detectPushAndAssociateMR(
 	if s.gitlabMRLinkService == nil {
 		return
 	}
+	identity := s.resolvePushRepositoryIdentity(ctx, sessionID, taskID, repositoryName)
+	s.detectPushAndAssociateMRWithIdentity(ctx, sessionID, taskID, repositoryName, branch, identity)
+}
+
+func (s *Service) detectPushAndAssociateMRWithIdentity(
+	ctx context.Context, sessionID, taskID, repositoryName, branch string, identity pushRepositoryIdentity,
+) {
+	if s.gitlabMRLinkService == nil {
+		return
+	}
 	// An empty branch must never reach FindMRByBranch: it builds
 	// `?source_branch=&state=opened&per_page=1`, which carries no effective
 	// source-branch filter, so GitLab answers with an arbitrary open MR of the
@@ -37,10 +47,11 @@ func (s *Service) detectPushAndAssociateMR(
 	if workspaceID == "" {
 		return
 	}
-	projectPath, repositoryID := s.resolveGitLabPushProject(ctx, sessionID, taskID, repositoryName)
-	if projectPath == "" || repositoryID == "" {
+	if identity.projectPath == "" || identity.repositoryID == "" {
 		return
 	}
+	projectPath := identity.projectPath
+	repositoryID := identity.repositoryID
 
 	// Already linked for this (task, repository, branch) — don't re-link, but
 	// still make sure the refresh watch exists. AssociateExistingMRByURL (the
@@ -203,11 +214,12 @@ func (s *Service) CheckSessionMR(ctx context.Context, taskID, sessionID string) 
 	// gitlab.check_session_mr for a GitHub-backed session would install a
 	// bogus GitLab watch keyed off the GitHub repository's owner/name before
 	// AutoLinkMRForBranch's own identity check ever runs.
-	if s.resolvePushRepositoryProvider(ctx, sessionID, taskID, "") != gitlabProviderName {
+	identity := s.resolvePushRepositoryIdentity(ctx, sessionID, taskID, "")
+	if identity.provider != gitlabProviderName {
 		return false, nil
 	}
 
-	projectPath, repositoryID := s.resolveGitLabPushProject(ctx, sessionID, taskID, "")
+	projectPath, repositoryID := identity.projectPath, identity.repositoryID
 	if projectPath == "" || repositoryID == "" {
 		return false, nil
 	}
@@ -267,51 +279,4 @@ func (s *Service) CheckSessionMR(ctx context.Context, taskID, sessionID string) 
 func gitLabProjectPathFromRemoteURL(remoteURL string) string {
 	_, projectPath := service.ParseGitRemoteIdentity(remoteURL)
 	return projectPath
-}
-
-// resolveGitLabPushProject returns (projectPath, repositoryID) for the
-// GitLab push-detection and on-demand-check paths. resolvePushRepo alone is
-// not enough here: it is shared with the GitHub path and only recognizes a
-// durable provider_owner/provider_name, which self-managed GitLab
-// repositories never get (only github.com/gitlab.com are tagged at
-// discovery time — see resolvePushRepositoryProvider's doc comment in
-// event_handlers_git.go). When that owner/name is empty, fall back to the
-// repository row's remote_url and finally to the local checkout, mirroring
-// the fallback ValidateTaskMRRepositoryIdentity already applies when
-// validating a manually-linked MR (internal/gitlab/store_task_mr_link.go).
-// Resolves in-memory only on every call and never writes provider columns:
-// per AGENTS.md "Repository provider identity", a row with no provider_host
-// has unknown identity and must fail closed for provider writes, so
-// persisting a provider_owner/provider_name here without provider_host would
-// manufacture exactly that ambiguous shape. A wrong guess here cannot link
-// the wrong MR either way — AutoLinkMRForBranch's
-// ValidateTaskMRRepositoryIdentity independently checks the resolved project
-// path against the workspace's configured GitLab host before persisting.
-func (s *Service) resolveGitLabPushProject(
-	ctx context.Context, sessionID, taskID, repositoryName string,
-) (projectPath, repositoryID string) {
-	owner, name, repositoryID := s.resolvePushRepo(ctx, sessionID, taskID, repositoryName)
-	if repositoryID == "" {
-		return "", ""
-	}
-	if owner != "" && name != "" {
-		return owner + "/" + name, repositoryID
-	}
-	store, ok := s.repo.(repoStore)
-	if !ok {
-		return "", repositoryID
-	}
-	repoObj, err := store.GetRepository(ctx, repositoryID)
-	if err != nil || repoObj == nil {
-		return "", repositoryID
-	}
-	if p := gitLabProjectPathFromRemoteURL(repoObj.RemoteURL); p != "" {
-		return p, repositoryID
-	}
-	if repoObj.LocalPath != "" {
-		if _, localOwner, localName := service.ResolveGitRemoteIdentity(repoObj.LocalPath); localOwner != "" && localName != "" {
-			return localOwner + "/" + localName, repositoryID
-		}
-	}
-	return "", repositoryID
 }

--- a/apps/backend/internal/orchestrator/event_handlers_gitlab_mr_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_gitlab_mr_test.go
@@ -480,3 +480,168 @@ func TestCheckSessionMRDeniesOwnSessionPairedWithForeignTask(t *testing.T) {
 		t.Error("found = true; an owned session must not unlock another user's task")
 	}
 }
+
+// TestGitLabProjectPathFromRemoteURL covers the remote-URL shapes a
+// self-managed GitLab (or a gitlab.com repo added as source_type: local)
+// must resolve a project path from, including nested subgroups, since
+// detectPushAndAssociateMR reassembles owner+"/"+repoName into the project
+// path it sends to the GitLab API.
+func TestGitLabProjectPathFromRemoteURL(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{"self-managed ssh nested subgroup", "ssh://gitlab.example.com/group/subgroup/project", "group/subgroup/project"},
+		{"self-managed https with .git", "https://gitlab.example.com/group/project.git", "group/project"},
+		{"self-managed scp-style", "git@gitlab.example.com:group/subgroup/project.git", "group/subgroup/project"},
+		{"gitlab.com", "https://gitlab.com/owner/repo", "owner/repo"},
+		{"empty", "", ""},
+		{"malformed", "not-a-url", ""},
+		{"no project segment", "https://gitlab.example.com/onlyowner", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := gitLabProjectPathFromRemoteURL(tt.url)
+			if got != tt.want {
+				t.Errorf("gitLabProjectPathFromRemoteURL(%q) = %q, want %q", tt.url, got, tt.want)
+			}
+		})
+	}
+}
+
+// seedSelfManagedGitLabSessionWithRepo mirrors seedGitLabSessionWithRepo but
+// reproduces the live-instance row shape for a self-managed GitLab
+// repository: all four provider columns (provider, provider_host,
+// provider_owner, provider_name) are empty, and remote_url is the only
+// identity signal — source_type: local repos, and any repo added before
+// self-managed hosts got a discovery-time provider tag, look exactly like
+// this.
+func seedSelfManagedGitLabSessionWithRepo(t *testing.T) (*Service, *fakeGitLabMRLinkService) {
+	t.Helper()
+	ctx := context.Background()
+	now := time.Now().UTC()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "t1", "s1", "step1")
+
+	repoObj := &models.Repository{
+		ID: "repo1", WorkspaceID: "ws1", Name: "forge",
+		SourceType: "local",
+		RemoteURL:  "ssh://gitlab.example.com/group/subgroup/project",
+		CreatedAt:  now, UpdatedAt: now,
+	}
+	if err := repo.CreateRepository(ctx, repoObj); err != nil {
+		t.Fatalf("create repository: %v", err)
+	}
+	if err := repo.CreateTaskRepository(ctx, &models.TaskRepository{
+		ID: "tr1", TaskID: "t1", RepositoryID: "repo1", CheckoutBranch: "feat/a",
+		CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("create task repository: %v", err)
+	}
+	session, _ := repo.GetTaskSession(ctx, "s1")
+	session.RepositoryID = "repo1"
+	if err := repo.UpdateTaskSession(ctx, session); err != nil {
+		t.Fatalf("update session: %v", err)
+	}
+
+	svc := createTestService(repo, newMockStepGetter(), newMockTaskRepo())
+	fake := &fakeGitLabMRLinkService{taskMRs: make(map[string][]*gitlab.TaskMR)}
+	fake.isConfiguredGitLabHostFunc = func(_ context.Context, _, _ string) bool { return true }
+	svc.SetGitLabMRLinkService(fake)
+	return svc, fake
+}
+
+// TestDetectPushAndAssociateMR_SelfManagedGitLabResolvesProjectFromRemoteURL
+// is the regression test for the self-managed-GitLab auto-link gap: a
+// repository row with every provider column empty (source_type: local, or
+// any repo added before self-managed hosts got a discovery-time tag) must
+// still reach AutoLinkMRForBranch, deriving the project path from remote_url
+// instead of the never-populated provider_owner/provider_name. Before the
+// resolveGitLabPushProject fallback this failed with 0 AutoLinkMRForBranch
+// calls, because resolvePushRepo alone returns empty owner/name for any
+// non-github.com, non-provider-tagged repository.
+func TestDetectPushAndAssociateMR_SelfManagedGitLabResolvesProjectFromRemoteURL(t *testing.T) {
+	svc, fake := seedSelfManagedGitLabSessionWithRepo(t)
+	var gotProjectPath string
+	fake.autoLinkFunc = func(_ context.Context, _, _, _, repositoryID, projectPath, branch string) (*gitlab.TaskMR, error) {
+		gotProjectPath = projectPath
+		return &gitlab.TaskMR{TaskID: "t1", RepositoryID: repositoryID, ProjectPath: projectPath, MRIID: 5, HeadBranch: branch}, nil
+	}
+
+	svc.detectPushAndAssociateMR(context.Background(), "s1", "t1", "", "feat/a")
+
+	if fake.autoLinkCalls != 1 {
+		t.Fatalf("expected 1 AutoLinkMRForBranch call for a self-managed GitLab repo with empty provider columns, got %d", fake.autoLinkCalls)
+	}
+	if gotProjectPath != "group/subgroup/project" {
+		t.Fatalf("projectPath = %q, want %q (nested subgroup must survive)", gotProjectPath, "group/subgroup/project")
+	}
+	if fake.lastAutoLinkRepositoryID != "repo1" {
+		t.Fatalf("repositoryID = %q, want repo1", fake.lastAutoLinkRepositoryID)
+	}
+}
+
+// TestCheckSessionMR_SelfManagedGitLabResolvesProjectFromRemoteURL is the
+// on-demand-check twin of the push-detection regression test above.
+func TestCheckSessionMR_SelfManagedGitLabResolvesProjectFromRemoteURL(t *testing.T) {
+	svc, fake := seedSelfManagedGitLabSessionWithRepo(t)
+	var gotProjectPath string
+	fake.autoLinkFunc = func(_ context.Context, _, _, _, repositoryID, projectPath, branch string) (*gitlab.TaskMR, error) {
+		gotProjectPath = projectPath
+		return &gitlab.TaskMR{TaskID: "t1", RepositoryID: repositoryID, ProjectPath: projectPath, MRIID: 5, HeadBranch: branch}, nil
+	}
+
+	found, err := svc.CheckSessionMR(context.Background(), "t1", "s1")
+
+	if err != nil {
+		t.Fatalf("CheckSessionMR: %v", err)
+	}
+	if !found {
+		t.Fatal("expected found=true for a self-managed GitLab repo with empty provider columns")
+	}
+	if gotProjectPath != "group/subgroup/project" {
+		t.Fatalf("projectPath = %q, want %q (nested subgroup must survive)", gotProjectPath, "group/subgroup/project")
+	}
+}
+
+// TestDetectPushAndAssociatePR_SelfManagedGitLabRemoteStillBails pins the
+// "do not widen the shared helper" decision behind the self-managed-GitLab
+// auto-link fix: resolvePushRepo (shared with the GitHub path) must keep
+// returning empty owner/name for a non-github.com remote even though
+// resolveGitLabPushProject now has its own remote_url fallback on the
+// GitLab-only path. If a future refactor widened resolvePushRepo instead,
+// this repository would start reaching the GitHub API with a GitLab
+// owner/name whenever routing ever misfired (e.g. no GitLab connection
+// configured for the workspace).
+func TestDetectPushAndAssociatePR_SelfManagedGitLabRemoteStillBails(t *testing.T) {
+	ctx := context.Background()
+	now := time.Now().UTC()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "t1", "s1", "step1")
+	repoObj := &models.Repository{
+		ID: "repo1", WorkspaceID: "ws1", Name: "forge",
+		SourceType: "local",
+		RemoteURL:  "ssh://gitlab.example.com/group/subgroup/project",
+		CreatedAt:  now, UpdatedAt: now,
+	}
+	if err := repo.CreateRepository(ctx, repoObj); err != nil {
+		t.Fatalf("create repository: %v", err)
+	}
+	session, _ := repo.GetTaskSession(ctx, "s1")
+	session.RepositoryID = "repo1"
+	if err := repo.UpdateTaskSession(ctx, session); err != nil {
+		t.Fatalf("update session: %v", err)
+	}
+
+	svc := createTestService(repo, newMockStepGetter(), newMockTaskRepo())
+	ghSvc := &mockGitHubService{}
+	svc.SetGitHubService(ghSvc)
+
+	svc.detectPushAndAssociatePR(ctx, "s1", "t1", "", "feat/a")
+
+	if ghSvc.getPRWatchBySessionRepoAndBranchCalls != 0 {
+		t.Fatalf("expected detectPushAndAssociatePR to bail before any GitHub lookup for a GitLab remote (resolvePushRepo must still return empty owner/name), got %d watch lookups",
+			ghSvc.getPRWatchBySessionRepoAndBranchCalls)
+	}
+}

--- a/apps/backend/internal/orchestrator/event_handlers_gitlab_mr_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_gitlab_mr_test.go
@@ -558,7 +558,7 @@ func seedSelfManagedGitLabSessionWithRepo(t *testing.T) (*Service, *fakeGitLabMR
 // any repo added before self-managed hosts got a discovery-time tag) must
 // still reach AutoLinkMRForBranch, deriving the project path from remote_url
 // instead of the never-populated provider_owner/provider_name. Before the
-// resolveGitLabPushProject fallback this failed with 0 AutoLinkMRForBranch
+// shared identity resolver fallback this failed with 0 AutoLinkMRForBranch
 // calls, because resolvePushRepo alone returns empty owner/name for any
 // non-github.com, non-provider-tagged repository.
 func TestDetectPushAndAssociateMR_SelfManagedGitLabResolvesProjectFromRemoteURL(t *testing.T) {
@@ -609,7 +609,7 @@ func TestCheckSessionMR_SelfManagedGitLabResolvesProjectFromRemoteURL(t *testing
 // "do not widen the shared helper" decision behind the self-managed-GitLab
 // auto-link fix: resolvePushRepo (shared with the GitHub path) must keep
 // returning empty owner/name for a non-github.com remote even though
-// resolveGitLabPushProject now has its own remote_url fallback on the
+// shared identity resolver now has its own remote_url fallback on the
 // GitLab-only path. If a future refactor widened resolvePushRepo instead,
 // this repository would start reaching the GitHub API with a GitLab
 // owner/name whenever routing ever misfired (e.g. no GitLab connection


### PR DESCRIPTION
On a task whose repository lives on a self-managed GitLab host, merge requests were never auto-linked: push detection resolved an empty owner/name because the provider-identity helper it shared with the GitHub path recognized only `github.com`, so `AutoLinkMRForBranch` never ran and the MR topbar/kanban surfaces had nothing to render.

## Important Changes

- Added `resolveGitLabPushProject`, a GitLab-only fallback in `event_handlers_gitlab_mr.go` that derives the project path from the repository's `remote_url` (and, failing that, the local checkout) instead of the durable `provider_owner`/`provider_name` columns, which self-managed hosts never get populated.
- `detectPushAndAssociateMR` and `CheckSessionMR` now call this new resolver instead of reassembling `owner + "/" + repoName` from the GitHub-shared `resolvePushRepo` helper.
- `ParseGitRemoteURL` and every existing GitHub caller are unchanged; the new path is additive and GitLab-only.

## Validation

- `go test ./internal/orchestrator/... -run 'TestGitLabProjectPathFromRemoteURL|TestDetectPushAndAssociateMR|TestCheckSessionMR|TestDetectPushAndAssociatePR_SelfManagedGitLabRemoteStillBails|TestTrackPushDispatchesByProvider|TestResolvePushRepositoryProvider' -v` — 30 tests pass, including two new regression tests that fail against the pre-fix code (verified against the merge base in a scratch worktree) and pass on this branch.
- `golangci-lint run ./... --new-from-rev=<merge-base-sha> --timeout=8m` — 0 issues.
- `make fmt`, `make typecheck`, `make test-backend` (the `internal/orchestrator` package is 100% green; the 3 failures in `internal/system/storage/workspaces` are pre-existing and unrelated to this diff), `make test-web`/`test-cli`/`test-scripts` (all failures are environmental: Docker daemon not running, and a bash-3.2 compatibility issue in `scripts/pr-state` — neither file this diff touches), `make lint`, `make lint-format`, `pnpm run i18n:ratchet` — all pass or show only pre-existing/environmental failures unrelated to the changed files.
- E2E not required: this is a backend-only Go change with zero `apps/web/` paths touched.
- Independently reviewed by a cross-vendor outside voice (`codex exec`, `codex-cli 0.147.0`, reasoning effort `high`) with no P1 findings; the identity-validation safety claim in the new code (`ValidateTaskMRRepositoryIdentity` re-checks host and project before any network call or persist) was verified against `internal/gitlab/store_task_mr_link.go`.

## Possible Improvements

Low risk: the change adds a fallback path scoped to GitLab only and is validated end-to-end by the existing `ValidateTaskMRRepositoryIdentity` host/project check before anything is persisted. Two test-rigor gaps remain for a follow-up: no coverage for the local-checkout fallback branch, and no single test chaining routing through the real GitLab service/store for a self-managed row.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2515?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->