### PR TITLE
test(e2e): replace the settings specs' unconditional sleeps with real waits

### DIFF
--- a/apps/web/e2e/helpers/pr-asset-capture.ts
+++ b/apps/web/e2e/helpers/pr-asset-capture.ts
@@ -122,6 +122,17 @@ export class PrAssetCapture {
   }
 
   /**
+   * Whether captures are actually being written (`CAPTURE_PR_ASSETS`).
+   *
+   * Every capture method is a no-op otherwise, so a spec that does extra work
+   * *for* a capture -- settling the UI, hiding transient chrome -- should skip
+   * that work in ordinary runs rather than pay for it on every shard.
+   */
+  get capturing(): boolean {
+    return this.enabled;
+  }
+
+  /**
    * Captures one asset. `opts.page` overrides the constructor page so a single
    * capture instance can shoot several clients in one test (a cross-device spec
    * drives two). Using a second instance instead would not work: flush() clears

--- a/apps/web/e2e/tests/settings/agent-install-streaming.spec.ts
+++ b/apps/web/e2e/tests/settings/agent-install-streaming.spec.ts
@@ -104,20 +104,21 @@ test.describe("agent install streaming", () => {
     const enqueueRes = await apiClient.rawRequest("POST", "/api/v1/agent-install/mock-agent");
     const job = (await enqueueRes.json()) as { job_id: string };
 
-    // Wait for it to finish (mock script is fast).
-    let finalStatus = "";
-    const deadline = Date.now() + 8_000;
-    while (Date.now() < deadline) {
-      const snap = (await (
-        await fetch(`${backend.baseUrl}/api/v1/agent-install/jobs/${job.job_id}`)
-      ).json()) as { status: string };
-      if (snap.status === "succeeded" || snap.status === "failed") {
-        finalStatus = snap.status;
-        break;
-      }
-      await new Promise((r) => setTimeout(r, 50));
-    }
-    expect(["succeeded", "failed"]).toContain(finalStatus);
+    // Wait for it to finish (mock script is fast). `expect.poll` owns the
+    // interval and the deadline, so this keeps the terminal-status assertion
+    // while dropping the hand-rolled sleep -- and it reports the last status it
+    // saw on timeout, where the loop reported the empty string it started with.
+    await expect
+      .poll(
+        async () => {
+          const snap = (await (
+            await fetch(`${backend.baseUrl}/api/v1/agent-install/jobs/${job.job_id}`)
+          ).json()) as { status: string };
+          return snap.status;
+        },
+        { timeout: 8_000, message: "install job never reached a terminal status" },
+      )
+      .toMatch(/^(succeeded|failed)$/);
 
     const listRes = await fetch(`${backend.baseUrl}/api/v1/agent-install/jobs`);
     expect(listRes.status).toBe(200);
@@ -172,11 +173,18 @@ async function openGatewayWS(baseUrl: string): Promise<WebSocket> {
   return ws;
 }
 
+/**
+ * Poll a flag these specs maintain themselves until it flips.
+ *
+ * What is being waited on is a local variable that a WebSocket listener writes,
+ * not a page, a response or a store, so none of the transport primitives in
+ * `helpers/causal-waits.ts` applies. `expect.poll` is the right tool anyway: it
+ * owns the interval and the deadline, so the hand-rolled 50ms sleep goes with
+ * the loop, and a timeout reports the label through Playwright rather than as a
+ * bare thrown Error.
+ */
 async function waitFor(check: () => boolean, timeoutMs: number, label: string) {
-  const start = Date.now();
-  while (Date.now() - start < timeoutMs) {
-    if (check()) return;
-    await new Promise((r) => setTimeout(r, 50));
-  }
-  throw new Error(`Timed out waiting for ${label}`);
+  await expect
+    .poll(check, { timeout: timeoutMs, message: `Timed out waiting for ${label}` })
+    .toBe(true);
 }

--- a/apps/web/e2e/tests/settings/agent-login-pty.spec.ts
+++ b/apps/web/e2e/tests/settings/agent-login-pty.spec.ts
@@ -135,11 +135,18 @@ test.describe("agent login PTY", () => {
   });
 });
 
+/**
+ * Poll a flag these specs maintain themselves until it flips.
+ *
+ * What is being waited on is a local variable that a WebSocket listener writes,
+ * not a page, a response or a store, so none of the transport primitives in
+ * `helpers/causal-waits.ts` applies. `expect.poll` is the right tool anyway: it
+ * owns the interval and the deadline, so the hand-rolled 50ms sleep goes with
+ * the loop, and a timeout reports the label through Playwright rather than as a
+ * bare thrown Error.
+ */
 async function waitFor(check: () => boolean, timeoutMs: number, label: string) {
-  const start = Date.now();
-  while (Date.now() - start < timeoutMs) {
-    if (check()) return;
-    await new Promise((r) => setTimeout(r, 50));
-  }
-  throw new Error(`Timed out waiting for ${label}`);
+  await expect
+    .poll(check, { timeout: timeoutMs, message: `Timed out waiting for ${label}` })
+    .toBe(true);
 }

