### PR TITLE
fix: make the Message Queue settings box fill the page width

### DIFF
--- a/apps/web/components/settings/system/message-queue-settings.test.tsx
+++ b/apps/web/components/settings/system/message-queue-settings.test.tsx
@@ -214,6 +214,17 @@ describe("MessageQueueSettings — per-session limit", () => {
   });
 });
 
+describe("MessageQueueSettings — card surface", () => {
+  it("fills the available page width like the other settings boxes", async () => {
+    fetchSettingsMock.mockResolvedValueOnce(response());
+    render(<MessageQueueSettings />);
+
+    const root = await screen.findByTestId("message-queue-settings");
+    expect(root.className).toContain("w-full");
+    expect(root.className).not.toMatch(/\bmax-w-/);
+  });
+});
+
 describe("MessageQueueSettings — merge toggle", () => {
   it("is enabled by default and shows its limitations notice", async () => {
     render(<MessageQueueSettings />);

--- a/apps/web/components/settings/system/message-queue-settings.tsx
+++ b/apps/web/components/settings/system/message-queue-settings.tsx
@@ -303,7 +303,7 @@ export function MessageQueueSettings() {
   return (
     <SettingsCard
       isDirty={state.isDirty}
-      className="min-w-0 w-full max-w-3xl"
+      className="min-w-0 w-full"
       data-testid="message-queue-settings"
     >
       <CardHeader>

--- a/apps/web/e2e/tests/system/message-queue-settings.spec.ts
+++ b/apps/web/e2e/tests/system/message-queue-settings.spec.ts
@@ -54,6 +54,16 @@ test.describe.serial("Message Queue general settings", () => {
     );
     await expect(testPage.getByText("Message Queue").first()).toBeVisible();
 
+    // The Message Queue box spans the full settings column like every other
+    // settings box; it must not be width-restricted.
+    const queueCard = testPage.getByTestId("message-queue-settings");
+    const siblingCard = testPage.getByTestId("voice-enable-card");
+    await expect(queueCard).toBeVisible();
+    expect((await queueCard.boundingBox())?.width ?? 0).toBeCloseTo(
+      (await siblingCard.boundingBox())?.width ?? 0,
+      0,
+    );
+
     const input = testPage.getByTestId("message-queue-max-per-session");
     await expect(input).toHaveValue(String(baseline));
     await input.fill(String(updated));

--- a/apps/web/e2e/tests/system/message-queue-settings.spec.ts
+++ b/apps/web/e2e/tests/system/message-queue-settings.spec.ts
@@ -59,6 +59,7 @@ test.describe.serial("Message Queue general settings", () => {
     const queueCard = testPage.getByTestId("message-queue-settings");
     const siblingCard = testPage.getByTestId("voice-enable-card");
     await expect(queueCard).toBeVisible();
+    await expect(siblingCard).toBeVisible();
     expect((await queueCard.boundingBox())?.width ?? 0).toBeCloseTo(
       (await siblingCard.boundingBox())?.width ?? 0,
       0,


### PR DESCRIPTION
The Message Queue settings box was the only settings card capped at `max-w-3xl`, so it rendered narrower than every other box on the page. The width cap is removed and the card now spans the full settings column like its siblings, guarded by a unit regression test and a desktop E2E width assertion.

Task: "Message Queue" setting is width restricted

## Validation

- `pnpm test -- components/settings/system/message-queue-settings.test.tsx` — 18/18 pass, including the new "fills the available page width like the other settings boxes" test (fails with the old `max-w-3xl` class, passes without it).
- `pnpm run typecheck` — clean.
- `pnpm run lint` (web, `--max-warnings 0`) — clean; `make fmt` — clean.
- `pnpm e2e:raw tests/system/message-queue-settings.spec.ts` — 4/4 pass, including the new assertion that the queue card's bounding-box width matches the `voice-enable-card` sibling.
- Manual check in a secondary `make dev` instance: at a 1440px viewport the card measures 1088px with `max-width: none`, identical to its siblings.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2555?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- kandev-screenshots-start -->
## Screenshots

![Message Queue settings box spans the full settings column (desktop)](https://raw.githubusercontent.com/Fclem/kandev/53210d4a39e0b84ba2d011dd4a3761c6a6c77e4c/message-queue-pr-capture--message-queue-settings-desktop.png)

![Message Queue settings box on a phone viewport](https://raw.githubusercontent.com/Fclem/kandev/53210d4a39e0b84ba2d011dd4a3761c6a6c77e4c/mobile-message-queue-pr-capture--message-queue-settings-mobile.png)
<!-- kandev-screenshots-end -->