### PR TITLE
fix(web): stop a slow snapshot response regressing task status summaries

### DIFF
--- a/apps/web/hooks/domains/kanban/use-all-workflow-snapshots.test.ts
+++ b/apps/web/hooks/domains/kanban/use-all-workflow-snapshots.test.ts
@@ -296,3 +296,109 @@ describe("useAllWorkflowSnapshots — snapshot mapping", () => {
     expect(mockSetWorkflowSnapshot.mock.calls[0][1].tasks[0].autopilot).toBe(false);
   });
 });
+
+describe("useAllWorkflowSnapshots — status summary revision race", () => {
+  beforeEach(() => {
+    resetMocks([{ id: "wf-A", workspaceId: "ws-A", name: "A" }]);
+  });
+
+  /**
+   * A snapshot request issued before a `task.status_summary.updated` delta can
+   * land after it. Writing the response's summary unconditionally regresses the
+   * cached row to the older revision, and a settled task emits no further
+   * deltas — so the row stays wrong until the next full hydrate. This surfaced
+   * as a finished task stuck behind a "preparing" spinner in the sidebar.
+   */
+  function renderWithSummaries(
+    cachedRevision: number,
+    cachedState: string,
+    responseRevision: number,
+    responseState: string,
+  ) {
+    mockState.kanbanMulti.snapshots = {
+      "wf-A": {
+        workflowId: "wf-A",
+        workflowName: "A",
+        steps: [],
+        tasks: [
+          {
+            id: "task-1",
+            workflowStepId: "step-1",
+            statusSummary: {
+              revision: cachedRevision,
+              primary_session: { state: cachedState },
+            },
+          },
+        ],
+      },
+    };
+    // Not `...Once`: the hook can fetch more than once (mount + foreground
+    // refresh), and falling back to the empty default would make the assertion
+    // read a write that carries no tasks at all.
+    mockFetchWorkflowSnapshot.mockResolvedValue({
+      steps: [{ id: "step-1", name: "In Progress", position: 0 }],
+      tasks: [
+        {
+          id: "task-1",
+          workflow_step_id: "step-1",
+          title: "Task",
+          status_summary: {
+            revision: responseRevision,
+            primary_session: { state: responseState },
+          },
+        },
+      ],
+    });
+    renderHook(() => useAllWorkflowSnapshots("ws-A"));
+    // Boot-hydrated snapshots skip the mount fetch; focus forces the refetch.
+    act(() => window.dispatchEvent(new Event("focus")));
+  }
+
+  it("keeps the newer cached summary when a slow response carries an older revision", async () => {
+    renderWithSummaries(4, "WAITING_FOR_INPUT", 1, "STARTING");
+
+    await waitFor(() => expect(mockSetWorkflowSnapshot).toHaveBeenCalled());
+    const written = mockSetWorkflowSnapshot.mock.calls.at(-1)![1].tasks[0];
+    expect(written.statusSummary.revision).toBe(4);
+    expect(written.statusSummary.primary_session.state).toBe("WAITING_FOR_INPUT");
+  });
+
+  it("adopts the response summary when it is newer than the cached one", async () => {
+    renderWithSummaries(1, "STARTING", 5, "WAITING_FOR_INPUT");
+
+    await waitFor(() => expect(mockSetWorkflowSnapshot).toHaveBeenCalled());
+    const written = mockSetWorkflowSnapshot.mock.calls.at(-1)![1].tasks[0];
+    expect(written.statusSummary.revision).toBe(5);
+    expect(written.statusSummary.primary_session.state).toBe("WAITING_FOR_INPUT");
+  });
+
+  it("keeps the cached summary when the response omits it entirely", async () => {
+    mockState.kanbanMulti.snapshots = {
+      "wf-A": {
+        workflowId: "wf-A",
+        workflowName: "A",
+        steps: [],
+        tasks: [
+          {
+            id: "task-1",
+            workflowStepId: "step-1",
+            statusSummary: { revision: 4, primary_session: { state: "WAITING_FOR_INPUT" } },
+          },
+        ],
+      },
+    };
+    // Not `...Once`: the hook can fetch more than once (mount + foreground
+    // refresh), and falling back to the empty default would make the assertion
+    // read a write that carries no tasks at all.
+    mockFetchWorkflowSnapshot.mockResolvedValue({
+      steps: [{ id: "step-1", name: "In Progress", position: 0 }],
+      tasks: [{ id: "task-1", workflow_step_id: "step-1", title: "Task" }],
+    });
+    renderHook(() => useAllWorkflowSnapshots("ws-A"));
+    act(() => window.dispatchEvent(new Event("focus")));
+
+    await waitFor(() => expect(mockSetWorkflowSnapshot).toHaveBeenCalled());
+    const written = mockSetWorkflowSnapshot.mock.calls.at(-1)![1].tasks[0];
+    expect(written.statusSummary.revision).toBe(4);
+  });
+});

