### PR TITLE
feat(backend): persist subagent fan-out context

### DIFF
--- a/apps/backend/internal/backendapp/adapters.go
+++ b/apps/backend/internal/backendapp/adapters.go
@@ -777,6 +777,16 @@ func (w *orchestratorWrapper) SteerTask(ctx context.Context, taskID, sessionID, 
 	return w.svc.SteerTask(ctx, taskID, sessionID, prompt, model, planMode, attachments)
 }
 
+// subagentContextAdapter adapts the task service to the
+// orchestrator.SubagentContextRecorder interface.
+type subagentContextAdapter struct {
+	svc *taskservice.Service
+}
+
+func (a *subagentContextAdapter) RecordSubagentContext(ctx context.Context, req taskservice.RecordSubagentContextRequest) {
+	a.svc.RecordSubagentContext(ctx, req)
+}
+
 // messageCreatorAdapter adapts the task service to the orchestrator.MessageCreator interface
 type messageCreatorAdapter struct {
 	svc    *taskservice.Service

--- a/apps/backend/internal/backendapp/orchestrator.go
+++ b/apps/backend/internal/backendapp/orchestrator.go
@@ -140,6 +140,7 @@ func provideOrchestrator(
 
 	msgCreator := &messageCreatorAdapter{svc: taskSvc, logger: log}
 	orchestratorSvc.SetMessageCreator(msgCreator)
+	orchestratorSvc.SetSubagentContextRecorder(&subagentContextAdapter{svc: taskSvc})
 
 	orchestratorSvc.SetTurnService(newTurnServiceAdapter(taskSvc))
 

--- a/apps/backend/internal/backendapp/services.go
+++ b/apps/backend/internal/backendapp/services.go
@@ -92,6 +92,7 @@ func provideServices(cfg *config.Config, log *logger.Logger, repos *Repositories
 			Reviews:           repos.Task,
 			ResourceCleanups:  repos.Task,
 			StatusSummaries:   repos.Task,
+			SubagentContexts:  repos.Task,
 		},
 		eventBus,
 		log,

--- a/apps/backend/internal/orchestrator/event_handlers_streaming.go
+++ b/apps/backend/internal/orchestrator/event_handlers_streaming.go
@@ -323,6 +323,12 @@ func (s *Service) handleToolCallEvent(ctx context.Context, payload *lifecycle.Ag
 		return
 	}
 	if s.shouldDropCompletedExecutionStreamEvent(payload) {
+		// A late-arriving frame for an already-completed execution is
+		// correctly dropped for message purposes (see the guard's own
+		// contract), but it can be the ONLY frame that ever recognizes and
+		// settles this subagent — dropping it here too would permanently
+		// omit the row's status/token/duration data (AC-1, AC-11).
+		s.recordSubagentContextFromFrame(ctx, payload, s.nonCreatingActiveTurnID(ctx, payload.SessionID))
 		return
 	}
 
@@ -355,7 +361,11 @@ func (s *Service) handleToolCallEvent(ctx context.Context, payload *lifecycle.Ag
 		// the task to REVIEW) leaves session=RUNNING with task=REVIEW.
 		s.setSessionRunningForExecution(ctx, payload.TaskID, payload.SessionID, payload.ExecutionID)
 	}
-	s.recordSubagentContextFromFrame(ctx, payload, s.getActiveTurnID(payload.SessionID))
+	// Recording a subagent-context observation must never itself start a
+	// turn as a side effect (that would mutate durable state purely to label
+	// a telemetry row) — use the non-creating lookup here even though
+	// message creation above may have legitimately started one already.
+	s.recordSubagentContextFromFrame(ctx, payload, s.nonCreatingActiveTurnID(ctx, payload.SessionID))
 
 	ownership := toolOwnershipForeground
 	if payload.Data.ParentToolCallID != "" {
@@ -539,6 +549,10 @@ func (s *Service) handleToolUpdateEvent(ctx context.Context, payload *lifecycle.
 		return
 	}
 	if s.shouldDropCompletedExecutionStreamEvent(payload) {
+		// See the matching guard in handleToolCallEvent: a dropped update can
+		// be the subagent's final terminal frame, and must still settle the
+		// durable row even though the message side is correctly ignored.
+		s.recordSubagentContextFromFrame(ctx, payload, s.nonCreatingActiveTurnID(ctx, payload.SessionID))
 		return
 	}
 	ownership := s.resolveToolUpdateOwnership(payload)
@@ -598,8 +612,14 @@ func (s *Service) persistToolUpdateMessage(ctx context.Context, payload *lifecyc
 			// update-only reconciliation and cannot wake a settled session.
 			turnID = ""
 		}
-	} else {
+	} else if s.messageCreator != nil {
+		// Only message creation needs a turn to attach a fallback-created
+		// card to, which is why this branch alone may lazily start one.
+		// Recording subagent context must never create a turn merely to
+		// label a row — see nonCreatingActiveTurnID.
 		turnID = s.getActiveTurnID(payload.SessionID)
+	} else {
+		turnID = s.nonCreatingActiveTurnID(ctx, payload.SessionID)
 	}
 
 	// Message persistence is optional (see SetMessageCreator); turn-id
@@ -814,6 +834,22 @@ func (s *Service) recordSubagentContextFromFrame(ctx context.Context, payload *l
 		Payload:          subagentTask,
 		ObservedAt:       time.Now().UTC(),
 	})
+}
+
+// nonCreatingActiveTurnID resolves sessionID's active turn without ever
+// starting one — unlike getActiveTurnID, whose doc comment explains it
+// lazily starts a turn "even in edge cases like resumed sessions". Every
+// caller here uses the result only to label a subagent-context row, never to
+// attach a message, so recording an observation must never itself mutate
+// state by creating a durable turn as a side effect. A lookup error is
+// treated as "no turn known", matching the fail-closed pattern already used
+// for terminal tool updates below.
+func (s *Service) nonCreatingActiveTurnID(ctx context.Context, sessionID string) string {
+	turnID, err := s.peekActiveTurnID(ctx, sessionID)
+	if err != nil {
+		return ""
+	}
+	return turnID
 }
 
 func (s *Service) shouldDropCompletedExecutionStreamEvent(payload *lifecycle.AgentStreamEventPayload) bool {

--- a/apps/backend/internal/orchestrator/event_handlers_streaming.go
+++ b/apps/backend/internal/orchestrator/event_handlers_streaming.go
@@ -566,10 +566,6 @@ func (s *Service) handleToolUpdateEvent(ctx context.Context, payload *lifecycle.
 // Split out of handleToolUpdateEvent to keep that function within the
 // package's function-length limits; no behavior change.
 func (s *Service) persistToolUpdateMessage(ctx context.Context, payload *lifecycle.AgentStreamEventPayload) {
-	if s.messageCreator == nil {
-		return
-	}
-
 	// Determine message type from normalized payload for fallback creation
 	msgType := toolKindToMessageType(payload.Data.Normalized)
 	status := payload.Data.ToolStatus
@@ -596,30 +592,34 @@ func (s *Service) persistToolUpdateMessage(ctx context.Context, payload *lifecyc
 	} else {
 		turnID = s.getActiveTurnID(payload.SessionID)
 	}
-	fallbackMsgType := msgType
-	if terminal && turnID == "" {
-		// A late terminal update can update its existing card, but must not
-		// create a message (and implicitly a turn) after the turn settled.
-		fallbackMsgType = ""
-	}
 
-	if err := s.messageCreator.UpdateToolCallMessage(
-		ctx,
-		payload.TaskID,
-		payload.Data.ToolCallID,
-		payload.Data.ParentToolCallID, // Pass parent for subagent nesting
-		status,
-		"", // result - no longer used, tool results in NormalizedPayload
-		payload.SessionID,
-		payload.Data.ToolTitle,  // Include title from update event
-		turnID,                  // Turn ID for fallback creation
-		fallbackMsgType,         // Empty for settled terminal reconciliations
-		payload.Data.Normalized, // Pass normalized tool data for message metadata
-	); err != nil {
-		s.logger.Warn("failed to update tool call message",
-			zap.String("task_id", payload.TaskID),
-			zap.String("tool_call_id", payload.Data.ToolCallID),
-			zap.Error(err))
+	// Message persistence is optional (see SetMessageCreator); turn-id
+	// resolution and subagent-context recording below must not depend on it.
+	if s.messageCreator != nil {
+		fallbackMsgType := msgType
+		if terminal && turnID == "" {
+			// A late terminal update can update its existing card, but must not
+			// create a message (and implicitly a turn) after the turn settled.
+			fallbackMsgType = ""
+		}
+		if err := s.messageCreator.UpdateToolCallMessage(
+			ctx,
+			payload.TaskID,
+			payload.Data.ToolCallID,
+			payload.Data.ParentToolCallID, // Pass parent for subagent nesting
+			status,
+			"", // result - no longer used, tool results in NormalizedPayload
+			payload.SessionID,
+			payload.Data.ToolTitle,  // Include title from update event
+			turnID,                  // Turn ID for fallback creation
+			fallbackMsgType,         // Empty for settled terminal reconciliations
+			payload.Data.Normalized, // Pass normalized tool data for message metadata
+		); err != nil {
+			s.logger.Warn("failed to update tool call message",
+				zap.String("task_id", payload.TaskID),
+				zap.String("tool_call_id", payload.Data.ToolCallID),
+				zap.Error(err))
+		}
 	}
 	s.recordSubagentContextFromFrame(ctx, payload, turnID)
 

--- a/apps/backend/internal/orchestrator/event_handlers_streaming.go
+++ b/apps/backend/internal/orchestrator/event_handlers_streaming.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kandev/kandev/internal/orchestrator/executor"
 	"github.com/kandev/kandev/internal/orchestrator/sessionstate"
 	"github.com/kandev/kandev/internal/task/models"
+	taskservice "github.com/kandev/kandev/internal/task/service"
 	v1 "github.com/kandev/kandev/pkg/api/v1"
 )
 
@@ -349,6 +350,7 @@ func (s *Service) handleToolCallEvent(ctx context.Context, payload *lifecycle.Ag
 		// the task to REVIEW) leaves session=RUNNING with task=REVIEW.
 		s.setSessionRunningForExecution(ctx, payload.TaskID, payload.SessionID, payload.ExecutionID)
 	}
+	s.recordSubagentContextFromFrame(ctx, payload, s.getActiveTurnID(payload.SessionID))
 
 	ownership := toolOwnershipForeground
 	if payload.Data.ParentToolCallID != "" {
@@ -619,6 +621,7 @@ func (s *Service) persistToolUpdateMessage(ctx context.Context, payload *lifecyc
 			zap.String("tool_call_id", payload.Data.ToolCallID),
 			zap.Error(err))
 	}
+	s.recordSubagentContextFromFrame(ctx, payload, turnID)
 
 	// Terminal updates only wake an async turn that was established by prior
 	// substantive output. A standalone terminal reconciliation belongs to the
@@ -766,6 +769,42 @@ func isTerminalToolStatus(status string) bool {
 	default:
 		return false
 	}
+}
+
+// recordSubagentContextFromFrame persists a durable relational record of a
+// subagent (Task tool) invocation when this frame's normalized payload is a
+// recognized subagent_task. No-op when subagentContexts is unwired, when the
+// frame isn't a subagent_task, or when the normalizer hasn't yet attached the
+// typed payload (the initial tool_call for Claude/OpenCode carries none —
+// recognition happens on a later tool_call_update, see AC-1a). turnID is
+// whatever the call site already resolved; this helper never re-derives one.
+//
+// payload.SessionID is the Kandev task session id despite the
+// agentSessionID-shaped naming downstream: messageCreatorAdapter passes the
+// same value into CreateMessageRequest.TaskSessionID
+// (internal/backendapp/adapters.go:879).
+func (s *Service) recordSubagentContextFromFrame(ctx context.Context, payload *lifecycle.AgentStreamEventPayload, turnID string) {
+	if s.subagentContexts == nil || payload == nil || payload.Data == nil {
+		return
+	}
+	normalized := payload.Data.Normalized
+	if normalized == nil || normalized.Kind() != streams.ToolKindSubagentTask {
+		return
+	}
+	subagentTask := normalized.SubagentTask()
+	if subagentTask == nil {
+		return
+	}
+	s.subagentContexts.RecordSubagentContext(ctx, taskservice.RecordSubagentContextRequest{
+		TaskSessionID:    payload.SessionID,
+		TaskID:           payload.TaskID,
+		TurnID:           turnID,
+		ToolCallID:       payload.Data.ToolCallID,
+		ParentToolCallID: payload.Data.ParentToolCallID,
+		ToolStatus:       payload.Data.ToolStatus,
+		Payload:          subagentTask,
+		ObservedAt:       time.Now().UTC(),
+	})
 }
 
 func (s *Service) shouldDropCompletedExecutionStreamEvent(payload *lifecycle.AgentStreamEventPayload) bool {

--- a/apps/backend/internal/orchestrator/event_handlers_streaming.go
+++ b/apps/backend/internal/orchestrator/event_handlers_streaming.go
@@ -315,6 +315,11 @@ func (s *Service) handleToolCallEvent(ctx context.Context, payload *lifecycle.Ag
 		s.logger.Warn("missing session_id for tool_call",
 			zap.String("task_id", payload.TaskID),
 			zap.String("tool_call_id", payload.Data.ToolCallID))
+		// A recognized subagent_task frame with no session id is exactly the
+		// AC-2 identity-skip case (skipped_no_identity++): this guard predates
+		// the subagent-context feature and exists to protect message
+		// creation, so it must not silently swallow that counter too.
+		s.recordSubagentContextFromFrame(ctx, payload, "")
 		return
 	}
 	if s.shouldDropCompletedExecutionStreamEvent(payload) {
@@ -527,6 +532,10 @@ func (s *Service) handleToolUpdateEvent(ctx context.Context, payload *lifecycle.
 		s.logger.Warn("missing session_id for tool_update",
 			zap.String("task_id", payload.TaskID),
 			zap.String("tool_call_id", payload.Data.ToolCallID))
+		// See the matching comment in handleToolCallEvent: this guard
+		// predates the subagent-context feature and must not silently
+		// swallow the AC-2 skipped_no_identity counter.
+		s.recordSubagentContextFromFrame(ctx, payload, "")
 		return
 	}
 	if s.shouldDropCompletedExecutionStreamEvent(payload) {

--- a/apps/backend/internal/orchestrator/event_handlers_streaming_subagent_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_streaming_subagent_test.go
@@ -384,3 +384,136 @@ func TestSubagentContextRecordedThroughRealServiceAndRepository(t *testing.T) {
 	require.NotNil(t, row.TotalTokens)
 	require.Equal(t, int64(500), *row.TotalTokens)
 }
+
+// TestHandleToolUpdateEventFromCompletedExecutionStillRecordsSubagentContext
+// covers AC-1/AC-11: shouldDropCompletedExecutionStreamEvent correctly drops
+// a late frame for message purposes, but a subagent's final terminal
+// tool_update can be exactly that late frame — dropping it there too would
+// leave the durable row permanently unsettled with no status/token/duration
+// data, even though this frame carries all of it.
+func TestHandleToolUpdateEventFromCompletedExecutionStillRecordsSubagentContext(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "task1", "session1", "step1")
+
+	svc := createTestService(repo, newMockStepGetter(), newMockTaskRepo())
+	svc.turnService = &repoTurnService{repo: repo}
+	messages := &mockMessageCreator{}
+	svc.messageCreator = messages
+	seedActiveTurn(t, svc, repo, "task1", "session1", "turn1")
+	recorder := &fakeSubagentContextRecorder{}
+	svc.subagentContexts = recorder
+	svc.markExecutionCompleted("session1", "exec-1")
+
+	terminalPayload := streams.NewSubagentTask("d", "p", "reviewer")
+	terminalPayload.SubagentTask().Status = "completed"
+	terminalPayload.SubagentTask().TotalTokens = 500
+	svc.handleToolUpdateEvent(ctx, &lifecycle.AgentStreamEventPayload{
+		TaskID: "task1", SessionID: "session1", ExecutionID: "exec-1",
+		Data: &lifecycle.AgentStreamEventData{
+			Type: "tool_update", ToolCallID: "tc-late", ToolStatus: agentEventComplete,
+			Normalized: terminalPayload,
+		},
+	})
+
+	require.Zero(t, messages.toolUpdateWrites,
+		"the completed-execution guard must still drop the message side")
+	requests := recorder.all()
+	require.Len(t, requests, 1,
+		"a subagent's terminal frame must still be recorded even after its execution is marked complete")
+	require.Equal(t, "tc-late", requests[0].ToolCallID)
+	require.Equal(t, agentEventComplete, requests[0].ToolStatus)
+}
+
+// TestHandleToolCallEventFromCompletedExecutionStillRecordsSubagentContext is
+// the tool_call-path counterpart: the very first recognizable frame for a
+// subagent can itself arrive after its execution is marked complete, and
+// dropping it there would mean the row never gets created at all (not just
+// unsettled) — a stronger violation of AC-1.
+func TestHandleToolCallEventFromCompletedExecutionStillRecordsSubagentContext(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "task1", "session1", "step1")
+
+	svc := createTestService(repo, newMockStepGetter(), newMockTaskRepo())
+	svc.turnService = &repoTurnService{repo: repo}
+	messages := &mockMessageCreator{}
+	svc.messageCreator = messages
+	seedActiveTurn(t, svc, repo, "task1", "session1", "turn1")
+	recorder := &fakeSubagentContextRecorder{}
+	svc.subagentContexts = recorder
+	svc.markExecutionCompleted("session1", "exec-1")
+
+	svc.handleToolCallEvent(ctx, newSubagentTaskToolCallPayload(
+		"task1", "session1", "tc-late-call", "", "pending", streams.NewSubagentTask("d", "p", "reviewer")))
+
+	require.Zero(t, messages.toolCallWrites,
+		"the completed-execution guard must still drop the message side")
+	requests := recorder.all()
+	require.Len(t, requests, 1,
+		"a subagent's first recognizable frame must still be recorded even after its execution is marked complete")
+	require.Equal(t, "tc-late-call", requests[0].ToolCallID)
+}
+
+// TestHandleToolUpdateEventNilMessageCreatorDoesNotCreateTurn covers the
+// coderabbitai/getActiveTurnID finding: recording a subagent-context
+// observation must never itself start a turn as a side effect. With no
+// active turn seeded and messageCreator nil, a non-terminal tool_update
+// previously called the turn-CREATING getActiveTurnID purely to label the
+// subagent row, silently starting a durable turn for a session that never
+// asked for one.
+func TestHandleToolUpdateEventNilMessageCreatorDoesNotCreateTurn(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "task1", "session1", "step1")
+
+	svc := createTestService(repo, newMockStepGetter(), newMockTaskRepo())
+	svc.turnService = &repoTurnService{repo: repo}
+	svc.messageCreator = nil
+	recorder := &fakeSubagentContextRecorder{}
+	svc.subagentContexts = recorder
+
+	updatePayload := streams.NewSubagentTask("review the diff", "prompt", "security-reviewer")
+	svc.handleToolUpdateEvent(ctx, &lifecycle.AgentStreamEventPayload{
+		TaskID: "task1", SessionID: "session1", ExecutionID: "exec-1",
+		Data: &lifecycle.AgentStreamEventData{
+			Type: "tool_update", ToolCallID: "tc-1", ToolStatus: "in_progress",
+			Normalized: updatePayload,
+		},
+	})
+
+	requests := recorder.all()
+	require.Len(t, requests, 1)
+	require.Empty(t, requests[0].TurnID,
+		"no turn existed and none should have been created merely to label this row")
+	turns, err := repo.ListTurnsBySession(ctx, "session1")
+	require.NoError(t, err)
+	require.Empty(t, turns, "recording subagent context alone must not create a durable turn")
+}
+
+// TestHandleToolCallEventNilMessageCreatorDoesNotCreateTurn is the tool_call
+// counterpart: the new unconditional recordSubagentContextFromFrame call in
+// handleToolCallEvent must use the same non-creating turn lookup as the
+// tool_update path.
+func TestHandleToolCallEventNilMessageCreatorDoesNotCreateTurn(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "task1", "session1", "step1")
+
+	svc := createTestService(repo, newMockStepGetter(), newMockTaskRepo())
+	svc.turnService = &repoTurnService{repo: repo}
+	svc.messageCreator = nil
+	recorder := &fakeSubagentContextRecorder{}
+	svc.subagentContexts = recorder
+
+	svc.handleToolCallEvent(ctx, newSubagentTaskToolCallPayload(
+		"task1", "session1", "tc-1", "", "pending", streams.NewSubagentTask("d", "p", "reviewer")))
+
+	requests := recorder.all()
+	require.Len(t, requests, 1)
+	require.Empty(t, requests[0].TurnID,
+		"no turn existed and none should have been created merely to label this row")
+	turns, err := repo.ListTurnsBySession(ctx, "session1")
+	require.NoError(t, err)
+	require.Empty(t, turns, "recording subagent context alone must not create a durable turn")
+}

--- a/apps/backend/internal/orchestrator/event_handlers_streaming_subagent_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_streaming_subagent_test.go
@@ -1,0 +1,298 @@
+package orchestrator
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kandev/kandev/internal/agent/runtime/lifecycle"
+	"github.com/kandev/kandev/internal/agentctl/types/streams"
+	"github.com/kandev/kandev/internal/events/bus"
+	"github.com/kandev/kandev/internal/task/models"
+	sqliterepo "github.com/kandev/kandev/internal/task/repository/sqlite"
+	taskservice "github.com/kandev/kandev/internal/task/service"
+)
+
+// fakeSubagentContextRecorder records every RecordSubagentContext call it
+// receives, for unit-level assertions on what the orchestrator handlers
+// build without going through a real repository.
+type fakeSubagentContextRecorder struct {
+	mu       sync.Mutex
+	requests []taskservice.RecordSubagentContextRequest
+}
+
+func (r *fakeSubagentContextRecorder) RecordSubagentContext(_ context.Context, req taskservice.RecordSubagentContextRequest) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.requests = append(r.requests, req)
+}
+
+func (r *fakeSubagentContextRecorder) all() []taskservice.RecordSubagentContextRequest {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]taskservice.RecordSubagentContextRequest, len(r.requests))
+	copy(out, r.requests)
+	return out
+}
+
+// serviceBackedSubagentContextRecorder adapts a real *taskservice.Service to
+// orchestrator.SubagentContextRecorder, mirroring
+// backendapp.subagentContextAdapter, so the integration test below exercises
+// handler -> service -> repository end to end (same pattern as
+// serviceBackedMessageCreator / newServiceBackedMessageCreator above).
+type serviceBackedSubagentContextRecorder struct {
+	svc *taskservice.Service
+}
+
+func (r *serviceBackedSubagentContextRecorder) RecordSubagentContext(ctx context.Context, req taskservice.RecordSubagentContextRequest) {
+	r.svc.RecordSubagentContext(ctx, req)
+}
+
+// seedActiveTurn creates an open turn row and warms the in-memory active-turn
+// cache getActiveTurnID reads first, so tests don't race a lazily-started
+// turn with a different ID than the one they seeded.
+func seedActiveTurn(t *testing.T, svc *Service, repo *sqliterepo.Repository, taskID, sessionID, turnID string) {
+	t.Helper()
+	now := time.Now().UTC()
+	require.NoError(t, repo.CreateTurn(context.Background(), &models.Turn{
+		ID: turnID, TaskSessionID: sessionID, TaskID: taskID,
+		StartedAt: now, CreatedAt: now, UpdatedAt: now,
+	}))
+	svc.activeTurns.Store(sessionID, turnID)
+}
+
+func newSubagentTaskToolCallPayload(taskID, sessionID, toolCallID, parentToolCallID, toolStatus string, normalized *streams.NormalizedPayload) *lifecycle.AgentStreamEventPayload {
+	return &lifecycle.AgentStreamEventPayload{
+		TaskID: taskID, SessionID: sessionID, ExecutionID: "exec-1",
+		Data: &lifecycle.AgentStreamEventData{
+			Type: "tool_call", ToolCallID: toolCallID, ParentToolCallID: parentToolCallID,
+			ToolStatus: toolStatus, ToolTitle: "Task", Normalized: normalized,
+		},
+	}
+}
+
+// TestHandleToolCallEventRecordsSubagentContext covers AC-1: a subagent_task
+// frame on handleToolCallEvent records a context with the active turn id.
+func TestHandleToolCallEventRecordsSubagentContext(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "task1", "session1", "step1")
+
+	svc := createTestService(repo, newMockStepGetter(), newMockTaskRepo())
+	svc.turnService = &repoTurnService{repo: repo}
+	svc.messageCreator = newServiceBackedMessageCreator(repo)
+	seedActiveTurn(t, svc, repo, "task1", "session1", "turn1")
+	recorder := &fakeSubagentContextRecorder{}
+	svc.subagentContexts = recorder
+
+	normalized := streams.NewSubagentTask("review the diff", "prompt", "security-reviewer")
+	svc.handleToolCallEvent(ctx, newSubagentTaskToolCallPayload("task1", "session1", "tc-1", "", "pending", normalized))
+
+	requests := recorder.all()
+	require.Len(t, requests, 1)
+	req := requests[0]
+	require.Equal(t, "session1", req.TaskSessionID)
+	require.Equal(t, "task1", req.TaskID)
+	require.Equal(t, "turn1", req.TurnID)
+	require.Equal(t, "tc-1", req.ToolCallID)
+	require.Equal(t, "pending", req.ToolStatus)
+	require.NotNil(t, req.Payload)
+	require.Equal(t, "security-reviewer", req.Payload.SubagentType)
+}
+
+// TestHandleToolUpdateEventRecordsSubagentContextAgain covers AC-3: a later
+// frame for the same tool call on the update path records again, so the
+// upsert's merge path runs.
+func TestHandleToolUpdateEventRecordsSubagentContextAgain(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "task1", "session1", "step1")
+
+	svc := createTestService(repo, newMockStepGetter(), newMockTaskRepo())
+	svc.turnService = &repoTurnService{repo: repo}
+	svc.messageCreator = newServiceBackedMessageCreator(repo)
+	seedActiveTurn(t, svc, repo, "task1", "session1", "turn1")
+	recorder := &fakeSubagentContextRecorder{}
+	svc.subagentContexts = recorder
+
+	launchPayload := streams.NewSubagentTask("review the diff", "prompt", "security-reviewer")
+	svc.handleToolCallEvent(ctx, newSubagentTaskToolCallPayload("task1", "session1", "tc-1", "", "pending", launchPayload))
+
+	updatePayload := streams.NewSubagentTask("review the diff", "prompt", "security-reviewer")
+	updatePayload.SubagentTask().Status = "completed"
+	svc.handleToolUpdateEvent(ctx, &lifecycle.AgentStreamEventPayload{
+		TaskID: "task1", SessionID: "session1", ExecutionID: "exec-1",
+		Data: &lifecycle.AgentStreamEventData{
+			Type: "tool_update", ToolCallID: "tc-1", ToolStatus: "in_progress",
+			Normalized: updatePayload,
+		},
+	})
+
+	requests := recorder.all()
+	require.Len(t, requests, 2, "one recorded request per frame")
+	require.Equal(t, "turn1", requests[0].TurnID)
+	require.Equal(t, "turn1", requests[1].TurnID)
+}
+
+// TestHandleToolUpdateEventCarriesTerminalToolStatus covers AC-11: a terminal
+// update's ACP tool_status reaches the recorded request.
+func TestHandleToolUpdateEventCarriesTerminalToolStatus(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "task1", "session1", "step1")
+
+	svc := createTestService(repo, newMockStepGetter(), newMockTaskRepo())
+	svc.turnService = &repoTurnService{repo: repo}
+	svc.messageCreator = newServiceBackedMessageCreator(repo)
+	seedActiveTurn(t, svc, repo, "task1", "session1", "turn1")
+	recorder := &fakeSubagentContextRecorder{}
+	svc.subagentContexts = recorder
+
+	svc.handleToolCallEvent(ctx, newSubagentTaskToolCallPayload(
+		"task1", "session1", "tc-1", "", "pending", streams.NewSubagentTask("d", "p", "reviewer")))
+
+	terminalPayload := streams.NewSubagentTask("d", "p", "reviewer")
+	terminalPayload.SubagentTask().Status = "completed"
+	svc.handleToolUpdateEvent(ctx, &lifecycle.AgentStreamEventPayload{
+		TaskID: "task1", SessionID: "session1", ExecutionID: "exec-1",
+		Data: &lifecycle.AgentStreamEventData{
+			Type: "tool_update", ToolCallID: "tc-1", ToolStatus: agentEventComplete,
+			Normalized: terminalPayload,
+		},
+	})
+
+	requests := recorder.all()
+	require.Len(t, requests, 2)
+	require.Equal(t, agentEventComplete, requests[1].ToolStatus)
+}
+
+// TestHandleToolCallEventIgnoresNonSubagentKind covers "a non-subagent_task
+// normalized kind records nothing".
+func TestHandleToolCallEventIgnoresNonSubagentKind(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "task1", "session1", "step1")
+
+	svc := createTestService(repo, newMockStepGetter(), newMockTaskRepo())
+	svc.turnService = &repoTurnService{repo: repo}
+	svc.messageCreator = newServiceBackedMessageCreator(repo)
+	seedActiveTurn(t, svc, repo, "task1", "session1", "turn1")
+	recorder := &fakeSubagentContextRecorder{}
+	svc.subagentContexts = recorder
+
+	svc.handleToolCallEvent(ctx, &lifecycle.AgentStreamEventPayload{
+		TaskID: "task1", SessionID: "session1", ExecutionID: "exec-1",
+		Data: &lifecycle.AgentStreamEventData{
+			Type: "tool_call", ToolCallID: "tc-read", ToolStatus: "pending",
+			Normalized: streams.NewReadFile("/tmp/file.txt", 0, 100),
+		},
+	})
+
+	require.Empty(t, recorder.all())
+}
+
+// TestHandleToolCallEventNilSubagentContextsRecorderIsSafe covers AC-27: a
+// nil recorder must not panic, and the message write still happens.
+func TestHandleToolCallEventNilSubagentContextsRecorderIsSafe(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "task1", "session1", "step1")
+
+	svc := createTestService(repo, newMockStepGetter(), newMockTaskRepo())
+	svc.turnService = &repoTurnService{repo: repo}
+	messages := &mockMessageCreator{}
+	svc.messageCreator = messages
+	seedActiveTurn(t, svc, repo, "task1", "session1", "turn1")
+	require.Nil(t, svc.subagentContexts)
+
+	require.NotPanics(t, func() {
+		svc.handleToolCallEvent(ctx, newSubagentTaskToolCallPayload(
+			"task1", "session1", "tc-1", "", "pending", streams.NewSubagentTask("d", "p", "reviewer")))
+	})
+
+	require.Equal(t, 1, messages.toolCallWrites, "message write must proceed even without a subagent context recorder")
+}
+
+// TestHandleToolCallEventRecordsNestedSubagent covers AC-6: a nested frame
+// (ParentToolCallID set) is recorded, not dropped.
+func TestHandleToolCallEventRecordsNestedSubagent(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "task1", "session1", "step1")
+
+	svc := createTestService(repo, newMockStepGetter(), newMockTaskRepo())
+	svc.turnService = &repoTurnService{repo: repo}
+	svc.messageCreator = newServiceBackedMessageCreator(repo)
+	seedActiveTurn(t, svc, repo, "task1", "session1", "turn1")
+	recorder := &fakeSubagentContextRecorder{}
+	svc.subagentContexts = recorder
+
+	svc.handleToolCallEvent(ctx, newSubagentTaskToolCallPayload(
+		"task1", "session1", "tc-nested-child", "tc-nested-parent", "pending",
+		streams.NewSubagentTask("d", "p", "reviewer")))
+
+	requests := recorder.all()
+	require.Len(t, requests, 1)
+	require.Equal(t, "tc-nested-parent", requests[0].ParentToolCallID)
+}
+
+// TestSubagentContextRecordedThroughRealServiceAndRepository is the
+// integration case: handler -> real taskservice.Service -> real repository,
+// mirroring newServiceBackedMessageCreator's pattern for messages. Confirms
+// the wiring in backendapp.subagentContextAdapter is exercised end to end and
+// that a terminal update settles the row.
+func TestSubagentContextRecordedThroughRealServiceAndRepository(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "task1", "session1", "step1")
+
+	svc := createTestService(repo, newMockStepGetter(), newMockTaskRepo())
+	svc.turnService = &repoTurnService{repo: repo}
+	svc.messageCreator = newServiceBackedMessageCreator(repo)
+	seedActiveTurn(t, svc, repo, "task1", "session1", "turn1")
+
+	taskSvc := taskservice.NewService(taskservice.Repos{
+		Workspaces:       repo,
+		Tasks:            repo,
+		TaskRepos:        repo,
+		Workflows:        repo,
+		Messages:         repo,
+		Turns:            repo,
+		Sessions:         repo,
+		GitSnapshots:     repo,
+		RepoEntities:     repo,
+		Executors:        repo,
+		Environments:     repo,
+		TaskEnvironments: repo,
+		Reviews:          repo,
+		SubagentContexts: repo,
+	}, bus.NewMemoryEventBus(testLogger()), testLogger(), taskservice.RepositoryDiscoveryConfig{})
+	svc.subagentContexts = &serviceBackedSubagentContextRecorder{svc: taskSvc}
+
+	svc.handleToolCallEvent(ctx, newSubagentTaskToolCallPayload(
+		"task1", "session1", "tc-e2e", "", "pending", streams.NewSubagentTask("d", "p", "reviewer")))
+
+	terminalPayload := streams.NewSubagentTask("d", "p", "reviewer")
+	terminalPayload.SubagentTask().Status = "completed"
+	terminalPayload.SubagentTask().TotalTokens = 500
+	svc.handleToolUpdateEvent(ctx, &lifecycle.AgentStreamEventPayload{
+		TaskID: "task1", SessionID: "session1", ExecutionID: "exec-1",
+		Data: &lifecycle.AgentStreamEventData{
+			Type: "tool_update", ToolCallID: "tc-e2e", ToolStatus: agentEventComplete,
+			Normalized: terminalPayload,
+		},
+	})
+
+	rows, err := repo.ListSubagentContextsBySession(ctx, "session1")
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	row := rows[0]
+	require.Equal(t, "tc-e2e", row.ToolCallID)
+	require.Equal(t, "live", row.Source)
+	require.NotNil(t, row.SettledAt)
+	require.NotNil(t, row.TotalTokens)
+	require.Equal(t, int64(500), *row.TotalTokens)
+}

