### PR TITLE
fix(workflow): clear resume token when reset_agent_context fires without live execution

### DIFF
--- a/apps/backend/internal/agent/runtime/lifecycle/manager_execution.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_execution.go
@@ -348,6 +348,24 @@ func (m *Manager) GetExecutionIDForSession(_ context.Context, sessionID string) 
 	return "", fmt.Errorf("%w: %s", ErrNoExecutionForSession, sessionID)
 }
 
+// GetACPSessionIDForSession returns the ACP conversation currently owned by a
+// live execution. The orchestrator uses this optional accessor after a context
+// reset to persist the new conversation immediately, instead of depending on
+// an asynchronous session-created event arriving before a backend restart.
+func (m *Manager) GetACPSessionIDForSession(sessionID string) (string, bool) {
+	execution, exists := m.executionStore.GetBySessionID(sessionID)
+	if !exists || execution == nil {
+		return "", false
+	}
+	var acpSessionID string
+	if err := m.executionStore.WithRLock(execution.ID, func(exec *AgentExecution) {
+		acpSessionID = exec.ACPSessionID
+	}); err != nil || acpSessionID == "" {
+		return "", false
+	}
+	return acpSessionID, true
+}
+
 // IsAgentCommandConfigured reports whether an execution has been promoted from
 // workspace-only infrastructure to an agent execution ready to start.
 func (m *Manager) IsAgentCommandConfigured(executionID string) bool {

--- a/apps/backend/internal/orchestrator/event_handlers.go
+++ b/apps/backend/internal/orchestrator/event_handlers.go
@@ -61,6 +61,22 @@ func (s *Service) handleACPSessionCreated(ctx context.Context, data watcher.ACPS
 // session/load vs session/new in session.go — agents without native resume (e.g.,
 // Claude Code) use the token for their own --resume CLI flag instead.
 func (s *Service) storeResumeToken(ctx context.Context, taskID, sessionID, expectedExecID, acpSessionID, lastMessageUUID string) {
+	// The lifecycle manager updates its in-memory ACP session ID before it
+	// publishes reset/start events. Events from the previous ACP session can
+	// still be queued after that point, so reject those events before the
+	// execution-level CAS. The execution ID alone does not identify an ACP
+	// session generation because context resets keep the same execution.
+	if currentACPSessionID := s.currentACPSessionID(sessionID); currentACPSessionID != "" &&
+		acpSessionID != "" && acpSessionID != currentACPSessionID {
+		s.logger.Info("dropping resume token from stale ACP session generation",
+			zap.String("task_id", taskID),
+			zap.String("session_id", sessionID),
+			zap.String("expected_exec_id", expectedExecID),
+			zap.String("resume_token", acpSessionID),
+			zap.String("current_resume_token", currentACPSessionID))
+		return
+	}
+
 	err := s.repo.UpdateResumeToken(ctx, sessionID, expectedExecID, acpSessionID, lastMessageUUID)
 	switch {
 	case err == nil:
@@ -102,6 +118,23 @@ func (s *Service) storeResumeToken(ctx context.Context, taskID, sessionID, expec
 			zap.String("session_id", sessionID),
 			zap.Error(err))
 	}
+}
+
+// currentACPSessionID returns the lifecycle manager's current ACP session ID
+// when the concrete manager exposes it. The optional seam keeps the generic
+// AgentManagerClient contract unchanged for remote clients and test doubles.
+func (s *Service) currentACPSessionID(sessionID string) string {
+	provider, ok := s.agentManager.(interface {
+		GetACPSessionIDForSession(string) (string, bool)
+	})
+	if !ok {
+		return ""
+	}
+	acpSessionID, ok := provider.GetACPSessionIDForSession(sessionID)
+	if !ok {
+		return ""
+	}
+	return acpSessionID
 }
 
 // persistACPSessionID mirrors the agent's ACP session id into the session's

--- a/apps/backend/internal/orchestrator/event_handlers_agent.go
+++ b/apps/backend/internal/orchestrator/event_handlers_agent.go
@@ -1466,20 +1466,24 @@ func (s *Service) wasResumeAttempt(ctx context.Context, sessionID string) bool {
 }
 
 // clearResumeToken removes the resume token from the executor running record so
-// the next agent start won't use --resume. It is reserved for explicit
-// user-initiated fresh-start recovery; ordinary ACP startup failures retain the
-// token so the session can be retried.
+// the next agent start won't use --resume. Callers use this for explicit fresh
+// starts and after a successful context reset; ordinary ACP startup failures
+// retain the token so the session can be retried.
 //
 // Unconditional clear: passes expectedExecID="" so the narrow update is not
 // CAS-guarded — clearing a token is always intentional regardless of which
 // execution is currently registered.
-func (s *Service) clearResumeToken(ctx context.Context, sessionID string) {
+func (s *Service) clearResumeToken(ctx context.Context, sessionID string) error {
 	err := s.repo.UpdateResumeToken(ctx, sessionID, "", "", "")
-	if err != nil && !errors.Is(err, models.ErrExecutorRunningNotFound) {
+	if errors.Is(err, models.ErrExecutorRunningNotFound) {
+		return nil
+	}
+	if err != nil {
 		s.logger.Error("failed to clear resume token",
 			zap.String("session_id", sessionID),
 			zap.Error(err))
 	}
+	return err
 }
 
 // handleRecoverableFailure handles agent failures by keeping the session recoverable.

--- a/apps/backend/internal/orchestrator/event_handlers_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_test.go
@@ -322,6 +322,8 @@ type mockAgentManager struct {
 	repoForExecutionLookup interface {
 		GetExecutorRunningBySessionID(ctx context.Context, sessionID string) (*models.ExecutorRunning, error)
 	}
+	// Optional current ACP session lookup used by reset-token generation tests.
+	getACPSessionIDForSessionFunc func(string) (string, bool)
 
 	// CancelAgent tracking. cancelAgentCalls counts every invocation. If
 	// cancelAgentBlock is non-nil, CancelAgent blocks on it before returning;
@@ -664,6 +666,14 @@ func (m *mockAgentManager) GetExecutionIDForSession(ctx context.Context, session
 	}
 	return "", fmt.Errorf("no execution found")
 }
+
+func (m *mockAgentManager) GetACPSessionIDForSession(sessionID string) (string, bool) {
+	if m.getACPSessionIDForSessionFunc == nil {
+		return "", false
+	}
+	return m.getACPSessionIDForSessionFunc(sessionID)
+}
+
 func (m *mockAgentManager) GetGitLog(ctx context.Context, sessionID, baseCommit string, limit int, targetBranch string) (*client.GitLogResult, error) {
 	if m.getGitLogFunc != nil {
 		return m.getGitLogFunc(ctx, sessionID, baseCommit, limit, targetBranch)

--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -2949,8 +2949,19 @@ func (s *Service) resetAgentContext(ctx context.Context, taskID string, session 
 
 	executionID, err := s.agentManager.GetExecutionIDForSession(ctx, sessionID)
 	if err != nil || executionID == "" {
-		s.logger.Debug("no agent execution for context reset, skipping",
-			zap.String("session_id", sessionID))
+		// No in-memory execution exists yet — most commonly a lazily-resumed
+		// session whose process has not been relaunched since the last run.
+		// The resume path (applyRunningRecordToResumeRequest) reads the ACP
+		// resume token straight from the executors_running row, bypassing any
+		// in-memory execution lookup entirely, so leaving that token in place
+		// here would let the next lazy launch reconnect to the pre-reset
+		// conversation and silently skip the reset. Clear the same persisted
+		// state the live-execution path clears below so the reset survives
+		// until the agent's first turn regardless of when the process starts.
+		s.logger.Debug("no live agent execution for context reset, clearing persisted resume state",
+			zap.String("session_id", sessionID),
+			zap.String("step_name", stepName))
+		s.clearPersistedResetState(ctx, sessionID, session)
 		return true
 	}
 
@@ -2972,12 +2983,25 @@ func (s *Service) resetAgentContext(ctx context.Context, taskID string, session 
 		return false
 	}
 
+	s.clearPersistedResetState(ctx, sessionID, session)
+	return true
+}
+
+// clearPersistedResetState clears the durable, DB-backed session state that a
+// later lazy resume would otherwise pick back up: the stored ACP session ID
+// in session metadata, the resume token on the executors_running row, and the
+// persisted context window. Runs for both the live-execution reset (after the
+// provider session is actually reset) and the no-in-memory-execution path
+// above (where there is nothing live to reset but the persisted state must
+// still be cleared before the next agent turn).
+func (s *Service) clearPersistedResetState(ctx context.Context, sessionID string, session *models.TaskSession) {
 	// Clear the stored ACP session ID using json_set to avoid clobbering other keys.
 	if updateErr := s.repo.SetSessionMetadataKey(ctx, sessionID, "acp_session_id", ""); updateErr != nil {
 		s.logger.Warn("failed to clear ACP session ID from session metadata",
 			zap.String("session_id", sessionID),
 			zap.Error(updateErr))
 	}
+	s.clearResumeToken(ctx, sessionID)
 	if updateErr := s.clearContextWindowForReset(ctx, sessionID); updateErr != nil {
 		s.logger.Warn("failed to clear context window from session metadata",
 			zap.String("session_id", sessionID),
@@ -2988,7 +3012,6 @@ func (s *Service) resetAgentContext(ctx context.Context, taskID string, session 
 	// its cache after the provider reset succeeds and must not receive stale data
 	// back through the final processOnEnter state event.
 	clearInMemoryContextWindow(session)
-	return true
 }
 
 // resolveSessionMCPSupport checks if the agent for a session supports MCP.

--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -2961,6 +2961,7 @@ func (s *Service) resetAgentContext(ctx context.Context, taskID string, session 
 		s.logger.Debug("no live agent execution for context reset, clearing persisted resume state",
 			zap.String("session_id", sessionID),
 			zap.String("step_name", stepName))
+		s.clearResumeToken(ctx, sessionID)
 		s.clearPersistedResetState(ctx, sessionID, session)
 		return true
 	}
@@ -2974,6 +2975,11 @@ func (s *Service) resetAgentContext(ctx context.Context, taskID string, session 
 	s.setSessionResetInProgress(sessionID, true)
 	defer s.setSessionResetInProgress(sessionID, false)
 
+	// Clear the resume token BEFORE the agent reset.  The new ACP session
+	// does not exist yet, so there is nothing for the async session.created
+	// event to write and nothing for clearResumeToken to race with.
+	s.clearResumeToken(ctx, sessionID)
+
 	if err := s.agentManager.ResetAgentContext(ctx, executionID); err != nil {
 		s.logger.Error("failed to reset agent context",
 			zap.String("task_id", taskID),
@@ -2983,6 +2989,11 @@ func (s *Service) resetAgentContext(ctx context.Context, taskID string, session 
 		return false
 	}
 
+	// Clear the remaining persisted state (ACP session metadata, context window)
+	// after the provider reset succeeds.  The resume_token was already cleared
+	// above so this call clears metadata/context only — it does NOT re-clear
+	// the resume token (clearResumeToken was extracted from the helper to avoid
+	// erasing a fresh token written by the async storeResumeToken event).
 	s.clearPersistedResetState(ctx, sessionID, session)
 	return true
 }
@@ -3001,7 +3012,6 @@ func (s *Service) clearPersistedResetState(ctx context.Context, sessionID string
 			zap.String("session_id", sessionID),
 			zap.Error(updateErr))
 	}
-	s.clearResumeToken(ctx, sessionID)
 	if updateErr := s.clearContextWindowForReset(ctx, sessionID); updateErr != nil {
 		s.logger.Warn("failed to clear context window from session metadata",
 			zap.String("session_id", sessionID),

--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -2947,6 +2947,11 @@ func (s *Service) resetAgentContext(ctx context.Context, taskID string, session 
 		return true
 	}
 
+	releaseLifecycleLock := s.acquireSessionLifecycleLock(sessionID)
+	defer releaseLifecycleLock()
+	s.setSessionResetInProgress(sessionID, true)
+	defer s.setSessionResetInProgress(sessionID, false)
+
 	executionID, err := s.agentManager.GetExecutionIDForSession(ctx, sessionID)
 	if err != nil || executionID == "" {
 		// No in-memory execution exists yet — most commonly a lazily-resumed
@@ -2961,7 +2966,14 @@ func (s *Service) resetAgentContext(ctx context.Context, taskID string, session 
 		s.logger.Debug("no live agent execution for context reset, clearing persisted resume state",
 			zap.String("session_id", sessionID),
 			zap.String("step_name", stepName))
-		s.clearResumeToken(ctx, sessionID)
+		if err := s.clearResumeToken(ctx, sessionID); err != nil {
+			s.logger.Error("failed to clear lazy resume token before context reset",
+				zap.String("task_id", taskID),
+				zap.String("session_id", sessionID),
+				zap.String("step_name", stepName),
+				zap.Error(err))
+			return false
+		}
 		s.clearPersistedResetState(ctx, sessionID, session)
 		return true
 	}
@@ -2972,14 +2984,6 @@ func (s *Service) resetAgentContext(ctx context.Context, taskID string, session 
 		zap.String("step_name", stepName),
 		zap.String("agent_execution_id", executionID))
 
-	s.setSessionResetInProgress(sessionID, true)
-	defer s.setSessionResetInProgress(sessionID, false)
-
-	// Clear the resume token BEFORE the agent reset.  The new ACP session
-	// does not exist yet, so there is nothing for the async session.created
-	// event to write and nothing for clearResumeToken to race with.
-	s.clearResumeToken(ctx, sessionID)
-
 	if err := s.agentManager.ResetAgentContext(ctx, executionID); err != nil {
 		s.logger.Error("failed to reset agent context",
 			zap.String("task_id", taskID),
@@ -2989,22 +2993,32 @@ func (s *Service) resetAgentContext(ctx context.Context, taskID string, session 
 		return false
 	}
 
+	// Clear the old resume token only after the provider reset succeeds. This
+	// keeps a valid recovery token when the runtime reset fails. A fresh ACP
+	// session event can race this clear, so persist the lifecycle manager's
+	// current session ID again below after the clear.
+	if err := s.clearResumeToken(ctx, sessionID); err != nil {
+		s.logger.Error("failed to clear resume token after context reset",
+			zap.String("task_id", taskID),
+			zap.String("session_id", sessionID),
+			zap.String("step_name", stepName),
+			zap.Error(err))
+		return false
+	}
+	if acpSessionID := s.currentACPSessionID(sessionID); acpSessionID != "" {
+		s.storeResumeToken(ctx, taskID, sessionID, executionID, acpSessionID, "")
+	}
+
 	// Clear the remaining persisted state (ACP session metadata, context window)
-	// after the provider reset succeeds.  The resume_token was already cleared
-	// above so this call clears metadata/context only — it does NOT re-clear
-	// the resume token (clearResumeToken was extracted from the helper to avoid
-	// erasing a fresh token written by the async storeResumeToken event).
+	// after the provider reset succeeds. The token is handled explicitly above.
 	s.clearPersistedResetState(ctx, sessionID, session)
 	return true
 }
 
 // clearPersistedResetState clears the durable, DB-backed session state that a
 // later lazy resume would otherwise pick back up: the stored ACP session ID
-// in session metadata, the resume token on the executors_running row, and the
-// persisted context window. Runs for both the live-execution reset (after the
-// provider session is actually reset) and the no-in-memory-execution path
-// above (where there is nothing live to reset but the persisted state must
-// still be cleared before the next agent turn).
+// in session metadata and the persisted context window. The resume token is
+// cleared explicitly by resetAgentContext so a reset failure can retain it.
 func (s *Service) clearPersistedResetState(ctx context.Context, sessionID string, session *models.TaskSession) {
 	// Clear the stored ACP session ID using json_set to avoid clobbering other keys.
 	if updateErr := s.repo.SetSessionMetadataKey(ctx, sessionID, "acp_session_id", ""); updateErr != nil {

--- a/apps/backend/internal/orchestrator/event_handlers_workflow_lazy_resume_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow_lazy_resume_test.go
@@ -2,16 +2,26 @@ package orchestrator
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/kandev/kandev/internal/task/models"
 	wfmodels "github.com/kandev/kandev/internal/workflow/models"
 )
 
+type failResumeTokenUpdateRepo struct {
+	sessionExecutorStore
+	err error
+}
+
+func (r *failResumeTokenUpdateRepo) UpdateResumeToken(context.Context, string, string, string, string) error {
+	return r.err
+}
+
 // TestProcessOnEnterResetAgentContext_ClearsLazyResumeTokenWithoutLiveExecution
 // is the regression test for the lazy-resume reset: when no in-memory execution
-// exists, clearPersistedResetState must erase the stale resume token so the
-// next lazy launch does not reconnect to the pre-reset ACP conversation.
+// exists, resetAgentContext must erase the stale resume token so the next lazy
+// launch does not reconnect to the pre-reset ACP conversation.
 func TestProcessOnEnterResetAgentContext_ClearsLazyResumeTokenWithoutLiveExecution(t *testing.T) {
 	ctx := context.Background()
 	repo := setupTestRepo(t)
@@ -53,9 +63,75 @@ func TestProcessOnEnterResetAgentContext_ClearsLazyResumeTokenWithoutLiveExecuti
 	}
 }
 
-// TestResetAgentContext_InterleavingB_ClearBeforeStore proves the favorable
-// interleaving: clearPersistedResetState erases the stale token before the
-// async ACP session.created event writes the fresh one.
+func TestProcessOnEnterResetAgentContext_ReportsLazyResumeTokenClearFailure(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "task-lazy-resume-error", "session-lazy-resume-error", "step-work")
+	if err := repo.UpsertExecutorRunning(ctx, &models.ExecutorRunning{
+		ID:          "session-lazy-resume-error",
+		SessionID:   "session-lazy-resume-error",
+		TaskID:      "task-lazy-resume-error",
+		ResumeToken: "old-acp-session",
+		Status:      "stopped",
+	}); err != nil {
+		t.Fatalf("seed resumable execution: %v", err)
+	}
+
+	agentManager := &mockAgentManager{repoForExecutionLookup: repo}
+	svc := createTestServiceWithAgent(repo, newMockStepGetter(), newMockTaskRepo(), agentManager)
+	svc.repo = &failResumeTokenUpdateRepo{
+		sessionExecutorStore: repo,
+		err:                  errors.New("resume token store unavailable"),
+	}
+	session, err := repo.GetTaskSession(ctx, "session-lazy-resume-error")
+	if err != nil {
+		t.Fatalf("load session: %v", err)
+	}
+
+	if svc.resetAgentContext(ctx, "task-lazy-resume-error", session, "review") {
+		t.Fatal("expected reset to fail when lazy resume token cannot be cleared")
+	}
+	if len(agentManager.restartProcessCalls) != 0 {
+		t.Fatalf("expected no provider reset without a live execution, got %d calls", len(agentManager.restartProcessCalls))
+	}
+}
+
+func TestResetAgentContext_FailedProviderResetRetainsResumeToken(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "t-reset-token", "s-reset-token", "step1")
+	seedExecutorRunning(t, repo, "s-reset-token", "t-reset-token", "exec-reset-token")
+	if err := repo.UpdateResumeToken(ctx, "s-reset-token", "exec-reset-token", "old-acp-session", ""); err != nil {
+		t.Fatalf("seed stale resume token: %v", err)
+	}
+
+	svc := createTestServiceWithAgent(
+		repo,
+		newMockStepGetter(),
+		newMockTaskRepo(),
+		&mockAgentManager{
+			repoForExecutionLookup: repo,
+			restartProcessErr:      errors.New("provider reset failed"),
+		},
+	)
+	session, err := repo.GetTaskSession(ctx, "s-reset-token")
+	if err != nil {
+		t.Fatalf("load session: %v", err)
+	}
+	if svc.resetAgentContext(ctx, "t-reset-token", session, "review") {
+		t.Fatal("expected provider reset to fail")
+	}
+	running, err := repo.GetExecutorRunningBySessionID(ctx, "s-reset-token")
+	if err != nil {
+		t.Fatalf("load executor row: %v", err)
+	}
+	if running.ResumeToken != "old-acp-session" {
+		t.Fatalf("failed reset must retain recovery token, got %q", running.ResumeToken)
+	}
+}
+
+// TestResetAgentContext_InterleavingB_ClearBeforeStore proves that a successful
+// reset persists the fresh token before an async session-created event arrives.
 func TestResetAgentContext_InterleavingB_ClearBeforeStore(t *testing.T) {
 	ctx := context.Background()
 	repo := setupTestRepo(t)
@@ -63,34 +139,41 @@ func TestResetAgentContext_InterleavingB_ClearBeforeStore(t *testing.T) {
 
 	const execID = "exec-1"
 	const staleToken = "old-acp-session"
+	const freshToken = "fresh-acp-session"
 	seedExecutorRunning(t, repo, "s1", "t1", execID)
 	if err := repo.UpdateResumeToken(ctx, "s1", execID, staleToken, ""); err != nil {
 		t.Fatalf("seed stale resume token: %v", err)
 	}
 
-	agentManager := &mockAgentManager{repoForExecutionLookup: repo}
+	agentManager := &mockAgentManager{
+		repoForExecutionLookup: repo,
+		getACPSessionIDForSessionFunc: func(string) (string, bool) {
+			return freshToken, true
+		},
+	}
 	svc := createTestServiceWithAgent(repo, newMockStepGetter(), newMockTaskRepo(), agentManager)
 	session, err := repo.GetTaskSession(ctx, "s1")
 	if err != nil {
 		t.Fatalf("load session: %v", err)
 	}
 
-	// 1. resetAgentContext — clears stale token before the reset.
+	// 1. resetAgentContext resets the provider, clears stale state, and
+	//    persists the current ACP session synchronously.
 	if !svc.resetAgentContext(ctx, "t1", session, "test") {
 		t.Fatal("expected reset to succeed")
 	}
 
-	// 2. Verify token was cleared.
+	// 2. Verify the old token was replaced without waiting for an async event.
 	running, err := repo.GetExecutorRunningBySessionID(ctx, "s1")
 	if err != nil {
 		t.Fatalf("load executor row after reset: %v", err)
 	}
-	if running.ResumeToken != "" {
-		t.Fatalf("expected cleared resume_token after reset, got %q", running.ResumeToken)
+	if running.ResumeToken != freshToken {
+		t.Fatalf("expected fresh resume_token after reset, got %q", running.ResumeToken)
 	}
 
-	// 3. Async storeResumeToken arrives with the new ACP session ID.
-	const freshToken = "fresh-acp-session"
+	// 3. An async session-created event with the same current ID remains
+	//    idempotent.
 	svc.storeResumeToken(ctx, "t1", "s1", execID, freshToken, "")
 
 	running, err = repo.GetExecutorRunningBySessionID(ctx, "s1")
@@ -102,15 +185,9 @@ func TestResetAgentContext_InterleavingB_ClearBeforeStore(t *testing.T) {
 	}
 }
 
-// TestResetAgentContext_InterleavingA_StoreBeforeClear proves that the
-// reverse interleaving — the async ACP session.created event fires BEFORE
-// resetAgentContext's clearResumeToken runs — is safe with the fix
-// (clearResumeToken is ordered before ResetAgentContext, so the new ACP
-// session does not exist when the old token is cleared).
-//
-// This test simulates interleaving A by calling storeResumeToken with the
-// fresh ACP session ID before clearPersistedResetState. The fix ensures
-// the fresh token survives.
+// TestResetAgentContext_InterleavingA_StoreBeforeClear proves that metadata
+// cleanup does not clear a token that was already persisted by the fresh ACP
+// session event.
 func TestResetAgentContext_InterleavingA_StoreBeforeClear(t *testing.T) {
 	ctx := context.Background()
 	repo := setupTestRepo(t)
@@ -130,9 +207,8 @@ func TestResetAgentContext_InterleavingA_StoreBeforeClear(t *testing.T) {
 		t.Fatalf("load session: %v", err)
 	}
 
-	// Simulate: the async ACP session.created event fires before
-	// clearPersistedResetState. storeResumeToken writes the fresh token
-	// first, then clearPersistedResetState must not erase it.
+	// Simulate the async ACP session.created event arriving before the remaining
+	// reset metadata is cleared. The token is handled separately and survives.
 	const freshToken = "fresh-acp-session"
 	svc.storeResumeToken(ctx, "t1", "s1", execID, freshToken, "")
 	svc.clearPersistedResetState(ctx, "s1", session)
@@ -149,18 +225,10 @@ func TestResetAgentContext_InterleavingA_StoreBeforeClear(t *testing.T) {
 	}
 }
 
-// TestResetAgentContext_InterleavingC_StaleOldEventOverwritesFresh
-// demonstrates that a stale ACP session.created event from the OLD session
-// (same execution ID, old ACP session ID) can overwrite the fresh resume
-// token. storeResumeToken's CAS keyed on agent_execution_id CANNOT
-// distinguish ACP session generations within the same execution.
-//
-// This is pre-existing: the old code had the same window for acp_session_id.
-// Our fix neither introduces nor widens it.  The correct long-term fix
-// requires a generation counter on the executors_running row (outside the
-// scope of this change).
-func TestResetAgentContext_InterleavingC_StaleOldEventOverwritesFresh(t *testing.T) {
-	t.Skip("pre-existing: storeResumeToken CAS cannot distinguish ACP generations within the same execution. Requires a generation counter on executors_running.")
+// TestResetAgentContext_InterleavingC_StaleOldEventOverwritesFresh proves that
+// the current ACP session ID filters a delayed event from the old session even
+// though both sessions share one lifecycle execution ID.
+func TestResetAgentContext_InterleavingC_StaleOldEventDoesNotOverwriteFresh(t *testing.T) {
 	ctx := context.Background()
 	repo := setupTestRepo(t)
 	seedSession(t, repo, "t1", "s1", "step1")
@@ -172,21 +240,25 @@ func TestResetAgentContext_InterleavingC_StaleOldEventOverwritesFresh(t *testing
 		t.Fatalf("seed stale resume token: %v", err)
 	}
 
-	agentManager := &mockAgentManager{repoForExecutionLookup: repo}
+	const freshToken = "fresh-acp-session"
+	agentManager := &mockAgentManager{
+		repoForExecutionLookup: repo,
+		getACPSessionIDForSessionFunc: func(string) (string, bool) {
+			return freshToken, true
+		},
+	}
 	svc := createTestServiceWithAgent(repo, newMockStepGetter(), newMockTaskRepo(), agentManager)
 	session, err := repo.GetTaskSession(ctx, "s1")
 	if err != nil {
 		t.Fatalf("load session: %v", err)
 	}
 
-	// 1. resetAgentContext — clears stale token before the reset, then calls
-	//    clearPersistedResetState after.
+	// 1. Reset the provider and persist the fresh ACP session.
 	if !svc.resetAgentContext(ctx, "t1", session, "test") {
 		t.Fatal("expected reset to succeed")
 	}
 
-	// 2. New session event arrives — writes fresh token.
-	const freshToken = "fresh-acp-session"
+	// 2. New session event arrives — writes the fresh token.
 	svc.storeResumeToken(ctx, "t1", "s1", execID, freshToken, "")
 
 	running, err := repo.GetExecutorRunningBySessionID(ctx, "s1")
@@ -197,8 +269,8 @@ func TestResetAgentContext_InterleavingC_StaleOldEventOverwritesFresh(t *testing
 		t.Fatalf("expected fresh token %q, got %q", freshToken, running.ResumeToken)
 	}
 
-	// 3. Stale old-session event arrives with the old ACP session ID.
-	//    Same execution ID → CAS accepts it → overwrites fresh token!
+	// 3. A stale old-session event arrives with the old ACP session ID. The
+	//    execution ID is unchanged, but the ACP generation check rejects it.
 	svc.storeResumeToken(ctx, "t1", "s1", execID, staleToken, "")
 
 	running, err = repo.GetExecutorRunningBySessionID(ctx, "s1")

--- a/apps/backend/internal/orchestrator/event_handlers_workflow_lazy_resume_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow_lazy_resume_test.go
@@ -48,3 +48,111 @@ func TestProcessOnEnterResetAgentContext_ClearsLazyResumeTokenWithoutLiveExecuti
 		t.Fatalf("reset must clear lazy resume before the next agent turn, got %q", running.ResumeToken)
 	}
 }
+
+// TestResetAgentContext_ClearsThenAllowsFreshStoreResumeToken proves that the
+// live-execution reset path clears the stale resume token AND that a subsequent
+// storeResumeToken (mimicking the async ACP session.created event from the new
+// session) can write the fresh token without interference — there is no race
+// between clearPersistedResetState and a concurrent storeResumeToken because
+// the event that triggers storeResumeToken for the new session arrives
+// asynchronously from the agent's streaming goroutine AFTER the reset call
+// returns.
+//
+// Race analysis (see also the structural proof in the function body of
+// resetAgentContext in event_handlers_workflow.go):
+//   - resetAgentContext calls agentManager.ResetAgentContext synchronously.
+//     ResetAgentContext (manager_interaction.go) creates the new ACP session
+//     via agentctl.ResetSession() — a synchronous RPC — and does NOT publish
+//     an OnACPSessionCreated event (that event is published only by the fresh-
+//     session and workspace-rebind paths).
+//   - After ResetAgentContext returns, clearPersistedResetState runs on the
+//     same goroutine and clears the resume token.
+//   - The ACP session.created streaming event from the agent's new session
+//     arrives later (on a separate WebSocket reader goroutine) and triggers
+//     storeResumeToken via handleSessionStatusEvent — so the clear
+//     deterministically precedes the store of the fresh token.
+//   - The only path where storeResumeToken could race is a tail-end event from
+//     the OLD ACP session arriving after the reset clear, but that stale event
+//     carries the old ACP session ID and would overwrite with a defunct value.
+//     This is a pre-existing concern unrelated to our fix (the old code already
+//     cleared acp_session_id after ResetAgentContext).  The event bus's
+//     QueueSubscribe already serializes event delivery per queue, so a stale
+//     event from the old session cannot interleave in the middle of the reset
+//     call itself.
+func TestResetAgentContext_ClearsThenAllowsFreshStoreResumeToken(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "task-live-reset", "session-live-reset", "step-work")
+
+	// Seed a live executor row with a stale resume token and a known
+	// agent_execution_id so storeResumeToken's CAS can validate.
+	const execID = "exec-live-reset"
+	const staleToken = "old-acp-session"
+	seedExecutorRunning(t, repo, "session-live-reset", "task-live-reset", execID)
+
+	// Write a stale resume token directly (seedExecutorRunning doesn't set one).
+	if err := repo.UpdateResumeToken(ctx, "session-live-reset", execID, staleToken, ""); err != nil {
+		t.Fatalf("seed stale resume token: %v", err)
+	}
+	// Verify precondition.
+	running, err := repo.GetExecutorRunningBySessionID(ctx, "session-live-reset")
+	if err != nil {
+		t.Fatalf("precondition: load executor row: %v", err)
+	}
+	if running.ResumeToken != staleToken {
+		t.Fatalf("precondition: expected resume_token %q, got %q", staleToken, running.ResumeToken)
+	}
+
+	agentManager := &mockAgentManager{repoForExecutionLookup: repo}
+	svc := createTestServiceWithAgent(repo, newMockStepGetter(), newMockTaskRepo(), agentManager)
+
+	session, err := repo.GetTaskSession(ctx, "session-live-reset")
+	if err != nil {
+		t.Fatalf("load session: %v", err)
+	}
+
+	// Step 1: resetAgentContext with a live execution — this clears the stale
+	// resume token via clearPersistedResetState -> clearResumeToken.
+	if !svc.resetAgentContext(ctx, "task-live-reset", session, "test") {
+		t.Fatal("expected live-execution reset to succeed")
+	}
+	// The mock's ResetAgentContext just records the call; verify it was exercised.
+	if len(agentManager.restartProcessCalls) != 1 || agentManager.restartProcessCalls[0] != execID {
+		t.Fatalf("expected ResetAgentContext(execID=%q), got %v", execID, agentManager.restartProcessCalls)
+	}
+
+	// Step 2: verify the stale token was cleared.
+	running, err = repo.GetExecutorRunningBySessionID(ctx, "session-live-reset")
+	if err != nil {
+		t.Fatalf("load executor row after reset: %v", err)
+	}
+	if running.ResumeToken != "" {
+		t.Fatalf("expected cleared resume_token after reset, got %q", running.ResumeToken)
+	}
+
+	// Step 3: simulate the async ACP session.created event arriving after the
+	// reset. The new session gets a fresh ACP session ID. storeResumeToken uses
+	// a CAS on agent_execution_id — since the execution didn't rotate (same
+	// execID), the write succeeds.
+	const freshToken = "new-acp-session-after-reset"
+	svc.storeResumeToken(ctx, "task-live-reset", "session-live-reset", execID, freshToken, "")
+
+	running, err = repo.GetExecutorRunningBySessionID(ctx, "session-live-reset")
+	if err != nil {
+		t.Fatalf("load executor row after storeResumeToken: %v", err)
+	}
+	if running.ResumeToken != freshToken {
+		t.Fatalf("expected fresh resume_token %q after storeResumeToken, got %q", freshToken, running.ResumeToken)
+	}
+
+	// Repeat: a second clearPersistedResetState (e.g., from a subsequent step
+	// re-entry) must again clear the fresh token.
+	svc.clearPersistedResetState(ctx, "session-live-reset", session)
+	running, err = repo.GetExecutorRunningBySessionID(ctx, "session-live-reset")
+	if err != nil {
+		t.Fatalf("load executor row after second clear: %v", err)
+	}
+	if running.ResumeToken != "" {
+		t.Fatalf("expected cleared resume_token after second clear, got %q", running.ResumeToken)
+	}
+}

--- a/apps/backend/internal/orchestrator/event_handlers_workflow_lazy_resume_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow_lazy_resume_test.go
@@ -1,0 +1,50 @@
+package orchestrator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kandev/kandev/internal/task/models"
+	wfmodels "github.com/kandev/kandev/internal/workflow/models"
+)
+
+func TestProcessOnEnterResetAgentContext_ClearsLazyResumeTokenWithoutLiveExecution(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "task-lazy-resume", "session-lazy-resume", "step-work")
+	if err := repo.UpsertExecutorRunning(ctx, &models.ExecutorRunning{
+		ID:          "session-lazy-resume",
+		SessionID:   "session-lazy-resume",
+		TaskID:      "task-lazy-resume",
+		ResumeToken: "old-acp-session",
+		Status:      "stopped",
+	}); err != nil {
+		t.Fatalf("seed resumable execution: %v", err)
+	}
+
+	agentManager := &mockAgentManager{repoForExecutionLookup: repo}
+	svc := createTestServiceWithAgent(repo, newMockStepGetter(), newMockTaskRepo(), agentManager)
+	step := &wfmodels.WorkflowStep{
+		ID: "step-review", WorkflowID: "workflow-1", Name: "Review",
+		Events: wfmodels.StepEvents{OnEnter: []wfmodels.OnEnterAction{
+			{Type: wfmodels.OnEnterResetAgentContext},
+		}},
+	}
+	session, err := repo.GetTaskSession(ctx, "session-lazy-resume")
+	if err != nil {
+		t.Fatalf("load session: %v", err)
+	}
+
+	svc.processOnEnter(ctx, "task-lazy-resume", session, step, "review task")
+
+	if len(agentManager.restartProcessCalls) != 0 {
+		t.Fatalf("expected no reset against a missing live execution, got %d calls", len(agentManager.restartProcessCalls))
+	}
+	running, err := repo.GetExecutorRunningBySessionID(ctx, "session-lazy-resume")
+	if err != nil {
+		t.Fatalf("load resumable execution: %v", err)
+	}
+	if running.ResumeToken != "" {
+		t.Fatalf("reset must clear lazy resume before the next agent turn, got %q", running.ResumeToken)
+	}
+}

--- a/apps/backend/internal/orchestrator/event_handlers_workflow_lazy_resume_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow_lazy_resume_test.go
@@ -8,6 +8,10 @@ import (
 	wfmodels "github.com/kandev/kandev/internal/workflow/models"
 )
 
+// TestProcessOnEnterResetAgentContext_ClearsLazyResumeTokenWithoutLiveExecution
+// is the regression test for the lazy-resume reset: when no in-memory execution
+// exists, clearPersistedResetState must erase the stale resume token so the
+// next lazy launch does not reconnect to the pre-reset ACP conversation.
 func TestProcessOnEnterResetAgentContext_ClearsLazyResumeTokenWithoutLiveExecution(t *testing.T) {
 	ctx := context.Background()
 	repo := setupTestRepo(t)
@@ -49,80 +53,35 @@ func TestProcessOnEnterResetAgentContext_ClearsLazyResumeTokenWithoutLiveExecuti
 	}
 }
 
-// TestResetAgentContext_ClearsThenAllowsFreshStoreResumeToken proves that the
-// live-execution reset path clears the stale resume token AND that a subsequent
-// storeResumeToken (mimicking the async ACP session.created event from the new
-// session) can write the fresh token without interference — there is no race
-// between clearPersistedResetState and a concurrent storeResumeToken because
-// the event that triggers storeResumeToken for the new session arrives
-// asynchronously from the agent's streaming goroutine AFTER the reset call
-// returns.
-//
-// Race analysis (see also the structural proof in the function body of
-// resetAgentContext in event_handlers_workflow.go):
-//   - resetAgentContext calls agentManager.ResetAgentContext synchronously.
-//     ResetAgentContext (manager_interaction.go) creates the new ACP session
-//     via agentctl.ResetSession() — a synchronous RPC — and does NOT publish
-//     an OnACPSessionCreated event (that event is published only by the fresh-
-//     session and workspace-rebind paths).
-//   - After ResetAgentContext returns, clearPersistedResetState runs on the
-//     same goroutine and clears the resume token.
-//   - The ACP session.created streaming event from the agent's new session
-//     arrives later (on a separate WebSocket reader goroutine) and triggers
-//     storeResumeToken via handleSessionStatusEvent — so the clear
-//     deterministically precedes the store of the fresh token.
-//   - The only path where storeResumeToken could race is a tail-end event from
-//     the OLD ACP session arriving after the reset clear, but that stale event
-//     carries the old ACP session ID and would overwrite with a defunct value.
-//     This is a pre-existing concern unrelated to our fix (the old code already
-//     cleared acp_session_id after ResetAgentContext).  The event bus's
-//     QueueSubscribe already serializes event delivery per queue, so a stale
-//     event from the old session cannot interleave in the middle of the reset
-//     call itself.
-func TestResetAgentContext_ClearsThenAllowsFreshStoreResumeToken(t *testing.T) {
+// TestResetAgentContext_InterleavingB_ClearBeforeStore proves the favorable
+// interleaving: clearPersistedResetState erases the stale token before the
+// async ACP session.created event writes the fresh one.
+func TestResetAgentContext_InterleavingB_ClearBeforeStore(t *testing.T) {
 	ctx := context.Background()
 	repo := setupTestRepo(t)
-	seedSession(t, repo, "task-live-reset", "session-live-reset", "step-work")
+	seedSession(t, repo, "t1", "s1", "step1")
 
-	// Seed a live executor row with a stale resume token and a known
-	// agent_execution_id so storeResumeToken's CAS can validate.
-	const execID = "exec-live-reset"
+	const execID = "exec-1"
 	const staleToken = "old-acp-session"
-	seedExecutorRunning(t, repo, "session-live-reset", "task-live-reset", execID)
-
-	// Write a stale resume token directly (seedExecutorRunning doesn't set one).
-	if err := repo.UpdateResumeToken(ctx, "session-live-reset", execID, staleToken, ""); err != nil {
+	seedExecutorRunning(t, repo, "s1", "t1", execID)
+	if err := repo.UpdateResumeToken(ctx, "s1", execID, staleToken, ""); err != nil {
 		t.Fatalf("seed stale resume token: %v", err)
-	}
-	// Verify precondition.
-	running, err := repo.GetExecutorRunningBySessionID(ctx, "session-live-reset")
-	if err != nil {
-		t.Fatalf("precondition: load executor row: %v", err)
-	}
-	if running.ResumeToken != staleToken {
-		t.Fatalf("precondition: expected resume_token %q, got %q", staleToken, running.ResumeToken)
 	}
 
 	agentManager := &mockAgentManager{repoForExecutionLookup: repo}
 	svc := createTestServiceWithAgent(repo, newMockStepGetter(), newMockTaskRepo(), agentManager)
-
-	session, err := repo.GetTaskSession(ctx, "session-live-reset")
+	session, err := repo.GetTaskSession(ctx, "s1")
 	if err != nil {
 		t.Fatalf("load session: %v", err)
 	}
 
-	// Step 1: resetAgentContext with a live execution — this clears the stale
-	// resume token via clearPersistedResetState -> clearResumeToken.
-	if !svc.resetAgentContext(ctx, "task-live-reset", session, "test") {
-		t.Fatal("expected live-execution reset to succeed")
-	}
-	// The mock's ResetAgentContext just records the call; verify it was exercised.
-	if len(agentManager.restartProcessCalls) != 1 || agentManager.restartProcessCalls[0] != execID {
-		t.Fatalf("expected ResetAgentContext(execID=%q), got %v", execID, agentManager.restartProcessCalls)
+	// 1. resetAgentContext — clears stale token before the reset.
+	if !svc.resetAgentContext(ctx, "t1", session, "test") {
+		t.Fatal("expected reset to succeed")
 	}
 
-	// Step 2: verify the stale token was cleared.
-	running, err = repo.GetExecutorRunningBySessionID(ctx, "session-live-reset")
+	// 2. Verify token was cleared.
+	running, err := repo.GetExecutorRunningBySessionID(ctx, "s1")
 	if err != nil {
 		t.Fatalf("load executor row after reset: %v", err)
 	}
@@ -130,29 +89,123 @@ func TestResetAgentContext_ClearsThenAllowsFreshStoreResumeToken(t *testing.T) {
 		t.Fatalf("expected cleared resume_token after reset, got %q", running.ResumeToken)
 	}
 
-	// Step 3: simulate the async ACP session.created event arriving after the
-	// reset. The new session gets a fresh ACP session ID. storeResumeToken uses
-	// a CAS on agent_execution_id — since the execution didn't rotate (same
-	// execID), the write succeeds.
-	const freshToken = "new-acp-session-after-reset"
-	svc.storeResumeToken(ctx, "task-live-reset", "session-live-reset", execID, freshToken, "")
+	// 3. Async storeResumeToken arrives with the new ACP session ID.
+	const freshToken = "fresh-acp-session"
+	svc.storeResumeToken(ctx, "t1", "s1", execID, freshToken, "")
 
-	running, err = repo.GetExecutorRunningBySessionID(ctx, "session-live-reset")
+	running, err = repo.GetExecutorRunningBySessionID(ctx, "s1")
 	if err != nil {
 		t.Fatalf("load executor row after storeResumeToken: %v", err)
 	}
 	if running.ResumeToken != freshToken {
-		t.Fatalf("expected fresh resume_token %q after storeResumeToken, got %q", freshToken, running.ResumeToken)
+		t.Fatalf("expected fresh token %q after storeResumeToken, got %q", freshToken, running.ResumeToken)
+	}
+}
+
+// TestResetAgentContext_InterleavingA_StoreBeforeClear proves that the
+// reverse interleaving — the async ACP session.created event fires BEFORE
+// resetAgentContext's clearResumeToken runs — is safe with the fix
+// (clearResumeToken is ordered before ResetAgentContext, so the new ACP
+// session does not exist when the old token is cleared).
+//
+// This test simulates interleaving A by calling storeResumeToken with the
+// fresh ACP session ID before clearPersistedResetState. The fix ensures
+// the fresh token survives.
+func TestResetAgentContext_InterleavingA_StoreBeforeClear(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "t1", "s1", "step1")
+
+	const execID = "exec-1"
+	const staleToken = "old-acp-session"
+	seedExecutorRunning(t, repo, "s1", "t1", execID)
+	if err := repo.UpdateResumeToken(ctx, "s1", execID, staleToken, ""); err != nil {
+		t.Fatalf("seed stale resume token: %v", err)
 	}
 
-	// Repeat: a second clearPersistedResetState (e.g., from a subsequent step
-	// re-entry) must again clear the fresh token.
-	svc.clearPersistedResetState(ctx, "session-live-reset", session)
-	running, err = repo.GetExecutorRunningBySessionID(ctx, "session-live-reset")
+	agentManager := &mockAgentManager{repoForExecutionLookup: repo}
+	svc := createTestServiceWithAgent(repo, newMockStepGetter(), newMockTaskRepo(), agentManager)
+	session, err := repo.GetTaskSession(ctx, "s1")
 	if err != nil {
-		t.Fatalf("load executor row after second clear: %v", err)
+		t.Fatalf("load session: %v", err)
 	}
-	if running.ResumeToken != "" {
-		t.Fatalf("expected cleared resume_token after second clear, got %q", running.ResumeToken)
+
+	// Simulate: the async ACP session.created event fires before
+	// clearPersistedResetState. storeResumeToken writes the fresh token
+	// first, then clearPersistedResetState must not erase it.
+	const freshToken = "fresh-acp-session"
+	svc.storeResumeToken(ctx, "t1", "s1", execID, freshToken, "")
+	svc.clearPersistedResetState(ctx, "s1", session)
+
+	running, err := repo.GetExecutorRunningBySessionID(ctx, "s1")
+	if err != nil {
+		t.Fatalf("load executor row: %v", err)
+	}
+	if running.ResumeToken == "" {
+		t.Fatal("RACE: clearResumeToken erased the fresh token written by storeResumeToken")
+	}
+	if running.ResumeToken != freshToken {
+		t.Fatalf("expected fresh token %q to survive, got %q", freshToken, running.ResumeToken)
+	}
+}
+
+// TestResetAgentContext_InterleavingC_StaleOldEventOverwritesFresh
+// demonstrates that a stale ACP session.created event from the OLD session
+// (same execution ID, old ACP session ID) can overwrite the fresh resume
+// token. storeResumeToken's CAS keyed on agent_execution_id CANNOT
+// distinguish ACP session generations within the same execution.
+//
+// This is pre-existing: the old code had the same window for acp_session_id.
+// Our fix neither introduces nor widens it.  The correct long-term fix
+// requires a generation counter on the executors_running row (outside the
+// scope of this change).
+func TestResetAgentContext_InterleavingC_StaleOldEventOverwritesFresh(t *testing.T) {
+	t.Skip("pre-existing: storeResumeToken CAS cannot distinguish ACP generations within the same execution. Requires a generation counter on executors_running.")
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "t1", "s1", "step1")
+
+	const execID = "exec-1"
+	const staleToken = "old-acp-session"
+	seedExecutorRunning(t, repo, "s1", "t1", execID)
+	if err := repo.UpdateResumeToken(ctx, "s1", execID, staleToken, ""); err != nil {
+		t.Fatalf("seed stale resume token: %v", err)
+	}
+
+	agentManager := &mockAgentManager{repoForExecutionLookup: repo}
+	svc := createTestServiceWithAgent(repo, newMockStepGetter(), newMockTaskRepo(), agentManager)
+	session, err := repo.GetTaskSession(ctx, "s1")
+	if err != nil {
+		t.Fatalf("load session: %v", err)
+	}
+
+	// 1. resetAgentContext — clears stale token before the reset, then calls
+	//    clearPersistedResetState after.
+	if !svc.resetAgentContext(ctx, "t1", session, "test") {
+		t.Fatal("expected reset to succeed")
+	}
+
+	// 2. New session event arrives — writes fresh token.
+	const freshToken = "fresh-acp-session"
+	svc.storeResumeToken(ctx, "t1", "s1", execID, freshToken, "")
+
+	running, err := repo.GetExecutorRunningBySessionID(ctx, "s1")
+	if err != nil {
+		t.Fatalf("load executor row: %v", err)
+	}
+	if running.ResumeToken != freshToken {
+		t.Fatalf("expected fresh token %q, got %q", freshToken, running.ResumeToken)
+	}
+
+	// 3. Stale old-session event arrives with the old ACP session ID.
+	//    Same execution ID → CAS accepts it → overwrites fresh token!
+	svc.storeResumeToken(ctx, "t1", "s1", execID, staleToken, "")
+
+	running, err = repo.GetExecutorRunningBySessionID(ctx, "s1")
+	if err != nil {
+		t.Fatalf("load executor row after stale event: %v", err)
+	}
+	if running.ResumeToken != freshToken {
+		t.Fatalf("stale old-session event overwrote fresh token: got %q, want %q", running.ResumeToken, freshToken)
 	}
 }

--- a/apps/backend/internal/orchestrator/service.go
+++ b/apps/backend/internal/orchestrator/service.go
@@ -691,6 +691,13 @@ type Service struct {
 	// Session reset flags: sessionID -> true while resetAgentContext is restarting process.
 	// Used to suppress stale ready events and avoid draining queued prompts mid-reset.
 	resetInProgressSessions sync.Map
+	// sessionLifecycleLocks serializes context resets with every path that can
+	// resume a session from executors_running. The lock is intentionally shared
+	// by resetAgentContext and ensureSessionRunning so a lazy resume cannot read
+	// the old token while a workflow reset is clearing it.
+	// Entries are not deleted: deleting a lock can let a new caller create a
+	// second mutex while an existing waiter still owns the old one.
+	sessionLifecycleLocks sync.Map // map[sessionID]*sync.Mutex
 	// contextWindowGuards serializes live context usage writes and gives each
 	// session a generation boundary that reset_agent_context can invalidate.
 	contextWindowGuards sync.Map
@@ -1776,6 +1783,20 @@ func (s *Service) setSessionResetInProgress(sessionID string, inProgress bool) {
 		return
 	}
 	s.resetInProgressSessions.Delete(sessionID)
+}
+
+// acquireSessionLifecycleLock serializes operations that change or consume a
+// session's persisted conversation identity. Keep the critical section around
+// the complete reset/resume operation, including the bounded runtime wait, so
+// no caller can launch with a token that a concurrent reset is invalidating.
+func (s *Service) acquireSessionLifecycleLock(sessionID string) func() {
+	if sessionID == "" {
+		return func() {}
+	}
+	value, _ := s.sessionLifecycleLocks.LoadOrStore(sessionID, &sync.Mutex{})
+	lock := value.(*sync.Mutex)
+	lock.Lock()
+	return lock.Unlock
 }
 
 func (s *Service) isSessionResetInProgress(sessionID string) bool {

--- a/apps/backend/internal/orchestrator/session_launch.go
+++ b/apps/backend/internal/orchestrator/session_launch.go
@@ -378,7 +378,9 @@ func (s *Service) RecoverSession(ctx context.Context, taskID, sessionID, action 
 	}
 	switch action {
 	case "fresh_start":
-		s.clearResumeToken(ctx, sessionID)
+		if err := s.clearResumeToken(ctx, sessionID); err != nil {
+			return nil, fmt.Errorf("failed to clear resume token for fresh start: %w", err)
+		}
 	case "resume":
 		// no-op — relaunch with existing resume token
 	default:

--- a/apps/backend/internal/orchestrator/task_operations.go
+++ b/apps/backend/internal/orchestrator/task_operations.go
@@ -1625,6 +1625,8 @@ func (s *Service) ResumeTaskSession(ctx context.Context, taskID, sessionID strin
 	s.logger.Debug("resuming task session",
 		zap.String("task_id", taskID),
 		zap.String("session_id", sessionID))
+	releaseLifecycleLock := s.acquireSessionLifecycleLock(sessionID)
+	defer releaseLifecycleLock()
 
 	session, err := s.repo.GetTaskSession(ctx, sessionID)
 	if err != nil {
@@ -1934,6 +1936,9 @@ func (s *Service) advanceTaskWorkflowStep(ctx context.Context, task *models.Task
 // After lazy recovery, a session may be in WAITING_FOR_INPUT with no agent process;
 // this function detects that case and triggers a resume.
 func (s *Service) ensureSessionRunning(ctx context.Context, sessionID string, session *models.TaskSession) error {
+	releaseLifecycleLock := s.acquireSessionLifecycleLock(sessionID)
+	defer releaseLifecycleLock()
+
 	isOfficeTask, err := s.lookupOfficeTask(ctx, session.TaskID)
 	if err != nil {
 		return fmt.Errorf("failed to determine office task status: %w", err)


### PR DESCRIPTION
## Problem

When a workflow step's `on_enter` declares `reset_agent_context` but no in-memory agent execution exists for the session (e.g. the session completed/stopped and is being lazily resumed), the reset was silently skipped. The early return omitted all persisted state clearing — the ACP session ID, resume token on the `executors_running` row, and context window metadata all survived.

The lazy resume path (`applyRunningRecordToResumeRequest`) reads the resume token directly from the persisted row, so a stale token would let the next lazy launch reconnect to the pre-reset ACP conversation. The agent would start its first turn with old, stale context — effectively ignoring the reset.

## Fix

- Extracted `clearResumeToken` out of `clearPersistedResetState` and call it BEFORE `ResetAgentContext` in the live-execution path. The new ACP session does not exist yet, so the async `session.created` event (which calls `storeResumeToken`) cannot race with the clear — eliminating the store-before-clear interleaving.

- For the no-in-memory-execution path (lazy resume), `clearResumeToken` is called separately before the unchanged `clearPersistedResetState`. There is no `ResetAgentContext` call on this path, so no async event exists to race with.

- `clearPersistedResetState` now handles only ACP session metadata and context-window cleanup, without touching the resume token. This prevents it from erasing a fresh token written by the concurrent `storeResumeToken` on the live-execution path.

- A pre-existing concern remains: a stale ACP `session.created` event from the OLD session (same execution ID, old ACP session ID) can overwrite the fresh token via the execution-ID CAS, since `ResetSession` does not rotate the execution identity. The old code had the same window for `acp_session_id` metadata. Full fix requires a generation counter on `executors_running` (outside this scope).

## Regression tests

- `TestProcessOnEnterResetAgentContext_ClearsLazyResumeTokenWithoutLiveExecution` — seeds a session with a stopped executor row carrying a resume token, triggers `processOnEnter` with a step that declares `resetAgentContext`, and asserts the resume token is cleared. (Original regression test, unchanged.)

- `TestResetAgentContext_InterleavingA_StoreBeforeClear` — simulates the dangerous interleaving where `storeResumeToken` fires before `clearResumeToken`. With the fix (clear before reset), the fresh token survives. **PASS.**

- `TestResetAgentContext_InterleavingB_ClearBeforeStore` — the favorable interleaving: clear runs before the async event writes the fresh token. **PASS.**

- `TestResetAgentContext_InterleavingC_StaleOldEventOverwritesFresh` — demonstrates the pre-existing concern where a stale old-session event overwrites the fresh token via the same execution-ID CAS. **SKIP** (pre-existing, requires generation counter).

## Evidence finding — Review↔QA loop

Session `8c401f9f` (task `6e0fc028`) completed at 04:26:31 UTC and was re-entered at ~04:54. The observed `already_signaled` at 04:56:06 is mechanistically consistent with a stale agent context — the agent would see old conversation history and loop rather than proceeding. However, direct production evidence does not prove that the re-entry crossed a `reset_agent_context` `on_enter` with no live execution: there is no saved record of the specific branch, execution state, or workflow step that triggered the re-entry. The mechanism fixed here is a plausible downstream cause for the loop, but the practical observation cannot be definitively attributed to this bug without that execution trace. The terminal-session revival path (which shares the same no-in-memory-execution gap for a different entry point) is independently fixed by PR #2766.

## Validation

- New regression test passes
- All existing orchestrator tests pass (`go test ./internal/orchestrator/...`)
- All pre-commit hooks pass (Conventional Commits, gofmt, Go lint, etc.)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/2765?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
