### PR TITLE
fix(orchestrator): route workflow steps to profile sessions (#2692)

### DIFF
--- a/apps/backend/internal/orchestrator/event_handlers_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_test.go
@@ -42,6 +42,7 @@ import (
 type mockStepGetter struct {
 	steps                  map[string]*wfmodels.WorkflowStep // stepID -> step
 	workflowAgentProfileID string                            // returned by GetWorkflowMeta
+	workflowAgentProfiles  []string                          // optional profiles returned per call
 	workflowPrompts        map[string]string                 // workflowID -> prompt
 	workflowMetaCalls      int                               // GetWorkflowMeta invocations
 	workflowMetaErr        error                             // optional error from GetWorkflowMeta
@@ -90,6 +91,7 @@ func (m *mockStepGetter) GetPreviousStepByPosition(_ context.Context, workflowID
 func (m *mockStepGetter) GetWorkflowMeta(_ context.Context, workflowID string) (WorkflowMeta, error) {
 	m.workflowMetaMu.Lock()
 	m.workflowMetaCalls++
+	callNumber := m.workflowMetaCalls
 	delay := m.workflowMetaDelay
 	m.workflowMetaMu.Unlock()
 	if delay > 0 {
@@ -102,8 +104,12 @@ func (m *mockStepGetter) GetWorkflowMeta(_ context.Context, workflowID string) (
 	if m.workflowPrompts != nil {
 		prompt = m.workflowPrompts[workflowID]
 	}
+	profileID := m.workflowAgentProfileID
+	if callNumber <= len(m.workflowAgentProfiles) {
+		profileID = m.workflowAgentProfiles[callNumber-1]
+	}
 	return WorkflowMeta{
-		AgentProfileID: m.workflowAgentProfileID,
+		AgentProfileID: profileID,
 		Prompt:         prompt,
 	}, nil
 }

--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -1721,17 +1721,21 @@ func (s *Service) completeAndStopSession(ctx context.Context, taskID string, ses
 	}
 }
 
-// maybySwitchSessionForProfile checks whether the step requires a different agent profile
-// and switches the session if so. Passthrough sessions are returned unchanged.
-// When the step has no explicit step/workflow profile, the current session is
-// preserved so workflow advancement does not reset the user's current agent mode.
-// Returns the effective session (new or original) and whether processing should continue.
-// A false return means the switch failed; the caller should return immediately.
-func (s *Service) maybySwitchSessionForProfile(
+// prepareWorkflowStepSession resolves the session that must execute a workflow
+// step before any on_enter action runs. Passthrough sessions and steps without
+// an effective profile keep the current session. Profile changes delegate to
+// the existing reuse/create lifecycle helpers.
+func (s *Service) prepareWorkflowStepSession(
 	ctx context.Context, taskID string, session *models.TaskSession, step *wfmodels.WorkflowStep,
-) (*models.TaskSession, bool) {
+) (*models.TaskSession, bool, error) {
+	if session == nil {
+		return nil, false, fmt.Errorf("workflow step session is nil")
+	}
+	if step == nil {
+		return nil, false, fmt.Errorf("workflow step is nil")
+	}
 	if s.agentManager.IsPassthroughSession(ctx, session.ID) {
-		return session, true
+		return session, false, nil
 	}
 	effectiveProfile := s.resolveStepAgentProfile(ctx, step)
 	if effectiveProfile == "" || effectiveProfile == session.AgentProfileID {
@@ -1749,18 +1753,33 @@ func (s *Service) maybySwitchSessionForProfile(
 				session.IsPrimary = true
 			}
 		}
-		return session, true
+		return session, false, nil
 	}
 	newSession, err := s.switchSessionForStep(ctx, taskID, session, effectiveProfile)
+	if err != nil {
+		return nil, false, err
+	}
+	return newSession, true, nil
+}
+
+// maybySwitchSessionForProfile preserves the legacy processOnEnter failure
+// handling while sharing the error-returning step-entry preflight with direct
+// workflow-engine dispatch.
+func (s *Service) maybySwitchSessionForProfile(
+	ctx context.Context, taskID string, session *models.TaskSession, step *wfmodels.WorkflowStep,
+) (*models.TaskSession, bool) {
+	effective, _, err := s.prepareWorkflowStepSession(ctx, taskID, session, step)
 	if err != nil {
 		s.logger.Error("failed to switch session for step agent profile",
 			zap.String("task_id", taskID),
 			zap.String("step_id", step.ID),
 			zap.Error(err))
-		s.setSessionWaitingForInput(ctx, taskID, session.ID, session)
+		if session != nil {
+			s.setSessionWaitingForInput(ctx, taskID, session.ID, session)
+		}
 		return nil, false
 	}
-	return newSession, true
+	return effective, true
 }
 
 // processOnEnter processes the on_enter events for a step after transitioning to it.

--- a/apps/backend/internal/orchestrator/event_handlers_workflow_profile_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow_profile_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kandev/kandev/internal/orchestrator/scheduler"
 	"github.com/kandev/kandev/internal/sysprompt"
 	"github.com/kandev/kandev/internal/task/models"
+	"github.com/kandev/kandev/internal/workflow/engine"
 	wfmodels "github.com/kandev/kandev/internal/workflow/models"
 )
 
@@ -159,6 +160,124 @@ func TestResolveStepAgentProfile(t *testing.T) {
 			t.Errorf("expected profile-step, got %q", got)
 		}
 	})
+}
+
+func TestPrepareWorkflowStepSession_PreservesMatchingProfileSession(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "t1", "s1", "step1")
+
+	session, err := repo.GetTaskSession(ctx, "s1")
+	if err != nil {
+		t.Fatalf("get session: %v", err)
+	}
+	session.AgentProfileID = "profile-a"
+	session.IsPrimary = true
+	if err := repo.UpdateTaskSession(ctx, session); err != nil {
+		t.Fatalf("update session: %v", err)
+	}
+
+	stepGetter := newMockStepGetter()
+	step := &wfmodels.WorkflowStep{
+		ID:             "step1",
+		WorkflowID:     "wf1",
+		AgentProfileID: "profile-a",
+	}
+	stepGetter.steps[step.ID] = step
+	svc := createTestService(repo, stepGetter, newMockTaskRepo())
+
+	effective, switched, err := svc.prepareWorkflowStepSession(ctx, "t1", session, step)
+	if err != nil {
+		t.Fatalf("prepareWorkflowStepSession returned error: %v", err)
+	}
+	if switched {
+		t.Fatal("matching profile must not switch sessions")
+	}
+	if effective.ID != session.ID {
+		t.Fatalf("effective session = %q, want %q", effective.ID, session.ID)
+	}
+	updated, err := repo.GetTaskSession(ctx, session.ID)
+	if err != nil {
+		t.Fatalf("reload session: %v", err)
+	}
+	if !updated.IsPrimary {
+		t.Fatal("matching profile session must remain primary")
+	}
+}
+
+func TestSwitchWorkflowDispatcherRoutesOnEnterToDestinationProfileSession(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "t1", "s1", "step2")
+
+	session, err := repo.GetTaskSession(ctx, "s1")
+	if err != nil {
+		t.Fatalf("get session: %v", err)
+	}
+	session.AgentProfileID = "profile-a"
+	session.ExecutorID = "exec-local"
+	session.ExecutorProfileID = "executor-profile"
+	session.IsPrimary = true
+	session.TaskEnvironmentID = "env-1"
+	if err := repo.UpdateTaskSession(ctx, session); err != nil {
+		t.Fatalf("update session: %v", err)
+	}
+
+	stepGetter := newMockStepGetter()
+	stepGetter.steps["step2"] = &wfmodels.WorkflowStep{
+		ID:             "step2",
+		WorkflowID:     "wf1",
+		AgentProfileID: "profile-b",
+		Events: wfmodels.StepEvents{OnEnter: []wfmodels.OnEnterAction{{
+			Type:   wfmodels.OnEnterSetSessionMode,
+			Config: map[string]any{"mode": "acceptEdits"},
+		}}},
+	}
+	taskRepo := newMockTaskRepo()
+	taskRepo.tasks["t1"] = &v1.Task{ID: "t1", WorkflowID: "wf1", State: v1.TaskStateInProgress}
+	agentMgr := &mockAgentManager{repoForExecutionLookup: repo}
+	log := testLogger()
+	exec := executor.NewExecutor(agentMgr, repo, log, executor.ExecutorConfig{})
+	svc := createTestServiceWithAgent(repo, stepGetter, taskRepo, agentMgr)
+	svc.logger = log
+	svc.executor = exec
+	svc.scheduler = scheduler.NewScheduler(queue.NewTaskQueue(10), exec, taskRepo, log, scheduler.SchedulerConfig{})
+	svc.initWorkflowEngine()
+
+	if err := switchWorkflowDispatcher(svc)(ctx, "t1", "s1", engine.TriggerOnEnter, "op-1"); err != nil {
+		t.Fatalf("dispatcher returned error: %v", err)
+	}
+
+	sessions, err := repo.ListTaskSessions(ctx, "t1")
+	if err != nil {
+		t.Fatalf("list sessions: %v", err)
+	}
+	var destination *models.TaskSession
+	for _, candidate := range sessions {
+		if candidate.AgentProfileID == "profile-b" {
+			destination = candidate
+			break
+		}
+	}
+	if destination == nil {
+		t.Fatal("expected destination profile session")
+	}
+	if !destination.IsPrimary {
+		t.Fatal("destination profile session must be primary")
+	}
+	if destination.TaskEnvironmentID != "env-1" {
+		t.Fatalf("destination TaskEnvironmentID = %q, want env-1", destination.TaskEnvironmentID)
+	}
+	if len(agentMgr.setSessionModeCalls) != 1 || agentMgr.setSessionModeCalls[0].SessionID != destination.ID {
+		t.Fatalf("set_session_mode calls = %+v, want destination session %q", agentMgr.setSessionModeCalls, destination.ID)
+	}
+	old, err := repo.GetTaskSession(ctx, "s1")
+	if err != nil {
+		t.Fatalf("reload initiating session: %v", err)
+	}
+	if old.State != models.TaskSessionStateCompleted {
+		t.Fatalf("initiating session state = %s, want completed", old.State)
+	}
 }
 
 func TestSwitchSessionForStep(t *testing.T) {

--- a/apps/backend/internal/orchestrator/event_handlers_workflow_profile_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow_profile_test.go
@@ -280,6 +280,61 @@ func TestSwitchWorkflowDispatcherRoutesOnEnterToDestinationProfileSession(t *tes
 	}
 }
 