--- a/apps/web/e2e/tests/settings/layout-profiles.spec.ts
+++ b/apps/web/e2e/tests/settings/layout-profiles.spec.ts
@@ -3,6 +3,7 @@ import { test, type SeedData } from "../../fixtures/test-base";
 import type { ApiClient } from "../../helpers/api-client";
 import { LayoutSettingsPage } from "../../pages/layout-settings-page";
 import { SessionPage } from "../../pages/session-page";
+import { dwell } from "../../helpers/causal-waits";
 
 const DONE_STATES = ["COMPLETED", "WAITING_FOR_INPUT"];
 const PR_NUMBER = 702;
@@ -141,6 +142,46 @@ async function dockviewSnapshot(page: Page): Promise<DockviewSnapshot> {
       rightGroupOrder: files?.group?.panels.map((panel) => panel.id) ?? [],
     };
   });
+}
+
+/**
+ * Wait until the dockview layout for this session has been persisted with the
+ * given panel in it.
+ *
+ * The layout write is debounced (~350ms) and publishes nothing, so the only
+ * honest anchor is the artifact it produces: `sessionStorage` under
+ * `kandev.dockview.env-layout-v3.<envId>`. Polling the artifact rather than
+ * sleeping past the debounce means a persist that never happens fails here
+ * instead of silently changing what a later step is testing. It cannot be
+ * satisfied by a stale write either: the panel is only in the layout after the
+ * preset that adds it has been applied.
+ */
+async function waitForPersistedLayoutWithPanel(
+  page: Page,
+  sessionId: string,
+  panelId: string,
+): Promise<void> {
+  await expect
+    .poll(
+      () =>
+        page.evaluate(
+          ({ sid, pid }) => {
+            type StoreWindow = Window & {
+              __KANDEV_E2E_STORE__?: {
+                getState: () => { environmentIdBySessionId: Record<string, string> };
+              };
+            };
+            const store = (window as StoreWindow).__KANDEV_E2E_STORE__;
+            const envId = store?.getState().environmentIdBySessionId[sid];
+            if (!envId) return false;
+            const raw = window.sessionStorage.getItem(`kandev.dockview.env-layout-v3.${envId}`);
+            return raw !== null && raw.includes(pid);
+          },
+          { sid: sessionId, pid: panelId },
+        ),
+      { timeout: 10_000, message: `layout for session ${sessionId} never persisted ${panelId}` },
+    )
+    .toBe(true);
 }
 
 async function expectNoTerminalDefault(page: Page): Promise<void> {
@@ -297,7 +338,10 @@ test.describe("Task layout profile defaults", () => {
     await testPage.getByTestId("layout-preset-trigger").click();
     await testPage.locator('[data-testid="layout-preset-item"][data-preset-id="default"]').click();
     await expect(testPage.getByTestId("terminal-panel")).toBeVisible({ timeout: 15_000 });
-    await testPage.waitForTimeout(500);
+    // Task A's layout has to be on disk before the default changes underneath
+    // it, or the later "existing tasks keep their terminal" assertion is
+    // testing the new default rather than A's saved layout.
+    await waitForPersistedLayoutWithPanel(testPage, taskA.session_id!, "terminal-default");
 
     await apiClient.saveUserSettings({
       saved_layouts: [
@@ -314,7 +358,12 @@ test.describe("Task layout profile defaults", () => {
     const taskB = await createTaskWithSession(apiClient, seedData, "Fresh Layout Task");
     await openTask(testPage, taskB.id);
     await expectNoTerminalDefault(testPage);
-    await testPage.waitForTimeout(500);
+    await dwell(
+      testPage,
+      500,
+      "negative-assertion",
+      "asserts that no ordinary shell is ever spawned for a task whose default layout has no terminal; a shell that must not be created publishes nothing, so the check needs real time to have any chance of catching one",
+    );
     expect(await ordinaryShells(apiClient, taskB.id)).toHaveLength(0);
 
     await openTask(testPage, taskA.id);

--- a/apps/web/e2e/tests/settings/mobile-general-settings.spec.ts
+++ b/apps/web/e2e/tests/settings/mobile-general-settings.spec.ts
@@ -60,12 +60,17 @@ test.describe("Mobile general settings", () => {
       expect(await testPage.evaluate(() => document.documentElement.scrollWidth)).toBe(
         await testPage.evaluate(() => document.documentElement.clientWidth),
       );
-      await testPage.waitForTimeout(1_000);
-      await testPage
-        .locator("[data-sonner-toast], [data-testid='toast-message']")
-        .evaluateAll((toasts) => {
-          for (const toast of toasts) (toast as HTMLElement).style.display = "none";
-        });
+      // Keeping stray toasts out of the capture. This ran unconditionally and
+      // cost every mobile shard a second, even though `prCapture.screenshot` is
+      // a no-op without `CAPTURE_PR_ASSETS` -- so the second bought nothing on
+      // the runs that pay for it. Gated, and waiting for the toasts to go
+      // rather than for a budget and then painting over whatever is left: a
+      // toast that outlives this fails the capture instead of being hidden.
+      if (prCapture.capturing) {
+        await expect(
+          testPage.locator("[data-sonner-toast], [data-testid='toast-message']"),
+        ).toHaveCount(0, { timeout: 10_000 });
+      }
       await prCapture.screenshot("sleep-inhibition-mobile-draft", {
         caption: "Mobile Task Actions sleep inhibition card above Save changes",
       });


### PR DESCRIPTION
Seven unconditional sleeps in `tests/settings` turned out to be four unrelated problems, and one of them was not synchronisation at all — it was a second per mobile shard spent preparing a screenshot that is never taken. Four of the seven are deleted rather than labelled, because what they were spacing out already had a primitive.

## Important Changes

- **Four sleeps deleted via `expect.poll`.** Three were the 50ms interval inside a hand-rolled polling loop (two copies of a `waitFor(check, timeoutMs, label)` helper, one `while (Date.now() < deadline)` fetch loop); the fourth was the debounced-persist wait below. `expect.poll` owns the interval and the deadline, so the sleep goes with the loop.
- **The debounced dockview persist is now waited on by its artifact.** In `layout-profiles`, task A's layout has to be on disk before the default changes underneath it, or the later "existing tasks keep their terminal" assertion is testing the new default rather than A's saved layout. The ~350ms persist debounce publishes nothing, but it writes `sessionStorage` under `kandev.dockview.env-layout-v3.<envId>` — so the wait polls that, and a persist that never happens now fails here.
- **One genuine negative assertion** keeps its wall clock as `dwell(..., "negative-assertion", ...)`: no ordinary shell may ever be spawned for a task whose default layout has no terminal.
- **`prCapture` work is gated on captures actually being enabled.** `screenshot()` is a no-op without `CAPTURE_PR_ASSETS`, so the 1s settle and the toast-hiding DOM write in `mobile-general-settings` ran on every mobile shard to prepare an image that was never written. The helper now exposes `capturing`, and inside the gate the sleep is a `toHaveCount(0)` on the toast locator.

## A sleep is where a test goes to stop asserting

This slice is the third instance in the program, and the first where what the sleep hid was dead *work* rather than a dead assertion:

- The old code waited a fixed second and then set `display: none` on whatever toast was still up. A toast that outlived the budget was painted over rather than noticed. The replacement waits for the toasts to actually go and fails the capture if one does not.
- The `while (deadline)` loop asserted on a `finalStatus` variable initialised to `""`, so a timeout reported the empty string it started with rather than the status it kept seeing. `expect.poll` reports the real one.

## Validation

Expected counts derived with `--list` before each run and matched against Playwright's first line. The `mobile-*` spec runs under `mobile-chrome`, where a `--project=chromium` sweep matches nothing and exits 0.

| Run | Project | Files | Expected | Collected |
|---|---|---|---|---|
| Desktop settings specs | chromium | `agent-login-pty`, `agent-install-streaming`, `layout-profiles` | 12 | 12 pass |
| Mobile settings spec | mobile-chrome | `mobile-general-settings` | 5 | 5 pass |
| Mobile settings spec, captures on | mobile-chrome (`CAPTURE_PR_ASSETS=1`) | `mobile-general-settings` | 5 | 5 pass |

The third run exists because the second one cannot see the branch this PR adds: gating the block on `capturing` means an ordinary run skips exactly the code under review. With the flag on it executed and wrote `.pr-assets/mobile-general-settings--sleep-inhibition-mobile-draft.png`, which is the only evidence that gating it did not silently disable it.

`changed-files ⊆ verified-files` holds for the four changed specs. The fifth changed file, `helpers/pr-asset-capture.ts`, has **84 consumer specs and they are not all run here** — stating that rather than implying coverage. The change is an accessor that adds no path to any existing caller, and its only use is in the changed mobile spec, which is covered in both directions.

## Possible Improvements

Low risk: test-only. The `sessionStorage` poll couples `layout-profiles` to the persistence key, which is already true of `pane-resize-right`; if that key is ever versioned again, both fail loudly rather than silently, which is the right failure mode.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2649?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->