### PR TITLE
fix: verify provider history ordering and retry

### DIFF
--- a/apps/backend/internal/github/mock_client.go
+++ b/apps/backend/internal/github/mock_client.go
@@ -98,27 +98,28 @@ type MockClient struct {
 	// `github_not_configured`. Used by e2e tests that need to verify the
 	// "Connect GitHub" banner in the Remote-tab chip popover without ripping
 	// the whole mock client out of the wiring.
-	reposUnavailable bool
-	prs              map[prKey]*PR
-	issues           map[issueKey]*Issue
-	prsByBranch      map[branchKey]*PR
-	orgs             []GitHubOrg
-	repos            map[string][]GitHubRepo
-	branches         map[repoKey][]RepoBranch
-	reviews          map[prKey][]PRReview
-	comments         map[prKey][]PRComment
-	checks           map[checkKey][]CheckRun
-	files            map[prKey][]PRFile
-	commits          map[prKey][]PRCommitInfo
-	commitDetails    map[commitDetailKey]PRCommitDetail
-	submittedReviews []submittedReview
-	requestedReviews []requestedReviewers
-	mergedPRs        []mergedPR
-	mergeMethods     map[repoKey]RepoMergeMethods
-	gists            map[string]mockGist
-	deletedGists     []string
-	nextGistID       int
-	repoFiles        map[repoKey][]repoFileEntry
+	reposUnavailable  bool
+	prs               map[prKey]*PR
+	issues            map[issueKey]*Issue
+	prsByBranch       map[branchKey]*PR
+	orgs              []GitHubOrg
+	repos             map[string][]GitHubRepo
+	branches          map[repoKey][]RepoBranch
+	reviews           map[prKey][]PRReview
+	comments          map[prKey][]PRComment
+	checks            map[checkKey][]CheckRun
+	files             map[prKey][]PRFile
+	commits           map[prKey][]PRCommitInfo
+	prCommitsFailures map[prKey]int
+	commitDetails     map[commitDetailKey]PRCommitDetail
+	submittedReviews  []submittedReview
+	requestedReviews  []requestedReviewers
+	mergedPRs         []mergedPR
+	mergeMethods      map[repoKey]RepoMergeMethods
+	gists             map[string]mockGist
+	deletedGists      []string
+	nextGistID        int
+	repoFiles         map[repoKey][]repoFileEntry
 
 	// findPRByBranchCalls counts FindPRByBranch invocations so tests can
 	// assert that branch-detection probes are throttled. Atomic because
@@ -146,22 +147,23 @@ type mockGist struct {
 // NewMockClient creates a new MockClient with default values.
 func NewMockClient() *MockClient {
 	return &MockClient{
-		user:          mockDefaultUser,
-		authenticated: true,
-		prs:           make(map[prKey]*PR),
-		issues:        make(map[issueKey]*Issue),
-		prsByBranch:   make(map[branchKey]*PR),
-		repos:         make(map[string][]GitHubRepo),
-		branches:      make(map[repoKey][]RepoBranch),
-		reviews:       make(map[prKey][]PRReview),
-		comments:      make(map[prKey][]PRComment),
-		checks:        make(map[checkKey][]CheckRun),
-		files:         make(map[prKey][]PRFile),
-		commits:       make(map[prKey][]PRCommitInfo),
-		commitDetails: make(map[commitDetailKey]PRCommitDetail),
-		mergeMethods:  make(map[repoKey]RepoMergeMethods),
-		gists:         make(map[string]mockGist),
-		repoFiles:     make(map[repoKey][]repoFileEntry),
+		user:              mockDefaultUser,
+		authenticated:     true,
+		prs:               make(map[prKey]*PR),
+		issues:            make(map[issueKey]*Issue),
+		prsByBranch:       make(map[branchKey]*PR),
+		repos:             make(map[string][]GitHubRepo),
+		branches:          make(map[repoKey][]RepoBranch),
+		reviews:           make(map[prKey][]PRReview),
+		comments:          make(map[prKey][]PRComment),
+		checks:            make(map[checkKey][]CheckRun),
+		files:             make(map[prKey][]PRFile),
+		commits:           make(map[prKey][]PRCommitInfo),
+		prCommitsFailures: make(map[prKey]int),
+		commitDetails:     make(map[commitDetailKey]PRCommitDetail),
+		mergeMethods:      make(map[repoKey]RepoMergeMethods),
+		gists:             make(map[string]mockGist),
+		repoFiles:         make(map[repoKey][]repoFileEntry),
 	}
 }
 
@@ -452,9 +454,14 @@ func (m *MockClient) ListPRFiles(_ context.Context, owner, repo string, number i
 }
 
 func (m *MockClient) ListPRCommits(_ context.Context, owner, repo string, number int) ([]PRCommitInfo, error) {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-	return m.commits[prKey{owner, repo, number}], nil
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	k := prKey{owner, repo, number}
+	if remaining := m.prCommitsFailures[k]; remaining > 0 {
+		m.prCommitsFailures[k] = remaining - 1
+		return nil, fmt.Errorf("mock: PR commits unavailable for %s/%s#%d", owner, repo, number)
+	}
+	return m.commits[k], nil
 }
 
 func (m *MockClient) GetPRCommitDetail(_ context.Context, owner, repo, sha string) (PRCommitDetail, error) {
@@ -874,6 +881,18 @@ func (m *MockClient) AddPRCommits(owner, repo string, number int, commits []PRCo
 	m.commits[k] = append(m.commits[k], commits...)
 }
 
+// SetPRCommitsFailures queues a number of failed ListPRCommits responses for a PR.
+func (m *MockClient) SetPRCommitsFailures(owner, repo string, number, failures int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	k := prKey{owner, repo, number}
+	if failures <= 0 {
+		delete(m.prCommitsFailures, k)
+		return
+	}
+	m.prCommitsFailures[k] = failures
+}
+
 // AddPRCommitDetail seeds an individual GitHub commit response.
 func (m *MockClient) AddPRCommitDetail(owner, repo, sha string, detail PRCommitDetail) {
 	m.mu.Lock()
@@ -904,6 +923,7 @@ func (m *MockClient) Reset() {
 	m.checks = make(map[checkKey][]CheckRun)
 	m.files = make(map[prKey][]PRFile)
 	m.commits = make(map[prKey][]PRCommitInfo)
+	m.prCommitsFailures = make(map[prKey]int)
 	m.commitDetails = make(map[commitDetailKey]PRCommitDetail)
 	m.submittedReviews = nil
 	m.requestedReviews = nil

--- a/apps/backend/internal/github/mock_client_test.go
+++ b/apps/backend/internal/github/mock_client_test.go
@@ -70,6 +70,23 @@ func TestMockClient_AddPR_GetPR(t *testing.T) {
 	}
 }
 
+func TestMockClient_PRCommitsFailuresAreConsumed(t *testing.T) {
+	m := NewMockClient()
+	m.AddPRCommits("owner", "repo", 7, []PRCommitInfo{{SHA: "commit-1"}})
+	m.SetPRCommitsFailures("owner", "repo", 7, 1)
+
+	if _, err := m.ListPRCommits(context.Background(), "owner", "repo", 7); err == nil {
+		t.Fatal("expected the queued PR commit failure")
+	}
+	commits, err := m.ListPRCommits(context.Background(), "owner", "repo", 7)
+	if err != nil {
+		t.Fatalf("expected the next PR commit request to succeed: %v", err)
+	}
+	if len(commits) != 1 || commits[0].SHA != "commit-1" {
+		t.Fatalf("unexpected commits after retry: %+v", commits)
+	}
+}
+
 func TestMockClient_AddIssueGetIssueAndReset(t *testing.T) {
 	m := NewMockClient()
 	ctx := context.Background()

--- a/apps/backend/internal/github/mock_controller.go
+++ b/apps/backend/internal/github/mock_controller.go
@@ -50,6 +50,7 @@ func (c *MockController) RegisterRoutes(router *gin.Engine) {
 	api.POST("/checks", c.addCheckRuns)
 	api.POST("/files", c.addPRFiles)
 	api.POST("/commits", c.addPRCommits)
+	api.PUT("/pr-commits-failures", c.setPRCommitsFailures)
 	api.POST("/commit-details", c.addPRCommitDetail)
 	api.POST("/branches", c.addBranches)
 	api.POST("/repo-files", c.addRepoFiles)
@@ -499,6 +500,22 @@ func (c *MockController) addPRCommits(ctx *gin.Context) {
 	}
 	c.mock.AddPRCommits(req.Owner, req.Repo, req.Number, req.Commits)
 	ctx.JSON(http.StatusOK, gin.H{"added": len(req.Commits)})
+}
+
+func (c *MockController) setPRCommitsFailures(ctx *gin.Context) {
+	var req struct {
+		Owner    string `json:"owner"`
+		Repo     string `json:"repo"`
+		Number   int    `json:"number"`
+		Failures int    `json:"failures"`
+	}
+	if err := ctx.ShouldBindJSON(&req); err != nil || strings.TrimSpace(req.Owner) == "" ||
+		strings.TrimSpace(req.Repo) == "" || req.Number <= 0 || req.Failures < 0 {
+		respondInvalidPayload(ctx)
+		return
+	}
+	c.mock.SetPRCommitsFailures(req.Owner, req.Repo, req.Number, req.Failures)
+	ctx.JSON(http.StatusOK, gin.H{"failures": req.Failures})
 }
 
 func (c *MockController) addPRCommitDetail(ctx *gin.Context) {

--- a/apps/backend/internal/github/mock_controller_test.go
+++ b/apps/backend/internal/github/mock_controller_test.go
@@ -35,6 +35,27 @@ func serveMockJSON(t *testing.T, router *gin.Engine, method, path, body string) 
 	return response
 }
 
+func TestMockControllerSequencesPRCommitFailureThenSuccess(t *testing.T) {
+	router, svc, _ := setupWorkspaceAuthMockController(t)
+	response := serveMockJSON(t, router, http.MethodPut,
+		"/api/v1/github/mock/pr-commits-failures",
+		`{"owner":"owner","repo":"repo","number":7,"failures":1}`)
+	if response.Code != http.StatusOK {
+		t.Fatalf("configure PR commit failure: %d %s", response.Code, response.Body.String())
+	}
+
+	mock, ok := svc.client.(*MockClient)
+	if !ok {
+		t.Fatalf("service client has type %T, want *MockClient", svc.client)
+	}
+	if _, err := mock.ListPRCommits(context.Background(), "owner", "repo", 7); err == nil {
+		t.Fatal("expected the configured request to fail")
+	}
+	if _, err := mock.ListPRCommits(context.Background(), "owner", "repo", 7); err != nil {
+		t.Fatalf("expected the next request to succeed: %v", err)
+	}
+}
+
 func TestMockControllerWorkspaceConnectionsResolveIsolatedPrincipals(t *testing.T) {
 	router, svc, _ := setupWorkspaceAuthMockController(t)
 	registration := serveMockJSON(t, router, http.MethodPut,

--- a/apps/web/components/task/changes-panel-helpers.ts
+++ b/apps/web/components/task/changes-panel-helpers.ts
@@ -542,6 +542,22 @@ function mapCurrentPRCommit(commit: PRCommitForMerge): MergedCommit | null {
   };
 }
 
+function reverseCommitsByRepository(commits: PRCommitForMerge[]): PRCommitForMerge[] {
+  const repositoryOrder: string[] = [];
+  const commitsByRepository = new Map<string, PRCommitForMerge[]>();
+  for (const commit of commits) {
+    const key = repositoryKey(commit.repository_name);
+    const repositoryCommits = commitsByRepository.get(key);
+    if (repositoryCommits) {
+      repositoryCommits.push(commit);
+      continue;
+    }
+    commitsByRepository.set(key, [commit]);
+    repositoryOrder.push(key);
+  }
+  return repositoryOrder.flatMap((key) => [...(commitsByRepository.get(key) ?? [])].reverse());
+}
+
 /**
  * Keeps provider and checkout rows independent after a proven history drift.
  * No SHA, message, or metadata matching occurs in this mode.
@@ -558,7 +574,7 @@ export function separateCommitHistories(
   prCommits: PRCommitForMerge[],
 ): { providerCommits: MergedCommit[]; localCommits: MergedCommit[] } {
   return {
-    providerCommits: prCommits.flatMap((commit) => {
+    providerCommits: reverseCommitsByRepository(prCommits).flatMap((commit) => {
       const mapped = mapCurrentPRCommit(commit);
       return mapped ? [mapped] : [];
     }),

--- a/apps/web/components/task/changes-panel-helpers.ts
+++ b/apps/web/components/task/changes-panel-helpers.ts
@@ -546,7 +546,7 @@ function reverseCommitsByRepository(commits: PRCommitForMerge[]): PRCommitForMer
   const repositoryOrder: string[] = [];
   const commitsByRepository = new Map<string, PRCommitForMerge[]>();
   for (const commit of commits) {
-    const key = repositoryKey(commit.repository_name);
+    const key = `${commit.owner}/${commit.repo}`;
     const repositoryCommits = commitsByRepository.get(key);
     if (repositoryCommits) {
       repositoryCommits.push(commit);

--- a/apps/web/components/task/changes-panel-remote.test.ts
+++ b/apps/web/components/task/changes-panel-remote.test.ts
@@ -229,8 +229,8 @@ describe("separateCommitHistories", () => {
     const result = separateCommitHistories(local, provider);
 
     expect(result.providerCommits.map((commit) => commit.commit_sha)).toEqual([
-      "new1111",
       "new3333",
+      "new1111",
     ]);
     expect(result.localCommits.map((commit) => commit.commit_sha)).toEqual(["old1111", "old2222"]);
     expect(result.providerCommits.every((commit) => commit.presentation === "current_pr")).toBe(
@@ -241,6 +241,7 @@ describe("separateCommitHistories", () => {
     );
     expect(result.localCommits.every((commit) => commit.pushed === false)).toBe(true);
   });
+
   it("does not create a PR-only target without complete provenance", () => {
     const pr = {
       ...makePR(SHARED_SHA, "remote"),
@@ -279,5 +280,53 @@ describe("separateCommitHistories", () => {
       repository_name: WIDGET_REPO,
       detailTarget: { source: "github", repo: WIDGET_REPO },
     });
+  });
+});
+
+describe("repository-scoped provider history", () => {
+  it("reverses provider history independently for each repository", () => {
+    const provider = [
+      {
+        ...makePR("old-a", "old a"),
+        stats_available: false,
+        workspace_id: WORKSPACE_ID,
+        owner: "acme",
+        repo: "widget-a",
+        repository_name: "widget-a",
+      },
+      {
+        ...makePR("old-b", "old b"),
+        stats_available: false,
+        workspace_id: WORKSPACE_ID,
+        owner: "acme",
+        repo: "widget-b",
+        repository_name: "widget-b",
+      },
+      {
+        ...makePR("new-a", "new a"),
+        stats_available: false,
+        workspace_id: WORKSPACE_ID,
+        owner: "acme",
+        repo: "widget-a",
+        repository_name: "widget-a",
+      },
+      {
+        ...makePR("new-b", "new b"),
+        stats_available: false,
+        workspace_id: WORKSPACE_ID,
+        owner: "acme",
+        repo: "widget-b",
+        repository_name: "widget-b",
+      },
+    ];
+
+    const result = separateCommitHistories([], provider);
+
+    expect(result.providerCommits.map((commit) => commit.commit_sha)).toEqual([
+      "new-a",
+      "old-a",
+      "new-b",
+      "old-b",
+    ]);
   });
 });

--- a/apps/web/components/task/changes-panel-remote.test.ts
+++ b/apps/web/components/task/changes-panel-remote.test.ts
@@ -285,6 +285,7 @@ describe("separateCommitHistories", () => {
 
 describe("repository-scoped provider history", () => {
   it("reverses provider history independently for each repository", () => {
+    const repositoryLabel = "shared-label";
     const provider = [
       {
         ...makePR("old-a", "old a"),
@@ -292,7 +293,7 @@ describe("repository-scoped provider history", () => {
         workspace_id: WORKSPACE_ID,
         owner: "acme",
         repo: "widget-a",
-        repository_name: "widget-a",
+        repository_name: repositoryLabel,
       },
       {
         ...makePR("old-b", "old b"),
@@ -300,7 +301,7 @@ describe("repository-scoped provider history", () => {
         workspace_id: WORKSPACE_ID,
         owner: "acme",
         repo: "widget-b",
-        repository_name: "widget-b",
+        repository_name: repositoryLabel,
       },
       {
         ...makePR("new-a", "new a"),
@@ -308,7 +309,7 @@ describe("repository-scoped provider history", () => {
         workspace_id: WORKSPACE_ID,
         owner: "acme",
         repo: "widget-a",
-        repository_name: "widget-a",
+        repository_name: repositoryLabel,
       },
       {
         ...makePR("new-b", "new b"),
@@ -316,7 +317,7 @@ describe("repository-scoped provider history", () => {
         workspace_id: WORKSPACE_ID,
         owner: "acme",
         repo: "widget-b",
-        repository_name: "widget-b",
+        repository_name: repositoryLabel,
       },
     ];
 

--- a/apps/web/e2e/helpers/api-client.ts
+++ b/apps/web/e2e/helpers/api-client.ts
@@ -1472,6 +1472,20 @@ export class ApiClient {
     });
   }
 
+  async mockGitHubSetPRCommitsFailures(
+    owner: string,
+    repo: string,
+    number: number,
+    failures: number,
+  ): Promise<void> {
+    await this.request("PUT", "/api/v1/github/mock/pr-commits-failures", {
+      owner,
+      repo,
+      number,
+      failures,
+    });
+  }
+
   async mockGitHubAddPRCommitDetail(
     owner: string,
     repo: string,

--- a/apps/web/e2e/tests/git/git-changes-panel.spec.ts
+++ b/apps/web/e2e/tests/git/git-changes-panel.spec.ts
@@ -534,6 +534,7 @@ test.describe("Git Changes Panel", () => {
       base_branch: "main",
       author_login: "remote-author",
     });
+    await apiClient.mockGitHubSetPRCommitsFailures("testorg", "testrepo", 2253, 1);
 
     await testPage.reload();
     await session.waitForLoad();
@@ -559,6 +560,7 @@ test.describe("Git Changes Panel", () => {
       "data-commit-provenance",
       "pushed",
     );
+    await expect(testPage.getByTestId("header-remote-contribution-warning")).toHaveCount(0);
     const commitMessages = await commitsList
       .locator('[data-testid^="commit-row-"]')
       .allTextContents();
@@ -1731,6 +1733,9 @@ test.describe("Git Changes Panel", () => {
       localSection.locator('[data-commit-provenance="local_checkout"]').first(),
     ).toHaveAttribute("title", "Local checkout commit");
     await expect(providerSection.locator('[data-testid^="commit-row-"]')).toHaveCount(15);
+    await expect(providerSection.locator('[data-testid^="commit-row-"]').first()).toContainText(
+      "Rewritten provider commit 15",
+    );
 
     // A rewritten provider history must not label the preserved checkout as
     // six unpushed commits, and reading the panel must not mutate the checkout.

--- a/apps/web/e2e/tests/git/git-changes-panel.spec.ts
+++ b/apps/web/e2e/tests/git/git-changes-panel.spec.ts
@@ -523,6 +523,7 @@ test.describe("Git Changes Panel", () => {
         },
       ],
     });
+    await apiClient.mockGitHubSetPRCommitsFailures("testorg", "testrepo", 2253, 1);
     await apiClient.mockGitHubAssociateTaskPR({
       task_id: task.id,
       owner: "testorg",
@@ -534,7 +535,6 @@ test.describe("Git Changes Panel", () => {
       base_branch: "main",
       author_login: "remote-author",
     });
-    await apiClient.mockGitHubSetPRCommitsFailures("testorg", "testrepo", 2253, 1);
 
     await testPage.reload();
     await session.waitForLoad();

--- a/apps/web/e2e/tests/git/mobile-pr-checkout-drift.spec.ts
+++ b/apps/web/e2e/tests/git/mobile-pr-checkout-drift.spec.ts
@@ -150,6 +150,9 @@ test.describe("Mobile rewritten contribution history", () => {
       base_branch: "main",
       author_login: "mobile-remote-contributor",
     });
+    // The first provider-history request fails. The resource must retry it
+    // without dropping the local checkout history from the final panel.
+    await apiClient.mockGitHubSetPRCommitsFailures("testorg", "testrepo", 902, 1);
 
     await testPage.goto(`/t/${task.id}`);
     const session = new SessionPage(testPage);
@@ -182,6 +185,9 @@ test.describe("Mobile rewritten contribution history", () => {
       localSection.locator('[data-commit-provenance="local_checkout"]').first(),
     ).toHaveAttribute("title", "Local checkout commit");
     await expect(providerSection.locator('[data-testid^="commit-row-"]')).toHaveCount(15);
+    await expect(providerSection.locator('[data-testid^="commit-row-"]').first()).toContainText(
+      "Mobile rewritten provider commit 15",
+    );
     await expect(providerSection.locator(".tabler-icon-arrow-up")).toHaveCount(0);
     await expect(localSection.locator(".tabler-icon-arrow-up")).toHaveCount(0);
 

--- a/apps/web/e2e/tests/task/mobile-changes-panel.spec.ts
+++ b/apps/web/e2e/tests/task/mobile-changes-panel.spec.ts
@@ -258,6 +258,7 @@ test.describe("Mobile changes panel", () => {
     testPage,
     apiClient,
     seedData,
+    backend,
   }) => {
     const checkoutBranch = "main";
     const task = await apiClient.createTaskWithAgent(
@@ -271,6 +272,16 @@ test.describe("Mobile changes panel", () => {
         repositories: [{ repository_id: seedData.repositoryId, checkout_branch: checkoutBranch }],
       },
     );
+
+    await testPage.goto(`/t/${task.id}`);
+    const session = new SessionPage(testPage);
+    await session.waitForLoad();
+    await session.waitForChatIdle({ timeout: 45_000 });
+    const repoDir = path.join(backend.tmpDir, "repos", "e2e-repo");
+    const git = new GitHelper(repoDir, makeGitEnv(backend.tmpDir));
+    git.createFile("mobile-pr-shared-marker.ts", "shared provider checkout commit");
+    git.stageFile("mobile-pr-shared-marker.ts");
+    const sharedSha = git.commit("Shared provider checkout commit");
 
     const remoteSha = "e".repeat(40);
     const remoteMessage = "Mobile force-pushed commit";
@@ -286,9 +297,16 @@ test.describe("Mobile changes panel", () => {
         author_login: "mobile-remote-author",
         repo_owner: "testorg",
         repo_name: "testrepo",
+        head_sha: remoteSha,
       },
     ]);
     await apiClient.mockGitHubAddPRCommits("testorg", "testrepo", 2254, [
+      {
+        sha: sharedSha,
+        message: "Shared provider checkout commit",
+        author_login: "mobile-remote-author",
+        author_date: "2026-08-03T12:00:00Z",
+      },
       {
         sha: remoteSha,
         message: remoteMessage,
@@ -326,9 +344,9 @@ test.describe("Mobile changes panel", () => {
       base_branch: "main",
       author_login: "mobile-remote-author",
     });
+    await apiClient.mockGitHubSetPRCommitsFailures("testorg", "testrepo", 2254, 1);
 
-    await testPage.goto(`/t/${task.id}`);
-    const session = new SessionPage(testPage);
+    await testPage.reload();
     await session.waitForLoad();
     await session.waitForChatIdle({ timeout: 45_000 });
     await openMobileChangesPanel(testPage);
@@ -336,6 +354,13 @@ test.describe("Mobile changes panel", () => {
 
     const row = testPage.getByTestId(`commit-row-${remoteSha.slice(0, 7)}`);
     await expect(row).toBeVisible({ timeout: 20_000 });
+    const sharedRow = testPage.getByTestId(`commit-row-${sharedSha.slice(0, 7)}`);
+    await expect(sharedRow).toBeVisible({ timeout: 20_000 });
+    await expect(sharedRow.getByTestId("commit-provenance")).toHaveAttribute(
+      "data-commit-provenance",
+      "pushed",
+    );
+    await expect(testPage.getByTestId("header-remote-contribution-warning")).toHaveCount(0);
     await expect(row.getByText("+0", { exact: true })).toHaveCount(0);
     await expect(row.getByText("-0", { exact: true })).toHaveCount(0);
     await row.tap();

--- a/apps/web/e2e/tests/task/mobile-changes-panel.spec.ts
+++ b/apps/web/e2e/tests/task/mobile-changes-panel.spec.ts
@@ -333,6 +333,7 @@ test.describe("Mobile changes panel", () => {
         },
       ],
     });
+    await apiClient.mockGitHubSetPRCommitsFailures("testorg", "testrepo", 2254, 1);
     await apiClient.mockGitHubAssociateTaskPR({
       task_id: task.id,
       owner: "testorg",
@@ -344,7 +345,6 @@ test.describe("Mobile changes panel", () => {
       base_branch: "main",
       author_login: "mobile-remote-author",
     });
-    await apiClient.mockGitHubSetPRCommitsFailures("testorg", "testrepo", 2254, 1);
 
     await testPage.reload();
     await session.waitForLoad();

--- a/docs/plans/remote-contribution-history-reconciliation/plan.md
+++ b/docs/plans/remote-contribution-history-reconciliation/plan.md
@@ -152,6 +152,10 @@ git diff --check
   provider-history body warning, and keeps remote actions fail-closed.
 - Task 03 passed the desktop Git Changes spec with 21 tests and the mobile rewritten-contribution spec
   with 1 test. Both surfaces expose the same provenance labels without horizontal overflow.
+- Review remediation adds repository-scoped newest-first assertions for commit 15 and deterministic
+  desktop/mobile browser coverage for one provider failure followed by automatic reconciliation. The
+  focused remediation scenarios passed 1 desktop test and 2 mobile tests; the helper unit file passed
+  10 tests and the mock-provider backend tests passed 2 tests.
 - Final focused tests passed 59 tests across 6 files. Typecheck, lint, i18n checks, i18n ratchet, and
   `git diff --check` passed.
 - PR fixup hardened unavailable-evidence action gates, repository-scoped ordering, single-repository

--- a/docs/plans/remote-contribution-history-reconciliation/task-03-verify-desktop-mobile-reconciliation.md
+++ b/docs/plans/remote-contribution-history-reconciliation/task-03-verify-desktop-mobile-reconciliation.md
@@ -43,8 +43,10 @@ fixture transitions and semantic assertions.
 
 1. Add the desktop assertions and confirm that the warning, order, or provenance test fails.
 2. Add the mobile assertions and confirm the provenance test fails.
-3. Complete any missing product behavior in Task 01 or Task 02 files.
-4. Run each focused spec with `--retries=0`.
+3. Add a one-request provider commit failure before navigation and verify the automatic retry keeps
+   checkout history visible, removes the warning, and adds the provider-only commit.
+4. Complete any missing product behavior in Task 01 or Task 02 files.
+5. Run each focused spec with `--retries=0`.
 
 Do not use arbitrary sleeps. Poll the semantic Changes state. Confirm that Playwright discovers the
 expected tests in each owning project.
@@ -73,8 +75,8 @@ Sequential. Run after the shared behavior is complete.
 
 ## Risks
 
-- Reset failure fixtures immediately after the intended request so later assertions do not inherit
-  the failure.
+- Use one-shot failure fixtures so the intended retry is deterministic and later assertions do not
+  inherit a queued failure.
 - Assert semantic provenance attributes and labels. Do not depend only on generated CSS strings.
 - Keep the mobile test in `mobile-chrome`. The default project excludes mobile specs.
 
@@ -86,10 +88,22 @@ conversation.
 
 ## Results
 
-- Desktop command passed 21 tests with Chromium:
+- The desktop divergence scenario asserts `Rewritten provider commit 15` is the first provider row,
+  proving newest-first provider history.
+- The mobile divergence scenario asserts `Mobile rewritten provider commit 15` is the first provider
+  row and exercises the same ordering contract on `mobile-chrome`.
+- A one-shot mock provider failure followed by the existing automatic retry now covers the original
+  failure-and-retry workflow. The desktop PR-only scenario and two mobile scenarios all keep local
+  history visible, show the provider-only commit after retry, and finish without the provider warning.
+- The desktop command passed 21 tests with Chromium before the review remediation:
   `cd apps/web && pnpm e2e:run tests/git/git-changes-panel.spec.ts -- --retries=0`
+- The review-remediation desktop retry scenario passed 1 test with Chromium:
+  `cd apps/web && pnpm e2e:run tests/git/git-changes-panel.spec.ts -- --grep "PR-only commit uses GitHub details when local history is stale" --retries=0`
 - Mobile command passed 1 test with `mobile-chrome`:
   `cd apps/web && pnpm e2e:run --project mobile-chrome tests/git/mobile-pr-checkout-drift.spec.ts -- --retries=0`
+- The review-remediation mobile retry scenarios passed 1 test each with `mobile-chrome`:
+  `cd apps/web && pnpm e2e:run --project mobile-chrome tests/git/mobile-pr-checkout-drift.spec.ts -- --retries=0`
+  `cd apps/web && pnpm e2e:run --project mobile-chrome tests/task/mobile-changes-panel.spec.ts -- --grep "PR-only commit opens the remote commit sheet when local history is stale" --retries=0`
 - The fixtures cover preserved local history, provider-only history order and provenance, shared
   commits, confirmed divergence, provider-ahead actions, and mobile zero-overflow/touch behavior.
 - Fresh desktop and Pixel 5 screenshots were captured, inspected, compressed, and mapped in


### PR DESCRIPTION
The Changes panel could retain GitHub's oldest-first provider ordering after a rewritten contribution, while the original provider failure-and-retry workflow had no browser coverage. Provider history now reverses independently per repository, and deterministic desktop/mobile fixtures prove automatic reconciliation preserves local history and removes the warning.

## Important Changes

- Reverse provider commits independently per repository before mapping them into the Changes timeline.
- Add a one-shot mock `ListPRCommits` failure queue so E2E tests can exercise a real failure followed by the existing automatic retry.
- Assert provider commit 15 first in desktop and mobile divergence scenarios, plus local-history preservation and warning removal after retry.

## Validation

- `cd apps/web && pnpm exec vitest run components/task/changes-panel-remote.test.ts --reporter=dot` (10 passed)
- `cd apps/backend && go test -race ./internal/github -run "TestMockClient_PRCommitsFailuresAreConsumed|TestMockControllerSequencesPRCommitFailureThenSuccess" -count=1` (passed)
- `cd apps/web && pnpm run typecheck` (passed)
- `cd apps && pnpm --filter @kandev/web lint` (passed)
- `cd apps/web && pnpm run i18n:check` (passed; existing real-locale parity warnings are advisory)
- `cd apps/web && pnpm run i18n:ratchet` (passed)
- `cd apps/web && pnpm e2e:run tests/git/git-changes-panel.spec.ts -- --retries=0` (21 passed)
- `cd apps/web && pnpm e2e:run --project mobile-chrome tests/git/mobile-pr-checkout-drift.spec.ts -- --retries=0` (1 passed)
- `cd apps/web && pnpm e2e:run --project mobile-chrome tests/task/mobile-changes-panel.spec.ts -- --grep "PR-only commit opens the remote commit sheet when local history is stale" --retries=0` (1 passed)
- Commit hooks passed with no bypass.

## Possible Improvements

Low risk: the one-shot provider failure fixture is test-only and can be extended later if more retry transitions need browser coverage.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2626?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- kandev-screenshots-start -->
## Screenshots

![Desktop rewritten provider history](https://raw.githubusercontent.com/kdlbs/kandev/69fc5b45c8130aa4923e810b37c752fe6fca0e7e/git-changes-panel--remote-contribution-drift-desktop.png)
![Mobile rewritten provider history](https://raw.githubusercontent.com/kdlbs/kandev/69fc5b45c8130aa4923e810b37c752fe6fca0e7e/mobile-pr-checkout-drift--remote-contribution-drift-mobile.png)
<!-- kandev-screenshots-end -->