### PR TITLE
ci(e2e): log the flake cross-check verdict on every run, not just mismatches

### DIFF
--- a/apps/web/e2e/README.md
+++ b/apps/web/e2e/README.md
@@ -172,6 +172,12 @@ test are classified the way Playwright classifies them. The report cross-checks
 its count against `stats.flaky` in the merged Playwright JSON report for the
 same run and prints **MISMATCH** plus a workflow warning if the two disagree.
 
+The cross-check reports its verdict in the workflow log on every run, not only
+on a mismatch, and annotates a skipped check as a warning. If only a mismatch
+spoke, a cross-check that had silently stopped running would be indistinguishable
+in the log from one that passed, which is the same shape of bug as a flake that
+never fails the build.
+
 The trend is carried between runs as the `e2e-flake-history` artifact (90 days,
 capped at 50 entries, newest first). `e2e-report` looks for the newest completed
 `main` run that published one, uses it as the baseline, appends this run's entry,

--- a/apps/web/e2e/scripts/flake-report.test.ts
+++ b/apps/web/e2e/scripts/flake-report.test.ts
@@ -1,11 +1,14 @@
+import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import {
   appendHistoryEntry,
   baselineFrom,
   crossCheckFlakeCount,
+  crossCheckLogLine,
   entryFromSummary,
   MAX_HISTORY_ENTRIES,
   median,
@@ -16,6 +19,8 @@ import {
   type FlakeHistoryEntry,
 } from "./flake-report";
 import type { RetrySummary, RetryTestSummary } from "./retry-summary";
+
+const scriptsRoot = path.dirname(fileURLToPath(import.meta.url));
 
 function entry(overrides: Partial<FlakeHistoryEntry> = {}): FlakeHistoryEntry {
   const runId = overrides.runId ?? "100";
@@ -178,6 +183,66 @@ describe("playwright cross-check", () => {
       flaky: 4,
     });
   });
