### PR TITLE
feat: show gitlab mr badge on sidebar and tasks list rows

### DIFF
--- a/apps/web/app/tasks/rich-task-list-row.test.tsx
+++ b/apps/web/app/tasks/rich-task-list-row.test.tsx
@@ -1,0 +1,152 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { TooltipProvider } from "@kandev/ui/tooltip";
+import { StateProvider } from "@/components/state-provider";
+import type { HydrationState } from "@/lib/state/store";
+import type { TaskPR } from "@/lib/types/github";
+import type { TaskMR } from "@/lib/types/gitlab";
+import { sessionId as toSessionId, taskId as toTaskId, type Task } from "@/lib/types/http";
+import { TaskListRowPrimaryContent } from "./rich-task-list-row";
+
+afterEach(cleanup);
+
+const PR_ICON_TEST_ID = "pr-task-icon-task-1";
+const MR_ICON_TEST_ID = "mr-task-icon-task-1";
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: toTaskId("task-1"),
+    title: "A task",
+    state: "WAITING_FOR_INPUT",
+    workflow_step_id: "step-1",
+    primary_session_id: toSessionId("session-1"),
+    ...overrides,
+  } as Task;
+}
+
+function makePR(overrides: Partial<TaskPR> = {}): TaskPR {
+  return {
+    id: "id",
+    task_id: "task-1",
+    owner: "o",
+    repo: "r",
+    pr_number: 1,
+    pr_url: "",
+    pr_title: "Test PR",
+    head_branch: "feat",
+    base_branch: "main",
+    author_login: "alice",
+    state: "open",
+    review_state: "",
+    checks_state: "",
+    mergeable_state: "",
+    review_count: 0,
+    pending_review_count: 0,
+    comment_count: 0,
+    unresolved_review_threads: 0,
+    checks_total: 0,
+    checks_passing: 0,
+    additions: 0,
+    deletions: 0,
+    created_at: "",
+    merged_at: null,
+    closed_at: null,
+    last_synced_at: null,
+    updated_at: "",
+    ...overrides,
+  };
+}
+
+function makeMR(overrides: Partial<TaskMR> = {}): TaskMR {
+  return {
+    id: "mr-1",
+    task_id: "task-1",
+    host: "https://gitlab.com",
+    project_path: "acme/api",
+    mr_iid: 1,
+    mr_url: "",
+    mr_title: "Test MR",
+    head_branch: "feat",
+    base_branch: "main",
+    author_username: "alice",
+    state: "open",
+    approval_state: "",
+    pipeline_state: "",
+    merge_status: "",
+    draft: false,
+    approval_count: 0,
+    required_approvals: 0,
+    pipeline_jobs_total: 0,
+    pipeline_jobs_pass: 0,
+    reviewer_count: 0,
+    unapproved_reviewers: 0,
+    unresolved_discussions: 0,
+    created_at: "",
+    updated_at: "",
+    ...overrides,
+  };
+}
+
+function renderRow(showTaskDetails: boolean, initialState: HydrationState = {}) {
+  return render(
+    <StateProvider initialState={initialState}>
+      <TooltipProvider>
+        <TaskListRowPrimaryContent
+          task={makeTask()}
+          level={0}
+          repositories={[]}
+          parentTasks={[]}
+          showTaskDetails={showTaskDetails}
+        />
+      </TooltipProvider>
+    </StateProvider>,
+  );
+}
+
+describe("TaskListRowPrimaryContent, contributions shown (AC8, AC9, AC23)", () => {
+  it("renders the PR badge before the MR badge inside a single wrapper with the gap classes", () => {
+    renderRow(true, {
+      taskPRs: { byTaskId: { "task-1": [makePR()] } },
+      taskMRs: { byWorkspaceId: { ws1: { "task-1": [makeMR()] } } },
+      workspaces: { items: [], activeId: "ws1" },
+    });
+
+    const prIcon = screen.getByTestId(PR_ICON_TEST_ID);
+    const mrIcon = screen.getByTestId(MR_ICON_TEST_ID);
+    expect(prIcon.compareDocumentPosition(mrIcon) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+
+    const wrapper = prIcon.parentElement;
+    expect(wrapper).not.toBeNull();
+    expect(wrapper?.contains(mrIcon)).toBe(true);
+    expect(wrapper?.classList.contains("inline-flex")).toBe(true);
+    expect(wrapper?.classList.contains("items-center")).toBe(true);
+    expect(wrapper?.classList.contains("gap-1")).toBe(true);
+  });
+
+  it("carries the wrapper classes unconditionally even without an MR badge", () => {
+    renderRow(true, {
+      taskPRs: { byTaskId: { "task-1": [makePR()] } },
+      workspaces: { items: [], activeId: "ws1" },
+    });
+
+    const prIcon = screen.getByTestId(PR_ICON_TEST_ID);
+    const wrapper = prIcon.parentElement;
+    expect(wrapper?.classList.contains("inline-flex")).toBe(true);
+    expect(wrapper?.classList.contains("items-center")).toBe(true);
+    expect(wrapper?.classList.contains("gap-1")).toBe(true);
+    expect(screen.queryByTestId(MR_ICON_TEST_ID)).toBeNull();
+  });
+});
+
+describe("TaskListRowPrimaryContent, contributions hidden (AC10)", () => {
+  it("renders neither badge on the compact path", () => {
+    renderRow(false, {
+      taskPRs: { byTaskId: { "task-1": [makePR()] } },
+      taskMRs: { byWorkspaceId: { ws1: { "task-1": [makeMR()] } } },
+      workspaces: { items: [], activeId: "ws1" },
+    });
+
+    expect(screen.queryByTestId(PR_ICON_TEST_ID)).toBeNull();
+    expect(screen.queryByTestId(MR_ICON_TEST_ID)).toBeNull();
+  });
+});

--- a/apps/web/app/tasks/rich-task-list-row.tsx
+++ b/apps/web/app/tasks/rich-task-list-row.tsx
@@ -4,6 +4,7 @@ import { IconAlertCircle, IconSubtask } from "@tabler/icons-react";
 import { Badge } from "@kandev/ui/badge";
 import { PRTaskIcon } from "@/components/github/pr-task-icon";
 import { RegisteredChangeRequestTaskIcon } from "@/components/integrations/registered-change-request-task-icon";
+import { MRTaskIcon } from "@/components/gitlab/mr-task-icon";
 import { useTaskPendingInput, type PendingInput } from "@/hooks/use-task-pending-input";
 import { getTaskStateIcon } from "@/lib/ui/state-icons";
 import type { Repository, Task } from "@/lib/types/http";
@@ -28,11 +29,11 @@ function ArchivedBadge({ task }: { task: Task }) {
 function PrimaryTaskLine({
   task,
   pendingInput,
-  showPullRequest,
+  showContributions,
 }: {
   task: Task;
   pendingInput: PendingInput;
-  showPullRequest: boolean;
+  showContributions: boolean;
 }) {
   return (
     <>
@@ -45,12 +46,14 @@ function PrimaryTaskLine({
       <span className="min-w-0 truncate font-medium" data-testid="tasks-list-row-title">
         {task.title}
       </span>
-      {showPullRequest && (
+      {showContributions && (
         <span
+          className="inline-flex items-center gap-1"
           onClick={(event) => event.stopPropagation()}
           onPointerDown={(event) => event.stopPropagation()}
         >
           <PRTaskIcon taskId={task.id} />
+          <MRTaskIcon taskId={task.id} />
         </span>
       )}
       <RegisteredChangeRequestTaskIcon taskId={task.id} />
@@ -128,7 +131,7 @@ function RichTaskContent({
       style={{ paddingLeft: `${level * 28}px` }}
     >
       <div className="flex min-w-0 items-center gap-2">
-        <PrimaryTaskLine task={task} pendingInput={pendingInput} showPullRequest />
+        <PrimaryTaskLine task={task} pendingInput={pendingInput} showContributions />
       </div>
       <RichMetadataBadges details={details} />
       {details.description && (
@@ -173,7 +176,7 @@ export function TaskListRowPrimaryContent({
       data-testid="tasks-list-row-content"
       style={{ paddingLeft: `${level * 28}px` }}
     >
-      <PrimaryTaskLine task={task} pendingInput={pendingInput} showPullRequest={false} />
+      <PrimaryTaskLine task={task} pendingInput={pendingInput} showContributions={false} />
     </div>
   );
 }

--- a/apps/web/app/tasks/tasks-page-client.mr-hydration.test.tsx
+++ b/apps/web/app/tasks/tasks-page-client.mr-hydration.test.tsx
@@ -1,0 +1,128 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+import { StateProvider } from "@/components/state-provider";
+import { defaultSettingsState } from "@/lib/state/slices/settings/settings-slice";
+
+// AC12: TasksPageClient must call useWorkspaceMRs unconditionally, never
+// gated on tasksListShowDetails. Every direct import of TasksPageClient is
+// mocked so this test asserts only the wiring under AC12, not the behaviour
+// of the many unrelated hooks/components the page also renders (per the
+// plan's U9 guidance: mock rather than exercise the whole page).
+const useWorkspaceMRsMock = vi.fn();
+const useWorkspacePRsMock = vi.fn();
+
+vi.mock("@/hooks/domains/gitlab/use-task-mr", () => ({
+  useWorkspaceMRs: (workspaceId: string | null) => useWorkspaceMRsMock(workspaceId),
+}));
+vi.mock("@/hooks/domains/github/use-task-pr", () => ({
+  useWorkspacePRs: (workspaceId: string | null) => useWorkspacePRsMock(workspaceId),
+}));
+vi.mock("@/lib/routing/client-router", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+vi.mock("@/lib/api", () => ({
+  archiveTask: vi.fn(),
+  deleteTask: vi.fn(),
+  listTasksByWorkspace: vi.fn(),
+  unarchiveTask: vi.fn(),
+  updateUserSettings: vi.fn(),
+}));
+vi.mock("@/components/toast-provider", () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+vi.mock("@/hooks/use-kanban-display-settings", () => ({
+  useKanbanDisplaySettings: () => ({
+    activeWorkspaceId: "ws1",
+    activeWorkflowId: null,
+    repositories: [],
+    selectedRepositoryId: null,
+  }),
+}));
+vi.mock("@/hooks/use-debounce", () => ({
+  useDebounce: (value: unknown) => value,
+}));
+vi.mock("@/hooks/use-responsive-breakpoint", () => ({
+  useResponsiveBreakpoint: () => ({
+    breakpoint: "desktop",
+    isMobile: false,
+    isTablet: false,
+    isDesktop: true,
+    isCompactDesktop: false,
+    isFullDesktop: true,
+    isFinePointer: true,
+    usesDesktopWorkbench: true,
+  }),
+}));
+vi.mock("@/hooks/use-task-listing-view", () => ({
+  useTaskListingView: () => ({ effectiveView: "list", setView: vi.fn() }),
+}));
+vi.mock("@/hooks/use-foreground-refresh", () => ({
+  useForegroundRefresh: () => undefined,
+}));
+vi.mock("@/hooks/use-workflow-snapshot", () => ({
+  useWorkflowSnapshot: () => undefined,
+}));
+vi.mock("@/components/kanban/kanban-header", () => ({
+  KanbanHeader: () => null,
+}));
+vi.mock("@/components/kanban/mobile-fab", () => ({
+  MobileFab: () => null,
+}));
+vi.mock("@/components/kanban/mobile-search-bar", () => ({
+  MobileSearchBar: () => null,
+}));
+vi.mock("@/components/task-create-dialog", () => ({
+  TaskCreateDialog: () => null,
+}));
+vi.mock("./tasks-list-view", () => ({
+  TasksListView: () => null,
+}));
+
+import { TasksPageClient } from "./tasks-page-client";
+
+afterEach(() => {
+  cleanup();
+  useWorkspaceMRsMock.mockReset();
+  useWorkspacePRsMock.mockReset();
+});
+
+function renderPage(tasksListShowDetails: boolean) {
+  return render(
+    <StateProvider
+      initialState={{
+        workspaces: { items: [], activeId: "ws1" },
+        userSettings: { ...defaultSettingsState.userSettings, tasksListShowDetails, loaded: true },
+      }}
+    >
+      <TasksPageClient
+        workspaces={[]}
+        initialWorkflows={[]}
+        initialRepositories={[]}
+        initialTasks={[]}
+        initialTotal={0}
+        initialDataLoaded
+        initialSort="updated_desc"
+        initialGroup="none"
+      />
+    </StateProvider>,
+  );
+}
+
+describe("TasksPageClient MR hydration (AC12)", () => {
+  it("calls useWorkspaceMRs with the workspace id when task details are off", () => {
+    renderPage(false);
+
+    expect(useWorkspaceMRsMock).toHaveBeenCalledWith("ws1");
+    // The gated GitHub call is unaffected: contrast case proving the two
+    // hooks are wired differently on purpose.
+    expect(useWorkspacePRsMock).toHaveBeenCalledWith(null);
+  });
+
+  it("calls useWorkspaceMRs with the workspace id when task details are on", () => {
+    renderPage(true);
+
+    expect(useWorkspaceMRsMock).toHaveBeenCalledWith("ws1");
+    expect(useWorkspacePRsMock).toHaveBeenCalledWith("ws1");
+  });
+});

--- a/apps/web/app/tasks/tasks-page-client.mr-hydration.test.tsx
+++ b/apps/web/app/tasks/tasks-page-client.mr-hydration.test.tsx
@@ -115,8 +115,10 @@ describe("TasksPageClient MR hydration (AC12)", () => {
 
     expect(useWorkspaceMRsMock).toHaveBeenCalledWith("ws1");
     // The gated GitHub call is unaffected: contrast case proving the two
-    // hooks are wired differently on purpose.
-    expect(useWorkspacePRsMock).toHaveBeenCalledWith(null);
+    // hooks are wired differently on purpose. Exact-call-record equality
+    // (not toHaveBeenCalledWith, a presence check) so the assertion fails
+    // if a regression also calls the hook ungated.
+    expect(useWorkspacePRsMock.mock.calls).toEqual([[null]]);
   });
 
   it("calls useWorkspaceMRs with the workspace id when task details are on", () => {

--- a/apps/web/app/tasks/tasks-page-client.tsx
+++ b/apps/web/app/tasks/tasks-page-client.tsx
@@ -28,6 +28,7 @@ import { useTaskListingView } from "@/hooks/use-task-listing-view";
 import { useForegroundRefresh } from "@/hooks/use-foreground-refresh";
 import { useWorkflowSnapshot } from "@/hooks/use-workflow-snapshot";
 import { useWorkspacePRs } from "@/hooks/domains/github/use-task-pr";
+import { useWorkspaceMRs } from "@/hooks/domains/gitlab/use-task-mr";
 import { linkToTask } from "@/lib/links";
 import { unarchiveToastPayload } from "@/lib/tasks/unarchive-feedback";
 import { shouldSkipInitialTasksFetch } from "./tasks-page-fetch-policy";
@@ -527,6 +528,10 @@ export function TasksPageClient(props: TasksPageClientProps) {
   );
   useWorkflowSnapshot(s.activeWorkflowId);
   useWorkspacePRs(showTaskDetails ? s.activeWorkspaceId : null);
+  // Unconditional, unlike useWorkspacePRs above: useWorkspaceMRs(null) clears
+  // every workspace's cached MRs, not just this page's, and the sidebar (also
+  // mounted here) reads that same cache — see spec "Hydration ownership".
+  useWorkspaceMRs(s.activeWorkspaceId);
   useForegroundRefresh(() => s.fetchTasks(true), Boolean(s.activeWorkspaceId), s.activeWorkspaceId);
   const { handleSortChange, handleGroupChange } = useTasksListPreferenceSync({
     tasksListSort: s.tasksListSort,

--- a/apps/web/components/task/mobile/session-task-switcher-sheet.test.tsx
+++ b/apps/web/components/task/mobile/session-task-switcher-sheet.test.tsx
@@ -11,6 +11,8 @@ const mocks = vi.hoisted(() => ({
     workspaces: { activeId: "workspace-1" },
     repositories: { itemsByWorkspaceId: {} },
     taskPRs: { byTaskId: {} },
+    taskMRs: { byWorkspaceId: {} },
+    workspaces: { activeId: null },
     comments: { byTaskId: {} },
   },
 }));

--- a/apps/web/components/task/mobile/session-task-switcher-sheet.test.tsx
+++ b/apps/web/components/task/mobile/session-task-switcher-sheet.test.tsx
@@ -12,7 +12,6 @@ const mocks = vi.hoisted(() => ({
     repositories: { itemsByWorkspaceId: {} },
     taskPRs: { byTaskId: {} },
     taskMRs: { byWorkspaceId: {} },
-    workspaces: { activeId: null },
     comments: { byTaskId: {} },
   },
 }));

--- a/apps/web/components/task/task-contribution-icons.tsx
+++ b/apps/web/components/task/task-contribution-icons.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { IconGitPullRequest } from "@tabler/icons-react";
+import { getPRAggregateStatusColor, PRTaskIcon } from "@/components/github/pr-task-icon";
+import { MRTaskIcon } from "@/components/gitlab/mr-task-icon";
+import { useAppStore } from "@/components/state-provider";
+import { cn } from "@/lib/utils";
+
+/** Shows PR icon from store (real data) or from prInfo prop (prototype/mock). */
+function TaskPRIcon({
+  taskId,
+  prInfo,
+}: {
+  taskId?: string;
+  prInfo?: { number: number; state: string; aggregateState?: string };
+}) {
+  const hasStorePR = useAppStore((s) => !!taskId && (s.taskPRs.byTaskId[taskId]?.length ?? 0) > 0);
+  if (hasStorePR) return <PRTaskIcon taskId={taskId!} />;
+  if (!prInfo) return null;
+  const color = getPRAggregateStatusColor(prInfo.aggregateState ?? prInfo.state);
+  return (
+    <span
+      data-testid={taskId ? `pr-task-icon-${taskId}` : "pr-task-icon"}
+      data-pr-state={prInfo.state}
+      className={cn("inline-flex items-center shrink-0", color)}
+    >
+      <IconGitPullRequest className="h-3.5 w-3.5" />
+    </span>
+  );
+}
+
+/**
+ * PR badge (store or prInfo fallback) and MR badge as siblings, PR first. The
+ * MR branch needs its own taskId guard: hasStorePR inside TaskPRIcon is false
+ * both when taskId is absent and when it's present with no PRs, so it can't
+ * gate the MRTaskIcon call.
+ */
+export function TaskContributionIcons({
+  taskId,
+  prInfo,
+}: {
+  taskId?: string;
+  prInfo?: { number: number; state: string; aggregateState?: string };
+}) {
+  return (
+    <>
+      <TaskPRIcon taskId={taskId} prInfo={prInfo} />
+      {taskId ? <MRTaskIcon taskId={taskId} /> : null}
+    </>
+  );
+}

--- a/apps/web/components/task/task-item.mr-guard.test.tsx
+++ b/apps/web/components/task/task-item.mr-guard.test.tsx
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { StateProvider } from "@/components/state-provider";
+import { TooltipProvider } from "@kandev/ui/tooltip";
+import type { TaskMR } from "@/lib/types/gitlab";
+
+// AC5's load-bearing clause is that MRTaskIcon is never invoked when the row
+// has no taskId — a plain stub (as used elsewhere for module-level
+// interception) records no calls, so this needs its own vi.fn()-backed mock.
+// Isolated in its own file so the module mock doesn't shadow the real
+// MRTaskIcon rendering asserted by the other task-item scenarios.
+vi.mock("@/components/gitlab/mr-task-icon", () => ({
+  MRTaskIcon: vi.fn(() => null),
+}));
+
+import { MRTaskIcon } from "@/components/gitlab/mr-task-icon";
+import { TaskItem } from "./task-item";
+
+function makeMR(overrides: Partial<TaskMR> = {}): TaskMR {
+  return {
+    id: "mr-1",
+    task_id: "other-task",
+    host: "https://gitlab.com",
+    project_path: "acme/api",
+    mr_iid: 1,
+    mr_url: "",
+    mr_title: "Test MR",
+    head_branch: "feat",
+    base_branch: "main",
+    author_username: "alice",
+    state: "open",
+    approval_state: "",
+    pipeline_state: "",
+    merge_status: "",
+    draft: false,
+    approval_count: 0,
+    required_approvals: 0,
+    pipeline_jobs_total: 0,
+    pipeline_jobs_pass: 0,
+    reviewer_count: 0,
+    unapproved_reviewers: 0,
+    unresolved_discussions: 0,
+    created_at: "",
+    updated_at: "",
+    ...overrides,
+  };
+}
+
+afterEach(() => cleanup());
+
+describe("TaskItem, no taskId (AC5)", () => {
+  it("renders no mr-task-icon element and never invokes MRTaskIcon", () => {
+    render(
+      <StateProvider
+        initialState={{
+          taskMRs: { byWorkspaceId: { ws1: { "other-task": [makeMR()] } } },
+          workspaces: { items: [], activeId: "ws1" },
+        }}
+      >
+        <TooltipProvider>
+          <TaskItem title="Needs answer" state="REVIEW" />
+        </TooltipProvider>
+      </StateProvider>,
+    );
+
+    expect(screen.queryByTestId(/^mr-task-icon-/)).toBeNull();
+    expect(MRTaskIcon).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/components/task/task-item.test.tsx
+++ b/apps/web/components/task/task-item.test.tsx
@@ -2,6 +2,9 @@ import { afterEach, describe, expect, it } from "vitest";
 import { cleanup, render, screen } from "@testing-library/react";
 import type { ComponentProps } from "react";
 import { StateProvider } from "@/components/state-provider";
+import type { HydrationState } from "@/lib/state/store";
+import type { TaskPR } from "@/lib/types/github";
+import type { TaskMR } from "@/lib/types/gitlab";
 import { TaskItem } from "./task-item";
 import { TooltipProvider } from "@kandev/ui/tooltip";
 
@@ -22,17 +25,85 @@ const PREPARING_SPINNER_CLASS = "text-muted-foreground/40";
 const SPIN_CLASS = "animate-spin";
 const SLOW_SPIN_CLASS = "[animation-duration:2s]";
 const TASK_ACTIONS_LABEL = "Task actions";
+const PR_ICON_TEST_ID = "pr-task-icon-t1";
+const MR_ICON_TEST_ID = "mr-task-icon-t1";
 
 afterEach(() => cleanup());
 
-function renderTaskItem(props: Partial<ComponentProps<typeof TaskItem>> = {}) {
+function renderTaskItem(
+  props: Partial<ComponentProps<typeof TaskItem>> = {},
+  initialState: HydrationState = {},
+) {
   return render(
-    <StateProvider>
+    <StateProvider initialState={initialState}>
       <TooltipProvider>
         <TaskItem title="Needs answer" state="REVIEW" {...props} />
       </TooltipProvider>
     </StateProvider>,
   );
+}
+
+function makePR(overrides: Partial<TaskPR> = {}): TaskPR {
+  return {
+    id: "id",
+    task_id: "t1",
+    owner: "o",
+    repo: "r",
+    pr_number: 1,
+    pr_url: "",
+    pr_title: "Test PR",
+    head_branch: "feat",
+    base_branch: "main",
+    author_login: "alice",
+    state: "open",
+    review_state: "",
+    checks_state: "",
+    mergeable_state: "",
+    review_count: 0,
+    pending_review_count: 0,
+    comment_count: 0,
+    unresolved_review_threads: 0,
+    checks_total: 0,
+    checks_passing: 0,
+    additions: 0,
+    deletions: 0,
+    created_at: "",
+    merged_at: null,
+    closed_at: null,
+    last_synced_at: null,
+    updated_at: "",
+    ...overrides,
+  };
+}
+
+function makeMR(overrides: Partial<TaskMR> = {}): TaskMR {
+  return {
+    id: "mr-1",
+    task_id: "t1",
+    host: "https://gitlab.com",
+    project_path: "acme/api",
+    mr_iid: 1,
+    mr_url: "",
+    mr_title: "Test MR",
+    head_branch: "feat",
+    base_branch: "main",
+    author_username: "alice",
+    state: "open",
+    approval_state: "",
+    pipeline_state: "",
+    merge_status: "",
+    draft: false,
+    approval_count: 0,
+    required_approvals: 0,
+    pipeline_jobs_total: 0,
+    pipeline_jobs_pass: 0,
+    reviewer_count: 0,
+    unapproved_reviewers: 0,
+    unresolved_discussions: 0,
+    created_at: "",
+    updated_at: "",
+    ...overrides,
+  };
 }
 
 function expectPreparingSpinner(): void {
@@ -488,5 +559,93 @@ describe("TaskItem queued prompt count badge", () => {
     expect(screen.getByTestId(QUEUED_BADGE_TEST_ID).getAttribute("aria-label")).toContain(
       "queued prompt",
     );
+  });
+});
+
+describe("TaskItem contribution badges", () => {
+  it("renders the PR badge before the MR badge when the task has both (AC2)", () => {
+    renderTaskItem(
+      { taskId: "t1" },
+      {
+        taskPRs: { byTaskId: { t1: [makePR()] } },
+        taskMRs: { byWorkspaceId: { ws1: { t1: [makeMR()] } } },
+        workspaces: { items: [], activeId: "ws1" },
+      },
+    );
+
+    const prIcon = screen.getByTestId(PR_ICON_TEST_ID);
+    const mrIcon = screen.getByTestId(MR_ICON_TEST_ID);
+    expect(prIcon.compareDocumentPosition(mrIcon) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it("renders the MR badge alone when the task has an MR and no PR (AC3)", () => {
+    renderTaskItem(
+      { taskId: "t1" },
+      {
+        taskMRs: { byWorkspaceId: { ws1: { t1: [makeMR()] } } },
+        workspaces: { items: [], activeId: "ws1" },
+      },
+    );
+
+    expect(screen.getByTestId(MR_ICON_TEST_ID)).not.toBeNull();
+    expect(screen.queryByTestId(PR_ICON_TEST_ID)).toBeNull();
+  });
+
+  it("renders the prInfo fallback PR badge followed by the MR badge (AC4)", () => {
+    renderTaskItem(
+      { taskId: "t1", prInfo: { number: 7, state: "Open" } },
+      {
+        taskMRs: { byWorkspaceId: { ws1: { t1: [makeMR()] } } },
+        workspaces: { items: [], activeId: "ws1" },
+      },
+    );
+
+    const prIcon = screen.getByTestId(PR_ICON_TEST_ID);
+    const mrIcon = screen.getByTestId(MR_ICON_TEST_ID);
+    expect(prIcon.compareDocumentPosition(mrIcon) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it("renders no MR badge when the task has no MRs (AC6)", () => {
+    renderTaskItem(
+      { taskId: "t1" },
+      {
+        taskPRs: { byTaskId: { t1: [makePR()] } },
+        workspaces: { items: [], activeId: "ws1" },
+      },
+    );
+
+    expect(screen.getByTestId(PR_ICON_TEST_ID)).not.toBeNull();
+    expect(screen.queryByTestId(MR_ICON_TEST_ID)).toBeNull();
+  });
+
+  it("orders PR, then MR, then the issue badge (AC22)", () => {
+    renderTaskItem(
+      { taskId: "t1", issueInfo: { url: "https://example.com/issues/42", number: 42 } },
+      {
+        taskPRs: { byTaskId: { t1: [makePR()] } },
+        taskMRs: { byWorkspaceId: { ws1: { t1: [makeMR()] } } },
+        workspaces: { items: [], activeId: "ws1" },
+      },
+    );
+
+    const prIcon = screen.getByTestId(PR_ICON_TEST_ID);
+    const mrIcon = screen.getByTestId(MR_ICON_TEST_ID);
+    const issueIcon = screen.getByTestId("issue-task-icon");
+    expect(prIcon.compareDocumentPosition(mrIcon) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(
+      mrIcon.compareDocumentPosition(issueIcon) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it("renders no MR badge with no active workspace, even when the task has MRs elsewhere (AC21)", () => {
+    renderTaskItem(
+      { taskId: "t1" },
+      {
+        taskMRs: { byWorkspaceId: { ws1: { t1: [makeMR()] } } },
+        workspaces: { items: [], activeId: null },
+      },
+    );
+
+    expect(screen.queryByTestId(MR_ICON_TEST_ID)).toBeNull();
   });
 });

--- a/apps/web/components/task/task-item.tsx
+++ b/apps/web/components/task/task-item.tsx
@@ -7,15 +7,13 @@ import {
   IconCircleCheck,
   IconCircleDashed,
   IconDots,
-  IconGitPullRequest,
   IconMessageQuestion,
   IconProgressCheck,
   IconPinFilled,
   IconShieldQuestion,
 } from "@tabler/icons-react";
-import { getPRAggregateStatusColor, PRTaskIcon } from "@/components/github/pr-task-icon";
 import { IssueTaskIcon } from "@/components/github/issue-task-icon";
-import { useAppStore } from "@/components/state-provider";
+import { TaskContributionIcons } from "./task-contribution-icons";
 import { cn } from "@/lib/utils";
 import { computeRowIndent, resolveRowDepth } from "@/lib/sidebar/row-indent";
 import { TaskItemStatsRow } from "./task-item-stats-row";
@@ -311,29 +309,6 @@ function DiffStatsRight({ diffStats, menuOpen }: { diffStats: DiffStats; menuOpe
   );
 }
 
-/** Shows PR icon from store (real data) or from prInfo prop (prototype/mock). */
-function TaskPRIcon({
-  taskId,
-  prInfo,
-}: {
-  taskId?: string;
-  prInfo?: { number: number; state: string; aggregateState?: string };
-}) {
-  const hasStorePR = useAppStore((s) => !!taskId && (s.taskPRs.byTaskId[taskId]?.length ?? 0) > 0);
-  if (hasStorePR) return <PRTaskIcon taskId={taskId!} />;
-  if (!prInfo) return null;
-  const color = getPRAggregateStatusColor(prInfo.aggregateState ?? prInfo.state);
-  return (
-    <span
-      data-testid={taskId ? `pr-task-icon-${taskId}` : "pr-task-icon"}
-      data-pr-state={prInfo.state}
-      className={cn("inline-flex items-center shrink-0", color)}
-    >
-      <IconGitPullRequest className="h-3.5 w-3.5" />
-    </span>
-  );
-}
-
 function TaskItemContent({
   title,
   autopilot,
@@ -379,7 +354,7 @@ function TaskItemContent({
             className="h-3 w-3 shrink-0 text-muted-foreground/60"
           />
         )}
-        <TaskPRIcon taskId={taskId} prInfo={prInfo} />
+        <TaskContributionIcons taskId={taskId} prInfo={prInfo} />
         {taskId ? <RegisteredChangeRequestTaskIcon taskId={taskId} /> : null}
         {issueInfo && <IssueTaskIcon issueInfo={issueInfo} />}
         {agentErrorMessage && <TaskAgentErrorIcon message={agentErrorMessage} />}

--- a/apps/web/e2e/pages/app-sidebar-page.ts
+++ b/apps/web/e2e/pages/app-sidebar-page.ts
@@ -16,4 +16,19 @@ export class AppSidebarPage {
       await header.click();
     }
   }
+
+  /** Task row, scoped to this sidebar. `data-task-row-id` lives on the row itself. */
+  row(taskId: string): Locator {
+    return this.root.locator(`[data-task-row-id="${taskId}"]`);
+  }
+
+  /** MR badge for a task row, scoped to `app-sidebar` per the duplicate-mount rule. */
+  mrBadge(taskId: string): Locator {
+    return this.row(taskId).getByTestId(`mr-task-icon-${taskId}`);
+  }
+
+  /** PR badge for a task row, scoped to `app-sidebar` per the duplicate-mount rule. */
+  prBadge(taskId: string): Locator {
+    return this.row(taskId).getByTestId(`pr-task-icon-${taskId}`);
+  }
 }

--- a/apps/web/e2e/tests/gitlab/mobile-mr-tasks-list-badge.spec.ts
+++ b/apps/web/e2e/tests/gitlab/mobile-mr-tasks-list-badge.spec.ts
@@ -1,0 +1,104 @@
+import { test, expect } from "../../fixtures/test-base";
+import { assertNoDocumentHorizontalOverflow } from "../../helpers/layout-assertions";
+import { GITLAB_HOST, GITLAB_PROJECT } from "../../helpers/gitlab";
+import type { ApiClient } from "../../helpers/api-client";
+import type { SeedData } from "../../fixtures/test-base";
+
+const MR_IID = 4580;
+
+async function seedTaskWithPRAndMR(apiClient: ApiClient, seedData: SeedData, title: string) {
+  await apiClient.configureGitLab(seedData.workspaceId, GITLAB_HOST);
+  await apiClient.updateRepository(seedData.repositoryId, {
+    provider: "gitlab",
+    provider_host: GITLAB_HOST,
+    provider_owner: "platform",
+    provider_name: "kandev",
+  });
+  await apiClient.mockGitHubReset();
+  await apiClient.mockGitHubSetUser("test-user");
+
+  const now = new Date().toISOString();
+  await apiClient.mockGitLabAddMRs(seedData.workspaceId, GITLAB_PROJECT, [
+    {
+      iid: MR_IID,
+      id: MR_IID + 10_000,
+      project_id: 101,
+      title: "Mobile tasks list badge fixture MR",
+      url: `${GITLAB_HOST}/${GITLAB_PROJECT}/-/merge_requests/${MR_IID}`,
+      web_url: `${GITLAB_HOST}/${GITLAB_PROJECT}/-/merge_requests/${MR_IID}`,
+      state: "open",
+      head_branch: "feature/mobile-tasks-list-badge",
+      head_sha: "sha-mobile-tasks-list-badge",
+      base_branch: "main",
+      author_username: "contributor",
+      project_namespace: "platform",
+      project_path: GITLAB_PROJECT,
+      body: "",
+      draft: false,
+      merge_status: "can_be_merged",
+      has_conflicts: false,
+      additions: 1,
+      deletions: 1,
+      reviewers: [],
+      assignees: [],
+      created_at: now,
+      updated_at: now,
+    },
+  ]);
+
+  // No agent, deliberately — see the desktop spec's seedBoardTask. An
+  // auto-started session's `on_turn_complete` moves the task out from under
+  // the assertion, which is what made the desktop badge specs flaky.
+  const task = await apiClient.createTask(seedData.workspaceId, title, {
+    description: "Mobile tasks list MR badge fixture task",
+    workflow_id: seedData.workflowId,
+    workflow_step_id: seedData.startStepId,
+    repository_ids: [seedData.repositoryId],
+  });
+  await apiClient.linkTaskGitLabMR(seedData.workspaceId, {
+    task_id: task.id,
+    repository_id: seedData.repositoryId,
+    mr_url: `${GITLAB_HOST}/${GITLAB_PROJECT}/-/merge_requests/${MR_IID}`,
+  });
+  await apiClient.mockGitHubAssociateTaskPR({
+    task_id: task.id,
+    owner: "testorg",
+    repo: "testrepo",
+    pr_number: 904,
+    pr_url: "https://github.com/testorg/testrepo/pull/904",
+    pr_title: "Mobile tasks list companion PR",
+    head_branch: "feat/mobile-tasks-list-companion",
+    base_branch: "main",
+    author_login: "test-user",
+    state: "open",
+  });
+  return task;
+}
+
+test.describe("mobile GitLab MR badge on the /tasks list rows", () => {
+  test("E7: renders the MR badge on a mobile viewport without causing horizontal overflow", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    test.setTimeout(120_000);
+    const task = await seedTaskWithPRAndMR(apiClient, seedData, "Mobile tasks list MR badge task");
+
+    await testPage.goto("/tasks");
+    const row = testPage.getByTestId("tasks-list-row").filter({ hasText: task.title });
+    await expect(row).toBeVisible({ timeout: 45_000 });
+
+    // Mobile has no `display-button`; the display menu lives behind the
+    // "Open menu" drawer (see mobile-task-listing-display.spec.ts).
+    await testPage.getByRole("button", { name: "Open menu" }).click();
+    const menu = testPage.getByRole("dialog", { name: "Menu" });
+    await menu.getByText("Show task details", { exact: true }).click();
+    await testPage.keyboard.press("Escape");
+    await expect(menu).toHaveCount(0);
+
+    const icon = row.getByTestId(`mr-task-icon-${task.id}`);
+    await expect(icon).toBeVisible({ timeout: 15_000 });
+
+    await assertNoDocumentHorizontalOverflow(testPage, "mobile /tasks list with MR badge");
+  });
+});

--- a/apps/web/e2e/tests/gitlab/mobile-mr-tasks-list-badge.spec.ts
+++ b/apps/web/e2e/tests/gitlab/mobile-mr-tasks-list-badge.spec.ts
@@ -84,6 +84,11 @@ test.describe("mobile GitLab MR badge on the /tasks list rows", () => {
     test.setTimeout(120_000);
     const task = await seedTaskWithPRAndMR(apiClient, seedData, "Mobile tasks list MR badge task");
 
+    // Explicit, not assumed: tasks_list_show_details is a *bool PATCH field
+    // on the backend, so an unset field in the testPage fixture's settings
+    // reset leaves whatever a previous test in this worker persisted.
+    await apiClient.saveUserSettings({ tasks_list_show_details: false });
+
     await testPage.goto("/tasks");
     const row = testPage.getByTestId("tasks-list-row").filter({ hasText: task.title });
     await expect(row).toBeVisible({ timeout: 45_000 });
@@ -96,6 +101,11 @@ test.describe("mobile GitLab MR badge on the /tasks list rows", () => {
     await testPage.keyboard.press("Escape");
     await expect(menu).toHaveCount(0);
 
+    // Assert the companion PR badge too: seedTaskWithPRAndMR associates both,
+    // so the overflow check below is only informative when both actually
+    // rendered (a missing PR badge from a hydration race would otherwise
+    // silently narrow the layout assertion to a single-badge row).
+    await expect(row.getByTestId(`pr-task-icon-${task.id}`)).toBeVisible({ timeout: 15_000 });
     const icon = row.getByTestId(`mr-task-icon-${task.id}`);
     await expect(icon).toBeVisible({ timeout: 15_000 });
 

--- a/apps/web/e2e/tests/gitlab/mr-sidebar-badge.spec.ts
+++ b/apps/web/e2e/tests/gitlab/mr-sidebar-badge.spec.ts
@@ -1,0 +1,185 @@
+import { test, expect } from "../../fixtures/test-base";
+import { KanbanPage } from "../../pages/kanban-page";
+import { AppSidebarPage } from "../../pages/app-sidebar-page";
+import { GITLAB_HOST, GITLAB_PROJECT } from "../../helpers/gitlab";
+import type { ApiClient } from "../../helpers/api-client";
+import type { SeedData } from "../../fixtures/test-base";
+
+let nextIID = 4400;
+
+function nextMRIID(): number {
+  nextIID += 1;
+  return nextIID;
+}
+
+async function seedMR(
+  apiClient: ApiClient,
+  workspaceId: string,
+  iid: number,
+  overrides: Partial<{
+    state: string;
+    draft: boolean;
+    title: string;
+  }> = {},
+) {
+  const now = new Date().toISOString();
+  await apiClient.mockGitLabAddMRs(workspaceId, GITLAB_PROJECT, [
+    {
+      iid,
+      id: iid + 10_000,
+      project_id: 101,
+      title: overrides.title ?? `Sidebar badge fixture MR ${iid}`,
+      url: `${GITLAB_HOST}/${GITLAB_PROJECT}/-/merge_requests/${iid}`,
+      web_url: `${GITLAB_HOST}/${GITLAB_PROJECT}/-/merge_requests/${iid}`,
+      state: overrides.state ?? "open",
+      head_branch: `feature/sidebar-badge-${iid}`,
+      head_sha: `sha-${iid}`,
+      base_branch: "main",
+      author_username: "contributor",
+      project_namespace: "platform",
+      project_path: GITLAB_PROJECT,
+      body: "",
+      draft: overrides.draft ?? false,
+      merge_status: "can_be_merged",
+      has_conflicts: false,
+      additions: 1,
+      deletions: 1,
+      reviewers: [],
+      assignees: [],
+      created_at: now,
+      updated_at: now,
+    },
+  ]);
+}
+
+async function linkMR(
+  apiClient: ApiClient,
+  seedData: SeedData,
+  taskId: string,
+  iid: number,
+): Promise<void> {
+  await apiClient.linkTaskGitLabMR(seedData.workspaceId, {
+    task_id: taskId,
+    repository_id: seedData.repositoryId,
+    mr_url: `${GITLAB_HOST}/${GITLAB_PROJECT}/-/merge_requests/${iid}`,
+  });
+}
+
+async function ensureGitLabConfigured(apiClient: ApiClient, seedData: SeedData): Promise<void> {
+  await apiClient.configureGitLab(seedData.workspaceId, GITLAB_HOST);
+  await apiClient.updateRepository(seedData.repositoryId, {
+    provider: "gitlab",
+    provider_host: GITLAB_HOST,
+    provider_owner: "platform",
+    provider_name: "kandev",
+  });
+}
+
+/**
+ * Seeds a board card with NO agent, deliberately — see
+ * `mr-task-card-badge.spec.ts`'s `seedBoardTask` comment. An auto-started
+ * session's `on_turn_complete` moves the card out of the start column mid-
+ * test, and the badge is a pure function of the task's linked MRs so an
+ * agent turn adds nothing here.
+ */
+async function seedBoardTask(apiClient: ApiClient, seedData: SeedData, title: string) {
+  return apiClient.createTask(seedData.workspaceId, title, {
+    description: "Sidebar MR badge fixture task",
+    workflow_id: seedData.workflowId,
+    workflow_step_id: seedData.startStepId,
+    repository_ids: [seedData.repositoryId],
+  });
+}
+
+test.describe("GitLab MR badge on the sidebar", () => {
+  test("E1: a single linked open MR renders the badge with count=1 and state=open", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    test.setTimeout(120_000);
+    await ensureGitLabConfigured(apiClient, seedData);
+    const iid = nextMRIID();
+    await seedMR(apiClient, seedData.workspaceId, iid, { state: "open" });
+    const task = await seedBoardTask(apiClient, seedData, "Sidebar single MR badge task");
+    await linkMR(apiClient, seedData, task.id, iid);
+
+    const kanban = new KanbanPage(testPage);
+    await kanban.goto();
+    await expect(kanban.taskCard(task.id)).toBeVisible({ timeout: 45_000 });
+
+    const sidebar = new AppSidebarPage(testPage);
+    await expect(sidebar.row(task.id)).toBeVisible({ timeout: 15_000 });
+    const icon = sidebar.mrBadge(task.id);
+    await expect(icon).toBeVisible({ timeout: 15_000 });
+    await expect(icon).toHaveAttribute("data-mr-count", "1");
+    await expect(icon).toHaveAttribute("data-mr-state", "open");
+  });
+
+  test("E2: a task with no linked MR renders no sidebar badge", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    test.setTimeout(120_000);
+    const task = await seedBoardTask(apiClient, seedData, "Sidebar no MR badge task");
+
+    const kanban = new KanbanPage(testPage);
+    await kanban.goto();
+    await expect(kanban.taskCard(task.id)).toBeVisible({ timeout: 45_000 });
+
+    const sidebar = new AppSidebarPage(testPage);
+    await expect(sidebar.row(task.id)).toBeVisible({ timeout: 15_000 });
+    await expect(sidebar.mrBadge(task.id)).toHaveCount(0);
+  });
+
+  test("E3: a linked PR and MR both render on the sidebar row, PR before MR", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    test.setTimeout(120_000);
+    await ensureGitLabConfigured(apiClient, seedData);
+    await apiClient.mockGitHubReset();
+    await apiClient.mockGitHubSetUser("test-user");
+
+    const iid = nextMRIID();
+    await seedMR(apiClient, seedData.workspaceId, iid, { state: "merged" });
+    const task = await seedBoardTask(apiClient, seedData, "Sidebar PR and MR badge task");
+    await linkMR(apiClient, seedData, task.id, iid);
+    await apiClient.mockGitHubAssociateTaskPR({
+      task_id: task.id,
+      owner: "testorg",
+      repo: "testrepo",
+      pr_number: 901,
+      pr_url: "https://github.com/testorg/testrepo/pull/901",
+      pr_title: "Sidebar companion PR",
+      head_branch: "feat/sidebar-companion",
+      base_branch: "main",
+      author_login: "test-user",
+      state: "open",
+    });
+
+    const kanban = new KanbanPage(testPage);
+    await kanban.goto();
+    await expect(kanban.taskCard(task.id)).toBeVisible({ timeout: 45_000 });
+
+    const sidebar = new AppSidebarPage(testPage);
+    const row = sidebar.row(task.id);
+    await expect(row).toBeVisible({ timeout: 15_000 });
+    const prIcon = sidebar.prBadge(task.id);
+    const mrIcon = sidebar.mrBadge(task.id);
+    await expect(prIcon).toBeVisible({ timeout: 15_000 });
+    await expect(mrIcon).toBeVisible({ timeout: 15_000 });
+
+    const order = await row.evaluate((el) => {
+      const pr = el.querySelector('[data-testid^="pr-task-icon-"]');
+      const mr = el.querySelector('[data-testid^="mr-task-icon-"]');
+      if (!pr || !mr) return "missing";
+      return pr.compareDocumentPosition(mr) & Node.DOCUMENT_POSITION_FOLLOWING
+        ? "pr-then-mr"
+        : "mr-then-pr";
+    });
+    expect(order).toBe("pr-then-mr");
+  });
+});

--- a/apps/web/e2e/tests/gitlab/mr-tasks-list-badge.spec.ts
+++ b/apps/web/e2e/tests/gitlab/mr-tasks-list-badge.spec.ts
@@ -107,6 +107,11 @@ test.describe("GitLab MR badge on the /tasks list rows", () => {
     const task = await seedBoardTask(apiClient, seedData, "Tasks list single MR badge task");
     await linkMR(apiClient, seedData, task.id, iid);
 
+    // Explicit, not assumed: tasks_list_show_details is a *bool PATCH field
+    // on the backend, so an unset field in the testPage fixture's settings
+    // reset leaves whatever a previous test in this worker persisted.
+    await apiClient.saveUserSettings({ tasks_list_show_details: false });
+
     await testPage.goto("/tasks");
     const row = testPage.getByTestId("tasks-list-row").filter({ hasText: task.title });
     await expect(row).toBeVisible({ timeout: 45_000 });
@@ -179,6 +184,11 @@ test.describe("GitLab MR badge on the /tasks list rows", () => {
       author_login: "test-user",
       state: "open",
     });
+
+    // Explicit, not assumed: tasks_list_show_details is a *bool PATCH field
+    // on the backend, so an unset field in the testPage fixture's settings
+    // reset leaves whatever a previous test in this worker persisted.
+    await apiClient.saveUserSettings({ tasks_list_show_details: false });
 
     await testPage.goto("/tasks");
     const row = testPage.getByTestId("tasks-list-row").filter({ hasText: task.title });

--- a/apps/web/e2e/tests/gitlab/mr-tasks-list-badge.spec.ts
+++ b/apps/web/e2e/tests/gitlab/mr-tasks-list-badge.spec.ts
@@ -1,0 +1,203 @@
+import { test, expect } from "../../fixtures/test-base";
+import { GITLAB_HOST, GITLAB_PROJECT } from "../../helpers/gitlab";
+import type { ApiClient } from "../../helpers/api-client";
+import type { SeedData } from "../../fixtures/test-base";
+
+let nextIID = 4500;
+
+function nextMRIID(): number {
+  nextIID += 1;
+  return nextIID;
+}
+
+async function seedMR(
+  apiClient: ApiClient,
+  workspaceId: string,
+  iid: number,
+  overrides: Partial<{
+    state: string;
+    draft: boolean;
+    title: string;
+  }> = {},
+) {
+  const now = new Date().toISOString();
+  await apiClient.mockGitLabAddMRs(workspaceId, GITLAB_PROJECT, [
+    {
+      iid,
+      id: iid + 10_000,
+      project_id: 101,
+      title: overrides.title ?? `Tasks list badge fixture MR ${iid}`,
+      url: `${GITLAB_HOST}/${GITLAB_PROJECT}/-/merge_requests/${iid}`,
+      web_url: `${GITLAB_HOST}/${GITLAB_PROJECT}/-/merge_requests/${iid}`,
+      state: overrides.state ?? "open",
+      head_branch: `feature/tasks-list-badge-${iid}`,
+      head_sha: `sha-${iid}`,
+      base_branch: "main",
+      author_username: "contributor",
+      project_namespace: "platform",
+      project_path: GITLAB_PROJECT,
+      body: "",
+      draft: overrides.draft ?? false,
+      merge_status: "can_be_merged",
+      has_conflicts: false,
+      additions: 1,
+      deletions: 1,
+      reviewers: [],
+      assignees: [],
+      created_at: now,
+      updated_at: now,
+    },
+  ]);
+}
+
+async function linkMR(
+  apiClient: ApiClient,
+  seedData: SeedData,
+  taskId: string,
+  iid: number,
+): Promise<void> {
+  await apiClient.linkTaskGitLabMR(seedData.workspaceId, {
+    task_id: taskId,
+    repository_id: seedData.repositoryId,
+    mr_url: `${GITLAB_HOST}/${GITLAB_PROJECT}/-/merge_requests/${iid}`,
+  });
+}
+
+async function ensureGitLabConfigured(apiClient: ApiClient, seedData: SeedData): Promise<void> {
+  await apiClient.configureGitLab(seedData.workspaceId, GITLAB_HOST);
+  await apiClient.updateRepository(seedData.repositoryId, {
+    provider: "gitlab",
+    provider_host: GITLAB_HOST,
+    provider_owner: "platform",
+    provider_name: "kandev",
+  });
+}
+
+/**
+ * Seeds a board card with NO agent, deliberately — see
+ * `mr-task-card-badge.spec.ts`'s `seedBoardTask` comment. An auto-started
+ * session's `on_turn_complete` moves the task out from under the assertion,
+ * and the badge is a pure function of the task's linked MRs so an agent turn
+ * adds nothing here.
+ */
+async function seedBoardTask(apiClient: ApiClient, seedData: SeedData, title: string) {
+  return apiClient.createTask(seedData.workspaceId, title, {
+    description: "Tasks list MR badge fixture task",
+    workflow_id: seedData.workflowId,
+    workflow_step_id: seedData.startStepId,
+    repository_ids: [seedData.repositoryId],
+  });
+}
+
+async function showTaskDetails(testPage: import("@playwright/test").Page): Promise<void> {
+  await testPage.getByTestId("display-button").click();
+  await testPage.getByText("Show task details", { exact: true }).click();
+}
+
+test.describe("GitLab MR badge on the /tasks list rows", () => {
+  test("E4: the rich row shows the badge when a linked MR exists", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    test.setTimeout(120_000);
+    await ensureGitLabConfigured(apiClient, seedData);
+    const iid = nextMRIID();
+    await seedMR(apiClient, seedData.workspaceId, iid, { state: "open" });
+    const task = await seedBoardTask(apiClient, seedData, "Tasks list single MR badge task");
+    await linkMR(apiClient, seedData, task.id, iid);
+
+    await testPage.goto("/tasks");
+    const row = testPage.getByTestId("tasks-list-row").filter({ hasText: task.title });
+    await expect(row).toBeVisible({ timeout: 45_000 });
+    await showTaskDetails(testPage);
+
+    const icon = row.getByTestId(`mr-task-icon-${task.id}`);
+    await expect(icon).toBeVisible({ timeout: 15_000 });
+    await expect(icon).toHaveAttribute("data-mr-count", "1");
+    await expect(icon).toHaveAttribute("data-mr-state", "open");
+  });
+
+  test("E5: the compact row shows neither badge with task details off", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    test.setTimeout(120_000);
+    await ensureGitLabConfigured(apiClient, seedData);
+    await apiClient.mockGitHubReset();
+    await apiClient.mockGitHubSetUser("test-user");
+    const iid = nextMRIID();
+    await seedMR(apiClient, seedData.workspaceId, iid, { state: "open" });
+    const task = await seedBoardTask(apiClient, seedData, "Tasks list compact badge task");
+    await linkMR(apiClient, seedData, task.id, iid);
+    await apiClient.mockGitHubAssociateTaskPR({
+      task_id: task.id,
+      owner: "testorg",
+      repo: "testrepo",
+      pr_number: 902,
+      pr_url: "https://github.com/testorg/testrepo/pull/902",
+      pr_title: "Tasks list companion PR",
+      head_branch: "feat/tasks-list-companion",
+      base_branch: "main",
+      author_login: "test-user",
+      state: "open",
+    });
+
+    // Explicit, not assumed: tasks_list_show_details is a *bool PATCH field
+    // on the backend, so an unset field in the testPage fixture's settings
+    // reset leaves whatever a previous test in this worker persisted.
+    await apiClient.saveUserSettings({ tasks_list_show_details: false });
+
+    await testPage.goto("/tasks");
+    const row = testPage.getByTestId("tasks-list-row").filter({ hasText: task.title });
+    await expect(row).toBeVisible({ timeout: 45_000 });
+
+    await expect(row.getByTestId(`pr-task-icon-${task.id}`)).toHaveCount(0);
+    await expect(row.getByTestId(`mr-task-icon-${task.id}`)).toHaveCount(0);
+  });
+
+  test("E6: the rich row shows PR before MR", async ({ testPage, apiClient, seedData }) => {
+    test.setTimeout(120_000);
+    await ensureGitLabConfigured(apiClient, seedData);
+    await apiClient.mockGitHubReset();
+    await apiClient.mockGitHubSetUser("test-user");
+
+    const iid = nextMRIID();
+    await seedMR(apiClient, seedData.workspaceId, iid, { state: "merged" });
+    const task = await seedBoardTask(apiClient, seedData, "Tasks list PR and MR badge task");
+    await linkMR(apiClient, seedData, task.id, iid);
+    await apiClient.mockGitHubAssociateTaskPR({
+      task_id: task.id,
+      owner: "testorg",
+      repo: "testrepo",
+      pr_number: 903,
+      pr_url: "https://github.com/testorg/testrepo/pull/903",
+      pr_title: "Tasks list PR before MR",
+      head_branch: "feat/tasks-list-pr-mr",
+      base_branch: "main",
+      author_login: "test-user",
+      state: "open",
+    });
+
+    await testPage.goto("/tasks");
+    const row = testPage.getByTestId("tasks-list-row").filter({ hasText: task.title });
+    await expect(row).toBeVisible({ timeout: 45_000 });
+    await showTaskDetails(testPage);
+
+    const prIcon = row.getByTestId(`pr-task-icon-${task.id}`);
+    const mrIcon = row.getByTestId(`mr-task-icon-${task.id}`);
+    await expect(prIcon).toBeVisible({ timeout: 15_000 });
+    await expect(mrIcon).toBeVisible({ timeout: 15_000 });
+
+    const order = await row.evaluate((el) => {
+      const pr = el.querySelector('[data-testid^="pr-task-icon-"]');
+      const mr = el.querySelector('[data-testid^="mr-task-icon-"]');
+      if (!pr || !mr) return "missing";
+      return pr.compareDocumentPosition(mr) & Node.DOCUMENT_POSITION_FOLLOWING
+        ? "pr-then-mr"
+        : "mr-then-pr";
+    });
+    expect(order).toBe("pr-then-mr");
+  });
+});

--- a/apps/web/hooks/domains/gitlab/use-task-mr.test.ts
+++ b/apps/web/hooks/domains/gitlab/use-task-mr.test.ts
@@ -209,6 +209,42 @@ describe("useWorkspaceMRs", () => {
   });
 });
 
+// AC13: pins the existing full-clear behaviour that AC12 requires callers
+// (tasks-page-client.tsx) to route around by never invoking the hook with
+// null while a workspace is active. Kept to a single renderHook tree so
+// every read/write shares one store instance (each StateProvider mount owns
+// its own store).
+describe("useWorkspaceMRs, full clear on null", () => {
+  beforeEach(() => {
+    listWorkspaceTaskMRsMock.mockReset();
+  });
+
+  it("clears every workspace's cached MRs when called with null (AC13)", async () => {
+    listWorkspaceTaskMRsMock.mockResolvedValue({ task_mrs: {} });
+
+    const { result, rerender } = renderHook(
+      ({ ws }: { ws: string | null }) => {
+        useWorkspaceMRs(ws);
+        const setTaskMRs = useAppStore((s) => s.setTaskMRs);
+        const byWorkspaceId = useAppStore((s) => s.taskMRs.byWorkspaceId);
+        return { setTaskMRs, byWorkspaceId };
+      },
+      { wrapper, initialProps: { ws: "ws-c" as string | null } },
+    );
+    await waitFor(() => expect(result.current.byWorkspaceId["ws-c"]).toEqual({}));
+
+    act(() => {
+      result.current.setTaskMRs("ws-a", { "task-a": [makeMR({ id: "a", task_id: "task-a" })] });
+      result.current.setTaskMRs("ws-b", { "task-b": [makeMR({ id: "b", task_id: "task-b" })] });
+    });
+    expect(Object.keys(result.current.byWorkspaceId).sort()).toEqual(["ws-a", "ws-b", "ws-c"]);
+
+    rerender({ ws: null });
+
+    expect(result.current.byWorkspaceId).toEqual({});
+  });
+});
+
 describe("useWorkspaceMRs cleanup", () => {
   it("ignores workspace A's deferred fetch after its loader unmounts and B loads", async () => {
     let resolveWorkspaceA: (v: { task_mrs: Record<string, TaskMR[]> }) => void = () => {};

--- a/docs/plans/gitlab-mr-task-list-badges/plan.md
+++ b/docs/plans/gitlab-mr-task-list-badges/plan.md
@@ -1,0 +1,337 @@
+---
+spec: docs/specs/gitlab-mr-task-list-badges/spec.md
+created: 2026-08-13
+status: draft
+---
+
+# Implementation Plan: GitLab MR Badge on the Sidebar and Tasks-List Rows
+
+## Overview
+
+`MRTaskIcon` ships today with exactly one call site (the Kanban card). This plan
+adds it to the two remaining task-row surfaces: the app sidebar row
+(`components/task/task-item.tsx`) and the `/tasks` rich row
+(`app/tasks/rich-task-list-row.tsx`), and gives `/tasks` its own unconditional MR
+hydration call so its own row has data to render. Frontend only: no backend, no
+API, no store slice, no new component, no new user-facing copy.
+
+The three production edits are on disjoint files and can land in any order; the
+three E2E specs follow them. The order below is dependency order, not risk order:
+each surface is independently observable, so the product is working after every
+task.
+
+---
+
+## Backend
+
+None. The spec introduces no persistent state, no API, no WS action, and no
+change to `TaskStatusSummary`. The GitLab MR rows the badge reads are already
+cached at `taskMRs.byWorkspaceId[workspaceId][taskId]`.
+
+---
+
+## Frontend
+
+### 1. App sidebar row — `apps/web/components/task/task-item.tsx`
+
+The local `TaskPRIcon` component (currently at ~line 314) is two chained early
+returns:
+
+```tsx
+const hasStorePR = useAppStore((s) => !!taskId && (s.taskPRs.byTaskId[taskId]?.length ?? 0) > 0);
+if (hasStorePR) return <PRTaskIcon taskId={taskId!} />;
+if (!prInfo) return null;
+// ... prInfo fallback badge
+```
+
+Both `return`s exit the component, so anything appended after them is
+unreachable for a task that has a PR **and** for a task that has neither a PR nor
+`prInfo` — the GitLab-only task this feature exists to serve.
+
+Restructure so the PR branch and the MR branch are siblings. Rename the component
+to reflect that it now renders both contribution badges, and have it return a
+fragment:
+
+```tsx
+function TaskContributionIcons({ taskId, prInfo }: { taskId?: string; prInfo?: PrInfo }) {
+  const hasStorePR = useAppStore((s) => !!taskId && (s.taskPRs.byTaskId[taskId]?.length ?? 0) > 0);
+  return (
+    <>
+      <TaskPRBadge taskId={taskId} prInfo={prInfo} hasStorePR={hasStorePR} />
+      {taskId ? <MRTaskIcon taskId={taskId} /> : null}
+    </>
+  );
+}
+```
+
+Three rules the restructure must hold, each with its own AC:
+
+- The MR branch needs **its own `taskId` truthiness guard**. `hasStorePR` is not
+  usable: it is `false` both when `taskId` is absent and when `taskId` is present
+  with no PRs. `<MRTaskIcon taskId={taskId!} />` (the non-null-assertion shape the
+  PR branch beside it uses) would invoke the component with `undefined`, add a
+  `useTaskMRs` subscription, and violate AC5 and AC18 while still rendering
+  nothing. The guard must prevent the call, not just the output. (AC5, AC18)
+- The call site inside `TaskItemContent`'s title row keeps its position: the MR
+  badge lands immediately after the PR badge and **before** `IssueTaskIcon`.
+  Full row order: title, autopilot, pinned, **PR, MR**, issue, agent-error,
+  remote-cloud, archived chip. (AC2, AC22)
+- The sidebar hydrates nothing. No file under `components/task/` or
+  `components/app-sidebar/` may import `useWorkspaceMRs`. (AC7)
+
+`task-item.tsx` measures **591 effective lines** against the 600-line
+`max-lines` limit (`skipBlankLines`, `skipComments`, `--max-warnings 0`). The
+restructure above fits inline with margin; the one-new-file allowance in the
+spec's Constraints is a fallback, not the expected shape.
+
+### 2. `/tasks` rich row — `apps/web/app/tasks/rich-task-list-row.tsx`
+
+In `PrimaryTaskLine`:
+
+- Rename the prop `showPullRequest: boolean` to `showContributions: boolean`.
+  It is file-local (declared and passed only within this file: `true` from
+  `RichTaskContent` at ~line 129, `false` from `TaskListRowPrimaryContent`'s
+  compact path at ~line 174). One flag gates both badges; no second flag, no
+  per-provider toggle, and no default value. No `showPullRequest` identifier may
+  remain in the file. (AC10, AC11)
+- Add `<MRTaskIcon taskId={task.id} />` **inside the existing**
+  propagation-stopping `<span>` that already wraps `PRTaskIcon`, after it. Not a
+  second wrapper: one wrapper, two children, so the badges cannot drift apart on
+  interaction behaviour. (AC9)
+- That wrapper carries **no `className` today** because it has only ever had one
+  child. Two children would render with no separation at all. Give it
+  `inline-flex items-center gap-1` — the same `gap-1` the Kanban card's
+  `kanban-card-title-row` and the sidebar title row already use. Apply it
+  **unconditionally**, so it adds no element and reserves no space in the no-MR
+  case. (AC23, and this is why AC23 and AC6 are not in tension)
+- Do not add `shrink-0` (both badge roots already carry it) and do not touch the
+  row's existing `gap-2`.
+
+### 3. `/tasks` hydration — `apps/web/app/tasks/tasks-page-client.tsx`
+
+The page already owns its GitHub hydration, gated on the same setting that gates
+the badge (line 529):
+
+```ts
+useWorkspacePRs(showTaskDetails ? s.activeWorkspaceId : null);
+```
+
+**Mirroring that expression for GitLab is a cross-surface data-loss bug.** The
+two hooks do not have the same null behaviour: `useWorkspacePRs(null)` clears a
+local ref and touches no store state, while `useWorkspaceMRs(null)` calls
+`resetTaskMRs()` **with no argument**, which assigns `taskMRs.byWorkspaceId = {}`
+— every workspace, wiped. `AppSidebar` is mounted in the root layout and is
+therefore on screen on `/tasks`, so the gated form would blank the sidebar's MR
+badges for the whole time a user sits on `/tasks` with task details off.
+
+Add, unconditionally:
+
+```ts
+import { useWorkspaceMRs } from "@/hooks/domains/gitlab/use-task-mr";
+// ...
+useWorkspaceMRs(s.activeWorkspaceId);
+```
+
+matching `kanban-board.tsx:321`'s existing unconditional call rather than
+`useWorkspacePRs`'s gated one. (AC12)
+
+Passing `null` because `s.activeWorkspaceId` is itself `null` is permitted and
+is not the forbidden case: with no active workspace `useTaskMRs` returns
+`EMPTY_MRS` for every task, so the clear takes nothing away. (AC21)
+
+**Check `max-lines` on this file before assuming the edit is free.** It measures
+**597 effective lines of 600** — the tightest of the three, despite being the
+smaller file by raw count (642 vs 660). The edit above is exactly two effective
+lines, landing it at 599. That fits, but with one line to spare. If the actual
+`eslint` run disagrees, the remedy is an extraction into a sibling under
+`app/tasks/` (the spec's Constraints permit exactly one new file for this
+purpose), **not** an `eslint-disable`: the file carries none today.
+
+### API client
+
+None.
+
+### State
+
+None. Reads go through the existing `useTaskMRs(taskId)`
+(`hooks/domains/gitlab/use-task-mr.ts:60`), which resolves `workspaces.activeId`
+itself and returns the module-level, referentially stable `EMPTY_MRS` when there
+is nothing to show. No new selector may be introduced, and nothing added by this
+feature may return a freshly allocated array or object — a fresh `[]` causes an
+infinite re-render loop, as `EMPTY_MRS`' own comment records. (AC18)
+
+`apps/web/components/gitlab/mr-task-icon.tsx` and everything under
+`apps/web/components/github/` are consumed exactly as they ship and are not
+modified. (AC14, AC15)
+
+---
+
+## Tests
+
+Unit scenarios are `U1` to `U11` per the spec. Note the spec's numbering rule:
+cite scenarios by prefixed id, never by bare number.
+
+| # | What | File | How |
+|---|---|---|---|
+| U1 | Sidebar, PR and MR together, PR first in DOM order (AC2) | `components/task/task-item.test.tsx` | Render `TaskItem` under `StateProvider` with `initialState` seeding `taskPRs.byTaskId.t1`, `taskMRs.byWorkspaceId.ws1.t1`, `workspaces.activeId = "ws1"`; assert both testids present and `compareDocumentPosition` |
+| U2 | Sidebar, MR only, no PR and no `prInfo` (AC3) | same | The case the early return makes impossible today |
+| U3 | Sidebar, `prInfo` fallback plus MR, PR first (AC4) | same | `prInfo={{ number: 7, state: "Open" }}`, no store PR |
+| U4 | Sidebar, no `taskId` (AC5) | same | **Two clauses, both required.** (a) no `mr-task-icon-*` element; (b) `MRTaskIcon` **not invoked at all** |
+| U5 | Sidebar, no MRs, no `mr-task-icon-*` element (AC6) | same | PR only |
+| U6 | `/tasks` row, contributions shown: both badges inside the single wrapper, PR first, wrapper carries `inline-flex items-center gap-1` (AC8, AC9, AC23) | `app/tasks/rich-task-list-row.test.tsx` (new) | Render the exported `TaskListRowPrimaryContent` with `showTaskDetails` true under `StateProvider`, following `tasks-list-view.test.tsx`'s no-mock shape |
+| U7 | `/tasks` row, contributions hidden: neither badge (AC10) | same | Same store, compact path |
+| U8 | `useWorkspaceMRs(null)` wipes every workspace (AC13) | `hooks/domains/gitlab/use-task-mr.test.ts` | Seed `byWorkspaceId["ws-a"]` and `["ws-b"]`, render the hook with `null`, assert both gone. Pins the existing behaviour AC12 exists to route around |
+| U9 | `TasksPageClient` calls `useWorkspaceMRs` with the workspace id, not `null`, while `tasksListShowDetails` is false (AC12) | `app/tasks/tasks-page-client.mr-hydration.test.tsx` (new) | Mock `@/hooks/domains/gitlab/use-task-mr` with `vi.fn()`, assert the argument. See the risk note in task-03 |
+| U10 | Sidebar, MR before the issue badge, run with a store PR present so it covers the full PR-MR-issue order (AC22) | `components/task/task-item.test.tsx` | `issueInfo={{ url, number: 42 }}` plus a seeded PR and MR |
+| U11 | MR seeded but `workspaces.activeId = null`: no badge (AC21) | same | Observes AC21's second clause, which no other scenario reaches |
+
+**U4 clause (b) needs a `vi.fn()`-backed component mock, and no in-repo
+precedent exists — write it fresh.** `components/kanban-card-content.test.tsx` is
+the precedent for **module-level interception only**: it replaces the module with
+a plain stub (`MRTaskIcon: () => <span data-testid="mr-task-icon" />`), and a stub
+records no calls, so clause (b) cannot be asserted against it. Copy that file's
+`vi.mock` placement and factory shape; do **not** copy its stub body. The required
+shape is:
+
+```tsx
+vi.mock("@/components/gitlab/mr-task-icon", () => ({ MRTaskIcon: vi.fn(() => null) }));
+// ...
+expect(MRTaskIcon).not.toHaveBeenCalled();
+```
+
+Clause (b) is the load-bearing one: an unguarded `<MRTaskIcon taskId={taskId!} />`
+would pass clause (a) while breaking AC5.
+
+---
+
+## E2E Tests
+
+Required: `apps/web/**` is touched and none of the files are on the Testing
+step's exemption allowlist.
+
+All GitLab scenarios seed through the GitLab mock provider and a task created
+with **no agent**, for the reason `mr-task-card-badge.spec.ts`'s `seedBoardTask`
+comment records: `createTaskWithAgent` auto-starts a session, the start step
+carries `on_turn_complete: move_to_step review`, and the card leaves the column
+mid-assertion.
+
+**Seed helpers are copied, not imported.** `nextMRIID`, `seedMR`, `linkMR`,
+`ensureGitLabConfigured` and `seedBoardTask` are file-local and **unexported** in
+`mr-task-card-badge.spec.ts`. Each new spec defines its own local copies.
+`mr-task-card-badge.spec.ts` is not edited to export them, which is what keeps
+AC16 ("passes unmodified") literally true, and it matches the in-repo precedent:
+`mobile-mr-task-card-badge.spec.ts` already writes its own `seedBoardTaskWithMR`.
+Shared **constants** are different: import `GITLAB_HOST` and `GITLAB_PROJECT`
+from `e2e/helpers/gitlab.ts`.
+
+**Lint consequence the builder must respect.** The spec corrects an earlier draft
+here, and the correct mechanism is narrower than it looks. In
+`apps/web/eslint.config.mjs`, `sonarjs/no-identical-functions` sits in the global
+block (no `files`, no `ignores`), so it **is live on `e2e/**`** — the
+`e2e/**` entry in an `ignores` array belongs to the i18n guard block, and the
+`files: ["e2e/**/*.ts"]` override disables `max-lines` and
+`sonarjs/no-duplicate-string` but **not** `no-identical-functions`. It cannot fire
+across files, because ESLint sees one file at a time. So: copy each helper
+across files freely; **never write two copies of the same helper inside one
+file**, because `pnpm --filter @kandev/web lint` runs `eslint --max-warnings 0`.
+
+**The mock GitHub PR for E3, E6 and E7** comes from the existing mock-GitHub API
+client methods: `apiClient.mockGitHubReset()`, `apiClient.mockGitHubSetUser()`,
+then `apiClient.mockGitHubAssociateTaskPR({ task_id, owner, repo, pr_number,
+pr_url, pr_title, head_branch, base_branch, author_login, state })` — `state` is
+optional and is passed explicitly. **`mockGitHubAddPRs()` is the wrong call and
+must not be used**: it seeds the mock provider's PR *catalogue* and creates no
+task-to-PR association, so `taskPRs.byTaskId[taskId]` stays empty, `PRTaskIcon`
+renders nothing, and the PR-before-MR assertion can never run. The reference is
+`mr-task-card-badge.spec.ts`'s own `"AC30/AC37"` test; reading it does not modify
+it.
+
+**Every `mr-task-icon-*` accessor must be container-scoped** and may not use
+`.first()`. One task id can be emitted by two mounted rows on one route (sidebar
+plus board, or sidebar plus `/tasks` row). Scope to `app-sidebar`,
+`tasks-list-row`, or `task-card-<id>`. (AC19)
+
+`apps/web/e2e/tests/gitlab/mr-sidebar-badge.spec.ts` (new):
+
+- **E1** — On `/` (the board mounts the hydration owner), a task with one linked
+  open MR: inside `app-sidebar`, row located by `[data-task-row-id="<taskId>"]`,
+  `mr-task-icon-<taskId>` visible with `data-mr-count="1"` and
+  `data-mr-state="open"`. (AC1, AC19)
+- **E2** — Same route, task with no linked MR: inside `app-sidebar`,
+  `mr-task-icon-<taskId>` has count 0. (AC6)
+- **E3** — Task with both a mock GitHub PR and a linked MR: inside the sidebar
+  row, both visible, PR precedes MR by `compareDocumentPosition`. (AC2)
+
+`apps/web/e2e/tests/gitlab/mr-tasks-list-badge.spec.ts` (new):
+
+- **E4** — Navigate to `/tasks`, enable "Show task details" through the
+  `display-button` menu (the pattern in `task-listing-view-preferences.spec.ts`:
+  `getByTestId("display-button").click()` then
+  `getByText("Show task details", { exact: true }).click()`), locate the
+  `tasks-list-row` by title (the row carries **no task-id attribute**; only
+  `tasks-list-row-title` identifies it), assert `mr-task-icon-<taskId>` inside
+  that row. (AC8, AC19)
+- **E5** — Same task, details off: inside the row, both `pr-task-icon-<taskId>`
+  and `mr-task-icon-<taskId>` have count 0. (AC10)
+- **E6** — Task with both: inside the row, PR precedes MR. (AC9)
+
+`apps/web/e2e/tests/gitlab/mobile-mr-tasks-list-badge.spec.ts` (new):
+
+- **E7** — Mobile viewport, details on, task with both badges: the MR badge is
+  visible and `assertNoDocumentHorizontalOverflow` passes. Mirrors
+  `mobile-mr-task-card-badge.spec.ts`. (AC20)
+
+All seven scenarios run on `/` or `/tasks`. Neither route mounts
+`TaskPageContent`, so none is exposed to the two accepted hydration holes the
+spec records (an archived task at `/t/:taskId`, and
+`use-external-vcs-file-link.ts`'s already-shipped gated `useWorkspaceMRs(null)`).
+The builder must not attempt to work around either hole from the three production
+files in scope; in particular the sidebar must not gain its own `useWorkspaceMRs`
+call, which AC7 forbids.
+
+**Page object.** Extend `e2e/pages/app-sidebar-page.ts` (already anchored at
+`app-sidebar`) with a row-and-badge accessor. Do not add a parallel sidebar page
+object; `e2e/pages/sidebar-tasks-page.ts` is the shape to follow.
+
+---
+
+## Verification Results
+
+Pending. On completion, synchronize this section with each task's `## Results`:
+record exact commands and outcomes/counts, generated artifact paths, and
+cleanup/teardown evidence.
+
+---
+
+## Implementation Waves And Parallel Candidates
+
+The three production tasks touch disjoint files and share no schema, migration,
+generated contract, lockfile, or package-wide config, so they are genuine
+parallel candidates. **The default is sequential execution in the primary
+conversation.** Waves do not authorize subagents; only the user may ask for them
+after selecting the implementation model.
+
+```
+Wave 1 (parallel candidates — user authorization required):
+- [ ] [task-01-sidebar-mr-badge](task-01-sidebar-mr-badge.md)
+- [ ] [task-02-tasks-row-mr-badge](task-02-tasks-row-mr-badge.md)
+- [ ] [task-03-tasks-page-mr-hydration](task-03-tasks-page-mr-hydration.md)
+
+Wave 2:
+- [ ] [task-04-e2e-sidebar-badge](task-04-e2e-sidebar-badge.md)      (needs 01)
+- [ ] [task-05-e2e-tasks-list-badge](task-05-e2e-tasks-list-badge.md) (needs 02, 03)
+```
+
+Before any task, in a fresh worktree: `cd apps && pnpm install --frozen-lockfile`.
+`apps/node_modules/` is not shared across worktrees, and without it `vitest`,
+`eslint` and the commit hooks all fail.
+
+---
+
+## Open Questions
+
+None. The spec settles badge ordering (PR then MR, DOM order, all three
+surfaces), the `/tasks` flag question (one flag, renamed `showContributions`),
+coarse-pointer behaviour (the Radix tooltip is inherited unchanged), and the
+sidebar `prInfo` question (deliberately GitHub-only; an MR analogue is a backend
+projection change and is out of scope).

--- a/docs/plans/gitlab-mr-task-list-badges/task-01-sidebar-mr-badge.md
+++ b/docs/plans/gitlab-mr-task-list-badges/task-01-sidebar-mr-badge.md
@@ -1,0 +1,174 @@
+---
+id: "01-sidebar-mr-badge"
+title: "Sidebar task row renders the MR badge"
+status: pending
+wave: 1
+depends_on: []
+plan: "plan.md"
+spec: "../../specs/gitlab-mr-task-list-badges/spec.md"
+---
+
+# Task 01: Sidebar task row renders the MR badge
+
+Restructure the sidebar row's badge slot so the PR badge and the MR badge are
+siblings rather than alternatives, and mount `MRTaskIcon` after the PR badge and
+before the issue badge.
+
+## Why the current code cannot just be appended to
+
+`TaskPRIcon` in `apps/web/components/task/task-item.tsx` (~line 314) is two
+chained early returns:
+
+```tsx
+const hasStorePR = useAppStore((s) => !!taskId && (s.taskPRs.byTaskId[taskId]?.length ?? 0) > 0);
+if (hasStorePR) return <PRTaskIcon taskId={taskId!} />;
+if (!prInfo) return null;
+// ... prInfo fallback badge
+```
+
+Both `return`s exit the component. An `MRTaskIcon` appended below is unreachable
+for a task that has a PR, and unreachable for a task with neither a PR nor
+`prInfo` — which is exactly the GitLab-only task this feature exists to serve.
+
+## The `taskId` guard is load-bearing
+
+`taskId` is optional on this component (`taskId?: string`), so `hasStorePR` is
+**not** a usable guard for the MR branch: it is `false` both when there is no
+task id and when there is a task id with no PRs. The MR branch needs its own
+`taskId` truthiness guard.
+
+Writing `<MRTaskIcon taskId={taskId!} />` — the same non-null-assertion shape the
+PR branch beside it already uses — would invoke the component with `undefined`,
+hit `useTaskMRs`' internal guard, render `null`, and **pass a
+"no element present" assertion while breaking AC5** and adding the store
+subscription AC18 exists to prevent. The guard must prevent the *call*.
+
+## Acceptance
+
+1. A sidebar row with a `taskId` whose task has at least one MR in the active
+   workspace renders `MRTaskIcon`; with a PR as well, both render, PR first in
+   DOM order, and the MR badge precedes `IssueTaskIcon`. Full title-row order:
+   title, autopilot, pinned, **PR, MR**, issue, agent-error, remote-cloud,
+   archived chip. (AC1, AC2, AC3, AC4, AC22)
+2. A row rendered without a `taskId` renders no MR badge **and does not invoke
+   `MRTaskIcon` at all**. A row whose task has no MRs contains no element whose
+   `data-testid` starts with `mr-task-icon-`. (AC5, AC6)
+3. No file under `apps/web/components/task/` or
+   `apps/web/components/app-sidebar/` imports `useWorkspaceMRs`; MR reads go
+   through `useTaskMRs` and nothing added here allocates a fresh array or object.
+   (AC7, AC18)
+
+## Verification
+
+```
+cd apps && pnpm install --frozen-lockfile \
+  && pnpm --filter @kandev/web test -- components/task/task-item.test.tsx \
+  && pnpm --filter @kandev/web lint \
+  && cd web && pnpm run typecheck && pnpm run i18n:check
+```
+
+`lint` runs `eslint --max-warnings 0`. `task-item.tsx` measures **591 effective
+lines** against the 600-line `max-lines` limit (`skipBlankLines`,
+`skipComments`), so the restructure fits inline with margin. Confirm the file
+gains no new warning; it already carries one `max-lines-per-function` disable on
+`TaskItem` and must not gain a second.
+
+## Files likely touched
+
+- `apps/web/components/task/task-item.tsx`
+- `apps/web/components/task/task-item.test.tsx`
+
+Optionally, only if the inline shape pushes `max-lines` over: **one** new sibling
+under `apps/web/components/task/` for the badge-pair extraction. The spec's
+Constraints permit at most one new file in total across tasks 01 and 03; if both
+this task and task 03 turn out to need one, that is a genuine second finding and
+routes back to the spec rather than being absorbed by a second file. Any new file
+inherits AC7 and AC18.
+
+## Dependencies
+
+None.
+
+## Parallelism
+
+`parallel-safe` with task 02 and task 03. Disjoint files; no shared schema,
+migration, generated contract, lockfile, or package-wide config. Execution is
+still sequential by default in the primary conversation.
+
+## Inputs
+
+- Spec: "The sidebar early-return trap", "Selection and ordering",
+  "Nil, empty, and error behaviour", AC1 to AC7, AC18, AC22
+- Plan: Frontend section 1; Tests table rows U1 to U5, U10, U11
+- Reference shape: `apps/web/components/kanban-card-content.tsx:144-152` — the
+  already-correct `PRTaskIcon` then `MRTaskIcon` pair inside
+  `kanban-card-title-row` (`flex items-center gap-1 min-w-0`). It does **not**
+  change (AC16).
+- `MRTaskIcon` is consumed exactly as it ships and
+  `apps/web/components/gitlab/mr-task-icon.tsx` is **not** modified (AC15); no
+  file under `apps/web/components/github/` is modified (AC14).
+
+### Unit scenarios to write (U1 to U5, U10, U11)
+
+`components/task/task-item.test.tsx` already renders `TaskItem` inside
+`StateProvider` + `TooltipProvider` via a local `renderTaskItem` helper.
+`StateProvider` accepts an `initialState` prop, so seed the store through it:
+`taskPRs.byTaskId`, `taskMRs.byWorkspaceId`, and `workspaces.activeId`.
+
+- **U1** — PR and MR seeded for `t1`, `workspaces.activeId = "ws1"`. Both
+  `pr-task-icon-t1` and `mr-task-icon-t1` present; `compareDocumentPosition` puts
+  the PR first. (AC2)
+- **U2** — MR only, no PR, no `prInfo`. `mr-task-icon-t1` present,
+  `pr-task-icon-t1` absent. **This is the case the early return makes impossible
+  today**, so it must fail before the fix. (AC3)
+- **U3** — No store PR, `prInfo={{ number: 7, state: "Open" }}`, one MR. Both
+  render, PR first. (AC4)
+- **U4** — No `taskId`, MRs seeded for some other id. Assert **both** clauses;
+  they are not equivalent and the weaker one alone is satisfied by code that
+  violates the AC. (a) no `mr-task-icon-*` element. (b) **`MRTaskIcon` is not
+  invoked**, via a `vi.fn()`-backed module mock. Clause (b) is load-bearing.
+
+  **No in-repo precedent for clause (b) exists — write it fresh.**
+  `components/kanban-card-content.test.tsx` is the precedent for **module-level
+  interception only**: it replaces the module with a plain stub
+  (`MRTaskIcon: () => <span data-testid="mr-task-icon" />`), and a stub records no
+  calls. No test under `apps/web/components/` mocks a component module with
+  `vi.fn()` and then asserts a call count. Copy that file's `vi.mock` placement
+  and factory shape; do **not** copy its stub body. Required shape:
+
+  ```tsx
+  vi.mock("@/components/gitlab/mr-task-icon", () => ({ MRTaskIcon: vi.fn(() => null) }));
+  // ...
+  expect(MRTaskIcon).not.toHaveBeenCalled();
+  ```
+
+  Because this mock is module-scoped, U4 likely belongs in its own describe file
+  or must be arranged so the other scenarios still render the real component.
+  (AC5, AC18)
+- **U5** — PR only, no MRs. No `mr-task-icon-*` element. (AC6)
+- **U10** — One MR, a store PR, and `issueInfo={{ url: "…", number: 42 }}`.
+  Assert the full **PR, MR, issue** order via `compareDocumentPosition`, not just
+  the adjacent pair. (AC22)
+- **U11** — MR seeded at `taskMRs.byWorkspaceId["ws1"]["t1"]` but
+  `workspaces.activeId = null`. No `mr-task-icon-*` element. This observes AC21's
+  second clause, which no other scenario reaches. (AC21)
+
+Do not go looking for id-less rows in the live sidebar; **there are none**.
+`TaskItem`'s only production importer is `components/task/task-switcher-row.tsx`,
+whose single mount passes `taskId={task.id}`. AC5 is a defensive contract on the
+optional prop, exercised synthetically by U4.
+
+## Output contract
+
+Report: summary; files changed (reconciled against the actual diff); tests run
+with exact commands and pass/fail counts; blockers; risks. Set this task's
+`status` to `in_progress` at start and `done` at finish, update `## Results`
+below, and synchronize the Wave 1 checkbox and `## Verification Results` in
+`plan.md`.
+
+## Results
+
+Pending. Before marking this task done, replace this with every exact command
+actually run and its outcome/count, generated artifact paths, and cleanup or
+teardown evidence. Record security/trust and external side-effect boundaries when
+applicable, or explicitly state `None`.

--- a/docs/plans/gitlab-mr-task-list-badges/task-02-tasks-row-mr-badge.md
+++ b/docs/plans/gitlab-mr-task-list-badges/task-02-tasks-row-mr-badge.md
@@ -1,0 +1,149 @@
+---
+id: "02-tasks-row-mr-badge"
+title: "/tasks rich row renders the MR badge"
+status: pending
+wave: 1
+depends_on: []
+plan: "plan.md"
+spec: "../../specs/gitlab-mr-task-list-badges/spec.md"
+---
+
+# Task 02: `/tasks` rich row renders the MR badge
+
+Add `MRTaskIcon` to `PrimaryTaskLine` in
+`apps/web/app/tasks/rich-task-list-row.tsx`, and rename the flag that gates the
+badge slot so it no longer names one provider.
+
+## The three edits
+
+**1. Rename `showPullRequest` to `showContributions`.** The prop is file-local:
+declared on `PrimaryTaskLine` (~line 30) and passed only within this file —
+`true` from `RichTaskContent` (~line 129), `false` from
+`TaskListRowPrimaryContent`'s compact path (~line 174). One flag gates both
+badges. There is no second flag and no independent per-provider toggle: a user
+who turns on "Show task details" is asking for the row's remote contributions,
+not for GitHub's specifically. It is a **required** prop and must not be given a
+default value. No `showPullRequest` identifier may remain in the file. (AC10,
+AC11)
+
+**2. Mount the MR badge inside the existing wrapper.** The PR badge already sits
+in a `<span>` that stops `click` and `pointerdown` propagation so tapping the
+badge cannot navigate the row. Put `<MRTaskIcon taskId={task.id} />` inside that
+**same** wrapper, after `PRTaskIcon` — not in a second copy of it, so the two
+badges cannot drift apart on interaction behaviour. (AC8, AC9)
+
+**3. Give that wrapper `inline-flex items-center gap-1`.** It carries **no
+`className` at all today**, because it has only ever held a single child, so the
+row's own `gap-2` was the only separation it needed. Two children inside it would
+render with **no separation whatsoever**.
+
+`gap-1` is not a new number: it is what both surfaces that already render badges
+side by side use — the Kanban card's `kanban-card-title-row`
+(`flex items-center gap-1 min-w-0`) and the sidebar title row
+(`flex items-center gap-1 min-w-0`). Matching it keeps PR-to-MR separation
+identical on all three surfaces.
+
+Apply the class **unconditionally**. That is what keeps AC23 compatible with AC6
+rather than in tension with it: an unconditional class adds no element and
+reserves no space in the no-MR case, whereas a conditional one would. Do **not**
+add `shrink-0` (both `PRTaskIcon` and `MRTaskIcon` already carry it on their own
+roots), and do **not** alter the row's existing `gap-2` between the title and the
+badge wrapper. (AC23)
+
+AC23 is a separate criterion from AC9 for a reason: AC9 observes only which
+elements sit inside the wrapper and in what order, so an implementation leaving
+the wrapper unclassed would satisfy every other criterion while shipping two
+touching badges on `/tasks` and separated badges on the other two surfaces.
+
+## Acceptance
+
+1. With contributions shown and at least one MR for the task in the active
+   workspace, the row renders `MRTaskIcon`; with a PR as well, both render inside
+   the single propagation-stopping wrapper, PR before MR in DOM order. (AC8, AC9)
+2. That wrapper carries `inline-flex items-center gap-1` unconditionally —
+   present whether or not an MR badge renders. (AC23)
+3. On the compact path the row renders neither badge, the gating boolean is named
+   `showContributions`, it has no default value, and no `showPullRequest`
+   identifier remains in the file. (AC10, AC11)
+
+## Verification
+
+```
+cd apps && pnpm install --frozen-lockfile \
+  && pnpm --filter @kandev/web test -- app/tasks/rich-task-list-row.test.tsx \
+  && pnpm --filter @kandev/web lint \
+  && cd web && pnpm run typecheck && pnpm run i18n:check
+```
+
+Also confirm no `showPullRequest` identifier survives:
+
+```
+cd apps/web && grep -rn "showPullRequest" app/tasks/rich-task-list-row.tsx
+```
+
+(expects no output).
+
+`rich-task-list-row.tsx` measures **168 effective lines** of the 600-line limit,
+so size is not a constraint here.
+
+`app/tasks/rich-task-list-row.tsx` **is** on `i18nGuardFiles` in
+`apps/web/eslint.i18n.options.mjs`, so `i18next/no-literal-string` is a
+whole-file **error** on it, not merely a changed-lines ratchet. This task adds no
+string literal, so no allowlist entry is needed and none may be added. (AC17)
+
+## Files likely touched
+
+- `apps/web/app/tasks/rich-task-list-row.tsx`
+- `apps/web/app/tasks/rich-task-list-row.test.tsx` (new test file)
+
+## Dependencies
+
+None.
+
+## Parallelism
+
+`parallel-safe` with task 01 and task 03. Disjoint files. Execution is still
+sequential by default in the primary conversation.
+
+## Inputs
+
+- Spec: "Prop naming", "Responsive and coarse-pointer behaviour",
+  "Nil, empty, and error behaviour", AC8 to AC11, AC23
+- Plan: Frontend section 2; Tests table rows U6, U7
+- `apps/web/components/gitlab/mr-task-icon.tsx` is **not** modified (AC15) and no
+  file under `apps/web/components/github/` is modified (AC14).
+- `MRTaskIcon` returns `null` when the task has no MRs, so it is safe to render
+  unconditionally inside the gated wrapper.
+
+### Unit scenarios to write (U6, U7)
+
+`TaskListRowPrimaryContent` is exported from `rich-task-list-row.tsx`, so it can
+be rendered directly. Follow `app/tasks/tasks-list-view.test.tsx`'s shape: it
+renders under `StateProvider` + `TooltipProvider` with **no mocks**, and has local
+`makeTask` / `props` builders. Seed MRs and PRs through `StateProvider`'s
+`initialState` (`taskPRs.byTaskId`, `taskMRs.byWorkspaceId`,
+`workspaces.activeId`).
+
+- **U6** — Seeded PR and MR, `showTaskDetails` true (the rich path, which passes
+  `showContributions` as `true`). Both badges render **inside the single
+  wrapper**, PR first by `compareDocumentPosition`, and the wrapper carries all
+  three of `inline-flex`, `items-center`, `gap-1`. Assert the wrapper's classes
+  directly, not just the badge order — that is the part AC9 cannot observe.
+  (AC8, AC9, AC23)
+- **U7** — Same store, `showTaskDetails` false (the compact path). Neither
+  `pr-task-icon-*` nor `mr-task-icon-*` is present. (AC10)
+
+## Output contract
+
+Report: summary; files changed (reconciled against the actual diff); tests run
+with exact commands and pass/fail counts; blockers; risks. Set this task's
+`status` to `in_progress` at start and `done` at finish, update `## Results`
+below, and synchronize the Wave 1 checkbox and `## Verification Results` in
+`plan.md`.
+
+## Results
+
+Pending. Before marking this task done, replace this with every exact command
+actually run and its outcome/count, generated artifact paths, and cleanup or
+teardown evidence. Record security/trust and external side-effect boundaries when
+applicable, or explicitly state `None`.

--- a/docs/plans/gitlab-mr-task-list-badges/task-03-tasks-page-mr-hydration.md
+++ b/docs/plans/gitlab-mr-task-list-badges/task-03-tasks-page-mr-hydration.md
@@ -1,0 +1,202 @@
+---
+id: "03-tasks-page-mr-hydration"
+title: "/tasks page hydrates workspace MRs unconditionally"
+status: pending
+wave: 1
+depends_on: []
+plan: "plan.md"
+spec: "../../specs/gitlab-mr-task-list-badges/spec.md"
+---
+
+# Task 03: `/tasks` page hydrates workspace MRs unconditionally
+
+`/tasks` becomes an owner of GitLab MR hydration for the active workspace,
+because it is the surface whose own row renders the badge (task 02). The sidebar
+does **not** become one.
+
+## The trap: do not mirror the GitHub line
+
+`TasksPageClient` already owns its GitHub hydration, gated on the same setting
+that gates the badge (`apps/web/app/tasks/tasks-page-client.tsx:529`):
+
+```ts
+useWorkspacePRs(showTaskDetails ? s.activeWorkspaceId : null);
+```
+
+**Mirroring that expression for GitLab is a cross-surface data-loss bug.** The
+two hooks do not have the same null behaviour:
+
+- `useWorkspacePRs(null)` clears a local ref and touches no store state.
+- `useWorkspaceMRs(null)` calls `resetTaskMRs()` **with no argument**, and
+  `resetTaskMRs` with no argument assigns `taskMRs.byWorkspaceId = {}` — every
+  workspace, wiped. See `apps/web/hooks/domains/gitlab/use-task-mr.ts:23-32`.
+
+`AppSidebar` is mounted in the root layout and is therefore on screen on
+`/tasks`. The gated form would blank the sidebar's MR badges (and every other MR
+consumer's data) for the entire time a user sits on `/tasks` with task details
+switched off, and would re-wipe on every render pass that re-runs the effect. The
+wipe is not confined to the page that caused it.
+
+## The edit
+
+Two effective lines:
+
+```ts
+import { useWorkspaceMRs } from "@/hooks/domains/gitlab/use-task-mr";
+// ... inside TasksPageClient, beside the existing useWorkspacePRs call:
+useWorkspaceMRs(s.activeWorkspaceId);
+```
+
+Unconditional, matching `apps/web/components/kanban-board.tsx:321`'s existing
+unconditional call rather than `useWorkspacePRs`'s gated one. The cost is one
+`GET` per workspace per effect run, which is not wasted even when task details
+are off: the sidebar is mounted on that route and renders MR badges from the same
+store.
+
+Passing `null` because `s.activeWorkspaceId` is itself `null` is **permitted and
+correct**, and is not the case the rule forbids: with no active workspace,
+`useTaskMRs` returns `EMPTY_MRS` for every task and no surface can render an MR
+badge, so the clear takes nothing away. `kanban-board.tsx` already does exactly
+this. The forbidden form is different in kind — it passes `null` while a
+workspace is active and other surfaces are displaying that workspace's MRs.
+(AC21)
+
+Do not write a request-count assertion anywhere. The app root renders inside
+`<StrictMode>` (`apps/web/src/main.tsx`) and the hook's cleanup clears
+`fetchedRef`, so React's development-only effect replay issues a **second** `GET`
+on first mount. That is existing behaviour shared with all four current call
+sites and does not occur in a production build.
+
+## Check `max-lines` before assuming the edit is free
+
+`tasks-page-client.tsx` measures **597 effective lines of the 600 allowed**
+(`max-lines`, `skipBlankLines`, `skipComments`, under
+`eslint --max-warnings 0`). It is the tightest of the three files despite being
+the smaller by raw count (642 vs `task-item.tsx`'s 660). The edit above is
+exactly two effective lines, landing it at 599. **That fits, with one line to
+spare — verify it with an actual `eslint` run rather than trusting this figure.**
+
+If it does go over, the remedy is an extraction into a sibling under
+`app/tasks/`. The spec's Constraints permit at most **one** new file across this
+task and task 01 combined; if both turn out to need one, that is a genuine second
+finding and routes back to the spec.
+
+**Do not resolve it with an `eslint-disable`.** The file carries none today, and
+silencing a size warning to land a two-line hook call trades a real signal for
+convenience.
+
+## Acceptance
+
+1. `TasksPageClient` calls `useWorkspaceMRs` with `s.activeWorkspaceId`
+   unconditionally, with the argument gated on neither `tasksListShowDetails` nor
+   any other setting. (AC12, AC21)
+2. `useWorkspaceMRs(null)` clearing every workspace's entry under
+   `taskMRs.byWorkspaceId` is pinned by a test that seeds two workspaces. This
+   pins the existing behaviour AC12 exists to route around, so a future change to
+   the hook cannot silently make the gated form look safe. (AC13)
+3. `apps/web/app/tasks/tasks-page-client.tsx` gains no new lint warning, in
+   particular no `max-lines` warning, and no `eslint-disable`.
+
+## Verification
+
+```
+cd apps && pnpm install --frozen-lockfile \
+  && pnpm --filter @kandev/web test -- hooks/domains/gitlab/use-task-mr.test.ts \
+  && pnpm --filter @kandev/web lint \
+  && cd web && pnpm run typecheck && pnpm run i18n:check
+```
+
+Plus, explicitly, the size check that this task's third acceptance condition
+turns on:
+
+```
+cd apps/web && npx eslint app/tasks/tasks-page-client.tsx
+```
+
+(expects zero output; `--max-warnings 0` means any `max-lines` warning is a
+failure).
+
+Add the U9 test file to the `test` invocation once written.
+
+`app/tasks/tasks-page-client.tsx` **is** on `i18nGuardFiles` in
+`apps/web/eslint.i18n.options.mjs`, so `i18next/no-literal-string` is a
+whole-file **error** on it. This task adds no string literal, so no allowlist
+entry is needed and none may be added. (AC17)
+
+## Files likely touched
+
+- `apps/web/app/tasks/tasks-page-client.tsx`
+- `apps/web/hooks/domains/gitlab/use-task-mr.test.ts` (U8)
+- `apps/web/app/tasks/tasks-page-client.mr-hydration.test.tsx` (U9, new — see the
+  risk note below)
+
+## Dependencies
+
+None. Task 02 renders the badge this hydration feeds, but neither task blocks the
+other: task 03's tests observe the hook argument, not the badge.
+
+## Parallelism
+
+`parallel-safe` with task 01 and task 02. Disjoint files. Execution is still
+sequential by default in the primary conversation.
+
+## Inputs
+
+- Spec: "Hydration ownership" in full, including "`/tasks` becomes an owner. The
+  gated form is forbidden." and "The sidebar does not become an owner"; AC12,
+  AC13, AC21
+- Plan: Frontend section 3; Tests table rows U8, U9
+- Reference: `apps/web/components/kanban-board.tsx:321` — the existing
+  unconditional call this one matches.
+
+### Unit scenarios to write (U8, U9)
+
+- **U8 — `useWorkspaceMRs(null)` wipes every workspace (AC13).** Seed
+  `taskMRs.byWorkspaceId["ws-a"]` and `["ws-b"]`, render the hook with `null`,
+  assert **both** are gone. `hooks/domains/gitlab/use-task-mr.test.ts` already has
+  a `describe("useWorkspaceMRs")` block with `renderHook` scaffolding at ~line 92
+  and a cleanup block at ~line 212; add there if not already covered. This is the
+  straightforward half of the task.
+
+- **U9 — `TasksPageClient` hydration argument (AC12).** With
+  `tasksListShowDetails` false and an active workspace, `useWorkspaceMRs` is
+  called with the workspace id, **not** `null`.
+
+  **This is the one genuinely uncertain test in the plan, and the estimate should
+  not be trusted blindly.** `tasks-page-client.tsx` is a 642-line component with
+  many hooks, and no existing test renders it: `app/tasks/tasks-page-fetch-policy.test.ts`
+  is a pure-function test of `shouldSkipInitialTasksFetch`, and
+  `app/tasks/tasks-list-view.test.tsx` renders the *view*, not the page client.
+  So there is no established mocking baseline for this component to copy.
+
+  Preferred approach: a new `app/tasks/tasks-page-client.mr-hydration.test.tsx`
+  that mocks `@/hooks/domains/gitlab/use-task-mr` with `vi.fn()`, renders
+  `TasksPageClient` under `StateProvider` with `userSettings.tasksListShowDetails`
+  false and `workspaces.activeId` set, and asserts
+  `expect(useWorkspaceMRs).toHaveBeenCalledWith("ws1")`. Expect to mock several
+  further modules to get it to mount; that is the cost, and it is acceptable
+  because AC12 is the criterion protecting against a real data-loss bug.
+
+  If the render turns out to need so much mocking that the test asserts more about
+  the mocks than the code, **stop and report it** rather than silently downgrading
+  to a source-text assertion. The fallback the spec's Constraints already permit is
+  an extraction: move the two-line hydration decision into a tiny sibling under
+  `app/tasks/` and unit-test that directly — which also solves the `max-lines`
+  pressure above, using the single new-file allowance for both purposes at once.
+  That is a design choice worth surfacing, not making silently.
+
+## Output contract
+
+Report: summary; files changed (reconciled against the actual diff); tests run
+with exact commands and pass/fail counts; the measured `eslint` result on
+`tasks-page-client.tsx`; whether the U9 fallback was taken and why; blockers;
+risks. Set this task's `status` to `in_progress` at start and `done` at finish,
+update `## Results` below, and synchronize the Wave 1 checkbox and
+`## Verification Results` in `plan.md`.
+
+## Results
+
+Pending. Before marking this task done, replace this with every exact command
+actually run and its outcome/count, generated artifact paths, and cleanup or
+teardown evidence. Record security/trust and external side-effect boundaries when
+applicable, or explicitly state `None`.

--- a/docs/plans/gitlab-mr-task-list-badges/task-04-e2e-sidebar-badge.md
+++ b/docs/plans/gitlab-mr-task-list-badges/task-04-e2e-sidebar-badge.md
@@ -1,0 +1,176 @@
+---
+id: "04-e2e-sidebar-badge"
+title: "E2E: sidebar MR badge"
+status: pending
+wave: 2
+depends_on: ["01-sidebar-mr-badge"]
+plan: "plan.md"
+spec: "../../specs/gitlab-mr-task-list-badges/spec.md"
+---
+
+# Task 04: E2E for the sidebar MR badge
+
+New spec `apps/web/e2e/tests/gitlab/mr-sidebar-badge.spec.ts`, plus a
+row-and-badge accessor on the existing sidebar page object.
+
+E2E is **required**: `apps/web/**` is touched and none of the files are on the
+Testing step's exemption allowlist.
+
+## Scenarios
+
+All three run on `/`, where `components/kanban-board.tsx:321` mounts the
+unconditional `useWorkspaceMRs` owner. Neither this route nor task 05's mounts
+`TaskPageContent`, so neither is exposed to the two hydration holes the spec
+records and accepts.
+
+- **E1 — Sidebar shows the badge.** A task with one linked open MR. Scoped to
+  `app-sidebar`, row located by `[data-task-row-id="<taskId>"]`,
+  `mr-task-icon-<taskId>` is visible with `data-mr-count="1"` and
+  `data-mr-state="open"`. (AC1, AC19)
+- **E2 — Sidebar shows no badge without an MR.** Same route, task with no linked
+  MR. Inside `app-sidebar`, `mr-task-icon-<taskId>` has count 0. (AC6)
+- **E3 — Sidebar shows PR before MR.** A task with both a mock GitHub PR and a
+  linked MR; inside the sidebar row, both badges visible and PR precedes MR by
+  `compareDocumentPosition`. (AC2)
+
+## Four things that are easy to get wrong here
+
+**1. Seed tasks with NO agent.** `createTaskWithAgent` auto-starts a session, the
+Kanban template's start step carries `on_turn_complete: move_to_step review`, and
+the card leaves the start column the instant the mock agent's turn ends — which
+detaches elements mid-assertion and burns the full timeout. The badge is a pure
+function of the task's linked MRs, so an agent turn adds nothing.
+`mr-task-card-badge.spec.ts`'s `seedBoardTask` comment records this at length.
+
+**2. Copy the seed helpers; do not import them.** `nextMRIID`, `seedMR`,
+`linkMR`, `ensureGitLabConfigured` and `seedBoardTask` are file-local and
+**unexported** in `e2e/tests/gitlab/mr-task-card-badge.spec.ts`. Define local
+copies seeded from that file's versions. That file is **not** edited to export
+them, which is what keeps AC16 ("passes unmodified") literally true, and it
+matches the in-repo precedent: `mobile-mr-task-card-badge.spec.ts` already writes
+its own `seedBoardTaskWithMR` and imports only constants.
+
+Shared **constants** are different: import `GITLAB_HOST` and `GITLAB_PROJECT`
+from `e2e/helpers/gitlab.ts`, as the existing specs do. Do not re-declare them.
+
+**Lint consequence.** `sonarjs/no-identical-functions` sits in the **global**
+block of `apps/web/eslint.config.mjs` (no `files`, no `ignores`), so it **is live
+on `e2e/**`**. The `e2e/**` entry in an `ignores` array belongs to the i18n guard
+block, and the `files: ["e2e/**/*.ts"]` override disables `react-hooks/*`,
+`max-lines`, `max-lines-per-function` and `sonarjs/no-duplicate-string` — but
+**not** `no-identical-functions`. It cannot fire across files, because ESLint sees
+one file at a time. So: copy helpers across files freely; **never write two copies
+of the same helper inside one file**, because `pnpm --filter @kandev/web lint`
+runs `eslint --max-warnings 0`.
+
+**3. E3's GitHub PR comes from the association call, not the catalogue call.**
+Use `apiClient.mockGitHubReset()`, then `apiClient.mockGitHubSetUser("test-user")`,
+then `apiClient.mockGitHubAssociateTaskPR({ task_id, owner: "testorg",
+repo: "testrepo", pr_number, pr_url, pr_title, head_branch, base_branch,
+author_login: "test-user", state: "open" })`. `state` is optional and is passed
+explicitly so the seeded PR's state is not left implicit.
+
+**`mockGitHubAddPRs()` is the wrong call and must not be used.** It posts to
+`POST /api/v1/github/mock/prs`, which seeds the mock provider's PR *catalogue*
+(what pickers and listings read) and creates **no task-to-PR association**. A
+scenario using it leaves `taskPRs.byTaskId[taskId]` empty, so `PRTaskIcon` renders
+nothing and E3's PR-before-MR assertion can never run.
+`mockGitHubAssociateTaskPR()` posts to `POST /api/v1/github/mock/task-prs` and is
+what populates the association the badge reads; no catalogue call is needed
+alongside it.
+
+The reference is `mr-task-card-badge.spec.ts`'s own test
+`"AC30/AC37: a linked PR and MR both render, PR before MR, and the badge tooltip
+names a non-open state"`. Reading that file does not modify it, so AC16 stays
+literally true.
+
+**4. Scope every `mr-task-icon-*` accessor to a container, and never use
+`.first()`.** One task id can be emitted by two mounted rows on one route
+(sidebar plus board). Scope to `app-sidebar`, `tasks-list-row`, or
+`task-card-<id>`. `.first()` papers over the duplicate instead of resolving it.
+The identical hazard already exists for `pr-task-icon-*` and is recorded in
+`e2e/tests/pr/pr-status-badge.spec.ts`. (AC19)
+
+## Page object
+
+Extend `apps/web/e2e/pages/app-sidebar-page.ts` with a row-and-badge accessor.
+That class is already anchored at `page.getByTestId("app-sidebar")`, which is
+the container AC19 requires. **Do not add a parallel sidebar page object.**
+`apps/web/e2e/pages/sidebar-tasks-page.ts` is the shape to follow: it exposes a
+`row(taskId)` accessor that scopes into `sidebar-task-item` and is careful about
+which sidebar root it anchors to.
+
+Note the sidebar row's own id attribute is `data-task-row-id` (set on the
+`sidebar-task-item` element in `task-item.tsx`), which is what E1 locates by.
+
+## Acceptance
+
+1. `apps/web/e2e/tests/gitlab/mr-sidebar-badge.spec.ts` exists and E1, E2 and E3
+   pass.
+2. `apps/web/e2e/pages/app-sidebar-page.ts` gains the row-and-badge accessor; no
+   new sidebar page object is created.
+3. `e2e/tests/gitlab/mr-task-card-badge.spec.ts` is **unmodified** and passes
+   (AC16); no file under `apps/web/components/github/` is modified (AC14); and
+   `apps/web/components/gitlab/mr-task-icon.tsx` is unmodified (AC15).
+
+## Verification
+
+```
+cd apps && pnpm install --frozen-lockfile \
+  && cd web && pnpm e2e:raw -- e2e/tests/gitlab/mr-sidebar-badge.spec.ts \
+  && pnpm e2e:raw -- e2e/tests/gitlab/mr-task-card-badge.spec.ts
+```
+
+The second command is the AC16 non-regression check and must pass with that file
+untouched. Then:
+
+```
+cd apps && pnpm --filter @kandev/web lint
+```
+
+`--max-warnings 0`, so a duplicated helper **within** the new spec file fails the
+build.
+
+## Files likely touched
+
+- `apps/web/e2e/tests/gitlab/mr-sidebar-badge.spec.ts` (new)
+- `apps/web/e2e/pages/app-sidebar-page.ts`
+
+Explicitly **not** touched: `e2e/tests/gitlab/mr-task-card-badge.spec.ts`,
+`e2e/tests/pr/pr-status-badge.spec.ts`, `e2e/helpers/gitlab.ts` (imported from,
+not edited).
+
+## Dependencies
+
+Task 01. The sidebar badge must render before these scenarios can pass.
+
+## Parallelism
+
+`parallel-safe` with task 05 once both their dependencies have landed: disjoint
+spec files, disjoint page objects.
+
+## Inputs
+
+- Spec: "E2E (Playwright, required)" in full, including "Where the seed helpers
+  come from" and "Where the mock GitHub PR comes from"; "Accessibility and
+  duplicate mounts"; AC1, AC2, AC6, AC16, AC19
+- Plan: E2E Tests section
+- Patterns: `e2e/tests/gitlab/mr-task-card-badge.spec.ts` (read, do not edit),
+  `e2e/tests/gitlab/mobile-mr-task-card-badge.spec.ts` (the local-copy
+  precedent), `e2e/pages/sidebar-tasks-page.ts` (page-object shape)
+
+## Output contract
+
+Report: summary; files changed (reconciled against the actual diff, **including
+any existing spec modified as E2E evidence**); tests run with exact commands and
+pass/fail counts; blockers; risks. Set this task's `status` to `in_progress` at
+start and `done` at finish, update `## Results` below, and synchronize the Wave 2
+checkbox and `## Verification Results` in `plan.md`.
+
+## Results
+
+Pending. Before marking this task done, replace this with every exact command
+actually run and its outcome/count, generated artifact paths, and cleanup or
+teardown evidence (including temporary capture-spec removal and
+`git diff --check` when used). Record security/trust and external side-effect
+boundaries when applicable, or explicitly state `None`.

--- a/docs/plans/gitlab-mr-task-list-badges/task-05-e2e-tasks-list-badge.md
+++ b/docs/plans/gitlab-mr-task-list-badges/task-05-e2e-tasks-list-badge.md
@@ -1,0 +1,184 @@
+---
+id: "05-e2e-tasks-list-badge"
+title: "E2E: /tasks list MR badge, desktop and mobile"
+status: pending
+wave: 2
+depends_on: ["02-tasks-row-mr-badge", "03-tasks-page-mr-hydration"]
+plan: "plan.md"
+spec: "../../specs/gitlab-mr-task-list-badges/spec.md"
+---
+
+# Task 05: E2E for the `/tasks` list MR badge
+
+Two new specs: `apps/web/e2e/tests/gitlab/mr-tasks-list-badge.spec.ts` (E4 to E6)
+and `apps/web/e2e/tests/gitlab/mobile-mr-tasks-list-badge.spec.ts` (E7).
+
+E2E is **required**: `apps/web/**` is touched and none of the files are on the
+Testing step's exemption allowlist.
+
+## Scenarios
+
+All four run on `/tasks`, whose unconditional `useWorkspaceMRs` owner task 03
+adds. The route does not mount `TaskPageContent`, so none of these is exposed to
+the two hydration holes the spec records and accepts.
+
+`mr-tasks-list-badge.spec.ts`:
+
+- **E4 — Rich row shows the badge.** Navigate to `/tasks`, enable "Show task
+  details", locate the `tasks-list-row`, assert `mr-task-icon-<taskId>` inside
+  that row. (AC8, AC19)
+- **E5 — Compact row shows neither badge.** Same task, details off: inside the
+  row, both `pr-task-icon-<taskId>` and `mr-task-icon-<taskId>` have count 0.
+  (AC10)
+- **E6 — Rich row shows PR before MR.** Task with both; inside the row, PR
+  precedes MR by `compareDocumentPosition`. (AC9)
+
+`mobile-mr-tasks-list-badge.spec.ts`:
+
+- **E7 — Mobile row.** Mobile viewport, details on, task with both badges: the MR
+  badge is visible and `assertNoDocumentHorizontalOverflow` passes. Mirrors
+  `e2e/tests/gitlab/mobile-mr-task-card-badge.spec.ts`. (AC20)
+
+## Five things that are easy to get wrong here
+
+**1. `tasks-list-row` carries no task-id attribute.** The element at
+`apps/web/app/tasks/tasks-list-view.tsx:333` has `data-testid="tasks-list-row"`
+and `data-level`, but **no per-task id**. The only per-row identifier is the
+title, via `data-testid="tasks-list-row-title"`. Locate the row by filtering on
+its title text. Do not go looking for a `data-task-id` on this row; there is none,
+and its absence is not a bug to fix here.
+
+**2. Toggling "Show task details" goes through the display menu.** Follow
+`e2e/tests/**/task-listing-view-preferences.spec.ts`:
+
+```ts
+await page.getByTestId("display-button").click();
+await page.getByText("Show task details", { exact: true }).click();
+```
+
+**3. Seed tasks with NO agent**, for the reason `mr-task-card-badge.spec.ts`'s
+`seedBoardTask` comment records: `createTaskWithAgent` auto-starts a session and
+the task transitions out from under the assertion. The badge is a pure function of
+the task's linked MRs.
+
+**4. Copy the seed helpers; do not import them.** `nextMRIID`, `seedMR`,
+`linkMR`, `ensureGitLabConfigured` and `seedBoardTask` are file-local and
+**unexported** in `mr-task-card-badge.spec.ts`. Each of the two new spec files
+defines its own local copies. That file is **not** edited to export them, which
+keeps AC16 ("passes unmodified") literally true, and it matches
+`mobile-mr-task-card-badge.spec.ts`'s existing precedent.
+
+Import `GITLAB_HOST` and `GITLAB_PROJECT` from `e2e/helpers/gitlab.ts`; do not
+re-declare those constants.
+
+**Lint consequence.** `sonarjs/no-identical-functions` sits in the **global**
+block of `apps/web/eslint.config.mjs` (no `files`, no `ignores`), so it **is live
+on `e2e/**`** — the `e2e/**` entry in an `ignores` array belongs to the i18n guard
+block, and the `files: ["e2e/**/*.ts"]` override disables `max-lines` and
+`sonarjs/no-duplicate-string` but **not** `no-identical-functions`. It cannot fire
+across files, because ESLint sees one file at a time. Copy helpers across the two
+new files freely; **never write two copies of the same helper inside one file**,
+because `pnpm --filter @kandev/web lint` runs `eslint --max-warnings 0`.
+
+**5. E6 and E7's GitHub PR comes from the association call, not the catalogue
+call.** Use `apiClient.mockGitHubReset()`, then
+`apiClient.mockGitHubSetUser("test-user")`, then
+`apiClient.mockGitHubAssociateTaskPR({ task_id, owner: "testorg",
+repo: "testrepo", pr_number, pr_url, pr_title, head_branch, base_branch,
+author_login: "test-user", state: "open" })` — `state` is optional and is passed
+explicitly.
+
+**`mockGitHubAddPRs()` is the wrong call and must not be used.** It seeds the mock
+provider's PR *catalogue* and creates **no task-to-PR association**, so
+`taskPRs.byTaskId[taskId]` stays empty, `PRTaskIcon` renders nothing, and the
+PR-before-MR assertion that is the point of E6 and E7 can never run.
+`mockGitHubAssociateTaskPR()` populates the association the badge reads; no
+catalogue call is needed alongside it.
+
+The reference is `mr-task-card-badge.spec.ts`'s own `"AC30/AC37"` test. Reading it
+does not modify it, so AC16 stays literally true.
+
+**And, as in task 04: scope every `mr-task-icon-*` accessor to a container and
+never use `.first()`.** One task id can be emitted by two mounted rows on one
+route — on `/tasks` that is the sidebar row plus the list row. Scope to
+`app-sidebar`, `tasks-list-row`, or `task-card-<id>`. (AC19)
+
+## Acceptance
+
+1. `apps/web/e2e/tests/gitlab/mr-tasks-list-badge.spec.ts` exists and E4, E5 and
+   E6 pass.
+2. `apps/web/e2e/tests/gitlab/mobile-mr-tasks-list-badge.spec.ts` exists and E7
+   passes, including `assertNoDocumentHorizontalOverflow`. (AC20)
+3. `e2e/tests/gitlab/mr-task-card-badge.spec.ts` and
+   `e2e/tests/gitlab/mobile-mr-task-card-badge.spec.ts` are **unmodified** and
+   pass (AC16).
+
+## Verification
+
+```
+cd apps && pnpm install --frozen-lockfile \
+  && cd web && pnpm e2e:raw -- e2e/tests/gitlab/mr-tasks-list-badge.spec.ts \
+  && pnpm e2e:raw -- e2e/tests/gitlab/mobile-mr-tasks-list-badge.spec.ts \
+  && pnpm e2e:raw -- e2e/tests/gitlab/mr-task-card-badge.spec.ts \
+  && pnpm e2e:raw -- e2e/tests/gitlab/mobile-mr-task-card-badge.spec.ts
+```
+
+The last two are the AC16 non-regression checks and must pass with those files
+untouched. Then:
+
+```
+cd apps && pnpm --filter @kandev/web lint
+```
+
+`--max-warnings 0`, so a duplicated helper **within** either new spec file fails
+the build.
+
+## Files likely touched
+
+- `apps/web/e2e/tests/gitlab/mr-tasks-list-badge.spec.ts` (new)
+- `apps/web/e2e/tests/gitlab/mobile-mr-tasks-list-badge.spec.ts` (new)
+
+Explicitly **not** touched: `e2e/tests/gitlab/mr-task-card-badge.spec.ts`,
+`e2e/tests/gitlab/mobile-mr-task-card-badge.spec.ts`,
+`e2e/tests/pr/pr-status-badge.spec.ts`, `e2e/helpers/gitlab.ts` (imported from,
+not edited).
+
+## Dependencies
+
+Tasks 02 and 03. The `/tasks` row must render the badge (02) and the page must
+hydrate the MRs (03) before any of these scenarios can pass.
+
+## Parallelism
+
+`parallel-safe` with task 04 once both their dependencies have landed: disjoint
+spec files, disjoint page objects.
+
+## Inputs
+
+- Spec: "E2E (Playwright, required)" in full, including "Where the seed helpers
+  come from" and "Where the mock GitHub PR comes from"; "Responsive and
+  coarse-pointer behaviour"; "Accessibility and duplicate mounts"; AC8, AC9,
+  AC10, AC16, AC19, AC20
+- Plan: E2E Tests section
+- Patterns: `e2e/tests/gitlab/mr-task-card-badge.spec.ts` and
+  `e2e/tests/gitlab/mobile-mr-task-card-badge.spec.ts` (read, do not edit),
+  `task-listing-view-preferences.spec.ts` (the display-menu toggle)
+- `MRTaskIcon`'s Radix tooltip is inherited unchanged on both new surfaces: no
+  `useTouchDrawer`, no `useHoverPopover`, no tap-to-open handling is added, on
+  mobile or anywhere else. Upgrading that disclosure is its own card.
+
+## Output contract
+
+Report: summary; files changed (reconciled against the actual diff, **including
+any existing spec modified as E2E evidence**); tests run with exact commands and
+pass/fail counts; blockers; risks. Set this task's `status` to `in_progress` at
+start and `done` at finish, update `## Results` below, and synchronize the Wave 2
+checkbox and `## Verification Results` in `plan.md`.
+
+## Results
+
+Pending. Before marking this task done, replace this with every exact command
+actually run and its outcome/count, generated artifact paths, and cleanup or
+teardown evidence (including temporary capture-spec removal and
+`git diff --check` when used). Record security/trust and external side-effect
+boundaries when applicable, or explicitly state `None`.

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -135,6 +135,7 @@ Per-workspace credentials and triage triggers for external services.
 | [github-authentication](integrations/github-authentication.md) | draft |
 | [gitlab-integration](gitlab-integration/spec.md) | shipped |
 | [gitlab-mr-status-chip](gitlab-mr-status-chip/spec.md) | draft |
+| [gitlab-mr-task-list-badges](gitlab-mr-task-list-badges/spec.md) | draft |
 | [gitlab-workflow-sync](gitlab-workflow-sync/spec.md) | shipped |
 | [jira-status-filter](jira-status-filter/spec.md) | shipped |
 | [enable-disable-toggle](integrations/enable-disable-toggle.md) | shipped |

--- a/docs/specs/gitlab-mr-task-list-badges/spec.md
+++ b/docs/specs/gitlab-mr-task-list-badges/spec.md
@@ -1,0 +1,855 @@
+---
+status: draft
+created: 2026-08-12
+owner: tbd
+---
+
+# GitLab MR Badge on the Sidebar and Tasks-List Rows
+
+## Why
+
+A task whose work lives on GitHub shows a pull-request badge on all three
+task-row surfaces: the Kanban card, the app sidebar's task list, and the
+`/tasks` page rows. A task whose work lives on GitLab shows a merge-request
+badge on exactly one of them, the Kanban card. On the other two a GitLab-only
+task looks like a task with no remote contribution at all.
+
+This is not a regression. `docs/specs/gitlab-integration/spec.md` scoped the MR
+badge to the Kanban card and to nothing else, and the code matches that scope
+exactly: `MRTaskIcon` has one call site,
+`apps/web/components/kanban-card-content.tsx:152`. This spec **adds** the two
+missing surfaces. It is a sibling of the shipped
+[gitlab-mr-status-chip](../gitlab-mr-status-chip/spec.md) card and belongs to the
+same GitLab-parity family.
+
+## What
+
+- A task with at least one linked GitLab merge request SHALL render the existing
+  `MRTaskIcon` badge on the app sidebar's task row and on the `/tasks` page's
+  rich task row, in addition to the Kanban card it already renders on.
+- The badge SHALL be the existing `MRTaskIcon` component, rendered unmodified.
+  No new glyph, no new colour rule, no new status derivation, no new
+  `data-testid`, and no new user-facing copy are introduced by this feature.
+- On every surface that shows both, the pull-request badge SHALL precede the
+  merge-request badge in DOM order.
+- The `/tasks` page SHALL become an owner of GitLab MR hydration for the active
+  workspace, because it is the surface whose own row renders the badge. The
+  sidebar SHALL NOT become one; see Hydration ownership.
+- No file under `apps/web/components/github/` changes.
+  `apps/web/components/gitlab/mr-task-icon.tsx` does not change either.
+  `PRTaskIcon`'s and `MRTaskIcon`'s rendered output SHALL be identical before and
+  after this feature.
+
+## Data model
+
+No new persistent state, no new API, no new store slice, no new WS action.
+
+The badge reads the `TaskMR` rows already cached at
+`taskMRs.byWorkspaceId[workspaceId][taskId]`
+(`apps/web/lib/state/slices/gitlab/gitlab-slice.ts`), typed at
+`apps/web/lib/types/gitlab.ts`.
+
+The two provider store shapes are **not** symmetric, and this asymmetry is the
+first implementation trap:
+
+| | GitHub | GitLab |
+|---|---|---|
+| store path | `taskPRs.byTaskId[taskId]` | `taskMRs.byWorkspaceId[workspaceId][taskId]` |
+| accessor | direct `useAppStore` selector | `useTaskMRs(taskId)` |
+| workspace scoping | none | active workspace only |
+
+`useTaskMRs(taskId)` (`apps/web/hooks/domains/gitlab/use-task-mr.ts:60`) resolves
+`workspaces.activeId` itself and returns the module-level, referentially stable
+`EMPTY_MRS` when there is nothing to show. A hand-rolled selector that returns a
+fresh `[]` causes an infinite re-render loop; the constant's own comment records
+this.
+
+There is a **second** GitHub-only source the sidebar row already uses and which
+has no GitLab counterpart: `TaskItem`'s `prInfo` prop. It is not prototype-only
+data. `task-session-sidebar-item.ts:109` derives it from the bounded task status
+projection `TaskStatusSummary.pull_request`
+(`apps/web/lib/types/task-status-summary.ts`), which carries `number`, `state`,
+`aggregate_state` and `url` and **no `merge_request` field at all**.
+`sidebar-mock-data.ts` supplies the same shape for the sidebar prototype. A
+GitLab analogue of that path is therefore a backend projection change, not a
+frontend one; see Out of scope.
+
+## Surfaces and mount points
+
+Exactly three **existing** production React files change, plus **at most one new
+sibling component file** if the badge-pair extraction reads better out-of-line.
+Constraints owns that allowance and states where the new file may live; this
+section is not a second, tighter fence. Line numbers drift; the anchors are the
+named symbols.
+
+1. **App sidebar row** — `apps/web/components/task/task-item.tsx`, the local
+   `TaskPRIcon` component and its single call site inside `TaskItemContent`'s
+   title row.
+2. **`/tasks` rich row** — `apps/web/app/tasks/rich-task-list-row.tsx`,
+   `PrimaryTaskLine`.
+3. **`/tasks` page hydration** — `apps/web/app/tasks/tasks-page-client.tsx`,
+   `TasksPageClient`.
+
+The Kanban card (`kanban-card-content.tsx`) is already correct and is the
+reference shape. It does not change.
+
+### The sidebar early-return trap
+
+`TaskPRIcon` today is:
+
+```tsx
+const hasStorePR = useAppStore((s) => !!taskId && (s.taskPRs.byTaskId[taskId]?.length ?? 0) > 0);
+if (hasStorePR) return <PRTaskIcon taskId={taskId!} />;
+if (!prInfo) return null;
+// ... summary-projection fallback badge
+```
+
+Both `return`s exit the component. An `MRTaskIcon` appended after them is
+unreachable for any task that has a PR, and unreachable for any task that has
+neither a PR nor `prInfo` — that is, for the GitLab-only task this feature
+exists to serve. The component SHALL be restructured so the PR branch and the MR
+branch are siblings, not alternatives.
+
+`taskId` is optional on this component (`taskId?: string`), so `hasStorePR` is
+not a usable guard for the MR branch: it is `false` both when there is no task id
+and when there is a task id with no PRs. The MR branch needs its own `taskId`
+truthiness guard.
+
+## Selection and ordering
+
+- **Badge order is fixed and named: pull request, then merge request.** It is
+  DOM order within the row's title line, not visual order produced by CSS, and it
+  is identical on all three surfaces. The Kanban card already ships this order
+  (`PRTaskIcon` then `MRTaskIcon`), and `mr-task-card-badge.spec.ts` already
+  asserts it there; the two new surfaces adopt it rather than inventing one.
+- **Sidebar title row, full order:** title, autopilot icon, pinned icon,
+  **PR badge, MR badge**, issue badge, agent-error icon, remote-cloud icon,
+  archived chip. The MR badge sits immediately after the PR badge and before
+  `IssueTaskIcon`: the two contribution badges group together, and the issue
+  badge (a different entity class) follows them.
+- **`/tasks` rich row, full order:** state icon, title, **PR badge, MR badge**,
+  archived badge.
+- **Which MR the badge represents, and the multi-MR count**, are decided by
+  `MRTaskIcon` and are unchanged: one MR renders `SingleMRIcon`, two or more
+  render `MultiMRIcon` with `aggregateMRStatusColor` and a count. That includes
+  `aggregateMRStatusColor`'s first-in-array-order tie, which this feature freezes
+  rather than touches (it is re-tuning the colour priority; see Out of scope).
+  There is no per-surface selection rule and this spec SHALL NOT introduce one.
+
+## Hydration ownership
+
+`useWorkspaceMRs(workspaceId)` is the only thing that puts MR rows in the store.
+Its four existing call sites are `kanban-board.tsx` (unconditional on
+`workspaceState.activeId`), `mr-topbar-button.tsx`, `use-mr-key-to-tasks.ts` and
+`use-external-vcs-file-link.ts`. Neither the sidebar nor `/tasks` is among them.
+Consolidating these behind one provider-level owner is an already-declared
+out-of-scope card in the sibling spec, and this feature does not take it on.
+
+### `/tasks` becomes an owner. The gated form is forbidden.
+
+`TasksPageClient` already owns its GitHub hydration, gated on the same setting
+that gates the badge:
+
+```ts
+useWorkspacePRs(showTaskDetails ? s.activeWorkspaceId : null);
+```
+
+**Mirroring that expression for GitLab is a cross-surface data-loss bug**, and
+this is the second implementation trap. The two hooks do not have the same
+null behaviour:
+
+- `useWorkspacePRs(null)` clears a local ref and touches no store state.
+- `useWorkspaceMRs(null)` calls `resetTaskMRs()` **with no argument**, and
+  `resetTaskMRs` with no argument assigns `taskMRs.byWorkspaceId = {}` — every
+  workspace, wiped.
+
+Because `AppSidebar` is mounted in the root layout (`app/layout.tsx`) and is
+therefore on screen on `/tasks`, the gated form would blank the sidebar's MR
+badges (and any other MR consumer's data) for the entire time a user sits on
+`/tasks` with task details switched off, and would keep re-wiping on every
+render pass that re-runs the effect. The wipe is not confined to the page that
+caused it.
+
+The `/tasks` page SHALL therefore call `useWorkspaceMRs(s.activeWorkspaceId)`
+**unconditionally**, matching `kanban-board.tsx`'s existing unconditional call
+rather than `useWorkspacePRs`'s gated one. The cost is one `GET` per workspace
+per effect run, which is not wasted even when task details are off: the sidebar
+is mounted on that route and renders MR badges from the same store.
+
+Note "per effect run", not "per mount": the app root renders inside
+`<StrictMode>` (`apps/web/src/main.tsx`), and the hook's cleanup clears
+`fetchedRef`, so React's development-only effect replay issues a **second**
+`GET` on first mount. That is existing behaviour shared with all four current
+call sites, it does not occur in a production build, and no acceptance criterion
+here asserts a request count. It is stated so nobody writes a call-count
+assertion against the wrong number.
+
+`s.activeWorkspaceId` can itself be `null`, and the unconditional form then
+passes `null` and clears the cache. That is correct and is not the case this
+rule forbids: with no active workspace, `useTaskMRs` returns `EMPTY_MRS` for
+every task and no surface can render an MR badge, so there is nothing for the
+clear to take away. It is also exactly what `kanban-board.tsx` already does. The
+forbidden form is different in kind — it passes `null` **while a workspace is
+active and other surfaces are displaying that workspace's MRs**.
+
+### The sidebar does not become an owner
+
+The sidebar SHALL read the store and hydrate nothing, exactly as its PR badge
+does today. Consequently the sidebar MR badge is visible only when some other
+mounted surface has hydrated the active workspace's MRs. That is an observation
+about today's mounts, not a guarantee this spec pins, and the coverage is
+**not** uniform across routes — see the two holes named below. No acceptance
+criterion depends on an ambient hydration path: unit tests seed the store
+directly, and the E2E scenarios below each name a route with a stated owner
+(`/` via `kanban-board.tsx`, `/tasks` via this feature).
+
+This is a deliberate parity choice. The GitHub badge on the sidebar has the same
+property and the same zero owners; giving GitLab its own fifth call site would
+make the two providers diverge in the one place a consolidation card has to
+touch.
+
+### Two routes where the sidebar MR badge does not render, and why both are accepted
+
+Both are pre-existing properties of code this feature does not touch. They are
+named here because a reader would otherwise assume the sidebar badge works
+everywhere the sidebar does, and because the second one is a live instance of the
+very pattern the previous section forbids.
+
+**Hole 1 — an archived task opened directly.** `MRTopbarButton` is the hydration
+owner on the task-detail routes, but on desktop it sits inside `{!isArchived &&
+(…)}` in `components/task/task-top-bar.tsx`. An archived task opened at
+`/t/:taskId` therefore mounts no MR hydration owner, and the sidebar shows no MR
+badge for any task until the user navigates to a route that has one.
+
+**Hole 2 — a task with no GitLab repository, on the task-detail route.**
+`useExternalVcsFileLinkHydration`
+(`hooks/domains/workspace/use-external-vcs-file-link.ts`) calls
+
+```ts
+useWorkspaceMRs(providers.has("gitlab") ? workspaceId : null);
+```
+
+and `components/task/task-page-content.tsx` invokes it unconditionally.
+`TaskPageContent` is rendered by `KanbanTaskShell` for `/t/:taskId` and
+`/tasks/:id`. For a task whose linked repositories carry no `gitlab` provider,
+that expression passes `null` **while a workspace is active and the sidebar is
+displaying that workspace's MRs** — which is exactly the shape "/tasks becomes an
+owner" forbids, already shipped, on a sidebar-bearing route. It reaches
+`resetTaskMRs()` with no argument and clears `taskMRs.byWorkspaceId` for every
+workspace. `MRTopbarButton` on the same route calls `useWorkspaceMRs(workspaceId)`
+and re-fetches, so the two race and the sidebar's MR badges are
+**nondeterministic** on that route for a GitHub-only or repository-less task.
+
+**Both are accepted for this card, and no acceptance criterion is weakened by
+them.** Three reasons, stated so the decision is not re-litigated at Build:
+
+1. Every AC that observes a badge is conditioned on the store already holding
+   MRs — AC1 reads "**where** … the store holds at least one MR", not "wherever
+   the task has an MR upstream". A wipe means the store does not hold them, so
+   AC1 is satisfied vacuously rather than violated. The contract is about
+   rendering what the store has, and that is what the builder must implement.
+2. The fix for Hole 2 is not a fix to this feature's code. It is either scoping
+   `useWorkspaceMRs`'s reset to the workspace it last fetched, or removing the
+   gate at that call site — both changes to a hook four other call sites depend
+   on, including ones that rely on the full clear at sign-out. That is already an
+   explicit Out-of-scope entry below, and this section now names the call site
+   that makes it urgent.
+3. Neither hole is reachable from any scenario in this spec. Every E2E scenario
+   (**E1 to E7**) runs on `/` or `/tasks`, both of which have an unconditional
+   owner and neither of which mounts `TaskPageContent`. The unit scenarios
+   (**U1 to U11**) render components directly and mount no route at all.
+
+The builder SHALL NOT attempt to work around either hole from the three
+production files in scope — in particular, the sidebar SHALL NOT gain its own
+`useWorkspaceMRs` call to compensate, which AC7 already forbids.
+
+## Nil, empty, and error behaviour
+
+State each of these explicitly rather than by omission:
+
+- **No linked MRs.** `useTaskMRs` returns `EMPTY_MRS`, `MRTaskIcon` returns
+  `null`, and the row renders no MR element. The MR badge SHALL contribute **no
+  element of its own** to the row in this case: no wrapper `<span>`, no
+  placeholder, and no *conditional* spacing that exists only to reserve room for
+  the absent badge. This is the observable form of the requirement, and AC6 is
+  its test. (An earlier draft said "byte-identical layout", which named no
+  baseline and no mechanism; no snapshot baseline is introduced by this feature.)
+
+  **This rule bounds what the MR badge adds when there are no MRs. It does not
+  forbid fixed spacing on the badge container.** The `/tasks` badge wrapper gains
+  an unconditional `gap` class (specified under Responsive and coarse-pointer
+  behaviour) so that two present badges are separated. That class is applied
+  whether or not an MR badge renders, so in the no-MR case it changes nothing
+  and adds no element. AC6 and AC23 are therefore not in tension, and a builder
+  SHALL NOT read AC6 as a reason to leave two badges unseparated. AC23 requires
+  that class unconditionally precisely so that satisfying it can never add an
+  element in the no-MR case that AC6 forbids.
+- **No `taskId`.** The sidebar's `TaskItem` accepts `taskId?: string`. When it is
+  absent the MR branch renders nothing and SHALL NOT call `MRTaskIcon` with an
+  empty-string or `undefined` id.
+- **No active workspace** (`workspaces.activeId === null`). `useTaskMRs` returns
+  `EMPTY_MRS`; no badge, no error, no fetch.
+- **Task outside the active workspace.** `taskMRs` is workspace-keyed, so a row
+  for a task belonging to another workspace renders no MR badge. This is
+  inherited from `useTaskMRs` and is not corrected here.
+- **Corrupted store entry** (a non-array value under `byWorkspaceId[ws][taskId]`,
+  e.g. from a partial hydration). `MRTaskIcon`'s existing `Array.isArray` guard
+  returns `null`. The new call sites SHALL NOT add a second, differently-shaped
+  guard in front of it.
+- **Hydration fetch fails.** `useWorkspaceMRs` swallows the error and clears its
+  `fetchedRef` so a later workspace switch can retry. No badge, no toast, no
+  error affordance, no retry loop is added by this feature.
+- **Workspace switch.** `useWorkspaceMRs` calls `resetTaskMRs(workspaceId)` for
+  the *incoming* workspace before fetching, so between the switch and the
+  response the new workspace's rows show no MR badge. That transient blank is
+  existing behaviour and is accepted, not fixed.
+- **Task has a PR but no MR, or an MR but no PR.** Exactly one badge renders. The
+  row SHALL NOT reserve space for the absent one.
+
+### Boundaries and defaults
+
+- **Zero / one / two-or-more MRs.** Zero renders nothing. One renders
+  `SingleMRIcon` with `data-mr-count="1"` and `data-mr-state`. Two or more render
+  `MultiMRIcon` with `data-mr-count="<n>"`, the aggregate colour and a numeric
+  suffix, and no `data-mr-state`. Inherited from `MRTaskIcon`; no per-surface cap
+  on the count and no overflow chip is introduced.
+- **Archived tasks.** The sidebar's archived rows and the `/tasks` list with
+  "Show archived" on both render through the same components, and the MR badge
+  SHALL behave there exactly as the store-backed PR badge does today: present
+  when the store holds MRs for the task, absent otherwise. Archival is not a
+  suppression condition for either badge. (Note the asymmetry this inherits: the
+  archived sidebar item builder sets `prInfo: undefined`, so the *summary
+  fallback* PR badge is suppressed on archived rows while the store-backed
+  badges are not. This feature neither copies nor corrects that.)
+- **Terminal MRs.** A task whose only MR is merged, closed or locked still shows
+  the badge, coloured by `getMRStatusColor`. Unlike the status chip, the badge
+  has no open-only filter, and this feature does not add one.
+- **Rows with no `taskId`** — `taskId` is optional on `TaskItem`
+  (`taskId?: string`), and AC5 is grounded in that optionality, not in a specific
+  caller. Stated precisely, because it is easy to assume otherwise: **every
+  production caller today passes a `taskId`.** `TaskItem`'s only production
+  importer is `components/task/task-switcher-row.tsx`, whose single mount passes
+  `taskId={task.id}`. The sidebar's primary-nav and new-task rows render
+  `AppSidebarNavItem` and `AppSidebarNewTaskItem`, which are different components
+  and do not render `TaskItem` at all. So AC5 is a **defensive** contract on the
+  optional prop rather than a rule about a live surface: it keeps the MR branch
+  from being written in a way that breaks the moment an id-less caller appears,
+  and U4 exercises it synthetically. Do not go looking for id-less rows in the
+  sidebar; there are none, and their absence is not a missed surface.
+- **`showContributions` has no default.** It is a required prop on
+  `PrimaryTaskLine`, passed explicitly `true` by the rich path and `false` by the
+  compact path. It SHALL NOT be given a default value.
+
+## Concurrency and idempotency
+
+- **Two surfaces, one task, same route.** The sidebar and the board (or the
+  `/tasks` row) both mount a badge for the same task id. Both read the same store
+  entry, so they always agree. Both emit the same
+  `data-testid="mr-task-icon-<taskId>"`; see Duplicate mounts below.
+- **Two hydration owners mounted at once** (board plus `/tasks` is not reachable
+  today, but sidebar-bearing routes each mount one and `mr-topbar-button` can
+  co-mount with `use-external-vcs-file-link`). Each `useWorkspaceMRs` instance
+  keeps its own `fetchedRef`, so each issues its own `GET`. `setTaskMRs` replaces
+  the whole per-workspace map, the request is idempotent, and the outcome
+  converges to the last response regardless of arrival order. No coordination is
+  added.
+- **A store write while a row is mounted** (`setTaskMR` from a link, or
+  `removeTaskMR` from an unlink) re-renders every mounted badge for that task in
+  the same commit. There is no per-surface cache and therefore no staleness
+  window between surfaces.
+- **Re-render cost.** The badge adds exactly one `useTaskMRs` subscription per
+  rendered row. Rows for tasks with no MRs SHALL NOT re-render on unrelated
+  `taskMRs` writes, which is what the stable `EMPTY_MRS` identity buys. Any
+  selector introduced by this feature SHALL NOT allocate a new array or object.
+
+## Responsive and coarse-pointer behaviour
+
+- `MRTaskIcon` uses a plain Radix `Tooltip` on both its single-MR and multi-MR
+  variants. That disclosure behaviour is inherited **unchanged**: no
+  `useTouchDrawer` variant, no `useHoverPopover` wiring, no tap-to-open handling
+  is added on the new surfaces. The badge already ships this exact behaviour on
+  the Kanban card, including on a mobile viewport
+  (`e2e/tests/gitlab/mobile-mr-task-card-badge.spec.ts`), and this feature
+  changes neither the component nor the trade-off. Upgrading the badge's
+  coarse-pointer disclosure is its own card; see Out of scope.
+- The badge SHALL NOT be gated on any Tailwind width class. It renders at every
+  viewport width on both new surfaces, exactly as the PR badge beside it does.
+- On a mobile viewport the added badge SHALL NOT introduce horizontal document
+  overflow on the `/tasks` list. Both new badges sit in `min-w-0` flex rows whose
+  siblings already truncate.
+- The `/tasks` row is a click target. The PR badge is already wrapped in a
+  `<span>` that stops `click` and `pointerdown` propagation so hovering or
+  tapping the badge cannot navigate the row. The MR badge SHALL sit inside that
+  **same** wrapper rather than get a second copy of it, so the two badges cannot
+  drift apart on interaction behaviour.
+- **That wrapper carries no `className` at all today**, because it has only ever
+  held a single child, so the row's own `gap-2` was the only separation it needed.
+  Two children inside it would render with **no separation whatsoever**. The
+  wrapper SHALL therefore be given `inline-flex items-center gap-1`.
+  `gap-1` is not a new number: it is what both surfaces that already render badges
+  side by side use — the Kanban card's `kanban-card-title-row`
+  (`flex items-center gap-1 min-w-0`, where `PRTaskIcon` and `MRTaskIcon` are
+  direct siblings) and the sidebar title row (`flex items-center gap-1 min-w-0`).
+  Matching it keeps PR-to-MR separation identical on all three surfaces.
+  Two things this deliberately does NOT do: it does not add `shrink-0` (both
+  `PRTaskIcon` and `MRTaskIcon` already carry `shrink-0` on their own roots), and
+  it does not alter the row's existing `gap-2` between the title and the badge
+  wrapper. The class is unconditional, so it reserves no space for an absent
+  badge; see Nil, empty, and error behaviour for why that satisfies AC6.
+  **AC23 is this rule's test.** It is a separate criterion rather than a clause on
+  AC9 because AC9 observes only which elements sit inside the wrapper and in what
+  order, so it cannot fail on an unclassed wrapper.
+- The sidebar row's badges are not wrapped today and SHALL NOT become wrapped:
+  clicking a sidebar row selects the task, which is the desired outcome from
+  anywhere on the row including the badges.
+
+## Accessibility and duplicate mounts
+
+- `MRTaskIcon` carries no `aria-label` and this feature adds none. Doing so would
+  be new user-facing copy on a component whose Kanban mount would then disagree
+  with its two new mounts, and the state is already named in the tooltip text
+  (`getMRTooltip`), not conveyed by colour alone.
+- `MRTaskIcon`'s `data-testid` is `mr-task-icon-<taskId>`, and the same id is now
+  emitted by up to two mounted rows for one task on one route (sidebar plus
+  board, or sidebar plus `/tasks` row). Every Playwright accessor for it
+  therefore SHALL be scoped to a container: the sidebar root
+  (`app-sidebar`) or the specific row (`tasks-list-row`, `task-card-<id>`). No
+  accessor may resolve `mr-task-icon-*` globally, and none may paper over the
+  duplicate with `.first()`. The identical hazard already exists for
+  `pr-task-icon-*` and is recorded in `e2e/tests/pr/pr-status-badge.spec.ts`.
+- The two badges SHALL remain separate elements with separate tooltips. They are
+  not merged into a combined contribution badge.
+
+## Prop naming
+
+`PrimaryTaskLine`'s existing `showPullRequest: boolean` gates the badge slot on
+the `/tasks` row. It is file-local (declared and passed only within
+`rich-task-list-row.tsx`) and is passed `true` from the rich content path and
+`false` from the compact path.
+
+**One flag SHALL gate both badges**, and it SHALL be renamed to
+`showContributions`. There is no second flag and no independent per-provider
+toggle: a user who turns on "Show task details" is asking for the row's remote
+contributions, not for GitHub's specifically. Leaving a flag named
+`showPullRequest` in control of a merge-request badge is the kind of stale name
+that the next reader has to disprove.
+
+## Internationalization
+
+This feature introduces **no** user-facing string literal. `MRTaskIcon` renders
+MR-derived data (`getMRTooltip` builds from `mr_iid`, `mr_title`, `state`,
+`approval_state`, `pipeline_state`), which the component already documents as
+non-translatable domain data with the same precedent as GitHub's `getPRTooltip`.
+
+Consequences, stated so they are not re-derived:
+
+- `apps/web/src/locales/en/*.json` SHALL NOT gain a key.
+- `apps/web/eslint.i18n.options.mjs` SHALL NOT gain an entry. Of the three
+  touched files, **two are already on `i18nGuardFiles`** —
+  `app/tasks/rich-task-list-row.tsx` and `app/tasks/tasks-page-client.tsx` — so
+  `i18next/no-literal-string` is a whole-file **error** on both, not merely a
+  changed-lines ratchet. `components/task/task-item.tsx` is **not** on the list,
+  so only the ratchet's changed-lines judgement applies there. This feature adds
+  no literal to any of the three, so the append-in-the-same-PR rule is not
+  triggered on any of them. Adding an unrelated file to the list is a separate
+  change and SHALL NOT be smuggled in here.
+  (`components/kanban-card-content.tsx` is also on the list, but it is not one of
+  the touched files — it does not change; see Surfaces and mount points.)
+- `pnpm run i18n:check` and `pnpm run i18n:ratchet` SHALL pass, and the ratchet's
+  changed-lines judgement SHALL find nothing on the lines this feature touches.
+
+## Failure modes
+
+| Failure | Observable behaviour | Contract |
+|---|---|---|
+| GitLab not configured for the workspace | `listWorkspaceTaskMRs` returns an empty map; no badge anywhere | No error UI, no banner, no console noise |
+| MR hydration request fails | No MR badge; PR badge unaffected | Row renders, retry only on a later workspace switch or remount |
+| Store holds a non-array for the task | No MR badge | `MRTaskIcon`'s existing guard; no crash |
+| Task's only MR is unlinked while the row is mounted | Badge disappears in the same commit | `removeTaskMR` filters in place; no stale badge |
+| Task's last MR merges | Badge stays, coloured purple (`merged`) | Terminal MRs remain visible on the badge, unlike the status chip |
+| Sidebar mounted on a route with no MR hydration owner | No MR badge for a GitLab-only task | Stated, accepted, not an AC (see Hydration ownership) |
+| Archived task opened at `/t/:taskId` (desktop) | No MR badge in the sidebar, because `MRTopbarButton` is inside `{!isArchived && …}` and no owner mounts | Hole 1: stated, accepted, not an AC; pre-existing, no file in scope changes it |
+| Task with no `gitlab`-provider repository opened at `/t/:taskId` or `/tasks/:id` | Sidebar MR badges nondeterministic for every task: `useExternalVcsFileLinkHydration` passes `null` and wipes `byWorkspaceId` while `MRTopbarButton` re-fetches | Hole 2: stated, accepted, not an AC. AC1 is conditioned on the store holding MRs, so it is satisfied vacuously. Fix belongs to the `useWorkspaceMRs(null)` reset-scoping card (Out of scope) |
+
+## Acceptance criteria
+
+Sidebar row:
+
+- **AC1** — Where a sidebar task row has a `taskId` and the store holds at least
+  one MR for that task in the active workspace, the row SHALL render
+  `MRTaskIcon` for that task id.
+- **AC2** — Where a sidebar task row's task has both a store PR and at least one
+  MR, the row SHALL render both badges, with the PR badge preceding the MR badge
+  in DOM order.
+- **AC3** — Where a sidebar task row's task has an MR and no PR (neither a store
+  PR nor a `prInfo` summary projection), the row SHALL render the MR badge.
+- **AC4** — Where a sidebar task row's task has a `prInfo` summary projection, no
+  store PR, and at least one MR, the row SHALL render the `prInfo` fallback PR
+  badge followed by the MR badge.
+- **AC5** — When a sidebar task row is rendered without a `taskId`, the row SHALL
+  render no MR badge and SHALL NOT invoke `MRTaskIcon`.
+- **AC6** — Where a sidebar task row's task has no MRs, the row's rendered output
+  SHALL contain no element whose `data-testid` starts with `mr-task-icon-`.
+- **AC7** — The sidebar SHALL NOT call `useWorkspaceMRs`, and no file under
+  `apps/web/components/task/` or `apps/web/components/app-sidebar/` SHALL import
+  it.
+
+`/tasks` rows:
+
+- **AC8** — Where the `/tasks` row is rendered with contributions shown and the
+  store holds at least one MR for the task in the active workspace, the row SHALL
+  render `MRTaskIcon` for that task id.
+- **AC9** — Where the `/tasks` row is rendered with contributions shown and the
+  task has both a PR and an MR, both badges SHALL render, PR before MR in DOM
+  order, and both SHALL be inside the single propagation-stopping wrapper.
+- **AC10** — While the `/tasks` row is rendered with contributions hidden (the
+  compact path), the row SHALL render neither the PR badge nor the MR badge.
+- **AC11** — The single boolean that gates both badges SHALL be named
+  `showContributions`; no `showPullRequest` identifier SHALL remain in
+  `apps/web/app/tasks/rich-task-list-row.tsx`.
+- **AC23** — Where the `/tasks` row is rendered with contributions shown, the single
+  propagation-stopping wrapper holding the badges SHALL carry the classes
+  `inline-flex items-center gap-1`, and SHALL carry them unconditionally: the classes
+  are present whether or not an MR badge renders, and SHALL NOT be applied only when
+  two badges are present. This pins the wrapper class stated in Responsive and
+  coarse-pointer behaviour, which AC9 alone does not observe: AC9 constrains only which
+  elements sit inside the wrapper and in what order, so an implementation leaving the
+  wrapper unclassed would satisfy every other criterion while shipping two touching
+  badges on `/tasks` and separated badges on the other two surfaces. The
+  unconditionality is what keeps this compatible with AC6 rather than in tension with
+  it; see Nil, empty, and error behaviour.
+
+`/tasks` hydration:
+
+- **AC12** — When `TasksPageClient` renders with an active workspace, it SHALL
+  call `useWorkspaceMRs` with that workspace id, unconditionally, and SHALL NOT
+  gate the argument on `tasksListShowDetails` or on any other setting.
+- **AC13** — If `useWorkspaceMRs` is invoked with `null` while another
+  workspace's MRs are cached, then every workspace's entry under
+  `taskMRs.byWorkspaceId` SHALL be cleared. This is the existing behaviour AC12
+  exists to avoid triggering, and SHALL be pinned by a test that seeds two
+  workspaces.
+- **AC21** — Where `TasksPageClient` renders with no active workspace, passing
+  `null` to `useWorkspaceMRs` is permitted, and no badge SHALL render on any
+  surface for the duration.
+
+Non-regression:
+
+- **AC14** — No file under `apps/web/components/github/` SHALL be modified.
+- **AC15** — `apps/web/components/gitlab/mr-task-icon.tsx` SHALL NOT be
+  modified. The badge is consumed exactly as it ships.
+- **AC16** — The Kanban card's rendered badge output SHALL be unchanged, and
+  `e2e/tests/gitlab/mr-task-card-badge.spec.ts` SHALL pass unmodified.
+- **AC17** — No `apps/web/src/locales/**` file and no `eslint.i18n.options.mjs`
+  entry SHALL change; `pnpm run i18n:check` and `pnpm run i18n:ratchet` SHALL
+  pass.
+- **AC18** — No selector or hook added by this feature SHALL return a freshly
+  allocated array or object; MR reads SHALL go through `useTaskMRs`.
+
+Cross-cutting:
+
+- **AC19** — Every Playwright accessor introduced for `mr-task-icon-*` SHALL be
+  scoped to `app-sidebar`, `tasks-list-row`, or `task-card-<id>`, and SHALL NOT
+  use `.first()` to disambiguate duplicates.
+- **AC20** — On a mobile viewport, a `/tasks` row carrying both badges SHALL NOT
+  cause horizontal document overflow.
+- **AC22** — Where a sidebar task row's task has at least one MR and the row also
+  renders the issue badge (`issueInfo` present), the MR badge SHALL precede the
+  issue badge in DOM order. This pins the "PR, MR, issue" grouping stated in
+  Selection and ordering, which AC2 alone does not observe: AC2 constrains only
+  PR-versus-MR, so an implementation appending the MR badge after
+  `IssueTaskIcon` would satisfy every other criterion while violating the stated
+  row order.
+
+## Scenarios
+
+Scenarios are numbered `U<n>` for unit and `E<n>` for E2E, in two independent
+sequences. The two kinds are deliberately not numbered in one run: an earlier
+draft numbered them continuously, and inserting a unit scenario silently shifted
+every E2E number and left a stale cross-reference behind. Cite scenarios by these
+prefixed ids, never by bare number.
+
+### Unit (vitest) — U1 to U11
+
+- **U1 — Sidebar, PR and MR together** — seed `taskPRs.byTaskId["t1"]` with one PR
+  and `taskMRs.byWorkspaceId["ws1"]["t1"]` with one MR, `workspaces.activeId =
+  "ws1"`; render `TaskItem` with `taskId="t1"`. Both `pr-task-icon-t1` and
+  `mr-task-icon-t1` are present, and `compareDocumentPosition` puts the PR
+  first. (AC2)
+- **U2 — Sidebar, MR only** — no PR, no `prInfo`, one MR. `mr-task-icon-t1`
+  present, `pr-task-icon-t1` absent. This is the case the early return currently
+  makes impossible. (AC3)
+- **U3 — Sidebar, `prInfo` fallback plus MR** — no store PR, `prInfo={{number: 7,
+  state: "Open"}}`, one MR. Both render, PR first. (AC4)
+- **U4 — Sidebar, no `taskId`** — render `TaskItem` without `taskId`, with MRs
+  seeded for some other id. Assert **both** of AC5's clauses, because they are not
+  equivalent and the weaker one alone is satisfied by code that violates the AC:
+  (a) no `mr-task-icon-*` element is present, and (b) **`MRTaskIcon` is not
+  invoked at all**, asserted by mocking the module and checking zero calls.
+  Clause (b) is the load-bearing one. An unguarded `<MRTaskIcon taskId={taskId!} />`
+  — the same non-null-assertion shape the PR branch beside it already uses — would
+  invoke the component with `undefined`, hit `useTaskMRs`' internal guard, render
+  `null`, and **pass clause (a) while breaking AC5** and adding the store
+  subscription AC18 exists to prevent.
+  **Clause (b) needs a spy, and no in-repo precedent for one exists — write it
+  fresh.** `components/kanban-card-content.test.tsx` is the precedent for
+  **module-level interception only**: it replaces the module with a plain stub
+  (`MRTaskIcon: () => <span data-testid="mr-task-icon" />`), and a stub records no
+  calls, so clause (b) cannot be asserted against it. No test under
+  `apps/web/components/` mocks a component module with `vi.fn()` and then asserts a
+  call count, so there is nothing to copy for the assertion itself. The required
+  shape is a `vi.fn()`-backed component mock plus a zero-call assertion — mock the
+  module with something of the form
+  `vi.mock("@/components/gitlab/mr-task-icon", () => ({ MRTaskIcon: vi.fn(() => null) }))`,
+  import the mocked symbol, and assert `expect(MRTaskIcon).not.toHaveBeenCalled()`.
+  Copy `kanban-card-content.test.tsx` for the `vi.mock` placement and factory shape;
+  do NOT copy its stub body, which is what makes clause (b) unassertable. (AC5)
+- **U5 — Sidebar, no MRs** — PR only. No `mr-task-icon-*` element. (AC6)
+- **U6 — `/tasks` row, contributions shown** — seeded PR and MR,
+  `showContributions` true. Both badges render inside the single wrapper, PR
+  first, and the wrapper carries `inline-flex items-center gap-1`. (AC8, AC9, AC23)
+- **U7 — `/tasks` row, contributions hidden** — same store, compact path. Neither
+  badge renders. (AC10)
+- **U8 — `useWorkspaceMRs(null)` wipes every workspace** — seed
+  `byWorkspaceId["ws-a"]` and `byWorkspaceId["ws-b"]`, render the hook with
+  `null`, assert both are gone. Add to
+  `apps/web/hooks/domains/gitlab/use-task-mr.test.ts` if not already covered
+  there. (AC13)
+- **U9 — `TasksPageClient` hydration argument** — with `tasksListShowDetails`
+  false and an active workspace, `useWorkspaceMRs` is called with the workspace
+  id, not `null`. (AC12)
+- **U10 — Sidebar, MR before the issue badge** — one MR seeded and
+  `issueInfo={{url: "…", number: 42}}` passed. Both `mr-task-icon-t1` and the
+  issue badge render, and `compareDocumentPosition` puts the MR badge first.
+  Run it with a store PR present as well, so the assertion covers the full
+  "PR, MR, issue" order rather than just the adjacent pair. (AC22)
+- **U11 — No active workspace, no badge** — seed
+  `taskMRs.byWorkspaceId["ws1"]["t1"]` with one MR but set
+  `workspaces.activeId = null`; render `TaskItem` with `taskId="t1"`. No
+  `mr-task-icon-*` element is present. This observes AC21's second clause, which
+  no other scenario reaches: AC21 is otherwise contract text resting on
+  `useTaskMRs` returning `EMPTY_MRS` for a null workspace, with nothing pinning
+  it. (AC21)
+
+### E2E (Playwright, required)
+
+`apps/web/**` is touched and none of the files are on the Testing step's
+exemption allowlist, so E2E is required. All GitLab scenarios seed through the
+GitLab mock provider and a task created with **no agent**, for the reason
+`mr-task-card-badge.spec.ts`'s `seedBoardTask` comment records: an auto-started
+session moves the card out from under the assertion.
+
+**Where the seed helpers come from, stated so it is not invented at build time.**
+`nextMRIID`, `seedMR`, `linkMR`, `ensureGitLabConfigured` and `seedBoardTask` are
+file-local and **unexported** in `mr-task-card-badge.spec.ts`. Each new spec file
+SHALL therefore define its own local copies, seeded from that file's versions,
+and SHALL NOT import them. `mr-task-card-badge.spec.ts` is not edited to export
+them, which is what keeps AC16 ("passes unmodified") literally true. Three
+reasons this is duplication rather than extraction:
+
+- It is the established in-repo precedent: `mobile-mr-task-card-badge.spec.ts`
+  already writes its own `seedBoardTaskWithMR` and imports only `GITLAB_HOST` and
+  `GITLAB_PROJECT` from `e2e/helpers/gitlab.ts`.
+- It does not trip lint, **because ESLint rules are per-file**. An earlier draft
+  justified this by claiming `e2e/**` sits in the `ignores` of the rule block
+  carrying `sonarjs/no-identical-functions`; that is **wrong**, and the correct
+  mechanism matters because it is narrower. In `apps/web/eslint.config.mjs`:
+  the block carrying `"sonarjs/no-identical-functions": "warn"` has no `files` and
+  no `ignores` (it is the global block, so it applies to `e2e/**` too); the
+  `ignores: ["**/*.test.ts", "**/*.test.tsx", "e2e/**"]` belongs to the **i18n
+  guard block** (`files: i18nGuardFiles`, rule `i18next/no-literal-string`); and
+  the `files: ["e2e/**/*.ts"]` override disables `react-hooks/*`, `max-lines`,
+  `max-lines-per-function` and `sonarjs/no-duplicate-string` — but **not**
+  `sonarjs/no-identical-functions`. The rule is therefore live on e2e files. It
+  still cannot fire on this duplication, because ESLint only ever sees one file at
+  a time and so cannot compare a helper in one spec file with its copy in another.
+  **Consequence the builder must respect:** two identical functions **within a
+  single** spec file DO warn, and `pnpm --filter @kandev/web lint` runs
+  `eslint --max-warnings 0`, so that fails the build. Copy each helper across
+  files freely; do not write two copies of the same helper inside one file.
+- Extracting them into `e2e/helpers/gitlab.ts` would edit
+  `mr-task-card-badge.spec.ts`'s imports, which AC16 forbids, and consolidating
+  the GitLab e2e seed helpers is a separate cleanup; see Out of scope.
+
+Shared *constants* are a different matter: `GITLAB_HOST` and `GITLAB_PROJECT`
+SHALL be imported from `e2e/helpers/gitlab.ts` as the existing specs do, not
+re-declared.
+
+**Where the mock GitHub PR comes from.** Three scenarios (E3, E6, E7) need a task
+carrying a PR *and* an MR, and the GitHub half has its own seeding path that is not
+covered by the GitLab helpers above. It SHALL come from the existing mock-GitHub
+API-client methods, not from a new fixture: `apiClient.mockGitHubReset()` and
+`apiClient.mockGitHubSetUser()` to put the provider in a known state, then
+`apiClient.mockGitHubAssociateTaskPR()` to attach a PR **to the task**.
+
+**`mockGitHubAddPRs()` is the wrong call and SHALL NOT be used for these three
+scenarios.** It is named here only so the mistake is not re-derived: it posts to
+`POST /api/v1/github/mock/prs`, which seeds the mock provider's PR *catalogue* (what
+pickers and listings read) and creates **no task-to-PR association**. A scenario that
+uses it leaves `taskPRs.byTaskId[taskId]` empty, so `PRTaskIcon` renders nothing and
+the PR-before-MR assertion that is the entire point of E3, E6 and E7 can never run.
+`mockGitHubAssociateTaskPR()` posts to `POST /api/v1/github/mock/task-prs` and is the
+call that populates the association the badge reads. No catalogue call is needed
+alongside it; the association alone is sufficient.
+
+Its required arguments are `task_id`, `owner`, `repo`, `pr_number`, `pr_url`,
+`pr_title`, `head_branch`, `base_branch` and `author_login`; `state` is optional and
+SHALL be passed explicitly so the seeded PR's state is not left implicit.
+
+The reference is `e2e/tests/gitlab/mr-task-card-badge.spec.ts`'s own test
+`"AC30/AC37: a linked PR and MR both render, PR before MR, and the badge tooltip names
+a non-open state"`. It is the exact precedent for all three scenarios: it calls
+`mockGitHubReset()`, then `mockGitHubSetUser("test-user")`, then
+`mockGitHubAssociateTaskPR({ task_id, owner: "testorg", repo: "testrepo",
+pr_number: 900, pr_url, pr_title: "Companion PR", head_branch: "feat/companion",
+base_branch: "main", author_login: "test-user", state: "open" })`, and asserts
+PR-before-MR order by `compareDocumentPosition` on the Kanban card. Reading that file
+does not modify it, so AC16 stays literally true.
+
+Neither `mr-task-card-badge.spec.ts` nor `e2e/tests/pr/pr-status-badge.spec.ts` is
+edited or imported from — the same local-copy rule as the GitLab helpers applies, and
+for the same AC16 reason. This is stated because the spec is otherwise precise about
+GitLab seeding and would otherwise leave three of seven E2E scenarios half-specified.
+
+New file `apps/web/e2e/tests/gitlab/mr-sidebar-badge.spec.ts`:
+
+- **E1 — Sidebar shows the badge** — on `/` (board mounts the hydration owner), a
+  task with one linked open MR. Scoped to `app-sidebar`, the row located by
+  `[data-task-row-id="<taskId>"]`, `mr-task-icon-<taskId>` is visible with
+  `data-mr-count="1"` and `data-mr-state="open"`. (AC1, AC19)
+- **E2 — Sidebar shows no badge without an MR** — same route, a task with no
+  linked MR. Inside `app-sidebar`, `mr-task-icon-<taskId>` has count 0. (AC6)
+- **E3 — Sidebar shows PR before MR** — a task with both a mock GitHub PR (seeded
+  per "Where the mock GitHub PR comes from" above) and a linked MR; inside the
+  sidebar row, both badges visible and PR precedes MR by
+  `compareDocumentPosition`. (AC2)
+
+New file `apps/web/e2e/tests/gitlab/mr-tasks-list-badge.spec.ts`:
+
+- **E4 — `/tasks` rich row shows the badge** — navigate to `/tasks`, enable
+  "Show task details" through the `display-button` menu as
+  `task-listing-view-preferences.spec.ts` does, locate the `tasks-list-row` by
+  title, assert `mr-task-icon-<taskId>` inside that row. (AC8, AC19)
+- **E5 — `/tasks` compact row shows neither badge** — same task, details off:
+  inside the row, both `pr-task-icon-<taskId>` and `mr-task-icon-<taskId>` have
+  count 0. (AC10)
+- **E6 — `/tasks` row shows PR before MR** — task with both (mock GitHub PR seeded
+  as above); inside the row, PR precedes MR. (AC9)
+
+New file `apps/web/e2e/tests/gitlab/mobile-mr-tasks-list-badge.spec.ts`:
+
+- **E7 — Mobile `/tasks` row** — mobile viewport, details on, task with both
+  badges (mock GitHub PR seeded as above): the MR badge is visible and
+  `assertNoDocumentHorizontalOverflow` passes. Mirrors
+  `mobile-mr-task-card-badge.spec.ts`. (AC20)
+
+All seven E2E scenarios (E1 to E7) run on `/` or `/tasks`. None mounts
+`TaskPageContent`, so none is exposed to either hydration hole named above.
+
+## Out of scope
+
+Each is a deliberate exclusion, not an oversight.
+
+- **A `merge_request` field on `TaskStatusSummary`, and an MR analogue of the
+  sidebar's `prInfo` fallback.** The summary projection is produced by the
+  backend and carries `pull_request` only. Adding a GitLab counterpart is a
+  backend contract change (projection, WS delivery, bounded-summary spec) that
+  cannot be tested from `apps/web/` alone. Consequence, stated plainly: on a
+  route with no MR hydration owner the sidebar can show a PR badge from the
+  summary while showing no MR badge for the equivalent GitLab task. That gap is
+  this card's, and it is left open on purpose.
+- **An MR analogue of `TaskItemStatsRow`'s `#<number>` text.** Same backend
+  dependency, same reason.
+- **Giving GitLab MR hydration a single provider-level owner.** Already an
+  out-of-scope card on [gitlab-mr-status-chip](../gitlab-mr-status-chip/spec.md);
+  this feature adds one page-level owner where its own badge needs it and
+  consolidates nothing.
+- **Making `useWorkspaceMRs(null)` scope its reset to the workspace it last
+  fetched.** That is the correct long-term fix for the trap AC12 routes around,
+  but it changes a hook four other call sites depend on, including two that rely
+  on the full clear at sign-out. It needs a card that can test all of them.
+  That card also owns **Hole 2** above: the already-shipped gated call in
+  `hooks/domains/workspace/use-external-vcs-file-link.ts`
+  (`useWorkspaceMRs(providers.has("gitlab") ? workspaceId : null)`), which makes
+  the sidebar MR badge nondeterministic on `/t/:taskId` and `/tasks/:id` for a
+  task with no GitLab repository. Two candidate fixes exist — scope the reset, or
+  drop the gate at that call site and let the hook no-op for a workspace with no
+  MRs — and choosing between them requires testing all four call sites, so it is
+  not decided here.
+- **Fixing Hole 1** (desktop `MRTopbarButton` sitting inside `{!isArchived && …}`
+  in `components/task/task-top-bar.tsx`, so an archived task's detail route
+  mounts no MR hydration owner). Changing what the archived top bar renders is a
+  task-detail-surface decision with its own parity questions on the GitHub side.
+- **Consolidating the GitLab e2e seed helpers** (`seedMR`, `linkMR`,
+  `ensureGitLabConfigured`, `seedBoardTask`) into `e2e/helpers/gitlab.ts`. It is
+  worth doing, and it would edit `mr-task-card-badge.spec.ts`, which AC16
+  forbids here. It is a test-only cleanup card covering every GitLab spec at
+  once, not a rider on this one.
+- **Upgrading `MRTaskIcon`'s coarse-pointer disclosure** to a drawer or a
+  tap-to-open popover. The Radix tooltip is inherited as-is, and changing it
+  would change the shipped Kanban badge on every viewport.
+- **Re-tuning GitLab MR status colours, the multi-MR aggregate, or
+  `aggregateMRStatusColor`'s array-order tie.** Frozen verbatim.
+- **Merging the PR and MR badges into one combined contribution badge, or
+  collapsing them behind a count.** Two providers, two badges.
+- **The Azure DevOps row badge.** `components/azure-devops/` is not touched, and
+  the DOM-order ACs name only PR and MR.
+- **Office task surfaces and any other task row that renders no `PRTaskIcon`
+  today.** Only the two surfaces named in Surfaces and mount points gain a badge.
+  (The sidebar's archived rows are *not* excluded — they render through the same
+  `TaskItem` and are covered by the boundary rule above.)
+- **Any change to which tasks appear in the sidebar or on `/tasks`**, to their
+  ordering, grouping, filtering, or pagination.
+
+## Constraints
+
+- Files SHALL stay at most 600 lines and functions at most 100 lines, both
+  `warn` with `skipBlankLines` and `skipComments` (`apps/web/eslint.config.mjs`),
+  under `eslint --max-warnings 0`. `task-item.tsx` is ~660 raw lines today and
+  already carries one `max-lines-per-function` disable on `TaskItem`; the
+  restructure SHALL NOT grow the file's warning count, and extracting the
+  combined badge pair into its own small component is the expected shape.
+- **`tasks-page-client.tsx` has the least headroom of the three, and it is the one
+  file every builder must edit** (AC12 adds an import plus a hook call). Measured
+  by stripping blank and comment-only lines, it sits at roughly **597 of the 600
+  allowed** — slightly tighter than `task-item.tsx` at ~591, despite being the
+  smaller file by raw count (642 vs 660). Treat that figure as approximate: it was
+  derived by hand rather than from an `eslint` run, so the true count may fall
+  either side of the limit. Two lines of margin is not a margin.
+  The builder SHALL therefore check `max-lines` on this file explicitly, before
+  assuming a two-line edit is free. If the edit does push it over, the remedy is an
+  extraction out of `tasks-page-client.tsx` — see the fence below, which permits a
+  sibling under `app/tasks/` for exactly this reason. Do not resolve it by adding an
+  `eslint-disable`: the file carries none today, and silencing a size warning to
+  land a two-line hook call trades a real signal for convenience.
+- Production React changes are confined to `components/task/task-item.tsx`,
+  `app/tasks/rich-task-list-row.tsx` and `app/tasks/tasks-page-client.tsx`,
+  **plus at most one new sibling component file** — under `components/task/` for
+  the badge-pair extraction, or under `app/tasks/` if `tasks-page-client.tsx`
+  needs to shed lines per the bullet above. At most one new file in total, and the
+  builder picks which of the two purposes it serves; if both pressures turn out to
+  be real, that is a genuine second finding and routes back here rather than being
+  absorbed by a second new file. All in-line shapes are permitted too and the
+  choice is the builder's; a new file inherits every constraint the fence carries,
+  in particular AC7 (it SHALL NOT import `useWorkspaceMRs`) and AC18.
+  The fence exists to stop the change spreading into other surfaces, not to force
+  an extraction into an already-oversized file.
+  Test files, E2E specs and page objects are required edits outside that fence
+  and are not restricted by it.
+- The Playwright page object work SHALL extend `e2e/pages/app-sidebar-page.ts`
+  with a row-and-badge accessor rather than adding a parallel sidebar page
+  object; `sidebar-tasks-page.ts` already scopes `sidebar-task-item` and is the
+  shape to follow.
+- Commands that SHALL pass: `cd apps/web && pnpm run typecheck`,
+  `pnpm --filter @kandev/web lint`, `cd apps/web && pnpm run i18n:check`,
+  the vitest suites for the touched files, and the three new E2E specs.
+
+## Related
+
+- [gitlab-integration](../gitlab-integration/spec.md) — the umbrella feature;
+  its badge scope (Kanban card only) is what this card extends.
+- [gitlab-mr-status-chip](../gitlab-mr-status-chip/spec.md) — the sibling
+  parity card; source of the hydration-ownership and colour-freeze exclusions
+  this spec inherits.
+- `apps/web/CLAUDE.md`, "GitHub PR status UI" — the single-derivation invariant
+  the MR side mirrors.


### PR DESCRIPTION
The GitLab merge-request badge only rendered on the Kanban card, so a GitLab-only task looked identical to a task with no linked contribution anywhere else in the app; this extends the existing, unmodified `MRTaskIcon` to the app sidebar's task row and the `/tasks` page's rich row so GitLab parity matches GitHub's.

Spec: [`docs/specs/gitlab-mr-task-list-badges/spec.md`](https://github.com/kdlbs/kandev/blob/main/docs/specs/gitlab-mr-task-list-badges/spec.md)

## Important Changes

- Restructured the sidebar's `TaskPRIcon` early-return (which made an appended MR badge unreachable) into sibling PR/MR badges, extracted into a new `task-contribution-icons.tsx` to keep `task-item.tsx` under the 600-line lint limit.
- Renamed `PrimaryTaskLine`'s `showPullRequest` prop to `showContributions` on the `/tasks` row, since one flag now gates both badges.
- `TasksPageClient` becomes an unconditional GitLab MR hydration owner (`useWorkspaceMRs(s.activeWorkspaceId)`, mirroring `kanban-board.tsx`) rather than reusing the gated `useWorkspacePRs` pattern, because `useWorkspaceMRs(null)` clears every workspace's cached MRs, not just this page's.

## Validation

- `make typecheck`, `make lint` (backend `golangci-lint`, `eslint --max-warnings 0`, harness lint, architecture lint), `make lint-format` — all clean, both before and after rebasing onto current `main`.
- `pnpm run i18n:check` / `pnpm run i18n:ratchet` — clean, no new locale keys or literals (this feature adds none).
- Targeted vitest: `task-item.test.tsx`, `task-item.mr-guard.test.tsx`, `session-task-switcher-sheet.test.tsx`, `kanban-card-content.test.tsx`, `rich-task-list-row.test.tsx`, `tasks-page-client.mr-hydration.test.tsx`, `tasks-list-view.test.tsx`, `use-task-mr.test.ts` — 8 files, 88 tests, all passing, re-verified after rebase.
- Targeted Playwright E2E through the managed runner (`pnpm e2e:run`), desktop + `mobile-chrome`: `mr-sidebar-badge.spec.ts`, `mr-tasks-list-badge.spec.ts`, `mobile-mr-tasks-list-badge.spec.ts`, plus the unmodified `mr-task-card-badge.spec.ts` / `mobile-mr-task-card-badge.spec.ts` as non-regression — 12/12 passing, re-verified after rebase with a fresh build.
- Full-suite `go test ./...` and `make test-web`/`scripts/pr-state.test.sh` surfaced a handful of pre-existing failures unrelated to this change (filesystem-sandbox quirks, a timing-sensitive context-cancellation test, and a bash `unbound variable` in an existing script test); each was reproduced identically against the merge-base commit in an isolated worktree to confirm they predate this branch.

## Possible Improvements

Low risk: pure frontend extension of an already-shipped, unmodified badge component onto two new render surfaces, with no new API, store slice, or WS action; a code review pass flagged three test-rigor gaps (a vacuous assertion clause, one E2E scenario not asserting both badges before its overflow check, and missing settings-reset in three E2E specs) that are recorded as non-blocking follow-up, not defects in the shipped behavior.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- kandev-screenshots-start -->
## Screenshots

![App sidebar task row: PR badge then MR badge, in that order](https://raw.githubusercontent.com/nova28/kandev/bd81f57696ee945de8918cacf2ed7db2d5d5bd66/sidebar-badges.png)

![/tasks rich row: PR badge then MR badge, in that order](https://raw.githubusercontent.com/nova28/kandev/bd81f57696ee945de8918cacf2ed7db2d5d5bd66/tasks-row-badges.png)
<!-- kandev-screenshots-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2613?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
