### PR TITLE
fix(queue): auto-merge sibling-session messages and full-queue admissions

### DIFF
--- a/apps/backend/internal/orchestrator/handlers/queue_handlers_auto_merge_test.go
+++ b/apps/backend/internal/orchestrator/handlers/queue_handlers_auto_merge_test.go
@@ -91,6 +91,51 @@ func TestWsQueueMessage_AutoMergeBlocksLaterAdmissionUntilClaimFinalizes(t *test
 	require.Equal(t, "first\n\nsecond\n\nthird", status.Entries[0].Content)
 }
 
+func TestWsQueueMessage_AutoMergeFoldsAdmissionAtFullQueue(t *testing.T) {
+	handlers, service := setupQueueHandlers(t)
+	// Fill the queue with auto-merge disabled so the session actually reaches
+	// capacity, then enable it: the next compatible message must fold into the
+	// tail instead of surfacing "queue full".
+	service.SetMaxPerSession(1)
+	service.SetAutoMergeEnabled(false)
+	_, err := service.QueueMessage(context.Background(), "session", "task", "first", "", messagequeue.QueuedByUser, false, nil)
+	require.NoError(t, err)
+	service.SetAutoMergeEnabled(true)
+
+	response, err := handlers.wsQueueMessage(context.Background(), createTestMessage(t, ws.ActionMessageQueueAdd, map[string]interface{}{
+		"session_id": "session",
+		"task_id":    "task",
+		"content":    "second",
+	}))
+	require.NoError(t, err)
+	require.Equal(t, ws.MessageTypeResponse, response.Type)
+	var queued messagequeue.QueuedMessage
+	require.NoError(t, json.Unmarshal(response.Payload, &queued))
+	require.Equal(t, "first\n\nsecond", queued.Content)
+	status := service.GetStatus(context.Background(), "session")
+	require.Equal(t, 1, status.Count)
+	require.Equal(t, "first\n\nsecond", status.Entries[0].Content)
+}
+
+func TestWsQueueMessage_AutoMergeAtFullQueueRejectsIncompatible(t *testing.T) {
+	handlers, service := setupQueueHandlers(t)
+	service.SetMaxPerSession(1)
+	service.SetAutoMergeEnabled(false)
+	_, err := service.QueueMessage(context.Background(), "session", "task", "first", "", messagequeue.QueuedByUser, false, nil)
+	require.NoError(t, err)
+	service.SetAutoMergeEnabled(true)
+
+	response, err := handlers.wsQueueMessage(context.Background(), createTestMessage(t, ws.ActionMessageQueueAdd, map[string]interface{}{
+		"session_id": "session",
+		"task_id":    "task",
+		"content":    "second",
+		"model":      "other-model",
+	}))
+	require.NoError(t, err)
+	require.Equal(t, ws.MessageTypeError, response.Type)
+	require.Equal(t, messagequeue.QueueFullErrorCode, parseError(t, response).Code)
+}
+
 type blockingQueueAttachmentClaimer struct {
 	started chan struct{}
 	release chan struct{}

--- a/apps/backend/internal/orchestrator/messagequeue/auto_merge.go
+++ b/apps/backend/internal/orchestrator/messagequeue/auto_merge.go
@@ -72,6 +72,16 @@ func comparableAutoMetadata(metadata map[string]interface{}) ([]byte, bool) {
 		if key == MetadataEntityReferences || key == MetadataContextFiles {
 			continue
 		}
+		if key == MetadataSenderSessionID || key == MetadataSenderSessionName {
+			// Per-session provenance of the sender task, not merge context.
+			// autoMergeAllowed already requires agent entries to share the
+			// same sender_task_id, so two messages from different sessions of
+			// that task (e.g. sibling reviewer sessions) are as foldable as
+			// manual merge treats them; the surviving entry keeps the target's
+			// session attribution. Without this exclusion every interleaved
+			// sibling-session message blocked the fold and the queue filled.
+			continue
+		}
 		comparable[key] = value
 	}
 	encoded, err := json.Marshal(comparable)

--- a/apps/backend/internal/orchestrator/messagequeue/repository.go
+++ b/apps/backend/internal/orchestrator/messagequeue/repository.go
@@ -122,6 +122,14 @@ type Repository interface {
 	// successful skip and returns false without mutating either row.
 	AutoMergeIntoAbove(ctx context.Context, sessionID, sourceID string) (*QueuedMessage, bool, error)
 
+	// AutoMergeCandidateIntoAbove folds a not-yet-admitted candidate message
+	// into the session's tail entry when compatible, without inserting it. Used
+	// by admission at full capacity: the fold itself is the admission, so a
+	// message that would merge anyway is accepted instead of rejected with
+	// ErrQueueFull. A missing tail or incompatible pair is a successful skip
+	// and returns false without mutating any row.
+	AutoMergeCandidateIntoAbove(ctx context.Context, candidate *QueuedMessage) (*QueuedMessage, bool, error)
+
 	// ReorderEntries atomically rewrites the FIFO positions of the session's
 	// pending entries to match orderedIDs. The submitted list must be an exact
 	// permutation of the currently visible pending (not reserved-in-flight)

--- a/apps/backend/internal/orchestrator/messagequeue/repository_auto_merge_test.go
+++ b/apps/backend/internal/orchestrator/messagequeue/repository_auto_merge_test.go
@@ -17,6 +17,10 @@ type automaticMergeRepository interface {
 	AutoMergeIntoAbove(context.Context, string, string) (*QueuedMessage, bool, error)
 }
 
+type automaticMergeCandidateRepository interface {
+	AutoMergeCandidateIntoAbove(context.Context, *QueuedMessage) (*QueuedMessage, bool, error)
+}
+
 type autoMergeRepositoryFactory struct {
 	name string
 	new  func(*testing.T) Repository
@@ -233,6 +237,150 @@ func TestRepository_AutoMergeIntoAbove_EmptyContentHasNoExtraSeparator(t *testin
 				})
 			}
 		})