+type workflowMetaProbeCallback struct {
+	svc             *Service
+	step            *wfmodels.WorkflowStep
+	resolvedProfile string
+}
+
+func (c *workflowMetaProbeCallback) Execute(ctx context.Context, _ engine.ActionInput) (engine.ActionResult, error) {
+	c.resolvedProfile = c.svc.resolveStepAgentProfile(ctx, c.step)
+	return engine.ActionResult{}, nil
+}
+
+func TestSwitchWorkflowDispatcherSharesWorkflowMetaCacheWithAutoStart(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "t1", "s1", "step2")
+	session, err := repo.GetTaskSession(ctx, "s1")
+	if err != nil {
+		t.Fatalf("get session: %v", err)
+	}
+	session.AgentProfileID = "profile-a"
+	session.IsPrimary = true
+	if err := repo.UpdateTaskSession(ctx, session); err != nil {
+		t.Fatalf("update session: %v", err)
+	}
+
+	stepGetter := newMockStepGetter()
+	stepGetter.workflowAgentProfiles = []string{"profile-a", "profile-b"}
+	stepGetter.workflowPrompts["wf1"] = "workflow instructions"
+	step := &wfmodels.WorkflowStep{
+		ID:         "step2",
+		WorkflowID: "wf1",
+		Events:     wfmodels.StepEvents{OnEnter: []wfmodels.OnEnterAction{{Type: wfmodels.OnEnterAutoStartAgent}}},
+	}
+	stepGetter.steps["step2"] = step
+	taskRepo := newMockTaskRepo()
+	taskRepo.tasks["t1"] = &v1.Task{ID: "t1", WorkflowID: "wf1", State: v1.TaskStateInProgress}
+	agentMgr := &mockAgentManager{repoForExecutionLookup: repo}
+	svc := createTestServiceWithAgent(repo, stepGetter, taskRepo, agentMgr)
+	svc.initWorkflowEngine()
+	probe := &workflowMetaProbeCallback{svc: svc, step: step}
+	svc.workflowEngine = engine.New(svc.workflowStore, engine.MapRegistry{
+		engine.ActionAutoStartAgent: probe,
+	})
+
+	if err := switchWorkflowDispatcher(svc)(ctx, "t1", "s1", engine.TriggerOnEnter, "op-1"); err != nil {
+		t.Fatalf("dispatcher returned error: %v", err)
+	}
+	if got := stepGetter.metaCalls(); got != 1 {
+		t.Fatalf("GetWorkflowMeta calls = %d, want 1 shared read", got)
+	}
+	if probe.resolvedProfile != "profile-a" {
+		t.Fatalf("callback resolved profile = %q, want cached profile-a", probe.resolvedProfile)
+	}
+}
+
 func TestSwitchSessionForStep(t *testing.T) {
 	ctx := context.Background()
 

--- a/apps/backend/internal/orchestrator/event_handlers_workflow_profile_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow_profile_test.go
@@ -280,6 +280,70 @@ func TestSwitchWorkflowDispatcherRoutesOnEnterToDestinationProfileSession(t *tes
 	}
 }
 
