### PR TITLE
fix(task): truncate title when linking an external issue

### DIFF
--- a/apps/web/components/task/task-external-link-dialog.test.tsx
+++ b/apps/web/components/task/task-external-link-dialog.test.tsx
@@ -160,6 +160,44 @@ describe("TaskExternalLinkDialog — long task titles", () => {
     expect(title.startsWith("ENG-20: ")).toBe(true);
     expect(title.endsWith("…")).toBe(true);
   });
+
+  it("caps the renamed title when a Sentry shortId rewrites the key", async () => {
+    mockSentryInstances("single", [instance("inst-1", "Production")]);
+    vi.mocked(getSentryIssue).mockResolvedValue({ shortId: "API-42" } as never);
+    vi.mocked(updateTask).mockResolvedValue({
+      id: TASK_ID,
+      title: "API-42: " + "x".repeat(51) + "…",
+    } as never);
+
+    const longTitle = "x".repeat(60);
+    render(
+      <StateProvider>
+        <ToastProvider>
+          <TaskExternalLinkDialog
+            open={true}
+            onOpenChange={vi.fn()}
+            provider="sentry"
+            task={{ id: TASK_ID, title: longTitle }}
+            workspaceId={WORKSPACE_ID}
+          />
+        </ToastProvider>
+      </StateProvider>,
+    );
+
+    fireEvent.change(screen.getByTestId(INPUT_TEST_ID), {
+      target: { value: "https://sentry.io/organizations/acme/issues/123456/" },
+    });
+    fireEvent.click(screen.getByTestId(SUBMIT_TEST_ID));
+
+    await waitFor(() => {
+      expect(getSentryIssue).toHaveBeenCalledWith(WORKSPACE_ID, "inst-1", "123456");
+    });
+    expect(updateTask).toHaveBeenCalledTimes(1);
+    const title = vi.mocked(updateTask).mock.calls[0][1].title as string;
+    expect(Array.from(title)).toHaveLength(60);
+    expect(title.startsWith("API-42: ")).toBe(true);
+    expect(title.endsWith("…")).toBe(true);
+  });
 });
 
 describe("TaskExternalLinkDialog — Sentry linking", () => {

--- a/apps/web/components/task/task-external-link-dialog.test.tsx
+++ b/apps/web/components/task/task-external-link-dialog.test.tsx
@@ -123,6 +123,45 @@ describe("TaskExternalLinkDialog — Jira and Linear", () => {
   });
 });
 
