### PR TITLE
fix(web): use canonical task priority type (#2733)

### DIFF
--- a/apps/web/app/office/components/new-task-bottom-bar.test.ts
+++ b/apps/web/app/office/components/new-task-bottom-bar.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import type { PriorityMeta } from "@/lib/state/slices/office/types";
+import { buildPriorityOptions } from "./new-task-bottom-bar";
+
+function makePriorityMeta(id: string, order: number): PriorityMeta {
+  return { id, label: id, order, color: "", value: order };
+}
+
+describe("buildPriorityOptions", () => {
+  it("accepts canonical priorities and rejects non-task metadata", () => {
+    const priorities = ["critical", "high", "medium", "low", "none", "custom"].map((id, order) =>
+      makePriorityMeta(id, order),
+    );
+
+    expect(buildPriorityOptions(priorities, (key) => key).map((option) => option.value)).toEqual([
+      "critical",
+      "high",
+      "medium",
+      "low",
+    ]);
+  });
+
+  it("uses all canonical priorities when metadata is absent", () => {
+    expect(buildPriorityOptions(undefined, (key) => key).map((option) => option.value)).toEqual([
+      "critical",
+      "high",
+      "medium",
+      "low",
+    ]);
+  });
+});

--- a/apps/web/app/office/components/new-task-bottom-bar.tsx
+++ b/apps/web/app/office/components/new-task-bottom-bar.tsx
@@ -13,12 +13,21 @@ import { Button } from "@kandev/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@kandev/ui/popover";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
 import { useAppStore } from "@/components/state-provider";
+import type { TaskPriority } from "@/lib/types/http";
+import type { PriorityMeta } from "@/lib/state/slices/office/types";
 import type { IssueDraft } from "./new-task-draft";
 import { PRIORITY_LABEL_KEYS, STATUS_LABEL_KEYS } from "../lib/label-keys";
 import { useTranslation } from "react-i18next";
 
 type StatusOption = { value: string; label: string; className: string };
-type PriorityOption = { value: string; label: string; icon: typeof IconMinus; className: string };
+type PriorityOption = {
+  value: TaskPriority;
+  label: string;
+  icon: typeof IconMinus;
+  className: string;
+};
+
+type FallbackPriorityOption = Omit<PriorityOption, "label"> & { labelKey: string };
 
 // The fallback tables carry `labelKey`, not `label`: they are module scope, so a
 // `t()` here would resolve once at import and freeze at the boot locale. The
@@ -45,7 +54,7 @@ const PRIORITY_ICONS: Record<string, typeof IconMinus> = {
   low: IconArrowDown,
 };
 
-const FALLBACK_PRIORITY_OPTIONS = [
+const FALLBACK_PRIORITY_OPTIONS: FallbackPriorityOption[] = [
   {
     value: "critical",
     labelKey: PRIORITY_LABEL_KEYS.critical,
@@ -71,6 +80,14 @@ const FALLBACK_PRIORITY_OPTIONS = [
     className: "text-blue-600",
   },
 ];
+
+function isTaskPriority(value: string): value is TaskPriority {
+  return value === "critical" || value === "high" || value === "medium" || value === "low";
+}
+
+function isTaskPriorityMeta(value: PriorityMeta): value is PriorityMeta & { id: TaskPriority } {
+  return isTaskPriority(value.id);
+}
 
 type Props = {
   draft: IssueDraft;
@@ -136,14 +153,12 @@ function usePriorityOptions(): PriorityOption[] {
   }
   // Exclude "none" from the creation picker. Labels come from the workspace's
   // own priority metadata, so they travel as-is.
-  return meta.priorities
-    .filter((p) => p.id !== "none")
-    .map((p) => ({
-      value: p.id,
-      label: p.label,
-      icon: PRIORITY_ICONS[p.id] ?? IconMinus,
-      className: p.color,
-    }));
+  return meta.priorities.filter(isTaskPriorityMeta).map((p) => ({
+    value: p.id,
+    label: p.label,
+    icon: PRIORITY_ICONS[p.id] ?? IconMinus,
+    className: p.color,
+  }));
 }
 
 function PriorityChip({ draft, onUpdate }: Props) {

--- a/apps/web/app/office/components/new-task-bottom-bar.tsx
+++ b/apps/web/app/office/components/new-task-bottom-bar.tsx
@@ -89,6 +89,29 @@ function isTaskPriorityMeta(value: PriorityMeta): value is PriorityMeta & { id: 
   return isTaskPriority(value.id);
 }
 
+export function buildPriorityOptions(
+  priorities: PriorityMeta[] | null | undefined,
+  translate: (key: string) => string,
+): PriorityOption[] {
+  if (!priorities) {
+    return FALLBACK_PRIORITY_OPTIONS.map((o) => ({
+      value: o.value,
+      label: translate(o.labelKey),
+      icon: o.icon,
+      className: o.className,
+    }));
+  }
+
+  // Exclude "none" from the creation picker. Labels come from the workspace's
+  // own priority metadata, so they travel as-is.
+  return priorities.filter(isTaskPriorityMeta).map((p) => ({
+    value: p.id,
+    label: p.label,
+    icon: PRIORITY_ICONS[p.id] ?? IconMinus,
+    className: p.color,
+  }));
+}
+
 type Props = {
   draft: IssueDraft;
   onUpdate: (patch: Partial<IssueDraft>) => void;
@@ -143,22 +166,7 @@ function StatusChip({ draft, onUpdate }: Props) {
 function usePriorityOptions(): PriorityOption[] {
   const { t } = useTranslation();
   const meta = useAppStore((s) => s.office.meta);
-  if (!meta) {
-    return FALLBACK_PRIORITY_OPTIONS.map((o) => ({
-      value: o.value,
-      label: t(o.labelKey),
-      icon: o.icon,
-      className: o.className,
-    }));
-  }
-  // Exclude "none" from the creation picker. Labels come from the workspace's
-  // own priority metadata, so they travel as-is.
-  return meta.priorities.filter(isTaskPriorityMeta).map((p) => ({
-    value: p.id,
-    label: p.label,
-    icon: PRIORITY_ICONS[p.id] ?? IconMinus,
-    className: p.color,
-  }));
+  return buildPriorityOptions(meta?.priorities, t);
 }
 
 function PriorityChip({ draft, onUpdate }: Props) {

--- a/apps/web/app/office/components/new-task-draft.ts
+++ b/apps/web/app/office/components/new-task-draft.ts
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback, useRef } from "react";
 import { clampTaskTitleInput } from "@/lib/task-title";
+import type { TaskPriority } from "@/lib/types/http";
 
 export type IssueDraft = {
   title: string;
@@ -9,7 +10,7 @@ export type IssueDraft = {
   assigneeId: string;
   projectId: string;
   status: string;
-  priority: string;
+  priority: TaskPriority;
   showReviewer: boolean;
   showApprover: boolean;
   reviewerIds: string[];

--- a/apps/web/app/office/tasks/[id]/types.ts
+++ b/apps/web/app/office/tasks/[id]/types.ts
@@ -1,3 +1,6 @@
+import type { TaskPriority } from "@/lib/types/http";
+export type { TaskPriority } from "@/lib/types/http";
+
 /**
  * Local task types for office task detail.
  * These will be replaced by backend-generated types once Wave 3A lands.
@@ -11,8 +14,6 @@ export type TaskStatus =
   | "done"
   | "cancelled"
   | "blocked";
-
-export type TaskPriority = "critical" | "high" | "medium" | "low";
 
 export type TaskRunStatus = "queued" | "claimed" | "finished" | "failed" | "cancelled";
 

--- a/apps/web/app/tasks/rich-task-row-details.test.ts
+++ b/apps/web/app/tasks/rich-task-row-details.test.ts
@@ -12,7 +12,7 @@ function task(overrides: Partial<Task>): Task {
     title: "Child task",
     description: "",
     state: "TODO",
-    priority: 0,
+    priority: "medium",
     created_at: "2026-07-25T00:00:00Z",
     updated_at: "2026-07-25T00:00:00Z",
     ...overrides,

--- a/apps/web/components/kanban-card.tsx
+++ b/apps/web/components/kanban-card.tsx
@@ -32,6 +32,7 @@ import {
   type ForegroundActivity,
   type Repository,
   type TaskPendingAction,
+  type TaskPriority,
   type TaskState,
 } from "@/lib/types/http";
 import type { PluginTaskMenuContext } from "@/lib/plugins/types";
@@ -44,7 +45,7 @@ export interface Task {
   title: string;
   workflowStepId: string;
   state?: TaskState;
-  priority?: string | number;
+  priority?: TaskPriority;
   description?: string;
   position?: number;
   repositoryId?: string;

--- a/apps/web/components/task/chat/messages/chat-message.test.tsx
+++ b/apps/web/components/task/chat/messages/chat-message.test.tsx
@@ -85,7 +85,7 @@ function wrapper(tasks: Array<{ id: string; title: string }> = [], prompts: Cust
               id: t.id,
               title: t.title,
               workflow_step_id: "",
-              priority: 0,
+              priority: "medium",
               parent_id: undefined,
             })),
           } as unknown as never,

--- a/apps/web/components/task/task-page-content-helpers.test.ts
+++ b/apps/web/components/task/task-page-content-helpers.test.ts
@@ -9,6 +9,7 @@ import type { KanbanState } from "@/lib/state/slices";
 import {
   buildArchivedValue,
   buildDebugEntries,
+  buildTaskFromKanban,
   hasResolvedTaskDetails,
   resolveEffectiveTask,
   resolveTaskContentState,
@@ -290,6 +291,12 @@ describe("syncActiveTaskSession", () => {
 });
 
 describe("resolveEffectiveTask archived state", () => {
+  it("preserves a non-default priority for kanban-only tasks", () => {
+    const resolved = buildTaskFromKanban(makeKanbanTask({ priority: "high" }));
+
+    expect(resolved.priority).toBe("high");
+  });
+
   it("builds a kanban-only task with its metadata", () => {
     const metadata = { port_forwarding_enabled: true };
     const resolved = resolveEffectiveTask(null, null, makeKanbanTask({ metadata }), "task-1");

--- a/apps/web/components/task/task-page-content-helpers.test.ts
+++ b/apps/web/components/task/task-page-content-helpers.test.ts
@@ -29,7 +29,7 @@ function makeArchivedTaskDetails(overrides: Partial<Task> = {}): Task {
     state: "TODO",
     workspace_id: "ws-1",
     workflow_id: "wf-1",
-    priority: 0,
+    priority: "medium",
     repositories: [],
     created_at: "",
     updated_at: ARCHIVED_AT,

--- a/apps/web/components/task/task-page-content-helpers.ts
+++ b/apps/web/components/task/task-page-content-helpers.ts
@@ -155,7 +155,7 @@ export function buildTaskFromKanban(kanbanTask: KanbanState["tasks"][number]): T
     state: kanbanTask.state ?? "CREATED",
     workspace_id: toWorkspaceId(""),
     workflow_id: toWorkflowId(""),
-    priority: 0,
+    priority: "medium",
     repositories: [],
     created_at: "",
     updated_at: kanbanTask.updatedAt ?? "",

--- a/apps/web/components/task/task-page-content-helpers.ts
+++ b/apps/web/components/task/task-page-content-helpers.ts
@@ -155,7 +155,7 @@ export function buildTaskFromKanban(kanbanTask: KanbanState["tasks"][number]): T
     state: kanbanTask.state ?? "CREATED",
     workspace_id: toWorkspaceId(""),
     workflow_id: toWorkflowId(""),
-    priority: "medium",
+    priority: kanbanTask.priority ?? "medium",
     repositories: [],
     created_at: "",
     updated_at: kanbanTask.updatedAt ?? "",

--- a/apps/web/lib/api/domains/kanban-api.ts
+++ b/apps/web/lib/api/domains/kanban-api.ts
@@ -8,6 +8,7 @@ import type {
   AttachTaskWorkspaceSourcesRequest,
   AttachTaskWorkspaceSourcesResponse,
   Task,
+  TaskPriority,
   MoveTaskResponse,
 } from "@/lib/types/http";
 
@@ -109,7 +110,7 @@ export async function createTask(
     /** Explicitly opt out of (false) or into (true) the auto-start-on-unblock intent. */
     start_when_unblocked?: boolean;
     workspace_path?: string;
-    priority?: string;
+    priority?: TaskPriority;
     project_id?: string;
     metadata?: Record<string, unknown>;
     /** Office task-handoffs phase 4/5 — workspace policy. */

--- a/apps/web/lib/kanban/map-task.test.ts
+++ b/apps/web/lib/kanban/map-task.test.ts
@@ -15,7 +15,7 @@ const BASE_SCALARS = {
   description: "Do it well",
   position: 3,
   state: "TODO" as const,
-  priority: 0,
+  priority: "critical",
   is_ephemeral: false,
   created_at: "2026-04-22T10:00:00Z",
   updated_at: "2026-04-22T10:05:00Z",
@@ -264,5 +264,12 @@ describe("toKanbanTask — state normalization", () => {
 
     expect(detached.parentTaskId).toBeUndefined();
     expect(detached.workspaceMode).toBe("shared_group");
+  });
+});
+
+describe("toKanbanTask priority", () => {
+  it("preserves the canonical priority from HTTP and WebSocket payloads", () => {
+    expect(toKanbanTask(httpDTO()).priority).toBe("critical");
+    expect(toKanbanTask(wsPayload()).priority).toBe("critical");
   });
 });

--- a/apps/web/lib/kanban/map-task.ts
+++ b/apps/web/lib/kanban/map-task.ts
@@ -7,6 +7,7 @@ import type { KanbanState, TaskDependencyRef } from "@/lib/state/slices/kanban/t
 import type {
   ForegroundActivity,
   TaskPendingAction,
+  TaskPriority,
   TaskState,
   TaskSessionState,
 } from "@/lib/types/http";
@@ -34,7 +35,7 @@ export type TaskLike = {
   autopilot?: boolean;
   position?: number;
   state?: TaskState;
-  priority?: string | number;
+  priority?: TaskPriority;
   repositories?: Array<{
     id?: string;
     repository_id: string;

--- a/apps/web/lib/kanban/wip-queue.test.ts
+++ b/apps/web/lib/kanban/wip-queue.test.ts
@@ -84,6 +84,22 @@ describe("wip queue helper", () => {
     ]);
   });
 
+  it("sorts every canonical priority in backend order", () => {
+    const tasks = [
+      task({ id: "low", priority: "low" }),
+      task({ id: "medium", priority: "medium" }),
+      task({ id: "high", priority: "high" }),
+      task({ id: "critical", priority: "critical" }),
+    ];
+
+    expect(getDestinationQueue(tasks, "review").map((entry) => entry.task.id)).toEqual([
+      "critical",
+      "high",
+      "medium",
+      "low",
+    ]);
+  });
+
   it("orders missing timestamps deterministically without producing NaN", () => {
     const left = task({ id: "left", queuedAt: null, createdAt: null });
     const right = task({ id: "right", queuedAt: "not-a-date", createdAt: "not-a-date" });

--- a/apps/web/lib/kanban/wip-queue.ts
+++ b/apps/web/lib/kanban/wip-queue.ts
@@ -1,10 +1,12 @@
+import type { TaskPriority } from "@/lib/types/http";
+
 export type WipQueueTask = {
   id: string;
   workflowStepId: string;
   queuedForStepId?: string | null;
   wipAdmitted?: boolean | null;
   position?: number | null;
-  priority?: string | number | null;
+  priority?: TaskPriority | null;
   queuedAt?: string | null;
   createdAt?: string | null;
 };
@@ -22,7 +24,6 @@ export type WipQueueStatus = {
 };
 
 function priorityRank(priority: WipQueueTask["priority"]): number {
-  if (typeof priority === "number" && Number.isFinite(priority)) return priority;
   switch (priority) {
     case "critical":
       return 0;

--- a/apps/web/lib/services/session-launch-helpers.test.ts
+++ b/apps/web/lib/services/session-launch-helpers.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { buildStartRequest } from "./session-launch-helpers";
+
+describe("buildStartRequest", () => {
+  it("serializes a canonical task priority string", () => {
+    const { request } = buildStartRequest("task-1", "agent-1", {
+      priority: "critical",
+    });
+
+    expect(request.priority).toBe("critical");
+  });
+});

--- a/apps/web/lib/services/session-launch-helpers.ts
+++ b/apps/web/lib/services/session-launch-helpers.ts
@@ -1,4 +1,5 @@
 import type { LaunchSessionRequest, MessageAttachment } from "./session-launch-service";
+import type { TaskPriority } from "@/lib/types/http";
 
 export type LayoutIntentHint = "default" | "plan" | "pr-review" | "keep";
 
@@ -15,7 +16,7 @@ export function buildStartRequest(
     executorProfileId?: string;
     prompt?: string;
     planMode?: boolean;
-    priority?: number;
+    priority?: TaskPriority;
     autoStart?: boolean;
     attachments?: MessageAttachment[];
   },

--- a/apps/web/lib/services/session-launch-service.ts
+++ b/apps/web/lib/services/session-launch-service.ts
@@ -1,4 +1,5 @@
 import { getWebSocketClient } from "@/lib/ws/connection";
+import type { TaskPriority } from "@/lib/types/http";
 
 export type SessionIntent =
   | "prepare"
@@ -28,7 +29,7 @@ export type LaunchSessionRequest = {
   prompt?: string;
   plan_mode?: boolean;
   workflow_step_id?: string;
-  priority?: number;
+  priority?: TaskPriority;
   launch_workspace?: boolean;
   skip_message_record?: boolean;
   auto_start?: boolean;

--- a/apps/web/lib/ssr/mapper.test.ts
+++ b/apps/web/lib/ssr/mapper.test.ts
@@ -37,7 +37,7 @@ function snapshotWithPendingAction(action: unknown): WorkflowSnapshot {
         title: "Task",
         description: "",
         state: "TODO",
-        priority: 0,
+        priority: "medium",
         primary_session_pending_action: action,
         created_at: now,
         updated_at: now,

--- a/apps/web/lib/ssr/session-page-state.test.ts
+++ b/apps/web/lib/ssr/session-page-state.test.ts
@@ -58,7 +58,7 @@ function makeTask(overrides: Partial<Task> = {}): Task {
     title: "Office task",
     description: "",
     state: "TODO",
-    priority: 0,
+    priority: "medium",
     created_at: NOW,
     updated_at: NOW,
     ...overrides,

--- a/apps/web/lib/state/slices/kanban/types.ts
+++ b/apps/web/lib/state/slices/kanban/types.ts
@@ -1,6 +1,7 @@
 import type {
   ForegroundActivity,
   TaskPendingAction,
+  TaskPriority,
   TaskState as TaskStatus,
 } from "@/lib/types/http";
 import type { TaskStatusSummary } from "@/lib/types/task-status-summary";
@@ -70,7 +71,7 @@ export type KanbanState = {
     title: string;
     description?: string;
     autopilot?: boolean;
-    priority?: string | number;
+    priority?: TaskPriority;
     position: number;
     state?: TaskStatus;
     /** Primary repository id (lowest position). Kept for backwards compat. */

--- a/apps/web/lib/types/backend.ts
+++ b/apps/web/lib/types/backend.ts
@@ -19,6 +19,7 @@ import type {
   AvailableAgent,
   ForegroundActivity,
   TaskPendingAction,
+  TaskPriority,
   TaskSessionState,
   StepEvents,
   TaskState,
@@ -80,7 +81,7 @@ export type TaskEventPayload = {
   title: string;
   description?: string;
   state?: TaskState;
-  priority?: number;
+  priority?: TaskPriority;
   wip_admitted?: boolean;
   queued_for_step_id?: string | null;
   queued_at?: string | null;

--- a/apps/web/lib/types/http.test.ts
+++ b/apps/web/lib/types/http.test.ts
@@ -68,19 +68,11 @@ function task(overrides: Partial<Task>): Task {
   };
 }
 
-describe("TaskPriority", () => {
-  it("accepts the canonical wire values", () => {
-    const priorities: TaskPriority[] = ["critical", "high", "medium", "low"];
+expectTypeOf<TaskPriority>().toEqualTypeOf<"critical" | "high" | "medium" | "low">();
 
-    expect(priorities).toEqual(["critical", "high", "medium", "low"]);
-  });
-
-  expectTypeOf<TaskPriority>().toEqualTypeOf<"critical" | "high" | "medium" | "low">();
-
-  // @ts-expect-error Numeric task priorities are no longer part of the wire contract.
-  const numericPriority: TaskPriority = 0;
-  void numericPriority;
-});
+// @ts-expect-error Numeric task priorities are no longer part of the wire contract.
+const numericPriority: TaskPriority = 0;
+void numericPriority;
 
 describe("isFromOffice", () => {
   it("is false for null/undefined", () => {

--- a/apps/web/lib/types/http.test.ts
+++ b/apps/web/lib/types/http.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, expectTypeOf } from "vitest";
 import {
   isFromOffice,
   primaryTaskRepository,
@@ -7,6 +7,7 @@ import {
   workflowId as toWorkflowId,
   workspaceId as toWorkspaceId,
   type Task,
+  type TaskPriority,
   type TaskRepository,
 } from "./http";
 
@@ -60,12 +61,26 @@ function task(overrides: Partial<Task>): Task {
     title: "t",
     description: "",
     state: "TODO",
-    priority: 0,
+    priority: "medium",
     created_at: new Date().toISOString(),
     updated_at: new Date().toISOString(),
     ...overrides,
   };
 }
+
+describe("TaskPriority", () => {
+  it("accepts the canonical wire values", () => {
+    const priorities: TaskPriority[] = ["critical", "high", "medium", "low"];
+
+    expect(priorities).toEqual(["critical", "high", "medium", "low"]);
+  });
+
+  expectTypeOf<TaskPriority>().toEqualTypeOf<"critical" | "high" | "medium" | "low">();
+
+  // @ts-expect-error Numeric task priorities are no longer part of the wire contract.
+  const numericPriority: TaskPriority = 0;
+  void numericPriority;
+});
 
 describe("isFromOffice", () => {
   it("is false for null/undefined", () => {

--- a/apps/web/lib/types/http.ts
+++ b/apps/web/lib/types/http.ts
@@ -73,6 +73,8 @@ export type TaskState =
   | "FAILED"
   | "CANCELLED";
 
+export type TaskPriority = "critical" | "high" | "medium" | "low";
+
 // Workflow Review Status
 export type WorkflowReviewStatus = "pending" | "approved" | "changes_requested" | "rejected";
 
@@ -334,7 +336,7 @@ export type Task = ActiveSubagentCountFields & {
   /** True when the task was created in autopilot mode. Immutable after creation. */
   autopilot?: boolean;
   state: TaskState;
-  priority: number;
+  priority: TaskPriority;
   wip_admitted?: boolean;
   queued_for_step_id?: string;
   queued_at?: string | null;

--- a/apps/web/src/task-detail-route.test.tsx
+++ b/apps/web/src/task-detail-route.test.tsx
@@ -52,7 +52,7 @@ function makeFetchedData(): FetchedSessionData {
       workflow_id: workflowId("workflow-1"),
       workflow_step_id: "step-1",
       state: "CREATED",
-      priority: 0,
+      priority: "medium",
       position: 0,
       repositories: [],
       created_at: "2026-06-16T00:00:00Z",


### PR DESCRIPTION
Correct the web task contract to use the backend's canonical priority vocabulary, so REST, WebSocket, Kanban, creation, and session-launch consumers remain type-safe and consistent.

## Validation

- `cd apps && pnpm --filter @kandev/web test -- lib/types/http.test.ts lib/kanban/map-task.test.ts lib/kanban/wip-queue.test.ts lib/services/session-launch-helpers.test.ts`
- `cd apps/web && pnpm run typecheck`
- Targeted ESLint on all changed web files
- Pre-commit hooks, including Conventional Commits validation
- `git diff --check`

Closes #2733

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
- [ ] I checked whether this affects public docs in `docs/public/**` and updated them or noted why no docs change is needed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2745?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->