### PR TITLE
ci: cache Go builds and run two workers per e2e shard

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -330,17 +330,24 @@ jobs:
       # container-bound specs would run here too, fail seeding (Docker not
       # enabled for these shards), and spam every shard.
       #
-      # E2E_WORKERS=2 runs two Playwright workers per shard. The backend
-      # fixture is fully worker-indexed (own backend process, port, agentctl
-      # range, HOME, tmpdir and database per worker — see e2e/worker-ports.ts),
-      # so the only limit is the runner: ubuntu-latest is 4 vCPU / 16 GB, which
-      # fits two backends plus two Chromiums. Deliberately not set on the
-      # `e2e-containers` job, which drives a real Docker daemon per worker.
+      # E2E_WORKERS is deliberately left at its default of 1.
+      #
+      # Two workers per shard cut shard time from ~11m to ~7m, but every shard
+      # then hit exactly one "Backend process exited with code 1" during a
+      # worker's backend boot (14/14 shards, twice in a row; zero occurrences on
+      # main at one worker). That took flaky from 4 to 18 and failed a shard
+      # outright. It is not the port reuse it first looked like — pinning the
+      # port slot and waiting for release before rebinding changed nothing — and
+      # two backends start fine side by side locally, so the cause is still
+      # unidentified.
+      #
+      # waitForHealth now reports the backend's own output on exit, so the next
+      # attempt at two workers can read the actual reason instead of guessing.
+      # Flip this to "2" to resume that experiment.
       - name: Run planned E2E tests (shard ${{ matrix.shard }}/14)
         working-directory: apps/web
         env:
           E2E_SHARD: ${{ matrix.shard }}
-          E2E_WORKERS: "2"
         run: bash e2e/scripts/run-planned-shard.sh "$GITHUB_WORKSPACE/e2e-manifests/normal/${{ matrix.shard }}.json"
 
       - name: Upload blob report

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -82,6 +82,23 @@ jobs:
         working-directory: apps
         run: pnpm install --frozen-lockfile
 
+      # Without this the backend compiles from a cold module + build cache on
+      # every run, which is by far the longest step in this job. Mirrors the
+      # cache in backend-tests.yml, whose `go build` step lands around 26s
+      # warm. Keyed on go.mod/go.sum so dependency bumps rebuild; the
+      # `go-${{ runner.os }}-` fallback lets a bumped run still start from the
+      # previous dependency set rather than from nothing.
+      - name: Cache Go modules
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: go-e2e-build-${{ runner.os }}-${{ hashFiles('apps/backend/go.mod', 'apps/backend/go.sum') }}
+          restore-keys: |
+            go-e2e-build-${{ runner.os }}-
+            go-${{ runner.os }}-
+
       # `build-web-e2e`, not `build-web`: the production web build no longer
       # bundles the pseudo QA catalog, and tests/i18n/pseudo-coverage.spec.ts
       # needs it. See apps/web/lib/i18n/bundling.ts.
@@ -312,10 +329,18 @@ jobs:
       # executor and the SSH executor's sshd target). Without --project the
       # container-bound specs would run here too, fail seeding (Docker not
       # enabled for these shards), and spam every shard.
+      #
+      # E2E_WORKERS=2 runs two Playwright workers per shard. The backend
+      # fixture is fully worker-indexed (own backend process, port, agentctl
+      # range, HOME, tmpdir and database per worker — see e2e/worker-ports.ts),
+      # so the only limit is the runner: ubuntu-latest is 4 vCPU / 16 GB, which
+      # fits two backends plus two Chromiums. Deliberately not set on the
+      # `e2e-containers` job, which drives a real Docker daemon per worker.
       - name: Run planned E2E tests (shard ${{ matrix.shard }}/14)
         working-directory: apps/web
         env:
           E2E_SHARD: ${{ matrix.shard }}
+          E2E_WORKERS: "2"
         run: bash e2e/scripts/run-planned-shard.sh "$GITHUB_WORKSPACE/e2e-manifests/normal/${{ matrix.shard }}.json"
 
       - name: Upload blob report

--- a/apps/web/e2e/README.md
+++ b/apps/web/e2e/README.md
@@ -182,10 +182,10 @@ Why a script instead of raw `docker run`: in docker mode it builds the CGO/`fts5
 
 Every Playwright worker gets:
 
-- A unique backend port (`18080 + E2E_PORT_OFFSET * E2E_MAX_WORKERS + workerIndex`).
+- A unique backend port (`18080 + E2E_PORT_OFFSET * E2E_MAX_WORKERS + parallelIndex`).
   The backend also serves the SPA, so the frontend uses that same port.
 - A fresh tmpdir (`HOME`, `KANDEV_HOME_DIR`, worktree base, repo clone base — all under that tmpdir).
-- A unique agentctl instance port range (`30001 + E2E_PORT_OFFSET * 1000 + workerIndex * 200`).
+- A unique agentctl instance port range (`30001 + E2E_PORT_OFFSET * 1000 + parallelIndex * 200`).
 - Its own SQLite DB.
 - A process-scoped Docker ownership label for backend-created E2E containers
   and test-created SSH/storage fixtures. Cleanup and storage reporting filter

--- a/apps/web/e2e/README.md
+++ b/apps/web/e2e/README.md
@@ -182,8 +182,8 @@ Why a script instead of raw `docker run`: in docker mode it builds the CGO/`fts5
 
 Every Playwright worker gets:
 
-- A unique backend port in `BACKEND_BASE_PORT + workerIndex` (default `18080+`).
-- A unique frontend port in `FRONTEND_BASE_PORT + workerIndex` (default `13000+`).
+- A unique backend port (`18080 + E2E_PORT_OFFSET * E2E_MAX_WORKERS + workerIndex`).
+  The backend also serves the SPA, so the frontend uses that same port.
 - A fresh tmpdir (`HOME`, `KANDEV_HOME_DIR`, worktree base, repo clone base — all under that tmpdir).
 - A unique agentctl instance port range (`30001 + E2E_PORT_OFFSET * 1000 + workerIndex * 200`).
 - Its own SQLite DB.
@@ -192,9 +192,19 @@ Every Playwright worker gets:
   by that label and never sweep another shard's `kandev.managed=true`
   containers.
 
