### PR TITLE
fix(task): persist labels from HTTP task creation (#2732)

### DIFF
--- a/apps/backend/internal/task/handlers/task_http_handlers.go
+++ b/apps/backend/internal/task/handlers/task_http_handlers.go
@@ -763,7 +763,8 @@ type httpCreateTaskRequest struct {
 	ProjectID          string `json:"project_id,omitempty"`
 	// ExternalID is a caller-supplied identity used for create-idempotency
 	// (docs/specs/tasks/external-id-idempotency/spec.md).
-	ExternalID string `json:"external_id,omitempty"`
+	ExternalID string   `json:"external_id,omitempty"`
+	Labels     []string `json:"labels,omitempty"`
 	// Office task-handoffs phase 5 — workspace policy. Optional; same
 	// shape as the MCP create_task_kandev fields.
 	WorkspaceMode         string `json:"workspace_mode,omitempty"`
@@ -796,6 +797,30 @@ var allowedAttachmentTypes = map[string]struct{}{
 	"image":    {},
 	"audio":    {},
 	"resource": {},
+}
+
+func encodeTaskLabels(labels []string) (string, error) {
+	normalized := make([]string, 0, len(labels))
+	seen := make(map[string]struct{}, len(labels))
+	for _, label := range labels {
+		label = strings.TrimSpace(label)
+		if label == "" {
+			continue
+		}
+		if _, ok := seen[label]; ok {
+			continue
+		}
+		seen[label] = struct{}{}
+		normalized = append(normalized, label)
+	}
+	if len(normalized) == 0 {
+		return "", nil
+	}
+	encoded, err := json.Marshal(normalized)
+	if err != nil {
+		return "", err
+	}
+	return string(encoded), nil
 }
 
 func validateAttachments(items []v1.MessageAttachment) error {
@@ -850,6 +875,12 @@ func (h *TaskHandlers) httpCreateTask(c *gin.Context) {
 	var body httpCreateTaskRequest
 	if err := c.ShouldBindJSON(&body); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid payload"})
+		return
+	}
+	labels, err := encodeTaskLabels(body.Labels)
+	if err != nil {
+		h.logger.Error("failed to encode task labels", zap.Error(err))
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to encode task labels"})
 		return
 	}
 	if err := validateAttachments(body.Attachments); err != nil {
@@ -929,6 +960,7 @@ func (h *TaskHandlers) httpCreateTask(c *gin.Context) {
 		BlockedBy:          body.BlockedBy,
 		StartWhenUnblocked: body.StartWhenUnblocked,
 		ProjectID:          body.ProjectID,
+		Labels:             labels,
 		ExternalID:         body.ExternalID,
 	})
 	if err != nil {

--- a/apps/backend/internal/task/handlers/task_http_labels_test.go
+++ b/apps/backend/internal/task/handlers/task_http_labels_test.go
@@ -1,0 +1,174 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kandev/kandev/internal/task/models"
+	taskrepo "github.com/kandev/kandev/internal/task/repository/sqlite"
+	"github.com/kandev/kandev/internal/task/service"
+)
+
+type labelTaskRepository struct {
+	mockRepository
+	mu         sync.Mutex
+	tasks      map[string]*models.Task
+	createCall int
+}
+
+func newLabelTaskRepository() *labelTaskRepository {
+	return &labelTaskRepository{tasks: make(map[string]*models.Task)}
+}
+
+func (r *labelTaskRepository) GetWorkflow(_ context.Context, id string) (*models.Workflow, error) {
+	return &models.Workflow{ID: id, WorkspaceID: "ws-1"}, nil
+}
+
+func (r *labelTaskRepository) CreateTask(_ context.Context, task *models.Task) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	copy := *task
+	r.tasks[task.ID] = &copy
+	r.createCall++
+	return nil
+}
+
+func (r *labelTaskRepository) GetTask(_ context.Context, id string) (*models.Task, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	task, ok := r.tasks[id]
+	if !ok {
+		return nil, taskrepo.ErrTaskNotFound
+	}
+	copy := *task
+	return &copy, nil
+}
+
+func newLabelTaskRouter(t *testing.T, repo *labelTaskRepository) *gin.Engine {
+	t.Helper()
+	log := newTestLogger(t)
+	svc := service.NewService(service.Repos{
+		Workspaces: repo, Tasks: repo, TaskRepos: repo,
+		Workflows: repo, Messages: repo, Turns: repo,
+		Sessions: repo, GitSnapshots: repo, RepoEntities: repo,
+		Executors: repo, Environments: repo, TaskEnvironments: repo,
+		Reviews: repo,
+	}, nil, log, service.RepositoryDiscoveryConfig{})
+	h := &TaskHandlers{service: svc, logger: log}
+	router := gin.New()
+	h.registerHTTP(router)
+	return router
+}
+
+func serveTaskCreate(router http.Handler, body string) *httptest.ResponseRecorder {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/tasks", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestHTTPCreateTaskLabelsPersistsAndRoundTrips(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	repo := newLabelTaskRepository()
+	router := newLabelTaskRouter(t, repo)
+
+	created := serveTaskCreate(router, `{
+		"workspace_id":"ws-1",
+		"workflow_id":"wf-1",
+		"title":"Label task",
+		"labels":[" bug ","triage","bug","  "]
+	}`)
+
+	require.Equal(t, http.StatusOK, created.Code, created.Body.String())
+	var createdBody struct {
+		ID     string `json:"id"`
+		Labels string `json:"labels"`
+	}
+	require.NoError(t, json.Unmarshal(created.Body.Bytes(), &createdBody))
+	assert.Equal(t, `["bug","triage"]`, createdBody.Labels)
+	assert.Equal(t, 1, repo.createCall)
+
+	stored, err := repo.GetTask(context.Background(), createdBody.ID)
+	require.NoError(t, err)
+	assert.Equal(t, `["bug","triage"]`, stored.Labels)
+
+	read := httptest.NewRecorder()
+	readRequest := httptest.NewRequest(http.MethodGet, "/api/v1/tasks/"+createdBody.ID, nil)
+	router.ServeHTTP(read, readRequest)
+
+	require.Equal(t, http.StatusOK, read.Code, read.Body.String())
+	var readBody struct {
+		Labels string `json:"labels"`
+	}
+	require.NoError(t, json.Unmarshal(read.Body.Bytes(), &readBody))
+	assert.Equal(t, `["bug","triage"]`, readBody.Labels)
+}
+
+func TestHTTPCreateTaskLabelsMissingAndEmptyUseDefault(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	tests := []struct {
+		name        string
+		labelsField string
+	}{
+		{name: "missing"},
+		{name: "empty", labelsField: `,"labels":[]`},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := newLabelTaskRepository()
+			router := newLabelTaskRouter(t, repo)
+			body := `{"workspace_id":"ws-1","workflow_id":"wf-1","title":"Default labels"` + tc.labelsField + `}`
+
+			created := serveTaskCreate(router, body)
+
+			require.Equal(t, http.StatusOK, created.Code, created.Body.String())
+			var response struct {
+				ID     string `json:"id"`
+				Labels string `json:"labels"`
+			}
+			require.NoError(t, json.Unmarshal(created.Body.Bytes(), &response))
+			assert.Equal(t, `[]`, response.Labels)
+			assert.Equal(t, 1, repo.createCall)
+
+			stored, err := repo.GetTask(context.Background(), response.ID)
+			require.NoError(t, err)
+			assert.Equal(t, `[]`, stored.Labels)
+		})
+	}
+}
+
+func TestHTTPCreateTaskLabelsRejectsInvalidShapes(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	tests := []struct {
+		name        string
+		labelsField string
+	}{
+		{name: "scalar", labelsField: `,"labels":"bug"`},
+		{name: "mixed array", labelsField: `,"labels":["bug",7]`},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := newLabelTaskRepository()
+			router := newLabelTaskRouter(t, repo)
+			body := `{"workspace_id":"ws-1","workflow_id":"wf-1","title":"Invalid labels"` + tc.labelsField + `}`
+
+			created := serveTaskCreate(router, body)
+
+			assert.Equal(t, http.StatusBadRequest, created.Code, created.Body.String())
+			assert.Equal(t, 0, repo.createCall)
+			assert.Empty(t, repo.tasks)
+		})
+	}
+}


### PR DESCRIPTION
Task creation requests could include labels, but the HTTP decoder ignored the unknown field and
stored empty labels. The endpoint now accepts and normalizes label arrays, preserves them through
creation and reads, and rejects malformed shapes.

## Validation

- `cd apps/backend && go test ./internal/task/handlers -run 'TestHTTPCreateTaskLabels'`
- `cd apps/backend && go test ./internal/task/handlers`
- `make -C apps/backend test`
- Backend commit hooks passed, including gofmt, changed-code Go lint, and commitlint.

Closes #2732

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2744?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->