### PR TITLE
fix: clear deleted session errors

### DIFF
--- a/apps/backend/internal/orchestrator/event_handlers_agent.go
+++ b/apps/backend/internal/orchestrator/event_handlers_agent.go
@@ -1491,11 +1491,16 @@ func (s *Service) handleRecoverableFailure(ctx context.Context, data watcher.Age
 	defer lock.Unlock()
 
 	if _, err := s.repo.GetTaskSession(ctx, data.SessionID); err != nil {
-		s.logger.Warn("skipping recoverable failure for unavailable session",
+		if errors.Is(err, models.ErrTaskSessionNotFound) {
+			s.logger.Debug("skipping recoverable failure for deleted session",
+				zap.String("task_id", data.TaskID),
+				zap.String("session_id", data.SessionID))
+			return
+		}
+		s.logger.Warn("failed to reload session before recoverable failure; continuing",
 			zap.String("task_id", data.TaskID),
 			zap.String("session_id", data.SessionID),
 			zap.Error(err))
-		return
 	}
 	s.handleRecoverableFailureLocked(ctx, data)
 }

--- a/apps/backend/internal/orchestrator/event_handlers_agent.go
+++ b/apps/backend/internal/orchestrator/event_handlers_agent.go
@@ -1228,7 +1228,7 @@ func (s *Service) handleAgentFailedLocked(ctx context.Context, data watcher.Agen
 
 	// Make all agent CLI failures recoverable — let the user choose to resume or start fresh.
 	if data.SessionID != "" {
-		s.handleRecoverableFailure(ctx, data)
+		s.handleRecoverableFailureLocked(ctx, data)
 		return
 	}
 
@@ -1480,6 +1480,30 @@ func (s *Service) clearResumeToken(ctx context.Context, sessionID string) {
 // creates an error message with recovery action buttons so the user can choose to
 // resume the agent session or start fresh.
 func (s *Service) handleRecoverableFailure(ctx context.Context, data watcher.AgentEventData) {
+	if data.SessionID == "" {
+		s.handleRecoverableFailureLocked(ctx, data)
+		return
+	}
+
+	lock, release := s.acquireCancelInFlightGuard(data.SessionID)
+	defer release()
+	lock.Lock()
+	defer lock.Unlock()
+
+	if _, err := s.repo.GetTaskSession(ctx, data.SessionID); err != nil {
+		s.logger.Warn("skipping recoverable failure for unavailable session",
+			zap.String("task_id", data.TaskID),
+			zap.String("session_id", data.SessionID),
+			zap.Error(err))
+		return
+	}
+	s.handleRecoverableFailureLocked(ctx, data)
+}
+
+// handleRecoverableFailureLocked performs recovery side effects while the
+// session's cancelInFlight guard is held. Deletion uses the same guard, so an
+// active error event cannot publish after the deleted-session inactive event.
+func (s *Service) handleRecoverableFailureLocked(ctx context.Context, data watcher.AgentEventData) {
 	s.logger.Warn("handling recoverable agent failure",
 		zap.String("task_id", data.TaskID),
 		zap.String("session_id", data.SessionID),
@@ -1791,7 +1815,7 @@ func (s *Service) handleAgentStartFailed(ctx context.Context, taskID, sessionID,
 	s.logger.Info("agent start failure is auth error, treating as recoverable",
 		zap.String("task_id", taskID),
 		zap.String("session_id", sessionID))
-	s.handleRecoverableFailure(ctx, watcher.AgentEventData{
+	s.handleRecoverableFailureLocked(ctx, watcher.AgentEventData{
 		TaskID:           taskID,
 		SessionID:        sessionID,
 		AgentExecutionID: agentExecutionID,

--- a/apps/backend/internal/orchestrator/queue_purge_status_test.go
+++ b/apps/backend/internal/orchestrator/queue_purge_status_test.go
@@ -250,7 +250,7 @@ func TestDeleteSessionRetainsOtherProjectedAgentErrorAfterRestart(t *testing.T) 
 	t.Cleanup(func() { eventBus.Close() })
 	svc.eventBus = eventBus
 
-	newProjector := func(parent context.Context) context.CancelFunc {
+	newProjector := func(parent context.Context) func() {
 		ctx, cancel := context.WithCancel(parent)
 		projector := statussummary.NewProjector(statussummary.ProjectorConfig{
 			Store:              repo,
@@ -258,14 +258,15 @@ func TestDeleteSessionRetainsOtherProjectedAgentErrorAfterRestart(t *testing.T) 
 			ResolveWorkspace:   func(context.Context, string) (string, error) { return "ws1", nil },
 			CountQueuedPrompts: svc.messageQueue.CountPendingByTask,
 		})
-		t.Cleanup(func() {
+		stop := func() {
 			cancel()
 			projector.Close()
-		})
+		}
+		t.Cleanup(stop)
 		if err := projector.Start(ctx); err != nil {
 			t.Fatalf("start status summary projector: %v", err)
 		}
-		return cancel
+		return stop
 	}
 
 	publishActiveError := func(sessionID, stamp, occurredAt string) {
@@ -286,7 +287,7 @@ func TestDeleteSessionRetainsOtherProjectedAgentErrorAfterRestart(t *testing.T) 
 		}
 	}
 
-	cancelFirst := newProjector(ctx)
+	stopFirst := newProjector(ctx)
 	publishActiveError(retainedSessionID, "error-older", "2026-08-15T10:00:00Z")
 	publishActiveError(deletedSessionID, "error-newer", "2026-08-15T11:00:00Z")
 	beforeRestart, err := repo.LoadTaskStatusSummaries(ctx, []string{taskID})
@@ -296,7 +297,7 @@ func TestDeleteSessionRetainsOtherProjectedAgentErrorAfterRestart(t *testing.T) 
 	if summary := beforeRestart[taskID]; summary == nil || summary.ActiveError == nil || summary.ActiveError.SessionID != deletedSessionID {
 		t.Fatalf("summary before restart = %+v, want newer deleted-session error", summary)
 	}
-	cancelFirst()
+	stopFirst()
 
 	newProjector(ctx)
 	if err := svc.DeleteSession(ctx, deletedSessionID); err != nil {

--- a/apps/backend/internal/orchestrator/queue_purge_status_test.go
+++ b/apps/backend/internal/orchestrator/queue_purge_status_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kandev/kandev/internal/events"
 	"github.com/kandev/kandev/internal/events/bus"
 	"github.com/kandev/kandev/internal/orchestrator/executor"
+	"github.com/kandev/kandev/internal/orchestrator/watcher"
 	"github.com/kandev/kandev/internal/task/models"
 	"github.com/kandev/kandev/internal/task/statussummary"
 )
@@ -20,6 +21,7 @@ func TestArchiveTaskPublishesQueueStatusWithTaskID(t *testing.T) {
 
 	svc := createTestService(repo, newMockStepGetter(), newMockTaskRepo())
 	eventBus := bus.NewMemoryEventBus(testLogger())
+	t.Cleanup(func() { eventBus.Close() })
 	svc.eventBus = eventBus
 
 	var saw atomic.Int32
@@ -125,6 +127,7 @@ func TestDeleteSessionClearsProjectedAgentError(t *testing.T) {
 
 	svc := createTestService(repo, newMockStepGetter(), newMockTaskRepo())
 	eventBus := bus.NewMemoryEventBus(testLogger())
+	t.Cleanup(func() { eventBus.Close() })
 	svc.eventBus = eventBus
 	projector := statussummary.NewProjector(statussummary.ProjectorConfig{
 		Store:              repo,
@@ -132,16 +135,13 @@ func TestDeleteSessionClearsProjectedAgentError(t *testing.T) {
 		ResolveWorkspace:   func(context.Context, string) (string, error) { return "ws1", nil },
 		CountQueuedPrompts: svc.messageQueue.CountPendingByTask,
 	})
-	if err := projector.Start(ctx); err != nil {
-		cancel()
-		eventBus.Close()
-		t.Fatalf("start status summary projector: %v", err)
-	}
 	t.Cleanup(func() {
 		cancel()
 		projector.Close()
-		eventBus.Close()
 	})
+	if err := projector.Start(ctx); err != nil {
+		t.Fatalf("start status summary projector: %v", err)
+	}
 
 	if err := eventBus.Publish(ctx, events.TaskSessionErrorChanged, bus.NewEvent(
 		events.TaskSessionErrorChanged,
@@ -175,6 +175,141 @@ func TestDeleteSessionClearsProjectedAgentError(t *testing.T) {
 	}
 	if summary := afterDelete[taskID]; summary == nil || summary.ActiveError != nil {
 		t.Fatalf("summary after delete = %+v, want deleted session error cleared", summary)
+	}
+}
+
+func TestRecoverableFailureWaitsForSessionDeletionGuard(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	const taskID = "task-session-error-guard"
+	const sessionID = "session-error-guard"
+	seedTaskAndSession(t, repo, taskID, sessionID, models.TaskSessionStateCompleted)
+
+	svc := createTestService(repo, newMockStepGetter(), newMockTaskRepo())
+	lock, release := svc.acquireCancelInFlightGuard(sessionID)
+	lock.Lock()
+
+	recoveryDone := make(chan struct{})
+	go func() {
+		svc.handleRecoverableFailure(ctx, watcher.AgentEventData{
+			TaskID:       taskID,
+			SessionID:    sessionID,
+			ErrorMessage: "agent failed",
+		})
+		close(recoveryDone)
+	}()
+
+	select {
+	case <-recoveryDone:
+		t.Fatal("recoverable failure bypassed the session deletion guard")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	lock.Unlock()
+	release()
+	select {
+	case <-recoveryDone:
+	case <-time.After(time.Second):
+		t.Fatal("recoverable failure did not finish after the guard was released")
+	}
+}
+
+func TestDeleteSessionRetainsOtherProjectedAgentErrorAfterRestart(t *testing.T) {
+	taskID := "task-session-errors"
+	deletedSessionID := "session-error-newer"
+	retainedSessionID := "session-error-older"
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedTaskAndSession(t, repo, taskID, retainedSessionID, models.TaskSessionStateCompleted)
+	now := time.Now().UTC()
+	if err := repo.CreateTaskSession(ctx, &models.TaskSession{
+		ID: deletedSessionID, TaskID: taskID, State: models.TaskSessionStateCompleted,
+		StartedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("CreateTaskSession(%s): %v", deletedSessionID, err)
+	}
+	retainedError := models.LastAgentError{
+		Message:    retainedSessionID + " failed",
+		OccurredAt: time.Date(2026, 8, 15, 10, 0, 0, 0, time.UTC),
+	}
+	deletedError := models.LastAgentError{
+		Message:    deletedSessionID + " failed",
+		OccurredAt: time.Date(2026, 8, 15, 11, 0, 0, 0, time.UTC),
+	}
+	for sessionID, lastError := range map[string]models.LastAgentError{
+		retainedSessionID: retainedError,
+		deletedSessionID:  deletedError,
+	} {
+		if err := repo.SetSessionMetadataKey(ctx, sessionID, models.SessionMetaKeyLastAgentError, lastError); err != nil {
+			t.Fatalf("set last agent error for %s: %v", sessionID, err)
+		}
+	}
+
+	svc := createTestService(repo, newMockStepGetter(), newMockTaskRepo())
+	eventBus := bus.NewMemoryEventBus(testLogger())
+	t.Cleanup(func() { eventBus.Close() })
+	svc.eventBus = eventBus
+
+	newProjector := func(parent context.Context) context.CancelFunc {
+		ctx, cancel := context.WithCancel(parent)
+		projector := statussummary.NewProjector(statussummary.ProjectorConfig{
+			Store:              repo,
+			EventBus:           eventBus,
+			ResolveWorkspace:   func(context.Context, string) (string, error) { return "ws1", nil },
+			CountQueuedPrompts: svc.messageQueue.CountPendingByTask,
+		})
+		t.Cleanup(func() {
+			cancel()
+			projector.Close()
+		})
+		if err := projector.Start(ctx); err != nil {
+			t.Fatalf("start status summary projector: %v", err)
+		}
+		return cancel
+	}
+
+	publishActiveError := func(sessionID, stamp, occurredAt string) {
+		t.Helper()
+		if err := eventBus.Publish(ctx, events.TaskSessionErrorChanged, bus.NewEvent(
+			events.TaskSessionErrorChanged,
+			"test",
+			map[string]interface{}{
+				"task_id":     taskID,
+				"session_id":  sessionID,
+				"active":      true,
+				"message":     sessionID + " failed",
+				"occurred_at": occurredAt,
+				"stamp":       stamp,
+			},
+		)); err != nil {
+			t.Fatalf("publish active error for %s: %v", sessionID, err)
+		}
+	}
+
+	cancelFirst := newProjector(ctx)
+	publishActiveError(retainedSessionID, "error-older", "2026-08-15T10:00:00Z")
+	publishActiveError(deletedSessionID, "error-newer", "2026-08-15T11:00:00Z")
+	beforeRestart, err := repo.LoadTaskStatusSummaries(ctx, []string{taskID})
+	if err != nil {
+		t.Fatalf("load summary before restart: %v", err)
+	}
+	if summary := beforeRestart[taskID]; summary == nil || summary.ActiveError == nil || summary.ActiveError.SessionID != deletedSessionID {
+		t.Fatalf("summary before restart = %+v, want newer deleted-session error", summary)
+	}
+	cancelFirst()
+
+	newProjector(ctx)
+	if err := svc.DeleteSession(ctx, deletedSessionID); err != nil {
+		t.Fatalf("DeleteSession: %v", err)
+	}
+
+	afterDelete, err := repo.LoadTaskStatusSummaries(ctx, []string{taskID})
+	if err != nil {
+		t.Fatalf("load summary after delete: %v", err)
+	}
+	summary := afterDelete[taskID]
+	if summary == nil || summary.ActiveError == nil || summary.ActiveError.SessionID != retainedSessionID {
+		t.Fatalf("summary after delete = %+v, want retained session error", summary)
 	}
 }
 

--- a/apps/backend/internal/orchestrator/queue_purge_status_test.go
+++ b/apps/backend/internal/orchestrator/queue_purge_status_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kandev/kandev/internal/events/bus"
 	"github.com/kandev/kandev/internal/orchestrator/executor"
 	"github.com/kandev/kandev/internal/task/models"
+	"github.com/kandev/kandev/internal/task/statussummary"
 )
 
 func TestArchiveTaskPublishesQueueStatusWithTaskID(t *testing.T) {
@@ -115,6 +116,67 @@ func TestDeleteSessionCancelsQueuedPromptsAndPublishesStatus(t *testing.T) {
 	}
 }
 
+func TestDeleteSessionClearsProjectedAgentError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	repo := setupTestRepo(t)
+	const taskID = "task-session-error"
+	const sessionID = "session-error"
+	seedTaskAndSession(t, repo, taskID, sessionID, models.TaskSessionStateCompleted)
+
+	svc := createTestService(repo, newMockStepGetter(), newMockTaskRepo())
+	eventBus := bus.NewMemoryEventBus(testLogger())
+	svc.eventBus = eventBus
+	projector := statussummary.NewProjector(statussummary.ProjectorConfig{
+		Store:              repo,
+		EventBus:           eventBus,
+		ResolveWorkspace:   func(context.Context, string) (string, error) { return "ws1", nil },
+		CountQueuedPrompts: svc.messageQueue.CountPendingByTask,
+	})
+	if err := projector.Start(ctx); err != nil {
+		cancel()
+		eventBus.Close()
+		t.Fatalf("start status summary projector: %v", err)
+	}
+	t.Cleanup(func() {
+		cancel()
+		projector.Close()
+		eventBus.Close()
+	})
+
+	if err := eventBus.Publish(ctx, events.TaskSessionErrorChanged, bus.NewEvent(
+		events.TaskSessionErrorChanged,
+		"test",
+		map[string]interface{}{
+			"task_id":     taskID,
+			"session_id":  sessionID,
+			"active":      true,
+			"message":     "agent failed",
+			"occurred_at": "2026-08-15T10:00:00Z",
+			"stamp":       "error-stamp",
+		},
+	)); err != nil {
+		t.Fatalf("publish active error: %v", err)
+	}
+	beforeDelete, err := repo.LoadTaskStatusSummaries(ctx, []string{taskID})
+	if err != nil {
+		t.Fatalf("load summary before delete: %v", err)
+	}
+	if summary := beforeDelete[taskID]; summary == nil || summary.ActiveError == nil {
+		t.Fatalf("summary before delete = %+v, want active error", summary)
+	}
+
+	if err := svc.DeleteSession(ctx, sessionID); err != nil {
+		t.Fatalf("DeleteSession: %v", err)
+	}
+
+	afterDelete, err := repo.LoadTaskStatusSummaries(ctx, []string{taskID})
+	if err != nil {
+		t.Fatalf("load summary after delete: %v", err)
+	}
+	if summary := afterDelete[taskID]; summary == nil || summary.ActiveError != nil {
+		t.Fatalf("summary after delete = %+v, want deleted session error cleared", summary)
+	}
+}
 
 func TestQueueStatusNotifyUsesDetachedContext(t *testing.T) {
 	// Production: ArchiveTask commits then calls notify with the request ctx.

--- a/apps/backend/internal/orchestrator/service.go
+++ b/apps/backend/internal/orchestrator/service.go
@@ -615,6 +615,12 @@ type Service struct {
 	// clobber the task back to REVIEW while work is active.
 	taskRuntimeStateMu sync.Mutex
 
+	// taskSessionErrorLocks serialize session deletion with retained-error
+	// selection and publication for each task. Entries are reference-counted
+	// and reclaimed after the last concurrent operation releases them.
+	taskSessionErrorLocksMu sync.Mutex
+	taskSessionErrorLocks   map[string]*taskSessionErrorGuard
+
 	// completedExecutions records execution IDs that have reached a terminal
 	// agent lifecycle event. Buffered stream/tool events for these executions
 	// must not wake their session back to RUNNING after the terminal path makes

--- a/apps/backend/internal/orchestrator/task_operations.go
+++ b/apps/backend/internal/orchestrator/task_operations.go
@@ -2830,20 +2830,90 @@ func (s *Service) publishDeletedSessionError(ctx context.Context, taskID, sessio
 	if s.eventBus == nil {
 		return
 	}
-	if err := s.eventBus.Publish(context.WithoutCancel(ctx), events.TaskSessionErrorChanged, bus.NewEvent(
-		events.TaskSessionErrorChanged,
-		"orchestrator",
-		map[string]interface{}{
-			"task_id":    taskID,
-			"session_id": sessionID,
-			"active":     false,
-		},
-	)); err != nil {
+	eventCtx := context.WithoutCancel(ctx)
+	if err := s.publishTaskSessionErrorEvent(eventCtx, taskID, sessionID, false, nil); err != nil {
 		s.logger.Warn("failed to publish deleted task session error event",
 			zap.String("task_id", taskID),
 			zap.String("session_id", sessionID),
 			zap.Error(err))
 	}
+
+	retainedSessionID, lastError, err := s.newestRetainedSessionError(eventCtx, taskID)
+	if err != nil {
+		s.logger.Warn("failed to reload retained task session error after delete",
+			zap.String("task_id", taskID),
+			zap.String("session_id", sessionID),
+			zap.Error(err))
+		return
+	}
+	if lastError == nil {
+		return
+	}
+	if err := s.publishTaskSessionErrorEvent(eventCtx, taskID, retainedSessionID, true, lastError); err != nil {
+		s.logger.Warn("failed to republish retained task session error after delete",
+			zap.String("task_id", taskID),
+			zap.String("session_id", retainedSessionID),
+			zap.Error(err))
+	}
+}
+
+func (s *Service) newestRetainedSessionError(
+	ctx context.Context,
+	taskID string,
+) (string, *models.LastAgentError, error) {
+	sessions, err := s.repo.ListTaskSessions(ctx, taskID)
+	if err != nil {
+		return "", nil, err
+	}
+	var newestSessionID string
+	var newest models.LastAgentError
+	found := false
+	for _, session := range sessions {
+		if session == nil {
+			continue
+		}
+		lastError, ok := models.LoadLastAgentError(session.Metadata)
+		if !ok || lastError.IsDismissed() {
+			continue
+		}
+		if found && !lastError.OccurredAt.After(newest.OccurredAt) {
+			continue
+		}
+		newestSessionID = session.ID
+		newest = lastError
+		found = true
+	}
+	if !found {
+		return "", nil, nil
+	}
+	return newestSessionID, &newest, nil
+}
+
+func (s *Service) publishTaskSessionErrorEvent(
+	ctx context.Context,
+	taskID, sessionID string,
+	active bool,
+	lastError *models.LastAgentError,
+) error {
+	eventData := map[string]interface{}{
+		"task_id":    taskID,
+		"session_id": sessionID,
+		"active":     active,
+	}
+	if active && lastError != nil {
+		eventData["message"] = lastError.Message
+		eventData["occurred_at"] = lastError.OccurredAt.Format(time.RFC3339Nano)
+		eventData["stamp"] = lastError.Stamp()
+		eventData["agent_execution_id"] = lastError.AgentExecutionID
+		if lastError.RemediationURL != "" {
+			eventData["remediation_url"] = lastError.RemediationURL
+		}
+	}
+	return s.eventBus.Publish(ctx, events.TaskSessionErrorChanged, bus.NewEvent(
+		events.TaskSessionErrorChanged,
+		"orchestrator",
+		eventData,
+	))
 }
 
 // cancelDeletedSessionQueue removes pending prompts left on a deleted session

--- a/apps/backend/internal/orchestrator/task_operations.go
+++ b/apps/backend/internal/orchestrator/task_operations.go
@@ -2793,10 +2793,9 @@ func (s *Service) DeleteSession(ctx context.Context, sessionID string) error {
 		zap.String("state", string(session.State)),
 		zap.Bool("was_primary", wasPrimary))
 
-	if err := s.repo.DeleteTaskSession(ctx, sessionID); err != nil {
+	if err := s.deleteSessionAndPublishError(ctx, taskID, sessionID); err != nil {
 		return fmt.Errorf("failed to delete session: %w", err)
 	}
-	s.publishDeletedSessionError(ctx, taskID, sessionID)
 
 	// Drop the in-memory git snapshot throttle entry — the session will
 	// never receive another git event, so its cache slot is dead weight.
@@ -2823,6 +2822,19 @@ func (s *Service) DeleteSession(ctx context.Context, sessionID string) error {
 		s.promoteNextPrimaryAfterRemoval(ctx, taskID, sessionID)
 	}
 
+	return nil
+}
+
+func (s *Service) deleteSessionAndPublishError(ctx context.Context, taskID, sessionID string) error {
+	lock, release := s.acquireTaskSessionErrorGuard(taskID)
+	defer release()
+	lock.Lock()
+	defer lock.Unlock()
+
+	if err := s.repo.DeleteTaskSession(ctx, sessionID); err != nil {
+		return err
+	}
+	s.publishDeletedSessionError(ctx, taskID, sessionID)
 	return nil
 }
 
@@ -4330,6 +4342,40 @@ func (s *Service) DrainQueuedMessage(ctx context.Context, sessionID string) (boo
 type cancelInFlightGuard struct {
 	mu   sync.Mutex
 	refs int
+}
+
+type taskSessionErrorGuard struct {
+	mu   sync.Mutex
+	refs int
+}
+
+func (s *Service) acquireTaskSessionErrorGuard(taskID string) (*sync.Mutex, func()) {
+	s.taskSessionErrorLocksMu.Lock()
+	if s.taskSessionErrorLocks == nil {
+		s.taskSessionErrorLocks = make(map[string]*taskSessionErrorGuard)
+	}
+	guard, ok := s.taskSessionErrorLocks[taskID]
+	if !ok {
+		guard = &taskSessionErrorGuard{}
+		s.taskSessionErrorLocks[taskID] = guard
+	}
+	guard.refs++
+	s.taskSessionErrorLocksMu.Unlock()
+
+	var released bool
+	release := func() {
+		if released {
+			return
+		}
+		released = true
+		s.taskSessionErrorLocksMu.Lock()
+		guard.refs--
+		if guard.refs == 0 {
+			delete(s.taskSessionErrorLocks, taskID)
+		}
+		s.taskSessionErrorLocksMu.Unlock()
+	}
+	return &guard.mu, release
 }
 
 type cancellationKind string

--- a/apps/backend/internal/orchestrator/task_operations.go
+++ b/apps/backend/internal/orchestrator/task_operations.go
@@ -2796,6 +2796,7 @@ func (s *Service) DeleteSession(ctx context.Context, sessionID string) error {
 	if err := s.repo.DeleteTaskSession(ctx, sessionID); err != nil {
 		return fmt.Errorf("failed to delete session: %w", err)
 	}
+	s.publishDeletedSessionError(ctx, taskID, sessionID)
 
 	// Drop the in-memory git snapshot throttle entry — the session will
 	// never receive another git event, so its cache slot is dead weight.
@@ -2823,6 +2824,26 @@ func (s *Service) DeleteSession(ctx context.Context, sessionID string) error {
 	}
 
 	return nil
+}
+
+func (s *Service) publishDeletedSessionError(ctx context.Context, taskID, sessionID string) {
+	if s.eventBus == nil {
+		return
+	}
+	if err := s.eventBus.Publish(context.WithoutCancel(ctx), events.TaskSessionErrorChanged, bus.NewEvent(
+		events.TaskSessionErrorChanged,
+		"orchestrator",
+		map[string]interface{}{
+			"task_id":    taskID,
+			"session_id": sessionID,
+			"active":     false,
+		},
+	)); err != nil {
+		s.logger.Warn("failed to publish deleted task session error event",
+			zap.String("task_id", taskID),
+			zap.String("session_id", sessionID),
+			zap.Error(err))
+	}
 }
 
 // cancelDeletedSessionQueue removes pending prompts left on a deleted session

--- a/apps/backend/internal/orchestrator/task_session_error_fixup_test.go
+++ b/apps/backend/internal/orchestrator/task_session_error_fixup_test.go
@@ -1,0 +1,227 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/events"
+	"github.com/kandev/kandev/internal/events/bus"
+	"github.com/kandev/kandev/internal/orchestrator/watcher"
+	"github.com/kandev/kandev/internal/task/models"
+	"github.com/kandev/kandev/internal/task/statussummary"
+	v1 "github.com/kandev/kandev/pkg/api/v1"
+)
+
+type recoverableFailureReadErrorRepo struct {
+	sessionExecutorStore
+	err  error
+	once sync.Once
+}
+
+func (r *recoverableFailureReadErrorRepo) GetTaskSession(
+	ctx context.Context,
+	sessionID string,
+) (*models.TaskSession, error) {
+	failed := false
+	r.once.Do(func() { failed = true })
+	if failed {
+		return nil, r.err
+	}
+	return r.sessionExecutorStore.GetTaskSession(ctx, sessionID)
+}
+
+func TestHandleRecoverableFailureContinuesAfterTransientSessionReadError(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	const taskID = "task-session-error-read"
+	const sessionID = "session-error-read"
+	seedTaskAndSession(t, repo, taskID, sessionID, models.TaskSessionStateRunning)
+
+	agentManager := &mockAgentManager{repoForExecutionLookup: repo}
+	taskRepo := newMockTaskRepo()
+	seedMockTaskState(taskRepo, taskID, v1.TaskStateInProgress)
+	svc := createTestServiceWithScheduler(repo, newMockStepGetter(), taskRepo, agentManager)
+	messageCreator := &mockMessageCreator{}
+	svc.messageCreator = messageCreator
+	svc.repo = &recoverableFailureReadErrorRepo{
+		sessionExecutorStore: svc.repo,
+		err:                  errors.New("temporary session read failure"),
+	}
+
+	svc.handleRecoverableFailure(ctx, watcher.AgentEventData{
+		TaskID:           taskID,
+		SessionID:        sessionID,
+		AgentExecutionID: "exec-read-error",
+		ErrorMessage:     "agent failed while loading session",
+	})
+
+	session, err := repo.GetTaskSession(ctx, sessionID)
+	if err != nil {
+		t.Fatalf("GetTaskSession: %v", err)
+	}
+	lastError, ok := models.LoadLastAgentError(session.Metadata)
+	if !ok || lastError.Message != "agent failed while loading session" {
+		t.Fatalf("last agent error = %#v, want persisted recovery error", lastError)
+	}
+	if session.State != models.TaskSessionStateWaitingForInput {
+		t.Fatalf("session state = %q, want WAITING_FOR_INPUT", session.State)
+	}
+	if len(messageCreator.sessionMessages) == 0 {
+		t.Fatal("recoverable failure did not create a recovery status message")
+	}
+	waitForStopCall(t, agentManager)
+}
+
+type blockingTaskSessionErrorBus struct {
+	bus.EventBus
+	taskID    string
+	sessionID string
+	entered   chan struct{}
+	release   chan struct{}
+	once      sync.Once
+}
+
+func (b *blockingTaskSessionErrorBus) Publish(
+	ctx context.Context,
+	subject string,
+	event *bus.Event,
+) error {
+	if subject == events.TaskSessionErrorChanged {
+		data, _ := event.Data.(map[string]interface{})
+		active, _ := data["active"].(bool)
+		if data["task_id"] == b.taskID && data["session_id"] == b.sessionID && active {
+			b.once.Do(func() {
+				close(b.entered)
+				<-b.release
+			})
+		}
+	}
+	return b.EventBus.Publish(ctx, subject, event)
+}
+
+func TestConcurrentSessionDeletionDoesNotRepublishDeletedSessionError(t *testing.T) {
+	ctx := context.Background()
+	const taskID = "task-session-error-delete-race"
+	const firstSessionID = "session-error-delete-first"
+	const secondSessionID = "session-error-delete-second"
+	repo := setupTestRepo(t)
+	seedTaskAndSession(t, repo, taskID, firstSessionID, models.TaskSessionStateCompleted)
+	now := time.Now().UTC()
+	if err := repo.CreateTaskSession(ctx, &models.TaskSession{
+		ID: secondSessionID, TaskID: taskID, State: models.TaskSessionStateCompleted,
+		StartedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("CreateTaskSession(%s): %v", secondSessionID, err)
+	}
+	for sessionID, lastError := range map[string]models.LastAgentError{
+		firstSessionID: {
+			Message:    firstSessionID + " failed",
+			OccurredAt: time.Date(2026, 8, 15, 10, 0, 0, 0, time.UTC),
+		},
+		secondSessionID: {
+			Message:    secondSessionID + " failed",
+			OccurredAt: time.Date(2026, 8, 15, 11, 0, 0, 0, time.UTC),
+		},
+	} {
+		if err := repo.SetSessionMetadataKey(ctx, sessionID, models.SessionMetaKeyLastAgentError, lastError); err != nil {
+			t.Fatalf("set last agent error for %s: %v", sessionID, err)
+		}
+	}
+
+	svc := createTestService(repo, newMockStepGetter(), newMockTaskRepo())
+	eventBus := bus.NewMemoryEventBus(testLogger())
+	t.Cleanup(func() { eventBus.Close() })
+	svc.eventBus = eventBus
+	projector := statussummary.NewProjector(statussummary.ProjectorConfig{
+		Store:              repo,
+		EventBus:           eventBus,
+		ResolveWorkspace:   func(context.Context, string) (string, error) { return "ws1", nil },
+		CountQueuedPrompts: svc.messageQueue.CountPendingByTask,
+	})
+	projectorCtx, stopProjector := context.WithCancel(ctx)
+	t.Cleanup(func() {
+		stopProjector()
+		projector.Close()
+	})
+	if err := projector.Start(projectorCtx); err != nil {
+		t.Fatalf("start status summary projector: %v", err)
+	}
+	for sessionID, stamp := range map[string]string{
+		firstSessionID:  "error-first",
+		secondSessionID: "error-second",
+	} {
+		if err := eventBus.Publish(ctx, events.TaskSessionErrorChanged, bus.NewEvent(
+			events.TaskSessionErrorChanged,
+			"test",
+			map[string]interface{}{
+				"task_id":     taskID,
+				"session_id":  sessionID,
+				"active":      true,
+				"message":     sessionID + " failed",
+				"occurred_at": "2026-08-15T10:00:00Z",
+				"stamp":       stamp,
+			},
+		)); err != nil {
+			t.Fatalf("publish active error for %s: %v", sessionID, err)
+		}
+	}
+
+	errorBus := &blockingTaskSessionErrorBus{
+		EventBus:  eventBus,
+		taskID:    taskID,
+		sessionID: secondSessionID,
+		entered:   make(chan struct{}),
+		release:   make(chan struct{}),
+	}
+	svc.eventBus = errorBus
+	firstDone := make(chan error, 1)
+	go func() { firstDone <- svc.DeleteSession(ctx, firstSessionID) }()
+	select {
+	case <-errorBus.entered:
+	case <-time.After(time.Second):
+		t.Fatal("first deletion did not reach retained-error selection barrier")
+	}
+
+	secondDone := make(chan error, 1)
+	go func() { secondDone <- svc.DeleteSession(ctx, secondSessionID) }()
+	secondFinishedBeforeRelease := false
+	select {
+	case err := <-secondDone:
+		if err != nil {
+			t.Fatalf("second DeleteSession: %v", err)
+		}
+		secondFinishedBeforeRelease = true
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(errorBus.release)
+
+	select {
+	case err := <-firstDone:
+		if err != nil {
+			t.Fatalf("first DeleteSession: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("first deletion did not finish after releasing barrier")
+	}
+	if !secondFinishedBeforeRelease {
+		select {
+		case err := <-secondDone:
+			if err != nil {
+				t.Fatalf("second DeleteSession: %v", err)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("second deletion did not finish after releasing barrier")
+		}
+	}
+
+	summaries, err := repo.LoadTaskStatusSummaries(ctx, []string{taskID})
+	if err != nil {
+		t.Fatalf("load summary after concurrent deletion: %v", err)
+	}
+	if summary := summaries[taskID]; summary == nil || summary.ActiveError != nil {
+		t.Fatalf("summary after concurrent deletion = %+v, want no deleted-session error", summary)
+	}
+}

--- a/docs/plans/deleted-session-error-summary/plan.md
+++ b/docs/plans/deleted-session-error-summary/plan.md
@@ -14,6 +14,9 @@ The repair publishes that occurrence after a successful deletion and proves the 
 When a restarted projector has hydrated the deleted session as the current winner,
 the repair also republishes the newest retained session error so the single-value
 summary converges to the remaining authoritative error.
+The repair treats only an authoritative not-found read as proof that a session was
+deleted, and serializes deletion, retained-error selection, and repair publication
+per task so concurrent deletions cannot restore a removed error.
 
 ## Backend
 
@@ -29,6 +32,12 @@ After the repository removes the session row, publish `events.TaskSessionErrorCh
 Use a context without request cancellation because the database deletion is complete.
 Treat publication as best effort and log an error with the task and session IDs.
 Keep the existing runtime quiescence, queue cleanup, workspace retention, and primary-session promotion behavior.
+
+The deletion and retained-error repair run under a reference-counted task-level
+guard. A transient session read failure in recoverable-error handling is logged
+and continues through the existing persistence, state-reconciliation, recovery
+message, and execution-cleanup path; only `models.ErrTaskSessionNotFound`
+suppresses that work.
 
 ## Frontend
 
@@ -53,6 +62,18 @@ Desktop and mobile task switchers already consume the complete `status_summary` 
 - **File:** `apps/backend/internal/orchestrator/queue_purge_status_test.go`
 - **How:** Hold the per-session deletion guard and assert that recovery waits before persisting
   or publishing an active error.
+- **What:** A transient session read failure does not suppress recovery or cleanup.
+- **File:** `apps/backend/internal/orchestrator/task_session_error_fixup_test.go`
+- **How:** Inject one non-not-found `GetTaskSession` error and assert that error metadata,
+  waiting-for-input state, recovery messaging, and execution cleanup still occur.
+- **What:** Concurrent deletions cannot re-publish an error for a session deleted by a sibling.
+- **File:** `apps/backend/internal/orchestrator/task_session_error_fixup_test.go`
+- **How:** Block the retained-error publication from one deletion, start a second deletion,
+  and assert that the second deletion waits and the final summary has no active error.
+- **What:** Projector restart tests stop the old projector before starting its replacement.
+- **File:** `apps/backend/internal/orchestrator/queue_purge_status_test.go`
+- **How:** Close the first projector synchronously in the returned stop function before cold-start
+  hydration, so deletion events cannot be consumed by the stale in-memory projector.
 
 No E2E change is required.
 The backend integration test covers the same complete summary payload that both task switchers consume.
@@ -68,6 +89,19 @@ cd apps/backend && go test -tags fts5 -run 'TestDeleteSessionClearsProjectedAgen
 Result: 2 tests passed initially; the retained-session restart regression and guard regression
 also passed during PR fixup, for 4 focused tests total.
 
+Blocker fixup verification:
+
+```text
+go test -tags fts5 -run 'TestHandleRecoverableFailureContinuesAfterTransientSessionReadError|TestConcurrentSessionDeletionDoesNotRepublishDeletedSessionError|TestDeleteSessionRetainsOtherProjectedAgentErrorAfterRestart' ./internal/orchestrator -count=1
+Go test: 3 passed in 1 packages
+
+go test -race -tags fts5 -run 'TestHandleRecoverableFailureContinuesAfterTransientSessionReadError|TestConcurrentSessionDeletionDoesNotRepublishDeletedSessionError|TestDeleteSessionRetainsOtherProjectedAgentErrorAfterRestart|TestRecoverableFailureWaitsForSessionDeletionGuard|TestDeleteSessionClearsProjectedAgentError|TestDeleteSessionCancelsQueuedPromptsAndPublishesStatus' ./internal/orchestrator -count=1
+Go test: 6 passed in 1 packages
+
+go test -tags fts5 ./internal/orchestrator -count=1
+Go test: 1812 passed in 1 packages
+```
+
 ## Implementation Waves And Parallel Candidates
 
 - [x] [Task 01: Clear the deleted session error](task-01-clear-deleted-session-error.md)
@@ -80,3 +114,7 @@ Execution is sequential in the primary conversation.
 - The repair does not delete task workspaces, task environments, transcripts, or replacement sessions.
 - The repair does not change error classification, error text, or error dismissal behavior.
 - A failed event publication retains the last valid summary until a later authoritative rebuild.
+- A transient read failure during recoverable-error handling is logged and follows the existing
+  recovery path; only an authoritative missing-session error suppresses it.
+- Task-level serialization keeps concurrent deletion repair events ordered with the authoritative
+  session-row removals.

--- a/docs/plans/deleted-session-error-summary/plan.md
+++ b/docs/plans/deleted-session-error-summary/plan.md
@@ -11,6 +11,9 @@ status: done
 `DeleteSession` removes the session row but does not publish an inactive session-error occurrence.
 The stored task summary therefore retains an error that belongs to a removed session.
 The repair publishes that occurrence after a successful deletion and proves the full summary path.
+When a restarted projector has hydrated the deleted session as the current winner,
+the repair also republishes the newest retained session error so the single-value
+summary converges to the remaining authoritative error.
 
 ## Backend
 
@@ -42,6 +45,14 @@ Desktop and mobile task switchers already consume the complete `status_summary` 
 - **What:** Session deletion still removes only the deleted session's queued prompts.
 - **File:** `apps/backend/internal/orchestrator/queue_purge_status_test.go`
 - **How:** Run the existing queue cleanup regression with the new error-summary regression.
+- **What:** Deleting the newer error after a projector restart preserves an older retained error.
+- **File:** `apps/backend/internal/orchestrator/queue_purge_status_test.go`
+- **How:** Hydrate a summary with two session errors, restart the projector, delete the newer
+  session, and assert that the retained session is the summary's active error.
+- **What:** Recoverable error handling serializes with session deletion.
+- **File:** `apps/backend/internal/orchestrator/queue_purge_status_test.go`
+- **How:** Hold the per-session deletion guard and assert that recovery waits before persisting
+  or publishing an active error.
 
 No E2E change is required.
 The backend integration test covers the same complete summary payload that both task switchers consume.
@@ -54,7 +65,8 @@ Passed:
 cd apps/backend && go test -tags fts5 -run 'TestDeleteSessionClearsProjectedAgentError|TestDeleteSessionCancelsQueuedPromptsAndPublishesStatus' ./internal/orchestrator -count=1
 ```
 
-Result: 2 tests passed.
+Result: 2 tests passed initially; the retained-session restart regression and guard regression
+also passed during PR fixup, for 4 focused tests total.
 
 ## Implementation Waves And Parallel Candidates
 

--- a/docs/plans/deleted-session-error-summary/plan.md
+++ b/docs/plans/deleted-session-error-summary/plan.md
@@ -1,0 +1,70 @@
+---
+spec: docs/specs/platform/bounded-task-status-delivery.md
+created: 2026-08-15
+status: done
+---
+
+# Implementation Plan: Clear Deleted Session Errors
+
+## Overview
+
+`DeleteSession` removes the session row but does not publish an inactive session-error occurrence.
+The stored task summary therefore retains an error that belongs to a removed session.
+The repair publishes that occurrence after a successful deletion and proves the full summary path.
+
+## Backend
+
+### Session deletion
+
+Update `Service.DeleteSession` in `apps/backend/internal/orchestrator/task_operations.go`.
+After the repository removes the session row, publish `events.TaskSessionErrorChanged` with these fields:
+
+- `task_id`: the owning task ID.
+- `session_id`: the removed session ID.
+- `active`: `false`.
+
+Use a context without request cancellation because the database deletion is complete.
+Treat publication as best effort and log an error with the task and session IDs.
+Keep the existing runtime quiescence, queue cleanup, workspace retention, and primary-session promotion behavior.
+
+## Frontend
+
+No frontend change is required.
+Desktop and mobile task switchers already consume the complete `status_summary` replacement.
+
+## Tests
+
+- **What:** A successful session deletion removes that session's active error from the persisted task summary.
+- **File:** `apps/backend/internal/orchestrator/queue_purge_status_test.go`
+- **How:** Start the real status-summary projector on the service event bus.
+  Publish an active error for a completed session, delete the session, and load the stored summary.
+  The test must fail before the source change and pass after it.
+- **What:** Session deletion still removes only the deleted session's queued prompts.
+- **File:** `apps/backend/internal/orchestrator/queue_purge_status_test.go`
+- **How:** Run the existing queue cleanup regression with the new error-summary regression.
+
+No E2E change is required.
+The backend integration test covers the same complete summary payload that both task switchers consume.
+
+## Verification Results
+
+Passed:
+
+```text
+cd apps/backend && go test -tags fts5 -run 'TestDeleteSessionClearsProjectedAgentError|TestDeleteSessionCancelsQueuedPromptsAndPublishesStatus' ./internal/orchestrator -count=1
+```
+
+Result: 2 tests passed.
+
+## Implementation Waves And Parallel Candidates
+
+- [x] [Task 01: Clear the deleted session error](task-01-clear-deleted-session-error.md)
+
+Execution is sequential in the primary conversation.
+
+## Risks And Out Of Scope
+
+- The repair does not change session deletion permissions or running-session validation.
+- The repair does not delete task workspaces, task environments, transcripts, or replacement sessions.
+- The repair does not change error classification, error text, or error dismissal behavior.
+- A failed event publication retains the last valid summary until a later authoritative rebuild.

--- a/docs/plans/deleted-session-error-summary/task-01-clear-deleted-session-error.md
+++ b/docs/plans/deleted-session-error-summary/task-01-clear-deleted-session-error.md
@@ -20,12 +20,18 @@ Remove a deleted session's error from the task status summary immediately after 
 - The persisted task summary has no error from the removed session after the projector processes the occurrence.
 - If another session has a recoverable error, deleting the current summary winner leaves the retained session's error projected.
 - Recoverable error persistence and publication serialize with session deletion for the same session.
+- A transient non-not-found session read error does not skip recovery state reconciliation, messaging, or execution cleanup.
+- Concurrent deletions of sessions in one task cannot restore an error for a session that was already deleted.
+- The projector restart regression stops the old projector synchronously before cold-start hydration.
 - Existing queue cleanup, workspace retention, and primary-session promotion behavior remains unchanged.
 
 ## Files Likely Touched
 
 - `apps/backend/internal/orchestrator/task_operations.go`
 - `apps/backend/internal/orchestrator/queue_purge_status_test.go`
+- `apps/backend/internal/orchestrator/event_handlers_agent.go`
+- `apps/backend/internal/orchestrator/service.go`
+- `apps/backend/internal/orchestrator/task_session_error_fixup_test.go`
 
 ## Dependencies
 
@@ -50,6 +56,10 @@ None.
 5. Use `context.WithoutCancel` for the post-commit publication and log publication errors.
 6. Re-publish the newest retained session error after deletion to repair a summary hydrated before the deletion.
 7. Serialize recoverable-error side effects with the session deletion guard.
+8. Continue recoverable-error handling after transient session reads, while suppressing it only for
+   `models.ErrTaskSessionNotFound`.
+9. Serialize deletion and retained-error repair by task, with a barrier regression for concurrent deletions.
+10. Stop the old status-summary projector synchronously in the restart regression.
 
 ## Verification
 
@@ -80,5 +90,11 @@ Completed.
   focused fixup command passed.
 - Re-published the newest retained session error after deletion and serialized
   recoverable-error publication with the session deletion guard.
+- Added a transient-read fault-injection regression and restored the existing
+  recovery/state/cleanup path for non-not-found read errors.
+- Added task-level serialization and a barrier-based concurrent-deletion regression.
+- The restart regression now closes the old projector before starting the replacement.
+- Verification passed: 3 focused tests, 6 focused race tests, and 1,812 orchestrator
+  package tests.
 - No blockers. Event publication remains best effort, and a later authoritative
   rebuild can repair a summary if publication fails.

--- a/docs/plans/deleted-session-error-summary/task-01-clear-deleted-session-error.md
+++ b/docs/plans/deleted-session-error-summary/task-01-clear-deleted-session-error.md
@@ -1,0 +1,76 @@
+---
+id: "01-clear-deleted-session-error"
+title: "Clear the deleted session error"
+status: done
+wave: 1
+depends_on: []
+plan: "plan.md"
+spec: "../../specs/platform/bounded-task-status-delivery.md"
+---
+
+# Task 01: Clear the Deleted Session Error
+
+## Intent
+
+Remove a deleted session's error from the task status summary immediately after session deletion.
+
+## Acceptance
+
+- A successful `Service.DeleteSession` publishes one inactive error occurrence for the removed session.
+- The persisted task summary has no error from the removed session after the projector processes the occurrence.
+- Existing queue cleanup, workspace retention, and primary-session promotion behavior remains unchanged.
+
+## Files Likely Touched
+
+- `apps/backend/internal/orchestrator/task_operations.go`
+- `apps/backend/internal/orchestrator/queue_purge_status_test.go`
+
+## Dependencies
+
+None.
+
+## Parallelism
+
+`sequential`
+
+## Inputs
+
+- The `active_error` derivation and deletion scenario in the bounded task-status delivery spec.
+- The existing inactive `TaskSessionErrorChanged` contract in `statussummary.Projector`.
+- The queue-status publication pattern in `Service.DeleteSession`.
+
+## Implementation
+
+1. Add a regression test that starts the status-summary projector on the service event bus.
+2. Publish an active error for a completed session and make sure that the stored summary contains it.
+3. Delete the session and make sure that the stored summary removes the error.
+4. Publish an inactive session-error occurrence after the repository removes the session row.
+5. Use `context.WithoutCancel` for the post-commit publication and log publication errors.
+
+## Verification
+
+Run this command from the repository root:
+
+```bash
+cd apps/backend && go test -tags fts5 -run 'TestDeleteSessionClearsProjectedAgentError|TestDeleteSessionCancelsQueuedPromptsAndPublishesStatus' ./internal/orchestrator -count=1
+```
+
+## Output Contract
+
+Report the source and test files that changed.
+Report the exact command and its result.
+Update this task status, this task's results, the plan checkbox, and the plan verification results.
+Report blockers and remaining risks.
+
+## Results
+
+Completed.
+
+- Changed `apps/backend/internal/orchestrator/task_operations.go` to publish an
+  inactive `TaskSessionErrorChanged` occurrence after session deletion commits.
+- Added `TestDeleteSessionClearsProjectedAgentError` to
+  `apps/backend/internal/orchestrator/queue_purge_status_test.go`.
+- Verification passed: 2 tests passed with the command in this task's
+  Verification section.
+- No blockers. Event publication remains best effort, and a later authoritative
+  rebuild can repair a summary if publication fails.

--- a/docs/plans/deleted-session-error-summary/task-01-clear-deleted-session-error.md
+++ b/docs/plans/deleted-session-error-summary/task-01-clear-deleted-session-error.md
@@ -18,6 +18,8 @@ Remove a deleted session's error from the task status summary immediately after 
 
 - A successful `Service.DeleteSession` publishes one inactive error occurrence for the removed session.
 - The persisted task summary has no error from the removed session after the projector processes the occurrence.
+- If another session has a recoverable error, deleting the current summary winner leaves the retained session's error projected.
+- Recoverable error persistence and publication serialize with session deletion for the same session.
 - Existing queue cleanup, workspace retention, and primary-session promotion behavior remains unchanged.
 
 ## Files Likely Touched
@@ -46,6 +48,8 @@ None.
 3. Delete the session and make sure that the stored summary removes the error.
 4. Publish an inactive session-error occurrence after the repository removes the session row.
 5. Use `context.WithoutCancel` for the post-commit publication and log publication errors.
+6. Re-publish the newest retained session error after deletion to repair a summary hydrated before the deletion.
+7. Serialize recoverable-error side effects with the session deletion guard.
 
 ## Verification
 
@@ -70,7 +74,11 @@ Completed.
   inactive `TaskSessionErrorChanged` occurrence after session deletion commits.
 - Added `TestDeleteSessionClearsProjectedAgentError` to
   `apps/backend/internal/orchestrator/queue_purge_status_test.go`.
-- Verification passed: 2 tests passed with the command in this task's
-  Verification section.
+- Added restart and guard regressions in
+  `apps/backend/internal/orchestrator/queue_purge_status_test.go`.
+- Verification passed: the original 2-test command passed, and the 4-test
+  focused fixup command passed.
+- Re-published the newest retained session error after deletion and serialized
+  recoverable-error publication with the session deletion guard.
 - No blockers. Event publication remains best effort, and a later authoritative
   rebuild can repair a summary if publication fails.

--- a/docs/specs/platform/bounded-task-status-delivery.md
+++ b/docs/specs/platform/bounded-task-status-delivery.md
@@ -236,6 +236,10 @@ intermediate replacement.
 - **GIVEN** a stopped session owns the task's `active_error`, **WHEN** the user
   deletes that session, **THEN** desktop and mobile task switchers remove its
   error indicator while the task and replacement sessions remain available.
+- **GIVEN** two sessions have recoverable errors and the stored summary points
+  to the newer error, **WHEN** the projector restarts and the newer session is
+  deleted, **THEN** the retained session's error becomes the task's
+  `active_error` instead of leaving the summary empty.
 - **GIVEN** a session's agent requests permission and, before that request is
   answered, the same session emits an unrelated tool call/execute/read message
   that reaches its own terminal status, **WHEN** the projector processes that

--- a/docs/specs/platform/bounded-task-status-delivery.md
+++ b/docs/specs/platform/bounded-task-status-delivery.md
@@ -135,6 +135,9 @@ remain during migration, but switchers use the summary when present.
   batch summary reads and may batch repairs; they do not perform an N+1 query.
 - Existing rows are repaired after startup recovery changes authoritative session state. Missing-row
   hydration is not the only recovery path for a stale summary.
+- Session deletion repair serializes the authoritative row removal, retained-error
+  selection, and inactive/active error publication by task. Concurrent deletions
+  therefore cannot restore an error for a session that has already been removed.
 - Live Git observations remain coalesced before persistence/publication.
   Running executions maintain the slow monitoring baseline independently of
   browser subscribers; active focus may request fast monitoring. Settled tasks
@@ -217,6 +220,10 @@ intermediate replacement.
 - If `status_summary` is temporarily absent during rollout, task rows use the
   existing coarse task fields and omit unavailable decorations; they do not
   subscribe to inactive sessions.
+- If recoverable-error handling cannot read a session because of a transient
+  database or metadata error, it logs the read failure and keeps the existing
+  recovery, state-reconciliation, and cleanup behavior. Only an authoritative
+  missing-session result suppresses those side effects.
 
 ## Scenarios
 
@@ -240,6 +247,9 @@ intermediate replacement.
   to the newer error, **WHEN** the projector restarts and the newer session is
   deleted, **THEN** the retained session's error becomes the task's
   `active_error` instead of leaving the summary empty.
+- **GIVEN** two sessions in one task have recoverable errors, **WHEN** both
+  sessions are deleted concurrently while retained-error repair is in flight,
+  **THEN** the final task summary contains no error for either deleted session.
 - **GIVEN** a session's agent requests permission and, before that request is
   answered, the same session emits an unrelated tool call/execute/read message
   that reaches its own terminal status, **WHEN** the projector processes that

--- a/docs/specs/platform/bounded-task-status-delivery.md
+++ b/docs/specs/platform/bounded-task-status-delivery.md
@@ -1,7 +1,7 @@
 ---
 status: approved
 created: 2026-08-01
-updated: 2026-08-09
+updated: 2026-08-15
 owner: kandev
 ---
 
@@ -86,6 +86,9 @@ remain during migration, but switchers use the summary when present.
 - `active_error` is independent of the primary state icon. It represents the
   newest relevant recoverable agent error and clears after an authoritative
   dismissal or a newer agent response according to the existing error rules.
+- Successful session deletion is an authoritative removal of that session's
+  error. The summary removes the error without a backend restart or another
+  session event.
 - Git totals aggregate the latest observation for every repository in the
   task. A multi-repository update must not expose a partial replacement that
   forgets unchanged repositories.
@@ -230,6 +233,9 @@ intermediate replacement.
 - **GIVEN** a recoverable error is dismissed or followed by a newer agent
   response, **WHEN** the projector processes that occurrence, **THEN** the
   independent error indicator clears on both task switchers.
+- **GIVEN** a stopped session owns the task's `active_error`, **WHEN** the user
+  deletes that session, **THEN** desktop and mobile task switchers remove its
+  error indicator while the task and replacement sessions remain available.
 - **GIVEN** a session's agent requests permission and, before that request is
   answered, the same session emits an unrelated tool call/execute/read message
   that reaches its own terminal status, **WHEN** the projector processes that
@@ -289,3 +295,5 @@ intermediate replacement.
   [`../../plans/session-stream-overload-isolation/plan.md`](../../plans/session-stream-overload-isolation/plan.md)
 - Startup-summary repair:
   [`../../plans/backend-runtime-state-ownership/plan.md`](../../plans/backend-runtime-state-ownership/plan.md)
+- Deleted-session error repair:
+  [`../../plans/deleted-session-error-summary/plan.md`](../../plans/deleted-session-error-summary/plan.md)


### PR DESCRIPTION
Deleting a completed session removed its authoritative row without notifying the task status projector, so the task switcher retained that session's active error. The deletion path now publishes a detached inactive error occurrence after commit, and an integration regression proves the persisted summary clears while queued prompts remain covered.

## Validation

- `cd apps/backend && go test -tags fts5 -run 'TestDeleteSessionClearsProjectedAgentError|TestDeleteSessionCancelsQueuedPromptsAndPublishesStatus' ./internal/orchestrator -count=1` (2 passed)
- `cd apps/backend && go test -race -tags fts5 -run 'TestDeleteSessionClearsProjectedAgentError|TestDeleteSessionCancelsQueuedPromptsAndPublishesStatus' ./internal/orchestrator -count=1` (2 passed)
- `git diff --check`
- Normal pre-commit and commit-msg hooks ran successfully during commit.
- No public docs change is needed; the bounded task-status spec and implementation plan record the internal contract and result.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2688?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->