+describe("TaskExternalLinkDialog — long task titles", () => {
+  it("caps the renamed title at the 60-character limit when linking a Linear issue", async () => {
+    const longTitle = "x".repeat(60);
+    vi.mocked(getLinearIssue).mockResolvedValue({ identifier: "ENG-20" } as never);
+    vi.mocked(updateTask).mockResolvedValue({
+      id: TASK_ID,
+      title: "ENG-20: " + "x".repeat(51) + "…",
+    } as never);
+
+    render(
+      <StateProvider>
+        <ToastProvider>
+          <TaskExternalLinkDialog
+            open={true}
+            onOpenChange={vi.fn()}
+            provider="linear"
+            task={{ id: TASK_ID, title: longTitle }}
+            workspaceId={WORKSPACE_ID}
+          />
+        </ToastProvider>
+      </StateProvider>,
+    );
+
+    fireEvent.change(screen.getByTestId(INPUT_TEST_ID), {
+      target: { value: "ENG-20" },
+    });
+    fireEvent.click(screen.getByTestId(SUBMIT_TEST_ID));
+
+    await waitFor(() => {
+      expect(getLinearIssue).toHaveBeenCalledWith("ENG-20", { workspaceId: WORKSPACE_ID });
+    });
+    expect(updateTask).toHaveBeenCalledTimes(1);
+    const title = vi.mocked(updateTask).mock.calls[0][1].title as string;
+    expect(Array.from(title)).toHaveLength(60);
+    expect(title.startsWith("ENG-20: ")).toBe(true);
+    expect(title.endsWith("…")).toBe(true);
+  });
+});
+
 describe("TaskExternalLinkDialog — Sentry linking", () => {
   it("auto-selects the sole healthy Sentry instance and links against it", async () => {
     mockSentryInstances("single", [instance("inst-1", "Production")]);

--- a/apps/web/components/task/task-external-link-utils.test.ts
+++ b/apps/web/components/task/task-external-link-utils.test.ts
@@ -17,6 +17,14 @@ describe("buildLinkedIssueTitle", () => {
     );
   });
 
+  it("replaces the prefix and keeps the limit when re-linking a truncated title", () => {
+    // Simulate a title already truncated by a previous link (60 chars, "…" tail).
+    const prev = `DO-916: ${"x".repeat(51)}…`;
+    const got = buildLinkedIssueTitle(prev, "ENG-20");
+    expect(Array.from(got)).toHaveLength(60);
+    expect(got).toBe(`ENG-20: ${"x".repeat(51)}…`);
+  });
+
   it("truncates a composed title that exceeds the 60-character limit", () => {
     const got = buildLinkedIssueTitle("x".repeat(60), "DO-916");
     expect(Array.from(got)).toHaveLength(60);

--- a/apps/web/components/task/task-external-link-utils.test.ts
+++ b/apps/web/components/task/task-external-link-utils.test.ts
@@ -16,4 +16,23 @@ describe("buildLinkedIssueTitle", () => {
       "SVC-7: Debug production crash",
     );
   });
+
+  it("truncates a composed title that exceeds the 60-character limit", () => {
+    const got = buildLinkedIssueTitle("x".repeat(60), "DO-916");
+    expect(Array.from(got)).toHaveLength(60);
+    expect(got.startsWith("DO-916: ")).toBe(true);
+    expect(got.endsWith("…")).toBe(true);
+  });
+
+  it("leaves a composed title at the 60-character limit unchanged", () => {
+    const title = "y".repeat(52);
+    expect(buildLinkedIssueTitle(title, "ENG-20")).toBe(`ENG-20: ${title}`);
+  });
+
+  it("counts Unicode code points when truncating", () => {
+    const got = buildLinkedIssueTitle("🙂".repeat(60), "DO-916");
+    expect(Array.from(got)).toHaveLength(60);
+    expect(got.startsWith("DO-916: ")).toBe(true);
+    expect(got.endsWith("…")).toBe(true);
+  });
 });

--- a/apps/web/components/task/task-external-link-utils.test.ts
+++ b/apps/web/components/task/task-external-link-utils.test.ts
@@ -17,12 +17,22 @@ describe("buildLinkedIssueTitle", () => {
     );
   });
 
-  it("replaces the prefix and keeps the limit when re-linking a truncated title", () => {
+  it("replaces the prefix on a previously-truncated title without exceeding the limit", () => {
     // Simulate a title already truncated by a previous link (60 chars, "…" tail).
+    // Equal-length keys keep the composed title at exactly the limit, so this
+    // locks prefix replacement, not truncation (see the longer-key case below).
     const prev = `DO-916: ${"x".repeat(51)}…`;
     const got = buildLinkedIssueTitle(prev, "ENG-20");
     expect(Array.from(got)).toHaveLength(60);
     expect(got).toBe(`ENG-20: ${"x".repeat(51)}…`);
+  });
+
+  it("truncates when re-linking to a longer key", () => {
+    // "DO-9: " (6 chars) → "PROJ-12345: " (12 chars) makes the re-composed
+    // title exceed the limit, so the truncation path fires after the prefix swap.
+    const got = buildLinkedIssueTitle(`DO-9: ${"x".repeat(54)}`, "PROJ-12345");
+    expect(Array.from(got)).toHaveLength(60);
+    expect(got).toBe(`PROJ-12345: ${"x".repeat(47)}…`);
   });
 
   it("truncates a composed title that exceeds the 60-character limit", () => {

--- a/apps/web/components/task/task-external-link-utils.ts
+++ b/apps/web/components/task/task-external-link-utils.ts
@@ -1,6 +1,11 @@
+import { truncateRemoteTaskTitle } from "@/lib/task-title";
+
 const LEADING_EXTERNAL_ISSUE_RE = /^[A-Z][A-Z0-9_-]*-\d+:\s*/;
 
 export function buildLinkedIssueTitle(taskTitle: string | null | undefined, key: string): string {
   const stripped = (taskTitle ?? "").trim().replace(LEADING_EXTERNAL_ISSUE_RE, "");
-  return stripped ? `${key}: ${stripped}` : key;
+  const composed = stripped ? `${key}: ${stripped}` : key;
+  // The task title limit is enforced server-side; cap the composed title here
+  // so linking an issue never fails with "task title is too long".
+  return truncateRemoteTaskTitle(composed);
 }

--- a/apps/web/e2e/tests/integrations/linear-link-title.spec.ts
+++ b/apps/web/e2e/tests/integrations/linear-link-title.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from "../../fixtures/test-base";
+import { useRegularMode } from "../../helpers/regular-mode";
+import { KanbanPage } from "../../pages/kanban-page";
+
+// The link-issue dialog (Link → Linear Issue) renames the task to
+// "<KEY>: <title>". The backend rejects titles longer than 60 characters, so
+// the composed title must be truncated client-side instead of surfacing
+// "task title is too long". Covers the desktop kanban card menu; the mobile
+// task-switcher sheet reaches the same dialog component.
+useRegularMode();
+
+test.describe("Linear issue link on long task titles", () => {
+  test.beforeEach(async ({ apiClient }) => {
+    await apiClient.setLinearConfig({
+      secret: "lin_api_xxx",
+    });
+    await apiClient.waitForIntegrationAuthHealthy("linear");
+  });
+
+  test("linking an issue truncates the renamed title instead of failing validation", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    await apiClient.mockLinearAddIssues([
+      {
+        id: "issue-1",
+        identifier: "ENG-12",
+        title: "Add billing endpoint",
+        description: "",
+        url: "https://linear.app/mock-org/issue/ENG-12",
+      },
+    ]);
+
+    const longTitle = "x".repeat(60);
+    const task = await apiClient.createTask(seedData.workspaceId, longTitle, {
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+    });
+
+    const kanban = new KanbanPage(testPage);
+    await kanban.goto();
+    await kanban.openTaskActionsMenu(task.id);
+
+    await testPage.getByTestId("task-context-link").hover();
+    await testPage.getByTestId("task-context-link-linear-issue").click();
+
+    const input = testPage.getByTestId("task-external-link-input");
+    await expect(input).toBeVisible();
+    await input.fill("ENG-12");
+    await testPage.getByTestId("task-external-link-submit").click();
+
+    // The rename succeeds (dialog closes) and the card shows the truncated
+    // 60-character title with the issue key preserved.
+    await expect(input).not.toBeVisible({ timeout: 10_000 });
+    await expect(kanban.taskCardByTitle(`ENG-12: ${"x".repeat(51)}…`)).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+});


### PR DESCRIPTION
Linking a Jira/Linear/Sentry issue renames the task to `<KEY>: <title>`, and a task title at or near the 60-character limit pushed the composed rename past the backend's 60-rune cap, failing with "task title is too long". The composed title is now capped client-side with the existing 60-code-point truncator (59 chars + ellipsis), so the link always succeeds and the issue key stays visible.

## Validation

- Unit + component suites: `pnpm --filter @kandev/web exec vitest run components/task/task-external-link-utils.test.ts components/task/task-external-link-dialog.test.tsx` — 18/18 green (utils 8, dialog 10), including the new long-title regression, re-link prefix swap with truncation (mutation-verified: fails if `truncateRemoteTaskTitle` is removed), and Sentry `shortId`-rewrite truncation.
- E2E: `linear-link-title.spec.ts` passes against a real backend (seeds a 60-char task, links `ENG-12` via mock Linear, asserts the card shows `ENG-12: <51×x>…` and the dialog closes). Pre-fix this flow failed server-side.
- Three independent adversarial review rounds (2× DeepSeek V4 Pro, 2× GPT-5.6 Luna): all APPROVE; rounds 3–5 reported no findings. Round-2 catch (vacuous re-link test) fixed and mutation-verified.
- `make fmt`, `make typecheck`, `make lint` (incl. i18n ratchet): pass. Full web suite: 10344 passed; remaining failures pre-existing/environmental (Docker-dependent `http-git-server` tests, sandbox load flake).

## Possible Improvements

Low risk. `truncateRemoteTaskTitle` slices by Unicode code point, so a 59-point cut can split a grapheme cluster (ZWJ emoji / combining mark). Pre-existing in the shared helper (also used by create-dialog import bars); the backend accepts the result (rune count only). A grapheme-aware `Intl.Segmenter` pass would be a separate task.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2527?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- kandev-screenshots-start -->
## Screenshots

![Link Linear issue dialog with ENG-12 entered on a task at the 60-character title limit](https://raw.githubusercontent.com/Fclem/kandev/e51d86f68f6390f56567a2d56e5807bc0dc4338b/link-dialog.png)

![Task card renamed to a 60-character title (ENG-12: 51x ellipsis) instead of failing with task title is too long](https://raw.githubusercontent.com/Fclem/kandev/e51d86f68f6390f56567a2d56e5807bc0dc4338b/card-truncated-title.png)

![Mobile link-issue dialog with ENG-12 entered on a task at the 60-character title limit](https://raw.githubusercontent.com/Fclem/kandev/e51d86f68f6390f56567a2d56e5807bc0dc4338b/mobile-link-dialog.png)

![Mobile kanban card renamed to the truncated 60-character title](https://raw.githubusercontent.com/Fclem/kandev/e51d86f68f6390f56567a2d56e5807bc0dc4338b/mobile-card-truncated-title.png)
<!-- kandev-screenshots-end -->