-Workers run in parallel across CI manifest shards; within a worker, tests run
-serially because the `testPage` fixture calls `e2eReset` on the shared backend
-before each test.
+Both port formulas are derived in `e2e/worker-ports.ts`, which reserves
+`E2E_MAX_WORKERS` slots per `E2E_PORT_OFFSET`. That stride is what lets the two
+axes coexist: `run-e2e.sh` gives concurrent local shards adjacent offsets, so
+without it offset _N_ worker 1 would land on the port offset _N+1_ worker 0 uses.
+
+Within a worker, tests run serially because the `testPage` fixture calls
+`e2eReset` on the shared backend before each test. Across workers, the unit of
+parallelism is the spec **file** (`fullyParallel: false`) — tests in one file
+never split across workers, so specs may keep relying on in-file ordering.
+
+Worker count comes from `E2E_WORKERS` (default 1, max `E2E_MAX_WORKERS`). CI's
+chromium/mobile-chrome shards set it to 2; the containers job leaves it unset
+because each of those workers also drives a real Docker daemon.
 
 Docker image usage remains daemon-wide because images and their layers are
 shared across shards; only container records, cleanup, and container-based

--- a/apps/web/e2e/backend-port-release.test.ts
+++ b/apps/web/e2e/backend-port-release.test.ts
@@ -1,0 +1,63 @@
+import net from "node:net";
+import { afterEach, describe, expect, it } from "vitest";
+import { waitForPortFree } from "./fixtures/backend";
+
+/**
+ * Guards the primitive the backend fixture relies on before rebinding a port.
+ *
+ * Playwright reuses a worker's `parallelIndex` when it replaces that worker
+ * after a failure, so the replacement rebinds the exact port its predecessor
+ * held. Spawning without waiting loses that race and exits the new backend with
+ * code 1, which took down a whole shard in CI.
+ */
+describe("waitForPortFree", () => {
+  const servers: net.Server[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      servers.splice(0).map((server) => new Promise((resolve) => server.close(resolve))),
+    );
+  });
+
+  async function listen(): Promise<number> {
+    const server = net.createServer(() => {});
+    servers.push(server);
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    return (server.address() as net.AddressInfo).port;
+  }
+
+  it("returns promptly when nothing holds the port", async () => {
+    const port = await listen();
+    await new Promise((resolve) => servers.splice(0)[0]!.close(resolve));
+
+    const started = Date.now();
+    await waitForPortFree(port, 5_000);
+    expect(Date.now() - started).toBeLessThan(1_000);
+  });
+
+  it("blocks while the port is held and resolves once it is released", async () => {
+    const port = await listen();
+    const holder = servers[0]!;
+
+    let released = false;
+    setTimeout(() => {
+      released = true;
+      holder.close();
+    }, 600);
+
+    await waitForPortFree(port, 10_000);
+    // The wait must have outlasted the holder rather than returning immediately.
+    expect(released).toBe(true);
+  });
+
+  it("gives up after the timeout so a leaked holder surfaces instead of hanging", async () => {
+    const port = await listen();
+
+    const started = Date.now();
+    await waitForPortFree(port, 700);
+    const elapsed = Date.now() - started;
+
+    expect(elapsed).toBeGreaterThanOrEqual(600);
+    expect(elapsed).toBeLessThan(5_000);
+  });
+});

