### PR TITLE
fix: refine task confirmation dialogs

### DIFF
--- a/apps/packages/ui/src/alert-dialog.tsx
+++ b/apps/packages/ui/src/alert-dialog.tsx
@@ -56,7 +56,7 @@ function AlertDialogContent({
   onKeyDown,
   ...props
 }: React.ComponentProps<typeof AlertDialogPrimitive.Content> & {
-  size?: "default" | "sm";
+  size?: "default" | "sm" | "lg";
   /** Pressing Enter activates the semantic action button. Default: true. */
   enterConfirms?: boolean;
   overlayClassName?: string;
@@ -72,7 +72,7 @@ function AlertDialogContent({
         data-slot="alert-dialog-content"
         data-size={size}
         className={cn(
-          "data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 bg-background ring-foreground/10 gap-3 rounded-xl p-4 ring-1 duration-100 data-[size=default]:max-w-xs data-[size=sm]:max-w-64 data-[size=default]:sm:max-w-sm group/alert-dialog-content fixed top-1/2 left-1/2 z-50 grid w-full -translate-x-1/2 -translate-y-1/2 outline-none",
+          "data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 bg-background ring-foreground/10 gap-3 rounded-xl p-4 ring-1 duration-100 data-[size=default]:max-w-xs data-[size=sm]:max-w-64 data-[size=default]:sm:max-w-sm data-[size=lg]:w-[calc(100vw-2rem)] data-[size=lg]:!max-w-[calc(100vw-2rem)] data-[size=lg]:sm:!max-w-lg group/alert-dialog-content fixed top-1/2 left-1/2 z-50 grid w-full -translate-x-1/2 -translate-y-1/2 outline-none",
           className,
         )}
         onKeyDown={handleKeyDown}

--- a/apps/web/components/task/task-archive-confirm-dialog.tsx
+++ b/apps/web/components/task/task-archive-confirm-dialog.tsx
@@ -18,6 +18,7 @@ import { useSubtaskCount } from "@/hooks/use-subtask-count";
 import { useTaskInFlight } from "@/hooks/use-task-in-flight";
 import { getCleanupSummary, getBulkCleanupSummary } from "./task-cleanup-summary";
 import { StillWorkingWarning } from "./task-still-working-warning";
+import { TASK_CONFIRM_CLASS, stopDialogPropagation } from "./task-confirm-dialog-shared";
 import { useTranslation } from "react-i18next";
 
 type TaskArchiveConfirmDialogProps = {
@@ -39,9 +40,6 @@ type TaskArchiveConfirmDialogProps = {
 };
 
 type ArchiveOpenMode = "pending" | "confirm" | "bypass";
-
-const dialogClass =
-  "w-[calc(100vw-2rem)] !max-w-[calc(100vw-2rem)] font-sans !text-sm sm:!max-w-lg";
 
 function useArchiveConfirmationMode(
   open: boolean,
@@ -132,7 +130,7 @@ export function TaskArchiveConfirmDialog({
 
   return (
     <AlertDialog open={open} onOpenChange={handleOpenChange}>
-      <AlertDialogContent className={dialogClass} onClick={(e) => e.stopPropagation()}>
+      <AlertDialogContent size="lg" className={TASK_CONFIRM_CLASS} onClick={stopDialogPropagation}>
         <AlertDialogHeader>
           <AlertDialogTitle className="text-base font-semibold">{title}</AlertDialogTitle>
           <AlertDialogDescription asChild className="text-sm leading-6">

--- a/apps/web/components/task/task-archive-confirm-dialog.tsx
+++ b/apps/web/components/task/task-archive-confirm-dialog.tsx
@@ -40,6 +40,9 @@ type TaskArchiveConfirmDialogProps = {
 
 type ArchiveOpenMode = "pending" | "confirm" | "bypass";
 
+const dialogClass =
+  "w-[calc(100vw-2rem)] !max-w-[calc(100vw-2rem)] font-sans !text-sm sm:!max-w-lg";
+
 function useArchiveConfirmationMode(
   open: boolean,
   confirmTaskArchive: boolean,
@@ -129,10 +132,10 @@ export function TaskArchiveConfirmDialog({
 
   return (
     <AlertDialog open={open} onOpenChange={handleOpenChange}>
-      <AlertDialogContent onClick={(e) => e.stopPropagation()}>
+      <AlertDialogContent className={dialogClass} onClick={(e) => e.stopPropagation()}>
         <AlertDialogHeader>
-          <AlertDialogTitle>{title}</AlertDialogTitle>
-          <AlertDialogDescription asChild>
+          <AlertDialogTitle className="text-base font-semibold">{title}</AlertDialogTitle>
+          <AlertDialogDescription asChild className="text-sm leading-6">
             <div>
               <p>{firstLine}</p>
               {cleanup.lines.map((line, i) => (
@@ -154,17 +157,19 @@ export function TaskArchiveConfirmDialog({
             />
             <span>
               {t("task:alsoArchiveSubtasks", { count: subtaskCount })}
-              <span className="block text-xs text-muted-foreground">
+              <span className="block text-sm text-muted-foreground">
                 {t("task:subtasksStayActiveUnlessYouTick")}
               </span>
             </span>
           </label>
         )}
         <AlertDialogFooter>
-          <AlertDialogCancel className="cursor-pointer">{t("common:cancel")}</AlertDialogCancel>
+          <AlertDialogCancel className="cursor-pointer !text-sm">
+            {t("common:cancel")}
+          </AlertDialogCancel>
           <AlertDialogAction
             disabled={isArchiving}
-            className="cursor-pointer"
+            className="cursor-pointer !text-sm"
             data-testid={confirmTestId}
             onClick={() => {
               if (isArchiving) return;

--- a/apps/web/components/task/task-confirm-dialog-shared.ts
+++ b/apps/web/components/task/task-confirm-dialog-shared.ts
@@ -1,0 +1,4 @@
+import type { MouseEvent } from "react";
+
+export const TASK_CONFIRM_CLASS = "font-sans !text-sm";
+export const stopDialogPropagation = (event: MouseEvent<HTMLDivElement>) => event.stopPropagation();

--- a/apps/web/components/task/task-delete-confirm-dialog.tsx
+++ b/apps/web/components/task/task-delete-confirm-dialog.tsx
@@ -17,6 +17,7 @@ import { useSubtaskCount } from "@/hooks/use-subtask-count";
 import { useTaskInFlight } from "@/hooks/use-task-in-flight";
 import { getCleanupSummary, getBulkCleanupSummary } from "./task-cleanup-summary";
 import { StillWorkingWarning } from "./task-still-working-warning";
+import { TASK_CONFIRM_CLASS, stopDialogPropagation } from "./task-confirm-dialog-shared";
 import { useTranslation } from "react-i18next";
 
 type TaskDeleteConfirmDialogProps = {
@@ -36,9 +37,6 @@ type TaskDeleteConfirmDialogProps = {
   onConfirm: (opts: { cascade: boolean }) => void;
   confirmTestId?: string;
 };
-
-const dialogClass =
-  "w-[calc(100vw-2rem)] !max-w-[calc(100vw-2rem)] font-sans !text-sm sm:!max-w-lg";
 
 export function TaskDeleteConfirmDialog({
   open,
@@ -78,7 +76,7 @@ export function TaskDeleteConfirmDialog({
 
   return (
     <AlertDialog open={open} onOpenChange={handleOpenChange}>
-      <AlertDialogContent className={dialogClass} onClick={(e) => e.stopPropagation()}>
+      <AlertDialogContent size="lg" className={TASK_CONFIRM_CLASS} onClick={stopDialogPropagation}>
         <AlertDialogHeader>
           <AlertDialogTitle className="text-base font-semibold">{title}</AlertDialogTitle>
           <AlertDialogDescription asChild className="text-sm leading-6">

--- a/apps/web/components/task/task-delete-confirm-dialog.tsx
+++ b/apps/web/components/task/task-delete-confirm-dialog.tsx
@@ -37,6 +37,9 @@ type TaskDeleteConfirmDialogProps = {
   confirmTestId?: string;
 };
 
+const dialogClass =
+  "w-[calc(100vw-2rem)] !max-w-[calc(100vw-2rem)] font-sans !text-sm sm:!max-w-lg";
+
 export function TaskDeleteConfirmDialog({
   open,
   onOpenChange,
@@ -75,10 +78,10 @@ export function TaskDeleteConfirmDialog({
 
   return (
     <AlertDialog open={open} onOpenChange={handleOpenChange}>
-      <AlertDialogContent onClick={(e) => e.stopPropagation()}>
+      <AlertDialogContent className={dialogClass} onClick={(e) => e.stopPropagation()}>
         <AlertDialogHeader>
-          <AlertDialogTitle>{title}</AlertDialogTitle>
-          <AlertDialogDescription asChild>
+          <AlertDialogTitle className="text-base font-semibold">{title}</AlertDialogTitle>
+          <AlertDialogDescription asChild className="text-sm leading-6">
             <div>
               <p>{description}</p>
               {cleanup.lines.map((line, i) => (
@@ -102,17 +105,19 @@ export function TaskDeleteConfirmDialog({
             />
             <span>
               {t("task:alsoDeleteSubtasks", { count: subtaskCount })}
-              <span className="block text-xs text-muted-foreground">
+              <span className="block text-sm text-muted-foreground">
                 {t("task:subtasksBecomeRootTasksUnlessYou")}
               </span>
             </span>
           </label>
         )}
         <AlertDialogFooter>
-          <AlertDialogCancel className="cursor-pointer">{t("common:cancel")}</AlertDialogCancel>
+          <AlertDialogCancel className="cursor-pointer !text-sm">
+            {t("common:cancel")}
+          </AlertDialogCancel>
           <AlertDialogAction
             disabled={isDeleting}
-            className="cursor-pointer bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            className="cursor-pointer bg-destructive !text-sm text-destructive-foreground hover:bg-destructive/90"
             data-testid={confirmTestId}
             onClick={() => {
               if (isDeleting) return;

--- a/apps/web/e2e/tests/kanban/card-menu-delete-archive.spec.ts
+++ b/apps/web/e2e/tests/kanban/card-menu-delete-archive.spec.ts
@@ -26,8 +26,13 @@ test.describe("Kanban card actions menu — delete/archive does not navigate", (
     await deleteItem.click();
 
     // Confirm dialog must appear with the task title
-    await expect(testPage.getByRole("alertdialog")).toBeVisible();
-    await expect(testPage.getByRole("alertdialog")).toContainText("Card Menu Delete Task");
+    const dialog = testPage.getByRole("alertdialog");
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toContainText("Card Menu Delete Task");
+    const dialogBox = await dialog.boundingBox();
+    if (!dialogBox) throw new Error("delete confirmation dialog has no layout box");
+    expect(dialogBox.width).toBeGreaterThanOrEqual(480);
+    await expect(dialog).toHaveClass(/font-sans/);
 
     // URL must not have changed (no navigation to /tasks/:id and no ?taskId=)
     expect(testPage.url()).toBe(startUrl);
@@ -55,6 +60,12 @@ test.describe("Kanban card actions menu — delete/archive does not navigate", (
 
     await expect(testPage.getByRole("alertdialog")).toBeVisible();
     await expect(testPage.getByRole("alertdialog")).toContainText("Card Menu Archive Task");
+
+    const dialog = testPage.getByRole("alertdialog");
+    const dialogBox = await dialog.boundingBox();
+    if (!dialogBox) throw new Error("archive confirmation dialog has no layout box");
+    expect(dialogBox.width).toBeGreaterThanOrEqual(480);
+    await expect(dialog).toHaveClass(/font-sans/);
 
     expect(testPage.url()).toBe(startUrl);
   });

--- a/apps/web/e2e/tests/kanban/card-menu-delete-archive.spec.ts
+++ b/apps/web/e2e/tests/kanban/card-menu-delete-archive.spec.ts
@@ -58,10 +58,9 @@ test.describe("Kanban card actions menu — delete/archive does not navigate", (
     await expect(archiveItem).toBeVisible();
     await archiveItem.click();
 
-    await expect(testPage.getByRole("alertdialog")).toBeVisible();
-    await expect(testPage.getByRole("alertdialog")).toContainText("Card Menu Archive Task");
-
     const dialog = testPage.getByRole("alertdialog");
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toContainText("Card Menu Archive Task");
     const dialogBox = await dialog.boundingBox();
     if (!dialogBox) throw new Error("archive confirmation dialog has no layout box");
     expect(dialogBox.width).toBeGreaterThanOrEqual(480);

--- a/apps/web/e2e/tests/task/mobile-sidebar-task-actions.spec.ts
+++ b/apps/web/e2e/tests/task/mobile-sidebar-task-actions.spec.ts
@@ -140,6 +140,13 @@ test.describe("Mobile sidebar task actions", () => {
     await expect(dialog).toBeVisible();
     await expect(dialog).toHaveClass(/font-sans/);
     await expect(dialog.locator('[data-slot="alert-dialog-description"]')).toHaveClass(/text-sm/);
+    await dialog.evaluate(async (element) => {
+      await Promise.all(
+        element
+          .getAnimations({ subtree: true })
+          .map((animation) => animation.finished.catch(() => undefined)),
+      );
+    });
 
     const [dialogBox, viewport] = await Promise.all([
       dialog.boundingBox(),
@@ -155,18 +162,23 @@ test.describe("Mobile sidebar task actions", () => {
     const typography = await dialog.evaluate((element) => {
       const description = element.querySelector('[data-slot="alert-dialog-description"]');
       const cancel = element.querySelector('[data-slot="alert-dialog-cancel"]');
+      const action = element.querySelector('[data-slot="alert-dialog-action"]');
       return {
         dialogFontFamily: getComputedStyle(element).fontFamily,
         descriptionFontFamily: description ? getComputedStyle(description).fontFamily : "",
         descriptionFontSize: description ? getComputedStyle(description).fontSize : "",
         cancelFontFamily: cancel ? getComputedStyle(cancel).fontFamily : "",
         cancelFontSize: cancel ? getComputedStyle(cancel).fontSize : "",
+        actionFontFamily: action ? getComputedStyle(action).fontFamily : "",
+        actionFontSize: action ? getComputedStyle(action).fontSize : "",
       };
     });
     expect(typography.dialogFontFamily).toContain("Figtree");
     expect(typography.descriptionFontFamily).toBe(typography.dialogFontFamily);
     expect(typography.cancelFontFamily).toBe(typography.dialogFontFamily);
     expect(typography.descriptionFontSize).toBe(typography.cancelFontSize);
+    expect(typography.actionFontFamily).toBe(typography.dialogFontFamily);
+    expect(typography.actionFontSize).toBe(typography.descriptionFontSize);
   });
 
   test("keeps the tablet task switcher as a left-side sheet", async ({

--- a/apps/web/e2e/tests/task/mobile-sidebar-task-actions.spec.ts
+++ b/apps/web/e2e/tests/task/mobile-sidebar-task-actions.spec.ts
@@ -114,6 +114,61 @@ test.describe("Mobile sidebar task actions", () => {
     expect(cardBox.y).toBeGreaterThan(0);
   });
 
+  test("keeps the archive confirmation readable on a phone", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    const task = await apiClient.seedTask(seedData.workspaceId, "Mobile archive dialog target", {
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+    });
+
+    await testPage.goto(`/t/${task.task_id}`);
+    const session = new SessionPage(testPage);
+    await session.waitForLoad();
+    await testPage.getByTestId("mobile-session-menu").tap();
+
+    const drawer = testPage.getByRole("dialog", { name: "Tasks" });
+    const taskRow = drawer
+      .getByTestId("sidebar-task-item")
+      .filter({ hasText: "Mobile archive dialog target" });
+    await taskRow.getByRole("button", { name: "Task actions" }).tap();
+    await testPage.getByRole("menuitem", { name: "Archive", exact: true }).tap();
+
+    const dialog = testPage.getByRole("alertdialog");
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toHaveClass(/font-sans/);
+    await expect(dialog.locator('[data-slot="alert-dialog-description"]')).toHaveClass(/text-sm/);
+
+    const [dialogBox, viewport] = await Promise.all([
+      dialog.boundingBox(),
+      testPage.evaluate(() => ({ width: window.innerWidth, height: window.innerHeight })),
+    ]);
+    if (!dialogBox) throw new Error("archive confirmation dialog has no layout box");
+    expect(dialogBox.width).toBeGreaterThanOrEqual(viewport.width - 40);
+    expect(dialogBox.x).toBeGreaterThanOrEqual(8);
+    expect(dialogBox.x + dialogBox.width).toBeLessThanOrEqual(viewport.width - 8);
+    expect(dialogBox.y).toBeGreaterThanOrEqual(8);
+    expect(dialogBox.y + dialogBox.height).toBeLessThanOrEqual(viewport.height - 8);
+
+    const typography = await dialog.evaluate((element) => {
+      const description = element.querySelector('[data-slot="alert-dialog-description"]');
+      const cancel = element.querySelector('[data-slot="alert-dialog-cancel"]');
+      return {
+        dialogFontFamily: getComputedStyle(element).fontFamily,
+        descriptionFontFamily: description ? getComputedStyle(description).fontFamily : "",
+        descriptionFontSize: description ? getComputedStyle(description).fontSize : "",
+        cancelFontFamily: cancel ? getComputedStyle(cancel).fontFamily : "",
+        cancelFontSize: cancel ? getComputedStyle(cancel).fontSize : "",
+      };
+    });
+    expect(typography.dialogFontFamily).toContain("Figtree");
+    expect(typography.descriptionFontFamily).toBe(typography.dialogFontFamily);
+    expect(typography.cancelFontFamily).toBe(typography.dialogFontFamily);
+    expect(typography.descriptionFontSize).toBe(typography.cancelFontSize);
+  });
+
   test("keeps the tablet task switcher as a left-side sheet", async ({
     testPage,
     apiClient,


### PR DESCRIPTION
The archive and delete confirmation dialogs now use a wider responsive surface and shared typography, keeping destructive task actions readable on desktop and mobile.

## Validation

- `pnpm exec vitest run components/task/task-archive-confirm-dialog.test.tsx components/task/task-delete-confirm-dialog.test.tsx`
- `pnpm exec eslint components/task/task-archive-confirm-dialog.tsx components/task/task-delete-confirm-dialog.tsx e2e/tests/task/mobile-sidebar-task-actions.spec.ts e2e/tests/kanban/card-menu-delete-archive.spec.ts --max-warnings 0`
- `pnpm exec prettier --check components/task/task-archive-confirm-dialog.tsx components/task/task-delete-confirm-dialog.tsx e2e/tests/task/mobile-sidebar-task-actions.spec.ts e2e/tests/kanban/card-menu-delete-archive.spec.ts`
- `pnpm run typecheck`
- `pnpm run build:e2e`
- `pnpm e2e:run --host --no-build --project mobile-chrome tests/task/mobile-sidebar-task-actions.spec.ts --grep "keeps the archive confirmation readable on a phone"`
- `pnpm e2e:run --host --no-build --project chromium tests/kanban/card-menu-delete-archive.spec.ts --grep "clicking (Delete|Archive) in card dropdown shows confirm dialog"`
- Fresh desktop and mobile PR captures with synthetic task data, inspected and PNG-compressed.
- `git diff --check`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2553?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


<!-- kandev-screenshots-start -->
## Screenshots

![Desktop archive confirmation](https://raw.githubusercontent.com/kdlbs/kandev/5a74e99e47f2227b5e9baf8d926507e256016382/archive-dialog-pr-capture--desktop-archive-confirmation.png)
![Mobile archive confirmation](https://raw.githubusercontent.com/kdlbs/kandev/5a74e99e47f2227b5e9baf8d926507e256016382/mobile-archive-dialog-pr-capture--mobile-archive-confirmation.png)
<!-- kandev-screenshots-end -->