+
+  // A cross-check that silently stopped running must not look like one that
+  // passed, so every status speaks in the workflow log, not just a mismatch.
+  it("logs a line for every cross-check status, warning on anything but a match", () => {
+    expect(crossCheckLogLine({ status: "match", ours: 3, theirs: 3 })).toBe(
+      "E2E flake cross-check: match. retry-summary and the merged Playwright report both report 3 flaky.",
+    );
+    expect(crossCheckLogLine({ status: "mismatch", ours: 3, theirs: 4 })).toBe(
+      "::warning::E2E flake cross-check: MISMATCH. retry-summary reports 3 flaky, the merged Playwright " +
+        "report reports 4. The trended flake rate is not trustworthy for this run.",
+    );
+    expect(
+      crossCheckLogLine({
+        status: "unavailable",
+        ours: 3,
+        reason: "no merged Playwright JSON report",
+      }),
+    ).toBe(
+      "::warning::E2E flake cross-check: SKIPPED (no merged Playwright JSON report). " +
+        "The reported flake count of 3 was not verified against Playwright.",
+    );
+  });
+
+  // Asserting the strings only proves they are right, not that the CLI ever
+  // prints them, so this drives the real entry point. Without it, restoring the
+  // "only a mismatch speaks" behaviour passes every other test in this file.
+  it("prints the cross-check verdict from the CLI on a match, not only on a mismatch", () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "kandev-flake-cli-"));
+    const summaryPath = path.join(directory, "retry-summary.json");
+    const mergedPath = path.join(directory, "merged-report.json");
+    fs.writeFileSync(summaryPath, JSON.stringify(summary({ flaky: 3 })));
+    fs.writeFileSync(
+      mergedPath,
+      '{"suites":[],"errors":[],"stats":{"expected":10,"skipped":0,"unexpected":0,"flaky":3}}',
+    );
+
+    const stdout = execFileSync(
+      path.join(scriptsRoot, "../../node_modules/.bin/tsx"),
+      [
+        path.join(scriptsRoot, "flake-report.ts"),
+        "--summary",
+        summaryPath,
+        "--step-summary",
+        path.join(directory, "step-summary.md"),
+        "--playwright-json",
+        mergedPath,
+        "--run-id",
+        "7",
+        "--branch",
+        "main",
+        "--sha",
+        "abcdef1234567",
+      ],
+      { encoding: "utf8" },
+    );
+
+    expect(stdout.trim()).toBe(
+      "E2E flake cross-check: match. retry-summary and the merged Playwright report both report 3 flaky.",
+    );
+  }, 30_000);
 
   it("reports match, mismatch, and unavailable distinctly", () => {
     const stats = { expected: 10, unexpected: 0, flaky: 4, skipped: 0 };

--- a/apps/web/e2e/scripts/flake-report.ts
+++ b/apps/web/e2e/scripts/flake-report.ts
@@ -204,6 +204,29 @@ function runLabel(entry: FlakeHistoryEntry): string {
   return entry.runUrl ? `[${label}](${entry.runUrl})` : label;
 }
 
+/**
+ * The workflow-log counterpart of the summary's cross-check line. Every status
+ * gets a line, including a match: if only a mismatch spoke, a cross-check that
+ * silently stopped running would be indistinguishable in the log from one that
+ * passed, and an unverified flake rate is the failure this whole report exists
+ * to prevent. A skip is annotated as a warning for the same reason.
+ */
+export function crossCheckLogLine(check: CrossCheck): string {
+  if (check.status === "match") {
+    return `E2E flake cross-check: match. retry-summary and the merged Playwright report both report ${check.ours} flaky.`;
+  }
+  if (check.status === "mismatch") {
+    return (
+      `::warning::E2E flake cross-check: MISMATCH. retry-summary reports ${check.ours} flaky, ` +
+      `the merged Playwright report reports ${check.theirs}. The trended flake rate is not trustworthy for this run.`
+    );
+  }
+  return (
+    `::warning::E2E flake cross-check: SKIPPED (${check.reason}). ` +
+    `The reported flake count of ${check.ours} was not verified against Playwright.`
+  );
+}
+
 function crossCheckLine(check: CrossCheck): string {
   if (check.status === "match") {
     return `- Playwright cross-check: **match** (${check.ours} flaky in both retry-summary and the merged report)`;
@@ -337,12 +360,7 @@ function runCli(): void {
     );
   }
 
-  if (check.status === "mismatch") {
-    console.log(
-      `::warning::E2E flake count mismatch: retry-summary reports ${check.ours}, ` +
-        `the merged Playwright report reports ${check.theirs}.`,
-    );
-  }
+  console.log(crossCheckLogLine(check));
 }
 
 if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {


### PR DESCRIPTION
The flake cross-check only spoke in the workflow log when it disagreed with Playwright, so a cross-check that had silently stopped running was indistinguishable from one that passed: "no warning" meant either "verified" or "never ran". Every status now prints a line, and a skipped check is annotated as a warning naming the reason and the count that went unverified.

The three lines, exercised through the real CLI:

```
E2E flake cross-check: match. retry-summary and the merged Playwright report both report 3 flaky.
::warning::E2E flake cross-check: MISMATCH. retry-summary reports 3 flaky, the merged Playwright report reports 4. The trended flake rate is not trustworthy for this run.
::warning::E2E flake cross-check: SKIPPED (no merged Playwright JSON report). The reported flake count of 3 was not verified against Playwright.
```

A skip is a warning on purpose: an unverified flake rate still gets trended, and that is the failure the cross-check exists to prevent.

## Validation

- `pnpm test -- --run e2e/scripts/` (46 passing), `pnpm run lint <changed files>`, exit codes checked directly.
- Ran the CLI against fixtures for all three statuses and confirmed the exact stdout above.
- Mutation tested. The first attempt at this had a hole worth recording: with only a unit test over the formatting helper, restoring the old "only a mismatch speaks" behaviour **passed every test in the file** — the strings were asserted, but nothing asserted they were ever printed. The test now drives the real entry point via `execFileSync`, and that mutant fails with `expected '' to be 'E2E flake cross-check: match…'`. Two further mutants (silent match line, skip not annotated as a warning) are also caught.
- Typechecked directly with a config that includes `e2e/scripts/**`, since `apps/web/tsconfig.json` excludes `e2e` and the repo's `pnpm run typecheck` does not cover this tree at all. The only error is pre-existing and in an untouched file (`run-planned-shard.test.ts` imports a non-existent `ShardManifest`).

## Possible Improvements

Negligible risk: one `console.log` at the end of a reporting step that is already `if: always()`, plus its test and a README paragraph. Separately worth knowing, and not addressed here: `apps/web/tsconfig.json` excludes `e2e`, so nothing in that tree is typechecked by CI. A survey found 107 errors across 54 files, 81 of them in `e2e/tests/`, 15 of them one missing `Window` augmentation.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2639?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->