### PR TITLE
fix(web): align task confirmation copy

### DIFF
--- a/apps/web/components/task/task-archive-confirm-dialog.tsx
+++ b/apps/web/components/task/task-archive-confirm-dialog.tsx
@@ -18,7 +18,11 @@ import { useSubtaskCount } from "@/hooks/use-subtask-count";
 import { useTaskInFlight } from "@/hooks/use-task-in-flight";
 import { getCleanupSummary, getBulkCleanupSummary } from "./task-cleanup-summary";
 import { StillWorkingWarning } from "./task-still-working-warning";
-import { TASK_CONFIRM_CLASS, stopDialogPropagation } from "./task-confirm-dialog-shared";
+import {
+  TASK_CONFIRM_CLASS,
+  TASK_CONFIRM_HEADER_CLASS,
+  stopDialogPropagation,
+} from "./task-confirm-dialog-shared";
 import { useTranslation } from "react-i18next";
 
 type TaskArchiveConfirmDialogProps = {
@@ -131,7 +135,7 @@ export function TaskArchiveConfirmDialog({
   return (
     <AlertDialog open={open} onOpenChange={handleOpenChange}>
       <AlertDialogContent size="lg" className={TASK_CONFIRM_CLASS} onClick={stopDialogPropagation}>
-        <AlertDialogHeader>
+        <AlertDialogHeader className={TASK_CONFIRM_HEADER_CLASS}>
           <AlertDialogTitle className="text-base font-semibold">{title}</AlertDialogTitle>
           <AlertDialogDescription asChild className="text-sm leading-6">
             <div>

--- a/apps/web/components/task/task-confirm-dialog-shared.ts
+++ b/apps/web/components/task/task-confirm-dialog-shared.ts
@@ -1,4 +1,5 @@
 import type { MouseEvent } from "react";
 
 export const TASK_CONFIRM_CLASS = "font-sans !text-sm";
+export const TASK_CONFIRM_HEADER_CLASS = "place-items-start text-left";
 export const stopDialogPropagation = (event: MouseEvent<HTMLDivElement>) => event.stopPropagation();

--- a/apps/web/components/task/task-delete-confirm-dialog.tsx
+++ b/apps/web/components/task/task-delete-confirm-dialog.tsx
@@ -17,7 +17,11 @@ import { useSubtaskCount } from "@/hooks/use-subtask-count";
 import { useTaskInFlight } from "@/hooks/use-task-in-flight";
 import { getCleanupSummary, getBulkCleanupSummary } from "./task-cleanup-summary";
 import { StillWorkingWarning } from "./task-still-working-warning";
-import { TASK_CONFIRM_CLASS, stopDialogPropagation } from "./task-confirm-dialog-shared";
+import {
+  TASK_CONFIRM_CLASS,
+  TASK_CONFIRM_HEADER_CLASS,
+  stopDialogPropagation,
+} from "./task-confirm-dialog-shared";
 import { useTranslation } from "react-i18next";
 
 type TaskDeleteConfirmDialogProps = {
@@ -77,7 +81,7 @@ export function TaskDeleteConfirmDialog({
   return (
     <AlertDialog open={open} onOpenChange={handleOpenChange}>
       <AlertDialogContent size="lg" className={TASK_CONFIRM_CLASS} onClick={stopDialogPropagation}>
-        <AlertDialogHeader>
+        <AlertDialogHeader className={TASK_CONFIRM_HEADER_CLASS}>
           <AlertDialogTitle className="text-base font-semibold">{title}</AlertDialogTitle>
           <AlertDialogDescription asChild className="text-sm leading-6">
             <div>

--- a/apps/web/e2e/tests/kanban/card-menu-delete-archive.spec.ts
+++ b/apps/web/e2e/tests/kanban/card-menu-delete-archive.spec.ts
@@ -33,6 +33,15 @@ test.describe("Kanban card actions menu — delete/archive does not navigate", (
     if (!dialogBox) throw new Error("delete confirmation dialog has no layout box");
     expect(dialogBox.width).toBeGreaterThanOrEqual(480);
     await expect(dialog).toHaveClass(/font-sans/);
+    const deleteHeader = dialog.locator('[data-slot="alert-dialog-header"]');
+    await expect
+      .poll(async () =>
+        deleteHeader.evaluate((element) => {
+          const style = getComputedStyle(element);
+          return { justifyItems: style.justifyItems, textAlign: style.textAlign };
+        }),
+      )
+      .toEqual({ justifyItems: "start", textAlign: "left" });
 
     // URL must not have changed (no navigation to /tasks/:id and no ?taskId=)
     expect(testPage.url()).toBe(startUrl);
@@ -65,6 +74,15 @@ test.describe("Kanban card actions menu — delete/archive does not navigate", (
     if (!dialogBox) throw new Error("archive confirmation dialog has no layout box");
     expect(dialogBox.width).toBeGreaterThanOrEqual(480);
     await expect(dialog).toHaveClass(/font-sans/);
+    const archiveHeader = dialog.locator('[data-slot="alert-dialog-header"]');
+    await expect
+      .poll(async () =>
+        archiveHeader.evaluate((element) => {
+          const style = getComputedStyle(element);
+          return { justifyItems: style.justifyItems, textAlign: style.textAlign };
+        }),
+      )
+      .toEqual({ justifyItems: "start", textAlign: "left" });
 
     expect(testPage.url()).toBe(startUrl);
   });

--- a/apps/web/e2e/tests/task/mobile-sidebar-task-actions.spec.ts
+++ b/apps/web/e2e/tests/task/mobile-sidebar-task-actions.spec.ts
@@ -139,6 +139,15 @@ test.describe("Mobile sidebar task actions", () => {
     const dialog = testPage.getByRole("alertdialog");
     await expect(dialog).toBeVisible();
     await expect(dialog).toHaveClass(/font-sans/);
+    const header = dialog.locator('[data-slot="alert-dialog-header"]');
+    await expect
+      .poll(async () =>
+        header.evaluate((element) => {
+          const style = getComputedStyle(element);
+          return { justifyItems: style.justifyItems, textAlign: style.textAlign };
+        }),
+      )
+      .toEqual({ justifyItems: "start", textAlign: "left" });
     await expect(dialog.locator('[data-slot="alert-dialog-description"]')).toHaveClass(/text-sm/);
     await dialog.evaluate(async (element) => {
       await Promise.all(


### PR DESCRIPTION
Task confirmation dialogs inherited centered header styles that made longer warning copy harder to scan; the shared task dialogs now use a consistent left-aligned content hierarchy while retaining right-aligned desktop actions and mobile stacking.

## Validation

- `pnpm test -- --run components/task/task-delete-confirm-dialog.test.tsx components/task/task-archive-confirm-dialog.test.tsx`
- `pnpm run typecheck`
- `pnpm exec eslint components/task/task-confirm-dialog-shared.ts components/task/task-delete-confirm-dialog.tsx components/task/task-archive-confirm-dialog.tsx e2e/tests/kanban/card-menu-delete-archive.spec.ts e2e/tests/task/mobile-sidebar-task-actions.spec.ts`
- Desktop delete and archive confirmation E2E tests passed.
- Mobile archive confirmation E2E test passed on the mobile-chrome project.
- Fresh desktop and mobile PR captures were manually inspected.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2625?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- kandev-screenshots-start -->
## Screenshots

![Desktop task delete confirmation](https://raw.githubusercontent.com/kdlbs/kandev/04bde38e4fc0c2dc5d74ecb6269f66fb4d1eb164/task-delete-dialog-desktop.png)

![Mobile task archive confirmation](https://raw.githubusercontent.com/kdlbs/kandev/04bde38e4fc0c2dc5d74ecb6269f66fb4d1eb164/archive-task-dialog-mobile.png)
<!-- kandev-screenshots-end -->