### PR TITLE
fix(github): scope legacy task PR mutations

### DIFF
--- a/apps/backend/internal/github/controller_task_pr_legacy_workspace_authorization_test.go
+++ b/apps/backend/internal/github/controller_task_pr_legacy_workspace_authorization_test.go
@@ -1,0 +1,92 @@
+package github
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	taskmodels "github.com/kandev/kandev/internal/task/models"
+)
+
+func TestHTTPTaskPRMutationsLegacyWorkspaceMismatch(t *testing.T) {
+	tests := []struct {
+		name   string
+		method string
+		body   string
+		check  func(t *testing.T, store *Store, associationID string)
+	}{
+		{
+			name:   "detach",
+			method: http.MethodDelete,
+			check: func(t *testing.T, store *Store, associationID string) {
+				t.Helper()
+				row, err := store.GetTaskPRByID(context.Background(), associationID)
+				if err != nil {
+					t.Fatalf("reload detached association: %v", err)
+				}
+				if row == nil || row.DetachedAt != nil {
+					t.Fatalf("row = %+v, want active association", row)
+				}
+			},
+		},
+		{
+			name:   "disposition",
+			method: http.MethodPatch,
+			body:   `{"disposition":"duplicate"}`,
+			check: func(t *testing.T, store *Store, associationID string) {
+				t.Helper()
+				row, err := store.GetTaskPRByID(context.Background(), associationID)
+				if err != nil {
+					t.Fatalf("reload disposition association: %v", err)
+				}
+				if row == nil || row.Disposition != nil || row.DispositionRecordedAt != nil {
+					t.Fatalf("row = %+v, want no disposition write", row)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			router, store := setupLegacyTaskPRControllerTest(t)
+			association := &TaskPR{
+				TaskID: "task-legacy", Owner: "acme", Repo: "demo", PRNumber: 12,
+				PRURL: "https://github.com/acme/demo/pull/12", PRTitle: "closed pr",
+				State: "closed", CreatedAt: time.Now().UTC(),
+			}
+			if err := store.CreateTaskPR(context.Background(), association); err != nil {
+				t.Fatalf("create legacy association: %v", err)
+			}
+			path := "/api/v1/github/task-prs/" + association.ID + "?workspace_id=ws-other"
+			if tt.method == http.MethodPatch {
+				path += "/disposition"
+			}
+			request := httptest.NewRequest(tt.method, path, bytes.NewBufferString(tt.body))
+			request.Header.Set("Content-Type", "application/json")
+			response := httptest.NewRecorder()
+			router.ServeHTTP(response, request)
+
+			if response.Code != http.StatusNotFound {
+				t.Fatalf("status = %d, body = %s, want 404", response.Code, response.Body.String())
+			}
+			tt.check(t, store, association.ID)
+		})
+	}
+}
+
+func setupLegacyTaskPRControllerTest(t *testing.T) (*gin.Engine, *Store) {
+	t.Helper()
+	svc, store := setupWatchServiceTest(t)
+	svc.SetTaskIssueStore(&fakeTaskIssueStore{
+		task: &taskmodels.Task{ID: "task-legacy", WorkspaceID: "ws-owner"},
+	})
+	controller := NewController(svc, newControllerTestLogger())
+	router := gin.New()
+	useControllerTestWorkspace(router)
+	controller.RegisterHTTPRoutes(router)
+	return router, store
+}

--- a/apps/backend/internal/github/controller_task_pr_legacy_workspace_authorization_test.go
+++ b/apps/backend/internal/github/controller_task_pr_legacy_workspace_authorization_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -61,10 +62,11 @@ func TestHTTPTaskPRMutationsLegacyWorkspaceMismatch(t *testing.T) {
 			if err := store.CreateTaskPR(context.Background(), association); err != nil {
 				t.Fatalf("create legacy association: %v", err)
 			}
-			path := "/api/v1/github/task-prs/" + association.ID + "?workspace_id=ws-other"
+			path := "/api/v1/github/task-prs/" + association.ID
 			if tt.method == http.MethodPatch {
 				path += "/disposition"
 			}
+			path += "?workspace_id=ws-other"
 			request := httptest.NewRequest(tt.method, path, bytes.NewBufferString(tt.body))
 			request.Header.Set("Content-Type", "application/json")
 			response := httptest.NewRecorder()
@@ -72,6 +74,9 @@ func TestHTTPTaskPRMutationsLegacyWorkspaceMismatch(t *testing.T) {
 
 			if response.Code != http.StatusNotFound {
 				t.Fatalf("status = %d, body = %s, want 404", response.Code, response.Body.String())
+			}
+			if got := strings.TrimSpace(response.Body.String()); got != `{"error":"task PR not found"}` {
+				t.Fatalf("body = %s, want task PR not-found response", got)
 			}
 			tt.check(t, store, association.ID)
 		})

--- a/apps/backend/internal/github/service_task_issue_test.go
+++ b/apps/backend/internal/github/service_task_issue_test.go
@@ -15,6 +15,8 @@ type fakeTaskIssueStore struct {
 	entities             map[string]*taskmodels.Repository
 	repositoryErrs       map[string]error
 	failOnCanceledUpdate bool
+	getCalls             int
+	returnNilTask        bool
 	// taskErr takes priority over the task-not-set fallback. Set it to an
 	// error wrapping ErrTaskNotFound when a test needs the controller's 404 path.
 	taskErr   error
@@ -42,6 +44,10 @@ func (c *countingIssueClient) GetIssue(ctx context.Context, owner, repo string, 
 }
 
 func (f *fakeTaskIssueStore) GetTask(_ context.Context, taskID string) (*taskmodels.Task, error) {
+	f.getCalls++
+	if f.returnNilTask {
+		return nil, nil
+	}
 	if f.taskErr != nil {
 		return nil, f.taskErr
 	}

--- a/apps/backend/internal/github/service_task_pr_authorization.go
+++ b/apps/backend/internal/github/service_task_pr_authorization.go
@@ -1,0 +1,38 @@
+package github
+
+import (
+	"context"
+	"errors"
+	"strings"
+)
+
+// authorizeTaskPRMutation checks the workspace that owns a task-PR
+// association before a mutation can proceed. Current rows carry that
+// workspace directly; legacy rows derive it from the owning task instead.
+func (s *Service) authorizeTaskPRMutation(ctx context.Context, tp *TaskPR, workspaceID string) error {
+	if tp == nil {
+		return ErrTaskPRNotFound
+	}
+	if strings.TrimSpace(tp.WorkspaceID) != "" {
+		if tp.WorkspaceID != workspaceID {
+			return ErrTaskPRNotFound
+		}
+		return s.authorizeWorkspaceAccess(ctx, tp.WorkspaceID)
+	}
+
+	taskStore := s.getTaskIssueStore()
+	if taskStore == nil {
+		return ErrTaskPRNotFound
+	}
+	task, err := taskStore.GetTask(ctx, tp.TaskID)
+	if err != nil {
+		if errors.Is(err, ErrTaskNotFound) {
+			return ErrTaskPRNotFound
+		}
+		return err
+	}
+	if task == nil || strings.TrimSpace(task.WorkspaceID) == "" || task.WorkspaceID != workspaceID {
+		return ErrTaskPRNotFound
+	}
+	return s.authorizeWorkspaceAccess(ctx, task.WorkspaceID)
+}

--- a/apps/backend/internal/github/service_task_pr_authorization.go
+++ b/apps/backend/internal/github/service_task_pr_authorization.go
@@ -19,6 +19,9 @@ func (s *Service) authorizeTaskPRMutation(ctx context.Context, tp *TaskPR, works
 		}
 		return s.authorizeWorkspaceAccess(ctx, tp.WorkspaceID)
 	}
+	if strings.TrimSpace(tp.TaskID) == "" {
+		return ErrTaskPRNotFound
+	}
 
 	taskStore := s.getTaskIssueStore()
 	if taskStore == nil {

--- a/apps/backend/internal/github/service_task_pr_authorization.go
+++ b/apps/backend/internal/github/service_task_pr_authorization.go
@@ -9,33 +9,39 @@ import (
 // authorizeTaskPRMutation checks the workspace that owns a task-PR
 // association before a mutation can proceed. Current rows carry that
 // workspace directly; legacy rows derive it from the owning task instead.
-func (s *Service) authorizeTaskPRMutation(ctx context.Context, tp *TaskPR, workspaceID string) error {
+func (s *Service) authorizeTaskPRMutation(ctx context.Context, tp *TaskPR, workspaceID string) (string, error) {
 	if tp == nil {
-		return ErrTaskPRNotFound
+		return "", ErrTaskPRNotFound
 	}
 	if strings.TrimSpace(tp.WorkspaceID) != "" {
 		if tp.WorkspaceID != workspaceID {
-			return ErrTaskPRNotFound
+			return "", ErrTaskPRNotFound
 		}
-		return s.authorizeWorkspaceAccess(ctx, tp.WorkspaceID)
+		if err := s.authorizeWorkspaceAccess(ctx, tp.WorkspaceID); err != nil {
+			return "", err
+		}
+		return tp.WorkspaceID, nil
 	}
 	if strings.TrimSpace(tp.TaskID) == "" {
-		return ErrTaskPRNotFound
+		return "", ErrTaskPRNotFound
 	}
 
 	taskStore := s.getTaskIssueStore()
 	if taskStore == nil {
-		return ErrTaskPRNotFound
+		return "", ErrTaskPRNotFound
 	}
 	task, err := taskStore.GetTask(ctx, tp.TaskID)
 	if err != nil {
 		if errors.Is(err, ErrTaskNotFound) {
-			return ErrTaskPRNotFound
+			return "", ErrTaskPRNotFound
 		}
-		return err
+		return "", err
 	}
 	if task == nil || strings.TrimSpace(task.WorkspaceID) == "" || task.WorkspaceID != workspaceID {
-		return ErrTaskPRNotFound
+		return "", ErrTaskPRNotFound
 	}
-	return s.authorizeWorkspaceAccess(ctx, task.WorkspaceID)
+	if err := s.authorizeWorkspaceAccess(ctx, task.WorkspaceID); err != nil {
+		return "", err
+	}
+	return task.WorkspaceID, nil
 }

--- a/apps/backend/internal/github/service_task_pr_authorization_test.go
+++ b/apps/backend/internal/github/service_task_pr_authorization_test.go
@@ -1,0 +1,175 @@
+package github
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	taskmodels "github.com/kandev/kandev/internal/task/models"
+)
+
+type recordingTaskPRTaskStore struct {
+	task     *taskmodels.Task
+	err      error
+	getCalls int
+}
+
+func (s *recordingTaskPRTaskStore) GetTask(context.Context, string) (*taskmodels.Task, error) {
+	s.getCalls++
+	return s.task, s.err
+}
+
+func (s *recordingTaskPRTaskStore) ListTaskRepositories(context.Context, string) ([]*taskmodels.TaskRepository, error) {
+	return nil, nil
+}
+
+func (s *recordingTaskPRTaskStore) GetRepository(context.Context, string) (*taskmodels.Repository, error) {
+	return nil, nil
+}
+
+func (s *recordingTaskPRTaskStore) UpdateTaskMetadata(context.Context, string, map[string]interface{}) (*taskmodels.Task, error) {
+	return s.task, s.err
+}
+
+type authorizeTaskPRMutationCase struct {
+	name             string
+	association      *TaskPR
+	taskStore        *recordingTaskPRTaskStore
+	workspaceID      string
+	authorizeErr     error
+	wantErr          error
+	wantAuthorized   string
+	wantTaskGetCalls int
+}
+
+func TestAuthorizeTaskPRMutationWorkspace(t *testing.T) {
+	tests := []authorizeTaskPRMutationCase{
+		{
+			name:           "modern uses stored workspace without task lookup",
+			association:    &TaskPR{WorkspaceID: "ws-modern"},
+			taskStore:      &recordingTaskPRTaskStore{task: &taskmodels.Task{WorkspaceID: "ws-other"}},
+			workspaceID:    "ws-modern",
+			wantAuthorized: "ws-modern",
+		},
+		{
+			name:        "modern mismatch is not authorized",
+			association: &TaskPR{WorkspaceID: "ws-modern"},
+			workspaceID: "ws-other",
+			wantErr:     ErrTaskPRNotFound,
+		},
+		{
+			name:             "legacy uses owning task workspace",
+			association:      &TaskPR{TaskID: "task-legacy"},
+			taskStore:        &recordingTaskPRTaskStore{task: &taskmodels.Task{WorkspaceID: "ws-legacy"}},
+			workspaceID:      "ws-legacy",
+			wantAuthorized:   "ws-legacy",
+			wantTaskGetCalls: 1,
+		},
+		{
+			name:             "legacy mismatch is not authorized",
+			association:      &TaskPR{TaskID: "task-legacy"},
+			taskStore:        &recordingTaskPRTaskStore{task: &taskmodels.Task{WorkspaceID: "ws-owner"}},
+			workspaceID:      "ws-other",
+			wantErr:          ErrTaskPRNotFound,
+			wantTaskGetCalls: 1,
+		},
+	}
+	runAuthorizeTaskPRMutationCases(t, tests)
+}
+
+func TestAuthorizeTaskPRMutationWorkspaceFailures(t *testing.T) {
+	lookupErr := errors.New("task store unavailable")
+	authorizeErr := errors.New("workspace denied")
+	tests := []authorizeTaskPRMutationCase{
+		{
+			name:        "missing task resolver fails closed",
+			association: &TaskPR{TaskID: "task-legacy"},
+			workspaceID: "ws-supplied",
+			wantErr:     ErrTaskPRNotFound,
+		},
+		{
+			name:             "absent task fails closed",
+			association:      &TaskPR{TaskID: "task-legacy"},
+			taskStore:        &recordingTaskPRTaskStore{},
+			workspaceID:      "ws-supplied",
+			wantErr:          ErrTaskPRNotFound,
+			wantTaskGetCalls: 1,
+		},
+		{
+			name:             "task not found sentinel fails closed",
+			association:      &TaskPR{TaskID: "task-legacy"},
+			taskStore:        &recordingTaskPRTaskStore{err: fmt.Errorf("lookup task: %w", ErrTaskNotFound)},
+			workspaceID:      "ws-supplied",
+			wantErr:          ErrTaskPRNotFound,
+			wantTaskGetCalls: 1,
+		},
+		{
+			name:             "blank task workspace fails closed",
+			association:      &TaskPR{TaskID: "task-legacy"},
+			taskStore:        &recordingTaskPRTaskStore{task: &taskmodels.Task{}},
+			workspaceID:      "ws-supplied",
+			wantErr:          ErrTaskPRNotFound,
+			wantTaskGetCalls: 1,
+		},
+		{
+			name:             "unrelated task lookup error is preserved",
+			association:      &TaskPR{TaskID: "task-legacy"},
+			taskStore:        &recordingTaskPRTaskStore{err: lookupErr},
+			workspaceID:      "ws-supplied",
+			wantErr:          lookupErr,
+			wantTaskGetCalls: 1,
+		},
+		{
+			name:             "workspace authorizer error is preserved",
+			association:      &TaskPR{TaskID: "task-legacy"},
+			taskStore:        &recordingTaskPRTaskStore{task: &taskmodels.Task{WorkspaceID: "ws-legacy"}},
+			workspaceID:      "ws-legacy",
+			authorizeErr:     authorizeErr,
+			wantErr:          authorizeErr,
+			wantAuthorized:   "ws-legacy",
+			wantTaskGetCalls: 1,
+		},
+		{
+			name:        "nil association fails closed",
+			workspaceID: "ws-any",
+			wantErr:     ErrTaskPRNotFound,
+		},
+	}
+	runAuthorizeTaskPRMutationCases(t, tests)
+}
+
+func runAuthorizeTaskPRMutationCases(t *testing.T, tests []authorizeTaskPRMutationCase) {
+	t.Helper()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := NewService(nil, AuthMethodNone, nil, nil, nil, testLogger(t))
+			if tt.taskStore != nil {
+				svc.SetTaskIssueStore(tt.taskStore)
+			}
+			var authorized string
+			svc.SetWorkspaceAuthorizer(func(_ context.Context, workspaceID string) error {
+				authorized = workspaceID
+				return tt.authorizeErr
+			})
+			err := svc.authorizeTaskPRMutation(context.Background(), tt.association, tt.workspaceID)
+			assertTaskPRAuthorizationResult(t, tt, err, authorized)
+		})
+	}
+}
+
+func assertTaskPRAuthorizationResult(t *testing.T, tt authorizeTaskPRMutationCase, err error, authorized string) {
+	t.Helper()
+	if tt.wantErr == nil && err != nil {
+		t.Fatalf("error = %v, want nil", err)
+	}
+	if tt.wantErr != nil && !errors.Is(err, tt.wantErr) {
+		t.Fatalf("error = %v, want %v", err, tt.wantErr)
+	}
+	if authorized != tt.wantAuthorized {
+		t.Fatalf("authorized workspace = %q, want %q", authorized, tt.wantAuthorized)
+	}
+	if tt.taskStore != nil && tt.taskStore.getCalls != tt.wantTaskGetCalls {
+		t.Fatalf("GetTask calls = %d, want %d", tt.taskStore.getCalls, tt.wantTaskGetCalls)
+	}
+}

--- a/apps/backend/internal/github/service_task_pr_authorization_test.go
+++ b/apps/backend/internal/github/service_task_pr_authorization_test.go
@@ -17,6 +17,7 @@ type authorizeTaskPRMutationCase struct {
 	authorizeErr     error
 	wantErr          error
 	wantAuthorized   string
+	wantResolved     string
 	wantTaskGetCalls int
 }
 
@@ -28,6 +29,7 @@ func TestAuthorizeTaskPRMutationWorkspace(t *testing.T) {
 			taskStore:      &fakeTaskIssueStore{task: &taskmodels.Task{WorkspaceID: "ws-other"}},
 			workspaceID:    "ws-modern",
 			wantAuthorized: "ws-modern",
+			wantResolved:   "ws-modern",
 		},
 		{
 			name:        "modern mismatch is not authorized",
@@ -41,6 +43,7 @@ func TestAuthorizeTaskPRMutationWorkspace(t *testing.T) {
 			taskStore:        &fakeTaskIssueStore{task: &taskmodels.Task{ID: "task-legacy", WorkspaceID: "ws-legacy"}},
 			workspaceID:      "ws-legacy",
 			wantAuthorized:   "ws-legacy",
+			wantResolved:     "ws-legacy",
 			wantTaskGetCalls: 1,
 		},
 		{
@@ -136,13 +139,13 @@ func runAuthorizeTaskPRMutationCases(t *testing.T, tests []authorizeTaskPRMutati
 				authorized = workspaceID
 				return tt.authorizeErr
 			})
-			err := svc.authorizeTaskPRMutation(context.Background(), tt.association, tt.workspaceID)
-			assertTaskPRAuthorizationResult(t, tt, err, authorized)
+			resolvedWorkspace, err := svc.authorizeTaskPRMutation(context.Background(), tt.association, tt.workspaceID)
+			assertTaskPRAuthorizationResult(t, tt, resolvedWorkspace, err, authorized)
 		})
 	}
 }
 
