### PR TITLE
fix(web): keep the model selector visible for sessions with an agent config key

### DIFF
--- a/apps/backend/internal/agent/settings/profileconfig/profileconfig.go
+++ b/apps/backend/internal/agent/settings/profileconfig/profileconfig.go
@@ -2,8 +2,10 @@ package profileconfig
 
 import "strings"
 
-// SanitizeConfigOptions drops reserved model/mode keys and blank entries so
-// profile config options persist only auxiliary select values.
+// SanitizeConfigOptions drops reserved identity keys (model/mode/agent) and
+// blank entries so profile config options persist only auxiliary select values.
+// "agent" records which agent runs the session; it is an identity field, never a
+// selectable ACP config option, so it must not leak into config_options.
 func SanitizeConfigOptions(in map[string]string) map[string]string {
 	if len(in) == 0 {
 		return nil
@@ -12,7 +14,7 @@ func SanitizeConfigOptions(in map[string]string) map[string]string {
 	for key, value := range in {
 		key = strings.TrimSpace(key)
 		value = strings.TrimSpace(value)
-		if key == "" || value == "" || key == "model" || key == "mode" {
+		if key == "" || value == "" || key == "model" || key == "mode" || key == "agent" {
 			continue
 		}
 		out[key] = value

--- a/apps/backend/internal/agent/settings/profileconfig/profileconfig.go
+++ b/apps/backend/internal/agent/settings/profileconfig/profileconfig.go
@@ -2,10 +2,8 @@ package profileconfig
 
 import "strings"
 
-// SanitizeConfigOptions drops reserved identity keys (model/mode/agent) and
-// blank entries so profile config options persist only auxiliary select values.
-// "agent" records which agent runs the session; it is an identity field, never a
-// selectable ACP config option, so it must not leak into config_options.
+// SanitizeConfigOptions drops the top-level model/mode keys and blank entries.
+// All other keys are provider-defined and must pass through unchanged.
 func SanitizeConfigOptions(in map[string]string) map[string]string {
 	if len(in) == 0 {
 		return nil
@@ -14,7 +12,7 @@ func SanitizeConfigOptions(in map[string]string) map[string]string {
 	for key, value := range in {
 		key = strings.TrimSpace(key)
 		value = strings.TrimSpace(value)
-		if key == "" || value == "" || key == "model" || key == "mode" || key == "agent" {
+		if key == "" || value == "" || key == "model" || key == "mode" {
 			continue
 		}
 		out[key] = value

--- a/apps/backend/internal/agent/settings/profileconfig/profileconfig_test.go
+++ b/apps/backend/internal/agent/settings/profileconfig/profileconfig_test.go
@@ -26,6 +26,11 @@ func TestSanitizeConfigOptions(t *testing.T) {
 			want: map[string]string{"effort": "low"},
 		},
 		{
+			name: "reserved agent key dropped",
+			in:   map[string]string{"agent": "claude", "effort": "high"},
+			want: map[string]string{"effort": "high"},
+		},
+		{
 			name: "blank value dropped",
 			in:   map[string]string{"effort": "", "level": "high"},
 			want: map[string]string{"level": "high"},
@@ -42,7 +47,7 @@ func TestSanitizeConfigOptions(t *testing.T) {
 		},
 		{
 			name: "all reserved returns nil",
-			in:   map[string]string{"model": "opus", "mode": "plan"},
+			in:   map[string]string{"model": "opus", "mode": "plan", "agent": "claude"},
 			want: nil,
 		},
 	}

--- a/apps/backend/internal/agent/settings/profileconfig/profileconfig_test.go
+++ b/apps/backend/internal/agent/settings/profileconfig/profileconfig_test.go
@@ -26,9 +26,9 @@ func TestSanitizeConfigOptions(t *testing.T) {
 			want: map[string]string{"effort": "low"},
 		},
 		{
-			name: "reserved agent key dropped",
-			in:   map[string]string{"agent": "claude", "effort": "high"},
-			want: map[string]string{"effort": "high"},
+			name: "provider agent key preserved",
+			in:   map[string]string{"agent": "build", "effort": "high"},
+			want: map[string]string{"agent": "build", "effort": "high"},
 		},
 		{
 			name: "blank value dropped",
@@ -47,7 +47,7 @@ func TestSanitizeConfigOptions(t *testing.T) {
 		},
 		{
 			name: "all reserved returns nil",
-			in:   map[string]string{"model": "opus", "mode": "plan", "agent": "claude"},
+			in:   map[string]string{"model": "opus", "mode": "plan"},
 			want: nil,
 		},
 	}

--- a/apps/backend/internal/task/models/models.go
+++ b/apps/backend/internal/task/models/models.go
@@ -355,8 +355,11 @@ func cleanRuntimeConfigOptions(options map[string]string) map[string]string {
 		return nil
 	}
 	cleaned := maps.Clone(options)
+	// Reserved identity keys: model/mode are carried as top-level fields and
+	// "agent" identifies the running agent. None is a selectable dynamic option.
 	delete(cleaned, "model")
 	delete(cleaned, "mode")
+	delete(cleaned, "agent")
 	if len(cleaned) == 0 {
 		return nil
 	}

--- a/apps/backend/internal/task/models/models.go
+++ b/apps/backend/internal/task/models/models.go
@@ -313,7 +313,7 @@ func LoadEffectiveSessionRuntimeConfig(session *TaskSession) (SessionRuntimeConf
 	if overrides, ok := LoadSessionRuntimeConfigOverrides(session.Metadata); ok {
 		mergeSessionRuntimeConfig(&effective, overrides)
 	}
-	effective.ConfigOptions = cleanRuntimeConfigOptions(effective.ConfigOptions)
+	effective.ConfigOptions = cleanRuntimeConfigOptions(effective.ConfigOptions, session)
 	return effective, !effective.IsZero()
 }
 
@@ -350,20 +350,33 @@ func mergeSessionRuntimeConfig(target *SessionRuntimeConfig, source SessionRunti
 	}
 }
 
-func cleanRuntimeConfigOptions(options map[string]string) map[string]string {
+func cleanRuntimeConfigOptions(options map[string]string, session *TaskSession) map[string]string {
 	if len(options) == 0 {
 		return nil
 	}
 	cleaned := maps.Clone(options)
-	// Reserved identity keys: model/mode are carried as top-level fields and
-	// "agent" identifies the running agent. None is a selectable dynamic option.
+	// Model and mode are carried as top-level fields. Other keys are provider-defined.
 	delete(cleaned, "model")
 	delete(cleaned, "mode")
-	delete(cleaned, "agent")
+	if isLegacyAgentIdentity(session, cleaned["agent"]) {
+		delete(cleaned, "agent")
+	}
 	if len(cleaned) == 0 {
 		return nil
 	}
 	return cleaned
+}
+
+func isLegacyAgentIdentity(session *TaskSession, value string) bool {
+	if session == nil || value == "" || session.AgentProfileSnapshot == nil {
+		return false
+	}
+	for _, key := range []string{"agent_id", "agent_name"} {
+		if StringFromAny(session.AgentProfileSnapshot[key]) == value {
+			return true
+		}
+	}
+	return false
 }
 
 // SessionOriginalEffectiveConfiguration is the immutable configuration a task

--- a/apps/backend/internal/task/models/session_runtime_config_test.go
+++ b/apps/backend/internal/task/models/session_runtime_config_test.go
@@ -9,8 +9,9 @@ import (
 func TestLoadEffectiveSessionRuntimeConfigMergesInPrecedenceOrder(t *testing.T) {
 	session := &TaskSession{
 		AgentProfileSnapshot: map[string]interface{}{
-			"model": "profile-model",
-			"mode":  "profile-mode",
+			"agent_id": "provider-agent",
+			"model":    "profile-model",
+			"mode":     "profile-mode",
 			"config_options": map[string]string{
 				"profile_only":      "profile",
 				"provider_replaced": "profile-value",
@@ -51,6 +52,26 @@ func TestLoadEffectiveSessionRuntimeConfigMergesInPrecedenceOrder(t *testing.T) 
 		"provider_only":     "provider",
 		"override_only":     "override",
 	}, got.ConfigOptions)
+}
+
+func TestLoadEffectiveSessionRuntimeConfigPreservesProviderAgentOption(t *testing.T) {
+	session := &TaskSession{
+		AgentProfileSnapshot: map[string]interface{}{
+			"agent_id": "claude",
+			"config_options": map[string]string{
+				"agent": "build",
+			},
+		},
+		Metadata: map[string]interface{}{
+			SessionMetaKeyRuntimeConfig: SessionRuntimeConfig{
+				ConfigOptions: map[string]string{"agent": "build"},
+			},
+		},
+	}
+
+	got, ok := LoadEffectiveSessionRuntimeConfig(session)
+	require.True(t, ok)
+	require.Equal(t, map[string]string{"agent": "build"}, got.ConfigOptions)
 }
 
 func TestLoadEffectiveSessionRuntimeConfigReturnsIndependentOptions(t *testing.T) {

--- a/apps/backend/internal/task/models/session_runtime_config_test.go
+++ b/apps/backend/internal/task/models/session_runtime_config_test.go
@@ -23,6 +23,7 @@ func TestLoadEffectiveSessionRuntimeConfigMergesInPrecedenceOrder(t *testing.T) 
 				ConfigOptions: map[string]string{
 					"model":             "provider-model",
 					"mode":              "provider-mode",
+					"agent":             "provider-agent",
 					"provider_replaced": "provider-value",
 					"provider_only":     "provider",
 				},

--- a/apps/web/components/task/model-selector.test.ts
+++ b/apps/web/components/task/model-selector.test.ts
@@ -281,6 +281,23 @@ describe("hasCompleteDynamicConfig", () => {
     expect(hydrated).toBe(false);
   });
 
+  it("treats the reserved agent identity key as satisfied without an ACP option", () => {
+    const session = makeSession({
+      metadata: {
+        runtime_config: { config_options: { agent: "claude", model: flatModelId } },
+      },
+    });
+    expect(requiredConfigKeys(session, noAgents)).toEqual(["agent", "model"]);
+
+    const hydrated = hasCompleteDynamicConfig(
+      session,
+      { currentModelId: flatModelId, models: flatModelEntries(), configOptions: [] },
+      noAgents,
+    );
+
+    expect(hydrated).toBe(true);
+  });
+
   it("is hydrated when there are no required config keys", () => {
     expect(hasCompleteDynamicConfig(makeSession(), undefined, noAgents)).toBe(true);
   });

--- a/apps/web/components/task/model-selector.test.ts
+++ b/apps/web/components/task/model-selector.test.ts
@@ -281,11 +281,12 @@ describe("hasCompleteDynamicConfig", () => {
     expect(hydrated).toBe(false);
   });
 
-  it("treats the reserved agent identity key as satisfied without an ACP option", () => {
+  it("treats a legacy agent identity key as satisfied without an ACP option", () => {
     const session = makeSession({
       metadata: {
         runtime_config: { config_options: { agent: "claude", model: flatModelId } },
       },
+      agent_profile_snapshot: { agent_id: "claude" },
     });
     expect(requiredConfigKeys(session, noAgents)).toEqual(["agent", "model"]);
 
@@ -296,6 +297,23 @@ describe("hasCompleteDynamicConfig", () => {
     );
 
     expect(hydrated).toBe(true);
+  });
+
+  it("keeps a provider-defined agent option required", () => {
+    const session = makeSession({
+      metadata: {
+        runtime_config: { config_options: { agent: "build", model: flatModelId } },
+      },
+      agent_profile_snapshot: { agent_id: "claude" },
+    });
+
+    const hydrated = hasCompleteDynamicConfig(
+      session,
+      { currentModelId: flatModelId, models: flatModelEntries(), configOptions: [] },
+      noAgents,
+    );
+
+    expect(hydrated).toBe(false);
   });
 
   it("is hydrated when there are no required config keys", () => {

--- a/apps/web/components/task/model-selector.tsx
+++ b/apps/web/components/task/model-selector.tsx
@@ -46,13 +46,48 @@ function configValueKeys(value: unknown): string[] {
     .map(([key]) => key);
 }
 
+function recordValue(value: unknown, key: string): unknown {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  return (value as Record<string, unknown>)[key];
+}
+
+function configValue(value: unknown, key: string): string | undefined {
+  const candidate = recordValue(value, key);
+  return typeof candidate === "string" && candidate ? candidate : undefined;
+}
+
 const MODEL_CONFIG_KEY = "model";
-// "agent" is a reserved identity key (which agent runs the session), enforced at
-// the shared backend boundary alongside model/mode (profileconfig.SanitizeConfigOptions
-// and cleanRuntimeConfigOptions strip it). It is never a selectable ACP config
-// option, so a residual or legacy "agent" key (e.g. a persisted session snapshot)
-// must not gate the selector.
+// Legacy snapshots used config_options.agent for agent identity. Provider-defined
+// agent options stay valid unless the value matches the session identity.
 const AGENT_CONFIG_KEY = "agent";
+
+function isLegacyAgentIdentityConfig(session: TaskSession | null, agents: Agent[]): boolean {
+  if (!session) return false;
+  const snapshot = session.agent_profile_snapshot;
+  const profile = agents
+    .flatMap((agent) => agent.profiles)
+    .find((item) => item.id === session.agent_profile_id);
+  const identityValues = new Set(
+    [
+      configValue(snapshot, "agent_id"),
+      configValue(snapshot, "agent_name"),
+      profile?.agentId,
+      profile?.agentDisplayName,
+    ].filter((value): value is string => !!value),
+  );
+  if (identityValues.size === 0) return false;
+  const metadata = session.metadata;
+  const optionSources = [
+    snapshot?.config_options,
+    profile?.configOptions,
+    recordValue(recordValue(metadata, "runtime_config"), "config_options"),
+    recordValue(recordValue(metadata, "runtime_config_overrides"), "config_options"),
+  ];
+  return optionSources.some((source) => {
+    const value = configValue(source, AGENT_CONFIG_KEY);
+    return !!value && identityValues.has(value);
+  });
+}
 
 export function requiredConfigKeys(session: TaskSession | null, agents: Agent[]): string[] {
   if (!session) return [];
@@ -89,10 +124,11 @@ export function hasCompleteDynamicConfig(
   // configOptions. Treat that key as satisfied when the session has a flat model
   // list — the selector renders fine from it.
   const hasFlatModelList = !!sessionModelsData.models.length;
+  const hasLegacyAgentIdentity = isLegacyAgentIdentityConfig(session, agents);
   return required.every(
     (key) =>
       available.has(key) ||
-      key === AGENT_CONFIG_KEY ||
+      (key === AGENT_CONFIG_KEY && hasLegacyAgentIdentity) ||
       (key === MODEL_CONFIG_KEY && hasFlatModelList),
   );
 }

--- a/apps/web/components/task/model-selector.tsx
+++ b/apps/web/components/task/model-selector.tsx
@@ -47,10 +47,11 @@ function configValueKeys(value: unknown): string[] {
 }
 
 const MODEL_CONFIG_KEY = "model";
-// "agent" records which agent runs the session — a reserved identity key, never
-// a runtime-selectable ACP config option, so it can never appear in configOptions
-// and must not gate the selector (mirrors the model/mode reserved keys the
-// backend already strips in SanitizeConfigOptions / cleanRuntimeConfigOptions).
+// "agent" is a reserved identity key (which agent runs the session), enforced at
+// the shared backend boundary alongside model/mode (profileconfig.SanitizeConfigOptions
+// and cleanRuntimeConfigOptions strip it). It is never a selectable ACP config
+// option, so a residual or legacy "agent" key (e.g. a persisted session snapshot)
+// must not gate the selector.
 const AGENT_CONFIG_KEY = "agent";
 
 export function requiredConfigKeys(session: TaskSession | null, agents: Agent[]): string[] {

--- a/apps/web/components/task/model-selector.tsx
+++ b/apps/web/components/task/model-selector.tsx
@@ -47,6 +47,11 @@ function configValueKeys(value: unknown): string[] {
 }
 
 const MODEL_CONFIG_KEY = "model";
+// "agent" records which agent runs the session — a reserved identity key, never
+// a runtime-selectable ACP config option, so it can never appear in configOptions
+// and must not gate the selector (mirrors the model/mode reserved keys the
+// backend already strips in SanitizeConfigOptions / cleanRuntimeConfigOptions).
+const AGENT_CONFIG_KEY = "agent";
 
 export function requiredConfigKeys(session: TaskSession | null, agents: Agent[]): string[] {
   if (!session) return [];
@@ -84,7 +89,10 @@ export function hasCompleteDynamicConfig(
   // list — the selector renders fine from it.
   const hasFlatModelList = !!sessionModelsData.models.length;
   return required.every(
-    (key) => available.has(key) || (key === MODEL_CONFIG_KEY && hasFlatModelList),
+    (key) =>
+      available.has(key) ||
+      key === AGENT_CONFIG_KEY ||
+      (key === MODEL_CONFIG_KEY && hasFlatModelList),
   );
 }
 


### PR DESCRIPTION
A session whose recorded config carried the reserved `agent` identity key kept the model selector permanently hidden: the selector's hydration gate (`hasCompleteDynamicConfig`) required every recorded config key to be a live ACP-selectable option, and `agent` (which identifies the agent, not a switchable option) never is. Exempting `agent` in that gate, like the existing `model`/`mode` reserved keys, restores the control while leaving the completeness check intact for real dynamic options.

Task: Restore missing agent model selector in task view.

## Validation

- `cd apps/web && pnpm exec vitest run components/task/model-selector.test.ts`: 20/20 pass, including the new regression test `treats the reserved agent identity key as satisfied without an ACP option`, which fails without the fix (`expected false to be true`) and passes with it.
- `cd apps/web && pnpm run typecheck`: clean (`tsc --noEmit`).
- `eslint` on `model-selector.tsx` and `model-selector.test.ts`: clean.
- `cd apps/web && pnpm run i18n:check`: pass.
- Manually verified in a local dev instance: the agent model selector renders and is functional (model list plus the Effort option) in a task session.

## Possible Improvements

Low risk: a one-key exemption in a pure gate function. Follow-up: centralize the reserved `agent`/`model`/`mode` keys shared by the frontend gate and the backend sanitizers (`SanitizeConfigOptions`, `cleanRuntimeConfigOptions`) so a new reserved key is added in one place.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2715?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->