--- a/apps/web/e2e/fixtures/backend.ts
+++ b/apps/web/e2e/fixtures/backend.ts
@@ -324,7 +324,10 @@ function spawnBackendProcess(
 export const backendFixture = base.extend<object, { backend: BackendContext }>({
   backend: [
     async ({ browserName: _browserName }, use, workerInfo) => {
-      const backendPort = backendPortFor(E2E_PORT_OFFSET, workerInfo.workerIndex);
+      // parallelIndex, not workerIndex: it is bounded by the worker count and
+      // the replacement process reuses it after a worker restart, so ports stay
+      // put across retries. See e2e/worker-ports.ts.
+      const backendPort = backendPortFor(E2E_PORT_OFFSET, workerInfo.parallelIndex);
       const frontendPort = backendPort;
       const tmpDir = fs.mkdtempSync(
         path.join(os.tmpdir(), `kandev-e2e-${workerInfo.workerIndex}-`),
@@ -353,7 +356,7 @@ export const backendFixture = base.extend<object, { backend: BackendContext }>({
         // See e2e/worker-ports.ts for the allocation and its budget assertion.
         const { base: agentctlPortBase, max: agentctlPortMax } = agentctlPortRangeFor(
           E2E_PORT_OFFSET,
-          workerInfo.workerIndex,
+          workerInfo.parallelIndex,
         );
 
         // Install a `git` shim that can sleep on `fetch`/`pull` before execing

--- a/apps/web/e2e/fixtures/backend.ts
+++ b/apps/web/e2e/fixtures/backend.ts
@@ -19,6 +19,11 @@ const WEB_DIST_DIR = path.join(WEB_DIR, "dist");
 // has to agree with it on how many worker slots each offset reserves.
 const E2E_PORT_OFFSET = parsePortOffset(process.env.E2E_PORT_OFFSET, process.pid);
 const HEALTH_TIMEOUT_MS = 30_000;
+// Generous because it is only ever paid when the port is genuinely still held:
+// a predecessor worker's backend shutting down releases it in well under a
+// second. If it does expire we spawn anyway and waitForHealth reports the bind
+// failure, so a leaked holder still surfaces rather than hanging the shard.
+const PORT_RELEASE_TIMEOUT_MS = 30_000;
 const HEALTH_POLL_MS = 250;
 
 /**
@@ -135,7 +140,7 @@ export async function waitForHealth(
  * OS may hold the port in TIME_WAIT for up to 60 s under heavy load, and
  * sleeping a fixed 2 s races against that window.
  */
-async function waitForPortFree(port: number, timeoutMs = 10_000): Promise<void> {
+export async function waitForPortFree(port: number, timeoutMs = 10_000): Promise<void> {
   const { createConnection } = await import("node:net");
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
@@ -460,6 +465,18 @@ export const backendFixture = base.extend<object, { backend: BackendContext }>({
         const scopedEnv = new BackendFixtureEnvOverrides();
 
         // --- Spawn backend ---
+        // Wait for the port before the *first* spawn too, not just in restart()
+        // below. When Playwright replaces a worker after a failure the new
+        // process keeps the same parallelIndex, so it rebinds the exact port its
+        // predecessor was using, and the predecessor's backend can still be
+        // shutting down. Losing that race exits the new backend with code 1 and
+        // takes down every test in the worker.
+        //
+        // This never happened while ports were derived from workerIndex, because
+        // each replacement drifted onto a fresh port — the same drift that made
+        // ports climb out of their range. Waiting here is what makes the stable
+        // parallelIndex slot safe to reuse.
+        await waitForPortFree(backendPort, PORT_RELEASE_TIMEOUT_MS);
         backendProc = spawnBackendProcess(scopedEnv.apply(baselineEnv), debug, backendPort);
         registerProcess(backendProc);
         await waitForHealth(`${baseUrl}/health`, HEALTH_TIMEOUT_MS, backendProc);

--- a/apps/web/e2e/fixtures/backend.ts
+++ b/apps/web/e2e/fixtures/backend.ts
@@ -19,11 +19,12 @@ const WEB_DIST_DIR = path.join(WEB_DIR, "dist");
 // has to agree with it on how many worker slots each offset reserves.
 const E2E_PORT_OFFSET = parsePortOffset(process.env.E2E_PORT_OFFSET, process.pid);
 const HEALTH_TIMEOUT_MS = 30_000;
-// Generous because it is only ever paid when the port is genuinely still held:
-// a predecessor worker's backend shutting down releases it in well under a
-// second. If it does expire we spawn anyway and waitForHealth reports the bind
-// failure, so a leaked holder still surfaces rather than hanging the shard.
-const PORT_RELEASE_TIMEOUT_MS = 30_000;
+// Must stay well under the 60 s fixture timeout minus HEALTH_TIMEOUT_MS: this
+// wait and the health wait run back to back, so 30 s here consumed the whole
+// budget and Playwright reported an opaque "fixture timeout" instead of the
+// backend's own boot error. A predecessor releases the port in well under a
+// second, so the shorter budget costs nothing real.
+const PORT_RELEASE_TIMEOUT_MS = 10_000;
 const HEALTH_POLL_MS = 250;
 
 /**
@@ -102,6 +103,33 @@ function observeProcessExit(proc?: ChildProcess): {
   };
 }
 
+/**
+ * Last lines the backend wrote before dying.
+ *
+ * Without this the fixture discarded backend output unless E2E_DEBUG was set,
+ * so a backend that exited during startup in CI reported only its exit code —
+ * enough to know something failed, never enough to know why. A boot failure you
+ * cannot reproduce locally is then pure guesswork.
+ */
+const recentBackendOutput = new WeakMap<ChildProcess, string[]>();
+const CAPTURED_OUTPUT_LINES = 40;
+
+function captureBackendOutput(proc: ChildProcess, chunk: Buffer): void {
+  const lines = recentBackendOutput.get(proc) ?? [];
+  for (const line of chunk.toString().split("\n")) {
+    if (line.trim()) lines.push(line.trimEnd());
+  }
+  if (lines.length > CAPTURED_OUTPUT_LINES) {
+    lines.splice(0, lines.length - CAPTURED_OUTPUT_LINES);
+  }
+  recentBackendOutput.set(proc, lines);
+}
+
+export function backendOutputTail(proc?: ChildProcess): string {
+  const lines = proc ? recentBackendOutput.get(proc) : undefined;
+  return lines?.length ? lines.join("\n") : "";
+}
+
 export async function waitForHealth(
   url: string,
   timeoutMs: number,
@@ -116,8 +144,12 @@ export async function waitForHealth(
         throw processExit.state.error;
       }
       if (processExit.state.exited) {
+        const tail = backendOutputTail(proc);
         throw new Error(
-          `Backend process exited with code ${processExit.state.exitCode} while waiting for health at ${url}`,
+          `Backend process exited with code ${processExit.state.exitCode} while waiting for health at ${url}\n` +
+            (tail
+              ? `Backend output before exit:\n${tail}`
+              : "Backend produced no output before exiting."),
         );
       }
       try {
@@ -304,12 +336,14 @@ function spawnBackendProcess(
     logFile?.end();
   });
   proc.stderr?.on("data", (chunk: Buffer) => {
+    captureBackendOutput(proc, chunk);
     if (debug) {
       process.stderr.write(`[backend:${port}] ${chunk.toString()}`);
       logFile?.write(chunk);
     }
   });
   proc.stdout?.on("data", (chunk: Buffer) => {
+    captureBackendOutput(proc, chunk);
     if (debug) {
       process.stderr.write(`[backend-log:${port}] ${chunk.toString()}`);
       logFile?.write(chunk);
@@ -466,16 +500,15 @@ export const backendFixture = base.extend<object, { backend: BackendContext }>({
 
         // --- Spawn backend ---
         // Wait for the port before the *first* spawn too, not just in restart()
-        // below. When Playwright replaces a worker after a failure the new
-        // process keeps the same parallelIndex, so it rebinds the exact port its
-        // predecessor was using, and the predecessor's backend can still be
-        // shutting down. Losing that race exits the new backend with code 1 and
-        // takes down every test in the worker.
+        // below. Playwright reuses a worker's parallelIndex when it replaces
+        // that worker, so the replacement rebinds the exact port its predecessor
+        // held; ports used to drift onto a fresh value on every restart, so this
+        // path could not previously collide. Same reasoning as restart()'s wait.
         //
-        // This never happened while ports were derived from workerIndex, because
-        // each replacement drifted onto a fresh port — the same drift that made
-        // ports climb out of their range. Waiting here is what makes the stable
-        // parallelIndex slot safe to reuse.
+        // Note this is a consistency guard, not a fix for any observed failure:
+        // an occupied port does not kill the backend, it just stops it becoming
+        // healthy. Cheap either way, since a free port returns in well under
+        // 100 ms.
         await waitForPortFree(backendPort, PORT_RELEASE_TIMEOUT_MS);
         backendProc = spawnBackendProcess(scopedEnv.apply(baselineEnv), debug, backendPort);
         registerProcess(backendProc);

--- a/apps/web/e2e/fixtures/backend.ts
+++ b/apps/web/e2e/fixtures/backend.ts
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { BackendFixtureEnvOverrides, createScopedEnvUse } from "./backend-env";
 import { E2E_DOCKER_SCOPE } from "./docker-probe";
+import { agentctlPortRangeFor, backendPortFor, parsePortOffset } from "../worker-ports";
 
 const BACKEND_DIR = path.resolve(__dirname, "../../../../apps/backend");
 const WEB_DIR = path.resolve(__dirname, "../..");
@@ -12,14 +13,11 @@ const WEB_DIR = path.resolve(__dirname, "../..");
 // the default artifact that `make build` provides for ordinary E2E runs.
 const KANDEV_BIN = process.env.KANDEV_E2E_BIN || path.join(BACKEND_DIR, "bin", "kandev");
 const WEB_DIST_DIR = path.join(WEB_DIR, "dist");
-// Auto-derive from PID if not explicitly set — prevents port clashes between concurrent test runs
-// Modulo 30 keeps agentctl ports under 65535 (30001 + 30*1000 = 60001 max)
-const rawPortOffset = process.env.E2E_PORT_OFFSET;
-const E2E_PORT_OFFSET = rawPortOffset === undefined ? process.pid % 30 : Number(rawPortOffset);
-if (!Number.isInteger(E2E_PORT_OFFSET) || E2E_PORT_OFFSET < 0 || E2E_PORT_OFFSET > 29) {
-  throw new Error(`E2E_PORT_OFFSET must be an integer 0-29, got: ${rawPortOffset}`);
-}
-const BACKEND_BASE_PORT = 18080 + E2E_PORT_OFFSET;
+// Auto-derive from PID if not explicitly set — prevents port clashes between concurrent test runs.
+// Modulo 30 keeps agentctl ports under 65535 (30001 + 30*1000 = 60001 max).
+// The offset→port math lives in e2e/worker-ports.ts because playwright.config.ts
+// has to agree with it on how many worker slots each offset reserves.
+const E2E_PORT_OFFSET = parsePortOffset(process.env.E2E_PORT_OFFSET, process.pid);
 const HEALTH_TIMEOUT_MS = 30_000;
 const HEALTH_POLL_MS = 250;
 
@@ -326,7 +324,7 @@ function spawnBackendProcess(
 export const backendFixture = base.extend<object, { backend: BackendContext }>({
   backend: [
     async ({ browserName: _browserName }, use, workerInfo) => {
-      const backendPort = BACKEND_BASE_PORT + workerInfo.workerIndex;
+      const backendPort = backendPortFor(E2E_PORT_OFFSET, workerInfo.workerIndex);
       const frontendPort = backendPort;
       const tmpDir = fs.mkdtempSync(
         path.join(os.tmpdir(), `kandev-e2e-${workerInfo.workerIndex}-`),
@@ -352,16 +350,11 @@ export const backendFixture = base.extend<object, { backend: BackendContext }>({
 
         // Give each worker its own agentctl port range, offset from the default
         // range (41001-41100) to avoid conflicts with a running dev instance.
-        // The async cleanup of agent instances runs after each test deletes its
-        // tasks, so during a 60+ test shard the in-flight cleanup queue can hold
-        // several dozen ports at any given moment. 200 ports per worker keeps
-        // headroom for that without overflowing the 65535 port space. With the
-        // current playwright config (workers: 1, so workerIndex == 0) and shard
-        // offsets capped at 29, the highest port used is 30001 + 29*1000 + 199
-        // = 59200. The `workerIndex * 200` term is defensive for the case where
-        // a future config sets workers > 1.
-        const agentctlPortBase = 30001 + E2E_PORT_OFFSET * 1000 + workerInfo.workerIndex * 200;
-        const agentctlPortMax = agentctlPortBase + 199;
+        // See e2e/worker-ports.ts for the allocation and its budget assertion.
+        const { base: agentctlPortBase, max: agentctlPortMax } = agentctlPortRangeFor(
+          E2E_PORT_OFFSET,
+          workerInfo.workerIndex,
+        );
 
         // Install a `git` shim that can sleep on `fetch`/`pull` before execing
         // the real git binary. Tests that need to simulate slow network git

--- a/apps/web/e2e/playwright.config.ts
+++ b/apps/web/e2e/playwright.config.ts
@@ -115,12 +115,15 @@ export default defineConfig({
       testMatch: [/docker\/.*\.spec\.ts/, /ssh\/.*\.spec\.ts/],
       use: { ...devices["Desktop Chrome"] },
       timeout: 180_000,
-      // Local `--shard=N/6` runs split this project by file, as CI does with
-      // the duration-aware containers manifests. Each CI shard is its own
-      // process, and the containers job deliberately leaves E2E_WORKERS unset
-      // (workers: 1) — these tests build images and run real containers, so a
-      // second worker contends for the Docker daemon for no critical-path gain.
-      fullyParallel: false,
+      // Single-worker operation for this project is enforced by the CI job, not
+      // here: `workers` is a top-level Playwright option with no per-project
+      // form, so the contract is the containers job leaving E2E_WORKERS unset.
+      // These tests build images and drive real containers, where a second
+      // worker contends for the Docker daemon for no critical-path gain.
+      //
+      // Parallelism granularity is inherited from the top-level
+      // `fullyParallel: false`, so local `--shard=N/6` runs split this project
+      // by file, matching the duration-aware containers manifests CI uses.
     },
   ],
 

--- a/apps/web/e2e/playwright.config.ts
+++ b/apps/web/e2e/playwright.config.ts
@@ -1,18 +1,33 @@
 import { defineConfig, devices } from "@playwright/test";
+import { resolveWorkerCount } from "./worker-ports";
 
 const CI = !!process.env.CI;
 
 export default defineConfig({
   testDir: "./tests",
-  // `fullyParallel: true` keeps direct local `--shard=N/M` runs at test level.
-  // CI uses explicit duration-aware file manifests from e2e/scripts instead;
-  // this setting preserves the existing local debugging behavior.
+  // The file is the unit of parallelism: different files run concurrently
+  // across workers, tests inside one file stay serial and in order on a single
+  // worker.
   //
-  // Concurrency is still capped by `workers: 1` below — only one test runs at a
-  // time per shard process, preserving the worker-scoped backend invariant that
-  // the testPage fixture relies on (e2eReset before each test on a shared
-  // backend). `fullyParallel: true` alone does not introduce intra-shard
-  // parallelism unless workers > 1.
+  // This was `true` while `workers: 1` pinned everything to one worker, so
+  // test-level splitting never actually happened and no spec has ever had to
+  // prove its tests are order-independent. Turning on a second worker with
+  // `fullyParallel: true` would have cashed that unverified assumption across
+  // all ~640 specs at once, and — because CI keeps `failOnFlakyTests` off —
+  // any order-dependence would have surfaced as a test that passes on retry
+  // rather than as an honest failure. File-level parallelism gets the same
+  // wall-clock win with today's semantics intact, and it matches how the
+  // duration-aware planner already reasons (it packs shards by file).
+  //
+  // Intra-shard concurrency is set by `workers` below (default 1, opt in via
+  // E2E_WORKERS). The worker-scoped backend invariant the testPage fixture
+  // relies on (e2eReset before each test on a shared backend) holds at any
+  // worker count: the fixture gives every worker its own backend process,
+  // port, agentctl range, HOME, tmpdir, and database, so tests only ever share
+  // a backend with others on the same worker — which Playwright runs serially.
+  // `beforeAll`/`afterAll` specs that call `backend.restart()` stay correct
+  // too: Playwright brackets those hooks per file per worker, and each worker
+  // restarts only its own backend.
   //
   // Isolation strategy: office-routing-* specs are gathered into their own
   // Playwright project (see below) so the worker-scoped backend env
@@ -21,11 +36,16 @@ export default defineConfig({
   // topbar agent name. Each routing spec restarts the backend back to
   // baseline in `afterAll` (see backend.restart() — no args = revert to
   // the fixture's baseline env snapshot).
-  fullyParallel: true,
+  fullyParallel: false,
   forbidOnly: CI,
   failOnFlakyTests: !CI || process.env.E2E_FAIL_ON_FLAKY === "1",
   retries: CI ? 2 : 0,
-  workers: 1,
+  // Each worker costs a backend process plus a browser, so this is bounded by
+  // runner CPU/RAM rather than by test isolation. CI's chromium/mobile-chrome
+  // shards set E2E_WORKERS=2 (4 vCPU / 16 GB runners); the container-backed
+  // project and local runs stay at 1 unless explicitly opted in, since each of
+  // those workers also drives real Docker containers.
+  workers: resolveWorkerCount(process.env.E2E_WORKERS),
   timeout: 60_000,
   // CI uses blob reporter for cross-shard merge-reports; local uses list.
   reporter: CI ? [["blob", { outputDir: "./blob-report" }]] : "list",
@@ -95,11 +115,12 @@ export default defineConfig({
       testMatch: [/docker\/.*\.spec\.ts/, /ssh\/.*\.spec\.ts/],
       use: { ...devices["Desktop Chrome"] },
       timeout: 180_000,
-      // Local `--shard=N/6` runs can still split this project at test level.
-      // CI uses explicit files from the duration-aware containers manifests.
-      // Each CI shard is its own process, and workers:1 still serializes tests
-      // within a shard, so the worker-scoped backend remains safe.
-      fullyParallel: true,
+      // Local `--shard=N/6` runs split this project by file, as CI does with
+      // the duration-aware containers manifests. Each CI shard is its own
+      // process, and the containers job deliberately leaves E2E_WORKERS unset
+      // (workers: 1) — these tests build images and run real containers, so a
+      // second worker contends for the Docker daemon for no critical-path gain.
+      fullyParallel: false,
     },
   ],
 

--- a/apps/web/e2e/worker-ports.test.ts
+++ b/apps/web/e2e/worker-ports.test.ts
@@ -38,7 +38,7 @@ describe("backendPortFor", () => {
   // The regression this guards: with a stride of 1, offset N worker 1 landed on
   // the same port as offset N+1 worker 0, so run-e2e.sh's adjacent-offset local
   // shards collided the moment a shard ran more than one worker.
-  it("assigns a unique port to every offset/worker slot", () => {
+  it("assigns a unique port to every offset/parallel slot", () => {
     const ports = SLOTS.map(({ offset, worker }) => backendPortFor(offset, worker));
     expect(new Set(ports).size).toBe(SLOTS.length);
   });
@@ -52,9 +52,23 @@ describe("backendPortFor", () => {
     expect(backendPortFor(MAX_PORT_OFFSET, E2E_MAX_WORKERS - 1)).toBeLessThan(65_536);
   });
 
-  it("rejects a worker index beyond the reserved slots", () => {
-    expect(() => backendPortFor(0, E2E_MAX_WORKERS)).toThrow(/workerIndex/);
-    expect(() => backendPortFor(0, -1)).toThrow(/workerIndex/);
+  it("rejects a parallel index beyond the reserved slots", () => {
+    expect(() => backendPortFor(0, E2E_MAX_WORKERS)).toThrow(/parallelIndex/);
+    expect(() => backendPortFor(0, -1)).toThrow(/parallelIndex/);
+  });
+
+  // Playwright's `workerIndex` counts every worker process a run creates, so a
+  // shard with failures walks it past the reserved slots (CI shard 11 reached
+  // 321). Only `parallelIndex` is bounded and reused after a restart. Passing
+  // the wrong one has to fail loudly rather than hand back a drifting port
+  // that climbs into another offset's range and then past 65535.
+  it("refuses a restart-incremented index instead of drifting the port", () => {
+    for (const restartedIndex of [E2E_MAX_WORKERS, 12, 321]) {
+      expect(() => backendPortFor(0, restartedIndex)).toThrow(/parallelIndex/);
+      expect(() => agentctlPortRangeFor(0, restartedIndex)).toThrow(/parallelIndex/);
+    }
+    // What the unguarded math would have produced for that last index.
+    expect(30_001 + 321 * 200).toBeGreaterThan(65_535);
   });
 
   it("rejects an out-of-range offset", () => {

--- a/apps/web/e2e/worker-ports.test.ts
+++ b/apps/web/e2e/worker-ports.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import {
+  agentctlPortRangeFor,
+  backendPortFor,
+  E2E_MAX_WORKERS,
+  MAX_PORT_OFFSET,
+  parsePortOffset,
+  resolveWorkerCount,
+} from "./worker-ports";
+
+const OFFSETS = Array.from({ length: MAX_PORT_OFFSET + 1 }, (_, index) => index);
+const WORKERS = Array.from({ length: E2E_MAX_WORKERS }, (_, index) => index);
+const SLOTS = OFFSETS.flatMap((offset) => WORKERS.map((worker) => ({ offset, worker })));
+
+describe("parsePortOffset", () => {
+  it("derives an in-range offset from the pid when unset", () => {
+    expect(parsePortOffset(undefined, 12_345)).toBe(12_345 % (MAX_PORT_OFFSET + 1));
+    expect(parsePortOffset(undefined, 0)).toBe(0);
+  });
+
+  it("accepts explicit offsets across the whole range", () => {
+    expect(parsePortOffset("0", 1)).toBe(0);
+    expect(parsePortOffset(String(MAX_PORT_OFFSET), 1)).toBe(MAX_PORT_OFFSET);
+  });
+
+  it.each(["-1", String(MAX_PORT_OFFSET + 1), "1.5", "abc"])("rejects %s", (raw) => {
+    expect(() => parsePortOffset(raw, 1)).toThrow(/E2E_PORT_OFFSET/);
+  });
+
+  // Pre-existing behaviour, kept deliberately: an exported-but-empty
+  // E2E_PORT_OFFSET is `Number("") === 0`, not a pid-derived offset.
+  it("treats an empty offset as 0 rather than unset", () => {
+    expect(parsePortOffset("", 12_345)).toBe(0);
+  });
+});
+
+describe("backendPortFor", () => {
+  // The regression this guards: with a stride of 1, offset N worker 1 landed on
+  // the same port as offset N+1 worker 0, so run-e2e.sh's adjacent-offset local
+  // shards collided the moment a shard ran more than one worker.
+  it("assigns a unique port to every offset/worker slot", () => {
+    const ports = SLOTS.map(({ offset, worker }) => backendPortFor(offset, worker));
+    expect(new Set(ports).size).toBe(SLOTS.length);
+  });
+
+  it("keeps adjacent offsets from overlapping", () => {
+    expect(backendPortFor(0, E2E_MAX_WORKERS - 1)).toBeLessThan(backendPortFor(1, 0));
+  });
+
+  it("stays inside the valid port space", () => {
+    expect(backendPortFor(0, 0)).toBe(18080);
+    expect(backendPortFor(MAX_PORT_OFFSET, E2E_MAX_WORKERS - 1)).toBeLessThan(65_536);
+  });
+
+  it("rejects a worker index beyond the reserved slots", () => {
+    expect(() => backendPortFor(0, E2E_MAX_WORKERS)).toThrow(/workerIndex/);
+    expect(() => backendPortFor(0, -1)).toThrow(/workerIndex/);
+  });
+
+  it("rejects an out-of-range offset", () => {
+    expect(() => backendPortFor(MAX_PORT_OFFSET + 1, 0)).toThrow(/portOffset/);
+  });
+});
+
+describe("agentctlPortRangeFor", () => {
+  it("gives every slot a disjoint range", () => {
+    const ranges = SLOTS.map(({ offset, worker }) => agentctlPortRangeFor(offset, worker)).sort(
+      (a, b) => a.base - b.base,
+    );
+    for (let index = 1; index < ranges.length; index += 1) {
+      expect(ranges[index]!.base).toBeGreaterThan(ranges[index - 1]!.max);
+    }
+  });
+
+  it("never overlaps the backend port range", () => {
+    const lowestAgentctl = agentctlPortRangeFor(0, 0).base;
+    const highestBackend = backendPortFor(MAX_PORT_OFFSET, E2E_MAX_WORKERS - 1);
+    expect(lowestAgentctl).toBeGreaterThan(highestBackend);
+  });
+
+  it("stays inside the valid port space", () => {
+    expect(agentctlPortRangeFor(0, 0)).toEqual({ base: 30_001, max: 30_200 });
+    expect(agentctlPortRangeFor(MAX_PORT_OFFSET, E2E_MAX_WORKERS - 1).max).toBeLessThan(65_536);
+  });
+});
+
+describe("resolveWorkerCount", () => {
+  it("defaults to a single worker", () => {
+    expect(resolveWorkerCount(undefined)).toBe(1);
+    expect(resolveWorkerCount("  ")).toBe(1);
+  });
+
+  it("accepts counts up to the reserved slot count", () => {
+    expect(resolveWorkerCount("2")).toBe(2);
+    expect(resolveWorkerCount(String(E2E_MAX_WORKERS))).toBe(E2E_MAX_WORKERS);
+  });
+
+  it.each(["0", "-1", "2.5", "many", String(E2E_MAX_WORKERS + 1)])("rejects %s", (raw) => {
+    expect(() => resolveWorkerCount(raw)).toThrow(/E2E_WORKERS/);
+  });
+});

--- a/apps/web/e2e/worker-ports.ts
+++ b/apps/web/e2e/worker-ports.ts
@@ -7,13 +7,21 @@
  *   - `E2E_PORT_OFFSET` (0-29) separates concurrent *processes*.
  *     `e2e/scripts/run-e2e.sh` launches local host shards with adjacent
  *     offsets, and an unset offset falls back to `pid % 30`.
- *   - `workerIndex` separates Playwright workers *inside* one process.
+ *   - `parallelIndex` separates Playwright workers *inside* one process.
  *
  * Reserving `E2E_MAX_WORKERS` slots per offset is what keeps the two apart.
- * Without the stride, `18080 + offset + workerIndex` puts offset N worker 1 on
+ * Without the stride, `18080 + offset + parallelIndex` puts offset N worker 1 on
  * the exact port offset N+1 worker 0 uses — harmless while `workers: 1` made
  * the second term always zero, but a real collision as soon as a shard runs
  * more than one worker.
+ *
+ * Callers must pass Playwright's `parallelIndex`, never `workerIndex`. Only
+ * `parallelIndex` is bounded by `0..workers-1` and reused by the replacement
+ * process when a worker is restarted after a failure; `workerIndex` is a
+ * monotonic counter over every worker process the run ever creates. Feeding
+ * `workerIndex` in here means the ports drift upward on every retry — with a
+ * failing shard it climbs into other offsets' ranges and eventually past
+ * 65535, which is exactly what `assertSlot` below now refuses to do silently.
  */
 
 /**
@@ -52,34 +60,34 @@ export function parsePortOffset(raw: string | undefined, pid: number): number {
   return offset;
 }
 
-function assertSlot(portOffset: number, workerIndex: number): void {
+function assertSlot(portOffset: number, parallelIndex: number): void {
   if (!Number.isInteger(portOffset) || portOffset < 0 || portOffset > MAX_PORT_OFFSET) {
     throw new Error(`portOffset must be an integer 0-${MAX_PORT_OFFSET}, got: ${portOffset}`);
   }
-  if (!Number.isInteger(workerIndex) || workerIndex < 0 || workerIndex >= E2E_MAX_WORKERS) {
+  if (!Number.isInteger(parallelIndex) || parallelIndex < 0 || parallelIndex >= E2E_MAX_WORKERS) {
     throw new Error(
-      `workerIndex must be an integer 0-${E2E_MAX_WORKERS - 1}, got: ${workerIndex}. ` +
+      `parallelIndex must be an integer 0-${E2E_MAX_WORKERS - 1}, got: ${parallelIndex}. ` +
         `Raise E2E_MAX_WORKERS in e2e/worker-ports.ts to run more workers per shard.`,
     );
   }
 }
 
 /** The backend (and, since they share a port, frontend) port for one worker. */
-export function backendPortFor(portOffset: number, workerIndex: number): number {
-  assertSlot(portOffset, workerIndex);
-  return BACKEND_PORT_FLOOR + portOffset * E2E_MAX_WORKERS + workerIndex;
+export function backendPortFor(portOffset: number, parallelIndex: number): number {
+  assertSlot(portOffset, parallelIndex);
+  return BACKEND_PORT_FLOOR + portOffset * E2E_MAX_WORKERS + parallelIndex;
 }
 
 /** The inclusive agentctl instance port range for one worker. */
 export function agentctlPortRangeFor(
   portOffset: number,
-  workerIndex: number,
+  parallelIndex: number,
 ): { base: number; max: number } {
-  assertSlot(portOffset, workerIndex);
+  assertSlot(portOffset, parallelIndex);
   const base =
     AGENTCTL_PORT_FLOOR +
     portOffset * AGENTCTL_PORTS_PER_OFFSET +
-    workerIndex * AGENTCTL_PORTS_PER_WORKER;
+    parallelIndex * AGENTCTL_PORTS_PER_WORKER;
   return { base, max: base + AGENTCTL_PORTS_PER_WORKER - 1 };
 }
 

--- a/apps/web/e2e/worker-ports.ts
+++ b/apps/web/e2e/worker-ports.ts
@@ -1,0 +1,99 @@
+/**
+ * Port allocation shared by `playwright.config.ts` and the worker-scoped
+ * backend fixture.
+ *
+ * Two independent axes have to stay collision-free:
+ *
+ *   - `E2E_PORT_OFFSET` (0-29) separates concurrent *processes*.
+ *     `e2e/scripts/run-e2e.sh` launches local host shards with adjacent
+ *     offsets, and an unset offset falls back to `pid % 30`.
+ *   - `workerIndex` separates Playwright workers *inside* one process.
+ *
+ * Reserving `E2E_MAX_WORKERS` slots per offset is what keeps the two apart.
+ * Without the stride, `18080 + offset + workerIndex` puts offset N worker 1 on
+ * the exact port offset N+1 worker 0 uses — harmless while `workers: 1` made
+ * the second term always zero, but a real collision as soon as a shard runs
+ * more than one worker.
+ */
+
+/**
+ * Worker slots reserved per port offset. Raising this widens the stride for
+ * every offset, so it must stay within the agentctl budget asserted below.
+ */
+export const E2E_MAX_WORKERS = 4;
+
+/** `E2E_PORT_OFFSET` is validated to this inclusive range. */
+export const MAX_PORT_OFFSET = 29;
+
+const BACKEND_PORT_FLOOR = 18080;
+
+// agentctl ranges start above the dev instance default (41001-41100) and are
+// offset far from the backend ports. The async cleanup of agent instances runs
+// after each test deletes its tasks, so during a long shard the in-flight
+// cleanup queue can hold several dozen ports at once; 200 per worker keeps
+// headroom for that.
+const AGENTCTL_PORT_FLOOR = 30001;
+const AGENTCTL_PORTS_PER_OFFSET = 1000;
+const AGENTCTL_PORTS_PER_WORKER = 200;
+
+// A worker's agentctl range must not spill into the next offset's block.
+if (E2E_MAX_WORKERS * AGENTCTL_PORTS_PER_WORKER > AGENTCTL_PORTS_PER_OFFSET) {
+  throw new Error(
+    `E2E_MAX_WORKERS=${E2E_MAX_WORKERS} needs ${E2E_MAX_WORKERS * AGENTCTL_PORTS_PER_WORKER} ` +
+      `agentctl ports per offset, but only ${AGENTCTL_PORTS_PER_OFFSET} are reserved`,
+  );
+}
+
+export function parsePortOffset(raw: string | undefined, pid: number): number {
+  const offset = raw === undefined ? pid % (MAX_PORT_OFFSET + 1) : Number(raw);
+  if (!Number.isInteger(offset) || offset < 0 || offset > MAX_PORT_OFFSET) {
+    throw new Error(`E2E_PORT_OFFSET must be an integer 0-${MAX_PORT_OFFSET}, got: ${raw}`);
+  }
+  return offset;
+}
+
+function assertSlot(portOffset: number, workerIndex: number): void {
+  if (!Number.isInteger(portOffset) || portOffset < 0 || portOffset > MAX_PORT_OFFSET) {
+    throw new Error(`portOffset must be an integer 0-${MAX_PORT_OFFSET}, got: ${portOffset}`);
+  }
+  if (!Number.isInteger(workerIndex) || workerIndex < 0 || workerIndex >= E2E_MAX_WORKERS) {
+    throw new Error(
+      `workerIndex must be an integer 0-${E2E_MAX_WORKERS - 1}, got: ${workerIndex}. ` +
+        `Raise E2E_MAX_WORKERS in e2e/worker-ports.ts to run more workers per shard.`,
+    );
+  }
+}
+
+/** The backend (and, since they share a port, frontend) port for one worker. */
+export function backendPortFor(portOffset: number, workerIndex: number): number {
+  assertSlot(portOffset, workerIndex);
+  return BACKEND_PORT_FLOOR + portOffset * E2E_MAX_WORKERS + workerIndex;
+}
+
+/** The inclusive agentctl instance port range for one worker. */
+export function agentctlPortRangeFor(
+  portOffset: number,
+  workerIndex: number,
+): { base: number; max: number } {
+  assertSlot(portOffset, workerIndex);
+  const base =
+    AGENTCTL_PORT_FLOOR +
+    portOffset * AGENTCTL_PORTS_PER_OFFSET +
+    workerIndex * AGENTCTL_PORTS_PER_WORKER;
+  return { base, max: base + AGENTCTL_PORTS_PER_WORKER - 1 };
+}
+
+/**
+ * Workers per shard process. Defaults to 1 so local runs and the
+ * container-backed project (which drives a real Docker daemon per worker) keep
+ * their existing single-worker behaviour; CI's chromium/mobile-chrome shards
+ * opt in via `E2E_WORKERS`.
+ */
+export function resolveWorkerCount(raw: string | undefined): number {
+  if (raw === undefined || raw.trim() === "") return 1;
+  const workers = Number(raw);
+  if (!Number.isInteger(workers) || workers < 1 || workers > E2E_MAX_WORKERS) {
+    throw new Error(`E2E_WORKERS must be an integer 1-${E2E_MAX_WORKERS}, got: ${raw}`);
+  }
+  return workers;
+}


### PR DESCRIPTION
Picks up the remaining items from the CI build-time analysis, now that duration-aware shard packing (#2489) removed the dominant imbalance.

**Ships: Go build cache in the e2e `build` job.** That job had no Go cache at all, so the backend compiled from a cold module and build cache on every run. This adds the block `backend-tests.yml` already uses, keyed the same way.

| Build job | |
|---|---|
| main baseline (two runs) | 6m18s / 6m36s |
| this PR, warm cache | **2m36s** |

Note GitHub scopes PR-branch caches to the branch, so other PRs only benefit once this lands on main and main's e2e workflow populates the key.

**Parked: two Playwright workers per shard.** The plumbing all ships, but the workflow leaves `E2E_WORKERS` at its default of 1. Flip it to `"2"` to resume.

It worked, and it was worth ~30%: shard time went from ~11m to ~7m across all 14. But every shard also hit exactly one `Backend process exited with code 1` during a worker's backend boot, in 14/14 shards on two consecutive runs, against **zero** occurrences on main at one worker. Flaky went 4 → 18 and one shard failed outright.

The cause is not identified, and it is **not** port reuse. Pinning the port slot to `parallelIndex` and waiting for release before rebinding left the count unchanged; holding a port shows an occupied port does not kill the backend, it only stops it becoming healthy; and two backends start fine side by side locally. Rather than ship a suite that is quietly 4x flakier, the experiment is parked until the actual reason is known.

**Also ships, and makes that diagnosable:** `waitForHealth` now reports the backend's own last output when the process exits. The fixture previously discarded backend stdout/stderr unless `E2E_DEBUG` was set, which is exactly why a boot failure that does not reproduce locally left nothing to go on.

**Supporting changes**

- Port derivation moves to `e2e/worker-ports.ts`, reserving `E2E_MAX_WORKERS` slots per `E2E_PORT_OFFSET` and shared with `playwright.config.ts`. It uses Playwright's `parallelIndex`, not `workerIndex`: only `parallelIndex` is bounded by `0..workers-1` and reused after a worker restart. The old `workerIndex` math drifted ports upward on every retry, walking into neighbouring offsets' ranges and eventually past 65535 — latent before, since `workers: 1` pinned the term to zero.
- `fullyParallel` is now `false`. It was `true`, but `workers: 1` meant test-level splitting never happened, so no spec has ever had to prove its tests are order-independent. With `failOnFlakyTests` off in CI, any order-dependence would surface as a pass-on-retry rather than a failure. File-level parallelism matches how the shard planner already packs.

## Validation

- Full green run at one worker: 14/14 shards, 0 failed, **3 flaky** (main baseline 4), **0** backend-exit occurrences
- `pnpm test -- e2e/` — 12 files, 68 passed
- `worker-ports` tests mutation-checked: restoring the old `portOffset + workerIndex` math fails the uniqueness and adjacent-offset assertions
- `waitForPortFree` tests mutation-checked: stubbing it to return immediately fails 2 of 3
- Backend-output-on-exit path verified end to end by holding the port until boot failed
- `pnpm run typecheck`, targeted ESLint, Prettier, YAML parse, `lint-action-pinning.py` + its 9 unit tests, `git diff --check` all pass
- `zizmor` not installed locally and not run; this diff adds no permissions, secrets, or untrusted-ref checkout

## Follow-ups

- Diagnose the two-worker backend boot failure using the new output capture, on a throwaway branch. Worth ~4 minutes per E2E run.
- Queue is now a first-class constraint: shards waited up to 6m34s for runners on a contended run. Once two workers is settled, cutting the shard count from 14 trades that queue pressure for runner minutes at equal wall clock.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have manually tested my changes and they work as expected.
- [x] My changes have tests that cover the new functionality and edge cases.
- [x] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [x] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.

No `docs/public/**` change needed: CI and test-harness configuration with no user-facing surface. `apps/web/e2e/README.md` is updated alongside.