-func assertTaskPRAuthorizationResult(t *testing.T, tt authorizeTaskPRMutationCase, err error, authorized string) {
+func assertTaskPRAuthorizationResult(t *testing.T, tt authorizeTaskPRMutationCase, resolvedWorkspace string, err error, authorized string) {
 	t.Helper()
 	if tt.wantErr == nil && err != nil {
 		t.Fatalf("error = %v, want nil", err)
@@ -152,6 +155,9 @@ func assertTaskPRAuthorizationResult(t *testing.T, tt authorizeTaskPRMutationCas
 	}
 	if authorized != tt.wantAuthorized {
 		t.Fatalf("authorized workspace = %q, want %q", authorized, tt.wantAuthorized)
+	}
+	if resolvedWorkspace != tt.wantResolved {
+		t.Fatalf("resolved workspace = %q, want %q", resolvedWorkspace, tt.wantResolved)
 	}
 	if tt.taskStore != nil && tt.taskStore.getCalls != tt.wantTaskGetCalls {
 		t.Fatalf("GetTask calls = %d, want %d", tt.taskStore.getCalls, tt.wantTaskGetCalls)

--- a/apps/backend/internal/github/service_task_pr_authorization_test.go
+++ b/apps/backend/internal/github/service_task_pr_authorization_test.go
@@ -9,33 +9,10 @@ import (
 	taskmodels "github.com/kandev/kandev/internal/task/models"
 )
 
-type recordingTaskPRTaskStore struct {
-	task     *taskmodels.Task
-	err      error
-	getCalls int
-}
-
-func (s *recordingTaskPRTaskStore) GetTask(context.Context, string) (*taskmodels.Task, error) {
-	s.getCalls++
-	return s.task, s.err
-}
-
-func (s *recordingTaskPRTaskStore) ListTaskRepositories(context.Context, string) ([]*taskmodels.TaskRepository, error) {
-	return nil, nil
-}
-
-func (s *recordingTaskPRTaskStore) GetRepository(context.Context, string) (*taskmodels.Repository, error) {
-	return nil, nil
-}
-
-func (s *recordingTaskPRTaskStore) UpdateTaskMetadata(context.Context, string, map[string]interface{}) (*taskmodels.Task, error) {
-	return s.task, s.err
-}
-
 type authorizeTaskPRMutationCase struct {
 	name             string
 	association      *TaskPR
-	taskStore        *recordingTaskPRTaskStore
+	taskStore        *fakeTaskIssueStore
 	workspaceID      string
 	authorizeErr     error
 	wantErr          error
@@ -48,7 +25,7 @@ func TestAuthorizeTaskPRMutationWorkspace(t *testing.T) {
 		{
 			name:           "modern uses stored workspace without task lookup",
 			association:    &TaskPR{WorkspaceID: "ws-modern"},
-			taskStore:      &recordingTaskPRTaskStore{task: &taskmodels.Task{WorkspaceID: "ws-other"}},
+			taskStore:      &fakeTaskIssueStore{task: &taskmodels.Task{WorkspaceID: "ws-other"}},
 			workspaceID:    "ws-modern",
 			wantAuthorized: "ws-modern",
 		},
@@ -61,7 +38,7 @@ func TestAuthorizeTaskPRMutationWorkspace(t *testing.T) {
 		{
 			name:             "legacy uses owning task workspace",
 			association:      &TaskPR{TaskID: "task-legacy"},
-			taskStore:        &recordingTaskPRTaskStore{task: &taskmodels.Task{WorkspaceID: "ws-legacy"}},
+			taskStore:        &fakeTaskIssueStore{task: &taskmodels.Task{ID: "task-legacy", WorkspaceID: "ws-legacy"}},
 			workspaceID:      "ws-legacy",
 			wantAuthorized:   "ws-legacy",
 			wantTaskGetCalls: 1,
@@ -69,7 +46,7 @@ func TestAuthorizeTaskPRMutationWorkspace(t *testing.T) {
 		{
 			name:             "legacy mismatch is not authorized",
 			association:      &TaskPR{TaskID: "task-legacy"},
-			taskStore:        &recordingTaskPRTaskStore{task: &taskmodels.Task{WorkspaceID: "ws-owner"}},
+			taskStore:        &fakeTaskIssueStore{task: &taskmodels.Task{ID: "task-legacy", WorkspaceID: "ws-owner"}},
 			workspaceID:      "ws-other",
 			wantErr:          ErrTaskPRNotFound,
 			wantTaskGetCalls: 1,
@@ -91,7 +68,7 @@ func TestAuthorizeTaskPRMutationWorkspaceFailures(t *testing.T) {
 		{
 			name:             "absent task fails closed",
 			association:      &TaskPR{TaskID: "task-legacy"},
-			taskStore:        &recordingTaskPRTaskStore{},
+			taskStore:        &fakeTaskIssueStore{returnNilTask: true},
 			workspaceID:      "ws-supplied",
 			wantErr:          ErrTaskPRNotFound,
 			wantTaskGetCalls: 1,
@@ -99,7 +76,7 @@ func TestAuthorizeTaskPRMutationWorkspaceFailures(t *testing.T) {
 		{
 			name:             "task not found sentinel fails closed",
 			association:      &TaskPR{TaskID: "task-legacy"},
-			taskStore:        &recordingTaskPRTaskStore{err: fmt.Errorf("lookup task: %w", ErrTaskNotFound)},
+			taskStore:        &fakeTaskIssueStore{taskErr: fmt.Errorf("lookup task: %w", ErrTaskNotFound)},
 			workspaceID:      "ws-supplied",
 			wantErr:          ErrTaskPRNotFound,
 			wantTaskGetCalls: 1,
@@ -107,7 +84,7 @@ func TestAuthorizeTaskPRMutationWorkspaceFailures(t *testing.T) {
 		{
 			name:             "blank task workspace fails closed",
 			association:      &TaskPR{TaskID: "task-legacy"},
-			taskStore:        &recordingTaskPRTaskStore{task: &taskmodels.Task{}},
+			taskStore:        &fakeTaskIssueStore{task: &taskmodels.Task{ID: "task-legacy"}},
 			workspaceID:      "ws-supplied",
 			wantErr:          ErrTaskPRNotFound,
 			wantTaskGetCalls: 1,
@@ -115,7 +92,7 @@ func TestAuthorizeTaskPRMutationWorkspaceFailures(t *testing.T) {
 		{
 			name:             "unrelated task lookup error is preserved",
 			association:      &TaskPR{TaskID: "task-legacy"},
-			taskStore:        &recordingTaskPRTaskStore{err: lookupErr},
+			taskStore:        &fakeTaskIssueStore{taskErr: lookupErr},
 			workspaceID:      "ws-supplied",
 			wantErr:          lookupErr,
 			wantTaskGetCalls: 1,
@@ -123,7 +100,7 @@ func TestAuthorizeTaskPRMutationWorkspaceFailures(t *testing.T) {
 		{
 			name:             "workspace authorizer error is preserved",
 			association:      &TaskPR{TaskID: "task-legacy"},
-			taskStore:        &recordingTaskPRTaskStore{task: &taskmodels.Task{WorkspaceID: "ws-legacy"}},
+			taskStore:        &fakeTaskIssueStore{task: &taskmodels.Task{ID: "task-legacy", WorkspaceID: "ws-legacy"}},
 			workspaceID:      "ws-legacy",
 			authorizeErr:     authorizeErr,
 			wantErr:          authorizeErr,
@@ -133,6 +110,13 @@ func TestAuthorizeTaskPRMutationWorkspaceFailures(t *testing.T) {
 		{
 			name:        "nil association fails closed",
 			workspaceID: "ws-any",
+			wantErr:     ErrTaskPRNotFound,
+		},
+		{
+			name:        "blank task ID fails closed before lookup",
+			association: &TaskPR{TaskID: "  "},
+			taskStore:   &fakeTaskIssueStore{task: &taskmodels.Task{ID: "task-legacy", WorkspaceID: "ws-owner"}},
+			workspaceID: "ws-owner",
 			wantErr:     ErrTaskPRNotFound,
 		},
 	}

--- a/apps/backend/internal/github/service_task_pr_detach.go
+++ b/apps/backend/internal/github/service_task_pr_detach.go
@@ -34,10 +34,10 @@ func (s *Service) DetachTaskPR(ctx context.Context, workspaceID, associationID s
 	if err != nil {
 		return nil, err
 	}
-	if tp == nil || (tp.WorkspaceID != "" && tp.WorkspaceID != workspaceID) {
+	if tp == nil {
 		return nil, ErrTaskPRNotFound
 	}
-	if err := s.authorizeWorkspaceAccess(ctx, workspaceID); err != nil {
+	if err := s.authorizeTaskPRMutation(ctx, tp, workspaceID); err != nil {
 		return nil, err
 	}
 	if tp.DetachedAt != nil {

--- a/apps/backend/internal/github/service_task_pr_detach.go
+++ b/apps/backend/internal/github/service_task_pr_detach.go
@@ -37,7 +37,8 @@ func (s *Service) DetachTaskPR(ctx context.Context, workspaceID, associationID s
 	if tp == nil {
 		return nil, ErrTaskPRNotFound
 	}
-	if err := s.authorizeTaskPRMutation(ctx, tp, workspaceID); err != nil {
+	resolvedWorkspaceID, err := s.authorizeTaskPRMutation(ctx, tp, workspaceID)
+	if err != nil {
 		return nil, err
 	}
 	if tp.DetachedAt != nil {
@@ -55,7 +56,7 @@ func (s *Service) DetachTaskPR(ctx context.Context, workspaceID, associationID s
 	}
 	if s.eventBus != nil {
 		event := bus.NewEvent(events.GitHubTaskPRDeleted, "github", &TaskPRDeletedEvent{
-			WorkspaceID:   workspaceID,
+			WorkspaceID:   resolvedWorkspaceID,
 			TaskID:        detached.TaskID,
 			AssociationID: detached.ID,
 		})

--- a/apps/backend/internal/github/service_task_pr_detach_test.go
+++ b/apps/backend/internal/github/service_task_pr_detach_test.go
@@ -2,9 +2,12 @@ package github
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"testing"
 	"time"
+
+	taskmodels "github.com/kandev/kandev/internal/task/models"
 )
 
 func TestServiceDetachTaskPRAuthorizesWorkspaceAndPublishesRemoval(t *testing.T) {
@@ -109,6 +112,9 @@ func TestServiceDetachTaskPRAllowsLegacyEmptyWorkspace(t *testing.T) {
 	if err := store.CreateTaskPR(ctx, pr); err != nil {
 		t.Fatalf("create legacy PR: %v", err)
 	}
+	svc.SetTaskIssueStore(&fakeTaskIssueStore{
+		task: &taskmodels.Task{ID: "task-legacy", WorkspaceID: "ws-legacy"},
+	})
 	var authorizedWorkspace string
 	svc.SetWorkspaceAuthorizer(func(_ context.Context, workspaceID string) error {
 		authorizedWorkspace = workspaceID
@@ -137,6 +143,79 @@ func TestServiceDetachTaskPRAllowsLegacyEmptyWorkspace(t *testing.T) {
 	}
 	if payload.FieldByName("WorkspaceID").String() != "ws-legacy" {
 		t.Fatalf("event workspace = %q, want ws-legacy", payload.FieldByName("WorkspaceID").String())
+	}
+}
+
+func TestServiceDetachTaskPRLegacyWorkspaceMismatchFailsClosed(t *testing.T) {
+	svc, store, eventBus := setupSyncTest(t)
+	ctx := context.Background()
+	pr := &TaskPR{
+		TaskID: "task-legacy", Owner: "acme", Repo: "demo", PRNumber: 8,
+		PRURL: "https://github.com/acme/demo/pull/8", CreatedAt: time.Now().UTC(),
+	}
+	if err := store.CreateTaskPR(ctx, pr); err != nil {
+		t.Fatalf("create legacy PR: %v", err)
+	}
+	svc.SetTaskIssueStore(&fakeTaskIssueStore{
+		task: &taskmodels.Task{ID: "task-legacy", WorkspaceID: "ws-owner"},
+	})
+	authorizerCalls := 0
+	svc.SetWorkspaceAuthorizer(func(context.Context, string) error {
+		authorizerCalls++
+		return nil
+	})
+
+	_, err := svc.DetachTaskPR(ctx, "ws-other", pr.ID)
+	if !errors.Is(err, ErrTaskPRNotFound) {
+		t.Fatalf("error = %v, want ErrTaskPRNotFound", err)
+	}
+	stored, err := store.GetTaskPRByID(ctx, pr.ID)
+	if err != nil {
+		t.Fatalf("reload legacy PR: %v", err)
+	}
+	if stored == nil || stored.DetachedAt != nil {
+		t.Fatalf("stored legacy PR = %+v, want active association", stored)
+	}
+	if authorizerCalls != 0 {
+		t.Fatalf("workspace authorizer calls = %d, want 0 on mismatch", authorizerCalls)
+	}
+	if eventBus.publishedCount() != 0 {
+		t.Fatalf("published events = %d, want 0 on rejected detach", eventBus.publishedCount())
+	}
+}
+
+func TestServiceDetachTaskPRLegacyWorkspaceRequiresTaskResolver(t *testing.T) {
+	svc, store, eventBus := setupSyncTest(t)
+	ctx := context.Background()
+	pr := &TaskPR{
+		TaskID: "task-legacy", Owner: "acme", Repo: "demo", PRNumber: 9,
+		PRURL: "https://github.com/acme/demo/pull/9", CreatedAt: time.Now().UTC(),
+	}
+	if err := store.CreateTaskPR(ctx, pr); err != nil {
+		t.Fatalf("create legacy PR: %v", err)
+	}
+	authorizerCalls := 0
+	svc.SetWorkspaceAuthorizer(func(context.Context, string) error {
+		authorizerCalls++
+		return nil
+	})
+
+	_, err := svc.DetachTaskPR(ctx, "ws-supplied", pr.ID)
+	if !errors.Is(err, ErrTaskPRNotFound) {
+		t.Fatalf("error = %v, want ErrTaskPRNotFound", err)
+	}
+	stored, err := store.GetTaskPRByID(ctx, pr.ID)
+	if err != nil {
+		t.Fatalf("reload legacy PR: %v", err)
+	}
+	if stored == nil || stored.DetachedAt != nil {
+		t.Fatalf("stored legacy PR = %+v, want active association", stored)
+	}
+	if authorizerCalls != 0 {
+		t.Fatalf("workspace authorizer calls = %d, want 0 without resolver", authorizerCalls)
+	}
+	if eventBus.publishedCount() != 0 {
+		t.Fatalf("published events = %d, want 0 on rejected detach", eventBus.publishedCount())
 	}
 }
 

--- a/apps/backend/internal/github/service_task_pr_disposition.go
+++ b/apps/backend/internal/github/service_task_pr_disposition.go
@@ -51,7 +51,8 @@ func (s *Service) SetTaskPRDisposition(
 	if tp == nil {
 		return nil, ErrTaskPRNotFound
 	}
-	if err := s.authorizeTaskPRMutation(ctx, tp, workspaceID); err != nil {
+	resolvedWorkspaceID, err := s.authorizeTaskPRMutation(ctx, tp, workspaceID)
+	if err != nil {
 		return nil, err
 	}
 	if !patch.HasAny() {
@@ -74,7 +75,7 @@ func (s *Service) SetTaskPRDisposition(
 	if disposition != nil {
 		action = "set"
 	}
-	return s.writeTaskPRDisposition(ctx, associationID, patch, action)
+	return s.writeTaskPRDisposition(ctx, associationID, patch, action, resolvedWorkspaceID)
 }
 
 // normalizeDispositionPatch puts the raw caller-supplied DispositionPatch
@@ -121,7 +122,7 @@ func normalizeDispositionPatch(patch DispositionPatch) (DispositionPatch, error)
 // final values SetTaskPRDisposition computed for validation — see
 // Store.UpdateTaskPRDisposition for why (SEC-001).
 func (s *Service) writeTaskPRDisposition(
-	ctx context.Context, associationID string, patch DispositionPatch, action string,
+	ctx context.Context, associationID string, patch DispositionPatch, action, workspaceID string,
 ) (*TaskPR, error) {
 	if err := s.store.UpdateTaskPRDisposition(ctx, associationID, patch); err != nil {
 		return nil, err
@@ -136,7 +137,9 @@ func (s *Service) writeTaskPRDisposition(
 		return nil, ErrTaskPRNotFound
 	}
 	if s.eventBus != nil {
-		event := bus.NewEvent(events.GitHubTaskPRUpdated, "github", updated)
+		eventPayload := *updated
+		eventPayload.WorkspaceID = workspaceID
+		event := bus.NewEvent(events.GitHubTaskPRUpdated, "github", &eventPayload)
 		if err := s.eventBus.Publish(ctx, events.GitHubTaskPRUpdated, event); err != nil {
 			s.logger.Debug("failed to publish task PR updated event", zap.Error(err))
 		}

--- a/apps/backend/internal/github/service_task_pr_disposition.go
+++ b/apps/backend/internal/github/service_task_pr_disposition.go
@@ -48,10 +48,10 @@ func (s *Service) SetTaskPRDisposition(
 	if err != nil {
 		return nil, err
 	}
-	if tp == nil || (tp.WorkspaceID != "" && tp.WorkspaceID != workspaceID) {
+	if tp == nil {
 		return nil, ErrTaskPRNotFound
 	}
-	if err := s.authorizeWorkspaceAccess(ctx, workspaceID); err != nil {
+	if err := s.authorizeTaskPRMutation(ctx, tp, workspaceID); err != nil {
 		return nil, err
 	}
 	if !patch.HasAny() {

--- a/apps/backend/internal/github/service_task_pr_disposition_test.go
+++ b/apps/backend/internal/github/service_task_pr_disposition_test.go
@@ -2,8 +2,11 @@ package github
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
+
+	taskmodels "github.com/kandev/kandev/internal/task/models"
 )
 
 // TestSetTaskPRDisposition_PublishesOnChangeNotOnIdenticalRePatch closes the
@@ -53,5 +56,133 @@ func TestSetTaskPRDisposition_PublishesOnChangeNotOnIdenticalRePatch(t *testing.
 	if updated.DispositionRecordedAt == nil || !updated.DispositionRecordedAt.Equal(*firstRecordedAt) {
 		t.Fatalf("DispositionRecordedAt after identical re-PATCH = %v, want unchanged %v",
 			updated.DispositionRecordedAt, firstRecordedAt)
+	}
+}
+
+func TestSetTaskPRDispositionLegacyWorkspaceMismatchFailsClosed(t *testing.T) {
+	svc, store, eventBus := setupSyncTest(t)
+	ctx := context.Background()
+	pr := &TaskPR{
+		TaskID: "task-legacy", Owner: "acme", Repo: "demo", PRNumber: 10,
+		PRURL: "https://github.com/acme/demo/pull/10", PRTitle: "closed pr",
+		State: "closed", CreatedAt: time.Now().UTC(),
+	}
+	if err := store.CreateTaskPR(ctx, pr); err != nil {
+		t.Fatalf("create legacy PR: %v", err)
+	}
+	svc.SetTaskIssueStore(&fakeTaskIssueStore{
+		task: &taskmodels.Task{ID: "task-legacy", WorkspaceID: "ws-owner"},
+	})
+	authorizerCalls := 0
+	svc.SetWorkspaceAuthorizer(func(context.Context, string) error {
+		authorizerCalls++
+		return nil
+	})
+	disposition := TaskPRDispositionDuplicate
+	patch := DispositionPatch{DispositionSet: true, Disposition: &disposition}
+	beforeMetric := readOutcomeCounter(t, taskPROutcomeDispositionsTotal, outcomeMetricLabel("action", "set"))
+
+	_, err := svc.SetTaskPRDisposition(ctx, "ws-other", pr.ID, patch)
+	if !errors.Is(err, ErrTaskPRNotFound) {
+		t.Fatalf("error = %v, want ErrTaskPRNotFound", err)
+	}
+	stored, err := store.GetTaskPRByID(ctx, pr.ID)
+	if err != nil {
+		t.Fatalf("reload legacy PR: %v", err)
+	}
+	if stored == nil || stored.Disposition != nil || stored.DispositionRecordedAt != nil {
+		t.Fatalf("stored legacy PR = %+v, want no disposition write", stored)
+	}
+	if authorizerCalls != 0 {
+		t.Fatalf("workspace authorizer calls = %d, want 0 on mismatch", authorizerCalls)
+	}
+	if got := readOutcomeCounter(t, taskPROutcomeDispositionsTotal, outcomeMetricLabel("action", "set")); got != beforeMetric {
+		t.Fatalf("set disposition metric = %d, want unchanged %d", got, beforeMetric)
+	}
+	if eventBus.publishedCount() != 0 {
+		t.Fatalf("published events = %d, want 0 on rejected disposition", eventBus.publishedCount())
+	}
+}
+
+func TestSetTaskPRDispositionLegacyWorkspaceUsesTaskWorkspace(t *testing.T) {
+	svc, store, eventBus := setupSyncTest(t)
+	ctx := context.Background()
+	pr := &TaskPR{
+		TaskID: "task-legacy", Owner: "acme", Repo: "demo", PRNumber: 13,
+		PRURL: "https://github.com/acme/demo/pull/13", PRTitle: "closed pr",
+		State: "closed", CreatedAt: time.Now().UTC(),
+	}
+	if err := store.CreateTaskPR(ctx, pr); err != nil {
+		t.Fatalf("create legacy PR: %v", err)
+	}
+	svc.SetTaskIssueStore(&fakeTaskIssueStore{
+		task: &taskmodels.Task{ID: "task-legacy", WorkspaceID: "ws-owner"},
+	})
+	var authorizedWorkspace string
+	svc.SetWorkspaceAuthorizer(func(_ context.Context, workspaceID string) error {
+		authorizedWorkspace = workspaceID
+		return nil
+	})
+	disposition := TaskPRDispositionDuplicate
+	updated, err := svc.SetTaskPRDisposition(ctx, "ws-owner", pr.ID, DispositionPatch{
+		DispositionSet: true,
+		Disposition:    &disposition,
+	})
+	if err != nil {
+		t.Fatalf("SetTaskPRDisposition: %v", err)
+	}
+	if updated == nil || updated.Disposition == nil || *updated.Disposition != disposition {
+		t.Fatalf("updated disposition = %+v, want %q", updated, disposition)
+	}
+	if authorizedWorkspace != "ws-owner" {
+		t.Fatalf("authorized workspace = %q, want ws-owner", authorizedWorkspace)
+	}
+	if updated.WorkspaceID != "" {
+		t.Fatalf("updated association workspace = %q, want legacy blank value", updated.WorkspaceID)
+	}
+	if eventBus.publishedCount() != 1 {
+		t.Fatalf("published events = %d, want one update event", eventBus.publishedCount())
+	}
+}
+
+func TestSetTaskPRDispositionLegacyWorkspaceRequiresTaskResolver(t *testing.T) {
+	svc, store, eventBus := setupSyncTest(t)
+	ctx := context.Background()
+	pr := &TaskPR{
+		TaskID: "task-legacy", Owner: "acme", Repo: "demo", PRNumber: 11,
+		PRURL: "https://github.com/acme/demo/pull/11", PRTitle: "closed pr",
+		State: "closed", CreatedAt: time.Now().UTC(),
+	}
+	if err := store.CreateTaskPR(ctx, pr); err != nil {
+		t.Fatalf("create legacy PR: %v", err)
+	}
+	authorizerCalls := 0
+	svc.SetWorkspaceAuthorizer(func(context.Context, string) error {
+		authorizerCalls++
+		return nil
+	})
+	disposition := TaskPRDispositionDuplicate
+	patch := DispositionPatch{DispositionSet: true, Disposition: &disposition}
+	beforeMetric := readOutcomeCounter(t, taskPROutcomeDispositionsTotal, outcomeMetricLabel("action", "set"))
+
+	_, err := svc.SetTaskPRDisposition(ctx, "ws-supplied", pr.ID, patch)
+	if !errors.Is(err, ErrTaskPRNotFound) {
+		t.Fatalf("error = %v, want ErrTaskPRNotFound", err)
+	}
+	stored, err := store.GetTaskPRByID(ctx, pr.ID)
+	if err != nil {
+		t.Fatalf("reload legacy PR: %v", err)
+	}
+	if stored == nil || stored.Disposition != nil || stored.DispositionRecordedAt != nil {
+		t.Fatalf("stored legacy PR = %+v, want no disposition write", stored)
+	}
+	if authorizerCalls != 0 {
+		t.Fatalf("workspace authorizer calls = %d, want 0 without resolver", authorizerCalls)
+	}
+	if got := readOutcomeCounter(t, taskPROutcomeDispositionsTotal, outcomeMetricLabel("action", "set")); got != beforeMetric {
+		t.Fatalf("set disposition metric = %d, want unchanged %d", got, beforeMetric)
+	}
+	if eventBus.publishedCount() != 0 {
+		t.Fatalf("published events = %d, want 0 on rejected disposition", eventBus.publishedCount())
 	}
 }

--- a/apps/backend/internal/github/service_task_pr_disposition_test.go
+++ b/apps/backend/internal/github/service_task_pr_disposition_test.go
@@ -143,6 +143,19 @@ func TestSetTaskPRDispositionLegacyWorkspaceUsesTaskWorkspace(t *testing.T) {
 	if eventBus.publishedCount() != 1 {
 		t.Fatalf("published events = %d, want one update event", eventBus.publishedCount())
 	}
+	eventBus.mu.Lock()
+	event := eventBus.events[0]
+	eventBus.mu.Unlock()
+	eventPayload, ok := event.Data.(*TaskPR)
+	if !ok {
+		t.Fatalf("event payload type = %T, want *TaskPR", event.Data)
+	}
+	if eventPayload.WorkspaceID != "ws-owner" {
+		t.Fatalf("event workspace = %q, want ws-owner", eventPayload.WorkspaceID)
+	}
+	if eventPayload == updated {
+		t.Fatal("event payload aliases stored legacy association")
+	}
 }
 
 func TestSetTaskPRDispositionLegacyWorkspaceRequiresTaskResolver(t *testing.T) {

--- a/docs/plans/task-pr-legacy-workspace-authorization/plan.md
+++ b/docs/plans/task-pr-legacy-workspace-authorization/plan.md
@@ -1,0 +1,110 @@
+---
+spec: docs/specs/task-pr-legacy-workspace-authorization/spec.md
+created: 2026-08-15
+status: implemented
+---
+
+# Implementation Plan: Task PR legacy workspace authorization
+
+## Overview
+
+Replace the two task-PR mutation endpoints' permissive blank-workspace check
+with one shared authorization helper. Modern rows continue to authorize their
+stored workspace; legacy blank rows resolve the owning task's workspace through
+the task store already wired into the GitHub service and fail closed when that
+ownership cannot be established.
+
+Implementation depends on the disposition endpoint from open PR #2614 being
+present in the implementation base. Prefer rebasing this branch after #2614
+merges; if the work is intentionally stacked, rebase onto its current head
+before starting the task and record that dependency in the PR.
+
+---
+
+## Backend
+
+### Shared task-PR mutation authorization
+
+- Add `apps/backend/internal/github/service_task_pr_authorization.go` with a
+  helper that accepts the loaded `TaskPR` and caller-supplied workspace ID.
+- For a non-empty association workspace, compare that stored value with the
+  supplied value before calling `authorizeWorkspaceAccess`.
+- For a blank association workspace, use the existing `TaskIssueStore.GetTask`
+  dependency to read `TaskPR.TaskID`, derive the task workspace, compare it with
+  the supplied value, and authorize the derived value.
+- Map an absent task, a task-not-found sentinel, a blank task workspace, a
+  missing task-store dependency, or a workspace mismatch to
+  `ErrTaskPRNotFound`. Preserve unrelated lookup errors so the controllers keep
+  returning an internal error without mutating data.
+- Keep authorization before every mutation, metric increment, and event
+  publication.
+
+### Mutation endpoints
+
+- Update `DetachTaskPR` in
+  `apps/backend/internal/github/service_task_pr_detach.go` to call the shared
+  helper after loading the association.
+- Update `SetTaskPRDisposition` in
+  `apps/backend/internal/github/service_task_pr_disposition.go` to call the same
+  helper before patch normalization or validation.
+- Do not update `github_task_prs.workspace_id`; the owning task is the fallback
+  authority for legacy rows.
+
+---
+
+## Tests
+
+- **What:** modern associations authorize the stored workspace without a task
+  lookup; legacy associations authorize only the owning task's workspace; a
+  missing resolver, missing task, blank task workspace, mismatch, and task
+  lookup failure all fail before mutation as specified.
+  **File:**
+  `apps/backend/internal/github/service_task_pr_authorization_test.go`.
+  **How:** table-driven unit tests around the shared helper with a recording
+  task store and workspace authorizer.
+- **What:** legacy detach rejects a caller-supplied workspace that differs from
+  the owning task workspace and leaves the association active; the correct
+  derived workspace still permits detach and preserves existing event behavior.
+  **File:**
+  `apps/backend/internal/github/service_task_pr_detach_test.go`.
+  **How:** service tests using the real GitHub SQLite store and fake task store.
+- **What:** legacy disposition rejects the same mismatch and leaves all
+  disposition columns, metrics, and events unchanged; the correct derived
+  workspace still permits the write.
+  **File:**
+  `apps/backend/internal/github/service_task_pr_disposition_test.go`.
+  **How:** service tests using the real GitHub SQLite store and fake task store.
+- **What:** DELETE and PATCH return the existing not-found response for a
+  legacy association owned by another task workspace.
+  **File:**
+  `apps/backend/internal/github/controller_task_pr_legacy_workspace_authorization_test.go`.
+  **How:** controller integration tests covering handler to service to real
+  GitHub store, with the task workspace supplied by the existing fake task
+  store.
+
+## Verification Results
+
+- Dependency PR #2614 remains open at `708d8d2`; this implementation is stacked
+  on `feature/tel-record-why-a-pul-p4w` and targets that branch.
+- The focused authorization and mutation command passed: 21 tests.
+- `go test ./internal/github -run 'TaskPR' -count=1` passed: 121 tests.
+- `go test ./internal/github -count=1` passed: 1,610 tests.
+- `git diff --check` passed.
+
+## Implementation Waves And Parallel Candidates
+
+Sequential execution in the primary conversation:
+
+- [x] [task-01-harden-task-pr-mutations](task-01-harden-task-pr-mutations.md)
+
+The work is not parallel-safe because both endpoint changes depend on the same
+authorization helper and regression-test fixtures.
+
+## Risks
+
+- PR #2614 is open, so the current `main` branch does not contain
+  `SetTaskPRDisposition`. Starting production edits before that dependency is
+  present would produce an incomplete one-endpoint fix.
+- The existing task lookup enforces task ownership under authenticated
+  contexts. Task-not-found errors must be normalized to `ErrTaskPRNotFound` so
+  the task-PR endpoints retain their non-enumerating 404 contract.

--- a/docs/plans/task-pr-legacy-workspace-authorization/plan.md
+++ b/docs/plans/task-pr-legacy-workspace-authorization/plan.md
@@ -86,9 +86,11 @@ before starting the task and record that dependency in the PR.
 
 - Dependency PR #2614 remains open at `708d8d2`; this implementation is stacked
   on `feature/tel-record-why-a-pul-p4w` and targets that branch.
-- The focused authorization and mutation command passed: 21 tests.
+- The focused authorization and mutation command passed: 22 tests.
 - `go test ./internal/github -run 'TaskPR' -count=1` passed: 121 tests.
-- `go test ./internal/github -count=1` passed: 1,610 tests.
+- `go test ./internal/github -count=1` passed: 1,611 tests.
+- PR review follow-up added a blank-task-ID fail-closed guard and reused the
+  shared task-store test double.
 - `git diff --check` passed.
 
 ## Implementation Waves And Parallel Candidates

--- a/docs/plans/task-pr-legacy-workspace-authorization/plan.md
+++ b/docs/plans/task-pr-legacy-workspace-authorization/plan.md
@@ -85,12 +85,16 @@ before starting the task and record that dependency in the PR.
 ## Verification Results
 
 - Dependency PR #2614 remains open at `708d8d2`; this implementation is stacked
-  on `feature/tel-record-why-a-pul-p4w` and targets that branch.
+  on `feature/tel-record-why-a-pul-p4w` and targets the base-repository mirror
+  branch `stack/pr-2614-708d8d2`.
 - The focused authorization and mutation command passed: 22 tests.
-- `go test ./internal/github -run 'TaskPR' -count=1` passed: 121 tests.
+- `go test ./internal/github -run 'TaskPR' -count=1` passed: 122 tests.
 - `go test ./internal/github -count=1` passed: 1,611 tests.
 - PR review follow-up added a blank-task-ID fail-closed guard and reused the
   shared task-store test double.
+- Legacy disposition events carry the derived workspace in an event-only copy,
+  and the controller PATCH regression covers the correctly ordered route and
+  task-PR not-found body.
 - `git diff --check` passed.
 
 ## Implementation Waves And Parallel Candidates

--- a/docs/plans/task-pr-legacy-workspace-authorization/task-01-harden-task-pr-mutations.md
+++ b/docs/plans/task-pr-legacy-workspace-authorization/task-01-harden-task-pr-mutations.md
@@ -1,0 +1,93 @@
+---
+id: "01-harden-task-pr-mutations"
+title: "Harden task PR mutations"
+status: done
+wave: 1
+depends_on: []
+plan: "plan.md"
+spec: "../../specs/task-pr-legacy-workspace-authorization/spec.md"
+---
+
+# Task 01: Harden task PR mutations
+
+## Acceptance
+
+- Both detach and disposition mutations authorize the association's stored or
+  task-derived workspace through one shared helper.
+- Legacy blank-workspace associations fail closed for a mismatched, absent, or
+  unresolved owning task and produce no mutation, metric, or event side effect.
+- Modern and correctly resolved legacy associations preserve their existing
+  success responses and event behavior without backfilling the association.
+
+## Verification
+
+Run after PR #2614 is present in the implementation base:
+
+```bash
+cd apps/backend
+go test ./internal/github -run 'Test(AuthorizeTaskPRMutationWorkspace|ServiceDetachTaskPRLegacyWorkspace|SetTaskPRDispositionLegacyWorkspace|HTTPTaskPRMutationsLegacyWorkspace)' -count=1
+go test ./internal/github -run 'TaskPR' -count=1
+cd ../..
+git diff --check
+```
+
+## Files likely touched
+
+- `apps/backend/internal/github/service_task_pr_authorization.go`
+- `apps/backend/internal/github/service_task_pr_authorization_test.go`
+- `apps/backend/internal/github/service_task_pr_detach.go`
+- `apps/backend/internal/github/service_task_pr_detach_test.go`
+- `apps/backend/internal/github/service_task_pr_disposition.go`
+- `apps/backend/internal/github/service_task_pr_disposition_test.go`
+- `apps/backend/internal/github/controller_task_pr_legacy_workspace_authorization_test.go`
+- `docs/plans/task-pr-legacy-workspace-authorization/plan.md`
+- `docs/plans/task-pr-legacy-workspace-authorization/task-01-harden-task-pr-mutations.md`
+
+## Dependencies
+
+- Open PR #2614 must be merged into the base or intentionally present beneath
+  this work as a stacked dependency.
+- The GitHub service's existing `TaskIssueStore.GetTask` production wiring in
+  `apps/backend/internal/backendapp/main.go` remains the task-workspace source.
+
+## Parallelism
+
+`sequential`. Both endpoints and their tests depend on the same helper and test
+fixtures.
+
+## Inputs
+
+- Spec permissions, failure modes, and scenarios.
+- `docs/decisions/0047-github-authentication-ownership.md`, which requires each
+  GitHub entry point to supply or derive a workspace and fail closed when
+  ownership is missing.
+- Existing `resolveAuthorizedTaskWorkspace` and `TaskIssueStore.GetTask`
+  patterns in `apps/backend/internal/github/service_ci_automation.go` and
+  `apps/backend/internal/github/service_task_issue.go`.
+- Existing legacy behavior test
+  `TestServiceDetachTaskPRAllowsLegacyEmptyWorkspace`.
+
+## Output contract
+
+Report the shared authorization behavior, all changed files, exact test command
+results, dependency/base state, side-effect boundaries verified, remaining
+risks, and synchronized task/plan status in the primary conversation.
+
+## Results
+
+- Added one shared task-PR mutation authorization helper. Modern rows use their
+  stored workspace; legacy rows resolve the owning task workspace through the
+  existing `TaskIssueStore`.
+- Workspace mismatches, missing resolvers, absent tasks, task-not-found errors,
+  and blank task workspaces return `ErrTaskPRNotFound` before authorization or
+  mutation. Unrelated task lookup errors remain unchanged.
+- Wired the helper into detach and disposition before validation, writes,
+  metrics, or event publication. Legacy rows remain blank in
+  `github_task_prs.workspace_id`.
+- Dependency PR #2614 remains open at `708d8d2`; this branch is intentionally
+  stacked on `feature/tel-record-why-a-pul-p4w`.
+- Verification passed:
+  - Focused authorization and mutation tests: 21 passed.
+  - `go test ./internal/github -run 'TaskPR' -count=1`: 121 passed.
+  - `go test ./internal/github -count=1`: 1,610 passed.
+  - `git diff --check` passed.

--- a/docs/plans/task-pr-legacy-workspace-authorization/task-01-harden-task-pr-mutations.md
+++ b/docs/plans/task-pr-legacy-workspace-authorization/task-01-harden-task-pr-mutations.md
@@ -79,15 +79,17 @@ risks, and synchronized task/plan status in the primary conversation.
   stored workspace; legacy rows resolve the owning task workspace through the
   existing `TaskIssueStore`.
 - Workspace mismatches, missing resolvers, absent tasks, task-not-found errors,
-  and blank task workspaces return `ErrTaskPRNotFound` before authorization or
-  mutation. Unrelated task lookup errors remain unchanged.
+  blank task IDs, and blank task workspaces return `ErrTaskPRNotFound` before
+  authorization or mutation. Unrelated task lookup errors remain unchanged.
 - Wired the helper into detach and disposition before validation, writes,
   metrics, or event publication. Legacy rows remain blank in
   `github_task_prs.workspace_id`.
 - Dependency PR #2614 remains open at `708d8d2`; this branch is intentionally
   stacked on `feature/tel-record-why-a-pul-p4w`.
 - Verification passed:
-  - Focused authorization and mutation tests: 21 passed.
+  - Focused authorization and mutation tests: 22 passed.
   - `go test ./internal/github -run 'TaskPR' -count=1`: 121 passed.
-  - `go test ./internal/github -count=1`: 1,610 passed.
+  - `go test ./internal/github -count=1`: 1,611 passed.
   - `git diff --check` passed.
+  - PR review follow-up added a blank-task-ID fail-closed guard and reused the
+    shared task-store test double.

--- a/docs/plans/task-pr-legacy-workspace-authorization/task-01-harden-task-pr-mutations.md
+++ b/docs/plans/task-pr-legacy-workspace-authorization/task-01-harden-task-pr-mutations.md
@@ -18,6 +18,8 @@ spec: "../../specs/task-pr-legacy-workspace-authorization/spec.md"
   unresolved owning task and produce no mutation, metric, or event side effect.
 - Modern and correctly resolved legacy associations preserve their existing
   success responses and event behavior without backfilling the association.
+- Legacy disposition events carry the derived workspace in an event-only copy,
+  while the stored association remains blank.
 
 ## Verification
 
@@ -82,13 +84,16 @@ risks, and synchronized task/plan status in the primary conversation.
   blank task IDs, and blank task workspaces return `ErrTaskPRNotFound` before
   authorization or mutation. Unrelated task lookup errors remain unchanged.
 - Wired the helper into detach and disposition before validation, writes,
-  metrics, or event publication. Legacy rows remain blank in
-  `github_task_prs.workspace_id`.
+  metrics, or event publication. Detach events use the resolved workspace, and
+  disposition events use an event-only copy with that workspace. Legacy rows
+  remain blank in `github_task_prs.workspace_id`.
+- Corrected the controller PATCH regression route to place `/disposition`
+  before the query string and assert the handler's task-PR not-found body.
 - Dependency PR #2614 remains open at `708d8d2`; this branch is intentionally
   stacked on `feature/tel-record-why-a-pul-p4w`.
 - Verification passed:
   - Focused authorization and mutation tests: 22 passed.
-  - `go test ./internal/github -run 'TaskPR' -count=1`: 121 passed.
+  - `go test ./internal/github -run 'TaskPR' -count=1`: 122 passed.
   - `go test ./internal/github -count=1`: 1,611 passed.
   - `git diff --check` passed.
   - PR review follow-up added a blank-task-ID fail-closed guard and reused the

--- a/docs/specs/task-pr-legacy-workspace-authorization/spec.md
+++ b/docs/specs/task-pr-legacy-workspace-authorization/spec.md
@@ -1,5 +1,5 @@
 ---
-status: draft
+status: shipped
 created: 2026-08-15
 owner: kandev
 ---

--- a/docs/specs/task-pr-legacy-workspace-authorization/spec.md
+++ b/docs/specs/task-pr-legacy-workspace-authorization/spec.md
@@ -1,0 +1,79 @@
+---
+status: draft
+created: 2026-08-15
+owner: kandev
+---
+
+# Task PR legacy workspace authorization
+
+## Why
+
+Legacy `github_task_prs` associations can have an empty `workspace_id`. A user
+who knows one of those association IDs can currently name any workspace they
+own when detaching the association or recording its disposition, even when the
+owning task belongs to a different workspace.
+
+This repair covers [GitHub issue #2615](https://github.com/kdlbs/kandev/issues/2615)
+and preserves the workspace ownership rules in the authentication spec and
+[ADR 0047](../../decisions/0047-github-authentication-ownership.md).
+
+## What
+
+- Task-PR mutation endpoints SHALL authorize the association's persisted
+  workspace when `github_task_prs.workspace_id` is present.
+- When an association has an empty `workspace_id`, the system SHALL derive its
+  workspace from the association's owning task.
+- The caller-supplied `workspace_id` SHALL match the persisted or derived
+  workspace before the mutation runs.
+- `DetachTaskPR` and `SetTaskPRDisposition` SHALL use the same authorization
+  behavior.
+- Authorization hardening SHALL NOT backfill or otherwise modify legacy
+  `github_task_prs.workspace_id` values.
+
+## Permissions
+
+A caller can detach a task-PR association or set its disposition only when the
+caller can access the association's persisted or task-derived workspace. Access
+to a different workspace owned by the same caller does not grant access to the
+association.
+
+## Failure modes
+
+- If the association is absent, belongs to another workspace, or has an empty
+  `workspace_id` whose task or task workspace cannot be resolved, the endpoint
+  returns the existing task-PR not-found response and performs no mutation.
+- If task lookup fails for an operational reason other than task absence, the
+  endpoint surfaces its existing internal-error response and performs no
+  mutation.
+- Authorization failure occurs before detach, disposition, metric, or event
+  side effects.
+
+## Scenarios
+
+- **GIVEN** an association with workspace `ws-a`, **WHEN** a caller authorized
+  for `ws-a` mutates it using `workspace_id=ws-a`, **THEN** the mutation succeeds
+  with its existing response and event behavior.
+- **GIVEN** an association with workspace `ws-a`, **WHEN** a caller mutates it
+  using `workspace_id=ws-b`, **THEN** the endpoint returns not found and the row
+  remains unchanged.
+- **GIVEN** a legacy association with an empty workspace whose task belongs to
+  `ws-a`, **WHEN** a caller authorized for `ws-a` mutates it using
+  `workspace_id=ws-a`, **THEN** the mutation succeeds without backfilling the
+  association workspace.
+- **GIVEN** the same legacy association, **WHEN** a caller authorized for
+  `ws-b` mutates it using `workspace_id=ws-b`, **THEN** the endpoint returns not
+  found, no workspace authorization is granted from the supplied ID, and the
+  row remains unchanged.
+- **GIVEN** a legacy association whose owning task is absent or has no
+  workspace, **WHEN** any caller tries to mutate it, **THEN** the endpoint
+  returns not found and the row remains unchanged.
+
+Each scenario applies to both detach and disposition mutations.
+
+## Out of scope
+
+- Backfilling or migrating legacy association rows.
+- Changing task-PR read endpoints, discovery, synchronization, or credential
+  selection.
+- Changing the request or response shape of either mutation endpoint.
+- Shipping the disposition endpoint itself, which remains owned by PR #2614.

--- a/docs/specs/task-pr-legacy-workspace-authorization/spec.md
+++ b/docs/specs/task-pr-legacy-workspace-authorization/spec.md
@@ -29,6 +29,8 @@ and preserves the workspace ownership rules in the authentication spec and
   behavior.
 - Authorization hardening SHALL NOT backfill or otherwise modify legacy
   `github_task_prs.workspace_id` values.
+- Mutation events for legacy associations SHALL carry the derived workspace
+  for routing while leaving the stored association workspace blank.
 
 ## Permissions
 


### PR DESCRIPTION
Legacy `github_task_prs` rows with a blank `workspace_id` could be mutated under any caller-owned workspace, bypassing task ownership. Task-PR detach and disposition mutations now derive legacy ownership from the owning task, fail closed on mismatched or unresolved ownership, and preserve existing side-effect ordering.

## Important Changes

- Added one shared authorization helper for modern stored-workspace and legacy task-derived associations.
- Wired both mutation endpoints to authorize before validation, writes, metrics, or event publication; legacy rows are never backfilled.
- Legacy disposition events carry the resolved workspace in an event-only payload copy, while stored legacy rows remain blank.
- Corrected the controller regression route so PATCH requests exercise the disposition handler and assert its not-found response.

## Validation

- `go test ./internal/github -run 'Test(AuthorizeTaskPRMutationWorkspace|ServiceDetachTaskPRLegacyWorkspace|SetTaskPRDispositionLegacyWorkspace|HTTPTaskPRMutationsLegacyWorkspace)' -count=1` (22 passed)
- `go test ./internal/github -run 'TaskPR' -count=1` (122 passed)
- `go test ./internal/github -count=1` (1,611 passed)
- `git diff --check`
- Normal pre-commit hooks passed, including backend gofmt and changed-code Go lint.
- Review follow-up added blank-TaskID fail-closed coverage and reused the shared task-store test double.
- PR #2614 is still open at `708d8d2`. This PR targets the base-repository mirror branch `stack/pr-2614-708d8d2`, which exists only to keep this stacked diff focused. Retarget to `main` after #2614 merges.

## Possible Improvements

Medium risk: the stacked base must be retargeted to `main` after #2614 merges; the mirror branch must remain available until then.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.

Closes #2615

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2685?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->