### PR TITLE
feat: publish Auggie token usage from disk to Token Grotto

### DIFF
--- a/apps/backend/internal/agent/auggieusage/session_file.go
+++ b/apps/backend/internal/agent/auggieusage/session_file.go
@@ -1,0 +1,145 @@
+// Package auggieusage reads privacy-safe token usage from Augment/Auggie
+// on-disk session files (~/.augment/sessions/<acpSessionId>.json).
+//
+// It never returns prompts, tool args, or response text. Callers publish
+// deltas through the existing session_prompt_usage bus (see docs/specs/office/costs.md).
+package auggieusage
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// ExchangeUsage is one completed chatHistory exchange with token totals only.
+type ExchangeUsage struct {
+	SequenceID int
+	ModelID    string
+	FinishedAt time.Time
+	Input      int64
+	Output     int64
+	CacheRead  int64
+	CacheWrite int64
+}
+
+// SessionPath returns ~/.augment/sessions/<acpSessionID>.json for homeDir.
+// homeDir should be the user home (empty uses os.UserHomeDir).
+func SessionPath(homeDir, acpSessionID string) (string, error) {
+	if acpSessionID == "" {
+		return "", errors.New("auggieusage: empty ACP session id")
+	}
+	if homeDir == "" {
+		var err error
+		homeDir, err = os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("auggieusage: home dir: %w", err)
+		}
+	}
+	return filepath.Join(homeDir, ".augment", "sessions", acpSessionID+".json"), nil
+}
+
+// ReadNewExchangeUsages loads sessionFile and returns completed exchanges with
+// sequenceId > afterSequence. Content fields are decoded only to reach token
+// nodes and are discarded from the returned values.
+func ReadNewExchangeUsages(sessionFile string, afterSequence int) ([]ExchangeUsage, error) {
+	raw, err := os.ReadFile(sessionFile)
+	if err != nil {
+		return nil, err
+	}
+	var file sessionFileDoc
+	if err := json.Unmarshal(raw, &file); err != nil {
+		return nil, fmt.Errorf("auggieusage: decode %s: %w", filepath.Base(sessionFile), err)
+	}
+	fallbackModel := file.AgentState.ModelID
+	out := make([]ExchangeUsage, 0)
+	for _, item := range file.ChatHistory {
+		if !item.Completed || item.SequenceID <= afterSequence {
+			continue
+		}
+		eu := ExchangeUsage{
+			SequenceID: item.SequenceID,
+			ModelID:    item.Exchange.ModelID,
+			FinishedAt: parseFinishedAt(item.FinishedAt),
+		}
+		if eu.ModelID == "" {
+			eu.ModelID = fallbackModel
+		}
+		for _, node := range item.Exchange.ResponseNodes {
+			if node.TokenUsage == nil {
+				continue
+			}
+			tu := node.TokenUsage
+			eu.Input += tu.InputTokens
+			eu.Output += tu.OutputTokens
+			eu.CacheRead += tu.CacheReadInputTokens
+			eu.CacheWrite += tu.CacheCreationInputTokens
+		}
+		out = append(out, eu)
+	}
+	return out, nil
+}
+
+// SumExchanges aggregates exchange token counts and returns the last model id.
+func SumExchanges(exchanges []ExchangeUsage) (input, output, cacheRead, cacheWrite int64, model string, maxSeq int) {
+	for _, ex := range exchanges {
+		input += ex.Input
+		output += ex.Output
+		cacheRead += ex.CacheRead
+		cacheWrite += ex.CacheWrite
+		if ex.SequenceID > maxSeq {
+			maxSeq = ex.SequenceID
+		}
+		if ex.ModelID != "" {
+			model = ex.ModelID
+		}
+	}
+	return input, output, cacheRead, cacheWrite, model, maxSeq
+}
+
+type sessionFileDoc struct {
+	AgentState  agentStateDoc `json:"agentState"`
+	ChatHistory []historyItem `json:"chatHistory"`
+}
+
+type agentStateDoc struct {
+	ModelID string `json:"modelId"`
+}
+
+type historyItem struct {
+	SequenceID int         `json:"sequenceId"`
+	Completed  bool        `json:"completed"`
+	FinishedAt string      `json:"finishedAt"`
+	Exchange   exchangeDoc `json:"exchange"`
+}
+
+type exchangeDoc struct {
+	ModelID       string         `json:"model_id"`
+	ResponseNodes []responseNode `json:"response_nodes"`
+}
+
+type responseNode struct {
+	TokenUsage *tokenUsageDoc `json:"token_usage"`
+}
+
+type tokenUsageDoc struct {
+	InputTokens              int64 `json:"input_tokens"`
+	OutputTokens             int64 `json:"output_tokens"`
+	CacheReadInputTokens     int64 `json:"cache_read_input_tokens"`
+	CacheCreationInputTokens int64 `json:"cache_creation_input_tokens"`
+}
+
+func parseFinishedAt(raw string) time.Time {
+	if raw == "" {
+		return time.Time{}
+	}
+	if t, err := time.Parse(time.RFC3339Nano, raw); err == nil {
+		return t.UTC()
+	}
+	if t, err := time.Parse(time.RFC3339, raw); err == nil {
+		return t.UTC()
+	}
+	return time.Time{}
+}