+	}
+}
+
+func TestRepository_AutoMergeIntoAbove_AgentSameTaskDifferentSessions(t *testing.T) {
+	for _, tt := range autoMergeRepositoryFactories() {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := tt.new(t)
+			autoRepo, ok := repo.(automaticMergeRepository)
+			if !ok {
+				t.Fatalf("repository %T does not implement automatic tail merge", repo)
+			}
+			targetEntry := defaultAutoMergeEntry("sessions", "first")
+			targetEntry.QueuedBy = QueuedByAgent
+			targetEntry.Metadata = map[string]interface{}{
+				MetadataSenderTaskID:    "sender-task",
+				MetadataSenderSessionID: "session-one",
+				"sender_session_name":   "reviewer-one",
+				"sender_task_title":     "Sender task",
+			}
+			target := insertAutoMergeEntry(t, repo, targetEntry)
+			sourceEntry := defaultAutoMergeEntry("sessions", "second")
+			sourceEntry.QueuedBy = QueuedByAgent
+			sourceEntry.Metadata = map[string]interface{}{
+				MetadataSenderTaskID:    "sender-task",
+				MetadataSenderSessionID: "session-two",
+				"sender_session_name":   "reviewer-two",
+				"sender_task_title":     "Sender task",
+			}
+			source := insertAutoMergeEntry(t, repo, sourceEntry)
+
+			merged, didMerge, err := autoRepo.AutoMergeIntoAbove(context.Background(), "sessions", source.ID)
+			if err != nil || !didMerge || merged == nil {
+				t.Fatalf("same-task different-session auto merge: result=%+v merged=%v err=%v", merged, didMerge, err)
+			}
+			if merged.ID != target.ID {
+				t.Fatalf("survivor = %s, want target %s", merged.ID, target.ID)
+			}
+			if got := metadataString(merged.Metadata, MetadataSenderSessionID); got != "session-one" {
+				t.Fatalf("survivor session = %q, want target session attribution", got)
+			}
+			if merged.Content != "first\n\nsecond" {
+				t.Fatalf("content = %q, want %q", merged.Content, "first\n\nsecond")
+			}
+		})
+	}
+}
+
+func TestRepository_AutoMergeCandidateIntoAbove_FoldsIntoTail(t *testing.T) {
+	for _, tt := range autoMergeRepositoryFactories() {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := tt.new(t)
+			autoRepo, ok := repo.(automaticMergeCandidateRepository)
+			if !ok {
+				t.Fatalf("repository %T does not implement candidate tail merge", repo)
+			}
+
+			insertAutoMergeEntry(t, repo, defaultAutoMergeEntry("candidate", "first"))
+			tail := insertAutoMergeEntry(t, repo, defaultAutoMergeEntry("candidate", "second"))
+			candidate := defaultAutoMergeEntry("candidate", "third")
+
+			merged, didMerge, err := autoRepo.AutoMergeCandidateIntoAbove(context.Background(), &candidate)
+			if err != nil || !didMerge || merged == nil {
+				t.Fatalf("candidate merge: result=%+v merged=%v err=%v", merged, didMerge, err)
+			}
+			if merged.ID != tail.ID {
+				t.Fatalf("survivor = %s, want tail %s", merged.ID, tail.ID)
+			}
+			if merged.Content != "second\n\nthird" {
+				t.Errorf("content = %q, want %q", merged.Content, "second\n\nthird")
+			}
+			entries, err := repo.ListBySession(context.Background(), "candidate")
+			if err != nil {
+				t.Fatalf("list: %v", err)
+			}
+			if len(entries) != 2 || entries[1].ID != tail.ID {
+				t.Fatalf("entries after candidate fold = %+v, want two rows with folded tail", entries)
+			}
+		})
+	}
+}
+
+func TestRepository_AutoMergeCandidateIntoAbove_IncompatibleSkips(t *testing.T) {
+	for _, tt := range autoMergeRepositoryFactories() {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := tt.new(t)
+			autoRepo, ok := repo.(automaticMergeCandidateRepository)
+			if !ok {
+				t.Fatalf("repository %T does not implement candidate tail merge", repo)
+			}
+			insertAutoMergeEntry(t, repo, defaultAutoMergeEntry("candidate-skip", "first"))
+			candidate := defaultAutoMergeEntry("candidate-skip", "other-model")
+			candidate.Model = "other-model"
+			before := autoQueueSnapshot(t, repo, "candidate-skip")
+
+			merged, didMerge, err := autoRepo.AutoMergeCandidateIntoAbove(context.Background(), &candidate)
+			if err != nil || didMerge || merged != nil {
+				t.Fatalf("incompatible candidate: result=%+v merged=%v err=%v", merged, didMerge, err)
+			}
+			if after := autoQueueSnapshot(t, repo, "candidate-skip"); after != before {
+				t.Fatalf("queue mutated on skip\nbefore=%s\nafter=%s", before, after)
+			}
+		})
+	}
+}
+
+func TestRepository_AutoMergeCandidateIntoAbove_EmptyQueueSkips(t *testing.T) {
+	for _, tt := range autoMergeRepositoryFactories() {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := tt.new(t)
+			autoRepo, ok := repo.(automaticMergeCandidateRepository)
+			if !ok {
+				t.Fatalf("repository %T does not implement candidate tail merge", repo)
+			}
+			candidate := defaultAutoMergeEntry("candidate-empty", "only")
+			merged, didMerge, err := autoRepo.AutoMergeCandidateIntoAbove(context.Background(), &candidate)
+			if err != nil || didMerge || merged != nil {
+				t.Fatalf("empty queue: result=%+v merged=%v err=%v", merged, didMerge, err)
+			}
+		})
+	}
+}
+
+func TestSQLiteRepository_AutoMergeCandidateIntoAbove_WriteFailureRollsBack(t *testing.T) {
+	repo := newTestSQLiteRepo(t)
+	db := repo.(*sqliteRepository).db
+	insertAutoMergeEntry(t, repo, defaultAutoMergeEntry("candidate-rollback", "first"))
+	insertAutoMergeEntry(t, repo, defaultAutoMergeEntry("candidate-rollback", "second"))
+	before := autoQueueSnapshot(t, repo, "candidate-rollback")
+	if _, err := db.Exec(`
+		CREATE TRIGGER fail_auto_merge_candidate_update
+		BEFORE UPDATE ON queued_messages
+		BEGIN
+			SELECT RAISE(ABORT, 'forced automatic candidate merge failure');
+		END;
+	`); err != nil {
+		t.Fatalf("create failure trigger: %v", err)
+	}
+	candidate := defaultAutoMergeEntry("candidate-rollback", "third")
+	merged, didMerge, err := repo.(automaticMergeCandidateRepository).AutoMergeCandidateIntoAbove(context.Background(), &candidate)
+	if err == nil || didMerge || merged != nil {
+		t.Fatalf("forced write failure: result=%+v merged=%v err=%v", merged, didMerge, err)
+	}
+	if after := autoQueueSnapshot(t, repo, "candidate-rollback"); after != before {
+		t.Fatalf("write failure was not atomic\nbefore=%s\nafter=%s", before, after)
 	}
 }
 