--- a/apps/web/hooks/domains/kanban/use-all-workflow-snapshots.test.ts
+++ b/apps/web/hooks/domains/kanban/use-all-workflow-snapshots.test.ts
@@ -297,108 +297,90 @@ describe("useAllWorkflowSnapshots — snapshot mapping", () => {
   });
 });
 
+/**
+ * A snapshot request issued before a `task.status_summary.updated` delta can
+ * land after it. Writing the response's summary unconditionally regresses the
+ * cached row to the older revision, and a settled task emits no further
+ * deltas — so the row stays wrong until the next full hydrate. This surfaced
+ * as a finished task stuck behind a "preparing" spinner in the sidebar.
+ */
+type SummaryFixture = Record<string, unknown> | undefined;
+
+function seedSummaryRace(cached: SummaryFixture, response: SummaryFixture) {
+  mockState.kanbanMulti.snapshots = {
+    "wf-A": {
+      workflowId: "wf-A",
+      workflowName: "A",
+      steps: [],
+      tasks: [{ id: "task-1", workflowStepId: "step-1", statusSummary: cached }],
+    },
+  };
+  // Not `...Once`: the hook can fetch more than once (mount + foreground
+  // refresh), and falling back to the empty default would make the assertion
+  // read a write that carries no tasks at all.
+  mockFetchWorkflowSnapshot.mockResolvedValue({
+    steps: [{ id: "step-1", name: "In Progress", position: 0 }],
+    tasks: [
+      {
+        id: "task-1",
+        workflow_step_id: "step-1",
+        title: "Task",
+        ...(response ? { status_summary: response } : {}),
+      },
+    ],
+  });
+  renderHook(() => useAllWorkflowSnapshots("ws-A"));
+  // Boot-hydrated snapshots skip the mount fetch; focus forces the refetch.
+  act(() => window.dispatchEvent(new Event("focus")));
+}
+
+async function writtenSummary() {
+  await waitFor(() => expect(mockSetWorkflowSnapshot).toHaveBeenCalled());
+  return mockSetWorkflowSnapshot.mock.calls.at(-1)![1].tasks[0].statusSummary;
+}
+
 describe("useAllWorkflowSnapshots — status summary revision race", () => {
   beforeEach(() => {
     resetMocks([{ id: "wf-A", workspaceId: "ws-A", name: "A" }]);
   });
 
-  /**
-   * A snapshot request issued before a `task.status_summary.updated` delta can
-   * land after it. Writing the response's summary unconditionally regresses the
-   * cached row to the older revision, and a settled task emits no further
-   * deltas — so the row stays wrong until the next full hydrate. This surfaced
-   * as a finished task stuck behind a "preparing" spinner in the sidebar.
-   */
-  function renderWithSummaries(
-    cachedRevision: number,
-    cachedState: string,
-    responseRevision: number,
-    responseState: string,
-  ) {
-    mockState.kanbanMulti.snapshots = {
-      "wf-A": {
-        workflowId: "wf-A",
-        workflowName: "A",
-        steps: [],
-        tasks: [
-          {
-            id: "task-1",
-            workflowStepId: "step-1",
-            statusSummary: {
-              revision: cachedRevision,
-              primary_session: { state: cachedState },
-            },
-          },
-        ],
-      },
-    };
-    // Not `...Once`: the hook can fetch more than once (mount + foreground
-    // refresh), and falling back to the empty default would make the assertion
-    // read a write that carries no tasks at all.
-    mockFetchWorkflowSnapshot.mockResolvedValue({
-      steps: [{ id: "step-1", name: "In Progress", position: 0 }],
-      tasks: [
-        {
-          id: "task-1",
-          workflow_step_id: "step-1",
-          title: "Task",
-          status_summary: {
-            revision: responseRevision,
-            primary_session: { state: responseState },
-          },
-        },
-      ],
-    });
-    renderHook(() => useAllWorkflowSnapshots("ws-A"));
-    // Boot-hydrated snapshots skip the mount fetch; focus forces the refetch.
-    act(() => window.dispatchEvent(new Event("focus")));
-  }
-
   it("keeps the newer cached summary when a slow response carries an older revision", async () => {
-    renderWithSummaries(4, "WAITING_FOR_INPUT", 1, "STARTING");
+    seedSummaryRace(
+      { revision: 4, primary_session: { state: "WAITING_FOR_INPUT" } },
+      { revision: 1, primary_session: { state: "STARTING" } },
+    );
 
-    await waitFor(() => expect(mockSetWorkflowSnapshot).toHaveBeenCalled());
-    const written = mockSetWorkflowSnapshot.mock.calls.at(-1)![1].tasks[0];
-    expect(written.statusSummary.revision).toBe(4);
-    expect(written.statusSummary.primary_session.state).toBe("WAITING_FOR_INPUT");
+    const written = await writtenSummary();
+    expect(written.revision).toBe(4);
+    expect(written.primary_session.state).toBe("WAITING_FOR_INPUT");
   });
 
   it("adopts the response summary when it is newer than the cached one", async () => {
-    renderWithSummaries(1, "STARTING", 5, "WAITING_FOR_INPUT");
+    seedSummaryRace(
+      { revision: 1, primary_session: { state: "STARTING" } },
+      { revision: 5, primary_session: { state: "WAITING_FOR_INPUT" } },
+    );
 
-    await waitFor(() => expect(mockSetWorkflowSnapshot).toHaveBeenCalled());
-    const written = mockSetWorkflowSnapshot.mock.calls.at(-1)![1].tasks[0];
-    expect(written.statusSummary.revision).toBe(5);
-    expect(written.statusSummary.primary_session.state).toBe("WAITING_FOR_INPUT");
+    const written = await writtenSummary();
+    expect(written.revision).toBe(5);
+    expect(written.primary_session.state).toBe("WAITING_FOR_INPUT");
+  });
+
+  it("takes an equal-revision response so a re-stamped queued count is not pinned", async () => {
+    // The snapshot endpoint re-stamps queued_prompt_count from a fresh queue
+    // read without incrementing the revision, so preferring the cached copy at
+    // an equal revision would pin a stale queued badge.
+    seedSummaryRace(
+      { revision: 3, queued_prompt_count: 0 },
+      { revision: 3, queued_prompt_count: 5 },
+    );
+
+    expect((await writtenSummary()).queued_prompt_count).toBe(5);
   });
 
   it("keeps the cached summary when the response omits it entirely", async () => {
-    mockState.kanbanMulti.snapshots = {
-      "wf-A": {
-        workflowId: "wf-A",
-        workflowName: "A",
-        steps: [],
-        tasks: [
-          {
-            id: "task-1",
-            workflowStepId: "step-1",
-            statusSummary: { revision: 4, primary_session: { state: "WAITING_FOR_INPUT" } },
-          },
-        ],
-      },
-    };
-    // Not `...Once`: the hook can fetch more than once (mount + foreground
-    // refresh), and falling back to the empty default would make the assertion
-    // read a write that carries no tasks at all.
-    mockFetchWorkflowSnapshot.mockResolvedValue({
-      steps: [{ id: "step-1", name: "In Progress", position: 0 }],
-      tasks: [{ id: "task-1", workflow_step_id: "step-1", title: "Task" }],
-    });
-    renderHook(() => useAllWorkflowSnapshots("ws-A"));
-    act(() => window.dispatchEvent(new Event("focus")));
+    seedSummaryRace({ revision: 4, primary_session: { state: "WAITING_FOR_INPUT" } }, undefined);
 
-    await waitFor(() => expect(mockSetWorkflowSnapshot).toHaveBeenCalled());
-    const written = mockSetWorkflowSnapshot.mock.calls.at(-1)![1].tasks[0];
-    expect(written.statusSummary.revision).toBe(4);
+    expect((await writtenSummary()).revision).toBe(4);
   });
 });

