### PR TITLE
fix: make pinned todos panel fill its hosting panel height

### DIFF
--- a/apps/web/components/task/chat/todo-indicator.test.tsx
+++ b/apps/web/components/task/chat/todo-indicator.test.tsx
@@ -1,0 +1,53 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { TodoIndicatorContent } from "./todo-indicator";
+
+afterEach(cleanup);
+
+/**
+ * The chat status-bar popover/hovercard and the pinned Todos panel share
+ * `TodoIndicatorContent`. `fillHeight` (pinned panel) is the opt-in full-
+ * height variant; the default must keep the popover's `max-h-48` cap and
+ * none of the panel-fill flex classes, or the chat surfaces silently change
+ * layout (review finding, round 5).
+ */
+describe("TodoIndicatorContent default (popover) path", () => {
+  it("keeps the popover max-height cap and no panel-fill classes when fillHeight is not set", () => {
+    render(
+      <TodoIndicatorContent
+        todos={[{ text: "Review code", status: "in_progress" }]}
+        completed={0}
+        progress={0}
+      />,
+    );
+
+    const root = screen.getByTestId("todo-indicator-popover");
+    expect(root.classList.contains("h-full")).toBe(false);
+
+    const list = root.querySelector<HTMLElement>(".overflow-y-auto");
+    expect(list).not.toBeNull();
+    expect(list!.classList.contains("max-h-48")).toBe(true);
+    expect(list!.classList.contains("flex-1")).toBe(false);
+    expect(list!.classList.contains("min-h-0")).toBe(false);
+  });
+
+  it("applies the panel-fill classes only when fillHeight is set", () => {
+    render(
+      <TodoIndicatorContent
+        todos={[{ text: "Review code", status: "in_progress" }]}
+        completed={0}
+        progress={0}
+        fillHeight
+      />,
+    );
+
+    const root = screen.getByTestId("todo-indicator-popover");
+    expect(root.classList.contains("h-full")).toBe(true);
+
+    const list = root.querySelector<HTMLElement>(".overflow-y-auto");
+    expect(list).not.toBeNull();
+    expect(list!.classList.contains("max-h-48")).toBe(false);
+    expect(list!.classList.contains("flex-1")).toBe(true);
+    expect(list!.classList.contains("min-h-0")).toBe(true);
+  });
+});

--- a/apps/web/components/task/chat/todo-indicator.tsx
+++ b/apps/web/components/task/chat/todo-indicator.tsx
@@ -36,7 +36,13 @@ function StatusIcon({ status, className }: { status: string; className?: string 
   }
 }
 
