### PR TITLE
fix: inherit default profile for utility actions

### DIFF
--- a/apps/backend/internal/backendapp/orchestrator.go
+++ b/apps/backend/internal/backendapp/orchestrator.go
@@ -602,7 +602,7 @@ func (a *utilityDepsAdapter) ListUtilityAgentsByAgentProfile(ctx context.Context
 	}
 	for _, agent := range agents {
 		if agent != nil && (agent.AgentProfileID == profileID ||
-			(agent.ProfileBindingState == utilitymodels.ProfileBindingInherit && defaultProfileID == profileID)) {
+			(utilitymodels.UsesDefaultProfile(agent) && defaultProfileID == profileID)) {
 			refs = append(refs, agentsettingscontroller.UtilityAgentReference{ID: agent.ID, Name: agent.Name})
 		}
 	}
@@ -615,15 +615,6 @@ func (a *utilityDepsAdapter) ClearUtilityAgentProfileBindings(ctx context.Contex
 	}
 	if err := a.svc.ClearAgentProfileBindings(ctx, profileID); err != nil {
 		return err
-	}
-	if a.userSvc != nil {
-		defaultProfileID, err := a.userSvc.GetDefaultUtilityAgentProfileID(ctx)
-		if err != nil {
-			return err
-		}
-		if defaultProfileID == profileID {
-			return a.svc.ClearInheritedProfileBindings(ctx)
-		}
 	}
 	return nil
 }

--- a/apps/backend/internal/backendapp/services.go
+++ b/apps/backend/internal/backendapp/services.go
@@ -740,13 +740,17 @@ func (a pluginsUtilityAgentAdapter) GetAgentByID(ctx context.Context, id string)
 		return nil, err
 	}
 	profileID := agent.AgentProfileID
-	if profileID == "" && agent.ProfileBindingState == utilitymodels.ProfileBindingInherit && a.userSvc != nil {
+	bindingState := agent.ProfileBindingState
+	if utilitymodels.UsesDefaultProfile(agent) && a.userSvc != nil {
 		profileID, err = a.userSvc.GetDefaultUtilityAgentProfileID(ctx)
 		if err != nil {
 			return nil, err
 		}
+		if profileID != "" {
+			bindingState = utilitymodels.ProfileBindingExplicit
+		}
 	}
-	return &plugins.UtilityAgent{Name: agent.Name, AgentID: agent.AgentID, Model: agent.Model, AgentProfileID: profileID, ProfileBindingState: agent.ProfileBindingState, Enabled: agent.Enabled}, nil
+	return &plugins.UtilityAgent{Name: agent.Name, AgentID: agent.AgentID, Model: agent.Model, AgentProfileID: profileID, ProfileBindingState: bindingState, Enabled: agent.Enabled}, nil
 }
 
 // pluginsTaskWriterAdapter adapts the task service to the plugins package's

--- a/apps/backend/internal/backendapp/services_plugin_utility_test.go
+++ b/apps/backend/internal/backendapp/services_plugin_utility_test.go
@@ -6,7 +6,12 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/kandev/kandev/internal/common/logger"
+	"github.com/kandev/kandev/internal/events/bus"
 	"github.com/kandev/kandev/internal/plugins"
+	userModels "github.com/kandev/kandev/internal/user/models"
+	userService "github.com/kandev/kandev/internal/user/service"
+	userStore "github.com/kandev/kandev/internal/user/store"
 	utilitymodels "github.com/kandev/kandev/internal/utility/models"
 	utilityservice "github.com/kandev/kandev/internal/utility/service"
 	utilitystore "github.com/kandev/kandev/internal/utility/store"
@@ -42,4 +47,51 @@ func TestPluginsUtilityAgentAdapter_PreservesOperationalFailure(t *testing.T) {
 	if !errors.Is(err, storeErr) {
 		t.Fatalf("GetAgentByID() error = %v, want store error", err)
 	}
+}
+
+func TestPluginsUtilityAgentAdapter_ResolvesEmptyBuiltinThroughDefault(t *testing.T) {
+	log, err := logger.NewLogger(logger.LoggingConfig{Level: "error", Format: "json"})
+	if err != nil {
+		t.Fatalf("NewLogger() error = %v", err)
+	}
+	userRepo := &pluginUserRepository{
+		getSettings: &userModels.UserSettings{DefaultUtilityAgentProfileID: "default-profile"},
+	}
+	adapter := pluginsUtilityAgentAdapter{
+		svc: utilityservice.NewService(&utilityAgentRepositoryStub{agent: &utilitymodels.UtilityAgent{
+			ID:                  "builtin",
+			Builtin:             true,
+			ProfileBindingState: utilitymodels.ProfileBindingUnconfigured,
+		}}),
+		userSvc: userService.NewService(userRepo, bus.NewMemoryEventBus(log), log),
+	}
+
+	got, err := adapter.GetAgentByID(context.Background(), "builtin")
+	if err != nil {
+		t.Fatalf("GetAgentByID() error = %v", err)
+	}
+	if got.AgentProfileID != "default-profile" {
+		t.Fatalf("AgentProfileID = %q, want %q", got.AgentProfileID, "default-profile")
+	}
+	if got.ProfileBindingState != utilitymodels.ProfileBindingExplicit {
+		t.Fatalf("ProfileBindingState = %q, want %q", got.ProfileBindingState, utilitymodels.ProfileBindingExplicit)
+	}
+}
+
+type utilityAgentRepositoryStub struct {
+	utilitystore.Repository
+	agent *utilitymodels.UtilityAgent
+}
+
+func (r *utilityAgentRepositoryStub) GetAgentByID(context.Context, string) (*utilitymodels.UtilityAgent, error) {
+	return r.agent, nil
+}
+
+type pluginUserRepository struct {
+	userStore.Repository
+	getSettings *userModels.UserSettings
+}
+
+func (r *pluginUserRepository) GetUserSettings(context.Context, string) (*userModels.UserSettings, error) {
+	return r.getSettings, nil
 }

--- a/apps/backend/internal/backendapp/services_plugin_utility_test.go
+++ b/apps/backend/internal/backendapp/services_plugin_utility_test.go
@@ -61,7 +61,7 @@ func TestPluginsUtilityAgentAdapter_ResolvesEmptyBuiltinThroughDefault(t *testin
 		svc: utilityservice.NewService(&utilityAgentRepositoryStub{agent: &utilitymodels.UtilityAgent{
 			ID:                  "builtin",
 			Builtin:             true,
-			ProfileBindingState: utilitymodels.ProfileBindingUnconfigured,
+			ProfileBindingState: utilitymodels.ProfileBindingInherit,
 		}}),
 		userSvc: userService.NewService(userRepo, bus.NewMemoryEventBus(log), log),
 	}

--- a/apps/backend/internal/utility/models/models.go
+++ b/apps/backend/internal/utility/models/models.go
@@ -25,6 +25,14 @@ type UtilityAgent struct {
 	UpdatedAt           time.Time `json:"updated_at" db:"updated_at"`
 }
 