--- a/apps/backend/internal/orchestrator/event_handlers_streaming_subagent_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_streaming_subagent_test.go
@@ -194,6 +194,58 @@ func TestHandleToolCallEventIgnoresNonSubagentKind(t *testing.T) {
 	require.Empty(t, recorder.all())
 }
 
+// TestHandleToolCallEventRecordsSkipCounterEvenWithEmptySessionID covers
+// AC-2: a subagent_task frame with an empty session id must still reach the
+// subagent-context identity gate (which increments skipped_no_identity) —
+// not be swallowed by the pre-existing "missing session_id" guard at the top
+// of handleToolCallEvent, which predates this feature and exists to protect
+// message creation, not subagent-context writer health.
+func TestHandleToolCallEventRecordsSkipCounterEvenWithEmptySessionID(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "task1", "session1", "step1")
+
+	svc := createTestService(repo, newMockStepGetter(), newMockTaskRepo())
+	svc.turnService = &repoTurnService{repo: repo}
+	svc.messageCreator = newServiceBackedMessageCreator(repo)
+	recorder := &fakeSubagentContextRecorder{}
+	svc.subagentContexts = recorder
+
+	svc.handleToolCallEvent(ctx, newSubagentTaskToolCallPayload(
+		"task1", "", "tc-1", "", "pending", streams.NewSubagentTask("d", "p", "reviewer")))
+
+	requests := recorder.all()
+	require.Len(t, requests, 1, "an empty session id must still reach the identity gate so skipped_no_identity increments")
+	require.Empty(t, requests[0].TaskSessionID)
+}
+
+// TestHandleToolUpdateEventRecordsSkipCounterEvenWithEmptySessionID is the
+// tool_update-path counterpart of
+// TestHandleToolCallEventRecordsSkipCounterEvenWithEmptySessionID.
+func TestHandleToolUpdateEventRecordsSkipCounterEvenWithEmptySessionID(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "task1", "session1", "step1")
+
+	svc := createTestService(repo, newMockStepGetter(), newMockTaskRepo())
+	svc.turnService = &repoTurnService{repo: repo}
+	svc.messageCreator = newServiceBackedMessageCreator(repo)
+	recorder := &fakeSubagentContextRecorder{}
+	svc.subagentContexts = recorder
+
+	svc.handleToolUpdateEvent(ctx, &lifecycle.AgentStreamEventPayload{
+		TaskID: "task1", SessionID: "", ExecutionID: "exec-1",
+		Data: &lifecycle.AgentStreamEventData{
+			Type: "tool_update", ToolCallID: "tc-1", ToolStatus: "in_progress",
+			Normalized: streams.NewSubagentTask("d", "p", "reviewer"),
+		},
+	})
+
+	requests := recorder.all()
+	require.Len(t, requests, 1, "an empty session id must still reach the identity gate so skipped_no_identity increments")
+	require.Empty(t, requests[0].TaskSessionID)
+}
+
 // TestHandleToolCallEventNilSubagentContextsRecorderIsSafe covers AC-27: a
 // nil recorder must not panic, and the message write still happens.
 func TestHandleToolCallEventNilSubagentContextsRecorderIsSafe(t *testing.T) {

--- a/apps/backend/internal/orchestrator/event_handlers_streaming_subagent_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_streaming_subagent_test.go
@@ -216,6 +216,42 @@ func TestHandleToolCallEventNilSubagentContextsRecorderIsSafe(t *testing.T) {
 	require.Equal(t, 1, messages.toolCallWrites, "message write must proceed even without a subagent context recorder")
 }
 
+// TestHandleToolUpdateEventNilMessageCreatorStillRecordsSubagentContext covers
+// the reverse combination of TestHandleToolCallEventNilSubagentContextsRecorderIsSafe:
+// messageCreator nil, subagentContexts recorder set, on the tool_update path.
+// persistToolUpdateMessage must not let its message-persistence guard (nil is
+// a supported SetMessageCreator configuration) block subagent-context
+// recording, mirroring handleToolCallEvent's already-correct behavior for the
+// insert path.
+func TestHandleToolUpdateEventNilMessageCreatorStillRecordsSubagentContext(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "task1", "session1", "step1")
+
+	svc := createTestService(repo, newMockStepGetter(), newMockTaskRepo())
+	svc.turnService = &repoTurnService{repo: repo}
+	svc.messageCreator = nil
+	seedActiveTurn(t, svc, repo, "task1", "session1", "turn1")
+	recorder := &fakeSubagentContextRecorder{}
+	svc.subagentContexts = recorder
+
+	updatePayload := streams.NewSubagentTask("review the diff", "prompt", "security-reviewer")
+	updatePayload.SubagentTask().Status = "completed"
+	require.NotPanics(t, func() {
+		svc.handleToolUpdateEvent(ctx, &lifecycle.AgentStreamEventPayload{
+			TaskID: "task1", SessionID: "session1", ExecutionID: "exec-1",
+			Data: &lifecycle.AgentStreamEventData{
+				Type: "tool_update", ToolCallID: "tc-1", ToolStatus: "in_progress",
+				Normalized: updatePayload,
+			},
+		})
+	})
+
+	requests := recorder.all()
+	require.Len(t, requests, 1, "subagent context recording must not depend on messageCreator being wired")
+	require.Equal(t, "turn1", requests[0].TurnID)
+}
+
 // TestHandleToolCallEventRecordsNestedSubagent covers AC-6: a nested frame
 // (ParentToolCallID set) is recorded, not dropped.
 func TestHandleToolCallEventRecordsNestedSubagent(t *testing.T) {

--- a/apps/backend/internal/orchestrator/service.go
+++ b/apps/backend/internal/orchestrator/service.go
@@ -37,6 +37,7 @@ import (
 	"github.com/kandev/kandev/internal/orchestrator/watcher"
 	"github.com/kandev/kandev/internal/secrets"
 	"github.com/kandev/kandev/internal/task/models"
+	taskservice "github.com/kandev/kandev/internal/task/service"
 	"github.com/kandev/kandev/internal/workflow/engine"
 	wfmodels "github.com/kandev/kandev/internal/workflow/models"
 	v1 "github.com/kandev/kandev/pkg/api/v1"
@@ -109,6 +110,17 @@ type MessageCreator interface {
 	// InvalidateModelCache clears any cached model for a session, forcing the next
 	// message to re-read the model from the DB. Called after model switches.
 	InvalidateModelCache(sessionID string)
+}
+
+// SubagentContextRecorder persists a durable relational record of a subagent
+// (Task tool) invocation observed on a tool-call frame. It returns nothing —
+// a repository failure never fails the enclosing message write, turn, or
+// agent stream (AC-27 in
+// docs/specs/subagent-context-persistence/spec.md). Implemented by
+// taskservice.Service via an adapter; optional, so an installation that
+// never wires it behaves exactly as before.
+type SubagentContextRecorder interface {
+	RecordSubagentContext(ctx context.Context, req taskservice.RecordSubagentContextRequest)
 }
 
 // TurnService is an interface for managing session turns
@@ -357,6 +369,11 @@ type Service struct {
 
 	// Message creator for saving agent responses
 	messageCreator MessageCreator
+
+	// subagentContexts optionally persists a relational record of subagent
+	// (Task tool) invocations recognized on the tool-call frame paths. Nil is
+	// safe: both call sites guard on it. See SetSubagentContextRecorder.
+	subagentContexts SubagentContextRecorder
 
 	// Turn service for managing session turns
 	turnService TurnService
@@ -899,6 +916,13 @@ func NewService(
 // If not set: Agent messages won't be saved to the database (events will still be published).
 func (s *Service) SetMessageCreator(mc MessageCreator) {
 	s.messageCreator = mc
+}
+
+// SetSubagentContextRecorder wires the optional subagent-context writer.
+// If not set, subagent tool-call frames are recognized and rendered exactly
+// as before; only the durable relational record is skipped.
+func (s *Service) SetSubagentContextRecorder(r SubagentContextRecorder) {
+	s.subagentContexts = r
 }
 
 // SetAttachmentReader wires the backend attachment store into passthrough

--- a/apps/backend/internal/task/models/subagent_context.go
+++ b/apps/backend/internal/task/models/subagent_context.go
@@ -1,0 +1,44 @@
+package models
+
+import "time"
+
+// SubagentContext is a durable, queryable row for one subagent (Task tool)
+// invocation observed by the orchestrator. See
+// docs/specs/subagent-context-persistence/spec.md.
+//
+// Every nullable column is a pointer. This is not style: ToolUseCount in
+// particular must distinguish a reported 0 from "not reported", and a
+// non-pointer int64 cannot carry that distinction.
+type SubagentContext struct {
+	ID            string
+	TaskSessionID string
+	TaskID        string
+	ToolCallID    string
+
+	TurnID           *string
+	ParentToolCallID *string
+	SubagentType     *string
+	Description      *string
+	AgentID          *string
+	ChildSessionID   *string
+	Model            *string
+	// AgentStatus is the child's own report (open, provider-defined vocabulary,
+	// e.g. "async_launched"). Stored verbatim, never consulted for terminality.
+	AgentStatus *string
+	// ToolStatus is the ACP tool-call status of the launching Task call
+	// (closed vocabulary). Terminality is decided from this field only.
+	ToolStatus *string
+
+	IsAsync bool
+
+	TotalTokens  *int64
+	ToolUseCount *int64
+	DurationMs   *int64
+
+	// Source is "live" or "backfill". Provenance, write-once.
+	Source string
+
+	ObservedAt time.Time
+	SettledAt  *time.Time
+	UpdatedAt  time.Time
+}

--- a/apps/backend/internal/task/repository/interface.go
+++ b/apps/backend/internal/task/repository/interface.go
@@ -481,3 +481,15 @@ type PlanRepository interface {
 	// otherwise a new revision is appended with revision_number computed inside the tx.
 	WritePlanRevision(ctx context.Context, head *models.TaskPlan, rev *models.TaskPlanRevision, coalesceLatestID *string) error
 }
+
+// SubagentContextRepository persists the durable, queryable record of a
+// subagent (Task tool) invocation. See
+// docs/specs/subagent-context-persistence/spec.md.
+type SubagentContextRepository interface {
+	// UpsertSubagentContext inserts or merges one subagent invocation row,
+	// keyed on (task_session_id, tool_call_id). A single atomic statement —
+	// no read-then-write.
+	UpsertSubagentContext(ctx context.Context, sc *models.SubagentContext) error
+	ListSubagentContextsBySession(ctx context.Context, sessionID string) ([]*models.SubagentContext, error)
+	ListSubagentContextsByTurn(ctx context.Context, turnID string) ([]*models.SubagentContext, error)
+}

--- a/apps/backend/internal/task/repository/sqlite/base_migrations.go
+++ b/apps/backend/internal/task/repository/sqlite/base_migrations.go
@@ -359,7 +359,25 @@ func (r *Repository) runMigrations() error {
 // a failure here must never abort boot, only log. Apply takes no bind args,
 // so the capture-since timestamp is inlined via fmt.Sprintf rather than
 // passed as a query parameter.
+//
+// runMigrations() (and therefore this function) runs on every boot, not just
+// the first — it's one of initSchema()'s steps, and initSchema() runs on
+// every NewWithDB. The backfill INSERT...SELECT below, and its companion
+// MAX() query for subagent_context_backfill_through, both filter on
+// json_extract(metadata,'$.normalized.kind') with no supporting index
+// (ensureMessageMetadataIndexes only indexes tool_call_id and pending_id),
+// so each is a full scan of task_session_messages. AC-23a is explicit that
+// this scan is "a real, accepted one-time cost ... taken once" — ON CONFLICT
+// DO NOTHING makes the resulting rows idempotent, but does nothing to avoid
+// re-running the scan itself. subagentContextBackfillActivated is the guard
+// that makes it actually run once: a single indexed point lookup on
+// kandev_meta's primary key, skipping the whole function on every boot after
+// the first successful one.
 func (r *Repository) migrateSubagentContextBackfill() {
+	if r.subagentContextBackfillActivated() {
+		return
+	}
+
 	postgres := dialect.IsPostgres(r.db.DriverName())
 
 	meta := func(path string) string { return jsonKey(postgres, "m.metadata", path) }
@@ -423,6 +441,23 @@ func (r *Repository) migrateSubagentContextBackfill() {
 		), '')
 		ON CONFLICT(key) DO NOTHING
 	`)
+}
+
+// subagentContextBackfillActivated reports whether
+// migrateSubagentContextBackfill has already completed successfully on this
+// database, via a single indexed point lookup on kandev_meta's primary key.
+// A missing key — including "kandev_meta doesn't exist yet", which cannot
+// happen in production (persistence.Provide creates it before any repository
+// runs) but can happen in a test that constructs a Repository directly —
+// reports not-activated, so the backfill still gets its chance to run and
+// its own swallow-and-WARN failure contract (AC-20) is unchanged.
+func (r *Repository) subagentContextBackfillActivated() bool {
+	var value string
+	err := r.db.QueryRow(
+		r.db.Rebind(`SELECT value FROM kandev_meta WHERE key = ?`),
+		"subagent_context_capture_since",
+	).Scan(&value)
+	return err == nil
 }
 
 // clearRecoveredAgentErrors repairs sessions whose stored agent failure was

--- a/apps/backend/internal/task/repository/sqlite/base_migrations.go
+++ b/apps/backend/internal/task/repository/sqlite/base_migrations.go
@@ -342,7 +342,87 @@ func (r *Repository) runMigrations() error {
 		return err
 	}
 
+	r.migrateSubagentContextBackfill()
+
 	return nil
+}
+
+// migrateSubagentContextBackfill recovers task_session_subagents history from
+// existing task_session_messages rows whose metadata.normalized.kind is
+// "subagent_task" (AC-21), and publishes the two write-once kandev_meta
+// activation keys that let a consumer distinguish "zero fan-out" from
+// "unmeasured, before capture began" (AC-24, AC-25). See
+// docs/specs/subagent-context-persistence/spec.md § Backfill.
+//
+// All three statements go through r.migrate.Apply, whose swallow-plus-WARN
+// contract (internal/db/migratelog.go:33) is what AC-20 is written against —
+// a failure here must never abort boot, only log. Apply takes no bind args,
+// so the capture-since timestamp is inlined via fmt.Sprintf rather than
+// passed as a query parameter.
+func (r *Repository) migrateSubagentContextBackfill() {
+	postgres := dialect.IsPostgres(r.db.DriverName())
+
+	meta := func(path string) string { return jsonKey(postgres, "m.metadata", path) }
+	nullable := func(expr string) string { return "NULLIF(" + expr + ", '')" }
+	subagentText := func(field string) string { return nullable(meta("normalized.subagent_task." + field)) }
+	subagentInt := func(field string) string { return jsonInt(postgres, "m.metadata", "normalized.subagent_task", field) }
+
+	toolCallID := meta("tool_call_id")
+	toolStatusRaw := meta("status")
+	terminal := "(" + toolStatusRaw + " IN ('complete','completed','success','error','failed','cancelled'))"
+	predicate := `
+			` + meta("normalized.kind") + ` = 'subagent_task'
+			AND m.task_id IS NOT NULL AND m.task_id != ''
+			AND ` + toolCallID + ` IS NOT NULL AND ` + toolCallID + ` != ''`
+
+	r.migrate.Apply("task_session_subagents.backfill", `
+		INSERT INTO task_session_subagents (
+			id, task_session_id, task_id, turn_id, tool_call_id, parent_tool_call_id,
+			subagent_type, description, agent_id, child_session_id, model,
+			agent_status, tool_status, is_async, total_tokens, tool_use_count,
+			duration_ms, source, observed_at, settled_at, updated_at
+		)
+		SELECT
+			m.id,
+			m.task_session_id,
+			m.task_id,
+			NULLIF(m.turn_id, ''),
+			`+toolCallID+`,
+			`+nullable(meta("parent_tool_call_id"))+`,
+			`+subagentText("subagent_type")+`,
+			`+subagentText("description")+`,
+			`+subagentText("agent_id")+`,
+			`+subagentText("child_session_id")+`,
+			`+subagentText("model")+`,
+			`+subagentText("status")+`,
+			`+nullable(toolStatusRaw)+`,
+			`+jsonBoolToInt(postgres, "m.metadata", "normalized.subagent_task", "is_async")+`,
+			`+subagentInt("total_tokens")+`,
+			`+subagentInt("tool_use_count")+`,
+			`+subagentInt("duration_ms")+`,
+			'backfill',
+			m.created_at,
+			(CASE WHEN `+terminal+` THEN m.updated_at ELSE NULL END),
+			m.updated_at
+		FROM task_session_messages m
+		WHERE`+predicate+`
+		ON CONFLICT (task_session_id, tool_call_id) DO NOTHING
+	`)
+
+	r.migrate.Apply("kandev_meta.subagent_context_capture_since", fmt.Sprintf(
+		`INSERT INTO kandev_meta (key, value) VALUES ('subagent_context_capture_since', '%s') ON CONFLICT(key) DO NOTHING`,
+		time.Now().UTC().Format(time.RFC3339),
+	))
+
+	r.migrate.Apply("kandev_meta.subagent_context_backfill_through", `
+		INSERT INTO kandev_meta (key, value)
+		SELECT 'subagent_context_backfill_through', COALESCE((
+			SELECT `+rfc3339Timestamp(postgres, "MAX(m.created_at)")+`
+			FROM task_session_messages m
+			WHERE`+predicate+`
+		), '')
+		ON CONFLICT(key) DO NOTHING
+	`)
 }
 
 // clearRecoveredAgentErrors repairs sessions whose stored agent failure was
@@ -446,6 +526,58 @@ func jsonRemoveKey(postgres bool, column, key string) string {
 		return "(" + base + " - '" + key + "')::text"
 	}
 	return "json_remove(" + base + ", '$." + key + "')"
+}
+
+// jsonKey extracts a text value at a JSON path from a TEXT-typed JSON column.
+// key may itself be dot-separated ("normalized.kind") to reach a field nested
+// several levels deep — jsonInt and jsonBoolToInt build on this by folding
+// their parent/key pair into one such path before extracting.
+func jsonKey(postgres bool, column, key string) string {
+	base := jsonColumn(postgres, column)
+	segments := strings.Join(strings.Split(key, "."), ",")
+	if postgres {
+		return "(" + base + " #>> '{" + segments + "}')"
+	}
+	return "json_extract(" + base + ", '$." + strings.ReplaceAll(segments, ",", ".") + "')"
+}
+
+// jsonInt extracts a nested numeric field and normalizes it the way every
+// unreported-or-invalid metric in this table normalizes: NULL, never a
+// fabricated 0 for "not reported" and never a negative count (AC-7, AC-9,
+// AC-23). Postgres casts to BIGINT, SQLite to INTEGER.
+func jsonInt(postgres bool, column, parent, key string) string {
+	extracted := jsonKey(postgres, column, parent+"."+key)
+	castType := "INTEGER"
+	if postgres {
+		castType = "BIGINT"
+	}
+	cast := "CAST(NULLIF(" + extracted + ", '') AS " + castType + ")"
+	return "(CASE WHEN " + cast + " < 0 THEN NULL ELSE " + cast + " END)"
+}
+
+// jsonBoolToInt normalizes is_async's dialect-inconsistent boolean spelling —
+// Postgres's #>> text extraction yields 'true'/'false', SQLite's json_extract
+// on a JSON boolean yields '1'/'0' — into the single 1/0 the column stores.
+// An absent or false field yields 0, matching the column's own DEFAULT 0.
+func jsonBoolToInt(postgres bool, column, parent, key string) string {
+	extracted := jsonKey(postgres, column, parent+"."+key)
+	// SQLite's json_extract returns a JSON boolean as the storage-class
+	// INTEGER 1/0, not the text '1'/'0' — comparing that INTEGER against a
+	// TEXT literal via IN never matches (SQLite orders INTEGER < TEXT by
+	// storage class), so the extracted value must be cast to TEXT first.
+	return "(CASE WHEN CAST(" + extracted + " AS TEXT) IN ('1', 'true') THEN 1 ELSE 0 END)"
+}
+
+// rfc3339Timestamp renders a timestamp expression (a column or an aggregate
+// like MAX(m.created_at)) as an RFC3339 UTC string. Every timestamp this
+// repository writes is already a UTC wall-clock instant with no zone suffix
+// (see the spec's Column-level normalization rules), so both dialects only
+// need to reformat, never convert zones.
+func rfc3339Timestamp(postgres bool, expression string) string {
+	if postgres {
+		return `to_char(` + expression + `, 'YYYY-MM-DD"T"HH24:MI:SS"Z"')`
+	}
+	return `strftime('%Y-%m-%dT%H:%M:%SZ', ` + expression + `)`
 }
 
 // ensureImproveKandevWorkflowTemplateUniqueness removes the broad index from

--- a/apps/backend/internal/task/repository/sqlite/base_schema.go
+++ b/apps/backend/internal/task/repository/sqlite/base_schema.go
@@ -610,7 +610,52 @@ func (r *Repository) initSessionSchema() error {
 	if err := r.initSessionWorktreeSchema(); err != nil {
 		return err
 	}
-	return r.initMessageTurnSchema()
+	if err := r.initMessageTurnSchema(); err != nil {
+		return err
+	}
+	return r.initSubagentContextSchema()
+}
+
+// initSubagentContextSchema creates task_session_subagents, the durable
+// relational record of a subagent (Task tool) invocation. See
+// docs/specs/subagent-context-persistence/spec.md. The three measurement
+// columns (total_tokens, tool_use_count, duration_ms) deliberately carry no
+// DEFAULT: an unreported value must store NULL, never 0 (75% of observed
+// invocations report none of them). turn_id carries no FOREIGN KEY so a turn
+// deletion never silently deletes the fan-out record it measured.
+func (r *Repository) initSubagentContextSchema() error {
+	_, err := r.db.Exec(`
+	CREATE TABLE IF NOT EXISTS task_session_subagents (
+		id                  TEXT PRIMARY KEY,
+		task_session_id     TEXT NOT NULL,
+		task_id             TEXT NOT NULL,
+		turn_id             TEXT,
+		tool_call_id        TEXT NOT NULL,
+		parent_tool_call_id TEXT,
+		subagent_type       TEXT,
+		description         TEXT,
+		agent_id            TEXT,
+		child_session_id    TEXT,
+		model               TEXT,
+		agent_status        TEXT,
+		tool_status         TEXT,
+		is_async            INTEGER NOT NULL DEFAULT 0,
+		total_tokens        INTEGER,
+		tool_use_count      INTEGER,
+		duration_ms         INTEGER,
+		source              TEXT NOT NULL DEFAULT 'live',
+		observed_at         TIMESTAMP NOT NULL,
+		settled_at          TIMESTAMP,
+		updated_at          TIMESTAMP NOT NULL,
+		UNIQUE (task_session_id, tool_call_id),
+		FOREIGN KEY (task_session_id) REFERENCES task_sessions(id) ON DELETE CASCADE
+	);
+
+	CREATE INDEX IF NOT EXISTS idx_subagents_session_id ON task_session_subagents(task_session_id);
+	CREATE INDEX IF NOT EXISTS idx_subagents_task_id    ON task_session_subagents(task_id);
+	CREATE INDEX IF NOT EXISTS idx_subagents_turn_id    ON task_session_subagents(turn_id);
+	`)
+	return err
 }
 
 func (r *Repository) initMessageTurnSchema() error {

--- a/apps/backend/internal/task/repository/sqlite/subagent_context.go
+++ b/apps/backend/internal/task/repository/sqlite/subagent_context.go
@@ -1,0 +1,144 @@
+// Package sqlite provides SQLite-based repository implementations.
+package sqlite
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/kandev/kandev/internal/db/dialect"
+	"github.com/kandev/kandev/internal/task/models"
+)
+
+// upsertSubagentContextSQL is a single atomic INSERT ... ON CONFLICT DO UPDATE.
+// No read-then-write anywhere (AC-14): every merge, terminality, and
+// write-once rule lives in the conflict clause.
+//
+//   - turn_id: the *original* turn wins (AC-2a); a later turn never
+//     re-attributes the fan-out.
+//   - every other nullable column: fill-forward — an absent/empty reported
+//     value never blanks a value already learned (AC-4, AC-5).
+//   - tool_status: frozen once settled_at is set (AC-12); until then it fills
+//     forward like any other column.
+//   - is_async: sticky — a later frame reporting false never resets it.
+//   - settled_at: write-once (AC-11).
+//   - source, observed_at, id: absent from the SET list entirely — write-once,
+//     so a backfilled row is never relabelled live (AC-22) and the first
+//     observation wins (AC-1a).
+const upsertSubagentContextSQL = `
+	INSERT INTO task_session_subagents (
+		id, task_session_id, task_id, turn_id, tool_call_id, parent_tool_call_id,
+		subagent_type, description, agent_id, child_session_id, model,
+		agent_status, tool_status, is_async, total_tokens, tool_use_count,
+		duration_ms, source, observed_at, settled_at, updated_at
+	) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	ON CONFLICT (task_session_id, tool_call_id) DO UPDATE SET
+		turn_id = COALESCE(task_session_subagents.turn_id, excluded.turn_id),
+		parent_tool_call_id = COALESCE(excluded.parent_tool_call_id, task_session_subagents.parent_tool_call_id),
+		subagent_type = COALESCE(excluded.subagent_type, task_session_subagents.subagent_type),
+		description = COALESCE(excluded.description, task_session_subagents.description),
+		agent_id = COALESCE(excluded.agent_id, task_session_subagents.agent_id),
+		child_session_id = COALESCE(excluded.child_session_id, task_session_subagents.child_session_id),
+		model = COALESCE(excluded.model, task_session_subagents.model),
+		agent_status = COALESCE(excluded.agent_status, task_session_subagents.agent_status),
+		tool_status = CASE
+			WHEN task_session_subagents.settled_at IS NOT NULL THEN task_session_subagents.tool_status
+			ELSE COALESCE(excluded.tool_status, task_session_subagents.tool_status)
+		END,
+		is_async = CASE WHEN excluded.is_async = 1 THEN 1 ELSE task_session_subagents.is_async END,
+		total_tokens = COALESCE(excluded.total_tokens, task_session_subagents.total_tokens),
+		tool_use_count = COALESCE(excluded.tool_use_count, task_session_subagents.tool_use_count),
+		duration_ms = COALESCE(excluded.duration_ms, task_session_subagents.duration_ms),
+		settled_at = COALESCE(task_session_subagents.settled_at, excluded.settled_at),
+		updated_at = excluded.updated_at
+`
+
+// subagentContextSourceLive is the default models.SubagentContext.Source for
+// a row observed on the live orchestrator frame path, as opposed to "backfill".
+const subagentContextSourceLive = "live"
+
+// UpsertSubagentContext inserts or merges one subagent invocation row, keyed
+// on (task_session_id, tool_call_id). Safe under concurrent calls for the
+// same key (AC-14) and for different keys in the same turn (AC-15): the
+// merge is expressed entirely in the statement's conflict clause, never in
+// Go-level read-then-write.
+func (r *Repository) UpsertSubagentContext(ctx context.Context, sc *models.SubagentContext) error {
+	if sc.ID == "" {
+		sc.ID = uuid.New().String()
+	}
+	if sc.Source == "" {
+		sc.Source = subagentContextSourceLive
+	}
+	now := time.Now().UTC()
+	if sc.ObservedAt.IsZero() {
+		sc.ObservedAt = now
+	}
+	if sc.UpdatedAt.IsZero() {
+		sc.UpdatedAt = now
+	}
+
+	_, err := r.db.ExecContext(ctx, r.db.Rebind(upsertSubagentContextSQL),
+		sc.ID, sc.TaskSessionID, sc.TaskID, sc.TurnID, sc.ToolCallID, sc.ParentToolCallID,
+		sc.SubagentType, sc.Description, sc.AgentID, sc.ChildSessionID, sc.Model,
+		sc.AgentStatus, sc.ToolStatus, dialect.BoolToInt(sc.IsAsync), sc.TotalTokens, sc.ToolUseCount,
+		sc.DurationMs, sc.Source, sc.ObservedAt, sc.SettledAt, sc.UpdatedAt,
+	)
+	return err
+}
+
+const selectSubagentContextColumns = `
+	id, task_session_id, task_id, turn_id, tool_call_id, parent_tool_call_id,
+	subagent_type, description, agent_id, child_session_id, model,
+	agent_status, tool_status, is_async, total_tokens, tool_use_count,
+	duration_ms, source, observed_at, settled_at, updated_at
+`
+
+// ListSubagentContextsBySession returns every subagent context for a session,
+// ordered observed_at ASC, tool_call_id ASC. tool_call_id is the named
+// tiebreak (AC-13): unique within a session by construction, stable across
+// replays, and total — the generated id is deliberately not used.
+func (r *Repository) ListSubagentContextsBySession(ctx context.Context, sessionID string) ([]*models.SubagentContext, error) {
+	return r.listSubagentContexts(ctx, "task_session_id", sessionID)
+}
+
+// ListSubagentContextsByTurn returns every subagent context recorded under a
+// turn, in the same observed_at ASC, tool_call_id ASC order. A subagent whose
+// tool_call_id was later re-attributed away from this turn (AC-2a preserves
+// the original turn) never appears here for the newer turn.
+func (r *Repository) ListSubagentContextsByTurn(ctx context.Context, turnID string) ([]*models.SubagentContext, error) {
+	return r.listSubagentContexts(ctx, "turn_id", turnID)
+}
+
+func (r *Repository) listSubagentContexts(ctx context.Context, column, value string) ([]*models.SubagentContext, error) {
+	rows, err := r.ro.QueryContext(ctx, r.ro.Rebind(`
+		SELECT `+selectSubagentContextColumns+`
+		FROM task_session_subagents
+		WHERE `+column+` = ?
+		ORDER BY observed_at ASC, tool_call_id ASC
+	`), value)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var result []*models.SubagentContext
+	for rows.Next() {
+		sc := &models.SubagentContext{}
+		var isAsync int
+		if err := rows.Scan(
+			&sc.ID, &sc.TaskSessionID, &sc.TaskID, &sc.TurnID, &sc.ToolCallID, &sc.ParentToolCallID,
+			&sc.SubagentType, &sc.Description, &sc.AgentID, &sc.ChildSessionID, &sc.Model,
+			&sc.AgentStatus, &sc.ToolStatus, &isAsync, &sc.TotalTokens, &sc.ToolUseCount,
+			&sc.DurationMs, &sc.Source, &sc.ObservedAt, &sc.SettledAt, &sc.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		sc.IsAsync = isAsync == 1
+		result = append(result, sc)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return result, nil
+}

--- a/apps/backend/internal/task/repository/sqlite/subagent_context.go
+++ b/apps/backend/internal/task/repository/sqlite/subagent_context.go
@@ -110,6 +110,10 @@ func (r *Repository) ListSubagentContextsByTurn(ctx context.Context, turnID stri
 	return r.listSubagentContexts(ctx, "turn_id", turnID)
 }
 
+// listSubagentContexts concatenates column directly into the query. Safe by
+// construction ONLY because both call sites above pass a hardcoded literal
+// ("task_session_id", "turn_id") — column must never be, or be derived from,
+// caller/request input.
 func (r *Repository) listSubagentContexts(ctx context.Context, column, value string) ([]*models.SubagentContext, error) {
 	rows, err := r.ro.QueryContext(ctx, r.ro.Rebind(`
 		SELECT `+selectSubagentContextColumns+`

--- a/apps/backend/internal/task/repository/sqlite/subagent_context_health_test.go
+++ b/apps/backend/internal/task/repository/sqlite/subagent_context_health_test.go
@@ -1,0 +1,128 @@
+package sqlite
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/task/models"
+)
+
+// subagentMessageCount runs the AC-28 message-side query verbatim: a count
+// of task_session_messages whose metadata.normalized.kind is subagent_task.
+// This is the independent expectation because the message write is
+// load-bearing for the UI subagent card — a broken message write is noticed
+// by a human within one turn, whereas a broken context write is noticed by
+// nobody. That asymmetry is what makes the comparison a real check.
+func subagentMessageCount(t *testing.T, repo *Repository) int {
+	t.Helper()
+	var count int
+	if err := repo.db.QueryRow(`
+		SELECT COUNT(*) FROM task_session_messages
+		WHERE json_extract(metadata, '$.normalized.kind') = 'subagent_task'
+	`).Scan(&count); err != nil {
+		t.Fatalf("subagent message count: %v", err)
+	}
+	return count
+}
+
+func subagentContextCount(t *testing.T, repo *Repository) int {
+	t.Helper()
+	var count int
+	if err := repo.db.QueryRow(`SELECT COUNT(*) FROM task_session_subagents`).Scan(&count); err != nil {
+		t.Fatalf("subagent context count: %v", err)
+	}
+	return count
+}
+
+// TestSubagentContextHealthCountsAgreeAfterLiveWrites covers AC-28: writing
+// through the same path production uses (a subagent_task message plus a
+// live UpsertSubagentContext call, exactly as the orchestrator's two frame
+// handlers do) keeps the message-side and context-side counts equal.
+func TestSubagentContextHealthCountsAgreeAfterLiveWrites(t *testing.T) {
+	repo, _ := newSubagentMigrationTestRepo(t)
+	seedForMsgTest(t, repo, "task-health", "session-health", "turn-health")
+	ctx := context.Background()
+	ts := time.Date(2026, 8, 12, 9, 0, 0, 0, time.UTC)
+
+	for i, toolCallID := range []string{"tc-health-1", "tc-health-2", "tc-health-3"} {
+		seedSubagentMessage(t, repo, "msg-health-"+toolCallID, "session-health", "task-health", "turn-health",
+			toolCallID, "", "completed", map[string]interface{}{"status": "completed"},
+			ts.Add(time.Duration(i)*time.Minute), ts.Add(time.Duration(i)*time.Minute))
+		if err := repo.UpsertSubagentContext(ctx, &models.SubagentContext{
+			TaskSessionID: "session-health", TaskID: "task-health", ToolCallID: toolCallID,
+			Source: "live", ObservedAt: ts.Add(time.Duration(i) * time.Minute), UpdatedAt: ts.Add(time.Duration(i) * time.Minute),
+		}); err != nil {
+			t.Fatalf("UpsertSubagentContext %s: %v", toolCallID, err)
+		}
+	}
+
+	messageCount := subagentMessageCount(t, repo)
+	contextCount := subagentContextCount(t, repo)
+	if messageCount != contextCount {
+		t.Fatalf("message count = %d, context count = %d; want equal after live writes", messageCount, contextCount)
+	}
+	if messageCount != 3 {
+		t.Fatalf("message count = %d, want 3", messageCount)
+	}
+}
+
+// TestSubagentContextHealthDivergesWhenWriterMissesAMessage covers AC-28/
+// AC-29: a subagent_task message the context writer never saw (simulating
+// the writer having stopped while message writes continued) makes the two
+// counts diverge, and MAX(observed_at) on task_session_subagents locates the
+// divergence in time — it stops advancing at the point the writer died,
+// while message writes (and their created_at) keep moving.
+func TestSubagentContextHealthDivergesWhenWriterMissesAMessage(t *testing.T) {
+	repo, _ := newSubagentMigrationTestRepo(t)
+	seedForMsgTest(t, repo, "task-diverge", "session-diverge", "turn-diverge")
+	ctx := context.Background()
+	writerAlive := time.Date(2026, 8, 12, 9, 0, 0, 0, time.UTC)
+	writerDead := writerAlive.Add(time.Hour)
+
+	// The writer was healthy for this one: both sides get a row.
+	seedSubagentMessage(t, repo, "msg-diverge-seen", "session-diverge", "task-diverge", "turn-diverge",
+		"tc-diverge-seen", "", "completed", map[string]interface{}{"status": "completed"}, writerAlive, writerAlive)
+	if err := repo.UpsertSubagentContext(ctx, &models.SubagentContext{
+		TaskSessionID: "session-diverge", TaskID: "task-diverge", ToolCallID: "tc-diverge-seen",
+		Source: "live", ObservedAt: writerAlive, UpdatedAt: writerAlive,
+	}); err != nil {
+		t.Fatalf("UpsertSubagentContext: %v", err)
+	}
+
+	if messageCount, contextCount := subagentMessageCount(t, repo), subagentContextCount(t, repo); messageCount != contextCount {
+		t.Fatalf("counts diverged before the simulated writer outage: messages=%d contexts=%d", messageCount, contextCount)
+	}
+
+	// The writer "stopped" here: the message write (load-bearing for the UI)
+	// still happens, but nothing calls UpsertSubagentContext for it.
+	seedSubagentMessage(t, repo, "msg-diverge-missed", "session-diverge", "task-diverge", "turn-diverge",
+		"tc-diverge-missed", "", "completed", map[string]interface{}{"status": "completed"}, writerDead, writerDead)
+
+	messageCount := subagentMessageCount(t, repo)
+	contextCount := subagentContextCount(t, repo)
+	if messageCount == contextCount {
+		t.Fatalf("counts = %d/%d, want divergence after the writer misses a message", messageCount, contextCount)
+	}
+	if messageCount != contextCount+1 {
+		t.Fatalf("message count = %d, context count = %d; want exactly one message uncovered by a context row", messageCount, contextCount)
+	}
+
+	// SQLite's MAX() aggregate loses the driver's automatic TIMESTAMP-column
+	// conversion, so scan the raw text and parse it explicitly rather than
+	// into time.Time directly.
+	var maxObservedAtRaw string
+	if err := repo.db.QueryRow(`SELECT MAX(observed_at) FROM task_session_subagents`).Scan(&maxObservedAtRaw); err != nil {
+		t.Fatalf("max observed_at: %v", err)
+	}
+	maxObservedAt, err := time.Parse("2006-01-02 15:04:05.999999999-07:00", maxObservedAtRaw)
+	if err != nil {
+		t.Fatalf("parse max observed_at %q: %v", maxObservedAtRaw, err)
+	}
+	if !maxObservedAt.Equal(writerAlive) {
+		t.Fatalf("MAX(observed_at) = %v, want %v (the last moment the writer was known healthy)", maxObservedAt, writerAlive)
+	}
+	if !maxObservedAt.Before(writerDead) {
+		t.Fatalf("MAX(observed_at) = %v, want it to predate the missed message at %v, locating the outage in time", maxObservedAt, writerDead)
+	}
+}

--- a/apps/backend/internal/task/repository/sqlite/subagent_context_health_test.go
+++ b/apps/backend/internal/task/repository/sqlite/subagent_context_health_test.go
@@ -5,22 +5,29 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kandev/kandev/internal/db/dialect"
 	"github.com/kandev/kandev/internal/task/models"
 )
 
-// subagentMessageCount runs the AC-28 message-side query verbatim: a count
-// of task_session_messages whose metadata.normalized.kind is subagent_task.
+// subagentMessageCount runs the AC-28 message-side query: a count of
+// task_session_messages whose metadata.normalized.kind is subagent_task.
 // This is the independent expectation because the message write is
 // load-bearing for the UI subagent card — a broken message write is noticed
 // by a human within one turn, whereas a broken context write is noticed by
 // nobody. That asymmetry is what makes the comparison a real check.
+//
+// AC-28's spec text gives the SQLite form (json_extract) as the illustrative
+// query; json_extract does not exist on PostgreSQL, so this helper builds the
+// dialect-appropriate expression via the same jsonKey helper the backfill
+// migration uses, and TestPostgresSubagentContextHealthCountsAgreeAfterLiveWrites
+// exercises the PostgreSQL form directly (AC-19).
 func subagentMessageCount(t *testing.T, repo *Repository) int {
 	t.Helper()
+	postgres := dialect.IsPostgres(repo.db.DriverName())
 	var count int
-	if err := repo.db.QueryRow(`
-		SELECT COUNT(*) FROM task_session_messages
-		WHERE json_extract(metadata, '$.normalized.kind') = 'subagent_task'
-	`).Scan(&count); err != nil {
+	query := `SELECT COUNT(*) FROM task_session_messages WHERE ` +
+		jsonKey(postgres, "metadata", "normalized.kind") + ` = 'subagent_task'`
+	if err := repo.db.QueryRow(repo.db.Rebind(query)).Scan(&count); err != nil {
 		t.Fatalf("subagent message count: %v", err)
 	}
 	return count

--- a/apps/backend/internal/task/repository/sqlite/subagent_context_migration_test.go
+++ b/apps/backend/internal/task/repository/sqlite/subagent_context_migration_test.go
@@ -1,0 +1,543 @@
+package sqlite
+
+import (
+	"database/sql"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+
+	dbutil "github.com/kandev/kandev/internal/db"
+)
+
+// seedSubagentMessage inserts a task_session_messages row shaped like the
+// orchestrator's real subagent_task tool-call message: tool_call_id and
+// parent_tool_call_id are top-level metadata keys (matching
+// messageCreatorAdapter.CreateToolCallMessage), and the agent-reported fields
+// live under metadata.normalized.subagent_task.
+func seedSubagentMessage(
+	t *testing.T, repo *Repository,
+	id, sessionID, taskID, turnID, toolCallID, parentToolCallID, toolStatus string,
+	subagentTask map[string]interface{},
+	createdAt, updatedAt time.Time,
+) {
+	t.Helper()
+	metadata := map[string]interface{}{
+		"tool_call_id": toolCallID,
+		"status":       toolStatus,
+		"normalized": map[string]interface{}{
+			"kind":          "subagent_task",
+			"subagent_task": subagentTask,
+		},
+	}
+	if parentToolCallID != "" {
+		metadata["parent_tool_call_id"] = parentToolCallID
+	}
+	metadataJSON, err := json.Marshal(metadata)
+	if err != nil {
+		t.Fatalf("marshal metadata: %v", err)
+	}
+	seedRawSubagentMessage(t, repo, id, sessionID, taskID, turnID, string(metadataJSON), createdAt, updatedAt)
+}
+
+func seedRawSubagentMessage(
+	t *testing.T, repo *Repository,
+	id, sessionID, taskID, turnID, metadataJSON string,
+	createdAt, updatedAt time.Time,
+) {
+	t.Helper()
+	_, err := repo.db.Exec(repo.db.Rebind(`
+		INSERT INTO task_session_messages
+			(id, task_session_id, task_id, turn_id, author_type, content, type, metadata, created_at, updated_at)
+		VALUES (?, ?, ?, ?, 'agent', 'Subagent', 'tool_call', ?, ?, ?)
+	`), id, sessionID, taskID, turnID, metadataJSON, createdAt, updatedAt)
+	if err != nil {
+		t.Fatalf("seed subagent message %s: %v", id, err)
+	}
+}
+
+type subagentContextRow struct {
+	id               string
+	taskSessionID    string
+	taskID           string
+	turnID           sql.NullString
+	parentToolCallID sql.NullString
+	subagentType     sql.NullString
+	description      sql.NullString
+	agentID          sql.NullString
+	childSessionID   sql.NullString
+	model            sql.NullString
+	agentStatus      sql.NullString
+	toolStatus       sql.NullString
+	isAsync          int
+	totalTokens      sql.NullInt64
+	toolUseCount     sql.NullInt64
+	durationMs       sql.NullInt64
+	source           string
+	observedAt       time.Time
+	settledAt        sql.NullTime
+	updatedAt        time.Time
+}
+
+func getSubagentContextRow(t *testing.T, repo *Repository, sessionID, toolCallID string) *subagentContextRow {
+	t.Helper()
+	row := &subagentContextRow{}
+	err := repo.db.QueryRow(repo.db.Rebind(`
+		SELECT id, task_session_id, task_id, turn_id, parent_tool_call_id, subagent_type, description,
+			agent_id, child_session_id, model, agent_status, tool_status, is_async,
+			total_tokens, tool_use_count, duration_ms, source, observed_at, settled_at, updated_at
+		FROM task_session_subagents WHERE task_session_id = ? AND tool_call_id = ?
+	`), sessionID, toolCallID).Scan(
+		&row.id, &row.taskSessionID, &row.taskID, &row.turnID, &row.parentToolCallID, &row.subagentType, &row.description,
+		&row.agentID, &row.childSessionID, &row.model, &row.agentStatus, &row.toolStatus, &row.isAsync,
+		&row.totalTokens, &row.toolUseCount, &row.durationMs, &row.source, &row.observedAt, &row.settledAt, &row.updatedAt,
+	)
+	if err != nil {
+		t.Fatalf("get subagent context row (%s,%s): %v", sessionID, toolCallID, err)
+	}
+	return row
+}
+
+func countSubagentContextRows(t *testing.T, repo *Repository, sessionID, toolCallID string) int {
+	t.Helper()
+	var count int
+	if err := repo.db.QueryRow(repo.db.Rebind(`
+		SELECT COUNT(*) FROM task_session_subagents WHERE task_session_id = ? AND tool_call_id = ?
+	`), sessionID, toolCallID).Scan(&count); err != nil {
+		t.Fatalf("count subagent context rows (%s,%s): %v", sessionID, toolCallID, err)
+	}
+	return count
+}
+
+func readMetaKey(t *testing.T, db *sqlx.DB, key string) (string, bool) {
+	t.Helper()
+	var value string
+	err := db.QueryRow(db.Rebind(`SELECT value FROM kandev_meta WHERE key = ?`), key).Scan(&value)
+	if err == sql.ErrNoRows {
+		return "", false
+	}
+	if err != nil {
+		t.Fatalf("read kandev_meta %q: %v", key, err)
+	}
+	return value, true
+}
+
+func newSubagentMigrationTestRepo(t *testing.T) (*Repository, *sqlx.DB) {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "subagent-context-migration.db")
+	dbConn, err := dbutil.OpenSQLite(dbPath)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	db := sqlx.NewDb(dbConn, "sqlite3")
+	t.Cleanup(func() { _ = db.Close() })
+	// Production boot order (internal/persistence/provider.go) creates
+	// kandev_meta before the task repository; mirror that here since this
+	// package's repository never creates it itself.
+	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS kandev_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL DEFAULT '')`); err != nil {
+		t.Fatalf("create kandev_meta: %v", err)
+	}
+	repo, err := NewWithDB(db, db, nil)
+	if err != nil {
+		t.Fatalf("initialize schema: %v", err)
+	}
+	return repo, db
+}
+
+// dropMessageMetadataIndex removes the expression index on
+// task_session_messages(metadata) so a malformed-metadata row (used to prove
+// AC-23b tolerates historical corruption) can be seeded at all: with the
+// index present, SQLite evaluates json_extract on every insert and rejects
+// invalid JSON outright, which real corrupt rows predate.
+func dropMessageMetadataIndex(t *testing.T, db *sqlx.DB) {
+	t.Helper()
+	for _, index := range []string{"idx_messages_metadata_tool_call_id", "idx_messages_metadata_pending_id"} {
+		if _, err := db.Exec(`DROP INDEX IF EXISTS ` + index); err != nil {
+			t.Fatalf("drop %s: %v", index, err)
+		}
+	}
+}
+
+// TestSubagentContextSchemaFreshAndReplay covers AC-17/AC-18: a fresh database
+// gets the table, its three indexes, and the UNIQUE constraint, and
+// runMigrations() replays cleanly (schema and row set unchanged).
+func TestSubagentContextSchemaFreshAndReplay(t *testing.T) {
+	repo, db := newSubagentMigrationTestRepo(t)
+	seedForMsgTest(t, repo, "task-schema", "session-schema", "turn-schema")
+
+	for _, index := range []string{"idx_subagents_session_id", "idx_subagents_task_id", "idx_subagents_turn_id"} {
+		var name string
+		if err := db.Get(&name, `SELECT name FROM sqlite_master WHERE type = 'index' AND name = ?`, index); err != nil {
+			t.Fatalf("index %s is missing: %v", index, err)
+		}
+	}
+
+	now := time.Now().UTC()
+	if _, err := db.Exec(db.Rebind(`
+		INSERT INTO task_session_subagents (id, task_session_id, task_id, tool_call_id, observed_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?)
+	`), "row-1", "session-schema", "task-schema", "tc-schema", now, now); err != nil {
+		t.Fatalf("first insert should succeed: %v", err)
+	}
+	if _, err := db.Exec(db.Rebind(`
+		INSERT INTO task_session_subagents (id, task_session_id, task_id, tool_call_id, observed_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?)
+	`), "row-2", "session-schema", "task-schema", "tc-schema", now, now); err == nil {
+		t.Fatal("duplicate (task_session_id, tool_call_id) should violate UNIQUE constraint")
+	}
+
+	if err := repo.runMigrations(); err != nil {
+		t.Fatalf("replay migrations: %v", err)
+	}
+	if err := repo.runMigrations(); err != nil {
+		t.Fatalf("replay migrations twice: %v", err)
+	}
+	if count := countSubagentContextRows(t, repo, "session-schema", "tc-schema"); count != 1 {
+		t.Fatalf("row count after replay = %d, want 1 (replay must not duplicate)", count)
+	}
+}
+
+// TestSubagentContextBackfillAsyncLaunchedStoresNullNotZero is the spec's
+// named must-not-get-wrong regression: 75% of real subagent invocations are
+// async_launched with no reported usage, and a DEFAULT 0 anywhere would
+// fabricate every one of them. (AC-7, AC-21)
+func TestSubagentContextBackfillAsyncLaunchedStoresNullNotZero(t *testing.T) {
+	repo, _ := newSubagentMigrationTestRepo(t)
+	seedForMsgTest(t, repo, "task-async", "session-async", "turn-async")
+	createdAt := time.Date(2026, 8, 5, 10, 0, 0, 0, time.UTC)
+	updatedAt := createdAt.Add(time.Second)
+
+	seedSubagentMessage(t, repo, "msg-async", "session-async", "task-async", "turn-async",
+		"tc-async", "", "complete",
+		map[string]interface{}{
+			"description":   "run tests",
+			"subagent_type": "test-runner",
+			"status":        "async_launched",
+			"is_async":      true,
+		},
+		createdAt, updatedAt,
+	)
+
+	if err := repo.runMigrations(); err != nil {
+		t.Fatalf("runMigrations: %v", err)
+	}
+
+	row := getSubagentContextRow(t, repo, "session-async", "tc-async")
+	if row.totalTokens.Valid {
+		t.Errorf("total_tokens = %v, want NULL", row.totalTokens)
+	}
+	if row.toolUseCount.Valid {
+		t.Errorf("tool_use_count = %v, want NULL", row.toolUseCount)
+	}
+	if row.durationMs.Valid {
+		t.Errorf("duration_ms = %v, want NULL", row.durationMs)
+	}
+	if row.source != "backfill" {
+		t.Errorf("source = %q, want backfill", row.source)
+	}
+	if !row.observedAt.Equal(createdAt) {
+		t.Errorf("observed_at = %v, want %v (message created_at)", row.observedAt, createdAt)
+	}
+	if row.isAsync != 1 {
+		t.Errorf("is_async = %d, want 1", row.isAsync)
+	}
+	if !row.agentStatus.Valid || row.agentStatus.String != "async_launched" {
+		t.Errorf("agent_status = %v, want async_launched", row.agentStatus)
+	}
+	// tool_status is the ACP status of the launching Task call, terminal here,
+	// so settled_at must be set from the message's updated_at.
+	if !row.toolStatus.Valid || row.toolStatus.String != "complete" {
+		t.Errorf("tool_status = %v, want complete", row.toolStatus)
+	}
+	if !row.settledAt.Valid || !row.settledAt.Time.Equal(updatedAt) {
+		t.Errorf("settled_at = %v, want %v", row.settledAt, updatedAt)
+	}
+}
+
+// TestSubagentContextBackfillReportedZeroToolUseCountSurvives covers AC-8: a
+// genuinely reported 0 must remain distinguishable from "not reported".
+func TestSubagentContextBackfillReportedZeroToolUseCountSurvives(t *testing.T) {
+	repo, _ := newSubagentMigrationTestRepo(t)
+	seedForMsgTest(t, repo, "task-zero", "session-zero", "turn-zero")
+	ts := time.Date(2026, 8, 5, 11, 0, 0, 0, time.UTC)
+
+	seedSubagentMessage(t, repo, "msg-zero", "session-zero", "task-zero", "turn-zero",
+		"tc-zero", "", "completed",
+		map[string]interface{}{
+			"status":         "completed",
+			"tool_use_count": 0,
+		},
+		ts, ts,
+	)
+
+	if err := repo.runMigrations(); err != nil {
+		t.Fatalf("runMigrations: %v", err)
+	}
+
+	row := getSubagentContextRow(t, repo, "session-zero", "tc-zero")
+	if !row.toolUseCount.Valid || row.toolUseCount.Int64 != 0 {
+		t.Errorf("tool_use_count = %v, want 0 (reported, not absent)", row.toolUseCount)
+	}
+}
+
+// TestSubagentContextBackfillNegativeMetricBecomesNull covers AC-9/AC-23: a
+// negative reported metric is not a measurement and must not be stored.
+func TestSubagentContextBackfillNegativeMetricBecomesNull(t *testing.T) {
+	repo, _ := newSubagentMigrationTestRepo(t)
+	seedForMsgTest(t, repo, "task-neg", "session-neg", "turn-neg")
+	ts := time.Date(2026, 8, 5, 12, 0, 0, 0, time.UTC)
+
+	seedSubagentMessage(t, repo, "msg-neg", "session-neg", "task-neg", "turn-neg",
+		"tc-neg", "", "completed",
+		map[string]interface{}{
+			"status":       "completed",
+			"total_tokens": -5,
+			"duration_ms":  1200,
+		},
+		ts, ts,
+	)
+
+	if err := repo.runMigrations(); err != nil {
+		t.Fatalf("runMigrations: %v", err)
+	}
+
+	row := getSubagentContextRow(t, repo, "session-neg", "tc-neg")
+	if row.totalTokens.Valid {
+		t.Errorf("total_tokens = %v, want NULL (negative reported value)", row.totalTokens)
+	}
+	if !row.durationMs.Valid || row.durationMs.Int64 != 1200 {
+		t.Errorf("duration_ms = %v, want 1200 (other fields unaffected)", row.durationMs)
+	}
+}
+
+// TestSubagentContextBackfillEmptyStringBecomesNull covers the empty-string
+// normalization rule: SubagentTaskPayload uses "" for absent; the column uses
+// NULL so COUNT(model) counts models, not blanks.
+func TestSubagentContextBackfillEmptyStringBecomesNull(t *testing.T) {
+	repo, _ := newSubagentMigrationTestRepo(t)
+	seedForMsgTest(t, repo, "task-empty", "session-empty", "turn-empty")
+	ts := time.Date(2026, 8, 5, 13, 0, 0, 0, time.UTC)
+
+	seedSubagentMessage(t, repo, "msg-empty", "session-empty", "task-empty", "turn-empty",
+		"tc-empty", "", "completed",
+		map[string]interface{}{
+			"status": "completed",
+			"model":  "",
+		},
+		ts, ts,
+	)
+
+	if err := repo.runMigrations(); err != nil {
+		t.Fatalf("runMigrations: %v", err)
+	}
+
+	row := getSubagentContextRow(t, repo, "session-empty", "tc-empty")
+	if row.model.Valid {
+		t.Errorf("model = %q, want NULL not empty string", row.model.String)
+	}
+}
+
+// TestSubagentContextBackfillMalformedMetadataDoesNotAbort covers AC-23b: a
+// single row with unparsable metadata (” or 'null') must not abort the
+// whole statement, so a valid row alongside it still lands.
+func TestSubagentContextBackfillMalformedMetadataDoesNotAbort(t *testing.T) {
+	repo, db := newSubagentMigrationTestRepo(t)
+	seedForMsgTest(t, repo, "task-malformed", "session-malformed", "turn-malformed")
+	ts := time.Date(2026, 8, 5, 14, 0, 0, 0, time.UTC)
+
+	// A literal empty-string metadata row can only exist as historical
+	// corruption predating idx_messages_metadata_tool_call_id (the index
+	// itself rejects an empty-string insert via its json_extract expression).
+	dropMessageMetadataIndex(t, db)
+	seedRawSubagentMessage(t, repo, "msg-blank", "session-malformed", "task-malformed", "turn-malformed", "", ts, ts)
+	seedRawSubagentMessage(t, repo, "msg-null", "session-malformed", "task-malformed", "turn-malformed", "null", ts, ts)
+	seedSubagentMessage(t, repo, "msg-valid", "session-malformed", "task-malformed", "turn-malformed",
+		"tc-malformed", "", "completed",
+		map[string]interface{}{"status": "completed"},
+		ts, ts,
+	)
+
+	if err := repo.runMigrations(); err != nil {
+		t.Fatalf("runMigrations must not abort on malformed metadata rows: %v", err)
+	}
+
+	if count := countSubagentContextRows(t, repo, "session-malformed", "tc-malformed"); count != 1 {
+		t.Fatalf("valid row alongside malformed metadata rows: count = %d, want 1", count)
+	}
+}
+
+// TestSubagentContextBackfillLiveRowWins covers AC-22: a live write always
+// wins over a backfilled one, and a replay of the backfill is a true no-op.
+func TestSubagentContextBackfillLiveRowWins(t *testing.T) {
+	repo, db := newSubagentMigrationTestRepo(t)
+	seedForMsgTest(t, repo, "task-live-wins", "session-live-wins", "turn-live-wins")
+	ts := time.Date(2026, 8, 5, 15, 0, 0, 0, time.UTC)
+
+	seedSubagentMessage(t, repo, "msg-live-wins", "session-live-wins", "task-live-wins", "turn-live-wins",
+		"tc-live-wins", "", "completed",
+		map[string]interface{}{"status": "completed", "model": "backfill-shape-model"},
+		ts, ts,
+	)
+
+	liveObservedAt := ts.Add(time.Hour)
+	if _, err := db.Exec(db.Rebind(`
+		INSERT INTO task_session_subagents
+			(id, task_session_id, task_id, tool_call_id, model, source, observed_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, 'live', ?, ?)
+	`), "row-live-wins", "session-live-wins", "task-live-wins", "tc-live-wins", "live-model", liveObservedAt, liveObservedAt); err != nil {
+		t.Fatalf("seed pre-existing live row: %v", err)
+	}
+
+	if err := repo.runMigrations(); err != nil {
+		t.Fatalf("runMigrations: %v", err)
+	}
+
+	row := getSubagentContextRow(t, repo, "session-live-wins", "tc-live-wins")
+	if row.source != "live" {
+		t.Errorf("source = %q, want live (backfill must not overwrite)", row.source)
+	}
+	if !row.model.Valid || row.model.String != "live-model" {
+		t.Errorf("model = %v, want live-model preserved", row.model)
+	}
+	if count := countSubagentContextRows(t, repo, "session-live-wins", "tc-live-wins"); count != 1 {
+		t.Fatalf("row count = %d, want exactly 1", count)
+	}
+}
+
+// TestSubagentContextBackfillSkipsRowsWithoutIdentity covers AC-2: a message
+// with no task_id or no tool_call_id must not backfill a row.
+func TestSubagentContextBackfillSkipsRowsWithoutIdentity(t *testing.T) {
+	repo, _ := newSubagentMigrationTestRepo(t)
+	seedForMsgTest(t, repo, "task-identity", "session-identity", "turn-identity")
+	ts := time.Date(2026, 8, 5, 16, 0, 0, 0, time.UTC)
+
+	// No task_id: seed the message row directly with task_id = ''.
+	seedRawSubagentMessage(t, repo, "msg-no-task", "session-identity", "", "turn-identity",
+		`{"tool_call_id":"tc-no-task","status":"completed","normalized":{"kind":"subagent_task","subagent_task":{"status":"completed"}}}`,
+		ts, ts,
+	)
+	// No tool_call_id.
+	seedSubagentMessage(t, repo, "msg-no-toolcall", "session-identity", "task-identity", "turn-identity",
+		"", "", "completed",
+		map[string]interface{}{"status": "completed"},
+		ts, ts,
+	)
+
+	if err := repo.runMigrations(); err != nil {
+		t.Fatalf("runMigrations: %v", err)
+	}
+
+	if count := countSubagentContextRows(t, repo, "session-identity", "tc-no-task"); count != 0 {
+		t.Fatalf("row backfilled for message with no task_id: count = %d, want 0", count)
+	}
+	if count := countSubagentContextRows(t, repo, "session-identity", ""); count != 0 {
+		t.Fatalf("row backfilled for message with no tool_call_id: count = %d, want 0", count)
+	}
+}
+
+// TestSubagentContextBackfillNestedParentToolCallID covers AC-6: a nested
+// subagent (parent_tool_call_id set) must be recorded, not suppressed.
+func TestSubagentContextBackfillNestedParentToolCallID(t *testing.T) {
+	repo, _ := newSubagentMigrationTestRepo(t)
+	seedForMsgTest(t, repo, "task-nested", "session-nested", "turn-nested")
+	ts := time.Date(2026, 8, 5, 17, 0, 0, 0, time.UTC)
+
+	seedSubagentMessage(t, repo, "msg-nested", "session-nested", "task-nested", "turn-nested",
+		"tc-nested-child", "tc-nested-parent", "completed",
+		map[string]interface{}{"status": "completed"},
+		ts, ts,
+	)
+
+	if err := repo.runMigrations(); err != nil {
+		t.Fatalf("runMigrations: %v", err)
+	}
+
+	row := getSubagentContextRow(t, repo, "session-nested", "tc-nested-child")
+	if !row.parentToolCallID.Valid || row.parentToolCallID.String != "tc-nested-parent" {
+		t.Errorf("parent_tool_call_id = %v, want tc-nested-parent", row.parentToolCallID)
+	}
+}
+
+// TestSubagentContextActivationKeysWrittenOnce covers AC-24: both kandev_meta
+// keys are written once, RFC3339-parseable (backfill_through may be empty),
+// and never overwritten on replay.
+//
+// initSchema() runs runMigrations() as one of its steps, so NewWithDB already
+// claims both keys once against the empty database created in this same
+// boot — correctly recording "no history to backfill" for a genuinely fresh
+// install. To exercise the "existing DB, historical messages predate this
+// boot" case AC-24 is actually written for, this test deletes the two
+// write-once rows (simulating that this is the database's first boot with
+// the new migration) before seeding messages and re-running.
+func TestSubagentContextActivationKeysWrittenOnce(t *testing.T) {
+	repo, db := newSubagentMigrationTestRepo(t)
+	seedForMsgTest(t, repo, "task-activation", "session-activation", "turn-activation")
+	newest := time.Date(2026, 8, 9, 9, 0, 0, 0, time.UTC)
+	older := time.Date(2026, 8, 6, 9, 0, 0, 0, time.UTC)
+
+	seedSubagentMessage(t, repo, "msg-activation-older", "session-activation", "task-activation", "turn-activation",
+		"tc-activation-older", "", "completed", map[string]interface{}{"status": "completed"}, older, older)
+	seedSubagentMessage(t, repo, "msg-activation-newest", "session-activation", "task-activation", "turn-activation",
+		"tc-activation-newest", "", "completed", map[string]interface{}{"status": "completed"}, newest, newest)
+
+	if _, err := db.Exec(`DELETE FROM kandev_meta WHERE key IN ('subagent_context_capture_since', 'subagent_context_backfill_through')`); err != nil {
+		t.Fatalf("reset activation keys to simulate first boot with data present: %v", err)
+	}
+	if err := repo.runMigrations(); err != nil {
+		t.Fatalf("runMigrations: %v", err)
+	}
+
+	captureSince, ok := readMetaKey(t, db, "subagent_context_capture_since")
+	if !ok {
+		t.Fatal("subagent_context_capture_since must be present")
+	}
+	if _, err := time.Parse(time.RFC3339, captureSince); err != nil {
+		t.Fatalf("subagent_context_capture_since = %q, not RFC3339: %v", captureSince, err)
+	}
+
+	backfillThrough, ok := readMetaKey(t, db, "subagent_context_backfill_through")
+	if !ok {
+		t.Fatal("subagent_context_backfill_through must be present")
+	}
+	parsed, err := time.Parse(time.RFC3339, backfillThrough)
+	if err != nil {
+		t.Fatalf("subagent_context_backfill_through = %q, not RFC3339: %v", backfillThrough, err)
+	}
+	if !parsed.Equal(newest) {
+		t.Fatalf("subagent_context_backfill_through = %v, want newest message created_at %v", parsed, newest)
+	}
+
+	if err := repo.runMigrations(); err != nil {
+		t.Fatalf("replay runMigrations: %v", err)
+	}
+	captureSinceReplayed, _ := readMetaKey(t, db, "subagent_context_capture_since")
+	backfillThroughReplayed, _ := readMetaKey(t, db, "subagent_context_backfill_through")
+	if captureSinceReplayed != captureSince {
+		t.Fatalf("subagent_context_capture_since changed on replay: %q -> %q", captureSince, captureSinceReplayed)
+	}
+	if backfillThroughReplayed != backfillThrough {
+		t.Fatalf("subagent_context_backfill_through changed on replay: %q -> %q", backfillThrough, backfillThroughReplayed)
+	}
+}
+
+// TestSubagentContextActivationBackfillThroughEmptyWithNoMessages covers the
+// AC-24 edge case: a fresh DB with no subagent messages sets
+// subagent_context_backfill_through to the empty string, not NULL and not a
+// missing key.
+func TestSubagentContextActivationBackfillThroughEmptyWithNoMessages(t *testing.T) {
+	repo, db := newSubagentMigrationTestRepo(t)
+
+	if err := repo.runMigrations(); err != nil {
+		t.Fatalf("runMigrations: %v", err)
+	}
+
+	backfillThrough, ok := readMetaKey(t, db, "subagent_context_backfill_through")
+	if !ok {
+		t.Fatal("subagent_context_backfill_through must be present even with no subagent messages")
+	}
+	if backfillThrough != "" {
+		t.Fatalf("subagent_context_backfill_through = %q, want empty string", backfillThrough)
+	}
+}

--- a/apps/backend/internal/task/repository/sqlite/subagent_context_migration_test.go
+++ b/apps/backend/internal/task/repository/sqlite/subagent_context_migration_test.go
@@ -8,7 +8,11 @@ import (
 	"time"
 
 	"github.com/jmoiron/sqlx"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 
+	"github.com/kandev/kandev/internal/common/logger"
 	dbutil "github.com/kandev/kandev/internal/db"
 )
 
@@ -143,6 +147,20 @@ func newSubagentMigrationTestRepo(t *testing.T) (*Repository, *sqlx.DB) {
 	if err != nil {
 		t.Fatalf("initialize schema: %v", err)
 	}
+	// NewWithDB's own initSchema() already ran the one-time backfill once,
+	// against an empty database with no messages seeded yet, and claimed the
+	// two activation keys (AC-24) — correct for a genuinely fresh install,
+	// but not what this file's tests want: they seed subagent-shaped
+	// messages AFTER construction and then call repo.runMigrations() again,
+	// expecting THAT call to be the real (only) backfill run — mirroring a
+	// DB upgrade where historical messages predate this boot. Reset to
+	// "not yet activated" so every test in this file gets that semantics by
+	// default. See subagentContextBackfillActivated in base_migrations.go,
+	// which gates the backfill's full-table scan on these same two keys so
+	// it runs at most once per installation (AC-23a).
+	if _, err := db.Exec(`DELETE FROM kandev_meta WHERE key IN ('subagent_context_capture_since', 'subagent_context_backfill_through')`); err != nil {
+		t.Fatalf("reset subagent context activation keys: %v", err)
+	}
 	return repo, db
 }
 
@@ -203,6 +221,13 @@ func TestSubagentContextSchemaFreshAndReplay(t *testing.T) {
 // named must-not-get-wrong regression: 75% of real subagent invocations are
 // async_launched with no reported usage, and a DEFAULT 0 anywhere would
 // fabricate every one of them. (AC-7, AC-21)
+//
+// It also covers AC-21's per-column derivation for every text column the
+// backfill's SELECT list populates: subagent_type, description, agent_id,
+// child_session_id, and model are five adjacent same-typed columns in that
+// SELECT with no other test giving each a distinct, individually-asserted
+// value — a column-order mistake in the SELECT list (e.g. subagent_type and
+// description swapped) would otherwise pass every existing test untouched.
 func TestSubagentContextBackfillAsyncLaunchedStoresNullNotZero(t *testing.T) {
 	repo, _ := newSubagentMigrationTestRepo(t)
 	seedForMsgTest(t, repo, "task-async", "session-async", "turn-async")
@@ -212,10 +237,13 @@ func TestSubagentContextBackfillAsyncLaunchedStoresNullNotZero(t *testing.T) {
 	seedSubagentMessage(t, repo, "msg-async", "session-async", "task-async", "turn-async",
 		"tc-async", "", "complete",
 		map[string]interface{}{
-			"description":   "run tests",
-			"subagent_type": "test-runner",
-			"status":        "async_launched",
-			"is_async":      true,
+			"description":      "run the test suite",
+			"subagent_type":    "test-runner",
+			"agent_id":         "agent-xyz",
+			"child_session_id": "child-session-xyz",
+			"model":            "claude-async-model",
+			"status":           "async_launched",
+			"is_async":         true,
 		},
 		createdAt, updatedAt,
 	)
@@ -225,6 +253,27 @@ func TestSubagentContextBackfillAsyncLaunchedStoresNullNotZero(t *testing.T) {
 	}
 
 	row := getSubagentContextRow(t, repo, "session-async", "tc-async")
+	if row.taskID != "task-async" {
+		t.Errorf("task_id = %q, want task-async", row.taskID)
+	}
+	if !row.turnID.Valid || row.turnID.String != "turn-async" {
+		t.Errorf("turn_id = %v, want turn-async", row.turnID)
+	}
+	if !row.subagentType.Valid || row.subagentType.String != "test-runner" {
+		t.Errorf("subagent_type = %v, want test-runner", row.subagentType)
+	}
+	if !row.description.Valid || row.description.String != "run the test suite" {
+		t.Errorf("description = %v, want %q", row.description, "run the test suite")
+	}
+	if !row.agentID.Valid || row.agentID.String != "agent-xyz" {
+		t.Errorf("agent_id = %v, want agent-xyz", row.agentID)
+	}
+	if !row.childSessionID.Valid || row.childSessionID.String != "child-session-xyz" {
+		t.Errorf("child_session_id = %v, want child-session-xyz", row.childSessionID)
+	}
+	if !row.model.Valid || row.model.String != "claude-async-model" {
+		t.Errorf("model = %v, want claude-async-model", row.model)
+	}
 	if row.totalTokens.Valid {
 		t.Errorf("total_tokens = %v, want NULL", row.totalTokens)
 	}
@@ -368,8 +417,43 @@ func TestSubagentContextBackfillMalformedMetadataDoesNotAbort(t *testing.T) {
 	}
 }
 
+// TestSubagentContextBackfillNonTerminalSettledAtNull covers AC-23a's ELSE
+// branch: a message whose derived ACP tool_status is NOT one of the terminal
+// values must backfill with settled_at NULL, not a fabricated value from the
+// message's updated_at. Every other backfill fixture in this file uses a
+// terminal status, so nothing else exercises this branch — the spec notes 5
+// real rows are in exactly this "started" (non-terminal) state.
+func TestSubagentContextBackfillNonTerminalSettledAtNull(t *testing.T) {
+	repo, _ := newSubagentMigrationTestRepo(t)
+	seedForMsgTest(t, repo, "task-started", "session-started", "turn-started")
+	ts := time.Date(2026, 8, 5, 14, 30, 0, 0, time.UTC)
+
+	seedSubagentMessage(t, repo, "msg-started", "session-started", "task-started", "turn-started",
+		"tc-started", "", "started",
+		map[string]interface{}{"status": "started"},
+		ts, ts,
+	)
+
+	if err := repo.runMigrations(); err != nil {
+		t.Fatalf("runMigrations: %v", err)
+	}
+
+	row := getSubagentContextRow(t, repo, "session-started", "tc-started")
+	if row.settledAt.Valid {
+		t.Errorf("settled_at = %v, want NULL (tool_status %q is not terminal)", row.settledAt, "started")
+	}
+	if !row.toolStatus.Valid || row.toolStatus.String != "started" {
+		t.Errorf("tool_status = %v, want started", row.toolStatus)
+	}
+}
+
 // TestSubagentContextBackfillLiveRowWins covers AC-22: a live write always
-// wins over a backfilled one, and a replay of the backfill is a true no-op.
+// wins over a backfilled one, a replay of the backfill is a true no-op, AND
+// the ON CONFLICT DO NOTHING clause that makes that possible does not abort
+// the rest of the single unbounded INSERT...SELECT (AC-23a) — a second,
+// unconflicted message in the same statement must still land. Without the
+// clause, SQLite's INSERT...SELECT aborts the WHOLE statement on the first
+// UNIQUE violation, silently dropping every other backfillable row too.
 func TestSubagentContextBackfillLiveRowWins(t *testing.T) {
 	repo, db := newSubagentMigrationTestRepo(t)
 	seedForMsgTest(t, repo, "task-live-wins", "session-live-wins", "turn-live-wins")
@@ -379,6 +463,11 @@ func TestSubagentContextBackfillLiveRowWins(t *testing.T) {
 		"tc-live-wins", "", "completed",
 		map[string]interface{}{"status": "completed", "model": "backfill-shape-model"},
 		ts, ts,
+	)
+	seedSubagentMessage(t, repo, "msg-live-wins-sibling", "session-live-wins", "task-live-wins", "turn-live-wins",
+		"tc-live-wins-sibling", "", "completed",
+		map[string]interface{}{"status": "completed", "model": "sibling-model"},
+		ts.Add(time.Minute), ts.Add(time.Minute),
 	)
 
 	liveObservedAt := ts.Add(time.Hour)
@@ -403,6 +492,14 @@ func TestSubagentContextBackfillLiveRowWins(t *testing.T) {
 	}
 	if count := countSubagentContextRows(t, repo, "session-live-wins", "tc-live-wins"); count != 1 {
 		t.Fatalf("row count = %d, want exactly 1", count)
+	}
+
+	sibling := getSubagentContextRow(t, repo, "session-live-wins", "tc-live-wins-sibling")
+	if sibling.source != "backfill" {
+		t.Errorf("sibling source = %q, want backfill (the UNIQUE violation on the OTHER row must not abort this insert)", sibling.source)
+	}
+	if !sibling.model.Valid || sibling.model.String != "sibling-model" {
+		t.Errorf("sibling model = %v, want sibling-model", sibling.model)
 	}
 }
 
@@ -462,15 +559,10 @@ func TestSubagentContextBackfillNestedParentToolCallID(t *testing.T) {
 
 // TestSubagentContextActivationKeysWrittenOnce covers AC-24: both kandev_meta
 // keys are written once, RFC3339-parseable (backfill_through may be empty),
-// and never overwritten on replay.
-//
-// initSchema() runs runMigrations() as one of its steps, so NewWithDB already
-// claims both keys once against the empty database created in this same
-// boot — correctly recording "no history to backfill" for a genuinely fresh
-// install. To exercise the "existing DB, historical messages predate this
-// boot" case AC-24 is actually written for, this test deletes the two
-// write-once rows (simulating that this is the database's first boot with
-// the new migration) before seeding messages and re-running.
+// and never overwritten on replay. newSubagentMigrationTestRepo already
+// resets both keys to "not yet activated" after construction (see its
+// comment), so the first runMigrations() call below is the real backfill run
+// this test exercises.
 func TestSubagentContextActivationKeysWrittenOnce(t *testing.T) {
 	repo, db := newSubagentMigrationTestRepo(t)
 	seedForMsgTest(t, repo, "task-activation", "session-activation", "turn-activation")
@@ -482,9 +574,6 @@ func TestSubagentContextActivationKeysWrittenOnce(t *testing.T) {
 	seedSubagentMessage(t, repo, "msg-activation-newest", "session-activation", "task-activation", "turn-activation",
 		"tc-activation-newest", "", "completed", map[string]interface{}{"status": "completed"}, newest, newest)
 
-	if _, err := db.Exec(`DELETE FROM kandev_meta WHERE key IN ('subagent_context_capture_since', 'subagent_context_backfill_through')`); err != nil {
-		t.Fatalf("reset activation keys to simulate first boot with data present: %v", err)
-	}
 	if err := repo.runMigrations(); err != nil {
 		t.Fatalf("runMigrations: %v", err)
 	}
@@ -539,5 +628,112 @@ func TestSubagentContextActivationBackfillThroughEmptyWithNoMessages(t *testing.
 	}
 	if backfillThrough != "" {
 		t.Fatalf("subagent_context_backfill_through = %q, want empty string", backfillThrough)
+	}
+}
+
+// TestSubagentContextBackfillDoesNotRescanOnceActivated covers AC-23a: the
+// backfill's full-table scan is "a real, accepted one-time cost ... taken
+// once", not a per-boot cost. Once subagent_context_capture_since is set, a
+// later runMigrations() call (a later boot) must skip the scan entirely —
+// proven here by deleting an already-backfilled row and confirming a second
+// runMigrations() call does not restore it. Under the pre-fix behaviour
+// (migrateSubagentContextBackfill ran its INSERT...SELECT unconditionally on
+// every call, relying only on ON CONFLICT DO NOTHING for row-level
+// idempotence) nothing would have stopped that second call from re-scanning
+// task_session_messages and re-inserting the deleted row, since deleting it
+// removes the only thing ON CONFLICT DO NOTHING keys off.
+func TestSubagentContextBackfillDoesNotRescanOnceActivated(t *testing.T) {
+	repo, db := newSubagentMigrationTestRepo(t)
+	seedForMsgTest(t, repo, "task-once", "session-once", "turn-once")
+	ts := time.Date(2026, 8, 5, 18, 0, 0, 0, time.UTC)
+
+	seedSubagentMessage(t, repo, "msg-once", "session-once", "task-once", "turn-once",
+		"tc-once", "", "completed",
+		map[string]interface{}{"status": "completed"},
+		ts, ts,
+	)
+
+	if err := repo.runMigrations(); err != nil {
+		t.Fatalf("first runMigrations (the real, one-time backfill): %v", err)
+	}
+	if count := countSubagentContextRows(t, repo, "session-once", "tc-once"); count != 1 {
+		t.Fatalf("row count after first backfill = %d, want 1", count)
+	}
+
+	if _, err := db.Exec(db.Rebind(`DELETE FROM task_session_subagents WHERE task_session_id = ? AND tool_call_id = ?`),
+		"session-once", "tc-once"); err != nil {
+		t.Fatalf("delete backfilled row: %v", err)
+	}
+
+	if err := repo.runMigrations(); err != nil {
+		t.Fatalf("second runMigrations (a later boot): %v", err)
+	}
+	if count := countSubagentContextRows(t, repo, "session-once", "tc-once"); count != 0 {
+		t.Fatalf("row count after second boot = %d, want 0 (backfill must not re-scan once activated)", count)
+	}
+}
+
+// TestSubagentContextBackfillStatementFailureLogsWarnWithMigrationName covers
+// AC-20: because MigrateLogger.Apply swallows a migration statement's error
+// (internal/db/migratelog.go), the only way a failure is observable is a WARN
+// log carrying the migration's name. Forces the backfill INSERT to fail (its
+// target table dropped out from under it) and asserts that WARN, using the
+// same zaptest/observer pattern as
+// TestCutover_RolledBackCutoverEmitsNoSuccessLog in
+// worktree_ownership_election_test.go.
+func TestSubagentContextBackfillStatementFailureLogsWarnWithMigrationName(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "subagent-context-migration-failure.db")
+	dbConn, err := dbutil.OpenSQLite(dbPath)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	db := sqlx.NewDb(dbConn, "sqlite3")
+	t.Cleanup(func() { _ = db.Close() })
+	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS kandev_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL DEFAULT '')`); err != nil {
+		t.Fatalf("create kandev_meta: %v", err)
+	}
+
+	core, logs := observer.New(zapcore.WarnLevel)
+	log, err := logger.NewFromZap(zap.New(core))
+	if err != nil {
+		t.Fatalf("create observer logger: %v", err)
+	}
+	repo := &Repository{db: db, ro: db, log: log, migrate: dbutil.NewMigrateLogger(db, log)}
+	if err := repo.initSchema(); err != nil {
+		t.Fatalf("initSchema: %v", err)
+	}
+
+	seedForMsgTest(t, repo, "task-migfail", "session-migfail", "turn-migfail")
+	seedSubagentMessage(t, repo, "msg-migfail", "session-migfail", "task-migfail", "turn-migfail",
+		"tc-migfail", "", "completed",
+		map[string]interface{}{"status": "completed"},
+		time.Date(2026, 8, 5, 19, 0, 0, 0, time.UTC), time.Date(2026, 8, 5, 19, 0, 0, 0, time.UTC),
+	)
+
+	// Reset to "not yet activated" (see newSubagentMigrationTestRepo's
+	// comment) so the next runMigrations() call actually attempts the
+	// backfill instead of being skipped by subagentContextBackfillActivated,
+	// then drop its INSERT target so that attempt fails.
+	if _, err := db.Exec(`DELETE FROM kandev_meta WHERE key IN ('subagent_context_capture_since', 'subagent_context_backfill_through')`); err != nil {
+		t.Fatalf("reset activation keys: %v", err)
+	}
+	if _, err := db.Exec(`DROP TABLE task_session_subagents`); err != nil {
+		t.Fatalf("drop task_session_subagents: %v", err)
+	}
+
+	if err := repo.runMigrations(); err != nil {
+		t.Fatalf("runMigrations must swallow the failure, not return it: %v", err)
+	}
+
+	entries := logs.FilterMessage("migration failed").All()
+	var found bool
+	for _, entry := range entries {
+		if entry.ContextMap()["name"] == "task_session_subagents.backfill" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("no WARN log carrying migration name %q found among %d entries", "task_session_subagents.backfill", len(entries))
 	}
 }

--- a/apps/backend/internal/task/repository/sqlite/subagent_context_postgres_test.go
+++ b/apps/backend/internal/task/repository/sqlite/subagent_context_postgres_test.go
@@ -1,0 +1,262 @@
+package sqlite
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+
+	"github.com/kandev/kandev/internal/task/models"
+	"github.com/kandev/kandev/internal/testutil"
+)
+
+func seedPostgresForMsgTest(t *testing.T, db *sqlx.DB, taskID, sessionID, turnID string) {
+	t.Helper()
+	now := time.Now().UTC()
+	if _, err := db.Exec(db.Rebind(`
+		INSERT INTO tasks (id, workspace_id, title, created_at, updated_at)
+		VALUES (?, '', 'test task', ?, ?)
+	`), taskID, now, now); err != nil {
+		t.Fatalf("seed task %s: %v", taskID, err)
+	}
+	if _, err := db.Exec(db.Rebind(`
+		INSERT INTO task_sessions (id, task_id, started_at, updated_at)
+		VALUES (?, ?, ?, ?)
+	`), sessionID, taskID, now, now); err != nil {
+		t.Fatalf("seed session %s: %v", sessionID, err)
+	}
+	if _, err := db.Exec(db.Rebind(`
+		INSERT INTO task_session_turns (id, task_session_id, task_id, started_at, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?)
+	`), turnID, sessionID, taskID, now, now, now); err != nil {
+		t.Fatalf("seed turn %s: %v", turnID, err)
+	}
+}
+
+// TestPostgresSubagentContextSchemaAndBackfill is the Postgres counterpart to
+// TestSubagentContextSchemaFreshAndReplay / TestSubagentContextBackfill*: a
+// fresh schema plus a migration replay produces the table, its indexes, the
+// backfilled rows, and both activation keys, matching SQLite (AC-19). Skips
+// unless KANDEV_TEST_POSTGRES_DSN is set.
+func TestPostgresSubagentContextSchemaAndBackfill(t *testing.T) {
+	db := testutil.OpenIsolatedPostgres(t, testutil.PostgresDSNFromEnv(t))
+	// Production boot order (internal/persistence/provider.go) creates
+	// kandev_meta before the task repository; mirror that here since this
+	// package's repository never creates it itself.
+	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS kandev_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL DEFAULT '')`); err != nil {
+		t.Fatalf("create kandev_meta: %v", err)
+	}
+	repo, err := NewWithDB(db, db, nil)
+	if err != nil {
+		t.Fatalf("init postgres schema: %v", err)
+	}
+	ctx := context.Background()
+
+	for _, index := range []string{"idx_subagents_session_id", "idx_subagents_task_id", "idx_subagents_turn_id"} {
+		var name string
+		if err := db.Get(&name, `SELECT indexname FROM pg_indexes WHERE indexname = $1`, index); err != nil {
+			t.Fatalf("index %s is missing on postgres: %v", index, err)
+		}
+	}
+
+	seedPostgresForMsgTest(t, db, "task-pg-schema", "session-pg-schema", "turn-pg-schema")
+	createdAt := time.Date(2026, 8, 5, 10, 0, 0, 0, time.UTC)
+	updatedAt := createdAt.Add(time.Second)
+	metadata := `{"tool_call_id":"tc-pg-backfill","status":"complete","normalized":{"kind":"subagent_task","subagent_task":{"status":"async_launched","is_async":true}}}`
+	if _, err := db.Exec(db.Rebind(`
+		INSERT INTO task_session_messages
+			(id, task_session_id, task_id, turn_id, author_type, content, type, metadata, created_at, updated_at)
+		VALUES (?, ?, ?, ?, 'agent', 'Subagent', 'tool_call', ?, ?, ?)
+	`), "msg-pg-backfill", "session-pg-schema", "task-pg-schema", "turn-pg-schema", metadata, createdAt, updatedAt); err != nil {
+		t.Fatalf("seed subagent message: %v", err)
+	}
+
+	// Reset the write-once activation keys to simulate this being the
+	// database's first boot with historical data present — mirrors
+	// TestSubagentContextActivationKeysWrittenOnce's SQLite technique, needed
+	// because NewWithDB above already claimed both keys against the
+	// then-empty database in this same boot.
+	if _, err := db.Exec(`DELETE FROM kandev_meta WHERE key IN ('subagent_context_capture_since', 'subagent_context_backfill_through')`); err != nil {
+		t.Fatalf("reset activation keys: %v", err)
+	}
+	if err := repo.runMigrations(); err != nil {
+		t.Fatalf("runMigrations: %v", err)
+	}
+	if err := repo.runMigrations(); err != nil {
+		t.Fatalf("replay runMigrations: %v", err)
+	}
+
+	rows, err := repo.ListSubagentContextsBySession(ctx, "session-pg-schema")
+	if err != nil {
+		t.Fatalf("ListSubagentContextsBySession: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("row count = %d, want 1", len(rows))
+	}
+	row := rows[0]
+	if row.Source != "backfill" {
+		t.Errorf("source = %q, want backfill", row.Source)
+	}
+	if row.TotalTokens != nil || row.ToolUseCount != nil || row.DurationMs != nil {
+		t.Errorf("metrics = tokens=%v count=%v duration=%v, want all NULL (async_launched)", row.TotalTokens, row.ToolUseCount, row.DurationMs)
+	}
+	if !row.IsAsync {
+		t.Error("is_async = false, want true")
+	}
+	if row.SettledAt == nil || !row.SettledAt.Equal(updatedAt) {
+		t.Errorf("settled_at = %v, want %v (tool_status complete is terminal)", row.SettledAt, updatedAt)
+	}
+
+	var captureSince, backfillThrough string
+	if err := db.Get(&captureSince, db.Rebind(`SELECT value FROM kandev_meta WHERE key = ?`), "subagent_context_capture_since"); err != nil {
+		t.Fatalf("read subagent_context_capture_since: %v", err)
+	}
+	if _, err := time.Parse(time.RFC3339, captureSince); err != nil {
+		t.Fatalf("subagent_context_capture_since = %q, not RFC3339: %v", captureSince, err)
+	}
+	if err := db.Get(&backfillThrough, db.Rebind(`SELECT value FROM kandev_meta WHERE key = ?`), "subagent_context_backfill_through"); err != nil {
+		t.Fatalf("read subagent_context_backfill_through: %v", err)
+	}
+	parsed, err := time.Parse(time.RFC3339, backfillThrough)
+	if err != nil {
+		t.Fatalf("subagent_context_backfill_through = %q, not RFC3339: %v", backfillThrough, err)
+	}
+	if !parsed.Equal(createdAt) {
+		t.Errorf("subagent_context_backfill_through = %v, want %v", parsed, createdAt)
+	}
+}
+
+// TestPostgresUpsertSubagentContextConflictBehavior verifies the upsert's
+// conflict clause behaviorally on Postgres — schema replay alone would not
+// exercise ON CONFLICT DO UPDATE semantics (ADR 0027). Covers fill-forward,
+// write-once settled_at, sticky is_async, and preserved original turn_id.
+func TestPostgresUpsertSubagentContextConflictBehavior(t *testing.T) {
+	db := testutil.OpenIsolatedPostgres(t, testutil.PostgresDSNFromEnv(t))
+	repo, err := NewWithDB(db, db, nil)
+	if err != nil {
+		t.Fatalf("init postgres schema: %v", err)
+	}
+	ctx := context.Background()
+	seedPostgresForMsgTest(t, db, "task-pg-upsert", "session-pg-upsert", "turn-pg-upsert-a")
+	if _, err := db.Exec(db.Rebind(`
+		INSERT INTO task_session_turns (id, task_session_id, task_id, started_at, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?)
+	`), "turn-pg-upsert-b", "session-pg-upsert", "task-pg-upsert", time.Now().UTC(), time.Now().UTC(), time.Now().UTC()); err != nil {
+		t.Fatalf("seed second turn: %v", err)
+	}
+
+	firstSettle := time.Date(2026, 8, 10, 9, 0, 0, 0, time.UTC)
+	turnA := "turn-pg-upsert-a"
+	if err := repo.UpsertSubagentContext(ctx, &models.SubagentContext{
+		TaskSessionID: "session-pg-upsert", TaskID: "task-pg-upsert", TurnID: &turnA,
+		ToolCallID: "tc-pg-upsert", Source: "live", ObservedAt: firstSettle, UpdatedAt: firstSettle,
+		SubagentType: sp("security-reviewer"), IsAsync: true,
+		ToolStatus: sp("completed"), SettledAt: &firstSettle,
+	}); err != nil {
+		t.Fatalf("first upsert: %v", err)
+	}
+
+	turnB := "turn-pg-upsert-b"
+	laterSettle := firstSettle.Add(time.Hour)
+	if err := repo.UpsertSubagentContext(ctx, &models.SubagentContext{
+		TaskSessionID: "session-pg-upsert", TaskID: "task-pg-upsert", TurnID: &turnB,
+		ToolCallID: "tc-pg-upsert", Source: "live", ObservedAt: firstSettle, UpdatedAt: laterSettle,
+		IsAsync: false, ToolStatus: sp("completed"), SettledAt: &laterSettle,
+		Model: sp("claude-opus-5"),
+	}); err != nil {
+		t.Fatalf("second upsert: %v", err)
+	}
+
+	rows, err := repo.ListSubagentContextsBySession(ctx, "session-pg-upsert")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("row count = %d, want 1", len(rows))
+	}
+	row := rows[0]
+	if row.TurnID == nil || *row.TurnID != "turn-pg-upsert-a" {
+		t.Errorf("turn_id = %v, want turn-pg-upsert-a (original turn preserved)", row.TurnID)
+	}
+	if !row.IsAsync {
+		t.Error("is_async = false, want sticky true")
+	}
+	if row.SettledAt == nil || !row.SettledAt.Equal(firstSettle) {
+		t.Errorf("settled_at = %v, want %v (write-once)", row.SettledAt, firstSettle)
+	}
+	if row.SubagentType == nil || *row.SubagentType != "security-reviewer" {
+		t.Errorf("subagent_type = %v, want preserved (fill-forward)", row.SubagentType)
+	}
+	if row.Model == nil || *row.Model != "claude-opus-5" {
+		t.Errorf("model = %v, want claude-opus-5 (filled from second frame)", row.Model)
+	}
+}
+
+// TestPostgresSubagentContextBackfillJSONHelpers verifies the backfill's
+// dialect-aware JSON helpers over jsonb (AC-23b): malformed metadata (” and
+// 'null') do not abort the migration, and the boolean spelling difference
+// (#>> yields 'true'/'false' text on Postgres vs SQLite's 1/0) normalizes
+// correctly.
+func TestPostgresSubagentContextBackfillJSONHelpers(t *testing.T) {
+	db := testutil.OpenIsolatedPostgres(t, testutil.PostgresDSNFromEnv(t))
+	repo, err := NewWithDB(db, db, nil)
+	if err != nil {
+		t.Fatalf("init postgres schema: %v", err)
+	}
+	seedPostgresForMsgTest(t, db, "task-pg-malformed", "session-pg-malformed", "turn-pg-malformed")
+	ts := time.Date(2026, 8, 5, 14, 0, 0, 0, time.UTC)
+
+	// idx_messages_metadata_tool_call_id / idx_messages_metadata_pending_id
+	// are expression indexes over metadata::jsonb; Postgres evaluates them on
+	// every insert, so a literal empty-string metadata row (simulating
+	// historical corruption that predates the index) can only be seeded with
+	// the index dropped first — matching subagent_context_migration_test.go's
+	// SQLite technique.
+	for _, index := range []string{"idx_messages_metadata_tool_call_id", "idx_messages_metadata_pending_id"} {
+		if _, err := db.Exec(`DROP INDEX IF EXISTS ` + index); err != nil {
+			t.Fatalf("drop %s: %v", index, err)
+		}
+	}
+	if _, err := db.Exec(db.Rebind(`
+		INSERT INTO task_session_messages
+			(id, task_session_id, task_id, turn_id, author_type, content, type, metadata, created_at, updated_at)
+		VALUES (?, ?, ?, ?, 'agent', 'Subagent', 'tool_call', ?, ?, ?)
+	`), "msg-pg-blank", "session-pg-malformed", "task-pg-malformed", "turn-pg-malformed", "", ts, ts); err != nil {
+		t.Fatalf("seed blank-metadata message: %v", err)
+	}
+	if _, err := db.Exec(db.Rebind(`
+		INSERT INTO task_session_messages
+			(id, task_session_id, task_id, turn_id, author_type, content, type, metadata, created_at, updated_at)
+		VALUES (?, ?, ?, ?, 'agent', 'Subagent', 'tool_call', ?, ?, ?)
+	`), "msg-pg-null", "session-pg-malformed", "task-pg-malformed", "turn-pg-malformed", "null", ts, ts); err != nil {
+		t.Fatalf("seed null-metadata message: %v", err)
+	}
+	validMetadata := `{"tool_call_id":"tc-pg-valid","status":"completed","normalized":{"kind":"subagent_task","subagent_task":{"status":"completed","is_async":true}}}`
+	if _, err := db.Exec(db.Rebind(`
+		INSERT INTO task_session_messages
+			(id, task_session_id, task_id, turn_id, author_type, content, type, metadata, created_at, updated_at)
+		VALUES (?, ?, ?, ?, 'agent', 'Subagent', 'tool_call', ?, ?, ?)
+	`), "msg-pg-valid", "session-pg-malformed", "task-pg-malformed", "turn-pg-malformed", validMetadata, ts, ts); err != nil {
+		t.Fatalf("seed valid message: %v", err)
+	}
+
+	if err := repo.runMigrations(); err != nil {
+		t.Fatalf("runMigrations must not abort on malformed metadata rows: %v", err)
+	}
+
+	rows, err := repo.ListSubagentContextsBySession(context.Background(), "session-pg-malformed")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("row count = %d, want 1 (only the valid row backfills)", len(rows))
+	}
+	row := rows[0]
+	if row.ToolCallID != "tc-pg-valid" {
+		t.Errorf("tool_call_id = %q, want tc-pg-valid", row.ToolCallID)
+	}
+	if !row.IsAsync {
+		t.Error("is_async = false, want true (Postgres #>> 'true' spelling must normalize to 1)")
+	}
+}

--- a/apps/backend/internal/task/repository/sqlite/subagent_context_postgres_test.go
+++ b/apps/backend/internal/task/repository/sqlite/subagent_context_postgres_test.go
@@ -260,3 +260,45 @@ func TestPostgresSubagentContextBackfillJSONHelpers(t *testing.T) {
 		t.Error("is_async = false, want true (Postgres #>> 'true' spelling must normalize to 1)")
 	}
 }
+
+// TestPostgresSubagentContextHealthCountsAgreeAfterLiveWrites is the
+// PostgreSQL counterpart to TestSubagentContextHealthCountsAgreeAfterLiveWrites:
+// AC-28's message-side query uses SQLite's json_extract in the spec's
+// illustrative form, which does not exist on PostgreSQL — subagentMessageCount
+// builds the dialect-appropriate expression instead, and this test proves that
+// expression actually agrees with the context-side count on PostgreSQL, not
+// just on SQLite (AC-19).
+func TestPostgresSubagentContextHealthCountsAgreeAfterLiveWrites(t *testing.T) {
+	db := testutil.OpenIsolatedPostgres(t, testutil.PostgresDSNFromEnv(t))
+	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS kandev_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL DEFAULT '')`); err != nil {
+		t.Fatalf("create kandev_meta: %v", err)
+	}
+	repo, err := NewWithDB(db, db, nil)
+	if err != nil {
+		t.Fatalf("init postgres schema: %v", err)
+	}
+	seedPostgresForMsgTest(t, db, "task-pg-health", "session-pg-health", "turn-pg-health")
+	ctx := context.Background()
+	ts := time.Date(2026, 8, 12, 9, 0, 0, 0, time.UTC)
+
+	for i, toolCallID := range []string{"tc-pg-health-1", "tc-pg-health-2", "tc-pg-health-3"} {
+		seedSubagentMessage(t, repo, "msg-pg-health-"+toolCallID, "session-pg-health", "task-pg-health", "turn-pg-health",
+			toolCallID, "", "completed", map[string]interface{}{"status": "completed"},
+			ts.Add(time.Duration(i)*time.Minute), ts.Add(time.Duration(i)*time.Minute))
+		if err := repo.UpsertSubagentContext(ctx, &models.SubagentContext{
+			TaskSessionID: "session-pg-health", TaskID: "task-pg-health", ToolCallID: toolCallID,
+			Source: "live", ObservedAt: ts.Add(time.Duration(i) * time.Minute), UpdatedAt: ts.Add(time.Duration(i) * time.Minute),
+		}); err != nil {
+			t.Fatalf("UpsertSubagentContext %s: %v", toolCallID, err)
+		}
+	}
+
+	messageCount := subagentMessageCount(t, repo)
+	contextCount := subagentContextCount(t, repo)
+	if messageCount != contextCount {
+		t.Fatalf("message count = %d, context count = %d; want equal after live writes", messageCount, contextCount)
+	}
+	if messageCount != 3 {
+		t.Fatalf("message count = %d, want 3", messageCount)
+	}
+}

