### PR TITLE
test(task-service): cover documents, attachments, messages and resources

### DIFF
--- a/apps/backend/internal/task/service/attachment_service_lifecycle_test.go
+++ b/apps/backend/internal/task/service/attachment_service_lifecycle_test.go
@@ -1,0 +1,614 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/task/models"
+	"github.com/kandev/kandev/internal/task/repository"
+	sqliterepo "github.com/kandev/kandev/internal/task/repository/sqlite"
+)
+
+// newAttachmentTestService wires an AttachmentService over the real repository
+// with a temp storage root and a recording workspace authorizer.
+func newAttachmentTestService(t *testing.T) (*AttachmentService, *sqliterepo.Repository, string, *recordingWorkspaceAuthorizer) {
+	t.Helper()
+	_, _, repo := createTestService(t)
+	if err := repo.CreateWorkspace(context.Background(), &models.Workspace{ID: "ws-att", Name: "attachments"}); err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	root := t.TempDir()
+	auth := &recordingWorkspaceAuthorizer{}
+	svc, err := NewAttachmentService(repo, root, auth.authorize, accessTestLogger(t))
+	if err != nil {
+		t.Fatalf("NewAttachmentService: %v", err)
+	}
+	return svc, repo, root, auth
+}
+
+type recordingWorkspaceAuthorizer struct {
+	workspaceIDs []string
+	err          error
+}
+
+func (a *recordingWorkspaceAuthorizer) authorize(_ context.Context, workspaceID string) error {
+	a.workspaceIDs = append(a.workspaceIDs, workspaceID)
+	return a.err
+}
+
+func stageTestAttachment(t *testing.T, svc *AttachmentService, ownerID, name, body string) *models.TaskMessageAttachment {
+	t.Helper()
+	attachment, err := svc.Stage(context.Background(), ownerID, "ws-att", name, "image/png", "image", "", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("Stage %s: %v", name, err)
+	}
+	return attachment
+}
+
+// nilAttachmentRepo returns a missing attachment as (nil, nil), the shape a
+// repository is allowed to use for "no row"; the service must still deny.
+type nilAttachmentRepo struct {
+	repository.AttachmentRepository
+}
+
+func (nilAttachmentRepo) GetMessageAttachment(context.Context, string) (*models.TaskMessageAttachment, error) {
+	return nil, nil
+}
+
+func TestNewAttachmentServiceValidatesDependencies(t *testing.T) {
+	_, _, repo := createTestService(t)
+	log := accessTestLogger(t)
+
+	if _, err := NewAttachmentService(nil, t.TempDir(), nil, log); err == nil ||
+		!strings.Contains(err.Error(), "repository is required") {
+		t.Fatalf("nil repo error = %v", err)
+	}
+	if _, err := NewAttachmentService(repo, "   ", nil, log); err == nil ||
+		!strings.Contains(err.Error(), "storage root is required") {
+		t.Fatalf("blank root error = %v", err)
+	}
+	if _, err := NewAttachmentService(repo, t.TempDir(), nil, nil); err == nil ||
+		!strings.Contains(err.Error(), "logger is required") {
+		t.Fatalf("nil logger error = %v", err)
+	}
+
+	root := t.TempDir()
+	svc, err := NewAttachmentService(repo, root, nil, log)
+	if err != nil {
+		t.Fatalf("NewAttachmentService: %v", err)
+	}
+	if svc.root != filepath.Join(root, "attachments") {
+		t.Fatalf("root = %q, want the attachments subdirectory of %q", svc.root, root)
+	}
+}
+
+func TestAttachmentStagePersistsRowAndBytes(t *testing.T) {
+	svc, repo, root, auth := newAttachmentTestService(t)
+	ctx := context.Background()
+
+	before := time.Now().UTC()
+	attachment, err := svc.Stage(ctx, "user-a", "ws-att", "diagram.png", "image/png", "image", "", strings.NewReader("payload"))
+	if err != nil {
+		t.Fatalf("Stage: %v", err)
+	}
+	if len(auth.workspaceIDs) != 1 || auth.workspaceIDs[0] != "ws-att" {
+		t.Fatalf("workspace authorizer calls = %v, want one ws-att call", auth.workspaceIDs)
+	}
+	if attachment.OwnerID != "user-a" || attachment.WorkspaceID != "ws-att" {
+		t.Fatalf("ownership = %q/%q", attachment.OwnerID, attachment.WorkspaceID)
+	}
+	if attachment.Name != "diagram.png" || attachment.MimeType != "image/png" || attachment.Kind != "image" {
+		t.Fatalf("metadata = %+v", attachment)
+	}
+	if attachment.DeliveryMode != attachmentDeliveryModePrompt {
+		t.Fatalf("delivery mode = %q, want the prompt default", attachment.DeliveryMode)
+	}
+	if attachment.State != models.AttachmentStateStaged {
+		t.Fatalf("state = %q, want staged", attachment.State)
+	}
+	if attachment.SizeBytes != int64(len("payload")) {
+		t.Fatalf("size = %d, want %d", attachment.SizeBytes, len("payload"))
+	}
+	if attachment.StorageKey != attachment.ID {
+		t.Fatalf("storage key = %q, want the attachment id", attachment.StorageKey)
+	}
+	if attachment.ExpiresAt.Before(before.Add(AttachmentStagedTTL - time.Minute)) {
+		t.Fatalf("expires_at = %v, want roughly now+%v", attachment.ExpiresAt, AttachmentStagedTTL)
+	}
+
+	stored, err := repo.GetMessageAttachment(ctx, attachment.ID)
+	if err != nil {
+		t.Fatalf("GetMessageAttachment: %v", err)
+	}
+	if stored.Name != "diagram.png" || stored.SizeBytes != int64(len("payload")) {
+		t.Fatalf("persisted row = %+v", stored)
+	}
+
+	bytes, err := os.ReadFile(filepath.Join(root, "attachments", attachment.StorageKey))
+	if err != nil {
+		t.Fatalf("read stored bytes: %v", err)
+	}
+	if string(bytes) != "payload" {
+		t.Fatalf("stored bytes = %q, want payload", bytes)
+	}
+}
+
+func TestAttachmentStageStripsDirectoriesFromName(t *testing.T) {
+	svc, _, _, _ := newAttachmentTestService(t)
+
+	// The metadata validator rejects separators in the *supplied* name, so the
+	// only names that reach filepath.Base are already clean. Assert the stored
+	// name is the base form and that a traversal name never gets that far.
+	attachment := stageTestAttachment(t, svc, "user-a", "clean.png", "x")
+	if attachment.Name != "clean.png" {
+		t.Fatalf("name = %q", attachment.Name)
+	}
+	_, err := svc.Stage(context.Background(), "user-a", "ws-att", "../escape.png", "image/png", "image", "", strings.NewReader("x"))
+	if !errors.Is(err, ErrAttachmentInvalid) {
+		t.Fatalf("traversal name = %v, want ErrAttachmentInvalid", err)
+	}
+}
+
+func TestAttachmentStageRejectsInvalidInput(t *testing.T) {
+	svc, _, root, auth := newAttachmentTestService(t)
+	ctx := context.Background()
+
+	cases := []struct {
+		name  string
+		owner string
+		ws    string
+		src   io.Reader
+	}{
+		{"no workspace", "user-a", "", strings.NewReader("x")},
+		{"no owner", "", "ws-att", strings.NewReader("x")},
+		{"nil reader", "user-a", "ws-att", nil},
+	}
+	for _, tc := range cases {
+		if _, err := svc.Stage(ctx, tc.owner, tc.ws, "f.png", "image/png", "image", "", tc.src); !errors.Is(err, ErrAttachmentInvalid) {
+			t.Fatalf("%s: error = %v, want ErrAttachmentInvalid", tc.name, err)
+		}
+	}
+	if len(auth.workspaceIDs) != 0 {
+		t.Fatalf("invalid input must not reach the workspace authorizer, got %v", auth.workspaceIDs)
+	}
+
+	metadata := []struct {
+		name, mime, kind, delivery string
+	}{
+		{"", "image/png", "image", "prompt"},
+		{"f.png", "", "image", "prompt"},
+		{"f.png", "image/png", "video", "prompt"},
+		{"f.png", "image/png", "image", "smoke-signal"},
+	}
+	for _, tc := range metadata {
+		_, err := svc.Stage(ctx, "user-a", "ws-att", tc.name, tc.mime, tc.kind, tc.delivery, strings.NewReader("x"))
+		if !errors.Is(err, ErrAttachmentInvalid) {
+			t.Fatalf("metadata %+v: error = %v, want ErrAttachmentInvalid", tc, err)
+		}
+	}
+
+	if entries, err := os.ReadDir(filepath.Join(root, "attachments")); err == nil && len(entries) != 0 {
+		t.Fatalf("rejected stages must leave no bytes behind, found %d", len(entries))
+	}
+}
+
+func TestAttachmentStagePropagatesWorkspaceDenial(t *testing.T) {
+	svc, _, root, auth := newAttachmentTestService(t)
+	denied := errors.New("workspace not found")
+	auth.err = denied
+
+	if _, err := svc.Stage(context.Background(), "user-a", "ws-att", "f.png", "image/png", "image", "", strings.NewReader("x")); !errors.Is(err, denied) {
+		t.Fatalf("error = %v, want the authorizer's denial", err)
+	}
+	if entries, err := os.ReadDir(filepath.Join(root, "attachments")); err == nil && len(entries) != 0 {
+		t.Fatalf("denied stage wrote %d entries", len(entries))
+	}
+}
+
+func TestAttachmentStageAcceptsPathDeliveryMode(t *testing.T) {
+	svc, _, _, _ := newAttachmentTestService(t)
+
+	attachment, err := svc.Stage(context.Background(), "user-a", "ws-att", "notes.txt", "text/plain", "resource",
+		attachmentDeliveryModePath, strings.NewReader("x"))
+	if err != nil {
+		t.Fatalf("Stage: %v", err)
+	}
+	if attachment.DeliveryMode != attachmentDeliveryModePath {
+		t.Fatalf("delivery mode = %q, want path", attachment.DeliveryMode)
+	}
+}
+
+func TestAttachmentStageRejectsOversizedStreamWithoutLeavingBytes(t *testing.T) {
+	svc, repo, root, _ := newAttachmentTestService(t)
+
+	oversized := io.LimitReader(zeroReader{}, MaxAttachmentBytes+1)
+	_, err := svc.Stage(context.Background(), "user-a", "ws-att", "big.bin", "application/octet-stream", "resource", "", oversized)
+	if !errors.Is(err, ErrAttachmentTooLarge) {
+		t.Fatalf("error = %v, want ErrAttachmentTooLarge", err)
+	}
+	entries, err := os.ReadDir(filepath.Join(root, "attachments"))
+	if err != nil {
+		t.Fatalf("read storage root: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("oversized upload left %d files behind", len(entries))
+	}
+	if rows, err := repo.ListMessageAttachments(context.Background(), []string{"any"}); err != nil || len(rows) != 0 {
+		t.Fatalf("oversized upload must not create rows: %v %v", rows, err)
+	}
+}
+
+type zeroReader struct{}
+
+func (zeroReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = 0
+	}
+	return len(p), nil
+}
+
+func TestAttachmentStageRemovesBytesWhenRegistryWriteFails(t *testing.T) {
+	_, _, repo := createTestService(t)
+	root := t.TempDir()
+	// No workspace row exists, so the FK rejects the registry insert.
+	svc, err := NewAttachmentService(repo, root, nil, accessTestLogger(t))
+	if err != nil {
+		t.Fatalf("NewAttachmentService: %v", err)
+	}
+	if _, err := svc.Stage(context.Background(), "user-a", "ws-missing", "f.png", "image/png", "image", "", strings.NewReader("x")); err == nil {
+		t.Fatal("stage into a nonexistent workspace must fail")
+	}
+	entries, err := os.ReadDir(filepath.Join(root, "attachments"))
+	if err != nil {
+		t.Fatalf("read storage root: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("failed registry write left %d orphan files", len(entries))
+	}
+}
+
+func TestAttachmentGetScopesToOwner(t *testing.T) {
+	svc, _, _, _ := newAttachmentTestService(t)
+	ctx := context.Background()
+	attachment := stageTestAttachment(t, svc, "user-a", "f.png", "x")
+
+	got, err := svc.Get(ctx, "user-a", attachment.ID)
+	if err != nil {
+		t.Fatalf("owner Get: %v", err)
+	}
+	if got.ID != attachment.ID || got.Name != "f.png" {
+		t.Fatalf("got = %+v", got)
+	}
+	if _, err := svc.Get(ctx, "user-b", attachment.ID); !errors.Is(err, ErrAttachmentForbidden) {
+		t.Fatalf("foreign Get = %v, want ErrAttachmentForbidden", err)
+	}
+	if _, err := svc.Get(ctx, "user-a", "no-such-id"); !errors.Is(err, ErrAttachmentNotFound) {
+		t.Fatalf("unknown id = %v, want ErrAttachmentNotFound", err)
+	}
+}
+
+func TestAttachmentGetDeniesWhenRepositoryReturnsNoRow(t *testing.T) {
+	svc, err := NewAttachmentService(nilAttachmentRepo{}, t.TempDir(), nil, accessTestLogger(t))
+	if err != nil {
+		t.Fatalf("NewAttachmentService: %v", err)
+	}
+	if _, err := svc.Get(context.Background(), "user-a", "id"); !errors.Is(err, ErrAttachmentForbidden) {
+		t.Fatalf("error = %v, want ErrAttachmentForbidden", err)
+	}
+}
+
+func TestAttachmentOpenReturnsBytesAndScopes(t *testing.T) {
+	svc, repo, root, _ := newAttachmentTestService(t)
+	ctx := context.Background()
+	attachment := stageTestAttachment(t, svc, "user-a", "f.png", "payload")
+
+	got, file, err := svc.Open(ctx, "user-a", attachment.ID)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = file.Close() })
+	if got.ID != attachment.ID {
+		t.Fatalf("opened %q, want %q", got.ID, attachment.ID)
+	}
+	content, err := io.ReadAll(file)
+	if err != nil {
+		t.Fatalf("read attachment: %v", err)
+	}
+	if string(content) != "payload" {
+		t.Fatalf("content = %q", content)
+	}
+
+	if _, _, err := svc.Open(ctx, "user-b", attachment.ID); !errors.Is(err, ErrAttachmentForbidden) {
+		t.Fatalf("foreign Open = %v, want ErrAttachmentForbidden", err)
+	}
+
+	// Bytes deleted underneath the row surface as not-found, not a raw os error.
+	if err := os.Remove(filepath.Join(root, "attachments", attachment.StorageKey)); err != nil {
+		t.Fatalf("remove bytes: %v", err)
+	}
+	if _, _, err := svc.Open(ctx, "user-a", attachment.ID); !errors.Is(err, ErrAttachmentNotFound) {
+		t.Fatalf("missing bytes = %v, want ErrAttachmentNotFound", err)
+	}
+
+	// A storage key that is not a bare filename is rejected before any open.
+	traversal := &models.TaskMessageAttachment{
+		ID: "att-traversal", OwnerID: "user-a", WorkspaceID: "ws-att", Name: "f.png",
+		MimeType: "image/png", Kind: "image", DeliveryMode: attachmentDeliveryModePrompt,
+		SizeBytes: 1, StorageKey: "../escape", State: models.AttachmentStateStaged,
+		ExpiresAt: time.Now().UTC().Add(time.Hour),
+	}
+	if err := repo.CreateMessageAttachment(ctx, traversal); err != nil {
+		t.Fatalf("seed traversal row: %v", err)
+	}
+	if _, _, err := svc.Open(ctx, "user-a", traversal.ID); !errors.Is(err, ErrAttachmentInvalid) {
+		t.Fatalf("traversal storage key = %v, want ErrAttachmentInvalid", err)
+	}
+}
+
+func TestAttachmentOpenClaimedAuthorizesByBinding(t *testing.T) {
+	svc, _, root, _ := newAttachmentTestService(t)
+	ctx := context.Background()
+	attachment := stageTestAttachment(t, svc, "user-a", "f.png", "payload")
+
+	// Staged rows are not deliverable.
+	if _, _, _, _, err := svc.OpenClaimed(ctx, attachment.ID, "task-1", "sess-1"); !errors.Is(err, ErrAttachmentForbidden) {
+		t.Fatalf("staged OpenClaimed = %v, want ErrAttachmentForbidden", err)
+	}
+	if err := svc.Claim(ctx, "user-a", "ws-att", "task-1", "sess-1", []string{attachment.ID}); err != nil {
+		t.Fatalf("Claim: %v", err)
+	}
+
+	reader, name, mime, size, err := svc.OpenClaimed(ctx, attachment.ID, "task-1", "sess-1")
+	if err != nil {
+		t.Fatalf("OpenClaimed: %v", err)
+	}
+	t.Cleanup(func() { _ = reader.Close() })
+	if name != "f.png" || mime != "image/png" || size != int64(len("payload")) {
+		t.Fatalf("metadata = %q/%q/%d", name, mime, size)
+	}
+	content, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("read claimed attachment: %v", err)
+	}
+	if string(content) != "payload" {
+		t.Fatalf("content = %q", content)
+	}
+
+	if _, _, _, _, err := svc.OpenClaimed(ctx, attachment.ID, "task-2", "sess-1"); !errors.Is(err, ErrAttachmentForbidden) {
+		t.Fatalf("foreign task = %v, want ErrAttachmentForbidden", err)
+	}
+	if _, _, _, _, err := svc.OpenClaimed(ctx, attachment.ID, "task-1", "sess-2"); !errors.Is(err, ErrAttachmentForbidden) {
+		t.Fatalf("foreign session = %v, want ErrAttachmentForbidden", err)
+	}
+	if _, _, _, _, err := svc.OpenClaimed(ctx, "no-such-id", "task-1", "sess-1"); !errors.Is(err, ErrAttachmentNotFound) {
+		t.Fatalf("unknown id = %v, want ErrAttachmentNotFound", err)
+	}
+
+	if err := os.Remove(filepath.Join(root, "attachments", attachment.StorageKey)); err != nil {
+		t.Fatalf("remove bytes: %v", err)
+	}
+	if _, _, _, _, err := svc.OpenClaimed(ctx, attachment.ID, "task-1", "sess-1"); !errors.Is(err, ErrAttachmentNotFound) {
+		t.Fatalf("missing bytes = %v, want ErrAttachmentNotFound", err)
+	}
+}
+
+func TestAttachmentDeleteOnlyRemovesStagedRows(t *testing.T) {
+	svc, repo, root, _ := newAttachmentTestService(t)
+	ctx := context.Background()
+	staged := stageTestAttachment(t, svc, "user-a", "staged.png", "x")
+	claimed := stageTestAttachment(t, svc, "user-a", "claimed.png", "y")
+	if err := svc.Claim(ctx, "user-a", "ws-att", "task-1", "sess-1", []string{claimed.ID}); err != nil {
+		t.Fatalf("Claim: %v", err)
+	}
+
+	if err := svc.Delete(ctx, "user-a", claimed.ID); !errors.Is(err, ErrAttachmentClaimConflict) {
+		t.Fatalf("delete claimed = %v, want ErrAttachmentClaimConflict", err)
+	}
+	if _, err := repo.GetMessageAttachment(ctx, claimed.ID); err != nil {
+		t.Fatalf("claimed row must survive a rejected delete: %v", err)
+	}
+	if err := svc.Delete(ctx, "user-b", staged.ID); !errors.Is(err, ErrAttachmentForbidden) {
+		t.Fatalf("foreign delete = %v, want ErrAttachmentForbidden", err)
+	}
+
+	if err := svc.Delete(ctx, "user-a", staged.ID); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := repo.GetMessageAttachment(ctx, staged.ID); !errors.Is(err, ErrAttachmentNotFound) {
+		t.Fatalf("deleted row = %v, want ErrAttachmentNotFound", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "attachments", staged.StorageKey)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("bytes still present after delete: %v", err)
+	}
+}
+
+func TestAttachmentClaimAuthorizesWorkspace(t *testing.T) {
+	svc, repo, _, auth := newAttachmentTestService(t)
+	ctx := context.Background()
+	attachment := stageTestAttachment(t, svc, "user-a", "f.png", "x")
+
+	denied := errors.New("workspace not found")
+	auth.err = denied
+	if err := svc.Claim(ctx, "user-a", "ws-att", "task-1", "sess-1", []string{attachment.ID}); !errors.Is(err, denied) {
+		t.Fatalf("denied claim = %v, want the authorizer's error", err)
+	}
+	stored, err := repo.GetMessageAttachment(ctx, attachment.ID)
+	if err != nil {
+		t.Fatalf("GetMessageAttachment: %v", err)
+	}
+	if stored.State != models.AttachmentStateStaged {
+		t.Fatalf("state = %q, want staged after a denied claim", stored.State)
+	}
+
+	auth.err = nil
+	if err := svc.Claim(ctx, "user-a", "ws-att", "task-1", "sess-1", []string{attachment.ID}); err != nil {
+		t.Fatalf("Claim: %v", err)
+	}
+	stored, err = repo.GetMessageAttachment(ctx, attachment.ID)
+	if err != nil {
+		t.Fatalf("GetMessageAttachment: %v", err)
+	}
+	if stored.State != models.AttachmentStateClaimed || stored.TaskID != "task-1" || stored.SessionID != "sess-1" {
+		t.Fatalf("claimed row = %+v", stored)
+	}
+}
+
+func TestAttachmentReleaseRemovesClaimedRowsAndBytes(t *testing.T) {
+	svc, repo, root, _ := newAttachmentTestService(t)
+	ctx := context.Background()
+	released := stageTestAttachment(t, svc, "user-a", "released.png", "x")
+	kept := stageTestAttachment(t, svc, "user-a", "kept.png", "y")
+	if err := svc.Claim(ctx, "user-a", "ws-att", "task-1", "sess-1", []string{released.ID, kept.ID}); err != nil {
+		t.Fatalf("Claim: %v", err)
+	}
+
+	if err := svc.Release(ctx, "user-a", "task-1", "sess-1", []string{released.ID}); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+	if _, err := repo.GetMessageAttachment(ctx, released.ID); !errors.Is(err, ErrAttachmentNotFound) {
+		t.Fatalf("released row = %v, want ErrAttachmentNotFound", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "attachments", released.StorageKey)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("released bytes still present: %v", err)
+	}
+	if _, err := repo.GetMessageAttachment(ctx, kept.ID); err != nil {
+		t.Fatalf("unreferenced release must not touch other rows: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "attachments", kept.StorageKey)); err != nil {
+		t.Fatalf("kept bytes removed: %v", err)
+	}
+
+	// A release scoped to a different session removes nothing.
+	if err := svc.Release(ctx, "user-a", "task-1", "sess-other", []string{kept.ID}); err != nil {
+		t.Fatalf("Release with a foreign session: %v", err)
+	}
+	if _, err := repo.GetMessageAttachment(ctx, kept.ID); err != nil {
+		t.Fatalf("foreign-session release deleted the row: %v", err)
+	}
+}
+
+func TestAttachmentDeleteByTaskRemovesStagedAndClaimed(t *testing.T) {
+	svc, repo, root, _ := newAttachmentTestService(t)
+	ctx := context.Background()
+	claimed := stageTestAttachment(t, svc, "user-a", "claimed.png", "x")
+	other := stageTestAttachment(t, svc, "user-a", "other.png", "y")
+	if err := svc.Claim(ctx, "user-a", "ws-att", "task-1", "sess-1", []string{claimed.ID}); err != nil {
+		t.Fatalf("Claim: %v", err)
+	}
+	if err := svc.Claim(ctx, "user-a", "ws-att", "task-2", "sess-2", []string{other.ID}); err != nil {
+		t.Fatalf("Claim other: %v", err)
+	}
+
+	if err := svc.DeleteByTask(ctx, "task-1"); err != nil {
+		t.Fatalf("DeleteByTask: %v", err)
+	}
+	if _, err := repo.GetMessageAttachment(ctx, claimed.ID); !errors.Is(err, ErrAttachmentNotFound) {
+		t.Fatalf("task-1 row = %v, want ErrAttachmentNotFound", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "attachments", claimed.StorageKey)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("task-1 bytes still present: %v", err)
+	}
+	if _, err := repo.GetMessageAttachment(ctx, other.ID); err != nil {
+		t.Fatalf("task-2 row must survive: %v", err)
+	}
+}
+
+func TestAttachmentCleanupExpiredRemovesStagedBytes(t *testing.T) {
+	svc, repo, root, _ := newAttachmentTestService(t)
+	ctx := context.Background()
+
+	fresh := stageTestAttachment(t, svc, "user-a", "fresh.png", "x")
+	stale := stageTestAttachment(t, svc, "user-a", "stale.png", "y")
+	if _, err := repo.DB().ExecContext(ctx,
+		`UPDATE task_message_attachments SET expires_at = ? WHERE id = ?`,
+		time.Now().UTC().Add(-time.Hour), stale.ID); err != nil {
+		t.Fatalf("age the staged row: %v", err)
+	}
+
+	count, err := svc.CleanupExpired(ctx)
+	if err != nil {
+		t.Fatalf("CleanupExpired: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expired count = %d, want 1", count)
+	}
+	if _, err := os.Stat(filepath.Join(root, "attachments", stale.StorageKey)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expired bytes still present: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "attachments", fresh.StorageKey)); err != nil {
+		t.Fatalf("unexpired bytes removed: %v", err)
+	}
+
+	again, err := svc.CleanupExpired(ctx)
+	if err != nil {
+		t.Fatalf("second CleanupExpired: %v", err)
+	}
+	if again != 0 {
+		t.Fatalf("second sweep = %d, want 0", again)
+	}
+}
+
+func TestAttachmentCleanupExpiredPropagatesRepositoryError(t *testing.T) {
+	boom := errors.New("registry unavailable")
+	svc, err := NewAttachmentService(&failingAttachmentRepo{err: boom}, t.TempDir(), nil, accessTestLogger(t))
+	if err != nil {
+		t.Fatalf("NewAttachmentService: %v", err)
+	}
+	ctx := context.Background()
+	if count, err := svc.CleanupExpired(ctx); !errors.Is(err, boom) || count != 0 {
+		t.Fatalf("CleanupExpired = %d, %v; want 0 and %v", count, err, boom)
+	}
+	if err := svc.Release(ctx, "user-a", "task-1", "sess-1", []string{"id"}); !errors.Is(err, boom) {
+		t.Fatalf("Release error = %v, want %v", err, boom)
+	}
+	if err := svc.DeleteByTask(ctx, "task-1"); !errors.Is(err, boom) {
+		t.Fatalf("DeleteByTask error = %v, want %v", err, boom)
+	}
+}
+
+type failingAttachmentRepo struct {
+	repository.AttachmentRepository
+	err error
+}
+
+func (f *failingAttachmentRepo) MarkExpiredMessageAttachments(context.Context, time.Time) ([]*models.TaskMessageAttachment, error) {
+	return nil, f.err
+}
+
+func (f *failingAttachmentRepo) DeleteClaimedMessageAttachments(context.Context, []string, string, string, string) ([]*models.TaskMessageAttachment, error) {
+	return nil, f.err
+}
+
+func (f *failingAttachmentRepo) DeleteMessageAttachmentsByTask(context.Context, string) ([]*models.TaskMessageAttachment, error) {
+	return nil, f.err
+}
+
+func TestAttachmentDescriptorExposesNoStorageKey(t *testing.T) {
+	svc, _, _, _ := newAttachmentTestService(t)
+	attachment := stageTestAttachment(t, svc, "user-a", "f.png", "payload")
+
+	descriptor := svc.Descriptor(attachment)
+	want := AttachmentDescriptor{
+		ID: attachment.ID, Name: "f.png", MimeType: "image/png", Kind: "image",
+		DeliveryMode: attachmentDeliveryModePrompt, SizeBytes: int64(len("payload")),
+		State: models.AttachmentStateStaged, ExpiresAt: attachment.ExpiresAt,
+	}
+	if descriptor != want {
+		t.Fatalf("descriptor = %+v, want %+v", descriptor, want)
+	}
+}
+
+func TestAttachmentRemoveBytesToleratesMissingFile(t *testing.T) {
+	svc, _, _, _ := newAttachmentTestService(t)
+
+	// Neither a missing file nor an empty storage key may panic or log-fail.
+	svc.removeBytes(nil)
+	svc.removeBytes(&models.TaskMessageAttachment{ID: "a"})
+	svc.removeBytes(&models.TaskMessageAttachment{ID: "a", StorageKey: "never-written"})
+}