+func TestSwitchWorkflowDispatcherSkipsPreflightForAppliedOperation(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "t1", "s1", "step2")
+
+	session, err := repo.GetTaskSession(ctx, "s1")
+	if err != nil {
+		t.Fatalf("get session: %v", err)
+	}
+	session.AgentProfileID = "profile-a"
+	session.ExecutorID = "exec-local"
+	session.ExecutorProfileID = "executor-profile"
+	session.IsPrimary = true
+	if err := repo.UpdateTaskSession(ctx, session); err != nil {
+		t.Fatalf("update session: %v", err)
+	}
+
+	stepGetter := newMockStepGetter()
+	stepGetter.steps["step2"] = &wfmodels.WorkflowStep{
+		ID:             "step2",
+		WorkflowID:     "wf1",
+		AgentProfileID: "profile-b",
+		Events: wfmodels.StepEvents{OnEnter: []wfmodels.OnEnterAction{{
+			Type:   wfmodels.OnEnterSetSessionMode,
+			Config: map[string]any{"mode": "acceptEdits"},
+		}}},
+	}
+	taskRepo := newMockTaskRepo()
+	taskRepo.tasks["t1"] = &v1.Task{ID: "t1", WorkflowID: "wf1", State: v1.TaskStateInProgress}
+	agentMgr := &mockAgentManager{repoForExecutionLookup: repo}
+	log := testLogger()
+	exec := executor.NewExecutor(agentMgr, repo, log, executor.ExecutorConfig{})
+	svc := createTestServiceWithAgent(repo, stepGetter, taskRepo, agentMgr)
+	svc.logger = log
+	svc.executor = exec
+	svc.scheduler = scheduler.NewScheduler(queue.NewTaskQueue(10), exec, taskRepo, log, scheduler.SchedulerConfig{})
+	svc.initWorkflowEngine()
+	if err := svc.workflowStore.MarkOperationApplied(ctx, "op-replay"); err != nil {
+		t.Fatalf("mark operation applied: %v", err)
+	}
+
+	if err := switchWorkflowDispatcher(svc)(ctx, "t1", "s1", engine.TriggerOnEnter, "op-replay"); err != nil {
+		t.Fatalf("dispatcher returned error: %v", err)
+	}
+
+	sessions, err := repo.ListTaskSessions(ctx, "t1")
+	if err != nil {
+		t.Fatalf("list sessions: %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("session count = %d, want original session only", len(sessions))
+	}
+	unchanged, err := repo.GetTaskSession(ctx, "s1")
+	if err != nil {
+		t.Fatalf("reload initiating session: %v", err)
+	}
+	if unchanged.State != models.TaskSessionStateRunning {
+		t.Fatalf("initiating session state = %s, want running", unchanged.State)
+	}
+	if len(agentMgr.setSessionModeCalls) != 0 {
+		t.Fatalf("set_session_mode calls = %+v, want none", agentMgr.setSessionModeCalls)
+	}
+}
+
 type workflowMetaProbeCallback struct {
 	svc             *Service
 	step            *wfmodels.WorkflowStep

--- a/apps/backend/internal/orchestrator/task_operations.go
+++ b/apps/backend/internal/orchestrator/task_operations.go
@@ -1800,6 +1800,7 @@ func (s *Service) waitForStartingSessionPromptable(ctx context.Context, taskID, 
 // If the session is not running, it will be resumed first. Then a prompt is sent using the
 // step's prompt_prefix, prompt_suffix, and plan_mode settings combined with the task description.
 func (s *Service) StartSessionForWorkflowStep(ctx context.Context, taskID, sessionID, workflowStepID string) error {
+	ctx = withWorkflowMetaCache(ctx)
 	s.logger.Debug("starting session for workflow step",
 		zap.String("task_id", taskID),
 		zap.String("session_id", sessionID),
@@ -1823,6 +1824,18 @@ func (s *Service) StartSessionForWorkflowStep(ctx context.Context, taskID, sessi
 	}
 	if session.TaskID != taskID {
 		return fmt.Errorf("session does not belong to task")
+	}
+	if !s.agentManager.IsPassthroughSession(ctx, session.ID) {
+		effectiveProfile := s.resolveStepAgentProfile(ctx, step)
+		if effectiveProfile != "" && effectiveProfile != session.AgentProfileID {
+			return fmt.Errorf(
+				"workflow step profile mismatch: step %q resolves to profile %q but session %q uses profile %q; route the session before prompting",
+				workflowStepID,
+				effectiveProfile,
+				session.ID,
+				session.AgentProfileID,
+			)
+		}
 	}
 
 	dbTask, err := s.repo.GetTask(ctx, taskID)

--- a/apps/backend/internal/orchestrator/task_operations_test.go
+++ b/apps/backend/internal/orchestrator/task_operations_test.go
@@ -69,6 +69,35 @@ func seedTaskAndSession(t *testing.T, repo *sqliterepo.Repository, taskID, sessi
 	}
 }
 
+func TestStartSessionForWorkflowStepRejectsProfileMismatchBeforePrompt(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "t1", "s1", "step1")
+
+	session, err := repo.GetTaskSession(ctx, "s1")
+	if err != nil {
+		t.Fatalf("get session: %v", err)
+	}
+	session.AgentProfileID = "profile-a"
+	session.State = models.TaskSessionStateWaitingForInput
+	if err := repo.UpdateTaskSession(ctx, session); err != nil {
+		t.Fatalf("update session: %v", err)
+	}
+
+	stepGetter := newMockStepGetter()
+	stepGetter.steps["step2"] = &wfmodels.WorkflowStep{
+		ID:             "step2",
+		WorkflowID:     "wf1",
+		AgentProfileID: "profile-b",
+	}
+	svc := createTestService(repo, stepGetter, newMockTaskRepo())
+
+	err = svc.StartSessionForWorkflowStep(ctx, "t1", "s1", "step2")
+	if err == nil || !strings.Contains(err.Error(), "profile mismatch") {
+		t.Fatalf("StartSessionForWorkflowStep error = %v, want profile mismatch", err)
+	}
+}
+
 // taskEnvironmentFailureRepo injects an error after session creation but before
 // Executor reaches AgentManager.LaunchAgent. This models workspace-preparation
 // failures, which do not trigger the executor's launch-failure callback.

--- a/apps/backend/internal/orchestrator/workflow_callbacks.go
+++ b/apps/backend/internal/orchestrator/workflow_callbacks.go
@@ -97,6 +97,7 @@ func switchWorkflowDispatcher(svc *Service) engine.DispatchTriggerFn {
 		if eng == nil {
 			return nil // engine not initialised; treat as no-op
 		}
+		ctx = withWorkflowMetaCache(ctx)
 		var preloadedState *engine.MachineState
 		if trigger == engine.TriggerOnEnter {
 			var err error

--- a/apps/backend/internal/orchestrator/workflow_callbacks.go
+++ b/apps/backend/internal/orchestrator/workflow_callbacks.go
@@ -97,14 +97,56 @@ func switchWorkflowDispatcher(svc *Service) engine.DispatchTriggerFn {
 		if eng == nil {
 			return nil // engine not initialised; treat as no-op
 		}
+		var preloadedState *engine.MachineState
+		if trigger == engine.TriggerOnEnter {
+			var err error
+			sessionID, preloadedState, err = svc.prepareDirectWorkflowStepEntry(ctx, taskID, sessionID)
+			if err != nil {
+				return err
+			}
+		}
 		_, err := eng.HandleTrigger(ctx, engine.HandleInput{
-			TaskID:      taskID,
-			SessionID:   sessionID,
-			Trigger:     trigger,
-			OperationID: operationID,
+			TaskID:         taskID,
+			SessionID:      sessionID,
+			Trigger:        trigger,
+			OperationID:    operationID,
+			PreloadedState: preloadedState,
 		})
 		return err
 	}
+}
+
+func (s *Service) prepareDirectWorkflowStepEntry(
+	ctx context.Context, taskID, sessionID string,
+) (string, *engine.MachineState, error) {
+	ctx = withWorkflowMetaCache(ctx)
+	task, err := s.repo.GetTask(ctx, taskID)
+	if err != nil {
+		return "", nil, fmt.Errorf("load task for workflow step entry: %w", err)
+	}
+	if task == nil {
+		return "", nil, fmt.Errorf("task %s not found for workflow step entry", taskID)
+	}
+	if s.workflowStepGetter == nil || task.WorkflowStepID == "" {
+		return "", nil, fmt.Errorf("workflow step is not available for task %s", taskID)
+	}
+	step, err := s.workflowStepGetter.GetStep(ctx, task.WorkflowStepID)
+	if err != nil {
+		return "", nil, fmt.Errorf("load destination workflow step: %w", err)
+	}
+	if step == nil {
+		return "", nil, fmt.Errorf("destination workflow step %s not found", task.WorkflowStepID)
+	}
+	session, err := s.repo.GetTaskSession(ctx, sessionID)
+	if err != nil {
+		return "", nil, fmt.Errorf("load session for workflow step entry: %w", err)
+	}
+	effectiveSession, _, err := s.prepareWorkflowStepSession(ctx, taskID, session, step)
+	if err != nil {
+		return "", nil, fmt.Errorf("prepare session for workflow step entry: %w", err)
+	}
+	state := s.buildMachineState(ctx, task, effectiveSession)
+	return effectiveSession.ID, &state, nil
 }
 
 // enablePlanModeCallback enables plan mode on the session.

--- a/apps/backend/internal/orchestrator/workflow_callbacks.go
+++ b/apps/backend/internal/orchestrator/workflow_callbacks.go
@@ -97,6 +97,19 @@ func switchWorkflowDispatcher(svc *Service) engine.DispatchTriggerFn {
 		if eng == nil {
 			return nil // engine not initialised; treat as no-op
 		}
+		// Direct on_enter preflight can create/promote sessions and retire the
+		// initiating session, so it must not run for a replayed operation. The
+		// engine performs the same check before executing actions, but that is
+		// necessarily after this dispatcher-side preparation.
+		if operationID != "" && svc.workflowStore != nil {
+			applied, err := svc.workflowStore.IsOperationApplied(ctx, operationID)
+			if err != nil {
+				return err
+			}
+			if applied {
+				return nil
+			}
+		}
 		ctx = withWorkflowMetaCache(ctx)
 		var preloadedState *engine.MachineState
 		if trigger == engine.TriggerOnEnter {


### PR DESCRIPTION
Fixes kdlbs/kandev#2692

## Important Changes

- Routes direct engine-driven workflow `on_enter` actions through a shared
  destination-session preflight.
- Creates or reuses the session for the destination agent profile before
  executing reset, configuration, mode, or auto-start actions.
- Preserves task environment inheritance, primary-session promotion, queue
  transfer, and previous-session retirement.
- Rejects workflow-step prompts when the supplied session profile does not match
  the resolved destination profile.
- Adds regression coverage for direct dispatch, profile switching, session
  continuity, and prompt-boundary mismatches.

## Validation

- `go test ./internal/orchestrator -run
  'Test.*(SwitchWorkflow|WorkflowStepProfile|SwitchSessionForStep|StartSessionForWorkflowStep)' -count=1`
- `go test -tags fts5 ./internal/orchestrator/...`
- `golangci-lint run ./internal/orchestrator/... --timeout=5m`
- Public documentation validation passed; no public docs change was required.
- Manual UAT completed.

## Possible Improvements

Low risk. The change is isolated to orchestrator workflow routing and keeps
passthrough-session behavior unchanged.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2697?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

