### PR TITLE
fix(lifecycle): resolve utility inference agents by name, not database UUID

### DIFF
--- a/apps/backend/internal/agent/runtime/lifecycle/utility.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/utility.go
@@ -83,13 +83,20 @@ func (m *Manager) ExecuteInferenceProfilePrompt(ctx context.Context, sessionID, 
 	if sessionID == "" {
 		return nil, fmt.Errorf("session_id is required")
 	}
-	ia, ok := m.registry.GetInferenceAgent(profile.AgentID)
+	// The registry is keyed by the agent name (claude-acp, codex-acp, ...),
+	// while AgentID is the agents row's generated UUID. AgentName is empty only
+	// for resolvers that never populated it, whose AgentID is already a name.
+	agentName := profile.AgentName
+	if agentName == "" {
+		agentName = profile.AgentID
+	}
+	ia, ok := m.registry.GetInferenceAgent(agentName)
 	if !ok {
-		return nil, fmt.Errorf("agent %q does not support inference", profile.AgentID)
+		return nil, fmt.Errorf("agent %q does not support inference", agentName)
 	}
 	cfg := ia.InferenceConfig()
 	if cfg == nil || !cfg.Supported {
-		return nil, fmt.Errorf("agent %q inference not supported", profile.AgentID)
+		return nil, fmt.Errorf("agent %q inference not supported", agentName)
 	}
 	execution, err := m.GetOrEnsureExecution(ctx, sessionID)
 	if err != nil {
@@ -121,7 +128,7 @@ func (m *Manager) ExecuteInferenceProfilePrompt(ctx context.Context, sessionID, 
 	}
 	autoApprove := profile.AutoApprove
 	return client.InferencePrompt(ctx, &utility.PromptRequest{
-		Prompt: prompt, AgentID: profile.AgentID, Model: profile.Model, Mode: profile.Mode,
+		Prompt: prompt, AgentID: agentName, Model: profile.Model, Mode: profile.Mode,
 		AutoApprovePermissions: &autoApprove,
 		InferenceConfig: &utility.InferenceConfigDTO{
 			Command: cfg.Command.Args(), ModelFlag: cfg.ModelFlag.Args(), WorkDir: execution.WorkspacePath,

--- a/apps/backend/internal/agent/runtime/lifecycle/utility_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/utility_test.go
@@ -361,6 +361,67 @@ func TestManagerExecuteInferenceProfilePrompt(t *testing.T) {
 	})
 }
 
+// The agents table's primary key is a generated UUID while the registry is
+// keyed by the agent slug, so AgentID and AgentName never carry the same value
+// in production. Every fixture above uses one string for both, which hid the
+// registry lookup reading AgentID.
+func TestManagerExecuteInferenceProfilePromptUsesTheRegistryAgentName(t *testing.T) {
+	const dbAgentUUID = "6a2b0f5c-6b9b-4f0e-8f3b-1f2c3d4e5f60"
+
+	harness := newInferenceHarness(t, &stubProfileResolver{profile: &AgentProfileInfo{
+		ProfileID: "profile-1",
+		AgentID:   dbAgentUUID,
+		AgentName: "inference-ok",
+		Model:     "claude-haiku-4-5",
+	}}, newInferenceAgent("inference-ok", true, true))
+
+	resp, err := harness.manager.ExecuteInferenceProfilePrompt(t.Context(), "session-1", "profile-1", "hello")
+	if err != nil {
+		t.Fatalf("ExecuteInferenceProfilePrompt: %v", err)
+	}
+	if resp.Response != "answer for hello" {
+		t.Fatalf("response = %+v", resp)
+	}
+	recorded := harness.recorded()
+	if len(recorded) != 1 {
+		t.Fatalf("agentctl calls = %d", len(recorded))
+	}
+	// agentctl keys its ACP compatibility and session handling off this field,
+	// so the database UUID must never reach the wire.
+	if recorded[0].AgentID != "inference-ok" {
+		t.Fatalf("outgoing AgentID = %q, want the registry agent name", recorded[0].AgentID)
+	}
+}
+
+func TestManagerExecuteInferenceProfilePromptFallsBackToAgentIDWithoutAName(t *testing.T) {
+	harness := newInferenceHarness(t, &stubProfileResolver{profile: &AgentProfileInfo{
+		ProfileID: "profile-1",
+		AgentID:   "inference-ok",
+	}}, newInferenceAgent("inference-ok", true, true))
+
+	if _, err := harness.manager.ExecuteInferenceProfilePrompt(t.Context(), "session-1", "profile-1", "hello"); err != nil {
+		t.Fatalf("ExecuteInferenceProfilePrompt: %v", err)
+	}
+	recorded := harness.recorded()
+	if len(recorded) != 1 || recorded[0].AgentID != "inference-ok" {
+		t.Fatalf("requests = %+v, want the AgentID fallback to reach agentctl", recorded)
+	}
+}
+
+func TestManagerExecuteInferenceProfilePromptReportsTheAgentNameOnLookupFailure(t *testing.T) {
+	harness := newInferenceHarness(t, &stubProfileResolver{profile: &AgentProfileInfo{
+		ProfileID: "profile-1",
+		AgentID:   "6a2b0f5c-6b9b-4f0e-8f3b-1f2c3d4e5f60",
+		AgentName: "not-registered",
+	}})
+
+	_, err := harness.manager.ExecuteInferenceProfilePrompt(t.Context(), "session-1", "profile-1", "hello")
+	// The UUID is meaningless to anyone reading the error; name the agent.
+	if err == nil || !strings.Contains(err.Error(), `agent "not-registered" does not support inference`) {
+		t.Fatalf("error = %v", err)
+	}
+}
+
 func TestManagerListInferenceAgentsOnlyReturnsInstalledOnes(t *testing.T) {
 	installed := newInferenceAgent("inference-installed", true, true)
 	missing := newInferenceAgent("inference-missing", true, false)


### PR DESCRIPTION
Every profile-backed utility prompt run from inside a task session failed in ~1ms with `agent "<uuid>" does not support inference`, because the session lifecycle looked up the agent registry with the `agents` row's generated UUID while that registry is keyed by the agent name. Utility prompts now resolve through the agent name, so PR title/description, commit message, branch name, enhance-prompt, session summary, and code review work again inside a session.

## Important Changes

- `ExecuteInferenceProfilePrompt` resolves the registry with `profile.AgentName` (falling back to `AgentID` for resolvers that leave the name empty), and sends that same name to agentctl. The database UUID reaching the wire also broke agentctl's ACP compatibility handling, which keys off `AgentID`.
- Two profile resolvers expose a field called `AgentID` with different meanings: `profilebinding.Resolver` normalizes it to the agent name, while `lifecycle.StoreProfileResolver` returns the UUID and puts the name in `AgentName`. The lifecycle path assumed the first. Upstream validation used the second, which is why the failure only appeared at dispatch.

## Validation

- `go test ./internal/agent/runtime/lifecycle/... ./internal/utility/... ./internal/agent/hostutility/... ./internal/agent/registry/... -count=1` — pass.
- `golangci-lint run ./internal/agent/runtime/lifecycle/... --new-from-rev=bd24f7f07` — 0 issues.
- Both new assertions were mutation-checked: reverting only the registry lookup, and separately reverting only the outgoing `AgentID`, each fail the regression test.

The existing fixtures used one string for both `AgentID` and the registry key and never set `AgentName`, so they could not observe the mismatch. The new test uses a realistic UUID/slug pair.

## Possible Improvements

Low risk; the change is confined to one function. `skill/manifest.go` carries a comment asserting `Profile.AgentID` is the agent type ID and passes it to `resolveProjectSkillDir` — that is the same raw UUID column, and a mismatch there would silently fall back to the default skill directory. Not traced far enough to confirm it fires in practice, so it is left for a separate look rather than widened into this fix.

Closes #2593

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2594?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->