--- a/apps/backend/internal/agent/auggieusage/session_file.go
+++ b/apps/backend/internal/agent/auggieusage/session_file.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -27,9 +28,10 @@ type ExchangeUsage struct {
 
 // SessionPath returns ~/.augment/sessions/<acpSessionID>.json for homeDir.
 // homeDir should be the user home (empty uses os.UserHomeDir).
+// acpSessionID must be a single path segment (no separators or "..").
 func SessionPath(homeDir, acpSessionID string) (string, error) {
-	if acpSessionID == "" {
-		return "", errors.New("auggieusage: empty ACP session id")
+	if err := validateACPSessionID(acpSessionID); err != nil {
+		return "", err
 	}
 	if homeDir == "" {
 		var err error
@@ -39,6 +41,23 @@ func SessionPath(homeDir, acpSessionID string) (string, error) {
 		}
 	}
 	return filepath.Join(homeDir, ".augment", "sessions", acpSessionID+".json"), nil
+}
+
+func validateACPSessionID(acpSessionID string) error {
+	if acpSessionID == "" {
+		return errors.New("auggieusage: empty ACP session id")
+	}
+	// ACP ids are file-stem join keys. Reject anything that could escape
+	// ~/.augment/sessions when joined (separators, parent refs, unclean forms).
+	if acpSessionID != filepath.Base(acpSessionID) ||
+		acpSessionID == "." ||
+		acpSessionID == ".." ||
+		strings.Contains(acpSessionID, string(os.PathSeparator)) ||
+		strings.Contains(acpSessionID, "/") ||
+		strings.Contains(acpSessionID, "\\") {
+		return errors.New("auggieusage: invalid ACP session id")
+	}
+	return nil
 }
 
 // ReadNewExchangeUsages loads sessionFile and returns completed exchanges with

--- a/apps/backend/internal/agent/auggieusage/session_file_test.go
+++ b/apps/backend/internal/agent/auggieusage/session_file_test.go
@@ -92,6 +92,20 @@ func TestSessionPath(t *testing.T) {
 
 	_, err = SessionPath("/tmp/home", "")
 	require.Error(t, err)
+
+	// Path traversal / multi-segment ids must not join under sessions/.
+	for _, bad := range []string{
+		"../escape",
+		"..",
+		".",
+		"a/b",
+		`a\b`,
+		"/abs",
+		"foo/../bar",
+	} {
+		_, err = SessionPath("/tmp/home", bad)
+		require.Error(t, err, "id %q", bad)
+	}
 }
 
 // Ensure returned structs have no string content fields beyond model id.

--- a/apps/backend/internal/agent/auggieusage/session_file_test.go
+++ b/apps/backend/internal/agent/auggieusage/session_file_test.go
@@ -1,0 +1,107 @@
+package auggieusage
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func fixturePath(t *testing.T, name string) string {
+	t.Helper()
+	return filepath.Join("testdata", name)
+}
+
+func TestReadNewExchangeUsages_MultiExchangeAndWatermark(t *testing.T) {
+	path := fixturePath(t, "multi_exchange.json")
+
+	all, err := ReadNewExchangeUsages(path, 0)
+	require.NoError(t, err)
+	require.Len(t, all, 2)
+
+	require.Equal(t, 1, all[0].SequenceID)
+	require.Equal(t, "claude-opus-4-8", all[0].ModelID)
+	require.Equal(t, int64(10), all[0].Input)
+	require.Equal(t, int64(20), all[0].Output)
+	require.Equal(t, int64(100), all[0].CacheRead)
+	require.Equal(t, int64(50), all[0].CacheWrite)
+	require.Equal(t, time.Date(2026, 8, 11, 10, 0, 0, 0, time.UTC), all[0].FinishedAt)
+
+	// Exchange 2 sums multiple token_usage nodes; incomplete seq 3 excluded.
+	require.Equal(t, 2, all[1].SequenceID)
+	require.Equal(t, int64(6), all[1].Input)
+	require.Equal(t, int64(10), all[1].Output)
+	require.Equal(t, int64(30), all[1].CacheRead)
+	require.Equal(t, int64(2), all[1].CacheWrite)
+
+	// Watermark after seq 1 returns only seq 2.
+	after, err := ReadNewExchangeUsages(path, 1)
+	require.NoError(t, err)
+	require.Len(t, after, 1)
+	require.Equal(t, 2, after[0].SequenceID)
+
+	// Fully consumed watermark.
+	none, err := ReadNewExchangeUsages(path, 2)
+	require.NoError(t, err)
+	require.Empty(t, none)
+
+	in, out, cr, cw, model, maxSeq := SumExchanges(all)
+	require.Equal(t, int64(16), in)
+	require.Equal(t, int64(30), out)
+	require.Equal(t, int64(130), cr)
+	require.Equal(t, int64(52), cw)
+	require.Equal(t, "claude-opus-4-8", model)
+	require.Equal(t, 2, maxSeq)
+}
+
+func TestReadNewExchangeUsages_NilTokenNodesAndFallbackModel(t *testing.T) {
+	path := fixturePath(t, "nil_token_nodes.json")
+	all, err := ReadNewExchangeUsages(path, 0)
+	require.NoError(t, err)
+	require.Len(t, all, 2)
+
+	// Seq 1 has no token_usage nodes; still returned (zeros) so watermark can advance.
+	require.Equal(t, 1, all[0].SequenceID)
+	require.Equal(t, "model-from-state", all[0].ModelID)
+	require.Zero(t, all[0].Input)
+	require.Zero(t, all[0].Output)
+
+	require.Equal(t, 2, all[1].SequenceID)
+	require.Equal(t, "model-b", all[1].ModelID)
+	require.Equal(t, int64(4), all[1].Input)
+	require.Equal(t, int64(6), all[1].Output)
+}
+
+func TestReadNewExchangeUsages_MissingFile(t *testing.T) {
+	_, err := ReadNewExchangeUsages(filepath.Join(t.TempDir(), "missing.json"), 0)
+	require.Error(t, err)
+	require.True(t, os.IsNotExist(err))
+}
+
+func TestReadNewExchangeUsages_CorruptJSON(t *testing.T) {
+	_, err := ReadNewExchangeUsages(fixturePath(t, "corrupt.json"), 0)
+	require.Error(t, err)
+}
+
+func TestSessionPath(t *testing.T) {
+	p, err := SessionPath("/tmp/home", "abc-123")
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join("/tmp/home", ".augment", "sessions", "abc-123.json"), p)
+
+	_, err = SessionPath("/tmp/home", "")
+	require.Error(t, err)
+}
+
+// Ensure returned structs have no string content fields beyond model id.
+func TestExchangeUsage_PrivacySurface(t *testing.T) {
+	var eu ExchangeUsage
+	_ = eu.SequenceID
+	_ = eu.ModelID
+	_ = eu.FinishedAt
+	_ = eu.Input
+	_ = eu.Output
+	_ = eu.CacheRead
+	_ = eu.CacheWrite
+}

--- a/apps/backend/internal/agent/auggieusage/testdata/corrupt.json
+++ b/apps/backend/internal/agent/auggieusage/testdata/corrupt.json
@@ -1,0 +1,1 @@
+{ not valid json

--- a/apps/backend/internal/agent/auggieusage/testdata/multi_exchange.json
+++ b/apps/backend/internal/agent/auggieusage/testdata/multi_exchange.json
@@ -1,0 +1,76 @@
+{
+  "sessionId": "fixture-multi",
+  "agentState": {
+    "modelId": "claude-sonnet-4-fallback"
+  },
+  "chatHistory": [
+    {
+      "sequenceId": 1,
+      "completed": true,
+      "finishedAt": "2026-08-11T10:00:00.000Z",
+      "exchange": {
+        "model_id": "claude-opus-4-8",
+        "request_message": "SCRUBBED",
+        "response_text": "SCRUBBED",
+        "response_nodes": [
+          {
+            "type": "text",
+            "text": "SCRUBBED",
+            "token_usage": {
+              "input_tokens": 10,
+              "output_tokens": 20,
+              "cache_read_input_tokens": 100,
+              "cache_creation_input_tokens": 50
+            }
+          }
+        ]
+      }
+    },
+    {
+      "sequenceId": 2,
+      "completed": true,
+      "finishedAt": "2026-08-11T10:01:00.000Z",
+      "exchange": {
+        "model_id": "claude-opus-4-8",
+        "request_message": "SCRUBBED",
+        "response_text": "SCRUBBED",
+        "response_nodes": [
+          {
+            "type": "tool",
+            "text": "SCRUBBED"
+          },
+          {
+            "type": "text",
+            "text": "SCRUBBED",
+            "token_usage": {
+              "input_tokens": 5,
+              "output_tokens": 7,
+              "cache_read_input_tokens": 30,
+              "cache_creation_input_tokens": 0
+            }
+          },
+          {
+            "type": "text",
+            "text": "SCRUBBED",
+            "token_usage": {
+              "input_tokens": 1,
+              "output_tokens": 3,
+              "cache_read_input_tokens": 0,
+              "cache_creation_input_tokens": 2
+            }
+          }
+        ]
+      }
+    },
+    {
+      "sequenceId": 3,
+      "completed": false,
+      "finishedAt": "2026-08-11T10:02:00.000Z",
+      "exchange": {
+        "model_id": "claude-opus-4-8",
+        "request_message": "SCRUBBED",
+        "response_nodes": []
+      }
+    }
+  ]
+}

--- a/apps/backend/internal/agent/auggieusage/testdata/nil_token_nodes.json
+++ b/apps/backend/internal/agent/auggieusage/testdata/nil_token_nodes.json
@@ -1,0 +1,42 @@
+{
+  "sessionId": "fixture-nil-nodes",
+  "agentState": {
+    "modelId": "model-from-state"
+  },
+  "chatHistory": [
+    {
+      "sequenceId": 1,
+      "completed": true,
+      "finishedAt": "2026-08-11T12:00:00.000Z",
+      "exchange": {
+        "model_id": "",
+        "request_message": "SCRUBBED",
+        "response_nodes": [
+          { "type": "text", "text": "SCRUBBED" },
+          { "type": "tool", "text": "SCRUBBED" }
+        ]
+      }
+    },
+    {
+      "sequenceId": 2,
+      "completed": true,
+      "finishedAt": "2026-08-11T12:01:00.000Z",
+      "exchange": {
+        "model_id": "model-b",
+        "request_message": "SCRUBBED",
+        "response_nodes": [
+          {
+            "type": "text",
+            "text": "SCRUBBED",
+            "token_usage": {
+              "input_tokens": 4,
+              "output_tokens": 6,
+              "cache_read_input_tokens": 1,
+              "cache_creation_input_tokens": 2
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/apps/backend/internal/orchestrator/auggie_kandy_compat_probe_test.go
+++ b/apps/backend/internal/orchestrator/auggie_kandy_compat_probe_test.go
@@ -1,0 +1,77 @@
+package orchestrator
+
+import (
+	"encoding/json"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kandev/kandev/internal/agent/runtime/lifecycle"
+	"github.com/kandev/kandev/internal/agentctl/types/streams"
+)
+
+// Kandy Token Grotto's normalizeTokenUsage (plugin) requires:
+// - usage map with integer-ish float64 fields (json numbers)
+// - timestamp parseable as RFC3339Nano (which accepts RFC3339)
+// - estimated either absent or bool
+// - total_tokens > 0 OR input+output > 0
+func TestAuggieDiskPayload_KandyNormalizeCompatible(t *testing.T) {
+	usage := &streams.PromptUsage{
+		InputTokens:       16,
+		OutputTokens:      30,
+		CachedReadTokens:  130,
+		CachedWriteTokens: 52,
+		TotalTokens:       46,
+		Estimated:         false,
+	}
+	payload := lifecycle.SessionPromptUsageEventPayload{
+		TaskID:    "t-auggie",
+		SessionID: "s-auggie",
+		AgentID:   "exec-auggie",
+		AgentType: "auggie",
+		Model:     "claude-opus-4-8",
+		Usage:     usage,
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+	}
+
+	raw, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var asMap map[string]any
+	require.NoError(t, json.Unmarshal(raw, &asMap))
+
+	// timestamp: Kandy uses time.Parse(RFC3339Nano, ...)
+	ts, ok := asMap["timestamp"].(string)
+	require.True(t, ok)
+	_, err = time.Parse(time.RFC3339Nano, ts)
+	require.NoError(t, err, "Kandy rejects timestamps that fail RFC3339Nano parse")
+
+	usageMap, ok := asMap["usage"].(map[string]any)
+	require.True(t, ok)
+
+	for _, name := range []string{
+		"input_tokens", "output_tokens", "cached_read_tokens",
+		"cached_write_tokens", "total_tokens",
+	} {
+		v, present := usageMap[name]
+		require.Truef(t, present, "%s missing from JSON (omitempty?)", name)
+		n, ok := v.(float64)
+		require.Truef(t, ok, "%s type %T want float64 after json roundtrip", name, v)
+		require.False(t, math.IsNaN(n) || math.IsInf(n, 0))
+		require.GreaterOrEqual(t, n, 0.0)
+		require.Less(t, n, float64(1<<53))
+		require.Equal(t, math.Trunc(n), n)
+	}
+
+	// thought_tokens is omitempty; Kandy treats missing as Present=false, valid.
+	// estimated is omitempty when false — Kandy accepts absence.
+	if rawEst, present := usageMap["estimated"]; present {
+		_, ok := rawEst.(bool)
+		require.True(t, ok, "estimated present but not bool")
+	}
+
+	require.Equal(t, "auggie", asMap["agent_type"])
+	require.Equal(t, "claude-opus-4-8", asMap["model"])
+}

--- a/apps/backend/internal/orchestrator/auggie_usage_bridge.go
+++ b/apps/backend/internal/orchestrator/auggie_usage_bridge.go
@@ -1,0 +1,296 @@
+package orchestrator
+
+import (
+	"context"
+	"os"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/kandev/kandev/internal/agent/auggieusage"
+	"github.com/kandev/kandev/internal/agent/runtime/lifecycle"
+	"github.com/kandev/kandev/internal/agentctl/types/streams"
+	"github.com/kandev/kandev/internal/events"
+	"github.com/kandev/kandev/internal/events/bus"
+	"github.com/kandev/kandev/internal/task/models"
+)
+
+const auggieAgentName = "auggie"
+
+// publishPromptUsageFromWireOrDisk publishes session_prompt_usage when wire
+// usage is present, or (for auggie only) when disk has new completed exchanges.
+// Wire wins: a non-nil payload.Data.Usage never double-counts disk.
+func (s *Service) publishPromptUsageFromWireOrDisk(
+	ctx context.Context,
+	payload *lifecycle.AgentStreamEventPayload,
+	session *models.TaskSession,
+) {
+	if payload == nil || payload.SessionID == "" || s.eventBus == nil {
+		return
+	}
+	if payload.Data != nil && payload.Data.Usage != nil {
+		s.emitPromptUsage(ctx, payload, session, payload.Data.Usage)
+		// Wire wins for publish; still advance the disk watermark when possible
+		// so a later nil-wire complete does not re-emit the same exchanges.
+		if isAuggieSession(session) {
+			s.advanceAuggieUsageWatermark(ctx, payload, session)
+		}
+		return
+	}
+	if !isAuggieSession(session) {
+		return
+	}
+	s.publishAuggieDiskPromptUsage(ctx, payload, session)
+}
+
+func isAuggieSession(session *models.TaskSession) bool {
+	if session == nil || session.AgentProfileSnapshot == nil {
+		return false
+	}
+	name, _ := session.AgentProfileSnapshot["agent_name"].(string)
+	return name == auggieAgentName
+}
+
+func (s *Service) publishAuggieDiskPromptUsage(
+	ctx context.Context,
+	payload *lifecycle.AgentStreamEventPayload,
+	session *models.TaskSession,
+) {
+	acpID := resolveAuggieACPSessionID(payload, session)
+	if acpID == "" {
+		return
+	}
+	path, err := auggieusage.SessionPath("", acpID)
+	if err != nil {
+		return
+	}
+	after := auggieUsageSeqFromMetadata(session)
+	exchanges, err := auggieusage.ReadNewExchangeUsages(path, after)
+	if err != nil {
+		if !os.IsNotExist(err) && s.logger != nil {
+			s.logger.Debug("auggie usage disk read failed",
+				zap.String("session_id", payload.SessionID),
+				zap.Error(err))
+		}
+		// Optional short deferred re-read if file not flushed yet.
+		if os.IsNotExist(err) {
+			s.scheduleAuggieUsageReread(payload.SessionID, payload.TaskID, payload.AgentID, acpID, after)
+		}
+		return
+	}
+	if len(exchanges) == 0 {
+		return
+	}
+	usage, maxSeq, model := promptUsageFromAuggieExchanges(exchanges)
+	if usage == nil {
+		// Zero-token completed exchanges: advance watermark without publishing
+		// empty piles so we do not re-walk them forever.
+		if maxSeq > after {
+			s.persistAuggieUsageSeq(ctx, payload.SessionID, maxSeq)
+		}
+		return
+	}
+	// Prefer disk model when present so piles key on the exchange model.
+	emitPayload := *payload
+	if model != "" {
+		dataCopy := lifecycle.AgentStreamEventData{}
+		if emitPayload.Data != nil {
+			dataCopy = *emitPayload.Data
+		}
+		dataCopy.CurrentModelID = model
+		emitPayload.Data = &dataCopy
+	}
+	s.emitPromptUsage(ctx, &emitPayload, session, usage)
+	// Advance only after publish so a failed bus publish can retry next complete.
+	s.persistAuggieUsageSeq(ctx, payload.SessionID, maxSeq)
+}
+
+func promptUsageFromAuggieExchanges(exchanges []auggieusage.ExchangeUsage) (*streams.PromptUsage, int, string) {
+	in, out, cr, cw, model, maxSeq := auggieusage.SumExchanges(exchanges)
+	// total_tokens = input+output for the delta batch (costs.md).
+	total := in + out
+	if total == 0 && cr == 0 && cw == 0 {
+		return nil, maxSeq, model
+	}
+	return &streams.PromptUsage{
+		InputTokens:       in,
+		OutputTokens:      out,
+		CachedReadTokens:  cr,
+		CachedWriteTokens: cw,
+		TotalTokens:       total,
+		Estimated:         false,
+	}, maxSeq, model
+}
+
+func (s *Service) advanceAuggieUsageWatermark(
+	ctx context.Context,
+	payload *lifecycle.AgentStreamEventPayload,
+	session *models.TaskSession,
+) {
+	acpID := resolveAuggieACPSessionID(payload, session)
+	if acpID == "" {
+		return
+	}
+	path, err := auggieusage.SessionPath("", acpID)
+	if err != nil {
+		return
+	}
+	after := auggieUsageSeqFromMetadata(session)
+	exchanges, err := auggieusage.ReadNewExchangeUsages(path, after)
+	if err != nil || len(exchanges) == 0 {
+		return
+	}
+	_, _, _, _, _, maxSeq := auggieusage.SumExchanges(exchanges)
+	if maxSeq > after {
+		s.persistAuggieUsageSeq(ctx, payload.SessionID, maxSeq)
+	}
+}
+
+func resolveAuggieACPSessionID(payload *lifecycle.AgentStreamEventPayload, session *models.TaskSession) string {
+	if session != nil {
+		if id := acpSessionIDFromTaskMetadata(session.Metadata); id != "" {
+			return id
+		}
+	}
+	if payload != nil && payload.Data != nil && payload.Data.ACPSessionID != "" {
+		return payload.Data.ACPSessionID
+	}
+	return ""
+}
+
+func acpSessionIDFromTaskMetadata(metadata map[string]interface{}) string {
+	if metadata == nil {
+		return ""
+	}
+	acp, ok := metadata["acp"].(map[string]interface{})
+	if !ok {
+		// JSON round-trip may yield map[string]any — same under Go 1.x.
+		acpAny, okAny := metadata["acp"].(map[string]any)
+		if !okAny {
+			return ""
+		}
+		id, _ := acpAny["session_id"].(string)
+		return id
+	}
+	id, _ := acp["session_id"].(string)
+	return id
+}
+
+func auggieUsageSeqFromMetadata(session *models.TaskSession) int {
+	if session == nil || session.Metadata == nil {
+		return 0
+	}
+	raw, ok := session.Metadata[models.SessionMetaKeyAuggieUsageSeq]
+	if !ok || raw == nil {
+		return 0
+	}
+	switch v := raw.(type) {
+	case float64:
+		return int(v)
+	case int:
+		return v
+	case int64:
+		return int(v)
+	case jsonNumber:
+		n, _ := v.Int64()
+		return int(n)
+	default:
+		return 0
+	}
+}
+
+// jsonNumber matches encoding/json.Number without importing encoding/json here
+// solely for the type assert (repo may return int from custom decode).
+type jsonNumber interface {
+	Int64() (int64, error)
+}
+
+func (s *Service) persistAuggieUsageSeq(ctx context.Context, sessionID string, maxSeq int) {
+	if s.repo == nil || sessionID == "" || maxSeq <= 0 {
+		return
+	}
+	if err := s.repo.SetSessionMetadataKey(ctx, sessionID, models.SessionMetaKeyAuggieUsageSeq, maxSeq); err != nil && s.logger != nil {
+		s.logger.Warn("failed to persist auggie usage watermark",
+			zap.String("session_id", sessionID),
+			zap.Int("auggie_usage_seq", maxSeq),
+			zap.Error(err))
+	}
+}
+
+func (s *Service) emitPromptUsage(
+	ctx context.Context,
+	payload *lifecycle.AgentStreamEventPayload,
+	session *models.TaskSession,
+	usage *streams.PromptUsage,
+) {
+	if usage == nil || payload == nil || payload.SessionID == "" || s.eventBus == nil {
+		return
+	}
+	model, agentType := resolvePromptUsageLabels(payload, session)
+	eventPayload := lifecycle.SessionPromptUsageEventPayload{
+		TaskID:    payload.TaskID,
+		SessionID: payload.SessionID,
+		AgentID:   payload.AgentID,
+		AgentType: agentType,
+		Model:     model,
+		Usage:     usage,
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+	}
+	subject := events.BuildSessionPromptUsageSubject(payload.SessionID)
+	_ = s.eventBus.Publish(ctx, subject, bus.NewEvent(events.SessionPromptUsageUpdated, "orchestrator", eventPayload))
+}
+
+// scheduleAuggieUsageReread attempts one deferred read if the session file was
+// not present at complete time. Does not block teardown.
+func (s *Service) scheduleAuggieUsageReread(sessionID, taskID, agentID, acpID string, after int) {
+	if s == nil || sessionID == "" || acpID == "" {
+		return
+	}
+	// Capture service pointer; fire-and-forget short delay.
+	time.AfterFunc(400*time.Millisecond, func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		path, err := auggieusage.SessionPath("", acpID)
+		if err != nil {
+			return
+		}
+		exchanges, err := auggieusage.ReadNewExchangeUsages(path, after)
+		if err != nil || len(exchanges) == 0 {
+			return
+		}
+		usage, maxSeq, model := promptUsageFromAuggieExchanges(exchanges)
+		if usage == nil {
+			return
+		}
+		// Reload session for labels + avoid clobbering a newer watermark.
+		var session *models.TaskSession
+		if s.repo != nil {
+			session, _ = s.repo.GetTaskSession(ctx, sessionID)
+			if session != nil {
+				cur := auggieUsageSeqFromMetadata(session)
+				if cur >= maxSeq {
+					return
+				}
+				// Re-filter against live watermark if it moved.
+				if cur > after {
+					exchanges, err = auggieusage.ReadNewExchangeUsages(path, cur)
+					if err != nil || len(exchanges) == 0 {
+						return
+					}
+					usage, maxSeq, model = promptUsageFromAuggieExchanges(exchanges)
+				}
+			}
+		}
+		payload := &lifecycle.AgentStreamEventPayload{
+			TaskID:    taskID,
+			SessionID: sessionID,
+			AgentID:   agentID,
+			Data: &lifecycle.AgentStreamEventData{
+				CurrentModelID: model,
+				ACPSessionID:   acpID,
+			},
+		}
+		s.emitPromptUsage(ctx, payload, session, usage)
+		s.persistAuggieUsageSeq(ctx, sessionID, maxSeq)
+	})
+}

--- a/apps/backend/internal/orchestrator/auggie_usage_bridge.go
+++ b/apps/backend/internal/orchestrator/auggie_usage_bridge.go
@@ -29,7 +29,9 @@ func (s *Service) publishPromptUsageFromWireOrDisk(
 		return
 	}
 	if payload.Data != nil && payload.Data.Usage != nil {
-		s.emitPromptUsage(ctx, payload, session, payload.Data.Usage)
+		if !s.emitPromptUsage(ctx, payload, session, payload.Data.Usage) {
+			return
+		}
 		// Wire wins for publish; still advance the disk watermark when possible
 		// so a later nil-wire complete does not re-emit the same exchanges.
 		if isAuggieSession(session) {
@@ -100,8 +102,10 @@ func (s *Service) publishAuggieDiskPromptUsage(
 		dataCopy.CurrentModelID = model
 		emitPayload.Data = &dataCopy
 	}
-	s.emitPromptUsage(ctx, &emitPayload, session, usage)
-	// Advance only after publish so a failed bus publish can retry next complete.
+	// Advance only after a successful publish so a failed bus write can retry.
+	if !s.emitPromptUsage(ctx, &emitPayload, session, usage) {
+		return
+	}
 	s.persistAuggieUsageSeq(ctx, payload.SessionID, maxSeq)
 }
 
@@ -162,15 +166,10 @@ func acpSessionIDFromTaskMetadata(metadata map[string]interface{}) string {
 	if metadata == nil {
 		return ""
 	}
-	acp, ok := metadata["acp"].(map[string]interface{})
+	// map[string]interface{} and map[string]any are the same type in Go.
+	acp, ok := metadata["acp"].(map[string]any)
 	if !ok {
-		// JSON round-trip may yield map[string]any — same under Go 1.x.
-		acpAny, okAny := metadata["acp"].(map[string]any)
-		if !okAny {
-			return ""
-		}
-		id, _ := acpAny["session_id"].(string)
-		return id
+		return ""
 	}
 	id, _ := acp["session_id"].(string)
 	return id
@@ -217,14 +216,16 @@ func (s *Service) persistAuggieUsageSeq(ctx context.Context, sessionID string, m
 	}
 }
 
+// emitPromptUsage publishes one session_prompt_usage event. Returns true when
+// the bus accepted the event so callers can advance the disk watermark safely.
 func (s *Service) emitPromptUsage(
 	ctx context.Context,
 	payload *lifecycle.AgentStreamEventPayload,
 	session *models.TaskSession,
 	usage *streams.PromptUsage,
-) {
+) bool {
 	if usage == nil || payload == nil || payload.SessionID == "" || s.eventBus == nil {
-		return
+		return false
 	}
 	model, agentType := resolvePromptUsageLabels(payload, session)
 	eventPayload := lifecycle.SessionPromptUsageEventPayload{
@@ -237,7 +238,15 @@ func (s *Service) emitPromptUsage(
 		Timestamp: time.Now().UTC().Format(time.RFC3339),
 	}
 	subject := events.BuildSessionPromptUsageSubject(payload.SessionID)
-	_ = s.eventBus.Publish(ctx, subject, bus.NewEvent(events.SessionPromptUsageUpdated, "orchestrator", eventPayload))
+	if err := s.eventBus.Publish(ctx, subject, bus.NewEvent(events.SessionPromptUsageUpdated, "orchestrator", eventPayload)); err != nil {
+		if s.logger != nil {
+			s.logger.Warn("failed to publish session prompt usage",
+				zap.String("session_id", payload.SessionID),
+				zap.Error(err))
+		}
+		return false
+	}
+	return true
 }
 
 // scheduleAuggieUsageReread attempts one deferred read if the session file was
@@ -248,49 +257,78 @@ func (s *Service) scheduleAuggieUsageReread(sessionID, taskID, agentID, acpID st
 	}
 	// Capture service pointer; fire-and-forget short delay.
 	time.AfterFunc(400*time.Millisecond, func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-		defer cancel()
-		path, err := auggieusage.SessionPath("", acpID)
-		if err != nil {
-			return
-		}
-		exchanges, err := auggieusage.ReadNewExchangeUsages(path, after)
-		if err != nil || len(exchanges) == 0 {
-			return
-		}
-		usage, maxSeq, model := promptUsageFromAuggieExchanges(exchanges)
-		if usage == nil {
-			return
-		}
-		// Reload session for labels + avoid clobbering a newer watermark.
-		var session *models.TaskSession
-		if s.repo != nil {
-			session, _ = s.repo.GetTaskSession(ctx, sessionID)
-			if session != nil {
-				cur := auggieUsageSeqFromMetadata(session)
-				if cur >= maxSeq {
-					return
-				}
-				// Re-filter against live watermark if it moved.
-				if cur > after {
-					exchanges, err = auggieusage.ReadNewExchangeUsages(path, cur)
-					if err != nil || len(exchanges) == 0 {
-						return
-					}
-					usage, maxSeq, model = promptUsageFromAuggieExchanges(exchanges)
-				}
-			}
-		}
-		payload := &lifecycle.AgentStreamEventPayload{
-			TaskID:    taskID,
-			SessionID: sessionID,
-			AgentID:   agentID,
-			Data: &lifecycle.AgentStreamEventData{
-				CurrentModelID: model,
-				ACPSessionID:   acpID,
-			},
-		}
-		s.emitPromptUsage(ctx, payload, session, usage)
-		s.persistAuggieUsageSeq(ctx, sessionID, maxSeq)
+		s.runAuggieUsageReread(sessionID, taskID, agentID, acpID, after)
 	})
+}
+
+func (s *Service) runAuggieUsageReread(sessionID, taskID, agentID, acpID string, after int) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	path, err := auggieusage.SessionPath("", acpID)
+	if err != nil {
+		return
+	}
+	exchanges, err := auggieusage.ReadNewExchangeUsages(path, after)
+	if err != nil || len(exchanges) == 0 {
+		return
+	}
+	usage, maxSeq, model := promptUsageFromAuggieExchanges(exchanges)
+	if usage == nil {
+		// Match the sync path: advance past zero-token completed exchanges.
+		if maxSeq > after {
+			s.persistAuggieUsageSeq(ctx, sessionID, maxSeq)
+		}
+		return
+	}
+	session, usage, maxSeq, model, ok := s.reconcileAuggieReread(ctx, sessionID, path, after, usage, maxSeq, model)
+	if !ok {
+		return
+	}
+	payload := &lifecycle.AgentStreamEventPayload{
+		TaskID:    taskID,
+		SessionID: sessionID,
+		AgentID:   agentID,
+		Data: &lifecycle.AgentStreamEventData{
+			CurrentModelID: model,
+			ACPSessionID:   acpID,
+		},
+	}
+	if !s.emitPromptUsage(ctx, payload, session, usage) {
+		return
+	}
+	s.persistAuggieUsageSeq(ctx, sessionID, maxSeq)
+}
+
+func (s *Service) reconcileAuggieReread(
+	ctx context.Context,
+	sessionID, path string,
+	after int,
+	usage *streams.PromptUsage,
+	maxSeq int,
+	model string,
+) (*models.TaskSession, *streams.PromptUsage, int, string, bool) {
+	if s.repo == nil {
+		return nil, usage, maxSeq, model, true
+	}
+	session, _ := s.repo.GetTaskSession(ctx, sessionID)
+	if session == nil {
+		return nil, usage, maxSeq, model, true
+	}
+	cur := auggieUsageSeqFromMetadata(session)
+	if cur >= maxSeq {
+		return session, nil, maxSeq, model, false
+	}
+	if cur <= after {
+		return session, usage, maxSeq, model, true
+	}
+	// Watermark moved since schedule; re-filter so we do not double-count.
+	exchanges, err := auggieusage.ReadNewExchangeUsages(path, cur)
+	if err != nil || len(exchanges) == 0 {
+		return session, nil, maxSeq, model, false
+	}
+	usage, maxSeq, model = promptUsageFromAuggieExchanges(exchanges)
+	if usage == nil {
+		return session, nil, maxSeq, model, false
+	}
+	return session, usage, maxSeq, model, true
 }

--- a/apps/backend/internal/orchestrator/auggie_usage_bridge.go
+++ b/apps/backend/internal/orchestrator/auggie_usage_bridge.go
@@ -66,47 +66,119 @@ func (s *Service) publishAuggieDiskPromptUsage(
 	if err != nil {
 		return
 	}
-	after := auggieUsageSeqFromMetadata(session)
+	// Prefer the persisted watermark over any stale in-memory session.Metadata
+	// (deferred re-read vs second complete, or callers holding an old snapshot).
+	after := s.liveAuggieUsageSeq(ctx, payload.SessionID, session)
 	exchanges, err := auggieusage.ReadNewExchangeUsages(path, after)
 	if err != nil {
-		if !os.IsNotExist(err) && s.logger != nil {
-			s.logger.Debug("auggie usage disk read failed",
-				zap.String("session_id", payload.SessionID),
-				zap.Error(err))
-		}
-		// Optional short deferred re-read if file not flushed yet.
-		if os.IsNotExist(err) {
-			s.scheduleAuggieUsageReread(payload.SessionID, payload.TaskID, payload.AgentID, acpID, after)
-		}
+		s.handleAuggieDiskReadError(payload, acpID, after, err)
 		return
 	}
-	if len(exchanges) == 0 {
+	usage, maxSeq, model, ok := s.usageDeltaFromExchanges(ctx, payload.SessionID, path, after, exchanges)
+	if !ok {
 		return
 	}
-	usage, maxSeq, model := promptUsageFromAuggieExchanges(exchanges)
-	if usage == nil {
-		// Zero-token completed exchanges: advance watermark without publishing
-		// empty piles so we do not re-walk them forever.
-		if maxSeq > after {
-			s.persistAuggieUsageSeq(ctx, payload.SessionID, maxSeq)
-		}
-		return
-	}
-	// Prefer disk model when present so piles key on the exchange model.
-	emitPayload := *payload
-	if model != "" {
-		dataCopy := lifecycle.AgentStreamEventData{}
-		if emitPayload.Data != nil {
-			dataCopy = *emitPayload.Data
-		}
-		dataCopy.CurrentModelID = model
-		emitPayload.Data = &dataCopy
-	}
+	emitPayload := withCurrentModel(payload, model)
 	// Advance only after a successful publish so a failed bus write can retry.
-	if !s.emitPromptUsage(ctx, &emitPayload, session, usage) {
+	if !s.emitPromptUsage(ctx, emitPayload, session, usage) {
 		return
 	}
 	s.persistAuggieUsageSeq(ctx, payload.SessionID, maxSeq)
+}
+
+func (s *Service) handleAuggieDiskReadError(
+	payload *lifecycle.AgentStreamEventPayload,
+	acpID string,
+	after int,
+	err error,
+) {
+	if payload == nil {
+		return
+	}
+	if !os.IsNotExist(err) && s.logger != nil {
+		s.logger.Debug("auggie usage disk read failed",
+			zap.String("session_id", payload.SessionID),
+			zap.Error(err))
+	}
+	// Optional short deferred re-read if file not flushed yet.
+	if os.IsNotExist(err) {
+		s.scheduleAuggieUsageReread(payload.SessionID, payload.TaskID, payload.AgentID, acpID, after)
+	}
+}
+
+// usageDeltaFromExchanges sums disk exchanges and re-filters against the live
+// watermark so a parallel complete/re-read cannot double-publish the same seqs.
+func (s *Service) usageDeltaFromExchanges(
+	ctx context.Context,
+	sessionID, path string,
+	after int,
+	exchanges []auggieusage.ExchangeUsage,
+) (*streams.PromptUsage, int, string, bool) {
+	if len(exchanges) == 0 {
+		return nil, 0, "", false
+	}
+	usage, maxSeq, model := promptUsageFromAuggieExchanges(exchanges)
+	if usage == nil {
+		// Zero-token completed exchanges: advance watermark without publishing.
+		if maxSeq > after {
+			s.persistAuggieUsageSeq(ctx, sessionID, maxSeq)
+		}
+		return nil, maxSeq, model, false
+	}
+	cur := s.liveAuggieUsageSeq(ctx, sessionID, nil)
+	if cur >= maxSeq {
+		return nil, maxSeq, model, false
+	}
+	if cur <= after {
+		return usage, maxSeq, model, true
+	}
+	// Watermark moved; re-sum only still-new exchanges.
+	exchanges, err := auggieusage.ReadNewExchangeUsages(path, cur)
+	if err != nil || len(exchanges) == 0 {
+		return nil, maxSeq, model, false
+	}
+	usage, maxSeq, model = promptUsageFromAuggieExchanges(exchanges)
+	if usage == nil {
+		if maxSeq > cur {
+			s.persistAuggieUsageSeq(ctx, sessionID, maxSeq)
+		}
+		return nil, maxSeq, model, false
+	}
+	return usage, maxSeq, model, true
+}
+
+func withCurrentModel(payload *lifecycle.AgentStreamEventPayload, model string) *lifecycle.AgentStreamEventPayload {
+	if payload == nil {
+		return nil
+	}
+	emit := *payload
+	if model == "" {
+		return &emit
+	}
+	dataCopy := lifecycle.AgentStreamEventData{}
+	if emit.Data != nil {
+		dataCopy = *emit.Data
+	}
+	dataCopy.CurrentModelID = model
+	emit.Data = &dataCopy
+	return &emit
+}
+
+// liveAuggieUsageSeq returns the max of the in-memory session watermark and the
+// value currently stored on the task_sessions row (when the repo is available).
+func (s *Service) liveAuggieUsageSeq(ctx context.Context, sessionID string, session *models.TaskSession) int {
+	after := auggieUsageSeqFromMetadata(session)
+	if s == nil || s.repo == nil || sessionID == "" {
+		return after
+	}
+	row, err := s.repo.GetTaskSession(ctx, sessionID)
+	if err != nil || row == nil {
+		return after
+	}
+	if cur := auggieUsageSeqFromMetadata(row); cur > after {
+		return cur
+	}
+	return after
 }
 
 func promptUsageFromAuggieExchanges(exchanges []auggieusage.ExchangeUsage) (*streams.PromptUsage, int, string) {
@@ -139,7 +211,7 @@ func (s *Service) advanceAuggieUsageWatermark(
 	if err != nil {
 		return
 	}
-	after := auggieUsageSeqFromMetadata(session)
+	after := s.liveAuggieUsageSeq(ctx, payload.SessionID, session)
 	exchanges, err := auggieusage.ReadNewExchangeUsages(path, after)
 	if err != nil || len(exchanges) == 0 {
 		return

--- a/apps/backend/internal/orchestrator/auggie_usage_bridge_test.go
+++ b/apps/backend/internal/orchestrator/auggie_usage_bridge_test.go
@@ -1,0 +1,200 @@
+package orchestrator
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kandev/kandev/internal/agent/runtime/lifecycle"
+	"github.com/kandev/kandev/internal/agentctl/types/streams"
+	"github.com/kandev/kandev/internal/events"
+	"github.com/kandev/kandev/internal/task/models"
+)
+
+func writeAuggieSessionFixture(t *testing.T, home, acpID, fixtureName string) {
+	t.Helper()
+	src := filepath.Join("..", "agent", "auggieusage", "testdata", fixtureName)
+	raw, err := os.ReadFile(src)
+	require.NoError(t, err)
+	dir := filepath.Join(home, ".augment", "sessions")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, acpID+".json"), raw, 0o644))
+}
+
+func auggieSession(meta map[string]interface{}) *models.TaskSession {
+	return &models.TaskSession{
+		ID: "s-auggie",
+		AgentProfileSnapshot: map[string]interface{}{
+			"agent_name": "auggie",
+			"model":      "snapshot-model",
+		},
+		Metadata: meta,
+	}
+}
+
+func usageEvents(eb *recordingEventBus, sessionID string) []lifecycle.SessionPromptUsageEventPayload {
+	want := events.BuildSessionPromptUsageSubject(sessionID)
+	var out []lifecycle.SessionPromptUsageEventPayload
+	for _, rec := range eb.events {
+		if rec.subject != want || rec.event == nil {
+			continue
+		}
+		// Event data may be the struct or a map after bus wrap; accept both.
+		switch d := rec.event.Data.(type) {
+		case lifecycle.SessionPromptUsageEventPayload:
+			out = append(out, d)
+		case *lifecycle.SessionPromptUsageEventPayload:
+			out = append(out, *d)
+		default:
+			b, err := json.Marshal(d)
+			if err != nil {
+				continue
+			}
+			var p lifecycle.SessionPromptUsageEventPayload
+			if json.Unmarshal(b, &p) == nil && p.SessionID != "" {
+				out = append(out, p)
+			}
+		}
+	}
+	return out
+}
+
+func TestPublishPromptUsage_AuggieDiskBridge(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	// Some platforms use UserHomeDir from other envs; force USERPROFILE too.
+	t.Setenv("USERPROFILE", home)
+
+	acpID := "acp-auggie-1"
+	writeAuggieSessionFixture(t, home, acpID, "multi_exchange.json")
+
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "t-auggie", "s-auggie", "step1")
+	require.NoError(t, repo.SetSessionMetadataKey(ctx, "s-auggie", "acp", map[string]any{
+		"session_id": acpID,
+	}))
+	// Attach agent snapshot on the row so reload paths would see it if needed.
+	sess, err := repo.GetTaskSession(ctx, "s-auggie")
+	require.NoError(t, err)
+	sess.AgentProfileSnapshot = map[string]interface{}{
+		"agent_name": "auggie",
+		"model":      "snapshot-model",
+	}
+	require.NoError(t, repo.UpdateTaskSession(ctx, sess))
+
+	eb := &recordingEventBus{}
+	svc := createTestService(repo, newMockStepGetter(), newMockTaskRepo())
+	svc.eventBus = eb
+
+	session := auggieSession(map[string]interface{}{
+		"acp": map[string]interface{}{"session_id": acpID},
+	})
+
+	payload := &lifecycle.AgentStreamEventPayload{
+		TaskID:    "t-auggie",
+		SessionID: "s-auggie",
+		AgentID:   "exec-auggie",
+		Data:      &lifecycle.AgentStreamEventData{ACPSessionID: acpID},
+	}
+
+	svc.publishPromptUsage(ctx, payload, session)
+
+	got := usageEvents(eb, "s-auggie")
+	require.Len(t, got, 1)
+	require.Equal(t, "auggie", got[0].AgentType)
+	require.Equal(t, "t-auggie", got[0].TaskID)
+	require.Equal(t, "claude-opus-4-8", got[0].Model)
+	require.NotNil(t, got[0].Usage)
+	require.Equal(t, int64(16), got[0].Usage.InputTokens)
+	require.Equal(t, int64(30), got[0].Usage.OutputTokens)
+	require.Equal(t, int64(130), got[0].Usage.CachedReadTokens)
+	require.Equal(t, int64(52), got[0].Usage.CachedWriteTokens)
+	require.Equal(t, int64(46), got[0].Usage.TotalTokens)
+	require.False(t, got[0].Usage.Estimated)
+	require.NotEmpty(t, got[0].Timestamp)
+
+	// Watermark advanced on session row.
+	reloaded, err := repo.GetTaskSession(ctx, "s-auggie")
+	require.NoError(t, err)
+	require.Equal(t, float64(2), reloaded.Metadata[models.SessionMetaKeyAuggieUsageSeq])
+
+	// Second complete must not double-count.
+	session.Metadata = reloaded.Metadata
+	eb.events = nil
+	svc.publishPromptUsage(ctx, payload, session)
+	require.Empty(t, usageEvents(eb, "s-auggie"))
+}
+
+func TestPublishPromptUsage_WireWinsOverAuggieDisk(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	acpID := "acp-auggie-wire"
+	writeAuggieSessionFixture(t, home, acpID, "multi_exchange.json")
+
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "t-wire", "s-wire", "step1")
+	require.NoError(t, repo.SetSessionMetadataKey(ctx, "s-wire", "acp", map[string]any{
+		"session_id": acpID,
+	}))
+
+	eb := &recordingEventBus{}
+	svc := createTestService(repo, newMockStepGetter(), newMockTaskRepo())
+	svc.eventBus = eb
+
+	session := auggieSession(map[string]interface{}{
+		"acp": map[string]interface{}{"session_id": acpID},
+	})
+	wire := &streams.PromptUsage{InputTokens: 1, OutputTokens: 2, TotalTokens: 3}
+	payload := &lifecycle.AgentStreamEventPayload{
+		TaskID:    "t-wire",
+		SessionID: "s-wire",
+		AgentID:   "exec-wire",
+		Data: &lifecycle.AgentStreamEventData{
+			ACPSessionID: acpID,
+			Usage:        wire,
+		},
+	}
+	svc.publishPromptUsage(ctx, payload, session)
+
+	got := usageEvents(eb, "s-wire")
+	require.Len(t, got, 1)
+	require.Equal(t, int64(1), got[0].Usage.InputTokens)
+	require.Equal(t, int64(2), got[0].Usage.OutputTokens)
+	// Disk totals must not replace wire.
+	require.NotEqual(t, int64(16), got[0].Usage.InputTokens)
+
+	reloaded, err := repo.GetTaskSession(ctx, "s-wire")
+	require.NoError(t, err)
+	// Watermark still advanced so a later nil-wire path does not double count.
+	require.Equal(t, float64(2), reloaded.Metadata[models.SessionMetaKeyAuggieUsageSeq])
+}
+
+func TestPublishPromptUsage_NonAuggieNilUsageNoop(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	writeAuggieSessionFixture(t, home, "should-not-read", "multi_exchange.json")
+
+	eb := &recordingEventBus{}
+	svc := createTestService(setupTestRepo(t), newMockStepGetter(), newMockTaskRepo())
+	svc.eventBus = eb
+
+	payload := &lifecycle.AgentStreamEventPayload{
+		TaskID:    "t1",
+		SessionID: "s1",
+		Data:      &lifecycle.AgentStreamEventData{ACPSessionID: "should-not-read"},
+	}
+	session := &models.TaskSession{
+		AgentProfileSnapshot: map[string]interface{}{"agent_name": "claude-acp"},
+	}
+	svc.publishPromptUsage(ctx, payload, session)
+	require.Empty(t, eb.events)
+}

--- a/apps/backend/internal/orchestrator/auggie_usage_bridge_test.go
+++ b/apps/backend/internal/orchestrator/auggie_usage_bridge_test.go
@@ -3,15 +3,18 @@ package orchestrator
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/kandev/kandev/internal/agent/runtime/lifecycle"
 	"github.com/kandev/kandev/internal/agentctl/types/streams"
 	"github.com/kandev/kandev/internal/events"
+	"github.com/kandev/kandev/internal/events/bus"
 	"github.com/kandev/kandev/internal/task/models"
 )
 
@@ -198,3 +201,266 @@ func TestPublishPromptUsage_NonAuggieNilUsageNoop(t *testing.T) {
 	svc.publishPromptUsage(ctx, payload, session)
 	require.Empty(t, eb.events)
 }
+
+func TestPublishPromptUsage_AuggiePayloadACPSessionIDOnly(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	acpID := "acp-payload-only"
+	writeAuggieSessionFixture(t, home, acpID, "multi_exchange.json")
+
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "t-payload", "s-payload", "step1")
+
+	eb := &recordingEventBus{}
+	svc := createTestService(repo, newMockStepGetter(), newMockTaskRepo())
+	svc.eventBus = eb
+
+	// No metadata.acp; only complete-frame ACPSessionID (common first-turn path).
+	session := auggieSession(nil)
+	session.ID = "s-payload"
+	payload := &lifecycle.AgentStreamEventPayload{
+		TaskID:    "t-payload",
+		SessionID: "s-payload",
+		AgentID:   "exec",
+		Data:      &lifecycle.AgentStreamEventData{ACPSessionID: acpID},
+	}
+	svc.publishPromptUsage(ctx, payload, session)
+	got := usageEvents(eb, "s-payload")
+	require.Len(t, got, 1)
+	require.Equal(t, int64(16), got[0].Usage.InputTokens)
+}
+
+func TestPublishPromptUsage_AuggieMissingACPSessionID(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	writeAuggieSessionFixture(t, home, "orphan-file", "multi_exchange.json")
+
+	eb := &recordingEventBus{}
+	svc := createTestService(setupTestRepo(t), newMockStepGetter(), newMockTaskRepo())
+	svc.eventBus = eb
+
+	session := auggieSession(nil)
+	payload := &lifecycle.AgentStreamEventPayload{
+		TaskID:    "t-miss",
+		SessionID: "s-miss",
+		Data:      &lifecycle.AgentStreamEventData{}, // no ACPSessionID
+	}
+	svc.publishPromptUsage(ctx, payload, session)
+	require.Empty(t, usageEvents(eb, "s-miss"))
+}
+
+func TestPublishPromptUsage_AuggieCacheOnlyTokens(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	acpID := "acp-cache-only"
+	dir := filepath.Join(home, ".augment", "sessions")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	// Real Augment shape: completed exchange with only cache counters (input/output 0).
+	raw := []byte(`{
+  "agentState": {"modelId": "cache-model"},
+  "chatHistory": [{
+    "sequenceId": 1,
+    "completed": true,
+    "finishedAt": "2026-08-11T12:00:00.000Z",
+    "exchange": {
+      "model_id": "cache-model",
+      "response_nodes": [{
+        "token_usage": {
+          "input_tokens": 0,
+          "output_tokens": 0,
+          "cache_read_input_tokens": 999,
+          "cache_creation_input_tokens": 12
+        }
+      }]
+    }
+  }]
+}`)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, acpID+".json"), raw, 0o644))
+
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "t-cache", "s-cache", "step1")
+	eb := &recordingEventBus{}
+	svc := createTestService(repo, newMockStepGetter(), newMockTaskRepo())
+	svc.eventBus = eb
+
+	session := auggieSession(map[string]interface{}{
+		"acp": map[string]interface{}{"session_id": acpID},
+	})
+	session.ID = "s-cache"
+	payload := &lifecycle.AgentStreamEventPayload{
+		TaskID: "t-cache", SessionID: "s-cache", AgentID: "exec",
+		Data: &lifecycle.AgentStreamEventData{ACPSessionID: acpID},
+	}
+	svc.publishPromptUsage(ctx, payload, session)
+
+	got := usageEvents(eb, "s-cache")
+	require.Len(t, got, 1, "cache-only exchange must still publish for Office costs / pile metadata")
+	require.Equal(t, int64(0), got[0].Usage.InputTokens)
+	require.Equal(t, int64(0), got[0].Usage.OutputTokens)
+	require.Equal(t, int64(0), got[0].Usage.TotalTokens)
+	require.Equal(t, int64(999), got[0].Usage.CachedReadTokens)
+	require.Equal(t, int64(12), got[0].Usage.CachedWriteTokens)
+
+	// Watermark advanced even though Kandy may ignore total=0 observations.
+	reloaded, err := repo.GetTaskSession(ctx, "s-cache")
+	require.NoError(t, err)
+	require.Equal(t, float64(1), reloaded.Metadata[models.SessionMetaKeyAuggieUsageSeq])
+}
+
+func TestPublishPromptUsage_FailedPublishDoesNotAdvanceWatermark(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	acpID := "acp-fail-bus"
+	writeAuggieSessionFixture(t, home, acpID, "multi_exchange.json")
+
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "t-fail", "s-fail", "step1")
+
+	svc := createTestService(repo, newMockStepGetter(), newMockTaskRepo())
+	svc.eventBus = &failingEventBus{err: errBusDown}
+
+	session := auggieSession(map[string]interface{}{
+		"acp": map[string]interface{}{"session_id": acpID},
+	})
+	session.ID = "s-fail"
+	payload := &lifecycle.AgentStreamEventPayload{
+		TaskID: "t-fail", SessionID: "s-fail",
+		Data: &lifecycle.AgentStreamEventData{ACPSessionID: acpID},
+	}
+	svc.publishPromptUsage(ctx, payload, session)
+
+	reloaded, err := repo.GetTaskSession(ctx, "s-fail")
+	require.NoError(t, err)
+	_, has := reloaded.Metadata[models.SessionMetaKeyAuggieUsageSeq]
+	require.False(t, has, "failed publish must leave watermark unset for retry")
+}
+
+func TestPublishPromptUsage_AuggieDeferredReread(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	acpID := "acp-deferred"
+	// File intentionally absent at first complete.
+
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "t-def", "s-def", "step1")
+	require.NoError(t, repo.SetSessionMetadataKey(ctx, "s-def", "acp", map[string]any{
+		"session_id": acpID,
+	}))
+	sess, err := repo.GetTaskSession(ctx, "s-def")
+	require.NoError(t, err)
+	sess.AgentProfileSnapshot = map[string]interface{}{"agent_name": "auggie", "model": "m"}
+	require.NoError(t, repo.UpdateTaskSession(ctx, sess))
+
+	eb := &recordingEventBus{}
+	svc := createTestService(repo, newMockStepGetter(), newMockTaskRepo())
+	svc.eventBus = eb
+
+	session := auggieSession(map[string]interface{}{
+		"acp": map[string]interface{}{"session_id": acpID},
+	})
+	session.ID = "s-def"
+	payload := &lifecycle.AgentStreamEventPayload{
+		TaskID: "t-def", SessionID: "s-def", AgentID: "exec",
+		Data: &lifecycle.AgentStreamEventData{ACPSessionID: acpID},
+	}
+	svc.publishPromptUsage(ctx, payload, session)
+	require.Empty(t, usageEvents(eb, "s-def"))
+
+	// Flush appears after complete (Auggie write lag).
+	writeAuggieSessionFixture(t, home, acpID, "multi_exchange.json")
+	// Drive deferred path immediately (same logic as AfterFunc callback).
+	svc.runAuggieUsageReread("s-def", "t-def", "exec", acpID, 0)
+
+	got := usageEvents(eb, "s-def")
+	require.Len(t, got, 1)
+	require.Equal(t, int64(16), got[0].Usage.InputTokens)
+	require.Equal(t, "auggie", got[0].AgentType)
+
+	reloaded, err := repo.GetTaskSession(ctx, "s-def")
+	require.NoError(t, err)
+	require.Equal(t, float64(2), reloaded.Metadata[models.SessionMetaKeyAuggieUsageSeq])
+}
+
+func TestPublishPromptUsage_StaleInMemoryWatermarkNoDoubleCount(t *testing.T) {
+	// Two completes with the same stale session.Metadata watermark (as when a
+	// deferred re-read and a second complete both started from after=0). The
+	// second path must reload auggie_usage_seq from the DB and skip.
+	ctx := context.Background()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	acpID := "acp-stale"
+	writeAuggieSessionFixture(t, home, acpID, "multi_exchange.json")
+
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "t-stale", "s-stale", "step1")
+
+	eb := &recordingEventBus{}
+	svc := createTestService(repo, newMockStepGetter(), newMockTaskRepo())
+	svc.eventBus = eb
+
+	meta := map[string]interface{}{"acp": map[string]interface{}{"session_id": acpID}}
+	sessionA := auggieSession(meta)
+	sessionA.ID = "s-stale"
+	sessionB := cloneSession(sessionA)
+	payload := &lifecycle.AgentStreamEventPayload{
+		TaskID: "t-stale", SessionID: "s-stale", AgentID: "exec",
+		Data: &lifecycle.AgentStreamEventData{ACPSessionID: acpID},
+	}
+
+	svc.publishPromptUsage(ctx, payload, sessionA)
+	svc.publishPromptUsage(ctx, payload, sessionB) // still after=0 in memory
+
+	got := usageEvents(eb, "s-stale")
+	require.Len(t, got, 1, "persisted watermark must prevent stale in-memory double publish")
+	require.Equal(t, int64(16), got[0].Usage.InputTokens)
+}
+
+func cloneSession(s *models.TaskSession) *models.TaskSession {
+	if s == nil {
+		return nil
+	}
+	cp := *s
+	if s.Metadata != nil {
+		cp.Metadata = make(map[string]interface{}, len(s.Metadata))
+		for k, v := range s.Metadata {
+			cp.Metadata[k] = v
+		}
+	}
+	if s.AgentProfileSnapshot != nil {
+		cp.AgentProfileSnapshot = make(map[string]interface{}, len(s.AgentProfileSnapshot))
+		for k, v := range s.AgentProfileSnapshot {
+			cp.AgentProfileSnapshot[k] = v
+		}
+	}
+	return &cp
+}
+
+var errBusDown = errors.New("bus down")
+
+type failingEventBus struct {
+	err error
+}
+
+func (b *failingEventBus) Publish(context.Context, string, *bus.Event) error { return b.err }
+func (b *failingEventBus) Subscribe(string, bus.EventHandler) (bus.Subscription, error) {
+	return nil, nil
+}
+func (b *failingEventBus) QueueSubscribe(string, string, bus.EventHandler) (bus.Subscription, error) {
+	return nil, nil
+}
+func (b *failingEventBus) Request(context.Context, string, *bus.Event, time.Duration) (*bus.Event, error) {
+	return nil, nil
+}
+func (b *failingEventBus) Close()            {}
+func (b *failingEventBus) IsConnected() bool { return true }

