### PR TITLE
fix(web): scope workspace integration settings links consistently

### DIFF
--- a/apps/web/app/azure-devops/azure-devops-page-client.test.tsx
+++ b/apps/web/app/azure-devops/azure-devops-page-client.test.tsx
@@ -1,0 +1,23 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { NotConfigured } from "./azure-devops-page-client";
+
+describe("Azure DevOps NotConfigured", () => {
+  afterEach(() => cleanup());
+
+  it("links to the workspace-scoped Azure DevOps settings when a workspace is provided", () => {
+    render(<NotConfigured workspaceId="ws 1/2" />);
+
+    expect(screen.getByRole("link").getAttribute("href")).toBe(
+      "/settings/workspaces/ws%201%2F2/integrations",
+    );
+  });
+
+  it("links to the global Azure DevOps settings without a workspace", () => {
+    render(<NotConfigured />);
+
+    expect(screen.getByRole("link").getAttribute("href")).toBe(
+      "/settings/integrations/azure-devops",
+    );
+  });
+});

--- a/apps/web/app/azure-devops/azure-devops-page-client.tsx
+++ b/apps/web/app/azure-devops/azure-devops-page-client.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable max-lines -- Azure DevOps page composition keeps the browse, board, and task-launch flows together. */
 
 "use client";
+import { workspaceSettingsHref } from "@/lib/settings/workspace-settings-tabs";
 
 import Link from "@/components/routing/app-link";
 import { useCallback, useEffect, useMemo, useRef, useState, type ComponentProps } from "react";
@@ -82,9 +83,9 @@ type PageProps = {
   repositories: Repository[];
 };
 