--- a/apps/backend/internal/task/service/document_service_test.go
+++ b/apps/backend/internal/task/service/document_service_test.go
@@ -1,0 +1,719 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/task/models"
+	sqliterepo "github.com/kandev/kandev/internal/task/repository/sqlite"
+	v1 "github.com/kandev/kandev/pkg/api/v1"
+)
+
+// newDocumentTestService builds a DocumentService over the real SQLite
+// repository used by the rest of the package, plus one task row the document
+// FK can point at.
+func newDocumentTestService(t *testing.T) (*DocumentService, *sqliterepo.Repository) {
+	t.Helper()
+	_, _, repo := createTestService(t)
+	seedDocumentTask(t, repo, "task-doc")
+	return NewDocumentService(repo, accessTestLogger(t)), repo
+}
+
+func seedDocumentTask(t *testing.T, repo *sqliterepo.Repository, taskID string) {
+	t.Helper()
+	ctx := context.Background()
+	if err := repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws-" + taskID, Name: taskID}); err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	if err := repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf-" + taskID, WorkspaceID: "ws-" + taskID, Name: taskID}); err != nil {
+		t.Fatalf("create workflow: %v", err)
+	}
+	if err := repo.CreateTask(ctx, &models.Task{
+		ID: taskID, WorkspaceID: "ws-" + taskID, WorkflowID: "wf-" + taskID, WorkflowStepID: "step-1",
+		Title: taskID, State: v1.TaskStateCreated, Priority: "medium",
+	}); err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+}
+
+// stubDocRepo wraps the real repository so individual calls can fail on demand.
+// Everything not overridden delegates, keeping the surrounding behavior real.
+type stubDocRepo struct {
+	docRepo
+	getDocErr     error
+	getDocErrOnNo int // 1 = fail the first GetDocument, 2 = fail the reload
+	getDocCalls   int
+	getDocNil     bool
+	latestErr     error
+	writeErr      error
+	revisionErr   error
+	deleteErr     error
+	createErr     error
+	updateErr     error
+}
+
+func (s *stubDocRepo) GetDocument(ctx context.Context, taskID, key string) (*models.TaskDocument, error) {
+	s.getDocCalls++
+	if s.getDocErr != nil && (s.getDocErrOnNo == 0 || s.getDocErrOnNo == s.getDocCalls) {
+		return nil, s.getDocErr
+	}
+	if s.getDocNil && s.getDocCalls > 1 {
+		return nil, nil
+	}
+	return s.docRepo.GetDocument(ctx, taskID, key)
+}
+
+func (s *stubDocRepo) GetLatestDocumentRevision(ctx context.Context, taskID, key string) (*models.TaskDocumentRevision, error) {
+	if s.latestErr != nil {
+		return nil, s.latestErr
+	}
+	return s.docRepo.GetLatestDocumentRevision(ctx, taskID, key)
+}
+
+func (s *stubDocRepo) WriteDocumentRevision(ctx context.Context, head *models.TaskDocument, rev *models.TaskDocumentRevision, coalesceID *string) error {
+	if s.writeErr != nil {
+		return s.writeErr
+	}
+	return s.docRepo.WriteDocumentRevision(ctx, head, rev, coalesceID)
+}
+
+func (s *stubDocRepo) GetDocumentRevision(ctx context.Context, id string) (*models.TaskDocumentRevision, error) {
+	if s.revisionErr != nil {
+		return nil, s.revisionErr
+	}
+	return s.docRepo.GetDocumentRevision(ctx, id)
+}
+
+func (s *stubDocRepo) DeleteDocument(ctx context.Context, taskID, key string) error {
+	if s.deleteErr != nil {
+		return s.deleteErr
+	}
+	return s.docRepo.DeleteDocument(ctx, taskID, key)
+}
+
+func (s *stubDocRepo) CreateDocument(ctx context.Context, doc *models.TaskDocument) error {
+	if s.createErr != nil {
+		return s.createErr
+	}
+	return s.docRepo.CreateDocument(ctx, doc)
+}
+
+func (s *stubDocRepo) UpdateDocument(ctx context.Context, doc *models.TaskDocument) error {
+	if s.updateErr != nil {
+		return s.updateErr
+	}
+	return s.docRepo.UpdateDocument(ctx, doc)
+}
+
+func TestDocumentServiceRequiresTaskAndKey(t *testing.T) {
+	svc, _ := newDocumentTestService(t)
+	ctx := context.Background()
+
+	cases := []struct {
+		name string
+		run  func() error
+	}{
+		{"create-no-task", func() error {
+			_, err := svc.CreateOrUpdateDocument(ctx, "", "k", "", "", "", "", "")
+			return err
+		}},
+		{"get-no-task", func() error { _, err := svc.GetDocument(ctx, "", "k"); return err }},
+		{"delete-no-task", func() error { return svc.DeleteDocument(ctx, "", "k") }},
+		{"list-no-task", func() error { _, err := svc.ListDocuments(ctx, ""); return err }},
+		{"revisions-no-task", func() error { _, err := svc.ListRevisions(ctx, "", "k", 10); return err }},
+		{"revert-no-task", func() error { _, err := svc.RevertDocument(ctx, "", "k", "rev"); return err }},
+		{"upload-no-task", func() error {
+			_, err := svc.UploadAttachment(ctx, "", "k", "f.png", "image/png", nil, t.TempDir())
+			return err
+		}},
+	}
+	for _, tc := range cases {
+		if err := tc.run(); !errors.Is(err, ErrDocumentTaskRequired) {
+			t.Fatalf("%s error = %v, want ErrDocumentTaskRequired", tc.name, err)
+		}
+	}
+
+	keyCases := []struct {
+		name string
+		run  func() error
+	}{
+		{"create-no-key", func() error {
+			_, err := svc.CreateOrUpdateDocument(ctx, "task-doc", "", "", "", "", "", "")
+			return err
+		}},
+		{"get-no-key", func() error { _, err := svc.GetDocument(ctx, "task-doc", ""); return err }},
+		{"delete-no-key", func() error { return svc.DeleteDocument(ctx, "task-doc", "") }},
+		{"revisions-no-key", func() error { _, err := svc.ListRevisions(ctx, "task-doc", "", 10); return err }},
+		{"revert-no-key", func() error { _, err := svc.RevertDocument(ctx, "task-doc", "", "rev"); return err }},
+		{"upload-no-key", func() error {
+			_, err := svc.UploadAttachment(ctx, "task-doc", "", "f.png", "image/png", nil, t.TempDir())
+			return err
+		}},
+	}
+	for _, tc := range keyCases {
+		if err := tc.run(); !errors.Is(err, ErrDocumentKeyRequired) {
+			t.Fatalf("%s error = %v, want ErrDocumentKeyRequired", tc.name, err)
+		}
+	}
+}
+
+func TestDocumentServiceCreateAppliesDefaultsAndPersistsRevision(t *testing.T) {
+	svc, repo := newDocumentTestService(t)
+	ctx := context.Background()
+
+	doc, err := svc.CreateOrUpdateDocument(ctx, "task-doc", "notes", "", "", "first body", "", "")
+	if err != nil {
+		t.Fatalf("CreateOrUpdateDocument: %v", err)
+	}
+	if doc.Type != "custom" {
+		t.Fatalf("type = %q, want custom", doc.Type)
+	}
+	if doc.Title != "notes" {
+		t.Fatalf("title = %q, want the key as fallback title", doc.Title)
+	}
+	if doc.AuthorKind != createdByAgent || doc.AuthorName != "Agent" {
+		t.Fatalf("author = %q/%q, want agent/Agent", doc.AuthorKind, doc.AuthorName)
+	}
+	if doc.Content != "first body" {
+		t.Fatalf("content = %q", doc.Content)
+	}
+	if doc.ID == "" || doc.CreatedAt.IsZero() {
+		t.Fatalf("reloaded HEAD must carry DB-set id/timestamps: %+v", doc)
+	}
+
+	revs, err := repo.ListDocumentRevisions(ctx, "task-doc", "notes", 10)
+	if err != nil {
+		t.Fatalf("ListDocumentRevisions: %v", err)
+	}
+	if len(revs) != 1 {
+		t.Fatalf("revisions = %d, want 1", len(revs))
+	}
+	if revs[0].RevisionNumber != 1 || revs[0].Content != "first body" {
+		t.Fatalf("revision = %+v, want number 1 with the created content", revs[0])
+	}
+	if revs[0].AuthorKind != createdByAgent || revs[0].AuthorName != "Agent" {
+		t.Fatalf("revision author = %q/%q, want the defaulted agent author", revs[0].AuthorKind, revs[0].AuthorName)
+	}
+}
+
+func TestDocumentServiceUserAuthorDefaultsToUserName(t *testing.T) {
+	svc, _ := newDocumentTestService(t)
+
+	doc, err := svc.CreateOrUpdateDocument(context.Background(), "task-doc", "k", "custom", "T", "body", "user", "")
+	if err != nil {
+		t.Fatalf("CreateOrUpdateDocument: %v", err)
+	}
+	if doc.AuthorKind != "user" || doc.AuthorName != "User" {
+		t.Fatalf("author = %q/%q, want user/User", doc.AuthorKind, doc.AuthorName)
+	}
+}
+
+func TestDocumentServiceCoalescesSameAuthorWithinWindow(t *testing.T) {
+	svc, repo := newDocumentTestService(t)
+	ctx := context.Background()
+
+	if _, err := svc.CreateOrUpdateDocument(ctx, "task-doc", "k", "custom", "T", "v1", "user", "Ada"); err != nil {
+		t.Fatalf("first write: %v", err)
+	}
+	updated, err := svc.CreateOrUpdateDocument(ctx, "task-doc", "k", "custom", "T", "v2", "user", "Ada")
+	if err != nil {
+		t.Fatalf("second write: %v", err)
+	}
+	if updated.Content != "v2" {
+		t.Fatalf("HEAD content = %q, want v2", updated.Content)
+	}
+
+	revs, err := repo.ListDocumentRevisions(ctx, "task-doc", "k", 10)
+	if err != nil {
+		t.Fatalf("ListDocumentRevisions: %v", err)
+	}
+	if len(revs) != 1 {
+		t.Fatalf("revisions = %d, want 1 (same author inside the window coalesces)", len(revs))
+	}
+	if revs[0].Content != "v2" || revs[0].RevisionNumber != 1 {
+		t.Fatalf("coalesced revision = %+v, want number 1 carrying v2", revs[0])
+	}
+}
+
+func TestDocumentServiceAppendsRevisionForDifferentAuthor(t *testing.T) {
+	svc, repo := newDocumentTestService(t)
+	ctx := context.Background()
+
+	if _, err := svc.CreateOrUpdateDocument(ctx, "task-doc", "k", "custom", "T", "v1", "user", "Ada"); err != nil {
+		t.Fatalf("first write: %v", err)
+	}
+	if _, err := svc.CreateOrUpdateDocument(ctx, "task-doc", "k", "custom", "T", "v2", "user", "Grace"); err != nil {
+		t.Fatalf("second write: %v", err)
+	}
+
+	revs, err := repo.ListDocumentRevisions(ctx, "task-doc", "k", 10)
+	if err != nil {
+		t.Fatalf("ListDocumentRevisions: %v", err)
+	}
+	if len(revs) != 2 {
+		t.Fatalf("revisions = %d, want 2 (different author must not coalesce)", len(revs))
+	}
+	// Newest first.
+	if revs[0].RevisionNumber != 2 || revs[0].AuthorName != "Grace" {
+		t.Fatalf("newest revision = %+v, want number 2 by Grace", revs[0])
+	}
+	if revs[1].RevisionNumber != 1 || revs[1].AuthorName != "Ada" {
+		t.Fatalf("oldest revision = %+v, want number 1 by Ada", revs[1])
+	}
+}
+
+func TestDocumentServiceZeroCoalesceWindowAlwaysAppends(t *testing.T) {
+	svc, repo := newDocumentTestService(t)
+	svc.coalesceWindow = 0
+	ctx := context.Background()
+
+	for i := 0; i < 2; i++ {
+		if _, err := svc.CreateOrUpdateDocument(ctx, "task-doc", "k", "custom", "T", "body", "user", "Ada"); err != nil {
+			t.Fatalf("write %d: %v", i, err)
+		}
+	}
+	revs, err := repo.ListDocumentRevisions(ctx, "task-doc", "k", 10)
+	if err != nil {
+		t.Fatalf("ListDocumentRevisions: %v", err)
+	}
+	if len(revs) != 2 {
+		t.Fatalf("revisions = %d, want 2 with coalescing disabled", len(revs))
+	}
+}
+
+func TestDocumentServiceCanDocCoalesceRules(t *testing.T) {
+	svc, _ := newDocumentTestService(t)
+	now := time.Now().UTC()
+	revertID := "rev-0"
+
+	cases := []struct {
+		name   string
+		latest *models.TaskDocumentRevision
+		window time.Duration
+		want   bool
+	}{
+		{"no latest revision", nil, time.Minute, false},
+		{"latest is a revert", &models.TaskDocumentRevision{
+			AuthorKind: "user", AuthorName: "Ada", UpdatedAt: now, RevertOfRevisionID: &revertID,
+		}, time.Minute, false},
+		{"different author kind", &models.TaskDocumentRevision{
+			AuthorKind: "agent", AuthorName: "Ada", UpdatedAt: now,
+		}, time.Minute, false},
+		{"different author name", &models.TaskDocumentRevision{
+			AuthorKind: "user", AuthorName: "Grace", UpdatedAt: now,
+		}, time.Minute, false},
+		{"outside window", &models.TaskDocumentRevision{
+			AuthorKind: "user", AuthorName: "Ada", UpdatedAt: now.Add(-2 * time.Minute),
+		}, time.Minute, false},
+		{"inside window", &models.TaskDocumentRevision{
+			AuthorKind: "user", AuthorName: "Ada", UpdatedAt: now.Add(-30 * time.Second),
+		}, time.Minute, true},
+	}
+	for _, tc := range cases {
+		svc.coalesceWindow = tc.window
+		if got := svc.canDocCoalesce(tc.latest, "user", "Ada", now); got != tc.want {
+			t.Fatalf("%s: canDocCoalesce = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestDocumentServiceGetDeleteAndList(t *testing.T) {
+	svc, repo := newDocumentTestService(t)
+	ctx := context.Background()
+
+	if _, err := svc.GetDocument(ctx, "task-doc", "missing"); !errors.Is(err, ErrDocumentNotFound) {
+		t.Fatalf("get missing = %v, want ErrDocumentNotFound", err)
+	}
+	if err := svc.DeleteDocument(ctx, "task-doc", "missing"); !errors.Is(err, ErrDocumentNotFound) {
+		t.Fatalf("delete missing = %v, want ErrDocumentNotFound", err)
+	}
+
+	if _, err := svc.CreateOrUpdateDocument(ctx, "task-doc", "b-key", "custom", "B", "b", "user", "Ada"); err != nil {
+		t.Fatalf("create b: %v", err)
+	}
+	if _, err := svc.CreateOrUpdateDocument(ctx, "task-doc", "a-key", "custom", "A", "a", "user", "Ada"); err != nil {
+		t.Fatalf("create a: %v", err)
+	}
+
+	got, err := svc.GetDocument(ctx, "task-doc", "a-key")
+	if err != nil {
+		t.Fatalf("GetDocument: %v", err)
+	}
+	if got.Key != "a-key" || got.Title != "A" || got.Content != "a" {
+		t.Fatalf("document = %+v, want a-key/A/a", got)
+	}
+
+	list, err := svc.ListDocuments(ctx, "task-doc")
+	if err != nil {
+		t.Fatalf("ListDocuments: %v", err)
+	}
+	if len(list) != 2 || list[0].Key != "a-key" || list[1].Key != "b-key" {
+		t.Fatalf("list = %+v, want a-key then b-key", list)
+	}
+
+	if err := svc.DeleteDocument(ctx, "task-doc", "a-key"); err != nil {
+		t.Fatalf("DeleteDocument: %v", err)
+	}
+	remaining, err := repo.ListDocuments(ctx, "task-doc")
+	if err != nil {
+		t.Fatalf("ListDocuments after delete: %v", err)
+	}
+	if len(remaining) != 1 || remaining[0].Key != "b-key" {
+		t.Fatalf("remaining = %+v, want only b-key", remaining)
+	}
+}
+
+func TestDocumentServiceListRevisionsHonorsLimit(t *testing.T) {
+	svc, _ := newDocumentTestService(t)
+	svc.coalesceWindow = 0
+	ctx := context.Background()
+
+	for _, body := range []string{"v1", "v2", "v3"} {
+		if _, err := svc.CreateOrUpdateDocument(ctx, "task-doc", "k", "custom", "T", body, "user", "Ada"); err != nil {
+			t.Fatalf("write %s: %v", body, err)
+		}
+	}
+	revs, err := svc.ListRevisions(ctx, "task-doc", "k", 2)
+	if err != nil {
+		t.Fatalf("ListRevisions: %v", err)
+	}
+	if len(revs) != 2 {
+		t.Fatalf("revisions = %d, want the 2 requested", len(revs))
+	}
+	if revs[0].Content != "v3" || revs[1].Content != "v2" {
+		t.Fatalf("revisions = %q/%q, want newest-first v3/v2", revs[0].Content, revs[1].Content)
+	}
+}
+
+func TestDocumentServiceRevertRestoresTargetRevision(t *testing.T) {
+	svc, repo := newDocumentTestService(t)
+	svc.coalesceWindow = 0
+	ctx := context.Background()
+
+	if _, err := svc.CreateOrUpdateDocument(ctx, "task-doc", "k", "plan", "First", "v1", "user", "Ada"); err != nil {
+		t.Fatalf("write v1: %v", err)
+	}
+	if _, err := svc.CreateOrUpdateDocument(ctx, "task-doc", "k", "plan", "Second", "v2", "user", "Ada"); err != nil {
+		t.Fatalf("write v2: %v", err)
+	}
+	revs, err := repo.ListDocumentRevisions(ctx, "task-doc", "k", 10)
+	if err != nil {
+		t.Fatalf("ListDocumentRevisions: %v", err)
+	}
+	target := revs[len(revs)-1] // oldest = v1
+
+	rev, err := svc.RevertDocument(ctx, "task-doc", "k", target.ID)
+	if err != nil {
+		t.Fatalf("RevertDocument: %v", err)
+	}
+	if rev.Content != "v1" || rev.Title != "First" {
+		t.Fatalf("revert revision = %+v, want v1/First", rev)
+	}
+	if rev.RevertOfRevisionID == nil || *rev.RevertOfRevisionID != target.ID {
+		t.Fatalf("revert_of_revision_id = %v, want %s", rev.RevertOfRevisionID, target.ID)
+	}
+	if rev.AuthorKind != "user" || rev.AuthorName != "User" {
+		t.Fatalf("revert author = %q/%q, want user/User", rev.AuthorKind, rev.AuthorName)
+	}
+
+	head, err := svc.GetDocument(ctx, "task-doc", "k")
+	if err != nil {
+		t.Fatalf("GetDocument after revert: %v", err)
+	}
+	if head.Content != "v1" || head.Title != "First" {
+		t.Fatalf("HEAD after revert = %q/%q, want v1/First", head.Content, head.Title)
+	}
+	if head.Type != "plan" {
+		t.Fatalf("HEAD type = %q, want the existing type preserved", head.Type)
+	}
+}
+
+func TestDocumentServiceRevertRejectsBadTargets(t *testing.T) {
+	svc, repo := newDocumentTestService(t)
+	ctx := context.Background()
+
+	if _, err := svc.RevertDocument(ctx, "task-doc", "k", ""); err == nil || !strings.Contains(err.Error(), "revision_id is required") {
+		t.Fatalf("empty revision id error = %v", err)
+	}
+	if _, err := svc.RevertDocument(ctx, "task-doc", "k", "no-such-revision"); !errors.Is(err, ErrDocumentNotFound) {
+		t.Fatalf("unknown revision = %v, want ErrDocumentNotFound", err)
+	}
+
+	if _, err := svc.CreateOrUpdateDocument(ctx, "task-doc", "other", "custom", "T", "body", "user", "Ada"); err != nil {
+		t.Fatalf("seed other document: %v", err)
+	}
+	otherRevs, err := repo.ListDocumentRevisions(ctx, "task-doc", "other", 10)
+	if err != nil {
+		t.Fatalf("ListDocumentRevisions: %v", err)
+	}
+	_, err = svc.RevertDocument(ctx, "task-doc", "k", otherRevs[0].ID)
+	if err == nil || !strings.Contains(err.Error(), "does not belong") {
+		t.Fatalf("cross-document revert error = %v, want a belonging error", err)
+	}
+}
+
+func TestDocumentServiceUploadAndDownloadAttachment(t *testing.T) {
+	svc, repo := newDocumentTestService(t)
+	ctx := context.Background()
+	base := t.TempDir()
+
+	doc, err := svc.UploadAttachment(ctx, "task-doc", "shot", "screen.png", "image/png", []byte("bytes"), base)
+	if err != nil {
+		t.Fatalf("UploadAttachment: %v", err)
+	}
+	if doc.Type != docTypeAttachment || doc.Filename != "screen.png" || doc.MimeType != "image/png" {
+		t.Fatalf("attachment doc = %+v", doc)
+	}
+	if doc.SizeBytes != int64(len("bytes")) {
+		t.Fatalf("size = %d, want %d", doc.SizeBytes, len("bytes"))
+	}
+	wantPath := filepath.Join(base, "attachments", "task-doc", "shot.png")
+	if doc.DiskPath != wantPath {
+		t.Fatalf("disk path = %q, want %q", doc.DiskPath, wantPath)
+	}
+	written, err := os.ReadFile(doc.DiskPath)
+	if err != nil {
+		t.Fatalf("read written attachment: %v", err)
+	}
+	if string(written) != "bytes" {
+		t.Fatalf("written bytes = %q", written)
+	}
+
+	path, downloaded, err := svc.DownloadAttachment(ctx, "task-doc", "shot")
+	if err != nil {
+		t.Fatalf("DownloadAttachment: %v", err)
+	}
+	if path != wantPath || downloaded.Key != "shot" {
+		t.Fatalf("download = %q/%+v", path, downloaded)
+	}
+
+	// Re-upload replaces in place: same row, preserved id and created_at.
+	second, err := svc.UploadAttachment(ctx, "task-doc", "shot", "screen2.png", "image/png", []byte("more"), base)
+	if err != nil {
+		t.Fatalf("second UploadAttachment: %v", err)
+	}
+	if second.ID != doc.ID {
+		t.Fatalf("re-upload id = %q, want the existing %q", second.ID, doc.ID)
+	}
+	if !second.CreatedAt.Equal(doc.CreatedAt) {
+		t.Fatalf("re-upload created_at = %v, want preserved %v", second.CreatedAt, doc.CreatedAt)
+	}
+	docs, err := repo.ListDocuments(ctx, "task-doc")
+	if err != nil {
+		t.Fatalf("ListDocuments: %v", err)
+	}
+	if len(docs) != 1 || docs[0].Filename != "screen2.png" {
+		t.Fatalf("documents after re-upload = %+v, want one updated row", docs)
+	}
+}
+
+func TestDocumentServiceUploadRejectsUnsafeComponents(t *testing.T) {
+	svc, _ := newDocumentTestService(t)
+	ctx := context.Background()
+	base := t.TempDir()
+
+	cases := []struct{ name, taskID, key, filename string }{
+		{"dot-dot task", "..", "k", "f.png"},
+		{"dot task", ".", "k", "f.png"},
+		{"slash task", "a/b", "k", "f.png"},
+		{"backslash task", `a\b`, "k", "f.png"},
+		{"nul task", "a\x00b", "k", "f.png"},
+		{"dot-dot key", "task-doc", "..", "f.png"},
+		{"slash key", "task-doc", "a/b", "f.png"},
+	}
+	for _, tc := range cases {
+		if _, err := svc.UploadAttachment(ctx, tc.taskID, tc.key, tc.filename, "image/png", []byte("x"), base); !errors.Is(err, ErrInvalidPathComponent) {
+			t.Fatalf("%s: error = %v, want ErrInvalidPathComponent", tc.name, err)
+		}
+	}
+
+	if _, err := svc.UploadAttachment(ctx, "task-doc", "k", "f."+string(rune(0))+"png", "image/png", []byte("x"), base); !errors.Is(err, ErrInvalidPathComponent) {
+		t.Fatalf("NUL extension must be rejected, got %v", err)
+	}
+
+	if entries, err := os.ReadDir(base); err != nil {
+		t.Fatalf("read base dir: %v", err)
+	} else if len(entries) != 0 {
+		t.Fatalf("rejected uploads must not create files, found %d entries", len(entries))
+	}
+}
+
+func TestDocumentServiceUploadRejectsOversizedPayload(t *testing.T) {
+	svc, _ := newDocumentTestService(t)
+
+	_, err := svc.UploadAttachment(context.Background(), "task-doc", "k", "big.bin", "application/octet-stream",
+		make([]byte, maxAttachmentBytes+1), t.TempDir())
+	if !errors.Is(err, ErrAttachmentTooLarge) {
+		t.Fatalf("oversized upload = %v, want ErrAttachmentTooLarge", err)
+	}
+}
+
+func TestDocumentServiceDownloadRejectsNonAttachments(t *testing.T) {
+	svc, repo := newDocumentTestService(t)
+	ctx := context.Background()
+
+	if _, err := svc.CreateOrUpdateDocument(ctx, "task-doc", "notes", "custom", "T", "body", "user", "Ada"); err != nil {
+		t.Fatalf("seed document: %v", err)
+	}
+	if _, _, err := svc.DownloadAttachment(ctx, "task-doc", "notes"); err == nil || !strings.Contains(err.Error(), "not an attachment") {
+		t.Fatalf("non-attachment download = %v", err)
+	}
+	if _, _, err := svc.DownloadAttachment(ctx, "task-doc", "missing"); !errors.Is(err, ErrDocumentNotFound) {
+		t.Fatalf("missing download = %v, want ErrDocumentNotFound", err)
+	}
+
+	// An attachment row whose disk path was lost still fails loudly.
+	if err := repo.CreateDocument(ctx, &models.TaskDocument{
+		ID: "doc-pathless", TaskID: "task-doc", Key: "pathless", Type: docTypeAttachment,
+		Title: "x", AuthorKind: "user", AuthorName: "User",
+	}); err != nil {
+		t.Fatalf("seed pathless attachment: %v", err)
+	}
+	if _, _, err := svc.DownloadAttachment(ctx, "task-doc", "pathless"); err == nil || !strings.Contains(err.Error(), "no disk path") {
+		t.Fatalf("pathless download = %v", err)
+	}
+}
+
+func TestDocumentServiceUpdatePreservesAttachmentFields(t *testing.T) {
+	svc, _ := newDocumentTestService(t)
+	ctx := context.Background()
+
+	if _, err := svc.UploadAttachment(ctx, "task-doc", "shot", "screen.png", "image/png", []byte("bytes"), t.TempDir()); err != nil {
+		t.Fatalf("UploadAttachment: %v", err)
+	}
+	updated, err := svc.CreateOrUpdateDocument(ctx, "task-doc", "shot", docTypeAttachment, "Caption", "note", "user", "Ada")
+	if err != nil {
+		t.Fatalf("CreateOrUpdateDocument: %v", err)
+	}
+	if updated.Filename != "screen.png" || updated.MimeType != "image/png" || updated.DiskPath == "" {
+		t.Fatalf("attachment fields lost on update: %+v", updated)
+	}
+	if updated.SizeBytes != int64(len("bytes")) {
+		t.Fatalf("size = %d, want the preserved %d", updated.SizeBytes, len("bytes"))
+	}
+
+	// Changing the type away from attachment drops them, by design.
+	retyped, err := svc.CreateOrUpdateDocument(ctx, "task-doc", "shot", "custom", "Caption", "note", "user", "Ada")
+	if err != nil {
+		t.Fatalf("retype: %v", err)
+	}
+	if retyped.Filename != "" || retyped.DiskPath != "" {
+		t.Fatalf("non-attachment type must not keep attachment fields: %+v", retyped)
+	}
+}
+
+func TestDocumentServicePropagatesRepositoryErrors(t *testing.T) {
+	_, _, repo := createTestService(t)
+	seedDocumentTask(t, repo, "task-doc")
+	ctx := context.Background()
+	boom := errors.New("db unavailable")
+
+	t.Run("get document fails", func(t *testing.T) {
+		svc := NewDocumentService(&stubDocRepo{docRepo: repo, getDocErr: boom}, accessTestLogger(t))
+		_, err := svc.CreateOrUpdateDocument(ctx, "task-doc", "k", "", "", "", "", "")
+		if !errors.Is(err, boom) || !strings.Contains(err.Error(), "get document") {
+			t.Fatalf("error = %v, want a wrapped get document failure", err)
+		}
+		if _, err := svc.GetDocument(ctx, "task-doc", "k"); !errors.Is(err, boom) {
+			t.Fatalf("GetDocument error = %v, want %v", err, boom)
+		}
+		if err := svc.DeleteDocument(ctx, "task-doc", "k"); !errors.Is(err, boom) {
+			t.Fatalf("DeleteDocument error = %v, want %v", err, boom)
+		}
+		if _, err := svc.UploadAttachment(ctx, "task-doc", "k", "f.png", "image/png", []byte("x"), t.TempDir()); !errors.Is(err, boom) {
+			t.Fatalf("UploadAttachment error = %v, want %v", err, boom)
+		}
+	})
+
+	t.Run("latest revision fails", func(t *testing.T) {
+		svc := NewDocumentService(&stubDocRepo{docRepo: repo, latestErr: boom}, accessTestLogger(t))
+		_, err := svc.CreateOrUpdateDocument(ctx, "task-doc", "k", "", "", "", "", "")
+		if !errors.Is(err, boom) || !strings.Contains(err.Error(), "get latest revision") {
+			t.Fatalf("error = %v, want a wrapped latest-revision failure", err)
+		}
+	})
+
+	t.Run("write revision fails", func(t *testing.T) {
+		svc := NewDocumentService(&stubDocRepo{docRepo: repo, writeErr: boom}, accessTestLogger(t))
+		if _, err := svc.CreateOrUpdateDocument(ctx, "task-doc", "k", "", "", "", "", ""); !errors.Is(err, boom) {
+			t.Fatalf("error = %v, want %v", err, boom)
+		}
+		if _, err := svc.RevertDocument(ctx, "task-doc", "k", "rev"); err == nil {
+			t.Fatal("revert must fail when the revision write fails")
+		}
+	})
+
+	t.Run("reload fails", func(t *testing.T) {
+		svc := NewDocumentService(&stubDocRepo{docRepo: repo, getDocErr: boom, getDocErrOnNo: 2}, accessTestLogger(t))
+		_, err := svc.CreateOrUpdateDocument(ctx, "task-doc", "reload-k", "", "", "body", "", "")
+		if !errors.Is(err, boom) || !strings.Contains(err.Error(), "reload document") {
+			t.Fatalf("error = %v, want a wrapped reload failure", err)
+		}
+	})
+
+	t.Run("reload returns nothing", func(t *testing.T) {
+		svc := NewDocumentService(&stubDocRepo{docRepo: repo, getDocNil: true}, accessTestLogger(t))
+		doc, err := svc.CreateOrUpdateDocument(ctx, "task-doc", "nil-k", "", "", "body", "", "")
+		if err != nil {
+			t.Fatalf("CreateOrUpdateDocument: %v", err)
+		}
+		if doc == nil || doc.Content != "body" || doc.Key != "nil-k" {
+			t.Fatalf("doc = %+v, want the in-memory HEAD as fallback", doc)
+		}
+	})
+
+	t.Run("revert head lookup fails", func(t *testing.T) {
+		seed := NewDocumentService(repo, accessTestLogger(t))
+		if _, err := seed.CreateOrUpdateDocument(ctx, "task-doc", "revert-k", "", "", "body", "", ""); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		revs, err := repo.ListDocumentRevisions(ctx, "task-doc", "revert-k", 1)
+		if err != nil || len(revs) != 1 {
+			t.Fatalf("seed revisions = %v, %v", revs, err)
+		}
+		svc := NewDocumentService(&stubDocRepo{docRepo: repo, getDocErr: boom}, accessTestLogger(t))
+		if _, err := svc.RevertDocument(ctx, "task-doc", "revert-k", revs[0].ID); !errors.Is(err, boom) {
+			t.Fatalf("error = %v, want %v", err, boom)
+		}
+	})
+
+	t.Run("revision lookup fails", func(t *testing.T) {
+		svc := NewDocumentService(&stubDocRepo{docRepo: repo, revisionErr: boom}, accessTestLogger(t))
+		if _, err := svc.RevertDocument(ctx, "task-doc", "k", "rev"); !errors.Is(err, boom) {
+			t.Fatalf("error = %v, want %v", err, boom)
+		}
+	})
+
+	t.Run("delete fails", func(t *testing.T) {
+		svc := NewDocumentService(&stubDocRepo{docRepo: repo, deleteErr: boom}, accessTestLogger(t))
+		if _, err := svc.CreateOrUpdateDocument(ctx, "task-doc", "del-k", "", "", "body", "", ""); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		if err := svc.DeleteDocument(ctx, "task-doc", "del-k"); !errors.Is(err, boom) {
+			t.Fatalf("error = %v, want %v", err, boom)
+		}
+	})
+
+	t.Run("attachment persistence fails", func(t *testing.T) {
+		createSvc := NewDocumentService(&stubDocRepo{docRepo: repo, createErr: boom}, accessTestLogger(t))
+		if _, err := createSvc.UploadAttachment(ctx, "task-doc", "new-att", "f.png", "image/png", []byte("x"), t.TempDir()); !errors.Is(err, boom) ||
+			!strings.Contains(err.Error(), "create attachment document") {
+			t.Fatalf("create error = %v, want a wrapped create failure", err)
+		}
+
+		updateSvc := NewDocumentService(&stubDocRepo{docRepo: repo, updateErr: boom}, accessTestLogger(t))
+		base := t.TempDir()
+		if _, err := updateSvc.UploadAttachment(ctx, "task-doc", "att", "f.png", "image/png", []byte("x"), base); err != nil {
+			t.Fatalf("first upload: %v", err)
+		}
+		if _, err := updateSvc.UploadAttachment(ctx, "task-doc", "att", "f.png", "image/png", []byte("y"), base); !errors.Is(err, boom) ||
+			!strings.Contains(err.Error(), "update attachment document") {
+			t.Fatalf("update error = %v, want a wrapped update failure", err)
+		}
+	})
+}

--- a/apps/backend/internal/task/service/document_service_test.go
+++ b/apps/backend/internal/task/service/document_service_test.go
@@ -643,8 +643,20 @@ func TestDocumentServicePropagatesRepositoryErrors(t *testing.T) {
 		if _, err := svc.CreateOrUpdateDocument(ctx, "task-doc", "k", "", "", "", "", ""); !errors.Is(err, boom) {
 			t.Fatalf("error = %v, want %v", err, boom)
 		}
-		if _, err := svc.RevertDocument(ctx, "task-doc", "k", "rev"); err == nil {
-			t.Fatal("revert must fail when the revision write fails")
+
+		// Revert reaches WriteDocumentRevision only once the target revision
+		// resolves, so seed a real one first — otherwise the revision lookup
+		// short-circuits and the injected write error is never exercised.
+		seed := NewDocumentService(repo, accessTestLogger(t))
+		if _, err := seed.CreateOrUpdateDocument(ctx, "task-doc", "revert-write-k", "", "", "body", "", ""); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		revs, err := repo.ListDocumentRevisions(ctx, "task-doc", "revert-write-k", 1)
+		if err != nil || len(revs) != 1 {
+			t.Fatalf("seed revisions = %v, %v", revs, err)
+		}
+		if _, err := svc.RevertDocument(ctx, "task-doc", "revert-write-k", revs[0].ID); !errors.Is(err, boom) {
+			t.Fatalf("revert write error = %v, want %v", err, boom)
 		}
 	})
 

--- a/apps/backend/internal/task/service/handoff_documents_test.go
+++ b/apps/backend/internal/task/service/handoff_documents_test.go
@@ -1,0 +1,223 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	officemodels "github.com/kandev/kandev/internal/office/models"
+	"github.com/kandev/kandev/internal/task/models"
+	sqliterepo "github.com/kandev/kandev/internal/task/repository/sqlite"
+	v1 "github.com/kandev/kandev/pkg/api/v1"
+)
+
+// docBlockerRepo is a BlockerRepository stub that only answers the blocker
+// lookup the document read guard uses.
+type docBlockerRepo struct {
+	BlockerRepository
+	blockers map[string][]string
+	err      error
+}
+
+func (d *docBlockerRepo) ListTaskBlockers(_ context.Context, taskID string) ([]*officemodels.TaskBlocker, error) {
+	if d.err != nil {
+		return nil, d.err
+	}
+	out := make([]*officemodels.TaskBlocker, 0, len(d.blockers[taskID]))
+	for _, blockerID := range d.blockers[taskID] {
+		out = append(out, &officemodels.TaskBlocker{TaskID: taskID, BlockerTaskID: blockerID})
+	}
+	return out, nil
+}
+
+// newDocumentHandoffService wires a HandoffService over the real repository
+// with a task tree: parent → (child-a, child-b), plus an unrelated task.
+func newDocumentHandoffService(t *testing.T, blockers *docBlockerRepo) (*HandoffService, *sqliterepo.Repository) {
+	t.Helper()
+	_, _, repo := createTestService(t)
+	ctx := context.Background()
+	if err := repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws-handoff", Name: "Handoff"}); err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	if err := repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws-other", Name: "Other"}); err != nil {
+		t.Fatalf("create other workspace: %v", err)
+	}
+	if err := repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf-handoff", WorkspaceID: "ws-handoff", Name: "flow"}); err != nil {
+		t.Fatalf("create workflow: %v", err)
+	}
+	if err := repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf-other", WorkspaceID: "ws-other", Name: "other flow"}); err != nil {
+		t.Fatalf("create other workflow: %v", err)
+	}
+	seed := func(id, parentID, workspaceID, workflowID string) {
+		if err := repo.CreateTask(ctx, &models.Task{
+			ID: id, WorkspaceID: workspaceID, WorkflowID: workflowID, WorkflowStepID: "step-1",
+			Title: id, State: v1.TaskStateCreated, Priority: "medium", ParentID: parentID,
+		}); err != nil {
+			t.Fatalf("create task %s: %v", id, err)
+		}
+	}
+	seed("parent", "", "ws-handoff", "wf-handoff")
+	seed("child-a", "parent", "ws-handoff", "wf-handoff")
+	seed("child-b", "parent", "ws-handoff", "wf-handoff")
+	seed("stranger", "", "ws-handoff", "wf-handoff")
+	seed("foreign", "", "ws-other", "wf-other")
+
+	log := accessTestLogger(t)
+	docs := NewDocumentService(repo, log)
+	var blockerRepo BlockerRepository
+	if blockers != nil {
+		blockerRepo = blockers
+	}
+	return NewHandoffService(repo, repo, docs, blockerRepo, nil, log), repo
+}
+
+func TestGetDocumentForCallerEnforcesReadAccess(t *testing.T) {
+	svc, repo := newDocumentHandoffService(t, nil)
+	ctx := context.Background()
+	seedHandoffDocument(t, repo, "parent", "spec", "parent body")
+	seedHandoffDocument(t, repo, "stranger", "spec", "stranger body")
+	seedHandoffDocument(t, repo, "foreign", "spec", "foreign body")
+
+	if _, err := svc.GetDocumentForCaller(ctx, "child-a", "parent", ""); !errors.Is(err, ErrDocumentKeyRequired) {
+		t.Fatalf("empty key = %v, want ErrDocumentKeyRequired", err)
+	}
+	if _, err := svc.GetDocumentForCaller(ctx, "child-a", "", "spec"); !errors.Is(err, ErrDocumentTaskRequired) {
+		t.Fatalf("empty target = %v, want ErrDocumentTaskRequired", err)
+	}
+
+	// Ancestor, self, and sibling reads are allowed.
+	for _, pair := range [][2]string{{"child-a", "parent"}, {"parent", "parent"}} {
+		doc, err := svc.GetDocumentForCaller(ctx, pair[0], pair[1], "spec")
+		if err != nil {
+			t.Fatalf("%s reading %s: %v", pair[0], pair[1], err)
+		}
+		if doc.Content != "parent body" {
+			t.Fatalf("content = %q", doc.Content)
+		}
+	}
+	seedHandoffDocument(t, repo, "child-b", "notes", "sibling body")
+	sibling, err := svc.GetDocumentForCaller(ctx, "child-a", "child-b", "notes")
+	if err != nil {
+		t.Fatalf("sibling read: %v", err)
+	}
+	if sibling.Content != "sibling body" {
+		t.Fatalf("sibling content = %q", sibling.Content)
+	}
+
+	// Unrelated same-workspace task and cross-workspace task are denied.
+	if _, err := svc.GetDocumentForCaller(ctx, "child-a", "stranger", "spec"); !errors.Is(err, ErrAccessDenied) {
+		t.Fatalf("unrelated read = %v, want ErrAccessDenied", err)
+	}
+	if _, err := svc.GetDocumentForCaller(ctx, "child-a", "foreign", "spec"); !errors.Is(err, ErrAccessDenied) {
+		t.Fatalf("cross-workspace read = %v, want ErrAccessDenied", err)
+	}
+}
+
+func TestGetDocumentForCallerGrantsBlockerReads(t *testing.T) {
+	blockers := &docBlockerRepo{blockers: map[string][]string{"stranger": {"child-a"}}}
+	svc, repo := newDocumentHandoffService(t, blockers)
+	ctx := context.Background()
+	seedHandoffDocument(t, repo, "child-a", "spec", "producer body")
+
+	doc, err := svc.GetDocumentForCaller(ctx, "stranger", "child-a", "spec")
+	if err != nil {
+		t.Fatalf("blocker read: %v", err)
+	}
+	if doc.Content != "producer body" {
+		t.Fatalf("content = %q", doc.Content)
+	}
+
+	// The edge is directional: the producer cannot read back through it.
+	seedHandoffDocument(t, repo, "stranger", "spec", "consumer body")
+	if _, err := svc.GetDocumentForCaller(ctx, "child-a", "stranger", "spec"); !errors.Is(err, ErrAccessDenied) {
+		t.Fatalf("reverse blocker read = %v, want ErrAccessDenied", err)
+	}
+	// Blocker edges never grant writes.
+	if _, err := svc.WriteDocumentForCaller(ctx, "stranger", "child-a", "spec", "", "", "x", "", ""); !errors.Is(err, ErrAccessDenied) {
+		t.Fatalf("blocker write = %v, want ErrAccessDenied", err)
+	}
+}
+
+func TestListDocumentsForCallerStripsContent(t *testing.T) {
+	svc, repo := newDocumentHandoffService(t, nil)
+	ctx := context.Background()
+	seedHandoffDocument(t, repo, "parent", "spec", "secret body")
+	seedHandoffDocument(t, repo, "parent", "notes", "another secret")
+
+	if _, err := svc.ListDocumentsForCaller(ctx, "child-a", ""); !errors.Is(err, ErrDocumentTaskRequired) {
+		t.Fatalf("empty target = %v, want ErrDocumentTaskRequired", err)
+	}
+	if _, err := svc.ListDocumentsForCaller(ctx, "child-a", "stranger"); !errors.Is(err, ErrAccessDenied) {
+		t.Fatalf("unrelated list = %v, want ErrAccessDenied", err)
+	}
+
+	listed, err := svc.ListDocumentsForCaller(ctx, "child-a", "parent")
+	if err != nil {
+		t.Fatalf("ListDocumentsForCaller: %v", err)
+	}
+	if len(listed) != 2 {
+		t.Fatalf("listed %d documents, want 2", len(listed))
+	}
+	keys := map[string]bool{}
+	for _, doc := range listed {
+		keys[doc.Key] = true
+		if doc.Content != "" {
+			t.Fatalf("document %q leaked content %q through the metadata listing", doc.Key, doc.Content)
+		}
+	}
+	if !keys["spec"] || !keys["notes"] {
+		t.Fatalf("listed keys = %v, want spec and notes", keys)
+	}
+
+	// The stripping is a copy: the stored rows keep their bodies.
+	stored, err := repo.GetDocument(ctx, "parent", "spec")
+	if err != nil {
+		t.Fatalf("GetDocument: %v", err)
+	}
+	if stored.Content != "secret body" {
+		t.Fatalf("stored content = %q, want it untouched", stored.Content)
+	}
+}
+
+func TestWriteDocumentForCallerEnforcesWriteAccess(t *testing.T) {
+	svc, repo := newDocumentHandoffService(t, nil)
+	ctx := context.Background()
+
+	if _, err := svc.WriteDocumentForCaller(ctx, "child-a", "parent", "", "", "", "body", "", ""); !errors.Is(err, ErrDocumentKeyRequired) {
+		t.Fatalf("empty key = %v, want ErrDocumentKeyRequired", err)
+	}
+	if _, err := svc.WriteDocumentForCaller(ctx, "child-a", "", "spec", "", "", "body", "", ""); !errors.Is(err, ErrDocumentTaskRequired) {
+		t.Fatalf("empty target = %v, want ErrDocumentTaskRequired", err)
+	}
+	if _, err := svc.WriteDocumentForCaller(ctx, "child-a", "stranger", "spec", "", "", "body", "", ""); !errors.Is(err, ErrAccessDenied) {
+		t.Fatalf("unrelated write = %v, want ErrAccessDenied", err)
+	}
+	if _, err := svc.WriteDocumentForCaller(ctx, "child-a", "foreign", "spec", "", "", "body", "", ""); !errors.Is(err, ErrAccessDenied) {
+		t.Fatalf("cross-workspace write = %v, want ErrAccessDenied", err)
+	}
+
+	doc, err := svc.WriteDocumentForCaller(ctx, "child-a", "child-a", "spec", "custom", "Spec", "own body", "user", "Ada")
+	if err != nil {
+		t.Fatalf("self write: %v", err)
+	}
+	if doc.Content != "own body" || doc.Title != "Spec" || doc.AuthorName != "Ada" {
+		t.Fatalf("document = %+v", doc)
+	}
+	stored, err := repo.GetDocument(ctx, "child-a", "spec")
+	if err != nil {
+		t.Fatalf("GetDocument: %v", err)
+	}
+	if stored.Content != "own body" {
+		t.Fatalf("persisted content = %q", stored.Content)
+	}
+}
+
+func seedHandoffDocument(t *testing.T, repo *sqliterepo.Repository, taskID, key, content string) {
+	t.Helper()
+	if err := repo.CreateDocument(context.Background(), &models.TaskDocument{
+		TaskID: taskID, Key: key, Type: "custom", Title: key, Content: content,
+		AuthorKind: "user", AuthorName: "User",
+	}); err != nil {
+		t.Fatalf("seed document %s/%s: %v", taskID, key, err)
+	}
+}

