### PR TITLE
fix(settings): show full-desktop profile actions inline (#2629)

### DIFF
--- a/apps/web/components/settings/agents/agent-profiles-section.test.tsx
+++ b/apps/web/components/settings/agents/agent-profiles-section.test.tsx
@@ -9,16 +9,20 @@ const mocks = vi.hoisted(() => ({
   duplicateAgentProfileAction: vi.fn(),
   toast: vi.fn(),
   routerPush: vi.fn(),
+  responsive: { isFullDesktop: false },
 }));
 
 function profile(id: string, name: string): AgentProfile {
   return { id, name, agentDisplayName: "Claude Code" } as AgentProfile;
 }
 
+const ALPHA_PROFILE_NAME = "Alpha";
+const PROFILE_ROW_SELECTOR = '[data-testid="agent-profile-row"]';
+
 const AGENT = {
   id: "agent-1",
   name: "claude",
-  profiles: [profile("p-1", "Alpha"), profile("p-2", "Beta")],
+  profiles: [profile("p-1", ALPHA_PROFILE_NAME), profile("p-2", "Beta")],
 } as unknown as Agent;
 
 const EMPTY_AGENT = { ...AGENT, profiles: [] } as unknown as Agent;
@@ -59,6 +63,10 @@ vi.mock("@/components/toast-provider", () => ({
 vi.mock("@/lib/routing/client-router", () => ({
   useRouter: () => ({ push: mocks.routerPush }),
   usePathname: () => "/settings/agents",
+}));
+
+vi.mock("@/hooks/use-responsive-breakpoint", () => ({
+  useResponsiveBreakpoint: () => mocks.responsive,
 }));
 
 vi.mock("@/components/routing/app-link", () => ({
@@ -115,9 +123,10 @@ function renderRows() {
 }
 
 function confirmDeleteFor(name: string) {
-  const row = screen.getByLabelText(name).closest('[data-testid="agent-profile-row"]');
+  const row = screen.getByLabelText(name).closest(PROFILE_ROW_SELECTOR);
   if (!row) throw new Error(`no row for ${name}`);
-  fireEvent.click(row.querySelector('[data-testid="delete-item"]')!);
+  const profileId = name === "Alpha" ? "p-1" : "p-2";
+  fireEvent.click(row.querySelector(`[data-testid="delete-profile-${profileId}"]`)!);
   fireEvent.click(row.querySelector('[data-testid="confirm-delete"]')!);
 }
 
@@ -173,11 +182,13 @@ describe("ProfileRow deletion", () => {
 
 describe("ProfileRow duplicate", () => {
   beforeEach(() => {
+    mocks.responsive.isFullDesktop = false;
     storeState = {
       settingsAgents: { items: [{ ...AGENT, profiles: [...AGENT.profiles] }] },
       agentProfiles: { items: [] },
     };
   });
+  afterEach(() => cleanup());
 
   it("calls the duplicate action with the profile id", async () => {
     mocks.duplicateAgentProfileAction.mockResolvedValue({
@@ -186,11 +197,65 @@ describe("ProfileRow duplicate", () => {
     } as unknown as AgentProfile);
     renderRows();
 
-    const row = screen.getByLabelText("Alpha").closest('[data-testid="agent-profile-row"]');
-    if (!row) throw new Error("no row for Alpha");
+    const row = screen.getByLabelText(ALPHA_PROFILE_NAME).closest(PROFILE_ROW_SELECTOR);
+    if (!row) throw new Error(`no row for ${ALPHA_PROFILE_NAME}`);
     fireEvent.click(row.querySelector('[data-testid="duplicate-profile-p-1"]')!);
 
     await waitFor(() => expect(mocks.duplicateAgentProfileAction).toHaveBeenCalledWith("p-1"));
+  });
+});
+
+describe("ProfileRow responsive actions", () => {
+  beforeEach(() => {
+    storeState = {
+      settingsAgents: { items: [{ ...AGENT, profiles: [...AGENT.profiles] }] },
+      agentProfiles: { items: [] },
+    };
+    mocks.responsive.isFullDesktop = false;
+    vi.clearAllMocks();
+  });
+  afterEach(() => cleanup());
+
+  it("renders labeled duplicate and delete actions inline on full desktop", () => {
+    mocks.responsive.isFullDesktop = true;
+    render(<ProfileRow agent={AGENT} profile={AGENT.profiles[0]} />);
+
+    const row = screen.getByLabelText(ALPHA_PROFILE_NAME).closest(PROFILE_ROW_SELECTOR);
+    if (!row) throw new Error(`no row for ${ALPHA_PROFILE_NAME}`);
+    expect(row.querySelector('[data-testid="profile-actions-inline-p-1"]')).not.toBeNull();
+    expect(row.querySelector('[data-testid="duplicate-profile-inline-p-1"]')).not.toBeNull();
+    expect(row.querySelector('[data-testid="delete-profile-inline-p-1"]')).not.toBeNull();
+    expect(row.querySelector('[data-testid="profile-actions-menu-p-1"]')).toBeNull();
+  });
+
+  it("keeps duplicate and delete in the overflow menu below full desktop", () => {
+    render(<ProfileRow agent={AGENT} profile={AGENT.profiles[0]} />);
+
+    const row = screen.getByLabelText(ALPHA_PROFILE_NAME).closest(PROFILE_ROW_SELECTOR);
+    if (!row) throw new Error(`no row for ${ALPHA_PROFILE_NAME}`);
+    expect(row.querySelector('[data-testid="profile-actions-inline-p-1"]')).toBeNull();
+    expect(row.querySelector('[data-testid="profile-actions-menu-p-1"]')).not.toBeNull();
+    expect(row.querySelector('[data-testid="duplicate-profile-p-1"]')).not.toBeNull();
+    expect(row.querySelector('[data-testid="delete-profile-p-1"]')).not.toBeNull();
+  });
+
+  it("wires inline duplicate and delete to the shared row behavior", async () => {
+    mocks.responsive.isFullDesktop = true;
+    mocks.duplicateAgentProfileAction.mockResolvedValue({
+      id: "p-3",
+      name: "Alpha Copy",
+    } as unknown as AgentProfile);
+    mocks.deleteAgentProfileAction.mockResolvedValue({ status: "ok" });
+    render(<ProfileRow agent={AGENT} profile={AGENT.profiles[0]} />);
+
+    const row = screen.getByLabelText("Alpha").closest('[data-testid="agent-profile-row"]');
+    if (!row) throw new Error("no row for Alpha");
+    fireEvent.click(row.querySelector('[data-testid="duplicate-profile-inline-p-1"]')!);
+    fireEvent.click(row.querySelector('[data-testid="delete-profile-inline-p-1"]')!);
+    fireEvent.click(row.querySelector('[data-testid="confirm-delete"]')!);
+
+    await waitFor(() => expect(mocks.duplicateAgentProfileAction).toHaveBeenCalledWith("p-1"));
+    await waitFor(() => expect(mocks.deleteAgentProfileAction).toHaveBeenCalledWith("p-1"));
   });
 });
 

--- a/apps/web/components/settings/agents/agent-profiles-section.test.tsx
+++ b/apps/web/components/settings/agents/agent-profiles-section.test.tsx
@@ -218,15 +218,25 @@ describe("ProfileRow responsive actions", () => {
   });
   afterEach(() => cleanup());
 
-  it("renders labeled duplicate and delete actions inline on full desktop", () => {
+  it("renders compact icon-only duplicate and delete actions inline on full desktop", () => {
     mocks.responsive.isFullDesktop = true;
     render(<ProfileRow agent={AGENT} profile={AGENT.profiles[0]} />);
 
     const row = screen.getByLabelText(ALPHA_PROFILE_NAME).closest(PROFILE_ROW_SELECTOR);
     if (!row) throw new Error(`no row for ${ALPHA_PROFILE_NAME}`);
     expect(row.querySelector('[data-testid="profile-actions-inline-p-1"]')).not.toBeNull();
-    expect(row.querySelector('[data-testid="duplicate-profile-inline-p-1"]')).not.toBeNull();
-    expect(row.querySelector('[data-testid="delete-profile-inline-p-1"]')).not.toBeNull();
+    const duplicate = row.querySelector<HTMLButtonElement>(
+      '[data-testid="duplicate-profile-inline-p-1"]',
+    );
+    const deleteButton = row.querySelector<HTMLButtonElement>(
+      '[data-testid="delete-profile-inline-p-1"]',
+    );
+    expect(duplicate).not.toBeNull();
+    expect(deleteButton).not.toBeNull();
+    expect(duplicate?.textContent).toBe("");
+    expect(deleteButton?.textContent).toBe("");
+    expect(duplicate?.getAttribute("data-size")).toBe("icon");
+    expect(deleteButton?.getAttribute("data-size")).toBe("icon");
     expect(row.querySelector('[data-testid="profile-actions-menu-p-1"]')).toBeNull();
   });
 

--- a/apps/web/components/settings/agents/agent-profiles-section.test.tsx
+++ b/apps/web/components/settings/agents/agent-profiles-section.test.tsx
@@ -125,13 +125,15 @@ function renderRows() {
 function confirmDeleteFor(name: string) {
   const row = screen.getByLabelText(name).closest(PROFILE_ROW_SELECTOR);
   if (!row) throw new Error(`no row for ${name}`);
-  const profileId = name === "Alpha" ? "p-1" : "p-2";
+  const profileId = AGENT.profiles.find((p) => p.name === name)?.id;
+  if (!profileId) throw new Error(`no profile id for ${name}`);
   fireEvent.click(row.querySelector(`[data-testid="delete-profile-${profileId}"]`)!);
   fireEvent.click(row.querySelector('[data-testid="confirm-delete"]')!);
 }
 
 describe("ProfileRow deletion", () => {
   beforeEach(() => {
+    mocks.responsive.isFullDesktop = false;
     storeState = {
       settingsAgents: { items: [{ ...AGENT, profiles: [...AGENT.profiles] }] },
       agentProfiles: { items: [{ id: "p-1" }, { id: "p-2" }] },
@@ -248,8 +250,8 @@ describe("ProfileRow responsive actions", () => {
     mocks.deleteAgentProfileAction.mockResolvedValue({ status: "ok" });
     render(<ProfileRow agent={AGENT} profile={AGENT.profiles[0]} />);
 
-    const row = screen.getByLabelText("Alpha").closest('[data-testid="agent-profile-row"]');
-    if (!row) throw new Error("no row for Alpha");
+    const row = screen.getByLabelText(ALPHA_PROFILE_NAME).closest(PROFILE_ROW_SELECTOR);
+    if (!row) throw new Error(`no row for ${ALPHA_PROFILE_NAME}`);
     fireEvent.click(row.querySelector('[data-testid="duplicate-profile-inline-p-1"]')!);
     fireEvent.click(row.querySelector('[data-testid="delete-profile-inline-p-1"]')!);
     fireEvent.click(row.querySelector('[data-testid="confirm-delete"]')!);

--- a/apps/web/components/settings/agents/agent-profiles-section.test.tsx
+++ b/apps/web/components/settings/agents/agent-profiles-section.test.tsx
@@ -1,6 +1,7 @@
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TooltipProvider } from "@kandev/ui/tooltip";
 
 import type { Agent, AgentProfile } from "@/lib/types/http";
 
@@ -112,8 +113,12 @@ vi.mock("@/components/settings/agent-profile-delete-dialog", () => ({
 
 import { AgentProfilesSubList, ProfileRow } from "./agent-profiles-section";
 
+function renderWithTooltipProvider(ui: ReactNode) {
+  return render(<TooltipProvider>{ui}</TooltipProvider>);
+}
+
 function renderRows() {
-  return render(
+  return renderWithTooltipProvider(
     <>
       {AGENT.profiles.map((p) => (
         <ProfileRow key={p.id} agent={AGENT} profile={p} />
@@ -218,9 +223,9 @@ describe("ProfileRow responsive actions", () => {
   });
   afterEach(() => cleanup());
 
-  it("renders compact icon-only duplicate and delete actions inline on full desktop", () => {
+  it("renders compact icon-only duplicate and delete actions inline on full desktop", async () => {
     mocks.responsive.isFullDesktop = true;
-    render(<ProfileRow agent={AGENT} profile={AGENT.profiles[0]} />);
+    renderWithTooltipProvider(<ProfileRow agent={AGENT} profile={AGENT.profiles[0]} />);
 
     const row = screen.getByLabelText(ALPHA_PROFILE_NAME).closest(PROFILE_ROW_SELECTOR);
     if (!row) throw new Error(`no row for ${ALPHA_PROFILE_NAME}`);
@@ -238,10 +243,15 @@ describe("ProfileRow responsive actions", () => {
     expect(duplicate?.getAttribute("data-size")).toBe("icon");
     expect(deleteButton?.getAttribute("data-size")).toBe("icon");
     expect(row.querySelector('[data-testid="profile-actions-menu-p-1"]')).toBeNull();
+
+    fireEvent.focus(duplicate!);
+    await waitFor(() => expect(screen.getByRole("tooltip", { name: "Duplicate" })).toBeTruthy());
+    fireEvent.focus(deleteButton!);
+    await waitFor(() => expect(screen.getByRole("tooltip", { name: "Delete" })).toBeTruthy());
   });
 
   it("keeps duplicate and delete in the overflow menu below full desktop", () => {
-    render(<ProfileRow agent={AGENT} profile={AGENT.profiles[0]} />);
+    renderWithTooltipProvider(<ProfileRow agent={AGENT} profile={AGENT.profiles[0]} />);
 
     const row = screen.getByLabelText(ALPHA_PROFILE_NAME).closest(PROFILE_ROW_SELECTOR);
     if (!row) throw new Error(`no row for ${ALPHA_PROFILE_NAME}`);
@@ -258,7 +268,7 @@ describe("ProfileRow responsive actions", () => {
       name: "Alpha Copy",
     } as unknown as AgentProfile);
     mocks.deleteAgentProfileAction.mockResolvedValue({ status: "ok" });
-    render(<ProfileRow agent={AGENT} profile={AGENT.profiles[0]} />);
+    renderWithTooltipProvider(<ProfileRow agent={AGENT} profile={AGENT.profiles[0]} />);
 
     const row = screen.getByLabelText(ALPHA_PROFILE_NAME).closest(PROFILE_ROW_SELECTOR);
     if (!row) throw new Error(`no row for ${ALPHA_PROFILE_NAME}`);
@@ -276,7 +286,7 @@ describe("AgentProfilesSubList layout", () => {
   afterEach(() => cleanup());
 
   it("renders profile rows without the count or create action", () => {
-    render(<AgentProfilesSubList savedAgent={AGENT} agentName="claude" />);
+    renderWithTooltipProvider(<AgentProfilesSubList savedAgent={AGENT} agentName="claude" />);
 
     expect(screen.queryByText("2 profiles", { exact: true })).toBeNull();
     expect(screen.getAllByTestId("agent-profile-row")).toHaveLength(2);
@@ -284,13 +294,13 @@ describe("AgentProfilesSubList layout", () => {
   });
 
   it("omits the profile body when no agent record exists", () => {
-    render(<AgentProfilesSubList savedAgent={undefined} agentName="claude" />);
+    renderWithTooltipProvider(<AgentProfilesSubList savedAgent={undefined} agentName="claude" />);
 
     expect(screen.queryByTestId("agent-profiles-claude")).toBeNull();
   });
 
   it("omits the profile body when the saved agent has no profiles", () => {
-    render(<AgentProfilesSubList savedAgent={EMPTY_AGENT} agentName="claude" />);
+    renderWithTooltipProvider(<AgentProfilesSubList savedAgent={EMPTY_AGENT} agentName="claude" />);
 
     expect(screen.queryByTestId("agent-profiles-claude")).toBeNull();
   });

--- a/apps/web/components/settings/agents/agent-profiles-section.tsx
+++ b/apps/web/components/settings/agents/agent-profiles-section.tsx
@@ -123,26 +123,24 @@ function ProfileRowInlineActions({
       <Button
         type="button"
         variant="outline"
-        size="sm"
-        className="cursor-pointer min-h-11"
+        size="icon"
+        className="cursor-pointer"
         data-testid={`duplicate-profile-inline-${profile.id}`}
         onClick={onDuplicate}
         aria-label={t("agents:duplicate")}
       >
-        <IconCopy className="mr-2 h-4 w-4" />
-        {t("agents:duplicate")}
+        <IconCopy className="h-4 w-4" />
       </Button>
       <Button
         type="button"
         variant="destructive"
-        size="sm"
-        className="cursor-pointer min-h-11"
+        size="icon"
+        className="cursor-pointer"
         data-testid={`delete-profile-inline-${profile.id}`}
         onClick={onConfirmDelete}
         aria-label={t("agents:delete")}
       >
-        <IconTrash className="mr-2 h-4 w-4" />
-        {t("agents:delete")}
+        <IconTrash className="h-4 w-4" />
       </Button>
     </div>
   );

--- a/apps/web/components/settings/agents/agent-profiles-section.tsx
+++ b/apps/web/components/settings/agents/agent-profiles-section.tsx
@@ -18,6 +18,7 @@ import { useToast } from "@/components/toast-provider";
 import { AgentProfileDeleteConfirmDialog } from "@/components/settings/agent-profile-delete-dialog";
 import { deleteAgentProfileAction } from "@/app/actions/agents";
 import { useProfileDuplicate } from "@/hooks/domains/settings/use-profile-duplicate";
+import { useResponsiveBreakpoint } from "@/hooks/use-responsive-breakpoint";
 import { useRouter } from "@/lib/routing/client-router";
 import { toAgentProfileOption } from "@/lib/state/slices/settings/types";
 import type { Agent, AgentProfile } from "@/lib/types/http";
@@ -63,16 +64,15 @@ export function AgentProfilesSubList({
  * guard, revision-aware store merge).
  */
 function ProfileRowActions({
-  agent,
   profile,
+  onDuplicate,
   onConfirmDelete,
 }: {
-  agent: Agent;
   profile: AgentProfile;
+  onDuplicate: () => void;
   onConfirmDelete: () => void;
 }) {
   const { t } = useTranslation();
-  const handleDuplicate = useProfileDuplicate();
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -81,6 +81,7 @@ function ProfileRowActions({
           size="sm"
           className="cursor-pointer min-h-11 min-w-11"
           aria-label={t("agents:profileActions")}
+          data-testid={`profile-actions-menu-${profile.id}`}
         >
           <IconDotsVertical className="h-4 w-4" />
         </Button>
@@ -89,13 +90,14 @@ function ProfileRowActions({
         <DropdownMenuItem
           className="cursor-pointer"
           data-testid={`duplicate-profile-${profile.id}`}
-          onSelect={() => void handleDuplicate(agent, profile)}
+          onSelect={onDuplicate}
         >
           <IconCopy className="h-4 w-4 mr-2" />
           {t("agents:duplicate")}
         </DropdownMenuItem>
         <DropdownMenuItem
           className="cursor-pointer text-destructive focus:text-destructive"
+          data-testid={`delete-profile-${profile.id}`}
           onSelect={onConfirmDelete}
         >
           <IconTrash className="h-4 w-4 mr-2" />
@@ -106,16 +108,59 @@ function ProfileRowActions({
   );
 }
 
+function ProfileRowInlineActions({
+  profile,
+  onDuplicate,
+  onConfirmDelete,
+}: {
+  profile: AgentProfile;
+  onDuplicate: () => void;
+  onConfirmDelete: () => void;
+}) {
+  const { t } = useTranslation();
+  return (
+    <div className="flex items-center gap-1" data-testid={`profile-actions-inline-${profile.id}`}>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="cursor-pointer min-h-11"
+        data-testid={`duplicate-profile-inline-${profile.id}`}
+        onClick={onDuplicate}
+        aria-label={t("agents:duplicate")}
+      >
+        <IconCopy className="mr-2 h-4 w-4" />
+        {t("agents:duplicate")}
+      </Button>
+      <Button
+        type="button"
+        variant="destructive"
+        size="sm"
+        className="cursor-pointer min-h-11"
+        data-testid={`delete-profile-inline-${profile.id}`}
+        onClick={onConfirmDelete}
+        aria-label={t("agents:delete")}
+      >
+        <IconTrash className="mr-2 h-4 w-4" />
+        {t("agents:delete")}
+      </Button>
+    </div>
+  );
+}
+
 /** One saved profile as a fully clickable row — shared by the Agents index and the agent page. */
 export function ProfileRow({ agent, profile }: { agent: Agent; profile: AgentProfile }) {
   const { t } = useTranslation();
   const { toast } = useToast();
   const router = useRouter();
+  const { isFullDesktop } = useResponsiveBreakpoint();
+  const handleDuplicate = useProfileDuplicate();
   const [confirmOpen, setConfirmOpen] = useState(false);
   const store = useAppStoreApi();
   const setSettingsAgents = useAppStore((state) => state.setSettingsAgents);
   const setAgentProfiles = useAppStore((state) => state.setAgentProfiles);
   const href = profileHref(agent.name, profile.id);
+  const onDuplicate = () => void handleDuplicate(agent, profile);
 
   const handleDelete = async () => {
     setConfirmOpen(false);
@@ -180,11 +225,19 @@ export function ProfileRow({ agent, profile }: { agent: Agent; profile: AgentPro
           )}
         </div>
         <div className="relative z-10 flex shrink-0 items-center gap-1">
-          <ProfileRowActions
-            agent={agent}
-            profile={profile}
-            onConfirmDelete={() => setConfirmOpen(true)}
-          />
+          {isFullDesktop ? (
+            <ProfileRowInlineActions
+              profile={profile}
+              onDuplicate={onDuplicate}
+              onConfirmDelete={() => setConfirmOpen(true)}
+            />
+          ) : (
+            <ProfileRowActions
+              profile={profile}
+              onDuplicate={onDuplicate}
+              onConfirmDelete={() => setConfirmOpen(true)}
+            />
+          )}
         </div>
       </CardContent>
       <AgentProfileDeleteConfirmDialog

--- a/apps/web/components/settings/agents/agent-profiles-section.tsx
+++ b/apps/web/components/settings/agents/agent-profiles-section.tsx
@@ -12,6 +12,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@kandev/ui/dropdown-menu";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
 import Link from "@/components/routing/app-link";
 import { useAppStore, useAppStoreApi } from "@/components/state-provider";
 import { useToast } from "@/components/toast-provider";
@@ -120,28 +121,38 @@ function ProfileRowInlineActions({
   const { t } = useTranslation();
   return (
     <div className="flex items-center gap-1" data-testid={`profile-actions-inline-${profile.id}`}>
-      <Button
-        type="button"
-        variant="outline"
-        size="icon"
-        className="cursor-pointer"
-        data-testid={`duplicate-profile-inline-${profile.id}`}
-        onClick={onDuplicate}
-        aria-label={t("agents:duplicate")}
-      >
-        <IconCopy className="h-4 w-4" />
-      </Button>
-      <Button
-        type="button"
-        variant="destructive"
-        size="icon"
-        className="cursor-pointer"
-        data-testid={`delete-profile-inline-${profile.id}`}
-        onClick={onConfirmDelete}
-        aria-label={t("agents:delete")}
-      >
-        <IconTrash className="h-4 w-4" />
-      </Button>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            type="button"
+            variant="outline"
+            size="icon"
+            className="cursor-pointer"
+            data-testid={`duplicate-profile-inline-${profile.id}`}
+            onClick={onDuplicate}
+            aria-label={t("agents:duplicate")}
+          >
+            <IconCopy className="h-4 w-4" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="top">{t("agents:duplicate")}</TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            type="button"
+            variant="destructive"
+            size="icon"
+            className="cursor-pointer"
+            data-testid={`delete-profile-inline-${profile.id}`}
+            onClick={onConfirmDelete}
+            aria-label={t("agents:delete")}
+          >
+            <IconTrash className="h-4 w-4" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="top">{t("agents:delete")}</TooltipContent>
+      </Tooltip>
     </div>
   );
 }

--- a/apps/web/e2e/tests/settings/agent-profile-duplicate.spec.ts
+++ b/apps/web/e2e/tests/settings/agent-profile-duplicate.spec.ts
@@ -39,6 +39,10 @@ test.describe("Agent profile duplicate", () => {
       await expect(deleteButton).toHaveAccessibleName("Delete");
       await expect(deleteButton).toHaveText("");
       await expect(deleteButton).toHaveAttribute("data-size", "icon");
+      await duplicate.hover();
+      await expect(testPage.getByRole("tooltip", { name: "Duplicate" })).toBeVisible();
+      await deleteButton.hover();
+      await expect(testPage.getByRole("tooltip", { name: "Delete" })).toBeVisible();
       await duplicate.click();
 
       // Backend state: the copy is a new row with the source's model. The

--- a/apps/web/e2e/tests/settings/agent-profile-duplicate.spec.ts
+++ b/apps/web/e2e/tests/settings/agent-profile-duplicate.spec.ts
@@ -3,7 +3,8 @@ import { test, expect } from "../../fixtures/test-base";
 /**
  * Verifies the agent profile duplicate flow:
  *
- * - The /settings/agents profile list shows a Duplicate button per row.
+ * - A full-desktop /settings/agents profile row shows inline Duplicate/Delete
+ *   buttons.
  * - Clicking it creates a "<source> Copy" profile that appears in the list
  *   without a page reload, copying the source's model.
  * - The copy is an independent profile with its own settings page.
@@ -24,12 +25,17 @@ test.describe("Agent profile duplicate", () => {
     try {
       await testPage.goto("/settings/agents");
 
-      // The per-row Duplicate action lives in the row's actions dropdown.
+      // Full desktop exposes the row actions directly, without the overflow menu.
       const row = testPage.getByTestId("agent-profile-row").filter({ hasText: profile.name });
       await expect(row).toBeVisible({ timeout: 15_000 });
-      await row.getByRole("button", { name: "Profile actions" }).click();
-      const duplicate = testPage.getByTestId(`duplicate-profile-${profile.id}`);
+      await expect(row.getByTestId(`profile-actions-inline-${profile.id}`)).toBeVisible();
+      await expect(row.getByTestId(`profile-actions-menu-${profile.id}`)).toHaveCount(0);
+      const duplicate = row.getByTestId(`duplicate-profile-inline-${profile.id}`);
       await expect(duplicate).toBeVisible({ timeout: 15_000 });
+      await expect(duplicate).toHaveAccessibleName("Duplicate");
+      await expect(row.getByTestId(`delete-profile-inline-${profile.id}`)).toHaveAccessibleName(
+        "Delete",
+      );
       await duplicate.click();
 
       // Backend state: the copy is a new row with the source's model. The
@@ -73,6 +79,34 @@ test.describe("Agent profile duplicate", () => {
         await apiClient.deleteAgentProfile(copy.id, true).catch(() => {});
       }
     }
+  });
+
+  test("keeps profile actions in the overflow menu at tablet width", async ({
+    tabletTestPage,
+    apiClient,
+  }) => {
+    const { agents } = await apiClient.listAgents();
+    const agent = agents[0];
+    const profile = agent.profiles[0];
+
+    await tabletTestPage.goto("/settings/agents");
+
+    await expect
+      .poll(
+        async () =>
+          tabletTestPage.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth),
+        { timeout: 15_000 },
+      )
+      .toBe(true);
+
+    const row = tabletTestPage.getByTestId("agent-profile-row").filter({ hasText: profile.name });
+    await expect(row).toBeVisible({ timeout: 15_000 });
+    await expect(row.getByTestId(`profile-actions-inline-${profile.id}`)).toHaveCount(0);
+    const trigger = row.getByTestId(`profile-actions-menu-${profile.id}`);
+    await expect(trigger).toBeVisible();
+    await trigger.tap();
+    await expect(tabletTestPage.getByTestId(`duplicate-profile-${profile.id}`)).toBeVisible();
+    await expect(tabletTestPage.getByTestId(`delete-profile-${profile.id}`)).toBeVisible();
   });
 
   test("duplicates from the profile page header and navigates to the copy", async ({

--- a/apps/web/e2e/tests/settings/agent-profile-duplicate.spec.ts
+++ b/apps/web/e2e/tests/settings/agent-profile-duplicate.spec.ts
@@ -31,11 +31,14 @@ test.describe("Agent profile duplicate", () => {
       await expect(row.getByTestId(`profile-actions-inline-${profile.id}`)).toBeVisible();
       await expect(row.getByTestId(`profile-actions-menu-${profile.id}`)).toHaveCount(0);
       const duplicate = row.getByTestId(`duplicate-profile-inline-${profile.id}`);
+      const deleteButton = row.getByTestId(`delete-profile-inline-${profile.id}`);
       await expect(duplicate).toBeVisible({ timeout: 15_000 });
       await expect(duplicate).toHaveAccessibleName("Duplicate");
-      await expect(row.getByTestId(`delete-profile-inline-${profile.id}`)).toHaveAccessibleName(
-        "Delete",
-      );
+      await expect(duplicate).toHaveText("");
+      await expect(duplicate).toHaveAttribute("data-size", "icon");
+      await expect(deleteButton).toHaveAccessibleName("Delete");
+      await expect(deleteButton).toHaveText("");
+      await expect(deleteButton).toHaveAttribute("data-size", "icon");
       await duplicate.click();
 
       // Backend state: the copy is a new row with the source's model. The

--- a/apps/web/e2e/tests/settings/mobile-agent-profile-duplicate.spec.ts
+++ b/apps/web/e2e/tests/settings/mobile-agent-profile-duplicate.spec.ts
@@ -31,9 +31,10 @@ test.describe("Mobile agent profile duplicate", () => {
 
       const row = testPage.getByTestId("agent-profile-row").filter({ hasText: profile.name });
       await expect(row).toBeVisible({ timeout: 15_000 });
+      await expect(row.getByTestId(`profile-actions-inline-${profile.id}`)).toHaveCount(0);
       // The row's actions trigger exposes a touch-sized hitbox (>= 44px).
       // Poll for the box: layout can settle a frame after visibility.
-      const trigger = row.getByRole("button", { name: "Profile actions" });
+      const trigger = row.getByTestId(`profile-actions-menu-${profile.id}`);
       await expect
         .poll(
           async () => {

--- a/docs/plans/agent-profile-inline-actions/plan.md
+++ b/docs/plans/agent-profile-inline-actions/plan.md
@@ -22,7 +22,8 @@ store contract, or translated copy.
   - Use the canonical `useResponsiveBreakpoint` hook and its
     `isFullDesktop` value, which maps to viewport widths of at least 1024px.
   - Render compact icon-only Duplicate and Delete buttons inline on full
-    desktop widths, retaining translated accessible names.
+    desktop widths, retaining translated accessible names and showing the same
+    translated action names in hover/focus tooltips.
   - Keep the existing three-dots menu as the only action presentation below
     that boundary, including compact desktop, tablet, and mobile.
   - Reuse `useProfileDuplicate`, `setConfirmOpen`, and
@@ -53,7 +54,8 @@ store contract, or translated copy.
   and the user can duplicate the seeded profile without opening a menu.
   **File:** `apps/web/e2e/tests/settings/agent-profile-duplicate.spec.ts`.
   **What to verify:** Assert the inline controls and absence of the overflow
-  trigger, activate Duplicate, and verify the copied row and model.
+  trigger, verify both tooltips on hover, activate Duplicate, and verify the
+  copied row and model.
 
 - **Scenario:** A 900px tablet-width profile row keeps both actions in the
   overflow menu and does not overflow its viewport.
@@ -121,3 +123,7 @@ Passed.
   fresh full-desktop screenshot. The screenshot shows compact 28px action
   buttons centered in the profile row; the old visible labels are absent while
   translated accessible names remain.
+- The tooltip refinement was verified with focus assertions in the component
+  suite and hover assertions in the desktop E2E flow. Both tooltips reuse the
+  existing translated Duplicate and Delete labels; the mobile overflow path is
+  unchanged.

--- a/docs/plans/agent-profile-inline-actions/plan.md
+++ b/docs/plans/agent-profile-inline-actions/plan.md
@@ -1,0 +1,118 @@
+---
+spec: docs/specs/agents/settings-profile-layout.md
+created: 2026-08-13
+status: done
+---
+
+# Implementation Plan: Inline agent profile actions
+
+## Overview
+
+Add a full-desktop presentation for profile-row Duplicate and Delete actions
+while retaining the existing overflow menu below the full-desktop breakpoint.
+The same action handlers and delete confirmation remain shared across both
+presentations. The work is frontend-only and does not change the profile API,
+store contract, or translated copy.
+
+## Frontend
+
+### Profile row action presentation
+
+- `apps/web/components/settings/agents/agent-profiles-section.tsx`
+  - Use the canonical `useResponsiveBreakpoint` hook and its
+    `isFullDesktop` value, which maps to viewport widths of at least 1024px.
+  - Render labeled, translated Duplicate and Delete buttons inline on full
+    desktop widths.
+  - Keep the existing three-dots menu as the only action presentation below
+    that boundary, including compact desktop, tablet, and mobile.
+  - Reuse `useProfileDuplicate`, `setConfirmOpen`, and
+    `AgentProfileDeleteConfirmDialog`; do not duplicate mutation or store
+    synchronization logic.
+  - Keep the absolute profile link underneath the action cluster and preserve
+    stable test IDs for both action presentations.
+
+## Tests
+
+- **What:** Profile rows render the correct action presentation at full desktop
+  and below the breakpoint, while Duplicate and Delete retain their existing
+  wiring.
+  **File:** `apps/web/components/settings/agents/agent-profiles-section.test.tsx`.
+  **How:** Mock the canonical responsive hook for full desktop and compact
+  layouts. Assert inline button visibility, overflow-menu visibility, and the
+  existing duplicate/delete behavior through the shared row controls.
+
+- **What:** Existing profile list behavior remains intact after the action
+  presentation split.
+  **File:** `apps/web/components/settings/agents/agent-profiles-section.test.tsx`.
+  **How:** Keep the current store read-after-write deletion and duplicate
+  coverage, updating only selectors needed for the two responsive branches.
+
+## E2E Tests
+
+- **Scenario:** A full desktop profile row exposes Duplicate and Delete inline
+  and the user can duplicate the seeded profile without opening a menu.
+  **File:** `apps/web/e2e/tests/settings/agent-profile-duplicate.spec.ts`.
+  **What to verify:** Assert the inline controls and absence of the overflow
+  trigger, activate Duplicate, and verify the copied row and model.
+
+- **Scenario:** A 900px tablet-width profile row keeps both actions in the
+  overflow menu and does not overflow its viewport.
+  **File:** `apps/web/e2e/tests/settings/agent-profile-duplicate.spec.ts`.
+  **What to verify:** Use the existing `tabletTestPage` fixture, assert inline
+  controls are absent, open the profile-actions menu, and verify both menu
+  actions are reachable with no document-level horizontal overflow.
+
+- **Scenario:** A Pixel 5 profile row keeps the overflow-menu path and retains
+  the same duplicate outcome.
+  **File:** `apps/web/e2e/tests/settings/mobile-agent-profile-duplicate.spec.ts`.
+  **What to verify:** Keep the touch-based menu interaction, assert the inline
+  controls are absent, and retain the existing 44px hitbox and overflow checks.
+
+## Mobile design contract
+
+- Desktop outcome: profile users can duplicate or delete directly from a full
+  desktop row without an extra menu click.
+- Mobile and tablet entry point: the existing visible three-dots trigger opens
+  the profile action menu; no new drawer or route is needed because these are
+  short contextual actions and the existing Radix menu has the repository's
+  mobile bottom-sheet treatment.
+- Nearest shipped exemplar: the current `ProfileRowActions` dropdown and the
+  existing mobile agent-profile duplicate flow. Reuse its trigger, menu,
+  touch-sized hitbox, and action handlers.
+- Mobile hierarchy: profile identity and metadata remain primary, with the
+  overflow trigger as the only row action control below the full-desktop
+  boundary.
+- Scroll owner and geometry: preserve the existing settings scroll owner; the
+  row action cluster must remain contained at 900px and phone widths, with no
+  document-level horizontal overflow.
+- Shared state and logic: both presentations call the same duplicate hook and
+  delete confirmation callback, so only visual composition changes by viewport.
+
+## Implementation Waves And Parallel Candidates
+
+Wave 1:
+
+- [x] [task-01-profile-row-actions](task-01-profile-row-actions.md)
+
+Wave 2:
+
+- [x] [task-02-profile-actions-e2e](task-02-profile-actions-e2e.md)
+
+The tasks are sequential because the E2E selectors and responsive assertions
+depend on the component markup from task 01.
+
+## Verification Results
+
+Passed.
+
+- `cd apps && pnpm install --frozen-lockfile` passed.
+- `cd apps/web && pnpm test -- components/settings/agents/agent-profiles-section.test.tsx` passed (9 tests).
+- `cd apps/web && pnpm run typecheck` passed.
+- `cd apps/web && pnpm exec eslint components/settings/agents/agent-profiles-section.tsx components/settings/agents/agent-profiles-section.test.tsx` passed with no errors or warnings.
+- `cd apps/web && pnpm run i18n:check` passed with the repository's existing advisory catalog warnings; no locale keys were added.
+- `cd apps/web && pnpm run i18n:ratchet` passed with 0 new-code violations and an intact guard allowlist.
+- `cd apps/web && pnpm e2e:run --project chromium tests/settings/agent-profile-duplicate.spec.ts` passed (3 tests: full desktop inline actions, 900px tablet overflow actions, and profile-page duplicate flow).
+- `cd apps/web && pnpm e2e:run --project mobile-chrome tests/settings/mobile-agent-profile-duplicate.spec.ts` passed (1 test).
+- The final desktop/tablet selector assertion rerun, `cd apps/web && pnpm e2e:run --no-build --project chromium tests/settings/agent-profile-duplicate.spec.ts`, passed (3 tests).
+- Both full managed E2E runs rebuilt the backend and pseudo-locale Vite assets; the final no-build rerun used those production artifacts. All runs cleaned their isolated E2E artifact directories. No failure artifacts remain.
+- Three fresh synthetic PR screenshots were captured, visually inspected, compressed, and validated through `.pr-assets/manifest.json` for full desktop, tablet, and mobile overflow-menu states. The capture-only spec was removed afterward.

--- a/docs/plans/agent-profile-inline-actions/plan.md
+++ b/docs/plans/agent-profile-inline-actions/plan.md
@@ -21,8 +21,8 @@ store contract, or translated copy.
 - `apps/web/components/settings/agents/agent-profiles-section.tsx`
   - Use the canonical `useResponsiveBreakpoint` hook and its
     `isFullDesktop` value, which maps to viewport widths of at least 1024px.
-  - Render labeled, translated Duplicate and Delete buttons inline on full
-    desktop widths.
+  - Render compact icon-only Duplicate and Delete buttons inline on full
+    desktop widths, retaining translated accessible names.
   - Keep the existing three-dots menu as the only action presentation below
     that boundary, including compact desktop, tablet, and mobile.
   - Reuse `useProfileDuplicate`, `setConfirmOpen`, and
@@ -116,3 +116,8 @@ Passed.
 - The final desktop/tablet selector assertion rerun, `cd apps/web && pnpm e2e:run --no-build --project chromium tests/settings/agent-profile-duplicate.spec.ts`, passed (3 tests).
 - Both full managed E2E runs rebuilt the backend and pseudo-locale Vite assets; the final no-build rerun used those production artifacts. All runs cleaned their isolated E2E artifact directories. No failure artifacts remain.
 - Three fresh synthetic PR screenshots were captured, visually inspected, compressed, and validated through `.pr-assets/manifest.json` for full desktop, tablet, and mobile overflow-menu states. The capture-only spec was removed afterward.
+- The icon-only refinement was verified with the focused component suite (9
+  tests), managed desktop E2E (3 tests), managed mobile E2E (1 test), and a
+  fresh full-desktop screenshot. The screenshot shows compact 28px action
+  buttons centered in the profile row; the old visible labels are absent while
+  translated accessible names remain.

--- a/docs/plans/agent-profile-inline-actions/task-01-profile-row-actions.md
+++ b/docs/plans/agent-profile-inline-actions/task-01-profile-row-actions.md
@@ -1,0 +1,72 @@
+---
+id: "01-profile-row-actions"
+title: "Profile row action presentation"
+status: done
+wave: 1
+depends_on: []
+plan: "plan.md"
+spec: "../../specs/agents/settings-profile-layout.md"
+---
+
+# Task 01: Profile row action presentation
+
+## Acceptance
+
+- Full desktop profile rows show translated Duplicate and Delete buttons
+  inline, with no visible profile-actions overflow trigger.
+- Compact desktop, tablet, and mobile profile rows keep the existing
+  three-dots menu as the only action presentation, with both actions inside it.
+- Duplicate and Delete use the existing mutation hook, confirmation dialog,
+  profile-link layering, and store synchronization behavior.
+
+## Verification
+
+```bash
+cd apps && pnpm install --frozen-lockfile
+cd apps/web && pnpm test -- components/settings/agents/agent-profiles-section.test.tsx
+cd apps/web && pnpm run typecheck
+cd apps/web && pnpm exec eslint components/settings/agents/agent-profiles-section.tsx components/settings/agents/agent-profiles-section.test.tsx
+cd apps/web && pnpm run i18n:check
+```
+
+## Files likely touched
+
+- `apps/web/components/settings/agents/agent-profiles-section.tsx`
+- `apps/web/components/settings/agents/agent-profiles-section.test.tsx`
+
+## Dependencies
+
+None.
+
+## Parallelism
+
+Sequential. The component and its responsive unit coverage form one vertical
+slice.
+
+## Inputs
+
+- Spec: `docs/specs/agents/settings-profile-layout.md`, especially the new
+  full-desktop and below-breakpoint scenarios.
+- Plan: `plan.md`, Frontend and Mobile design contract sections.
+- Existing patterns: `useResponsiveBreakpoint`, `useProfileDuplicate`, and
+  `AgentProfileDeleteConfirmDialog`.
+
+## Output contract
+
+Report changed files, the exact focused test/typecheck/lint/i18n commands and
+results, responsive selector decisions, and any blockers. Update this task's
+status and the parent plan only after all listed checks pass.
+
+## Results
+
+- `cd apps && pnpm install --frozen-lockfile` passed.
+- `cd apps/web && pnpm test -- components/settings/agents/agent-profiles-section.test.tsx` passed (9 tests).
+- `cd apps/web && pnpm run typecheck` passed.
+- `cd apps/web && pnpm exec eslint components/settings/agents/agent-profiles-section.tsx components/settings/agents/agent-profiles-section.test.tsx` passed with no errors or warnings.
+- `cd apps/web && pnpm run i18n:check` passed with the repository's existing advisory catalog warnings.
+- `cd apps/web && pnpm run i18n:ratchet` passed with 0 new-code violations.
+
+The responsive boundary uses the canonical `isFullDesktop` value. Inline
+buttons have profile-scoped test IDs; the overflow trigger and menu actions
+retain separate stable IDs. Both presentations call the same duplicate hook
+and delete confirmation callback.

--- a/docs/plans/agent-profile-inline-actions/task-01-profile-row-actions.md
+++ b/docs/plans/agent-profile-inline-actions/task-01-profile-row-actions.md
@@ -13,8 +13,8 @@ spec: "../../specs/agents/settings-profile-layout.md"
 ## Acceptance
 
 - Full desktop profile rows show compact icon-only Duplicate and Delete buttons
-  inline, with translated accessible names and no visible profile-actions
-  overflow trigger.
+  inline, with translated accessible names, matching hover/focus tooltips, and
+  no visible profile-actions overflow trigger.
 - Compact desktop, tablet, and mobile profile rows keep the existing
   three-dots menu as the only action presentation, with both actions inside it.
 - Duplicate and Delete use the existing mutation hook, confirmation dialog,
@@ -69,6 +69,7 @@ status and the parent plan only after all listed checks pass.
 
 The responsive boundary uses the canonical `isFullDesktop` value. Full-desktop
 actions are compact icon-only buttons with translated accessible names and
-profile-scoped test IDs; the overflow trigger and menu actions retain separate
+profile-scoped test IDs. Each inline button has a tooltip using the same
+translated action label; the overflow trigger and menu actions retain separate
 stable IDs. Both presentations call the same duplicate hook and delete
 confirmation callback.

--- a/docs/plans/agent-profile-inline-actions/task-01-profile-row-actions.md
+++ b/docs/plans/agent-profile-inline-actions/task-01-profile-row-actions.md
@@ -12,8 +12,9 @@ spec: "../../specs/agents/settings-profile-layout.md"
 
 ## Acceptance
 
-- Full desktop profile rows show translated Duplicate and Delete buttons
-  inline, with no visible profile-actions overflow trigger.
+- Full desktop profile rows show compact icon-only Duplicate and Delete buttons
+  inline, with translated accessible names and no visible profile-actions
+  overflow trigger.
 - Compact desktop, tablet, and mobile profile rows keep the existing
   three-dots menu as the only action presentation, with both actions inside it.
 - Duplicate and Delete use the existing mutation hook, confirmation dialog,
@@ -66,7 +67,8 @@ status and the parent plan only after all listed checks pass.
 - `cd apps/web && pnpm run i18n:check` passed with the repository's existing advisory catalog warnings.
 - `cd apps/web && pnpm run i18n:ratchet` passed with 0 new-code violations.
 
-The responsive boundary uses the canonical `isFullDesktop` value. Inline
-buttons have profile-scoped test IDs; the overflow trigger and menu actions
-retain separate stable IDs. Both presentations call the same duplicate hook
-and delete confirmation callback.
+The responsive boundary uses the canonical `isFullDesktop` value. Full-desktop
+actions are compact icon-only buttons with translated accessible names and
+profile-scoped test IDs; the overflow trigger and menu actions retain separate
+stable IDs. Both presentations call the same duplicate hook and delete
+confirmation callback.

--- a/docs/plans/agent-profile-inline-actions/task-01-profile-row-actions.md
+++ b/docs/plans/agent-profile-inline-actions/task-01-profile-row-actions.md
@@ -22,11 +22,11 @@ spec: "../../specs/agents/settings-profile-layout.md"
 ## Verification
 
 ```bash
-cd apps && pnpm install --frozen-lockfile
-cd apps/web && pnpm test -- components/settings/agents/agent-profiles-section.test.tsx
-cd apps/web && pnpm run typecheck
-cd apps/web && pnpm exec eslint components/settings/agents/agent-profiles-section.tsx components/settings/agents/agent-profiles-section.test.tsx
-cd apps/web && pnpm run i18n:check
+(cd apps && pnpm install --frozen-lockfile)
+(cd apps/web && pnpm test -- components/settings/agents/agent-profiles-section.test.tsx)
+(cd apps/web && pnpm run typecheck)
+(cd apps/web && pnpm exec eslint components/settings/agents/agent-profiles-section.tsx components/settings/agents/agent-profiles-section.test.tsx)
+(cd apps/web && pnpm run i18n:check)
 ```
 
 ## Files likely touched

--- a/docs/plans/agent-profile-inline-actions/task-02-profile-actions-e2e.md
+++ b/docs/plans/agent-profile-inline-actions/task-02-profile-actions-e2e.md
@@ -68,9 +68,9 @@ synchronized task/plan status.
 
 The managed runner rebuilt the backend and pseudo-locale Vite assets for both
 runs, started from cleaned E2E artifact directories, and left no failure
-artifacts. Desktop coverage proves the direct inline path, the 900px tablet
-fixture proves the overflow path and document containment, and the mobile
-coverage keeps the touch menu and 44px trigger check.
+artifacts. Desktop coverage proves the compact icon-only inline path, the 900px
+tablet fixture proves the overflow path and document containment, and the
+mobile coverage keeps the touch menu and 44px trigger check.
 
 Three fresh synthetic PR screenshots were captured and visually inspected for
 full desktop, tablet, and mobile states. They were compressed, validated

--- a/docs/plans/agent-profile-inline-actions/task-02-profile-actions-e2e.md
+++ b/docs/plans/agent-profile-inline-actions/task-02-profile-actions-e2e.md
@@ -22,9 +22,9 @@ spec: "../../specs/agents/settings-profile-layout.md"
 ## Verification
 
 ```bash
-cd apps && pnpm install --frozen-lockfile
-cd apps/web && pnpm e2e:run --project chromium tests/settings/agent-profile-duplicate.spec.ts
-cd apps/web && pnpm e2e:run --project mobile-chrome tests/settings/mobile-agent-profile-duplicate.spec.ts
+(cd apps && pnpm install --frozen-lockfile)
+(cd apps/web && pnpm e2e:run --project chromium tests/settings/agent-profile-duplicate.spec.ts)
+(cd apps/web && pnpm e2e:run --project mobile-chrome tests/settings/mobile-agent-profile-duplicate.spec.ts)
 ```
 
 The managed runner must rebuild the production Vite assets before the tests.

--- a/docs/plans/agent-profile-inline-actions/task-02-profile-actions-e2e.md
+++ b/docs/plans/agent-profile-inline-actions/task-02-profile-actions-e2e.md
@@ -13,7 +13,8 @@ spec: "../../specs/agents/settings-profile-layout.md"
 ## Acceptance
 
 - Desktop E2E proves that a full desktop profile row exposes Duplicate and
-  Delete inline and duplicates the seeded profile through the direct button.
+  Delete inline, shows both action tooltips on hover, and duplicates the seeded
+  profile through the direct button.
 - Tablet-width E2E proves that inline controls are absent, the overflow menu
   contains both actions, and the document remains horizontally contained.
 - Mobile E2E keeps the touch-based overflow path, proves inline controls are
@@ -71,6 +72,9 @@ runs, started from cleaned E2E artifact directories, and left no failure
 artifacts. Desktop coverage proves the compact icon-only inline path, the 900px
 tablet fixture proves the overflow path and document containment, and the
 mobile coverage keeps the touch menu and 44px trigger check.
+
+The desktop flow also verifies that hovering the icon-only Duplicate and Delete
+buttons exposes their matching translated action names.
 
 Three fresh synthetic PR screenshots were captured and visually inspected for
 full desktop, tablet, and mobile states. They were compressed, validated

--- a/docs/plans/agent-profile-inline-actions/task-02-profile-actions-e2e.md
+++ b/docs/plans/agent-profile-inline-actions/task-02-profile-actions-e2e.md
@@ -1,0 +1,78 @@
+---
+id: "02-profile-actions-e2e"
+title: "Profile action responsive E2E coverage"
+status: done
+wave: 2
+depends_on: ["01-profile-row-actions"]
+plan: "plan.md"
+spec: "../../specs/agents/settings-profile-layout.md"
+---
+
+# Task 02: Profile action responsive E2E coverage
+
+## Acceptance
+
+- Desktop E2E proves that a full desktop profile row exposes Duplicate and
+  Delete inline and duplicates the seeded profile through the direct button.
+- Tablet-width E2E proves that inline controls are absent, the overflow menu
+  contains both actions, and the document remains horizontally contained.
+- Mobile E2E keeps the touch-based overflow path, proves inline controls are
+  absent, and preserves the existing duplicate outcome and 44px geometry.
+
+## Verification
+
+```bash
+cd apps && pnpm install --frozen-lockfile
+cd apps/web && pnpm e2e:run --project chromium tests/settings/agent-profile-duplicate.spec.ts
+cd apps/web && pnpm e2e:run --project mobile-chrome tests/settings/mobile-agent-profile-duplicate.spec.ts
+```
+
+The managed runner must rebuild the production Vite assets before the tests.
+Run headless only. Record the exact test counts and any failure-artifact or
+cleanup results below.
+
+## Files likely touched
+
+- `apps/web/e2e/tests/settings/agent-profile-duplicate.spec.ts`
+- `apps/web/e2e/tests/settings/mobile-agent-profile-duplicate.spec.ts`
+
+## Dependencies
+
+Task 01 must land first because the E2E selectors and responsive branches
+depend on the final profile-row markup.
+
+## Parallelism
+
+Sequential. Desktop, tablet, and mobile assertions share the same responsive
+action contract and managed fixture state.
+
+## Inputs
+
+- Spec: `docs/specs/agents/settings-profile-layout.md`, responsive action
+  scenarios.
+- Plan: `plan.md`, E2E Tests and Mobile design contract sections.
+- Existing patterns: `agent-profile-duplicate.spec.ts`,
+  `mobile-agent-profile-duplicate.spec.ts`, and the `tabletTestPage` fixture.
+
+## Output contract
+
+Report changed test files, exact managed-runner commands and test counts,
+screenshots or failure artifacts if produced, cleanup evidence, and
+synchronized task/plan status.
+
+## Results
+
+- `cd apps/web && pnpm e2e:run --project chromium tests/settings/agent-profile-duplicate.spec.ts` passed (3 tests).
+- `cd apps/web && pnpm e2e:run --project mobile-chrome tests/settings/mobile-agent-profile-duplicate.spec.ts` passed (1 test).
+- Final desktop/tablet selector assertion rerun with `cd apps/web && pnpm e2e:run --no-build --project chromium tests/settings/agent-profile-duplicate.spec.ts` passed (3 tests).
+
+The managed runner rebuilt the backend and pseudo-locale Vite assets for both
+runs, started from cleaned E2E artifact directories, and left no failure
+artifacts. Desktop coverage proves the direct inline path, the 900px tablet
+fixture proves the overflow path and document containment, and the mobile
+coverage keeps the touch menu and 44px trigger check.
+
+Three fresh synthetic PR screenshots were captured and visually inspected for
+full desktop, tablet, and mobile states. They were compressed, validated
+against `.pr-assets/manifest.json`, and the disposable capture spec was
+removed. The ignored asset files are ready for PR media publication.

--- a/docs/specs/agents/settings-profile-layout.md
+++ b/docs/specs/agents/settings-profile-layout.md
@@ -34,6 +34,14 @@ to associate with the agent it changes.
 - Existing profile rows, profile links, duplicate/delete actions, agent status
   badges, authentication controls, and runtime-update controls keep their
   current behavior.
+- On a full desktop viewport (at least 1024px wide), each profile row shows
+  translated **Duplicate** and **Delete** buttons directly in the row action
+  area. The row does not show the three-dots profile-actions trigger at this
+  width.
+- Below the full desktop boundary, including compact desktop, tablet, and
+  mobile viewports, each profile row keeps the three-dots profile-actions
+  trigger and exposes **Duplicate** and **Delete** in its overflow menu. Inline
+  action buttons are not rendered in these viewports.
 - The desktop and mobile layouts expose the same actions and outcomes. On a
   narrow touch viewport, card-header actions remain visible, reachable with a
   touch target of at least 44px, and do not create document-level horizontal
@@ -56,6 +64,16 @@ to associate with the agent it changes.
 - **GIVEN** a configured agent card, **WHEN** the user clicks **New profile**,
   **THEN** the browser navigates to that agent's profile creation route and
   the existing profile rows remain unchanged.
+- **GIVEN** a profile row in a viewport at least 1024px wide, **WHEN** the user
+  views the row, **THEN** translated **Duplicate** and **Delete** buttons are
+  visible inline and the three-dots profile-actions trigger is absent.
+- **GIVEN** a profile row in a viewport narrower than 1024px, **WHEN** the user
+  opens the profile-actions trigger, **THEN** the overflow menu contains
+  **Duplicate** and **Delete**, and no inline action buttons are rendered.
+- **GIVEN** a profile row with inline actions or overflow actions, **WHEN** the
+  user activates **Duplicate** or confirms **Delete**, **THEN** the existing
+  duplicate or delete behavior completes without changing the profile link or
+  other row metadata.
 - **GIVEN** a phone viewport below 768px, **WHEN** the user opens the agents
   settings page, **THEN** the card-header creation action and the section
   toolbar actions remain visible and touch-reachable, the profile rows remain
@@ -66,6 +84,8 @@ to associate with the agent it changes.
 
 - Changing the profile editor, profile-row actions, agent discovery, agent
   installation, or the backend/API contracts.
+- Changing the duplicate or delete operation, confirmation flow, profile link,
+  or store synchronization behavior.
 - Renaming the existing translated **New profile**, **Setup profile**, refresh,
   or agent-creation labels.
 - Changing the profile count text used by unrelated task or picker surfaces.

--- a/docs/specs/agents/settings-profile-layout.md
+++ b/docs/specs/agents/settings-profile-layout.md
@@ -37,7 +37,8 @@ to associate with the agent it changes.
 - On a full desktop viewport (at least 1024px wide), each profile row shows
   compact icon-only **Duplicate** and **Delete** action buttons directly in the
   row action area. The buttons retain translated accessible names, are small
-  and vertically centered, and the row does not show the three-dots
+  and vertically centered. Hovering or focusing either button shows a tooltip
+  with its translated action name, and the row does not show the three-dots
   profile-actions trigger at this width.
 - Below the full desktop boundary, including compact desktop, tablet, and
   mobile viewports, each profile row keeps the three-dots profile-actions
@@ -68,7 +69,8 @@ to associate with the agent it changes.
 - **GIVEN** a profile row in a viewport at least 1024px wide, **WHEN** the user
   views the row, **THEN** compact icon-only **Duplicate** and **Delete** buttons
   with translated accessible names are visible inline, vertically centered,
-  and the three-dots profile-actions trigger is absent.
+  and the three-dots profile-actions trigger is absent. Hovering or focusing an
+  inline button shows a tooltip with the matching translated action name.
 - **GIVEN** a profile row in a viewport narrower than 1024px, **WHEN** the user
   opens the profile-actions trigger, **THEN** the overflow menu contains
   **Duplicate** and **Delete**, and no inline action buttons are rendered.

--- a/docs/specs/agents/settings-profile-layout.md
+++ b/docs/specs/agents/settings-profile-layout.md
@@ -82,8 +82,8 @@ to associate with the agent it changes.
 
 ## Out of scope
 
-- Changing the profile editor, profile-row actions, agent discovery, agent
-  installation, or the backend/API contracts.
+- Changing the profile editor, agent discovery, agent installation, or the
+  backend/API contracts.
 - Changing the duplicate or delete operation, confirmation flow, profile link,
   or store synchronization behavior.
 - Renaming the existing translated **New profile**, **Setup profile**, refresh,

--- a/docs/specs/agents/settings-profile-layout.md
+++ b/docs/specs/agents/settings-profile-layout.md
@@ -35,9 +35,10 @@ to associate with the agent it changes.
   badges, authentication controls, and runtime-update controls keep their
   current behavior.
 - On a full desktop viewport (at least 1024px wide), each profile row shows
-  translated **Duplicate** and **Delete** buttons directly in the row action
-  area. The row does not show the three-dots profile-actions trigger at this
-  width.
+  compact icon-only **Duplicate** and **Delete** action buttons directly in the
+  row action area. The buttons retain translated accessible names, are small
+  and vertically centered, and the row does not show the three-dots
+  profile-actions trigger at this width.
 - Below the full desktop boundary, including compact desktop, tablet, and
   mobile viewports, each profile row keeps the three-dots profile-actions
   trigger and exposes **Duplicate** and **Delete** in its overflow menu. Inline
@@ -65,8 +66,9 @@ to associate with the agent it changes.
   **THEN** the browser navigates to that agent's profile creation route and
   the existing profile rows remain unchanged.
 - **GIVEN** a profile row in a viewport at least 1024px wide, **WHEN** the user
-  views the row, **THEN** translated **Duplicate** and **Delete** buttons are
-  visible inline and the three-dots profile-actions trigger is absent.
+  views the row, **THEN** compact icon-only **Duplicate** and **Delete** buttons
+  with translated accessible names are visible inline, vertically centered,
+  and the three-dots profile-actions trigger is absent.
 - **GIVEN** a profile row in a viewport narrower than 1024px, **WHEN** the user
   opens the profile-actions trigger, **THEN** the overflow menu contains
   **Duplicate** and **Delete**, and no inline action buttons are rendered.


### PR DESCRIPTION
Agent profile actions are difficult to discover on wide desktop rows because they are hidden behind an overflow menu. Full desktop now exposes compact icon-only Duplicate and Delete actions with accessible names inline while compact desktop, tablet, and mobile retain the overflow path.

## Validation

- `cd apps && pnpm install --frozen-lockfile`
- `cd apps/web && pnpm test -- components/settings/agents/agent-profiles-section.test.tsx` (9 tests)
- `cd apps/web && pnpm run typecheck`
- `cd apps/web && pnpm exec eslint components/settings/agents/agent-profiles-section.tsx components/settings/agents/agent-profiles-section.test.tsx`
- `cd apps/web && pnpm run i18n:check`
- `cd apps/web && pnpm run i18n:ratchet`
- `cd apps/web && pnpm e2e:run --project chromium tests/settings/agent-profile-duplicate.spec.ts` (3 tests)
- `cd apps/web && pnpm e2e:run --project mobile-chrome tests/settings/mobile-agent-profile-duplicate.spec.ts` (1 test)
- Fresh synthetic full-desktop, tablet, and mobile screenshots were captured, visually inspected, compressed, and validated through the PR asset manifest.

## Screenshots

![Full desktop profile row with compact icon-only Duplicate and Delete actions](https://raw.githubusercontent.com/kdlbs/kandev/42feb593889f4746059faaadf9ecc73a522cd5c5/full-desktop-icon-actions.png)

![Tablet profile row with Duplicate and Delete in the overflow menu](https://raw.githubusercontent.com/kdlbs/kandev/e646084667e5f6e5f67c1c73951c79b68dadd239/tablet-overflow-actions.png)

![Mobile profile row with touch-reachable overflow actions](https://raw.githubusercontent.com/kdlbs/kandev/e646084667e5f6e5f67c1c73951c79b68dadd239/mobile-overflow-actions.png)

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.

Closes #2629

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2644?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->