### PR TITLE
chore: add fork-test.txt to verify fork PR association

### DIFF
--- a/fork-test.txt
+++ b/fork-test.txt
@@ -1,0 +1,1 @@
+fork PR association test


### PR DESCRIPTION
Verify that a pull request opened from a fork correctly associates with the upstream repository; adds a throwaway marker file at the repo root as the change under test.

## Validation

- Confirmed `fork-test.txt` sits at the git root and contains the single line `fork PR association test` (LF, no CRLF).
- `git diff origin/main...HEAD --name-only` shows only `fork-test.txt` — no other files touched.

## Possible Improvements

Negligible risk: the file is an inert test marker and should be removed once fork PR association is confirmed.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2703?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->