--- a/apps/backend/internal/task/repository/sqlite/subagent_context_test.go
+++ b/apps/backend/internal/task/repository/sqlite/subagent_context_test.go
@@ -1,0 +1,549 @@
+package sqlite
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/task/models"
+)
+
+func sp(s string) *string       { return &s }
+func i64p(n int64) *int64       { return &n }
+func tp(t time.Time) *time.Time { return &t }
+
+func newSubagentContextTestRepo(t *testing.T, taskID, sessionID, turnID string) *Repository {
+	t.Helper()
+	repo, _ := newSubagentMigrationTestRepo(t)
+	seedForMsgTest(t, repo, taskID, sessionID, turnID)
+	return repo
+}
+
+func mustGetSubagentContext(t *testing.T, repo *Repository, sessionID, toolCallID string) *models.SubagentContext {
+	t.Helper()
+	rows, err := repo.ListSubagentContextsBySession(context.Background(), sessionID)
+	if err != nil {
+		t.Fatalf("ListSubagentContextsBySession: %v", err)
+	}
+	for _, row := range rows {
+		if row.ToolCallID == toolCallID {
+			return row
+		}
+	}
+	t.Fatalf("no subagent context row for (%s, %s) among %d rows", sessionID, toolCallID, len(rows))
+	return nil
+}
+
+// TestUpsertSubagentContextInsertsRow covers AC-1: a first observation
+// creates a row.
+func TestUpsertSubagentContextInsertsRow(t *testing.T) {
+	repo := newSubagentContextTestRepo(t, "task-1", "session-1", "turn-1")
+	ctx := context.Background()
+	observedAt := time.Date(2026, 8, 10, 9, 0, 0, 0, time.UTC)
+
+	err := repo.UpsertSubagentContext(ctx, &models.SubagentContext{
+		TaskSessionID: "session-1",
+		TaskID:        "task-1",
+		TurnID:        sp("turn-1"),
+		ToolCallID:    "tc-1",
+		Source:        "live",
+		ObservedAt:    observedAt,
+		UpdatedAt:     observedAt,
+	})
+	if err != nil {
+		t.Fatalf("UpsertSubagentContext: %v", err)
+	}
+
+	row := mustGetSubagentContext(t, repo, "session-1", "tc-1")
+	if row.Source != "live" {
+		t.Errorf("source = %q, want live", row.Source)
+	}
+	if !row.ObservedAt.Equal(observedAt) {
+		t.Errorf("observed_at = %v, want %v", row.ObservedAt, observedAt)
+	}
+	if row.TurnID == nil || *row.TurnID != "turn-1" {
+		t.Errorf("turn_id = %v, want turn-1", row.TurnID)
+	}
+}
+
+// TestUpsertSubagentContextSecondCallUpdatesInPlace covers AC-3: a later
+// frame for an already-recorded key updates the same row, never a second one.
+func TestUpsertSubagentContextSecondCallUpdatesInPlace(t *testing.T) {
+	repo := newSubagentContextTestRepo(t, "task-2", "session-2", "turn-2")
+	ctx := context.Background()
+	first := time.Date(2026, 8, 10, 9, 0, 0, 0, time.UTC)
+	second := first.Add(time.Minute)
+
+	base := models.SubagentContext{
+		TaskSessionID: "session-2", TaskID: "task-2", TurnID: sp("turn-2"),
+		ToolCallID: "tc-2", Source: "live", ObservedAt: first, UpdatedAt: first,
+	}
+	if err := repo.UpsertSubagentContext(ctx, &base); err != nil {
+		t.Fatalf("first upsert: %v", err)
+	}
+	second_ := base
+	second_.Model = sp("claude-opus-5")
+	second_.UpdatedAt = second
+	if err := repo.UpsertSubagentContext(ctx, &second_); err != nil {
+		t.Fatalf("second upsert: %v", err)
+	}
+
+	rows, err := repo.ListSubagentContextsBySession(ctx, "session-2")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("row count = %d, want 1", len(rows))
+	}
+	if rows[0].Model == nil || *rows[0].Model != "claude-opus-5" {
+		t.Errorf("model = %v, want claude-opus-5", rows[0].Model)
+	}
+}
+
+// TestUpsertSubagentContextFillForward covers AC-4: a frame with an
+// empty/absent field never blanks a value already learned.
+func TestUpsertSubagentContextFillForward(t *testing.T) {
+	repo := newSubagentContextTestRepo(t, "task-3", "session-3", "turn-3")
+	ctx := context.Background()
+	ts := time.Date(2026, 8, 10, 9, 0, 0, 0, time.UTC)
+
+	if err := repo.UpsertSubagentContext(ctx, &models.SubagentContext{
+		TaskSessionID: "session-3", TaskID: "task-3", TurnID: sp("turn-3"),
+		ToolCallID: "tc-3", Source: "live", ObservedAt: ts, UpdatedAt: ts,
+		SubagentType: sp("security-reviewer"), Description: sp("review the diff"),
+		Model: sp("claude-opus-5"), TotalTokens: i64p(500),
+	}); err != nil {
+		t.Fatalf("first upsert: %v", err)
+	}
+
+	// A later frame reports nothing new — every already-learned field must
+	// survive untouched.
+	if err := repo.UpsertSubagentContext(ctx, &models.SubagentContext{
+		TaskSessionID: "session-3", TaskID: "task-3",
+		ToolCallID: "tc-3", Source: "live", ObservedAt: ts, UpdatedAt: ts.Add(time.Second),
+	}); err != nil {
+		t.Fatalf("second upsert: %v", err)
+	}
+
+	row := mustGetSubagentContext(t, repo, "session-3", "tc-3")
+	if row.SubagentType == nil || *row.SubagentType != "security-reviewer" {
+		t.Errorf("subagent_type = %v, want preserved", row.SubagentType)
+	}
+	if row.Description == nil || *row.Description != "review the diff" {
+		t.Errorf("description = %v, want preserved", row.Description)
+	}
+	if row.Model == nil || *row.Model != "claude-opus-5" {
+		t.Errorf("model = %v, want preserved", row.Model)
+	}
+	if row.TotalTokens == nil || *row.TotalTokens != 500 {
+		t.Errorf("total_tokens = %v, want preserved", row.TotalTokens)
+	}
+}
+
+// TestUpsertSubagentContextReplacesWithNonEmptyValue covers AC-5: a
+// non-empty reported value replaces the stored value.
+func TestUpsertSubagentContextReplacesWithNonEmptyValue(t *testing.T) {
+	repo := newSubagentContextTestRepo(t, "task-4", "session-4", "turn-4")
+	ctx := context.Background()
+	ts := time.Date(2026, 8, 10, 9, 0, 0, 0, time.UTC)
+
+	if err := repo.UpsertSubagentContext(ctx, &models.SubagentContext{
+		TaskSessionID: "session-4", TaskID: "task-4", ToolCallID: "tc-4",
+		Source: "live", ObservedAt: ts, UpdatedAt: ts, TotalTokens: i64p(100),
+	}); err != nil {
+		t.Fatalf("first upsert: %v", err)
+	}
+	if err := repo.UpsertSubagentContext(ctx, &models.SubagentContext{
+		TaskSessionID: "session-4", TaskID: "task-4", ToolCallID: "tc-4",
+		Source: "live", ObservedAt: ts, UpdatedAt: ts.Add(time.Second), TotalTokens: i64p(250),
+	}); err != nil {
+		t.Fatalf("second upsert: %v", err)
+	}
+
+	row := mustGetSubagentContext(t, repo, "session-4", "tc-4")
+	if row.TotalTokens == nil || *row.TotalTokens != 250 {
+		t.Errorf("total_tokens = %v, want 250 (replaced)", row.TotalTokens)
+	}
+}
+
+// TestUpsertSubagentContextSettledAtWriteOnce covers AC-11: a second terminal
+// frame with a later timestamp leaves the first settled_at value.
+func TestUpsertSubagentContextSettledAtWriteOnce(t *testing.T) {
+	repo := newSubagentContextTestRepo(t, "task-5", "session-5", "turn-5")
+	ctx := context.Background()
+	firstSettle := time.Date(2026, 8, 10, 9, 0, 0, 0, time.UTC)
+	laterSettle := firstSettle.Add(time.Hour)
+
+	if err := repo.UpsertSubagentContext(ctx, &models.SubagentContext{
+		TaskSessionID: "session-5", TaskID: "task-5", ToolCallID: "tc-5",
+		Source: "live", ObservedAt: firstSettle, UpdatedAt: firstSettle,
+		ToolStatus: sp("completed"), SettledAt: tp(firstSettle),
+	}); err != nil {
+		t.Fatalf("first upsert: %v", err)
+	}
+	if err := repo.UpsertSubagentContext(ctx, &models.SubagentContext{
+		TaskSessionID: "session-5", TaskID: "task-5", ToolCallID: "tc-5",
+		Source: "live", ObservedAt: firstSettle, UpdatedAt: laterSettle,
+		ToolStatus: sp("completed"), SettledAt: tp(laterSettle),
+	}); err != nil {
+		t.Fatalf("second upsert: %v", err)
+	}
+
+	row := mustGetSubagentContext(t, repo, "session-5", "tc-5")
+	if row.SettledAt == nil || !row.SettledAt.Equal(firstSettle) {
+		t.Errorf("settled_at = %v, want %v (write-once)", row.SettledAt, firstSettle)
+	}
+}
+
+// TestUpsertSubagentContextPostSettleFillsNullsButFreezesStatus covers AC-12:
+// a non-terminal frame after settling leaves settled_at and tool_status
+// alone but still fills columns that are currently NULL.
+func TestUpsertSubagentContextPostSettleFillsNullsButFreezesStatus(t *testing.T) {
+	repo := newSubagentContextTestRepo(t, "task-6", "session-6", "turn-6")
+	ctx := context.Background()
+	settleTime := time.Date(2026, 8, 10, 9, 0, 0, 0, time.UTC)
+
+	if err := repo.UpsertSubagentContext(ctx, &models.SubagentContext{
+		TaskSessionID: "session-6", TaskID: "task-6", ToolCallID: "tc-6",
+		Source: "live", ObservedAt: settleTime, UpdatedAt: settleTime,
+		ToolStatus: sp("completed"), SettledAt: tp(settleTime),
+	}); err != nil {
+		t.Fatalf("first (terminal) upsert: %v", err)
+	}
+
+	// A stray non-terminal/duplicate frame arrives after settling — it must
+	// not resurrect tool_status or settled_at, but new information (model)
+	// still fills the NULL column.
+	if err := repo.UpsertSubagentContext(ctx, &models.SubagentContext{
+		TaskSessionID: "session-6", TaskID: "task-6", ToolCallID: "tc-6",
+		Source: "live", ObservedAt: settleTime, UpdatedAt: settleTime.Add(time.Second),
+		ToolStatus: sp("running"), Model: sp("claude-opus-5"),
+	}); err != nil {
+		t.Fatalf("second (post-settle) upsert: %v", err)
+	}
+
+	row := mustGetSubagentContext(t, repo, "session-6", "tc-6")
+	if row.ToolStatus == nil || *row.ToolStatus != "completed" {
+		t.Errorf("tool_status = %v, want frozen at completed", row.ToolStatus)
+	}
+	if row.SettledAt == nil || !row.SettledAt.Equal(settleTime) {
+		t.Errorf("settled_at = %v, want frozen at %v", row.SettledAt, settleTime)
+	}
+	if row.Model == nil || *row.Model != "claude-opus-5" {
+		t.Errorf("model = %v, want filled from post-settle frame", row.Model)
+	}
+}
+
+// TestUpsertSubagentContextNeverTerminalRowSettledAtNull covers AC-10: a row
+// that never reaches terminal keeps settled_at NULL and still exists.
+func TestUpsertSubagentContextNeverTerminalRowSettledAtNull(t *testing.T) {
+	repo := newSubagentContextTestRepo(t, "task-7", "session-7", "turn-7")
+	ctx := context.Background()
+	ts := time.Date(2026, 8, 10, 9, 0, 0, 0, time.UTC)
+
+	if err := repo.UpsertSubagentContext(ctx, &models.SubagentContext{
+		TaskSessionID: "session-7", TaskID: "task-7", ToolCallID: "tc-7",
+		Source: "live", ObservedAt: ts, UpdatedAt: ts, ToolStatus: sp("in_progress"),
+	}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	row := mustGetSubagentContext(t, repo, "session-7", "tc-7")
+	if row.SettledAt != nil {
+		t.Errorf("settled_at = %v, want NULL", row.SettledAt)
+	}
+}
+
+// TestUpsertSubagentContextTurnIDPreservedFromFirstFrame covers AC-2a: the
+// original turn_id survives a later frame carrying a different turn.
+func TestUpsertSubagentContextTurnIDPreservedFromFirstFrame(t *testing.T) {
+	repo := newSubagentContextTestRepo(t, "task-8", "session-8", "turn-8a")
+	ctx := context.Background()
+	if err := seedTurn(t, repo, "turn-8b", "session-8", "task-8"); err != nil {
+		t.Fatalf("seed second turn: %v", err)
+	}
+	ts := time.Date(2026, 8, 10, 9, 0, 0, 0, time.UTC)
+
+	if err := repo.UpsertSubagentContext(ctx, &models.SubagentContext{
+		TaskSessionID: "session-8", TaskID: "task-8", TurnID: sp("turn-8a"),
+		ToolCallID: "tc-8", Source: "live", ObservedAt: ts, UpdatedAt: ts,
+	}); err != nil {
+		t.Fatalf("first upsert: %v", err)
+	}
+	if err := repo.UpsertSubagentContext(ctx, &models.SubagentContext{
+		TaskSessionID: "session-8", TaskID: "task-8", TurnID: sp("turn-8b"),
+		ToolCallID: "tc-8", Source: "live", ObservedAt: ts, UpdatedAt: ts.Add(time.Second),
+	}); err != nil {
+		t.Fatalf("second upsert under a different turn: %v", err)
+	}
+
+	row := mustGetSubagentContext(t, repo, "session-8", "tc-8")
+	if row.TurnID == nil || *row.TurnID != "turn-8a" {
+		t.Errorf("turn_id = %v, want turn-8a (original turn preserved)", row.TurnID)
+	}
+}
+
+// TestUpsertSubagentContextIsAsyncSticky covers "is_async is sticky": once
+// set true, a later frame reporting false must not reset it.
+func TestUpsertSubagentContextIsAsyncSticky(t *testing.T) {
+	repo := newSubagentContextTestRepo(t, "task-9", "session-9", "turn-9")
+	ctx := context.Background()
+	ts := time.Date(2026, 8, 10, 9, 0, 0, 0, time.UTC)
+
+	if err := repo.UpsertSubagentContext(ctx, &models.SubagentContext{
+		TaskSessionID: "session-9", TaskID: "task-9", ToolCallID: "tc-9",
+		Source: "live", ObservedAt: ts, UpdatedAt: ts, IsAsync: true,
+	}); err != nil {
+		t.Fatalf("first upsert: %v", err)
+	}
+	if err := repo.UpsertSubagentContext(ctx, &models.SubagentContext{
+		TaskSessionID: "session-9", TaskID: "task-9", ToolCallID: "tc-9",
+		Source: "live", ObservedAt: ts, UpdatedAt: ts.Add(time.Second), IsAsync: false,
+	}); err != nil {
+		t.Fatalf("second upsert: %v", err)
+	}
+
+	row := mustGetSubagentContext(t, repo, "session-9", "tc-9")
+	if !row.IsAsync {
+		t.Error("is_async = false, want sticky true")
+	}
+}
+
+// TestUpsertSubagentContextSourceAndObservedAtNotOverwritten covers write-once
+// source/observed_at (AC-1a, AC-22): neither is present in the conflict SET
+// list, so a later upsert (even one that claims a different source or a
+// different observed_at) must not change them.
+func TestUpsertSubagentContextSourceAndObservedAtNotOverwritten(t *testing.T) {
+	repo := newSubagentContextTestRepo(t, "task-10", "session-10", "turn-10")
+	ctx := context.Background()
+	firstObserved := time.Date(2026, 8, 10, 9, 0, 0, 0, time.UTC)
+	laterObserved := firstObserved.Add(time.Hour)
+
+	if err := repo.UpsertSubagentContext(ctx, &models.SubagentContext{
+		TaskSessionID: "session-10", TaskID: "task-10", ToolCallID: "tc-10",
+		Source: "backfill", ObservedAt: firstObserved, UpdatedAt: firstObserved,
+	}); err != nil {
+		t.Fatalf("first upsert: %v", err)
+	}
+	if err := repo.UpsertSubagentContext(ctx, &models.SubagentContext{
+		TaskSessionID: "session-10", TaskID: "task-10", ToolCallID: "tc-10",
+		Source: "live", ObservedAt: laterObserved, UpdatedAt: laterObserved,
+	}); err != nil {
+		t.Fatalf("second (live) upsert: %v", err)
+	}
+
+	row := mustGetSubagentContext(t, repo, "session-10", "tc-10")
+	if row.Source != "backfill" {
+		t.Errorf("source = %q, want backfill preserved (a live write must not relabel a backfilled row)", row.Source)
+	}
+	if !row.ObservedAt.Equal(firstObserved) {
+		t.Errorf("observed_at = %v, want %v (first observation wins)", row.ObservedAt, firstObserved)
+	}
+}
+
+// TestUpsertSubagentContextNestedParentToolCallID covers AC-6: a nested
+// subagent is stored, not suppressed.
+func TestUpsertSubagentContextNestedParentToolCallID(t *testing.T) {
+	repo := newSubagentContextTestRepo(t, "task-11", "session-11", "turn-11")
+	ctx := context.Background()
+	ts := time.Date(2026, 8, 10, 9, 0, 0, 0, time.UTC)
+
+	if err := repo.UpsertSubagentContext(ctx, &models.SubagentContext{
+		TaskSessionID: "session-11", TaskID: "task-11", ToolCallID: "tc-11-child",
+		ParentToolCallID: sp("tc-11-parent"), Source: "live", ObservedAt: ts, UpdatedAt: ts,
+	}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	row := mustGetSubagentContext(t, repo, "session-11", "tc-11-child")
+	if row.ParentToolCallID == nil || *row.ParentToolCallID != "tc-11-parent" {
+		t.Errorf("parent_tool_call_id = %v, want tc-11-parent", row.ParentToolCallID)
+	}
+}
+
+// TestUpsertSubagentContextCascadeDeletesWithSession covers AC-16: deleting
+// the parent session removes its subagent context rows.
+func TestUpsertSubagentContextCascadeDeletesWithSession(t *testing.T) {
+	repo := newSubagentContextTestRepo(t, "task-12", "session-12", "turn-12")
+	ctx := context.Background()
+	ts := time.Date(2026, 8, 10, 9, 0, 0, 0, time.UTC)
+
+	if err := repo.UpsertSubagentContext(ctx, &models.SubagentContext{
+		TaskSessionID: "session-12", TaskID: "task-12", ToolCallID: "tc-12",
+		Source: "live", ObservedAt: ts, UpdatedAt: ts,
+	}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	if err := repo.DeleteTaskSession(ctx, "session-12"); err != nil {
+		t.Fatalf("DeleteTaskSession: %v", err)
+	}
+
+	rows, err := repo.ListSubagentContextsBySession(ctx, "session-12")
+	if err != nil {
+		t.Fatalf("list after cascade: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Fatalf("row count after session delete = %d, want 0 (FK cascade)", len(rows))
+	}
+}
+
+// TestListSubagentContextsOrderingUsesToolCallIDTiebreak covers AC-13: rows
+// sharing an observed_at order by tool_call_id, never by the generated id.
+func TestListSubagentContextsOrderingUsesToolCallIDTiebreak(t *testing.T) {
+	repo := newSubagentContextTestRepo(t, "task-13", "session-13", "turn-13")
+	ctx := context.Background()
+	sharedObservedAt := time.Date(2026, 8, 10, 9, 0, 0, 0, time.UTC)
+
+	// Insert in an order that would produce the wrong result if id (insertion
+	// order / generated UUID) were used as the tiebreak instead of tool_call_id.
+	for _, toolCallID := range []string{"tc-z", "tc-a", "tc-m"} {
+		if err := repo.UpsertSubagentContext(ctx, &models.SubagentContext{
+			TaskSessionID: "session-13", TaskID: "task-13", ToolCallID: toolCallID,
+			Source: "live", ObservedAt: sharedObservedAt, UpdatedAt: sharedObservedAt,
+		}); err != nil {
+			t.Fatalf("upsert %s: %v", toolCallID, err)
+		}
+	}
+
+	rows, err := repo.ListSubagentContextsBySession(ctx, "session-13")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(rows) != 3 {
+		t.Fatalf("row count = %d, want 3", len(rows))
+	}
+	got := []string{rows[0].ToolCallID, rows[1].ToolCallID, rows[2].ToolCallID}
+	want := []string{"tc-a", "tc-m", "tc-z"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("order = %v, want %v (tool_call_id tiebreak)", got, want)
+		}
+	}
+}
+
+// TestListSubagentContextsByTurn covers the turn-scoped read seam.
+func TestListSubagentContextsByTurn(t *testing.T) {
+	repo := newSubagentContextTestRepo(t, "task-14", "session-14", "turn-14a")
+	ctx := context.Background()
+	if err := seedTurn(t, repo, "turn-14b", "session-14", "task-14"); err != nil {
+		t.Fatalf("seed second turn: %v", err)
+	}
+	ts := time.Date(2026, 8, 10, 9, 0, 0, 0, time.UTC)
+
+	if err := repo.UpsertSubagentContext(ctx, &models.SubagentContext{
+		TaskSessionID: "session-14", TaskID: "task-14", TurnID: sp("turn-14a"),
+		ToolCallID: "tc-14a", Source: "live", ObservedAt: ts, UpdatedAt: ts,
+	}); err != nil {
+		t.Fatalf("upsert turn-14a: %v", err)
+	}
+	if err := repo.UpsertSubagentContext(ctx, &models.SubagentContext{
+		TaskSessionID: "session-14", TaskID: "task-14", TurnID: sp("turn-14b"),
+		ToolCallID: "tc-14b", Source: "live", ObservedAt: ts.Add(time.Second), UpdatedAt: ts.Add(time.Second),
+	}); err != nil {
+		t.Fatalf("upsert turn-14b: %v", err)
+	}
+
+	rows, err := repo.ListSubagentContextsByTurn(ctx, "turn-14a")
+	if err != nil {
+		t.Fatalf("ListSubagentContextsByTurn: %v", err)
+	}
+	if len(rows) != 1 || rows[0].ToolCallID != "tc-14a" {
+		t.Fatalf("turn-14a rows = %+v, want exactly tc-14a", rows)
+	}
+}
+
+// TestUpsertSubagentContextConcurrentSameKey covers AC-14: concurrent frames
+// for the same key produce exactly one row via the atomic upsert statement,
+// with no read-then-write race. Run with -race.
+func TestUpsertSubagentContextConcurrentSameKey(t *testing.T) {
+	repo := newSubagentContextTestRepo(t, "task-15", "session-15", "turn-15")
+	ctx := context.Background()
+	ts := time.Date(2026, 8, 10, 9, 0, 0, 0, time.UTC)
+
+	const concurrency = 8
+	var wg sync.WaitGroup
+	errs := make([]error, concurrency)
+	for i := 0; i < concurrency; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			errs[i] = repo.UpsertSubagentContext(ctx, &models.SubagentContext{
+				TaskSessionID: "session-15", TaskID: "task-15", ToolCallID: "tc-15",
+				Source: "live", ObservedAt: ts, UpdatedAt: ts.Add(time.Duration(i) * time.Millisecond),
+				TotalTokens: i64p(int64(i)),
+			})
+		}(i)
+	}
+	wg.Wait()
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent upsert %d: %v", i, err)
+		}
+	}
+
+	rows, err := repo.ListSubagentContextsBySession(ctx, "session-15")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("row count = %d, want exactly 1 for concurrent same-key upserts", len(rows))
+	}
+}
+
+// TestUpsertSubagentContextConcurrentDifferentKeys covers AC-15: concurrent
+// frames for different tool_call_ids in one turn (the observed 3-, 4-, 5-,
+// and 8-way fan-outs) all land, and neither blocks the other.
+func TestUpsertSubagentContextConcurrentDifferentKeys(t *testing.T) {
+	for _, fanOut := range []int{3, 4, 5, 8} {
+		t.Run(fmt.Sprintf("fanout-%d", fanOut), func(t *testing.T) {
+			repo := newSubagentContextTestRepo(t, "task-16", "session-16", "turn-16")
+			ctx := context.Background()
+			ts := time.Date(2026, 8, 10, 9, 0, 0, 0, time.UTC)
+
+			var wg sync.WaitGroup
+			errs := make([]error, fanOut)
+			for i := 0; i < fanOut; i++ {
+				wg.Add(1)
+				go func(i int) {
+					defer wg.Done()
+					errs[i] = repo.UpsertSubagentContext(ctx, &models.SubagentContext{
+						TaskSessionID: "session-16", TaskID: "task-16", TurnID: sp("turn-16"),
+						ToolCallID: sprintfToolCallID(i), Source: "live", ObservedAt: ts, UpdatedAt: ts,
+					})
+				}(i)
+			}
+			wg.Wait()
+			for i, err := range errs {
+				if err != nil {
+					t.Fatalf("concurrent upsert %d: %v", i, err)
+				}
+			}
+
+			rows, err := repo.ListSubagentContextsBySession(ctx, "session-16")
+			if err != nil {
+				t.Fatalf("list: %v", err)
+			}
+			if len(rows) != fanOut {
+				t.Fatalf("row count = %d, want %d for a %d-way fan-out", len(rows), fanOut, fanOut)
+			}
+		})
+	}
+}
+
+func sprintfToolCallID(i int) string {
+	return fmt.Sprintf("tc-fanout-%d", i)
+}
+
+// seedTurn inserts an additional turn row for a session already seeded by
+// seedForMsgTest (which creates exactly one turn).
+func seedTurn(t *testing.T, repo *Repository, turnID, sessionID, taskID string) error {
+	t.Helper()
+	now := time.Now().UTC()
+	_, err := repo.db.Exec(repo.db.Rebind(`
+		INSERT INTO task_session_turns (id, task_session_id, task_id, started_at, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?)
+	`), turnID, sessionID, taskID, now, now, now)
+	return err
+}

