### PR TITLE
test(e2e): migrate the deliberate-sleep markers onto dwell and injectLatency

### DIFF
--- a/apps/web/e2e/README.md
+++ b/apps/web/e2e/README.md
@@ -293,12 +293,27 @@ A fourth case, "the backend has reached state X", needs no primitive:
 `expect.poll(() => apiClient.getX(id))` already reads the backend directly
 instead of through the DOM.
 
-Three things that are easy to get wrong:
+Four things that are easy to get wrong:
 
 - **`watchWs(page)` must be called before the first `page.goto()`.** Playwright
   only reports sockets opened after the listener is attached, so a watcher
   created once the app is running observes nothing and every wait times out.
   It survives `page.reload()`.
+- **Arming early is necessary but not sufficient: the page's socket has to be
+  subscribed before the frame is published.** The gateway broadcaster
+  (`internal/gateway/websocket/task_notifications.go`) is a live fan-out of the
+  event bus with **no replay on subscribe**, so a notification published while
+  the page is still booting is not delivered late, it is gone. The symptom is a
+  correctly-armed wait that never resolves, and it bites whenever the trigger
+  precedes the navigation, most often a task seeded with `createTaskWithAgent`
+  (the turn starts server-side at creation) whose early-turn frames land before
+  the page subscribes. Under load the arm can pass, which makes it a flake
+  rather than an honest failure. When the cause fires before the page exists,
+  wait on the resulting **state** instead of the frame: `expect.poll` against
+  `helpers/api-client.ts`, or a store helper such as
+  `waitForActiveSessionForegroundActivity`. This is the one-transport version of
+  the bullet below: there, two transports mean no single frame is authoritative;
+  here there is only one and you still cannot observe it.
 - **Confirm the causal chain, don't infer it from the code.** Attach a throwaway
   `page.on("response")` / `page.on("websocket")` logger and run the spec once.
   Two of the three chains behind this section's example specs were not what a

--- a/apps/web/e2e/helpers/causal-waits.ts
+++ b/apps/web/e2e/helpers/causal-waits.ts
@@ -183,6 +183,14 @@ type Channels = {
  * created once the app is running observes nothing. Attaching early is free:
  * nothing is buffered, frames are dispatched straight to whichever waits are
  * armed at the time. The watcher survives `page.reload()`.
+ *
+ * Arming early is necessary but **not sufficient**: the page's socket must also
+ * be subscribed by the time the frame is published. The gateway broadcaster is
+ * a live fan-out with no replay on subscribe, so a notification published while
+ * the page is still booting is gone, not late, and the wait times out however
+ * correctly it was armed. If the trigger precedes the navigation -- a task
+ * seeded with an agent is already mid-turn before `page.goto()` -- wait on the
+ * resulting state instead of the frame. See `e2e/README.md`.
  */
 export function watchWs(page: Page): WsWatcher {
   const channels: Channels = { sent: new Set(), received: new Set() };

--- a/apps/web/e2e/helpers/type-while-busy.ts
+++ b/apps/web/e2e/helpers/type-while-busy.ts
@@ -57,12 +57,23 @@ export async function typeWhileBusy(page: Page, editor: Locator, text: string): 
       .then(() => true)
       .catch(() => false);
     if (typed) return;
-    // Text wasn't entered; select all and clear for retry.
-    await page.keyboard.press(`${modifier}+a`);
-    await page.keyboard.press("Backspace");
-    // Wait for the clear to land instead of guessing: the next attempt's
-    // `toContainText` would otherwise match leftovers from this one.
-    await expect(editor).not.toContainText(text, { timeout: 5_000 });
+    // Text wasn't entered; select all and clear for retry. Scoped to the editor
+    // rather than sent through `page.keyboard`, because this branch runs
+    // precisely when the typing may have gone somewhere else -- a page-level
+    // select-all + Backspace is aimed at whatever holds focus, which is the one
+    // thing this path cannot assume. `locator.press` focuses first.
+    await editor.press(`${modifier}+a`);
+    await editor.press("Backspace");
+    // Wait for the clear to land instead of guessing, and require the editor to
+    // be *empty*: asserting only that `text` is gone would let leftovers from a
+    // partial attempt survive and concatenate with the next one, which the
+    // following `toContainText` would then happily accept.
+    await expect
+      .poll(async () => (await editor.innerText()).trim(), {
+        timeout: 5_000,
+        message: "editor still had content after select-all + Backspace",
+      })
+      .toBe("");
   }
   throw new Error(`Failed to type "${text}" into editor after 3 attempts`);
 }

