### PR TITLE
fix(lifecycle): forward TaskID in container create-instance request

### DIFF
--- a/apps/backend/internal/agent/runtime/lifecycle/container.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/container.go
@@ -102,6 +102,7 @@ func buildContainerCreateInstanceRequest(
 		AutoStart:           false,
 		McpServers:          config.McpServers,
 		SessionID:           config.SessionID,
+		TaskID:              config.TaskID,
 		DisableAskQuestion:  disableAskQuestion,
 		AssumeMcpSse:        assumeMcpSse,
 		AssumeMcpHttp:       assumeMcpHttp,

--- a/apps/backend/internal/agent/runtime/lifecycle/provider_propagation_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/provider_propagation_test.go
@@ -43,6 +43,46 @@ func TestAgentctlProviderMappingsPreserveProviderCapabilities(t *testing.T) {
 	}
 }
 
+// Regression: the container (docker executor fresh-launch) create-instance
+// builder dropped TaskID while SessionID survived, leaving the in-container
+// MCP server unbound — set_task_title_kandev / step_complete_kandev then fail
+// with "requires a bound task" for every task running in a docker container.
+// Keep all five executor builders forwarding the same identity fields.
+func TestExecutorCreateInstanceBuildersPropagateTaskAndSession(t *testing.T) {
+	const wantTask = "task-identity-propagation"
+	const wantSession = "session-identity-propagation"
+
+	req := &ExecutorCreateRequest{TaskID: wantTask, SessionID: wantSession}
+	containerCfg := ContainerConfig{TaskID: wantTask, SessionID: wantSession}
+
+	standalone := buildStandaloneCreateInstanceRequest(req, nil, "", false, false, false, false, nil)
+	container := buildContainerCreateInstanceRequest(containerCfg, "", false, false, false, false, nil)
+	reconnect := buildReconnectCreateInstanceRequest(req, "previous-execution")
+	sprites := spriteCreateInstanceRequest(req)
+	ssh := buildSSHCreateInstanceRequest(req, "/workspace")
+
+	mapped := map[string]*agentctlCreateInstanceIdentity{
+		"standalone": {standalone.TaskID, standalone.SessionID},
+		"container":  {container.TaskID, container.SessionID},
+		"reconnect":  {reconnect.TaskID, reconnect.SessionID},
+		"sprites":    {sprites.TaskID, sprites.SessionID},
+		"ssh":        {ssh.TaskID, ssh.SessionID},
+	}
+	for backend, got := range mapped {
+		if got.taskID != wantTask {
+			t.Errorf("%s TaskID = %q, want %q", backend, got.taskID, wantTask)
+		}
+		if got.sessionID != wantSession {
+			t.Errorf("%s SessionID = %q, want %q", backend, got.sessionID, wantSession)
+		}
+	}
+}
+
+type agentctlCreateInstanceIdentity struct {
+	taskID    string
+	sessionID string
+}
+
 func TestManagerLaunchCarriesMCPProvidersToExecutor(t *testing.T) {
 	mgr, backend := newEnvironmentExecutionTestManager(t, nil)
 	want := []string{"github", "gitlab"}


### PR DESCRIPTION
## Root cause

`buildContainerCreateInstanceRequest` in `apps/backend/internal/agent/runtime/lifecycle/container.go` forwards `SessionID` but not `TaskID` into the agentctl instance create request. The instance config then keeps `TaskID == ""`, so the MCP server built for the agent session inside every freshly-launched docker-executor container runs **unbound**: `s.taskID == ""`.

Symptom agents see:
- `set_task_title_kandev` → `set_task_title_kandev requires a bound task`
- `step_complete_kandev` → `step_complete_kandev requires a bound task and session`
- `add_branch_to_task_kandev` / `add_workspace_sources_kandev` → `task_id is not available in this session` (even with an explicit task_id, since it must equal the bound one)
- `create_task_kandev` with `parent_id: "self"` → `no current task context`; `source_task_id` silently empty

Tools that take an explicit `task_id` keep working because the bidirectional channel to the backend carries execution identity independently — which masked this in smoke tests.

## Scope

Only the docker executor **fresh-launch** path is affected, which covers both `local_docker` and `remote_docker` (every containerized task). The sibling builders all forward `TaskID` correctly:

- `buildStandaloneCreateInstanceRequest` (executor_standalone.go)
- `buildReconnectCreateInstanceRequest` (executor_docker.go)
- `buildSSHCreateInstanceRequest` (executor_ssh_operations.go)
- sprites' `spriteCreateInstanceRequest`

Since the binding is immutable after server construction (no setter), a running session can never repair itself.

## Verification

- New regression test `TestExecutorCreateInstanceBuildersPropagateTaskAndSession` asserts all five create-instance builders propagate TaskID + SessionID.
- Fails without the fix: `container TaskID = "", want "task-identity-propagation"`
- Passes with it; also reproduced end-to-end against a live 0.86.0 deployment (probe of the in-container instance MCP endpoint showed the empty binding; the same endpoint accepts task-bound tools after the config fix).

Found in production on kandev 0.86.0.

Assisted-by: OpenCode investigation agent

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2643?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

