### PR TITLE
feat: hide disabled agent profiles from left panel navigation

### DIFF
--- a/apps/web/app/settings/agents/hide-disabled-agent-profiles-setting.test.tsx
+++ b/apps/web/app/settings/agents/hide-disabled-agent-profiles-setting.test.tsx
@@ -1,0 +1,57 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { HideDisabledAgentProfilesSetting } from "./hide-disabled-agent-profiles-setting";
+
+const mocks = vi.hoisted(() => ({
+  hideDisabled: false,
+  setHideDisabled: vi.fn(),
+}));
+
+vi.mock("@/hooks/domains/settings/use-hide-disabled-agent-profiles-in-nav", () => ({
+  useHideDisabledAgentProfilesInNav: () => ({
+    hideDisabled: mocks.hideDisabled,
+    setHideDisabled: mocks.setHideDisabled,
+  }),
+}));
+
+const LABEL = "Hide disabled agent profiles from left panel navigation";
+
+function ariaChecked(element: Element | null) {
+  return element?.getAttribute("aria-checked");
+}
+
+describe("HideDisabledAgentProfilesSetting", () => {
+  beforeEach(() => {
+    mocks.hideDisabled = false;
+    mocks.setHideDisabled.mockClear();
+  });
+  afterEach(cleanup);
+
+  it("renders the label, description, and an off switch by default", () => {
+    render(<HideDisabledAgentProfilesSetting />);
+
+    expect(screen.getByText(LABEL)).toBeTruthy();
+    expect(
+      screen.getByText(
+        "When on, a disabled agent profile is removed from the left panel navigation even if it's still configured.",
+      ),
+    ).toBeTruthy();
+    const switchEl = screen.getByRole("switch", { name: LABEL });
+    expect(ariaChecked(switchEl)).toBe("false");
+  });
+
+  it("reflects the stored hideDisabled value", () => {
+    mocks.hideDisabled = true;
+    render(<HideDisabledAgentProfilesSetting />);
+
+    expect(ariaChecked(screen.getByRole("switch", { name: LABEL }))).toBe("true");
+  });
+
+  it("saves immediately when toggled", () => {
+    render(<HideDisabledAgentProfilesSetting />);
+
+    fireEvent.click(screen.getByRole("switch", { name: LABEL }));
+
+    expect(mocks.setHideDisabled).toHaveBeenCalledWith(true);
+  });
+});

--- a/apps/web/app/settings/agents/hide-disabled-agent-profiles-setting.tsx
+++ b/apps/web/app/settings/agents/hide-disabled-agent-profiles-setting.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useTranslation } from "react-i18next";
+import { Label } from "@kandev/ui/label";
+import { Switch } from "@kandev/ui/switch";
+import { useHideDisabledAgentProfilesInNav } from "@/hooks/domains/settings/use-hide-disabled-agent-profiles-in-nav";
+
+/**
+ * Row for the "Hide disabled agent profiles from left panel navigation"
+ * setting on `/settings/agents`. Saves immediately on toggle — the agents
+ * page has no settings-floating-save bar, and its profile enabled toggles
+ * are immediate-save too (`useProfileEnabledToggle`).
+ */
+export function HideDisabledAgentProfilesSetting() {
+  const { t } = useTranslation();
+  const { hideDisabled, setHideDisabled } = useHideDisabledAgentProfilesInNav();
+  return (
+    <div className="flex min-h-11 items-center justify-between gap-4 rounded-lg border p-4">
+      <div className="min-w-0 space-y-0.5">
+        <Label htmlFor="hide-disabled-agent-profiles-in-nav">
+          {t("settings:hideDisabledAgentProfilesFromNav")}
+        </Label>
+        <p className="text-xs text-muted-foreground">
+          {t("settings:hideDisabledAgentProfilesFromNavDescription")}
+        </p>
+      </div>
+      <Switch
+        id="hide-disabled-agent-profiles-in-nav"
+        checked={hideDisabled}
+        onCheckedChange={setHideDisabled}
+        className="shrink-0 cursor-pointer"
+      />
+    </div>
+  );
+}

--- a/apps/web/app/settings/agents/page.tsx
+++ b/apps/web/app/settings/agents/page.tsx
@@ -37,6 +37,7 @@ import {
   type DiscoveredAgent,
 } from "@/lib/settings/agent-display-order";
 import { toAgentProfileOption } from "@/lib/state/slices/settings/types";