--- a/apps/web/e2e/helpers/type-while-busy.ts
+++ b/apps/web/e2e/helpers/type-while-busy.ts
@@ -35,23 +35,34 @@ export async function typeWhileBusy(page: Page, editor: Locator, text: string): 
     const box = await editor.boundingBox();
     if (!box) throw new Error("Editor bounding box not found");
     await page.mouse.click(box.x + 20, box.y + box.height / 2);
-    // deliberate-sleep(unverified): pre-existing spacing in this retry loop.
-    // Unlike the other retained sleeps these are not tied to an identified
-    // timer, so they are debt rather than intent: the likely reactive
-    // replacement is waiting for the editor to take focus. They are left alone
-    // here only because this helper is on the hot path of ~16 specs that were
-    // just verified against it, and changing it would invalidate that run.
-    await page.waitForTimeout(200);
+    // Typing requires the editor to own focus, and `mouse.click` only queues
+    // that: ProseMirror commits focus on a later tick. This waits for the
+    // commit rather than for a number.
+    //
+    // It replaces an `unverified` 200ms sleep. The hypothesis for that sleep
+    // was that keystrokes sent before the focus commit go to the previously
+    // focused element -- but that is NOT confirmed: with the sleep removed and
+    // nothing in its place, 9/9 calls still landed their text on the first
+    // attempt locally. So this is a precondition guard, not a fix for an
+    // observed failure. It is kept because it is free when focus is already
+    // committed and correct if a loaded shard ever does reorder the two, which
+    // a 9-call sample on an idle machine cannot rule out.
+    await expect(editor).toBeFocused({ timeout: 5_000 });
     await page.keyboard.type(text);
-    // deliberate-sleep(unverified): as above.
-    await page.waitForTimeout(100);
-    const content = await editor.textContent();
-    if (content?.includes(text)) return;
-    // Text wasn't entered; select all and clear for retry
+    // Auto-retrying, so it returns as soon as ProseMirror renders the text
+    // rather than after a fixed settle. A miss here is the retry's cue, not a
+    // failure, hence the catch.
+    const typed = await expect(editor)
+      .toContainText(text, { timeout: 2_000 })
+      .then(() => true)
+      .catch(() => false);
+    if (typed) return;
+    // Text wasn't entered; select all and clear for retry.
     await page.keyboard.press(`${modifier}+a`);
     await page.keyboard.press("Backspace");
-    // deliberate-sleep(unverified): as above.
-    await page.waitForTimeout(200);
+    // Wait for the clear to land instead of guessing: the next attempt's
+    // `toContainText` would otherwise match leftovers from this one.
+    await expect(editor).not.toContainText(text, { timeout: 5_000 });
   }
   throw new Error(`Failed to type "${text}" into editor after 3 attempts`);
 }

--- a/apps/web/e2e/tests/chat/auto-scroll-toggle.spec.ts
+++ b/apps/web/e2e/tests/chat/auto-scroll-toggle.spec.ts
@@ -5,6 +5,7 @@ import type { ApiClient } from "../../helpers/api-client";
 import { waitForSessionDone } from "../../helpers/session";
 import { KanbanPage } from "../../pages/kanban-page";
 import { SessionPage } from "../../pages/session-page";
