### PR TITLE
fix(launcher): detect wildcard listeners in port availability probe

### DIFF
--- a/apps/backend/go.mod
+++ b/apps/backend/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/godbus/dbus/v5 v5.1.0
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
+	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/go-plugin v1.8.0
 	github.com/jackc/pgx/v5 v5.9.2
 	github.com/jmoiron/sqlx v1.4.0
@@ -21,6 +22,7 @@ require (
 	github.com/moby/moby/client v0.5.0
 	github.com/nats-io/nats.go v1.31.0
 	github.com/pkg/sftp v1.13.10
+	github.com/robfig/cron/v3 v3.0.1
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/spf13/viper v1.16.0
 	github.com/stretchr/testify v1.11.1
@@ -71,7 +73,6 @@ require (
 	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
-	github.com/hashicorp/go-hclog v1.6.3 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hashicorp/yamux v0.1.2 // indirect
 	github.com/invopop/jsonschema v0.13.0 // indirect
@@ -98,7 +99,6 @@ require (
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.8 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/spf13/afero v1.9.5 // indirect
 	github.com/spf13/cast v1.7.1 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect

--- a/apps/backend/go.sum
+++ b/apps/backend/go.sum
@@ -83,6 +83,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
+github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
+github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/docker/go-connections v0.7.0 h1:6SsRfJddP22WMrCkj19x9WKjEDTB+ahsdiGYf0mN39c=
 github.com/docker/go-connections v0.7.0/go.mod h1:no1qkHdjq7kLMGUXYAduOhYPSJxxvgWBh7ogVvptn3Q=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=

--- a/apps/backend/internal/agent/hostutility/instance_notfound_test.go
+++ b/apps/backend/internal/agent/hostutility/instance_notfound_test.go
@@ -1,0 +1,50 @@
+package hostutility
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestIsInstanceNotFound(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{
+			// The exact shape ControlClient.DeleteInstance produces on shutdown.
+			name: "delete instance 404",
+			err:  fmt.Errorf("failed to delete instance: instance not found (status 404)"),
+			want: true,
+		},
+		{
+			name: "not found phrase without status",
+			err:  errors.New("instance \"inst-3\" not found"),
+			want: true,
+		},
+		{
+			name: "status 404 uppercased",
+			err:  errors.New("DELETE returned STATUS 404"),
+			want: true,
+		},
+		{
+			name: "transport failure is not not-found",
+			err:  errors.New("failed to delete instance: connection refused"),
+			want: false,
+		},
+		{
+			name: "server error is not not-found",
+			err:  errors.New("failed to delete instance: internal error (status 500)"),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isInstanceNotFound(tt.err); got != tt.want {
+				t.Fatalf("isInstanceNotFound(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}

--- a/apps/backend/internal/agent/hostutility/manager.go
+++ b/apps/backend/internal/agent/hostutility/manager.go
@@ -241,10 +241,20 @@ func (m *Manager) deleteInstance(ctx context.Context, inst *instance) {
 	}
 	if m.controlClient != nil {
 		if err := m.controlClient.DeleteInstance(ctx, inst.instanceID); err != nil {
-			m.log.Warn("failed to delete host utility instance",
-				zap.String("agent_type", inst.agentType),
-				zap.String("instance_id", inst.instanceID),
-				zap.Error(err))
+			// During shutdown agentctl may already be gone, so the delete
+			// returns a not-found/404. That is benign and idempotent: log DEBUG
+			// so it does not add teardown noise. Any other failure stays WARN.
+			if isInstanceNotFound(err) {
+				m.log.Debug("host utility instance already deleted",
+					zap.String("agent_type", inst.agentType),
+					zap.String("instance_id", inst.instanceID),
+					zap.String("error", err.Error()))
+			} else {
+				m.log.Warn("failed to delete host utility instance",
+					zap.String("agent_type", inst.agentType),
+					zap.String("instance_id", inst.instanceID),
+					zap.Error(err))
+			}
 		}
 	}
 	if inst.workDir == "" {
@@ -256,6 +266,19 @@ func (m *Manager) deleteInstance(ctx context.Context, inst *instance) {
 			zap.String("path", inst.workDir),
 			zap.Error(err))
 	}
+}
+
+// isInstanceNotFound reports whether a DeleteInstance error means the agentctl
+// instance was already gone. ControlClient.DeleteInstance stringifies the
+// upstream error as "failed to delete instance: <msg> (status 404)" without a
+// wrapped sentinel, so this matches on the 404 status and the not-found phrase
+// rather than errors.Is.
+func isInstanceNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "status 404") || strings.Contains(msg, "not found")
 }
 
 // eligibleAgents returns enabled agents that implement InferenceAgent AND whose

--- a/apps/backend/internal/agent/runtime/lifecycle/session.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/session.go
@@ -832,9 +832,20 @@ func (sm *SessionManager) dispatchInitialPrompt(ctx context.Context, execution *
 			defer cancel()
 			_, err := sm.SendPrompt(promptCtx, execution, effectivePrompt, false, acpAttachments, false)
 			if err != nil {
-				sm.logger.Error("initial prompt failed",
-					zap.String("execution_id", execution.ID),
-					zap.Error(err))
+				// During graceful shutdown the agent subprocess is terminated,
+				// so an in-flight initial prompt fails with a transport death
+				// or context cancellation. That is an expected teardown race,
+				// not a fault: log WARN without a stack trace so it does not
+				// masquerade as a crash.
+				if sm.stopChClosed() || isTransportDeadErr(err) {
+					sm.logger.Warn("initial prompt aborted during shutdown",
+						zap.String("execution_id", execution.ID),
+						zap.String("error", err.Error()))
+				} else {
+					sm.logger.Error("initial prompt failed",
+						zap.String("execution_id", execution.ID),
+						zap.Error(err))
+				}
 				if sm.initialPromptFailure != nil {
 					sm.initialPromptFailure(execution.ID)
 				}
@@ -916,9 +927,19 @@ func (sm *SessionManager) waitForPromptDone(
 				continue
 			}
 			if signal.IsError {
-				sm.logger.Error("prompt completed with error",
-					zap.String("execution_id", execution.ID),
-					zap.String("error", signal.Error))
+				// A transport death or cancel-release during shutdown is a
+				// benign teardown race, not an agent fault. Log WARN (no stack
+				// trace) for those; keep ERROR for genuine agent failures on an
+				// active session.
+				if isBenignPromptTeardown(signal.Error) || sm.stopChClosed() {
+					sm.logger.Warn("prompt aborted during shutdown",
+						zap.String("execution_id", execution.ID),
+						zap.String("error", signal.Error))
+				} else {
+					sm.logger.Error("prompt completed with error",
+						zap.String("execution_id", execution.ID),
+						zap.String("error", signal.Error))
+				}
 				// Wrap cancel-release sentinels so PromptTask can identify them and
 				// skip the REVIEW task-state transition — the user is cancelling, not
 				// hitting a real agent failure.
@@ -976,6 +997,40 @@ func (sm *SessionManager) waitForPromptDone(
 func isCancelReleaseError(msg string) bool {
 	return strings.HasPrefix(msg, "cancel escalated") ||
 		strings.Contains(msg, "prompt abandoned after cancel")
+}
+
+// stopChClosed reports whether graceful shutdown has already been signalled.
+// A closed stopCh means an in-flight prompt failure is a teardown race rather
+// than a fault. A nil stopCh (e.g. tests that don't wire shutdown) is treated
+// as not shutting down.
+func (sm *SessionManager) stopChClosed() bool {
+	if sm.stopCh == nil {
+		return false
+	}
+	select {
+	case <-sm.stopCh:
+		return true
+	default:
+		return false
+	}
+}
+
+// isBenignPromptTeardown reports whether a prompt-completion error string is a
+// benign teardown race: an ACP transport death (the agent subprocess was
+// terminated mid-prompt during shutdown) or a cancel-release sentinel. The
+// prompt-completion signal carries the error as a string, so this matches the
+// same phrases isTransportDeadErr matches on an error value.
+func isBenignPromptTeardown(msg string) bool {
+	if msg == "" {
+		return false
+	}
+	if isCancelReleaseError(msg) {
+		return true
+	}
+	return strings.Contains(msg, "peer disconnected") ||
+		strings.Contains(msg, "connection closed") ||
+		strings.Contains(msg, "notification queue overflow") ||
+		strings.Contains(msg, context.Canceled.Error())
 }
 
 // SendPrompt sends a prompt to an agent execution and waits for completion.

--- a/apps/backend/internal/agent/runtime/lifecycle/session_shutdown_log_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/session_shutdown_log_test.go
@@ -1,0 +1,129 @@
+package lifecycle
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/kandev/kandev/internal/common/logger"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestIsBenignPromptTeardown(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  string
+		want bool
+	}{
+		{name: "empty", msg: "", want: false},
+		{name: "peer disconnected", msg: "-32603 ... peer disconnected before response", want: true},
+		{name: "connection closed", msg: "prompt failed: connection closed", want: true},
+		{name: "notification queue overflow", msg: "notification queue overflow", want: true},
+		{name: "context canceled", msg: fmt.Sprintf("send prompt: %s", context.Canceled.Error()), want: true},
+		{name: "cancel escalated sentinel", msg: "cancel escalated after grace", want: true},
+		{name: "prompt abandoned after cancel", msg: "prompt abandoned after cancel", want: true},
+		{name: "genuine agent error", msg: "agent reported: tool execution failed", want: false},
+		{name: "deadline exceeded is not benign as string", msg: context.DeadlineExceeded.Error(), want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isBenignPromptTeardown(tt.msg); got != tt.want {
+				t.Fatalf("isBenignPromptTeardown(%q) = %v, want %v", tt.msg, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStopChClosed(t *testing.T) {
+	t.Run("nil stopCh is not shutting down", func(t *testing.T) {
+		sm := &SessionManager{}
+		if sm.stopChClosed() {
+			t.Fatal("nil stopCh should report not shutting down")
+		}
+	})
+	t.Run("open stopCh is not shutting down", func(t *testing.T) {
+		sm := &SessionManager{stopCh: make(chan struct{})}
+		if sm.stopChClosed() {
+			t.Fatal("open stopCh should report not shutting down")
+		}
+	})
+	t.Run("closed stopCh is shutting down", func(t *testing.T) {
+		ch := make(chan struct{})
+		close(ch)
+		sm := &SessionManager{stopCh: ch}
+		if !sm.stopChClosed() {
+			t.Fatal("closed stopCh should report shutting down")
+		}
+	})
+}
+
+// observedLogger returns a Logger backed by an observer core capturing entries
+// at WARN and above, so tests can assert the exact level a site logged at.
+func observedLogger(t *testing.T) (*logger.Logger, *observer.ObservedLogs) {
+	t.Helper()
+	core, logs := observer.New(zapcore.WarnLevel)
+	log, err := logger.NewFromZap(zap.New(core))
+	if err != nil {
+		t.Fatalf("NewFromZap: %v", err)
+	}
+	return log, logs
+}
+
+func TestPromptCompletionLogLevel(t *testing.T) {
+	tests := []struct {
+		name       string
+		errText    string
+		stopClosed bool
+		wantLevel  zapcore.Level
+		wantMsg    string
+	}{
+		{
+			name:      "transport death logs warn",
+			errText:   "-32603 ... peer disconnected before response",
+			wantLevel: zapcore.WarnLevel,
+			wantMsg:   "prompt aborted during shutdown",
+		},
+		{
+			name:       "shutdown in progress logs warn",
+			errText:    "some agent error",
+			stopClosed: true,
+			wantLevel:  zapcore.WarnLevel,
+			wantMsg:    "prompt aborted during shutdown",
+		},
+		{
+			name:      "genuine agent error on active session logs error",
+			errText:   "agent reported: tool execution failed",
+			wantLevel: zapcore.ErrorLevel,
+			wantMsg:   "prompt completed with error",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			log, logs := observedLogger(t)
+			// Mirror the classification branch in waitForPromptDone.
+			sm := &SessionManager{logger: log}
+			if tt.stopClosed {
+				ch := make(chan struct{})
+				close(ch)
+				sm.stopCh = ch
+			}
+			if isBenignPromptTeardown(tt.errText) || sm.stopChClosed() {
+				sm.logger.Warn("prompt aborted during shutdown", zap.String("error", tt.errText))
+			} else {
+				sm.logger.Error("prompt completed with error", zap.String("error", tt.errText))
+			}
+			entries := logs.All()
+			if len(entries) != 1 {
+				t.Fatalf("expected 1 log entry, got %d", len(entries))
+			}
+			if entries[0].Level != tt.wantLevel {
+				t.Fatalf("level = %v, want %v", entries[0].Level, tt.wantLevel)
+			}
+			if entries[0].Message != tt.wantMsg {
+				t.Fatalf("message = %q, want %q", entries[0].Message, tt.wantMsg)
+			}
+		})
+	}
+}

--- a/apps/backend/internal/launcher/ports.go
+++ b/apps/backend/internal/launcher/ports.go
@@ -165,11 +165,41 @@ func pickAvailablePortExcept(preferred int, used map[int]bool) (int, error) {
 	return 0, fmt.Errorf("unable to find a free port")
 }
 
+// connectProbeTimeout bounds each loopback connect probe so a silently dropped
+// SYN (for example under WSL2 mirrored networking to an unbound loopback port)
+// cannot hang port selection. A timed-out connect counts as "nothing listening".
+const connectProbeTimeout = 500 * time.Millisecond
+
+// canBind reports whether a port is available. It is available only when a
+// dual-stack loopback connect finds nothing listening AND a fresh loopback bind
+// succeeds. The connect probe is required because a running backend binds the
+// wildcard address (0.0.0.0 and [::]): on macOS/BSD a specific 127.0.0.1 bind
+// succeeds against an active wildcard listener (Go also sets SO_REUSEADDR), so a
+// bind-only check would falsely report the busy port as free. The bind probe is
+// retained because it catches reservations a connect misses (Windows phantom
+// reservations, TIME_WAIT).
 func canBind(port int) bool {
+	if portHasListener(port) {
+		return false
+	}
 	ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
 	if err != nil {
 		return false
 	}
 	_ = ln.Close()
 	return true
+}
+
+// portHasListener reports whether anything answers a loopback connect on either
+// the IPv4 or IPv6 loopback address. The existing backend may hold only the IPv6
+// wildcard socket, so both families are probed.
+func portHasListener(port int) bool {
+	for _, host := range []string{"127.0.0.1", "::1"} {
+		conn, err := net.DialTimeout("tcp", net.JoinHostPort(host, strconv.Itoa(port)), connectProbeTimeout)
+		if err == nil {
+			_ = conn.Close()
+			return true
+		}
+	}
+	return false
 }

--- a/apps/backend/internal/launcher/ports_test.go
+++ b/apps/backend/internal/launcher/ports_test.go
@@ -195,3 +195,38 @@ func TestPickPortsIgnoresOccupiedWebPort(t *testing.T) {
 		t.Fatalf("pickPorts collided with the occupied web port %d: %+v", webPort, cfg)
 	}
 }
+
+func TestCanBindDetectsWildcardListener(t *testing.T) {
+	// A running backend binds the wildcard address. On macOS/BSD a bind to the
+	// specific 127.0.0.1 address succeeds against an active wildcard listener
+	// (Go also sets SO_REUSEADDR), so a bind-only probe falsely reports the busy
+	// port as free. The probe must connect-check both loopback families first.
+	ln, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	port := ln.Addr().(*net.TCPAddr).Port
+	if canBind(port) {
+		t.Fatalf("canBind(%d) = true while a wildcard listener holds the port", port)
+	}
+	if got, err := pickAvailablePortExcept(port, map[int]bool{}); err != nil {
+		t.Fatalf("pickAvailablePortExcept(%d) failed: %v", port, err)
+	} else if got == port {
+		t.Fatalf("pickAvailablePortExcept returned the occupied wildcard port %d", port)
+	}
+}
+
+func TestCanBindAcceptsFreePort(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	_ = ln.Close()
+
+	if !canBind(port) {
+		t.Fatalf("canBind(%d) = false for a free port", port)
+	}
+}

--- a/apps/backend/internal/orchestrator/handlers/handlers.go
+++ b/apps/backend/internal/orchestrator/handlers/handlers.go
@@ -88,10 +88,21 @@ func (h *Handlers) wsLaunchSession(ctx context.Context, msg *ws.Message) (*ws.Me
 
 	resp, err := h.service.LaunchSession(ctx, &req)
 	if err != nil {
-		h.logger.Error("failed to launch session",
-			zap.String("task_id", req.TaskID),
-			zap.String("intent", string(orchestrator.ResolveIntent(&req))),
-			zap.Error(err))
+		// A launch failing because the root context was cancelled or the
+		// session is already terminal is an expected shutdown teardown race,
+		// not a fault: log WARN (no stack trace) so it does not masquerade as a
+		// crash. Genuine failures (unknown task, validation) stay ERROR.
+		if orchestrator.IsBenignLaunchTeardownErr(err) {
+			h.logger.Warn("session launch aborted during shutdown",
+				zap.String("task_id", req.TaskID),
+				zap.String("intent", string(orchestrator.ResolveIntent(&req))),
+				zap.String("error", err.Error()))
+		} else {
+			h.logger.Error("failed to launch session",
+				zap.String("task_id", req.TaskID),
+				zap.String("intent", string(orchestrator.ResolveIntent(&req))),
+				zap.Error(err))
+		}
 		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError, "Failed to launch session: "+err.Error(), nil)
 	}
 	return ws.NewResponse(msg.ID, msg.Action, resp)

--- a/apps/backend/internal/orchestrator/session_launch.go
+++ b/apps/backend/internal/orchestrator/session_launch.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -12,6 +13,14 @@ import (
 	wfmodels "github.com/kandev/kandev/internal/workflow/models"
 	v1 "github.com/kandev/kandev/pkg/api/v1"
 )
+
+// sessionTerminalErrText mirrors lifecycle.ErrSessionTerminal's message. It is
+// duplicated as a string rather than imported so this higher-level orchestrator
+// file does not take a direct dependency on internal/agent/runtime/lifecycle
+// (ARCH-RUNTIME-IMPORT): the launch failures reach here only as wrapped-error
+// strings or a stringified persisted session error, so a string match is both
+// sufficient and required (see IsBenignLaunchTeardownErr).
+const sessionTerminalErrText = "session is terminal"
 
 // SessionIntent represents the type of session operation requested.
 type SessionIntent string
@@ -97,6 +106,33 @@ func ResolveIntent(req *LaunchSessionRequest) SessionIntent {
 		return IntentPrepare
 	}
 	return IntentStart
+}
+
+// IsBenignLaunchTeardownErr reports whether a session-launch failure is an
+// expected graceful-shutdown teardown race rather than a genuine fault. During
+// shutdown the root context is cancelled and terminal sessions reject launches,
+// so an in-flight session.launch fails predictably; those should log WARN
+// without a stack trace, not ERROR.
+//
+// Two shapes reach the launch handler on shutdown:
+//   - restore_workspace wraps lifecycle.ErrSessionTerminal with %w and the
+//     cancelled root context surfaces context.Canceled, so errors.Is matches
+//     the context sentinel.
+//   - resume stringifies a persisted session error (task_operations.go uses %s
+//     on sess.ErrorMessage), destroying any sentinel, so a bounded string
+//     fallback for "context canceled"/"session is terminal" is required. The
+//     terminal-session text is matched as a string (not errors.Is) to avoid a
+//     higher-level import of the runtime/lifecycle seam.
+func IsBenignLaunchTeardownErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) {
+		return true
+	}
+	msg := err.Error()
+	return strings.Contains(msg, context.Canceled.Error()) ||
+		strings.Contains(msg, sessionTerminalErrText)
 }
 
 // LaunchSession is the unified entry point for all session operations.

--- a/apps/backend/internal/orchestrator/session_launch_test.go
+++ b/apps/backend/internal/orchestrator/session_launch_test.go
@@ -3,9 +3,11 @@ package orchestrator
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
+	"github.com/kandev/kandev/internal/agent/runtime/lifecycle"
 	"github.com/kandev/kandev/internal/task/models"
 	sqliterepo "github.com/kandev/kandev/internal/task/repository/sqlite"
 	wfmodels "github.com/kandev/kandev/internal/workflow/models"
@@ -490,5 +492,54 @@ func TestLaunchRestoreWorkspace_IncludesWorktreeInfo(t *testing.T) {
 	}
 	if resp.WorktreeBranch == nil || *resp.WorktreeBranch != "feature/test" {
 		t.Errorf("expected worktree_branch 'feature/test', got %v", resp.WorktreeBranch)
+	}
+}
+
+func TestIsBenignLaunchTeardownErr(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{
+			name: "wrapped context.Canceled",
+			err:  fmt.Errorf("launch failed: %w", context.Canceled),
+			want: true,
+		},
+		{
+			name: "wrapped ErrSessionTerminal",
+			err:  fmt.Errorf("restore workspace: %w", lifecycle.ErrSessionTerminal),
+			want: true,
+		},
+		{
+			// resume path stringifies a persisted session error, destroying the
+			// sentinel (task_operations.go uses %s): the string fallback catches it.
+			name: "stringified context canceled (resume)",
+			err:  fmt.Errorf("session failed: %s", "context canceled"),
+			want: true,
+		},
+		{
+			name: "stringified session is terminal",
+			err:  errors.New("session failed: session is terminal"),
+			want: true,
+		},
+		{
+			name: "unknown task is not benign",
+			err:  errors.New("task not found"),
+			want: false,
+		},
+		{
+			name: "validation error is not benign",
+			err:  errors.New("task_id is required"),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsBenignLaunchTeardownErr(tt.err); got != tt.want {
+				t.Fatalf("IsBenignLaunchTeardownErr(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
 	}
 }

--- a/apps/backend/internal/plugins/runtime/hclog_adapter.go
+++ b/apps/backend/internal/plugins/runtime/hclog_adapter.go
@@ -1,0 +1,111 @@
+package runtime
+
+import (
+	"strings"
+	"sync/atomic"
+
+	hclog "github.com/hashicorp/go-hclog"
+	"go.uber.org/zap"
+
+	"github.com/kandev/kandev/internal/common/logger"
+)
+
+// pluginExitedMsg is the message go-plugin's monitor goroutine logs when the
+// subprocess exits. On a deliberate shutdown kill the wait error is an
+// expected "signal: terminated" / "signal: killed", which go-plugin emits at
+// ERROR — misleading noise during graceful teardown. See client.go's
+// "plugin process exited" site in hashicorp/go-plugin.
+const pluginExitedMsg = "plugin process exited"
+
+// hclogZapAdapter routes hashicorp/go-plugin's internal hclog output through
+// Kandev's zap logger so plugin diagnostics land in the backend log stream.
+// It embeds a base hclog.Logger purely to satisfy the large hclog.Logger
+// interface's boilerplate (Is*, StandardLogger, level bookkeeping); the
+// level-emitting methods are overridden to forward to zap.
+//
+// The stopping flag (shared per client) lets the deliberate-kill path mark a
+// process as intentionally terminated: while set, the expected
+// "plugin process exited" ERROR is downgraded to DEBUG so a graceful shutdown
+// does not print a stack-trace-bearing error. Genuine crashes (stopping unset)
+// still surface at ERROR.
+type hclogZapAdapter struct {
+	hclog.Logger
+	log      *logger.Logger
+	stopping *atomic.Bool
+}
+
+// newHCLogAdapter builds an adapter forwarding to log, sharing stopping with
+// the owning process so Kill can flag an expected exit.
+func newHCLogAdapter(log *logger.Logger, stopping *atomic.Bool) *hclogZapAdapter {
+	return &hclogZapAdapter{
+		Logger:   hclog.NewNullLogger(),
+		log:      log,
+		stopping: stopping,
+	}
+}
+
+func (a *hclogZapAdapter) fields(args []interface{}) []zap.Field {
+	fields := make([]zap.Field, 0, len(args)/2+1)
+	for i := 0; i+1 < len(args); i += 2 {
+		key, ok := args[i].(string)
+		if !ok {
+			continue
+		}
+		fields = append(fields, zap.Any(key, args[i+1]))
+	}
+	return fields
+}
+
+func (a *hclogZapAdapter) Trace(msg string, args ...interface{}) { a.log.Debug(msg, a.fields(args)...) }
+func (a *hclogZapAdapter) Debug(msg string, args ...interface{}) { a.log.Debug(msg, a.fields(args)...) }
+func (a *hclogZapAdapter) Info(msg string, args ...interface{})  { a.log.Info(msg, a.fields(args)...) }
+func (a *hclogZapAdapter) Warn(msg string, args ...interface{})  { a.log.Warn(msg, a.fields(args)...) }
+
+func (a *hclogZapAdapter) Error(msg string, args ...interface{}) {
+	// An expected exit during a deliberate kill is teardown noise, not a fault.
+	if a.stopping != nil && a.stopping.Load() && strings.Contains(msg, pluginExitedMsg) {
+		a.log.Debug(msg, a.fields(args)...)
+		return
+	}
+	a.log.Error(msg, a.fields(args)...)
+}
+
+func (a *hclogZapAdapter) Log(level hclog.Level, msg string, args ...interface{}) {
+	switch level {
+	case hclog.Trace, hclog.Debug:
+		a.Debug(msg, args...)
+	case hclog.Info:
+		a.Info(msg, args...)
+	case hclog.Warn:
+		a.Warn(msg, args...)
+	case hclog.Error:
+		a.Error(msg, args...)
+	default:
+		a.Info(msg, args...)
+	}
+}
+
+// With/Named/ResetNamed return the same adapter so the stopping flag and zap
+// sink survive go-plugin's sublogger creation. go-plugin decorates its client
+// logger with fields/names; a base-logger passthrough would drop the override.
+func (a *hclogZapAdapter) With(args ...interface{}) hclog.Logger {
+	return &hclogZapAdapter{Logger: a.Logger.With(args...), log: a.log.WithFields(a.fields(args)...), stopping: a.stopping}
+}
+
+func (a *hclogZapAdapter) Named(name string) hclog.Logger {
+	return &hclogZapAdapter{Logger: a.Logger.Named(name), log: a.log, stopping: a.stopping}
+}
+
+func (a *hclogZapAdapter) ResetNamed(name string) hclog.Logger {
+	return &hclogZapAdapter{Logger: a.Logger.ResetNamed(name), log: a.log, stopping: a.stopping}
+}
+
+// IsError/IsWarn/IsInfo/IsDebug report true so go-plugin does not elide the
+// messages the adapter forwards to zap; zap applies its own level filtering.
+func (a *hclogZapAdapter) IsTrace() bool { return true }
+func (a *hclogZapAdapter) IsDebug() bool { return true }
+func (a *hclogZapAdapter) IsInfo() bool  { return true }
+func (a *hclogZapAdapter) IsWarn() bool  { return true }
+func (a *hclogZapAdapter) IsError() bool { return true }
+
+var _ hclog.Logger = (*hclogZapAdapter)(nil)

--- a/apps/backend/internal/plugins/runtime/hclog_adapter_test.go
+++ b/apps/backend/internal/plugins/runtime/hclog_adapter_test.go
@@ -1,0 +1,106 @@
+package runtime
+
+import (
+	"sync/atomic"
+	"testing"
+
+	hclog "github.com/hashicorp/go-hclog"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/kandev/kandev/internal/common/logger"
+)
+
+func newObservedLogger(t *testing.T) (*logger.Logger, *observer.ObservedLogs) {
+	t.Helper()
+	core, logs := observer.New(zapcore.DebugLevel)
+	log, err := logger.NewFromZap(zap.New(core))
+	if err != nil {
+		t.Fatalf("NewFromZap: %v", err)
+	}
+	return log, logs
+}
+
+func TestHCLogAdapterDowngradesExpectedExitOnStop(t *testing.T) {
+	tests := []struct {
+		name      string
+		stopping  bool
+		msg       string
+		wantLevel zapcore.Level
+	}{
+		{
+			name:      "expected exit during deliberate kill logs debug",
+			stopping:  true,
+			msg:       "plugin process exited",
+			wantLevel: zapcore.DebugLevel,
+		},
+		{
+			name:      "unexpected exit while running logs error",
+			stopping:  false,
+			msg:       "plugin process exited",
+			wantLevel: zapcore.ErrorLevel,
+		},
+		{
+			name:      "unrelated error during stop still logs error",
+			stopping:  true,
+			msg:       "handshake failed",
+			wantLevel: zapcore.ErrorLevel,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			log, logs := newObservedLogger(t)
+			stopping := &atomic.Bool{}
+			stopping.Store(tt.stopping)
+			a := newHCLogAdapter(log, stopping)
+
+			a.Error(tt.msg, "error", "signal: terminated")
+
+			entries := logs.All()
+			if len(entries) != 1 {
+				t.Fatalf("expected 1 log entry, got %d", len(entries))
+			}
+			if entries[0].Level != tt.wantLevel {
+				t.Fatalf("level = %v, want %v", entries[0].Level, tt.wantLevel)
+			}
+			if entries[0].Message != tt.msg {
+				t.Fatalf("message = %q, want %q", entries[0].Message, tt.msg)
+			}
+		})
+	}
+}
+
+func TestHCLogAdapterForwardsArgsAsFields(t *testing.T) {
+	log, logs := newObservedLogger(t)
+	a := newHCLogAdapter(log, &atomic.Bool{})
+
+	a.Warn("plugin restarting", "plugin", "github-status", "attempt", 2)
+
+	entries := logs.All()
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 log entry, got %d", len(entries))
+	}
+	fields := entries[0].ContextMap()
+	if fields["plugin"] != "github-status" {
+		t.Fatalf("plugin field = %v, want github-status", fields["plugin"])
+	}
+	if fields["attempt"] != int64(2) {
+		t.Fatalf("attempt field = %v, want 2", fields["attempt"])
+	}
+}
+
+func TestHCLogAdapterLevelRouting(t *testing.T) {
+	log, logs := newObservedLogger(t)
+	a := newHCLogAdapter(log, &atomic.Bool{})
+
+	a.Log(hclog.Warn, "via Log", "k", "v")
+
+	entries := logs.All()
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 log entry, got %d", len(entries))
+	}
+	if entries[0].Level != zapcore.WarnLevel {
+		t.Fatalf("level = %v, want warn", entries[0].Level)
+	}
+}

--- a/apps/backend/internal/plugins/runtime/manager.go
+++ b/apps/backend/internal/plugins/runtime/manager.go
@@ -16,9 +16,11 @@ import (
 	"path/filepath"
 	goruntime "runtime"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	hcplugin "github.com/hashicorp/go-plugin"
+	"go.uber.org/zap"
 
 	"github.com/kandev/kandev/internal/common/logger"
 	"github.com/kandev/kandev/internal/plugins/manifest"
@@ -391,6 +393,10 @@ func (m *Manager) spawnFuncFor(id string, mf *manifest.Manifest, installPath str
 		cmd.Dir = installPath
 		cmd.Env = append(os.Environ(), pluginDataDirEnv+"="+dataDir)
 
+		// Route go-plugin's internal hclog through zap and share a stopping
+		// flag with the returned hcProcess so a deliberate Kill downgrades the
+		// expected "signal: terminated" exit from ERROR to DEBUG.
+		stopping := &atomic.Bool{}
 		client := hcplugin.NewClient(&hcplugin.ClientConfig{
 			HandshakeConfig:  pluginsdk.Handshake,
 			Plugins:          map[string]hcplugin.Plugin{pluginsdk.PluginMapKey: &pluginsdk.GRPCPlugin{Host: hostFactory(id)}},
@@ -398,6 +404,7 @@ func (m *Manager) spawnFuncFor(id string, mf *manifest.Manifest, installPath str
 			AutoMTLS:         true,
 			Cmd:              cmd,
 			StartTimeout:     startTimeout,
+			Logger:           newHCLogAdapter(m.log.WithFields(zap.String("plugin_id", id)), stopping),
 		})
 
 		rpcClient, err := client.Client()
@@ -415,7 +422,7 @@ func (m *Manager) spawnFuncFor(id string, mf *manifest.Manifest, installPath str
 			client.Kill()
 			return nil, fmt.Errorf("plugins/runtime: plugin %q dispensed %T, want *pluginsdk.RemotePlugin", id, raw)
 		}
-		return &hcProcess{client: client, proto: rpcClient, remote: remote}, nil
+		return &hcProcess{client: client, proto: rpcClient, remote: remote, stopping: stopping}, nil
 	}, nil
 }
 
@@ -426,11 +433,20 @@ type hcProcess struct {
 	client *hcplugin.Client
 	proto  hcplugin.ClientProtocol
 	remote *pluginsdk.RemotePlugin
+	// stopping is shared with the client's hclog adapter: setting it before
+	// Kill marks the resulting subprocess exit as an expected teardown so the
+	// adapter logs it at DEBUG rather than ERROR.
+	stopping *atomic.Bool
 }
 
-func (h *hcProcess) Ping() error                     { return h.proto.Ping() }
-func (h *hcProcess) Exited() bool                    { return h.client.Exited() }
-func (h *hcProcess) Kill()                           { h.client.Kill() }
+func (h *hcProcess) Ping() error  { return h.proto.Ping() }
+func (h *hcProcess) Exited() bool { return h.client.Exited() }
+func (h *hcProcess) Kill() {
+	if h.stopping != nil {
+		h.stopping.Store(true)
+	}
+	h.client.Kill()
+}
 func (h *hcProcess) Remote() *pluginsdk.RemotePlugin { return h.remote }
 
 var _ spawnedProcess = (*hcProcess)(nil)

--- a/docs/plans/launcher-port-wildcard-detection/plan.md
+++ b/docs/plans/launcher-port-wildcard-detection/plan.md
@@ -1,0 +1,95 @@
+---
+status: implemented
+created: 2026-08-11
+spec: "../../specs/port-collision-safety/spec.md"
+---
+
+# Plan: Launcher port-availability probe detects wildcard listeners
+
+## Root cause
+
+`make dev` failed to bind the default backend port `38429` and did not fall back to a
+random port, even though the launcher is supposed to. The launcher's port-availability
+check is `canBind` in `apps/backend/internal/launcher/ports.go`:
+
+```go
+func canBind(port int) bool {
+	ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	if err != nil {
+		return false
+	}
+	_ = ln.Close()
+	return true
+}
+```
+
+A running Kandev backend binds the **wildcard** address (`0.0.0.0` and `[::]`). On
+BSD-derived systems including macOS, a bind to the specific `127.0.0.1` address succeeds
+even while a wildcard listener already holds the port, and Go's `net.Listen` sets
+`SO_REUSEADDR`, which reinforces the false success. So `canBind(38429)` returns `true`
+against the live backend, `pickAvailablePortExcept` keeps the occupied preferred port,
+and the child backend later dies on the real wildcard bind.
+
+Before PR #2411 moved `make dev` to the native Go launcher, `make dev` ran through the
+TypeScript launcher (`apps/cli/src/ports.ts`), whose `isPortAvailable` did a **connect**
+probe on both `127.0.0.1` and `::1` **and** a bind probe, and only reported a port free
+when nothing answered the connect and the bind succeeded. That connect probe is exactly
+what detected the wildcard listener; the Go rewrite dropped it. This is a regression from
+that migration.
+
+## Approach
+
+Restore the dual connect-and-bind, dual-stack probe in the Go launcher's `canBind`,
+mirroring the deleted TypeScript logic:
+
+- Connect to `127.0.0.1:<port>` and `::1:<port>` with a short bounded timeout. If either
+  connect succeeds, something is listening: the port is busy.
+- Otherwise attempt a fresh loopback bind. Success means the port is free.
+
+All existing callers (`pickAvailablePortExcept`, explicit backend/web preflight in
+`pickDevPorts`) route through `canBind`, so the single change fixes preflight and
+automatic selection together. No signature change, so no downstream caller updates.
+
+### Design decisions
+
+- **Keep the bind probe.** It catches Windows phantom reservations and TIME_WAIT ports a
+  connect-only check misses. The spec requires both probes.
+- **Bounded connect timeout.** A silently dropped SYN to an unbound loopback port (WSL2
+  mirrored networking) must not hang selection; a timeout counts as "nothing listening".
+  Reuse the TypeScript value of 500ms.
+- **Probe both loopback families.** The backend may hold only the IPv6 wildcard socket, so
+  an IPv4-only connect probe would miss it.
+- **No signature change.** `canBind(port int) bool` stays; internals gain the connect step.
+
+## Regression test
+
+`TestCanBindDetectsWildcardListener` (new, in `ports_test.go`): stand up a wildcard TCP
+listener (`net.Listen("tcp", ":0")` on the IPv6/dual wildcard, or `0.0.0.0:0`), take its
+port, and assert `canBind(port)` returns `false`. This fails before the fix (bind-only
+`canBind` returns `true` against the wildcard listener) and passes after. A companion
+assertion confirms `pickAvailablePortExcept(port, nil)` does not return the occupied port.
+
+## Tasks
+
+| Task | Wave | Parallel-safe | Summary |
+| --- | --- | --- | --- |
+| task-01-wildcard-port-probe | 1 | no | Add failing regression test, implement connect+bind dual-stack `canBind`. |
+
+## Validation
+
+From `apps/backend`:
+
+```bash
+go test ./internal/launcher/ -run 'Port|CanBind|Bind' -race -count=1
+go test ./internal/launcher/ -race -count=1
+gofmt -l internal/launcher/ports.go internal/launcher/ports_test.go
+golangci-lint run ./internal/launcher/... --new-from-rev=origin/main --timeout=5m
+```
+
+## Risks and out of scope
+
+- **Out of scope:** changing default ports, fallback ranges, the health-token ownership
+  path, the Windows address-in-use classifier, or backend runtime-state locking.
+- **Risk:** a slow or firewalled loopback connect could add up to the timeout per busy
+  candidate. Mitigated by the 500ms bound and by the connect only running during port
+  selection, not on the hot path.

--- a/docs/plans/launcher-port-wildcard-detection/task-01-wildcard-port-probe.md
+++ b/docs/plans/launcher-port-wildcard-detection/task-01-wildcard-port-probe.md
@@ -1,0 +1,71 @@
+---
+status: done
+plan: "./plan.md"
+spec: "../../specs/port-collision-safety/spec.md"
+wave: 1
+parallel-safe: no
+parallelism: sequential
+---
+
+# Task 01: Detect wildcard listeners in the launcher port probe
+
+## Goal
+
+Make `canBind` in `apps/backend/internal/launcher/ports.go` report a port as available
+only when a dual-stack loopback connect finds nothing listening **and** a fresh loopback
+bind succeeds, so `make dev` falls back to a random port when a running backend holds the
+preferred port through a wildcard bind.
+
+## Root cause (confirmed)
+
+`canBind` bind-probes only `127.0.0.1`. A running backend binds the wildcard address, and
+on macOS/BSD a specific-address bind succeeds against an active wildcard listener (Go also
+sets `SO_REUSEADDR`), so `canBind` falsely returns `true`. The TypeScript launcher this
+replaced (PR #2411) also ran a dual-stack connect probe; the Go rewrite dropped it.
+
+## Files
+
+- `apps/backend/internal/launcher/ports.go` — replace the bind-only `canBind` with a
+  connect-then-bind probe: connect `127.0.0.1` and `::1` with a bounded timeout; if either
+  answers, return `false`; otherwise return the result of the loopback bind. Add a
+  `connectProbeTimeout` constant (500ms) and a private `portHasListener(port)` helper.
+- `apps/backend/internal/launcher/ports_test.go` — add the regression test(s).
+
+## Steps (TDD)
+
+1. Mark this task `in_progress`.
+2. Add `TestCanBindDetectsWildcardListener`: create a wildcard listener on a free port
+   (`net.Listen("tcp", ":0")`), read `port := ln.Addr().(*net.TCPAddr).Port`, assert
+   `canBind(port)` is `false`, and assert `pickAvailablePortExcept(port, map[int]bool{})`
+   does not return `port`. Run it and confirm it FAILS for the expected reason (bind-only
+   `canBind` returns `true`).
+3. Implement the connect+bind dual-stack probe. Keep the exported signature
+   `canBind(port int) bool` unchanged.
+4. Run the targeted commands below; confirm the new test passes and existing launcher
+   tests still pass.
+5. Mark this task `done` and update `plan.md` status.
+
+## Acceptance criteria
+
+- `canBind(port)` returns `false` while a wildcard listener holds `port` (IPv4 or IPv6).
+- `canBind(port)` returns `true` for a genuinely free port.
+- Existing tests (`TestPickPortsRejectsOccupiedExplicitBackendPort`,
+  `TestPickDevPorts*`, `TestPickAvailablePortExceptSkipsUsedPreferredPort`) still pass.
+- No caller signature changes; `pickDevPorts`/`pickPorts` behavior is unchanged for free
+  ports.
+
+## Validation commands
+
+From `apps/backend`:
+
+```bash
+go test ./internal/launcher/ -run 'CanBind|Port|Bind' -race -count=1
+go test ./internal/launcher/ -race -count=1
+gofmt -l internal/launcher/ports.go internal/launcher/ports_test.go
+golangci-lint run ./internal/launcher/... --new-from-rev=origin/main --timeout=5m
+```
+
+## Out of scope
+
+Default ports, fallback ranges, health-token ownership, the Windows address-in-use
+classifier, and backend runtime-state locking.

--- a/docs/plans/shutdown-log-noise/plan.md
+++ b/docs/plans/shutdown-log-noise/plan.md
@@ -1,0 +1,60 @@
+---
+spec: docs/specs/shutdown-log-noise/spec.md
+created: 2026-08-11
+status: done
+---
+
+# Implementation Plan: Quiet benign teardown log noise on shutdown
+
+## Overview
+Downgrade benign shutdown teardown log lines from ERROR (with stack traces) to
+WARN, and stop the go-plugin library from logging an expected `signal:
+terminated` exit as ERROR. Logging-severity only: no control-flow, state, or
+contract changes. Each task reuses existing teardown-classification helpers and
+adds a focused regression test.
+
+## Confirmed root cause
+Ctrl+C runs `runGracefulShutdown` (`internal/backendapp/helpers.go`), which
+cancels the root context and SIGTERMs the plugin and agent subprocesses. In-flight
+operations then fail with `context.Canceled` / `peer disconnected before
+response` / `ErrSessionTerminal`. Most of the codebase already classifies these
+as WARN teardown races (`executor.handleAgentProcessStartFailure`, the ACP
+`session/load` path), but three sites do not participate:
+- `session.go` prompt-completion / initial-prompt logging (ERROR).
+- `orchestrator/handlers.go` `wsLaunchSession` (ERROR, unconditional).
+- go-plugin's own default hclog logger (ERROR on kill), because
+  `hcplugin.NewClient` is constructed without a `Logger`.
+
+## Key subtlety (must be handled)
+For `intent=resume`, the underlying `context.Canceled` sentinel is destroyed by
+`task_operations.go:2229` `fmt.Errorf("session failed: %s", errMsg)` (`%s`, not
+`%w`). So `errors.Is(err, context.Canceled)` is FALSE on that path. For
+`intent=restore_workspace`, `manager_launch.go:1397` wraps `ErrSessionTerminal`
+with `%w`, so `errors.Is(err, lifecycle.ErrSessionTerminal)` is TRUE. The
+orchestrator classifier must handle both: `errors.Is` for the wrapped sentinels
+AND a bounded string fallback (`context canceled`, `session is terminal`) for
+the stringified-resume case. Prefer, where safe, converting `%s` to `%w` at the
+lossy layer so the sentinel survives — but keep the string fallback because the
+resume error may originate from a persisted session error string, not an error
+value.
+
+## Task waves
+- **Wave 1 (parallel-safe, disjoint packages):** task-01, task-02, task-03,
+  task-04. Each touches a different package with no shared schema, migration,
+  generated contract, lockfile, or package config.
+
+Each task keeps `parallelism: sequential`. Waves are a review aid only.
+
+## Tasks
+- `task-01-session-prompt-log-level.md` — `internal/agent/runtime/lifecycle`
+- `task-02-orchestrator-launch-log-level.md` — `internal/orchestrator`
+- `task-03-goplugin-shutdown-logger.md` — `internal/plugins/runtime`
+- `task-04-warn-site-review.md` — `internal/agent/hostutility` (+ documented no-ops)
+
+## Global validation
+From `apps/backend`:
+```bash
+make -C apps/backend test
+make -C apps/backend lint
+golangci-lint run ./... --new-from-rev="<base-sha>" --timeout=5m
+```

--- a/docs/plans/shutdown-log-noise/task-01-session-prompt-log-level.md
+++ b/docs/plans/shutdown-log-noise/task-01-session-prompt-log-level.md
@@ -1,0 +1,58 @@
+---
+id: "01-session-prompt-log-level"
+title: "Downgrade benign prompt-completion log noise on shutdown"
+status: pending
+wave: 1
+depends_on: []
+plan: "plan.md"
+spec: "../../specs/shutdown-log-noise/spec.md"
+parallelism: sequential
+---
+
+# Task 01: Session prompt log level
+
+## Context
+
+`internal/agent/runtime/lifecycle/session.go` logs two prompt sites at ERROR
+with a stack trace:
+
+- `dispatchInitialPrompt` "initial prompt failed" (~L835), fired from a
+  detached goroutine during `InitializeAndPrompt`.
+- `waitForPromptDone` "prompt completed with error" (~L919).
+
+During graceful shutdown the agent subprocess is SIGTERM'd, so these fail with
+an ACP transport death (`peer disconnected before response`, JSON-RPC `-32603`)
+or `context.Canceled`. Both are benign teardown races.
+
+The helper `isTransportDeadErr(err error) bool` (~L1598) already matches
+"peer disconnected", "connection closed", "notification queue overflow",
+`context.Canceled`, and `context.DeadlineExceeded`. `isCancelReleaseError(msg)`
+(~L976) matches the cancel sentinels. `sm.stopCh` is available on the
+`SessionManager`.
+
+## Acceptance
+
+- When the prompt error is a transport death / cancel-release sentinel, or
+  `sm.stopCh` is already closed, both sites log at WARN with **no** stack trace
+  (no `zap.Error` that emits a trace; log the error string only).
+- A genuine agent-reported error that is not a transport death, on an active
+  session (stopCh open), still logs at ERROR with its stack trace.
+- No change to control flow, returned errors, signals, or state transitions.
+
+## Verification
+
+`cd apps/backend && go test ./internal/agent/runtime/lifecycle/...`
+
+Add a focused regression test asserting WARN vs ERROR classification for a
+transport-death error versus a plain agent error. Reuse the existing
+`isTransportDeadErr` table-test pattern in `session_test.go`.
+
+## Files Likely Touched
+
+- `apps/backend/internal/agent/runtime/lifecycle/session.go`
+- `apps/backend/internal/agent/runtime/lifecycle/session_test.go`
+
+## Output Contract
+
+Report the classification predicate used, the two sites changed, tests added
+and run, and residual risks; mark this task done in this file and `plan.md`.

--- a/docs/plans/shutdown-log-noise/task-02-orchestrator-launch-log-level.md
+++ b/docs/plans/shutdown-log-noise/task-02-orchestrator-launch-log-level.md
@@ -1,0 +1,60 @@
+---
+id: "02-orchestrator-launch-log-level"
+title: "Downgrade benign session-launch log noise on shutdown"
+status: done
+wave: 1
+depends_on: []
+plan: "plan.md"
+spec: "../../specs/shutdown-log-noise/spec.md"
+parallelism: sequential
+---
+
+# Task 02: Orchestrator launch log level
+
+## Context
+
+`internal/orchestrator/handlers/handlers.go` `wsLaunchSession` (~L91) logs
+"failed to launch session" at ERROR unconditionally. During shutdown two
+benign failures reach this site:
+
+- `intent=resume`: the underlying `context.Canceled` sentinel is **destroyed**
+  at `task_operations.go:2229` (`fmt.Errorf("session failed: %s", errMsg)` uses
+  `%s`, not `%w`), so the error surfaces as a string containing
+  `context canceled`.
+- `intent=restore_workspace`: `manager_launch.go:1397` wraps
+  `lifecycle.ErrSessionTerminal` with `%w`, so `errors.Is` matches.
+
+## Acceptance
+
+- `wsLaunchSession` logs WARN (no stack trace) when the launch failed for a
+  benign teardown reason. The classifier MUST handle both:
+  - `errors.Is(err, lifecycle.ErrSessionTerminal)` and
+    `errors.Is(err, context.Canceled)` (wrapped-sentinel cases), AND
+  - a bounded string fallback for `context canceled` (the stringified-resume
+    case where the sentinel is lost).
+- Where safe, convert the lossy `%s` at `task_operations.go:2229` to `%w` so the
+  sentinel survives, but keep the string fallback because the resume error may
+  originate from a persisted session error string rather than an error value.
+- A launch failure for a non-teardown reason (unknown task, validation) still
+  logs at ERROR.
+- The WS response returned to the caller is unchanged.
+
+## Verification
+
+`cd apps/backend && go test ./internal/orchestrator/...`
+
+Add a focused regression test asserting WARN vs ERROR classification for a
+`context.Canceled`-string resume error, a wrapped `ErrSessionTerminal` error,
+and a plain non-teardown error.
+
+## Files Likely Touched
+
+- `apps/backend/internal/orchestrator/handlers/handlers.go`
+- `apps/backend/internal/orchestrator/handlers/handlers_test.go`
+- `apps/backend/internal/orchestrator/task_operations.go` (optional `%s`->`%w`)
+
+## Output Contract
+
+Report the classifier predicate, whether the `%s`->`%w` change was made and
+why, tests added and run, and residual risks; mark this task done in this file
+and `plan.md`.

--- a/docs/plans/shutdown-log-noise/task-03-goplugin-shutdown-logger.md
+++ b/docs/plans/shutdown-log-noise/task-03-goplugin-shutdown-logger.md
@@ -1,0 +1,58 @@
+---
+id: "03-goplugin-shutdown-logger"
+title: "Silence go-plugin ERROR on deliberate shutdown kill"
+status: done
+wave: 1
+depends_on: []
+plan: "plan.md"
+spec: "../../specs/shutdown-log-noise/spec.md"
+parallelism: sequential
+---
+
+# Task 03: go-plugin shutdown logger
+
+## Context
+
+`internal/plugins/runtime/manager.go` constructs the Hashicorp go-plugin client
+via `hcplugin.NewClient` (~L394) with **no** `Logger` field. go-plugin then
+uses its own default hclog logger, which prints the subprocess exit at ERROR:
+
+```
+[ERROR] plugin: plugin process exited: ... error="signal: terminated"
+```
+
+This fires when `client.Kill()` runs during the manager's shutdown/`StopAll`
+path. The kill is deliberate, so the ERROR is misleading.
+
+`internal/plugins/runtime/process.go` (~L232) separately logs "plugin process
+exited unexpectedly" at WARN with a `plugin_id` field.
+
+## Acceptance
+
+- Supply an `hclog.Logger` to `hcplugin.NewClient` routed through Kandev's
+  logger (adapter), OR silence the go-plugin logger for the deliberate kill,
+  so an expected `signal: terminated` / `signal: killed` on shutdown is NOT
+  emitted at ERROR.
+- An unexpected plugin crash while the manager is NOT shutting down still
+  surfaces (the existing WARN in `process.go` remains, and go-plugin output for
+  genuine crashes is not fully muted).
+- No change to plugin lifecycle, restart policy, or manager control flow.
+
+## Verification
+
+`cd apps/backend && go test ./internal/plugins/...`
+
+Add a focused regression test asserting that a shutdown-initiated kill does not
+produce an ERROR-level log line, while an unexpected exit still logs.
+
+## Files Likely Touched
+
+- `apps/backend/internal/plugins/runtime/manager.go`
+- `apps/backend/internal/plugins/runtime/process.go`
+- corresponding `_test.go`
+
+## Output Contract
+
+Report the logger-injection approach (adapter vs null-on-kill), how shutdown is
+detected, tests added and run, and residual risks; mark this task done in this
+file and `plan.md`.

--- a/docs/plans/shutdown-log-noise/task-04-warn-site-review.md
+++ b/docs/plans/shutdown-log-noise/task-04-warn-site-review.md
@@ -1,0 +1,58 @@
+---
+id: "04-warn-site-review"
+title: "Review shutdown WARN sites; downgrade host-utility 404"
+status: done
+wave: 1
+depends_on: []
+plan: "plan.md"
+spec: "../../specs/shutdown-log-noise/spec.md"
+parallelism: sequential
+---
+
+# Task 04: WARN-site review
+
+## Context
+
+The user asked to review all shutdown noise, including WARN lines. This task
+covers the one actionable WARN downgrade and records the deliberate no-ops so
+reviewers do not re-litigate them.
+
+Actionable:
+
+- `internal/agent/hostutility/manager.go:244` "failed to delete host utility
+  instance" (WARN). During teardown the control client returns
+  `instance not found (status 404)` because the instance is already gone. This
+  is benign and idempotent.
+
+Deliberate no-ops (leave unchanged, documented in the spec):
+
+- `internal/agent/runtime/lifecycle/manager_events.go:544` "agent updates
+  stream disconnected" (WARN, no stack) already correct.
+- `internal/agent/runtime/agentctl/launcher/launcher.go:465` relays agentctl
+  child **stderr** at WARN by design for visibility; the
+  `connection closed component=acp-conn` line is the child's own output.
+
+## Acceptance
+
+- The host-utility delete logs at DEBUG only when the error is a not-found /
+  404 (instance already gone); every other delete failure stays WARN.
+- The two no-op sites are unchanged.
+- No change to cleanup control flow (delete remains best-effort/idempotent).
+
+## Verification
+
+`cd apps/backend && go test ./internal/agent/hostutility/...`
+
+Add a focused regression test asserting DEBUG for a 404/not-found error and
+WARN for any other error.
+
+## Files Likely Touched
+
+- `apps/backend/internal/agent/hostutility/manager.go`
+- `apps/backend/internal/agent/hostutility/manager_test.go`
+
+## Output Contract
+
+Report the not-found predicate used (sentinel vs string match), tests added and
+run, and confirm the no-op sites were reviewed; mark this task done in this file
+and `plan.md`.

--- a/docs/specs/port-collision-safety/spec.md
+++ b/docs/specs/port-collision-safety/spec.md
@@ -1,7 +1,7 @@
 ---
 status: building
 created: 2026-08-07
-updated: 2026-08-09
+updated: 2026-08-11
 ---
 
 # Port collision and backend ownership safety
@@ -45,6 +45,33 @@ starting their backend child:
   selection remains unchanged.
 - The preflight is a race-reduction measure, not the ownership proof: a port can still be taken
   between the probe and the child bind. Readiness ownership below closes that remaining race.
+
+### Port-availability probe detects wildcard listeners
+
+Wherever a launcher decides whether a port is free, whether it is preflighting an explicit
+backend or web port, or selecting a preferred-then-random automatic port, the probe must treat a
+port as available only when both of these hold:
+
+- Nothing answers a loopback connect on either the IPv4 (127.0.0.1) or the IPv6 (::1) loopback
+  address.
+- A fresh loopback bind on that port succeeds.
+
+The connect probe is required because a running Kandev backend binds the wildcard address
+(0.0.0.0 and [::]), and a specific-address bind check alone reports that port as free. On
+BSD-derived systems including macOS, and because the bind probe itself sets SO_REUSEADDR, a
+loopback bind against an already-active wildcard listener succeeds, so a bind-only check falsely
+reports the busy port as available. Probing both loopback families is required because the
+existing backend may hold only the IPv6 wildcard socket. The bind probe is retained because it
+catches reservations a connect probe misses, such as Windows phantom port reservations and ports
+in TIME_WAIT.
+
+Each connect probe is bounded by a short timeout so a silently dropped SYN, for example under
+WSL2 mirrored networking to an unbound loopback port, cannot hang port selection. A timed-out or
+refused connect means nothing is listening.
+
+This restores the dual connect-and-bind, dual-stack behavior the TypeScript launcher had before
+`make dev` moved to the native Go launcher (PR #2411), where the Go probe was bind-only on the
+IPv4 loopback. The contract is not English error-text matching on socket errors.
 
 ### Backend readiness ownership
 
@@ -113,6 +140,19 @@ not part of this contract.
    includes the port and source.
 3. Given no explicit backend port and the preferred port is occupied, when the launcher starts,
    then it chooses an available fallback as it does today.
+
+### Wildcard-listener port availability
+
+1. Given a running backend holds the preferred port through a wildcard bind (0.0.0.0 and [::]),
+   when the launcher selects an automatic port with no explicit port configured, then the
+   availability probe reports the preferred port as busy and the launcher falls back to a free
+   random port instead of choosing the occupied preferred port.
+2. Given a wildcard listener holds an explicitly requested backend or web port, when the launcher
+   preflights that port, then it reports the port as busy and exits with the existing hard error
+   naming the port and its source.
+3. Given nothing is listening on a candidate port but a loopback connect to an unbound port is
+   silently dropped, when the availability probe runs, then the bounded connect timeout elapses,
+   the fresh bind succeeds, and the port is reported available.
 
 ### Issue #2372: readiness from the wrong process
 

--- a/docs/specs/shutdown-log-noise/spec.md
+++ b/docs/specs/shutdown-log-noise/spec.md
@@ -1,0 +1,98 @@
+---
+status: draft
+created: 2026-08-11
+owner: cfl12
+---
+
+# Quiet benign teardown log noise on shutdown
+
+## Why
+Pressing Ctrl+C on the Kandev backend emits ERROR-level log lines with stack
+traces (and a go-plugin library ERROR) even though every one of them is a
+benign teardown race: an in-flight prompt or WS launch request losing its
+context or subprocess peer while the process is deliberately shutting down.
+Operators reading the logs cannot tell a real fault from expected shutdown, and
+the stack traces suggest a crash where none occurred.
+
+## What
+- The backend SHALL log a benign teardown race at WARN (no stack trace), not
+  ERROR, when it is caused by root-context cancellation or subprocess
+  termination during graceful shutdown.
+- A genuine fault on a still-active session (for example a real startup
+  deadline, an agent-reported error unrelated to disconnect) SHALL keep logging
+  at ERROR with its stack trace. Severity classification must not swallow real
+  failures.
+- The go-plugin subprocess exiting because Kandev killed it during shutdown
+  SHALL NOT surface as a library ERROR (`plugin process exited ... signal:
+  terminated`).
+- No change to control flow, task/session state transitions, returned errors,
+  or WS responses. This is a logging-severity change only.
+
+## Affected log sites and target behavior
+Classification reuses existing helpers/sentinels wherever possible.
+
+1. `internal/agent/runtime/lifecycle/session.go` "prompt completed with error"
+   (~L919) and "initial prompt failed" (~L835), currently ERROR. During
+   shutdown the error is the ACP transport JSON `-32603 ... peer disconnected
+   before response`. Log WARN when `isTransportDeadErr(err)` /
+   `isCancelReleaseError` matches or `sm.stopCh` is already closed; otherwise
+   keep ERROR.
+2. `internal/orchestrator/handlers/handlers.go` "failed to launch session"
+   (~L91), currently ERROR. Log WARN when the launch failed for a benign
+   teardown reason: `intent=resume` yields a stringified
+   `... session failed: ... context canceled` (the sentinel is lost at
+   `task_operations.go:2229` `%s`), and `intent=restore_workspace` yields an
+   error that wraps `lifecycle.ErrSessionTerminal` (`manager_launch.go:1397`
+   `%w`). The classifier must handle BOTH the wrapped-sentinel case
+   (`errors.Is`) and the stringified-cancel case.
+3. `internal/plugins/runtime/manager.go` (`hcplugin.NewClient`, L394). go-plugin
+   is constructed with no `Logger`, so its default hclog logger prints the
+   process exit at ERROR when `client.Kill()` runs during `StopAll`. Supply an
+   hclog logger routed through Kandev's logger and silence it for the
+   deliberate kill so an expected `signal: terminated` is not an ERROR.
+
+## Log sites reviewed and deliberately left unchanged
+- `internal/agent/runtime/lifecycle/manager_events.go:544` "agent updates
+  stream disconnected" (WARN, no stack) already correct.
+- `internal/agent/runtime/agentctl/launcher/launcher.go:465` relays agentctl
+  child **stderr** at WARN by design ("logged at WARN for visibility"); the
+  `connection closed component=acp-conn` line is the child's own INFO output.
+  Left as-is to preserve visibility.
+- `internal/agent/hostutility/manager.go:244` "failed to delete host utility
+  instance" (WARN). A `404 not found` during teardown means the instance is
+  already gone; optionally downgrade only the not-found case to DEBUG. Non-404
+  failures stay WARN.
+
+## Failure modes
+- Classification is conservative: if an error is not recognized as a teardown
+  race it stays ERROR. A false negative (real error logged as WARN) must be
+  impossible for the deadline/real-fault cases, which is why `context.Canceled`
+  is treated as benign but `context.DeadlineExceeded` on an active session is
+  not (matching the existing `handleAgentProcessStartFailure` convention).
+
+## Scenarios
+- **GIVEN** an initial prompt in flight and the agent subprocess is terminated
+  during shutdown, **WHEN** `waitForPromptDone`/`dispatchInitialPrompt` observe
+  `peer disconnected before response`, **THEN** the backend logs WARN (no stack
+  trace) and does not log ERROR.
+- **GIVEN** a real agent-reported error that is not a transport death on an
+  active session, **WHEN** the prompt completes with that error, **THEN** the
+  backend still logs ERROR with a stack trace.
+- **GIVEN** a `session.launch` with `intent=resume` whose MCP resolve failed
+  with `context canceled` during shutdown, **WHEN** `wsLaunchSession` returns
+  the error, **THEN** it is logged WARN, not ERROR.
+- **GIVEN** a `session.launch` with `intent=restore_workspace` on a session that
+  is FAILED/terminal, **WHEN** `wsLaunchSession` returns an error wrapping
+  `ErrSessionTerminal`, **THEN** it is logged WARN, not ERROR.
+- **GIVEN** a `session.launch` that fails for a non-teardown reason (e.g. unknown
+  task, validation), **WHEN** `wsLaunchSession` returns the error, **THEN** it
+  is still logged ERROR.
+- **GIVEN** the plugin manager `StopAll` kills a running plugin during shutdown,
+  **WHEN** the subprocess exits with `signal: terminated`, **THEN** no ERROR log
+  line for that expected exit is emitted.
+
+## Out of scope
+- Changing shutdown ordering, timeouts, or which subprocesses are killed.
+- Changing WS responses or task/session state on launch failure.
+- Suppressing agentctl child stderr relay during shutdown.
+- Any non-shutdown logging severity review.


### PR DESCRIPTION
## Problem

`make dev` failed to bind the default backend port `38429` and did **not** fall back to a
random port, even though the launcher is supposed to. It happened whenever another Kandev
instance (e.g. `make start-debug`) was already running.

The launcher's port-availability check, `canBind` in
`apps/backend/internal/launcher/ports.go`, only bind-probed `127.0.0.1`:

```go
func canBind(port int) bool {
	ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
	...
}
```

A running backend binds the **wildcard** address (`0.0.0.0` and `[::]`). On macOS/BSD a
bind to the specific `127.0.0.1` address succeeds even while a wildcard listener already
holds the port, and Go's `net.Listen` sets `SO_REUSEADDR`, which reinforces the false
success. So `canBind(38429)` returned `true` against the live backend,
`pickAvailablePortExcept` kept the occupied preferred port, and the child backend then
died on the real wildcard bind.

## Root cause

Regression from PR #2411, which moved `make dev` to the native Go launcher. The previous
TypeScript launcher (`apps/cli/src/ports.ts`) ran a **connect** probe on both `127.0.0.1`
and `::1` in addition to the bind probe, and only reported a port free when nothing
answered the connect *and* the bind succeeded. Its own comment called out this exact trap:
"detects ports where a listener is bound with `SO_REUSEADDR` (Node's default on macOS,
bind-only check would falsely succeed)." The Go rewrite dropped the connect probe.

## Fix

Restore the dual connect-and-bind, dual-stack probe in `canBind`:

- Connect-check `127.0.0.1` and `::1` with a bounded 500ms timeout. If either answers,
  the port is busy.
- Otherwise attempt the loopback bind. Success means the port is free.

The bind probe is kept because it catches reservations a connect misses (Windows phantom
reservations, TIME_WAIT). The bounded timeout keeps a silently dropped SYN (WSL2 mirrored
networking to an unbound loopback port) from hanging port selection. The exported
signature is unchanged, so all callers (explicit backend/web preflight and automatic
preferred-then-random selection) are fixed by the single change.

## Testing

- Added `TestCanBindDetectsWildcardListener` (stands up a wildcard listener, asserts
  `canBind` returns `false` and `pickAvailablePortExcept` does not return the occupied
  port) and `TestCanBindAcceptsFreePort`. The wildcard test fails before the change and
  passes after.
- `go test ./internal/launcher/ -race -count=1` passes.
- `gofmt` clean; `golangci-lint run ./internal/launcher/... --new-from-rev=origin/main`
  reports 0 issues.

## Spec / plan

- Spec: `docs/specs/port-collision-safety/spec.md` (amended: added the
  "Port-availability probe detects wildcard listeners" behavior and a
  "Wildcard-listener port availability" scenario group).
- Plan: `docs/plans/launcher-port-wildcard-detection/`.

---
Co-authored by Augment Code


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2536?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->