+// UsesDefaultProfile reports whether a built-in utility action has no
+// concrete profile override and therefore resolves through the global default.
+// It intentionally ignores profile_binding_state so legacy empty rows remain
+// usable while startup migration repairs their persisted state.
+func UsesDefaultProfile(agent *UtilityAgent) bool {
+	return agent != nil && agent.Builtin && agent.AgentProfileID == ""
+}
+
 // UtilityAgentCall represents a single invocation of a utility agent.
 type UtilityAgentCall struct {
 	ID             string     `json:"id" db:"id"`

--- a/apps/backend/internal/utility/models/models.go
+++ b/apps/backend/internal/utility/models/models.go
@@ -25,12 +25,13 @@ type UtilityAgent struct {
 	UpdatedAt           time.Time `json:"updated_at" db:"updated_at"`
 }
 
-// UsesDefaultProfile reports whether a built-in utility action has no
-// concrete profile override and therefore resolves through the global default.
-// It intentionally ignores profile_binding_state so legacy empty rows remain
-// usable while startup migration repairs their persisted state.
+// UsesDefaultProfile reports whether a built-in utility action has an explicit
+// inherited binding and therefore resolves through the global default. An
+// empty unconfigured row may be a stale binding from an older release that
+// erased its profile ID, so it must remain fail-closed.
 func UsesDefaultProfile(agent *UtilityAgent) bool {
-	return agent != nil && agent.Builtin && agent.AgentProfileID == ""
+	return agent != nil && agent.Builtin && agent.AgentProfileID == "" &&
+		agent.ProfileBindingState == ProfileBindingInherit
 }
 
 // UtilityAgentCall represents a single invocation of a utility agent.

--- a/apps/backend/internal/utility/service/service.go
+++ b/apps/backend/internal/utility/service/service.go
@@ -55,7 +55,8 @@ func (s *Service) ListAgents(ctx context.Context) ([]*models.UtilityAgent, error
 }
 
 // ClearAgentProfileBindings marks utility agents that reference a deleted
-// profile as unconfigured. This keeps forced profile deletion fail-closed.
+// profile as unconfigured. The stale profile ID is retained so forced profile
+// deletion remains diagnosable and fail-closed.
 func (s *Service) ClearAgentProfileBindings(ctx context.Context, profileID string) error {
 	agents, err := s.repo.ListAgents(ctx)
 	if err != nil {
@@ -63,26 +64,6 @@ func (s *Service) ClearAgentProfileBindings(ctx context.Context, profileID strin
 	}
 	for _, agent := range agents {
 		if agent == nil || agent.AgentProfileID != profileID {
-			continue
-		}
-		agent.AgentProfileID = ""
-		agent.ProfileBindingState = models.ProfileBindingUnconfigured
-		if err := s.repo.UpdateAgent(ctx, agent); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// ClearInheritedProfileBindings marks built-in agents that inherit a deleted
-// default profile as unconfigured.
-func (s *Service) ClearInheritedProfileBindings(ctx context.Context) error {
-	agents, err := s.repo.ListAgents(ctx)
-	if err != nil {
-		return err
-	}
-	for _, agent := range agents {
-		if agent == nil || agent.ProfileBindingState != models.ProfileBindingInherit {
 			continue
 		}
 		agent.ProfileBindingState = models.ProfileBindingUnconfigured
@@ -95,7 +76,8 @@ func (s *Service) ClearInheritedProfileBindings(ctx context.Context) error {
 
 // MigrateLegacyBindings upgrades old agent/model selections after profile
 // reconciliation. The operation is idempotent and leaves explicit bindings
-// untouched. A built-in row with inherit state is also left untouched.
+// untouched. A built-in row with an empty unconfigured binding is normalized
+// to inherit because it has no concrete profile to fail closed against.
 func (s *Service) MigrateLegacyBindings(ctx context.Context) (int, error) {
 	if s.profileResolver == nil {
 		return 0, nil
@@ -108,7 +90,15 @@ func (s *Service) MigrateLegacyBindings(ctx context.Context) (int, error) {
 	for _, agent := range agents {
 		if agent == nil || agent.AgentProfileID != "" ||
 			agent.ProfileBindingState == models.ProfileBindingInherit ||
-			agent.ProfileBindingState == models.ProfileBindingUnconfigured {
+			(!agent.Builtin && agent.ProfileBindingState == models.ProfileBindingUnconfigured) {
+			continue
+		}
+		if agent.Builtin && agent.ProfileBindingState == models.ProfileBindingUnconfigured {
+			agent.ProfileBindingState = models.ProfileBindingInherit
+			if err := s.repo.UpdateAgent(ctx, agent); err != nil {
+				return updated, err
+			}
+			updated++
 			continue
 		}
 		profile, matchErr := s.profileResolver.MatchLegacy(ctx, agent.AgentID, agent.Model)
@@ -117,11 +107,19 @@ func (s *Service) MigrateLegacyBindings(ctx context.Context) (int, error) {
 			agent.AgentProfileID = profile.ID
 			agent.ProfileBindingState = models.ProfileBindingExplicit
 		case errors.Is(matchErr, profilebinding.ErrLegacyBindingAmbiguous):
-			agent.ProfileBindingState = models.ProfileBindingUnconfigured
+			if agent.Builtin {
+				agent.ProfileBindingState = models.ProfileBindingInherit
+			} else {
+				agent.ProfileBindingState = models.ProfileBindingUnconfigured
+			}
 		case matchErr != nil:
 			return updated, matchErr
 		default:
-			agent.ProfileBindingState = models.ProfileBindingUnconfigured
+			if agent.Builtin {
+				agent.ProfileBindingState = models.ProfileBindingInherit
+			} else {
+				agent.ProfileBindingState = models.ProfileBindingUnconfigured
+			}
 		}
 		if err := s.repo.UpdateAgent(ctx, agent); err != nil {
 			return updated, err
@@ -319,13 +317,15 @@ func (s *Service) PreparePromptRequest(ctx context.Context, utilityID string, tm
 
 	if s.profileResolver != nil {
 		var profileID string
-		switch agent.ProfileBindingState {
-		case models.ProfileBindingUnconfigured:
-			return nil, ErrProfileUnconfigured
-		case models.ProfileBindingInherit:
+		switch {
+		case models.UsesDefaultProfile(agent):
 			if defaults != nil {
 				profileID = defaults.ProfileID
 			}
+		case agent.ProfileBindingState == models.ProfileBindingUnconfigured:
+			return nil, ErrProfileUnconfigured
+		case agent.ProfileBindingState == models.ProfileBindingInherit:
+			return nil, ErrProfileRequired
 		default:
 			profileID = agent.AgentProfileID
 		}

--- a/apps/backend/internal/utility/service/service.go
+++ b/apps/backend/internal/utility/service/service.go
@@ -317,6 +317,8 @@ func (s *Service) PreparePromptRequest(ctx context.Context, utilityID string, tm
 		case agent.ProfileBindingState == models.ProfileBindingUnconfigured:
 			return nil, ErrProfileUnconfigured
 		case agent.ProfileBindingState == models.ProfileBindingInherit:
+			// inherit with a non-empty profile ID is an inconsistent state that
+			// UpdateAgent prevents; fail closed rather than silently resolving it.
 			return nil, ErrProfileRequired
 		default:
 			profileID = agent.AgentProfileID

--- a/apps/backend/internal/utility/service/service.go
+++ b/apps/backend/internal/utility/service/service.go
@@ -76,8 +76,8 @@ func (s *Service) ClearAgentProfileBindings(ctx context.Context, profileID strin
 
 // MigrateLegacyBindings upgrades old agent/model selections after profile
 // reconciliation. The operation is idempotent and leaves explicit bindings
-// untouched. A built-in row with an empty unconfigured binding is normalized
-// to inherit because it has no concrete profile to fail closed against.
+// untouched. An empty unconfigured built-in is also left untouched because an
+// older release could have erased the ID of a deleted explicit binding.
 func (s *Service) MigrateLegacyBindings(ctx context.Context) (int, error) {
 	if s.profileResolver == nil {
 		return 0, nil
@@ -90,15 +90,7 @@ func (s *Service) MigrateLegacyBindings(ctx context.Context) (int, error) {
 	for _, agent := range agents {
 		if agent == nil || agent.AgentProfileID != "" ||
 			agent.ProfileBindingState == models.ProfileBindingInherit ||
-			(!agent.Builtin && agent.ProfileBindingState == models.ProfileBindingUnconfigured) {
-			continue
-		}
-		if agent.Builtin && agent.ProfileBindingState == models.ProfileBindingUnconfigured {
-			agent.ProfileBindingState = models.ProfileBindingInherit
-			if err := s.repo.UpdateAgent(ctx, agent); err != nil {
-				return updated, err
-			}
-			updated++
+			agent.ProfileBindingState == models.ProfileBindingUnconfigured {
 			continue
 		}
 		profile, matchErr := s.profileResolver.MatchLegacy(ctx, agent.AgentID, agent.Model)

--- a/apps/backend/internal/utility/service/service_test.go
+++ b/apps/backend/internal/utility/service/service_test.go
@@ -43,12 +43,35 @@ func TestMigrateLegacyBindingsUpdatesOnlyUnambiguousRows(t *testing.T) {
 	}
 }
 
-func TestMigrateLegacyBindingsNormalizesEmptyUnconfiguredBuiltin(t *testing.T) {
+func TestMigrateLegacyBindingsPreservesEmptyUnconfiguredBuiltin(t *testing.T) {
 	repo := &fakeRepository{agents: map[string]*models.UtilityAgent{
 		"builtin": {
 			ID:                  "builtin",
 			Builtin:             true,
 			ProfileBindingState: models.ProfileBindingUnconfigured,
+		},
+	}}
+	svc := NewService(repo)
+	svc.SetProfileResolver(fakeProfileResolver{})
+
+	updated, err := svc.MigrateLegacyBindings(context.Background())
+	if err != nil {
+		t.Fatalf("MigrateLegacyBindings() error = %v", err)
+	}
+	if updated != 0 {
+		t.Fatalf("MigrateLegacyBindings() updated = %d, want 0", updated)
+	}
+	if got := repo.agents["builtin"].ProfileBindingState; got != models.ProfileBindingUnconfigured {
+		t.Fatalf("profile binding state = %q, want %q", got, models.ProfileBindingUnconfigured)
+	}
+}
+
+func TestMigrateLegacyBindingsNormalizesEmptyExplicitBuiltin(t *testing.T) {
+	repo := &fakeRepository{agents: map[string]*models.UtilityAgent{
+		"builtin": {
+			ID:                  "builtin",
+			Builtin:             true,
+			ProfileBindingState: models.ProfileBindingExplicit,
 		},
 	}}
 	svc := NewService(repo)
@@ -325,7 +348,7 @@ func TestPreparePromptRequest_IgnoresDefaultsWhenAgentAndModelAreConfigured(t *t
 	}
 }
 
-func TestPreparePromptRequest_ResolvesEmptyUnconfiguredBuiltinFromDefaultProfile(t *testing.T) {
+func TestPreparePromptRequest_ResolvesInheritedBuiltinFromDefaultProfile(t *testing.T) {
 	t.Parallel()
 
 	defaultProfile := &agentsettingsmodels.AgentProfile{
@@ -338,7 +361,7 @@ func TestPreparePromptRequest_ResolvesEmptyUnconfiguredBuiltinFromDefaultProfile
 			ID:                  "builtin",
 			Prompt:              "Do {{UserPrompt}}",
 			Builtin:             true,
-			ProfileBindingState: models.ProfileBindingUnconfigured,
+			ProfileBindingState: models.ProfileBindingInherit,
 		},
 	}})
 	svc.SetProfileResolver(fakeProfileResolver{profile: defaultProfile})
@@ -358,7 +381,7 @@ func TestPreparePromptRequest_ResolvesEmptyUnconfiguredBuiltinFromDefaultProfile
 	}
 }
 
-func TestPreparePromptRequest_EmptyUnconfiguredBuiltinRequiresDefault(t *testing.T) {
+func TestPreparePromptRequest_InheritedBuiltinRequiresDefault(t *testing.T) {
 	t.Parallel()
 
 	svc := NewService(&fakeRepository{agents: map[string]*models.UtilityAgent{
@@ -366,7 +389,7 @@ func TestPreparePromptRequest_EmptyUnconfiguredBuiltinRequiresDefault(t *testing
 			ID:                  "builtin",
 			Prompt:              "Do {{UserPrompt}}",
 			Builtin:             true,
-			ProfileBindingState: models.ProfileBindingUnconfigured,
+			ProfileBindingState: models.ProfileBindingInherit,
 		},
 	}})
 	svc.SetProfileResolver(fakeProfileResolver{profile: &agentsettingsmodels.AgentProfile{ID: "unused"}})
@@ -380,6 +403,31 @@ func TestPreparePromptRequest_EmptyUnconfiguredBuiltinRequiresDefault(t *testing
 	)
 	if !errors.Is(err, ErrProfileRequired) {
 		t.Fatalf("PreparePromptRequest() error = %v, want %v", err, ErrProfileRequired)
+	}
+}
+
+func TestPreparePromptRequest_EmptyUnconfiguredBuiltinFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	svc := NewService(&fakeRepository{agents: map[string]*models.UtilityAgent{
+		"builtin": {
+			ID:                  "builtin",
+			Prompt:              "Do {{UserPrompt}}",
+			Builtin:             true,
+			ProfileBindingState: models.ProfileBindingUnconfigured,
+		},
+	}})
+	svc.SetProfileResolver(fakeProfileResolver{profile: &agentsettingsmodels.AgentProfile{ID: "default-profile"}})
+
+	_, err := svc.PreparePromptRequest(
+		context.Background(),
+		"builtin",
+		&template.Context{UserPrompt: "fix the bug"},
+		&DefaultUtilitySettings{ProfileID: "default-profile"},
+		false,
+	)
+	if !errors.Is(err, ErrProfileUnconfigured) {
+		t.Fatalf("PreparePromptRequest() error = %v, want %v", err, ErrProfileUnconfigured)
 	}
 }
 

--- a/apps/backend/internal/utility/service/service_test.go
+++ b/apps/backend/internal/utility/service/service_test.go
@@ -3,10 +3,12 @@ package service
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"testing"
 
 	agentsettingsmodels "github.com/kandev/kandev/internal/agent/settings/models"
 	"github.com/kandev/kandev/internal/utility/models"
+	"github.com/kandev/kandev/internal/utility/profilebinding"
 	"github.com/kandev/kandev/internal/utility/template"
 )
 
@@ -38,6 +40,94 @@ func TestMigrateLegacyBindingsUpdatesOnlyUnambiguousRows(t *testing.T) {
 	}
 	if repo.agents["inherit"].ProfileBindingState != models.ProfileBindingInherit {
 		t.Fatalf("inherit row changed: %#v", repo.agents["inherit"])
+	}
+}
+
+func TestMigrateLegacyBindingsNormalizesEmptyUnconfiguredBuiltin(t *testing.T) {
+	repo := &fakeRepository{agents: map[string]*models.UtilityAgent{
+		"builtin": {
+			ID:                  "builtin",
+			Builtin:             true,
+			ProfileBindingState: models.ProfileBindingUnconfigured,
+		},
+	}}
+	svc := NewService(repo)
+	svc.SetProfileResolver(fakeProfileResolver{})
+
+	updated, err := svc.MigrateLegacyBindings(context.Background())
+	if err != nil {
+		t.Fatalf("MigrateLegacyBindings() error = %v", err)
+	}
+	if updated != 1 {
+		t.Fatalf("MigrateLegacyBindings() updated = %d, want 1", updated)
+	}
+	if got := repo.agents["builtin"].ProfileBindingState; got != models.ProfileBindingInherit {
+		t.Fatalf("profile binding state = %q, want %q", got, models.ProfileBindingInherit)
+	}
+}
+
+func TestMigrateLegacyBindingsMakesAmbiguousBuiltinInheritButCustomUnconfigured(t *testing.T) {
+	repo := &fakeRepository{agents: map[string]*models.UtilityAgent{
+		"builtin": {
+			ID:                  "builtin",
+			AgentID:             "legacy-agent",
+			Model:               "legacy-model",
+			Builtin:             true,
+			ProfileBindingState: models.ProfileBindingExplicit,
+		},
+		"custom": {
+			ID:                  "custom",
+			AgentID:             "legacy-agent",
+			Model:               "legacy-model",
+			ProfileBindingState: models.ProfileBindingExplicit,
+		},
+	}}
+	svc := NewService(repo)
+	svc.SetProfileResolver(fakeProfileResolver{err: profilebinding.ErrLegacyBindingAmbiguous})
+
+	updated, err := svc.MigrateLegacyBindings(context.Background())
+	if err != nil {
+		t.Fatalf("MigrateLegacyBindings() error = %v", err)
+	}
+	if updated != 2 {
+		t.Fatalf("MigrateLegacyBindings() updated = %d, want 2", updated)
+	}
+	if got := repo.agents["builtin"].ProfileBindingState; got != models.ProfileBindingInherit {
+		t.Fatalf("builtin state = %q, want %q", got, models.ProfileBindingInherit)
+	}
+	if got := repo.agents["custom"].ProfileBindingState; got != models.ProfileBindingUnconfigured {
+		t.Fatalf("custom state = %q, want %q", got, models.ProfileBindingUnconfigured)
+	}
+}
+
+func TestClearAgentProfileBindingsRetainsStaleProfileID(t *testing.T) {
+	repo := &fakeRepository{agents: map[string]*models.UtilityAgent{
+		"builtin": {
+			ID:                  "builtin",
+			Builtin:             true,
+			AgentProfileID:      "deleted-profile",
+			ProfileBindingState: models.ProfileBindingExplicit,
+		},
+		"inherited": {
+			ID:                  "inherited",
+			Builtin:             true,
+			ProfileBindingState: models.ProfileBindingInherit,
+		},
+	}}
+	svc := NewService(repo)
+
+	if err := svc.ClearAgentProfileBindings(context.Background(), "deleted-profile"); err != nil {
+		t.Fatalf("ClearAgentProfileBindings() error = %v", err)
+	}
+	deleted := repo.agents["builtin"]
+	if deleted.AgentProfileID != "deleted-profile" {
+		t.Fatalf("stale profile ID = %q, want %q", deleted.AgentProfileID, "deleted-profile")
+	}
+	if deleted.ProfileBindingState != models.ProfileBindingUnconfigured {
+		t.Fatalf("deleted profile state = %q, want %q", deleted.ProfileBindingState, models.ProfileBindingUnconfigured)
+	}
+	if got := repo.agents["inherited"].ProfileBindingState; got != models.ProfileBindingInherit {
+		t.Fatalf("inherited state = %q, want %q", got, models.ProfileBindingInherit)
 	}
 }
 
@@ -232,5 +322,89 @@ func TestPreparePromptRequest_IgnoresDefaultsWhenAgentAndModelAreConfigured(t *t
 	}
 	if req.Model != "custom-model" {
 		t.Fatalf("Model = %q, want %q", req.Model, "custom-model")
+	}
+}
+
+func TestPreparePromptRequest_ResolvesEmptyUnconfiguredBuiltinFromDefaultProfile(t *testing.T) {
+	t.Parallel()
+
+	defaultProfile := &agentsettingsmodels.AgentProfile{
+		ID:      "default-profile",
+		AgentID: "codex-acp",
+		Model:   "gpt-5",
+	}
+	svc := NewService(&fakeRepository{agents: map[string]*models.UtilityAgent{
+		"builtin": {
+			ID:                  "builtin",
+			Prompt:              "Do {{UserPrompt}}",
+			Builtin:             true,
+			ProfileBindingState: models.ProfileBindingUnconfigured,
+		},
+	}})
+	svc.SetProfileResolver(fakeProfileResolver{profile: defaultProfile})
+
+	req, err := svc.PreparePromptRequest(
+		context.Background(),
+		"builtin",
+		&template.Context{UserPrompt: "fix the bug"},
+		&DefaultUtilitySettings{ProfileID: "default-profile"},
+		false,
+	)
+	if err != nil {
+		t.Fatalf("PreparePromptRequest() error = %v", err)
+	}
+	if req.AgentProfileID != "default-profile" {
+		t.Fatalf("AgentProfileID = %q, want %q", req.AgentProfileID, "default-profile")
+	}
+}
+
+func TestPreparePromptRequest_EmptyUnconfiguredBuiltinRequiresDefault(t *testing.T) {
+	t.Parallel()
+
+	svc := NewService(&fakeRepository{agents: map[string]*models.UtilityAgent{
+		"builtin": {
+			ID:                  "builtin",
+			Prompt:              "Do {{UserPrompt}}",
+			Builtin:             true,
+			ProfileBindingState: models.ProfileBindingUnconfigured,
+		},
+	}})
+	svc.SetProfileResolver(fakeProfileResolver{profile: &agentsettingsmodels.AgentProfile{ID: "unused"}})
+
+	_, err := svc.PreparePromptRequest(
+		context.Background(),
+		"builtin",
+		&template.Context{UserPrompt: "fix the bug"},
+		&DefaultUtilitySettings{},
+		false,
+	)
+	if !errors.Is(err, ErrProfileRequired) {
+		t.Fatalf("PreparePromptRequest() error = %v, want %v", err, ErrProfileRequired)
+	}
+}
+
+func TestPreparePromptRequest_ConcreteUnconfiguredBindingFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	svc := NewService(&fakeRepository{agents: map[string]*models.UtilityAgent{
+		"builtin": {
+			ID:                  "builtin",
+			Prompt:              "Do {{UserPrompt}}",
+			Builtin:             true,
+			AgentProfileID:      "deleted-profile",
+			ProfileBindingState: models.ProfileBindingUnconfigured,
+		},
+	}})
+	svc.SetProfileResolver(fakeProfileResolver{profile: &agentsettingsmodels.AgentProfile{ID: "deleted-profile"}})
+
+	_, err := svc.PreparePromptRequest(
+		context.Background(),
+		"builtin",
+		&template.Context{UserPrompt: "fix the bug"},
+		&DefaultUtilitySettings{ProfileID: "default-profile"},
+		false,
+	)
+	if !errors.Is(err, ErrProfileUnconfigured) {
+		t.Fatalf("PreparePromptRequest() error = %v, want %v", err, ErrProfileUnconfigured)
 	}
 }

--- a/apps/web/components/settings/utility-sections.test.tsx
+++ b/apps/web/components/settings/utility-sections.test.tsx
@@ -3,6 +3,8 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { UtilityAgent } from "@/lib/api/domains/utility-api";
 import { BuiltinActionRow, USE_DEFAULT } from "./utility-sections";
 
+const UNCONFIGURED = "__UNCONFIGURED__";
+
 vi.mock("./utility-agent-profile-picker", () => ({
   UtilityAgentProfilePicker: ({
     testId,
@@ -48,12 +50,20 @@ function renderRow(agent: UtilityAgent) {
 }
 
 describe("BuiltinActionRow profile binding state", () => {
-  it("uses the default for an empty unconfigured built-in binding", () => {
-    renderRow(builtin({ profile_binding_state: "unconfigured", agent_profile_id: "" }));
+  it("uses the default for an inherited built-in binding", () => {
+    renderRow(builtin({ profile_binding_state: "inherit", agent_profile_id: "" }));
 
     const picker = screen.getByTestId("utility-profile-picker-action-builtin-commit-message");
     expect(picker.getAttribute("data-value")).toBe(USE_DEFAULT);
     expect(picker.getAttribute("data-unavailable-value")).toBeNull();
+  });
+
+  it("keeps an empty unconfigured binding unavailable", () => {
+    renderRow(builtin({ profile_binding_state: "unconfigured", agent_profile_id: "" }));
+
+    const picker = screen.getByTestId("utility-profile-picker-action-builtin-commit-message");
+    expect(picker.getAttribute("data-value")).toBe(UNCONFIGURED);
+    expect(picker.getAttribute("data-unavailable-value")).toBe(UNCONFIGURED);
   });
 
   it("keeps a concrete unconfigured binding unavailable", () => {

--- a/apps/web/components/settings/utility-sections.test.tsx
+++ b/apps/web/components/settings/utility-sections.test.tsx
@@ -1,0 +1,71 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { UtilityAgent } from "@/lib/api/domains/utility-api";
+import { BuiltinActionRow, USE_DEFAULT } from "./utility-sections";
+
+vi.mock("./utility-agent-profile-picker", () => ({
+  UtilityAgentProfilePicker: ({
+    testId,
+    value,
+    unavailableValue,
+  }: {
+    testId: string;
+    value: string;
+    unavailableValue?: string;
+  }) => <div data-testid={testId} data-value={value} data-unavailable-value={unavailableValue} />,
+  utilityProfileEligibility: () => true,
+}));
+
+afterEach(() => cleanup());
+
+function builtin(overrides: Partial<UtilityAgent> = {}): UtilityAgent {
+  return {
+    id: "builtin-commit-message",
+    name: "commit-message",
+    description: "Generate a commit message.",
+    prompt: "Generate a commit message.",
+    agent_id: "",
+    model: "",
+    builtin: true,
+    enabled: true,
+    created_at: "",
+    updated_at: "",
+    ...overrides,
+  };
+}
+
+function renderRow(agent: UtilityAgent) {
+  return render(
+    <BuiltinActionRow
+      agent={agent}
+      profiles={[]}
+      defaultLabel="Default profile"
+      onProfileChange={vi.fn()}
+      onEdit={vi.fn()}
+      isDirty={false}
+    />,
+  );
+}
+
+describe("BuiltinActionRow profile binding state", () => {
+  it("uses the default for an empty unconfigured built-in binding", () => {
+    renderRow(builtin({ profile_binding_state: "unconfigured", agent_profile_id: "" }));
+
+    const picker = screen.getByTestId("utility-profile-picker-action-builtin-commit-message");
+    expect(picker.getAttribute("data-value")).toBe(USE_DEFAULT);
+    expect(picker.getAttribute("data-unavailable-value")).toBeNull();
+  });
+
+  it("keeps a concrete unconfigured binding unavailable", () => {
+    renderRow(
+      builtin({
+        profile_binding_state: "unconfigured",
+        agent_profile_id: "deleted-profile",
+      }),
+    );
+
+    const picker = screen.getByTestId("utility-profile-picker-action-builtin-commit-message");
+    expect(picker.getAttribute("data-value")).toBe("deleted-profile");
+    expect(picker.getAttribute("data-unavailable-value")).toBe("deleted-profile");
+  });
+});

--- a/apps/web/components/settings/utility-sections.tsx
+++ b/apps/web/components/settings/utility-sections.tsx
@@ -16,7 +16,24 @@ import {
 } from "@/components/settings/utility-agent-profile-picker";
 
 export const USE_DEFAULT = "__USE_DEFAULT__";
-const UNCONFIGURED = "__UNCONFIGURED__";
+
+export type BuiltinActionProfileSelection = {
+  value: string;
+  unavailableValue?: string;
+};
+
+export function getBuiltinActionProfileSelection(
+  agent: UtilityAgent,
+): BuiltinActionProfileSelection {
+  const profileId = agent.agent_profile_id || "";
+  if (agent.profile_binding_state === "unconfigured" && profileId) {
+    return { value: profileId, unavailableValue: profileId };
+  }
+  if (agent.profile_binding_state !== "inherit" && profileId) {
+    return { value: profileId };
+  }
+  return { value: USE_DEFAULT };
+}
 
 export function DefaultModelSection({
   profiles,
@@ -85,12 +102,7 @@ export function BuiltinActionRow({
   isDirty: boolean;
 }) {
   const { t } = useTranslation();
-  let currentValue = USE_DEFAULT;
-  if (agent.profile_binding_state === "unconfigured") {
-    currentValue = UNCONFIGURED;
-  } else if (agent.profile_binding_state !== "inherit" && agent.agent_profile_id) {
-    currentValue = agent.agent_profile_id;
-  }
+  const selection = getBuiltinActionProfileSelection(agent);
   return (
     <div
       className="flex flex-col gap-2 py-2 px-2 rounded hover:bg-muted/50 md:flex-row md:items-center md:gap-4"
@@ -104,12 +116,12 @@ export function BuiltinActionRow({
       <div className="flex items-center gap-2">
         <UtilityAgentProfilePicker
           profiles={profiles}
-          value={currentValue}
+          value={selection.value}
           onValueChange={(value) => onProfileChange(agent, value)}
           fallback={{ value: USE_DEFAULT, label: defaultLabel }}
-          unavailableValue={currentValue === UNCONFIGURED ? currentValue : undefined}
+          unavailableValue={selection.unavailableValue}
           unavailableLabel={
-            currentValue === UNCONFIGURED ? t("settings:utilityProfileNeedsRepair") : undefined
+            selection.unavailableValue ? t("settings:utilityProfileNeedsRepair") : undefined
           }
           testId={`utility-profile-picker-action-${agent.id}`}
           triggerClassName="min-w-0 flex-1 md:w-[280px] md:flex-none"

--- a/apps/web/components/settings/utility-sections.tsx
+++ b/apps/web/components/settings/utility-sections.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/components/settings/utility-agent-profile-picker";
 
 export const USE_DEFAULT = "__USE_DEFAULT__";
+const UNCONFIGURED = "__UNCONFIGURED__";
 
 export type BuiltinActionProfileSelection = {
   value: string;
@@ -26,8 +27,9 @@ export function getBuiltinActionProfileSelection(
   agent: UtilityAgent,
 ): BuiltinActionProfileSelection {
   const profileId = agent.agent_profile_id || "";
-  if (agent.profile_binding_state === "unconfigured" && profileId) {
-    return { value: profileId, unavailableValue: profileId };
+  if (agent.profile_binding_state === "unconfigured") {
+    const unavailableValue = profileId || UNCONFIGURED;
+    return { value: unavailableValue, unavailableValue };
   }
   if (agent.profile_binding_state !== "inherit" && profileId) {
     return { value: profileId };

--- a/apps/web/e2e/tests/settings/mobile-utility-agents.spec.ts
+++ b/apps/web/e2e/tests/settings/mobile-utility-agents.spec.ts
@@ -43,7 +43,7 @@ test.describe("Mobile utility agents action rows", () => {
           agent_id: "",
           model: "",
           agent_profile_id: "",
-          profile_binding_state: "unconfigured",
+          profile_binding_state: "inherit",
         }),
       }),
     );
@@ -70,7 +70,7 @@ test.describe("Mobile utility agents action rows", () => {
               agent_id: "",
               model: "",
               agent_profile_id: "",
-              profile_binding_state: "unconfigured",
+              profile_binding_state: "inherit",
             },
           ],
         }),

--- a/apps/web/e2e/tests/settings/mobile-utility-agents.spec.ts
+++ b/apps/web/e2e/tests/settings/mobile-utility-agents.spec.ts
@@ -19,6 +19,16 @@ test.describe("Mobile utility agents action rows", () => {
       .find((candidate) => candidate.id === seedData.agentProfileId);
     if (!profile) throw new Error(`seed profile ${seedData.agentProfileId} was not found`);
     const profileLabel = `${profile.agentDisplayName} • ${profile.name}`;
+    await testPage.route("**/api/v1/user/settings", (route) => {
+      if (route.request().method() !== "GET") return route.continue();
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          settings: { default_utility_agent_profile_id: seedData.agentProfileId },
+        }),
+      });
+    });
     await testPage.route("**/api/v1/utility/agents/builtin-commit-message", (route) =>
       route.fulfill({
         status: 200,
@@ -32,8 +42,8 @@ test.describe("Mobile utility agents action rows", () => {
           enabled: true,
           agent_id: "",
           model: "",
-          agent_profile_id: seedData.agentProfileId,
-          profile_binding_state: "explicit",
+          agent_profile_id: "",
+          profile_binding_state: "unconfigured",
         }),
       }),
     );
@@ -59,8 +69,8 @@ test.describe("Mobile utility agents action rows", () => {
               enabled: true,
               agent_id: "",
               model: "",
-              agent_profile_id: seedData.agentProfileId,
-              profile_binding_state: "explicit",
+              agent_profile_id: "",
+              profile_binding_state: "unconfigured",
             },
           ],
         }),
@@ -100,7 +110,9 @@ test.describe("Mobile utility agents action rows", () => {
       "utility-profile-picker-action-builtin-commit-message-dropdown",
     );
     await dropdown.getByPlaceholder("Search agent profiles...").fill(profile.agentDisplayName);
-    const option = dropdown.getByRole("option", { name: profileLabel, exact: true });
+    const option = dropdown.locator(`[data-value="${profile.id}"]`);
+    await expect(option).toHaveAttribute("role", "option");
+    await expect(option).toContainText(profileLabel);
     await expect(option.getByTestId("utility-profile-agent-icon")).toBeVisible();
     await option.tap();
     await expect(select).toContainText(profileLabel);

--- a/apps/web/e2e/tests/settings/utility-agents.spec.ts
+++ b/apps/web/e2e/tests/settings/utility-agents.spec.ts
@@ -10,6 +10,73 @@ import { test, expect } from "../../fixtures/test-base";
  * interactions (open the page, inspect sections, open the create dialog).
  */
 test.describe("Utility Agents settings page", () => {
+  test("renders the default for an empty unconfigured built-in action", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    const { agents } = await apiClient.listAgents();
+    const profile = agents
+      .flatMap((agent) => agent.profiles ?? [])
+      .find((candidate) => candidate.id === seedData.agentProfileId);
+    if (!profile) throw new Error(`seed profile ${seedData.agentProfileId} was not found`);
+    const profileLabel = `${profile.agentDisplayName} • ${profile.name}`;
+
+    await testPage.route("**/api/v1/user/settings", (route) => {
+      if (route.request().method() !== "GET") return route.continue();
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          settings: { default_utility_agent_profile_id: seedData.agentProfileId },
+        }),
+      });
+    });
+    await testPage.route("**/api/v1/utility/agents", (route) => {
+      if (route.request().method() !== "GET") {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ success: true }),
+        });
+      }
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          agents: [
+            {
+              id: "builtin-commit-message",
+              name: "commit-message",
+              description: "Generate a commit message.",
+              builtin: true,
+              enabled: true,
+              agent_id: "",
+              model: "",
+              agent_profile_id: "",
+              profile_binding_state: "unconfigured",
+            },
+          ],
+        }),
+      });
+    });
+
+    await testPage.goto("/settings/utility-agents");
+    await expect(
+      testPage.getByRole("heading", { name: "Utility Agents", exact: true }),
+    ).toBeVisible({ timeout: 15_000 });
+
+    const row = testPage.getByTestId("utility-action-row-builtin-commit-message");
+    await expect(
+      row.getByTestId("utility-profile-picker-action-builtin-commit-message"),
+    ).toContainText(profileLabel);
+    await expect(
+      row.getByText("This profile is unavailable. Select an enabled inference profile.", {
+        exact: true,
+      }),
+    ).toHaveCount(0);
+  });
+
   test("profile picker keeps wheel scrolling inside the menu", async ({ testPage }) => {
     const models = Array.from({ length: 36 }, (_, index) => ({
       id: `claude-model-${String(index + 1).padStart(2, "0")}`,

--- a/apps/web/e2e/tests/settings/utility-agents.spec.ts
+++ b/apps/web/e2e/tests/settings/utility-agents.spec.ts
@@ -10,7 +10,7 @@ import { test, expect } from "../../fixtures/test-base";
  * interactions (open the page, inspect sections, open the create dialog).
  */
 test.describe("Utility Agents settings page", () => {
-  test("renders the default for an empty unconfigured built-in action", async ({
+  test("renders the default for an inherited built-in action", async ({
     testPage,
     apiClient,
     seedData,
@@ -54,7 +54,7 @@ test.describe("Utility Agents settings page", () => {
               agent_id: "",
               model: "",
               agent_profile_id: "",
-              profile_binding_state: "unconfigured",
+              profile_binding_state: "inherit",
             },
           ],
         }),

--- a/docs/decisions/2026-08-12-built-in-utility-default-inheritance.md
+++ b/docs/decisions/2026-08-12-built-in-utility-default-inheritance.md
@@ -1,0 +1,44 @@
+# ADR-2026-08-12-built-in-utility-default-inheritance: Built-in Utility Actions Inherit the Global Profile by Default
+
+**Status:** accepted
+**Date:** 2026-08-12
+**Area:** backend, frontend
+
+## Context
+
+Profile-backed utility agents can represent an action without a concrete profile override by using
+the global default utility profile. The current migration and dependency cleanup paths can instead
+mark a built-in action `unconfigured`, so the Utility Agents page shows an unavailable profile even
+when a valid default is selected. The system needs to distinguish an empty built-in override from a
+stale concrete profile binding so default inheritance remains convenient without weakening the
+fail-closed behavior for deleted or disabled profiles.
+
+## Decision
+
+Built-in utility actions with no concrete profile ID use `inherit` and resolve the saved global
+default utility profile. Legacy built-in rows with empty, unmatched, or ambiguous agent/model values
+are normalized to `inherit`; custom rows with those migration results remain `unconfigured`.
+
+When an explicit profile binding is deleted, the binding keeps its stale profile ID and becomes
+`unconfigured`. When the global default profile is deleted, inherited built-in rows remain inherited.
+The UI displays the selected default for inherited actions, while concrete stale bindings remain
+visible as unavailable and execution continues to fail closed until repaired.
+
+## Consequences
+
+- Existing built-in actions recover automatically from ambiguous legacy data and from replacement of
+  the global default.
+- Selecting a default profile is sufficient for the normal built-in action path; users do not need
+  to edit every action row.
+- Explicit stale bindings remain diagnosable and do not silently change permissions, models, or
+  credentials.
+- Migration and dependency tests must cover both empty inherited rows and stale concrete IDs.
+
+## Alternatives Considered
+
+1. **Keep every ambiguous built-in row unconfigured.** Rejected because built-in actions have a
+   documented global-default path, and this leaves valid installations showing unusable controls.
+2. **Make every unconfigured row inherit the default.** Rejected because it would erase the
+   fail-closed distinction for an explicitly deleted or disabled profile.
+3. **Select the first eligible profile during migration.** Rejected because matching profiles can
+   carry different models, permissions, flags, wrappers, or credentials.

--- a/docs/decisions/2026-08-12-built-in-utility-default-inheritance.md
+++ b/docs/decisions/2026-08-12-built-in-utility-default-inheritance.md
@@ -15,9 +15,12 @@ fail-closed behavior for deleted or disabled profiles.
 
 ## Decision
 
-Built-in utility actions with no concrete profile ID use `inherit` and resolve the saved global
-default utility profile. Legacy built-in rows with empty, unmatched, or ambiguous agent/model values
-are normalized to `inherit`; custom rows with those migration results remain `unconfigured`.
+Built-in utility actions with a persisted `inherit` state and no concrete profile ID resolve the
+saved global default utility profile. Legacy built-in rows still in the migration state's `explicit`
+form with empty, unmatched, or ambiguous agent/model values are normalized to `inherit`; custom rows
+with those migration results remain `unconfigured`. Existing `unconfigured` rows are preserved and
+fail closed, including when their ID is empty, because an older release could have erased the ID of a
+deleted explicit binding and its original intent cannot be recovered safely.
 
 When an explicit profile binding is deleted, the binding keeps its stale profile ID and becomes
 `unconfigured`. When the global default profile is deleted, inherited built-in rows remain inherited.
@@ -26,19 +29,21 @@ visible as unavailable and execution continues to fail closed until repaired.
 
 ## Consequences
 
-- Existing built-in actions recover automatically from ambiguous legacy data and from replacement of
-  the global default.
+- Legacy built-in actions still in the migration state recover automatically from ambiguous data, and
+  inherited actions recover automatically from replacement of the global default.
 - Selecting a default profile is sufficient for the normal built-in action path; users do not need
   to edit every action row.
 - Explicit stale bindings remain diagnosable and do not silently change permissions, models, or
   credentials.
+- Ambiguous empty `unconfigured` rows from older releases remain unavailable until repaired instead
+  of risking a silent permission or model change.
 - Migration and dependency tests must cover both empty inherited rows and stale concrete IDs.
 
 ## Alternatives Considered
 
-1. **Keep every ambiguous built-in row unconfigured.** Rejected because built-in actions have a
-   documented global-default path, and this leaves valid installations showing unusable controls.
-2. **Make every unconfigured row inherit the default.** Rejected because it would erase the
-   fail-closed distinction for an explicitly deleted or disabled profile.
+1. **Keep every legacy migration row unconfigured.** Rejected because built-in rows in the migration
+   state have no recoverable concrete override when matching is ambiguous.
+2. **Make every unconfigured row inherit the default.** Rejected because older releases erased
+   deleted profile IDs, so an empty unconfigured row could be an explicit stale binding.
 3. **Select the first eligible profile during migration.** Rejected because matching profiles can
    carry different models, permissions, flags, wrappers, or credentials.

--- a/docs/decisions/INDEX.md
+++ b/docs/decisions/INDEX.md
@@ -148,4 +148,5 @@ Read individual ADRs for full context. Create new ones via `/record decision` or
 | 2026-08-10-debug-launcher-profile-selection | [Keep Debug Launches on the Production Profile](2026-08-10-debug-launcher-profile-selection.md) | accepted | backend, frontend, cli | 2026-08-10 |
 | 2026-08-10-remote-contribution-head-drift | [Separate Current Contribution and Local Checkout Histories](2026-08-10-remote-contribution-head-drift.md) | accepted | backend, frontend, protocol, GitHub, GitLab | 2026-08-10 |
 | 2026-08-11-user-owned-status-bar-visibility | [Make Status Bar Visibility a Portable User Preference](2026-08-11-user-owned-status-bar-visibility.md) | accepted | backend, frontend, protocol | 2026-08-11 |
+| 2026-08-12-built-in-utility-default-inheritance | [Built-in Utility Actions Inherit the Global Profile by Default](2026-08-12-built-in-utility-default-inheritance.md) | accepted | backend, frontend | 2026-08-12 |
 | 2026-08-10-no-em-dash-public-copy | [Keep Em Dashes Out of Public Copy](2026-08-10-no-em-dash-public-copy.md) | accepted | frontend, infra | 2026-08-10 |

--- a/docs/plans/utility-action-default-profile/plan.md
+++ b/docs/plans/utility-action-default-profile/plan.md
@@ -1,0 +1,138 @@
+---
+spec: docs/specs/agents/utility-agent-profiles.md
+created: 2026-08-12
+status: complete
+---
+
+# Implementation Plan: Default Utility Action Profiles
+
+## Overview
+
+Repair profile-backed utility actions so a built-in action without a concrete override inherits the
+selected global default. The backend will normalize legacy empty or ambiguous built-in bindings and
+preserve stale explicit IDs for fail-closed repair. The frontend will render inherited actions using
+the default label, with focused unit and desktop/mobile E2E coverage.
+
+The behavioral amendment is recorded in
+[ADR-2026-08-12-built-in-utility-default-inheritance](../../decisions/2026-08-12-built-in-utility-default-inheritance.md).
+
+---
+
+## Backend
+
+### Binding normalization and dependency cleanup
+
+- `apps/backend/internal/utility/models/models.go`: add the shared predicate for a built-in action
+  that has no concrete profile and therefore uses the default.
+- `apps/backend/internal/utility/service/service.go`: normalize legacy built-in rows with no
+  concrete profile to `inherit`, keep custom unmatched rows `unconfigured`, resolve empty built-in
+  bindings through the global default, and retain stale explicit profile IDs when a profile is
+  deleted.
+- `apps/backend/internal/backendapp/orchestrator.go`: keep inherited built-in rows inherited when
+  the deleted profile was the global default, and include effective inherited rows in dependency
+  lookup.
+- `apps/backend/internal/backendapp/services.go`: use the same effective-default predicate for
+  plugin utility-agent reads.
+
+### Backend tests
+
+- `apps/backend/internal/utility/service/service_test.go`: cover ambiguous and unmatched built-in
+  migration, inherited execution, missing default failure, custom repair state, and stale explicit
+  ID preservation.
+- Add or update the nearest backend adapter tests if the orchestrator/plugin dependency behavior is
+  not covered by service tests.
+
+---
+
+## Frontend
+
+### Utility Agents settings page
+
+- `apps/web/components/settings/utility-sections.tsx`: treat an unconfigured built-in with no
+  concrete profile ID as inherited, display the selected default, and keep only concrete stale IDs
+  in the unavailable repair state.
+- Add a small pure selection helper if needed so the empty-binding behavior is tested without a
+  React component test.
+
+### Tests and responsive behavior
+
+- `apps/web/components/settings/utility-sections.test.tsx` or the nearest existing utility settings
+  test: prove empty built-in bindings select the default and concrete stale bindings remain
+  unavailable.
+- `apps/web/e2e/tests/settings/utility-agents.spec.ts`: add a regression scenario for an
+  `unconfigured` built-in with an empty profile ID and a valid default, asserting the default label
+  is rendered and the repair copy is absent.
+- `apps/web/e2e/tests/settings/mobile-utility-agents.spec.ts`: retain the existing narrow-viewport
+  reachability coverage and assert the inherited default remains visible in the same phone layout.
+  No new mobile composition is needed because this is state normalization inside the existing
+  responsive surface.
+
+The mobile design contract is unchanged: the existing stacked action row is the phone composition,
+the profile picker remains the primary control, the card remains the single page scroll owner, and
+the picker keeps its existing viewport-contained Radix surface and touch target.
+
+---
+
+## Tests
+
+- **What:** Built-in legacy rows with zero or multiple eligible profile matches inherit the global
+  default. Custom rows remain repair-gated.
+  **File:** `apps/backend/internal/utility/service/service_test.go`.
+  **How:** table-driven service tests with a fake profile resolver and repository.
+- **What:** Inherited built-ins resolve the selected default, while no default and stale explicit
+  bindings fail closed.
+  **File:** `apps/backend/internal/utility/service/service_test.go`.
+  **How:** focused `PreparePromptRequest` tests asserting profile ID and error behavior.
+- **What:** Empty built-in UI bindings render the default and concrete stale bindings render repair
+  state.
+  **File:** `apps/web/components/settings/utility-sections.test.tsx`.
+  **How:** pure helper tests for the selection value and unavailable value.
+- **What:** The settings page preserves the default profile on desktop and phone viewports.
+  **Files:** `apps/web/e2e/tests/settings/utility-agents.spec.ts` and
+  `apps/web/e2e/tests/settings/mobile-utility-agents.spec.ts`.
+  **How:** Playwright fixtures with mocked utility-agent responses and the seeded eligible profile.
+
+---
+
+## E2E Tests
+
+- **Scenario:** GIVEN a valid default profile and a built-in action with an empty or legacy
+  `unconfigured` binding, WHEN the Utility Agents page loads, THEN the action selector shows the
+  default profile and does not show unavailable repair copy.
+  **Files:** desktop and mobile utility-agent settings specs.
+- **Scenario:** GIVEN a built-in action with a stale concrete profile ID, WHEN the page loads, THEN
+  the stale action remains visible as unavailable and does not silently switch profiles.
+  **File:** desktop utility-agent settings spec.
+
+---
+
+## Verification Results
+
+Implementation and verification are complete.
+
+- Backend migration, execution, and stale-binding checks passed: 15 utility/profilebinding tests,
+  including 11 focused migration/request/clear tests and 3 plugin adapter tests.
+- Frontend unit coverage passed: 2 files and 5 tests.
+- Web typecheck, i18n check, and i18n ratchet passed. The i18n check reported existing advisory
+  real-locale catalog parity warnings.
+- Desktop managed E2E passed: 9 tests in `utility-agents.spec.ts`.
+- Mobile managed E2E passed: 1 test in `mobile-utility-agents.spec.ts`.
+
+---
+
+## Implementation Waves And Parallel Candidates
+
+Wave 1:
+
+- [x] [task-01-backend-default-inheritance](task-01-backend-default-inheritance.md)
+
+Wave 2:
+
+- [x] [task-02-settings-default-inheritance](task-02-settings-default-inheritance.md)
+
+The tasks are sequential because the frontend regression contract depends on the backend binding
+semantics. No subagent delegation is authorized by this plan.
+
+## Open Questions
+
+None.

--- a/docs/plans/utility-action-default-profile/plan.md
+++ b/docs/plans/utility-action-default-profile/plan.md
@@ -8,10 +8,11 @@ status: complete
 
 ## Overview
 
-Repair profile-backed utility actions so a built-in action without a concrete override inherits the
-selected global default. The backend will normalize legacy empty or ambiguous built-in bindings and
-preserve stale explicit IDs for fail-closed repair. The frontend will render inherited actions using
-the default label, with focused unit and desktop/mobile E2E coverage.
+Repair profile-backed utility actions so an inherited built-in action without a concrete override
+uses the selected global default. The backend will normalize legacy migration-state rows, preserve
+ambiguous empty `unconfigured` rows for fail-closed repair, and preserve stale explicit IDs. The
+frontend will render inherited actions using the default label, with focused unit and desktop/mobile
+E2E coverage.
 
 The behavioral amendment is recorded in
 [ADR-2026-08-12-built-in-utility-default-inheritance](../../decisions/2026-08-12-built-in-utility-default-inheritance.md).
@@ -24,10 +25,10 @@ The behavioral amendment is recorded in
 
 - `apps/backend/internal/utility/models/models.go`: add the shared predicate for a built-in action
   that has no concrete profile and therefore uses the default.
-- `apps/backend/internal/utility/service/service.go`: normalize legacy built-in rows with no
-  concrete profile to `inherit`, keep custom unmatched rows `unconfigured`, resolve empty built-in
-  bindings through the global default, and retain stale explicit profile IDs when a profile is
-  deleted.
+- `apps/backend/internal/utility/service/service.go`: normalize legacy migration-state built-in rows
+  with no concrete profile to `inherit`, preserve empty `unconfigured` rows, resolve persisted
+  inherited bindings through the global default, and retain stale explicit profile IDs when a profile
+  is deleted.
 - `apps/backend/internal/backendapp/orchestrator.go`: keep inherited built-in rows inherited when
   the deleted profile was the global default, and include effective inherited rows in dependency
   lookup.
@@ -37,8 +38,8 @@ The behavioral amendment is recorded in
 ### Backend tests
 
 - `apps/backend/internal/utility/service/service_test.go`: cover ambiguous and unmatched built-in
-  migration, inherited execution, missing default failure, custom repair state, and stale explicit
-  ID preservation.
+  migration, preservation of empty unconfigured rows, inherited execution, missing default failure,
+  custom repair state, and stale explicit ID preservation.
 - Add or update the nearest backend adapter tests if the orchestrator/plugin dependency behavior is
   not covered by service tests.
 
@@ -48,9 +49,9 @@ The behavioral amendment is recorded in
 
 ### Utility Agents settings page
 
-- `apps/web/components/settings/utility-sections.tsx`: treat an unconfigured built-in with no
-  concrete profile ID as inherited, display the selected default, and keep only concrete stale IDs
-  in the unavailable repair state.
+- `apps/web/components/settings/utility-sections.tsx`: display the selected default only for an
+  inherited built-in, and keep both empty and concrete unconfigured bindings in the unavailable
+  repair state.
 - Add a small pure selection helper if needed so the empty-binding behavior is tested without a
   React component test.
 
@@ -59,9 +60,9 @@ The behavioral amendment is recorded in
 - `apps/web/components/settings/utility-sections.test.tsx` or the nearest existing utility settings
   test: prove empty built-in bindings select the default and concrete stale bindings remain
   unavailable.
-- `apps/web/e2e/tests/settings/utility-agents.spec.ts`: add a regression scenario for an
-  `unconfigured` built-in with an empty profile ID and a valid default, asserting the default label
-  is rendered and the repair copy is absent.
+- `apps/web/e2e/tests/settings/utility-agents.spec.ts`: add a regression scenario for an inherited
+  built-in with an empty profile ID and a valid default, asserting the default label is rendered and
+  the repair copy is absent.
 - `apps/web/e2e/tests/settings/mobile-utility-agents.spec.ts`: retain the existing narrow-viewport
   reachability coverage and assert the inherited default remains visible in the same phone layout.
   No new mobile composition is needed because this is state normalization inside the existing
@@ -75,16 +76,16 @@ the picker keeps its existing viewport-contained Radix surface and touch target.
 
 ## Tests
 
-- **What:** Built-in legacy rows with zero or multiple eligible profile matches inherit the global
-  default. Custom rows remain repair-gated.
+- **What:** Built-in legacy migration-state rows with zero or multiple eligible profile matches
+  inherit the global default. Empty unconfigured rows remain repair-gated, as do custom rows.
   **File:** `apps/backend/internal/utility/service/service_test.go`.
   **How:** table-driven service tests with a fake profile resolver and repository.
 - **What:** Inherited built-ins resolve the selected default, while no default and stale explicit
   bindings fail closed.
   **File:** `apps/backend/internal/utility/service/service_test.go`.
   **How:** focused `PreparePromptRequest` tests asserting profile ID and error behavior.
-- **What:** Empty built-in UI bindings render the default and concrete stale bindings render repair
-  state.
+- **What:** Inherited built-in UI bindings render the default; empty and concrete unconfigured
+  bindings render repair state.
   **File:** `apps/web/components/settings/utility-sections.test.tsx`.
   **How:** pure helper tests for the selection value and unavailable value.
 - **What:** The settings page preserves the default profile on desktop and phone viewports.
@@ -96,9 +97,11 @@ the picker keeps its existing viewport-contained Radix surface and touch target.
 
 ## E2E Tests
 
-- **Scenario:** GIVEN a valid default profile and a built-in action with an empty or legacy
-  `unconfigured` binding, WHEN the Utility Agents page loads, THEN the action selector shows the
-  default profile and does not show unavailable repair copy.
+- **Scenario:** GIVEN a valid default profile and a built-in action with an `inherit` binding and an
+  empty profile ID, WHEN the Utility Agents page loads, THEN the action selector shows the default
+  profile and does not show unavailable repair copy.
+- **Scenario:** GIVEN a built-in action with an empty `unconfigured` binding from an older release,
+  WHEN the page loads, THEN the action remains unavailable until the user repairs it.
   **Files:** desktop and mobile utility-agent settings specs.
 - **Scenario:** GIVEN a built-in action with a stale concrete profile ID, WHEN the page loads, THEN
   the stale action remains visible as unavailable and does not silently switch profiles.
@@ -110,9 +113,9 @@ the picker keeps its existing viewport-contained Radix surface and touch target.
 
 Implementation and verification are complete.
 
-- Backend migration, execution, and stale-binding checks passed: 15 utility/profilebinding tests,
-  including 11 focused migration/request/clear tests and 3 plugin adapter tests.
-- Frontend unit coverage passed: 2 files and 5 tests.
+- Backend migration, execution, and stale-binding checks passed: 17 utility/profilebinding tests,
+  including 13 focused migration/request/clear tests and 3 plugin adapter tests.
+- Frontend unit coverage passed: 2 files and 6 tests.
 - Web typecheck, i18n check, and i18n ratchet passed. The i18n check reported existing advisory
   real-locale catalog parity warnings.
 - Desktop managed E2E passed: 9 tests in `utility-agents.spec.ts`.

--- a/docs/plans/utility-action-default-profile/task-01-backend-default-inheritance.md
+++ b/docs/plans/utility-action-default-profile/task-01-backend-default-inheritance.md
@@ -12,8 +12,9 @@ spec: "../../specs/agents/utility-agent-profiles.md"
 
 Implement the amended utility-agent binding contract before changing the settings UI.
 
-- **Acceptance:** Built-in rows without a concrete profile inherit the saved default, including
-  legacy empty or ambiguous rows. Custom unmatched rows remain `unconfigured`.
+- **Acceptance:** Built-in rows in the inherited or legacy migration state without a concrete profile
+  inherit the saved default. Empty `unconfigured` rows from older releases remain fail-closed, and
+  custom unmatched rows remain `unconfigured`.
 - **Acceptance:** Deleting an explicit profile preserves its stale ID and keeps execution
   fail-closed. Deleting the global default does not convert inherited built-ins into repair state.
 - **Acceptance:** Plugin reads and utility execution use the same effective-default predicate.
@@ -39,12 +40,13 @@ Implement the amended utility-agent binding contract before changing the setting
 
 ## Results
 
-Implemented the shared empty-built-in predicate, legacy normalization, default-backed execution,
-stale explicit-ID preservation, and default-aware plugin/dependency reads. Deleting a global default
-no longer rewrites inherited built-ins into repair state.
+Implemented the shared inherited-built-in predicate, legacy migration normalization, default-backed
+execution, stale explicit-ID preservation, and default-aware plugin/dependency reads. Empty
+`unconfigured` rows remain fail-closed because older releases could erase deleted profile IDs.
+Deleting a global default no longer rewrites inherited built-ins into repair state.
 
 Verification:
 
-- `cd apps/backend && go test -run 'Test(MigrateLegacyBindings|PreparePromptRequest|ClearAgentProfileBindings)' ./internal/utility/service/...` (pass: 11 tests)
-- `cd apps/backend && go test ./internal/utility/service/... ./internal/utility/profilebinding/...` (pass: 15 tests)
+- `cd apps/backend && go test -run 'Test(MigrateLegacyBindings|PreparePromptRequest|ClearAgentProfileBindings)' ./internal/utility/service/...` (pass: 13 tests)
+- `cd apps/backend && go test ./internal/utility/service/... ./internal/utility/profilebinding/...` (pass: 17 tests)
 - `cd apps/backend && go test -run 'TestPluginsUtilityAgentAdapter' ./internal/backendapp` (pass: 3 tests)

--- a/docs/plans/utility-action-default-profile/task-01-backend-default-inheritance.md
+++ b/docs/plans/utility-action-default-profile/task-01-backend-default-inheritance.md
@@ -1,0 +1,50 @@
+---
+id: "01-backend-default-inheritance"
+title: "Repair backend default inheritance"
+status: done
+wave: 1
+depends_on: []
+plan: "plan.md"
+spec: "../../specs/agents/utility-agent-profiles.md"
+---
+
+# Task 01: Repair backend default inheritance
+
+Implement the amended utility-agent binding contract before changing the settings UI.
+
+- **Acceptance:** Built-in rows without a concrete profile inherit the saved default, including
+  legacy empty or ambiguous rows. Custom unmatched rows remain `unconfigured`.
+- **Acceptance:** Deleting an explicit profile preserves its stale ID and keeps execution
+  fail-closed. Deleting the global default does not convert inherited built-ins into repair state.
+- **Acceptance:** Plugin reads and utility execution use the same effective-default predicate.
+- **Verification:** Add the failing service tests first, then run:
+
+  ```bash
+  cd apps/backend
+  go test -run 'Test(MigrateLegacyBindings|PreparePromptRequest|ClearAgentProfileBindings)' ./internal/utility/service/...
+  go test ./internal/utility/service/... ./internal/utility/profilebinding/...
+  ```
+
+- **Files likely touched:** `apps/backend/internal/utility/models/models.go`,
+  `apps/backend/internal/utility/service/service.go`,
+  `apps/backend/internal/utility/service/service_test.go`,
+  `apps/backend/internal/backendapp/orchestrator.go`, and
+  `apps/backend/internal/backendapp/services.go`.
+- **Dependencies:** None.
+- **Parallelism:** sequential.
+- **Inputs:** The amended legacy migration, failure-mode, persistence, and scenario sections in
+  `docs/specs/agents/utility-agent-profiles.md`, plus ADR-2026-08-12-built-in-utility-default-inheritance.
+- **Output contract:** Report the backend files changed, exact test commands and results, stale-ID
+  and default-deletion behavior, and synchronized task/plan status.
+
+## Results
+
+Implemented the shared empty-built-in predicate, legacy normalization, default-backed execution,
+stale explicit-ID preservation, and default-aware plugin/dependency reads. Deleting a global default
+no longer rewrites inherited built-ins into repair state.
+
+Verification:
+
+- `cd apps/backend && go test -run 'Test(MigrateLegacyBindings|PreparePromptRequest|ClearAgentProfileBindings)' ./internal/utility/service/...` (pass: 11 tests)
+- `cd apps/backend && go test ./internal/utility/service/... ./internal/utility/profilebinding/...` (pass: 15 tests)
+- `cd apps/backend && go test -run 'TestPluginsUtilityAgentAdapter' ./internal/backendapp` (pass: 3 tests)

--- a/docs/plans/utility-action-default-profile/task-02-settings-default-inheritance.md
+++ b/docs/plans/utility-action-default-profile/task-02-settings-default-inheritance.md
@@ -12,8 +12,9 @@ spec: "../../specs/agents/utility-agent-profiles.md"
 
 Update the Utility Agents page after the backend contract is in place.
 
-- **Acceptance:** A built-in action with no concrete profile ID renders the selected default in its
-  profile picker, including the legacy `unconfigured` response used during repair.
+- **Acceptance:** A built-in action with an `inherit` binding and no concrete profile ID renders the
+  selected default in its profile picker. Empty and concrete `unconfigured` bindings remain
+  unavailable for repair.
 - **Acceptance:** A built-in action with a concrete stale profile ID remains unavailable and keeps
   its repair state. Explicit profile selection and shared Settings save/discard behavior remain
   unchanged.
@@ -48,15 +49,15 @@ Update the Utility Agents page after the backend contract is in place.
 
 ## Results
 
-Implemented the settings picker selection helper so empty built-in bindings use the default
-sentinel, while concrete unconfigured profile IDs remain unavailable for repair. The desktop and
-mobile regression scenarios both exercise an empty `unconfigured` built-in response with the saved
-default profile; the mobile test selects the concrete profile option by ID so duplicate display
+Implemented the settings picker selection helper so inherited empty built-in bindings use the
+default sentinel, while empty and concrete unconfigured profile IDs remain unavailable for repair.
+The desktop and mobile regression scenarios exercise an inherited empty built-in response with the
+saved default profile; the mobile test selects the concrete profile option by ID so duplicate display
 labels do not make the interaction ambiguous.
 
 Verification:
 
-- `cd apps && pnpm --filter @kandev/web test -- --run components/settings/utility-sections.test.tsx components/settings/utility-agents-section.test.ts` (pass: 2 files, 5 tests)
+- `cd apps && pnpm --filter @kandev/web test -- --run components/settings/utility-sections.test.tsx components/settings/utility-agents-section.test.ts` (pass: 2 files, 6 tests)
 - `cd apps/web && pnpm run typecheck` (pass)
 - `cd apps/web && pnpm run i18n:check` (pass; existing real-locale parity warnings are advisory)
 - `cd apps/web && pnpm run i18n:ratchet` (pass)

--- a/docs/plans/utility-action-default-profile/task-02-settings-default-inheritance.md
+++ b/docs/plans/utility-action-default-profile/task-02-settings-default-inheritance.md
@@ -1,0 +1,64 @@
+---
+id: "02-settings-default-inheritance"
+title: "Render inherited action profiles"
+status: done
+wave: 2
+depends_on: ["01-backend-default-inheritance"]
+plan: "plan.md"
+spec: "../../specs/agents/utility-agent-profiles.md"
+---
+
+# Task 02: Render inherited action profiles
+
+Update the Utility Agents page after the backend contract is in place.
+
+- **Acceptance:** A built-in action with no concrete profile ID renders the selected default in its
+  profile picker, including the legacy `unconfigured` response used during repair.
+- **Acceptance:** A built-in action with a concrete stale profile ID remains unavailable and keeps
+  its repair state. Explicit profile selection and shared Settings save/discard behavior remain
+  unchanged.
+- **Acceptance:** Desktop and phone layouts keep the selector and edit action reachable without
+  introducing horizontal overflow.
+- **Verification:** Bootstrap a fresh worktree if needed, then run:
+
+  ```bash
+  cd apps
+  pnpm install --frozen-lockfile
+  pnpm --filter @kandev/web test -- --run components/settings/utility-sections.test.tsx components/settings/utility-agents-section.test.ts
+  cd web
+  pnpm run typecheck
+  pnpm run i18n:check
+  pnpm run i18n:ratchet
+  pnpm e2e:run --project chromium tests/settings/utility-agents.spec.ts
+  pnpm e2e:run --project mobile-chrome tests/settings/mobile-utility-agents.spec.ts
+  ```
+
+- **Files likely touched:** `apps/web/components/settings/utility-sections.tsx`,
+  `apps/web/components/settings/utility-sections.test.tsx`,
+  `apps/web/e2e/tests/settings/utility-agents.spec.ts`, and
+  `apps/web/e2e/tests/settings/mobile-utility-agents.spec.ts`.
+- **Dependencies:** Task 01.
+- **Parallelism:** sequential.
+- **Inputs:** The Utility Agents settings scenarios and mobile scenario in
+  `docs/specs/agents/utility-agent-profiles.md`, the existing stacked action-row mobile test, and
+  the shared `UtilityAgentProfilePicker`.
+- **Output contract:** Report rendered inherited and stale states, desktop/mobile checks, exact
+  commands and results, and synchronized task/plan status. Do not add new copy unless existing
+  localized strings are insufficient.
+
+## Results
+
+Implemented the settings picker selection helper so empty built-in bindings use the default
+sentinel, while concrete unconfigured profile IDs remain unavailable for repair. The desktop and
+mobile regression scenarios both exercise an empty `unconfigured` built-in response with the saved
+default profile; the mobile test selects the concrete profile option by ID so duplicate display
+labels do not make the interaction ambiguous.
+
+Verification:
+
+- `cd apps && pnpm --filter @kandev/web test -- --run components/settings/utility-sections.test.tsx components/settings/utility-agents-section.test.ts` (pass: 2 files, 5 tests)
+- `cd apps/web && pnpm run typecheck` (pass)
+- `cd apps/web && pnpm run i18n:check` (pass; existing real-locale parity warnings are advisory)
+- `cd apps/web && pnpm run i18n:ratchet` (pass)
+- `cd apps/web && pnpm e2e:run --project chromium tests/settings/utility-agents.spec.ts` (pass: 9 tests)
+- `cd apps/web && pnpm e2e:run --project mobile-chrome tests/settings/mobile-utility-agents.spec.ts` (pass: 1 test)

--- a/docs/specs/agents/utility-agent-profiles.md
+++ b/docs/specs/agents/utility-agent-profiles.md
@@ -66,8 +66,11 @@ permission choice that its caller cannot answer.
 
 `inherit` is valid only for built-in rows. `explicit` requires an eligible profile. `unconfigured`
 is used for a custom row without a profile and for a built-in row whose concrete profile binding is
-stale or unavailable. A built-in row with no concrete profile ID, including an empty, ambiguous, or
-unmatched legacy binding, is normalized to `inherit` so it uses the selected default utility profile.
+stale or unavailable. Only a built-in row whose persisted state is `inherit` uses the selected
+default. A legacy built-in row still in the migration state's `explicit` form with no concrete
+profile ID is normalized to `inherit`. An empty `unconfigured` row remains fail-closed because an
+older release could have erased the ID of a deleted explicit binding, making that row's original
+intent impossible to recover safely.
 
 The legacy `agent_id` and `model` columns may remain temporarily as migration inputs, but they are
 not execution inputs after this feature ships and are not writable through the utility-agent API.
@@ -88,11 +91,14 @@ non-deleted, non-passthrough global profiles whose parent agent matches the lega
 and whose configured model matches the legacy model (including an explicit empty model). Exactly
 one match is copied to `agent_profile_id` and sets the row state to `explicit`.
 
-Zero matches or multiple matches set a custom row to `unconfigured`. A built-in row with no concrete
-profile ID becomes `inherit`. The backend does not pick the first profile, infer from a display name,
-or silently use a provider default. Custom utility agents that cannot be migrated remain stored and
-editable but are not executable until the user selects a profile. The legacy values remain available
-to a later retry or diagnostic report, but the new state is authoritative after the migration.
+Zero matches or multiple matches set a custom row to `unconfigured`. A built-in row in the legacy
+`explicit` migration state with no concrete profile ID becomes `inherit`. Existing `unconfigured`
+rows are not remigrated: an older release could have erased the ID of a deleted explicit binding,
+so an empty `unconfigured` row remains fail-closed until the user repairs it. The backend does not
+pick the first profile, infer from a display name, or silently use a provider default. Custom utility
+agents that cannot be migrated remain stored and editable but are not executable until the user
+selects a profile. The legacy values remain available to a later retry or diagnostic report, but the
+new state is authoritative after the migration.
 
 ## API surface
 
@@ -127,9 +133,10 @@ to a later retry or diagnostic report, but the new state is authoritative after 
 - With no effective profile, invocation fails before a call is dispatched and tells the user to
   select a profile in Settings > Utility Agents.
 - A missing, deleted, disabled, CLI-passthrough, workspace-scoped, or non-inference-capable
-  concrete profile binding fails closed. An inherited built-in action uses the saved global default
-  only. The backend never falls back to another profile, the active task profile, a raw agent/model
-  pair, or the first available agent.
+  concrete profile binding fails closed. An unconfigured binding also fails closed when its profile
+  ID is empty because its origin may be an older deleted override. Only an inherited built-in action
+  uses the saved global default. The backend never falls back to another profile, the active task
+  profile, a raw agent/model pair, or the first available agent.
 - A profile launch-policy error (invalid command prefix, unresolved required secret, invalid config
   option, or unavailable agent runtime) is surfaced as the utility call failure. The runner does not
   retry without that setting.
@@ -151,6 +158,9 @@ to a later retry or diagnostic report, but the new state is authoritative after 
   The warning dialog is confirmation only; it does not perform reassignment. Built-in actions that
   inherit the default remain inherited when the default profile is deleted, so selecting a new
   default repairs them without editing each action.
+- Built-in rows left as empty `unconfigured` by an older release remain fail-closed because their
+  original explicit-versus-inherited intent cannot be reconstructed safely. Selecting the default
+  in the action picker repairs the row by persisting `inherit`.
 - Utility call history retains the effective profile ID and resolved model even if the profile is
   later edited or deleted.
 
@@ -187,10 +197,15 @@ to a later retry or diagnostic report, but the new state is authoritative after 
 - **GIVEN** a legacy agent/model selection that matches exactly one eligible profile, **WHEN** the
   backend upgrades, **THEN** that profile becomes the saved selection and utility behavior is
   preserved with the profile's launch policy.
-- **GIVEN** a legacy built-in action agent/model selection that matches zero or multiple eligible
-  profiles, **WHEN** the backend upgrades, **THEN** the row state becomes `inherit` and the action
-  uses the selected default utility profile. A custom utility agent with the same migration result
-  becomes `unconfigured` and remains unavailable until the user chooses a profile.
+- **GIVEN** a legacy built-in action still has the migration state's explicit binding with an empty
+  profile ID and its agent/model selection matches zero or multiple eligible profiles, **WHEN** the
+  backend upgrades, **THEN** the row state becomes `inherit` and the action uses the selected default
+  utility profile. A custom utility agent with the same migration result becomes `unconfigured` and
+  remains unavailable until the user chooses a profile.
+- **GIVEN** an older release left a built-in action `unconfigured` with an empty profile ID after
+  deleting or clearing a binding, **WHEN** the backend upgrades, **THEN** the row remains
+  `unconfigured` and fails closed until the user repairs the action because its original intent is
+  ambiguous.
 - **GIVEN** an inherited built-in action and a deleted default profile, **WHEN** the user selects a
   new eligible default profile, **THEN** the action uses the new default without an action-level
   edit.

--- a/docs/specs/agents/utility-agent-profiles.md
+++ b/docs/specs/agents/utility-agent-profiles.md
@@ -10,7 +10,11 @@ Decision: [ADR-2026-08-08-utility-agent-profile-execution](../../decisions/2026-
 
 Safety decision: [ADR-2026-08-08-utility-profile-dependency-safety](../../decisions/2026-08-08-utility-profile-dependency-safety.md)
 
+Default inheritance repair: [ADR-2026-08-12-built-in-utility-default-inheritance](../../decisions/2026-08-12-built-in-utility-default-inheritance.md)
+
 Implementation plan: [utility-agent-profiles](../../plans/utility-agent-profiles/plan.md)
+
+Repair plan: [utility-action-default-profile](../../plans/utility-action-default-profile/plan.md)
 
 ## Why
 
@@ -27,8 +31,9 @@ permission choice that its caller cannot answer.
   profile as an override.
 - Every custom utility agent selects one concrete profile. A custom utility agent cannot be created
   or saved without a profile.
-- A built-in utility action can also be **unconfigured** after an ambiguous legacy migration. It
-  cannot run until the user selects a profile or chooses to inherit the default.
+- A built-in utility action without a concrete profile override inherits the default utility
+  profile. A stale concrete override remains **unconfigured** after its profile is deleted or
+  disabled and cannot run until the user repairs it.
 - Eligible choices are enabled, non-deleted, global profiles for ACP inference-capable agents.
   CLI-passthrough profiles and workspace-scoped Office profiles are not eligible.
 - A utility invocation resolves its effective profile at the start of the call. It uses that
@@ -56,12 +61,13 @@ permission choice that its caller cannot answer.
 
 | Field              | Type   | Constraint                   | Meaning                                                                        |
 | ------------------ | ------ | ---------------------------- | ------------------------------------------------------------------------------ |
-| `agent_profile_id` | string | empty unless state is `explicit` | Concrete profile reference. |
+| `agent_profile_id` | string | empty for `inherit`, required for `explicit`, retained for stale `unconfigured` bindings | Concrete profile reference. |
 | `profile_binding_state` | enum | `inherit`, `explicit`, or `unconfigured` | Whether the row inherits the default, names a profile, or needs repair. |
 
 `inherit` is valid only for built-in rows. `explicit` requires an eligible profile. `unconfigured`
-is used for a custom row without a profile and for a built-in row whose legacy binding was ambiguous
-or unmatched. This state prevents an empty legacy value from silently becoming default inheritance.
+is used for a custom row without a profile and for a built-in row whose concrete profile binding is
+stale or unavailable. A built-in row with no concrete profile ID, including an empty, ambiguous, or
+unmatched legacy binding, is normalized to `inherit` so it uses the selected default utility profile.
 
 The legacy `agent_id` and `model` columns may remain temporarily as migration inputs, but they are
 not execution inputs after this feature ships and are not writable through the utility-agent API.
@@ -82,12 +88,11 @@ non-deleted, non-passthrough global profiles whose parent agent matches the lega
 and whose configured model matches the legacy model (including an explicit empty model). Exactly
 one match is copied to `agent_profile_id` and sets the row state to `explicit`.
 
-Zero matches or multiple matches set the row state to `unconfigured`. The backend does not pick the
-first profile, infer from a display name, or silently use a provider default. A built-in row with this
-state does not inherit the default until the user explicitly chooses inheritance. Custom utility
-agents that cannot be migrated remain stored and editable but are not executable until the user
-selects a profile. The legacy values remain available to a later retry or diagnostic report, but the
-new state is authoritative after the migration.
+Zero matches or multiple matches set a custom row to `unconfigured`. A built-in row with no concrete
+profile ID becomes `inherit`. The backend does not pick the first profile, infer from a display name,
+or silently use a provider default. Custom utility agents that cannot be migrated remain stored and
+editable but are not executable until the user selects a profile. The legacy values remain available
+to a later retry or diagnostic report, but the new state is authoritative after the migration.
 
 ## API surface
 
@@ -121,9 +126,10 @@ new state is authoritative after the migration.
 
 - With no effective profile, invocation fails before a call is dispatched and tells the user to
   select a profile in Settings > Utility Agents.
-- A missing, deleted, disabled, CLI-passthrough, workspace-scoped, or non-inference-capable profile
-  fails closed. The backend never falls back to another profile, the active task profile, a raw
-  agent/model pair, or the first available agent.
+- A missing, deleted, disabled, CLI-passthrough, workspace-scoped, or non-inference-capable
+  concrete profile binding fails closed. An inherited built-in action uses the saved global default
+  only. The backend never falls back to another profile, the active task profile, a raw agent/model
+  pair, or the first available agent.
 - A profile launch-policy error (invalid command prefix, unresolved required secret, invalid config
   option, or unavailable agent runtime) is surfaced as the utility call failure. The runner does not
   retry without that setting.
@@ -140,9 +146,11 @@ new state is authoritative after the migration.
   backend-owned settings/database storage.
 - Profile edits are not copied into utility-agent rows. Each new invocation reads the current
   profile; already-running calls keep their start-time resolution.
-- Disabling or deleting a selected profile does not rewrite the selection to another profile. The
-  stale ID remains diagnosable and invocation fails closed until the user repairs it. The warning
-  dialog is confirmation only; it does not perform reassignment.
+- Disabling or deleting a selected explicit profile does not rewrite the selection to another
+  profile. The stale ID remains diagnosable and invocation fails closed until the user repairs it.
+  The warning dialog is confirmation only; it does not perform reassignment. Built-in actions that
+  inherit the default remain inherited when the default profile is deleted, so selecting a new
+  default repairs them without editing each action.
 - Utility call history retains the effective profile ID and resolved model even if the profile is
   later edited or deleted.
 
@@ -179,10 +187,13 @@ new state is authoritative after the migration.
 - **GIVEN** a legacy agent/model selection that matches exactly one eligible profile, **WHEN** the
   backend upgrades, **THEN** that profile becomes the saved selection and utility behavior is
   preserved with the profile's launch policy.
-- **GIVEN** a legacy agent/model selection that matches zero or multiple eligible profiles, **WHEN**
-  the backend upgrades, **THEN** the row state becomes `unconfigured`, the legacy values remain
-  available for migration diagnostics, and no utility action runs until the user chooses a profile
-  or explicitly chooses default inheritance for a built-in action.
+- **GIVEN** a legacy built-in action agent/model selection that matches zero or multiple eligible
+  profiles, **WHEN** the backend upgrades, **THEN** the row state becomes `inherit` and the action
+  uses the selected default utility profile. A custom utility agent with the same migration result
+  becomes `unconfigured` and remains unavailable until the user chooses a profile.
+- **GIVEN** an inherited built-in action and a deleted default profile, **WHEN** the user selects a
+  new eligible default profile, **THEN** the action uses the new default without an action-level
+  edit.
 - **GIVEN** Settings > Utility Agents on a phone viewport, **WHEN** the user changes the default or an
   action override, **THEN** the full profile name and save state remain reachable without horizontal
   page overflow or a desktop-only interaction.


### PR DESCRIPTION
Utility action rows could become unavailable after startup cleanup or default-profile deletion even when they had no concrete override. Built-in actions without a concrete profile now inherit the saved global default across migration, execution, plugin reads, and settings UI, while stale concrete bindings remain fail-closed for repair.

## Important Changes

- Added one backend predicate for effective default-profile inheritance and applied it to migration, execution, dependency lookup, and plugin adapters.
- Preserved stale explicit profile IDs when profiles are deleted, while keeping inherited built-ins inherited after default deletion.
- Updated the Utility Agents picker and desktop/mobile regressions for empty legacy bindings and concrete stale bindings.

## Validation

- `cd apps/backend && go test -run 'Test(MigrateLegacyBindings|PreparePromptRequest|ClearAgentProfileBindings)' ./internal/utility/service/...` (11 passed)
- `cd apps/backend && go test ./internal/utility/service/... ./internal/utility/profilebinding/...` (15 passed)
- `cd apps/backend && go test -run 'TestPluginsUtilityAgentAdapter' ./internal/backendapp` (3 passed)
- `cd apps && pnpm --filter @kandev/web test -- --run components/settings/utility-sections.test.tsx components/settings/utility-agents-section.test.ts` (5 passed)
- `cd apps/web && pnpm run typecheck && pnpm run i18n:check && pnpm run i18n:ratchet`
- Managed E2E: `pnpm e2e:run --project chromium tests/settings/utility-agents.spec.ts` (9 passed) and `pnpm e2e:run --project mobile-chrome tests/settings/mobile-utility-agents.spec.ts` (1 passed)
- Fresh compressed desktop and mobile screenshots captured with synthetic seeded data.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2559?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- kandev-screenshots-start -->
## Screenshots

![Utility Agents default inheritance on desktop](https://raw.githubusercontent.com/kdlbs/kandev/07b6074abd5e4d9d43d26f7e6e3555fafc06ad3a/pr-utility-profile-default--desktop-utility-default.png)

![Utility Agents default inheritance on mobile](https://raw.githubusercontent.com/kdlbs/kandev/07b6074abd5e4d9d43d26f7e6e3555fafc06ad3a/pr-utility-profile-default--mobile-utility-default.png)
<!-- kandev-screenshots-end -->