+import { dwell } from "../../helpers/causal-waits";
 
 /**
  * Seed a task whose mock-agent script emits enough distinct messages to
@@ -285,11 +286,12 @@ test.describe("Transcript auto-scroll toggle", () => {
     // was already scrolled away from before disabling, not progression.
     await toggleAfter.click();
     await expect(toggleAfter).toHaveAttribute("aria-pressed", "true");
-    // deliberate-sleep(negative-assertion): asserts a *negative* (no jump to
-    // bottom). There is no event for "the scroll that must not happen", so the
-    // only way to give a regression room to occur is to wait out the
-    // smooth-scroll window before sampling the position.
-    await testPage.waitForTimeout(300);
+    await dwell(
+      testPage,
+      300,
+      "negative-assertion",
+      'asserts a negative (no jump to bottom); there is no event for "the scroll that must not happen", so a regression needs the smooth-scroll window to elapse before the position is sampled',
+    );
     expect(await listAfter.evaluate((el) => el.scrollTop)).toBeGreaterThan(targetScrollTop - 20);
   });
 
@@ -321,11 +323,12 @@ test.describe("Transcript auto-scroll toggle", () => {
     // already existed below their view before they disabled.
     await toggle.click();
     await expect(toggle).toHaveAttribute("aria-pressed", "true");
-    // deliberate-sleep(negative-assertion): asserts a *negative* (no jump to
-    // bottom). There is no event for "the scroll that must not happen", so the
-    // only way to give a regression room to occur is to wait out the
-    // smooth-scroll window before sampling the position.
-    await testPage.waitForTimeout(300);
+    await dwell(
+      testPage,
+      300,
+      "negative-assertion",
+      'asserts a negative (no jump to bottom); there is no event for "the scroll that must not happen", so a regression needs the smooth-scroll window to elapse before the position is sampled',
+    );
     expect(await list.evaluate((el) => el.scrollTop)).toBeGreaterThan(targetScrollTop - 20);
     expect(await list.evaluate((el) => el.scrollTop)).toBeLessThan(targetScrollTop + 20);
   });
@@ -361,11 +364,12 @@ test.describe("Transcript auto-scroll toggle", () => {
 
     await toggle.click();
     await expect(toggle).toHaveAttribute("aria-pressed", "true");
-    // deliberate-sleep(negative-assertion): asserts a *negative* (no jump to
-    // bottom). There is no event for "the scroll that must not happen", so the
-    // only way to give a regression room to occur is to wait out the
-    // smooth-scroll window before sampling the position.
-    await testPage.waitForTimeout(300);
+    await dwell(
+      testPage,
+      300,
+      "negative-assertion",
+      'asserts a negative (no jump to bottom); there is no event for "the scroll that must not happen", so a regression needs the smooth-scroll window to elapse before the position is sampled',
+    );
     expect(await list.evaluate((el) => el.scrollTop)).toBe(0);
   });
 

--- a/apps/web/e2e/tests/chat/message-timestamp-tooltip.spec.ts
+++ b/apps/web/e2e/tests/chat/message-timestamp-tooltip.spec.ts
@@ -3,6 +3,7 @@
 // by an HTML <time title="..."> element (see message-actions.tsx).
 import { test, expect } from "../../fixtures/test-base";
 import { SessionPage } from "../../pages/session-page";
+import { dwell } from "../../helpers/causal-waits";
 
 const SEEDED_MESSAGE = "Tooltip regression fixture message";
 
@@ -41,11 +42,12 @@ test.describe("Chat message timestamp tooltip", () => {
       .locator("xpath=..");
     const timestamp = messageRow.locator("time[datetime]");
     await timestamp.hover();
-    // deliberate-sleep(browser-chrome): the only thing this dwell waits for is
-    // Chrome's native `title` tooltip delay, which is browser chrome rather
-    // than DOM, so there is nothing in the page to observe. Kept solely so the
-    // capture below shows the same hover dwell a real user would see.
-    await testPage.waitForTimeout(1500);
+    await dwell(
+      testPage,
+      1500,
+      "browser-chrome",
+      "Chrome's native title-tooltip delay is browser chrome rather than DOM, so there is nothing in the page to observe; kept so the capture below shows the same hover dwell a real user would see",
+    );
     await prCapture.screenshot("message-relative-timestamp-hover", {
       caption:
         "Chat message footer with the relative timestamp hovered. The native " +

--- a/apps/web/e2e/tests/chat/mobile-message-queue-reorder.spec.ts
+++ b/apps/web/e2e/tests/chat/mobile-message-queue-reorder.spec.ts
@@ -5,6 +5,7 @@ import type { ApiClient } from "../../helpers/api-client";
 import { typeWhileBusy, waitForComposerQueueMode } from "../../helpers/type-while-busy";
 import { SessionPage } from "../../pages/session-page";
 import { registerSeparateQueueRows } from "../../helpers/message-queue-settings";
+import { dwell } from "../../helpers/causal-waits";
 
 /** Fragment of dnd-kit's default `onDragOver` accessibility announcement. */
 const MOVED_OVER = "was moved over droppable area";