--- a/apps/backend/internal/task/service/service_messages_coverage_test.go
+++ b/apps/backend/internal/task/service/service_messages_coverage_test.go
@@ -1,0 +1,666 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/agentctl/types/streams"
+	"github.com/kandev/kandev/internal/events"
+	"github.com/kandev/kandev/internal/task/models"
+	"github.com/kandev/kandev/internal/task/repository/repoerrors"
+	sqliterepo "github.com/kandev/kandev/internal/task/repository/sqlite"
+	v1 "github.com/kandev/kandev/pkg/api/v1"
+)
+
+// newMessageTestService seeds one workspace/workflow/task/session so message
+// writes have a real session and task to hang off.
+func newMessageTestService(t *testing.T) (*Service, *MockEventBus, *sqliterepo.Repository) {
+	t.Helper()
+	svc, bus, repo := createTestService(t)
+	ctx := context.Background()
+	if err := repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws-msg", Name: "Messages"}); err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	if err := repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf-msg", WorkspaceID: "ws-msg", Name: "flow"}); err != nil {
+		t.Fatalf("create workflow: %v", err)
+	}
+	if err := repo.CreateTask(ctx, &models.Task{
+		ID: "task-msg", WorkspaceID: "ws-msg", WorkflowID: "wf-msg", WorkflowStepID: "step-1",
+		Title: "Messages", State: v1.TaskStateCreated, Priority: "medium",
+	}); err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	if err := repo.CreateTaskSession(ctx, &models.TaskSession{
+		ID: "sess-msg", TaskID: "task-msg", State: models.TaskSessionStateCreated,
+	}); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	seedTurn(t, repo, "turn-msg", "sess-msg", "task-msg")
+	bus.ClearEvents()
+	return svc, bus, repo
+}
+
+// seedTurn inserts the turn row that every message must reference.
+func seedTurn(t *testing.T, repo *sqliterepo.Repository, turnID, sessionID, taskID string) {
+	t.Helper()
+	now := time.Now().UTC()
+	if err := repo.CreateTurn(context.Background(), &models.Turn{
+		ID: turnID, TaskSessionID: sessionID, TaskID: taskID, StartedAt: now, CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("seed turn %s: %v", turnID, err)
+	}
+}
+
+func seedMessage(t *testing.T, repo *sqliterepo.Repository, message *models.Message) *models.Message {
+	t.Helper()
+	if message.TurnID == "" {
+		message.TurnID = "turn-msg"
+	}
+	if message.TaskSessionID == "" {
+		message.TaskSessionID = "sess-msg"
+	}
+	if message.TaskID == "" {
+		message.TaskID = "task-msg"
+	}
+	if message.Type == "" {
+		message.Type = models.MessageTypeMessage
+	}
+	if message.AuthorType == "" {
+		message.AuthorType = models.MessageAuthorAgent
+	}
+	if err := repo.CreateMessage(context.Background(), message); err != nil {
+		t.Fatalf("seed message %s: %v", message.ID, err)
+	}
+	return message
+}
+
+func TestCreateMessageAppliesDefaultsStartsTurnAndPublishes(t *testing.T) {
+	svc, bus, repo := newMessageTestService(t)
+	ctx := context.Background()
+
+	message, err := svc.CreateMessage(ctx, &CreateMessageRequest{
+		TaskSessionID: "sess-msg",
+		Content:       "hello",
+	})
+	if err != nil {
+		t.Fatalf("CreateMessage: %v", err)
+	}
+	if message.AuthorType != models.MessageAuthorUser {
+		t.Fatalf("author type = %q, want the user default", message.AuthorType)
+	}
+	if message.Type != models.MessageTypeMessage {
+		t.Fatalf("type = %q, want the message default", message.Type)
+	}
+	if message.TaskID != "task-msg" {
+		t.Fatalf("task id = %q, want it resolved from the session", message.TaskID)
+	}
+	if message.TurnID == "" {
+		t.Fatal("turn id must be filled by starting a turn")
+	}
+
+	stored, err := repo.GetMessage(ctx, message.ID)
+	if err != nil {
+		t.Fatalf("GetMessage: %v", err)
+	}
+	if stored.Content != "hello" || stored.TurnID != message.TurnID {
+		t.Fatalf("persisted message = %+v", stored)
+	}
+	turn, err := repo.GetTurn(ctx, message.TurnID)
+	if err != nil {
+		t.Fatalf("GetTurn: %v", err)
+	}
+	if turn.CompletedAt != nil {
+		t.Fatal("a normal message must start an open turn")
+	}
+
+	types := eventTypes(bus.GetPublishedEvents())
+	if len(types) == 0 || types[len(types)-1] != events.MessageAdded {
+		t.Fatalf("published %v, want a trailing %s", types, events.MessageAdded)
+	}
+}
+
+func TestCreateMessageHonorsExplicitFields(t *testing.T) {
+	svc, _, _ := newMessageTestService(t)
+	ctx := context.Background()
+
+	message, err := svc.CreateMessage(ctx, &CreateMessageRequest{
+		TaskSessionID: "sess-msg",
+		TaskID:        "task-msg",
+		TurnID:        "turn-msg",
+		AuthorType:    "agent",
+		AuthorID:      "agent-1",
+		Type:          string(models.MessageTypeToolExecute),
+		Content:       "run",
+		RequestsInput: true,
+		Metadata:      map[string]interface{}{"tool_call_id": "tc-1"},
+	})
+	if err != nil {
+		t.Fatalf("CreateMessage: %v", err)
+	}
+	if message.AuthorType != models.MessageAuthorAgent || message.AuthorID != "agent-1" {
+		t.Fatalf("author = %q/%q", message.AuthorType, message.AuthorID)
+	}
+	if message.Type != models.MessageTypeToolExecute {
+		t.Fatalf("type = %q", message.Type)
+	}
+	if message.TurnID != "turn-msg" {
+		t.Fatalf("turn id = %q, want the supplied turn preserved", message.TurnID)
+	}
+	if !message.RequestsInput {
+		t.Fatal("requests_input must be carried through")
+	}
+	if message.Metadata["tool_call_id"] != "tc-1" {
+		t.Fatalf("metadata = %v", message.Metadata)
+	}
+}
+
+func TestCreateMessageWithCompletedTurnRecordsClosedTurn(t *testing.T) {
+	svc, _, repo := newMessageTestService(t)
+	ctx := context.Background()
+
+	message, err := svc.CreateMessage(ctx, &CreateMessageRequest{
+		TaskSessionID: "sess-msg",
+		Content:       "already done",
+		CompletedTurn: true,
+	})
+	if err != nil {
+		t.Fatalf("CreateMessage: %v", err)
+	}
+	turn, err := repo.GetTurn(ctx, message.TurnID)
+	if err != nil {
+		t.Fatalf("GetTurn: %v", err)
+	}
+	if turn.CompletedAt == nil {
+		t.Fatal("CompletedTurn must create an already-completed turn")
+	}
+	if turn.TaskSessionID != "sess-msg" || turn.TaskID != "task-msg" {
+		t.Fatalf("turn = %+v, want it bound to the session's task", turn)
+	}
+}
+
+func TestCreateMessageFailsWhenSessionIsUnknown(t *testing.T) {
+	svc, bus, _ := newMessageTestService(t)
+
+	if _, err := svc.CreateMessage(context.Background(), &CreateMessageRequest{
+		TaskSessionID: "sess-missing", Content: "x",
+	}); err == nil {
+		t.Fatal("CreateMessage must fail for an unknown session")
+	}
+	if published := bus.GetPublishedEvents(); len(published) != 0 {
+		t.Fatalf("failed create published %d events, want none", len(published))
+	}
+}
+
+func TestCreateMessageIdempotentReplaysExistingRow(t *testing.T) {
+	svc, bus, repo := newMessageTestService(t)
+	ctx := context.Background()
+
+	if _, err := svc.CreateMessageIdempotent(ctx, "", &CreateMessageRequest{TaskSessionID: "sess-msg"}); err == nil {
+		t.Fatal("an empty id must be rejected")
+	}
+
+	first, err := svc.CreateMessageIdempotent(ctx, "msg-idem", &CreateMessageRequest{
+		TaskSessionID: "sess-msg", Content: "first",
+	})
+	if err != nil {
+		t.Fatalf("first CreateMessageIdempotent: %v", err)
+	}
+	if first.ID != "msg-idem" {
+		t.Fatalf("id = %q, want the caller-owned id", first.ID)
+	}
+	afterFirst := len(bus.GetPublishedEvents())
+
+	replay, err := svc.CreateMessageIdempotent(ctx, "msg-idem", &CreateMessageRequest{
+		TaskSessionID: "sess-msg", Content: "second",
+	})
+	if err != nil {
+		t.Fatalf("replayed CreateMessageIdempotent: %v", err)
+	}
+	if replay.Content != "first" {
+		t.Fatalf("replay content = %q, want the committed first row", replay.Content)
+	}
+	if got := len(bus.GetPublishedEvents()); got != afterFirst {
+		t.Fatalf("replay published %d extra events, want none", got-afterFirst)
+	}
+
+	all, err := repo.ListMessages(ctx, "sess-msg")
+	if err != nil {
+		t.Fatalf("ListMessages: %v", err)
+	}
+	if len(all) != 1 {
+		t.Fatalf("stored %d messages, want the replay to be a no-op", len(all))
+	}
+}
+
+func TestCreateMessageWithIDPersistsCallerID(t *testing.T) {
+	svc, bus, repo := newMessageTestService(t)
+	ctx := context.Background()
+
+	message, err := svc.CreateMessageWithID(ctx, "msg-stream", &CreateMessageRequest{
+		TaskSessionID: "sess-msg", AuthorType: "agent", Content: "chunk",
+	})
+	if err != nil {
+		t.Fatalf("CreateMessageWithID: %v", err)
+	}
+	if message.ID != "msg-stream" || message.AuthorType != models.MessageAuthorAgent {
+		t.Fatalf("message = %+v", message)
+	}
+	if message.TurnID == "" {
+		t.Fatal("streaming create must resolve a turn")
+	}
+	if _, err := repo.GetMessage(ctx, "msg-stream"); err != nil {
+		t.Fatalf("persisted lookup: %v", err)
+	}
+	types := eventTypes(bus.GetPublishedEvents())
+	if len(types) == 0 || types[len(types)-1] != events.MessageAdded {
+		t.Fatalf("published %v, want a trailing %s", types, events.MessageAdded)
+	}
+}
+
+func TestGetMessageScopesToSessionOwner(t *testing.T) {
+	svc, _, repo := createTestService(t)
+	seedScopedWorkspaces(t, repo)
+	seedTurn(t, repo, "turn-b", "sess-b", "task-b")
+	seedMessage(t, repo, &models.Message{
+		ID: "msg-b", TaskSessionID: "sess-b", TaskID: "task-b", TurnID: "turn-b", Content: "secret output",
+	})
+
+	if _, err := svc.GetMessage(ctxAs("user-a"), "msg-b"); !errors.Is(err, repoerrors.ErrTaskNotFound) {
+		t.Fatalf("foreign GetMessage = %v, want ErrTaskNotFound", err)
+	}
+	got, err := svc.GetMessage(ctxAs("user-b"), "msg-b")
+	if err != nil {
+		t.Fatalf("owner GetMessage: %v", err)
+	}
+	if got.Content != "secret output" {
+		t.Fatalf("content = %q", got.Content)
+	}
+	if _, err := svc.GetMessage(context.Background(), "msg-b"); err != nil {
+		t.Fatalf("internal GetMessage: %v", err)
+	}
+}
+
+func TestListMessagesPaginatedClampsLimit(t *testing.T) {
+	svc, _, repo := newMessageTestService(t)
+	ctx := context.Background()
+	for _, id := range []string{"m1", "m2", "m3"} {
+		seedMessage(t, repo, &models.Message{ID: id, Content: id})
+	}
+
+	all, _, err := svc.ListMessagesPaginated(ctx, ListMessagesRequest{TaskSessionID: "sess-msg"})
+	if err != nil {
+		t.Fatalf("ListMessagesPaginated: %v", err)
+	}
+	if len(all) != 3 {
+		t.Fatalf("unpaginated list = %d, want 3", len(all))
+	}
+
+	page, hasMore, err := svc.ListMessagesPaginated(ctx, ListMessagesRequest{
+		TaskSessionID: "sess-msg", Limit: 2,
+	})
+	if err != nil {
+		t.Fatalf("paginated: %v", err)
+	}
+	if len(page) != 2 || !hasMore {
+		t.Fatalf("page = %d messages, hasMore = %v; want 2 and true", len(page), hasMore)
+	}
+
+	clamped, _, err := svc.ListMessagesPaginated(ctx, ListMessagesRequest{
+		TaskSessionID: "sess-msg", Limit: MaxMessagesPageSize + 500,
+	})
+	if err != nil {
+		t.Fatalf("clamped: %v", err)
+	}
+	if len(clamped) != 3 {
+		t.Fatalf("clamped list = %d, want all 3", len(clamped))
+	}
+}
+
+func TestListMessagesForPluginFiltersBySession(t *testing.T) {
+	svc, _, repo := newMessageTestService(t)
+	seedMessage(t, repo, &models.Message{ID: "m-plugin", Content: "visible"})
+
+	got, err := svc.ListMessagesForPlugin(context.Background(), models.PluginMessageFilter{
+		SessionIDs: []string{"sess-msg"}, Limit: 10,
+	})
+	if err != nil {
+		t.Fatalf("ListMessagesForPlugin: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != "m-plugin" {
+		t.Fatalf("plugin messages = %+v, want just m-plugin", got)
+	}
+}
+
+func TestDeleteMessagePublishesDeletedEvent(t *testing.T) {
+	svc, bus, repo := newMessageTestService(t)
+	ctx := context.Background()
+	seedMessage(t, repo, &models.Message{ID: "msg-del", Content: "bye"})
+
+	if err := svc.DeleteMessage(ctx, "msg-del"); err != nil {
+		t.Fatalf("DeleteMessage: %v", err)
+	}
+	if types := eventTypes(bus.GetPublishedEvents()); len(types) != 1 || types[0] != events.MessageDeleted {
+		t.Fatalf("published %v, want exactly one %s", types, events.MessageDeleted)
+	}
+	if _, err := repo.GetMessage(ctx, "msg-del"); err == nil {
+		t.Fatal("message row must be gone")
+	}
+}
+
+func TestUpdateMessagePublishesUpdatedEvent(t *testing.T) {
+	svc, bus, repo := newMessageTestService(t)
+	ctx := context.Background()
+	message := seedMessage(t, repo, &models.Message{ID: "msg-upd", Content: "before"})
+
+	message.Content = "after"
+	if err := svc.UpdateMessage(ctx, message); err != nil {
+		t.Fatalf("UpdateMessage: %v", err)
+	}
+	if types := eventTypes(bus.GetPublishedEvents()); len(types) != 1 || types[0] != events.MessageUpdated {
+		t.Fatalf("published %v, want exactly one %s", types, events.MessageUpdated)
+	}
+	stored, err := repo.GetMessage(ctx, "msg-upd")
+	if err != nil {
+		t.Fatalf("GetMessage: %v", err)
+	}
+	if stored.Content != "after" {
+		t.Fatalf("content = %q, want after", stored.Content)
+	}
+}
+
+func TestAppendMessageContentAccumulatesAndPublishes(t *testing.T) {
+	svc, bus, repo := newMessageTestService(t)
+	ctx := context.Background()
+	seedMessage(t, repo, &models.Message{ID: "msg-append", Content: "Hel"})
+
+	if err := svc.AppendMessageContent(ctx, "msg-append", "lo "); err != nil {
+		t.Fatalf("AppendMessageContent: %v", err)
+	}
+	if err := svc.AppendMessageContent(ctx, "msg-append", "world"); err != nil {
+		t.Fatalf("second AppendMessageContent: %v", err)
+	}
+	stored, err := repo.GetMessage(ctx, "msg-append")
+	if err != nil {
+		t.Fatalf("GetMessage: %v", err)
+	}
+	if stored.Content != "Hello world" {
+		t.Fatalf("content = %q, want Hello world", stored.Content)
+	}
+	if types := eventTypes(bus.GetPublishedEvents()); len(types) != 2 {
+		t.Fatalf("published %v, want one update per append", types)
+	}
+
+	if err := svc.AppendMessageContent(ctx, "msg-missing", "x"); err == nil {
+		t.Fatal("appending to an unknown message must fail")
+	}
+}
+
+func TestAppendThinkingContentInitializesAndAccumulates(t *testing.T) {
+	svc, bus, repo := newMessageTestService(t)
+	ctx := context.Background()
+	seedMessage(t, repo, &models.Message{ID: "msg-think", Content: ""})
+
+	if err := svc.AppendThinkingContent(ctx, "msg-think", "step 1. "); err != nil {
+		t.Fatalf("AppendThinkingContent: %v", err)
+	}
+	stored, err := repo.GetMessage(ctx, "msg-think")
+	if err != nil {
+		t.Fatalf("GetMessage: %v", err)
+	}
+	if stored.Metadata["thinking"] != "step 1. " {
+		t.Fatalf("thinking = %v, want the first chunk on a fresh metadata map", stored.Metadata["thinking"])
+	}
+
+	if err := svc.AppendThinkingContent(ctx, "msg-think", "step 2."); err != nil {
+		t.Fatalf("second AppendThinkingContent: %v", err)
+	}
+	stored, err = repo.GetMessage(ctx, "msg-think")
+	if err != nil {
+		t.Fatalf("GetMessage: %v", err)
+	}
+	if stored.Metadata["thinking"] != "step 1. step 2." {
+		t.Fatalf("thinking = %v, want both chunks", stored.Metadata["thinking"])
+	}
+	if types := eventTypes(bus.GetPublishedEvents()); len(types) != 2 {
+		t.Fatalf("published %v, want one update per append", types)
+	}
+
+	if err := svc.AppendThinkingContent(ctx, "msg-missing", "x"); err == nil {
+		t.Fatal("appending thinking to an unknown message must fail")
+	}
+}
+
+func TestUpdateToolCallMessageAppliesStatusResultAndTitle(t *testing.T) {
+	svc, bus, repo := newMessageTestService(t)
+	ctx := context.Background()
+	seedMessage(t, repo, &models.Message{
+		ID: "msg-tool", Type: models.MessageTypeToolExecute, Content: "old title",
+		Metadata: map[string]interface{}{"tool_call_id": "tc-1", "status": "running"},
+	})
+
+	if err := svc.UpdateToolCallMessage(ctx, "sess-msg", "tc-1", "complete", "exit 0", "new title", nil); err != nil {
+		t.Fatalf("UpdateToolCallMessage: %v", err)
+	}
+	stored, err := repo.GetMessage(ctx, "msg-tool")
+	if err != nil {
+		t.Fatalf("GetMessage: %v", err)
+	}
+	if stored.Metadata["status"] != "complete" {
+		t.Fatalf("status = %v, want complete", stored.Metadata["status"])
+	}
+	if stored.Metadata["result"] != "exit 0" {
+		t.Fatalf("result = %v, want exit 0", stored.Metadata["result"])
+	}
+	if stored.Content != "new title" || stored.Metadata["title"] != "new title" {
+		t.Fatalf("title not applied: content=%q metadata=%v", stored.Content, stored.Metadata["title"])
+	}
+	if types := eventTypes(bus.GetPublishedEvents()); len(types) != 1 || types[0] != events.MessageUpdated {
+		t.Fatalf("published %v, want exactly one %s", types, events.MessageUpdated)
+	}
+}
+
+func TestUpdateToolCallMessageRetypesFromNormalizedKind(t *testing.T) {
+	svc, _, repo := newMessageTestService(t)
+	ctx := context.Background()
+	seedMessage(t, repo, &models.Message{
+		ID: "msg-normalized", Type: models.MessageTypeToolExecute, Content: "cmd",
+		Metadata: map[string]interface{}{"tool_call_id": "tc-norm"},
+	})
+
+	normalized := streams.NewShellExec("make test", "/workspace", "", 0, false)
+	if err := svc.UpdateToolCallMessage(ctx, "sess-msg", "tc-norm", "complete", "", "", normalized); err != nil {
+		t.Fatalf("UpdateToolCallMessage: %v", err)
+	}
+	stored, err := repo.GetMessage(ctx, "msg-normalized")
+	if err != nil {
+		t.Fatalf("GetMessage: %v", err)
+	}
+	wantType := models.MessageType(normalized.Kind().ToMessageType())
+	if stored.Type != wantType {
+		t.Fatalf("type = %q, want %q from the normalized kind", stored.Type, wantType)
+	}
+	if stored.Metadata["normalized"] == nil {
+		t.Fatal("normalized payload must be stored in metadata")
+	}
+}
+
+func TestApplyToolCallMessageUpdateRefusesPermissionRequests(t *testing.T) {
+	svc, _, _ := newMessageTestService(t)
+	message := &models.Message{
+		ID: "msg-perm", Type: models.MessageTypePermissionRequest, Content: "Allow?",
+		Metadata: map[string]interface{}{"status": "approved", "tool_call_id": "tc-1"},
+	}
+
+	svc.applyToolCallMessageUpdate(message, "error", "result", "new title", nil)
+
+	if message.Metadata["status"] != "approved" {
+		t.Fatalf("status = %v, want the user's decision preserved", message.Metadata["status"])
+	}
+	if message.Type != models.MessageTypePermissionRequest {
+		t.Fatalf("type = %q, want permission_request preserved", message.Type)
+	}
+	if message.Content != "Allow?" {
+		t.Fatalf("content = %q, want it untouched", message.Content)
+	}
+	if _, ok := message.Metadata["result"]; ok {
+		t.Fatal("result must not be written onto a permission request")
+	}
+}
+
+func TestUpdateToolCallMessageWithCreateFallsBackToCreation(t *testing.T) {
+	svc, bus, repo := newMessageTestService(t)
+	ctx := context.Background()
+
+	normalized := streams.NewShellExec("ls", "/workspace", "", 0, false)
+	err := svc.UpdateToolCallMessageWithCreate(ctx, "sess-msg", "tc-new", "tc-parent", "running", "",
+		"List files", normalized, "task-msg", "", string(models.MessageTypeToolExecute))
+	if err != nil {
+		t.Fatalf("UpdateToolCallMessageWithCreate: %v", err)
+	}
+
+	created, err := repo.GetMessageByToolCallID(ctx, "sess-msg", "tc-new")
+	if err != nil {
+		t.Fatalf("GetMessageByToolCallID: %v", err)
+	}
+	if created.Type != models.MessageTypeToolExecute || created.Content != "List files" {
+		t.Fatalf("created message = %+v", created)
+	}
+	if created.Metadata["status"] != "running" || created.Metadata["title"] != "List files" {
+		t.Fatalf("metadata = %v", created.Metadata)
+	}
+	if created.Metadata["parent_tool_call_id"] != "tc-parent" {
+		t.Fatalf("parent tool call = %v, want tc-parent for subagent nesting", created.Metadata["parent_tool_call_id"])
+	}
+	if created.Metadata["normalized"] == nil {
+		t.Fatal("normalized payload must be carried into the fallback message")
+	}
+	if types := eventTypes(bus.GetPublishedEvents()); len(types) == 0 || types[len(types)-1] != events.MessageAdded {
+		t.Fatalf("published %v, want the fallback create to publish %s", types, events.MessageAdded)
+	}
+}
+
+func TestUpdateToolCallMessageWithoutFallbackInfoReturnsError(t *testing.T) {
+	svc, bus, _ := newMessageTestService(t)
+
+	err := svc.UpdateToolCallMessage(context.Background(), "sess-msg", "tc-unknown", "complete", "", "", nil)
+	if err == nil {
+		t.Fatal("updating an unknown tool call without create info must fail")
+	}
+	if published := bus.GetPublishedEvents(); len(published) != 0 {
+		t.Fatalf("failed update published %d events, want none", len(published))
+	}
+}
+
+func TestUpdatePermissionMessageSetsStatus(t *testing.T) {
+	svc, bus, repo := newMessageTestService(t)
+	ctx := context.Background()
+	seedMessage(t, repo, &models.Message{
+		ID: "msg-permission", Type: models.MessageTypePermissionRequest, Content: "Allow?",
+		Metadata: map[string]interface{}{"pending_id": "pend-1"},
+	})
+
+	if err := svc.UpdatePermissionMessage(ctx, "sess-msg", "pend-1", models.PermissionStatusApproved); err != nil {
+		t.Fatalf("UpdatePermissionMessage: %v", err)
+	}
+	stored, err := repo.GetMessage(ctx, "msg-permission")
+	if err != nil {
+		t.Fatalf("GetMessage: %v", err)
+	}
+	if stored.Metadata["status"] != string(models.PermissionStatusApproved) {
+		t.Fatalf("status = %v, want approved", stored.Metadata["status"])
+	}
+	if types := eventTypes(bus.GetPublishedEvents()); len(types) != 1 || types[0] != events.MessageUpdated {
+		t.Fatalf("published %v, want exactly one %s", types, events.MessageUpdated)
+	}
+
+	if err := svc.UpdatePermissionMessage(ctx, "sess-msg", "pend-missing", models.PermissionStatusApproved); err == nil {
+		t.Fatal("an unknown pending id must fail")
+	}
+}
+
+func TestUpdatePermissionMessageExpiryCancelsRelatedToolCall(t *testing.T) {
+	svc, _, repo := newMessageTestService(t)
+	ctx := context.Background()
+	seedMessage(t, repo, &models.Message{
+		ID: "msg-perm-expire", Type: models.MessageTypePermissionRequest, Content: "Allow?",
+		Metadata: map[string]interface{}{"pending_id": "pend-exp", "tool_call_id": "tc-exp"},
+	})
+	seedMessage(t, repo, &models.Message{
+		ID: "msg-tool-expire", Type: models.MessageTypeToolExecute, Content: "run",
+		Metadata: map[string]interface{}{"tool_call_id": "tc-exp", "status": "running"},
+	})
+
+	if err := svc.UpdatePermissionMessage(ctx, "sess-msg", "pend-exp", models.PermissionStatusExpired); err != nil {
+		t.Fatalf("UpdatePermissionMessage: %v", err)
+	}
+
+	permission, err := repo.GetMessage(ctx, "msg-perm-expire")
+	if err != nil {
+		t.Fatalf("GetMessage permission: %v", err)
+	}
+	if permission.Metadata["status"] != string(models.PermissionStatusExpired) {
+		t.Fatalf("permission status = %v, want expired", permission.Metadata["status"])
+	}
+	tool, err := repo.GetMessage(ctx, "msg-tool-expire")
+	if err != nil {
+		t.Fatalf("GetMessage tool: %v", err)
+	}
+	if tool.Metadata["status"] != "error" {
+		t.Fatalf("tool status = %v, want the related tool call cancelled", tool.Metadata["status"])
+	}
+}
+
+func TestUpdateClarificationMessageForQuestionStoresAnswer(t *testing.T) {
+	svc, bus, repo := newMessageTestService(t)
+	ctx := context.Background()
+	seedMessage(t, repo, &models.Message{
+		ID: "msg-clarify", Content: "Which one?",
+		Metadata: map[string]interface{}{"pending_id": "pend-c", "question_id": "q-1"},
+	})
+
+	if err := svc.UpdateClarificationMessageForQuestion(ctx, "sess-msg", "pend-c", "q-1", "answered", "option-b"); err != nil {
+		t.Fatalf("UpdateClarificationMessageForQuestion: %v", err)
+	}
+	stored, err := repo.GetMessage(ctx, "msg-clarify")
+	if err != nil {
+		t.Fatalf("GetMessage: %v", err)
+	}
+	if stored.Metadata["status"] != "answered" {
+		t.Fatalf("status = %v, want answered", stored.Metadata["status"])
+	}
+	if stored.Metadata["response"] != "option-b" {
+		t.Fatalf("response = %v, want option-b", stored.Metadata["response"])
+	}
+	if types := eventTypes(bus.GetPublishedEvents()); len(types) != 1 || types[0] != events.MessageUpdated {
+		t.Fatalf("published %v, want exactly one %s", types, events.MessageUpdated)
+	}
+
+	if err := svc.UpdateClarificationMessageForQuestion(ctx, "sess-msg", "pend-c", "q-missing", "answered", nil); err == nil {
+		t.Fatal("an unknown question id must fail")
+	}
+}
+
+func TestUpdateClarificationMessageForQuestionKeepsAnswerWhenNil(t *testing.T) {
+	svc, _, repo := newMessageTestService(t)
+	ctx := context.Background()
+	seedMessage(t, repo, &models.Message{
+		ID: "msg-clarify-nil", Content: "Which one?",
+		Metadata: map[string]interface{}{"pending_id": "pend-n", "question_id": "q-n", "response": "prior"},
+	})
+
+	if err := svc.UpdateClarificationMessageForQuestion(ctx, "sess-msg", "pend-n", "q-n", "rejected", nil); err != nil {
+		t.Fatalf("UpdateClarificationMessageForQuestion: %v", err)
+	}
+	stored, err := repo.GetMessage(ctx, "msg-clarify-nil")
+	if err != nil {
+		t.Fatalf("GetMessage: %v", err)
+	}
+	if stored.Metadata["status"] != "rejected" {
+		t.Fatalf("status = %v, want rejected", stored.Metadata["status"])
+	}
+	if stored.Metadata["response"] != "prior" {
+		t.Fatalf("response = %v, want the prior answer left alone", stored.Metadata["response"])
+	}
+}

--- a/apps/backend/internal/task/service/service_resources_executors_test.go
+++ b/apps/backend/internal/task/service/service_resources_executors_test.go
@@ -96,9 +96,6 @@ func TestUpdateExecutorAppliesOnlySuppliedFields(t *testing.T) {
 	if updated.Type != models.ExecutorTypeLocal || !updated.Resumable {
 		t.Fatalf("unsupplied fields changed: %+v", updated)
 	}
-	if !updated.UpdatedAt.After(executor.CreatedAt) && updated.UpdatedAt.IsZero() {
-		t.Fatalf("updated_at = %v, want a fresh timestamp", updated.UpdatedAt)
-	}
 
 	reloaded, err := svc.GetExecutor(ctx, executor.ID)
 	if err != nil {

--- a/apps/backend/internal/task/service/service_resources_executors_test.go
+++ b/apps/backend/internal/task/service/service_resources_executors_test.go
@@ -1,0 +1,790 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/kandev/kandev/internal/events"
+	"github.com/kandev/kandev/internal/task/models"
+	"github.com/kandev/kandev/internal/task/repository/repoerrors"
+	sqliterepo "github.com/kandev/kandev/internal/task/repository/sqlite"
+	v1 "github.com/kandev/kandev/pkg/api/v1"
+)
+
+func createTestExecutor(t *testing.T, svc *Service, name string, executorType models.ExecutorType) *models.Executor {
+	t.Helper()
+	executor, err := svc.CreateExecutor(context.Background(), &CreateExecutorRequest{
+		Name: name, Type: executorType, Status: models.ExecutorStatusActive, Resumable: true,
+	})
+	if err != nil {
+		t.Fatalf("CreateExecutor %s: %v", name, err)
+	}
+	return executor
+}
+
+func TestCreateExecutorPersistsAndPublishes(t *testing.T) {
+	svc, bus, repo := createTestService(t)
+	ctx := context.Background()
+	bus.ClearEvents()
+
+	executor, err := svc.CreateExecutor(ctx, &CreateExecutorRequest{
+		Name: "Local runner", Type: models.ExecutorTypeLocal, Status: models.ExecutorStatusActive,
+		Resumable: true, Config: map[string]string{"mcp_policy": `{"allow":["fs"]}`},
+	})
+	if err != nil {
+		t.Fatalf("CreateExecutor: %v", err)
+	}
+	if executor.ID == "" || executor.Name != "Local runner" || executor.Type != models.ExecutorTypeLocal {
+		t.Fatalf("executor = %+v", executor)
+	}
+	if !executor.Resumable || executor.Status != models.ExecutorStatusActive {
+		t.Fatalf("executor flags = %+v", executor)
+	}
+
+	stored, err := repo.GetExecutor(ctx, executor.ID)
+	if err != nil {
+		t.Fatalf("GetExecutor: %v", err)
+	}
+	if stored.Config["mcp_policy"] != `{"allow":["fs"]}` {
+		t.Fatalf("stored config = %v", stored.Config)
+	}
+	if types := eventTypes(bus.GetPublishedEvents()); len(types) != 1 || types[0] != events.ExecutorCreated {
+		t.Fatalf("published %v, want exactly one %s", types, events.ExecutorCreated)
+	}
+}
+
+func TestCreateExecutorRejectsInvalidMCPPolicy(t *testing.T) {
+	svc, bus, _ := createTestService(t)
+	ctx := context.Background()
+	bus.ClearEvents()
+
+	for name, policy := range map[string]string{
+		"not json":      "{oops",
+		"not an object": `["a"]`,
+	} {
+		_, err := svc.CreateExecutor(ctx, &CreateExecutorRequest{
+			Name: "bad", Type: models.ExecutorTypeLocal, Config: map[string]string{"mcp_policy": policy},
+		})
+		if !errors.Is(err, ErrInvalidExecutorConfig) {
+			t.Fatalf("%s: error = %v, want ErrInvalidExecutorConfig", name, err)
+		}
+	}
+	if published := bus.GetPublishedEvents(); len(published) != 0 {
+		t.Fatalf("rejected create published %d events, want none", len(published))
+	}
+}
+
+func TestUpdateExecutorAppliesOnlySuppliedFields(t *testing.T) {
+	svc, bus, _ := createTestService(t)
+	ctx := context.Background()
+	executor := createTestExecutor(t, svc, "Runner", models.ExecutorTypeLocal)
+	bus.ClearEvents()
+
+	newName := "Renamed runner"
+	newStatus := models.ExecutorStatusDisabled
+	updated, err := svc.UpdateExecutor(ctx, executor.ID, &UpdateExecutorRequest{
+		Name: &newName, Status: &newStatus,
+	})
+	if err != nil {
+		t.Fatalf("UpdateExecutor: %v", err)
+	}
+	if updated.Name != newName || updated.Status != newStatus {
+		t.Fatalf("updated = %+v", updated)
+	}
+	if updated.Type != models.ExecutorTypeLocal || !updated.Resumable {
+		t.Fatalf("unsupplied fields changed: %+v", updated)
+	}
+	if !updated.UpdatedAt.After(executor.CreatedAt) && updated.UpdatedAt.IsZero() {
+		t.Fatalf("updated_at = %v, want a fresh timestamp", updated.UpdatedAt)
+	}
+
+	reloaded, err := svc.GetExecutor(ctx, executor.ID)
+	if err != nil {
+		t.Fatalf("GetExecutor: %v", err)
+	}
+	if reloaded.Name != newName || reloaded.Status != newStatus {
+		t.Fatalf("persisted executor = %+v", reloaded)
+	}
+	if types := eventTypes(bus.GetPublishedEvents()); len(types) != 1 || types[0] != events.ExecutorUpdated {
+		t.Fatalf("published %v, want exactly one %s", types, events.ExecutorUpdated)
+	}
+}
+
+func TestUpdateExecutorRejectsInvalidConfigAndMissingExecutor(t *testing.T) {
+	svc, _, _ := createTestService(t)
+	ctx := context.Background()
+	executor := createTestExecutor(t, svc, "Runner", models.ExecutorTypeLocal)
+
+	if _, err := svc.UpdateExecutor(ctx, executor.ID, &UpdateExecutorRequest{
+		Config: map[string]string{"mcp_policy": "{oops"},
+	}); !errors.Is(err, ErrInvalidExecutorConfig) {
+		t.Fatalf("invalid config = %v, want ErrInvalidExecutorConfig", err)
+	}
+	if _, err := svc.UpdateExecutor(ctx, "no-such-executor", &UpdateExecutorRequest{}); err == nil {
+		t.Fatal("updating a missing executor must fail")
+	}
+}
+
+func TestSystemExecutorsAreImmutableAndUndeletable(t *testing.T) {
+	svc, _, repo := createTestService(t)
+	ctx := context.Background()
+	system := &models.Executor{
+		ID: "exec-system", Name: "System", Type: models.ExecutorTypeLocal,
+		Status: models.ExecutorStatusActive, IsSystem: true, Resumable: true,
+	}
+	if err := repo.CreateExecutor(ctx, system); err != nil {
+		t.Fatalf("seed system executor: %v", err)
+	}
+
+	otherName := "Hijacked"
+	otherType := models.ExecutorTypeLocalDocker
+	otherStatus := models.ExecutorStatusDisabled
+	otherResumable := false
+	rejections := map[string]*UpdateExecutorRequest{
+		"name":      {Name: &otherName},
+		"type":      {Type: &otherType},
+		"status":    {Status: &otherStatus},
+		"resumable": {Resumable: &otherResumable},
+	}
+	for field, req := range rejections {
+		if _, err := svc.UpdateExecutor(ctx, system.ID, req); err == nil ||
+			!strings.Contains(err.Error(), "system executors cannot be modified") {
+			t.Fatalf("%s update error = %v, want a system-executor rejection", field, err)
+		}
+	}
+
+	// A no-op update that matches the current values is allowed through.
+	sameName := system.Name
+	if _, err := svc.UpdateExecutor(ctx, system.ID, &UpdateExecutorRequest{Name: &sameName}); err != nil {
+		t.Fatalf("identical-value update on a system executor: %v", err)
+	}
+
+	if err := svc.DeleteExecutor(ctx, system.ID); err == nil ||
+		!strings.Contains(err.Error(), "system executors cannot be deleted") {
+		t.Fatalf("delete error = %v, want a system-executor rejection", err)
+	}
+}
+
+func TestDeleteExecutorBlocksOnActiveSessions(t *testing.T) {
+	svc, bus, repo := createTestService(t)
+	ctx := context.Background()
+	executor := createTestExecutor(t, svc, "Runner", models.ExecutorTypeLocal)
+	seedExecutorSession(t, repo, "exec-active", executor.ID)
+	bus.ClearEvents()
+
+	if err := svc.DeleteExecutor(ctx, executor.ID); !errors.Is(err, ErrActiveTaskSessions) {
+		t.Fatalf("delete with an active session = %v, want ErrActiveTaskSessions", err)
+	}
+	if _, err := svc.GetExecutor(ctx, executor.ID); err != nil {
+		t.Fatalf("blocked delete must leave the executor: %v", err)
+	}
+	if published := bus.GetPublishedEvents(); len(published) != 0 {
+		t.Fatalf("blocked delete published %d events, want none", len(published))
+	}
+}
+
+func TestDeleteExecutorRemovesIdleExecutor(t *testing.T) {
+	svc, bus, _ := createTestService(t)
+	ctx := context.Background()
+	executor := createTestExecutor(t, svc, "Idle runner", models.ExecutorTypeLocal)
+	bus.ClearEvents()
+
+	if err := svc.DeleteExecutor(ctx, executor.ID); err != nil {
+		t.Fatalf("DeleteExecutor: %v", err)
+	}
+	if _, err := svc.GetExecutor(ctx, executor.ID); err == nil {
+		t.Fatal("deleted executor must not be readable")
+	}
+	if types := eventTypes(bus.GetPublishedEvents()); len(types) != 1 || types[0] != events.ExecutorDeleted {
+		t.Fatalf("published %v, want exactly one %s", types, events.ExecutorDeleted)
+	}
+	if err := svc.DeleteExecutor(ctx, "no-such-executor"); err == nil {
+		t.Fatal("deleting a missing executor must fail")
+	}
+}
+
+func TestListExecutorsReturnsCreatedExecutors(t *testing.T) {
+	svc, _, _ := createTestService(t)
+	ctx := context.Background()
+	before, err := svc.ListExecutors(ctx)
+	if err != nil {
+		t.Fatalf("ListExecutors: %v", err)
+	}
+	created := createTestExecutor(t, svc, "Listed", models.ExecutorTypeLocal)
+
+	after, err := svc.ListExecutors(ctx)
+	if err != nil {
+		t.Fatalf("ListExecutors: %v", err)
+	}
+	if len(after) != len(before)+1 {
+		t.Fatalf("list grew from %d to %d, want exactly one more", len(before), len(after))
+	}
+	found := false
+	for _, executor := range after {
+		if executor.ID == created.ID {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("created executor %s missing from the list", created.ID)
+	}
+}
+
+// seedExecutorSession attaches an active session to an executor so the
+// delete-blocking checks have something to find.
+func seedExecutorSession(t *testing.T, repo *sqliterepo.Repository, sessionID, executorID string) {
+	t.Helper()
+	ctx := context.Background()
+	if err := repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws-" + sessionID, Name: sessionID}); err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	if err := repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf-" + sessionID, WorkspaceID: "ws-" + sessionID, Name: sessionID}); err != nil {
+		t.Fatalf("create workflow: %v", err)
+	}
+	if err := repo.CreateTask(ctx, &models.Task{
+		ID: "task-" + sessionID, WorkspaceID: "ws-" + sessionID, WorkflowID: "wf-" + sessionID,
+		WorkflowStepID: "step-1", Title: sessionID, State: v1.TaskStateCreated, Priority: "medium",
+	}); err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	if err := repo.CreateTaskSession(ctx, &models.TaskSession{
+		ID: sessionID, TaskID: "task-" + sessionID, ExecutorID: executorID,
+		State: models.TaskSessionStateRunning,
+	}); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+}
+
+func TestCreateExecutorProfileValidatesRequest(t *testing.T) {
+	svc, bus, _ := createTestService(t)
+	ctx := context.Background()
+	executor := createTestExecutor(t, svc, "Runner", models.ExecutorTypeLocal)
+	bus.ClearEvents()
+
+	if _, err := svc.CreateExecutorProfile(ctx, &CreateExecutorProfileRequest{ExecutorID: executor.ID}); err == nil ||
+		!strings.Contains(err.Error(), "profile name is required") {
+		t.Fatalf("missing name error = %v", err)
+	}
+	if _, err := svc.CreateExecutorProfile(ctx, &CreateExecutorProfileRequest{Name: "p"}); err == nil ||
+		!strings.Contains(err.Error(), "executor_id is required") {
+		t.Fatalf("missing executor error = %v", err)
+	}
+	if _, err := svc.CreateExecutorProfile(ctx, &CreateExecutorProfileRequest{
+		Name: "p", ExecutorID: "no-such-executor",
+	}); err == nil || !strings.Contains(err.Error(), "executor not found") {
+		t.Fatalf("unknown executor error = %v", err)
+	}
+	if published := bus.GetPublishedEvents(); len(published) != 0 {
+		t.Fatalf("rejected creates published %d events, want none", len(published))
+	}
+}
+
+func TestCreateExecutorProfilePersistsAndPublishes(t *testing.T) {
+	svc, bus, repo := createTestService(t)
+	ctx := context.Background()
+	executor := createTestExecutor(t, svc, "Runner", models.ExecutorTypeLocal)
+	bus.ClearEvents()
+
+	profile, err := svc.CreateExecutorProfile(ctx, &CreateExecutorProfileRequest{
+		ExecutorID: executor.ID, Name: "default", McpPolicy: "allow",
+		PrepareScript: "make setup", CleanupScript: "make clean",
+		Config:  map[string]string{"cpu": "2"},
+		EnvVars: []models.ProfileEnvVar{{Key: "FOO", Value: "bar"}},
+	})
+	if err != nil {
+		t.Fatalf("CreateExecutorProfile: %v", err)
+	}
+	if profile.Name != "default" || profile.ExecutorID != executor.ID {
+		t.Fatalf("profile = %+v", profile)
+	}
+
+	stored, err := repo.GetExecutorProfile(ctx, profile.ID)
+	if err != nil {
+		t.Fatalf("GetExecutorProfile: %v", err)
+	}
+	if stored.PrepareScript != "make setup" || stored.CleanupScript != "make clean" {
+		t.Fatalf("stored scripts = %q/%q", stored.PrepareScript, stored.CleanupScript)
+	}
+	if len(stored.EnvVars) != 1 || stored.EnvVars[0].Key != "FOO" || stored.EnvVars[0].Value != "bar" {
+		t.Fatalf("stored env vars = %+v", stored.EnvVars)
+	}
+	if types := eventTypes(bus.GetPublishedEvents()); len(types) != 1 || types[0] != events.ExecutorProfileCreated {
+		t.Fatalf("published %v, want exactly one %s", types, events.ExecutorProfileCreated)
+	}
+}
+
+func TestCreateExecutorProfileRequiresSpritesToken(t *testing.T) {
+	svc, _, _ := createTestService(t)
+	ctx := context.Background()
+	sprites := createTestExecutor(t, svc, "Sprites", models.ExecutorTypeSprites)
+
+	if _, err := svc.CreateExecutorProfile(ctx, &CreateExecutorProfileRequest{
+		ExecutorID: sprites.ID, Name: "sprites profile",
+	}); err == nil || !strings.Contains(err.Error(), spritesTokenEnvKey) {
+		t.Fatalf("missing token error = %v, want a %s requirement", err, spritesTokenEnvKey)
+	}
+	// A blank-valued token entry does not satisfy the requirement.
+	if _, err := svc.CreateExecutorProfile(ctx, &CreateExecutorProfileRequest{
+		ExecutorID: sprites.ID, Name: "sprites profile",
+		EnvVars: []models.ProfileEnvVar{{Key: spritesTokenEnvKey, Value: "  "}},
+	}); err == nil {
+		t.Fatal("a blank sprites token must be rejected")
+	}
+
+	profile, err := svc.CreateExecutorProfile(ctx, &CreateExecutorProfileRequest{
+		ExecutorID: sprites.ID, Name: "sprites profile",
+		EnvVars: []models.ProfileEnvVar{{Key: spritesTokenEnvKey, Value: "tok"}},
+	})
+	if err != nil {
+		t.Fatalf("CreateExecutorProfile with a token: %v", err)
+	}
+	if len(profile.EnvVars) != 1 {
+		t.Fatalf("env vars = %+v", profile.EnvVars)
+	}
+}
+
+func TestHasSpritesTokenAcceptsSecretReference(t *testing.T) {
+	cases := []struct {
+		name    string
+		envVars []models.ProfileEnvVar
+		want    bool
+	}{
+		{"empty", nil, false},
+		{"other key", []models.ProfileEnvVar{{Key: "FOO", Value: "bar"}}, false},
+		{"blank value", []models.ProfileEnvVar{{Key: spritesTokenEnvKey, Value: " "}}, false},
+		{"literal value", []models.ProfileEnvVar{{Key: spritesTokenEnvKey, Value: "tok"}}, true},
+		{"secret reference", []models.ProfileEnvVar{{Key: spritesTokenEnvKey, SecretID: "secret-1"}}, true},
+	}
+	for _, tc := range cases {
+		if got := hasSpritesToken(tc.envVars); got != tc.want {
+			t.Fatalf("%s: hasSpritesToken = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestMergeSpritesTokenEnvVarsPreservesUnlessExplicitlyRemoved(t *testing.T) {
+	existing := []models.ProfileEnvVar{
+		{Key: "OTHER", Value: "keep-me"},
+		{Key: spritesTokenEnvKey, Value: "existing-token"},
+	}
+
+	// An update that omits the token keeps the stored one.
+	merged := mergeSpritesTokenEnvVars(existing, []models.ProfileEnvVar{{Key: "NEW", Value: "1"}})
+	if len(merged) != 2 || merged[0].Key != "NEW" || merged[1].Key != spritesTokenEnvKey ||
+		merged[1].Value != "existing-token" {
+		t.Fatalf("merged = %+v, want the existing token carried over", merged)
+	}
+
+	// An explicit blank entry removes it.
+	merged = mergeSpritesTokenEnvVars(existing, []models.ProfileEnvVar{{Key: spritesTokenEnvKey, Value: ""}})
+	if len(merged) != 0 {
+		t.Fatalf("merged = %+v, want the token explicitly removed", merged)
+	}
+
+	// An incoming token wins over the stored one.
+	merged = mergeSpritesTokenEnvVars(existing, []models.ProfileEnvVar{{Key: spritesTokenEnvKey, Value: "new-token"}})
+	if len(merged) != 1 || merged[0].Value != "new-token" {
+		t.Fatalf("merged = %+v, want the incoming token", merged)
+	}
+
+	// With no stored token there is nothing to preserve.
+	merged = mergeSpritesTokenEnvVars(nil, []models.ProfileEnvVar{{Key: "A", Value: "1"}})
+	if len(merged) != 1 || merged[0].Key != "A" {
+		t.Fatalf("merged = %+v", merged)
+	}
+}
+
+func TestUpdateExecutorProfileAppliesSuppliedFields(t *testing.T) {
+	svc, bus, repo := createTestService(t)
+	ctx := context.Background()
+	executor := createTestExecutor(t, svc, "Runner", models.ExecutorTypeLocal)
+	profile, err := svc.CreateExecutorProfile(ctx, &CreateExecutorProfileRequest{
+		ExecutorID: executor.ID, Name: "default", PrepareScript: "old prepare",
+	})
+	if err != nil {
+		t.Fatalf("CreateExecutorProfile: %v", err)
+	}
+	bus.ClearEvents()
+
+	name := "renamed"
+	policy := "deny"
+	prepare := "new prepare"
+	cleanup := "new cleanup"
+	updated, err := svc.UpdateExecutorProfile(ctx, profile.ID, &UpdateExecutorProfileRequest{
+		Name: &name, McpPolicy: &policy, PrepareScript: &prepare, CleanupScript: &cleanup,
+		Config:  map[string]string{"cpu": "4"},
+		EnvVars: []models.ProfileEnvVar{{Key: "BAR", Value: "baz"}},
+	})
+	if err != nil {
+		t.Fatalf("UpdateExecutorProfile: %v", err)
+	}
+	if updated.Name != name || updated.McpPolicy != policy ||
+		updated.PrepareScript != prepare || updated.CleanupScript != cleanup {
+		t.Fatalf("updated profile = %+v", updated)
+	}
+
+	stored, err := repo.GetExecutorProfile(ctx, profile.ID)
+	if err != nil {
+		t.Fatalf("GetExecutorProfile: %v", err)
+	}
+	if stored.Config["cpu"] != "4" || len(stored.EnvVars) != 1 || stored.EnvVars[0].Key != "BAR" {
+		t.Fatalf("stored profile = %+v", stored)
+	}
+	if types := eventTypes(bus.GetPublishedEvents()); len(types) != 1 || types[0] != events.ExecutorProfileUpdated {
+		t.Fatalf("published %v, want exactly one %s", types, events.ExecutorProfileUpdated)
+	}
+
+	if _, err := svc.UpdateExecutorProfile(ctx, "no-such-profile", &UpdateExecutorProfileRequest{}); err == nil {
+		t.Fatal("updating a missing profile must fail")
+	}
+}
+
+func TestUpdateExecutorProfileKeepsSpritesTokenWhenOmitted(t *testing.T) {
+	svc, _, repo := createTestService(t)
+	ctx := context.Background()
+	sprites := createTestExecutor(t, svc, "Sprites", models.ExecutorTypeSprites)
+	profile, err := svc.CreateExecutorProfile(ctx, &CreateExecutorProfileRequest{
+		ExecutorID: sprites.ID, Name: "sprites profile",
+		EnvVars: []models.ProfileEnvVar{{Key: spritesTokenEnvKey, Value: "tok"}},
+	})
+	if err != nil {
+		t.Fatalf("CreateExecutorProfile: %v", err)
+	}
+
+	updated, err := svc.UpdateExecutorProfile(ctx, profile.ID, &UpdateExecutorProfileRequest{
+		EnvVars: []models.ProfileEnvVar{{Key: "OTHER", Value: "1"}},
+	})
+	if err != nil {
+		t.Fatalf("UpdateExecutorProfile: %v", err)
+	}
+	if len(updated.EnvVars) != 2 {
+		t.Fatalf("env vars = %+v, want the sprites token preserved alongside OTHER", updated.EnvVars)
+	}
+	stored, err := repo.GetExecutorProfile(ctx, profile.ID)
+	if err != nil {
+		t.Fatalf("GetExecutorProfile: %v", err)
+	}
+	if !hasSpritesToken(stored.EnvVars) {
+		t.Fatalf("stored env vars = %+v, want the sprites token preserved", stored.EnvVars)
+	}
+}
+
+func TestDeleteAndListExecutorProfiles(t *testing.T) {
+	svc, bus, _ := createTestService(t)
+	ctx := context.Background()
+	executor := createTestExecutor(t, svc, "Runner", models.ExecutorTypeLocal)
+	profile, err := svc.CreateExecutorProfile(ctx, &CreateExecutorProfileRequest{
+		ExecutorID: executor.ID, Name: "default",
+	})
+	if err != nil {
+		t.Fatalf("CreateExecutorProfile: %v", err)
+	}
+
+	scoped, err := svc.ListExecutorProfiles(ctx, executor.ID)
+	if err != nil {
+		t.Fatalf("ListExecutorProfiles: %v", err)
+	}
+	if len(scoped) != 1 || scoped[0].ID != profile.ID {
+		t.Fatalf("profiles for executor = %+v, want just the created one", scoped)
+	}
+	all, err := svc.ListAllExecutorProfiles(ctx)
+	if err != nil {
+		t.Fatalf("ListAllExecutorProfiles: %v", err)
+	}
+	if len(all) < 1 {
+		t.Fatal("ListAllExecutorProfiles returned nothing")
+	}
+
+	bus.ClearEvents()
+	if err := svc.DeleteExecutorProfile(ctx, profile.ID); err != nil {
+		t.Fatalf("DeleteExecutorProfile: %v", err)
+	}
+	if _, err := svc.GetExecutorProfile(ctx, profile.ID); err == nil {
+		t.Fatal("deleted profile must not be readable")
+	}
+	if types := eventTypes(bus.GetPublishedEvents()); len(types) != 1 || types[0] != events.ExecutorProfileDeleted {
+		t.Fatalf("published %v, want exactly one %s", types, events.ExecutorProfileDeleted)
+	}
+	if err := svc.DeleteExecutorProfile(ctx, "no-such-profile"); err == nil {
+		t.Fatal("deleting a missing profile must fail")
+	}
+}
+
+func TestEnvironmentCRUDPublishesEvents(t *testing.T) {
+	svc, bus, _ := createTestService(t)
+	ctx := context.Background()
+	bus.ClearEvents()
+
+	environment, err := svc.CreateEnvironment(ctx, &CreateEnvironmentRequest{
+		Name: "docker env", Kind: models.EnvironmentKindDockerImage,
+		WorktreeRoot: "/tmp/worktrees", ImageTag: "kandev:test", Dockerfile: "FROM alpine",
+		BuildConfig: map[string]string{"target": "dev"},
+	})
+	if err != nil {
+		t.Fatalf("CreateEnvironment: %v", err)
+	}
+	if environment.ID == "" || environment.IsSystem {
+		t.Fatalf("environment = %+v, want a non-system row with an id", environment)
+	}
+	if types := eventTypes(bus.GetPublishedEvents()); len(types) != 1 || types[0] != events.EnvironmentCreated {
+		t.Fatalf("published %v, want exactly one %s", types, events.EnvironmentCreated)
+	}
+
+	fetched, err := svc.GetEnvironment(ctx, environment.ID)
+	if err != nil {
+		t.Fatalf("GetEnvironment: %v", err)
+	}
+	if fetched.ImageTag != "kandev:test" || fetched.BuildConfig["target"] != "dev" {
+		t.Fatalf("fetched = %+v", fetched)
+	}
+
+	bus.ClearEvents()
+	name := "renamed env"
+	root := "/tmp/other"
+	tag := "kandev:next"
+	updated, err := svc.UpdateEnvironment(ctx, environment.ID, &UpdateEnvironmentRequest{
+		Name: &name, WorktreeRoot: &root, ImageTag: &tag,
+	})
+	if err != nil {
+		t.Fatalf("UpdateEnvironment: %v", err)
+	}
+	if updated.Name != name || updated.WorktreeRoot != root || updated.ImageTag != tag {
+		t.Fatalf("updated = %+v", updated)
+	}
+	if updated.Dockerfile != "FROM alpine" {
+		t.Fatalf("unsupplied dockerfile changed to %q", updated.Dockerfile)
+	}
+	if types := eventTypes(bus.GetPublishedEvents()); len(types) != 1 || types[0] != events.EnvironmentUpdated {
+		t.Fatalf("published %v, want exactly one %s", types, events.EnvironmentUpdated)
+	}
+
+	listed, err := svc.ListEnvironments(ctx)
+	if err != nil {
+		t.Fatalf("ListEnvironments: %v", err)
+	}
+	found := false
+	for _, env := range listed {
+		if env.ID == environment.ID {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("created environment missing from %d listed environments", len(listed))
+	}
+
+	bus.ClearEvents()
+	if err := svc.DeleteEnvironment(ctx, environment.ID); err != nil {
+		t.Fatalf("DeleteEnvironment: %v", err)
+	}
+	if types := eventTypes(bus.GetPublishedEvents()); len(types) != 1 || types[0] != events.EnvironmentDeleted {
+		t.Fatalf("published %v, want exactly one %s", types, events.EnvironmentDeleted)
+	}
+	if _, err := svc.GetEnvironment(ctx, environment.ID); err == nil {
+		t.Fatal("deleted environment must not be readable")
+	}
+	if err := svc.DeleteEnvironment(ctx, "no-such-environment"); err == nil {
+		t.Fatal("deleting a missing environment must fail")
+	}
+	if _, err := svc.UpdateEnvironment(ctx, "no-such-environment", &UpdateEnvironmentRequest{}); err == nil {
+		t.Fatal("updating a missing environment must fail")
+	}
+}
+
+func TestSystemEnvironmentAllowsOnlyWorktreeRootUpdates(t *testing.T) {
+	svc, _, repo := createTestService(t)
+	ctx := context.Background()
+	system := &models.Environment{
+		ID: "env-system", Name: "System", Kind: models.EnvironmentKindLocalPC, IsSystem: true,
+	}
+	if err := repo.CreateEnvironment(ctx, system); err != nil {
+		t.Fatalf("seed system environment: %v", err)
+	}
+
+	name := "renamed"
+	kind := models.EnvironmentKindDockerImage
+	tag := "img"
+	dockerfile := "FROM alpine"
+	rejections := map[string]*UpdateEnvironmentRequest{
+		"name":         {Name: &name},
+		"kind":         {Kind: &kind},
+		"image tag":    {ImageTag: &tag},
+		"dockerfile":   {Dockerfile: &dockerfile},
+		"build config": {BuildConfig: map[string]string{"a": "b"}},
+	}
+	for field, req := range rejections {
+		if _, err := svc.UpdateEnvironment(ctx, system.ID, req); err == nil ||
+			!strings.Contains(err.Error(), "system environments can only update the worktree root") {
+			t.Fatalf("%s update error = %v, want a system-environment rejection", field, err)
+		}
+	}
+
+	root := "/tmp/system-worktrees"
+	updated, err := svc.UpdateEnvironment(ctx, system.ID, &UpdateEnvironmentRequest{WorktreeRoot: &root})
+	if err != nil {
+		t.Fatalf("worktree root update on a system environment: %v", err)
+	}
+	if updated.WorktreeRoot != root {
+		t.Fatalf("worktree root = %q, want %q", updated.WorktreeRoot, root)
+	}
+
+	if err := svc.DeleteEnvironment(ctx, system.ID); err == nil ||
+		!strings.Contains(err.Error(), "system environments cannot be deleted") {
+		t.Fatalf("delete error = %v, want a system-environment rejection", err)
+	}
+}
+
+func TestDeleteEnvironmentBlocksOnActiveSessions(t *testing.T) {
+	svc, _, repo := createTestService(t)
+	ctx := context.Background()
+	environment, err := svc.CreateEnvironment(ctx, &CreateEnvironmentRequest{
+		Name: "busy", Kind: models.EnvironmentKindLocalPC,
+	})
+	if err != nil {
+		t.Fatalf("CreateEnvironment: %v", err)
+	}
+	seedEnvironmentSession(t, repo, "env-busy-session", environment.ID)
+
+	if err := svc.DeleteEnvironment(ctx, environment.ID); !errors.Is(err, ErrActiveTaskSessions) {
+		t.Fatalf("delete with an active session = %v, want ErrActiveTaskSessions", err)
+	}
+	if _, err := svc.GetEnvironment(ctx, environment.ID); err != nil {
+		t.Fatalf("blocked delete must leave the environment: %v", err)
+	}
+}
+
+func seedEnvironmentSession(t *testing.T, repo *sqliterepo.Repository, sessionID, environmentID string) {
+	t.Helper()
+	ctx := context.Background()
+	if err := repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws-" + sessionID, Name: sessionID}); err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	if err := repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf-" + sessionID, WorkspaceID: "ws-" + sessionID, Name: sessionID}); err != nil {
+		t.Fatalf("create workflow: %v", err)
+	}
+	if err := repo.CreateTask(ctx, &models.Task{
+		ID: "task-" + sessionID, WorkspaceID: "ws-" + sessionID, WorkflowID: "wf-" + sessionID,
+		WorkflowStepID: "step-1", Title: sessionID, State: v1.TaskStateCreated, Priority: "medium",
+	}); err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	if err := repo.CreateTaskSession(ctx, &models.TaskSession{
+		ID: sessionID, TaskID: "task-" + sessionID, EnvironmentID: environmentID,
+		State: models.TaskSessionStateRunning,
+	}); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+}
+
+func TestRepositoryScriptUpdateDeleteAreWorkspaceScoped(t *testing.T) {
+	svc, bus, repo := createTestService(t)
+	seedScopedWorkspaces(t, repo)
+	ctx := context.Background()
+	if err := repo.CreateRepository(ctx, &models.Repository{ID: "repo-b", WorkspaceID: "ws-b", Name: "b"}); err != nil {
+		t.Fatalf("seed repository: %v", err)
+	}
+	script, err := svc.CreateRepositoryScript(ctxAs("user-b"), &CreateRepositoryScriptRequest{
+		RepositoryID: "repo-b", Name: "setup", Command: "make", Position: 1,
+	})
+	if err != nil {
+		t.Fatalf("CreateRepositoryScript: %v", err)
+	}
+	bus.ClearEvents()
+
+	hijacked := "evil"
+	if _, err := svc.UpdateRepositoryScript(ctxAs("user-a"), script.ID, &UpdateRepositoryScriptRequest{
+		Command: &hijacked,
+	}); !errors.Is(err, repoerrors.ErrRepositoryNotFound) {
+		t.Fatalf("foreign update = %v, want ErrRepositoryNotFound", err)
+	}
+	if err := svc.DeleteRepositoryScript(ctxAs("user-a"), script.ID); !errors.Is(err, repoerrors.ErrRepositoryNotFound) {
+		t.Fatalf("foreign delete = %v, want ErrRepositoryNotFound", err)
+	}
+	if published := bus.GetPublishedEvents(); len(published) != 0 {
+		t.Fatalf("denied script mutations published %d events, want none", len(published))
+	}
+
+	name := "renamed"
+	command := "make test"
+	position := 5
+	updated, err := svc.UpdateRepositoryScript(ctxAs("user-b"), script.ID, &UpdateRepositoryScriptRequest{
+		Name: &name, Command: &command, Position: &position,
+	})
+	if err != nil {
+		t.Fatalf("owner UpdateRepositoryScript: %v", err)
+	}
+	if updated.Name != name || updated.Command != command || updated.Position != position {
+		t.Fatalf("updated script = %+v", updated)
+	}
+	if types := eventTypes(bus.GetPublishedEvents()); len(types) != 1 || types[0] != events.RepositoryScriptUpdated {
+		t.Fatalf("published %v, want exactly one %s", types, events.RepositoryScriptUpdated)
+	}
+
+	bus.ClearEvents()
+	if err := svc.DeleteRepositoryScript(ctxAs("user-b"), script.ID); err != nil {
+		t.Fatalf("owner DeleteRepositoryScript: %v", err)
+	}
+	if types := eventTypes(bus.GetPublishedEvents()); len(types) != 1 || types[0] != events.RepositoryScriptDeleted {
+		t.Fatalf("published %v, want exactly one %s", types, events.RepositoryScriptDeleted)
+	}
+	remaining, err := repo.ListRepositoryScripts(ctx, "repo-b")
+	if err != nil {
+		t.Fatalf("ListRepositoryScripts: %v", err)
+	}
+	if len(remaining) != 0 {
+		t.Fatalf("scripts after delete = %+v, want none", remaining)
+	}
+}
+
+func TestListScriptsByRepositoryIDsGroupsByRepository(t *testing.T) {
+	svc, _, repo := createTestService(t)
+	ctx := context.Background()
+	if err := repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws-scripts", Name: "scripts"}); err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	for _, id := range []string{"repo-1", "repo-2"} {
+		if err := repo.CreateRepository(ctx, &models.Repository{ID: id, WorkspaceID: "ws-scripts", Name: id}); err != nil {
+			t.Fatalf("create repository %s: %v", id, err)
+		}
+		if _, err := svc.CreateRepositoryScript(ctx, &CreateRepositoryScriptRequest{
+			RepositoryID: id, Name: "setup-" + id, Command: "make",
+		}); err != nil {
+			t.Fatalf("create script for %s: %v", id, err)
+		}
+	}
+
+	grouped, err := svc.ListScriptsByRepositoryIDs(ctx, []string{"repo-1", "repo-2"})
+	if err != nil {
+		t.Fatalf("ListScriptsByRepositoryIDs: %v", err)
+	}
+	if len(grouped["repo-1"]) != 1 || grouped["repo-1"][0].Name != "setup-repo-1" {
+		t.Fatalf("repo-1 scripts = %+v", grouped["repo-1"])
+	}
+	if len(grouped["repo-2"]) != 1 || grouped["repo-2"][0].Name != "setup-repo-2" {
+		t.Fatalf("repo-2 scripts = %+v", grouped["repo-2"])
+	}
+}
+
+func TestCountActiveSessionsByRepositoryIsScoped(t *testing.T) {
+	svc, _, repo := createTestService(t)
+	seedScopedWorkspaces(t, repo)
+	ctx := context.Background()
+	if err := repo.CreateRepository(ctx, &models.Repository{ID: "repo-b", WorkspaceID: "ws-b", Name: "b"}); err != nil {
+		t.Fatalf("seed repository: %v", err)
+	}
+
+	if _, err := svc.CountActiveSessionsByRepository(ctxAs("user-a"), "repo-b"); !errors.Is(err, repoerrors.ErrRepositoryNotFound) {
+		t.Fatalf("foreign count = %v, want ErrRepositoryNotFound", err)
+	}
+	count, err := svc.CountActiveSessionsByRepository(ctxAs("user-b"), "repo-b")
+	if err != nil {
+		t.Fatalf("owner count: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("count = %d, want 0 with no attached sessions", count)
+	}
+	if _, err := svc.CountActiveSessionsByRepository(ctx, "no-such-repository"); err == nil {
+		t.Fatal("counting for a missing repository must fail")
+	}
+}

--- a/apps/backend/internal/task/service/service_resources_workflows_test.go
+++ b/apps/backend/internal/task/service/service_resources_workflows_test.go
@@ -1,0 +1,175 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/kandev/kandev/internal/events"
+	"github.com/kandev/kandev/internal/task/models"
+	"github.com/kandev/kandev/internal/task/repository/repoerrors"
+	v1 "github.com/kandev/kandev/pkg/api/v1"
+)
+
+func TestSetWorkflowSourceStampsProvenanceAndPublishes(t *testing.T) {
+	svc, bus, repo := createTestService(t)
+	ctx := context.Background()
+	if err := repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws-src", Name: "Sources"}); err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	if err := repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf-src", WorkspaceID: "ws-src", Name: "flow"}); err != nil {
+		t.Fatalf("create workflow: %v", err)
+	}
+	bus.ClearEvents()
+
+	if err := svc.SetWorkflowSource(ctx, "wf-src", "github", ".kandev/workflows/review.yaml"); err != nil {
+		t.Fatalf("SetWorkflowSource: %v", err)
+	}
+	stored, err := repo.GetWorkflow(ctx, "wf-src")
+	if err != nil {
+		t.Fatalf("GetWorkflow: %v", err)
+	}
+	if stored.Source != "github" || stored.SourcePath != ".kandev/workflows/review.yaml" {
+		t.Fatalf("workflow provenance = %q/%q", stored.Source, stored.SourcePath)
+	}
+	if types := eventTypes(bus.GetPublishedEvents()); len(types) != 1 || types[0] != events.WorkflowUpdated {
+		t.Fatalf("published %v, want exactly one %s", types, events.WorkflowUpdated)
+	}
+
+	// Re-stamping identical provenance is a no-op with no duplicate event.
+	bus.ClearEvents()
+	if err := svc.SetWorkflowSource(ctx, "wf-src", "github", ".kandev/workflows/review.yaml"); err != nil {
+		t.Fatalf("repeat SetWorkflowSource: %v", err)
+	}
+	if published := bus.GetPublishedEvents(); len(published) != 0 {
+		t.Fatalf("unchanged provenance published %v, want nothing", eventTypes(published))
+	}
+
+	if err := svc.SetWorkflowSource(ctx, "wf-missing", "github", "x.yaml"); err == nil {
+		t.Fatal("stamping an unknown workflow must fail")
+	}
+}
+
+func TestReorderWorkflowsIsWorkspaceScoped(t *testing.T) {
+	svc, _, repo := createTestService(t)
+	seedScopedWorkspaces(t, repo)
+	ctx := context.Background()
+	if err := repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf-b2", WorkspaceID: "ws-b", Name: "second"}); err != nil {
+		t.Fatalf("create second workflow: %v", err)
+	}
+
+	if err := svc.ReorderWorkflows(ctxAs("user-a"), "ws-b", []string{"wf-b2", "wf-b"}); !errors.Is(err, repoerrors.ErrWorkspaceNotFound) {
+		t.Fatalf("foreign reorder = %v, want ErrWorkspaceNotFound", err)
+	}
+
+	if err := svc.ReorderWorkflows(ctxAs("user-b"), "ws-b", []string{"wf-b2", "wf-b"}); err != nil {
+		t.Fatalf("owner ReorderWorkflows: %v", err)
+	}
+	first, err := repo.GetWorkflow(ctx, "wf-b2")
+	if err != nil {
+		t.Fatalf("GetWorkflow: %v", err)
+	}
+	second, err := repo.GetWorkflow(ctx, "wf-b")
+	if err != nil {
+		t.Fatalf("GetWorkflow: %v", err)
+	}
+	if first.SortOrder != 0 || second.SortOrder != 1 {
+		t.Fatalf("sort orders = %d/%d, want 0/1 in the requested order", first.SortOrder, second.SortOrder)
+	}
+
+	// A workflow from another workspace cannot be smuggled into the ordering.
+	if err := svc.ReorderWorkflows(ctxAs("user-b"), "ws-b", []string{"wf-b", "wf-legacy-missing"}); err == nil {
+		t.Fatal("reordering an unknown workflow must fail")
+	}
+}
+
+func TestStandaloneTaskEventPublishers(t *testing.T) {
+	svc, bus, repo := createTestService(t)
+	ctx := context.Background()
+	if err := repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws-pub", Name: "Publishers"}); err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	if err := repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf-pub", WorkspaceID: "ws-pub", Name: "flow"}); err != nil {
+		t.Fatalf("create workflow: %v", err)
+	}
+	task := &models.Task{
+		ID: "task-pub", WorkspaceID: "ws-pub", WorkflowID: "wf-pub", WorkflowStepID: "step-1",
+		Title: "Publish me", State: v1.TaskStateInProgress, Priority: "medium",
+	}
+	if err := repo.CreateTask(ctx, task); err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	bus.ClearEvents()
+
+	svc.PublishTaskQueuePromoted(ctx, task)
+	if types := eventTypes(bus.GetPublishedEvents()); len(types) != 1 || types[0] != events.TaskQueuePromoted {
+		t.Fatalf("published %v, want exactly one %s", types, events.TaskQueuePromoted)
+	}
+
+	bus.ClearEvents()
+	svc.PublishTaskStateChanged(ctx, task, v1.TaskStateCreated)
+	published := bus.GetPublishedEvents()
+	if len(published) != 1 || published[0].Type != events.TaskStateChanged {
+		t.Fatalf("published %v, want exactly one %s", eventTypes(published), events.TaskStateChanged)
+	}
+	data, ok := published[0].Data.(map[string]interface{})
+	if !ok {
+		t.Fatalf("event data = %T, want a map payload", published[0].Data)
+	}
+	if data["old_state"] != string(v1.TaskStateCreated) || data["state"] != string(v1.TaskStateInProgress) {
+		t.Fatalf("state transition = %v → %v", data["old_state"], data["state"])
+	}
+}
+
+func TestPublishAfterTaskEventsRunsCallback(t *testing.T) {
+	svc, _, _ := createTestService(t)
+	ctx := context.Background()
+
+	// A nil callback is ignored rather than panicking.
+	svc.PublishAfterTaskEvents(ctx, "task-pub", events.TaskUpdated, nil)
+
+	// Without a task id the callback runs inline.
+	inline := false
+	svc.PublishAfterTaskEvents(ctx, "", events.TaskUpdated, func(context.Context) { inline = true })
+	if !inline {
+		t.Fatal("an id-less publication must run inline")
+	}
+
+	queued := make(chan struct{}, 1)
+	svc.PublishAfterTaskEvents(ctx, "task-pub", events.TaskUpdated, func(context.Context) { queued <- struct{}{} })
+	select {
+	case <-queued:
+	default:
+		t.Fatal("a task-scoped publication must be drained")
+	}
+}
+
+func TestPublishWorkspaceSourcesAdoptedSkipsBlankSessions(t *testing.T) {
+	svc, bus, _ := createTestService(t)
+	ctx := context.Background()
+	bus.ClearEvents()
+
+	svc.PublishWorkspaceSourcesAdopted(ctx, "task-pub", "/tmp/workspace", []string{"sess-1", "", "sess-2"})
+
+	published := bus.GetPublishedEvents()
+	if len(published) != 2 {
+		t.Fatalf("published %v, want one event per non-empty session", eventTypes(published))
+	}
+	seen := map[string]bool{}
+	for _, event := range published {
+		if event.Type != events.SessionWorkspaceSourcesUpdated {
+			t.Fatalf("event type = %q, want %q", event.Type, events.SessionWorkspaceSourcesUpdated)
+		}
+		data, ok := event.Data.(map[string]interface{})
+		if !ok {
+			t.Fatalf("event data = %T, want a map payload", event.Data)
+		}
+		if data["task_id"] != "task-pub" || data["workspace_path"] != "/tmp/workspace" {
+			t.Fatalf("payload = %v", data)
+		}
+		seen[data["session_id"].(string)] = true
+	}
+	if !seen["sess-1"] || !seen["sess-2"] {
+		t.Fatalf("session ids = %v, want sess-1 and sess-2", seen)
+	}
+}