-function NotConfigured({ workspaceId }: { workspaceId?: string }) {
+export function NotConfigured({ workspaceId }: { workspaceId?: string }) {
   const href = workspaceId
-    ? `/settings/workspaces/${encodeURIComponent(workspaceId)}/integrations/azure-devops`
+    ? workspaceSettingsHref(workspaceId, "integrations")
     : "/settings/integrations/azure-devops";
   return (
     <div className="max-w-2xl p-6">

--- a/apps/web/app/github/github-page-client.test.tsx
+++ b/apps/web/app/github/github-page-client.test.tsx
@@ -1,0 +1,21 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { NotAuthenticatedNotice } from "./github-page-client";
+
+describe("GitHub NotAuthenticatedNotice", () => {
+  afterEach(() => cleanup());
+
+  it("links to the workspace-scoped GitHub settings when a workspace is provided", () => {
+    render(<NotAuthenticatedNotice workspaceId="ws 1/2" personalRequired={false} />);
+
+    expect(screen.getByRole("link").getAttribute("href")).toBe(
+      "/settings/workspaces/ws%201%2F2/integrations",
+    );
+  });
+
+  it("links to the global GitHub settings without a workspace", () => {
+    render(<NotAuthenticatedNotice personalRequired={false} />);
+
+    expect(screen.getByRole("link").getAttribute("href")).toBe("/settings/integrations/github");
+  });
+});

--- a/apps/web/app/github/github-page-client.tsx
+++ b/apps/web/app/github/github-page-client.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { workspaceSettingsHref } from "@/lib/settings/workspace-settings-tabs";
 
 import Link from "@/components/routing/app-link";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -78,7 +79,7 @@ function MobileFiltersButton({ show, onClick }: { show: boolean; onClick: () => 
   );
 }
 
-function NotAuthenticatedNotice({
+export function NotAuthenticatedNotice({
   workspaceId,
   personalRequired,
 }: {
@@ -87,7 +88,7 @@ function NotAuthenticatedNotice({
 }) {
   const { t } = useTranslation();
   const settingsHref = workspaceId
-    ? `/settings/workspaces/${workspaceId}/integrations/github`
+    ? workspaceSettingsHref(workspaceId, "integrations")
     : "/settings/integrations/github";
   return (
     <Alert>

--- a/apps/web/app/gitlab/gitlab-page-client.test.tsx
+++ b/apps/web/app/gitlab/gitlab-page-client.test.tsx
@@ -1,0 +1,21 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { NotConnectedNotice } from "./gitlab-page-client";
+
+describe("GitLab NotConnectedNotice", () => {
+  afterEach(() => cleanup());
+
+  it("links to the workspace-scoped GitLab settings when a workspace is provided", () => {
+    render(<NotConnectedNotice workspaceId="ws 1/2" />);
+
+    expect(screen.getByRole("link").getAttribute("href")).toBe(
+      "/settings/workspaces/ws%201%2F2/integrations",
+    );
+  });
+
+  it("links to the global GitLab settings without a workspace", () => {
+    render(<NotConnectedNotice />);
+
+    expect(screen.getByRole("link").getAttribute("href")).toBe("/settings/integrations/gitlab");
+  });
+});

--- a/apps/web/app/gitlab/gitlab-page-client.tsx
+++ b/apps/web/app/gitlab/gitlab-page-client.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { workspaceSettingsHref } from "@/lib/settings/workspace-settings-tabs";
 
 import Link from "@/components/routing/app-link";
 import { useCallback, useEffect, useMemo, useState } from "react";
@@ -47,7 +48,13 @@ type GitLabPageClientProps = {
   repositories?: Repository[];
 };
 
-function NotConnectedNotice({ reconnect }: { reconnect?: boolean }) {
+export function NotConnectedNotice({
+  reconnect,
+  workspaceId,
+}: {
+  reconnect?: boolean;
+  workspaceId?: string;
+}) {
   const { t } = useTranslation();
   return (
     <Alert>
@@ -57,7 +64,11 @@ function NotConnectedNotice({ reconnect }: { reconnect?: boolean }) {
           : t("gitlab:gitlabIsNotConnectedConfigureGitlab")}
         <Trans i18nKey="gitlab:openSettingsToSeeMrsAndIssues">
           <Link
-            href="/settings/integrations/gitlab"
+            href={
+              workspaceId
+                ? workspaceSettingsHref(workspaceId, "integrations")
+                : "/settings/integrations/gitlab"
+            }
             className="underline font-medium cursor-pointer"
           />
           to see your merge requests and issues.
@@ -396,7 +407,7 @@ function GitLabPageBody({
   if (!connected) {
     return (
       <div className="p-6 max-w-2xl">
-        <NotConnectedNotice reconnect={reconnect} />
+        <NotConnectedNotice reconnect={reconnect} workspaceId={workspaceId} />
       </div>
     );
   }

--- a/apps/web/app/jira/jira-page-client.test.tsx
+++ b/apps/web/app/jira/jira-page-client.test.tsx
@@ -1,0 +1,21 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { NotConfiguredNotice } from "./jira-page-client";
+
+describe("Jira NotConfiguredNotice", () => {
+  afterEach(() => cleanup());
+
+  it("links to the workspace-scoped Jira settings when a workspace is provided", () => {
+    render(<NotConfiguredNotice workspaceId="ws 1/2" />);
+
+    expect(screen.getByRole("link").getAttribute("href")).toBe(
+      "/settings/workspaces/ws%201%2F2/integrations",
+    );
+  });
+
+  it("links to the global Jira settings without a workspace", () => {
+    render(<NotConfiguredNotice />);
+
+    expect(screen.getByRole("link").getAttribute("href")).toBe("/settings/integrations/jira");
+  });
+});

--- a/apps/web/app/jira/jira-page-client.tsx
+++ b/apps/web/app/jira/jira-page-client.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { workspaceSettingsHref } from "@/lib/settings/workspace-settings-tabs";
 
 import Link from "@/components/routing/app-link";
 import { useCallback, useEffect, useMemo, useState } from "react";
@@ -40,7 +41,7 @@ type JiraPageClientProps = {
   steps: WorkflowStep[];
 };
 
-function NotConfiguredNotice() {
+export function NotConfiguredNotice({ workspaceId }: { workspaceId?: string }) {
   return (
     <div className="p-6 max-w-2xl">
       <Alert>
@@ -48,7 +49,11 @@ function NotConfiguredNotice() {
           <Trans i18nKey="jira:notConfiguredNotice">
             Jira is not configured.{" "}
             <Link
-              href="/settings/integrations/jira"
+              href={
+                workspaceId
+                  ? workspaceSettingsHref(workspaceId, "integrations")
+                  : "/settings/integrations/jira"
+              }
               className="underline font-medium cursor-pointer"
             />{" "}
             to see your tickets here.
@@ -130,6 +135,7 @@ function TicketResults({
   presets,
   onStartTask,
   onOpen,
+  workspaceId,
 }: {
   items: JiraTicket[];
   loading: boolean;
@@ -137,12 +143,13 @@ function TicketResults({
   presets: JiraTaskPreset[];
   onStartTask: (ticket: JiraTicket, preset: JiraTaskPreset) => void;
   onOpen: (ticket: JiraTicket) => void;
+  workspaceId?: string;
 }) {
   const { t } = useTranslation();
   if (error) {
     return (
       <div className="flex justify-center py-16">
-        <JiraErrorMessage error={error} />
+        <JiraErrorMessage error={error} workspaceId={workspaceId} />
       </div>
     );
   }
@@ -252,6 +259,7 @@ function AuthenticatedView({
           presets={presets}
           onStartTask={onStartTask}
           onOpen={onOpenTicket}
+          workspaceId={workspaceId}
         />
       </div>
       <ResultsPagination
@@ -349,7 +357,7 @@ export function JiraPageClient({ workspaceId, workflows, steps }: JiraPageClient
         {!loaded && (
           <div className="p-6 text-sm text-muted-foreground">{t("jira:checkingJiraStatus")}</div>
         )}
-        {loaded && !configured && <NotConfiguredNotice />}
+        {loaded && !configured && <NotConfiguredNotice workspaceId={workspaceId} />}
         {loaded && configured && (
           <AuthenticatedView
             workspaceId={workspaceId}

--- a/apps/web/app/linear/linear-page-client.test.tsx
+++ b/apps/web/app/linear/linear-page-client.test.tsx
@@ -1,0 +1,39 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { DisabledNotice, NotConfiguredNotice } from "./linear-page-client";
+
+describe("Linear NotConfiguredNotice", () => {
+  afterEach(() => cleanup());
+
+  it("links to the workspace-scoped Linear settings when a workspace is provided", () => {
+    render(<NotConfiguredNotice workspaceId="ws 1/2" />);
+
+    expect(screen.getByRole("link").getAttribute("href")).toBe(
+      "/settings/workspaces/ws%201%2F2/integrations",
+    );
+  });
+
+  it("links to the global Linear settings without a workspace", () => {
+    render(<NotConfiguredNotice />);
+
+    expect(screen.getByRole("link").getAttribute("href")).toBe("/settings/integrations/linear");
+  });
+});
+
+describe("Linear DisabledNotice", () => {
+  afterEach(() => cleanup());
+
+  it("links to the workspace-scoped Linear settings when a workspace is provided", () => {
+    render(<DisabledNotice workspaceId="ws 1/2" />);
+
+    expect(screen.getByRole("link").getAttribute("href")).toBe(
+      "/settings/workspaces/ws%201%2F2/integrations",
+    );
+  });
+
+  it("links to the global Linear settings without a workspace", () => {
+    render(<DisabledNotice />);
+
+    expect(screen.getByRole("link").getAttribute("href")).toBe("/settings/integrations/linear");
+  });
+});

--- a/apps/web/app/linear/linear-page-client.tsx
+++ b/apps/web/app/linear/linear-page-client.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { workspaceSettingsHref } from "@/lib/settings/workspace-settings-tabs";
 
 import Link from "@/components/routing/app-link";
 import { useEffect, useMemo, useState } from "react";
@@ -41,7 +42,7 @@ type LinearPageClientProps = {
   steps: WorkflowStep[];
 };
 
-function NotConfiguredNotice() {
+export function NotConfiguredNotice({ workspaceId }: { workspaceId?: string }) {
   return (
     <div className="p-6 max-w-2xl">
       <Alert>
@@ -49,7 +50,11 @@ function NotConfiguredNotice() {
           <Trans i18nKey="linear:notConfiguredNotice">
             Linear is not configured.{" "}
             <Link
-              href="/settings/integrations/linear"
+              href={
+                workspaceId
+                  ? workspaceSettingsHref(workspaceId, "integrations")
+                  : "/settings/integrations/linear"
+              }
               className="underline font-medium cursor-pointer"
             />{" "}
             to see your issues here.
@@ -305,7 +310,7 @@ function LinearFrame({ children }: { children: React.ReactNode }) {
   );
 }
 
-function DisabledNotice() {
+export function DisabledNotice({ workspaceId }: { workspaceId?: string }) {
   const { t } = useTranslation();
   return (
     <div className="p-6 max-w-2xl">
@@ -313,7 +318,11 @@ function DisabledNotice() {
         <AlertDescription>
           {t("linear:integrationDisabled")}{" "}
           <Link
-            href="/settings/integrations/linear"
+            href={
+              workspaceId
+                ? workspaceSettingsHref(workspaceId, "integrations")
+                : "/settings/integrations/linear"
+            }
             className="underline font-medium cursor-pointer"
           >
             {t("linear:reEnableItInSettings")}
@@ -330,18 +339,20 @@ function ResultsArea({
   empty,
   onOpen,
   onStartTask,
+  workspaceId,
 }: {
   search: LinearSearchState;
   empty: boolean;
   onOpen: (issue: LinearIssue) => void;
   onStartTask: (issue: LinearIssue) => void;
+  workspaceId?: string;
 }) {
   const { t } = useTranslation();
   return (
     <div className="flex-1 overflow-y-auto px-6 py-3">
       {search.error && !search.loading && (
         <div className="py-8 flex justify-center">
-          <LinearErrorMessage error={search.error} />
+          <LinearErrorMessage error={search.error} workspaceId={workspaceId} />
         </div>
       )}
       {!search.error && empty && (
@@ -419,6 +430,7 @@ export function LinearPageClient({ workspaceId, workflows, steps }: LinearPageCl
         empty={empty}
         onOpen={setOpenIssue}
         onStartTask={setLaunchIssue}
+        workspaceId={workspaceId}
       />
       <PaginationBar
         page={search.page}

--- a/apps/web/components/automations/automation-editor.tsx
+++ b/apps/web/components/automations/automation-editor.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback, useMemo } from "react";
+import { workspaceSettingsHref } from "@/lib/settings/workspace-settings-tabs";
 import { useTranslation } from "react-i18next";
 import { t } from "@/lib/i18n";
 import { useRouter } from "@/lib/routing/client-router";
@@ -175,7 +176,7 @@ function useSaveHandler(opts: SaveHandlerOpts): () => Promise<void> {
         } else {
           toast.success(t("automations:automationCreated"));
           runWithNavigationBlockerBypassed(() =>
-            router.push(`/settings/workspaces/${workspaceId}/automations`),
+            router.push(workspaceSettingsHref(workspaceId, "automations")),
           );
         }
       } else if (currentId) {
@@ -219,7 +220,7 @@ function useLoadAutomation(opts: LoadAutomationOpts) {
         onLoaded(loadedForm, loadedTriggers);
       })
       .catch(() => {
-        router.push(`/settings/workspaces/${workspaceId}/automations`);
+        router.push(workspaceSettingsHref(workspaceId, "automations"));
       });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [automationId]);
@@ -306,7 +307,7 @@ function useRemoveAutomation(
     try {
       await remove(currentId);
       runWithNavigationBlockerBypassed(() =>
-        router.push(`/settings/workspaces/${workspaceId}/automations`),
+        router.push(workspaceSettingsHref(workspaceId, "automations")),
       );
     } catch (error) {
       onError(error);
@@ -458,7 +459,7 @@ export function AutomationEditor({ workspaceId, automationId }: AutomationEditor
         details={createdWebhook}
         onClose={() => {
           setCreatedWebhook(null);
-          router.push(`/settings/workspaces/${workspaceId}/automations`);
+          router.push(workspaceSettingsHref(workspaceId, "automations"));
         }}
       />
     </div>

--- a/apps/web/components/automations/automations-list-page.tsx
+++ b/apps/web/components/automations/automations-list-page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useTranslation } from "react-i18next";
+import { workspaceSettingsHref } from "@/lib/settings/workspace-settings-tabs";
 import { useRouter } from "@/lib/routing/client-router";
 import { Button } from "@kandev/ui/button";
 import { Separator } from "@kandev/ui/separator";
@@ -57,7 +58,7 @@ export function AutomationsListPage({ workspaceId }: AutomationsListPageProps) {
             size="sm"
             data-testid="new-automation-button"
             className="cursor-pointer"
-            onClick={() => router.push(`/settings/workspaces/${workspaceId}/automations/new`)}
+            onClick={() => router.push(`${workspaceSettingsHref(workspaceId, "automations")}/new`)}
           >
             <IconPlus className="h-4 w-4 mr-2" />
             {t("automations:newAutomation")}

--- a/apps/web/components/automations/automations-table.tsx
+++ b/apps/web/components/automations/automations-table.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useTranslation } from "react-i18next";
+import { workspaceSettingsHref } from "@/lib/settings/workspace-settings-tabs";
 import { useRouter } from "@/lib/routing/client-router";
 import { Badge } from "@kandev/ui/badge";
 import { Button } from "@kandev/ui/button";
@@ -150,7 +151,7 @@ export function AutomationsTable({
                 data-settings-dirty-level="container"
                 className="cursor-pointer hover:bg-muted/50"
                 onClick={() =>
-                  router.push(`/settings/workspaces/${workspaceId}/automations/${a.id}`)
+                  router.push(`${workspaceSettingsHref(workspaceId, "automations")}/${a.id}`)
                 }
               >
                 <TableCell className="font-medium">{a.name}</TableCell>

--- a/apps/web/components/jira/jira-ticket-common.test.tsx
+++ b/apps/web/components/jira/jira-ticket-common.test.tsx
@@ -1,0 +1,23 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { JiraErrorMessage } from "./jira-ticket-common";
+
+describe("JiraErrorMessage reconnect link", () => {
+  afterEach(() => cleanup());
+
+  it("links to the workspace-scoped Jira settings when a workspace is provided", () => {
+    render(<JiraErrorMessage error="status 401" workspaceId="ws 1/2" />);
+
+    expect(screen.getByRole("link", { name: /Reconnect/ }).getAttribute("href")).toBe(
+      "/settings/workspaces/ws%201%2F2/integrations",
+    );
+  });
+
+  it("links to the global Jira settings without a workspace", () => {
+    render(<JiraErrorMessage error="status 401" />);
+
+    expect(screen.getByRole("link", { name: /Reconnect/ }).getAttribute("href")).toBe(
+      "/settings/integrations/jira",
+    );
+  });
+});

--- a/apps/web/components/jira/jira-ticket-common.tsx
+++ b/apps/web/components/jira/jira-ticket-common.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { workspaceSettingsHref } from "@/lib/settings/workspace-settings-tabs";
 
 import { useCallback, useEffect, useState } from "react";
 import { formatTimeDistance } from "@/lib/i18n/date-locale";
@@ -158,15 +159,21 @@ type JiraErrorMessageProps = {
   error: string;
   /** Inline variant for cases where a ticket is already rendered above. */
   compact?: boolean;
+  /** When present, the reconnect link targets the workspace's Jira settings. */
+  workspaceId?: string | null;
 };
 
-export function JiraErrorMessage({ error, compact }: JiraErrorMessageProps) {
+export function JiraErrorMessage({ error, compact, workspaceId }: JiraErrorMessageProps) {
   const { t } = useTranslation();
   return (
     <IntegrationAuthErrorMessage
       error={error}
       name="Jira"
-      reconnectHref="/settings/integrations/jira"
+      reconnectHref={
+        workspaceId
+          ? workspaceSettingsHref(workspaceId, "integrations")
+          : "/settings/integrations/jira"
+      }
       isAuthError={isJiraAuthError}
       authErrorBody={t("jira:yourJiraSessionExpiredOrNeeds")}
       compact={compact}

--- a/apps/web/components/jira/jira-ticket-dialog.tsx
+++ b/apps/web/components/jira/jira-ticket-dialog.tsx
@@ -75,7 +75,7 @@ export function JiraTicketDialog({
         <DialogTitle className="sr-only">{dialogTitle(ticket, ticketKey, t)}</DialogTitle>
         {errorOnly ? (
           <div className="flex-1 flex items-center justify-center px-8 py-16">
-            <JiraErrorMessage error={state.error ?? ""} />
+            <JiraErrorMessage error={state.error ?? ""} workspaceId={workspaceId} />
           </div>
         ) : (
           <>
@@ -88,6 +88,7 @@ export function JiraTicketDialog({
               ticket={ticket}
               state={state}
               ticketKey={effectiveTicketKey(ticket, ticketKey)}
+              workspaceId={workspaceId}
             />
             {showFooter && (
               <TicketFooter ticket={ticket} presets={presets} onStartTask={onStartTask} />
@@ -103,17 +104,19 @@ function DialogBody({
   ticket,
   state,
   ticketKey,
+  workspaceId,
 }: {
   ticket: JiraTicket | null;
   state: TicketState;
   ticketKey: string;
+  workspaceId?: string | null;
 }) {
   const { t } = useTranslation();
   return (
     <div className="flex-1 overflow-y-auto">
       {state.error && ticket && (
         <div className="px-8 pt-4">
-          <JiraErrorMessage error={state.error} compact />
+          <JiraErrorMessage error={state.error} compact workspaceId={workspaceId} />
         </div>
       )}
       {!ticket && state.loading && (

--- a/apps/web/components/linear/linear-issue-common.test.tsx
+++ b/apps/web/components/linear/linear-issue-common.test.tsx
@@ -104,3 +104,27 @@ describe("priorityClass", () => {
     expect(priorityClass(undefined)).toContain("muted");
   });
 });
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach } from "vitest";
+import { LinearErrorMessage } from "./linear-issue-common";
+
+describe("LinearErrorMessage reconnect link", () => {
+  afterEach(() => cleanup());
+
+  it("links to the workspace-scoped Linear settings when a workspace is provided", () => {
+    render(<LinearErrorMessage error="status 401" workspaceId="ws 1/2" />);
+
+    expect(screen.getByRole("link", { name: /Reconnect/ }).getAttribute("href")).toBe(
+      "/settings/workspaces/ws%201%2F2/integrations",
+    );
+  });
+
+  it("links to the global Linear settings without a workspace", () => {
+    render(<LinearErrorMessage error="status 401" />);
+
+    expect(screen.getByRole("link", { name: /Reconnect/ }).getAttribute("href")).toBe(
+      "/settings/integrations/linear",
+    );
+  });
+});

--- a/apps/web/components/linear/linear-issue-common.tsx
+++ b/apps/web/components/linear/linear-issue-common.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { workspaceSettingsHref } from "@/lib/settings/workspace-settings-tabs";
 
 import { useCallback, useEffect, useState } from "react";
 import { formatTimeDistance } from "@/lib/i18n/date-locale";
@@ -161,15 +162,21 @@ export { cleanIntegrationErrorMessage as cleanLinearErrorMessage } from "@/compo
 type LinearErrorMessageProps = {
   error: string;
   compact?: boolean;
+  /** When present, the reconnect link targets the workspace's Linear settings. */
+  workspaceId?: string | null;
 };
 
-export function LinearErrorMessage({ error, compact }: LinearErrorMessageProps) {
+export function LinearErrorMessage({ error, compact, workspaceId }: LinearErrorMessageProps) {
   const { t } = useTranslation();
   return (
     <IntegrationAuthErrorMessage
       error={error}
       name="Linear"
-      reconnectHref="/settings/integrations/linear"
+      reconnectHref={
+        workspaceId
+          ? workspaceSettingsHref(workspaceId, "integrations")
+          : "/settings/integrations/linear"
+      }
       isAuthError={isLinearAuthError}
       authErrorBody={t("linear:yourLinearApiKeyIsInvalid")}
       compact={compact}

--- a/apps/web/components/linear/linear-issue-dialog.tsx
+++ b/apps/web/components/linear/linear-issue-dialog.tsx
@@ -74,7 +74,7 @@ export function LinearIssueDialog({
         <DialogTitle className="sr-only">{dialogTitle(issue, identifier, t)}</DialogTitle>
         {errorOnly ? (
           <div className="flex-1 flex items-center justify-center px-8 py-16">
-            <LinearErrorMessage error={state.error ?? ""} />
+            <LinearErrorMessage error={state.error ?? ""} workspaceId={workspaceId} />
           </div>
         ) : (
           <>
@@ -87,6 +87,7 @@ export function LinearIssueDialog({
               issue={issue}
               state={state}
               identifier={effectiveIdentifier(issue, identifier)}
+              workspaceId={workspaceId}
             />
             {showFooter && <IssueFooter onStart={handleStart} />}
           </>
@@ -112,17 +113,19 @@ function DialogBody({
   issue,
   state,
   identifier,
+  workspaceId,
 }: {
   issue: LinearIssue | null;
   state: IssueState;
   identifier: string;
+  workspaceId?: string | null;
 }) {
   const { t } = useTranslation();
   return (
     <div className="flex-1 overflow-y-auto">
       {state.error && issue && (
         <div className="px-8 pt-4">
-          <LinearErrorMessage error={state.error} compact />
+          <LinearErrorMessage error={state.error} compact workspaceId={workspaceId} />
         </div>
       )}
       {!issue && state.loading && (

--- a/apps/web/components/sentry/sentry-issue-common.test.tsx
+++ b/apps/web/components/sentry/sentry-issue-common.test.tsx
@@ -1,0 +1,23 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { SentryErrorMessage } from "./sentry-issue-common";
+
+describe("SentryErrorMessage reconnect link", () => {
+  afterEach(() => cleanup());
+
+  it("links to the workspace-scoped Sentry settings when a workspace is provided", () => {
+    render(<SentryErrorMessage error="status 401" workspaceId="ws 1/2" />);
+
+    expect(screen.getByRole("link", { name: /Reconnect/ }).getAttribute("href")).toBe(
+      "/settings/workspaces/ws%201%2F2/integrations",
+    );
+  });
+
+  it("links to the global Sentry settings without a workspace", () => {
+    render(<SentryErrorMessage error="status 401" />);
+
+    expect(screen.getByRole("link", { name: /Reconnect/ }).getAttribute("href")).toBe(
+      "/settings/integrations/sentry",
+    );
+  });
+});

--- a/apps/web/components/sentry/sentry-issue-common.tsx
+++ b/apps/web/components/sentry/sentry-issue-common.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { workspaceSettingsHref } from "@/lib/settings/workspace-settings-tabs";
 
 import { formatTimeDistance, useDateLocale } from "@/lib/i18n/date-locale";
 import { Badge } from "@kandev/ui/badge";
@@ -115,15 +116,21 @@ export function isSentryAuthError(error: string): boolean {
 type SentryErrorMessageProps = {
   error: string;
   compact?: boolean;
+  /** When present, the reconnect link targets the workspace's Sentry settings. */
+  workspaceId?: string | null;
 };
 
-export function SentryErrorMessage({ error, compact }: SentryErrorMessageProps) {
+export function SentryErrorMessage({ error, compact, workspaceId }: SentryErrorMessageProps) {
   const { t } = useTranslation();
   return (
     <IntegrationAuthErrorMessage
       error={error}
       name="Sentry"
-      reconnectHref="/settings/integrations/sentry"
+      reconnectHref={
+        workspaceId
+          ? workspaceSettingsHref(workspaceId, "integrations")
+          : "/settings/integrations/sentry"
+      }
       isAuthError={isSentryAuthError}
       authErrorBody={t("sentry:yourSentryAuthTokenIsInvalid")}
       compact={compact}

--- a/apps/web/components/sentry/sentry-issue-dialog.tsx
+++ b/apps/web/components/sentry/sentry-issue-dialog.tsx
@@ -73,7 +73,7 @@ export function SentryIssueDialog({ open, onOpenChange, workspaceId }: SentryIss
       <DialogContent className="!max-w-[min(1080px,95vw)] w-[95vw] max-h-[90vh] overflow-hidden flex flex-col gap-0 p-0 sm:rounded-lg">
         <DialogTitle className="sr-only">{t("sentry:browseSentryIssues")}</DialogTitle>
         <FiltersBar state={dialog} />
-        <ResultsBody state={dialog} />
+        <ResultsBody state={dialog} workspaceId={workspaceId} />
       </DialogContent>
     </Dialog>
   );
@@ -546,14 +546,14 @@ function SearchActionRow({ state }: { state: DialogState }) {
   );
 }
 
-function ResultsBody({ state }: { state: DialogState }) {
+function ResultsBody({ state, workspaceId }: { state: DialogState; workspaceId?: string }) {
   const { t } = useTranslation();
   const { issues, loading, error, isLast, nextCursor, search, instanceId } = state;
   const empty = useMemo(() => !loading && !error && issues.length === 0, [loading, error, issues]);
 
   return (
     <div className="flex-1 overflow-y-auto px-5 py-4 space-y-2">
-      {error && <SentryErrorMessage error={error} compact />}
+      {error && <SentryErrorMessage error={error} compact workspaceId={workspaceId} />}
       {empty && (
         <div className="text-sm text-muted-foreground py-12 text-center">
           {instanceId

--- a/apps/web/components/task/ensure-session-error.tsx
+++ b/apps/web/components/task/ensure-session-error.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "@/components/routing/app-link";
+import { workspaceSettingsHref } from "@/lib/settings/workspace-settings-tabs";
 import { IconAlertTriangle, IconRefresh } from "@tabler/icons-react";
 import { Alert, AlertDescription, AlertTitle } from "@kandev/ui/alert";
 import { Button } from "@kandev/ui/button";
@@ -33,7 +34,7 @@ export function describeEnsureError(
       action: workspaceId
         ? {
             label: t("task:openWorkspaceSettings"),
-            href: `/settings/workspaces/${workspaceId}`,
+            href: workspaceSettingsHref(workspaceId, "overview"),
           }
         : null,
     };

--- a/apps/web/e2e/pages/automations-page.ts
+++ b/apps/web/e2e/pages/automations-page.ts
@@ -1,4 +1,5 @@
 import { type Locator, type Page } from "@playwright/test";
+import { workspaceSettingsHref } from "@/lib/settings/workspace-settings-tabs";
 
 export class AutomationsPage {
   readonly listPage: Locator;
@@ -43,12 +44,12 @@ export class AutomationsPage {
   }
 
   async goto() {
-    await this.page.goto(`/settings/workspaces/${this.workspaceId}/automations`);
+    await this.page.goto(workspaceSettingsHref(this.workspaceId, "automations"));
     await this.listPage.waitFor({ state: "visible", timeout: 15_000 });
   }
 
   async gotoNew() {
-    await this.page.goto(`/settings/workspaces/${this.workspaceId}/automations/new`);
+    await this.page.goto(`${workspaceSettingsHref(this.workspaceId, "automations")}/new`);
     await this.editor.waitFor({ state: "visible", timeout: 15_000 });
   }
 

--- a/apps/web/e2e/pages/github-auth-settings-page.ts
+++ b/apps/web/e2e/pages/github-auth-settings-page.ts
@@ -1,12 +1,11 @@
 import type { Locator, Page } from "@playwright/test";
+import { workspaceSettingsHref } from "@/lib/settings/workspace-settings-tabs";
 
 export class GitHubAuthSettingsPage {
   constructor(private readonly page: Page) {}
 
   async goto(workspaceId: string, query = "") {
-    await this.page.goto(
-      `/settings/workspaces/${encodeURIComponent(workspaceId)}/integrations/github${query}`,
-    );
+    await this.page.goto(`${workspaceSettingsHref(workspaceId, "integrations")}/github${query}`);
   }
 
   automation() {

--- a/apps/web/e2e/pages/gitlab-settings-page.ts
+++ b/apps/web/e2e/pages/gitlab-settings-page.ts
@@ -1,4 +1,5 @@
 import { type Locator, type Page } from "@playwright/test";
+import { workspaceSettingsHref } from "@/lib/settings/workspace-settings-tabs";
 
 export class GitLabSettingsPage {
   readonly hostInput: Locator;
@@ -15,7 +16,7 @@ export class GitLabSettingsPage {
 
   async goto(workspaceId?: string) {
     const path = workspaceId
-      ? `/settings/workspaces/${workspaceId}/integrations/gitlab`
+      ? workspaceSettingsHref(workspaceId, "integrations")
       : "/settings/integrations/gitlab";
     await this.page.goto(path);
     await this.hostInput.waitFor();

--- a/apps/web/e2e/pages/gitlab-settings-page.ts
+++ b/apps/web/e2e/pages/gitlab-settings-page.ts
@@ -16,7 +16,7 @@ export class GitLabSettingsPage {
 
   async goto(workspaceId?: string) {
     const path = workspaceId
-      ? workspaceSettingsHref(workspaceId, "integrations")
+      ? `${workspaceSettingsHref(workspaceId, "integrations")}/gitlab`
       : "/settings/integrations/gitlab";
     await this.page.goto(path);
     await this.hostInput.waitFor();

--- a/apps/web/e2e/pages/linear-settings-page.ts
+++ b/apps/web/e2e/pages/linear-settings-page.ts
@@ -1,4 +1,5 @@
 import { type Locator, type Page } from "@playwright/test";
+import { workspaceSettingsHref } from "@/lib/settings/workspace-settings-tabs";
 
 export class LinearSettingsPage {
   readonly secretInput: Locator;
@@ -29,7 +30,7 @@ export class LinearSettingsPage {
   }
 
   async gotoWorkspace(workspaceId: string) {
-    await this.page.goto(`/settings/workspaces/${workspaceId}/integrations/linear`);
+    await this.page.goto(workspaceSettingsHref(workspaceId, "integrations"));
     await this.secretInput.waitFor({ state: "visible" });
   }
 }

--- a/apps/web/e2e/pages/linear-settings-page.ts
+++ b/apps/web/e2e/pages/linear-settings-page.ts
@@ -30,7 +30,7 @@ export class LinearSettingsPage {
   }
 
   async gotoWorkspace(workspaceId: string) {
-    await this.page.goto(workspaceSettingsHref(workspaceId, "integrations"));
+    await this.page.goto(`${workspaceSettingsHref(workspaceId, "integrations")}/linear`);
     await this.secretInput.waitFor({ state: "visible" });
   }
 }

--- a/apps/web/e2e/pages/workflow-settings-page.ts
+++ b/apps/web/e2e/pages/workflow-settings-page.ts
@@ -1,4 +1,5 @@
 import { type Locator, type Page, expect } from "@playwright/test";
+import { workspaceSettingsHref } from "../../lib/settings/workspace-settings-tabs";
 
 export class WorkflowSettingsPage {
   readonly page: Page;
@@ -20,7 +21,7 @@ export class WorkflowSettingsPage {
   }
 
   async goto(workspaceId: string) {
-    await this.page.goto(`/settings/workspaces/${workspaceId}/workflows`);
+    await this.page.goto(workspaceSettingsHref(workspaceId, "workflows"));
     // Wait for a client-rendered element to confirm hydration is complete
     // (networkidle is unreliable with persistent WebSocket connections)
     await expect(this.addWorkflowButton).toBeVisible();

--- a/docs/plans/settings-nav-expansion/plan.md
+++ b/docs/plans/settings-nav-expansion/plan.md
@@ -1,0 +1,69 @@
+---
+spec: docs/specs/settings-nav-expansion/spec.md
+created: 2026-08-11
+status: done
+---
+
+# Implementation Plan: Workspace-Scoped Integration Settings Links
+
+## Overview
+
+The settings menu restructure (`#2322`, merged after this branch forked)
+superseded the original settings-tree work: the new menu is static and
+data-driven, so the navigation-expansion defects and the top-level Integrations
+shortcut no longer apply. This rebased change keeps the surviving, still-needed
+part: consistently scope integration settings links to the active workspace,
+built with the canonical `workspaceSettingsHref(workspaceId, tab)` helper
+(`apps/web/lib/settings/workspace-settings-tabs.ts`), with global fallbacks.
+
+## Changes
+
+### Notices and error CTAs
+
+- GitHub `NotAuthenticatedNotice`, GitLab `NotConnectedNotice`, Jira
+  `NotConfiguredNotice`, Linear `NotConfiguredNotice` + `DisabledNotice`,
+  Azure DevOps `NotConfigured`, and the Jira/Linear/Sentry `ErrorMessage`
+  reconnect CTAs accept `workspaceId` and build the scoped href via
+  `workspaceSettingsHref(workspaceId, "integrations")`; without a workspace
+  they keep `/settings/integrations/<slug>`.
+- `workspaceId` is threaded through the page clients (`TicketResults`,
+  `ResultsArea`) and dialogs (`JiraTicketDialog`, `LinearIssueDialog`,
+  `SentryIssueDialog` and their body components).
+- Azure DevOps and GitHub notices also adopt the canonical helper (fixing the
+  raw-id/plural inconsistencies introduced by the restructure).
+- Notice/error components are exported for tests; each test pins the encoded
+  scoped href (with a non-URL-safe id `"ws 1/2"`) and the global fallback.
+
+### Automations and navigation
+
+- `automation-editor`, `automations-list-page`, `automations-table`, and
+  `ensure-session-error` replace hand-assembled `/settings/workspaces/<id>/...`
+  paths with `workspaceSettingsHref(workspaceId, <tab>)`.
+- e2e page helpers (`github-auth-settings-page`, `gitlab-settings-page`,
+  `linear-settings-page`, `automations-page`, `workflow-settings-page`) use the
+  same helper.
+
+## Verification
+
+```bash
+cd apps/web
+pnpm exec vitest run app/gitlab app/jira app/linear app/github app/azure-devops \
+  components/jira components/linear components/sentry components/automations components/task
+pnpm run typecheck
+pnpm run i18n:ratchet
+pnpm exec eslint app/gitlab app/jira app/linear app/github app/azure-devops \
+  components/jira components/linear components/sentry components/automations components/task e2e/pages
+pnpm e2e:run tests/settings/settings-gear-only.spec.ts tests/workflow/workflow-settings.spec.ts \
+  automations-settings.spec.ts
+```
+
+## Risks
+
+- Import placement: the helper import must land after `"use client"` /
+  directive comments.
+- The e2e helper files are not covered by web typecheck, so runtime E2E runs
+  are the verification for them.
+
+## Open Questions
+
+None.

--- a/docs/specs/settings-nav-expansion/spec.md
+++ b/docs/specs/settings-nav-expansion/spec.md
@@ -1,0 +1,73 @@
+---
+title: Repair workspace-scoped integration settings links
+status: building
+created: 2026-08-11
+owner: kandev
+---
+
+# Repair workspace-scoped integration settings links
+
+## Problem
+
+Integration settings links that appear inside workspace-scoped surfaces pointed
+at the global `/settings/integrations/<slug>` pages even when a workspace
+context was available, and workspace-scoped paths were built by hand with
+inconsistent encoding.
+
+- The GitHub, GitLab, Jira, Linear, Azure DevOps and Sentry "not
+  connected"/"disabled" notices and the Jira/Linear/Sentry error-message
+  reconnect CTAs linked to the global settings page instead of the active
+  workspace's integration settings.
+- Workspace settings navigation (`/settings/workspaces/<id>/...`) was
+  hand-assembled in several places with the raw workspace id, so ids with
+  reserved URL characters broke the route, and the encoding form differed
+  between call sites (raw vs `encodeURIComponent`).
+
+After the settings menu restructure (`#2322`), the settings tree itself is a
+static data-driven menu (no route-driven accordion), so the navigation
+expansion defects previously reported for the old tree no longer apply; the
+surviving defect is the inconsistent, unscoped integration settings links.
+
+## Desired behavior
+
+- Every integration settings link rendered from a workspace-scoped surface
+  (page clients, dialogs, notices, error CTAs) targets
+  `/settings/workspaces/<encoded-id>/integrations/<slug>` when a workspace
+  context exists, and falls back to the global `/settings/integrations/<slug>`
+  when it does not.
+- All workspace settings paths are built with the shared
+  `workspaceSettingsHref(workspaceId, tab)` helper
+  (`apps/web/lib/settings/workspace-settings-tabs.ts`), which encodes the id;
+  no surface hand-assembles the route.
+- The change covers page clients (GitHub, GitLab, Jira, Linear, Azure DevOps,
+  Sentry), their dialogs, the automations pages/editor/table, the task session
+  error action, and the e2e page helpers.
+
+## Regression scenarios
+
+- **GIVEN** a workspace-scoped integration page or dialog, **WHEN** the
+  not-connected/disabled notice or a reconnect CTA renders, **THEN** its link
+  points at `/settings/workspaces/<encoded-id>/integrations/<slug>`.
+- **GIVEN** no workspace context, **WHEN** the notice or CTA renders, **THEN**
+  the link points at the global `/settings/integrations/<slug>`.
+- **GIVEN** a workspace id with reserved URL characters, **WHEN** any
+  workspace settings link is built, **THEN** the id is percent-encoded and the
+  route round-trips through the router's decoder.
+- **GIVEN** automations navigation (list, editor, table, page redirects),
+  **WHEN** a workspace is present, **THEN** the destination uses the encoded
+  workspace path via `workspaceSettingsHref`.
+
+## Constraints
+
+- Use the canonical `workspaceSettingsHref` helper; do not add a parallel
+  route builder.
+- The settings-discovery catalog and command palette keep their global
+  routes by design; only workspace-scoped surfaces retarget.
+- No new user-facing copy; workspace ids and integration slugs are user/brand
+  data and are never translated.
+
+## Out of scope
+
+- The settings menu information architecture (superseded by `#2322`).
+- The task-create dialog's `ConnectProvidersBanner`, which keeps its global
+  link because the dialog is a global surface that may target any workspace.


### PR DESCRIPTION
Fixes integration settings links rendered from workspace-scoped surfaces (GitHub, GitLab, Jira, Linear, Azure DevOps, Sentry notices, reconnect CTAs, dialogs, automations navigation, and the task session error action) so they target the active workspace's integration settings (`/settings/workspaces/<encoded-id>/integrations/<slug>`) instead of the global page, with consistent percent-encoding everywhere via the canonical `workspaceSettingsHref` helper and global fallbacks when no workspace context exists.

Rebased onto the settings-menu restructure (#2322), which superseded the original settings-tree navigation changes: the new data-driven menu has no route-driven accordion and no top-level Integrations leaf, so the navigation-expansion defects reported against the old tree no longer apply. This PR carries the surviving, still-needed part of that work.

Original task: "Fix navigation expand and integration shortcut".

## Important Changes

- Integration notices and error-message reconnect CTAs (GitHub `NotAuthenticatedNotice`, GitLab `NotConnectedNotice`, Jira/Linear `NotConfiguredNotice`, Linear `DisabledNotice`, Azure DevOps `NotConfigured`, Jira/Linear/Sentry `ErrorMessage`) now accept `workspaceId` and link to `/settings/workspaces/<encoded-id>/integrations/<slug>` when a workspace context is present; `workspaceId` is threaded through page clients (`TicketResults`, `ResultsArea`) and the Jira/Linear/Sentry dialogs.
- All workspace settings paths are built with the canonical `workspaceSettingsHref(workspaceId, tab)` helper (encodes the id), replacing hand-assembled `/settings/workspaces/<id>/...` templates in the automations editor/list/table, the task session error action, and the e2e page helpers.
- Azure DevOps and GitHub notices adopt the same helper, fixing the raw-id and plural-route inconsistencies introduced by the restructure.
- Unit tests pin the encoded scoped href (with a non-URL-safe workspace id) and the global fallback for each notice/CTA.

## Validation

- Unit: 2657 passed (4 skipped) across the affected suites
- E2E: 38/38 (settings gear-only, workflow settings, automations settings)
- `make fmt`, web typecheck, ESLint, i18n ratchet: all pass
- Rebased onto `main` (includes #2322 restructure); CI re-running

## Possible Improvements

Low risk. Deliberately deferred: the task-create dialog's `ConnectProvidersBanner` keeps its global `/settings/integrations` link (global dialog surface, may target any workspace), and the settings-discovery catalog / command palette keep global routes by design.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.