-function TodoList({ todos }: { todos: TodoDisplayItem[] }) {
+function TodoList({
+  todos,
+  fillHeight = false,
+}: {
+  todos: TodoDisplayItem[];
+  fillHeight?: boolean;
+}) {
   const listRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -44,7 +50,17 @@ function TodoList({ todos }: { todos: TodoDisplayItem[] }) {
   }, []);
 
   return (
-    <div ref={listRef} className="space-y-1.5 max-h-48 overflow-y-auto">
+    <div
+      ref={listRef}
+      className={cn(
+        "space-y-1.5 overflow-y-auto",
+        // The popover/hovercard caps the list at max-h-48 so it never
+        // outgrows its small surface; a pinned panel instead lets the list
+        // flex to fill the whole height of its hosting panel and scrolls
+        // internally there.
+        fillHeight ? "min-h-0 flex-1" : "max-h-48",
+      )}
+    >
       {todos.map((todo, idx) => {
         const s = resolveStatus(todo);
         return (
@@ -67,14 +83,19 @@ function TodoIndicatorContent({
   todos,
   completed,
   progress,
+  fillHeight = false,
 }: {
   todos: TodoDisplayItem[];
   completed: number;
   progress: number;
+  fillHeight?: boolean;
 }) {
   const { t } = useTranslation();
   return (
-    <div data-testid="todo-indicator-popover">
+    <div
+      data-testid="todo-indicator-popover"
+      className={cn(fillHeight && "flex h-full min-h-0 flex-col")}
+    >
       <div className="flex items-center justify-between text-xs mb-2">
         <span className="font-medium text-foreground">{t("task:todos")}</span>
         <span className="text-muted-foreground">
@@ -87,7 +108,7 @@ function TodoIndicatorContent({
           style={{ width: `${progress}%` }}
         />
       </div>
-      <TodoList todos={todos} />
+      <TodoList todos={todos} fillHeight={fillHeight} />
     </div>
   );
 }

--- a/apps/web/components/task/dockview-panel-content.todos.test.tsx
+++ b/apps/web/components/task/dockview-panel-content.todos.test.tsx
@@ -57,11 +57,15 @@ vi.mock("@/components/state-provider", () => ({
 }));
 
 import { renderPanel } from "./dockview-panel-content";
+import { TodosContent } from "./todos-panel-content";
 
 afterEach(cleanup);
 
 const WRITE_TESTS = "Write tests";
 const IMPLEMENT_FEATURE = "Implement feature";
+// The dockview panel id equals the root testid; sharing one constant keeps
+// the string under the lint duplicate-literal threshold.
+const TODOS_PANEL_ID = "todos-panel";
 
 describe("dockview-panel-content todos panel (desktop task workbench)", () => {
   it("renders the same checklist rows, order, and status semantics the todo indicator shows", () => {
@@ -73,7 +77,7 @@ describe("dockview-panel-content todos panel (desktop task workbench)", () => {
     };
     mockMessages.items = [];
 
-    render(<>{renderPanel("todos-panel", "todos", {})}</>);
+    render(<>{renderPanel(TODOS_PANEL_ID, "todos", {})}</>);
 
     const rows = screen.getAllByText(new RegExp(`${WRITE_TESTS}|${IMPLEMENT_FEATURE}`));
     expect(rows.map((row) => row.textContent)).toEqual([WRITE_TESTS, IMPLEMENT_FEATURE]);
@@ -86,7 +90,7 @@ describe("dockview-panel-content todos panel (desktop task workbench)", () => {
     mockAppState.sessionTodos.bySessionId = {};
     mockMessages.items = [];
 
-    render(<>{renderPanel("todos-panel", "todos", {})}</>);
+    render(<>{renderPanel(TODOS_PANEL_ID, "todos", {})}</>);
 
     expect(screen.getByTestId("todos-panel-empty-state").textContent).toBe("No todos yet.");
   });
@@ -107,11 +111,33 @@ describe("dockview-panel-content todos panel (desktop task workbench)", () => {
       },
     ];
 
-    render(<>{renderPanel("todos-panel", "todos", {})}</>);
+    render(<>{renderPanel(TODOS_PANEL_ID, "todos", {})}</>);
 
     const rows = screen.getAllByText(new RegExp(`${WRITE_TESTS}|${IMPLEMENT_FEATURE}`));
     expect(rows.map((row) => row.textContent)).toEqual([WRITE_TESTS, IMPLEMENT_FEATURE]);
     expect(screen.getByText("1/2 completed")).toBeTruthy();
     expect(screen.queryByTestId("todos-panel-empty-state")).toBeNull();
+  });
+
+  it("fills the hosting panel height instead of capping the checklist at the popover height", () => {
+    mockAppState.sessionTodos.bySessionId = {
+      "session-1": [
+        { description: WRITE_TESTS, status: "completed" },
+        { description: IMPLEMENT_FEATURE, status: "in_progress" },
+      ],
+    };
+    mockMessages.items = [];
+
+    render(<TodosContent />);
+
+    // The pinned panel root must stretch to the portal slot's full height
+    // (`h-full`), and its scroll container must not carry the popover-only
+    // `max-h-48` cap — that cap is what left the lower part of the hosting
+    // panel empty (the reported bug).
+    const panel = screen.getByTestId(TODOS_PANEL_ID);
+    expect(panel.classList.contains("h-full")).toBe(true);
+    const list = panel.querySelector(".overflow-y-auto");
+    expect(list).not.toBeNull();
+    expect(list!.classList.contains("max-h-48")).toBe(false);
   });
 });

--- a/apps/web/components/task/dockview-panel-content.todos.test.tsx
+++ b/apps/web/components/task/dockview-panel-content.todos.test.tsx
@@ -93,6 +93,9 @@ describe("dockview-panel-content todos panel (desktop task workbench)", () => {
     render(<>{renderPanel(TODOS_PANEL_ID, "todos", {})}</>);
 
     expect(screen.getByTestId("todos-panel-empty-state").textContent).toBe("No todos yet.");
+    // The empty state must occupy the full hosting panel like the populated
+    // state (review finding, round 3), not collapse to its intrinsic height.
+    expect(screen.getByTestId("todos-panel-empty-state").classList.contains("h-full")).toBe(true);
   });
 
   it("falls back to the latest persisted todo message when the live store has no entry for the session (a completed/reopened session)", () => {

--- a/apps/web/components/task/todos-panel-content.tsx
+++ b/apps/web/components/task/todos-panel-content.tsx
@@ -40,8 +40,8 @@ export function TodosContent() {
   const completed = todos.filter((todo) => resolveStatus(todo) === "completed").length;
   const progress = Math.round((completed / todos.length) * 100);
   return (
-    <div data-testid="todos-panel" className="p-3">
-      <TodoIndicatorContent todos={todos} completed={completed} progress={progress} />
+    <div data-testid="todos-panel" className="flex h-full min-h-0 flex-col p-3">
+      <TodoIndicatorContent todos={todos} completed={completed} progress={progress} fillHeight />
     </div>
   );
 }

--- a/apps/web/components/task/todos-panel-content.tsx
+++ b/apps/web/components/task/todos-panel-content.tsx
@@ -31,7 +31,10 @@ export function TodosContent() {
 
   if (todos.length === 0) {
     return (
-      <div data-testid="todos-panel-empty-state" className="p-4 text-sm text-muted-foreground">
+      <div
+        data-testid="todos-panel-empty-state"
+        className="flex h-full min-h-0 flex-col p-4 text-sm text-muted-foreground"
+      >
         {t("chat:noTodosYet")}
       </div>
     );

--- a/apps/web/e2e/tests/settings/todo-list-panel.spec.ts
+++ b/apps/web/e2e/tests/settings/todo-list-panel.spec.ts
@@ -242,6 +242,38 @@ test.describe("Todo list panel preference", () => {
     await expect(panel.getByText("1/2 completed")).toBeVisible();
   });
 
+  test("checklist fills the height of its hosting panel instead of the popover cap", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    test.setTimeout(120_000);
+    const task = await createTaskWithTodos(apiClient, seedData, "Todos fills panel height");
+    await setTodoListPanelPreference(apiClient, true);
+    await openTask(testPage, task.id);
+
+    await expect(todosTabWrapper(testPage)).toBeVisible({ timeout: 15_000 });
+    await todosTabWrapper(testPage).click();
+    const panel = testPage.getByTestId("todos-panel");
+    await expect(panel).toBeVisible({ timeout: 15_000 });
+
+    // The panel root must stretch to its layout parent, the portal slot
+    // (`h-full w-full overflow-hidden`). `xpath=../..` skips the
+    // `display: contents` portal element, which carries no box of its own.
+    const slot = panel.locator("xpath=../..");
+    const [panelBox, slotBox] = await Promise.all([panel.boundingBox(), slot.boundingBox()]);
+    expect(slotBox).not.toBeNull();
+    expect(Math.abs((panelBox?.height ?? 0) - (slotBox?.height ?? 0))).toBeLessThanOrEqual(4);
+
+    // The checklist scroll container is no longer a fixed-size popover list
+    // (~40px for two rows, capped at 192px): it flexes to consume the
+    // panel's remaining height below the header/progress chrome.
+    const listBox = await panel.locator(".overflow-y-auto").boundingBox();
+    expect(listBox).not.toBeNull();
+    expect(listBox!.height).toBeGreaterThan(120);
+    expect(listBox!.height).toBeGreaterThan((slotBox?.height ?? 0) - 100);
+  });
+
   test("is manually addable from the task workbench's own + menu, independent of the preference", async ({
     testPage,
     apiClient,

--- a/apps/web/e2e/tests/settings/todo-list-panel.spec.ts
+++ b/apps/web/e2e/tests/settings/todo-list-panel.spec.ts
@@ -154,7 +154,7 @@ test.describe("Todo list panel preference", () => {
     // Toggle the preference from a second tab; `testPage` never navigates
     // away from the task — proves the change is live, not reload-dependent.
     const settingsPage = await testPage.context().newPage();
-    await settingsPage.goto("/settings/general/task-actions");
+    await settingsPage.goto("/settings/preferences/task-behavior");
     const toggle = settingsPage.getByRole("switch", { name: "Show agent todo list panel" });
     await expect(toggle).toHaveAttribute("aria-checked", "false");
     await toggle.click();

--- a/apps/web/e2e/tests/settings/todo-list-panel.spec.ts
+++ b/apps/web/e2e/tests/settings/todo-list-panel.spec.ts
@@ -272,12 +272,13 @@ test.describe("Todo list panel preference", () => {
     // p-3 padding remains below). A capped 192px (max-h-48) list can never
     // reach the bottom of a taller hosting panel, so this measured invariant
     // is layout-independent — it holds in short split groups and any
-    // viewport, with no arbitrary pixel allowance.
+    // viewport, with no arbitrary pixel allowance. Two-sided (Math.abs) so
+    // content spilling below the panel also fails the guard (round 5).
     const listBox = await panel.locator(".overflow-y-auto").boundingBox();
     expect(listBox).not.toBeNull();
     const panelBottom = (panelBox?.y ?? 0) + (panelBox?.height ?? 0);
     const listBottom = (listBox?.y ?? 0) + listBox!.height;
-    expect(panelBottom - listBottom).toBeLessThanOrEqual(24);
+    expect(Math.abs(panelBottom - listBottom)).toBeLessThanOrEqual(24);
   });
 
   test("is manually addable from the task workbench's own + menu, independent of the preference", async ({

--- a/apps/web/e2e/tests/settings/todo-list-panel.spec.ts
+++ b/apps/web/e2e/tests/settings/todo-list-panel.spec.ts
@@ -268,14 +268,16 @@ test.describe("Todo list panel preference", () => {
     expect(Math.abs((panelBox?.height ?? 0) - (slotBox?.height ?? 0))).toBeLessThanOrEqual(4);
 
     // The checklist scroll container is no longer a fixed-size popover list:
-    // it must consume the panel height below the header/progress chrome
-    // (~66px). A relative bound against the measured slot keeps this
-    // assertion layout-independent (no absolute pixel floor, valid in short
-    // split groups), while still failing the pre-fix 192px cap in any
-    // hosting panel taller than ~280px.
+    // its bottom edge must track the panel's bottom content edge (only the
+    // p-3 padding remains below). A capped 192px (max-h-48) list can never
+    // reach the bottom of a taller hosting panel, so this measured invariant
+    // is layout-independent — it holds in short split groups and any
+    // viewport, with no arbitrary pixel allowance.
     const listBox = await panel.locator(".overflow-y-auto").boundingBox();
     expect(listBox).not.toBeNull();
-    expect(listBox!.height).toBeGreaterThan((slotBox?.height ?? 0) - 90);
+    const panelBottom = (panelBox?.y ?? 0) + (panelBox?.height ?? 0);
+    const listBottom = (listBox?.y ?? 0) + listBox!.height;
+    expect(panelBottom - listBottom).toBeLessThanOrEqual(24);
   });
 
   test("is manually addable from the task workbench's own + menu, independent of the preference", async ({

--- a/apps/web/e2e/tests/settings/todo-list-panel.spec.ts
+++ b/apps/web/e2e/tests/settings/todo-list-panel.spec.ts
@@ -248,6 +248,8 @@ test.describe("Todo list panel preference", () => {
     seedData,
   }) => {
     test.setTimeout(120_000);
+    // Deterministic viewport so the geometry assertions below are stable.
+    await testPage.setViewportSize({ width: 1440, height: 900 });
     const task = await createTaskWithTodos(apiClient, seedData, "Todos fills panel height");
     await setTodoListPanelPreference(apiClient, true);
     await openTask(testPage, task.id);
@@ -265,13 +267,15 @@ test.describe("Todo list panel preference", () => {
     expect(slotBox).not.toBeNull();
     expect(Math.abs((panelBox?.height ?? 0) - (slotBox?.height ?? 0))).toBeLessThanOrEqual(4);
 
-    // The checklist scroll container is no longer a fixed-size popover list
-    // (~40px for two rows, capped at 192px): it flexes to consume the
-    // panel's remaining height below the header/progress chrome.
+    // The checklist scroll container is no longer a fixed-size popover list:
+    // it must consume the panel height below the header/progress chrome
+    // (~66px). A relative bound against the measured slot keeps this
+    // assertion layout-independent (no absolute pixel floor, valid in short
+    // split groups), while still failing the pre-fix 192px cap in any
+    // hosting panel taller than ~280px.
     const listBox = await panel.locator(".overflow-y-auto").boundingBox();
     expect(listBox).not.toBeNull();
-    expect(listBox!.height).toBeGreaterThan(120);
-    expect(listBox!.height).toBeGreaterThan((slotBox?.height ?? 0) - 100);
+    expect(listBox!.height).toBeGreaterThan((slotBox?.height ?? 0) - 90);
   });
 
   test("is manually addable from the task workbench's own + menu, independent of the preference", async ({


### PR DESCRIPTION
The pinned **Todos** panel in the task workbench reused the chat todo popover's checklist, whose list is hard-capped at `max-h-48` (192px), so the pinned panel never filled its hosting panel and left empty space below the list. The checklist now stretches to the full panel height (empty state included) and scrolls internally, with unit and Playwright regression coverage.

## Validation

- `make fmt`, `pnpm run typecheck`, `pnpm run lint` (web, `--max-warnings 0`) — all clean
- Unit: full web suite `pnpm test` passes (10500+ tests); new regression guards in `dockview-panel-content.todos.test.tsx` (panel root `h-full`, no `max-h-48` cap, empty state fills) and `todo-indicator.test.tsx` (default popover path keeps `max-h-48`; `fillHeight` path opts in)
- E2E: `pnpm exec playwright test --config e2e/playwright.config.ts tests/settings/todo-list-panel.spec.ts` — 6/6 pass, including a new geometry test asserting the panel fills its portal slot and the list's bottom edge tracks the panel
- Live browser verification: before/after measured and captured (192px-capped list vs. full-height fill with internal scroll)
- Four adversarial review rounds (OMP GPT luna) — every finding addressed; final round reported CLEAN
- No public docs impact: the feature spec (`docs/specs/ui/agent-todo-list-panel.md`) is unchanged

## Possible Improvements

Low residual risk: the height contract is enforced by a measured bottom-edge invariant valid across layouts, but E2E exercises only the default right-column placement.

## Related Issues

Original task: "Todo pinned pannel does not uses the whole high of its hosting pannel"

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.

## Screenshots

Before (list capped at 192px, empty space below in the hosting panel):

![Before: todos list capped at 192px with empty panel space below](https://raw.githubusercontent.com/Fclem/kandev/8f646ef9fe62a6b0892c5f6294ef337b23f40072/before-todos-panel.png)

After (checklist fills the full panel height and scrolls internally):

![After: todos checklist fills the full panel height](https://raw.githubusercontent.com/Fclem/kandev/8f646ef9fe62a6b0892c5f6294ef337b23f40072/after-todos-panel.png)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2532?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->