### PR TITLE
ci(e2e): cache Go modules and build cache in the E2E build job

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -78,6 +78,21 @@ jobs:
           key: pnpm-${{ runner.os }}-${{ hashFiles('apps/pnpm-lock.yaml') }}
           restore-keys: pnpm-${{ runner.os }}-
 
+      # Same reasoning as the pnpm store above: the image sets GOPATH=/root/go
+      # and leaves GOCACHE at its default, and $HOME is /root, so these are the
+      # same two paths backend-tests.yml caches. Without this the backend build
+      # below starts from a cold module *and* build cache on every run.
+      - name: Cache Go modules
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: go-e2e-build-${{ runner.os }}-${{ hashFiles('apps/backend/go.mod', 'apps/backend/go.sum') }}
+          restore-keys: |
+            go-e2e-build-${{ runner.os }}-
+            go-${{ runner.os }}-
+
       - name: Install dependencies
         working-directory: apps
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
The E2E workflow's `build` job compiled the backend with no Go cache at all, so every E2E run paid for a cold module *and* build cache. This adds the same `actions/cache` step `backend-tests.yml` already uses, which measured at ~3m40s off the job (6m18s cold → 2m36s warm).

## Important Changes

- Cache `~/go/pkg/mod` + `~/.cache/go-build` in the `build` job, keyed on `apps/backend/go.{mod,sum}` with `go-e2e-build-…` and the shared `go-${{ runner.os }}-` fallback, matching the `go-static-…` / `go-test-…` convention in `backend-tests.yml`.

The container (`ghcr.io/kdlbs/kandev-ci:build-latest`) sets `GOPATH=/root/go`, leaves `GOCACHE` at its default, and `HOME` is `/root` — so both `~` paths resolve inside the container, the same reason the identical paths work in `backend-tests.yml`.

**Note for reviewers: the saving will not show up on this PR's first run.** GitHub scopes caches to the branch that writes them, so the first run here writes the cache cold and sees no speedup. It appears on a re-run of this branch, and for everyone once this lands on `main` and a `main` run populates the key. A cold first run is not evidence the change does nothing.

## Validation

- `python3 .github/scripts/lint-action-pinning.py` — all 18 workflows SHA-pinned
- `python3 .github/scripts/lint-action-pinning_test.py` — 9 tests OK
- All `.github/scripts/*_test.py` workflow-contract suites — OK
- YAML parse + step-order check on the `build` job (cache step lands before `make build-backend build-web-e2e`)
- `git diff --check` — clean
- Cache behaviour confirmed against this PR's own CI run logs (cold miss + save, then hit on re-run); job durations reported in the PR thread.

## Possible Improvements

Low risk: worst case the cache misses and the job behaves exactly as it does today. No workflow logic, worker counts, or sharding changed.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2657?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->