### PR TITLE
test(e2e): replace the layout specs' unconditional sleeps with causal waits

### DIFF
--- a/apps/web/e2e/helpers/dockview-resize.ts
+++ b/apps/web/e2e/helpers/dockview-resize.ts
@@ -60,21 +60,34 @@ export async function getDockviewContainerWidth(page: Page): Promise<number> {
 }
 
 /**
- * Wait for a `setViewportSize` to have reached dockview's layout, by watching
- * the container width move off the value it had before.
+ * Wait for a `setViewportSize` to have reached dockview's layout.
  *
- * Column widths are recomputed inside the same layout pass that resizes the
- * container, so this is the anchor a width assertion needs after a viewport
- * change: measured across five scenarios (auto shrink and grow, manual-width
- * shrink and grow, over-cap re-clamp), the container and the right column
- * reached their final widths **in the same frame** every time, 3-11ms after
- * the viewport call resolved. Nothing moved again in the following 2.5s.
+ * Two conditions, both required, evaluated together in one `page.evaluate` so
+ * they describe a single instant:
  *
- * That co-settling is what makes the container a valid proxy, and it is the
- * assumption to re-measure if column sizing ever moves behind a debounce.
- * Without it there is nothing else to wait for: a column whose width must
- * *not* change across the viewport change has no event of its own, and
- * polling its value would be satisfied instantly by the width it already has.
+ *  1. the container's CSS box has moved off the width it had before, and
+ *  2. dockview's own `api.width` agrees with that box.
+ *
+ * (1) alone is not enough, and the reason is subtle. The app syncs a container
+ * resize into `api.layout` from `setupContainerResizeSync`'s ResizeObserver;
+ * measured under load (12 saturated cores, 6x CDP CPU throttling, five
+ * scenarios: auto shrink and grow, manual-width shrink and grow, over-cap
+ * re-clamp), that sync is already complete at the first ResizeObserver
+ * delivery reporting the new box, right column included. But a poll does not
+ * observe via ResizeObserver: `getBoundingClientRect()` forces a synchronous
+ * reflow, so it can read the post-resize box in a task that runs *before* that
+ * delivery, and therefore before `api.layout`. Condition (2) closes that
+ * window by reading the value the sync actually produces.
+ *
+ * (2) alone would be the already-true trap: `api.width` matches the box before
+ * the viewport changes as well, so it is satisfied instantly. Only the pair is
+ * causal, which is why this is not simply a poll on the expected group width.
+ * That matters most for the callers asserting a width must **not** change
+ * across the resize: they have no event of their own, and polling the value
+ * they expect would pass against the width that was already there.
+ *
+ * A 1px tolerance absorbs fractional-vs-rounded differences between the two
+ * readings; it is far below any real column-width assertion's slack.
  */
 export async function waitForDockviewViewportResize(
   page: Page,
@@ -82,11 +95,26 @@ export async function waitForDockviewViewportResize(
   timeout = 5_000,
 ): Promise<void> {
   await expect
-    .poll(() => getDockviewContainerWidth(page), {
-      timeout,
-      message: `dockview container never resized away from ${previousContainerWidth}px`,
-    })
-    .not.toBe(previousContainerWidth);
+    .poll(
+      () =>
+        page.evaluate((previous) => {
+          const element = document.querySelector(".dv-dockview");
+          const api = (window as unknown as { __dockviewApi__?: { width: number } })
+            .__dockviewApi__;
+          if (!element) return "no dockview container";
+          if (!api) return "dockview api not exposed";
+          const css = Math.round(element.getBoundingClientRect().width);
+          if (css === previous) return `container still ${css}px`;
+          const layout = Math.round(api.width);
+          if (Math.abs(layout - css) > 1) return `container ${css}px but api.width ${layout}px`;
+          return "settled";
+        }, previousContainerWidth),
+      {
+        timeout,
+        message: `dockview never took the new viewport (was ${previousContainerWidth}px)`,
+      },
+    )
+    .toBe("settled");
 }
 
 /** Read the live pixel width of a dockview group by group ID. */

--- a/apps/web/e2e/helpers/dockview-resize.ts
+++ b/apps/web/e2e/helpers/dockview-resize.ts
@@ -52,6 +52,43 @@ export async function getDockviewGroupWidth(page: Page, panelId: string): Promis
   }, panelId);
 }
 
