### PR TITLE
fix: reduce clarification context font size

### DIFF
--- a/apps/web/components/github/my-github/use-saved-presets.test.ts
+++ b/apps/web/components/github/my-github/use-saved-presets.test.ts
@@ -58,10 +58,11 @@ function workspaceSettings(
 async function expectRandomUuidPresetId() {
   const uuid = "123e4567-e89b-42d3-a456-426614174000";
   vi.spyOn(globalThis.crypto, "randomUUID").mockReturnValue(uuid);
-  vi.mocked(fetchGitHubWorkspaceSettings).mockResolvedValue(workspaceSettings());
+  const existing = { ...valid, id: "p_existing" };
+  vi.mocked(fetchGitHubWorkspaceSettings).mockResolvedValue(workspaceSettings([existing]));
   vi.mocked(updateGitHubWorkspaceSettings).mockResolvedValue(workspaceSettings());
   const { result } = renderHook(() => useSavedPresets(WORKSPACE_ID));
-  await waitFor(() => expect(result.current.presets).toEqual([]));
+  await waitFor(() => expect(result.current.presets).toEqual([existing]));
 
   let created: SavedPreset | null = null;
   await act(async () => {

--- a/apps/web/components/task/chat/clarification-input-overlay.tsx
+++ b/apps/web/components/task/chat/clarification-input-overlay.tsx
@@ -597,7 +597,7 @@ export function ClarificationInputOverlay({
       {sharedContext && (
         <div
           data-testid="clarification-context"
-          className="mx-4 mt-3 mb-2 break-words whitespace-pre-wrap"
+          className="mx-4 mt-3 mb-2 break-words whitespace-pre-wrap text-[13px]"
         >
           {sharedContext}
         </div>

--- a/apps/web/e2e/tests/chat/mobile-clarification.spec.ts
+++ b/apps/web/e2e/tests/chat/mobile-clarification.spec.ts
@@ -98,6 +98,7 @@ test.describe("Mobile clarification multiline answer", () => {
     await expect(context).toHaveText(
       "Picking the foundational stack: answer all three so we can move forward.",
     );
+    await expect(context).toHaveCSS("font-size", "13px");
     await expect(context).toHaveCSS("margin-top", "12px");
     await expect(context).toHaveCSS("padding", "0px");
     await expect(context).toHaveCSS("border-width", "0px");


### PR DESCRIPTION
The clarification overlay's shared context inherited the 16px base size, which made agent-provided background compete with the question content. It now renders at 13px, with a mobile regression assertion for the rendered size.

## Validation

- `pnpm e2e:run --project mobile-chrome tests/chat/mobile-clarification.spec.ts -- --grep "shows shared context once above the question on mobile" --retries=0` (1 passed)
- `pnpm exec eslint components/task/chat/clarification-input-overlay.tsx e2e/tests/chat/mobile-clarification.spec.ts` (passed)
- `git diff --check` (passed)
- Fresh desktop and Pixel 5 screenshots captured, compressed, and visually inspected.
- No public documentation change is needed because this is an internal presentation adjustment.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2659?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

## Screenshots

<!-- kandev-screenshots-start -->
![Desktop clarification overlay with 13px shared context](https://raw.githubusercontent.com/kdlbs/kandev/7f9c6bd28bff3c0744dc1165c0367fcc125cf98f/clarification-context-desktop.png)

![Mobile clarification overlay with 13px shared context](https://raw.githubusercontent.com/kdlbs/kandev/7f9c6bd28bff3c0744dc1165c0367fcc125cf98f/clarification-context-mobile.png)
<!-- kandev-screenshots-end -->