--- a/apps/backend/internal/orchestrator/messagequeue/repository_memory.go
+++ b/apps/backend/internal/orchestrator/messagequeue/repository_memory.go
@@ -698,6 +698,33 @@ func (r *memoryRepository) AutoMergeIntoAbove(_ context.Context, sessionID, sour
 	return cloneQueuedMessage(target), true, nil
 }
 
+// AutoMergeCandidateIntoAbove folds a not-yet-admitted candidate into the
+// session's tail entry when compatible, without inserting it. Incompatibility
+// and missing tails are successful skips.
+func (r *memoryRepository) AutoMergeCandidateIntoAbove(_ context.Context, candidate *QueuedMessage) (*QueuedMessage, bool, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	list := r.entries[candidate.SessionID]
+	var target *QueuedMessage
+	for _, message := range list {
+		if target == nil || message.Position > target.Position {
+			target = message
+		}
+	}
+	if target == nil {
+		return nil, false, nil
+	}
+	values, compatible := buildAutoMergedEntry(target, candidate)
+	if !compatible {
+		return nil, false, nil
+	}
+	target.Content = values.content
+	target.Attachments = values.attachments
+	target.Metadata = values.metadata
+	return cloneQueuedMessage(target), true, nil
+}
+
 // ReorderEntries rewrites the session's visible pending order to match
 // orderedIDs, mirroring the sqlite repository's semantics: reserved in-flight
 // rows keep their place in the sequence, visible rows appear in the submitted