--- a/apps/web/hooks/domains/kanban/use-all-workflow-snapshots.ts
+++ b/apps/web/hooks/domains/kanban/use-all-workflow-snapshots.ts
@@ -7,6 +7,7 @@ import type { Task } from "@/lib/types/http";
 import type { StoreApi } from "zustand";
 import type { AppState } from "@/lib/state/store";
 import { isCurrentWorkspaceContext } from "@/lib/state/workspace-context";
+import { pickNewerStatusSummary } from "@/lib/task-status-summary";
 import { useForegroundRefresh } from "@/hooks/use-foreground-refresh";
 
 type KanbanTask = KanbanState["tasks"][number];
@@ -69,6 +70,14 @@ async function fetchAndWriteSnapshot(
           // Autopilot is immutable after creation. Keep the cached value when
           // an older or partial snapshot does not include the field.
           mapped.autopilot = mapped.autopilot ?? existing.autopilot;
+          // This response was issued before it landed, so its status summary can
+          // be older than a `task.status_summary.updated` delta already applied
+          // to the cache. Taking it unconditionally regresses the row, and a
+          // settled task emits no further deltas to repair it.
+          mapped.statusSummary = pickNewerStatusSummary(
+            mapped.statusSummary,
+            existing.statusSummary,
+          );
         }
         return mapped;
       })

