### PR TITLE
feat: prioritize active workspace in settings

### DIFF
--- a/apps/web/app/settings/workspace/workspaces-page-client.tsx
+++ b/apps/web/app/settings/workspace/workspaces-page-client.tsx
@@ -23,6 +23,7 @@ import {
   ActiveWorkspaceBadge,
   workspaceSettingsHref,
 } from "@/components/settings/workspaces/workspace-settings-shell";
+import { orderWorkspacesForDisplay } from "@/lib/settings/workspace-display-order";
 import type { WorkspaceState } from "@/lib/state/slices";
 
 type Workspace = WorkspaceState["items"][number];
@@ -120,12 +121,14 @@ function WorkspaceListItem({ workspace }: { workspace: Workspace }) {
 
 export function WorkspacesPageClient() {
   const items = useAppStore((state) => state.workspaces.items);
+  const activeWorkspaceId = useAppStore((state) => state.workspaces.activeId);
   const setWorkspaces = useAppStore((state) => state.setWorkspaces);
   const [isAdding, setIsAdding] = useState(false);
   const [newWorkspaceName, setNewWorkspaceName] = useState("");
   const createRequest = useRequest(createWorkspaceAction);
   const { toast } = useToast();
   const { t } = useTranslation();
+  const orderedItems = orderWorkspacesForDisplay(items, activeWorkspaceId);
 
   const handleAddWorkspace = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -197,7 +200,7 @@ export function WorkspacesPageClient() {
             />
           )}
 
-          {items.map((workspace: Workspace) => (
+          {orderedItems.map((workspace: Workspace) => (
             <WorkspaceListItem key={workspace.id} workspace={workspace} />
           ))}
 

--- a/apps/web/app/settings/workspace/workspaces-page-client.tsx
+++ b/apps/web/app/settings/workspace/workspaces-page-client.tsx
@@ -204,7 +204,7 @@ export function WorkspacesPageClient() {
             <WorkspaceListItem key={workspace.id} workspace={workspace} />
           ))}
 
-          {items.length === 0 && (
+          {orderedItems.length === 0 && (
             <Card>
               <CardContent className="py-8 text-center">
                 <p className="text-sm text-muted-foreground">

--- a/apps/web/components/app-sidebar/sections/settings/settings-menu-branches.test.ts
+++ b/apps/web/components/app-sidebar/sections/settings/settings-menu-branches.test.ts
@@ -15,6 +15,11 @@ import {
 const WORKSPACE_ID = "ws-1";
 const WORKSPACES_HREF = "/settings/workspaces";
 const WORKSPACES = [{ id: WORKSPACE_ID, name: "Main Workspace" }];
+const ORDERED_WORKSPACES = [
+  { id: "ws-first", name: "First" },
+  { id: "ws-active", name: "Active" },
+  { id: "ws-last", name: "Last" },
+];
 // Hoisted so the filter tests can build fixtures without re-spelling the
 // display name (sonar duplicate-literal rule).
 const AGENT_DISPLAY_NAME = "Claude Code";
@@ -46,6 +51,17 @@ function integrationsTabOf(tabs: readonly SettingsMenuNode[]): SettingsMenuNode 
 }
 
 describe("buildWorkspacesBranch", () => {
+  it("places the active workspace first without disturbing the remaining order", () => {
+    const branch = buildWorkspacesBranch(ORDERED_WORKSPACES, "ws-active");
+
+    expect(branch.map((workspace) => workspace.key)).toEqual([
+      "workspace:ws-active",
+      "workspace:ws-first",
+      "workspace:ws-last",
+    ]);
+    expect(branch[0].badge).toBe("active");
+  });
+
   it("hangs each workspace's tabs under it, minus its own overview page", () => {
     const [workspace] = buildWorkspacesBranch(WORKSPACES);
 

--- a/apps/web/components/app-sidebar/sections/settings/settings-menu-branches.ts
+++ b/apps/web/components/app-sidebar/sections/settings/settings-menu-branches.ts
@@ -10,6 +10,7 @@ import {
   WORKSPACE_SETTINGS_TABS,
   workspaceSettingsHref,
 } from "@/lib/settings/workspace-settings-tabs";
+import { orderWorkspacesForDisplay } from "@/lib/settings/workspace-display-order";
 
 /**
  * What the settings menu grows *underneath* a row when a tree mode is on.
@@ -204,7 +205,7 @@ export function buildWorkspacesBranch(
   visibleIntegrationSlugsFor?: (workspaceId: string) => ReadonlySet<IntegrationSlug> | undefined,
   integrationContributions: ReadonlyArray<BranchIntegrationContribution> = [],
 ): SettingsMenuNode[] {
-  return workspaces.map((workspace) => {
+  return orderWorkspacesForDisplay(workspaces, activeWorkspaceId).map((workspace) => {
     const integrationsHref = workspaceSettingsHref(workspace.id, "integrations");
     return {
       key: `workspace:${workspace.id}`,

--- a/apps/web/e2e/tests/settings/mobile-workspace-display-order.spec.ts
+++ b/apps/web/e2e/tests/settings/mobile-workspace-display-order.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect } from "../../fixtures/test-base";
+import { setSettingsMenuMode } from "../../helpers/settings-menu";
+
+test.describe("Mobile workspace display order", () => {
+  test("places the active workspace first in the phone Settings tree", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    const other = await apiClient.createWorkspace("Mobile Non-active Workspace");
+
+    try {
+      await testPage.setViewportSize({ width: 390, height: 844 });
+      await setSettingsMenuMode(testPage, "accordion");
+      await testPage.goto("/settings");
+
+      const { workspaces } = await apiClient.listWorkspaces();
+      const expectedWorkspaceIds = [
+        seedData.workspaceId,
+        ...workspaces
+          .filter((workspace) => workspace.id !== seedData.workspaceId)
+          .map((workspace) => workspace.id),
+      ];
+      const index = testPage.getByTestId("settings-index");
+      await expect(index).toBeVisible();
+      await index.getByRole("button", { name: /Expand Workspaces/ }).tap();
+
+      const workspaceRows = index.locator('[data-record="true"]');
+      await expect(workspaceRows).toHaveCount(expectedWorkspaceIds.length);
+      const sidebarHrefs = await workspaceRows
+        .locator("a")
+        .evaluateAll((links) =>
+          links.map(
+            (link) => new URL(link.getAttribute("href") ?? "", "http://kandev.test").pathname,
+          ),
+        );
+      expect(sidebarHrefs).toEqual(expectedWorkspaceIds.map((id) => `/settings/workspaces/${id}`));
+      await expect(workspaceRows.first()).toContainText("Active");
+
+      const documentWidth = await testPage.evaluate(() => ({
+        clientWidth: document.documentElement.clientWidth,
+        scrollWidth: document.documentElement.scrollWidth,
+      }));
+      expect(documentWidth.scrollWidth).toBeLessThanOrEqual(documentWidth.clientWidth);
+    } finally {
+      await apiClient.deleteWorkspace(other.id, other.name);
+    }
+  });
+});

--- a/apps/web/e2e/tests/settings/workspace-display-order.spec.ts
+++ b/apps/web/e2e/tests/settings/workspace-display-order.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect } from "../../fixtures/test-base";
+import { setSettingsMenuMode } from "../../helpers/settings-menu";
+
+test.describe("Workspace display order", () => {
+  test("places the active workspace first on the page and sidebar", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    const other = await apiClient.createWorkspace("Non-active Workspace");
+
+    try {
+      await testPage.goto("/settings/workspaces");
+
+      const { workspaces } = await apiClient.listWorkspaces();
+      const expectedWorkspaceIds = [
+        seedData.workspaceId,
+        ...workspaces
+          .filter((workspace) => workspace.id !== seedData.workspaceId)
+          .map((workspace) => workspace.id),
+      ];
+      const cards = testPage.getByTestId("workspace-list-item");
+      await expect(cards).toHaveCount(expectedWorkspaceIds.length);
+      const cardHrefs = await cards
+        .locator('[data-testid="workspace-overview-link"]')
+        .evaluateAll((links) =>
+          links.map(
+            (link) => new URL(link.getAttribute("href") ?? "", "http://kandev.test").pathname,
+          ),
+        );
+      expect(cardHrefs).toEqual(expectedWorkspaceIds.map((id) => `/settings/workspaces/${id}`));
+      await expect(cards.first()).toContainText("Active");
+
+      await setSettingsMenuMode(testPage, "accordion");
+      const takeover = testPage.getByTestId("app-sidebar-settings-mode");
+      await expect(takeover.getByRole("button", { name: /Expand Workspaces/ })).toBeVisible();
+      await takeover.getByRole("button", { name: /Expand Workspaces/ }).click();
+
+      const workspaceRows = takeover.locator('[data-record="true"]');
+      await expect(workspaceRows).toHaveCount(expectedWorkspaceIds.length);
+      const sidebarHrefs = await workspaceRows
+        .locator("a")
+        .evaluateAll((links) =>
+          links.map(
+            (link) => new URL(link.getAttribute("href") ?? "", "http://kandev.test").pathname,
+          ),
+        );
+      expect(sidebarHrefs).toEqual(expectedWorkspaceIds.map((id) => `/settings/workspaces/${id}`));
+      await expect(workspaceRows.first()).toContainText("Active");
+    } finally {
+      await apiClient.deleteWorkspace(other.id, other.name);
+    }
+  });
+});

--- a/apps/web/lib/settings/workspace-display-order.test.ts
+++ b/apps/web/lib/settings/workspace-display-order.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { orderWorkspacesForDisplay } from "./workspace-display-order";
+
+const WORKSPACES = [
+  { id: "first", name: "First" },
+  { id: "active", name: "Active" },
+  { id: "last", name: "Last" },
+];
+
+describe("orderWorkspacesForDisplay", () => {
+  it("moves the active workspace first and preserves the remaining order", () => {
+    const ordered = orderWorkspacesForDisplay(WORKSPACES, "active");
+
+    expect(ordered.map((workspace) => workspace.id)).toEqual(["active", "first", "last"]);
+    expect(ordered).not.toBe(WORKSPACES);
+    expect(WORKSPACES.map((workspace) => workspace.id)).toEqual(["first", "active", "last"]);
+  });
+
+  it.each([undefined, null, "missing"])(
+    "preserves the input order when the active workspace is %s",
+    (activeWorkspaceId) => {
+      expect(orderWorkspacesForDisplay(WORKSPACES, activeWorkspaceId)).toEqual(WORKSPACES);
+    },
+  );
+
+  it("preserves the input order when the active workspace is already first", () => {
+    const workspaces = [WORKSPACES[1], WORKSPACES[0], WORKSPACES[2]];
+
+    expect(orderWorkspacesForDisplay(workspaces, "active")).toEqual(workspaces);
+  });
+});

--- a/apps/web/lib/settings/workspace-display-order.ts
+++ b/apps/web/lib/settings/workspace-display-order.ts
@@ -1,0 +1,23 @@
+type WorkspaceDisplayItem = { id: string };
+
+/**
+ * Puts the active workspace first without changing the order of any other
+ * workspace. Unknown or missing active IDs leave the input order unchanged.
+ */
+export function orderWorkspacesForDisplay<S extends WorkspaceDisplayItem>(
+  workspaces: ReadonlyArray<S>,
+  activeWorkspaceId?: string | null,
+): S[] {
+  const activeIndex =
+    activeWorkspaceId == null
+      ? -1
+      : workspaces.findIndex((workspace) => workspace.id === activeWorkspaceId);
+
+  if (activeIndex <= 0) return [...workspaces];
+
+  return [
+    workspaces[activeIndex],
+    ...workspaces.slice(0, activeIndex),
+    ...workspaces.slice(activeIndex + 1),
+  ];
+}

--- a/docs/plans/workspace-active-first-order/plan.md
+++ b/docs/plans/workspace-active-first-order/plan.md
@@ -1,0 +1,124 @@
+---
+spec: docs/specs/ui/workspace-active-first-order.md
+created: 2026-08-14
+status: complete
+---
+
+# Implementation Plan: Active workspace first in Settings
+
+## Overview
+
+Add one pure, stable display-order helper that moves the workspace matching
+`workspaces.activeId` to the front while preserving every other item's order.
+Use that helper at the two existing Settings consumers: the branched sidebar
+builder and the workspace cards page. The feature has no backend, API, store
+shape, persistence, or copy changes.
+
+## Frontend
+
+### Shared display ordering
+
+- `apps/web/lib/settings/workspace-display-order.ts`: add a generic helper that
+  returns a new array, moves one matching active id to index zero, and leaves
+  the input order intact when the id is null, unknown, or already first.
+- `apps/web/lib/settings/workspace-display-order.test.ts`: cover active-middle,
+  active-first, null/unknown active id, empty input, and stable non-active order.
+
+### Settings sidebar tree
+
+- `apps/web/components/app-sidebar/sections/settings/settings-menu-branches.ts`:
+  apply the shared helper inside `buildWorkspacesBranch` before building the
+  existing workspace nodes. Keep the current active badge assignment and all
+  workspace tab/integration ordering unchanged.
+- `apps/web/components/app-sidebar/sections/settings/settings-menu-branches.test.ts`:
+  add a builder-level assertion that an active workspace in the middle is the
+  first workspace node and that the remaining nodes preserve order.
+
+### Workspaces page
+
+- `apps/web/app/settings/workspace/workspaces-page-client.tsx`: subscribe to
+  the existing active workspace id, derive the ordered list for rendering, and
+  keep creation state updates and card actions unchanged.
+
+### Mobile design contract
+
+- Desktop outcome: the active workspace is the first actionable record in the
+  Settings sidebar tree and the first workspace card on the management page.
+- Phone entry point: `/settings` remains the existing Settings index; in a tree
+  menu mode, the user expands the existing Workspaces branch. The management
+  page remains the existing vertical card list.
+- Nearest shipped exemplar: `apps/web/components/settings/settings-page-nav.tsx`
+  and `apps/web/e2e/tests/settings/mobile-settings-sidebar.spec.ts`, which use
+  the same Settings tree on a phone. Reuse their current navigation and scroll
+  behavior; this change only changes record order.
+- Hierarchy, primary action, presentation, scroll owner, safe areas, and touch
+  targets remain unchanged. Shared ordering is derived from store state and is
+  used by both viewport compositions; no mobile-only state or control is added.
+
+## Tests
+
+- **What:** the shared ordering contract moves only the active workspace and
+  preserves all other relative order, including missing-active fallbacks.
+  **File:** `apps/web/lib/settings/workspace-display-order.test.ts`.
+  **How:** focused Vitest unit tests against the pure helper.
+- **What:** the Settings sidebar branch receives the same active-first order.
+  **File:** `apps/web/components/app-sidebar/sections/settings/settings-menu-branches.test.ts`.
+  **How:** build a branch from plain workspace records and assert node ids.
+- **What:** the desktop Settings page and sidebar visibly show the active
+  workspace first when another workspace is created ahead of it.
+  **File:** `apps/web/e2e/tests/settings/workspace-display-order.spec.ts`.
+  **How:** create a second workspace through the fixture API, render the
+  existing active workspace on `/settings/workspaces`, opt into the existing
+  accordion menu mode, and assert the first card and first record row by
+  workspace id/name.
+- **What:** the phone Settings index exposes the same active-first workspace
+  branch order without horizontal overflow.
+  **File:** `apps/web/e2e/tests/settings/mobile-workspace-display-order.spec.ts`.
+  **How:** use the `mobile-chrome` project, expand the existing Workspaces
+  branch, assert record order, and assert document width remains contained.
+
+## E2E Tests
+
+- **Scenario:** GIVEN a non-active workspace is inserted before the active
+  workspace in live data, WHEN the desktop workspace page renders, THEN the
+  active workspace card is first.
+  **File:** `apps/web/e2e/tests/settings/workspace-display-order.spec.ts`.
+- **Scenario:** GIVEN the same two workspaces and an accordion settings menu,
+  WHEN the Workspaces branch is expanded, THEN the active workspace row is
+  first and its active badge remains visible.
+  **File:** `apps/web/e2e/tests/settings/workspace-display-order.spec.ts`.
+- **Scenario:** GIVEN a phone Settings index in accordion mode, WHEN the
+  Workspaces branch is expanded, THEN the active workspace row is first and the
+  document has no horizontal overflow.
+  **File:** `apps/web/e2e/tests/settings/mobile-workspace-display-order.spec.ts`.
+
+## Verification Results
+
+- `cd apps && pnpm install --frozen-lockfile` — passed.
+- RED focused Vitest run — 30 tests, 1 expected active-order failure before
+  implementation; the helper-plus-builder run then showed 35 tests, 1 expected
+  builder-order failure before wiring.
+- RED desktop and phone E2E runs — both failed on the expected active-order
+  assertion before the consumer wiring.
+- `cd apps && pnpm --filter @kandev/web test -- --run lib/settings/workspace-display-order.test.ts components/app-sidebar/sections/settings/settings-menu-branches.test.ts` — 2 files, 35 tests passed.
+- `cd apps/web && pnpm run typecheck` — passed.
+- `cd apps/web && pnpm run lint` — passed.
+- `cd apps/web && pnpm e2e:run --project chromium tests/settings/workspace-display-order.spec.ts` — 1 test passed with a fresh build.
+- `cd apps/web && pnpm e2e:run --project mobile-chrome tests/settings/mobile-workspace-display-order.spec.ts` — 1 test passed with a fresh build.
+- Disposable managed PR capture — 1 test passed with fresh desktop and 390px
+  phone screenshots; both assets were visually inspected, compressed, and kept
+  only in ignored `apps/web/.pr-assets/` for PR publication.
+- `git diff --check` — passed.
+
+## Implementation Waves And Parallel Candidates
+
+Wave 1 — sequential:
+
+- [x] [task-01-active-workspace-first](task-01-active-workspace-first.md)
+
+The helper, its consumers, and their focused browser evidence share the same
+display-order contract and should be implemented and verified as one task.
+
+## Open Questions
+
+None.

--- a/docs/plans/workspace-active-first-order/task-01-active-workspace-first.md
+++ b/docs/plans/workspace-active-first-order/task-01-active-workspace-first.md
@@ -86,5 +86,5 @@ Verification:
 - `git diff --check`: passed.
 
 The initial RED runs failed on the intended active-order assertions. No
-blockers or known risks remain; the spec is marked `building` pending PR
-review and merge.
+blockers or known risks remain; the spec is marked `shipped` after review
+triage.

--- a/docs/plans/workspace-active-first-order/task-01-active-workspace-first.md
+++ b/docs/plans/workspace-active-first-order/task-01-active-workspace-first.md
@@ -1,0 +1,90 @@
+---
+id: "01-active-workspace-first"
+title: "Order active workspace first"
+status: done
+wave: 1
+depends_on: []
+plan: "plan.md"
+spec: "../../specs/ui/workspace-active-first-order.md"
+---
+
+# Task 01: Order active workspace first
+
+- **Acceptance:**
+  - The shared display-order helper puts the workspace matching
+    `workspaces.activeId` first and preserves the relative order of all other
+    workspaces, including null and unknown active ids.
+  - The Settings sidebar workspace branch and `/settings/workspaces` cards both
+    use that order without changing active badges, selection, or persistence.
+  - Desktop and phone E2E coverage proves the active workspace is first in both
+    Settings surfaces.
+- **Verification:**
+
+  ```bash
+  (cd apps && pnpm install --frozen-lockfile)
+  (cd apps && pnpm --filter @kandev/web test -- --run lib/settings/workspace-display-order.test.ts components/app-sidebar/sections/settings/settings-menu-branches.test.ts)
+  (cd apps/web && pnpm run typecheck)
+  (cd apps/web && pnpm e2e:run --project chromium tests/settings/workspace-display-order.spec.ts)
+  (cd apps/web && pnpm e2e:run --project mobile-chrome tests/settings/mobile-workspace-display-order.spec.ts)
+  git diff --check
+  ```
+
+- **Files likely touched:**
+  - `apps/web/lib/settings/workspace-display-order.ts`
+  - `apps/web/lib/settings/workspace-display-order.test.ts`
+  - `apps/web/components/app-sidebar/sections/settings/settings-menu-branches.ts`
+  - `apps/web/components/app-sidebar/sections/settings/settings-menu-branches.test.ts`
+  - `apps/web/app/settings/workspace/workspaces-page-client.tsx`
+  - `apps/web/e2e/tests/settings/workspace-display-order.spec.ts`
+  - `apps/web/e2e/tests/settings/mobile-workspace-display-order.spec.ts`
+- **Dependencies:** None.
+- **Parallelism:** sequential. The sidebar and page must consume the same
+  helper, and E2E should run after both consumers are wired.
+- **Inputs:**
+  - `docs/specs/ui/workspace-active-first-order.md`
+  - `docs/plans/workspace-active-first-order/plan.md`
+  - `apps/web/AGENTS.md`
+  - `apps/web/components/app-sidebar/sections/settings/settings-menu-branches.ts`
+  - `apps/web/app/settings/workspace/workspaces-page-client.tsx`
+  - `apps/web/e2e/helpers/settings-menu.ts`
+  - `apps/web/e2e/tests/settings/mobile-settings-sidebar.spec.ts`
+- **Output contract:** Summarize the helper and both consumers, list the exact
+  files changed, record red/green unit and E2E results plus typecheck and diff
+  checks, note blockers/risks, and update this task and `plan.md` status in the
+  same conversation.
+
+## Results
+
+Implemented a shared `orderWorkspacesForDisplay` helper and applied it to the
+Settings sidebar branch builder and the `/settings/workspaces` card list. The
+helper returns a new array, moves only the matching active workspace, and
+preserves input order for null, unknown, and already-first active ids.
+
+Files changed:
+
+- `apps/web/lib/settings/workspace-display-order.ts`
+- `apps/web/lib/settings/workspace-display-order.test.ts`
+- `apps/web/components/app-sidebar/sections/settings/settings-menu-branches.ts`
+- `apps/web/components/app-sidebar/sections/settings/settings-menu-branches.test.ts`
+- `apps/web/app/settings/workspace/workspaces-page-client.tsx`
+- `apps/web/e2e/tests/settings/workspace-display-order.spec.ts`
+- `apps/web/e2e/tests/settings/mobile-workspace-display-order.spec.ts`
+- `docs/specs/INDEX.md`
+- `docs/specs/ui/workspace-active-first-order.md`
+- `docs/plans/workspace-active-first-order/plan.md`
+- `docs/plans/workspace-active-first-order/task-01-active-workspace-first.md`
+
+Verification:
+
+- Focused Vitest: 2 files, 35 tests passed.
+- Web typecheck: passed.
+- Web lint: passed.
+- Fresh-build desktop E2E: 1 test passed.
+- Fresh-build phone E2E: 1 test passed.
+- PR capture: 1 managed test passed and produced inspected, compressed desktop
+  (1280x720) and phone (390x844) screenshots in ignored `.pr-assets/`.
+- `git diff --check`: passed.
+
+The initial RED runs failed on the intended active-order assertions. No
+blockers or known risks remain; the spec is marked `building` pending PR
+review and merge.

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -170,6 +170,7 @@ Subscription quota tracking and per-agent cheap-model profile routing.
 
 | Spec | Status |
 |---|---|
+| [workspace-active-first-order](ui/workspace-active-first-order.md) | building |
 | [ci-pr-automation](ui/ci-pr-automation.md) | building |
 | [github-pr-review-actions](ui/github-pr-review-actions.md) | shipped |
 | [github-saved-query-defaults](ui/github-saved-query-defaults.md) | shipped |

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -170,7 +170,7 @@ Subscription quota tracking and per-agent cheap-model profile routing.
 
 | Spec | Status |
 |---|---|
-| [workspace-active-first-order](ui/workspace-active-first-order.md) | building |
+| [workspace-active-first-order](ui/workspace-active-first-order.md) | shipped |
 | [ci-pr-automation](ui/ci-pr-automation.md) | building |
 | [github-pr-review-actions](ui/github-pr-review-actions.md) | shipped |
 | [github-saved-query-defaults](ui/github-saved-query-defaults.md) | shipped |

--- a/docs/specs/ui/workspace-active-first-order.md
+++ b/docs/specs/ui/workspace-active-first-order.md
@@ -1,5 +1,5 @@
 ---
-status: building
+status: shipped
 created: 2026-08-14
 owner: Kandev
 ---

--- a/docs/specs/ui/workspace-active-first-order.md
+++ b/docs/specs/ui/workspace-active-first-order.md
@@ -1,0 +1,58 @@
+---
+status: building
+created: 2026-08-14
+owner: Kandev
+---
+
+# Active workspace first in settings
+
+## Why
+
+When several workspaces are available, the workspace currently in use can be
+buried below another workspace in Settings. Users should see the workspace
+that receives their next settings action first in both relevant Settings
+surfaces.
+
+## What
+
+- The workspace list on `/settings/workspaces` places the active workspace first.
+- The workspace records shown by the Settings sidebar tree place the active
+  workspace first.
+- The active workspace is the workspace whose id matches the existing
+  `workspaces.activeId` state.
+- All non-active workspaces retain their existing relative order.
+- When there is no active workspace, or the active id is not present in the
+  list, the incoming workspace order remains unchanged.
+- The active badge and active styling continue to identify the same workspace;
+  ordering does not change workspace selection or persistence.
+- The same ordering is visible on the phone Settings index, which renders the
+  Settings tree, without changing the phone layout or interaction model.
+
+## Scenarios
+
+- **GIVEN** three workspaces in the order `First`, `Active`, `Last`, **WHEN**
+  the Settings sidebar tree renders with `Active` as `workspaces.activeId`,
+  **THEN** the workspace records appear as `Active`, `First`, `Last` and
+  `Active` retains its active badge.
+- **GIVEN** three workspaces in the order `First`, `Active`, `Last`, **WHEN**
+  `/settings/workspaces` renders with `Active` as `workspaces.activeId`,
+  **THEN** the workspace cards appear as `Active`, `First`, `Last` and
+  `Active` retains its active styling.
+- **GIVEN** the active workspace is already first, **WHEN** either Settings
+  surface renders, **THEN** the list stays in its existing order.
+- **GIVEN** no active workspace exists, or the active id is not in the returned
+  list, **WHEN** either Settings surface renders, **THEN** the returned order is
+  preserved and no workspace is incorrectly marked active.
+- **GIVEN** the phone Settings index is open in a tree menu mode, **WHEN** the
+  Workspaces branch is expanded, **THEN** it shows the same active-first order
+  as the desktop Settings sidebar.
+
+## Out of scope
+
+- Reordering the global workspace store or changing the order of workspace
+  pickers and non-Settings workspace consumers.
+- Persisting a new workspace sort preference.
+- Changing which workspace is active, the active-workspace cookie, workspace
+  selection behavior, or workspace creation/deletion behavior.
+- Redesigning the Settings sidebar or adding a separate mobile navigation
+  surface.


### PR DESCRIPTION
When workspaces arrive in an order that does not match the current context, the workspace receiving the next Settings action can be buried below another one. Settings now derives a shared display order from the active workspace id, putting that workspace first while preserving every other workspace's relative order.

## Validation

- `cd apps && pnpm install --frozen-lockfile`
- Focused Vitest: 2 files, 35 tests passed.
- `cd apps/web && pnpm run typecheck`
- `cd apps/web && pnpm run lint`
- Fresh-build desktop E2E: 1 test passed.
- Fresh-build phone E2E: 1 test passed.
- `git diff --check`

The capture-only E2E pass also produced inspected desktop and 390px phone screenshots. Public documentation was not required because this changes Settings display ordering only.

## Possible Improvements

Low risk: other workspace consumers intentionally retain their existing order because this behavior is scoped to Settings.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2663?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

## Screenshots

### Desktop

![Active workspace first on desktop](https://raw.githubusercontent.com/kdlbs/kandev/media/pr-2663-screenshots/desktop-active-workspace-first.png)

### Phone

![Active workspace first on phone](https://raw.githubusercontent.com/kdlbs/kandev/media/pr-2663-screenshots/mobile-active-workspace-first.png)