### PR TITLE
test: fix flaky HTTP Git fixture listener assertion

### DIFF
--- a/apps/web/e2e/helpers/http-git-server.ts
+++ b/apps/web/e2e/helpers/http-git-server.ts
@@ -20,7 +20,6 @@ type HTTPGitFixture = {
 };
 
 export type HTTPGitFixtureOptions = {
-  onListening?: (port: number) => void;
   writeBackendGitConfig?: (file: string, content: string) => void;
   closeServer?: (server: Server) => Promise<void>;
 };
@@ -54,7 +53,6 @@ export async function startHTTPGitFixture(
   const server = createStaticGitServer(root);
   const port = await listen(server);
   try {
-    options.onListening?.(port);
     const fixtureOrigin = `http://${dockerBridgeGateway()}:${port}/`;
     const remoteURL = `https://gitlab.com/fixture/${name}.git`;
     execFileSync("git", ["remote", "set-url", "origin", remoteURL], { cwd: checkout });

--- a/apps/web/e2e/helpers/http-git-server.ts
+++ b/apps/web/e2e/helpers/http-git-server.ts
@@ -20,7 +20,7 @@ type HTTPGitFixture = {
 };
 
 export type HTTPGitFixtureOptions = {
-  onListening?: (port: number) => void;
+  onListening?: (server: Server, port: number) => void;
   writeBackendGitConfig?: (file: string, content: string) => void;
   closeServer?: (server: Server) => Promise<void>;
 };
@@ -54,7 +54,7 @@ export async function startHTTPGitFixture(
   const server = createStaticGitServer(root);
   const port = await listen(server);
   try {
-    options.onListening?.(port);
+    options.onListening?.(server, port);
     const fixtureOrigin = `http://${dockerBridgeGateway()}:${port}/`;
     const remoteURL = `https://gitlab.com/fixture/${name}.git`;
     execFileSync("git", ["remote", "set-url", "origin", remoteURL], { cwd: checkout });

--- a/apps/web/e2e/helpers/http-git-server.ts
+++ b/apps/web/e2e/helpers/http-git-server.ts
@@ -20,6 +20,7 @@ type HTTPGitFixture = {
 };
 
 export type HTTPGitFixtureOptions = {
+  onListening?: (port: number) => void;
   writeBackendGitConfig?: (file: string, content: string) => void;
   closeServer?: (server: Server) => Promise<void>;
 };
@@ -53,6 +54,7 @@ export async function startHTTPGitFixture(
   const server = createStaticGitServer(root);
   const port = await listen(server);
   try {
+    options.onListening?.(port);
     const fixtureOrigin = `http://${dockerBridgeGateway()}:${port}/`;
     const remoteURL = `https://gitlab.com/fixture/${name}.git`;
     execFileSync("git", ["remote", "set-url", "origin", remoteURL], { cwd: checkout });

--- a/apps/web/lib/http-git-server.test.ts
+++ b/apps/web/lib/http-git-server.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { expect, test } from "vitest";
 import { startHTTPGitFixture } from "../e2e/helpers/http-git-server";
 import { execFileSync } from "node:child_process";

--- a/apps/web/lib/http-git-server.test.ts
+++ b/apps/web/lib/http-git-server.test.ts
@@ -54,18 +54,17 @@ test("closes its listener when backend config setup fails after listening", asyn
   try {
     await expect(
       startHTTPGitFixture(root, "config-write-failure", {
+        onListening: (listeningServer) => {
+          server = listeningServer;
+        },
         writeBackendGitConfig: () => {
           throw new Error("config write failed");
-        },
-        closeServer: async (closingServer) => {
-          server = closingServer;
-          await closeTestServer(closingServer);
         },
       }),
     ).rejects.toThrow("config write failed");
 
     expect(server).toBeDefined();
-    expect(server!.listening).toBe(false);
+    expect(server?.listening).toBe(false);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }

--- a/apps/web/lib/http-git-server.test.ts
+++ b/apps/web/lib/http-git-server.test.ts
@@ -3,7 +3,6 @@ import { startHTTPGitFixture } from "../e2e/helpers/http-git-server";
 import { execFileSync } from "node:child_process";
 import { type Server } from "node:http";
 import fs from "node:fs";
-import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 
@@ -50,21 +49,22 @@ test("uses a trusted GitLab URL with isolated executor and backend Git rewrites"
 
 test("closes its listener when backend config setup fails after listening", async () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "kandev-http-git-test-"));
-  let port: number | undefined;
+  let server: Server | undefined;
   try {
     await expect(
       startHTTPGitFixture(root, "config-write-failure", {
-        onListening: (listeningPort) => {
-          port = listeningPort;
-        },
         writeBackendGitConfig: () => {
           throw new Error("config write failed");
+        },
+        closeServer: async (closingServer) => {
+          server = closingServer;
+          await closeTestServer(closingServer);
         },
       }),
     ).rejects.toThrow("config write failed");
 
-    expect(port).toBeDefined();
-    expect(await canConnect(port!)).toBe(false);
+    expect(server).toBeDefined();
+    expect(server!.listening).toBe(false);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }
@@ -93,17 +93,6 @@ test("aggregates setup and listener-close failures", async () => {
     fs.rmSync(root, { recursive: true, force: true });
   }
 });
-
-function canConnect(port: number): Promise<boolean> {
-  return new Promise((resolve) => {
-    const socket = net.connect(port, "127.0.0.1");
-    socket.once("connect", () => {
-      socket.destroy();
-      resolve(true);
-    });
-    socket.once("error", () => resolve(false));
-  });
-}
 
 function closeTestServer(server: Server): Promise<void> {
   return new Promise((resolve, reject) =>


### PR DESCRIPTION
The flaky HTTP Git fixture regression test now asserts the listener server state directly, so parallel Vitest workers can no longer fail by reusing the same ephemeral port after teardown.

## Validation

- `cd apps/web && corepack pnpm exec vitest run lib/http-git-server.test.ts`
- `cd apps/web && env -u NODE_ENV corepack pnpm test`
- `cd apps/web && env -u NODE_ENV corepack pnpm test`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2612?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->