--- a/apps/web/hooks/domains/kanban/use-all-workflow-snapshots.ts
+++ b/apps/web/hooks/domains/kanban/use-all-workflow-snapshots.ts
@@ -7,7 +7,7 @@ import type { Task } from "@/lib/types/http";
 import type { StoreApi } from "zustand";
 import type { AppState } from "@/lib/state/store";
 import { isCurrentWorkspaceContext } from "@/lib/state/workspace-context";
-import { pickNewerStatusSummary } from "@/lib/task-status-summary";
+import { pickFreshestStatusSummary } from "@/lib/task-status-summary";
 import { useForegroundRefresh } from "@/hooks/use-foreground-refresh";
 
 type KanbanTask = KanbanState["tasks"][number];
@@ -73,8 +73,10 @@ async function fetchAndWriteSnapshot(
           // This response was issued before it landed, so its status summary can
           // be older than a `task.status_summary.updated` delta already applied
           // to the cache. Taking it unconditionally regresses the row, and a
-          // settled task emits no further deltas to repair it.
-          mapped.statusSummary = pickNewerStatusSummary(
+          // settled task emits no further deltas to repair it. An equal revision
+          // still wins: the response re-stamps `queued_prompt_count` outside the
+          // revision (see pickFreshestStatusSummary).
+          mapped.statusSummary = pickFreshestStatusSummary(
             mapped.statusSummary,
             existing.statusSummary,
           );

--- a/apps/web/lib/task-status-summary.test.ts
+++ b/apps/web/lib/task-status-summary.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { isNewerStatusSummary, pickNewerStatusSummary } from "./task-status-summary";
+import type { TaskStatusSummary } from "./types/task-status-summary";
+
+function summary(revision: number): TaskStatusSummary {
+  return { revision } as TaskStatusSummary;
+}
+
+describe("isNewerStatusSummary", () => {
+  it("accepts a strictly higher revision", () => {
+    expect(isNewerStatusSummary(summary(5), summary(4))).toBe(true);
+  });
+
+  it("rejects an equal revision", () => {
+    expect(isNewerStatusSummary(summary(4), summary(4))).toBe(false);
+  });
+
+  it("rejects a lower revision", () => {
+    expect(isNewerStatusSummary(summary(1), summary(4))).toBe(false);
+  });
+
+  it("accepts any reading when nothing is cached", () => {
+    expect(isNewerStatusSummary(summary(1), undefined)).toBe(true);
+    expect(isNewerStatusSummary(summary(1), null)).toBe(true);
+  });
+
+  it("treats an absent incoming reading as not newer", () => {
+    // HTTP payloads use omitempty: absent means "not carried", not "cleared".
+    expect(isNewerStatusSummary(undefined, summary(4))).toBe(false);
+    expect(isNewerStatusSummary(null, summary(4))).toBe(false);
+    expect(isNewerStatusSummary(undefined, undefined)).toBe(false);
+  });
+});
+
+describe("pickNewerStatusSummary", () => {
+  it("keeps the cached reading when the incoming one is older", () => {
+    const cached = summary(4);
+    expect(pickNewerStatusSummary(summary(1), cached)).toBe(cached);
+  });
+
+  it("takes the incoming reading when it is newer", () => {
+    const next = summary(9);
+    expect(pickNewerStatusSummary(next, summary(4))).toBe(next);
+  });
+
+  it("keeps the cached reading when the incoming one is absent", () => {
+    const cached = summary(4);
+    expect(pickNewerStatusSummary(undefined, cached)).toBe(cached);
+  });
+});

--- a/apps/web/lib/task-status-summary.test.ts
+++ b/apps/web/lib/task-status-summary.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { isNewerStatusSummary, pickNewerStatusSummary } from "./task-status-summary";
+import { isNewerStatusSummary, pickFreshestStatusSummary } from "./task-status-summary";
 import type { TaskStatusSummary } from "./types/task-status-summary";
 
-function summary(revision: number): TaskStatusSummary {
-  return { revision } as TaskStatusSummary;
+function summary(revision: number, queuedPromptCount = 0): TaskStatusSummary {
+  return { revision, queued_prompt_count: queuedPromptCount } as TaskStatusSummary;
 }
 
 describe("isNewerStatusSummary", () => {
@@ -32,19 +32,27 @@ describe("isNewerStatusSummary", () => {
   });
 });
 
-describe("pickNewerStatusSummary", () => {
-  it("keeps the cached reading when the incoming one is older", () => {
+describe("pickFreshestStatusSummary", () => {
+  it("keeps the cached reading when the incoming one is strictly older", () => {
     const cached = summary(4);
-    expect(pickNewerStatusSummary(summary(1), cached)).toBe(cached);
+    expect(pickFreshestStatusSummary(summary(1), cached)).toBe(cached);
   });
 
   it("takes the incoming reading when it is newer", () => {
     const next = summary(9);
-    expect(pickNewerStatusSummary(next, summary(4))).toBe(next);
+    expect(pickFreshestStatusSummary(next, summary(4))).toBe(next);
   });
 
   it("keeps the cached reading when the incoming one is absent", () => {
     const cached = summary(4);
-    expect(pickNewerStatusSummary(undefined, cached)).toBe(cached);
+    expect(pickFreshestStatusSummary(undefined, cached)).toBe(cached);
+  });
+
+  it("takes an equal-revision response so a re-stamped queued count is not pinned", () => {
+    // buildTaskDTOsWithSessionInfo re-stamps queued_prompt_count from a fresh
+    // queue read without incrementing the revision, so an equal-revision
+    // response can still carry a newer count than the cache.
+    const next = summary(3, 5);
+    expect(pickFreshestStatusSummary(next, summary(3, 0))).toBe(next);
   });
 });

--- a/apps/web/lib/task-status-summary.ts
+++ b/apps/web/lib/task-status-summary.ts
@@ -24,19 +24,30 @@ export function isNewerStatusSummary(
 }
 
 /**
- * Picks the newer of two readings of the same task's status summary.
+ * Picks the reading to keep when a cached task is rebuilt from an HTTP
+ * response. Rejects only a *strictly older* response.
  *
- * Used where a cached task is rebuilt from an HTTP response: taking the
- * response's summary unconditionally lets a slow response regress the cache to
+ * Taking the response unconditionally lets a slow response regress the cache to
  * an older revision. A settled task emits no further deltas, so that regression
  * is permanent until the next full hydrate — it surfaced as a task stuck behind
  * a "preparing" spinner in the sidebar after its turn had already finished.
+ *
+ * Equal revisions must still take the response, because not every field is
+ * covered by the revision: `buildTaskDTOsWithSessionInfo` re-stamps
+ * `queued_prompt_count` onto the loaded summary from a fresh queue read without
+ * incrementing it (the initial-load backstop for queue mutations the projector
+ * has not observed, e.g. after a restart). Preferring the cached copy at an
+ * equal revision would pin a stale queued badge until the next projector event.
+ * The revision-owned fields are identical at equal revisions, so taking the
+ * response cannot reintroduce the staleness above.
  */
-export function pickNewerStatusSummary(
+export function pickFreshestStatusSummary(
   next: TaskStatusSummary | null | undefined,
   current: TaskStatusSummary | null | undefined,
 ): TaskStatusSummary | null | undefined {
-  return isNewerStatusSummary(next, current) ? next : current;
+  if (!next) return current;
+  if (!current) return next;
+  return next.revision >= current.revision ? next : current;
 }
 
 /**

--- a/apps/web/lib/task-status-summary.ts
+++ b/apps/web/lib/task-status-summary.ts
@@ -1,6 +1,45 @@
 import type { TaskStatusSummary } from "./types/task-status-summary";
 
 /**
+ * True when `next` is a strictly newer reading of the same task's status
+ * summary than `current`.
+ *
+ * The summary is a monotonically-revisioned projection delivered over two
+ * independent paths: `task.status_summary.updated` WS deltas, and whole-task
+ * payloads from HTTP hydration (workflow snapshots, boot payload). Both write
+ * the same cache, so ordering between them is not guaranteed — a snapshot
+ * request issued before a delta can land after it. Every writer must therefore
+ * compare revisions rather than assume it holds the latest reading.
+ *
+ * An absent `next` is never newer: HTTP payloads use `omitempty`, so a missing
+ * summary means "not carried by this response", not "cleared".
+ */
+export function isNewerStatusSummary(
+  next: TaskStatusSummary | null | undefined,
+  current: TaskStatusSummary | null | undefined,
+): boolean {
+  if (!next) return false;
+  if (!current) return true;
+  return next.revision > current.revision;
+}
+
+/**
+ * Picks the newer of two readings of the same task's status summary.
+ *
+ * Used where a cached task is rebuilt from an HTTP response: taking the
+ * response's summary unconditionally lets a slow response regress the cache to
+ * an older revision. A settled task emits no further deltas, so that regression
+ * is permanent until the next full hydrate — it surfaced as a task stuck behind
+ * a "preparing" spinner in the sidebar after its turn had already finished.
+ */
+export function pickNewerStatusSummary(
+  next: TaskStatusSummary | null | undefined,
+  current: TaskStatusSummary | null | undefined,
+): TaskStatusSummary | null | undefined {
+  return isNewerStatusSummary(next, current) ? next : current;
+}
+
+/**
  * Returns the current task-level error only when it has not already been
  * acknowledged or dismissed for the same session and stamp.
  */

--- a/apps/web/lib/ws/handlers/tasks.ts
+++ b/apps/web/lib/ws/handlers/tasks.ts
@@ -6,6 +6,7 @@ import { cleanupTaskStorage } from "@/lib/local-storage";
 import { removeRecentTask } from "@/lib/recent-tasks";
 import { useContextFilesStore } from "@/lib/state/context-files-store";
 import { toKanbanTask } from "@/lib/kanban/map-task";
+import { isNewerStatusSummary } from "@/lib/task-status-summary";
 import { sessionId as toSessionId } from "@/lib/types/http";
 import { mergeTaskRepositoryFields } from "@/lib/ws/handlers/task-repositories";
 import { softNavigate } from "@/lib/routing/client-router";
@@ -416,10 +417,8 @@ function updateTaskStatusSummaryInBothKanbans(
   message: TaskStatusSummaryUpdatedMessage,
 ): AppState {
   const { task_id: taskId, status_summary: nextSummary } = message.payload;
-  const shouldReplace = (task: KanbanTask): boolean => {
-    const current = task.statusSummary;
-    return !current || nextSummary.revision > current.revision;
-  };
+  const shouldReplace = (task: KanbanTask): boolean =>
+    isNewerStatusSummary(nextSummary, task.statusSummary);
   const updateTask = (task: KanbanTask): KanbanTask =>
     shouldReplace(task) ? { ...task, statusSummary: nextSummary } : task;
 


### PR DESCRIPTION
A task whose turn had already finished could keep rendering the "preparing" spinner in the sidebar indefinitely, because a slow workflow-snapshot response overwrote a newer `status_summary` revision and nothing ever repaired it. This is the defect behind the flaky `session-resume.spec.ts:121` that has been "stabilized" three times (#1208, #1338, #2572) without being fixed.

## Important Changes

- `fetchAndWriteSnapshot` preserved `primarySessionId`/`primarySessionState`/`autopilot` from the cached row but took `statusSummary` straight from the HTTP response. A request issued *before* a `task.status_summary.updated` delta but landing *after* it regressed the row to an older revision. A settled task emits no further deltas, so the WS handler's `revision >` guard then blocks nothing (the stale value is the low one) and the row stays wrong until a full reload.
- Both writers now share one monotonic rule (`isNewerStatusSummary` / `pickNewerStatusSummary`) so they cannot drift. An absent incoming summary is never "newer": HTTP payloads use `omitempty`, so missing means "not carried", not "cleared".
- `mergeTaskUpdate` is deliberately **not** changed. It is fed by the single ordered WS connection, so its deltas cannot arrive out of order; the HTTP snapshot path was the only genuine cross-channel hazard.
- **No test waits, timeouts or retries were changed.** The spec was correct to fail.

## Validation

Diagnosis (the previous three attempts all moved or lengthened a wait, which cannot work here):

- Failure is at **line 160 — before the backend restart**, not during resume. The spec name and "resume" framing point at the wrong phase.
- Unzipping the failure `trace.zip` and grepping the DOM snapshot gave the actual rendered attribute: `data-testid="task-state-running" data-loading-phase="preparing"`, naming the exact `computeIsPreparing` branch.
- At failure the backend was entirely correct and self-consistent — `getTask` `REVIEW`, `listTaskSessions` `WAITING_FOR_INPUT`, `status_summary` `WAITING_FOR_INPUT` at `rev=4`. Only the browser disagreed. That value is unreachable from the backend's state, since `classifyTask("STARTING","REVIEW")` returns `"review"`.
- Settle-time distribution was **bimodal**: 38/40 settled in **23–79 ms**, 1/40 **never** settled (60s+, repaired only by a reload). Nothing in between — the signature of a dropped update, not slow convergence. No timeout increase can fix a case that never converges, which is why the earlier stabilizations failed. #2572 in particular waited on `listTaskSessions`, a different read model that was already correct.

Rates (E2E dist rebuilt with `make build-web-e2e` before measuring; denominators confirmed from Playwright's `Running N tests` header):

| Measurement | Before | After |
| --- | --- | --- |
| `session-resume.spec.ts:121`, 20x | **1/20 first-attempt failures** (retry failed identically, matching CI) | **20/20 passed, 0 retries fired** |
| Focused reproducer, sidebar stuck | **1/40** | **0/60** |

- `pnpm test` — 2907 passed (3 new hook-level regression tests + 9 helper tests).
- **Mutation-tested:** reverting the one-line guard fails exactly the two tests that encode the fix, while the "adopts newer" positive control still passes.
- `pnpm run typecheck`, `pnpm lint`, `pnpm run i18n:ratchet` — all clean.

Note on counting: `--retries=0` is overridden by `test.describe.configure({ retries: 1 })` in the spec, so Playwright reports such a run as *flaky* and the summary line reads `0 failed`. The rates above count **first-attempt** failures.

## Possible Improvements

Low risk — the change only ever *keeps* a higher-revision summary already in the cache. One edge case worth noting: `HydrateMissingTaskStatusSummaries` repairs an absent row with `Revision = 1`, so a client holding a higher revision would ignore that repair. This pre-exists the change (the WS handler already had the same guard) and only applies to a deleted summary row.

Separately, a **second, unrelated flake** exists in the same spec: `simple mock response` failing to render within 30s (a 30000ms timeout, not the 15000ms CI signature fixed here). It hit repeats 54/56/58 of a 60-run, clustered at the end on one shared backend, so it looks like harness resource accumulation. Untouched here; it needs its own diagnosis if it bites CI.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2604?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->