### PR TITLE
fix(backend): report missing agent profile and unknown agent as 404

### DIFF
--- a/apps/backend/internal/agent/settings/controller/agent_config.go
+++ b/apps/backend/internal/agent/settings/controller/agent_config.go
@@ -266,7 +266,7 @@ func previewPrefersNativeBinary(agentConfig agents.Agent) bool {
 // flag triggers a live Refresh() call against the warm host instance.
 func (c *Controller) FetchDynamicModels(ctx context.Context, agentName string, refresh bool) (*dto.DynamicModelsResponse, error) {
 	if _, ok := c.agentRegistry.Get(agentName); !ok {
-		return nil, fmt.Errorf("agent %q not found", agentName)
+		return nil, ErrAgentNotFound
 	}
 	if c.hostUtility == nil {
 		return &dto.DynamicModelsResponse{

--- a/apps/backend/internal/agent/settings/controller/profile_crud.go
+++ b/apps/backend/internal/agent/settings/controller/profile_crud.go
@@ -521,7 +521,11 @@ func validateCommandPrefix(prefix string) error {
 func (c *Controller) DeleteProfile(ctx context.Context, id string, force bool) (*dto.AgentProfileDTO, error) {
 	profile, err := c.repo.GetAgentProfile(ctx, id)
 	if err != nil {
-		if strings.Contains(err.Error(), "agent profile not found") {
+		// The read path reports a missing (or already soft-deleted) row as
+		// sql.ErrNoRows, not as the "agent profile not found" message the
+		// update/delete paths use, so this has to go through the helper that
+		// knows both shapes or the sentinel is never returned.
+		if isProfileNotFoundErr(err) {
 			return nil, ErrAgentProfileNotFound
 		}
 		return nil, err
@@ -536,7 +540,7 @@ func (c *Controller) DeleteProfile(ctx context.Context, id string, force bool) (
 		return nil, err
 	}
 	if err := c.repo.DeleteAgentProfile(ctx, id); err != nil {
-		if strings.Contains(err.Error(), "agent profile not found") {
+		if isProfileNotFoundErr(err) {
 			return nil, ErrAgentProfileNotFound
 		}
 		return nil, err

--- a/apps/backend/internal/agent/settings/controller/profile_crud_soft_delete_test.go
+++ b/apps/backend/internal/agent/settings/controller/profile_crud_soft_delete_test.go
@@ -1,0 +1,77 @@
+package controller
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/jmoiron/sqlx"
+	_ "github.com/mattn/go-sqlite3"
+
+	"github.com/kandev/kandev/internal/agent/registry"
+	"github.com/kandev/kandev/internal/agent/settings/models"
+	"github.com/kandev/kandev/internal/agent/settings/store"
+	"github.com/kandev/kandev/internal/common/logger"
+)
+
+// newSQLiteBackedController wires the controller to the real sqlite settings
+// store rather than a fake. The not-found classification below depends on the
+// exact error shapes that store produces (sql.ErrNoRows from the read path, a
+// message from the delete path), which is precisely what a fake cannot pin.
+func newSQLiteBackedController(t *testing.T) (*Controller, store.Repository) {
+	t.Helper()
+	log, err := logger.NewLogger(logger.LoggingConfig{Level: "error", Format: "json"})
+	if err != nil {
+		t.Fatalf("logger: %v", err)
+	}
+	db, err := sqlx.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	repo, cleanup, err := store.Provide(db, db, log)
+	if err != nil {
+		t.Fatalf("settings store: %v", err)
+	}
+	t.Cleanup(func() { _ = cleanup() })
+
+	return NewController(repo, nil, registry.NewRegistry(log), nil, log), repo
+}
+
+// TestDeleteProfile_SoftDeletedRowIsNotFound is the production shape of the
+// bug: the row exists but carries deleted_at, so GetAgentProfile hides it
+// behind sql.ErrNoRows. Classifying that lookup by error message alone never
+// matched, and the raw sql.ErrNoRows fell through to the caller's 500 branch.
+func TestDeleteProfile_SoftDeletedRowIsNotFound(t *testing.T) {
+	ctrl, repo := newSQLiteBackedController(t)
+	ctx := context.Background()
+
+	profile := &models.AgentProfile{AgentID: "agent-1", Name: "Doomed", Model: "model-a"}
+	if err := repo.CreateAgentProfile(ctx, profile); err != nil {
+		t.Fatalf("seed profile: %v", err)
+	}
+
+	if _, err := ctrl.DeleteProfile(ctx, profile.ID, false); err != nil {
+		t.Fatalf("first delete: %v", err)
+	}
+	if _, err := repo.GetAgentProfileIncludingDeleted(ctx, profile.ID); err != nil {
+		t.Fatalf("row should still exist as a soft-deleted row: %v", err)
+	}
+
+	_, err := ctrl.DeleteProfile(ctx, profile.ID, false)
+	if !errors.Is(err, ErrAgentProfileNotFound) {
+		t.Fatalf("second delete err = %v, want ErrAgentProfileNotFound", err)
+	}
+}
+
+// TestDeleteProfile_UnknownIDIsNotFound covers the other entry into the same
+// branch, where no row was ever written.
+func TestDeleteProfile_UnknownIDIsNotFound(t *testing.T) {
+	ctrl, _ := newSQLiteBackedController(t)
+
+	_, err := ctrl.DeleteProfile(context.Background(), "never-existed", false)
+	if !errors.Is(err, ErrAgentProfileNotFound) {
+		t.Fatalf("delete err = %v, want ErrAgentProfileNotFound", err)
+	}
+}

--- a/apps/backend/internal/agent/settings/handlers/discovery_handlers_test.go
+++ b/apps/backend/internal/agent/settings/handlers/discovery_handlers_test.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"errors"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/kandev/kandev/internal/agent/settings/controller"
@@ -62,13 +63,6 @@ func TestListAvailableAgentsEndpointIncludesUninstalledAgents(t *testing.T) {
 
 // TestGetAgentModelsEndpoint covers the two reachable outcomes of
 // /agent-models/:agentName.
-//
-// KNOWN DEFECT, asserted as-is rather than fixed here (test-only work): the
-// handler's controller.ErrAgentNotFound -> 404 branch is unreachable, because
-// FetchDynamicModels reports an unknown agent with a fresh fmt.Errorf rather
-// than the sentinel. An unknown agent therefore surfaces as a 500 carrying the
-// raw message. When FetchDynamicModels is switched to the sentinel, the second
-// expectation below becomes 404 / "agent not found".
 func TestGetAgentModelsEndpoint(t *testing.T) {
 	t.Run("registered agent without a probe reports not_configured", func(t *testing.T) {
 		router, _, reg := newSettingsHarness(t, newFakeSettingsRepo(), nil)
@@ -85,10 +79,18 @@ func TestGetAgentModelsEndpoint(t *testing.T) {
 		}
 	})
 
-	t.Run("unknown agent currently reports 500 instead of 404", func(t *testing.T) {
+	// FetchDynamicModels returns controller.ErrAgentNotFound for an agent the
+	// registry does not know, which is the sentinel the handler's 404 branch
+	// matches on. The body is the handler's fixed message: unlike the 500
+	// branch it must not echo the controller error, so the caller-supplied
+	// agent name never reaches the wire.
+	t.Run("unknown agent is 404 with a fixed body", func(t *testing.T) {
 		router := newSettingsRouter(t, newFakeSettingsRepo(), nil)
 		response := doSettingsRequest(router, http.MethodGet, "/api/v1/agent-models/ghost", "")
-		requireErrorBody(t, response, http.StatusInternalServerError, `agent "ghost" not found`)
+		requireErrorBody(t, response, http.StatusNotFound, "agent not found")
+		if strings.Contains(response.Body.String(), "ghost") {
+			t.Errorf("404 body %s echoes the raw error", response.Body.String())
+		}
 	})
 }
 

--- a/apps/backend/internal/agent/settings/handlers/profile_crud_handlers_test.go
+++ b/apps/backend/internal/agent/settings/handlers/profile_crud_handlers_test.go
@@ -255,21 +255,14 @@ func TestDeleteProfileEndpoint(t *testing.T) {
 		}
 	})
 
-	// KNOWN DEFECT, asserted as-is rather than fixed here: this test is
-	// test-only work. controller.DeleteProfile classifies the missing-source
-	// lookup with a `strings.Contains(err.Error(), "agent profile not found")`
-	// check, but the sqlite store returns sql.ErrNoRows from GetAgentProfile
-	// (its soft-delete tests pin that), so the message never matches and the
-	// error falls through as a 500. The sibling helper isProfileNotFoundErr in
-	// the same file already handles both shapes and is what DuplicateProfile
-	// uses. When DeleteProfile is switched to it, this expectation becomes 404
-	// with an "agent profile not found" body.
-	t.Run("unknown profile currently reports 500 instead of 404", func(t *testing.T) {
+	// The source lookup reports a missing row as sql.ErrNoRows, so classifying
+	// it by message alone silently drops through to the 500 branch.
+	t.Run("unknown profile is 404", func(t *testing.T) {
 		repo := newFakeSettingsRepo()
 		hub := &duplicateHub{}
 		router := newSettingsRouter(t, repo, hub)
 		response := doSettingsRequest(router, http.MethodDelete, "/api/v1/agent-profiles/missing", "")
-		requireErrorBody(t, response, http.StatusInternalServerError, "failed to delete profile")
+		requireErrorBody(t, response, http.StatusNotFound, "agent profile not found")
 		if len(hub.actions()) != 0 {
 			t.Fatalf("failed delete broadcast %v", hub.actions())
 		}

--- a/apps/backend/internal/mcp/handlers/config_agent_handlers.go
+++ b/apps/backend/internal/mcp/handlers/config_agent_handlers.go
@@ -110,7 +110,6 @@ func (h *Handlers) handleDeleteAgentProfile(ctx context.Context, msg *ws.Message
 
 	profile, err := h.agentSettingsCtrl.DeleteProfile(ctx, profileID, false)
 	if err != nil {
-		h.logger.Error("failed to delete agent profile", zap.Error(err))
 		var inUseErr *agentsettingscontroller.ErrProfileInUseDetail
 		if errors.As(err, &inUseErr) {
 			return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeValidation, "Cannot delete: profile is used by an active agent session", nil)
@@ -118,6 +117,10 @@ func (h *Handlers) handleDeleteAgentProfile(ctx context.Context, msg *ws.Message
 		if errors.Is(err, agentsettingscontroller.ErrAgentProfileNotFound) {
 			return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeNotFound, "Agent profile not found", nil)
 		}
+		// Only an unclassified failure is a server error. Deleting a profile
+		// that is gone, or one still in use, are client conditions, and the
+		// REST sibling likewise logs only in its 500 branch.
+		h.logger.Error("failed to delete agent profile", zap.Error(err))
 		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError, "Failed to delete agent profile: "+err.Error(), nil)
 	}
 	h.publishAgentProfileEvent(ctx, events.AgentProfileDeleted, profile)

--- a/apps/backend/internal/mcp/handlers/config_agent_handlers.go
+++ b/apps/backend/internal/mcp/handlers/config_agent_handlers.go
@@ -115,6 +115,9 @@ func (h *Handlers) handleDeleteAgentProfile(ctx context.Context, msg *ws.Message
 		if errors.As(err, &inUseErr) {
 			return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeValidation, "Cannot delete: profile is used by an active agent session", nil)
 		}
+		if errors.Is(err, agentsettingscontroller.ErrAgentProfileNotFound) {
+			return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeNotFound, "Agent profile not found", nil)
+		}
 		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError, "Failed to delete agent profile: "+err.Error(), nil)
 	}
 	h.publishAgentProfileEvent(ctx, events.AgentProfileDeleted, profile)

--- a/apps/backend/internal/mcp/handlers/config_agent_handlers_test.go
+++ b/apps/backend/internal/mcp/handlers/config_agent_handlers_test.go
@@ -1,0 +1,108 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jmoiron/sqlx"
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kandev/kandev/internal/agent/registry"
+	agentsettingscontroller "github.com/kandev/kandev/internal/agent/settings/controller"
+	settingsmodels "github.com/kandev/kandev/internal/agent/settings/models"
+	settingsstore "github.com/kandev/kandev/internal/agent/settings/store"
+	"github.com/kandev/kandev/internal/common/logger"
+	ws "github.com/kandev/kandev/pkg/websocket"
+)
+
+// newAgentSettingsHandlers wires the MCP handlers to a real agent-settings
+// controller over an in-memory sqlite store, so the delete tool below is
+// classified from the error shapes production actually produces.
+func newAgentSettingsHandlers(t *testing.T) (*Handlers, settingsstore.Repository, *agentsettingscontroller.Controller) {
+	t.Helper()
+	log, err := logger.NewLogger(logger.LoggingConfig{Level: "error", Format: "json"})
+	require.NoError(t, err)
+
+	db, err := sqlx.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	repo, cleanup, err := settingsstore.Provide(db, db, log)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = cleanup() })
+
+	ctrl := agentsettingscontroller.NewController(repo, nil, registry.NewRegistry(log), nil, log)
+	return &Handlers{logger: log, agentSettingsCtrl: ctrl}, repo, ctrl
+}
+
+// stubUtilityDeps reports a fixed set of utility agents bound to a profile so
+// the in-use branch of the delete tool stays reachable.
+type stubUtilityDeps struct {
+	refs []agentsettingscontroller.UtilityAgentReference
+}
+
+func (s *stubUtilityDeps) ListUtilityAgentsByAgentProfile(
+	context.Context, string,
+) ([]agentsettingscontroller.UtilityAgentReference, error) {
+	return s.refs, nil
+}
+
+func (s *stubUtilityDeps) ClearUtilityAgentProfileBindings(context.Context, string) error {
+	return nil
+}
+
+// TestHandleDeleteAgentProfile_UnknownProfileIsNotFound pins the MCP surface of
+// the missing-profile classification. Without a not-found branch every failure
+// but the in-use one collapsed into INTERNAL_ERROR, so an agent deleting a
+// profile that was already gone was told the server had broken.
+func TestHandleDeleteAgentProfile_UnknownProfileIsNotFound(t *testing.T) {
+	h, _, _ := newAgentSettingsHandlers(t)
+
+	msg := makeWSMessage(t, ws.ActionMCPDeleteAgentProfile, map[string]interface{}{
+		"profile_id": "never-existed",
+	})
+	resp, err := h.handleDeleteAgentProfile(context.Background(), msg)
+	require.NoError(t, err)
+	assertWSError(t, resp, ws.ErrorCodeNotFound)
+}
+
+// TestHandleDeleteAgentProfile_SoftDeletedProfileIsNotFound is the same
+// classification reached the way a user reaches it: the row exists but is
+// already soft-deleted, which the store hides behind sql.ErrNoRows.
+func TestHandleDeleteAgentProfile_SoftDeletedProfileIsNotFound(t *testing.T) {
+	h, repo, _ := newAgentSettingsHandlers(t)
+	ctx := context.Background()
+
+	profile := &settingsmodels.AgentProfile{AgentID: "agent-1", Name: "Doomed", Model: "model-a"}
+	require.NoError(t, repo.CreateAgentProfile(ctx, profile))
+	require.NoError(t, repo.DeleteAgentProfile(ctx, profile.ID))
+
+	msg := makeWSMessage(t, ws.ActionMCPDeleteAgentProfile, map[string]interface{}{
+		"profile_id": profile.ID,
+	})
+	resp, err := h.handleDeleteAgentProfile(ctx, msg)
+	require.NoError(t, err)
+	assertWSError(t, resp, ws.ErrorCodeNotFound)
+}
+
+// TestHandleDeleteAgentProfile_InUseStaysAValidationError guards the branch the
+// not-found mapping was added next to: a profile still bound to a utility agent
+// must keep reporting VALIDATION_ERROR rather than being swallowed by it.
+func TestHandleDeleteAgentProfile_InUseStaysAValidationError(t *testing.T) {
+	h, repo, ctrl := newAgentSettingsHandlers(t)
+	ctx := context.Background()
+
+	profile := &settingsmodels.AgentProfile{AgentID: "agent-1", Name: "Bound", Model: "model-a"}
+	require.NoError(t, repo.CreateAgentProfile(ctx, profile))
+	ctrl.SetUtilityDependencyChecker(&stubUtilityDeps{
+		refs: []agentsettingscontroller.UtilityAgentReference{{ID: "utility-1", Name: "Title"}},
+	})
+
+	msg := makeWSMessage(t, ws.ActionMCPDeleteAgentProfile, map[string]interface{}{
+		"profile_id": profile.ID,
+	})
+	resp, err := h.handleDeleteAgentProfile(ctx, msg)
+	require.NoError(t, err)
+	assertWSError(t, resp, ws.ErrorCodeValidation)
+}


### PR DESCRIPTION
Two "not found" conditions in the agent-settings controller surfaced as 500s because their sentinels were never returned: `DeleteProfile` classified its source lookup by error message while the store's read path reports a missing (or already soft-deleted) row as `sql.ErrNoRows`, and `FetchDynamicModels` returned a fresh `fmt.Errorf` instead of `ErrAgentNotFound`. Both handler 404 branches were dead code; deleting an already-deleted profile and asking for an unknown agent's models now answer 404, and the models route no longer echoes the caller-supplied agent name back in the body.

## Important Changes

- `DeleteProfile` uses the existing `isProfileNotFoundErr` helper (already used by `DuplicateProfile`) instead of a drifted duplicate string match.
- The MCP `delete_agent_profile` tool gained a not-found branch; without it, everything but `ErrProfileInUseDetail` collapsed into `INTERNAL_ERROR`. The in-use mapping is unchanged and pinned by a new test.

## Validation

- `CGO_ENABLED=1 go test -tags fts5 -race -count=1 ./internal/agent/settings/... ./internal/mcp/handlers/...` — pass.
- `make -C apps/backend lint` and `golangci-lint run ./... --new-from-rev=origin/main` — 0 issues.
- Mutation-verified: reverting the `DeleteProfile` guard fails the controller, REST, and MCP tests (`want ErrAgentProfileNotFound`, `status = 500, want 404`, `expected NOT_FOUND, actual INTERNAL_ERROR`); reverting only the MCP mapping fails the MCP tests while REST stays green; reverting the `FetchDynamicModels` sentinel fails `TestGetAgentModelsEndpoint` with `body = {"error":"agent \"ghost\" not found"}`. Restored, all green.
- The two tests #2634 deliberately pinned to the defective behaviour are flipped here; new coverage adds the soft-deleted delete path over a real sqlite store, the MCP not-found and in-use mappings, and the no-raw-error assertion on the 404 body.

## Possible Improvements

Low risk. The only behaviour change is the status code and message on three previously-500 paths; the MCP surface returns `NOT_FOUND` where it returned `INTERNAL_ERROR`, which a client keying off the error code would now see differently.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2636?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->