### PR TITLE
test(e2e): use a secure random source for secret name tokens

### DIFF
--- a/apps/web/e2e/tests/settings/mobile-secrets-copy-move.spec.ts
+++ b/apps/web/e2e/tests/settings/mobile-secrets-copy-move.spec.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+
 import { test, expect } from "../../fixtures/test-base";
 import {
   assertNoDescendantOverflowsRight,
@@ -8,7 +10,7 @@ const WORKSPACE_VALUE = "e2e-mobile-copy-move-value";
 const GLOBAL_VALUE = "e2e-mobile-copy-move-global";
 
 /** Unique per run so retries never collide with leftovers from a failed attempt. */
-const runToken = () => `${Date.now()}${Math.random().toString(36).slice(2, 6)}`;
+const runToken = () => `${Date.now()}${randomUUID().slice(0, 8)}`;
 
 test.describe("mobile-secrets-copy-move", () => {
   test("moves a workspace secret to General and copies one back at phone width", async ({

--- a/apps/web/e2e/tests/settings/secrets-copy-move.spec.ts
+++ b/apps/web/e2e/tests/settings/secrets-copy-move.spec.ts
@@ -1,9 +1,11 @@
+import { randomUUID } from "node:crypto";
+
 import { test, expect } from "../../fixtures/test-base";
 
 const GLOBAL_VALUE = "e2e-copy-move-global-value";
 
 /** Unique per run so retries never collide with leftovers from a failed attempt. */
-const runToken = () => `${Date.now()}${Math.random().toString(36).slice(2, 6)}`;
+const runToken = () => `${Date.now()}${randomUUID().slice(0, 8)}`;
 const WORKSPACE_VALUE = "e2e-copy-move-workspace-value";
 
 /** Creates a secret from the settings page via the Add secret dialog. */
@@ -167,7 +169,7 @@ test.describe("secrets-copy-move", () => {
   test("restores focus to the trigger after closing the dialog", async ({ testPage }) => {
     // Unique per run: retries must not collide with a secret a previous
     // attempt left behind (the fixture reset does not remove secrets).
-    const sourceName = `E2E Copy Move Focus ${Date.now()} ${Math.random().toString(36).slice(2, 6)}`;
+    const sourceName = `E2E Copy Move Focus ${runToken()}`;
     await createSecretFromSettings(testPage, "/settings/general/secrets", sourceName, GLOBAL_VALUE);
 
     await testPage.getByRole("button", { name: `Copy or move ${sourceName}` }).click();


### PR DESCRIPTION
CodeQL alert #318 (`js/insecure-randomness`, high) was the only open code-scanning alert on the repository: `Math.random()` fed the run token that ends up in the secret name `submitCopyMove` consumes, and the query treats that parameter as a security context. Moving the token to `randomUUID()` removes the taint source, so the alert has nothing left to report.

The token only ever needed per-run uniqueness so retries do not collide with secrets a failed attempt left behind, and `randomUUID()` from `node:crypto` is already the convention here (`e2e/fixtures/docker-probe.ts`). The mobile spec's identical helper gets the same swap even though it was not flagged, and the one call site that inlined the expression now routes through `runToken()`.

## Validation

- `./e2e/scripts/run-e2e.sh --host --project chromium tests/settings/secrets-copy-move.spec.ts` — 5 passed
- `./e2e/scripts/run-e2e.sh --host --project mobile-chrome tests/settings/mobile-secrets-copy-move.spec.ts` — 2 passed
- `pnpm run typecheck` (apps/web) — clean
- `pnpm exec eslint` on both specs — clean
- `pnpm run e2e:sleep-ratchet` — clean
- `pnpm exec prettier --check` on both specs — clean

## Possible Improvements

Low risk, test-only. The token stays alphanumeric (a UUID's first 8 characters are pure hex, no hyphen), so secret-name validation and `getByRole` name matching are unchanged. Verification that alert #318 actually closes comes from the CodeQL scan on the merge commit, not from this branch.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2665?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->