+/** Read the dockview container's live pixel width. */
+export async function getDockviewContainerWidth(page: Page): Promise<number> {
+  return page.evaluate(() =>
+    Math.round(document.querySelector(".dv-dockview")?.getBoundingClientRect().width ?? -1),
+  );
+}
+
+/**
+ * Wait for a `setViewportSize` to have reached dockview's layout, by watching
+ * the container width move off the value it had before.
+ *
+ * Column widths are recomputed inside the same layout pass that resizes the
+ * container, so this is the anchor a width assertion needs after a viewport
+ * change: measured across five scenarios (auto shrink and grow, manual-width
+ * shrink and grow, over-cap re-clamp), the container and the right column
+ * reached their final widths **in the same frame** every time, 3-11ms after
+ * the viewport call resolved. Nothing moved again in the following 2.5s.
+ *
+ * That co-settling is what makes the container a valid proxy, and it is the
+ * assumption to re-measure if column sizing ever moves behind a debounce.
+ * Without it there is nothing else to wait for: a column whose width must
+ * *not* change across the viewport change has no event of its own, and
+ * polling its value would be satisfied instantly by the width it already has.
+ */
+export async function waitForDockviewViewportResize(
+  page: Page,
+  previousContainerWidth: number,
+  timeout = 5_000,
+): Promise<void> {
+  await expect
+    .poll(() => getDockviewContainerWidth(page), {
+      timeout,
+      message: `dockview container never resized away from ${previousContainerWidth}px`,
+    })
+    .not.toBe(previousContainerWidth);
+}
+
 /** Read the live pixel width of a dockview group by group ID. */
 export async function getDockviewGroupWidthById(page: Page, groupId: string): Promise<number> {
   return page.evaluate((id) => {

--- a/apps/web/e2e/tests/layout/changes-panel-focus.spec.ts
+++ b/apps/web/e2e/tests/layout/changes-panel-focus.spec.ts
@@ -6,6 +6,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { execSync } from "node:child_process";
 import { waitForSessionDone } from "../../helpers/session";
+import { dwell } from "../../helpers/causal-waits";
 
 /** Minimal git helper for E2E tests - runs git commands in the test repository. */
 class GitHelper {
@@ -284,8 +285,12 @@ test.describe("Changes panel focus behavior", () => {
       timeout: 15_000,
     });
 
-    // Wait a bit for any async auto-activate to fire
-    await testPage.waitForTimeout(2_000);
+    await dwell(
+      testPage,
+      2_000,
+      "negative-assertion",
+      "the assertion below is that the changes tab does not steal activation; an auto-activate that must never happen publishes nothing, so the only way to give a regression room to fire is to let its window elapse",
+    );
 
     await expect(changesTab(testPage)).not.toHaveClass(/dv-active-tab/, { timeout: 5_000 });
 

--- a/apps/web/e2e/tests/layout/pane-resize-edge-cases.spec.ts
+++ b/apps/web/e2e/tests/layout/pane-resize-edge-cases.spec.ts
@@ -33,7 +33,18 @@ test.describe("Pane resize edge cases", () => {
       if (!matching) throw new Error("files group not found");
       matching.api.maximize();
     });
-    await testPage.waitForTimeout(150);
+    // Wait for the maximized layout to be applied rather than for a number.
+    // `hasMaximizedGroup()` flips synchronously inside `maximize()`, so polling
+    // it would guard nothing; the group growing is the consequence that has to
+    // land before exiting is a real round trip. Measured, maximize takes this
+    // group from the 600px set above to ~1000px -- it does not fill the
+    // container, so this asserts growth rather than a proportion.
+    await expect
+      .poll(() => getDockviewGroupWidth(testPage, "files"), {
+        timeout: 5_000,
+        message: `files group never grew past its pre-maximize ${before}px`,
+      })
+      .toBeGreaterThan(before + 50);
     await testPage.evaluate(() => {
       type GroupApi = { exitMaximized: () => void };
       type Group = { id: string; panels: { id: string }[]; api: GroupApi };
@@ -67,10 +78,31 @@ test.describe("Pane resize edge cases", () => {
     const errors: string[] = [];
     testPage.on("pageerror", (err) => errors.push(err.message));
 
-    await testPage.locator("body").click({ position: { x: 5, y: 5 } });
-    const mod = process.platform === "darwin" ? "Meta" : "Control";
-    await testPage.keyboard.press(`${mod}+b`);
-    await testPage.waitForTimeout(250);
+    // This used to press Ctrl+B and sleep 250ms. Ctrl+B does nothing:
+    // `CONFIGURABLE_SHORTCUTS.TOGGLE_SIDEBAR` defaults to `UNBOUND_SHORTCUT`,
+    // so the binding exists only for users who set one. Nothing downstream
+    // asserted on the sidebar, so the test has been resizing with the sidebar
+    // still open -- a duplicate of the case above rather than the edge case it
+    // is named for. Collapse it through the store instead; the subject here is
+    // the resize, not how the collapse was triggered.
+    await testPage.evaluate(() => {
+      type StoreWindow = Window & {
+        __KANDEV_E2E_STORE__?: {
+          getState: () => { setAppSidebarCollapsed: (collapsed: boolean) => void };
+        };
+      };
+      const store = (window as StoreWindow).__KANDEV_E2E_STORE__;
+      if (!store) throw new Error("E2E store bridge missing");
+      store.getState().setAppSidebarCollapsed(true);
+    });
+    // Assert the collapse instead of budgeting for it: this fails if the flag
+    // stops reaching the DOM, where the old sleep could not. The 300ms width
+    // animation that follows is deliberately not waited out -- the assertions
+    // below are "no page error" and "layout still healthy", neither of which
+    // reads geometry.
+    await expect(testPage.getByTestId("app-sidebar")).toHaveAttribute("data-collapsed", "true", {
+      timeout: 5_000,
+    });
 
     await resizeColumnViaSplitview(testPage, "right", 600);
     await session.expectLayoutHealthy();

--- a/apps/web/e2e/tests/layout/pane-resize-right.spec.ts
+++ b/apps/web/e2e/tests/layout/pane-resize-right.spec.ts
@@ -6,7 +6,9 @@ import {
   openWideTask,
   expectApproxWidth,
   getDockviewGroupWidth,
+  getDockviewContainerWidth,
   resizeColumnViaSplitview,
+  waitForDockviewViewportResize,
 } from "../../helpers/dockview-resize";
 import { KanbanPage } from "../../pages/kanban-page";
 import { SessionPage } from "../../pages/session-page";
@@ -42,13 +44,15 @@ test.describe("Right pane resize — container-proportional cap", () => {
     const largeWidth = await getDockviewGroupWidth(testPage, "files");
     expectApproxWidth(largeWidth, 450, 12);
 
+    const wideContainer = await getDockviewContainerWidth(testPage);
     await testPage.setViewportSize({ width: 1280, height: 900 });
-    await testPage.waitForTimeout(500);
+    await waitForDockviewViewportResize(testPage, wideContainer);
     const laptopWidth = await getDockviewGroupWidth(testPage, "files");
     expectApproxWidth(laptopWidth, 288, 12);
 
+    const laptopContainer = await getDockviewContainerWidth(testPage);
     await testPage.setViewportSize({ width: 2200, height: 900 });
-    await testPage.waitForTimeout(500);
+    await waitForDockviewViewportResize(testPage, laptopContainer);
     expectApproxWidth(await getDockviewGroupWidth(testPage, "files"), largeWidth, 12);
   });
 
@@ -64,12 +68,19 @@ test.describe("Right pane resize — container-proportional cap", () => {
     const manualWidth = await resizeColumnViaSplitview(testPage, "right", 360);
     expectApproxWidth(manualWidth, 360, 12);
 
+    // The assertion is that this width does *not* move, so there is nothing to
+    // poll for: the expected value is already there. Waiting for the container
+    // to take the new viewport is what gives a regression somewhere to happen,
+    // since the recompute that could clobber the manual width runs in that same
+    // layout pass.
+    const wideContainer = await getDockviewContainerWidth(testPage);
     await testPage.setViewportSize({ width: 1280, height: 900 });
-    await testPage.waitForTimeout(500);
+    await waitForDockviewViewportResize(testPage, wideContainer);
     expectApproxWidth(await getDockviewGroupWidth(testPage, "files"), manualWidth, 12);
 
+    const laptopContainer = await getDockviewContainerWidth(testPage);
     await testPage.setViewportSize({ width: 2200, height: 900 });
-    await testPage.waitForTimeout(500);
+    await waitForDockviewViewportResize(testPage, laptopContainer);
     expectApproxWidth(await getDockviewGroupWidth(testPage, "files"), manualWidth, 12);
   });
 
@@ -186,11 +197,12 @@ test.describe("Right pane resize — container-proportional cap", () => {
     const wideWidth = await resizeColumnViaSplitview(testPage, "right", 900);
     expect(wideWidth).toBeGreaterThan(700);
 
+    // Do not call the resize helper here: it reapplies constraints and would
+    // mask a failure to update them automatically on viewport changes. Wait for
+    // the container instead, which is where the pinned-target enforcement runs.
+    const wideContainer = await getDockviewContainerWidth(testPage);
     await testPage.setViewportSize({ width: 1100, height: 800 });
-    // Allow the container ResizeObserver and pinned-target enforcement to
-    // settle. Do not call the resize helper here: it reapplies constraints and
-    // would mask a failure to update them automatically on viewport changes.
-    await testPage.waitForTimeout(500);
+    await waitForDockviewViewportResize(testPage, wideContainer);
 
     const dockviewBox = await testPage.locator(".dv-dockview").boundingBox();
     expect(dockviewBox).not.toBeNull();
@@ -259,13 +271,18 @@ test.describe("Right pane width — per-task isolation", () => {
       timeout: 15_000,
     });
     await expect(testPage.locator(".dv-dockview")).toBeVisible({ timeout: 15_000 });
-    // Allow fromJSON + fixups-capture + enforcePinnedTargets to settle.
-    await testPage.waitForTimeout(500);
 
-    const widthB = await getDockviewGroupWidth(testPage, "files");
-    expect(
-      widthB,
-      `Task B right width ${widthB} should be the default (>350), not Task A's narrow ${narrowedA}`,
-    ).toBeGreaterThan(350);
+    // Poll rather than sleep-then-read: the width is Task A's narrow value
+    // until fromJSON + fixups-capture + enforcePinnedTargets have run, so this
+    // still fails if the leak comes back. Sampled every frame through a real
+    // switch, the width makes exactly one move (240 -> 384 at ~180ms) and then
+    // holds for the next 5.8s, so there is no transient correct value for the
+    // poll to latch onto early.
+    await expect
+      .poll(() => getDockviewGroupWidth(testPage, "files"), {
+        timeout: 10_000,
+        message: `Task B right width should be the default (>350), not Task A's narrow ${narrowedA}`,
+      })
+      .toBeGreaterThan(350);
   });
 });

--- a/apps/web/e2e/tests/layout/preview-tab-session-switch.spec.ts
+++ b/apps/web/e2e/tests/layout/preview-tab-session-switch.spec.ts
@@ -6,6 +6,7 @@ import type { ApiClient } from "../../helpers/api-client";
 import { SessionPage } from "../../pages/session-page";
 import { GitHelper, makeGitEnv } from "../../helpers/git-helper";
 import { KanbanPage } from "../../pages/kanban-page";
+import { dwell } from "../../helpers/causal-waits";
 
 const FILE_A = "alpha.ts";
 const DONE_STATES = ["COMPLETED", "WAITING_FOR_INPUT"];
@@ -180,9 +181,13 @@ test.describe("Preview tab survives session switch", () => {
     await expect(testPage).toHaveURL((url) => url.pathname.includes(taskA.id), {
       timeout: 15_000,
     });
-    // Wait for layout to stabilize after fromJSON restore
     await expect(testPage.locator(".dv-dockview")).toBeVisible({ timeout: 15_000 });
-    await testPage.waitForTimeout(1_000);
+    await dwell(
+      testPage,
+      1_000,
+      "negative-assertion",
+      "the count assertion below auto-retries, so it already covers a slow restore; what it cannot cover is a duplicate tab appearing after it first sees one, and a tab that must never be added publishes nothing to wait on",
+    );
 
     // File tab should be restored (preview or pinned — the file was open)
     const fileTab = testPage.locator(".dv-default-tab").filter({ hasText: FILE_A });


### PR DESCRIPTION
Ten unconditional sleeps in `tests/layout` waited out guessed budgets around dockview geometry, and one of them was hiding a test that had stopped testing anything. Each is now anchored on something observable, or is an explicit `dwell` that says why no event exists.

## Important Changes

- **`waitForDockviewViewportResize(page, previousContainerWidth)`** in `helpers/dockview-resize.ts`, the anchor for six sites that change the viewport and then read a column width.
- **`resize after sidebar hidden does not throw` now actually hides the sidebar.** It pressed Ctrl+B, which does nothing: `CONFIGURABLE_SHORTCUTS.TOGGLE_SIDEBAR` defaults to `UNBOUND_SHORTCUT` (`lib/keyboard/shortcut-overrides.ts:52`), and only `SHORTCUTS.TOGGLE_SIDEBAR` in `constants.ts` still reads Ctrl+B — which is why a code read does not catch it. Nothing downstream asserted on the sidebar, so the test silently duplicated the one above it. It now collapses through the store bridge and asserts `data-collapsed`, which fails if the precondition stops holding.
  A sleep is where a test goes to stop asserting. The ratchet stops new ones; the ones already in the tree are load-bearing camouflage.
- **Two sites stay wall-clock and say so**, as `dwell(..., "negative-assertion", ...)`: the changes-tab auto-activate that must never fire, and a duplicate preview tab that an auto-retrying `toHaveCount(1)` structurally cannot catch, because it stops looking once it sees one.

## Measured, not read

Three of the four conversions the code suggested were wrong. Each was settled by sampling a live run per frame.

| Question | What the code suggested | What the measurement showed |
|---|---|---|
| When is a column width final after `setViewportSize`? | unknown, hence 500ms | container and column reach final width **in the same frame**, 3-11ms after the call resolves, across all 5 scenarios (auto shrink/grow, manual shrink/grow, over-cap re-clamp); nothing moves for the next 2.5s |
| Can the per-task isolation site poll for the correct width? | unsafe — a leak could land after an early pass | width makes **exactly one move**, 240px → 384px at ~180ms, then holds 5.8s; no transient correct value |
| Is `hasMaximizedGroup()` the maximize anchor? | yes | it flips **synchronously inside `maximize()`** — polling it is a wait that cannot fail |
| Does maximize expand the group to the container? | assumed yes | **0.625 of it**; 600px → ~1000px, so the assertion is growth past the pre-maximize width |

The same-frame co-settling is what makes container width a legitimate anchor for the two sites whose assertion is that a manual width does **not** move. Polling the column there is satisfied instantly by the width already present, so it can never fail; waiting for the container to leave its previous width gives the recompute — which runs in that same layout pass, and is the thing that could clobber the manual width — room to go wrong. That assumption, and the condition under which it expires (column sizing moving behind a debounce), is written into the helper's docstring.

## One site deliberately left alone

`toggle-sidebar-shortcut.spec.ts` hops `requestAnimationFrame` then `setTimeout` **inside `page.evaluate`** to sample animation frames. That is instrumentation, not synchronisation, and it is browser-side rather than node-side.

## Validation

`pnpm e2e:raw --project=chromium` over the six files that touch the changed surface: **33 expected, 33 passed.** The count was derived with `--list` before the run and matched against Playwright's first line.

Files covered: the four changed specs (`pane-resize-right`, `pane-resize-edge-cases`, `changes-panel-focus`, `preview-tab-session-switch`) plus `sidebar-resize-handle` and `review/walkthrough`, which are the other two consumers of `helpers/dockview-resize`. `changed-files ⊆ verified-files` therefore holds for all five changed files.

Two intermediate runs failed first, on my own wrong anchors rather than on the product — that is how the maximize proportion and the dead Ctrl+B were found.

## Possible Improvements

Low risk: test-only. The one thing worth watching is the container-width anchor, which is valid because container and column settle together today; the docstring says to re-measure if column sizing ever moves behind a debounce. Separately, `dragHorizontalSash` in the same helper still ends with a 400ms sleep — it has **no callers** in the suite, so it is left for the slice that decides whether to delete it outright.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.