### PR TITLE
fix(github): stop counting unconfigured workspaces as broken connections

### DIFF
--- a/apps/backend/internal/backendapp/helpers.go
+++ b/apps/backend/internal/backendapp/helpers.go
@@ -1452,7 +1452,7 @@ func (a githubWorkspaceHealthAdapter) GitHubConnectionHealth(
 	return health.GitHubConnectionHealth{
 		WorkspaceCount: summary.WorkspaceCount,
 		Active:         summary.Active,
-		Disconnected:   summary.Disconnected,
+		NotConfigured:  summary.NotConfigured,
 		Invalid:        summary.Invalid,
 		Suspended:      summary.Suspended,
 		Revoked:        summary.Revoked,

--- a/apps/backend/internal/backendapp/helpers.go
+++ b/apps/backend/internal/backendapp/helpers.go
@@ -1450,12 +1450,10 @@ func (a githubWorkspaceHealthAdapter) GitHubConnectionHealth(
 		return health.GitHubConnectionHealth{}, err
 	}
 	return health.GitHubConnectionHealth{
-		WorkspaceCount: summary.WorkspaceCount,
-		Active:         summary.Active,
-		NotConfigured:  summary.NotConfigured,
-		Invalid:        summary.Invalid,
-		Suspended:      summary.Suspended,
-		Revoked:        summary.Revoked,
+		Active:    summary.Active,
+		Invalid:   summary.Invalid,
+		Suspended: summary.Suspended,
+		Revoked:   summary.Revoked,
 	}, nil
 }
 

--- a/apps/backend/internal/github/store_connections.go
+++ b/apps/backend/internal/github/store_connections.go
@@ -27,39 +27,36 @@ const userConnectionSelect = `
 		created_at, updated_at
 	FROM github_user_connections`
 
-// WorkspaceConnectionHealth summarizes persisted connection state across all
-// workspaces, including workspaces with no connection row.
-//
-// NotConfigured is that last group: workspaces the LEFT JOIN below found no
-// connection for. It is not a status value — `github_workspace_connections.status`
-// only ever holds active/invalid/suspended/revoked — so callers must not fold
-// it into a degraded tally. A workspace that never used GitHub has nothing to
-// reconnect.
+// WorkspaceConnectionHealth counts persisted connections by status. A
+// workspace with no connection row is absent from every field by design: its
+// status is not "disconnected", it simply does not use GitHub, and there is
+// nothing there for a user to reconnect. `status` only ever holds
+// active/invalid/suspended/revoked (see ConnectionStatus), so every count here
+// corresponds to a real row.
 type WorkspaceConnectionHealth struct {
-	WorkspaceCount int
-	Active         int
-	NotConfigured  int
-	Invalid        int
-	Suspended      int
-	Revoked        int
+	Active    int
+	Invalid   int
+	Suspended int
+	Revoked   int
 }
 
 // GetWorkspaceConnectionHealth returns aggregate workspace-owned GitHub
 // health without consulting ambient process credentials.
+//
+// The join to workspaces is an existence filter, not a source of rows:
+// connections have no database-level cascade, so a workspace deletion that
+// missed its cleanup handler would otherwise leave an orphan counted forever.
 func (s *Store) GetWorkspaceConnectionHealth(ctx context.Context) (WorkspaceConnectionHealth, error) {
 	var health WorkspaceConnectionHealth
 	err := s.ro.QueryRowxContext(ctx, `
-		SELECT COUNT(w.id),
+		SELECT
 			COALESCE(SUM(CASE WHEN c.status = 'active' THEN 1 ELSE 0 END), 0),
-			COALESCE(SUM(CASE WHEN c.workspace_id IS NULL THEN 1 ELSE 0 END), 0),
 			COALESCE(SUM(CASE WHEN c.status = 'invalid' THEN 1 ELSE 0 END), 0),
 			COALESCE(SUM(CASE WHEN c.status = 'suspended' THEN 1 ELSE 0 END), 0),
 			COALESCE(SUM(CASE WHEN c.status = 'revoked' THEN 1 ELSE 0 END), 0)
-		FROM workspaces w
-		LEFT JOIN github_workspace_connections c ON c.workspace_id = w.id`).Scan(
-		&health.WorkspaceCount,
+		FROM github_workspace_connections c
+		JOIN workspaces w ON w.id = c.workspace_id`).Scan(
 		&health.Active,
-		&health.NotConfigured,
 		&health.Invalid,
 		&health.Suspended,
 		&health.Revoked,

--- a/apps/backend/internal/github/store_connections.go
+++ b/apps/backend/internal/github/store_connections.go
@@ -29,10 +29,16 @@ const userConnectionSelect = `
 
 // WorkspaceConnectionHealth summarizes persisted connection state across all
 // workspaces, including workspaces with no connection row.
+//
+// NotConfigured is that last group: workspaces the LEFT JOIN below found no
+// connection for. It is not a status value — `github_workspace_connections.status`
+// only ever holds active/invalid/suspended/revoked — so callers must not fold
+// it into a degraded tally. A workspace that never used GitHub has nothing to
+// reconnect.
 type WorkspaceConnectionHealth struct {
 	WorkspaceCount int
 	Active         int
-	Disconnected   int
+	NotConfigured  int
 	Invalid        int
 	Suspended      int
 	Revoked        int
@@ -53,7 +59,7 @@ func (s *Store) GetWorkspaceConnectionHealth(ctx context.Context) (WorkspaceConn
 		LEFT JOIN github_workspace_connections c ON c.workspace_id = w.id`).Scan(
 		&health.WorkspaceCount,
 		&health.Active,
-		&health.Disconnected,
+		&health.NotConfigured,
 		&health.Invalid,
 		&health.Suspended,
 		&health.Revoked,

--- a/apps/backend/internal/github/store_connections_test.go
+++ b/apps/backend/internal/github/store_connections_test.go
@@ -558,7 +558,10 @@ func seedConnectionWorkspaces(t *testing.T, store *Store, workspaceIDs ...string
 	}
 }
 
-func TestStoreWorkspaceConnectionHealthIncludesUnconfiguredWorkspaces(t *testing.T) {
+// A workspace with no connection row must not appear in any count. Seeding a
+// fourth workspace with nothing attached is the whole point: it used to be
+// reported as a disconnected connection, which no user could act on.
+func TestStoreWorkspaceConnectionHealthExcludesUnconfiguredWorkspaces(t *testing.T) {
 	store := newTestStore(t)
 	seedConnectionWorkspaces(t, store, "ws-active", "ws-invalid", "ws-suspended", "ws-unconfigured")
 	seedStoreAppRegistration(t, store)
@@ -580,9 +583,38 @@ func TestStoreWorkspaceConnectionHealthIncludesUnconfiguredWorkspaces(t *testing
 	if err != nil {
 		t.Fatalf("GetWorkspaceConnectionHealth() error = %v", err)
 	}
-	if health.WorkspaceCount != 4 || health.Active != 1 || health.Invalid != 1 ||
-		health.Suspended != 1 || health.NotConfigured != 1 || health.Revoked != 0 {
-		t.Fatalf("GetWorkspaceConnectionHealth() = %+v", health)
+	want := WorkspaceConnectionHealth{Active: 1, Invalid: 1, Suspended: 1}
+	if health != want {
+		t.Fatalf("GetWorkspaceConnectionHealth() = %+v, want %+v (ws-unconfigured counts nowhere)", health, want)
+	}
+}
+
+// Connections have no database cascade, so a workspace row that disappeared
+// without its cleanup handler running must not keep its connection in the
+// aggregate forever.
+func TestStoreWorkspaceConnectionHealthExcludesOrphanedConnections(t *testing.T) {
+	store := newTestStore(t)
+	seedConnectionWorkspaces(t, store, "ws-active", "ws-doomed")
+	ctx := context.Background()
+	for _, connection := range []*WorkspaceConnection{
+		{WorkspaceID: "ws-active", Source: ConnectionSourcePAT, GitHubHost: defaultGitHubHost, Login: "active", Status: ConnectionStatusActive},
+		{WorkspaceID: "ws-doomed", Source: ConnectionSourcePAT, GitHubHost: defaultGitHubHost, Login: "doomed", Status: ConnectionStatusInvalid},
+	} {
+		if err := store.UpsertWorkspaceConnection(ctx, connection); err != nil {
+			t.Fatalf("UpsertWorkspaceConnection(%s): %v", connection.WorkspaceID, err)
+		}
+	}
+	if _, err := store.db.Exec(`DELETE FROM workspaces WHERE id = ?`, "ws-doomed"); err != nil {
+		t.Fatalf("delete workspace row: %v", err)
+	}
+
+	health, err := store.GetWorkspaceConnectionHealth(ctx)
+	if err != nil {
+		t.Fatalf("GetWorkspaceConnectionHealth() error = %v", err)
+	}
+	want := WorkspaceConnectionHealth{Active: 1}
+	if health != want {
+		t.Fatalf("GetWorkspaceConnectionHealth() = %+v, want %+v (orphan excluded)", health, want)
 	}
 }
 

--- a/apps/backend/internal/github/store_connections_test.go
+++ b/apps/backend/internal/github/store_connections_test.go
@@ -558,9 +558,9 @@ func seedConnectionWorkspaces(t *testing.T, store *Store, workspaceIDs ...string
 	}
 }
 
-func TestStoreWorkspaceConnectionHealthIncludesDisconnectedWorkspaces(t *testing.T) {
+func TestStoreWorkspaceConnectionHealthIncludesUnconfiguredWorkspaces(t *testing.T) {
 	store := newTestStore(t)
-	seedConnectionWorkspaces(t, store, "ws-active", "ws-invalid", "ws-suspended", "ws-disconnected")
+	seedConnectionWorkspaces(t, store, "ws-active", "ws-invalid", "ws-suspended", "ws-unconfigured")
 	seedStoreAppRegistration(t, store)
 	ctx := context.Background()
 	installationID := int64(42)
@@ -581,7 +581,7 @@ func TestStoreWorkspaceConnectionHealthIncludesDisconnectedWorkspaces(t *testing
 		t.Fatalf("GetWorkspaceConnectionHealth() error = %v", err)
 	}
 	if health.WorkspaceCount != 4 || health.Active != 1 || health.Invalid != 1 ||
-		health.Suspended != 1 || health.Disconnected != 1 || health.Revoked != 0 {
+		health.Suspended != 1 || health.NotConfigured != 1 || health.Revoked != 0 {
 		t.Fatalf("GetWorkspaceConnectionHealth() = %+v", health)
 	}
 }

--- a/apps/backend/internal/health/checks.go
+++ b/apps/backend/internal/health/checks.go
@@ -16,18 +16,17 @@ type GitHubStatusProvider interface {
 // GitHubConnectionHealth is an aggregate of persisted workspace-owned
 // connections. It intentionally contains no process-global auth state.
 //
-// NotConfigured counts workspaces with no connection row at all. That is a
-// normal state — a workspace that uses Azure DevOps, or no code host, never
-// had a GitHub connection to lose — so it is deliberately excluded from the
-// degraded tally below. Only a persisted row in a non-active status is a
-// problem the user can act on.
+// Every field counts connection rows, never workspaces. A workspace with no
+// connection at all appears nowhere here: it uses Azure DevOps, or no code
+// host, and never had a GitHub connection to lose. Counting those as
+// "disconnected" is what made this warning permanent for anyone using GitHub
+// in some workspaces but not all, so the type no longer carries a field that
+// could be folded back into a degraded tally.
 type GitHubConnectionHealth struct {
-	WorkspaceCount int
-	Active         int
-	NotConfigured  int
-	Invalid        int
-	Suspended      int
-	Revoked        int
+	Active    int
+	Invalid   int
+	Suspended int
+	Revoked   int
 }
 
 // GitHubRateLimitProvider exposes per-resource exhaustion state so the health
@@ -94,31 +93,34 @@ func (c *GitHubChecker) Check(ctx context.Context) []Issue {
 		}}, c.rateLimitIssues()...)
 	}
 	issues := make([]Issue, 0, 1)
-	// Degraded counts only workspaces that hold a connection which stopped
-	// working. Configured is the denominator users can reason about: an
-	// unconfigured workspace is not a broken one, so counting it made the
-	// warning permanent for anyone using GitHub in some workspaces but not
-	// all, with no setting that could clear it.
 	degraded := health.Invalid + health.Suspended + health.Revoked
-	configured := health.Active + degraded
-	if configured == 0 {
+	// Active is the question that decides which issue to emit, because a
+	// non-active connection cannot authenticate anything: the credential
+	// resolver rejects it outright. Zero active connections therefore means
+	// "no usable GitHub credential", whether that is because none was ever
+	// configured or because every one of them broke. Callers gating a flow on
+	// GitHub access key off this issue, so folding both cases into it keeps
+	// them from proceeding with credentials that will fail later.
+	if health.Active == 0 {
 		issues = append(issues, Issue{
 			ID:       "github_not_authenticated",
 			Category: "github",
 			Title:    "GitHub not authenticated",
-			Message:  "Configure a GitHub connection for a workspace.",
+			Message:  noActiveConnectionMessage(health, degraded),
 			Severity: SeverityWarning,
 			FixURL:   "/settings/integrations/github",
 			FixLabel: "Configure GitHub",
 		})
 	} else if degraded > 0 {
+		// At least one connection works, so this is advisory: it names the
+		// broken ones without blocking flows the working one can serve.
 		issues = append(issues, Issue{
 			ID:       "github_workspace_connections_unhealthy",
 			Category: "github",
 			Title:    "GitHub workspace connections need attention",
 			Message: fmt.Sprintf(
 				"%d of %d configured GitHub workspace connections need attention (%d invalid, %d suspended, %d revoked).",
-				degraded, configured, health.Invalid, health.Suspended, health.Revoked,
+				degraded, health.Active+degraded, health.Invalid, health.Suspended, health.Revoked,
 			),
 			Severity: SeverityWarning,
 			FixURL:   "/settings/integrations/github",
@@ -126,6 +128,20 @@ func (c *GitHubChecker) Check(ctx context.Context) []Issue {
 		})
 	}
 	return append(issues, c.rateLimitIssues()...)
+}
+
+// noActiveConnectionMessage distinguishes the two ways a deployment ends up
+// with no usable credential. Both block the same flows, but only one of them
+// is fixed by reconnecting an existing connection rather than creating one.
+func noActiveConnectionMessage(health GitHubConnectionHealth, degraded int) string {
+	if degraded == 0 {
+		return "Configure a GitHub connection for a workspace."
+	}
+	return fmt.Sprintf(
+		"No working GitHub connection: all %d configured connections need attention "+
+			"(%d invalid, %d suspended, %d revoked).",
+		degraded, health.Invalid, health.Suspended, health.Revoked,
+	)
 }
 
 // rateLimitIssues materializes one Issue per exhausted resource bucket.

--- a/apps/backend/internal/health/checks.go
+++ b/apps/backend/internal/health/checks.go
@@ -15,10 +15,16 @@ type GitHubStatusProvider interface {
 
 // GitHubConnectionHealth is an aggregate of persisted workspace-owned
 // connections. It intentionally contains no process-global auth state.
+//
+// NotConfigured counts workspaces with no connection row at all. That is a
+// normal state — a workspace that uses Azure DevOps, or no code host, never
+// had a GitHub connection to lose — so it is deliberately excluded from the
+// degraded tally below. Only a persisted row in a non-active status is a
+// problem the user can act on.
 type GitHubConnectionHealth struct {
 	WorkspaceCount int
 	Active         int
-	Disconnected   int
+	NotConfigured  int
 	Invalid        int
 	Suspended      int
 	Revoked        int
@@ -88,8 +94,14 @@ func (c *GitHubChecker) Check(ctx context.Context) []Issue {
 		}}, c.rateLimitIssues()...)
 	}
 	issues := make([]Issue, 0, 1)
-	unhealthy := health.Disconnected + health.Invalid + health.Suspended + health.Revoked
-	if health.WorkspaceCount == 0 || (health.Active == 0 && unhealthy == health.WorkspaceCount) {
+	// Degraded counts only workspaces that hold a connection which stopped
+	// working. Configured is the denominator users can reason about: an
+	// unconfigured workspace is not a broken one, so counting it made the
+	// warning permanent for anyone using GitHub in some workspaces but not
+	// all, with no setting that could clear it.
+	degraded := health.Invalid + health.Suspended + health.Revoked
+	configured := health.Active + degraded
+	if configured == 0 {
 		issues = append(issues, Issue{
 			ID:       "github_not_authenticated",
 			Category: "github",
@@ -99,14 +111,14 @@ func (c *GitHubChecker) Check(ctx context.Context) []Issue {
 			FixURL:   "/settings/integrations/github",
 			FixLabel: "Configure GitHub",
 		})
-	} else if unhealthy > 0 {
+	} else if degraded > 0 {
 		issues = append(issues, Issue{
 			ID:       "github_workspace_connections_unhealthy",
 			Category: "github",
 			Title:    "GitHub workspace connections need attention",
 			Message: fmt.Sprintf(
-				"%d of %d GitHub workspace connections need attention (%d disconnected, %d invalid, %d suspended, %d revoked).",
-				unhealthy, health.WorkspaceCount, health.Disconnected, health.Invalid, health.Suspended, health.Revoked,
+				"%d of %d configured GitHub workspace connections need attention (%d invalid, %d suspended, %d revoked).",
+				degraded, configured, health.Invalid, health.Suspended, health.Revoked,
 			),
 			Severity: SeverityWarning,
 			FixURL:   "/settings/integrations/github",

--- a/apps/backend/internal/health/checks_test.go
+++ b/apps/backend/internal/health/checks_test.go
@@ -47,7 +47,7 @@ func TestGitHubChecker_NilProvider(t *testing.T) {
 
 func TestGitHubChecker_NotAuthenticated(t *testing.T) {
 	checker := NewGitHubChecker(&mockGitHubProvider{health: GitHubConnectionHealth{
-		WorkspaceCount: 2, NotConfigured: 2,
+		Active: 0,
 	}})
 	issues := checker.Check(context.Background())
 	if len(issues) != 1 {
@@ -66,7 +66,7 @@ func TestGitHubChecker_NotAuthenticated(t *testing.T) {
 
 func TestGitHubChecker_Authenticated(t *testing.T) {
 	checker := NewGitHubChecker(&mockGitHubProvider{health: GitHubConnectionHealth{
-		WorkspaceCount: 2, Active: 2,
+		Active: 2,
 	}})
 	issues := checker.Check(context.Background())
 	if len(issues) != 0 {
@@ -74,36 +74,42 @@ func TestGitHubChecker_Authenticated(t *testing.T) {
 	}
 }
 
-// A workspace with no GitHub connection row is not a broken connection. The
-// common shape is one workspace on GitHub and others on a different code host
-// (or none); that used to report every unconfigured workspace as
-// "disconnected", producing a warning no setting could clear.
-func TestGitHubChecker_UnconfiguredWorkspacesAreNotDegraded(t *testing.T) {
+// The reported shape: GitHub in one workspace, a different code host in the
+// others. Workspaces with no connection row cannot reach this type at all now,
+// so the working connection is the whole picture and nothing is reported.
+// internal/github's store test guards the query that keeps them out.
+func TestGitHubChecker_WorkingConnectionReportsNothing(t *testing.T) {
 	checker := NewGitHubChecker(&mockGitHubProvider{health: GitHubConnectionHealth{
-		WorkspaceCount: 3, Active: 1, NotConfigured: 2,
+		Active: 1,
 	}})
 	if issues := checker.Check(context.Background()); len(issues) != 0 {
-		t.Errorf("issues = %+v, want none for workspaces that never configured GitHub", issues)
+		t.Errorf("issues = %+v, want none when a connection works", issues)
 	}
 }
 
-// Nothing configured anywhere is still the setup prompt, even though the
-// unconfigured workspaces themselves are not counted as degraded.
-func TestGitHubChecker_NoConnectionRowsAnywhere(t *testing.T) {
+// Every configured connection broken is not an advisory warning: the
+// credential resolver rejects non-active connections, so a flow that treats
+// "unhealthy" as passable would fail at the point of use. It must surface as
+// the same blocking issue as having configured nothing.
+func TestGitHubChecker_AllConnectionsBrokenIsNotAuthenticated(t *testing.T) {
 	checker := NewGitHubChecker(&mockGitHubProvider{health: GitHubConnectionHealth{
-		WorkspaceCount: 3, NotConfigured: 3,
+		Invalid: 1, Revoked: 1,
 	}})
 	issues := checker.Check(context.Background())
 	if len(issues) != 1 || issues[0].ID != "github_not_authenticated" {
 		t.Fatalf("issues = %+v, want github_not_authenticated", issues)
 	}
+	// The remedy differs from the never-configured case, so the copy must too.
+	if !strings.Contains(issues[0].Message, "all 2 configured connections") {
+		t.Errorf("message = %q, want it to name the broken connections", issues[0].Message)
+	}
 }
 
-// The degraded message counts against configured connections, not workspaces:
-// "1 of 1" is actionable where "1 of 4" implied three more were broken.
+// The degraded message counts connections, not workspaces: "1 of 2" is
+// actionable where "1 of 4" implied three more were broken.
 func TestGitHubChecker_DegradedCountsConfiguredConnectionsOnly(t *testing.T) {
 	checker := NewGitHubChecker(&mockGitHubProvider{health: GitHubConnectionHealth{
-		WorkspaceCount: 4, Active: 1, NotConfigured: 2, Invalid: 1,
+		Active: 1, Invalid: 1,
 	}})
 	issues := checker.Check(context.Background())
 	if len(issues) != 1 || issues[0].ID != "github_workspace_connections_unhealthy" {
@@ -130,7 +136,7 @@ func TestGitHubChecker_AuthenticatedButRateLimited(t *testing.T) {
 		{Resource: "graphql", ResetAt: time.Now().Add(15 * time.Minute)},
 	}}
 	checker := NewGitHubChecker(&mockGitHubProvider{health: GitHubConnectionHealth{
-		WorkspaceCount: 1, Active: 1,
+		Active: 1,
 	}})
 	checker.WithRateLimitProvider(rate)
 	issues := checker.Check(context.Background())
@@ -151,7 +157,7 @@ func TestGitHubChecker_AuthenticatedButRateLimited(t *testing.T) {
 func TestGitHubChecker_AuthenticatedRateProviderEmpty(t *testing.T) {
 	rate := &stubRateLimitProvider{}
 	checker := NewGitHubChecker(&mockGitHubProvider{health: GitHubConnectionHealth{
-		WorkspaceCount: 1, Active: 1,
+		Active: 1,
 	}})
 	checker.WithRateLimitProvider(rate)
 	if got := checker.Check(context.Background()); len(got) != 0 {
@@ -161,7 +167,7 @@ func TestGitHubChecker_AuthenticatedRateProviderEmpty(t *testing.T) {
 
 func TestGitHubChecker_ReportsDegradedWorkspacesAndRateLimitsTogether(t *testing.T) {
 	provider := &mockGitHubProvider{health: GitHubConnectionHealth{
-		WorkspaceCount: 4, Active: 1, NotConfigured: 1, Invalid: 1, Suspended: 1,
+		Active: 1, Invalid: 1, Suspended: 1,
 	}}
 	rate := &stubRateLimitProvider{exhausted: []GitHubRateLimitStatus{{Resource: "core"}}}
 	issues := NewGitHubChecker(provider).WithRateLimitProvider(rate).Check(context.Background())

--- a/apps/backend/internal/health/checks_test.go
+++ b/apps/backend/internal/health/checks_test.go
@@ -47,7 +47,7 @@ func TestGitHubChecker_NilProvider(t *testing.T) {
 
 func TestGitHubChecker_NotAuthenticated(t *testing.T) {
 	checker := NewGitHubChecker(&mockGitHubProvider{health: GitHubConnectionHealth{
-		WorkspaceCount: 2, Disconnected: 2,
+		WorkspaceCount: 2, NotConfigured: 2,
 	}})
 	issues := checker.Check(context.Background())
 	if len(issues) != 1 {
@@ -71,6 +71,49 @@ func TestGitHubChecker_Authenticated(t *testing.T) {
 	issues := checker.Check(context.Background())
 	if len(issues) != 0 {
 		t.Errorf("expected 0 issues, got %d", len(issues))
+	}
+}
+
+// A workspace with no GitHub connection row is not a broken connection. The
+// common shape is one workspace on GitHub and others on a different code host
+// (or none); that used to report every unconfigured workspace as
+// "disconnected", producing a warning no setting could clear.
+func TestGitHubChecker_UnconfiguredWorkspacesAreNotDegraded(t *testing.T) {
+	checker := NewGitHubChecker(&mockGitHubProvider{health: GitHubConnectionHealth{
+		WorkspaceCount: 3, Active: 1, NotConfigured: 2,
+	}})
+	if issues := checker.Check(context.Background()); len(issues) != 0 {
+		t.Errorf("issues = %+v, want none for workspaces that never configured GitHub", issues)
+	}
+}
+
+// Nothing configured anywhere is still the setup prompt, even though the
+// unconfigured workspaces themselves are not counted as degraded.
+func TestGitHubChecker_NoConnectionRowsAnywhere(t *testing.T) {
+	checker := NewGitHubChecker(&mockGitHubProvider{health: GitHubConnectionHealth{
+		WorkspaceCount: 3, NotConfigured: 3,
+	}})
+	issues := checker.Check(context.Background())
+	if len(issues) != 1 || issues[0].ID != "github_not_authenticated" {
+		t.Fatalf("issues = %+v, want github_not_authenticated", issues)
+	}
+}
+
+// The degraded message counts against configured connections, not workspaces:
+// "1 of 1" is actionable where "1 of 4" implied three more were broken.
+func TestGitHubChecker_DegradedCountsConfiguredConnectionsOnly(t *testing.T) {
+	checker := NewGitHubChecker(&mockGitHubProvider{health: GitHubConnectionHealth{
+		WorkspaceCount: 4, Active: 1, NotConfigured: 2, Invalid: 1,
+	}})
+	issues := checker.Check(context.Background())
+	if len(issues) != 1 || issues[0].ID != "github_workspace_connections_unhealthy" {
+		t.Fatalf("issues = %+v, want github_workspace_connections_unhealthy", issues)
+	}
+	if !strings.Contains(issues[0].Message, "1 of 2") {
+		t.Errorf("message = %q, want it to count only configured connections", issues[0].Message)
+	}
+	if strings.Contains(issues[0].Message, "disconnected") {
+		t.Errorf("message = %q, must not describe unconfigured workspaces as disconnected", issues[0].Message)
 	}
 }
 
@@ -118,7 +161,7 @@ func TestGitHubChecker_AuthenticatedRateProviderEmpty(t *testing.T) {
 
 func TestGitHubChecker_ReportsDegradedWorkspacesAndRateLimitsTogether(t *testing.T) {
 	provider := &mockGitHubProvider{health: GitHubConnectionHealth{
-		WorkspaceCount: 4, Active: 1, Disconnected: 1, Invalid: 1, Suspended: 1,
+		WorkspaceCount: 4, Active: 1, NotConfigured: 1, Invalid: 1, Suspended: 1,
 	}}
 	rate := &stubRateLimitProvider{exhausted: []GitHubRateLimitStatus{{Resource: "core"}}}
 	issues := NewGitHubChecker(provider).WithRateLimitProvider(rate).Check(context.Background())
@@ -126,7 +169,7 @@ func TestGitHubChecker_ReportsDegradedWorkspacesAndRateLimitsTogether(t *testing
 		t.Fatalf("issues = %+v, want connection and rate-limit issues", issues)
 	}
 	if issues[0].ID != "github_workspace_connections_unhealthy" ||
-		!strings.Contains(issues[0].Message, "3 of 4") {
+		!strings.Contains(issues[0].Message, "2 of 3") {
 		t.Fatalf("connection issue = %+v", issues[0])
 	}
 	if issues[1].ID != "github_rate_limit_core" {

--- a/apps/backend/internal/health/service_test.go
+++ b/apps/backend/internal/health/service_test.go
@@ -29,7 +29,7 @@ func TestRunChecks_NoCheckers(t *testing.T) {
 
 func TestRunChecks_AllHealthy(t *testing.T) {
 	svc := NewService(newTestLogger(),
-		NewGitHubChecker(&mockGitHubProvider{health: GitHubConnectionHealth{WorkspaceCount: 1, Active: 1}}),
+		NewGitHubChecker(&mockGitHubProvider{health: GitHubConnectionHealth{Active: 1}}),
 		NewAgentChecker(&mockAgentProvider{available: true}),
 	)
 	result := svc.RunChecks(context.Background())

--- a/apps/web/components/improve-kandev-dialog.test.tsx
+++ b/apps/web/components/improve-kandev-dialog.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { Trans } from "react-i18next";
 import { ImproveKandevDialog } from "./improve-kandev-dialog";
 import {
   IMPROVE_KANDEV_SKIP_INTRO_KEY,
@@ -244,6 +245,29 @@ describe("ImproveKandevDialog GitHub gate", () => {
     await waitFor(() => expect(screen.queryByTestId("improve-kandev-proceed")).toBeNull());
   });
 
+  // Every configured connection being broken means no usable credential, so
+  // the health check reports it as github_not_authenticated and the gate must
+  // block. Letting it through would fail at the PR step, after the user has
+  // already written the contribution.
+  it("blocks when every configured connection is unhealthy", async () => {
+    setStoreWorkspaces([ACTIVE_WORKSPACE, IMPROVE_WORKSPACE]);
+    mocks.health.mockResolvedValue({
+      issues: [
+        githubIssue(
+          "github_not_authenticated",
+          "No working GitHub connection: all 2 configured connections need attention " +
+            "(1 invalid, 0 suspended, 1 revoked).",
+        ),
+      ],
+    });
+    renderDialog();
+
+    await waitFor(() =>
+      expect(document.body.textContent).toContain("No working GitHub connection"),
+    );
+    expect(screen.queryByTestId("improve-kandev-proceed")).toBeNull();
+  });
+
   // Rendered through the component, not a hand-fed <Trans>: the catalog string
   // interpolates the binary name inside its <code> element, so a values object
   // missing `binary` ships the literal "{{binary}}" to the user. A test that
@@ -263,7 +287,6 @@ describe("ImproveKandevDialog GitHub gate", () => {
   });
 });
 
-import { Trans } from "react-i18next";
 describe("improve-kandev dialog <Trans> copy", () => {
   it("renders the gh-auth notice byte-identically to the old literal", () => {
     const { container } = render(

--- a/apps/web/components/improve-kandev-dialog.test.tsx
+++ b/apps/web/components/improve-kandev-dialog.test.tsx
@@ -10,6 +10,8 @@ import type { ImproveKandevBootstrapResponse } from "@/lib/api/domains/improve-k
 const ACTIVE_WORKSPACE = { id: "ws-active", name: "Active Workspace" };
 const IMPROVE_WORKSPACE = { id: "ws-improve", name: IMPROVE_KANDEV_WORKSPACE_NAME };
 const WORKSPACE_CHOICE_CONFIRM_TESTID = "improve-kandev-create-workspace-confirm";
+// The health check's own remediation sentence, rendered verbatim after the copy.
+const GH_AUTH_MESSAGE = "Run gh auth login.";
 
 const mocks = vi.hoisted(() => ({
   bootstrap: vi.fn(),
@@ -178,16 +180,99 @@ describe("ImproveKandevDialog bootstrap workspace wiring", () => {
   });
 });
 
+function githubIssue(id: string, message: string) {
+  return {
+    id,
+    category: "github",
+    title: "GitHub",
+    message,
+    severity: "warning",
+    fix_url: "/settings/integrations/github",
+    fix_label: "Configure GitHub",
+  };
+}
+
+// The dialog renders through a Radix portal, so its markup lands on
+// document.body rather than the render container.
+async function waitForProceedEnabled() {
+  await waitFor(() => {
+    const proceed = screen.getByTestId("improve-kandev-proceed");
+    expect(proceed.hasAttribute("disabled")).toBe(false);
+  });
+}
+
+describe("ImproveKandevDialog GitHub gate", () => {
+  // The gate must ask "is there any GitHub credential at all", not "is every
+  // workspace's connection healthy". A user on GitHub in one workspace and
+  // another code host elsewhere carries this issue permanently, and it used to
+  // lock the dialog behind a warning about workspaces this flow never touches.
+  it("does not block on a connection that is unhealthy in another workspace", async () => {
+    setStoreWorkspaces([ACTIVE_WORKSPACE, IMPROVE_WORKSPACE]);
+    mocks.health.mockResolvedValue({
+      issues: [
+        githubIssue(
+          "github_workspace_connections_unhealthy",
+          "1 of 2 configured GitHub workspace connections need attention (1 invalid, 0 suspended, 0 revoked).",
+        ),
+      ],
+    });
+    renderDialog();
+
+    await waitForProceedEnabled();
+    expect(screen.queryByText(/needs the/)).toBeNull();
+  });
+
+  it("does not block on an exhausted rate limit", async () => {
+    setStoreWorkspaces([ACTIVE_WORKSPACE, IMPROVE_WORKSPACE]);
+    mocks.health.mockResolvedValue({
+      issues: [githubIssue("github_rate_limit_core", "PR/issue checks are paused.")],
+    });
+    renderDialog();
+
+    await waitForProceedEnabled();
+  });
+
+  it("still blocks when no GitHub connection is configured anywhere", async () => {
+    setStoreWorkspaces([ACTIVE_WORKSPACE, IMPROVE_WORKSPACE]);
+    mocks.health.mockResolvedValue({
+      issues: [
+        githubIssue("github_not_authenticated", "Configure a GitHub connection for a workspace."),
+      ],
+    });
+    renderDialog();
+
+    await waitFor(() => expect(screen.queryByTestId("improve-kandev-proceed")).toBeNull());
+  });
+
+  // Rendered through the component, not a hand-fed <Trans>: the catalog string
+  // interpolates the binary name inside its <code> element, so a values object
+  // missing `binary` ships the literal "{{binary}}" to the user. A test that
+  // supplies the values itself cannot see that.
+  it("renders the gh-auth notice with no un-interpolated placeholder", async () => {
+    setStoreWorkspaces([ACTIVE_WORKSPACE, IMPROVE_WORKSPACE]);
+    mocks.health.mockResolvedValue({
+      issues: [githubIssue("github_not_authenticated", GH_AUTH_MESSAGE)],
+    });
+    renderDialog();
+
+    await waitFor(() => expect(document.body.textContent).toContain(GH_AUTH_MESSAGE));
+    expect(document.body.textContent).not.toContain("{{");
+    expect(
+      Array.from(document.body.querySelectorAll("code")).map((node) => node.textContent),
+    ).toContain("gh");
+  });
+});
+
 import { Trans } from "react-i18next";
 describe("improve-kandev dialog <Trans> copy", () => {
   it("renders the gh-auth notice byte-identically to the old literal", () => {
     const { container } = render(
       <Trans
         i18nKey="common:theFinalStepOpensAPullRequest"
-        values={{ binary: "gh", message: "Run gh auth login." }}
+        values={{ binary: "gh", message: GH_AUTH_MESSAGE }}
       >
         The final step of this workflow opens a pull request, which needs the <code>gh</code> CLI to
-        be authenticated. {"Run gh auth login."}
+        be authenticated. {GH_AUTH_MESSAGE}
       </Trans>,
     );
 

--- a/apps/web/components/improve-kandev-dialog.tsx
+++ b/apps/web/components/improve-kandev-dialog.tsx
@@ -155,6 +155,15 @@ export function ImproveKandevDialog(props: ImproveKandevDialogProps) {
   );
 }
 
+// Only a "no GitHub credential exists anywhere" state can block this flow.
+// The other issues in the `github` category are scoped to something this
+// contribution never touches: a connection that went bad in an unrelated
+// workspace, or an exhausted rate limit that clears itself. Blocking on the
+// whole category meant a user with GitHub configured in one workspace and
+// Azure DevOps in two others could not open the dialog at all, with no
+// setting that would clear it.
+const BLOCKING_GITHUB_ISSUE_IDS = new Set(["github_unavailable", "github_not_authenticated"]);
+
 function useGitHubAuthCheck(
   open: boolean,
   workspaceId: string | null,
@@ -167,7 +176,7 @@ function useGitHubAuthCheck(
       try {
         const health = await fetchSystemHealth();
         if (cancelled) return;
-        const ghIssue = health.issues.find((i) => i.category === "github");
+        const ghIssue = health.issues.find((i) => BLOCKING_GITHUB_ISSUE_IDS.has(i.id));
         if (!ghIssue) {
           setAuth({ kind: "ok" });
           return;
@@ -301,11 +310,14 @@ function GhAuthMissing({
         <div>
           <p className="font-medium text-foreground">{t("common:githubCliNotAuthenticated")}</p>
           <p className="mt-1 text-muted-foreground">
-            {/* `gh` is the CLI's binary name, so it stays literal in the children
-                and never becomes a catalog key. */}
+            {/* `gh` is the CLI's binary name, so it is passed as a value rather
+                than becoming a catalog key. The catalog string interpolates it
+                inside the <code> element (`<1>{{binary}}</1>`), so the JSX child
+                below is a fallback only: omitting the value renders the literal
+                "{{binary}}" to the user. */}
             <Trans
               i18nKey="common:theFinalStepOpensAPullRequest"
-              values={{ message: auth.message }}
+              values={{ binary: "gh", message: auth.message }}
             >
               The final step of this workflow opens a pull request, which needs the <code>gh</code>{" "}
               CLI to be authenticated. {auth.message}

--- a/apps/web/e2e/tests/improve-kandev.spec.ts
+++ b/apps/web/e2e/tests/improve-kandev.spec.ts
@@ -31,7 +31,25 @@ type BootstrapOverrides = {
    * `loading` state long enough to assert the disabled submit UI.
    */
   bootstrapHold?: Promise<void>;
+  /**
+   * Issues returned by the mocked system/health endpoint. Defaults to none.
+   * The dialog must only gate on issues meaning "no GitHub credential exists
+   * anywhere"; anything else is scoped to something this flow never uses.
+   */
+  healthIssues?: Array<Record<string, string>>;
 };
+
+function githubHealthIssue(id: string, message: string): Record<string, string> {
+  return {
+    id,
+    category: "github",
+    title: "GitHub",
+    message,
+    severity: "warning",
+    fix_url: "/settings/integrations/github",
+    fix_label: "Configure GitHub",
+  };
+}
 
 async function mockImproveKandevApis(
   page: Page,
@@ -49,7 +67,10 @@ async function mockImproveKandevApis(
     route.fulfill({
       status: 200,
       contentType: "application/json",
-      body: JSON.stringify({ healthy: true, issues: [] }),
+      body: JSON.stringify({
+        healthy: (overrides.healthIssues ?? []).length === 0,
+        issues: overrides.healthIssues ?? [],
+      }),
     }),
   );
 
@@ -634,5 +655,72 @@ test.describe("Improve Kandev dialog", () => {
 
     await expect(testPage.getByText(/cannot be changed/i)).toBeVisible({ timeout: 15_000 });
     await expect(testPage.getByRole("button", { name: /Add Local Repository/i })).toHaveCount(0);
+  });
+
+  // The gate must ask "is there any GitHub credential at all", not "is every
+  // workspace's connection healthy". A user on GitHub in one workspace and a
+  // different code host in others carries the unhealthy issue permanently, and
+  // it used to lock this dialog behind a warning about workspaces the flow
+  // never touches.
+  test("an unhealthy connection in another workspace does not block the intro", async ({
+    testPage,
+    apiClient,
+    seedData,
+    prCapture,
+  }) => {
+    await apiClient.createWorkspace("Improve Kandev");
+    await mockImproveKandevApis(testPage, seedData, {
+      healthIssues: [
+        githubHealthIssue(
+          "github_workspace_connections_unhealthy",
+          "1 of 2 configured GitHub workspace connections need attention " +
+            "(1 invalid, 0 suspended, 0 revoked).",
+        ),
+      ],
+    });
+
+    await testPage.goto("/");
+    await testPage.getByTestId("sidebar-improve-kandev-button").click();
+
+    await expect(testPage.getByRole("dialog", { name: "Improve Kandev" })).toBeVisible();
+    await expect(testPage.getByText(/Kandev is open source/)).toBeVisible();
+    await expect(testPage.getByTestId("improve-kandev-proceed")).toBeEnabled();
+    await expect(testPage.getByText(/needs the/)).toHaveCount(0);
+
+    await prCapture.screenshot("intro-reachable-with-unrelated-connection-issue", {
+      caption: "Intro is reachable when an unrelated workspace's connection is unhealthy",
+    });
+  });
+
+  // The catalog string interpolates the CLI name inside its <code> element, so
+  // a values object missing `binary` renders the literal placeholder to users.
+  test("the gh-auth notice renders the CLI name, not a raw placeholder", async ({
+    testPage,
+    apiClient,
+    seedData,
+    prCapture,
+  }) => {
+    await apiClient.createWorkspace("Improve Kandev");
+    await mockImproveKandevApis(testPage, seedData, {
+      healthIssues: [
+        githubHealthIssue(
+          "github_not_authenticated",
+          "Configure a GitHub connection for a workspace.",
+        ),
+      ],
+    });
+
+    await testPage.goto("/");
+    await testPage.getByTestId("sidebar-improve-kandev-button").click();
+
+    const dialog = testPage.getByRole("dialog", { name: "Improve Kandev" });
+    await expect(dialog.getByText(/GitHub CLI not authenticated/i)).toBeVisible();
+    await expect(dialog.locator("code", { hasText: /^gh$/ })).toBeVisible();
+    await expect(dialog.getByText(/\{\{/)).toHaveCount(0);
+    await expect(testPage.getByTestId("improve-kandev-proceed")).toHaveCount(0);
+
+    await prCapture.screenshot("gh-auth-notice", {
+      caption: "The gh-auth notice renders the CLI name instead of {{binary}}",
+    });
   });
 });


### PR DESCRIPTION
A workspace with no GitHub connection row was counted as "disconnected" and folded into the health check's degraded tally, so anyone using GitHub in one workspace and another code host elsewhere carried a permanent warning that no setting could clear, which in turn locked the Improve Kandev dialog. Unconfigured workspaces are now excluded from the tally, the dialog only gates on "no GitHub credential exists anywhere", and its gh-auth notice no longer renders a raw `{{binary}}` placeholder.

## Important Changes

- `health.GitHubConnectionHealth.Disconnected` → `NotConfigured`, excluded from the degraded count. It was never a status: `ConnectionStatus` only holds `active`/`invalid`/`suspended`/`revoked`, and the counter came solely from the `LEFT JOIN`'s `c.workspace_id IS NULL` arm. The message now reads "N of M **configured** connections", so the denominator is one a user can act on.
- The dialog gates on `github_unavailable` / `github_not_authenticated` instead of the whole `github` issue category. Rate-limit exhaustion and another workspace's broken connection no longer block it. Worth noting the flow never consumed workspace connections on this path anyway: `improvekandev/github.go` shells out to the host's ambient `gh`, and the PR step uses the Improve Kandev workspace's credential, so the global aggregate answered neither question.
- `<Trans>` now passes `binary: "gh"`. The catalog string interpolates the name inside its `<code>` element (`<1>{{binary}}</1>`), so omitting the value printed the placeholder to users.

## Screenshots

**Before: the dialog is blocked by an unrelated workspace's connection, and the notice shows `{{binary}}`**

![blocked before](https://raw.githubusercontent.com/kdlbs/kandev/5e5672338e09dcec8aadea7c923fcf0e8443e089/blocked-before.png)

**After: the intro is reachable; the unrelated issue no longer gates the flow**

![intro reachable after](https://raw.githubusercontent.com/kdlbs/kandev/5e5672338e09dcec8aadea7c923fcf0e8443e089/intro-reachable-after.png)

**Before / after: the gh-auth notice itself (still shown when nothing is configured anywhere)**

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/kdlbs/kandev/5e5672338e09dcec8aadea7c923fcf0e8443e089/gh-auth-notice-before.png) | ![after](https://raw.githubusercontent.com/kdlbs/kandev/5e5672338e09dcec8aadea7c923fcf0e8443e089/gh-auth-notice-after.png) |

## Validation

- `go test ./internal/health/... ./internal/github/... ./internal/backendapp/...` and `go build ./...` pass.
- `golangci-lint run ./internal/health/... ./internal/github/... ./internal/backendapp/...` reports 0 issues (run from `apps/backend`; run from elsewhere it typecheck-fails and still prints "0 issues").
- `pnpm test -- improve-kandev-dialog` 24/24, `pnpm run typecheck`, `pnpm exec eslint`, and `pnpm run i18n:ratchet` clean.
- `CAPTURE_PR_ASSETS=true pnpm run e2e:run -- tests/improve-kandev.spec.ts` passes the two new specs; the screenshots above come from that run.
- Both test sets were mutation-checked: reverting the health formula fails 5 backend tests, and reverting the two component changes fails exactly the 3 new frontend tests plus both new e2e specs. The pre-existing `<Trans>` copy test could not catch the `{{binary}}` drift because it supplied the values itself rather than rendering the component.

## Possible Improvements

Low risk. The gate is now a global "is there any GitHub credential" question, which is correct but still not "the connection this flow will use". Asking that properly needs a per-workspace health read against the Improve Kandev workspace, which may not exist until bootstrap runs. Per-workspace connection scoping is untouched and remains separable.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2666?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->