--- a/apps/backend/internal/orchestrator/event_handlers_streaming.go
+++ b/apps/backend/internal/orchestrator/event_handlers_streaming.go
@@ -2133,34 +2133,16 @@ func (s *Service) publishAgentPlanForTurn(ctx context.Context, payload *lifecycl
 	}
 }
 
-// publishPromptUsage broadcasts prompt token usage to the WebSocket for the frontend.
-// Model and agent type (CLI engine slug) come from payload first; when absent
-// (which is the common case — CurrentModelID only travels on session_models
-// frames) we fall back to the session's AgentProfileSnapshot, populated at
-// session creation and refreshed by persistSessionModel on ACP model updates.
+// publishPromptUsage broadcasts prompt token usage for the frontend, plugins
+// (Kandy Token Grotto), and Office costs. Wire usage wins when present; for
+// auggie sessions with nil wire Usage the host disk bridge may fill from
+// ~/.augment/sessions/<acpSessionId>.json (docs/specs/office/costs.md).
 func (s *Service) publishPromptUsage(
 	ctx context.Context,
 	payload *lifecycle.AgentStreamEventPayload,
 	session *models.TaskSession,
 ) {
-	sessionID := payload.SessionID
-	if sessionID == "" || s.eventBus == nil || payload.Data.Usage == nil {
-		return
-	}
-
-	model, agentType := resolvePromptUsageLabels(payload, session)
-
-	eventPayload := lifecycle.SessionPromptUsageEventPayload{
-		TaskID:    payload.TaskID,
-		SessionID: sessionID,
-		AgentID:   payload.AgentID,
-		AgentType: agentType,
-		Model:     model,
-		Usage:     payload.Data.Usage,
-		Timestamp: time.Now().UTC().Format(time.RFC3339),
-	}
-	subject := events.BuildSessionPromptUsageSubject(sessionID)
-	_ = s.eventBus.Publish(ctx, subject, bus.NewEvent(events.SessionPromptUsageUpdated, "orchestrator", eventPayload))
+	s.publishPromptUsageFromWireOrDisk(ctx, payload, session)
 }
 
 func resolvePromptUsageLabels(

--- a/apps/backend/internal/task/models/models.go
+++ b/apps/backend/internal/task/models/models.go
@@ -214,6 +214,11 @@ const SessionMetaKeyMCPAttachmentState = "mcp_attachment_state"
 // routing contract that successfully launched or resumed a session.
 const SessionMetaKeyGitCredentialSnapshot = "git_credential_snapshot"
 
+// SessionMetaKeyAuggieUsageSeq is the max Augment chatHistory sequenceId already
+// published into session_prompt_usage from the host disk bridge. See
+// docs/specs/office/costs.md (Auggie disk bridge).
+const SessionMetaKeyAuggieUsageSeq = "auggie_usage_seq"
+
 // GitCredentialSnapshot is launch-time display metadata. It never contains a
 // token, broker lease, helper command, credential file, or SSH key detail.
 type GitCredentialSnapshot struct {

--- a/docs/plans/auggie-disk-usage-bridge/plan.md
+++ b/docs/plans/auggie-disk-usage-bridge/plan.md
@@ -1,0 +1,55 @@
+---
+status: done
+spec: docs/specs/office/costs.md
+created: 2026-08-11
+---
+
+# Plan: Auggie disk usage bridge
+
+## Goal
+
+On Auggie stream complete with nil wire usage, read new completed exchanges from `~/.augment/sessions/<acpSessionId>.json`, watermark `sequenceId`, and publish `session_prompt_usage.updated.<sessionId>` so Kandy Token Grotto and Office costs see real tokens.
+
+## Approach (locked)
+
+Host disk bridge (Approach A). Wire-wins when `payload.Data.Usage != nil`. v1 Local + Worktree only.
+
+## Work
+
+| Wave | Task | Status |
+|------|------|--------|
+| 1 | Spec amend (`costs.md`) | done |
+| 2 | Private reader + unit tests | done |
+| 3 | Complete-path bridge + watermark + tests | done |
+| 4 | Targeted backend verification | done |
+
+## Files
+
+| Path | Change |
+|------|--------|
+| `docs/specs/office/costs.md` | Auggie disk bridge contract |
+| `apps/backend/internal/agent/auggieusage/` | Reader, types, fixtures, tests |
+| `apps/backend/internal/task/models/models.go` | `SessionMetaKeyAuggieUsageSeq` |
+| `apps/backend/internal/orchestrator/event_handlers_streaming.go` | Bridge on complete |
+| New orchestrator test file | Bus event + watermark + wire-wins |
+
+Note: `internal/agent/usage` is subscription billing; keep Auggie session-file reader in `auggieusage` to avoid package collision.
+
+## Design notes
+
+- Reader: `ReadNewExchangeUsages(path, afterSeq) ([]ExchangeUsage, error)` — privacy-safe structs only.
+- Home: `filepath.Join(userHome, ".augment", "sessions", acpID+".json")`.
+- ACP id: metadata `acp.session_id`, else `payload.Data.ACPSessionID`, else empty skip.
+- One publish per complete with summed deltas; model = last exchange model_id.
+- Optional deferred re-read: short `time.AfterFunc` if file missing at complete; do not block handler.
+- Soft-fail on I/O/JSON errors with warn log (no content).
+
+## Verification
+
+```bash
+cd apps/backend && go test ./internal/agent/auggieusage/ ./internal/orchestrator/ -count=1 -run 'Auggie|PromptUsage|auggie'
+```
+
+## Out of scope
+
+Plugin walk UI; Copilot; Docker/SSH/Sprites; XP fakes; plugin label rename.

--- a/docs/plans/auggie-disk-usage-bridge/task-01-spec-amend.md
+++ b/docs/plans/auggie-disk-usage-bridge/task-01-spec-amend.md
@@ -1,0 +1,25 @@
+---
+id: task-01-spec-amend
+title: Amend office costs spec for Auggie disk bridge
+status: done
+wave: 1
+depends_on: []
+plan: docs/plans/auggie-disk-usage-bridge/plan.md
+spec: docs/specs/office/costs.md
+---
+
+# Task 01 — Spec amend
+
+## Acceptance
+
+- [x] `docs/specs/office/costs.md` no longer claims Auggie is blanket untracked.
+- [x] Documents disk bridge, join key, privacy, watermark, wire-wins, v1 executor scope, ACP 0.35/0.36 no wire usage.
+- [x] Scenarios for publish, no double-count, wire-wins, non-auggie unchanged, soft-fail.
+
+## Verification
+
+Manual read of amended sections under Per-CLI usage, Disk-runner, Auggie disk bridge, Failure modes, Persistence, Scenarios, Out of scope.
+
+## Files
+
+- `docs/specs/office/costs.md`

--- a/docs/plans/auggie-disk-usage-bridge/task-02-disk-reader.md
+++ b/docs/plans/auggie-disk-usage-bridge/task-02-disk-reader.md
@@ -1,0 +1,31 @@
+---
+id: task-02-disk-reader
+title: TDD Auggie session-file usage reader
+status: done
+wave: 2
+depends_on: [task-01-spec-amend]
+plan: docs/plans/auggie-disk-usage-bridge/plan.md
+spec: docs/specs/office/costs.md
+---
+
+# Task 02 — Disk reader
+
+## Acceptance
+
+- [x] `ReadNewExchangeUsages` returns only sequenceId, model_id, finishedAt, token ints.
+- [x] Filters `completed==true` and `sequenceId > after`.
+- [x] Sums all non-nil `response_nodes[].token_usage` per exchange.
+- [x] Missing file / corrupt JSON soft errors; fixtures use scrubbed content.
+- [x] Helper for Augment sessions path under HOME.
+
+## Verification
+
+```bash
+cd apps/backend && go test ./internal/agent/auggieusage/ -count=1
+```
+
+## Files
+
+- `apps/backend/internal/agent/auggieusage/session_file.go`
+- `apps/backend/internal/agent/auggieusage/session_file_test.go`
+- `apps/backend/internal/agent/auggieusage/testdata/*.json`

--- a/docs/plans/auggie-disk-usage-bridge/task-03-complete-path-bridge.md
+++ b/docs/plans/auggie-disk-usage-bridge/task-03-complete-path-bridge.md
@@ -1,0 +1,31 @@
+---
+id: task-03-complete-path-bridge
+title: Wire Auggie disk bridge on stream complete
+status: done
+wave: 3
+depends_on: [task-02-disk-reader]
+plan: docs/plans/auggie-disk-usage-bridge/plan.md
+spec: docs/specs/office/costs.md
+---
+
+# Task 03 — Complete-path bridge
+
+## Acceptance
+
+- [x] `publishPromptUsage`: wire path unchanged when Usage non-nil.
+- [x] When agent is auggie and Usage nil: resolve ACP id, read disk after watermark, publish summed `SessionPromptUsageEventPayload`, advance `auggie_usage_seq`.
+- [x] Second complete does not republish same exchanges.
+- [x] Non-auggie nil Usage still no-ops.
+- [x] Tests use temp HOME + fixture session file + event bus capture.
+
+## Verification
+
+```bash
+cd apps/backend && go test ./internal/orchestrator/ -count=1 -run 'AuggieUsage|PromptUsage'
+```
+
+## Files
+
+- `apps/backend/internal/orchestrator/event_handlers_streaming.go`
+- `apps/backend/internal/orchestrator/auggie_usage_bridge_test.go` (new; keep streaming_test.go under line limits)
+- `apps/backend/internal/task/models/models.go` (metadata key constant)

--- a/docs/plans/auggie-disk-usage-bridge/task-04-verify.md
+++ b/docs/plans/auggie-disk-usage-bridge/task-04-verify.md
@@ -1,0 +1,24 @@
+---
+id: task-04-verify
+title: Verify Auggie usage bridge tests
+status: done
+wave: 4
+depends_on: [task-03-complete-path-bridge]
+plan: docs/plans/auggie-disk-usage-bridge/plan.md
+spec: docs/specs/office/costs.md
+---
+
+# Task 04 — Verify
+
+## Acceptance
+
+- [x] Reader package tests pass.
+- [x] Orchestrator Auggie bridge tests pass.
+- [x] gofmt clean on touched Go files.
+
+## Verification
+
+```bash
+cd apps/backend && go test ./internal/agent/auggieusage/ ./internal/orchestrator/ -count=1 -run 'Auggie|PromptUsage|auggie'
+gofmt -l internal/agent/auggieusage internal/orchestrator/event_handlers_streaming.go internal/task/models/models.go
+```

--- a/docs/specs/office/costs.md
+++ b/docs/specs/office/costs.md
@@ -1,7 +1,7 @@
 ---
 status: in-progress
 created: 2026-04-25
-updated: 2026-08-08
+updated: 2026-08-11
 owner: cfl
 ---
 
@@ -93,14 +93,53 @@ replaced successfully.
 - **opencode-acp**: `result.usage` with `inputTokens`/`outputTokens`/`thoughtTokens` (no cached tokens). Optional `usage_update.cost.amount` (often `0` on BYOK).
 - **gemini**: `result._meta.quota.token_count.{input_tokens, output_tokens}` (snake_case, no cached, no cost).
 - **codex-acp**: current context occupancy in `usage_update.used`; adapter uses nonnegative occupancy growth as a per-turn estimate and flags rows `estimated=true`. Input vs output cannot be split on the wire. Compaction or other decreases reset the estimate baseline.
-- **auggie**, **copilot-acp**: not tracked. `_meta.copilotUsage` is a billing multiplier; Copilot `/usage` would require scraping.
+- **auggie**: ACP 0.35.0 and 0.36.0-prerelease still emit no per-turn wire usage (`session/prompt` result is `{ stopReason }` only; no host-facing `usage_update`). Token counts live on disk under the Augment session file (see Auggie disk bridge below). When a future Auggie release ships wire `result.usage` or `usage_update`, **wire wins** for that complete and the disk bridge must not also publish for the same turn.
+- **copilot-acp**: not tracked. `_meta.copilotUsage` is a billing multiplier; Copilot `/usage` would require scraping.
 
 ### Disk-runner provider coverage
 
 - **codex** - disk runner is the preferred source. Cost rows promoted from `estimated=true` to `estimated=false` with full token split.
 - **amp** - disk runner is the only source. Cost events emitted with `estimated=false`; `credits` captured in `provider_credits`.
 - **claude, opencode, gemini** - disk runner NOT used; wire data is authoritative.
-- **auggie, copilot** - no `@ccusage/*` package; out of scope.
+- **auggie** - not via `@ccusage/*`. Host-owned private reader of `~/.augment/sessions/<acpSessionId>.json` on stream complete (see Auggie disk bridge).
+- **copilot** - no `@ccusage/*` package; out of scope.
+
+### Auggie disk bridge (host-owned, not ccusage)
+
+Kandy Token Grotto and Office costs both observe `session_prompt_usage.updated.*`. For Auggie, the host fills that bus from disk when the wire path has nothing.
+
+**When.** On agent stream complete for a session whose `agent_profile_snapshot.agent_name` is `auggie`:
+1. If `payload.Data.Usage != nil`, publish the existing wire path only (**wire-wins**). Do not also count disk for that complete.
+2. If wire Usage is nil, resolve the ACP session id, read new exchanges from the Augment session file, sum token deltas since the watermark, publish one `session_prompt_usage.updated.<sessionId>`, then advance the watermark.
+
+**Join key.** ACP session id equals the Augment session filename stem (`~/.augment/sessions/<acpSessionId>.json`). Resolve ACP id the same way as plugin host data: `TaskSession.Metadata["acp"]["session_id"]`, else resume token / `payload.Data.ACPSessionID` when present. HOME follows Augment conventions (`os.UserHomeDir` + `.augment`), never a hardcoded user path.
+
+**Privacy.** The reader returns only `sequenceId`, `model_id`, `finishedAt`, and token integers. It must not return prompts, tool args, response text, or log content fields.
+
+**Exchange selection.** Only history items with `completed == true` and `sequenceId > afterSequence`. Sum non-nil `exchange.response_nodes[].token_usage` per exchange. Incomplete exchanges are left for a later complete (optional short deferred re-read if the file is not flushed yet; do not block teardown long).
+
+**Field map into `streams.PromptUsage` / Kandy `normalizeTokenUsage`:**
+
+| Disk | Wire / event |
+|---|---|
+| sum `input_tokens` | `usage.input_tokens` |
+| sum `output_tokens` | `usage.output_tokens` |
+| sum `cache_read_input_tokens` | `usage.cached_read_tokens` |
+| sum `cache_creation_input_tokens` | `usage.cached_write_tokens` |
+| (none today) | `usage.thought_tokens` = 0 |
+| input + output of the delta batch | `usage.total_tokens` (document; do not invent totals from cache alone) |
+| from disk nodes | `usage.estimated` = false |
+| last exchange `model_id` (else `agentState.modelId`) | top-level `model` |
+| fixed | `agent_type` = `"auggie"` |
+| now UTC | top-level `timestamp` RFC3339 |
+
+JSON numbers must stay ≤ 2^53-1 for plugin float64 parse.
+
+**Watermark.** Persist the max consumed `sequenceId` on `task_sessions.metadata` under `auggie_usage_seq`. Advance only after a successful publish of the summed delta (or when there is nothing new). Restarts and re-completes must not double-count.
+
+**Executor scope (v1).** Local host and Worktree host only (reader sees the same `HOME` / `~/.augment` as the Auggie process). Docker, SSH, and Sprites require mirrored HOME/session bind and are explicit follow-ups.
+
+**Office.** The same bus event feeds `handlePromptUsage`. Auggie rows may still show "pricing unavailable" when models.dev has no Augment model id; Grotto pile growth does not require USD pricing.
 
 ## API surface
 
@@ -180,6 +219,9 @@ There is no per-field permission model. Conformance tests should assert that cos
 - **ccusage JSON schema drift**: schema validator returns decode error; office subscriber treats run as no-op (no rows touched). Codex falls back to wire-side estimated path; amp absent. Nightly fixture-smoke CI alerts maintainers.
 - **`@ccusage/<provider>@latest` yanked**: next runner invocation fails; coverage degrades the same as parse failure.
 - **Coalescing**: if `session/complete` fires while a runner is already executing for that provider, the second invocation is dropped. The 60s sweep catches sessions in the gap.
+- **Auggie session file missing/corrupt/not flushed**: soft-fail; optional short deferred re-read; no publish; watermark unchanged. Never log prompt or response bodies from the file.
+- **Auggie ACP id unknown**: skip disk bridge for that complete (no join key).
+- **Auggie on Docker/SSH/Sprites (v1)**: bridge does not read remote HOME; no fake usage. Documented follow-up.
 
 ## Persistence guarantees
 
@@ -194,6 +236,7 @@ There is no per-field permission model. Conformance tests should assert that cos
 - A failed refresh never replaces or invalidates the last valid cache. Refresh
   coordination and temporary files are transient and do not survive restart.
 - Activity log entries `budget.alert` and `budget.exceeded` (workspace-scoped, included in the standard office backup as part of normal SQLite persistence - see `persistence.Provide` for the snapshot policy).
+- Auggie disk-bridge watermark `task_sessions.metadata.auggie_usage_seq` (max consumed Augment `sequenceId`), so restart + re-complete does not republish old exchanges.
 
 **Does NOT survive restart:**
 
@@ -241,6 +284,16 @@ No TTL or retention is applied to `office_cost_events`; rows accumulate for the 
 
 - **GIVEN** a codex session that completed during a backend restart, **WHEN** the 60s periodic sweep runs after startup, **THEN** the runner discovers the rollout file via ccusage's normal scan, emits cost rows, and the session shows accurate cost in the explorer.
 
+- **GIVEN** an Auggie session whose ACP stream complete carries no wire Usage, and `~/.augment/sessions/<acpSessionId>.json` has completed exchanges after the stored `auggie_usage_seq` watermark, **WHEN** the complete handler runs on a Local or Worktree host, **THEN** one `session_prompt_usage.updated.<sessionId>` event is published with `agent_type="auggie"`, `estimated=false`, token fields mapped from disk, and the watermark advances to the max consumed `sequenceId`.
+
+- **GIVEN** the same Auggie complete is processed again (or the session restarts with the watermark already advanced), **WHEN** no newer completed exchanges exist on disk, **THEN** no second usage event is published and chamber totals do not inflate.
+
+- **GIVEN** an Auggie complete where `payload.Data.Usage != nil` (future wire path), **WHEN** the complete handler runs, **THEN** only the wire usage is published and disk deltas are not double-counted for that complete.
+
+- **GIVEN** a non-Auggie agent complete with nil Usage, **WHEN** the complete handler runs, **THEN** behavior is unchanged (no Augment session file read).
+
+- **GIVEN** the Augment session file is missing, corrupt, or not yet flushed at complete time, **WHEN** the bridge runs, **THEN** it fails soft (optional short deferred re-read); teardown is not blocked and no partial content is logged.
+
 ## Out of scope
 
 - Actual billing integration or payment processing (costs are estimates, not invoices).
@@ -248,11 +301,13 @@ No TTL or retention is applied to `office_cost_events`; rows accumulate for the 
 - Per-turn cost limits (budgets are per-period, not per-turn).
 - Cost allocation across multiple users (single-user workspace model).
 - Cost forecasting or spend predictions.
-- Auggie support - no `@ccusage/*` package exists.
+- Auggie via `@ccusage/*` (host-owned private reader instead). Docker/SSH/Sprites HOME bridging for Auggie session files in v1.
 - Copilot support - billing is request-multiplier-based, not token-based.
 - Retroactive ingestion of sessions from before this feature ships.
 - Replacing the wire-side ingestion for claude-acp / opencode-acp / gemini (their wire data is authoritative).
 - A user-facing UI surface for the disk-runner binary; visibility flows through the existing cost explorer.
+- Inventing token counts from turn length or XP events.
+- Plugin chamber walk animation or optional `agentRoomLabel` "Augment" rename (plugin repo).
 
 ## Open questions
 


### PR DESCRIPTION
Kandy's Token Grotto stayed empty for Auggie sessions because Auggie's ACP protocol (0.35.0 / 0.36.0-prerelease.5) returns only `{ stopReason }` on `session/prompt` and never emits token usage over the wire, so the host's `publishPromptUsage` no-opped. This adds a host-side disk bridge that reads the real token counts Auggie already writes to `~/.augment/sessions/<acpSessionId>.json` and publishes them on stream complete, so `kandev-plugin-kandy` can grow an Auggie chamber.

## Important Changes

- **New `internal/agent/auggieusage` reader** — parses only `sequenceId`, `model_id`, `finishedAt`, and token integers from the session file; prompts, tool args, and response text are never returned or logged. Path building validates the ACP session id so a malformed id cannot traverse outside the sessions directory.
- **Disk bridge on stream complete** (`internal/orchestrator/auggie_usage_bridge.go`) — for `agent_name == "auggie"` sessions with nil wire usage, sums new exchanges past a persisted watermark and publishes the existing `session_prompt_usage.updated.<sessionId>` event in the exact shape Kandy's `normalizeTokenUsage` parses. **Wire-wins:** if the wire provides usage, the disk path is skipped so nothing is double-counted.
- **Watermark on `task_sessions.metadata` (`auggie_usage_seq`)** — tracks the max consumed Augment `sequenceId`. Reloaded live from the DB row immediately before publishing so a deferred re-read racing a second complete cannot re-emit the same tokens across restarts or re-completes.
- **Spec amend** (`docs/specs/office/costs.md`) — documents the bridge, the ACP-session-id join key, the privacy constraint, wire-wins, the watermark rule, and the v1 executor scope (Local + Worktree host only; Docker/SSH/Sprites are explicit follow-ups).

## Validation

- `go test -race ./internal/orchestrator/... ./internal/agent/auggieusage/...` — all pass, including the double-count regression test and reader fixtures (multi-exchange, nil token nodes, missing file, corrupt JSON, watermark).
- `golangci-lint run ./... --new-from-rev=<branch-base> --timeout=5m` — 0 issues on changed code.
- `gofmt -l` on all changed Go files — clean.
- Kandy payload compatibility asserted directly in `auggie_kandy_compat_probe_test.go` against the plugin's `normalizeTokenUsage` field mapping.

## Diagram

```mermaid
flowchart LR
  A[Auggie stream complete] --> B{wire Usage present?}
  B -- yes --> C[existing wire path]
  B -- no + agent=auggie --> D[read ~/.augment/sessions/&lt;id&gt;.json]
  D --> E[sum exchanges &gt; watermark]
  E --> F[publish session_prompt_usage.updated]
  F --> G[advance auggie_usage_seq]
  G --> H[Kandy Token Grotto + Office costs]
```

## Possible Improvements

- Low risk. v1 covers Local + Worktree host executors only; Docker / SSH / Sprites need the file surfaced from the execution environment (documented as follow-up). A short 400ms deferred re-read covers the case where the session file is not yet flushed at complete time; it does not block teardown.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2570?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->