--- a/apps/backend/internal/task/service/service_tasks_title_test.go
+++ b/apps/backend/internal/task/service/service_tasks_title_test.go
@@ -1,0 +1,319 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/kandev/kandev/internal/events"
+	"github.com/kandev/kandev/internal/task/models"
+	"github.com/kandev/kandev/internal/task/repository/repoerrors"
+	sqliterepo "github.com/kandev/kandev/internal/task/repository/sqlite"
+	v1 "github.com/kandev/kandev/pkg/api/v1"
+)
+
+// seedPendingTitleTask creates a task whose generated title is claimed by
+// ownerSessionID (empty means pending but unclaimed).
+func seedPendingTitleTask(t *testing.T, repo *sqliterepo.Repository, taskID, ownerSessionID string, pending bool) {
+	t.Helper()
+	metadata := map[string]interface{}{}
+	if pending {
+		metadata[models.MetaKeyAgentTitlePending] = true
+	}
+	if ownerSessionID != "" {
+		metadata[models.MetaKeyAgentTitleOwnerSessionID] = ownerSessionID
+	}
+	if err := repo.CreateTask(context.Background(), &models.Task{
+		ID: taskID, WorkspaceID: "ws-title", WorkflowID: "wf-title", WorkflowStepID: "step-1",
+		Title: "Untitled", State: v1.TaskStateCreated, Priority: "medium", Metadata: metadata,
+	}); err != nil {
+		t.Fatalf("create task %s: %v", taskID, err)
+	}
+}
+
+func newTitleTestService(t *testing.T) (*Service, *MockEventBus, *sqliterepo.Repository) {
+	t.Helper()
+	svc, bus, repo := createTestService(t)
+	ctx := context.Background()
+	if err := repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws-title", Name: "Titles"}); err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	if err := repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf-title", WorkspaceID: "ws-title", Name: "flow"}); err != nil {
+		t.Fatalf("create workflow: %v", err)
+	}
+	bus.ClearEvents()
+	return svc, bus, repo
+}
+
+func TestSetPendingAgentTitleAppliesClaimedTitle(t *testing.T) {
+	svc, bus, repo := newTitleTestService(t)
+	ctx := context.Background()
+	seedPendingTitleTask(t, repo, "task-title", "sess-owner", true)
+
+	task, accepted, reason, err := svc.SetPendingAgentTitle(ctx, "task-title", "sess-owner", "  Fix the login bug  ")
+	if err != nil {
+		t.Fatalf("SetPendingAgentTitle: %v", err)
+	}
+	if !accepted || reason != "" {
+		t.Fatalf("accepted = %v, reason = %q; want an accepted write", accepted, reason)
+	}
+	if task.Title != "Fix the login bug" {
+		t.Fatalf("title = %q, want the trimmed title", task.Title)
+	}
+	if models.IsAgentTitlePending(task.Metadata) {
+		t.Fatalf("metadata = %v, want the pending marker cleared", task.Metadata)
+	}
+	if models.AgentTitleOwnerSessionID(task.Metadata) != "" {
+		t.Fatalf("metadata = %v, want the owner claim cleared", task.Metadata)
+	}
+
+	stored, err := repo.GetTask(ctx, "task-title")
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if stored.Title != "Fix the login bug" {
+		t.Fatalf("persisted title = %q", stored.Title)
+	}
+	if types := eventTypes(bus.GetPublishedEvents()); len(types) != 1 || types[0] != events.TaskUpdated {
+		t.Fatalf("published %v, want exactly one %s", types, events.TaskUpdated)
+	}
+}
+
+func TestSetPendingAgentTitleRefusesUnclaimedAndForeignSessions(t *testing.T) {
+	svc, bus, repo := newTitleTestService(t)
+	ctx := context.Background()
+	seedPendingTitleTask(t, repo, "task-not-pending", "sess-owner", false)
+	seedPendingTitleTask(t, repo, "task-other-owner", "sess-owner", true)
+
+	task, accepted, reason, err := svc.SetPendingAgentTitle(ctx, "task-not-pending", "sess-owner", "New title")
+	if err != nil {
+		t.Fatalf("SetPendingAgentTitle: %v", err)
+	}
+	if accepted || reason != titleNotPendingReason {
+		t.Fatalf("accepted = %v, reason = %q; want %q", accepted, reason, titleNotPendingReason)
+	}
+	if task.Title != "Untitled" {
+		t.Fatalf("title = %q, want it untouched", task.Title)
+	}
+
+	task, accepted, reason, err = svc.SetPendingAgentTitle(ctx, "task-other-owner", "sess-intruder", "New title")
+	if err != nil {
+		t.Fatalf("SetPendingAgentTitle: %v", err)
+	}
+	if accepted || reason != titleNotOwnerReason {
+		t.Fatalf("accepted = %v, reason = %q; want %q", accepted, reason, titleNotOwnerReason)
+	}
+	if task.Title != "Untitled" {
+		t.Fatalf("title = %q, want it untouched", task.Title)
+	}
+
+	// An empty session id can never own the claim.
+	_, accepted, reason, err = svc.SetPendingAgentTitle(ctx, "task-other-owner", "", "New title")
+	if err != nil {
+		t.Fatalf("SetPendingAgentTitle: %v", err)
+	}
+	if accepted || reason != titleNotOwnerReason {
+		t.Fatalf("accepted = %v, reason = %q; want %q", accepted, reason, titleNotOwnerReason)
+	}
+
+	if published := bus.GetPublishedEvents(); len(published) != 0 {
+		t.Fatalf("refused title writes published %v, want nothing", eventTypes(published))
+	}
+}
+
+func TestSetPendingAgentTitleValidatesTitle(t *testing.T) {
+	svc, bus, repo := newTitleTestService(t)
+	ctx := context.Background()
+	seedPendingTitleTask(t, repo, "task-validate", "sess-owner", true)
+
+	if _, _, _, err := svc.SetPendingAgentTitle(ctx, "task-validate", "sess-owner", "   "); err == nil {
+		t.Fatal("a blank title must be rejected")
+	}
+	stored, err := repo.GetTask(ctx, "task-validate")
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if stored.Title != "Untitled" {
+		t.Fatalf("title = %q, want it untouched after a rejected write", stored.Title)
+	}
+	if published := bus.GetPublishedEvents(); len(published) != 0 {
+		t.Fatalf("rejected title published %v, want nothing", eventTypes(published))
+	}
+
+	if _, _, _, err := svc.SetPendingAgentTitle(ctx, "task-missing", "sess-owner", "Title"); err == nil {
+		t.Fatal("setting a title on an unknown task must fail")
+	}
+}
+
+func TestSetPendingAgentTitleIsWorkspaceScoped(t *testing.T) {
+	svc, bus, repo := createTestService(t)
+	seedScopedWorkspaces(t, repo)
+	ctx := context.Background()
+	// UpdateTask deliberately strips the pending-title keys, so claim them the
+	// way production does: a targeted metadata write.
+	if err := repo.SetTaskMetadataKey(ctx, "task-b", models.MetaKeyAgentTitlePending, true); err != nil {
+		t.Fatalf("mark task title pending: %v", err)
+	}
+	if err := repo.SetTaskMetadataKey(ctx, "task-b", models.MetaKeyAgentTitleOwnerSessionID, "sess-b"); err != nil {
+		t.Fatalf("claim task title: %v", err)
+	}
+	if reloaded, err := repo.GetTask(ctx, "task-b"); err != nil {
+		t.Fatalf("GetTask: %v", err)
+	} else if !models.IsAgentTitleOwner(reloaded.Metadata, "sess-b") {
+		t.Fatalf("fixture metadata = %v, want a pending title claimed by sess-b", reloaded.Metadata)
+	}
+	bus.ClearEvents()
+
+	_, _, _, err := svc.SetPendingAgentTitle(ctxAs("user-a"), "task-b", "sess-b", "Hijacked")
+	if !errors.Is(err, repoerrors.ErrTaskNotFound) {
+		t.Fatalf("foreign SetPendingAgentTitle = %v, want ErrTaskNotFound", err)
+	}
+	stored, err := repo.GetTask(ctx, "task-b")
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if stored.Title != "B's task" {
+		t.Fatalf("title = %q, want it untouched by a denied caller", stored.Title)
+	}
+	if published := bus.GetPublishedEvents(); len(published) != 0 {
+		t.Fatalf("denied title write published %v, want nothing", eventTypes(published))
+	}
+
+	if _, accepted, _, err := svc.SetPendingAgentTitle(ctxAs("user-b"), "task-b", "sess-b", "Owner title"); err != nil || !accepted {
+		t.Fatalf("owner SetPendingAgentTitle accepted = %v, err = %v", accepted, err)
+	}
+}
+
+func TestReplaceTaskRepositoriesSwapsAssociations(t *testing.T) {
+	svc, _, repo := newTitleTestService(t)
+	ctx := context.Background()
+	seedPendingTitleTask(t, repo, "task-repos", "", false)
+	for _, id := range []string{"repo-a", "repo-b"} {
+		if err := repo.CreateRepository(ctx, &models.Repository{
+			ID: id, WorkspaceID: "ws-title", Name: id, DefaultBranch: "main",
+		}); err != nil {
+			t.Fatalf("create repository %s: %v", id, err)
+		}
+	}
+
+	if err := svc.ReplaceTaskRepositories(ctx, "task-repos", "ws-title", []TaskRepositoryInput{
+		{RepositoryID: "repo-a", BaseBranch: "main"},
+	}); err != nil {
+		t.Fatalf("first ReplaceTaskRepositories: %v", err)
+	}
+	linked, err := repo.ListTaskRepositories(ctx, "task-repos")
+	if err != nil {
+		t.Fatalf("ListTaskRepositories: %v", err)
+	}
+	if len(linked) != 1 || linked[0].RepositoryID != "repo-a" {
+		t.Fatalf("task repositories = %+v, want just repo-a", linked)
+	}
+
+	if err := svc.ReplaceTaskRepositories(ctx, "task-repos", "ws-title", []TaskRepositoryInput{
+		{RepositoryID: "repo-b", BaseBranch: "develop"},
+	}); err != nil {
+		t.Fatalf("second ReplaceTaskRepositories: %v", err)
+	}
+	linked, err = repo.ListTaskRepositories(ctx, "task-repos")
+	if err != nil {
+		t.Fatalf("ListTaskRepositories: %v", err)
+	}
+	if len(linked) != 1 || linked[0].RepositoryID != "repo-b" {
+		t.Fatalf("task repositories = %+v, want the previous link replaced by repo-b", linked)
+	}
+	if linked[0].BaseBranch != "develop" {
+		t.Fatalf("base branch = %q, want develop", linked[0].BaseBranch)
+	}
+
+	// Replacing with an empty list clears every association.
+	if err := svc.ReplaceTaskRepositories(ctx, "task-repos", "ws-title", nil); err != nil {
+		t.Fatalf("clearing ReplaceTaskRepositories: %v", err)
+	}
+	linked, err = repo.ListTaskRepositories(ctx, "task-repos")
+	if err != nil {
+		t.Fatalf("ListTaskRepositories: %v", err)
+	}
+	if len(linked) != 0 {
+		t.Fatalf("task repositories = %+v, want none", linked)
+	}
+}
+
+func TestIsConfigTaskAcceptsNumericAndBooleanMarkers(t *testing.T) {
+	cases := []struct {
+		name string
+		meta map[string]interface{}
+		want bool
+	}{
+		{"no metadata", nil, false},
+		{"unrelated key", map[string]interface{}{"other": 1}, false},
+		{"json number", map[string]interface{}{"config_mode": float64(1)}, true},
+		{"json number zero", map[string]interface{}{"config_mode": float64(0)}, false},
+		{"int", map[string]interface{}{"config_mode": 1}, true},
+		{"int other", map[string]interface{}{"config_mode": 2}, false},
+		{"bool true", map[string]interface{}{"config_mode": true}, true},
+		{"bool false", map[string]interface{}{"config_mode": false}, false},
+		{"string is not a marker", map[string]interface{}{"config_mode": "1"}, false},
+	}
+	for _, tc := range cases {
+		if got := isConfigTask(&models.Task{Metadata: tc.meta}); got != tc.want {
+			t.Fatalf("%s: isConfigTask = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestListTasksByWorkspaceWithArchiveModeSeparatesArchived(t *testing.T) {
+	svc, _, repo := newTitleTestService(t)
+	ctx := context.Background()
+	seedPendingTitleTask(t, repo, "task-live", "", false)
+	seedPendingTitleTask(t, repo, "task-archived", "", false)
+	if err := svc.ArchiveTask(ctx, "task-archived"); err != nil {
+		t.Fatalf("ArchiveTask: %v", err)
+	}
+
+	live, total, err := svc.ListTasksByWorkspace(ctx, "ws-title", "", "", "", 1, 50, "", false, false, false, false)
+	if err != nil {
+		t.Fatalf("ListTasksByWorkspace: %v", err)
+	}
+	if total != 1 || len(live) != 1 || live[0].ID != "task-live" {
+		t.Fatalf("live listing = %d tasks (total %d), want just task-live", len(live), total)
+	}
+
+	archived, total, err := svc.ListTasksByWorkspaceWithArchiveMode(ctx, "ws-title", "", "", "", 1, 50, "", false, false, false, false, true)
+	if err != nil {
+		t.Fatalf("ListTasksByWorkspaceWithArchiveMode: %v", err)
+	}
+	if total != 1 || len(archived) != 1 || archived[0].ID != "task-archived" {
+		t.Fatalf("archived listing = %+v (total %d), want just task-archived", archived, total)
+	}
+
+	both, total, err := svc.ListTasksByWorkspace(ctx, "ws-title", "", "", "", 1, 50, "", true, false, false, false)
+	if err != nil {
+		t.Fatalf("ListTasksByWorkspace including archived: %v", err)
+	}
+	if total != 2 || len(both) != 2 {
+		t.Fatalf("combined listing = %d tasks (total %d), want 2", len(both), total)
+	}
+}
+
+func TestParsePRQueryAcceptsOptionalHash(t *testing.T) {
+	cases := []struct {
+		query string
+		want  int
+		ok    bool
+	}{
+		{"123", 123, true},
+		{"#123", 123, true},
+		{"  #42  ", 42, true},
+		{"", 0, false},
+		{"#", 0, false},
+		{"0", 0, false},
+		{"-5", 0, false},
+		{"login bug", 0, false},
+	}
+	for _, tc := range cases {
+		got, ok := parsePRQuery(tc.query)
+		if got != tc.want || ok != tc.ok {
+			t.Fatalf("parsePRQuery(%q) = %d, %v; want %d, %v", tc.query, got, ok, tc.want, tc.ok)
+		}
+	}
+}

--- a/apps/backend/internal/task/service/service_turns_coverage_test.go
+++ b/apps/backend/internal/task/service/service_turns_coverage_test.go
@@ -1,0 +1,365 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/events"
+	"github.com/kandev/kandev/internal/task/models"
+	sqliterepo "github.com/kandev/kandev/internal/task/repository/sqlite"
+)
+
+func TestGetAndListTurns(t *testing.T) {
+	svc, _, repo := newMessageTestService(t)
+	ctx := context.Background()
+	seedTurn(t, repo, "turn-second", "sess-msg", "task-msg")
+
+	turn, err := svc.GetTurn(ctx, "turn-msg")
+	if err != nil {
+		t.Fatalf("GetTurn: %v", err)
+	}
+	if turn.ID != "turn-msg" || turn.TaskSessionID != "sess-msg" || turn.TaskID != "task-msg" {
+		t.Fatalf("turn = %+v", turn)
+	}
+
+	turns, err := svc.ListTurnsBySession(ctx, "sess-msg")
+	if err != nil {
+		t.Fatalf("ListTurnsBySession: %v", err)
+	}
+	if len(turns) != 2 {
+		t.Fatalf("turns = %d, want 2", len(turns))
+	}
+	ids := map[string]bool{turns[0].ID: true, turns[1].ID: true}
+	if !ids["turn-msg"] || !ids["turn-second"] {
+		t.Fatalf("turn ids = %v, want both seeded turns", ids)
+	}
+
+	empty, err := svc.ListTurnsBySession(ctx, "sess-none")
+	if err != nil {
+		t.Fatalf("ListTurnsBySession for an unknown session: %v", err)
+	}
+	if len(empty) != 0 {
+		t.Fatalf("turns for an unknown session = %d, want 0", len(empty))
+	}
+}
+
+func TestUpdateTurnPersistsChangesAndIgnoresNil(t *testing.T) {
+	svc, _, repo := newMessageTestService(t)
+	ctx := context.Background()
+
+	if err := svc.UpdateTurn(ctx, nil); err != nil {
+		t.Fatalf("UpdateTurn(nil) must be a no-op, got %v", err)
+	}
+
+	turn, err := svc.GetTurn(ctx, "turn-msg")
+	if err != nil {
+		t.Fatalf("GetTurn: %v", err)
+	}
+	turn.Metadata = map[string]interface{}{"model": "opus"}
+	if err := svc.UpdateTurn(ctx, turn); err != nil {
+		t.Fatalf("UpdateTurn: %v", err)
+	}
+	stored, err := repo.GetTurn(ctx, "turn-msg")
+	if err != nil {
+		t.Fatalf("GetTurn: %v", err)
+	}
+	if stored.Metadata["model"] != "opus" {
+		t.Fatalf("metadata = %v, want the persisted model", stored.Metadata)
+	}
+}
+
+func TestCompleteTurnPublishesHadOutput(t *testing.T) {
+	svc, bus, repo := newMessageTestService(t)
+	ctx := context.Background()
+
+	// An empty turn: no agent output.
+	if err := svc.CompleteTurn(ctx, "turn-msg"); err != nil {
+		t.Fatalf("CompleteTurn: %v", err)
+	}
+	completed := singleTurnCompletedEvent(t, bus)
+	if completed["had_output"] != false {
+		t.Fatalf("had_output = %v, want false for a turn with no agent output", completed["had_output"])
+	}
+	if completed["id"] != "turn-msg" || completed["session_id"] != "sess-msg" {
+		t.Fatalf("turn event identity = %v/%v, want turn-msg/sess-msg", completed["id"], completed["session_id"])
+	}
+	if completed["completed_at"] == nil {
+		t.Fatal("turn.completed payload must carry completed_at")
+	}
+	stored, err := repo.GetTurn(ctx, "turn-msg")
+	if err != nil {
+		t.Fatalf("GetTurn: %v", err)
+	}
+	if stored.CompletedAt == nil {
+		t.Fatal("completed_at must be set")
+	}
+
+	// A turn carrying agent text reports had_output.
+	seedTurn(t, repo, "turn-output", "sess-msg", "task-msg")
+	seedMessage(t, repo, &models.Message{
+		ID: "msg-output", TurnID: "turn-output", AuthorType: models.MessageAuthorAgent, Content: "done",
+	})
+	bus.ClearEvents()
+	if err := svc.CompleteTurn(ctx, "turn-output"); err != nil {
+		t.Fatalf("CompleteTurn: %v", err)
+	}
+	if got := singleTurnCompletedEvent(t, bus)["had_output"]; got != true {
+		t.Fatalf("had_output = %v, want true", got)
+	}
+}
+
+func TestCompleteTurnIgnoresEmptyIDAndMissingTurn(t *testing.T) {
+	svc, bus, _ := newMessageTestService(t)
+	ctx := context.Background()
+
+	if err := svc.CompleteTurn(ctx, ""); err != nil {
+		t.Fatalf("CompleteTurn(\"\") must be a no-op, got %v", err)
+	}
+	if published := bus.GetPublishedEvents(); len(published) != 0 {
+		t.Fatalf("empty turn id published %v, want nothing", eventTypes(published))
+	}
+}
+
+func TestCompleteTurnClosesPendingToolCalls(t *testing.T) {
+	svc, _, repo := newMessageTestService(t)
+	ctx := context.Background()
+	seedMessage(t, repo, &models.Message{
+		ID: "msg-pending-tool", TurnID: "turn-msg", Type: models.MessageTypeToolExecute,
+		AuthorType: models.MessageAuthorAgent, Content: "run",
+		Metadata: map[string]interface{}{"tool_call_id": "tc-pending", "status": "running"},
+	})
+
+	if err := svc.CompleteTurn(ctx, "turn-msg"); err != nil {
+		t.Fatalf("CompleteTurn: %v", err)
+	}
+	stored, err := repo.GetMessage(ctx, "msg-pending-tool")
+	if err != nil {
+		t.Fatalf("GetMessage: %v", err)
+	}
+	if stored.Metadata["status"] != "complete" {
+		t.Fatalf("tool status = %v, want the safety net to complete it", stored.Metadata["status"])
+	}
+}
+
+// singleTurnCompletedEvent returns the one turn.completed payload.
+func singleTurnCompletedEvent(t *testing.T, bus *MockEventBus) map[string]interface{} {
+	t.Helper()
+	published := bus.GetPublishedEvents()
+	var matched []map[string]interface{}
+	for _, event := range published {
+		if event.Type != events.TurnCompleted {
+			continue
+		}
+		data, ok := event.Data.(map[string]interface{})
+		if !ok {
+			t.Fatalf("event data = %T, want a map payload", event.Data)
+		}
+		matched = append(matched, data)
+	}
+	if len(matched) != 1 {
+		t.Fatalf("published %v, want exactly one %s", eventTypes(published), events.TurnCompleted)
+	}
+	return matched[0]
+}
+
+func TestTurnHadAgentOutputAllowlist(t *testing.T) {
+	cases := []struct {
+		name string
+		msg  *models.Message
+		want bool
+	}{
+		{"nil message", nil, false},
+		{"other turn", &models.Message{
+			TurnID: "other", AuthorType: models.MessageAuthorAgent, Type: models.MessageTypeToolCall,
+		}, false},
+		{"user message", &models.Message{
+			TurnID: "turn-1", AuthorType: models.MessageAuthorUser, Content: "hi",
+		}, false},
+		{"tool call", &models.Message{
+			TurnID: "turn-1", AuthorType: models.MessageAuthorAgent, Type: models.MessageTypeToolCall,
+		}, true},
+		{"permission request", &models.Message{
+			TurnID: "turn-1", AuthorType: models.MessageAuthorAgent, Type: models.MessageTypePermissionRequest,
+		}, true},
+		{"agent plan", &models.Message{
+			TurnID: "turn-1", AuthorType: models.MessageAuthorAgent, Type: models.MessageTypeAgentPlan,
+		}, true},
+		{"blank text", &models.Message{
+			TurnID: "turn-1", AuthorType: models.MessageAuthorAgent, Type: models.MessageTypeMessage, Content: "  ",
+		}, false},
+		{"non-empty text", &models.Message{
+			TurnID: "turn-1", AuthorType: models.MessageAuthorAgent, Type: models.MessageTypeMessage, Content: "hi",
+		}, true},
+		{"untyped text counts", &models.Message{
+			TurnID: "turn-1", AuthorType: models.MessageAuthorAgent, Content: "hi",
+		}, true},
+		{"status notice does not count", &models.Message{
+			TurnID: "turn-1", AuthorType: models.MessageAuthorAgent,
+			Type: models.MessageType("status"), Content: "starting",
+		}, false},
+	}
+	for _, tc := range cases {
+		if got := turnHadAgentOutput([]*models.Message{tc.msg}, "turn-1"); got != tc.want {
+			t.Fatalf("%s: turnHadAgentOutput = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+	if turnHadAgentOutput(nil, "turn-1") {
+		t.Fatal("an empty message list must report no output")
+	}
+}
+
+func TestStringConfigOptionsNormalizesShapes(t *testing.T) {
+	typed := stringConfigOptions(map[string]string{"a": "1"})
+	if len(typed) != 1 || typed["a"] != "1" {
+		t.Fatalf("typed map = %v", typed)
+	}
+
+	loose := stringConfigOptions(map[string]interface{}{"a": "1", "b": 2, "empty": ""})
+	if loose["a"] != "1" {
+		t.Fatalf("loose map = %v, want string values carried over", loose)
+	}
+	if _, ok := loose["empty"]; ok {
+		t.Fatalf("loose map = %v, want empty values dropped", loose)
+	}
+
+	if got := stringConfigOptions("not a map"); got != nil {
+		t.Fatalf("unsupported shape = %v, want nil", got)
+	}
+	if got := stringConfigOptions(nil); got != nil {
+		t.Fatalf("nil = %v, want nil", got)
+	}
+}
+
+func TestGitSnapshotAndCommitReads(t *testing.T) {
+	svc, _, repo := newMessageTestService(t)
+	ctx := context.Background()
+
+	// No snapshots yet: the cumulative diff is a valid empty state.
+	diff, err := svc.GetCumulativeDiff(ctx, "sess-msg")
+	if err != nil {
+		t.Fatalf("GetCumulativeDiff with no snapshots: %v", err)
+	}
+	if diff != nil {
+		t.Fatalf("cumulative diff = %+v, want nil for a fresh session", diff)
+	}
+
+	first := seedGitSnapshot(t, repo, "snap-1", "sess-msg", "base-sha", "head-1")
+	time.Sleep(2 * time.Millisecond)
+	latest := seedGitSnapshot(t, repo, "snap-2", "sess-msg", "base-sha-2", "head-2")
+
+	snapshots, err := svc.GetGitSnapshots(ctx, "sess-msg", 10)
+	if err != nil {
+		t.Fatalf("GetGitSnapshots: %v", err)
+	}
+	if len(snapshots) != 2 {
+		t.Fatalf("snapshots = %d, want 2", len(snapshots))
+	}
+
+	gotFirst, err := svc.GetFirstGitSnapshot(ctx, "sess-msg")
+	if err != nil {
+		t.Fatalf("GetFirstGitSnapshot: %v", err)
+	}
+	if gotFirst.ID != first.ID {
+		t.Fatalf("first snapshot = %q, want %q", gotFirst.ID, first.ID)
+	}
+	gotLatest, err := svc.GetLatestGitSnapshot(ctx, "sess-msg")
+	if err != nil {
+		t.Fatalf("GetLatestGitSnapshot: %v", err)
+	}
+	if gotLatest.ID != latest.ID {
+		t.Fatalf("latest snapshot = %q, want %q", gotLatest.ID, latest.ID)
+	}
+
+	if err := repo.CreateSessionCommit(ctx, &models.SessionCommit{
+		ID: "commit-1", SessionID: "sess-msg", CommitSHA: "sha-1", CommitMessage: "first",
+		CommittedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("CreateSessionCommit: %v", err)
+	}
+	commits, err := svc.GetSessionCommits(ctx, "sess-msg")
+	if err != nil {
+		t.Fatalf("GetSessionCommits: %v", err)
+	}
+	if len(commits) != 1 || commits[0].CommitSHA != "sha-1" {
+		t.Fatalf("commits = %+v", commits)
+	}
+	latestCommit, err := svc.GetLatestSessionCommit(ctx, "sess-msg")
+	if err != nil {
+		t.Fatalf("GetLatestSessionCommit: %v", err)
+	}
+	if latestCommit.ID != "commit-1" {
+		t.Fatalf("latest commit = %+v", latestCommit)
+	}
+
+	diff, err = svc.GetCumulativeDiff(ctx, "sess-msg")
+	if err != nil {
+		t.Fatalf("GetCumulativeDiff: %v", err)
+	}
+	if diff == nil {
+		t.Fatal("cumulative diff must be present once snapshots exist")
+	}
+	if diff.BaseCommit != "base-sha" {
+		t.Fatalf("base commit = %q, want the first snapshot's base", diff.BaseCommit)
+	}
+	if diff.HeadCommit != "head-2" {
+		t.Fatalf("head commit = %q, want the latest snapshot's head", diff.HeadCommit)
+	}
+	if diff.TotalCommits != 1 {
+		t.Fatalf("total commits = %d, want 1", diff.TotalCommits)
+	}
+	if diff.SessionID != "sess-msg" {
+		t.Fatalf("session id = %q", diff.SessionID)
+	}
+	if _, ok := diff.Files["main.go"]; !ok {
+		t.Fatalf("files = %v, want the latest snapshot's files", diff.Files)
+	}
+}
+
+func seedGitSnapshot(t *testing.T, repo *sqliterepo.Repository, id, sessionID, baseCommit, headCommit string) *models.GitSnapshot {
+	t.Helper()
+	snapshot := &models.GitSnapshot{
+		ID: id, SessionID: sessionID, SnapshotType: models.SnapshotTypeStatusUpdate,
+		Branch: "main", HeadCommit: headCommit, BaseCommit: baseCommit,
+		Files: map[string]interface{}{"main.go": map[string]interface{}{"status": "modified"}},
+	}
+	if err := repo.CreateGitSnapshot(context.Background(), snapshot); err != nil {
+		t.Fatalf("CreateGitSnapshot %s: %v", id, err)
+	}
+	return snapshot
+}
+
+func TestPersistSessionRuntimeModeStoresOverrideAndMetadata(t *testing.T) {
+	svc, _, repo := newMessageTestService(t)
+	ctx := context.Background()
+
+	if err := svc.PersistSessionRuntimeMode(ctx, "sess-msg", ""); err != nil {
+		t.Fatalf("empty mode must be a no-op, got %v", err)
+	}
+	session, err := repo.GetTaskSession(ctx, "sess-msg")
+	if err != nil {
+		t.Fatalf("GetTaskSession: %v", err)
+	}
+	if _, ok := session.Metadata[models.SessionMetaKeySessionMode]; ok {
+		t.Fatalf("metadata = %v, want no mode written for an empty mode", session.Metadata)
+	}
+
+	if err := svc.PersistSessionRuntimeMode(ctx, "sess-msg", "plan"); err != nil {
+		t.Fatalf("PersistSessionRuntimeMode: %v", err)
+	}
+	session, err = repo.GetTaskSession(ctx, "sess-msg")
+	if err != nil {
+		t.Fatalf("GetTaskSession: %v", err)
+	}
+	if session.Metadata[models.SessionMetaKeySessionMode] != "plan" {
+		t.Fatalf("session mode = %v, want plan", session.Metadata[models.SessionMetaKeySessionMode])
+	}
+	overrides, _ := models.LoadSessionRuntimeConfigOverrides(session.Metadata)
+	if overrides.Mode != "plan" {
+		t.Fatalf("runtime overrides = %+v, want mode plan", overrides)
+	}
+
+	if err := svc.PersistSessionRuntimeMode(ctx, "sess-unknown", "plan"); err == nil {
+		t.Fatal("persisting a mode on an unknown session must fail")
+	}
+}

--- a/apps/backend/internal/task/service/service_turns_coverage_test.go
+++ b/apps/backend/internal/task/service/service_turns_coverage_test.go
@@ -244,9 +244,11 @@ func TestGitSnapshotAndCommitReads(t *testing.T) {
 		t.Fatalf("cumulative diff = %+v, want nil for a fresh session", diff)
 	}
 
-	first := seedGitSnapshot(t, repo, "snap-1", "sess-msg", "base-sha", "head-1")
-	time.Sleep(2 * time.Millisecond)
-	latest := seedGitSnapshot(t, repo, "snap-2", "sess-msg", "base-sha-2", "head-2")
+	// Explicit created_at values pin first-vs-latest ordering without depending
+	// on wall-clock spacing between two inserts.
+	base := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	first := seedGitSnapshot(t, repo, "snap-1", "sess-msg", "base-sha", "head-1", base)
+	latest := seedGitSnapshot(t, repo, "snap-2", "sess-msg", "base-sha-2", "head-2", base.Add(time.Minute))
 
 	snapshots, err := svc.GetGitSnapshots(ctx, "sess-msg", 10)
 	if err != nil {
@@ -316,12 +318,13 @@ func TestGitSnapshotAndCommitReads(t *testing.T) {
 	}
 }
 
-func seedGitSnapshot(t *testing.T, repo *sqliterepo.Repository, id, sessionID, baseCommit, headCommit string) *models.GitSnapshot {
+func seedGitSnapshot(t *testing.T, repo *sqliterepo.Repository, id, sessionID, baseCommit, headCommit string, createdAt time.Time) *models.GitSnapshot {
 	t.Helper()
 	snapshot := &models.GitSnapshot{
 		ID: id, SessionID: sessionID, SnapshotType: models.SnapshotTypeStatusUpdate,
 		Branch: "main", HeadCommit: headCommit, BaseCommit: baseCommit,
-		Files: map[string]interface{}{"main.go": map[string]interface{}{"status": "modified"}},
+		Files:     map[string]interface{}{"main.go": map[string]interface{}{"status": "modified"}},
+		CreatedAt: createdAt,
 	}
 	if err := repo.CreateGitSnapshot(context.Background(), snapshot); err != nil {
 		t.Fatalf("CreateGitSnapshot %s: %v", id, err)

--- a/apps/backend/internal/task/service/service_workflow_state_test.go
+++ b/apps/backend/internal/task/service/service_workflow_state_test.go
@@ -1,0 +1,367 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/events"
+	"github.com/kandev/kandev/internal/task/models"
+	sqliterepo "github.com/kandev/kandev/internal/task/repository/sqlite"
+	v1 "github.com/kandev/kandev/pkg/api/v1"
+)
+
+// newWorkflowStateTestService seeds a workspace/workflow plus one task and
+// session so the guarded state writers have real rows to CAS against.
+func newWorkflowStateTestService(t *testing.T) (*Service, *MockEventBus, *sqliterepo.Repository) {
+	t.Helper()
+	svc, bus, repo := createTestService(t)
+	ctx := context.Background()
+	if err := repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws-state", Name: "State"}); err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	if err := repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf-state", WorkspaceID: "ws-state", Name: "flow"}); err != nil {
+		t.Fatalf("create workflow: %v", err)
+	}
+	if err := repo.CreateTask(ctx, &models.Task{
+		ID: "task-state", WorkspaceID: "ws-state", WorkflowID: "wf-state", WorkflowStepID: "step-1",
+		Title: "State", State: v1.TaskStateCreated, Priority: "medium",
+	}); err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	if err := repo.CreateTaskSession(ctx, &models.TaskSession{
+		ID: "sess-state", TaskID: "task-state", State: models.TaskSessionStateRunning,
+	}); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	bus.ClearEvents()
+	return svc, bus, repo
+}
+
+// stateChangedEvent returns the single task.state_changed payload, failing when
+// the count is not exactly one.
+func stateChangedEvent(t *testing.T, bus *MockEventBus) map[string]interface{} {
+	t.Helper()
+	published := bus.GetPublishedEvents()
+	var matched []map[string]interface{}
+	for _, event := range published {
+		if event.Type != events.TaskStateChanged {
+			continue
+		}
+		data, ok := event.Data.(map[string]interface{})
+		if !ok {
+			t.Fatalf("event data = %T, want a map payload", event.Data)
+		}
+		matched = append(matched, data)
+	}
+	if len(matched) != 1 {
+		t.Fatalf("published %v, want exactly one %s", eventTypes(published), events.TaskStateChanged)
+	}
+	return matched[0]
+}
+
+func TestUpdateTaskStateIfCurrentInWritesOnlyFromAllowedStates(t *testing.T) {
+	svc, bus, repo := newWorkflowStateTestService(t)
+	ctx := context.Background()
+
+	// Current state is CREATED, which is not in the allowed set: no write, no event.
+	updated, err := svc.UpdateTaskStateIfCurrentIn(ctx, "task-state", v1.TaskStateCompleted,
+		[]v1.TaskState{v1.TaskStateInProgress})
+	if err != nil {
+		t.Fatalf("UpdateTaskStateIfCurrentIn: %v", err)
+	}
+	if updated {
+		t.Fatal("state must not change from a disallowed current state")
+	}
+	if published := bus.GetPublishedEvents(); len(published) != 0 {
+		t.Fatalf("no-op CAS published %v, want nothing", eventTypes(published))
+	}
+	stored, err := repo.GetTask(ctx, "task-state")
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if stored.State != v1.TaskStateCreated {
+		t.Fatalf("state = %q, want it untouched", stored.State)
+	}
+
+	// Now the current state is allowed: the row changes and one event fires.
+	updated, err = svc.UpdateTaskStateIfCurrentIn(ctx, "task-state", v1.TaskStateInProgress,
+		[]v1.TaskState{v1.TaskStateCreated})
+	if err != nil {
+		t.Fatalf("UpdateTaskStateIfCurrentIn: %v", err)
+	}
+	if !updated {
+		t.Fatal("state must change from an allowed current state")
+	}
+	stored, err = repo.GetTask(ctx, "task-state")
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if stored.State != v1.TaskStateInProgress {
+		t.Fatalf("state = %q, want in_progress", stored.State)
+	}
+	data := stateChangedEvent(t, bus)
+	if data["task_id"] != "task-state" {
+		t.Fatalf("event task_id = %v", data["task_id"])
+	}
+	if data["state"] != string(v1.TaskStateInProgress) {
+		t.Fatalf("event state = %v, want in_progress", data["state"])
+	}
+	if data["old_state"] != string(v1.TaskStateCreated) {
+		t.Fatalf("event old_state = %v, want created", data["old_state"])
+	}
+}
+
+func TestUpdateTaskStateIfCurrentInRejectsEmptyAllowedSet(t *testing.T) {
+	svc, bus, _ := newWorkflowStateTestService(t)
+
+	updated, err := svc.UpdateTaskStateIfCurrentIn(context.Background(), "task-state", v1.TaskStateCompleted, nil)
+	if err != nil {
+		t.Fatalf("UpdateTaskStateIfCurrentIn: %v", err)
+	}
+	if updated {
+		t.Fatal("an empty allowed set must never write")
+	}
+	if published := bus.GetPublishedEvents(); len(published) != 0 {
+		t.Fatalf("published %v, want nothing", eventTypes(published))
+	}
+}
+
+func TestUpdateTaskStateIfNotArchivedFreezesArchivedTasks(t *testing.T) {
+	svc, bus, repo := newWorkflowStateTestService(t)
+	ctx := context.Background()
+
+	updated, err := svc.UpdateTaskStateIfNotArchived(ctx, "task-state", v1.TaskStateInProgress)
+	if err != nil {
+		t.Fatalf("UpdateTaskStateIfNotArchived: %v", err)
+	}
+	if !updated {
+		t.Fatal("an unarchived task must accept the write")
+	}
+	if data := stateChangedEvent(t, bus); data["old_state"] != string(v1.TaskStateCreated) {
+		t.Fatalf("event old_state = %v, want created", data["old_state"])
+	}
+
+	// Writing the same state again is a no-op with no duplicate event.
+	bus.ClearEvents()
+	updated, err = svc.UpdateTaskStateIfNotArchived(ctx, "task-state", v1.TaskStateInProgress)
+	if err != nil {
+		t.Fatalf("repeat UpdateTaskStateIfNotArchived: %v", err)
+	}
+	if updated {
+		t.Fatal("re-writing the same state must report no change")
+	}
+	if published := bus.GetPublishedEvents(); len(published) != 0 {
+		t.Fatalf("same-state write published %v, want nothing", eventTypes(published))
+	}
+
+	// Archived tasks are frozen.
+	if err := svc.ArchiveTask(ctx, "task-state"); err != nil {
+		t.Fatalf("ArchiveTask: %v", err)
+	}
+	bus.ClearEvents()
+	updated, err = svc.UpdateTaskStateIfNotArchived(ctx, "task-state", v1.TaskStateCompleted)
+	if err != nil {
+		t.Fatalf("archived UpdateTaskStateIfNotArchived: %v", err)
+	}
+	if updated {
+		t.Fatal("an archived task must not accept a state write")
+	}
+	stored, err := repo.GetTask(ctx, "task-state")
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if stored.State != v1.TaskStateInProgress {
+		t.Fatalf("archived task state = %q, want the pre-archive value", stored.State)
+	}
+	if published := bus.GetPublishedEvents(); len(published) != 0 {
+		t.Fatalf("frozen write published %v, want nothing", eventTypes(published))
+	}
+}
+
+func TestUpdateTaskStateIfSessionStateRequiresExpectedSessionState(t *testing.T) {
+	svc, bus, repo := newWorkflowStateTestService(t)
+	ctx := context.Background()
+
+	// The session is RUNNING, so a COMPLETED expectation must not write.
+	updated, err := svc.UpdateTaskStateIfSessionState(ctx, "task-state", "sess-state",
+		models.TaskSessionStateCompleted, v1.TaskStateCompleted)
+	if err != nil {
+		t.Fatalf("UpdateTaskStateIfSessionState: %v", err)
+	}
+	if updated {
+		t.Fatal("a mismatched session state must block the write")
+	}
+	if published := bus.GetPublishedEvents(); len(published) != 0 {
+		t.Fatalf("blocked write published %v, want nothing", eventTypes(published))
+	}
+
+	updated, err = svc.UpdateTaskStateIfSessionState(ctx, "task-state", "sess-state",
+		models.TaskSessionStateRunning, v1.TaskStateInProgress)
+	if err != nil {
+		t.Fatalf("UpdateTaskStateIfSessionState: %v", err)
+	}
+	if !updated {
+		t.Fatal("a matching session state must allow the write")
+	}
+	stored, err := repo.GetTask(ctx, "task-state")
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if stored.State != v1.TaskStateInProgress {
+		t.Fatalf("state = %q, want in_progress", stored.State)
+	}
+	if data := stateChangedEvent(t, bus); data["state"] != string(v1.TaskStateInProgress) {
+		t.Fatalf("event state = %v", data["state"])
+	}
+}
+
+func TestCountTasksByWorkflowAndStep(t *testing.T) {
+	svc, _, repo := newWorkflowStateTestService(t)
+	ctx := context.Background()
+	if err := repo.CreateTask(ctx, &models.Task{
+		ID: "task-state-2", WorkspaceID: "ws-state", WorkflowID: "wf-state", WorkflowStepID: "step-2",
+		Title: "Second", State: v1.TaskStateCreated, Priority: "medium",
+	}); err != nil {
+		t.Fatalf("create second task: %v", err)
+	}
+
+	workflowCount, err := svc.CountTasksByWorkflow(ctx, "wf-state")
+	if err != nil {
+		t.Fatalf("CountTasksByWorkflow: %v", err)
+	}
+	if workflowCount != 2 {
+		t.Fatalf("workflow count = %d, want 2", workflowCount)
+	}
+
+	stepCount, err := svc.CountTasksByWorkflowStep(ctx, "step-1")
+	if err != nil {
+		t.Fatalf("CountTasksByWorkflowStep: %v", err)
+	}
+	if stepCount != 1 {
+		t.Fatalf("step-1 count = %d, want 1", stepCount)
+	}
+	emptyCount, err := svc.CountTasksByWorkflowStep(ctx, "step-empty")
+	if err != nil {
+		t.Fatalf("CountTasksByWorkflowStep: %v", err)
+	}
+	if emptyCount != 0 {
+		t.Fatalf("empty step count = %d, want 0", emptyCount)
+	}
+}
+
+func TestQueuedTaskBeforeOrdersByPositionPriorityThenAge(t *testing.T) {
+	earlier := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	later := earlier.Add(time.Hour)
+
+	cases := []struct {
+		name        string
+		left, right *models.Task
+		want        bool
+	}{
+		{
+			name:  "lower position wins",
+			left:  &models.Task{ID: "a", Position: 1, Priority: "low"},
+			right: &models.Task{ID: "b", Position: 2, Priority: "critical"},
+			want:  true,
+		},
+		{
+			name:  "higher position loses",
+			left:  &models.Task{ID: "a", Position: 3, Priority: "critical"},
+			right: &models.Task{ID: "b", Position: 2, Priority: "low"},
+			want:  false,
+		},
+		{
+			name:  "critical beats high at equal position",
+			left:  &models.Task{ID: "a", Position: 1, Priority: "critical"},
+			right: &models.Task{ID: "b", Position: 1, Priority: "high"},
+			want:  true,
+		},
+		{
+			name:  "medium beats low",
+			left:  &models.Task{ID: "a", Position: 1, Priority: priorityMedium},
+			right: &models.Task{ID: "b", Position: 1, Priority: priorityLow},
+			want:  true,
+		},
+		{
+			name:  "known priority beats an unrecognized one",
+			left:  &models.Task{ID: "a", Position: 1, Priority: priorityLow},
+			right: &models.Task{ID: "b", Position: 1, Priority: "whenever"},
+			want:  true,
+		},
+		{
+			name:  "earlier queued_at wins at equal priority",
+			left:  &models.Task{ID: "a", Position: 1, Priority: priorityMedium, QueuedAt: &earlier},
+			right: &models.Task{ID: "b", Position: 1, Priority: priorityMedium, QueuedAt: &later},
+			want:  true,
+		},
+		{
+			name: "created_at breaks a queued_at tie",
+			left: &models.Task{
+				ID: "a", Position: 1, Priority: priorityMedium, QueuedAt: &earlier, CreatedAt: earlier,
+			},
+			right: &models.Task{
+				ID: "b", Position: 1, Priority: priorityMedium, QueuedAt: &earlier, CreatedAt: later,
+			},
+			want: true,
+		},
+		{
+			name: "id breaks a full tie",
+			left: &models.Task{
+				ID: "a", Position: 1, Priority: priorityMedium, QueuedAt: &earlier, CreatedAt: earlier,
+			},
+			right: &models.Task{
+				ID: "b", Position: 1, Priority: priorityMedium, QueuedAt: &earlier, CreatedAt: earlier,
+			},
+			want: true,
+		},
+		{
+			name: "identical tasks are not before each other",
+			left: &models.Task{
+				ID: "same", Position: 1, Priority: priorityMedium, QueuedAt: &earlier, CreatedAt: earlier,
+			},
+			right: &models.Task{
+				ID: "same", Position: 1, Priority: priorityMedium, QueuedAt: &earlier, CreatedAt: earlier,
+			},
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		if got := queuedTaskBefore(tc.left, tc.right); got != tc.want {
+			t.Fatalf("%s: queuedTaskBefore = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestFindSameStepQueuedCandidatePicksFirstEligible(t *testing.T) {
+	admitted := &models.Task{ID: "admitted", QueuedForStepID: "step-1", WIPAdmitted: true, Position: 0}
+	otherStep := &models.Task{ID: "other-step", QueuedForStepID: "step-2", Position: 0}
+	skippedTask := &models.Task{ID: "skipped", QueuedForStepID: "step-1", Position: 0}
+	first := &models.Task{ID: "first", QueuedForStepID: "step-1", Position: 1, Priority: priorityMedium}
+	second := &models.Task{ID: "second", QueuedForStepID: "step-1", Position: 2, Priority: "critical"}
+
+	candidates := []*models.Task{nil, admitted, otherStep, skippedTask, second, first}
+	skipped := map[string]struct{}{"skipped": {}}
+
+	selected := findSameStepQueuedCandidate(candidates, "step-1", skipped)
+	if selected == nil || selected.ID != "first" {
+		t.Fatalf("selected = %+v, want the lowest-position unskipped queued task", selected)
+	}
+
+	// With every eligible candidate skipped there is nothing to promote.
+	if got := findSameStepQueuedCandidate(candidates, "step-1", map[string]struct{}{
+		"skipped": {}, "first": {}, "second": {},
+	}); got != nil {
+		t.Fatalf("selected = %+v, want nil when all candidates are skipped", got)
+	}
+}
+
+func TestSkippedTaskIDsDropsEmptyEntries(t *testing.T) {
+	ids := skippedTaskIDs(map[string]struct{}{"a": {}, "": {}})
+	if len(ids) != 1 || ids[0] != "a" {
+		t.Fatalf("ids = %v, want just [a]", ids)
+	}
+	if got := skippedTaskIDs(nil); len(got) != 0 {
+		t.Fatalf("ids = %v, want empty", got)
+	}
+}


### PR DESCRIPTION
`internal/task/service` is the chokepoint for per-user workspace scoping and task lifecycle event publishing, but four of its surfaces had almost no coverage — `document_service.go` sat at 0% and `attachment_service.go` at 13%, so nothing guarded their authorization or cleanup behavior. This adds 9 test files that lift the package from 68.8% to 78.2% of statements, concentrating on the scoping sentinels and the publish-on-mutation rule rather than happy paths.

## Important Changes

- Denials assert the specific sentinel (`ErrTaskNotFound`, `ErrRepositoryNotFound`, `ErrAttachmentForbidden`, `ErrAccessDenied`) via `errors.Is`, not just a non-nil error — returning the wrong error type is itself an existence leak.
- Mutation paths assert the exact event set published (`message.deleted`, `task.state_changed`, `executor.updated`, …) and that refused writes publish nothing.
- All tests reuse the existing package fixtures (`createTestService`, `seedScopedWorkspaces`, `MockEventBus`) over the real SQLite repository; no new harness.

Per-file movement: `document_service.go` 0% → 98%, `attachment_service.go` 13% → 91%, `service_resources.go` 57% → 78%, `service_workflow.go` 67% → 76%, `service_turns.go` 72% → 82%, plus `service_messages.go`, `service_tasks.go` and `handoff_service.go`.

## Validation

- `CGO_ENABLED=1 go test -tags fts5 -race -count=1 -cover ./internal/task/service/...` → coverage 78.2% (from a 68.8% baseline on the same run). The failure set is byte-identical to the pre-change baseline: 8 `local_repository_initialization` / `CreateDirectory` tests fail with `parent directory cannot be accessed`, a pre-existing sandbox artifact in task worktrees that CI does not hit.
- `make -C apps/backend lint` → 0 issues; `golangci-lint run ./... --new-from-rev=origin/main` → 0 issues.
- Verified by mutation: five production defects were injected one at a time, each confirmed to fail the intended test by name, then reverted to green.
  1. Dropped `head.Filename` preservation in `buildDocHead` → `TestDocumentServiceUpdatePreservesAttachmentFields` fails (`attachment fields lost on update: … Filename:`).
  2. Returned a generic error instead of `ErrAttachmentForbidden` in `AttachmentService.Get` → 3 tests fail (`foreign Get = attachment lookup failed, want ErrAttachmentForbidden`).
  3. Removed the `message.deleted` publish in `DeleteMessage` → `TestDeleteMessagePublishesDeletedEvent` fails (`published [], want exactly one message.deleted`).
  4. Removed the `authorizeRepositoryID` call from `UpdateRepositoryScript` → `TestRepositoryScriptUpdateDeleteAreWorkspaceScoped` fails (`foreign update = <nil>, want ErrRepositoryNotFound`).
  5. Removed content stripping in `ListDocumentsForCaller` → `TestListDocumentsForCallerStripsContent` fails (`document "notes" leaked content "another secret"`).
- `git status` clean of production changes after every cycle; the diff touches only `*_test.go`.

## Possible Improvements

Negligible risk — test-only, no production code modified. The `Stage` oversize test streams 100 MiB + 1 through `io.Copy` to exercise the `LimitReader` cap, which costs about a second of disk I/O.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2588?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->