### PR TITLE
fix(web): keep selection and searching state stable across partial content-search results

### DIFF
--- a/apps/web/components/command-panel.tsx
+++ b/apps/web/components/command-panel.tsx
@@ -4,7 +4,11 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { usePathname } from "@/lib/routing/client-router";
 import { useCommands, useCommandPanelOpen } from "@/lib/commands/command-registry";
 import type { CommandPanelMode, CommandItem as CommandItemType } from "@/lib/commands/types";
-import { findFirstMatchingCommand, selectCommandSearchResult } from "@/lib/commands/search";
+import {
+  findFirstMatchingCommand,
+  selectCommandSearchResult,
+  selectContentSearchResult,
+} from "@/lib/commands/search";
 import { useCommandPanelShortcuts } from "@/hooks/use-command-panel-shortcuts";
 import { useContentSearchResultOpener } from "@/hooks/use-content-search-result-opener";
 import { useWorkspaceContentSearch } from "@/hooks/domains/session/use-workspace-content-search";
@@ -388,8 +392,8 @@ function useFirstResultSelection(
     }
 
     if (mode === MODE_SEARCH_CONTENT) {
-      const firstResult = contentResults[0];
-      setSelectedValue(firstResult ? getContentSearchResultValue(firstResult) : "");
+      const values = contentResults.map(getContentSearchResultValue);
+      setSelectedValue((current) => selectContentSearchResult(values, current));
       return;
     }
 

--- a/apps/web/components/workspace-content-search.test.tsx
+++ b/apps/web/components/workspace-content-search.test.tsx
@@ -141,7 +141,52 @@ describe("WorkspaceContentSearch", () => {
     fireEvent.click(resultRows[1]);
     expect(onSelect).toHaveBeenCalledWith(results[1]);
   });
+});
 