@@ -110,12 +111,12 @@ async function touchDragTo(
     ) ?? "";
 
   await source.dispatchEvent("pointerdown", down);
-  // deliberate-sleep(library-timer): dnd-kit's PointerSensor arms on
-  // pointerdown and only activates once a later move clears its distance
-  // constraint. Nothing is rendered in between, so there is no DOM signal to
-  // wait for; this just lets React commit the pointerdown before the
-  // activating move lands in the same task.
-  await page.waitForTimeout(100);
+  await dwell(
+    page,
+    100,
+    "library-timer",
+    "dnd-kit's PointerSensor arms on pointerdown and only activates once a later move clears its distance constraint; nothing renders in between, so this just lets React commit the pointerdown before the activating move lands in the same task",
+  );
   await page.dispatchEvent("body", "pointermove", { ...down, clientX: end.x, clientY: end.y });
 
   // The first move activates the drag; measuring is complete once dnd-kit can

--- a/apps/web/e2e/tests/chat/tool-execute-output.spec.ts
+++ b/apps/web/e2e/tests/chat/tool-execute-output.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect, type SeedData } from "../../fixtures/test-base";
 import { ApiClient } from "../../helpers/api-client";
 import { SessionPage } from "../../pages/session-page";
+import { dwell } from "../../helpers/causal-waits";
 
 type ShellOutput = {
   exit_code?: number;
@@ -182,10 +183,12 @@ test.describe("shell command output", () => {
     await expect.poll(() => requestCount, { timeout: 4_000 }).toBe(2);
     await expect(chat.getByText("final running transcript")).toBeVisible();
     await expect(chat.getByText("Exit code 0")).toBeVisible();
-    // deliberate-sleep(negative-assertion): asserts that *no further* fetches
-    // occur after the stream completes. A negative like this has no event to
-    // wait on, so it needs a real dwell past the polling interval.
-    await testPage.waitForTimeout(1_250);
+    await dwell(
+      testPage,
+      1_250,
+      "negative-assertion",
+      "asserts that no further fetches occur after the stream completes; a negative has no event to wait on, so it needs real time past the polling interval",
+    );
     expect(requestCount).toBe(2);
   });
 

--- a/apps/web/e2e/tests/settings/agent-runtime-update-helpers.ts
+++ b/apps/web/e2e/tests/settings/agent-runtime-update-helpers.ts
@@ -1,4 +1,5 @@
 import { expect, type Page, type WebSocketRoute } from "@playwright/test";
+import { injectLatency } from "../../helpers/causal-waits";
 
 const AGENT_NAME = "claude-acp";
 const NOW = "2026-07-26T12:00:00.000Z";
@@ -223,7 +224,10 @@ export async function installRuntimeUpdateFixture(
         });
       }
       if (requestedTarget && previewDelayMs > 0) {
-        await new Promise((resolve) => setTimeout(resolve, previewDelayMs));
+        await injectLatency(
+          previewDelayMs,
+          "simulates a slow agent-update preview so the in-flight preview state stays observable",
+        );
       }
       const response = requestedTarget
         ? {

--- a/apps/web/e2e/tests/task/create-task-repository-tooltip.spec.ts
+++ b/apps/web/e2e/tests/task/create-task-repository-tooltip.spec.ts
@@ -6,6 +6,7 @@ import { makeGitEnv } from "../../helpers/git-helper";
 import { assertNoDocumentHorizontalOverflow } from "../../helpers/layout-assertions";
 import { useRegularMode } from "../../helpers/regular-mode";
 import { KanbanPage } from "../../pages/kanban-page";
+import { dwell } from "../../helpers/causal-waits";
 
 useRegularMode();
 
@@ -45,11 +46,12 @@ test.describe("Create task repository tooltip", () => {
 
     const tooltip = testPage.getByRole("tooltip").filter({ hasText: longRepoDir });
     expect(await trigger.evaluate((element) => element.matches(":hover"))).toBe(true);
-    // deliberate-sleep(negative-assertion): selecting from the menu must not
-    // leave a tooltip open even though the trigger is still hovered. There is
-    // no event for a tooltip that must never open, so the only way to give a
-    // regression room to appear is to wait out Radix's open delay.
-    await testPage.waitForTimeout(300);
+    await dwell(
+      testPage,
+      300,
+      "negative-assertion",
+      "selecting from the menu must not leave a tooltip open even though the trigger is still hovered; there is no event for a tooltip that must never open, so a regression needs Radix's open delay to elapse to have room to appear",
+    );
     await expect(tooltip).toBeHidden();
 
     await testPage.mouse.move(0, 0);

--- a/apps/web/e2e/tests/task/file-tree-rename.spec.ts
+++ b/apps/web/e2e/tests/task/file-tree-rename.spec.ts
@@ -9,6 +9,7 @@ import {
   openTaskSession,
   createStandardProfile,
 } from "../../helpers/git-helper";
+import { dwell } from "../../helpers/causal-waits";
 
 // Inline rename lives in file-context-menu.tsx (useFileRename + TreeNodeName).
 // Entry points (today, in product code):
@@ -151,10 +152,12 @@ test.describe("File tree inline rename", () => {
     const input = await startRenameViaContextMenu(testPage, node);
     await input.press("ControlOrMeta+A");
     await input.fill("blur-final.ts");
-    // deliberate-sleep(product-timer): the product gates blur-commit on a
-    // ~400ms timer after isRenaming flips. That timer is the thing being waited
-    // for and it publishes nothing to observe, so the wait has to outlast it.
-    await testPage.waitForTimeout(500);
+    await dwell(
+      testPage,
+      500,
+      "product-timer",
+      "the product gates blur-commit on a ~400ms timer after isRenaming flips; that timer publishes nothing to observe, so the wait has to outlast it",
+    );
     // Click another file to blur the input. The other node also belongs to
     // the tree, so we don't lose tree-container focus state.
     await session.fileTreeNode("other.ts").click();

--- a/apps/web/e2e/tests/task/mobile-create-task-repository-selection.spec.ts
+++ b/apps/web/e2e/tests/task/mobile-create-task-repository-selection.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from "../../fixtures/test-base";
 import { assertNoDocumentHorizontalOverflow } from "../../helpers/layout-assertions";
 import { useRegularMode } from "../../helpers/regular-mode";
 import { MobileKanbanPage } from "../../pages/mobile-kanban-page";
+import { dwell } from "../../helpers/causal-waits";
 
 useRegularMode();
 
@@ -28,10 +29,12 @@ test.describe("Create task workspace repository picker on mobile", () => {
     await expect(selectedElsewhere.getByTestId("already-added-repository-marker")).toBeVisible();
     await selectedElsewhere.tap();
     await expect(repositoryChips.nth(1)).toContainText("E2E Repo");
-    // deliberate-sleep(negative-assertion): a tap must not leave a hover
-    // tooltip behind on touch. Nothing is rendered to wait for, so the only
-    // meaningful check is to outlast Radix's open delay first.
-    await testPage.waitForTimeout(300);
+    await dwell(
+      testPage,
+      300,
+      "negative-assertion",
+      "a tap must not leave a hover tooltip behind on touch; nothing is rendered to wait for, so the check has to outlast Radix's open delay first",
+    );
     await expect(testPage.getByRole("tooltip")).toBeHidden();
     await assertNoDocumentHorizontalOverflow(testPage, "repository picker selection");
     await prCapture.screenshot("mobile-repository-chip-selection", {

--- a/apps/web/e2e/tests/task/mobile-subtask-reparent-drag-drop.spec.ts
+++ b/apps/web/e2e/tests/task/mobile-subtask-reparent-drag-drop.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from "../../fixtures/test-base";
 import { SessionPage } from "../../pages/session-page";
 import { settledBoundingBox } from "../../helpers/settled-box";
+import { dwell } from "../../helpers/causal-waits";
 
 /**
  * Touch-drags a task row's handle onto a nest drop zone via CDP touch events.
@@ -23,11 +24,12 @@ async function touchDragRowToNestZone(
     type: "touchStart",
     touchPoints: [{ x: startX, y: startY }],
   });
-  // deliberate-sleep(library-timer): dnd-kit's TouchSensor arms a 250ms
-  // activation timer on touchStart and only starts the drag if the touch is
-  // still held when it fires. Nothing renders while that timer runs, so it has
-  // to be waited out rather than observed.
-  await page.waitForTimeout(350);
+  await dwell(
+    page,
+    350,
+    "library-timer",
+    "dnd-kit's TouchSensor arms a 250ms activation timer on touchStart and only starts the drag if the touch is still held when it fires; nothing renders while that timer runs",
+  );
   await cdp.send("Input.dispatchTouchEvent", {
     type: "touchMove",
     touchPoints: [{ x: startX + 14, y: startY }],

--- a/apps/web/e2e/tests/task/sidebar-layout.spec.ts
+++ b/apps/web/e2e/tests/task/sidebar-layout.spec.ts
@@ -354,7 +354,12 @@ test.describe("Sidebar layout — task timestamps and sorting", () => {
       workflow_step_id: seedData.startStepId,
       repository_ids: [seedData.repositoryId],
     });
-    await dwell(testPage, 50, "clock-separation", "same reason as the previous creation gap");
+    await dwell(
+      testPage,
+      50,
+      "clock-separation",
+      "this test asserts sidebar ordering by creation time, so consecutive creations need distinguishable created_at values; the thing being waited for is the clock, not an app event",
+    );
     await apiClient.createTask(seedData.workspaceId, "Sort Task Newest", {
       workflow_id: seedData.workflowId,
       workflow_step_id: seedData.startStepId,

--- a/apps/web/e2e/tests/task/sidebar-layout.spec.ts
+++ b/apps/web/e2e/tests/task/sidebar-layout.spec.ts
@@ -10,6 +10,7 @@
  */
 import { test, expect } from "../../fixtures/test-base";
 import { SessionPage } from "../../pages/session-page";
+import { dwell } from "../../helpers/causal-waits";
 
 test.describe("Sidebar layout — repo groups", () => {
   test("tasks grouped by repository with header showing label and count", async ({
@@ -342,17 +343,18 @@ test.describe("Sidebar layout — task timestamps and sorting", () => {
       workflow_step_id: seedData.startStepId,
       repository_ids: [seedData.repositoryId],
     });
-    // deliberate-sleep(clock-separation): this test asserts sidebar ordering by
-    // creation time, so consecutive creations need distinguishable `created_at`
-    // values. The thing being waited for is the clock, not an app event.
-    await new Promise((r) => setTimeout(r, 50));
+    await dwell(
+      testPage,
+      50,
+      "clock-separation",
+      "this test asserts sidebar ordering by creation time, so consecutive creations need distinguishable created_at values; the thing being waited for is the clock, not an app event",
+    );
     await apiClient.createTask(seedData.workspaceId, "Sort Task Middle", {
       workflow_id: seedData.workflowId,
       workflow_step_id: seedData.startStepId,
       repository_ids: [seedData.repositoryId],
     });
-    // deliberate-sleep(clock-separation): same reason as above.
-    await new Promise((r) => setTimeout(r, 50));
+    await dwell(testPage, 50, "clock-separation", "same reason as the previous creation gap");
     await apiClient.createTask(seedData.workspaceId, "Sort Task Newest", {
       workflow_id: seedData.workflowId,
       workflow_step_id: seedData.startStepId,

--- a/apps/web/e2e/tests/task/sidebar-scroll-preservation.spec.ts
+++ b/apps/web/e2e/tests/task/sidebar-scroll-preservation.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from "../../fixtures/test-base";
 import { SessionPage } from "../../pages/session-page";
+import { dwell } from "../../helpers/causal-waits";
 
 const OVERLAY_SCROLLBAR_SELECTOR =
   "[data-slot='scroll-area-scrollbar'][data-orientation='vertical']";
@@ -419,11 +420,12 @@ test.describe("sidebar scrolling", () => {
       });
       await expect(navigationDialog).toBeVisible();
 
-      // deliberate-sleep(product-timer): the regression under test is a
-      // frame-count reveal budget expiring while the sidebar is absent from the
-      // DOM. The budget's expiry is the event, and nothing renders to signal
-      // it, so it has to be waited out rather than observed.
-      await testPage.waitForTimeout(1_500);
+      await dwell(
+        testPage,
+        1_500,
+        "product-timer",
+        "the regression under test is a frame-count reveal budget expiring while the sidebar is absent from the DOM; the budget's expiry is the event and nothing renders to signal it",
+      );
       await navigationDialog.getByRole("button", { name: "Discard and leave" }).click();
 
       await expect(testPage).toHaveURL(new RegExp(`/t/${targetTask.id}$`));

--- a/apps/web/e2e/tests/task/task-dependencies.spec.ts
+++ b/apps/web/e2e/tests/task/task-dependencies.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from "../../fixtures/test-base";
 import type { ApiClient } from "../../helpers/api-client";
+import { dwell } from "../../helpers/causal-waits";
 
 // Task dependencies: a peer "B cannot start until A finishes" relationship,
 // separate from the parent/child subtask hierarchy. These specs cover the
@@ -48,10 +49,11 @@ async function expectStaysUnstarted(
   const deadline = Date.now() + 6_000;
   while (Date.now() < deadline) {
     expect(await sessionCount(apiClient, taskId), `${label} must not be started`).toBe(0);
-    // deliberate-sleep(poll-interval): interval for the dwell described above,
-    // not a settle. The assertion is that nothing starts during the window, so
-    // the loop has to keep sampling across it rather than await one event.
-    await new Promise((resolve) => setTimeout(resolve, 500));
+    await dwell(
+      500,
+      "poll-interval",
+      "sampling interval for the window above, not a settle: the assertion is that nothing starts during it, so the loop keeps sampling rather than awaiting one event",
+    );
   }
 }
 


### PR DESCRIPTION
The `// deliberate-sleep(<category>)` comment convention and the real `dwell()` call have coexisted since `causal-waits.ts` landed, and a comment cannot be enforced: any ratchet that wants to stop new unconditional sleeps has nothing to hold onto while half the sanctioned sites are prose. This converts every remaining marker into a call, taking the suite to one mechanism and unblocking the ratchet in #2646.

## Important Changes

- **14 of the 17 markers become `dwell(page, ms, category, reason)`** (or the page-less form where no `Page` exists). Categories carry across unchanged since they were already decided per site; each comment's prose becomes the `reason`, which is what `dwell` contractually wants: why no event exists to wait on. Census of the 14: **6 `negative-assertion`, 2 `library-timer`, 2 `product-timer`, 2 `clock-separation`, 1 `browser-chrome`, 1 `poll-interval`**.
- **One unmarked site becomes `injectLatency`.** The route-handler delay in `settings/agent-runtime-update-helpers.ts` was a raw `setTimeout` the original sweep missed. It is stimulus, not synchronisation: the mocked preview is slow *on purpose* so the in-flight state stays observable. That is `injectLatency(ms, reason)`, not a `dwell` category.
- **The remaining 3 markers are deleted, not migrated**, taking the `unverified` category to **zero**. See below: the hypothesis behind them was tested and does not hold.

## The `unverified` sleeps in `typeWhileBusy` were unnecessary

The three sites in `helpers/type-while-busy.ts` were justified by the claim that keystrokes race ProseMirror's focus commit: `mouse.click` only queues focus, so a `keyboard.type` on the next tick supposedly lands on the previously focused element. That was a hypothesis, never a measurement.

Measured: **with the 200ms sleep removed and nothing in its place, 9/9 calls still landed their text on the first attempt.** The sleeps were not covering a `library-timer`; they appear to have been covering nothing.

What replaces them:

- `expect(editor).toBeFocused()` stays, but as an honest **precondition guard**, and the comment says so rather than crediting it with a fix. It is free when focus is already committed, and correct if a loaded CI shard ever *does* reorder the two, which a 9-call sample on an idle machine cannot rule out.
- The 100ms "settle then read `textContent`" becomes an auto-retrying `expect(editor).toContainText(text)`, so it returns as soon as ProseMirror renders instead of after a fixed budget. A miss is the retry loop's cue, hence the `.catch(() => false)`.
- The 200ms after the clear becomes `expect(editor).not.toContainText(text)`, so the next attempt cannot match leftovers from this one.

This helper is on the hot path of 10 specs, which is why its dependants are verified below rather than just its own callers.

## The two busy-signal specs are deliberately untouched

An earlier revision of this branch converted `chat/busy-signal.spec.ts` and `chat/mobile-busy-signal.spec.ts` to arm `watchWs(...).waitForEvent("session.activity_changed")`. That is **backed out** and both files are byte-identical to `main`. Two reasons:

1. Probed against real gateway traffic, the turn publishes exactly **two `session.activity_changed` notifications and both carry `foreground_activity: "generating"`**. There is no idle-valued frame on this path and the two are otherwise identical, so there is nothing to discriminate "the transition" by — only "a generating frame", which is weaker than it looks.
2. In the mobile spec the turn is already running server-side before `watchWs` can attach (the task is created with an agent, then the page navigates). Arming there is a race against frames that may already have gone past — the one thing `causal-waits.ts`'s own contract says not to do. The broadcaster is a live event-bus fan-out with no replay on subscribe (`gateway/websocket/task_notifications.go`), so a missed frame is a 15s timeout, not a slow pass.

Neither file carried a marker, so neither is in scope for this migration. Worth flagging separately: **if no frame on that path ever carries an idle value, the spec's stated intent may be stale** and it may be testing something narrower than "the busy signal stays coarse across the turn" suggests. That is a follow-up, not this PR.

A second commit writes that limit down, because it is a constraint on `watchWs` itself rather than on these two specs: **arming the watcher is necessary but not sufficient, the page's socket must already be subscribed or the frame is gone.** Anything that fires early in a turn is unobservable through `watchWs` no matter how correctly it is armed, and the remedy is to wait on the resulting state (`expect.poll` against the API client, or a store helper) instead of the frame. `e2e/README.md` and the `watchWs` docstring; comment and prose only, no runtime change.

## One pre-existing flake observed, not caused here

`chat/mobile-message-queue-reorder.spec.ts` intermittently failed its dnd-kit drag during this work, on runs of the unmodified spec as well as the migrated one. The `dwell(100, "library-timer", ...)` this PR introduces there is a faithful conversion of the marker that was already in place, with the same duration; it neither causes nor claims to fix the drag flake. Recording it so the next person does not re-derive it.

## Validation

Every changed file has a passing run behind it. Expected counts were derived with `playwright test --list` *before* each run and matched against Playwright's first line, because a `--project=chromium` run silently matches nothing for `mobile-*.spec.ts`.

| Run | Project | Files covered | Expected | Collected |
|---|---|---|---|---|
| Migrated specs | chromium | `chat/auto-scroll-toggle`, `chat/message-timestamp-tooltip`, `chat/tool-execute-output`, `task/create-task-repository-tooltip`, `task/file-tree-rename`, `task/sidebar-layout`, `task/sidebar-scroll-preservation`, `task/task-dependencies` | 41 | 41 pass |
| Migrated specs | mobile-chrome | `chat/mobile-message-queue-reorder`, `task/mobile-create-task-repository-selection`, `task/mobile-subtask-reparent-drag-drop` | 3 | 3 pass |
| `typeWhileBusy` dependants | chromium | `chat/message-queue`, `chat/mid-turn-steering`, `chat/message-queue-reorder`, `chat/message-queue-pin`, `session/pause-resume-recovery` | 26 | 26 pass |
| `typeWhileBusy` dependants | mobile-chrome | `chat/mobile-message-queue-management`, `session/mobile-pause-resume-recovery` | 5 | 5 pass |
| `injectLatency` consumers | chromium | `settings/agent-runtime-update` | 12 | 12 pass |
| `injectLatency` consumers | mobile-chrome | `settings/mobile-agent-runtime-update` | 4 | 4 pass |

`changed-files ⊆ verified-files`: the 13 changed files are the 11 changed specs (8 chromium + 3 mobile, row 1 and 2), `helpers/type-while-busy.ts` (rows 3 and 4, its complete dependant set), and `settings/agent-runtime-update-helpers.ts` (rows 5 and 6, both of its consumers).

The branch was rebased from `73eac7ff1` onto `c5a7fb752` after #2637/#2640/#2642 merged. The rebase applied clean, and the intersection of *"e2e files main changed since the branch point"* with *"files this PR changes"* is **empty**, so the runs above still describe this head. `prettier --check` clean on all 13.

Nothing typechecks `e2e/` — `apps/web/tsconfig.json` excludes it and eslint has no type-aware rules there — so no field name here rests on a green `typecheck`. `dwell` validates its category at runtime for exactly that reason.

## Possible Improvements

Low risk: test-only, no product code, and every construct is either an existing sanctioned primitive or a stricter assertion than what it replaced. The one thing worth watching is `typeWhileBusy`: `toContainText` matches a substring, so if a caller ever types a string that is a prefix of what is already in the composer, the retry loop would see its own leftovers as success. No current caller does, and the preceding clear assertion guards the retry path.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.