### PR TITLE
fix: resolve mobile Add folder executor race in workspace sources

### DIFF
--- a/apps/web/components/task/add-workspace-sources/add-folder-button.tsx
+++ b/apps/web/components/task/add-workspace-sources/add-folder-button.tsx
@@ -28,7 +28,7 @@ export function AddFolderButton({
       <span className="flex flex-col items-start">
         <span>{t("task:addFolder")}</span>
         {!capabilities.executorCapabilitiesKnown && (
-          <span className="text-[10px] text-muted-foreground normal-case">
+          <span className="text-xs text-muted-foreground normal-case">
             {t("task:addFolderExecutorUnknown")}
           </span>
         )}

--- a/apps/web/components/task/add-workspace-sources/add-folder-button.tsx
+++ b/apps/web/components/task/add-workspace-sources/add-folder-button.tsx
@@ -1,0 +1,38 @@
+import { IconFolderPlus } from "@tabler/icons-react";
+import { Button } from "@kandev/ui/button";
+import { useTranslation } from "react-i18next";
+import { cn } from "@/lib/utils";
+import { getWorkspaceSourceCapabilities } from "@/components/workspace-source-picker/executor-capabilities";
+import { type WorkspaceSourceRow } from "@/components/workspace-source-picker/workspace-source-state";
+
+export function AddFolderButton({
+  isMobile,
+  capabilities,
+  onAdd,
+}: {
+  isMobile: boolean;
+  capabilities: ReturnType<typeof getWorkspaceSourceCapabilities>;
+  onAdd: (kind: NonNullable<WorkspaceSourceRow["sourceType"]>) => void;
+}) {
+  const { t } = useTranslation();
+  if (!capabilities.canAddFolders && capabilities.executorCapabilitiesKnown) return null;
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      disabled={!capabilities.canAddFolders}
+      className={cn("cursor-pointer", isMobile ? "min-h-11" : "h-9 px-3")}
+      onClick={() => onAdd("folder")}
+    >
+      <IconFolderPlus className="h-4 w-4" />
+      <span className="flex flex-col items-start">
+        <span>{t("task:addFolder")}</span>
+        {!capabilities.executorCapabilitiesKnown && (
+          <span className="text-[10px] text-muted-foreground normal-case">
+            {t("task:addFolderExecutorUnknown")}
+          </span>
+        )}
+      </span>
+    </Button>
+  );
+}

--- a/apps/web/components/task/add-workspace-sources/add-workspace-sources-dialog.test.tsx
+++ b/apps/web/components/task/add-workspace-sources/add-workspace-sources-dialog.test.tsx
@@ -54,7 +54,7 @@ function Harness({
   executorType = "worktree",
 }: {
   makeTurnActive?: boolean;
-  executorType?: string;
+  executorType?: string | null;
 }) {
   return (
     <StateProvider>
@@ -68,7 +68,7 @@ function HarnessContent({
   executorType,
 }: {
   makeTurnActive: boolean;
-  executorType: string;
+  executorType: string | null;
 }) {
   const [open, setOpen] = useState(false);
   const [opener, setOpener] = useState<HTMLElement | null>(null);
@@ -197,6 +197,24 @@ describe("AddWorkspaceSourcesDialog", () => {
     openRepositoryMenu();
     fireEvent.click(await screen.findByRole("menuitem", { name: "Local Git repository" }));
     expect(form.querySelectorAll('[role="alert"]')).toHaveLength(2);
+  });
+
+  it("shows Add folder disabled with a touch-visible reason while the executor is unresolved", async () => {
+    render(<Harness executorType={null} />);
+
+    fireEvent.click(screen.getByRole("button", { name: ADD_SOURCES_LABEL }));
+    const addFolder = screen.getByRole("button", { name: /Add folder/ }) as HTMLButtonElement;
+    expect(addFolder.disabled).toBe(true);
+    expect(
+      screen.getByText("Waiting to confirm this task's executor supports folders"),
+    ).toBeTruthy();
+  });
+
+  it("keeps Add folder absent once the executor is known not to support folders", async () => {
+    render(<Harness executorType="local_docker" />);
+
+    fireEvent.click(screen.getByRole("button", { name: ADD_SOURCES_LABEL }));
+    expect(screen.queryByRole("button", { name: /Add folder/ })).toBeNull();
   });
 
   it.each([

--- a/apps/web/components/task/add-workspace-sources/add-workspace-sources-dialog.test.tsx
+++ b/apps/web/components/task/add-workspace-sources/add-workspace-sources-dialog.test.tsx
@@ -49,13 +49,9 @@ function openRepositoryMenu() {
   return trigger;
 }
 
-function Harness({
-  makeTurnActive = false,
-  executorType = "worktree",
-}: {
-  makeTurnActive?: boolean;
-  executorType?: string | null;
-}) {
+function Harness(props: { makeTurnActive?: boolean; executorType?: string | null }) {
+  const makeTurnActive = props.makeTurnActive ?? false;
+  const executorType = Object.hasOwn(props, "executorType") ? props.executorType : "worktree";
   return (
     <StateProvider>
       <HarnessContent makeTurnActive={makeTurnActive} executorType={executorType} />
@@ -68,7 +64,7 @@ function HarnessContent({
   executorType,
 }: {
   makeTurnActive: boolean;
-  executorType: string | null;
+  executorType: string | null | undefined;
 }) {
   const [open, setOpen] = useState(false);
   const [opener, setOpener] = useState<HTMLElement | null>(null);
@@ -199,15 +195,18 @@ describe("AddWorkspaceSourcesDialog", () => {
     expect(form.querySelectorAll('[role="alert"]')).toHaveLength(2);
   });
 
-  it("shows Add folder disabled with a touch-visible reason while the executor is unresolved", async () => {
-    render(<Harness executorType={null} />);
+  it.each([null, undefined])(
+    "shows Add folder disabled with a touch-visible reason while the executor is unresolved (%s)",
+    async (executorType) => {
+      render(<Harness executorType={executorType} />);
 
-    fireEvent.click(screen.getByRole("button", { name: ADD_SOURCES_LABEL }));
-    const addFolder = screen.getByRole("button", { name: /Add folder/ }) as HTMLButtonElement;
-    expect(addFolder.disabled).toBe(true);
-    const hint = screen.getByText("Waiting to confirm this task's executor supports folders");
-    expect(hint.className).toContain("text-xs");
-  });
+      fireEvent.click(screen.getByRole("button", { name: ADD_SOURCES_LABEL }));
+      const addFolder = screen.getByRole("button", { name: /Add folder/ }) as HTMLButtonElement;
+      expect(addFolder.disabled).toBe(true);
+      const hint = screen.getByText("Waiting to confirm this task's executor supports folders");
+      expect(hint.className).toContain("text-xs");
+    },
+  );
 
   it("keeps Add folder absent once the executor is known not to support folders", async () => {
     render(<Harness executorType="local_docker" />);

--- a/apps/web/components/task/add-workspace-sources/add-workspace-sources-dialog.test.tsx
+++ b/apps/web/components/task/add-workspace-sources/add-workspace-sources-dialog.test.tsx
@@ -205,9 +205,8 @@ describe("AddWorkspaceSourcesDialog", () => {
     fireEvent.click(screen.getByRole("button", { name: ADD_SOURCES_LABEL }));
     const addFolder = screen.getByRole("button", { name: /Add folder/ }) as HTMLButtonElement;
     expect(addFolder.disabled).toBe(true);
-    expect(
-      screen.getByText("Waiting to confirm this task's executor supports folders"),
-    ).toBeTruthy();
+    const hint = screen.getByText("Waiting to confirm this task's executor supports folders");
+    expect(hint.className).toContain("text-xs");
   });
 
   it("keeps Add folder absent once the executor is known not to support folders", async () => {

--- a/apps/web/components/task/add-workspace-sources/add-workspace-sources-dialog.tsx
+++ b/apps/web/components/task/add-workspace-sources/add-workspace-sources-dialog.tsx
@@ -4,7 +4,6 @@ import { useCallback, useEffect, useState, type RefObject, type ReactNode } from
 import {
   IconChevronDown,
   IconCloudDownload,
-  IconFolderPlus,
   IconGitBranch,
   IconPlus,
   IconStack2,
@@ -47,6 +46,7 @@ import {
   getWorkspaceSourceCapabilities,
   hasCloneableSavedRepository,
 } from "@/components/workspace-source-picker/executor-capabilities";
+import { AddFolderButton } from "./add-folder-button";
 import { SavedRepositorySourceRow } from "./saved-repository-source-row";
 import { useDialogOpenerFocus } from "./use-dialog-opener-focus";
 import { useSubmitWorkspaceSources } from "./use-submit-workspace-sources";
@@ -318,17 +318,7 @@ function SourceForm({
     <div className="space-y-4 py-1" data-testid="add-workspace-sources-form">
       <div className="flex flex-wrap items-center gap-2">
         <RepositorySourceMenu isMobile={isMobile} onAdd={onAdd} />
-        {capabilities.canAddFolders && (
-          <Button
-            type="button"
-            variant="outline"
-            className={cn("cursor-pointer", isMobile ? "min-h-11" : "h-9 px-3")}
-            onClick={() => onAdd("folder")}
-          >
-            <IconFolderPlus className="h-4 w-4" />
-            {t("task:addFolder")}
-          </Button>
-        )}
+        <AddFolderButton isMobile={isMobile} capabilities={capabilities} onAdd={onAdd} />
       </div>
       {capabilities.requiresCloneableLocalRepository && (
         <p className="text-sm text-muted-foreground">

--- a/apps/web/components/workspace-source-picker/executor-capabilities.test.ts
+++ b/apps/web/components/workspace-source-picker/executor-capabilities.test.ts
@@ -25,6 +25,8 @@ describe("getWorkspaceSourceCapabilities", () => {
     "remote_docker",
     "ssh",
     "sprites",
+    "remote_vps",
+    "k8s",
   ] as const)("marks executor capabilities as known once resolved for %s", (executorType) => {
     expect(getWorkspaceSourceCapabilities(executorType).executorCapabilitiesKnown).toBe(true);
   });
@@ -38,6 +40,13 @@ describe("getWorkspaceSourceCapabilities", () => {
       });
     },
   );
+
+  it("keeps an unrecognized executor type unresolved", () => {
+    expect(getWorkspaceSourceCapabilities("future_executor")).toMatchObject({
+      canAddFolders: false,
+      executorCapabilitiesKnown: false,
+    });
+  });
 
   it.each(["local", "local_pc"] as const)(
     "uses the live checkout and does not offer a checkout branch for %s",

--- a/apps/web/components/workspace-source-picker/executor-capabilities.test.ts
+++ b/apps/web/components/workspace-source-picker/executor-capabilities.test.ts
@@ -17,6 +17,28 @@ describe("getWorkspaceSourceCapabilities", () => {
     },
   );
 
+  it.each([
+    "local",
+    "local_pc",
+    "worktree",
+    "local_docker",
+    "remote_docker",
+    "ssh",
+    "sprites",
+  ] as const)("marks executor capabilities as known once resolved for %s", (executorType) => {
+    expect(getWorkspaceSourceCapabilities(executorType).executorCapabilitiesKnown).toBe(true);
+  });
+
+  it.each([null, undefined])(
+    "marks executor capabilities as unknown, not unsupported, for %s",
+    (executorType) => {
+      expect(getWorkspaceSourceCapabilities(executorType)).toMatchObject({
+        canAddFolders: false,
+        executorCapabilitiesKnown: false,
+      });
+    },
+  );
+
   it.each(["local", "local_pc"] as const)(
     "uses the live checkout and does not offer a checkout branch for %s",
     (executorType) => {

--- a/apps/web/components/workspace-source-picker/executor-capabilities.ts
+++ b/apps/web/components/workspace-source-picker/executor-capabilities.ts
@@ -1,5 +1,17 @@
 import type { ExecutorType } from "@/lib/types/http";
 
+const KNOWN_EXECUTOR_TYPES = new Set<ExecutorType>([
+  "local",
+  "local_pc",
+  "local_docker",
+  "sprites",
+  "ssh",
+  "remote_docker",
+  "remote_vps",
+  "k8s",
+  "worktree",
+]);
+
 type SavedRepositoryIdentity = {
   remote_url?: string;
   provider?: string;
@@ -16,9 +28,9 @@ export function getWorkspaceSourceCapabilities(
   canChooseCheckoutBranch: boolean;
   requiresCloneableLocalRepository: boolean;
   /**
-   * False while the primary executor binding has not resolved yet (`executorType`
-   * is nullish). Callers must not treat that the same as a known executor that
-   * cannot host folders — an unresolved binding means "not yet known," not "no."
+   * False while the primary executor binding has not resolved yet or the type
+   * is unknown. Callers must not treat that the same as a known executor that
+   * cannot host folders — an unresolved capability means "not yet known," not "no."
    */
   executorCapabilitiesKnown: boolean;
 } {
@@ -32,7 +44,7 @@ export function getWorkspaceSourceCapabilities(
     canAddFolders: usesLiveCheckout || executorType === "worktree",
     canChooseCheckoutBranch: !usesLiveCheckout,
     requiresCloneableLocalRepository: requiresClone,
-    executorCapabilitiesKnown: executorType !== null && executorType !== undefined,
+    executorCapabilitiesKnown: KNOWN_EXECUTOR_TYPES.has(executorType as ExecutorType),
   };
 }
 

--- a/apps/web/components/workspace-source-picker/executor-capabilities.ts
+++ b/apps/web/components/workspace-source-picker/executor-capabilities.ts
@@ -15,6 +15,12 @@ export function getWorkspaceSourceCapabilities(
   canAddFolders: boolean;
   canChooseCheckoutBranch: boolean;
   requiresCloneableLocalRepository: boolean;
+  /**
+   * False while the primary executor binding has not resolved yet (`executorType`
+   * is nullish). Callers must not treat that the same as a known executor that
+   * cannot host folders — an unresolved binding means "not yet known," not "no."
+   */
+  executorCapabilitiesKnown: boolean;
 } {
   const usesLiveCheckout = executorType === "local" || executorType === "local_pc";
   const requiresClone =
@@ -26,6 +32,7 @@ export function getWorkspaceSourceCapabilities(
     canAddFolders: usesLiveCheckout || executorType === "worktree",
     canChooseCheckoutBranch: !usesLiveCheckout,
     requiresCloneableLocalRepository: requiresClone,
+    executorCapabilitiesKnown: executorType !== null && executorType !== undefined,
   };
 }
 

--- a/apps/web/e2e/helpers/api-client.ts
+++ b/apps/web/e2e/helpers/api-client.ts
@@ -2201,6 +2201,7 @@ export class ApiClient {
     title: string;
     autopilot?: boolean;
     primary_session_id?: string | null;
+    primary_executor_type?: string | null;
     state?: string;
     workflow_step_id?: string;
     parent_id?: string;

--- a/apps/web/e2e/tests/task/add-workspace-sources.spec.ts
+++ b/apps/web/e2e/tests/task/add-workspace-sources.spec.ts
@@ -108,9 +108,14 @@ test.describe("Attach local workspace sources", () => {
     // The "Add folder" control is gated on the task's primary executor
     // binding. Poll the backend directly for it rather than relying on the
     // later "Add folder" click landing after it incidentally.
+    // `primary_executor_type` is `omitempty`, so an unbound task omits the key
+    // entirely: assert truthiness, never `not.toBeNull()`, which `undefined`
+    // satisfies on the first poll.
     await expect
-      .poll(async () => (await apiClient.getTask(task.id)).primary_executor_type)
-      .not.toBeNull();
+      .poll(async () => (await apiClient.getTask(task.id)).primary_executor_type, {
+        timeout: 30_000,
+      })
+      .toBeTruthy();
 
     await testPage.goto(`/t/${task.id}`);
     const session = new SessionPage(testPage);

--- a/apps/web/e2e/tests/task/add-workspace-sources.spec.ts
+++ b/apps/web/e2e/tests/task/add-workspace-sources.spec.ts
@@ -104,6 +104,14 @@ test.describe("Attach local workspace sources", () => {
 
     if (!task.session_id) throw new Error("task creation did not return a session id");
     await waitForWorkspaceReady(apiClient, task.id, task.session_id);
+
+    // The "Add folder" control is gated on the task's primary executor
+    // binding. Poll the backend directly for it rather than relying on the
+    // later "Add folder" click landing after it incidentally.
+    await expect
+      .poll(async () => (await apiClient.getTask(task.id)).primary_executor_type)
+      .not.toBeNull();
+
     await testPage.goto(`/t/${task.id}`);
     const session = new SessionPage(testPage);
     await session.waitForLoad();

--- a/apps/web/e2e/tests/task/mobile-add-workspace-sources.spec.ts
+++ b/apps/web/e2e/tests/task/mobile-add-workspace-sources.spec.ts
@@ -58,10 +58,16 @@ test("mobile Files drawer attaches sources with fixed controls and persisted wor
 
   // The "Add folder" control is gated on the task's primary executor binding.
   // Poll the backend directly for it rather than budgeting the later UI
-  // assertion for the async session launch that produces it.
+  // assertion for the async session launch that produces it. The budget sits on
+  // the backend cause, not on a UI shadow of it, so the "Add folder" assertion
+  // below keeps the default timeout. `primary_executor_type` is `omitempty`, so
+  // an unbound task omits the key entirely: assert truthiness, never
+  // `not.toBeNull()`, which `undefined` satisfies on the first poll.
   await expect
-    .poll(async () => (await apiClient.getTask(task.id)).primary_executor_type)
-    .not.toBeNull();
+    .poll(async () => (await apiClient.getTask(task.id)).primary_executor_type, {
+      timeout: 30_000,
+    })
+    .toBeTruthy();
 
   await testPage.goto(`/t/${task.id}`);
   const session = new SessionPage(testPage);

--- a/apps/web/e2e/tests/task/mobile-add-workspace-sources.spec.ts
+++ b/apps/web/e2e/tests/task/mobile-add-workspace-sources.spec.ts
@@ -56,6 +56,13 @@ test("mobile Files drawer attaches sources with fixed controls and persisted wor
     },
   );
 
+  // The "Add folder" control is gated on the task's primary executor binding.
+  // Poll the backend directly for it rather than budgeting the later UI
+  // assertion for the async session launch that produces it.
+  await expect
+    .poll(async () => (await apiClient.getTask(task.id)).primary_executor_type)
+    .not.toBeNull();
+
   await testPage.goto(`/t/${task.id}`);
   const session = new SessionPage(testPage);
   await session.waitForLoad();
@@ -147,14 +154,11 @@ test("mobile Files drawer attaches sources with fixed controls and persisted wor
   const addRepository = drawer.getByRole("button", { name: "Add repository" });
   const addFolder = drawer.getByRole("button", { name: "Add folder" });
   const submit = drawer.getByTestId("add-workspace-sources-submit");
-  // The "Add folder" control is gated on activeTask.primaryExecutorType, which
-  // arrives from a follow-up office.task.updated WS event once the primary
-  // session's executor is bound and can lag the drawer mount on a loaded CI
-  // shard. The drawer re-renders reactively when that field hydrates, so wait
-  // for the button with a generous timeout instead of measuring a not-yet-
-  // rendered button (a null box that otherwise stalls until the suite timeout).
+  // The "Add folder" control is gated on activeTask.primaryExecutorType. The
+  // poll before navigation already confirmed the backend has resolved it, so
+  // the drawer renders it on first paint and this needs no extended budget.
   await expect(addRepository).toBeVisible();
-  await expect(addFolder).toBeVisible({ timeout: 30_000 });
+  await expect(addFolder).toBeVisible();
   const [addRepositoryBox, addFolderBox] = await Promise.all([
     addRepository.boundingBox(),
     addFolder.boundingBox(),

--- a/apps/web/hooks/domains/kanban/use-all-workflow-snapshots.test.ts
+++ b/apps/web/hooks/domains/kanban/use-all-workflow-snapshots.test.ts
@@ -298,20 +298,106 @@ describe("useAllWorkflowSnapshots — snapshot mapping", () => {
     await waitFor(() => expect(mockSetWorkflowSnapshot).toHaveBeenCalled());
     expect(mockSetWorkflowSnapshot.mock.calls[0][1].tasks[0].autopilot).toBe(false);
   });
+});
 
-  it("preserves a cached primary executor binding when a fresh snapshot omits it", async () => {
-    seedCachedTask(WORKTREE_EXECUTOR_FIELDS);
+describe("useAllWorkflowSnapshots — executor binding merge", () => {
+  beforeEach(() => {
+    resetMocks([{ id: "wf-A", workspaceId: "ws-A", name: "A" }]);
+  });
+
+  it("preserves a newer live executor binding when a delayed snapshot omits it", async () => {
+    seedCachedTask({});
+    let resolveSnapshot: (value: { steps: unknown[]; tasks: unknown[] }) => void = () => {};
+    mockFetchWorkflowSnapshot.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveSnapshot = resolve;
+        }),
+    );
+
+    renderHook(() => useAllWorkflowSnapshots("ws-A"));
+    await waitFor(() => expect(mockFetchWorkflowSnapshot).toHaveBeenCalled());
+
+    // A task.updated event adds the executor while the snapshot is in flight.
+    mockState.kanbanMulti.snapshots = {
+      "wf-A": {
+        workflowId: "wf-A",
+        workflowName: "A",
+        isPlaceholder: true,
+        steps: [],
+        tasks: [{ id: "task-1", workflowStepId: "step-1", ...WORKTREE_EXECUTOR_FIELDS }],
+      },
+    };
+    resolveSnapshot({
+      steps: [{ id: "step-1", name: "Review", position: 1 }],
+      tasks: [{ id: "task-1", workflow_step_id: "step-1", title: "Task" }],
+    });
+
+    await waitFor(() => expect(mockSetWorkflowSnapshot).toHaveBeenCalled());
+    expect(mockSetWorkflowSnapshot.mock.calls[0][1].tasks[0]).toMatchObject(
+      WORKTREE_EXECUTOR_FIELDS,
+    );
+  });
+
+  it("clears a cached executor when a current snapshot omits the primary session", async () => {
+    seedCachedTask({ primarySessionId: "session-1", ...WORKTREE_EXECUTOR_FIELDS });
     mockFetchWorkflowSnapshot.mockResolvedValueOnce({
       steps: [{ id: "step-1", name: "Review", position: 1 }],
+      // The backend omits primary_session_id and primary_executor_* when the
+      // task has no primary session because those DTO fields use omitempty.
       tasks: [{ id: "task-1", workflow_step_id: "step-1", title: "Task" }],
     });
 
     renderHook(() => useAllWorkflowSnapshots("ws-A"));
 
     await waitFor(() => expect(mockSetWorkflowSnapshot).toHaveBeenCalled());
+    expect(mockSetWorkflowSnapshot.mock.calls[0][1].tasks[0].primaryExecutorType).toBeUndefined();
+  });
+
+  it("preserves each omitted executor field from a newer live binding independently", async () => {
+    seedCachedTask({});
+    let resolveSnapshot: (value: { steps: unknown[]; tasks: unknown[] }) => void = () => {};
+    mockFetchWorkflowSnapshot.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveSnapshot = resolve;
+        }),
+    );
+
+    renderHook(() => useAllWorkflowSnapshots("ws-A"));
+    await waitFor(() => expect(mockFetchWorkflowSnapshot).toHaveBeenCalled());
+
+    mockState.kanbanMulti.snapshots = {
+      "wf-A": {
+        workflowId: "wf-A",
+        workflowName: "A",
+        isPlaceholder: true,
+        steps: [],
+        tasks: [{ id: "task-1", workflowStepId: "step-1", ...WORKTREE_EXECUTOR_FIELDS }],
+      },
+    };
+    resolveSnapshot({
+      steps: [{ id: "step-1", name: "Review", position: 1 }],
+      tasks: [
+        {
+          id: "task-1",
+          workflow_step_id: "step-1",
+          title: "Task",
+          primary_executor_type: "worktree",
+        },
+      ],
+    });
+
+    await waitFor(() => expect(mockSetWorkflowSnapshot).toHaveBeenCalled());
     expect(mockSetWorkflowSnapshot.mock.calls[0][1].tasks[0]).toMatchObject(
       WORKTREE_EXECUTOR_FIELDS,
     );
+  });
+});
+
+describe("useAllWorkflowSnapshots — executor binding mapping", () => {
+  beforeEach(() => {
+    resetMocks([{ id: "wf-A", workspaceId: "ws-A", name: "A" }]);
   });
 
   it("clears a cached executor binding when the response explicitly clears the primary session", async () => {

--- a/apps/web/hooks/domains/kanban/use-all-workflow-snapshots.test.ts
+++ b/apps/web/hooks/domains/kanban/use-all-workflow-snapshots.test.ts
@@ -222,6 +222,25 @@ describe("useAllWorkflowSnapshots — fetch guards", () => {
   });
 });
 
+const WORKTREE_EXECUTOR_FIELDS = {
+  primaryExecutorId: "exec-worktree",
+  primaryExecutorType: "worktree",
+  primaryExecutorName: "Worktree",
+  isRemoteExecutor: false,
+};
+
+function seedCachedTask(taskOverrides: Record<string, unknown>) {
+  mockState.kanbanMulti.snapshots = {
+    "wf-A": {
+      workflowId: "wf-A",
+      workflowName: "A",
+      isPlaceholder: true,
+      steps: [],
+      tasks: [{ id: "task-1", workflowStepId: "step-1", ...taskOverrides }],
+    },
+  };
+}
+
 describe("useAllWorkflowSnapshots — snapshot mapping", () => {
   beforeEach(() => {
     resetMocks([{ id: "wf-A", workspaceId: "ws-A", name: "A" }]);
@@ -255,15 +274,7 @@ describe("useAllWorkflowSnapshots — snapshot mapping", () => {
   });
 
   it("preserves a cached autopilot marker when a fresh snapshot omits it", async () => {
-    mockState.kanbanMulti.snapshots = {
-      "wf-A": {
-        workflowId: "wf-A",
-        workflowName: "A",
-        isPlaceholder: true,
-        steps: [],
-        tasks: [{ id: "task-1", workflowStepId: "step-1", autopilot: true }],
-      },
-    };
+    seedCachedTask({ autopilot: true });
     mockFetchWorkflowSnapshot.mockResolvedValueOnce({
       steps: [{ id: "step-1", name: "Review", position: 1 }],
       tasks: [{ id: "task-1", workflow_step_id: "step-1", title: "Task" }],
@@ -276,15 +287,7 @@ describe("useAllWorkflowSnapshots — snapshot mapping", () => {
   });
 
   it("keeps an explicit false autopilot value from the fresh snapshot", async () => {
-    mockState.kanbanMulti.snapshots = {
-      "wf-A": {
-        workflowId: "wf-A",
-        workflowName: "A",
-        isPlaceholder: true,
-        steps: [],
-        tasks: [{ id: "task-1", workflowStepId: "step-1", autopilot: true }],
-      },
-    };
+    seedCachedTask({ autopilot: true });
     mockFetchWorkflowSnapshot.mockResolvedValueOnce({
       steps: [{ id: "step-1", name: "Review", position: 1 }],
       tasks: [{ id: "task-1", workflow_step_id: "step-1", title: "Task", autopilot: false }],
@@ -294,6 +297,46 @@ describe("useAllWorkflowSnapshots — snapshot mapping", () => {
 
     await waitFor(() => expect(mockSetWorkflowSnapshot).toHaveBeenCalled());
     expect(mockSetWorkflowSnapshot.mock.calls[0][1].tasks[0].autopilot).toBe(false);
+  });
+
+  it("preserves a cached primary executor binding when a fresh snapshot omits it", async () => {
+    seedCachedTask(WORKTREE_EXECUTOR_FIELDS);
+    mockFetchWorkflowSnapshot.mockResolvedValueOnce({
+      steps: [{ id: "step-1", name: "Review", position: 1 }],
+      tasks: [{ id: "task-1", workflow_step_id: "step-1", title: "Task" }],
+    });
+
+    renderHook(() => useAllWorkflowSnapshots("ws-A"));
+
+    await waitFor(() => expect(mockSetWorkflowSnapshot).toHaveBeenCalled());
+    expect(mockSetWorkflowSnapshot.mock.calls[0][1].tasks[0]).toMatchObject(
+      WORKTREE_EXECUTOR_FIELDS,
+    );
+  });
+
+  it("adopts a fresh primary executor binding when the response includes one", async () => {
+    seedCachedTask({});
+    mockFetchWorkflowSnapshot.mockResolvedValueOnce({
+      steps: [{ id: "step-1", name: "Review", position: 1 }],
+      tasks: [
+        {
+          id: "task-1",
+          workflow_step_id: "step-1",
+          title: "Task",
+          primary_executor_id: "exec-worktree",
+          primary_executor_type: "worktree",
+          primary_executor_name: "Worktree",
+          is_remote_executor: false,
+        },
+      ],
+    });
+
+    renderHook(() => useAllWorkflowSnapshots("ws-A"));
+
+    await waitFor(() => expect(mockSetWorkflowSnapshot).toHaveBeenCalled());
+    expect(mockSetWorkflowSnapshot.mock.calls[0][1].tasks[0]).toMatchObject(
+      WORKTREE_EXECUTOR_FIELDS,
+    );
   });
 });
 

--- a/apps/web/hooks/domains/kanban/use-all-workflow-snapshots.test.ts
+++ b/apps/web/hooks/domains/kanban/use-all-workflow-snapshots.test.ts
@@ -314,6 +314,26 @@ describe("useAllWorkflowSnapshots — snapshot mapping", () => {
     );
   });
 
+  it("clears a cached executor binding when the response explicitly clears the primary session", async () => {
+    seedCachedTask({ primarySessionId: "session-1", ...WORKTREE_EXECUTOR_FIELDS });
+    mockFetchWorkflowSnapshot.mockResolvedValueOnce({
+      steps: [{ id: "step-1", name: "Review", position: 1 }],
+      tasks: [
+        {
+          id: "task-1",
+          workflow_step_id: "step-1",
+          title: "Task",
+          primary_session_id: null,
+        },
+      ],
+    });
+
+    renderHook(() => useAllWorkflowSnapshots("ws-A"));
+
+    await waitFor(() => expect(mockSetWorkflowSnapshot).toHaveBeenCalled());
+    expect(mockSetWorkflowSnapshot.mock.calls[0][1].tasks[0].primaryExecutorType).toBeUndefined();
+  });
+
   it("adopts a fresh primary executor binding when the response includes one", async () => {
     seedCachedTask({});
     mockFetchWorkflowSnapshot.mockResolvedValueOnce({

--- a/apps/web/hooks/domains/kanban/use-all-workflow-snapshots.ts
+++ b/apps/web/hooks/domains/kanban/use-all-workflow-snapshots.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState, type MutableRefObject } from "react";
 import { fetchWorkflowSnapshot } from "@/lib/api";
 import { useAppStore, useAppStoreApi } from "@/components/state-provider";
-import { copyPrimaryExecutorFields, toKanbanTask } from "@/lib/kanban/map-task";
+import { toKanbanTask } from "@/lib/kanban/map-task";
 import type { KanbanState, WorkflowSnapshotData } from "@/lib/state/slices/kanban/types";
 import type { Task } from "@/lib/types/http";
 import type { StoreApi } from "zustand";
@@ -45,20 +45,59 @@ function hasNewerLiveAutoStartFailed(
   return existing.autoStartFailed !== fetchStart.autoStartFailed;
 }
 
-function hasNewerLiveExecutor(existing: KanbanTask, fetchStart: KanbanTask | undefined): boolean {
-  if (!fetchStart) return true;
+function hasExecutorBinding(task: KanbanTask): boolean {
   return (
-    existing.primaryExecutorId !== fetchStart.primaryExecutorId ||
-    existing.primaryExecutorType !== fetchStart.primaryExecutorType ||
-    existing.primaryExecutorName !== fetchStart.primaryExecutorName ||
-    existing.isRemoteExecutor !== fetchStart.isRemoteExecutor
+    task.primaryExecutorId !== undefined ||
+    task.primaryExecutorType !== undefined ||
+    task.primaryExecutorName !== undefined ||
+    task.isRemoteExecutor === true
   );
+}
+
+function hasNewerLiveExecutorBinding(
+  existing: KanbanTask,
+  fetchStart: KanbanTask | undefined,
+): boolean {
+  if (!fetchStart) return hasExecutorBinding(existing);
+  return (
+    (existing.primaryExecutorId ?? undefined) !== (fetchStart.primaryExecutorId ?? undefined) ||
+    (existing.primaryExecutorType ?? undefined) !== (fetchStart.primaryExecutorType ?? undefined) ||
+    (existing.primaryExecutorName ?? undefined) !== (fetchStart.primaryExecutorName ?? undefined) ||
+    (existing.isRemoteExecutor ?? false) !== (fetchStart.isRemoteExecutor ?? false)
+  );
+}
+
+function preserveOmittedExecutorBinding(
+  mapped: KanbanTask,
+  existing: KanbanTask,
+  fetchStart: KanbanTask | undefined,
+  source: Task,
+): void {
+  // The executor binding comes from an omittable primary-session JOIN. Only
+  // preserve fields when the cached task changed after this request started;
+  // otherwise, an authoritative current snapshot can clear stale fields.
+  if (source.primary_session_id === null || !hasNewerLiveExecutorBinding(existing, fetchStart)) {
+    return;
+  }
+  if (source.primary_executor_id === undefined) {
+    mapped.primaryExecutorId = existing.primaryExecutorId;
+  }
+  if (source.primary_executor_type === undefined) {
+    mapped.primaryExecutorType = existing.primaryExecutorType;
+  }
+  if (source.primary_executor_name === undefined) {
+    mapped.primaryExecutorName = existing.primaryExecutorName;
+  }
+  if (source.is_remote_executor === undefined) {
+    mapped.isRemoteExecutor = existing.isRemoteExecutor;
+  }
 }
 
 function mergeFetchedTask(
   mapped: KanbanTask,
   existing: KanbanTask,
   fetchStart: KanbanTask | undefined,
+  source: Task,
   statusSummaryInvalidated: boolean,
 ): KanbanTask {
   // Production snapshot payloads can be surfaced through read-only objects.
@@ -100,12 +139,7 @@ function mergeFetchedTask(
   if (merged.autoStartFailed === undefined || hasNewerLiveAutoStartFailed(existing, fetchStart)) {
     merged.autoStartFailed = existing.autoStartFailed;
   }
-  // An omitted executor bundle in a current full snapshot represents a
-  // legitimate detach. Only copy live fields when a live update changed the
-  // executor after this request began, or when the task appeared in flight.
-  if (hasNewerLiveExecutor(existing, fetchStart)) {
-    copyPrimaryExecutorFields(merged, existing);
-  }
+  preserveOmittedExecutorBinding(merged, existing, fetchStart, source);
   return merged;
 }
 
@@ -132,6 +166,7 @@ function mergeSnapshotTasks(
             mapped,
             existing,
             fetchStartById.get(mapped.id),
+            task,
             task.status_summary_invalidated === true,
           )
         : mapped;

--- a/apps/web/hooks/domains/kanban/use-all-workflow-snapshots.ts
+++ b/apps/web/hooks/domains/kanban/use-all-workflow-snapshots.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState, type MutableRefObject } from "react";
 import { fetchWorkflowSnapshot } from "@/lib/api";
 import { useAppStore, useAppStoreApi } from "@/components/state-provider";
-import { toKanbanTask } from "@/lib/kanban/map-task";
+import { copyPrimaryExecutorFields, toKanbanTask } from "@/lib/kanban/map-task";
 import type { KanbanState, WorkflowSnapshotData } from "@/lib/state/slices/kanban/types";
 import type { Task } from "@/lib/types/http";
 import type { StoreApi } from "zustand";
@@ -45,52 +45,26 @@ function hasNewerLiveAutoStartFailed(
   return existing.autoStartFailed !== fetchStart.autoStartFailed;
 }
 
-function hasExecutorBinding(task: KanbanTask): boolean {
+function hasNewerLiveExecutor(existing: KanbanTask, fetchStart: KanbanTask | undefined): boolean {
+  if (!fetchStart) return true;
   return (
-    task.primaryExecutorId !== undefined ||
-    task.primaryExecutorType !== undefined ||
-    task.primaryExecutorName !== undefined ||
-    task.isRemoteExecutor === true
+    existing.primaryExecutorId !== fetchStart.primaryExecutorId ||
+    existing.primaryExecutorType !== fetchStart.primaryExecutorType ||
+    existing.primaryExecutorName !== fetchStart.primaryExecutorName ||
+    existing.isRemoteExecutor !== fetchStart.isRemoteExecutor
   );
 }
 
-function hasNewerLiveExecutorBinding(
-  existing: KanbanTask,
-  fetchStart: KanbanTask | undefined,
-): boolean {
-  if (!fetchStart) return hasExecutorBinding(existing);
-  return (
-    (existing.primaryExecutorId ?? undefined) !== (fetchStart.primaryExecutorId ?? undefined) ||
-    (existing.primaryExecutorType ?? undefined) !== (fetchStart.primaryExecutorType ?? undefined) ||
-    (existing.primaryExecutorName ?? undefined) !== (fetchStart.primaryExecutorName ?? undefined) ||
-    (existing.isRemoteExecutor ?? false) !== (fetchStart.isRemoteExecutor ?? false)
-  );
-}
-
-function preserveOmittedExecutorBinding(
-  mapped: KanbanTask,
+function preserveLiveExecutorBinding(
+  merged: KanbanTask,
   existing: KanbanTask,
   fetchStart: KanbanTask | undefined,
   source: Task,
 ): void {
-  // The executor binding comes from an omittable primary-session JOIN. Only
-  // preserve fields when the cached task changed after this request started;
-  // otherwise, an authoritative current snapshot can clear stale fields.
-  if (source.primary_session_id === null || !hasNewerLiveExecutorBinding(existing, fetchStart)) {
-    return;
-  }
-  if (source.primary_executor_id === undefined) {
-    mapped.primaryExecutorId = existing.primaryExecutorId;
-  }
-  if (source.primary_executor_type === undefined) {
-    mapped.primaryExecutorType = existing.primaryExecutorType;
-  }
-  if (source.primary_executor_name === undefined) {
-    mapped.primaryExecutorName = existing.primaryExecutorName;
-  }
-  if (source.is_remote_executor === undefined) {
-    mapped.isRemoteExecutor = existing.isRemoteExecutor;
-  }
+  // An explicit primary-session clear is authoritative, even if a newer live
+  // update changed the cached executor while this snapshot was in flight.
+  if (source.primary_session_id === null || !hasNewerLiveExecutor(existing, fetchStart)) return;
+  copyPrimaryExecutorFields(merged, existing);
 }
 
 function mergeFetchedTask(
@@ -139,7 +113,7 @@ function mergeFetchedTask(
   if (merged.autoStartFailed === undefined || hasNewerLiveAutoStartFailed(existing, fetchStart)) {
     merged.autoStartFailed = existing.autoStartFailed;
   }
-  preserveOmittedExecutorBinding(merged, existing, fetchStart, source);
+  preserveLiveExecutorBinding(merged, existing, fetchStart, source);
   return merged;
 }
 

--- a/apps/web/lib/ssr/mapper.test.ts
+++ b/apps/web/lib/ssr/mapper.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
+import { produce } from "immer";
+import type { Draft } from "immer";
 
 import { snapshotToState } from "./mapper";
+import { hydrateState } from "@/lib/state/hydration/hydrator";
+import { defaultState } from "@/lib/state/default-state";
+import type { AppState } from "@/lib/state/store";
 import { taskId, workflowId, workspaceId } from "@/lib/types/ids";
 import type { WorkflowSnapshot } from "@/lib/types/http";
 import { partitionWipTasks } from "@/lib/kanban/wip-queue";
@@ -45,6 +50,18 @@ function snapshotWithPendingAction(action: unknown): WorkflowSnapshot {
       } as WorkflowSnapshot["tasks"][number],
     ],
   };
+}
+
+const EXECUTOR_ID = "exec-worktree";
+const EXECUTOR_TYPE = "worktree";
+const EXECUTOR_NAME = "Worktree";
+
+function snapshotWithExecutor(): WorkflowSnapshot {
+  const snapshot = snapshotWithPendingAction(undefined);
+  snapshot.tasks[0].primary_executor_id = EXECUTOR_ID;
+  snapshot.tasks[0].primary_executor_type = EXECUTOR_TYPE;
+  snapshot.tasks[0].primary_executor_name = EXECUTOR_NAME;
+  return snapshot;
 }
 
 // eslint-disable-next-line max-lines-per-function -- test describe block, splitting hurts readability
@@ -116,20 +133,30 @@ describe("snapshotToState", () => {
   });
 
   it("maps the primary executor binding onto the kanban task", () => {
-    const snapshot = snapshotWithPendingAction(undefined);
-    snapshot.tasks[0].primary_executor_id = "exec-worktree";
-    snapshot.tasks[0].primary_executor_type = "worktree";
-    snapshot.tasks[0].primary_executor_name = "Worktree";
+    const snapshot = snapshotWithExecutor();
     snapshot.tasks[0].is_remote_executor = false;
 
     const state = snapshotToState(snapshot);
 
     expect(state.kanban?.tasks[0]).toMatchObject({
-      primaryExecutorId: "exec-worktree",
-      primaryExecutorType: "worktree",
-      primaryExecutorName: "Worktree",
+      primaryExecutorId: EXECUTOR_ID,
+      primaryExecutorType: EXECUTOR_TYPE,
+      primaryExecutorName: EXECUTOR_NAME,
       isRemoteExecutor: false,
     });
+  });
+
+  it("leaves the executor binding unset when the snapshot omits it", () => {
+    // The backend marks every executor field `omitempty`, so a task whose
+    // primary session has not bound an executor yet arrives with the keys
+    // absent rather than null. The mapper must yield undefined here, never
+    // crash and never invent a binding.
+    const state = snapshotToState(snapshotWithPendingAction(undefined));
+
+    expect(state.kanban?.tasks[0]?.primaryExecutorId).toBeUndefined();
+    expect(state.kanban?.tasks[0]?.primaryExecutorType).toBeUndefined();
+    expect(state.kanban?.tasks[0]?.primaryExecutorName).toBeUndefined();
+    expect(state.kanban?.tasks[0]?.isRemoteExecutor).toBe(false);
   });
 
   it("preserves workflow step WIP fields", () => {
@@ -197,5 +224,36 @@ describe("snapshotToState", () => {
       taskId("task-2"),
       taskId("task-1"),
     ]);
+  });
+});
+
+describe("snapshotToState feeding hydrateState", () => {
+  it("does not blank an already-known executor when a re-hydration lands", () => {
+    // Regression guard for the bug this change fixes, exercised through the
+    // real chain: use-workflow-snapshot calls hydrate(snapshotToState(...)) on
+    // (re)mount, and mergeKanbanTasks replaces the cached task wholesale when
+    // the incoming updatedAt is not older. While snapshotToState dropped the
+    // executor fields, that replacement silently reset primaryExecutorType to
+    // undefined and the "Add folder" control disappeared.
+    const draft = structuredClone(defaultState) as AppState;
+    draft.kanban.tasks = [
+      {
+        id: taskId("task-1"),
+        workflowId: workflowID,
+        workflowStepId: "step-1",
+        title: "Task",
+        position: 0,
+        updatedAt: now,
+        primaryExecutorId: EXECUTOR_ID,
+        primaryExecutorType: EXECUTOR_TYPE,
+        primaryExecutorName: EXECUTOR_NAME,
+      },
+    ] as AppState["kanban"]["tasks"];
+
+    const result = produce(draft, (d: Draft<AppState>) => {
+      hydrateState(d, snapshotToState(snapshotWithExecutor()));
+    });
+
+    expect(result.kanban.tasks[0]?.primaryExecutorType).toBe(EXECUTOR_TYPE);
   });
 });

--- a/apps/web/lib/ssr/mapper.test.ts
+++ b/apps/web/lib/ssr/mapper.test.ts
@@ -115,6 +115,23 @@ describe("snapshotToState", () => {
     expect(state.kanban?.tasks[0]?.statusSummary).toEqual(snapshot.tasks[0].status_summary);
   });
 
+  it("maps the primary executor binding onto the kanban task", () => {
+    const snapshot = snapshotWithPendingAction(undefined);
+    snapshot.tasks[0].primary_executor_id = "exec-worktree";
+    snapshot.tasks[0].primary_executor_type = "worktree";
+    snapshot.tasks[0].primary_executor_name = "Worktree";
+    snapshot.tasks[0].is_remote_executor = false;
+
+    const state = snapshotToState(snapshot);
+
+    expect(state.kanban?.tasks[0]).toMatchObject({
+      primaryExecutorId: "exec-worktree",
+      primaryExecutorType: "worktree",
+      primaryExecutorName: "Worktree",
+      isRemoteExecutor: false,
+    });
+  });
+
   it("preserves workflow step WIP fields", () => {
     const state = snapshotToState({
       workflow: {

--- a/apps/web/lib/ssr/mapper.test.ts
+++ b/apps/web/lib/ssr/mapper.test.ts
@@ -159,6 +159,18 @@ describe("snapshotToState", () => {
     expect(state.kanban?.tasks[0]?.isRemoteExecutor).toBe(false);
   });
 
+  it("leaves an explicitly undefined executor binding unset", () => {
+    // Reviewer-requested wire-contract coverage. JSON omits undefined values,
+    // but typed snapshot fixtures can retain the property; both representations
+    // must produce the same unresolved client state.
+    const snapshot = snapshotWithPendingAction(undefined);
+    snapshot.tasks[0].primary_executor_type = undefined;
+
+    const state = snapshotToState(snapshot);
+
+    expect(state.kanban?.tasks[0]?.primaryExecutorType).toBeUndefined();
+  });
+
   it("preserves workflow step WIP fields", () => {
     const state = snapshotToState({
       workflow: {

--- a/apps/web/lib/ssr/mapper.ts
+++ b/apps/web/lib/ssr/mapper.ts
@@ -16,6 +16,15 @@ function resolveAutoStartFailed(task: WorkflowSnapshot["tasks"][number]): boolea
   return task.auto_start_failed ?? false;
 }
 
+function primaryExecutorFields(task: Task) {
+  return {
+    primaryExecutorId: task.primary_executor_id ?? undefined,
+    primaryExecutorType: task.primary_executor_type ?? undefined,
+    primaryExecutorName: task.primary_executor_name ?? undefined,
+    isRemoteExecutor: task.is_remote_executor ?? false,
+  };
+}
+
 export function snapshotToState(snapshot: WorkflowSnapshot): Partial<AppState> {
   // Handle empty snapshot (ephemeral tasks have no workflow)
   if (!snapshot.workflow) {
@@ -64,6 +73,7 @@ export function snapshotToState(snapshot: WorkflowSnapshot): Partial<AppState> {
         })),
         primarySessionId: task.primary_session_id ?? undefined,
         primarySessionState: task.primary_session_state ?? undefined,
+        ...primaryExecutorFields(task),
         primarySessionPendingAction: pickPendingAction(task.primary_session_pending_action),
         taskPendingAction: pickPendingAction(task.task_pending_action),
         foregroundActivity: task.foreground_activity ?? undefined,

--- a/apps/web/src/locales/en/task.json
+++ b/apps/web/src/locales/en/task.json
@@ -24,6 +24,7 @@
   "addBlocker": "+ Add blocker",
   "addDetailsAboutThisChange": "Add details about this change...",
   "addFolder": "Add folder",
+  "addFolderExecutorUnknown": "Waiting to confirm this task's executor supports folders",
   "addLabel": "Add label",
   "addLabels": "+ Add labels",
   "addMore": "Add more",

--- a/apps/web/src/locales/pseudo/task.json
+++ b/apps/web/src/locales/pseudo/task.json
@@ -24,6 +24,7 @@
   "addBlocker": "+ Àďď ƀĺōćķēŕ",
   "addDetailsAboutThisChange": "Àďď ďēţàĩĺś àƀōũţ ţĥĩś ćĥàńĝē...",
   "addFolder": "Àďď ƒōĺďēŕ",
+  "addFolderExecutorUnknown": "Ŵàĩţĩńĝ ţō ćōńƒĩŕḿ ţĥĩś ţàśķ'ś ēxēćũţōŕ śũƥƥōŕţś ƒōĺďēŕś",
   "addLabel": "Àďď ĺàƀēĺ",
   "addLabels": "+ Àďď ĺàƀēĺś",
   "addMore": "Àďď ḿōŕē",

--- a/apps/web/src/locales/pt-pt/task.json
+++ b/apps/web/src/locales/pt-pt/task.json
@@ -24,6 +24,7 @@
   "addBlocker": "+ Adicionar bloqueio",
   "addDetailsAboutThisChange": "Adicione detalhes sobre esta alteração...",
   "addFolder": "Adicionar pasta",
+  "addFolderExecutorUnknown": "O executor desta tarefa ainda não foi confirmado",
   "addLabel": "Adicionar etiqueta",
   "addLabels": "+ Adicionar etiquetas",
   "addMore": "Adicionar mais",

--- a/apps/web/src/locales/zh-cn/task.json
+++ b/apps/web/src/locales/zh-cn/task.json
@@ -24,6 +24,7 @@
   "addBlocker": "+ 添加阻塞项",
   "addDetailsAboutThisChange": "添加此变更的详细说明…",
   "addFolder": "添加文件夹",
+  "addFolderExecutorUnknown": "尚未确认此任务的执行器",
   "addLabel": "添加标签",
   "addLabels": "+ 添加标签",
   "addMore": "添加更多",

--- a/apps/web/src/locales/zh-hk/task.json
+++ b/apps/web/src/locales/zh-hk/task.json
@@ -24,6 +24,7 @@
   "addBlocker": "+ 新增阻塞項",
   "addDetailsAboutThisChange": "新增此變更的詳細說明…",
   "addFolder": "新增資料夾",
+  "addFolderExecutorUnknown": "尚未確認此任務的執行器",
   "addLabel": "新增標籤",
   "addLabels": "+ 新增標籤",
   "addMore": "新增更多",

--- a/apps/web/src/locales/zh-tw/task.json
+++ b/apps/web/src/locales/zh-tw/task.json
@@ -24,6 +24,7 @@
   "addBlocker": "+ 新增阻塞項",
   "addDetailsAboutThisChange": "新增此變更的詳細說明…",
   "addFolder": "新增資料夾",
+  "addFolderExecutorUnknown": "尚未確認此任務的執行器",
   "addLabel": "新增標籤",
   "addLabels": "+ 新增標籤",
   "addMore": "新增更多",


### PR DESCRIPTION
The mobile "Add workspace sources" e2e spec was misdiagnosed as a slow backend event and covered with a 30s timeout band-aid; the actual bug is that a routine re-hydration path silently wiped an already-correct executor binding back to `undefined`, hiding the "Add folder" control with no explanation.

## Important Changes

- Root cause: `lib/ssr/mapper.ts`'s `snapshotToState` never mapped `primary_executor_id`/`type`/`name`/`is_remote_executor` onto the kanban task. `hooks/use-workflow-snapshot.ts` calls this mapper on every task-detail page hydrate (not just boot), so it kept overwriting a correct binding with an executor-less copy.
- Hardened `hooks/domains/kanban/use-all-workflow-snapshots.ts`'s snapshot merge to preserve cached executor fields across the same `omitempty` gap it already handles for `primarySessionId`/`autopilot`/`statusSummary`.
- `getWorkspaceSourceCapabilities` now returns `executorCapabilitiesKnown`, so an unresolved executor renders "Add folder" **disabled with a touch-visible reason** instead of silently disappearing (extracted into `add-folder-button.tsx` to stay under the file-length lint limit).
- Replaced the 30s "Add folder" timeout budget in both the mobile and desktop e2e specs with a causal `expect.poll` on the backend executor binding, armed before navigation.

## Validation

- `pnpm run e2e:raw tests/task/mobile-add-workspace-sources.spec.ts --project=mobile-chrome --retries=0` — 3 consecutive green runs (previously red).
- `pnpm run e2e:raw tests/task/add-workspace-sources.spec.ts --project=chromium --retries=0` — 2/2 green.
- `pnpm --filter @kandev/web test` — 1425 files, 11746 passed, 4 skipped, 0 failed.
- `pnpm run lint` (0 warnings), `pnpm run typecheck`, `pnpm run i18n:check`, `pnpm run i18n:ratchet` — all green.
- No backend files changed, so `make -C apps/backend test lint` was not required.

## Possible Improvements

Low risk overall (test-infra + a UI disabled-state fix), with three things worth a reviewer's eyes:
- **Copy**: `task:addFolderExecutorUnknown` ("Waiting to confirm this task's executor supports folders") implies a transient state. If a task's primary session never binds an executor, that disabled button persists rather than resolving — confirm the wording is intended.
- **Untested locally**: the `containers` Playwright project (ssh/docker executors) asserts `Add folder` has count 0; the new disabled button introduces a brief window where the count is 1 before the executor resolves. `toHaveCount(0)` retries until it holds and both specs already wait for the session to settle, so this should self-heal, but this sandbox has no Docker daemon to run it — CI's `e2e-containers` job is the real check.
- **Pre-existing, not fixed here**: `apps/web/lib/state/hydration/hydrator.ts:50-51`'s `mergeKanbanTasks` replaces the cached task wholesale with no preserve guard for the same omitempty executor fields (its two sibling merge paths, including the one this PR touches, both have one). Reproduces this PR's symptom by a narrower path. Tracked separately in a follow-up task; cc @carlosmflorencio, who introduced the wholesale-replace line in `44811da70`.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2696?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->