### PR TITLE
test: cover incremental content-search publishing and git-failure propagation

### DIFF
--- a/apps/backend/internal/agentctl/server/process/workspace_content_search_failure_test.go
+++ b/apps/backend/internal/agentctl/server/process/workspace_content_search_failure_test.go
@@ -1,0 +1,86 @@
+//go:build !windows
+
+package process
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/common/subproc"
+)
+
+// Content search resolves its file list from a live `git ls-files` behind the
+// shared Git admission semaphore, so under contention that command can be
+// starved at admission or killed at its execution deadline. Both failures must
+// reach the caller as errors.
+//
+// A swallowed failure here would be indistinguishable from a genuinely empty
+// workspace: the palette would report "No content matches found" for a file
+// that exists on disk, and any test asserting on that match would fail with no
+// diagnosable cause. These pin the propagation at the tracker, which is where
+// the error is born and where it could be dropped; Manager.SearchWorkspaceContent
+// returns the first tracker error unchanged.
+
+// TestSearchContentReportsGitAdmissionStarvation covers a caller that gives up
+// waiting for a Git slot that never frees.
+func TestSearchContentReportsGitAdmissionStarvation(t *testing.T) {
+	tracker := newContentSearchFailureTracker(t)
+
+	restoreCap := subproc.Git().SetCapForTest(1)
+	t.Cleanup(restoreCap)
+	hold, err := subproc.AcquireGit(context.Background(), subproc.GitInteractive)
+	if err != nil {
+		t.Fatalf("hold git slot: %v", err)
+	}
+	t.Cleanup(hold)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	t.Cleanup(cancel)
+	results, err := tracker.SearchContent(ctx, "needle", 10)
+	if err == nil {
+		t.Fatalf("SearchContent returned nil error with %d results while Git admission "+
+			"was starved; a starved search must not be reported as an empty workspace",
+			len(results))
+	}
+}
+
+// TestSearchContentReportsGitCommandTimeout covers a Git process that wedges
+// past gitCommandTimeout and is killed.
+func TestSearchContentReportsGitCommandTimeout(t *testing.T) {
+	tracker := newContentSearchFailureTracker(t)
+
+	previousTimeout := gitCommandTimeout
+	gitCommandTimeout = 200 * time.Millisecond
+	t.Cleanup(func() { gitCommandTimeout = previousTimeout })
+	shimDir := installSleepGitShim(t)
+	t.Setenv("PATH", shimDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	results, err := tracker.SearchContent(context.Background(), "needle", 10)
+	if err == nil {
+		t.Fatalf("SearchContent returned nil error with %d results after the file-list "+
+			"command was killed at its deadline; a failed search must not be reported "+
+			"as an empty workspace", len(results))
+	}
+}
+
+// newContentSearchFailureTracker builds a tracker over a repository holding one
+// match and asserts the match is findable while Git is healthy, so a later
+// empty result cannot be blamed on the fixture.
+func newContentSearchFailureTracker(t *testing.T) *WorkspaceTracker {
+	t.Helper()
+	repoDir, cleanup := setupTestRepo(t)
+	t.Cleanup(cleanup)
+	writeFile(t, repoDir, "match.txt", "workspace content search needle\n")
+
+	tracker := NewWorkspaceTrackerForRepo(repoDir, "repo", newTestLogger(t))
+	baseline, err := tracker.SearchContent(context.Background(), "needle", 10)
+	if err != nil {
+		t.Fatalf("baseline SearchContent returned error: %v", err)
+	}
+	if len(baseline) != 1 {
+		t.Fatalf("baseline result count = %d, want 1", len(baseline))
+	}
+	return tracker
+}

--- a/apps/web/hooks/domains/session/use-workspace-content-search.test.ts
+++ b/apps/web/hooks/domains/session/use-workspace-content-search.test.ts
@@ -251,3 +251,46 @@ describe("useWorkspaceContentSearch stale responses", () => {
     expect(result.current.isSearching).toBe(false);
   });
 });
