### PR TITLE
fix(ci): grant pull-requests write to fork label job

### DIFF
--- a/.github/scripts/claude-code-review-workflow-contract_test.py
+++ b/.github/scripts/claude-code-review-workflow-contract_test.py
@@ -155,6 +155,7 @@ class ClaudeCodeReviewWorkflowContractTest(unittest.TestCase):
             label_job,
         )
         self.assertIn("issues: write", label_job)
+        self.assertIn("pull-requests: write", label_job)
         self.assertIn("github.rest.issues.addLabels", label_job)
         self.assertIn(
             "const labels = ['safe-to-review', 'safe-to-test'];",

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -86,6 +86,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
+      # issues.addLabels on a *pull request* requires the PR-scoped
+      # permission; issues: write alone 403s with "Resource not accessible
+      # by integration" (see kdlbs/kandev#2532 and siblings).
+      pull-requests: write
 
     steps:
       - name: Add automatic fork approval labels


### PR DESCRIPTION
The `label-allowlisted-fork` job in the Claude Code Review workflow has failed on every allowlisted fork PR since #2380 merged, with `403 Resource not accessible by integration` from `issues.addLabels` (e.g. #2532, and the `feature/add-mrstatuschip-to-0cb`, `feature/fix-cursor-jump-in-t-2ea`, `feature/hide-disabled-agent-c43` runs). The job's token declared only `issues: write`, but adding labels to a *pull request* requires the PR-scoped `pull-requests: write` permission — the failed 403 response's `x-accepted-github-permissions: issues=write; pull_requests=write` header confirms it. Result: `safe-to-review`/`safe-to-test` are never auto-applied to allowlisted fork PRs.

## Validation

- `.github/scripts/claude-code-review-workflow-contract_test.py` — 9 tests pass, including a new regression assertion that the label job declares `pull-requests: write` (fails on the pre-fix workflow)
- `.github/scripts/preview-env-workflow-contract_test.py` — passes
- `.github/scripts/lint-action-pinning.py` — all 18 workflow files SHA-pinned
- `git diff --check` — clean

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2542?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->