+describe("WorkspaceContentSearch in-progress state", () => {
+  it("keeps the searching state visible next to partial results", () => {
+    // Results arrive incrementally, so a populated list can still be growing.
+    render(
+      <WorkspaceContentSearch
+        results={results}
+        isSearching={true}
+        error={null}
+        search="needle"
+        sessionId="session-1"
+        onSelect={vi.fn()}
+      />,
+    );
+
+    expect(screen.getAllByTestId("content-search-result").length).toBeGreaterThan(0);
+    const indicator = screen.getByTestId("content-search-in-progress");
+    expect(indicator).toBeTruthy();
+
+    // CommandList scrolls (max-h-72 overflow-y-auto), so existing in the DOM is
+    // not enough: appended below the groups it drops out of view the moment the
+    // early matches fill the palette. It has to lead the list and stick.
+    const groups = screen.getAllByTestId("content-search-repo-group");
+    expect(indicator.compareDocumentPosition(groups[0])).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    expect(indicator.className).toContain("sticky");
+    expect(indicator.className).toContain("top-0");
+  });
+
+  it("drops the searching state once the search finishes", () => {
+    render(
+      <WorkspaceContentSearch
+        results={results}
+        isSearching={false}
+        error={null}
+        search="needle"
+        sessionId="session-1"
+        onSelect={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByTestId("content-search-in-progress")).toBeNull();
+  });
+});
+
+describe("WorkspaceContentSearch labels", () => {
   it("uses a non-empty label for a single repository with an empty transport key", () => {
     render(
       <WorkspaceContentSearch

--- a/apps/web/components/workspace-content-search.tsx
+++ b/apps/web/components/workspace-content-search.tsx
@@ -162,25 +162,48 @@ export function WorkspaceContentSearch({
 
   const groups = groupByRepositoryName(results, (result) => result.repository_name);
   const singleRepo = isSingleRepoGroup(groups);
-  return groups.map((group) => (
-    <CommandGroup
-      key={group.repositoryName}
-      heading={
-        singleRepo
-          ? t("common:results")
-          : (getRepoDisplayName(group.repositoryName) ?? t("common:workspace"))
-      }
-      forceMount
-      data-testid="content-search-repo-group"
-      data-repository={group.repositoryName}
+  // Results are published as each retry attempt returns, so a populated list
+  // can still be growing. The spec requires the searching state to stay
+  // distinguishable from a finished one, and without this a partial list looks
+  // identical to "that is everything" while another repository is still
+  // starting up.
+  //
+  // It leads the list and sticks to the top of CommandList's own scroll box
+  // (max-h-72 overflow-y-auto): appended after the groups it fell below the
+  // fold as soon as the early matches filled the palette, which is exactly the
+  // case it exists for.
+  const stillSearching = isSearching ? (
+    <div
+      key="content-search-in-progress"
+      data-testid="content-search-in-progress"
+      className="sticky top-0 z-10 flex items-center bg-popover px-2 py-1.5 text-xs text-muted-foreground"
     >
-      {group.items.map((result) => (
-        <SearchResultRow
-          key={getContentSearchResultValue(result)}
-          result={result}
-          onSelect={onSelect}
-        />
-      ))}
-    </CommandGroup>
-  ));
+      <IconLoader2 className="mr-2 inline size-3 animate-spin" />
+      {t("common:searchingTaskWorkspace")}
+    </div>
+  ) : null;
+  return [
+    stillSearching,
+    ...groups.map((group) => (
+      <CommandGroup
+        key={group.repositoryName}
+        heading={
+          singleRepo
+            ? t("common:results")
+            : (getRepoDisplayName(group.repositoryName) ?? t("common:workspace"))
+        }
+        forceMount
+        data-testid="content-search-repo-group"
+        data-repository={group.repositoryName}
+      >
+        {group.items.map((result) => (
+          <SearchResultRow
+            key={getContentSearchResultValue(result)}
+            result={result}
+            onSelect={onSelect}
+          />
+        ))}
+      </CommandGroup>
+    )),
+  ];
 }

--- a/apps/web/hooks/domains/session/use-workspace-content-search.test.ts
+++ b/apps/web/hooks/domains/session/use-workspace-content-search.test.ts
@@ -348,5 +348,48 @@ describe("useWorkspaceContentSearch incremental publishing", () => {
     await act(async () => vi.advanceTimersByTimeAsync(500));
     expect(result.current.results).toEqual([primary, extra]);
     expect(result.current.isSearching).toBe(true);
+  it("drops a partial result published by a superseded query", async () => {
+    const staleResult = {
+      repository_name: "",
+      path: "stale.ts",
+      line: 1,
+      column: 1,
+      preview: "stale",
+      match_ranges: [],
+    };
+    const liveResult = {
+      repository_name: "",
+      path: "live.ts",
+      line: 1,
+      column: 1,
+      preview: "live",
+      match_ranges: [],
+    };
+    let resolveStale: ((value: { results: (typeof staleResult)[] }) => void) | undefined;
+    mockSearchWorkspaceContent
+      .mockImplementationOnce(
+        () =>
+          new Promise<{ results: (typeof staleResult)[] }>((resolve) => {
+            resolveStale = resolve;
+          }),
+      )
+      .mockResolvedValue({ results: [liveResult] });
+    const { result, rerender } = renderHook(
+      ({ query }) => useWorkspaceContentSearch({ enabled: true, query, sessionId: "session-1" }),
+      { initialProps: { query: "stale" } },
+    );
+    await act(async () => vi.advanceTimersByTimeAsync(250));
+
+    rerender({ query: "live" });
+    await act(async () => vi.advanceTimersByTimeAsync(250));
+    expect(result.current.results).toEqual([liveResult]);
+
+    // The superseded query's first attempt lands late. Only promises are
+    // flushed here, so the live query's next attempt cannot mask an overwrite.
+    await act(async () => {
+      resolveStale?.({ results: [staleResult] });
+    });
+
+    expect(result.current.results).toEqual([liveResult]);
   });
 });

--- a/apps/web/hooks/domains/session/use-workspace-content-search.test.ts
+++ b/apps/web/hooks/domains/session/use-workspace-content-search.test.ts
@@ -348,6 +348,8 @@ describe("useWorkspaceContentSearch incremental publishing", () => {
     await act(async () => vi.advanceTimersByTimeAsync(500));
     expect(result.current.results).toEqual([primary, extra]);
     expect(result.current.isSearching).toBe(true);
+  });
+
   it("drops a partial result published by a superseded query", async () => {
     const staleResult = {
       repository_name: "",

--- a/apps/web/lib/commands/search.test.ts
+++ b/apps/web/lib/commands/search.test.ts
@@ -6,6 +6,7 @@ import {
   scoreCommandSearch,
   selectCommandSearchResult,
   sortCommandsForSearch,
+  selectContentSearchResult,
 } from "./search";
 
 const SHARED_TERM = "Shared term";
@@ -100,5 +101,29 @@ describe("command search", () => {
 
   it("returns no command when nothing matches", () => {
     expect(findFirstMatchingCommand([command("home", "Go Home")], "terminal")).toBeUndefined();
+  });
+});
+
+describe("selectContentSearchResult", () => {
+  const values = ["repo\u0000a.ts\u00001", "repo\u0000b.ts\u00002"];
+
+  it("keeps a selection the user moved when a later batch appends", () => {
+    // The second batch appends a row; the highlighted one must not jump back.
+    expect(selectContentSearchResult([...values, "repo\u0000c.ts\u00003"], values[1])).toBe(
+      values[1],
+    );
+  });
+
+  it("falls back to the first row when the selection is gone", () => {
+    expect(selectContentSearchResult(values, "repo\u0000removed.ts\u00009")).toBe(values[0]);
+  });
+
+  it("selects the first row when nothing is selected yet", () => {
+    expect(selectContentSearchResult(values, "")).toBe(values[0]);
+    expect(selectContentSearchResult(values, undefined)).toBe(values[0]);
+  });
+
+  it("selects nothing when there are no results", () => {
+    expect(selectContentSearchResult([], "anything")).toBe("");
   });
 });

--- a/apps/web/lib/commands/search.ts
+++ b/apps/web/lib/commands/search.ts
@@ -69,6 +69,18 @@ export function findFirstMatchingCommand(
   );
 }
 
+/**
+ * Picks the highlighted row for content search, which publishes its results
+ * incrementally while later retry attempts are still running. A selection the
+ * user moved is kept as long as it still points at a row: resetting to the
+ * first result whenever a late repository appends would pull focus back and
+ * open a different file than the highlighted one.
+ */
+export function selectContentSearchResult(resultValues: string[], preferredValue?: string): string {
+  if (preferredValue && resultValues.includes(preferredValue)) return preferredValue;
+  return resultValues[0] ?? "";
+}
+
 export function selectCommandSearchResult(
   commands: CommandItem[],
   search: string,


### PR DESCRIPTION
#2710 landed incremental content-search results while this branch was open, which is the fix this PR originally carried, so that part is gone. What remains is the two things incremental publishing exposes, both of which are live on `main` today.

The palette resets its highlighted row whenever the result array changes, and that is now a mid-search event: a repository appending a result pulls focus back to the first row, so Enter opens a file the user had already moved off.

The searching indicator only renders while the result list is empty, so a partial list is indistinguishable from a finished search for the rest of the retry window. `docs/specs/ui/task-workspace-content-search.md` requires those states to stay distinguishable, which matters most in a multi-repository task where an absent match may just mean another repository is still starting.

## Important Changes

- The content-search selection is kept whenever it still points at a row, falling back to the first only when it is empty or stale. Extracted as `selectContentSearchResult` next to the existing `selectCommandSearchResult` so the rule is unit-testable rather than buried in an effect.
- The in-progress row leads the list and is `sticky top-0` against `CommandList`'s own scroll box. Appended after the groups it drops below the fold as soon as early matches fill the `max-h-72` palette, which is exactly the case it exists for.
- Adds coverage for #2710's incremental publish itself: results appear after the first response while `isSearching` is still true, and a superseded query cannot overwrite the live results.

## Validation

- `pnpm test`: 35 passed across the three affected files, rebased onto `8d006c401`.
- Mutation-checked: removing the selection-preserve branch fails the append case; appending the indicator after the groups, or dropping `sticky`, each fail the visibility case; removing #2710's publish fails three tests; removing **both** of its cancelled guards fails the stale-partial case. Removing either guard alone does not, since they are redundant by design.
- `pnpm e2e:raw tests/search/task-workspace-content-search.spec.ts`: 3 passed.
- `pnpm run lint`, `pnpm run typecheck`: clean.

## Possible Improvements

Low risk, and no behaviour from #2710 is reverted. The retry budget still issues up to eight round trips per search even after a complete answer; trimming that needs a repository-readiness signal the `workspace.content.search` response does not carry, which is worth doing separately rather than inferring from result counts.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.