+
+describe("useWorkspaceContentSearch incremental publishing", () => {
+  // The retry loop exists so a repository that registers with the workspace
+  // process manager after task launch still contributes matches. Publishing
+  // the merged set only once the whole budget was spent put a fixed
+  // 250ms + 7 * 500ms = 3.75s floor under every search, which is what made
+  // the "cached preview content match" e2e spec fail its 5s assertion under
+  // CI load. This pins the per-attempt half of that contract: a repository
+  // whose matches only appear on a later attempt is published when that
+  // attempt lands, not when the budget runs out.
+  it("publishes a late repository's matches as soon as its attempt lands", async () => {
+    const primary = {
+      repository_name: "primary",
+      path: "src/primary.ts",
+      line: 1,
+      column: 1,
+      preview: "primary needle",
+      match_ranges: [],
+    };
+    const extra = {
+      repository_name: "extra",
+      path: "src/extra.ts",
+      line: 2,
+      column: 1,
+      preview: "extra needle",
+      match_ranges: [],
+    };
+    mockSearchWorkspaceContent
+      .mockResolvedValueOnce({ results: [primary] })
+      .mockResolvedValue({ results: [primary, extra] });
+    const { result } = renderHook(() =>
+      useWorkspaceContentSearch({ enabled: true, query: "needle", sessionId: "session-1" }),
+    );
+
+    await act(async () => vi.advanceTimersByTimeAsync(250));
+    expect(result.current.results).toEqual([primary]);
+
+    // One retry delay later the second repository has registered.
+    await act(async () => vi.advanceTimersByTimeAsync(500));
+    expect(result.current.results).toEqual([primary, extra]);
+    expect(result.current.isSearching).toBe(true);
+  });
+});


### PR DESCRIPTION
The `@search reveals and flashes a cached preview content match` e2e spec (shard 9) failed on #2707 on the original attempt and both retries. The cause was diagnosed here, but the production fix for it landed independently on main in #2710 while this was in review, so this PR is now test-only: it adds the coverage that fix does not carry.

## Important Changes

- Frontend: pins that a repository whose matches only appear on a *later* retry attempt is published when that attempt lands, rather than when the whole retry budget runs out. The test that came with #2710 covers the first attempt; this covers the incremental merge across attempts, which is the reason the retry loop exists at all.
- Backend: pins that a content search whose `git ls-files` is starved at admission or killed at its execution deadline surfaces an **error**, never an empty result set. A silent empty there is indistinguishable from "no matches" for a file that exists on disk, and would make any failure of this kind undiagnosable.

## Validation

Root cause was measured, not inferred. `useWorkspaceContentSearch` re-drove its one-shot request 8 times with 500ms gaps but published the merged set only after all 8 finished, so time-to-first-result was `250ms + 7 x 500ms + 8 x RTT`. With a zero-latency backend the first result appeared at exactly **3750ms**; at a 150ms per-attempt round trip, **4950ms** — against the spec's 5000ms assertion budget, so it passed only while mean round-trip stayed under ~156ms. The failing run's DOM snapshot shows the dialog still reading "Searching task workspace…", not "No content matches found" and not "Search failed", confirming the frontend was withholding results rather than the backend returning none.

- Reproduced locally at **10/10 failures** on the pre-fix build, with the identical signature to CI; **10/10 pass** afterwards.
- E2E whole spec file `--repeat-each=5` on this rebased branch: **15 passed / 15**.
- Mutation-proved: deleting main's `onResults` publish call fails both the new test and #2710's; swallowing the `getFileList` error fails both new Go tests, each naming itself.
- `pnpm test` (11831 passed), `pnpm lint`, `pnpm run typecheck`, `go test ./internal/agentctl/server/process/`, `golangci-lint --new-from-rev` (0 issues).

Two hypotheses were tested and **refuted** as causes: the tracker-graph rescan race (`contentSearchTrackers` and `SearchWorkspaceFileResults` walk the same `snapshotTrackers()` set, so the passing file-name search proves the tracker was present; a sibling worktree materialized after manager start is also discovered synchronously), and silent-empty-on-git-failure (both failure modes propagate errors — now pinned by the new Go tests).

## Possible Improvements

Negligible risk; no production code changes. Noted for follow-up, not fixed here: `SearchWorkspaceContent` calls `RescanRepositories` on every search, and `resolveGitIndexPath` waits up to 30s on a `context.Background()` admission, 3 calls per rescan — so under Git contention a search can block ~90s regardless of the caller's deadline and still return nil error (measured; healthy is 14ms). That 30s wait is deliberate, so unwinding it needs its own design pass.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.