### PR TITLE
chore(plugins): list the Voice plugin in the marketplace registry

### DIFF
--- a/plugin-registry/plugins.yaml
+++ b/plugin-registry/plugins.yaml
@@ -44,6 +44,9 @@ plugins:
   - id: kandev-plugin-notes
     repo: yattdev/kandev-plugin-notes
     categories: [tools]
+  - id: kandev-plugin-voice
+    repo: kdlbs/kandev-plugin-voice
+    categories: [tools]
 # Example entry (copy, uncomment, and fill in when adding a plugin):
 #
 # plugins:


### PR DESCRIPTION
Lists `kdlbs/kandev-plugin-voice` in the curated marketplace registry, so Voice Mode is installable from **Settings > Plugins > Browse** now that it no longer ships in core (#2576).

## Validation

- `parsePluginsYaml` on the edited file parses 8 entries and reads the new one as `{id: kandev-plugin-voice, repo: kdlbs/kandev-plugin-voice, categories: [tools]}`.
- `categories: [tools]` reuses an existing tag on purpose: the marketplace derives its filter chips from the entries themselves (`useCatalogCategories`), so a novel tag would add a chip that matches one plugin.

**This entry is inert until the plugin repo publishes a release.** `buildEntry` resolves each pointer to `/releases/latest`, and `kdlbs/kandev-plugin-voice` has no release or tag yet. Verified against the live API:

```
skip: kandev-plugin-voice: no latest release (GET .../releases/latest -> 404)
built: [ 'kandev-session-cost' ]
```

The build only fails when *zero* entries resolve, so a missing release is a silent skip: this PR's own CI will pass and the catalog simply will not list Voice. Cut `v0.1.0` in the plugin repo before or shortly after merging, and the next index build (push to `main`, or the daily 06:00 rebuild) picks it up with no further change here.

## Possible Improvements

Low risk, and it is data rather than code. The one sharp edge is the silent-skip behavior above, which makes a mistyped `repo` or a missing release look identical to success in CI.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2595?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->