### PR TITLE
fix(web): reveal content search matches in editors

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1853,6 +1853,7 @@ html[data-rendering-engine="webkit"] [data-webkit-safe-motion="true"][data-state
 /* One-shot destination cue for workspace content-search editor reveals. */
 .editor-content-search-flash {
   background-color: color-mix(in oklab, var(--warning) 34%, transparent);
+  /* Keep duration in sync with EDITOR_CONTENT_SEARCH_FLASH_DURATION_MS. */
   animation: editor-content-search-flash 1.2s ease-out forwards;
 }
 @keyframes editor-content-search-flash {

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1850,6 +1850,25 @@ html[data-rendering-engine="webkit"] [data-webkit-safe-motion="true"][data-state
   }
 }
 
+/* One-shot destination cue for workspace content-search editor reveals. */
+.editor-content-search-flash {
+  background-color: color-mix(in oklab, var(--warning) 34%, transparent);
+  animation: editor-content-search-flash 1.2s ease-out forwards;
+}
+@keyframes editor-content-search-flash {
+  from {
+    background-color: color-mix(in oklab, var(--warning) 34%, transparent);
+  }
+  to {
+    background-color: transparent;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .editor-content-search-flash {
+    animation: none;
+  }
+}
+
 /* Highlights a review finding card after "go to finding" scrolls it into view,
  * so the eye lands on the right card among several inline in the diff. */
 .review-finding-flash {

--- a/apps/web/components/editors/codemirror/codemirror-code-editor.cursor.test.tsx
+++ b/apps/web/components/editors/codemirror/codemirror-code-editor.cursor.test.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/hooks/file-editor-cursor";
 
 const editorHarness = vi.hoisted(() => ({
+  extensions: [] as unknown[],
   onCreateEditor: null as ((view: unknown) => void) | null,
 }));
 const getMonacoInstance = vi.hoisted(() => vi.fn());
@@ -20,7 +21,14 @@ vi.mock("@/components/editors/monaco/monaco-init", () => ({
 }));
 
 vi.mock("@uiw/react-codemirror", () => ({
-  default: ({ onCreateEditor }: { onCreateEditor: (view: unknown) => void }) => {
+  default: ({
+    extensions,
+    onCreateEditor,
+  }: {
+    extensions: unknown[];
+    onCreateEditor: (view: unknown) => void;
+  }) => {
+    editorHarness.extensions = extensions;
     editorHarness.onCreateEditor = onCreateEditor;
     return <div data-testid="codemirror" />;
   },
@@ -50,6 +58,7 @@ vi.mock("@/components/editors/external-vcs-file-link", () => ({
 }));
 
 import { CodeMirrorCodeEditor } from "./codemirror-code-editor";
+import { codeMirrorCursorFlashExtension } from "./codemirror-cursor-navigation";
 
 const FILE_PATH = "src/app.ts";
 const FRONTEND_REPO = "frontend";
@@ -101,6 +110,12 @@ afterEach(() => {
 });
 
 describe("CodeMirrorCodeEditor pending cursor navigation", () => {
+  it("installs the shared cursor-flash extension", () => {
+    renderEditor();
+
+    expect(editorHarness.extensions).toContain(codeMirrorCursorFlashExtension);
+  });
+
   it("reveals the pending 1-based line and column for its repository", () => {
     setPendingCursorPosition(FILE_PATH, 2, 3, FRONTEND_REPO);
     const view = createEditorView();

--- a/apps/web/components/editors/codemirror/codemirror-code-editor.tsx
+++ b/apps/web/components/editors/codemirror/codemirror-code-editor.tsx
@@ -30,6 +30,8 @@ import { registerCodeMirrorCursorRevealer } from "@/hooks/file-editor-cursor";
 import { useCodeMirrorEditorState } from "./use-codemirror-editor-state";
 import { useCodeMirrorWalkthroughRange } from "./use-codemirror-walkthrough-range";
 import {
+  clearCodeMirrorCursorFlash,
+  codeMirrorCursorFlashExtension,
   revealCodeMirrorCursor,
   revealPendingCodeMirrorCursor,
 } from "./codemirror-cursor-navigation";
@@ -374,9 +376,16 @@ function useCodeMirrorCodeEditorSetup(props: FileEditorContentProps) {
   });
   useEffect(() => {
     if (!editorView) return;
-    return registerCodeMirrorCursorRevealer(path, repo, sessionId, (line, column) =>
-      revealCodeMirrorCursor(editorView, line, column),
+    const unregister = registerCodeMirrorCursorRevealer(
+      path,
+      repo,
+      sessionId,
+      (line, column, options) => revealCodeMirrorCursor(editorView, line, column, options),
     );
+    return () => {
+      unregister();
+      clearCodeMirrorCursorFlash(editorView);
+    };
   }, [editorView, path, repo, sessionId]);
   const handleCreateEditor = useCallback((view: EditorView) => setEditorView(view), []);
   return { wrapperRef, editorAreaRef, editorRef, state, walkthroughRange, handleCreateEditor };
@@ -431,7 +440,7 @@ export function CodeMirrorCodeEditor(props: FileEditorContentProps) {
           value={content}
           height="100%"
           theme={vscodeDark}
-          extensions={state.extensions}
+          extensions={[...state.extensions, codeMirrorCursorFlashExtension]}
           onChange={state.handleChange}
           basicSetup={{
             lineNumbers: true,

--- a/apps/web/components/editors/codemirror/codemirror-cursor-navigation.test.ts
+++ b/apps/web/components/editors/codemirror/codemirror-cursor-navigation.test.ts
@@ -1,8 +1,22 @@
-import { Text } from "@codemirror/state";
-import { describe, expect, it } from "vitest";
-import { getCodeMirrorCursorOffset } from "./codemirror-cursor-navigation";
+import { EditorState, Text } from "@codemirror/state";
+import { EditorView as CodeMirrorView, type EditorView } from "@codemirror/view";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  EDITOR_CONTENT_SEARCH_FLASH_DURATION_MS,
+  EDITOR_CONTENT_SEARCH_FLASH_CLASS,
+} from "@/hooks/file-editor-cursor";
+import {
+  codeMirrorCursorFlashExtension,
+  getCodeMirrorCursorOffset,
+  revealCodeMirrorCursor,
+} from "./codemirror-cursor-navigation";
 
 const DOCUMENT = Text.of(["alpha", "bravo", "charlie"]);
+
+afterEach(() => {
+  document.body.replaceChildren();
+  vi.useRealTimers();
+});
 
 describe("getCodeMirrorCursorOffset", () => {
   it("translates a 1-based line and column into a document offset", () => {
@@ -15,5 +29,68 @@ describe("getCodeMirrorCursorOffset", () => {
 
   it("clamps a position after the document to its end", () => {
     expect(getCodeMirrorCursorOffset(DOCUMENT, 99, 99)).toBe(DOCUMENT.length);
+  });
+});
+
+describe("revealCodeMirrorCursor", () => {
+  it("dispatches a line-flash effect for a flashed reveal", () => {
+    const dispatch = vi.fn();
+    const view = {
+      state: EditorState.create({ doc: DOCUMENT }),
+      dispatch,
+      focus: vi.fn(),
+    } as unknown as EditorView;
+
+    revealCodeMirrorCursor(view, 2, 3, { flashLine: true });
+
+    const request = dispatch.mock.calls[0][0] as { effects: unknown };
+    expect(Array.isArray(request.effects)).toBe(true);
+  });
+
+  it("renders the destination line flash for a bounded interval", () => {
+    vi.useFakeTimers();
+    const parent = document.createElement("div");
+    document.body.append(parent);
+    const view = new CodeMirrorView({
+      parent,
+      state: EditorState.create({
+        doc: DOCUMENT,
+        extensions: [codeMirrorCursorFlashExtension],
+      }),
+    });
+
+    revealCodeMirrorCursor(view, 2, 3, { flashLine: true });
+    expect(parent.querySelector(`.${EDITOR_CONTENT_SEARCH_FLASH_CLASS}`)?.textContent).toBe(
+      "bravo",
+    );
+
+    vi.advanceTimersByTime(EDITOR_CONTENT_SEARCH_FLASH_DURATION_MS);
+    expect(parent.querySelector(`.${EDITOR_CONTENT_SEARCH_FLASH_CLASS}`)).toBeNull();
+    view.destroy();
+  });
+
+  it("restarts the flash without letting the older timer clear it", () => {
+    vi.useFakeTimers();
+    const parent = document.createElement("div");
+    document.body.append(parent);
+    const view = new CodeMirrorView({
+      parent,
+      state: EditorState.create({
+        doc: DOCUMENT,
+        extensions: [codeMirrorCursorFlashExtension],
+      }),
+    });
+
+    revealCodeMirrorCursor(view, 1, 1, { flashLine: true });
+    vi.advanceTimersByTime(EDITOR_CONTENT_SEARCH_FLASH_DURATION_MS / 2);
+    revealCodeMirrorCursor(view, 3, 1, { flashLine: true });
+    vi.advanceTimersByTime(EDITOR_CONTENT_SEARCH_FLASH_DURATION_MS / 2);
+    expect(parent.querySelector(`.${EDITOR_CONTENT_SEARCH_FLASH_CLASS}`)?.textContent).toBe(
+      "charlie",
+    );
+
+    vi.advanceTimersByTime(EDITOR_CONTENT_SEARCH_FLASH_DURATION_MS / 2);
+    expect(parent.querySelector(`.${EDITOR_CONTENT_SEARCH_FLASH_CLASS}`)).toBeNull();
+    view.destroy();
   });
 });

--- a/apps/web/components/editors/codemirror/codemirror-cursor-navigation.ts
+++ b/apps/web/components/editors/codemirror/codemirror-cursor-navigation.ts
@@ -1,6 +1,36 @@
-import type { Text } from "@codemirror/state";
-import { EditorView } from "@codemirror/view";
-import { consumePendingCursorPosition } from "@/hooks/file-editor-cursor";
+import { StateEffect, StateField, type Extension, type Text } from "@codemirror/state";
+import { Decoration, EditorView, type DecorationSet } from "@codemirror/view";
+import {
+  consumePendingCursorPosition,
+  EDITOR_CONTENT_SEARCH_FLASH_CLASS,
+  EDITOR_CONTENT_SEARCH_FLASH_DURATION_MS,
+  type CursorRevealOptions,
+} from "@/hooks/file-editor-cursor";
+
+const setCursorLineFlash = StateEffect.define<number | null>();
+const cursorLineFlashField = StateField.define<DecorationSet>({
+  create: () => Decoration.none,
+  update: (decorations, transaction) => {
+    let next = decorations.map(transaction.changes);
+    for (const effect of transaction.effects) {
+      if (!effect.is(setCursorLineFlash)) continue;
+      if (effect.value === null) return Decoration.none;
+      const line = transaction.state.doc.line(
+        clampOneBased(effect.value, transaction.state.doc.lines),
+      );
+      next = Decoration.set([
+        Decoration.line({ class: EDITOR_CONTENT_SEARCH_FLASH_CLASS }).range(line.from),
+      ]);
+    }
+    return next;
+  },
+  provide: (field) => EditorView.decorations.from(field),
+});
+
+export const codeMirrorCursorFlashExtension: Extension = cursorLineFlashField;
+
+type CodeMirrorCursorFlash = { timeout: ReturnType<typeof setTimeout> };
+const codeMirrorCursorFlashes = new WeakMap<EditorView, CodeMirrorCursorFlash>();
 
 function clampOneBased(value: number, maximum: number): number {
   const integer = Number.isNaN(value) ? 1 : Math.trunc(value);
@@ -13,12 +43,41 @@ export function getCodeMirrorCursorOffset(doc: Text, line: number, column: numbe
   return targetLine.from + targetColumn - 1;
 }
 
-export function revealCodeMirrorCursor(view: EditorView, line: number, column: number): boolean {
+function scheduleCodeMirrorCursorFlashCleanup(view: EditorView): void {
+  const previous = codeMirrorCursorFlashes.get(view);
+  if (previous) clearTimeout(previous.timeout);
+  const flash: CodeMirrorCursorFlash = {
+    timeout: setTimeout(() => {
+      if (codeMirrorCursorFlashes.get(view) !== flash) return;
+      view.dispatch({ effects: setCursorLineFlash.of(null) });
+      codeMirrorCursorFlashes.delete(view);
+    }, EDITOR_CONTENT_SEARCH_FLASH_DURATION_MS),
+  };
+  codeMirrorCursorFlashes.set(view, flash);
+}
+
+export function clearCodeMirrorCursorFlash(view: EditorView): void {
+  const flash = codeMirrorCursorFlashes.get(view);
+  if (!flash) return;
+  clearTimeout(flash.timeout);
+  view.dispatch({ effects: setCursorLineFlash.of(null) });
+  codeMirrorCursorFlashes.delete(view);
+}
+
+export function revealCodeMirrorCursor(
+  view: EditorView,
+  line: number,
+  column: number,
+  options: CursorRevealOptions = {},
+): boolean {
   const anchor = getCodeMirrorCursorOffset(view.state.doc, line, column);
+  const effects = [EditorView.scrollIntoView(anchor, { y: "center" })];
+  if (options.flashLine) effects.push(setCursorLineFlash.of(line));
   view.dispatch({
     selection: { anchor },
-    effects: EditorView.scrollIntoView(anchor, { y: "center" }),
+    effects,
   });
+  if (options.flashLine) scheduleCodeMirrorCursorFlashCleanup(view);
   view.focus();
   return true;
 }
@@ -31,5 +90,7 @@ export function revealPendingCodeMirrorCursor(
 ): boolean {
   const pending = consumePendingCursorPosition(path, repo, sessionId);
   if (!pending) return false;
-  return revealCodeMirrorCursor(view, pending.line, pending.column);
+  return revealCodeMirrorCursor(view, pending.line, pending.column, {
+    flashLine: pending.flashLine,
+  });
 }

--- a/apps/web/components/editors/monaco/monaco-code-editor.tsx
+++ b/apps/web/components/editors/monaco/monaco-code-editor.tsx
@@ -15,6 +15,7 @@ import { MonacoEditorToolbar } from "./monaco-editor-toolbar";
 import { useMonacoEditorComments } from "./use-monaco-editor-state";
 import { useMonacoEditorLsp, useMonacoDiffDecorations } from "./use-monaco-editor-lsp";
 import { useMonacoWalkthroughRange } from "./use-monaco-walkthrough-range";
+import { useMonacoCursorNavigation } from "./use-monaco-cursor-navigation";
 import { initMonacoThemes } from "./monaco-init";
 import { useTranslation } from "react-i18next";
 
@@ -150,6 +151,13 @@ function useMonacoCodeEditorSetup(props: MonacoCodeEditorProps) {
     contentRef,
     editorRef: state.editorRef,
     editorReady: state.editorInstance !== null,
+  });
+  useMonacoCursorNavigation({
+    editor: state.editorInstance,
+    path,
+    worktreePath,
+    repo,
+    sessionId,
   });
   const { diffStats } = useMonacoDiffDecorations({
     originalContent,

--- a/apps/web/components/editors/monaco/use-monaco-cursor-navigation.test.tsx
+++ b/apps/web/components/editors/monaco/use-monaco-cursor-navigation.test.tsx
@@ -1,0 +1,100 @@
+import { act, renderHook } from "@testing-library/react";
+import type { editor as monacoEditor } from "monaco-editor";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  consumePendingCursorPosition,
+  EDITOR_CONTENT_SEARCH_FLASH_DURATION_MS,
+  setPendingCursorPosition,
+} from "@/hooks/file-editor-cursor";
+import { useMonacoCursorNavigation } from "./use-monaco-cursor-navigation";
+
+const TARGET_PATH = "src/target.ts";
+const OTHER_PATH = "src/other.ts";
+const WORKTREE_PATH = "/worktree";
+
+function fileModel(path: string, id: string) {
+  const filePath = `${WORKTREE_PATH}/${path}`;
+  return {
+    id,
+    uri: {
+      path: filePath,
+      toString: () => `file://${filePath}`,
+    },
+  };
+}
+
+function createModelSwitchingEditor() {
+  let model = fileModel(OTHER_PATH, "other-model");
+  const modelListeners = new Set<() => void>();
+  const decorationCollections: Array<{
+    initial: monacoEditor.IModelDeltaDecoration[];
+    set: ReturnType<typeof vi.fn>;
+  }> = [];
+  const editor = {
+    createDecorationsCollection: vi.fn((initial: monacoEditor.IModelDeltaDecoration[]) => {
+      const collection = { initial, set: vi.fn() };
+      decorationCollections.push(collection);
+      return collection;
+    }),
+    focus: vi.fn(),
+    getModel: () => model,
+    layout: vi.fn(),
+    onDidChangeModel: (listener: () => void) => {
+      modelListeners.add(listener);
+      return { dispose: () => modelListeners.delete(listener) };
+    },
+    revealLineInCenter: vi.fn(),
+    setPosition: vi.fn(),
+  } as unknown as monacoEditor.IStandaloneCodeEditor;
+
+  return {
+    decorationCollections,
+    editor,
+    switchToTarget() {
+      model = fileModel(TARGET_PATH, "target-model");
+      for (const listener of modelListeners) listener();
+    },
+  };
+}
+
+afterEach(() => {
+  consumePendingCursorPosition(TARGET_PATH);
+  vi.useRealTimers();
+});
+
+describe("useMonacoCursorNavigation", () => {
+  it("reveals a flashed pending cursor after a cached Monaco model swap", () => {
+    vi.useFakeTimers();
+    const fake = createModelSwitchingEditor();
+    const { rerender } = renderHook(
+      ({ path }) =>
+        useMonacoCursorNavigation({
+          editor: fake.editor,
+          path,
+          worktreePath: WORKTREE_PATH,
+        }),
+      { initialProps: { path: OTHER_PATH } },
+    );
+    setPendingCursorPosition(TARGET_PATH, 180, 7, undefined, { flashLine: true });
+
+    rerender({ path: TARGET_PATH });
+    expect(fake.editor.setPosition).not.toHaveBeenCalled();
+    act(() => fake.switchToTarget());
+
+    expect(fake.editor.setPosition).toHaveBeenCalledWith({ lineNumber: 180, column: 7 });
+    expect(fake.editor.revealLineInCenter).toHaveBeenCalledWith(180);
+    expect(fake.decorationCollections[0].initial).toEqual([
+      expect.objectContaining({
+        range: expect.objectContaining({ startLineNumber: 180, endLineNumber: 180 }),
+        options: expect.objectContaining({
+          isWholeLine: true,
+          className: "editor-content-search-flash",
+        }),
+      }),
+    ]);
+    expect(consumePendingCursorPosition(TARGET_PATH)).toBeUndefined();
+
+    act(() => vi.advanceTimersByTime(EDITOR_CONTENT_SEARCH_FLASH_DURATION_MS));
+    expect(fake.decorationCollections[0].set).toHaveBeenLastCalledWith([]);
+  });
+});

--- a/apps/web/components/editors/monaco/use-monaco-cursor-navigation.test.tsx
+++ b/apps/web/components/editors/monaco/use-monaco-cursor-navigation.test.tsx
@@ -81,6 +81,7 @@ describe("useMonacoCursorNavigation", () => {
     expect(fake.editor.setPosition).not.toHaveBeenCalled();
     act(() => fake.switchToTarget());
 
+    expect(fake.editor.layout).toHaveBeenCalledTimes(1);
     expect(fake.editor.setPosition).toHaveBeenCalledWith({ lineNumber: 180, column: 7 });
     expect(fake.editor.revealLineInCenter).toHaveBeenCalledWith(180);
     expect(fake.decorationCollections[0].initial).toEqual([

--- a/apps/web/components/editors/monaco/use-monaco-cursor-navigation.ts
+++ b/apps/web/components/editors/monaco/use-monaco-cursor-navigation.ts
@@ -1,0 +1,61 @@
+import { useCallback, useEffect, useSyncExternalStore } from "react";
+import type { editor as monacoEditor } from "monaco-editor";
+import {
+  clearMonacoCursorFlash,
+  consumePendingCursorPosition,
+  monacoEditorMatchesFile,
+  revealMonacoEditor,
+} from "@/hooks/file-editor-cursor";
+
+type UseMonacoCursorNavigationOptions = {
+  editor: monacoEditor.IStandaloneCodeEditor | null;
+  path: string;
+  worktreePath?: string;
+  repo?: string;
+  sessionId?: string;
+};
+
+function useMonacoModelSnapshot(editor: monacoEditor.IStandaloneCodeEditor | null): string {
+  const subscribe = useCallback(
+    (onStoreChange: () => void) => {
+      if (!editor) return () => {};
+      const subscription = editor.onDidChangeModel(() => {
+        clearMonacoCursorFlash(editor);
+        onStoreChange();
+      });
+      return () => subscription.dispose();
+    },
+    [editor],
+  );
+  const getSnapshot = useCallback(() => {
+    const model = editor?.getModel();
+    return model ? `${model.id}:${model.uri.toString()}` : "";
+  }, [editor]);
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}
+
+export function useMonacoCursorNavigation({
+  editor,
+  path,
+  worktreePath,
+  repo,
+  sessionId,
+}: UseMonacoCursorNavigationOptions): void {
+  const modelSnapshot = useMonacoModelSnapshot(editor);
+
+  useEffect(() => {
+    if (
+      !editor ||
+      !monacoEditorMatchesFile(editor, path, worktreePath ?? null, { repo, sessionId })
+    ) {
+      return;
+    }
+    const pending = consumePendingCursorPosition(path, repo, sessionId);
+    if (pending) revealMonacoEditor(editor, pending);
+  }, [editor, modelSnapshot, path, repo, sessionId, worktreePath]);
+
+  useEffect(() => {
+    if (!editor) return;
+    return () => clearMonacoCursorFlash(editor);
+  }, [editor]);
+}

--- a/apps/web/components/editors/monaco/use-monaco-editor-state.ts
+++ b/apps/web/components/editors/monaco/use-monaco-editor-state.ts
@@ -9,7 +9,6 @@ import { useAppStore } from "@/components/state-provider";
 import { useToast } from "@/components/toast-provider";
 import { useCommandPanelOpen } from "@/lib/commands/command-registry";
 import { useGutterComments } from "@/hooks/use-gutter-comments";
-import { consumePendingCursorPosition } from "@/hooks/use-file-editors";
 import type { DiffComment } from "@/lib/diff/types";
 import { useTranslation } from "react-i18next";
 
@@ -112,11 +111,6 @@ export function useMonacoEditorComments(opts: UseMonacoEditorStateOpts) {
       setEditorInstance(editor);
       decorationsRef.current = editor.createDecorationsCollection([]);
       diffDecorationsRef.current = editor.createDecorationsCollection([]);
-      const pendingPos = consumePendingCursorPosition(path, repo, sessionId);
-      if (pendingPos) {
-        editor.setPosition({ lineNumber: pendingPos.line, column: pendingPos.column });
-        editor.revealLineInCenter(pendingPos.line);
-      }
       if (enableComments && sessionId) {
         disposablesRef.current.push(
           editor.onDidChangeCursorSelection(() => {

--- a/apps/web/components/task/file-viewer-content.test.tsx
+++ b/apps/web/components/task/file-viewer-content.test.tsx
@@ -1,8 +1,10 @@
 import { act, render } from "@testing-library/react";
 import type { EditorView } from "@codemirror/view";
-import { describe, expect, it, vi } from "vitest";
+import { useLayoutEffect } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 const editorHarness = vi.hoisted(() => ({
+  autoCreateView: null as EditorView | null,
   extensions: [] as unknown[],
   onCreateEditor: null as ((view: EditorView) => void) | null,
 }));
@@ -20,6 +22,9 @@ vi.mock("@uiw/react-codemirror", () => ({
   }) => {
     editorHarness.extensions = extensions;
     editorHarness.onCreateEditor = onCreateEditor;
+    useLayoutEffect(() => {
+      if (editorHarness.autoCreateView) onCreateEditor(editorHarness.autoCreateView);
+    }, [onCreateEditor]);
     return <div data-testid="file-viewer-codemirror" />;
   },
 }));
@@ -44,6 +49,11 @@ vi.mock("@/hooks/use-file-editors", () => ({
 
 import { FileViewerContent } from "./file-viewer-content";
 
+afterEach(() => {
+  editorHarness.autoCreateView = null;
+  vi.clearAllMocks();
+});
+
 describe("FileViewerContent cursor navigation", () => {
   it("uses shared CodeMirror reveal behavior on mount and reused path changes", () => {
     const view = {} as EditorView;
@@ -64,6 +74,7 @@ describe("FileViewerContent cursor navigation", () => {
       "frontend",
       "session-1",
     );
+    expect(revealPendingCodeMirrorCursor).toHaveBeenCalledTimes(1);
 
     rendered.rerender(
       <FileViewerContent
@@ -80,5 +91,21 @@ describe("FileViewerContent cursor navigation", () => {
       "frontend",
       "session-1",
     );
+  });
+
+  it("consumes the initial pending reveal once when CodeMirror creates in a layout effect", () => {
+    const view = {} as EditorView;
+    editorHarness.autoCreateView = view;
+
+    render(
+      <FileViewerContent
+        path="src/first.ts"
+        content="first"
+        repo="frontend"
+        sessionId="session-1"
+      />,
+    );
+
+    expect(revealPendingCodeMirrorCursor).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/components/task/file-viewer-content.test.tsx
+++ b/apps/web/components/task/file-viewer-content.test.tsx
@@ -1,0 +1,84 @@
+import { act, render } from "@testing-library/react";
+import type { EditorView } from "@codemirror/view";
+import { describe, expect, it, vi } from "vitest";
+
+const editorHarness = vi.hoisted(() => ({
+  extensions: [] as unknown[],
+  onCreateEditor: null as ((view: EditorView) => void) | null,
+}));
+const revealPendingCodeMirrorCursor = vi.hoisted(() => vi.fn());
+const clearCodeMirrorCursorFlash = vi.hoisted(() => vi.fn());
+const codeMirrorCursorFlashExtension = vi.hoisted(() => ({}));
+
+vi.mock("@uiw/react-codemirror", () => ({
+  default: ({
+    extensions,
+    onCreateEditor,
+  }: {
+    extensions: unknown[];
+    onCreateEditor: (view: EditorView) => void;
+  }) => {
+    editorHarness.extensions = extensions;
+    editorHarness.onCreateEditor = onCreateEditor;
+    return <div data-testid="file-viewer-codemirror" />;
+  },
+}));
+
+vi.mock("@/lib/languages", () => ({
+  getCodeMirrorExtensionFromPath: () => null,
+}));
+
+vi.mock("@/components/editors/codemirror/use-codemirror-walkthrough-range", () => ({
+  useCodeMirrorWalkthroughRange: () => null,
+}));
+
+vi.mock("@/components/editors/codemirror/codemirror-cursor-navigation", () => ({
+  clearCodeMirrorCursorFlash,
+  codeMirrorCursorFlashExtension,
+  revealPendingCodeMirrorCursor,
+}));
+
+vi.mock("@/hooks/use-file-editors", () => ({
+  consumePendingCursorPosition: () => undefined,
+}));
+
+import { FileViewerContent } from "./file-viewer-content";
+
+describe("FileViewerContent cursor navigation", () => {
+  it("uses shared CodeMirror reveal behavior on mount and reused path changes", () => {
+    const view = {} as EditorView;
+    const rendered = render(
+      <FileViewerContent
+        path="src/first.ts"
+        content="first"
+        repo="frontend"
+        sessionId="session-1"
+      />,
+    );
+
+    act(() => editorHarness.onCreateEditor?.(view));
+    expect(editorHarness.extensions).toContain(codeMirrorCursorFlashExtension);
+    expect(revealPendingCodeMirrorCursor).toHaveBeenLastCalledWith(
+      view,
+      "src/first.ts",
+      "frontend",
+      "session-1",
+    );
+
+    rendered.rerender(
+      <FileViewerContent
+        path="src/second.ts"
+        content="second"
+        repo="frontend"
+        sessionId="session-1"
+      />,
+    );
+    expect(clearCodeMirrorCursorFlash).toHaveBeenLastCalledWith(view);
+    expect(revealPendingCodeMirrorCursor).toHaveBeenLastCalledWith(
+      view,
+      "src/second.ts",
+      "frontend",
+      "session-1",
+    );
+  });
+});

--- a/apps/web/components/task/file-viewer-content.tsx
+++ b/apps/web/components/task/file-viewer-content.tsx
@@ -6,8 +6,12 @@ import { vscodeDark } from "@uiw/codemirror-theme-vscode";
 import { EditorView } from "@codemirror/view";
 import type { Extension } from "@codemirror/state";
 import { getCodeMirrorExtensionFromPath } from "@/lib/languages";
-import { consumePendingCursorPosition } from "@/hooks/use-file-editors";
 import { useCodeMirrorWalkthroughRange } from "@/components/editors/codemirror/use-codemirror-walkthrough-range";
+import {
+  clearCodeMirrorCursorFlash,
+  codeMirrorCursorFlashExtension,
+  revealPendingCodeMirrorCursor,
+} from "@/components/editors/codemirror/codemirror-cursor-navigation";
 import { cn } from "@/lib/utils";
 
 type FileViewerContentProps = {
@@ -26,12 +30,17 @@ export function FileViewerContent({
   className,
 }: FileViewerContentProps) {
   const langExt = getCodeMirrorExtensionFromPath(path);
-  const extensions: Extension[] = [EditorView.lineWrapping, EditorView.editable.of(false)];
+  const extensions: Extension[] = [
+    EditorView.lineWrapping,
+    EditorView.editable.of(false),
+    codeMirrorCursorFlashExtension,
+  ];
   if (langExt) {
     extensions.push(langExt);
   }
 
   const viewRef = useRef<EditorView | null>(null);
+  const fileIdentityRef = useRef({ path, repo, sessionId });
   const [editorView, setEditorView] = useState<EditorView | null>(null);
   const areaRef = useRef<HTMLDivElement>(null);
   const walkthroughRange = useCodeMirrorWalkthroughRange({
@@ -41,33 +50,13 @@ export function FileViewerContent({
     repo,
   });
 
-  // Consume a pending cursor position (set by chat read/edit file links before
-  // they open the file) and scroll CodeMirror so the target 1-based line is
-  // centered. No pending entry → no scroll, so normal file browsing stays at
-  // the top. Desktop's Monaco consumes the same entry; on mobile there is no
-  // Monaco, so this CodeMirror viewer must consume it instead.
-  const scrollToPendingLine = useCallback(
-    (view: EditorView, filePath: string) => {
-      const pending = consumePendingCursorPosition(filePath, repo, sessionId);
-      if (!pending) return;
-      const totalLines = view.state.doc.lines;
-      const clampedLine = Math.min(Math.max(pending.line, 1), totalLines);
-      const pos = view.state.doc.line(clampedLine).from;
-      view.dispatch({
-        selection: { anchor: pos },
-        effects: EditorView.scrollIntoView(pos, { y: "center" }),
-      });
-    },
-    [repo, sessionId],
-  );
-
   const handleCreateEditor = useCallback(
     (view: EditorView) => {
       viewRef.current = view;
       setEditorView(view);
-      scrollToPendingLine(view, path);
+      revealPendingCodeMirrorCursor(view, path, repo, sessionId);
     },
-    [path, scrollToPendingLine],
+    [path, repo, sessionId],
   );
 
   // The same FileViewerContent instance is reused when switching files (the
@@ -75,10 +64,20 @@ export function FileViewerContent({
   // the editor already mounted. Re-consume + scroll whenever path changes and
   // the EditorView exists, so the second open of a different file still jumps.
   useEffect(() => {
-    if (viewRef.current) {
-      scrollToPendingLine(viewRef.current, path);
-    }
-  }, [path, scrollToPendingLine]);
+    const view = viewRef.current;
+    const previous = fileIdentityRef.current;
+    const fileChanged =
+      previous.path !== path || previous.repo !== repo || previous.sessionId !== sessionId;
+    fileIdentityRef.current = { path, repo, sessionId };
+    if (!view) return;
+    if (fileChanged) clearCodeMirrorCursorFlash(view);
+    revealPendingCodeMirrorCursor(view, path, repo, sessionId);
+  }, [path, repo, sessionId]);
+
+  useEffect(() => {
+    if (!editorView) return;
+    return () => clearCodeMirrorCursorFlash(editorView);
+  }, [editorView]);
 
   return (
     <div ref={areaRef} className={cn("relative h-full overflow-hidden", className)}>

--- a/apps/web/components/task/file-viewer-content.tsx
+++ b/apps/web/components/task/file-viewer-content.tsx
@@ -69,8 +69,8 @@ export function FileViewerContent({
     const fileChanged =
       previous.path !== path || previous.repo !== repo || previous.sessionId !== sessionId;
     fileIdentityRef.current = { path, repo, sessionId };
-    if (!view) return;
-    if (fileChanged) clearCodeMirrorCursorFlash(view);
+    if (!view || !fileChanged) return;
+    clearCodeMirrorCursorFlash(view);
     revealPendingCodeMirrorCursor(view, path, repo, sessionId);
   }, [path, repo, sessionId]);
 

--- a/apps/web/e2e/tests/search/task-workspace-content-search.spec.ts
+++ b/apps/web/e2e/tests/search/task-workspace-content-search.spec.ts
@@ -10,7 +10,10 @@ import { dwell } from "../../helpers/causal-waits";
 
 const SEARCH_TERM = "TaskWorkspaceNeedle";
 const EXTRA_REPOSITORY_NAME = "content-search-extra";
-const TARGET_LINE = 9;
+const TARGET_LINE = 180;
+const CACHED_PREVIEW_TARGET_LINE = 180;
+const CACHED_PREVIEW_MARKER = "CACHED_PREVIEW_CONTENT_MATCH";
+const PREVIEW_REPLACEMENT_MARKER = "PREVIEW_REPLACEMENT_FILE";
 
 function fileContent(marker: string, targetLine: number): string {
   const lines = Array.from(
@@ -221,20 +224,159 @@ test("@search searches all task repositories and opens the selected match", asyn
     .poll(
       () =>
         testPage.evaluate((marker) => {
+          type Model = {
+            getAllDecorations: () => Array<{ options: { className?: string } }>;
+            getValue: () => string;
+          };
           type Editor = {
-            getModel: () => { getValue: () => string } | null;
+            getModel: () => Model | null;
             getPosition: () => { lineNumber: number } | null;
+            getVisibleRanges: () => Array<{ startLineNumber: number; endLineNumber: number }>;
           };
           type MonacoWindow = Window & {
             monaco?: { editor: { getEditors: () => Editor[] } };
           };
-          const editors = (window as MonacoWindow).monaco?.editor.getEditors() ?? [];
-          return (
-            editors.find((editor) => editor.getModel()?.getValue().includes(marker))?.getPosition()
-              ?.lineNumber ?? null
+          const editor = ((window as MonacoWindow).monaco?.editor.getEditors() ?? []).find(
+            (candidate) => candidate.getModel()?.getValue().includes(marker),
           );
+          const line = editor?.getPosition()?.lineNumber ?? null;
+          return {
+            line,
+            visible:
+              line !== null &&
+              (editor?.getVisibleRanges() ?? []).some(
+                (range) => line >= range.startLineNumber && line <= range.endLineNumber,
+              ),
+            flash:
+              editor
+                ?.getModel()
+                ?.getAllDecorations()
+                .some(
+                  (decoration) => decoration.options.className === "editor-content-search-flash",
+                ) ?? false,
+          };
         }, "EXTRA_REPOSITORY_MATCH"),
       { timeout: 10_000 },
     )
-    .toBe(TARGET_LINE);
+    .toEqual({ line: TARGET_LINE, visible: true, flash: true });
+});
+
+test("@search reveals and flashes a cached preview content match selected with Enter", async ({
+  testPage,
+  apiClient,
+  seedData,
+  backend,
+}) => {
+  test.setTimeout(120_000);
+
+  const suffix = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const targetPath = `src/cached-content-target-${suffix}.ts`;
+  const replacementPath = `src/cached-content-replacement-${suffix}.ts`;
+  const gitEnv = makeGitEnv(backend.tmpDir);
+  const primaryGit = new GitHelper(path.join(backend.tmpDir, "repos", "e2e-repo"), gitEnv);
+  primaryGit.createFile(targetPath, fileContent(CACHED_PREVIEW_MARKER, CACHED_PREVIEW_TARGET_LINE));
+  primaryGit.createFile(replacementPath, `export const ${PREVIEW_REPLACEMENT_MARKER} = true;\n`);
+  primaryGit.stageAll();
+  primaryGit.commit("seed cached preview content search");
+
+  const task = await apiClient.createTaskWithAgent(
+    seedData.workspaceId,
+    "Cached preview workspace content search",
+    seedData.agentProfileId,
+    {
+      description: "/e2e:simple-message",
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+      repository_ids: [seedData.repositoryId],
+      executor_profile_id: seedData.worktreeExecutorProfileId,
+    },
+  );
+
+  await testPage.goto(`/t/${task.id}`);
+  const session = new SessionPage(testPage);
+  await session.waitForLoad();
+  await session.waitForChatIdle({ timeout: 30_000 });
+
+  const openFileFromPalette = async (filePath: string, marker: string) => {
+    await testPage.keyboard.press(`${MODIFIER}+Shift+k`);
+    const dialog = testPage.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+    const input = dialog.getByRole("combobox");
+    const fileName = path.basename(filePath);
+    await input.fill(fileName);
+    await expect(dialog.locator("[cmdk-item]").filter({ hasText: fileName })).toHaveCount(1);
+    await testPage.keyboard.press("Enter");
+    await expect(dialog).not.toBeVisible();
+    await expect
+      .poll(() =>
+        testPage.evaluate((expectedMarker) => {
+          type Editor = { getModel: () => { getValue: () => string } | null };
+          type MonacoWindow = Window & {
+            monaco?: { editor: { getEditors: () => Editor[] } };
+          };
+          return ((window as MonacoWindow).monaco?.editor.getEditors() ?? []).some((editor) =>
+            editor.getModel()?.getValue().includes(expectedMarker),
+          );
+        }, marker),
+      )
+      .toBe(true);
+  };
+
+  // Warm the target model, then reuse the shared preview for another cached file.
+  await openFileFromPalette(targetPath, CACHED_PREVIEW_MARKER);
+  await openFileFromPalette(replacementPath, PREVIEW_REPLACEMENT_MARKER);
+
+  await testPage.keyboard.press(`${MODIFIER}+Shift+f`);
+  const dialog = testPage.getByRole("dialog");
+  await expect(dialog).toBeVisible();
+  await dialog.getByRole("combobox").fill(CACHED_PREVIEW_MARKER);
+  const targetResult = dialog.getByTestId("content-search-result").filter({ hasText: targetPath });
+  await expect(targetResult).toHaveCount(1);
+  await testPage.keyboard.press("Enter");
+  await expect(dialog).not.toBeVisible();
+
+  const revealState = () =>
+    testPage.evaluate((expectedMarker) => {
+      type Model = {
+        getAllDecorations: () => Array<{ options: { className?: string } }>;
+        getValue: () => string;
+      };
+      type Editor = {
+        getModel: () => Model | null;
+        getPosition: () => { lineNumber: number } | null;
+        getVisibleRanges: () => Array<{ startLineNumber: number; endLineNumber: number }>;
+      };
+      type MonacoWindow = Window & {
+        monaco?: { editor: { getEditors: () => Editor[] } };
+      };
+      const editor = ((window as MonacoWindow).monaco?.editor.getEditors() ?? []).find(
+        (candidate) => candidate.getModel()?.getValue().includes(expectedMarker),
+      );
+      const line = editor?.getPosition()?.lineNumber ?? null;
+      return {
+        line,
+        visible:
+          line !== null &&
+          (editor?.getVisibleRanges() ?? []).some(
+            (range) => line >= range.startLineNumber && line <= range.endLineNumber,
+          ),
+        flash:
+          editor
+            ?.getModel()
+            ?.getAllDecorations()
+            .some((decoration) => decoration.options.className === "editor-content-search-flash") ??
+          false,
+      };
+    }, CACHED_PREVIEW_MARKER);
+
+  await expect.poll(revealState).toEqual({
+    line: CACHED_PREVIEW_TARGET_LINE,
+    visible: true,
+    flash: true,
+  });
+  await expect.poll(revealState).toEqual({
+    line: CACHED_PREVIEW_TARGET_LINE,
+    visible: true,
+    flash: false,
+  });
 });

--- a/apps/web/hooks/file-editor-cursor.ts
+++ b/apps/web/hooks/file-editor-cursor.ts
@@ -11,12 +11,25 @@ import {
   parseSessionModelUri,
 } from "@/lib/lsp/file-uri";
 
-type CursorPosition = { line: number; column: number };
-type CodeMirrorCursorRevealer = (line: number, column: number) => boolean;
+export type CursorPosition = { line: number; column: number; flashLine?: boolean };
+export type CursorRevealOptions = { sessionId?: string; flashLine?: boolean };
+type CodeMirrorCursorRevealer = (
+  line: number,
+  column: number,
+  options: CursorRevealOptions,
+) => boolean;
 type MonacoInstance = NonNullable<ReturnType<typeof getMonacoInstance>>;
 type MountedMonacoEditor = ReturnType<MonacoInstance["editor"]["getEditors"]>[number];
+type MonacoCursorFlash = {
+  collection: ReturnType<MountedMonacoEditor["createDecorationsCollection"]>;
+  timeout: ReturnType<typeof setTimeout>;
+};
+
+export const EDITOR_CONTENT_SEARCH_FLASH_CLASS = "editor-content-search-flash";
+export const EDITOR_CONTENT_SEARCH_FLASH_DURATION_MS = 1_200;
 
 const pendingCursorPositions = new Map<string, CursorPosition>();
+const monacoCursorFlashes = new WeakMap<MountedMonacoEditor, MonacoCursorFlash>();
 const codeMirrorCursorRevealers = new Map<
   string,
   Map<string | undefined, Set<CodeMirrorCursorRevealer>>
@@ -38,9 +51,17 @@ export function setPendingCursorPosition(
   line: number,
   column: number,
   repo?: string,
-  sessionId?: string,
+  sessionIdOrOptions?: string | CursorRevealOptions,
 ) {
-  pendingCursorPositions.set(pendingCursorKey(path, repo, sessionId), { line, column });
+  const options =
+    typeof sessionIdOrOptions === "string"
+      ? { sessionId: sessionIdOrOptions }
+      : (sessionIdOrOptions ?? {});
+  pendingCursorPositions.set(pendingCursorKey(path, repo, options.sessionId), {
+    line,
+    column,
+    ...(options.flashLine ? { flashLine: true } : {}),
+  });
 }
 
 export function consumePendingCursorPosition(
@@ -75,12 +96,11 @@ export function registerCodeMirrorCursorRevealer(
 
 function runCodeMirrorRevealers(
   revealers: Set<CodeMirrorCursorRevealer> | undefined,
-  line: number,
-  column: number,
+  target: CursorPosition,
 ): boolean {
   if (!revealers) return false;
   for (const reveal of [...revealers].reverse()) {
-    if (reveal(line, column)) return true;
+    if (reveal(target.line, target.column, { flashLine: target.flashLine })) return true;
   }
   return false;
 }
@@ -89,12 +109,11 @@ function revealMountedCodeMirror(
   path: string,
   repo: string | undefined,
   sessionId: string | undefined,
-  line: number,
-  column: number,
+  target: CursorPosition,
 ): boolean {
   const revealersBySession = codeMirrorCursorRevealers.get(buildRepoScopedItemId(path, repo));
   if (!revealersBySession) return false;
-  if (runCodeMirrorRevealers(revealersBySession.get(sessionId), line, column)) {
+  if (runCodeMirrorRevealers(revealersBySession.get(sessionId), target)) {
     consumePendingCursorPosition(path, repo, sessionId);
     return true;
   }
@@ -103,10 +122,7 @@ function revealMountedCodeMirror(
   const scopedRevealerSets = [...revealersBySession.entries()]
     .filter(([registeredSessionId]) => registeredSessionId !== undefined)
     .map(([, revealers]) => revealers);
-  if (
-    scopedRevealerSets.length !== 1 ||
-    !runCodeMirrorRevealers(scopedRevealerSets[0], line, column)
-  ) {
+  if (scopedRevealerSets.length !== 1 || !runCodeMirrorRevealers(scopedRevealerSets[0], target)) {
     return false;
   }
   consumePendingCursorPosition(path, repo);
@@ -133,7 +149,7 @@ function editorModelMatches(modelPath: string, monacoPath: string, path: string,
   return exactMatch || walkthroughFileMatches(modelPath, path);
 }
 
-type EditorFileScope = { repo?: string; sessionId?: string };
+export type EditorFileScope = { repo?: string } & CursorRevealOptions;
 
 type ModelMatchContext = EditorFileScope & {
   targetUri: string | null;
@@ -180,9 +196,44 @@ function sessionModelMatchesTarget(documentUri: string, context: ModelMatchConte
   );
 }
 
-function revealMonacoEditor(editor: MountedMonacoEditor, line: number, column: number) {
-  editor.setPosition({ lineNumber: line, column });
-  editor.revealLineInCenter(line);
+export function clearMonacoCursorFlash(editor: MountedMonacoEditor): void {
+  const flash = monacoCursorFlashes.get(editor);
+  if (!flash) return;
+  clearTimeout(flash.timeout);
+  flash.collection.set([]);
+  monacoCursorFlashes.delete(editor);
+}
+
+function flashMonacoEditorLine(editor: MountedMonacoEditor, line: number): void {
+  clearMonacoCursorFlash(editor);
+  const collection = editor.createDecorationsCollection([
+    {
+      range: { startLineNumber: line, startColumn: 1, endLineNumber: line, endColumn: 1 },
+      options: {
+        isWholeLine: true,
+        className: EDITOR_CONTENT_SEARCH_FLASH_CLASS,
+      },
+    },
+  ]);
+  const flash: MonacoCursorFlash = {
+    collection,
+    timeout: setTimeout(() => {
+      if (monacoCursorFlashes.get(editor) !== flash) return;
+      collection.set([]);
+      monacoCursorFlashes.delete(editor);
+    }, EDITOR_CONTENT_SEARCH_FLASH_DURATION_MS),
+  };
+  monacoCursorFlashes.set(editor, flash);
+}
+
+export function revealMonacoEditor(editor: MountedMonacoEditor, target: CursorPosition): void {
+  // A fresh Dockview panel can mount Monaco before automaticLayout has measured
+  // the newly active container. Centering against that stale zero-size layout
+  // updates the cursor but leaves the viewport at the top of the file.
+  editor.layout();
+  editor.setPosition({ lineNumber: target.line, column: target.column });
+  editor.revealLineInCenter(target.line);
+  if (target.flashLine) flashMonacoEditorLine(editor, target.line);
   editor.focus();
 }
 
@@ -198,6 +249,32 @@ function targetUriForPath(
   } catch {
     return null;
   }
+}
+
+function modelMatchContext(
+  path: string,
+  worktreePath: string | null,
+  scope: EditorFileScope,
+): ModelMatchContext {
+  const { repo } = scope;
+  return {
+    targetUri: targetUriForPath(worktreePath, repo, path),
+    monacoPath: worktreePath ? `${worktreePath}/${repo ? `${repo}/` : ""}${path}` : path,
+    path,
+    ...scope,
+  };
+}
+
+export function monacoEditorMatchesFile(
+  editor: MountedMonacoEditor,
+  path: string,
+  worktreePath: string | null,
+  scope: EditorFileScope = {},
+): boolean {
+  const model = editor.getModel();
+  return (
+    model !== null && editorModelMatchesTarget(model, modelMatchContext(path, worktreePath, scope))
+  );
 }
 
 function findMountedMonacoEditor(
@@ -230,16 +307,11 @@ function revealMountedMonaco(
   const monaco = getMonacoInstance();
   if (!monaco) return false;
   const { repo } = scope;
-  const context = {
-    targetUri: targetUriForPath(worktreePath, repo, path),
-    monacoPath: worktreePath ? `${worktreePath}/${repo ? `${repo}/` : ""}${path}` : path,
-    path,
-    ...scope,
-  };
+  const context = modelMatchContext(path, worktreePath, scope);
   const editor = findMountedMonacoEditor(monaco.editor.getEditors(), context);
   if (!editor) return false;
   consumePendingCursorPosition(path, repo, scope.sessionId);
-  revealMonacoEditor(editor, line, column);
+  revealMonacoEditor(editor, { line, column, flashLine: scope.flashLine });
   return true;
 }
 
@@ -251,5 +323,9 @@ export function scrollEditorIfMounted(
   scope: EditorFileScope = {},
 ): boolean {
   if (revealMountedMonaco(path, worktreePath, line, column, scope)) return true;
-  return revealMountedCodeMirror(path, scope.repo, scope.sessionId, line, column);
+  return revealMountedCodeMirror(path, scope.repo, scope.sessionId, {
+    line,
+    column,
+    flashLine: scope.flashLine,
+  });
 }

--- a/apps/web/hooks/file-editor-cursor.ts
+++ b/apps/web/hooks/file-editor-cursor.ts
@@ -230,7 +230,7 @@ export function revealMonacoEditor(editor: MountedMonacoEditor, target: CursorPo
   // A fresh Dockview panel can mount Monaco before automaticLayout has measured
   // the newly active container. Centering against that stale zero-size layout
   // updates the cursor but leaves the viewport at the top of the file.
-  editor.layout();
+  if (target.flashLine) editor.layout();
   editor.setPosition({ lineNumber: target.line, column: target.column });
   editor.revealLineInCenter(target.line);
   if (target.flashLine) flashMonacoEditorLine(editor, target.line);

--- a/apps/web/hooks/use-file-editors.test.tsx
+++ b/apps/web/hooks/use-file-editors.test.tsx
@@ -24,6 +24,7 @@ import {
   setPendingCursorPosition,
   useOpenFileAtLine,
 } from "./use-file-editors";
+import { EDITOR_CONTENT_SEARCH_FLASH_DURATION_MS } from "./file-editor-cursor";
 
 function createEditor(modelPath: string | null, modelUri?: string) {
   return {
@@ -37,20 +38,22 @@ function createEditor(modelPath: string | null, modelUri?: string) {
           }
         : null,
     ),
+    layout: vi.fn(),
     setPosition: vi.fn(),
     revealLineInCenter: vi.fn(),
     focus: vi.fn(),
   };
 }
 
-describe("scrollEditorIfMounted", () => {
-  afterEach(() => {
-    getMonacoInstance.mockReset();
-    consumePendingCursorPosition(APP_PATH);
-    consumePendingCursorPosition(APP_PATH, REPO);
-    consumePendingCursorPosition(MISSING_PATH);
-  });
+afterEach(() => {
+  getMonacoInstance.mockReset();
+  consumePendingCursorPosition(APP_PATH);
+  consumePendingCursorPosition(APP_PATH, REPO);
+  consumePendingCursorPosition(MISSING_PATH);
+  vi.useRealTimers();
+});
 
+describe("scrollEditorIfMounted", () => {
   it("scrolls the mounted Monaco editor that matches the worktree path", () => {
     const editor = createEditor(WORKTREE_APP_PATH);
     getMonacoInstance.mockReturnValue({ editor: { getEditors: () => [editor] } });
@@ -63,7 +66,61 @@ describe("scrollEditorIfMounted", () => {
     expect(editor.focus).toHaveBeenCalledTimes(1);
     expect(consumePendingCursorPosition(APP_PATH)).toBeUndefined();
   });
+});
 
+describe("scrollEditorIfMounted flashes", () => {
+  it("adds a one-shot whole-line decoration for a flashed reveal", () => {
+    const editor = {
+      ...createEditor(WORKTREE_APP_PATH),
+      createDecorationsCollection: vi.fn(() => ({ set: vi.fn() })),
+    };
+    getMonacoInstance.mockReturnValue({ editor: { getEditors: () => [editor] } });
+    setPendingCursorPosition(APP_PATH, 42, 3);
+
+    expect(
+      scrollEditorIfMounted(APP_PATH, WORKTREE_PATH, 42, 3, {
+        flashLine: true,
+      }),
+    ).toBe(true);
+
+    expect(editor.createDecorationsCollection).toHaveBeenCalledWith([
+      expect.objectContaining({
+        range: expect.objectContaining({ startLineNumber: 42, endLineNumber: 42 }),
+        options: expect.objectContaining({
+          isWholeLine: true,
+          className: "editor-content-search-flash",
+        }),
+      }),
+    ]);
+  });
+
+  it("keeps a restarted Monaco flash until the latest request expires", () => {
+    vi.useFakeTimers();
+    const collections = [vi.fn(), vi.fn()];
+    const editor = {
+      ...createEditor(WORKTREE_APP_PATH),
+      createDecorationsCollection: vi
+        .fn()
+        .mockImplementationOnce(() => ({ set: collections[0] }))
+        .mockImplementationOnce(() => ({ set: collections[1] })),
+    };
+    getMonacoInstance.mockReturnValue({ editor: { getEditors: () => [editor] } });
+
+    scrollEditorIfMounted(APP_PATH, WORKTREE_PATH, 42, 3, { flashLine: true });
+    vi.advanceTimersByTime(EDITOR_CONTENT_SEARCH_FLASH_DURATION_MS / 2);
+    scrollEditorIfMounted(APP_PATH, WORKTREE_PATH, 43, 1, { flashLine: true });
+    vi.advanceTimersByTime(EDITOR_CONTENT_SEARCH_FLASH_DURATION_MS / 2);
+
+    expect(editor.createDecorationsCollection).toHaveBeenCalledTimes(2);
+    expect(collections[0]).toHaveBeenLastCalledWith([]);
+    expect(collections[1]).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(EDITOR_CONTENT_SEARCH_FLASH_DURATION_MS / 2);
+    expect(collections[1]).toHaveBeenLastCalledWith([]);
+  });
+});
+
+describe("scrollEditorIfMounted matching", () => {
   it("falls back to a path-segment suffix match when the worktree path is unknown", () => {
     const editor = createEditor(WORKTREE_APP_PATH);
     getMonacoInstance.mockReturnValue({ editor: { getEditors: () => [editor] } });

--- a/apps/web/hooks/use-file-editors.test.tsx
+++ b/apps/web/hooks/use-file-editors.test.tsx
@@ -63,6 +63,7 @@ describe("scrollEditorIfMounted", () => {
 
     expect(editor.setPosition).toHaveBeenCalledWith({ lineNumber: 42, column: 3 });
     expect(editor.revealLineInCenter).toHaveBeenCalledWith(42);
+    expect(editor.layout).not.toHaveBeenCalled();
     expect(editor.focus).toHaveBeenCalledTimes(1);
     expect(consumePendingCursorPosition(APP_PATH)).toBeUndefined();
   });

--- a/apps/web/lib/commands/content-search-selection.test.ts
+++ b/apps/web/lib/commands/content-search-selection.test.ts
@@ -41,35 +41,34 @@ describe("openContentSearchResult", () => {
   it("opens the matching repository file at its exact cursor position", () => {
     openContentSearchResult(result, "/tasks/task-1", SESSION_ID);
 
-    expect(mockSetPendingCursorPosition).toHaveBeenCalledWith(
-      FILE_PATH,
-      42,
-      7,
-      "frontend",
-      SESSION_ID,
-    );
+    expect(mockSetPendingCursorPosition).toHaveBeenCalledWith(FILE_PATH, 42, 7, "frontend", {
+      sessionId: SESSION_ID,
+      flashLine: true,
+    });
     expect(mockScrollEditorIfMounted).toHaveBeenCalledWith(FILE_PATH, "/tasks/task-1", 42, 7, {
       repo: "frontend",
       sessionId: SESSION_ID,
+      flashLine: true,
     });
     expect(mockAddFileEditorPanel).toHaveBeenCalledWith(FILE_PATH, FILE_NAME, {
       repo: "frontend",
     });
+    expect(mockAddFileEditorPanel.mock.invocationCallOrder[0]).toBeLessThan(
+      mockScrollEditorIfMounted.mock.invocationCallOrder[0],
+    );
   });
 
   it("omits an empty repository key for a single-repo workspace", () => {
     openContentSearchResult({ ...result, repository_name: "" }, null, SESSION_ID);
 
-    expect(mockSetPendingCursorPosition).toHaveBeenCalledWith(
-      FILE_PATH,
-      42,
-      7,
-      undefined,
-      SESSION_ID,
-    );
+    expect(mockSetPendingCursorPosition).toHaveBeenCalledWith(FILE_PATH, 42, 7, undefined, {
+      sessionId: SESSION_ID,
+      flashLine: true,
+    });
     expect(mockScrollEditorIfMounted).toHaveBeenCalledWith(FILE_PATH, null, 42, 7, {
       repo: undefined,
       sessionId: SESSION_ID,
+      flashLine: true,
     });
     expect(mockAddFileEditorPanel).toHaveBeenCalledWith(FILE_PATH, FILE_NAME, {
       repo: undefined,

--- a/apps/web/lib/commands/content-search-selection.ts
+++ b/apps/web/lib/commands/content-search-selection.ts
@@ -9,10 +9,14 @@ export function openContentSearchResult(
   sessionId: string,
 ): void {
   const repo = result.repository_name || undefined;
-  setPendingCursorPosition(result.path, result.line, result.column, repo, sessionId);
+  setPendingCursorPosition(result.path, result.line, result.column, repo, {
+    sessionId,
+    flashLine: true,
+  });
+  useDockviewStore.getState().addFileEditorPanel(result.path, getFileName(result.path), { repo });
   scrollEditorIfMounted(result.path, worktreePath, result.line, result.column, {
     repo,
     sessionId,
+    flashLine: true,
   });
-  useDockviewStore.getState().addFileEditorPanel(result.path, getFileName(result.path), { repo });
 }

--- a/docs/plans/content-search-match-reveal/plan.md
+++ b/docs/plans/content-search-match-reveal/plan.md
@@ -1,0 +1,267 @@
+---
+spec: docs/specs/ui/task-workspace-content-search.md
+created: 2026-08-14
+status: done
+---
+
+# Implementation Plan: Content Search Match Reveal
+
+## Overview
+
+Make content-search selection a model-aware editor reveal instead of a
+mount-only cursor hint. Preserve the existing path, repository, and session
+scope; activate the preview first; consume the reveal only after the matching
+editor model is ready; then center and briefly highlight the selected line in
+Monaco and CodeMirror. Finish with the cached-preview keyboard regression that
+exposed the bug.
+
+---
+
+## Root Cause (Confirmed)
+
+`openContentSearchResult` currently writes `{ line, column }`, calls
+`scrollEditorIfMounted`, and only then calls `addFileEditorPanel`. When a target
+file is cached but the reusable preview currently displays another file,
+`scrollEditorIfMounted` cannot find the target model. Dockview then swaps the
+existing Monaco editor to the cached model without remounting it.
+`useMonacoEditorComments.handleEditorDidMount` is the only delayed Monaco
+consumer, so it never sees that pending cursor request after the model swap.
+
+A throwaway production-build Playwright regression reproduced the exact path:
+open a 180-line target through Files search, switch the preview to another
+file, then press Enter on the target's Contents result. The current build
+returned `{ position: 1, visible: false }` instead of
+`{ position: 180, visible: true }`. The temporary spec was removed after the
+failed run.
+
+The highlight half is absent rather than mistimed. The pending payload contains
+only line and column; Monaco and CodeMirror set the cursor, center it, and focus
+the editor without creating any transient decoration. Existing E2E coverage
+opens a fresh file at line 9 and asserts only `getPosition()`, so it covers
+neither an off-screen reveal nor cached preview reuse nor a visible highlight.
+
+---
+
+## Frontend
+
+### Scoped Reveal Request Broker
+
+Update `apps/web/hooks/file-editor-cursor.ts` so the pending value can carry an
+optional one-shot line-flash intent while preserving every existing caller and
+the current path/repository/session key rules.
+
+- Keep `setPendingCursorPosition` backward compatible and add an optional
+  reveal-options argument rather than making file links, walkthroughs, or LSP
+  navigation flash unexpectedly.
+- Make immediate mounted-editor reveal and delayed model/mount consumption use
+  the same target shape and cleanup semantics.
+- Scope active flash state and cleanup to the editor instance and latest
+  request. Re-selecting a match restarts the flash; an older timer cannot clear
+  a newer decoration.
+- Keep missing, ambiguous, wrong-repository, and wrong-session editors as
+  no-ops that leave the pending request available for the correct consumer.
+
+### Content Search Selection Order
+
+Update `apps/web/lib/commands/content-search-selection.ts` to attach the
+one-shot flash intent, activate or replace the file preview, and then try the
+immediate mounted-editor reveal. This order handles an already-active target
+immediately while leaving cached model swaps and delayed mounts for the editor
+lifecycle consumer.
+
+### Monaco Model Lifecycle
+
+Extract a small model-aware cursor-navigation hook beside the Monaco editor,
+following the existing `useMonacoModelSnapshot` subscription pattern in
+`apps/web/components/editors/monaco/use-monaco-walkthrough-range.ts`.
+
+- Move pending-cursor consumption out of the mount-only callback in
+  `use-monaco-editor-state.ts`.
+- Subscribe to `onDidChangeModel` and retry when the editor instance, target
+  file identity, or active model changes. Consume only after the target model
+  is active.
+- Apply a whole-line Monaco decoration, center the line, set the returned
+  cursor column, and focus the editor. Remove the decoration after the bounded
+  flash interval and on teardown/model replacement.
+
+Likely new files:
+
+- `apps/web/components/editors/monaco/use-monaco-cursor-navigation.ts`
+- `apps/web/components/editors/monaco/use-monaco-cursor-navigation.test.tsx`
+
+### CodeMirror And Mobile Viewer
+
+Extend `apps/web/components/editors/codemirror/codemirror-cursor-navigation.ts`
+with a small `StateEffect`/`StateField` decoration extension so desktop
+CodeMirror and the read-only mobile `FileViewerContent` can render and clear
+the same optional whole-line flash. Reuse the existing line/column clamping,
+centered `scrollIntoView`, and focus behavior. Install the extension in both
+CodeMirror surfaces and have `FileViewerContent` reuse the shared reveal helper
+instead of maintaining a second position-only implementation.
+
+### Visual Treatment
+
+Add one scoped editor-result class and one one-shot keyframe in
+`apps/web/app/globals.css`.
+
+- Use the existing warning/search hue at restrained opacity so the line reads
+  as a destination, not an error or persistent selection.
+- Fade only the background over about 1.2 seconds. Do not animate layout,
+  scrolling, transform, or unrelated properties, and do not use
+  `transition: all`.
+- Under `prefers-reduced-motion: reduce`, suppress the fade but retain the
+  static highlight for the same bounded interval before cleanup.
+- The class is shared by Monaco and CodeMirror and coexists with comment and
+  walkthrough decorations.
+
+### Mobile Design Contract
+
+- **Desktop outcome and entry:** Cmd/Ctrl+Shift+F, query, then Enter opens the
+  selected Dockview file preview with its result line centered and flashed.
+- **Nearest mobile exemplar:**
+  `apps/web/components/task/mobile/mobile-file-viewer-panel.tsx` and its
+  `FileViewerContent` child already provide a full-height, single-scroll-owner
+  CodeMirror viewer and consume pending cursor positions.
+- **Presentation:** inline whole-line decoration inside the existing editor.
+  No drawer, route, toolbar, touch target, safe-area, or scroll-owner change.
+- **Shared behavior:** path/repository/session scoping, clamping, reveal intent,
+  and highlight cleanup are shared; editor-provider adapters own only their
+  decoration APIs.
+- **Mobile E2E boundary:** the current command-palette content selection calls
+  Dockview's `addFileEditorPanel`, while `SessionMobileLayout` owns a separate
+  `selectedFile` flow. There is no supported mobile command-palette destination
+  to exercise without adding a new navigation contract. That capability is out
+  of scope; focused `FileViewerContent` coverage proves the shared mobile
+  viewer consumes and clears a flashed reveal request.
+
+No new user-facing copy, API, persistence, backend, or public documentation is
+needed.
+
+---
+
+## Tests
+
+- **Content selection contract:** update
+  `apps/web/lib/commands/content-search-selection.test.ts` to prove the reveal
+  request carries flash intent and the panel is activated before the immediate
+  mounted-editor attempt.
+- **Broker scoping and cleanup:** update
+  `apps/web/hooks/use-file-editors.test.tsx` for direct Monaco reveal, latest
+  request/timer ownership, and unchanged repository/session ambiguity behavior.
+- **Monaco cached model swap:** add
+  `apps/web/components/editors/monaco/use-monaco-cursor-navigation.test.tsx`.
+  Mount once on file A, queue a flashed target for cached file B, fire the model
+  change, and assert position, centered reveal, decoration, restart, and cleanup
+  with fake timers. This test must fail before production code changes.
+- **CodeMirror behavior:** extend
+  `apps/web/components/editors/codemirror/codemirror-cursor-navigation.test.ts`
+  and `codemirror-code-editor.cursor.test.tsx` for the optional whole-line
+  decoration, repeated flash, cleanup, and unchanged clamping/scope behavior.
+- **Read-only mobile consumer:** add
+  `apps/web/components/task/file-viewer-content.test.tsx` for delayed/path-change
+  consumption through the shared CodeMirror reveal helper.
+
+Targeted unit command:
+
+```bash
+cd apps && pnpm --filter @kandev/web test -- --run lib/commands/content-search-selection.test.ts hooks/use-file-editors.test.tsx components/editors/monaco/use-monaco-cursor-navigation.test.tsx components/editors/codemirror/codemirror-cursor-navigation.test.ts components/editors/codemirror/codemirror-code-editor.cursor.test.tsx components/task/file-viewer-content.test.tsx
+```
+
+Then run direct web typechecking and focused lint:
+
+```bash
+cd apps/web && pnpm run typecheck
+cd apps/web && pnpm exec eslint lib/commands/content-search-selection.ts lib/commands/content-search-selection.test.ts hooks/file-editor-cursor.ts hooks/use-file-editors.test.tsx components/editors/monaco/use-monaco-cursor-navigation.ts components/editors/monaco/use-monaco-cursor-navigation.test.tsx components/editors/monaco/use-monaco-editor-state.ts components/editors/monaco/monaco-code-editor.tsx components/editors/codemirror/codemirror-cursor-navigation.ts components/editors/codemirror/codemirror-cursor-navigation.test.ts components/editors/codemirror/codemirror-code-editor.tsx components/editors/codemirror/codemirror-code-editor.cursor.test.tsx components/task/file-viewer-content.tsx components/task/file-viewer-content.test.tsx e2e/tests/search/task-workspace-content-search.spec.ts
+```
+
+---
+
+## E2E Tests
+
+- **Scenario:** GIVEN a deep target file has already been opened and the shared
+  preview now displays another cached file, WHEN the user opens Contents search
+  and presses Enter on the target result, THEN the target Monaco model is
+  active, its returned cursor line is inside `getVisibleRanges()`, the scoped
+  line-flash decoration appears, and that decoration clears without a raw
+  sleep.
+- **File:**
+  `apps/web/e2e/tests/search/task-workspace-content-search.spec.ts`.
+- **Method:** seed the target beyond the first viewport (about line 180), warm
+  its model through Files search, switch the reusable preview, and select the
+  Contents result with the keyboard. Preserve the existing multi-repository
+  assertions.
+
+Production-build command:
+
+```bash
+cd apps/web && pnpm e2e:run tests/search/task-workspace-content-search.spec.ts
+```
+
+The managed runner rebuilds the production frontend and backend. Confirm it
+discovers the intended desktop scenarios before treating the run as evidence.
+
+---
+
+## Verification Results
+
+Completed on 2026-08-14.
+
+- RED: focused selection/Monaco tests failed 3 assertions while 15 tests
+  passed; the cached-preview production regression returned line 1 with no
+  flash; CodeMirror/mobile tests then failed the two missing shared-highlight
+  behaviors; the mobile reuse cleanup test failed before its fix.
+- GREEN: the exact targeted unit set passed 6 files and 38 tests. Direct web
+  typecheck and the exact focused ESLint command passed.
+- Rendered production evidence: the fresh-build cached-preview scenario passed,
+  then the full content-search spec passed all 3 desktop scenarios against the
+  same production artifacts. It proved Enter activates the cached model, line
+  180 is within Monaco's visible ranges, the whole-line decoration appears,
+  and polling observes its bounded cleanup.
+- Mobile boundary: shared `FileViewerContent` and real CodeMirror decoration
+  tests prove install, path-change cleanup, repeated flash ownership, and
+  bounded removal. No mobile E2E was added because the command palette still
+  has no supported mobile file destination.
+- The managed runner tore down cleanly, build/test artifacts stayed ignored,
+  `git diff --check` passed, and no external side effect or subagent was used.
+
+Seed-environment follow-up on 2026-08-15:
+
+- A fresh-editor smoke test with the match on line 180 exposed a second path:
+  Monaco accepted the cursor position before Dockview had measured the active
+  container, leaving the viewport at lines 1-49. The permanent
+  multi-repository E2E was deepened to assert line visibility and the flash;
+  it failed before the follow-up fix.
+- The Monaco reveal now forces a layout measurement before centering. The
+  focused fresh-editor E2E passed, the full content-search spec passed all 3
+  scenarios, the targeted unit set passed 6 files and 38 tests, and typecheck,
+  focused ESLint, and `git diff --check` passed.
+
+---
+
+## Implementation Waves And Parallel Candidates
+
+Wave 1:
+
+- [x] [Task 01: Reveal and flash selected content match](task-01-reveal-selected-content-match.md)
+
+Single sequential task. Editor lifecycle, decoration cleanup, and its E2E
+regression form one coupled behavior. No subagents are authorized.
+
+---
+
+## Risks And Boundaries
+
+- Monaco keeps cached models and can change the active model without remounting;
+  correctness must follow model identity, not React mount timing.
+- Repeated selections and model switches can leave stale timers or decorations;
+  latest-request ownership and teardown are acceptance requirements.
+- Existing LSP, walkthrough, chat-file-link, and plain file-open callers must
+  keep position-only behavior and must not start flashing.
+- CodeMirror decorations must map through document changes while active and
+  clear without mutating file content or dirty state.
+- Mobile command-palette-to-file navigation is a separate missing integration,
+  not part of this desktop Dockview repair.
+
+## Open Questions
+
+None.

--- a/docs/plans/content-search-match-reveal/task-01-reveal-selected-content-match.md
+++ b/docs/plans/content-search-match-reveal/task-01-reveal-selected-content-match.md
@@ -1,0 +1,169 @@
+---
+id: "01-reveal-selected-content-match"
+title: "Reveal and flash selected content match"
+status: done
+wave: 1
+depends_on: []
+plan: "plan.md"
+spec: "../../specs/ui/task-workspace-content-search.md"
+---
+
+# Task 01: Reveal And Flash Selected Content Match
+
+## Intent
+
+Make Enter on a workspace content-search result activate the correct cached or
+new editor model, center the returned line, and show a bounded one-shot
+whole-line highlight in Monaco and CodeMirror.
+
+## Acceptance
+
+1. A content result opened through a reused cached Monaco preview lands at the
+   returned one-based line and column with that line inside the visible range;
+   first mounts and already-active editors retain the same behavior.
+2. Content-search reveals flash the destination line for about 1.2 seconds,
+   repeated selection restarts it, reduced motion removes only the fade, and
+   stale timers/model switches cannot clear a newer decoration.
+3. Repository/session scoping, CodeMirror and read-only mobile consumption,
+   ordinary position-only callers, file contents, dirty state, and existing
+   multi-repository search behavior remain unchanged.
+
+## TDD Sequence
+
+1. Add the cached-model Monaco unit regression and the deep cached-preview
+   Playwright scenario. Run both against current code and record the expected
+   RED evidence.
+2. Add highlight lifecycle assertions for Monaco, CodeMirror, and
+   `FileViewerContent`; confirm they fail because the reveal payload and
+   decorations do not yet exist.
+3. Implement the smallest model-aware reveal request, editor adapters, selection
+   ordering, and scoped CSS treatment needed to make those tests GREEN.
+4. Refactor only duplicated reveal/highlight mechanics, rerun exact checks, and
+   record results in this file and `plan.md`.
+
+## Verification
+
+Fresh-worktree bootstrap is already complete for the current workspace. In any
+new worktree, run this first:
+
+```bash
+cd apps && pnpm install --frozen-lockfile
+```
+
+Targeted unit tests:
+
+```bash
+cd apps && pnpm --filter @kandev/web test -- --run lib/commands/content-search-selection.test.ts hooks/use-file-editors.test.tsx components/editors/monaco/use-monaco-cursor-navigation.test.tsx components/editors/codemirror/codemirror-cursor-navigation.test.ts components/editors/codemirror/codemirror-code-editor.cursor.test.tsx components/task/file-viewer-content.test.tsx
+```
+
+Typecheck and focused lint:
+
+```bash
+cd apps/web && pnpm run typecheck
+cd apps/web && pnpm exec eslint lib/commands/content-search-selection.ts lib/commands/content-search-selection.test.ts hooks/file-editor-cursor.ts hooks/use-file-editors.test.tsx components/editors/monaco/use-monaco-cursor-navigation.ts components/editors/monaco/use-monaco-cursor-navigation.test.tsx components/editors/monaco/use-monaco-editor-state.ts components/editors/monaco/monaco-code-editor.tsx components/editors/codemirror/codemirror-cursor-navigation.ts components/editors/codemirror/codemirror-cursor-navigation.test.ts components/editors/codemirror/codemirror-code-editor.tsx components/editors/codemirror/codemirror-code-editor.cursor.test.tsx components/task/file-viewer-content.tsx components/task/file-viewer-content.test.tsx e2e/tests/search/task-workspace-content-search.spec.ts
+```
+
+Production-build browser regression:
+
+```bash
+cd apps/web && pnpm e2e:run tests/search/task-workspace-content-search.spec.ts
+```
+
+Confirm Playwright discovers the existing multi-repository scenario plus the new
+cached-preview scenario. Do not use a raw timeout to wait for highlight cleanup.
+
+## Files Likely Touched
+
+- `apps/web/lib/commands/content-search-selection.ts`
+- `apps/web/lib/commands/content-search-selection.test.ts`
+- `apps/web/hooks/file-editor-cursor.ts`
+- `apps/web/hooks/use-file-editors.test.tsx`
+- `apps/web/components/editors/monaco/use-monaco-cursor-navigation.ts` (new)
+- `apps/web/components/editors/monaco/use-monaco-cursor-navigation.test.tsx` (new)
+- `apps/web/components/editors/monaco/use-monaco-editor-state.ts`
+- `apps/web/components/editors/monaco/monaco-code-editor.tsx`
+- `apps/web/components/editors/codemirror/codemirror-cursor-navigation.ts`
+- `apps/web/components/editors/codemirror/codemirror-cursor-navigation.test.ts`
+- `apps/web/components/editors/codemirror/codemirror-code-editor.tsx`
+- `apps/web/components/editors/codemirror/codemirror-code-editor.cursor.test.tsx`
+- `apps/web/components/task/file-viewer-content.tsx`
+- `apps/web/components/task/file-viewer-content.test.tsx` (new)
+- `apps/web/app/globals.css`
+- `apps/web/e2e/tests/search/task-workspace-content-search.spec.ts`
+
+Reconcile this list with the actual diff before marking the task done.
+
+## Dependencies
+
+None.
+
+## Parallelism
+
+`sequential`. The broker, provider adapters, CSS lifecycle, and browser
+regression share one behavior and cannot be reviewed safely as independent
+changes.
+
+## Inputs
+
+- `docs/specs/ui/task-workspace-content-search.md`, especially result selection
+  and cached-preview scenarios.
+- `plan.md`, especially Root Cause, Frontend, Tests, and Risks.
+- `apps/web/components/editors/monaco/use-monaco-walkthrough-range.ts` for the
+  existing model-snapshot subscription pattern.
+- `apps/web/components/task/file-viewer-content.tsx` for mobile single-scroll
+  ownership and path-change consumption.
+
+## Output Contract
+
+Report RED/GREEN commands and counts, changed files, model/timer cleanup
+behavior, desktop rendered evidence, generated artifacts, teardown, remaining
+risks, and synchronized task/plan status. External side effects: none.
+
+## Results
+
+Completed on 2026-08-14.
+
+### RED evidence
+
+- The initial focused unit run reported 3 expected failures and 15 passing
+  tests. Content selection still sent a position-only request before panel
+  activation, and Monaco created no whole-line decoration.
+- The permanent cached-preview browser regression ran against the old
+  production build and received `{ line: 1, visible: true, flash: false }`
+  instead of `{ line: 180, visible: true, flash: true }`.
+- The first CodeMirror/mobile unit run reported 2 expected failures and 3
+  passing tests because no flash effect existed and `FileViewerContent` still
+  had a second position-only implementation.
+- The mobile reuse cleanup regression failed once as expected because a flash
+  from the prior file was not cleared on an in-place path change.
+
+### GREEN evidence
+
+- Targeted unit command: 6 files passed, 38 tests passed.
+- `cd apps/web && pnpm run typecheck`: passed.
+- The exact focused ESLint command from this task: passed with zero findings.
+- Fresh production build plus the new cached-preview Playwright scenario: 1
+  test passed.
+- Final full production-artifact run:
+  `pnpm e2e:run --no-build tests/search/task-workspace-content-search.spec.ts`:
+  3 tests passed (route boundary, multi-repository selection, cached-preview
+  reveal/flash).
+- `git diff --check`: passed.
+
+The managed runner cleaned its result directories and exited with no Kandev or
+Playwright process left running. Build output remained ignored; no generated
+artifact was added to the change. Mobile verification is the shared
+`FileViewerContent` component regression plus real CodeMirror decoration tests;
+there is still no supported mobile command-palette-to-file destination, as
+recorded in the plan. No subagents or external side effects were used.
+
+### Seed-environment follow-up (2026-08-15)
+
+- A fresh-editor manual smoke test put the cursor on line 180 but left Monaco's
+  visible range at lines 1-49. The deepened multi-repository E2E reproduced the
+  missing reveal before the fix.
+- `revealMonacoEditor` now lays out the fresh Dockview-mounted editor before it
+  sets and centers the target position.
+- Focused fresh-editor E2E: 1 test passed. Full content-search E2E: 3 tests
+  passed. Targeted units: 6 files and 38 tests passed. Typecheck, focused
+  ESLint, and `git diff --check` also passed.

--- a/docs/specs/ui/task-workspace-content-search.md
+++ b/docs/specs/ui/task-workspace-content-search.md
@@ -55,7 +55,13 @@ repositories.
   raw transport identity.
 - Selecting a result opens or activates that repository's file and places the
   cursor at the result's one-based line and column. Both Monaco and CodeMirror
-  reveal the location, including when the editor is mounted after selection.
+  center the result line after the target file model is active, including when
+  an existing preview tab swaps from another cached file without remounting the
+  editor.
+- The selected result line receives a one-shot whole-line highlight for about
+  1.2 seconds so the destination is easy to locate. Selecting the result again
+  restarts the highlight. Reduced-motion users see the same bounded highlight
+  without a fade animation.
 - Empty-query, searching, no-match, unavailable-session, and failed-search
   states are distinguishable without closing the palette.
 - Search is bounded: a query contains at most 200 characters, each repository
@@ -156,6 +162,13 @@ repositories without parsing path strings.
 - **GIVEN** two repositories with the same relative path, **WHEN** the user
   selects the result from the second repository, **THEN** Kandev opens the
   second repository's file at the returned line and column.
+- **GIVEN** a result file was previously opened and its preview tab now shows a
+  different cached file, **WHEN** the user selects an off-screen content result
+  with **Enter**, **THEN** the target model becomes active, the returned line is
+  centered in the editor, and its one-shot line highlight appears and clears.
+- **GIVEN** either Monaco or CodeMirror displays a selected content result,
+  **WHEN** the same result is selected again, **THEN** its one-shot line
+  highlight restarts without changing file contents.
 - **GIVEN** an untracked non-ignored text file and an ignored text file,
   **WHEN** both contain the query, **THEN** only the untracked non-ignored file
   appears.
@@ -174,4 +187,6 @@ repositories without parsing path strings.
   terminal output, or files outside attached repositories.
 - Regular-expression, whole-word, case-sensitive, replace, or persistent search
   options.
+- Persistent editor markers or highlighting every fuzzy-match character in the
+  source line.
 - A persistent full-text index or external search service.


### PR DESCRIPTION
Content-search results could open a file without bringing an off-screen match into view, especially when Dockview reused a cached Monaco preview. Selection now centers the active match and briefly highlights it in Monaco and CodeMirror.

## Important Changes

- Carry a scoped, one-shot reveal request through fresh mounts and cached model swaps.
- Clean up and restart whole-line highlights without changing file contents or dirty state.

## Validation

- Targeted Vitest suite: 6 files, 38 tests passed.
- `pnpm run typecheck` passed.
- Focused ESLint passed.
- Content-search Playwright spec: 3 tests passed against production artifacts.
- Fresh desktop capture verified line 180 centered and highlighted.
- No public docs change: this repairs existing behavior; the behavioral spec was updated.
- Mobile has no supported command-palette file destination; shared CodeMirror viewer coverage passed.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2681?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- kandev-screenshots-start -->
## Screenshots

Desktop result reveal. Mobile capture omitted because this command-palette action has no supported mobile file destination.

![Selected content match centered and highlighted](https://raw.githubusercontent.com/kdlbs/kandev/90d73aec33dea4f86fecacf08125c84c116db22c/task-workspace-content-search--content-search-match-reveal.png)
<!-- kandev-screenshots-end -->