--- a/apps/backend/internal/orchestrator/messagequeue/repository_sqlite.go
+++ b/apps/backend/internal/orchestrator/messagequeue/repository_sqlite.go
@@ -1365,6 +1365,66 @@ func (r *sqliteRepository) AutoMergeIntoAbove(ctx context.Context, sessionID, so
 	return target, true, nil
 }
 
+// AutoMergeCandidateIntoAbove folds a not-yet-admitted candidate into the
+// session's tail entry when compatible. Unlike AutoMergeIntoAbove there is no
+// source row to delete: admission at full capacity could not insert one, so
+// the fold is the admission. Missing or incompatible tails are successful
+// skips and leave storage unchanged.
+func (r *sqliteRepository) AutoMergeCandidateIntoAbove(ctx context.Context, candidate *QueuedMessage) (*QueuedMessage, bool, error) {
+	unlock := r.withSessionLock(candidate.SessionID)
+	defer unlock()
+
+	tx, err := r.db.BeginTxx(ctx, nil)
+	if err != nil {
+		return nil, false, fmt.Errorf("begin automatic candidate merge tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	target, err := r.scanTail(ctx, tx, candidate.SessionID)
+	if err != nil {
+		return nil, false, err
+	}
+	if target == nil {
+		return nil, false, nil
+	}
+	values, compatible := buildAutoMergedEntry(target, candidate)
+	if !compatible {
+		return nil, false, nil
+	}
+	attachmentsJSON, err := marshalAttachments(values.attachments)
+	if err != nil {
+		return nil, false, err
+	}
+	metadataJSON, err := marshalMetadata(values.metadata)
+	if err != nil {
+		return nil, false, err
+	}
+	res, err := tx.ExecContext(ctx, r.db.Rebind(`
+		UPDATE queued_messages
+		SET content = ?, attachments_json = ?, metadata_json = ?
+		WHERE id = ? AND session_id = ?
+	`), values.content, attachmentsJSON, metadataJSON, target.ID, candidate.SessionID)
+	if err != nil {
+		return nil, false, fmt.Errorf("update automatic candidate merge target: %w", err)
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return nil, false, fmt.Errorf("update automatic candidate merge rows affected: %w", err)
+	}
+	if affected == 0 {
+		// The tail was drained concurrently; roll back rather than folding
+		// into a row that no longer exists.
+		return nil, false, nil
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, false, err
+	}
+	target.Content = values.content
+	target.Attachments = values.attachments
+	target.Metadata = values.metadata
+	return target, true, nil
+}
+
 // ReorderEntries atomically rewrites the FIFO positions of the session's
 // visible pending entries to match orderedIDs. Reserved in-flight lifecycle
 // rows keep their place in the sequence; visible rows are interleaved in the

--- a/apps/backend/internal/orchestrator/messagequeue/service.go
+++ b/apps/backend/internal/orchestrator/messagequeue/service.go
@@ -179,6 +179,37 @@ func (s *Service) queueMessageWithMetadataAdmission(ctx context.Context, session
 			admittedCtx, sessionID, taskID, content, model, userID, planMode, attachments, metadata, maxPerSession,
 		)
 		if err != nil {
+			if errors.Is(err, ErrQueueFull) && autoMergeEnabled && afterInsert == nil {
+				// A full queue must still accept a message that would fold into
+				// the tail: admission-time auto-merge runs after a successful
+				// insert, so at capacity it could never fire. Fold the
+				// candidate directly — the fold is the admission. The
+				// afterInsert hook is excluded because it claims staged
+				// attachments against a persisted source row, which this path
+				// never creates.
+				candidate := &QueuedMessage{
+					SessionID:   sessionID,
+					TaskID:      taskID,
+					Content:     content,
+					Model:       model,
+					PlanMode:    planMode,
+					Attachments: attachments,
+					Metadata:    copyMessageMetadata(metadata, 0),
+					QueuedBy:    userID,
+				}
+				merged, didMerge, mergeErr := s.repo.AutoMergeCandidateIntoAbove(admittedCtx, candidate)
+				if mergeErr != nil {
+					s.logger.Error("automatic merge into full queue failed; preserving queue full rejection",
+						zap.String("session_id", sessionID),
+						zap.Error(mergeErr))
+				} else if didMerge && merged != nil {
+					s.logger.Info("automatically merged queued entry into full tail",
+						zap.String("session_id", sessionID),
+						zap.String("surviving_entry_id", merged.ID))
+					queued = merged
+					return nil
+				}
+			}
 			return err
 		}
 		if afterInsert != nil {

--- a/apps/backend/internal/orchestrator/messagequeue/service_auto_merge_test.go
+++ b/apps/backend/internal/orchestrator/messagequeue/service_auto_merge_test.go
@@ -69,19 +69,95 @@ func TestService_AutoMergeChainsThreeAdmissions(t *testing.T) {
 	}
 }
 
-func TestService_AutoMergeDoesNotBypassCapacity(t *testing.T) {
+func TestService_AutoMergeFoldsSameTaskSiblingSessions(t *testing.T) {
+	svc := newAutoMergeTestService(t, 10)
+	first, err := svc.QueueMessageWithMetadata(context.Background(), "session", "task", "first", "", QueuedByAgent, false, nil, map[string]interface{}{
+		MetadataSenderTaskID:    "sender-task",
+		MetadataSenderSessionID: "session-one",
+		"sender_session_name":   "reviewer-one",
+		"sender_task_title":     "Sender task",
+	})
+	if err != nil {
+		t.Fatalf("queue first: %v", err)
+	}
+	second, err := svc.QueueMessageWithMetadata(context.Background(), "session", "task", "second", "", QueuedByAgent, false, nil, map[string]interface{}{
+		MetadataSenderTaskID:    "sender-task",
+		MetadataSenderSessionID: "session-two",
+		"sender_session_name":   "reviewer-two",
+		"sender_task_title":     "Sender task",
+	})
+	if err != nil {
+		t.Fatalf("queue second: %v", err)
+	}
+	if second.ID != first.ID || second.Content != "first\n\nsecond" {
+		t.Fatalf("second admission = %+v, want folded survivor %s", second, first.ID)
+	}
+	status := svc.GetStatus(context.Background(), "session")
+	if status.Count != 1 || status.Entries[0].ID != first.ID {
+		t.Fatalf("status = %+v, want one merged entry", status)
+	}
+}
+
+func TestService_AutoMergeFoldsCompatibleAdmissionAtCapacity(t *testing.T) {
 	svc := newAutoMergeTestService(t, 1)
 	first, err := svc.QueueMessage(context.Background(), "session", "task", "first", "", QueuedByUser, false, nil)
 	if err != nil {
 		t.Fatalf("queue first: %v", err)
 	}
+	// A compatible message must fold into the tail instead of being rejected:
+	// the fold is the admission, so the queue never reports full for a message
+	// that would merge anyway.
 	second, err := svc.QueueMessage(context.Background(), "session", "task", "second", "", QueuedByUser, false, nil)
-	if !errors.Is(err, ErrQueueFull) || second != nil {
-		t.Fatalf("second admission = %+v, err=%v, want queue full", second, err)
+	if err != nil {
+		t.Fatalf("compatible admission at capacity = %v, want fold", err)
+	}
+	if second.ID != first.ID || second.Content != "first\n\nsecond" {
+		t.Fatalf("second admission = %+v, want folded survivor %s", second, first.ID)
 	}
 	status := svc.GetStatus(context.Background(), "session")
-	if status.Count != 1 || status.Entries[0].ID != first.ID || status.Entries[0].Content != "first" {
-		t.Fatalf("queue changed after full admission: %+v", status)
+	if status.Count != 1 || status.Entries[0].ID != first.ID || status.Entries[0].Content != "first\n\nsecond" {
+		t.Fatalf("queue after full-queue fold: %+v", status)
+	}
+}
+
+func TestService_AutoMergeAtFullQueueRejectsIncompatibleAdmission(t *testing.T) {
+	svc := newAutoMergeTestService(t, 1)
+	if _, err := svc.QueueMessage(context.Background(), "session", "task", "first", "model-a", QueuedByUser, false, nil); err != nil {
+		t.Fatalf("queue first: %v", err)
+	}
+	second, err := svc.QueueMessage(context.Background(), "session", "task", "second", "model-b", QueuedByUser, false, nil)
+	if !errors.Is(err, ErrQueueFull) || second != nil {
+		t.Fatalf("incompatible full admission = %+v, err=%v, want queue full", second, err)
+	}
+}
+
+func TestService_AutoMergeDisabledAtFullQueueRejects(t *testing.T) {
+	svc := newAutoMergeTestService(t, 1)
+	svc.SetAutoMergeEnabled(false)
+	if _, err := svc.QueueMessage(context.Background(), "session", "task", "first", "", QueuedByUser, false, nil); err != nil {
+		t.Fatalf("queue first: %v", err)
+	}
+	second, err := svc.QueueMessage(context.Background(), "session", "task", "second", "", QueuedByUser, false, nil)
+	if !errors.Is(err, ErrQueueFull) || second != nil {
+		t.Fatalf("disabled full admission = %+v, err=%v, want queue full", second, err)
+	}
+}
+
+func TestService_AutoMergeAtFullQueueSkipsAfterInsertHook(t *testing.T) {
+	svc := newAutoMergeTestService(t, 1)
+	if _, err := svc.QueueMessage(context.Background(), "session", "task", "first", "", QueuedByUser, false, nil); err != nil {
+		t.Fatalf("queue first: %v", err)
+	}
+	ran := false
+	second, err := svc.QueueMessageWithMetadataAfterInsert(
+		context.Background(), "session", "task", "second", "", QueuedByUser, false, nil, nil,
+		func(context.Context, *QueuedMessage) error { ran = true; return nil },
+	)
+	if !errors.Is(err, ErrQueueFull) || second != nil {
+		t.Fatalf("after-insert full admission = %+v, err=%v, want queue full", second, err)
+	}
+	if ran {
+		t.Fatal("after-insert hook ran for a rejected full-queue admission")
 	}
 }
 

--- a/apps/backend/internal/orchestrator/messagequeue/types.go
+++ b/apps/backend/internal/orchestrator/messagequeue/types.go
@@ -72,6 +72,17 @@ const MetadataLifecycleReserved = "lifecycle_reserved_in_flight"
 // never mixes prompts issued by different agents.
 const MetadataSenderTaskID = "sender_task_id"
 
+// MetadataSenderSessionID identifies the specific session of the sender task
+// that produced an agent message. It is per-session provenance, not merge
+// context: two messages from different sessions of the same sender task are
+// both prompts from that task's agents and fold like manual merge allows.
+const MetadataSenderSessionID = "sender_session_id"
+
+// MetadataSenderSessionName is the sender session's user-supplied name,
+// snapshotted for the receiving chat's sender badge. Like the session id it
+// is provenance and never blocks merging between same-task entries.
+const MetadataSenderSessionName = "sender_session_name"
+
 // QueueFullErrorCode is the well-known WS / MCP error code surfaced when an
 // insert would exceed the per-session cap. Shared between the user-side WS
 // handlers and the inter-task MCP handler so the wire contract stays in sync.

--- a/apps/web/e2e/tests/chat/message-queue-scroll-helpers.ts
+++ b/apps/web/e2e/tests/chat/message-queue-scroll-helpers.ts
@@ -5,12 +5,18 @@ import { SessionPage } from "../../pages/session-page";
 
 const FULL_QUEUE_SIZE = 10;
 
+export type FullQueueSeed = {
+  taskId: string;
+  sessionId: string;
+  session: SessionPage;
+};
+
 export async function seedFullQueueTask(
   page: Page,
   apiClient: ApiClient,
   seedData: SeedData,
   title: string,
-): Promise<SessionPage> {
+): Promise<FullQueueSeed> {
   const task = await apiClient.createTask(seedData.workspaceId, title, {
     description: "Queue scrolling regression",
     workflow_id: seedData.workflowId,
@@ -34,7 +40,7 @@ export async function seedFullQueueTask(
   await page.goto(`/t/${task.id}`);
   const session = new SessionPage(page);
   await session.waitForLoad();
-  return session;
+  return { taskId: task.id, sessionId, session };
 }
 
 export async function expectFullQueueScrolls(session: SessionPage): Promise<void> {

--- a/apps/web/e2e/tests/chat/message-queue.spec.ts
+++ b/apps/web/e2e/tests/chat/message-queue.spec.ts
@@ -225,7 +225,7 @@ test.describe("Task session queue", () => {
     apiClient,
     seedData,
   }) => {
-    const session = await seedFullQueueTask(
+    const { session } = await seedFullQueueTask(
       testPage,
       apiClient,
       seedData,
@@ -269,6 +269,35 @@ test.describe("Task session queue", () => {
     await expect(entries).toHaveCount(3, { timeout: 10_000 });
     await expect(entries.nth(1)).toHaveText("separate third");
     await expect(entries.nth(2)).toHaveText("separate fourth");
+  });
+
+  test("automatic merge accepts a compatible message into a full queue", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    const { taskId, sessionId, session } = await seedFullQueueTask(
+      testPage,
+      apiClient,
+      seedData,
+      "Full queue auto merge",
+    );
+
+    // The queue is at capacity (10 separate rows, auto-merge off per spec
+    // isolation). Enabling automatic merge must fold the next compatible
+    // message into the tail instead of rejecting it as "queue full".
+    await requestMessageQueueSettings(apiClient, "PATCH", { auto_merge_enabled: true });
+    await apiClient.queueMessage(taskId, sessionId, "folded while full");
+
+    const chat = session.activeChat();
+    const chip = chat.getByTestId("queue-chip");
+    await expect(chip).toBeVisible({ timeout: 10_000 });
+    await chip.click();
+    const panel = chat.getByTestId("queued-ghost-list");
+    const entries = panel.getByTestId("queue-entry-text");
+    await expect(entries).toHaveCount(10);
+    await expect(entries.last()).toContainText("Queued item 10");
+    await expect(entries.last()).toContainText("folded while full");
   });
 
   test("queue message via submit button on task session page", async ({

--- a/apps/web/e2e/tests/chat/mobile-message-queue-management.spec.ts
+++ b/apps/web/e2e/tests/chat/mobile-message-queue-management.spec.ts
@@ -48,7 +48,12 @@ test("mobile full queue stays usable while removing and clearing messages", asyn
   apiClient,
   seedData,
 }) => {
-  const session = await seedFullQueueTask(testPage, apiClient, seedData, "Mobile queue management");
+  const { session } = await seedFullQueueTask(
+    testPage,
+    apiClient,
+    seedData,
+    "Mobile queue management",
+  );
 
   await expectFullQueueScrolls(session);
 


### PR DESCRIPTION
Auto-merge skipped consecutive queued messages when they came from different sessions of the same sender task (per-session provenance keys blocked the metadata-equivalence fold), and rejected foldable messages outright once the queue hit its per-session cap. Both cases now fold the same way manual merge does, keeping the queue compact at and below capacity. Addresses the "Fix auto message merging" improve task.

## Important Changes

- `messagequeue`: `comparableAutoMetadata` now ignores `sender_session_id`/`sender_session_name` when deciding fold compatibility. Agent entries already must share `sender_task_id` (via `autoMergeAllowed`), so two messages from different sessions of that task — e.g. interleaved sibling reviewer sessions — fold like manual merge treats them; the surviving entry keeps the tail's session attribution.
- `messagequeue`: admission at a full queue (`ErrQueueFull`) now attempts to fold the incoming message directly into the tail via a new repository method `AutoMergeCandidateIntoAbove` (SQLite + memory). The fold is the admission, so a compatible message is accepted instead of rejected with "Queue is full". The attachment-claim (`afterInsert`) path is excluded because it claims staged attachments against a persisted source row the fold never creates.

## Validation

- `go test -tags fts5 ./internal/orchestrator/... ./internal/backendapp/ ./internal/mcp/...` — pass (remaining full-suite failures in `internal/launcher`, `internal/system/updates`, `internal/agentctl/server/*` are pre-existing environment issues, reproduced on a clean tree).
- `golangci-lint run ./...` — 0 issues; `gofmt` clean.
- New unit tests (red→green): repository fold for same-task/different-session agent entries across memory+sqlite+postgres backends, full-queue candidate fold, incompatible/disabled/after-insert rejections; handler-level WS tests for fold-at-capacity and `queue_full` rejection.
- Playwright e2e: "automatic merge accepts a compatible message into a full queue" (`apps/web/e2e/tests/chat/message-queue.spec.ts`) — passed via `run-e2e.sh --host`.
- Verified against the reported production case from backend logs: session `45da903d` on task `94a59d0f` — same-session reviewer chains folded, different-session transitions stayed separate (the bug), and the queue sat full with `queue full` rejections; both behaviors now fixed.

## Possible Improvements

Low risk: a merged entry keeps the tail entry's session attribution (identical to existing manual-merge semantics); attachment-bearing messages at a full queue still reject with `ErrQueueFull`.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2633?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->