--- a/apps/backend/internal/task/repository/sqlite/workspace_test.go
+++ b/apps/backend/internal/task/repository/sqlite/workspace_test.go
@@ -291,6 +291,15 @@ func seedWorkspaceCascadeRows(t *testing.T, repo *Repository, workspaceID string
 	}); err != nil {
 		t.Fatalf("CreateMessage: %v", err)
 	}
+	turnDeleteID := "turn-delete"
+	if err := repo.UpsertSubagentContext(ctx, &models.SubagentContext{
+		TaskSessionID: "session-delete",
+		TaskID:        "task-delete",
+		TurnID:        &turnDeleteID,
+		ToolCallID:    "tc-delete",
+	}); err != nil {
+		t.Fatalf("UpsertSubagentContext: %v", err)
+	}
 	if err := repo.CreateTaskPlan(ctx, &models.TaskPlan{
 		ID:        "plan-delete",
 		TaskID:    "task-delete",
@@ -323,6 +332,7 @@ func assertNoWorkspaceCascadeDependents(t *testing.T, repo *Repository) {
 		"task_environment_repos",
 		"task_session_turns",
 		"task_session_messages",
+		"task_session_subagents",
 		"task_plans",
 		"task_plan_revisions",
 	} {

--- a/apps/backend/internal/task/service/service.go
+++ b/apps/backend/internal/task/service/service.go
@@ -260,6 +260,7 @@ type Repos struct {
 	Reviews           repository.ReviewRepository
 	ResourceCleanups  repository.TaskResourceCleanupRepository
 	StatusSummaries   repository.TaskStatusSummaryRepository
+	SubagentContexts  repository.SubagentContextRepository
 }
 
 // Service provides task business logic
@@ -282,6 +283,7 @@ type Service struct {
 	reviews                     repository.ReviewRepository
 	resourceCleanups            repository.TaskResourceCleanupRepository
 	statusSummaries             repository.TaskStatusSummaryRepository
+	subagentContexts            repository.SubagentContextRepository
 	attachmentSvc               *AttachmentService
 	statusSummaryPRs            TaskStatusSummaryPRReader
 	queuedPromptCounter         QueuedPromptCounter
@@ -407,6 +409,7 @@ func NewService(repos Repos, eventBus bus.EventBus, log *logger.Logger, discover
 		reviews:               repos.Reviews,
 		resourceCleanups:      repos.ResourceCleanups,
 		statusSummaries:       repos.StatusSummaries,
+		subagentContexts:      repos.SubagentContexts,
 		eventBus:              eventBus,
 		logger:                log,
 		discoveryConfig:       discoveryConfig,

--- a/apps/backend/internal/task/service/subagent_context.go
+++ b/apps/backend/internal/task/service/subagent_context.go
@@ -32,9 +32,12 @@ type RecordSubagentContextRequest struct {
 }
 
 // subagentTerminalToolStatuses mirrors internal/orchestrator's unexported
-// isTerminalToolStatus (event_handlers_streaming.go:762). The two lists are
-// pinned together by TestSubagentContextTerminalStatusesMatchOrchestrator so
-// a future edit to one fails the other.
+// isTerminalToolStatus (event_handlers_streaming.go, function
+// isTerminalToolStatus — deliberately not pinned to a line number here,
+// since TestSubagentContextTerminalStatusesMatchOrchestrator re-parses the
+// function by name and a hardcoded line drifts on every unrelated edit to
+// that file). The two lists are pinned together by that test so a future
+// edit to one fails the other.
 var subagentTerminalToolStatuses = map[string]bool{
 	"complete": true, "completed": true, "success": true,
 	"error": true, "failed": true, "cancelled": true,

--- a/apps/backend/internal/task/service/subagent_context.go
+++ b/apps/backend/internal/task/service/subagent_context.go
@@ -1,0 +1,154 @@
+package service
+
+import (
+	"context"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/kandev/kandev/internal/agentctl/types/streams"
+	"github.com/kandev/kandev/internal/task/models"
+)
+
+// RecordSubagentContextRequest carries the orchestrator's already-resolved
+// identity and the parsed subagent_task payload for one frame. The
+// orchestrator owns turn-id resolution and the ToolStatus/normalized-kind
+// guard; this request is the seam between that decision and persistence.
+type RecordSubagentContextRequest struct {
+	TaskSessionID    string
+	TaskID           string
+	TurnID           string
+	ToolCallID       string
+	ParentToolCallID string
+	// ToolStatus is the ACP tool-call status of the launching Task call.
+	// Terminality (AC-11) keys off this field only; Payload.Status
+	// ("agent_status" — the child's own report) is stored verbatim and never
+	// consulted for terminality.
+	ToolStatus string
+	Payload    *streams.SubagentTaskPayload
+	// ObservedAt is Kandev's observation time for this frame (AC-1a) — not a
+	// subagent start time.
+	ObservedAt time.Time
+}
+
+// subagentTerminalToolStatuses mirrors internal/orchestrator's unexported
+// isTerminalToolStatus (event_handlers_streaming.go:762). The two lists are
+// pinned together by TestSubagentContextTerminalStatusesMatchOrchestrator so
+// a future edit to one fails the other.
+var subagentTerminalToolStatuses = map[string]bool{
+	"complete": true, "completed": true, "success": true,
+	"error": true, "failed": true, "cancelled": true,
+}
+
+func isTerminalToolStatus(status string) bool {
+	return subagentTerminalToolStatuses[status]
+}
+
+// subagentContextSourceLive is the models.SubagentContext.Source value for
+// a row observed on the live orchestrator frame path, as opposed to
+// "backfill" (written only by the one-time migration).
+const subagentContextSourceLive = "live"
+
+// RecordSubagentContext persists one observation of a subagent (Task tool)
+// invocation. It returns nothing: that is the mechanism by which AC-27
+// holds — a writer with no error return cannot fail the enclosing message
+// write, turn, or agent stream, and no future caller can accidentally
+// propagate one. See docs/specs/subagent-context-persistence/spec.md.
+func (s *Service) RecordSubagentContext(ctx context.Context, req RecordSubagentContextRequest) {
+	if s.subagentContexts == nil {
+		return
+	}
+	if req.TaskSessionID == "" || req.TaskID == "" || req.ToolCallID == "" {
+		subagentContextTotal.Add("skipped_no_identity", 1)
+		return
+	}
+	if req.Payload == nil {
+		return
+	}
+	subagentContextTotal.Add("attempted", 1)
+
+	totalTokens, totalTokensAnomalous := normalizeOmitEmptyMetric(req.Payload.TotalTokens)
+	durationMs, durationAnomalous := normalizeOmitEmptyMetric(req.Payload.DurationMs)
+	toolUseCount, toolUseCountAnomalous := normalizeToolUseCount(req.Payload.ToolUseCount)
+	for _, anomalous := range []bool{totalTokensAnomalous, durationAnomalous, toolUseCountAnomalous} {
+		if anomalous {
+			subagentContextTotal.Add("anomalous_value", 1)
+		}
+	}
+
+	sc := &models.SubagentContext{
+		TaskSessionID:    req.TaskSessionID,
+		TaskID:           req.TaskID,
+		ToolCallID:       req.ToolCallID,
+		TurnID:           nilIfEmpty(req.TurnID),
+		ParentToolCallID: nilIfEmpty(req.ParentToolCallID),
+		SubagentType:     nilIfEmpty(req.Payload.SubagentType),
+		Description:      nilIfEmpty(req.Payload.Description),
+		AgentID:          nilIfEmpty(req.Payload.AgentID),
+		ChildSessionID:   nilIfEmpty(req.Payload.ChildSessionID),
+		Model:            nilIfEmpty(req.Payload.Model),
+		AgentStatus:      nilIfEmpty(req.Payload.Status),
+		ToolStatus:       nilIfEmpty(req.ToolStatus),
+		IsAsync:          req.Payload.IsAsync,
+		TotalTokens:      totalTokens,
+		ToolUseCount:     toolUseCount,
+		DurationMs:       durationMs,
+		Source:           subagentContextSourceLive,
+		ObservedAt:       req.ObservedAt,
+		UpdatedAt:        req.ObservedAt,
+	}
+	if isTerminalToolStatus(req.ToolStatus) {
+		settledAt := req.ObservedAt
+		sc.SettledAt = &settledAt
+	}
+
+	if err := s.subagentContexts.UpsertSubagentContext(ctx, sc); err != nil {
+		if s.logger != nil {
+			s.logger.Warn("failed to record subagent context",
+				zap.String("session_id", req.TaskSessionID),
+				zap.String("tool_call_id", req.ToolCallID),
+				zap.Error(err))
+		}
+		subagentContextTotal.Add("failed", 1)
+		return
+	}
+	subagentContextTotal.Add("persisted", 1)
+}
+
+// nilIfEmpty turns the payload's "" (absent) into NULL, so COUNT(model)
+// counts models rather than blanks.
+func nilIfEmpty(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}
+
+// normalizeOmitEmptyMetric handles TotalTokens/DurationMs, which are plain
+// int64 with `omitempty` on the wire payload: a genuine 0 and "not reported"
+// are indistinguishable at this layer, so both normalize to NULL, matching
+// AC-7. A negative value normalizes to NULL and reports anomalous (AC-9).
+func normalizeOmitEmptyMetric(value int64) (*int64, bool) {
+	if value == 0 {
+		return nil, false
+	}
+	if value < 0 {
+		return nil, true
+	}
+	v := value
+	return &v, false
+}
+
+// normalizeToolUseCount handles ToolUseCount, which is a *int specifically so
+// a reported 0 survives (AC-8) while "not reported" stays nil (AC-7). A
+// negative reported value normalizes to NULL and reports anomalous (AC-9).
+func normalizeToolUseCount(reported *int) (*int64, bool) {
+	if reported == nil {
+		return nil, false
+	}
+	v := int64(*reported)
+	if v < 0 {
+		return nil, true
+	}
+	return &v, false
+}

--- a/apps/backend/internal/task/service/subagent_context_metrics.go
+++ b/apps/backend/internal/task/service/subagent_context_metrics.go
@@ -1,0 +1,11 @@
+package service
+
+import "expvar"
+
+// subagentContextTotal exposes writer-health counters for
+// RecordSubagentContext, under the existing expvar convention used by
+// routing_* (internal/office/scheduler) and subproc_*. Counters only — see
+// AC-26 in docs/specs/subagent-context-persistence/spec.md.
+//
+// Keys: attempted, persisted, skipped_no_identity, anomalous_value, failed.
+var subagentContextTotal = expvar.NewMap("subagent_context_total")

--- a/apps/backend/internal/task/service/subagent_context_test.go
+++ b/apps/backend/internal/task/service/subagent_context_test.go
@@ -405,6 +405,11 @@ func TestSubagentContextTerminalStatusesMatchOrchestrator(t *testing.T) {
 		t.Fatalf("read orchestrator event_handlers_streaming.go: %v", err)
 	}
 
+	// Captures only the first "case ...:" clause, i.e. isTerminalToolStatus's
+	// switch must stay a single comma-separated case (not one "case" per
+	// line) for this regex to see every status. A refactor that splits it
+	// shrinks orchestratorSet below the size check at line ~435 and fails
+	// loudly — if you land here from that failure, this is why.
 	caseRe := regexp.MustCompile(`(?s)func isTerminalToolStatus\(status string\) bool \{.*?case (.*?):`)
 	match := caseRe.FindSubmatch(switchSrc)
 	if match == nil {

--- a/apps/backend/internal/task/service/subagent_context_test.go
+++ b/apps/backend/internal/task/service/subagent_context_test.go
@@ -1,0 +1,444 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"expvar"
+	"os"
+	"regexp"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/kandev/kandev/internal/agentctl/types/streams"
+	commonlogger "github.com/kandev/kandev/internal/common/logger"
+	"github.com/kandev/kandev/internal/task/models"
+)
+
+// stubSubagentContextRepo is a minimal repository.SubagentContextRepository
+// double: it records every upsert it receives (or returns a fixed error),
+// with no other behavior.
+type stubSubagentContextRepo struct {
+	mu      sync.Mutex
+	upserts []*models.SubagentContext
+	err     error
+}
+
+func (s *stubSubagentContextRepo) UpsertSubagentContext(_ context.Context, sc *models.SubagentContext) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.err != nil {
+		return s.err
+	}
+	s.upserts = append(s.upserts, sc)
+	return nil
+}
+
+func (s *stubSubagentContextRepo) ListSubagentContextsBySession(context.Context, string) ([]*models.SubagentContext, error) {
+	return nil, nil
+}
+
+func (s *stubSubagentContextRepo) ListSubagentContextsByTurn(context.Context, string) ([]*models.SubagentContext, error) {
+	return nil, nil
+}
+
+func (s *stubSubagentContextRepo) last(t *testing.T) *models.SubagentContext {
+	t.Helper()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.upserts) == 0 {
+		t.Fatal("no subagent context was upserted")
+	}
+	return s.upserts[len(s.upserts)-1]
+}
+
+func (s *stubSubagentContextRepo) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.upserts)
+}
+
+func newSubagentContextTestService(t *testing.T, repo *stubSubagentContextRepo) *Service {
+	t.Helper()
+	log, err := commonlogger.NewFromZap(zap.NewNop())
+	if err != nil {
+		t.Fatalf("create logger: %v", err)
+	}
+	return &Service{subagentContexts: repo, logger: log}
+}
+
+func readSubagentCounter(t *testing.T, key string) int64 {
+	t.Helper()
+	v := subagentContextTotal.Get(key)
+	if v == nil {
+		return 0
+	}
+	iv, ok := v.(*expvar.Int)
+	if !ok {
+		t.Fatalf("counter %q is %T, want *expvar.Int", key, v)
+	}
+	return iv.Value()
+}
+
+// counterDelta runs fn and returns how much the named subagentContextTotal
+// counter moved. Safe against cross-test accumulation on the shared
+// package-level expvar.Map because it snapshots before and after.
+func counterDelta(t *testing.T, key string, fn func()) int64 {
+	t.Helper()
+	before := readSubagentCounter(t, key)
+	fn()
+	return readSubagentCounter(t, key) - before
+}
+
+func intptr(n int) *int { return &n }
+
+// TestRecordSubagentContextIdentityGate covers AC-2: each of an empty
+// session id, task id, or tool_call_id skips the write entirely and
+// increments skipped_no_identity by exactly one.
+func TestRecordSubagentContextIdentityGate(t *testing.T) {
+	cases := []struct {
+		name string
+		req  RecordSubagentContextRequest
+	}{
+		{"missing_session_id", RecordSubagentContextRequest{
+			TaskSessionID: "", TaskID: "task-1", ToolCallID: "tc-1",
+			Payload: &streams.SubagentTaskPayload{},
+		}},
+		{"missing_task_id", RecordSubagentContextRequest{
+			TaskSessionID: "session-1", TaskID: "", ToolCallID: "tc-1",
+			Payload: &streams.SubagentTaskPayload{},
+		}},
+		{"missing_tool_call_id", RecordSubagentContextRequest{
+			TaskSessionID: "session-1", TaskID: "task-1", ToolCallID: "",
+			Payload: &streams.SubagentTaskPayload{},
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := &stubSubagentContextRepo{}
+			svc := newSubagentContextTestService(t, repo)
+
+			delta := counterDelta(t, "skipped_no_identity", func() {
+				svc.RecordSubagentContext(context.Background(), tc.req)
+			})
+			if delta != 1 {
+				t.Errorf("skipped_no_identity delta = %d, want 1", delta)
+			}
+			if repo.count() != 0 {
+				t.Errorf("repository call count = %d, want 0 (no write)", repo.count())
+			}
+		})
+	}
+}
+
+// TestRecordSubagentContextNilPayloadIsNoop is a defensive guard: the
+// orchestrator only calls this after confirming Normalized.SubagentTask() is
+// non-nil, but a nil payload must still be handled without a panic or a
+// write.
+func TestRecordSubagentContextNilPayloadIsNoop(t *testing.T) {
+	repo := &stubSubagentContextRepo{}
+	svc := newSubagentContextTestService(t, repo)
+
+	svc.RecordSubagentContext(context.Background(), RecordSubagentContextRequest{
+		TaskSessionID: "session-1", TaskID: "task-1", ToolCallID: "tc-1", Payload: nil,
+	})
+	if repo.count() != 0 {
+		t.Errorf("repository call count = %d, want 0", repo.count())
+	}
+}
+
+// TestRecordSubagentContextEmptyStringsNormalizeToNil covers the
+// empty-string-to-NULL normalization rule for every nullable TEXT field.
+func TestRecordSubagentContextEmptyStringsNormalizeToNil(t *testing.T) {
+	repo := &stubSubagentContextRepo{}
+	svc := newSubagentContextTestService(t, repo)
+
+	svc.RecordSubagentContext(context.Background(), RecordSubagentContextRequest{
+		TaskSessionID: "session-1", TaskID: "task-1", ToolCallID: "tc-1",
+		TurnID: "", ParentToolCallID: "", ToolStatus: "",
+		Payload: &streams.SubagentTaskPayload{
+			SubagentType: "", Description: "", AgentID: "", ChildSessionID: "", Model: "", Status: "",
+		},
+		ObservedAt: time.Now().UTC(),
+	})
+
+	sc := repo.last(t)
+	for name, field := range map[string]*string{
+		"turn_id": sc.TurnID, "parent_tool_call_id": sc.ParentToolCallID,
+		"subagent_type": sc.SubagentType, "description": sc.Description,
+		"agent_id": sc.AgentID, "child_session_id": sc.ChildSessionID,
+		"model": sc.Model, "agent_status": sc.AgentStatus, "tool_status": sc.ToolStatus,
+	} {
+		if field != nil {
+			t.Errorf("%s = %q, want NULL for an empty string", name, *field)
+		}
+	}
+}
+
+// TestRecordSubagentContextMetricNormalization covers AC-7, AC-8, AC-9: an
+// absent metric is nil, a reported zero ToolUseCount survives as 0, and a
+// negative value becomes nil while incrementing anomalous_value and leaving
+// the rest of the frame intact.
+func TestRecordSubagentContextMetricNormalization(t *testing.T) {
+	t.Run("absent_metrics_are_nil", func(t *testing.T) {
+		repo := &stubSubagentContextRepo{}
+		svc := newSubagentContextTestService(t, repo)
+		svc.RecordSubagentContext(context.Background(), RecordSubagentContextRequest{
+			TaskSessionID: "session-1", TaskID: "task-1", ToolCallID: "tc-1",
+			Payload:    &streams.SubagentTaskPayload{TotalTokens: 0, DurationMs: 0, ToolUseCount: nil},
+			ObservedAt: time.Now().UTC(),
+		})
+		sc := repo.last(t)
+		if sc.TotalTokens != nil || sc.DurationMs != nil || sc.ToolUseCount != nil {
+			t.Errorf("metrics = tokens=%v duration=%v count=%v, want all nil", sc.TotalTokens, sc.DurationMs, sc.ToolUseCount)
+		}
+	})
+
+	t.Run("reported_zero_tool_use_count_survives", func(t *testing.T) {
+		repo := &stubSubagentContextRepo{}
+		svc := newSubagentContextTestService(t, repo)
+		svc.RecordSubagentContext(context.Background(), RecordSubagentContextRequest{
+			TaskSessionID: "session-1", TaskID: "task-1", ToolCallID: "tc-1",
+			Payload:    &streams.SubagentTaskPayload{ToolUseCount: intptr(0)},
+			ObservedAt: time.Now().UTC(),
+		})
+		sc := repo.last(t)
+		if sc.ToolUseCount == nil || *sc.ToolUseCount != 0 {
+			t.Errorf("tool_use_count = %v, want *0", sc.ToolUseCount)
+		}
+	})
+
+	t.Run("negative_total_tokens_becomes_nil_others_intact", func(t *testing.T) {
+		repo := &stubSubagentContextRepo{}
+		svc := newSubagentContextTestService(t, repo)
+		delta := counterDelta(t, "anomalous_value", func() {
+			svc.RecordSubagentContext(context.Background(), RecordSubagentContextRequest{
+				TaskSessionID: "session-1", TaskID: "task-1", ToolCallID: "tc-1",
+				Payload: &streams.SubagentTaskPayload{
+					TotalTokens: -5, DurationMs: 1200, Description: "kept",
+				},
+				ObservedAt: time.Now().UTC(),
+			})
+		})
+		if delta != 1 {
+			t.Errorf("anomalous_value delta = %d, want 1", delta)
+		}
+		sc := repo.last(t)
+		if sc.TotalTokens != nil {
+			t.Errorf("total_tokens = %v, want nil", sc.TotalTokens)
+		}
+		if sc.DurationMs == nil || *sc.DurationMs != 1200 {
+			t.Errorf("duration_ms = %v, want 1200 (unaffected)", sc.DurationMs)
+		}
+		if sc.Description == nil || *sc.Description != "kept" {
+			t.Errorf("description = %v, want kept (unaffected)", sc.Description)
+		}
+	})
+
+	t.Run("negative_duration_ms_becomes_nil", func(t *testing.T) {
+		repo := &stubSubagentContextRepo{}
+		svc := newSubagentContextTestService(t, repo)
+		delta := counterDelta(t, "anomalous_value", func() {
+			svc.RecordSubagentContext(context.Background(), RecordSubagentContextRequest{
+				TaskSessionID: "session-1", TaskID: "task-1", ToolCallID: "tc-1",
+				Payload:    &streams.SubagentTaskPayload{DurationMs: -1},
+				ObservedAt: time.Now().UTC(),
+			})
+		})
+		if delta != 1 {
+			t.Errorf("anomalous_value delta = %d, want 1", delta)
+		}
+		if repo.last(t).DurationMs != nil {
+			t.Errorf("duration_ms = %v, want nil", repo.last(t).DurationMs)
+		}
+	})
+
+	t.Run("negative_tool_use_count_becomes_nil", func(t *testing.T) {
+		repo := &stubSubagentContextRepo{}
+		svc := newSubagentContextTestService(t, repo)
+		delta := counterDelta(t, "anomalous_value", func() {
+			svc.RecordSubagentContext(context.Background(), RecordSubagentContextRequest{
+				TaskSessionID: "session-1", TaskID: "task-1", ToolCallID: "tc-1",
+				Payload:    &streams.SubagentTaskPayload{ToolUseCount: intptr(-3)},
+				ObservedAt: time.Now().UTC(),
+			})
+		})
+		if delta != 1 {
+			t.Errorf("anomalous_value delta = %d, want 1", delta)
+		}
+		if repo.last(t).ToolUseCount != nil {
+			t.Errorf("tool_use_count = %v, want nil", repo.last(t).ToolUseCount)
+		}
+	})
+}
+
+// TestRecordSubagentContextTerminality covers AC-10a/AC-11: settled_at is
+// set only from a terminal ACP tool_status, never from agent_status —
+// including the Claude-specific "async_launched" agent status, whose own
+// tool call is nonetheless terminal in the ACP sense.
+func TestRecordSubagentContextTerminality(t *testing.T) {
+	observedAt := time.Date(2026, 8, 11, 9, 0, 0, 0, time.UTC)
+
+	t.Run("terminal_tool_status_sets_settled_at", func(t *testing.T) {
+		repo := &stubSubagentContextRepo{}
+		svc := newSubagentContextTestService(t, repo)
+		svc.RecordSubagentContext(context.Background(), RecordSubagentContextRequest{
+			TaskSessionID: "session-1", TaskID: "task-1", ToolCallID: "tc-1",
+			ToolStatus: "completed", Payload: &streams.SubagentTaskPayload{Status: "async_launched"},
+			ObservedAt: observedAt,
+		})
+		sc := repo.last(t)
+		if sc.SettledAt == nil || !sc.SettledAt.Equal(observedAt) {
+			t.Errorf("settled_at = %v, want %v", sc.SettledAt, observedAt)
+		}
+		if sc.AgentStatus == nil || *sc.AgentStatus != "async_launched" {
+			t.Errorf("agent_status = %v, want async_launched stored verbatim", sc.AgentStatus)
+		}
+	})
+
+	t.Run("async_launched_agent_status_alone_does_not_settle", func(t *testing.T) {
+		repo := &stubSubagentContextRepo{}
+		svc := newSubagentContextTestService(t, repo)
+		svc.RecordSubagentContext(context.Background(), RecordSubagentContextRequest{
+			TaskSessionID: "session-1", TaskID: "task-1", ToolCallID: "tc-1",
+			ToolStatus: "in_progress", Payload: &streams.SubagentTaskPayload{Status: "async_launched"},
+			ObservedAt: observedAt,
+		})
+		if repo.last(t).SettledAt != nil {
+			t.Errorf("settled_at = %v, want nil (tool_status is non-terminal)", repo.last(t).SettledAt)
+		}
+	})
+
+	t.Run("unrecognised_agent_status_stored_verbatim_and_does_not_settle", func(t *testing.T) {
+		repo := &stubSubagentContextRepo{}
+		svc := newSubagentContextTestService(t, repo)
+		svc.RecordSubagentContext(context.Background(), RecordSubagentContextRequest{
+			TaskSessionID: "session-1", TaskID: "task-1", ToolCallID: "tc-1",
+			ToolStatus: "pending", Payload: &streams.SubagentTaskPayload{Status: "a-status-kandev-has-never-seen"},
+			ObservedAt: observedAt,
+		})
+		sc := repo.last(t)
+		if sc.AgentStatus == nil || *sc.AgentStatus != "a-status-kandev-has-never-seen" {
+			t.Errorf("agent_status = %v, want stored verbatim", sc.AgentStatus)
+		}
+		if sc.SettledAt != nil {
+			t.Errorf("settled_at = %v, want nil", sc.SettledAt)
+		}
+	})
+}
+
+// TestRecordSubagentContextRepositoryFailure covers AC-27: a repository
+// error logs WARN with the session and tool-call id, increments failed, and
+// the call still returns normally (no panic, no error surfaced to caller).
+func TestRecordSubagentContextRepositoryFailure(t *testing.T) {
+	repo := &stubSubagentContextRepo{err: errors.New("disk full")}
+	core, logs := observer.New(zapcore.WarnLevel)
+	log, err := commonlogger.NewFromZap(zap.New(core))
+	if err != nil {
+		t.Fatalf("create logger: %v", err)
+	}
+	svc := &Service{subagentContexts: repo, logger: log}
+
+	delta := counterDelta(t, "failed", func() {
+		svc.RecordSubagentContext(context.Background(), RecordSubagentContextRequest{
+			TaskSessionID: "session-fail", TaskID: "task-1", ToolCallID: "tc-fail",
+			Payload: &streams.SubagentTaskPayload{}, ObservedAt: time.Now().UTC(),
+		})
+	})
+	if delta != 1 {
+		t.Errorf("failed delta = %d, want 1", delta)
+	}
+	entries := logs.FilterMessage("failed to record subagent context").All()
+	if len(entries) != 1 {
+		t.Fatalf("WARN log count = %d, want 1", len(entries))
+	}
+	fields := entries[0].ContextMap()
+	if fields["session_id"] != "session-fail" || fields["tool_call_id"] != "tc-fail" {
+		t.Errorf("log fields = %#v, want session_id=session-fail tool_call_id=tc-fail", fields)
+	}
+}
+
+// TestRecordSubagentContextHappyPathCounters covers AC-26: attempted and
+// persisted both move by one on a successful write.
+func TestRecordSubagentContextHappyPathCounters(t *testing.T) {
+	repo := &stubSubagentContextRepo{}
+	svc := newSubagentContextTestService(t, repo)
+
+	var attemptedDelta, persistedDelta int64
+	attemptedDelta = counterDelta(t, "attempted", func() {
+		persistedDelta = counterDelta(t, "persisted", func() {
+			svc.RecordSubagentContext(context.Background(), RecordSubagentContextRequest{
+				TaskSessionID: "session-1", TaskID: "task-1", ToolCallID: "tc-1",
+				Payload: &streams.SubagentTaskPayload{}, ObservedAt: time.Now().UTC(),
+			})
+		})
+	})
+	if attemptedDelta != 1 {
+		t.Errorf("attempted delta = %d, want 1", attemptedDelta)
+	}
+	if persistedDelta != 1 {
+		t.Errorf("persisted delta = %d, want 1", persistedDelta)
+	}
+	if repo.count() != 1 {
+		t.Errorf("repository upsert count = %d, want 1", repo.count())
+	}
+}
+
+// TestSubagentContextTerminalStatusesMatchOrchestrator pins
+// subagentTerminalToolStatuses against the orchestrator's unexported peer
+// isTerminalToolStatus (event_handlers_streaming.go:762). This package
+// cannot import internal/orchestrator directly — orchestrator already
+// imports internal/task/service for RecordSubagentContext, so that would be
+// a cycle — so the peer's source is read and parsed instead.
+func TestSubagentContextTerminalStatusesMatchOrchestrator(t *testing.T) {
+	constsSrc, err := os.ReadFile("../../orchestrator/event_handlers.go")
+	if err != nil {
+		t.Fatalf("read orchestrator event_handlers.go: %v", err)
+	}
+	switchSrc, err := os.ReadFile("../../orchestrator/event_handlers_streaming.go")
+	if err != nil {
+		t.Fatalf("read orchestrator event_handlers_streaming.go: %v", err)
+	}
+
+	caseRe := regexp.MustCompile(`(?s)func isTerminalToolStatus\(status string\) bool \{.*?case (.*?):`)
+	match := caseRe.FindSubmatch(switchSrc)
+	if match == nil {
+		t.Fatal("could not find isTerminalToolStatus's case clause in event_handlers_streaming.go")
+	}
+	tokens := strings.Split(string(match[1]), ",")
+
+	constRe := regexp.MustCompile(`(\w+)\s*=\s*"([^"]+)"`)
+	constValues := map[string]string{}
+	for _, m := range constRe.FindAllSubmatch(constsSrc, -1) {
+		constValues[string(m[1])] = string(m[2])
+	}
+
+	orchestratorSet := map[string]bool{}
+	for _, tok := range tokens {
+		tok = strings.TrimSpace(tok)
+		if strings.HasPrefix(tok, `"`) {
+			orchestratorSet[strings.Trim(tok, `"`)] = true
+			continue
+		}
+		value, ok := constValues[tok]
+		if !ok {
+			t.Fatalf("orchestrator case token %q resolves to no known string constant", tok)
+		}
+		orchestratorSet[value] = true
+	}
+
+	if len(orchestratorSet) != len(subagentTerminalToolStatuses) {
+		t.Fatalf("orchestrator terminal set = %v (%d), service set = %v (%d)",
+			orchestratorSet, len(orchestratorSet), subagentTerminalToolStatuses, len(subagentTerminalToolStatuses))
+	}
+	for status := range subagentTerminalToolStatuses {
+		if !orchestratorSet[status] {
+			t.Errorf("service terminal set has %q, orchestrator's does not: %v", status, orchestratorSet)
+		}
+	}
+}

--- a/docs/plans/subagent-context-persistence/plan.md
+++ b/docs/plans/subagent-context-persistence/plan.md
@@ -1,0 +1,475 @@
+---
+spec: docs/specs/subagent-context-persistence/spec.md
+created: 2026-08-13
+status: draft
+---
+
+# Implementation Plan: Subagent context persistence
+
+## Overview
+
+Add one new table, `task_session_subagents`, and a write path that fills it from
+the two orchestrator frame handlers that already parse the subagent payload. The
+order is forced by dependency: table DDL and the one-time backfill first, then
+the repository upsert that encodes every merge rule, then the service-level
+writer that owns normalization and the `expvar` counters, then the orchestrator
+call sites, and finally the Postgres parity and health-query coverage. Nothing
+user-facing changes, so there is no frontend and no E2E work.
+
+The whole feature is additive telemetry. The governing constraint from the spec
+is that it must be structurally impossible for this writer to break the product
+path (AC-27), and that an unreported measurement must never be stored as `0`
+(AC-7, and the regression named in the spec's *The one shape a builder must not
+get wrong*).
+
+---
+
+## Backend
+
+### Schema (task 01)
+
+New table created in the schema-init DDL, in
+`apps/backend/internal/task/repository/sqlite/base_schema.go`, as a new
+`initSubagentContextSchema()` called from `initSessionSchema()` immediately after
+`initMessageTurnSchema()`.
+
+**On the spec's "DDL *and* migration" wording.** `apps/backend/AGENTS.md`
+§ *Schema & migrations* is explicit that `initSchema()` runs every
+`CREATE TABLE IF NOT EXISTS` step **before** `runMigrations()`, on every boot.
+A *new table* is therefore fully created on existing databases by the schema-init
+DDL alone, which satisfies AC-17. The "add it only via a migration" rule in that
+document governs **new columns on existing tables**, which this feature has none
+of. Do **not** duplicate the `CREATE TABLE` into `base_migrations.go` — the
+migration entry for this feature is the backfill and the activation keys, and
+nothing else.
+
+Columns exactly as the spec's *Data model* table. The three measurement columns
+carry **no `DEFAULT`**:
+
+```sql
+CREATE TABLE IF NOT EXISTS task_session_subagents (
+    id                  TEXT PRIMARY KEY,
+    task_session_id     TEXT NOT NULL,
+    task_id             TEXT NOT NULL,
+    turn_id             TEXT,
+    tool_call_id        TEXT NOT NULL,
+    parent_tool_call_id TEXT,
+    subagent_type       TEXT,
+    description         TEXT,
+    agent_id            TEXT,
+    child_session_id    TEXT,
+    model               TEXT,
+    agent_status        TEXT,
+    tool_status         TEXT,
+    is_async            INTEGER NOT NULL DEFAULT 0,
+    total_tokens        INTEGER,
+    tool_use_count      INTEGER,
+    duration_ms         INTEGER,
+    source              TEXT NOT NULL DEFAULT 'live',
+    observed_at         TIMESTAMP NOT NULL,
+    settled_at          TIMESTAMP,
+    updated_at          TIMESTAMP NOT NULL,
+    UNIQUE (task_session_id, tool_call_id),
+    FOREIGN KEY (task_session_id) REFERENCES task_sessions(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_subagents_session_id ON task_session_subagents(task_session_id);
+CREATE INDEX IF NOT EXISTS idx_subagents_task_id    ON task_session_subagents(task_id);
+CREATE INDEX IF NOT EXISTS idx_subagents_turn_id    ON task_session_subagents(turn_id);
+```
+
+No `FOREIGN KEY` on `turn_id` — deliberate, per the spec: a turn deletion must
+not delete the fan-out record.
+
+### Migration: backfill and activation keys (task 01)
+
+`apps/backend/internal/task/repository/sqlite/base_migrations.go`, a new
+`migrateSubagentContextBackfill()` called from `runMigrations()` **after** the
+existing statements. Three `r.migrate.Apply(...)` calls, all argument-free SQL
+(`MigrateLogger.Apply` takes no bind args, and its swallow-plus-`WARN`
+contract at `internal/db/migratelog.go:33` is what AC-20 is written against):
+
+1. `task_session_subagents.backfill` — one unbounded
+   `INSERT INTO task_session_subagents (...) SELECT ... FROM task_session_messages m
+   WHERE <kind> = 'subagent_task' AND ... ON CONFLICT (task_session_id, tool_call_id) DO NOTHING`.
+   No `LIMIT`, no batching (AC-23a).
+2. `kandev_meta.subagent_context_capture_since` — write-once
+   `INSERT ... ON CONFLICT(key) DO NOTHING` with an `fmt.Sprintf`-inlined
+   `time.Now().UTC().Format(time.RFC3339)` literal.
+3. `kandev_meta.subagent_context_backfill_through` — write-once, value from a
+   subselect `COALESCE(MAX(m.created_at), '')` over the same predicate as (1).
+
+`kandev_meta` is guaranteed to exist: `persistence.Provide` calls
+`ensureMetaTable` (`internal/persistence/provider.go:72`) before
+`repository.Provide` builds the task repo (`internal/backendapp/storage.go:41`).
+
+Backfill derivations, all via dialect-aware helpers in the same file:
+
+| Target | Source | Notes |
+|---|---|---|
+| `id` | `m.id` | The message's own UUID. Deterministic, so a replay maps to the same row and `DO NOTHING` is a true no-op. |
+| `task_session_id`, `task_id` | `m.task_session_id`, `m.task_id` | Rows with `task_id = ''` are excluded by the `WHERE` (AC-2). |
+| `turn_id` | `NULLIF(m.turn_id, '')` | |
+| `tool_call_id` | `metadata.tool_call_id` | Excluded by `WHERE` when empty (AC-2). |
+| `parent_tool_call_id` | `metadata.parent_tool_call_id` | Top-level metadata key, not inside `normalized`. |
+| `agent_status` | `metadata.normalized.subagent_task.status` | |
+| `tool_status` | `metadata.status` | The ACP status the message row already stores. |
+| `observed_at` | `m.created_at` | |
+| `settled_at` | `m.updated_at` when the derived `tool_status` is terminal, else NULL | Terminal set mirrors `isTerminalToolStatus`. |
+| `source` | literal `'backfill'` | |
+
+Three new helpers beside `jsonColumn` / `jsonText`
+(`base_migrations.go:319-335`), each reusing `jsonColumn`'s empty/`'null'`
+normalization so one malformed metadata document cannot abort the statement
+(AC-23b):
+
+- `jsonKey(postgres, column, key string) string` — a **top-level** text extract
+  (`#>> '{key}'` / `json_extract(..., '$.key')`), needed for `tool_call_id`,
+  `parent_tool_call_id`, `status`, and `normalized.kind`.
+- `jsonInt(postgres, column, parent, key string) string` — `CAST` of the text
+  extract to `BIGINT` (Postgres) / `INTEGER` (SQLite), wrapped so an empty
+  extract and a **negative** value both yield NULL (AC-9, AC-23).
+- `jsonBoolToInt(postgres, column, parent, key string) string` — `1` / `0`.
+  Postgres `#>>` yields `'true'`; SQLite `json_extract` yields `1`. The helper
+  must accept both spellings, which is the whole reason it exists.
+
+`total_tokens` and `duration_ms` are `omitempty int64` on the payload, so a
+reported `0` never reaches the JSON and absent-means-NULL falls out for free.
+`tool_use_count` is `*int` with `omitempty`, so it is present in the JSON exactly
+when the agent reported it — including a genuine `0` (AC-8).
+
+### Model and repository upsert (task 02)
+
+`apps/backend/internal/task/models/subagent_context.go`:
+
+```go
+type SubagentContext struct {
+    ID, TaskSessionID, TaskID, ToolCallID string
+    TurnID, ParentToolCallID, SubagentType, Description *string
+    AgentID, ChildSessionID, Model, AgentStatus, ToolStatus *string
+    IsAsync       bool
+    TotalTokens   *int64
+    ToolUseCount  *int64
+    DurationMs    *int64
+    Source        string
+    ObservedAt    time.Time
+    SettledAt     *time.Time
+    UpdatedAt     time.Time
+}
+```
+
+Every nullable column is a pointer. This is not style: `ToolUseCount` must
+distinguish a reported `0` from "not reported", and a non-pointer `int64` cannot.
+
+`apps/backend/internal/task/repository/sqlite/subagent_context.go`:
+
+- `UpsertSubagentContext(ctx context.Context, sc *models.SubagentContext) error`
+  — a **single** `INSERT ... ON CONFLICT (task_session_id, tool_call_id) DO UPDATE SET ...`.
+  No read-then-write anywhere (AC-14). Every merge rule lives in the conflict
+  clause:
+
+  | Column | Conflict expression | AC |
+  |---|---|---|
+  | `turn_id` | `COALESCE(task_session_subagents.turn_id, excluded.turn_id)` | AC-2a — the *original* turn wins; a later turn never re-attributes |
+  | text fields | `COALESCE(excluded.<c>, task_session_subagents.<c>)` | AC-4, AC-5 — fill-forward, never blank |
+  | `tool_status` | `CASE WHEN task_session_subagents.settled_at IS NOT NULL THEN task_session_subagents.tool_status ELSE COALESCE(excluded.tool_status, ...) END` | AC-12 — frozen at the terminal value |
+  | `is_async` | `CASE WHEN excluded.is_async = 1 THEN 1 ELSE task_session_subagents.is_async END` | sticky, never reset to 0 |
+  | metrics | `COALESCE(excluded.<c>, task_session_subagents.<c>)` | AC-4, AC-7 |
+  | `settled_at` | `COALESCE(task_session_subagents.settled_at, excluded.settled_at)` | AC-11 — write-once |
+  | `updated_at` | `excluded.updated_at` | |
+  | `source`, `observed_at`, `id` | **absent from the SET list** | write-once: a backfilled row is never relabelled `live` (AC-22), and first observation wins (AC-1a) |
+
+  Both dialects accept `excluded.` on the right and unqualified names on the
+  left; the self-qualified `task_session_subagents.<c>` reads are valid on both.
+  Statement built once as a package-level `const` and passed through
+  `r.db.Rebind`, matching `review.go:27` and `document.go:291`.
+
+- `ListSubagentContextsBySession(ctx, sessionID string) ([]*models.SubagentContext, error)`
+  and `ListSubagentContextsByTurn(ctx, turnID string)` — both
+  `ORDER BY observed_at ASC, tool_call_id ASC` (AC-13). These are the read seam
+  AC-13 is written against and the seam the tests assert ordering through. They
+  are repository-level only: no service method, no DTO, no route. The spec's
+  *Out of scope* forbids a read API, not a repository accessor.
+
+### Service writer and counters (task 03)
+
+`apps/backend/internal/task/service/subagent_context.go`, one entry point:
+
+```go
+type RecordSubagentContextRequest struct {
+    TaskSessionID, TaskID, TurnID string
+    ToolCallID, ParentToolCallID  string
+    ToolStatus                    string
+    Payload                       *streams.SubagentTaskPayload
+    ObservedAt                    time.Time
+}
+
+func (s *Service) RecordSubagentContext(ctx context.Context, req RecordSubagentContextRequest)
+```
+
+**It returns nothing.** That is the mechanism by which AC-27 holds: a writer
+with no error return cannot fail the enclosing message write, turn, or stream,
+and no future caller can accidentally propagate one. It owns:
+
+- Identity gate — empty `TaskSessionID`, `TaskID`, or `ToolCallID` ⇒ no write,
+  `skipped_no_identity`++, return (AC-2).
+- `nilIfEmpty(string) *string` applied to every nullable TEXT field, so `""`
+  becomes NULL and `COUNT(model)` counts models (spec § *Column-level
+  normalization rules*).
+- Metric normalization: `DurationMs`/`TotalTokens` map to `*int64` and are left
+  nil when zero-or-absent; `ToolUseCount` maps to `*int64` **only** when the
+  payload pointer is non-nil, preserving a reported `0` (AC-7, AC-8). Any
+  negative value ⇒ that field nil **and** `anomalous_value`++, other fields
+  unaffected (AC-9).
+- Terminality: `settled_at = &req.ObservedAt` only when
+  `orchestrator`-equivalent terminal classification of `req.ToolStatus` is true.
+  `agent_status` is stored verbatim and never consulted (AC-10a, AC-11). The
+  classifier is unexported in `internal/orchestrator`, so the service gets its
+  own `isTerminalToolStatus` over the identical set
+  (`complete`, `completed`, `success`, `error`, `failed`, `cancelled`) with a
+  comment naming `event_handlers_streaming.go:762` as the peer, plus a test that
+  pins the two lists together.
+- Failure handling: repository error ⇒ `WARN` with session id and tool call id,
+  `failed`++, return (AC-27).
+- `attempted`++ on entry past the nil-payload check; `persisted`++ on success.
+
+`apps/backend/internal/task/service/subagent_context_metrics.go` — one
+`expvar.NewMap("subagent_context_total")` with the five keys AC-26 names
+(`attempted`, `persisted`, `skipped_no_identity`, `anomalous_value`, `failed`),
+following `internal/office/scheduler/metrics_vars.go` (package-level `NewMap`,
+counters only, no gauges).
+
+### Orchestrator wiring (task 04)
+
+`apps/backend/internal/orchestrator/service.go` — a narrow interface beside
+`MessageCreator`:
+
+```go
+type SubagentContextRecorder interface {
+    RecordSubagentContext(ctx context.Context, req taskservice.RecordSubagentContextRequest)
+}
+```
+
+held as an optional `subagentContexts` field on `Service`, nil-checked at both
+call sites exactly as `messageCreator` is.
+
+Two call sites in `event_handlers_streaming.go`, each already holding every
+input:
+
+- `handleToolCallEvent` (~line 312) — after the `CreateToolCallMessage` block,
+  using `s.getActiveTurnID(payload.SessionID)`.
+- `persistToolUpdateMessage` (~line 565) — after `UpdateToolCallMessage`, using
+  the `turnID` that function already resolved (`peekActiveTurnID` for terminal
+  frames, `getActiveTurnID` otherwise).
+
+Both guarded by `payload.Data.Normalized.Kind() == streams.ToolKindSubagentTask`
+and a non-nil `Normalized.SubagentTask()`. A new
+`recordSubagentContextFromFrame(ctx, payload, turnID)` helper holds the guard and
+the request build so neither handler grows past the package's `funlen` limit of
+80 lines / 50 statements.
+
+`payload.SessionID` is the Kandev task session id: `messageCreatorAdapter`
+passes the same value straight into `CreateMessageRequest.TaskSessionID`
+(`internal/backendapp/adapters.go:879`), despite the `agentSessionID` parameter
+name.
+
+`apps/backend/internal/backendapp/adapters.go` — a `subagentContextAdapter` over
+`*taskservice.Service`, wired where `messageCreatorAdapter` is wired.
+
+---
+
+## Frontend
+
+None. The spec's *What this feature is, and is not* rules out any frontend
+surface: the subagent card keeps rendering from message metadata, unchanged. No
+DTO field, no WebSocket event, no store slice.
+
+---
+
+## Tests
+
+### Migration and backfill — `subagent_context_migration_test.go` (task 01)
+
+Patterned on `task_external_id_migration_test.go`.
+
+- **Fresh DB creates the table, indexes, and UNIQUE constraint.** File:
+  `apps/backend/internal/task/repository/sqlite/subagent_context_migration_test.go`.
+  How: `NewWithDB` over a temp SQLite file, then assert
+  `idx_subagents_session_id`, `idx_subagents_task_id`, `idx_subagents_turn_id`
+  exist in `sqlite_master` and that a duplicate
+  `(task_session_id, tool_call_id)` insert is rejected. (AC-17)
+- **Replay is a no-op.** How: `repo.runMigrations()` twice; assert no error and
+  an unchanged row count. (AC-18)
+- **Backfill inserts one row per subagent message.** How: seed a session, a
+  turn, and message rows whose `metadata.normalized.kind = 'subagent_task'`,
+  then `runMigrations()`; assert one row each with `source = 'backfill'` and
+  `observed_at = m.created_at`. (AC-21)
+- **`async_launched` shape stores NULL, not `0`** — the spec's named
+  must-not-get-wrong regression. How: seed a message whose
+  `subagent_task` object has `status: "async_launched"` and no
+  `total_tokens` / `tool_use_count` / `duration_ms`; assert all three columns
+  `IS NULL` and that none is `0`. (AC-7)
+- **A reported `tool_use_count` of `0` survives as `0`.** (AC-8)
+- **A negative reported metric backfills as NULL.** (AC-9, AC-23)
+- **Empty JSON strings become NULL.** How: a payload with `model: ""`; assert
+  `model IS NULL`, not `''`.
+- **Malformed metadata does not abort the statement.** How: seed one message row
+  with `metadata = ''` and another with `metadata = 'null'` alongside a valid
+  subagent row; assert the valid row still lands. (AC-23b)
+- **A live row wins over the backfill.** How: pre-insert a `source = 'live'` row
+  for a `(session, tool_call_id)` that also exists as a message, run
+  `runMigrations()`, assert `source` is still `'live'` and there is exactly one
+  row. (AC-22)
+- **Rows with no `task_id` or no `tool_call_id` are not backfilled.** (AC-2)
+- **Activation keys are written once.** How: assert both `kandev_meta` keys are
+  present and RFC3339-parseable (`backfill_through` may be `''`), capture their
+  values, `runMigrations()` again, assert both unchanged. (AC-24)
+- **Fresh DB with no subagent messages sets `backfill_through` to `''`.** (AC-24)
+
+### Repository upsert — `subagent_context_test.go` (task 02)
+
+File: `apps/backend/internal/task/repository/sqlite/subagent_context_test.go`.
+
+- **First upsert inserts.** (AC-1)
+- **Second upsert for the same key updates in place, one row.** (AC-3)
+- **Fill-forward: a frame with empty fields does not blank learned values.**
+  Table-driven over every nullable column. (AC-4)
+- **A non-empty value replaces the stored value.** (AC-5)
+- **`settled_at` is write-once**: a second terminal frame with a later timestamp
+  leaves the first value. (AC-11)
+- **A non-terminal frame after settling leaves `settled_at` and `tool_status`
+  alone but still fills NULL columns.** (AC-12)
+- **Never-terminal row exists with `settled_at IS NULL`.** (AC-10)
+- **`turn_id` from the first frame survives a later frame carrying a different
+  turn.** (AC-2a)
+- **`is_async` is sticky** across a later frame reporting false.
+- **`source` and `observed_at` are not overwritten** by a later upsert.
+- **Nested `parent_tool_call_id` is stored and the row is not suppressed.**
+  (AC-6)
+- **Concurrent upserts of the same key** — N goroutines, `errgroup`; assert
+  exactly one row and that the invariants above hold regardless of commit order.
+  (AC-14)
+- **Concurrent upserts of different keys in one turn** — the observed 3-, 4-,
+  5- and 8-way fan-outs; assert every row lands. (AC-15)
+- **Deleting the parent session cascades the rows away.** (AC-16) Also add
+  `task_session_subagents` to `assertNoWorkspaceCascadeDependents` in
+  `workspace_test.go:317`, so the workspace cascade test covers the new table.
+- **Read ordering is `observed_at ASC, tool_call_id ASC`** — seed rows sharing an
+  `observed_at` and assert the `tool_call_id` tiebreak, per AC-13's explicit
+  rejection of `id` as a tiebreak.
+
+### Service writer — `subagent_context_test.go` (task 03)
+
+File: `apps/backend/internal/task/service/subagent_context_test.go`.
+
+- **Table-driven identity gate**: each of empty session id, empty task id, empty
+  tool call id ⇒ no repository call, `skipped_no_identity` incremented by one.
+  (AC-2)
+- **Table-driven normalization**: `""` ⇒ NULL for every nullable TEXT column;
+  absent metric ⇒ nil; reported `0` `ToolUseCount` ⇒ `*int64(0)`; negative
+  ⇒ nil plus `anomalous_value`++ with the other fields of the same frame intact.
+  (AC-7, AC-8, AC-9)
+- **Terminal `tool_status` sets `settled_at`; `agent_status = "async_launched"`
+  alone does not.** (AC-10a, AC-11)
+- **An unrecognised `agent_status` is stored verbatim and does not settle.**
+  (AC-10a)
+- **A repository error logs `WARN`, increments `failed`, and the call still
+  returns normally.** How: a stub repo returning an error plus
+  `zaptest`/observed-logs. (AC-27)
+- **`attempted` and `persisted` move as specified** on the happy path. (AC-26)
+- **The service's terminal-status set equals the orchestrator's** — pin both
+  lists so a future edit to one breaks the test. (AC-11)
+
+### Orchestrator integration — `event_handlers_streaming_subagent_test.go` (task 04)
+
+File:
+`apps/backend/internal/orchestrator/event_handlers_streaming_subagent_test.go`.
+
+- **`handleToolCallEvent` with a `subagent_task` payload records a context** with
+  the active turn id. (AC-1)
+- **`handleToolUpdateEvent` for the same tool call records again** so the merge
+  path runs; assert one recorded request per frame with the right turn id.
+  (AC-3)
+- **A terminal update carries the terminal `tool_status` through.** (AC-11)
+- **A non-`subagent_task` normalized kind records nothing.**
+- **A nil `subagentContexts` field is safe** — no panic, message write still
+  happens. (AC-27)
+- **A nested frame (`ParentToolCallID` set) is recorded, not dropped.** (AC-6)
+- **Integration through the real service and repository**, using
+  `newServiceBackedMessageCreator(repo)` as `event_handlers_streaming_test.go:906`
+  does, so one test exercises handler → service → repo end to end.
+
+### Postgres parity and the health query (task 05)
+
+- **Fresh Postgres schema plus migration replay**, including the backfill and
+  both activation keys. File:
+  `apps/backend/internal/task/repository/sqlite/subagent_context_postgres_test.go`,
+  gated on `KANDEV_TEST_POSTGRES_DSN` via `testutil.OpenIsolatedPostgres`.
+  (AC-19)
+- **The upsert's conflict clause behaves identically on Postgres** — fill-forward,
+  `settled_at` write-once, `is_async` sticky, `turn_id` preserved. This is the
+  ADR-0027 requirement that schema replay alone is insufficient for a
+  dialect-sensitive method. (AC-19)
+- **The backfill's JSON helpers work on `jsonb`**, including the `''`/`'null'`
+  metadata rows and the boolean spelling difference. (AC-23b)
+- **AC-28 health query** on a seeded store: assert the
+  `task_session_messages` `subagent_task` count equals
+  `COUNT(*) FROM task_session_subagents` after live writes, and that seeding a
+  message the writer never saw makes the two diverge. File:
+  `apps/backend/internal/task/repository/sqlite/subagent_context_health_test.go`.
+  (AC-28, AC-29)
+
+---
+
+## E2E Tests
+
+None. The spec's *Out of scope* states no UI surface changes, therefore "no E2E
+coverage is implied". Adding one would test nothing this feature changes.
+
+---
+
+## Verification Results
+
+Pending. On completion, synchronize this section with each task's `## Results`:
+record exact commands and outcomes/counts, generated artifact paths, and
+cleanup/teardown evidence.
+
+---
+
+## Implementation Waves And Parallel Candidates
+
+Every task shares the `internal/task` subtree and each depends on the previous
+one's schema or seam, so the chain is sequential. Nothing here is
+parallel-safe: tasks 01 and 02 both edit the same package and task 01 owns
+shared schema DDL.
+
+```
+Wave 1:
+- [ ] [task-01-schema-and-backfill](task-01-schema-and-backfill.md)
+
+Wave 2:
+- [ ] [task-02-repository-upsert](task-02-repository-upsert.md)
+
+Wave 3:
+- [ ] [task-03-service-writer](task-03-service-writer.md)
+
+Wave 4:
+- [ ] [task-04-orchestrator-wiring](task-04-orchestrator-wiring.md)
+
+Wave 5:
+- [ ] [task-05-postgres-and-health](task-05-postgres-and-health.md)
+```
+
+## Open Questions
+
+None. Two spec ambiguities were resolved against repository convention rather
+than left open, and both are recorded above so a builder does not re-litigate
+them:
+
+1. **"Schema-init DDL *and* an idempotent migration"** for a new table would be
+   a duplicated `CREATE TABLE`. `apps/backend/AGENTS.md` settles it: schema init
+   runs before `runMigrations()` on every boot, so the DDL alone satisfies
+   AC-17. See *Schema (task 01)*.
+2. **AC-13 mandates a read ordering** while *Out of scope* forbids a read API.
+   Resolved as two repository-level list methods and no service, DTO, or route.
+   See *Model and repository upsert (task 02)*.

--- a/docs/plans/subagent-context-persistence/task-01-schema-and-backfill.md
+++ b/docs/plans/subagent-context-persistence/task-01-schema-and-backfill.md
@@ -1,0 +1,83 @@
+---
+id: "01-schema-and-backfill"
+title: "Schema, backfill migration, activation keys"
+status: pending
+wave: 1
+depends_on: []
+plan: "plan.md"
+spec: "../../specs/subagent-context-persistence/spec.md"
+---
+
+# Task 01: Schema, backfill migration, activation keys
+
+Create the `task_session_subagents` table, the one-time backfill from existing
+message metadata, and the two write-once `kandev_meta` activation keys.
+
+## Acceptance
+
+1. A fresh database and an existing database both end up with the table, its
+   three indexes, the `UNIQUE (task_session_id, tool_call_id)` constraint, and
+   the `task_sessions` cascade FK — and no FK on `turn_id`. `runMigrations()`
+   replays cleanly twice with no schema or row-set change. (AC-17, AC-18)
+2. The backfill inserts one `source = 'backfill'` row per existing
+   `subagent_task` message, deriving NULL (never `0`, never `''`) for every
+   unreported or empty field, skipping rows with no `task_id` or no
+   `tool_call_id`, and leaving any pre-existing row untouched. (AC-21, AC-22,
+   AC-23, AC-23a, AC-2)
+3. `subagent_context_capture_since` and `subagent_context_backfill_through` are
+   written once and never overwritten on replay. (AC-24)
+
+## Files likely touched
+
+- `apps/backend/internal/task/repository/sqlite/base_schema.go` — new
+  `initSubagentContextSchema()`, called from `initSessionSchema()` right after
+  `initMessageTurnSchema()`.
+- `apps/backend/internal/task/repository/sqlite/base_migrations.go` — new
+  `migrateSubagentContextBackfill()` called from `runMigrations()` after the
+  existing statements; new `jsonKey`, `jsonInt`, `jsonBoolToInt` helpers beside
+  `jsonColumn` / `jsonText` (currently lines 319-335).
+- `apps/backend/internal/task/repository/sqlite/subagent_context_migration_test.go`
+  — new.
+
+## Dependencies
+
+None.
+
+## Parallelism
+
+`sequential` — owns shared schema DDL and the migration runner.
+
+## Inputs
+
+- Spec § *Data model*, § *Column-level normalization rules*, § *Migration*,
+  § *Backfill*, § *Activation point and provenance*.
+- Plan § *Schema (task 01)* and § *Migration: backfill and activation keys*,
+  which carry the full DDL, the derivation table, and the resolution of the
+  spec's "DDL *and* migration" wording. **Do not duplicate the `CREATE TABLE`
+  into `base_migrations.go`** — read that section before starting.
+- Pattern to copy: `task_external_id_migration_test.go` (seed a pre-migration
+  row, call `runMigrations` twice, assert idempotence).
+- `internal/db/migratelog.go:33` — `MigrateLogger.Apply` swallows errors and logs
+  `WARN` with the migration name. It takes **no bind args**, so every statement
+  in this task must be argument-free SQL; inline the `capture_since` timestamp
+  with `fmt.Sprintf` over `time.Now().UTC().Format(time.RFC3339)`.
+- `internal/persistence/provider.go:72` — `ensureMetaTable` runs before the task
+  repo is built, so `kandev_meta` is guaranteed present.
+- ADR `docs/decisions/0027-replayable-schema-migrations.md` — use `internal/db`
+  error classification, never local error-string matching.
+
+## Verification
+
+```
+cd apps/backend && gofmt -l internal/task/repository/sqlite && make lint && go test -run 'TestSubagentContext' ./internal/task/repository/sqlite/... && go test ./internal/task/repository/sqlite/...
+```
+
+The final unscoped run is required: it re-runs `TestSQLiteSchemaReinitializes`
+and the existing migration suite against the new DDL.
+
+## Results
+
+Pending. Before marking the task done, replace this with every exact command
+actually run and its outcome/count, generated artifact paths, and cleanup or
+teardown evidence. Record security/trust and external side-effect boundaries
+when applicable, or explicitly state `None`.

--- a/docs/plans/subagent-context-persistence/task-02-repository-upsert.md
+++ b/docs/plans/subagent-context-persistence/task-02-repository-upsert.md
@@ -1,0 +1,80 @@
+---
+id: "02-repository-upsert"
+title: "Model and repository upsert"
+status: pending
+wave: 2
+depends_on: ["01-schema-and-backfill"]
+plan: "plan.md"
+spec: "../../specs/subagent-context-persistence/spec.md"
+---
+
+# Task 02: Model and repository upsert
+
+Add the `SubagentContext` model and the single atomic upsert that encodes every
+merge, terminality, and ordering rule in SQL.
+
+## Acceptance
+
+1. `UpsertSubagentContext` is one `INSERT ... ON CONFLICT DO UPDATE` statement
+   with no read-then-write anywhere. Repeated calls for one
+   `(task_session_id, tool_call_id)` produce exactly one row; concurrent calls
+   for the same key and for different keys in one turn both hold. (AC-3, AC-14,
+   AC-15)
+2. The conflict clause satisfies fill-forward (AC-4, AC-5), write-once
+   `settled_at` (AC-11), post-settle immutability of `tool_status` with
+   continued NULL-filling (AC-12), original-`turn_id` preservation (AC-2a),
+   sticky `is_async`, and write-once `source` / `observed_at` (AC-1a, AC-22).
+3. Reads are ordered `observed_at ASC, tool_call_id ASC`, and deleting the
+   parent session cascades the rows away. (AC-13, AC-16)
+
+## Files likely touched
+
+- `apps/backend/internal/task/models/subagent_context.go` — new. Every nullable
+  column is a pointer; `ToolUseCount *int64` specifically so a reported `0` is
+  distinguishable from "not reported".
+- `apps/backend/internal/task/repository/sqlite/subagent_context.go` — new:
+  `UpsertSubagentContext`, `ListSubagentContextsBySession`,
+  `ListSubagentContextsByTurn`.
+- `apps/backend/internal/task/repository/sqlite/subagent_context_test.go` — new.
+- `apps/backend/internal/task/repository/sqlite/workspace_test.go` — add
+  `task_session_subagents` to `assertNoWorkspaceCascadeDependents` (line ~317).
+- The task repository interface in `apps/backend/internal/task/repository/`, if
+  the service consumes the repo through an interface rather than the concrete
+  type — check before assuming either way.
+
+## Dependencies
+
+Task 01 — the table must exist.
+
+## Parallelism
+
+`sequential` — same package as task 01.
+
+## Inputs
+
+- Plan § *Model and repository upsert (task 02)* — carries the full
+  column-by-column conflict-expression table with its AC mapping. Implement from
+  that table; do not re-derive it.
+- Spec § *Data model*, AC-2a, AC-3 through AC-6, AC-10 through AC-16.
+- Upsert patterns already in the package: `review.go:27`, `document.go:291`,
+  `executor.go:171`. Build the statement as a package-level `const` and pass it
+  through `r.db.Rebind`.
+- `git_snapshots.go` — the sibling read/scan shape for a session-scoped child
+  table.
+- Concurrency test shape: `messagequeue/repository_reorder_test.go:212`.
+
+## Verification
+
+```
+cd apps/backend && gofmt -l internal/task/models internal/task/repository/sqlite && make lint && go test -run 'TestSubagentContext' ./internal/task/repository/sqlite/... && go test -race -run 'TestSubagentContext' ./internal/task/repository/sqlite/... && go test ./internal/task/repository/sqlite/...
+```
+
+The `-race` run is not optional: AC-14 and AC-15 are concurrency claims and a
+non-race pass is not evidence for them.
+
+## Results
+
+Pending. Before marking the task done, replace this with every exact command
+actually run and its outcome/count, generated artifact paths, and cleanup or
+teardown evidence. Record security/trust and external side-effect boundaries
+when applicable, or explicitly state `None`.

--- a/docs/plans/subagent-context-persistence/task-03-service-writer.md
+++ b/docs/plans/subagent-context-persistence/task-03-service-writer.md
@@ -1,0 +1,82 @@
+---
+id: "03-service-writer"
+title: "Service writer and expvar counters"
+status: pending
+wave: 3
+depends_on: ["02-repository-upsert"]
+plan: "plan.md"
+spec: "../../specs/subagent-context-persistence/spec.md"
+---
+
+# Task 03: Service writer and expvar counters
+
+Add the single service entry point that owns identity gating, value
+normalization, terminality, and the five writer-health counters.
+
+## Acceptance
+
+1. `RecordSubagentContext` has **no error return**. A repository failure logs
+   `WARN` with the session id and tool call id, increments `failed`, and returns
+   normally — so it is structurally impossible for this writer to fail the
+   enclosing message write, turn, or agent stream. (AC-27)
+2. Normalization is exact: every empty nullable TEXT field becomes NULL, never
+   `''`; an unreported `total_tokens` / `tool_use_count` / `duration_ms` becomes
+   NULL, never `0`; a reported `tool_use_count` of `0` stays `0`; a negative
+   value becomes NULL and increments `anomalous_value` while leaving the frame's
+   other fields intact. (AC-7, AC-8, AC-9)
+3. `settled_at` is set only from a terminal ACP `tool_status`. `agent_status` is
+   stored verbatim and never consulted for terminality — including
+   `async_launched` and any value Kandev does not recognise. (AC-10a, AC-11)
+4. `expvar` exposes `attempted`, `persisted`, `skipped_no_identity`,
+   `anomalous_value`, `failed`. Missing session id, task id, or tool call id
+   writes nothing and increments `skipped_no_identity`. (AC-2, AC-26)
+
+## Files likely touched
+
+- `apps/backend/internal/task/service/subagent_context.go` — new:
+  `RecordSubagentContextRequest`, `RecordSubagentContext`, `nilIfEmpty`, the
+  metric normalizer, and a local `isTerminalToolStatus`.
+- `apps/backend/internal/task/service/subagent_context_metrics.go` — new: one
+  `expvar.NewMap("subagent_context_total")`.
+- `apps/backend/internal/task/service/subagent_context_test.go` — new.
+
+## Dependencies
+
+Task 02 — the repository upsert is the collaborator under test.
+
+## Parallelism
+
+`sequential`.
+
+## Inputs
+
+- Plan § *Service writer and counters (task 03)* — carries the request struct,
+  the no-error-return rationale, and the counter names.
+- Spec § *Column-level normalization rules*, § *Two statuses, deliberately
+  separate*, AC-2, AC-7 through AC-11, AC-26, AC-27.
+- `streams.SubagentTaskPayload` at
+  `internal/agentctl/types/streams/tool_payload.go` — note `ToolUseCount *int`
+  is a pointer *specifically* to carry a reported `0`, and that `DurationMs` /
+  `TotalTokens` are `omitempty int64` so a reported `0` is indistinguishable from
+  absent for those two. Preserve that asymmetry rather than smoothing it.
+- `internal/orchestrator/event_handlers_streaming.go:762` — the peer
+  `isTerminalToolStatus`. It is unexported, so copy the set
+  (`complete`, `completed`, `success`, `error`, `failed`, `cancelled`), name the
+  peer in a comment, and add a test that pins the two lists together so a future
+  edit to one fails.
+- Counter convention: `internal/office/scheduler/metrics_vars.go` (package-level
+  `expvar.NewMap`, counters only) and its test
+  `metrics_vars_test.go` for the name-assertion shape.
+
+## Verification
+
+```
+cd apps/backend && gofmt -l internal/task/service && make lint && go test -run 'TestRecordSubagentContext|TestSubagentContext' ./internal/task/service/... && go test ./internal/task/service/...
+```
+
+## Results
+
+Pending. Before marking the task done, replace this with every exact command
+actually run and its outcome/count, generated artifact paths, and cleanup or
+teardown evidence. Record security/trust and external side-effect boundaries
+when applicable, or explicitly state `None`.

--- a/docs/plans/subagent-context-persistence/task-04-orchestrator-wiring.md
+++ b/docs/plans/subagent-context-persistence/task-04-orchestrator-wiring.md
@@ -1,0 +1,84 @@
+---
+id: "04-orchestrator-wiring"
+title: "Orchestrator frame wiring"
+status: pending
+wave: 4
+depends_on: ["03-service-writer"]
+plan: "plan.md"
+spec: "../../specs/subagent-context-persistence/spec.md"
+---
+
+# Task 04: Orchestrator frame wiring
+
+Call the writer from the two frame handlers that already parse the subagent
+payload, and wire the adapter in `backendapp`.
+
+## Acceptance
+
+1. A `subagent_task` frame on `handleToolCallEvent` records a context with the
+   active turn id; a later frame for the same tool call on
+   `persistToolUpdateMessage` records again so the upsert's merge path runs. A
+   nested frame (`ParentToolCallID` set) is recorded, not dropped. (AC-1, AC-3,
+   AC-6)
+2. A non-`subagent_task` normalized kind records nothing, and a nil recorder is
+   safe — no panic, and the message write still happens. (AC-27)
+3. Neither handler exceeds the package's `funlen` limit (80 lines / 50
+   statements); the guard and request build live in one
+   `recordSubagentContextFromFrame` helper.
+
+## Files likely touched
+
+- `apps/backend/internal/orchestrator/service.go` — new
+  `SubagentContextRecorder` interface beside `MessageCreator` (line ~86) and an
+  optional `subagentContexts` field on `Service`.
+- `apps/backend/internal/orchestrator/event_handlers_streaming.go` — new
+  `recordSubagentContextFromFrame` helper; call it from `handleToolCallEvent`
+  (~line 312, after the `CreateToolCallMessage` block) and from
+  `persistToolUpdateMessage` (~line 565, after `UpdateToolCallMessage`).
+- `apps/backend/internal/backendapp/adapters.go` — new `subagentContextAdapter`
+  over `*taskservice.Service`, wired where `messageCreatorAdapter` is wired.
+- `apps/backend/internal/orchestrator/event_handlers_streaming_subagent_test.go`
+  — new.
+
+## Dependencies
+
+Task 03 — the service method is what the interface abstracts.
+
+## Parallelism
+
+`sequential`.
+
+## Inputs
+
+- Plan § *Orchestrator wiring (task 04)* — carries the interface shape, both call
+  sites, and the turn-id sourcing rule.
+- Spec AC-1, AC-1a, AC-2a, AC-3, AC-6, AC-11, AC-27.
+- **Turn id must come from what each call site already resolved**, not from a
+  fresh lookup: `handleToolCallEvent` uses `s.getActiveTurnID(payload.SessionID)`
+  and `persistToolUpdateMessage` uses its local `turnID`, which is
+  `peekActiveTurnID` for terminal frames and `getActiveTurnID` otherwise. A
+  terminal frame on a settled turn deliberately resolves to `""`, and AC-2a's
+  original-turn preservation lives in the upsert, not here — do not re-derive a
+  turn to "fix" an empty one.
+- `payload.SessionID` **is** the Kandev task session id, despite the
+  `agentSessionID` parameter name downstream: `messageCreatorAdapter` passes the
+  same value into `CreateMessageRequest.TaskSessionID`
+  (`internal/backendapp/adapters.go:879`).
+- Guard on `payload.Data.Normalized.Kind() == streams.ToolKindSubagentTask` and a
+  non-nil `Normalized.SubagentTask()`.
+- Test patterns: `event_handlers_streaming_test.go:906`
+  (`newServiceBackedMessageCreator(repo)`) for the end-to-end
+  handler → service → repo case, and `mockMessageCreator` for the unit cases.
+
+## Verification
+
+```
+cd apps/backend && gofmt -l internal/orchestrator internal/backendapp && make lint && go test -run 'Subagent' ./internal/orchestrator/... && go test ./internal/orchestrator/... ./internal/backendapp/...
+```
+
+## Results
+
+Pending. Before marking the task done, replace this with every exact command
+actually run and its outcome/count, generated artifact paths, and cleanup or
+teardown evidence. Record security/trust and external side-effect boundaries
+when applicable, or explicitly state `None`.

--- a/docs/plans/subagent-context-persistence/task-05-postgres-and-health.md
+++ b/docs/plans/subagent-context-persistence/task-05-postgres-and-health.md
@@ -1,0 +1,81 @@
+---
+id: "05-postgres-and-health"
+title: "Postgres parity and health-query coverage"
+status: pending
+wave: 5
+depends_on: ["04-orchestrator-wiring"]
+plan: "plan.md"
+spec: "../../specs/subagent-context-persistence/spec.md"
+---
+
+# Task 05: Postgres parity and health-query coverage
+
+Prove the dialect-sensitive statements behave identically on PostgreSQL, and pin
+the AC-28 expected-versus-observed health comparison.
+
+## Acceptance
+
+1. Against `KANDEV_TEST_POSTGRES_DSN`, a fresh schema plus a migration replay
+   produces the same table, the same backfilled rows, and the same two
+   activation keys as SQLite. (AC-19)
+2. The upsert's conflict clause is verified *behaviorally* on Postgres —
+   fill-forward, write-once `settled_at`, sticky `is_async`, preserved original
+   `turn_id` — not merely replayed. The backfill's JSON helpers are verified over
+   `jsonb`, including `''` and `'null'` metadata rows and the boolean spelling
+   difference (`'true'` vs `1`). (AC-19, AC-23b)
+3. The AC-28 comparison is asserted both ways: the two counts agree after live
+   writes, and seeding a `subagent_task` message the writer never saw makes them
+   diverge, with `MAX(observed_at)` locating the divergence in time. (AC-28,
+   AC-29)
+
+## Files likely touched
+
+- `apps/backend/internal/task/repository/sqlite/subagent_context_postgres_test.go`
+  — new.
+- `apps/backend/internal/task/repository/sqlite/subagent_context_health_test.go`
+  — new.
+
+## Dependencies
+
+Task 04 — the health check compares rows written by the live path.
+
+## Parallelism
+
+`sequential`.
+
+## Inputs
+
+- Spec AC-19, AC-23b, AC-28, AC-29, and § *Writer health* — in particular *why*
+  the message count is a valid independent expectation: the message write is
+  load-bearing for the UI and a break is noticed within one turn, whereas a
+  broken context write is noticed by nobody. Keep that asymmetry in the test
+  comment; it is the reason the check is real.
+- ADR `docs/decisions/0027-replayable-schema-migrations.md` and
+  `apps/backend/AGENTS.md` § *Schema & migrations*: "add an environment-gated
+  PostgreSQL behavior test for every changed dialect-sensitive method (schema
+  replay is insufficient)".
+- Patterns: `postgres_schema_test.go` (env-gated fresh-schema + replay),
+  `document_plan_postgres_test.go` (asserting `ON CONFLICT` updates rather than
+  inserts on Postgres), `testutil.OpenIsolatedPostgres` /
+  `testutil.PostgresDSNFromEnv` (`internal/testutil/postgres.go:45`).
+- The AC-28 query is dialect-specific (`json_extract` vs `#>>`); reuse the
+  helpers from task 01 rather than hand-writing it twice.
+
+## Verification
+
+```
+cd apps/backend && gofmt -l internal/task/repository/sqlite && make lint && go test -run 'TestSubagentContextHealth' ./internal/task/repository/sqlite/... && KANDEV_TEST_POSTGRES_DSN="$KANDEV_TEST_POSTGRES_DSN" go test -run 'Postgres.*Subagent|Subagent.*Postgres' ./internal/task/repository/sqlite/...
+```
+
+If `KANDEV_TEST_POSTGRES_DSN` is unset the Postgres run **skips rather than
+fails**. A skip is not evidence for AC-19: record it explicitly as a skip in
+`## Results` and state that AC-19 remains unverified locally, rather than
+reporting the task fully verified.
+
+## Results
+
+Pending. Before marking the task done, replace this with every exact command
+actually run and its outcome/count, generated artifact paths, and cleanup or
+teardown evidence. Record whether the Postgres suite ran or skipped. Record
+security/trust and external side-effect boundaries when applicable, or explicitly
+state `None`.

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -246,6 +246,7 @@ System pages (Radarr/Sonarr-style) for status, disk usage, database maintenance,
 | [agent-resume-runtime-recovery](agent-resume-runtime-recovery/spec.md) | shipped |
 | [agent-stall-recovery](agent-stall-recovery/spec.md) | approved |
 | [mcp-session-observability](mcp-session-observability/spec.md) | approved |
+| [subagent-context-persistence](subagent-context-persistence/spec.md) | draft |
 | [auth](auth/spec.md) | building |
 | [create-local-repository](create-local-repository/spec.md) | shipped |
 | [workflow-cycle-guardrails](workflow-cycle-guardrails/spec.md) | building |

--- a/docs/specs/subagent-context-persistence/spec.md
+++ b/docs/specs/subagent-context-persistence/spec.md
@@ -1,0 +1,544 @@
+---
+status: draft
+created: 2026-08-12
+updated: 2026-08-12
+owner: nova28
+---
+
+# Subagent context persistence
+
+## Why
+
+When an agent fans out to subagents (Claude's `Task` tool, OpenCode's `task`,
+Cursor's `Task`, Auggie's `sub-agent-<type>:`), Kandev already recognises the
+fan-out and already receives the child's identity and usage on the completion
+frame. It renders them, counts them in memory, and then keeps no queryable
+record of them.
+
+The consequence is a specific, measured distortion. In the reference store
+(`~/.kandev/data/kandev.db`, snapshotted 2026-08-12), **sessions per card is
+exactly 1.0 for every step**, while 253 subagent invocations exist across 38
+sessions and 127 turns — including **42 turns that fanned out to exactly three
+subagents**. A step that spawned three parallel reviewers is, in the store,
+indistinguishable from one long conversation. Every per-context cost figure is
+therefore wrong in the same direction, and the Ops Cost analysis of the Review
+step's cache cost had to *infer* a three-way fan-out by reading the step's
+prompt, because nothing in the store recorded it.
+
+## What this feature is, and is not
+
+**It is persistence and a parent link.** The data already arrives on a frame
+Kandev parses (`internal/agentctl/server/adapter/transport/acp/subagent.go`) and
+is already carried in a typed payload
+(`streams.SubagentTaskPayload`). This spec adds a durable, queryable row per
+subagent invocation, linked to the session and turn that spawned it. It adds no
+new instrumentation, no new agent-side capability, and no new wire fields.
+
+**It is not a session.** A subagent context is deliberately *not* a
+`task_sessions` row. See *The design question*, below — that decision is part of
+the contract, not an implementation detail.
+
+**It is not a UI feature.** No frontend surface changes. The existing subagent
+card already renders from message metadata and continues to do so, unchanged.
+
+**It is not cost attribution.** Token counts are stored exactly as the agent
+reported them, with provenance. No pricing, no dollars, no rollup into
+`task_sessions.cost_subcents`.
+
+### One correction to the framing
+
+The originating analysis states the data is "never persisted". That is
+imprecise, and the imprecision matters to the design. The normalized payload
+*is* written today — as opaque JSON at
+`task_session_messages.metadata.normalized.subagent_task` (253 such rows exist
+in the reference store). What does not exist is a **relational fact**: no
+stable row identity, no first-class parent link, no column a query can group by,
+and no independent record — the JSON lives inside a row that is cascade-deleted
+with its session.
+
+This matters twice over:
+
+1. It makes a **backfill possible**, which this spec takes (see *Backfill*).
+2. It makes the message table an **independent expected-count source** for
+   writer health (see *Writer health*).
+
+---
+
+## The design question: a row in `task_sessions`, or its own table?
+
+**Answer: its own table, `task_session_subagents`.** The parent link is a
+foreign key from that table to `task_sessions`, not a `parent_session_id` column
+added to `task_sessions`.
+
+The reasoning, from the code as it stands:
+
+**A subagent has none of the things a `task_sessions` row asserts.** It has no
+workspace and no `workspace_path`; no executor, `executor_profile_id`, or
+`task_environment_id`; no worktree or `base_branch`; no `agent_profile_id`; no
+`executors_running` row; no ACP session Kandev can `session/load` or resume; no
+`state` machine (`CREATED` → `RUNNING` → …); no launch, stop, or recover path.
+A row in `task_sessions` implies all of those, and every one would be a lie.
+
+**`task_sessions` is read by paths that would be actively harmed.** Session
+rows feed lifecycle recovery (`RecoverInstances`), the orchestrator, session-tab
+listings, WebSocket subscription scoping, the auth scoper
+(`AuthorizeSessionAccess` resolves session → task → workspace → owner), the boot
+payload, and cost rollups. Inserting non-launchable rows there forces a new
+"is this real" predicate into every one of them, and any path that forgets it
+becomes a defect.
+
+**It would silently break the very series this feature exists to fix.** The
+downstream extract's `dim_session` is `SELECT … FROM task_sessions`. Adding
+subagent rows to that table would change what "sessions per card" *means*
+mid-series, with no schema versioning to signal it — which is precisely the
+discontinuity the cross-cutting rule for this work forbids. A separate table is
+purely additive: the existing series stays comparable, and the new fact is
+opt-in for any consumer that wants it.
+
+The name follows the existing sibling convention: `task_session_messages`,
+`task_session_turns`, `task_session_commits`, `task_session_subagents`.
+
+---
+
+## Sampled input shapes
+
+Every shape below was read from the live store on 2026-08-12, not assumed.
+
+### Population by terminal status (n = 253)
+
+| status | n | agent_id | child_session_id | model | total_tokens | tool_use_count | duration_ms |
+|---|---|---|---|---|---|---|---|
+| `async_launched` | 190 | 190 | 0 | 190 | **0** | **0** | **0** |
+| `completed` | 57 | 57 | 0 | 49 | 57 | 57 | 57 |
+| `started` | 5 | 0 | 5 | 0 | 0 | 0 | 0 |
+| *(absent)* | 1 | 0 | 0 | 0 | 0 | 0 | 0 |
+
+Three facts drive the whole contract:
+
+1. **75% of subagent invocations report no usage at all.** `async_launched` is
+   Claude's `run_in_background` dispatch; the dispatch is terminal for the
+   `Task` tool, the subagent runs out-of-band and writes to an `outputFile`
+   Kandev never reads. These rows will never gain tokens, duration, or a tool
+   count. Storing `0` for them would fabricate 190 measurements.
+2. **`child_session_id` is empty for every Claude row** and is populated only by
+   OpenCode (5 rows, all non-terminal). It cannot be the identity.
+3. **`tool_call_id` is present on all 253 rows and unique across all 253.**
+   `agent_id` is unique among the 247 rows that carry one, but is absent for
+   three of the four supported agents. `tool_call_id` is the identity.
+
+### Other measured facts
+
+- **Fan-out distribution per turn:** 1→65 turns, 2→12, **3→42**, 4→5, 5→2, 8→1.
+- **Nesting:** exactly 1 of 253 rows carries a `parent_tool_call_id` — a
+  subagent that spawned a subagent. Rare, real, and must be specified.
+- `turn_id` and `task_session_id` are non-empty on all 253 rows.
+- `subagent_type` is missing on 3 rows.
+- No two subagent rows within a turn share a `created_at` (microsecond
+  precision), so ties are not observed — but they are not prevented either.
+- Observed window: 2026-08-03 15:32:20Z to 2026-08-12 13:24:58Z.
+
+### The payload as parsed
+
+`streams.SubagentTaskPayload` carries `Description`, `Prompt`, `SubagentType`,
+`Status`, `AgentID`, `Model`, `ChildSessionID`, `DurationMs`, `TotalTokens`,
+`ToolUseCount *int`, `ResultText`, `IsAsync`, `OutputFile`,
+`CanReadOutputFile`. `ToolUseCount` is already a pointer specifically so a
+reported `0` is distinguishable from "not reported" — that distinction is
+load-bearing here and must survive into the column.
+
+---
+
+## Data model
+
+A new table, created on fresh databases in the schema-init DDL **and**
+introduced on existing databases by an idempotent migration in
+`runMigrations()`, per the repository's schema rules.
+
+| Column | Type | Null? | Meaning |
+|---|---|---|---|
+| `id` | TEXT PK | no | Kandev-generated UUID. Not an ordering key. |
+| `task_session_id` | TEXT | no | Parent session. FK → `task_sessions(id)` ON DELETE CASCADE. |
+| `task_id` | TEXT | no | Denormalised parent task, mirroring `task_session_turns`. |
+| `turn_id` | TEXT | yes | Turn that spawned it. NULL when no turn was active. |
+| `tool_call_id` | TEXT | no | Agent-supplied invocation identity. |
+| `parent_tool_call_id` | TEXT | yes | Set when a subagent spawned this subagent. NULL for top-level. |
+| `subagent_type` | TEXT | yes | e.g. `security-reviewer`. NULL when not reported. |
+| `description` | TEXT | yes | Short label from `rawInput.description`. |
+| `agent_id` | TEXT | yes | Provider-supplied child agent id. NULL for providers that omit it. |
+| `child_session_id` | TEXT | yes | OpenCode child ACP session. NULL elsewhere. |
+| `model` | TEXT | yes | Resolved child model, verbatim (e.g. `claude-opus-5[1m]`). |
+| `agent_status` | TEXT | yes | The **agent-reported subagent** status, verbatim (`completed`, `async_launched`, `started`, …). NULL when never reported. |
+| `tool_status` | TEXT | yes | The **ACP tool-call** status of the launching `Task` call (`pending`, `in_progress`, `completed`, `failed`, `cancelled`). NULL when never reported. |
+| `is_async` | INTEGER | no | 1 for a detached dispatch, else 0. Default 0. |
+| `total_tokens` | INTEGER | **yes** | As reported. **NULL when not reported.** |
+| `tool_use_count` | INTEGER | **yes** | As reported. **NULL when not reported; 0 only when the agent reported 0.** |
+| `duration_ms` | INTEGER | **yes** | As reported. **NULL when not reported.** |
+| `source` | TEXT | no | `live` or `backfill`. Provenance. Default `live`. |
+| `observed_at` | TIMESTAMP | no | When Kandev first observed the launch frame. |
+| `settled_at` | TIMESTAMP | yes | When a terminal status was first observed. NULL while outstanding. |
+| `updated_at` | TIMESTAMP | no | Last write to this row. |
+
+Constraints and indexes:
+
+- `UNIQUE(task_session_id, tool_call_id)` — the upsert key. Uniqueness is
+  **session-scoped by design**; global uniqueness of an agent-supplied
+  `tool_call_id` is not assumed, even though it holds for all 253 observed rows.
+- FK `task_session_id` → `task_sessions(id)` ON DELETE CASCADE.
+- **`turn_id` carries no foreign key.** `task_session_messages.turn_id`
+  cascades from `task_session_turns`, which would mean deleting a turn silently
+  deletes the fan-out record for that turn. The measurement must outlive the
+  turn row, so `turn_id` is a plain nullable column.
+- `INDEX(task_session_id)`, `INDEX(task_id)`, `INDEX(turn_id)`.
+
+Deliberately **not** stored: `prompt`, `result_text`, `output_file`. The prompt
+and result are free text already retained on the message row; duplicating them
+here doubles the store's largest text payload and adds a second copy of
+prompt content to any extract. This table is structure, not content.
+
+### Two statuses, deliberately separate
+
+`agent_status` and `tool_status` are different measurements from different
+layers and are **not** merged into one column:
+
+- `agent_status` is the child's own report, read from
+  `_meta.claudeCode.toolResponse.status` (or the provider's equivalent). Its
+  vocabulary is provider-defined and open — `async_launched` is a value only
+  Claude produces, and it means *dispatched, will never report usage*.
+- `tool_status` is the ACP status of the launching `Task` tool call, which
+  Kandev already classifies via `isTerminalToolStatus`. Its vocabulary is
+  closed and provider-neutral.
+
+Terminality (AC-11) keys off `tool_status`, because that is the signal the
+orchestrator already treats as authoritative everywhere else. `agent_status` is
+stored verbatim and is never used to decide whether the row has settled.
+
+### Column-level normalization rules
+
+These apply to every write path, live and backfill:
+
+- **An empty string is stored as NULL**, never as `''`, for every nullable TEXT
+  column. `SubagentTaskPayload` uses `""` for "absent"; the column uses NULL, so
+  that `COUNT(model)` counts models rather than blanks.
+- `is_async` defaults to `0` and is set to `1` only on a positive report; it is
+  never set back to `0` by a later frame.
+- `source` defaults to `'live'`.
+- `observed_at`, `settled_at`, `updated_at` are UTC wall-clock instants from the
+  backend process (`time.Now().UTC()`), at the same precision as the sibling
+  session tables.
+- `task_id` is required (NOT NULL). WHEN a frame carries no task id, the row is
+  not written and AC-2's `skipped_no_identity` path applies — a session-scoped
+  row with no card cannot be joined to anything the feature exists to answer.
+- Reported metrics are stored verbatim within `int64`; there is no upper clamp.
+  The largest observed `total_tokens` is 275,717.
+
+---
+
+## Acceptance criteria
+
+EARS-style. Each is observable from the database or from a logged/exported
+counter without reading source.
+
+### Capture
+
+**AC-1** — WHEN the orchestrator observes a tool-call frame whose normalized
+kind is `subagent_task`, and a non-empty session id, task id and `tool_call_id`
+are all present, THEN a `task_session_subagents` row SHALL exist for
+`(task_session_id, tool_call_id)` with `source = 'live'` and `observed_at` set
+to Kandev's observation time.
+
+**AC-1a** — `observed_at` SHALL be the instant Kandev first observed a frame it
+could *recognise* as a subagent, not the instant the subagent began work. For
+Claude and OpenCode the initial `tool_call` carries no `rawInput`, so
+recognition occurs on a later `tool_call_update`; the column is therefore a
+Kandev observation time and SHALL NOT be published as a subagent start time.
+
+**AC-2** — WHEN a subagent frame carries an empty `tool_call_id`, an empty
+session id, or an empty task id, THEN the system SHALL NOT write a row, SHALL
+increment the `skipped_no_identity` writer counter, and SHALL NOT fail the
+enclosing message write or turn.
+
+**AC-2a** — WHEN a `tool_call_id` that already has a row in a session is
+observed again under a *different* `turn_id`, THEN the existing row SHALL be
+updated per AC-3 and its original `turn_id` SHALL be preserved. A second row
+SHALL NOT be created, and the fan-out SHALL NOT be re-attributed to the later
+turn.
+
+**AC-3** — WHEN a later frame for an already-recorded `(task_session_id,
+tool_call_id)` arrives, THEN the system SHALL update that same row and SHALL NOT
+create a second row.
+
+**AC-4** — WHEN a frame reports a field that the stored row already holds
+non-NULL, and the frame's value for that field is absent or empty, THEN the
+stored value SHALL be preserved unchanged. (This mirrors `applySubagentResult`,
+which never blanks a value already learned from an earlier frame.)
+
+**AC-5** — WHEN a frame reports a non-empty value for a field, THEN that value
+SHALL replace the stored value, EXCEPT as constrained by AC-9.
+
+**AC-6** — WHEN a frame reports a subagent whose `parent_tool_call_id` is
+non-empty, THEN the row SHALL be written with that `parent_tool_call_id`, and
+SHALL NOT be suppressed for being nested.
+
+### Nulls, zeroes, and absence
+
+**AC-7** — WHEN an agent does not report `total_tokens`, `tool_use_count`, or
+`duration_ms`, THEN the corresponding column SHALL be NULL. The system SHALL NOT
+write `0` for an unreported value. (This is not hypothetical: 190 of 253
+observed rows report none of the three.)
+
+**AC-8** — WHEN an agent reports `tool_use_count` as exactly `0` (the payload's
+`ToolUseCountKnown` is true and the count is 0), THEN the column SHALL be `0`,
+distinguishable by query from an unreported count.
+
+**AC-9** — WHEN a reported numeric value for `total_tokens`, `tool_use_count`,
+or `duration_ms` is negative, THEN the system SHALL store NULL for that field,
+SHALL increment the `anomalous_value` writer counter, and SHALL leave every
+other field of the frame unaffected. A negative count is not a measurement.
+
+**AC-10** — WHEN a subagent is never observed reaching a terminal `tool_status`,
+THEN `agent_status` and `tool_status` SHALL hold their last observed values (or
+NULL if none was ever reported) and `settled_at` SHALL be NULL. The row SHALL
+still exist. (5 observed rows are in exactly this state.)
+
+**AC-10a** — WHEN a frame reports an `agent_status` value Kandev does not
+recognise, THEN it SHALL be stored verbatim and SHALL NOT affect `settled_at`.
+`agent_status` has an open, provider-defined vocabulary.
+
+### Terminality and ordering
+
+**AC-11** — WHEN a frame's **ACP `tool_status`** is first classified terminal by
+`isTerminalToolStatus` (`completed`, `failed`, `cancelled`), THEN `settled_at`
+SHALL be set to that observation time and SHALL NOT be modified by any later
+frame. `agent_status` SHALL NOT be used to decide terminality — in particular,
+`async_launched` is a Claude *agent* status meaning "dispatched, no usage will
+follow", and its own tool call is terminal in the ACP sense, so those rows
+settle via `tool_status` like any other.
+
+**AC-12** — WHEN a non-terminal frame arrives for a row whose `settled_at` is
+already set, THEN `settled_at` SHALL remain set, `tool_status` SHALL remain the
+terminal value, and the frame MAY still fill columns that are currently NULL.
+(Out-of-order and duplicate frame delivery is an observed reality on this
+stream.)
+
+**AC-13** — WHEN subagent contexts are read for a session or a turn, THEN the
+order SHALL be `observed_at ASC, tool_call_id ASC`. `tool_call_id` is the named
+tiebreak: it is unique within the session by construction (the UNIQUE
+constraint), stable across replays, and total. `id` is a generated UUID and
+SHALL NOT be used as a tiebreak.
+
+### Concurrency
+
+**AC-14** — WHEN two frames for the same `(task_session_id, tool_call_id)` are
+processed concurrently, THEN the write SHALL be a single atomic upsert
+statement, and the resulting row SHALL satisfy AC-4, AC-5, AC-11 and AC-12
+regardless of which frame commits first. The implementation SHALL NOT use a
+read-then-write sequence for field merging; the fill-forward and
+terminality rules are expressed inside the upsert's conflict clause.
+
+**AC-15** — WHEN two frames for *different* `tool_call_id`s in the same turn are
+processed concurrently (the observed 3-, 4-, 5- and 8-way fan-outs), THEN both
+rows SHALL be written, and neither SHALL block the other.
+
+**AC-16** — WHEN the parent session row is deleted, THEN its
+`task_session_subagents` rows SHALL be removed by the foreign key cascade,
+consistent with `task_session_messages` and `task_session_turns`.
+
+### Migration
+
+**AC-17** — WHEN `runMigrations()` runs against a database that predates this
+feature, THEN the table, its indexes and its constraints SHALL be created, and
+existing data SHALL be unaffected.
+
+**AC-18** — WHEN `runMigrations()` is invoked twice in succession against the
+same database, THEN the second invocation SHALL succeed and SHALL leave the
+schema and the row set unchanged. (Mirrors
+`task_external_id_migration_test.go`: seed a pre-migration row, call
+`runMigrations` twice, assert idempotence.)
+
+**AC-19** — WHEN the migration runs against PostgreSQL, THEN it SHALL apply and
+replay with the same result as SQLite, using `internal/db` error classification
+rather than local error-string matching, per ADR 0027.
+
+**AC-20** — WHEN a statement in this migration fails, THEN — because the
+repository's migration runner swallows errors
+(`internal/db/migratelog.go:33`) — the failure SHALL be observable as a `WARN`
+log carrying the migration's name, and the writer's health signals (AC-24,
+AC-25) SHALL make the resulting absence of rows detectable rather than silent.
+
+### Backfill
+
+**AC-21** — WHEN the migration runs, THEN it SHALL insert one row with
+`source = 'backfill'` for every existing `task_session_messages` row whose
+`metadata.normalized.kind` is `subagent_task`, deriving each column from
+`metadata.normalized.subagent_task` and `metadata.tool_call_id`, and setting
+`observed_at` from the message's `created_at`.
+
+**AC-22** — WHEN the backfill encounters a `(task_session_id, tool_call_id)`
+that already has a row, THEN it SHALL leave the existing row untouched
+(`ON CONFLICT DO NOTHING`), so a live write always wins over a backfilled one
+and a replay is a no-op.
+
+**AC-23** — WHEN the backfill derives a value, THEN AC-7 through AC-9 and the
+empty-string-to-NULL rule SHALL apply identically: an absent JSON field becomes
+NULL, never `0` and never `''`.
+
+**AC-23a** — The backfill SHALL be a single unbounded `INSERT … SELECT` with no
+`LIMIT` and no batching, and SHALL set `settled_at` from the message's
+`updated_at` when the derived `tool_status` is terminal, else NULL. It performs
+one full scan of `task_session_messages` at first boot after upgrade — a real,
+accepted one-time cost on a large store (the reference store is 328 MB), taken
+once because a partial or resumable backfill would produce exactly the
+mid-series discontinuity AC-25 exists to prevent.
+
+**AC-23b** — WHEN the backfill runs on PostgreSQL, THEN it SHALL use the
+dialect-aware JSON helpers already present in `base_migrations.go`
+(`jsonColumn`, `jsonText`), which normalise empty and `'null'` metadata
+documents so a single malformed row cannot abort the statement.
+
+### Activation point and provenance
+
+**AC-24** — WHEN the migration completes successfully for the first time on an
+installation, THEN `kandev_meta` SHALL hold two keys, written once and never
+overwritten:
+
+- `subagent_context_capture_since` — RFC3339 UTC instant from which `live`
+  capture is authoritative.
+- `subagent_context_backfill_through` — the RFC3339 UTC `created_at` of the
+  newest message the backfill read, or the empty string when the backfill
+  inserted no rows.
+
+**AC-25** — The published contract for consumers SHALL be: a session whose
+activity predates `subagent_context_backfill_through` has **unknown** fan-out,
+not zero fan-out; rows with `source = 'backfill'` are limited to what survived
+in message metadata and SHALL NOT be compared like-for-like against `live`
+rows without disclosing the provenance split. Absence of a row is never
+evidence of absence of a subagent before `subagent_context_capture_since`.
+
+### Writer health
+
+**AC-26** — The system SHALL expose counters, under the existing `expvar`
+convention used by `routing_*` and `subproc_*`, for: `attempted`, `persisted`,
+`skipped_no_identity`, `anomalous_value`, and `failed`.
+
+**AC-27** — WHEN a persist attempt fails, THEN the system SHALL log at `WARN`
+with the session id and tool-call id, SHALL increment the `failed` counter, and
+SHALL NOT fail the enclosing message write, the turn, or the agent stream.
+Telemetry never breaks the product path.
+
+**AC-28** — The expected-versus-observed health check SHALL be answerable from
+the database alone, with no counter access, as:
+
+```sql
+SELECT COUNT(*) FROM task_session_messages
+ WHERE json_extract(metadata,'$.normalized.kind') = 'subagent_task';
+-- versus
+SELECT COUNT(*) FROM task_session_subagents;
+```
+
+These two counts SHALL agree for all activity after
+`subagent_context_capture_since`, up to rows skipped under AC-2. The message
+count is a valid independent expectation **because the message write is
+load-bearing for the UI**: a broken message write is noticed by a human within
+one turn, whereas a broken context write is noticed by nobody. That asymmetry
+is what makes the comparison a real check rather than two readings of the same
+failure.
+
+**AC-29** — WHEN the writer has stopped while message writes continue, THEN the
+AC-28 comparison SHALL diverge, and the divergence SHALL be attributable in time
+via `MAX(observed_at)` on `task_session_subagents`. No separate heartbeat row is
+written, precisely so that the health signal cannot itself be the thing that
+silently stops.
+
+---
+
+## Failure modes
+
+| Condition | Behaviour |
+|---|---|
+| Frame with no `tool_call_id` or no session id | No row; `skipped_no_identity`++; product path unaffected (AC-2). |
+| Upsert returns an error | `WARN` + `failed`++; product path unaffected (AC-27). |
+| Negative reported metric | That field NULL; `anomalous_value`++; other fields written (AC-9). |
+| Frames arrive out of order | Terminality is monotonic; NULLs may still fill (AC-11, AC-12). |
+| Duplicate frames | Upsert; exactly one row (AC-3). |
+| Parent session deleted mid-turn | FK cascade removes rows; no orphan (AC-16). |
+| Migration statement fails | Swallowed by the runner; surfaced as `WARN` + detectable via AC-28 (AC-20). |
+| Backfill re-runs | `ON CONFLICT DO NOTHING`; no duplicates, no clobber (AC-22). |
+| Agent reports an `agent_status` Kandev does not recognise | Stored verbatim; never affects `settled_at` (AC-10a). |
+| Frame carries no task id | No row; `skipped_no_identity`++ (AC-2). |
+| Same `tool_call_id` observed under a later turn | Existing row updated; original `turn_id` preserved (AC-2a). |
+| A turn row is deleted | Subagent rows survive; `turn_id` has no FK, by design. |
+
+## Persistence guarantees
+
+- A row, once written, is durable until its parent session is deleted.
+- `settled_at` is write-once (AC-11).
+- `source` is write-once: a backfilled row is never relabelled `live`, and a
+  live row is never overwritten by the backfill (AC-22).
+- The two `kandev_meta` activation keys are write-once (AC-24).
+- No column in this table participates in any existing rollup
+  (`task_sessions.cost_subcents`, `tokens_in`, `tokens_out` are untouched).
+
+## Permissions
+
+The table is session-scoped and inherits the session's scope. Any read surface
+added later MUST authorize via the parent session's task
+(`authorizeTaskID(session.TaskID)`), per the backend's session-keyed entry-point
+rule. This spec adds no read surface, so it adds no new authorization path.
+
+---
+
+## Out of scope
+
+Named exclusions. Each is a contract, not an omission.
+
+- **No `parent_session_id` column on `task_sessions`.** Rejected above.
+- **No change to `dim_session` or to "sessions per card".** That series keeps its
+  current meaning; the new table is a separate, additive fact.
+- **No UI surface, no DTO field, no WebSocket event.** The subagent card
+  continues to render from message metadata. No E2E coverage is implied,
+  because no user-visible surface changes.
+- **No REST/MCP read API.** Consumers read the table directly via the extract.
+  If a product surface is wanted later, it is a separate spec with its own
+  authorization design.
+- **No merging of OpenCode's child ACP session.** `child_session_id` is stored;
+  resolving it into the parent transcript is a separate feature.
+- **No reading of Claude's async `outputFile`.** The 190 `async_launched` rows
+  stay usage-less by design; inventing their usage is out of scope, and
+  approximating it is forbidden by AC-7.
+- **No cost or dollar attribution.** Tokens are as-reported, unpriced,
+  unaggregated into any existing cost column.
+- **No `prompt` or `result_text` column.** Structure, not content.
+- **No recursive subagent-tree API.** `parent_tool_call_id` is recorded (AC-6);
+  walking it is a consumer concern.
+- **No retention or pruning policy beyond the FK cascade.** The table grows with
+  message history and is bounded by the same session lifetime.
+- **No retroactive repair of rows the backfill could not see.** Sessions already
+  deleted are gone; AC-25 requires disclosing that, not fixing it.
+
+## Verification
+
+- Repository tests alongside `task_external_id_migration_test.go`: fresh-DB
+  create, pre-migration seeded row, `runMigrations` twice, backfill idempotence,
+  and the NULL-not-zero assertions for an `async_launched`-shaped payload.
+- The same fresh-plus-replay matrix under `KANDEV_TEST_POSTGRES_DSN` (AC-19).
+- Orchestrator tests for the frame paths: first-frame insert, later-frame merge,
+  out-of-order terminal, nested `parent_tool_call_id`, empty-identity skip
+  (each of the three missing ids), same-`tool_call_id`-later-turn, negative
+  metric, reported-zero tool count, empty-string-to-NULL, and concurrent
+  same-key upsert.
+- A query-level check of AC-28 against a seeded store.
+
+### The one shape a builder must not get wrong
+
+A regression test SHALL assert, on an `async_launched`-shaped payload, that
+`total_tokens`, `tool_use_count` and `duration_ms` are all `IS NULL` and none is
+`0`. This is 75% of real traffic; a `DEFAULT 0` on any of those three columns
+would make every future token-per-subagent average wrong by roughly a factor of
+four, silently and permanently, and would do so *after* the activation point,
+where AC-25 offers consumers no protection.
+
+## Related
+
+- ADR [0027 — replayable schema migrations](../../decisions/0027-replayable-schema-migrations.md)
+- `apps/backend/AGENTS.md` § *Schema & migrations (SQLite repository)*
+- `apps/backend/internal/agentctl/AGENTS.md` § *Subagent tool-call nesting: what each agent emits*


### PR DESCRIPTION
Subagent fan-out (Claude's `Task` tool, OpenCode's `task`, etc.) was already recognized and rendered, but kept no queryable record, so sessions-per-card stayed pinned at 1.0 for every step and per-context cost analysis had to be inferred from a step's prompt rather than measured. This adds a durable, queryable `task_session_subagents` table for it.

Spec: [`docs/specs/subagent-context-persistence/spec.md`](docs/specs/subagent-context-persistence/spec.md)

## Important Changes

- New `task_session_subagents` table, deliberately its own table rather than a `task_sessions` row or a `parent_session_id` column — a subagent has no workspace, executor, or lifecycle of its own, and a `task_sessions` row would assert things about it that aren't true (see the spec's "design question" section).
- Idempotent schema migration plus a one-time backfill from existing `task_session_messages` metadata, gated by write-once `kandev_meta` activation keys so the backfill's full-table scan runs once, not every boot.
- Single atomic `INSERT ... ON CONFLICT DO UPDATE` upsert (no read-then-write) implementing fill-forward, write-once `settled_at`/`source`, and turn-attribution rules directly in the conflict clause for concurrency safety.
- NULL-vs-zero-accurate metric columns (`total_tokens`, `tool_use_count`, `duration_ms`) — an unreported value is stored as NULL, never 0, since 75% of observed subagent invocations (Claude's `async_launched` dispatch) report no usage at all.
- Writer-health `expvar` counters (`attempted`, `persisted`, `skipped_no_identity`, `anomalous_value`, `failed`) and a query-level health check comparing subagent-context rows against the independent message-table count.
- No UI surface, no new read/HTTP/MCP API — the existing subagent card continues rendering from message metadata unchanged; this is pure persistence and a parent link.

## Validation

- `go build ./...`
- `make typecheck test lint` (backend `golangci-lint`: 0 issues; web `eslint`: clean; harness: 118/118; architecture: clean)
- `pnpm run i18n:ratchet` (apps/web) — clean; this diff touches zero `apps/web/` files, so the E2E suite is correctly not required
- Full backend (`go test -tags fts5 ./...`), web (`vitest`), CLI (`node --test`), and script test suites pass. A handful of failures unrelated to this change — a Docker-daemon-unavailable precondition in 3 web e2e-helper tests, a macOS temp-dir quirk in `internal/system/storage/workspaces`, and a shell scripting bug in `scripts/pr-state`'s own test — were each reproduced identically against the pre-branch merge-base to confirm they are pre-existing, not regressions.
- No screenshots: backend-only change, no UI surface.
- Two Review rounds (code-reviewer, security-reviewer, test-supervisor, plus a cross-vendor `codex` pass) converged on no unresolved production-bug residual.

## Possible Improvements

Low risk: a narrow, already-tested edge case exists where a first-boot backfill that fails outright can still leave the activation key set with zero backfilled rows — accepted under the spec's own swallow-and-detect migration contract (AC-20/AC-25), not a regression. Three test-rigor gaps (an AC-14 merge-under-race assertion, an AC-13 primary-sort assertion, and confirming CI runs the env-gated Postgres parity tests) are recorded for a follow-up pass.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2617?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->