### PR TITLE
fix: persist Codex MCP approval (#2691)

### DIFF
--- a/apps/backend/internal/agent/mcpconfig/passthrough.go
+++ b/apps/backend/internal/agent/mcpconfig/passthrough.go
@@ -170,7 +170,7 @@ type CodexStrategy struct{}
 
 const (
 	codexKandevServerName   = "kandev"
-	codexKandevApprovalMode = "auto"
+	codexKandevApprovalMode = "approve"
 )
 
 func (CodexStrategy) BuildPassthroughMCP(servers []types.McpServer, _ PassthroughPaths) (PassthroughArtifacts, error) {

--- a/apps/backend/internal/agent/mcpconfig/passthrough.go
+++ b/apps/backend/internal/agent/mcpconfig/passthrough.go
@@ -168,6 +168,11 @@ func claudeRemoteType(t string) string {
 // inferred from the presence of `command` vs `url` (there is no `type` key).
 type CodexStrategy struct{}
 
+const (
+	codexKandevServerName   = "kandev"
+	codexKandevApprovalMode = "auto"
+)
+
 func (CodexStrategy) BuildPassthroughMCP(servers []types.McpServer, _ PassthroughPaths) (PassthroughArtifacts, error) {
 	args := make([]string, 0, len(servers)*4)
 	for _, srv := range servers {
@@ -214,6 +219,9 @@ func codexServerArgs(srv types.McpServer) ([]string, error) {
 		if len(srv.Headers) > 0 {
 			pairs = append(pairs, pair{"http_headers", srv.Headers})
 		}
+	}
+	if srv.Name == codexKandevServerName {
+		pairs = append(pairs, pair{"default_tools_approval_mode", codexKandevApprovalMode})
 	}
 	// NOTE: env vars and headers are JSON-encoded into `-c` overrides, which
 	// land in the process argument list (visible via `ps aux`) — a local user

--- a/apps/backend/internal/agent/mcpconfig/passthrough_test.go
+++ b/apps/backend/internal/agent/mcpconfig/passthrough_test.go
@@ -140,6 +140,7 @@ func TestCodexStrategy_Args(t *testing.T) {
 	// stdio server: command + args + env
 	for _, want := range []string{
 		`-c mcp_servers.kandev.url="http://localhost:1234/mcp"`,
+		`-c mcp_servers.kandev.default_tools_approval_mode="auto"`,
 		`-c mcp_servers.github.command="npx"`,
 		`-c mcp_servers.github.args=["-y","@mcp/github"]`,
 		`-c mcp_servers.github.env={"GITHUB_TOKEN":"tok"}`,
@@ -149,6 +150,10 @@ func TestCodexStrategy_Args(t *testing.T) {
 		if !strings.Contains(joined, want) {
 			t.Errorf("missing arg %q in:\n%s", want, joined)
 		}
+	}
+	if strings.Contains(joined, `mcp_servers.github.default_tools_approval_mode`) ||
+		strings.Contains(joined, `mcp_servers.stream.default_tools_approval_mode`) {
+		t.Errorf("external MCP servers must not receive Kandev approval policy:\n%s", joined)
 	}
 	// Every value token must be preceded by a -c flag.
 	for i := 0; i < len(art.Args); i += 2 {
@@ -163,6 +168,27 @@ func TestCodexStrategy_OmitsEmptyArgsAndEnv(t *testing.T) {
 	art, _ := CodexStrategy{}.BuildPassthroughMCP(servers, PassthroughPaths{})
 	if got := strings.Join(art.Args, " "); got != `-c mcp_servers.bare.command="run"` {
 		t.Errorf("Args = %q", got)
+	}
+}
+
+func TestCodexStrategy_KandevPolicyIsAppliedPerLaunch(t *testing.T) {
+	for _, url := range []string{
+		"http://localhost:1001/mcp",
+		"http://localhost:1002/mcp",
+	} {
+		art, err := CodexStrategy{}.BuildPassthroughMCP([]types.McpServer{
+			{Name: "kandev", Type: "http", URL: url},
+		}, PassthroughPaths{})
+		if err != nil {
+			t.Fatalf("unexpected error for %s: %v", url, err)
+		}
+		joined := strings.Join(art.Args, " ")
+		if !strings.Contains(joined, `mcp_servers.kandev.default_tools_approval_mode="auto"`) {
+			t.Errorf("launch for %s omitted Kandev approval policy: %s", url, joined)
+		}
+		if !strings.Contains(joined, `mcp_servers.kandev.url="`+url+`"`) {
+			t.Errorf("launch for %s omitted dynamic Kandev URL: %s", url, joined)
+		}
 	}
 }
 

--- a/apps/backend/internal/agent/mcpconfig/passthrough_test.go
+++ b/apps/backend/internal/agent/mcpconfig/passthrough_test.go
@@ -140,7 +140,7 @@ func TestCodexStrategy_Args(t *testing.T) {
 	// stdio server: command + args + env
 	for _, want := range []string{
 		`-c mcp_servers.kandev.url="http://localhost:1234/mcp"`,
-		`-c mcp_servers.kandev.default_tools_approval_mode="auto"`,
+		`-c mcp_servers.kandev.default_tools_approval_mode="approve"`,
 		`-c mcp_servers.github.command="npx"`,
 		`-c mcp_servers.github.args=["-y","@mcp/github"]`,
 		`-c mcp_servers.github.env={"GITHUB_TOKEN":"tok"}`,
@@ -183,7 +183,7 @@ func TestCodexStrategy_KandevPolicyIsAppliedPerLaunch(t *testing.T) {
 			t.Fatalf("unexpected error for %s: %v", url, err)
 		}
 		joined := strings.Join(art.Args, " ")
-		if !strings.Contains(joined, `mcp_servers.kandev.default_tools_approval_mode="auto"`) {
+		if !strings.Contains(joined, `mcp_servers.kandev.default_tools_approval_mode="approve"`) {
 			t.Errorf("launch for %s omitted Kandev approval policy: %s", url, joined)
 		}
 		if !strings.Contains(joined, `mcp_servers.kandev.url="`+url+`"`) {


### PR DESCRIPTION
## Summary

- Persist Codex MCP approval for Kandev's dynamically injected `kandev` server.
- Emit the server-level `default_tools_approval_mode="auto"` override only for Kandev.
- Keep external MCP approval behavior unchanged.

## Validation

- `go test ./internal/agent/mcpconfig ./internal/agent/agents ./internal/agent/runtime/lifecycle`
- `gofmt` and `git diff --check`
- Codex 0.147.0 accepted the override through repeated `-c` arguments.
- UAT completed with two fresh Codex sessions and dynamic MCP ports; no repeated Kandev authorization prompt occurred.
- UAT server shutdown was graceful after the sessions completed.

`golangci-lint` could not load the package in the local read-only runner and reported `no go files to analyze`; this is an environment/tooling limitation.

Fixes #2691


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2699?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