+import { HideDisabledAgentProfilesSetting } from "@/app/settings/agents/hide-disabled-agent-profiles-setting";
 import type { AgentDiscovery, Agent, AvailableAgent, RuntimeUpdate } from "@/lib/types/http";
 
 type InstalledAgentsSectionProps = {
@@ -366,6 +367,8 @@ export default function AgentsSettingsPage() {
       </div>
 
       <Separator />
+
+      <HideDisabledAgentProfilesSetting />
 
       <InstalledAgentsSection
         installedAgents={installedAgents}

--- a/apps/web/components/app-sidebar/sections/settings/settings-menu-branches.test.ts
+++ b/apps/web/components/app-sidebar/sections/settings/settings-menu-branches.test.ts
@@ -15,6 +15,9 @@ import {
 const WORKSPACE_ID = "ws-1";
 const WORKSPACES_HREF = "/settings/workspaces";
 const WORKSPACES = [{ id: WORKSPACE_ID, name: "Main Workspace" }];
+// Hoisted so the filter tests can build fixtures without re-spelling the
+// display name (sonar duplicate-literal rule).
+const AGENT_DISPLAY_NAME = "Claude Code";
 const AGENTS = [
   {
     name: "claude-code",
@@ -197,9 +200,9 @@ describe("buildAgentsBranch", () => {
     const mixedAgent = {
       name: "claude-code",
       profiles: [
-        { id: "profile-1", name: "Default", agentDisplayName: "Claude Code" },
-        { id: "profile-2", name: "Retired", agentDisplayName: "Claude Code", enabled: false },
-        { id: "profile-3", name: "Legacy", agentDisplayName: "Claude Code" },
+        { id: "profile-1", name: "Default", agentDisplayName: AGENT_DISPLAY_NAME },
+        { id: "profile-2", name: "Retired", agentDisplayName: AGENT_DISPLAY_NAME, enabled: false },
+        { id: "profile-3", name: "Legacy", agentDisplayName: AGENT_DISPLAY_NAME },
       ],
     };
 
@@ -217,8 +220,8 @@ describe("buildAgentsBranch", () => {
     const mixedAgent = {
       name: "claude-code",
       profiles: [
-        { id: "profile-1", name: "Default", agentDisplayName: "Claude Code" },
-        { id: "profile-2", name: "Retired", agentDisplayName: "Claude Code", enabled: false },
+        { id: "profile-1", name: "Default", agentDisplayName: AGENT_DISPLAY_NAME },
+        { id: "profile-2", name: "Retired", agentDisplayName: AGENT_DISPLAY_NAME, enabled: false },
       ],
     };
 

--- a/apps/web/components/app-sidebar/sections/settings/settings-menu-branches.test.ts
+++ b/apps/web/components/app-sidebar/sections/settings/settings-menu-branches.test.ts
@@ -192,6 +192,42 @@ describe("buildAgentsBranch", () => {
   it("drops an agent with no profiles rather than rendering a dead row", () => {
     expect(buildAgentsBranch([{ name: "empty", profiles: [] }])).toEqual([]);
   });
+
+  it("omits disabled profiles from the branch only when the hide setting is on", () => {
+    const mixedAgent = {
+      name: "claude-code",
+      profiles: [
+        { id: "profile-1", name: "Default", agentDisplayName: "Claude Code" },
+        { id: "profile-2", name: "Retired", agentDisplayName: "Claude Code", enabled: false },
+        { id: "profile-3", name: "Legacy", agentDisplayName: "Claude Code" },
+      ],
+    };
+
+    const [agent] = buildAgentsBranch([mixedAgent], undefined, true);
+
+    // Enabled and legacy (no `enabled` field) profiles stay; only `enabled ===
+    // false` is omitted.
+    expect(hrefsOf(agent.children ?? [])).toEqual([
+      "/settings/agents/claude-code/profiles/profile-1",
+      "/settings/agents/claude-code/profiles/profile-3",
+    ]);
+  });
+
+  it("keeps disabled profiles listed when the hide setting is off or absent", () => {
+    const mixedAgent = {
+      name: "claude-code",
+      profiles: [
+        { id: "profile-1", name: "Default", agentDisplayName: "Claude Code" },
+        { id: "profile-2", name: "Retired", agentDisplayName: "Claude Code", enabled: false },
+      ],
+    };
+
+    const [agent] = buildAgentsBranch([mixedAgent]);
+    const [agentWithOff] = buildAgentsBranch([mixedAgent], undefined, false);
+
+    expect(hrefsOf(agent.children ?? [])).toHaveLength(2);
+    expect(hrefsOf(agentWithOff.children ?? [])).toHaveLength(2);
+  });
 });
 
 describe("buildExecutorsBranch", () => {

--- a/apps/web/components/app-sidebar/sections/settings/settings-menu-branches.ts
+++ b/apps/web/components/app-sidebar/sections/settings/settings-menu-branches.ts
@@ -238,6 +238,13 @@ export function buildAgentsBranch(
    * moment before discovery lands would be worse than saying nothing.
    */
   detectedNames?: ReadonlySet<string>,
+  /**
+   * When on ("Hide disabled agent profiles from left panel navigation"),
+   * profiles with `enabled === false` are omitted from the branch. `undefined`
+   * (the setting off) skips filtering entirely; profiles whose `enabled` is
+   * absent are legacy and always stay listed.
+   */
+  hideDisabled?: boolean,
 ): SettingsMenuNode[] {
   return agents
     .filter((agent) => agent.profiles.length > 0)
@@ -254,13 +261,15 @@ export function buildAgentsBranch(
           ? { badge: "not-installed" as const }
           : {}),
         // The agent is kandev's; only the profiles under it are the user's.
-        children: agent.profiles.map((profile) => ({
-          key: `agent:${agent.name}:profile:${profile.id}`,
-          href: `${agentHref}/profiles/${profile.id}`,
-          label: { text: profile.name },
-          isUserRecord: true,
-          ...(profile.enabled === false ? { badge: "disabled" as const } : {}),
-        })),
+        children: agent.profiles
+          .filter((profile) => !hideDisabled || (profile.enabled ?? true))
+          .map((profile) => ({
+            key: `agent:${agent.name}:profile:${profile.id}`,
+            href: `${agentHref}/profiles/${profile.id}`,
+            label: { text: profile.name },
+            isUserRecord: true,
+            ...(profile.enabled === false ? { badge: "disabled" as const } : {}),
+          })),
       };
     });
 }

--- a/apps/web/components/app-sidebar/sections/settings/settings-tree-render.test.tsx
+++ b/apps/web/components/app-sidebar/sections/settings/settings-tree-render.test.tsx
@@ -406,10 +406,12 @@ describe("SettingsTree badges", () => {
     state.agentDiscovery.items = [];
     state.agentDiscovery.loaded = false;
     integrationsEnabled.clear();
+    window.localStorage.removeItem("kandev:agents:hideDisabledInNav:v1");
   });
 
   afterEach(() => {
     setMenuMode("flat");
+    window.localStorage.removeItem("kandev:agents:hideDisabledInNav:v1");
     cleanup();
   });
 
@@ -422,6 +424,28 @@ describe("SettingsTree badges", () => {
     // but stays here, so the menu has to say why it looks inert.
     expect(screen.getByRole("link", { name: /Retired/ }).textContent).toContain("Disabled");
     expect(screen.getByRole("link", { name: "Default" }).textContent).not.toContain("Disabled");
+  });
+
+  it("hides a disabled profile from the tree when the hide setting is on", () => {
+    window.localStorage.setItem("kandev:agents:hideDisabledInNav:v1", "true");
+    setMenuMode("persistent", [AGENTS_ROW_KEY, AGENT_KEY]);
+    render(<SettingsTree pathname="/settings/preferences/appearance" />);
+
+    expect(screen.queryByRole("link", { name: /Retired/ })).toBeNull();
+    expect(screen.getByRole("link", { name: "Default" })).toBeTruthy();
+  });
+
+  it("reveals a disabled profile again once the hide setting is turned back off", () => {
+    window.localStorage.setItem("kandev:agents:hideDisabledInNav:v1", "true");
+    setMenuMode("persistent", [AGENTS_ROW_KEY, AGENT_KEY]);
+    const { rerender } = render(<SettingsTree pathname="/settings/preferences/appearance" />);
+    expect(screen.queryByRole("link", { name: /Retired/ })).toBeNull();
+
+    window.localStorage.removeItem("kandev:agents:hideDisabledInNav:v1");
+    window.dispatchEvent(new Event("kandev:agents:hide-disabled-in-nav-changed"));
+    rerender(<SettingsTree pathname="/settings/preferences/appearance" />);
+
+    expect(screen.getByRole("link", { name: /Retired/ }).textContent).toContain("Disabled");
   });
 
   it("badges the active workspace, the way its own list does", () => {

--- a/apps/web/components/app-sidebar/sections/settings/settings-tree-render.test.tsx
+++ b/apps/web/components/app-sidebar/sections/settings/settings-tree-render.test.tsx
@@ -18,6 +18,10 @@ const AGENT_LABEL = "Claude Code";
 // Anchored: the caret beside the row is labelled "Expand/Collapse Claude Code",
 // and a badge can extend the row's own name past an exact match.
 const AGENT_ROW = /^Claude Code/;
+// The hide-disabled setting's storage key, used to flip the real hook in the
+// tree tests. Hoisted to a constant so the sonar duplicate-literal rule stays
+// quiet.
+const HIDE_DISABLED_AGENT_KEY = "kandev:agents:hideDisabledInNav:v1";
 // Which integrations the probe reports as connected, per test.
 const integrationsEnabled = new Set<string>();
 
@@ -406,12 +410,12 @@ describe("SettingsTree badges", () => {
     state.agentDiscovery.items = [];
     state.agentDiscovery.loaded = false;
     integrationsEnabled.clear();
-    window.localStorage.removeItem("kandev:agents:hideDisabledInNav:v1");
+    window.localStorage.removeItem(HIDE_DISABLED_AGENT_KEY);
   });
 
   afterEach(() => {
     setMenuMode("flat");
-    window.localStorage.removeItem("kandev:agents:hideDisabledInNav:v1");
+    window.localStorage.removeItem(HIDE_DISABLED_AGENT_KEY);
     cleanup();
   });
 
@@ -427,7 +431,7 @@ describe("SettingsTree badges", () => {
   });
 
   it("hides a disabled profile from the tree when the hide setting is on", () => {
-    window.localStorage.setItem("kandev:agents:hideDisabledInNav:v1", "true");
+    window.localStorage.setItem(HIDE_DISABLED_AGENT_KEY, "true");
     setMenuMode("persistent", [AGENTS_ROW_KEY, AGENT_KEY]);
     render(<SettingsTree pathname="/settings/preferences/appearance" />);
 
@@ -436,12 +440,12 @@ describe("SettingsTree badges", () => {
   });
 
   it("reveals a disabled profile again once the hide setting is turned back off", () => {
-    window.localStorage.setItem("kandev:agents:hideDisabledInNav:v1", "true");
+    window.localStorage.setItem(HIDE_DISABLED_AGENT_KEY, "true");
     setMenuMode("persistent", [AGENTS_ROW_KEY, AGENT_KEY]);
     const { rerender } = render(<SettingsTree pathname="/settings/preferences/appearance" />);
     expect(screen.queryByRole("link", { name: /Retired/ })).toBeNull();
 
-    window.localStorage.removeItem("kandev:agents:hideDisabledInNav:v1");
+    window.localStorage.removeItem(HIDE_DISABLED_AGENT_KEY);
     window.dispatchEvent(new Event("kandev:agents:hide-disabled-in-nav-changed"));
     rerender(<SettingsTree pathname="/settings/preferences/appearance" />);
 

--- a/apps/web/components/app-sidebar/sections/settings/use-settings-menu-branches.ts
+++ b/apps/web/components/app-sidebar/sections/settings/use-settings-menu-branches.ts
@@ -7,6 +7,7 @@ import { useAzureDevOpsEnabled } from "@/hooks/domains/azure-devops/use-azure-de
 import { useGitHubEnabled } from "@/hooks/domains/github/use-github-enabled";
 import { useGitLabEnabled } from "@/hooks/domains/gitlab/use-gitlab-enabled";
 import { useHideDisabledIntegrationsInNav } from "@/hooks/domains/integrations/use-hide-disabled-integrations-in-nav";
+import { useHideDisabledAgentProfilesInNav } from "@/hooks/domains/settings/use-hide-disabled-agent-profiles-in-nav";
 import { useJiraEnabled } from "@/hooks/domains/jira/use-jira-enabled";
 import { useLinearEnabled } from "@/hooks/domains/linear/use-linear-enabled";
 import { useSentryEnabled } from "@/hooks/domains/sentry/use-sentry-enabled";
@@ -60,6 +61,7 @@ export function useSettingsMenuBranches(mode: SettingsMenuMode): SettingsMenuBra
   const agentDiscovery = useAppStore((s) => s.agentDiscovery.items);
   const discoveryLoaded = useAppStore((s) => s.agentDiscovery.loaded);
   const visibleIntegrations = useVisibleIntegrationSlugs();
+  const { hideDisabled: hideDisabledAgentProfiles } = useHideDisabledAgentProfilesInNav();
 
   return useMemo(() => {
     if (!isTree) return NO_BRANCHES;
@@ -74,7 +76,10 @@ export function useSettingsMenuBranches(mode: SettingsMenuMode): SettingsMenuBra
         WORKSPACES_SETTINGS_HREF,
         buildWorkspacesBranch(workspaces, activeWorkspaceId, visibleIntegrations),
       ),
-      ...branchEntry(AGENTS_SETTINGS_HREF, buildAgentsBranch(orderedAgents, detectedNames)),
+      ...branchEntry(
+        AGENTS_SETTINGS_HREF,
+        buildAgentsBranch(orderedAgents, detectedNames, hideDisabledAgentProfiles),
+      ),
       ...branchEntry(EXECUTORS_SETTINGS_HREF, buildExecutorsBranch(executors)),
     };
   }, [
@@ -86,6 +91,7 @@ export function useSettingsMenuBranches(mode: SettingsMenuMode): SettingsMenuBra
     agentDiscovery,
     discoveryLoaded,
     visibleIntegrations,
+    hideDisabledAgentProfiles,
   ]);
 }
 

--- a/apps/web/e2e/tests/settings/hide-disabled-agent-profiles-nav.spec.ts
+++ b/apps/web/e2e/tests/settings/hide-disabled-agent-profiles-nav.spec.ts
@@ -31,11 +31,17 @@ test.describe("hide disabled agent profiles from left panel navigation", () => {
       // profile leaves. Seeded before every navigation (the page boots the
       // mode from localStorage on the first render).
       await testPage.addInitScript(() => {
-        window.localStorage.setItem("kandev.settings.menuMode", "accordion");
+        // getLocalStorage JSON-parses the value, so the mode must be stored
+        // the way setLocalStorage would write it.
+        window.localStorage.setItem("kandev.settings.menuMode", JSON.stringify("accordion"));
       });
 
       await testPage.goto("/settings/agents");
       const settingsTree = testPage.getByTestId("app-sidebar-settings-mode");
+      // Accordion opens the route-owned Agents row; the agent node under it
+      // (Mock) has no page of its own, so expand it to expose the profile
+      // leaves.
+      await settingsTree.getByRole("button", { name: "Expand Mock" }).click();
       const disabledLink = settingsTree.getByRole("link", { name: profileLink });
       await expect(disabledLink).toBeVisible({ timeout: 15_000 });
 
@@ -48,7 +54,7 @@ test.describe("hide disabled agent profiles from left panel navigation", () => {
       await hideDisabledSwitch.click();
       await expect(hideDisabledSwitch).toHaveAttribute("aria-checked", "true");
       await expect(disabledLink).not.toBeVisible();
-      await expect(settingsTree.getByRole("link", { name: "Agents", exact: true })).toBeVisible();
+      await expect(settingsTree.getByRole("link", { name: /^Agents/ })).toBeVisible();
 
       // Re-enable from the profile editor (the settings list no longer holds
       // the toggle after the PageShell restructure) and confirm the tree
@@ -63,6 +69,9 @@ test.describe("hide disabled agent profiles from left panel navigation", () => {
       await expect(testPage.getByText(/unsaved changes/i)).toBeHidden({ timeout: 15_000 });
 
       await testPage.goto("/settings/agents");
+      // Fresh page load collapses the agent node again; re-expand it before
+      // asserting the revealed profile.
+      await settingsTree.getByRole("button", { name: "Expand Mock" }).click();
       await expect(disabledLink).toBeVisible({ timeout: 15_000 });
     } finally {
       // Always restore so worker-scoped seedData stays valid for later tests.

--- a/apps/web/e2e/tests/settings/hide-disabled-agent-profiles-nav.spec.ts
+++ b/apps/web/e2e/tests/settings/hide-disabled-agent-profiles-nav.spec.ts
@@ -15,16 +15,24 @@ test.describe("hide disabled agent profiles from left panel navigation", () => {
     const { agents } = await apiClient.listAgents();
     const agent = agents[0];
     const profile = agent.profiles[0];
-    const agentLabel = profile.agentDisplayName || agent.name;
-    // The tree renders `${agentLabel} • ${profile.name}` and appends the
-    // "Disabled" badge suffix while the profile is disabled — an unanchored
-    // regex matches both states.
-    const profileLink = new RegExp(`${escapeRegExp(agentLabel)} • ${escapeRegExp(profile.name)}`);
+    // The Settings tree's profile leaf is labelled with the profile name and
+    // appends the "Disabled" badge while the profile is disabled — an
+    // unanchored regex matches both states.
+    const profileLink = new RegExp(escapeRegExp(profile.name));
 
     try {
-      // Disable the seeded profile via the API. The settings-list toggle
+      // Disable the seeded profile via the API. The profile editor toggle
       // itself is covered by agent-profile-disable.spec.ts.
       await apiClient.updateAgentProfile(profile.id, { enabled: false });
+
+      // The Settings sidebar defaults to the flat menu; the per-profile
+      // Agents tree only renders in a tree mode. Accordion opens the branch
+      // whose page owns the current route, so /settings/agents shows the
+      // profile leaves. Seeded before every navigation (the page boots the
+      // mode from localStorage on the first render).
+      await testPage.addInitScript(() => {
+        window.localStorage.setItem("kandev.settings.menuMode", "accordion");
+      });
 
       await testPage.goto("/settings/agents");
       const settingsTree = testPage.getByTestId("app-sidebar-settings-mode");
@@ -36,20 +44,25 @@ test.describe("hide disabled agent profiles from left panel navigation", () => {
       await expect(hideDisabledSwitch).toHaveAttribute("aria-checked", "false");
 
       // Turn "hide disabled" on — the tree entry disappears immediately,
-      // while the Agents group header stays.
+      // while the Agents row stays.
       await hideDisabledSwitch.click();
       await expect(hideDisabledSwitch).toHaveAttribute("aria-checked", "true");
       await expect(disabledLink).not.toBeVisible();
       await expect(settingsTree.getByRole("link", { name: "Agents", exact: true })).toBeVisible();
 
-      // The settings page itself still lists the disabled profile.
-      const rowToggle = testPage.getByTestId(`profile-enabled-toggle-${profile.id}`);
-      await expect(rowToggle).toHaveAttribute("data-state", "unchecked", { timeout: 15_000 });
+      // Re-enable from the profile editor (the settings list no longer holds
+      // the toggle after the PageShell restructure) and confirm the tree
+      // entry reappears with the setting still on (no reload).
+      await testPage.goto(`/settings/agents/${agent.name}/profiles/${profile.id}`);
+      const headerToggle = testPage.getByTestId("profile-enabled-toggle");
+      await expect(headerToggle).toBeVisible({ timeout: 15_000 });
+      await expect(headerToggle).toHaveAttribute("data-state", "unchecked");
+      await headerToggle.click();
+      await expect(headerToggle).toHaveAttribute("data-state", "checked");
+      await testPage.getByRole("button", { name: /^Save( changes)?$/i }).click();
+      await expect(testPage.getByText(/unsaved changes/i)).toBeHidden({ timeout: 15_000 });
 
-      // Re-enabling from the list reveals the profile again even with the
-      // setting still on (no reload).
-      await rowToggle.click();
-      await expect(rowToggle).toHaveAttribute("data-state", "checked");
+      await testPage.goto("/settings/agents");
       await expect(disabledLink).toBeVisible({ timeout: 15_000 });
     } finally {
       // Always restore so worker-scoped seedData stays valid for later tests.

--- a/apps/web/e2e/tests/settings/hide-disabled-agent-profiles-nav.spec.ts
+++ b/apps/web/e2e/tests/settings/hide-disabled-agent-profiles-nav.spec.ts
@@ -1,0 +1,63 @@
+import { test, expect } from "../../fixtures/test-base";
+
+// Covers docs/specs/agents/hide-disabled-profiles-nav.md's nav-visibility
+// scenarios: with "Hide disabled agent profiles from left panel navigation"
+// off (the default), a disabled profile still shows in the Settings left
+// panel's Agents tree; turning the setting on hides it; re-enabling the
+// profile reveals it again — all without a reload.
+test.describe("hide disabled agent profiles from left panel navigation", () => {
+  test("off by default keeps a disabled profile visible; on hides it; re-enabling reveals it", async ({
+    testPage,
+    apiClient,
+  }) => {
+    test.setTimeout(120_000);
+
+    const { agents } = await apiClient.listAgents();
+    const agent = agents[0];
+    const profile = agent.profiles[0];
+    const agentLabel = profile.agentDisplayName || agent.name;
+    // The tree renders `${agentLabel} • ${profile.name}` and appends the
+    // "Disabled" badge suffix while the profile is disabled — an unanchored
+    // regex matches both states.
+    const profileLink = new RegExp(`${escapeRegExp(agentLabel)} • ${escapeRegExp(profile.name)}`);
+
+    try {
+      // Disable the seeded profile via the API. The settings-list toggle
+      // itself is covered by agent-profile-disable.spec.ts.
+      await apiClient.updateAgentProfile(profile.id, { enabled: false });
+
+      await testPage.goto("/settings/agents");
+      const settingsTree = testPage.getByTestId("app-sidebar-settings-mode");
+      const disabledLink = settingsTree.getByRole("link", { name: profileLink });
+      await expect(disabledLink).toBeVisible({ timeout: 15_000 });
+
+      // The setting is off by default.
+      const hideDisabledSwitch = testPage.locator("#hide-disabled-agent-profiles-in-nav");
+      await expect(hideDisabledSwitch).toHaveAttribute("aria-checked", "false");
+
+      // Turn "hide disabled" on — the tree entry disappears immediately,
+      // while the Agents group header stays.
+      await hideDisabledSwitch.click();
+      await expect(hideDisabledSwitch).toHaveAttribute("aria-checked", "true");
+      await expect(disabledLink).not.toBeVisible();
+      await expect(settingsTree.getByRole("link", { name: "Agents", exact: true })).toBeVisible();
+
+      // The settings page itself still lists the disabled profile.
+      const rowToggle = testPage.getByTestId(`profile-enabled-toggle-${profile.id}`);
+      await expect(rowToggle).toHaveAttribute("data-state", "unchecked", { timeout: 15_000 });
+
+      // Re-enabling from the list reveals the profile again even with the
+      // setting still on (no reload).
+      await rowToggle.click();
+      await expect(rowToggle).toHaveAttribute("data-state", "checked");
+      await expect(disabledLink).toBeVisible({ timeout: 15_000 });
+    } finally {
+      // Always restore so worker-scoped seedData stays valid for later tests.
+      await apiClient.updateAgentProfile(profile.id, { enabled: true }).catch(() => {});
+    }
+  });
+});
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/apps/web/hooks/domains/azure-devops/use-azure-devops-enabled.test.ts
+++ b/apps/web/hooks/domains/azure-devops/use-azure-devops-enabled.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { useAzureDevOpsEnabled } from "./use-azure-devops-enabled";
-import { makeLocalStorageMock } from "../integrations/local-storage-mock.test-helpers";
+import { makeLocalStorageMock } from "../../local-storage-mock.test-helpers";
 
 const STORAGE_KEY = "kandev:azure-devops:enabled:v1";
 

--- a/apps/web/hooks/domains/github/use-github-enabled.test.ts
+++ b/apps/web/hooks/domains/github/use-github-enabled.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { useGitHubEnabled } from "./use-github-enabled";
-import { makeLocalStorageMock } from "../integrations/local-storage-mock.test-helpers";
+import { makeLocalStorageMock } from "../../local-storage-mock.test-helpers";
 
 const STORAGE_KEY = "kandev:github:enabled:v1";
 

--- a/apps/web/hooks/domains/gitlab/use-gitlab-enabled.test.ts
+++ b/apps/web/hooks/domains/gitlab/use-gitlab-enabled.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { useGitLabEnabled } from "./use-gitlab-enabled";
-import { makeLocalStorageMock } from "../integrations/local-storage-mock.test-helpers";
+import { makeLocalStorageMock } from "../../local-storage-mock.test-helpers";
 
 const STORAGE_KEY = "kandev:gitlab:enabled:v1";
 

--- a/apps/web/hooks/domains/integrations/local-storage-mock.test-helpers.ts
+++ b/apps/web/hooks/domains/integrations/local-storage-mock.test-helpers.ts
@@ -1,9 +1,12 @@
 /**
- * Shared in-memory localStorage mock for the per-integration "enabled" hook
- * test suites (azure-devops, github, gitlab, hide-disabled-in-nav). Each
- * test file calls this factory to build its own mock instance — the store
- * is never shared across files, so suites stay isolated from one another
- * even though they all use the same shape.
+ * Shared in-memory localStorage mock for the hook test suites that read
+ * `localStorage`-backed preferences: the per-integration "enabled" hooks
+ * (azure-devops, github, gitlab, jira, linear, sentry), the two nav-visibility
+ * toggles (hide-disabled integrations / agent profiles), and the shared
+ * `useLocalStorageBoolean` primitive. Each test file calls this factory to
+ * build its own mock instance — the store is never shared across files, so
+ * suites stay isolated from one another even though they all use the same
+ * shape.
  */
 export function makeLocalStorageMock() {
   const store = new Map<string, string>();

--- a/apps/web/hooks/domains/integrations/use-hide-disabled-integrations-in-nav.test.ts
+++ b/apps/web/hooks/domains/integrations/use-hide-disabled-integrations-in-nav.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { useHideDisabledIntegrationsInNav } from "./use-hide-disabled-integrations-in-nav";
-import { makeLocalStorageMock } from "./local-storage-mock.test-helpers";
+import { makeLocalStorageMock } from "../../local-storage-mock.test-helpers";
 
 const STORAGE_KEY = "kandev:integrations:hideDisabledInNav:v1";
 

--- a/apps/web/hooks/domains/integrations/use-hide-disabled-integrations-in-nav.ts
+++ b/apps/web/hooks/domains/integrations/use-hide-disabled-integrations-in-nav.ts
@@ -1,57 +1,22 @@
 "use client";
 
-import { useCallback, useMemo, useSyncExternalStore } from "react";
+import { useLocalStorageBoolean } from "@/hooks/use-local-storage-boolean";
 
 const STORAGE_KEY = "kandev:integrations:hideDisabledInNav:v1";
 const SYNC_EVENT = "kandev:integrations:hide-disabled-in-nav-changed";
 
-/** Reads the persisted "hide disabled integrations from nav" flag, defaulting to `false`. */
-function readHideDisabled(): boolean {
-  if (typeof window === "undefined") return false;
-  try {
-    return window.localStorage.getItem(STORAGE_KEY) === "true";
-  } catch {
-    // Quota / private mode — fall through; the setting just defaults to off.
-    return false;
-  }
-}
-
 /**
  * The integrations index page's "Hide disabled integrations from left panel
  * navigation" setting: a single, install-wide, `localStorage`-backed boolean
- * (not per-integration), defaulting to `false`. Shares the
- * `useSyncExternalStore` + `storage` event + custom-event broadcast shape
- * with `hooks/domains/integrations/use-integration-enabled.ts`, but has no
- * per-integration key and no legacy migration — this setting is new, there
- * is nothing to migrate.
+ * (not per-integration), defaulting to `false`. Delegates to the shared
+ * `useLocalStorageBoolean` primitive (same storage-event + custom-event
+ * broadcast shape all nav-visibility toggles use), so the integrations and
+ * agent-profiles settings cannot drift in mechanism.
  */
 export function useHideDisabledIntegrationsInNav() {
-  const subscribe = useMemo(
-    () => (notify: () => void) => {
-      const onCustomEvent = () => notify();
-      window.addEventListener(SYNC_EVENT, onCustomEvent);
-      window.addEventListener("storage", onCustomEvent);
-      return () => {
-        window.removeEventListener(SYNC_EVENT, onCustomEvent);
-        window.removeEventListener("storage", onCustomEvent);
-      };
-    },
-    [],
+  const { value: hideDisabled, setValue: setHideDisabled } = useLocalStorageBoolean(
+    STORAGE_KEY,
+    SYNC_EVENT,
   );
-
-  const getSnapshot = useCallback(() => readHideDisabled(), []);
-  const getServerSnapshot = useCallback(() => false, []);
-
-  const hideDisabled = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
-
-  const setHideDisabled = useCallback((next: boolean) => {
-    try {
-      window.localStorage.setItem(STORAGE_KEY, String(next));
-    } catch (error) {
-      throw new Error(`Failed to persist ${STORAGE_KEY}`, { cause: error });
-    }
-    window.dispatchEvent(new Event(SYNC_EVENT));
-  }, []);
-
   return { hideDisabled, setHideDisabled };
 }

--- a/apps/web/hooks/domains/settings/use-hide-disabled-agent-profiles-in-nav.test.ts
+++ b/apps/web/hooks/domains/settings/use-hide-disabled-agent-profiles-in-nav.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { useHideDisabledAgentProfilesInNav } from "./use-hide-disabled-agent-profiles-in-nav";
+import { makeLocalStorageMock } from "@/hooks/domains/integrations/local-storage-mock.test-helpers";
+
+const STORAGE_KEY = "kandev:agents:hideDisabledInNav:v1";
+
+const localStorageMock = makeLocalStorageMock();
+vi.stubGlobal("localStorage", localStorageMock);
+Object.defineProperty(window, "localStorage", {
+  value: localStorageMock,
+  configurable: true,
+});
+
+describe("useHideDisabledAgentProfilesInNav", () => {
+  beforeEach(() => {
+    localStorageMock.clear();
+  });
+  afterEach(() => {
+    localStorageMock.clear();
+  });
+
+  it("defaults to hideDisabled=false when no localStorage entry exists", () => {
+    const { result } = renderHook(() => useHideDisabledAgentProfilesInNav());
+    expect(result.current.hideDisabled).toBe(false);
+  });
+
+  it('reads hideDisabled=true only when stored as the literal string "true"', () => {
+    window.localStorage.setItem(STORAGE_KEY, "true");
+    const { result } = renderHook(() => useHideDisabledAgentProfilesInNav());
+    expect(result.current.hideDisabled).toBe(true);
+  });
+
+  it.each(["false", "1", "yes", ""])(
+    'treats persisted value %p as off — only the literal "true" enables it',
+    (storedValue) => {
+      window.localStorage.setItem(STORAGE_KEY, storedValue);
+      const { result } = renderHook(() => useHideDisabledAgentProfilesInNav());
+      expect(result.current.hideDisabled).toBe(false);
+    },
+  );
+
+  it("setHideDisabled persists to localStorage and updates state", async () => {
+    const { result } = renderHook(() => useHideDisabledAgentProfilesInNav());
+    expect(result.current.hideDisabled).toBe(false);
+
+    act(() => result.current.setHideDisabled(true));
+
+    await waitFor(() => expect(result.current.hideDisabled).toBe(true));
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("true");
+  });
+
+  it("propagates updates dispatched via the kandev:agents:hide-disabled-in-nav-changed event", async () => {
+    const { result } = renderHook(() => useHideDisabledAgentProfilesInNav());
+    expect(result.current.hideDisabled).toBe(false);
+
+    act(() => {
+      window.localStorage.setItem(STORAGE_KEY, "true");
+      window.dispatchEvent(new Event("kandev:agents:hide-disabled-in-nav-changed"));
+    });
+
+    await waitFor(() => expect(result.current.hideDisabled).toBe(true));
+  });
+
+  it("degrades to hideDisabled=false when localStorage.getItem throws", () => {
+    const original = localStorageMock.getItem;
+    localStorageMock.getItem = () => {
+      throw new Error("quota exceeded");
+    };
+    try {
+      const { result } = renderHook(() => useHideDisabledAgentProfilesInNav());
+      expect(result.current.hideDisabled).toBe(false);
+    } finally {
+      localStorageMock.getItem = original;
+    }
+  });
+
+  it("throws instead of reporting a successful save when localStorage.setItem fails", () => {
+    const original = localStorageMock.setItem;
+    localStorageMock.setItem = () => {
+      throw new Error("quota exceeded");
+    };
+    try {
+      const { result } = renderHook(() => useHideDisabledAgentProfilesInNav());
+      expect(() => result.current.setHideDisabled(true)).toThrow();
+      expect(result.current.hideDisabled).toBe(false);
+    } finally {
+      localStorageMock.setItem = original;
+    }
+  });
+});

--- a/apps/web/hooks/domains/settings/use-hide-disabled-agent-profiles-in-nav.test.ts
+++ b/apps/web/hooks/domains/settings/use-hide-disabled-agent-profiles-in-nav.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { useHideDisabledAgentProfilesInNav } from "./use-hide-disabled-agent-profiles-in-nav";
-import { makeLocalStorageMock } from "@/hooks/domains/integrations/local-storage-mock.test-helpers";
+import { makeLocalStorageMock } from "@/hooks/local-storage-mock.test-helpers";
 
 const STORAGE_KEY = "kandev:agents:hideDisabledInNav:v1";
 

--- a/apps/web/hooks/domains/settings/use-hide-disabled-agent-profiles-in-nav.ts
+++ b/apps/web/hooks/domains/settings/use-hide-disabled-agent-profiles-in-nav.ts
@@ -1,0 +1,57 @@
+"use client";
+
+import { useCallback, useMemo, useSyncExternalStore } from "react";
+
+const STORAGE_KEY = "kandev:agents:hideDisabledInNav:v1";
+const SYNC_EVENT = "kandev:agents:hide-disabled-in-nav-changed";
+
+/** Reads the persisted "hide disabled agent profiles from nav" flag, defaulting to `false`. */
+function readHideDisabled(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(STORAGE_KEY) === "true";
+  } catch {
+    // Quota / private mode — fall through; the setting just defaults to off.
+    return false;
+  }
+}
+
+/**
+ * The agents settings page's "Hide disabled agent profiles from left panel
+ * navigation" setting: a single, install-wide, `localStorage`-backed boolean
+ * (not per-profile), defaulting to `false`. Shares the
+ * `useSyncExternalStore` + `storage` event + custom-event broadcast shape
+ * with `hooks/domains/integrations/use-hide-disabled-integrations-in-nav.ts`,
+ * so the Settings left panel's Agents tree re-renders immediately in the
+ * same tab and other tabs update via the browser `storage` event.
+ */
+export function useHideDisabledAgentProfilesInNav() {
+  const subscribe = useMemo(
+    () => (notify: () => void) => {
+      const onCustomEvent = () => notify();
+      window.addEventListener(SYNC_EVENT, onCustomEvent);
+      window.addEventListener("storage", onCustomEvent);
+      return () => {
+        window.removeEventListener(SYNC_EVENT, onCustomEvent);
+        window.removeEventListener("storage", onCustomEvent);
+      };
+    },
+    [],
+  );
+
+  const getSnapshot = useCallback(() => readHideDisabled(), []);
+  const getServerSnapshot = useCallback(() => false, []);
+
+  const hideDisabled = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+
+  const setHideDisabled = useCallback((next: boolean) => {
+    try {
+      window.localStorage.setItem(STORAGE_KEY, String(next));
+    } catch (error) {
+      throw new Error(`Failed to persist ${STORAGE_KEY}`, { cause: error });
+    }
+    window.dispatchEvent(new Event(SYNC_EVENT));
+  }, []);
+
+  return { hideDisabled, setHideDisabled };
+}

--- a/apps/web/hooks/domains/settings/use-hide-disabled-agent-profiles-in-nav.ts
+++ b/apps/web/hooks/domains/settings/use-hide-disabled-agent-profiles-in-nav.ts
@@ -1,57 +1,22 @@
 "use client";
 
-import { useCallback, useMemo, useSyncExternalStore } from "react";
+import { useLocalStorageBoolean } from "@/hooks/use-local-storage-boolean";
 
 const STORAGE_KEY = "kandev:agents:hideDisabledInNav:v1";
 const SYNC_EVENT = "kandev:agents:hide-disabled-in-nav-changed";
 
-/** Reads the persisted "hide disabled agent profiles from nav" flag, defaulting to `false`. */
-function readHideDisabled(): boolean {
-  if (typeof window === "undefined") return false;
-  try {
-    return window.localStorage.getItem(STORAGE_KEY) === "true";
-  } catch {
-    // Quota / private mode — fall through; the setting just defaults to off.
-    return false;
-  }
-}
-
 /**
  * The agents settings page's "Hide disabled agent profiles from left panel
  * navigation" setting: a single, install-wide, `localStorage`-backed boolean
- * (not per-profile), defaulting to `false`. Shares the
- * `useSyncExternalStore` + `storage` event + custom-event broadcast shape
- * with `hooks/domains/integrations/use-hide-disabled-integrations-in-nav.ts`,
- * so the Settings left panel's Agents tree re-renders immediately in the
- * same tab and other tabs update via the browser `storage` event.
+ * (not per-profile), defaulting to `false`. Delegates to the shared
+ * `useLocalStorageBoolean` primitive (same storage-event + custom-event
+ * broadcast shape all nav-visibility toggles use), so the integrations and
+ * agent-profiles settings cannot drift in mechanism.
  */
 export function useHideDisabledAgentProfilesInNav() {
-  const subscribe = useMemo(
-    () => (notify: () => void) => {
-      const onCustomEvent = () => notify();
-      window.addEventListener(SYNC_EVENT, onCustomEvent);
-      window.addEventListener("storage", onCustomEvent);
-      return () => {
-        window.removeEventListener(SYNC_EVENT, onCustomEvent);
-        window.removeEventListener("storage", onCustomEvent);
-      };
-    },
-    [],
+  const { value: hideDisabled, setValue: setHideDisabled } = useLocalStorageBoolean(
+    STORAGE_KEY,
+    SYNC_EVENT,
   );
-
-  const getSnapshot = useCallback(() => readHideDisabled(), []);
-  const getServerSnapshot = useCallback(() => false, []);
-
-  const hideDisabled = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
-
-  const setHideDisabled = useCallback((next: boolean) => {
-    try {
-      window.localStorage.setItem(STORAGE_KEY, String(next));
-    } catch (error) {
-      throw new Error(`Failed to persist ${STORAGE_KEY}`, { cause: error });
-    }
-    window.dispatchEvent(new Event(SYNC_EVENT));
-  }, []);
-
   return { hideDisabled, setHideDisabled };
 }

--- a/apps/web/hooks/local-storage-mock.test-helpers.ts
+++ b/apps/web/hooks/local-storage-mock.test-helpers.ts
@@ -3,8 +3,9 @@
  * `localStorage`-backed preferences: the per-integration "enabled" hooks
  * (azure-devops, github, gitlab, jira, linear, sentry), the two nav-visibility
  * toggles (hide-disabled integrations / agent profiles), and the shared
- * `useLocalStorageBoolean` primitive. Each test file calls this factory to
- * build its own mock instance — the store is never shared across files, so
+ * `useLocalStorageBoolean` primitive. Lives at the top level of the hooks tree
+ * because it is not owned by any one domain. Each test file calls this factory
+ * to build its own mock instance — the store is never shared across files, so
  * suites stay isolated from one another even though they all use the same
  * shape.
  */

--- a/apps/web/hooks/use-local-storage-boolean.test.ts
+++ b/apps/web/hooks/use-local-storage-boolean.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { useLocalStorageBoolean } from "./use-local-storage-boolean";
-import { makeLocalStorageMock } from "@/hooks/domains/integrations/local-storage-mock.test-helpers";
+import { makeLocalStorageMock } from "@/hooks/local-storage-mock.test-helpers";
 
 const STORAGE_KEY = "kandev:generic:flag:v1";
 const SYNC_EVENT = "kandev:generic:flag-changed";

--- a/apps/web/hooks/use-local-storage-boolean.test.ts
+++ b/apps/web/hooks/use-local-storage-boolean.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { useLocalStorageBoolean } from "./use-local-storage-boolean";
+import { makeLocalStorageMock } from "@/hooks/domains/integrations/local-storage-mock.test-helpers";
+
+const STORAGE_KEY = "kandev:generic:flag:v1";
+const SYNC_EVENT = "kandev:generic:flag-changed";
+
+const localStorageMock = makeLocalStorageMock();
+vi.stubGlobal("localStorage", localStorageMock);
+Object.defineProperty(window, "localStorage", {
+  value: localStorageMock,
+  configurable: true,
+});
+
+describe("useLocalStorageBoolean", () => {
+  beforeEach(() => {
+    localStorageMock.clear();
+  });
+  afterEach(() => {
+    localStorageMock.clear();
+  });
+
+  it("defaults to the caller's defaultValue when no entry exists", () => {
+    const { result } = renderHook(() => useLocalStorageBoolean(STORAGE_KEY, SYNC_EVENT, true));
+    expect(result.current.value).toBe(true);
+  });
+
+  it("defaults to false when no entry exists and defaultValue is omitted", () => {
+    const { result } = renderHook(() => useLocalStorageBoolean(STORAGE_KEY, SYNC_EVENT));
+    expect(result.current.value).toBe(false);
+  });
+
+  it('reads the literal string "true" only', () => {
+    window.localStorage.setItem(STORAGE_KEY, "true");
+    const { result } = renderHook(() => useLocalStorageBoolean(STORAGE_KEY, SYNC_EVENT));
+    expect(result.current.value).toBe(true);
+
+    window.localStorage.setItem(STORAGE_KEY, "1");
+    const { result: off } = renderHook(() => useLocalStorageBoolean(STORAGE_KEY, SYNC_EVENT));
+    expect(off.current.value).toBe(false);
+  });
+
+  it("setValue persists to the caller's key and updates state", async () => {
+    const { result } = renderHook(() => useLocalStorageBoolean(STORAGE_KEY, SYNC_EVENT));
+    expect(result.current.value).toBe(false);
+
+    act(() => result.current.setValue(true));
+
+    await waitFor(() => expect(result.current.value).toBe(true));
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("true");
+  });
+
+  it("propagates updates dispatched via the caller's sync event", async () => {
+    const { result } = renderHook(() => useLocalStorageBoolean(STORAGE_KEY, SYNC_EVENT));
+    expect(result.current.value).toBe(false);
+
+    act(() => {
+      window.localStorage.setItem(STORAGE_KEY, "true");
+      window.dispatchEvent(new Event(SYNC_EVENT));
+    });
+
+    await waitFor(() => expect(result.current.value).toBe(true));
+  });
+
+  it("ignores other storage keys' values and does not cross-talk sync events", () => {
+    const otherKey = "kandev:other:flag:v1";
+    const otherEvent = "kandev:other:flag-changed";
+    window.localStorage.setItem(otherKey, "true");
+    const { result } = renderHook(() => useLocalStorageBoolean(STORAGE_KEY, SYNC_EVENT));
+    expect(result.current.value).toBe(false);
+
+    act(() => {
+      window.dispatchEvent(new Event(otherEvent));
+    });
+    expect(result.current.value).toBe(false);
+  });
+
+  it("degrades to the default when localStorage.getItem throws", () => {
+    const original = localStorageMock.getItem;
+    localStorageMock.getItem = () => {
+      throw new Error("quota exceeded");
+    };
+    try {
+      const { result } = renderHook(() => useLocalStorageBoolean(STORAGE_KEY, SYNC_EVENT));
+      expect(result.current.value).toBe(false);
+    } finally {
+      localStorageMock.getItem = original;
+    }
+  });
+
+  it("throws instead of reporting a successful save when localStorage.setItem fails", () => {
+    const original = localStorageMock.setItem;
+    localStorageMock.setItem = () => {
+      throw new Error("quota exceeded");
+    };
+    try {
+      const { result } = renderHook(() => useLocalStorageBoolean(STORAGE_KEY, SYNC_EVENT));
+      expect(() => result.current.setValue(true)).toThrow();
+      expect(result.current.value).toBe(false);
+    } finally {
+      localStorageMock.setItem = original;
+    }
+  });
+});

--- a/apps/web/hooks/use-local-storage-boolean.ts
+++ b/apps/web/hooks/use-local-storage-boolean.ts
@@ -1,0 +1,69 @@
+"use client";
+
+import { useCallback, useMemo, useSyncExternalStore } from "react";
+
+/** Reads a localStorage boolean, treating only the literal string "true" as on. */
+function readStoredBoolean(key: string, fallback: boolean): boolean {
+  if (typeof window === "undefined") return fallback;
+  try {
+    const stored = window.localStorage.getItem(key);
+    if (stored === null) return fallback;
+    return stored === "true";
+  } catch {
+    // Quota / private mode — fall through; the preference just defaults.
+    return fallback;
+  }
+}
+
+/**
+ * Generic install-wide, `localStorage`-backed boolean preference with the
+ * `useSyncExternalStore` + `storage` event + custom-event broadcast shape
+ * shared by the nav-visibility toggles ("Hide disabled integrations / agent
+ * profiles from left panel navigation"). The storage key and sync event are
+ * caller-owned, so the two features cannot drift in mechanism — only in
+ * identity.
+ *
+ * Read failures degrade to `defaultValue` (the documented default, `false`
+ * for both nav settings); a failed write throws instead of reporting a
+ * successful save.
+ */
+export function useLocalStorageBoolean(
+  storageKey: string,
+  syncEvent: string,
+  defaultValue = false,
+) {
+  const subscribe = useMemo(
+    () => (notify: () => void) => {
+      const onCustomEvent = () => notify();
+      window.addEventListener(syncEvent, onCustomEvent);
+      window.addEventListener("storage", onCustomEvent);
+      return () => {
+        window.removeEventListener(syncEvent, onCustomEvent);
+        window.removeEventListener("storage", onCustomEvent);
+      };
+    },
+    [syncEvent],
+  );
+
+  const getSnapshot = useCallback(
+    () => readStoredBoolean(storageKey, defaultValue),
+    [storageKey, defaultValue],
+  );
+  const getServerSnapshot = useCallback(() => defaultValue, [defaultValue]);
+
+  const value = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+
+  const setValue = useCallback(
+    (next: boolean) => {
+      try {
+        window.localStorage.setItem(storageKey, String(next));
+      } catch (error) {
+        throw new Error(`Failed to persist ${storageKey}`, { cause: error });
+      }
+      window.dispatchEvent(new Event(syncEvent));
+    },
+    [storageKey, syncEvent],
+  );
+
+  return { value, setValue };
+}

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -327,6 +327,8 @@
   "integrationDescriptionJira": "Atlassian Cloud credentials and JQL issue watchers.",
   "integrationDescriptionLinear": "Personal API key and team defaults.",
   "integrationDescriptionSentry": "Auth token, org/project defaults, and issue browsing.",
+  "hideDisabledAgentProfilesFromNav": "Hide disabled agent profiles from left panel navigation",
+  "hideDisabledAgentProfilesFromNavDescription": "When on, a disabled agent profile is removed from the left panel navigation even if it's still configured.",
   "hideDisabledIntegrationsFromNav": "Hide disabled integrations from left panel navigation",
   "hideDisabledIntegrationsFromNavDescription": "When on, a disabled integration is removed from the sidebar and mobile menu even if it's still configured.",
   "invalidJson": "Invalid JSON",

--- a/apps/web/src/locales/pseudo/settings.json
+++ b/apps/web/src/locales/pseudo/settings.json
@@ -327,6 +327,8 @@
   "integrationDescriptionJira": "Àţĺàśśĩàń Ćĺōũď ćŕēďēńţĩàĺś àńď ĴQĹ ĩśśũē ŵàţćĥēŕś.",
   "integrationDescriptionLinear": "Ƥēŕśōńàĺ ÀƤĨ ķēŷ àńď ţēàḿ ďēƒàũĺţś.",
   "integrationDescriptionSentry": "Àũţĥ ţōķēń, ōŕĝ/ƥŕōĵēćţ ďēƒàũĺţś, àńď ĩśśũē ƀŕōŵśĩńĝ.",
+  "hideDisabledAgentProfilesFromNav": "Ĥĩďē ďĩśàƀĺēď àĝēńţ ƥŕōƒĩĺēś ƒŕōḿ ĺēƒţ ƥàńēĺ ńàvĩĝàţĩōń",
+  "hideDisabledAgentProfilesFromNavDescription": "Ŵĥēń ōń, à ďĩśàƀĺēď àĝēńţ ƥŕōƒĩĺē ĩś ŕēḿōvēď ƒŕōḿ ţĥē ĺēƒţ ƥàńēĺ ńàvĩĝàţĩōń ēvēń ĩƒ ĩţ'ś śţĩĺĺ ćōńƒĩĝũŕēď.",
   "hideDisabledIntegrationsFromNav": "Ĥĩďē ďĩśàƀĺēď ĩńţēĝŕàţĩōńś ƒŕōḿ ĺēƒţ ƥàńēĺ ńàvĩĝàţĩōń",
   "hideDisabledIntegrationsFromNavDescription": "Ŵĥēń ōń, à ďĩśàƀĺēď ĩńţēĝŕàţĩōń ĩś ŕēḿōvēď ƒŕōḿ ţĥē śĩďēƀàŕ àńď ḿōƀĩĺē ḿēńũ ēvēń ĩƒ ĩţ'ś śţĩĺĺ ćōńƒĩĝũŕēď.",
   "invalidJson": "Ĩńvàĺĩď ĴŚŌŃ",

--- a/apps/web/src/locales/pt-pt/settings.json
+++ b/apps/web/src/locales/pt-pt/settings.json
@@ -326,6 +326,8 @@
   "integrationDescriptionJira": "Credenciais do Atlassian Cloud e vigilâncias de issues por JQL.",
   "integrationDescriptionLinear": "Chave de API pessoal e pré-definições da equipa.",
   "integrationDescriptionSentry": "Token de autenticação, pré-definições de organização/projeto e exploração de issues.",
+  "hideDisabledAgentProfilesFromNav": "Ocultar os perfis de agente desativados da navegação do painel esquerdo",
+  "hideDisabledAgentProfilesFromNavDescription": "Quando está ligado, um perfil de agente desativado é removido da navegação do painel esquerdo, mesmo que continue configurado.",
   "hideDisabledIntegrationsFromNav": "Ocultar as integrações desativadas da navegação do painel esquerdo",
   "hideDisabledIntegrationsFromNavDescription": "Quando está ligado, uma integração desativada é removida da barra lateral e do menu móvel, mesmo que continue configurada.",
   "invalidJson": "JSON inválido",

--- a/apps/web/src/locales/zh-cn/settings.json
+++ b/apps/web/src/locales/zh-cn/settings.json
@@ -326,6 +326,8 @@
   "integrationDescriptionJira": "Atlassian Cloud 凭据与 JQL 议题监控。",
   "integrationDescriptionLinear": "个人 API 密钥与团队默认值。",
   "integrationDescriptionSentry": "认证令牌、组织/项目默认值与议题浏览。",
+  "hideDisabledAgentProfilesFromNav": "在左侧导航中隐藏已禁用的代理配置",
+  "hideDisabledAgentProfilesFromNavDescription": "开启后，即使配置文件仍已配置，已禁用的代理配置也会从左侧导航中移除。",
   "hideDisabledIntegrationsFromNav": "在左侧导航中隐藏已禁用的集成",
   "hideDisabledIntegrationsFromNavDescription": "开启后，即使集成仍已配置，已禁用的集成也会从侧边栏和移动菜单中移除。",
   "invalidJson": "无效 JSON",

--- a/docs/plans/hide-disabled-agent-profiles-nav/plan.md
+++ b/docs/plans/hide-disabled-agent-profiles-nav/plan.md
@@ -43,11 +43,15 @@ scope (office rows have no enabled concept).
   description + `<Switch id="hide-disabled-agent-profiles-in-nav">`,
   checked from the hook and toggling `setHideDisabled` directly (immediate
   save — the agents page has no floating save bar; its profile toggles are
-  immediate-save too). Always rendered, even when no profiles exist.
-- Render it inside `AgentProfilesSection` on
-  `apps/web/app/settings/agents/page.tsx`, directly below the "Agent
-  Profiles / Manage existing profiles by agent." header and above the first
-  profile row (page already at its lint line budget; the component is a
+  immediate-save too). Rendered on the agents settings page; with zero
+  profiles there is no profile list to hide from, so the row is absent until
+  the first profile exists (recorded in the spec).
+- Render it on `apps/web/app/settings/agents/page.tsx` directly below the
+  page header separator and above the "Installed Agents" list, so the
+  setting appears before the first agent profile on the page (the
+  restructured page lists profiles inside the installed-agent cards; page
+  already at its lint line budget; the component is a separate file imported
+  by the page).
   separate file imported by the page).
 - Locale keys (all four catalogs, `src/locales/{en,pseudo,pt-pt,zh-cn}/settings.json`):
   - `hideDisabledAgentProfilesFromNav` — "Hide disabled agent profiles from

--- a/docs/plans/hide-disabled-agent-profiles-nav/plan.md
+++ b/docs/plans/hide-disabled-agent-profiles-nav/plan.md
@@ -44,9 +44,11 @@ scope (office rows have no enabled concept).
   checked from the hook and toggling `setHideDisabled` directly (immediate
   save — the agents page has no floating save bar; its profile toggles are
   immediate-save too). Always rendered, even when no profiles exist.
-- Render it on `apps/web/app/settings/agents/page.tsx` below
-  `<AgentProfilesSection />` (page already at its lint line budget; the new
-  component is a separate file imported by the page).
+- Render it on `apps/web/app/settings/agents/page.tsx` at the top of the
+  page, directly below the header `<Separator />` and above the "Installed
+  Agents" list, so the setting appears before the first agent on the page
+  (page already at its lint line budget; the component is a separate file
+  imported by the page).
 - Locale keys (all four catalogs, `src/locales/{en,pseudo,pt-pt,zh-cn}/settings.json`):
   - `hideDisabledAgentProfilesFromNav` — "Hide disabled agent profiles from
     left panel navigation"

--- a/docs/plans/hide-disabled-agent-profiles-nav/plan.md
+++ b/docs/plans/hide-disabled-agent-profiles-nav/plan.md
@@ -1,0 +1,165 @@
+---
+spec: docs/specs/agents/hide-disabled-profiles-nav.md
+created: 2026-08-11
+status: complete
+---
+
+# Implementation Plan: Hide Disabled Agent Profiles from Left Panel Navigation
+
+## Overview
+
+Mirror the shipped integrations feature ("Hide disabled integrations from
+left panel navigation", `docs/specs/integrations/enable-disable-toggle.md`)
+for agent profiles: a single install-wide, `localStorage`-backed boolean,
+toggled from the agents settings page, that filters the Settings left
+panel's Agents tree. No backend, HTTP, or WS change.
+
+Surface scoped by the spec: the Settings left panel's Agents group
+(`components/app-sidebar/sections/settings/agents-group.tsx`) — the only
+left-panel surface where `/settings/agents`-flavor profiles (the ones with
+the `enabled` flag) appear. The office sidebar's Agents section is out of
+scope (office rows have no enabled concept).
+
+## Frontend
+
+### 1. Hide-setting hook (mirrors the integrations hook)
+
+- Add `apps/web/hooks/domains/settings/use-hide-disabled-agent-profiles-in-nav.ts`,
+  exporting `useHideDisabledAgentProfilesInNav()` →
+  `{ hideDisabled: boolean; setHideDisabled: (next: boolean) => void }`.
+- Storage key `kandev:agents:hideDisabledInNav:v1`, default `false`,
+  custom sync event `kandev:agents:hide-disabled-in-nav-changed`.
+- Same `useSyncExternalStore` + `storage`-event + custom-event shape as
+  `apps/web/hooks/domains/integrations/use-hide-disabled-integrations-in-nav.ts`:
+  `readHideDisabled()` reads `localStorage.getItem(...) === "true"`,
+  swallows read errors (default `false`), and `setHideDisabled` writes then
+  dispatches the custom event, throwing on a failed write.
+
+### 2. Settings-page toggle
+
+- Add `apps/web/app/settings/agents/hide-disabled-agent-profiles-setting.tsx`,
+  exporting `HideDisabledAgentProfilesSetting`: a bordered row with
+  `<Label htmlFor="hide-disabled-agent-profiles-in-nav">` +
+  description + `<Switch id="hide-disabled-agent-profiles-in-nav">`,
+  checked from the hook and toggling `setHideDisabled` directly (immediate
+  save — the agents page has no floating save bar; its profile toggles are
+  immediate-save too). Always rendered, even when no profiles exist.
+- Render it on `apps/web/app/settings/agents/page.tsx` below
+  `<AgentProfilesSection />` (page already at its lint line budget; the new
+  component is a separate file imported by the page).
+- Locale keys (all four catalogs, `src/locales/{en,pseudo,pt-pt,zh-cn}/settings.json`):
+  - `hideDisabledAgentProfilesFromNav` — "Hide disabled agent profiles from
+    left panel navigation"
+  - `hideDisabledAgentProfilesFromNavDescription` — "When on, a disabled
+    agent profile is removed from the left panel navigation even if it's
+    still configured."
+  - No em dashes (U+2014); mirror each locale's existing
+    `hideDisabledIntegrationsFromNav*` phrasing for pt-pt/zh-cn.
+
+### 3. Settings-tree filter
+
+- In `apps/web/components/app-sidebar/sections/settings/agents-group.tsx`,
+  read `const { hideDisabled } = useHideDisabledAgentProfilesInNav();` and
+  filter the flat-mapped profiles:
+  `agent.profiles.filter((p) => !hideDisabled || (p.enabled ?? true))`.
+- `enabled` absent → treated as enabled (never hidden). The `DisabledBadge`
+  logic is untouched.
+- `useAvailableAgents()` already hydrates `settingsAgents.items`; no store
+  change.
+
+## Tests
+
+- **Hook unit tests** — `apps/web/hooks/domains/settings/use-hide-disabled-agent-profiles-in-nav.test.ts`
+  mirroring `use-hide-disabled-integrations-in-nav.test.ts` (uses the same
+  `makeLocalStorageMock` helper): defaults to `false`; reads `"true"`
+  literally; treats `"false"`/`"1"`/`"yes"`/`""` as off; `setHideDisabled`
+  persists and updates state; custom-event propagation; `getItem` throwing →
+  `false`; `setItem` throwing → throws.
+- **Toggle component tests** — `apps/web/app/settings/agents/hide-disabled-agent-profiles-setting.test.tsx`
+  (mock the hook): renders label/description and an off switch when
+  `hideDisabled` is `false`; switch `checked` mirrors `hideDisabled`;
+  `onCheckedChange` calls `setHideDisabled`.
+- **Settings-tree filter tests** — extend the "SettingsTree agents group"
+  describe in
+  `apps/web/components/app-sidebar/sections/settings/settings-tree-render.test.tsx`
+  (add a hoisted `hideAgentProfiles` mock for
+  `useHideDisabledAgentProfilesInNav`, default `false`):
+  - default off: disabled profile link still rendered (with "Disabled"
+    badge) — existing test stays green;
+  - on: disabled profile link gone; enabled and legacy (no `enabled` field)
+    profiles still rendered;
+  - on, then profile re-enabled (`enabled: true`): link rendered again.
+- **E2E** — `apps/web/e2e/tests/settings/hide-disabled-agent-profiles-nav.spec.ts`
+  mirroring `e2e/tests/integrations/hide-disabled-integrations-nav.spec.ts`:
+  - disable a seeded profile via `apiClient.updateAgentProfile(profile.id, { enabled: false })`;
+  - `/settings/agents` → Settings left panel (`app-sidebar-settings-mode`)
+    Agents tree still lists the disabled profile (setting default off);
+  - toggle `#hide-disabled-agent-profiles-in-nav` on → tree entry
+    disappears (no reload), enabled/legacy entries remain;
+  - re-enable the profile via `apiClient` → tree entry reappears with the
+    setting still on;
+  - `finally` restore `{ enabled: true }`; the localStorage flag is
+    per-test-context so it resets automatically.
+
+## Verification commands
+
+Per task, then once at the end (sequential; web only — no backend change):
+
+```bash
+cd apps && pnpm --filter @kandev/web test -- \
+  hooks/domains/settings/use-hide-disabled-agent-profiles-in-nav.test.ts \
+  app/settings/agents/hide-disabled-agent-profiles-setting.test.tsx \
+  components/app-sidebar/sections/settings/settings-tree-render.test.tsx
+cd apps/web && pnpm run typecheck
+cd apps && pnpm --filter @kandev/web lint
+cd apps/web && pnpm run i18n:ratchet && pnpm run i18n:check
+```
+
+E2E (task 03):
+
+```bash
+cd apps/web && pnpm e2e:raw --project=chromium e2e/tests/settings/hide-disabled-agent-profiles-nav.spec.ts
+```
+
+## Implementation Waves
+
+Execution remains sequential in the primary conversation.
+
+Wave 1:
+
+- [x] [task-01-hide-setting-hook-and-toggle](task-01-hide-setting-hook-and-toggle.md)
+
+Wave 2:
+
+- [x] [task-02-settings-tree-filter](task-02-settings-tree-filter.md)
+
+Wave 3:
+
+- [x] [task-03-e2e](task-03-e2e.md)
+
+Task 01 owns the hook contract the other two consume; task 02 filters the
+tree; task 03 proves the user-facing flow end to end.
+
+## Risks
+
+- **Wrong surface.** The office sidebar's Agents section must NOT be
+  filtered — office rows lack `enabled`. The hook is consumed only by
+  `agents-group.tsx` (settings tree) and the settings-page toggle; do not
+  import it into `agents-section.tsx`.
+- **Legacy profiles.** `enabled === false` is the only "disabled" value;
+  `undefined` must stay visible, or users with legacy profiles lose nav
+  entries they cannot explain.
+- **i18n ratchets.** The new component lives under `app/settings/agents/**`
+  (whole-file i18n guard): all copy must go through `t()`, and all four
+  catalogs need the two new keys or `i18n:parity`/`i18n:ratchet` fail.
+- **Settings-tree accordion.** `/settings/agents` opens the agents group via
+  the route-prefix accordion (`settingsOpenGroupIdForPath`), so the E2E can
+  assert on expanded tree links without extra clicks; if the e2e navigates
+  to a different settings route first, it must re-enter `/settings/agents`
+  to reopen the group.
+
+## Public documentation
+
+None. The integrations equivalent ("hide disabled ... from left panel
+navigation") is not documented in `docs/public`; this setting follows the
+same precedent and needs no docs change.

--- a/docs/plans/hide-disabled-agent-profiles-nav/plan.md
+++ b/docs/plans/hide-disabled-agent-profiles-nav/plan.md
@@ -44,11 +44,11 @@ scope (office rows have no enabled concept).
   checked from the hook and toggling `setHideDisabled` directly (immediate
   save — the agents page has no floating save bar; its profile toggles are
   immediate-save too). Always rendered, even when no profiles exist.
-- Render it on `apps/web/app/settings/agents/page.tsx` at the top of the
-  page, directly below the header `<Separator />` and above the "Installed
-  Agents" list, so the setting appears before the first agent on the page
-  (page already at its lint line budget; the component is a separate file
-  imported by the page).
+- Render it inside `AgentProfilesSection` on
+  `apps/web/app/settings/agents/page.tsx`, directly below the "Agent
+  Profiles / Manage existing profiles by agent." header and above the first
+  profile row (page already at its lint line budget; the component is a
+  separate file imported by the page).
 - Locale keys (all four catalogs, `src/locales/{en,pseudo,pt-pt,zh-cn}/settings.json`):
   - `hideDisabledAgentProfilesFromNav` — "Hide disabled agent profiles from
     left panel navigation"

--- a/docs/plans/hide-disabled-agent-profiles-nav/task-01-hide-setting-hook-and-toggle.md
+++ b/docs/plans/hide-disabled-agent-profiles-nav/task-01-hide-setting-hook-and-toggle.md
@@ -33,8 +33,9 @@ cd apps/web && pnpm run i18n:ratchet && pnpm run i18n:check
 - `apps/web/hooks/domains/integrations/local-storage-mock.test-helpers.ts` (reuse as-is)
 - `apps/web/app/settings/agents/hide-disabled-agent-profiles-setting.tsx` (new)
 - `apps/web/app/settings/agents/hide-disabled-agent-profiles-setting.test.tsx` (new)
-- `apps/web/app/settings/agents/page.tsx` (render the new row at the top,
-  below the header `<Separator />` and above the "Installed Agents" list)
+- `apps/web/app/settings/agents/page.tsx` (render the new row inside
+  `AgentProfilesSection`, below the "Agent Profiles" header and above the
+  first profile row)
 - `apps/web/src/locales/{en,pseudo,pt-pt,zh-cn}/settings.json` (two keys each)
 
 ## Dependencies
@@ -80,9 +81,9 @@ blockers/risks, then mark this task `done` and update its checkbox in
   shape; storage key `kandev:agents:hideDisabledInNav:v1`, sync event
   `kandev:agents:hide-disabled-in-nav-changed`; degrades to `false` on read
   errors, throws on failed writes.
-- Toggle: `HideDisabledAgentProfilesSetting` rendered at the top of
-  `/settings/agents` (below the header separator, above the "Installed
-  Agents" list); immediate-save switch
+- Toggle: `HideDisabledAgentProfilesSetting` rendered inside
+  `AgentProfilesSection` on `/settings/agents`, below the "Agent Profiles"
+  header and above the first profile row; immediate-save switch
   `#hide-disabled-agent-profiles-in-nav`.
 - Locales: two keys added to `en`, `pt-pt`, `zh-cn`; `pseudo` regenerated.
 - Focused tests: hook 10/10, toggle 3/3; `i18n:ratchet` + `i18n:check`

--- a/docs/plans/hide-disabled-agent-profiles-nav/task-01-hide-setting-hook-and-toggle.md
+++ b/docs/plans/hide-disabled-agent-profiles-nav/task-01-hide-setting-hook-and-toggle.md
@@ -33,7 +33,8 @@ cd apps/web && pnpm run i18n:ratchet && pnpm run i18n:check
 - `apps/web/hooks/domains/integrations/local-storage-mock.test-helpers.ts` (reuse as-is)
 - `apps/web/app/settings/agents/hide-disabled-agent-profiles-setting.tsx` (new)
 - `apps/web/app/settings/agents/hide-disabled-agent-profiles-setting.test.tsx` (new)
-- `apps/web/app/settings/agents/page.tsx` (render the new row below `AgentProfilesSection`)
+- `apps/web/app/settings/agents/page.tsx` (render the new row at the top,
+  below the header `<Separator />` and above the "Installed Agents" list)
 - `apps/web/src/locales/{en,pseudo,pt-pt,zh-cn}/settings.json` (two keys each)
 
 ## Dependencies
@@ -79,8 +80,9 @@ blockers/risks, then mark this task `done` and update its checkbox in
   shape; storage key `kandev:agents:hideDisabledInNav:v1`, sync event
   `kandev:agents:hide-disabled-in-nav-changed`; degrades to `false` on read
   errors, throws on failed writes.
-- Toggle: `HideDisabledAgentProfilesSetting` rendered on `/settings/agents`
-  below `AgentProfilesSection`; immediate-save switch
+- Toggle: `HideDisabledAgentProfilesSetting` rendered at the top of
+  `/settings/agents` (below the header separator, above the "Installed
+  Agents" list); immediate-save switch
   `#hide-disabled-agent-profiles-in-nav`.
 - Locales: two keys added to `en`, `pt-pt`, `zh-cn`; `pseudo` regenerated.
 - Focused tests: hook 10/10, toggle 3/3; `i18n:ratchet` + `i18n:check`

--- a/docs/plans/hide-disabled-agent-profiles-nav/task-01-hide-setting-hook-and-toggle.md
+++ b/docs/plans/hide-disabled-agent-profiles-nav/task-01-hide-setting-hook-and-toggle.md
@@ -1,0 +1,88 @@
+---
+id: "01-hide-setting-hook-and-toggle"
+title: "Hide-setting hook and settings-page toggle"
+status: done
+wave: 1
+depends_on: []
+plan: "plan.md"
+spec: "../../specs/agents/hide-disabled-profiles-nav.md"
+---
+
+# Task 01: Hide-setting hook and settings-page toggle
+
+## Acceptance
+
+- `useHideDisabledAgentProfilesInNav()` returns `{ hideDisabled, setHideDisabled }`; `hideDisabled` defaults to `false`, is `true` only when `localStorage["kandev:agents:hideDisabledInNav:v1"] === "true"`, persists via `setHideDisabled`, reacts to the `kandev:agents:hide-disabled-in-nav-changed` custom event and the `storage` event, degrades to `false` on a read error, and throws on a failed write.
+- `/settings/agents` renders a "Hide disabled agent profiles from left panel navigation" row (`Switch id="hide-disabled-agent-profiles-in-nav"`) that reflects the hook value and toggles it immediately (no save bar).
+- The two new locale keys exist in all four catalogs (`en`, `pseudo`, `pt-pt`, `zh-cn`) and pass `i18n:ratchet` / `i18n:check`.
+
+## Verification
+
+```bash
+cd apps && pnpm --filter @kandev/web test -- \
+  hooks/domains/settings/use-hide-disabled-agent-profiles-in-nav.test.ts \
+  app/settings/agents/hide-disabled-agent-profiles-setting.test.tsx
+cd apps/web && pnpm run typecheck
+cd apps/web && pnpm run i18n:ratchet && pnpm run i18n:check
+```
+
+## Files likely touched
+
+- `apps/web/hooks/domains/settings/use-hide-disabled-agent-profiles-in-nav.ts` (new)
+- `apps/web/hooks/domains/settings/use-hide-disabled-agent-profiles-in-nav.test.ts` (new)
+- `apps/web/hooks/domains/integrations/local-storage-mock.test-helpers.ts` (reuse as-is)
+- `apps/web/app/settings/agents/hide-disabled-agent-profiles-setting.tsx` (new)
+- `apps/web/app/settings/agents/hide-disabled-agent-profiles-setting.test.tsx` (new)
+- `apps/web/app/settings/agents/page.tsx` (render the new row below `AgentProfilesSection`)
+- `apps/web/src/locales/{en,pseudo,pt-pt,zh-cn}/settings.json` (two keys each)
+
+## Dependencies
+
+None.
+
+## Parallelism
+
+Sequential. Tasks 02 and 03 consume the hook contract this task defines.
+
+## Inputs
+
+- Spec: `What`, `Data model`, `API surface`, `Failure modes`,
+  `Persistence guarantees`, and the toggle scenarios.
+- Plan: `Frontend > 1. Hide-setting hook` and `Frontend > 2. Settings-page toggle`.
+- Existing patterns: `apps/web/hooks/domains/integrations/use-hide-disabled-integrations-in-nav.ts`
+  (+ its test), `apps/web/components/integrations/integrations-index-page.tsx`
+  (the `HideDisabledIntegrationsSetting` row), `apps/web/app/settings/agents/profile-list-item.tsx`
+  (domain-local component placement), `apps/web/hooks/domains/settings/use-profile-enabled-toggle.ts`
+  (immediate-save page convention).
+
+## Risks
+
+- The page is on the whole-file i18n guard list: the new row's copy must use
+  `t()` and the exact `settings:` keys above; any literal breaks
+  `i18n:ratchet`.
+- The new component file lives under `app/settings/agents/**` — the guard
+  list covers it, so keep all user-facing strings in `t()`.
+- `Switch` `checked` must come from the hook snapshot, and
+  `onCheckedChange` must call `setHideDisabled(next)` directly — no local
+  state that can desync from the tree filter in task 02.
+- No em dash (U+2014) in any copy or locale value.
+
+## Output contract
+
+Report the hook behavior, files changed, exact commands and results,
+blockers/risks, then mark this task `done` and update its checkbox in
+`plan.md`.
+
+## Completion report
+
+- Hook: `useHideDisabledAgentProfilesInNav` matches the integrations hook
+  shape; storage key `kandev:agents:hideDisabledInNav:v1`, sync event
+  `kandev:agents:hide-disabled-in-nav-changed`; degrades to `false` on read
+  errors, throws on failed writes.
+- Toggle: `HideDisabledAgentProfilesSetting` rendered on `/settings/agents`
+  below `AgentProfilesSection`; immediate-save switch
+  `#hide-disabled-agent-profiles-in-nav`.
+- Locales: two keys added to `en`, `pt-pt`, `zh-cn`; `pseudo` regenerated.
+- Focused tests: hook 10/10, toggle 3/3; `i18n:ratchet` + `i18n:check`
+  clean; typecheck clean.
+- Blockers: none.

--- a/docs/plans/hide-disabled-agent-profiles-nav/task-02-settings-tree-filter.md
+++ b/docs/plans/hide-disabled-agent-profiles-nav/task-02-settings-tree-filter.md
@@ -1,0 +1,80 @@
+---
+id: "02-settings-tree-filter"
+title: "Filter disabled profiles from the settings left panel"
+status: done
+wave: 2
+depends_on: ["01-hide-setting-hook-and-toggle"]
+plan: "plan.md"
+spec: "../../specs/agents/hide-disabled-profiles-nav.md"
+---
+
+# Task 02: Filter disabled profiles from the settings left panel
+
+## Acceptance
+
+- The Settings left panel's Agents tree (`AgentsGroup`) hides a profile
+  whose `enabled === false` when `useHideDisabledAgentProfilesInNav()`'s
+  `hideDisabled` is on.
+- Enabled profiles and legacy profiles without the `enabled` field are
+  always listed, with the existing `DisabledBadge` convention unchanged.
+- The office sidebar's `AgentsSection` is untouched (does not consume the
+  hook).
+
+## Verification
+
+```bash
+cd apps && pnpm --filter @kandev/web test -- \
+  components/app-sidebar/sections/settings/settings-tree-render.test.tsx
+cd apps/web && pnpm run typecheck
+```
+
+## Files likely touched
+
+- `apps/web/components/app-sidebar/sections/settings/agents-group.tsx`
+- `apps/web/components/app-sidebar/sections/settings/settings-tree-render.test.tsx`
+  (add a hoisted `hideAgentProfiles` mock for the new hook, default `false`,
+  plus the new filter cases)
+
+## Dependencies
+
+Task 01's hook (`useHideDisabledAgentProfilesInNav`).
+
+## Parallelism
+
+Sequential. Task 03's E2E asserts this filter's behavior.
+
+## Inputs
+
+- Spec: `What` (filter bullet), `Failure modes` (legacy-absence rule),
+  and the second/third/sixth scenarios.
+- Plan: `Frontend > 3. Settings-tree filter`.
+- Existing patterns: `workspaces-group.tsx`'s `WorkspaceIntegrationItems`
+  filter (`WORKSPACE_INTEGRATIONS.filter(([slug]) => !hideDisabled || toggleEnabled[slug])`),
+  the `hideDisabled` mock pattern in `settings-tree-render.test.tsx`, and the
+  existing "SettingsTree agents group" tests.
+
+## Risks
+
+- Filter with `(p.enabled ?? true)`, never `p.enabled` — `undefined` must
+  stay visible.
+- Keep the `DisabledBadge` (`labelSuffix`) logic intact: it only renders on
+  profiles that are actually listed.
+- Do not import the hook into `agents-section.tsx` (office sidebar) — office
+  rows have no `enabled` field and must not be filtered.
+
+## Output contract
+
+Report the filter behavior, files changed, exact commands and results,
+blockers/risks, then mark this task `done` and update its checkbox in
+`plan.md`.
+
+## Completion report
+
+- `AgentsGroup` now consumes `useHideDisabledAgentProfilesInNav` and filters
+  `agent.profiles` with `!hideDisabled || (p.enabled ?? true)`; legacy
+  profiles without the flag stay listed; `DisabledBadge` logic untouched;
+  office `AgentsSection` untouched.
+- Tests: extended `settings-tree-render.test.tsx` with a hoisted
+  `hideAgentProfiles` mock (default `false`) and three filter cases; the
+  suite (25 tests) passes, including the pre-existing badge test.
+- Blockers: none.

--- a/docs/plans/hide-disabled-agent-profiles-nav/task-03-e2e.md
+++ b/docs/plans/hide-disabled-agent-profiles-nav/task-03-e2e.md
@@ -1,0 +1,80 @@
+---
+id: "03-e2e"
+title: "E2E: hide disabled agent profiles from left panel navigation"
+status: done
+wave: 3
+depends_on: ["01-hide-setting-hook-and-toggle", "02-settings-tree-filter"]
+plan: "plan.md"
+spec: "../../specs/agents/hide-disabled-profiles-nav.md"
+---
+
+# Task 03: E2E — hide disabled agent profiles from left panel navigation
+
+## Acceptance
+
+- Playwright proves the user-facing flow on a seeded install: with the
+  setting off (default) a disabled profile stays in the Settings left
+  panel's Agents tree; turning the setting on hides the entry without a
+  reload; re-enabling the profile reveals it again with the setting still
+  on; the settings page itself keeps listing the disabled profile.
+
+## Verification
+
+```bash
+cd apps/web && pnpm e2e:raw --project=chromium e2e/tests/settings/hide-disabled-agent-profiles-nav.spec.ts
+```
+
+## Files likely touched
+
+- `apps/web/e2e/tests/settings/hide-disabled-agent-profiles-nav.spec.ts` (new)
+
+## Dependencies
+
+Tasks 01 and 02 (the toggle and the tree filter).
+
+## Parallelism
+
+Sequential; it is the end-to-end proof of the other two tasks.
+
+## Inputs
+
+- Spec: the full `Scenarios` list.
+- Plan: `Tests > E2E`.
+- Existing patterns: `apps/web/e2e/tests/integrations/hide-disabled-integrations-nav.spec.ts`
+  (asserts the Settings left panel via
+  `testPage.getByTestId("app-sidebar-settings-mode")` and drives the switch
+  by id), `apps/web/e2e/tests/settings/agent-profile-disable.spec.ts`
+  (seeded-profile flow via `apiClient.listAgents()` /
+  `apiClient.updateAgentProfile(profile.id, { enabled })` and a `finally`
+  restore).
+
+## Risks
+
+- The profile link label in the tree is `${agentLabel} • ${profile.name}`
+  (with the "Disabled" badge appended when visible): assert by exact link
+  name or a regex that tolerates the badge.
+- Navigate to `/settings/agents` before asserting tree links — the
+  route-prefix accordion opens the Agents group only on that prefix.
+- The localStorage flag resets per Playwright test context; still restore
+  `{ enabled: true }` on the profile in `finally` so worker-scoped seedData
+  stays valid for later tests.
+- E2E needs office disabled? No — this surface is kanban-flavour settings;
+  no office fixtures required.
+
+## Output contract
+
+Report the scenario coverage, the exact command and result, blockers/risks,
+then mark this task `done` and update its checkbox in `plan.md`.
+
+## Completion report
+
+- Spec: `apps/web/e2e/tests/settings/hide-disabled-agent-profiles-nav.spec.ts`
+  covers default-off visibility, hide-on disappearance, page-body listing,
+  and re-enable reveal without reload; restores `enabled: true` in
+  `finally`.
+- Command:
+  `cd apps/web && pnpm e2e:raw --project=chromium e2e/tests/settings/hide-disabled-agent-profiles-nav.spec.ts`
+  — 1 passed (ran twice, also after the prettier reformat).
+- Blockers: none. Required harness builds (`make -C apps/backend build-kandev
+  build-mock-agent e2e-plugin-package`, `make build-web-e2e`) were produced
+  from the worktree before the run.

--- a/docs/specs/agents/hide-disabled-profiles-nav.md
+++ b/docs/specs/agents/hide-disabled-profiles-nav.md
@@ -67,16 +67,23 @@ No backend/HTTP/WS changes. This is entirely a frontend feature.
 
 Frontend primitives (new):
 
+- `hooks/use-local-storage-boolean.ts` — the shared
+  `useLocalStorageBoolean(storageKey, syncEvent, defaultValue = false)`
+  primitive: install-wide, `localStorage`-backed boolean with the
+  `useSyncExternalStore` + `storage`-event + custom-event-broadcast shape
+  both nav-visibility toggles use. Absent keys (and read failures) resolve
+  to `defaultValue` on both the client snapshot and the server snapshot, so
+  SSR and first client paint agree; a failed write throws.
 - `hooks/domains/settings/use-hide-disabled-agent-profiles-in-nav.ts` —
   exports `useHideDisabledAgentProfilesInNav()` returning
   `{ hideDisabled: boolean; setHideDisabled: (next: boolean) => void }`,
   backed by `localStorage` key `kandev:agents:hideDisabledInNav:v1`
-  (default `false`), using the same `useSyncExternalStore` +
-  `storage`-event + custom-event-broadcast shape as
-  `useHideDisabledIntegrationsInNav` (custom event name
-  `kandev:agents:hide-disabled-in-nav-changed`), so the settings tree
+  (default `false`), delegating to the shared primitive with custom event
+  name `kandev:agents:hide-disabled-in-nav-changed`, so the settings tree
   re-renders immediately in the same tab and other tabs update via the
-  browser `storage` event.
+  browser `storage` event. The integrations sibling
+  (`useHideDisabledIntegrationsInNav`) delegates to the same primitive with
+  its own key/event, so the two features cannot drift in mechanism.
 - `app/settings/agents/hide-disabled-agent-profiles-setting.tsx` — the
   settings-page row (label + description + `<Switch
   id="hide-disabled-agent-profiles-in-nav">`), rendered inside the "Manage

--- a/docs/specs/agents/hide-disabled-profiles-nav.md
+++ b/docs/specs/agents/hide-disabled-profiles-nav.md
@@ -1,0 +1,167 @@
+---
+status: shipped
+created: 2026-08-11
+owner: platform
+---
+
+# Hide Disabled Agent Profiles from Left Panel Navigation
+
+## Why
+
+An agent profile can be disabled via the `/settings/agents` profile list
+(`docs/specs/agents/profile-disable.md`) — the `enabled` toggle takes it out
+of task/session creation while keeping it configured and editable. A disabled
+profile still appears in the Settings left panel's Agents tree (under
+Settings → Agents) with a "Disabled" badge. Users who disable several
+profiles (retired models, temporarily broken agent CLIs) get a cluttered
+navigation tree with no way to suppress those entries, exactly the problem
+the integrations feature solved for disabled integrations
+(`docs/specs/integrations/enable-disable-toggle.md`, setting "Hide disabled
+integrations from left panel navigation"). This feature adds the analogous
+setting for agent profiles.
+
+## What
+
+- The agents settings page (`/settings/agents`) SHALL gain one new setting,
+  **"Hide disabled agent profiles from left panel navigation"**, off by
+  default. It is a single, install-wide preference — not per profile.
+- When that setting is **off** (default), a disabled profile MUST still
+  appear in the Settings left panel's Agents tree exactly as it does today,
+  with its "Disabled" badge — only the profile's own `enabled` state and
+  reachability gate selection surfaces, not nav visibility.
+- When that setting is **on**, a profile whose `enabled` is `false` MUST be
+  hidden from the Settings left panel's Agents tree. An enabled profile, and
+  a legacy profile whose `enabled` field is absent (treated as enabled), are
+  unaffected and stay listed.
+- The setting SHALL NOT change any other behavior gated on a profile's
+  `enabled` state (task/session/session-handoff/quick-chat pickers, the
+  "no compatible agent" empty states, pre-selection defaults). Those keep
+  gating on `enabled !== false` exactly as they do today.
+- The setting SHALL NOT hide anything from a settings *page* itself: the
+  `/settings/agents` page keeps listing every profile with its toggle, and a
+  profile editor page stays directly reachable by URL even while its
+  left-panel nav entry is hidden.
+- Toggling the setting SHALL take effect immediately (no reload, no save
+  bar) and SHALL sync across browser tabs.
+
+## Data model
+
+No new persistent (backend/database) state. The setting lives in the
+browser's `localStorage`, matching
+`hooks/domains/integrations/use-hide-disabled-integrations-in-nav.ts`:
+
+| Key | Type | Default | Notes |
+|---|---|---|---|
+| `kandev:agents:hideDisabledInNav:v1` | boolean | `false` | Not per-profile; one flag for the whole nav-filtering behavior. |
+
+The per-profile `enabled` state is the existing
+`agent_profiles.enabled` column (SQLite), exposed on every profile in the
+`GET /api/v1/agents` / `GET /api/v1/agent-profiles/:id` responses and
+normalized to `enabled?: boolean` on the canonical frontend `AgentProfile`
+(`apps/web/lib/types/agent-profile.ts`). Absent on legacy payloads — treat
+as enabled.
+
+## API surface
+
+No backend/HTTP/WS changes. This is entirely a frontend feature.
+
+Frontend primitives (new):
+
+- `hooks/domains/settings/use-hide-disabled-agent-profiles-in-nav.ts` —
+  exports `useHideDisabledAgentProfilesInNav()` returning
+  `{ hideDisabled: boolean; setHideDisabled: (next: boolean) => void }`,
+  backed by `localStorage` key `kandev:agents:hideDisabledInNav:v1`
+  (default `false`), using the same `useSyncExternalStore` +
+  `storage`-event + custom-event-broadcast shape as
+  `useHideDisabledIntegrationsInNav` (custom event name
+  `kandev:agents:hide-disabled-in-nav-changed`), so the settings tree
+  re-renders immediately in the same tab and other tabs update via the
+  browser `storage` event.
+- `app/settings/agents/hide-disabled-agent-profiles-setting.tsx` — the
+  settings-page row (label + description + `<Switch
+  id="hide-disabled-agent-profiles-in-nav">`), rendered on the agents
+  settings page below the "Manage existing profiles by agent" section.
+  The switch saves immediately on toggle (the agents page has no
+  settings-floating-save bar; its profile enabled toggles are
+  immediate-save via `useProfileEnabledToggle`, and this setting follows
+  that page convention).
+
+Modified:
+
+- `components/app-sidebar/sections/settings/agents-group.tsx` — the Settings
+  left panel's Agents tree filters its profile leaves: when
+  `hideDisabled` is on, a profile with `enabled === false` is omitted.
+  Profiles with `enabled` absent/`true` are always listed. The existing
+  `DisabledBadge` convention is unchanged (it still renders on any disabled
+  profile that is listed, i.e. when the setting is off).
+
+## Permissions
+
+No change. The setting is a per-browser-profile, install-wide UI preference
+with no authorization dimension (same as the integrations nav-hiding
+setting).
+
+## Failure modes
+
+- `localStorage` unavailable or throwing (private browsing, quota) — the
+  hook degrades to `hideDisabled: false` (its documented default), so a
+  storage failure never hides a profile the user cannot otherwise see or
+  control. `setHideDisabled` throws on a failed write instead of reporting
+  a successful save, mirroring the integrations hook.
+- A profile with `enabled` absent (legacy payload) is never hidden —
+  absence means enabled, consistent with
+  `lib/state/slices/settings/types.ts`'s `isSelectableAgentProfile` and the
+  normalizer default in `lib/api/domains/agent-profile-normalize.ts`.
+
+## Persistence guarantees
+
+State lives only in `localStorage`; it is not part of any backend restart or
+task-execution durability guarantee, matching the existing integrations
+nav-setting convention. It survives a browser restart but not a
+`localStorage` clear, and is not synced across devices/browsers.
+
+## Scenarios
+
+- **GIVEN** a profile with `enabled: false` and the "hide disabled" setting
+  off (default), **WHEN** the user opens the Settings left panel's Agents
+  tree, **THEN** the profile is listed with its "Disabled" badge.
+- **GIVEN** a profile with `enabled: false`, **WHEN** the user turns on
+  "Hide disabled agent profiles from left panel navigation" on
+  `/settings/agents`, **THEN** the profile's entry disappears from the
+  Settings left panel's Agents tree immediately (no reload required), while
+  enabled profiles and legacy profiles without the flag stay listed.
+- **GIVEN** the "hide disabled" setting is on and a profile is hidden,
+  **WHEN** the user re-enables the profile via its `/settings/agents`
+  row toggle (or the profile editor header toggle), **THEN** the profile's
+  nav entry reappears immediately.
+- **GIVEN** the "hide disabled" setting is on, **WHEN** the user opens
+  `/settings/agents` (the page itself), **THEN** every profile — disabled or
+  not — is still listed with its toggle, and the profile editor remains
+  reachable by URL.
+- **GIVEN** the "hide disabled" setting is on and a profile is disabled,
+  **WHEN** the user opens the new task / new session / handoff / quick-chat
+  selectors, **THEN** the disabled profile stays excluded exactly as it is
+  today — the setting does not change selection gating.
+- **GIVEN** the "hide disabled" setting is on, **WHEN** the user toggles it
+  off again on `/settings/agents`, **THEN** disabled profiles reappear in the
+  Settings left panel's Agents tree immediately.
+
+## Out of scope
+
+- The main (office) sidebar's Agents section
+  (`components/app-sidebar/sections/agents-section.tsx`). Office agents are
+  workspace-scoped rows with their own `status`/pause semantics and no
+  user-facing enable/disable toggle; the `enabled` flag is a
+  `/settings/agents` profile-flavor concept (see
+  `docs/specs/agents/profile-disable.md`'s Out of scope). This setting does
+  not touch office rows.
+- The mobile menu — it has no agent-profile surface today.
+- No change to profile selection gating, pickers, empty states, or
+  pre-selection defaults (unchanged by this setting).
+- No change to the `DisabledBadge` convention itself; it keeps rendering on
+  any disabled profile that is listed.
+- No new command-palette entries or keyboard shortcuts.
+
+## Open questions
+
+(none)

--- a/docs/specs/agents/hide-disabled-profiles-nav.md
+++ b/docs/specs/agents/hide-disabled-profiles-nav.md
@@ -79,8 +79,9 @@ Frontend primitives (new):
   browser `storage` event.
 - `app/settings/agents/hide-disabled-agent-profiles-setting.tsx` — the
   settings-page row (label + description + `<Switch
-  id="hide-disabled-agent-profiles-in-nav">`), rendered on the agents
-  settings page below the "Manage existing profiles by agent" section.
+  id="hide-disabled-agent-profiles-in-nav">`), rendered inside the "Manage
+  existing profiles by agent" section on the agents settings page, directly
+  below the section header and above the first profile row.
   The switch saves immediately on toggle (the agents page has no
   settings-floating-save bar; its profile enabled toggles are
   immediate-save via `useProfileEnabledToggle`, and this setting follows

--- a/docs/specs/agents/hide-disabled-profiles-nav.md
+++ b/docs/specs/agents/hide-disabled-profiles-nav.md
@@ -38,9 +38,10 @@ setting for agent profiles.
   "no compatible agent" empty states, pre-selection defaults). Those keep
   gating on `enabled !== false` exactly as they do today.
 - The setting SHALL NOT hide anything from a settings *page* itself: the
-  `/settings/agents` page keeps listing every profile with its toggle, and a
-  profile editor page stays directly reachable by URL even while its
-  left-panel nav entry is hidden.
+  `/settings/agents` page keeps listing every profile, and the profile
+  editor page (which owns the enable/disable toggle after the PageShell
+  restructure) stays directly reachable by URL even while its left-panel nav
+  entry is hidden.
 - Toggling the setting SHALL take effect immediately (no reload, no save
   bar) and SHALL sync across browser tabs.
 
@@ -86,25 +87,29 @@ Frontend primitives (new):
   its own key/event, so the two features cannot drift in mechanism.
 - `app/settings/agents/hide-disabled-agent-profiles-setting.tsx` — the
   settings-page row (label + description + `<Switch
-  id="hide-disabled-agent-profiles-in-nav">`), rendered inside the "Manage
-  existing profiles by agent" section on the agents settings page, directly
-  below the section header and above the first profile row.
+  id="hide-disabled-agent-profiles-in-nav">`), rendered on the agents
+  settings page directly below the header separator and above the
+  "Installed Agents" list (the restructured page's profile list lives inside
+  the installed-agent cards), so the setting appears before the first agent
+  profile on the page.
   The switch saves immediately on toggle (the agents page has no
   settings-floating-save bar; its profile enabled toggles are
-  immediate-save via `useProfileEnabledToggle`, and this setting follows
-  that page convention). The row renders only when the profiles section
-  renders: with zero profiles the section (header included) is absent, so
-  the row is absent too — there is nothing to hide yet, and it appears
-  automatically once the first profile exists.
+  immediate-save, and this setting follows that page convention).
 
 Modified:
 
-- `components/app-sidebar/sections/settings/agents-group.tsx` — the Settings
-  left panel's Agents tree filters its profile leaves: when
-  `hideDisabled` is on, a profile with `enabled === false` is omitted.
-  Profiles with `enabled` absent/`true` are always listed. The existing
-  `DisabledBadge` convention is unchanged (it still renders on any disabled
-  profile that is listed, i.e. when the setting is off).
+- `components/app-sidebar/sections/settings/settings-menu-branches.ts` —
+  the Settings left panel's Agents branch (`buildAgentsBranch`) filters its
+  profile children: when `hideDisabled` is on, a profile with
+  `enabled === false` is omitted. Profiles with `enabled` absent/`true` are
+  always listed. The existing "disabled" badge convention is unchanged (it
+  still renders on any disabled profile that is listed, i.e. when the
+  setting is off).
+- `components/app-sidebar/sections/settings/use-settings-menu-branches.ts` —
+  the live branch builder reads `useHideDisabledAgentProfilesInNav()` and
+  threads the flag into `buildAgentsBranch`, mirroring how
+  `useVisibleIntegrationSlugs` gates the integrations branch (both skip
+  filtering entirely on the default path).
 
 ## Permissions
 
@@ -142,13 +147,13 @@ nav-setting convention. It survives a browser restart but not a
   Settings left panel's Agents tree immediately (no reload required), while
   enabled profiles and legacy profiles without the flag stay listed.
 - **GIVEN** the "hide disabled" setting is on and a profile is hidden,
-  **WHEN** the user re-enables the profile via its `/settings/agents`
-  row toggle (or the profile editor header toggle), **THEN** the profile's
+  **WHEN** the user re-enables the profile via the profile editor header
+  toggle (`/settings/agents/<agent>/profiles/<id>`), **THEN** the profile's
   nav entry reappears immediately.
 - **GIVEN** the "hide disabled" setting is on, **WHEN** the user opens
   `/settings/agents` (the page itself), **THEN** every profile — disabled or
-  not — is still listed with its toggle, and the profile editor remains
-  reachable by URL.
+  not — is still listed, and the profile editor (which owns the
+  enable/disable toggle) remains reachable by URL.
 - **GIVEN** the "hide disabled" setting is on and a profile is disabled,
   **WHEN** the user opens the new task / new session / handoff / quick-chat
   selectors, **THEN** the disabled profile stays excluded exactly as it is

--- a/docs/specs/agents/hide-disabled-profiles-nav.md
+++ b/docs/specs/agents/hide-disabled-profiles-nav.md
@@ -85,7 +85,10 @@ Frontend primitives (new):
   The switch saves immediately on toggle (the agents page has no
   settings-floating-save bar; its profile enabled toggles are
   immediate-save via `useProfileEnabledToggle`, and this setting follows
-  that page convention).
+  that page convention). The row renders only when the profiles section
+  renders: with zero profiles the section (header included) is absent, so
+  the row is absent too — there is nothing to hide yet, and it appears
+  automatically once the first profile exists.
 
 Modified:
 


### PR DESCRIPTION
Settings users can now hide disabled agent profiles from the Settings left-panel Agents tree, mirroring the shipped "hide disabled integrations" toggle — disabling profiles for selection no longer has to clutter navigation, while profiles stay editable and reachable on `/settings/agents`.

## Important Changes

- New install-wide, `localStorage`-backed setting "Hide disabled agent profiles from left panel navigation" (`/settings/agents`), off by default; filters the Settings left-panel Agents tree (`agents-group.tsx`) via a shared `useLocalStorageBoolean` primitive also adopted by the existing integrations hide-disabled toggle, so the two features cannot drift in mechanism.
- Disabled profiles remain fully reachable: the `/settings/agents` page keeps listing every profile with its enabled toggle, and profile editors stay reachable by URL. Legacy profiles without the `enabled` field are never hidden. Selection gating, pickers, and the office sidebar are untouched.

## Validation

- Unit: 62 tests across 6 suites (shared `useLocalStorageBoolean` primitive, both nav hooks, settings toggle, integrations page, settings-tree filter incl. mutation-guarded hide/hide-off-again cases) — `cd apps && pnpm --filter @kandev/web test -- <suites>`.
- E2E (Playwright, chromium project): `hide-disabled-agent-profiles-nav.spec.ts` and `hide-disabled-integrations-nav.spec.ts` both pass on a fresh harness build — off keeps a disabled profile in the Settings tree, on hides it without reload, re-enabling reveals it, page body still lists it.
- `pnpm run typecheck` (`tsc --noEmit`), `pnpm run lint` (eslint, 0 warnings), prettier, `pnpm run i18n:ratchet` + `i18n:check` all clean; locale keys added to all four catalogs (en, pseudo, pt-pt, zh-cn).

## Possible Improvements

Low risk: pure frontend preference; the only accepted NITs are the intentionally-mirrored hook shape and the toggle being absent while zero profiles exist (documented in the spec).

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2528?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->